### PR TITLE
feat: read log memory usage from native graph

### DIFF
--- a/packages/log/benchmark/native-graph.ts
+++ b/packages/log/benchmark/native-graph.ts
@@ -357,4 +357,15 @@ for (const nativeGraph of [false, true]) {
 	await store.stop();
 }
 
+for (const nativeGraph of [false, true]) {
+	const { log, store } = await createHeadsLog(nativeGraph);
+	rows.push(
+		await measure("getMemoryUsage()", nativeGraph, async () => {
+			await log.entryIndex.getMemoryUsage();
+		}),
+	);
+	await log.close();
+	await store.stop();
+}
+
 console.table(rows);

--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -49,6 +49,7 @@ export type NativeJoinCutCheck = {
 type NativeLogIndexHandle = {
 	clear: () => void;
 	len: () => number;
+	payload_size_sum: () => number;
 	has: (hash: string) => boolean;
 	has_many: (hashes: string[]) => string[];
 	put: (
@@ -139,6 +140,10 @@ export class LogGraphIndex {
 
 	get length(): number {
 		return this.native.len();
+	}
+
+	payloadSizeSum(): number {
+		return this.native.payload_size_sum();
 	}
 
 	has(hash: string): boolean {

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -65,6 +65,7 @@ pub struct LogGraphIndex {
     entries: IndexMap<String, LogIndexEntry>,
     children: HashMap<String, IndexSet<String>>,
     query: NativeQueryIndex,
+    payload_size_total: u64,
 }
 
 impl LogGraphIndex {
@@ -76,6 +77,10 @@ impl LogGraphIndex {
         self.entries.len()
     }
 
+    pub fn payload_size_sum(&self) -> u64 {
+        self.payload_size_total
+    }
+
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
@@ -84,6 +89,7 @@ impl LogGraphIndex {
         self.entries.clear();
         self.children.clear();
         self.query.clear();
+        self.payload_size_total = 0;
     }
 
     pub fn has(&self, hash: &str) -> bool {
@@ -110,8 +116,10 @@ impl LogGraphIndex {
         let hash = entry.hash.clone();
         let demotes_nexts = entry.entry_type != ENTRY_TYPE_CUT;
         let nexts = entry.next.clone();
+        let payload_size = entry.payload_size as u64;
 
         self.entries.insert(hash.clone(), entry);
+        self.payload_size_total += payload_size;
         self.reindex(&hash);
 
         for next in nexts {
@@ -129,6 +137,9 @@ impl LogGraphIndex {
     pub fn delete(&mut self, hash: &str) -> Option<LogIndexEntry> {
         let entry = self.entries.shift_remove(hash)?;
         self.query.delete(hash);
+        self.payload_size_total = self
+            .payload_size_total
+            .saturating_sub(entry.payload_size as u64);
 
         for next in &entry.next {
             if let Some(children) = self.children.get_mut(next) {
@@ -399,6 +410,10 @@ impl NativeLogIndex {
         self.inner.len()
     }
 
+    pub fn payload_size_sum(&self) -> f64 {
+        self.inner.payload_size_sum() as f64
+    }
+
     pub fn has(&self, hash: &str) -> bool {
         self.inner.has(hash)
     }
@@ -621,6 +636,36 @@ mod tests {
         assert_eq!(index.heads(None), vec!["a", "b", "c"]);
         assert_eq!(index.heads(Some("one")), vec!["a", "b"]);
         assert_eq!(index.heads(Some("two")), vec!["c"]);
+    }
+
+    #[test]
+    fn sums_payload_sizes() {
+        let mut index = LogGraphIndex::new();
+        index.put(LogIndexEntry::new(
+            "a",
+            "one",
+            Vec::new(),
+            APPEND,
+            1,
+            0,
+            7,
+            true,
+        ));
+        index.put(LogIndexEntry::new(
+            "b",
+            "one",
+            Vec::new(),
+            APPEND,
+            2,
+            0,
+            9,
+            true,
+        ));
+
+        assert_eq!(index.payload_size_sum(), 16);
+
+        index.delete("a");
+        assert_eq!(index.payload_size_sum(), 9);
     }
 
     #[test]

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -130,6 +130,17 @@ describe("native log graph index", () => {
 		expect([...index.hasMany(["missing", "a", "c"])]).to.deep.equal(["a", "c"]);
 	});
 
+	it("sums payload sizes", async () => {
+		const index = await createLogGraphIndex();
+		index.put({ ...entry("a", "g", [], 1n), payloadSize: 7 });
+		index.put({ ...entry("b", "g", [], 2n), payloadSize: 9 });
+
+		expect(index.payloadSizeSum()).to.equal(16);
+
+		index.delete("a");
+		expect(index.payloadSizeSum()).to.equal(9);
+	});
+
 	it("returns child join entries for cut recursion", async () => {
 		const index = await createLogGraphIndex();
 		index.put(entry("a", "g", [], 1n));

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -78,6 +78,7 @@ export type NativeLogGraph = {
 		hashes: Iterable<string>,
 		skipFirst?: boolean,
 	) => string[];
+	payloadSizeSum: () => number;
 	countHasNext: (next: string, excludeHash?: string) => number;
 	shadowedGids: (gid: string, next: string[], excludeHash?: string) => string[];
 	planJoin: (
@@ -897,6 +898,9 @@ export class EntryIndex<T> {
 	}
 
 	async getMemoryUsage() {
+		if (this.properties.nativeGraph) {
+			return this.properties.nativeGraph.graph.payloadSizeSum();
+		}
 		const indexed =
 			(await this.properties.index.sum({ key: "payloadSize" })) || 0;
 		const pending = [...this.pendingIndexWrites.values()].reduce(

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -202,6 +202,28 @@ describe("native graph", () => {
 		}
 	});
 
+	it("reads memory usage from the native graph", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+		});
+		const indexSumSpy = sinon.spy(log.entryIndex.properties.index, "sum");
+		const nativeGraph = log.entryIndex.properties.nativeGraph!.graph;
+		const payloadSizeSumSpy = sinon.spy(nativeGraph, "payloadSizeSum");
+		try {
+			await log.append(new Uint8Array([1, 2, 3]), { meta: { next: [] } });
+
+			expect(await log.entryIndex.getMemoryUsage()).greaterThan(0);
+			expect(payloadSizeSumSpy.callCount).equal(1);
+			expect(indexSumSpy.callCount).equal(0);
+		} finally {
+			payloadSizeSumSpy.restore();
+			indexSumSpy.restore();
+			await log.close();
+		}
+	});
+
 	it("plans cut recursion deletes in the native graph", async () => {
 		const log = new Log<Uint8Array>();
 		await log.open(store, signKey, {


### PR DESCRIPTION
## Summary
- add constant-time native payload-size accounting to `@peerbit/log-rust`
- route `EntryIndex.getMemoryUsage()` through the native graph when `nativeGraph` is enabled
- add coverage proving native memory accounting bypasses generic `index.sum`
- add `getMemoryUsage()` to the native graph benchmark

## Local validation
- `cargo fmt --manifest-path packages/log/rust/Cargo.toml`
- `pnpm exec prettier --write packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/src/entry-index.ts packages/log/test/native-graph.spec.ts packages/log/benchmark/native-graph.ts`
- `cargo test --manifest-path packages/log/rust/Cargo.toml`
- `pnpm --filter @peerbit/log-rust run build`
- `pnpm exec eslint --config eslint.config.js packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/src/entry-index.ts packages/log/test/native-graph.spec.ts packages/log/benchmark/native-graph.ts`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log/rust -- -t node --grep "sums payload sizes|plans recursive cut deletes|child join entries|batches membership checks"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "native graph"`

## Benchmark signal
Command:
`PEERBIT_LOG_NATIVE_GRAPH_ENTRIES=1000 PEERBIT_LOG_NATIVE_GRAPH_JOIN_PARENTS=1000 PEERBIT_LOG_NATIVE_GRAPH_APPEND_ENTRIES=500 PEERBIT_LOG_NATIVE_GRAPH_ITERATIONS=1000 TS_NODE_PROJECT=./tsconfig.json node --loader ts-node/esm ./packages/log/benchmark/native-graph.ts`

Local row for this PR:
- `getMemoryUsage()`, nativeGraph=false: 105 ms, ~9.5k ops/sec
- `getMemoryUsage()`, nativeGraph=true: 1 ms, ~1.79M ops/sec
