### PR TITLE
feat(rpc): expose missing response groups on timeout

### DIFF
--- a/packages/programs/rpc/src/utils.ts
+++ b/packages/programs/rpc/src/utils.ts
@@ -13,8 +13,10 @@ import type {
 } from "./io.js";
 
 export class MissingResponsesError extends Error {
-	constructor(message: string) {
+	missingGroups: string[][];
+	constructor(message: string, missingGroups: string[][] = []) {
 		super(message);
+		this.missingGroups = missingGroups;
 	}
 }
 export type RPCRequestAllOptions<_Q, R> = RPCRequestResponseOptions<R> &
@@ -84,6 +86,7 @@ export const queryAll = async <Q, R>(
 		throw new MissingResponsesError(
 			"Did not receive responses from all shards: " +
 				JSON.stringify(missingReponses),
+			missingReponses,
 		);
 	}
 };


### PR DESCRIPTION
## Summary
- add `missingGroups` metadata to `MissingResponsesError`
- include the unresolved shard groups when throwing from `queryAll`
- add a focused regression test in RPC

## Why
`queryAll` already knows which shard groups failed to respond, but callers could only inspect a stringified message. Exposing structured metadata enables targeted retries and better diagnostics.

## Changes
- `packages/programs/rpc/src/utils.ts`
  - `MissingResponsesError` now has `missingGroups: string[][]`
  - `queryAll` passes unresolved groups when constructing the error
- `packages/programs/rpc/test/index.spec.ts`
  - new test: `reports missing groups on timeout`

## Verification
- `pnpm --filter @peerbit/rpc test -- --grep "reports missing groups on timeout"`

Refs #607
