### PR TITLE
feat(pubsub): add typed unsubscribe reason metadata

### DIFF
--- a/packages/transport/pubsub-interface/src/index.ts
+++ b/packages/transport/pubsub-interface/src/index.ts
@@ -35,11 +35,23 @@ export class UnsubcriptionEvent {
 	@field({ type: vec("string") })
 	topics: string[];
 
-	constructor(from: PublicSignKey, topics: string[]) {
+	reason?: UnsubscriptionReason;
+
+	constructor(
+		from: PublicSignKey,
+		topics: string[],
+		reason?: UnsubscriptionReason,
+	) {
 		this.from = from;
 		this.topics = topics;
+		this.reason = reason;
 	}
 }
+
+export type UnsubscriptionReason =
+	| "remote-unsubscribe"
+	| "peer-unreachable"
+	| "peer-session-reset";
 
 export class PublishEvent {
 	@field({ type: PubSubData })

--- a/packages/transport/pubsub/src/index.ts
+++ b/packages/transport/pubsub/src/index.ts
@@ -17,6 +17,7 @@ import {
 	SubscriptionEvent,
 	TopicRootCandidates,
 	UnsubcriptionEvent,
+	type UnsubscriptionReason,
 	Unsubscribe,
 } from "@peerbit/pubsub-interface";
 import {
@@ -1496,16 +1497,19 @@ export class TopicControlPlane
 	}
 
 	public onPeerSession(key: PublicSignKey, _session: number): void {
-		this.removeSubscriptions(key);
+		this.removeSubscriptions(key, "peer-session-reset");
 	}
 
 	public override onPeerUnreachable(publicKeyHash: string) {
 		super.onPeerUnreachable(publicKeyHash);
 		const key = this.peerKeyHashToPublicKey.get(publicKeyHash);
-		if (key) this.removeSubscriptions(key);
+		if (key) this.removeSubscriptions(key, "peer-unreachable");
 	}
 
-	private removeSubscriptions(publicKey: PublicSignKey) {
+	private removeSubscriptions(
+		publicKey: PublicSignKey,
+		reason: UnsubscriptionReason,
+	) {
 		const peerHash = publicKey.hashcode();
 		const peerTopics = this.peerToTopic.get(peerHash);
 		const changed: string[] = [];
@@ -1524,7 +1528,7 @@ export class TopicControlPlane
 		if (changed.length > 0) {
 			this.dispatchEvent(
 				new CustomEvent<UnsubcriptionEvent>("unsubscribe", {
-					detail: new UnsubcriptionEvent(publicKey, changed),
+					detail: new UnsubcriptionEvent(publicKey, changed, reason),
 				}),
 			);
 		}
@@ -1741,7 +1745,11 @@ export class TopicControlPlane
 				if (changed.length > 0) {
 					this.dispatchEvent(
 						new CustomEvent<UnsubcriptionEvent>("unsubscribe", {
-							detail: new UnsubcriptionEvent(sender, changed),
+							detail: new UnsubcriptionEvent(
+								sender,
+								changed,
+								"remote-unsubscribe",
+							),
 						}),
 					);
 				}

--- a/packages/transport/pubsub/test/unsubscribe-reason.spec.ts
+++ b/packages/transport/pubsub/test/unsubscribe-reason.spec.ts
@@ -1,0 +1,175 @@
+import { getPublicKeyFromPeerId } from "@peerbit/crypto";
+import { TestSession } from "@peerbit/libp2p-test-utils";
+import type {
+	UnsubcriptionEvent,
+	UnsubscriptionReason,
+} from "@peerbit/pubsub-interface";
+import { waitForResolved } from "@peerbit/time";
+import { expect } from "chai";
+import { FanoutTree, TopicControlPlane, TopicRootControlPlane } from "../src/index.js";
+
+describe("pubsub (unsubscribe reason)", function () {
+	const createDisconnectedSession = async (
+		peerCount: number,
+		options?: {
+			pubsub?: Partial<ConstructorParameters<typeof TopicControlPlane>[1]>;
+		},
+	) => {
+		const topicRootControlPlane = new TopicRootControlPlane();
+		const fanoutByHash = new Map<string, FanoutTree>();
+		const getOrCreateFanout = (c: any) => {
+			const hash = getPublicKeyFromPeerId(c.peerId).hashcode();
+			let fanout = fanoutByHash.get(hash);
+			if (!fanout) {
+				fanout = new FanoutTree(c, {
+					connectionManager: false,
+					topicRootControlPlane,
+				});
+				fanoutByHash.set(hash, fanout);
+			}
+			return fanout;
+		};
+
+		return TestSession.disconnected<{
+			pubsub: TopicControlPlane;
+			fanout: FanoutTree;
+		}>(peerCount, {
+			services: {
+				fanout: (c: any) => getOrCreateFanout(c),
+				pubsub: (c: any) =>
+					new TopicControlPlane(c, {
+						canRelayMessage: true,
+						connectionManager: false,
+						topicRootControlPlane,
+						fanout: getOrCreateFanout(c),
+						shardCount: 16,
+						fanoutJoin: {
+							timeoutMs: 10_000,
+							retryMs: 50,
+							bootstrapEnsureIntervalMs: 200,
+							trackerQueryIntervalMs: 200,
+							joinReqTimeoutMs: 1_000,
+							trackerQueryTimeoutMs: 1_000,
+						},
+						...(options?.pubsub || {}),
+					}),
+			},
+		});
+	};
+
+	const setupTrackedSubscribers = async (
+		topic: string,
+		session: Awaited<ReturnType<typeof createDisconnectedSession>>,
+	) => {
+		const a = session.peers[0]!.services.pubsub;
+		const b = session.peers[1]!.services.pubsub;
+
+		await session.connect([[session.peers[0], session.peers[1]]]);
+		await Promise.all([a.subscribe(topic), b.subscribe(topic)]);
+
+		await waitForResolved(() => {
+			const aTopics = a.topics.get(topic);
+			const bTopics = b.topics.get(topic);
+			expect(aTopics?.has(b.publicKeyHash)).to.equal(true);
+			expect(bTopics?.has(a.publicKeyHash)).to.equal(true);
+		});
+
+		return { a, b };
+	};
+
+	const expectUnsubscribeEvent = async (properties: {
+		events: UnsubcriptionEvent[];
+		fromHash: string;
+		topic: string;
+		reason: UnsubscriptionReason;
+	}) => {
+		await waitForResolved(() => {
+			const match = properties.events.find(
+				(e) =>
+					e.from.hashcode() === properties.fromHash &&
+					e.topics.includes(properties.topic),
+			);
+			expect(match).to.not.equal(undefined);
+			expect(match!.reason).to.equal(properties.reason);
+		});
+	};
+
+	it("emits reason=remote-unsubscribe on explicit unsubscribe", async () => {
+		const topic = "unsubscribe-reason-remote";
+		const session = await createDisconnectedSession(2);
+		try {
+			const { a, b } = await setupTrackedSubscribers(topic, session);
+			const events: UnsubcriptionEvent[] = [];
+			const onUnsubscribe = (ev: CustomEvent<UnsubcriptionEvent>) =>
+				events.push(ev.detail);
+
+			a.addEventListener("unsubscribe", onUnsubscribe as any);
+			try {
+				await b.unsubscribe(topic);
+				await expectUnsubscribeEvent({
+					events,
+					fromHash: b.publicKeyHash,
+					topic,
+					reason: "remote-unsubscribe",
+				});
+			} finally {
+				a.removeEventListener("unsubscribe", onUnsubscribe as any);
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("emits reason=peer-unreachable when a tracked peer becomes unreachable", async () => {
+		const topic = "unsubscribe-reason-unreachable";
+		const session = await createDisconnectedSession(2);
+		try {
+			const { a, b } = await setupTrackedSubscribers(topic, session);
+			const events: UnsubcriptionEvent[] = [];
+			const onUnsubscribe = (ev: CustomEvent<UnsubcriptionEvent>) =>
+				events.push(ev.detail);
+
+			a.addEventListener("unsubscribe", onUnsubscribe as any);
+			try {
+				a.onPeerUnreachable(b.publicKeyHash);
+				await expectUnsubscribeEvent({
+					events,
+					fromHash: b.publicKeyHash,
+					topic,
+					reason: "peer-unreachable",
+				});
+			} finally {
+				a.removeEventListener("unsubscribe", onUnsubscribe as any);
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("emits reason=peer-session-reset on peer session updates", async () => {
+		const topic = "unsubscribe-reason-session";
+		const session = await createDisconnectedSession(2);
+		try {
+			const { a, b } = await setupTrackedSubscribers(topic, session);
+			const events: UnsubcriptionEvent[] = [];
+			const onUnsubscribe = (ev: CustomEvent<UnsubcriptionEvent>) =>
+				events.push(ev.detail);
+			const bPublicKey = getPublicKeyFromPeerId(session.peers[1]!.peerId);
+
+			a.addEventListener("unsubscribe", onUnsubscribe as any);
+			try {
+				a.onPeerSession(bPublicKey, 1);
+				await expectUnsubscribeEvent({
+					events,
+					fromHash: b.publicKeyHash,
+					topic,
+					reason: "peer-session-reset",
+				});
+			} finally {
+				a.removeEventListener("unsubscribe", onUnsubscribe as any);
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- add typed `UnsubscriptionReason` to `UnsubcriptionEvent` (`remote-unsubscribe`, `peer-unreachable`, `peer-session-reset`)
- propagate reason values from all unsubscribe emit paths in `TopicControlPlane`
- add regression coverage for all three reasons in `unsubscribe-reason.spec.ts`

## Why
`unsubscribe` currently conflates explicit remote leave with transport/session-driven removal. Reason metadata lets higher layers and diagnostics distinguish intentional leave vs reachability/session churn.

## Validation
- `pnpm --filter @peerbit/pubsub-interface build`
- `pnpm --filter @peerbit/pubsub test -- --grep "unsubscribe reason"`
- `pnpm --filter @peerbit/pubsub test`

Supersedes #590.
