### PR TITLE
fix(rpc): bound requests during slow publish

### DIFF
--- a/packages/programs/rpc/src/controller.ts
+++ b/packages/programs/rpc/src/controller.ts
@@ -466,29 +466,40 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 		const allResults: RPCResponse<R>[] = [];
 
 		const deferredPromise = pDefer<void>();
+		const publishAbortController = new AbortController();
+		const abortPublish = (reason: unknown) => {
+			if (!publishAbortController.signal.aborted) {
+				publishAbortController.abort(reason);
+			}
+		};
 
 		if (this.closed) {
 			throw new AbortError("Closed");
 		}
 		const timeoutFn = setTimeout(
 			() => {
+				abortPublish(new AbortError("RPC request timeout"));
 				deferredPromise.resolve();
 			},
 			options?.timeout || 10 * 1000,
 		);
 
 		const abortListener = (err: Event) => {
-			deferredPromise.reject(
-				(err.target as any)?.["reason"] || new AbortError(),
-			);
+			const reason = (err.target as any)?.["reason"] || new AbortError();
+			abortPublish(reason);
+			deferredPromise.reject(reason);
 		};
 		options?.signal?.addEventListener("abort", abortListener);
 
 		const closeListener = () => {
-			deferredPromise.reject(new AbortError("Closed"));
+			const reason = new AbortError("Closed");
+			abortPublish(reason);
+			deferredPromise.reject(reason);
 		};
 		const dropListener = () => {
-			deferredPromise.reject(new AbortError("Dropped"));
+			const reason = new AbortError("Dropped");
+			abortPublish(reason);
+			deferredPromise.reject(reason);
 		};
 
 		this.events.addEventListener("close", closeListener);
@@ -510,17 +521,13 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 			options,
 		);
 		this._responseResolver.set(id, responseHandler);
-		let publishSignal: AbortSignal | undefined = undefined;
-		let publishAbortReason: unknown | undefined = undefined;
+		void deferredPromise.promise
+			.finally(() => {
+				abortPublish(new AbortError("Resolved early"));
+			})
+			.catch(() => {});
+
 		if (options?.responseInterceptor) {
-			const abortController = new AbortController();
-			void deferredPromise.promise
-				.finally(() => {
-					publishAbortReason = new AbortError("Resolved early");
-					abortController.abort(publishAbortReason);
-				})
-				.catch(() => {});
-			publishSignal = abortController.signal;
 			options.responseInterceptor((response: RPCResponse<R>) => {
 				return this.handleDecodedResponse(
 					response,
@@ -534,25 +541,38 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 		}
 
 		try {
-			await this.node.services.pubsub.publish(
-				requestBytes,
-				this.getPublishOptions(messageId, options, publishSignal),
-			);
+			const publishPromise = Promise.resolve(
+				this.node.services.pubsub.publish(
+					requestBytes,
+					this.getPublishOptions(
+						messageId,
+						options,
+						publishAbortController.signal,
+					),
+				),
+			)
+				.catch((error: any) => {
+					if (
+						publishAbortController.signal.aborted &&
+						(error instanceof AbortError ||
+							error === publishAbortController.signal.reason)
+					) {
+						return;
+					}
+					if (error instanceof TimeoutError) {
+						// Ignore publish timeouts
+						return;
+					}
+					throw error;
+				});
+			await Promise.race([publishPromise, deferredPromise.promise]);
 			await deferredPromise.promise;
 		} catch (error: any) {
-			if (error instanceof TimeoutError) {
-				// Ignore publish timeouts
-			} else if (
-				publishAbortReason &&
-				(error === publishAbortReason ||
-					(error instanceof AbortError &&
-						error.message === (publishAbortReason as AbortError).message))
-			) {
-				// Response interceptor resolved early; canceling publish is expected
-			} else {
+			if (!(error instanceof TimeoutError)) {
 				throw error;
 			}
 		} finally {
+			abortPublish(new AbortError("RPC request finished"));
 			clearTimeout(timeoutFn);
 			this.events.removeEventListener("close", closeListener);
 			this.events.removeEventListener("drop", dropListener);

--- a/packages/programs/rpc/test/index.spec.ts
+++ b/packages/programs/rpc/test/index.spec.ts
@@ -240,6 +240,38 @@ describe("rpc", () => {
 			expect(deferred.resolve.calledOnce).to.be.true;
 		});
 
+		it("bounds slow publishes by the request timeout", async () => {
+			let observedSignal: AbortSignal | undefined;
+			const publishStub = sinon
+				.stub(reader.node.services.pubsub, "publish")
+				.callsFake((_data, options?: { signal?: AbortSignal }) => {
+					observedSignal = options?.signal;
+					return new Promise<Uint8Array | undefined>((_resolve, reject) => {
+						observedSignal?.addEventListener(
+							"abort",
+							() => {
+								reject(observedSignal?.reason ?? new AbortError("Aborted"));
+							},
+							{ once: true },
+						);
+					});
+				});
+
+			try {
+				const started = Date.now();
+				const result = await reader.query.request(
+					new Body({ arr: new Uint8Array([1, 2, 3]) }),
+					{ timeout: 25 },
+				);
+
+				expect(result).to.deep.equal([]);
+				expect(observedSignal?.aborted).to.be.true;
+				expect(Date.now() - started).to.be.lessThan(1_000);
+			} finally {
+				publishStub.restore();
+			}
+		});
+
 		it("custom signer", async () => {
 			const requestEventFromResponder: CustomEvent<RequestEvent<Body>>[] = [];
 			const responseEventsFromResponder: CustomEvent<ResponseEvent<Body>>[] =

--- a/packages/transport/stream/src/index.ts
+++ b/packages/transport/stream/src/index.ts
@@ -3106,11 +3106,17 @@ export abstract class DirectStream<
 										stream,
 										message.bytes(),
 										message.header.priority,
+										signal,
 									),
 								);
 							} else {
 								promises.push(
-									this.waitForPeerWrite(stream, bytes, message.header.priority),
+									this.waitForPeerWrite(
+										stream,
+										bytes,
+										message.header.priority,
+										signal,
+									),
 								);
 							}
 							usedNeighbours.add(neighbour);
@@ -3135,7 +3141,12 @@ export abstract class DirectStream<
 								if (usedNeighbours.has(neighbour)) continue;
 								usedNeighbours.add(neighbour);
 								promises.push(
-									this.waitForPeerWrite(stream, bytes, message.header.priority),
+									this.waitForPeerWrite(
+										stream,
+										bytes,
+										message.header.priority,
+										signal,
+									),
 								);
 							}
 						}
@@ -3166,6 +3177,7 @@ export abstract class DirectStream<
 									stream,
 									message.bytes(),
 									message.header.priority,
+									signal,
 								),
 							);
 						}
@@ -3210,7 +3222,9 @@ export abstract class DirectStream<
 					continue;
 				}
 				sentOnce = true;
-				promises.push(this.waitForPeerWrite(id, bytes, message.header.priority));
+				promises.push(
+					this.waitForPeerWrite(id, bytes, message.header.priority, signal),
+				);
 			}
 			await Promise.all(promises);
 			startDeliveryTimeout?.();

--- a/packages/transport/stream/test/stream.spec.ts
+++ b/packages/transport/stream/test/stream.spec.ts
@@ -29,7 +29,13 @@ import {
 	SilentDelivery,
 	getMsgId,
 } from "@peerbit/stream-interface";
-import { TimeoutError, delay, waitFor, waitForResolved } from "@peerbit/time";
+import {
+	AbortError,
+	TimeoutError,
+	delay,
+	waitFor,
+	waitForResolved,
+} from "@peerbit/time";
 import { expect } from "chai";
 import crypto from "crypto";
 import { type Libp2pOptions, createLibp2p } from "libp2p";
@@ -2726,6 +2732,70 @@ describe("streams", function () {
 					await publishPromise.catch(() => {});
 				} finally {
 					process.off("unhandledRejection", onUnhandledRejection);
+					await isolated.stop();
+				}
+			});
+
+			it("passes publish abort signals into queued peer writes", async () => {
+				const isolated = await disconnected(1, {
+					services: {
+						directstream: (c) =>
+							new TestDirectStream(c, {
+								connectionManager: false,
+							}),
+					},
+				});
+
+				try {
+					const writer = stream(isolated, 0) as TestDirectStream;
+					const remoteKey = await Ed25519Keypair.create();
+					const peer = writer.addPeer(
+						{ toString: () => "blocked-peer" } as PeerId,
+						remoteKey.publicKey,
+						"/test/0.0.0",
+						"conn-blocked",
+					);
+
+					let observedSignal: AbortSignal | undefined;
+					peer.waitForWrite = async (_bytes, _priority, signal) => {
+						observedSignal = signal;
+						return new Promise<void>((_resolve, reject) => {
+							signal?.addEventListener(
+								"abort",
+								() => reject(signal.reason ?? new AbortError("Aborted")),
+								{ once: true },
+							);
+						});
+					};
+
+					const message = await writer.createMessage(crypto.randomBytes(32), {
+						mode: new AcknowledgeDelivery({
+							redundancy: 1,
+							to: [remoteKey.publicKey.hashcode()],
+						}),
+					});
+					const abortController = new AbortController();
+					const started = Date.now();
+					const publishPromise = writer.publishMessage(
+						writer.publicKey,
+						message,
+						[peer],
+						undefined,
+						abortController.signal,
+					);
+
+					await delay(10);
+					abortController.abort(new AbortError("intentional test abort"));
+
+					let rejection: unknown;
+					await publishPromise.catch((error) => {
+						rejection = error;
+					});
+
+					expect(observedSignal).to.equal(abortController.signal);
+					expect(rejection).to.be.instanceOf(Error);
+					expect(Date.now() - started).to.be.lessThan(1_000);
+				} finally {
 					await isolated.stop();
 				}
 			});


### PR DESCRIPTION
## Summary
- bound RPC request completion by racing slow pubsub publishes against the request timeout/response promise
- abort in-flight request publishes once the request settles so backpressure does not keep callers waiting
- pass stream publish abort signals into queued peer writes

## Why
File-share 64 MB benches still showed direct remote chunk gets taking tens of seconds even though the chunk attempt timeout was 5s. The underlying Peerbit path armed the RPC timeout, but awaited pubsub publish first; if publish/backpressure/ACK delivery was slow, the caller could not observe the timeout until publish returned.

## Tests
- direnv exec . node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/rpc -- -t node --grep "bounds slow publishes"
- direnv exec . node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/stream -- -t node --grep "passes publish abort signals"
- direnv exec . pnpm --filter @peerbit/rpc test
- direnv exec . pnpm --filter @peerbit/stream test
- git diff --check
- direnv exec . pnpm run build