### PR TITLE
test: cover rust any-store opfs batches

### DIFF
--- a/packages/utils/any-store/rust/e2e/src/main.ts
+++ b/packages/utils/any-store/rust/e2e/src/main.ts
@@ -2,6 +2,8 @@ type WorkerRequest =
 	| { op: "open"; directory: string }
 	| { op: "close" | "listKeys" | "size" | "clear" }
 	| { op: "put" | "get" | "del" | "writeOpfsFile"; key: string; value?: string }
+	| { op: "putMany"; entries: [string, string][] }
+	| { op: "getMany" | "delMany"; keys: string[] }
 	| { op: "subPut" | "subGet"; level: string; key: string; value?: string };
 
 type WorkerResponse =

--- a/packages/utils/any-store/rust/e2e/src/worker.ts
+++ b/packages/utils/any-store/rust/e2e/src/worker.ts
@@ -6,6 +6,8 @@ type WorkerRequest = {
 	directory?: string;
 	level?: string;
 	key?: string;
+	keys?: string[];
+	entries?: [string, string][];
 	value?: string;
 };
 
@@ -85,6 +87,19 @@ const handle = async (message: WorkerRequest): Promise<unknown> => {
 	if (message.op === "del") {
 		await requireStore().del(message.key!);
 		return undefined;
+	}
+	if (message.op === "putMany") {
+		await requireStore().putMany(
+			message.entries!.map(([key, value]) => [key, encoder.encode(value)]),
+		);
+		return undefined;
+	}
+	if (message.op === "getMany") {
+		const values = await requireStore().getMany(message.keys!);
+		return values.map((bytes) => (bytes ? decoder.decode(bytes) : undefined));
+	}
+	if (message.op === "delMany") {
+		return requireStore().delMany(message.keys!);
 	}
 	if (message.op === "subPut") {
 		const sublevel = await getSublevel(message.level!);

--- a/packages/utils/any-store/rust/e2e/tests/opfs.spec.ts
+++ b/packages/utils/any-store/rust/e2e/tests/opfs.spec.ts
@@ -113,6 +113,79 @@ test.describe("any-store-rust OPFS", () => {
 		});
 	});
 
+	test("persists batched mutations across worker reloads", async ({
+		page,
+	}, testInfo) => {
+		await page.goto("/");
+		await expect(page.getByTestId("status")).toHaveText("ready");
+
+		const directory = testDirectory(testInfo.workerIndex);
+		const entries = Array.from({ length: 128 }, (_, index) => [
+			`batch-${index}`,
+			`value-${index}`,
+		] as [string, string]);
+
+		const putElapsedMs = await page.evaluate(
+			async ({ directory, entries }) => {
+				const api = (window as any).__rustAnyStoreTest;
+				await api.request({ op: "open", directory });
+				const started = performance.now();
+				await api.request({ op: "putMany", entries });
+				const elapsed = performance.now() - started;
+				await api.request({ op: "close" });
+				await api.restartWorker();
+				return elapsed;
+			},
+			{ directory, entries },
+		);
+		expect(putElapsedMs).toBeGreaterThan(0);
+
+		await page.evaluate(async (directory) => {
+			const api = (window as any).__rustAnyStoreTest;
+			await api.request({ op: "open", directory });
+		}, directory);
+		expect(
+			await page.evaluate((keys) => {
+				const api = (window as any).__rustAnyStoreTest;
+				return api.request({ op: "getMany", keys });
+			}, entries.map(([key]) => key)),
+		).toEqual(entries.map(([, value]) => value));
+		expect(
+			await page.evaluate((keys) => {
+				const api = (window as any).__rustAnyStoreTest;
+				return api.request({ op: "delMany", keys });
+			}, entries.slice(0, 16).map(([key]) => key)),
+		).toBe(16);
+		await page.evaluate(async () => {
+			const api = (window as any).__rustAnyStoreTest;
+			await api.request({ op: "close" });
+			await api.restartWorker();
+		});
+
+		await page.evaluate(async (directory) => {
+			const api = (window as any).__rustAnyStoreTest;
+			await api.request({ op: "open", directory });
+		}, directory);
+		expect(
+			await page.evaluate((keys) => {
+				const api = (window as any).__rustAnyStoreTest;
+				return api.request({ op: "getMany", keys });
+			}, entries.slice(0, 20).map(([key]) => key)),
+		).toEqual([
+			...Array.from({ length: 16 }, () => undefined),
+			"value-16",
+			"value-17",
+			"value-18",
+			"value-19",
+		]);
+
+		await page.evaluate(async () => {
+			const api = (window as any).__rustAnyStoreTest;
+			await api.request({ op: "clear" });
+			await api.request({ op: "close" });
+		});
+	});
+
 	test("falls back when the newest manifest points at an incomplete checkpoint", async ({
 		page,
 	}, testInfo) => {


### PR DESCRIPTION
## Summary
- Extends the any-store Rust OPFS worker harness with `putMany`, `getMany`, and `delMany`.
- Adds a browser-worker persistence test that writes a batch, reloads the worker, verifies values, deletes a subset with `delMany`, reloads again, and verifies the journaled deletes.

## Stack
- Base: #802 (`feat/rust-peerbit-options`)
- This is stack step 2: browser/OPFS coverage for the Rust storage batch paths.

## Verification
- `pnpm --filter @peerbit/any-store-rust run build`
- `pnpm --filter @peerbit/any-store-rust run test:e2e`