### PR TITLE
Remove rust indexer query fallbacks

### DIFF
--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -1,11 +1,6 @@
 import { BinaryWriter, deserialize, serialize } from "@dao-xyz/borsh";
 import * as types from "@peerbit/indexer-interface";
-import { logger as loggerFn } from "@peerbit/logger";
-import { equals } from "uint8arrays";
 import { createSnapshotFile, type SnapshotFile } from "./persistence.js";
-
-const logger = loggerFn("peerbit:indexer:rust");
-const warn = logger.newScope("warn");
 
 type NativeIndexStore<T extends Record<string, any>> = {
 	put: (key: string, id: types.IdKey, value: T) => void;
@@ -29,6 +24,8 @@ type NativeQueryPlanner = {
 		limit: number,
 	) => string[];
 	count: (query: Uint8Array) => number;
+	sum: (query: Uint8Array, field: string) => [NativeSumKind, string];
+	delete_matching: (query: Uint8Array) => string[];
 };
 
 type WasmModule = {
@@ -80,6 +77,8 @@ type NativeSortField = {
 	field: string;
 	direction: "asc" | "desc";
 };
+
+type NativeSumKind = "none" | "i64" | "u64";
 
 type NativeCandidatePage = {
 	compiled: NativeQueryCompileResult;
@@ -168,6 +167,9 @@ const keyToStoreKey = (id: types.IdKey): string => {
 };
 
 const nativeFieldKey = (path: string[]): string => JSON.stringify(path);
+
+const nativeArrayElementFieldKey = (path: string[]): string =>
+	JSON.stringify(["\u0000array", ...path]);
 
 const bytesToNativeString = (bytes: Uint8Array): string => {
 	let hex = "";
@@ -271,7 +273,15 @@ const collectNativeFieldFacts = (
 
 	if (Array.isArray(value)) {
 		for (const item of value) {
-			collectNativeFieldFacts(item, path, facts, state, state.nextScope++);
+			const itemScope = state.nextScope++;
+			if (path.length > 0) {
+				facts.push({
+					scope: itemScope,
+					field: nativeArrayElementFieldKey(path),
+					value: { type: "bool", value: true },
+				});
+			}
+			collectNativeFieldFacts(item, path, facts, state, itemScope);
 		}
 		return facts;
 	}
@@ -447,19 +457,38 @@ const encodeNativeFieldFacts = (facts: NativeFieldFact[]): Uint8Array => {
 	return writer.finalize();
 };
 
+const decodeNativeSum = ([kind, value]: [NativeSumKind, string]): number | bigint => {
+	if (kind === "none") {
+		return 0;
+	}
+	const sum = BigInt(value);
+	if (
+		sum >= BigInt(Number.MIN_SAFE_INTEGER) &&
+		sum <= BigInt(Number.MAX_SAFE_INTEGER)
+	) {
+		return Number(sum);
+	}
+	return sum;
+};
+
+const describeNativeQueries = (queries: types.Query[]) =>
+	queries.map((query) => query.constructor.name).join(", ") || "All";
+
 const compileNativeQueries = (
 	queries: types.Query[],
+	prefix: string[] = [],
 ): NativeQueryCompileResult | undefined => {
-	return compileNativeAnd(queries);
+	return compileNativeAnd(queries, prefix);
 };
 
 const compileNativeAnd = (
 	queries: types.Query[],
+	prefix: string[] = [],
 ): NativeQueryCompileResult | undefined => {
 	const compiled: NativeQuerySpec[] = [];
 
 	for (const query of queries) {
-		const next = compileNativeQuery(query);
+		const next = compileNativeQuery(query, prefix);
 		if (!next) {
 			return;
 		}
@@ -477,14 +506,15 @@ const compileNativeAnd = (
 
 const compileNativeQuery = (
 	query: types.Query,
+	prefix: string[] = [],
 ): NativeQueryCompileResult | undefined => {
 	if (query instanceof types.And) {
-		return compileNativeAnd(query.and);
+		return compileNativeAnd(query.and, prefix);
 	}
 	if (query instanceof types.Or) {
 		const compiled: NativeQuerySpec[] = [];
 		for (const child of query.or) {
-			const next = compileNativeQuery(child);
+			const next = compileNativeQuery(child, prefix);
 			if (!next) {
 				return;
 			}
@@ -493,17 +523,36 @@ const compileNativeQuery = (
 		return { spec: { op: "or", queries: compiled }, exact: true };
 	}
 	if (query instanceof types.Not) {
-		const child = compileNativeQuery(query.not);
+		const child = compileNativeQuery(query.not, prefix);
 		if (!child) {
 			return;
 		}
 		return { spec: { op: "not", query: child.spec }, exact: true };
 	}
+	if (query instanceof types.Nested) {
+		const nestedPath = [...prefix, ...query.path];
+		const nested = compileNativeAnd(query.query, nestedPath);
+		if (!nested) {
+			return;
+		}
+		const arrayElementMarker: NativeQuerySpec = {
+			op: "exact",
+			field: nativeArrayElementFieldKey(nestedPath),
+			value: { type: "bool", value: true },
+		};
+		if (nested.spec.op === "all") {
+			return { spec: arrayElementMarker, exact: true };
+		}
+		return {
+			spec: { op: "and", queries: [arrayElementMarker, nested.spec] },
+			exact: true,
+		};
+	}
 	if (query instanceof types.BoolQuery) {
 		return {
 			spec: {
 				op: "exact",
-				field: nativeFieldKey(query.key),
+				field: nativeFieldKey([...prefix, ...query.key]),
 				value: { type: "bool", value: query.value },
 			},
 			exact: true,
@@ -513,7 +562,7 @@ const compileNativeQuery = (
 		return {
 			spec: {
 				op: "string",
-				field: nativeFieldKey(query.key),
+				field: nativeFieldKey([...prefix, ...query.key]),
 				value: query.value,
 				method:
 					query.method === types.StringMatchMethod.exact
@@ -530,7 +579,7 @@ const compileNativeQuery = (
 		return {
 			spec: {
 				op: "exact",
-				field: nativeFieldKey(query.key),
+				field: nativeFieldKey([...prefix, ...query.key]),
 				value: { type: "string", value: bytesToNativeString(query.value) },
 			},
 			exact: true,
@@ -545,7 +594,7 @@ const compileNativeQuery = (
 			return {
 				spec: {
 					op: "exact",
-					field: nativeFieldKey(query.key),
+					field: nativeFieldKey([...prefix, ...query.key]),
 					value,
 				},
 				exact: true,
@@ -554,7 +603,7 @@ const compileNativeQuery = (
 		return {
 			spec: {
 				op: "range",
-				field: nativeFieldKey(query.key),
+				field: nativeFieldKey([...prefix, ...query.key]),
 				compare: compareToNative(query.compare),
 				value,
 			},
@@ -562,6 +611,9 @@ const compileNativeQuery = (
 		};
 	}
 	if (query instanceof types.IsNull) {
+		if (prefix.length > 0) {
+			return;
+		}
 		return {
 			spec: {
 				op: "is_null",
@@ -571,21 +623,6 @@ const compileNativeQuery = (
 		};
 	}
 	return;
-};
-
-const getBatchFromResults = <T extends Record<string, any>>(
-	results: types.IndexedValue<T>[],
-	wantedSize: number,
-) => {
-	const batch: types.IndexedValue<T>[] = [];
-	for (const result of results) {
-		batch.push(result);
-		if (wantedSize <= batch.length) {
-			break;
-		}
-	}
-	results.splice(0, batch.length);
-	return batch;
 };
 
 const cloneResults = <T>(
@@ -677,12 +714,20 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 	}
 
 	async del(query: types.DeleteOptions): Promise<types.IdKey[]> {
+		const compiled = this.requireNativePlan(types.toQuery(query.query), {
+			allowAll: true,
+		});
+		const storeKeys = this.getPlanner().delete_matching(
+			encodeNativeQuerySpec(compiled.spec),
+		);
 		const deleted: types.IdKey[] = [];
-		for (const doc of await this.queryAll(query)) {
-			const storeKey = keyToStoreKey(doc.id);
+		for (const storeKey of storeKeys) {
+			const doc = this.getStore().get(storeKey);
+			if (!doc) {
+				continue;
+			}
 			if (this.getStore().delete(storeKey)) {
-				this.planner?.delete_document(storeKey);
-				deleted.push(doc.id);
+				deleted.push(doc[0]);
 			}
 		}
 		if (deleted.length > 0) {
@@ -719,23 +764,13 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 	}
 
 	async sum(query: types.SumOptions): Promise<number | bigint> {
-		let sum: undefined | number | bigint = undefined;
-		outer: for (const doc of await this.queryAll(query)) {
-			let value: any = doc.value;
-			for (const path of Array.isArray(query.key) ? query.key : [query.key]) {
-				value = value[path];
-				if (!value) {
-					continue outer;
-				}
-			}
-
-			if (typeof value === "number") {
-				sum = ((sum as unknown as number) || 0) + value;
-			} else if (typeof value === "bigint") {
-				sum = ((sum as unknown as bigint) || 0n) + value;
-			}
-		}
-		return sum != null ? sum : 0;
+		const compiled = this.requireNativePlan(types.toQuery(query.query), {
+			allowAll: true,
+		});
+		const field = nativeFieldKey(Array.isArray(query.key) ? query.key : [query.key]);
+		return decodeNativeSum(
+			this.getPlanner().sum(encodeNativeQuerySpec(compiled.spec), field),
+		);
 	}
 
 	async count(query?: types.CountOptions): Promise<number> {
@@ -743,442 +778,88 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		if (queryCoerced.length === 0) {
 			return this.getSize();
 		}
-		const nativeCount = this.countNativeExact(queryCoerced);
-		if (nativeCount != null) {
-			return nativeCount;
-		}
-		return (await this.queryAll(query)).length;
-	}
-
-	private async queryAll(
-		query?:
-			| types.IterateOptions
-			| types.DeleteOptions
-			| types.CountOptions
-			| types.SumOptions,
-	): Promise<types.IndexedValue<T>[]> {
-		const queryCoerced = types.toQuery(query?.query);
-		if (
-			queryCoerced.length === 1 &&
-			(queryCoerced[0] instanceof types.ByteMatchQuery ||
-				queryCoerced[0] instanceof types.StringMatch) &&
-			types.stringArraysEquals(queryCoerced[0].key, this.indexByArr)
-		) {
-			const firstQuery = queryCoerced[0];
-			if (firstQuery instanceof types.ByteMatchQuery) {
-				const doc = this.getStore().get(
-					keyToStoreKey(types.toId(firstQuery.value)),
-				);
-				return doc ? [{ id: doc[0], value: doc[1] }] : [];
-			} else if (
-				firstQuery instanceof types.StringMatch &&
-				firstQuery.method === types.StringMatchMethod.exact &&
-				firstQuery.caseInsensitive === false
-			) {
-				const doc = this.getStore().get(
-					keyToStoreKey(types.toId(firstQuery.value)),
-				);
-				return doc ? [{ id: doc[0], value: doc[1] }] : [];
-			}
-		}
-
-		const nativeResults = this.getNativeCandidates(queryCoerced);
-		if (nativeResults) {
-			return nativeResults;
-		}
-
-		const indexedDocuments = await this.queryDocuments(
-			async (doc) => {
-				const innerHits = new Map();
-				for (const f of queryCoerced) {
-					if (!(await this.handleQueryObject(f, doc.value, innerHits))) {
-						return false;
-					}
-				}
-				return true;
-			},
+		return this.countNativePlan(
+			this.requireNativePlan(queryCoerced, { allowAll: true }),
 		);
-
-		return indexedDocuments;
 	}
 
 	iterate<S extends types.Shape | undefined>(
 		query?: types.IterateOptions,
 		properties?: { shape?: S; reference?: boolean },
 	): types.IndexIterator<T, S> {
-		const nativePagePlan = this.getNativePagePlan(types.toQuery(query?.query), query);
-		if (nativePagePlan) {
-			let done: boolean | undefined = undefined;
-			let offset = 0;
-			let total: number | undefined;
-			const getTotal = () =>
-				(total ??= this.countNativePlan(nativePagePlan.compiled) ?? 0);
-			const clonePage = (batch: types.IndexedValue<T>[]) =>
-				(properties?.reference
-					? batch
-					: cloneResults(batch, this.properties.schema)) as types.IndexedResults<
-					types.ReturnTypeFromShape<T, S>
-				>;
-
-			const fetch = async (
-				n: number,
-			): Promise<types.IndexedResults<types.ReturnTypeFromShape<T, S>>> => {
-				if (done) {
-					return [];
-				}
-				const remaining = getTotal() - offset;
-				const wanted = Math.max(
-					0,
-					Math.min(Number.isFinite(n) ? Math.floor(n) : remaining, remaining),
-				);
-				if (wanted === 0) {
-					done = remaining === 0;
-					return [];
-				}
-				const batch = this.getNativeCandidatesForPlan({
-					compiled: nativePagePlan.compiled,
-					sort: nativePagePlan.sort,
-					offset,
-					limit: wanted,
-				});
-				offset += batch.length;
-				done = offset >= getTotal();
-				return clonePage(batch);
-			};
-
-			return {
-				all: async () => fetch(Infinity),
-				next: (n: number) => fetch(n),
-				done: () => done,
-				pending: async () => (done ? 0 : Math.max(0, getTotal() - offset)),
-				close: () => {
-					done = true;
-				},
-			};
-		}
-
+		const nativePagePlan = this.requireNativePagePlan(
+			types.toQuery(query?.query),
+			query,
+		);
 		let done: boolean | undefined = undefined;
-		let queue:
-			| {
-					arr: types.IndexedValue<T>[];
-					reference: boolean | undefined;
-			  }
-			| undefined = undefined;
+		let offset = 0;
+		let total: number | undefined;
+		const getTotal = () =>
+			(total ??= this.countNativePlan(nativePagePlan.compiled) ?? 0);
+		const clonePage = (batch: types.IndexedValue<T>[]) =>
+			(properties?.reference
+				? batch
+				: cloneResults(batch, this.properties.schema)) as types.IndexedResults<
+				types.ReturnTypeFromShape<T, S>
+			>;
+
 		const fetch = async (
 			n: number,
 		): Promise<types.IndexedResults<types.ReturnTypeFromShape<T, S>>> => {
-			if (!queue && !done) {
-				const indexedDocuments = await this.queryAll(query);
-				if (indexedDocuments.length > 1) {
-					if (query?.sort) {
-						const sortArr = Array.isArray(query.sort)
-							? query.sort
-							: [query.sort];
-						sortArr.length > 0 &&
-							indexedDocuments.sort((a, b) =>
-								types.extractSortCompare(a.value, b.value, sortArr),
-							);
-					}
-				}
-
-				if (indexedDocuments.length > 0) {
-					queue = {
-						arr: indexedDocuments,
-						reference: properties?.reference,
-					};
-					done = false;
-				} else {
-					done = true;
-				}
-			}
-			if (queue && queue.arr.length <= n) {
-				done = true;
-			}
-
-			if (!queue) {
+			if (done) {
 				return [];
 			}
-
-			const batch = getBatchFromResults<T>(queue.arr, n);
-
-			return (
-				queue.reference ? batch : cloneResults(batch, this.properties.schema)
-			) as types.IndexedResults<types.ReturnTypeFromShape<T, S>>;
+			const remaining = getTotal() - offset;
+			const wanted = Math.max(
+				0,
+				Math.min(Number.isFinite(n) ? Math.floor(n) : remaining, remaining),
+			);
+			if (wanted === 0) {
+				done = remaining === 0;
+				return [];
+			}
+			const batch = this.getNativeCandidatesForPlan({
+				compiled: nativePagePlan.compiled,
+				sort: nativePagePlan.sort,
+				offset,
+				limit: wanted,
+			});
+			offset += batch.length;
+			done = offset >= getTotal();
+			return clonePage(batch);
 		};
 
 		return {
-			all: async () => {
-				const results = await fetch(Infinity);
-				return results;
-			},
+			all: async () => fetch(Infinity),
 			next: (n: number) => fetch(n),
 			done: () => done,
-			pending: async () => {
-				if (done == null) {
-					await fetch(0);
-				}
-				return done ? 0 : (queue?.arr.length ?? 0);
-			},
+			pending: async () => (done ? 0 : Math.max(0, getTotal() - offset)),
 			close: () => {
 				done = true;
-				queue = undefined;
 			},
 		};
-	}
-
-	private async handleFieldQuery(
-		f: types.StateFieldQuery,
-		obj: any,
-		skipKeys: number,
-		innerHits: Map<string, any[] | false>,
-		buildInnerHits = true,
-	): Promise<boolean | undefined> {
-		const handleArrayResults = async (
-			path: string[],
-			obj: any[] | Uint8Array,
-			skipKeys: number,
-		): Promise<boolean> => {
-			const pathKey = buildInnerHits ? path.join(".") : undefined;
-			const innerHitsValue = pathKey ? innerHits.get(pathKey) : undefined;
-			if (pathKey && innerHitsValue === false) {
-				return false;
-			}
-
-			const fromInnerHits = pathKey;
-			const objArr =
-				fromInnerHits && innerHitsValue && (innerHitsValue as []).length > 0
-					? (innerHitsValue as any[])
-					: obj;
-			const newInnerHits: any[] | undefined = fromInnerHits ? [] : undefined;
-			for (const element of objArr!) {
-				if (await this.handleFieldQuery(f, element, skipKeys, innerHits)) {
-					if (!buildInnerHits) {
-						return true;
-					}
-					newInnerHits!.push(element);
-				}
-			}
-			if (!fromInnerHits) {
-				return false;
-			}
-
-			if (newInnerHits!.length === 0) {
-				innerHits.set(pathKey!, false);
-				return false;
-			}
-
-			innerHits.set(pathKey!, newInnerHits!);
-			return true;
-		};
-
-		if (
-			Array.isArray(obj) ||
-			(obj instanceof Uint8Array && f instanceof types.ByteMatchQuery === false)
-		) {
-			return handleArrayResults(f.key, obj, skipKeys);
-		}
-
-		for (let i = skipKeys; i < f.key.length; i++) {
-			obj = obj[f.key[i]];
-			if (
-				Array.isArray(obj) ||
-				(obj instanceof Uint8Array &&
-					f instanceof types.ByteMatchQuery === false)
-			) {
-				return handleArrayResults(f.key.slice(0, i + 1), obj, i + 1);
-			}
-			if (this.properties.nested?.match(obj)) {
-				const queryCloned = f.clone();
-				queryCloned.key.splice(0, i + 1);
-				const results = await this.properties.nested.iterate(obj, {
-					query: [queryCloned],
-				});
-				return results.length > 0 ? true : false;
-			}
-		}
-
-		if (f instanceof types.IsNull) {
-			if (obj == null) {
-				return true;
-			}
-			return false;
-		}
-
-		if (obj == null) {
-			return undefined;
-		}
-
-		if (f instanceof types.StringMatch) {
-			let compare = f.value;
-			if (f.caseInsensitive) {
-				compare = compare.toLowerCase();
-			}
-
-			if (this.handleStringMatch(f, compare, obj)) {
-				return true;
-			}
-			return false;
-		} else if (f instanceof types.ByteMatchQuery) {
-			if (obj instanceof Uint8Array === false) {
-				if (types.stringArraysEquals(f.key, this.indexByArr)) {
-					return f.valueString === obj;
-				}
-				return false;
-			}
-			return equals(obj as Uint8Array, f.value);
-		} else if (f instanceof types.IntegerCompare) {
-			const value: bigint | number = obj as any as bigint | number;
-
-			if (typeof value !== "bigint" && typeof value !== "number") {
-				return false;
-			}
-			return types.compare(value, f.compare, f.value.value);
-		} else if (f instanceof types.BoolQuery) {
-			return obj === f.value;
-		}
-		warn("Unsupported query type: " + f.constructor.name);
-		return false;
-	}
-
-	private async handleQueryObject(
-		f: types.Query,
-		value: Record<string, any> | T,
-		innerHits: Map<string, any[]>,
-		skipKeys = 0,
-	): Promise<{ result: true; innerHits: any[] } | boolean | undefined> {
-		if (f instanceof types.StateFieldQuery) {
-			return this.handleFieldQuery(f, value as T, skipKeys, innerHits);
-		} else if (f instanceof types.Nested) {
-			let arr = value;
-
-			for (let i = skipKeys; i < f.path.length; i++) {
-				arr = arr[f.path[i]];
-			}
-
-			if (!Array.isArray(arr)) {
-				throw new Error("Nested field is not an array");
-			}
-
-			const newSkipKeys = skipKeys + f.path.length;
-			outer: for (const element of arr) {
-				for (const query of f.query) {
-					if (
-						!(await this.handleQueryObject(
-							query,
-							element,
-							innerHits,
-							newSkipKeys,
-						))
-					) {
-						continue outer;
-					}
-				}
-				return true;
-			}
-			return false;
-		} else if (f instanceof types.LogicalQuery) {
-			if (f instanceof types.And) {
-				for (const and of f.and) {
-					const ret = await this.handleQueryObject(
-						and,
-						value,
-						innerHits,
-						skipKeys,
-					);
-					if (!ret) {
-						return ret;
-					}
-				}
-				return true;
-			}
-
-			if (f instanceof types.Or) {
-				for (const or of f.or) {
-					const innerHits = new Map();
-					const ret = await this.handleQueryObject(
-						or,
-						value,
-						innerHits,
-						skipKeys,
-					);
-					if (ret === true) {
-						return true;
-					} else if (ret === undefined) {
-						return undefined;
-					}
-				}
-				return false;
-			}
-			if (f instanceof types.Not) {
-				const ret = await this.handleQueryObject(
-					f.not,
-					value,
-					innerHits,
-					skipKeys,
-				);
-				if (ret === undefined) {
-					return undefined;
-				}
-				return !ret;
-			}
-		}
-
-		logger("Unsupported query type: " + f.constructor.name);
-		return false;
-	}
-
-	private handleStringMatch(f: types.StringMatch, compare: string, fv: string) {
-		if (typeof fv !== "string") {
-			return false;
-		}
-		if (f.caseInsensitive) {
-			fv = fv.toLowerCase();
-		}
-		if (f.method === types.StringMatchMethod.exact) {
-			return fv === compare;
-		}
-		if (f.method === types.StringMatchMethod.prefix) {
-			return fv.startsWith(compare);
-		}
-		if (f.method === types.StringMatchMethod.contains) {
-			return fv.includes(compare);
-		}
-		throw new Error("Unsupported");
-	}
-
-	private async queryDocuments(
-		filter: (doc: types.IndexedValue<T>) => Promise<boolean>,
-		documents = this.snapshot(),
-	): Promise<types.IndexedValue<T>[]> {
-		const results: types.IndexedValue<T>[] = [];
-		for (const value of documents) {
-			if (await filter(value)) {
-				results.push(value);
-			}
-		}
-		return results;
-	}
-
-	private getNativeCandidates(
-		queryCoerced: types.Query[],
-	): types.IndexedValue<T>[] | undefined {
-		const compiled = this.getNativePlan(queryCoerced);
-		if (!compiled) {
-			return;
-		}
-		return this.getNativeCandidatesForPlan({ compiled, sort: [], offset: 0 });
 	}
 
 	private getNativePlan(
 		queryCoerced: types.Query[],
 		options?: { allowAll?: boolean },
 	): NativeQueryCompileResult | undefined {
-		if (!this.planner) {
-			return;
-		}
 		const compiled = compileNativeQueries(queryCoerced);
 		if (!compiled || (compiled.spec.op === "all" && !options?.allowAll)) {
 			return;
+		}
+		return compiled;
+	}
+
+	private requireNativePlan(
+		queryCoerced: types.Query[],
+		options?: { allowAll?: boolean },
+	): NativeQueryCompileResult {
+		const compiled = this.getNativePlan(queryCoerced, options);
+		if (!compiled) {
+			throw new Error(
+				`Query is not supported by the native Rust indexer: ${describeNativeQueries(queryCoerced)}`,
+			);
 		}
 		return compiled;
 	}
@@ -1198,21 +879,21 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		};
 	}
 
-	private countNativeExact(queryCoerced: types.Query[]): number | undefined {
-		const compiled = this.getNativePlan(queryCoerced);
-		if (!compiled?.exact) {
-			return;
+	private requireNativePagePlan(
+		queryCoerced: types.Query[],
+		query?: types.IterateOptions,
+	): NativeCandidatePage {
+		const page = this.getNativePagePlan(queryCoerced, query);
+		if (!page) {
+			throw new Error(
+				`Query is not supported by the native Rust indexer: ${describeNativeQueries(queryCoerced)}`,
+			);
 		}
-		return this.countNativePlan(compiled);
+		return page;
 	}
 
-	private countNativePlan(
-		compiled: NativeQueryCompileResult,
-	): number | undefined {
-		if (!this.planner) {
-			return;
-		}
-		return this.planner.count(encodeNativeQuerySpec(compiled.spec));
+	private countNativePlan(compiled: NativeQueryCompileResult): number {
+		return this.getPlanner().count(encodeNativeQuerySpec(compiled.spec));
 	}
 
 	private getNativeCandidatesForPlan(
@@ -1223,8 +904,13 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		const sortBytes = encodeNativeSort(page.sort);
 		const storeKeys =
 			page.limit == null
-				? this.planner!.query(queryBytes, sortBytes)
-				: this.planner!.query_page(queryBytes, sortBytes, page.offset, page.limit);
+				? this.getPlanner().query(queryBytes, sortBytes)
+				: this.getPlanner().query_page(
+						queryBytes,
+						sortBytes,
+						page.offset,
+						page.limit,
+					);
 		for (const storeKey of storeKeys) {
 			const value = this.getStore().get(storeKey);
 			if (value) {
@@ -1235,7 +921,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 	}
 
 	private indexNativeDocument(storeKey: string, value: T): void {
-		this.planner?.put_document(
+		this.getPlanner().put_document(
 			storeKey,
 			encodeNativeFieldFacts(collectNativeFieldFacts(value)),
 		);
@@ -1254,6 +940,13 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			throw new Error("Index has not been initialized");
 		}
 		return this.store;
+	}
+
+	private getPlanner(): NativeQueryPlanner {
+		if (!this.planner) {
+			throw new Error("Index has not been initialized");
+		}
+		return this.planner;
 	}
 
 	private async persistSnapshot(): Promise<void> {

--- a/packages/utils/indexer/rust/src/lib.rs
+++ b/packages/utils/indexer/rust/src/lib.rs
@@ -3,7 +3,7 @@ use indexmap::IndexMap;
 use js_sys::Array;
 use planner::{
     Compare, DocumentFields, FieldValue, NativeQueryIndex, Query, SortDirection, SortField,
-    StringMatchMethod,
+    StringMatchMethod, SumResult,
 };
 use wasm_bindgen::prelude::*;
 
@@ -127,12 +127,43 @@ impl NativeQueryPlanner {
         let query = decode_query(&query_bytes)?;
         Ok(self.index.count(&query) as usize)
     }
+
+    pub fn sum(&self, query_bytes: Vec<u8>, field: String) -> Result<Array, JsValue> {
+        let query = decode_query(&query_bytes)?;
+        let sum = self.index.sum(&query, &field).map_err(js_error)?;
+        Ok(sum_to_js(sum))
+    }
+
+    pub fn delete_matching(&mut self, query_bytes: Vec<u8>) -> Result<Array, JsValue> {
+        let query = decode_query(&query_bytes)?;
+        let ids = self.index.delete_matching(&query);
+        Ok(ids_to_js(ids))
+    }
 }
 
 fn ids_to_js(ids: Vec<String>) -> Array {
     let out = Array::new();
     for id in ids {
         out.push(&JsValue::from_str(&id));
+    }
+    out
+}
+
+fn sum_to_js(sum: SumResult) -> Array {
+    let out = Array::new();
+    match sum {
+        SumResult::None => {
+            out.push(&JsValue::from_str("none"));
+            out.push(&JsValue::from_str("0"));
+        }
+        SumResult::I64(value) => {
+            out.push(&JsValue::from_str("i64"));
+            out.push(&JsValue::from_str(&value.to_string()));
+        }
+        SumResult::U64(value) => {
+            out.push(&JsValue::from_str("u64"));
+            out.push(&JsValue::from_str(&value.to_string()));
+        }
     }
     out
 }

--- a/packages/utils/indexer/rust/src/planner.rs
+++ b/packages/utils/indexer/rust/src/planner.rs
@@ -210,6 +210,13 @@ pub struct ScoredDocument {
     pub score: f32,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SumResult {
+    None,
+    I64(i128),
+    U64(u128),
+}
+
 #[derive(Default)]
 pub struct IndexBatch {
     deletes: Vec<String>,
@@ -349,6 +356,31 @@ impl NativeQueryIndex {
 
     pub fn count(&self, query: &Query) -> u64 {
         self.matching_doc_ids(query).len()
+    }
+
+    pub fn sum(&self, query: &Query, field: &str) -> Result<SumResult, String> {
+        let mut result = SumResult::None;
+        for doc_id in self.matching_doc_ids(query).iter() {
+            let Some(value) = self.first_scalar(doc_id, field) else {
+                continue;
+            };
+            result.add(value)?;
+        }
+        Ok(result)
+    }
+
+    pub fn delete_matching(&mut self, query: &Query) -> Vec<String> {
+        let ids: Vec<_> = self
+            .matching_doc_ids(query)
+            .iter()
+            .filter_map(|doc_id| self.internal_to_external.get(&doc_id).cloned())
+            .collect();
+        let mut batch = IndexBatch::new();
+        for id in &ids {
+            batch = batch.delete(id.clone());
+        }
+        self.apply_batch(batch);
+        ids
     }
 
     pub fn search(&self, query: &Query, sort: &[SortField], limit: Option<usize>) -> Vec<String> {
@@ -1011,6 +1043,64 @@ impl NativeQueryIndex {
     }
 }
 
+impl SumResult {
+    fn add(&mut self, value: &FieldValue) -> Result<(), String> {
+        match value {
+            FieldValue::I64(value) => self.add_i64(*value as i128),
+            FieldValue::U64(value) => self.add_u64(*value as u128),
+            FieldValue::Bool(_) | FieldValue::String(_) | FieldValue::Bytes(_) => Ok(()),
+        }
+    }
+
+    fn add_i64(&mut self, value: i128) -> Result<(), String> {
+        match self {
+            Self::None => {
+                *self = Self::I64(value);
+                Ok(())
+            }
+            Self::I64(sum) => {
+                *sum = sum
+                    .checked_add(value)
+                    .ok_or_else(|| "native i64 sum overflow".to_string())?;
+                Ok(())
+            }
+            Self::U64(sum) => {
+                let signed_sum = i128::try_from(*sum)
+                    .map_err(|_| "native sum cannot mix large u64 values with i64".to_string())?;
+                *self = Self::I64(
+                    signed_sum
+                        .checked_add(value)
+                        .ok_or_else(|| "native mixed sum overflow".to_string())?,
+                );
+                Ok(())
+            }
+        }
+    }
+
+    fn add_u64(&mut self, value: u128) -> Result<(), String> {
+        match self {
+            Self::None => {
+                *self = Self::U64(value);
+                Ok(())
+            }
+            Self::U64(sum) => {
+                *sum = sum
+                    .checked_add(value)
+                    .ok_or_else(|| "native u64 sum overflow".to_string())?;
+                Ok(())
+            }
+            Self::I64(sum) => {
+                let signed_value = i128::try_from(value)
+                    .map_err(|_| "native sum cannot mix large u64 values with i64".to_string())?;
+                *sum = sum
+                    .checked_add(signed_value)
+                    .ok_or_else(|| "native mixed sum overflow".to_string())?;
+                Ok(())
+            }
+        }
+    }
+}
+
 fn root_scope() -> RoaringBitmap {
     let mut scopes = RoaringBitmap::new();
     scopes.insert(0);
@@ -1262,7 +1352,7 @@ fn vector_distance(left: &[f32], right: &[f32], metric: VectorMetric) -> f32 {
 mod tests {
     use super::{
         Compare, DocumentFields, FieldValue, IndexBatch, NativeQueryIndex, Query, SortDirection,
-        SortField, VectorMetric, VectorSort,
+        SortField, SumResult, VectorMetric, VectorSort,
     };
 
     #[test]
@@ -1425,6 +1515,38 @@ mod tests {
             ),
             vec!["bytes", "string", "u64"]
         );
+    }
+
+    #[test]
+    fn sums_and_deletes_matching_docs() {
+        let mut index = NativeQueryIndex::new();
+        index.put(
+            "a",
+            DocumentFields::new()
+                .with_scalar("group", "left")
+                .with_scalar("value", 1_u64),
+        );
+        index.put(
+            "b",
+            DocumentFields::new()
+                .with_scalar("group", "right")
+                .with_scalar("value", 2_u64),
+        );
+        index.put(
+            "c",
+            DocumentFields::new()
+                .with_scalar("group", "left")
+                .with_scalar("value", 3_u64),
+        );
+
+        let query = Query::Exact {
+            field: "group".to_string(),
+            value: FieldValue::String("left".to_string()),
+        };
+
+        assert_eq!(index.sum(&query, "value").unwrap(), SumResult::U64(4));
+        assert_eq!(index.delete_matching(&query), vec!["a", "c"]);
+        assert_eq!(index.search(&Query::All, &[], None), vec!["b"]);
     }
 
     #[test]

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -3,6 +3,7 @@ import {
 	And,
 	Compare,
 	IntegerCompare,
+	Nested,
 	Or,
 	Sort,
 	SortDirection,
@@ -44,6 +45,49 @@ class BridgeArrayDocument {
 	}
 }
 
+class BridgeMetricDocument {
+	@id({ type: "string" })
+	id: string;
+
+	@field({ type: "string" })
+	tag: string;
+
+	@field({ type: "u32" })
+	value: number;
+
+	constructor(id: string, tag: string, value: number) {
+		this.id = id;
+		this.tag = tag;
+		this.value = value;
+	}
+}
+
+class BridgeNestedItem {
+	@field({ type: "string" })
+	tag: string;
+
+	@field({ type: "u32" })
+	score: number;
+
+	constructor(tag: string, score: number) {
+		this.tag = tag;
+		this.score = score;
+	}
+}
+
+class BridgeNestedDocument {
+	@id({ type: "string" })
+	id: string;
+
+	@field({ type: vec(BridgeNestedItem) })
+	items: BridgeNestedItem[];
+
+	constructor(id: string, items: BridgeNestedItem[]) {
+		this.id = id;
+		this.items = items;
+	}
+}
+
 describe("all", () => {
 	tests(create, "persist", {
 		shapingSupported: false,
@@ -58,6 +102,21 @@ describe("all", () => {
 });
 
 describe("native planner bridge", () => {
+	it("does not expose the previous typescript query fallback evaluator", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeDocument });
+
+		expect((index as unknown as Record<string, unknown>).handleFieldQuery).to.equal(
+			undefined,
+		);
+		expect((index as unknown as Record<string, unknown>).handleQueryObject).to.equal(
+			undefined,
+		);
+
+		await indices.drop();
+	});
+
 	it("evaluates exact and contains predicates in native rust", async () => {
 		const indices = create();
 		await indices.start();
@@ -80,6 +139,61 @@ describe("native planner bridge", () => {
 			.all();
 
 		expect(results.map((result) => result.value.id)).to.deep.equal(["a"]);
+		await indices.drop();
+	});
+
+	it("evaluates explicit nested queries in native rust", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeNestedDocument });
+		await index.put(
+			new BridgeNestedDocument("a", [
+				new BridgeNestedItem("left", 1),
+				new BridgeNestedItem("right", 3),
+			]),
+		);
+		await index.put(
+			new BridgeNestedDocument("b", [new BridgeNestedItem("left", 4)]),
+		);
+		await index.put(
+			new BridgeNestedDocument("c", [new BridgeNestedItem("right", 5)]),
+		);
+
+		const query = new Nested({
+			path: "items",
+			query: [
+				new StringMatch({ key: "tag", value: "left" }),
+				new IntegerCompare({
+					key: "score",
+					compare: Compare.Greater,
+					value: 2,
+				}),
+			],
+		});
+		const results = await index.iterate({ query }).all();
+
+		expect(results.map((result) => result.value.id)).to.deep.equal(["b"]);
+		expect(await index.count({ query })).to.equal(1);
+		await indices.drop();
+	});
+
+	it("sums and deletes through native rust queries", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeMetricDocument });
+		await index.put(new BridgeMetricDocument("a", "peerbit", 1));
+		await index.put(new BridgeMetricDocument("b", "other", 2));
+		await index.put(new BridgeMetricDocument("c", "peerbit", 3));
+
+		const query = new StringMatch({ key: "tag", value: "peerbit" });
+		expect(await index.sum({ key: "value" })).to.equal(6);
+		expect(await index.sum({ key: "value", query })).to.equal(4);
+
+		const deleted = await index.del({ query });
+		expect(deleted.map((id) => id.primitive)).to.deep.equal(["a", "c"]);
+		expect(await index.count()).to.equal(1);
+		expect(await index.sum({ key: "value" })).to.equal(2);
+
 		await indices.drop();
 	});
 


### PR DESCRIPTION
## Summary
- remove the TypeScript scan/query evaluator fallback from `@peerbit/indexer-rust`
- route iterate/count/sum/delete-by-query through native Rust planner operations
- compile explicit `Nested` queries into native prefixed field paths guarded by array-element markers
- add native Rust planner sum and delete_matching operations
- add bridge tests proving the fallback evaluator methods are gone, explicit nested queries run natively, and sum/delete use native queries

Stacked on #793.

## Benchmark
Final run: `pnpm --filter @peerbit/indexer-rust benchmark`

Key rows:
- `non bool query fetch with sort 10 - transient`: `2,317,683 ns` avg
- `non bool query fetch with sort 10 - persist`: `2,143,780 ns` avg

This remains roughly 10x faster than the pre-native-sort baseline (~22-23ms). It is slightly slower than the #793 run (~1.8-2.0ms), likely from run variance / wasm shape changes; the important change in this PR is removing the behavioral TS fallback, not adding a new sorted-read optimization.

## Validation
- `cargo fmt`
- `cargo test`
- `pnpm --filter @peerbit/indexer-rust lint`
- `pnpm --filter @peerbit/indexer-rust test`
- `pnpm --filter @peerbit/indexer-rust benchmark`