### PR TITLE
Fold cut checks into native join planning

### DIFF
--- a/packages/log/benchmark/native-graph.ts
+++ b/packages/log/benchmark/native-graph.ts
@@ -1,6 +1,7 @@
 import { AnyBlockStore } from "@peerbit/blocks";
 import { Ed25519Keypair } from "@peerbit/crypto";
 import { HashmapIndices } from "@peerbit/indexer-simple";
+import { EntryType } from "../src/entry-type.js";
 import { type Entry } from "../src/entry.js";
 import { Log } from "../src/log.js";
 
@@ -187,6 +188,55 @@ const measureWideJoin = async (nativeGraph: boolean): Promise<BenchRow> => {
 
 for (const nativeGraph of [false, true]) {
 	rows.push(await measureWideJoin(nativeGraph));
+}
+
+const measureCutCoveredJoin = async (
+	nativeGraph: boolean,
+): Promise<BenchRow> => {
+	const sourceStore = new AnyBlockStore();
+	const targetStore = new AnyBlockStore();
+	await sourceStore.start();
+	await targetStore.start();
+	const source = new Log<Uint8Array>();
+	const target = new Log<Uint8Array>();
+	await source.open(sourceStore, key, {
+		appendDurability: "strict",
+		indexer: new HashmapIndices(),
+		nativeGraph,
+	});
+	await target.open(targetStore, key, {
+		appendDurability: "strict",
+		indexer: new HashmapIndices(),
+		nativeGraph,
+	});
+	const { entry: old } = await source.append(new Uint8Array([1]), {
+		meta: { next: [] },
+	});
+	await target.append(new Uint8Array([2]), {
+		meta: { type: EntryType.CUT, next: [old] },
+	});
+
+	const started = performance.now();
+	for (let i = 0; i < iterations; i++) {
+		await target.join([old]);
+	}
+	const elapsed = performance.now() - started;
+	await source.close();
+	await target.close();
+	await sourceStore.stop();
+	await targetStore.stop();
+	return {
+		name: "join cut-covered skip",
+		nativeGraph,
+		entries: 1,
+		iterations,
+		elapsedMs: Math.round(elapsed),
+		opsPerSecond: Math.round((iterations / elapsed) * 1000),
+	};
+};
+
+for (const nativeGraph of [false, true]) {
+	rows.push(await measureCutCoveredJoin(nativeGraph));
 }
 
 for (const nativeGraph of [false, true]) {

--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -36,6 +36,14 @@ export type NativeLogJoinEntry = NativeLogHeadEntry & {
 export type NativeJoinPlan = {
 	skip: boolean;
 	missingParents: string[];
+	cutChecked: boolean;
+	coveredByCut: boolean;
+};
+
+export type NativeJoinCutCheck = {
+	gid: string;
+	wallTime: bigint | number | string;
+	logical?: number;
 };
 
 type NativeLogIndexHandle = {
@@ -68,7 +76,10 @@ type NativeLogIndexHandle = {
 		next: string[],
 		type: number,
 		reset: boolean,
-	) => [boolean, string[]];
+		gid?: string,
+		wallTime?: bigint,
+		logical?: number,
+	) => [boolean, string[], boolean, boolean];
 };
 
 type WasmModule = {
@@ -219,14 +230,19 @@ export class LogGraphIndex {
 		next: string[],
 		type: number,
 		reset = false,
+		cutCheck?: NativeJoinCutCheck,
 	): NativeJoinPlan {
-		const [skip, missingParents] = this.native.plan_join(
-			hash,
-			next,
-			type,
-			reset,
-		);
-		return { skip, missingParents };
+		const [skip, missingParents, cutChecked, coveredByCut] =
+			this.native.plan_join(
+				hash,
+				next,
+				type,
+				reset,
+				cutCheck?.gid,
+				cutCheck ? BigInt(cutCheck.wallTime) : undefined,
+				cutCheck ? (cutCheck.logical ?? 0) : undefined,
+			);
+		return { skip, missingParents, cutChecked, coveredByCut };
 	}
 }
 

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -56,6 +56,8 @@ impl LogIndexEntry {
 pub struct JoinPlan {
     pub skip: bool,
     pub missing_parents: Vec<String>,
+    pub cut_checked: bool,
+    pub covered_by_cut: bool,
 }
 
 #[derive(Default)]
@@ -196,15 +198,36 @@ impl LogGraphIndex {
         shadowed.into_iter().collect()
     }
 
-    pub fn plan_join(&self, hash: &str, nexts: &[String], entry_type: u8, reset: bool) -> JoinPlan {
+    pub fn plan_join(
+        &self,
+        hash: &str,
+        nexts: &[String],
+        entry_type: u8,
+        reset: bool,
+        gid: Option<&str>,
+        wall_time: Option<u64>,
+        logical: Option<u32>,
+    ) -> JoinPlan {
+        let cut_checked = gid.is_some() && wall_time.is_some() && logical.is_some();
         if !reset && self.has(hash) {
             return JoinPlan {
                 skip: true,
                 missing_parents: Vec::new(),
+                cut_checked,
+                covered_by_cut: false,
             };
         }
 
+        let covered_by_cut = match (gid, wall_time, logical) {
+            (Some(gid), Some(wall_time), Some(logical)) => {
+                self.covered_by_cut(hash, gid, wall_time, logical)
+            }
+            _ => false,
+        };
+
         let missing_parents = if entry_type == ENTRY_TYPE_CUT {
+            Vec::new()
+        } else if covered_by_cut {
             Vec::new()
         } else {
             nexts
@@ -217,7 +240,17 @@ impl LogGraphIndex {
         JoinPlan {
             skip: false,
             missing_parents,
+            cut_checked,
+            covered_by_cut,
         }
+    }
+
+    fn covered_by_cut(&self, hash: &str, gid: &str, wall_time: u64, logical: u32) -> bool {
+        self.head_entries(Some(gid)).into_iter().any(|entry| {
+            entry.entry_type == ENTRY_TYPE_CUT
+                && entry.next.iter().any(|next| next == hash)
+                && compare_clock(wall_time, logical, &entry).is_lt()
+        })
     }
 
     fn set_head(&mut self, hash: &str, head: bool) {
@@ -286,6 +319,12 @@ fn head_sort() -> [SortField; 3] {
             direction: SortDirection::Asc,
         },
     ]
+}
+
+fn compare_clock(wall_time: u64, logical: u32, other: &LogIndexEntry) -> std::cmp::Ordering {
+    wall_time
+        .cmp(&other.wall_time)
+        .then_with(|| logical.cmp(&other.logical))
 }
 
 #[wasm_bindgen]
@@ -383,11 +422,20 @@ impl NativeLogIndex {
         next: Array,
         entry_type: u8,
         reset: bool,
+        gid: Option<String>,
+        wall_time: Option<u64>,
+        logical: Option<u32>,
     ) -> Result<Array, JsValue> {
         let next = strings_from_array(next)?;
-        Ok(join_plan_to_row(
-            self.inner.plan_join(hash, &next, entry_type, reset),
-        ))
+        Ok(join_plan_to_row(self.inner.plan_join(
+            hash,
+            &next,
+            entry_type,
+            reset,
+            gid.as_deref(),
+            wall_time,
+            logical,
+        )))
     }
 }
 
@@ -448,6 +496,8 @@ fn join_plan_to_row(plan: JoinPlan) -> Array {
     let row = Array::new();
     row.push(&JsValue::from_bool(plan.skip));
     row.push(&strings_to_array(plan.missing_parents));
+    row.push(&JsValue::from_bool(plan.cut_checked));
+    row.push(&JsValue::from_bool(plan.covered_by_cut));
     row
 }
 
@@ -577,32 +627,101 @@ mod tests {
                 "b",
                 &["a".to_string(), "missing".to_string()],
                 APPEND,
-                false
+                false,
+                None,
+                None,
+                None
             ),
             JoinPlan {
                 skip: false,
-                missing_parents: vec!["missing".to_string()]
+                missing_parents: vec!["missing".to_string()],
+                cut_checked: false,
+                covered_by_cut: false
             }
         );
         assert_eq!(
-            index.plan_join("a", &[], APPEND, false),
+            index.plan_join("a", &[], APPEND, false, None, None, None),
             JoinPlan {
                 skip: true,
-                missing_parents: Vec::new()
+                missing_parents: Vec::new(),
+                cut_checked: false,
+                covered_by_cut: false
             }
         );
         assert_eq!(
-            index.plan_join("a", &[], APPEND, true),
+            index.plan_join("a", &[], APPEND, true, None, None, None),
             JoinPlan {
                 skip: false,
-                missing_parents: Vec::new()
+                missing_parents: Vec::new(),
+                cut_checked: false,
+                covered_by_cut: false
             }
         );
         assert_eq!(
-            index.plan_join("cut", &["missing".to_string()], CUT, false),
+            index.plan_join(
+                "cut",
+                &["missing".to_string()],
+                CUT,
+                false,
+                None,
+                None,
+                None
+            ),
             JoinPlan {
                 skip: false,
-                missing_parents: Vec::new()
+                missing_parents: Vec::new(),
+                cut_checked: false,
+                covered_by_cut: false
+            }
+        );
+    }
+
+    #[test]
+    fn plans_join_cut_coverage() {
+        let mut index = LogGraphIndex::new();
+        index.put(LogIndexEntry::new(
+            "cut",
+            "g",
+            vec!["old".to_string()],
+            CUT,
+            2,
+            0,
+            1,
+            true,
+        ));
+
+        assert_eq!(
+            index.plan_join(
+                "old",
+                &["missing".to_string()],
+                APPEND,
+                false,
+                Some("g"),
+                Some(1),
+                Some(0)
+            ),
+            JoinPlan {
+                skip: false,
+                missing_parents: Vec::new(),
+                cut_checked: true,
+                covered_by_cut: true
+            }
+        );
+        assert_eq!(
+            index.plan_join(
+                "new",
+                &["missing".to_string()],
+                APPEND,
+                false,
+                Some("g"),
+                Some(3),
+                Some(0)
+            ),
+            JoinPlan {
+                skip: false,
+                missing_parents: vec!["missing".to_string()],
+                cut_checked: true,
+                covered_by_cut: false
             }
         );
     }

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -129,18 +129,56 @@ describe("native log graph index", () => {
 		expect(index.planJoin("b", ["a", "missing"], APPEND)).to.deep.equal({
 			skip: false,
 			missingParents: ["missing"],
+			cutChecked: false,
+			coveredByCut: false,
 		});
 		expect(index.planJoin("a", [], APPEND)).to.deep.equal({
 			skip: true,
 			missingParents: [],
+			cutChecked: false,
+			coveredByCut: false,
 		});
 		expect(index.planJoin("a", [], APPEND, true)).to.deep.equal({
 			skip: false,
 			missingParents: [],
+			cutChecked: false,
+			coveredByCut: false,
 		});
 		expect(index.planJoin("cut", ["missing"], CUT)).to.deep.equal({
 			skip: false,
 			missingParents: [],
+			cutChecked: false,
+			coveredByCut: false,
+		});
+	});
+
+	it("plans cut-covered joins", async () => {
+		const index = await createLogGraphIndex();
+		index.put(entry("cut", "g", ["old"], 2n, CUT));
+
+		expect(
+			index.planJoin("old", ["missing"], APPEND, false, {
+				gid: "g",
+				wallTime: 1n,
+				logical: 0,
+			}),
+		).to.deep.equal({
+			skip: false,
+			missingParents: [],
+			cutChecked: true,
+			coveredByCut: true,
+		});
+		expect(
+			index.planJoin("new", ["missing"], APPEND, false, {
+				gid: "g",
+				wallTime: 3n,
+				logical: 0,
+			}),
+		).to.deep.equal({
+			skip: false,
+			missingParents: ["missing"],
+			cutChecked: true,
+			coveredByCut: false,
 		});
 	});
 });

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -58,6 +58,12 @@ type NativeLogEntry = {
 	};
 };
 
+type NativeJoinCutCheck = {
+	gid: string;
+	wallTime: bigint | number | string;
+	logical?: number;
+};
+
 export type NativeLogGraph = {
 	put: (entry: NativeLogEntry) => void;
 	delete: (hash: string) => boolean;
@@ -72,12 +78,15 @@ export type NativeLogGraph = {
 		next: string[],
 		type: number,
 		reset?: boolean,
+		cutCheck?: NativeJoinCutCheck,
 	) => JoinPlan;
 };
 
 export type JoinPlan = {
 	skip: boolean;
 	missingParents: string[];
+	cutChecked: boolean;
+	coveredByCut: boolean;
 };
 
 export type NativeLogJoinEntry = SortableEntry & {
@@ -553,18 +562,36 @@ export class EntryIndex<T> {
 		reset?: boolean,
 	): Promise<JoinPlan> {
 		if (this.properties.nativeGraph) {
+			const cutCheck = this.properties.nativeGraph.useHeads
+				? {
+						gid: entry.meta.gid,
+						wallTime: entry.meta.clock.timestamp.wallTime,
+						logical: entry.meta.clock.timestamp.logical,
+					}
+				: undefined;
 			return this.properties.nativeGraph.graph.planJoin(
 				entry.hash,
 				entry.meta.next,
 				entry.meta.type,
 				reset === true,
+				cutCheck,
 			);
 		}
 		if (!reset && (await this.getShallow(entry.hash)) != null) {
-			return { skip: true, missingParents: [] };
+			return {
+				skip: true,
+				missingParents: [],
+				cutChecked: false,
+				coveredByCut: false,
+			};
 		}
 		if (entry.meta.type === EntryType.CUT) {
-			return { skip: false, missingParents: [] };
+			return {
+				skip: false,
+				missingParents: [],
+				cutChecked: false,
+				coveredByCut: false,
+			};
 		}
 
 		const missingParents: string[] = [];
@@ -573,7 +600,12 @@ export class EntryIndex<T> {
 				missingParents.push(next);
 			}
 		}
-		return { skip: false, missingParents };
+		return {
+			skip: false,
+			missingParents,
+			cutChecked: false,
+			coveredByCut: false,
+		};
 	}
 
 	async getShallow(k: string) {

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -1068,10 +1068,14 @@ export class Log<T> {
 			}
 		}
 
-		const headsWithGid: JoinableEntry[] = await this.entryIndex.getJoinHeads(
-			entry.meta.gid,
-		);
-		if (headsWithGid) {
+		if (joinPlan.coveredByCut) {
+			return false;
+		}
+
+		if (!joinPlan.cutChecked) {
+			const headsWithGid: JoinableEntry[] = await this.entryIndex.getJoinHeads(
+				entry.meta.gid,
+			);
 			for (const v of headsWithGid) {
 				// TODO second argument should be a time compare instead? what about next nexts?
 				// and check the cut entry is newer than the current 'entry'

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -3,6 +3,7 @@ import { Ed25519Keypair } from "@peerbit/crypto";
 import { HashmapIndices } from "@peerbit/indexer-simple";
 import { expect } from "chai";
 import sinon from "sinon";
+import { EntryType } from "../src/entry-type.js";
 import { Log } from "../src/log.js";
 
 describe("native graph", () => {
@@ -136,15 +137,18 @@ describe("native graph", () => {
 			await target.join([merge]);
 
 			expect(planJoinSpy.callCount).greaterThan(0);
-			expect(planJoinSpy.firstCall.args).to.deep.equal([
+			expect(planJoinSpy.firstCall.args.slice(0, 4)).to.deep.equal([
 				merge.hash,
 				[present.hash, missing.hash],
 				merge.meta.type,
 				false,
 			]);
+			expect(planJoinSpy.firstCall.args[4]).to.include({ gid: merge.meta.gid });
 			expect(planJoinSpy.firstCall.returnValue).to.deep.equal({
 				skip: false,
 				missingParents: [missing.hash],
+				cutChecked: true,
+				coveredByCut: false,
 			});
 			expect(getShallowSpy.callCount).equal(0);
 			expect(await target.toArray()).to.have.length(3);
@@ -153,6 +157,50 @@ describe("native graph", () => {
 			planJoinSpy.restore();
 			await source.close();
 			await target.close();
+		}
+	});
+
+	it("checks cut-covered joins in the native plan", async () => {
+		const sourceStore = new AnyBlockStore();
+		const targetStore = new AnyBlockStore();
+		const source = new Log<Uint8Array>();
+		const target = new Log<Uint8Array>();
+
+		await sourceStore.start();
+		await targetStore.start();
+		await source.open(sourceStore, signKey, { nativeGraph: true });
+		await target.open(targetStore, signKey, { nativeGraph: true });
+
+		const { entry: old } = await source.append(new Uint8Array([1]), {
+			meta: { next: [] },
+		});
+		await target.append(new Uint8Array([2]), {
+			meta: { type: EntryType.CUT, next: [old] },
+		});
+
+		const nativeGraph = target.entryIndex.properties.nativeGraph!.graph;
+		const planJoinSpy = sinon.spy(nativeGraph, "planJoin");
+		const joinHeadEntriesSpy = sinon.spy(nativeGraph, "joinHeadEntries");
+		const verifySpy = sinon.spy(old, "verifySignatures");
+		try {
+			await target.join([old], { verifySignatures: true });
+
+			expect(planJoinSpy.firstCall.returnValue).to.include({
+				skip: false,
+				cutChecked: true,
+				coveredByCut: true,
+			});
+			expect(verifySpy.callCount).equal(1);
+			expect(joinHeadEntriesSpy.callCount).equal(0);
+			expect(await target.has(old.hash)).to.equal(false);
+		} finally {
+			verifySpy.restore();
+			joinHeadEntriesSpy.restore();
+			planJoinSpy.restore();
+			await source.close();
+			await target.close();
+			await sourceStore.stop();
+			await targetStore.stop();
 		}
 	});
 


### PR DESCRIPTION
## Summary

- extend the native log join planner so it can also answer whether an incoming entry is covered by a newer CUT head
- keep duplicate skip before signature verification, but only honor `coveredByCut` after signature verification, preserving the old validation order
- avoid the `joinHeadEntries()` native-to-TS row materialization when native head planning is available
- add a cut-covered join benchmark case to the native graph benchmark

## Local benchmark signal

`PEERBIT_LOG_NATIVE_GRAPH_ITERATIONS=1000 node packages/log/dist/benchmark/native-graph.js` on this machine:

- `join cut-covered skip`, `nativeGraph=false`: 14 ms, ~73.8k ops/sec
- `join cut-covered skip`, `nativeGraph=true`: 5 ms, ~200.8k ops/sec

This is about 2.8x faster for repeated cut-covered join skips in this local run.

## Validation

- `cargo test --manifest-path packages/log/rust/Cargo.toml`
- `pnpm --filter @peerbit/log-rust run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log/rust -- -t node --grep "plans joins with missing parents|plans cut-covered joins"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "checks cut-covered joins in the native plan"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "native graph"`
- `pnpm --filter @peerbit/log-rust run lint`
- `pnpm exec eslint --config eslint.config.js packages/log/benchmark/native-graph.ts packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/src/entry-index.ts packages/log/src/log.ts packages/log/test/native-graph.spec.ts`
- `pnpm --filter @peerbit/log run build`

Note: I also explored a native graph `putMany` batch boundary before this PR, but the microbenchmark showed it was slower than direct repeated `put` calls, so I dropped that direction instead of shipping it.
