### PR TITLE
Batch rust indexer store result lookups

### DIFF
--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -5,7 +5,9 @@ import { createSnapshotFile, type SnapshotFile } from "./persistence.js";
 type NativeIndexStore<T extends Record<string, any>> = {
 	put: (key: string, id: types.IdKey, value: T) => void;
 	get: (key: string) => [types.IdKey, T] | undefined;
+	get_many: (keys: string[]) => Array<[types.IdKey, T]>;
 	delete: (key: string) => boolean;
+	delete_many: (keys: string[]) => Array<[types.IdKey, T]>;
 	clear: () => void;
 	len: () => number;
 	entries: () => Array<[types.IdKey, T]>;
@@ -720,16 +722,9 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		const storeKeys = this.getPlanner().delete_matching(
 			encodeNativeQuerySpec(compiled.spec),
 		);
-		const deleted: types.IdKey[] = [];
-		for (const storeKey of storeKeys) {
-			const doc = this.getStore().get(storeKey);
-			if (!doc) {
-				continue;
-			}
-			if (this.getStore().delete(storeKey)) {
-				deleted.push(doc[0]);
-			}
-		}
+		const deleted = this.getStore()
+			.delete_many(storeKeys)
+			.map((entry) => entry[0]);
 		if (deleted.length > 0) {
 			this.markDirty();
 		}
@@ -899,7 +894,6 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 	private getNativeCandidatesForPlan(
 		page: NativeCandidatePage,
 	): types.IndexedValue<T>[] {
-		const results: types.IndexedValue<T>[] = [];
 		const queryBytes = encodeNativeQuerySpec(page.compiled.spec);
 		const sortBytes = encodeNativeSort(page.sort);
 		const storeKeys =
@@ -911,13 +905,9 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 						page.offset,
 						page.limit,
 					);
-		for (const storeKey of storeKeys) {
-			const value = this.getStore().get(storeKey);
-			if (value) {
-				results.push({ id: value[0], value: value[1] });
-			}
-		}
-		return results;
+		return this.getStore()
+			.get_many(storeKeys)
+			.map((value) => ({ id: value[0], value: value[1] }));
 	}
 
 	private indexNativeDocument(storeKey: string, value: T): void {

--- a/packages/utils/indexer/rust/src/lib.rs
+++ b/packages/utils/indexer/rust/src/lib.rs
@@ -43,8 +43,34 @@ impl NativeIndexStore {
         }
     }
 
+    pub fn get_many(&self, keys: Array) -> Array {
+        let entries = Array::new();
+        for key in keys.iter() {
+            let Some(key) = key.as_string() else {
+                continue;
+            };
+            if let Some(entry) = self.entries.get(&key) {
+                entries.push(&entry_to_js(entry));
+            }
+        }
+        entries
+    }
+
     pub fn delete(&mut self, key: &str) -> bool {
         self.entries.shift_remove(key).is_some()
+    }
+
+    pub fn delete_many(&mut self, keys: Array) -> Array {
+        let entries = Array::new();
+        for key in keys.iter() {
+            let Some(key) = key.as_string() else {
+                continue;
+            };
+            if let Some(entry) = self.entries.shift_remove(&key) {
+                entries.push(&entry_to_js(&entry));
+            }
+        }
+        entries
     }
 
     pub fn clear(&mut self) {


### PR DESCRIPTION
## Summary

Stacked on #794.

This reduces the remaining adapter overhead in the Rust indexer result path by batching store row materialization:

- adds native `NativeIndexStore.get_many` for query result hydration
- adds native `NativeIndexStore.delete_many` for query deletes
- replaces TS per-key `store.get()` / `store.delete()` loops with one wasm call per result page/delete result set

## Why

After moving query evaluation, sorting, sum, and delete matching into Rust, the next hot path was the wrapper crossing the wasm boundary once per returned store key. For fetch-heavy shared-log/indexer cases, this keeps planner work native and also hydrates returned entries in bulk.

## Validation

- `cargo fmt && cargo test`
- `pnpm --filter @peerbit/indexer-rust lint`
- `pnpm --filter @peerbit/indexer-rust test`
- `pnpm --filter @peerbit/indexer-rust benchmark`

Benchmark highlights from this branch:

- `non bool query fetch with sort 10 - transient`: `2,050,224 ns` avg
- `non bool query fetch with sort 10 - persist`: `1,837,264 ns` avg

Compared with the previous stacked PR run (`2,317,683 ns` transient, `2,143,780 ns` persist), this is about 12-14% faster on the existing sorted-fetch benchmark, while keeping the change scoped to result materialization.
