### PR TITLE
Page sorted native index results

### DIFF
--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -76,8 +76,14 @@ type NativeQueryCompileResult = {
 	exact: boolean;
 };
 
+type NativeSortField = {
+	field: string;
+	direction: "asc" | "desc";
+};
+
 type NativeCandidatePage = {
 	compiled: NativeQueryCompileResult;
+	sort: NativeSortField[];
 	offset: number;
 	limit?: number;
 };
@@ -115,6 +121,11 @@ const enum NativeStringMatchMethodTag {
 	Exact = 0,
 	Prefix = 1,
 	Contains = 2,
+}
+
+const enum NativeSortDirectionTag {
+	Asc = 0,
+	Desc = 1,
 }
 
 let wasmModulePromise: Promise<WasmModule> | undefined;
@@ -318,6 +329,15 @@ const nativeStringMatchMethodTag = (
 	}
 };
 
+const nativeSortDirectionTag = (direction: "asc" | "desc") => {
+	switch (direction) {
+		case "asc":
+			return NativeSortDirectionTag.Asc;
+		case "desc":
+			return NativeSortDirectionTag.Desc;
+	}
+};
+
 const writeNativeValue = (writer: BinaryWriter, value: NativeValue): void => {
 	switch (value.type) {
 		case "bool":
@@ -397,10 +417,21 @@ const encodeNativeQuerySpec = (query: NativeQuerySpec): Uint8Array => {
 	return writer.finalize();
 };
 
-const encodeNativeSort = (): Uint8Array => {
+const nativeSortFields = (sort?: types.Sort | types.Sort[]): NativeSortField[] =>
+	types.toSort(sort).map((field) => ({
+		field: nativeFieldKey(field.key),
+		direction:
+			field.direction === types.SortDirection.ASC ? "asc" : "desc",
+	}));
+
+const encodeNativeSort = (sort: NativeSortField[] = []): Uint8Array => {
 	const writer = new BinaryWriter();
 	writer.u8(BRIDGE_VERSION);
-	writer.u32(0);
+	writer.u32(sort.length);
+	for (const field of sort) {
+		writer.string(field.field);
+		writer.u8(nativeSortDirectionTag(field.direction));
+	}
 	return writer.finalize();
 };
 
@@ -806,6 +837,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				}
 				const batch = this.getNativeCandidatesForPlan({
 					compiled: nativePagePlan.compiled,
+					sort: nativePagePlan.sort,
 					offset,
 					limit: wanted,
 				});
@@ -818,7 +850,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				all: async () => fetch(Infinity),
 				next: (n: number) => fetch(n),
 				done: () => done,
-				pending: async () => Math.max(0, getTotal() - offset),
+				pending: async () => (done ? 0 : Math.max(0, getTotal() - offset)),
 				close: () => {
 					done = true;
 				},
@@ -1134,17 +1166,18 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		if (!compiled) {
 			return;
 		}
-		return this.getNativeCandidatesForPlan({ compiled, offset: 0 });
+		return this.getNativeCandidatesForPlan({ compiled, sort: [], offset: 0 });
 	}
 
 	private getNativePlan(
 		queryCoerced: types.Query[],
+		options?: { allowAll?: boolean },
 	): NativeQueryCompileResult | undefined {
-		if (!this.planner || queryCoerced.length === 0) {
+		if (!this.planner) {
 			return;
 		}
 		const compiled = compileNativeQueries(queryCoerced);
-		if (!compiled || compiled.spec.op === "all") {
+		if (!compiled || (compiled.spec.op === "all" && !options?.allowAll)) {
 			return;
 		}
 		return compiled;
@@ -1154,14 +1187,15 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		queryCoerced: types.Query[],
 		query?: types.IterateOptions,
 	): NativeCandidatePage | undefined {
-		if (query?.sort) {
-			return;
-		}
-		const compiled = this.getNativePlan(queryCoerced);
+		const compiled = this.getNativePlan(queryCoerced, { allowAll: true });
 		if (!compiled?.exact) {
 			return;
 		}
-		return { compiled, offset: 0 };
+		return {
+			compiled,
+			sort: nativeSortFields(query?.sort),
+			offset: 0,
+		};
 	}
 
 	private countNativeExact(queryCoerced: types.Query[]): number | undefined {
@@ -1186,7 +1220,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 	): types.IndexedValue<T>[] {
 		const results: types.IndexedValue<T>[] = [];
 		const queryBytes = encodeNativeQuerySpec(page.compiled.spec);
-		const sortBytes = encodeNativeSort();
+		const sortBytes = encodeNativeSort(page.sort);
 		const storeKeys =
 			page.limit == null
 				? this.planner!.query(queryBytes, sortBytes)

--- a/packages/utils/indexer/rust/src/planner.rs
+++ b/packages/utils/indexer/rust/src/planner.rs
@@ -247,6 +247,11 @@ pub struct NativeQueryIndex {
     exact: HashMap<FieldPath, HashMap<FieldValue, RoaringBitmap>>,
     range_i64: HashMap<FieldPath, BTreeMap<i64, RoaringBitmap>>,
     range_u64: HashMap<FieldPath, BTreeMap<u64, RoaringBitmap>>,
+    sort_bool: HashMap<FieldPath, BTreeMap<bool, RoaringBitmap>>,
+    sort_i64: HashMap<FieldPath, BTreeMap<i64, RoaringBitmap>>,
+    sort_u64: HashMap<FieldPath, BTreeMap<u64, RoaringBitmap>>,
+    sort_string: HashMap<FieldPath, BTreeMap<String, RoaringBitmap>>,
+    sort_bytes: HashMap<FieldPath, BTreeMap<Vec<u8>, RoaringBitmap>>,
     vectors: HashMap<FieldPath, HashMap<DocId, Vec<f32>>>,
 }
 
@@ -369,6 +374,10 @@ impl NativeQueryIndex {
             return iter
                 .filter_map(|doc_id| self.internal_to_external.get(&doc_id).cloned())
                 .collect();
+        }
+
+        if let Some(page) = self.search_index_sorted_page(query, sort, offset, limit) {
+            return page;
         }
 
         let mut doc_ids: Vec<_> = self.matching_doc_ids(query).iter().collect();
@@ -574,6 +583,9 @@ impl NativeQueryIndex {
             return;
         };
         for (path, values) in fields.scalars {
+            if let Some(value) = values.first() {
+                self.remove_sort_value(&path, value, doc_id);
+            }
             for value in values {
                 remove_from_exact(&mut self.exact, &path, &value, doc_id);
                 if let Some(value) = value.as_i64() {
@@ -592,6 +604,9 @@ impl NativeQueryIndex {
 
     fn index_document(&mut self, doc_id: DocId, fields: &DocumentFields) {
         for (path, values) in &fields.scalars {
+            if let Some(value) = values.first() {
+                self.insert_sort_value(path, value, doc_id);
+            }
             for value in values {
                 self.exact
                     .entry(path.clone())
@@ -683,6 +698,316 @@ impl NativeQueryIndex {
             .get(&doc_id)
             .and_then(|document| document.scalar_values(path))
             .and_then(|values| values.first())
+    }
+
+    fn search_index_sorted_page(
+        &self,
+        query: &Query,
+        sort: &[SortField],
+        offset: usize,
+        limit: Option<usize>,
+    ) -> Option<Vec<String>> {
+        if sort.len() != 1 {
+            return None;
+        }
+
+        let sort = &sort[0];
+        let limit = limit.unwrap_or(usize::MAX);
+        if limit == 0 {
+            return Some(Vec::new());
+        }
+
+        let mut result = Vec::new();
+        let mut skipped = 0;
+        let mut seen = RoaringBitmap::new();
+        let mut has_ordered_index = false;
+
+        if sort.direction == SortDirection::Desc
+            && !self.collect_missing_sorted_docs(
+                &sort.field,
+                query,
+                offset,
+                limit,
+                &mut skipped,
+                &mut seen,
+                &mut result,
+            )
+        {
+            return Some(result);
+        }
+
+        match sort.direction {
+            SortDirection::Asc => {
+                has_ordered_index |= self.collect_sort_index_docs(
+                    self.sort_bool.get(&sort.field),
+                    false,
+                    query,
+                    offset,
+                    limit,
+                    &mut skipped,
+                    &mut seen,
+                    &mut result,
+                );
+                has_ordered_index |= self.collect_sort_index_docs(
+                    self.sort_i64.get(&sort.field),
+                    false,
+                    query,
+                    offset,
+                    limit,
+                    &mut skipped,
+                    &mut seen,
+                    &mut result,
+                );
+                has_ordered_index |= self.collect_sort_index_docs(
+                    self.sort_u64.get(&sort.field),
+                    false,
+                    query,
+                    offset,
+                    limit,
+                    &mut skipped,
+                    &mut seen,
+                    &mut result,
+                );
+                has_ordered_index |= self.collect_sort_index_docs(
+                    self.sort_string.get(&sort.field),
+                    false,
+                    query,
+                    offset,
+                    limit,
+                    &mut skipped,
+                    &mut seen,
+                    &mut result,
+                );
+                has_ordered_index |= self.collect_sort_index_docs(
+                    self.sort_bytes.get(&sort.field),
+                    false,
+                    query,
+                    offset,
+                    limit,
+                    &mut skipped,
+                    &mut seen,
+                    &mut result,
+                );
+            }
+            SortDirection::Desc => {
+                has_ordered_index |= self.collect_sort_index_docs(
+                    self.sort_bytes.get(&sort.field),
+                    true,
+                    query,
+                    offset,
+                    limit,
+                    &mut skipped,
+                    &mut seen,
+                    &mut result,
+                );
+                has_ordered_index |= self.collect_sort_index_docs(
+                    self.sort_string.get(&sort.field),
+                    true,
+                    query,
+                    offset,
+                    limit,
+                    &mut skipped,
+                    &mut seen,
+                    &mut result,
+                );
+                has_ordered_index |= self.collect_sort_index_docs(
+                    self.sort_u64.get(&sort.field),
+                    true,
+                    query,
+                    offset,
+                    limit,
+                    &mut skipped,
+                    &mut seen,
+                    &mut result,
+                );
+                has_ordered_index |= self.collect_sort_index_docs(
+                    self.sort_i64.get(&sort.field),
+                    true,
+                    query,
+                    offset,
+                    limit,
+                    &mut skipped,
+                    &mut seen,
+                    &mut result,
+                );
+                has_ordered_index |= self.collect_sort_index_docs(
+                    self.sort_bool.get(&sort.field),
+                    true,
+                    query,
+                    offset,
+                    limit,
+                    &mut skipped,
+                    &mut seen,
+                    &mut result,
+                );
+            }
+        }
+
+        if !has_ordered_index {
+            return None;
+        }
+        if result.len() >= limit {
+            return Some(result);
+        }
+
+        if sort.direction == SortDirection::Asc {
+            self.collect_missing_sorted_docs(
+                &sort.field,
+                query,
+                offset,
+                limit,
+                &mut skipped,
+                &mut seen,
+                &mut result,
+            );
+        }
+
+        Some(result)
+    }
+
+    fn collect_sort_index_docs<T: Ord>(
+        &self,
+        index: Option<&BTreeMap<T, RoaringBitmap>>,
+        reverse: bool,
+        query: &Query,
+        offset: usize,
+        limit: usize,
+        skipped: &mut usize,
+        seen: &mut RoaringBitmap,
+        result: &mut Vec<String>,
+    ) -> bool {
+        let Some(index) = index else {
+            return false;
+        };
+        if reverse {
+            self.collect_index_sorted_docs(
+                index.values().rev(),
+                query,
+                offset,
+                limit,
+                skipped,
+                seen,
+                result,
+            );
+        } else {
+            self.collect_index_sorted_docs(
+                index.values(),
+                query,
+                offset,
+                limit,
+                skipped,
+                seen,
+                result,
+            );
+        }
+        true
+    }
+
+    fn collect_index_sorted_docs<'a>(
+        &self,
+        bitmaps: impl Iterator<Item = &'a RoaringBitmap>,
+        query: &Query,
+        offset: usize,
+        limit: usize,
+        skipped: &mut usize,
+        seen: &mut RoaringBitmap,
+        result: &mut Vec<String>,
+    ) -> bool {
+        for bitmap in bitmaps {
+            for doc_id in bitmap.iter() {
+                if !self.collect_sorted_doc(doc_id, query, offset, limit, skipped, seen, result) {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    fn collect_missing_sorted_docs(
+        &self,
+        field: &str,
+        query: &Query,
+        offset: usize,
+        limit: usize,
+        skipped: &mut usize,
+        seen: &mut RoaringBitmap,
+        result: &mut Vec<String>,
+    ) -> bool {
+        for doc_id in self.all_docs.iter() {
+            if self.first_scalar(doc_id, field).is_some() {
+                continue;
+            }
+            if !self.collect_sorted_doc(doc_id, query, offset, limit, skipped, seen, result) {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn collect_sorted_doc(
+        &self,
+        doc_id: DocId,
+        query: &Query,
+        offset: usize,
+        limit: usize,
+        skipped: &mut usize,
+        seen: &mut RoaringBitmap,
+        result: &mut Vec<String>,
+    ) -> bool {
+        if result.len() >= limit {
+            return false;
+        }
+        if !seen.insert(doc_id) || !self.matches_doc(doc_id, query) {
+            return true;
+        }
+        if *skipped < offset {
+            *skipped += 1;
+            return true;
+        }
+        if let Some(id) = self.internal_to_external.get(&doc_id) {
+            result.push(id.clone());
+        }
+        result.len() < limit
+    }
+
+    fn insert_sort_value(&mut self, path: &str, value: &FieldValue, doc_id: DocId) {
+        match value {
+            FieldValue::Bool(value) => {
+                insert_into_ordered_index(&mut self.sort_bool, path, *value, doc_id)
+            }
+            FieldValue::I64(value) => {
+                insert_into_ordered_index(&mut self.sort_i64, path, *value, doc_id)
+            }
+            FieldValue::U64(value) => {
+                insert_into_ordered_index(&mut self.sort_u64, path, *value, doc_id)
+            }
+            FieldValue::String(value) => {
+                insert_into_ordered_index(&mut self.sort_string, path, value.clone(), doc_id)
+            }
+            FieldValue::Bytes(value) => {
+                insert_into_ordered_index(&mut self.sort_bytes, path, value.clone(), doc_id)
+            }
+        }
+    }
+
+    fn remove_sort_value(&mut self, path: &str, value: &FieldValue, doc_id: DocId) {
+        match value {
+            FieldValue::Bool(value) => {
+                remove_from_ordered_index(&mut self.sort_bool, path, value, doc_id)
+            }
+            FieldValue::I64(value) => {
+                remove_from_ordered_index(&mut self.sort_i64, path, value, doc_id)
+            }
+            FieldValue::U64(value) => {
+                remove_from_ordered_index(&mut self.sort_u64, path, value, doc_id)
+            }
+            FieldValue::String(value) => {
+                remove_from_ordered_index(&mut self.sort_string, path, value, doc_id)
+            }
+            FieldValue::Bytes(value) => {
+                remove_from_ordered_index(&mut self.sort_bytes, path, value, doc_id)
+            }
+        }
     }
 }
 
@@ -839,6 +1164,33 @@ fn remove_from_range_u64(
 ) {
     if let Some(values) = index.get_mut(path) {
         if let Some(bitmap) = values.get_mut(&value) {
+            bitmap.remove(doc_id);
+        }
+    }
+}
+
+fn insert_into_ordered_index<T: Ord>(
+    index: &mut HashMap<FieldPath, BTreeMap<T, RoaringBitmap>>,
+    path: &str,
+    value: T,
+    doc_id: DocId,
+) {
+    index
+        .entry(path.to_string())
+        .or_default()
+        .entry(value)
+        .or_default()
+        .insert(doc_id);
+}
+
+fn remove_from_ordered_index<T: Ord>(
+    index: &mut HashMap<FieldPath, BTreeMap<T, RoaringBitmap>>,
+    path: &str,
+    value: &T,
+    doc_id: DocId,
+) {
+    if let Some(values) = index.get_mut(path) {
+        if let Some(bitmap) = values.get_mut(value) {
             bitmap.remove(doc_id);
         }
     }
@@ -1004,6 +1356,75 @@ mod tests {
         );
 
         assert_eq!(results, vec!["c", "d"]);
+    }
+
+    #[test]
+    fn sorted_pages_use_first_scalar_values() {
+        let mut index = NativeQueryIndex::new();
+        index.put(
+            "a",
+            DocumentFields::new()
+                .with_scalar("title", "delta")
+                .with_scalar("title", "aardvark"),
+        );
+        index.put("b", DocumentFields::new().with_scalar("title", "bravo"));
+        index.put("c", DocumentFields::new().with_scalar("title", "charlie"));
+
+        let sort = [SortField {
+            field: "title".to_string(),
+            direction: SortDirection::Asc,
+        }];
+
+        assert_eq!(
+            index.search_page(&Query::All, &sort, 0, None),
+            vec!["b", "c", "a"]
+        );
+        assert_eq!(index.search_page(&Query::All, &sort, 1, Some(1)), vec!["c"]);
+        assert_eq!(
+            index.search_page(&Query::All, &sort, 0, Some(0)),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn sorted_pages_match_mixed_scalar_and_missing_order() {
+        let mut index = NativeQueryIndex::new();
+        index.put(
+            "missing",
+            DocumentFields::new().with_scalar("group", "left"),
+        );
+        index.put("bool", DocumentFields::new().with_scalar("sort", false));
+        index.put("i64", DocumentFields::new().with_scalar("sort", -1_i64));
+        index.put("u64", DocumentFields::new().with_scalar("sort", 2_u64));
+        index.put("string", DocumentFields::new().with_scalar("sort", "alpha"));
+        index.put(
+            "bytes",
+            DocumentFields::new().with_scalar("sort", vec![1_u8, 2_u8]),
+        );
+
+        assert_eq!(
+            index.search(
+                &Query::All,
+                &[SortField {
+                    field: "sort".to_string(),
+                    direction: SortDirection::Asc,
+                }],
+                None,
+            ),
+            vec!["bool", "i64", "u64", "string", "bytes", "missing"]
+        );
+        assert_eq!(
+            index.search_page(
+                &Query::All,
+                &[SortField {
+                    field: "sort".to_string(),
+                    direction: SortDirection::Desc,
+                }],
+                1,
+                Some(3),
+            ),
+            vec!["bytes", "string", "u64"]
+        );
     }
 
     #[test]

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -5,6 +5,7 @@ import {
 	IntegerCompare,
 	Or,
 	Sort,
+	SortDirection,
 	StringMatch,
 	StringMatchMethod,
 	id,
@@ -168,6 +169,57 @@ describe("native planner bridge", () => {
 		]);
 		expect(iterator.done()).to.equal(true);
 		expect(await iterator.pending()).to.equal(0);
+
+		await indices.drop();
+	});
+
+	it("pages sorted native candidates in rust", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeDocument });
+		await index.put(new BridgeDocument("a", "peerbit", "delta"));
+		await index.put(new BridgeDocument("b", "peerbit", "alpha"));
+		await index.put(new BridgeDocument("c", "other", "zero"));
+		await index.put(new BridgeDocument("d", "peerbit", "charlie"));
+		await index.put(new BridgeDocument("e", "peerbit", "bravo"));
+
+		const iterator = index.iterate({
+			query: new StringMatch({ key: "tag", value: "peerbit" }),
+			sort: new Sort({ key: "title" }),
+		});
+
+		expect(await iterator.pending()).to.equal(4);
+		expect((await iterator.next(2)).map((result) => result.value.id)).to.deep.equal([
+			"b",
+			"e",
+		]);
+		expect(iterator.done()).to.equal(false);
+		expect((await iterator.next(2)).map((result) => result.value.id)).to.deep.equal([
+			"d",
+			"a",
+		]);
+		expect(iterator.done()).to.equal(true);
+
+		const allIterator = index.iterate({
+			sort: new Sort({ key: "title" }),
+		});
+		expect((await allIterator.next(5)).map((result) => result.value.id)).to.deep.equal([
+			"b",
+			"e",
+			"d",
+			"a",
+			"c",
+		]);
+		expect(allIterator.done()).to.equal(true);
+
+		const descIterator = index.iterate({
+			sort: new Sort({ key: "title", direction: SortDirection.DESC }),
+		});
+		expect((await descIterator.next(3)).map((result) => result.value.id)).to.deep.equal([
+			"c",
+			"a",
+			"d",
+		]);
 
 		await indices.drop();
 	});


### PR DESCRIPTION
## Summary
- bridge scalar sort fields into the native Rust planner page path
- allow native page plans for unfiltered `All` queries, so sorted full scans can stay in Rust
- add first-scalar ordered sort indexes for bool, i64, u64, string, and bytes values
- add Rust and TS bridge coverage for native sorted paging, descending order, missing values, mixed scalar ranks, and first-scalar array semantics

Stacked on #791.

## Benchmark
Final run: `pnpm --filter @peerbit/indexer-rust benchmark`

Key row versus the previous stacked branch baseline:
- `non bool query fetch with sort 10 - transient`: `1,777,742 ns` avg, down from ~`22,583,873 ns` avg, about `12.7x` faster
- `non bool query fetch with sort 10 - persist`: `1,955,429 ns` avg, down from ~`23,119,094 ns` avg, about `11.8x` faster

Tradeoff: put paths now maintain first-scalar sort indexes. The final benchmark showed higher and noisier put averages on persistent storage, while medians remained low; this PR optimizes the repeated sorted-page read path rather than write-heavy workloads.

## Validation
- `cargo fmt`
- `cargo test`
- `pnpm --filter @peerbit/indexer-rust lint`
- `pnpm --filter @peerbit/indexer-rust test`
- `pnpm --filter @peerbit/indexer-rust benchmark`