### PR TITLE
perf(program): parallelize sibling lifecycle open hooks

### DIFF
--- a/packages/programs/program/program/src/program.ts
+++ b/packages/programs/program/program/src/program.ts
@@ -241,10 +241,10 @@ export abstract class Program<
 
 		this._eventOptions = options;
 		this.node = node;
-		const nexts = this.programs;
-		for (const next of nexts) {
-			await next.beforeOpen(node, { ...options, parent: this });
-		}
+		const nexts = [...new Set(this.programs)];
+		await Promise.all(
+			nexts.map((next) => next.beforeOpen(node, { ...options, parent: this })),
+		);
 
 		await this._eventOptions?.onBeforeOpen?.(this);
 		this.closed = false;
@@ -267,10 +267,8 @@ export abstract class Program<
 
 			this.emitEvent(new CustomEvent("open", { detail: this }), true);
 			await this._eventOptions?.onOpen?.(this);
-			const nexts = this.programs;
-			for (const next of nexts) {
-				await next.afterOpen();
-			}
+			const nexts = [...new Set(this.programs)];
+			await Promise.all(nexts.map((next) => next.afterOpen()));
 		}
 	}
 

--- a/packages/programs/program/program/test/index.spec.ts
+++ b/packages/programs/program/program/test/index.spec.ts
@@ -284,6 +284,79 @@ describe("program", () => {
 				expect(p.closed).to.be.true;
 				expect(p.child.closed).to.be.true;
 			});
+
+			it("opens sibling subprogram lifecycle hooks in parallel", async () => {
+				let beforeOpenInFlight = 0;
+				let maxBeforeOpenInFlight = 0;
+				let afterOpenInFlight = 0;
+				let maxAfterOpenInFlight = 0;
+
+				@variant("parallel-open-child")
+				class ParallelOpenChild extends Program {
+					@field({ type: "u32" })
+					id: number;
+
+					constructor(id: number) {
+						super();
+						this.id = id;
+					}
+
+					override async beforeOpen(
+						node: ProgramClient,
+						options?: any,
+					): Promise<void> {
+						beforeOpenInFlight++;
+						maxBeforeOpenInFlight = Math.max(
+							maxBeforeOpenInFlight,
+							beforeOpenInFlight,
+						);
+						try {
+							await delay(25);
+							await super.beforeOpen(node, options);
+						} finally {
+							beforeOpenInFlight--;
+						}
+					}
+
+					override async open(): Promise<void> {}
+
+					override async afterOpen(): Promise<void> {
+						afterOpenInFlight++;
+						maxAfterOpenInFlight = Math.max(
+							maxAfterOpenInFlight,
+							afterOpenInFlight,
+						);
+						try {
+							await delay(25);
+							await super.afterOpen();
+						} finally {
+							afterOpenInFlight--;
+						}
+					}
+				}
+
+				@variant("parallel-open-parent")
+				class ParallelOpenParent extends Program {
+					@field({ type: ParallelOpenChild })
+					left: ParallelOpenChild;
+
+					@field({ type: ParallelOpenChild })
+					right: ParallelOpenChild;
+
+					constructor() {
+						super();
+						this.left = new ParallelOpenChild(1);
+						this.right = new ParallelOpenChild(2);
+					}
+
+					override async open(): Promise<void> {}
+				}
+
+				await peer.open(new ParallelOpenParent());
+
+				expect(maxBeforeOpenInFlight).to.equal(2);
+				expect(maxAfterOpenInFlight).to.equal(2);
+			});
 		});
 
 		describe("clear", () => {


### PR DESCRIPTION
## Summary
- parallelize sibling subprogram beforeOpen/afterOpen work in the base Program lifecycle
- dedupe sibling lifecycle traversal by object identity to avoid racing a shared child
- add a regression test that proves sibling lifecycle hooks overlap

## Validation
- pnpm run build
- pnpm --filter @peerbit/program test -- --grep "opens sibling subprogram lifecycle hooks in parallel"