### PR TITLE
fix: prevent stream priority stalls under backpressure

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -3508,26 +3508,18 @@ export class SharedLog<
 					const frontierTargets = this._repairFrontierByMode.get(mode);
 					for (const target of pendingPeersByMode.get(mode) ?? []) {
 						const replacement = nextTargets.get(target);
-						if (mode === "join-authoritative") {
-							// Authoritative join repair is receipt-driven: a later sweep can have a
-							// narrower transient leader view, but it must not forget unconfirmed
-							// hashes that were already queued for this joiner.
-							if (replacement && replacement.size > 0) {
-								const existing = frontierTargets?.get(target);
-								if (existing && existing.size > 0) {
-									for (const [hash, entry] of replacement) {
-										existing.set(hash, entry);
-									}
-								} else {
-									frontierTargets?.set(target, replacement);
-								}
-							}
-							continue;
-						}
+						// These repairs are receipt-driven: a later sweep can have a narrower
+						// transient leader view, but it must not forget unconfirmed hashes
+						// that were already queued for this target.
 						if (replacement && replacement.size > 0) {
-							frontierTargets?.set(target, replacement);
-						} else {
-							frontierTargets?.delete(target);
+							const existing = frontierTargets?.get(target);
+							if (existing && existing.size > 0) {
+								for (const [hash, entry] of replacement) {
+									existing.set(hash, entry);
+								}
+							} else {
+								frontierTargets?.set(target, replacement);
+							}
 						}
 					}
 				}

--- a/packages/programs/data/shared-log/test/sharding.spec.ts
+++ b/packages/programs/data/shared-log/test/sharding.spec.ts
@@ -1505,6 +1505,51 @@ testSetups.forEach((setup) => {
 				};
 				const originalPushRepairEntries =
 					sourceLog.pushRepairEntries.bind(sourceDb.log);
+
+				// Regression for the CI failure mode: an underfilled churn sweep must
+				// not replace a receipt-driven frontier and forget an unconfirmed hash.
+				const sourceLogInternals = sourceDb.log as any;
+				const candidateIndexEntry = (
+					await sourceLogInternals.entryCoordinatesIndex
+						.iterate({ query: { hash: candidateHash } })
+						.all()
+				)[0]?.value;
+				expect(candidateIndexEntry).to.exist;
+				const churnFrontier =
+					sourceLogInternals._repairFrontierByMode.get("churn");
+				churnFrontier.set(
+					targetHash,
+					new Map([[candidateHash, candidateIndexEntry]]),
+				);
+				const pendingChurnPeers =
+					sourceLogInternals._repairSweepPendingPeersByMode.get("churn");
+				const originalEntryCoordinateIterate =
+					sourceLogInternals.entryCoordinatesIndex.iterate.bind(
+						sourceLogInternals.entryCoordinatesIndex,
+					);
+				sourceLogInternals.entryCoordinatesIndex.iterate = () => ({
+					close: async () => undefined,
+					done: () => true,
+					next: async () => [],
+				});
+				try {
+					sourceLogInternals._repairSweepPendingModes.add("churn");
+					pendingChurnPeers.add(targetHash);
+					sourceLogInternals._repairSweepRunning = true;
+					await sourceLogInternals.runRepairSweep();
+					expect(
+						churnFrontier.get(targetHash)?.has(candidateHash),
+						"churn repair frontier should keep unconfirmed hashes across underfilled sweeps",
+					).to.be.true;
+				} finally {
+					sourceLogInternals.entryCoordinatesIndex.iterate =
+						originalEntryCoordinateIterate;
+					churnFrontier.delete(targetHash);
+					pendingChurnPeers.delete(targetHash);
+					sourceLogInternals._repairSweepPendingModes.delete("churn");
+					sourceLogInternals._repairSweepRunning = false;
+				}
+
 				let droppedCandidateHash = false;
 
 				sourceLog.pushRepairEntries = async (target, entries) => {

--- a/packages/transport/stream/src/index.ts
+++ b/packages/transport/stream/src/index.ts
@@ -2148,7 +2148,8 @@ export abstract class DirectStream<
 				decodedMessage = Message.from(message);
 				priority = decodedMessage.header.priority ?? 0;
 			} catch {
-				// Let processMessage keep the existing decode warning/ignore behavior.
+				// This is only a best-effort priority peek. processMessage()
+				// performs the authoritative decode and logs invalid frames.
 			}
 			//	logger.trace("messages from " + from);
 			await this.queue

--- a/packages/transport/stream/src/index.ts
+++ b/packages/transport/stream/src/index.ts
@@ -139,6 +139,7 @@ const waitForDrain = async (
 		const cleanup = () => {
 			if (done) return;
 			done = true;
+			clearTimeout(fallbackTimer);
 			stream.removeEventListener("drain", onDrain);
 			stream.removeEventListener("close", onClose);
 			signal?.removeEventListener("abort", onAbort);
@@ -157,6 +158,9 @@ const waitForDrain = async (
 			const err = detail?.error ?? (event as any)?.error;
 			reject(err ?? new Error("Stream closed"));
 		};
+		// Some libp2p streams can return backpressure without later emitting drain.
+		// Do not let a missed drain permanently stall higher-priority traffic.
+		const fallbackTimer = setTimeout(onDrain, 250);
 		stream.addEventListener("drain", onDrain, { once: true });
 		stream.addEventListener("close", onClose, { once: true });
 		signal?.addEventListener("abort", onAbort, { once: true });
@@ -2138,15 +2142,28 @@ export abstract class DirectStream<
 		// logger.trace("rpc from " + from + ", " + this.peerIdStr);
 
 		if (message.length > 0) {
+			let decodedMessage: Message | undefined;
+			let priority = 0;
+			try {
+				decodedMessage = Message.from(message);
+				priority = decodedMessage.header.priority ?? 0;
+			} catch {
+				// Let processMessage keep the existing decode warning/ignore behavior.
+			}
 			//	logger.trace("messages from " + from);
 			await this.queue
 				.add(async () => {
 					try {
-						await this.processMessage(from, peerStreams, message);
+						await this.processMessage(
+							from,
+							peerStreams,
+							message,
+							decodedMessage,
+						);
 					} catch (err: any) {
 						logger.error(err);
 					}
-				})
+				}, { priority })
 				.catch(logError);
 		}
 
@@ -2172,15 +2189,16 @@ export abstract class DirectStream<
 		from: PublicSignKey,
 		peerStream: PeerStreams,
 		msg: Uint8ArrayList,
+		decodedMessage?: Message,
 	) {
 		if (!this.started) {
 			return;
 		}
 
 		// Ensure the message is valid before processing it
-		let message: Message | undefined;
+		let message: Message | undefined = decodedMessage;
 		try {
-			message = Message.from(msg);
+			message ??= Message.from(msg);
 		} catch (error) {
 			warn(error, "Failed to decode message frame from", from.hashcode());
 			return;

--- a/packages/transport/stream/test/priority-lanes.spec.ts
+++ b/packages/transport/stream/test/priority-lanes.spec.ts
@@ -81,6 +81,31 @@ describe("priority lanes", () => {
 		await streams.close();
 	});
 
+	it("does not permanently stall when a stream misses drain", async () => {
+		const keypair = await Ed25519Keypair.create();
+		const streams = new PeerStreams({
+			peerId: { toString: () => "test-peer" } as unknown as PeerId,
+			publicKey: keypair.publicKey,
+			protocol: "/test",
+			connId: "test-conn",
+		});
+
+		const outbound = new TestOutboundStream();
+		await streams.attachOutboundStream(outbound as any);
+
+		streams.write(new Uint8Array([1]), 0);
+		await waitForResolved(() =>
+			expect(outbound.sentPayloads).to.deep.equal([1]),
+		);
+
+		streams.write(new Uint8Array([200]), 3);
+		await waitForResolved(() =>
+			expect(outbound.sentPayloads).to.deep.equal([1, 200]),
+		);
+
+		await streams.close();
+	});
+
 	it("applies backpressure to bulk writes while reserving capacity for higher priority traffic", async () => {
 		const keypair = await Ed25519Keypair.create();
 		const streams = new PeerStreams({

--- a/packages/transport/stream/test/stream.spec.ts
+++ b/packages/transport/stream/test/stream.spec.ts
@@ -314,6 +314,79 @@ const service = <
 	(s.peers[i].services as Record<string, unknown>)[serviceName] as TService;
 
 describe("streams", function () {
+	it("processes queued inbound messages by transport priority", async () => {
+		const session = await disconnected(2);
+		try {
+			const sender = stream(session, 0);
+			const receiver = stream(session, 1);
+			receiver.queue.concurrency = 1;
+
+			const processed: number[] = [];
+			const firstLowStarted = pDefer<void>();
+			const releaseFirstLow = pDefer<void>();
+			let lowMessagesStarted = 0;
+
+			(receiver as any).processMessage = async (
+				_from: PublicSignKey,
+				_peerStream: PeerStreams,
+				msg: Uint8ArrayList,
+				decoded?: Message,
+			) => {
+				const message = decoded ?? Message.from(msg);
+				const priority = message.header.priority ?? 0;
+				processed.push(priority);
+
+				if (priority === 0) {
+					lowMessagesStarted++;
+					if (lowMessagesStarted === 1) {
+						firstLowStarted.resolve();
+						await releaseFirstLow.promise;
+					}
+				}
+			};
+
+			const create = (priority: number, byte: number) =>
+				sender.createMessage(new Uint8Array([byte]), {
+					mode: new SilentDelivery({
+						to: [receiver.publicKeyHash],
+						redundancy: 1,
+					}),
+					priority,
+				});
+			const asList = (bytes: Uint8Array | Uint8ArrayList) =>
+				bytes instanceof Uint8ArrayList ? bytes : new Uint8ArrayList(bytes);
+
+			const lowMessages = await Promise.all([
+				create(0, 1),
+				create(0, 2),
+				create(0, 3),
+			]);
+			const lowPromises = lowMessages.map((message) =>
+				receiver.processRpc(
+					sender.publicKey,
+					{} as PeerStreams,
+					asList(message.bytes()),
+				),
+			);
+
+			await firstLowStarted.promise;
+			const highMessage = await create(3, 200);
+			const highPromise = receiver.processRpc(
+				sender.publicKey,
+				{} as PeerStreams,
+				asList(highMessage.bytes()),
+			);
+
+			await delay(0);
+			releaseFirstLow.resolve();
+			await Promise.all([...lowPromises, highPromise]);
+
+			expect(processed).to.deep.equal([0, 3, 0, 0]);
+		} finally {
+			await session.stop();
+		}
+	});
+
 	describe("signing", () => {
 		let session: TestSessionStream;
 


### PR DESCRIPTION
## Summary
- prevent the outbound stream pump from stalling forever when a stream reports backpressure but does not later emit `drain`
- enqueue inbound DirectStream processing with the message header priority so control/RPC responses do not sit behind already-queued bulk work
- add regressions for missed-drain stalls and inbound priority ordering

## Tests
- `pnpm --filter @peerbit/stream test -- --grep "does not permanently stall|processes queued inbound|priority lanes|ACKs back through a congested reverse path|higher priority"`
- `pnpm --filter @peerbit/stream test`
- local distributed-backup two-daemon 16 MiB cold download with patched dependency: HTTP 200 and matching SHA-256

Note: `pnpm --filter @peerbit/stream lint` currently fails on pre-existing style issues in `packages/transport/stream/src/core/seek-routing.ts` and existing stream files.
