### PR TITLE
fix(shared-log): dedupe sync coordinate aliases

### DIFF
--- a/packages/programs/data/shared-log/src/sync/simple.ts
+++ b/packages/programs/data/shared-log/src/sync/simple.ts
@@ -428,6 +428,25 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		}
 	}
 
+	private getQueuedSyncKey(key: SyncableKey): SyncableKey | undefined {
+		if (this.syncInFlightQueue.has(key)) {
+			return key;
+		}
+		if (typeof key === "string") {
+			for (const queuedKey of this.syncInFlightQueue.keys()) {
+				if (
+					typeof queuedKey === "bigint" &&
+					this.coordinateToHash.get(queuedKey) === key
+				) {
+					return queuedKey;
+				}
+			}
+			return undefined;
+		}
+		const hash = this.coordinateToHash.get(key);
+		return hash && this.syncInFlightQueue.has(hash) ? hash : undefined;
+	}
+
 	startRepairSession(properties: {
 		entries: Map<string, EntryReplicated<R>>;
 		targets: string[];
@@ -649,13 +668,10 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		const resolvedHashes: string[] = [];
 		for (const entry of properties.entries) {
 			resolvedHashes.push(entry.entry.hash);
-			const set = this.syncInFlight.get(properties.from.hashcode());
-			if (set) {
-				set.delete(entry.entry.hash);
-				if (set?.size === 0) {
-					this.syncInFlight.delete(properties.from.hashcode());
-				}
-			}
+			this.clearSyncInFlightForPeer(
+				properties.from.hashcode(),
+				entry.entry.hash,
+			);
 		}
 		this.markRepairSessionResolvedHashes(resolvedHashes);
 	}
@@ -670,7 +686,8 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		const startedAt = syncProfileStart(profile);
 
 		try {
-			for (const coordinateOrHash of keys) {
+			for (const key of keys) {
+				const coordinateOrHash = this.getQueuedSyncKey(key) ?? key;
 				const inFlight = this.syncInFlightQueue.get(coordinateOrHash);
 				if (inFlight) {
 					if (!inFlight.find((x) => x.hashcode() === from.hashcode())) {
@@ -905,10 +922,49 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 
 			this.syncInFlightQueue.delete(key);
 		}
+
+		this.clearSyncInFlightKey(key);
+	}
+
+	private clearSyncInFlightKey(key: SyncableKey) {
+		for (const [peer, map] of this.syncInFlight) {
+			map.delete(key);
+			if (map.size === 0) {
+				this.syncInFlight.delete(peer);
+			}
+		}
+	}
+
+	private getKnownAliases(hash: string): SyncableKey[] {
+		const aliases = new Set<SyncableKey>([hash]);
+		for (const key of [
+			...this.syncInFlightQueue.keys(),
+			...[...this.syncInFlight.values()].flatMap((map) => [...map.keys()]),
+		]) {
+			if (typeof key === "bigint" && this.coordinateToHash.get(key) === hash) {
+				aliases.add(key);
+			}
+		}
+		return [...aliases];
+	}
+
+	private clearSyncInFlightForPeer(publicKeyHash: string, hash: string) {
+		const map = this.syncInFlight.get(publicKeyHash);
+		if (!map) {
+			return;
+		}
+		for (const key of this.getKnownAliases(hash)) {
+			map.delete(key);
+		}
+		if (map.size === 0) {
+			this.syncInFlight.delete(publicKeyHash);
+		}
 	}
 
 	private clearSyncProcess(hash: string) {
-		this.clearSyncProcessKey(hash);
+		for (const key of this.getKnownAliases(hash)) {
+			this.clearSyncProcessKey(key);
+		}
 	}
 
 	onPeerDisconnected(key: PublicSignKey | string): Promise<void> | void {

--- a/packages/programs/data/shared-log/test/sync-session.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-session.spec.ts
@@ -4,6 +4,133 @@ import sinon from "sinon";
 import { SimpleSyncronizer } from "../src/sync/simple.js";
 
 describe("sync-repair-session", () => {
+	it("deduplicates known hash aliases without changing coordinate requests", async () => {
+		const send = sinon.stub().resolves();
+		const coordinateToHash = new Cache<string>({ max: 10 });
+		coordinateToHash.add(42n, "entry-hash");
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {
+				count: async () => 0,
+			} as any,
+			log: {
+				has: async () => false,
+			} as any,
+			coordinateToHash,
+		});
+		const from = {
+			hashcode: () => "p1",
+			equals: () => false,
+		} as any;
+
+		await sync.queueSync([42n, "entry-hash"], from);
+
+		expect(sync.syncInFlightQueue.has(42n)).to.equal(true);
+		expect(sync.syncInFlightQueue.has("entry-hash")).to.equal(false);
+		expect(sync.syncInFlightQueueInverted.get("p1")).to.deep.equal(
+			new Set([42n]),
+		);
+		expect(send.calledOnce).to.equal(true);
+	});
+
+	it("deduplicates hash sync requests with already queued coordinate aliases", async () => {
+		const send = sinon.stub().resolves();
+		const coordinateToHash = new Cache<string>({ max: 10 });
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {
+				count: async () => 0,
+			} as any,
+			log: {
+				has: async () => false,
+			} as any,
+			coordinateToHash,
+		});
+		const p1 = {
+			hashcode: () => "p1",
+			equals: () => false,
+		} as any;
+		const p2 = {
+			hashcode: () => "p2",
+			equals: () => false,
+		} as any;
+
+		await sync.queueSync([42n], p1);
+		coordinateToHash.add(42n, "entry-hash");
+		await sync.queueSync(["entry-hash"], p2);
+
+		expect(sync.syncInFlightQueue.has(42n)).to.equal(true);
+		expect(sync.syncInFlightQueue.has("entry-hash")).to.equal(false);
+		expect(
+			sync.syncInFlightQueue.get(42n)?.map((x) => x.hashcode()),
+		).to.deep.equal(["p1", "p2"]);
+		expect(sync.syncInFlightQueueInverted.get("p2")).to.deep.equal(
+			new Set([42n]),
+		);
+		expect(send.calledOnce).to.equal(true);
+	});
+
+	it("clears in-flight coordinate aliases when an entry is received by hash", () => {
+		const coordinateToHash = new Cache<string>({ max: 10 });
+		coordinateToHash.add(42n, "entry-hash");
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {
+				count: async () => 0,
+			} as any,
+			log: {
+				has: async () => false,
+			} as any,
+			coordinateToHash,
+		});
+		const from = {
+			hashcode: () => "p1",
+			equals: () => false,
+		} as any;
+
+		sync.syncInFlightQueue.set(42n, [from]);
+		sync.syncInFlightQueueInverted.set("p1", new Set([42n]));
+		sync.syncInFlight.set("p1", new Map([[42n, { timestamp: Date.now() }]]));
+
+		sync.onReceivedEntries({
+			entries: [{ entry: { hash: "entry-hash" } }] as any,
+			from,
+		});
+
+		expect(sync.syncInFlightQueue.has(42n)).to.equal(true);
+		expect(sync.syncInFlightQueueInverted.has("p1")).to.equal(true);
+		expect(sync.syncInFlight.has("p1")).to.equal(false);
+	});
+
+	it("clears pending coordinate aliases when an entry is added by hash", () => {
+		const coordinateToHash = new Cache<string>({ max: 10 });
+		coordinateToHash.add(42n, "entry-hash");
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {
+				count: async () => 0,
+			} as any,
+			log: {
+				has: async () => false,
+			} as any,
+			coordinateToHash,
+		});
+		const from = {
+			hashcode: () => "p1",
+			equals: () => false,
+		} as any;
+
+		sync.syncInFlightQueue.set(42n, [from]);
+		sync.syncInFlightQueueInverted.set("p1", new Set([42n]));
+		sync.syncInFlight.set("p1", new Map([[42n, { timestamp: Date.now() }]]));
+
+		sync.onEntryAdded({ hash: "entry-hash" } as any);
+
+		expect(sync.syncInFlightQueue.has(42n)).to.equal(false);
+		expect(sync.syncInFlightQueueInverted.has("p1")).to.equal(false);
+		expect(sync.syncInFlight.has("p1")).to.equal(false);
+	});
+
 	it("resolves convergent session when missing entries are received", async () => {
 		const send = sinon.stub().resolves();
 		const rpc = { send } as any;


### PR DESCRIPTION
This is the first shared-log sync cleanup PR.

It canonicalizes simple sync work to known hash aliases when possible, reuses already queued coordinate/hash aliases instead of enqueueing duplicates, and clears coordinate aliases when the resolved hash is received or added locally.

I ran:
- pnpm --filter @peerbit/shared-log run build
- pnpm --filter @peerbit/shared-log test -- --no-build --grep sync-repair-session
- pnpm test:ci:part-4