### PR TITLE
perf(riblt): batch wasm symbol processing

### DIFF
--- a/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
+++ b/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
@@ -54,6 +54,108 @@ class SymbolSerialized implements SSymbol {
 	}
 }
 
+const CODED_SYMBOL_WORDS = 3;
+
+type RibltSymbolAdder = {
+	add_symbol: (symbol: bigint) => void;
+	add_symbols?: (symbols: BigUint64Array) => void;
+};
+
+type BatchEncoderWrapper = EncoderWrapper & {
+	produce_next_coded_symbols?: (count: number) => BigUint64Array;
+};
+
+type BatchDecoderWrapper = DecoderWrapper & {
+	add_symbols?: (symbols: BigUint64Array) => void;
+	add_coded_symbols_and_try_decode?: (symbols: BigUint64Array) => boolean;
+	get_remote_symbol_values?: () => BigUint64Array;
+};
+
+const addSymbolsToRiblt = (
+	target: RibltSymbolAdder,
+	symbols: Iterable<NumberOrBigint> | BigUint64Array,
+) => {
+	if (
+		typeof BigUint64Array !== "undefined" &&
+		typeof target.add_symbols === "function"
+	) {
+		target.add_symbols(
+			symbols instanceof BigUint64Array
+				? symbols
+				: BigUint64Array.from(symbols, coerceBigInt),
+		);
+		return;
+	}
+
+	for (const symbol of symbols) {
+		target.add_symbol(coerceBigInt(symbol));
+	}
+};
+
+const serializedSymbolsFromFlat = (
+	flat: BigUint64Array,
+): SymbolSerialized[] => {
+	if (flat.length % CODED_SYMBOL_WORDS !== 0) {
+		throw new Error("Invalid RIBLT coded symbol batch");
+	}
+
+	const symbols: SymbolSerialized[] = [];
+	for (let i = 0; i < flat.length; i += CODED_SYMBOL_WORDS) {
+		symbols.push(
+			new SymbolSerialized({
+				count: flat[i],
+				hash: flat[i + 1],
+				symbol: flat[i + 2],
+			}),
+		);
+	}
+	return symbols;
+};
+
+const produceNextSerializedSymbols = (
+	encoder: EncoderWrapper,
+	count: number,
+): SymbolSerialized[] => {
+	const produceBatch = (encoder as BatchEncoderWrapper)
+		.produce_next_coded_symbols;
+	if (typeof BigUint64Array !== "undefined" && produceBatch) {
+		return serializedSymbolsFromFlat(produceBatch.call(encoder, count));
+	}
+
+	const symbols: SymbolSerialized[] = [];
+	for (let i = 0; i < count; i++) {
+		symbols.push(new SymbolSerialized(encoder.produce_next_coded_symbol()));
+	}
+	return symbols;
+};
+
+const flatFromCodedSymbols = (
+	symbols: readonly (SSymbol | SymbolSerialized)[],
+): BigUint64Array => {
+	const flat = new BigUint64Array(symbols.length * CODED_SYMBOL_WORDS);
+	for (let i = 0; i < symbols.length; i++) {
+		const offset = i * CODED_SYMBOL_WORDS;
+		const symbol = symbols[i];
+		flat[offset] = coerceBigInt(symbol.count);
+		flat[offset + 1] = coerceBigInt(symbol.hash);
+		flat[offset + 2] = coerceBigInt(symbol.symbol);
+	}
+	return flat;
+};
+
+const getRemoteSymbolValues = (decoder: DecoderWrapper): bigint[] => {
+	const getBatch = (decoder as BatchDecoderWrapper).get_remote_symbol_values;
+	if (typeof BigUint64Array !== "undefined" && getBatch) {
+		return Array.from(getBatch.call(decoder));
+	}
+
+	const symbols: bigint[] = [];
+	for (const missingSymbol of decoder.get_remote_symbols()) {
+		symbols.push(coerceBigInt(missingSymbol));
+	}
+	return symbols;
+};
+
 const getSyncIdString = (message: { syncId: Uint8Array }) => {
 	return toBase64(message.syncId);
 };
@@ -271,7 +373,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			encoder: EncoderWrapper;
 			timeout: ReturnType<typeof setTimeout>;
 			refresh: () => void;
-			next: (message: { lastSeqNo: bigint }) => SSymbol[];
+			next: (message: { lastSeqNo: bigint }) => SymbolSerialized[];
 			free: () => void;
 		}
 	>;
@@ -696,16 +798,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 
 		const startSync = new StartSync({ from: start, to: end, symbols: [] });
 		const encoder = new EncoderWrapper();
-		if (
-			typeof BigUint64Array !== "undefined" &&
-			sortedEntries instanceof BigUint64Array
-		) {
-			encoder.add_symbols(sortedEntries);
-		} else {
-			for (const entry of sortedEntries) {
-				encoder.add_symbol(coerceBigInt(entry));
-			}
-		}
+		addSymbolsToRiblt(encoder, sortedEntries);
 
 		// For smaller sets, the original `sqrt(n)` heuristic can occasionally under-provision
 		// low-degree symbols early, causing an unnecessary `MoreSymbols` round-trip. Use a
@@ -714,11 +807,9 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			Math.sqrt(allCoordinatesToSyncWithIblt.length),
 		); // TODO choose better
 		initialSymbols = Math.max(64, initialSymbols);
-		for (let i = 0; i < initialSymbols; i++) {
-			startSync.symbols.push(
-				new SymbolSerialized(encoder.produce_next_coded_symbol()),
-			);
-		}
+		startSync.symbols.push(
+			...produceNextSerializedSymbols(encoder, initialSymbols),
+		);
 
 		const clear = () => {
 			encoder.free();
@@ -743,18 +834,14 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				}
 				obj.timeout = createTimeout();
 			},
-			next: (properties: { lastSeqNo: bigint }): SSymbol[] => {
+			next: (properties: { lastSeqNo: bigint }): SymbolSerialized[] => {
 				if (properties.lastSeqNo <= lastSeqNo) {
 					return [];
 				}
 				lastSeqNo++;
 				obj.refresh(); // TODO use timestamp instead and collective pruning/refresh
 
-				let result: SSymbol[] = [];
-				for (let i = 0; i < nextBatch; i++) {
-					result.push(encoder.produce_next_coded_symbol());
-				}
-				return result;
+				return produceNextSerializedSymbols(encoder, nextBatch);
 			},
 			free: clear,
 			outgoing: properties.entries,
@@ -847,10 +934,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 							return false;
 						}
 
-						const allMissingSymbolsInRemote: bigint[] = [];
-						for (const missingSymbol of decoder.get_remote_symbols()) {
-							allMissingSymbolsInRemote.push(missingSymbol);
-						}
+						const allMissingSymbolsInRemote = getRemoteSymbolValues(decoder);
 
 						// The IBLT decoder is based on a local snapshot. Entries can arrive via
 						// overlapping repair before we issue the follow-up simple request, so
@@ -870,6 +954,23 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 						}
 
 						lastSeqNo = symbolMessage.seqNo;
+
+						const addBatchAndDecode:
+							| ((symbols: BigUint64Array) => boolean)
+							| undefined = (decoder as BatchDecoderWrapper)
+							.add_coded_symbols_and_try_decode;
+						if (typeof BigUint64Array !== "undefined" && addBatchAndDecode) {
+							if (
+								addBatchAndDecode.call(
+									decoder,
+									flatFromCodedSymbols(symbolMessage.symbols),
+								) &&
+								finalizeIfDecoded()
+							) {
+								return true;
+							}
+							continue;
+						}
 
 						for (const symbol of symbolMessage.symbols) {
 							const normalizedSymbol =
@@ -965,7 +1066,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				new MoreSymbols({
 					lastSeqNo: message.lastSeqNo,
 					syncId: message.syncId,
-					symbols: obj.next(message).map((x) => new SymbolSerialized(x)),
+					symbols: obj.next(message),
 				}),
 				{
 					mode: new SilentDelivery({ to: [context.from!], redundancy: 1 }),

--- a/packages/utils/rateless-iblt/src/wasm.rs
+++ b/packages/utils/rateless-iblt/src/wasm.rs
@@ -36,6 +36,32 @@ impl Symbol for MyU64 {
 
 pub type IdentityU64 = u64;
 
+const CODED_SYMBOL_WORDS: usize = 3;
+
+fn coded_symbol_from_flat(
+    flat: &[u64],
+    offset: usize,
+) -> Result<CodedSymbol<IdentityU64>, JsValue> {
+    let count = flat[offset];
+    if count > i64::MAX as u64 {
+        return Err(JsValue::from_str("Invalid coded symbol count"));
+    }
+    Ok(CodedSymbol {
+        count: count as i64,
+        hash: flat[offset + 1],
+        symbol: flat[offset + 2],
+    })
+}
+
+fn validate_flat_coded_symbols(symbols: &[u64]) -> Result<(), JsValue> {
+    if symbols.len() % CODED_SYMBOL_WORDS != 0 {
+        return Err(JsValue::from_str(
+            "Expected coded symbols flat array length to be a multiple of 3",
+        ));
+    }
+    Ok(())
+}
+
 #[wasm_bindgen]
 pub struct EncoderWrapper {
     encoder: Encoder<IdentityU64>,
@@ -82,6 +108,17 @@ impl EncoderWrapper {
         JsValue::from(obj)
     }
 
+    pub fn produce_next_coded_symbols(&mut self, count: usize) -> Vec<u64> {
+        let mut symbols = Vec::with_capacity(count * CODED_SYMBOL_WORDS);
+        for _ in 0..count {
+            let coded_symbol = self.encoder.produce_next_coded_symbol();
+            symbols.push(coded_symbol.count as u64);
+            symbols.push(coded_symbol.hash);
+            symbols.push(coded_symbol.symbol);
+        }
+        symbols
+    }
+
     pub fn reset(&mut self) {
         self.encoder.reset();
     }
@@ -118,6 +155,12 @@ impl DecoderWrapper {
         self.decoder.add_symbol(&my_symbol);
     }
 
+    pub fn add_symbols(&mut self, symbols: Vec<u64>) {
+        for symbol in symbols.iter() {
+            self.decoder.add_symbol(symbol);
+        }
+    }
+
     pub fn add_coded_symbol(&mut self, coded_symbol_js: &JsValue) {
         // Extract symbol, hash, and count from JsValue
         let symbol_js =
@@ -135,6 +178,34 @@ impl DecoderWrapper {
         };
 
         self.decoder.add_coded_symbol(&coded_symbol);
+    }
+
+    pub fn add_coded_symbols(&mut self, symbols: Vec<u64>) -> Result<(), JsValue> {
+        validate_flat_coded_symbols(&symbols)?;
+        for offset in (0..symbols.len()).step_by(CODED_SYMBOL_WORDS) {
+            let coded_symbol = coded_symbol_from_flat(&symbols, offset)?;
+            self.decoder.add_coded_symbol(&coded_symbol);
+        }
+        Ok(())
+    }
+
+    pub fn add_coded_symbols_and_try_decode(&mut self, symbols: Vec<u64>) -> Result<bool, JsValue> {
+        validate_flat_coded_symbols(&symbols)?;
+        for offset in (0..symbols.len()).step_by(CODED_SYMBOL_WORDS) {
+            let coded_symbol = coded_symbol_from_flat(&symbols, offset)?;
+            self.decoder.add_coded_symbol(&coded_symbol);
+            match self.decoder.try_decode() {
+                Ok(_) => {
+                    if self.decoder.decoded() {
+                        return Ok(true);
+                    }
+                }
+                Err(Error::InvalidDegree) => {}
+                Err(Error::InvalidSize) => return Err(JsValue::from_str("Invalid size")),
+                Err(Error::DecodeFailed) => return Err(JsValue::from_str("Decode failed")),
+            }
+        }
+        Ok(self.decoder.decoded())
     }
 
     pub fn try_decode(&mut self) -> Result<(), JsValue> {
@@ -164,6 +235,14 @@ impl DecoderWrapper {
         array
     }
 
+    pub fn get_remote_symbol_values(&self) -> Vec<u64> {
+        self.decoder
+            .get_remote_symbols()
+            .iter()
+            .map(|sym| sym.symbol)
+            .collect()
+    }
+
     pub fn get_local_symbols(&self) -> Array {
         let symbols = self.decoder.get_local_symbols();
         let array = Array::new();
@@ -171,6 +250,14 @@ impl DecoderWrapper {
             array.push(&JsValue::from(sym.symbol));
         }
         array
+    }
+
+    pub fn get_local_symbol_values(&self) -> Vec<u64> {
+        self.decoder
+            .get_local_symbols()
+            .iter()
+            .map(|sym| sym.symbol)
+            .collect()
     }
 
     pub fn reset(&mut self) {

--- a/packages/utils/rateless-iblt/test/node.js
+++ b/packages/utils/rateless-iblt/test/node.js
@@ -72,6 +72,32 @@ describe("riblt", () => {
 		expect(cost).to.equal(2);
 	});
 
+	it("diff (batched coded symbols)", async () => {
+		const aliceSymbols = [1n, 2n, 3n, 4n, 5n, 6n, 7n, 8n, 9n, 10n];
+		const bobSymbols = [1n, 3n, 4n, 5n, 6n, 7n, 8n, 9n, 10n, 11n];
+
+		const encoder = new EncoderWrapper();
+		encoder.add_symbols(BigUint64Array.from(aliceSymbols));
+
+		const decoder = new DecoderWrapper();
+		decoder.add_symbols(BigUint64Array.from(bobSymbols));
+
+		const codedSymbols = encoder.produce_next_coded_symbols(2);
+		expect(codedSymbols).to.be.instanceOf(BigUint64Array);
+		expect(codedSymbols.length).to.equal(6);
+		expect(decoder.add_coded_symbols_and_try_decode(codedSymbols)).to.equal(
+			true,
+		);
+
+		const remoteSymbols = decoder.get_remote_symbol_values();
+		const localSymbols = decoder.get_local_symbol_values();
+
+		expect(remoteSymbols).to.be.instanceOf(BigUint64Array);
+		expect(localSymbols).to.be.instanceOf(BigUint64Array);
+		expect(Array.from(remoteSymbols)).to.deep.equal([2n]);
+		expect(Array.from(localSymbols)).to.deep.equal([11n]);
+	});
+
 	it("no diff", async () => {
 		const aliceSymbols = [1n, 2n, 3n, 4n, 5n, 6n, 7n, 8n, 9n, 10n];
 		const bobSymbols = [1n, 2n, 3n, 4n, 5n, 6n, 7n, 8n, 9n, 10n];


### PR DESCRIPTION
## Summary
- add batched RIBLT WASM APIs for coded symbol production and decode
- route shared-log RIBLT sync through batch APIs with fallback to legacy methods
- keep local range encoder construction on the faster existing per-symbol path after benchmarking
- add node coverage for batched coded-symbol diff decoding

## Performance
- direct produce 10k coded symbols: 22.31ms -> 9.80ms median (~2.3x)
- direct decode 10k coded symbols: 23.21ms -> 0.65ms median (~35.9x)
- sender StartSync setup: modest higher-level wins (~5-17% in local tinybench runs)

## Testing
- pnpm --filter @peerbit/riblt run test
- pnpm --filter @peerbit/shared-log run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep \"rateless-iblt-syncronizer\"