### PR TITLE
Batch recursive join parent reads

### DIFF
--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -1092,6 +1092,8 @@ export class Log<T> {
 				options.remote && typeof options.remote === "object"
 					? options.remote
 					: undefined;
+			const parents: Array<{ hash: string; entry?: Entry<T> }> = [];
+			const unresolvedParentHashes: string[] = [];
 
 			for (const a of entry.meta.next) {
 				const prev = this._joining.get(a);
@@ -1103,18 +1105,50 @@ export class Log<T> {
 					continue;
 				}
 
-				const from = await options.resolveRemoteFrom?.(a, remote?.signal);
-				let nested: Entry<T>;
+				const referenced = options.references?.get(a);
+				parents.push({ hash: a, entry: referenced });
+				if (!referenced) {
+					unresolvedParentHashes.push(a);
+				}
+			}
+
+			const localParents =
+				unresolvedParentHashes.length > 0
+					? await this.entryIndex.getMany(unresolvedParentHashes, {
+							type: "full",
+							ignoreMissing: true,
+						})
+					: [];
+			const localParentByHash = new Map<string, Entry<T>>();
+			for (const parent of localParents) {
+				if (parent) {
+					localParentByHash.set(parent.hash, parent);
+				}
+			}
+
+			for (const parent of parents) {
+				const a = parent.hash;
+				const prev = this._joining.get(a);
+				if (prev) {
+					await prev;
+					continue;
+				}
+				if ((await this.entryIndex.getShallow(a)) != null && !options.reset) {
+					continue;
+				}
+
+				let nested = parent.entry ?? localParentByHash.get(a);
 				try {
-					nested =
-						options.references?.get(a) ??
-						(await Entry.fromMultihash<T>(this._storage, a, {
+					if (!nested) {
+						const from = await options.resolveRemoteFrom?.(a, remote?.signal);
+						nested = await Entry.fromMultihash<T>(this._storage, a, {
 							remote: {
 								timeout: remote?.timeout,
 								signal: remote?.signal,
 								...(from && from.length > 0 ? { from } : {}),
 							},
-						}));
+						});
+					}
 				} catch (error) {
 					if (isRecoverableJoinResolveError(error)) {
 						return false;

--- a/packages/log/test/join.spec.ts
+++ b/packages/log/test/join.spec.ts
@@ -1,3 +1,4 @@
+import { AnyBlockStore } from "@peerbit/blocks";
 import { Ed25519Keypair } from "@peerbit/crypto";
 import { TestSession } from "@peerbit/test-utils";
 import assert from "assert";
@@ -275,6 +276,49 @@ describe("join", function () {
 				new Uint8Array([1]),
 				new Uint8Array([2]),
 			]);
+		});
+
+		it("batches local parent reads while joining recursively", async () => {
+			const store = new AnyBlockStore();
+			await store.start();
+			const source = new Log<Uint8Array>();
+			const target = new Log<Uint8Array>();
+			try {
+				await source.open(store, signKey);
+				await target.open(store, signKey2);
+
+				const { entry: a } = await source.append(new Uint8Array([1]), {
+					meta: { next: [] },
+				});
+				const { entry: b } = await source.append(new Uint8Array([2]), {
+					meta: { next: [] },
+				});
+				const { entry: c } = await source.append(new Uint8Array([3]), {
+					meta: { next: [] },
+				});
+				const { entry: merge } = await source.append(new Uint8Array([4]), {
+					meta: { next: [a, b, c] },
+				});
+
+				const getManySpy = sinon.spy(store, "getMany");
+				try {
+					await target.join([merge]);
+
+					expect(getManySpy.callCount).equal(1);
+					expect(getManySpy.firstCall.args[0]).to.have.members([
+						a.hash,
+						b.hash,
+						c.hash,
+					]);
+					expect(await target.toArray()).to.have.length(4);
+				} finally {
+					getManySpy.restore();
+				}
+			} finally {
+				await source.close();
+				await target.close();
+				await store.stop();
+			}
 		});
 
 		describe("cut", () => {


### PR DESCRIPTION
## Summary
- prefetch missing local parent entries in joinRecursively with EntryIndex.getMany()
- keep remote fallback per hash for parents not found locally
- avoid resolveRemotePeers for parents already supplied as references or resolved locally
- add coverage for a merge entry with three missing local parents using one getMany()

## Verification
- pnpm --filter @peerbit/log run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "batches local parent reads|does not reject join when a nested entry block is temporarily missing|does not reject join when a hash head has a transient delivery failure|canAppend bottom first|joins with references"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "native graph|finds two heads|joins cut|batches local parent reads"

## Bench signal
Rust any-store transient, local wide-parent join:
- 1k parents: parent #806 ~229 ms, this branch ~199 ms
- 5k parents: parent #806 ~805 ms, this branch ~787 ms

This is a modest cleanup that reduces local parent block read call count before the existing remote fallback path.