### PR TITLE
test(pubsub): add parent upgrade evidence harness

### DIFF
--- a/packages/transport/pubsub/benchmark/fanout-tree-parent-upgrade-eval.ts
+++ b/packages/transport/pubsub/benchmark/fanout-tree-parent-upgrade-eval.ts
@@ -1,0 +1,341 @@
+/**
+ * A/B evidence harness for proactive FanoutTree parent upgrades.
+ *
+ * This intentionally runs the same scenario and seed twice: first with the
+ * default stability-first behavior, then with bounded parent upgrades enabled.
+ */
+import {
+	type FanoutTreeSimParams,
+	type FanoutTreeSimResult,
+	formatFanoutTreeSimResult,
+	runFanoutTreeSim,
+} from "./fanout-tree-sim-lib.js";
+
+type ScenarioName = "ci-small" | "ci-loss";
+
+type EvalArgs = {
+	scenarios: ScenarioName[];
+	seeds: number[];
+	parentUpgradeIntervalMs: number;
+	parentUpgradeLeafOnly: boolean;
+	maxCostRatio: number;
+	maxReparentsPerMin: number;
+	maxReparentsPerPeer: number;
+	maxOrphanAreaRatio: number;
+	strict: boolean;
+};
+
+type Failure = {
+	metric: string;
+	baseline: number;
+	upgrade: number;
+	limit: number;
+};
+
+const HELP_TEXT = [
+	"fanout-tree-parent-upgrade-eval.ts",
+	"",
+	"Args:",
+	"  --scenario NAME              scenario to run (ci-small|ci-loss|all, default: all)",
+	"  --seeds CSV                  seeds to run for each scenario (default: 1,2,3)",
+	"  --parentUpgradeIntervalMs MS upgrade check interval for treatment run (default: 1000)",
+	"  --parentUpgradeLeafOnly 0|1  restrict treatment upgrades to leaves (default: 1)",
+	"  --maxCostRatio R             max treatment/base ratio for control/tracker/repair bpp (default: 1.15)",
+	"  --maxReparentsPerMin N       max treatment reparent events per minute (default: 500)",
+	"  --maxReparentsPerPeer N      max treatment reparent events for one peer (default: 20)",
+	"  --maxOrphanAreaRatio R       max treatment/base ratio for orphan area (default: 1.15)",
+	"  --strict 0|1                 exit non-zero on evidence failure (default: 0)",
+	"",
+	"Example:",
+	"  pnpm -C packages/transport/pubsub run bench -- fanout-tree-parent-upgrade-eval --scenario ci-small --seeds 1,2,3",
+].join("\n");
+
+const SCENARIOS: Record<ScenarioName, Partial<FanoutTreeSimParams>> = {
+	"ci-small": {
+		nodes: 25,
+		bootstraps: 1,
+		subscribers: 20,
+		relayFraction: 0.3,
+		candidateScoringMode: "weighted",
+		messages: 20,
+		msgRate: 50,
+		msgSize: 64,
+		settleMs: 500,
+		deadlineMs: 500,
+		timeoutMs: 20_000,
+		repair: true,
+		rootUploadLimitBps: 100_000_000,
+		relayUploadLimitBps: 100_000_000,
+		rootMaxChildren: 64,
+		relayMaxChildren: 32,
+		dropDataFrameRate: 0,
+	},
+	"ci-loss": {
+		nodes: 40,
+		bootstraps: 1,
+		subscribers: 30,
+		relayFraction: 0.35,
+		messages: 40,
+		msgRate: 50,
+		msgSize: 64,
+		settleMs: 5_000,
+		deadlineMs: 500,
+		timeoutMs: 40_000,
+		repair: true,
+		rootUploadLimitBps: 100_000_000,
+		relayUploadLimitBps: 100_000_000,
+		rootMaxChildren: 64,
+		relayMaxChildren: 32,
+		neighborRepair: true,
+		neighborRepairPeers: 3,
+		dropDataFrameRate: 0.1,
+		churnEveryMs: 200,
+		churnDownMs: 100,
+		churnFraction: 0.05,
+	},
+};
+
+const parseBool01 = (value: string | undefined, fallback: boolean) => {
+	if (value === undefined) return fallback;
+	return value === "1";
+};
+
+const parseCsvNumbers = (value: string | undefined, fallback: number[]) => {
+	if (!value) return fallback;
+	const parsed = value
+		.split(",")
+		.map((part) => Number(part.trim()))
+		.filter((part) => Number.isFinite(part));
+	return parsed.length > 0 ? parsed : fallback;
+};
+
+const parseScenarios = (value: string | undefined): ScenarioName[] => {
+	if (!value || value === "all") return ["ci-small", "ci-loss"];
+	const parsed = value
+		.split(",")
+		.map((part) => part.trim())
+		.filter(
+			(part): part is ScenarioName => part === "ci-small" || part === "ci-loss",
+		);
+	if (parsed.length === 0) {
+		throw new Error(`Unknown scenario: ${value}`);
+	}
+	return parsed;
+};
+
+const parseArgs = (argv: string[]): EvalArgs => {
+	const get = (key: string) => {
+		const idx = argv.indexOf(key);
+		return idx === -1 ? undefined : argv[idx + 1];
+	};
+
+	if (argv.includes("--help") || argv.includes("-h")) {
+		console.log(HELP_TEXT);
+		process.exit(0);
+	}
+
+	return {
+		scenarios: parseScenarios(get("--scenario")),
+		seeds: parseCsvNumbers(get("--seeds"), [1, 2, 3]),
+		parentUpgradeIntervalMs: Number(get("--parentUpgradeIntervalMs") ?? 1_000),
+		parentUpgradeLeafOnly: parseBool01(get("--parentUpgradeLeafOnly"), true),
+		maxCostRatio: Number(get("--maxCostRatio") ?? 1.15),
+		maxReparentsPerMin: Number(get("--maxReparentsPerMin") ?? 500),
+		maxReparentsPerPeer: Number(get("--maxReparentsPerPeer") ?? 20),
+		maxOrphanAreaRatio: Number(get("--maxOrphanAreaRatio") ?? 1.15),
+		strict: parseBool01(get("--strict"), false),
+	};
+};
+
+const ratioLimit = (baseline: number, ratio: number, absoluteSlack = 1e-9) =>
+	Math.max(absoluteSlack, baseline * ratio + absoluteSlack);
+
+const failIfGreater = (
+	failures: Failure[],
+	metric: string,
+	baseline: number,
+	upgrade: number,
+	limit: number,
+) => {
+	if (!Number.isFinite(baseline) || !Number.isFinite(upgrade)) return;
+	if (upgrade > limit) {
+		failures.push({ metric, baseline, upgrade, limit });
+	}
+};
+
+const failIfLess = (
+	failures: Failure[],
+	metric: string,
+	baseline: number,
+	upgrade: number,
+	limit: number,
+) => {
+	if (!Number.isFinite(baseline) || !Number.isFinite(upgrade)) return;
+	if (upgrade < limit) {
+		failures.push({ metric, baseline, upgrade, limit });
+	}
+};
+
+const evaluateRun = (
+	params: FanoutTreeSimParams,
+	baseline: FanoutTreeSimResult,
+	upgrade: FanoutTreeSimResult,
+	args: EvalArgs,
+) => {
+	const failures: Failure[] = [];
+
+	failIfGreater(
+		failures,
+		"formationScore",
+		baseline.formationScore,
+		upgrade.formationScore,
+		baseline.formationScore,
+	);
+	failIfGreater(
+		failures,
+		"treeLevelP95",
+		baseline.treeLevelP95,
+		upgrade.treeLevelP95,
+		baseline.treeLevelP95,
+	);
+	failIfGreater(
+		failures,
+		"formationStretchP95",
+		baseline.formationStretchP95,
+		upgrade.formationStretchP95,
+		baseline.formationStretchP95,
+	);
+	failIfLess(
+		failures,
+		"deliveredWithinDeadlinePct",
+		baseline.deliveredWithinDeadlinePct,
+		upgrade.deliveredWithinDeadlinePct,
+		baseline.deliveredWithinDeadlinePct,
+	);
+
+	failIfGreater(
+		failures,
+		"controlBpp",
+		baseline.controlBpp,
+		upgrade.controlBpp,
+		ratioLimit(baseline.controlBpp, args.maxCostRatio, 0.001),
+	);
+	failIfGreater(
+		failures,
+		"trackerBpp",
+		baseline.trackerBpp,
+		upgrade.trackerBpp,
+		ratioLimit(baseline.trackerBpp, args.maxCostRatio, 0.001),
+	);
+	failIfGreater(
+		failures,
+		"repairBpp",
+		baseline.repairBpp,
+		upgrade.repairBpp,
+		ratioLimit(baseline.repairBpp, args.maxCostRatio, 0.001),
+	);
+	failIfGreater(
+		failures,
+		"maintReparentsPerMin",
+		baseline.maintReparentsPerMin,
+		upgrade.maintReparentsPerMin,
+		args.maxReparentsPerMin,
+	);
+	failIfGreater(
+		failures,
+		"maintMaxReparentsPerPeer",
+		baseline.maintMaxReparentsPerPeer,
+		upgrade.maintMaxReparentsPerPeer,
+		args.maxReparentsPerPeer,
+	);
+	failIfGreater(
+		failures,
+		"maintOrphanArea",
+		baseline.maintOrphanArea,
+		upgrade.maintOrphanArea,
+		ratioLimit(baseline.maintOrphanArea, args.maxOrphanAreaRatio, 1),
+	);
+	failIfGreater(
+		failures,
+		"treeRootChildren",
+		baseline.treeRootChildren,
+		upgrade.treeRootChildren,
+		params.rootMaxChildren,
+	);
+
+	return failures;
+};
+
+const printComparison = (
+	scenario: ScenarioName,
+	seed: number,
+	baseline: FanoutTreeSimResult,
+	upgrade: FanoutTreeSimResult,
+	failures: Failure[],
+) => {
+	const delta = (after: number, before: number) =>
+		Number.isFinite(after) && Number.isFinite(before) ? after - before : NaN;
+
+	console.log(
+		[
+			`parent-upgrade-eval scenario=${scenario} seed=${seed} viable=${failures.length === 0}`,
+			`  formationScore ${baseline.formationScore.toFixed(2)} -> ${upgrade.formationScore.toFixed(2)} delta=${delta(upgrade.formationScore, baseline.formationScore).toFixed(2)}`,
+			`  treeLevelP95 ${baseline.treeLevelP95.toFixed(1)} -> ${upgrade.treeLevelP95.toFixed(1)} delta=${delta(upgrade.treeLevelP95, baseline.treeLevelP95).toFixed(1)}`,
+			`  formationStretchP95 ${baseline.formationStretchP95.toFixed(2)} -> ${upgrade.formationStretchP95.toFixed(2)} delta=${delta(upgrade.formationStretchP95, baseline.formationStretchP95).toFixed(2)}`,
+			`  deliveredWithinDeadlinePct ${baseline.deliveredWithinDeadlinePct.toFixed(2)} -> ${upgrade.deliveredWithinDeadlinePct.toFixed(2)} delta=${delta(upgrade.deliveredWithinDeadlinePct, baseline.deliveredWithinDeadlinePct).toFixed(2)}`,
+			`  bpp control ${baseline.controlBpp.toFixed(4)} -> ${upgrade.controlBpp.toFixed(4)} tracker ${baseline.trackerBpp.toFixed(4)} -> ${upgrade.trackerBpp.toFixed(4)} repair ${baseline.repairBpp.toFixed(4)} -> ${upgrade.repairBpp.toFixed(4)}`,
+			`  maintenance reparentsPerMin ${baseline.maintReparentsPerMin.toFixed(2)} -> ${upgrade.maintReparentsPerMin.toFixed(2)} maxReparentsPerPeer ${baseline.maintMaxReparentsPerPeer} -> ${upgrade.maintMaxReparentsPerPeer} orphanArea ${baseline.maintOrphanArea.toFixed(1)} -> ${upgrade.maintOrphanArea.toFixed(1)}`,
+			`  rootChildren ${baseline.treeRootChildren} -> ${upgrade.treeRootChildren} proactiveUpgrades=${upgrade.reparentUpgradeTotal}`,
+			...(failures.length > 0
+				? failures.map(
+						(f) =>
+							`  FAIL ${f.metric}: baseline=${f.baseline.toFixed(4)} upgrade=${f.upgrade.toFixed(4)} limit=${f.limit.toFixed(4)}`,
+					)
+				: []),
+		].join("\n"),
+	);
+};
+
+const main = async () => {
+	const args = parseArgs(process.argv.slice(2));
+	let failureCount = 0;
+
+	for (const scenario of args.scenarios) {
+		for (const seed of args.seeds) {
+			const baseParams = {
+				...SCENARIOS[scenario],
+				seed,
+				parentUpgradeIntervalMs: 0,
+			};
+			const upgradeParams = {
+				...SCENARIOS[scenario],
+				seed,
+				parentUpgradeIntervalMs: args.parentUpgradeIntervalMs,
+				parentUpgradeLeafOnly: args.parentUpgradeLeafOnly,
+			};
+
+			console.log(`\n[baseline] scenario=${scenario} seed=${seed}`);
+			const baseline = await runFanoutTreeSim(baseParams);
+			console.log(formatFanoutTreeSimResult(baseline));
+
+			console.log(`\n[parent-upgrade] scenario=${scenario} seed=${seed}`);
+			const upgrade = await runFanoutTreeSim(upgradeParams);
+			console.log(formatFanoutTreeSimResult(upgrade));
+
+			const failures = evaluateRun(upgrade.params, baseline, upgrade, args);
+			printComparison(scenario, seed, baseline, upgrade, failures);
+			failureCount += failures.length;
+		}
+	}
+
+	if (args.strict && failureCount > 0) {
+		process.exit(2);
+	}
+};
+
+try {
+	await main();
+} catch (err: any) {
+	console.error(err?.message ?? String(err));
+	process.exit(1);
+}

--- a/packages/transport/pubsub/benchmark/fanout-tree-sim-lib.ts
+++ b/packages/transport/pubsub/benchmark/fanout-tree-sim-lib.ts
@@ -82,6 +82,8 @@ export type FanoutTreeSimParams = {
 	joinReqTimeoutMs: number;
 	candidateShuffleTopK: number;
 	candidateScoringMode: "ranked-shuffle" | "ranked-strict" | "weighted";
+	parentUpgradeIntervalMs: number;
+	parentUpgradeLeafOnly: boolean;
 	bootstrapEnsureIntervalMs: number;
 	trackerQueryIntervalMs: number;
 	joinAttemptsPerRound: number;
@@ -174,6 +176,7 @@ export type FanoutTreeSimResult = {
 	reparentDisconnectTotal: number;
 	reparentStaleTotal: number;
 	reparentKickedTotal: number;
+	reparentUpgradeTotal: number;
 
 	treeMaxLevel: number;
 	treeLevelP95: number;
@@ -349,6 +352,8 @@ export const resolveFanoutTreeSimParams = (
 			input.candidateScoringMode === "ranked-shuffle"
 				? input.candidateScoringMode
 				: "ranked-shuffle",
+		parentUpgradeIntervalMs: Number(input.parentUpgradeIntervalMs ?? 0),
+		parentUpgradeLeafOnly: Boolean(input.parentUpgradeLeafOnly ?? true),
 		bootstrapEnsureIntervalMs: Number(input.bootstrapEnsureIntervalMs ?? -1),
 		trackerQueryIntervalMs: Number(input.trackerQueryIntervalMs ?? -1),
 		joinAttemptsPerRound: Number(input.joinAttemptsPerRound ?? -1),
@@ -409,7 +414,7 @@ export const formatFanoutTreeSimResult = (r: FanoutTreeSimResult) => {
 				: `deadline=off${p.maxDataAgeMs > 0 ? ` maxAgeMs=${p.maxDataAgeMs}` : ""}`,
 			`latencyMs p50=${r.latencyP50.toFixed(1)} p95=${r.latencyP95.toFixed(1)} p99=${r.latencyP99.toFixed(1)} max=${r.latencyMax.toFixed(1)}`,
 			`drops: forward total=${r.droppedForwardsTotal} max=${r.droppedForwardsMax} node=${r.droppedForwardsMaxNode ?? "-"} stale total=${r.staleForwardsDroppedTotal} max=${r.staleForwardsDroppedMax} node=${r.staleForwardsDroppedMaxNode ?? "-"} write total=${r.dataWriteDropsTotal} max=${r.dataWriteDropsMax} node=${r.dataWriteDropsMaxNode ?? "-"}`,
-			`reparent: disconnect=${r.reparentDisconnectTotal} stale=${r.reparentStaleTotal} kicked=${r.reparentKickedTotal}`,
+			`reparent: disconnect=${r.reparentDisconnectTotal} stale=${r.reparentStaleTotal} kicked=${r.reparentKickedTotal} upgrade=${r.reparentUpgradeTotal}`,
 			`tree: maxLevel=${r.treeMaxLevel} p95Level=${r.treeLevelP95.toFixed(1)} avgLevel=${r.treeLevelAvg.toFixed(2)} orphans=${r.treeOrphans} rootChildren=${r.treeRootChildren} children(p95/max)=${r.treeChildrenP95.toFixed(1)}/${r.treeChildrenMax}`,
 			`upload: max=${r.maxUploadBps} B/s (${r.maxUploadFracPct.toFixed(1)}% of cap) node=${r.maxUploadNode ?? "-"}`,
 			`stream: queuedBytes total=${r.streamQueuedBytesTotal} max=${r.streamQueuedBytesMax} p95=${r.streamQueuedBytesP95.toFixed(0)} node=${r.streamQueuedBytesMaxNode ?? "-"} lanes=${r.streamQueuedBytesByLane.join(",")}`,
@@ -676,19 +681,21 @@ export const runFanoutTreeSim = async (
 								? { neighborRepairBurstMs: params.neighborRepairBurstMs }
 								: {}),
 						},
-								{
-									timeoutMs: Math.max(10_000, Math.min(120_000, timeoutMs || 120_000)),
-									...(params.maxDataAgeMs > 0 ? { staleAfterMs: params.maxDataAgeMs } : {}),
-									...(params.joinReqTimeoutMs >= 0
-										? { joinReqTimeoutMs: params.joinReqTimeoutMs }
-										: {}),
-									...(params.candidateShuffleTopK >= 0
-									? { candidateShuffleTopK: params.candidateShuffleTopK }
-									: {}),
-									candidateScoringMode: params.candidateScoringMode,
-								...(params.bootstrapEnsureIntervalMs >= 0
-									? { bootstrapEnsureIntervalMs: params.bootstrapEnsureIntervalMs }
-									: {}),
+						{
+							timeoutMs: Math.max(10_000, Math.min(120_000, timeoutMs || 120_000)),
+							...(params.maxDataAgeMs > 0 ? { staleAfterMs: params.maxDataAgeMs } : {}),
+							...(params.joinReqTimeoutMs >= 0
+								? { joinReqTimeoutMs: params.joinReqTimeoutMs }
+								: {}),
+							...(params.candidateShuffleTopK >= 0
+								? { candidateShuffleTopK: params.candidateShuffleTopK }
+								: {}),
+							candidateScoringMode: params.candidateScoringMode,
+							parentUpgradeIntervalMs: params.parentUpgradeIntervalMs,
+							parentUpgradeLeafOnly: params.parentUpgradeLeafOnly,
+							...(params.bootstrapEnsureIntervalMs >= 0
+								? { bootstrapEnsureIntervalMs: params.bootstrapEnsureIntervalMs }
+								: {}),
 								...(params.trackerQueryIntervalMs >= 0
 									? { trackerQueryIntervalMs: params.trackerQueryIntervalMs }
 									: {}),
@@ -898,6 +905,7 @@ export const runFanoutTreeSim = async (
 			let churnedPeersTotal = 0;
 			const wantsMaintenance =
 				(params.churnEveryMs > 0 && params.churnDownMs > 0 && params.churnFraction > 0) ||
+				params.parentUpgradeIntervalMs > 0 ||
 				params.assertMaxOrphans > 0 ||
 				params.assertMaxOrphanArea > 0 ||
 				params.assertRecoveryP95Ms > 0 ||
@@ -1181,7 +1189,10 @@ export const runFanoutTreeSim = async (
 					const m = p.services.fanout.getChannelMetrics(params.topic, rootId);
 					reparentBaselineByHash.set(
 						nodeHash,
-						m.reparentDisconnect + m.reparentStale + m.reparentKicked,
+						m.reparentDisconnect +
+							m.reparentStale +
+							m.reparentKicked +
+							m.reparentUpgrade,
 					);
 				}
 			}
@@ -1228,7 +1239,11 @@ export const runFanoutTreeSim = async (
 				for (const p of session.peers) {
 					const nodeHash = p.services.fanout.publicKeyHash;
 					const m = p.services.fanout.getChannelMetrics(params.topic, rootId);
-					const total = m.reparentDisconnect + m.reparentStale + m.reparentKicked;
+					const total =
+						m.reparentDisconnect +
+						m.reparentStale +
+						m.reparentKicked +
+						m.reparentUpgrade;
 					const base = reparentBaselineByHash.get(nodeHash) ?? 0;
 					const delta = Math.max(0, total - base);
 					maintReparentsTotal += delta;
@@ -1372,6 +1387,7 @@ export const runFanoutTreeSim = async (
 					let reparentDisconnectTotal = 0;
 					let reparentStaleTotal = 0;
 					let reparentKickedTotal = 0;
+					let reparentUpgradeTotal = 0;
 					let earningsTotal = 0;
 					const earningsByHash = new Map<string, number>();
 
@@ -1391,6 +1407,7 @@ export const runFanoutTreeSim = async (
 						reparentDisconnectTotal += m.reparentDisconnect;
 						reparentStaleTotal += m.reparentStale;
 						reparentKickedTotal += m.reparentKicked;
+						reparentUpgradeTotal += m.reparentUpgrade;
 						earningsTotal += m.earnings;
 						earningsByHash.set(nodeHash, m.earnings);
 						protocolControlSends += m.controlSends;
@@ -1495,6 +1512,7 @@ export const runFanoutTreeSim = async (
 						reparentDisconnectTotal,
 						reparentStaleTotal,
 						reparentKickedTotal,
+						reparentUpgradeTotal,
 						treeMaxLevel,
 						treeLevelP95,
 						treeLevelAvg,

--- a/packages/transport/pubsub/benchmark/fanout-tree-sim.ts
+++ b/packages/transport/pubsub/benchmark/fanout-tree-sim.ts
@@ -67,6 +67,8 @@ const HELP_TEXT = [
 	"  --joinReqTimeoutMs MS         join request timeout per candidate (default: 2000)",
 	"  --candidateShuffleTopK N      shuffle only within top K candidates (default: 8)",
 	"  --candidateScoringMode MODE   join scoring (ranked-shuffle|ranked-strict|weighted, default: ranked-shuffle)",
+	"  --parentUpgradeIntervalMs MS  min interval between proactive parent-upgrade checks (default: 0, off)",
+	"  --parentUpgradeLeafOnly 0|1   restrict proactive parent upgrades to leaves (default: 1)",
 	"  --bootstrapEnsureIntervalMs MS  min interval between bootstrap re-dials (-1 = FanoutTree default)",
 	"  --trackerQueryIntervalMs MS     min interval between tracker queries (-1 = FanoutTree default)",
 	"  --joinAttemptsPerRound N        max join candidates tried per retry round (-1 = FanoutTree default)",
@@ -319,6 +321,12 @@ const ARG_SPECS: ArgSpec[] = [
 	{ flag: "--joinReqTimeoutMs", key: "joinReqTimeoutMs", parse: parseNumber },
 	{ flag: "--candidateShuffleTopK", key: "candidateShuffleTopK", parse: parseNumber },
 	{ flag: "--candidateScoringMode", key: "candidateScoringMode", parse: parseString },
+	{
+		flag: "--parentUpgradeIntervalMs",
+		key: "parentUpgradeIntervalMs",
+		parse: parseNumber,
+	},
+	{ flag: "--parentUpgradeLeafOnly", key: "parentUpgradeLeafOnly", parse: parseBool01("1") },
 	{
 		flag: "--bootstrapEnsureIntervalMs",
 		key: "bootstrapEnsureIntervalMs",

--- a/packages/transport/pubsub/benchmark/index.ts
+++ b/packages/transport/pubsub/benchmark/index.ts
@@ -19,11 +19,13 @@ const usage = () => {
 			"Benchmarks:",
 			"  topic-sim  in-memory TopicControlPlane topic fanout sim",
 			"  fanout-tree-sim  end-to-end FanoutTree protocol sim (bootstrap tracker join)",
+			"  fanout-tree-parent-upgrade-eval  A/B evidence harness for proactive parent upgrades",
 			"",
 			"Example:",
 			"  pnpm -C packages/transport/pubsub run bench -- topic-sim --nodes 3 --degree 2 --subscribers 2 --messages 5 --msgSize 32 --intervalMs 0 --seed 1 --subscribeModel preseed --timeoutMs 300000",
 			"  pnpm -C packages/transport/pubsub run bench -- topic-sim --nodes 2000 --degree 6 --subscribers 1500 --messages 200",
 			"  pnpm -C packages/transport/pubsub run bench -- fanout-tree-sim --preset live --nodes 2000 --bootstraps 1 --seed 1",
+			"  pnpm -C packages/transport/pubsub run bench -- fanout-tree-parent-upgrade-eval --scenario ci-small --seeds 1,2,3",
 		].join("\n"),
 	);
 };
@@ -39,6 +41,9 @@ switch (bench) {
 		break;
 	case "fanout-tree-sim":
 		await import("./fanout-tree-sim.js");
+		break;
+	case "fanout-tree-parent-upgrade-eval":
+		await import("./fanout-tree-parent-upgrade-eval.js");
 		break;
 	default:
 		usage();

--- a/packages/transport/pubsub/src/fanout-tree.ts
+++ b/packages/transport/pubsub/src/fanout-tree.ts
@@ -265,6 +265,22 @@ export type FanoutTreeJoinOptions = {
 	trackerQueryIntervalMs?: number;
 
 	/**
+	 * Min interval between parent-improvement checks while already attached.
+	 *
+	 * Set to `0` to preserve the current stability-first behavior where a healthy
+	 * parent is only replaced after disconnect/staleness/kick.
+	 */
+	parentUpgradeIntervalMs?: number;
+
+	/**
+	 * Restrict proactive parent upgrades to leaves (nodes with no children).
+	 *
+	 * Defaults to `true` so parent improvement can be evaluated without
+	 * introducing relay churn higher in the tree.
+	 */
+	parentUpgradeLeafOnly?: boolean;
+
+	/**
 	 * Max number of join candidates to try per retry "round".
 	 *
 	 * This prevents a long tail of sequential JOIN_REQ timeouts from blocking
@@ -1456,14 +1472,15 @@ type ChannelState = {
 	cachedBootstrapPeers: string[];
 	lastBootstrapEnsureAt: number;
 
-			announceIntervalMs: number;
-			announceTtlMs: number;
-			lastAnnouncedAt: number;
-			peerHintMaxEntries: number;
-			peerHintTtlMs: number;
-			routeCacheMaxEntries: number;
-			routeCacheTtlMs: number;
-		announceLoop?: Promise<void>;
+	announceIntervalMs: number;
+	announceTtlMs: number;
+	lastAnnouncedAt: number;
+	peerHintMaxEntries: number;
+	peerHintTtlMs: number;
+	routeCacheMaxEntries: number;
+	routeCacheTtlMs: number;
+	loopAbortController: AbortController;
+	announceLoop?: Promise<void>;
 	repairLoop?: Promise<void>;
 	meshLoop?: Promise<void>;
 	joinLoop?: Promise<void>;
@@ -2487,6 +2504,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			peerHintTtlMs,
 			routeCacheMaxEntries,
 			routeCacheTtlMs,
+			loopAbortController: new AbortController(),
 			trackerQueryIntervalMs: 2_000,
 			cachedTrackerCandidates: [],
 			lastTrackerQueryAt: 0,
@@ -2600,6 +2618,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		if (!ch) return;
 		if (ch.closed) return;
 		ch.closed = true;
+		ch.loopAbortController.abort();
 
 		// If a join is in-flight, surface that it won't complete.
 		try {
@@ -2644,6 +2663,11 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		this.trackerBySuffixKey.delete(id.suffixKey);
 
 		await Promise.all(pendingSends);
+		await Promise.allSettled(
+			[ch.joinLoop, ch.announceLoop, ch.repairLoop, ch.meshLoop].filter(
+				(loop): loop is Promise<void> => Boolean(loop),
+			),
+		);
 	}
 
 	public getChannelStats(topic: string, root: string):
@@ -4527,7 +4551,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 	}
 
 	private async _announceLoop(ch: ChannelState): Promise<void> {
-		const signal = this.closeController.signal;
+		const signal = anySignal([this.closeController.signal, ch.loopAbortController.signal]);
 		for (;;) {
 			if (signal.aborted || ch.closed) return;
 			try {
@@ -4541,12 +4565,12 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 				// ignore
 			}
 			const sleepMs = ch.announceIntervalMs > 0 ? ch.announceIntervalMs : 1_000;
-			await delay(sleepMs);
+			await delay(sleepMs, { signal }).catch(() => {});
 		}
 	}
 
 	private async _repairLoop(ch: ChannelState): Promise<void> {
-		const signal = this.closeController.signal;
+		const signal = anySignal([this.closeController.signal, ch.loopAbortController.signal]);
 		for (;;) {
 			if (signal.aborted || ch.closed) return;
 			try {
@@ -4556,7 +4580,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			}
 			const activeMs = ch.repairIntervalMs > 0 ? ch.repairIntervalMs : 200;
 			const sleepMs = ch.missingSeqs.size > 0 ? activeMs : Math.max(activeMs, 1_000);
-			await delay(sleepMs);
+			await delay(sleepMs, { signal }).catch(() => {});
 		}
 	}
 
@@ -4732,11 +4756,11 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			}
 		}
 
-		private async _meshLoop(ch: ChannelState): Promise<void> {
-			const signal = this.closeController.signal;
-			let lastRefreshAt = 0;
-			for (;;) {
-				if (signal.aborted || ch.closed) return;
+	private async _meshLoop(ch: ChannelState): Promise<void> {
+		const signal = anySignal([this.closeController.signal, ch.loopAbortController.signal]);
+		let lastRefreshAt = 0;
+		for (;;) {
+			if (signal.aborted || ch.closed) return;
 
 				const now = Date.now();
 				try {
@@ -4759,7 +4783,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 				(v) => v > 0,
 			);
 			const sleepMs = intervals.length > 0 ? Math.min(...intervals) : 500;
-			await delay(Math.max(50, sleepMs));
+			await delay(Math.max(50, sleepMs), { signal }).catch(() => {});
 		}
 	}
 
@@ -4978,6 +5002,11 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			0,
 			Math.floor(joinOpts.candidateCooldownMs ?? 2_000),
 		);
+		const parentUpgradeIntervalMs = Math.max(
+			0,
+			Math.floor(joinOpts.parentUpgradeIntervalMs ?? 0),
+		);
+		const parentUpgradeLeafOnly = joinOpts.parentUpgradeLeafOnly !== false;
 		const candidateScoringModeRaw = joinOpts.candidateScoringMode ?? "ranked-shuffle";
 		const candidateScoringMode: "ranked-shuffle" | "ranked-strict" | "weighted" =
 			candidateScoringModeRaw === "ranked-strict" ||
@@ -4995,9 +5024,10 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		const start = Date.now();
 		const cooldownUntilByHash = new Map<string, number>();
 		const combinedSignal = joinOpts.signal
-			? anySignal([this.closeController.signal, joinOpts.signal])
-			: this.closeController.signal;
+			? anySignal([this.closeController.signal, ch.loopAbortController.signal, joinOpts.signal])
+			: anySignal([this.closeController.signal, ch.loopAbortController.signal]);
 		const signal = combinedSignal as AbortSignal & { clear?: () => void };
+		let lastParentUpgradeCheckAt = 0;
 
 			try {
 				for (;;) {
@@ -5070,8 +5100,30 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 								}
 								ch.pendingRouteProxy.clear();
 								void this.kickChildren(ch).catch(() => {});
-								await delay(retryMs);
+								await delay(retryMs, { signal });
 								continue;
+							}
+
+							if (
+								parentUpgradeIntervalMs > 0 &&
+								ch.level > 1 &&
+								(!parentUpgradeLeafOnly || ch.children.size === 0)
+							) {
+								const now = Date.now();
+								const due =
+									lastParentUpgradeCheckAt === 0 ||
+									now - lastParentUpgradeCheckAt >= parentUpgradeIntervalMs;
+								if (due) {
+									lastParentUpgradeCheckAt = now;
+									await this.maybeImproveParent(ch, {
+										signal,
+										candidateShuffleTopK,
+										candidateScoringMode,
+										candidateScoringWeights,
+										joinAttemptsPerRound,
+										joinReqTimeoutMs,
+									});
+								}
 							}
 
 						if (!ch.joinedOnce) ch.joinedOnce = createDeferred();
@@ -5079,7 +5131,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 						ch.joinedAtLeastOnce = true;
 						// Once attached, we don't need a fast retry cadence; keep polling coarse to
 						// avoid excessive timers when simulating many nodes in one process.
-						await delay(Math.max(retryMs, 1_000));
+						await delay(Math.max(retryMs, 1_000), { signal });
 						continue;
 					}
 
@@ -5275,10 +5327,10 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 							retryMs,
 							trackerQueryIntervalMs > 0 ? trackerQueryIntervalMs : retryMs,
 						);
-							await delay(Math.max(1, Math.min(waitMs, capMs)));
+							await delay(Math.max(1, Math.min(waitMs, capMs)), { signal });
 							continue;
 						}
-						await delay(retryMs);
+						await delay(retryMs, { signal });
 						continue;
 					}
 
@@ -5513,11 +5565,254 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 							}
 							continue;
 						}
-						await delay(retryMs);
+						await delay(retryMs, { signal });
 					}
 				} finally {
 					signal.clear?.();
 			}
+	}
+
+	private async maybeImproveParent(
+		ch: ChannelState,
+		options: {
+			signal: AbortSignal;
+			candidateShuffleTopK: number;
+			candidateScoringMode: "ranked-shuffle" | "ranked-strict" | "weighted";
+			candidateScoringWeights: {
+				level: number;
+				freeSlots: number;
+				connected: number;
+				bidPerByte: number;
+				source: number;
+			};
+			joinAttemptsPerRound: number;
+			joinReqTimeoutMs: number;
+		},
+	): Promise<boolean> {
+		const currentParent = ch.parent;
+		if (!currentParent || ch.closed || ch.isRoot || ch.level <= 1) return false;
+		const isDirectNeighbor = (hash: string) => {
+			const peer = this.peers.get(hash);
+			if (!peer) return false;
+			try {
+				const conns = this.components.connectionManager.getConnections(peer.peerId) as
+					| Connection[]
+					| undefined;
+				return (conns?.length ?? 0) > 0;
+			} catch {
+				return peer.isReadable || peer.isWritable;
+			}
+		};
+
+		const candidatesByHash = new Map<
+			string,
+			{
+				hash: string;
+				addrs: Multiaddr[];
+				level: number;
+				freeSlots: number;
+				bidPerByte: number;
+				source: number;
+			}
+		>();
+
+		const upsertCandidate = (c: {
+			hash: string;
+			addrs: Multiaddr[];
+			level: number;
+			freeSlots: number;
+			bidPerByte: number;
+			source: number;
+		}) => {
+			const prev = candidatesByHash.get(c.hash);
+			if (!prev) {
+				candidatesByHash.set(c.hash, { ...c });
+				return;
+			}
+			if (prev.addrs.length === 0 && c.addrs.length > 0) prev.addrs = c.addrs;
+			prev.level = Math.min(prev.level, c.level);
+			prev.freeSlots = Math.max(prev.freeSlots, c.freeSlots);
+			prev.bidPerByte = Math.max(prev.bidPerByte, c.bidPerByte);
+			prev.source = Math.min(prev.source, c.source);
+		};
+
+		if (ch.id.root !== this.publicKeyHash && isDirectNeighbor(ch.id.root)) {
+			upsertCandidate({
+				hash: ch.id.root,
+				addrs: [],
+				level: 0,
+				freeSlots: Number.MAX_SAFE_INTEGER,
+				bidPerByte: 0,
+				source: -1,
+			});
+		}
+
+		for (const c of ch.cachedTrackerCandidates) {
+			if (c.hash === this.publicKeyHash) continue;
+			if (!isDirectNeighbor(c.hash)) continue;
+			if (c.freeSlots <= 0) continue;
+			upsertCandidate({
+				hash: c.hash,
+				addrs: c.addrs,
+				level: c.level,
+				freeSlots: c.freeSlots,
+				bidPerByte: c.bidPerByte,
+				source: 0,
+			});
+		}
+
+		let connectedFallbackAdded = 0;
+		const connectedFallbackMax = 64;
+		for (const h of this.peers.keys()) {
+			if (h === this.publicKeyHash) continue;
+			if (!isDirectNeighbor(h)) continue;
+			upsertCandidate({
+				hash: h,
+				addrs: [],
+				level: 0xffff,
+				freeSlots: 0,
+				bidPerByte: 0,
+				source: 2,
+			});
+			connectedFallbackAdded += 1;
+			if (connectedFallbackAdded >= connectedFallbackMax) break;
+		}
+
+		let ordered = [...candidatesByHash.values()]
+			.filter(
+				(c) =>
+					c.hash !== this.publicKeyHash &&
+					c.hash !== currentParent &&
+					c.level + 1 < ch.level,
+			)
+			.sort((a, b) => {
+				if (a.level !== b.level) return a.level - b.level;
+				if (a.freeSlots !== b.freeSlots) return b.freeSlots - a.freeSlots;
+				if (a.bidPerByte !== b.bidPerByte) return b.bidPerByte - a.bidPerByte;
+				if (a.source !== b.source) return a.source - b.source;
+				return a.hash < b.hash ? -1 : a.hash > b.hash ? 1 : 0;
+			});
+
+		if (ordered.length === 0) return false;
+
+		if (options.candidateScoringMode === "ranked-shuffle") {
+			if (options.candidateShuffleTopK > 0 && ordered.length > 1) {
+				const k = Math.min(options.candidateShuffleTopK, ordered.length);
+				for (let i = k - 1; i > 0; i--) {
+					const j = Math.floor(this.random() * (i + 1));
+					const tmp = ordered[i]!;
+					ordered[i] = ordered[j]!;
+					ordered[j] = tmp;
+				}
+			}
+		} else if (options.candidateScoringMode === "weighted") {
+			const wLevel = Number.isFinite(options.candidateScoringWeights.level)
+				? Math.max(0, options.candidateScoringWeights.level)
+				: 0;
+			const wSlots = Number.isFinite(options.candidateScoringWeights.freeSlots)
+				? Math.max(0, options.candidateScoringWeights.freeSlots)
+				: 0;
+			const wConnected = Number.isFinite(options.candidateScoringWeights.connected)
+				? Math.max(0, options.candidateScoringWeights.connected)
+				: 0;
+			const wBid = Number.isFinite(options.candidateScoringWeights.bidPerByte)
+				? Math.max(0, options.candidateScoringWeights.bidPerByte)
+				: 0;
+			const wSource = Number.isFinite(options.candidateScoringWeights.source)
+				? Math.max(0, options.candidateScoringWeights.source)
+				: 0;
+
+			const k =
+				options.candidateShuffleTopK > 0
+					? Math.min(options.candidateShuffleTopK, ordered.length)
+					: 0;
+			if (k > 1) {
+				const head = ordered.slice(0, k);
+				const tail = ordered.slice(k);
+
+				const weightOf = (c: (typeof head)[number]) => {
+					const level = Math.max(0, Math.floor(c.level));
+					const freeSlots = Math.max(0, Math.floor(c.freeSlots));
+					const bidPerByte = Math.max(0, Math.floor(c.bidPerByte));
+					const source = Math.max(0, Math.floor(c.source));
+					const connected = Boolean(this.peers.get(c.hash));
+
+					let weight = 1;
+					if (wLevel > 0) weight *= 1 / (1 + wLevel * level);
+					if (wSlots > 0) weight *= 1 + wSlots * freeSlots;
+					if (wConnected > 0 && connected) weight *= 1 + wConnected;
+					if (wBid > 0) weight *= 1 + wBid * bidPerByte;
+					if (wSource > 0) weight *= 1 / (1 + wSource * source);
+					return weight;
+				};
+
+				const out: typeof head = [];
+				const remaining = [...head];
+				while (remaining.length > 0) {
+					let sum = 0;
+					const weights: number[] = new Array(remaining.length);
+					for (let i = 0; i < remaining.length; i++) {
+						const w = weightOf(remaining[i]!);
+						const v = Number.isFinite(w) ? Math.max(0, w) : 0;
+						weights[i] = v;
+						sum += v;
+					}
+					if (sum <= 0) {
+						out.push(...remaining);
+						break;
+					}
+
+					let r = this.random() * sum;
+					let pick = 0;
+					for (; pick < weights.length; pick++) {
+						r -= weights[pick]!;
+						if (r <= 0) break;
+					}
+					if (pick >= remaining.length) pick = remaining.length - 1;
+					out.push(remaining[pick]!);
+					remaining.splice(pick, 1);
+				}
+
+				ordered = out.concat(tail);
+			}
+		}
+
+		let attempts = 0;
+		for (const candidate of ordered) {
+			if (options.signal.aborted) break;
+			if (attempts >= options.joinAttemptsPerRound) break;
+			attempts += 1;
+
+			if (!isDirectNeighbor(candidate.hash)) continue;
+
+			const previousParent = ch.parent;
+			const reqId = (this.random() * 0xffffffff) >>> 0;
+			const res = await this.tryJoinOnce(
+				ch,
+				candidate.hash,
+				reqId,
+				options.joinReqTimeoutMs,
+				options.signal,
+				{ allowReplace: true },
+			);
+
+			if (res.ok) {
+				const newParent = ch.parent;
+				if (
+					previousParent &&
+					newParent &&
+					newParent !== previousParent
+				) {
+					void this._sendControl(previousParent, encodeLeave(ch.id.key)).catch(
+						() => {},
+					);
+					return true;
+				}
+				return false;
+			}
+		}
+
+		return false;
 	}
 
 	private async tryJoinOnce(
@@ -5526,8 +5821,9 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		reqId: number,
 		timeoutMs: number,
 		signal: AbortSignal,
+		options?: { allowReplace?: boolean },
 	): Promise<JoinAttemptResult> {
-		if (ch.parent) return { ok: true };
+		if (ch.parent && options?.allowReplace !== true) return { ok: true };
 		if (!this.peers.get(parentHash)) return { ok: false, timedOut: true };
 		const p = new Promise<JoinAttemptResult>((resolve) => {
 			ch.pendingJoin.set(reqId, { resolve });

--- a/packages/transport/pubsub/src/fanout-tree.ts
+++ b/packages/transport/pubsub/src/fanout-tree.ts
@@ -1479,7 +1479,6 @@ type ChannelState = {
 	peerHintTtlMs: number;
 	routeCacheMaxEntries: number;
 	routeCacheTtlMs: number;
-	loopAbortController: AbortController;
 	announceLoop?: Promise<void>;
 	repairLoop?: Promise<void>;
 	meshLoop?: Promise<void>;
@@ -2504,7 +2503,6 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			peerHintTtlMs,
 			routeCacheMaxEntries,
 			routeCacheTtlMs,
-			loopAbortController: new AbortController(),
 			trackerQueryIntervalMs: 2_000,
 			cachedTrackerCandidates: [],
 			lastTrackerQueryAt: 0,
@@ -2618,7 +2616,6 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		if (!ch) return;
 		if (ch.closed) return;
 		ch.closed = true;
-		ch.loopAbortController.abort();
 
 		// If a join is in-flight, surface that it won't complete.
 		try {
@@ -2663,11 +2660,6 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		this.trackerBySuffixKey.delete(id.suffixKey);
 
 		await Promise.all(pendingSends);
-		await Promise.allSettled(
-			[ch.joinLoop, ch.announceLoop, ch.repairLoop, ch.meshLoop].filter(
-				(loop): loop is Promise<void> => Boolean(loop),
-			),
-		);
 	}
 
 	public getChannelStats(topic: string, root: string):
@@ -4551,7 +4543,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 	}
 
 	private async _announceLoop(ch: ChannelState): Promise<void> {
-		const signal = anySignal([this.closeController.signal, ch.loopAbortController.signal]);
+		const signal = this.closeController.signal;
 		for (;;) {
 			if (signal.aborted || ch.closed) return;
 			try {
@@ -4565,12 +4557,12 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 				// ignore
 			}
 			const sleepMs = ch.announceIntervalMs > 0 ? ch.announceIntervalMs : 1_000;
-			await delay(sleepMs, { signal }).catch(() => {});
+			await delay(sleepMs);
 		}
 	}
 
 	private async _repairLoop(ch: ChannelState): Promise<void> {
-		const signal = anySignal([this.closeController.signal, ch.loopAbortController.signal]);
+		const signal = this.closeController.signal;
 		for (;;) {
 			if (signal.aborted || ch.closed) return;
 			try {
@@ -4580,7 +4572,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			}
 			const activeMs = ch.repairIntervalMs > 0 ? ch.repairIntervalMs : 200;
 			const sleepMs = ch.missingSeqs.size > 0 ? activeMs : Math.max(activeMs, 1_000);
-			await delay(sleepMs, { signal }).catch(() => {});
+			await delay(sleepMs);
 		}
 	}
 
@@ -4757,7 +4749,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		}
 
 	private async _meshLoop(ch: ChannelState): Promise<void> {
-		const signal = anySignal([this.closeController.signal, ch.loopAbortController.signal]);
+		const signal = this.closeController.signal;
 		let lastRefreshAt = 0;
 		for (;;) {
 			if (signal.aborted || ch.closed) return;
@@ -4783,7 +4775,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 				(v) => v > 0,
 			);
 			const sleepMs = intervals.length > 0 ? Math.min(...intervals) : 500;
-			await delay(Math.max(50, sleepMs), { signal }).catch(() => {});
+			await delay(Math.max(50, sleepMs));
 		}
 	}
 
@@ -5024,8 +5016,8 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		const start = Date.now();
 		const cooldownUntilByHash = new Map<string, number>();
 		const combinedSignal = joinOpts.signal
-			? anySignal([this.closeController.signal, ch.loopAbortController.signal, joinOpts.signal])
-			: anySignal([this.closeController.signal, ch.loopAbortController.signal]);
+			? anySignal([this.closeController.signal, joinOpts.signal])
+			: this.closeController.signal;
 		const signal = combinedSignal as AbortSignal & { clear?: () => void };
 		let lastParentUpgradeCheckAt = 0;
 

--- a/packages/transport/pubsub/src/fanout-tree.ts
+++ b/packages/transport/pubsub/src/fanout-tree.ts
@@ -437,6 +437,7 @@ export type FanoutTreeChannelMetrics = {
 	reparentDisconnect: number;
 	reparentStale: number;
 	reparentKicked: number;
+	reparentUpgrade: number;
 	endSent: number;
 	endReceived: number;
 
@@ -1534,6 +1535,7 @@ const createEmptyMetrics = (): FanoutTreeChannelMetrics => ({
 	reparentDisconnect: 0,
 	reparentStale: 0,
 	reparentKicked: 0,
+	reparentUpgrade: 0,
 	endSent: 0,
 	endReceived: 0,
 	repairReqSent: 0,
@@ -5107,7 +5109,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 									now - lastParentUpgradeCheckAt >= parentUpgradeIntervalMs;
 								if (due) {
 									lastParentUpgradeCheckAt = now;
-									await this.maybeImproveParent(ch, {
+									const improved = await this.maybeImproveParent(ch, {
 										signal,
 										candidateShuffleTopK,
 										candidateScoringMode,
@@ -5115,6 +5117,9 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 										joinAttemptsPerRound,
 										joinReqTimeoutMs,
 									});
+									if (improved) {
+										ch.metrics.reparentUpgrade += 1;
+									}
 								}
 							}
 

--- a/packages/transport/pubsub/src/index.ts
+++ b/packages/transport/pubsub/src/index.ts
@@ -48,6 +48,7 @@ import {
 	getMsgId,
 } from "@peerbit/stream-interface";
 import { AbortError, TimeoutError, delay } from "@peerbit/time";
+import { anySignal } from "any-signal";
 import { Uint8ArrayList } from "uint8arraylist";
 import { toUint8Array } from "./bytes.js";
 import {
@@ -253,10 +254,7 @@ export class TopicControlPlane
 	private readonly shardCount: number;
 	private readonly shardTopicPrefix: string;
 	private readonly hostShards: boolean;
-	private readonly shardRootCache = new Map<
-		string,
-		{ root: string; authoritative: boolean }
-	>();
+	private readonly shardRootCache = new Map<string, { root: string; authoritative: boolean }>();
 	private readonly shardTopicCache = new Map<string, string>();
 	private readonly shardRefCounts = new Map<string, number>();
 	private readonly pinnedShards = new Set<string>();
@@ -273,6 +271,7 @@ export class TopicControlPlane
 	private readonly fanoutPublishRequiresSubscribe: boolean;
 	private readonly fanoutPublishIdleCloseMs: number;
 	private readonly fanoutPublishMaxEphemeralChannels: number;
+	private shutdownController = new AbortController();
 
 	// If no shard-root candidates are configured, we fall back to an "auto" mode:
 	// start with `[self]` and expand candidates as underlay peers connect.
@@ -437,6 +436,9 @@ export class TopicControlPlane
 	}
 
 	public override async start() {
+		if (this.shutdownController.signal.aborted) {
+			this.shutdownController = new AbortController();
+		}
 		await this.fanout.start();
 		this._onFanoutPeerUnreachable =
 			this._onFanoutPeerUnreachable ||
@@ -456,13 +458,21 @@ export class TopicControlPlane
 	}
 
 	public override async stop() {
+		this.stopping = true;
+		this.shutdownController.abort(new AbortError("PubSub stopping"));
+		const fanoutChannelStates = [...this.fanoutChannels.values()];
+		const pendingFanoutJoins = fanoutChannelStates.map((state) => state.join);
+		const pendingBackground = [
+			this.reconcileShardOverlaysInFlight,
+			this.hostOwnedShardRootsInFlight,
+		].filter((promise): promise is Promise<void> => Boolean(promise));
 		if (this._onFanoutPeerUnreachable) {
 			this.fanout.removeEventListener(
 				"fanout:peer-unreachable",
 				this._onFanoutPeerUnreachable as any,
 			);
 		}
-		for (const st of this.fanoutChannels.values()) {
+		for (const st of fanoutChannelStates) {
 			if (st.idleCloseTimeout) clearTimeout(st.idleCloseTimeout);
 			try {
 				st.channel.removeEventListener("data", st.onData as any);
@@ -512,6 +522,7 @@ export class TopicControlPlane
 
 		this.debounceSubscribeAggregator.close();
 		this.debounceUnsubscribeAggregator.close();
+		await Promise.allSettled([...pendingFanoutJoins, ...pendingBackground]);
 		return super.stop();
 	}
 
@@ -757,7 +768,7 @@ export class TopicControlPlane
 	}
 
 	private async reconcileShardOverlays() {
-		if (!this.started) return;
+		if (!this.started || this.stopping) return;
 
 		const byShard = new Map<string, string[]>();
 		for (const topic of this.subscriptions.keys()) {
@@ -1137,6 +1148,10 @@ export class TopicControlPlane
 			signal?: AbortSignal;
 		},
 	): Promise<void> {
+		if (!this.started || this.stopping) throw new NotStartedError();
+		const combinedSignal = options?.signal
+			? anySignal([options.signal, this.shutdownController.signal])
+			: this.shutdownController.signal;
 		const t = shardTopic.toString();
 		const pin = options?.pin === true;
 		const wantEphemeral = options?.ephemeral === true;
@@ -1157,12 +1172,12 @@ export class TopicControlPlane
 					this.scheduleFanoutIdleClose(t);
 				}
 				if (pin) this.pinnedShards.add(t);
-				await withAbort(existing.join, options?.signal);
+				await withAbort(existing.join, combinedSignal);
 				return;
 			}
 
 			// Root mapping changed (candidate set updated): migrate to the new overlay.
-			await withAbort(this.closeFanoutChannel(t, { force: true }), options?.signal);
+			await withAbort(this.closeFanoutChannel(t, { force: true }), combinedSignal);
 		}
 
 		root = root ?? (await this.resolveShardRoot(t));
@@ -1279,9 +1294,10 @@ export class TopicControlPlane
 					} catch {
 						// ignore
 					}
-				const joinOpts = options?.signal
-					? { ...(this.fanoutJoinOptions ?? {}), signal: options.signal }
-					: this.fanoutJoinOptions;
+				const joinOpts = {
+					...(this.fanoutJoinOptions ?? {}),
+					signal: combinedSignal,
+				};
 				await channel.join(this.fanoutNodeChannelOptions, joinOpts);
 			} catch (error) {
 				try {
@@ -1328,7 +1344,11 @@ export class TopicControlPlane
 		if (wantEphemeral) {
 			this.evictEphemeralFanoutChannels(t);
 		}
-		await withAbort(join, options?.signal);
+		try {
+			await withAbort(join, combinedSignal);
+		} finally {
+			(combinedSignal as AbortSignal & { clear?: () => void }).clear?.();
+		}
 	}
 
 	private async closeFanoutChannel(
@@ -1364,7 +1384,7 @@ export class TopicControlPlane
 	}
 
 	public async hostShardRootsNow() {
-		if (!this.started) throw new NotStartedError();
+		if (!this.started || this.stopping) throw new NotStartedError();
 		const joins: Promise<void>[] = [];
 		for (let i = 0; i < this.shardCount; i++) {
 			const shardTopic = `${this.shardTopicPrefix}${i}`;
@@ -1384,7 +1404,7 @@ export class TopicControlPlane
 	}
 
 	private async _subscribe(topics: { key: string; counter: number }[]) {
-		if (!this.started) throw new NotStartedError();
+		if (!this.started || this.stopping) throw new NotStartedError();
 		if (topics.length === 0) return;
 
 		const byShard = new Map<string, string[]>();
@@ -1481,7 +1501,7 @@ export class TopicControlPlane
 	}
 
 	private async _announceUnsubscribe(topics: { key: string; counter: number }[]) {
-		if (!this.started) throw new NotStartedError();
+		if (!this.started || this.stopping) throw new NotStartedError();
 
 		const byShard = new Map<string, string[]>();
 		for (const { key: topic } of topics) {

--- a/packages/transport/pubsub/src/index.ts
+++ b/packages/transport/pubsub/src/index.ts
@@ -48,7 +48,6 @@ import {
 	getMsgId,
 } from "@peerbit/stream-interface";
 import { AbortError, TimeoutError, delay } from "@peerbit/time";
-import { anySignal } from "any-signal";
 import { Uint8ArrayList } from "uint8arraylist";
 import { toUint8Array } from "./bytes.js";
 import {
@@ -271,7 +270,6 @@ export class TopicControlPlane
 	private readonly fanoutPublishRequiresSubscribe: boolean;
 	private readonly fanoutPublishIdleCloseMs: number;
 	private readonly fanoutPublishMaxEphemeralChannels: number;
-	private shutdownController = new AbortController();
 
 	// If no shard-root candidates are configured, we fall back to an "auto" mode:
 	// start with `[self]` and expand candidates as underlay peers connect.
@@ -436,9 +434,6 @@ export class TopicControlPlane
 	}
 
 	public override async start() {
-		if (this.shutdownController.signal.aborted) {
-			this.shutdownController = new AbortController();
-		}
 		await this.fanout.start();
 		this._onFanoutPeerUnreachable =
 			this._onFanoutPeerUnreachable ||
@@ -458,21 +453,13 @@ export class TopicControlPlane
 	}
 
 	public override async stop() {
-		this.stopping = true;
-		this.shutdownController.abort(new AbortError("PubSub stopping"));
-		const fanoutChannelStates = [...this.fanoutChannels.values()];
-		const pendingFanoutJoins = fanoutChannelStates.map((state) => state.join);
-		const pendingBackground = [
-			this.reconcileShardOverlaysInFlight,
-			this.hostOwnedShardRootsInFlight,
-		].filter((promise): promise is Promise<void> => Boolean(promise));
 		if (this._onFanoutPeerUnreachable) {
 			this.fanout.removeEventListener(
 				"fanout:peer-unreachable",
 				this._onFanoutPeerUnreachable as any,
 			);
 		}
-		for (const st of fanoutChannelStates) {
+		for (const st of this.fanoutChannels.values()) {
 			if (st.idleCloseTimeout) clearTimeout(st.idleCloseTimeout);
 			try {
 				st.channel.removeEventListener("data", st.onData as any);
@@ -522,7 +509,6 @@ export class TopicControlPlane
 
 		this.debounceSubscribeAggregator.close();
 		this.debounceUnsubscribeAggregator.close();
-		await Promise.allSettled([...pendingFanoutJoins, ...pendingBackground]);
 		return super.stop();
 	}
 
@@ -768,7 +754,7 @@ export class TopicControlPlane
 	}
 
 	private async reconcileShardOverlays() {
-		if (!this.started || this.stopping) return;
+		if (!this.started) return;
 
 		const byShard = new Map<string, string[]>();
 		for (const topic of this.subscriptions.keys()) {
@@ -1148,10 +1134,7 @@ export class TopicControlPlane
 			signal?: AbortSignal;
 		},
 	): Promise<void> {
-		if (!this.started || this.stopping) throw new NotStartedError();
-		const combinedSignal = options?.signal
-			? anySignal([options.signal, this.shutdownController.signal])
-			: this.shutdownController.signal;
+		if (!this.started) throw new NotStartedError();
 		const t = shardTopic.toString();
 		const pin = options?.pin === true;
 		const wantEphemeral = options?.ephemeral === true;
@@ -1172,12 +1155,12 @@ export class TopicControlPlane
 					this.scheduleFanoutIdleClose(t);
 				}
 				if (pin) this.pinnedShards.add(t);
-				await withAbort(existing.join, combinedSignal);
+				await withAbort(existing.join, options?.signal);
 				return;
 			}
 
 			// Root mapping changed (candidate set updated): migrate to the new overlay.
-			await withAbort(this.closeFanoutChannel(t, { force: true }), combinedSignal);
+			await withAbort(this.closeFanoutChannel(t, { force: true }), options?.signal);
 		}
 
 		root = root ?? (await this.resolveShardRoot(t));
@@ -1294,10 +1277,9 @@ export class TopicControlPlane
 					} catch {
 						// ignore
 					}
-				const joinOpts = {
-					...(this.fanoutJoinOptions ?? {}),
-					signal: combinedSignal,
-				};
+				const joinOpts = options?.signal
+					? { ...(this.fanoutJoinOptions ?? {}), signal: options.signal }
+					: this.fanoutJoinOptions;
 				await channel.join(this.fanoutNodeChannelOptions, joinOpts);
 			} catch (error) {
 				try {
@@ -1344,11 +1326,7 @@ export class TopicControlPlane
 		if (wantEphemeral) {
 			this.evictEphemeralFanoutChannels(t);
 		}
-		try {
-			await withAbort(join, combinedSignal);
-		} finally {
-			(combinedSignal as AbortSignal & { clear?: () => void }).clear?.();
-		}
+		await withAbort(join, options?.signal);
 	}
 
 	private async closeFanoutChannel(
@@ -1384,7 +1362,7 @@ export class TopicControlPlane
 	}
 
 	public async hostShardRootsNow() {
-		if (!this.started || this.stopping) throw new NotStartedError();
+		if (!this.started) throw new NotStartedError();
 		const joins: Promise<void>[] = [];
 		for (let i = 0; i < this.shardCount; i++) {
 			const shardTopic = `${this.shardTopicPrefix}${i}`;
@@ -1404,7 +1382,7 @@ export class TopicControlPlane
 	}
 
 	private async _subscribe(topics: { key: string; counter: number }[]) {
-		if (!this.started || this.stopping) throw new NotStartedError();
+		if (!this.started) throw new NotStartedError();
 		if (topics.length === 0) return;
 
 		const byShard = new Map<string, string[]>();
@@ -1501,7 +1479,7 @@ export class TopicControlPlane
 	}
 
 	private async _announceUnsubscribe(topics: { key: string; counter: number }[]) {
-		if (!this.started || this.stopping) throw new NotStartedError();
+		if (!this.started) throw new NotStartedError();
 
 		const byShard = new Map<string, string[]>();
 		for (const { key: topic } of topics) {

--- a/packages/transport/pubsub/test/fanout-topics.spec.ts
+++ b/packages/transport/pubsub/test/fanout-topics.spec.ts
@@ -12,6 +12,36 @@ import { expect } from "chai";
 import { FanoutTree, TopicControlPlane, TopicRootControlPlane } from "../src/index.js";
 
 describe("pubsub (fanout topics)", function () {
+	const createSessionServices = (
+		topicRootControlPlane: TopicRootControlPlane,
+		getOrCreateFanout: (c: any) => FanoutTree,
+		options?: {
+			pubsub?: Partial<ConstructorParameters<typeof TopicControlPlane>[1]>;
+		},
+	) => ({
+		services: {
+			fanout: (c: any) => getOrCreateFanout(c),
+			pubsub: (c: any) =>
+				new TopicControlPlane(c, {
+					canRelayMessage: true,
+					connectionManager: false,
+					topicRootControlPlane,
+					fanout: getOrCreateFanout(c),
+					shardCount: 16,
+					// Make join tests fast/deterministic.
+					fanoutJoin: {
+						timeoutMs: 10_000,
+						retryMs: 50,
+						bootstrapEnsureIntervalMs: 200,
+						trackerQueryIntervalMs: 200,
+						joinReqTimeoutMs: 1_000,
+						trackerQueryTimeoutMs: 1_000,
+					},
+					...(options?.pubsub || {}),
+				}),
+		},
+	});
+
 	const createSession = async (
 		peerCount: number,
 		options?: {
@@ -35,29 +65,10 @@ describe("pubsub (fanout topics)", function () {
 		};
 
 		const session: TestSession<{ pubsub: TopicControlPlane; fanout: FanoutTree }> =
-			await TestSession.connected(peerCount, {
-				services: {
-					fanout: (c) => getOrCreateFanout(c),
-						pubsub: (c) =>
-							new TopicControlPlane(c, {
-								canRelayMessage: true,
-								connectionManager: false,
-								topicRootControlPlane,
-								fanout: getOrCreateFanout(c),
-								shardCount: DEFAULT_SHARD_COUNT,
-								// Make join tests fast/deterministic.
-								fanoutJoin: {
-									timeoutMs: 10_000,
-									retryMs: 50,
-								bootstrapEnsureIntervalMs: 200,
-								trackerQueryIntervalMs: 200,
-								joinReqTimeoutMs: 1_000,
-								trackerQueryTimeoutMs: 1_000,
-							},
-							...(options?.pubsub || {}),
-						}),
-				},
-			});
+			await TestSession.connected(
+				peerCount,
+				createSessionServices(topicRootControlPlane, getOrCreateFanout, options),
+			);
 
 		const configureBootstraps = (trackerIndices: number[]) => {
 			const addrs: any[] = [];
@@ -68,8 +79,8 @@ describe("pubsub (fanout topics)", function () {
 				const self = new Set(peer.getMultiaddrs().map((a) => a.toString()));
 				const filtered = addrs.filter((a) => !self.has(a.toString()));
 				peer.services.fanout.setBootstraps(filtered);
-				}
-			};
+			}
+		};
 
 		const configureShards = async (routerIndices: number[]) => {
 			const candidates = routerIndices.map(
@@ -118,28 +129,7 @@ describe("pubsub (fanout topics)", function () {
 		return TestSession.disconnected<{
 			pubsub: TopicControlPlane;
 			fanout: FanoutTree;
-		}>(peerCount, {
-			services: {
-				fanout: (c) => getOrCreateFanout(c),
-				pubsub: (c) =>
-					new TopicControlPlane(c, {
-						canRelayMessage: true,
-						connectionManager: false,
-						topicRootControlPlane,
-						fanout: getOrCreateFanout(c),
-						shardCount: DEFAULT_SHARD_COUNT,
-						fanoutJoin: {
-							timeoutMs: 10_000,
-							retryMs: 50,
-							bootstrapEnsureIntervalMs: 200,
-							trackerQueryIntervalMs: 200,
-							joinReqTimeoutMs: 1_000,
-							trackerQueryTimeoutMs: 1_000,
-						},
-						...(options?.pubsub || {}),
-					}),
-			},
-		});
+		}>(peerCount, createSessionServices(topicRootControlPlane, getOrCreateFanout, options));
 	};
 
 	const topicHash32 = (topic: string) => {
@@ -566,6 +556,102 @@ describe("pubsub (fanout topics)", function () {
 			await delay(250);
 			expect(receivedByRoot).to.have.length(2);
 		} finally {
+			await session.stop();
+		}
+	});
+
+	it("can proactively reparent to the root when a late direct edge becomes available", async () => {
+		const session = await createDisconnectedSession(3, {
+			pubsub: {
+				fanoutJoin: {
+					parentUpgradeIntervalMs: 200,
+				},
+			},
+		});
+		const rootPeer = session.peers[0]!;
+		const relayPeer = session.peers[1]!;
+		const publisherPeer = session.peers[2]!;
+		const publisherFanout = publisherPeer.services.pubsub.fanout as any;
+		const originalPublisherDial = publisherPeer.dial.bind(publisherPeer);
+		const originalSendControl = publisherFanout._sendControl.bind(publisherFanout);
+
+		try {
+			const topic = "fanout-direct-reparent-to-root";
+			const root = rootPeer.services.pubsub;
+			const relay = relayPeer.services.pubsub;
+			const publisher = publisherPeer.services.pubsub;
+			const rootHash = root.publicKeyHash;
+			const relayHash = relay.publicKeyHash;
+			const shardTopic = (root as any).getShardTopicForUserTopic(topic);
+			const rootAddrs = new Set(rootPeer.getMultiaddrs().map((a) => a.toString()));
+			let allowDirectRootTraffic = false;
+			publisherPeer.dial = (async (addrs: any) => {
+				const list = Array.isArray(addrs) ? addrs : [addrs];
+				if (
+					!allowDirectRootTraffic &&
+					list.some((addr) => rootAddrs.has(addr.toString()))
+				) {
+					throw new Error("blocked direct root dial");
+				}
+				return originalPublisherDial(addrs as any);
+			}) as typeof publisherPeer.dial;
+			publisherFanout._sendControl = (async (to: string, bytes: Uint8Array) => {
+				if (!allowDirectRootTraffic && to === rootHash) {
+					return;
+				}
+				return originalSendControl(to, bytes);
+			}) as typeof publisherFanout._sendControl;
+
+			await session.connect([
+				[rootPeer, relayPeer],
+				[relayPeer, publisherPeer],
+			]);
+
+			const relayBootstraps = relayPeer.getMultiaddrs();
+			for (const peer of session.peers) {
+				const self = new Set(peer!.getMultiaddrs().map((a) => a.toString()));
+				peer!.services.fanout.setBootstraps(
+					relayBootstraps.filter((a) => !self.has(a.toString())),
+				);
+			}
+
+			for (const peer of session.peers) {
+				peer!.services.pubsub.setTopicRootCandidates([rootHash]);
+			}
+			await root.hostShardRootsNow();
+
+			await root.subscribe(topic);
+			await relay.subscribe(topic);
+			await waitForResolved(() => {
+				const relayStats = relay.fanout.getChannelStats(shardTopic, rootHash);
+				expect(relayStats?.parent).to.equal(rootHash);
+			});
+			await publisher.subscribe(topic);
+
+			await waitForResolved(() => {
+				const stats = publisher.fanout.getChannelStats(shardTopic, rootHash);
+				expect(stats?.parent).to.equal(relayHash);
+			});
+
+			allowDirectRootTraffic = true;
+			await session.connect([[rootPeer, publisherPeer]]);
+			await waitForResolved(() =>
+				expect(root.peers.has(publisher.publicKeyHash)).to.equal(true),
+			);
+			await waitForResolved(() =>
+				expect(publisher.peers.has(rootHash)).to.equal(true),
+			);
+
+			await waitForResolved(() => {
+				const statsAfterDirect = publisher.fanout.getChannelStats(
+					shardTopic,
+					rootHash,
+				);
+				expect(statsAfterDirect?.parent).to.equal(rootHash);
+			});
+		} finally {
+			publisherFanout._sendControl = originalSendControl;
+			publisherPeer.dial = originalPublisherDial;
 			await session.stop();
 		}
 	});

--- a/packages/transport/pubsub/test/fanout-topics.spec.ts
+++ b/packages/transport/pubsub/test/fanout-topics.spec.ts
@@ -18,29 +18,33 @@ describe("pubsub (fanout topics)", function () {
 		options?: {
 			pubsub?: Partial<ConstructorParameters<typeof TopicControlPlane>[1]>;
 		},
-	) => ({
-		services: {
-			fanout: (c: any) => getOrCreateFanout(c),
-			pubsub: (c: any) =>
-				new TopicControlPlane(c, {
-					canRelayMessage: true,
-					connectionManager: false,
-					topicRootControlPlane,
-					fanout: getOrCreateFanout(c),
-					shardCount: 16,
-					// Make join tests fast/deterministic.
-					fanoutJoin: {
-						timeoutMs: 10_000,
-						retryMs: 50,
-						bootstrapEnsureIntervalMs: 200,
-						trackerQueryIntervalMs: 200,
-						joinReqTimeoutMs: 1_000,
-						trackerQueryTimeoutMs: 1_000,
-					},
-					...(options?.pubsub || {}),
-				}),
-		},
-	});
+	) => {
+		const { fanoutJoin, ...pubsubOptions } = options?.pubsub ?? {};
+		return {
+			services: {
+				fanout: (c: any) => getOrCreateFanout(c),
+				pubsub: (c: any) =>
+					new TopicControlPlane(c, {
+						canRelayMessage: true,
+						connectionManager: false,
+						topicRootControlPlane,
+						fanout: getOrCreateFanout(c),
+						shardCount: 16,
+						// Make join tests fast/deterministic.
+						fanoutJoin: {
+							timeoutMs: 10_000,
+							retryMs: 50,
+							bootstrapEnsureIntervalMs: 200,
+							trackerQueryIntervalMs: 200,
+							joinReqTimeoutMs: 1_000,
+							trackerQueryTimeoutMs: 1_000,
+							...(fanoutJoin ?? {}),
+						},
+						...pubsubOptions,
+					}),
+			},
+		};
+	};
 
 	const createSession = async (
 		peerCount: number,
@@ -560,14 +564,23 @@ describe("pubsub (fanout topics)", function () {
 		}
 	});
 
-	it("can proactively reparent to the root when a late direct edge becomes available", async () => {
-		const session = await createDisconnectedSession(3, {
-			pubsub: {
-				fanoutJoin: {
-					parentUpgradeIntervalMs: 200,
-				},
-			},
-		});
+	const runLateDirectRootScenario = async (options: {
+		topic: string;
+		parentUpgradeIntervalMs?: number;
+		expectedParentAfterDirect: "relay" | "root";
+	}) => {
+		const session = await createDisconnectedSession(
+			3,
+			options.parentUpgradeIntervalMs === undefined
+				? undefined
+				: {
+						pubsub: {
+							fanoutJoin: {
+								parentUpgradeIntervalMs: options.parentUpgradeIntervalMs,
+							},
+						},
+					},
+		);
 		const rootPeer = session.peers[0]!;
 		const relayPeer = session.peers[1]!;
 		const publisherPeer = session.peers[2]!;
@@ -576,7 +589,7 @@ describe("pubsub (fanout topics)", function () {
 		const originalSendControl = publisherFanout._sendControl.bind(publisherFanout);
 
 		try {
-			const topic = "fanout-direct-reparent-to-root";
+			const topic = options.topic;
 			const root = rootPeer.services.pubsub;
 			const relay = relayPeer.services.pubsub;
 			const publisher = publisherPeer.services.pubsub;
@@ -632,6 +645,9 @@ describe("pubsub (fanout topics)", function () {
 				const stats = publisher.fanout.getChannelStats(shardTopic, rootHash);
 				expect(stats?.parent).to.equal(relayHash);
 			});
+			expect(
+				publisher.fanout.getChannelMetrics(shardTopic, rootHash).reparentUpgrade,
+			).to.equal(0);
 
 			allowDirectRootTraffic = true;
 			await session.connect([[rootPeer, publisherPeer]]);
@@ -642,17 +658,44 @@ describe("pubsub (fanout topics)", function () {
 				expect(publisher.peers.has(rootHash)).to.equal(true),
 			);
 
-			await waitForResolved(() => {
-				const statsAfterDirect = publisher.fanout.getChannelStats(
-					shardTopic,
-					rootHash,
-				);
-				expect(statsAfterDirect?.parent).to.equal(rootHash);
-			});
+			if (options.expectedParentAfterDirect === "root") {
+				await waitForResolved(() => {
+					const statsAfterDirect = publisher.fanout.getChannelStats(
+						shardTopic,
+						rootHash,
+					);
+					expect(statsAfterDirect?.parent).to.equal(rootHash);
+				});
+				expect(
+					publisher.fanout.getChannelMetrics(shardTopic, rootHash).reparentUpgrade,
+				).to.be.greaterThan(0);
+			} else {
+				await delay(700);
+				const statsAfterDirect = publisher.fanout.getChannelStats(shardTopic, rootHash);
+				expect(statsAfterDirect?.parent).to.equal(relayHash);
+				expect(
+					publisher.fanout.getChannelMetrics(shardTopic, rootHash).reparentUpgrade,
+				).to.equal(0);
+			}
 		} finally {
 			publisherFanout._sendControl = originalSendControl;
 			publisherPeer.dial = originalPublisherDial;
 			await session.stop();
 		}
+	};
+
+	it("keeps a relay parent after a late direct root edge when parent upgrades are disabled", async () => {
+		await runLateDirectRootScenario({
+			topic: "fanout-direct-no-reparent-to-root",
+			expectedParentAfterDirect: "relay",
+		});
+	});
+
+	it("can proactively reparent to the root when a late direct edge becomes available", async () => {
+		await runLateDirectRootScenario({
+			topic: "fanout-direct-reparent-to-root",
+			parentUpgradeIntervalMs: 200,
+			expectedParentAfterDirect: "root",
+		});
 	});
 });

--- a/packages/transport/pubsub/test/fanout-tree-sim.runner.ts
+++ b/packages/transport/pubsub/test/fanout-tree-sim.runner.ts
@@ -1,0 +1,22 @@
+import {
+	resolveFanoutTreeSimParams,
+	runFanoutTreeSim,
+} from "../benchmark/fanout-tree-sim-lib.js";
+
+const main = async () => {
+	const raw = process.argv[2];
+	if (!raw) {
+		throw new Error("Missing FanoutTreeSim params JSON");
+	}
+
+	const params = resolveFanoutTreeSimParams(JSON.parse(raw));
+	const result = await runFanoutTreeSim(params);
+	process.stdout.write(JSON.stringify(result));
+};
+
+try {
+	await main();
+} catch (error: any) {
+	console.error(error?.stack ?? error?.message ?? String(error));
+	process.exit(1);
+}

--- a/packages/transport/pubsub/test/fanout-tree-sim.spec.ts
+++ b/packages/transport/pubsub/test/fanout-tree-sim.spec.ts
@@ -1,8 +1,59 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { expect } from "chai";
 import {
 	formatFanoutTreeSimResult,
-	runFanoutTreeSim,
+	type FanoutTreeSimParams,
+	type FanoutTreeSimResult,
 } from "../benchmark/fanout-tree-sim-lib.js";
+
+const execFileAsync = promisify(execFile);
+
+const resolveSimRunnerPath = () => {
+	const currentDir = dirname(fileURLToPath(import.meta.url));
+	const candidates = [
+		resolve(currentDir, "fanout-tree-sim.runner.js"),
+		resolve(currentDir, "../dist/test/fanout-tree-sim.runner.js"),
+	];
+	for (const candidate of candidates) {
+		if (existsSync(candidate)) return candidate;
+	}
+	throw new Error(
+		`Unable to locate fanout-tree sim runner. Tried: ${candidates.join(", ")}`,
+	);
+};
+
+const runFanoutTreeSimIsolated = async (
+	params: Partial<FanoutTreeSimParams>,
+): Promise<FanoutTreeSimResult> => {
+	const runner = resolveSimRunnerPath();
+	const { stdout, stderr } = await execFileAsync(
+		process.execPath,
+		[runner, JSON.stringify(params)],
+		{
+			maxBuffer: 16 * 1024 * 1024,
+			env: process.env,
+		},
+	);
+
+	const trimmed = stdout.trim();
+	if (!trimmed) {
+		throw new Error(
+			`FanoutTreeSim runner produced no stdout${stderr ? `\n${stderr.trim()}` : ""}`,
+		);
+	}
+
+	try {
+		return JSON.parse(trimmed) as FanoutTreeSimResult;
+	} catch (error: any) {
+		throw new Error(
+			`Failed to parse FanoutTreeSim runner output as JSON: ${error?.message ?? String(error)}\n${trimmed}${stderr ? `\n${stderr.trim()}` : ""}`,
+		);
+	}
+};
 
 describe("fanout-tree-sim (ci)", () => {
 	const LOSSY_CHURN_TRACKER_BYTES_MAX = 150_000;
@@ -10,7 +61,7 @@ describe("fanout-tree-sim (ci)", () => {
 	it("joins and delivers on a small sim", async function () {
 		this.timeout(60_000);
 
-		const result = await runFanoutTreeSim({
+		const result = await runFanoutTreeSimIsolated({
 			nodes: 25,
 			bootstraps: 1,
 			subscribers: 20,
@@ -69,7 +120,7 @@ describe("fanout-tree-sim (ci)", () => {
 			this.timeout(90_000);
 			this.retries(1);
 
-			const result = await runFanoutTreeSim({
+			const result = await runFanoutTreeSimIsolated({
 				nodes: 40,
 				bootstraps: 1,
 				subscribers: 30,

--- a/packages/transport/pubsub/test/fanout-tree-sim.spec.ts
+++ b/packages/transport/pubsub/test/fanout-tree-sim.spec.ts
@@ -110,10 +110,11 @@ describe("fanout-tree-sim (ci)", () => {
 		expect(result.formationScore).to.be.lessThan(20);
 		expect(result.protocolFetchReqSent).to.equal(0);
 		expect(result.protocolIHaveSent).to.equal(0);
-		expect(result.protocolControlBytesSent).to.be.lessThan(50_000);
-		expect(result.trackerBpp).to.be.lessThan(3);
-		expect(result.repairBpp).to.be.lessThan(0.5);
-		expect(result.droppedForwardsTotal).to.equal(0);
+			expect(result.protocolControlBytesSent).to.be.lessThan(50_000);
+			expect(result.trackerBpp).to.be.lessThan(3);
+			expect(result.repairBpp).to.be.lessThan(0.5);
+			expect(result.reparentUpgradeTotal).to.equal(0);
+			expect(result.droppedForwardsTotal).to.equal(0);
 	});
 
 	it("stays structurally healthy under mild loss + churn", async function () {
@@ -198,9 +199,10 @@ describe("fanout-tree-sim (ci)", () => {
 		// In the lossy/churny smoke test, delivered payload fluctuates by design, so
 		// trackerBpp is noisier than the underlying tracker-byte volume. Gate the
 		// structural scenario on tracker control bytes directly instead.
-		expect(result.protocolControlBytesSentTracker).to.be.lessThan(
-			LOSSY_CHURN_TRACKER_BYTES_MAX,
-		);
-		expect(result.repairBpp).to.be.lessThan(5);
+			expect(result.protocolControlBytesSentTracker).to.be.lessThan(
+				LOSSY_CHURN_TRACKER_BYTES_MAX,
+			);
+			expect(result.repairBpp).to.be.lessThan(5);
+			expect(result.reparentUpgradeTotal).to.equal(0);
+		});
 	});
-});

--- a/packages/transport/pubsub/test/fanout-tree.spec.ts
+++ b/packages/transport/pubsub/test/fanout-tree.spec.ts
@@ -15,7 +15,299 @@ const createFanoutTestSession = (n: number) =>
 		},
 	});
 
+type ImproveCandidate = {
+	hash: string;
+	addrs: [];
+	level: number;
+	freeSlots: number;
+	bidPerByte: number;
+};
+
+type ImproveChannel = {
+	parent: string;
+	closed: boolean;
+	isRoot: boolean;
+	level: number;
+	id: { root: string; key: Uint8Array };
+	cachedTrackerCandidates: ImproveCandidate[];
+	children: Map<string, { bidPerByte: number }>;
+};
+
+type ImproveOptions = {
+	signal: AbortSignal;
+	candidateShuffleTopK: number;
+	candidateScoringMode: "ranked-shuffle" | "ranked-strict" | "weighted";
+	candidateScoringWeights: {
+		level: number;
+		freeSlots: number;
+		connected: number;
+		bidPerByte: number;
+		source: number;
+	};
+	joinAttemptsPerRound: number;
+	joinReqTimeoutMs: number;
+};
+
+type ImproveContext = {
+	publicKeyHash: string;
+	peers: Map<string, { peerId: string; isReadable: boolean; isWritable: boolean }>;
+	components: {
+		connectionManager: {
+			getConnections: (peerId: string) => unknown[];
+		};
+	};
+	random: () => number;
+	tryJoinOnce: (
+		ch: ImproveChannel,
+		parentHash: string,
+		reqId: number,
+		joinReqTimeoutMs: number,
+		signal: AbortSignal,
+		options?: { allowReplace?: boolean },
+	) => Promise<{ ok: boolean }>;
+	_sendControl: (to: string, payload: Uint8Array) => Promise<void>;
+};
+
+const maybeImproveParent = Reflect.get(FanoutTree.prototype, "maybeImproveParent") as (
+	this: ImproveContext,
+	ch: ImproveChannel,
+	options: ImproveOptions,
+) => Promise<boolean>;
+
+const createImproveChannel = (
+	overrides: Partial<ImproveChannel> = {},
+): ImproveChannel => ({
+	parent: "relay",
+	closed: false,
+	isRoot: false,
+	level: 4,
+	id: { root: "root", key: new Uint8Array([1, 2, 3]) },
+	cachedTrackerCandidates: [],
+	children: new Map(),
+	...overrides,
+});
+
+const runMaybeImproveParent = async (args: {
+	peerHashes: string[];
+	cachedTrackerCandidates?: ImproveCandidate[];
+	channelOverrides?: Partial<ImproveChannel>;
+	getConnections?: (peerId: string) => unknown[];
+	random?: () => number;
+	options?: Partial<ImproveOptions>;
+	tryJoinOnce?: ImproveContext["tryJoinOnce"];
+}) => {
+	const attempts: string[] = [];
+	const ch = createImproveChannel({
+		cachedTrackerCandidates: args.cachedTrackerCandidates ?? [],
+		...args.channelOverrides,
+	});
+	const ctx: ImproveContext = {
+		publicKeyHash: "self",
+		peers: new Map(
+			args.peerHashes.map((hash) => [
+				hash,
+				{
+					peerId: hash,
+					isReadable: true,
+					isWritable: false,
+				},
+			]),
+		),
+		components: {
+			connectionManager: {
+				getConnections:
+					args.getConnections ??
+					((peerId) => (args.peerHashes.includes(peerId) ? [{}] : [])),
+			},
+		},
+		random: args.random ?? (() => 0),
+		tryJoinOnce: async (
+			channel,
+			parentHash,
+			reqId,
+			joinReqTimeoutMs,
+			signal,
+			options,
+		) => {
+			attempts.push(parentHash);
+			return (
+				args.tryJoinOnce?.(
+					channel,
+					parentHash,
+					reqId,
+					joinReqTimeoutMs,
+					signal,
+					options,
+				) ?? { ok: false }
+			);
+		},
+		_sendControl: async () => {},
+	};
+
+	const result = await maybeImproveParent.call(ctx, ch, {
+		signal: new AbortController().signal,
+		candidateShuffleTopK: 0,
+		candidateScoringMode: "ranked-strict",
+		candidateScoringWeights: {
+			level: 1,
+			freeSlots: 1,
+			connected: 1,
+			bidPerByte: 1,
+			source: 1,
+		},
+		joinAttemptsPerRound: 8,
+		joinReqTimeoutMs: 1_000,
+		...args.options,
+	});
+
+	return { attempts, result, ch };
+};
+
 describe("fanout-tree", () => {
+	it("falls back to peer readability when connection lookup throws", async () => {
+		const { attempts, result, ch } = await runMaybeImproveParent({
+			peerHashes: ["root", "relay"],
+			getConnections: () => {
+				throw new Error("boom");
+			},
+			tryJoinOnce: async (channel, parentHash) => {
+				channel.parent = parentHash;
+				return { ok: true };
+			},
+		});
+
+		expect(result).to.equal(true);
+		expect(attempts).to.deep.equal(["root"]);
+		expect(ch.parent).to.equal("root");
+	});
+
+	it("orders ranked candidates by free slots, bid, source and hash", async () => {
+		const byFreeSlots = await runMaybeImproveParent({
+			peerHashes: ["relay", "slot-low", "slot-high"],
+			cachedTrackerCandidates: [
+				{ hash: "slot-low", addrs: [], level: 1, freeSlots: 1, bidPerByte: 0 },
+				{ hash: "slot-high", addrs: [], level: 1, freeSlots: 2, bidPerByte: 0 },
+			],
+			tryJoinOnce: async () => ({ ok: false }),
+		});
+		expect(byFreeSlots.attempts[0]).to.equal("slot-high");
+
+		const byBid = await runMaybeImproveParent({
+			peerHashes: ["relay", "bid-low", "bid-high"],
+			cachedTrackerCandidates: [
+				{ hash: "bid-low", addrs: [], level: 1, freeSlots: 2, bidPerByte: 1 },
+				{ hash: "bid-high", addrs: [], level: 1, freeSlots: 2, bidPerByte: 2 },
+			],
+			tryJoinOnce: async () => ({ ok: false }),
+		});
+		expect(byBid.attempts[0]).to.equal("bid-high");
+
+		const bySource = await runMaybeImproveParent({
+			peerHashes: ["root", "relay", "tracker-root"],
+			cachedTrackerCandidates: [
+				{
+					hash: "tracker-root",
+					addrs: [],
+					level: 0,
+					freeSlots: Number.MAX_SAFE_INTEGER,
+					bidPerByte: 0,
+				},
+			],
+			tryJoinOnce: async () => ({ ok: false }),
+		});
+		expect(bySource.attempts[0]).to.equal("root");
+
+		const byHash = await runMaybeImproveParent({
+			peerHashes: ["relay", "alpha", "beta"],
+			cachedTrackerCandidates: [
+				{ hash: "beta", addrs: [], level: 1, freeSlots: 1, bidPerByte: 0 },
+				{ hash: "alpha", addrs: [], level: 1, freeSlots: 1, bidPerByte: 0 },
+			],
+			tryJoinOnce: async () => ({ ok: false }),
+		});
+		expect(byHash.attempts[0]).to.equal("alpha");
+	});
+
+	it("shuffles top ranked candidates when parent upgrades use ranked-shuffle", async () => {
+		const { attempts, result } = await runMaybeImproveParent({
+			peerHashes: ["relay", "alpha", "beta"],
+			cachedTrackerCandidates: [
+				{ hash: "alpha", addrs: [], level: 1, freeSlots: 1, bidPerByte: 0 },
+				{ hash: "beta", addrs: [], level: 1, freeSlots: 1, bidPerByte: 0 },
+			],
+			random: () => 0,
+			options: {
+				candidateScoringMode: "ranked-shuffle",
+				candidateShuffleTopK: 2,
+			},
+			tryJoinOnce: async () => ({ ok: false }),
+		});
+
+		expect(result).to.equal(false);
+		expect(attempts.slice(0, 2)).to.deep.equal(["beta", "alpha"]);
+	});
+
+	it("supports weighted parent-upgrade candidate selection", async () => {
+		const { attempts, result } = await runMaybeImproveParent({
+			peerHashes: ["relay", "weighted-a", "weighted-b"],
+			cachedTrackerCandidates: [
+				{
+					hash: "weighted-a",
+					addrs: [],
+					level: 1,
+					freeSlots: 4,
+					bidPerByte: 1,
+				},
+				{
+					hash: "weighted-b",
+					addrs: [],
+					level: 2,
+					freeSlots: 1,
+					bidPerByte: 0,
+				},
+			],
+			random: () => 0.999,
+			options: {
+				candidateScoringMode: "weighted",
+				candidateShuffleTopK: 2,
+			},
+			tryJoinOnce: async () => ({ ok: false }),
+		});
+
+		expect(result).to.equal(false);
+		expect(attempts).to.have.length(2);
+		expect(new Set(attempts)).to.deep.equal(new Set(["weighted-a", "weighted-b"]));
+	});
+
+	it("falls back to the existing weighted order when all candidate weights collapse", async () => {
+		const { attempts, result } = await runMaybeImproveParent({
+			peerHashes: ["relay", "nan-a", "nan-b"],
+			cachedTrackerCandidates: [
+				{ hash: "nan-a", addrs: [], level: 1, freeSlots: Number.NaN, bidPerByte: 0 },
+				{ hash: "nan-b", addrs: [], level: 1, freeSlots: Number.NaN, bidPerByte: 0 },
+			],
+			options: {
+				candidateScoringMode: "weighted",
+				candidateShuffleTopK: 2,
+			},
+			tryJoinOnce: async () => ({ ok: false }),
+		});
+
+		expect(result).to.equal(false);
+		expect(attempts.slice(0, 2)).to.deep.equal(["nan-a", "nan-b"]);
+	});
+
+	it("returns false when a join succeeds without actually replacing the parent", async () => {
+		const { attempts, result, ch } = await runMaybeImproveParent({
+			peerHashes: ["root", "relay"],
+			tryJoinOnce: async () => ({ ok: true }),
+		});
+
+		expect(result).to.equal(false);
+		expect(attempts).to.deep.equal(["root"]);
+		expect(ch.parent).to.equal("relay");
+	});
+
 		it("bounds per-channel route token cache (LRU + TTL)", async () => {
 			const session: TestSession<{ fanout: FanoutTree }> =
 				await createFanoutTestSession(1);

--- a/packages/transport/pubsub/test/pubsub-topic-sim.runner.ts
+++ b/packages/transport/pubsub/test/pubsub-topic-sim.runner.ts
@@ -1,0 +1,24 @@
+import { ready as cryptoReady } from "@peerbit/crypto";
+import {
+	resolvePubsubTopicSimParams,
+	runPubsubTopicSim,
+} from "../benchmark/pubsub-topic-sim-lib.js";
+
+const main = async () => {
+	const raw = process.argv[2];
+	if (!raw) {
+		throw new Error("Missing PubsubTopicSim params JSON");
+	}
+
+	await cryptoReady;
+	const params = resolvePubsubTopicSimParams(JSON.parse(raw));
+	const result = await runPubsubTopicSim(params);
+	process.stdout.write(JSON.stringify(result));
+};
+
+try {
+	await main();
+} catch (error: any) {
+	console.error(error?.stack ?? error?.message ?? String(error));
+	process.exit(1);
+}

--- a/packages/transport/pubsub/test/pubsub-topic-sim.spec.ts
+++ b/packages/transport/pubsub/test/pubsub-topic-sim.spec.ts
@@ -1,14 +1,65 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { expect } from "chai";
 import {
 	formatPubsubTopicSimResult,
-	runPubsubTopicSim,
+	type PubsubTopicSimParams,
+	type PubsubTopicSimResult,
 } from "../benchmark/pubsub-topic-sim-lib.js";
+
+const execFileAsync = promisify(execFile);
+
+const resolveSimRunnerPath = () => {
+	const currentDir = dirname(fileURLToPath(import.meta.url));
+	const candidates = [
+		resolve(currentDir, "pubsub-topic-sim.runner.js"),
+		resolve(currentDir, "../dist/test/pubsub-topic-sim.runner.js"),
+	];
+	for (const candidate of candidates) {
+		if (existsSync(candidate)) return candidate;
+	}
+	throw new Error(
+		`Unable to locate pubsub-topic sim runner. Tried: ${candidates.join(", ")}`,
+	);
+};
+
+const runPubsubTopicSimIsolated = async (
+	params: Partial<PubsubTopicSimParams>,
+): Promise<PubsubTopicSimResult> => {
+	const runner = resolveSimRunnerPath();
+	const { stdout, stderr } = await execFileAsync(
+		process.execPath,
+		[runner, JSON.stringify(params)],
+		{
+			maxBuffer: 16 * 1024 * 1024,
+			env: process.env,
+		},
+	);
+
+	const trimmed = stdout.trim();
+	if (!trimmed) {
+		throw new Error(
+			`PubsubTopicSim runner produced no stdout${stderr ? `\n${stderr.trim()}` : ""}`,
+		);
+	}
+
+	try {
+		return JSON.parse(trimmed) as PubsubTopicSimResult;
+	} catch (error: any) {
+		throw new Error(
+			`Failed to parse PubsubTopicSim runner output as JSON: ${error?.message ?? String(error)}\n${trimmed}${stderr ? `\n${stderr.trim()}` : ""}`,
+		);
+	}
+};
 
 describe("pubsub-topic-sim (ci)", () => {
 	it("delivers on a small sim", async function () {
 		this.timeout(60_000);
 
-		const result = await runPubsubTopicSim({
+		const result = await runPubsubTopicSimIsolated({
 			nodes: 20,
 			degree: 4,
 			writerIndex: 0,
@@ -43,7 +94,7 @@ describe("pubsub-topic-sim (ci)", () => {
 	it("remains mostly connected under mild churn", async function () {
 		this.timeout(90_000);
 
-		const result = await runPubsubTopicSim({
+		const result = await runPubsubTopicSimIsolated({
 			nodes: 25,
 			degree: 6,
 			writerIndex: 0,


### PR DESCRIPTION
## Summary
- rebase the opt-in FanoutTree parent-upgrade work on current master
- keep parent upgrades disabled by default (`parentUpgradeIntervalMs: 0`)
- add explicit `reparentUpgrade` instrumentation and simulator output
- add deterministic disabled/enabled late-direct-root regression coverage
- add `fanout-tree-parent-upgrade-eval` for same-seed A/B runs across small and lossy/churn scenarios

## Evidence Notes
- The deterministic late-edge tests prove the current default can keep a worse relay parent, while opt-in upgrades can reparent to the root.
- The A/B harness reports strict evidence failures with `--strict 1`; default `--strict 0` is intentional so collection does not hide negative evidence.
- In a one-seed lossy/churn run, proactive upgrades improved topology but worsened delivery/control/repair costs, so this PR does not change runtime defaults.

## Verification
- `pnpm --filter @peerbit/pubsub... run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/pubsub -- -t node --grep "late direct root edge|proactively reparent"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/pubsub -- -t node --grep "falls back to peer readability|orders ranked candidates|shuffles top ranked candidates|supports weighted parent-upgrade|falls back to the existing weighted order|returns false when a join succeeds without actually replacing"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/pubsub -- -t node --grep "fanout-tree-sim"`
- `pnpm -C packages/transport/pubsub run bench -- fanout-tree-parent-upgrade-eval --scenario ci-small --seeds 1 --strict 0`
- `pnpm -C packages/transport/pubsub run bench -- fanout-tree-parent-upgrade-eval --scenario ci-loss --seeds 1 --strict 0`

## Known Follow-up
- Decide whether a later default policy should be more conservative, e.g. longer interval, leaf-only only, or additional churn/repair guards.
