### PR TITLE
feat: batch shared log head membership checks

### DIFF
--- a/packages/log/benchmark/native-graph.ts
+++ b/packages/log/benchmark/native-graph.ts
@@ -55,13 +55,15 @@ const createHeadsLog = async (nativeGraph: boolean) => {
 		nativeGraph,
 	});
 	let gid: string | undefined;
+	const hashes: string[] = [];
 	for (let i = 0; i < entries; i++) {
 		const { entry } = await log.append(new Uint8Array([i & 0xff]), {
 			meta: { next: [] },
 		});
 		gid ??= entry.meta.gid;
+		hashes.push(entry.hash);
 	}
-	return { log, store, gid: gid! };
+	return { log, store, gid: gid!, hashes };
 };
 
 const createReplicaHeadsLog = async (nativeGraph: boolean) => {
@@ -107,9 +109,10 @@ const measure = async (
 	name: string,
 	nativeGraph: boolean,
 	fn: () => Promise<void>,
+	measureIterations = iterations,
 ): Promise<BenchRow> => {
 	const started = performance.now();
-	for (let i = 0; i < iterations; i++) {
+	for (let i = 0; i < measureIterations; i++) {
 		await fn();
 	}
 	const elapsed = performance.now() - started;
@@ -117,9 +120,9 @@ const measure = async (
 		name,
 		nativeGraph,
 		entries,
-		iterations,
+		iterations: measureIterations,
 		elapsedMs: Math.round(elapsed),
-		opsPerSecond: Math.round((iterations / elapsed) * 1000),
+		opsPerSecond: Math.round((measureIterations / elapsed) * 1000),
 	};
 };
 
@@ -447,11 +450,21 @@ for (const nativeGraph of [false, true]) {
 }
 
 for (const nativeGraph of [false, true]) {
-	const { log, store, gid } = await createHeadsLog(nativeGraph);
+	const { log, store, gid, hashes } = await createHeadsLog(nativeGraph);
 	rows.push(
 		await measure("hasHead()", nativeGraph, async () => {
 			await hasHead(log);
 		}),
+	);
+	rows.push(
+		await measure(
+			"hasMany(incoming heads)",
+			nativeGraph,
+			async () => {
+				await log.hasMany(hashes);
+			},
+			Math.min(iterations, 100),
+		),
 	);
 	rows.push(
 		await measure("hasAnyHead(refs)", nativeGraph, async () => {

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -386,6 +386,11 @@ export class Log<T> {
 	has(cid: string) {
 		return this._entryIndex.has(cid);
 	}
+
+	hasMany(cids: Iterable<string>) {
+		return this._entryIndex.hasMany(cids);
+	}
+
 	/**
 	 * Get all entries sorted. Don't use this method anywhere where performance matters
 	 */

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -309,9 +309,12 @@ describe("native graph", () => {
 		const hasManySpy = sinon.spy(nativeGraph, "hasMany");
 		const iterateSpy = sinon.spy(target.entryIndex.properties.index, "iterate");
 		try {
+			expect(await target.hasMany([present.hash, missing.hash])).to.deep.equal(
+				new Set([present.hash]),
+			);
 			await target.join([present, missing]);
 
-			expect(hasManySpy.callCount).equal(1);
+			expect(hasManySpy.callCount).equal(2);
 			expect(hasManySpy.firstCall.args[0]).to.deep.equal(
 				new Set([present.hash, missing.hash]),
 			);

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -5385,8 +5385,11 @@ export class SharedLog<
 				if (heads) {
 					const filteredHeads: EntryWithRefs<any>[] = [];
 					const confirmedHashes = new Set<string>();
+					const existingHashes = await this.log.hasMany(
+						heads.map((head) => head.entry.hash),
+					);
 					for (const head of heads) {
-						if (!(await this.log.has(head.entry.hash))) {
+						if (!existingHashes.has(head.entry.hash)) {
 							head.entry.init({
 								// we need to init because we perhaps need to decrypt gid
 								keychain: this.log.keychain,


### PR DESCRIPTION
## Summary
- expose `Log.hasMany()` as a public batch membership API over the existing `EntryIndex.hasMany()` path
- use it in shared-log receive-head filtering so incoming `ExchangeHeadsMessage` batches are checked with one coalesced membership call
- keep the same confirmed/missing behavior, but avoid per-head `log.has()` calls
- add a native-graph test assertion and benchmark row for incoming-head-style membership batches

## Local benchmark
Command:
`PEERBIT_LOG_NATIVE_GRAPH_ENTRIES=1000 PEERBIT_LOG_NATIVE_GRAPH_APPEND_ENTRIES=500 PEERBIT_LOG_NATIVE_GRAPH_JOIN_PARENTS=1000 node --loader ts-node/esm ./packages/log/benchmark/native-graph.ts`

Relevant row:
- `hasMany(incoming heads)`: fallback 6 batch calls/sec, native graph 1688 batch calls/sec for 1,000-hash batches

This is a higher-up coalescing step: shared-log now enters one `JS -> native -> END` membership batch for received heads instead of looping through per-head checks.

## Validation
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "native graph"`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm exec eslint --config eslint.config.js packages/log/src/log.ts packages/log/test/native-graph.spec.ts packages/log/benchmark/native-graph.ts packages/programs/data/shared-log/src/index.ts`
- benchmark command above
