### PR TITLE
feat: fill leader peer filters natively

### DIFF
--- a/packages/programs/data/shared-log/rust/benchmark/get-samples.ts
+++ b/packages/programs/data/shared-log/rust/benchmark/get-samples.ts
@@ -144,6 +144,49 @@ const getFullReplicaLeadersTs = async (
 	return leaders.size > 0 ? leaders : undefined;
 };
 
+const includeMaturedPeersTs = async (
+	sharedLog: Awaited<ReturnType<typeof loadSharedLog>>,
+	index: RangeIndex,
+	peerFilter: Set<string> | undefined,
+	replicas: number,
+	roleAge: number,
+	selfHash: string,
+	selfReplicating: boolean,
+) => {
+	if (!peerFilter || peerFilter.size > replicas) {
+		return peerFilter;
+	}
+
+	const now = Date.now();
+	const iterator = index.iterate(
+		{},
+		{ shape: { hash: true, timestamp: true }, reference: true },
+	);
+
+	try {
+		for (;;) {
+			const batch = await iterator.next(64);
+			if (batch.length === 0) {
+				break;
+			}
+			for (const result of batch) {
+				const range = result.value;
+				if (range.hash === selfHash && !selfReplicating) {
+					continue;
+				}
+				if (!sharedLog.isMatured(range, now, roleAge)) {
+					continue;
+				}
+				peerFilter.add(range.hash);
+			}
+		}
+	} finally {
+		await iterator.close();
+	}
+
+	return peerFilter;
+};
+
 const runResolution = async (resolution: Resolution): Promise<BenchResult[]> => {
 	const sharedLog = await loadSharedLog();
 	const numbers = sharedLog.createNumbers(resolution);
@@ -330,6 +373,59 @@ const runResolution = async (resolution: Resolution): Promise<BenchResult[]> => 
 
 			rows.push({
 				scenario: `full replica scan (${resolution}, ${ranges.length} ranges)`,
+				tsOpsPerSecond: format(ts.opsPerSecond),
+				tsMeanMs: format(ts.meanMs),
+				nativeOpsPerSecond: format(native.opsPerSecond),
+				nativeMeanMs: format(native.meanMs),
+				speedup: `${format(native.opsPerSecond / ts.opsPerSecond)}x`,
+			});
+		} finally {
+			await indices.stop();
+		}
+	}
+
+	{
+		const ranges = fullReplicaRanges();
+		const indices = await createIndex();
+		const index = await indices.init({ schema: RangeClass });
+		await indices.start();
+		const planner = await createRangePlanner(resolution);
+
+		for (const range of ranges) {
+			await index.put(range);
+			planner.put(toNativeRange(range));
+		}
+
+		try {
+			const ts = await benchmark(100, async () => {
+				const peers = await includeMaturedPeersTs(
+					sharedLog,
+					index as unknown as RangeIndex,
+					new Set([peerHashes[0]]),
+					1,
+					0,
+					"peer-self",
+					true,
+				);
+				if (!peers || peers.size <= 1) {
+					throw new Error("Expected TypeScript peer filter expansion");
+				}
+			});
+
+			const native = await benchmark(10_000, () => {
+				const peers = planner.includeMaturedPeers(new Set([peerHashes[0]]), 1, {
+					now: Date.now(),
+					roleAge: 0,
+					selfHash: "peer-self",
+					selfReplicating: true,
+				});
+				if (!peers || peers.size <= 1) {
+					throw new Error("Expected native peer filter expansion");
+				}
+			});
+
+			rows.push({
+				scenario: `peer filter fill (${resolution}, ${ranges.length} ranges)`,
 				tsOpsPerSecond: format(ts.opsPerSecond),
 				tsMeanMs: format(ts.meanMs),
 				nativeOpsPerSecond: format(native.opsPerSecond),

--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -27,6 +27,13 @@ export type FullReplicaLeaderOptions = {
 	peerFilter?: Iterable<string>;
 };
 
+export type MaturedPeerOptions = {
+	roleAge?: number;
+	now?: bigint | number | string;
+	selfHash: string;
+	selfReplicating: boolean;
+};
+
 export type LeaderSample = {
 	intersecting: boolean;
 };
@@ -60,6 +67,14 @@ type NativeRangePlannerHandle = {
 		now: string,
 		includeStrict: boolean,
 		peerFilter?: string[],
+	) => unknown[] | undefined;
+	include_matured_peers: (
+		peerFilter: string[] | undefined,
+		replicas: number,
+		roleAgeMs: number,
+		now: string,
+		selfHash: string,
+		includeSelf: boolean,
 	) => unknown[] | undefined;
 };
 
@@ -185,6 +200,22 @@ export class SharedLogRangePlanner {
 			options?.peerFilter ? [...options.peerFilter] : undefined,
 		);
 		return rows ? rowsToSamples(rows) : undefined;
+	}
+
+	includeMaturedPeers(
+		peerFilter: Iterable<string> | undefined,
+		replicas: number,
+		options: MaturedPeerOptions,
+	): Set<string> | undefined {
+		const peers = this.native.include_matured_peers(
+			peerFilter ? [...peerFilter] : undefined,
+			replicas,
+			options.roleAge ?? 0,
+			asIntegerString(options.now ?? Date.now()),
+			options.selfHash,
+			options.selfReplicating,
+		);
+		return peers ? new Set(peers as string[]) : undefined;
 	}
 }
 

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -382,6 +382,31 @@ impl RangePlanner {
         )
     }
 
+    pub fn include_matured_peers(
+        &self,
+        peer_filter: Option<IndexSet<String>>,
+        replicas: usize,
+        options: &SampleOptions,
+        self_hash: &str,
+        include_self: bool,
+    ) -> Option<Vec<String>> {
+        let mut peers = peer_filter?;
+        if peers.len() > replicas {
+            return Some(peers.into_iter().collect());
+        }
+
+        for (hash, stats) in self.peer_ranges.iter() {
+            if !include_self && hash == self_hash {
+                continue;
+            }
+            if stats.has_matured_range(options.now, options.role_age_ms, true) {
+                peers.insert(hash.clone());
+            }
+        }
+
+        Some(peers.into_iter().collect())
+    }
+
     fn include_range(
         &self,
         range: &ReplicationRange,
@@ -673,6 +698,37 @@ impl NativeRangePlanner {
             },
         )
     }
+
+    pub fn include_matured_peers(
+        &self,
+        peer_filter: JsValue,
+        replicas: usize,
+        role_age_ms: f64,
+        now: String,
+        self_hash: String,
+        include_self: bool,
+    ) -> Result<JsValue, JsValue> {
+        let options = SampleOptions {
+            role_age_ms: if role_age_ms <= 0.0 {
+                0
+            } else {
+                role_age_ms.floor() as u64
+            },
+            now: parse_u64(&now)?,
+            ..Default::default()
+        };
+        let Some(peers) = self.inner.include_matured_peers(
+            optional_string_set(peer_filter)?.map(IndexSet::from_iter),
+            replicas,
+            &options,
+            &self_hash,
+            include_self,
+        ) else {
+            return Ok(JsValue::UNDEFINED);
+        };
+
+        Ok(strings_to_array(peers).into())
+    }
 }
 
 impl Default for NativeRangePlanner {
@@ -708,6 +764,14 @@ fn optional_string_set(value: JsValue) -> Result<Option<Vec<String>>, JsValue> {
     Ok(Some(strings_from_array(Array::from(&value))?))
 }
 
+fn strings_to_array(values: Vec<String>) -> Array {
+    let out = Array::new();
+    for value in values {
+        out.push(&JsValue::from_str(&value));
+    }
+    out
+}
+
 fn samples_to_rows(samples: Vec<LeaderSample>) -> Array {
     let out = Array::new();
     for sample in samples {
@@ -722,6 +786,7 @@ fn samples_to_rows(samples: Vec<LeaderSample>) -> Array {
 #[cfg(test)]
 mod tests {
     use super::{RangePlanner, ReplicationRange, SampleOptions};
+    use indexmap::IndexSet;
 
     #[test]
     fn returns_intersecting_leader() {
@@ -997,5 +1062,61 @@ mod tests {
 
         assert_eq!(leaders.len(), 1);
         assert_eq!(leaders[0].hash, "peer-a");
+    }
+
+    #[test]
+    fn include_matured_peers_expands_underfilled_filters() {
+        let mut planner = RangePlanner::new("u32");
+        planner.put(ReplicationRange::new(
+            "a", "peer-a", 0, 10, 20, 10, 20, 10, 0,
+        ));
+        planner.put(ReplicationRange::new(
+            "b", "peer-b", 0, 30, 40, 30, 40, 10, 1,
+        ));
+        planner.put(ReplicationRange::new(
+            "c", "peer-c", 950, 50, 60, 50, 60, 10, 0,
+        ));
+
+        let peers = planner
+            .include_matured_peers(
+                Some(IndexSet::from_iter(["peer-a".to_string()])),
+                1,
+                &SampleOptions {
+                    now: 1_000,
+                    role_age_ms: 100,
+                    ..Default::default()
+                },
+                "peer-self",
+                true,
+            )
+            .expect("peers");
+
+        assert_eq!(peers, vec!["peer-a".to_string(), "peer-b".to_string()]);
+    }
+
+    #[test]
+    fn include_matured_peers_skips_self_when_not_replicating() {
+        let mut planner = RangePlanner::new("u32");
+        planner.put(ReplicationRange::new(
+            "a", "peer-a", 0, 10, 20, 10, 20, 10, 0,
+        ));
+        planner.put(ReplicationRange::new(
+            "b", "peer-b", 0, 30, 40, 30, 40, 10, 0,
+        ));
+
+        let peers = planner
+            .include_matured_peers(
+                Some(IndexSet::from_iter(["peer-a".to_string()])),
+                1,
+                &SampleOptions {
+                    now: 1_000,
+                    ..Default::default()
+                },
+                "peer-b",
+                false,
+            )
+            .expect("peers");
+
+        assert_eq!(peers, vec!["peer-a".to_string()]);
     }
 }

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -104,6 +104,52 @@ describe("native shared-log range planner", () => {
 		).to.deep.equal(new Map([["peer-a", { intersecting: true }]]));
 	});
 
+	it("expands underfilled peer filters with mature indexed peers", async () => {
+		const planner = await createRangePlanner("u32");
+		planner.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));
+		planner.put(
+			range({
+				id: "b",
+				hash: "peer-b",
+				start1: 20,
+				end1: 30,
+				mode: 1,
+			}),
+		);
+		planner.put(
+			range({
+				id: "c",
+				hash: "peer-c",
+				start1: 40,
+				end1: 50,
+				timestamp: 950n,
+			}),
+		);
+
+		expect(
+			planner.includeMaturedPeers(["peer-a"], 1, {
+				now: 1_000,
+				roleAge: 100,
+				selfHash: "peer-self",
+				selfReplicating: true,
+			}),
+		).to.deep.equal(new Set(["peer-a", "peer-b"]));
+	});
+
+	it("does not add self to peer filters when self is not replicating", async () => {
+		const planner = await createRangePlanner("u32");
+		planner.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));
+		planner.put(range({ id: "b", hash: "peer-b", start1: 20, end1: 30 }));
+
+		expect(
+			planner.includeMaturedPeers(["peer-a"], 1, {
+				now: 1_000,
+				selfHash: "peer-b",
+				selfReplicating: false,
+			}),
+		).to.deep.equal(new Set(["peer-a"]));
+	});
+
 	it("honors peer filters and maturity", async () => {
 		const planner = await createRangePlanner("u32");
 		planner.put(range({ id: "a", hash: "peer-a", start1: 10, end1: 20 }));

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -6920,12 +6920,23 @@ export class SharedLog<
 		if (!options?.candidates) {
 			// Reachability snapshots can briefly under-report peers. Do not let that
 			// turn a known mature indexed range into a false self-only full replica.
-			peerFilter = await this.includeIndexedLeaderCandidatesWhenUnderfilled(
-				peerFilter,
-				roleAge,
-				cursors.length,
-				selfReplicating,
-			);
+			peerFilter =
+				this._nativeRangePlanner?.includeMaturedPeers(
+					peerFilter,
+					cursors.length,
+					{
+						roleAge,
+						now: Date.now(),
+						selfHash,
+						selfReplicating,
+					},
+				) ??
+				(await this.includeIndexedLeaderCandidatesWhenUnderfilled(
+					peerFilter,
+					roleAge,
+					cursors.length,
+					selfReplicating,
+				));
 		}
 
 		if (!options?.candidates) {


### PR DESCRIPTION
## Summary
- add a native mature-peer expansion query to @peerbit/shared-log-rust
- use native per-peer stats to avoid the shared-log replicationIndex scan in includeIndexedLeaderCandidatesWhenUnderfilled when the native planner is active
- keep the TypeScript scan as the fallback for non-native planner mode
- add Rust and wasm wrapper coverage, plus a benchmark row for peer-filter fill

## Validation
- cargo test --manifest-path packages/programs/data/shared-log/rust/Cargo.toml
- pnpm --filter @peerbit/shared-log-rust run build
- pnpm --filter @peerbit/shared-log-rust run lint
- pnpm --filter @peerbit/shared-log-rust run test
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "uses indexed peers when the leader peer filter is temporarily underfilled"
- pnpm --filter @peerbit/shared-log-rust run benchmark:get-samples

## Benchmark signal
- peer filter fill, u32, 40k ranges: TS/sqlite 5.5 ops/sec vs native 644,383.5 ops/sec
- peer filter fill, u64, 40k ranges: TS/sqlite 5.4 ops/sec vs native 779,648.6 ops/sec
