### PR TITLE
feat: use native log graph for membership checks

### DIFF
--- a/packages/log/benchmark/native-graph.ts
+++ b/packages/log/benchmark/native-graph.ts
@@ -190,6 +190,56 @@ for (const nativeGraph of [false, true]) {
 	rows.push(await measureWideJoin(nativeGraph));
 }
 
+const measureDuplicateJoinArray = async (
+	nativeGraph: boolean,
+): Promise<BenchRow> => {
+	const store = new AnyBlockStore();
+	await store.start();
+	const source = new Log<Uint8Array>();
+	const target = new Log<Uint8Array>();
+	await source.open(store, key, {
+		appendDurability: "strict",
+		indexer: new HashmapIndices(),
+		nativeGraph,
+	});
+	await target.open(store, key, {
+		appendDurability: "strict",
+		indexer: new HashmapIndices(),
+		nativeGraph,
+	});
+
+	const existing: Entry<Uint8Array>[] = [];
+	for (let i = 0; i < joinParents; i++) {
+		existing.push(
+			(
+				await source.append(new Uint8Array([i & 0xff]), {
+					meta: { next: [] },
+				})
+			).entry,
+		);
+	}
+	await target.join(existing);
+
+	const started = performance.now();
+	await target.join(existing);
+	const elapsed = performance.now() - started;
+	await source.close();
+	await target.close();
+	await store.stop();
+	return {
+		name: "join duplicate array membership",
+		nativeGraph,
+		entries: joinParents,
+		iterations: joinParents,
+		elapsedMs: Math.round(elapsed),
+		opsPerSecond: Math.round((joinParents / elapsed) * 1000),
+	};
+};
+
+for (const nativeGraph of [false, true]) {
+	rows.push(await measureDuplicateJoinArray(nativeGraph));
+}
+
 const measureCutCoveredJoin = async (
 	nativeGraph: boolean,
 ): Promise<BenchRow> => {

--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -50,6 +50,7 @@ type NativeLogIndexHandle = {
 	clear: () => void;
 	len: () => number;
 	has: (hash: string) => boolean;
+	has_many: (hashes: string[]) => string[];
 	put: (
 		hash: string,
 		gid: string,
@@ -140,6 +141,10 @@ export class LogGraphIndex {
 
 	has(hash: string): boolean {
 		return this.native.has(hash);
+	}
+
+	hasMany(hashes: Iterable<string>): Set<string> {
+		return new Set(this.native.has_many([...hashes]));
 	}
 
 	put(entry: NativeLogEntry): void {

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -90,6 +90,14 @@ impl LogGraphIndex {
         self.entries.contains_key(hash)
     }
 
+    pub fn has_many(&self, hashes: &[String]) -> Vec<String> {
+        hashes
+            .iter()
+            .filter(|hash| self.has(hash))
+            .cloned()
+            .collect()
+    }
+
     pub fn get(&self, hash: &str) -> Option<&LogIndexEntry> {
         self.entries.get(hash)
     }
@@ -353,6 +361,11 @@ impl NativeLogIndex {
         self.inner.has(hash)
     }
 
+    pub fn has_many(&self, hashes: Array) -> Result<Array, JsValue> {
+        let hashes = strings_from_array(hashes)?;
+        Ok(strings_to_array(self.inner.has_many(&hashes)))
+    }
+
     pub fn put(
         &mut self,
         hash: String,
@@ -555,6 +568,18 @@ mod tests {
         assert_eq!(index.heads(None), vec!["a", "b", "c"]);
         assert_eq!(index.heads(Some("one")), vec!["a", "b"]);
         assert_eq!(index.heads(Some("two")), vec!["c"]);
+    }
+
+    #[test]
+    fn batches_membership_checks() {
+        let mut index = LogGraphIndex::new();
+        index.put(entry("a", "one", &[], 1));
+        index.put(entry("c", "one", &[], 3));
+
+        assert_eq!(
+            index.has_many(&["missing".to_string(), "a".to_string(), "c".to_string()]),
+            vec!["a".to_string(), "c".to_string()]
+        );
     }
 
     #[test]

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -122,6 +122,14 @@ describe("native log graph index", () => {
 		expect(index.shadowedGids("new", ["a"], "b")).to.deep.equal([]);
 	});
 
+	it("batches membership checks", async () => {
+		const index = await createLogGraphIndex();
+		index.put(entry("a", "g", [], 1n));
+		index.put(entry("c", "g", [], 3n));
+
+		expect([...index.hasMany(["missing", "a", "c"])]).to.deep.equal(["a", "c"]);
+	});
+
 	it("plans joins with missing parents", async () => {
 		const index = await createLogGraphIndex();
 		index.put(entry("a", "g", [], 1n));

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -65,6 +65,8 @@ type NativeJoinCutCheck = {
 };
 
 export type NativeLogGraph = {
+	has: (hash: string) => boolean;
+	hasMany: (hashes: Iterable<string>) => Set<string>;
 	put: (entry: NativeLogEntry) => void;
 	delete: (hash: string) => boolean;
 	clear: () => void;
@@ -617,6 +619,9 @@ export class EntryIndex<T> {
 	}
 
 	async has(k: string) {
+		if (this.properties.nativeGraph) {
+			return this.properties.nativeGraph.graph.has(k);
+		}
 		if (this.pendingIndexWrites.has(k)) {
 			return true;
 		}
@@ -627,6 +632,11 @@ export class EntryIndex<T> {
 	}
 
 	async hasMany(hashes: Iterable<string>) {
+		if (this.properties.nativeGraph) {
+			return this.properties.nativeGraph.graph.hasMany(
+				new Set([...hashes].filter(Boolean)),
+			);
+		}
 		const batchSize = 64;
 		const existing = new Set<string>();
 		const missing: string[] = [];

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -160,6 +160,48 @@ describe("native graph", () => {
 		}
 	});
 
+	it("checks joined array membership in the native graph", async () => {
+		const source = new Log<Uint8Array>();
+		const target = new Log<Uint8Array>();
+
+		await source.open(store, signKey, { nativeGraph: true });
+		await target.open(store, signKey, {
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+		});
+
+		const present = (
+			await source.append(new Uint8Array([1]), {
+				meta: { next: [] },
+			})
+		).entry;
+		const missing = (
+			await source.append(new Uint8Array([2]), {
+				meta: { next: [] },
+			})
+		).entry;
+		await target.join([present]);
+
+		const nativeGraph = target.entryIndex.properties.nativeGraph!.graph;
+		const hasManySpy = sinon.spy(nativeGraph, "hasMany");
+		const iterateSpy = sinon.spy(target.entryIndex.properties.index, "iterate");
+		try {
+			await target.join([present, missing]);
+
+			expect(hasManySpy.callCount).equal(1);
+			expect(hasManySpy.firstCall.args[0]).to.deep.equal(
+				new Set([present.hash, missing.hash]),
+			);
+			expect(iterateSpy.callCount).equal(0);
+			expect(await target.toArray()).to.have.length(2);
+		} finally {
+			iterateSpy.restore();
+			hasManySpy.restore();
+			await source.close();
+			await target.close();
+		}
+	});
+
 	it("checks cut-covered joins in the native plan", async () => {
 		const sourceStore = new AnyBlockStore();
 		const targetStore = new AnyBlockStore();


### PR DESCRIPTION
## Summary

- add a batched `hasMany` API to `@peerbit/log-rust` / the Rust log graph
- route `EntryIndex.has()` and `EntryIndex.hasMany()` through the native graph when `nativeGraph` is enabled
- add coverage proving joined array prefiltering avoids the generic indexer path
- add a native graph benchmark row for duplicate join-array membership

## Local validation

- `cargo test --manifest-path packages/log/rust/Cargo.toml`
- `pnpm --filter @peerbit/log-rust run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log/rust -- -t node --grep "batches membership checks|plans joins with missing parents|plans cut-covered joins"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "native graph"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "fromEntryHash"`
- `pnpm exec eslint --config eslint.config.js packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/src/entry-index.ts packages/log/test/native-graph.spec.ts packages/log/benchmark/native-graph.ts`

## Benchmark signal

Command:

```sh
PEERBIT_LOG_NATIVE_GRAPH_ENTRIES=1000 PEERBIT_LOG_NATIVE_GRAPH_JOIN_PARENTS=1000 PEERBIT_LOG_NATIVE_GRAPH_APPEND_ENTRIES=500 PEERBIT_LOG_NATIVE_GRAPH_ITERATIONS=1000 TS_NODE_PROJECT=./tsconfig.json node --loader ts-node/esm ./packages/log/benchmark/native-graph.ts
```

New row:

- `join duplicate array membership`, nativeGraph=false: 168 ms, ~5.9k ops/sec
- `join duplicate array membership`, nativeGraph=true: 1 ms, ~1.06M ops/sec

The main practical win is that repeated shared-log join batches with already-known entries no longer need to query the generic TS indexer just to discard duplicates.