### PR TITLE
feat: compute shared log replica heads in native graph

### DIFF
--- a/packages/log/benchmark/native-graph.ts
+++ b/packages/log/benchmark/native-graph.ts
@@ -27,6 +27,24 @@ const joinParents = Number(
 
 const key = await Ed25519Keypair.create();
 
+const absoluteReplicaData = (value: number) =>
+	new Uint8Array([
+		0,
+		value & 0xff,
+		(value >>> 8) & 0xff,
+		(value >>> 16) & 0xff,
+		(value >>> 24) & 0xff,
+	]);
+
+const decodeAbsoluteReplicaData = (data?: Uint8Array) => {
+	if (!data || data.length !== 5 || data[0] !== 0) {
+		return undefined;
+	}
+	return (
+		(data[1]! | (data[2]! << 8) | (data[3]! << 16) | (data[4]! << 24)) >>> 0
+	);
+};
+
 const createHeadsLog = async (nativeGraph: boolean) => {
 	const store = new AnyBlockStore();
 	await store.start();
@@ -38,6 +56,23 @@ const createHeadsLog = async (nativeGraph: boolean) => {
 	});
 	for (let i = 0; i < entries; i++) {
 		await log.append(new Uint8Array([i & 0xff]), { meta: { next: [] } });
+	}
+	return { log, store };
+};
+
+const createReplicaHeadsLog = async (nativeGraph: boolean) => {
+	const store = new AnyBlockStore();
+	await store.start();
+	const log = new Log<Uint8Array>();
+	await log.open(store, key, {
+		appendDurability: "strict",
+		indexer: new HashmapIndices(),
+		nativeGraph,
+	});
+	for (let i = 0; i < entries; i++) {
+		await log.append(new Uint8Array([i & 0xff]), {
+			meta: { next: [], data: absoluteReplicaData((i % 8) + 1) },
+		});
 	}
 	return { log, store };
 };
@@ -85,6 +120,27 @@ const measure = async (
 };
 
 const rows: BenchRow[] = [];
+
+const getMaxHeadDataU32 = async (log: Log<Uint8Array>) => {
+	const nativeMax = await log.entryIndex.getMaxHeadDataU32();
+	if (nativeMax != null) {
+		return nativeMax;
+	}
+	const heads = (await log.entryIndex
+		.getHeads(undefined, {
+			type: "shape",
+			shape: { meta: { data: true } },
+		})
+		.all()) as { meta: { data?: Uint8Array } }[];
+	let max = 0;
+	for (const head of heads) {
+		const value = decodeAbsoluteReplicaData(head.meta.data);
+		if (value != null) {
+			max = Math.max(max, value);
+		}
+	}
+	return max;
+};
 
 const measureAppend = async (
 	name: string,
@@ -360,7 +416,7 @@ for (const nativeGraph of [false, true]) {
 }
 
 for (const nativeGraph of [false, true]) {
-	const { log, store } = await createHeadsLog(nativeGraph);
+	const { log, store } = await createReplicaHeadsLog(nativeGraph);
 	rows.push(
 		await measure("getHeads(data shape).all()", nativeGraph, async () => {
 			await log.entryIndex
@@ -369,6 +425,17 @@ for (const nativeGraph of [false, true]) {
 					shape: { hash: true, meta: { data: true } },
 				})
 				.all();
+		}),
+	);
+	await log.close();
+	await store.stop();
+}
+
+for (const nativeGraph of [false, true]) {
+	const { log, store } = await createReplicaHeadsLog(nativeGraph);
+	rows.push(
+		await measure("getMaxHeadDataU32()", nativeGraph, async () => {
+			await getMaxHeadDataU32(log);
 		}),
 	);
 	await log.close();

--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -75,6 +75,7 @@ type NativeLogIndexHandle = {
 	heads: (gid?: string) => string[];
 	head_entries: (gid?: string) => unknown[];
 	head_data_entries: (gid?: string) => unknown[];
+	max_head_data_u32: (gid?: string) => number | undefined;
 	head_join_entries: (gid?: string) => unknown[];
 	child_join_entries: (hash: string) => unknown[];
 	plan_delete_recursively: (hashes: string[], skipFirst: boolean) => string[];
@@ -219,6 +220,10 @@ export class LogGraphIndex {
 				},
 			};
 		});
+	}
+
+	maxHeadDataU32(gid?: string): number | undefined {
+		return this.native.max_head_data_u32(gid);
 	}
 
 	joinHeadEntries(gid?: string): NativeLogJoinEntry[] {

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -202,6 +202,15 @@ impl LogGraphIndex {
         self.head_entries(gid)
     }
 
+    pub fn max_head_data_u32(&self, gid: Option<&str>) -> Option<u32> {
+        let mut max = None;
+        for entry in self.head_data_entries(gid) {
+            let value = decode_absolute_replica_data_u32(entry.data.as_deref())?;
+            max = Some(max.map_or(value, |current: u32| current.max(value)));
+        }
+        max
+    }
+
     pub fn head_join_entries(&self, gid: Option<&str>) -> Vec<LogIndexEntry> {
         self.head_entries(gid)
     }
@@ -496,6 +505,13 @@ impl NativeLogIndex {
         log_data_entries_to_rows(self.inner.head_data_entries(gid.as_deref()))
     }
 
+    pub fn max_head_data_u32(&self, gid: Option<String>) -> JsValue {
+        self.inner
+            .max_head_data_u32(gid.as_deref())
+            .map(|value| JsValue::from_f64(value as f64))
+            .unwrap_or(JsValue::UNDEFINED)
+    }
+
     pub fn head_join_entries(&self, gid: Option<String>) -> Array {
         log_join_entries_to_rows(self.inner.head_join_entries(gid.as_deref()))
     }
@@ -586,6 +602,14 @@ fn optional_bytes_from_js(value: JsValue) -> Option<Vec<u8>> {
         return None;
     }
     Some(Uint8Array::new(&value).to_vec())
+}
+
+fn decode_absolute_replica_data_u32(data: Option<&[u8]>) -> Option<u32> {
+    let data = data?;
+    if data.len() != 5 || data[0] != 0 {
+        return None;
+    }
+    Some(u32::from_le_bytes([data[1], data[2], data[3], data[4]]))
 }
 
 fn log_entries_to_rows(values: Vec<LogIndexEntry>) -> Array {

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -20,6 +20,15 @@ const entry = (
 	clock: { timestamp: { wallTime, logical: 0 } },
 });
 
+const absoluteReplicaData = (value: number) =>
+	new Uint8Array([
+		0,
+		value & 0xff,
+		(value >>> 8) & 0xff,
+		(value >>> 16) & 0xff,
+		(value >>> 24) & 0xff,
+	]);
+
 describe("native log graph index", () => {
 	it("tracks heads and next adjacency", async () => {
 		const index = await createLogGraphIndex();
@@ -104,13 +113,33 @@ describe("native log graph index", () => {
 		const index = await createLogGraphIndex();
 		index.put({
 			...entry("a", "one", [], 1n),
-			data: new Uint8Array([7, 8, 9]),
+			data: absoluteReplicaData(9),
 		});
 
 		const heads = index.headDataEntries("one");
 		expect(heads).to.have.length(1);
 		expect(heads[0]!.hash).equal("a");
-		expect([...(heads[0]!.meta.data ?? [])]).to.deep.equal([7, 8, 9]);
+		expect([...(heads[0]!.meta.data ?? [])]).to.deep.equal([0, 9, 0, 0, 0]);
+	});
+
+	it("computes max u32 from shaped head metadata", async () => {
+		const index = await createLogGraphIndex();
+		index.put({
+			...entry("a", "one", [], 1n),
+			data: absoluteReplicaData(2),
+		});
+		index.put({
+			...entry("b", "one", [], 2n),
+			data: absoluteReplicaData(5),
+		});
+		index.put({
+			...entry("c", "two", [], 3n),
+			data: absoluteReplicaData(9),
+		});
+
+		expect(index.maxHeadDataU32("one")).equal(5);
+		expect(index.maxHeadDataU32("two")).equal(9);
+		expect(index.maxHeadDataU32("missing")).equal(undefined);
 	});
 
 	it("does not demote nexts for cut entries", async () => {

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -73,6 +73,7 @@ export type NativeLogGraph = {
 	clear: () => void;
 	heads: (gid?: string) => string[];
 	headDataEntries: (gid?: string) => NativeLogHeadDataEntry[];
+	maxHeadDataU32: (gid?: string) => number | undefined;
 	headEntries: (gid?: string) => SortableEntry[];
 	joinHeadEntries: (gid?: string) => NativeLogJoinEntry[];
 	childJoinEntries: (hash: string) => NativeLogJoinEntry[];
@@ -321,6 +322,14 @@ export class EntryIndex<T> {
 			return undefined;
 		}
 		return this.properties.nativeGraph.graph.headEntries(gid);
+	}
+
+	async getMaxHeadDataU32(gid?: string): Promise<number | undefined> {
+		if (!this.properties.nativeGraph?.useHeads) {
+			return undefined;
+		}
+		await this.flushPendingWrites();
+		return this.properties.nativeGraph.graph.maxHeadDataU32(gid);
 	}
 
 	getJoinHeads(gid?: string): Promise<NativeLogJoinEntry[]> {

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -6,6 +6,15 @@ import sinon from "sinon";
 import { EntryType } from "../src/entry-type.js";
 import { Log } from "../src/log.js";
 
+const absoluteReplicaData = (value: number) =>
+	new Uint8Array([
+		0,
+		value & 0xff,
+		(value >>> 8) & 0xff,
+		(value >>> 16) & 0xff,
+		(value >>> 24) & 0xff,
+	]);
+
 describe("native graph", () => {
 	let store: AnyBlockStore;
 	let signKey: Ed25519Keypair;
@@ -154,6 +163,37 @@ describe("native graph", () => {
 			headsSpy.restore();
 			indexIterateSpy.restore();
 			indexGetSpy.restore();
+			await log.close();
+		}
+	});
+
+	it("computes max head data u32 in the native graph", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			appendDurability: "strict",
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+		});
+		await log.append(new Uint8Array([1]), {
+			meta: { next: [], data: absoluteReplicaData(2) },
+		});
+		await log.append(new Uint8Array([2]), {
+			meta: { next: [], data: absoluteReplicaData(5) },
+		});
+
+		const indexIterateSpy = sinon.spy(
+			log.entryIndex.properties.index,
+			"iterate",
+		);
+		const nativeGraph = log.entryIndex.properties.nativeGraph!.graph;
+		const maxHeadDataU32Spy = sinon.spy(nativeGraph, "maxHeadDataU32");
+		try {
+			expect(await log.entryIndex.getMaxHeadDataU32()).equal(5);
+			expect(maxHeadDataU32Spy.callCount).equal(1);
+			expect(indexIterateSpy.callCount).equal(0);
+		} finally {
+			maxHeadDataU32Spy.restore();
+			indexIterateSpy.restore();
 			await log.close();
 		}
 	});

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -4917,6 +4917,29 @@ export class SharedLog<
 		/* ((await this.log.entryIndex?.getMemoryUsage()) || 0) */ // + (await this.log.blocks.size())
 	}
 
+	private clampReplicas(value: number) {
+		const lower = this.replicas.min?.getValue(this) || 1;
+		const higher = this.replicas.max?.getValue(this) ?? Number.MAX_SAFE_INTEGER;
+		return Math.max(Math.min(higher, value), lower);
+	}
+
+	private async getMaxReplicasFromHeads(gid: string) {
+		const nativeMax = await this.log.entryIndex.getMaxHeadDataU32(gid);
+		if (nativeMax != null) {
+			return this.clampReplicas(nativeMax);
+		}
+		const headsWithGid = (await this.log.entryIndex
+			.getHeads(gid, {
+				type: "shape",
+				shape: { meta: { data: true } },
+			})
+			.all()) as { meta: { data?: Uint8Array } }[];
+		if (headsWithGid.length === 0) {
+			return undefined;
+		}
+		return maxReplicas(this, headsWithGid.values());
+	}
+
 	get topic() {
 		return this.log.idString;
 	}
@@ -5368,19 +5391,11 @@ export class SharedLog<
 								from: context.from!,
 							});
 
-							const headsWithGid = (await this.log.entryIndex
-								.getHeads(gid, {
-									type: "shape",
-									shape: { meta: { data: true } },
-								})
-								.all()) as { meta: { data?: Uint8Array } }[];
-
 							const latestEntry = getLatestEntry(entries)!;
 
 							const maxReplicasFromHead =
-								headsWithGid && headsWithGid.length > 0
-									? maxReplicas(this, [...headsWithGid.values()])
-									: this.replicas.min.getValue(this);
+								(await this.getMaxReplicasFromHeads(gid)) ??
+								this.replicas.min.getValue(this);
 
 							const maxReplicasFromNewEntries = maxReplicas(
 								this,
@@ -5536,18 +5551,10 @@ export class SharedLog<
 
 							if (maybeDelete) {
 								for (const entries of maybeDelete as EntryWithRefs<any>[][]) {
-									const headsWithGid = (await this.log.entryIndex
-										.getHeads(entries[0].entry.meta.gid, {
-											type: "shape",
-											shape: { meta: { data: true } },
-										})
-										.all()) as { meta: { data?: Uint8Array } }[];
-									if (headsWithGid && headsWithGid.length > 0) {
-										const minReplicas = maxReplicas(
-											this,
-											headsWithGid.values(),
-										);
-
+									const minReplicas = await this.getMaxReplicasFromHeads(
+										entries[0].entry.meta.gid,
+									);
+									if (minReplicas != null) {
 										const isLeader = await this.isLeader({
 											entry: entries[0].entry,
 											replicas: minReplicas,


### PR DESCRIPTION
## Summary
- expose a native graph max-head-data-u32 helper for shared-log AbsoluteReplicas head metadata
- let EntryIndex flush pending writes and answer that max from the Rust graph without scanning the TS index
- switch shared-log replica head planning/maybe-delete checks to the native helper, with the existing shaped-head decode path as compatibility fallback
- add native-graph tests and a benchmark row for the new path

## Local benchmark
Command:
`PEERBIT_LOG_NATIVE_GRAPH_ENTRIES=1000 PEERBIT_LOG_NATIVE_GRAPH_APPEND_ENTRIES=500 PEERBIT_LOG_NATIVE_GRAPH_JOIN_PARENTS=1000 node --loader ts-node/esm ./packages/log/benchmark/native-graph.ts`

Relevant rows:
- `getHeads(data shape).all()`: JS fallback 282 ops/sec, native graph 1014 ops/sec
- `getMaxHeadDataU32()`: JS fallback 278 ops/sec, native graph 2356 ops/sec

This moves the shared-log replica-head decision from "read every shaped head into JS and decode there" to "ask the Rust graph for the max value" when native heads are enabled.

## Validation
- `cargo fmt --manifest-path packages/log/rust/Cargo.toml`
- `pnpm exec prettier --write packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/src/entry-index.ts packages/log/test/native-graph.spec.ts packages/log/benchmark/native-graph.ts`
- `cargo test --manifest-path packages/log/rust/Cargo.toml`
- `pnpm --filter @peerbit/log-rust run build`
- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm exec eslint --config eslint.config.js packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/src/entry-index.ts packages/log/test/native-graph.spec.ts packages/log/benchmark/native-graph.ts packages/programs/data/shared-log/src/index.ts`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log/rust -- -t node --grep "max u32|shaped head metadata|sums payload sizes|plans recursive cut deletes|child join entries|batches membership checks"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "native graph"`
