### PR TITLE
Batch log append block writes

### DIFF
--- a/packages/log/src/entry-create.ts
+++ b/packages/log/src/entry-create.ts
@@ -26,6 +26,7 @@ export const createEntry = async <T>(properties: {
 	encoding?: Encoding<T>;
 	canAppend?: CanAppend<T>;
 	encryption?: EntryEncryption;
+	deferStore?: boolean;
 	identity: Identity;
 	signers?: ((
 		data: Uint8Array,

--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -412,6 +412,7 @@ export class EntryV0<T>
 		encoding?: Encoding<T>;
 		canAppend?: CanAppend<T>;
 		encryption?: EntryEncryption;
+		deferStore?: boolean;
 		identity: Identity;
 		signers?: ((
 			data: Uint8Array,
@@ -570,7 +571,9 @@ export class EntryV0<T>
 		}
 
 		// Append hash
-		entry.hash = await Entry.toMultihash(properties.store, entry);
+		entry.hash = properties.deferStore
+			? await Entry.prepareMultihash(entry)
+			: await Entry.toMultihash(properties.store, entry);
 
 		entry.init({ encoding: properties.encoding });
 

--- a/packages/log/src/entry.ts
+++ b/packages/log/src/entry.ts
@@ -1,5 +1,9 @@
 import { deserialize, serialize } from "@dao-xyz/borsh";
-import { type Blocks, type GetOptions } from "@peerbit/blocks-interface";
+import {
+	type Blocks,
+	type GetOptions,
+	calculateRawCid,
+} from "@peerbit/blocks-interface";
 import type { PublicSignKey, SignatureWithKey } from "@peerbit/crypto";
 import type { CryptoKeychain } from "@peerbit/keychain";
 import { LamportClock as Clock } from "./clock.js";
@@ -10,6 +14,9 @@ import type { Payload } from "./payload.js";
 
 export type CanAppend<T> = (canAppend: Entry<T>) => Promise<boolean> | boolean;
 export type ShallowOrFullEntry<T> = ShallowEntry | Entry<T>;
+export type PreparedEntryBlock = Awaited<ReturnType<typeof calculateRawCid>>;
+
+const preparedEntryBlocks = new WeakMap<object, PreparedEntryBlock>();
 
 interface Meta {
 	clock: Clock;
@@ -87,6 +94,26 @@ export abstract class Entry<T> {
 		const bytes = entry.getStorageBytes();
 		entry.size = bytes.length;
 		return store.put(bytes);
+	}
+
+	static async prepareMultihash<T>(entry: Entry<T>): Promise<string> {
+		if (entry.hash) {
+			throw new Error("Expected hash to be missing");
+		}
+
+		const bytes = entry.getStorageBytes();
+		entry.size = bytes.length;
+		const prepared = await calculateRawCid(bytes);
+		preparedEntryBlocks.set(entry, prepared);
+		return prepared.cid;
+	}
+
+	static takePreparedBlock<T>(entry: Entry<T>): PreparedEntryBlock | undefined {
+		const prepared = preparedEntryBlocks.get(entry);
+		if (prepared) {
+			preparedEntryBlocks.delete(entry);
+		}
+		return prepared;
 	}
 
 	static fromMultihash = async <T>(

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -33,7 +33,12 @@ import { ShallowEntry } from "./entry-shallow.js";
 import { EntryType } from "./entry-type.js";
 import { type EncryptionTemplateMaybeEncrypted, EntryV0 } from "./entry-v0.js";
 import { type EntryWithRefs } from "./entry-with-refs.js";
-import { type CanAppend, Entry, type ShallowOrFullEntry } from "./entry.js";
+import {
+	type CanAppend,
+	Entry,
+	type PreparedEntryBlock,
+	type ShallowOrFullEntry,
+} from "./entry.js";
 import { findUniques } from "./find-uniques.js";
 import * as LogError from "./log-errors.js";
 import * as Sorting from "./log-sorting.js";
@@ -41,6 +46,13 @@ import type { Payload } from "./payload.js";
 import { Trim, type TrimOptions } from "./trim.js";
 
 const { LastWriteWins } = Sorting;
+
+type BlocksWithPutMany = Blocks & {
+	putMany?: (blocks: PreparedEntryBlock[]) => Promise<string[]> | string[];
+};
+
+const hasPutMany = (storage: Blocks): storage is BlocksWithPutMany =>
+	typeof (storage as BlocksWithPutMany).putMany === "function";
 
 const getErrorName = (error: unknown) =>
 	typeof (error as { name?: unknown })?.name === "string"
@@ -602,14 +614,20 @@ export class Log<T> {
 			| PendingDelete<T>
 			| { entry: Entry<T>; fn: undefined }
 		)[] = [];
+		const deferBlockStore = hasPutMany(this._storage);
 
 		for (const item of data) {
-			const entry = await this.createAppendEntry(item, options, nexts);
+			const entry = await this.createAppendEntry(item, options, nexts, {
+				deferStore: deferBlockStore,
+			});
 			entries.push(entry);
 			nexts = [entry];
 		}
 
 		await this.joinMissingNexts(entries[0]!, initialNexts);
+		if (deferBlockStore) {
+			await this.putAppendEntryBlocks(entries);
+		}
 		await this.putAppendEntries(entries, options);
 
 		for (const entry of entries) {
@@ -668,6 +686,9 @@ export class Log<T> {
 		data: T,
 		options: AppendOptions<T>,
 		nexts: Sorting.SortableEntry[],
+		storeOptions?: {
+			deferStore?: boolean;
+		},
 	): Promise<Entry<T>> {
 		const clock = new Clock({
 			id: this._identity.publicKey.bytes,
@@ -696,6 +717,7 @@ export class Log<T> {
 					}
 				: undefined,
 			canAppend: options.canAppend || this._canAppend,
+			deferStore: storeOptions?.deferStore,
 		});
 
 		if (!entry.hash) {
@@ -744,7 +766,10 @@ export class Log<T> {
 		});
 	}
 
-	private async putAppendEntries(entries: Entry<T>[], options: AppendOptions<T>) {
+	private async putAppendEntries(
+		entries: Entry<T>[],
+		options: AppendOptions<T>,
+	) {
 		await this.entryIndex.putAppendBatch(entries, {
 			unique: true,
 			deferIndexWrite:
@@ -753,6 +778,27 @@ export class Log<T> {
 					? options.durability === "buffered"
 					: this._appendDurability === "buffered"),
 		});
+	}
+
+	private async putAppendEntryBlocks(entries: Entry<T>[]) {
+		const blocks: PreparedEntryBlock[] = [];
+		for (const entry of entries) {
+			const prepared = Entry.takePreparedBlock(entry);
+			if (!prepared) {
+				throw new Error("Missing prepared entry block");
+			}
+			blocks.push(prepared);
+		}
+
+		const cids = await (this._storage as BlocksWithPutMany).putMany!(blocks);
+		if (cids.length !== blocks.length) {
+			throw new Error("Unexpected block batch result length");
+		}
+		for (let i = 0; i < cids.length; i++) {
+			if (cids[i] !== blocks[i].cid) {
+				throw new Error("Unexpected block batch cid");
+			}
+		}
 	}
 
 	async remove(

--- a/packages/log/test/append.spec.ts
+++ b/packages/log/test/append.spec.ts
@@ -161,31 +161,50 @@ describe("append", function () {
 
 		const iterateSpy = sinon.spy(log.entryIndex.properties.index, "iterate");
 		const putSpy = sinon.spy(log.entryIndex.properties.index, "put");
-		const result = await log.appendMany([
-			new Uint8Array([1]),
-			new Uint8Array([2]),
-			new Uint8Array([3]),
-		]);
+		const blockPutSpy = sinon.spy(store, "put");
+		const blockPutManySpy = sinon.spy(store, "putMany");
 
-		expect(result.entries).to.have.length(3);
-		expect(result.entries[0].meta.next).to.deep.equal([root.hash]);
-		expect(result.entries[1].meta.next).to.deep.equal([result.entries[0].hash]);
-		expect(result.entries[2].meta.next).to.deep.equal([result.entries[1].hash]);
-		expect((await log.getHeads().all()).map((head) => head.hash)).to.deep.equal([
-			result.entries[2].hash,
-		]);
-		expect(changes).to.have.length(1);
-		expect(changes[0].added.map((added: any) => added.head)).to.deep.equal([
-			false,
-			false,
-			true,
-		]);
-		expect(iterateSpy.callCount).equal(0);
-		expect(putSpy.callCount).equal(result.entries.length + 1);
+		try {
+			const result = await log.appendMany([
+				new Uint8Array([1]),
+				new Uint8Array([2]),
+				new Uint8Array([3]),
+			]);
 
-		iterateSpy.restore();
-		putSpy.restore();
-		await log.close();
+			expect(result.entries).to.have.length(3);
+			expect(result.entries[0].meta.next).to.deep.equal([root.hash]);
+			expect(result.entries[1].meta.next).to.deep.equal([
+				result.entries[0].hash,
+			]);
+			expect(result.entries[2].meta.next).to.deep.equal([
+				result.entries[1].hash,
+			]);
+			for (const entry of result.entries) {
+				expect((await log.get(entry.hash))?.hash).equal(entry.hash);
+			}
+			expect(
+				(await log.getHeads().all()).map((head) => head.hash),
+			).to.deep.equal([result.entries[2].hash]);
+			expect(changes).to.have.length(1);
+			expect(changes[0].added.map((added: any) => added.head)).to.deep.equal([
+				false,
+				false,
+				true,
+			]);
+			expect(iterateSpy.callCount).equal(0);
+			expect(putSpy.callCount).equal(result.entries.length + 1);
+			expect(blockPutSpy.callCount).equal(0);
+			expect(blockPutManySpy.callCount).equal(1);
+			expect(blockPutManySpy.firstCall.args[0]).to.have.length(
+				result.entries.length,
+			);
+		} finally {
+			iterateSpy.restore();
+			putSpy.restore();
+			blockPutSpy.restore();
+			blockPutManySpy.restore();
+			await log.close();
+		}
 	});
 
 	describe("append 100 items to a log", () => {

--- a/packages/transport/blocks-interface/src/index.ts
+++ b/packages/transport/blocks-interface/src/index.ts
@@ -22,6 +22,9 @@ export interface Blocks extends WaitForPeer {
 	put(
 		data: Uint8Array | { block: Block<any, any, any, any>; cid: string },
 	): MaybePromise<string>;
+	putMany?(
+		data: Array<Uint8Array | { block: Block<any, any, any, any>; cid: string }>,
+	): MaybePromise<string[]>;
 	has(cid: string): MaybePromise<boolean>;
 	get(cid: string, options?: GetOptions): MaybePromise<Uint8Array | undefined>;
 	/**

--- a/packages/transport/blocks/src/libp2p.ts
+++ b/packages/transport/blocks/src/libp2p.ts
@@ -10,6 +10,7 @@ import {
 	type DataMessage,
 	type WaitForPeersFn,
 } from "@peerbit/stream-interface";
+import type { Block } from "multiformats/block";
 import { AnyBlockStore } from "./any-blockstore.js";
 import { BlockMessage, RemoteBlocks } from "./remote.js";
 
@@ -126,11 +127,17 @@ export class DirectBlock extends DirectStream implements IBlocks {
 			this.remoteBlocks.onReachable(evt.detail);
 	}
 
-	async put(bytes: Uint8Array): Promise<string> {
+	async put(
+		bytes: Uint8Array | { block: Block<any, any, any, any>; cid: string },
+	): Promise<string> {
 		return this.remoteBlocks.put(bytes);
 	}
 
-	async putMany(blocks: Uint8Array[]): Promise<string[]> {
+	async putMany(
+		blocks: Array<
+			Uint8Array | { block: Block<any, any, any, any>; cid: string }
+		>,
+	): Promise<string[]> {
 		return this.remoteBlocks.putMany(blocks);
 	}
 


### PR DESCRIPTION
## Summary
- defer appendMany entry block writes when the block store exposes putMany
- prepare raw entry blocks without changing entry hashes, then flush them before indexing
- add coverage that appendMany uses one block-store putMany and zero per-entry block puts

## Verification
- pnpm --filter @peerbit/blocks run build
- pnpm --filter @peerbit/blocks-interface run build
- pnpm --filter @peerbit/log run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "appendMany appends|native graph"

## Bench signal
Persistent Rust any-store, strict durability, nativeGraph=true, appendMany(5000):
- parent feat/blocks-batch-helpers: 28,798 ms, ~174 ops/sec
- this branch: 403 ms, ~12,404 ops/sec

The default in-memory native-graph benchmark stays roughly neutral/noisy because it does not exercise durable WAL batching.