### PR TITLE
fix(stream): handle internal delivery rejections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ coverage
 references
 .npmrc
 .env.github
+.envrc
 
 # Supabase local secrets (do not commit)
 .env.supabase

--- a/packages/transport/stream/src/index.ts
+++ b/packages/transport/stream/src/index.ts
@@ -2798,9 +2798,11 @@ export abstract class DirectStream<
 
 		if (haveReceivers && this.peers.size === 0) {
 			return {
-				promise: Promise.reject(
-					new DeliveryError(
-						"Cannnot deliver message to peers because there are no peers to deliver to",
+				promise: markPromiseHandled(
+					Promise.reject(
+						new DeliveryError(
+							"Cannnot deliver message to peers because there are no peers to deliver to",
+						),
 					),
 				),
 				startTimeout: () => {},
@@ -2808,6 +2810,7 @@ export abstract class DirectStream<
 		}
 
 		const deliveryDeferredPromise = pDefer<void>();
+		markPromiseHandled(deliveryDeferredPromise.promise);
 
 		if (!haveReceivers) {
 			deliveryDeferredPromise.resolve(); // we dont know how many answer to expect, just resolve immediately

--- a/packages/transport/stream/test/stream.spec.ts
+++ b/packages/transport/stream/test/stream.spec.ts
@@ -2672,6 +2672,64 @@ describe("streams", function () {
 				}
 			});
 
+			it("does not emit unhandledRejection when delivery aborts before publishMessage returns", async () => {
+				const isolated = await disconnected(1, {
+					services: {
+						directstream: (c) =>
+							new TestDirectStream(c, {
+								connectionManager: false,
+							}),
+					},
+				});
+
+				const unhandled: unknown[] = [];
+				const onUnhandledRejection = (reason: unknown) => {
+					unhandled.push(reason);
+				};
+
+				process.on("unhandledRejection", onUnhandledRejection);
+
+				try {
+					const writer = stream(isolated, 0) as TestDirectStream;
+					const remoteKey = await Ed25519Keypair.create();
+					const peer = writer.addPeer(
+						{ toString: () => "blocked-peer" } as PeerId,
+						remoteKey.publicKey,
+						"/test/0.0.0",
+						"conn-blocked",
+					);
+					peer.waitForWrite = async () => {
+						await delay(100);
+					};
+
+					const message = await writer.createMessage(crypto.randomBytes(32), {
+						mode: new AcknowledgeDelivery({
+							redundancy: 1,
+							to: [remoteKey.publicKey.hashcode()],
+						}),
+					});
+					const abortController = new AbortController();
+					const publishPromise = writer.publishMessage(
+						writer.publicKey,
+						message,
+						[peer],
+						undefined,
+						abortController.signal,
+					);
+					publishPromise.catch(() => {});
+
+					await delay(10);
+					abortController.abort(new Error("intentional test abort"));
+					await delay(25);
+					expect(unhandled).to.deep.equal([]);
+
+					await publishPromise.catch(() => {});
+				} finally {
+					process.off("unhandledRejection", onUnhandledRejection);
+					await isolated.stop();
+				}
+			});
+
 			it("publishMaybe returns false for delivery errors and still throws internal errors", async () => {
 				const isolated = await disconnected(1, {
 					services: {


### PR DESCRIPTION
## Summary
- mark internal delivery promises as handled when they are created
- keep caller-visible publish/publishMessage rejection behavior unchanged
- add a regression test for delivery aborting before publishMessage returns
- ignore local .envrc files

## Verification
- pnpm --filter @peerbit/stream... run build
- pnpm --filter @peerbit/stream test -- --grep "(unhandledRejection|publishMaybe returns false|publishMessageMaybe returns false|will resolve immediately of no neighbours)"
- pnpm --filter @peerbit/stream test