### PR TITLE
fix(document): align remote RPC timeout with wait timeout

### DIFF
--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -2283,6 +2283,15 @@ export class DocumentIndex<
 			// this will lead to bad UX as you usually want to list/expore whats going on before doing any replication work
 			remote.priority = 2;
 		}
+		if (remote && remote.timeout == null && options?.remote) {
+			const waitPolicy =
+				typeof options.remote === "object" ? options.remote.wait : undefined;
+			const waitTimeout =
+				typeof waitPolicy === "object" ? waitPolicy.timeout : undefined;
+			if (waitTimeout != null) {
+				remote.timeout = waitTimeout;
+			}
+		}
 
 		if (!local && !remote) {
 			throw new Error(


### PR DESCRIPTION
## Summary
- align remote RPC timeout with `remote.wait.timeout` when `remote.timeout` is omitted
- add a regression test that verifies the effective RPC timeout passed to `_query.request`

## Why
Document remote search/iterate supports longer `remote.wait.timeout`, but RPC request timeout defaults to 10s when `remote.timeout` is not explicitly set. Under load/churn this can cause premature missing-response outcomes before the intended wait window.

## Changes
- `packages/programs/data/document/document/src/search.ts`
  - In `queryCommence`, if `remote.timeout` is unset and `remote.wait.timeout` exists, set `remote.timeout = remote.wait.timeout`.
- `packages/programs/data/document/document/test/index.spec.ts`
  - New regression test:
    - `uses wait timeout as remote rpc timeout when timeout is omitted`

## Verification
- `pnpm --filter @peerbit/document test -- --grep "uses wait timeout as remote rpc timeout when timeout is omitted"`

Refs #606
