### PR TITLE
refactor(shared-log): centralize subscriber cache invalidation

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -1492,6 +1492,10 @@ export class SharedLog<
 		}
 	}
 
+	private invalidateSharedLogTopicSubscribersCache() {
+		this.invalidateTopicSubscribersCache(this.topic, this.rpc.topic);
+	}
+
 	// @deprecated
 	private async getRole() {
 		const segments = await this.getMyReplicationSegments();
@@ -6476,7 +6480,7 @@ export class SharedLog<
 		if (!prev || prev < now) {
 			this.latestReplicationInfoMessage.set(fromHash, now);
 		}
-		this.invalidateTopicSubscribersCache(this.topic, this.rpc.topic);
+		this.invalidateSharedLogTopicSubscribersCache();
 
 		return this.handleSubscriptionChange(
 			evt.detail.from,
@@ -6497,7 +6501,7 @@ export class SharedLog<
 
 		this.remoteBlocks.onReachable(evt.detail.from);
 		this._replicationInfoBlockedPeers.delete(evt.detail.from.hashcode());
-		this.invalidateTopicSubscribersCache(this.topic, this.rpc.topic);
+		this.invalidateSharedLogTopicSubscribersCache();
 
 		await this.handleSubscriptionChange(
 			evt.detail.from,


### PR DESCRIPTION
Small follow-up on top of the shared-log subscriber cache work.

This just centralizes the shared-log topic cache invalidation helper used on subscribe/unsubscribe events.

The practical reason for landing this separately is that the shared-log runtime changes merged in #719 were classified as `perf(...)`, which Release Please skips in this repo. This `refactor(shared-log)` commit keeps the code change honest while allowing the already-merged shared-log improvements to flow into the next release PR.