### PR TITLE
shared-log: make waitForReplicator request loop configurable

### DIFF
--- a/packages/programs/data/shared-log/test/utils/stores/event-store.ts
+++ b/packages/programs/data/shared-log/test/utils/stores/event-store.ts
@@ -62,6 +62,8 @@ export type Args<
 	timeUntilRoleMaturity?: number;
 	waitForPruneDelay?: number;
 	waitForReplicatorTimeout?: number;
+	waitForReplicatorRequestIntervalMs?: number;
+	waitForReplicatorRequestMaxAttempts?: number;
 	keep?: (
 		entry: Entry<Operation<T>> | ShallowEntry | EntryReplicated<R>,
 	) => boolean;
@@ -125,6 +127,10 @@ export class EventStore<
 			trim: properties?.trim,
 			replicas: properties?.replicas,
 			waitForReplicatorTimeout: properties?.waitForReplicatorTimeout,
+			waitForReplicatorRequestIntervalMs:
+				properties?.waitForReplicatorRequestIntervalMs,
+			waitForReplicatorRequestMaxAttempts:
+				properties?.waitForReplicatorRequestMaxAttempts,
 			encoding: JSON_ENCODING,
 			timeUntilRoleMaturity: properties?.timeUntilRoleMaturity ?? 3000,
 			waitForPruneDelay: properties?.waitForPruneDelay ?? 0,

--- a/packages/programs/data/shared-log/test/wait-for-replicator.spec.ts
+++ b/packages/programs/data/shared-log/test/wait-for-replicator.spec.ts
@@ -1,0 +1,52 @@
+import { TestSession } from "@peerbit/test-utils";
+import { TimeoutError } from "@peerbit/time";
+import { expect } from "chai";
+import { RequestReplicationInfoMessage } from "../src/replication.js";
+import { EventStore } from "./utils/stores/index.js";
+
+describe("waitForReplicator", () => {
+	let session: TestSession;
+	let db: EventStore<string, any>;
+
+	afterEach(async () => {
+		if (db && db.closed === false) {
+			await db.drop();
+		}
+		await session?.stop();
+	});
+
+	it("respects configured request retry limits", async () => {
+		session = await TestSession.connected(2);
+		db = await session.peers[0].open(new EventStore<string, any>(), {
+			args: {
+				timeUntilRoleMaturity: 0,
+				waitForReplicatorRequestIntervalMs: 50,
+				waitForReplicatorRequestMaxAttempts: 2,
+			},
+		});
+
+		const originalSend = db.log.rpc.send.bind(db.log.rpc);
+		let requestCount = 0;
+		db.log.rpc.send = async (message: any, options: any) => {
+			if (message instanceof RequestReplicationInfoMessage) {
+				requestCount++;
+				return;
+			}
+			return originalSend(message, options);
+		};
+
+		try {
+			await db.log.waitForReplicator(session.peers[1].identity.publicKey, {
+				timeout: 300,
+				eager: true,
+			});
+			throw new Error("Expected waitForReplicator() to time out");
+		} catch (error) {
+			expect(error).to.be.instanceOf(TimeoutError);
+		} finally {
+			db.log.rpc.send = originalSend;
+		}
+
+		expect(requestCount).to.equal(2);
+	});
+});


### PR DESCRIPTION
Adds SharedLog options to configure the waitForReplicator() replication-info request loop.\n\n- New options: waitForReplicatorRequestIntervalMs, waitForReplicatorRequestMaxAttempts (defaults preserve current behaviour).\n- waitForReplicator() now uses these values instead of hardcoding 1s / derived attempts.\n- Adds a focused unit test covering the configured max-attempts behaviour.