### PR TITLE
feat: use native full replica leaders

### DIFF
--- a/packages/programs/data/shared-log/rust/benchmark/get-samples.ts
+++ b/packages/programs/data/shared-log/rust/benchmark/get-samples.ts
@@ -22,6 +22,15 @@ type RangeLike = {
 	width: number | bigint;
 	mode: number;
 };
+type RangeIndex = {
+	iterate: (
+		query?: unknown,
+		options?: unknown,
+	) => {
+		next: (count?: number) => Promise<Array<{ value: RangeLike }>>;
+		close: () => Promise<void>;
+	};
+};
 
 const loadSharedLog = async () => {
 	const integersPath = "../../../dist/src/integers.js";
@@ -35,7 +44,9 @@ const loadSharedLog = async () => {
 		denormalizer: integers.denormalizer,
 		ReplicationRangeIndexableU32: ranges.ReplicationRangeIndexableU32,
 		ReplicationRangeIndexableU64: ranges.ReplicationRangeIndexableU64,
+		ReplicationIntent: ranges.ReplicationIntent,
 		getSamples: ranges.getSamples,
+		isMatured: ranges.isMatured,
 	};
 };
 
@@ -83,6 +94,54 @@ const benchmark = async (iterations: number, fn: () => Promise<void> | void) => 
 		meanMs: elapsedMs / iterations,
 		opsPerSecond: iterations / (elapsedMs / 1000),
 	};
+};
+
+const getFullReplicaLeadersTs = async (
+	sharedLog: Awaited<ReturnType<typeof loadSharedLog>>,
+	index: RangeIndex,
+	replicas: number,
+	roleAge: number,
+	peerFilter?: Set<string>,
+	includeStrict = true,
+) => {
+	const now = Date.now();
+	const leaders = new Map<string, { intersecting: boolean }>();
+	const iterator = index.iterate(
+		{},
+		{ shape: { hash: true, timestamp: true, mode: true } },
+	);
+
+	try {
+		for (;;) {
+			const batch = await iterator.next(64);
+			if (batch.length === 0) {
+				break;
+			}
+			for (const result of batch) {
+				const range = result.value;
+				if (peerFilter && !peerFilter.has(range.hash)) {
+					continue;
+				}
+				if (!sharedLog.isMatured(range, now, roleAge)) {
+					continue;
+				}
+				if (
+					range.mode === sharedLog.ReplicationIntent.Strict &&
+					!includeStrict
+				) {
+					continue;
+				}
+				leaders.set(range.hash, { intersecting: true });
+				if (leaders.size > replicas) {
+					return undefined;
+				}
+			}
+		}
+	} finally {
+		await iterator.close();
+	}
+
+	return leaders.size > 0 ? leaders : undefined;
 };
 
 const runResolution = async (resolution: Resolution): Promise<BenchResult[]> => {
@@ -134,6 +193,17 @@ const runResolution = async (resolution: Resolution): Promise<BenchResult[]> => 
 			out.push(makeRange(id++, peerHashes[1], 0.4 / 10_000, random()));
 			out.push(makeRange(id++, peerHashes[2], 0.6 / 10_000, random()));
 			out.push(makeRange(id++, peerHashes[2], 0.6 / 10_000, random()));
+		}
+		return out;
+	};
+
+	const fullReplicaRanges = () => {
+		const out: RangeLike[] = [];
+		const random = createRandom(314159265);
+		let id = 1;
+		for (let i = 0; i < 20_000; i++) {
+			out.push(makeRange(id++, peerHashes[0], 0.2 / 20_000, random()));
+			out.push(makeRange(id++, peerHashes[1], 0.4 / 20_000, random()));
 		}
 		return out;
 	};
@@ -212,6 +282,54 @@ const runResolution = async (resolution: Resolution): Promise<BenchResult[]> => 
 
 			rows.push({
 				scenario: `${scenario.name} (${resolution}, ${ranges.length} ranges)`,
+				tsOpsPerSecond: format(ts.opsPerSecond),
+				tsMeanMs: format(ts.meanMs),
+				nativeOpsPerSecond: format(native.opsPerSecond),
+				nativeMeanMs: format(native.meanMs),
+				speedup: `${format(native.opsPerSecond / ts.opsPerSecond)}x`,
+			});
+		} finally {
+			await indices.stop();
+		}
+	}
+
+	{
+		const ranges = fullReplicaRanges();
+		const indices = await createIndex();
+		const index = await indices.init({ schema: RangeClass });
+		await indices.start();
+		const planner = await createRangePlanner(resolution);
+
+		for (const range of ranges) {
+			await index.put(range);
+			planner.put(toNativeRange(range));
+		}
+
+		try {
+			const ts = await benchmark(100, async () => {
+				const leaders = await getFullReplicaLeadersTs(
+					sharedLog,
+					index as unknown as RangeIndex,
+					3,
+					0,
+				);
+				if (!leaders || leaders.size === 0) {
+					throw new Error("Expected TypeScript full-replica leaders");
+				}
+			});
+
+			const native = await benchmark(1_000, () => {
+				const leaders = planner.getFullReplicaLeaders(3, {
+					now: Date.now(),
+					roleAge: 0,
+				});
+				if (!leaders || leaders.size === 0) {
+					throw new Error("Expected native full-replica leaders");
+				}
+			});
+
+			rows.push({
+				scenario: `full replica scan (${resolution}, ${ranges.length} ranges)`,
 				tsOpsPerSecond: format(ts.opsPerSecond),
 				tsMeanMs: format(ts.meanMs),
 				nativeOpsPerSecond: format(native.opsPerSecond),

--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -20,6 +20,13 @@ export type SampleOptions = {
 	peerFilter?: Iterable<string>;
 };
 
+export type FullReplicaLeaderOptions = {
+	roleAge?: number;
+	now?: bigint | number | string;
+	includeStrict?: boolean;
+	peerFilter?: Iterable<string>;
+};
+
 export type LeaderSample = {
 	intersecting: boolean;
 };
@@ -47,6 +54,13 @@ type NativeRangePlannerHandle = {
 		uniqueReplicators?: string[],
 		peerFilter?: string[],
 	) => unknown[];
+	get_full_replica_leaders: (
+		replicas: number,
+		roleAgeMs: number,
+		now: string,
+		includeStrict: boolean,
+		peerFilter?: string[],
+	) => unknown[] | undefined;
 };
 
 type WasmModule = {
@@ -99,6 +113,15 @@ const asIntegerString = (value: bigint | number | string) =>
 			? Math.trunc(value).toString()
 			: value;
 
+const rowsToSamples = (rows: unknown[]): Map<string, LeaderSample> => {
+	const out = new Map<string, LeaderSample>();
+	for (const row of rows) {
+		const [hash, intersecting] = row as [string, boolean];
+		out.set(hash, { intersecting });
+	}
+	return out;
+};
+
 export class SharedLogRangePlanner {
 	private constructor(private readonly native: NativeRangePlannerHandle) {}
 
@@ -147,12 +170,21 @@ export class SharedLogRangePlanner {
 			options?.uniqueReplicators ? [...options.uniqueReplicators] : undefined,
 			options?.peerFilter ? [...options.peerFilter] : undefined,
 		);
-		const out = new Map<string, LeaderSample>();
-		for (const row of rows) {
-			const [hash, intersecting] = row as [string, boolean];
-			out.set(hash, { intersecting });
-		}
-		return out;
+		return rowsToSamples(rows);
+	}
+
+	getFullReplicaLeaders(
+		replicas: number,
+		options?: FullReplicaLeaderOptions,
+	): Map<string, LeaderSample> | undefined {
+		const rows = this.native.get_full_replica_leaders(
+			replicas,
+			options?.roleAge ?? 0,
+			asIntegerString(options?.now ?? Date.now()),
+			options?.includeStrict !== false,
+			options?.peerFilter ? [...options.peerFilter] : undefined,
+		);
+		return rows ? rowsToSamples(rows) : undefined;
 	}
 }
 

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -97,6 +97,7 @@ pub struct RangePlanner {
     ranges: IndexMap<String, ReplicationRange>,
     by_start1: BTreeSet<RangeIndexKey>,
     by_end2: BTreeSet<RangeIndexKey>,
+    peer_ranges: IndexMap<String, PeerRangeStats>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -162,6 +163,78 @@ impl PartialOrd for RangeIndexKey {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PeerRangeKey {
+    timestamp: u64,
+    id: String,
+}
+
+impl PeerRangeKey {
+    fn from_range(range: &ReplicationRange) -> Self {
+        Self {
+            timestamp: range.timestamp,
+            id: range.id.clone(),
+        }
+    }
+
+    fn is_matured(&self, now: u64, role_age_ms: u64) -> bool {
+        now >= self.timestamp && now - self.timestamp >= role_age_ms
+    }
+}
+
+impl Ord for PeerRangeKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.timestamp
+            .cmp(&other.timestamp)
+            .then_with(|| self.id.cmp(&other.id))
+    }
+}
+
+impl PartialOrd for PeerRangeKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct PeerRangeStats {
+    all: BTreeSet<PeerRangeKey>,
+    non_strict: BTreeSet<PeerRangeKey>,
+}
+
+impl PeerRangeStats {
+    fn insert(&mut self, range: &ReplicationRange) {
+        let key = PeerRangeKey::from_range(range);
+        self.all.insert(key.clone());
+        if range.mode == MODE_NON_STRICT {
+            self.non_strict.insert(key);
+        }
+    }
+
+    fn remove(&mut self, range: &ReplicationRange) {
+        let key = PeerRangeKey::from_range(range);
+        self.all.remove(&key);
+        if range.mode == MODE_NON_STRICT {
+            self.non_strict.remove(&key);
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.all.is_empty()
+    }
+
+    fn has_matured_range(&self, now: u64, role_age_ms: u64, include_strict: bool) -> bool {
+        let ranges = if include_strict {
+            &self.all
+        } else {
+            &self.non_strict
+        };
+        ranges
+            .first()
+            .is_some_and(|range| range.is_matured(now, role_age_ms))
+    }
+}
+
 impl RangePlanner {
     pub fn new(resolution: &str) -> Self {
         Self {
@@ -169,6 +242,7 @@ impl RangePlanner {
             ranges: IndexMap::new(),
             by_start1: BTreeSet::new(),
             by_end2: BTreeSet::new(),
+            peer_ranges: IndexMap::new(),
         }
     }
 
@@ -184,6 +258,7 @@ impl RangePlanner {
         self.ranges.clear();
         self.by_start1.clear();
         self.by_end2.clear();
+        self.peer_ranges.clear();
     }
 
     pub fn put(&mut self, range: ReplicationRange) {
@@ -268,6 +343,45 @@ impl RangePlanner {
             .collect()
     }
 
+    pub fn get_full_replica_leaders(
+        &self,
+        replicas: usize,
+        options: &SampleOptions,
+        include_strict: bool,
+    ) -> Option<Vec<LeaderSample>> {
+        let mut leaders: IndexSet<String> = IndexSet::new();
+
+        for (hash, stats) in self.peer_ranges.iter() {
+            if let Some(peer_filter) = options.peer_filter.as_ref() {
+                if !peer_filter.contains(hash) {
+                    continue;
+                }
+            }
+            if !stats.has_matured_range(options.now, options.role_age_ms, include_strict) {
+                continue;
+            }
+
+            leaders.insert(hash.clone());
+            if leaders.len() > replicas {
+                return None;
+            }
+        }
+
+        if leaders.is_empty() {
+            return None;
+        }
+
+        Some(
+            leaders
+                .into_iter()
+                .map(|hash| LeaderSample {
+                    hash,
+                    intersecting: true,
+                })
+                .collect(),
+        )
+    }
+
     fn include_range(
         &self,
         range: &ReplicationRange,
@@ -291,12 +405,22 @@ impl RangePlanner {
             self.by_start1.insert(RangeIndexKey::start(range));
             self.by_end2.insert(RangeIndexKey::end(range));
         }
+        self.peer_ranges
+            .entry(range.hash.clone())
+            .or_default()
+            .insert(range);
     }
 
     fn unindex_range(&mut self, range: &ReplicationRange) {
         if Self::is_fallback_indexed(range) {
             self.by_start1.remove(&RangeIndexKey::start(range));
             self.by_end2.remove(&RangeIndexKey::end(range));
+        }
+        if let Some(stats) = self.peer_ranges.get_mut(&range.hash) {
+            stats.remove(range);
+            if stats.is_empty() {
+                self.peer_ranges.swap_remove(&range.hash);
+            }
         }
     }
 
@@ -519,6 +643,36 @@ impl NativeRangePlanner {
         };
         Ok(samples_to_rows(self.inner.get_samples(&cursors, &options)))
     }
+
+    pub fn get_full_replica_leaders(
+        &self,
+        replicas: usize,
+        role_age_ms: f64,
+        now: String,
+        include_strict: bool,
+        peer_filter: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        let options = SampleOptions {
+            role_age_ms: if role_age_ms <= 0.0 {
+                0
+            } else {
+                role_age_ms.floor() as u64
+            },
+            now: parse_u64(&now)?,
+            peer_filter: optional_string_set(peer_filter)?.map(HashSet::from_iter),
+            ..Default::default()
+        };
+
+        Ok(
+            match self
+                .inner
+                .get_full_replica_leaders(replicas, &options, include_strict)
+            {
+                Some(leaders) => samples_to_rows(leaders).into(),
+                None => JsValue::UNDEFINED,
+            },
+        )
+    }
 }
 
 impl Default for NativeRangePlanner {
@@ -697,5 +851,151 @@ mod tests {
         assert_eq!(samples.len(), 1);
         assert_eq!(samples[0].hash, "peer-b");
         assert!(samples[0].intersecting);
+    }
+
+    #[test]
+    fn returns_full_replica_leaders_when_under_replica_count() {
+        let mut planner = RangePlanner::new("u32");
+        planner.put(ReplicationRange::new(
+            "a", "peer-a", 0, 10, 20, 10, 20, 10, 0,
+        ));
+        planner.put(ReplicationRange::new(
+            "b", "peer-b", 0, 30, 40, 30, 40, 10, 0,
+        ));
+
+        let leaders = planner
+            .get_full_replica_leaders(
+                2,
+                &SampleOptions {
+                    now: 1_000,
+                    ..Default::default()
+                },
+                true,
+            )
+            .expect("leaders");
+
+        assert_eq!(leaders.len(), 2);
+        assert_eq!(leaders[0].hash, "peer-a");
+        assert_eq!(leaders[1].hash, "peer-b");
+        assert!(leaders.iter().all(|leader| leader.intersecting));
+    }
+
+    #[test]
+    fn rejects_full_replica_leaders_when_over_replica_count() {
+        let mut planner = RangePlanner::new("u32");
+        planner.put(ReplicationRange::new(
+            "a", "peer-a", 0, 10, 20, 10, 20, 10, 0,
+        ));
+        planner.put(ReplicationRange::new(
+            "b", "peer-b", 0, 30, 40, 30, 40, 10, 0,
+        ));
+
+        assert!(planner
+            .get_full_replica_leaders(
+                1,
+                &SampleOptions {
+                    now: 1_000,
+                    ..Default::default()
+                },
+                true,
+            )
+            .is_none());
+    }
+
+    #[test]
+    fn full_replica_leaders_honor_filters_maturity_and_strict_mode() {
+        let mut planner = RangePlanner::new("u32");
+        planner.put(ReplicationRange::new(
+            "a", "peer-a", 0, 10, 20, 10, 20, 10, 0,
+        ));
+        planner.put(ReplicationRange::new(
+            "b", "peer-b", 0, 30, 40, 30, 40, 10, 1,
+        ));
+        planner.put(ReplicationRange::new(
+            "c", "peer-c", 950, 50, 60, 50, 60, 10, 0,
+        ));
+
+        let leaders = planner
+            .get_full_replica_leaders(
+                3,
+                &SampleOptions {
+                    now: 1_000,
+                    role_age_ms: 100,
+                    peer_filter: Some(
+                        [
+                            "peer-a".to_string(),
+                            "peer-b".to_string(),
+                            "peer-c".to_string(),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    ),
+                    ..Default::default()
+                },
+                false,
+            )
+            .expect("leaders");
+
+        assert_eq!(leaders.len(), 1);
+        assert_eq!(leaders[0].hash, "peer-a");
+        assert!(leaders[0].intersecting);
+    }
+
+    #[test]
+    fn full_replica_leaders_track_delete_and_replace() {
+        let mut planner = RangePlanner::new("u32");
+        planner.put(ReplicationRange::new(
+            "a", "peer-a", 0, 10, 20, 10, 20, 10, 0,
+        ));
+        planner.put(ReplicationRange::new(
+            "b", "peer-b", 0, 30, 40, 30, 40, 10, 0,
+        ));
+
+        assert!(planner
+            .get_full_replica_leaders(
+                1,
+                &SampleOptions {
+                    now: 1_000,
+                    ..Default::default()
+                },
+                true,
+            )
+            .is_none());
+
+        assert!(planner.delete("b"));
+        let leaders = planner
+            .get_full_replica_leaders(
+                1,
+                &SampleOptions {
+                    now: 1_000,
+                    ..Default::default()
+                },
+                true,
+            )
+            .expect("leaders after delete");
+
+        assert_eq!(leaders.len(), 1);
+        assert_eq!(leaders[0].hash, "peer-a");
+
+        planner.put(ReplicationRange::new(
+            "b", "peer-b", 0, 30, 40, 30, 40, 10, 0,
+        ));
+        planner.put(ReplicationRange::new(
+            "b", "peer-b", 0, 30, 40, 30, 40, 10, 1,
+        ));
+
+        let leaders = planner
+            .get_full_replica_leaders(
+                1,
+                &SampleOptions {
+                    now: 1_000,
+                    ..Default::default()
+                },
+                false,
+            )
+            .expect("leaders after replace");
+
+        assert_eq!(leaders.len(), 1);
+        assert_eq!(leaders[0].hash, "peer-a");
     }
 }

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -49,6 +49,61 @@ describe("native shared-log range planner", () => {
 		);
 	});
 
+	it("returns full replica leaders when ranges fit within the replica count", async () => {
+		const planner = await createRangePlanner("u32");
+		planner.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));
+		planner.put(range({ id: "b", hash: "peer-b", start1: 90, end1: 100 }));
+
+		expect(planner.getFullReplicaLeaders(2, { now: 1_000 })).to.deep.equal(
+			new Map([
+				["peer-a", { intersecting: true }],
+				["peer-b", { intersecting: true }],
+			]),
+		);
+	});
+
+	it("skips full replica leaders when ranges exceed the replica count", async () => {
+		const planner = await createRangePlanner("u32");
+		planner.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));
+		planner.put(range({ id: "b", hash: "peer-b", start1: 90, end1: 100 }));
+
+		expect(planner.getFullReplicaLeaders(1, { now: 1_000 })).to.equal(
+			undefined,
+		);
+	});
+
+	it("honors full replica filters, maturity, and strict fallback options", async () => {
+		const planner = await createRangePlanner("u32");
+		planner.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));
+		planner.put(
+			range({
+				id: "b",
+				hash: "peer-b",
+				start1: 20,
+				end1: 30,
+				mode: 1,
+			}),
+		);
+		planner.put(
+			range({
+				id: "c",
+				hash: "peer-c",
+				start1: 40,
+				end1: 50,
+				timestamp: 950n,
+			}),
+		);
+
+		expect(
+			planner.getFullReplicaLeaders(3, {
+				now: 1_000,
+				roleAge: 100,
+				includeStrict: false,
+				peerFilter: ["peer-a", "peer-b", "peer-c"],
+			}),
+		).to.deep.equal(new Map([["peer-a", { intersecting: true }]]));
+	});
+
 	it("honors peer filters and maturity", async () => {
 		const planner = await createRangePlanner("u32");
 		planner.put(range({ id: "a", hash: "peer-a", start1: 10, end1: 20 }));

--- a/packages/programs/data/shared-log/rust/test/node.parity.ts
+++ b/packages/programs/data/shared-log/rust/test/node.parity.ts
@@ -269,6 +269,68 @@ describe("native shared-log range planner parity", () => {
 			});
 		});
 
+		it(`matches TypeScript fallback after filtered endpoint candidates for ${resolution}`, async () => {
+			const ranges = [
+				createRange(resolution, {
+					id: 1,
+					hash: "peer-a",
+					offset: 0.49,
+					width: 0.01,
+				}),
+				createRange(resolution, {
+					id: 2,
+					hash: "peer-b",
+					offset: 0.51,
+					width: 0.01,
+				}),
+				createRange(resolution, {
+					id: 3,
+					hash: "peer-c",
+					offset: 0.8,
+					width: 0.01,
+				}),
+			];
+
+			await expectNativeParity(resolution, {
+				ranges,
+				cursors: [denormalize(0.5)],
+				options: {
+					peerFilter: new Set(["peer-c"]),
+				},
+			});
+		});
+
+		it(`matches TypeScript fallback tie-breaking for ${resolution}`, async () => {
+			const ranges = [
+				createRange(resolution, {
+					id: 1,
+					hash: "peer-c",
+					offset: 0.49,
+					width: 0.01,
+					timestamp: 1n,
+				}),
+				createRange(resolution, {
+					id: 2,
+					hash: "peer-b",
+					offset: 0.49,
+					width: 0.01,
+					timestamp: 0n,
+				}),
+				createRange(resolution, {
+					id: 3,
+					hash: "peer-a",
+					offset: 0.49,
+					width: 0.01,
+					timestamp: 0n,
+				}),
+			];
+
+			await expectNativeParity(resolution, {
+				ranges,
+				cursors: numbers.getGrid(denormalize(0.5), 2),
+			});
+		});
+
 		it(`matches TypeScript only-intersecting behavior for ${resolution}`, async () => {
 			const ranges = [
 				createRange(resolution, {

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -6929,11 +6929,19 @@ export class SharedLog<
 		}
 
 		if (!options?.candidates) {
-			const fullReplicaLeaders = await this.findFullReplicaLeaders(
-				cursors.length,
-				roleAge,
-				peerFilter,
-			);
+			const fullReplicaLeaders = this._nativeRangePlanner
+				? this._nativeRangePlanner.getFullReplicaLeaders(cursors.length, {
+						roleAge,
+						now: Date.now(),
+						includeStrict:
+							this._logProperties?.strictFullReplicaFallback !== false,
+						peerFilter,
+					})
+				: await this.findFullReplicaLeaders(
+						cursors.length,
+						roleAge,
+						peerFilter,
+					);
 			if (fullReplicaLeaders) {
 				return fullReplicaLeaders;
 			}


### PR DESCRIPTION
## Summary
- add a native full-replica leader query to @peerbit/shared-log-rust
- maintain per-peer timestamp/mode stats so the full-replica check is O(peers) instead of O(ranges)
- route shared-log _findLeaders through the native full-replica path when the native planner is active
- add wrapper tests, Rust delete/replace coverage, parity edge cases, and a benchmark case for the full-replica scan

## Validation
- cargo test --manifest-path packages/programs/data/shared-log/rust/Cargo.toml
- pnpm --filter @peerbit/shared-log-rust run lint
- pnpm --filter @peerbit/shared-log-rust run test
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "uses indexed peers when the leader peer filter is temporarily underfilled"
- pnpm --filter @peerbit/shared-log-rust run benchmark:get-samples

## Benchmark signal
- full replica scan, u32, 40k ranges: TS/sqlite 4.9 ops/sec vs native 556,315.2 ops/sec
- full replica scan, u64, 40k ranges: TS/sqlite 5.1 ops/sec vs native 611,091.2 ops/sec
