### PR TITLE
fix: stabilize file-share large transfer paths

### DIFF
--- a/packages/programs/data/document/document/benchmark/file-ingest.ts
+++ b/packages/programs/data/document/document/benchmark/file-ingest.ts
@@ -6,6 +6,7 @@ import { delay } from "@peerbit/time";
 import {
 	Documents,
 	SearchRequest,
+	SearchRequestIndexed,
 	StringMatch,
 	type SetupOptions,
 } from "../src/index.js";
@@ -45,6 +46,27 @@ type Task = {
 };
 
 const modes = ["adaptive", "fixed1"] as const satisfies readonly BenchMode[];
+const argv = process.argv.slice(2);
+const hasFlag = (name: string) => argv.includes(name);
+const getArg = (name: string) => {
+	const index = argv.indexOf(name);
+	if (index === -1) {
+		return undefined;
+	}
+	return argv[index + 1];
+};
+const modeArg = getArg("--mode");
+const selectedModes: readonly BenchMode[] =
+	modeArg == null
+		? modes
+		: modes.includes(modeArg as BenchMode)
+			? [modeArg as BenchMode]
+			: (() => {
+					throw new Error(
+						`Invalid --mode '${modeArg}'. Expected one of: ${modes.join(", ")}`,
+					);
+				})();
+const outputJson = process.env.BENCH_JSON === "1" || hasFlag("--json");
 const envInt = (name: string, fallback: number) => {
 	const value = process.env[name];
 	if (value == null) {
@@ -276,6 +298,7 @@ const waitForObserverReady = async (
 	upload: Awaited<ReturnType<typeof uploadChunkedFile>>,
 	expectedChunks: number,
 	startedAt: number,
+	debugPeers?: Record<string, string>,
 ) => {
 	const deadline = startedAt + readyTimeoutMs;
 	let entryPolls = 0;
@@ -286,6 +309,13 @@ const waitForObserverReady = async (
 	let finalManifestEntryKnownMs: number | undefined;
 	let chunkEntriesKnownMs: number | undefined;
 	let manifestReadyMs: number | undefined;
+	let lastKnownChunkEntries = 0;
+	let lastManifestFound = false;
+	let lastManifestReady = false;
+	let lastChunkResults = 0;
+	let lastChunkResponses: string[] = [];
+	const labelPeer = (hash: string | undefined) =>
+		hash ? (debugPeers?.[hash] ?? hash) : "unknown";
 
 	while (performance.now() < deadline) {
 		entryPolls += 1;
@@ -311,6 +341,8 @@ const waitForObserverReady = async (
 				}
 				remainingChunkEntries -= 1;
 			}
+			lastKnownChunkEntries =
+				upload.chunkEntryHashes.length - remainingChunkEntries;
 			if (remainingChunkEntries === 0) {
 				chunkEntriesKnownMs = performance.now() - startedAt;
 			}
@@ -330,11 +362,14 @@ const waitForObserverReady = async (
 		);
 		manifestSearchMs += performance.now() - manifestSearchStartedAt;
 		const manifest = manifests[0] as FileRecord | undefined;
+		lastManifestFound = manifest != null;
+		lastManifestReady = manifest?.ready === true;
 
 		if (manifest?.ready) {
 			manifestReadyMs ??= performance.now() - startedAt;
 			chunkPolls += 1;
 			const chunkSearchStartedAt = performance.now();
+			const chunkResponses: string[] = [];
 			const chunkResults = await observer.files.index.search(
 				new SearchRequest({
 					query: new StringMatch({
@@ -343,9 +378,20 @@ const waitForObserverReady = async (
 					}),
 					fetch: 0xffffffff,
 				}),
-				queryOptions,
+				{
+					...queryOptions,
+					onResponse: (response: any, from: any) => {
+						chunkResponses.push(
+							`${labelPeer(from?.hashcode?.())}:results=${
+								response?.results?.length ?? "?"
+							},kept=${response?.kept?.toString?.() ?? "?"}`,
+						);
+					},
+				} as any,
 			);
 			chunkSearchMs += performance.now() - chunkSearchStartedAt;
+			lastChunkResults = chunkResults.length;
+			lastChunkResponses = chunkResponses;
 			if (chunkResults.length === expectedChunks) {
 				return {
 					finalManifestEntryKnownMs:
@@ -367,9 +413,33 @@ const waitForObserverReady = async (
 	}
 
 	throw new Error(
-		`Timed out waiting for observer readiness for upload ${upload.uploadId}`,
+		`Timed out waiting for observer readiness for upload ${upload.uploadId}. ` +
+			`progress finalManifestEntryKnown=${finalManifestEntryKnownMs != null}, ` +
+			`chunkEntriesKnown=${lastKnownChunkEntries}/${upload.chunkEntryHashes.length}, ` +
+			`manifestFound=${lastManifestFound}, manifestReady=${lastManifestReady}, ` +
+			`chunkResults=${lastChunkResults}/${expectedChunks}, ` +
+			`chunkResponses=[${lastChunkResponses.join(";")}], ` +
+			`entryPolls=${entryPolls}, manifestPolls=${manifestPolls}, chunkPolls=${chunkPolls}`,
 	);
 };
+
+const countLocalChunks = async (store: FileStore, uploadId: string) =>
+	(
+		await store.files.index.search(
+			new SearchRequestIndexed({
+				query: new StringMatch({
+					key: "parentId",
+					value: uploadId,
+				}),
+				fetch: 0xffffffff,
+			}),
+			{
+				local: true,
+				remote: false,
+				resolve: false,
+			} as any,
+		)
+	).length;
 
 const waitForReplicationSetup = async (
 	writer: FileStore,
@@ -448,12 +518,38 @@ const runIteration = async (
 		);
 		const writerCompleteMs = performance.now() - startedAt;
 
-		const observerProgress = await waitForObserverReady(
-			observer,
-			upload,
-			payloadChunks.length,
-			startedAt,
-		);
+		let observerProgress: Awaited<ReturnType<typeof waitForObserverReady>>;
+		try {
+			observerProgress = await waitForObserverReady(
+				observer,
+				upload,
+				payloadChunks.length,
+				startedAt,
+				{
+					[writer.node.identity.publicKey.hashcode()]: "writer",
+					[seeder.node.identity.publicKey.hashcode()]: "seeder",
+					[observer.node.identity.publicKey.hashcode()]: "observer",
+				},
+			);
+		} catch (error) {
+			const counts = await Promise.allSettled([
+				countLocalChunks(writer, upload.uploadId),
+				countLocalChunks(seeder, upload.uploadId),
+				countLocalChunks(observer, upload.uploadId),
+			]);
+			const [writerChunks, seederChunks, observerChunks] = counts.map(
+				(result) =>
+					result.status === "fulfilled"
+						? String(result.value)
+						: `error:${result.reason?.message ?? result.reason}`,
+			);
+			const detail = `localChunks writer=${writerChunks}, seeder=${seederChunks}, observer=${observerChunks}`;
+			if (error instanceof Error) {
+				error.message = `${error.message}. ${detail}`;
+				throw error;
+			}
+			throw new Error(`${String(error)}. ${detail}`);
+		}
 
 		return {
 			writerCompleteMs,
@@ -514,7 +610,7 @@ const runMode = async (mode: BenchMode, payloadChunks: Uint8Array[]) => {
 
 const payloadChunks = makePayloadChunks();
 const results = await Promise.all(
-	modes.map(async (mode) => ({
+	selectedModes.map(async (mode) => ({
 		mode,
 		samples: await runMode(mode, payloadChunks),
 	})),
@@ -708,7 +804,7 @@ const output = {
 	},
 };
 
-if (process.env.BENCH_JSON === "1") {
+if (outputJson) {
 	await new Promise<void>((resolve, reject) => {
 		process.stdout.write(JSON.stringify(output, null, 2), (error) => {
 			if (error) {

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -1852,6 +1852,7 @@ export class DocumentIndex<
 						);
 					} else {
 						missingValues = true;
+						set.results[i] = undefined as any;
 					}
 				}
 
@@ -2074,8 +2075,11 @@ export class DocumentIndex<
 			} else {
 				const context = result.value.__context;
 				const head = await this._log.log.get(context.head);
-				// assume remote peer will start to replicate (TODO is this ideal?)
 				if (replicateIndexFlag) {
+					if (!head) {
+						continue;
+					}
+					// assume remote peer will start to replicate (TODO is this ideal?)
 					this._log.addPeersToGidPeerHistory(context.gid, [from.hashcode()]);
 				}
 
@@ -2527,11 +2531,17 @@ export class DocumentIndex<
 
 				let extraPromises: Promise<void>[] | undefined = undefined;
 
+				const seenRemoteHashes = new Set<string>();
 				const groupHashes: string[][] = replicatorGroups
 					.filter((hash) => {
 						if (hash === this.node.identity.publicKey.hashcode()) {
 							return false;
 						}
+
+						if (seenRemoteHashes.has(hash)) {
+							return false;
+						}
+						seenRemoteHashes.add(hash);
 
 						if (fetchFirstForRemote?.has(hash)) {
 							// we already fetched this one for remote, no need to do it again
@@ -3825,7 +3835,7 @@ export class DocumentIndex<
 				coercedBatch = (
 					await Promise.all(
 						batch.map(async (x) => {
-							const withContext = coerceWithContext(
+							const resolved =
 								x.value instanceof this.documentType
 									? x.value
 									: (
@@ -3833,9 +3843,11 @@ export class DocumentIndex<
 												head: x.context.head,
 												indexed: x.indexed,
 											})
-										)?.value,
-								x.context,
-							);
+										)?.value;
+							if (!resolved) {
+								return undefined;
+							}
+							const withContext = coerceWithContext(resolved, x.context);
 							const withIndexed = coerceWithIndexed(withContext, x.indexed);
 							return withIndexed;
 						}),

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -2863,6 +2863,44 @@ describe("index", () => {
 					);
 				});
 
+				it("does not advertise stale indexed rows as replicable", async () => {
+					const store = new TestStore({
+						docs: new Documents<Document>(),
+					});
+					await session.peers[0].open(store, {
+						args: {
+							replicate: {
+								factor: 1,
+							},
+							replicas: {
+								min: 1,
+							},
+							timeUntilRoleMaturity: 0,
+						},
+					});
+
+					const put = await store.docs.put(new Document({ id: "stale" }));
+					expect(await store.docs.index.getSize()).to.eq(1);
+
+					await store.docs.log.log.blocks.rm(put.entry.hash);
+					(store.docs.log.log.entryIndex as any).cache.del(put.entry.hash);
+
+					const response = await store.docs.index.processQuery(
+						new SearchRequestIndexed({
+							query: new StringMatch({
+								key: "id",
+								value: "stale",
+							}),
+							fetch: 1,
+							replicate: true,
+						}),
+						session.peers[1].identity.publicKey,
+						false,
+					);
+
+					expect(response.results).to.have.length(0);
+				});
+
 				it("will not keep if undefined", async () => {
 					const store = new TestStore({
 						docs: new Documents<Document>(),
@@ -6872,6 +6910,66 @@ describe("index", () => {
 					});
 
 					await check(store, undefined, true);
+				});
+
+				it("drops unresolved indexed placeholders when resolving iterator batches", async () => {
+					session = await TestSession.connected(1);
+
+					const store = new TestStore<Indexable>({
+						docs: new Documents<Document, Indexable>(),
+					});
+
+					await session.peers[0].open(store, {
+						args: {
+							replicate: { factor: 1 },
+							index: {
+								type: Indexable,
+								transform: (doc) => new Indexable(doc),
+							},
+						},
+					});
+
+					const doc = new Document({ id: "unresolved", name: "omega" });
+					const put = await store.docs.put(doc);
+					const indexed = Object.assign(new Indexable(doc), {
+						__context: (doc as any).__context,
+					});
+					const results = new Results({
+						results: [
+							new ResultIndexedValue({
+								context: (doc as any).__context,
+								source: serialize(indexed),
+								indexed,
+								entries: [put.entry],
+							}),
+						],
+						kept: 0n,
+					});
+					const queryCommenceStub = sinon
+						.stub(store.docs.index as any, "queryCommence")
+						.callsFake(async (_query: any, options: any) => {
+							await options?.onResponse?.(results, store.node.identity.publicKey);
+							return [results];
+						});
+					const resolveStub = sinon
+						.stub(store.docs.index as any, "resolveDocument")
+						.resolves(undefined);
+					let iterator: ReturnType<typeof store.docs.index.iterate> | undefined;
+
+					try {
+						iterator = store.docs.index.iterate(
+							{},
+							{ remote: { replicate: true } },
+						);
+
+						const batch = await iterator.next(1);
+						expect(batch).to.have.length(0);
+					} finally {
+						queryCommenceStub.restore();
+						resolveStub.restore();
+						await iterator?.close();
+						await session.stop();
+					}
 				});
 
 					it("returns documents even if indexed representation arrives first", async () => {

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -3568,7 +3568,7 @@ export class SharedLog<
 	private async pruneJoinedEntriesNoLongerLed(entries: Entry<T>[]) {
 		const selfHash = this.node.identity.publicKey.hashcode();
 		for (const entry of entries) {
-			if (this.closed || this._pendingDeletes.has(entry.hash)) {
+			if (this.closed) {
 				continue;
 			}
 
@@ -3580,6 +3580,13 @@ export class SharedLog<
 
 			if (leaders.has(selfHash)) {
 				this.pruneDebouncedFn.delete(entry.hash);
+				await this._pendingDeletes
+					.get(entry.hash)
+					?.reject(new Error("Failed to delete, is leader again"));
+				continue;
+			}
+
+			if (this._pendingDeletes.has(entry.hash)) {
 				continue;
 			}
 
@@ -3604,7 +3611,7 @@ export class SharedLog<
 				const entries = await iterator.next(REPAIR_SWEEP_ENTRY_BATCH_SIZE);
 				for (const entry of entries) {
 					const entryReplicated = entry.value;
-					if (this.closed || this._pendingDeletes.has(entryReplicated.hash)) {
+					if (this.closed) {
 						continue;
 					}
 
@@ -3620,6 +3627,10 @@ export class SharedLog<
 							.get(entryReplicated.hash)
 							?.reject(new Error("Failed to delete, is leader again"));
 						this.removePruneRequestSent(entryReplicated.hash);
+						continue;
+					}
+
+					if (this._pendingDeletes.has(entryReplicated.hash)) {
 						continue;
 					}
 

--- a/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
+++ b/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
@@ -852,9 +852,10 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 							allMissingSymbolsInRemote.push(missingSymbol);
 						}
 
-						this.simple.queueSync(allMissingSymbolsInRemote, context.from!, {
-							skipCheck: true,
-						});
+						// The IBLT decoder is based on a local snapshot. Entries can arrive via
+						// overlapping repair before we issue the follow-up simple request, so
+						// re-check local presence to avoid stale duplicate bounce-back.
+						this.simple.queueSync(allMissingSymbolsInRemote, context.from!);
 						obj.free();
 						return true;
 					};

--- a/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
+++ b/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
@@ -8,14 +8,14 @@ import {
 	Or,
 	type Query,
 } from "@peerbit/indexer-interface";
-import type { Entry, Log } from "@peerbit/log";
+import type { Entry } from "@peerbit/log";
 import { logger as loggerFn } from "@peerbit/logger";
 import {
 	DecoderWrapper,
 	EncoderWrapper,
 	ready as ribltReady,
 } from "@peerbit/riblt";
-import type { RPC, RequestContext } from "@peerbit/rpc";
+import type { RequestContext } from "@peerbit/rpc";
 import { SilentDelivery } from "@peerbit/stream-interface";
 import { type EntryWithRefs } from "../exchange-heads.js";
 import { TransportMessage } from "../message.js";

--- a/packages/programs/data/shared-log/test/rateless-iblt.spec.ts
+++ b/packages/programs/data/shared-log/test/rateless-iblt.spec.ts
@@ -13,6 +13,7 @@ import {
 	RequestAll,
 	StartSync,
 } from "../src/sync/rateless-iblt.js";
+import { RequestMaybeSyncCoordinate } from "../src/sync/simple.js";
 import { EventStore } from "./utils/stores/index.js";
 
 const setup = {
@@ -225,6 +226,61 @@ describe("rateless-iblt-syncronizer", () => {
 			expect(
 				(startSyncMessages[0] as StartSync).symbols.length,
 			).to.be.greaterThan(0);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("skips decoded remote symbols that are already present locally", async () => {
+		const sentMessages: TransportMessage[] = [];
+		let localPresenceChecks = 0;
+		const sync = new RatelessIBLTSynchronizer<"u64">({
+			rpc: {
+				send: async (message: TransportMessage) => {
+					sentMessages.push(message);
+				},
+			} as any,
+			rangeIndex: {} as any,
+			entryIndex: {
+				count: async () => {
+					localPresenceChecks += 1;
+					return 1;
+				},
+			} as any,
+			log: { has: async () => false } as any,
+			coordinateToHash: new Cache<string>({ max: 1000, ttl: 1000 }),
+			numbers: { maxValue: 2n ** 64n - 1n } as any,
+		});
+
+		(sync as any).getLocalDecoderForRange = async () => ({
+			add_coded_symbol: () => {},
+			try_decode: () => {},
+			decoded: () => true,
+			get_remote_symbols: () => [42n],
+			free: () => {},
+		});
+
+		try {
+			await sync.onMessage(
+				new StartSync({
+					from: 0n,
+					to: 100n,
+					symbols: [{ count: 0n, hash: 0n, symbol: 0n } as any],
+				}),
+				{
+					from: {
+						hashcode: () => "peer-a",
+						equals: () => false,
+					},
+				} as any,
+			);
+
+			await waitForResolved(() => expect(localPresenceChecks).to.equal(1));
+			expect(
+				sentMessages.some(
+					(message) => message instanceof RequestMaybeSyncCoordinate,
+				),
+			).to.equal(false);
 		} finally {
 			await sync.close();
 		}

--- a/packages/programs/data/shared-log/test/sharding.spec.ts
+++ b/packages/programs/data/shared-log/test/sharding.spec.ts
@@ -270,6 +270,53 @@ testSetups.forEach((setup) => {
 				);
 			};
 
+			it("cancels pending checked prune when local peer leads again", async () => {
+				db1 = await session.peers[0].open(new EventStore<string, any>(), {
+					args: {
+						replicate: {
+							offset: 0,
+						},
+						replicas: {
+							min: new AbsoluteReplicas(1),
+							max: new AbsoluteReplicas(1),
+						},
+						setup,
+						timeUntilRoleMaturity: 0,
+					},
+				});
+
+				const { entry } = await db1.add("hello", { meta: { next: [] } });
+				await waitForResolved(
+					async () => expect(await db1.log.entryCoordinatesIndex.count()).eq(1),
+					{ timeout: 10_000, delayInterval: 100 },
+				);
+
+				const log = db1.log as any;
+				const seedPendingDelete = () => {
+					let rejected: Error | undefined;
+					log._pendingDeletes.set(entry.hash, {
+						promise: { promise: new Promise<void>(() => {}) },
+						clear: () => log._pendingDeletes.delete(entry.hash),
+						resolve: () => {},
+						reject: (reason: Error) => {
+							rejected = reason;
+							log._pendingDeletes.delete(entry.hash);
+						},
+					});
+					return () => rejected;
+				};
+
+				let rejected = seedPendingDelete();
+				await log.pruneJoinedEntriesNoLongerLed([entry]);
+				expect(rejected()?.message).equal("Failed to delete, is leader again");
+				expect(log._pendingDeletes.has(entry.hash)).false;
+
+				rejected = seedPendingDelete();
+				await log.pruneIndexedEntriesNoLongerLed();
+				expect(rejected()?.message).equal("Failed to delete, is leader again");
+				expect(log._pendingDeletes.has(entry.hash)).false;
+			});
+
 			const countIdleUnderReplicatedEntries = async (
 				minReplicas: number,
 				...dbs: { log: EventStore<string, ReplicationDomainHash<any>>["log"] }[]
@@ -291,7 +338,7 @@ testSetups.forEach((setup) => {
 						),
 				).length;
 			};
-			const waitForChurnReplicationSettled = async (
+			const waitForReplicationCoverageSettled = async (
 				dbs: { log: EventStore<string, ReplicationDomainHash<any>>["log"] }[],
 				minReplicas: number,
 				expectedUnionSize: number,
@@ -503,7 +550,7 @@ testSetups.forEach((setup) => {
 				);
 
 				await waitForParticipationToSettle(db1, db2);
-				await waitForDistributionQuiesced(db1, db2);
+				await waitForReplicationCoverageSettled([db1, db2], 1, entryCount);
 
 				await checkBounded(
 					entryCount,
@@ -555,10 +602,10 @@ testSetups.forEach((setup) => {
 				);
 
 				// Participation can report "full" while redistribution is still in flight.
-				// The bounded assertion is about the settled final split, so wait for the
-				// actual distribution helpers instead of sampling the transient join state.
+				// The bounded assertion is about the settled final split, so wait for
+				// coverage rather than raw repair-sweep idleness.
 				await waitForParticipationToSettle(db1, db2);
-				await waitForDistributionQuiesced(db1, db2);
+				await waitForReplicationCoverageSettled([db1, db2], 1, entryCount);
 				// The 30-entry u64 sample can land one or two entries outside a strict
 				// 30/70 split while still preserving the full union and replica floor.
 				await checkBounded(
@@ -637,9 +684,9 @@ testSetups.forEach((setup) => {
 					db3.log.rebalanceAll({ clearCache: true }),
 				]);
 				await waitForParticipationToSettle(db1, db2, db3);
-				await waitForDistributionQuiesced(db1, db2, db3);
+				await waitForReplicationCoverageSettled([db1, db2, db3], 2, entryCount);
 				if (setup.name === "u64-iblt") {
-					// `waitForParticipationToSettle()` and `waitForDistributionQuiesced()` already
+					// `waitForParticipationToSettle()` and coverage checks already
 					// give the redistribution time to settle. An extra polling loop on exact
 					// participation closeness can hang in CI even when the final sharding shape is
 					// acceptable. Check the fairness signal once after quiescence instead of turning
@@ -1028,7 +1075,7 @@ testSetups.forEach((setup) => {
 						// This churn regression is about settled redistribution correctness, not
 						// whether every prune/rebalance timer reaches a totally idle state under
 						// adversarial delayed traffic on a loaded runner.
-						await waitForChurnReplicationSettled(
+						await waitForReplicationCoverageSettled(
 							[db1, db3, db4],
 							2,
 							entryCount,
@@ -1193,7 +1240,7 @@ testSetups.forEach((setup) => {
 						// union, replica floor, and lack of idle under-replication are the
 						// source of truth. Full internal quiescence is stronger than necessary
 						// and remains timing-sensitive under seeded pubsub jitter.
-						await waitForChurnReplicationSettled(
+						await waitForReplicationCoverageSettled(
 							[db1, db3, db4],
 							2,
 							entryCount,
@@ -1566,7 +1613,10 @@ testSetups.forEach((setup) => {
 				);
 
 				await waitForParticipationToSettle(db1, db2, db3);
-				await waitForDistributionQuiesced(db1, db2, db3);
+				// Join repair may still have receipt-driven follow-up sweeps queued under
+				// full-shard load. The correctness contract here is settled coverage and
+				// distribution before churn starts, not total internal repair idleness.
+				await waitForReplicationCoverageSettled([db1, db2, db3], 2, entryCount);
 
 				// This first three-peer bound is only a coarse fairness check before the close/reopen
 				// churn below. With a 30-entry u64 sample, one entry is 3.3%, so allowing 14/30 to

--- a/packages/programs/rpc/src/controller.ts
+++ b/packages/programs/rpc/src/controller.ts
@@ -27,7 +27,6 @@ import {
 	type RequestTransportContext,
 	SilentDelivery,
 	type WithExtraSigners,
-	deliveryModeHasReceiver,
 } from "@peerbit/stream-interface";
 import { AbortError, TimeoutError } from "@peerbit/time";
 import pDefer, { type DeferredPromise } from "p-defer";
@@ -64,6 +63,19 @@ const createValueResolver = <T>(
 	} else {
 		return (decrypted) => decrypted.getValue(type as AbstractType<T>);
 	}
+};
+
+const getExpectedResponders = (
+	mode: PubSubPublishOptions["mode"] | undefined,
+): Set<string> | undefined => {
+	const to = (mode as { to?: unknown } | undefined)?.to;
+	if (!Array.isArray(to) || to.length === 0) {
+		return undefined;
+	}
+	const responders = to.filter(
+		(value): value is string => typeof value === "string",
+	);
+	return responders.length > 0 ? new Set(responders) : undefined;
 };
 
 export type ResponseEvent<R> = {
@@ -341,6 +353,18 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 		expectedResponders?: Set<string>,
 		options?: RPCRequestOptions<R>,
 	) {
+		const expectedResponseHash =
+			expectedResponders && response.from
+				? response.from.hashcode()
+				: undefined;
+		if (
+			expectedResponseHash &&
+			expectedResponders.has(expectedResponseHash) &&
+			responders.has(expectedResponseHash)
+		) {
+			return;
+		}
+
 		this.events.dispatchEvent(
 			new CustomEvent("response", {
 				detail: response,
@@ -470,10 +494,7 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 		this.events.addEventListener("close", closeListener);
 		this.events.addEventListener("drop", dropListener);
 
-		const expectedResponders =
-			options?.mode && deliveryModeHasReceiver(options.mode)
-				? new Set(options.mode.to)
-				: undefined;
+		const expectedResponders = getExpectedResponders(options?.mode);
 
 		const responders = new Set<string>();
 

--- a/packages/programs/rpc/test/index.spec.ts
+++ b/packages/programs/rpc/test/index.spec.ts
@@ -201,6 +201,45 @@ describe("rpc", () => {
 			);
 		});
 
+		it("ignores duplicate responses from an expected responder", () => {
+			const from = responder.node.identity.publicKey;
+			const allResults: RPCResponse<Body>[] = [];
+			const responders = new Set<string>();
+			const expectedResponders = new Set<string>([from.hashcode()]);
+			const deferred = {
+				resolve: sinon.spy(),
+				reject: sinon.spy(),
+				promise: Promise.resolve(),
+			};
+			const onResponse = sinon.spy();
+			const decoded = {
+				response: new Body({ arr: new Uint8Array([1, 2, 3]) }),
+				from,
+				message: undefined as any,
+			};
+
+			(reader.query as any).handleDecodedResponse(
+				decoded,
+				deferred,
+				allResults,
+				responders,
+				expectedResponders,
+				{ onResponse },
+			);
+			(reader.query as any).handleDecodedResponse(
+				decoded,
+				deferred,
+				allResults,
+				responders,
+				expectedResponders,
+				{ onResponse },
+			);
+
+			expect(allResults).to.have.length(1);
+			expect(onResponse.calledOnce).to.be.true;
+			expect(deferred.resolve.calledOnce).to.be.true;
+		});
+
 		it("custom signer", async () => {
 			const requestEventFromResponder: CustomEvent<RequestEvent<Body>>[] = [];
 			const responseEventsFromResponder: CustomEvent<ResponseEvent<Body>>[] =

--- a/packages/transport/stream/src/index.ts
+++ b/packages/transport/stream/src/index.ts
@@ -2759,10 +2759,11 @@ export abstract class DirectStream<
 		message: DataMessage | Goodbye,
 		relayed?: boolean,
 		signal?: AbortSignal,
-	): Promise<{ promise: Promise<void> }> {
+	): Promise<{ promise: Promise<void>; startTimeout: () => void }> {
 		if (message.header.mode instanceof AnyWhere) {
 			return {
 				promise: Promise.resolve(),
+				startTimeout: () => {},
 			};
 		}
 
@@ -2772,6 +2773,7 @@ export abstract class DirectStream<
 		if (existing) {
 			return {
 				promise: existing.promise,
+				startTimeout: () => {},
 			};
 		}
 
@@ -2801,6 +2803,7 @@ export abstract class DirectStream<
 						"Cannnot deliver message to peers because there are no peers to deliver to",
 					),
 				),
+				startTimeout: () => {},
 			};
 		}
 
@@ -2836,7 +2839,13 @@ export abstract class DirectStream<
 		onUnreachable && this.addEventListener("peer:unreachable", onUnreachable);
 
 		let onAbort: (() => void) | undefined;
+		let timeout: ReturnType<typeof setTimeout> | undefined;
+		let cleared = false;
 		const clear = () => {
+			if (cleared) {
+				return;
+			}
+			cleared = true;
 			timeout && clearTimeout(timeout);
 			onUnreachable &&
 				this.removeEventListener("peer:unreachable", onUnreachable);
@@ -2844,7 +2853,11 @@ export abstract class DirectStream<
 			onAbort && signal?.removeEventListener("abort", onAbort);
 		};
 
-			const timeout = setTimeout(async () => {
+		const startTimeout = () => {
+			if (cleared || timeout) {
+				return;
+			}
+			timeout = setTimeout(async () => {
 				clear();
 
 			let hasAll = true;
@@ -2886,6 +2899,7 @@ export abstract class DirectStream<
 				deliveryDeferredPromise.resolve();
 			}
 			}, this.seekTimeout);
+		};
 
 		if (signal) {
 			onAbort = () => {
@@ -2992,7 +3006,10 @@ export abstract class DirectStream<
 				deliveryDeferredPromise.resolve();
 			},
 		});
-		return deliveryDeferredPromise;
+		return {
+			promise: deliveryDeferredPromise.promise,
+			startTimeout,
+		};
 	}
 
 	public async publishMessage(
@@ -3008,6 +3025,7 @@ export abstract class DirectStream<
 
 		const isRelayed = relayed ?? from.hashcode() !== this.publicKeyHash;
 		let delivereyPromise: Promise<void> | undefined = undefined as any;
+		let startDeliveryTimeout: (() => void) | undefined;
 		let ackCallbackId: string | undefined;
 
 		if (
@@ -3035,6 +3053,7 @@ export abstract class DirectStream<
 				signal,
 			);
 			delivereyPromise = deliveryDeferredPromise.promise;
+			startDeliveryTimeout = deliveryDeferredPromise.startTimeout;
 			ackCallbackId = toBase64(message.id);
 		}
 
@@ -3057,6 +3076,7 @@ export abstract class DirectStream<
 				) {
 					if (message.header.mode.to.length === 0) {
 						// we definitely know that we should not forward the message anywhere
+						startDeliveryTimeout?.();
 						return delivereyPromise;
 					}
 
@@ -3118,6 +3138,7 @@ export abstract class DirectStream<
 						}
 
 						await Promise.all(promises);
+						startDeliveryTimeout?.();
 						return delivereyPromise;
 					}
 
@@ -3149,6 +3170,7 @@ export abstract class DirectStream<
 						if (promises.length > 0) {
 							await Promise.all(promises);
 						}
+						startDeliveryTimeout?.();
 						return delivereyPromise;
 					}
 				}
@@ -3162,6 +3184,7 @@ export abstract class DirectStream<
 				(peers instanceof Map && peers.size === 0)
 			) {
 				logger.trace("No peers to send to");
+				startDeliveryTimeout?.();
 				return delivereyPromise;
 			}
 
@@ -3187,6 +3210,7 @@ export abstract class DirectStream<
 				promises.push(this.waitForPeerWrite(id, bytes, message.header.priority));
 			}
 			await Promise.all(promises);
+			startDeliveryTimeout?.();
 
 			if (!sentOnce) {
 				// If the caller provided an explicit peer list, treat "no valid receivers" as an error

--- a/packages/transport/stream/test/stream.spec.ts
+++ b/packages/transport/stream/test/stream.spec.ts
@@ -2785,21 +2785,73 @@ describe("streams", function () {
 		afterEach(async () => {
 			await session.stop();
 		});
-		it("max message size", async () => {
-			await expect(
-				session.peers[0].services.directstream.publish(
-					new Uint8Array(1e7 + 1001),
+			it("max message size", async () => {
+				await expect(
+					session.peers[0].services.directstream.publish(
+						new Uint8Array(1e7 + 1001),
 					{
 						mode: new AcknowledgeDelivery({
 							to: [session.peers[1].services.directstream.publicKeyHash],
 							redundancy: 1,
 						}),
 					},
-				),
-			).rejectedWith(/^Message too large/);
+					),
+				).rejectedWith(/^Message too large/);
+			});
+
+			it("delivers 512 KiB acknowledged direct messages", async () => {
+				const payload = new Uint8Array(512 * 1024);
+				const received = pDefer<void>();
+				stream(session, 1).addEventListener(
+					"data",
+					(event) => {
+						const message = event.detail;
+						if (message.dataByteLength === payload.byteLength) {
+							received.resolve();
+						}
+					},
+					{ once: true },
+				);
+
+				await stream(session, 0).publish(payload, {
+					mode: new AcknowledgeDelivery({
+						to: [stream(session, 1).publicKeyHash],
+						redundancy: 1,
+					}),
+				});
+				await received.promise;
+			});
+
+			it("delivers sustained 512 KiB acknowledged direct messages", async function () {
+				this.timeout(120_000);
+
+				const payload = new Uint8Array(512 * 1024);
+				const count = 1_000;
+				const received = pDefer<void>();
+				let receivedCount = 0;
+
+				stream(session, 1).addEventListener("data", (event) => {
+					const message = event.detail;
+					if (message.dataByteLength === payload.byteLength) {
+						receivedCount += 1;
+						if (receivedCount === count) {
+							received.resolve();
+						}
+					}
+				});
+
+				for (let i = 0; i < count; i++) {
+					await stream(session, 0).publish(payload, {
+						mode: new AcknowledgeDelivery({
+							to: [stream(session, 1).publicKeyHash],
+							redundancy: 1,
+						}),
+					});
+				}
+				await received.promise;
+			});
 		});
 	});
-});
 
 // TODO test that messages are not sent backward, triangles etc
 

--- a/scripts/file-share/common.mjs
+++ b/scripts/file-share/common.mjs
@@ -24,6 +24,18 @@ export const defaultExamplesDest = () => {
 	return path.join(parent, "peerbit-examples-local-peerbit");
 };
 
+export const defaultFileShareLocalPackages = [
+	"peerbit",
+	"@peerbit/document",
+	"@peerbit/shared-log",
+	"@peerbit/stream",
+	"@peerbit/react",
+	"@peerbit/crypto",
+	"@peerbit/trusted-network",
+	"@peerbit/vite",
+	"@peerbit/test-utils",
+];
+
 const BOOLEAN_ARGS = new Set([
 	"fresh",
 	"install",
@@ -375,6 +387,7 @@ export const overlayInstalledPackages = async ({
 	peerbitRoot = repoRoot,
 	packageNames,
 }) => {
+	const skipMissing = !Array.isArray(packageNames);
 	const localPackages = await collectLocalPeerbitPackages(peerbitRoot, {
 		names: packageNames,
 	});
@@ -384,6 +397,9 @@ export const overlayInstalledPackages = async ({
 			packageName,
 		});
 		if (!fs.existsSync(installedPackagePath)) {
+			if (skipMissing) {
+				continue;
+			}
 			throw new Error(
 				`Cannot overlay ${packageName}: missing installed package at ${installedPackagePath}`,
 			);

--- a/scripts/file-share/prepare-peerbit-examples.mjs
+++ b/scripts/file-share/prepare-peerbit-examples.mjs
@@ -1,6 +1,7 @@
 import {
 	defaultExamplesDest,
 	defaultExamplesSource,
+	defaultFileShareLocalPackages,
 	parseArgs,
 	prepareExamplesRepo,
 	repoRoot,
@@ -17,7 +18,7 @@ Options:
   --dest <path>              output directory (default: ${defaultExamplesDest()})
   --peerbit-root <path>      peerbit workspace root (default: ${repoRoot})
   --integration-mode <mode>  one of none, link, overlay (default: overlay)
-  --local-packages <csv>     package names to link/overlay (default: @peerbit/shared-log)
+  --local-packages <csv>     package names to link/overlay (default: ${defaultFileShareLocalPackages.join(",")}; use "all" for every installed local package)
   --fresh                    delete the destination before cloning
   --install                  run pnpm install in the prepared checkout
 `);
@@ -33,10 +34,12 @@ const main = async () => {
 	const localPackages =
 		integrationMode === "none"
 			? []
-			: (args["local-packages"] ?? "@peerbit/shared-log")
-					.split(",")
-					.map((value) => value.trim())
-					.filter(Boolean);
+			: args["local-packages"] === "all"
+				? undefined
+				: (args["local-packages"] ?? defaultFileShareLocalPackages.join(","))
+						.split(",")
+						.map((value) => value.trim())
+						.filter(Boolean);
 
 	const prepared = await prepareExamplesRepo({
 		source: args.source,

--- a/scripts/file-share/run-file-share-benchmark-matrix.mjs
+++ b/scripts/file-share/run-file-share-benchmark-matrix.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import {
 	defaultExamplesDest,
 	defaultExamplesSource,
+	defaultFileShareLocalPackages,
 	parseArgs,
 	repoRoot,
 	run,
@@ -500,7 +501,8 @@ const main = async () => {
 	const mode = args.mode ?? "both";
 	const scenario = args.scenario ?? "upload";
 	const integrationMode = args["integration-mode"] ?? "overlay";
-	const localPackages = args["local-packages"] ?? "@peerbit/shared-log";
+	const localPackages =
+		args["local-packages"] ?? defaultFileShareLocalPackages.join(",");
 	const network = args.network ?? "local";
 	const uploadTimeoutMs = args["upload-timeout-ms"];
 	const postUploadMonitorMs = args["post-upload-monitor-ms"];

--- a/scripts/file-share/run-file-share-benchmark.mjs
+++ b/scripts/file-share/run-file-share-benchmark.mjs
@@ -7,6 +7,7 @@ import {
 	copyTemplate,
 	defaultExamplesDest,
 	defaultExamplesSource,
+	defaultFileShareLocalPackages,
 	ensureExamplesAssetPackageLinks,
 	overlayInstalledPackages,
 	parseArgs,
@@ -50,8 +51,6 @@ const REMOTE_NETWORK_DEFAULTS = {
 	viteMode: "staging",
 	viteConfig: "vite.config.remote.ts",
 };
-
-const DEFAULT_LOCAL_PACKAGES = ["@peerbit/shared-log"];
 
 const getScenarioConfig = (scenario) => {
 	const config = SCENARIOS[scenario];
@@ -595,7 +594,7 @@ const main = async () => {
 			? []
 			: localPackagesArg === "all"
 				? undefined
-				: (localPackagesArg ?? DEFAULT_LOCAL_PACKAGES.join(","))
+				: (localPackagesArg ?? defaultFileShareLocalPackages.join(","))
 						.split(",")
 						.map((value) => value.trim())
 						.filter(Boolean);

--- a/scripts/file-share/run-file-share-benchmark.mjs
+++ b/scripts/file-share/run-file-share-benchmark.mjs
@@ -161,9 +161,17 @@ const maybeCopyFrontendCerts = async ({
 const instrumentFileShareFrontend = async (frontendRoot) => {
 	const dropPath = path.join(frontendRoot, "src", "Drop.tsx");
 	let contents = await fsp.readFile(dropPath, "utf8");
+	const hasExistingBenchmarkHook =
+		contents.includes("__peerbitFileShareTestHooks") &&
+		contents.includes("setReplicationRole") &&
+		contents.includes("getDiagnostics");
+	const hasExistingUpdateListStats =
+		contents.includes("__peerbitFileShareBenchmarkStats") &&
+		contents.includes("updateListStats") &&
+		contents.includes("updateListCalls.push(updateListStats)");
 	if (
-		contents.includes(DROP_HOOK_MARKER) &&
-		contents.includes(DROP_UPDATE_LIST_MARKER)
+		(contents.includes(DROP_HOOK_MARKER) || hasExistingBenchmarkHook) &&
+		(contents.includes(DROP_UPDATE_LIST_MARKER) || hasExistingUpdateListStats)
 	) {
 		return;
 	}


### PR DESCRIPTION
## Summary
- defer acknowledged stream delivery timeout until outbound writes are queued
- filter stale/unresolved document indexed results before advertising or resolving them
- ignore duplicate RPC responses from expected responders
- make file-share benchmark overlays include the runtime Peerbit package set by default

## Verification
- pnpm run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/stream -- -t node --grep "delivers sustained 512 KiB acknowledged direct messages"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/stream -- -t node --grep "delivers 512 KiB acknowledged direct messages"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/rpc -- -t node --grep "ignores duplicate responses"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "does not advertise stale indexed rows as replicable|drops unresolved indexed placeholders"
- BENCH_JSON=1 FILE_INGEST_WARMUP=0 FILE_INGEST_ITERATIONS=1 FILE_INGEST_CHUNKS=4 FILE_INGEST_CHUNK_BYTES=65536 pnpm run bench:file-ingest -- --mode adaptive --json
- pnpm run bench:file-share:local -- --integration-mode overlay --file-mb 5 --runs 1 --mode adaptive --network local --results-dir /Users/admin/git/tmp/peerbit-file-share-current-default-local/runs --summary-file /Users/admin/git/tmp/peerbit-file-share-current-default-local/summary.json
- pnpm run bench:file-share:local -- --scenario seeder-probe --integration-mode overlay --mode adaptive --network local --sample-ms 1000 --sample-count 5 --target-seeders 2 --results-dir /Users/admin/git/tmp/peerbit-file-share-current-default-probe/runs --summary-file /Users/admin/git/tmp/peerbit-file-share-current-default-probe/summary.json
- git diff --check origin/master..HEAD