### PR TITLE
Fix Nightly pubsub sim stream cleanup

### DIFF
--- a/.github/workflows/nightly-sims.yml
+++ b/.github/workflows/nightly-sims.yml
@@ -41,15 +41,18 @@ jobs:
 
       - name: Run fanout-tree-sim (scale-5k)
         run: |
+          set -euo pipefail
           mkdir -p sim-results
           pnpm -C packages/transport/pubsub run bench -- fanout-tree-sim --preset scale-5k --profile 1 --progress 1 --timeoutMs 1200000 2>&1 | tee sim-results/fanout-tree-scale-5k.txt
 
       - name: Run fanout-peerbit-sim (scale-1k)
         run: |
+          set -euo pipefail
           pnpm -C packages/clients/test-utils run bench -- fanout-peerbit-sim --preset scale-1k --seed 1 > sim-results/fanout-peerbit-scale-1k.txt
 
       - name: Run DirectSub topic-sim (500 nodes)
         run: |
+          set -euo pipefail
           pnpm -C packages/transport/pubsub run bench -- topic-sim \
             --nodes 500 --degree 6 --subscribers 400 \
             --messages 50 --msgSize 256 --intervalMs 0 \

--- a/packages/transport/libp2p-test-utils/src/inmemory-libp2p.ts
+++ b/packages/transport/libp2p-test-utils/src/inmemory-libp2p.ts
@@ -183,6 +183,7 @@ class InMemoryStream extends EventTarget {
 	private readonly recordSend?: (encodedFrame: Uint8Array) => void;
 	private readonly shouldDrop?: (encodedFrame: Uint8Array) => boolean;
 	private readonly recordDrop?: (encodedFrame: Uint8Array) => void;
+	private readonly onClose?: (stream: InMemoryStream) => void;
 
 	constructor(opts: {
 		id: string;
@@ -192,6 +193,7 @@ class InMemoryStream extends EventTarget {
 		recordSend?: (encodedFrame: Uint8Array) => void;
 		shouldDrop?: (encodedFrame: Uint8Array) => boolean;
 		recordDrop?: (encodedFrame: Uint8Array) => void;
+		onClose?: (stream: InMemoryStream) => void;
 		rxDelayMs?: number;
 	}) {
 		super();
@@ -201,6 +203,7 @@ class InMemoryStream extends EventTarget {
 		this.recordSend = opts.recordSend;
 		this.shouldDrop = opts.shouldDrop;
 		this.recordDrop = opts.recordDrop;
+		this.onClose = opts.onClose;
 		this.rxDelayMs = opts.rxDelayMs ?? 0;
 		this.highWaterMark = opts.highWaterMarkBytes ?? 256 * 1024;
 		this.lowWaterMark = Math.floor(this.highWaterMark / 2);
@@ -253,6 +256,7 @@ class InMemoryStream extends EventTarget {
 
 			const remote = this.peer;
 			if (!remote) throw new Error("Missing remote stream endpoint");
+			if (remote.closed) throw new Error("Remote stream endpoint is closed");
 			remote.bufferedBytes += frame.byteLength;
 			remote.inbound.push(frame);
 			if (remote.bufferedBytes > remote.highWaterMark) {
@@ -283,6 +287,9 @@ class InMemoryStream extends EventTarget {
 		if (!remote) {
 			throw new Error("Missing remote stream endpoint");
 		}
+		if (remote.closed) {
+			throw new Error("Remote stream endpoint is closed");
+		}
 		remote.bufferedBytes += data.byteLength;
 		remote.inbound.push(data);
 		if (remote.bufferedBytes > remote.highWaterMark) {
@@ -293,17 +300,23 @@ class InMemoryStream extends EventTarget {
 	}
 
 	abort(_err?: any): void {
-		if (this.closed) return;
-		this.closed = true;
-		try {
-			this.inbound.end();
-		} catch {}
-		this.dispatchEvent(new Event("close"));
+		this.closeLocal();
+		this.peer?.closeLocal();
 	}
 
 	close(_opts?: AbortOptions): Promise<void> {
 		this.abort();
 		return Promise.resolve();
+	}
+
+	private closeLocal(): void {
+		if (this.closed) return;
+		this.closed = true;
+		try {
+			this.inbound.end();
+		} catch {}
+		this.onClose?.(this);
+		this.dispatchEvent(new Event("close"));
 	}
 }
 
@@ -362,6 +375,11 @@ class InMemoryConnection {
 		this.pair = pair;
 	}
 
+	_removeStream(stream: Stream) {
+		const index = this.streams.indexOf(stream);
+		if (index !== -1) this.streams.splice(index, 1);
+	}
+
 	async newStream(
 		protocols: string | string[],
 		opts?: { signal?: AbortSignal; negotiateFully?: boolean },
@@ -402,6 +420,7 @@ class InMemoryConnection {
 			recordSend: this.recordSend,
 			shouldDrop: this.shouldDrop,
 			recordDrop: this.recordDrop,
+			onClose: (stream) => this._removeStream(stream as any),
 			highWaterMarkBytes: this.streamHighWaterMarkBytes,
 		});
 		const inbound = new InMemoryStream({
@@ -409,6 +428,7 @@ class InMemoryConnection {
 			protocol,
 			direction: "inbound",
 			highWaterMarkBytes: this.streamHighWaterMarkBytes,
+			onClose: (stream) => remoteConn._removeStream(stream as any),
 			rxDelayMs: this.streamRxDelayMs,
 		});
 
@@ -441,7 +461,7 @@ class InMemoryConnection {
 		if (this.status !== "open") return;
 		this.status = "closed";
 		this.timeline.close = Date.now();
-		for (const s of this.streams) {
+		for (const s of [...this.streams]) {
 			try {
 				s.close?.();
 			} catch {}

--- a/packages/transport/libp2p-test-utils/test/index.spec.ts
+++ b/packages/transport/libp2p-test-utils/test/index.spec.ts
@@ -1,6 +1,96 @@
+import { expect } from "chai";
 import { TestSession } from "../src/session.js";
+import {
+	InMemoryConnectionManager,
+	InMemoryNetwork,
+} from "../src/inmemory-libp2p.js";
 
 it("connect", async () => {
 	const session = await TestSession.connected(3);
 	await session.stop();
+});
+
+it("removes in-memory streams from both connections when a stream closes", async () => {
+	const network = new InMemoryNetwork();
+	const { runtime: a } = InMemoryNetwork.createPeer({
+		index: 0,
+		port: 34_000,
+		network,
+	});
+	const { runtime: b } = InMemoryNetwork.createPeer({
+		index: 1,
+		port: 34_001,
+		network,
+	});
+
+	a.connectionManager = new InMemoryConnectionManager(network, a);
+	b.connectionManager = new InMemoryConnectionManager(network, b);
+	network.registerPeer(a, 34_000);
+	network.registerPeer(b, 34_001);
+
+	const protocol = "/proto/1.0.0";
+	await b.registrar.handle(protocol, async () => {});
+
+	const connA = await a.connectionManager.openConnection(
+		b.addressManager.getAddresses()[0]!,
+	);
+	const connB = b.connectionManager.getConnections(a.peerId)[0]!;
+	const stream = await (connA as any).newStream(protocol, {
+		negotiateFully: true,
+	});
+
+	expect((connA as any).streams).to.have.length(1);
+	expect((connB as any).streams).to.have.length(1);
+
+	await stream.close();
+
+	expect((connA as any).streams).to.have.length(0);
+	expect((connB as any).streams).to.have.length(0);
+
+	await stream.close();
+});
+
+it("rejects writes when the paired in-memory stream endpoint has closed", async () => {
+	const network = new InMemoryNetwork();
+	const { runtime: a } = InMemoryNetwork.createPeer({
+		index: 0,
+		port: 34_010,
+		network,
+	});
+	const { runtime: b } = InMemoryNetwork.createPeer({
+		index: 1,
+		port: 34_011,
+		network,
+	});
+
+	a.connectionManager = new InMemoryConnectionManager(network, a);
+	b.connectionManager = new InMemoryConnectionManager(network, b);
+	network.registerPeer(a, 34_010);
+	network.registerPeer(b, 34_011);
+
+	const protocol = "/proto/1.0.0";
+	await b.registrar.handle(protocol, async () => {});
+
+	const connA = await a.connectionManager.openConnection(
+		b.addressManager.getAddresses()[0]!,
+	);
+
+	const wholeFrameStream = await (connA as any).newStream(protocol, {
+		negotiateFully: true,
+	});
+	wholeFrameStream.peer.closeLocal();
+	expect(() => wholeFrameStream.send(new Uint8Array([0x01, 0x00]))).to.throw(
+		"Remote stream endpoint is closed",
+	);
+	await wholeFrameStream.close();
+
+	const splitFrameStream = await (connA as any).newStream(protocol, {
+		negotiateFully: true,
+	});
+	expect(splitFrameStream.send(new Uint8Array([1]))).to.equal(true);
+	splitFrameStream.peer.closeLocal();
+	expect(() => splitFrameStream.send(new Uint8Array([0x01]))).to.throw(
+		"Remote stream endpoint is closed",
+	);
+	await splitFrameStream.close();
 });


### PR DESCRIPTION
## Summary
- remove closed in-memory stream endpoints from both connection.streams arrays
- propagate in-memory stream close to the paired endpoint so readers are released
- make PubSub Nightly sim shell steps fail on piped command failures

## Validation
- pnpm --filter @peerbit/libp2p-test-utils test
- pnpm --filter @peerbit/test-utils build
- pnpm --filter @peerbit/pubsub... run build
- pnpm -C packages/clients/test-utils run bench -- fanout-peerbit-sim --preset ci-small --seed 1
- pnpm -C packages/clients/test-utils run bench -- fanout-peerbit-sim --nodes 150 --degree 6 --subscribers 120 --messages 40 --msgRate 40 --settleMs 1000 --timeoutMs 120000 --seed 2
- git diff --check