### PR TITLE
feat: use native planner for shared log leaders

### DIFF
--- a/packages/programs/data/shared-log/package.json
+++ b/packages/programs/data/shared-log/package.json
@@ -81,6 +81,7 @@
 		"@peerbit/pubsub-interface": "workspace:*",
 		"@peerbit/riblt": "workspace:*",
 		"@peerbit/rpc": "workspace:*",
+		"@peerbit/shared-log-rust": "workspace:*",
 		"@peerbit/stream-interface": "workspace:*",
 		"@peerbit/time": "workspace:*",
 		"json-stringify-deterministic": "^1.0.7",

--- a/packages/programs/data/shared-log/rust/package.json
+++ b/packages/programs/data/shared-log/rust/package.json
@@ -53,7 +53,7 @@
 	"scripts": {
 		"clean": "aegir clean && shx rm -rf ./wasm && cargo clean",
 		"build": "aegir build --no-bundle && wasm-pack build --target web --out-dir dist/wasm --out-name shared_log_rust && shx rm -rf ./dist/wasm/.gitignore ./dist/wasm/package.json && shx rm -rf ./wasm && shx cp -r ./dist/wasm ./wasm",
-		"test": "cargo test && pnpm --filter @peerbit/shared-log run build && npm run build && aegir test",
+		"test": "cargo test && npm run build && pnpm --filter @peerbit/shared-log run build && aegir test",
 		"lint": "cargo fmt --check && pnpm exec eslint --config ../../../../../eslint.config.js \"src/**/*.ts\" \"test/**/*.ts\""
 	},
 	"author": "dao.xyz",

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -22,6 +22,11 @@ import {
 	toId,
 } from "@peerbit/indexer-interface";
 import {
+	type NativeReplicationRange,
+	type SharedLogRangePlanner,
+	createRangePlanner,
+} from "@peerbit/shared-log-rust";
+import {
 	type AppendOptions,
 	type Change,
 	Entry,
@@ -461,6 +466,7 @@ export type SharedLogOptions<
 > = {
 	appendDurability?: LogProperties<T>["appendDurability"];
 	nativeGraph?: LogProperties<T>["nativeGraph"];
+	nativeRangePlanner?: false | { optional?: boolean };
 	replicate?: ReplicationOptions<R>;
 	replicas?: ReplicationLimitsOptions;
 	respondToIHaveTimeout?: number;
@@ -772,6 +778,7 @@ export class SharedLog<
 
 	private _replicationRangeIndex!: Index<ReplicationRangeIndexable<R>>;
 	private _entryCoordinatesIndex!: Index<EntryReplicated<R>>;
+	private _nativeRangePlanner?: SharedLogRangePlanner;
 		private coordinateToHash!: Cache<string>;
 		private recentlyRebalanced!: Cache<string>;
 
@@ -2182,6 +2189,9 @@ export class SharedLog<
 			this.uniqueReplicators.delete(keyHash);
 			this._replicatorJoinEmitted.delete(keyHash);
 			await this.replicationIndex.del({ query: { hash: keyHash } });
+			for (const result of deleted) {
+				this.deleteNativeReplicationRange(result.value);
+			}
 
 		await this.updateOldestTimestampFromIndex();
 
@@ -2299,6 +2309,9 @@ export class SharedLog<
 				ranges.map((x) => new ByteMatchQuery({ key: "id", value: x.id })),
 			),
 		});
+		for (const range of ranges) {
+			this.deleteNativeReplicationRange(range);
+		}
 
 		const otherSegmentsIterator = this.replicationIndex.iterate(
 			{ query: { hash: from.hashcode() } },
@@ -2491,6 +2504,7 @@ export class SharedLog<
 					return;
 				} */
 				await this.replicationIndex.put(diff.range);
+				this.putNativeReplicationRange(diff.range);
 
 				if (!reset) {
 					this.oldestOpenTime = Math.min(
@@ -2551,6 +2565,7 @@ export class SharedLog<
 					}
 				}
 			} else if (diff.type === "removed") {
+				this.deleteNativeReplicationRange(diff.range);
 				const pendingFromPeer = this.pendingMaturity.get(diff.range.hash);
 				if (pendingFromPeer) {
 					const prev = pendingFromPeer.get(diff.range.idString);
@@ -4188,6 +4203,7 @@ export class SharedLog<
 		this._entryCoordinatesIndex = await replicationIndex.init({
 			schema: this.indexableDomain.constructorEntry,
 		});
+		await this.openNativeRangePlanner(options?.nativeRangePlanner);
 
 		await remoteBlocksStartPromise;
 		const hasIndexedReplicationInfo =
@@ -4440,6 +4456,74 @@ export class SharedLog<
 		}, RECALCULATE_PARTICIPATION_DEBOUNCE_INTERVAL);
 	}
 
+	private toNativeReplicationRange(
+		range: ReplicationRangeIndexable<R>,
+	): NativeReplicationRange {
+		return {
+			id: range.idString,
+			hash: range.hash,
+			timestamp: range.timestamp,
+			start1: range.start1,
+			end1: range.end1,
+			start2: range.start2,
+			end2: range.end2,
+			width: range.width,
+			mode: range.mode,
+		};
+	}
+
+	private putNativeReplicationRange(range: ReplicationRangeIndexable<R>): void {
+		this._nativeRangePlanner?.put(this.toNativeReplicationRange(range));
+	}
+
+	private deleteNativeReplicationRange(range: ReplicationRangeIndexable<R>): void {
+		this._nativeRangePlanner?.delete(range.idString);
+	}
+
+	private async hydrateNativeRangePlanner(
+		planner: SharedLogRangePlanner,
+	): Promise<void> {
+		planner.clear();
+		const iterator = this.replicationIndex.iterate();
+		try {
+			for (;;) {
+				const batch = await iterator.next(256);
+				if (batch.length === 0) {
+					break;
+				}
+				for (const result of batch) {
+					planner.put(this.toNativeReplicationRange(result.value));
+				}
+			}
+		} finally {
+			await iterator.close();
+		}
+	}
+
+	private async openNativeRangePlanner(
+		options: SharedLogOptions<T, D, R>["nativeRangePlanner"],
+	): Promise<void> {
+		this._nativeRangePlanner = undefined;
+		if (options === false) {
+			return;
+		}
+
+		try {
+			const planner = await createRangePlanner(this.domain.resolution);
+			await this.hydrateNativeRangePlanner(planner);
+			this._nativeRangePlanner = planner;
+		} catch (error) {
+			if (options?.optional === false) {
+				throw error;
+			}
+			warn(
+				`Native range planner unavailable, falling back to TypeScript getSamples: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		}
+	}
+
 	private async updateTimestampOfOwnedReplicationRanges(
 		timestamp: number = +new Date(),
 	) {
@@ -4452,6 +4536,7 @@ export class SharedLog<
 		for (const x of all) {
 			x.value.timestamp = bnTimestamp;
 			await this.replicationIndex.put(x.value);
+			this.putNativeReplicationRange(x.value);
 		}
 
 		if (all.length > 0) {
@@ -5244,6 +5329,7 @@ export class SharedLog<
 		this._entryCoordinatesIndex.stop();
 		this._replicationRangeIndex = undefined as any;
 		this._entryCoordinatesIndex = undefined as any;
+		this._nativeRangePlanner = undefined;
 
 		this.cpuUsage?.stop?.();
 		/* this._totalParticipation = 0; */
@@ -6851,6 +6937,15 @@ export class SharedLog<
 			if (fullReplicaLeaders) {
 				return fullReplicaLeaders;
 			}
+		}
+
+		if (this._nativeRangePlanner) {
+			return this._nativeRangePlanner.getSamples(cursors, {
+				roleAge,
+				now: Date.now(),
+				peerFilter,
+				uniqueReplicators: peerFilter,
+			});
 		}
 
 		return getSamples<R>(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1667,6 +1667,9 @@ importers:
       '@peerbit/rpc':
         specifier: workspace:*
         version: link:../../rpc
+      '@peerbit/shared-log-rust':
+        specifier: workspace:*
+        version: link:rust
       '@peerbit/stream-interface':
         specifier: workspace:*
         version: link:../../../transport/stream-interface


### PR DESCRIPTION
## Summary
- add @peerbit/shared-log-rust as a shared-log dependency
- maintain a native range-planner mirror from the existing replication index mutations
- route the getSamples portion of SharedLog._findLeaders through the native planner when available, with TypeScript fallback
- keep the existing replication index as source of truth and hydrate the native mirror on open

## Notes
- full-replica fast path and peer-filter preparation still stay in TypeScript
- this is the first practical shared-log path using the native planner; next stacks can push more of findLeaders preparation into Rust

## Validation
- pnpm --filter @peerbit/shared-log-rust run test
- pnpm --filter @peerbit/shared-log run build
- pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/index.ts
- pnpm --filter @peerbit/shared-log-rust run lint
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "uses indexed peers when the leader peer filter is temporarily underfilled"
- pnpm install --lockfile-only --frozen-lockfile

Full shared-log lint was not used as a gate because it currently reports pre-existing style errors across unrelated shared-log files.