### PR TITLE
fix(shared-log): recover memory-limited adaptive replicas

### DIFF
--- a/packages/programs/data/shared-log/src/pid.ts
+++ b/packages/programs/data/shared-log/src/pid.ts
@@ -1,3 +1,5 @@
+const MIN_MEMORY_HEADROOM_BALANCE_SCALER = 0.25;
+
 export class PIDReplicationController {
 	integral!: number;
 	prevError!: number;
@@ -65,7 +67,7 @@ export class PIDReplicationController {
 		}
 
 		const errorCoverageUnmodified = Math.min(1 - totalFactor, 1);
-		const errorCoverage =
+		let errorCoverage =
 			(this.maxMemoryLimit ? 1 - Math.sqrt(Math.abs(errorMemory)) : 1) *
 			errorCoverageUnmodified;
 
@@ -82,8 +84,22 @@ export class PIDReplicationController {
 		const errorFromEvenForBalance =
 			errorFromEven >= 0 ? errorFromEven : errorFromEven * negativeBalanceScale;
 
+		const hasMemoryHeadroom =
+			this.maxMemoryLimit != null && this.maxMemoryLimit > 0 && errorMemory > 0;
+		if (hasMemoryHeadroom && errorFromEvenForBalance > 0) {
+			// Coverage surplus often means another peer has not pruned yet. Do not let
+			// that transient surplus cancel a constrained peer that is still below an
+			// even share and has storage headroom to take more work.
+			errorCoverage = Math.max(errorCoverage, 0);
+		}
+
 		const balanceErrorScaler = this.maxMemoryLimit
-			? Math.abs(errorMemory)
+			? hasMemoryHeadroom
+				? Math.max(
+						Math.abs(errorMemory),
+						MIN_MEMORY_HEADROOM_BALANCE_SCALER,
+					)
+				: Math.abs(errorMemory)
 			: 1 - Math.abs(errorCoverage);
 
 		// Balance should be symmetric (allow negative error) so a peer can *reduce*

--- a/packages/programs/data/shared-log/test/pid.spec.ts
+++ b/packages/programs/data/shared-log/test/pid.spec.ts
@@ -131,4 +131,37 @@ describe("PIDReplicationController", () => {
 			expect(f).to.be.at.least(0.5);
 		});
 	});
+
+	describe("memory", () => {
+		it("uses storage headroom to recover toward an even share during transient surplus", () => {
+			const controller = new PIDReplicationController("", {
+				storage: { max: 100_000 },
+			});
+			const f = controller.step({
+				currentFactor: 0.07,
+				memoryUsage: 45_540,
+				totalFactor: 1.06,
+				peerCount: 2,
+				cpuUsage: undefined,
+			});
+
+			expect(f).to.be.greaterThan(0.1);
+			expect(f).to.be.lessThan(0.5);
+		});
+
+		it("does not grow past an even share just because storage is available", () => {
+			const controller = new PIDReplicationController("", {
+				storage: { max: 100_000 },
+			});
+			const f = controller.step({
+				currentFactor: 0.5,
+				memoryUsage: 45_540,
+				totalFactor: 1,
+				peerCount: 2,
+				cpuUsage: undefined,
+			});
+
+			expect(f).to.be.within(0.49, 0.51);
+		});
+	});
 });

--- a/packages/programs/data/shared-log/test/sharding.spec.ts
+++ b/packages/programs/data/shared-log/test/sharding.spec.ts
@@ -1855,21 +1855,32 @@ testSetups.forEach((setup) => {
 
 							await delay(db1.log.timeUntilRoleMaturity + 1000);
 
-							await waitForParticipationToSettle(db1, db2);
+							const assertMemoryNearLimit = async () => {
+								const memoryUsage = await db2.log.getMemoryUsage();
+								const tolerance = Math.max((memoryLimit / 100) * 12, 10_000);
+								expect(
+									Math.abs(memoryLimit - memoryUsage),
+									`memoryUsage=${memoryUsage} memoryLimit=${memoryLimit}`,
+								).lessThan(tolerance);
+							};
 
-							await waitForDistributionQuiesced(db1, db2);
-
-							await waitForResolved(
-								async () => {
-									const memoryUsage = await db2.log.getMemoryUsage();
-									const tolerance = Math.max((memoryLimit / 100) * 12, 10_000);
-									expect(
-										Math.abs(memoryLimit - memoryUsage),
-										`memoryUsage=${memoryUsage} memoryLimit=${memoryLimit}`,
-									).lessThan(tolerance);
-								},
-								{ timeout: 60 * 1000, delayInterval: 1000 },
-							);
+							try {
+								// The contract here is the storage objective, not an idle PID
+								// curve. Under u64/IBLT the participation range can keep making
+								// small corrective moves while memory is already within target.
+								await waitForResolved(assertMemoryNearLimit, {
+									timeout: 180_000,
+									delayInterval: 1000,
+								});
+								await waitForDistributionQuiesced(db1, db2);
+								await waitForResolved(assertMemoryNearLimit, {
+									timeout: 120_000,
+									delayInterval: 1000,
+								});
+							} catch (error) {
+								await dbgLogs([db1.log, db2.log]);
+								throw error;
+							}
 						});
 
 						it("joining half limited", async () => {


### PR DESCRIPTION
## Summary
- let memory-limited adaptive replicas recover toward an even share when they still have storage headroom despite transient coverage surplus
- add PID regressions for the underutilized-storage case and the no-overgrowth-at-even-share guard
- make the sharding memory objective wait on the storage objective instead of requiring the PID participation curve to become idle

## Verification
- pnpm --dir packages/programs/data/shared-log run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --no-build --grep "PIDReplicationController"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --no-build --grep "(u32-simple|u64-iblt).*inserting half limited"
- pnpm run test:ci:part-7 (199 passing, 7 pending)
