### PR TITLE
feat: batch native log head existence checks

### DIFF
--- a/packages/log/benchmark/native-graph.ts
+++ b/packages/log/benchmark/native-graph.ts
@@ -54,10 +54,14 @@ const createHeadsLog = async (nativeGraph: boolean) => {
 		indexer: new HashmapIndices(),
 		nativeGraph,
 	});
+	let gid: string | undefined;
 	for (let i = 0; i < entries; i++) {
-		await log.append(new Uint8Array([i & 0xff]), { meta: { next: [] } });
+		const { entry } = await log.append(new Uint8Array([i & 0xff]), {
+			meta: { next: [] },
+		});
+		gid ??= entry.meta.gid;
 	}
-	return { log, store };
+	return { log, store, gid: gid! };
 };
 
 const createReplicaHeadsLog = async (nativeGraph: boolean) => {
@@ -130,6 +134,22 @@ const hasHead = async (log: Log<Uint8Array>) => {
 		.getHeads(undefined, { type: "shape", shape: { hash: true } })
 		.all();
 	return heads.length > 0;
+};
+
+const hasAnyHead = async (log: Log<Uint8Array>, gids: string[]) => {
+	const nativeHasHead = await log.entryIndex.hasAnyHead(gids);
+	if (nativeHasHead != null) {
+		return nativeHasHead;
+	}
+	for (const gid of gids) {
+		const heads = await log.entryIndex
+			.getHeads(gid, { type: "shape", shape: { hash: true } })
+			.all();
+		if (heads.length > 0) {
+			return true;
+		}
+	}
+	return false;
 };
 
 const getMaxHeadDataU32 = async (log: Log<Uint8Array>) => {
@@ -427,10 +447,15 @@ for (const nativeGraph of [false, true]) {
 }
 
 for (const nativeGraph of [false, true]) {
-	const { log, store } = await createHeadsLog(nativeGraph);
+	const { log, store, gid } = await createHeadsLog(nativeGraph);
 	rows.push(
 		await measure("hasHead()", nativeGraph, async () => {
 			await hasHead(log);
+		}),
+	);
+	rows.push(
+		await measure("hasAnyHead(refs)", nativeGraph, async () => {
+			await hasAnyHead(log, ["missing", gid]);
 		}),
 	);
 	await log.close();

--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -74,6 +74,7 @@ type NativeLogIndexHandle = {
 	delete: (hash: string) => boolean;
 	heads: (gid?: string) => string[];
 	has_head: (gid?: string) => boolean;
+	has_any_head: (gids: string[]) => boolean;
 	head_entries: (gid?: string) => unknown[];
 	head_data_entries: (gid?: string) => unknown[];
 	max_head_data_u32: (gid?: string) => number | undefined;
@@ -190,6 +191,10 @@ export class LogGraphIndex {
 
 	hasHead(gid?: string): boolean {
 		return this.native.has_head(gid);
+	}
+
+	hasAnyHead(gids: Iterable<string>): boolean {
+		return this.native.has_any_head([...gids]);
 	}
 
 	headEntries(gid?: string): NativeLogHeadEntry[] {

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -199,6 +199,10 @@ impl LogGraphIndex {
         self.query.count(&query) > 0
     }
 
+    pub fn has_any_head(&self, gids: &[String]) -> bool {
+        gids.iter().any(|gid| self.has_head(Some(gid)))
+    }
+
     pub fn head_entries(&self, gid: Option<&str>) -> Vec<LogIndexEntry> {
         self.heads(gid)
             .into_iter()
@@ -509,6 +513,11 @@ impl NativeLogIndex {
         self.inner.has_head(gid.as_deref())
     }
 
+    pub fn has_any_head(&self, gids: Array) -> Result<bool, JsValue> {
+        let gids = strings_from_array(gids)?;
+        Ok(self.inner.has_any_head(&gids))
+    }
+
     pub fn head_entries(&self, gid: Option<String>) -> Array {
         log_entries_to_rows(self.inner.head_entries(gid.as_deref()))
     }
@@ -733,6 +742,8 @@ mod tests {
         assert!(index.has_head(Some("one")));
         assert!(index.has_head(Some("two")));
         assert!(!index.has_head(Some("missing")));
+        assert!(index.has_any_head(&["missing".to_string(), "two".to_string()]));
+        assert!(!index.has_any_head(&["missing".to_string()]));
     }
 
     #[test]

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -66,6 +66,8 @@ describe("native log graph index", () => {
 		expect(index.hasHead("one")).equal(true);
 		expect(index.hasHead("two")).equal(true);
 		expect(index.hasHead("missing")).equal(false);
+		expect(index.hasAnyHead(["missing", "two"])).equal(true);
+		expect(index.hasAnyHead(["missing"])).equal(false);
 	});
 
 	it("returns sortable head metadata for append planning", async () => {

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -73,6 +73,7 @@ export type NativeLogGraph = {
 	clear: () => void;
 	heads: (gid?: string) => string[];
 	hasHead: (gid?: string) => boolean;
+	hasAnyHead: (gids: Iterable<string>) => boolean;
 	headDataEntries: (gid?: string) => NativeLogHeadDataEntry[];
 	maxHeadDataU32: (gid?: string) => number | undefined;
 	headEntries: (gid?: string) => SortableEntry[];
@@ -331,6 +332,18 @@ export class EntryIndex<T> {
 		}
 		await this.flushPendingWrites();
 		return this.properties.nativeGraph.graph.hasHead(gid);
+	}
+
+	async hasAnyHead(gids: Iterable<string>): Promise<boolean | undefined> {
+		if (!this.properties.nativeGraph?.useHeads) {
+			return undefined;
+		}
+		const uniqueGids = new Set([...gids].filter(Boolean));
+		if (uniqueGids.size === 0) {
+			return false;
+		}
+		await this.flushPendingWrites();
+		return this.properties.nativeGraph.graph.hasAnyHead(uniqueGids);
 	}
 
 	async getMaxHeadDataU32(gid?: string): Promise<number | undefined> {

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -205,7 +205,9 @@ describe("native graph", () => {
 			indexer: new HashmapIndices(),
 			nativeGraph: true,
 		});
-		await log.append(new Uint8Array([1]), { meta: { next: [] } });
+		const { entry } = await log.append(new Uint8Array([1]), {
+			meta: { next: [] },
+		});
 
 		const indexIterateSpy = sinon.spy(
 			log.entryIndex.properties.index,
@@ -213,12 +215,19 @@ describe("native graph", () => {
 		);
 		const nativeGraph = log.entryIndex.properties.nativeGraph!.graph;
 		const hasHeadSpy = sinon.spy(nativeGraph, "hasHead");
+		const hasAnyHeadSpy = sinon.spy(nativeGraph, "hasAnyHead");
 		try {
 			expect(await log.entryIndex.hasHead()).equal(true);
 			expect(await log.entryIndex.hasHead("missing")).equal(false);
+			expect(
+				await log.entryIndex.hasAnyHead(["missing", entry.meta.gid]),
+			).equal(true);
+			expect(await log.entryIndex.hasAnyHead(["missing"])).equal(false);
 			expect(hasHeadSpy.callCount).equal(2);
+			expect(hasAnyHeadSpy.callCount).equal(2);
 			expect(indexIterateSpy.callCount).equal(0);
 		} finally {
+			hasAnyHeadSpy.restore();
 			hasHeadSpy.restore();
 			indexIterateSpy.restore();
 			await log.close();

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -4954,6 +4954,23 @@ export class SharedLog<
 		return heads.length > 0;
 	}
 
+	private async hasAnyHeadForGids(gids: string[]) {
+		const uniqueGids = [...new Set(gids.filter(Boolean))];
+		if (uniqueGids.length === 0) {
+			return false;
+		}
+		const nativeHasHead = await this.log.entryIndex.hasAnyHead(uniqueGids);
+		if (nativeHasHead != null) {
+			return nativeHasHead;
+		}
+		for (const gid of uniqueGids) {
+			if (await this.hasHeadForGid(gid)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	get topic() {
 		return this.log.idString;
 	}
@@ -5506,12 +5523,10 @@ export class SharedLog<
 									toMerge.push(entry.entry);
 									toPersist.push(entry.entry);
 								} else {
-									for (const ref of entry.gidRefrences) {
-										if (await this.hasHeadForGid(ref)) {
-											toMerge.push(entry.entry);
-											(toDelete || (toDelete = [])).push(entry.entry);
-											continue outer;
-										}
+									if (await this.hasAnyHeadForGids(entry.gidRefrences)) {
+										toMerge.push(entry.entry);
+										(toDelete || (toDelete = [])).push(entry.entry);
+										continue outer;
 									}
 								}
 


### PR DESCRIPTION
## Summary
- add a batched native `hasAnyHead` predicate to the Rust log graph
- expose it through `EntryIndex`
- switch shared-log gid-reference checks from per-reference existence probing to one batched native call when available
- keep the non-native fallback path intact

## Local benchmark
Command:
`PEERBIT_LOG_NATIVE_GRAPH_ENTRIES=1000 PEERBIT_LOG_NATIVE_GRAPH_APPEND_ENTRIES=500 PEERBIT_LOG_NATIVE_GRAPH_JOIN_PARENTS=1000 node --loader ts-node/esm ./packages/log/benchmark/native-graph.ts`

Relevant rows:
- `hasHead()`: JS fallback 300 ops/sec, native graph 9352 ops/sec
- `hasAnyHead(refs)`: JS fallback 1240 ops/sec, native graph 360047 ops/sec

I also tried a fuller pure shallow-head return path, but did not land it because returning 1k rich JS objects across WASM regressed `getHeads().all()`. This PR keeps the native work as a predicate, where it stays cheap and avoids object materialization.

## Validation
- `cargo fmt --manifest-path packages/log/rust/Cargo.toml`
- `pnpm exec prettier --write packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/src/entry-index.ts packages/log/test/native-graph.spec.ts packages/log/benchmark/native-graph.ts`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log/rust -- -t node --grep "hasAnyHead|hasHead|filters heads|max u32|shaped head metadata|sums payload sizes|plans recursive cut deletes|child join entries|batches membership checks"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "native graph"`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm exec eslint --config eslint.config.js packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/src/entry-index.ts packages/log/test/native-graph.spec.ts packages/log/benchmark/native-graph.ts packages/programs/data/shared-log/src/index.ts`
