### PR TITLE
feat(pubsub): support opt-in parent upgrades

### DIFF
--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -3502,7 +3502,9 @@ describe("index", () => {
 						expect(writer.docs.index.hasPending).to.be.false;
 					});
 
-					it("onMissedResults respects already emitted results", async () => {
+					it("onMissedResults respects already emitted results", async function () {
+						this.timeout(120_000);
+
 						// test that we will get missed results accuruately
 						session = await TestSession.disconnected(3);
 

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -3569,7 +3569,6 @@ describe("index", () => {
 						expect(second.map((x) => x.id)).to.deep.equal(["2"]);
 
 						await session.connect([[session.peers[0], session.peers[1]]]); // connect the nodes!
-						await observer.docs.index.waitFor(writer1.node.identity.publicKey);
 
 						await waitForResolved(() => expect(missedResults).to.deep.equal([1]), {
 							timeout: 30_000,

--- a/packages/transport/pubsub/src/fanout-tree.ts
+++ b/packages/transport/pubsub/src/fanout-tree.ts
@@ -1349,7 +1349,6 @@ type ChannelState = {
 	peerHintTtlMs: number;
 	routeCacheMaxEntries: number;
 	routeCacheTtlMs: number;
-	loopAbortController: AbortController;
 	announceLoop?: Promise<void>;
 	repairLoop?: Promise<void>;
 	meshLoop?: Promise<void>;
@@ -2150,7 +2149,6 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			peerHintTtlMs,
 			routeCacheMaxEntries,
 			routeCacheTtlMs,
-			loopAbortController: new AbortController(),
 			trackerQueryIntervalMs: 2_000,
 			cachedTrackerCandidates: [],
 			lastTrackerQueryAt: 0,
@@ -2264,7 +2262,6 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		if (!ch) return;
 		if (ch.closed) return;
 		ch.closed = true;
-		ch.loopAbortController.abort();
 
 		// If a join is in-flight, surface that it won't complete.
 		try {
@@ -2309,11 +2306,6 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		this.trackerBySuffixKey.delete(id.suffixKey);
 
 		await Promise.all(pendingSends);
-		await Promise.allSettled(
-			[ch.joinLoop, ch.announceLoop, ch.repairLoop, ch.meshLoop].filter(
-				(loop): loop is Promise<void> => Boolean(loop),
-			),
-		);
 	}
 
 	public getChannelStats(topic: string, root: string):
@@ -4173,7 +4165,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 	}
 
 	private async _announceLoop(ch: ChannelState): Promise<void> {
-		const signal = anySignal([this.closeController.signal, ch.loopAbortController.signal]);
+		const signal = this.closeController.signal;
 		for (;;) {
 			if (signal.aborted || ch.closed) return;
 			try {
@@ -4187,12 +4179,12 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 				// ignore
 			}
 			const sleepMs = ch.announceIntervalMs > 0 ? ch.announceIntervalMs : 1_000;
-			await delay(sleepMs, { signal }).catch(() => {});
+			await delay(sleepMs);
 		}
 	}
 
 	private async _repairLoop(ch: ChannelState): Promise<void> {
-		const signal = anySignal([this.closeController.signal, ch.loopAbortController.signal]);
+		const signal = this.closeController.signal;
 		for (;;) {
 			if (signal.aborted || ch.closed) return;
 			try {
@@ -4202,7 +4194,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			}
 			const activeMs = ch.repairIntervalMs > 0 ? ch.repairIntervalMs : 200;
 			const sleepMs = ch.missingSeqs.size > 0 ? activeMs : Math.max(activeMs, 1_000);
-			await delay(sleepMs, { signal }).catch(() => {});
+			await delay(sleepMs);
 		}
 	}
 
@@ -4379,7 +4371,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		}
 
 	private async _meshLoop(ch: ChannelState): Promise<void> {
-		const signal = anySignal([this.closeController.signal, ch.loopAbortController.signal]);
+		const signal = this.closeController.signal;
 		let lastRefreshAt = 0;
 		for (;;) {
 			if (signal.aborted || ch.closed) return;
@@ -4405,7 +4397,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 				(v) => v > 0,
 			);
 			const sleepMs = intervals.length > 0 ? Math.min(...intervals) : 500;
-			await delay(Math.max(50, sleepMs), { signal }).catch(() => {});
+			await delay(Math.max(50, sleepMs));
 		}
 	}
 
@@ -4646,8 +4638,8 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		const start = Date.now();
 		const cooldownUntilByHash = new Map<string, number>();
 		const combinedSignal = joinOpts.signal
-			? anySignal([this.closeController.signal, ch.loopAbortController.signal, joinOpts.signal])
-			: anySignal([this.closeController.signal, ch.loopAbortController.signal]);
+			? anySignal([this.closeController.signal, joinOpts.signal])
+			: this.closeController.signal;
 		const signal = combinedSignal as AbortSignal & { clear?: () => void };
 		let lastParentUpgradeCheckAt = 0;
 

--- a/packages/transport/pubsub/src/fanout-tree.ts
+++ b/packages/transport/pubsub/src/fanout-tree.ts
@@ -264,6 +264,22 @@ export type FanoutTreeJoinOptions = {
 	trackerQueryIntervalMs?: number;
 
 	/**
+	 * Min interval between parent-improvement checks while already attached.
+	 *
+	 * Set to `0` to preserve the current stability-first behavior where a healthy
+	 * parent is only replaced after disconnect/staleness/kick.
+	 */
+	parentUpgradeIntervalMs?: number;
+
+	/**
+	 * Restrict proactive parent upgrades to leaves (nodes with no children).
+	 *
+	 * Defaults to `true` so parent improvement can be evaluated without
+	 * introducing relay churn higher in the tree.
+	 */
+	parentUpgradeLeafOnly?: boolean;
+
+	/**
 	 * Max number of join candidates to try per retry "round".
 	 *
 	 * This prevents a long tail of sequential JOIN_REQ timeouts from blocking
@@ -1326,14 +1342,15 @@ type ChannelState = {
 	cachedBootstrapPeers: string[];
 	lastBootstrapEnsureAt: number;
 
-			announceIntervalMs: number;
-			announceTtlMs: number;
-			lastAnnouncedAt: number;
-			peerHintMaxEntries: number;
-			peerHintTtlMs: number;
-			routeCacheMaxEntries: number;
-			routeCacheTtlMs: number;
-		announceLoop?: Promise<void>;
+	announceIntervalMs: number;
+	announceTtlMs: number;
+	lastAnnouncedAt: number;
+	peerHintMaxEntries: number;
+	peerHintTtlMs: number;
+	routeCacheMaxEntries: number;
+	routeCacheTtlMs: number;
+	loopAbortController: AbortController;
+	announceLoop?: Promise<void>;
 	repairLoop?: Promise<void>;
 	meshLoop?: Promise<void>;
 	joinLoop?: Promise<void>;
@@ -2133,6 +2150,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			peerHintTtlMs,
 			routeCacheMaxEntries,
 			routeCacheTtlMs,
+			loopAbortController: new AbortController(),
 			trackerQueryIntervalMs: 2_000,
 			cachedTrackerCandidates: [],
 			lastTrackerQueryAt: 0,
@@ -2246,6 +2264,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		if (!ch) return;
 		if (ch.closed) return;
 		ch.closed = true;
+		ch.loopAbortController.abort();
 
 		// If a join is in-flight, surface that it won't complete.
 		try {
@@ -2290,6 +2309,11 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		this.trackerBySuffixKey.delete(id.suffixKey);
 
 		await Promise.all(pendingSends);
+		await Promise.allSettled(
+			[ch.joinLoop, ch.announceLoop, ch.repairLoop, ch.meshLoop].filter(
+				(loop): loop is Promise<void> => Boolean(loop),
+			),
+		);
 	}
 
 	public getChannelStats(topic: string, root: string):
@@ -4149,7 +4173,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 	}
 
 	private async _announceLoop(ch: ChannelState): Promise<void> {
-		const signal = this.closeController.signal;
+		const signal = anySignal([this.closeController.signal, ch.loopAbortController.signal]);
 		for (;;) {
 			if (signal.aborted || ch.closed) return;
 			try {
@@ -4163,12 +4187,12 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 				// ignore
 			}
 			const sleepMs = ch.announceIntervalMs > 0 ? ch.announceIntervalMs : 1_000;
-			await delay(sleepMs);
+			await delay(sleepMs, { signal }).catch(() => {});
 		}
 	}
 
 	private async _repairLoop(ch: ChannelState): Promise<void> {
-		const signal = this.closeController.signal;
+		const signal = anySignal([this.closeController.signal, ch.loopAbortController.signal]);
 		for (;;) {
 			if (signal.aborted || ch.closed) return;
 			try {
@@ -4178,7 +4202,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			}
 			const activeMs = ch.repairIntervalMs > 0 ? ch.repairIntervalMs : 200;
 			const sleepMs = ch.missingSeqs.size > 0 ? activeMs : Math.max(activeMs, 1_000);
-			await delay(sleepMs);
+			await delay(sleepMs, { signal }).catch(() => {});
 		}
 	}
 
@@ -4354,11 +4378,11 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			}
 		}
 
-		private async _meshLoop(ch: ChannelState): Promise<void> {
-			const signal = this.closeController.signal;
-			let lastRefreshAt = 0;
-			for (;;) {
-				if (signal.aborted || ch.closed) return;
+	private async _meshLoop(ch: ChannelState): Promise<void> {
+		const signal = anySignal([this.closeController.signal, ch.loopAbortController.signal]);
+		let lastRefreshAt = 0;
+		for (;;) {
+			if (signal.aborted || ch.closed) return;
 
 				const now = Date.now();
 				try {
@@ -4381,7 +4405,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 				(v) => v > 0,
 			);
 			const sleepMs = intervals.length > 0 ? Math.min(...intervals) : 500;
-			await delay(Math.max(50, sleepMs));
+			await delay(Math.max(50, sleepMs), { signal }).catch(() => {});
 		}
 	}
 
@@ -4600,6 +4624,11 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			0,
 			Math.floor(joinOpts.candidateCooldownMs ?? 2_000),
 		);
+		const parentUpgradeIntervalMs = Math.max(
+			0,
+			Math.floor(joinOpts.parentUpgradeIntervalMs ?? 0),
+		);
+		const parentUpgradeLeafOnly = joinOpts.parentUpgradeLeafOnly !== false;
 		const candidateScoringModeRaw = joinOpts.candidateScoringMode ?? "ranked-shuffle";
 		const candidateScoringMode: "ranked-shuffle" | "ranked-strict" | "weighted" =
 			candidateScoringModeRaw === "ranked-strict" ||
@@ -4617,9 +4646,10 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		const start = Date.now();
 		const cooldownUntilByHash = new Map<string, number>();
 		const combinedSignal = joinOpts.signal
-			? anySignal([this.closeController.signal, joinOpts.signal])
-			: this.closeController.signal;
+			? anySignal([this.closeController.signal, ch.loopAbortController.signal, joinOpts.signal])
+			: anySignal([this.closeController.signal, ch.loopAbortController.signal]);
 		const signal = combinedSignal as AbortSignal & { clear?: () => void };
+		let lastParentUpgradeCheckAt = 0;
 
 			try {
 				for (;;) {
@@ -4692,8 +4722,30 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 								}
 								ch.pendingRouteProxy.clear();
 								void this.kickChildren(ch).catch(() => {});
-								await delay(retryMs);
+								await delay(retryMs, { signal });
 								continue;
+							}
+
+							if (
+								parentUpgradeIntervalMs > 0 &&
+								ch.level > 1 &&
+								(!parentUpgradeLeafOnly || ch.children.size === 0)
+							) {
+								const now = Date.now();
+								const due =
+									lastParentUpgradeCheckAt === 0 ||
+									now - lastParentUpgradeCheckAt >= parentUpgradeIntervalMs;
+								if (due) {
+									lastParentUpgradeCheckAt = now;
+									await this.maybeImproveParent(ch, {
+										signal,
+										candidateShuffleTopK,
+										candidateScoringMode,
+										candidateScoringWeights,
+										joinAttemptsPerRound,
+										joinReqTimeoutMs,
+									});
+								}
 							}
 
 						if (!ch.joinedOnce) ch.joinedOnce = createDeferred();
@@ -4701,7 +4753,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 						ch.joinedAtLeastOnce = true;
 						// Once attached, we don't need a fast retry cadence; keep polling coarse to
 						// avoid excessive timers when simulating many nodes in one process.
-						await delay(Math.max(retryMs, 1_000));
+						await delay(Math.max(retryMs, 1_000), { signal });
 						continue;
 					}
 
@@ -4897,10 +4949,10 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 							retryMs,
 							trackerQueryIntervalMs > 0 ? trackerQueryIntervalMs : retryMs,
 						);
-							await delay(Math.max(1, Math.min(waitMs, capMs)));
+							await delay(Math.max(1, Math.min(waitMs, capMs)), { signal });
 							continue;
 						}
-						await delay(retryMs);
+						await delay(retryMs, { signal });
 						continue;
 					}
 
@@ -5135,11 +5187,254 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 							}
 							continue;
 						}
-						await delay(retryMs);
+						await delay(retryMs, { signal });
 					}
 				} finally {
 					signal.clear?.();
 			}
+	}
+
+	private async maybeImproveParent(
+		ch: ChannelState,
+		options: {
+			signal: AbortSignal;
+			candidateShuffleTopK: number;
+			candidateScoringMode: "ranked-shuffle" | "ranked-strict" | "weighted";
+			candidateScoringWeights: {
+				level: number;
+				freeSlots: number;
+				connected: number;
+				bidPerByte: number;
+				source: number;
+			};
+			joinAttemptsPerRound: number;
+			joinReqTimeoutMs: number;
+		},
+	): Promise<boolean> {
+		const currentParent = ch.parent;
+		if (!currentParent || ch.closed || ch.isRoot || ch.level <= 1) return false;
+		const isDirectNeighbor = (hash: string) => {
+			const peer = this.peers.get(hash);
+			if (!peer) return false;
+			try {
+				const conns = this.components.connectionManager.getConnections(peer.peerId) as
+					| Connection[]
+					| undefined;
+				return (conns?.length ?? 0) > 0;
+			} catch {
+				return peer.isReadable || peer.isWritable;
+			}
+		};
+
+		const candidatesByHash = new Map<
+			string,
+			{
+				hash: string;
+				addrs: Multiaddr[];
+				level: number;
+				freeSlots: number;
+				bidPerByte: number;
+				source: number;
+			}
+		>();
+
+		const upsertCandidate = (c: {
+			hash: string;
+			addrs: Multiaddr[];
+			level: number;
+			freeSlots: number;
+			bidPerByte: number;
+			source: number;
+		}) => {
+			const prev = candidatesByHash.get(c.hash);
+			if (!prev) {
+				candidatesByHash.set(c.hash, { ...c });
+				return;
+			}
+			if (prev.addrs.length === 0 && c.addrs.length > 0) prev.addrs = c.addrs;
+			prev.level = Math.min(prev.level, c.level);
+			prev.freeSlots = Math.max(prev.freeSlots, c.freeSlots);
+			prev.bidPerByte = Math.max(prev.bidPerByte, c.bidPerByte);
+			prev.source = Math.min(prev.source, c.source);
+		};
+
+		if (ch.id.root !== this.publicKeyHash && isDirectNeighbor(ch.id.root)) {
+			upsertCandidate({
+				hash: ch.id.root,
+				addrs: [],
+				level: 0,
+				freeSlots: Number.MAX_SAFE_INTEGER,
+				bidPerByte: 0,
+				source: -1,
+			});
+		}
+
+		for (const c of ch.cachedTrackerCandidates) {
+			if (c.hash === this.publicKeyHash) continue;
+			if (!isDirectNeighbor(c.hash)) continue;
+			if (c.freeSlots <= 0) continue;
+			upsertCandidate({
+				hash: c.hash,
+				addrs: c.addrs,
+				level: c.level,
+				freeSlots: c.freeSlots,
+				bidPerByte: c.bidPerByte,
+				source: 0,
+			});
+		}
+
+		let connectedFallbackAdded = 0;
+		const connectedFallbackMax = 64;
+		for (const h of this.peers.keys()) {
+			if (h === this.publicKeyHash) continue;
+			if (!isDirectNeighbor(h)) continue;
+			upsertCandidate({
+				hash: h,
+				addrs: [],
+				level: 0xffff,
+				freeSlots: 0,
+				bidPerByte: 0,
+				source: 2,
+			});
+			connectedFallbackAdded += 1;
+			if (connectedFallbackAdded >= connectedFallbackMax) break;
+		}
+
+		let ordered = [...candidatesByHash.values()]
+			.filter(
+				(c) =>
+					c.hash !== this.publicKeyHash &&
+					c.hash !== currentParent &&
+					c.level + 1 < ch.level,
+			)
+			.sort((a, b) => {
+				if (a.level !== b.level) return a.level - b.level;
+				if (a.freeSlots !== b.freeSlots) return b.freeSlots - a.freeSlots;
+				if (a.bidPerByte !== b.bidPerByte) return b.bidPerByte - a.bidPerByte;
+				if (a.source !== b.source) return a.source - b.source;
+				return a.hash < b.hash ? -1 : a.hash > b.hash ? 1 : 0;
+			});
+
+		if (ordered.length === 0) return false;
+
+		if (options.candidateScoringMode === "ranked-shuffle") {
+			if (options.candidateShuffleTopK > 0 && ordered.length > 1) {
+				const k = Math.min(options.candidateShuffleTopK, ordered.length);
+				for (let i = k - 1; i > 0; i--) {
+					const j = Math.floor(this.random() * (i + 1));
+					const tmp = ordered[i]!;
+					ordered[i] = ordered[j]!;
+					ordered[j] = tmp;
+				}
+			}
+		} else if (options.candidateScoringMode === "weighted") {
+			const wLevel = Number.isFinite(options.candidateScoringWeights.level)
+				? Math.max(0, options.candidateScoringWeights.level)
+				: 0;
+			const wSlots = Number.isFinite(options.candidateScoringWeights.freeSlots)
+				? Math.max(0, options.candidateScoringWeights.freeSlots)
+				: 0;
+			const wConnected = Number.isFinite(options.candidateScoringWeights.connected)
+				? Math.max(0, options.candidateScoringWeights.connected)
+				: 0;
+			const wBid = Number.isFinite(options.candidateScoringWeights.bidPerByte)
+				? Math.max(0, options.candidateScoringWeights.bidPerByte)
+				: 0;
+			const wSource = Number.isFinite(options.candidateScoringWeights.source)
+				? Math.max(0, options.candidateScoringWeights.source)
+				: 0;
+
+			const k =
+				options.candidateShuffleTopK > 0
+					? Math.min(options.candidateShuffleTopK, ordered.length)
+					: 0;
+			if (k > 1) {
+				const head = ordered.slice(0, k);
+				const tail = ordered.slice(k);
+
+				const weightOf = (c: (typeof head)[number]) => {
+					const level = Math.max(0, Math.floor(c.level));
+					const freeSlots = Math.max(0, Math.floor(c.freeSlots));
+					const bidPerByte = Math.max(0, Math.floor(c.bidPerByte));
+					const source = Math.max(0, Math.floor(c.source));
+					const connected = Boolean(this.peers.get(c.hash));
+
+					let weight = 1;
+					if (wLevel > 0) weight *= 1 / (1 + wLevel * level);
+					if (wSlots > 0) weight *= 1 + wSlots * freeSlots;
+					if (wConnected > 0 && connected) weight *= 1 + wConnected;
+					if (wBid > 0) weight *= 1 + wBid * bidPerByte;
+					if (wSource > 0) weight *= 1 / (1 + wSource * source);
+					return weight;
+				};
+
+				const out: typeof head = [];
+				const remaining = [...head];
+				while (remaining.length > 0) {
+					let sum = 0;
+					const weights: number[] = new Array(remaining.length);
+					for (let i = 0; i < remaining.length; i++) {
+						const w = weightOf(remaining[i]!);
+						const v = Number.isFinite(w) ? Math.max(0, w) : 0;
+						weights[i] = v;
+						sum += v;
+					}
+					if (sum <= 0) {
+						out.push(...remaining);
+						break;
+					}
+
+					let r = this.random() * sum;
+					let pick = 0;
+					for (; pick < weights.length; pick++) {
+						r -= weights[pick]!;
+						if (r <= 0) break;
+					}
+					if (pick >= remaining.length) pick = remaining.length - 1;
+					out.push(remaining[pick]!);
+					remaining.splice(pick, 1);
+				}
+
+				ordered = out.concat(tail);
+			}
+		}
+
+		let attempts = 0;
+		for (const candidate of ordered) {
+			if (options.signal.aborted) break;
+			if (attempts >= options.joinAttemptsPerRound) break;
+			attempts += 1;
+
+			if (!isDirectNeighbor(candidate.hash)) continue;
+
+			const previousParent = ch.parent;
+			const reqId = (this.random() * 0xffffffff) >>> 0;
+			const res = await this.tryJoinOnce(
+				ch,
+				candidate.hash,
+				reqId,
+				options.joinReqTimeoutMs,
+				options.signal,
+				{ allowReplace: true },
+			);
+
+			if (res.ok) {
+				const newParent = ch.parent;
+				if (
+					previousParent &&
+					newParent &&
+					newParent !== previousParent
+				) {
+					void this._sendControl(previousParent, encodeLeave(ch.id.key)).catch(
+						() => {},
+					);
+					return true;
+				}
+				return false;
+			}
+		}
+
+		return false;
 	}
 
 	private async tryJoinOnce(
@@ -5148,8 +5443,9 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		reqId: number,
 		timeoutMs: number,
 		signal: AbortSignal,
+		options?: { allowReplace?: boolean },
 	): Promise<JoinAttemptResult> {
-		if (ch.parent) return { ok: true };
+		if (ch.parent && options?.allowReplace !== true) return { ok: true };
 		if (!this.peers.get(parentHash)) return { ok: false, timedOut: true };
 		const p = new Promise<JoinAttemptResult>((resolve) => {
 			ch.pendingJoin.set(reqId, { resolve });

--- a/packages/transport/pubsub/src/index.ts
+++ b/packages/transport/pubsub/src/index.ts
@@ -48,6 +48,7 @@ import {
 	getMsgId,
 } from "@peerbit/stream-interface";
 import { AbortError, TimeoutError, delay } from "@peerbit/time";
+import { anySignal } from "any-signal";
 import { Uint8ArrayList } from "uint8arraylist";
 import {
 	type DebouncedAccumulatorCounterMap,
@@ -254,10 +255,7 @@ export class TopicControlPlane
 	private readonly shardCount: number;
 	private readonly shardTopicPrefix: string;
 	private readonly hostShards: boolean;
-	private readonly shardRootCache = new Map<
-		string,
-		{ root: string; authoritative: boolean }
-	>();
+	private readonly shardRootCache = new Map<string, { root: string; authoritative: boolean }>();
 	private readonly shardTopicCache = new Map<string, string>();
 	private readonly shardRefCounts = new Map<string, number>();
 	private readonly pinnedShards = new Set<string>();
@@ -274,6 +272,7 @@ export class TopicControlPlane
 	private readonly fanoutPublishRequiresSubscribe: boolean;
 	private readonly fanoutPublishIdleCloseMs: number;
 	private readonly fanoutPublishMaxEphemeralChannels: number;
+	private shutdownController = new AbortController();
 
 	// If no shard-root candidates are configured, we fall back to an "auto" mode:
 	// start with `[self]` and expand candidates as underlay peers connect.
@@ -438,6 +437,9 @@ export class TopicControlPlane
 	}
 
 	public override async start() {
+		if (this.shutdownController.signal.aborted) {
+			this.shutdownController = new AbortController();
+		}
 		await this.fanout.start();
 		this._onFanoutPeerUnreachable =
 			this._onFanoutPeerUnreachable ||
@@ -457,13 +459,21 @@ export class TopicControlPlane
 	}
 
 	public override async stop() {
+		this.stopping = true;
+		this.shutdownController.abort(new AbortError("PubSub stopping"));
+		const fanoutChannelStates = [...this.fanoutChannels.values()];
+		const pendingFanoutJoins = fanoutChannelStates.map((state) => state.join);
+		const pendingBackground = [
+			this.reconcileShardOverlaysInFlight,
+			this.hostOwnedShardRootsInFlight,
+		].filter((promise): promise is Promise<void> => Boolean(promise));
 		if (this._onFanoutPeerUnreachable) {
 			this.fanout.removeEventListener(
 				"fanout:peer-unreachable",
 				this._onFanoutPeerUnreachable as any,
 			);
 		}
-		for (const st of this.fanoutChannels.values()) {
+		for (const st of fanoutChannelStates) {
 			if (st.idleCloseTimeout) clearTimeout(st.idleCloseTimeout);
 			try {
 				st.channel.removeEventListener("data", st.onData as any);
@@ -513,6 +523,7 @@ export class TopicControlPlane
 
 		this.debounceSubscribeAggregator.close();
 		this.debounceUnsubscribeAggregator.close();
+		await Promise.allSettled([...pendingFanoutJoins, ...pendingBackground]);
 		return super.stop();
 	}
 
@@ -758,7 +769,7 @@ export class TopicControlPlane
 	}
 
 	private async reconcileShardOverlays() {
-		if (!this.started) return;
+		if (!this.started || this.stopping) return;
 
 		const byShard = new Map<string, string[]>();
 		for (const topic of this.subscriptions.keys()) {
@@ -1114,6 +1125,10 @@ export class TopicControlPlane
 			signal?: AbortSignal;
 		},
 	): Promise<void> {
+		if (!this.started || this.stopping) throw new NotStartedError();
+		const combinedSignal = options?.signal
+			? anySignal([options.signal, this.shutdownController.signal])
+			: this.shutdownController.signal;
 		const t = shardTopic.toString();
 		const pin = options?.pin === true;
 		const wantEphemeral = options?.ephemeral === true;
@@ -1134,12 +1149,12 @@ export class TopicControlPlane
 					this.scheduleFanoutIdleClose(t);
 				}
 				if (pin) this.pinnedShards.add(t);
-				await withAbort(existing.join, options?.signal);
+				await withAbort(existing.join, combinedSignal);
 				return;
 			}
 
 			// Root mapping changed (candidate set updated): migrate to the new overlay.
-			await withAbort(this.closeFanoutChannel(t, { force: true }), options?.signal);
+			await withAbort(this.closeFanoutChannel(t, { force: true }), combinedSignal);
 		}
 
 		root = root ?? (await this.resolveShardRoot(t));
@@ -1256,9 +1271,10 @@ export class TopicControlPlane
 					} catch {
 						// ignore
 					}
-				const joinOpts = options?.signal
-					? { ...(this.fanoutJoinOptions ?? {}), signal: options.signal }
-					: this.fanoutJoinOptions;
+				const joinOpts = {
+					...(this.fanoutJoinOptions ?? {}),
+					signal: combinedSignal,
+				};
 				await channel.join(this.fanoutNodeChannelOptions, joinOpts);
 			} catch (error) {
 				try {
@@ -1305,7 +1321,11 @@ export class TopicControlPlane
 		if (wantEphemeral) {
 			this.evictEphemeralFanoutChannels(t);
 		}
-		await withAbort(join, options?.signal);
+		try {
+			await withAbort(join, combinedSignal);
+		} finally {
+			(combinedSignal as AbortSignal & { clear?: () => void }).clear?.();
+		}
 	}
 
 	private async closeFanoutChannel(
@@ -1341,7 +1361,7 @@ export class TopicControlPlane
 	}
 
 	public async hostShardRootsNow() {
-		if (!this.started) throw new NotStartedError();
+		if (!this.started || this.stopping) throw new NotStartedError();
 		const joins: Promise<void>[] = [];
 		for (let i = 0; i < this.shardCount; i++) {
 			const shardTopic = `${this.shardTopicPrefix}${i}`;
@@ -1361,7 +1381,7 @@ export class TopicControlPlane
 	}
 
 	private async _subscribe(topics: { key: string; counter: number }[]) {
-		if (!this.started) throw new NotStartedError();
+		if (!this.started || this.stopping) throw new NotStartedError();
 		if (topics.length === 0) return;
 
 		const byShard = new Map<string, string[]>();
@@ -1458,7 +1478,7 @@ export class TopicControlPlane
 	}
 
 	private async _announceUnsubscribe(topics: { key: string; counter: number }[]) {
-		if (!this.started) throw new NotStartedError();
+		if (!this.started || this.stopping) throw new NotStartedError();
 
 		const byShard = new Map<string, string[]>();
 		for (const { key: topic } of topics) {

--- a/packages/transport/pubsub/src/index.ts
+++ b/packages/transport/pubsub/src/index.ts
@@ -48,7 +48,6 @@ import {
 	getMsgId,
 } from "@peerbit/stream-interface";
 import { AbortError, TimeoutError, delay } from "@peerbit/time";
-import { anySignal } from "any-signal";
 import { Uint8ArrayList } from "uint8arraylist";
 import {
 	type DebouncedAccumulatorCounterMap,
@@ -272,7 +271,6 @@ export class TopicControlPlane
 	private readonly fanoutPublishRequiresSubscribe: boolean;
 	private readonly fanoutPublishIdleCloseMs: number;
 	private readonly fanoutPublishMaxEphemeralChannels: number;
-	private shutdownController = new AbortController();
 
 	// If no shard-root candidates are configured, we fall back to an "auto" mode:
 	// start with `[self]` and expand candidates as underlay peers connect.
@@ -437,9 +435,6 @@ export class TopicControlPlane
 	}
 
 	public override async start() {
-		if (this.shutdownController.signal.aborted) {
-			this.shutdownController = new AbortController();
-		}
 		await this.fanout.start();
 		this._onFanoutPeerUnreachable =
 			this._onFanoutPeerUnreachable ||
@@ -459,21 +454,13 @@ export class TopicControlPlane
 	}
 
 	public override async stop() {
-		this.stopping = true;
-		this.shutdownController.abort(new AbortError("PubSub stopping"));
-		const fanoutChannelStates = [...this.fanoutChannels.values()];
-		const pendingFanoutJoins = fanoutChannelStates.map((state) => state.join);
-		const pendingBackground = [
-			this.reconcileShardOverlaysInFlight,
-			this.hostOwnedShardRootsInFlight,
-		].filter((promise): promise is Promise<void> => Boolean(promise));
 		if (this._onFanoutPeerUnreachable) {
 			this.fanout.removeEventListener(
 				"fanout:peer-unreachable",
 				this._onFanoutPeerUnreachable as any,
 			);
 		}
-		for (const st of fanoutChannelStates) {
+		for (const st of this.fanoutChannels.values()) {
 			if (st.idleCloseTimeout) clearTimeout(st.idleCloseTimeout);
 			try {
 				st.channel.removeEventListener("data", st.onData as any);
@@ -523,7 +510,6 @@ export class TopicControlPlane
 
 		this.debounceSubscribeAggregator.close();
 		this.debounceUnsubscribeAggregator.close();
-		await Promise.allSettled([...pendingFanoutJoins, ...pendingBackground]);
 		return super.stop();
 	}
 
@@ -769,7 +755,7 @@ export class TopicControlPlane
 	}
 
 	private async reconcileShardOverlays() {
-		if (!this.started || this.stopping) return;
+		if (!this.started) return;
 
 		const byShard = new Map<string, string[]>();
 		for (const topic of this.subscriptions.keys()) {
@@ -1125,10 +1111,7 @@ export class TopicControlPlane
 			signal?: AbortSignal;
 		},
 	): Promise<void> {
-		if (!this.started || this.stopping) throw new NotStartedError();
-		const combinedSignal = options?.signal
-			? anySignal([options.signal, this.shutdownController.signal])
-			: this.shutdownController.signal;
+		if (!this.started) throw new NotStartedError();
 		const t = shardTopic.toString();
 		const pin = options?.pin === true;
 		const wantEphemeral = options?.ephemeral === true;
@@ -1149,12 +1132,12 @@ export class TopicControlPlane
 					this.scheduleFanoutIdleClose(t);
 				}
 				if (pin) this.pinnedShards.add(t);
-				await withAbort(existing.join, combinedSignal);
+				await withAbort(existing.join, options?.signal);
 				return;
 			}
 
 			// Root mapping changed (candidate set updated): migrate to the new overlay.
-			await withAbort(this.closeFanoutChannel(t, { force: true }), combinedSignal);
+			await withAbort(this.closeFanoutChannel(t, { force: true }), options?.signal);
 		}
 
 		root = root ?? (await this.resolveShardRoot(t));
@@ -1271,10 +1254,9 @@ export class TopicControlPlane
 					} catch {
 						// ignore
 					}
-				const joinOpts = {
-					...(this.fanoutJoinOptions ?? {}),
-					signal: combinedSignal,
-				};
+				const joinOpts = options?.signal
+					? { ...(this.fanoutJoinOptions ?? {}), signal: options.signal }
+					: this.fanoutJoinOptions;
 				await channel.join(this.fanoutNodeChannelOptions, joinOpts);
 			} catch (error) {
 				try {
@@ -1321,11 +1303,7 @@ export class TopicControlPlane
 		if (wantEphemeral) {
 			this.evictEphemeralFanoutChannels(t);
 		}
-		try {
-			await withAbort(join, combinedSignal);
-		} finally {
-			(combinedSignal as AbortSignal & { clear?: () => void }).clear?.();
-		}
+		await withAbort(join, options?.signal);
 	}
 
 	private async closeFanoutChannel(
@@ -1361,7 +1339,7 @@ export class TopicControlPlane
 	}
 
 	public async hostShardRootsNow() {
-		if (!this.started || this.stopping) throw new NotStartedError();
+		if (!this.started) throw new NotStartedError();
 		const joins: Promise<void>[] = [];
 		for (let i = 0; i < this.shardCount; i++) {
 			const shardTopic = `${this.shardTopicPrefix}${i}`;
@@ -1381,7 +1359,7 @@ export class TopicControlPlane
 	}
 
 	private async _subscribe(topics: { key: string; counter: number }[]) {
-		if (!this.started || this.stopping) throw new NotStartedError();
+		if (!this.started) throw new NotStartedError();
 		if (topics.length === 0) return;
 
 		const byShard = new Map<string, string[]>();
@@ -1478,7 +1456,7 @@ export class TopicControlPlane
 	}
 
 	private async _announceUnsubscribe(topics: { key: string; counter: number }[]) {
-		if (!this.started || this.stopping) throw new NotStartedError();
+		if (!this.started) throw new NotStartedError();
 
 		const byShard = new Map<string, string[]>();
 		for (const { key: topic } of topics) {

--- a/packages/transport/pubsub/test/fanout-topics.spec.ts
+++ b/packages/transport/pubsub/test/fanout-topics.spec.ts
@@ -12,6 +12,36 @@ import { expect } from "chai";
 import { FanoutTree, TopicControlPlane, TopicRootControlPlane } from "../src/index.js";
 
 describe("pubsub (fanout topics)", function () {
+	const createSessionServices = (
+		topicRootControlPlane: TopicRootControlPlane,
+		getOrCreateFanout: (c: any) => FanoutTree,
+		options?: {
+			pubsub?: Partial<ConstructorParameters<typeof TopicControlPlane>[1]>;
+		},
+	) => ({
+		services: {
+			fanout: (c: any) => getOrCreateFanout(c),
+			pubsub: (c: any) =>
+				new TopicControlPlane(c, {
+					canRelayMessage: true,
+					connectionManager: false,
+					topicRootControlPlane,
+					fanout: getOrCreateFanout(c),
+					shardCount: 16,
+					// Make join tests fast/deterministic.
+					fanoutJoin: {
+						timeoutMs: 10_000,
+						retryMs: 50,
+						bootstrapEnsureIntervalMs: 200,
+						trackerQueryIntervalMs: 200,
+						joinReqTimeoutMs: 1_000,
+						trackerQueryTimeoutMs: 1_000,
+					},
+					...(options?.pubsub || {}),
+				}),
+		},
+	});
+
 	const createSession = async (
 		peerCount: number,
 		options?: {
@@ -35,29 +65,10 @@ describe("pubsub (fanout topics)", function () {
 		};
 
 		const session: TestSession<{ pubsub: TopicControlPlane; fanout: FanoutTree }> =
-			await TestSession.connected(peerCount, {
-				services: {
-					fanout: (c) => getOrCreateFanout(c),
-						pubsub: (c) =>
-							new TopicControlPlane(c, {
-								canRelayMessage: true,
-								connectionManager: false,
-								topicRootControlPlane,
-								fanout: getOrCreateFanout(c),
-								shardCount: DEFAULT_SHARD_COUNT,
-								// Make join tests fast/deterministic.
-								fanoutJoin: {
-									timeoutMs: 10_000,
-									retryMs: 50,
-								bootstrapEnsureIntervalMs: 200,
-								trackerQueryIntervalMs: 200,
-								joinReqTimeoutMs: 1_000,
-								trackerQueryTimeoutMs: 1_000,
-							},
-							...(options?.pubsub || {}),
-						}),
-				},
-			});
+			await TestSession.connected(
+				peerCount,
+				createSessionServices(topicRootControlPlane, getOrCreateFanout, options),
+			);
 
 		const configureBootstraps = (trackerIndices: number[]) => {
 			const addrs: any[] = [];
@@ -68,8 +79,8 @@ describe("pubsub (fanout topics)", function () {
 				const self = new Set(peer.getMultiaddrs().map((a) => a.toString()));
 				const filtered = addrs.filter((a) => !self.has(a.toString()));
 				peer.services.fanout.setBootstraps(filtered);
-				}
-			};
+			}
+		};
 
 		const configureShards = async (routerIndices: number[]) => {
 			const candidates = routerIndices.map(
@@ -118,28 +129,7 @@ describe("pubsub (fanout topics)", function () {
 		return TestSession.disconnected<{
 			pubsub: TopicControlPlane;
 			fanout: FanoutTree;
-		}>(peerCount, {
-			services: {
-				fanout: (c) => getOrCreateFanout(c),
-				pubsub: (c) =>
-					new TopicControlPlane(c, {
-						canRelayMessage: true,
-						connectionManager: false,
-						topicRootControlPlane,
-						fanout: getOrCreateFanout(c),
-						shardCount: DEFAULT_SHARD_COUNT,
-						fanoutJoin: {
-							timeoutMs: 10_000,
-							retryMs: 50,
-							bootstrapEnsureIntervalMs: 200,
-							trackerQueryIntervalMs: 200,
-							joinReqTimeoutMs: 1_000,
-							trackerQueryTimeoutMs: 1_000,
-						},
-						...(options?.pubsub || {}),
-					}),
-			},
-		});
+		}>(peerCount, createSessionServices(topicRootControlPlane, getOrCreateFanout, options));
 	};
 
 	const topicHash32 = (topic: string) => {
@@ -566,6 +556,102 @@ describe("pubsub (fanout topics)", function () {
 			await delay(250);
 			expect(receivedByRoot).to.have.length(2);
 		} finally {
+			await session.stop();
+		}
+	});
+
+	it("can proactively reparent to the root when a late direct edge becomes available", async () => {
+		const session = await createDisconnectedSession(3, {
+			pubsub: {
+				fanoutJoin: {
+					parentUpgradeIntervalMs: 200,
+				},
+			},
+		});
+		const rootPeer = session.peers[0]!;
+		const relayPeer = session.peers[1]!;
+		const publisherPeer = session.peers[2]!;
+		const publisherFanout = publisherPeer.services.pubsub.fanout as any;
+		const originalPublisherDial = publisherPeer.dial.bind(publisherPeer);
+		const originalSendControl = publisherFanout._sendControl.bind(publisherFanout);
+
+		try {
+			const topic = "fanout-direct-reparent-to-root";
+			const root = rootPeer.services.pubsub;
+			const relay = relayPeer.services.pubsub;
+			const publisher = publisherPeer.services.pubsub;
+			const rootHash = root.publicKeyHash;
+			const relayHash = relay.publicKeyHash;
+			const shardTopic = (root as any).getShardTopicForUserTopic(topic);
+			const rootAddrs = new Set(rootPeer.getMultiaddrs().map((a) => a.toString()));
+			let allowDirectRootTraffic = false;
+			publisherPeer.dial = (async (addrs: any) => {
+				const list = Array.isArray(addrs) ? addrs : [addrs];
+				if (
+					!allowDirectRootTraffic &&
+					list.some((addr) => rootAddrs.has(addr.toString()))
+				) {
+					throw new Error("blocked direct root dial");
+				}
+				return originalPublisherDial(addrs as any);
+			}) as typeof publisherPeer.dial;
+			publisherFanout._sendControl = (async (to: string, bytes: Uint8Array) => {
+				if (!allowDirectRootTraffic && to === rootHash) {
+					return;
+				}
+				return originalSendControl(to, bytes);
+			}) as typeof publisherFanout._sendControl;
+
+			await session.connect([
+				[rootPeer, relayPeer],
+				[relayPeer, publisherPeer],
+			]);
+
+			const relayBootstraps = relayPeer.getMultiaddrs();
+			for (const peer of session.peers) {
+				const self = new Set(peer!.getMultiaddrs().map((a) => a.toString()));
+				peer!.services.fanout.setBootstraps(
+					relayBootstraps.filter((a) => !self.has(a.toString())),
+				);
+			}
+
+			for (const peer of session.peers) {
+				peer!.services.pubsub.setTopicRootCandidates([rootHash]);
+			}
+			await root.hostShardRootsNow();
+
+			await root.subscribe(topic);
+			await relay.subscribe(topic);
+			await waitForResolved(() => {
+				const relayStats = relay.fanout.getChannelStats(shardTopic, rootHash);
+				expect(relayStats?.parent).to.equal(rootHash);
+			});
+			await publisher.subscribe(topic);
+
+			await waitForResolved(() => {
+				const stats = publisher.fanout.getChannelStats(shardTopic, rootHash);
+				expect(stats?.parent).to.equal(relayHash);
+			});
+
+			allowDirectRootTraffic = true;
+			await session.connect([[rootPeer, publisherPeer]]);
+			await waitForResolved(() =>
+				expect(root.peers.has(publisher.publicKeyHash)).to.equal(true),
+			);
+			await waitForResolved(() =>
+				expect(publisher.peers.has(rootHash)).to.equal(true),
+			);
+
+			await waitForResolved(() => {
+				const statsAfterDirect = publisher.fanout.getChannelStats(
+					shardTopic,
+					rootHash,
+				);
+				expect(statsAfterDirect?.parent).to.equal(rootHash);
+			});
+		} finally {
+			publisherFanout._sendControl = originalSendControl;
+			publisherPeer.dial = originalPublisherDial;
 			await session.stop();
 		}
 	});

--- a/packages/transport/pubsub/test/fanout-tree-sim.runner.ts
+++ b/packages/transport/pubsub/test/fanout-tree-sim.runner.ts
@@ -1,0 +1,22 @@
+import {
+	resolveFanoutTreeSimParams,
+	runFanoutTreeSim,
+} from "../benchmark/fanout-tree-sim-lib.js";
+
+const main = async () => {
+	const raw = process.argv[2];
+	if (!raw) {
+		throw new Error("Missing FanoutTreeSim params JSON");
+	}
+
+	const params = resolveFanoutTreeSimParams(JSON.parse(raw));
+	const result = await runFanoutTreeSim(params);
+	process.stdout.write(JSON.stringify(result));
+};
+
+try {
+	await main();
+} catch (error: any) {
+	console.error(error?.stack ?? error?.message ?? String(error));
+	process.exit(1);
+}

--- a/packages/transport/pubsub/test/fanout-tree-sim.spec.ts
+++ b/packages/transport/pubsub/test/fanout-tree-sim.spec.ts
@@ -1,8 +1,59 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { expect } from "chai";
 import {
 	formatFanoutTreeSimResult,
-	runFanoutTreeSim,
+	type FanoutTreeSimParams,
+	type FanoutTreeSimResult,
 } from "../benchmark/fanout-tree-sim-lib.js";
+
+const execFileAsync = promisify(execFile);
+
+const resolveSimRunnerPath = () => {
+	const currentDir = dirname(fileURLToPath(import.meta.url));
+	const candidates = [
+		resolve(currentDir, "fanout-tree-sim.runner.js"),
+		resolve(currentDir, "../dist/test/fanout-tree-sim.runner.js"),
+	];
+	for (const candidate of candidates) {
+		if (existsSync(candidate)) return candidate;
+	}
+	throw new Error(
+		`Unable to locate fanout-tree sim runner. Tried: ${candidates.join(", ")}`,
+	);
+};
+
+const runFanoutTreeSimIsolated = async (
+	params: Partial<FanoutTreeSimParams>,
+): Promise<FanoutTreeSimResult> => {
+	const runner = resolveSimRunnerPath();
+	const { stdout, stderr } = await execFileAsync(
+		process.execPath,
+		[runner, JSON.stringify(params)],
+		{
+			maxBuffer: 16 * 1024 * 1024,
+			env: process.env,
+		},
+	);
+
+	const trimmed = stdout.trim();
+	if (!trimmed) {
+		throw new Error(
+			`FanoutTreeSim runner produced no stdout${stderr ? `\n${stderr.trim()}` : ""}`,
+		);
+	}
+
+	try {
+		return JSON.parse(trimmed) as FanoutTreeSimResult;
+	} catch (error: any) {
+		throw new Error(
+			`Failed to parse FanoutTreeSim runner output as JSON: ${error?.message ?? String(error)}\n${trimmed}${stderr ? `\n${stderr.trim()}` : ""}`,
+		);
+	}
+};
 
 describe("fanout-tree-sim (ci)", () => {
 	const LOSSY_CHURN_TRACKER_BYTES_MAX = 150_000;
@@ -10,7 +61,7 @@ describe("fanout-tree-sim (ci)", () => {
 	it("joins and delivers on a small sim", async function () {
 		this.timeout(60_000);
 
-		const result = await runFanoutTreeSim({
+		const result = await runFanoutTreeSimIsolated({
 			nodes: 25,
 			bootstraps: 1,
 			subscribers: 20,
@@ -69,7 +120,7 @@ describe("fanout-tree-sim (ci)", () => {
 			this.timeout(90_000);
 			this.retries(1);
 
-			const result = await runFanoutTreeSim({
+			const result = await runFanoutTreeSimIsolated({
 				nodes: 40,
 				bootstraps: 1,
 				subscribers: 30,

--- a/packages/transport/pubsub/test/fanout-tree.spec.ts
+++ b/packages/transport/pubsub/test/fanout-tree.spec.ts
@@ -15,7 +15,299 @@ const createFanoutTestSession = (n: number) =>
 		},
 	});
 
+type ImproveCandidate = {
+	hash: string;
+	addrs: [];
+	level: number;
+	freeSlots: number;
+	bidPerByte: number;
+};
+
+type ImproveChannel = {
+	parent: string;
+	closed: boolean;
+	isRoot: boolean;
+	level: number;
+	id: { root: string; key: Uint8Array };
+	cachedTrackerCandidates: ImproveCandidate[];
+	children: Map<string, { bidPerByte: number }>;
+};
+
+type ImproveOptions = {
+	signal: AbortSignal;
+	candidateShuffleTopK: number;
+	candidateScoringMode: "ranked-shuffle" | "ranked-strict" | "weighted";
+	candidateScoringWeights: {
+		level: number;
+		freeSlots: number;
+		connected: number;
+		bidPerByte: number;
+		source: number;
+	};
+	joinAttemptsPerRound: number;
+	joinReqTimeoutMs: number;
+};
+
+type ImproveContext = {
+	publicKeyHash: string;
+	peers: Map<string, { peerId: string; isReadable: boolean; isWritable: boolean }>;
+	components: {
+		connectionManager: {
+			getConnections: (peerId: string) => unknown[];
+		};
+	};
+	random: () => number;
+	tryJoinOnce: (
+		ch: ImproveChannel,
+		parentHash: string,
+		reqId: number,
+		joinReqTimeoutMs: number,
+		signal: AbortSignal,
+		options?: { allowReplace?: boolean },
+	) => Promise<{ ok: boolean }>;
+	_sendControl: (to: string, payload: Uint8Array) => Promise<void>;
+};
+
+const maybeImproveParent = Reflect.get(FanoutTree.prototype, "maybeImproveParent") as (
+	this: ImproveContext,
+	ch: ImproveChannel,
+	options: ImproveOptions,
+) => Promise<boolean>;
+
+const createImproveChannel = (
+	overrides: Partial<ImproveChannel> = {},
+): ImproveChannel => ({
+	parent: "relay",
+	closed: false,
+	isRoot: false,
+	level: 4,
+	id: { root: "root", key: new Uint8Array([1, 2, 3]) },
+	cachedTrackerCandidates: [],
+	children: new Map(),
+	...overrides,
+});
+
+const runMaybeImproveParent = async (args: {
+	peerHashes: string[];
+	cachedTrackerCandidates?: ImproveCandidate[];
+	channelOverrides?: Partial<ImproveChannel>;
+	getConnections?: (peerId: string) => unknown[];
+	random?: () => number;
+	options?: Partial<ImproveOptions>;
+	tryJoinOnce?: ImproveContext["tryJoinOnce"];
+}) => {
+	const attempts: string[] = [];
+	const ch = createImproveChannel({
+		cachedTrackerCandidates: args.cachedTrackerCandidates ?? [],
+		...args.channelOverrides,
+	});
+	const ctx: ImproveContext = {
+		publicKeyHash: "self",
+		peers: new Map(
+			args.peerHashes.map((hash) => [
+				hash,
+				{
+					peerId: hash,
+					isReadable: true,
+					isWritable: false,
+				},
+			]),
+		),
+		components: {
+			connectionManager: {
+				getConnections:
+					args.getConnections ??
+					((peerId) => (args.peerHashes.includes(peerId) ? [{}] : [])),
+			},
+		},
+		random: args.random ?? (() => 0),
+		tryJoinOnce: async (
+			channel,
+			parentHash,
+			reqId,
+			joinReqTimeoutMs,
+			signal,
+			options,
+		) => {
+			attempts.push(parentHash);
+			return (
+				args.tryJoinOnce?.(
+					channel,
+					parentHash,
+					reqId,
+					joinReqTimeoutMs,
+					signal,
+					options,
+				) ?? { ok: false }
+			);
+		},
+		_sendControl: async () => {},
+	};
+
+	const result = await maybeImproveParent.call(ctx, ch, {
+		signal: new AbortController().signal,
+		candidateShuffleTopK: 0,
+		candidateScoringMode: "ranked-strict",
+		candidateScoringWeights: {
+			level: 1,
+			freeSlots: 1,
+			connected: 1,
+			bidPerByte: 1,
+			source: 1,
+		},
+		joinAttemptsPerRound: 8,
+		joinReqTimeoutMs: 1_000,
+		...args.options,
+	});
+
+	return { attempts, result, ch };
+};
+
 describe("fanout-tree", () => {
+	it("falls back to peer readability when connection lookup throws", async () => {
+		const { attempts, result, ch } = await runMaybeImproveParent({
+			peerHashes: ["root", "relay"],
+			getConnections: () => {
+				throw new Error("boom");
+			},
+			tryJoinOnce: async (channel, parentHash) => {
+				channel.parent = parentHash;
+				return { ok: true };
+			},
+		});
+
+		expect(result).to.equal(true);
+		expect(attempts).to.deep.equal(["root"]);
+		expect(ch.parent).to.equal("root");
+	});
+
+	it("orders ranked candidates by free slots, bid, source and hash", async () => {
+		const byFreeSlots = await runMaybeImproveParent({
+			peerHashes: ["relay", "slot-low", "slot-high"],
+			cachedTrackerCandidates: [
+				{ hash: "slot-low", addrs: [], level: 1, freeSlots: 1, bidPerByte: 0 },
+				{ hash: "slot-high", addrs: [], level: 1, freeSlots: 2, bidPerByte: 0 },
+			],
+			tryJoinOnce: async () => ({ ok: false }),
+		});
+		expect(byFreeSlots.attempts[0]).to.equal("slot-high");
+
+		const byBid = await runMaybeImproveParent({
+			peerHashes: ["relay", "bid-low", "bid-high"],
+			cachedTrackerCandidates: [
+				{ hash: "bid-low", addrs: [], level: 1, freeSlots: 2, bidPerByte: 1 },
+				{ hash: "bid-high", addrs: [], level: 1, freeSlots: 2, bidPerByte: 2 },
+			],
+			tryJoinOnce: async () => ({ ok: false }),
+		});
+		expect(byBid.attempts[0]).to.equal("bid-high");
+
+		const bySource = await runMaybeImproveParent({
+			peerHashes: ["root", "relay", "tracker-root"],
+			cachedTrackerCandidates: [
+				{
+					hash: "tracker-root",
+					addrs: [],
+					level: 0,
+					freeSlots: Number.MAX_SAFE_INTEGER,
+					bidPerByte: 0,
+				},
+			],
+			tryJoinOnce: async () => ({ ok: false }),
+		});
+		expect(bySource.attempts[0]).to.equal("root");
+
+		const byHash = await runMaybeImproveParent({
+			peerHashes: ["relay", "alpha", "beta"],
+			cachedTrackerCandidates: [
+				{ hash: "beta", addrs: [], level: 1, freeSlots: 1, bidPerByte: 0 },
+				{ hash: "alpha", addrs: [], level: 1, freeSlots: 1, bidPerByte: 0 },
+			],
+			tryJoinOnce: async () => ({ ok: false }),
+		});
+		expect(byHash.attempts[0]).to.equal("alpha");
+	});
+
+	it("shuffles top ranked candidates when parent upgrades use ranked-shuffle", async () => {
+		const { attempts, result } = await runMaybeImproveParent({
+			peerHashes: ["relay", "alpha", "beta"],
+			cachedTrackerCandidates: [
+				{ hash: "alpha", addrs: [], level: 1, freeSlots: 1, bidPerByte: 0 },
+				{ hash: "beta", addrs: [], level: 1, freeSlots: 1, bidPerByte: 0 },
+			],
+			random: () => 0,
+			options: {
+				candidateScoringMode: "ranked-shuffle",
+				candidateShuffleTopK: 2,
+			},
+			tryJoinOnce: async () => ({ ok: false }),
+		});
+
+		expect(result).to.equal(false);
+		expect(attempts.slice(0, 2)).to.deep.equal(["beta", "alpha"]);
+	});
+
+	it("supports weighted parent-upgrade candidate selection", async () => {
+		const { attempts, result } = await runMaybeImproveParent({
+			peerHashes: ["relay", "weighted-a", "weighted-b"],
+			cachedTrackerCandidates: [
+				{
+					hash: "weighted-a",
+					addrs: [],
+					level: 1,
+					freeSlots: 4,
+					bidPerByte: 1,
+				},
+				{
+					hash: "weighted-b",
+					addrs: [],
+					level: 2,
+					freeSlots: 1,
+					bidPerByte: 0,
+				},
+			],
+			random: () => 0.999,
+			options: {
+				candidateScoringMode: "weighted",
+				candidateShuffleTopK: 2,
+			},
+			tryJoinOnce: async () => ({ ok: false }),
+		});
+
+		expect(result).to.equal(false);
+		expect(attempts).to.have.length(2);
+		expect(new Set(attempts)).to.deep.equal(new Set(["weighted-a", "weighted-b"]));
+	});
+
+	it("falls back to the existing weighted order when all candidate weights collapse", async () => {
+		const { attempts, result } = await runMaybeImproveParent({
+			peerHashes: ["relay", "nan-a", "nan-b"],
+			cachedTrackerCandidates: [
+				{ hash: "nan-a", addrs: [], level: 1, freeSlots: Number.NaN, bidPerByte: 0 },
+				{ hash: "nan-b", addrs: [], level: 1, freeSlots: Number.NaN, bidPerByte: 0 },
+			],
+			options: {
+				candidateScoringMode: "weighted",
+				candidateShuffleTopK: 2,
+			},
+			tryJoinOnce: async () => ({ ok: false }),
+		});
+
+		expect(result).to.equal(false);
+		expect(attempts.slice(0, 2)).to.deep.equal(["nan-a", "nan-b"]);
+	});
+
+	it("returns false when a join succeeds without actually replacing the parent", async () => {
+		const { attempts, result, ch } = await runMaybeImproveParent({
+			peerHashes: ["root", "relay"],
+			tryJoinOnce: async () => ({ ok: true }),
+		});
+
+		expect(result).to.equal(false);
+		expect(attempts).to.deep.equal(["root"]);
+		expect(ch.parent).to.equal("relay");
+	});
+
 		it("bounds per-channel route token cache (LRU + TTL)", async () => {
 			const session: TestSession<{ fanout: FanoutTree }> =
 				await createFanoutTestSession(1);

--- a/packages/transport/pubsub/test/pubsub-topic-sim.runner.ts
+++ b/packages/transport/pubsub/test/pubsub-topic-sim.runner.ts
@@ -1,0 +1,24 @@
+import { ready as cryptoReady } from "@peerbit/crypto";
+import {
+	resolvePubsubTopicSimParams,
+	runPubsubTopicSim,
+} from "../benchmark/pubsub-topic-sim-lib.js";
+
+const main = async () => {
+	const raw = process.argv[2];
+	if (!raw) {
+		throw new Error("Missing PubsubTopicSim params JSON");
+	}
+
+	await cryptoReady;
+	const params = resolvePubsubTopicSimParams(JSON.parse(raw));
+	const result = await runPubsubTopicSim(params);
+	process.stdout.write(JSON.stringify(result));
+};
+
+try {
+	await main();
+} catch (error: any) {
+	console.error(error?.stack ?? error?.message ?? String(error));
+	process.exit(1);
+}

--- a/packages/transport/pubsub/test/pubsub-topic-sim.spec.ts
+++ b/packages/transport/pubsub/test/pubsub-topic-sim.spec.ts
@@ -1,14 +1,65 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { expect } from "chai";
 import {
 	formatPubsubTopicSimResult,
-	runPubsubTopicSim,
+	type PubsubTopicSimParams,
+	type PubsubTopicSimResult,
 } from "../benchmark/pubsub-topic-sim-lib.js";
+
+const execFileAsync = promisify(execFile);
+
+const resolveSimRunnerPath = () => {
+	const currentDir = dirname(fileURLToPath(import.meta.url));
+	const candidates = [
+		resolve(currentDir, "pubsub-topic-sim.runner.js"),
+		resolve(currentDir, "../dist/test/pubsub-topic-sim.runner.js"),
+	];
+	for (const candidate of candidates) {
+		if (existsSync(candidate)) return candidate;
+	}
+	throw new Error(
+		`Unable to locate pubsub-topic sim runner. Tried: ${candidates.join(", ")}`,
+	);
+};
+
+const runPubsubTopicSimIsolated = async (
+	params: Partial<PubsubTopicSimParams>,
+): Promise<PubsubTopicSimResult> => {
+	const runner = resolveSimRunnerPath();
+	const { stdout, stderr } = await execFileAsync(
+		process.execPath,
+		[runner, JSON.stringify(params)],
+		{
+			maxBuffer: 16 * 1024 * 1024,
+			env: process.env,
+		},
+	);
+
+	const trimmed = stdout.trim();
+	if (!trimmed) {
+		throw new Error(
+			`PubsubTopicSim runner produced no stdout${stderr ? `\n${stderr.trim()}` : ""}`,
+		);
+	}
+
+	try {
+		return JSON.parse(trimmed) as PubsubTopicSimResult;
+	} catch (error: any) {
+		throw new Error(
+			`Failed to parse PubsubTopicSim runner output as JSON: ${error?.message ?? String(error)}\n${trimmed}${stderr ? `\n${stderr.trim()}` : ""}`,
+		);
+	}
+};
 
 describe("pubsub-topic-sim (ci)", () => {
 	it("delivers on a small sim", async function () {
 		this.timeout(60_000);
 
-		const result = await runPubsubTopicSim({
+		const result = await runPubsubTopicSimIsolated({
 			nodes: 20,
 			degree: 4,
 			writerIndex: 0,
@@ -43,7 +94,7 @@ describe("pubsub-topic-sim (ci)", () => {
 	it("remains mostly connected under mild churn", async function () {
 		this.timeout(90_000);
 
-		const result = await runPubsubTopicSim({
+		const result = await runPubsubTopicSimIsolated({
 			nodes: 25,
 			degree: 6,
 			writerIndex: 0,


### PR DESCRIPTION
## Summary
- add an opt-in parent-upgrade path for fanout joins so a node can reparent to a materially better direct parent after it already joined
- keep the behavior conservative by requiring explicit configuration rather than changing the default routing policy
- isolate the fanout-tree sim in a child-process runner and add regressions around late direct-edge upgrades

## Why
Today fanout delivery stays correct when a late direct edge appears, but the overlay does not improve its parent choice after it has already attached. This PR adds a guarded path for eventual better-parent convergence without changing the default stability-first behavior.

## Tests
- `pnpm run build`
- `pnpm --filter @peerbit/pubsub test -- -t node`
