### PR TITLE
shared-log: extend churn repair retry tail to fix leave-distribution flake

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -444,8 +444,13 @@ const DEFAULT_DISTRIBUTION_DEBOUNCE_TIME = 500;
 const RECENT_REPAIR_DISPATCH_TTL_MS = 5_000;
 const REPAIR_SWEEP_ENTRY_BATCH_SIZE = 1_000;
 const REPAIR_SWEEP_TARGET_BUFFER_SIZE = 1024;
-const FORCE_FRESH_RETRY_SCHEDULE_MS = [0, 1_000, 3_000, 7_000];
-const JOIN_WARMUP_RETRY_SCHEDULE_MS = [0, 1_000, 3_000];
+// Churn/join repair can race with pruning and transient missed sync requests under
+// heavy event-loop load. Keep retries alive with a longer tail so reassigned
+// entries are retried after short bursts and slower recovery windows.
+const FORCE_FRESH_RETRY_SCHEDULE_MS = [
+	0, 1_000, 3_000, 7_000, 15_000, 30_000, 45_000,
+];
+const JOIN_WARMUP_RETRY_SCHEDULE_MS = [0, 1_000, 3_000, 7_000, 15_000];
 
 const toPositiveInteger = (
 	value: number | undefined,
@@ -2376,6 +2381,12 @@ export class SharedLog<
 		if (filteredEntries.size === 0) {
 			return;
 		}
+		const retrySchedule =
+			options?.retryScheduleMs && options.retryScheduleMs.length > 0
+				? options.retryScheduleMs
+				: options?.forceFreshDelivery
+					? FORCE_FRESH_RETRY_SCHEDULE_MS
+					: [0];
 
 		const run = () => {
 			// For force-fresh churn repair we intentionally bypass rateless IBLT and
@@ -2401,13 +2412,6 @@ export class SharedLog<
 				}),
 			).catch((error: any) => logger.error(error));
 		};
-
-		const retrySchedule =
-			options?.retryScheduleMs && options.retryScheduleMs.length > 0
-				? options.retryScheduleMs
-				: options?.forceFreshDelivery
-					? FORCE_FRESH_RETRY_SCHEDULE_MS
-					: [0];
 
 		for (const delayMs of retrySchedule) {
 			if (delayMs === 0) {


### PR DESCRIPTION
## Summary
Fix flaky shared-log churn redistribution in CI by extending repair retry tails for:

- force-fresh churn redistribution (`FORCE_FRESH_RETRY_SCHEDULE_MS`)
- join warmup delivery (`JOIN_WARMUP_RETRY_SCHEDULE_MS`)

The previous retry windows were short (`0,1,3,7s`) and could miss late recovery under heavy suite load/event-loop contention, leaving a single hash under-replicated in `u32-simple sharding distributes to leaving peers`.

## Root cause observed
In CI run https://github.com/dao-xyz/peerbit/actions/runs/22680475411, `part-4` failed with:

- `u32-simple > sharding > distributes to leaving peers`
- `Log did not reach lower bound length of 600 got 599`

I also reproduced a related local failure in the same path where one hash stayed at replica count 1 after peer leave.

## Change
`packages/programs/data/shared-log/src/index.ts`

- `FORCE_FRESH_RETRY_SCHEDULE_MS`:
  - from `[0, 1_000, 3_000, 7_000]`
  - to `[0, 1_000, 3_000, 7_000, 15_000, 30_000, 45_000]`
- `JOIN_WARMUP_RETRY_SCHEDULE_MS`:
  - from `[0, 1_000, 3_000]`
  - to `[0, 1_000, 3_000, 7_000, 15_000]`

No behavior model change beyond keeping retry windows alive longer for churn/join repair.

## Validation
- Reproducer tests:
  - `pnpm --dir packages/programs/data/shared-log run test -- -t node --no-build --grep "u32-simple.*distributes to leaving peers|u64-iblt.*repairs redistributed entry when maybe-sync misses one hash on peer leave"`
- Stress loop:
  - 20x repeated runs of the same reproducer pair, all passed.
- CI-equivalent shard locally (master baseline command):
  - `pnpm run test:ci:part-4`
  - Passed (`1770 passing, 2 pending` for shared-log + proxy pass)
