### PR TITLE
feat(pubsub): add reason field to UnsubscriptionEvent

### DIFF
--- a/packages/transport/pubsub/src/index.ts
+++ b/packages/transport/pubsub/src/index.ts
@@ -526,9 +526,11 @@ export class DirectSub extends DirectStream<PubSubEvents> implements PubSub {
 		this.lastSubscriptionMessages.delete(publicKey.hashcode());
 
 		if (changed.length > 0) {
+			const event = new UnsubcriptionEvent(publicKey, changed);
+			(event as any).reason = "peer-unreachable";
 			this.dispatchEvent(
 				new CustomEvent<UnsubcriptionEvent>("unsubscribe", {
-					detail: new UnsubcriptionEvent(publicKey, changed),
+					detail: event,
 				}),
 			);
 		}
@@ -771,9 +773,11 @@ export class DirectSub extends DirectStream<PubSubEvents> implements PubSub {
 					}
 
 					if (changed.length > 0 && seenBefore === 0) {
+						const event = new UnsubcriptionEvent(sender, changed);
+						(event as any).reason = "remote-unsubscribe";
 						this.dispatchEvent(
 							new CustomEvent<UnsubcriptionEvent>("unsubscribe", {
-								detail: new UnsubcriptionEvent(sender, changed),
+								detail: event,
 							}),
 						);
 					}

--- a/packages/transport/pubsub/test/bug2-unsubscribe-reason.spec.ts
+++ b/packages/transport/pubsub/test/bug2-unsubscribe-reason.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * BUG 2: UnsubcriptionEvent lacks .reason property
+ *
+ * The upstream UnsubcriptionEvent is dispatched in two different scenarios:
+ *   1. Peer becomes unreachable (removeSubscriptions → "peer-unreachable")
+ *   2. Peer explicitly unsubscribes (Unsubscribe message → "remote-unsubscribe")
+ *
+ * However, the event.detail has NO .reason field, making it impossible for
+ * consumers to distinguish WHY an unsubscription happened. This is important
+ * for connection management UX (e.g., showing "peer went offline" vs
+ * "peer left the topic").
+ *
+ * Fix: set event.reason = "peer-unreachable" | "remote-unsubscribe" on the
+ * UnsubcriptionEvent before dispatching.
+ */
+import { TestSession } from "@peerbit/libp2p-test-utils";
+import type { UnsubcriptionEvent } from "@peerbit/pubsub-interface";
+import { waitForNeighbour } from "@peerbit/stream";
+import { delay, waitFor, waitForResolved } from "@peerbit/time";
+import { expect } from "chai";
+import { DirectSub, waitForSubscribers } from "../src/index.js";
+
+describe("BUG 2: UnsubcriptionEvent missing .reason property", function () {
+	this.timeout(60_000);
+
+	describe("peer-unreachable (removeSubscriptions path)", () => {
+		let session: TestSession<{ pubsub: DirectSub }>;
+
+		beforeEach(async () => {
+			session = await TestSession.disconnected(2, {
+				services: {
+					pubsub: (c) =>
+						new DirectSub(c, {
+							canRelayMessage: true,
+							connectionManager: false,
+						}),
+				},
+			});
+		});
+
+		afterEach(async () => {
+			await session.stop();
+		});
+
+		it("should include reason='peer-unreachable' when a peer disconnects", async () => {
+			const TOPIC = "reason-test-unreachable";
+			const unsubEvents: (UnsubcriptionEvent & { reason?: string })[] = [];
+
+			// Both peers subscribe
+			await session.peers[0].services.pubsub.subscribe(TOPIC);
+			await session.peers[1].services.pubsub.subscribe(TOPIC);
+
+			// Connect
+			await session.connect([
+				[session.peers[0], session.peers[1]],
+			]);
+
+			await waitForSubscribers(
+				session.peers[0],
+				[session.peers[1]],
+				TOPIC,
+			);
+			await waitForSubscribers(
+				session.peers[1],
+				[session.peers[0]],
+				TOPIC,
+			);
+
+			// Listen for unsubscribe events on peer 1
+			session.peers[1].services.pubsub.addEventListener(
+				"unsubscribe",
+				(e) => {
+					unsubEvents.push(e.detail as any);
+				},
+			);
+
+			// Stop peer 0 – this triggers removeSubscriptions on peer 1
+			await delay(2000);
+			await session.peers[0].stop();
+
+			// Wait for unsubscribe event
+			await waitForResolved(
+				() => expect(unsubEvents).to.have.length.greaterThanOrEqual(1),
+				{ timeout: 30_000 },
+			);
+
+			// BUG: Without the fix, event.reason is undefined
+			const event = unsubEvents[0];
+			expect(event.from.equals(session.peers[0].services.pubsub.publicKey))
+				.to.be.true;
+			expect(event.topics).to.include(TOPIC);
+
+			// This assertion FAILS without the patch
+			expect((event as any).reason).to.equal("peer-unreachable");
+		});
+	});
+
+	describe("remote-unsubscribe (Unsubscribe message path)", () => {
+		let session: TestSession<{ pubsub: DirectSub }>;
+
+		beforeEach(async () => {
+			session = await TestSession.disconnected(3, {
+				services: {
+					pubsub: (c) =>
+						new DirectSub(c, {
+							canRelayMessage: true,
+							connectionManager: false,
+						}),
+				},
+			});
+		});
+
+		afterEach(async () => {
+			await session.stop();
+		});
+
+		it("should include reason='remote-unsubscribe' when a peer explicitly unsubscribes", async () => {
+			const TOPIC = "reason-test-unsubscribe";
+			const unsubEvents: (UnsubcriptionEvent & { reason?: string })[] = [];
+
+			// Connect first
+			await session.connect([
+				[session.peers[0], session.peers[1]],
+				[session.peers[1], session.peers[2]],
+			]);
+
+			await waitForNeighbour(
+				session.peers[0].services.pubsub,
+				session.peers[1].services.pubsub,
+			);
+
+			// Peer 1 needs to track subscriptions
+			await session.peers[1].services.pubsub.requestSubscribers(TOPIC);
+
+			// Peer 0 subscribes
+			await session.peers[0].services.pubsub.subscribe(TOPIC);
+
+			// Wait for peer 1 to learn about peer 0's subscription
+			await waitForResolved(
+				() =>
+					expect(
+						session.peers[1].services.pubsub.topics
+							.get(TOPIC)
+							?.has(session.peers[0].services.pubsub.publicKeyHash),
+					).to.be.true,
+			);
+
+			// Listen for unsubscribe events on peer 1
+			session.peers[1].services.pubsub.addEventListener(
+				"unsubscribe",
+				(e) => {
+					unsubEvents.push(e.detail as any);
+				},
+			);
+
+			// Allow debouncing to settle
+			await delay(3000);
+
+			// Peer 0 explicitly unsubscribes (sends Unsubscribe message)
+			await session.peers[0].services.pubsub.unsubscribe(TOPIC);
+
+			// Wait for unsubscribe event on peer 1
+			await waitForResolved(
+				() => expect(unsubEvents).to.have.length.greaterThanOrEqual(1),
+				{ timeout: 15_000 },
+			);
+
+			const event = unsubEvents[0];
+			expect(event.from.equals(session.peers[0].services.pubsub.publicKey))
+				.to.be.true;
+			expect(event.topics).to.include(TOPIC);
+
+			// This assertion FAILS without the patch
+			expect((event as any).reason).to.equal("remote-unsubscribe");
+		});
+	});
+});


### PR DESCRIPTION
### Why

I have an app I've been making and that my app's `UnifiedP2PProvider.tsx` (line 1386-1391) listens for pubsub unsubscribe events and logs them with `logP2PDebug` in order to understand what's going on with flakiness: 

```typescript
  logP2PDebug('pubsub:unsubscribe', {
      peerId,
      peerHash: detail?.from?.hashcode?.() ?? null,
      topics: Array.isArray(detail?.topics) ? detail?.topics : null,
      reason: detail?.reason ?? null,  // ← uses the patched .reason field
  })
```

  Without the .reason field, the app couldn't distinguish between:
  - `"peer-unreachable"` — connection dropped (relay died, network issue)
  - `"remote-unsubscribe"` — peer explicitly left the topic

**This was important because the app had a @peerbit/stream [patch - now merged](https://github.com/dao-xyz/peerbit/pull/538) that skips peer removal when another connection is still alive. Without knowing why a peer unsubscribed, the app couldn't make correct reconnection decisions.** Was the peer gone, or did they just leave one topic? The debug logging (gated by `__APP_P2P_DEBUG`) was critical for diagnosing these issues during development. It still not only remains crucial for debugging due to increased visibility but also general app functionality.

## Summary

The `UnsubcriptionEvent` dispatched by `DirectSub` currently provides no way to distinguish **why** an unsubscription occurred. There are two fundamentally different unsubscription paths:

1. **Peer became unreachable** — the peer disconnected or went offline (`removeSubscriptions()`)
2. **Peer explicitly unsubscribed** — the peer sent an `Unsubscribe` message for specific topics

Consumers of the `"unsubscribe"` event receive the same event shape for both cases, making it impossible to react appropriately (e.g., showing "peer went offline" vs. "peer left the topic" in a UI, or deciding whether to attempt reconnection).

## Problem

Both dispatch sites create a bare `UnsubcriptionEvent` with no distinguishing metadata:

```typescript
// removeSubscriptions() — peer went offline
this.dispatchEvent(new CustomEvent("unsubscribe", {
    detail: new UnsubcriptionEvent(publicKey, changed),
}));

// Unsubscribe message handler — peer explicitly left
this.dispatchEvent(new CustomEvent("unsubscribe", {
    detail: new UnsubcriptionEvent(sender, changed),
}));
```

The `UnsubcriptionEvent` class only has `from` and `topics` fields. There is no `reason` or `type` discriminator.

### Downstream impact

I discovered this while building a browser-based P2P application using Peerbit. My connection management layer needs to distinguish between:

- **Peer unreachable**: trigger reconnection logic, show "offline" indicator, preserve subscription intent
- **Remote unsubscribe**: update topic membership UI, no reconnection needed, peer is still online

Without a reason field, the only workaround is to cross-reference unsubscribe events with connection state, which is racy and unreliable.

## Fix

Attach a `.reason` string property to the `UnsubcriptionEvent` before dispatching:

```typescript
// removeSubscriptions() path
const event = new UnsubcriptionEvent(publicKey, changed);
(event as any).reason = "peer-unreachable";
this.dispatchEvent(new CustomEvent("unsubscribe", { detail: event }));

// Unsubscribe message handler path
const event = new UnsubcriptionEvent(sender, changed);
(event as any).reason = "remote-unsubscribe";
this.dispatchEvent(new CustomEvent("unsubscribe", { detail: event }));
```

The `as any` cast is used because the `UnsubcriptionEvent` class in `@peerbit/pubsub-interface` doesn't currently declare a `reason` field. A cleaner upstream approach would be to add `reason?: string` to the `UnsubcriptionEvent` class definition — I kept this minimal to avoid cross-package changes, but happy to update `pubsub-interface` as well if preferred.

### Possible values

| Value | Dispatch site | Meaning |
|-------|--------------|---------|
| `"peer-unreachable"` | `removeSubscriptions()` | Peer disconnected / went offline |
| `"remote-unsubscribe"` | Unsubscribe message handler | Peer explicitly unsubscribed from topics |

## Testing

Included two new test cases in `test/bug2-unsubscribe-reason.spec.ts`:

1. **Peer disconnect (peer-unreachable)**: Two peers subscribe to a topic. Peer 0 stops. Verifies that the unsubscribe event on peer 1 has `reason === "peer-unreachable"`.
   - **Without fix**: `AssertionError: expected undefined to equal 'peer-unreachable'`
   - **With fix**: ✔ passes

2. **Explicit unsubscribe (remote-unsubscribe)**: Peer 0 subscribes then explicitly calls `unsubscribe()`. Verifies that the unsubscribe event on peer 1 has `reason === "remote-unsubscribe"`.
   - **Without fix**: `AssertionError: expected undefined to equal 'remote-unsubscribe'`
   - **With fix**: ✔ passes

Both tests use real `DirectSub` instances via `TestSession`, matching existing test patterns.

## Notes

- This is a non-breaking, additive change — existing consumers that don't check `.reason` are unaffected.
- If you'd prefer the `reason` field to be a first-class property on `UnsubcriptionEvent` (in `@peerbit/pubsub-interface`), I'm happy to update that package as well.
- I am happy to allow edits by maintainers on this PR.