### PR TITLE
fix(blocks): widen in-flight provider hints

### DIFF
--- a/packages/programs/data/shared-log/test/sharding.spec.ts
+++ b/packages/programs/data/shared-log/test/sharding.spec.ts
@@ -1254,7 +1254,7 @@ testSetups.forEach((setup) => {
 				await checkBounded(entryCount, 1, 1, db1, db2);
 			});
 
-			it("repairs redistributed entry when maybe-sync misses one hash on peer leave", async function () {
+			it("repairs redistributed entry when churn repair misses one hash on peer leave", async function () {
 				if (setup.name !== "u64-iblt") {
 					this.skip();
 				}
@@ -1363,32 +1363,29 @@ testSetups.forEach((setup) => {
 				const leavingDb = candidate!.leaving;
 				const targetHash = targetDb.node.identity.publicKey.hashcode();
 
-				const sync = sourceDb.log.syncronizer as {
-					onMaybeMissingEntries: (properties: {
-						entries: Map<string, any>;
-						targets: string[];
-					}) => Promise<void>;
+				const sourceLog = sourceDb.log as unknown as {
+					pushRepairEntries: (
+						target: string,
+						entries: Map<string, any>,
+					) => Promise<void>;
 				};
-				const originalOnMaybeMissingEntries =
-					sync.onMaybeMissingEntries.bind(sync);
+				const originalPushRepairEntries =
+					sourceLog.pushRepairEntries.bind(sourceDb.log);
 				let droppedCandidateHash = false;
 
-				sync.onMaybeMissingEntries = async (properties) => {
+				sourceLog.pushRepairEntries = async (target, entries) => {
 					if (
 						candidateHash &&
 						!droppedCandidateHash &&
-						properties.targets.includes(targetHash) &&
-						properties.entries.has(candidateHash)
+						target === targetHash &&
+						entries.has(candidateHash)
 					) {
 						droppedCandidateHash = true;
-						const filtered = new Map(properties.entries);
+						const filtered = new Map(entries);
 						filtered.delete(candidateHash);
-						return originalOnMaybeMissingEntries({
-							...properties,
-							entries: filtered,
-						});
+						return originalPushRepairEntries(target, filtered);
 					}
-					return originalOnMaybeMissingEntries(properties);
+					return originalPushRepairEntries(target, entries);
 				};
 
 				try {
@@ -1407,7 +1404,7 @@ testSetups.forEach((setup) => {
 						async () =>
 							expect(
 								droppedCandidateHash,
-								"expected the repair path to drop the selected hash once",
+								"expected the churn repair path to drop the selected hash once",
 							).to.be.true,
 						{
 							timeout: 30_000,
@@ -1426,7 +1423,7 @@ testSetups.forEach((setup) => {
 
 					await checkBounded(entryCount, 1, 1, sourceDb, targetDb);
 				} finally {
-					sync.onMaybeMissingEntries = originalOnMaybeMissingEntries;
+					sourceLog.pushRepairEntries = originalPushRepairEntries;
 				}
 			});
 

--- a/packages/transport/blocks/src/remote.ts
+++ b/packages/transport/blocks/src/remote.ts
@@ -63,6 +63,11 @@ type BlockMessageContext = {
 	transport?: RequestTransportContext;
 };
 
+type InFlightRead = {
+	promise: Promise<Block<any, any, any, 1> | undefined>;
+	addProviders: (providers: string[]) => void;
+};
+
 export class RemoteBlocks implements IBlocks {
 	localStore: BlockStore;
 
@@ -78,10 +83,7 @@ export class RemoteBlocks implements IBlocks {
 	private readonly maxRequeryOnReachable: number;
 
 	private _loadFetchQueue: PQueue;
-	private _readFromPeersPromises: Map<
-		string,
-		Promise<Block<any, any, any, 1> | undefined> | undefined
-	>;
+	private _readFromPeersPromises: Map<string, InFlightRead>;
 	_open = false;
 	private _events: TypedEventEmitter<{
 		"peer:reachable": CustomEvent<PublicSignKey>;
@@ -498,10 +500,10 @@ export class RemoteBlocks implements IBlocks {
 			this.rememberProviderHints(cidString, providers);
 		}
 
-		let promise = this._readFromPeersPromises.get(cidString);
-		if (!promise) {
-			const attemptedProviders = new Set<string>(providers);
-			promise = new Promise<Block<any, any, any, 1> | undefined>(
+		let inFlight = this._readFromPeersPromises.get(cidString);
+		if (!inFlight) {
+			let publishAdditionalProviders: (providers: string[]) => void = () => {};
+			const promise = new Promise<Block<any, any, any, 1> | undefined>(
 				(resolve, reject) => {
 					let timeoutCallback: ReturnType<typeof setTimeout> | undefined;
 					const abortHandler = () => {
@@ -535,8 +537,6 @@ export class RemoteBlocks implements IBlocks {
 				},
 			);
 
-			this._readFromPeersPromises.set(cidString, promise);
-
 			let requeryCount = 0;
 			const maxRequests = Math.max(1, this.maxRequeryOnReachable);
 			const requestRetryIntervalMs = Math.max(
@@ -564,23 +564,25 @@ export class RemoteBlocks implements IBlocks {
 				});
 				if (resolved.length > 0) {
 					providers = this.normalizeProviderHints([...providers, ...resolved]);
-					for (const provider of providers) {
-						attemptedProviders.add(provider);
-					}
 				}
 			};
-			const tryPublishRequest = async (properties?: { refreshProviders?: boolean }) => {
-				if (requeryCount >= maxRequests) return;
+			const tryPublishRequest = async (properties?: {
+				refreshProviders?: boolean;
+				force?: boolean;
+				providers?: string[];
+			}) => {
+				if (requeryCount >= maxRequests && !properties?.force) return;
 				if (providers.length === 0 || properties?.refreshProviders) {
 					await refreshProviders(properties?.refreshProviders === true);
 				}
 				if (providers.length === 0) return;
 				try {
 					const expiresAt = Date.now() + (options.timeout ?? 30_000);
-					const requestProviders = this.pickRequestBatch(
-						providers,
-						requeryCount,
-					);
+					const requestProviders =
+						properties?.providers && properties.providers.length > 0
+							? this.normalizeProviderHints(properties.providers)
+							: this.pickRequestBatch(providers, requeryCount);
+					if (requestProviders.length === 0) return;
 					await this.options.publish(
 						new BlockRequest(cidString),
 						{
@@ -598,6 +600,36 @@ export class RemoteBlocks implements IBlocks {
 					dontThrowIfDeliveryError(e);
 				}
 			};
+			publishAdditionalProviders = (nextProviders: string[]) => {
+				if (!this._resolvers.has(cidString)) return;
+				const requestProviders = this.normalizeProviderHints(nextProviders);
+				if (requestProviders.length === 0) return;
+				const merged = this.normalizeProviderHints([
+					...requestProviders,
+					...providers,
+				]);
+				if (merged.length === 0) return;
+				let changed = merged.length !== providers.length;
+				if (!changed) {
+					for (let i = 0; i < merged.length; i++) {
+						if (merged[i] !== providers[i]) {
+							changed = true;
+							break;
+						}
+					}
+				}
+				if (!changed) return;
+				providers = merged;
+				tryPublishRequest({ force: true, providers: requestProviders }).catch(
+					dontThrowIfDeliveryError,
+				);
+			};
+			inFlight = {
+				promise,
+				addProviders: (nextProviders) => publishAdditionalProviders(nextProviders),
+			};
+			this._readFromPeersPromises.set(cidString, inFlight);
+
 			const scheduleRetry = () => {
 				if (retryTimeout) {
 					clearTimeout(retryTimeout);
@@ -625,10 +657,9 @@ export class RemoteBlocks implements IBlocks {
 			};
 
 			const publishOnProviderHints = (ev: CustomEvent<{ cid: string }>) => {
-				if (requeryCount >= maxRequests) return;
 				if (!ev?.detail?.cid) return;
 				if (ev.detail.cid !== cidString) return;
-				tryPublishRequest({ refreshProviders: true }).catch(
+				tryPublishRequest({ refreshProviders: true, force: true }).catch(
 					dontThrowIfDeliveryError,
 				);
 			};
@@ -642,10 +673,9 @@ export class RemoteBlocks implements IBlocks {
 						if (normalized.length === 0) return;
 						this.rememberProviderHints(cidString, normalized);
 						providers = this.normalizeProviderHints([...providers, ...normalized]);
-						for (const provider of normalized) {
-							attemptedProviders.add(provider);
-						}
-						tryPublishRequest().catch(dontThrowIfDeliveryError);
+						tryPublishRequest({ force: true, providers: normalized }).catch(
+							dontThrowIfDeliveryError,
+						);
 					},
 				});
 			}
@@ -671,7 +701,10 @@ export class RemoteBlocks implements IBlocks {
 				}
 			}
 		} else {
-			const result = await promise;
+			if (providers.length > 0) {
+				inFlight.addProviders(providers);
+			}
+			const result = await inFlight.promise;
 			return result?.bytes;
 		}
 	}

--- a/packages/transport/blocks/test/libp2p.spec.ts
+++ b/packages/transport/blocks/test/libp2p.spec.ts
@@ -297,6 +297,96 @@ describe("transport", function () {
 		expect(new Uint8Array(read!)).to.deep.equal(data);
 	});
 
+	it("widens an in-flight read when a later caller supplies a better explicit provider", async () => {
+		session = await TestSession.disconnected(3, {
+			services: {
+				blocks: (c) =>
+					new DirectBlock(c, {
+						resolveProviders: () => [],
+						requeryOnReachable: 1,
+					}),
+			},
+		});
+
+		await store(session, 0).start();
+		await store(session, 1).start();
+		await store(session, 2).start();
+
+		await session.connect([[session.peers[0], session.peers[1]]]);
+		await waitForNeighbour(store(session, 0), store(session, 1));
+
+		const data = new Uint8Array([5, 4, 3]);
+		const cid = await store(session, 0).put(data);
+		expect(cid).equal("zb2rhbnwihVzMMEGAPf9EwTZBsQz9fszCnM4Y8mJmBFgiyN7J");
+
+		const requesterRemoteBlocks = (store(session, 1) as any)[
+			"remoteBlocks"
+		] as RemoteBlocks;
+		const providerRemoteBlocks = (store(session, 0) as any)[
+			"remoteBlocks"
+		] as RemoteBlocks;
+		const originalRequesterPublish = requesterRemoteBlocks.options.publish;
+		const originalProviderPublish = providerRemoteBlocks.options.publish;
+		let requestsToProvider = 0;
+		const staleRequestSeen = pDefer<void>();
+
+		requesterRemoteBlocks.options.publish = async (message: any, options: any) => {
+			if (message instanceof BlockRequest) {
+				const to = (options?.mode as any)?.to ?? [];
+				if (to.includes(store(session, 2).publicKeyHash)) {
+					staleRequestSeen.resolve();
+				}
+				if (to.includes(store(session, 0).publicKeyHash)) {
+					requestsToProvider++;
+					await providerRemoteBlocks.onMessage(message, {
+						from: store(session, 1).publicKeyHash,
+					});
+				}
+				return;
+			}
+			return originalRequesterPublish(message, options);
+		};
+
+		providerRemoteBlocks.options.publish = async (message: any, options: any) => {
+			if (message instanceof BlockResponse) {
+				const to = (options?.to ?? (options?.mode as any)?.to ?? []) as string[];
+				if (to.includes(store(session, 1).publicKeyHash)) {
+					await requesterRemoteBlocks.onMessage(message, {
+						from: store(session, 0).publicKeyHash,
+					});
+				}
+				return;
+			}
+			return originalProviderPublish(message, options);
+		};
+
+		try {
+			const staleRead = store(session, 1).get(cid, {
+				remote: {
+					timeout: 5_000,
+					from: [store(session, 2).publicKeyHash],
+				},
+			});
+
+			await staleRequestSeen.promise;
+
+			const widenedRead = store(session, 1).get(cid, {
+				remote: {
+					timeout: 5_000,
+					from: [store(session, 0).publicKeyHash],
+				},
+			});
+
+			const read = await widenedRead;
+			expect(new Uint8Array(read!)).to.deep.equal(data);
+			expect(new Uint8Array((await staleRead)!)).to.deep.equal(data);
+			expect(requestsToProvider).to.equal(1);
+		} finally {
+			requesterRemoteBlocks.options.publish = originalRequesterPublish;
+			providerRemoteBlocks.options.publish = originalProviderPublish;
+		}
+	});
+
 	it("probes additional explicit providers when the first candidate does not answer", async () => {
 		session = await TestSession.disconnected(3, {
 			services: { blocks: (c) => new DirectBlock(c) },


### PR DESCRIPTION
## Summary
- let `RemoteBlocks` keep mutable in-flight read state per CID instead of only an opaque promise
- merge later explicit provider hints into an existing CID read and publish to those newly supplied providers immediately
- keep retry budgets for timer/reachability retries, but allow fresh provider information to wake an in-flight request without waiting for the retry timer
- add a regression where a stale explicit provider starts a read and a later caller supplies the actual provider for the same CID
- update the shared-log churn repair regression harness to drop the selected hash at the actual churn repair push path, instead of depending on a rateless maybe-sync path that the current leave repair does not always use

## Verification
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/blocks -- -t node --grep "widens an in-flight read"` (failed before the fix, passed after)
- `pnpm --filter @peerbit/blocks test -- -t node`
- `pnpm run build`
- `pnpm run test:part-3`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "repairs redistributed entry when churn repair misses one hash"`
- `git diff --check`

## Notes
- `pnpm --filter @peerbit/blocks lint` still fails on existing package-wide style configuration issues in untouched files, so it is not a useful signal for this patch.
