### PR TITLE
fix(stream): materialize list-like message payloads

### DIFF
--- a/packages/clients/peerbit/test/connect.spec.ts
+++ b/packages/clients/peerbit/test/connect.spec.ts
@@ -18,9 +18,13 @@ describe(`dial`, function () {
 	if (isNode) {
 		it("waits for blocks", async () => {
 			const cid = await clients[0].services.blocks.put(new Uint8Array([1]));
-			await clients[0].dial(clients[1].getMultiaddrs()[0]);
+			await clients[1].dial(clients[0].getMultiaddrs()[0]);
 			expect(
-				new Uint8Array((await clients[0].services.blocks.get(cid))!),
+				new Uint8Array(
+					(await clients[1].services.blocks.get(cid, {
+						remote: { timeout: 10_000 },
+					}))!,
+				),
 			).to.deep.equal(new Uint8Array([1]));
 		});
 

--- a/packages/transport/stream-interface/src/messages.ts
+++ b/packages/transport/stream-interface/src/messages.ts
@@ -715,7 +715,7 @@ export class DataMessage<
 	}
 
 	get data(): Uint8Array | undefined {
-		if (this._data == null && this._dataBytes instanceof Uint8ArrayList) {
+		if (this._data == null && this._dataBytes != null) {
 			this._data = this._dataBytes.subarray();
 		}
 		return this._data;

--- a/packages/transport/stream/test/messages-signing.spec.ts
+++ b/packages/transport/stream/test/messages-signing.spec.ts
@@ -179,6 +179,30 @@ describe("message signing", () => {
 		expect(Array.from(decoded.data!)).to.deep.equal(Array.from(payload));
 	});
 
+	it("materializes payloads from list-like byte sources", () => {
+		const payload = new Uint8Array([31, 32, 33, 34]);
+		const decoded = new DataMessage({
+			header: new MessageHeader({
+				session: 1,
+				mode: new SilentDelivery({
+					to: ["peer-a"],
+					redundancy: 1,
+				}),
+			}),
+			data: payload,
+		});
+		const decodedAny = decoded as any;
+
+		decodedAny._data = undefined;
+		decodedAny._dataBytes = {
+			byteLength: payload.byteLength,
+			subarray: () => payload,
+		};
+
+		expect(decoded.hasData).to.equal(true);
+		expect(Array.from(decoded.data!)).to.deep.equal(Array.from(payload));
+	});
+
 	it("caches prepared signable sha256 bytes for a data-message", async () => {
 		const message = new DataMessage({
 			header: new MessageHeader({


### PR DESCRIPTION
## Summary
- materialize DataMessage payloads from any stored byte source with subarray(), avoiding constructor-instance checks across duplicate uint8arraylist copies
- tighten Peerbit dial block test so a remote peer actually fetches the writer's block
- add a regression for list-like DataMessage payload materialization

## Verification
- pnpm --filter @peerbit/stream-interface run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/stream -- -t node --grep "materializes payloads from list-like byte sources|decodes segmented payloads lazily"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/clients/peerbit -- -t node --grep "waits for blocks"