### PR TITLE
Page native Rust index results

### DIFF
--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -22,6 +22,13 @@ type NativeQueryPlanner = {
 	clear: () => void;
 	len: () => number;
 	query: (query: Uint8Array, sort: Uint8Array) => string[];
+	query_page: (
+		query: Uint8Array,
+		sort: Uint8Array,
+		offset: number,
+		limit: number,
+	) => string[];
+	count: (query: Uint8Array) => number;
 };
 
 type WasmModule = {
@@ -58,6 +65,12 @@ type NativeQuerySpec =
 type NativeQueryCompileResult = {
 	spec: NativeQuerySpec;
 	exact: boolean;
+};
+
+type NativeCandidatePage = {
+	compiled: NativeQueryCompileResult;
+	offset: number;
+	limit?: number;
 };
 
 const BRIDGE_VERSION = 1;
@@ -470,6 +483,26 @@ const compileNativeQuery = (
 	return;
 };
 
+const canSkipResidualForNativeQuery = (queryCoerced: types.Query[]): boolean => {
+	if (queryCoerced.length !== 1) {
+		return false;
+	}
+	const query = queryCoerced[0];
+	if (query instanceof types.BoolQuery || query instanceof types.ByteMatchQuery) {
+		return true;
+	}
+	if (query instanceof types.StringMatch) {
+		return (
+			query.method === types.StringMatchMethod.exact &&
+			query.caseInsensitive === false
+		);
+	}
+	if (query instanceof types.IntegerCompare) {
+		return nativeIntegerValue(query.value.value) != null;
+	}
+	return false;
+};
+
 const getBatchFromResults = <T extends Record<string, any>>(
 	results: types.IndexedValue<T>[],
 	wantedSize: number,
@@ -636,6 +669,14 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 	}
 
 	async count(query?: types.CountOptions): Promise<number> {
+		const queryCoerced = types.toQuery(query?.query);
+		if (queryCoerced.length === 0) {
+			return this.getSize();
+		}
+		const nativeCount = this.countNativeExact(queryCoerced);
+		if (nativeCount != null) {
+			return nativeCount;
+		}
 		return (await this.queryAll(query)).length;
 	}
 
@@ -692,6 +733,56 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		query?: types.IterateOptions,
 		properties?: { shape?: S; reference?: boolean },
 	): types.IndexIterator<T, S> {
+		const nativePagePlan = this.getNativePagePlan(types.toQuery(query?.query), query);
+		if (nativePagePlan) {
+			let done: boolean | undefined = undefined;
+			let offset = 0;
+			let total: number | undefined;
+			const getTotal = () =>
+				(total ??= this.countNativePlan(nativePagePlan.compiled) ?? 0);
+			const clonePage = (batch: types.IndexedValue<T>[]) =>
+				(properties?.reference
+					? batch
+					: cloneResults(batch, this.properties.schema)) as types.IndexedResults<
+					types.ReturnTypeFromShape<T, S>
+				>;
+
+			const fetch = async (
+				n: number,
+			): Promise<types.IndexedResults<types.ReturnTypeFromShape<T, S>>> => {
+				if (done) {
+					return [];
+				}
+				const remaining = getTotal() - offset;
+				const wanted = Math.max(
+					0,
+					Math.min(Number.isFinite(n) ? Math.floor(n) : remaining, remaining),
+				);
+				if (wanted === 0) {
+					done = remaining === 0;
+					return [];
+				}
+				const batch = this.getNativeCandidatesForPlan({
+					compiled: nativePagePlan.compiled,
+					offset,
+					limit: wanted,
+				});
+				offset += batch.length;
+				done = offset >= getTotal();
+				return clonePage(batch);
+			};
+
+			return {
+				all: async () => fetch(Infinity),
+				next: (n: number) => fetch(n),
+				done: () => done,
+				pending: async () => Math.max(0, getTotal() - offset),
+				close: () => {
+					done = true;
+				},
+			};
+		}
+
 		let done: boolean | undefined = undefined;
 		let queue:
 			| {
@@ -997,6 +1088,16 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 	private getNativeCandidates(
 		queryCoerced: types.Query[],
 	): types.IndexedValue<T>[] | undefined {
+		const compiled = this.getNativePlan(queryCoerced);
+		if (!compiled) {
+			return;
+		}
+		return this.getNativeCandidatesForPlan({ compiled, offset: 0 });
+	}
+
+	private getNativePlan(
+		queryCoerced: types.Query[],
+	): NativeQueryCompileResult | undefined {
 		if (!this.planner || queryCoerced.length === 0) {
 			return;
 		}
@@ -1004,12 +1105,51 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		if (compiled.spec.op === "all") {
 			return;
 		}
+		return compiled;
+	}
 
+	private getNativePagePlan(
+		queryCoerced: types.Query[],
+		query?: types.IterateOptions,
+	): NativeCandidatePage | undefined {
+		if (query?.sort) {
+			return;
+		}
+		const compiled = this.getNativePlan(queryCoerced);
+		if (!compiled?.exact || !canSkipResidualForNativeQuery(queryCoerced)) {
+			return;
+		}
+		return { compiled, offset: 0 };
+	}
+
+	private countNativeExact(queryCoerced: types.Query[]): number | undefined {
+		const compiled = this.getNativePlan(queryCoerced);
+		if (!compiled?.exact || !canSkipResidualForNativeQuery(queryCoerced)) {
+			return;
+		}
+		return this.countNativePlan(compiled);
+	}
+
+	private countNativePlan(
+		compiled: NativeQueryCompileResult,
+	): number | undefined {
+		if (!this.planner) {
+			return;
+		}
+		return this.planner.count(encodeNativeQuerySpec(compiled.spec));
+	}
+
+	private getNativeCandidatesForPlan(
+		page: NativeCandidatePage,
+	): types.IndexedValue<T>[] {
 		const results: types.IndexedValue<T>[] = [];
-		for (const storeKey of this.planner.query(
-			encodeNativeQuerySpec(compiled.spec),
-			encodeNativeSort(),
-		)) {
+		const queryBytes = encodeNativeQuerySpec(page.compiled.spec);
+		const sortBytes = encodeNativeSort();
+		const storeKeys =
+			page.limit == null
+				? this.planner!.query(queryBytes, sortBytes)
+				: this.planner!.query_page(queryBytes, sortBytes, page.offset, page.limit);
+		for (const storeKey of storeKeys) {
 			const value = this.getStore().get(storeKey);
 			if (value) {
 				results.push({ id: value[0], value: value[1] });

--- a/packages/utils/indexer/rust/src/lib.rs
+++ b/packages/utils/indexer/rust/src/lib.rs
@@ -106,12 +106,34 @@ impl NativeQueryPlanner {
         let query = decode_query(&query_bytes)?;
         let sort = decode_sort(&sort_bytes)?;
         let ids = self.index.search(&query, &sort, None);
-        let out = Array::new();
-        for id in ids {
-            out.push(&JsValue::from_str(&id));
-        }
-        Ok(out)
+        Ok(ids_to_js(ids))
     }
+
+    pub fn query_page(
+        &self,
+        query_bytes: Vec<u8>,
+        sort_bytes: Vec<u8>,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Array, JsValue> {
+        let query = decode_query(&query_bytes)?;
+        let sort = decode_sort(&sort_bytes)?;
+        let ids = self.index.search_page(&query, &sort, offset, Some(limit));
+        Ok(ids_to_js(ids))
+    }
+
+    pub fn count(&self, query_bytes: Vec<u8>) -> Result<usize, JsValue> {
+        let query = decode_query(&query_bytes)?;
+        Ok(self.index.count(&query) as usize)
+    }
+}
+
+fn ids_to_js(ids: Vec<String>) -> Array {
+    let out = Array::new();
+    for id in ids {
+        out.push(&JsValue::from_str(&id));
+    }
+    out
 }
 
 const BRIDGE_VERSION: u8 = 1;

--- a/packages/utils/indexer/rust/src/planner.rs
+++ b/packages/utils/indexer/rust/src/planner.rs
@@ -286,16 +286,45 @@ impl NativeQueryIndex {
         }
     }
 
+    pub fn count(&self, query: &Query) -> u64 {
+        self.candidates(query).len()
+    }
+
     pub fn search(&self, query: &Query, sort: &[SortField], limit: Option<usize>) -> Vec<String> {
-        let mut doc_ids: Vec<_> = self.candidates(query).iter().collect();
-        if !sort.is_empty() {
-            doc_ids.sort_by(|left, right| self.compare_docs(*left, *right, sort));
+        self.search_page(query, sort, 0, limit)
+    }
+
+    pub fn search_page(
+        &self,
+        query: &Query,
+        sort: &[SortField],
+        offset: usize,
+        limit: Option<usize>,
+    ) -> Vec<String> {
+        if sort.is_empty() {
+            let candidates = self.candidates(query);
+            let iter = candidates.iter().skip(offset);
+            if let Some(limit) = limit {
+                return iter
+                    .take(limit)
+                    .filter_map(|doc_id| self.internal_to_external.get(&doc_id).cloned())
+                    .collect();
+            }
+            return iter
+                .filter_map(|doc_id| self.internal_to_external.get(&doc_id).cloned())
+                .collect();
         }
+
+        let mut doc_ids: Vec<_> = self.candidates(query).iter().collect();
+        doc_ids.sort_by(|left, right| self.compare_docs(*left, *right, sort));
+        let doc_ids = doc_ids.into_iter().skip(offset);
         if let Some(limit) = limit {
-            doc_ids.truncate(limit);
+            return doc_ids
+                .take(limit)
+                .filter_map(|doc_id| self.internal_to_external.get(&doc_id).cloned())
+                .collect();
         }
         doc_ids
-            .into_iter()
             .filter_map(|doc_id| self.internal_to_external.get(&doc_id).cloned())
             .collect()
     }
@@ -723,6 +752,32 @@ mod tests {
         );
 
         assert_eq!(results, vec!["c", "d"]);
+    }
+
+    #[test]
+    fn counts_and_pages_candidates_without_materializing_all_ids() {
+        let mut index = NativeQueryIndex::new();
+        for i in 0..10_u64 {
+            index.put(
+                format!("doc-{i}"),
+                DocumentFields::new().with_scalar("even", i % 2 == 0),
+            );
+        }
+
+        let query = Query::Exact {
+            field: "even".to_string(),
+            value: FieldValue::Bool(true),
+        };
+
+        assert_eq!(index.count(&query), 5);
+        assert_eq!(
+            index.search_page(&query, &[], 1, Some(2)),
+            vec!["doc-2", "doc-4"]
+        );
+        assert_eq!(
+            index.search_page(&query, &[], 5, Some(2)),
+            Vec::<String>::new()
+        );
     }
 
     #[test]

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -96,4 +96,35 @@ describe("native planner bridge", () => {
 		]);
 		await indices.drop();
 	});
+
+	it("pages exact native candidates without materializing the full result", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeDocument });
+		await index.put(new BridgeDocument("a", "peerbit", "native index"));
+		await index.put(new BridgeDocument("b", "peerbit", "native bridge"));
+		await index.put(new BridgeDocument("c", "other", "typescript fallback"));
+		await index.put(new BridgeDocument("d", "peerbit", "native count"));
+		await index.put(new BridgeDocument("e", "peerbit", "native page"));
+
+		const query = new StringMatch({ key: "tag", value: "peerbit" });
+		expect(await index.count({ query })).to.equal(4);
+
+		const iterator = index.iterate({ query });
+		expect(await iterator.pending()).to.equal(4);
+		expect((await iterator.next(2)).map((result) => result.value.id)).to.deep.equal([
+			"a",
+			"b",
+		]);
+		expect(iterator.done()).to.equal(false);
+		expect(await iterator.pending()).to.equal(2);
+		expect((await iterator.next(2)).map((result) => result.value.id)).to.deep.equal([
+			"d",
+			"e",
+		]);
+		expect(iterator.done()).to.equal(true);
+		expect(await iterator.pending()).to.equal(0);
+
+		await indices.drop();
+	});
 });


### PR DESCRIPTION
## Summary

Stacked on #789.

This adds native result modes on top of the Borsh bridge:

- add `NativeQueryIndex::count` and `search_page`
- expose WASM `NativeQueryPlanner.count` and `query_page`
- use native count for exact single-field predicates
- use native paged iteration for exact unsorted single-field predicates, so `next(n)` only moves the requested page of IDs across the WASM boundary
- keep compound queries on the residual TypeScript correctness path, because flattened native facts can be a superset for array/nested AND semantics

## Correctness note

The first implementation tried to treat all compiled-native `And` queries as exact. The conformance suite caught why that is unsafe: flattened array facts do not prove that multiple predicates hit the same nested array element. This PR therefore only skips residual evaluation for a single supported field predicate. Compound queries still benefit from native candidate narrowing, but they are checked by the existing TS evaluator.

## Benchmark signal

Compared with #789:

- transient `number query fetch 10`: ~93.9k ops/s, up from ~76.7k
- persistent `number query fetch 10`: ~80.6k ops/s, up from ~68.1k
- transient `string query matching`: ~76.9k ops/s, up from ~6.6k
- persistent `string query matching`: ~73.6k ops/s, up from ~6.5k
- transient `string count matching`: ~1.09M ops/s
- persistent `string count matching`: ~1.08M ops/s
- broad multi-field OR remains ~6 ops/s because it correctly stays on the residual scan path

## Verification

- `cargo test`
- `pnpm --filter @peerbit/indexer-rust lint`
- `pnpm --filter @peerbit/indexer-rust test`
- `pnpm --filter @peerbit/indexer-rust benchmark`