### PR TITLE
chore(pubsub): add parent-upgrade evaluation benchmark

### DIFF
--- a/packages/transport/pubsub/benchmark/fanout-tree-parent-upgrade-eval.ts
+++ b/packages/transport/pubsub/benchmark/fanout-tree-parent-upgrade-eval.ts
@@ -4,7 +4,7 @@ import {
 	type FanoutTreeSimResult,
 } from "./fanout-tree-sim-lib.js";
 
-type EvalScenarioName = "mild" | "tight";
+type EvalScenarioName = "mild" | "tight" | "live-like";
 type EvalMode = "off" | "on";
 
 type MetricKey =
@@ -34,7 +34,7 @@ const HELP_TEXT = [
 	"Runs an A/B fanout-tree simulation sweep with parent upgrades disabled and enabled.",
 	"",
 	"Args:",
-	"  --scenario NAME     scenario to run (mild|tight|all, default: all)",
+	"  --scenario NAME     scenario to run (mild|tight|live-like|all, default: all)",
 	"  --seeds LIST        comma-separated seeds (default: 1,2,3)",
 	"  --parentUpgradeIntervalMs MS  upgrade interval for the enabled variant (default: 200)",
 	"  --parentUpgradeLeafOnly 0|1   restrict upgrades to leaves (default: 1)",
@@ -105,6 +105,36 @@ const SCENARIOS: Record<EvalScenarioName, Partial<FanoutTreeSimParams>> = {
 		churnDownMs: 120,
 		churnFraction: 0.04,
 	},
+	"live-like": {
+		nodes: 120,
+		bootstraps: 3,
+		bootstrapMaxPeers: 1,
+		subscribers: 90,
+		relayFraction: 0.25,
+		messages: 180,
+		msgRate: 30,
+		msgSize: 1024,
+		settleMs: 2_000,
+		deadlineMs: 2_000,
+		timeoutMs: 120_000,
+		allowKick: true,
+		bidPerByteRelay: 1,
+		bidPerByteLeaf: 0,
+		repair: true,
+		repairMaxBackfillMessages: 60,
+		neighborRepair: true,
+		neighborRepairPeers: 3,
+		joinPhases: true,
+		joinPhaseSettleMs: 2_000,
+		rootUploadLimitBps: 20_000_000,
+		relayUploadLimitBps: 10_000_000,
+		rootMaxChildren: 64,
+		relayMaxChildren: 32,
+		dropDataFrameRate: 0.01,
+		churnEveryMs: 2_000,
+		churnDownMs: 1_000,
+		churnFraction: 0.01,
+	},
 };
 
 const avg = (rows: FanoutTreeSimResult[], metric: MetricKey) =>
@@ -126,7 +156,9 @@ const parseArgs = () => {
 
 	const scenarioArg = readArg("--scenario") ?? "all";
 	if (scenarioArg !== "all" && !(scenarioArg in SCENARIOS)) {
-		throw new Error(`Unknown scenario '${scenarioArg}'. Expected mild, tight, or all.`);
+		throw new Error(
+			`Unknown scenario '${scenarioArg}'. Expected mild, tight, live-like, or all.`,
+		);
 	}
 
 	const seedsArg = readArg("--seeds") ?? "1,2,3";

--- a/packages/transport/pubsub/benchmark/fanout-tree-parent-upgrade-eval.ts
+++ b/packages/transport/pubsub/benchmark/fanout-tree-parent-upgrade-eval.ts
@@ -1,0 +1,215 @@
+import {
+	runFanoutTreeSim,
+	type FanoutTreeSimParams,
+	type FanoutTreeSimResult,
+} from "./fanout-tree-sim-lib.js";
+
+type EvalScenarioName = "mild" | "tight";
+type EvalMode = "off" | "on";
+
+type MetricKey =
+	| "joinedPct"
+	| "deliveredPct"
+	| "deliveredWithinDeadlinePct"
+	| "latencyP95"
+	| "treeLevelP95"
+	| "formationScore"
+	| "maintReparentsPerMin"
+	| "maintRecoveryP95Ms"
+	| "trackerBpp"
+	| "repairBpp"
+	| "protocolControlBytesSentTracker"
+	| "treeRootChildren";
+
+type ScenarioSummary = {
+	seeds: number[];
+	off: Record<MetricKey, number>;
+	on: Record<MetricKey, number>;
+	delta: Record<MetricKey, number>;
+};
+
+const HELP_TEXT = [
+	"fanout-tree-parent-upgrade-eval.ts",
+	"",
+	"Runs an A/B fanout-tree simulation sweep with parent upgrades disabled and enabled.",
+	"",
+	"Args:",
+	"  --scenario NAME     scenario to run (mild|tight|all, default: all)",
+	"  --seeds LIST        comma-separated seeds (default: 1,2,3)",
+	"  --parentUpgradeIntervalMs MS  upgrade interval for the enabled variant (default: 200)",
+	"  --parentUpgradeLeafOnly 0|1   restrict upgrades to leaves (default: 1)",
+	"",
+	"Example:",
+	"  pnpm -C packages/transport/pubsub run bench -- fanout-tree-parent-upgrade-eval --scenario all --seeds 1,2,3",
+].join("\n");
+
+const METRICS: MetricKey[] = [
+	"joinedPct",
+	"deliveredPct",
+	"deliveredWithinDeadlinePct",
+	"latencyP95",
+	"treeLevelP95",
+	"formationScore",
+	"maintReparentsPerMin",
+	"maintRecoveryP95Ms",
+	"trackerBpp",
+	"repairBpp",
+	"protocolControlBytesSentTracker",
+	"treeRootChildren",
+];
+
+const SCENARIOS: Record<EvalScenarioName, Partial<FanoutTreeSimParams>> = {
+	mild: {
+		nodes: 40,
+		bootstraps: 1,
+		subscribers: 30,
+		relayFraction: 0.35,
+		messages: 40,
+		msgRate: 50,
+		msgSize: 64,
+		settleMs: 5_000,
+		deadlineMs: 500,
+		timeoutMs: 40_000,
+		repair: true,
+		rootUploadLimitBps: 100_000_000,
+		relayUploadLimitBps: 100_000_000,
+		rootMaxChildren: 64,
+		relayMaxChildren: 32,
+		neighborRepair: true,
+		neighborRepairPeers: 3,
+		dropDataFrameRate: 0.1,
+		churnEveryMs: 200,
+		churnDownMs: 100,
+		churnFraction: 0.05,
+	},
+	tight: {
+		nodes: 60,
+		bootstraps: 1,
+		subscribers: 45,
+		relayFraction: 0.3,
+		messages: 50,
+		msgRate: 40,
+		msgSize: 64,
+		settleMs: 4_000,
+		deadlineMs: 500,
+		timeoutMs: 50_000,
+		repair: true,
+		rootUploadLimitBps: 100_000_000,
+		relayUploadLimitBps: 100_000_000,
+		rootMaxChildren: 8,
+		relayMaxChildren: 8,
+		neighborRepair: true,
+		neighborRepairPeers: 3,
+		dropDataFrameRate: 0.05,
+		churnEveryMs: 300,
+		churnDownMs: 120,
+		churnFraction: 0.04,
+	},
+};
+
+const avg = (rows: FanoutTreeSimResult[], metric: MetricKey) =>
+	rows.reduce((sum, row) => sum + row[metric], 0) / rows.length;
+
+const pickMetrics = (rows: FanoutTreeSimResult[]) =>
+	Object.fromEntries(
+		METRICS.map((metric) => [metric, avg(rows, metric)]),
+	) as Record<MetricKey, number>;
+
+const parseArgs = () => {
+	const argv = process.argv.slice(2);
+	const args = argv[0] === "--" ? argv.slice(1) : argv;
+
+	const readArg = (name: string) => {
+		const index = args.indexOf(name);
+		return index >= 0 ? args[index + 1] : undefined;
+	};
+
+	const scenarioArg = readArg("--scenario") ?? "all";
+	if (scenarioArg !== "all" && !(scenarioArg in SCENARIOS)) {
+		throw new Error(`Unknown scenario '${scenarioArg}'. Expected mild, tight, or all.`);
+	}
+
+	const seedsArg = readArg("--seeds") ?? "1,2,3";
+	const seeds = seedsArg
+		.split(",")
+		.map((value) => Number(value.trim()))
+		.filter((value) => Number.isFinite(value) && value > 0);
+	if (!seeds.length) {
+		throw new Error(`Invalid --seeds value '${seedsArg}'.`);
+	}
+
+	return {
+		scenarios:
+			scenarioArg === "all"
+				? (Object.keys(SCENARIOS) as EvalScenarioName[])
+				: [scenarioArg as EvalScenarioName],
+		seeds,
+		parentUpgradeIntervalMs: Number(
+			readArg("--parentUpgradeIntervalMs") ?? 200,
+		),
+		parentUpgradeLeafOnly:
+			(readArg("--parentUpgradeLeafOnly") ?? "1") !== "0",
+	};
+};
+
+const runScenario = async (
+	name: EvalScenarioName,
+	seeds: number[],
+	parentUpgradeIntervalMs: number,
+	parentUpgradeLeafOnly: boolean,
+) => {
+	const scenario = SCENARIOS[name];
+	const byMode: Record<EvalMode, FanoutTreeSimResult[]> = {
+		off: [],
+		on: [],
+	};
+
+	for (const seed of seeds) {
+		byMode.off.push(await runFanoutTreeSim({ ...scenario, seed }));
+		byMode.on.push(
+			await runFanoutTreeSim({
+				...scenario,
+				seed,
+				parentUpgradeIntervalMs,
+				parentUpgradeLeafOnly,
+			}),
+		);
+	}
+
+	const off = pickMetrics(byMode.off);
+	const on = pickMetrics(byMode.on);
+	const delta = Object.fromEntries(
+		METRICS.map((metric) => [metric, on[metric] - off[metric]]),
+	) as Record<MetricKey, number>;
+
+	return {
+		seeds,
+		off,
+		on,
+		delta,
+	} satisfies ScenarioSummary;
+};
+
+if (process.argv.includes("--help") || process.argv.includes("-h")) {
+	console.log(HELP_TEXT);
+	process.exit(0);
+}
+
+const { scenarios, seeds, parentUpgradeIntervalMs, parentUpgradeLeafOnly } =
+	parseArgs();
+
+const results = Object.fromEntries(
+	await Promise.all(
+		scenarios.map(async (scenario) => [
+			scenario,
+			await runScenario(
+				scenario,
+				seeds,
+				parentUpgradeIntervalMs,
+				parentUpgradeLeafOnly,
+			),
+		]),
+	),
+);
+
+console.log(JSON.stringify(results, null, 2));

--- a/packages/transport/pubsub/benchmark/fanout-tree-sim-lib.ts
+++ b/packages/transport/pubsub/benchmark/fanout-tree-sim-lib.ts
@@ -82,6 +82,8 @@ export type FanoutTreeSimParams = {
 	joinReqTimeoutMs: number;
 	candidateShuffleTopK: number;
 	candidateScoringMode: "ranked-shuffle" | "ranked-strict" | "weighted";
+	parentUpgradeIntervalMs: number;
+	parentUpgradeLeafOnly: boolean;
 	bootstrapEnsureIntervalMs: number;
 	trackerQueryIntervalMs: number;
 	joinAttemptsPerRound: number;
@@ -348,6 +350,8 @@ export const resolveFanoutTreeSimParams = (
 			input.candidateScoringMode === "ranked-shuffle"
 				? input.candidateScoringMode
 				: "ranked-shuffle",
+		parentUpgradeIntervalMs: Number(input.parentUpgradeIntervalMs ?? 0),
+		parentUpgradeLeafOnly: Boolean(input.parentUpgradeLeafOnly ?? true),
 		bootstrapEnsureIntervalMs: Number(input.bootstrapEnsureIntervalMs ?? -1),
 		trackerQueryIntervalMs: Number(input.trackerQueryIntervalMs ?? -1),
 		joinAttemptsPerRound: Number(input.joinAttemptsPerRound ?? -1),
@@ -684,6 +688,12 @@ export const runFanoutTreeSim = async (
 									? { candidateShuffleTopK: params.candidateShuffleTopK }
 									: {}),
 									candidateScoringMode: params.candidateScoringMode,
+									...(params.parentUpgradeIntervalMs > 0
+										? {
+												parentUpgradeIntervalMs: params.parentUpgradeIntervalMs,
+												parentUpgradeLeafOnly: params.parentUpgradeLeafOnly,
+											}
+										: {}),
 								...(params.bootstrapEnsureIntervalMs >= 0
 									? { bootstrapEnsureIntervalMs: params.bootstrapEnsureIntervalMs }
 									: {}),

--- a/packages/transport/pubsub/benchmark/index.ts
+++ b/packages/transport/pubsub/benchmark/index.ts
@@ -19,6 +19,7 @@ const usage = () => {
 			"Benchmarks:",
 			"  topic-sim  in-memory TopicControlPlane topic fanout sim",
 			"  fanout-tree-sim  end-to-end FanoutTree protocol sim (bootstrap tracker join)",
+			"  fanout-tree-parent-upgrade-eval  A/B compare parent upgrades off vs on",
 			"",
 			"Example:",
 			"  pnpm -C packages/transport/pubsub run bench -- topic-sim --nodes 3 --degree 2 --subscribers 2 --messages 5 --msgSize 32 --intervalMs 0 --seed 1 --subscribeModel preseed --timeoutMs 300000",
@@ -39,6 +40,9 @@ switch (bench) {
 		break;
 	case "fanout-tree-sim":
 		await import("./fanout-tree-sim.js");
+		break;
+	case "fanout-tree-parent-upgrade-eval":
+		await import("./fanout-tree-parent-upgrade-eval.js");
 		break;
 	default:
 		usage();


### PR DESCRIPTION
## Summary
- add a reusable `fanout-tree-parent-upgrade-eval` benchmark entrypoint for A/B comparison of parent upgrades off vs on
- extend the fanout-tree sim params so the benchmark can pass parent-upgrade options through to the join logic
- add a smaller `live-like` scenario alongside the existing `mild` and `tight` evaluation scenarios

## Why
We are not promoting proactive parent upgrades to a default behavior right now. The useful part of the investigation is the measurement tooling: it lets us compare future routing-policy ideas with the same repeatable command instead of relying on ad hoc shell snippets.

## Verification
- `pnpm --filter @peerbit/pubsub build`
- `pnpm -C packages/transport/pubsub run bench -- fanout-tree-parent-upgrade-eval --scenario mild --seeds 1`

## Notes
This PR does not change the fanout runtime behavior. It only adds benchmark and evaluation support.
