### PR TITLE
feat: plan isLeader gid natively

### DIFF
--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -49,6 +49,11 @@ export type LeaderSample = {
 	intersecting: boolean;
 };
 
+export type LeaderPlan = {
+	coordinates: Array<number | bigint>;
+	leaders: Map<string, LeaderSample>;
+};
+
 type NativeRangePlannerHandle = {
 	len: () => number;
 	clear: () => void;
@@ -96,6 +101,18 @@ type NativeRangePlannerHandle = {
 		fullReplicaFallback: boolean,
 		includeStrictFullReplica: boolean,
 	) => unknown[];
+	plan_leaders_for_gid: (
+		gid: string,
+		replicas: number,
+		roleAgeMs: number,
+		now: string,
+		peerFilter: string[] | undefined,
+		expandPeerFilter: boolean,
+		selfHash: string,
+		includeSelf: boolean,
+		fullReplicaFallback: boolean,
+		includeStrictFullReplica: boolean,
+	) => [unknown[], unknown[]];
 	get_full_replica_leaders: (
 		replicas: number,
 		roleAgeMs: number,
@@ -278,6 +295,29 @@ export class SharedLogRangePlanner {
 			options?.includeStrictFullReplica !== false,
 		);
 		return rowsToSamples(rows);
+	}
+
+	planLeadersForGid(
+		gid: string,
+		replicas: number,
+		options?: FindLeaderOptions,
+	): LeaderPlan {
+		const [coordinateRows, leaderRows] = this.native.plan_leaders_for_gid(
+			gid,
+			replicas,
+			options?.roleAge ?? 0,
+			asIntegerString(options?.now ?? Date.now()),
+			options?.peerFilter ? [...options.peerFilter] : undefined,
+			options?.expandPeerFilter === true,
+			options?.selfHash ?? "",
+			options?.selfReplicating === true,
+			options?.fullReplicaFallback === true,
+			options?.includeStrictFullReplica !== false,
+		);
+		return {
+			coordinates: rowsToNumbers(this.resolution, coordinateRows),
+			leaders: rowsToSamples(leaderRows),
+		};
 	}
 
 	getFullReplicaLeaders(

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -807,11 +807,7 @@ impl NativeRangePlanner {
             .map(|value| parse_u64(&value))
             .collect::<Result<Vec<_>, _>>()?;
         let options = SampleOptions {
-            role_age_ms: if role_age_ms <= 0.0 {
-                0
-            } else {
-                role_age_ms.floor() as u64
-            },
+            role_age_ms: role_age_ms_from_f64(role_age_ms),
             now: parse_u64(&now)?,
             only_intersecting,
             unique_replicators: optional_string_set(unique_replicators)?.map(IndexSet::from_iter),
@@ -838,16 +834,7 @@ impl NativeRangePlanner {
             .into_iter()
             .map(|value| parse_u64(&value))
             .collect::<Result<Vec<_>, _>>()?;
-        let options = SampleOptions {
-            role_age_ms: if role_age_ms <= 0.0 {
-                0
-            } else {
-                role_age_ms.floor() as u64
-            },
-            now: parse_u64(&now)?,
-            peer_filter: optional_string_set(peer_filter)?.map(HashSet::from_iter),
-            ..Default::default()
-        };
+        let options = find_leader_options(role_age_ms, &now, peer_filter)?;
 
         Ok(samples_to_rows(self.inner.find_leaders(
             &cursors,
@@ -876,16 +863,7 @@ impl NativeRangePlanner {
         include_strict_full_replica: bool,
     ) -> Result<Array, JsValue> {
         let coordinates = self.inner.get_gid_coordinates(&gid, replicas);
-        let options = SampleOptions {
-            role_age_ms: if role_age_ms <= 0.0 {
-                0
-            } else {
-                role_age_ms.floor() as u64
-            },
-            now: parse_u64(&now)?,
-            peer_filter: optional_string_set(peer_filter)?.map(HashSet::from_iter),
-            ..Default::default()
-        };
+        let options = find_leader_options(role_age_ms, &now, peer_filter)?;
         Ok(samples_to_rows(self.inner.find_leaders(
             &coordinates,
             replicas,
@@ -896,6 +874,38 @@ impl NativeRangePlanner {
             full_replica_fallback,
             include_strict_full_replica,
         )))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn plan_leaders_for_gid(
+        &self,
+        gid: String,
+        replicas: usize,
+        role_age_ms: f64,
+        now: String,
+        peer_filter: JsValue,
+        expand_peer_filter: bool,
+        self_hash: String,
+        include_self: bool,
+        full_replica_fallback: bool,
+        include_strict_full_replica: bool,
+    ) -> Result<Array, JsValue> {
+        let coordinates = self.inner.get_gid_coordinates(&gid, replicas);
+        let options = find_leader_options(role_age_ms, &now, peer_filter)?;
+        let leaders = self.inner.find_leaders(
+            &coordinates,
+            replicas,
+            &options,
+            expand_peer_filter,
+            &self_hash,
+            include_self,
+            full_replica_fallback,
+            include_strict_full_replica,
+        );
+        let out = Array::new();
+        out.push(&numbers_to_rows(coordinates, self.inner.resolution));
+        out.push(&samples_to_rows(leaders));
+        Ok(out)
     }
 
     pub fn get_grid(&self, from: String, count: usize) -> Result<Array, JsValue> {
@@ -920,16 +930,7 @@ impl NativeRangePlanner {
         include_strict: bool,
         peer_filter: JsValue,
     ) -> Result<JsValue, JsValue> {
-        let options = SampleOptions {
-            role_age_ms: if role_age_ms <= 0.0 {
-                0
-            } else {
-                role_age_ms.floor() as u64
-            },
-            now: parse_u64(&now)?,
-            peer_filter: optional_string_set(peer_filter)?.map(HashSet::from_iter),
-            ..Default::default()
-        };
+        let options = find_leader_options(role_age_ms, &now, peer_filter)?;
 
         Ok(
             match self
@@ -952,11 +953,7 @@ impl NativeRangePlanner {
         include_self: bool,
     ) -> Result<JsValue, JsValue> {
         let options = SampleOptions {
-            role_age_ms: if role_age_ms <= 0.0 {
-                0
-            } else {
-                role_age_ms.floor() as u64
-            },
+            role_age_ms: role_age_ms_from_f64(role_age_ms),
             now: parse_u64(&now)?,
             ..Default::default()
         };
@@ -978,6 +975,27 @@ impl Default for NativeRangePlanner {
     fn default() -> Self {
         Self::new("u32".to_string())
     }
+}
+
+fn role_age_ms_from_f64(value: f64) -> u64 {
+    if value <= 0.0 {
+        0
+    } else {
+        value.floor() as u64
+    }
+}
+
+fn find_leader_options(
+    role_age_ms: f64,
+    now: &str,
+    peer_filter: JsValue,
+) -> Result<SampleOptions, JsValue> {
+    Ok(SampleOptions {
+        role_age_ms: role_age_ms_from_f64(role_age_ms),
+        now: parse_u64(now)?,
+        peer_filter: optional_string_set(peer_filter)?.map(HashSet::from_iter),
+        ..Default::default()
+    })
 }
 
 fn parse_u64(value: &str) -> Result<u64, JsValue> {

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -201,6 +201,27 @@ describe("native shared-log range planner", () => {
 		);
 	});
 
+	it("plans hash gid coordinates and leaders together", async () => {
+		const planner = await createRangePlanner("u32");
+		planner.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));
+		planner.put(range({ id: "b", hash: "peer-b", start1: 20, end1: 30 }));
+
+		const gid = "entry-gid";
+		const coordinates = planner.getGidCoordinates(gid, 2);
+		expect(
+			planner.planLeadersForGid(gid, 2, {
+				now: 1_000,
+				fullReplicaFallback: true,
+			}),
+		).to.deep.equal({
+			coordinates,
+			leaders: planner.findLeaders(coordinates, 2, {
+				now: 1_000,
+				fullReplicaFallback: true,
+			}),
+		});
+	});
+
 	it("expands peer filters through the combined native path", async () => {
 		const planner = await createRangePlanner("u32");
 		planner.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -6819,30 +6819,49 @@ export class SharedLog<
 		},
 	): Promise<Map<string, { intersecting: boolean }>> {
 		// we consume a list of coordinates in this method since if we are leader of one coordinate we want to persist all of them
-		let isLeader = false;
-
 		const set = await this._findLeaders(cursors, options);
-		for (const key of set.keys()) {
+		await this.applyLeaderSelection(cursors, entry, set, options);
+		return set;
+	}
+
+	private async applyLeaderSelection(
+		cursors: NumberFromType<R>[],
+		entry: Entry<T> | EntryReplicated<R> | ShallowEntry,
+		leaders: Map<string, { intersecting: boolean }>,
+		options?: {
+			onLeader?: (key: string) => void;
+			persist?:
+				| {
+						prev?: EntryReplicated<R>;
+				  }
+				| false;
+		},
+	): Promise<boolean> {
+		const selfHash = this.node.identity.publicKey.hashcode();
+		const isLeader = leaders.has(selfHash);
+		let shouldPersistLocalLeader = false;
+		for (const key of leaders.keys()) {
 			if (options?.onLeader) {
 				options.onLeader(key);
-				isLeader = isLeader || key === this.node.identity.publicKey.hashcode();
+				shouldPersistLocalLeader = shouldPersistLocalLeader || key === selfHash;
 			}
 		}
 
-		if (options?.persist !== false) {
-			if (isLeader || options?.persist) {
-				!this.closed &&
-					(await this.persistCoordinate({
-						leaders: set,
-						coordinates: cursors,
-						replicas: cursors.length,
-						entry,
-						prev: options?.persist?.prev,
-					}));
-			}
+		if (
+			options?.persist !== false &&
+			(shouldPersistLocalLeader || options?.persist)
+		) {
+			!this.closed &&
+				(await this.persistCoordinate({
+					leaders,
+					coordinates: cursors,
+					replicas: cursors.length,
+					entry,
+					prev: options?.persist?.prev,
+				}));
 		}
 
-		return set;
+		return isLeader;
 	}
 
 	async isLeader(
@@ -6862,6 +6881,25 @@ export class SharedLog<
 				| false;
 		},
 	): Promise<boolean> {
+		if (
+			this.domain.type === "hash" &&
+			typeof properties.entry.meta.gid === "string"
+		) {
+			const plan = await this._findLeaderPlanFromHashGid(
+				properties.entry.meta.gid,
+				properties.replicas,
+				options,
+			);
+			if (plan) {
+				return this.applyLeaderSelection(
+					plan.coordinates as NumberFromType<R>[],
+					properties.entry,
+					plan.leaders,
+					options,
+				);
+			}
+		}
+
 		let cursors: NumberFromType<R>[] = await this.createCoordinates(
 			properties.entry,
 			properties.replicas,
@@ -6944,6 +6982,30 @@ export class SharedLog<
 		};
 	}
 
+	private createNativeLeaderOptions(
+		context: {
+			roleAge: number;
+			selfHash: string;
+			selfReplicating: boolean;
+			peerFilter: Set<string> | undefined;
+		},
+		options?: {
+			candidates?: Iterable<string>;
+		},
+	) {
+		return {
+			roleAge: context.roleAge,
+			now: Date.now(),
+			peerFilter: context.peerFilter,
+			expandPeerFilter: !options?.candidates,
+			selfHash: context.selfHash,
+			selfReplicating: context.selfReplicating,
+			fullReplicaFallback: !options?.candidates,
+			includeStrictFullReplica:
+				this._logProperties?.strictFullReplicaFallback !== false,
+		};
+	}
+
 	private async _findLeaders(
 		cursors: NumberFromType<R>[],
 		options?: {
@@ -6951,25 +7013,12 @@ export class SharedLog<
 			candidates?: Iterable<string>;
 		},
 	): Promise<Map<string, { intersecting: boolean }>> {
-		const {
-			roleAge,
-			selfHash,
-			selfReplicating,
-			peerFilter: initialPeerFilter,
-		} = await this.createLeaderSelectionContext(options);
-		let peerFilter = initialPeerFilter;
+		const context = await this.createLeaderSelectionContext(options);
+		let peerFilter = context.peerFilter;
 
 		if (this._nativeRangePlanner) {
 			return this._nativeRangePlanner.findLeaders(cursors, cursors.length, {
-				roleAge,
-				now: Date.now(),
-				peerFilter,
-				expandPeerFilter: !options?.candidates,
-				selfHash,
-				selfReplicating,
-				fullReplicaFallback: !options?.candidates,
-				includeStrictFullReplica:
-					this._logProperties?.strictFullReplicaFallback !== false,
+				...this.createNativeLeaderOptions(context, options),
 			});
 		}
 
@@ -6978,16 +7027,16 @@ export class SharedLog<
 			// turn a known mature indexed range into a false self-only full replica.
 			peerFilter = await this.includeIndexedLeaderCandidatesWhenUnderfilled(
 				peerFilter,
-				roleAge,
+				context.roleAge,
 				cursors.length,
-				selfReplicating,
+				context.selfReplicating,
 			);
 		}
 
 		if (!options?.candidates) {
 			const fullReplicaLeaders = await this.findFullReplicaLeaders(
 				cursors.length,
-				roleAge,
+				context.roleAge,
 				peerFilter,
 			);
 			if (fullReplicaLeaders) {
@@ -6998,7 +7047,7 @@ export class SharedLog<
 		return getSamples<R>(
 			cursors,
 			this.replicationIndex,
-			roleAge,
+			context.roleAge,
 			this.indexableDomain.numbers,
 			{
 				peerFilter,
@@ -7104,19 +7153,38 @@ export class SharedLog<
 			return undefined;
 		}
 
-		const { roleAge, selfHash, selfReplicating, peerFilter } =
-			await this.createLeaderSelectionContext(options);
-		return this._nativeRangePlanner.findLeadersForGid(gid, replicas, {
-			roleAge,
-			now: Date.now(),
-			peerFilter,
-			expandPeerFilter: !options?.candidates,
-			selfHash,
-			selfReplicating,
-			fullReplicaFallback: !options?.candidates,
-			includeStrictFullReplica:
-				this._logProperties?.strictFullReplicaFallback !== false,
-		});
+		const context = await this.createLeaderSelectionContext(options);
+		return this._nativeRangePlanner.findLeadersForGid(
+			gid,
+			replicas,
+			this.createNativeLeaderOptions(context, options),
+		);
+	}
+
+	private async _findLeaderPlanFromHashGid(
+		gid: string,
+		replicas: number,
+		options?: {
+			roleAge?: number;
+			candidates?: Iterable<string>;
+		},
+	): Promise<
+		| {
+				coordinates: Array<number | bigint>;
+				leaders: Map<string, { intersecting: boolean }>;
+		  }
+		| undefined
+	> {
+		if (!this._nativeRangePlanner) {
+			return undefined;
+		}
+
+		const context = await this.createLeaderSelectionContext(options);
+		return this._nativeRangePlanner.planLeadersForGid(
+			gid,
+			replicas,
+			this.createNativeLeaderOptions(context, options),
+		);
 	}
 
 	async findLeadersFromEntry(
@@ -7126,7 +7194,7 @@ export class SharedLog<
 			roleAge?: number;
 		},
 	): Promise<Map<string, { intersecting: boolean }>> {
-		if (this.domain.type === "hash") {
+		if (this.domain.type === "hash" && typeof entry.meta.gid === "string") {
 			const nativeResult = await this._findLeadersFromHashGid(
 				entry.meta.gid,
 				replicas,


### PR DESCRIPTION
## Summary
- add a Rust/WASM `planLeadersForGid` call that returns hash-domain coordinates and leaders from one native call
- route hash-domain `isLeader` through that native plan when the entry has a real `meta.gid`, preserving the existing fallback for custom/synthetic entries
- debloat leader-planning option construction in Rust and shared-log leader-result handling in TypeScript

## Benchmark signal
40k ranges loaded, 50k iterations, Node local microbench:
- u32 split `getGidCoordinates + findLeaders`: 89,956 ops/sec
- u32 combined `planLeadersForGid`: 106,978 ops/sec
- u64 split `getGidCoordinates + findLeaders`: 81,598 ops/sec
- u64 combined `planLeadersForGid`: 86,878 ops/sec

## Validation
- `pnpm --filter @peerbit/shared-log-rust run lint`
- `pnpm --filter @peerbit/shared-log-rust run test`
- `pnpm --filter @peerbit/shared-log run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "leader are selected from 1 replicating peer"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "settles towards the current replicators"`
