### PR TITLE
Classify fanout attachment timeout as delivery timeout

### DIFF
--- a/packages/transport/pubsub/src/fanout-tree.ts
+++ b/packages/transport/pubsub/src/fanout-tree.ts
@@ -3576,7 +3576,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 				if (resolveIfAttached()) return;
 				cleanup();
 				reject(
-					new Error(
+					new TimeoutError(
 						`fanout proxy publish timed out waiting for attachment (topic=${ch.id.topic} root=${ch.id.root} self=${this.publicKeyHash})`,
 					),
 				);

--- a/packages/transport/pubsub/test/fanout-tree.spec.ts
+++ b/packages/transport/pubsub/test/fanout-tree.spec.ts
@@ -1,5 +1,5 @@
 import { TestSession } from "@peerbit/libp2p-test-utils";
-import { delay, waitForResolved } from "@peerbit/time";
+import { TimeoutError, delay, waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
 import { FanoutChannel, FanoutTree } from "../src/index.js";
 
@@ -184,6 +184,31 @@ describe("fanout-tree", () => {
 
 				await waitForChannelAttachment(ch, 25);
 				expect(ch.parent).to.equal("parent");
+			} finally {
+				await session.stop();
+			}
+		});
+
+		it("reports attachment waits as delivery timeouts", async () => {
+			const session: TestSession<{ fanout: FanoutTree }> =
+				await createFanoutTestSession(1);
+
+			try {
+				const fanout = session.peers[0].services.fanout as any;
+				const waitForChannelAttachment = fanout.waitForChannelAttachment.bind(fanout) as (
+					ch: any,
+					timeoutMs: number,
+				) => Promise<void>;
+				const ch = {
+					isRoot: false,
+					parent: undefined as string | undefined,
+					id: { topic: "attachment-timeout", root: "root" },
+				};
+
+				await expect(waitForChannelAttachment(ch, 5)).to.be.rejectedWith(
+					TimeoutError,
+					"fanout proxy publish timed out waiting for attachment",
+				);
 			} finally {
 				await session.stop();
 			}


### PR DESCRIPTION
## Summary
- Return a TimeoutError when fanout proxy publish waits too long for channel attachment
- Keeps transient attachment churn on the existing delivery-error path instead of surfacing as an unexpected page/runtime error
- Add regression coverage for the attachment wait classification

## Verification
- node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/pubsub -- -t node --grep "reports attachment waits as delivery timeouts"