### PR TITLE
Bridge Rust index planner into indexer adapter

### DIFF
--- a/packages/utils/indexer/rust/Cargo.lock
+++ b/packages/utils/indexer/rust/Cargo.lock
@@ -73,6 +73,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +89,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "once_cell"
@@ -97,6 +109,8 @@ dependencies = [
  "indexmap",
  "js-sys",
  "roaring",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
 ]
 
@@ -139,6 +153,49 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
 
 [[package]]
 name = "slab"
@@ -207,3 +264,9 @@ checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/packages/utils/indexer/rust/Cargo.toml
+++ b/packages/utils/indexer/rust/Cargo.toml
@@ -12,6 +12,8 @@ crate-type = ["cdylib", "rlib"]
 indexmap = "2.7.1"
 js-sys = "0.3.80"
 roaring = "0.11.4"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 wasm-bindgen = "0.2.103"
 
 [package.metadata.wasm-pack.profile.release]

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -16,10 +16,48 @@ type NativeIndexStore<T extends Record<string, any>> = {
 	entries: () => Array<[types.IdKey, T]>;
 };
 
+type NativeQueryPlanner = {
+	put_document: (id: string, fieldsJson: string) => void;
+	delete_document: (id: string) => void;
+	clear: () => void;
+	len: () => number;
+	query: (queryJson: string, sortJson: string) => string[];
+};
+
 type WasmModule = {
 	default: (input?: unknown) => Promise<unknown>;
 	initSync: (input?: unknown) => unknown;
 	NativeIndexStore: new <T extends Record<string, any>>() => NativeIndexStore<T>;
+	NativeQueryPlanner: new () => NativeQueryPlanner;
+};
+
+type NativeValue =
+	| { type: "bool"; value: boolean }
+	| { type: "i64"; value: string }
+	| { type: "u64"; value: string }
+	| { type: "string"; value: string };
+
+type NativeFieldFact = {
+	field: string;
+	value: NativeValue;
+};
+
+type NativeQuerySpec =
+	| { op: "all" }
+	| { op: "exact"; field: string; value: NativeValue }
+	| {
+			op: "range";
+			field: string;
+			compare: "eq" | "gt" | "gte" | "lt" | "lte";
+			value: NativeValue;
+	  }
+	| { op: "and"; queries: NativeQuerySpec[] }
+	| { op: "or"; queries: NativeQuerySpec[] }
+	| { op: "not"; query: NativeQuerySpec };
+
+type NativeQueryCompileResult = {
+	spec: NativeQuerySpec;
+	exact: boolean;
 };
 
 let wasmModulePromise: Promise<WasmModule> | undefined;
@@ -61,6 +99,249 @@ const keyToStoreKey = (id: types.IdKey): string => {
 	return `${typeof key}:${key.toString()}`;
 };
 
+const nativeFieldKey = (path: string[]): string => JSON.stringify(path);
+
+const bytesToNativeString = (bytes: Uint8Array): string => {
+	let hex = "";
+	for (const byte of bytes) {
+		hex += byte.toString(16).padStart(2, "0");
+	}
+	return `\u0000bytes:${hex}`;
+};
+
+const nativeIntegerValue = (value: number | bigint): NativeValue | undefined => {
+	if (typeof value === "bigint") {
+		if (value >= 0n && value <= 18446744073709551615n) {
+			return { type: "u64", value: value.toString() };
+		}
+		if (value >= -9223372036854775808n && value <= 9223372036854775807n) {
+			return { type: "i64", value: value.toString() };
+		}
+		return undefined;
+	}
+	if (!Number.isSafeInteger(value)) {
+		return undefined;
+	}
+	return value >= 0
+		? { type: "u64", value: value.toString() }
+		: { type: "i64", value: value.toString() };
+};
+
+const scalarToNativeValue = (value: any): NativeValue | undefined => {
+	if (typeof value === "boolean") {
+		return { type: "bool", value };
+	}
+	if (typeof value === "string") {
+		return { type: "string", value };
+	}
+	if (typeof value === "number" || typeof value === "bigint") {
+		return nativeIntegerValue(value);
+	}
+	if (value instanceof Uint8Array || ArrayBuffer.isView(value)) {
+		const bytes =
+			value instanceof Uint8Array
+				? value
+				: new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+		return { type: "string", value: bytesToNativeString(bytes) };
+	}
+	return undefined;
+};
+
+const collectNativeFieldFacts = (
+	value: any,
+	path: string[] = [],
+	facts: NativeFieldFact[] = [],
+	seen: WeakSet<object> = new WeakSet(),
+): NativeFieldFact[] => {
+	if (value instanceof Uint8Array || ArrayBuffer.isView(value)) {
+		if (path.length > 0) {
+			const bytes =
+				value instanceof Uint8Array
+					? value
+					: new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+			facts.push({
+				field: nativeFieldKey(path),
+				value: { type: "string", value: bytesToNativeString(bytes) },
+			});
+			for (const byte of bytes) {
+				facts.push({
+					field: nativeFieldKey(path),
+					value: { type: "u64", value: byte.toString() },
+				});
+			}
+		}
+		return facts;
+	}
+
+	const nativeValue = scalarToNativeValue(value);
+	if (nativeValue) {
+		if (path.length > 0) {
+			facts.push({ field: nativeFieldKey(path), value: nativeValue });
+		}
+		return facts;
+	}
+
+	if (!value || typeof value !== "object") {
+		return facts;
+	}
+	if (seen.has(value)) {
+		return facts;
+	}
+	seen.add(value);
+
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			collectNativeFieldFacts(item, path, facts, seen);
+		}
+		return facts;
+	}
+
+	for (const [key, child] of Object.entries(value)) {
+		collectNativeFieldFacts(child, [...path, key], facts, seen);
+	}
+	return facts;
+};
+
+const compareToNative = (
+	compare: types.Compare,
+): "eq" | "gt" | "gte" | "lt" | "lte" => {
+	switch (compare) {
+		case types.Compare.Equal:
+			return "eq";
+		case types.Compare.Greater:
+			return "gt";
+		case types.Compare.GreaterOrEqual:
+			return "gte";
+		case types.Compare.Less:
+			return "lt";
+		case types.Compare.LessOrEqual:
+			return "lte";
+		default:
+			throw new Error("Unexpected compare");
+	}
+};
+
+const compileNativeQueries = (
+	queries: types.Query[],
+): NativeQueryCompileResult => {
+	return compileNativeAnd(queries);
+};
+
+const compileNativeAnd = (
+	queries: types.Query[],
+): NativeQueryCompileResult => {
+	const compiled: NativeQuerySpec[] = [];
+	let exact = true;
+
+	for (const query of queries) {
+		const next = compileNativeQuery(query);
+		if (next) {
+			compiled.push(next.spec);
+			exact &&= next.exact;
+		} else {
+			exact = false;
+		}
+	}
+
+	if (compiled.length === 0) {
+		return { spec: { op: "all" }, exact: false };
+	}
+	if (compiled.length === 1) {
+		return { spec: compiled[0], exact };
+	}
+	return { spec: { op: "and", queries: compiled }, exact };
+};
+
+const compileNativeQuery = (
+	query: types.Query,
+): NativeQueryCompileResult | undefined => {
+	if (query instanceof types.And) {
+		return compileNativeAnd(query.and);
+	}
+	if (query instanceof types.Or) {
+		const compiled: NativeQuerySpec[] = [];
+		let exact = true;
+		for (const child of query.or) {
+			const next = compileNativeQuery(child);
+			if (!next) {
+				return { spec: { op: "all" }, exact: false };
+			}
+			compiled.push(next.spec);
+			exact &&= next.exact;
+		}
+		return { spec: { op: "or", queries: compiled }, exact };
+	}
+	if (query instanceof types.Not) {
+		const child = compileNativeQuery(query.not);
+		if (!child?.exact) {
+			return { spec: { op: "all" }, exact: false };
+		}
+		return { spec: { op: "not", query: child.spec }, exact: true };
+	}
+	if (query instanceof types.BoolQuery) {
+		return {
+			spec: {
+				op: "exact",
+				field: nativeFieldKey(query.key),
+				value: { type: "bool", value: query.value },
+			},
+			exact: true,
+		};
+	}
+	if (query instanceof types.StringMatch) {
+		if (
+			query.method !== types.StringMatchMethod.exact ||
+			query.caseInsensitive !== false
+		) {
+			return;
+		}
+		return {
+			spec: {
+				op: "exact",
+				field: nativeFieldKey(query.key),
+				value: { type: "string", value: query.value },
+			},
+			exact: true,
+		};
+	}
+	if (query instanceof types.ByteMatchQuery) {
+		return {
+			spec: {
+				op: "exact",
+				field: nativeFieldKey(query.key),
+				value: { type: "string", value: bytesToNativeString(query.value) },
+			},
+			exact: true,
+		};
+	}
+	if (query instanceof types.IntegerCompare) {
+		const value = nativeIntegerValue(query.value.value);
+		if (!value) {
+			return;
+		}
+		if (query.compare === types.Compare.Equal) {
+			return {
+				spec: {
+					op: "exact",
+					field: nativeFieldKey(query.key),
+					value,
+				},
+				exact: true,
+			};
+		}
+		return {
+			spec: {
+				op: "range",
+				field: nativeFieldKey(query.key),
+				compare: compareToNative(query.compare),
+				value,
+			},
+			exact: true,
+		};
+	}
+	return;
+};
+
 const getBatchFromResults = <T extends Record<string, any>>(
 	results: types.IndexedValue<T>[],
 	wantedSize: number,
@@ -90,6 +371,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 {
 	private snapshotFile?: SnapshotFile;
 	private store?: NativeIndexStore<T>;
+	private planner?: NativeQueryPlanner;
 	private indexByArr!: string[];
 	private properties!: types.IndexEngineInitProperties<T, NestedType>;
 	private persistQueue: Promise<void> = Promise.resolve();
@@ -121,6 +403,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 
 		const wasm = await loadWasm();
 		this.store = new wasm.NativeIndexStore<T>();
+		this.planner = new wasm.NativeQueryPlanner();
 		this.snapshotFile = await createSnapshotFile(
 			this.directory,
 			this.path,
@@ -129,7 +412,9 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		if (this.snapshotFile) {
 			for (const value of await this.snapshotFile.read(properties.schema)) {
 				const id = types.toId(types.extractFieldValue(value, this.indexByArr));
-				this.store.put(keyToStoreKey(id), id, value);
+				const storeKey = keyToStoreKey(id);
+				this.store.put(storeKey, id, value);
+				this.indexNativeDocument(storeKey, value);
 			}
 		}
 		return this;
@@ -154,14 +439,18 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		id = types.toId(types.extractFieldValue(value, this.indexByArr)),
 		_options?: { replace?: boolean },
 	): Promise<void> {
-		this.getStore().put(keyToStoreKey(id), id, value);
+		const storeKey = keyToStoreKey(id);
+		this.getStore().put(storeKey, id, value);
+		this.indexNativeDocument(storeKey, value);
 		this.markDirty();
 	}
 
 	async del(query: types.DeleteOptions): Promise<types.IdKey[]> {
 		const deleted: types.IdKey[] = [];
 		for (const doc of await this.queryAll(query)) {
-			if (this.getStore().delete(keyToStoreKey(doc.id))) {
+			const storeKey = keyToStoreKey(doc.id);
+			if (this.getStore().delete(storeKey)) {
+				this.planner?.delete_document(storeKey);
 				deleted.push(doc.id);
 			}
 		}
@@ -193,6 +482,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 
 	async drop(): Promise<void> {
 		this.store?.clear();
+		this.planner?.clear();
 		this.persistedVersion = this.dirtyVersion;
 		await this.snapshotFile?.remove();
 	}
@@ -253,15 +543,19 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			}
 		}
 
-		const indexedDocuments = await this.queryDocuments(async (doc) => {
-			const innerHits = new Map();
-			for (const f of queryCoerced) {
-				if (!(await this.handleQueryObject(f, doc.value, innerHits))) {
-					return false;
+		const nativeCandidates = this.getNativeCandidates(queryCoerced);
+		const indexedDocuments = await this.queryDocuments(
+			async (doc) => {
+				const innerHits = new Map();
+				for (const f of queryCoerced) {
+					if (!(await this.handleQueryObject(f, doc.value, innerHits))) {
+						return false;
+					}
 				}
-			}
-			return true;
-		});
+				return true;
+			},
+			nativeCandidates,
+		);
 
 		return indexedDocuments;
 	}
@@ -561,14 +855,46 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 
 	private async queryDocuments(
 		filter: (doc: types.IndexedValue<T>) => Promise<boolean>,
+		documents = this.snapshot(),
 	): Promise<types.IndexedValue<T>[]> {
 		const results: types.IndexedValue<T>[] = [];
-		for (const value of this.snapshot()) {
+		for (const value of documents) {
 			if (await filter(value)) {
 				results.push(value);
 			}
 		}
 		return results;
+	}
+
+	private getNativeCandidates(
+		queryCoerced: types.Query[],
+	): types.IndexedValue<T>[] | undefined {
+		if (!this.planner || queryCoerced.length === 0) {
+			return;
+		}
+		const compiled = compileNativeQueries(queryCoerced);
+		if (compiled.spec.op === "all") {
+			return;
+		}
+
+		const results: types.IndexedValue<T>[] = [];
+		for (const storeKey of this.planner.query(
+			JSON.stringify(compiled.spec),
+			"[]",
+		)) {
+			const value = this.getStore().get(storeKey);
+			if (value) {
+				results.push({ id: value[0], value: value[1] });
+			}
+		}
+		return results;
+	}
+
+	private indexNativeDocument(storeKey: string, value: T): void {
+		this.planner?.put_document(
+			storeKey,
+			JSON.stringify(collectNativeFieldFacts(value)),
+		);
 	}
 
 	private snapshot(): types.IndexedValue<T>[] {

--- a/packages/utils/indexer/rust/src/lib.rs
+++ b/packages/utils/indexer/rust/src/lib.rs
@@ -1,5 +1,9 @@
 use indexmap::IndexMap;
 use js_sys::Array;
+use planner::{
+    Compare, DocumentFields, FieldValue, NativeQueryIndex, Query, SortDirection, SortField,
+};
+use serde::Deserialize;
 use wasm_bindgen::prelude::*;
 
 pub mod planner;
@@ -64,4 +68,201 @@ fn entry_to_js(entry: &StoredEntry) -> JsValue {
     pair.push(&entry.id);
     pair.push(&entry.value);
     pair.into()
+}
+
+#[wasm_bindgen]
+pub struct NativeQueryPlanner {
+    index: NativeQueryIndex,
+}
+
+#[wasm_bindgen]
+impl NativeQueryPlanner {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> NativeQueryPlanner {
+        NativeQueryPlanner {
+            index: NativeQueryIndex::new(),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.index.clear();
+    }
+
+    pub fn len(&self) -> usize {
+        self.index.len()
+    }
+
+    pub fn put_document(&mut self, id: String, fields_json: String) -> Result<(), JsValue> {
+        let fields = decode_document_fields(&fields_json)?;
+        self.index.put(id, fields);
+        Ok(())
+    }
+
+    pub fn delete_document(&mut self, id: String) {
+        self.index.delete(id);
+    }
+
+    pub fn query(&self, query_json: String, sort_json: String) -> Result<Array, JsValue> {
+        let query = decode_query(&query_json)?;
+        let sort = decode_sort(&sort_json)?;
+        let ids = self.index.search(&query, &sort, None);
+        let out = Array::new();
+        for id in ids {
+            out.push(&JsValue::from_str(&id));
+        }
+        Ok(out)
+    }
+}
+
+#[derive(Deserialize)]
+struct FieldFactDto {
+    field: String,
+    value: FieldValueDto,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", content = "value")]
+enum FieldValueDto {
+    #[serde(rename = "bool")]
+    Bool(bool),
+    #[serde(rename = "i64")]
+    I64(String),
+    #[serde(rename = "u64")]
+    U64(String),
+    #[serde(rename = "string")]
+    String(String),
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "op")]
+enum QueryDto {
+    #[serde(rename = "all")]
+    All,
+    #[serde(rename = "exact")]
+    Exact { field: String, value: FieldValueDto },
+    #[serde(rename = "range")]
+    Range {
+        field: String,
+        compare: CompareDto,
+        value: FieldValueDto,
+    },
+    #[serde(rename = "and")]
+    And { queries: Vec<QueryDto> },
+    #[serde(rename = "or")]
+    Or { queries: Vec<QueryDto> },
+    #[serde(rename = "not")]
+    Not { query: Box<QueryDto> },
+}
+
+#[derive(Clone, Copy, Deserialize)]
+enum CompareDto {
+    #[serde(rename = "eq")]
+    Equal,
+    #[serde(rename = "gt")]
+    Greater,
+    #[serde(rename = "gte")]
+    GreaterOrEqual,
+    #[serde(rename = "lt")]
+    Less,
+    #[serde(rename = "lte")]
+    LessOrEqual,
+}
+
+#[derive(Deserialize)]
+struct SortFieldDto {
+    field: String,
+    direction: SortDirectionDto,
+}
+
+#[derive(Deserialize)]
+enum SortDirectionDto {
+    #[serde(rename = "asc")]
+    Asc,
+    #[serde(rename = "desc")]
+    Desc,
+}
+
+fn decode_document_fields(fields_json: &str) -> Result<DocumentFields, JsValue> {
+    let facts: Vec<FieldFactDto> = serde_json::from_str(fields_json).map_err(js_error)?;
+    let mut fields = DocumentFields::new();
+    for fact in facts {
+        fields.insert_scalar(fact.field, decode_field_value(fact.value)?);
+    }
+    Ok(fields)
+}
+
+fn decode_query(query_json: &str) -> Result<Query, JsValue> {
+    let query: QueryDto = serde_json::from_str(query_json).map_err(js_error)?;
+    query.try_into()
+}
+
+fn decode_sort(sort_json: &str) -> Result<Vec<SortField>, JsValue> {
+    let fields: Vec<SortFieldDto> = serde_json::from_str(sort_json).map_err(js_error)?;
+    fields
+        .into_iter()
+        .map(|field| {
+            Ok(SortField {
+                field: field.field,
+                direction: match field.direction {
+                    SortDirectionDto::Asc => SortDirection::Asc,
+                    SortDirectionDto::Desc => SortDirection::Desc,
+                },
+            })
+        })
+        .collect()
+}
+
+impl TryFrom<QueryDto> for Query {
+    type Error = JsValue;
+
+    fn try_from(value: QueryDto) -> Result<Self, Self::Error> {
+        Ok(match value {
+            QueryDto::All => Query::All,
+            QueryDto::Exact { field, value } => Query::Exact {
+                field,
+                value: decode_field_value(value)?,
+            },
+            QueryDto::Range {
+                field,
+                compare,
+                value,
+            } => Query::Range {
+                field,
+                compare: compare.into(),
+                value: decode_field_value(value)?,
+            },
+            QueryDto::And { queries } => Query::And(decode_queries(queries)?),
+            QueryDto::Or { queries } => Query::Or(decode_queries(queries)?),
+            QueryDto::Not { query } => Query::Not(Box::new((*query).try_into()?)),
+        })
+    }
+}
+
+impl From<CompareDto> for Compare {
+    fn from(value: CompareDto) -> Self {
+        match value {
+            CompareDto::Equal => Compare::Equal,
+            CompareDto::Greater => Compare::Greater,
+            CompareDto::GreaterOrEqual => Compare::GreaterOrEqual,
+            CompareDto::Less => Compare::Less,
+            CompareDto::LessOrEqual => Compare::LessOrEqual,
+        }
+    }
+}
+
+fn decode_queries(queries: Vec<QueryDto>) -> Result<Vec<Query>, JsValue> {
+    queries.into_iter().map(Query::try_from).collect()
+}
+
+fn decode_field_value(value: FieldValueDto) -> Result<FieldValue, JsValue> {
+    match value {
+        FieldValueDto::Bool(value) => Ok(FieldValue::Bool(value)),
+        FieldValueDto::I64(value) => value.parse::<i64>().map(FieldValue::I64).map_err(js_error),
+        FieldValueDto::U64(value) => value.parse::<u64>().map(FieldValue::U64).map_err(js_error),
+        FieldValueDto::String(value) => Ok(FieldValue::String(value)),
+    }
+}
+
+fn js_error(error: impl ToString) -> JsValue {
+    JsValue::from_str(&error.to_string())
 }

--- a/packages/utils/indexer/rust/src/planner.rs
+++ b/packages/utils/indexer/rust/src/planner.rs
@@ -223,6 +223,10 @@ impl NativeQueryIndex {
         self.documents.is_empty()
     }
 
+    pub fn clear(&mut self) {
+        *self = Self::default();
+    }
+
     pub fn put(&mut self, id: impl Into<String>, fields: DocumentFields) {
         self.apply_batch(IndexBatch::new().put(id, fields));
     }

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -1,5 +1,32 @@
+import { field } from "@dao-xyz/borsh";
+import {
+	And,
+	Or,
+	Sort,
+	StringMatch,
+	StringMatchMethod,
+	id,
+} from "@peerbit/indexer-interface";
 import { tests } from "@peerbit/indexer-tests";
+import { expect } from "chai";
 import { create } from "../src/index.js";
+
+class BridgeDocument {
+	@id({ type: "string" })
+	id: string;
+
+	@field({ type: "string" })
+	tag: string;
+
+	@field({ type: "string" })
+	title: string;
+
+	constructor(id: string, tag: string, title: string) {
+		this.id = id;
+		this.tag = tag;
+		this.title = title;
+	}
+}
 
 describe("all", () => {
 	tests(create, "persist", {
@@ -11,5 +38,62 @@ describe("all", () => {
 		shapingSupported: false,
 		u64SumSupported: true,
 		iteratorsMutable: false,
+	});
+});
+
+describe("native planner bridge", () => {
+	it("uses supported native candidates with residual predicates", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeDocument });
+		await index.put(new BridgeDocument("a", "peerbit", "native index"));
+		await index.put(new BridgeDocument("b", "other", "native bridge"));
+		await index.put(new BridgeDocument("c", "peerbit", "typescript fallback"));
+
+		const results = await index
+			.iterate({
+				query: new And([
+					new StringMatch({ key: "tag", value: "peerbit" }),
+					new StringMatch({
+						key: "title",
+						value: "native",
+						method: StringMatchMethod.contains,
+					}),
+				]),
+			})
+			.all();
+
+		expect(results.map((result) => result.value.id)).to.deep.equal(["a"]);
+		await indices.drop();
+	});
+
+	it("falls back safely when an or branch is not native", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeDocument });
+		await index.put(new BridgeDocument("a", "peerbit", "native index"));
+		await index.put(new BridgeDocument("b", "other", "native bridge"));
+		await index.put(new BridgeDocument("c", "peerbit", "typescript fallback"));
+
+		const results = await index
+			.iterate({
+				query: new Or([
+					new StringMatch({ key: "tag", value: "peerbit" }),
+					new StringMatch({
+						key: "title",
+						value: "native",
+						method: StringMatchMethod.contains,
+					}),
+				]),
+				sort: new Sort({ key: "id" }),
+			})
+			.all();
+
+		expect(results.map((result) => result.value.id)).to.deep.equal([
+			"a",
+			"b",
+			"c",
+		]);
+		await indices.drop();
 	});
 });


### PR DESCRIPTION
## Summary

Stacked on #787.

This wires the Rust query planner into the `@peerbit/indexer-rust` TypeScript adapter behind a conservative candidate-filtering bridge:

- expose a WASM `NativeQueryPlanner` wrapper for put/delete/clear/query
- index scalar field facts from adapter documents into the Rust planner on put and snapshot load
- use native candidates for supported exact/range predicates, then keep the existing TypeScript evaluator as the residual correctness gate
- fall back safely for unsupported query shapes such as contains/case-insensitive string matching, nested queries, and mixed unsupported OR/NOT branches
- index `Uint8Array` fields both as exact byte blobs and as per-byte numeric facts so existing conformance behavior is preserved

## Benchmark signal

The bridge shows the expected wins on selective scalar predicates while broad/unsupported shapes still scan through the existing TS evaluator.

Transient examples from `pnpm --filter @peerbit/indexer-rust benchmark`:

- `number query fetch 10`: ~71.8k ops/s
- `string query matching`: ~6.6k ops/s
- `string count no-matches`: ~539k ops/s
- broad 3-field OR query: still ~6 ops/s because it safely falls back

Persistent examples:

- `number query fetch 10`: ~65.3k ops/s
- `string query matching`: ~6.6k ops/s
- `string count no-matches`: ~533k ops/s

## Verification

- `cargo test`
- `pnpm --filter @peerbit/indexer-rust lint`
- `pnpm --filter @peerbit/indexer-rust test`
- `pnpm --filter @peerbit/indexer-rust benchmark`