### PR TITLE
Minor SQL Indexer access tweaks.

### DIFF
--- a/packages/utils/indexer/sqlite3/src/engine.ts
+++ b/packages/utils/indexer/sqlite3/src/engine.ts
@@ -693,10 +693,10 @@ export class SQLLiteIndex<T extends Record<string, any>>
 }
 
 export class SQLiteIndices implements types.Indices {
-	private _scope: string[];
-	private scopes: Map<string, SQLiteIndices>;
-	private indices: { schema: any; index: Index<any, any> }[];
-	private closed = true;
+	protected _scope: string[];
+	protected scopes: Map<string, SQLiteIndices>;
+	protected indices: { schema: any; index: Index<any, any> }[];
+	protected closed = true;
 
 	constructor(
 		readonly properties: {

--- a/packages/utils/indexer/sqlite3/src/index.ts
+++ b/packages/utils/indexer/sqlite3/src/index.ts
@@ -2,6 +2,7 @@ import { BinaryWriter } from "@dao-xyz/borsh";
 import { sha256Sync, toBase58 } from "@peerbit/crypto";
 import { SQLLiteIndex, SQLiteIndices } from "./engine.js";
 import { create as sqlite3 } from "./sqlite3.js";
+export type { Database } from './types.js'
 
 export const encodeName = (name: string): string => {
 	const writer = new BinaryWriter();

--- a/packages/utils/indexer/sqlite3/src/index.ts
+++ b/packages/utils/indexer/sqlite3/src/index.ts
@@ -14,4 +14,4 @@ const create = async (directory?: string): Promise<SQLiteIndices> => {
 	const db = await sqlite3(directory);
 	return new SQLiteIndices({ db });
 };
-export { create, SQLiteIndices, SQLLiteIndex };
+export { create, sqlite3, SQLiteIndices, SQLLiteIndex };


### PR DESCRIPTION
This PR is to start a conversation on the best way to expose some of the underlying SQLite functionality to the user, as a quick and dirty start I have:
- Changed the `SQLiteIndices` class methods to protected instead of private to allow access when extending the class.
- Exposed the database type to allow typing the overridden constructor externally. 
- Exposed sqlite3 creation.

This allows me to override the `SQLiteIndices` and `SQLLiteIndex` to inject hooks and add a way to query the underlying SQL database.

Also what is up with the extra 'L' in `SQLLiteIndex`?