### PR TITLE
bench(shared-log): profile sync phases

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 		"packages/utils/build-assets",
 		"packages/utils/time",
 		"packages/utils/cache",
+		"packages/utils/diagnostics",
 		"packages/utils/logger",
 		"packages/utils/keychain",
 		"packages/utils/indexer/*",

--- a/packages/programs/data/shared-log/benchmark/sync-phase-profile.ts
+++ b/packages/programs/data/shared-log/benchmark/sync-phase-profile.ts
@@ -1,0 +1,407 @@
+// Profiles where catch-up sync spends time across simple and rateless phases.
+//
+// Run with:
+//   cd packages/programs/data/shared-log
+//   node --loader ts-node/esm ./benchmark/sync-phase-profile.ts --entries 20000 --seededEntries 10000 --runs 1
+//
+// JSON output:
+//   node --loader ts-node/esm ./benchmark/sync-phase-profile.ts --json
+import { TestSession } from "@peerbit/test-utils";
+import { waitForResolved } from "@peerbit/time";
+import { expect } from "chai";
+import { performance } from "node:perf_hooks";
+import {
+	type ReplicationDomainHash,
+	createReplicationDomainHash,
+} from "../src/index.js";
+import type { SyncProfileEvent, SyncProfileFn } from "../src/sync/index.js";
+import {
+	MoreSymbols,
+	RatelessIBLTSynchronizer,
+	RequestAll,
+	StartSync,
+} from "../src/sync/rateless-iblt.js";
+import {
+	RequestMaybeSync,
+	RequestMaybeSyncCoordinate,
+} from "../src/sync/simple.js";
+import { EventStore } from "../test/utils/stores/event-store.js";
+
+type MessageCounters = {
+	startSync: number;
+	moreSymbols: number;
+	requestAll: number;
+	requestMaybeSync: number;
+	requestMaybeSyncCoordinate: number;
+};
+
+type ProfileRecord = SyncProfileEvent & {
+	peer: string;
+	atMs: number;
+};
+
+type PhaseSummary = {
+	phase: string;
+	count: number;
+	totalMs: number;
+	meanMs: number;
+	maxMs: number;
+	entries: number;
+	symbols: number;
+	messages: number;
+	bytes: number;
+	peers: Record<string, number>;
+};
+
+const parseArgs = () => {
+	const args = process.argv.slice(2);
+	const readNumber = (name: string, fallback: number) => {
+		const index = args.indexOf(`--${name}`);
+		const raw =
+			index >= 0
+				? args[index + 1]
+				: process.env[`SYNC_PROFILE_${name.toUpperCase()}`];
+		if (!raw) {
+			return fallback;
+		}
+		const parsed = Number.parseInt(raw, 10);
+		if (!Number.isFinite(parsed) || parsed <= 0) {
+			throw new Error(`Expected --${name} to be a positive integer`);
+		}
+		return parsed;
+	};
+	const readNonNegativeNumber = (name: string, fallback: number) => {
+		const index = args.indexOf(`--${name}`);
+		const raw =
+			index >= 0
+				? args[index + 1]
+				: process.env[`SYNC_PROFILE_${name.toUpperCase()}`];
+		if (!raw) {
+			return fallback;
+		}
+		const parsed = Number.parseInt(raw, 10);
+		if (!Number.isFinite(parsed) || parsed < 0) {
+			throw new Error(`Expected --${name} to be a non-negative integer`);
+		}
+		return parsed;
+	};
+
+	return {
+		entryCount: readNumber("entries", 10_000),
+		seededEntries: readNonNegativeNumber("seededEntries", 1_000),
+		batchSize: readNumber("batchSize", 16_384),
+		timeoutMs: readNumber("timeoutMs", 120_000),
+		drainMs: readNonNegativeNumber("drainMs", 250),
+		runs: readNumber("runs", 1),
+		warmupRuns: readNonNegativeNumber("warmupRuns", 0),
+		json: args.includes("--json") || process.env.BENCH_JSON === "1",
+	};
+};
+
+const writeStdout = (text: string) =>
+	new Promise<void>((resolve, reject) => {
+		process.stdout.write(text, (error) => {
+			if (error) {
+				reject(error);
+				return;
+			}
+			resolve();
+		});
+	});
+
+const createEmptyCounters = (): MessageCounters => ({
+	startSync: 0,
+	moreSymbols: 0,
+	requestAll: 0,
+	requestMaybeSync: 0,
+	requestMaybeSyncCoordinate: 0,
+});
+
+const mergeCounters = (
+	left: MessageCounters,
+	right: MessageCounters,
+): MessageCounters => ({
+	startSync: left.startSync + right.startSync,
+	moreSymbols: left.moreSymbols + right.moreSymbols,
+	requestAll: left.requestAll + right.requestAll,
+	requestMaybeSync: left.requestMaybeSync + right.requestMaybeSync,
+	requestMaybeSyncCoordinate:
+		left.requestMaybeSyncCoordinate + right.requestMaybeSyncCoordinate,
+});
+
+const attachMessageCounter = (
+	store: EventStore<string, ReplicationDomainHash<"u64">>,
+) => {
+	const counters = createEmptyCounters();
+	const original = store.log.onMessage.bind(store.log);
+
+	store.log.onMessage = async (msg, context) => {
+		if (msg instanceof StartSync) counters.startSync += 1;
+		else if (msg instanceof MoreSymbols) counters.moreSymbols += 1;
+		else if (msg instanceof RequestAll) counters.requestAll += 1;
+		else if (msg instanceof RequestMaybeSync) counters.requestMaybeSync += 1;
+		else if (msg instanceof RequestMaybeSyncCoordinate)
+			counters.requestMaybeSyncCoordinate += 1;
+
+		return original(msg, context);
+	};
+
+	return {
+		read: () => ({ ...counters }),
+		restore: () => {
+			store.log.onMessage = original;
+		},
+	};
+};
+
+class SyncProfileCollector {
+	readonly records: ProfileRecord[] = [];
+
+	profile(peer: string): SyncProfileFn {
+		return (event) => {
+			this.records.push({
+				...event,
+				peer,
+				atMs: performance.now(),
+			});
+		};
+	}
+}
+
+const summarizeRecords = (records: ProfileRecord[]): PhaseSummary[] => {
+	const summaries = new Map<
+		string,
+		{
+			count: number;
+			totalMs: number;
+			maxMs: number;
+			entries: number;
+			symbols: number;
+			messages: number;
+			bytes: number;
+			peers: Map<string, number>;
+		}
+	>();
+
+	for (const record of records) {
+		let summary = summaries.get(record.name);
+		if (!summary) {
+			summary = {
+				count: 0,
+				totalMs: 0,
+				maxMs: 0,
+				entries: 0,
+				symbols: 0,
+				messages: 0,
+				bytes: 0,
+				peers: new Map(),
+			};
+			summaries.set(record.name, summary);
+		}
+
+		const durationMs = record.durationMs ?? 0;
+		summary.count += 1;
+		summary.totalMs += durationMs;
+		summary.maxMs = Math.max(summary.maxMs, durationMs);
+		summary.entries += record.entries ?? 0;
+		summary.symbols += record.symbols ?? 0;
+		summary.messages += record.messages ?? 0;
+		summary.bytes += record.bytes ?? 0;
+		summary.peers.set(record.peer, (summary.peers.get(record.peer) ?? 0) + 1);
+	}
+
+	return [...summaries.entries()]
+		.map(([phase, summary]) => ({
+			phase,
+			count: summary.count,
+			totalMs: summary.totalMs,
+			meanMs: summary.count > 0 ? summary.totalMs / summary.count : 0,
+			maxMs: summary.maxMs,
+			entries: summary.entries,
+			symbols: summary.symbols,
+			messages: summary.messages,
+			bytes: summary.bytes,
+			peers: Object.fromEntries(summary.peers),
+		}))
+		.sort((a, b) => b.totalMs - a.totalMs || b.count - a.count);
+};
+
+const setup = {
+	domain: createReplicationDomainHash("u64"),
+	type: "u64" as const,
+	syncronizer: RatelessIBLTSynchronizer,
+	name: "u64-iblt",
+};
+
+const runCatchup = async (properties: {
+	batchSize: number;
+	entryCount: number;
+	seededEntries: number;
+	timeoutMs: number;
+	drainMs: number;
+	run: number;
+}) => {
+	const collector = new SyncProfileCollector();
+	const session = await TestSession.disconnected(2);
+	const store = new EventStore<string, ReplicationDomainHash<"u64">>();
+	let db1: EventStore<string, ReplicationDomainHash<"u64">> | undefined;
+	let db2: EventStore<string, ReplicationDomainHash<"u64">> | undefined;
+	let counter1: ReturnType<typeof attachMessageCounter> | undefined;
+	let counter2: ReturnType<typeof attachMessageCounter> | undefined;
+	let catchupMs = 0;
+	let counters = createEmptyCounters();
+
+	try {
+		db1 = await session.peers[0].open(store.clone(), {
+			args: {
+				replicate: { factor: 2 },
+				setup,
+				sync: {
+					repairSweepTargetBufferSize: properties.batchSize,
+					profile: collector.profile("source"),
+				},
+			},
+		});
+
+		db2 = await session.peers[1].open(store.clone(), {
+			args: {
+				replicate: { factor: 2 },
+				setup,
+				sync: {
+					repairSweepTargetBufferSize: properties.batchSize,
+					profile: collector.profile("joiner"),
+				},
+			},
+		});
+
+		for (let i = 0; i < properties.seededEntries; i++) {
+			const out = await db1.add(`seed-${i}`, { meta: { next: [] } });
+			await db2.log.join([out.entry]);
+		}
+
+		for (let i = 0; i < properties.entryCount; i++) {
+			await db1.add(`entry-${i}`, { meta: { next: [] } });
+		}
+
+		const expectedLength = properties.seededEntries + properties.entryCount;
+		expect(db1.log.log.length).to.equal(expectedLength);
+		expect(db2.log.log.length).to.equal(properties.seededEntries);
+
+		counter1 = attachMessageCounter(db1);
+		counter2 = attachMessageCounter(db2);
+
+		await waitForResolved(() =>
+			session.peers[0].dial(session.peers[1].getMultiaddrs()),
+		);
+
+		const t0 = performance.now();
+		await waitForResolved(
+			() => expect(db2!.log.log.length).to.equal(expectedLength),
+			{ timeout: properties.timeoutMs, delayInterval: 250 },
+		);
+		catchupMs = performance.now() - t0;
+
+		if (properties.drainMs > 0) {
+			await new Promise((resolve) => setTimeout(resolve, properties.drainMs));
+		}
+
+		counters = mergeCounters(counter1.read(), counter2.read());
+	} finally {
+		counter1?.restore();
+		counter2?.restore();
+		await session.stop();
+	}
+
+	const records = [...collector.records];
+	return {
+		run: properties.run,
+		catchupMs,
+		counters,
+		records,
+		phases: summarizeRecords(records),
+	};
+};
+
+const options = parseArgs();
+const measuredRuns = [];
+const allMeasuredRecords: ProfileRecord[] = [];
+let counterTotals = createEmptyCounters();
+const totalRuns = options.warmupRuns + options.runs;
+
+for (let run = 0; run < totalRuns; run++) {
+	const result = await runCatchup({
+		batchSize: options.batchSize,
+		entryCount: options.entryCount,
+		seededEntries: options.seededEntries,
+		timeoutMs: options.timeoutMs,
+		drainMs: options.drainMs,
+		run,
+	});
+	if (run < options.warmupRuns) {
+		continue;
+	}
+	measuredRuns.push({
+		run: result.run,
+		catchupMs: result.catchupMs,
+		counters: result.counters,
+		phases: result.phases,
+	});
+	counterTotals = mergeCounters(counterTotals, result.counters);
+	allMeasuredRecords.push(...result.records);
+}
+
+const catchupSamples = measuredRuns.map((run) => run.catchupMs);
+const meanCatchupMs =
+	catchupSamples.reduce((sum, value) => sum + value, 0) / catchupSamples.length;
+const aggregatePhases = summarizeRecords(allMeasuredRecords);
+const output = {
+	name: "shared-log-sync-phase-profile",
+	meta: {
+		entryCount: options.entryCount,
+		seededEntries: options.seededEntries,
+		batchSize: options.batchSize,
+		timeoutMs: options.timeoutMs,
+		drainMs: options.drainMs,
+		warmupRuns: options.warmupRuns,
+		measuredRuns: options.runs,
+	},
+	task: {
+		name: "rateless-catchup",
+		mean_ms: meanCatchupMs,
+		hz: meanCatchupMs > 0 ? 1000 / meanCatchupMs : 0,
+		rme: null,
+		samples: catchupSamples.length,
+		counters: counterTotals,
+		phases: aggregatePhases,
+	},
+	runs: measuredRuns,
+};
+
+if (options.json) {
+	await writeStdout(`${JSON.stringify(output, null, 2)}\n`);
+} else {
+	console.log(
+		`shared-log sync phase profile: entries=${options.entryCount} seededEntries=${options.seededEntries} batchSize=${options.batchSize} drainMs=${options.drainMs} runs=${options.runs}`,
+	);
+	console.log(
+		`catchup mean=${meanCatchupMs.toFixed(2)}ms hz=${output.task.hz.toFixed(2)}`,
+	);
+	console.table(counterTotals);
+	console.table(
+		aggregatePhases.map((phase) => ({
+			phase: phase.phase,
+			count: phase.count,
+			total_ms: phase.totalMs.toFixed(2),
+			mean_ms: phase.meanMs.toFixed(2),
+			max_ms: phase.maxMs.toFixed(2),
+			entries: phase.entries,
+			symbols: phase.symbols,
+			messages: phase.messages,
+			peers: Object.entries(phase.peers)
+				.map(([peer, count]) => `${peer}:${count}`)
+				.join(","),
+		})),
+	);
+}
+
+process.exit(process.exitCode ?? 0);

--- a/packages/programs/data/shared-log/package.json
+++ b/packages/programs/data/shared-log/package.json
@@ -54,6 +54,7 @@
 		"build": "aegir build --no-bundle",
 		"benchmark:adaptive-ingest": "node --loader ts-node/esm ./benchmark/adaptive-ingest.ts",
 		"benchmark:join-backfill-repair": "node --loader ts-node/esm ./benchmark/join-backfill-repair.ts",
+		"benchmark:sync-phase-profile": "node --loader ts-node/esm ./benchmark/sync-phase-profile.ts",
 		"test": "aegir test --target node",
 		"lint": "aegir lint",
 		"test:cov": "aegir test -t node --cov"
@@ -68,6 +69,7 @@
 		"@peerbit/blocks-interface": "workspace:*",
 		"@peerbit/cache": "workspace:*",
 		"@peerbit/crypto": "workspace:*",
+		"@peerbit/diagnostics": "workspace:*",
 		"@peerbit/indexer-interface": "workspace:*",
 		"@peerbit/indexer-sqlite3": "workspace:*",
 		"@peerbit/log": "workspace:*",

--- a/packages/programs/data/shared-log/src/sync/index.ts
+++ b/packages/programs/data/shared-log/src/sync/index.ts
@@ -7,6 +7,9 @@ import type { EntryWithRefs } from "../exchange-heads.js";
 import type { Numbers } from "../integers.js";
 import type { TransportMessage } from "../message.js";
 import type { EntryReplicated, ReplicationRangeIndexable } from "../ranges.js";
+import type { SyncProfileFn } from "./profile.js";
+
+export type { SyncProfileEvent, SyncProfileFn } from "./profile.js";
 
 export type SyncPriorityFn<R extends "u32" | "u64"> = (
 	entry: EntryReplicated<R>,
@@ -48,6 +51,12 @@ export type SyncOptions<R extends "u32" | "u64"> = {
 	 * Larger values reduce orchestration overhead but increase per-target memory.
 	 */
 	repairSweepTargetBufferSize?: number;
+
+	/**
+	 * Optional profiling callback. It is only invoked when provided, and should
+	 * avoid blocking because it runs inside sync hot paths.
+	 */
+	profile?: SyncProfileFn;
 };
 
 export type SynchronizerComponents<R extends "u32" | "u64"> = {

--- a/packages/programs/data/shared-log/src/sync/profile.ts
+++ b/packages/programs/data/shared-log/src/sync/profile.ts
@@ -1,0 +1,9 @@
+export {
+	diagnosticStart as syncProfileStart,
+	emitDiagnosticDuration as emitSyncProfileDuration,
+	emitDiagnosticEvent as emitSyncProfileEvent,
+} from "@peerbit/diagnostics";
+export type {
+	DiagnosticEvent as SyncProfileEvent,
+	DiagnosticSink as SyncProfileFn,
+} from "@peerbit/diagnostics";

--- a/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
+++ b/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
@@ -33,6 +33,12 @@ import type {
 	SynchronizerComponents,
 	Syncronizer,
 } from "./index.js";
+import {
+	type SyncProfileFn,
+	emitSyncProfileDuration,
+	emitSyncProfileEvent,
+	syncProfileStart,
+} from "./profile.js";
 import { SimpleSyncronizer } from "./simple.js";
 
 export const logger = loggerFn("peerbit:shared-log:rateless");
@@ -590,11 +596,13 @@ const buildEncoderOrDecoderFromRange = async <
 	},
 	entryIndex: Index<EntryReplicated<D>>,
 	type: T,
+	profile?: SyncProfileFn,
 ): Promise<E | false> => {
 	await ribltReady;
 	const encoder =
 		type === "encoder" ? new EncoderWrapper() : new DecoderWrapper();
 
+	const rangeQueryStartedAt = syncProfileStart(profile);
 	const entries = await entryIndex
 		.iterate(
 			{
@@ -614,11 +622,19 @@ const buildEncoderOrDecoderFromRange = async <
 			},
 		)
 		.all();
+	if (profile) {
+		emitSyncProfileDuration(profile, rangeQueryStartedAt, {
+			name: "rateless.rangeQuery",
+			entries: entries.length,
+			details: { type },
+		});
+	}
 
 	if (entries.length === 0) {
 		return false;
 	}
 
+	const addSymbolsStartedAt = syncProfileStart(profile);
 	if (
 		typeof BigUint64Array !== "undefined" &&
 		typeof (encoder as RibltSymbolAdder).add_symbols === "function"
@@ -632,6 +648,14 @@ const buildEncoderOrDecoderFromRange = async <
 		for (const entry of entries) {
 			encoder.add_symbol(coerceBigInt(entry.value.hashNumber));
 		}
+	}
+	if (profile) {
+		emitSyncProfileDuration(profile, addSymbolsStartedAt, {
+			name: "rateless.rangeAddSymbols",
+			entries: entries.length,
+			symbols: entries.length,
+			details: { type },
+		});
 	}
 	return encoder as E;
 };
@@ -709,8 +733,11 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 		}
 
 		let index = 0;
-		const scored: { entry: EntryReplicated<D>; index: number; priority: number }[] =
-			[];
+		const scored: {
+			entry: EntryReplicated<D>;
+			index: number;
+			priority: number;
+		}[] = [];
 		for (const entry of entries.values()) {
 			const priorityValue = priorityFn(entry);
 			scored.push({
@@ -737,7 +764,9 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			1,
 			Math.floor(properties.timeoutMs ?? DEFAULT_CONVERGENT_REPAIR_TIMEOUT_MS),
 		);
-		const retryIntervalsMs = this.normalizeRetryIntervals(properties.retryIntervalsMs);
+		const retryIntervalsMs = this.normalizeRetryIntervals(
+			properties.retryIntervalsMs,
+		);
 		const trackedLimit = this.maxConvergentTrackedHashes;
 		const requestedHashes = [...properties.entries.keys()];
 		const requestedHashesTracked = requestedHashes.slice(0, trackedLimit);
@@ -887,19 +916,39 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 		start2: NumberOrBigint;
 		end2: NumberOrBigint;
 	}): Promise<DecoderWrapper | false> {
+		const profile = this.properties.sync?.profile;
 		const key = this.localRangeEncoderCacheKey(ranges);
 		const cached = this.localRangeEncoderCache.get(key);
 		if (cached && cached.version === this.localRangeEncoderCacheVersion) {
+			const startedAt = syncProfileStart(profile);
 			cached.lastUsed = Date.now();
-			return this.decoderFromCachedEncoder(cached.encoder);
+			try {
+				return this.decoderFromCachedEncoder(cached.encoder);
+			} finally {
+				if (profile) {
+					emitSyncProfileDuration(profile, startedAt, {
+						name: "rateless.localDecoder",
+						cacheHit: true,
+					});
+				}
+			}
 		}
 
+		const startedAt = syncProfileStart(profile);
 		const encoder = (await buildEncoderOrDecoderFromRange(
 			ranges,
 			this.properties.entryIndex,
 			"encoder",
+			profile,
 		)) as EncoderWrapper | false;
 		if (!encoder) {
+			if (profile) {
+				emitSyncProfileDuration(profile, startedAt, {
+					name: "rateless.localDecoder",
+					cacheHit: false,
+					entries: 0,
+				});
+			}
 			return false;
 		}
 
@@ -933,13 +982,24 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			this.localRangeEncoderCache.delete(oldestKey);
 		}
 
-		return this.decoderFromCachedEncoder(encoder);
+		try {
+			return this.decoderFromCachedEncoder(encoder);
+		} finally {
+			if (profile) {
+				emitSyncProfileDuration(profile, startedAt, {
+					name: "rateless.localDecoder",
+					cacheHit: false,
+				});
+			}
+		}
 	}
 
 	async onMaybeMissingEntries(properties: {
 		entries: Map<string, EntryReplicated<D>>;
 		targets: string[];
 	}): Promise<void> {
+		const profile = this.properties.sync?.profile;
+		const startedAt = syncProfileStart(profile);
 		// NOTE: this method is best-effort dispatch, not a per-hash convergence API.
 		// It may require follow-up repair rounds under churn/loss to fully close all gaps.
 		// Strategy:
@@ -954,13 +1014,33 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 
 		// Small batch => use simple synchronizer entirely
 		if (properties.entries.size <= minSyncIbltSize) {
-			await this.simple.onMaybeMissingEntries({
-				entries: properties.entries,
-				targets: properties.targets,
-			});
+			if (profile) {
+				emitSyncProfileEvent(profile, {
+					name: "rateless.dispatchMode",
+					entries: properties.entries.size,
+					targets: properties.targets.length,
+					details: { mode: "simple-small" },
+				});
+			}
+			try {
+				await this.simple.onMaybeMissingEntries({
+					entries: properties.entries,
+					targets: properties.targets,
+				});
+			} finally {
+				if (profile) {
+					emitSyncProfileDuration(profile, startedAt, {
+						name: "rateless.onMaybeMissingEntries",
+						entries: properties.entries.size,
+						targets: properties.targets.length,
+						details: { mode: "simple-small" },
+					});
+				}
+			}
 			return;
 		}
 
+		const selectStartedAt = syncProfileStart(profile);
 		const nonBoundaryEntries: EntryReplicated<D>[] = [];
 		for (const entry of properties.entries.values()) {
 			if (entry.assignedToRangeBoundary) {
@@ -1035,7 +1115,34 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			}
 		}
 
+		if (profile) {
+			emitSyncProfileDuration(profile, selectStartedAt, {
+				name: "rateless.selectEntries",
+				entries: properties.entries.size,
+				symbols: allCoordinatesToSyncWithIblt.length,
+				targets: properties.targets.length,
+				details: {
+					naiveEntries: entriesToSyncNaively.size,
+					priority: priorityFn != null,
+				},
+			});
+		}
+
 		if (allCoordinatesToSyncWithIblt.length === 0) {
+			if (profile) {
+				emitSyncProfileEvent(profile, {
+					name: "rateless.dispatchMode",
+					entries: properties.entries.size,
+					targets: properties.targets.length,
+					details: { mode: "simple-only" },
+				});
+				emitSyncProfileDuration(profile, startedAt, {
+					name: "rateless.onMaybeMissingEntries",
+					entries: properties.entries.size,
+					targets: properties.targets.length,
+					details: { mode: "simple-only" },
+				});
+			}
 			return;
 		}
 
@@ -1048,25 +1155,47 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			Math.sqrt(allCoordinatesToSyncWithIblt.length),
 		); // TODO choose better
 		initialSymbolCount = Math.max(64, initialSymbolCount);
+		const prepareStartedAt = syncProfileStart(profile);
 		const { encoder, start, end, initialSymbols } = prepareStartSyncEncoder(
 			allCoordinatesToSyncWithIblt,
 			this.properties.numbers.maxValue,
 			initialSymbolCount,
 		);
+		if (profile) {
+			emitSyncProfileDuration(profile, prepareStartedAt, {
+				name: "rateless.prepareStartSyncEncoder",
+				entries: allCoordinatesToSyncWithIblt.length,
+				symbols: initialSymbols?.length,
+				details: {
+					initialSymbolCount,
+					includesInitialSymbols: initialSymbols != null,
+				},
+			});
+		}
+
+		let startSyncSymbols = initialSymbols;
+		if (!startSyncSymbols) {
+			const produceStartedAt = syncProfileStart(profile);
+			startSyncSymbols = produceNextCodedSymbols(encoder, initialSymbolCount);
+			if (profile) {
+				emitSyncProfileDuration(profile, produceStartedAt, {
+					name: "rateless.produceStartSyncSymbols",
+					symbols: startSyncSymbols.length,
+				});
+			}
+		}
 
 		const startSync = new StartSync({
 			from: start,
 			to: end,
-			symbols:
-				initialSymbols ?? produceNextCodedSymbols(encoder, initialSymbolCount),
+			symbols: startSyncSymbols,
 		});
+		const syncId = getSyncIdString(startSync);
 
 		const clear = () => {
 			encoder.free();
-			clearTimeout(
-				this.outgoingSyncProcesses.get(getSyncIdString(startSync))?.timeout,
-			);
-			this.outgoingSyncProcesses.delete(getSyncIdString(startSync));
+			clearTimeout(this.outgoingSyncProcesses.get(syncId)?.timeout);
+			this.outgoingSyncProcesses.delete(syncId);
 		};
 		const createTimeout = () => {
 			return setTimeout(clear, 1e4); // TODO arg
@@ -1100,23 +1229,79 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				lastSeqNo++;
 				obj.refresh(); // TODO use timestamp instead and collective pruning/refresh
 
-				return produceNextCodedSymbols(encoder, nextBatch);
+				const produceStartedAt = syncProfileStart(profile);
+				const symbols = produceNextCodedSymbols(encoder, nextBatch);
+				if (profile) {
+					emitSyncProfileDuration(profile, produceStartedAt, {
+						name: "rateless.produceMoreSymbols",
+						syncId,
+						symbols: symbols.length,
+					});
+				}
+				return symbols;
 			},
 			free: clear,
 			outgoing: properties.entries,
 		};
 
-		this.outgoingSyncProcesses.set(getSyncIdString(startSync), obj);
-		this.simple.rpc.send(startSync, {
+		this.outgoingSyncProcesses.set(syncId, obj);
+		if (profile) {
+			emitSyncProfileEvent(profile, {
+				name: "rateless.dispatchMode",
+				entries: properties.entries.size,
+				symbols: startSyncSymbols.length,
+				targets: properties.targets.length,
+				syncId,
+				details: { mode: "rateless" },
+			});
+		}
+		const sendStartedAt = syncProfileStart(profile);
+		const sendResult = this.simple.rpc.send(startSync, {
 			mode: new SilentDelivery({ to: properties.targets, redundancy: 1 }),
 			priority: 1,
 		});
+		if (profile) {
+			void Promise.resolve(sendResult).then(
+				() =>
+					emitSyncProfileDuration(profile, sendStartedAt, {
+						name: "rateless.sendStartSync",
+						messages: 1,
+						symbols: startSyncSymbols.length,
+						targets: properties.targets.length,
+						syncId,
+					}),
+				() =>
+					emitSyncProfileDuration(profile, sendStartedAt, {
+						name: "rateless.sendStartSync",
+						messages: 1,
+						symbols: startSyncSymbols.length,
+						targets: properties.targets.length,
+						syncId,
+						details: { rejected: true },
+					}),
+			);
+		}
+		if (profile) {
+			emitSyncProfileDuration(profile, startedAt, {
+				name: "rateless.onMaybeMissingEntries",
+				entries: properties.entries.size,
+				messages: 1,
+				symbols: startSyncSymbols.length,
+				targets: properties.targets.length,
+				details: {
+					mode: "rateless",
+					ibltEntries: allCoordinatesToSyncWithIblt.length,
+					naiveEntries: entriesToSyncNaively.size,
+				},
+			});
+		}
 	}
 
 	async onMessage(
 		message: TransportMessage,
 		context: RequestContext,
 	): Promise<boolean> {
+		const profile = this.properties.sync?.profile;
 		if (message instanceof StartSync) {
 			const syncId = getSyncIdString(message);
 			if (this.ingoingSyncProcesses.has(syncId)) {
@@ -1130,14 +1315,23 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			this.startedOrCompletedSynchronizations.add(syncId);
 
 			const wrapped = message.end < message.start;
+			const decoderStartedAt = syncProfileStart(profile);
 			const decoder = await this.getLocalDecoderForRange({
 				start1: message.start,
 				end1: wrapped ? this.properties.numbers.maxValue : message.end,
 				start2: 0n,
 				end2: wrapped ? message.end : 0n,
 			});
+			if (profile) {
+				emitSyncProfileDuration(profile, decoderStartedAt, {
+					name: "rateless.getLocalDecoderForRange",
+					syncId,
+					details: { wrapped, found: decoder !== false },
+				});
+			}
 
 			if (!decoder) {
+				const sendStartedAt = syncProfileStart(profile);
 				await this.simple.rpc.send(
 					new RequestAll({
 						syncId: message.syncId,
@@ -1147,6 +1341,14 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 						priority: 1,
 					},
 				);
+				if (profile) {
+					emitSyncProfileDuration(profile, sendStartedAt, {
+						name: "rateless.sendRequestAll",
+						messages: 1,
+						targets: 1,
+						syncId,
+					});
+				}
 				return true;
 			}
 
@@ -1193,7 +1395,16 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 							return false;
 						}
 
+						const remoteStartedAt = syncProfileStart(profile);
 						const allMissingSymbolsInRemote = getRemoteSymbolValues(decoder);
+						if (profile) {
+							emitSyncProfileDuration(profile, remoteStartedAt, {
+								name: "rateless.remoteSymbols",
+								entries: allMissingSymbolsInRemote.length,
+								symbols: allMissingSymbolsInRemote.length,
+								syncId,
+							});
+						}
 
 						// The IBLT decoder is based on a local snapshot. Entries can arrive via
 						// overlapping repair before we issue the follow-up simple request, so
@@ -1219,19 +1430,36 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 							| undefined = (decoder as BatchDecoderWrapper)
 							.add_coded_symbols_and_try_decode;
 						if (typeof BigUint64Array !== "undefined" && addBatchAndDecode) {
-							if (
-								addBatchAndDecode.call(
-									decoder,
-									flatFromCodedSymbols(symbolMessage.symbols),
-								) &&
-								finalizeIfDecoded()
-							) {
+							const flatStartedAt = syncProfileStart(profile);
+							const flatSymbols = flatFromCodedSymbols(symbolMessage.symbols);
+							if (profile) {
+								emitSyncProfileDuration(profile, flatStartedAt, {
+									name: "rateless.symbolBatchToFlat",
+									symbols: flatSymbols.length / CODED_SYMBOL_WORDS,
+									syncId,
+								});
+							}
+
+							const decodeStartedAt = syncProfileStart(profile);
+							const decoded = addBatchAndDecode.call(decoder, flatSymbols);
+							if (profile) {
+								emitSyncProfileDuration(profile, decodeStartedAt, {
+									name: "rateless.decodeBatch",
+									symbols: flatSymbols.length / CODED_SYMBOL_WORDS,
+									syncId,
+									details: { decoded },
+								});
+							}
+							if (decoded && finalizeIfDecoded()) {
 								return true;
 							}
 							continue;
 						}
 
+						const decodeLoopStartedAt = syncProfileStart(profile);
+						let symbolsProcessed = 0;
 						for (const symbol of CodedSymbolBatch.from(symbolMessage.symbols)) {
+							symbolsProcessed += 1;
 							const normalizedSymbol =
 								symbol instanceof SymbolSerialized
 									? symbol
@@ -1260,6 +1488,13 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 								throw error;
 							}
 						}
+						if (profile) {
+							emitSyncProfileDuration(profile, decodeLoopStartedAt, {
+								name: "rateless.decodeSymbolLoop",
+								symbols: symbolsProcessed,
+								syncId,
+							});
+						}
 					}
 					return false;
 				},
@@ -1277,6 +1512,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			}
 
 			// not done, request more symbols
+			const sendStartedAt = syncProfileStart(profile);
 			await this.simple.rpc.send(
 				new RequestMoreSymbols({
 					lastSeqNo: 0n,
@@ -1287,10 +1523,19 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 					priority: 1,
 				},
 			);
+			if (profile) {
+				emitSyncProfileDuration(profile, sendStartedAt, {
+					name: "rateless.sendRequestMoreSymbols",
+					messages: 1,
+					targets: 1,
+					syncId,
+				});
+			}
 
 			return true;
 		} else if (message instanceof MoreSymbols) {
-			const obj = this.ingoingSyncProcesses.get(getSyncIdString(message));
+			const syncId = getSyncIdString(message);
+			const obj = this.ingoingSyncProcesses.get(syncId);
 			if (!obj) {
 				return true;
 			}
@@ -1304,7 +1549,8 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 
 			// we are not done
 
-			this.simple.rpc.send(
+			const sendStartedAt = syncProfileStart(profile);
+			const sendResult = this.simple.rpc.send(
 				new RequestMoreSymbols({
 					lastSeqNo: message.seqNo,
 					syncId: message.syncId,
@@ -1314,24 +1560,55 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 					priority: 1,
 				},
 			);
+			if (profile) {
+				void Promise.resolve(sendResult).then(
+					() =>
+						emitSyncProfileDuration(profile, sendStartedAt, {
+							name: "rateless.sendRequestMoreSymbols",
+							messages: 1,
+							targets: 1,
+							syncId,
+						}),
+					() =>
+						emitSyncProfileDuration(profile, sendStartedAt, {
+							name: "rateless.sendRequestMoreSymbols",
+							messages: 1,
+							targets: 1,
+							syncId,
+							details: { rejected: true },
+						}),
+				);
+			}
 
 			return true;
 		} else if (message instanceof RequestMoreSymbols) {
-			const obj = this.outgoingSyncProcesses.get(getSyncIdString(message));
+			const syncId = getSyncIdString(message);
+			const obj = this.outgoingSyncProcesses.get(syncId);
 			if (!obj) {
 				return true;
 			}
+			const symbols = obj.next(message);
+			const sendStartedAt = syncProfileStart(profile);
 			await this.properties.rpc.send(
 				new MoreSymbols({
 					lastSeqNo: message.lastSeqNo,
 					syncId: message.syncId,
-					symbols: obj.next(message),
+					symbols,
 				}),
 				{
 					mode: new SilentDelivery({ to: [context.from!], redundancy: 1 }),
 					priority: 1,
 				},
 			);
+			if (profile) {
+				emitSyncProfileDuration(profile, sendStartedAt, {
+					name: "rateless.sendMoreSymbols",
+					messages: 1,
+					symbols: symbols.length,
+					targets: 1,
+					syncId,
+				});
+			}
 			return true;
 		} else if (message instanceof RequestAll) {
 			const p = this.outgoingSyncProcesses.get(getSyncIdString(message));

--- a/packages/programs/data/shared-log/src/sync/simple.ts
+++ b/packages/programs/data/shared-log/src/sync/simple.ts
@@ -24,6 +24,7 @@ import type {
 	SyncableKey,
 	Syncronizer,
 } from "./index.js";
+import { emitSyncProfileDuration, syncProfileStart } from "./profile.js";
 
 @variant([0, 1])
 export class RequestMaybeSync extends TransportMessage {
@@ -451,7 +452,8 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		);
 		const allHashes = this.getPrioritizedHashes(properties.entries);
 		const trackedHashes =
-			mode === "convergent" && allHashes.length > this.maxConvergentTrackedHashes
+			mode === "convergent" &&
+			allHashes.length > this.maxConvergentTrackedHashes
 				? allHashes.slice(0, this.maxConvergentTrackedHashes)
 				: allHashes;
 		const truncated = trackedHashes.length < allHashes.length;
@@ -489,7 +491,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				cancel: () => {
 					// no-op
 				},
-				};
+			};
 		}
 
 		// For capped convergent sessions, still dispatch the full set once so large
@@ -522,25 +524,38 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		};
 	}
 
-	onMaybeMissingEntries(properties: {
+	async onMaybeMissingEntries(properties: {
 		entries: Map<string, EntryReplicated<R>>;
 		targets: string[];
 	}): Promise<void> {
+		const profile = this.syncOptions?.profile;
+		const startedAt = syncProfileStart(profile);
 		const hashes = this.getPrioritizedHashes(properties.entries);
 		const chunks = this.chunk(hashes, this.maxHashesPerMessage);
-		return chunks.reduce(
-			(promise, chunk) =>
-				promise.then(() =>
-					this.rpc.send(new RequestMaybeSync({ hashes: chunk }), {
-						priority: 1,
-						mode: new SilentDelivery({
-							to: properties.targets,
-							redundancy: 1,
+		try {
+			await chunks.reduce(
+				(promise, chunk) =>
+					promise.then(() =>
+						this.rpc.send(new RequestMaybeSync({ hashes: chunk }), {
+							priority: 1,
+							mode: new SilentDelivery({
+								to: properties.targets,
+								redundancy: 1,
+							}),
 						}),
-					}),
-				),
-			Promise.resolve(),
-		);
+					),
+				Promise.resolve(),
+			);
+		} finally {
+			if (profile) {
+				emitSyncProfileDuration(profile, startedAt, {
+					name: "simple.onMaybeMissingEntries",
+					entries: hashes.length,
+					messages: chunks.length,
+					targets: properties.targets.length,
+				});
+			}
+		}
 	}
 
 	async onMessage(
@@ -555,29 +570,70 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			// TODO perhaps send less messages to more receivers for performance reasons?
 			// TODO wait for previous send to target before trying to send more?
 
-			for await (const message of createExchangeHeadsMessages(
-				this.log,
-				msg.hashes,
-			)) {
-				await this.rpc.send(message, {
-					mode: new SilentDelivery({ to: [context.from!], redundancy: 1 }),
-				});
+			const profile = this.syncOptions?.profile;
+			const startedAt = syncProfileStart(profile);
+			let messages = 0;
+			try {
+				for await (const message of createExchangeHeadsMessages(
+					this.log,
+					msg.hashes,
+				)) {
+					messages += 1;
+					await this.rpc.send(message, {
+						mode: new SilentDelivery({ to: [context.from!], redundancy: 1 }),
+					});
+				}
+			} finally {
+				if (profile) {
+					emitSyncProfileDuration(profile, startedAt, {
+						name: "simple.exchangeHeads",
+						entries: msg.hashes.length,
+						messages,
+						targets: 1,
+						details: { source: "responseMaybeSync" },
+					});
+				}
 			}
 			return true;
 		} else if (msg instanceof RequestMaybeSyncCoordinate) {
+			const profile = this.syncOptions?.profile;
+			const lookupStartedAt = syncProfileStart(profile);
 			const hashes = await getHashesFromSymbols(
 				msg.hashNumbers,
 				this.entryIndex,
 				this.coordinateToHash,
 			);
-			for await (const message of createExchangeHeadsMessages(
-				this.log,
-				hashes,
-			)) {
-				await this.rpc.send(message, {
-					mode: new SilentDelivery({ to: [context.from!], redundancy: 1 }),
-					// dont set priority 1 here because this will block other messages that should higher priority
+			if (profile) {
+				emitSyncProfileDuration(profile, lookupStartedAt, {
+					name: "simple.coordinateLookup",
+					entries: hashes.size,
+					symbols: msg.hashNumbers.length,
 				});
+			}
+
+			const exchangeStartedAt = syncProfileStart(profile);
+			let messages = 0;
+			try {
+				for await (const message of createExchangeHeadsMessages(
+					this.log,
+					hashes,
+				)) {
+					messages += 1;
+					await this.rpc.send(message, {
+						mode: new SilentDelivery({ to: [context.from!], redundancy: 1 }),
+						// dont set priority 1 here because this will block other messages that should higher priority
+					});
+				}
+			} finally {
+				if (profile) {
+					emitSyncProfileDuration(profile, exchangeStartedAt, {
+						name: "simple.exchangeHeads",
+						entries: hashes.size,
+						messages,
+						targets: 1,
+						details: { source: "requestMaybeSyncCoordinate" },
+					});
+				}
 			}
 
 			return true;
@@ -610,84 +666,128 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		options?: { skipCheck?: boolean },
 	) {
 		const requestHashes: SyncableKey[] = [];
+		const profile = this.syncOptions?.profile;
+		const startedAt = syncProfileStart(profile);
 
-		for (const coordinateOrHash of keys) {
-			const inFlight = this.syncInFlightQueue.get(coordinateOrHash);
-			if (inFlight) {
-				if (!inFlight.find((x) => x.hashcode() === from.hashcode())) {
-					inFlight.push(from);
+		try {
+			for (const coordinateOrHash of keys) {
+				const inFlight = this.syncInFlightQueue.get(coordinateOrHash);
+				if (inFlight) {
+					if (!inFlight.find((x) => x.hashcode() === from.hashcode())) {
+						inFlight.push(from);
+						let inverted = this.syncInFlightQueueInverted.get(from.hashcode());
+						if (!inverted) {
+							inverted = new Set();
+							this.syncInFlightQueueInverted.set(from.hashcode(), inverted);
+						}
+						inverted.add(coordinateOrHash);
+					}
+				} else if (
+					options?.skipCheck ||
+					!(await this.checkHasCoordinateOrHash(coordinateOrHash))
+				) {
+					// Track the initial sender so we can retry if the first request is lost.
+					this.syncInFlightQueue.set(coordinateOrHash, [from]);
 					let inverted = this.syncInFlightQueueInverted.get(from.hashcode());
 					if (!inverted) {
 						inverted = new Set();
 						this.syncInFlightQueueInverted.set(from.hashcode(), inverted);
 					}
 					inverted.add(coordinateOrHash);
+					requestHashes.push(coordinateOrHash); // request immediately (first time we have seen this hash)
 				}
-			} else if (
-				options?.skipCheck ||
-				!(await this.checkHasCoordinateOrHash(coordinateOrHash))
-			) {
-				// Track the initial sender so we can retry if the first request is lost.
-				this.syncInFlightQueue.set(coordinateOrHash, [from]);
-				let inverted = this.syncInFlightQueueInverted.get(from.hashcode());
-				if (!inverted) {
-					inverted = new Set();
-					this.syncInFlightQueueInverted.set(from.hashcode(), inverted);
-				}
-				inverted.add(coordinateOrHash);
-				requestHashes.push(coordinateOrHash); // request immediately (first time we have seen this hash)
+			}
+
+			requestHashes.length > 0 &&
+				(await this.requestSync(requestHashes, [from!.hashcode()]));
+		} finally {
+			if (profile) {
+				emitSyncProfileDuration(profile, startedAt, {
+					name: "simple.queueSync",
+					entries: keys.length,
+					targets: 1,
+					details: {
+						requested: requestHashes.length,
+						skipCheck: options?.skipCheck === true,
+					},
+				});
 			}
 		}
-
-		requestHashes.length > 0 &&
-			(await this.requestSync(requestHashes, [from!.hashcode()]));
 	}
 
 	private async requestSync(hashes: SyncableKey[], to: Set<string> | string[]) {
 		if (hashes.length === 0) {
 			return;
 		}
+		const profile = this.syncOptions?.profile;
+		const startedAt = syncProfileStart(profile);
+		let coordinateMessages = 0;
+		let stringMessages = 0;
+		let coordinateHashCount = 0;
+		let stringHashCount = 0;
 
-		const now = +new Date();
-		for (const node of to) {
-			let map = this.syncInFlight.get(node);
-			if (!map) {
-				map = new Map();
-				this.syncInFlight.set(node, map);
+		try {
+			const now = +new Date();
+			for (const node of to) {
+				let map = this.syncInFlight.get(node);
+				if (!map) {
+					map = new Map();
+					this.syncInFlight.set(node, map);
+				}
+				for (const hash of hashes) {
+					map.set(hash, { timestamp: now });
+				}
 			}
+
+			const coordinateHashes: bigint[] = [];
+			const stringHashes: string[] = [];
 			for (const hash of hashes) {
-				map.set(hash, { timestamp: now });
+				if (typeof hash === "bigint") {
+					coordinateHashes.push(hash);
+				} else {
+					stringHashes.push(hash);
+				}
 			}
-		}
+			coordinateHashCount = coordinateHashes.length;
+			stringHashCount = stringHashes.length;
 
-		const coordinateHashes: bigint[] = [];
-		const stringHashes: string[] = [];
-		for (const hash of hashes) {
-			if (typeof hash === "bigint") {
-				coordinateHashes.push(hash);
-			} else {
-				stringHashes.push(hash);
+			if (coordinateHashes.length > 0) {
+				const chunks = this.chunk(
+					coordinateHashes,
+					this.maxCoordinatesPerMessage,
+				);
+				coordinateMessages = chunks.length;
+				for (const chunk of chunks) {
+					await this.rpc.send(
+						new RequestMaybeSyncCoordinate({ hashNumbers: chunk }),
+						{
+							mode: new SilentDelivery({ to, redundancy: 1 }),
+							priority: 1,
+						},
+					);
+				}
 			}
-		}
-
-		if (coordinateHashes.length > 0) {
-			const chunks = this.chunk(coordinateHashes, this.maxCoordinatesPerMessage);
-			for (const chunk of chunks) {
-				await this.rpc.send(
-					new RequestMaybeSyncCoordinate({ hashNumbers: chunk }),
-					{
+			if (stringHashes.length > 0) {
+				const chunks = this.chunk(stringHashes, this.maxHashesPerMessage);
+				stringMessages = chunks.length;
+				for (const chunk of chunks) {
+					await this.rpc.send(new ResponseMaybeSync({ hashes: chunk }), {
 						mode: new SilentDelivery({ to, redundancy: 1 }),
 						priority: 1,
-					},
-				);
+					});
+				}
 			}
-		}
-		if (stringHashes.length > 0) {
-			const chunks = this.chunk(stringHashes, this.maxHashesPerMessage);
-			for (const chunk of chunks) {
-				await this.rpc.send(new ResponseMaybeSync({ hashes: chunk }), {
-					mode: new SilentDelivery({ to, redundancy: 1 }),
-					priority: 1,
+		} finally {
+			if (profile) {
+				emitSyncProfileDuration(profile, startedAt, {
+					name: "simple.requestSync",
+					entries: hashes.length,
+					messages: coordinateMessages + stringMessages,
+					targets: Array.isArray(to) ? to.length : to.size,
+					details: {
+						coordinateHashes: coordinateHashCount,
+						stringHashes: stringHashCount,
+					},
 				});
 			}
 		}

--- a/packages/programs/data/shared-log/test/rateless-iblt.spec.ts
+++ b/packages/programs/data/shared-log/test/rateless-iblt.spec.ts
@@ -236,6 +236,7 @@ describe("rateless-iblt-syncronizer", () => {
 
 	it("large missing sets dispatch with rateless IBLT", async () => {
 		const sentMessages: TransportMessage[] = [];
+		const profileEvents: { name: string }[] = [];
 		const sync = new RatelessIBLTSynchronizer<"u64">({
 			rpc: {
 				send: async (message: TransportMessage) => {
@@ -247,6 +248,7 @@ describe("rateless-iblt-syncronizer", () => {
 			log: {} as any,
 			coordinateToHash: new Cache<string>({ max: 1000, ttl: 1000 }),
 			numbers: { maxValue: 2n ** 64n - 1n } as any,
+			sync: { profile: (event) => profileEvents.push(event) },
 		});
 
 		try {
@@ -273,6 +275,9 @@ describe("rateless-iblt-syncronizer", () => {
 			expect(
 				(startSyncMessages[0] as StartSync).symbols.length,
 			).to.be.greaterThan(0);
+			const profileNames = profileEvents.map((event) => event.name);
+			expect(profileNames).to.include("rateless.prepareStartSyncEncoder");
+			expect(profileNames).to.include("rateless.onMaybeMissingEntries");
 		} finally {
 			await sync.close();
 		}

--- a/packages/utils/diagnostics/package.json
+++ b/packages/utils/diagnostics/package.json
@@ -1,0 +1,69 @@
+{
+	"name": "@peerbit/diagnostics",
+	"version": "0.0.1",
+	"description": "Structured diagnostics helpers",
+	"sideEffects": false,
+	"type": "module",
+	"types": "./dist/src/index.d.ts",
+	"typesVersions": {
+		"*": {
+			"*": [
+				"*",
+				"dist/*",
+				"dist/src/*",
+				"dist/src/*/index"
+			],
+			"src/*": [
+				"*",
+				"dist/*",
+				"dist/src/*",
+				"dist/src/*/index"
+			]
+		}
+	},
+	"files": [
+		"src",
+		"dist",
+		"!dist/test",
+		"!**/*.tsbuildinfo"
+	],
+	"exports": {
+		".": {
+			"types": "./dist/src/index.d.ts",
+			"import": "./dist/src/index.js"
+		}
+	},
+	"eslintConfig": {
+		"extends": "peerbit",
+		"parserOptions": {
+			"project": true,
+			"sourceType": "module"
+		},
+		"ignorePatterns": [
+			"!.aegir.js",
+			"test/ts-use",
+			"*.d.ts"
+		]
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"clean": "aegir clean",
+		"build": "aegir build --no-bundle",
+		"test": "aegir test --target node",
+		"lint": "aegir lint",
+		"test:cov": "aegir test -t node --cov"
+	},
+	"author": "dao.xyz",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/dao-xyz/peerbit.git",
+		"directory": "packages/utils/diagnostics"
+	},
+	"bugs": {
+		"url": "https://github.com/dao-xyz/peerbit/issues"
+	},
+	"homepage": "https://github.com/dao-xyz/peerbit#readme"
+}

--- a/packages/utils/diagnostics/src/index.ts
+++ b/packages/utils/diagnostics/src/index.ts
@@ -1,0 +1,50 @@
+export type DiagnosticValue = string | number | boolean | undefined;
+
+export type DiagnosticEvent = {
+	/**
+	 * Stable event or phase name, for example "shared-log.sync.queueSync".
+	 */
+	name: string;
+	component?: string;
+	durationMs?: number;
+	count?: number;
+	entries?: number;
+	symbols?: number;
+	messages?: number;
+	bytes?: number;
+	targets?: number;
+	cacheHit?: boolean;
+	peer?: string;
+	traceId?: string;
+	syncId?: string;
+	details?: Record<string, DiagnosticValue>;
+};
+
+export type DiagnosticSink = (event: DiagnosticEvent) => void;
+
+export const diagnosticNow = () =>
+	globalThis.performance?.now?.() ?? Date.now();
+
+export const diagnosticStart = (sink: DiagnosticSink | undefined) =>
+	sink ? diagnosticNow() : 0;
+
+export const emitDiagnosticEvent = (
+	sink: DiagnosticSink | undefined,
+	event: DiagnosticEvent,
+) => {
+	sink?.(event);
+};
+
+export const emitDiagnosticDuration = (
+	sink: DiagnosticSink | undefined,
+	startedAt: number,
+	event: Omit<DiagnosticEvent, "durationMs">,
+) => {
+	if (!sink) {
+		return;
+	}
+	sink({
+		...event,
+		durationMs: diagnosticNow() - startedAt,
+	});
+};

--- a/packages/utils/diagnostics/test/index.spec.ts
+++ b/packages/utils/diagnostics/test/index.spec.ts
@@ -1,0 +1,27 @@
+import { expect } from "chai";
+import {
+	type DiagnosticEvent,
+	diagnosticStart,
+	emitDiagnosticDuration,
+} from "../src/index.js";
+
+describe("diagnostics", () => {
+	it("does not take a timestamp when disabled", () => {
+		expect(diagnosticStart(undefined)).to.equal(0);
+	});
+
+	it("emits duration events", () => {
+		const events: DiagnosticEvent[] = [];
+		const startedAt = diagnosticStart((event) => events.push(event));
+
+		emitDiagnosticDuration((event) => events.push(event), startedAt, {
+			name: "test.phase",
+			count: 1,
+		});
+
+		expect(events).to.have.length(1);
+		expect(events[0].name).to.equal("test.phase");
+		expect(events[0].count).to.equal(1);
+		expect(events[0].durationMs).to.be.a("number");
+	});
+});

--- a/packages/utils/diagnostics/tsconfig.json
+++ b/packages/utils/diagnostics/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "aegir/src/config/tsconfig.aegir.json",
+	"compilerOptions": {
+		"strictNullChecks": false,
+		"outDir": "dist"
+	},
+	"include": ["src", "test"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1625,6 +1625,9 @@ importers:
       '@peerbit/crypto':
         specifier: workspace:*
         version: link:../../../utils/crypto
+      '@peerbit/diagnostics':
+        specifier: workspace:*
+        version: link:../../../utils/diagnostics
       '@peerbit/indexer-interface':
         specifier: workspace:*
         version: link:../../../utils/indexer/interface
@@ -2478,6 +2481,8 @@ importers:
       '@peerbit/time':
         specifier: workspace:*
         version: link:../time
+
+  packages/utils/diagnostics: {}
 
   packages/utils/crypto:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,6 +45,7 @@ packages:
   - packages/utils/build-assets
   - packages/utils/time
   - packages/utils/cache
+  - packages/utils/diagnostics
   - packages/utils/logger
   - packages/utils/keychain
   - packages/utils/indexer/*


### PR DESCRIPTION
## Summary
- add tiny `@peerbit/diagnostics` package with structured event/sink types and zero-disabled-overhead timing helpers
- add optional `sync.profile` phase events for simple and rateless shared-log sync through the diagnostics helpers
- add `benchmark:sync-phase-profile` for seeded or empty catch-up profiling with JSON/table output
- cover diagnostics/profile emission in focused tests

## Local verification
- `pnpm --filter @peerbit/diagnostics run test`
- `pnpm --filter @peerbit/shared-log run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "large missing sets dispatch with rateless IBLT"`
- `pnpm --filter @peerbit/shared-log run benchmark:sync-phase-profile -- --entries 200 --seededEntries 400 --runs 1 --timeoutMs 60000 --json`
- `git diff --check`

## Notes
Disabled profiling avoids event-object construction and timer reads; the hot path only reads the optional sink and branches.

## Smoke finding
With seeded catch-up, the profiler exercised the rateless path without `RequestAll` fallback and highlighted `simple.queueSync`, `simple.exchangeHeads`, and local decoder/range query work as the largest measured sync-phase buckets on small runs.