### PR TITLE
fix(document): query connected peers during cold-start search

### DIFF
--- a/packages/programs/acl/trusted-network/test/index.spec.ts
+++ b/packages/programs/acl/trusted-network/test/index.spec.ts
@@ -15,8 +15,10 @@ import {
 	TrustedNetwork,
 	createIdentityGraphStore,
 	getFromByTo,
+	getFromByToLocalOnly,
 	getPathGenerator,
 	getToByFrom,
+	getToByFromLocalOnly,
 } from "../src/index.js";
 
 const createIdentity = async () => {
@@ -89,19 +91,19 @@ describe("index", () => {
 			await store.relationGraph.put(bc);
 
 			// Get relations one by one
-			const trustingC = await getFromByTo.resolve(c, store.relationGraph);
+			const trustingC = await getFromByToLocalOnly.resolve(c, store.relationGraph);
 			expect(trustingC).to.have.length(1);
 			expect(trustingC[0].id).to.deep.equal(bc.id);
 
-			const bIsTrusting = await getToByFrom.resolve(b, store.relationGraph);
+			const bIsTrusting = await getToByFromLocalOnly.resolve(b, store.relationGraph);
 			expect(bIsTrusting).to.have.length(1);
 			expect(bIsTrusting[0].id).to.deep.equal(bc.id);
 
-			const trustingB = await getFromByTo.resolve(b, store.relationGraph);
+			const trustingB = await getFromByToLocalOnly.resolve(b, store.relationGraph);
 			expect(trustingB).to.have.length(1);
 			expect(trustingB[0].id).to.deep.equal(ab.id);
 
-			const aIsTrusting = await getToByFrom.resolve(a, store.relationGraph);
+			const aIsTrusting = await getToByFromLocalOnly.resolve(a, store.relationGraph);
 			expect(aIsTrusting).to.have.length(1);
 			expect(aIsTrusting[0].id).to.deep.equal(ab.id);
 
@@ -110,7 +112,7 @@ describe("index", () => {
 			for await (const relation of getPathGenerator(
 				c,
 				store.relationGraph,
-				getFromByTo,
+				getFromByToLocalOnly,
 			)) {
 				relationsFromGeneratorFromByTo.push(relation);
 			}
@@ -122,7 +124,7 @@ describe("index", () => {
 			for await (const relation of getPathGenerator(
 				a,
 				store.relationGraph,
-				getToByFrom,
+				getToByFromLocalOnly,
 			)) {
 				relationsFromGeneratorToByFrom.push(relation);
 			}
@@ -147,12 +149,12 @@ describe("index", () => {
 
 			await store.relationGraph.put(ab);
 
-			let trustingB = await getFromByTo.resolve(b, store.relationGraph);
+			let trustingB = await getFromByToLocalOnly.resolve(b, store.relationGraph);
 			expect(trustingB).to.have.length(1);
 			expect(trustingB[0].id).to.deep.equal(ab.id);
 
 			await store.relationGraph.del(ab.id);
-			trustingB = await getFromByTo.resolve(b, store.relationGraph);
+			trustingB = await getFromByToLocalOnly.resolve(b, store.relationGraph);
 			expect(trustingB).to.be.empty;
 		});
 

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -2451,6 +2451,7 @@ export class DocumentIndex<
 				const isDefaultDomainArgs =
 					!("range" in coverProps) &&
 					(!("args" in coverProps) || (coverProps as any).args == null);
+				const remoteWasExplicit = options?.remote != null;
 
 				let replicatorGroups = options?.remote?.from
 					? options?.remote?.from
@@ -2461,10 +2462,10 @@ export class DocumentIndex<
 							signal: options?.signal,
 						});
 
-					// Cold start: cover can be temporarily empty/self-only while replication metadata
-					// converges. For remote search, it's sometimes better to at least try currently
-					// connected peers, but only if we have evidence that a remote replicator exists.
-					if (!options?.remote?.from && isDefaultDomainArgs) {
+					// Cold start: cover can be temporarily self-only while replication metadata
+					// converges. For explicit remote searches, query bounded connected peers
+					// instead of waiting for replicator metadata to catch up.
+					if (!options?.remote?.from && isDefaultDomainArgs && remoteWasExplicit) {
 						const selfHash = this.node.identity.publicKey.hashcode();
 						const remoteCount = replicatorGroups.filter((h) => h !== selfHash).length;
 						if (remoteCount === 0) {
@@ -2474,25 +2475,7 @@ export class DocumentIndex<
 
 							// If the cover is explicitly empty (no shards), don't override it unless
 							// the caller requested waiting for joins (e.g. get(waitFor)).
-							if (!waitEnabled && !coverIsSelfOnly) {
-								// no-op
-							} else {
-							let hasKnownRemoteReplicator = false;
-							if (!waitEnabled) {
-								try {
-									const replicators = await this._log.getReplicators();
-									for (const hash of replicators.keys()) {
-										if (hash !== selfHash) {
-											hasKnownRemoteReplicator = true;
-											break;
-										}
-									}
-								} catch {
-									// Best-effort only.
-								}
-							}
-
-							if (waitEnabled || hasKnownRemoteReplicator) {
+							if (waitEnabled || coverIsSelfOnly) {
 								const peerMap: Map<string, unknown> | undefined = (this.node.services
 									.pubsub as any)?.peers;
 								if (peerMap?.keys) {
@@ -2509,7 +2492,6 @@ export class DocumentIndex<
 									}
 								}
 							}
-						}
 						}
 					}
 

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -3626,6 +3626,61 @@ describe("index", () => {
 							expect(writer.docs.index.hasPending).to.be.false;
 					});
 
+					it("remote search queries connected peers while replicator metadata is self-only", async function () {
+						this.timeout(120_000);
+
+						const { observer, writer } = await writerObserverSetup();
+						const document = new Document({ id: "connected-peer-self-only" });
+						await writer.docs.put(document);
+
+						await session.connect();
+						await observer.docs.index.waitFor(writer.node.identity.publicKey);
+
+						const writerHash = writer.node.identity.publicKey.hashcode();
+						await waitForResolved(
+							async () => {
+								const peers = (session.peers[0].services.pubsub as TopicControlPlane)
+									.peers;
+								expect(peers.has(writerHash)).to.equal(true);
+							},
+							{ timeout: 30_000, delayInterval: 100 },
+						);
+
+						const selfHash = observer.node.identity.publicKey.hashcode();
+						const originalGetCover = observer.docs.log.getCover.bind(
+							observer.docs.log,
+						);
+						const originalGetReplicators =
+							observer.docs.log.getReplicators.bind(observer.docs.log);
+
+						(observer.docs.log.getCover as typeof observer.docs.log.getCover) =
+							(async () => [selfHash]) as typeof observer.docs.log.getCover;
+						(
+							observer.docs.log.getReplicators as typeof observer.docs.log.getReplicators
+						) = (async () => {
+							const replicators = await originalGetReplicators();
+							for (const hash of [...replicators.keys()]) {
+								if (hash !== selfHash) {
+									replicators.delete(hash);
+								}
+							}
+							return replicators;
+						}) as typeof observer.docs.log.getReplicators;
+
+						try {
+							const result = await observer.docs.index.get(toId(document.id), {
+								remote: { throwOnMissing: false },
+							});
+							expect(result?.id).to.equal(document.id);
+						} finally {
+							(observer.docs.log.getCover as typeof observer.docs.log.getCover) =
+								originalGetCover as typeof observer.docs.log.getCover;
+							(
+								observer.docs.log.getReplicators as typeof observer.docs.log.getReplicators
+							) = originalGetReplicators as typeof observer.docs.log.getReplicators;
+						}
+					});
+
 					it("late join will not re-open iterator", async () => {
 						session = await TestSession.disconnected(2);
 


### PR DESCRIPTION
## Summary
- query bounded connected pubsub peers when an explicit default-domain remote document search sees a temporarily self-only cover
- avoid applying that cold-start fallback to implicit graph/index searches, so local lookups do not wait on unrelated connected peers
- add a document regression for self-only getCover/getReplicators with a connected writer
- keep trusted-network pure local graph tests on existing local-only resolvers; the observer test still covers remote resolver behavior

## Verification
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "remote search queries connected peers while replicator metadata is self-only|keep-open search recovers connected peers missing from replicator refresh"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "remote search queries connected peers while replicator metadata is self-only"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/acl/trusted-network -- -t node --grep "identity-graph|path|can revoke"
- pnpm run build