### PR TITLE
feat: combine native leader planning

### DIFF
--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -34,6 +34,17 @@ export type MaturedPeerOptions = {
 	selfReplicating: boolean;
 };
 
+export type FindLeaderOptions = {
+	roleAge?: number;
+	now?: bigint | number | string;
+	peerFilter?: Iterable<string>;
+	expandPeerFilter?: boolean;
+	selfHash?: string;
+	selfReplicating?: boolean;
+	fullReplicaFallback?: boolean;
+	includeStrictFullReplica?: boolean;
+};
+
 export type LeaderSample = {
 	intersecting: boolean;
 };
@@ -60,6 +71,18 @@ type NativeRangePlannerHandle = {
 		onlyIntersecting: boolean,
 		uniqueReplicators?: string[],
 		peerFilter?: string[],
+	) => unknown[];
+	find_leaders: (
+		cursors: string[],
+		replicas: number,
+		roleAgeMs: number,
+		now: string,
+		peerFilter: string[] | undefined,
+		expandPeerFilter: boolean,
+		selfHash: string,
+		includeSelf: boolean,
+		fullReplicaFallback: boolean,
+		includeStrictFullReplica: boolean,
 	) => unknown[];
 	get_full_replica_leaders: (
 		replicas: number,
@@ -184,6 +207,26 @@ export class SharedLogRangePlanner {
 			options?.onlyIntersecting === true,
 			options?.uniqueReplicators ? [...options.uniqueReplicators] : undefined,
 			options?.peerFilter ? [...options.peerFilter] : undefined,
+		);
+		return rowsToSamples(rows);
+	}
+
+	findLeaders(
+		cursors: Iterable<bigint | number | string>,
+		replicas: number,
+		options?: FindLeaderOptions,
+	): Map<string, LeaderSample> {
+		const rows = this.native.find_leaders(
+			[...cursors].map(asIntegerString),
+			replicas,
+			options?.roleAge ?? 0,
+			asIntegerString(options?.now ?? Date.now()),
+			options?.peerFilter ? [...options.peerFilter] : undefined,
+			options?.expandPeerFilter === true,
+			options?.selfHash ?? "",
+			options?.selfReplicating === true,
+			options?.fullReplicaFallback === true,
+			options?.includeStrictFullReplica !== false,
 		);
 		return rowsToSamples(rows);
 	}

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -361,6 +361,51 @@ impl RangePlanner {
             .collect()
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn find_leaders(
+        &self,
+        cursors: &[u64],
+        replicas: usize,
+        options: &SampleOptions,
+        expand_peer_filter: bool,
+        self_hash: &str,
+        include_self: bool,
+        full_replica_fallback: bool,
+        include_strict_full_replica: bool,
+    ) -> Vec<LeaderSample> {
+        let mut options = options.clone();
+
+        if expand_peer_filter {
+            options.peer_filter = self
+                .include_matured_peers(
+                    options
+                        .peer_filter
+                        .as_ref()
+                        .map(|peers| IndexSet::from_iter(peers.iter().cloned())),
+                    replicas,
+                    &options,
+                    self_hash,
+                    include_self,
+                )
+                .map(HashSet::from_iter);
+        }
+
+        if full_replica_fallback {
+            if let Some(leaders) =
+                self.get_full_replica_leaders(replicas, &options, include_strict_full_replica)
+            {
+                return leaders;
+            }
+        }
+
+        options.unique_replicators = options
+            .peer_filter
+            .as_ref()
+            .map(|peers| IndexSet::from_iter(peers.iter().cloned()));
+
+        self.get_samples(cursors, &options)
+    }
+
     pub fn get_full_replica_leaders(
         &self,
         replicas: usize,
@@ -727,6 +772,47 @@ impl NativeRangePlanner {
             peer_filter: optional_string_set(peer_filter)?.map(HashSet::from_iter),
         };
         Ok(samples_to_rows(self.inner.get_samples(&cursors, &options)))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn find_leaders(
+        &self,
+        cursors: Array,
+        replicas: usize,
+        role_age_ms: f64,
+        now: String,
+        peer_filter: JsValue,
+        expand_peer_filter: bool,
+        self_hash: String,
+        include_self: bool,
+        full_replica_fallback: bool,
+        include_strict_full_replica: bool,
+    ) -> Result<Array, JsValue> {
+        let cursors = strings_from_array(cursors)?
+            .into_iter()
+            .map(|value| parse_u64(&value))
+            .collect::<Result<Vec<_>, _>>()?;
+        let options = SampleOptions {
+            role_age_ms: if role_age_ms <= 0.0 {
+                0
+            } else {
+                role_age_ms.floor() as u64
+            },
+            now: parse_u64(&now)?,
+            peer_filter: optional_string_set(peer_filter)?.map(HashSet::from_iter),
+            ..Default::default()
+        };
+
+        Ok(samples_to_rows(self.inner.find_leaders(
+            &cursors,
+            replicas,
+            &options,
+            expand_peer_filter,
+            &self_hash,
+            include_self,
+            full_replica_fallback,
+            include_strict_full_replica,
+        )))
     }
 
     pub fn get_full_replica_leaders(
@@ -1178,5 +1264,66 @@ mod tests {
             .expect("peers");
 
         assert_eq!(peers, vec!["peer-a".to_string()]);
+    }
+
+    #[test]
+    fn find_leaders_combines_filter_fill_full_replica_and_sampling() {
+        let mut planner = RangePlanner::new("u32");
+        planner.put(ReplicationRange::new(
+            "a", "peer-a", 0, 10, 20, 10, 20, 10, 0,
+        ));
+        planner.put(ReplicationRange::new(
+            "b", "peer-b", 0, 30, 40, 30, 40, 10, 0,
+        ));
+
+        let leaders = planner.find_leaders(
+            &[50, 75],
+            2,
+            &SampleOptions {
+                now: 1_000,
+                peer_filter: Some(["peer-a".to_string()].into_iter().collect()),
+                ..Default::default()
+            },
+            true,
+            "peer-self",
+            true,
+            true,
+            true,
+        );
+
+        assert_eq!(leaders.len(), 2);
+        assert_eq!(leaders[0].hash, "peer-a");
+        assert_eq!(leaders[1].hash, "peer-b");
+        assert!(leaders.iter().all(|leader| leader.intersecting));
+    }
+
+    #[test]
+    fn find_leaders_respects_candidate_mode_without_fill_or_full_replica() {
+        let mut planner = RangePlanner::new("u32");
+        planner.put(ReplicationRange::new(
+            "a", "peer-a", 0, 10, 20, 10, 20, 10, 0,
+        ));
+        planner.put(ReplicationRange::new(
+            "b", "peer-b", 0, 30, 40, 30, 40, 10, 0,
+        ));
+
+        let leaders = planner.find_leaders(
+            &[50],
+            1,
+            &SampleOptions {
+                now: 1_000,
+                peer_filter: Some(["peer-a".to_string()].into_iter().collect()),
+                ..Default::default()
+            },
+            false,
+            "peer-self",
+            true,
+            false,
+            true,
+        );
+
+        assert_eq!(leaders.len(), 1);
+        assert_eq!(leaders[0].hash, "peer-a");
+        assert!(!leaders[0].intersecting);
     }
 }

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -150,6 +150,60 @@ describe("native shared-log range planner", () => {
 		).to.deep.equal(new Set(["peer-a"]));
 	});
 
+	it("finds leaders through the combined native path", async () => {
+		const planner = await createRangePlanner("u32");
+		planner.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));
+		planner.put(range({ id: "b", hash: "peer-b", start1: 20, end1: 30 }));
+
+		expect(
+			planner.findLeaders([5], 1, {
+				now: 1_000,
+				peerFilter: ["peer-a"],
+				fullReplicaFallback: false,
+			}),
+		).to.deep.equal(new Map([["peer-a", { intersecting: true }]]));
+	});
+
+	it("uses full replica fallback through the combined native path", async () => {
+		const planner = await createRangePlanner("u32");
+		planner.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));
+		planner.put(range({ id: "b", hash: "peer-b", start1: 20, end1: 30 }));
+
+		expect(
+			planner.findLeaders([50, 75], 2, {
+				now: 1_000,
+				fullReplicaFallback: true,
+			}),
+		).to.deep.equal(
+			new Map([
+				["peer-a", { intersecting: true }],
+				["peer-b", { intersecting: true }],
+			]),
+		);
+	});
+
+	it("expands peer filters through the combined native path", async () => {
+		const planner = await createRangePlanner("u32");
+		planner.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));
+		planner.put(range({ id: "b", hash: "peer-b", start1: 20, end1: 30 }));
+
+		expect(
+			planner.findLeaders([50, 75], 2, {
+				now: 1_000,
+				peerFilter: ["peer-a"],
+				expandPeerFilter: true,
+				selfHash: "peer-self",
+				selfReplicating: true,
+				fullReplicaFallback: true,
+			}),
+		).to.deep.equal(
+			new Map([
+				["peer-a", { intersecting: true }],
+				["peer-b", { intersecting: true }],
+			]),
+		);
+	});
+
 	it("honors peer filters and maturity", async () => {
 		const planner = await createRangePlanner("u32");
 		planner.put(range({ id: "a", hash: "peer-a", start1: 10, end1: 20 }));

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -6917,54 +6917,40 @@ export class SharedLog<
 			}
 		}
 
-		if (!options?.candidates) {
-			// Reachability snapshots can briefly under-report peers. Do not let that
-			// turn a known mature indexed range into a false self-only full replica.
-			peerFilter =
-				this._nativeRangePlanner?.includeMaturedPeers(
-					peerFilter,
-					cursors.length,
-					{
-						roleAge,
-						now: Date.now(),
-						selfHash,
-						selfReplicating,
-					},
-				) ??
-				(await this.includeIndexedLeaderCandidatesWhenUnderfilled(
-					peerFilter,
-					roleAge,
-					cursors.length,
-					selfReplicating,
-				));
-		}
-
-		if (!options?.candidates) {
-			const fullReplicaLeaders = this._nativeRangePlanner
-				? this._nativeRangePlanner.getFullReplicaLeaders(cursors.length, {
-						roleAge,
-						now: Date.now(),
-						includeStrict:
-							this._logProperties?.strictFullReplicaFallback !== false,
-						peerFilter,
-					})
-				: await this.findFullReplicaLeaders(
-						cursors.length,
-						roleAge,
-						peerFilter,
-					);
-			if (fullReplicaLeaders) {
-				return fullReplicaLeaders;
-			}
-		}
-
 		if (this._nativeRangePlanner) {
-			return this._nativeRangePlanner.getSamples(cursors, {
+			return this._nativeRangePlanner.findLeaders(cursors, cursors.length, {
 				roleAge,
 				now: Date.now(),
 				peerFilter,
-				uniqueReplicators: peerFilter,
+				expandPeerFilter: !options?.candidates,
+				selfHash,
+				selfReplicating,
+				fullReplicaFallback: !options?.candidates,
+				includeStrictFullReplica:
+					this._logProperties?.strictFullReplicaFallback !== false,
 			});
+		}
+
+		if (!options?.candidates) {
+			// Reachability snapshots can briefly under-report peers. Do not let that
+			// turn a known mature indexed range into a false self-only full replica.
+			peerFilter = await this.includeIndexedLeaderCandidatesWhenUnderfilled(
+				peerFilter,
+				roleAge,
+				cursors.length,
+				selfReplicating,
+			);
+		}
+
+		if (!options?.candidates) {
+			const fullReplicaLeaders = await this.findFullReplicaLeaders(
+				cursors.length,
+				roleAge,
+				peerFilter,
+			);
+			if (fullReplicaLeaders) {
+				return fullReplicaLeaders;
+			}
 		}
 
 		return getSamples<R>(


### PR DESCRIPTION
## Summary
- add a single native findLeaders path in @peerbit/shared-log-rust
- combine peer-filter expansion, full-replica fallback, and getSamples into one Rust call
- route shared-log _findLeaders through that combined native path when the native planner is active
- keep the old TypeScript path as the non-native fallback

## Validation
- cargo test --manifest-path packages/programs/data/shared-log/rust/Cargo.toml
- pnpm --filter @peerbit/shared-log-rust run build
- pnpm --filter @peerbit/shared-log-rust run lint
- pnpm --filter @peerbit/shared-log-rust run test
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "uses indexed peers when the leader peer filter is temporarily underfilled"
- pnpm --filter @peerbit/shared-log-rust run benchmark:get-samples

## Benchmark signal
- Native split wrapper calls: 349,555.1 ops/sec in a local 40k-range full-replica microbench
- Combined native findLeaders: 446,887 ops/sec in the same microbench
- Existing 40k-range getSamples benchmark remains in the ~50k-63k ops/sec native range for u32 and ~50k-54k ops/sec for u64 after this change
