### PR TITLE
feat: plan recursive log cuts in native graph

### DIFF
--- a/packages/log/benchmark/native-graph.ts
+++ b/packages/log/benchmark/native-graph.ts
@@ -273,7 +273,7 @@ const measureCutRecursiveDelete = async (
 	await log.close();
 	await store.stop();
 	return {
-		name: "cut recursive child scan",
+		name: "cut recursive delete plan",
 		nativeGraph,
 		entries: joinParents,
 		iterations: joinParents,

--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -66,6 +66,7 @@ type NativeLogIndexHandle = {
 	head_entries: (gid?: string) => unknown[];
 	head_join_entries: (gid?: string) => unknown[];
 	child_join_entries: (hash: string) => unknown[];
+	plan_delete_recursively: (hashes: string[], skipFirst: boolean) => string[];
 	children: (hash: string) => string[];
 	count_has_next: (next: string, excludeHash?: string) => number;
 	shadowed_gids: (
@@ -244,6 +245,10 @@ export class LogGraphIndex {
 				},
 			};
 		});
+	}
+
+	planDeleteRecursively(hashes: Iterable<string>, skipFirst = false): string[] {
+		return this.native.plan_delete_recursively([...hashes], skipFirst);
 	}
 
 	children(hash: string): string[] {

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -172,6 +172,41 @@ impl LogGraphIndex {
             .collect()
     }
 
+    pub fn plan_delete_recursively(&self, from: &[String], skip_first: bool) -> Vec<String> {
+        let mut stack = from.to_vec();
+        let mut visited = IndexSet::new();
+        let mut delete_hashes = IndexSet::new();
+        let mut counter = 0;
+
+        while let Some(hash) = stack.pop() {
+            if !visited.insert(hash.clone()) {
+                continue;
+            }
+            let Some(entry) = self.entries.get(&hash) else {
+                counter += 1;
+                continue;
+            };
+
+            let skip = counter == 0 && skip_first;
+            if !skip {
+                delete_hashes.insert(hash.clone());
+            }
+
+            for next in &entry.next {
+                let has_alternative_next = self
+                    .child_join_entries(next)
+                    .into_iter()
+                    .any(|child| child.entry_type != ENTRY_TYPE_CUT && child.hash != entry.hash);
+                if !has_alternative_next && self.entries.contains_key(next) {
+                    stack.push(next.clone());
+                }
+            }
+            counter += 1;
+        }
+
+        delete_hashes.into_iter().collect()
+    }
+
     pub fn children(&self, hash: &str) -> Vec<String> {
         self.children
             .get(hash)
@@ -418,6 +453,13 @@ impl NativeLogIndex {
         log_join_entries_to_rows(self.inner.child_join_entries(hash))
     }
 
+    pub fn plan_delete_recursively(&self, from: Array, skip_first: bool) -> Result<Array, JsValue> {
+        let from = strings_from_array(from)?;
+        Ok(strings_to_array(
+            self.inner.plan_delete_recursively(&from, skip_first),
+        ))
+    }
+
     pub fn children(&self, hash: &str) -> Array {
         strings_to_array(self.inner.children(hash))
     }
@@ -653,6 +695,51 @@ mod tests {
         assert_eq!(children[0].entry_type, APPEND);
         assert_eq!(children[1].hash, "cut");
         assert_eq!(children[1].entry_type, CUT);
+    }
+
+    #[test]
+    fn plans_recursive_cut_deletes() {
+        let mut index = LogGraphIndex::new();
+        index.put(entry("root", "g", &[], 1));
+        index.put(entry("child", "g", &["root"], 2));
+        index.put(LogIndexEntry::new(
+            "cut",
+            "g",
+            vec!["child".to_string()],
+            CUT,
+            3,
+            0,
+            1,
+            true,
+        ));
+
+        assert_eq!(
+            index.plan_delete_recursively(&["cut".to_string()], true),
+            vec!["child".to_string(), "root".to_string()]
+        );
+    }
+
+    #[test]
+    fn recursive_cut_delete_plan_keeps_alternative_branches() {
+        let mut index = LogGraphIndex::new();
+        index.put(entry("root", "g", &[], 1));
+        index.put(entry("child", "g", &["root"], 2));
+        index.put(entry("sibling", "g", &["root"], 3));
+        index.put(LogIndexEntry::new(
+            "cut",
+            "g",
+            vec!["child".to_string()],
+            CUT,
+            4,
+            0,
+            1,
+            true,
+        ));
+
+        assert_eq!(
+            index.plan_delete_recursively(&["cut".to_string()], true),
+            vec!["child".to_string()]
+        );
     }
 
     #[test]

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -144,6 +144,28 @@ describe("native log graph index", () => {
 		]);
 	});
 
+	it("plans recursive cut deletes", async () => {
+		const index = await createLogGraphIndex();
+		index.put(entry("root", "g", [], 1n));
+		index.put(entry("child", "g", ["root"], 2n));
+		index.put(entry("cut", "g", ["child"], 3n, CUT));
+
+		expect(index.planDeleteRecursively(["cut"], true)).to.deep.equal([
+			"child",
+			"root",
+		]);
+
+		const branched = await createLogGraphIndex();
+		branched.put(entry("root", "g", [], 1n));
+		branched.put(entry("child", "g", ["root"], 2n));
+		branched.put(entry("sibling", "g", ["root"], 3n));
+		branched.put(entry("cut", "g", ["child"], 4n, CUT));
+
+		expect(branched.planDeleteRecursively(["cut"], true)).to.deep.equal([
+			"child",
+		]);
+	});
+
 	it("plans joins with missing parents", async () => {
 		const index = await createLogGraphIndex();
 		index.put(entry("a", "g", [], 1n));

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -74,6 +74,10 @@ export type NativeLogGraph = {
 	headEntries: (gid?: string) => SortableEntry[];
 	joinHeadEntries: (gid?: string) => NativeLogJoinEntry[];
 	childJoinEntries: (hash: string) => NativeLogJoinEntry[];
+	planDeleteRecursively: (
+		hashes: Iterable<string>,
+		skipFirst?: boolean,
+	) => string[];
 	countHasNext: (next: string, excludeHash?: string) => number;
 	shadowedGids: (gid: string, next: string[], excludeHash?: string) => string[];
 	planJoin: (
@@ -321,6 +325,19 @@ export class EntryIndex<T> {
 				meta: { type: true, next: true, gid: true, clock: true },
 			},
 		}).all() as Promise<NativeLogJoinEntry[]>;
+	}
+
+	planDeleteRecursively(
+		from: Iterable<{ hash: string }>,
+		skipFirst = false,
+	): string[] | undefined {
+		if (!this.properties.nativeGraph) {
+			return undefined;
+		}
+		return this.properties.nativeGraph.graph.planDeleteRecursively(
+			[...from].map((entry) => entry.hash),
+			skipFirst,
+		);
 	}
 
 	getHasNext<R extends MaybeResolveOptions>(

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -1240,7 +1240,22 @@ export class Log<T> {
 			| { hash: string; meta: { next: string[] } }[],
 		skipFirst = false,
 	) {
-		const stack = Array.isArray(from) ? [...from] : [from];
+		const entries = Array.isArray(from) ? [...from] : [from];
+		const nativeDeletePlan = this.entryIndex.planDeleteRecursively(
+			entries,
+			skipFirst,
+		);
+		if (nativeDeletePlan) {
+			const toDelete: PendingDelete<T>[] = [];
+			for (const hash of nativeDeletePlan) {
+				const deleteFn = await this.prepareDelete(hash);
+				deleteFn.entry &&
+					toDelete.push({ entry: deleteFn.entry, fn: deleteFn.fn });
+			}
+			return toDelete;
+		}
+
+		const stack = entries;
 		const promises: (Promise<void> | void)[] = [];
 		let counter = 0;
 		const toDelete: PendingDelete<T>[] = [];

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -202,7 +202,7 @@ describe("native graph", () => {
 		}
 	});
 
-	it("scans cut recursion children in the native graph", async () => {
+	it("plans cut recursion deletes in the native graph", async () => {
 		const log = new Log<Uint8Array>();
 		await log.open(store, signKey, {
 			indexer: new HashmapIndices(),
@@ -221,20 +221,27 @@ describe("native graph", () => {
 		).entry;
 
 		const nativeGraph = log.entryIndex.properties.nativeGraph!.graph;
-		const childJoinEntriesSpy = sinon.spy(nativeGraph, "childJoinEntries");
+		const planDeleteRecursivelySpy = sinon.spy(
+			nativeGraph,
+			"planDeleteRecursively",
+		);
 		const iterateSpy = sinon.spy(log.entryIndex.properties.index, "iterate");
 		try {
 			await log.append(new Uint8Array([3]), {
 				meta: { type: EntryType.CUT, next: [child] },
 			});
 
-			expect(childJoinEntriesSpy.callCount).greaterThan(0);
+			expect(planDeleteRecursivelySpy.callCount).equal(1);
+			expect(planDeleteRecursivelySpy.firstCall.returnValue).to.deep.equal([
+				child.hash,
+				root.hash,
+			]);
 			expect(iterateSpy.callCount).equal(0);
 			expect(await log.has(root.hash)).to.equal(false);
 			expect(await log.has(child.hash)).to.equal(false);
 		} finally {
 			iterateSpy.restore();
-			childJoinEntriesSpy.restore();
+			planDeleteRecursivelySpy.restore();
 			await log.close();
 		}
 	});


### PR DESCRIPTION
## Summary

- add a native recursive delete planner to the Rust log graph
- use that planner from `prepareDeleteRecursively()` when `nativeGraph` is enabled
- keep JS responsible for applying deletes, trim cache cleanup, and change semantics
- update native graph tests and benchmark naming for the deeper delete plan path

## Local validation

- `cargo test --manifest-path packages/log/rust/Cargo.toml`
- `pnpm --filter @peerbit/log-rust run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log/rust -- -t node --grep "plans recursive cut deletes|child join entries|batches membership checks|plans joins with missing parents|plans cut-covered joins"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "native graph"`
- `pnpm exec eslint --config eslint.config.js packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/src/entry-index.ts packages/log/src/log.ts packages/log/test/native-graph.spec.ts packages/log/benchmark/native-graph.ts`

## Benchmark signal

Command:

```sh
PEERBIT_LOG_NATIVE_GRAPH_ENTRIES=1000 PEERBIT_LOG_NATIVE_GRAPH_JOIN_PARENTS=1000 PEERBIT_LOG_NATIVE_GRAPH_APPEND_ENTRIES=500 PEERBIT_LOG_NATIVE_GRAPH_ITERATIONS=1000 TS_NODE_PROJECT=./tsconfig.json node --loader ts-node/esm ./packages/log/benchmark/native-graph.ts
```

New/updated row:

- `cut recursive delete plan`, nativeGraph=false: 505 ms, ~2.0k ops/sec
- `cut recursive delete plan`, nativeGraph=true: 15 ms, ~66.4k ops/sec

Compared with the previous per-child native scan, this moves the recursive traversal itself into Rust and leaves JS to apply the planned deletes.
