### PR TITLE
fix(shared-log): stabilize part 7 replication churn

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -6892,11 +6892,12 @@ export class SharedLog<
 		this._replicationInfoRequestByPeer.set(peerHash, state);
 
 		const intervalMs = Math.max(50, this.waitForReplicatorRequestIntervalMs);
-		const maxAttempts = Math.min(
-			5,
+		const maxAttempts =
 			this.waitForReplicatorRequestMaxAttempts ??
+			Math.max(
 				WAIT_FOR_REPLICATOR_REQUEST_MIN_ATTEMPTS,
-		);
+				Math.ceil(this.waitForReplicatorTimeout / intervalMs),
+			);
 
 		const tick = () => {
 			if (this.closed || this._closeController.signal.aborted) {

--- a/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
+++ b/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
@@ -290,6 +290,8 @@ const getSyncIdString = (message: { syncId: Uint8Array }) => {
 const DEFAULT_CONVERGENT_REPAIR_TIMEOUT_MS = 30_000;
 const DEFAULT_CONVERGENT_RETRY_INTERVALS_MS = [0, 1_000, 3_000, 7_000];
 const DEFAULT_MAX_CONVERGENT_TRACKED_HASHES = 4_096;
+const MIN_MORE_SYMBOLS_BATCH_SIZE = 64;
+const MAX_MORE_SYMBOLS_BATCH_SIZE = 1_024;
 
 @variant([3, 0])
 export class StartSync extends TransportMessage {
@@ -914,7 +916,16 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 		};
 
 		let lastSeqNo = -1n;
-		let nextBatch = 1e4;
+		// Keep follow-up symbol payloads bounded. Each symbol is serialized as an
+		// object with three bigint fields, so very large batches can dominate heap under
+		// concurrent churn even though the native RIBLT encoder itself is compact.
+		const nextBatch = Math.max(
+			MIN_MORE_SYMBOLS_BATCH_SIZE,
+			Math.min(
+				MAX_MORE_SYMBOLS_BATCH_SIZE,
+				Math.ceil(allCoordinatesToSyncWithIblt.length / 4),
+			),
+		);
 		const obj = {
 			encoder,
 			timeout: createTimeout(),

--- a/packages/programs/data/shared-log/test/sharding.spec.ts
+++ b/packages/programs/data/shared-log/test/sharding.spec.ts
@@ -14,6 +14,7 @@ import {
 	AbsoluteReplicas,
 	AddedReplicationSegmentMessage,
 	AllReplicatingSegmentsMessage,
+	RequestReplicationInfoMessage,
 } from "../src/replication.js";
 import {
 	MoreSymbols,
@@ -296,6 +297,26 @@ testSetups.forEach((setup) => {
 				);
 			};
 
+			const waitForReplicationIndexes = async (
+				expectedSize: number,
+				...dbs: { log: EventStore<string, ReplicationDomainHash<any>>["log"] }[]
+			) => {
+				await Promise.all(
+					dbs.map((db) =>
+						waitForResolved(
+							async () =>
+								expect(await db.log.replicationIndex.getSize()).to.equal(
+									expectedSize,
+								),
+							{
+								timeout: 120_000,
+								delayInterval: 500,
+							},
+						),
+					),
+				);
+			};
+
 			it("cancels pending checked prune when local peer leads again", async () => {
 				db1 = await session.peers[0].open(
 					new EventStore<string, ReplicationDomainHash<any>>(),
@@ -541,6 +562,42 @@ testSetups.forEach((setup) => {
 					subscribers.restore();
 					log.uniqueReplicators = originalUniqueReplicators;
 					log._topicSubscribersCache.clear();
+				}
+			});
+
+			it("keeps requesting replication info through the replicator wait window", async () => {
+				db1 = await session.peers[0].open(new EventStore<string, any>(), {
+					args: {
+						setup,
+						timeUntilRoleMaturity: 0,
+						waitForReplicatorRequestIntervalMs: 50,
+						waitForReplicatorTimeout: 300,
+					},
+				});
+
+				const log = db1.log as any;
+				const remoteKey = session.peers[1].identity.publicKey;
+				let requestCount = 0;
+				const send = sinon.stub(log.rpc, "send").callsFake((message: any) => {
+					if (message instanceof RequestReplicationInfoMessage) {
+						requestCount += 1;
+					}
+					return Promise.resolve();
+				});
+
+				try {
+					await log.handleSubscriptionChange(remoteKey, [db1.log.topic], true);
+
+					await waitForResolved(
+						() => expect(requestCount).to.be.greaterThan(3),
+						{
+							timeout: 1_000,
+							delayInterval: 25,
+						},
+					);
+				} finally {
+					log.cancelReplicationInfoRequests(remoteKey.hashcode());
+					send.restore();
 				}
 			});
 
@@ -1724,6 +1781,7 @@ testSetups.forEach((setup) => {
 						},
 					},
 				);
+				await waitForReplicationIndexes(3, db1, db2, db3);
 
 				// This test verifies repeated join/leave convergence, not throughput. Keep the
 				// u64 sample correctness-sized so the final leave/rebalance path is what we are
@@ -1787,6 +1845,7 @@ testSetups.forEach((setup) => {
 					},
 				});
 				await db3.close();
+				await waitForReplicationIndexes(2, db1, db2);
 				/* 	await session.peers[2].open(db3, {
 						args: {
 							replicate: {


### PR DESCRIPTION
## Summary

- extend replication-info retry attempts across the configured replicator wait window so peers do not retain stale ownership views after churn
- bound RIBLT follow-up symbol batches to reduce heap pressure during concurrent churn sync
- add a regression for subscription-triggered replication-info retries and tighten the join/leave churn test preconditions

## Verification

- `PATH=/Users/marcuspousette/.nvm/versions/node/v22.22.2/bin:$PATH pnpm run test:ci:part-7` -> 209 passing, 7 pending
- `PATH=/Users/marcuspousette/.nvm/versions/node/v22.22.2/bin:$PATH pnpm run build`
- `git diff --check`