### PR TITLE
Evaluate scoped native index queries

### DIFF
--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -45,6 +45,7 @@ type NativeValue =
 	| { type: "string"; value: string };
 
 type NativeFieldFact = {
+	scope: number;
 	field: string;
 	value: NativeValue;
 };
@@ -60,7 +61,15 @@ type NativeQuerySpec =
 	  }
 	| { op: "and"; queries: NativeQuerySpec[] }
 	| { op: "or"; queries: NativeQuerySpec[] }
-	| { op: "not"; query: NativeQuerySpec };
+	| { op: "not"; query: NativeQuerySpec }
+	| {
+			op: "string";
+			field: string;
+			value: string;
+			method: "exact" | "prefix" | "contains";
+			caseInsensitive: boolean;
+	  }
+	| { op: "is_null"; field: string };
 
 type NativeQueryCompileResult = {
 	spec: NativeQuerySpec;
@@ -90,6 +99,8 @@ const enum NativeQueryTag {
 	And = 3,
 	Or = 4,
 	Not = 5,
+	StringMatch = 6,
+	IsNull = 7,
 }
 
 const enum NativeCompareTag {
@@ -98,6 +109,12 @@ const enum NativeCompareTag {
 	GreaterOrEqual = 2,
 	Less = 3,
 	LessOrEqual = 4,
+}
+
+const enum NativeStringMatchMethodTag {
+	Exact = 0,
+	Prefix = 1,
+	Contains = 2,
 }
 
 let wasmModulePromise: Promise<WasmModule> | undefined;
@@ -187,11 +204,20 @@ const scalarToNativeValue = (value: any): NativeValue | undefined => {
 	return undefined;
 };
 
+type NativeFactCollectorState = {
+	seen: WeakSet<object>;
+	nextScope: number;
+};
+
 const collectNativeFieldFacts = (
 	value: any,
 	path: string[] = [],
 	facts: NativeFieldFact[] = [],
-	seen: WeakSet<object> = new WeakSet(),
+	state: NativeFactCollectorState = {
+		seen: new WeakSet(),
+		nextScope: 1,
+	},
+	scope = 0,
 ): NativeFieldFact[] => {
 	if (value instanceof Uint8Array || ArrayBuffer.isView(value)) {
 		if (path.length > 0) {
@@ -200,11 +226,14 @@ const collectNativeFieldFacts = (
 					? value
 					: new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
 			facts.push({
+				scope,
 				field: nativeFieldKey(path),
 				value: { type: "string", value: bytesToNativeString(bytes) },
 			});
 			for (const byte of bytes) {
+				const byteScope = state.nextScope++;
 				facts.push({
+					scope: byteScope,
 					field: nativeFieldKey(path),
 					value: { type: "u64", value: byte.toString() },
 				});
@@ -216,7 +245,7 @@ const collectNativeFieldFacts = (
 	const nativeValue = scalarToNativeValue(value);
 	if (nativeValue) {
 		if (path.length > 0) {
-			facts.push({ field: nativeFieldKey(path), value: nativeValue });
+			facts.push({ scope, field: nativeFieldKey(path), value: nativeValue });
 		}
 		return facts;
 	}
@@ -224,20 +253,20 @@ const collectNativeFieldFacts = (
 	if (!value || typeof value !== "object") {
 		return facts;
 	}
-	if (seen.has(value)) {
+	if (state.seen.has(value)) {
 		return facts;
 	}
-	seen.add(value);
+	state.seen.add(value);
 
 	if (Array.isArray(value)) {
 		for (const item of value) {
-			collectNativeFieldFacts(item, path, facts, seen);
+			collectNativeFieldFacts(item, path, facts, state, state.nextScope++);
 		}
 		return facts;
 	}
 
 	for (const [key, child] of Object.entries(value)) {
-		collectNativeFieldFacts(child, [...path, key], facts, seen);
+		collectNativeFieldFacts(child, [...path, key], facts, state, scope);
 	}
 	return facts;
 };
@@ -273,6 +302,19 @@ const nativeCompareTag = (compare: "eq" | "gt" | "gte" | "lt" | "lte") => {
 			return NativeCompareTag.Less;
 		case "lte":
 			return NativeCompareTag.LessOrEqual;
+	}
+};
+
+const nativeStringMatchMethodTag = (
+	method: "exact" | "prefix" | "contains",
+) => {
+	switch (method) {
+		case "exact":
+			return NativeStringMatchMethodTag.Exact;
+		case "prefix":
+			return NativeStringMatchMethodTag.Prefix;
+		case "contains":
+			return NativeStringMatchMethodTag.Contains;
 	}
 };
 
@@ -334,6 +376,17 @@ const writeNativeQuerySpec = (
 			writer.u8(NativeQueryTag.Not);
 			writeNativeQuerySpec(writer, query.query);
 			return;
+		case "string":
+			writer.u8(NativeQueryTag.StringMatch);
+			writer.string(query.field);
+			writer.string(query.value);
+			writer.u8(nativeStringMatchMethodTag(query.method));
+			writer.bool(query.caseInsensitive);
+			return;
+		case "is_null":
+			writer.u8(NativeQueryTag.IsNull);
+			writer.string(query.field);
+			return;
 	}
 };
 
@@ -356,6 +409,7 @@ const encodeNativeFieldFacts = (facts: NativeFieldFact[]): Uint8Array => {
 	writer.u8(BRIDGE_VERSION);
 	writer.u32(facts.length);
 	for (const fact of facts) {
+		writer.u32(fact.scope);
 		writer.string(fact.field);
 		writeNativeValue(writer, fact.value);
 	}
@@ -364,33 +418,30 @@ const encodeNativeFieldFacts = (facts: NativeFieldFact[]): Uint8Array => {
 
 const compileNativeQueries = (
 	queries: types.Query[],
-): NativeQueryCompileResult => {
+): NativeQueryCompileResult | undefined => {
 	return compileNativeAnd(queries);
 };
 
 const compileNativeAnd = (
 	queries: types.Query[],
-): NativeQueryCompileResult => {
+): NativeQueryCompileResult | undefined => {
 	const compiled: NativeQuerySpec[] = [];
-	let exact = true;
 
 	for (const query of queries) {
 		const next = compileNativeQuery(query);
-		if (next) {
-			compiled.push(next.spec);
-			exact &&= next.exact;
-		} else {
-			exact = false;
+		if (!next) {
+			return;
 		}
+		compiled.push(next.spec);
 	}
 
 	if (compiled.length === 0) {
-		return { spec: { op: "all" }, exact: false };
+		return { spec: { op: "all" }, exact: true };
 	}
 	if (compiled.length === 1) {
-		return { spec: compiled[0], exact };
+		return { spec: compiled[0], exact: true };
 	}
-	return { spec: { op: "and", queries: compiled }, exact };
+	return { spec: { op: "and", queries: compiled }, exact: true };
 };
 
 const compileNativeQuery = (
@@ -401,21 +452,19 @@ const compileNativeQuery = (
 	}
 	if (query instanceof types.Or) {
 		const compiled: NativeQuerySpec[] = [];
-		let exact = true;
 		for (const child of query.or) {
 			const next = compileNativeQuery(child);
 			if (!next) {
-				return { spec: { op: "all" }, exact: false };
+				return;
 			}
 			compiled.push(next.spec);
-			exact &&= next.exact;
 		}
-		return { spec: { op: "or", queries: compiled }, exact };
+		return { spec: { op: "or", queries: compiled }, exact: true };
 	}
 	if (query instanceof types.Not) {
 		const child = compileNativeQuery(query.not);
-		if (!child?.exact) {
-			return { spec: { op: "all" }, exact: false };
+		if (!child) {
+			return;
 		}
 		return { spec: { op: "not", query: child.spec }, exact: true };
 	}
@@ -430,17 +479,18 @@ const compileNativeQuery = (
 		};
 	}
 	if (query instanceof types.StringMatch) {
-		if (
-			query.method !== types.StringMatchMethod.exact ||
-			query.caseInsensitive !== false
-		) {
-			return;
-		}
 		return {
 			spec: {
-				op: "exact",
+				op: "string",
 				field: nativeFieldKey(query.key),
-				value: { type: "string", value: query.value },
+				value: query.value,
+				method:
+					query.method === types.StringMatchMethod.exact
+						? "exact"
+						: query.method === types.StringMatchMethod.prefix
+							? "prefix"
+							: "contains",
+				caseInsensitive: query.caseInsensitive,
 			},
 			exact: true,
 		};
@@ -480,27 +530,16 @@ const compileNativeQuery = (
 			exact: true,
 		};
 	}
+	if (query instanceof types.IsNull) {
+		return {
+			spec: {
+				op: "is_null",
+				field: nativeFieldKey(query.key),
+			},
+			exact: true,
+		};
+	}
 	return;
-};
-
-const canSkipResidualForNativeQuery = (queryCoerced: types.Query[]): boolean => {
-	if (queryCoerced.length !== 1) {
-		return false;
-	}
-	const query = queryCoerced[0];
-	if (query instanceof types.BoolQuery || query instanceof types.ByteMatchQuery) {
-		return true;
-	}
-	if (query instanceof types.StringMatch) {
-		return (
-			query.method === types.StringMatchMethod.exact &&
-			query.caseInsensitive === false
-		);
-	}
-	if (query instanceof types.IntegerCompare) {
-		return nativeIntegerValue(query.value.value) != null;
-	}
-	return false;
 };
 
 const getBatchFromResults = <T extends Record<string, any>>(
@@ -712,7 +751,11 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			}
 		}
 
-		const nativeCandidates = this.getNativeCandidates(queryCoerced);
+		const nativeResults = this.getNativeCandidates(queryCoerced);
+		if (nativeResults) {
+			return nativeResults;
+		}
+
 		const indexedDocuments = await this.queryDocuments(
 			async (doc) => {
 				const innerHits = new Map();
@@ -723,7 +766,6 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				}
 				return true;
 			},
-			nativeCandidates,
 		);
 
 		return indexedDocuments;
@@ -1102,7 +1144,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			return;
 		}
 		const compiled = compileNativeQueries(queryCoerced);
-		if (compiled.spec.op === "all") {
+		if (!compiled || compiled.spec.op === "all") {
 			return;
 		}
 		return compiled;
@@ -1116,7 +1158,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			return;
 		}
 		const compiled = this.getNativePlan(queryCoerced);
-		if (!compiled?.exact || !canSkipResidualForNativeQuery(queryCoerced)) {
+		if (!compiled?.exact) {
 			return;
 		}
 		return { compiled, offset: 0 };
@@ -1124,7 +1166,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 
 	private countNativeExact(queryCoerced: types.Query[]): number | undefined {
 		const compiled = this.getNativePlan(queryCoerced);
-		if (!compiled?.exact || !canSkipResidualForNativeQuery(queryCoerced)) {
+		if (!compiled?.exact) {
 			return;
 		}
 		return this.countNativePlan(compiled);

--- a/packages/utils/indexer/rust/src/lib.rs
+++ b/packages/utils/indexer/rust/src/lib.rs
@@ -3,6 +3,7 @@ use indexmap::IndexMap;
 use js_sys::Array;
 use planner::{
     Compare, DocumentFields, FieldValue, NativeQueryIndex, Query, SortDirection, SortField,
+    StringMatchMethod,
 };
 use wasm_bindgen::prelude::*;
 
@@ -146,6 +147,7 @@ struct DocumentFieldsDto {
 
 #[derive(BorshDeserialize)]
 struct FieldFactDto {
+    scope: u32,
     field: String,
     value: FieldValueDto,
 }
@@ -187,6 +189,15 @@ enum QueryDto {
     Not {
         query: Box<QueryDto>,
     },
+    StringMatch {
+        field: String,
+        value: String,
+        method: StringMatchMethodDto,
+        case_insensitive: bool,
+    },
+    IsNull {
+        field: String,
+    },
 }
 
 // Enum declaration order is part of the TS/Rust bridge ABI.
@@ -218,12 +229,20 @@ enum SortDirectionDto {
     Desc,
 }
 
+// Enum declaration order is part of the TS/Rust bridge ABI.
+#[derive(Clone, Copy, BorshDeserialize)]
+enum StringMatchMethodDto {
+    Exact,
+    Prefix,
+    Contains,
+}
+
 fn decode_document_fields(fields_bytes: &[u8]) -> Result<DocumentFields, JsValue> {
     let payload = DocumentFieldsDto::try_from_slice(fields_bytes).map_err(js_error)?;
     ensure_bridge_version(payload.version)?;
     let mut fields = DocumentFields::new();
     for fact in payload.facts {
-        fields.insert_scalar(fact.field, FieldValue::from(fact.value));
+        fields.insert_scoped_scalar(fact.scope, fact.field, FieldValue::from(fact.value));
     }
     Ok(fields)
 }
@@ -269,6 +288,18 @@ impl TryFrom<QueryDto> for Query {
             QueryDto::And { queries } => Query::And(decode_queries(queries)?),
             QueryDto::Or { queries } => Query::Or(decode_queries(queries)?),
             QueryDto::Not { query } => Query::Not(Box::new((*query).try_into()?)),
+            QueryDto::StringMatch {
+                field,
+                value,
+                method,
+                case_insensitive,
+            } => Query::StringMatch {
+                field,
+                value,
+                method: method.into(),
+                case_insensitive,
+            },
+            QueryDto::IsNull { field } => Query::IsNull { field },
         })
     }
 }
@@ -301,6 +332,16 @@ impl From<SortDirectionDto> for SortDirection {
         match value {
             SortDirectionDto::Asc => SortDirection::Asc,
             SortDirectionDto::Desc => SortDirection::Desc,
+        }
+    }
+}
+
+impl From<StringMatchMethodDto> for StringMatchMethod {
+    fn from(value: StringMatchMethodDto) -> Self {
+        match value {
+            StringMatchMethodDto::Exact => StringMatchMethod::Exact,
+            StringMatchMethodDto::Prefix => StringMatchMethod::Prefix,
+            StringMatchMethodDto::Contains => StringMatchMethod::Contains,
         }
     }
 }

--- a/packages/utils/indexer/rust/src/planner.rs
+++ b/packages/utils/indexer/rust/src/planner.rs
@@ -70,7 +70,22 @@ impl From<Vec<u8>> for FieldValue {
 #[derive(Clone, Debug, Default)]
 pub struct DocumentFields {
     scalars: HashMap<FieldPath, Vec<FieldValue>>,
+    scoped_scalars: Vec<ScopedScalar>,
     vectors: HashMap<FieldPath, Vec<f32>>,
+}
+
+#[derive(Clone, Debug)]
+struct ScopedScalar {
+    scope: u32,
+    path: FieldPath,
+    value: FieldValue,
+}
+
+#[derive(Debug)]
+enum QueryMatch {
+    Matched(RoaringBitmap),
+    False,
+    Undefined,
 }
 
 impl DocumentFields {
@@ -89,10 +104,23 @@ impl DocumentFields {
     }
 
     pub fn insert_scalar(&mut self, path: impl Into<FieldPath>, value: impl Into<FieldValue>) {
+        self.insert_scoped_scalar(0, path, value);
+    }
+
+    pub fn insert_scoped_scalar(
+        &mut self,
+        scope: u32,
+        path: impl Into<FieldPath>,
+        value: impl Into<FieldValue>,
+    ) {
+        let path = path.into();
+        let value = value.into();
         self.scalars
-            .entry(path.into())
+            .entry(path.clone())
             .or_default()
-            .push(value.into());
+            .push(value.clone());
+        self.scoped_scalars
+            .push(ScopedScalar { scope, path, value });
     }
 
     pub fn insert_vector(&mut self, path: impl Into<FieldPath>, value: Vec<f32>) {
@@ -129,9 +157,25 @@ pub enum Query {
         compare: Compare,
         value: FieldValue,
     },
+    StringMatch {
+        field: FieldPath,
+        value: String,
+        method: StringMatchMethod,
+        case_insensitive: bool,
+    },
+    IsNull {
+        field: FieldPath,
+    },
     And(Vec<Query>),
     Or(Vec<Query>),
     Not(Box<Query>),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StringMatchMethod {
+    Exact,
+    Prefix,
+    Contains,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -280,6 +324,18 @@ impl NativeQueryIndex {
                 compare,
                 value,
             } => self.range_candidates(field, *compare, value),
+            Query::StringMatch {
+                field,
+                value,
+                method: StringMatchMethod::Exact,
+                case_insensitive: false,
+            } => self
+                .exact
+                .get(field)
+                .and_then(|values| values.get(&FieldValue::String(value.clone())))
+                .cloned()
+                .unwrap_or_default(),
+            Query::StringMatch { .. } | Query::IsNull { .. } => self.all_docs.clone(),
             Query::And(queries) => self.and_candidates(queries),
             Query::Or(queries) => self.or_candidates(queries),
             Query::Not(query) => &self.all_docs - &self.candidates(query),
@@ -287,7 +343,7 @@ impl NativeQueryIndex {
     }
 
     pub fn count(&self, query: &Query) -> u64 {
-        self.candidates(query).len()
+        self.matching_doc_ids(query).len()
     }
 
     pub fn search(&self, query: &Query, sort: &[SortField], limit: Option<usize>) -> Vec<String> {
@@ -302,8 +358,8 @@ impl NativeQueryIndex {
         limit: Option<usize>,
     ) -> Vec<String> {
         if sort.is_empty() {
-            let candidates = self.candidates(query);
-            let iter = candidates.iter().skip(offset);
+            let matches = self.matching_doc_ids(query);
+            let iter = matches.iter().skip(offset);
             if let Some(limit) = limit {
                 return iter
                     .take(limit)
@@ -315,7 +371,7 @@ impl NativeQueryIndex {
                 .collect();
         }
 
-        let mut doc_ids: Vec<_> = self.candidates(query).iter().collect();
+        let mut doc_ids: Vec<_> = self.matching_doc_ids(query).iter().collect();
         doc_ids.sort_by(|left, right| self.compare_docs(*left, *right, sort));
         let doc_ids = doc_ids.into_iter().skip(offset);
         if let Some(limit) = limit {
@@ -327,6 +383,133 @@ impl NativeQueryIndex {
         doc_ids
             .filter_map(|doc_id| self.internal_to_external.get(&doc_id).cloned())
             .collect()
+    }
+
+    fn matching_doc_ids(&self, query: &Query) -> RoaringBitmap {
+        let mut matches = RoaringBitmap::new();
+        for doc_id in self.candidates(query).iter() {
+            if self.matches_doc(doc_id, query) {
+                matches.insert(doc_id);
+            }
+        }
+        matches
+    }
+
+    fn matches_doc(&self, doc_id: DocId, query: &Query) -> bool {
+        match self.evaluate_doc(doc_id, query) {
+            QueryMatch::Matched(scopes) => !scopes.is_empty(),
+            QueryMatch::False | QueryMatch::Undefined => false,
+        }
+    }
+
+    fn evaluate_doc(&self, doc_id: DocId, query: &Query) -> QueryMatch {
+        let Some(document) = self.documents.get(&doc_id) else {
+            return QueryMatch::Undefined;
+        };
+        self.evaluate_query(document, query)
+    }
+
+    fn evaluate_query(&self, document: &DocumentFields, query: &Query) -> QueryMatch {
+        match query {
+            Query::All => QueryMatch::Matched(root_scope()),
+            Query::Exact { field, value } => {
+                self.matching_field_scopes(document, field, |field_value| field_value == value)
+            }
+            Query::Range {
+                field,
+                compare,
+                value,
+            } => self.matching_field_scopes(document, field, |field_value| {
+                compare_range_values(field_value, *compare, value)
+            }),
+            Query::StringMatch {
+                field,
+                value,
+                method,
+                case_insensitive,
+            } => self.matching_field_scopes(document, field, |field_value| {
+                matches_string_value(field_value, value, *method, *case_insensitive)
+            }),
+            Query::IsNull { field } => {
+                if document
+                    .scoped_scalars
+                    .iter()
+                    .any(|fact| fact.path == *field)
+                {
+                    QueryMatch::False
+                } else {
+                    QueryMatch::Matched(root_scope())
+                }
+            }
+            Query::And(queries) => {
+                let mut scopes = root_scope();
+                for query in queries {
+                    match self.evaluate_query(document, query) {
+                        QueryMatch::Matched(next) => {
+                            scopes = and_scope_sets(&scopes, &next);
+                            if scopes.is_empty() {
+                                return QueryMatch::False;
+                            }
+                        }
+                        QueryMatch::False => return QueryMatch::False,
+                        QueryMatch::Undefined => return QueryMatch::Undefined,
+                    }
+                }
+                QueryMatch::Matched(scopes)
+            }
+            Query::Or(queries) => {
+                let mut scopes = RoaringBitmap::new();
+                let mut saw_undefined = false;
+                for query in queries {
+                    match self.evaluate_query(document, query) {
+                        QueryMatch::Matched(next) => scopes |= next,
+                        QueryMatch::False => {}
+                        QueryMatch::Undefined => saw_undefined = true,
+                    }
+                }
+                if scopes.is_empty() {
+                    if saw_undefined {
+                        QueryMatch::Undefined
+                    } else {
+                        QueryMatch::False
+                    }
+                } else {
+                    QueryMatch::Matched(scopes)
+                }
+            }
+            Query::Not(query) => match self.evaluate_query(document, query) {
+                QueryMatch::Matched(scopes) if !scopes.is_empty() => QueryMatch::False,
+                QueryMatch::Matched(_) | QueryMatch::False => QueryMatch::Matched(root_scope()),
+                QueryMatch::Undefined => QueryMatch::Undefined,
+            },
+        }
+    }
+
+    fn matching_field_scopes(
+        &self,
+        document: &DocumentFields,
+        field: &str,
+        predicate: impl Fn(&FieldValue) -> bool,
+    ) -> QueryMatch {
+        let mut scopes = RoaringBitmap::new();
+        let mut field_present = false;
+        for fact in &document.scoped_scalars {
+            if fact.path == field {
+                field_present = true;
+                if predicate(&fact.value) {
+                    scopes.insert(fact.scope);
+                }
+            }
+        }
+        if scopes.is_empty() {
+            if field_present {
+                QueryMatch::False
+            } else {
+                QueryMatch::Undefined
+            }
+        } else {
+            QueryMatch::Matched(scopes)
+        }
     }
 
     pub fn vector_search(
@@ -500,6 +683,75 @@ impl NativeQueryIndex {
             .get(&doc_id)
             .and_then(|document| document.scalar_values(path))
             .and_then(|values| values.first())
+    }
+}
+
+fn root_scope() -> RoaringBitmap {
+    let mut scopes = RoaringBitmap::new();
+    scopes.insert(0);
+    scopes
+}
+
+fn and_scope_sets(left: &RoaringBitmap, right: &RoaringBitmap) -> RoaringBitmap {
+    let mut result = RoaringBitmap::new();
+    if left.contains(0) {
+        result |= right;
+    }
+    if right.contains(0) {
+        result |= left;
+    }
+    let mut left_scoped = left.clone();
+    left_scoped.remove(0);
+    let mut right_scoped = right.clone();
+    right_scoped.remove(0);
+    result |= left_scoped & right_scoped;
+    result
+}
+
+fn compare_range_values(left: &FieldValue, compare: Compare, right: &FieldValue) -> bool {
+    match (left, right) {
+        (FieldValue::I64(left), FieldValue::I64(right)) => {
+            compare_ordering(left.cmp(right), compare)
+        }
+        (FieldValue::U64(left), FieldValue::U64(right)) => {
+            compare_ordering(left.cmp(right), compare)
+        }
+        _ => false,
+    }
+}
+
+fn compare_ordering(ordering: Ordering, compare: Compare) -> bool {
+    match compare {
+        Compare::Equal => ordering == Ordering::Equal,
+        Compare::Less => ordering == Ordering::Less,
+        Compare::LessOrEqual => ordering != Ordering::Greater,
+        Compare::Greater => ordering == Ordering::Greater,
+        Compare::GreaterOrEqual => ordering != Ordering::Less,
+    }
+}
+
+fn matches_string_value(
+    field_value: &FieldValue,
+    query: &str,
+    method: StringMatchMethod,
+    case_insensitive: bool,
+) -> bool {
+    let FieldValue::String(value) = field_value else {
+        return false;
+    };
+    if case_insensitive {
+        let value = value.to_lowercase();
+        let query = query.to_lowercase();
+        return matches_string(&value, &query, method);
+    }
+    matches_string(value, query, method)
+}
+
+fn matches_string(value: &str, query: &str, method: StringMatchMethod) -> bool {
+    match method {
+        StringMatchMethod::Exact => value == query,
+        StringMatchMethod::Prefix => value.starts_with(query),
+        StringMatchMethod::Contains => value.contains(query),
     }
 }
 

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -1,6 +1,8 @@
-import { field } from "@dao-xyz/borsh";
+import { field, vec } from "@dao-xyz/borsh";
 import {
 	And,
+	Compare,
+	IntegerCompare,
 	Or,
 	Sort,
 	StringMatch,
@@ -28,6 +30,19 @@ class BridgeDocument {
 	}
 }
 
+class BridgeArrayDocument {
+	@id({ type: "string" })
+	id: string;
+
+	@field({ type: vec("u32") })
+	numbers: number[];
+
+	constructor(id: string, numbers: number[]) {
+		this.id = id;
+		this.numbers = numbers;
+	}
+}
+
 describe("all", () => {
 	tests(create, "persist", {
 		shapingSupported: false,
@@ -42,7 +57,7 @@ describe("all", () => {
 });
 
 describe("native planner bridge", () => {
-	it("uses supported native candidates with residual predicates", async () => {
+	it("evaluates exact and contains predicates in native rust", async () => {
 		const indices = create();
 		await indices.start();
 		const index = await indices.init({ schema: BridgeDocument });
@@ -67,7 +82,36 @@ describe("native planner bridge", () => {
 		await indices.drop();
 	});
 
-	it("falls back safely when an or branch is not native", async () => {
+	it("keeps array and predicates scoped to the same native element", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeArrayDocument });
+		await index.put(new BridgeArrayDocument("a", [1]));
+		await index.put(new BridgeArrayDocument("b", [2]));
+		await index.put(new BridgeArrayDocument("c", [0, 3]));
+
+		const results = await index
+			.iterate({
+				query: new And([
+					new IntegerCompare({
+						key: "numbers",
+						compare: Compare.Less,
+						value: 2,
+					}),
+					new IntegerCompare({
+						key: "numbers",
+						compare: Compare.GreaterOrEqual,
+						value: 1,
+					}),
+				]),
+			})
+			.all();
+
+		expect(results.map((result) => result.value.id)).to.deep.equal(["a"]);
+		await indices.drop();
+	});
+
+	it("evaluates string or predicates in native rust", async () => {
 		const indices = create();
 		await indices.start();
 		const index = await indices.init({ schema: BridgeDocument });


### PR DESCRIPTION
Stacked on #790.

## What changed
- Adds scoped native field facts so array/object-array predicates can be evaluated against the same element in Rust.
- Moves supported field/logical query correctness into the Rust planner: integer ranges, exact values, bool/bytes, string exact/prefix/contains with case-insensitive support, `is_null`, `and`, `or`, and `not`.
- Removes TS residual filtering for native-supported query ASTs; unsupported query shapes still fall back before compiling a partial native plan.
- Makes native count/page/query use the Rust evaluator, not just candidate bitmaps.
- Adds bridge coverage proving compound array predicates do not match across different array elements.

## Verification
- `cargo test` in `packages/utils/indexer/rust`
- `pnpm --filter @peerbit/indexer-rust lint`
- `pnpm --filter @peerbit/indexer-rust test` (node, browser, webworker)
- `pnpm --filter @peerbit/indexer-rust benchmark`

## Benchmark notes from this run
- Transient number query fetch 10: ~13.6us avg, ~76.9k ops/s avg.
- Persist number query fetch 10: ~15.2us avg, ~69.3k ops/s avg.
- Transient string query matching: ~63.9us avg, ~16.1k ops/s avg.
- Persist string query matching: ~64.9us avg, ~15.9k ops/s avg.
- Broad 3-field OR small fetch remains the slow path at ~313ms avg in both transient and persist runs.