### PR TITLE
fix(stream): stabilize delivery error identity

### DIFF
--- a/packages/transport/stream-interface/src/index.ts
+++ b/packages/transport/stream-interface/src/index.ts
@@ -63,8 +63,19 @@ export interface PublicKeyFromHashResolver {
 export class NotStartedError extends Error {
 	constructor() {
 		super("Not started");
+		this.name = "NotStartedError";
 	}
 }
 
-export class DeliveryError extends Error {}
-export class InvalidMessageError extends Error {}
+export class DeliveryError extends Error {
+	constructor(message?: string) {
+		super(message);
+		this.name = "DeliveryError";
+	}
+}
+export class InvalidMessageError extends Error {
+	constructor(message?: string) {
+		super(message);
+		this.name = "InvalidMessageError";
+	}
+}

--- a/packages/transport/stream/src/index.ts
+++ b/packages/transport/stream/src/index.ts
@@ -97,11 +97,18 @@ const warn = logger.newScope("warn");
 
 export { BandwidthTracker }; // might be useful for others
 
+const getErrorName = (e: any): string | undefined =>
+	e?.name ?? e?.constructor?.name;
+
 export const dontThrowIfDeliveryError = (e: any) => {
+	const errorName = getErrorName(e);
 	if (
 		e instanceof DeliveryError ||
 		e instanceof TimeoutError ||
-		e instanceof AbortError
+		e instanceof AbortError ||
+		errorName === "DeliveryError" ||
+		errorName === "TimeoutError" ||
+		errorName === "AbortError"
 	) {
 		return;
 	}

--- a/packages/transport/stream/test/errors.spec.ts
+++ b/packages/transport/stream/test/errors.spec.ts
@@ -1,0 +1,26 @@
+import { expect } from "chai";
+import {
+	DeliveryError,
+	InvalidMessageError,
+	NotStartedError,
+} from "@peerbit/stream-interface";
+import { dontThrowIfDeliveryError } from "../src/index.js";
+
+describe("stream errors", () => {
+	it("uses stable error names", () => {
+		expect(new DeliveryError("failed").name).to.equal("DeliveryError");
+		expect(new InvalidMessageError("invalid").name).to.equal(
+			"InvalidMessageError",
+		);
+		expect(new NotStartedError().name).to.equal("NotStartedError");
+	});
+
+	it("recognizes delivery errors from other module identities", () => {
+		const foreignDeliveryError = new Error("delivery failed");
+		foreignDeliveryError.name = "DeliveryError";
+
+		expect(() => dontThrowIfDeliveryError(foreignDeliveryError)).to.not.throw();
+		expect(() => dontThrowIfDeliveryError(new DeliveryError("local"))).to.not.throw();
+		expect(() => dontThrowIfDeliveryError(new Error("boom"))).to.throw("boom");
+	});
+});


### PR DESCRIPTION
## Summary
- assign stable names to stream-interface error classes
- recognize delivery/timeout/abort errors by stable name as well as instanceof
- add regression coverage for cross-module delivery errors

## Why
The file-share two-runner 50 MiB benchmark reached chunk download progress, then failed from an unhandled delivery error whose constructor name was minified instead of DeliveryError. These errors are intentionally best-effort in several delivery paths, so the classifier needs to survive bundling and module-identity boundaries without adding retries or app-level fallbacks.

## Verification
- node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/stream -- -t node --grep "stream errors"
- pnpm --filter @peerbit/stream test
- pnpm run build
