### PR TITLE
feat: scan log cut children in native graph

### DIFF
--- a/packages/log/benchmark/native-graph.ts
+++ b/packages/log/benchmark/native-graph.ts
@@ -240,6 +240,52 @@ for (const nativeGraph of [false, true]) {
 	rows.push(await measureDuplicateJoinArray(nativeGraph));
 }
 
+const measureCutRecursiveDelete = async (
+	nativeGraph: boolean,
+): Promise<BenchRow> => {
+	const store = new AnyBlockStore();
+	await store.start();
+	const log = new Log<Uint8Array>();
+	await log.open(store, key, {
+		appendDurability: "strict",
+		indexer: new HashmapIndices(),
+		nativeGraph,
+	});
+
+	let previous = (
+		await log.append(new Uint8Array([0]), {
+			meta: { next: [] },
+		})
+	).entry;
+	for (let i = 1; i < joinParents; i++) {
+		previous = (
+			await log.append(new Uint8Array([i & 0xff]), {
+				meta: { next: [previous] },
+			})
+		).entry;
+	}
+
+	const started = performance.now();
+	await log.append(new Uint8Array([0xff]), {
+		meta: { type: EntryType.CUT, next: [previous] },
+	});
+	const elapsed = performance.now() - started;
+	await log.close();
+	await store.stop();
+	return {
+		name: "cut recursive child scan",
+		nativeGraph,
+		entries: joinParents,
+		iterations: joinParents,
+		elapsedMs: Math.round(elapsed),
+		opsPerSecond: Math.round((joinParents / elapsed) * 1000),
+	};
+};
+
+for (const nativeGraph of [false, true]) {
+	rows.push(await measureCutRecursiveDelete(nativeGraph));
+}
+
 const measureCutCoveredJoin = async (
 	nativeGraph: boolean,
 ): Promise<BenchRow> => {

--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -65,6 +65,7 @@ type NativeLogIndexHandle = {
 	heads: (gid?: string) => string[];
 	head_entries: (gid?: string) => unknown[];
 	head_join_entries: (gid?: string) => unknown[];
+	child_join_entries: (hash: string) => unknown[];
 	children: (hash: string) => string[];
 	count_has_next: (next: string, excludeHash?: string) => number;
 	shadowed_gids: (
@@ -193,6 +194,33 @@ export class LogGraphIndex {
 
 	joinHeadEntries(gid?: string): NativeLogJoinEntry[] {
 		return this.native.head_join_entries(gid).map((row) => {
+			const [hash, gid, wallTime, logical, type, next] = row as [
+				string,
+				string,
+				string,
+				number,
+				number,
+				string[],
+			];
+			return {
+				hash,
+				meta: {
+					gid,
+					type,
+					next,
+					clock: {
+						timestamp: {
+							wallTime: BigInt(wallTime),
+							logical,
+						},
+					},
+				},
+			};
+		});
+	}
+
+	childJoinEntries(hash: string): NativeLogJoinEntry[] {
+		return this.native.child_join_entries(hash).map((row) => {
 			const [hash, gid, wallTime, logical, type, next] = row as [
 				string,
 				string,

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -165,6 +165,13 @@ impl LogGraphIndex {
         self.head_entries(gid)
     }
 
+    pub fn child_join_entries(&self, hash: &str) -> Vec<LogIndexEntry> {
+        self.children(hash)
+            .into_iter()
+            .filter_map(|child_hash| self.entries.get(&child_hash).cloned())
+            .collect()
+    }
+
     pub fn children(&self, hash: &str) -> Vec<String> {
         self.children
             .get(hash)
@@ -407,6 +414,10 @@ impl NativeLogIndex {
         log_join_entries_to_rows(self.inner.head_join_entries(gid.as_deref()))
     }
 
+    pub fn child_join_entries(&self, hash: &str) -> Array {
+        log_join_entries_to_rows(self.inner.child_join_entries(hash))
+    }
+
     pub fn children(&self, hash: &str) -> Array {
         strings_to_array(self.inner.children(hash))
     }
@@ -618,6 +629,30 @@ mod tests {
         assert_eq!(heads[0].hash, "cut");
         assert_eq!(heads[0].entry_type, CUT);
         assert_eq!(heads[0].next, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn returns_child_join_entries_for_cut_recursion() {
+        let mut index = LogGraphIndex::new();
+        index.put(entry("a", "g", &[], 1));
+        index.put(entry("b", "g", &["a"], 2));
+        index.put(LogIndexEntry::new(
+            "cut",
+            "g",
+            vec!["a".to_string()],
+            CUT,
+            3,
+            0,
+            1,
+            true,
+        ));
+
+        let children = index.child_join_entries("a");
+        assert_eq!(children.len(), 2);
+        assert_eq!(children[0].hash, "b");
+        assert_eq!(children[0].entry_type, APPEND);
+        assert_eq!(children[1].hash, "cut");
+        assert_eq!(children[1].entry_type, CUT);
     }
 
     #[test]

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -130,6 +130,20 @@ describe("native log graph index", () => {
 		expect([...index.hasMany(["missing", "a", "c"])]).to.deep.equal(["a", "c"]);
 	});
 
+	it("returns child join entries for cut recursion", async () => {
+		const index = await createLogGraphIndex();
+		index.put(entry("a", "g", [], 1n));
+		index.put(entry("b", "g", ["a"], 2n));
+		index.put(entry("cut", "g", ["a"], 3n, CUT));
+
+		expect(
+			index.childJoinEntries("a").map((entry) => [entry.hash, entry.meta.type]),
+		).to.deep.equal([
+			["b", APPEND],
+			["cut", CUT],
+		]);
+	});
+
 	it("plans joins with missing parents", async () => {
 		const index = await createLogGraphIndex();
 		index.put(entry("a", "g", [], 1n));

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -73,6 +73,7 @@ export type NativeLogGraph = {
 	heads: (gid?: string) => string[];
 	headEntries: (gid?: string) => SortableEntry[];
 	joinHeadEntries: (gid?: string) => NativeLogJoinEntry[];
+	childJoinEntries: (hash: string) => NativeLogJoinEntry[];
 	countHasNext: (next: string, excludeHash?: string) => number;
 	shadowedGids: (gid: string, next: string[], excludeHash?: string) => string[];
 	planJoin: (
@@ -299,6 +300,21 @@ export class EntryIndex<T> {
 			);
 		}
 		return this.getHeads(gid, {
+			type: "shape",
+			shape: {
+				hash: true,
+				meta: { type: true, next: true, gid: true, clock: true },
+			},
+		}).all() as Promise<NativeLogJoinEntry[]>;
+	}
+
+	getJoinChildren(next: string): Promise<NativeLogJoinEntry[]> {
+		if (this.properties.nativeGraph) {
+			return Promise.resolve(
+				this.properties.nativeGraph.graph.childJoinEntries(next),
+			);
+		}
+		return this.getHasNext(next, {
 			type: "shape",
 			shape: {
 				hash: true,

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -1255,8 +1255,7 @@ export class Log<T> {
 			}
 
 			for (const next of entry.meta.next) {
-				const nextFromNext = this.entryIndex.getHasNext(next);
-				const entriesThatHasNext = await nextFromNext.all();
+				const entriesThatHasNext = await this.entryIndex.getJoinChildren(next);
 
 				// if there are no entries which is not of "CUT" type, we can safely delete the next entry
 				// figureately speaking, these means where are cutting all branches to a stem, so we can delete the stem as well

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -202,6 +202,43 @@ describe("native graph", () => {
 		}
 	});
 
+	it("scans cut recursion children in the native graph", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+		});
+
+		const root = (
+			await log.append(new Uint8Array([1]), {
+				meta: { next: [] },
+			})
+		).entry;
+		const child = (
+			await log.append(new Uint8Array([2]), {
+				meta: { next: [root] },
+			})
+		).entry;
+
+		const nativeGraph = log.entryIndex.properties.nativeGraph!.graph;
+		const childJoinEntriesSpy = sinon.spy(nativeGraph, "childJoinEntries");
+		const iterateSpy = sinon.spy(log.entryIndex.properties.index, "iterate");
+		try {
+			await log.append(new Uint8Array([3]), {
+				meta: { type: EntryType.CUT, next: [child] },
+			});
+
+			expect(childJoinEntriesSpy.callCount).greaterThan(0);
+			expect(iterateSpy.callCount).equal(0);
+			expect(await log.has(root.hash)).to.equal(false);
+			expect(await log.has(child.hash)).to.equal(false);
+		} finally {
+			iterateSpy.restore();
+			childJoinEntriesSpy.restore();
+			await log.close();
+		}
+	});
+
 	it("checks cut-covered joins in the native plan", async () => {
 		const sourceStore = new AnyBlockStore();
 		const targetStore = new AnyBlockStore();


### PR DESCRIPTION
## Summary

- add native child join-entry lookup to `@peerbit/log-rust`
- route cut/delete recursion through `EntryIndex.getJoinChildren()` so native graph users avoid generic indexer child-edge scans
- add tests proving cut recursion uses the native child edge view without `index.iterate`
- add a benchmark row for recursive cut child scanning

## Local validation

- `cargo test --manifest-path packages/log/rust/Cargo.toml`
- `pnpm --filter @peerbit/log-rust run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log/rust -- -t node --grep "child join entries|batches membership checks|plans joins with missing parents|plans cut-covered joins"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "native graph"`
- `pnpm exec eslint --config eslint.config.js packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/src/entry-index.ts packages/log/src/log.ts packages/log/test/native-graph.spec.ts packages/log/benchmark/native-graph.ts`

## Benchmark signal

Command:

```sh
PEERBIT_LOG_NATIVE_GRAPH_ENTRIES=1000 PEERBIT_LOG_NATIVE_GRAPH_JOIN_PARENTS=1000 PEERBIT_LOG_NATIVE_GRAPH_APPEND_ENTRIES=500 PEERBIT_LOG_NATIVE_GRAPH_ITERATIONS=1000 TS_NODE_PROJECT=./tsconfig.json node --loader ts-node/esm ./packages/log/benchmark/native-graph.ts
```

New row:

- `cut recursive child scan`, nativeGraph=false: 516 ms, ~1.9k ops/sec
- `cut recursive child scan`, nativeGraph=true: 27 ms, ~37.7k ops/sec

This keeps pruning/cut traversal inside the native graph for the edge-discovery part, while still using the existing log deletion semantics.
