### PR TITLE
feat: add rust peerbit options helper

### DIFF
--- a/docs/topics/rust-storage-indexer/README.md
+++ b/docs/topics/rust-storage-indexer/README.md
@@ -1,0 +1,48 @@
+# Rust Storage And Indexer
+
+Peerbit can opt into the experimental Rust-backed key/value store and indexer
+without changing the default SQLite/Level-backed client setup.
+
+```ts
+import { Peerbit } from "peerbit";
+import { createRustPeerbitOptions } from "peerbit/rust";
+
+const peer = await Peerbit.create({
+	directory: "./peerbit-data",
+	...createRustPeerbitOptions(),
+});
+```
+
+`createRustPeerbitOptions()` wires the client cache, keychain store, block store,
+and root indexer to the Rust-backed implementations:
+
+- `@peerbit/any-store-rust` for Peerbit `AnyStore` instances.
+- `@peerbit/indexer-rust` for the client-wide indexer.
+- Shared-log programs still use their own log configuration, but the shared-log
+  package enables the optional native log graph when `@peerbit/log-rust` is
+  available.
+
+The helper is exported from `peerbit/rust` so regular `peerbit` imports do not
+load the Rust/WASM packages unless the application opts in.
+
+## Options
+
+```ts
+const peer = await Peerbit.create({
+	directory: "./peerbit-data",
+	...createRustPeerbitOptions({
+		storage: {
+			default: { durability: "normal" },
+			blocks: { durability: "normal" },
+			keychain: { durability: "strict" },
+		},
+		indexer: {
+			persistence: { durability: "normal" },
+		},
+	}),
+});
+```
+
+Use `strict` durability only where the caller needs each write flushed before
+its promise resolves. `normal` durability keeps the WAL append path fast and
+compacts snapshots during normal lifecycle operations.

--- a/packages/clients/peerbit/package.json
+++ b/packages/clients/peerbit/package.json
@@ -34,6 +34,10 @@
 		".": {
 			"types": "./dist/src/index.d.ts",
 			"import": "./dist/src/index.js"
+		},
+		"./rust": {
+			"types": "./dist/src/rust.d.ts",
+			"import": "./dist/src/rust.js"
 		}
 	},
 	"eslintConfig": {
@@ -78,10 +82,12 @@
 		"@multiformats/multiaddr": "^13.0.1",
 		"@peerbit/any-store": "workspace:*",
 		"@peerbit/any-store-opfs": "workspace:*",
+		"@peerbit/any-store-rust": "workspace:*",
 		"@peerbit/blocks": "workspace:*",
 		"@peerbit/build-assets": "workspace:*",
 		"@peerbit/crypto": "workspace:*",
 		"@peerbit/indexer-interface": "workspace:*",
+		"@peerbit/indexer-rust": "workspace:*",
 		"@peerbit/indexer-simple": "workspace:*",
 		"@peerbit/indexer-sqlite3": "workspace:*",
 		"@peerbit/keychain": "workspace:*",

--- a/packages/clients/peerbit/src/rust.ts
+++ b/packages/clients/peerbit/src/rust.ts
@@ -1,0 +1,51 @@
+import {
+	createStore as createRustStore,
+	type RustAnyStoreOptions,
+} from "@peerbit/any-store-rust";
+import {
+	create as createRustIndexer,
+	type RustIndexerOptions,
+} from "@peerbit/indexer-rust";
+import type {
+	CreateInstanceOptions,
+	StorageCreateOptions,
+	StoreFactory,
+} from "./peer.js";
+
+export type PeerbitRustStorageOptions = {
+	default?: RustAnyStoreOptions;
+	blocks?: RustAnyStoreOptions;
+	keychain?: RustAnyStoreOptions;
+};
+
+export type PeerbitRustOptions = {
+	storage?: PeerbitRustStorageOptions;
+	indexer?: RustIndexerOptions;
+};
+
+export type PeerbitRustCreateOptions = {
+	storage: StorageCreateOptions;
+	indexer: NonNullable<CreateInstanceOptions["indexer"]>;
+};
+
+const createRustStoreFactory =
+	(options: RustAnyStoreOptions | undefined): StoreFactory =>
+	(directory) =>
+		createRustStore(directory, options);
+
+export const createRustStorageOptions = (
+	options: PeerbitRustStorageOptions = {},
+): StorageCreateOptions => ({
+	storeFactory: createRustStoreFactory(options.default),
+	blocksStoreFactory: createRustStoreFactory(options.blocks ?? options.default),
+	keychainStoreFactory: createRustStoreFactory(
+		options.keychain ?? options.default,
+	),
+});
+
+export const createRustPeerbitOptions = (
+	options: PeerbitRustOptions = {},
+): PeerbitRustCreateOptions => ({
+	storage: createRustStorageOptions(options.storage),
+	indexer: (directory) => createRustIndexer(directory, options.indexer),
+});

--- a/packages/clients/peerbit/test/create.ts
+++ b/packages/clients/peerbit/test/create.ts
@@ -1,11 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 import { keys } from "@libp2p/crypto";
 import { createStore } from "@peerbit/any-store";
+import { RustAnyStore } from "@peerbit/any-store-rust";
 import { Ed25519Keypair } from "@peerbit/crypto";
+import { RustIndices } from "@peerbit/indexer-rust";
 import { expect } from "chai";
 import path from "path";
 import { v4 as uuid } from "uuid";
 import { Peerbit } from "../src/peer.js";
+import { createRustPeerbitOptions } from "../src/rust.js";
 
 describe("Create", function () {
 	describe("with db", function () {
@@ -57,6 +60,26 @@ describe("Create", function () {
 		expect(directories).to.include(path.join(clientDirectory, "/cache"));
 		expect(directories).to.include(path.join(clientDirectory, "/keychain"));
 		expect(directories).to.include(path.join(clientDirectory, "/blocks"));
+		await client.stop();
+	});
+
+	it("can create with the rust storage preset", async () => {
+		const clientDirectory = path.join(
+			"tmp",
+			"peerbit",
+			"tests",
+			"create-rust-preset-" + uuid(),
+		);
+		const client = await Peerbit.create({
+			directory: clientDirectory,
+			...createRustPeerbitOptions(),
+		});
+
+		expect(client.storage).to.be.instanceOf(RustAnyStore);
+		expect(client.indexer).to.be.instanceOf(RustIndices);
+		expect(await client.storage.persisted()).to.be.true;
+		expect(await client.indexer.persisted()).to.be.true;
+		expect(await client.libp2p.services.blocks.persisted()).to.be.true;
 		await client.stop();
 	});
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,6 +370,9 @@ importers:
       '@peerbit/any-store-opfs':
         specifier: workspace:*
         version: link:../../utils/any-store/opfs
+      '@peerbit/any-store-rust':
+        specifier: workspace:*
+        version: link:../../utils/any-store/rust
       '@peerbit/blocks':
         specifier: workspace:*
         version: link:../../transport/blocks
@@ -382,6 +385,9 @@ importers:
       '@peerbit/indexer-interface':
         specifier: workspace:*
         version: link:../../utils/indexer/interface
+      '@peerbit/indexer-rust':
+        specifier: workspace:*
+        version: link:../../utils/indexer/rust
       '@peerbit/indexer-simple':
         specifier: workspace:*
         version: link:../../utils/indexer/simple
@@ -1007,10 +1013,6 @@ importers:
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
-    optionalDependencies:
-      '@peerbit/log-rust':
-        specifier: workspace:*
-        version: link:rust
     devDependencies:
       '@peerbit/test-utils':
         specifier: workspace:*
@@ -1033,6 +1035,10 @@ importers:
       tty-table:
         specifier: ^4.2.1
         version: 4.2.3
+    optionalDependencies:
+      '@peerbit/log-rust':
+        specifier: workspace:*
+        version: link:rust
 
   packages/log/rust: {}
 


### PR DESCRIPTION
## Summary
- Adds a `peerbit/rust` subpath with `createRustPeerbitOptions()` and `createRustStorageOptions()` so apps can opt into Rust storage and the Rust indexer from one place.
- Keeps default `peerbit` imports/defaults unchanged; Rust/WASM packages are behind the subpath helper.
- Documents the opt-in setup and durability options.

## Stack
- Base: #801 (`feat/any-store-rust`)
- This is stack step 1: productize the opt-in path.

## Verification
- `pnpm --filter peerbit run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/clients/peerbit -- -t node --grep "rust storage preset|local store factory|sqlite indexer by default"`
- `node --input-type=module -e "import { createRustPeerbitOptions } from './packages/clients/peerbit/dist/src/rust.js'; console.log(typeof createRustPeerbitOptions)"`

## Notes
- `pnpm --filter peerbit run lint` currently fails on pre-existing style issues across `packages/clients/peerbit/src/*`; not introduced by this PR.