### PR TITLE
perf: index native shared log range planner

### DIFF
--- a/packages/programs/data/shared-log/rust/benchmark/get-samples.ts
+++ b/packages/programs/data/shared-log/rust/benchmark/get-samples.ts
@@ -1,0 +1,234 @@
+import { create as createIndex } from "@peerbit/indexer-sqlite3";
+import { performance } from "node:perf_hooks";
+import { createRangePlanner } from "../src/index.js";
+
+type Resolution = "u32" | "u64";
+type BenchResult = {
+	scenario: string;
+	tsOpsPerSecond: string;
+	tsMeanMs: string;
+	nativeOpsPerSecond: string;
+	nativeMeanMs: string;
+	speedup: string;
+};
+type RangeLike = {
+	idString: string;
+	hash: string;
+	timestamp: bigint;
+	start1: number | bigint;
+	end1: number | bigint;
+	start2: number | bigint;
+	end2: number | bigint;
+	width: number | bigint;
+	mode: number;
+};
+
+const loadSharedLog = async () => {
+	const integersPath = "../../../dist/src/integers.js";
+	const rangesPath = "../../../dist/src/ranges.js";
+	const [integers, ranges] = await Promise.all([
+		import(integersPath),
+		import(rangesPath),
+	]);
+	return {
+		createNumbers: integers.createNumbers,
+		denormalizer: integers.denormalizer,
+		ReplicationRangeIndexableU32: ranges.ReplicationRangeIndexableU32,
+		ReplicationRangeIndexableU64: ranges.ReplicationRangeIndexableU64,
+		getSamples: ranges.getSamples,
+	};
+};
+
+const format = (value: number) =>
+	value.toLocaleString("en-US", { maximumFractionDigits: 1 });
+
+const deterministicId = (id: number) => {
+	const bytes = new Uint8Array(32);
+	new DataView(bytes.buffer).setUint32(28, id, false);
+	return bytes;
+};
+
+const toNativeRange = (range: RangeLike) => ({
+	id: range.idString,
+	hash: range.hash,
+	timestamp: range.timestamp,
+	start1: range.start1,
+	end1: range.end1,
+	start2: range.start2,
+	end2: range.end2,
+	width: range.width,
+	mode: range.mode,
+});
+
+const createRandom = (seed: number) => {
+	let state = seed;
+	return () => {
+		state = (1664525 * state + 1013904223) >>> 0;
+		return state / 0x100000000;
+	};
+};
+
+const benchmark = async (iterations: number, fn: () => Promise<void> | void) => {
+	const warmup = Math.min(50, Math.max(5, Math.floor(iterations / 10)));
+	for (let i = 0; i < warmup; i++) {
+		await fn();
+	}
+
+	const start = performance.now();
+	for (let i = 0; i < iterations; i++) {
+		await fn();
+	}
+	const elapsedMs = performance.now() - start;
+	return {
+		meanMs: elapsedMs / iterations,
+		opsPerSecond: iterations / (elapsedMs / 1000),
+	};
+};
+
+const runResolution = async (resolution: Resolution): Promise<BenchResult[]> => {
+	const sharedLog = await loadSharedLog();
+	const numbers = sharedLog.createNumbers(resolution);
+	const denormalize = sharedLog.denormalizer(resolution);
+	const RangeClass =
+		resolution === "u32"
+			? sharedLog.ReplicationRangeIndexableU32
+			: sharedLog.ReplicationRangeIndexableU64;
+	const peerHashes = ["peer-a", "peer-b", "peer-c"];
+
+	const makeRange = (
+		id: number,
+		hash: string,
+		width: number,
+		offset: number,
+	): RangeLike =>
+		new RangeClass({
+			id: deterministicId(id),
+			publicKeyHash: hash,
+			width: denormalize(width),
+			offset: denormalize(offset % 1),
+			timestamp: 0n,
+		});
+
+	const sparseRanges = () => {
+		const out: RangeLike[] = [];
+		const random = createRandom(987654321);
+		let id = 1;
+		for (let i = 0; i < 10_000; i++) {
+			out.push(makeRange(id++, peerHashes[0], 0.2 / 10_000, random()));
+			out.push(makeRange(id++, peerHashes[1], 0.4 / 10_000, random()));
+			out.push(makeRange(id++, peerHashes[2], 0.6 / 10_000, random()));
+			out.push(makeRange(id++, peerHashes[2], 0.6 / 10_000, random()));
+		}
+		return out;
+	};
+
+	const overlapRanges = () => {
+		const out = [
+			makeRange(1, peerHashes[0], 1, 0.1),
+			makeRange(2, peerHashes[1], 1, 0.7),
+		];
+		const random = createRandom(123456789);
+		let id = 3;
+		for (let i = 0; i < 10_000; i++) {
+			out.push(makeRange(id++, peerHashes[0], 0.2 / 10_000, random()));
+			out.push(makeRange(id++, peerHashes[1], 0.4 / 10_000, random()));
+			out.push(makeRange(id++, peerHashes[2], 0.6 / 10_000, random()));
+			out.push(makeRange(id++, peerHashes[2], 0.6 / 10_000, random()));
+		}
+		return out;
+	};
+
+	const scenarios = [
+		{
+			name: "one full range",
+			ranges: () => [makeRange(1, peerHashes[0], 1, 0.1)],
+			iterations: 1_000,
+			options: undefined,
+		},
+		{
+			name: "one full range with unique filter",
+			ranges: () => [makeRange(1, peerHashes[0], 1, 0.1)],
+			iterations: 1_000,
+			options: { uniqueReplicators: new Set([peerHashes[0]]) },
+		},
+		{
+			name: "overlap onlyIntersecting with 40k sparse noise",
+			ranges: overlapRanges,
+			iterations: 200,
+			options: { onlyIntersecting: true },
+		},
+		{
+			name: "sparse fallback with 40k ranges",
+			ranges: sparseRanges,
+			iterations: 100,
+			options: undefined,
+		},
+	];
+
+	const rows: BenchResult[] = [];
+	for (const scenario of scenarios) {
+		const ranges = scenario.ranges();
+		const indices = await createIndex();
+		const index = await indices.init({ schema: RangeClass });
+		await indices.start();
+		const planner = await createRangePlanner(resolution);
+
+		for (const range of ranges) {
+			await index.put(range);
+			planner.put(toNativeRange(range));
+		}
+
+		const makeCursors = () => {
+			const random = createRandom(246813579);
+			return () => numbers.getGrid(numbers.denormalize(random()), 2);
+		};
+
+		try {
+			let cursors = makeCursors();
+			const ts = await benchmark(scenario.iterations, async () => {
+				const samples = await sharedLog.getSamples(
+					cursors(),
+					index,
+					0,
+					numbers,
+					scenario.options,
+				);
+				if (samples.size === 0) {
+					throw new Error("Expected TypeScript samples");
+				}
+			});
+
+			cursors = makeCursors();
+			const native = await benchmark(scenario.iterations, () => {
+				const samples = planner.getSamples(cursors(), {
+					now: Date.now(),
+					roleAge: 0,
+					...scenario.options,
+				});
+				if (samples.size === 0) {
+					throw new Error("Expected native samples");
+				}
+			});
+
+			rows.push({
+				scenario: `${scenario.name} (${resolution}, ${ranges.length} ranges)`,
+				tsOpsPerSecond: format(ts.opsPerSecond),
+				tsMeanMs: format(ts.meanMs),
+				nativeOpsPerSecond: format(native.opsPerSecond),
+				nativeMeanMs: format(native.meanMs),
+				speedup: `${format(native.opsPerSecond / ts.opsPerSecond)}x`,
+			});
+		} finally {
+			await indices.stop();
+		}
+	}
+
+	return rows;
+};
+
+const rows = [
+	...(await runResolution("u32")),
+	...(await runResolution("u64")),
+];
+
+console.table(rows);

--- a/packages/programs/data/shared-log/rust/package.json
+++ b/packages/programs/data/shared-log/rust/package.json
@@ -51,10 +51,11 @@
 		"access": "public"
 	},
 	"scripts": {
+		"benchmark:get-samples": "npm run build && pnpm --filter @peerbit/shared-log run build && node ./dist/benchmark/get-samples.js",
 		"clean": "aegir clean && shx rm -rf ./wasm && cargo clean",
 		"build": "aegir build --no-bundle && wasm-pack build --target web --out-dir dist/wasm --out-name shared_log_rust && shx rm -rf ./dist/wasm/.gitignore ./dist/wasm/package.json && shx rm -rf ./wasm && shx cp -r ./dist/wasm ./wasm",
 		"test": "cargo test && npm run build && pnpm --filter @peerbit/shared-log run build && aegir test",
-		"lint": "cargo fmt --check && pnpm exec eslint --config ../../../../../eslint.config.js \"src/**/*.ts\" \"test/**/*.ts\""
+		"lint": "cargo fmt --check && pnpm exec eslint --config ../../../../../eslint.config.js \"src/**/*.ts\" \"test/**/*.ts\" \"benchmark/**/*.ts\""
 	},
 	"author": "dao.xyz",
 	"license": "MIT",

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -1,6 +1,7 @@
 use indexmap::{IndexMap, IndexSet};
 use js_sys::Array;
-use std::collections::HashSet;
+use std::cmp::Ordering;
+use std::collections::{BTreeSet, HashSet};
 use wasm_bindgen::prelude::*;
 
 const MODE_NON_STRICT: u8 = 0;
@@ -94,6 +95,71 @@ pub struct SampleOptions {
 pub struct RangePlanner {
     resolution: Resolution,
     ranges: IndexMap<String, ReplicationRange>,
+    by_start1: BTreeSet<RangeIndexKey>,
+    by_end2: BTreeSet<RangeIndexKey>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RangeIndexKey {
+    value: u64,
+    timestamp: u64,
+    hash: String,
+    id: String,
+}
+
+impl RangeIndexKey {
+    fn start(range: &ReplicationRange) -> Self {
+        Self {
+            value: range.start1,
+            timestamp: range.timestamp,
+            hash: range.hash.clone(),
+            id: range.id.clone(),
+        }
+    }
+
+    fn end(range: &ReplicationRange) -> Self {
+        Self {
+            value: range.end2,
+            timestamp: range.timestamp,
+            hash: range.hash.clone(),
+            id: range.id.clone(),
+        }
+    }
+
+    fn min_at(value: u64) -> Self {
+        Self {
+            value,
+            timestamp: 0,
+            hash: String::new(),
+            id: String::new(),
+        }
+    }
+
+    fn max_at(value: u64) -> Self {
+        let max_string = char::MAX.to_string();
+        Self {
+            value,
+            timestamp: u64::MAX,
+            hash: max_string.clone(),
+            id: max_string,
+        }
+    }
+}
+
+impl Ord for RangeIndexKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.value
+            .cmp(&other.value)
+            .then_with(|| self.timestamp.cmp(&other.timestamp))
+            .then_with(|| self.hash.cmp(&other.hash))
+            .then_with(|| self.id.cmp(&other.id))
+    }
+}
+
+impl PartialOrd for RangeIndexKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 impl RangePlanner {
@@ -101,6 +167,8 @@ impl RangePlanner {
         Self {
             resolution: Resolution::from_str(resolution),
             ranges: IndexMap::new(),
+            by_start1: BTreeSet::new(),
+            by_end2: BTreeSet::new(),
         }
     }
 
@@ -114,14 +182,26 @@ impl RangePlanner {
 
     pub fn clear(&mut self) {
         self.ranges.clear();
+        self.by_start1.clear();
+        self.by_end2.clear();
     }
 
     pub fn put(&mut self, range: ReplicationRange) {
+        if let Some(previous) = self.ranges.get(&range.id).cloned() {
+            self.unindex_range(&previous);
+        }
+        self.index_range(&range);
         self.ranges.insert(range.id.clone(), range);
     }
 
     pub fn delete(&mut self, id: &str) -> bool {
-        self.ranges.shift_remove(id).is_some()
+        match self.ranges.swap_remove(id) {
+            Some(range) => {
+                self.unindex_range(&range);
+                true
+            }
+            None => false,
+        }
     }
 
     pub fn get_samples(&self, cursors: &[u64], options: &SampleOptions) -> Vec<LeaderSample> {
@@ -163,8 +243,11 @@ impl RangePlanner {
                 continue;
             }
 
-            let mut closest = self.closest_non_strict(point, options.peer_filter.as_ref());
-            for range in closest.drain(..) {
+            let mut seen_closest_ids = HashSet::new();
+            while let Some(range) =
+                self.closest_non_strict(point, options.peer_filter.as_ref(), &seen_closest_ids)
+            {
+                seen_closest_ids.insert(range.id.clone());
                 unique_visited.insert(range.hash.clone());
                 if !range.is_matured(options.now, options.role_age_ms) {
                     continue;
@@ -199,27 +282,149 @@ impl RangePlanner {
         }
     }
 
+    fn is_fallback_indexed(range: &ReplicationRange) -> bool {
+        range.width > 0 && range.mode == MODE_NON_STRICT
+    }
+
+    fn index_range(&mut self, range: &ReplicationRange) {
+        if Self::is_fallback_indexed(range) {
+            self.by_start1.insert(RangeIndexKey::start(range));
+            self.by_end2.insert(RangeIndexKey::end(range));
+        }
+    }
+
+    fn unindex_range(&mut self, range: &ReplicationRange) {
+        if Self::is_fallback_indexed(range) {
+            self.by_start1.remove(&RangeIndexKey::start(range));
+            self.by_end2.remove(&RangeIndexKey::end(range));
+        }
+    }
+
+    fn candidate_from_key(
+        &self,
+        key: &RangeIndexKey,
+        peer_filter: Option<&HashSet<String>>,
+        seen_ids: &HashSet<String>,
+    ) -> Option<&ReplicationRange> {
+        if seen_ids.contains(&key.id) {
+            return None;
+        }
+        let range = self.ranges.get(&key.id)?;
+        if !self.include_range(range, peer_filter) || range.mode != MODE_NON_STRICT {
+            return None;
+        }
+        Some(range)
+    }
+
+    fn first_candidate_from_keys<'a, I>(
+        &'a self,
+        keys: I,
+        peer_filter: Option<&HashSet<String>>,
+        seen_ids: &HashSet<String>,
+    ) -> Option<&'a ReplicationRange>
+    where
+        I: IntoIterator<Item = &'a RangeIndexKey>,
+    {
+        keys.into_iter()
+            .find_map(|key| self.candidate_from_key(key, peer_filter, seen_ids))
+    }
+
+    fn closest_start_candidate(
+        &self,
+        point: u64,
+        above: bool,
+        peer_filter: Option<&HashSet<String>>,
+        seen_ids: &HashSet<String>,
+    ) -> Option<&ReplicationRange> {
+        if above {
+            self.first_candidate_from_keys(
+                self.by_start1.range(RangeIndexKey::min_at(point)..),
+                peer_filter,
+                seen_ids,
+            )
+            .or_else(|| {
+                self.first_candidate_from_keys(self.by_start1.iter(), peer_filter, seen_ids)
+            })
+        } else {
+            self.first_candidate_from_keys(
+                self.by_start1.range(..=RangeIndexKey::max_at(point)).rev(),
+                peer_filter,
+                seen_ids,
+            )
+            .or_else(|| {
+                self.first_candidate_from_keys(self.by_start1.iter().rev(), peer_filter, seen_ids)
+            })
+        }
+    }
+
+    fn closest_end_candidate(
+        &self,
+        point: u64,
+        above: bool,
+        peer_filter: Option<&HashSet<String>>,
+        seen_ids: &HashSet<String>,
+    ) -> Option<&ReplicationRange> {
+        if above {
+            self.first_candidate_from_keys(
+                self.by_end2.range(RangeIndexKey::min_at(point)..),
+                peer_filter,
+                seen_ids,
+            )
+            .or_else(|| self.first_candidate_from_keys(self.by_end2.iter(), peer_filter, seen_ids))
+        } else {
+            self.first_candidate_from_keys(
+                self.by_end2.range(..=RangeIndexKey::max_at(point)).rev(),
+                peer_filter,
+                seen_ids,
+            )
+            .or_else(|| {
+                self.first_candidate_from_keys(self.by_end2.iter().rev(), peer_filter, seen_ids)
+            })
+        }
+    }
+
     fn closest_non_strict(
         &self,
         point: u64,
         peer_filter: Option<&HashSet<String>>,
-    ) -> Vec<&ReplicationRange> {
+        seen_ids: &HashSet<String>,
+    ) -> Option<&ReplicationRange> {
         let max_value = self.resolution.max_value();
-        let mut ranges: Vec<&ReplicationRange> = self
-            .ranges
-            .values()
-            .filter(|range| self.include_range(range, peer_filter))
-            .filter(|range| range.mode == MODE_NON_STRICT)
-            .collect();
-        ranges.sort_by(|left, right| {
-            closest_distance(left, point, max_value)
-                .cmp(&closest_distance(right, point, max_value))
-                .then_with(|| left.timestamp.cmp(&right.timestamp))
-                .then_with(|| left.hash.cmp(&right.hash))
-                .then_with(|| left.id.cmp(&right.id))
-        });
-        ranges
+        let mut best: Option<&ReplicationRange> = None;
+
+        for range in [
+            self.closest_start_candidate(point, true, peer_filter, seen_ids),
+            self.closest_start_candidate(point, false, peer_filter, seen_ids),
+            self.closest_end_candidate(point, true, peer_filter, seen_ids),
+            self.closest_end_candidate(point, false, peer_filter, seen_ids),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            if let Some(previous) = best {
+                if compare_closest(range, previous, point, max_value) == Ordering::Less {
+                    best = Some(range);
+                }
+            } else {
+                best = Some(range);
+            }
+        }
+
+        best
     }
+}
+
+fn compare_closest(
+    left: &ReplicationRange,
+    right: &ReplicationRange,
+    point: u64,
+    max_value: u64,
+) -> Ordering {
+    closest_distance(left, point, max_value)
+        .cmp(&closest_distance(right, point, max_value))
+        .then_with(|| left.timestamp.cmp(&right.timestamp))
+        .then_with(|| left.hash.cmp(&right.hash))
+        .then_with(|| left.id.cmp(&right.id))
 }
 
 fn closest_distance(range: &ReplicationRange, point: u64, max_value: u64) -> u64 {
@@ -465,6 +670,32 @@ mod tests {
 
         assert_eq!(samples.len(), 1);
         assert_eq!(samples[0].hash, "peer-a");
+        assert!(samples[0].intersecting);
+    }
+
+    #[test]
+    fn delete_removes_range_from_sampling() {
+        let mut planner = RangePlanner::new("u32");
+        planner.put(ReplicationRange::new(
+            "a", "peer-a", 0, 10, 20, 10, 20, 10, 0,
+        ));
+        planner.put(ReplicationRange::new(
+            "b", "peer-b", 0, 10, 20, 10, 20, 10, 0,
+        ));
+
+        assert!(planner.delete("a"));
+        assert!(!planner.delete("a"));
+
+        let samples = planner.get_samples(
+            &[15],
+            &SampleOptions {
+                now: 1_000,
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(samples.len(), 1);
+        assert_eq!(samples[0].hash, "peer-b");
         assert!(samples[0].intersecting);
     }
 }

--- a/packages/programs/data/shared-log/rust/tsconfig.json
+++ b/packages/programs/data/shared-log/rust/tsconfig.json
@@ -4,5 +4,5 @@
 		"outDir": "dist",
 		"checkJs": false
 	},
-	"include": ["src", "test"]
+	"include": ["src", "test", "benchmark"]
 }


### PR DESCRIPTION
## Summary
- add native endpoint indexes over shared-log ranges for closest fallback sampling
- switch native planner deletes from order-preserving removal to swap removal while keeping index cleanup
- add a reproducible getSamples benchmark comparing the TypeScript/SQLite path with the native planner

## Local performance
- sparse fallback, 40k ranges, u32: ~50 ops/sec TS vs ~4.5k ops/sec native (~89x)
- sparse fallback, 40k ranges, u64: ~41 ops/sec TS vs ~4.0k ops/sec native (~97x)
- native mirror delete: ~0.87M-0.90M deletes/sec locally after index cleanup

## Validation
- cargo fmt --manifest-path packages/programs/data/shared-log/rust/Cargo.toml
- cargo test --manifest-path packages/programs/data/shared-log/rust/Cargo.toml
- pnpm --filter @peerbit/shared-log-rust run build
- pnpm --filter @peerbit/shared-log-rust run test
- pnpm --filter @peerbit/shared-log-rust run lint
- pnpm --filter @peerbit/shared-log-rust run benchmark:get-samples