### PR TITLE
fix(pubsub): normalize byte sources across package boundaries

### DIFF
--- a/packages/transport/pubsub/src/bytes.ts
+++ b/packages/transport/pubsub/src/bytes.ts
@@ -1,0 +1,33 @@
+import type { Uint8ArrayList } from "uint8arraylist";
+
+export type ByteListLike = {
+	byteLength: number;
+	subarray(start?: number, end?: number): Uint8Array;
+};
+
+export const normalizeUint8Array = (bytes: unknown): Uint8Array | undefined => {
+	if (bytes instanceof Uint8Array) {
+		return bytes;
+	}
+	if (ArrayBuffer.isView(bytes)) {
+		return new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+	}
+	if (
+		bytes &&
+		typeof bytes === "object" &&
+		typeof (bytes as ByteListLike).subarray === "function"
+	) {
+		return normalizeUint8Array((bytes as ByteListLike).subarray());
+	}
+	return undefined;
+};
+
+export const toUint8Array = (
+	arr: Uint8Array | Uint8ArrayList | ByteListLike,
+): Uint8Array => {
+	const normalized = normalizeUint8Array(arr);
+	if (!normalized) {
+		throw new Error("Expected byte source");
+	}
+	return normalized;
+};

--- a/packages/transport/pubsub/src/fanout-tree.ts
+++ b/packages/transport/pubsub/src/fanout-tree.ts
@@ -17,6 +17,7 @@ import {
 import { AbortError, TimeoutError, delay } from "@peerbit/time";
 import { anySignal } from "any-signal";
 import { Uint8ArrayList } from "uint8arraylist";
+import { normalizeUint8Array, toUint8Array } from "./bytes.js";
 import { TopicRootControlPlane } from "./topic-root-control-plane.js";
 
 export type FanoutTreeChannelId = {
@@ -4830,8 +4831,8 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			const out: Uint8Array[] = [];
 			for (const a of addresses) {
 				const ma: any = a?.multiaddr ?? a;
-				const bytes: Uint8Array | undefined = ma?.bytes;
-				if (!(bytes instanceof Uint8Array)) continue;
+				const bytes = normalizeUint8Array(ma?.bytes);
+				if (!bytes) continue;
 				out.push(bytes);
 				if (out.length >= JOIN_REJECT_REDIRECT_ADDR_MAX) break;
 			}
@@ -5559,7 +5560,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 	) {
 		const ignore = this.shouldIgnore(message, seenBefore);
 		const raw = message.data as Uint8ArrayList | Uint8Array | undefined;
-		const data = raw instanceof Uint8ArrayList ? raw.subarray() : raw;
+		const data = raw ? toUint8Array(raw) : undefined;
 		if (!data || data.length === 0) return false;
 
 			const kind = data[0]!;
@@ -5639,8 +5640,8 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 						const addresses: any[] = Array.isArray(peer?.addresses) ? peer.addresses : [];
 						for (const a of addresses) {
 							const ma: any = a?.multiaddr ?? a;
-							const bytes: Uint8Array | undefined = ma?.bytes;
-							if (bytes instanceof Uint8Array) addrs.push(bytes);
+							const bytes = normalizeUint8Array(ma?.bytes);
+							if (bytes) addrs.push(bytes);
 							if (addrs.length >= 16) break;
 						}
 					} catch {
@@ -5784,8 +5785,8 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 								: [];
 							for (const a of addresses) {
 								const ma: any = a?.multiaddr ?? a;
-								const bytes: Uint8Array | undefined = ma?.bytes;
-								if (bytes instanceof Uint8Array) addrs.push(bytes);
+								const bytes = normalizeUint8Array(ma?.bytes);
+								if (bytes) addrs.push(bytes);
 								if (addrs.length >= 16) break;
 							}
 						} catch {

--- a/packages/transport/pubsub/src/index.ts
+++ b/packages/transport/pubsub/src/index.ts
@@ -49,6 +49,7 @@ import {
 } from "@peerbit/stream-interface";
 import { AbortError, TimeoutError, delay } from "@peerbit/time";
 import { Uint8ArrayList } from "uint8arraylist";
+import { toUint8Array } from "./bytes.js";
 import {
 	type DebouncedAccumulatorCounterMap,
 	debouncedAccumulatorSetCounter,
@@ -65,9 +66,7 @@ import { TopicRootControlPlane } from "./topic-root-control-plane.js";
 export * from "./fanout-tree.js";
 export * from "./fanout-channel.js";
 export * from "./topic-root-control-plane.js";
-
-export const toUint8Array = (arr: Uint8ArrayList | Uint8Array) =>
-	arr instanceof Uint8ArrayList ? arr.subarray() : arr;
+export { toUint8Array } from "./bytes.js";
 
 export const logger = loggerFn("peerbit:transport:topic-control-plane");
 const warn = logger.newScope("warn");

--- a/packages/transport/pubsub/test/index.spec.ts
+++ b/packages/transport/pubsub/test/index.spec.ts
@@ -1,9 +1,38 @@
 import { AbortError, TimeoutError } from "@peerbit/time";
 import { expect } from "chai";
+import { runInNewContext } from "node:vm";
 import sinon from "sinon";
-import { waitForSubscribers } from "../src/index.js";
+import { normalizeUint8Array } from "../src/bytes.js";
+import { toUint8Array, waitForSubscribers } from "../src/index.js";
 
 describe("pubsub", function () {
+	describe("byte normalization", () => {
+		it("materializes list-like byte sources without relying on Uint8ArrayList identity", () => {
+			const payload = new Uint8Array([1, 2, 3]);
+			const listLike = {
+				byteLength: payload.byteLength,
+				subarray: () => payload,
+			};
+
+			expect(toUint8Array(listLike)).to.equal(payload);
+		});
+
+		it("normalizes cross-realm and view-backed bytes to local Uint8Array", () => {
+			const foreignBytes = runInNewContext("new Uint8Array([4, 5, 6])");
+			const normalizedForeign = normalizeUint8Array(foreignBytes);
+
+			expect(normalizedForeign).to.be.instanceOf(Uint8Array);
+			expect([...normalizedForeign!]).to.deep.equal([4, 5, 6]);
+
+			const backing = new Uint8Array([0, 7, 8, 0]);
+			const view = new DataView(backing.buffer, 1, 2);
+			const normalizedView = normalizeUint8Array(view);
+
+			expect(normalizedView).to.be.instanceOf(Uint8Array);
+			expect([...normalizedView!]).to.deep.equal([7, 8]);
+		});
+	});
+
 	describe("waitForSubscribers", () => {
 		let clock: ReturnType<typeof sinon.useFakeTimers>;
 


### PR DESCRIPTION
## Summary
- add a shared pubsub byte normalizer for list-like byte sources and cross-realm typed-array views
- stop relying on `instanceof Uint8ArrayList` when materializing fanout data payloads
- accept normalized typed-array views for fanout peer-store multiaddr bytes instead of dropping anything that fails local `Uint8Array` identity

## Verification
- node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/pubsub -- -t node --grep "byte normalization"
- pnpm --filter @peerbit/pubsub test

Note: `pnpm --filter @peerbit/pubsub lint` still fails on pre-existing package-wide style violations in unchanged files; I did not include those unrelated rewrites.