### PR TITLE
Querying documents for null/undefined fields

### DIFF
--- a/packages/programs/data/document/src/document-index.ts
+++ b/packages/programs/data/document/src/document-index.ts
@@ -311,7 +311,7 @@ export class DocumentIndex<T> extends ComposableProgram {
                               if (f instanceof FieldIsEmptyQuery) {
                                   const value: bigint | number | undefined = fv;
 
-                                  return value === null || value === undefined;
+                                  return !(f.isempty && (value === null || value === undefined))
                               }
                           } else if (f instanceof MemoryCompareQuery) {
                               const operation =

--- a/packages/programs/data/document/src/document-index.ts
+++ b/packages/programs/data/document/src/document-index.ts
@@ -15,6 +15,7 @@ import {
     FieldBigIntCompareQuery,
     FieldByteMatchQuery,
     FieldStringMatchQuery,
+    FieldIsNullQuery,
     MemoryCompareQuery,
     DocumentQueryRequest,
     Query,
@@ -306,6 +307,11 @@ export class DocumentIndex<T> extends ComposableProgram {
                                   }
 
                                   return compare(value, f.compare, f.value);
+                              }
+                              if (f instanceof FieldIsNullQuery) {
+                                  const value: bigint | number = fv;
+
+                                  return value === null;
                               }
                           } else if (f instanceof MemoryCompareQuery) {
                               const operation =

--- a/packages/programs/data/document/src/document-index.ts
+++ b/packages/programs/data/document/src/document-index.ts
@@ -15,7 +15,7 @@ import {
     FieldBigIntCompareQuery,
     FieldByteMatchQuery,
     FieldStringMatchQuery,
-    FieldIsNullQuery,
+    FieldIsEmptyQuery,
     MemoryCompareQuery,
     DocumentQueryRequest,
     Query,
@@ -308,10 +308,10 @@ export class DocumentIndex<T> extends ComposableProgram {
 
                                   return compare(value, f.compare, f.value);
                               }
-                              if (f instanceof FieldIsNullQuery) {
-                                  const value: bigint | number = fv;
+                              if (f instanceof FieldIsEmptyQuery) {
+                                  const value: bigint | number | undefined = fv;
 
-                                  return value === null;
+                                  return value === null || value === undefined;
                               }
                           } else if (f instanceof MemoryCompareQuery) {
                               const operation =

--- a/packages/programs/data/document/src/query.ts
+++ b/packages/programs/data/document/src/query.ts
@@ -155,9 +155,14 @@ export class FieldBigIntCompareQuery extends StateFieldQuery {
 
 @variant(4)
 export class FieldIsEmptyQuery extends StateFieldQuery {
+    @field({ type: "bool" })
+    isempty: boolean
 
-    constructor(props?: { key: string[] | string }) {
+    constructor(props?: { key: string[] | string; isempty: boolean }) {
         super(props);
+        if (props) {
+            this.isempty = props.isempty;
+        }
     }
 }
 

--- a/packages/programs/data/document/src/query.ts
+++ b/packages/programs/data/document/src/query.ts
@@ -154,7 +154,7 @@ export class FieldBigIntCompareQuery extends StateFieldQuery {
 }
 
 @variant(4)
-export class FieldIsNullQuery extends StateFieldQuery {
+export class FieldIsEmptyQuery extends StateFieldQuery {
 
     constructor(props?: { key: string[] | string }) {
         super(props);

--- a/packages/programs/data/document/src/query.ts
+++ b/packages/programs/data/document/src/query.ts
@@ -153,6 +153,14 @@ export class FieldBigIntCompareQuery extends StateFieldQuery {
     }
 }
 
+@variant(4)
+export class FieldIsNullQuery extends StateFieldQuery {
+
+    constructor(props?: { key: string[] | string }) {
+        super(props);
+    }
+}
+
 @variant(0)
 export class MemoryCompare {
     @field({ type: Uint8Array })


### PR DESCRIPTION
This adds a document query "FieldIsEmptyQuery" that allows you to specify a field to query if the value of that field is (or isn't) null or undefined:

`new FieldIsEmptyQuery({key: 'favoritefood', isempty: true})`


Please let me know if the name (or anything else) should be changed to fit the current naming scheme, or if this should be gone about in a different way.