### PR TITLE
Plan log joins in native graph

### DIFF
--- a/packages/log/benchmark/native-graph.ts
+++ b/packages/log/benchmark/native-graph.ts
@@ -1,6 +1,7 @@
 import { AnyBlockStore } from "@peerbit/blocks";
 import { Ed25519Keypair } from "@peerbit/crypto";
 import { HashmapIndices } from "@peerbit/indexer-simple";
+import { type Entry } from "../src/entry.js";
 import { Log } from "../src/log.js";
 
 type BenchRow = {
@@ -18,6 +19,9 @@ const iterations = Number(
 );
 const appendEntries = Number(
 	process.env.PEERBIT_LOG_NATIVE_GRAPH_APPEND_ENTRIES ?? 1_000,
+);
+const joinParents = Number(
+	process.env.PEERBIT_LOG_NATIVE_GRAPH_JOIN_PARENTS ?? entries,
 );
 
 const key = await Ed25519Keypair.create();
@@ -131,6 +135,58 @@ for (const nativeGraph of [false, true]) {
 			);
 		}),
 	);
+}
+
+const measureWideJoin = async (nativeGraph: boolean): Promise<BenchRow> => {
+	const store = new AnyBlockStore();
+	await store.start();
+	const source = new Log<Uint8Array>();
+	const target = new Log<Uint8Array>();
+	await source.open(store, key, {
+		appendDurability: "strict",
+		indexer: new HashmapIndices(),
+		nativeGraph,
+	});
+	await target.open(store, key, {
+		appendDurability: "strict",
+		indexer: new HashmapIndices(),
+		nativeGraph,
+	});
+
+	const parents: Entry<Uint8Array>[] = [];
+	for (let i = 0; i < joinParents; i++) {
+		parents.push(
+			(
+				await source.append(new Uint8Array([i & 0xff]), {
+					meta: { next: [] },
+				})
+			).entry,
+		);
+	}
+
+	await target.join(parents.slice(0, Math.floor(joinParents / 2)));
+	const { entry: merge } = await source.append(new Uint8Array([0xff]), {
+		meta: { next: parents },
+	});
+
+	const started = performance.now();
+	await target.join([merge]);
+	const elapsed = performance.now() - started;
+	await source.close();
+	await target.close();
+	await store.stop();
+	return {
+		name: "join wide merge parent planning",
+		nativeGraph,
+		entries: joinParents,
+		iterations: joinParents,
+		elapsedMs: Math.round(elapsed),
+		opsPerSecond: Math.round((joinParents / elapsed) * 1000),
+	};
+};
+
+for (const nativeGraph of [false, true]) {
+	rows.push(await measureWideJoin(nativeGraph));
 }
 
 for (const nativeGraph of [false, true]) {

--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -26,6 +26,18 @@ export type NativeLogHeadEntry = {
 	};
 };
 
+export type NativeLogJoinEntry = NativeLogHeadEntry & {
+	meta: NativeLogHeadEntry["meta"] & {
+		type: number;
+		next: string[];
+	};
+};
+
+export type NativeJoinPlan = {
+	skip: boolean;
+	missingParents: string[];
+};
+
 type NativeLogIndexHandle = {
 	clear: () => void;
 	len: () => number;
@@ -43,6 +55,7 @@ type NativeLogIndexHandle = {
 	delete: (hash: string) => boolean;
 	heads: (gid?: string) => string[];
 	head_entries: (gid?: string) => unknown[];
+	head_join_entries: (gid?: string) => unknown[];
 	children: (hash: string) => string[];
 	count_has_next: (next: string, excludeHash?: string) => number;
 	shadowed_gids: (
@@ -50,6 +63,12 @@ type NativeLogIndexHandle = {
 		next: string[],
 		excludeHash?: string,
 	) => string[];
+	plan_join: (
+		hash: string,
+		next: string[],
+		type: number,
+		reset: boolean,
+	) => [boolean, string[]];
 };
 
 type WasmModule = {
@@ -69,11 +88,14 @@ const loadWasm = async (): Promise<WasmModule> => {
 
 	const wasm = await wasmModulePromise;
 	if (!wasmInitialized) {
-		const processLike = (globalThis as { process?: { versions?: { node?: string } } })
-			.process;
+		const processLike = (
+			globalThis as { process?: { versions?: { node?: string } } }
+		).process;
 		if (processLike?.versions?.node) {
 			const fsPromises = "fs/promises";
-			const { readFile } = (await import(fsPromises)) as typeof import("fs/promises");
+			const { readFile } = (await import(
+				fsPromises
+			)) as typeof import("fs/promises");
 			const bytes = await readFile(
 				new URL("../wasm/log_rust_bg.wasm", import.meta.url),
 			);
@@ -153,6 +175,33 @@ export class LogGraphIndex {
 		});
 	}
 
+	joinHeadEntries(gid?: string): NativeLogJoinEntry[] {
+		return this.native.head_join_entries(gid).map((row) => {
+			const [hash, gid, wallTime, logical, type, next] = row as [
+				string,
+				string,
+				string,
+				number,
+				number,
+				string[],
+			];
+			return {
+				hash,
+				meta: {
+					gid,
+					type,
+					next,
+					clock: {
+						timestamp: {
+							wallTime: BigInt(wallTime),
+							logical,
+						},
+					},
+				},
+			};
+		});
+	}
+
 	children(hash: string): string[] {
 		return this.native.children(hash);
 	}
@@ -163,6 +212,21 @@ export class LogGraphIndex {
 
 	shadowedGids(gid: string, next: string[], excludeHash?: string): string[] {
 		return this.native.shadowed_gids(gid, next, excludeHash);
+	}
+
+	planJoin(
+		hash: string,
+		next: string[],
+		type: number,
+		reset = false,
+	): NativeJoinPlan {
+		const [skip, missingParents] = this.native.plan_join(
+			hash,
+			next,
+			type,
+			reset,
+		);
+		return { skip, missingParents };
 	}
 }
 

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -52,6 +52,12 @@ impl LogIndexEntry {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct JoinPlan {
+    pub skip: bool,
+    pub missing_parents: Vec<String>,
+}
+
 #[derive(Default)]
 pub struct LogGraphIndex {
     entries: IndexMap<String, LogIndexEntry>,
@@ -145,6 +151,10 @@ impl LogGraphIndex {
             .collect()
     }
 
+    pub fn head_join_entries(&self, gid: Option<&str>) -> Vec<LogIndexEntry> {
+        self.head_entries(gid)
+    }
+
     pub fn children(&self, hash: &str) -> Vec<String> {
         self.children
             .get(hash)
@@ -184,6 +194,30 @@ impl LogGraphIndex {
             }
         }
         shadowed.into_iter().collect()
+    }
+
+    pub fn plan_join(&self, hash: &str, nexts: &[String], entry_type: u8, reset: bool) -> JoinPlan {
+        if !reset && self.has(hash) {
+            return JoinPlan {
+                skip: true,
+                missing_parents: Vec::new(),
+            };
+        }
+
+        let missing_parents = if entry_type == ENTRY_TYPE_CUT {
+            Vec::new()
+        } else {
+            nexts
+                .iter()
+                .filter(|next| reset || !self.has(next))
+                .cloned()
+                .collect()
+        };
+
+        JoinPlan {
+            skip: false,
+            missing_parents,
+        }
     }
 
     fn set_head(&mut self, hash: &str, head: bool) {
@@ -317,6 +351,10 @@ impl NativeLogIndex {
         log_entries_to_rows(self.inner.head_entries(gid.as_deref()))
     }
 
+    pub fn head_join_entries(&self, gid: Option<String>) -> Array {
+        log_join_entries_to_rows(self.inner.head_join_entries(gid.as_deref()))
+    }
+
     pub fn children(&self, hash: &str) -> Array {
         strings_to_array(self.inner.children(hash))
     }
@@ -337,6 +375,19 @@ impl NativeLogIndex {
             &next,
             exclude_hash.as_deref(),
         )))
+    }
+
+    pub fn plan_join(
+        &self,
+        hash: &str,
+        next: Array,
+        entry_type: u8,
+        reset: bool,
+    ) -> Result<Array, JsValue> {
+        let next = strings_from_array(next)?;
+        Ok(join_plan_to_row(
+            self.inner.plan_join(hash, &next, entry_type, reset),
+        ))
     }
 }
 
@@ -378,9 +429,31 @@ fn log_entries_to_rows(values: Vec<LogIndexEntry>) -> Array {
     out
 }
 
+fn log_join_entries_to_rows(values: Vec<LogIndexEntry>) -> Array {
+    let out = Array::new();
+    for entry in values {
+        let row = Array::new();
+        row.push(&JsValue::from_str(&entry.hash));
+        row.push(&JsValue::from_str(&entry.gid));
+        row.push(&JsValue::from_str(&entry.wall_time.to_string()));
+        row.push(&JsValue::from_f64(entry.logical as f64));
+        row.push(&JsValue::from_f64(entry.entry_type as f64));
+        row.push(&strings_to_array(entry.next));
+        out.push(&row);
+    }
+    out
+}
+
+fn join_plan_to_row(plan: JoinPlan) -> Array {
+    let row = Array::new();
+    row.push(&JsValue::from_bool(plan.skip));
+    row.push(&strings_to_array(plan.missing_parents));
+    row
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{LogGraphIndex, LogIndexEntry};
+    use super::{JoinPlan, LogGraphIndex, LogIndexEntry};
 
     const APPEND: u8 = 0;
     const CUT: u8 = 1;
@@ -452,6 +525,27 @@ mod tests {
     }
 
     #[test]
+    fn returns_head_join_entries_for_cut_checks() {
+        let mut index = LogGraphIndex::new();
+        index.put(LogIndexEntry::new(
+            "cut",
+            "one",
+            vec!["a".to_string()],
+            CUT,
+            2,
+            0,
+            1,
+            true,
+        ));
+
+        let heads = index.head_join_entries(Some("one"));
+        assert_eq!(heads.len(), 1);
+        assert_eq!(heads[0].hash, "cut");
+        assert_eq!(heads[0].entry_type, CUT);
+        assert_eq!(heads[0].next, vec!["a".to_string()]);
+    }
+
+    #[test]
     fn cut_entries_do_not_demote_their_nexts() {
         let mut index = LogGraphIndex::new();
         index.put(entry("a", "g", &[], 1));
@@ -471,6 +565,46 @@ mod tests {
 
         assert!(index.delete("cut").is_some());
         assert_eq!(index.heads(None), vec!["a"]);
+    }
+
+    #[test]
+    fn plans_join_missing_parents() {
+        let mut index = LogGraphIndex::new();
+        index.put(entry("a", "g", &[], 1));
+
+        assert_eq!(
+            index.plan_join(
+                "b",
+                &["a".to_string(), "missing".to_string()],
+                APPEND,
+                false
+            ),
+            JoinPlan {
+                skip: false,
+                missing_parents: vec!["missing".to_string()]
+            }
+        );
+        assert_eq!(
+            index.plan_join("a", &[], APPEND, false),
+            JoinPlan {
+                skip: true,
+                missing_parents: Vec::new()
+            }
+        );
+        assert_eq!(
+            index.plan_join("a", &[], APPEND, true),
+            JoinPlan {
+                skip: false,
+                missing_parents: Vec::new()
+            }
+        );
+        assert_eq!(
+            index.plan_join("cut", &["missing".to_string()], CUT, false),
+            JoinPlan {
+                skip: false,
+                missing_parents: Vec::new()
+            }
+        );
     }
 
     #[test]

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { createLogGraphIndex, type NativeLogEntry } from "../src/index.js";
+import { type NativeLogEntry, createLogGraphIndex } from "../src/index.js";
 
 const APPEND = 0;
 const CUT = 1;
@@ -77,6 +77,27 @@ describe("native log graph index", () => {
 				},
 			},
 		]);
+
+		expect(index.joinHeadEntries("one")).to.deep.equal([
+			{
+				hash: "a",
+				meta: {
+					gid: "one",
+					type: APPEND,
+					next: [],
+					clock: { timestamp: { wallTime: 1n, logical: 0 } },
+				},
+			},
+			{
+				hash: "b",
+				meta: {
+					gid: "one",
+					type: APPEND,
+					next: [],
+					clock: { timestamp: { wallTime: 2n, logical: 0 } },
+				},
+			},
+		]);
 	});
 
 	it("does not demote nexts for cut entries", async () => {
@@ -99,5 +120,27 @@ describe("native log graph index", () => {
 
 		index.put(entry("c", "other", ["a"], 2n));
 		expect(index.shadowedGids("new", ["a"], "b")).to.deep.equal([]);
+	});
+
+	it("plans joins with missing parents", async () => {
+		const index = await createLogGraphIndex();
+		index.put(entry("a", "g", [], 1n));
+
+		expect(index.planJoin("b", ["a", "missing"], APPEND)).to.deep.equal({
+			skip: false,
+			missingParents: ["missing"],
+		});
+		expect(index.planJoin("a", [], APPEND)).to.deep.equal({
+			skip: true,
+			missingParents: [],
+		});
+		expect(index.planJoin("a", [], APPEND, true)).to.deep.equal({
+			skip: false,
+			missingParents: [],
+		});
+		expect(index.planJoin("cut", ["missing"], CUT)).to.deep.equal({
+			skip: false,
+			missingParents: [],
+		});
 	});
 });

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -64,8 +64,27 @@ export type NativeLogGraph = {
 	clear: () => void;
 	heads: (gid?: string) => string[];
 	headEntries: (gid?: string) => SortableEntry[];
+	joinHeadEntries: (gid?: string) => NativeLogJoinEntry[];
 	countHasNext: (next: string, excludeHash?: string) => number;
 	shadowedGids: (gid: string, next: string[], excludeHash?: string) => string[];
+	planJoin: (
+		hash: string,
+		next: string[],
+		type: number,
+		reset?: boolean,
+	) => JoinPlan;
+};
+
+export type JoinPlan = {
+	skip: boolean;
+	missingParents: string[];
+};
+
+export type NativeLogJoinEntry = SortableEntry & {
+	meta: SortableEntry["meta"] & {
+		type: EntryType;
+		next: string[];
+	};
 };
 
 type ResolveFullyOptions =
@@ -260,6 +279,21 @@ export class EntryIndex<T> {
 			return undefined;
 		}
 		return this.properties.nativeGraph.graph.headEntries(gid);
+	}
+
+	getJoinHeads(gid?: string): Promise<NativeLogJoinEntry[]> {
+		if (this.properties.nativeGraph?.useHeads) {
+			return Promise.resolve(
+				this.properties.nativeGraph.graph.joinHeadEntries(gid),
+			);
+		}
+		return this.getHeads(gid, {
+			type: "shape",
+			shape: {
+				hash: true,
+				meta: { type: true, next: true, gid: true, clock: true },
+			},
+		}).all() as Promise<NativeLogJoinEntry[]>;
 	}
 
 	getHasNext<R extends MaybeResolveOptions>(
@@ -512,6 +546,34 @@ export class EntryIndex<T> {
 
 	async getMany(k: string[], options?: ResolveFullyOptions) {
 		return this.resolveMany(k, options);
+	}
+
+	async planJoin(
+		entry: Pick<Entry<T>, "hash" | "meta">,
+		reset?: boolean,
+	): Promise<JoinPlan> {
+		if (this.properties.nativeGraph) {
+			return this.properties.nativeGraph.graph.planJoin(
+				entry.hash,
+				entry.meta.next,
+				entry.meta.type,
+				reset === true,
+			);
+		}
+		if (!reset && (await this.getShallow(entry.hash)) != null) {
+			return { skip: true, missingParents: [] };
+		}
+		if (entry.meta.type === EntryType.CUT) {
+			return { skip: false, missingParents: [] };
+		}
+
+		const missingParents: string[] = [];
+		for (const next of entry.meta.next) {
+			if (reset || (await this.getShallow(next)) == null) {
+				missingParents.push(next);
+			}
+		}
+		return { skip: false, missingParents };
 	}
 
 	async getShallow(k: string) {

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -585,10 +585,6 @@ export class EntryIndex<T> {
 	}
 
 	async has(k: string) {
-		let mem = this.cache.get(k);
-		if (mem) {
-			return true;
-		}
 		if (this.pendingIndexWrites.has(k)) {
 			return true;
 		}
@@ -603,7 +599,7 @@ export class EntryIndex<T> {
 		const existing = new Set<string>();
 		const missing: string[] = [];
 		for (const hash of new Set([...hashes].filter(Boolean))) {
-			if (this.cache.get(hash) || this.pendingIndexWrites.has(hash)) {
+			if (this.pendingIndexWrites.has(hash)) {
 				existing.add(hash);
 				continue;
 			}

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -1055,10 +1055,8 @@ export class Log<T> {
 			throw new Error("Unexpected");
 		}
 
-		if (
-			(await this.entryIndex.getShallow(entry.hash)) != null &&
-			!options.reset
-		) {
+		const joinPlan = await this.entryIndex.planJoin(entry, options.reset);
+		if (joinPlan.skip) {
 			return false;
 		}
 
@@ -1070,9 +1068,9 @@ export class Log<T> {
 			}
 		}
 
-		const headsWithGid: JoinableEntry[] = await this.entryIndex
-			.getHeads(entry.meta.gid, { type: "shape", shape: ENTRY_JOIN_SHAPE })
-			.all();
+		const headsWithGid: JoinableEntry[] = await this.entryIndex.getJoinHeads(
+			entry.meta.gid,
+		);
 		if (headsWithGid) {
 			for (const v of headsWithGid) {
 				// TODO second argument should be a time compare instead? what about next nexts?
@@ -1095,13 +1093,10 @@ export class Log<T> {
 			const parents: Array<{ hash: string; entry?: Entry<T> }> = [];
 			const unresolvedParentHashes: string[] = [];
 
-			for (const a of entry.meta.next) {
+			for (const a of joinPlan.missingParents) {
 				const prev = this._joining.get(a);
 				if (prev) {
 					await prev;
-					continue;
-				}
-				if ((await this.entryIndex.getShallow(a)) != null && !options.reset) {
 					continue;
 				}
 
@@ -1131,9 +1126,6 @@ export class Log<T> {
 				const prev = this._joining.get(a);
 				if (prev) {
 					await prev;
-					continue;
-				}
-				if ((await this.entryIndex.getShallow(a)) != null && !options.reset) {
 					continue;
 				}
 

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -110,6 +110,52 @@ describe("native graph", () => {
 		}
 	});
 
+	it("plans recursive joins through the native graph", async () => {
+		const source = new Log<Uint8Array>();
+		const target = new Log<Uint8Array>();
+
+		await source.open(store, signKey, { nativeGraph: true });
+		await target.open(store, signKey, { nativeGraph: true });
+
+		const { entry: present } = await source.append(new Uint8Array([1]), {
+			meta: { next: [] },
+		});
+		await target.join([present]);
+
+		const { entry: missing } = await source.append(new Uint8Array([2]), {
+			meta: { next: [] },
+		});
+		const { entry: merge } = await source.append(new Uint8Array([3]), {
+			meta: { next: [present, missing] },
+		});
+
+		const nativeGraph = target.entryIndex.properties.nativeGraph!.graph;
+		const planJoinSpy = sinon.spy(nativeGraph, "planJoin");
+		const getShallowSpy = sinon.spy(target.entryIndex, "getShallow");
+		try {
+			await target.join([merge]);
+
+			expect(planJoinSpy.callCount).greaterThan(0);
+			expect(planJoinSpy.firstCall.args).to.deep.equal([
+				merge.hash,
+				[present.hash, missing.hash],
+				merge.meta.type,
+				false,
+			]);
+			expect(planJoinSpy.firstCall.returnValue).to.deep.equal({
+				skip: false,
+				missingParents: [missing.hash],
+			});
+			expect(getShallowSpy.callCount).equal(0);
+			expect(await target.toArray()).to.have.length(3);
+		} finally {
+			getShallowSpy.restore();
+			planJoinSpy.restore();
+			await source.close();
+			await target.close();
+		}
+	});
+
 	it("keeps gid removal behavior when joins use the native graph mirror", async () => {
 		const source = new Log<Uint8Array>();
 		const target = new Log<Uint8Array>();


### PR DESCRIPTION
## Summary

- add a native log graph join planner that decides whether an incoming entry is already known and which parents are missing
- expose native join-head metadata so recursive join cut checks avoid round-tripping through the TS entry index when the native graph is enabled
- route `Log.joinRecursively()` through `EntryIndex.planJoin()` and keep the existing TS fallback for non-native graph users
- add a wide-merge native graph benchmark for recursive join parent planning

## Local benchmark signal

`PEERBIT_LOG_NATIVE_GRAPH_JOIN_PARENTS=1000 node packages/log/dist/benchmark/native-graph.js` on this machine:

- `join wide merge parent planning`, `nativeGraph=false`: 157 ms, ~6,358 parent refs/sec
- `join wide merge parent planning`, `nativeGraph=true`: 34 ms, ~29,797 parent refs/sec

That is about 4.7x faster for the benchmarked 1k-parent merge path.

## Validation

- `cargo test --manifest-path packages/log/rust/Cargo.toml`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log/rust -- -t node --grep "returns sortable head metadata|plans joins with missing parents"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "plans recursive joins through the native graph"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "native graph"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "batches local parent reads while joining recursively"`
- `pnpm --filter @peerbit/log-rust run lint`
- `pnpm exec eslint --config eslint.config.js packages/log/benchmark/native-graph.ts packages/log/src/entry-index.ts packages/log/src/log.ts packages/log/test/native-graph.spec.ts`
- `pnpm --filter @peerbit/log run build`

Note: full `pnpm --filter @peerbit/log run lint` is still blocked by pre-existing style errors in unrelated files such as `packages/log/src/change.ts` and `packages/log/src/clock.ts`.