### PR TITLE
feat: plan gid leaders natively

### DIFF
--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -84,6 +84,18 @@ type NativeRangePlannerHandle = {
 		fullReplicaFallback: boolean,
 		includeStrictFullReplica: boolean,
 	) => unknown[];
+	find_leaders_for_gid: (
+		gid: string,
+		replicas: number,
+		roleAgeMs: number,
+		now: string,
+		peerFilter: string[] | undefined,
+		expandPeerFilter: boolean,
+		selfHash: string,
+		includeSelf: boolean,
+		fullReplicaFallback: boolean,
+		includeStrictFullReplica: boolean,
+	) => unknown[];
 	get_full_replica_leaders: (
 		replicas: number,
 		roleAgeMs: number,
@@ -235,6 +247,26 @@ export class SharedLogRangePlanner {
 	): Map<string, LeaderSample> {
 		const rows = this.native.find_leaders(
 			[...cursors].map(asIntegerString),
+			replicas,
+			options?.roleAge ?? 0,
+			asIntegerString(options?.now ?? Date.now()),
+			options?.peerFilter ? [...options.peerFilter] : undefined,
+			options?.expandPeerFilter === true,
+			options?.selfHash ?? "",
+			options?.selfReplicating === true,
+			options?.fullReplicaFallback === true,
+			options?.includeStrictFullReplica !== false,
+		);
+		return rowsToSamples(rows);
+	}
+
+	findLeadersForGid(
+		gid: string,
+		replicas: number,
+		options?: FindLeaderOptions,
+	): Map<string, LeaderSample> {
+		const rows = this.native.find_leaders_for_gid(
+			gid,
 			replicas,
 			options?.roleAge ?? 0,
 			asIntegerString(options?.now ?? Date.now()),

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -861,6 +861,43 @@ impl NativeRangePlanner {
         )))
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn find_leaders_for_gid(
+        &self,
+        gid: String,
+        replicas: usize,
+        role_age_ms: f64,
+        now: String,
+        peer_filter: JsValue,
+        expand_peer_filter: bool,
+        self_hash: String,
+        include_self: bool,
+        full_replica_fallback: bool,
+        include_strict_full_replica: bool,
+    ) -> Result<Array, JsValue> {
+        let coordinates = self.inner.get_gid_coordinates(&gid, replicas);
+        let options = SampleOptions {
+            role_age_ms: if role_age_ms <= 0.0 {
+                0
+            } else {
+                role_age_ms.floor() as u64
+            },
+            now: parse_u64(&now)?,
+            peer_filter: optional_string_set(peer_filter)?.map(HashSet::from_iter),
+            ..Default::default()
+        };
+        Ok(samples_to_rows(self.inner.find_leaders(
+            &coordinates,
+            replicas,
+            &options,
+            expand_peer_filter,
+            &self_hash,
+            include_self,
+            full_replica_fallback,
+            include_strict_full_replica,
+        )))
+    }
+
     pub fn get_grid(&self, from: String, count: usize) -> Result<Array, JsValue> {
         Ok(numbers_to_rows(
             self.inner.get_grid(parse_u64(&from)?, count),

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -182,6 +182,25 @@ describe("native shared-log range planner", () => {
 		);
 	});
 
+	it("finds hash gid leaders without returning coordinates to TypeScript", async () => {
+		const planner = await createRangePlanner("u32");
+		planner.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));
+		planner.put(range({ id: "b", hash: "peer-b", start1: 20, end1: 30 }));
+
+		const gid = "entry-gid";
+		expect(
+			planner.findLeadersForGid(gid, 2, {
+				now: 1_000,
+				fullReplicaFallback: true,
+			}),
+		).to.deep.equal(
+			planner.findLeaders(planner.getGidCoordinates(gid, 2), 2, {
+				now: 1_000,
+				fullReplicaFallback: true,
+			}),
+		);
+	});
+
 	it("expands peer filters through the combined native path", async () => {
 		const planner = await createRangePlanner("u32");
 		planner.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -6874,13 +6874,15 @@ export class SharedLog<
 		return false;
 	}
 
-	private async _findLeaders(
-		cursors: NumberFromType<R>[],
-		options?: {
-			roleAge?: number;
-			candidates?: Iterable<string>;
-		},
-	): Promise<Map<string, { intersecting: boolean }>> {
+	private async createLeaderSelectionContext(options?: {
+		roleAge?: number;
+		candidates?: Iterable<string>;
+	}): Promise<{
+		roleAge: number;
+		selfHash: string;
+		selfReplicating: boolean;
+		peerFilter: Set<string> | undefined;
+	}> {
 		const roleAge = options?.roleAge ?? (await this.getDefaultMinRoleAge()); // TODO -500 as is added so that i f someone else is just as new as us, then we treat them as mature as us. without -500 we might be slower syncing if two nodes starts almost at the same time
 		const selfHash = this.node.identity.publicKey.hashcode();
 
@@ -6933,6 +6935,29 @@ export class SharedLog<
 				}
 			}
 		}
+
+		return {
+			roleAge,
+			selfHash,
+			selfReplicating,
+			peerFilter,
+		};
+	}
+
+	private async _findLeaders(
+		cursors: NumberFromType<R>[],
+		options?: {
+			roleAge?: number;
+			candidates?: Iterable<string>;
+		},
+	): Promise<Map<string, { intersecting: boolean }>> {
+		const {
+			roleAge,
+			selfHash,
+			selfReplicating,
+			peerFilter: initialPeerFilter,
+		} = await this.createLeaderSelectionContext(options);
+		let peerFilter = initialPeerFilter;
 
 		if (this._nativeRangePlanner) {
 			return this._nativeRangePlanner.findLeaders(cursors, cursors.length, {
@@ -7067,6 +7092,33 @@ export class SharedLog<
 		return leaders.size > 0 ? leaders : undefined;
 	}
 
+	private async _findLeadersFromHashGid(
+		gid: string,
+		replicas: number,
+		options?: {
+			roleAge?: number;
+			candidates?: Iterable<string>;
+		},
+	): Promise<Map<string, { intersecting: boolean }> | undefined> {
+		if (!this._nativeRangePlanner) {
+			return undefined;
+		}
+
+		const { roleAge, selfHash, selfReplicating, peerFilter } =
+			await this.createLeaderSelectionContext(options);
+		return this._nativeRangePlanner.findLeadersForGid(gid, replicas, {
+			roleAge,
+			now: Date.now(),
+			peerFilter,
+			expandPeerFilter: !options?.candidates,
+			selfHash,
+			selfReplicating,
+			fullReplicaFallback: !options?.candidates,
+			includeStrictFullReplica:
+				this._logProperties?.strictFullReplicaFallback !== false,
+		});
+	}
+
 	async findLeadersFromEntry(
 		entry: ShallowOrFullEntry<any> | EntryReplicated<R>,
 		replicas: number,
@@ -7074,6 +7126,17 @@ export class SharedLog<
 			roleAge?: number;
 		},
 	): Promise<Map<string, { intersecting: boolean }>> {
+		if (this.domain.type === "hash") {
+			const nativeResult = await this._findLeadersFromHashGid(
+				entry.meta.gid,
+				replicas,
+				options,
+			);
+			if (nativeResult) {
+				return nativeResult;
+			}
+		}
+
 		const coordinates = await this.createCoordinates(entry, replicas);
 		const result = await this._findLeaders(coordinates, options);
 		return result;


### PR DESCRIPTION
## Summary
- add a Rust/WASM `findLeadersForGid` path that hashes the entry gid, creates the replica coordinate grid, and plans leaders in one native call
- route hash-domain shared-log `findLeadersFromEntry` through the combined native path while preserving the existing candidate/subscriber peer-filter semantics
- add Rust planner coverage for the gid leader path

## Benchmark signal
40k ranges loaded, 50k iterations, Node local microbench:
- u32 split `getGidCoordinates + findLeaders`: 93,726 ops/sec
- u32 combined `findLeadersForGid`: 113,805 ops/sec
- u64 split `getGidCoordinates + findLeaders`: 82,161 ops/sec
- u64 combined `findLeadersForGid`: 97,991 ops/sec

## Validation
- `pnpm --filter @peerbit/shared-log-rust run lint`
- `pnpm --filter @peerbit/shared-log-rust run test`
- `pnpm --filter @peerbit/shared-log run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "settles towards the current replicators"`

Note: `pnpm --filter @peerbit/shared-log run lint` still reports existing repo-wide style failures in unrelated files such as `src/blocks.ts`, `src/cpu.ts`, and `src/exchange-heads.ts`.
