### PR TITLE
fix(pubsub): catch 'Channel not open' in publishToChannelMaybe()

### DIFF
--- a/packages/transport/pubsub/src/fanout-tree.ts
+++ b/packages/transport/pubsub/src/fanout-tree.ts
@@ -3151,6 +3151,12 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			await this.publishToChannel(topic, root, payload);
 			return true;
 		} catch (error) {
+			if (
+				error instanceof Error &&
+				error.message.startsWith("Channel not open:")
+			) {
+				return false;
+			}
 			dontThrowIfDeliveryError(error);
 			return false;
 		}

--- a/packages/transport/pubsub/test/channel-not-open.spec.ts
+++ b/packages/transport/pubsub/test/channel-not-open.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * Regression: publishToChannelMaybe() throws "Channel not open"
+ *
+ * dontThrowIfDeliveryError() only recognises DeliveryError, TimeoutError, and
+ * AbortError — it re-throws the "Channel not open" Error. This surfaces as an
+ * unhandled promise rejection during teardown.
+ *
+ * The fix catches "Channel not open:" before calling dontThrowIfDeliveryError.
+ */
+
+import { TestSession } from "@peerbit/libp2p-test-utils";
+import { expect } from "chai";
+import { FanoutTree } from "../src/index.js";
+
+type FanoutServices = { fanout: FanoutTree };
+
+const createFanoutService = (components: any) =>
+	new FanoutTree(components, { connectionManager: false });
+
+const createFanoutTestSession = (n: number) =>
+	TestSession.disconnected<FanoutServices>(n, {
+		services: {
+			fanout: createFanoutService,
+		},
+	});
+
+describe("@peerbit/pubsub — Channel not open during shutdown", () => {
+	it("publishToChannelMaybe() returns false after channel is closed (direct)", async () => {
+		const session = await createFanoutTestSession(1);
+
+		try {
+			const fanout = session.peers[0].services.fanout;
+			const topic = "shutdown-repro";
+			const root = fanout.publicKeyHash;
+
+			fanout.openChannel(topic, root, {
+				role: "root",
+				msgRate: 10,
+				msgSize: 64,
+				uploadLimitBps: 1_000_000,
+				maxChildren: 4,
+				repair: false,
+			});
+
+			const payload = new Uint8Array([1, 2, 3]);
+			const okResult = await fanout.publishToChannelMaybe(
+				topic,
+				root,
+				payload,
+			);
+			expect(okResult).to.equal(true);
+
+			fanout.closeChannel(topic, root);
+
+			// On unpatched code this throws "Channel not open"
+			const result = await fanout.publishToChannelMaybe(
+				topic,
+				root,
+				payload,
+			);
+			expect(result).to.equal(false);
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("publishToChannel() still throws for callers who want the error", async () => {
+		const session = await createFanoutTestSession(1);
+
+		try {
+			const fanout = session.peers[0].services.fanout;
+			const topic = "throw-check";
+			const root = fanout.publicKeyHash;
+
+			fanout.openChannel(topic, root, {
+				role: "root",
+				msgRate: 10,
+				msgSize: 64,
+				uploadLimitBps: 1_000_000,
+				maxChildren: 4,
+				repair: false,
+			});
+
+			fanout.closeChannel(topic, root);
+
+			try {
+				await fanout.publishToChannel(topic, root, new Uint8Array([1]));
+				expect.fail("Expected publishToChannel to throw after channel close");
+			} catch (err: any) {
+				expect(err).to.be.instanceOf(Error);
+				expect(err.message).to.match(/^Channel not open:/);
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- **Bug**: `publishToChannelMaybe()` throws "Channel not open" during shutdown because `dontThrowIfDeliveryError()` only recognizes `DeliveryError`, `TimeoutError`, and `AbortError` — it re-throws the plain `Error("Channel not open: ...")`. This surfaces as an unhandled promise rejection.
- **Fix**: Add a check for `error.message.startsWith("Channel not open:")` before calling `dontThrowIfDeliveryError()`, returning `false` to honor the method's best-effort "maybe" semantics.
- **Test**: Added `channel-not-open.spec.ts` with tests for both the maybe (silent) and non-maybe (throwing) publish paths.

## Test plan

- [x] New test `publishToChannelMaybe() returns false after channel is closed` fails without fix (throws "Channel not open")
- [x] New test passes with fix applied (returns `false`)
- [x] `publishToChannel()` still throws for callers who want the error (verified in second test)
- [x] Full test suite passes via aegir

## Full Test Suite Results

Built the entire monorepo (`pnpm run build`) and ran the full `@peerbit/pubsub` test suite via aegir on an isolated worktree.

**71 passing, 0 failing**

### New tests (2/2 passing)
- `publishToChannelMaybe() returns false after channel is closed (direct)` — PASS
- `publishToChannel() still throws for callers who want the error` — PASS

### Existing tests (69/69 passing)
| Suite | Tests |
|---|---|
| pubsub (fanout topics) | 8 |
| fanout-tree-sim (ci) | 2 |
| fanout-tree | 26 |
| pubsub (waitForSubscribers) | 3 |
| pubsub in-memory libp2p shim | 2 |
| fanout provider discovery | 1 |
| pubsub-topic-sim (ci) | 2 |
| subscribe race regressions | 6 |
| topic-root-control-plane | 6 |
| topic-root-directory | 3 |
| unsubscribe reason | 10 |

**No regressions.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)