### PR TITLE
fix(peerbit-org): redirect updates confirm/unsubscribe

### DIFF
--- a/apps/peerbit-org/supabase/functions/updates-unsubscribe/index.ts
+++ b/apps/peerbit-org/supabase/functions/updates-unsubscribe/index.ts
@@ -2,23 +2,15 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 import { corsHeaders } from "../_shared/cors.ts";
 
-function htmlRedirect(title: string, message: string, redirectTo: string) {
-	const safeTitle = title.replace(/</g, "&lt;").replace(/>/g, "&gt;");
-	const safeMessage = message.replace(/</g, "&lt;").replace(/>/g, "&gt;");
-	return `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="refresh" content="2;url=${redirectTo}" />
-    <title>${safeTitle}</title>
-  </head>
-  <body style="font-family: ui-sans-serif, system-ui, sans-serif; padding: 24px; line-height: 1.5;">
-    <h1 style="margin: 0 0 8px 0; font-size: 18px;">${safeTitle}</h1>
-    <p style="margin: 0 0 16px 0; color: #334155;">${safeMessage}</p>
-    <p style="margin: 0;"><a href="${redirectTo}">Continue</a></p>
-  </body>
-</html>`;
+function redirectTo(url: string, headers: Record<string, string>, status = 303) {
+	return new Response(null, {
+		status,
+		headers: {
+			...headers,
+			"Cache-Control": "no-store",
+			Location: url,
+		},
+	});
 }
 
 Deno.serve(async (req) => {
@@ -35,11 +27,12 @@ Deno.serve(async (req) => {
 	const email = (url.searchParams.get("email") ?? "").trim().toLowerCase();
 	const token = url.searchParams.get("token") ?? "";
 
-	const redirectTo = `${siteUrl}/#/updates?unsubscribed=1`;
+	const base = siteUrl.replace(/\/$/, "");
+	const successUrl = `${base}/#/updates?unsubscribed=1`;
+	const errorUrl = `${base}/#/updates?unsubscribed=0`;
 
 	if (!email || !token) {
-		const body = htmlRedirect("Invalid link", "Missing email or token.", redirectTo);
-		return new Response(body, { status: 400, headers: { ...headers, "Content-Type": "text/html; charset=utf-8" } });
+		return redirectTo(`${errorUrl}&reason=missing`, headers);
 	}
 
 	const supabase = createClient(supabaseUrl, serviceKey, { auth: { persistSession: false } });
@@ -51,11 +44,10 @@ Deno.serve(async (req) => {
 		.maybeSingle<{ email: string; unsubscribe_token: string; status: string }>();
 
 	if (!row || row.unsubscribe_token !== token) {
-		const body = htmlRedirect("Invalid link", "This unsubscribe link is invalid.", redirectTo);
-		return new Response(body, { status: 400, headers: { ...headers, "Content-Type": "text/html; charset=utf-8" } });
+		return redirectTo(`${errorUrl}&reason=invalid`, headers);
 	}
 
-	await supabase
+	const { error: updateError } = await supabase
 		.from("updates_subscribers")
 		.update({
 			status: "unsubscribed",
@@ -63,7 +55,9 @@ Deno.serve(async (req) => {
 		})
 		.eq("email", email);
 
-	const body = htmlRedirect("Unsubscribed", "You've been unsubscribed from Peerbit Updates.", redirectTo);
-	return new Response(body, { headers: { ...headers, "Content-Type": "text/html; charset=utf-8" } });
-});
+	if (updateError) {
+		return redirectTo(`${errorUrl}&reason=error`, headers);
+	}
 
+	return redirectTo(successUrl, headers);
+});


### PR DESCRIPTION
- Edge: return HTTP redirects for updates-confirm/updates-unsubscribe (Supabase serves the HTML body as text/plain for GET)
- UI: show a small banner on /#/updates for confirmed/unsubscribed results and clear the query params