### PR TITLE
feat: check log head existence in native graph

### DIFF
--- a/packages/log/benchmark/native-graph.ts
+++ b/packages/log/benchmark/native-graph.ts
@@ -121,6 +121,17 @@ const measure = async (
 
 const rows: BenchRow[] = [];
 
+const hasHead = async (log: Log<Uint8Array>) => {
+	const nativeHasHead = await log.entryIndex.hasHead();
+	if (nativeHasHead != null) {
+		return nativeHasHead;
+	}
+	const heads = await log.entryIndex
+		.getHeads(undefined, { type: "shape", shape: { hash: true } })
+		.all();
+	return heads.length > 0;
+};
+
 const getMaxHeadDataU32 = async (log: Log<Uint8Array>) => {
 	const nativeMax = await log.entryIndex.getMaxHeadDataU32();
 	if (nativeMax != null) {
@@ -409,6 +420,17 @@ for (const nativeGraph of [false, true]) {
 			await log.entryIndex
 				.getHeads(undefined, { type: "shape", shape: { hash: true } })
 				.all();
+		}),
+	);
+	await log.close();
+	await store.stop();
+}
+
+for (const nativeGraph of [false, true]) {
+	const { log, store } = await createHeadsLog(nativeGraph);
+	rows.push(
+		await measure("hasHead()", nativeGraph, async () => {
+			await hasHead(log);
 		}),
 	);
 	await log.close();

--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -73,6 +73,7 @@ type NativeLogIndexHandle = {
 	) => void;
 	delete: (hash: string) => boolean;
 	heads: (gid?: string) => string[];
+	has_head: (gid?: string) => boolean;
 	head_entries: (gid?: string) => unknown[];
 	head_data_entries: (gid?: string) => unknown[];
 	max_head_data_u32: (gid?: string) => number | undefined;
@@ -185,6 +186,10 @@ export class LogGraphIndex {
 
 	heads(gid?: string): string[] {
 		return this.native.heads(gid);
+	}
+
+	hasHead(gid?: string): boolean {
+		return this.native.has_head(gid);
 	}
 
 	headEntries(gid?: string): NativeLogHeadEntry[] {

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -191,6 +191,14 @@ impl LogGraphIndex {
         self.query.search(&query, &head_sort(), None)
     }
 
+    pub fn has_head(&self, gid: Option<&str>) -> bool {
+        let query = match gid {
+            Some(gid) => Query::And(vec![head_query(), gid_query(gid)]),
+            None => head_query(),
+        };
+        self.query.count(&query) > 0
+    }
+
     pub fn head_entries(&self, gid: Option<&str>) -> Vec<LogIndexEntry> {
         self.heads(gid)
             .into_iter()
@@ -497,6 +505,10 @@ impl NativeLogIndex {
         strings_to_array(self.inner.heads(gid.as_deref()))
     }
 
+    pub fn has_head(&self, gid: Option<String>) -> bool {
+        self.inner.has_head(gid.as_deref())
+    }
+
     pub fn head_entries(&self, gid: Option<String>) -> Array {
         log_entries_to_rows(self.inner.head_entries(gid.as_deref()))
     }
@@ -717,6 +729,10 @@ mod tests {
         assert_eq!(index.heads(None), vec!["a", "b", "c"]);
         assert_eq!(index.heads(Some("one")), vec!["a", "b"]);
         assert_eq!(index.heads(Some("two")), vec!["c"]);
+        assert!(index.has_head(None));
+        assert!(index.has_head(Some("one")));
+        assert!(index.has_head(Some("two")));
+        assert!(!index.has_head(Some("missing")));
     }
 
     #[test]

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -62,6 +62,10 @@ describe("native log graph index", () => {
 		expect(index.heads()).to.deep.equal(["a", "b", "c"]);
 		expect(index.heads("one")).to.deep.equal(["a", "b"]);
 		expect(index.heads("two")).to.deep.equal(["c"]);
+		expect(index.hasHead()).equal(true);
+		expect(index.hasHead("one")).equal(true);
+		expect(index.hasHead("two")).equal(true);
+		expect(index.hasHead("missing")).equal(false);
 	});
 
 	it("returns sortable head metadata for append planning", async () => {

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -72,6 +72,7 @@ export type NativeLogGraph = {
 	delete: (hash: string) => boolean;
 	clear: () => void;
 	heads: (gid?: string) => string[];
+	hasHead: (gid?: string) => boolean;
 	headDataEntries: (gid?: string) => NativeLogHeadDataEntry[];
 	maxHeadDataU32: (gid?: string) => number | undefined;
 	headEntries: (gid?: string) => SortableEntry[];
@@ -322,6 +323,14 @@ export class EntryIndex<T> {
 			return undefined;
 		}
 		return this.properties.nativeGraph.graph.headEntries(gid);
+	}
+
+	async hasHead(gid?: string): Promise<boolean | undefined> {
+		if (!this.properties.nativeGraph?.useHeads) {
+			return undefined;
+		}
+		await this.flushPendingWrites();
+		return this.properties.nativeGraph.graph.hasHead(gid);
 	}
 
 	async getMaxHeadDataU32(gid?: string): Promise<number | undefined> {

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -198,6 +198,33 @@ describe("native graph", () => {
 		}
 	});
 
+	it("checks head existence in the native graph", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			appendDurability: "strict",
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+		});
+		await log.append(new Uint8Array([1]), { meta: { next: [] } });
+
+		const indexIterateSpy = sinon.spy(
+			log.entryIndex.properties.index,
+			"iterate",
+		);
+		const nativeGraph = log.entryIndex.properties.nativeGraph!.graph;
+		const hasHeadSpy = sinon.spy(nativeGraph, "hasHead");
+		try {
+			expect(await log.entryIndex.hasHead()).equal(true);
+			expect(await log.entryIndex.hasHead("missing")).equal(false);
+			expect(hasHeadSpy.callCount).equal(2);
+			expect(indexIterateSpy.callCount).equal(0);
+		} finally {
+			hasHeadSpy.restore();
+			indexIterateSpy.restore();
+			await log.close();
+		}
+	});
+
 	it("plans recursive joins through the native graph", async () => {
 		const source = new Log<Uint8Array>();
 		const target = new Log<Uint8Array>();

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -4940,6 +4940,20 @@ export class SharedLog<
 		return maxReplicas(this, headsWithGid.values());
 	}
 
+	private async hasHeadForGid(gid: string) {
+		const nativeHasHead = await this.log.entryIndex.hasHead(gid);
+		if (nativeHasHead != null) {
+			return nativeHasHead;
+		}
+		const heads = await this.log.entryIndex
+			.getHeads(gid, {
+				type: "shape",
+				shape: { hash: true },
+			})
+			.all();
+		return heads.length > 0;
+	}
+
 	get topic() {
 		return this.log.idString;
 	}
@@ -5493,13 +5507,7 @@ export class SharedLog<
 									toPersist.push(entry.entry);
 								} else {
 									for (const ref of entry.gidRefrences) {
-										const map = await this.log.entryIndex
-											.getHeads(ref, {
-												type: "shape",
-												shape: { hash: true },
-											})
-											.all();
-										if (map && map.length > 0) {
+										if (await this.hasHeadForGid(ref)) {
 											toMerge.push(entry.entry);
 											(toDelete || (toDelete = [])).push(entry.entry);
 											continue outer;


### PR DESCRIPTION
## Summary
- add a native `hasHead` predicate to the Rust log graph and expose it through `EntryIndex`
- switch the shared-log gid-reference merge check from shaped `getHeads(...).all().length` to the native predicate when available
- keep the shaped-head path as fallback for non-native graph configurations
- add native tests and a benchmark row for the predicate

## Local benchmark
Command:
`PEERBIT_LOG_NATIVE_GRAPH_ENTRIES=1000 PEERBIT_LOG_NATIVE_GRAPH_APPEND_ENTRIES=500 PEERBIT_LOG_NATIVE_GRAPH_JOIN_PARENTS=1000 node --loader ts-node/esm ./packages/log/benchmark/native-graph.ts`

Relevant row:
- `hasHead()`: JS fallback 308 ops/sec, native graph 9361 ops/sec

## Validation
- `cargo fmt --manifest-path packages/log/rust/Cargo.toml`
- `pnpm exec prettier --write packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/src/entry-index.ts packages/log/test/native-graph.spec.ts packages/log/benchmark/native-graph.ts`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log/rust -- -t node --grep "hasHead|filters heads|max u32|shaped head metadata|sums payload sizes|plans recursive cut deletes|child join entries|batches membership checks"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "native graph"`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm exec eslint --config eslint.config.js packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/src/entry-index.ts packages/log/test/native-graph.spec.ts packages/log/benchmark/native-graph.ts packages/programs/data/shared-log/src/index.ts`
