### PR TITLE
feat: serve shaped log heads from native graph

### DIFF
--- a/packages/log/benchmark/native-graph.ts
+++ b/packages/log/benchmark/native-graph.ts
@@ -347,6 +347,35 @@ for (const nativeGraph of [false, true]) {
 }
 
 for (const nativeGraph of [false, true]) {
+	const { log, store } = await createHeadsLog(nativeGraph);
+	rows.push(
+		await measure("getHeads(hash shape).all()", nativeGraph, async () => {
+			await log.entryIndex
+				.getHeads(undefined, { type: "shape", shape: { hash: true } })
+				.all();
+		}),
+	);
+	await log.close();
+	await store.stop();
+}
+
+for (const nativeGraph of [false, true]) {
+	const { log, store } = await createHeadsLog(nativeGraph);
+	rows.push(
+		await measure("getHeads(data shape).all()", nativeGraph, async () => {
+			await log.entryIndex
+				.getHeads(undefined, {
+					type: "shape",
+					shape: { hash: true, meta: { data: true } },
+				})
+				.all();
+		}),
+	);
+	await log.close();
+	await store.stop();
+}
+
+for (const nativeGraph of [false, true]) {
 	const { log, rootHash, store } = await createChainLog(nativeGraph);
 	rows.push(
 		await measure("countHasNext(root)", nativeGraph, async () => {

--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -5,6 +5,7 @@ export type NativeLogEntry = {
 	type: number;
 	head?: boolean;
 	payloadSize?: number;
+	data?: Uint8Array;
 	clock: {
 		timestamp: {
 			wallTime: bigint | number | string;
@@ -30,6 +31,13 @@ export type NativeLogJoinEntry = NativeLogHeadEntry & {
 	meta: NativeLogHeadEntry["meta"] & {
 		type: number;
 		next: string[];
+	};
+};
+
+export type NativeLogHeadDataEntry = {
+	hash: string;
+	meta: {
+		data?: Uint8Array;
 	};
 };
 
@@ -61,10 +69,12 @@ type NativeLogIndexHandle = {
 		logical: number,
 		payloadSize: number,
 		head: boolean,
+		data?: Uint8Array,
 	) => void;
 	delete: (hash: string) => boolean;
 	heads: (gid?: string) => string[];
 	head_entries: (gid?: string) => unknown[];
+	head_data_entries: (gid?: string) => unknown[];
 	head_join_entries: (gid?: string) => unknown[];
 	child_join_entries: (hash: string) => unknown[];
 	plan_delete_recursively: (hashes: string[], skipFirst: boolean) => string[];
@@ -164,6 +174,7 @@ export class LogGraphIndex {
 			entry.clock.timestamp.logical ?? 0,
 			entry.payloadSize ?? 0,
 			entry.head ?? true,
+			entry.data,
 		);
 	}
 
@@ -193,6 +204,18 @@ export class LogGraphIndex {
 							logical,
 						},
 					},
+				},
+			};
+		});
+	}
+
+	headDataEntries(gid?: string): NativeLogHeadDataEntry[] {
+		return this.native.head_data_entries(gid).map((row) => {
+			const [hash, data] = row as [string, Uint8Array | undefined];
+			return {
+				hash,
+				meta: {
+					data,
 				},
 			};
 		});

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -1,5 +1,5 @@
 use indexmap::{IndexMap, IndexSet};
-use js_sys::Array;
+use js_sys::{Array, Uint8Array};
 use peerbit_indexer_rust::planner::{
     DocumentFields, FieldValue, NativeQueryIndex, Query, SortDirection, SortField,
 };
@@ -26,6 +26,7 @@ pub struct LogIndexEntry {
     pub logical: u32,
     pub payload_size: u32,
     pub head: bool,
+    pub data: Option<Vec<u8>>,
 }
 
 impl LogIndexEntry {
@@ -39,6 +40,30 @@ impl LogIndexEntry {
         payload_size: u32,
         head: bool,
     ) -> Self {
+        Self::new_with_data(
+            hash,
+            gid,
+            next,
+            entry_type,
+            wall_time,
+            logical,
+            payload_size,
+            head,
+            None,
+        )
+    }
+
+    pub fn new_with_data(
+        hash: impl Into<String>,
+        gid: impl Into<String>,
+        next: Vec<String>,
+        entry_type: u8,
+        wall_time: u64,
+        logical: u32,
+        payload_size: u32,
+        head: bool,
+        data: Option<Vec<u8>>,
+    ) -> Self {
         Self {
             hash: hash.into(),
             gid: gid.into(),
@@ -48,6 +73,7 @@ impl LogIndexEntry {
             logical,
             payload_size,
             head,
+            data,
         }
     }
 }
@@ -170,6 +196,10 @@ impl LogGraphIndex {
             .into_iter()
             .filter_map(|hash| self.entries.get(&hash).cloned())
             .collect()
+    }
+
+    pub fn head_data_entries(&self, gid: Option<&str>) -> Vec<LogIndexEntry> {
+        self.head_entries(gid)
     }
 
     pub fn head_join_entries(&self, gid: Option<&str>) -> Vec<LogIndexEntry> {
@@ -433,9 +463,10 @@ impl NativeLogIndex {
         logical: u32,
         payload_size: u32,
         head: bool,
+        data: JsValue,
     ) -> Result<(), JsValue> {
         let next = strings_from_array(next)?;
-        self.inner.put(LogIndexEntry::new(
+        self.inner.put(LogIndexEntry::new_with_data(
             hash,
             gid,
             next,
@@ -444,6 +475,7 @@ impl NativeLogIndex {
             logical,
             payload_size,
             head,
+            optional_bytes_from_js(data),
         ));
         Ok(())
     }
@@ -458,6 +490,10 @@ impl NativeLogIndex {
 
     pub fn head_entries(&self, gid: Option<String>) -> Array {
         log_entries_to_rows(self.inner.head_entries(gid.as_deref()))
+    }
+
+    pub fn head_data_entries(&self, gid: Option<String>) -> Array {
+        log_data_entries_to_rows(self.inner.head_data_entries(gid.as_deref()))
     }
 
     pub fn head_join_entries(&self, gid: Option<String>) -> Array {
@@ -545,6 +581,13 @@ fn strings_to_array(values: Vec<String>) -> Array {
     out
 }
 
+fn optional_bytes_from_js(value: JsValue) -> Option<Vec<u8>> {
+    if value.is_undefined() || value.is_null() {
+        return None;
+    }
+    Some(Uint8Array::new(&value).to_vec())
+}
+
 fn log_entries_to_rows(values: Vec<LogIndexEntry>) -> Array {
     let out = Array::new();
     for entry in values {
@@ -553,6 +596,20 @@ fn log_entries_to_rows(values: Vec<LogIndexEntry>) -> Array {
         row.push(&JsValue::from_str(&entry.gid));
         row.push(&JsValue::from_str(&entry.wall_time.to_string()));
         row.push(&JsValue::from_f64(entry.logical as f64));
+        out.push(&row);
+    }
+    out
+}
+
+fn log_data_entries_to_rows(values: Vec<LogIndexEntry>) -> Array {
+    let out = Array::new();
+    for entry in values {
+        let row = Array::new();
+        row.push(&JsValue::from_str(&entry.hash));
+        match entry.data {
+            Some(data) => row.push(&Uint8Array::from(data.as_slice())),
+            None => row.push(&JsValue::UNDEFINED),
+        };
         out.push(&row);
     }
     out

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -100,6 +100,19 @@ describe("native log graph index", () => {
 		]);
 	});
 
+	it("returns shaped head metadata", async () => {
+		const index = await createLogGraphIndex();
+		index.put({
+			...entry("a", "one", [], 1n),
+			data: new Uint8Array([7, 8, 9]),
+		});
+
+		const heads = index.headDataEntries("one");
+		expect(heads).to.have.length(1);
+		expect(heads[0]!.hash).equal("a");
+		expect([...(heads[0]!.meta.data ?? [])]).to.deep.equal([7, 8, 9]);
+	});
+
 	it("does not demote nexts for cut entries", async () => {
 		const index = await createLogGraphIndex();
 		index.put(entry("a", "g", [], 1n));

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -50,6 +50,7 @@ type NativeLogEntry = {
 	type: number;
 	head?: boolean;
 	payloadSize?: number;
+	data?: Uint8Array;
 	clock: {
 		timestamp: {
 			wallTime: bigint | number | string;
@@ -71,6 +72,7 @@ export type NativeLogGraph = {
 	delete: (hash: string) => boolean;
 	clear: () => void;
 	heads: (gid?: string) => string[];
+	headDataEntries: (gid?: string) => NativeLogHeadDataEntry[];
 	headEntries: (gid?: string) => SortableEntry[];
 	joinHeadEntries: (gid?: string) => NativeLogJoinEntry[];
 	childJoinEntries: (hash: string) => NativeLogJoinEntry[];
@@ -101,6 +103,13 @@ export type NativeLogJoinEntry = SortableEntry & {
 	meta: SortableEntry["meta"] & {
 		type: EntryType;
 		next: string[];
+	};
+};
+
+export type NativeLogHeadDataEntry = {
+	hash: string;
+	meta: {
+		data?: Uint8Array;
 	};
 };
 
@@ -270,6 +279,22 @@ export class EntryIndex<T> {
 		resolve: R = false as R,
 	): ResultsIterator<ReturnTypeFromResolveOptions<R, T>> {
 		if (this.properties.nativeGraph?.useHeads) {
+			const shape = getResolveShape(resolve);
+			if (shape && isHeadHashOnlyShape(shape)) {
+				return this.iterateNativeProjected(
+					() =>
+						this.properties
+							.nativeGraph!.graph.heads(gid)
+							.map((hash) => ({ hash })),
+					shape,
+				) as ResultsIterator<ReturnTypeFromResolveOptions<R, T>>;
+			}
+			if (shape && isHeadDataShape(shape)) {
+				return this.iterateNativeProjected(
+					() => this.properties.nativeGraph!.graph.headDataEntries(gid),
+					shape,
+				) as ResultsIterator<ReturnTypeFromResolveOptions<R, T>>;
+			}
 			return this.iterateNativeHashes(
 				() => this.properties.nativeGraph!.graph.heads(gid),
 				resolve,
@@ -450,6 +475,44 @@ export class EntryIndex<T> {
 			},
 			all: async () => {
 				const all = await getHashes();
+				const remaining = all.slice(offset);
+				offset = all.length;
+				complete = true;
+				return coerce(remaining);
+			},
+		};
+	}
+
+	private iterateNativeProjected<TValue>(
+		values: () => TValue[],
+		shape: Shape,
+	): ResultsIterator<unknown> {
+		let valuesPromise: Promise<TValue[]> | undefined;
+		let offset = 0;
+		let complete = false;
+
+		const getValues = async () => {
+			if (!valuesPromise) {
+				valuesPromise = this.flushPendingWrites().then(() => values());
+			}
+			return valuesPromise;
+		};
+
+		const coerce = (values: TValue[]) =>
+			values.map((value) => projectShape(value, shape));
+
+		return {
+			close: () => undefined,
+			done: () => complete,
+			next: async (amount: number) => {
+				const all = await getValues();
+				const batch = all.slice(offset, offset + amount);
+				offset += batch.length;
+				complete = offset >= all.length;
+				return coerce(batch);
+			},
+			all: async () => {
+				const all = await getValues();
 				const remaining = all.slice(offset);
 				offset = all.length;
 				complete = true;
@@ -1225,6 +1288,7 @@ const toNativeLogEntry = (entry: ShallowEntry): NativeLogEntry => ({
 	type: entry.meta.type,
 	head: entry.head,
 	payloadSize: entry.payloadSize,
+	data: entry.meta.data,
 	clock: {
 		timestamp: {
 			wallTime: entry.meta.clock.timestamp.wallTime,
@@ -1232,6 +1296,32 @@ const toNativeLogEntry = (entry: ShallowEntry): NativeLogEntry => ({
 		},
 	},
 });
+
+const getResolveShape = (options: MaybeResolveOptions | undefined) =>
+	options && options !== true && options.type === "shape"
+		? options.shape
+		: undefined;
+
+const isHeadHashOnlyShape = (shape: Shape) => {
+	const keys = Object.keys(shape);
+	return keys.length === 1 && shape.hash === true;
+};
+
+const isHeadDataShape = (shape: Shape) => {
+	const keys = Object.keys(shape);
+	if (keys.some((key) => key !== "hash" && key !== "meta")) {
+		return false;
+	}
+	if (shape.hash !== undefined && shape.hash !== true) {
+		return false;
+	}
+	const meta = shape.meta as Shape | undefined;
+	if (!meta || typeof meta !== "object") {
+		return false;
+	}
+	const metaKeys = Object.keys(meta);
+	return metaKeys.length === 1 && meta.data === true;
+};
 
 const projectShape = (value: any, shape: Shape): any => {
 	const out: any = {};

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -111,6 +111,53 @@ describe("native graph", () => {
 		}
 	});
 
+	it("serves shaped native graph heads without index reads", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			appendDurability: "strict",
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+		});
+		const { entry } = await log.append(new Uint8Array([1]), {
+			meta: { next: [], data: new Uint8Array([7, 8]) },
+		});
+
+		const indexGetSpy = sinon.spy(log.entryIndex.properties.index, "get");
+		const indexIterateSpy = sinon.spy(
+			log.entryIndex.properties.index,
+			"iterate",
+		);
+		const nativeGraph = log.entryIndex.properties.nativeGraph!.graph;
+		const headsSpy = sinon.spy(nativeGraph, "heads");
+		const headDataEntriesSpy = sinon.spy(nativeGraph, "headDataEntries");
+		try {
+			const hashes = await log.entryIndex
+				.getHeads(undefined, { type: "shape", shape: { hash: true } })
+				.all();
+			const data = await log.entryIndex
+				.getHeads(undefined, {
+					type: "shape",
+					shape: { hash: true, meta: { data: true } },
+				})
+				.all();
+
+			expect(hashes).to.deep.equal([{ hash: entry.hash }]);
+			expect(data).to.have.length(1);
+			expect(data[0]!.hash).equal(entry.hash);
+			expect([...data[0]!.meta.data!]).to.deep.equal([7, 8]);
+			expect(headsSpy.callCount).equal(1);
+			expect(headDataEntriesSpy.callCount).equal(1);
+			expect(indexGetSpy.callCount).equal(0);
+			expect(indexIterateSpy.callCount).equal(0);
+		} finally {
+			headDataEntriesSpy.restore();
+			headsSpy.restore();
+			indexIterateSpy.restore();
+			indexGetSpy.restore();
+			await log.close();
+		}
+	});
+
 	it("plans recursive joins through the native graph", async () => {
 		const source = new Log<Uint8Array>();
 		const target = new Log<Uint8Array>();

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -5368,9 +5368,12 @@ export class SharedLog<
 								from: context.from!,
 							});
 
-							const headsWithGid = await this.log.entryIndex
-								.getHeads(gid)
-								.all();
+							const headsWithGid = (await this.log.entryIndex
+								.getHeads(gid, {
+									type: "shape",
+									shape: { meta: { data: true } },
+								})
+								.all()) as { meta: { data?: Uint8Array } }[];
 
 							const latestEntry = getLatestEntry(entries)!;
 
@@ -5475,7 +5478,12 @@ export class SharedLog<
 									toPersist.push(entry.entry);
 								} else {
 									for (const ref of entry.gidRefrences) {
-										const map = await this.log.entryIndex.getHeads(ref).all();
+										const map = await this.log.entryIndex
+											.getHeads(ref, {
+												type: "shape",
+												shape: { hash: true },
+											})
+											.all();
 										if (map && map.length > 0) {
 											toMerge.push(entry.entry);
 											(toDelete || (toDelete = [])).push(entry.entry);
@@ -5528,9 +5536,12 @@ export class SharedLog<
 
 							if (maybeDelete) {
 								for (const entries of maybeDelete as EntryWithRefs<any>[][]) {
-									const headsWithGid = await this.log.entryIndex
-										.getHeads(entries[0].entry.meta.gid)
-										.all();
+									const headsWithGid = (await this.log.entryIndex
+										.getHeads(entries[0].entry.meta.gid, {
+											type: "shape",
+											shape: { meta: { data: true } },
+										})
+										.all()) as { meta: { data?: Uint8Array } }[];
 									if (headsWithGid && headsWithGid.length > 0) {
 										const minReplicas = maxReplicas(
 											this,


### PR DESCRIPTION
## Summary
- mirror log entry `meta.data` into the native log graph
- serve `getHeads(..., { shape: { hash: true } })` and `getHeads(..., { shape: { hash: true, meta: { data: true } } })` directly from the native graph
- route shared-log replica math call sites to shaped head reads so they avoid generic shallow-entry index hydration
- add shaped head rows to the native graph benchmark

## Local validation
- `cargo fmt --manifest-path packages/log/rust/Cargo.toml`
- `cargo test --manifest-path packages/log/rust/Cargo.toml`
- `pnpm --filter @peerbit/log-rust run build`
- `pnpm exec eslint --config eslint.config.js packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/src/entry-index.ts packages/log/test/native-graph.spec.ts packages/log/benchmark/native-graph.ts packages/programs/data/shared-log/src/index.ts`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log/rust -- -t node --grep "shaped head metadata|sums payload sizes|plans recursive cut deletes|child join entries|batches membership checks"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "native graph"`
- `pnpm --filter @peerbit/shared-log run build`
- `PEERBIT_SHARED_LOG_NATIVE_GRAPH_ENTRIES=100 PEERBIT_SHARED_LOG_NATIVE_GRAPH_RUNS=1 PEERBIT_SHARED_LOG_NATIVE_GRAPH_INDEXERS=rust PEERBIT_SHARED_LOG_NATIVE_GRAPH_SCENARIOS=auto-next TS_NODE_PROJECT=./tsconfig.json node --loader ts-node/esm ./packages/programs/data/shared-log/benchmark/native-graph.ts`

## Benchmark signal
Command:
`PEERBIT_LOG_NATIVE_GRAPH_ENTRIES=1000 PEERBIT_LOG_NATIVE_GRAPH_JOIN_PARENTS=1000 PEERBIT_LOG_NATIVE_GRAPH_APPEND_ENTRIES=500 PEERBIT_LOG_NATIVE_GRAPH_ITERATIONS=1000 TS_NODE_PROJECT=./tsconfig.json node --loader ts-node/esm ./packages/log/benchmark/native-graph.ts`

Local rows for this PR:
- `getHeads(hash shape).all()`, nativeGraph=false: 3320 ms, ~301 ops/sec
- `getHeads(hash shape).all()`, nativeGraph=true: 457 ms, ~2189 ops/sec
- `getHeads(data shape).all()`, nativeGraph=false: 3401 ms, ~294 ops/sec
- `getHeads(data shape).all()`, nativeGraph=true: 706 ms, ~1417 ops/sec
