### PR TITLE
test(shared-log): drop repair hash once

### DIFF
--- a/packages/programs/data/shared-log/test/sharding.spec.ts
+++ b/packages/programs/data/shared-log/test/sharding.spec.ts
@@ -1353,13 +1353,16 @@ testSetups.forEach((setup) => {
 				};
 				const originalOnMaybeMissingEntries =
 					sync.onMaybeMissingEntries.bind(sync);
+				let droppedCandidateHash = false;
 
 				sync.onMaybeMissingEntries = async (properties) => {
 					if (
 						candidateHash &&
+						!droppedCandidateHash &&
 						properties.targets.includes(targetHash) &&
 						properties.entries.has(candidateHash)
 					) {
+						droppedCandidateHash = true;
 						const filtered = new Map(properties.entries);
 						filtered.delete(candidateHash);
 						return originalOnMaybeMissingEntries({
@@ -1381,6 +1384,18 @@ testSetups.forEach((setup) => {
 							expect(await targetDb.log.replicationIndex?.getSize()).equal(2),
 						),
 					]);
+
+					await waitForResolved(
+						async () =>
+							expect(
+								droppedCandidateHash,
+								"expected the repair path to drop the selected hash once",
+							).to.be.true,
+						{
+							timeout: 30_000,
+							delayInterval: 500,
+						},
+					);
 
 					await waitForResolved(
 						async () =>


### PR DESCRIPTION
## Summary
- make the adaptive sharding repair regression simulate one missed hash only once
- assert the miss is actually injected before waiting for the target to repair the entry

## Verification
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --no-build --grep "repairs redistributed entry when maybe-sync misses one hash on peer leave"` repeated 10x
- `pnpm run test:ci:part-7` (`199 passing`, `7 pending`)

This follows up #737. The previous version could drop the candidate hash on every matching maybe-sync call, so the test could permanently starve the repair path instead of modelling a single missed hash.
