### PR TITLE
fix(log): do not cache missing entries

### DIFF
--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -654,7 +654,9 @@ export class EntryIndex<T> {
 			} else if (coercedOptions?.ignoreMissing !== true) {
 				throw new Error("Failed to load entry from head with hash: " + k);
 			}
-			this.cache.add(k, mem ?? undefined);
+			if (mem) {
+				this.cache.add(k, mem);
+			}
 		}
 		return mem ? mem : undefined;
 		/* }

--- a/packages/log/test/log.spec.ts
+++ b/packages/log/test/log.spec.ts
@@ -99,6 +99,40 @@ describe("properties", function () {
 			assert.deepStrictEqual(entry, undefined);
 		});
 
+		it("rechecks storage after a previous miss", async () => {
+			const sourceStore = new AnyBlockStore();
+			const targetStore = new AnyBlockStore();
+			await Promise.all([sourceStore.start(), targetStore.start()]);
+
+			const sourceLog = new Log<string>();
+			const targetLog = new Log<string>();
+			try {
+				await sourceLog.open(sourceStore, signKey, {
+					encoding: JSON_ENCODING,
+				});
+				await targetLog.open(targetStore, signKey, {
+					encoding: JSON_ENCODING,
+				});
+
+				const { entry } = await sourceLog.append("late");
+				const encodedEntry = await sourceStore.get(entry.hash);
+				expect(encodedEntry).to.exist;
+
+				expect(await targetLog.get(entry.hash)).to.equal(undefined);
+				expect(await targetStore.put(encodedEntry!)).to.equal(entry.hash);
+
+				const resolved = await targetLog.get(entry.hash);
+				expect(await resolved?.getPayloadValue()).to.equal("late");
+			} finally {
+				await Promise.all([
+					sourceLog.close(),
+					targetLog.close(),
+					sourceStore.stop(),
+					targetStore.stop(),
+				]);
+			}
+		});
+
 		it("does not fetch from remotes by if missing block by default", async () => {
 			const storeGetFn = store.get.bind(store);
 			let remoteFetchOptions: any = undefined;


### PR DESCRIPTION
## Summary
- stop caching missing log entries as negative cache hits
- add a regression proving a later block write can resolve after an earlier miss

## Verification
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "rechecks storage after a previous miss"
- pnpm --filter @peerbit/log test
- pnpm run build