### PR TITLE
feat(peer): add dial readiness modes for fanout-backed pubsub

### DIFF
--- a/packages/programs/program/program/src/client.ts
+++ b/packages/programs/program/program/src/client.ts
@@ -22,7 +22,15 @@ export interface Client<T extends Manageable<ExtractArgs<T>>> {
 	peerId: Libp2pPeerId;
 	identity: Identity<Ed25519PublicKey>;
 	getMultiaddrs: () => Multiaddr[];
-	dial(address: string | Multiaddr | Multiaddr[]): Promise<boolean>;
+	dial(
+		address: string | Multiaddr | Multiaddr[],
+		options?: {
+			dialTimeoutMs?: number;
+			serviceWaitTimeoutMs?: number;
+			readiness?: "connection" | "services" | "services-and-fanout";
+			signal?: AbortSignal;
+		},
+	): Promise<boolean>;
 	hangUp(address: PeerId | PublicSignKey | string | Multiaddr): Promise<void>;
 	services: {
 		pubsub: PubSub;


### PR DESCRIPTION
## Summary
- add dial readiness options so callers can choose connection-only, services, or services-and-fanout semantics
- make default dial readiness include fanout neighbor readiness when fanout-backed pubsub is present
- wire timeout/signal through service wait paths
- add connect regression tests for default fanout wait, skip fanout wait, and connection-only readiness

## Validation
- node ./node_modules/aegir/src/index.js run test --roots ./packages/clients/peerbit -- -t node --grep "dial"
- pnpm -C packages/programs/program/program run build

Refs #599
