### PR TITLE
fix(blocks): retry provider discovery sooner for pending gets

### DIFF
--- a/packages/transport/blocks/src/remote.ts
+++ b/packages/transport/blocks/src/remote.ts
@@ -524,12 +524,16 @@ export class RemoteBlocks implements IBlocks {
 
 			let requeryCount = 0;
 			const maxRequests = Math.max(1, this.maxRequeryOnReachable);
-			const retryIntervalMs = Math.max(
+			const requestRetryIntervalMs = Math.max(
 				1_000,
 				Math.min(
 					5_000,
 					Math.floor((options.timeout ?? 30_000) / Math.max(2, maxRequests)),
 				),
+			);
+			const providerDiscoveryRetryIntervalMs = Math.max(
+				250,
+				Math.min(1_000, Math.floor(requestRetryIntervalMs / 2)),
 			);
 			let retryTimeout: ReturnType<typeof setTimeout> | undefined;
 			const refreshProviders = async (force = false) => {
@@ -580,6 +584,10 @@ export class RemoteBlocks implements IBlocks {
 					clearTimeout(retryTimeout);
 				}
 				if (requeryCount >= maxRequests) return;
+				const retryIntervalMs =
+					providers.length > 0
+						? requestRetryIntervalMs
+						: providerDiscoveryRetryIntervalMs;
 				retryTimeout = setTimeout(() => {
 					if (!this._resolvers.has(cidString)) return;
 					tryPublishRequest({ refreshProviders: true })

--- a/packages/transport/blocks/test/libp2p.spec.ts
+++ b/packages/transport/blocks/test/libp2p.spec.ts
@@ -167,6 +167,40 @@ describe("transport", function () {
 		expect(new Uint8Array(read!)).to.deep.equal(data);
 	});
 
+	it("rechecks provider discovery quickly while a get is already waiting", async () => {
+		let providersReady = false;
+		session = await TestSession.connected(2, {
+			services: {
+				blocks: (c) =>
+					new DirectBlock(c, {
+						resolveProviders: () =>
+							providersReady ? [store(session, 0).publicKeyHash] : [],
+					}),
+			},
+		});
+
+		await store(session, 0).start();
+		await store(session, 1).start();
+		await waitForNeighbour(store(session, 0), store(session, 1));
+
+		const data = new Uint8Array([5, 4, 3]);
+		const cid = await store(session, 0).put(data);
+		expect(cid).equal("zb2rhbnwihVzMMEGAPf9EwTZBsQz9fszCnM4Y8mJmBFgiyN7J");
+
+		const startedAt = Date.now();
+		const readPromise = store(session, 1).get(cid, {
+			remote: { timeout: 10_000 },
+		});
+
+		setTimeout(() => {
+			providersReady = true;
+		}, 250);
+
+		const read = await readPromise;
+		expect(new Uint8Array(read!)).to.deep.equal(data);
+		expect(Date.now() - startedAt).to.be.lessThan(3_000);
+	});
+
 	it("can recover when explicit providers are stale but resolver knows a better peer", async () => {
 		session = await TestSession.disconnected(3, {
 			services: {


### PR DESCRIPTION
## Summary
- retry provider discovery faster while a remote block get is already waiting and still has no providers
- keep the slower bounded retry cadence once provider candidates exist and actual request retries are in flight
- add a transport regression covering delayed provider discovery during an in-flight get

## Why
File-share open profiling showed the dominant reader-open delay was before nested `Files.open()` started. The gap traced back to `Program.load(...)` waiting on `RemoteBlocks.get(...)` for the root CID, where an empty provider set could sit on a coarse ~5s retry timer before rechecking discovery.

## Validation
- `pnpm run build`
- targeted `@peerbit/blocks` package test entrypoint is currently blocked by an existing aegir/workspace resolution issue in this fresh worktree (`Cannot find module` errors during package-local build), so I validated the change through the full repo build and the new regression coverage added in the transport test file