### PR TITLE
feat: create shared log coordinates natively

### DIFF
--- a/packages/programs/data/shared-log/rust/Cargo.lock
+++ b/packages/programs/data/shared-log/rust/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +22,35 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "equivalent"
@@ -45,6 +83,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +121,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +138,7 @@ version = "0.0.0"
 dependencies = [
  "indexmap",
  "js-sys",
+ "sha2",
  "wasm-bindgen",
 ]
 
@@ -118,6 +173,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,10 +201,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasm-bindgen"

--- a/packages/programs/data/shared-log/rust/Cargo.toml
+++ b/packages/programs/data/shared-log/rust/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 indexmap = "2.7.1"
 js-sys = "0.3.80"
+sha2 = "0.10.8"
 wasm-bindgen = "0.2.103"
 
 [package.metadata.wasm-pack.profile.release]

--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -99,6 +99,8 @@ type NativeRangePlannerHandle = {
 		selfHash: string,
 		includeSelf: boolean,
 	) => unknown[] | undefined;
+	get_grid: (from: string, count: number) => unknown[];
+	get_gid_coordinates: (gid: string, count: number) => unknown[];
 };
 
 type WasmModule = {
@@ -160,14 +162,29 @@ const rowsToSamples = (rows: unknown[]): Map<string, LeaderSample> => {
 	return out;
 };
 
+const rowsToNumbers = (
+	resolution: RangeResolution,
+	rows: unknown[],
+): Array<number | bigint> =>
+	rows.map((row) => {
+		const value = row as string;
+		return resolution === "u64" ? BigInt(value) : Number(value);
+	});
+
 export class SharedLogRangePlanner {
-	private constructor(private readonly native: NativeRangePlannerHandle) {}
+	private constructor(
+		private readonly native: NativeRangePlannerHandle,
+		private readonly resolution: RangeResolution,
+	) {}
 
 	static async create(
 		resolution: RangeResolution,
 	): Promise<SharedLogRangePlanner> {
 		const wasm = await loadWasm();
-		return new SharedLogRangePlanner(new wasm.NativeRangePlanner(resolution));
+		return new SharedLogRangePlanner(
+			new wasm.NativeRangePlanner(resolution),
+			resolution,
+		);
 	}
 
 	get length(): number {
@@ -259,6 +276,23 @@ export class SharedLogRangePlanner {
 			options.selfReplicating,
 		);
 		return peers ? new Set(peers as string[]) : undefined;
+	}
+
+	getGrid(
+		from: bigint | number | string,
+		count: number,
+	): Array<number | bigint> {
+		return rowsToNumbers(
+			this.resolution,
+			this.native.get_grid(asIntegerString(from), count),
+		);
+	}
+
+	getGidCoordinates(gid: string, count: number): Array<number | bigint> {
+		return rowsToNumbers(
+			this.resolution,
+			this.native.get_gid_coordinates(gid, count),
+		);
 	}
 }
 

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -1,5 +1,6 @@
 use indexmap::{IndexMap, IndexSet};
 use js_sys::Array;
+use sha2::{Digest, Sha256};
 use std::cmp::Ordering;
 use std::collections::{BTreeSet, HashSet};
 use wasm_bindgen::prelude::*;
@@ -37,6 +38,13 @@ impl Resolution {
     fn containment_bucket(self, value: u64) -> usize {
         let bucket = (value as u128 * CONTAINMENT_BUCKETS as u128) / self.domain_size();
         (bucket as usize).min(CONTAINMENT_BUCKETS - 1)
+    }
+
+    fn number_from_digest(self, digest: &[u8]) -> u64 {
+        match self {
+            Self::U32 => u32::from_le_bytes(digest[0..4].try_into().expect("sha256 digest")) as u64,
+            Self::U64 => u64::from_le_bytes(digest[0..8].try_into().expect("sha256 digest")),
+        }
     }
 }
 
@@ -404,6 +412,44 @@ impl RangePlanner {
             .map(|peers| IndexSet::from_iter(peers.iter().cloned()));
 
         self.get_samples(cursors, &options)
+    }
+
+    pub fn get_grid(&self, from: u64, count: usize) -> Vec<u64> {
+        if count == 0 {
+            return Vec::new();
+        }
+
+        match self.resolution {
+            Resolution::U32 => {
+                let max = MAX_U32 as f64;
+                (0..count)
+                    .map(|index| {
+                        ((from as f64 + (index as f64 * max) / count as f64).round() as u64)
+                            % MAX_U32
+                    })
+                    .collect()
+            }
+            Resolution::U64 => {
+                let max = MAX_U64 as u128;
+                (0..count)
+                    .map(|index| {
+                        ((from as u128 + (index as u128 * max) / count as u128) % max) as u64
+                    })
+                    .collect()
+            }
+        }
+    }
+
+    pub fn hash_gid(&self, gid: &str) -> u64 {
+        let mut bytes = Vec::with_capacity(4 + gid.len());
+        bytes.extend_from_slice(&(gid.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(gid.as_bytes());
+        let digest = Sha256::digest(bytes);
+        self.resolution.number_from_digest(&digest)
+    }
+
+    pub fn get_gid_coordinates(&self, gid: &str, count: usize) -> Vec<u64> {
+        self.get_grid(self.hash_gid(gid), count)
     }
 
     pub fn get_full_replica_leaders(
@@ -815,6 +861,20 @@ impl NativeRangePlanner {
         )))
     }
 
+    pub fn get_grid(&self, from: String, count: usize) -> Result<Array, JsValue> {
+        Ok(numbers_to_rows(
+            self.inner.get_grid(parse_u64(&from)?, count),
+            self.inner.resolution,
+        ))
+    }
+
+    pub fn get_gid_coordinates(&self, gid: String, count: usize) -> Array {
+        numbers_to_rows(
+            self.inner.get_gid_coordinates(&gid, count),
+            self.inner.resolution,
+        )
+    }
+
     pub fn get_full_replica_leaders(
         &self,
         replicas: usize,
@@ -914,6 +974,17 @@ fn strings_to_array(values: Vec<String>) -> Array {
     let out = Array::new();
     for value in values {
         out.push(&JsValue::from_str(&value));
+    }
+    out
+}
+
+fn numbers_to_rows(values: Vec<u64>, resolution: Resolution) -> Array {
+    let out = Array::new();
+    for value in values {
+        match resolution {
+            Resolution::U32 => out.push(&JsValue::from_f64(value as f64)),
+            Resolution::U64 => out.push(&JsValue::from_str(&value.to_string())),
+        };
     }
     out
 }

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -277,4 +277,28 @@ describe("native shared-log range planner", () => {
 			new Map([["peer-a", { intersecting: true }]]),
 		);
 	});
+
+	it("creates u32 coordinate grids", async () => {
+		const planner = await createRangePlanner("u32");
+		const max = 4_294_967_295;
+		const from = 100;
+
+		expect(planner.getGrid(from, 3)).to.deep.equal([
+			from,
+			Math.round(from + max / 3) % max,
+			Math.round(from + (2 * max) / 3) % max,
+		]);
+	});
+
+	it("creates u64 coordinate grids", async () => {
+		const planner = await createRangePlanner("u64");
+		const max = 18_446_744_073_709_551_615n;
+		const from = 100n;
+
+		expect(planner.getGrid(from, 3)).to.deep.equal([
+			from,
+			(from + max / 3n) % max,
+			(from + (2n * max) / 3n) % max,
+		]);
+	});
 });

--- a/packages/programs/data/shared-log/rust/test/node.parity.ts
+++ b/packages/programs/data/shared-log/rust/test/node.parity.ts
@@ -1,3 +1,5 @@
+import { BinaryWriter } from "@dao-xyz/borsh";
+import { sha256 } from "@peerbit/crypto";
 import { create as createIndices } from "@peerbit/indexer-sqlite3";
 import { expect } from "chai";
 import {
@@ -18,6 +20,7 @@ type AnyRange = {
 	mode: number;
 };
 type SharedLogModules = {
+	bytesToNumber: (resolution: Resolution) => (bytes: Uint8Array) => number | bigint;
 	createNumbers: (resolution: Resolution) => any;
 	denormalizer: (resolution: Resolution) => (value: number) => number | bigint;
 	ReplicationIntent: {
@@ -45,11 +48,12 @@ const loadSharedLog = async (): Promise<SharedLogModules> => {
 	if (!sharedLog) {
 		const integersPath = "../../../dist/src/integers.js";
 		const rangesPath = "../../../dist/src/ranges.js";
-		const [{ createNumbers, denormalizer }, ranges] = await Promise.all([
+		const [{ bytesToNumber, createNumbers, denormalizer }, ranges] = await Promise.all([
 			import(integersPath),
 			import(rangesPath),
 		]);
 		sharedLog = {
+			bytesToNumber,
 			createNumbers,
 			denormalizer,
 			ReplicationIntent: ranges.ReplicationIntent,
@@ -116,6 +120,16 @@ const toNativeRange = (range: AnyRange): NativeReplicationRange => ({
 const mapEntries = (map: Map<string, { intersecting: boolean }>) =>
 	[...map.entries()];
 
+const hashGidCursor = async (resolution: Resolution, gid: string) => {
+	if (!sharedLog) {
+		throw new Error("Shared log modules are not loaded");
+	}
+	const writer = new BinaryWriter();
+	writer.string(gid);
+	const digest = await sha256(writer.finalize());
+	return sharedLog.bytesToNumber(resolution)(digest);
+};
+
 const expectNativeParity = async (
 	resolution: Resolution,
 	properties: {
@@ -178,6 +192,16 @@ describe("native shared-log range planner parity", () => {
 			const modules = await loadSharedLog();
 			numbers = modules.createNumbers(resolution);
 			denormalize = modules.denormalizer(resolution);
+		});
+
+		it(`matches TypeScript hash-domain coordinate creation for ${resolution}`, async () => {
+			const planner = await createRangePlanner(resolution);
+			const gid = `native-coordinate-${resolution}`;
+			const cursor = await hashGidCursor(resolution, gid);
+
+			expect(planner.getGidCoordinates(gid, 3)).to.deep.equal(
+				numbers.getGrid(cursor, 3),
+			);
 		});
 
 		it(`matches TypeScript fallback ordering for ${resolution}`, async () => {

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -6658,12 +6658,29 @@ export class SharedLog<
 		entry: ShallowOrFullEntry<any> | EntryReplicated<R> | NumberFromType<R>,
 		minReplicas: number,
 	) {
+		if (
+			typeof entry !== "number" &&
+			typeof entry !== "bigint" &&
+			this.domain.type === "hash"
+		) {
+			const nativeCoordinates = this._nativeRangePlanner?.getGidCoordinates(
+				entry.meta.gid,
+				minReplicas,
+			) as NumberFromType<R>[] | undefined;
+			if (nativeCoordinates) {
+				return nativeCoordinates;
+			}
+		}
+
 		const cursor =
 			typeof entry === "number" || typeof entry === "bigint"
 				? entry
 				: await this.domain.fromEntry(entry);
-		const out = this.indexableDomain.numbers.getGrid(cursor, minReplicas);
-		return out;
+		const nativeGrid = this._nativeRangePlanner?.getGrid(
+			cursor,
+			minReplicas,
+		) as NumberFromType<R>[] | undefined;
+		return nativeGrid ?? this.indexableDomain.numbers.getGrid(cursor, minReplicas);
 	}
 
 	private async getCoordinates(entry: { hash: string }) {


### PR DESCRIPTION
## Summary
- add native grid generation for shared-log coordinates
- add native default hash-domain gid coordinate generation using Borsh string bytes + SHA-256
- route SharedLog.createCoordinates through the native planner when available, with JS fallback for custom/time domains
- return u32 native coordinates as JS numbers while preserving u64 precision as strings -> BigInt

## Validation
- cargo test --manifest-path packages/programs/data/shared-log/rust/Cargo.toml
- pnpm --filter @peerbit/shared-log-rust run build
- pnpm --filter @peerbit/shared-log-rust run lint
- pnpm --filter @peerbit/shared-log-rust run test
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "uses indexed peers when the leader peer filter is temporarily underfilled"

## Benchmark signal
Local coordinate microbench, 50k gids, 3 replicas:
- u32: TS 873,100 ops/sec vs native 1,270,419 ops/sec (~1.5x)
- u64: TS 763,954 ops/sec vs native 739,315 ops/sec (~neutral)

The main value is structural: default hash-domain coordinate hashing/grid generation now stays in the native shared-log planner before the native findLeaders path.
