### PR TITLE
Use Borsh binary bridge for Rust planner adapter

### DIFF
--- a/packages/utils/indexer/rust/Cargo.lock
+++ b/packages/utils/indexer/rust/Cargo.lock
@@ -3,6 +3,30 @@
 version = 4
 
 [[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,10 +45,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "equivalent"
@@ -73,12 +109,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,11 +136,10 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 name = "peerbit_indexer_rust"
 version = "0.0.0"
 dependencies = [
+ "borsh",
  "indexmap",
  "js-sys",
  "roaring",
- "serde",
- "serde_json",
  "wasm-bindgen",
 ]
 
@@ -119,6 +148,15 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -155,16 +193,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "serde"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
-dependencies = [
- "serde_core",
- "serde_derive",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,19 +213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.149"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
-dependencies = [
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +227,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -266,7 +311,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "zmij"
-version = "1.0.21"
+name = "winnow"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]

--- a/packages/utils/indexer/rust/Cargo.toml
+++ b/packages/utils/indexer/rust/Cargo.toml
@@ -9,11 +9,10 @@ description = "Rust-backed index storage for Peerbit"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+borsh = { version = "1.5", features = ["derive"] }
 indexmap = "2.7.1"
 js-sys = "0.3.80"
 roaring = "0.11.4"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.145"
 wasm-bindgen = "0.2.103"
 
 [package.metadata.wasm-pack.profile.release]

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -1,4 +1,4 @@
-import { deserialize, serialize } from "@dao-xyz/borsh";
+import { BinaryWriter, deserialize, serialize } from "@dao-xyz/borsh";
 import * as types from "@peerbit/indexer-interface";
 import { logger as loggerFn } from "@peerbit/logger";
 import { equals } from "uint8arrays";
@@ -17,11 +17,11 @@ type NativeIndexStore<T extends Record<string, any>> = {
 };
 
 type NativeQueryPlanner = {
-	put_document: (id: string, fieldsJson: string) => void;
+	put_document: (id: string, fields: Uint8Array) => void;
 	delete_document: (id: string) => void;
 	clear: () => void;
 	len: () => number;
-	query: (queryJson: string, sortJson: string) => string[];
+	query: (query: Uint8Array, sort: Uint8Array) => string[];
 };
 
 type WasmModule = {
@@ -59,6 +59,33 @@ type NativeQueryCompileResult = {
 	spec: NativeQuerySpec;
 	exact: boolean;
 };
+
+const BRIDGE_VERSION = 1;
+
+// Keep bridge enum tags in sync with the Rust Borsh DTO declaration order.
+const enum NativeValueTag {
+	Bool = 0,
+	I64 = 1,
+	U64 = 2,
+	String = 3,
+}
+
+const enum NativeQueryTag {
+	All = 0,
+	Exact = 1,
+	Range = 2,
+	And = 3,
+	Or = 4,
+	Not = 5,
+}
+
+const enum NativeCompareTag {
+	Equal = 0,
+	Greater = 1,
+	GreaterOrEqual = 2,
+	Less = 3,
+	LessOrEqual = 4,
+}
 
 let wasmModulePromise: Promise<WasmModule> | undefined;
 let wasmInitialized = false;
@@ -219,6 +246,107 @@ const compareToNative = (
 		default:
 			throw new Error("Unexpected compare");
 	}
+};
+
+const nativeCompareTag = (compare: "eq" | "gt" | "gte" | "lt" | "lte") => {
+	switch (compare) {
+		case "eq":
+			return NativeCompareTag.Equal;
+		case "gt":
+			return NativeCompareTag.Greater;
+		case "gte":
+			return NativeCompareTag.GreaterOrEqual;
+		case "lt":
+			return NativeCompareTag.Less;
+		case "lte":
+			return NativeCompareTag.LessOrEqual;
+	}
+};
+
+const writeNativeValue = (writer: BinaryWriter, value: NativeValue): void => {
+	switch (value.type) {
+		case "bool":
+			writer.u8(NativeValueTag.Bool);
+			writer.bool(value.value);
+			return;
+		case "i64":
+			writer.u8(NativeValueTag.I64);
+			writer.u64(BigInt.asUintN(64, BigInt(value.value)));
+			return;
+		case "u64":
+			writer.u8(NativeValueTag.U64);
+			writer.u64(BigInt(value.value));
+			return;
+		case "string":
+			writer.u8(NativeValueTag.String);
+			writer.string(value.value);
+			return;
+	}
+};
+
+const writeNativeQuerySpec = (
+	writer: BinaryWriter,
+	query: NativeQuerySpec,
+): void => {
+	switch (query.op) {
+		case "all":
+			writer.u8(NativeQueryTag.All);
+			return;
+		case "exact":
+			writer.u8(NativeQueryTag.Exact);
+			writer.string(query.field);
+			writeNativeValue(writer, query.value);
+			return;
+		case "range":
+			writer.u8(NativeQueryTag.Range);
+			writer.string(query.field);
+			writer.u8(nativeCompareTag(query.compare));
+			writeNativeValue(writer, query.value);
+			return;
+		case "and":
+			writer.u8(NativeQueryTag.And);
+			writer.u32(query.queries.length);
+			for (const child of query.queries) {
+				writeNativeQuerySpec(writer, child);
+			}
+			return;
+		case "or":
+			writer.u8(NativeQueryTag.Or);
+			writer.u32(query.queries.length);
+			for (const child of query.queries) {
+				writeNativeQuerySpec(writer, child);
+			}
+			return;
+		case "not":
+			writer.u8(NativeQueryTag.Not);
+			writeNativeQuerySpec(writer, query.query);
+			return;
+	}
+};
+
+const encodeNativeQuerySpec = (query: NativeQuerySpec): Uint8Array => {
+	const writer = new BinaryWriter();
+	writer.u8(BRIDGE_VERSION);
+	writeNativeQuerySpec(writer, query);
+	return writer.finalize();
+};
+
+const encodeNativeSort = (): Uint8Array => {
+	const writer = new BinaryWriter();
+	writer.u8(BRIDGE_VERSION);
+	writer.u32(0);
+	return writer.finalize();
+};
+
+const encodeNativeFieldFacts = (facts: NativeFieldFact[]): Uint8Array => {
+	const writer = new BinaryWriter();
+	writer.u8(BRIDGE_VERSION);
+	writer.u32(facts.length);
+	for (const fact of facts) {
+		writer.string(fact.field);
+		writeNativeValue(writer, fact.value);
+	}
+	return writer.finalize();
 };
 
 const compileNativeQueries = (
@@ -879,8 +1007,8 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 
 		const results: types.IndexedValue<T>[] = [];
 		for (const storeKey of this.planner.query(
-			JSON.stringify(compiled.spec),
-			"[]",
+			encodeNativeQuerySpec(compiled.spec),
+			encodeNativeSort(),
 		)) {
 			const value = this.getStore().get(storeKey);
 			if (value) {
@@ -893,7 +1021,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 	private indexNativeDocument(storeKey: string, value: T): void {
 		this.planner?.put_document(
 			storeKey,
-			JSON.stringify(collectNativeFieldFacts(value)),
+			encodeNativeFieldFacts(collectNativeFieldFacts(value)),
 		);
 	}
 

--- a/packages/utils/indexer/rust/src/lib.rs
+++ b/packages/utils/indexer/rust/src/lib.rs
@@ -1,9 +1,9 @@
+use borsh::BorshDeserialize;
 use indexmap::IndexMap;
 use js_sys::Array;
 use planner::{
     Compare, DocumentFields, FieldValue, NativeQueryIndex, Query, SortDirection, SortField,
 };
-use serde::Deserialize;
 use wasm_bindgen::prelude::*;
 
 pub mod planner;
@@ -92,8 +92,8 @@ impl NativeQueryPlanner {
         self.index.len()
     }
 
-    pub fn put_document(&mut self, id: String, fields_json: String) -> Result<(), JsValue> {
-        let fields = decode_document_fields(&fields_json)?;
+    pub fn put_document(&mut self, id: String, fields_bytes: Vec<u8>) -> Result<(), JsValue> {
+        let fields = decode_document_fields(&fields_bytes)?;
         self.index.put(id, fields);
         Ok(())
     }
@@ -102,9 +102,9 @@ impl NativeQueryPlanner {
         self.index.delete(id);
     }
 
-    pub fn query(&self, query_json: String, sort_json: String) -> Result<Array, JsValue> {
-        let query = decode_query(&query_json)?;
-        let sort = decode_sort(&sort_json)?;
+    pub fn query(&self, query_bytes: Vec<u8>, sort_bytes: Vec<u8>) -> Result<Array, JsValue> {
+        let query = decode_query(&query_bytes)?;
+        let sort = decode_sort(&sort_bytes)?;
         let ids = self.index.search(&query, &sort, None);
         let out = Array::new();
         for id in ids {
@@ -114,102 +114,115 @@ impl NativeQueryPlanner {
     }
 }
 
-#[derive(Deserialize)]
+const BRIDGE_VERSION: u8 = 1;
+
+#[derive(BorshDeserialize)]
+struct DocumentFieldsDto {
+    version: u8,
+    facts: Vec<FieldFactDto>,
+}
+
+#[derive(BorshDeserialize)]
 struct FieldFactDto {
     field: String,
     value: FieldValueDto,
 }
 
-#[derive(Deserialize)]
-#[serde(tag = "type", content = "value")]
+// Enum declaration order is part of the TS/Rust bridge ABI.
+#[derive(Clone, BorshDeserialize)]
 enum FieldValueDto {
-    #[serde(rename = "bool")]
     Bool(bool),
-    #[serde(rename = "i64")]
-    I64(String),
-    #[serde(rename = "u64")]
-    U64(String),
-    #[serde(rename = "string")]
+    I64(i64),
+    U64(u64),
     String(String),
 }
 
-#[derive(Deserialize)]
-#[serde(tag = "op")]
+#[derive(BorshDeserialize)]
+struct QueryPayloadDto {
+    version: u8,
+    query: QueryDto,
+}
+
+// Enum declaration order is part of the TS/Rust bridge ABI.
+#[derive(Clone, BorshDeserialize)]
 enum QueryDto {
-    #[serde(rename = "all")]
     All,
-    #[serde(rename = "exact")]
-    Exact { field: String, value: FieldValueDto },
-    #[serde(rename = "range")]
+    Exact {
+        field: String,
+        value: FieldValueDto,
+    },
     Range {
         field: String,
         compare: CompareDto,
         value: FieldValueDto,
     },
-    #[serde(rename = "and")]
-    And { queries: Vec<QueryDto> },
-    #[serde(rename = "or")]
-    Or { queries: Vec<QueryDto> },
-    #[serde(rename = "not")]
-    Not { query: Box<QueryDto> },
+    And {
+        queries: Vec<QueryDto>,
+    },
+    Or {
+        queries: Vec<QueryDto>,
+    },
+    Not {
+        query: Box<QueryDto>,
+    },
 }
 
-#[derive(Clone, Copy, Deserialize)]
+// Enum declaration order is part of the TS/Rust bridge ABI.
+#[derive(Clone, Copy, BorshDeserialize)]
 enum CompareDto {
-    #[serde(rename = "eq")]
     Equal,
-    #[serde(rename = "gt")]
     Greater,
-    #[serde(rename = "gte")]
     GreaterOrEqual,
-    #[serde(rename = "lt")]
     Less,
-    #[serde(rename = "lte")]
     LessOrEqual,
 }
 
-#[derive(Deserialize)]
+#[derive(BorshDeserialize)]
+struct SortPayloadDto {
+    version: u8,
+    fields: Vec<SortFieldDto>,
+}
+
+#[derive(BorshDeserialize)]
 struct SortFieldDto {
     field: String,
     direction: SortDirectionDto,
 }
 
-#[derive(Deserialize)]
+// Enum declaration order is part of the TS/Rust bridge ABI.
+#[derive(BorshDeserialize)]
 enum SortDirectionDto {
-    #[serde(rename = "asc")]
     Asc,
-    #[serde(rename = "desc")]
     Desc,
 }
 
-fn decode_document_fields(fields_json: &str) -> Result<DocumentFields, JsValue> {
-    let facts: Vec<FieldFactDto> = serde_json::from_str(fields_json).map_err(js_error)?;
+fn decode_document_fields(fields_bytes: &[u8]) -> Result<DocumentFields, JsValue> {
+    let payload = DocumentFieldsDto::try_from_slice(fields_bytes).map_err(js_error)?;
+    ensure_bridge_version(payload.version)?;
     let mut fields = DocumentFields::new();
-    for fact in facts {
-        fields.insert_scalar(fact.field, decode_field_value(fact.value)?);
+    for fact in payload.facts {
+        fields.insert_scalar(fact.field, FieldValue::from(fact.value));
     }
     Ok(fields)
 }
 
-fn decode_query(query_json: &str) -> Result<Query, JsValue> {
-    let query: QueryDto = serde_json::from_str(query_json).map_err(js_error)?;
-    query.try_into()
+fn decode_query(query_bytes: &[u8]) -> Result<Query, JsValue> {
+    let payload = QueryPayloadDto::try_from_slice(query_bytes).map_err(js_error)?;
+    ensure_bridge_version(payload.version)?;
+    payload.query.try_into()
 }
 
-fn decode_sort(sort_json: &str) -> Result<Vec<SortField>, JsValue> {
-    let fields: Vec<SortFieldDto> = serde_json::from_str(sort_json).map_err(js_error)?;
-    fields
+fn decode_sort(sort_bytes: &[u8]) -> Result<Vec<SortField>, JsValue> {
+    let payload = SortPayloadDto::try_from_slice(sort_bytes).map_err(js_error)?;
+    ensure_bridge_version(payload.version)?;
+    Ok(payload
+        .fields
         .into_iter()
-        .map(|field| {
-            Ok(SortField {
-                field: field.field,
-                direction: match field.direction {
-                    SortDirectionDto::Asc => SortDirection::Asc,
-                    SortDirectionDto::Desc => SortDirection::Desc,
-                },
-            })
+        .map(|field| SortField {
+            field: field.field,
+            direction: field.direction.into(),
         })
-        .collect()
+        .collect())
 }
 
 impl TryFrom<QueryDto> for Query {
@@ -220,7 +233,7 @@ impl TryFrom<QueryDto> for Query {
             QueryDto::All => Query::All,
             QueryDto::Exact { field, value } => Query::Exact {
                 field,
-                value: decode_field_value(value)?,
+                value: value.into(),
             },
             QueryDto::Range {
                 field,
@@ -229,12 +242,23 @@ impl TryFrom<QueryDto> for Query {
             } => Query::Range {
                 field,
                 compare: compare.into(),
-                value: decode_field_value(value)?,
+                value: value.into(),
             },
             QueryDto::And { queries } => Query::And(decode_queries(queries)?),
             QueryDto::Or { queries } => Query::Or(decode_queries(queries)?),
             QueryDto::Not { query } => Query::Not(Box::new((*query).try_into()?)),
         })
+    }
+}
+
+impl From<FieldValueDto> for FieldValue {
+    fn from(value: FieldValueDto) -> Self {
+        match value {
+            FieldValueDto::Bool(value) => FieldValue::Bool(value),
+            FieldValueDto::I64(value) => FieldValue::I64(value),
+            FieldValueDto::U64(value) => FieldValue::U64(value),
+            FieldValueDto::String(value) => FieldValue::String(value),
+        }
     }
 }
 
@@ -250,16 +274,26 @@ impl From<CompareDto> for Compare {
     }
 }
 
+impl From<SortDirectionDto> for SortDirection {
+    fn from(value: SortDirectionDto) -> Self {
+        match value {
+            SortDirectionDto::Asc => SortDirection::Asc,
+            SortDirectionDto::Desc => SortDirection::Desc,
+        }
+    }
+}
+
 fn decode_queries(queries: Vec<QueryDto>) -> Result<Vec<Query>, JsValue> {
     queries.into_iter().map(Query::try_from).collect()
 }
 
-fn decode_field_value(value: FieldValueDto) -> Result<FieldValue, JsValue> {
-    match value {
-        FieldValueDto::Bool(value) => Ok(FieldValue::Bool(value)),
-        FieldValueDto::I64(value) => value.parse::<i64>().map(FieldValue::I64).map_err(js_error),
-        FieldValueDto::U64(value) => value.parse::<u64>().map(FieldValue::U64).map_err(js_error),
-        FieldValueDto::String(value) => Ok(FieldValue::String(value)),
+fn ensure_bridge_version(version: u8) -> Result<(), JsValue> {
+    if version == BRIDGE_VERSION {
+        Ok(())
+    } else {
+        Err(js_error(format!(
+            "Unsupported bridge payload version {version}"
+        )))
     }
 }
 


### PR DESCRIPTION
## Summary

Stacked on #788.

This replaces the temporary JSON bridge between the TypeScript adapter and the Rust planner with a compact Borsh-compatible binary ABI:

- TS encodes planner facts/query payloads with `@dao-xyz/borsh` `BinaryWriter`
- Rust decodes DTOs with `borsh-rs` `BorshDeserialize`
- bridge payloads include a version byte for future ABI changes
- removes `serde`/`serde_json` from the adapter bridge path
- keeps the same residual TypeScript correctness gate from #788

The enum tag order is documented on both sides because that order is part of the bridge ABI.

## Benchmark signal

Compared with the JSON bridge from #788, this is modestly faster on the paths where bridge overhead matters most:

- transient `number query fetch 10`: ~76.7k ops/s, up from ~71.8k
- persistent `number query fetch 10`: ~68.1k ops/s, up from ~65.3k
- transient `string count no-matches`: ~691.7k ops/s, up from ~539k
- persistent `string count no-matches`: ~667.0k ops/s, up from ~533k

Exact string matching is roughly neutral at ~6.5k-6.6k ops/s, which suggests that candidate materialization/residual checking dominates there now.

## Verification

- `cargo test`
- `pnpm --filter @peerbit/indexer-rust lint`
- `pnpm --filter @peerbit/indexer-rust test`
- `pnpm --filter @peerbit/indexer-rust benchmark`