### PR TITLE
test(pubsub): add regression coverage for subscribe race edges

### DIFF
--- a/packages/transport/pubsub/test/subscribe-races.spec.ts
+++ b/packages/transport/pubsub/test/subscribe-races.spec.ts
@@ -93,7 +93,13 @@ describe("pubsub (subscribe race regressions)", function () {
 			await waitForNeighbour(a, b);
 
 			await b.subscribe(TOPIC);
-			await delay(250);
+			await waitForResolved(() => {
+				expect(b.subscriptions.has(TOPIC)).to.equal(true);
+				const bSubscribers = b.getSubscribers(TOPIC);
+				expect(
+					bSubscribers?.some((subscriber) => subscriber.hashcode() === b.publicKeyHash),
+				).to.equal(true);
+			});
 
 			expect(a.topics.has(TOPIC)).to.equal(false);
 			expect(a.topics.get(TOPIC)).to.equal(undefined);
@@ -131,10 +137,8 @@ describe("pubsub (subscribe race regressions)", function () {
 
 			expect(a.topics.has(TOPIC)).to.equal(false);
 			const bTopics = b.topics.get(TOPIC);
-			if (bTopics) {
-				expect(bTopics.has(a.publicKeyHash)).to.equal(false);
-			}
-
+			expect(bTopics).to.not.equal(undefined);
+			expect(bTopics!.has(a.publicKeyHash)).to.equal(false);
 		} finally {
 			await session.stop();
 		}


### PR DESCRIPTION
## Summary

This PR adds focused pubsub regression coverage based on historical issues discussed in #596.

`master` already has coverage for:
- immediate pending-subscribe tracking / local cleanup
- strict direct delivery while subscribe is pending

But it did not have explicit regression tests for a few race/design edges that #596 attempted to protect.

## What this adds

New file:
- `packages/transport/pubsub/test/subscribe-races.spec.ts`

New regression tests:
1. **concurrent subscribe + connect**
- Verifies peers still discover each other when `subscribe()` and `connect()` happen concurrently.

2. **non-subscriber topic tracking guard**
- Verifies a peer that never subscribed does not start tracking a topic just from incoming subscription traffic.

3. **cancelled pending subscription is not advertised**
- Verifies `subscribe()` followed by `unsubscribe()` within the debounce window does not leave stale remote subscriber state.

## Why these tests are useful

These are race-sensitive behaviors that are easy to regress during refactors around:
- subscription debounce/pending state handling
- topic map lifecycle
- fanout control-plane synchronization during connect/subscribe interleaving

They complement existing `fanout-topics.spec.ts` checks by asserting **network-visible behavior** (peer discovery / non-discovery), not only local state transitions.

## Notes from PR #596 analysis

- The old `requestSubscribers while remote _subscribe() is blocked` scenario from #596 still fails on current master when enabled.
- That case is **not** added as an active test in this PR because it currently represents behavior that would require implementation changes, not just regression guarding.

## Verification

Run:

```bash
node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/pubsub -- -t node
```

Result locally: passing (`53 passing`).


Looped regression test 50 times and it passes every time.