### PR TITLE
feat: expose block batch helpers

### DIFF
--- a/packages/transport/blocks/src/any-blockstore.ts
+++ b/packages/transport/blocks/src/any-blockstore.ts
@@ -2,6 +2,7 @@ import { createStore } from "@peerbit/any-store";
 import { type AnyStore } from "@peerbit/any-store-interface";
 import {
 	type Blocks,
+	type GetOptions,
 	calculateRawCid,
 	cidifyString,
 	codecCodes,
@@ -25,6 +26,27 @@ export class AnyBlockStore implements Blocks {
 		this._store = store;
 	}
 
+	private async decodeStoredBytes(
+		cid: string,
+		bytes: Uint8Array,
+		options?: { hasher?: any },
+	): Promise<Uint8Array> {
+		const cidObject = cidifyString(cid);
+		if (
+			cidObject.code === raw.code &&
+			(options?.hasher == null || options.hasher === defaultHasher)
+		) {
+			return bytes;
+		}
+		const codec = (codecCodes as any)[cidObject.code];
+		const block = await decode({
+			bytes,
+			codec,
+			hasher: options?.hasher || defaultHasher,
+		});
+		return (block as Block<Uint8Array, any, any, any>).bytes;
+	}
+
 	async get(
 		cid: string,
 		options?: {
@@ -36,31 +58,48 @@ export class AnyBlockStore implements Blocks {
 			};
 		},
 	): Promise<Uint8Array | undefined> {
-		const cidObject = cidifyString(cid);
 		try {
 			const bytes = await this._store.get(cid);
 			if (!bytes) {
 				return undefined;
 			}
-			if (
-				cidObject.code === raw.code &&
-				(options?.hasher == null || options.hasher === defaultHasher)
-			) {
-				return bytes;
-			}
-			const codec = (codecCodes as any)[cidObject.code];
-			const block = await decode({
-				bytes,
-				codec,
-				hasher: options?.hasher || defaultHasher,
-			});
-			return (block as Block<Uint8Array, any, any, any>).bytes;
+			return this.decodeStoredBytes(cid, bytes, options);
 		} catch (error: any) {
 			if (
 				typeof error?.code === "string" &&
 				error?.code?.indexOf("LEVEL_NOT_FOUND") !== -1
 			) {
 				return undefined;
+			}
+			throw error;
+		}
+	}
+
+	async getMany(
+		cids: string[],
+		options?: GetOptions & { hasher?: any },
+	): Promise<Array<Uint8Array | undefined>> {
+		const store = this._store as AnyStore & {
+			getMany?: (keys: string[]) => Promise<Array<Uint8Array | undefined>>;
+		};
+		try {
+			if (typeof store.getMany === "function") {
+				const values = await store.getMany(cids);
+				return Promise.all(
+					values.map((bytes, index) =>
+						bytes
+							? this.decodeStoredBytes(cids[index]!, bytes, options)
+							: undefined,
+					),
+				);
+			}
+			return Promise.all(cids.map((cid) => this.get(cid, options as any)));
+		} catch (error: any) {
+			if (
+				typeof error?.code === "string" &&
+				error?.code?.indexOf("LEVEL_NOT_FOUND") !== -1
+			) {
+				return Promise.all(cids.map((cid) => this.get(cid, options as any)));
 			}
 			throw error;
 		}
@@ -127,6 +166,17 @@ export class AnyBlockStore implements Blocks {
 
 	async rm(cid: string): Promise<void> {
 		await this._store.del(cid);
+	}
+
+	async rmMany(cids: string[]): Promise<number> {
+		const store = this._store as AnyStore & {
+			delMany?: (keys: string[]) => Promise<number>;
+		};
+		if (typeof store.delMany === "function") {
+			return store.delMany(cids);
+		}
+		await Promise.all(cids.map((cid) => this._store.del(cid)));
+		return cids.length;
 	}
 
 	async *iterator(): AsyncGenerator<[string, Uint8Array], void, void> {

--- a/packages/transport/blocks/src/interface.ts
+++ b/packages/transport/blocks/src/interface.ts
@@ -1,10 +1,19 @@
 import type { MaybePromise } from "@peerbit/any-store-interface";
-import type { Blocks as IBlockStore } from "@peerbit/blocks-interface";
+import type { Blocks as IBlockStore, GetOptions } from "@peerbit/blocks-interface";
+import type { Block } from "multiformats/block";
 
 export type StoreStatus = MaybePromise<
 	"open" | "opening" | "closed" | "closing"
 >;
 export interface BlockStore extends IBlockStore {
+	putMany(
+		blocks: Array<Uint8Array | { block: Block<any, any, any, any>; cid: string }>,
+	): Promise<string[]>;
+	getMany(
+		cids: string[],
+		options?: GetOptions,
+	): Promise<Array<Uint8Array | undefined>>;
+	rmMany(cids: string[]): Promise<number | void>;
 	start(): Promise<void>;
 	stop(): Promise<void>;
 	status(): StoreStatus;

--- a/packages/transport/blocks/src/libp2p.ts
+++ b/packages/transport/blocks/src/libp2p.ts
@@ -130,6 +130,10 @@ export class DirectBlock extends DirectStream implements IBlocks {
 		return this.remoteBlocks.put(bytes);
 	}
 
+	async putMany(blocks: Uint8Array[]): Promise<string[]> {
+		return this.remoteBlocks.putMany(blocks);
+	}
+
 	async has(cid: string) {
 		return this.remoteBlocks.has(cid);
 	}
@@ -140,12 +144,23 @@ export class DirectBlock extends DirectStream implements IBlocks {
 		return this.remoteBlocks.get(cid, options);
 	}
 
+	async getMany(
+		cids: string[],
+		options?: GetOptions | undefined,
+	): Promise<Array<Uint8Array | undefined>> {
+		return this.remoteBlocks.getMany(cids, options);
+	}
+
 	hintProviders(cid: string, providers: string[]) {
 		this.remoteBlocks.hintProviders(cid, providers);
 	}
 
 	async rm(cid: string) {
 		return this.remoteBlocks.rm(cid);
+	}
+
+	async rmMany(cids: string[]) {
+		return this.remoteBlocks.rmMany(cids);
 	}
 
 	async *iterator(): AsyncGenerator<[string, Uint8Array], void, void> {

--- a/packages/transport/blocks/src/remote.ts
+++ b/packages/transport/blocks/src/remote.ts
@@ -324,6 +324,25 @@ export class RemoteBlocks implements IBlocks {
 		return cid;
 	}
 
+	async putMany(
+		blocks: Array<Uint8Array | { block: Block<any, any, any, any>; cid: string }>,
+	): Promise<string[]> {
+		if (!this.localStore) {
+			throw new Error("Local store not set");
+		}
+		const cids = await this.localStore.putMany(blocks);
+		await Promise.all(
+			cids.map(async (cid) => {
+				try {
+					await this.options.onPut?.(cid);
+				} catch {
+					// ignore best-effort hooks
+				}
+			}),
+		);
+		return cids;
+	}
+
 	async has(cid: string) {
 		return this.localStore.has(cid);
 	}
@@ -351,6 +370,16 @@ export class RemoteBlocks implements IBlocks {
 		return value;
 	}
 
+	async getMany(
+		cids: string[],
+		options?: GetOptions | undefined,
+	): Promise<Array<Uint8Array | undefined>> {
+		if (!options?.remote) {
+			return this.localStore.getMany(cids, options);
+		}
+		return Promise.all(cids.map((cid) => this.get(cid, options)));
+	}
+
 	hintProviders(cid: string, providers: string[]) {
 		const cidString = stringifyCid(cid);
 		this.rememberProviderHints(cidString, providers);
@@ -361,6 +390,10 @@ export class RemoteBlocks implements IBlocks {
 
 	async rm(cid: string) {
 		await this.localStore?.rm(cid);
+	}
+
+	async rmMany(cids: string[]) {
+		await this.localStore?.rmMany(cids);
 	}
 
 	async *iterator(): AsyncGenerator<[string, Uint8Array], void, void> {

--- a/packages/transport/blocks/test/level.spec.ts
+++ b/packages/transport/blocks/test/level.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import { createStore as createRustStore } from "@peerbit/any-store-rust";
 import { equals } from "uint8arrays";
 import { AnyBlockStore } from "../src/any-blockstore.js";
 
@@ -51,5 +52,20 @@ describe(`level`, function () {
 		expect(cids).to.have.length(2);
 		expect(await store.get(cids[0])).to.deep.equal(datas[0]);
 		expect(await store.get(cids[1])).to.deep.equal(datas[1]);
+	});
+
+	it("gets and removes many blocks through store batch helpers", async () => {
+		store = new AnyBlockStore(createRustStore());
+		await store.start();
+		const datas = [new Uint8Array([0]), new Uint8Array([1, 2])];
+		const cids = await store.putMany(datas);
+
+		expect(await store.getMany([...cids, "missing"])).to.deep.equal([
+			datas[0],
+			datas[1],
+			undefined,
+		]);
+		expect(await store.rmMany([cids[0], "missing"])).to.equal(1);
+		expect(await store.getMany(cids)).to.deep.equal([undefined, datas[1]]);
 	});
 });


### PR DESCRIPTION
## Summary
- Adds `getMany` and `rmMany` to `AnyBlockStore`, using underlying `AnyStore` batch helpers when available and falling back to per-CID operations otherwise.
- Exposes `putMany`, `getMany`, and `rmMany` through `RemoteBlocks` and `DirectBlock` for local batch paths.
- Adds coverage with `@peerbit/any-store-rust` to prove block batch reads/deletes use the Rust store helper path correctly.

## Stack
- Base: #803 (`feat/rust-opfs-coverage`)
- This is stack step 3: blockstore/KV batch surface on top of the Rust store work.

## Verification
- `pnpm --filter @peerbit/blocks run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/blocks -- -t node --grep "puts many blocks|gets and removes many|putMany\(\) after stop"`