### PR TITLE
Improve SQLite query planner index selection

### DIFF
--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -1019,16 +1019,14 @@ export class Log<T> {
 		skipFirst = false,
 	) {
 		const toDelete = await this.prepareDeleteRecursively(from, skipFirst);
-		const promises = toDelete.map(async (x) => {
-			const removed = await x.fn();
-			if (removed) {
-				return removed;
+		const removedEntries: ShallowEntry[] = [];
+		for (const x of toDelete) {
+			const removedEntry = await x.fn();
+			if (removedEntry) {
+				removedEntries.push(removedEntry);
 			}
-			return undefined;
-		});
-
-		const results = Promise.all(promises);
-		return (await results).filter((x) => x) as ShallowEntry[];
+		}
+		return removedEntries;
 	}
 
 	/// TODO simplify methods below

--- a/packages/programs/data/shared-log/benchmark/sync-batch-sweep.ts
+++ b/packages/programs/data/shared-log/benchmark/sync-batch-sweep.ts
@@ -13,7 +13,9 @@ import { keys } from "@libp2p/crypto";
 import { TestSession } from "@peerbit/test-utils";
 import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
+import { spawn } from "node:child_process";
 import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
 import { createReplicationDomainHash, type ReplicationDomainHash } from "../src/index.js";
 import {
 	MoreSymbols,
@@ -303,36 +305,95 @@ const assertMaxMeanByBatch = parseBatchThresholdMap(
 	process.env.SWEEP_ASSERT_MAX_MEAN_MS,
 );
 
-const tasks: BatchTask[] = [];
+const runBatchTasks = async (sizes: number[]) => {
+	const tasks: BatchTask[] = [];
 
-for (const batchSize of batchSizes) {
-	let counterTotals = createEmptyCounters();
-	const samples: number[] = [];
-	const totalRuns = warmupRuns + measuredRuns;
+	for (const batchSize of sizes) {
+		let counterTotals = createEmptyCounters();
+		const samples: number[] = [];
+		const totalRuns = warmupRuns + measuredRuns;
 
-	for (let run = 0; run < totalRuns; run++) {
-		const result = await runCatchup({ batchSize, entryCount, timeoutMs });
-		if (run < warmupRuns) {
-			continue;
+		for (let run = 0; run < totalRuns; run++) {
+			const result = await runCatchup({ batchSize, entryCount, timeoutMs });
+			if (run < warmupRuns) {
+				continue;
+			}
+			samples.push(result.catchupMs);
+			counterTotals = mergeCounters(counterTotals, result.counters);
 		}
-		samples.push(result.catchupMs);
-		counterTotals = mergeCounters(counterTotals, result.counters);
+
+		const meanMs = mean(samples);
+		tasks.push({
+			name: `repairSweepTargetBufferSize=${batchSize}`,
+			batchSize,
+			mean_ms: meanMs,
+			hz: meanMs > 0 ? 1000 / meanMs : 0,
+			rme: null,
+			samples: samples.length,
+			startSyncTotal: counterTotals.startSync,
+			moreSymbolsTotal: counterTotals.moreSymbols,
+			requestAllTotal: counterTotals.requestAll,
+			requestMaybeSyncTotal: counterTotals.requestMaybeSync,
+			requestMaybeSyncCoordinateTotal: counterTotals.requestMaybeSyncCoordinate,
+		});
 	}
 
-	const meanMs = mean(samples);
-	tasks.push({
-		name: `repairSweepTargetBufferSize=${batchSize}`,
-		batchSize,
-		mean_ms: meanMs,
-		hz: meanMs > 0 ? 1000 / meanMs : 0,
-		rme: null,
-		samples: samples.length,
-		startSyncTotal: counterTotals.startSync,
-		moreSymbolsTotal: counterTotals.moreSymbols,
-		requestAllTotal: counterTotals.requestAll,
-		requestMaybeSyncTotal: counterTotals.requestMaybeSync,
-		requestMaybeSyncCoordinateTotal: counterTotals.requestMaybeSyncCoordinate,
+	return tasks;
+};
+
+const runIsolatedBatchTask = async (batchSize: number): Promise<BatchTask> => {
+	// Fixed-key test sessions can leave transport work in-process; isolate
+	// batches while keeping the parent responsible for combined assertions.
+	const child = spawn(
+		process.execPath,
+		[...process.execArgv, fileURLToPath(import.meta.url)],
+		{
+			env: {
+				...process.env,
+				BENCH_JSON: "1",
+				SWEEP_BATCH_SIZES: String(batchSize),
+				SWEEP_ISOLATED_CHILD: "1",
+				SWEEP_ASSERT_MAX_RATIO: "",
+				SWEEP_ASSERT_REQUIRE_STARTSYNC_FOR_BATCH_GTE: "",
+				SWEEP_ASSERT_MAX_MEAN_MS: "",
+			},
+			stdio: ["ignore", "pipe", "inherit"],
+		},
+	);
+
+	let stdout = "";
+	child.stdout.setEncoding("utf8");
+	child.stdout.on("data", (chunk) => {
+		stdout += chunk;
 	});
+
+	const code = await new Promise<number | null>((resolve) => {
+		child.on("close", resolve);
+	});
+	if (code !== 0) {
+		throw new Error(
+			`sync-batch-sweep child for batch ${batchSize} exited with ${code}`,
+		);
+	}
+
+	const output = JSON.parse(stdout) as { tasks: BatchTask[] };
+	if (output.tasks.length !== 1) {
+		throw new Error(
+			`Expected one task from batch ${batchSize}, got ${output.tasks.length}`,
+		);
+	}
+	return output.tasks[0];
+};
+
+const tasks: BatchTask[] =
+	process.env.SWEEP_ISOLATED_CHILD === "1" || batchSizes.length <= 1
+		? await runBatchTasks(batchSizes)
+		: [];
+
+if (process.env.SWEEP_ISOLATED_CHILD !== "1" && batchSizes.length > 1) {
+	for (const batchSize of batchSizes) {
+		tasks.push(await runIsolatedBatchTask(batchSize));
+	}
 }
 
 const failures: string[] = [];
@@ -406,4 +467,8 @@ if (failures.length > 0) {
 	throw new Error(
 		`sync-batch-sweep assertions failed:\n- ${failures.join("\n- ")}`,
 	);
+}
+
+if (process.env.SWEEP_ISOLATED_CHILD === "1") {
+	process.exit(0);
 }

--- a/packages/utils/indexer/sqlite3/benchmark/query-planner.ts
+++ b/packages/utils/indexer/sqlite3/benchmark/query-planner.ts
@@ -1,0 +1,134 @@
+import DB from "better-sqlite3";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+
+const rows = Number(process.env.QUERY_PLANNER_BENCH_ROWS ?? 500_000);
+const runs = Number(process.env.QUERY_PLANNER_BENCH_RUNS ?? 50);
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "peerbit-qplanner-"));
+const dbPath = path.join(tmpDir, "bench.sqlite");
+
+type BenchResult = {
+	name: string;
+	avgMs: number;
+	p50Ms: number;
+	minMs: number;
+	maxMs: number;
+	plan: string;
+};
+
+const percentile = (values: number[], p: number) => {
+	const sorted = [...values].sort((a, b) => a - b);
+	return sorted[Math.floor((sorted.length - 1) * p)];
+};
+
+const bench = (
+	db: DB.Database,
+	name: string,
+	sql: string,
+	params: unknown[],
+): BenchResult => {
+	const stmt = db.prepare(sql);
+	for (let i = 0; i < 5; i++) {
+		stmt.all(...params);
+	}
+
+	const times: number[] = [];
+	for (let i = 0; i < runs; i++) {
+		const start = performance.now();
+		stmt.all(...params);
+		times.push(performance.now() - start);
+	}
+
+	const plan = db
+		.prepare(`EXPLAIN QUERY PLAN ${sql}`)
+		.all(...params)
+		.map((row) => String((row as { detail: string }).detail))
+		.join("\n");
+
+	return {
+		name,
+		avgMs: times.reduce((sum, value) => sum + value, 0) / times.length,
+		p50Ms: percentile(times, 0.5),
+		minMs: Math.min(...times),
+		maxMs: Math.max(...times),
+		plan,
+	};
+};
+
+try {
+	const db = new DB(dbPath);
+	db.pragma("journal_mode = OFF");
+	db.pragma("synchronous = OFF");
+	db.pragma("temp_store = MEMORY");
+	db.exec("CREATE TABLE t(id INTEGER PRIMARY KEY, a INT, b INT, c INT)");
+
+	const insert = db.prepare("INSERT INTO t(id, a, b, c) VALUES (?, ?, ?, ?)");
+	const insertMany = db.transaction(() => {
+		for (let i = 1; i <= rows; i++) {
+			insert.run(i, i % 10, i % 1000, Math.floor(Math.random() * rows));
+		}
+	});
+
+	const loadStart = performance.now();
+	insertMany();
+	const loadMs = performance.now() - loadStart;
+
+	const indexTimes: Record<string, number> = {};
+	for (const [name, sql] of [
+		["old_forward", "CREATE INDEX idx_old_a_b_c ON t(a, b, c)"],
+		["old_reverse", "CREATE INDEX idx_old_c_b_a ON t(c, b, a)"],
+		["new_semantic", "CREATE INDEX idx_new_a_c_b ON t(a, c, b)"],
+	] as const) {
+		const start = performance.now();
+		db.exec(sql);
+		indexTimes[name] = performance.now() - start;
+	}
+	db.exec("ANALYZE");
+
+	const query =
+		"SELECT id FROM t WHERE a = ? AND b BETWEEN ? AND ? ORDER BY c LIMIT ?";
+	const forcedOldForward =
+		"SELECT id FROM t INDEXED BY idx_old_a_b_c WHERE a = ? AND b BETWEEN ? AND ? ORDER BY c LIMIT ?";
+	const forcedOldReverse =
+		"SELECT id FROM t INDEXED BY idx_old_c_b_a WHERE a = ? AND b BETWEEN ? AND ? ORDER BY c LIMIT ?";
+	const forcedNew =
+		"SELECT id FROM t INDEXED BY idx_new_a_c_b WHERE a = ? AND b BETWEEN ? AND ? ORDER BY c LIMIT ?";
+	const params = [1, 0, 999, 50];
+
+	const results = [
+		bench(db, "old forced (a,b,c)", forcedOldForward, params),
+		bench(db, "old forced reverse (c,b,a)", forcedOldReverse, params),
+		bench(db, "new semantic forced (a,c,b)", forcedNew, params),
+		bench(db, "sqlite choice with all indexes", query, params),
+	];
+
+	/* eslint-disable no-console */
+	console.log(
+		JSON.stringify(
+			{
+				rows,
+				runs,
+				loadMs,
+				indexTimes,
+			},
+			null,
+			2,
+		),
+	);
+	console.table(
+		results.map(({ name, avgMs, p50Ms, minMs, maxMs }) => ({
+			name,
+			avgMs: Number(avgMs.toFixed(3)),
+			p50Ms: Number(p50Ms.toFixed(3)),
+			minMs: Number(minMs.toFixed(3)),
+			maxMs: Number(maxMs.toFixed(3)),
+		})),
+	);
+	for (const result of results) {
+		console.log(`\n${result.name}\n${result.plan}`);
+	}
+} finally {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+}

--- a/packages/utils/indexer/sqlite3/package.json
+++ b/packages/utils/indexer/sqlite3/package.json
@@ -65,7 +65,8 @@
 		"test:browser": "aegir clean && aegir test -t browser",
 		"test:node": "aegir clean && aegir test -t node",
 		"lint": "aegir lint",
-		"test:cov": "aegir test -t node --cov"
+		"test:cov": "aegir test -t node --cov",
+		"bench:query-planner": "node --loader ts-node/esm ./benchmark/query-planner.ts"
 	},
 	"author": "dao.xyz",
 	"license": "MIT",

--- a/packages/utils/indexer/sqlite3/src/engine.ts
+++ b/packages/utils/indexer/sqlite3/src/engine.ts
@@ -349,7 +349,6 @@ export class SQLiteIndex<T extends Record<string, any>>
 					}
 				}
 			} */
-
 		}
 
 		if (startupTableStatements.size > 0) {
@@ -819,13 +818,24 @@ export class SQLiteIndex<T extends Record<string, any>>
 			let lastError: Error | undefined = undefined;
 			for (const table of this._rootTables) {
 				try {
+					const planningScope = this.planner.scope(
+						new PlannableQuery({
+							query: coerceLocalQueries(query.query),
+						}),
+					);
 					const { sql, bindable } = convertDeleteRequestToQuery(
 						query,
 						this.tables,
 						table,
+						{
+							planner: planningScope,
+						},
 					);
+					await planningScope.beforePrepare();
 					const stmt = await this.properties.db.prepare(sql, sql);
-					const results: any[] = await stmt.all(bindable);
+					const results: any[] = await planningScope.perform(async () =>
+						stmt.all(bindable),
+					);
 
 					// TODO types
 					for (const result of results) {
@@ -873,13 +883,24 @@ export class SQLiteIndex<T extends Record<string, any>>
 					continue;
 				}
 
+				const planningScope = this.planner.scope(
+					new PlannableQuery({
+						query: coerceLocalQueries(query.query),
+					}),
+				);
 				const { sql, bindable } = convertSumRequestToQuery(
 					query,
 					this.tables,
 					table,
+					{
+						planner: planningScope,
+					},
 				);
+				await planningScope.beforePrepare();
 				const stmt = await this.properties.db.prepare(sql, sql);
-				const result = await stmt.get(bindable);
+				const result = await planningScope.perform(async () =>
+					stmt.get(bindable),
+				);
 				if (result != null) {
 					const value = result.sum as number;
 

--- a/packages/utils/indexer/sqlite3/src/query-planner.ts
+++ b/packages/utils/indexer/sqlite3/src/query-planner.ts
@@ -16,11 +16,17 @@ import {
 	Query,
 	Sort,
 	StringMatch,
+	StringMatchMethod,
 	UnsignedIntegerValue,
 } from "@peerbit/indexer-interface";
 import { hrtime } from "@peerbit/time";
 import pDefer, { type DeferredPromise } from "p-defer";
 import { escapeColumnName } from "./schema.js";
+
+type IndexColumn = {
+	name: string;
+	collation?: "NOCASE";
+};
 
 export interface QueryIndexPlanner {
 	// assumes withing a query, each index can be picked independently. For example if we are to join two tables, we can pick the best index for each table
@@ -33,6 +39,7 @@ export interface QueryIndexPlanner {
 				avg: number;
 				times: number[];
 				indexKey: string;
+				columns: IndexColumn[];
 				created: () => boolean;
 				creationPromiseDeferred: DeferredPromise<void>;
 			}[];
@@ -43,12 +50,18 @@ export interface QueryIndexPlanner {
 type StmtStats = Map<string, QueryIndexPlanner>;
 
 const getSortedNameKey = (tableName: string, names: string[]) =>
-	[tableName, ...names.sort()].join(",");
-const createIndexKey = (tableName: string, fields: string[]) =>
-	`${tableName}_index_${fields.map((x) => x).join("_")}`;
+	[tableName, ...[...names].sort()].join(",");
+const getIndexColumnKey = (field: IndexColumn) =>
+	`${field.name}${field.collation ? `_collate_${field.collation.toLowerCase()}` : ""}`;
+const createIndexKey = (tableName: string, fields: IndexColumn[]) =>
+	`${tableName}_index_${fields.map((x) => getIndexColumnKey(x).replace(/[^a-zA-Z0-9_]/g, "_")).join("_")}`;
+const createIndexColumnSQL = (field: IndexColumn) =>
+	`${escapeColumnName(field.name)}${field.collation ? ` COLLATE ${field.collation}` : ""}`;
 
 const HALF_MAX_U32 = 2147483647; // rounded down
 const HALF_MAX_U64 = 9223372036854775807n; // rounded down
+const PARENT_TABLE_ID = "__parent_id";
+const AMBIGUOUS_CHILD_FORCE_AFTER_USES = 6_000;
 
 export const flattenQuery = function* (props?: {
 	query: Query[];
@@ -194,7 +207,16 @@ export class QueryPlanner {
 	pendingIndexCreation: Map<string, Promise<void>> = new Map();
 
 	constructor(
-		readonly props: { exec: (query: string) => Promise<any> | any },
+		readonly props: {
+			exec: (query: string) => Promise<any> | any;
+			/**
+			 * INDEXED BY is a hard SQLite requirement, not a hint. Keep the legacy
+			 * forced-index behavior by default and allow callers to disable it once
+			 * their query shapes have been verified against SQLite's own planner.
+			 */
+			forceIndexes?: boolean;
+			optimizeAfterCreate?: boolean;
+		},
 	) {}
 
 	async stop() {
@@ -219,7 +241,11 @@ export class QueryPlanner {
 			| undefined = undefined;
 		let pickedIndexKeys: Map<string, string> = new Map(); // index key to column names key
 		let indexCreationPromiseToAwait: Promise<void>[] = [];
+		let forceIndex = this.props.forceIndexes !== false;
 		return {
+			get forceIndex() {
+				return forceIndex;
+			},
 			beforePrepare: async () => {
 				// create missing indices
 				if (indexCreateCommands != null) {
@@ -235,7 +261,12 @@ export class QueryPlanner {
 					if (commandsToCreate.length > 0) {
 						const creationPromise = Promise.resolve(
 							this.props.exec(
-								commandsToCreate.map((command) => command.cmd).join(";"),
+								[
+									...commandsToCreate.map((command) => command.cmd),
+									...(this.props.optimizeAfterCreate === false
+										? []
+										: ["PRAGMA optimize"]),
+								].join(";"),
 							),
 						);
 						for (const { key } of commandsToCreate) {
@@ -265,6 +296,8 @@ export class QueryPlanner {
 				await Promise.all(indexCreationPromiseToAwait);
 			},
 			resolveIndex: (tableName: string, columns: string[]): string => {
+				forceIndex = this.props.forceIndexes !== false;
+
 				// first we figure out whether we want to reuse the fastest index or try a new one
 				// only assume we either do forward or backward column order for now (not all n! permutations)
 				const sortedNameKey = getSortedNameKey(tableName, columns);
@@ -277,11 +310,10 @@ export class QueryPlanner {
 				}
 
 				if (indexStats.results.length === 0) {
-					// create both forward and backward permutations
-					const permutations = generatePermutations(columns);
-					for (const columns of permutations) {
+					const candidates = generateIndexCandidates(query, columns);
+					for (const columns of candidates) {
 						const indexKey = createIndexKey(tableName, columns);
-						const command = `create index if not exists ${indexKey} on ${tableName} (${columns.map((n) => escapeColumnName(n)).join(", ")})`;
+						const command = `create index if not exists ${indexKey} on ${tableName} (${columns.map((n) => createIndexColumnSQL(n)).join(", ")})`;
 
 						let deferred = pDefer<void>();
 						(indexCreateCommands || (indexCreateCommands = [])).push({
@@ -299,10 +331,25 @@ export class QueryPlanner {
 							times: [],
 							avg: -1, // setting -1 will force the first time to be the fastest (i.e. new indices are always tested once)
 							indexKey,
+							columns,
 							created: () => created,
 							creationPromiseDeferred: deferred,
 						});
 					}
+				}
+
+				const isAmbiguousChildPredicate =
+					query.sort.length === 0 &&
+					columns.includes(PARENT_TABLE_ID) &&
+					columns.length > 1;
+				if (isAmbiguousChildPredicate) {
+					const totalUses = indexStats.results.reduce(
+						(sum, result) => sum + result.used,
+						0,
+					);
+					forceIndex =
+						this.props.forceIndexes !== false &&
+						totalUses >= AMBIGUOUS_CHILD_FORCE_AFTER_USES;
 				}
 
 				// find the fastest index
@@ -352,9 +399,172 @@ export class QueryPlanner {
 	}
 }
 
-const generatePermutations = (list: string[]) => {
-	if (list.length === 1) return [list];
-	return [list, [...list].reverse()];
+const queryKeyToColumnName = (key: string[]) => {
+	if (key.length > 2) {
+		return `${key.slice(0, -1).join("_")}__${key[key.length - 1]}`;
+	}
+	return key.join("__");
+};
+
+const pushUniqueColumn = (list: IndexColumn[], column: IndexColumn) => {
+	const key = getIndexColumnKey(column);
+	if (!list.some((x) => getIndexColumnKey(x) === key)) {
+		list.push(column);
+	}
+};
+
+const pushColumns = (target: IndexColumn[], columns: IndexColumn[]) => {
+	for (const column of columns) {
+		pushUniqueColumn(target, column);
+	}
+};
+
+const getIndexableQueryColumns = (
+	query: Query[],
+	availableColumns: Set<string>,
+) => {
+	const equality: IndexColumn[] = [];
+	const range: IndexColumn[] = [];
+
+	const visit = (item: Query, path: string[] = []) => {
+		if (item instanceof And) {
+			for (const condition of item.and) {
+				visit(condition, path);
+			}
+			return;
+		}
+		if (item instanceof Or) {
+			for (const condition of item.or) {
+				visit(condition, path);
+			}
+			return;
+		}
+		if (item instanceof Not) {
+			return;
+		}
+		if (item instanceof Nested) {
+			for (const condition of item.query) {
+				visit(condition, [...path, ...item.path]);
+			}
+			return;
+		}
+
+		let key: string[] | undefined;
+		let target: IndexColumn[] | undefined;
+		let collation: IndexColumn["collation"] | undefined;
+		if (item instanceof IntegerCompare) {
+			key = item.key;
+			target = item.compare === Compare.Equal ? equality : range;
+		} else if (item instanceof StringMatch) {
+			key = item.key;
+			if (item.method === StringMatchMethod.contains) {
+				return;
+			}
+			target = item.method === StringMatchMethod.exact ? equality : range;
+			collation = item.caseInsensitive ? "NOCASE" : undefined;
+		} else if (
+			item instanceof ByteMatchQuery ||
+			item instanceof BoolQuery ||
+			item instanceof IsNull
+		) {
+			key = item.key;
+			target = equality;
+		}
+
+		if (!key || !target) {
+			return;
+		}
+		const columnName = queryKeyToColumnName([...path, ...key]);
+		if (availableColumns.has(columnName)) {
+			pushUniqueColumn(target, { name: columnName, collation });
+		}
+	};
+
+	for (const item of query) {
+		visit(item);
+	}
+
+	return { equality, range };
+};
+
+const getSortableColumns = (sort: Sort[], availableColumns: Set<string>) => {
+	const out: IndexColumn[] = [];
+	for (const item of sort) {
+		const columnName = queryKeyToColumnName(item.key);
+		if (availableColumns.has(columnName)) {
+			pushUniqueColumn(out, { name: columnName });
+		}
+	}
+	return out;
+};
+
+const normalizeCandidate = (columns: IndexColumn[]) => {
+	const out: IndexColumn[] = [];
+	pushColumns(out, columns);
+	return out;
+};
+
+const generateIndexCandidates = (query: PlannableQuery, columns: string[]) => {
+	if (columns.length === 0) {
+		return [];
+	}
+
+	const availableColumns = new Set(columns);
+	const { equality, range } = getIndexableQueryColumns(
+		query.query,
+		availableColumns,
+	);
+	const sort = getSortableColumns(query.sort, availableColumns);
+	const join = availableColumns.has(PARENT_TABLE_ID)
+		? [{ name: PARENT_TABLE_ID }]
+		: [];
+	const knownColumnNames = new Set(
+		[...join, ...equality, ...range, ...sort].map((x) => x.name),
+	);
+	const remaining = columns
+		.filter((column) => !knownColumnNames.has(column))
+		.map((name) => ({ name }));
+
+	const candidates: IndexColumn[][] = [];
+	const pushCandidate = (...parts: IndexColumn[][]) => {
+		const candidate = normalizeCandidate(parts.flat());
+		if (
+			candidate.length > 0 &&
+			!candidates.some(
+				(existing) =>
+					existing.map(getIndexColumnKey).join(",") ===
+					candidate.map(getIndexColumnKey).join(","),
+			)
+		) {
+			candidates.push(candidate);
+		}
+	};
+
+	if (sort.length > 0 && range.length > 0) {
+		pushCandidate(join, equality, sort, range, remaining);
+		pushCandidate(join, equality, range, sort, remaining);
+	} else if (sort.length > 0) {
+		pushCandidate(join, equality, sort, range, remaining);
+	} else {
+		if (join.length > 0 && (equality.length > 0 || range.length > 0)) {
+			pushCandidate(equality, range, join, remaining);
+		}
+		pushCandidate(join, equality, range, remaining);
+	}
+
+	if (join.length > 0 && (equality.length > 0 || range.length > 0)) {
+		if (sort.length > 0 && range.length > 0) {
+			pushCandidate(equality, sort, range, join, remaining);
+			pushCandidate(equality, range, sort, join, remaining);
+		} else if (sort.length > 0) {
+			pushCandidate(equality, range, sort, join, remaining);
+		}
+	}
+
+	pushCandidate(columns.map((name) => ({ name })));
+	pushCandidate([...columns].reverse().map((name) => ({ name })));
+
+	return candidates;
 };
 /* const generatePermutations = (list: string[]) => {
 	const results: string[][] = [];

--- a/packages/utils/indexer/sqlite3/src/schema.ts
+++ b/packages/utils/indexer/sqlite3/src/schema.ts
@@ -1565,12 +1565,18 @@ export const convertDeleteRequestToQuery = (
 	request: types.DeleteOptions,
 	tables: Map<string, Table>,
 	table: Table,
+	options?: {
+		planner?: PlanningSession;
+	},
 ): { sql: string; bindable: any[] } => {
 	const { query, bindable } = convertRequestToQuery(
 		"delete",
 		{ query: coerceLocalQueries(request.query) },
 		tables,
 		table,
+		undefined,
+		[],
+		options,
 	);
 	return {
 		sql: `DELETE FROM ${table.name} WHERE ${table.name}.${table.primary} IN (SELECT ${table.primary} from ${table.name} ${query}) returning ${table.primary}`,
@@ -1582,12 +1588,18 @@ export const convertSumRequestToQuery = (
 	request: types.SumOptions,
 	tables: Map<string, Table>,
 	table: Table,
+	options?: {
+		planner?: PlanningSession;
+	},
 ): { sql: string; bindable: any[] } => {
 	const { query, bindable } = convertRequestToQuery(
 		"sum",
 		{ query: coerceLocalQueries(request.query), key: request.key },
 		tables,
 		table,
+		undefined,
+		[],
+		options,
 	);
 
 	const inlineName = getInlineTableFieldName(request.key);
@@ -1983,10 +1995,15 @@ const _buildJoin = (
 			table.table.primary !== false &&
 			usedColumns.length === 1 &&
 			usedColumns[0] === table.table.primary;
-		indexedBy =
-			options?.planner && !usesImplicitPrimaryKeyIndex
-				? ` INDEXED BY ${options.planner.resolveIndex(table.table.name, usedColumns)} `
-				: "";
+		if (options?.planner && !usesImplicitPrimaryKeyIndex) {
+			const indexKey = options.planner.resolveIndex(
+				table.table.name,
+				usedColumns,
+			);
+			indexedBy = options.planner.forceIndex ? ` INDEXED BY ${indexKey} ` : "";
+		} else {
+			indexedBy = "";
+		}
 	}
 
 	if (table.type !== "root") {

--- a/packages/utils/indexer/sqlite3/test/query-planner.spec.ts
+++ b/packages/utils/indexer/sqlite3/test/query-planner.spec.ts
@@ -163,7 +163,7 @@ describe("QueryPlanner", () => {
 		await perform2;
 	});
 
-	it("batches new index permutations into one exec", async () => {
+	it("batches new index candidates into one exec", async () => {
 		let executed: string[] = [];
 
 		const planner = new QueryPlanner({
@@ -181,9 +181,91 @@ describe("QueryPlanner", () => {
 		expect(executed[0]).to.contain(
 			"create index if not exists table_index_field1_field2",
 		);
+		expect(executed[0]).to.contain("PRAGMA optimize");
+	});
+
+	it("orders candidates by equality, sort, and range semantics", async () => {
+		let executed: string[] = [];
+
+		const planner = new QueryPlanner({
+			exec: async (query: string) => {
+				executed.push(query);
+			},
+		});
+		const query = new PlannableQuery({
+			query: [
+				new IntegerCompare({
+					key: "a",
+					compare: Compare.Equal,
+					value: 1,
+				}),
+				new IntegerCompare({
+					key: "b",
+					compare: Compare.GreaterOrEqual,
+					value: 0,
+				}),
+			],
+			sort: new Sort({ key: "c", direction: SortDirection.ASC }),
+		});
+		const scope = planner.scope(query);
+
+		scope.resolveIndex("table", ["c", "a", "b"]);
+		await scope.beforePrepare();
+
+		expect(executed).to.have.length(1);
 		expect(executed[0]).to.contain(
-			"create index if not exists table_index_field2_field1",
+			"create index if not exists table_index_a_c_b",
 		);
+		expect(executed[0]).to.contain(
+			"create index if not exists table_index_a_b_c",
+		);
+	});
+
+	it("does not mutate resolved column order while building stats keys", async () => {
+		const planner = new QueryPlanner({
+			exec: async () => {},
+		});
+		const query = new PlannableQuery({ query: [] });
+		const scope = planner.scope(query);
+		const columns = ["field2", "field1"];
+
+		scope.resolveIndex("table", columns);
+
+		expect(columns).to.deep.equal(["field2", "field1"]);
+	});
+
+	it("keeps hard INDEXED BY compatibility mode by default", async () => {
+		const defaultPlanner = new QueryPlanner({
+			exec: async () => {},
+		});
+		const relaxedPlanner = new QueryPlanner({
+			exec: async () => {},
+			forceIndexes: false,
+		});
+
+		const defaultScope = defaultPlanner.scope(new PlannableQuery({ query: [] }));
+		const relaxedScope = relaxedPlanner.scope(new PlannableQuery({ query: [] }));
+
+		expect(defaultScope.forceIndex).to.equal(true);
+		expect(relaxedScope.forceIndex).to.equal(false);
+	});
+
+	it("relaxes ambiguous child-table predicates until the index has warmed", async () => {
+		const planner = new QueryPlanner({
+			exec: async () => {},
+		});
+		const scope = planner.scope(new PlannableQuery({ query: [] }));
+
+		scope.resolveIndex("child", ["__parent_id", "value"]);
+		expect(scope.forceIndex).to.equal(false);
+
+		scope.resolveIndex("root", ["value"]);
+		expect(scope.forceIndex).to.equal(true);
+
+		for (let i = 0; i < 6_000; i++) {
+			scope.resolveIndex("child", ["__parent_id", "value"]);
+		}
+		expect(scope.forceIndex).to.equal(true);
 	});
 });
 


### PR DESCRIPTION
## Summary

- generate query-shape-aware SQLite index candidates for equality, sort, range, join, and NOCASE string-match columns
- keep legacy hard `INDEXED BY` behavior by default; ambiguous child-table predicates run unforced while cold, then return to forced-index mode after 6k uses once the planner has warmed
- reset `forceIndex` per resolved table so one child-table decision does not leak into another table in the same plan
- apply planner-created indexes to `del` and `sum`; keep `count` on the pre-existing path after shared-log sync regression testing
- add a focused query-planner benchmark and isolate shared-log sync sweep batch runs, including explicit child exit after JSON output so fixed-key test sessions cannot leave child processes alive
- fix a `Log.deleteRecursively` race exposed by the faster delete path by applying prepared recursive deletes sequentially, preventing a removed ancestor from being reinserted as a stale head

## Benchmark

Command:

```bash
PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" pnpm --filter @peerbit/indexer-sqlite3 run bench:query-planner
```

Local result on 500k rows / 50 runs:

| case | avg ms | plan |
| --- | ---: | --- |
| old forced `(a,b,c)` | 2.018 | `SEARCH ... idx_old_a_b_c`, temp B-tree for order |
| old forced reverse `(c,b,a)` | 0.039 | covering index scan |
| new semantic `(a,c,b)` | 0.019 | `SEARCH ... idx_new_a_c_b (a=?)` |
| SQLite choice with all indexes | 0.022 | chooses `idx_new_a_c_b` |

## Validation

- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" node ./node_modules/aegir/src/index.js run test --roots ./packages/utils/indexer/sqlite3 -- -t node --grep "statement|QueryPlanner|PlannableQuery|flattenQuery"` (`21 passing`)
- `PEERBIT_TEST_SESSION=mock PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --no-build --grep "many missing"` (`1 passing`, test body 16.982s)
- `PEERBIT_TEST_SESSION=mock NODE_OPTIONS=--no-warnings SWEEP_BATCH_SIZES=512,1024,16384 SWEEP_RUNS=1 SWEEP_TIMEOUT=120000 SWEEP_ASSERT_MAX_RATIO=8 SWEEP_ASSERT_REQUIRE_STARTSYNC_FOR_BATCH_GTE=512 SWEEP_ASSERT_MAX_MEAN_MS=512:90000,1024:90000,16384:90000 PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" node packages/programs/data/shared-log/dist/benchmark/sync-batch-sweep.js`
  - 512: 25.938s, StartSync 45
  - 1024: 25.901s, StartSync 22
  - 16384: 26.238s, StartSync 4
- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "deleted unreferences"` (`1 passing`)
- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" pnpm --filter @peerbit/log run test:cov` (`201 passing`)
- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" pnpm --filter @peerbit/indexer-sqlite3 run bench:query-planner`
- `git diff --check`