### PR TITLE
feat(transport): unify directstream and fanout route hints

### DIFF
--- a/packages/transport/pubsub-interface/src/index.ts
+++ b/packages/transport/pubsub-interface/src/index.ts
@@ -9,6 +9,7 @@ import {
 	type PeerEvents,
 	type PriorityOptions,
 	type PublicKeyFromHashResolver,
+	type RouteHint,
 	type WaitForPeer,
 	type WithExtraSigners,
 } from "@peerbit/stream-interface";
@@ -136,6 +137,10 @@ export interface PubSub
 		WaitForPeer,
 		PublicKeyFromHashResolver {
 	getSubscribers(topic: string): MaybePromise<PublicSignKey[] | undefined>;
+	getUnifiedRouteHints?(
+		topic: string,
+		targetHash: string,
+	): MaybePromise<RouteHint[]>;
 
 	requestSubscribers(topic: string, from?: PublicSignKey): MaybePromise<void>;
 

--- a/packages/transport/stream-interface/src/index.ts
+++ b/packages/transport/stream-interface/src/index.ts
@@ -18,6 +18,7 @@ export interface StreamEvents extends PeerEvents, MessageEvents {
 }
 
 export * from "./messages.js";
+export * from "./route-hints.js";
 
 // ---------- wait for peer types ----------
 export type Target = "neighbor" | "reachable";

--- a/packages/transport/stream-interface/src/route-hints.ts
+++ b/packages/transport/stream-interface/src/route-hints.ts
@@ -1,0 +1,21 @@
+export type DirectStreamAckRouteHint = {
+	kind: "directstream-ack";
+	from: string;
+	target: string;
+	nextHop: string;
+	distance: number;
+	session: number;
+	updatedAt: number;
+	expiresAt?: number;
+};
+
+export type FanoutRouteTokenHint = {
+	kind: "fanout-token";
+	root: string;
+	target: string;
+	route: string[];
+	updatedAt: number;
+	expiresAt?: number;
+};
+
+export type RouteHint = DirectStreamAckRouteHint | FanoutRouteTokenHint;

--- a/packages/transport/stream/src/index.ts
+++ b/packages/transport/stream/src/index.ts
@@ -47,6 +47,7 @@ import {
 	getMsgId,
 } from "@peerbit/stream-interface";
 import type {
+	DirectStreamAckRouteHint,
 	IdOptions,
 	PeerRefs,
 	PriorityOptions,
@@ -1746,6 +1747,20 @@ export abstract class DirectStream<
 	}
 	public invalidateSession(key: string) {
 		this.routes.updateSession(key, undefined);
+	}
+
+	public getRouteHints(
+		target: string,
+		from: string = this.publicKeyHash,
+	): DirectStreamAckRouteHint[] {
+		return this.routes.getRouteHints(from, target);
+	}
+
+	public getBestRouteHint(
+		target: string,
+		from: string = this.publicKeyHash,
+	): DirectStreamAckRouteHint | undefined {
+		return this.routes.getBestRouteHint(from, target);
 	}
 
 	public onPeerSession(key: PublicSignKey, session: number) {


### PR DESCRIPTION
## Summary
- add shared RouteHint types in stream-interface for directstream ACK route hints and fanout route token hints
- expose route hint accessors from DirectStream routes (best + full list)
- expose fanout route-token hint lookup for topic/root/target
- add getUnifiedRouteHints in pubsub control plane to combine directstream and fanout hints
- add fanout topics test asserting both hint types are available

## Validation
- pnpm -C packages/transport/stream-interface run build
- pnpm -C packages/transport/stream run build
- pnpm -C packages/transport/pubsub-interface run build
- pnpm -C packages/transport/pubsub run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/stream -- -t node --grep "route"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/pubsub -- -t node --grep "unified route hints"

Refs #600
