### PR TITLE
perf(riblt): prepare StartSync encoder in WASM

### DIFF
--- a/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
+++ b/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
@@ -65,6 +65,18 @@ type BatchEncoderWrapper = EncoderWrapper & {
 	produce_next_coded_symbols?: (count: number) => BigUint64Array;
 };
 
+type StartSyncEncoderWrapper = EncoderWrapper & {
+	add_symbols_sorted_and_find_range?: (
+		symbols: BigUint64Array,
+		maxValue: bigint,
+	) => BigUint64Array;
+	add_symbols_sorted_find_range_and_produce?: (
+		symbols: BigUint64Array,
+		maxValue: bigint,
+		count: number,
+	) => BigUint64Array;
+};
+
 type BatchDecoderWrapper = DecoderWrapper & {
 	add_symbols?: (symbols: BigUint64Array) => void;
 	add_coded_symbols_and_try_decode?: (symbols: BigUint64Array) => boolean;
@@ -154,6 +166,121 @@ const getRemoteSymbolValues = (decoder: DecoderWrapper): bigint[] => {
 		symbols.push(coerceBigInt(missingSymbol));
 	}
 	return symbols;
+};
+
+const prepareStartSyncEncoder = (
+	coordinates: readonly bigint[],
+	maxValue: NumberOrBigint,
+	initialSymbolCount: number,
+): {
+	encoder: EncoderWrapper;
+	start: bigint;
+	end: bigint;
+	initialSymbols?: SymbolSerialized[];
+} => {
+	const encoder = new EncoderWrapper();
+	let complete = false;
+	try {
+		const prepareAndProduceNative = (encoder as StartSyncEncoderWrapper)
+			.add_symbols_sorted_find_range_and_produce;
+		if (typeof BigUint64Array !== "undefined" && prepareAndProduceNative) {
+			const prepared = prepareAndProduceNative.call(
+				encoder,
+				BigUint64Array.from(coordinates),
+				coerceBigInt(maxValue),
+				initialSymbolCount,
+			);
+			if (
+				prepared.length < 2 ||
+				(prepared.length - 2) % CODED_SYMBOL_WORDS !== 0
+			) {
+				throw new Error("Invalid RIBLT prepared encoder result");
+			}
+			complete = true;
+			return {
+				encoder,
+				start: prepared[0],
+				end: prepared[1],
+				initialSymbols: serializedSymbolsFromFlat(prepared.subarray(2)),
+			};
+		}
+
+		const prepareNative = (encoder as StartSyncEncoderWrapper)
+			.add_symbols_sorted_and_find_range;
+		if (typeof BigUint64Array !== "undefined" && prepareNative) {
+			const range = prepareNative.call(
+				encoder,
+				BigUint64Array.from(coordinates),
+				coerceBigInt(maxValue),
+			);
+			if (range.length !== 2) {
+				throw new Error("Invalid RIBLT range result");
+			}
+			complete = true;
+			return { encoder, start: range[0], end: range[1] };
+		}
+
+		let sortedEntries: bigint[] | BigUint64Array;
+		if (typeof BigUint64Array !== "undefined") {
+			const typed = new BigUint64Array(coordinates.length);
+			for (let i = 0; i < coordinates.length; i++) {
+				typed[i] = coordinates[i];
+			}
+			typed.sort();
+			sortedEntries = typed;
+		} else {
+			sortedEntries = [...coordinates].sort((a, b) => {
+				if (a > b) {
+					return 1;
+				} else if (a < b) {
+					return -1;
+				} else {
+					return 0;
+				}
+			});
+		}
+
+		// assume sorted, and find the largest gap
+		let largestGap = 0n;
+		let largestGapIndex = 0;
+		for (let i = 0; i < sortedEntries.length; i++) {
+			const current = sortedEntries[i];
+			const next = sortedEntries[(i + 1) % sortedEntries.length];
+			const gap =
+				next >= current
+					? next - current
+					: coerceBigInt(maxValue) - current + next;
+			if (gap > largestGap) {
+				largestGap = gap;
+				largestGapIndex = i;
+			}
+		}
+
+		const smallestRangeStartIndex =
+			(largestGapIndex + 1) % sortedEntries.length;
+		const smallestRangeEndIndex = largestGapIndex; /// === (smallRangeStartIndex + 1) % sortedEntries.length
+		let smallestRangeStart = sortedEntries[smallestRangeStartIndex];
+		let smallestRangeEnd = sortedEntries[smallestRangeEndIndex];
+		let start: bigint, end: bigint;
+		if (smallestRangeEnd === smallestRangeStart) {
+			start = smallestRangeEnd;
+			end = smallestRangeEnd + 1n;
+			if (end > maxValue) {
+				end = 0n;
+			}
+		} else {
+			start = smallestRangeStart;
+			end = smallestRangeEnd;
+		}
+
+		addSymbolsToRiblt(encoder, sortedEntries);
+		complete = true;
+		return { encoder, start, end };
+	} finally {
+		if (!complete) {
+			encoder.free();
+		}
+	}
 };
 
 const getSyncIdString = (message: { syncId: Uint8Array }) => {
@@ -743,73 +870,26 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 
 		await ribltReady;
 
-		let sortedEntries: bigint[] | BigUint64Array;
-		if (typeof BigUint64Array !== "undefined") {
-			const typed = new BigUint64Array(allCoordinatesToSyncWithIblt.length);
-			for (let i = 0; i < allCoordinatesToSyncWithIblt.length; i++) {
-				typed[i] = allCoordinatesToSyncWithIblt[i];
-			}
-			typed.sort();
-			sortedEntries = typed;
-		} else {
-			sortedEntries = allCoordinatesToSyncWithIblt.sort((a, b) => {
-				if (a > b) {
-					return 1;
-				} else if (a < b) {
-					return -1;
-				} else {
-					return 0;
-				}
-			});
-		}
-
-		// assume sorted, and find the largest gap
-		let largestGap = 0n;
-		let largestGapIndex = 0;
-		for (let i = 0; i < sortedEntries.length; i++) {
-			const current = sortedEntries[i];
-			const next = sortedEntries[(i + 1) % sortedEntries.length];
-			const gap =
-				next >= current
-					? next - current
-					: coerceBigInt(this.properties.numbers.maxValue) - current + next;
-			if (gap > largestGap) {
-				largestGap = gap;
-				largestGapIndex = i;
-			}
-		}
-
-		const smallestRangeStartIndex =
-			(largestGapIndex + 1) % sortedEntries.length;
-		const smallestRangeEndIndex = largestGapIndex; /// === (smallRangeStartIndex + 1) % sortedEntries.length
-		let smallestRangeStart = sortedEntries[smallestRangeStartIndex];
-		let smallestRangeEnd = sortedEntries[smallestRangeEndIndex];
-		let start: bigint, end: bigint;
-		if (smallestRangeEnd === smallestRangeStart) {
-			start = smallestRangeEnd;
-			end = smallestRangeEnd + 1n;
-			if (end > this.properties.numbers.maxValue) {
-				end = 0n;
-			}
-		} else {
-			start = smallestRangeStart;
-			end = smallestRangeEnd;
-		}
-
-		const startSync = new StartSync({ from: start, to: end, symbols: [] });
-		const encoder = new EncoderWrapper();
-		addSymbolsToRiblt(encoder, sortedEntries);
-
 		// For smaller sets, the original `sqrt(n)` heuristic can occasionally under-provision
 		// low-degree symbols early, causing an unnecessary `MoreSymbols` round-trip. Use a
 		// small floor to make small-delta syncs more reliable without affecting large-n behavior.
-		let initialSymbols = Math.round(
+		let initialSymbolCount = Math.round(
 			Math.sqrt(allCoordinatesToSyncWithIblt.length),
 		); // TODO choose better
-		initialSymbols = Math.max(64, initialSymbols);
-		startSync.symbols.push(
-			...produceNextSerializedSymbols(encoder, initialSymbols),
+		initialSymbolCount = Math.max(64, initialSymbolCount);
+		const { encoder, start, end, initialSymbols } = prepareStartSyncEncoder(
+			allCoordinatesToSyncWithIblt,
+			this.properties.numbers.maxValue,
+			initialSymbolCount,
 		);
+
+		const startSync = new StartSync({
+			from: start,
+			to: end,
+			symbols:
+				initialSymbols ??
+				produceNextSerializedSymbols(encoder, initialSymbolCount),
+		});
 
 		const clear = () => {
 			encoder.free();

--- a/packages/utils/rateless-iblt/src/wasm.rs
+++ b/packages/utils/rateless-iblt/src/wasm.rs
@@ -62,6 +62,50 @@ fn validate_flat_coded_symbols(symbols: &[u64]) -> Result<(), JsValue> {
     Ok(())
 }
 
+fn smallest_wrapping_range_from_sorted_symbols(symbols: &[u64], max_value: u64) -> (u64, u64) {
+    let mut largest_gap = 0u64;
+    let mut largest_gap_index = 0usize;
+
+    for i in 0..symbols.len() {
+        let current = symbols[i];
+        let next = symbols[(i + 1) % symbols.len()];
+        let gap = if next >= current {
+            next - current
+        } else {
+            max_value - current + next
+        };
+
+        if gap > largest_gap {
+            largest_gap = gap;
+            largest_gap_index = i;
+        }
+    }
+
+    let start_index = (largest_gap_index + 1) % symbols.len();
+    let end_index = largest_gap_index;
+    let start = symbols[start_index];
+    let mut end = symbols[end_index];
+
+    if end == start {
+        end = if end >= max_value { 0 } else { end + 1 };
+    }
+
+    (start, end)
+}
+
+fn push_next_coded_symbols(
+    encoder: &mut Encoder<IdentityU64>,
+    output: &mut Vec<u64>,
+    count: usize,
+) {
+    for _ in 0..count {
+        let coded_symbol = encoder.produce_next_coded_symbol();
+        output.push(coded_symbol.count as u64);
+        output.push(coded_symbol.hash);
+        output.push(coded_symbol.symbol);
+    }
+}
+
 #[wasm_bindgen]
 pub struct EncoderWrapper {
     encoder: Encoder<IdentityU64>,
@@ -87,6 +131,47 @@ impl EncoderWrapper {
         }
     }
 
+    pub fn add_symbols_sorted_and_find_range(
+        &mut self,
+        mut symbols: Vec<u64>,
+        max_value: u64,
+    ) -> Result<Vec<u64>, JsValue> {
+        if symbols.is_empty() {
+            return Err(JsValue::from_str("Expected at least one RIBLT symbol"));
+        }
+
+        symbols.sort_unstable();
+        let (start, end) = smallest_wrapping_range_from_sorted_symbols(&symbols, max_value);
+        for symbol in symbols.iter() {
+            self.encoder.add_symbol(symbol);
+        }
+
+        Ok(vec![start, end])
+    }
+
+    pub fn add_symbols_sorted_find_range_and_produce(
+        &mut self,
+        mut symbols: Vec<u64>,
+        max_value: u64,
+        count: usize,
+    ) -> Result<Vec<u64>, JsValue> {
+        if symbols.is_empty() {
+            return Err(JsValue::from_str("Expected at least one RIBLT symbol"));
+        }
+
+        symbols.sort_unstable();
+        let (start, end) = smallest_wrapping_range_from_sorted_symbols(&symbols, max_value);
+        for symbol in symbols.iter() {
+            self.encoder.add_symbol(symbol);
+        }
+
+        let mut output = Vec::with_capacity(2 + count * CODED_SYMBOL_WORDS);
+        output.push(start);
+        output.push(end);
+        push_next_coded_symbols(&mut self.encoder, &mut output, count);
+        Ok(output)
+    }
+
     pub fn produce_next_coded_symbol(&mut self) -> JsValue {
         let coded_symbol = self.encoder.produce_next_coded_symbol();
         let symbol_u64 = coded_symbol.symbol;
@@ -110,12 +195,7 @@ impl EncoderWrapper {
 
     pub fn produce_next_coded_symbols(&mut self, count: usize) -> Vec<u64> {
         let mut symbols = Vec::with_capacity(count * CODED_SYMBOL_WORDS);
-        for _ in 0..count {
-            let coded_symbol = self.encoder.produce_next_coded_symbol();
-            symbols.push(coded_symbol.count as u64);
-            symbols.push(coded_symbol.hash);
-            symbols.push(coded_symbol.symbol);
-        }
+        push_next_coded_symbols(&mut self.encoder, &mut symbols, count);
         symbols
     }
 

--- a/packages/utils/rateless-iblt/test/node.js
+++ b/packages/utils/rateless-iblt/test/node.js
@@ -98,6 +98,60 @@ describe("riblt", () => {
 		expect(Array.from(localSymbols)).to.deep.equal([11n]);
 	});
 
+	it("prepares an encoder from unsorted symbols", async () => {
+		const symbols = [10n, 1n, 3n, 8n];
+		const encoder = new EncoderWrapper();
+		const range = encoder.add_symbols_sorted_and_find_range(
+			BigUint64Array.from(symbols),
+			11n,
+		);
+
+		expect(range).to.be.instanceOf(BigUint64Array);
+		expect(Array.from(range)).to.deep.equal([8n, 3n]);
+
+		const decoder = new DecoderWrapper();
+		decoder.add_symbols(BigUint64Array.from(symbols));
+		expect(
+			decoder.add_coded_symbols_and_try_decode(
+				encoder.produce_next_coded_symbols(1),
+			),
+		).to.equal(true);
+		expect(Array.from(decoder.get_remote_symbol_values())).to.deep.equal([]);
+		expect(Array.from(decoder.get_local_symbol_values())).to.deep.equal([]);
+
+		const single = new EncoderWrapper();
+		expect(
+			Array.from(
+				single.add_symbols_sorted_and_find_range(
+					BigUint64Array.from([11n]),
+					11n,
+				),
+			),
+		).to.deep.equal([11n, 0n]);
+	});
+
+	it("prepares an encoder and produces coded symbols", async () => {
+		const symbols = [10n, 1n, 3n, 8n];
+		const encoder = new EncoderWrapper();
+		const prepared = encoder.add_symbols_sorted_find_range_and_produce(
+			BigUint64Array.from(symbols),
+			11n,
+			1,
+		);
+
+		expect(prepared).to.be.instanceOf(BigUint64Array);
+		expect(prepared.length).to.equal(5);
+		expect(Array.from(prepared.subarray(0, 2))).to.deep.equal([8n, 3n]);
+
+		const decoder = new DecoderWrapper();
+		decoder.add_symbols(BigUint64Array.from(symbols));
+		expect(decoder.add_coded_symbols_and_try_decode(prepared.subarray(2))).to.equal(
+			true,
+		);
+		expect(Array.from(decoder.get_remote_symbol_values())).to.deep.equal([]);
+		expect(Array.from(decoder.get_local_symbol_values())).to.deep.equal([]);
+	});
+
 	it("no diff", async () => {
 		const aliceSymbols = [1n, 2n, 3n, 4n, 5n, 6n, 7n, 8n, 9n, 10n];
 		const bobSymbols = [1n, 2n, 3n, 4n, 5n, 6n, 7n, 8n, 9n, 10n];


### PR DESCRIPTION
## Summary
- add WASM helpers that sort RIBLT symbols, compute the wrapping StartSync range, fill the encoder, and optionally produce initial coded symbols in one call
- route shared-log StartSync sender setup through the native prepare path with the existing JS implementation as fallback
- add node coverage for native prepare, wraparound single-symbol ranges, and combined prepare+produce output

## Performance
Local `rateless-iblt-sender-startsync` benchmark with random hash numbers:
- n=1000: 0.381ms -> 0.331ms
- n=10000: 5.98ms -> 4.87ms
- n=50000: 40.30ms -> 33.78ms

## Testing
- pnpm --filter @peerbit/riblt run test
- pnpm --filter @peerbit/shared-log run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep \"rateless-iblt-syncronizer\"