### PR TITLE
Route rust indexer through native facade

### DIFF
--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -2,39 +2,36 @@ import { BinaryWriter, deserialize, serialize } from "@dao-xyz/borsh";
 import * as types from "@peerbit/indexer-interface";
 import { createSnapshotFile, type SnapshotFile } from "./persistence.js";
 
-type NativeIndexStore<T extends Record<string, any>> = {
-	put: (key: string, id: types.IdKey, value: T) => void;
+type NativeRustIndex<T extends Record<string, any>> = {
+	put: (
+		key: string,
+		id: types.IdKey,
+		value: T,
+		fields: Uint8Array,
+	) => void;
 	get: (key: string) => [types.IdKey, T] | undefined;
-	get_many: (keys: string[]) => Array<[types.IdKey, T]>;
-	delete: (key: string) => boolean;
-	delete_many: (keys: string[]) => Array<[types.IdKey, T]>;
 	clear: () => void;
 	len: () => number;
 	entries: () => Array<[types.IdKey, T]>;
-};
-
-type NativeQueryPlanner = {
-	put_document: (id: string, fields: Uint8Array) => void;
-	delete_document: (id: string) => void;
-	clear: () => void;
-	len: () => number;
-	query: (query: Uint8Array, sort: Uint8Array) => string[];
+	query: (
+		query: Uint8Array,
+		sort: Uint8Array,
+	) => Array<[types.IdKey, T]>;
 	query_page: (
 		query: Uint8Array,
 		sort: Uint8Array,
 		offset: number,
 		limit: number,
-	) => string[];
+	) => Array<[types.IdKey, T]>;
 	count: (query: Uint8Array) => number;
 	sum: (query: Uint8Array, field: string) => [NativeSumKind, string];
-	delete_matching: (query: Uint8Array) => string[];
+	delete_matching: (query: Uint8Array) => Array<[types.IdKey, T]>;
 };
 
 type WasmModule = {
 	default: (input?: unknown) => Promise<unknown>;
 	initSync: (input?: unknown) => unknown;
-	NativeIndexStore: new <T extends Record<string, any>>() => NativeIndexStore<T>;
-	NativeQueryPlanner: new () => NativeQueryPlanner;
+	NativeRustIndex: new <T extends Record<string, any>>() => NativeRustIndex<T>;
 };
 
 type NativeValue =
@@ -640,8 +637,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 	implements types.Index<T, NestedType>
 {
 	private snapshotFile?: SnapshotFile;
-	private store?: NativeIndexStore<T>;
-	private planner?: NativeQueryPlanner;
+	private native?: NativeRustIndex<T>;
 	private indexByArr!: string[];
 	private properties!: types.IndexEngineInitProperties<T, NestedType>;
 	private persistQueue: Promise<void> = Promise.resolve();
@@ -672,8 +668,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		}
 
 		const wasm = await loadWasm();
-		this.store = new wasm.NativeIndexStore<T>();
-		this.planner = new wasm.NativeQueryPlanner();
+		this.native = new wasm.NativeRustIndex<T>();
 		this.snapshotFile = await createSnapshotFile(
 			this.directory,
 			this.path,
@@ -683,8 +678,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			for (const value of await this.snapshotFile.read(properties.schema)) {
 				const id = types.toId(types.extractFieldValue(value, this.indexByArr));
 				const storeKey = keyToStoreKey(id);
-				this.store.put(storeKey, id, value);
-				this.indexNativeDocument(storeKey, value);
+				this.putNativeDocument(storeKey, id, value);
 			}
 		}
 		return this;
@@ -694,7 +688,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		id: types.IdKey,
 		_options?: { shape: types.Shape },
 	): types.IndexedResult<T> | undefined {
-		const value = this.getStore().get(keyToStoreKey(id));
+		const value = this.getNative().get(keyToStoreKey(id));
 		if (!value) {
 			return;
 		}
@@ -710,8 +704,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		_options?: { replace?: boolean },
 	): Promise<void> {
 		const storeKey = keyToStoreKey(id);
-		this.getStore().put(storeKey, id, value);
-		this.indexNativeDocument(storeKey, value);
+		this.putNativeDocument(storeKey, id, value);
 		this.markDirty();
 	}
 
@@ -719,11 +712,8 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		const compiled = this.requireNativePlan(types.toQuery(query.query), {
 			allowAll: true,
 		});
-		const storeKeys = this.getPlanner().delete_matching(
-			encodeNativeQuerySpec(compiled.spec),
-		);
-		const deleted = this.getStore()
-			.delete_many(storeKeys)
+		const deleted = this.getNative()
+			.delete_matching(encodeNativeQuerySpec(compiled.spec))
 			.map((entry) => entry[0]);
 		if (deleted.length > 0) {
 			this.markDirty();
@@ -732,7 +722,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 	}
 
 	getSize(): number {
-		return this.getStore().len();
+		return this.getNative().len();
 	}
 
 	persisted(): boolean {
@@ -752,8 +742,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 	}
 
 	async drop(): Promise<void> {
-		this.store?.clear();
-		this.planner?.clear();
+		this.native?.clear();
 		this.persistedVersion = this.dirtyVersion;
 		await this.snapshotFile?.remove();
 	}
@@ -764,7 +753,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		});
 		const field = nativeFieldKey(Array.isArray(query.key) ? query.key : [query.key]);
 		return decodeNativeSum(
-			this.getPlanner().sum(encodeNativeQuerySpec(compiled.spec), field),
+			this.getNative().sum(encodeNativeQuerySpec(compiled.spec), field),
 		);
 	}
 
@@ -888,7 +877,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 	}
 
 	private countNativePlan(compiled: NativeQueryCompileResult): number {
-		return this.getPlanner().count(encodeNativeQuerySpec(compiled.spec));
+		return this.getNative().count(encodeNativeQuerySpec(compiled.spec));
 	}
 
 	private getNativeCandidatesForPlan(
@@ -896,53 +885,46 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 	): types.IndexedValue<T>[] {
 		const queryBytes = encodeNativeQuerySpec(page.compiled.spec);
 		const sortBytes = encodeNativeSort(page.sort);
-		const storeKeys =
+		const results =
 			page.limit == null
-				? this.getPlanner().query(queryBytes, sortBytes)
-				: this.getPlanner().query_page(
+				? this.getNative().query(queryBytes, sortBytes)
+				: this.getNative().query_page(
 						queryBytes,
 						sortBytes,
 						page.offset,
 						page.limit,
 					);
-		return this.getStore()
-			.get_many(storeKeys)
-			.map((value) => ({ id: value[0], value: value[1] }));
+		return results.map((value) => ({ id: value[0], value: value[1] }));
 	}
 
-	private indexNativeDocument(storeKey: string, value: T): void {
-		this.getPlanner().put_document(
+	private putNativeDocument(storeKey: string, id: types.IdKey, value: T): void {
+		this.getNative().put(
 			storeKey,
+			id,
+			value,
 			encodeNativeFieldFacts(collectNativeFieldFacts(value)),
 		);
 	}
 
 	private snapshot(): types.IndexedValue<T>[] {
-		return this.getStore()
+		return this.getNative()
 			.entries()
 			.map((entry) => {
 				return { id: entry[0], value: entry[1] };
 			});
 	}
 
-	private getStore(): NativeIndexStore<T> {
-		if (!this.store) {
+	private getNative(): NativeRustIndex<T> {
+		if (!this.native) {
 			throw new Error("Index has not been initialized");
 		}
-		return this.store;
-	}
-
-	private getPlanner(): NativeQueryPlanner {
-		if (!this.planner) {
-			throw new Error("Index has not been initialized");
-		}
-		return this.planner;
+		return this.native;
 	}
 
 	private async persistSnapshot(): Promise<void> {
 		if (
 			!this.snapshotFile ||
-			!this.store ||
+			!this.native ||
 			this.persistedVersion === this.dirtyVersion
 		) {
 			return;

--- a/packages/utils/indexer/rust/src/lib.rs
+++ b/packages/utils/indexer/rust/src/lib.rs
@@ -44,16 +44,8 @@ impl NativeIndexStore {
     }
 
     pub fn get_many(&self, keys: Array) -> Array {
-        let entries = Array::new();
-        for key in keys.iter() {
-            let Some(key) = key.as_string() else {
-                continue;
-            };
-            if let Some(entry) = self.entries.get(&key) {
-                entries.push(&entry_to_js(entry));
-            }
-        }
-        entries
+        let keys: Vec<_> = keys.iter().filter_map(|key| key.as_string()).collect();
+        self.entries_for_keys(&keys)
     }
 
     pub fn delete(&mut self, key: &str) -> bool {
@@ -61,16 +53,8 @@ impl NativeIndexStore {
     }
 
     pub fn delete_many(&mut self, keys: Array) -> Array {
-        let entries = Array::new();
-        for key in keys.iter() {
-            let Some(key) = key.as_string() else {
-                continue;
-            };
-            if let Some(entry) = self.entries.shift_remove(&key) {
-                entries.push(&entry_to_js(&entry));
-            }
-        }
-        entries
+        let keys: Vec<_> = keys.iter().filter_map(|key| key.as_string()).collect();
+        self.delete_keys(&keys)
     }
 
     pub fn clear(&mut self) {
@@ -85,6 +69,28 @@ impl NativeIndexStore {
         let entries = Array::new();
         for entry in self.entries.values() {
             entries.push(&entry_to_js(entry));
+        }
+        entries
+    }
+}
+
+impl NativeIndexStore {
+    fn entries_for_keys(&self, keys: &[String]) -> Array {
+        let entries = Array::new();
+        for key in keys {
+            if let Some(entry) = self.entries.get(key) {
+                entries.push(&entry_to_js(entry));
+            }
+        }
+        entries
+    }
+
+    fn delete_keys(&mut self, keys: &[String]) -> Array {
+        let entries = Array::new();
+        for key in keys {
+            if let Some(entry) = self.entries.shift_remove(key) {
+                entries.push(&entry_to_js(&entry));
+            }
         }
         entries
     }
@@ -164,6 +170,90 @@ impl NativeQueryPlanner {
         let query = decode_query(&query_bytes)?;
         let ids = self.index.delete_matching(&query);
         Ok(ids_to_js(ids))
+    }
+}
+
+#[wasm_bindgen]
+pub struct NativeRustIndex {
+    store: NativeIndexStore,
+    planner: NativeQueryPlanner,
+}
+
+#[wasm_bindgen]
+impl NativeRustIndex {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> NativeRustIndex {
+        NativeRustIndex {
+            store: NativeIndexStore::new(),
+            planner: NativeQueryPlanner::new(),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.store.clear();
+        self.planner.clear();
+    }
+
+    pub fn len(&self) -> usize {
+        self.store.len()
+    }
+
+    pub fn put(
+        &mut self,
+        key: String,
+        id: JsValue,
+        value: JsValue,
+        fields_bytes: Vec<u8>,
+    ) -> Result<(), JsValue> {
+        let fields = decode_document_fields(&fields_bytes)?;
+        self.store.put(key.clone(), id, value);
+        self.planner.index.put(key, fields);
+        Ok(())
+    }
+
+    pub fn get(&self, key: &str) -> JsValue {
+        self.store.get(key)
+    }
+
+    pub fn entries(&self) -> Array {
+        self.store.entries()
+    }
+
+    pub fn query(&self, query_bytes: Vec<u8>, sort_bytes: Vec<u8>) -> Result<Array, JsValue> {
+        let query = decode_query(&query_bytes)?;
+        let sort = decode_sort(&sort_bytes)?;
+        let keys = self.planner.index.search(&query, &sort, None);
+        Ok(self.store.entries_for_keys(&keys))
+    }
+
+    pub fn query_page(
+        &self,
+        query_bytes: Vec<u8>,
+        sort_bytes: Vec<u8>,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Array, JsValue> {
+        let query = decode_query(&query_bytes)?;
+        let sort = decode_sort(&sort_bytes)?;
+        let keys = self
+            .planner
+            .index
+            .search_page(&query, &sort, offset, Some(limit));
+        Ok(self.store.entries_for_keys(&keys))
+    }
+
+    pub fn count(&self, query_bytes: Vec<u8>) -> Result<usize, JsValue> {
+        self.planner.count(query_bytes)
+    }
+
+    pub fn sum(&self, query_bytes: Vec<u8>, field: String) -> Result<Array, JsValue> {
+        self.planner.sum(query_bytes, field)
+    }
+
+    pub fn delete_matching(&mut self, query_bytes: Vec<u8>) -> Result<Array, JsValue> {
+        let query = decode_query(&query_bytes)?;
+        let keys = self.planner.index.delete_matching(&query);
+        Ok(self.store.delete_keys(&keys))
     }
 }
 


### PR DESCRIPTION
## Summary

Stacked on #796.

This adds a `NativeRustIndex` facade that owns both the native store and native query planner, then routes the Peerbit TS wrapper through that single object.

The Peerbit index path now uses one native object for:

- snapshot restore indexing
- `put`
- query result materialization, including sorted pages
- query deletes
- `count` / `sum`
- snapshot enumeration / size / clear

The older exported `NativeIndexStore` and `NativeQueryPlanner` remain available for now, but the actual `RustIndex` wrapper no longer shuttles planner keys through JS to another native object.

## Why

After #796, result row lookup was batched, but TS still had to call planner, receive store keys in JS, and then call back into the native store. This PR removes that split for the production wrapper so query planning and row materialization stay inside Rust for each operation.

## Validation

- `cargo fmt && cargo test`
- `pnpm --filter @peerbit/indexer-rust lint`
- `pnpm --filter @peerbit/indexer-rust test`
- `pnpm --filter @peerbit/indexer-rust benchmark`

Benchmark highlights versus #796 on the same existing suite:

- `number query fetch 10 - transient`: `15,096 ns` -> `10,894 ns` (~28% faster)
- `number query fetch 10 - persist`: `16,591 ns` -> `12,336 ns` (~26% faster)
- `string query matching - transient`: `68,794 ns` -> `61,320 ns` (~11% faster)
- `bool query fetch 10 - transient`: `5,367,347 ns` -> `3,896,186 ns` (~27% faster)
- `non bool query fetch with sort 10 - transient`: `2,050,224 ns` -> `1,954,628 ns` (~5% faster)
- `nested bool query - persist`: `5,300,224 ns` -> `4,022,555 ns` (~24% faster)

Some persistent bool/sorted rows were roughly flat to slightly slower in this run, so the practical claim here is narrower: the facade removes the avoidable JS/native object handoff and improves several fetch-heavy rows, while keeping conformance green across Node/browser/webworker.
