### PR TITLE
feat(document): allow foreground reads to cache without blocking

### DIFF
--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -201,6 +201,13 @@ export type ReachScope = {
 
 export type RemoteQueryOptions<Q, R, D> = RPCRequestAllOptions<Q, R> & {
 	replicate?: boolean;
+	/**
+	 * When `replicate` is true, wait for local replication bookkeeping before
+	 * resolving query results. Defaults to true for existing sync semantics. Set
+	 * to false for foreground reads that should return once remote results arrive
+	 * while caching those results locally in the background.
+	 */
+	waitForReplication?: boolean;
 	minAge?: number;
 	throwOnMissing?: boolean;
 	retryMissingResponses?: boolean;
@@ -216,6 +223,24 @@ export type RemoteQueryOptions<Q, R, D> = RPCRequestAllOptions<Q, R> & {
 	reach?: ReachScope;
 	/** WHEN are we allowed to proceed? Quorum semantics over a chosen group. */
 	wait?: WaitPolicy;
+};
+
+type RemoteReplicationOptions = {
+	replicate?: boolean;
+	waitForReplication?: boolean;
+};
+
+const shouldReplicateRemoteResults = (
+	remote?: boolean | RemoteReplicationOptions,
+): boolean => typeof remote !== "boolean" && remote?.replicate === true;
+
+const shouldWaitForRemoteReplication = (
+	remote?: boolean | RemoteReplicationOptions,
+): boolean => {
+	if (typeof remote === "boolean" || remote?.replicate !== true) {
+		return false;
+	}
+	return remote.waitForReplication !== false;
 };
 
 export type QueryOptions<T, I, D, Resolve extends boolean | undefined> = {
@@ -327,8 +352,7 @@ const coerceQuery = <Resolve extends boolean | undefined>(
 	| types.SearchRequest
 	| types.SearchRequestIndexed
 	| types.IterationRequest => {
-	const replicate =
-		typeof options?.remote !== "boolean" ? options?.remote?.replicate : false;
+	const replicate = shouldReplicateRemoteResults(options?.remote);
 	const shouldResolve = options?.resolve !== false;
 	const useLegacyRequests = compatibility != null && compatibility <= 9;
 
@@ -421,7 +445,7 @@ const introduceEntries = async <
 			response.response.results.forEach((r) =>
 				initializeResultType(r, documentType, indexedType),
 			);
-			if (typeof options?.remote !== "boolean" && options?.remote?.replicate) {
+			if (shouldReplicateRemoteResults(options?.remote)) {
 				const uniqueResults = response.response.results.filter((result) => {
 					const resultWithContext = result as
 						| types.ResultValue<T>
@@ -438,13 +462,23 @@ const introduceEntries = async <
 					return true;
 				});
 				if (uniqueResults.length > 0) {
-					await sync(
+					const syncPromise = sync(
 						queryRequest,
 						new types.Results({
 							results: uniqueResults,
 							kept: response.response.kept,
 						}),
 					);
+					if (shouldWaitForRemoteReplication(options?.remote)) {
+						await syncPromise;
+					} else {
+						void syncPromise.catch((error) => {
+							logger.error(
+								"Failed to replicate remote query results in the background",
+								error,
+							);
+						});
+					}
 				}
 			}
 			options?.onResponse &&

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -1225,6 +1225,141 @@ describe("index", () => {
 						}
 					});
 
+					it("waits for replicated remote search sync by default", async () => {
+						stores[0] = await session.peers[0].open<TestStore>(
+							new TestStore({ docs: new Documents() }),
+							{
+								args: {
+									replicate: true,
+								},
+							},
+						);
+
+						stores[1] = await session.peers[1].open<TestStore>(
+							stores[0].clone(),
+							{
+								args: {
+									replicate: false,
+								},
+							},
+						);
+
+						await stores[0].docs.put(new Document({ id: "sync-wait" }));
+						await stores[1].docs.index.waitFor(
+							stores[0].node.identity.publicKey,
+						);
+
+						const joinStarted = pDefer<void>();
+						const joinGate = pDefer<void>();
+						const originalJoin = stores[1].docs.log.join.bind(
+							stores[1].docs.log,
+						);
+						const joinStub = sinon
+							.stub(stores[1].docs.log, "join")
+							.callsFake(async (entries, options) => {
+								joinStarted.resolve();
+								await joinGate.promise;
+								return originalJoin(entries, options);
+							});
+
+						try {
+							let resolvedBeforeJoin = false;
+							const searchPromise = stores[1].docs.index
+								.search(
+									new SearchRequest({
+										query: [],
+									}),
+									{ remote: { replicate: true } },
+								)
+								.then((results) => {
+									resolvedBeforeJoin = true;
+									return results;
+								});
+
+							await joinStarted.promise;
+							await delay(50);
+							expect(resolvedBeforeJoin).equal(false);
+
+							joinGate.resolve();
+							const results = await searchPromise;
+							expect(results).to.have.length(1);
+						} finally {
+							joinGate.resolve();
+							joinStub.restore();
+						}
+					});
+
+					it("can replicate remote search results without blocking foreground results", async () => {
+						stores[0] = await session.peers[0].open<TestStore>(
+							new TestStore({ docs: new Documents() }),
+							{
+								args: {
+									replicate: true,
+								},
+							},
+						);
+
+						stores[1] = await session.peers[1].open<TestStore>(
+							stores[0].clone(),
+							{
+								args: {
+									replicate: false,
+								},
+							},
+						);
+
+						await stores[0].docs.put(new Document({ id: "async-sync" }));
+						await stores[1].docs.index.waitFor(
+							stores[0].node.identity.publicKey,
+						);
+
+						const joinStarted = pDefer<void>();
+						const joinGate = pDefer<void>();
+						const originalJoin = stores[1].docs.log.join.bind(
+							stores[1].docs.log,
+						);
+						const joinStub = sinon
+							.stub(stores[1].docs.log, "join")
+							.callsFake(async (entries, options) => {
+								joinStarted.resolve();
+								await joinGate.promise;
+								return originalJoin(entries, options);
+							});
+
+						try {
+							const timeout = Symbol("timeout");
+							const searchPromise = stores[1].docs.index.search(
+								new SearchRequest({
+									query: [],
+								}),
+								{
+									remote: {
+										replicate: true,
+										waitForReplication: false,
+									},
+								},
+							);
+
+							await joinStarted.promise;
+							const resultOrTimeout = await Promise.race([
+								searchPromise,
+								delay(50).then(() => timeout),
+							]);
+							expect(resultOrTimeout).to.not.equal(timeout);
+							expect(resultOrTimeout).to.have.length(1);
+
+							joinGate.resolve();
+							const results = await searchPromise;
+							expect(results).to.have.length(1);
+							await waitForResolved(async () =>
+								expect(await stores[1].docs.index.getSize()).equal(1),
+							);
+						} finally {
+							joinGate.resolve();
+							joinStub.restore();
+						}
+					});
+
 					it("iterate replicate", async () => {
 						stores[0] = await session.peers[0].open<TestStore>(
 							new TestStore({ docs: new Documents() }),


### PR DESCRIPTION
## Summary

Adds an opt-in `remote.waitForReplication: false` mode for document queries that request `remote.replicate: true`.

By default, `remote.replicate: true` keeps its existing synchronous contract: search/iterate waits for local replication bookkeeping before resolving. Foreground reads can now choose non-blocking cache-fill behavior: remote results are returned once received, while local replication of those results continues in the background.

This addresses the Peerbit-level contention seen in file-share style workloads where foreground document reads and background chunk replication compete on the same peer/log. See #776.

## What changed

- Added `waitForReplication?: boolean` to `RemoteQueryOptions`.
- Preserved default wait-before-return semantics for existing callers.
- Added non-blocking background replication handling when `waitForReplication: false`.
- Added regression coverage proving both behaviors:
  - default replicated remote search waits for `SharedLog.join` to settle.
  - opt-in foreground search returns results while `SharedLog.join` is still blocked, then local replication settles afterward.

## Validation

- `pnpm run build` passed on rebased `origin/master`.
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "search replicate"` passed: 15 passing.
- Before rebasing, `PEERBIT_TEST_SESSION=mock pnpm run test:ci:part-2a` passed: 202 document tests + 3 document-proxy tests.
- Before rebasing, `PEERBIT_TEST_SESSION=mock pnpm run test:ci:part-7` had one intermittent shared-log distribution-objective failure in `u32-simple sharding distribution objectives memory joining half limited`; isolated rerun of `joining half limited` passed for both u32-simple and u64-iblt (`2 passing`).
