### PR TITLE
Fix contended remote reads for file-share

### DIFF
--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -23,6 +23,7 @@ import type { SortFn } from "./log-sorting.js";
 import { logger as baseLogger } from "./logger.js";
 
 const log = baseLogger.newScope("entry-index");
+const LOG_ENTRY_REMOTE_READ_PRIORITY = 2;
 
 export type ResultsIterator<T> = {
 	close: () => void | Promise<void>;
@@ -43,6 +44,7 @@ type ResolveFullyOptions =
 						signal?: AbortSignal;
 						timeout?: number;
 						from?: string[];
+						priority?: number;
 				  }
 				| boolean;
 			ignoreMissing?: boolean;
@@ -52,6 +54,44 @@ export type MaybeResolveOptions =
 	| false
 	| ResolveFullyOptions
 	| ResolveShapeOptions;
+
+type RemoteReadOptionsWithPriority = {
+	remote?:
+		| {
+				replicate?: boolean;
+				signal?: AbortSignal;
+				timeout?: number;
+				from?: string[];
+				priority?: number;
+		  }
+		| boolean;
+};
+
+const withDefaultRemoteReadPriority = <
+	O extends RemoteReadOptionsWithPriority | undefined,
+>(
+	options: O,
+): O => {
+	if (!options?.remote) {
+		return options;
+	}
+	if (options.remote === true) {
+		return {
+			...options,
+			remote: { priority: LOG_ENTRY_REMOTE_READ_PRIORITY },
+		} as O;
+	}
+	if (options.remote.priority != null) {
+		return options;
+	}
+	return {
+		...options,
+		remote: {
+			...options.remote,
+			priority: LOG_ENTRY_REMOTE_READ_PRIORITY,
+		},
+	} as O;
+};
 export type ReturnTypeFromResolveOptions<
 	R extends MaybeResolveOptions,
 	T,
@@ -672,6 +712,7 @@ export class EntryIndex<T> {
 						replicate?: boolean;
 						timeout?: number;
 						from?: string[];
+						priority?: number;
 				  }
 				| boolean;
 		},
@@ -706,7 +747,10 @@ export class EntryIndex<T> {
 			}
 		}
 
-		const value = await this.properties.store.get(k, coercedOptions);
+		const value = await this.properties.store.get(
+			k,
+			withDefaultRemoteReadPriority(coercedOptions),
+		);
 		if (value) {
 			const entry = deserialize(value, Entry);
 			entry.size = value.length;

--- a/packages/log/test/log.spec.ts
+++ b/packages/log/test/log.spec.ts
@@ -154,10 +154,13 @@ describe("properties", function () {
 
 		it("fetches remotes with timeout", async () => {
 			const storeGetFn = store.get.bind(store);
-			let timeout: any = undefined;
+			let timeout: number | undefined;
 			let fetched = false;
 			store.get = async (hash, options) => {
-				timeout = (options?.remote as any)?.["timeout"];
+				timeout =
+					typeof options?.remote === "object"
+						? options.remote.timeout
+						: undefined;
 				fetched = true;
 				return storeGetFn(hash, options);
 			};
@@ -176,12 +179,56 @@ describe("properties", function () {
 			expect(timeout).to.eq(123);
 		});
 
+		it("fetches remote entries with metadata priority by default", async () => {
+			const storeGetFn = store.get.bind(store);
+			let priority: number | undefined;
+			store.get = async (hash, options) => {
+				priority =
+					typeof options?.remote === "object"
+						? options.remote.priority
+						: undefined;
+				return storeGetFn(hash, options);
+			};
+
+			const entry = await log.get(
+				"zb2rhbnwihVVVVEGAPf9EwTZBsQz9fszCnM4Y8mJmBFgiyN7J",
+				{ remote: true },
+			);
+			assert.deepStrictEqual(entry, undefined);
+			expect(priority).to.eq(2);
+		});
+
+		it("preserves explicit remote entry priority", async () => {
+			const storeGetFn = store.get.bind(store);
+			let priority: number | undefined;
+			store.get = async (hash, options) => {
+				priority =
+					typeof options?.remote === "object"
+						? options.remote.priority
+						: undefined;
+				return storeGetFn(hash, options);
+			};
+
+			const entry = await log.get(
+				"zb2rhbnwihVVVVEGAPf9EwTZBsQz9fszCnM4Y8mJmBFgiyN7J",
+				{ remote: { timeout: 123, priority: 1 } },
+			);
+			assert.deepStrictEqual(entry, undefined);
+			expect(priority).to.eq(1);
+		});
+
 		it("injects remote.from when resolveRemotePeers is configured", async () => {
 			const fromPeers = ["peer-a", "peer-b", "peer-c"];
 			const storeGetFn = store.get.bind(store);
-			let observedFrom: any = undefined;
+			let observedFrom: string[] | undefined;
+			let observedPriority: number | undefined;
 			store.get = async (hash, options) => {
-				observedFrom = (options?.remote as any)?.from;
+				observedFrom =
+					typeof options?.remote === "object" ? options.remote.from : undefined;
+				observedPriority =
+					typeof options?.remote === "object"
+						? options.remote.priority
+						: undefined;
 				return storeGetFn(hash, options);
 			};
 
@@ -198,6 +245,7 @@ describe("properties", function () {
 			);
 			assert.deepStrictEqual(entry, undefined);
 			expect(observedFrom).to.deep.equal(fromPeers);
+			expect(observedPriority).to.eq(2);
 		});
 	});
 

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -1756,6 +1756,19 @@ export class DocumentIndex<
 		let requestClazz = resolve
 			? types.SearchRequest
 			: types.SearchRequestIndexed;
+		const wantsReplication =
+			coercedOptions?.remote &&
+			typeof coercedOptions.remote !== "boolean" &&
+			coercedOptions.remote.replicate;
+		if (
+			resolve &&
+			wantsReplication &&
+			(this.compatibility == null || this.compatibility > 8)
+		) {
+			// SearchRequest cannot carry entries, so a replicated resolved get would
+			// fetch the value and then fetch the entry again during sync.
+			requestClazz = types.SearchRequestIndexed;
+		}
 		if (key instanceof Uint8Array) {
 			const request = new requestClazz({
 				query: [

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -8237,6 +8237,41 @@ describe("index", () => {
 				expect((getRemote as any)["__indexed"]).to.exist;
 			});
 
+			it("uses indexed requests for replicated resolved remote get", async () => {
+				const processQuerySpy = sinon.spy(
+					stores[0].docs.index,
+					"processQuery",
+				);
+				try {
+					const getRemote = await stores[1].docs.index.get("1", {
+						remote: { replicate: true },
+					});
+
+					expect(getRemote!.name).to.eq("name1");
+					expect(getRemote.__indexed).to.be.instanceOf(Indexable);
+
+					const searchRequests = processQuerySpy
+						.getCalls()
+						.map((call) => call.args[0])
+						.filter(
+							(request) =>
+								request instanceof SearchRequest ||
+								request instanceof SearchRequestIndexed,
+						);
+
+					expect(
+						searchRequests.some(
+							(request) => request instanceof SearchRequestIndexed,
+						),
+					).to.be.true;
+					expect(
+						searchRequests.some((request) => request instanceof SearchRequest),
+					).to.be.false;
+				} finally {
+					processQuerySpy.restore();
+				}
+			});
+
 			it("get local first", async () => {
 				const localReadyWait = {
 					timeout: 120_000,

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -70,7 +70,7 @@ import {
 } from "@peerbit/time";
 import pDefer, { type DeferredPromise } from "p-defer";
 import PQueue from "p-queue";
-import { concat } from "uint8arrays";
+import { concat, fromString } from "uint8arrays";
 import { BlocksMessage } from "./blocks.js";
 import { type CPUUsage, CPUUsageIntervalLag } from "./cpu.js";
 import {
@@ -2065,6 +2065,14 @@ export class SharedLog<
 			) => void;
 		},
 	) {
+		const entryRangeId = (entry: Entry<T>) =>
+			sha256Sync(
+				concat([
+					this.log.id,
+					fromString(entry.hash),
+					fromString(this.node.identity.publicKey.hashcode()),
+				]),
+			);
 		let range:
 			| ReplicationRangeMessage<any>[]
 			| ReplicationOptions<R>
@@ -2074,6 +2082,7 @@ export class SharedLog<
 			range = rangeOrEntry;
 		} else if (rangeOrEntry instanceof Entry) {
 			range = {
+				id: entryRangeId(rangeOrEntry),
 				factor: 1,
 				offset: await this.domain.fromEntry(rangeOrEntry),
 				normalized: false,
@@ -2084,6 +2093,7 @@ export class SharedLog<
 			for (const entry of rangeOrEntry) {
 				if (entry instanceof Entry) {
 					ranges.push({
+						id: entryRangeId(entry),
 						factor: 1,
 						offset: await this.domain.fromEntry(entry),
 						normalized: false,
@@ -6072,7 +6082,7 @@ export class SharedLog<
 
 			await this.replicate(entriesToReplicate, {
 				rebalance: assumeSynced ? false : true,
-				checkDuplicates: true,
+				checkDuplicates: assumeSynced ? false : true,
 				mergeSegments:
 					typeof options.replicate !== "boolean" && options.replicate
 						? options.replicate.mergeSegments

--- a/packages/programs/data/shared-log/test/join.spec.ts
+++ b/packages/programs/data/shared-log/test/join.spec.ts
@@ -561,6 +561,15 @@ describe("join", () => {
 		expect(syncMessagesSent).to.be.false;
 		expect(rebalanced).to.be.false;
 
+		const replicationSegmentsAfterFirstJoin =
+			await db2.log.replicationIndex.getSize();
+		await db2.log.join([e1.entry], {
+			replicate: { mergeSegments: true, assumeSynced: true },
+		});
+		expect(await db2.log.replicationIndex.getSize()).to.equal(
+			replicationSegmentsAfterFirstJoin,
+		);
+
 		// checkl that no rebalance occurs
 	});
 

--- a/packages/transport/blocks/src/remote.ts
+++ b/packages/transport/blocks/src/remote.ts
@@ -68,6 +68,10 @@ type InFlightRead = {
 	addProviders: (providers: string[]) => void;
 };
 
+type RemoteReadOptions = Exclude<GetOptions["remote"], boolean | undefined> & {
+	hasher?: any;
+};
+
 export class RemoteBlocks implements IBlocks {
 	localStore: BlockStore;
 
@@ -453,13 +457,7 @@ export class RemoteBlocks implements IBlocks {
 	private async _readFromPeers(
 		cidString: string,
 		cidObject: CID,
-		options: {
-			signal?: AbortSignal;
-			timeout?: number;
-			hasher?: any;
-			from?: string[];
-			priority?: number;
-		} = {},
+		options: RemoteReadOptions = {},
 	): Promise<Uint8Array | undefined> {
 		const codec = (codecCodes as any)[cidObject.code];
 
@@ -704,9 +702,53 @@ export class RemoteBlocks implements IBlocks {
 			if (providers.length > 0) {
 				inFlight.addProviders(providers);
 			}
-			const result = await inFlight.promise;
-			return result?.bytes;
+			return this.waitForInFlightRead(inFlight, options);
 		}
+	}
+
+	private waitForInFlightRead(
+		inFlight: InFlightRead,
+		options: RemoteReadOptions,
+	): Promise<Uint8Array | undefined> {
+		if (options.timeout == null && options.signal == null) {
+			return inFlight.promise.then((result) => result?.bytes);
+		}
+
+		return new Promise((resolve, reject) => {
+			let settled = false;
+			let timeout: ReturnType<typeof setTimeout> | undefined;
+
+			const cleanup = () => {
+				if (timeout) clearTimeout(timeout);
+				options.signal?.removeEventListener("abort", abort);
+			};
+			const finish = (callback: () => void) => {
+				if (settled) return;
+				settled = true;
+				cleanup();
+				callback();
+			};
+			const abort = () => {
+				finish(() => reject(new AbortError()));
+			};
+
+			if (options.signal?.aborted) {
+				abort();
+				return;
+			}
+
+			if (options.timeout != null) {
+				timeout = setTimeout(() => {
+					finish(() => resolve(undefined));
+				}, Math.max(0, options.timeout));
+			}
+			options.signal?.addEventListener("abort", abort, { once: true });
+
+			inFlight.promise.then(
+				(result) => finish(() => resolve(result?.bytes)),
+				(error) => finish(() => reject(error)),
+			);
+		});
 	}
 
 	async stop(): Promise<void> {

--- a/packages/transport/blocks/test/libp2p.spec.ts
+++ b/packages/transport/blocks/test/libp2p.spec.ts
@@ -697,6 +697,32 @@ describe("transport", function () {
 		expect(t2 - t1 < 3100);
 	});
 
+	it("honors shorter caller timeout when reusing an in-flight get", async () => {
+		session = await TestSession.connected(2, {
+			services: { blocks: (c) => new DirectBlock(c) },
+		});
+		await waitForNeighbour(store(session, 0), store(session, 1));
+
+		const missingCid = "zb3we1BmfxpFg6bCXmrsuEo8JuQrGEf7RyFBdRxEHLuqc4CSr";
+		const firstRead = store(session, 0)
+			.get(missingCid, {
+				remote: { timeout: 1000, from: [store(session, 1).publicKeyHash] },
+			})
+			.catch((): undefined => undefined);
+
+		await delay(25);
+
+		const t1 = +new Date();
+		const secondRead = await store(session, 0).get(missingCid, {
+			remote: { timeout: 100, from: [store(session, 1).publicKeyHash] },
+		});
+		const t2 = +new Date();
+
+		expect(secondRead).equal(undefined);
+		expect(t2 - t1).to.be.lessThan(500);
+		await firstRead;
+	});
+
 	it("iterate", async () => {
 		session = await TestSession.disconnected(1, {
 			services: { blocks: (c) => new DirectBlock(c) },


### PR DESCRIPTION
## Summary
- Prioritize remote log-entry block reads as metadata traffic, while preserving explicit caller priorities.
- Avoid duplicate remote document fetches for replicated resolved `get` calls by using indexed search requests when compatible.
- Let later callers waiting on an existing block read enforce their own shorter timeout or abort signal.
- Avoid repeated replication segment churn for `assumeSynced` single-entry joins by giving entry ranges deterministic IDs and skipping duplicate scans in that path.

## Why
The file-share adaptive 64 MB benchmark was not just slow from throughput. Chunks were often blocked behind a shared manifest-head probe whose log-entry block read used bulk priority. Under upload/sync contention that metadata request could miss the 5s file-share timeout, forcing the slower document RPC fallback. Prioritizing log-entry metadata reads eliminated those manifest-head misses in local samples.

## Benchmark Evidence
Local file-share adaptive 64 MB samples after this patch, results kept under `/Users/admin/git/tmp/peerbit-file-share-local-timing-results`:

- `adaptive-64mb-log-priority-1.json`: upload 2790ms, discovery 2160ms, download 9942ms, no manifest misses, no `remote-get` chunks.
- `adaptive-64mb-log-priority-2.json`: upload 2515ms, discovery 2755ms, download 5353ms, no manifest misses, no `remote-get` chunks.
- `adaptive-64mb-log-priority-3.json`: upload 2754ms, discovery 1139ms, download 5633ms, no manifest misses, no `remote-get` chunks.

Before the metadata-priority fix, comparable 64 MB local samples had download tails around 25s to 38s and multiple `remote-get` fallback chunks.

## Test Plan
- `direnv exec . pnpm run build`
- `direnv exec . node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "remote"`
- `direnv exec . node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/blocks -- -t node --grep "honors shorter caller timeout"`
- `direnv exec . node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses indexed requests for replicated resolved remote get"`
- `direnv exec . node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "join replicate, assume synced"`
- `direnv exec . node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node`
- `direnv exec . node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/blocks -- -t node`
- `direnv exec . node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "custom index"`
- `direnv exec . env NODE_OPTIONS=--max-old-space-size=8192 PEERBIT_TEST_SESSION=mock pnpm run test:ci:part-7`
