### PR TITLE
perf(shared-log): batch local RIBLT range loading

### DIFF
--- a/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
+++ b/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
@@ -459,8 +459,19 @@ const buildEncoderOrDecoderFromRange = async <
 		return false;
 	}
 
-	for (const entry of entries) {
-		encoder.add_symbol(coerceBigInt(entry.value.hashNumber));
+	if (
+		typeof BigUint64Array !== "undefined" &&
+		typeof (encoder as RibltSymbolAdder).add_symbols === "function"
+	) {
+		const symbols = new BigUint64Array(entries.length);
+		for (let i = 0; i < entries.length; i++) {
+			symbols[i] = coerceBigInt(entries[i].value.hashNumber);
+		}
+		addSymbolsToRiblt(encoder as RibltSymbolAdder, symbols);
+	} else {
+		for (const entry of entries) {
+			encoder.add_symbol(coerceBigInt(entry.value.hashNumber));
+		}
 	}
 	return encoder as E;
 };


### PR DESCRIPTION
Summary:
- batch local range hash numbers into a BigUint64Array before loading the RIBLT encoder/decoder
- keep the existing per-symbol fallback when batched WASM helpers are unavailable

Performance (rateless-iblt-startsync-cache, warmup=3, iterations=10):
- cold n=1000: 0.032 ms -> 0.029 ms
- cold n=10000: 0.299 ms -> 0.260 ms
- cold n=50000: 1.49 ms -> 1.35 ms
- warm-cache path unchanged, as expected

Testing:
- pnpm --filter @peerbit/shared-log run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "rateless-iblt"
- git diff --check