### PR TITLE
feat: batch repair session membership refresh

### DIFF
--- a/packages/programs/data/shared-log/src/sync/simple.ts
+++ b/packages/programs/data/shared-log/src/sync/simple.ts
@@ -322,10 +322,9 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			return;
 		}
 		for (const state of session.targets.values()) {
-			for (const hash of [...state.unresolved]) {
-				if (await this.log.has(hash)) {
-					state.unresolved.delete(hash);
-				}
+			const resolved = await this.log.hasMany(state.unresolved);
+			for (const hash of resolved) {
+				state.unresolved.delete(hash);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- switch simple sync repair-session refresh from per-hash `log.has()` calls to one `log.hasMany()` batch per target state
- this reuses the native graph membership path added below the stack when nativeGraph is enabled
- preserves the same unresolved-set deletion semantics

## Why
Repair sessions can carry many unresolved hashes. Batched membership keeps this path aligned with the native backbone work: one `JS -> native -> END` membership call instead of repeated per-hash checks.

## Validation
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/sync/simple.ts`
