### PR TITLE
fix(shared-log): prioritize foreground traffic over sync

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -175,7 +175,11 @@ import type {
 	Syncronizer,
 } from "./sync/index.js";
 import { RatelessIBLTSynchronizer } from "./sync/rateless-iblt.js";
-import { ConfirmEntriesMessage, SimpleSyncronizer } from "./sync/simple.js";
+import {
+	ConfirmEntriesMessage,
+	SYNC_MESSAGE_PRIORITY,
+	SimpleSyncronizer,
+} from "./sync/simple.js";
 import { groupByGid } from "./utils.js";
 
 const toLocalPublicSignKey = (
@@ -2918,7 +2922,7 @@ export class SharedLog<
 		)) {
 			message.reserved[0] |= EXCHANGE_HEADS_REPAIR_HINT;
 			await this.rpc.send(message, {
-				priority: 1,
+				priority: SYNC_MESSAGE_PRIORITY,
 				mode: new SilentDelivery({ to: [target], redundancy: 1 }),
 			});
 		}

--- a/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
+++ b/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
@@ -39,7 +39,10 @@ import {
 	emitSyncProfileEvent,
 	syncProfileStart,
 } from "./profile.js";
-import { SimpleSyncronizer } from "./simple.js";
+import {
+	SYNC_MESSAGE_PRIORITY,
+	SimpleSyncronizer,
+} from "./simple.js";
 
 export const logger = loggerFn("peerbit:shared-log:rateless");
 
@@ -1258,7 +1261,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 		const sendStartedAt = syncProfileStart(profile);
 		const sendResult = this.simple.rpc.send(startSync, {
 			mode: new SilentDelivery({ to: properties.targets, redundancy: 1 }),
-			priority: 1,
+			priority: SYNC_MESSAGE_PRIORITY,
 		});
 		if (profile) {
 			void Promise.resolve(sendResult).then(
@@ -1338,7 +1341,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 					}),
 					{
 						mode: new SilentDelivery({ to: [context.from!], redundancy: 1 }),
-						priority: 1,
+						priority: SYNC_MESSAGE_PRIORITY,
 					},
 				);
 				if (profile) {
@@ -1520,7 +1523,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				}),
 				{
 					mode: new SilentDelivery({ to: [context.from!], redundancy: 1 }),
-					priority: 1,
+					priority: SYNC_MESSAGE_PRIORITY,
 				},
 			);
 			if (profile) {
@@ -1557,7 +1560,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				}),
 				{
 					mode: new SilentDelivery({ to: [context.from!], redundancy: 1 }),
-					priority: 1,
+					priority: SYNC_MESSAGE_PRIORITY,
 				},
 			);
 			if (profile) {
@@ -1597,7 +1600,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				}),
 				{
 					mode: new SilentDelivery({ to: [context.from!], redundancy: 1 }),
-					priority: 1,
+					priority: SYNC_MESSAGE_PRIORITY,
 				},
 			);
 			if (profile) {

--- a/packages/programs/data/shared-log/src/sync/simple.ts
+++ b/packages/programs/data/shared-log/src/sync/simple.ts
@@ -121,6 +121,9 @@ const SESSION_POLL_INTERVAL_MS = 100;
 const DEFAULT_MAX_HASHES_PER_MESSAGE = 1_024;
 const DEFAULT_MAX_COORDINATES_PER_MESSAGE = 1_024;
 const DEFAULT_MAX_CONVERGENT_TRACKED_HASHES = 4_096;
+// Keep convergence sync above the default/background lane. Dropping it to
+// priority 0 lets repair traffic starve behind foreground work and breaks liveness.
+export const SYNC_MESSAGE_PRIORITY = 1;
 // Retry missing entry requests when the first response was lost (for example, due to
 // pubsub stream warmup). Keep it coarse-grained so we do not hammer the network under
 // large historical backfills.
@@ -556,7 +559,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				(promise, chunk) =>
 					promise.then(() =>
 						this.rpc.send(new RequestMaybeSync({ hashes: chunk }), {
-							priority: 1,
+							priority: SYNC_MESSAGE_PRIORITY,
 							mode: new SilentDelivery({
 								to: properties.targets,
 								redundancy: 1,
@@ -779,7 +782,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 						new RequestMaybeSyncCoordinate({ hashNumbers: chunk }),
 						{
 							mode: new SilentDelivery({ to, redundancy: 1 }),
-							priority: 1,
+							priority: SYNC_MESSAGE_PRIORITY,
 						},
 					);
 				}
@@ -790,7 +793,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				for (const chunk of chunks) {
 					await this.rpc.send(new ResponseMaybeSync({ hashes: chunk }), {
 						mode: new SilentDelivery({ to, redundancy: 1 }),
-						priority: 1,
+						priority: SYNC_MESSAGE_PRIORITY,
 					});
 				}
 			}

--- a/packages/programs/data/shared-log/test/sync-chunking.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-chunking.spec.ts
@@ -5,6 +5,7 @@ import {
 	RequestMaybeSync,
 	RequestMaybeSyncCoordinate,
 	ResponseMaybeSync,
+	SYNC_MESSAGE_PRIORITY,
 	SimpleSyncronizer,
 } from "../src/sync/simple.js";
 
@@ -35,6 +36,7 @@ describe("sync-chunking", () => {
 		expect(send.callCount).to.equal(3);
 		const sentHashes = send.getCalls().map((call) => {
 			const message = call.args[0];
+			expect(call.args[1].priority).to.equal(SYNC_MESSAGE_PRIORITY);
 			expect(message).to.be.instanceOf(RequestMaybeSync);
 			return (message as RequestMaybeSync).hashes;
 		});
@@ -67,6 +69,7 @@ describe("sync-chunking", () => {
 		expect(send.callCount).to.equal(3);
 		const sentCoordinates = send.getCalls().map((call) => {
 			const message = call.args[0];
+			expect(call.args[1].priority).to.equal(SYNC_MESSAGE_PRIORITY);
 			expect(message).to.be.instanceOf(RequestMaybeSyncCoordinate);
 			return (message as RequestMaybeSyncCoordinate).hashNumbers;
 		});
@@ -94,6 +97,10 @@ describe("sync-chunking", () => {
 
 		const sentHashMessages = send
 			.getCalls()
+			.filter((call) => {
+				expect(call.args[1].priority).to.equal(SYNC_MESSAGE_PRIORITY);
+				return true;
+			})
 			.map((call) => call.args[0])
 			.filter((message) => message instanceof ResponseMaybeSync);
 		expect(sentHashMessages).to.have.length(1);


### PR DESCRIPTION
Stacked on #795.

This demotes background shared-log sync traffic to the default background priority while leaving document foreground remote queries above it. The scheduler can still use all bandwidth when no higher-priority work exists, but query/collect traffic no longer sits behind rateless/simple repair messages under cold-start backfill pressure.

I ran:
- pnpm --filter @peerbit/shared-log run build
- pnpm --filter @peerbit/shared-log test -- --no-build --grep "sync-(chunking|repair-session|priority)"
- shared-log half of pnpm test:ci:part-6: 1516 passing; local proxy subcommand fails because @peerbit/shared-log-proxy has no node test files in this worktree