### PR TITLE
perf(shared-log): overlap subscriber discovery during open

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -3115,13 +3115,11 @@ export class SharedLog<
 		this._replicationRangeIndex = await replicationIndex.init({
 			schema: this.indexableDomain.constructorRange,
 		});
-
 		this._entryCoordinatesIndex = await replicationIndex.init({
 			schema: this.indexableDomain.constructorEntry,
 		});
 
 		await remoteBlocksStartPromise;
-
 		const hasIndexedReplicationInfo =
 			(await this.replicationIndex.count({
 				query: [
@@ -3379,25 +3377,26 @@ export class SharedLog<
 
 	async afterOpen(): Promise<void> {
 		await super.afterOpen();
+		const existingSubscribersPromise = this._getTopicSubscribers(this.topic);
 
 		// We do this here, because these calls requires this.closed == false
-			void this.pruneOfflineReplicators()
-				.then(() => {
-					this._replicatorsReconciled = true;
-				})
+		void this.pruneOfflineReplicators()
+			.then(() => {
+				this._replicatorsReconciled = true;
+			})
 			.catch((error) => {
 				if (isNotStartedError(error as Error)) {
 					return;
 				}
-					logger.error(error);
-				});
+				logger.error(error);
+			});
 
-			this.startReplicatorLivenessSweep();
+		this.startReplicatorLivenessSweep();
 
-			await this.rebalanceParticipation();
+		await this.rebalanceParticipation();
 
 		// Take into account existing subscription
-		(await this._getTopicSubscribers(this.topic))?.forEach((v) => {
+		(await existingSubscribersPromise)?.forEach((v) => {
 			if (v.equals(this.node.identity.publicKey)) {
 				return;
 			}

--- a/packages/programs/data/shared-log/test/replicator-liveness.spec.ts
+++ b/packages/programs/data/shared-log/test/replicator-liveness.spec.ts
@@ -295,6 +295,58 @@ describe("waitForReplicator liveness", () => {
 		}
 	});
 
+	it("starts subscriber discovery while rebalancing during open", async () => {
+		session = await TestSession.connected(1);
+
+		const store = new EventStore<string, any>();
+		const hooks = getLivenessTestHooks(store);
+		const originalGetTopicSubscribers =
+			hooks._getTopicSubscribers.bind(hooks);
+		const originalRebalanceParticipation =
+			store.log.rebalanceParticipation.bind(store.log);
+
+		let rebalanceStarted = false;
+		let subscribersStarted = false;
+		let releaseRebalance!: () => void;
+		const rebalanceGate = new Promise<void>((resolve) => {
+			releaseRebalance = resolve;
+		});
+
+		hooks._getTopicSubscribers = async (topic: string) => {
+			subscribersStarted = true;
+			return originalGetTopicSubscribers(topic);
+		};
+		store.log.rebalanceParticipation = async () => {
+			rebalanceStarted = true;
+			await rebalanceGate;
+			return originalRebalanceParticipation();
+		};
+
+		const openPromise = session.peers[0].open(store, {
+			args: {
+				replicate: { factor: 1 },
+				timeUntilRoleMaturity: 0,
+			},
+		});
+
+		try {
+			await waitForResolved(() => expect(rebalanceStarted).to.be.true, {
+				timeout: 5_000,
+				delayInterval: 20,
+			});
+			await waitForResolved(() => expect(subscribersStarted).to.be.true, {
+				timeout: 1_000,
+				delayInterval: 20,
+			});
+		} finally {
+			releaseRebalance();
+			hooks._getTopicSubscribers = originalGetTopicSubscribers;
+			store.log.rebalanceParticipation = originalRebalanceParticipation;
+		}
+
+		await openPromise;
+	});
+
 	it("invalidates cached topic subscribers when the cache is cleared", async () => {
 		session = await TestSession.connected(2);
 


### PR DESCRIPTION
## Summary
- overlap topic-subscriber discovery with `SharedLog.afterOpen()` rebalancing instead of waiting for rebalance first
- keep the actual subscription handling after rebalance so readiness semantics stay the same
- add a shared-log regression proving subscriber discovery starts while rebalance is still blocked

## Validation
- `pnpm run build`
- `pnpm --filter @peerbit/shared-log test -- --grep "waitForReplicator liveness"`
- `pnpm --filter @peerbit/shared-log test -- --grep "restart after adding|will not be blocked by replicator re-check on start|starts subscriber discovery while rebalancing during open"`

## Notes
- targeted startup slice on the same machine moved from roughly `279ms -> 270ms` for `restart after adding`
- targeted startup slice on the same machine moved from roughly `253ms -> 250ms` for `will not be blocked by replicator re-check on start`
