### PR TITLE
feat: batch native head reference checks

### DIFF
--- a/packages/log/benchmark/native-graph.ts
+++ b/packages/log/benchmark/native-graph.ts
@@ -155,6 +155,18 @@ const hasAnyHead = async (log: Log<Uint8Array>, gids: string[]) => {
 	return false;
 };
 
+const hasAnyHeadBatch = async (log: Log<Uint8Array>, gidSets: string[][]) => {
+	const nativeHasHeads = await log.entryIndex.hasAnyHeadBatch(gidSets);
+	if (nativeHasHeads != null) {
+		return nativeHasHeads;
+	}
+	const out: boolean[] = [];
+	for (const gids of gidSets) {
+		out.push(await hasAnyHead(log, gids));
+	}
+	return out;
+};
+
 const getMaxHeadDataU32 = async (log: Log<Uint8Array>) => {
 	const nativeMax = await log.entryIndex.getMaxHeadDataU32();
 	if (nativeMax != null) {
@@ -469,6 +481,11 @@ for (const nativeGraph of [false, true]) {
 	rows.push(
 		await measure("hasAnyHead(refs)", nativeGraph, async () => {
 			await hasAnyHead(log, ["missing", gid]);
+		}),
+	);
+	rows.push(
+		await measure("hasAnyHeadBatch(refs)", nativeGraph, async () => {
+			await hasAnyHeadBatch(log, [["missing"], ["missing", gid], [gid]]);
 		}),
 	);
 	await log.close();

--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -75,6 +75,7 @@ type NativeLogIndexHandle = {
 	heads: (gid?: string) => string[];
 	has_head: (gid?: string) => boolean;
 	has_any_head: (gids: string[]) => boolean;
+	has_any_head_batch: (gidSets: string[][]) => boolean[];
 	head_entries: (gid?: string) => unknown[];
 	head_data_entries: (gid?: string) => unknown[];
 	max_head_data_u32: (gid?: string) => number | undefined;
@@ -195,6 +196,12 @@ export class LogGraphIndex {
 
 	hasAnyHead(gids: Iterable<string>): boolean {
 		return this.native.has_any_head([...gids]);
+	}
+
+	hasAnyHeadBatch(gidSets: Iterable<Iterable<string>>): boolean[] {
+		return this.native.has_any_head_batch(
+			[...gidSets].map((gids) => [...gids]),
+		);
 	}
 
 	headEntries(gid?: string): NativeLogHeadEntry[] {

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -203,6 +203,13 @@ impl LogGraphIndex {
         gids.iter().any(|gid| self.has_head(Some(gid)))
     }
 
+    pub fn has_any_head_batch(&self, gid_sets: &[Vec<String>]) -> Vec<bool> {
+        gid_sets
+            .iter()
+            .map(|gids| self.has_any_head(gids))
+            .collect()
+    }
+
     pub fn head_entries(&self, gid: Option<&str>) -> Vec<LogIndexEntry> {
         self.heads(gid)
             .into_iter()
@@ -518,6 +525,15 @@ impl NativeLogIndex {
         Ok(self.inner.has_any_head(&gids))
     }
 
+    pub fn has_any_head_batch(&self, gid_sets: Array) -> Result<Array, JsValue> {
+        let gid_sets = string_arrays_from_array(gid_sets)?;
+        let out = Array::new();
+        for value in self.inner.has_any_head_batch(&gid_sets) {
+            out.push(&JsValue::from_bool(value));
+        }
+        Ok(out)
+    }
+
     pub fn head_entries(&self, gid: Option<String>) -> Array {
         log_entries_to_rows(self.inner.head_entries(gid.as_deref()))
     }
@@ -606,6 +622,17 @@ fn strings_from_array(values: Array) -> Result<Vec<String>, JsValue> {
             return Err(JsValue::from_str("Expected string array"));
         };
         out.push(value);
+    }
+    Ok(out)
+}
+
+fn string_arrays_from_array(values: Array) -> Result<Vec<Vec<String>>, JsValue> {
+    let mut out = Vec::with_capacity(values.length() as usize);
+    for value in values.iter() {
+        if !Array::is_array(&value) {
+            return Err(JsValue::from_str("Expected string array array"));
+        }
+        out.push(strings_from_array(Array::from(&value))?);
     }
     Ok(out)
 }
@@ -744,6 +771,14 @@ mod tests {
         assert!(!index.has_head(Some("missing")));
         assert!(index.has_any_head(&["missing".to_string(), "two".to_string()]));
         assert!(!index.has_any_head(&["missing".to_string()]));
+        assert_eq!(
+            index.has_any_head_batch(&[
+                vec!["missing".to_string(), "two".to_string()],
+                vec!["missing".to_string()],
+                Vec::new(),
+            ]),
+            vec![true, false, false],
+        );
     }
 
     #[test]

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -68,6 +68,9 @@ describe("native log graph index", () => {
 		expect(index.hasHead("missing")).equal(false);
 		expect(index.hasAnyHead(["missing", "two"])).equal(true);
 		expect(index.hasAnyHead(["missing"])).equal(false);
+		expect(
+			index.hasAnyHeadBatch([["missing", "two"], ["missing"], []]),
+		).to.deep.equal([true, false, false]);
 	});
 
 	it("returns sortable head metadata for append planning", async () => {

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -74,6 +74,7 @@ export type NativeLogGraph = {
 	heads: (gid?: string) => string[];
 	hasHead: (gid?: string) => boolean;
 	hasAnyHead: (gids: Iterable<string>) => boolean;
+	hasAnyHeadBatch: (gidSets: Iterable<Iterable<string>>) => boolean[];
 	headDataEntries: (gid?: string) => NativeLogHeadDataEntry[];
 	maxHeadDataU32: (gid?: string) => number | undefined;
 	headEntries: (gid?: string) => SortableEntry[];
@@ -344,6 +345,22 @@ export class EntryIndex<T> {
 		}
 		await this.flushPendingWrites();
 		return this.properties.nativeGraph.graph.hasAnyHead(uniqueGids);
+	}
+
+	async hasAnyHeadBatch(
+		gidSets: Iterable<Iterable<string>>,
+	): Promise<boolean[] | undefined> {
+		if (!this.properties.nativeGraph?.useHeads) {
+			return undefined;
+		}
+		const normalized = [...gidSets].map(
+			(gids) => new Set([...gids].filter(Boolean)),
+		);
+		if (normalized.length === 0) {
+			return [];
+		}
+		await this.flushPendingWrites();
+		return this.properties.nativeGraph.graph.hasAnyHeadBatch(normalized);
 	}
 
 	async getMaxHeadDataU32(gid?: string): Promise<number | undefined> {

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -216,6 +216,7 @@ describe("native graph", () => {
 		const nativeGraph = log.entryIndex.properties.nativeGraph!.graph;
 		const hasHeadSpy = sinon.spy(nativeGraph, "hasHead");
 		const hasAnyHeadSpy = sinon.spy(nativeGraph, "hasAnyHead");
+		const hasAnyHeadBatchSpy = sinon.spy(nativeGraph, "hasAnyHeadBatch");
 		try {
 			expect(await log.entryIndex.hasHead()).equal(true);
 			expect(await log.entryIndex.hasHead("missing")).equal(false);
@@ -223,10 +224,19 @@ describe("native graph", () => {
 				await log.entryIndex.hasAnyHead(["missing", entry.meta.gid]),
 			).equal(true);
 			expect(await log.entryIndex.hasAnyHead(["missing"])).equal(false);
+			expect(
+				await log.entryIndex.hasAnyHeadBatch([
+					["missing", entry.meta.gid],
+					["missing"],
+					[],
+				]),
+			).to.deep.equal([true, false, false]);
 			expect(hasHeadSpy.callCount).equal(2);
 			expect(hasAnyHeadSpy.callCount).equal(2);
+			expect(hasAnyHeadBatchSpy.callCount).equal(1);
 			expect(indexIterateSpy.callCount).equal(0);
 		} finally {
+			hasAnyHeadBatchSpy.restore();
 			hasAnyHeadSpy.restore();
 			hasHeadSpy.restore();
 			indexIterateSpy.restore();

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -4971,6 +4971,18 @@ export class SharedLog<
 		return false;
 	}
 
+	private async hasAnyHeadForGidSets(gidSets: string[][]) {
+		const nativeHasHeads = await this.log.entryIndex.hasAnyHeadBatch(gidSets);
+		if (nativeHasHeads != null) {
+			return nativeHasHeads;
+		}
+		const out: boolean[] = [];
+		for (const gids of gidSets) {
+			out.push(await this.hasAnyHeadForGids(gids));
+		}
+		return out;
+	}
+
 	get topic() {
 		return this.log.idString;
 	}
@@ -5501,6 +5513,11 @@ export class SharedLog<
 							// truly no longer owns the entry.
 							const acceptsTargetedRepair = isRepairHint && fromIsLeader;
 							const keepAsLeader = isLeader || acceptsTargetedRepair;
+							const gidReferenceHeads = keepAsLeader
+								? undefined
+								: await this.hasAnyHeadForGidSets(
+										entries.map((entry) => entry.gidRefrences),
+									);
 							if (keepAsLeader) {
 								for (const entry of entries) {
 									this.pruneDebouncedFn.delete(entry.entry.hash);
@@ -5521,12 +5538,13 @@ export class SharedLog<
 								}
 							}
 
-							outer: for (const entry of entries) {
+							outer: for (let i = 0; i < entries.length; i++) {
+								const entry = entries[i]!;
 								if (keepAsLeader || (await this.keep?.(entry.entry))) {
 									toMerge.push(entry.entry);
 									toPersist.push(entry.entry);
 								} else {
-									if (await this.hasAnyHeadForGids(entry.gidRefrences)) {
+									if (gidReferenceHeads?.[i]) {
 										toMerge.push(entry.entry);
 										(toDelete || (toDelete = [])).push(entry.entry);
 										continue outer;


### PR DESCRIPTION
## Summary
- add `hasAnyHeadBatch` to the Rust log graph and expose it through `@peerbit/log-rust` / `EntryIndex`
- use it in shared-log receive planning so all incoming entries' gid-reference head checks are answered in one native call per gid group
- preserve the existing non-native fallback behavior

## Local benchmark
Command:
`PEERBIT_LOG_NATIVE_GRAPH_ENTRIES=1000 PEERBIT_LOG_NATIVE_GRAPH_APPEND_ENTRIES=500 PEERBIT_LOG_NATIVE_GRAPH_JOIN_PARENTS=1000 node --loader ts-node/esm ./packages/log/benchmark/native-graph.ts`

Relevant rows:
- `hasAnyHead(refs)`: fallback 1246 ops/sec, native graph 389219 ops/sec
- `hasAnyHeadBatch(refs)`: fallback 622 ops/sec, native graph 179304 ops/sec

The batch row answers three gid-reference sets per call, so it is expected to be slower than the single predicate while still removing per-entry JS/native calls in shared-log receive planning.

## Validation
- `cargo fmt --manifest-path packages/log/rust/Cargo.toml`
- `pnpm exec prettier --write packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/src/entry-index.ts packages/log/test/native-graph.spec.ts packages/log/benchmark/native-graph.ts`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log/rust -- -t node --grep "hasAnyHead|hasHead|filters heads|max u32|shaped head metadata|sums payload sizes|plans recursive cut deletes|child join entries|batches membership checks"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "native graph"`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm exec eslint --config eslint.config.js packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/src/entry-index.ts packages/log/test/native-graph.spec.ts packages/log/benchmark/native-graph.ts packages/programs/data/shared-log/src/index.ts`
