### PR TITLE
fix(peerbit): default bootstrap to v5 list and lock with tests

### DIFF
--- a/docs/modules/client/README.md
+++ b/docs/modules/client/README.md
@@ -20,7 +20,7 @@ Data is not only things that you generate in your databases, but also keys that 
 ## Connecting nodes
 
 ### Bootstrapping
-The easiest way to go online is to "bootstrap" your node. At the moment, this will dial all addresses available in the [public bootstrap list](https://github.com/dao-xyz/peerbit-bootstrap/blob/master/bootstrap.env)
+The easiest way to go online is to "bootstrap" your node. At the moment, this will dial all addresses available in the [public bootstrap list](https://github.com/dao-xyz/peerbit-bootstrap/blob/master/bootstrap-5.env)
 
 [bootstrap](./bootstrap.ts ':include')
 
@@ -45,4 +45,3 @@ Browser-to-browser connections can not be established without an intermediate no
 You can read more about deploying a relay [here](/modules/deploy/server/)
 
 [connectivity](./connectivity-relay.ts ':include')
-

--- a/packages/clients/peerbit/src/bootstrap.ts
+++ b/packages/clients/peerbit/src/bootstrap.ts
@@ -1,5 +1,5 @@
 export const resolveBootstrapAddresses = async (
-	v: string = "4",
+	v: string = "5",
 ): Promise<string[]> => {
 	// Bootstrap addresses for network
 	return (

--- a/packages/clients/peerbit/test/bootstrap-addresses.spec.ts
+++ b/packages/clients/peerbit/test/bootstrap-addresses.spec.ts
@@ -1,0 +1,55 @@
+import { expect } from "chai";
+import { resolveBootstrapAddresses } from "../src/bootstrap.js";
+
+describe("resolveBootstrapAddresses", () => {
+	const originalFetch = globalThis.fetch;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("defaults to the v5 public bootstrap list", async () => {
+		const requested: string[] = [];
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			requested.push(
+				typeof input === "string"
+					? input
+					: input instanceof URL
+						? input.toString()
+						: input.url,
+			);
+			return new Response(
+				"/dns4/node-a.peerchecker.com/tcp/4003/wss/p2p/12D3KooA\n\n/dns4/node-b.peerchecker.com/tcp/4003/wss/p2p/12D3KooB\n",
+				{ status: 200 },
+			);
+		}) as typeof fetch;
+
+		const result = await resolveBootstrapAddresses();
+		expect(requested).to.deep.equal([
+			"https://bootstrap.peerbit.org/bootstrap-5.env",
+		]);
+		expect(result).to.deep.equal([
+			"/dns4/node-a.peerchecker.com/tcp/4003/wss/p2p/12D3KooA",
+			"/dns4/node-b.peerchecker.com/tcp/4003/wss/p2p/12D3KooB",
+		]);
+	});
+
+	it("uses an explicit version override", async () => {
+		const requested: string[] = [];
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			requested.push(
+				typeof input === "string"
+					? input
+					: input instanceof URL
+						? input.toString()
+						: input.url,
+			);
+			return new Response("", { status: 200 });
+		}) as typeof fetch;
+
+		await resolveBootstrapAddresses("4");
+		expect(requested).to.deep.equal([
+			"https://bootstrap.peerbit.org/bootstrap-4.env",
+		]);
+	});
+});


### PR DESCRIPTION
## Summary
- switch `resolveBootstrapAddresses()` default from v4 to v5 in the peerbit client
- add deterministic unit tests for default and explicit version URL resolution
- update client docs link to the published v5 bootstrap list

## Why
`Peerbit.bootstrap()` without explicit addresses should now resolve against the active v5 bootstrap fleet. This aligns the client default with the current bootstrap rollout/cutover.

## Validation
- `pnpm -C packages/clients/peerbit test:node -- --grep "bootstrap|resolveBootstrapAddresses"`
- `PEERBIT_RUN_REMOTE_BOOTSTRAP_TEST=1 pnpm -C packages/clients/peerbit test:node -- --grep "bootstrap"`
