### PR TITLE
Add sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ import { Peerbit } from "@dao-xyz/peerbit";
 import {
 	Documents,
 	DocumentIndex,
-	DocumentQuery,
+	SearchRequest,
 	StringMatch,
 	StringMatchMethod,
 	Results,
@@ -182,7 +182,7 @@ await peer2.dial(peer)
 const store2 = peer2.open(store.address);
 
 let responses: Document[] =  await store2.docs.index.query(
-    new DocumentQuery({
+    new SearchRequest({
         queries: [
             new StringMatch({
                 key: "name",

--- a/jest.config.integration.ts
+++ b/jest.config.integration.ts
@@ -2,6 +2,7 @@ import type { JestConfigWithTsJest } from "ts-jest";
 
 const jestConfig: JestConfigWithTsJest = {
 	preset: "ts-jest",
+	workerThreads: true,
 	testEnvironment: "node",
 	roots: ["./packages/"],
 	transform: {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,6 +2,7 @@ import type { JestConfigWithTsJest } from "ts-jest";
 
 const jestConfig: JestConfigWithTsJest = {
 	preset: "ts-jest",
+	workerThreads: true,
 	testEnvironment: "node",
 	roots: ["./packages/"],
 	transform: {

--- a/jest.config.unit.ts
+++ b/jest.config.unit.ts
@@ -2,6 +2,7 @@ import type { JestConfigWithTsJest } from "ts-jest";
 
 const jestConfig: JestConfigWithTsJest = {
 	preset: "ts-jest",
+	workerThreads: true,
 	testEnvironment: "node",
 	roots: ["./packages/"],
 	transform: {

--- a/packages/client/src/__benchmark__/index.ts
+++ b/packages/client/src/__benchmark__/index.ts
@@ -115,6 +115,5 @@ suite
 	.on("complete", async function (this: any, ...args: any[]) {
 		await Promise.all(peers.map((x) => x.disconnect()));
 		await Promise.all(peers.map((n) => n.libp2p.stop()));
-		console.log("DISCONNECTED!");
 	})
 	.run();

--- a/packages/client/src/__tests__/profile.test.ts
+++ b/packages/client/src/__tests__/profile.test.ts
@@ -1,0 +1,126 @@
+import { field, option, variant } from "@dao-xyz/borsh";
+import { Documents, DocumentIndex } from "@dao-xyz/peerbit-document";
+import {
+	ObserverType,
+	Program,
+	ReplicatorType,
+} from "@dao-xyz/peerbit-program";
+import { v4 as uuid } from "uuid";
+import { Peerbit } from "../peer.js";
+import { createLibp2pExtended } from "@dao-xyz/peerbit-libp2p";
+import { tcp } from "@libp2p/tcp";
+import defer from "p-defer";
+import { randomBytes } from "@dao-xyz/peerbit-crypto";
+
+/**
+ * A test meant for profiling purposes
+ */
+
+@variant("document")
+class Document {
+	@field({ type: "string" })
+	id: string;
+
+	@field({ type: option("string") })
+	name?: string;
+
+	@field({ type: Uint8Array })
+	bytes: Uint8Array;
+
+	constructor(opts: Document) {
+		if (opts) {
+			this.id = opts.id;
+			this.name = opts.name;
+			this.bytes = opts.bytes;
+		}
+	}
+}
+
+@variant("test_documents")
+class TestStore extends Program {
+	@field({ type: Documents })
+	docs: Documents<Document>;
+
+	constructor() {
+		super();
+		this.docs = new Documents({ index: new DocumentIndex({ indexBy: "id" }) });
+	}
+
+	async setup(): Promise<void> {
+		await this.docs.setup({ type: Document });
+	}
+}
+const RANDOM_BYTES = randomBytes(14 * 1000);
+
+describe("profile", () => {
+	let readerResolver: Map<string, () => void>;
+	let stores: TestStore[];
+	let peers: Peerbit[];
+
+	beforeEach(async () => {
+		readerResolver = new Map();
+		peers = await Promise.all(
+			[
+				await createLibp2pExtended({ transports: [tcp()] }),
+				await createLibp2pExtended({ transports: [tcp()] }),
+				await createLibp2pExtended({ transports: [tcp()] }),
+			].map((x) => Peerbit.create({ libp2p: x }))
+		);
+
+		await peers[0].dial(peers[1]);
+		await peers[1].dial(peers[2]);
+
+		stores = [];
+
+		// Create store
+		let address: string | undefined = undefined;
+
+		for (const [i, client] of peers.entries()) {
+			const onChange =
+				i === peers.length - 1
+					? (_log, change) => {
+							change.added.forEach((e) => {
+								readerResolver.get(e.hash)?.();
+								readerResolver.delete(e.hash);
+							});
+					  }
+					: undefined;
+			const store: TestStore = await client.open(address || new TestStore(), {
+				log: {
+					onChange,
+				},
+				role:
+					i === peers.length - 1 ? new ReplicatorType() : new ObserverType(),
+			});
+
+			await store.load();
+			stores.push(store);
+			address = store.address.toString();
+		}
+	});
+
+	afterEach(async () => {
+		await Promise.all(peers.map((x) => x.disconnect()));
+		await Promise.all(peers.map((n) => n.libp2p.stop()));
+	});
+	it("puts", async () => {
+		let COUNT = 100;
+		const writeStore = stores[0];
+		let promises: Promise<any>[] = [];
+		for (let i = 0; i < COUNT; i++) {
+			const doc = new Document({
+				id: uuid(),
+				name: uuid(),
+				bytes: RANDOM_BYTES,
+			});
+			const deferred = defer();
+			const entry = await writeStore.docs.put(doc, { unique: true });
+
+			// wait for reading
+			readerResolver.set(entry.entry.hash, deferred.resolve.bind(deferred));
+			await deferred.promise;
+			promises.push(deferred.promise);
+		}
+		await Promise.all(promises);
+	});
+});

--- a/packages/libp2p/direct-block/package.json
+++ b/packages/libp2p/direct-block/package.json
@@ -59,7 +59,7 @@
 		"@dao-xyz/peerbit-crypto": "^0.1.14",
 		"@ipld/dag-cbor": "^9.0.0",
 		"abstract-level": "^1.0.3",
-		"libp2p": "^0.45.3",
+		"libp2p": "^0.45.4",
 		"memory-level": "^1.0.0"
 	}
 }

--- a/packages/libp2p/direct-stream/package.json
+++ b/packages/libp2p/direct-stream/package.json
@@ -63,7 +63,7 @@
 		"abstract-level": "^1.0.3",
 		"graphology": "^0.25.1",
 		"graphology-shortest-path": "^2.0.1",
-		"libp2p": "^0.45.3",
+		"libp2p": "^0.45.4",
 		"memory-level": "^1.0.0",
 		"yallist": "^4.0.0"
 	}

--- a/packages/libp2p/direct-stream/src/__tests__/stream.test.ts
+++ b/packages/libp2p/direct-stream/src/__tests__/stream.test.ts
@@ -311,6 +311,22 @@ describe("streams", function () {
 				expect(metrics[2].recieved).toHaveLength(1);
 				expect(metrics[1].recieved).toHaveLength(0);
 			});
+
+			it("1->3 still works even if routing is missing", async () => {
+				metrics[0].stream.routes.clear();
+				metrics[1].stream.routes.clear();
+				await metrics[0].stream.publish(data, {
+					to: [metrics[2].stream.components.peerId],
+				});
+				await waitForResolved(() =>
+					expect(metrics[2].recieved).toHaveLength(1)
+				);
+				expect(new Uint8Array(metrics[2].recieved[0].data)).toEqual(data);
+				await delay(1000); // wait some more time to make sure we dont get more messages
+				expect(metrics[2].recieved).toHaveLength(1);
+				expect(metrics[1].recieved).toHaveLength(0);
+			});
+
 			it("publishes on direct stream, even path is longer", async () => {
 				await session.connect([[session.peers[0], session.peers[2]]]);
 				await waitForPeerStreams(metrics[0].stream, metrics[2].stream);
@@ -584,6 +600,19 @@ describe("streams", function () {
 					await waitForPeerStreams(metrics[1].stream, metrics[4].stream);
 					await waitForPeerStreams(metrics[2].stream, metrics[3].stream);
 					await waitForPeerStreams(metrics[2].stream, metrics[4].stream);
+
+					await waitForResolved(() =>
+						expect(metrics[0].stream.routes.nodeCount).toEqual(4)
+					);
+					await waitForResolved(() =>
+						expect(metrics[1].stream.routes.nodeCount).toEqual(4)
+					);
+					await waitForResolved(() =>
+						expect(metrics[2].stream.routes.nodeCount).toEqual(4)
+					);
+					await waitForResolved(() =>
+						expect(metrics[3].stream.routes.nodeCount).toEqual(4)
+					);
 				});
 
 				afterEach(async () => {

--- a/packages/libp2p/direct-stream/src/__tests__/stream.test.ts
+++ b/packages/libp2p/direct-stream/src/__tests__/stream.test.ts
@@ -155,6 +155,7 @@ describe("streams", function () {
 						?.pingLatency! < 1000
 			);
 		});
+		// TODO add test to make sure Hello's are not resent uneccessary amount of times
 
 		it("ping interval", async () => {
 			// 0 and 2 not connected
@@ -255,14 +256,30 @@ describe("streams", function () {
 			});
 
 			it("1->2", async () => {
+				metrics[0].seen.clear();
+				metrics[1].seen.clear();
+				metrics[2].seen.clear();
+
 				await metrics[0].stream.publish(data, {
 					to: [metrics[1].stream.components.peerId],
 				});
 				await waitFor(() => metrics[1].recieved.length === 1);
-				expect(new Uint8Array(metrics[1].recieved[0].data)).toEqual(data);
+				let recievedMessage = metrics[1].recieved[0];
+				expect(new Uint8Array(recievedMessage.data)).toEqual(data);
 				await delay(1000); // wait some more time to make sure we dont get more messages
 				expect(metrics[1].recieved).toHaveLength(1);
 				expect(metrics[2].recieved).toHaveLength(0);
+
+				// Never seen a message twice
+				expect(
+					[...metrics[0].seen.values()].find((x) => x > 1)
+				).toBeUndefined();
+				expect(
+					[...metrics[1].seen.values()].find((x) => x > 1)
+				).toBeUndefined();
+				expect(
+					[...metrics[2].seen.values()].find((x) => x > 1)
+				).toBeUndefined();
 			});
 
 			it("1->3", async () => {
@@ -341,12 +358,17 @@ describe("streams", function () {
 						metrics[0].stream.routes.graph
 					);
 
+				let link02 = metrics[0].stream.routes.getLink(
+					metrics[0].stream.publicKeyHash,
+					metrics[2].stream.publicKeyHash
+				);
+
 				// make path long
 				metrics[0].stream.routes.graph.getEdgeAttribute = (
 					edge: unknown,
 					name: any
 				) => {
-					if (edge === link) {
+					if (edge === link02) {
 						return 1e5;
 					}
 					return defaultEdgeWeightFnPeer0(edge, name);
@@ -358,25 +380,23 @@ describe("streams", function () {
 
 				metrics[1].messages = [];
 
-				await waitFor(
-					() =>
+				await waitForResolved(() =>
+					expect(
 						metrics[1].messages.filter((x) => x instanceof DataMessage)
-							.length === 1
+					).toHaveLength(1)
 				); // will send through peer [1] since path [0] -> [2] -> [3] directly is currently longer
-				await waitFor(() => metrics[3].recieved.length === 1);
+				await waitForResolved(() =>
+					expect(metrics[3].recieved).toHaveLength(1)
+				);
 
 				metrics[1].messages = [];
 
 				// Make [0] -> [2] path short
-				let link = metrics[0].stream.routes.getLink(
-					metrics[0].stream.publicKeyHash,
-					metrics[2].stream.publicKeyHash
-				);
 				metrics[0].stream.routes.graph.getEdgeAttribute = (
 					edge: unknown,
 					name: any
 				) => {
-					if (edge === link) {
+					if (edge === link02) {
 						return 0;
 					}
 					return defaultEdgeWeightFnPeer0(edge, name);
@@ -401,7 +421,112 @@ describe("streams", function () {
 		});
 
 		describe("fanout", () => {
-			/** 
+			describe("basic", () => {
+				let session: TestSession;
+				let metrics: ReturnType<typeof createMetrics>[];
+
+				beforeAll(async () => {});
+
+				beforeEach(async () => {
+					session = await connected(3, {
+						services: {
+							directstream: (c) =>
+								new TestDirectStream(c, {
+									connectionManager: { autoDial: false },
+								}),
+						},
+					});
+					metrics = [];
+					for (const peer of session.peers) {
+						metrics.push(createMetrics(peer.services.directstream));
+					}
+
+					await waitForPeerStreams(metrics[0].stream, metrics[1].stream);
+				});
+
+				afterEach(async () => {
+					await session.stop();
+				});
+
+				/**
+				 * If tests below fails, dead-locks can apphear in unpredictable ways
+				 */
+				it("will not publish to from when explicitly providing to", async () => {
+					const msg = new DataMessage({ data: new Uint8Array([0]) });
+					await msg.sign(metrics[1].stream.sign);
+					metrics[2].stream.canRelayMessage = false; // so that 2 does not relay to 0
+					await metrics[1].stream.publishMessage(session.peers[0].peerId, msg, [
+						metrics[1].stream.peers.get(metrics[0].stream.publicKeyHash)!,
+						metrics[1].stream.peers.get(metrics[2].stream.publicKeyHash)!,
+					]);
+					const msgId = await getMsgId(msg.serialize());
+					await waitForResolved(() =>
+						expect(metrics[2].seen.get(msgId)).toEqual(1)
+					);
+
+					await delay(1000); // wait for more messages eventually propagate
+					expect(metrics[0].seen.get(msgId)).toBeUndefined();
+					expect(metrics[1].seen.get(msgId)).toBeUndefined();
+				});
+
+				it("to in message will not send back", async () => {
+					const msg = new DataMessage({
+						data: new Uint8Array([0]),
+						to: [
+							metrics[0].stream.publicKeyHash,
+							metrics[2].stream.publicKeyHash,
+						],
+					});
+					await msg.sign(metrics[1].stream.sign);
+					await metrics[1].stream.publishMessage(session.peers[0].peerId, msg);
+					await delay(1000);
+					const msgId = await getMsgId(msg.serialize());
+					expect(metrics[0].seen.get(msgId)).toBeUndefined();
+					expect(metrics[1].seen.get(msgId)).toBeUndefined();
+					expect(metrics[2].seen.get(msgId)).toEqual(1);
+				});
+
+				it("rejects when to peers is from", async () => {
+					const msg = new DataMessage({ data: new Uint8Array([0]) });
+					await msg.sign(metrics[1].stream.sign);
+					await expect(
+						metrics[1].stream.publishMessage(session.peers[0].peerId, msg, [
+							metrics[1].stream.peers.get(metrics[0].stream.publicKeyHash)!,
+						])
+					).rejects.toThrowError("Message did not have any valid recievers");
+				});
+				it("rejects when only to is from", async () => {
+					const msg = new DataMessage({
+						data: new Uint8Array([0]),
+						to: [metrics[1].stream.publicKeyHash],
+					});
+					await msg.sign(metrics[1].stream.sign);
+					await metrics[1].stream.publishMessage(session.peers[0].peerId, msg);
+					const msgId = await getMsgId(msg.serialize());
+					await delay(1000);
+					expect(metrics[0].seen.get(msgId)).toBeUndefined();
+					expect(metrics[1].seen.get(msgId)).toBeUndefined();
+					expect(metrics[2].seen.get(msgId)).toBeUndefined();
+				});
+
+				it("will send through peer", async () => {
+					await session.peers[0].hangUp(session.peers[1].peerId);
+
+					// send a message with to=[2]
+					// make sure message is received
+					const msg = new DataMessage({
+						data: new Uint8Array([0]),
+						to: [metrics[2].stream.publicKeyHash],
+					});
+					await msg.sign(metrics[1].stream.sign);
+					await metrics[0].stream.publishMessage(session.peers[0].peerId, msg);
+					await waitForResolved(() =>
+						expect(metrics[2].recieved).toHaveLength(1)
+					);
+				});
+			});
+			describe("1->2->2", () => {
+				/** 
 			┌─────┐ 
 			│0    │ 
 			└┬───┬┘ 
@@ -419,85 +544,86 @@ describe("streams", function () {
 			└──┘└──┘
 			*/
 
-			let session: TestSession;
-			let metrics: ReturnType<typeof createMetrics>[];
-			const data = new Uint8Array([1, 2, 3]);
+				let session: TestSession;
+				let metrics: ReturnType<typeof createMetrics>[];
+				const data = new Uint8Array([1, 2, 3]);
 
-			beforeAll(async () => {});
+				beforeAll(async () => {});
 
-			beforeEach(async () => {
-				session = await disconnected(5, {
-					services: {
-						directstream: (c) =>
-							new TestDirectStream(c, {
-								connectionManager: { autoDial: false },
-							}),
-					},
+				beforeEach(async () => {
+					session = await disconnected(5, {
+						services: {
+							directstream: (c) =>
+								new TestDirectStream(c, {
+									connectionManager: { autoDial: false },
+								}),
+						},
+					});
+					metrics = [];
+					for (const peer of session.peers) {
+						metrics.push(createMetrics(peer.services.directstream));
+					}
+					await session.connect([
+						// behaviour seems to be more predictable if we connect after start (TODO improve startup to use existing connections in a better way)
+						[session.peers[0], session.peers[1]],
+						[session.peers[0], session.peers[2]],
+
+						[session.peers[1], session.peers[3]],
+						[session.peers[1], session.peers[4]],
+
+						[session.peers[2], session.peers[3]],
+						[session.peers[2], session.peers[4]],
+					]);
+
+					await waitForPeerStreams(metrics[0].stream, metrics[1].stream);
+					await waitForPeerStreams(metrics[0].stream, metrics[2].stream);
+					await waitForPeerStreams(metrics[1].stream, metrics[3].stream);
+					await waitForPeerStreams(metrics[1].stream, metrics[4].stream);
+					await waitForPeerStreams(metrics[2].stream, metrics[3].stream);
+					await waitForPeerStreams(metrics[2].stream, metrics[4].stream);
 				});
-				metrics = [];
-				for (const peer of session.peers) {
-					metrics.push(createMetrics(peer.services.directstream));
-				}
-				await session.connect([
-					// behaviour seems to be more predictable if we connect after start (TODO improve startup to use existing connections in a better way)
-					[session.peers[0], session.peers[1]],
-					[session.peers[0], session.peers[2]],
 
-					[session.peers[1], session.peers[3]],
-					[session.peers[1], session.peers[4]],
-
-					[session.peers[2], session.peers[3]],
-					[session.peers[2], session.peers[4]],
-				]);
-
-				await waitForPeerStreams(metrics[0].stream, metrics[1].stream);
-				await waitForPeerStreams(metrics[0].stream, metrics[2].stream);
-				await waitForPeerStreams(metrics[1].stream, metrics[3].stream);
-				await waitForPeerStreams(metrics[1].stream, metrics[4].stream);
-				await waitForPeerStreams(metrics[2].stream, metrics[3].stream);
-				await waitForPeerStreams(metrics[2].stream, metrics[4].stream);
-			});
-
-			afterEach(async () => {
-				await session.stop();
-			});
-
-			it("messages are only sent once to each peer", async () => {
-				await waitForResolved(() =>
-					expect(metrics[0].stream.routes.nodeCount).toEqual(5)
-				);
-				await waitForResolved(() =>
-					expect(metrics[1].stream.routes.nodeCount).toEqual(5)
-				);
-				await waitForResolved(() =>
-					expect(metrics[2].stream.routes.nodeCount).toEqual(5)
-				);
-				await waitForResolved(() =>
-					expect(metrics[3].stream.routes.nodeCount).toEqual(5)
-				);
-				await waitForResolved(() =>
-					expect(metrics[4].stream.routes.nodeCount).toEqual(5)
-				);
-
-				metrics[0].stream.publish(data, {
-					to: [
-						metrics[3].stream.publicKeyHash,
-						metrics[4].stream.publicKeyHash,
-					],
+				afterEach(async () => {
+					await session.stop();
 				});
-				await waitForResolved(() =>
-					expect(metrics[3].recieved).toHaveLength(1)
-				);
-				await waitForResolved(() =>
-					expect(metrics[4].recieved).toHaveLength(1)
-				);
 
-				const id1 = await getMsgId(serialize(metrics[3].recieved[0]));
+				it("messages are only sent once to each peer", async () => {
+					await waitForResolved(() =>
+						expect(metrics[0].stream.routes.nodeCount).toEqual(5)
+					);
+					await waitForResolved(() =>
+						expect(metrics[1].stream.routes.nodeCount).toEqual(5)
+					);
+					await waitForResolved(() =>
+						expect(metrics[2].stream.routes.nodeCount).toEqual(5)
+					);
+					await waitForResolved(() =>
+						expect(metrics[3].stream.routes.nodeCount).toEqual(5)
+					);
+					await waitForResolved(() =>
+						expect(metrics[4].stream.routes.nodeCount).toEqual(5)
+					);
 
-				await delay(3000); // Wait some extra time if additional messages are propagating throughß
+					metrics[0].stream.publish(data, {
+						to: [
+							metrics[3].stream.publicKeyHash,
+							metrics[4].stream.publicKeyHash,
+						],
+					});
+					await waitForResolved(() =>
+						expect(metrics[3].recieved).toHaveLength(1)
+					);
+					await waitForResolved(() =>
+						expect(metrics[4].recieved).toHaveLength(1)
+					);
 
-				expect(metrics[3].seen.get(id1)).toEqual(1); // 1 delivery even though there are multiple path leading to this node
-				expect(metrics[4].seen.get(id1)).toEqual(1); // 1 delivery even though there are multiple path leading to this node
+					const id1 = await getMsgId(serialize(metrics[3].recieved[0]));
+
+					await delay(3000); // Wait some extra time if additional messages are propagating throughß
+
+					expect(metrics[3].seen.get(id1)).toEqual(1); // 1 delivery even though there are multiple path leading to this node
+					expect(metrics[4].seen.get(id1)).toEqual(1); // 1 delivery even though there are multiple path leading to this node
+				});
 			});
 		});
 	});
@@ -929,9 +1055,9 @@ describe("streams", function () {
 			┌▽┐
 			│2│
 			└─┘
-	
+		
 			< 2 connects with 3 >
-	
+		
 			┌─┐
 			│3│
 			└△┘

--- a/packages/libp2p/direct-stream/src/__tests__/stream.test.ts
+++ b/packages/libp2p/direct-stream/src/__tests__/stream.test.ts
@@ -286,7 +286,9 @@ describe("streams", function () {
 				await metrics[0].stream.publish(data, {
 					to: [metrics[2].stream.components.peerId],
 				});
-				await waitFor(() => metrics[2].recieved.length === 1);
+				await waitForResolved(() =>
+					expect(metrics[2].recieved).toHaveLength(1)
+				);
 				expect(new Uint8Array(metrics[2].recieved[0].data)).toEqual(data);
 				await delay(1000); // wait some more time to make sure we dont get more messages
 				expect(metrics[2].recieved).toHaveLength(1);
@@ -298,10 +300,11 @@ describe("streams", function () {
 				await metrics[0].stream.publish(bigData, {
 					to: [metrics[2].stream.components.peerId],
 				});
-				await waitFor(() => metrics[2].recieved.length === 1, {
-					delayInterval: 10,
-					timeout: 10 * 1000,
-				});
+
+				await waitForResolved(() =>
+					expect(metrics[2].recieved).toHaveLength(1)
+				);
+
 				expect(new Uint8Array(metrics[2].recieved[0].data)).toHaveLength(
 					bigData.length
 				);
@@ -325,10 +328,10 @@ describe("streams", function () {
 					to: [metrics[2].stream.components.peerId],
 				});
 				metrics[1].messages = [];
-				await waitFor(() => metrics[2].recieved.length === 1, {
-					delayInterval: 10,
-					timeout: 10 * 1000,
-				});
+				await waitForResolved(() =>
+					expect(metrics[2].recieved).toHaveLength(1)
+				);
+
 				expect(
 					metrics[1].messages.filter((x) => x instanceof DataMessage)
 				).toHaveLength(0);

--- a/packages/libp2p/direct-stream/src/__tests__/stream.test.ts
+++ b/packages/libp2p/direct-stream/src/__tests__/stream.test.ts
@@ -602,25 +602,6 @@ describe("streams", function () {
 					await waitForPeerStreams(metrics[2].stream, metrics[4].stream);
 
 					await waitForResolved(() =>
-						expect(metrics[0].stream.routes.nodeCount).toEqual(4)
-					);
-					await waitForResolved(() =>
-						expect(metrics[1].stream.routes.nodeCount).toEqual(4)
-					);
-					await waitForResolved(() =>
-						expect(metrics[2].stream.routes.nodeCount).toEqual(4)
-					);
-					await waitForResolved(() =>
-						expect(metrics[3].stream.routes.nodeCount).toEqual(4)
-					);
-				});
-
-				afterEach(async () => {
-					await session.stop();
-				});
-
-				it("messages are only sent once to each peer", async () => {
-					await waitForResolved(() =>
 						expect(metrics[0].stream.routes.nodeCount).toEqual(5)
 					);
 					await waitForResolved(() =>
@@ -635,7 +616,13 @@ describe("streams", function () {
 					await waitForResolved(() =>
 						expect(metrics[4].stream.routes.nodeCount).toEqual(5)
 					);
+				});
 
+				afterEach(async () => {
+					await session.stop();
+				});
+
+				it("messages are only sent once to each peer", async () => {
 					metrics[0].stream.publish(data, {
 						to: [
 							metrics[3].stream.publicKeyHash,

--- a/packages/libp2p/direct-stream/src/index.ts
+++ b/packages/libp2p/direct-stream/src/index.ts
@@ -429,48 +429,6 @@ export abstract class DirectStream<
 
 		// register protocol with topology
 		// Topology callbacks called on connection manager changes
-
-		// TODO remove when https://github.com/libp2p/js-libp2p/issues/1755 fixed
-		this.components.events.removeEventListener(
-			"connection:close",
-			this.components.registrar["_onDisconnect"]
-		);
-		this.components.registrar["_onDisconnect"] = (
-			evt: CustomEvent<Connection>
-		): void => {
-			const connection = evt.detail;
-			void this.components.peerStore
-				.get(connection.remotePeer)
-				.then((peer) => {
-					for (const protocol of peer.protocols) {
-						const topologies =
-							this.components.registrar.getTopologies(protocol);
-						if (topologies == null) {
-							// no topologies are interested in this protocol
-							continue;
-						}
-
-						for (const topology of topologies.values()) {
-							(topology as TopologyImpl).onDisconnect(
-								connection.remotePeer,
-								connection
-							);
-						}
-					}
-				})
-				.catch((err) => {
-					console.error(
-						"could not inform topologies of disconnecting peer %p",
-						connection.remotePeer,
-						err
-					);
-				});
-		};
-		this.components.events.addEventListener(
-			"connection:close",
-			this.components.registrar["_onDisconnect"]
-		);
-
 		this._registrarTopologyIds = await Promise.all(
 			this.multicodecs.map((multicodec) =>
 				this.components.registrar.register(multicodec, this.topology)

--- a/packages/libp2p/direct-stream/src/messages.ts
+++ b/packages/libp2p/direct-stream/src/messages.ts
@@ -454,11 +454,7 @@ export class Hello extends Message {
 			this,
 			this.signatures.signatures.length
 		).next().value!;
-		try {
-			this.signatures.signatures.push(await sign(toSign));
-		} catch (error) {
-			const q = 123;
-		}
+		this.signatures.signatures.push(await sign(toSign));
 		return this;
 	}
 

--- a/packages/libp2p/direct-sub/package.json
+++ b/packages/libp2p/direct-sub/package.json
@@ -58,7 +58,7 @@
 		"@dao-xyz/uint8arrays": "^0.0.3",
 		"@libp2p/interfaces": "^3.3.1",
 		"abstract-level": "^1.0.3",
-		"libp2p": "^0.45.3",
+		"libp2p": "^0.45.4",
 		"memory-level": "^1.0.0"
 	}
 }

--- a/packages/libp2p/direct-sub/src/index.ts
+++ b/packages/libp2p/direct-sub/src/index.ts
@@ -423,7 +423,6 @@ export class DirectSub extends DirectStream<PubSubEvents> {
 
 			const isFromSelf = this.components.peerId.equals(from);
 			if (!isFromSelf || this.emitSelf) {
-				//	const isForAll = message.to.length === 0;
 				let isForMe: boolean;
 				if (pubsubMessage.strict) {
 					isForMe =

--- a/packages/libp2p/libp2p-test-utils/package.json
+++ b/packages/libp2p/libp2p-test-utils/package.json
@@ -42,7 +42,7 @@
 		"@libp2p/mplex": "^8.0.3",
 		"@libp2p/tcp": "^7.0.1",
 		"datastore-level": "^9.0.4",
-		"libp2p": "^0.45.3",
+		"libp2p": "^0.45.4",
 		"memory-level": "^1.0.0"
 	},
 	"devDependencies": {

--- a/packages/libp2p/peerbit-libp2p/package.json
+++ b/packages/libp2p/peerbit-libp2p/package.json
@@ -51,7 +51,7 @@
 		"@libp2p/webrtc": "^2.0.4",
 		"@libp2p/websockets": "^6.0.1",
 		"level": "^8.0.0",
-		"libp2p": "^0.45.3"
+		"libp2p": "^0.45.4"
 	},
 	"devDependencies": {
 		"@dao-xyz/peerbit-time": "^0.0.23"

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -37,7 +37,7 @@
 		"@dao-xyz/peerbit-crypto": "^0.1.14",
 		"@dao-xyz/peerbit-logger": "^0.0.6",
 		"json-stringify-deterministic": "^1.0.7",
-		"libp2p": "^0.45.3",
+		"libp2p": "^0.45.4",
 		"p-do-whilst": "^1.1.0",
 		"p-map": "^5.5.0",
 		"p-queue": "^7.3.3",

--- a/packages/programs/acl/identity-access-controller/src/__tests__/index.integration.test.ts
+++ b/packages/programs/acl/identity-access-controller/src/__tests__/index.integration.test.ts
@@ -7,14 +7,12 @@ import {
 	AccessError,
 	Ed25519Keypair,
 	randomBytes,
-	sha256Sync,
 } from "@dao-xyz/peerbit-crypto";
 import {
 	Documents,
 	DocumentIndex,
-	DocumentQuery,
+	SearchRequest,
 	StringMatch,
-	Results,
 } from "@dao-xyz/peerbit-document";
 import type { CanAppend, Identity } from "@dao-xyz/peerbit-log";
 import { CanRead, RPC } from "@dao-xyz/peerbit-rpc";
@@ -443,7 +441,7 @@ describe("index", () => {
 
 			const q = async (): Promise<Document[]> => {
 				return l0b.store.index.query(
-					new DocumentQuery({
+					new SearchRequest({
 						queries: [
 							new StringMatch({
 								key: "id",
@@ -536,7 +534,7 @@ describe("index", () => {
 		await waitFor(() => l0b.accessController.access.index.size === 1);
 
 		let results: Document[] = await l0b.accessController.access.index.query(
-			new DocumentQuery({
+			new SearchRequest({
 				queries: [],
 			}),
 			{

--- a/packages/programs/acl/trusted-network/src/__tests__/index.integration.test.ts
+++ b/packages/programs/acl/trusted-network/src/__tests__/index.integration.test.ts
@@ -19,7 +19,7 @@ import {
 	ReplicatorType,
 	SubscriptionType,
 } from "@dao-xyz/peerbit-program";
-import { Documents, DocumentQuery, Operation } from "@dao-xyz/peerbit-document";
+import { Documents, SearchRequest, Operation } from "@dao-xyz/peerbit-document";
 import { v4 as uuid } from "uuid";
 import { waitForPeers as waitForPeersBlock } from "@dao-xyz/libp2p-direct-stream";
 import { waitForSubscribers } from "@dao-xyz/libp2p-direct-sub";
@@ -292,7 +292,7 @@ describe("index", () => {
 			// Try query with trusted
 			let responseCount = 0;
 			let responses: IdentityRelation[] = await l0c.trustGraph.index.query(
-				new DocumentQuery({
+				new SearchRequest({
 					queries: [],
 				}),
 				{
@@ -313,7 +313,7 @@ describe("index", () => {
 			// TODO we are not using read access control on the trust graph anymore, but should we?
 			/* let untrustedResponse: Results<IdentityRelation>[] =
 				await l0d.trustGraph.index.query(
-					new DocumentQuery({
+					new SearchRequest({
 						queries: [],
 					}),
 					{

--- a/packages/programs/acl/trusted-network/src/controller.ts
+++ b/packages/programs/acl/trusted-network/src/controller.ts
@@ -1,6 +1,6 @@
 import { deserialize, field, serialize, variant, vec } from "@dao-xyz/borsh";
 import {
-	DocumentQuery,
+	SearchRequest,
 	Documents,
 	Operation,
 	PutOperation,
@@ -229,7 +229,7 @@ export class TrustedNetwork extends Program {
 		if (this.trustGraph.role instanceof ReplicatorType) {
 			return this._isTrustedLocal(trustee, truster);
 		} else {
-			this.trustGraph.index.query(new DocumentQuery({ queries: [] }), {
+			this.trustGraph.index.query(new SearchRequest({ queries: [] }), {
 				remote: { sync: true },
 			});
 			return this._isTrustedLocal(trustee, truster);

--- a/packages/programs/acl/trusted-network/src/identity-graph.ts
+++ b/packages/programs/acl/trusted-network/src/identity-graph.ts
@@ -2,7 +2,7 @@ import { field, fixedArray, serialize, variant } from "@dao-xyz/borsh";
 import {
 	Documents,
 	DocumentIndex,
-	DocumentQuery,
+	SearchRequest,
 	StringMatch,
 } from "@dao-xyz/peerbit-document";
 import { PublicSignKey } from "@dao-xyz/peerbit-crypto";
@@ -24,7 +24,7 @@ export const getFromByTo: RelationResolver = {
 		return Promise.all(
 			(
 				await db.index.queryHandler(
-					new DocumentQuery({
+					new SearchRequest({
 						queries: [
 							new StringMatch({
 								key: "to",
@@ -33,7 +33,7 @@ export const getFromByTo: RelationResolver = {
 						],
 					})
 				)
-			).map((x) => x.value)
+			).results.map((x) => x.value)
 		);
 	},
 	next: (relation) => relation.from,
@@ -44,7 +44,7 @@ export const getToByFrom: RelationResolver = {
 		return Promise.all(
 			(
 				await db.index.queryHandler(
-					new DocumentQuery({
+					new SearchRequest({
 						queries: [
 							new StringMatch({
 								key: "from",
@@ -53,7 +53,7 @@ export const getToByFrom: RelationResolver = {
 						],
 					})
 				)
-			).map((x) => x.value)
+			).results.map((x) => x.value)
 		);
 	},
 	next: (relation) => relation.to,

--- a/packages/programs/data/document/README.md
+++ b/packages/programs/data/document/README.md
@@ -16,7 +16,7 @@ import { Peerbit } from "@dao-xyz/peerbit";
 import {
 	Documents,
 	DocumentIndex,
-	DocumentQuery,
+	SearchRequest,
 	StringMatch,
 	StringMatchMethod,
 	Results,
@@ -96,7 +96,7 @@ const peer2 = await Peerbit.create ({libp2: another_libp2p_instance})
 const store2 = peer2.open(store.address);
 
 let responses: Document[] = await store2.docs.index.query(
-    new DocumentQuery({
+    new SearchRequest({
         queries: [
           new StringMatch({
                 key: "name",

--- a/packages/programs/data/document/src/__tests__/index.integration.test.ts
+++ b/packages/programs/data/document/src/__tests__/index.integration.test.ts
@@ -30,7 +30,7 @@ import {
 	Program,
 	ReplicatorType,
 } from "@dao-xyz/peerbit-program";
-import { delay, waitFor } from "@dao-xyz/peerbit-time";
+import { waitFor } from "@dao-xyz/peerbit-time";
 import { DocumentIndex } from "../document-index.js";
 import { waitForPeers as waitForPeersStreams } from "@dao-xyz/libp2p-direct-stream";
 import { waitForSubscribers } from "@dao-xyz/libp2p-direct-sub";

--- a/packages/programs/data/document/src/__tests__/index.integration.test.ts
+++ b/packages/programs/data/document/src/__tests__/index.integration.test.ts
@@ -6,11 +6,14 @@ import {
 	Compare,
 	MissingField,
 	And,
-	DocumentQuery,
+	SearchRequest,
 	StringMatchMethod,
 	Or,
 	ByteMatchQuery,
 	BoolQuery,
+	Sort,
+	SortDirection,
+	SearchSortedRequest,
 } from "../query.js";
 import { LSession, createStore } from "@dao-xyz/peerbit-test-utils";
 import { Identity, Log } from "@dao-xyz/peerbit-log";
@@ -29,9 +32,12 @@ import {
 } from "@dao-xyz/peerbit-program";
 import { delay, waitFor } from "@dao-xyz/peerbit-time";
 import { DocumentIndex } from "../document-index.js";
-
 import { waitForPeers as waitForPeersStreams } from "@dao-xyz/libp2p-direct-stream";
 import { waitForSubscribers } from "@dao-xyz/libp2p-direct-sub";
+
+BigInt.prototype["toJSON"] = function () {
+	return this.toString();
+};
 
 @variant("document")
 class Document {
@@ -346,9 +352,11 @@ describe("index", () => {
 						id: "abc 123",
 						value: "Hello world",
 					});
+
 					await (store as TestSimpleStore).docs.put(doc);
+
 					const results = await (store as TestSimpleStore).docs.index.query(
-						new DocumentQuery({
+						new SearchRequest({
 							queries: [
 								new StringMatch({
 									key: "id",
@@ -357,7 +365,8 @@ describe("index", () => {
 									method: StringMatchMethod.contains,
 								}),
 							],
-						})
+						}),
+						{ remote: { amount: 1 } }
 					);
 					expect(results).toHaveLength(1);
 				});
@@ -416,7 +425,7 @@ describe("index", () => {
 
 					await (store as TestSimpleStore).docs.put(doc);
 					const results = await (store as TestSimpleStore).docs.index.query(
-						new DocumentQuery({
+						new SearchRequest({
 							queries: [
 								new ByteMatchQuery({
 									key: "id",
@@ -609,7 +618,7 @@ describe("index", () => {
 					});
 
 					let results = await store2.docs.index.query(
-						new DocumentQuery({ queries: [] })
+						new SearchRequest({ queries: [] })
 					);
 					expect(results).toHaveLength(1);
 				});
@@ -724,20 +733,19 @@ describe("index", () => {
 
 			afterAll(async () => {
 				await Promise.all(stores.map((x) => x.drop()));
-
 				await session.stop();
 			});
 
 			it("no-args", async () => {
 				let results: Document[] = await stores[0].docs.index.query(
-					new DocumentQuery({ queries: [] })
+					new SearchRequest({ queries: [] })
 				);
 				expect(results).toHaveLength(4);
 			});
 
 			it("match locally", async () => {
 				let results: Document[] = await stores[0].docs.index.query(
-					new DocumentQuery({
+					new SearchRequest({
 						queries: [],
 					}),
 					{ remote: false }
@@ -747,7 +755,7 @@ describe("index", () => {
 
 			it("match all", async () => {
 				let results: Document[] = await stores[1].docs.index.query(
-					new DocumentQuery({
+					new SearchRequest({
 						queries: [],
 					}),
 					{ remote: { amount: 1 } }
@@ -774,7 +782,7 @@ describe("index", () => {
 					};
 
 					await stores[1].docs.index.query(
-						new DocumentQuery({
+						new SearchRequest({
 							queries: [],
 						}),
 						{ remote: { amount: 1, sync: true } }
@@ -785,7 +793,7 @@ describe("index", () => {
 					expect(syncEvents).toEqual(1);
 
 					await stores[1].docs.index.query(
-						new DocumentQuery({
+						new SearchRequest({
 							queries: [],
 						}),
 						{ remote: { amount: 1, sync: true } }
@@ -799,7 +807,7 @@ describe("index", () => {
 			describe("string", () => {
 				it("exact", async () => {
 					let responses: Document[] = await stores[1].docs.index.query(
-						new DocumentQuery({
+						new SearchRequest({
 							queries: [
 								new StringMatch({
 									key: "name",
@@ -816,7 +824,7 @@ describe("index", () => {
 
 				it("exact-case-insensitive", async () => {
 					let responses: Document[] = await stores[1].docs.index.query(
-						new DocumentQuery({
+						new SearchRequest({
 							queries: [
 								new StringMatch({
 									key: "name",
@@ -834,7 +842,7 @@ describe("index", () => {
 
 				it("exact case sensitive", async () => {
 					let responses: Document[] = await stores[1].docs.index.query(
-						new DocumentQuery({
+						new SearchRequest({
 							queries: [
 								new StringMatch({
 									key: "name",
@@ -849,7 +857,7 @@ describe("index", () => {
 						responses.map((x) => Buffer.from(x.id).toString("utf8"))
 					).toContainAllValues(["2"]);
 					responses = await stores[1].docs.index.query(
-						new DocumentQuery({
+						new SearchRequest({
 							queries: [
 								new StringMatch({
 									key: "name",
@@ -865,7 +873,7 @@ describe("index", () => {
 				});
 				it("prefix", async () => {
 					let responses: Document[] = await stores[1].docs.index.query(
-						new DocumentQuery({
+						new SearchRequest({
 							queries: [
 								new StringMatch({
 									key: "name",
@@ -885,7 +893,7 @@ describe("index", () => {
 
 				it("contains", async () => {
 					let responses: Document[] = await stores[1].docs.index.query(
-						new DocumentQuery({
+						new SearchRequest({
 							queries: [
 								new StringMatch({
 									key: "name",
@@ -926,7 +934,7 @@ describe("index", () => {
 					});
 					it("arr", async () => {
 						let responses: Document[] = await stores[1].docs.index.query(
-							new DocumentQuery({
+							new SearchRequest({
 								queries: [
 									new StringMatch({
 										key: "tags",
@@ -947,7 +955,7 @@ describe("index", () => {
 
 			it("missing", async () => {
 				let responses: Document[] = await stores[1].docs.index.query(
-					new DocumentQuery({
+					new SearchRequest({
 						queries: [
 							new MissingField({
 								key: "name",
@@ -964,7 +972,7 @@ describe("index", () => {
 
 			it("bytes", async () => {
 				let responses: Document[] = await stores[1].docs.index.query(
-					new DocumentQuery({
+					new SearchRequest({
 						queries: [
 							new ByteMatchQuery({
 								key: "data",
@@ -981,7 +989,7 @@ describe("index", () => {
 
 			it("bool", async () => {
 				let responses: Document[] = await stores[1].docs.index.query(
-					new DocumentQuery({
+					new SearchRequest({
 						queries: [
 							new BoolQuery({
 								key: "bool",
@@ -1000,7 +1008,7 @@ describe("index", () => {
 			describe("logical", () => {
 				it("and", async () => {
 					let responses: Document[] = await stores[1].docs.index.query(
-						new DocumentQuery({
+						new SearchRequest({
 							queries: [
 								new And([
 									new StringMatch({
@@ -1028,7 +1036,7 @@ describe("index", () => {
 
 				it("or", async () => {
 					let responses: Document[] = await stores[1].docs.index.query(
-						new DocumentQuery({
+						new SearchRequest({
 							queries: [
 								new Or([
 									new ByteMatchQuery({
@@ -1054,7 +1062,7 @@ describe("index", () => {
 			describe("number", () => {
 				it("equal", async () => {
 					let response: Document[] = await stores[1].docs.index.query(
-						new DocumentQuery({
+						new SearchRequest({
 							queries: [
 								new IntegerCompare({
 									key: "number",
@@ -1071,7 +1079,7 @@ describe("index", () => {
 
 				it("gt", async () => {
 					let response: Document[] = await stores[1].docs.index.query(
-						new DocumentQuery({
+						new SearchRequest({
 							queries: [
 								new IntegerCompare({
 									key: "number",
@@ -1088,7 +1096,7 @@ describe("index", () => {
 
 				it("gte", async () => {
 					let response: Document[] = await stores[1].docs.index.query(
-						new DocumentQuery({
+						new SearchRequest({
 							queries: [
 								new IntegerCompare({
 									key: "number",
@@ -1109,7 +1117,7 @@ describe("index", () => {
 
 				it("lt", async () => {
 					let response: Document[] = await stores[1].docs.index.query(
-						new DocumentQuery({
+						new SearchRequest({
 							queries: [
 								new IntegerCompare({
 									key: "number",
@@ -1126,7 +1134,7 @@ describe("index", () => {
 
 				it("lte", async () => {
 					let response: Document[] = await stores[1].docs.index.query(
-						new DocumentQuery({
+						new SearchRequest({
 							queries: [
 								new IntegerCompare({
 									key: "number",
@@ -1155,7 +1163,7 @@ describe("index", () => {
 						if (i % 2 === 0) {
 							promises.push(
 								stores[1].docs.index.query(
-									new DocumentQuery({
+									new SearchRequest({
 										queries: [
 											new IntegerCompare({
 												key: "number",
@@ -1170,7 +1178,7 @@ describe("index", () => {
 						} else {
 							promises.push(
 								stores[1].docs.index.query(
-									new DocumentQuery({
+									new SearchRequest({
 										queries: [
 											new IntegerCompare({
 												key: "number",
@@ -1201,6 +1209,228 @@ describe("index", () => {
 					}
 				});
 			});
+		});
+
+		describe("sort", () => {
+			let peersCount = 3,
+				stores: TestStore[] = [];
+
+			const put = async (storeIndex: number, id: number) => {
+				let doc = new Document({
+					id: Buffer.from(String(id)),
+					name: String(id),
+					number: BigInt(id),
+				});
+				return stores[storeIndex].docs.put(doc);
+			};
+
+			const checkIterate = async (
+				fromStoreIndex: number,
+				batches: bigint[][],
+				query = new IntegerCompare({
+					key: "number",
+					compare: Compare.GreaterOrEqual,
+					value: 0n,
+				})
+			) => {
+				const req = new SearchSortedRequest({
+					queries: [query],
+					sort: [new Sort({ direction: SortDirection.ASC, key: "number" })],
+				});
+				const iterator = await stores[fromStoreIndex].docs.index.iterate(req);
+				for (const batch of batches) {
+					expect(iterator.done()).toBeFalse();
+					const next = await iterator.next(batch.length);
+					expect(next.map((x) => x.number)).toEqual(batch);
+				}
+				expect(iterator.done()).toBeTrue();
+			};
+
+			beforeAll(async () => {
+				session = await LSession.connected(peersCount);
+			});
+
+			beforeEach(async () => {
+				// Create store
+				for (let i = 0; i < peersCount; i++) {
+					const store =
+						i > 0
+							? (await TestStore.load<TestStore>(
+									session.peers[i].services.blocks,
+									stores[0].address!
+							  ))!
+							: new TestStore({
+									docs: new Documents<Document>({
+										index: new DocumentIndex({
+											indexBy: "id",
+										}),
+										immutable: false,
+									}),
+							  });
+					const keypair = await X25519Keypair.create();
+					await store.init(session.peers[i], await createIdentity(), {
+						role: new ReplicatorType(),
+						log: {
+							replication: {
+								replicators: () =>
+									session.peers.map((x) => [x.services.pubsub.publicKeyHash]),
+							},
+							encryption: {
+								getEncryptionKeypair: () => keypair,
+								getAnyKeypair: async (publicKeys: X25519PublicKey[]) => {
+									for (let i = 0; i < publicKeys.length; i++) {
+										if (
+											publicKeys[i].equals((keypair as X25519Keypair).publicKey)
+										) {
+											return {
+												index: i,
+												keypair: keypair as Ed25519Keypair | X25519Keypair,
+											};
+										}
+									}
+								},
+							},
+
+							cache: () => new Cache(createStore()),
+						},
+					});
+
+					stores.push(store);
+				}
+
+				// Wait for ack that everone can connect to each outher through the rpc topic
+				for (let i = 0; i < session.peers.length; i++) {
+					await waitForSubscribers(
+						session.peers[i],
+						session.peers.filter((_v, ix) => ix !== i),
+						stores[i].docs.index._query.rpcTopic
+					);
+				}
+			});
+
+			afterEach(async () => {
+				await Promise.all(stores.map((x) => x.drop()));
+				stores = [];
+			});
+
+			afterAll(async () => {
+				await session.stop();
+			});
+
+			it("empty", async () => {
+				for (let i = 0; i < session.peers.length; i++) {
+					await checkIterate(i, []);
+				}
+			});
+			it("one peer", async () => {
+				await put(0, 0);
+				await put(0, 1);
+				await put(0, 2);
+				expect(stores[0].docs.index.size).toEqual(3);
+				for (let i = 0; i < session.peers.length; i++) {
+					await checkIterate(i, [[0n], [1n], [2n]]);
+					await checkIterate(i, [[0n, 1n, 2n]]);
+					await checkIterate(i, [[0n, 1n], [2n]]);
+					await checkIterate(i, [[0n], [1n, 2n]]);
+				}
+			});
+
+			it("multiple peers", async () => {
+				await put(0, 0);
+				await put(0, 1);
+				let e2 = await put(0, 2);
+				await stores[1].docs.log.join([e2.entry]); // keep doc2 at both node 0 and 1
+				await put(1, 3);
+				await put(1, 4);
+				expect(stores[1].docs.index.size).toEqual(3);
+				for (let i = 0; i < session.peers.length; i++) {
+					await checkIterate(i, [[0n, 1n, 2n, 3n, 4n]]);
+					await checkIterate(i, [[0n], [1n, 2n, 3n, 4n]]);
+				}
+			});
+
+			it("concurrently-multiple peers", async () => {
+				await put(0, 0);
+				await put(0, 1);
+				let e2 = await put(0, 2);
+				await stores[1].docs.log.join([e2.entry]); // keep doc2 at both node 0 and 1
+				await put(1, 3);
+				await put(1, 4);
+
+				expect(stores[1].docs.index.size).toEqual(3);
+				let promises: Promise<any>[] = [];
+				for (let i = 0; i < session.peers.length; i++) {
+					promises.push(checkIterate(i, [[0n, 1n, 2n, 3n, 4n]]));
+					promises.push(checkIterate(i, [[0n], [1n, 2n, 3n, 4n]]));
+					promises.push(
+						checkIterate(i, [
+							[0n, 1n],
+							[2n, 3n, 4n],
+						])
+					);
+					promises.push(
+						checkIterate(i, [
+							[0n, 1n, 2n],
+							[3n, 4n],
+						])
+					);
+					promises.push(checkIterate(i, [[0n, 1n, 2n, 3n], [4n]]));
+				}
+				await Promise.all(promises);
+			});
+
+			it("sorts by order", async () => {
+				await put(0, 0);
+				await put(0, 1);
+				await put(0, 2);
+				{
+					const iterator = await stores[0].docs.index.iterate(
+						new SearchSortedRequest({
+							queries: [],
+							sort: [new Sort({ direction: SortDirection.ASC, key: "name" })],
+						})
+					);
+					expect(iterator.done()).toBeFalse();
+					const next = await iterator.next(3);
+					expect(next.map((x) => x.name)).toEqual(["0", "1", "2"]);
+					expect(iterator.done()).toBeTrue();
+				}
+				{
+					const iterator = await stores[0].docs.index.iterate(
+						new SearchSortedRequest({
+							queries: [],
+							sort: [new Sort({ direction: SortDirection.DESC, key: "name" })],
+						})
+					);
+					expect(iterator.done()).toBeFalse();
+					const next = await iterator.next(3);
+					expect(next.map((x) => x.name)).toEqual(["2", "1", "0"]);
+					expect(iterator.done()).toBeTrue();
+				}
+			});
+
+			it("strings", async () => {
+				await put(0, 0);
+				await put(0, 1);
+				await put(0, 2);
+
+				const iterator = await stores[0].docs.index.iterate(
+					new SearchSortedRequest({
+						queries: [],
+						sort: [new Sort({ direction: SortDirection.ASC, key: "name" })],
+					})
+				);
+				expect(iterator.done()).toBeFalse();
+				const next = await iterator.next(3);
+				expect(next.map((x) => x.name)).toEqual(["0", "1", "2"]);
+				expect(iterator.done()).toBeTrue();
+			});
+
+			// TODO test iterator.return() to stop pending promises
+
+			// TODO deletion while sort
+
+			// TODO session timeouts?
 		});
 	});
 
@@ -1489,22 +1719,24 @@ describe("index", () => {
 				await session.stop();
 			});
 
+			/*  TODO query all if undefined?
+			
 			it("queries all if undefined", async () => {
 				stores[0].docs.log["_replication"].replicators = () => undefined;
-				await stores[0].docs.index.query(new DocumentQuery({ queries: [] }), {
+				await stores[0].docs.index.query(new SearchRequest({ queries: [] }), {
 					remote: { amount: 2 },
 				});
 				expect(counters[0]).toEqual(1);
 				expect(counters[1]).toEqual(1);
 				expect(counters[2]).toEqual(1);
-			});
+			}); */
 
 			it("all", async () => {
 				stores[0].docs.log["_replication"].replicators = () => [
 					[stores[1].libp2p.services.pubsub.publicKey.hashcode()],
 					[stores[2].libp2p.services.pubsub.publicKey.hashcode()],
 				];
-				await stores[0].docs.index.query(new DocumentQuery({ queries: [] }));
+				await stores[0].docs.index.query(new SearchRequest({ queries: [] }));
 				expect(counters[0]).toEqual(1);
 				expect(counters[1]).toEqual(1);
 				expect(counters[2]).toEqual(1);
@@ -1512,7 +1744,7 @@ describe("index", () => {
 
 			it("will always query locally", async () => {
 				stores[0].docs.log["_replication"].replicators = () => [];
-				await stores[0].docs.index.query(new DocumentQuery({ queries: [] }));
+				await stores[0].docs.index.query(new SearchRequest({ queries: [] }));
 				expect(counters[0]).toEqual(1);
 				expect(counters[1]).toEqual(0);
 				expect(counters[2]).toEqual(0);
@@ -1522,7 +1754,7 @@ describe("index", () => {
 				stores[0].docs.log["_replication"].replicators = () => [
 					[stores[1].libp2p.services.pubsub.publicKey.hashcode()],
 				];
-				await stores[0].docs.index.query(new DocumentQuery({ queries: [] }));
+				await stores[0].docs.index.query(new SearchRequest({ queries: [] }));
 				expect(counters[0]).toEqual(1);
 				expect(counters[1]).toEqual(1);
 				expect(counters[2]).toEqual(0);
@@ -1533,7 +1765,7 @@ describe("index", () => {
 					[stores[1].libp2p.services.pubsub.publicKey.hashcode()],
 					[stores[2].libp2p.services.pubsub.publicKey.hashcode()],
 				];
-				await stores[0].docs.index.query(new DocumentQuery({ queries: [] }), {
+				await stores[0].docs.index.query(new SearchRequest({ queries: [] }), {
 					local: false,
 				});
 				expect(counters[0]).toEqual(0);
@@ -1547,7 +1779,7 @@ describe("index", () => {
 						stores[1].libp2p.services.pubsub.publicKey.hashcode(),
 					],
 				];
-				await stores[0].docs.index.query(new DocumentQuery({ queries: [] }));
+				await stores[0].docs.index.query(new SearchRequest({ queries: [] }));
 				expect(counters[0]).toEqual(1);
 				expect(counters[1]).toEqual(0);
 				expect(counters[2]).toEqual(0);
@@ -1588,7 +1820,7 @@ describe("index", () => {
 						};
 					}
 					let timeout = 1000;
-					await stores[0].docs.index.query(new DocumentQuery({ queries: [] }), {
+					await stores[0].docs.index.query(new SearchRequest({ queries: [] }), {
 						remote: { timeout },
 					});
 					expect(failedOnce).toBeTrue();
@@ -1612,7 +1844,7 @@ describe("index", () => {
 
 					let timeout = 1000;
 
-					await stores[0].docs.index.query(new DocumentQuery({ queries: [] }), {
+					await stores[0].docs.index.query(new SearchRequest({ queries: [] }), {
 						remote: { timeout },
 					});
 					expect(counters[0]).toEqual(1);

--- a/packages/programs/data/document/src/document-index.ts
+++ b/packages/programs/data/document/src/document-index.ts
@@ -779,12 +779,12 @@ export class DocumentIndex<T> extends ComposableProgram {
 							this._query
 								.send(collectRequest, {
 									...options,
-									stopper: (s) => stopperFns.push(s),
+									stopper: (fn) => stopperFns.push(fn),
 									to: [peer],
 								})
 								.then((response) =>
 									introduceEntries(response, this.type, this._sync, options)
-										.then((responses) =>
+										.then((responses) => {
 											responses.map((response) => {
 												resultsLeft += Number(response.response.kept);
 												if (!response.from) {
@@ -812,8 +812,8 @@ export class DocumentIndex<T> extends ComposableProgram {
 															})
 													);
 												}
-											})
-										)
+											});
+										})
 										.catch((e) => {
 											logger.error(
 												"Failed to collect sorted results from: " +

--- a/packages/programs/data/document/src/document-index.ts
+++ b/packages/programs/data/document/src/document-index.ts
@@ -7,7 +7,7 @@ import {
 	IntegerCompare,
 	ByteMatchQuery,
 	StringMatch,
-	DocumentQuery,
+	SearchRequest,
 	Query,
 	ResultWithSource,
 	StateFieldQuery,
@@ -19,6 +19,11 @@ import {
 	And,
 	Or,
 	BoolQuery,
+	Sort,
+	CollectNextRequest,
+	AbstractSearchRequest,
+	SearchSortedRequest,
+	SortDirection,
 } from "./query.js";
 import {
 	CanRead,
@@ -31,7 +36,8 @@ import {
 import { Results } from "./query.js";
 import { logger as loggerFn } from "@dao-xyz/peerbit-logger";
 import { Log } from "@dao-xyz/peerbit-log";
-import { sha256Base64Sync } from "@dao-xyz/peerbit-crypto";
+import { Cache } from "@dao-xyz/cache";
+import { PublicSignKey } from "@dao-xyz/peerbit-crypto";
 
 const logger = loggerFn({ module: "document-index" });
 
@@ -109,7 +115,7 @@ export interface IndexedValue<T> {
 
 export type RemoteQueryOptions<R> = RPCOptions<R> & { sync?: boolean };
 export type QueryOptions<R> = {
-	onResponse?: (response: Results<R>) => void;
+	onResponse?: (response: Results<R>, from?: PublicSignKey) => void;
 	remote?: boolean | RemoteQueryOptions<Results<R>>;
 	local?: boolean;
 };
@@ -119,10 +125,84 @@ export type Indexable<T> = (
 	entry: Entry<Operation<T>>
 ) => Record<string, any>;
 
+const extractFieldValue = <T>(doc: any, path: string[]): T => {
+	for (let i = 0; i < path.length; i++) {
+		doc = doc[path[i]];
+	}
+	return doc;
+};
+
+export type ResultsIterator<T> = {
+	return: () => void;
+	next: (number: number) => Promise<T[]>;
+	done: () => boolean;
+};
+
+const sortCompare = (av: any, bv: any) => {
+	if (typeof av === "string" && typeof bv === "string") {
+		return av.localeCompare(bv);
+	}
+	if (av < bv) {
+		return -1;
+	} else if (av > bv) {
+		return 1;
+	}
+	return 0;
+};
+const extractSortCompare = (a: any, b: any, sorts: Sort[]) => {
+	for (const sort of sorts) {
+		const av = extractFieldValue(a, sort.key);
+		const bv = extractFieldValue(b, sort.key);
+		const cmp = sortCompare(av, bv);
+		if (cmp != 0) {
+			if (sort.direction === SortDirection.ASC) {
+				return cmp;
+			} else {
+				return -cmp;
+			}
+		}
+	}
+	return 0;
+};
+const introduceEntries = async <T>(
+	responses: RPCResponse<Results<T>>[],
+	type: AbstractType<T>,
+	sync: (result: Results<T>) => Promise<void>,
+	options?: QueryOptions<T>
+): Promise<RPCResponse<Results<T>>[]> => {
+	return Promise.all(
+		responses.map(async (x) => {
+			x.response.results.forEach((r) => r.init(type));
+			if (typeof options?.remote !== "boolean" && options?.remote?.sync) {
+				await sync(x.response);
+			}
+			if (!x.from) {
+				logger.error("Missing from for response");
+			}
+			options?.onResponse && options.onResponse(x.response, x.from!);
+			return x;
+		})
+	);
+};
+
+const dedup = <T>(allResult: T[], dedupBy: string) => {
+	const unique: Set<Keyable> = new Set();
+	const dedup: T[] = [];
+	for (const result of allResult) {
+		const key = asString(result[dedupBy]);
+		if (unique.has(key)) {
+			continue;
+		}
+		unique.add(key);
+		dedup.push(result);
+	}
+	return dedup;
+};
+
 @variant("documents_index")
 export class DocumentIndex<T> extends ComposableProgram {
 	@field({ type: RPC })
-	_query: RPC<DocumentQuery, Results<T>>;
+	_query: RPC<AbstractSearchRequest, Results<T>>;
 
 	@field({ type: "string" })
 	indexBy: string;
@@ -135,8 +215,10 @@ export class DocumentIndex<T> extends ComposableProgram {
 	private _log: Log<Operation<T>>;
 	private _toIndex: Indexable<T>;
 
+	private _resultsCollectQueue: Cache<{ value: T; context: Context }[]>;
+
 	constructor(properties: {
-		query?: RPC<DocumentQuery, Results<T>>;
+		query?: RPC<SearchRequest, Results<T>>;
 		indexBy: string;
 	}) {
 		super();
@@ -169,6 +251,7 @@ export class DocumentIndex<T> extends ComposableProgram {
 		this._sync = properties.sync;
 		this._toIndex = properties.fields;
 		this._valueEncoding = BORSH_ENCODING(this.type);
+		this._resultsCollectQueue = new Cache({ max: 10000 }); // TODO choose limit better
 
 		await this._query.setup({
 			topic: this._log.idString + "/document",
@@ -177,17 +260,18 @@ export class DocumentIndex<T> extends ComposableProgram {
 				const results = await this.queryHandler(query);
 				return new Results({
 					// Even if results might have length 0, respond, because then we now at least there are no matching results
-					results: results.map(
+					results: results.results.map(
 						(r) =>
 							new ResultWithSource({
 								source: serialize(r.value),
 								context: r.context,
 							})
 					),
+					kept: BigInt(results.kept),
 				});
 			},
 			responseType: Results,
-			queryType: DocumentQuery,
+			queryType: AbstractSearchRequest,
 		});
 	}
 
@@ -205,14 +289,15 @@ export class DocumentIndex<T> extends ComposableProgram {
 		let results: Results<T>[] | undefined;
 		if (key instanceof Uint8Array) {
 			results = await this.queryDetailed(
-				new DocumentQuery({
+				new SearchRequest({
 					queries: [new ByteMatchQuery({ key: [this.indexBy], value: key })],
-				})
+				}),
+				options
 			);
 		} else {
 			const stringValue = asString(key);
 			results = await this.queryDetailed(
-				new DocumentQuery({
+				new SearchRequest({
 					queries: [
 						new StringMatch({
 							key: [this.indexBy],
@@ -258,60 +343,104 @@ export class DocumentIndex<T> extends ComposableProgram {
 	}
 
 	async queryHandler(
-		query: DocumentQuery
-	): Promise<{ context: Context; value: T }[]> {
+		query: AbstractSearchRequest
+	): Promise<{ results: { context: Context; value: T }[]; kept: number }> {
 		// We do special case for querying the id as we can do it faster than iterating
 		if (
-			query.queries.length === 1 &&
-			(query.queries[0] instanceof ByteMatchQuery ||
-				query.queries[0] instanceof StringMatch) &&
-			query.queries[0].key.length === 1 &&
-			query.queries[0].key[0] === this.indexBy
+			query instanceof SearchRequest ||
+			query instanceof SearchSortedRequest
 		) {
-			const firstQuery = query.queries[0];
-			if (firstQuery instanceof ByteMatchQuery) {
-				const doc = this._index.get(asString(firstQuery.value)); // TODO could there be a issue with types here?
-				return doc
-					? [
-							{
-								value: await this.getDocument(doc),
-								context: doc.context,
-							},
-					  ]
-					: [];
-			} else if (
-				firstQuery instanceof StringMatch &&
-				firstQuery.method === StringMatchMethod.exact &&
-				firstQuery.caseInsensitive === false
+			if (
+				query.queries.length === 1 &&
+				(query.queries[0] instanceof ByteMatchQuery ||
+					query.queries[0] instanceof StringMatch) &&
+				query.queries[0].key.length === 1 &&
+				query.queries[0].key[0] === this.indexBy
 			) {
-				const doc = this._index.get(firstQuery.value); // TODO could there be a issue with types here?
-				return doc
-					? [
-							{
-								value: await this.getDocument(doc),
-								context: doc.context,
-							},
-					  ]
-					: [];
-			}
-		}
-
-		return this._queryDocuments((doc) => {
-			for (const f of query.queries) {
-				if (!this.handleQueryObject(f, doc)) {
-					return false;
+				const firstQuery = query.queries[0];
+				if (firstQuery instanceof ByteMatchQuery) {
+					const doc = this._index.get(asString(firstQuery.value)); // TODO could there be a issue with types here?
+					return doc
+						? {
+								results: [
+									{
+										value: await this.getDocument(doc),
+										context: doc.context,
+									},
+								],
+								kept: 0,
+						  }
+						: { results: [], kept: 0 };
+				} else if (
+					firstQuery instanceof StringMatch &&
+					firstQuery.method === StringMatchMethod.exact &&
+					firstQuery.caseInsensitive === false
+				) {
+					const doc = this._index.get(firstQuery.value); // TODO could there be a issue with types here?
+					return doc
+						? {
+								results: [
+									{
+										value: await this.getDocument(doc),
+										context: doc.context,
+									},
+								],
+								kept: 0,
+						  }
+						: { results: [], kept: 0 };
 				}
 			}
-			return true;
-		});
+
+			const results = await this._queryDocuments((doc) => {
+				for (const f of query.queries) {
+					if (!this.handleQueryObject(f, doc)) {
+						return false;
+					}
+				}
+				return true;
+			});
+
+			if (query instanceof SearchSortedRequest) {
+				if (query.sort.length === 0) {
+					query.sort = [
+						new Sort({ key: this.indexBy, direction: SortDirection.ASC }),
+					];
+				}
+
+				// Sort?
+				results.sort((a, b) =>
+					extractSortCompare(a.value, b.value, query.sort)
+				);
+				const batch = results.splice(0, query.initialAmount);
+				this._resultsCollectQueue.add(query.idString, results);
+				return { results: batch, kept: results.length }; // Only return 1 result since we are doing distributed sort, TODO buffer more initially
+			}
+			return { results, kept: 0 };
+		} else if (query instanceof CollectNextRequest) {
+			const results = this._resultsCollectQueue.get(query.idString);
+
+			if (!results) {
+				return {
+					results: [],
+					kept: 0,
+				};
+			}
+
+			if (results.length === 0) {
+				this._resultsCollectQueue.del(query.idString); // TODO add tests for proper cleanup/timeouts
+			}
+
+			const batch = results.splice(0, query.amount);
+
+			return { results: batch, kept: results.length };
+		}
+
+		throw new Error("Unsupported");
 	}
 
 	private handleQueryObject(f: Query, doc: IndexedValue<T>) {
 		if (f instanceof StateFieldQuery) {
-			let fv: any = doc.value;
-			for (let i = 0; i < f.key.length; i++) {
-				fv = fv[f.key[i]];
-			}
+			const fv: any = extractFieldValue(doc.value, f.key);
 
 			if (f instanceof StringMatch) {
 				let compare = f.value;
@@ -403,7 +532,7 @@ export class DocumentIndex<T> extends ComposableProgram {
 	 * @returns
 	 */
 	public async queryDetailed(
-		queryRequest: DocumentQuery,
+		queryRequest: SearchRequest | SearchSortedRequest,
 		options?: QueryOptions<T>
 	): Promise<Results<T>[]> {
 		const local = typeof options?.local == "boolean" ? options?.local : true;
@@ -428,10 +557,10 @@ export class DocumentIndex<T> extends ComposableProgram {
 
 		if (local) {
 			const results = await this.queryHandler(queryRequest);
-			if (results.length > 0) {
+			if (results.results.length > 0) {
 				const resultsObject = new Results<T>({
 					results: await Promise.all(
-						results.map(async (r) => {
+						results.results.map(async (r) => {
 							const payloadValue = await (
 								await this._log.get(r.context.head)
 							)?.getPayloadValue();
@@ -445,26 +574,18 @@ export class DocumentIndex<T> extends ComposableProgram {
 							throw new Error("Unexpected");
 						})
 					),
+					kept: BigInt(results.kept),
 				});
-				options?.onResponse && options.onResponse(resultsObject);
+				options?.onResponse &&
+					options.onResponse(
+						resultsObject,
+						this.libp2p.services.pubsub.publicKey
+					);
 				allResults.push(resultsObject);
 			}
 		}
 
 		if (remote) {
-			const initFn = async (responses: RPCResponse<Results<T>>[]) => {
-				return Promise.all(
-					responses.map(async (x) => {
-						x.response.results.forEach((r) => r.init(this.type));
-						if (typeof options?.remote !== "boolean" && options?.remote?.sync) {
-							await this._sync(x.response);
-						}
-						options?.onResponse && options.onResponse(x.response);
-						return x.response;
-					})
-				);
-			};
-
 			const replicatorGroups = await this._log.replication?.replicators?.();
 			if (replicatorGroups) {
 				const fn = async () => {
@@ -472,8 +593,12 @@ export class DocumentIndex<T> extends ComposableProgram {
 					const responseHandler = async (
 						results: RPCResponse<Results<T>>[]
 					) => {
-						const resultsInitialized = await initFn(results);
-						rs.push(...resultsInitialized);
+						await introduceEntries(
+							results,
+							this.type,
+							this._sync,
+							options
+						).then((x) => x.forEach((y) => rs.push(y.response)));
 					};
 					try {
 						await queryAll(
@@ -492,11 +617,15 @@ export class DocumentIndex<T> extends ComposableProgram {
 				};
 				promises.push(fn());
 			} else {
-				promises.push(
-					this._query
-						.send(queryRequest, remote)
-						.then((response) => initFn(response))
-				);
+				// TODO send without direction out to the world? or just assume we can insert?
+				/* 	promises.push(
+						this._query
+							.send(queryRequest, remote)
+							.then((results) => introduceEntries(results, this.type, this._sync, options).then(x => x.map(y => y.response)))
+					); */
+				/* throw new Error(
+					"Missing remote replicator info for performing distributed document query"
+				); */
 			}
 		}
 		const resolved = await Promise.all(promises);
@@ -519,24 +648,240 @@ export class DocumentIndex<T> extends ComposableProgram {
 	 * @returns
 	 */
 	public async query(
-		queryRequest: DocumentQuery,
+		queryRequest: SearchRequest,
 		options?: QueryOptions<T>
 	): Promise<T[]> {
 		const allResult = await this.queryDetailed(queryRequest, options);
 
 		// Deduplicate and return values directly
-		const unique: Set<Keyable> = new Set();
-		const dedup: T[] = [];
-		for (const result of allResult) {
-			for (const innerResult of result.results) {
-				const key = asString(innerResult.value[this.indexBy]);
-				if (unique.has(key)) {
+		return dedup(
+			allResult.map((x) => x.results.map((y) => y.value)).flat(),
+			this.indexBy
+		);
+	}
+
+	/**
+	 * Query and retrieve deduplicated results with sorting
+	 * @param queryRequest
+	 * @param options
+	 * @returns
+	 */
+	public async iterate(
+		queryRequest: SearchSortedRequest,
+		options?: QueryOptions<T>
+	): Promise<ResultsIterator<T>> {
+		let fetchPromise: Promise<any> | undefined = undefined;
+		const peerBufferMap: Map<
+			string,
+			{ kept: number; buffer: { value: T; from: PublicSignKey }[] }
+		> = new Map();
+		const visited = new Set<string>();
+
+		let done = true;
+
+		await this.queryDetailed(queryRequest, {
+			...options,
+			onResponse: (response, from) => {
+				if (!from) {
+					logger.error("Missing from for sorted query");
+					return;
+				}
+
+				if (response.kept === 0n && response.results.length === 0) {
+					return;
+				}
+
+				done = false;
+				peerBufferMap.set(from.hashcode(), {
+					buffer: response.results
+						.filter((x) => !visited.has(asString(x.value[this.indexBy])))
+						.map((x) => {
+							visited.add(asString(x.value[this.indexBy]));
+							return { from, value: x.value };
+						}),
+					kept: Number(response.kept),
+				});
+			},
+		});
+
+		// TODO handle join/leave while iterating
+		let stopperFns: (() => void)[] = [];
+
+		const peerBuffers = (): { value: T; from: PublicSignKey }[] => {
+			return [...peerBufferMap.values()].map((x) => x.buffer).flat();
+		};
+
+		const fetchAtLeast = async (n: number) => {
+			if (done) {
+				return;
+			}
+
+			await fetchPromise;
+			const newPromises: Promise<any>[] = [];
+
+			stopperFns = [];
+
+			let resultsLeft = 0;
+
+			for (const [peer, buffer] of peerBufferMap) {
+				if (buffer.buffer.length < n) {
+					if (buffer.kept === 0) {
+						peerBufferMap.delete(peer);
+						continue;
+					}
+
+					// TODO buffer more than deleted?
+					// TODO batch to multiple 'to's
+					const collectRequest = new CollectNextRequest({
+						id: queryRequest.id,
+						amount: n - buffer.buffer.length,
+					});
+					// Fetch locally?
+					if (peer === this.libp2p.services.pubsub.publicKeyHash) {
+						newPromises.push(
+							this.queryHandler(collectRequest)
+								.then((results) => {
+									resultsLeft += results.kept;
+
+									if (results.results.length === 0) {
+										peerBufferMap.delete(peer); // No more results
+									} else {
+										const peerBuffer = peerBufferMap.get(peer);
+										if (!peerBuffer) {
+											return;
+										}
+										peerBuffer.kept = results.kept;
+										peerBuffer.buffer.push(
+											...results.results
+												.filter(
+													(x) => !visited.has(asString(x.value[this.indexBy]))
+												)
+												.map((x) => {
+													visited.add(asString(x.value[this.indexBy]));
+													return {
+														value: x.value,
+														from: this.libp2p.services.pubsub.publicKey,
+													};
+												})
+										);
+									}
+								})
+								.catch((e) => {
+									logger.error(
+										"Failed to collect sorted results self. " + e?.message
+									);
+									peerBufferMap.delete(peer);
+								})
+						);
+					} else {
+						// Fetch remotely
+						newPromises.push(
+							this._query
+								.send(collectRequest, {
+									...options,
+									stopper: (s) => stopperFns.push(s),
+									to: [peer],
+								})
+								.then((response) =>
+									introduceEntries(response, this.type, this._sync, options)
+										.then((responses) =>
+											responses.map((response) => {
+												resultsLeft += Number(response.response.kept);
+												if (!response.from) {
+													logger.error("Missing from for sorted query");
+													return;
+												}
+
+												if (response.response.results.length === 0) {
+													peerBufferMap.delete(peer); // No more results
+												} else {
+													const peerBuffer = peerBufferMap.get(peer);
+													if (!peerBuffer) {
+														return;
+													}
+													peerBuffer.kept = Number(response.response.kept);
+													peerBuffer.buffer.push(
+														...response.response.results
+															.filter(
+																(x) =>
+																	!visited.has(asString(x.value[this.indexBy]))
+															)
+															.map((x) => {
+																visited.add(asString(x.value[this.indexBy]));
+																return { value: x.value, from: response.from! };
+															})
+													);
+												}
+											})
+										)
+										.catch((e) => {
+											logger.error(
+												"Failed to collect sorted results from: " +
+													peer +
+													". " +
+													e?.message
+											);
+											peerBufferMap.delete(peer);
+										})
+								)
+						);
+					}
+				} else {
+					resultsLeft += peerBufferMap.get(peer)?.kept || 0;
+				}
+			}
+			return (fetchPromise = Promise.all(newPromises).then(() => {
+				return resultsLeft === 0; // 0 results left to fetch and 0 pending results
+			}));
+		};
+
+		const next = async (n: number) => {
+			if (n < 0) {
+				throw new Error("Expecting to fetch a positive amount of element");
+			}
+
+			if (n === 0) {
+				return [];
+			}
+
+			// TODO everything below is not very optimized
+			const fetchedAll = await fetchAtLeast(n);
+
+			// get n next top entries, shift and pull more results
+			const results = peerBuffers().sort((a, b) =>
+				extractSortCompare(a.value, b.value, queryRequest.sort)
+			);
+			const pendingMoreResults = n < results.length;
+			const batch = results.splice(0, n);
+			for (const result of batch) {
+				const arr = peerBufferMap.get(result.from.hashcode());
+				if (!arr) {
+					logger.error("Unexpected empty result buffer");
 					continue;
 				}
-				unique.add(key);
-				dedup.push(innerResult.value);
+				const idx = arr.buffer.findIndex((x) => x == result);
+				if (idx >= 0) {
+					arr.buffer.splice(idx, 1);
+				}
 			}
-		}
-		return dedup;
+
+			done = fetchedAll && !pendingMoreResults;
+			return dedup(
+				batch.map((x) => x.value),
+				this.indexBy
+			);
+		};
+
+		const close = () => {
+			for (const fn of stopperFns) {
+				fn();
+			}
+		};
+
+		return {
+			return: close,
+			next,
+			done: () => done,
+		};
 	}
 }

--- a/packages/programs/data/document/src/document-store.ts
+++ b/packages/programs/data/document/src/document-store.ts
@@ -249,7 +249,7 @@ export class Documents<
 			: (
 					await this._index.getDetailed(key, {
 						local: true,
-						remote: { sync: true },
+						remote: { sync: true }, // only query remote if we know they exist
 					})
 			  )?.[0]?.results[0];
 

--- a/packages/programs/data/string/src/__tests__/index.integration.test.ts
+++ b/packages/programs/data/string/src/__tests__/index.integration.test.ts
@@ -31,13 +31,13 @@ describe("query", () => {
 		writeStore: DString,
 		observerStore: DString;
 
-	beforeAll(async () => {
+	beforeEach(async () => {
+		// we reinit sesion for every test since DString does always have same address
+		// and that might lead to sideeffects running all tests in one go
 		session = await LSession.connected(2);
 		observer = session.peers[0];
 		writer = session.peers[1];
-	});
 
-	beforeEach(async () => {
 		// Create store
 		writeStore = new DString({});
 		await writeStore.init(writer, await createIdentity(), {
@@ -71,14 +71,10 @@ describe("query", () => {
 	});
 
 	afterEach(async () => {
-		await writeStore.close();
-		await observerStore.close();
-	});
-
-	afterAll(async () => {
+		await writeStore.drop();
+		await observerStore.drop();
 		await session.stop();
 	});
-
 	it("match all", async () => {
 		await writeStore.add(
 			"hello",
@@ -176,7 +172,9 @@ describe("query", () => {
 		let callbackValues: string[] = [];
 		const string = await observerStore.toString({
 			remote: {
-				callback: (s) => callbackValues.push(s),
+				callback: (s) => {
+					callbackValues.push(s);
+				},
 				queryOptions: { amount: 1 },
 			},
 		});

--- a/packages/programs/rpc/src/utils.ts
+++ b/packages/programs/rpc/src/utils.ts
@@ -14,7 +14,7 @@ export const queryAll = <Q, R>(
 ) => {
 	// In each shard/group only query a subset
 	groups = [...groups].filter(
-		(x) => !x.find((x) => x === rpc.libp2p.services.pubsub.publicKey.hashcode())
+		(x) => !x.find((y) => y === rpc.libp2p.services.pubsub.publicKey.hashcode())
 	);
 
 	let rng = Math.round(Math.random() * groups.length);
@@ -36,12 +36,14 @@ export const queryAll = <Q, R>(
 					...options,
 					to: peersToQuery,
 				});
+
 				for (const result of results) {
 					if (!result.from) {
 						throw new Error("Unexpected, missing from");
 					}
 					peerToGroupIndex.delete(result.from.hashcode());
 				}
+
 				await responseHandler(results);
 
 				const indicesLeft = new Set([...peerToGroupIndex.values()]);

--- a/packages/server-node/test-lib/package.json
+++ b/packages/server-node/test-lib/package.json
@@ -36,7 +36,7 @@
 	},
 	"devDependencies": {
 		"@dao-xyz/peerbit-test-utils": "*",
-		"libp2p": "^0.45.3"
+		"libp2p": "^0.45.4"
 	},
 	"dependencies": {
 		"@dao-xyz/peerbit-string": "*",

--- a/packages/utils/crypto/package.json
+++ b/packages/utils/crypto/package.json
@@ -48,6 +48,6 @@
 		"@ethersproject/wallet": "^5.7.0",
 		"@libp2p/crypto": "^1.0.14",
 		"@libp2p/peer-id": "^2.0.1",
-		"libsodium-wrappers": "^0.7.10"
+		"libsodium-wrappers": "^0.7.11"
 	}
 }

--- a/packages/utils/crypto/src/ed25519-sign.ts
+++ b/packages/utils/crypto/src/ed25519-sign.ts
@@ -46,35 +46,35 @@ export const verifySignatureEd25519 = async (
 	return res;
 };
 
+const DER_PREFIX = Buffer.from([
+	48, 46, 2, 1, 0, 48, 5, 6, 3, 43, 101, 112, 4, 34, 4, 32,
+]);
+const ED25519_OID = Buffer.from([0x06, 0x03, 0x2b, 0x65, 0x70]);
+const SEQUENCE_TAG = Buffer.from([0x30]); // Sequence tag
+const BIT_TAG = Buffer.from([0x03]); // Bit tag
+const ZERO_BIT_TAG = Buffer.from([0x00]); // Zero bit
 function toDER(key: Uint8Array, p = false) {
 	if (p) {
-		return Buffer.concat([
-			Buffer.from([48, 46, 2, 1, 0, 48, 5, 6, 3, 43, 101, 112, 4, 34, 4, 32]),
-			key,
-		]);
+		return Buffer.concat([DER_PREFIX, key]);
 	}
 
 	// Ed25519's OID
-	const oid = Buffer.from([0x06, 0x03, 0x2b, 0x65, 0x70]);
+	const oid = ED25519_OID;
 
 	// Create a byte sequence containing the OID and key
 	const elements = Buffer.concat([
-		Buffer.concat([
-			Buffer.from([0x30]), // Sequence tag
-			Buffer.from([oid.length]),
-			oid,
-		]),
-		Buffer.concat([
-			Buffer.from([0x03]), // Bit tag
-			Buffer.from([key.length + 1]),
-			Buffer.from([0x00]), // Zero bit
-			key,
-		]),
+		SEQUENCE_TAG,
+		Buffer.from([oid.length]),
+		oid,
+		BIT_TAG,
+		Buffer.from([key.length + 1]),
+		ZERO_BIT_TAG,
+		key,
 	]);
 
 	// Wrap up by creating a sequence of elements
 	const der = Buffer.concat([
-		Buffer.from([0x30]), // Sequence tag
+		SEQUENCE_TAG,
 		Buffer.from([elements.length]),
 		elements,
 	]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7625,10 +7625,10 @@ libnpmpublish@^6.0.4:
     semver "^7.3.7"
     ssri "^9.0.0"
 
-libp2p@^0.45.3:
-  version "0.45.3"
-  resolved "https://registry.yarnpkg.com/libp2p/-/libp2p-0.45.3.tgz#7eb225222985ffa0cd38046f037910c5f4991fc6"
-  integrity sha512-rIeT5noHOI8jo9mY6UopQSEvZPgcQKCSJJH/F6T8TpDJclfyu2VsB/C3xttXKRwDY6n6KaXJJUwOEqiRDv8fnQ==
+libp2p@^0.45.4:
+  version "0.45.4"
+  resolved "https://registry.yarnpkg.com/libp2p/-/libp2p-0.45.4.tgz#1e1b85431a82ddc678f2f62b3d2b73bc3956578c"
+  integrity sha512-cbmiDxrUL3q3yYn9M3QwTVNrpHxhisVfy+ObV9c/HmnDguZzEezZY7gQUVkN+DxCpAR/lbaDPwnu7PucTuhcnA==
   dependencies:
     "@achingbrain/nat-port-mapper" "^1.0.3"
     "@libp2p/crypto" "^1.0.4"
@@ -7695,7 +7695,7 @@ libp2p@^0.45.3:
     wherearewe "^2.0.0"
     xsalsa20 "^1.1.0"
 
-libsodium-wrappers@^0.7.10, libsodium-wrappers@^0.7.11:
+libsodium-wrappers@^0.7.11:
   version "0.7.11"
   resolved "https://registry.yarnpkg.com/libsodium-wrappers/-/libsodium-wrappers-0.7.11.tgz#53bd20606dffcc54ea2122133c7da38218f575f7"
   integrity sha512-SrcLtXj7BM19vUKtQuyQKiQCRJPgbpauzl3s0rSwD+60wtHqSUuqcoawlMDheCJga85nKOQwxNYQxf/CKAvs6Q==


### PR DESCRIPTION
Solves #72 #71.
- Add sort through ```.index.iterate(query)``` .
- Breaking change:  ```document-store```. Don't query all by default if no replicators to query
- Breaking change:  ```document-store```. `DocumentRequest` -> `SearchRequest`