### PR TITLE
fix(ci): avoid Vite ENOTEMPTY by skipping party wrapper build

### DIFF
--- a/packages/programs/data/document/react/e2e/party/package.json
+++ b/packages/programs/data/document/react/e2e/party/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "node ./scripts/dev.mjs",
-		"build": "pnpm --dir ./shared build && pnpm --dir ./browser-node build",
+		"build": "echo 'No build step for @peerbit/document-react-party'",
 		"preview": "pnpm --dir ./shared build && pnpm --dir ./browser-node preview",
 		"test": "playwright test --config playwright.config.ts",
 		"test:headed": "PWDEBUG=1 pnpm test -- --headed"


### PR DESCRIPTION
CI on `master` is currently failing during `pnpm run build` with:

```
[vite:prepare-out-dir] ENOTEMPTY: directory not empty, rmdir '.../packages/programs/data/document/react/e2e/party/browser-node/dist/peerbit/sqlite3'
```

Root cause: `@peerbit/document-react-party` is a workspace that runs `pnpm --dir ./browser-node build` in its own `build` script, while `document-react-party-app` (the `browser-node` workspace) is also built as part of `aegir run build`. These builds can overlap and fight over the same `dist/` directory.

Fix: make the wrapper workspace's `build` script a no-op (consistent with `packages/transport/stream/e2e/browser`), so the real build happens only once in the `browser-node` workspace.