### PR TITLE
feat: batch shared-log leader planning natively

### DIFF
--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -54,6 +54,16 @@ export type LeaderPlan = {
 	leaders: Map<string, LeaderSample>;
 };
 
+export type LeaderBatchInput = {
+	cursors: Iterable<bigint | number | string>;
+	replicas: number;
+};
+
+export type LeaderGidBatchInput = {
+	gid: string;
+	replicas: number;
+};
+
 type NativeRangePlannerHandle = {
 	len: () => number;
 	clear: () => void;
@@ -89,6 +99,18 @@ type NativeRangePlannerHandle = {
 		fullReplicaFallback: boolean,
 		includeStrictFullReplica: boolean,
 	) => unknown[];
+	find_leaders_batch: (
+		cursorBatches: string[][],
+		replicaCounts: number[],
+		roleAgeMs: number,
+		now: string,
+		peerFilter: string[] | undefined,
+		expandPeerFilter: boolean,
+		selfHash: string,
+		includeSelf: boolean,
+		fullReplicaFallback: boolean,
+		includeStrictFullReplica: boolean,
+	) => unknown[];
 	find_leaders_for_gid: (
 		gid: string,
 		replicas: number,
@@ -113,6 +135,18 @@ type NativeRangePlannerHandle = {
 		fullReplicaFallback: boolean,
 		includeStrictFullReplica: boolean,
 	) => [unknown[], unknown[]];
+	plan_leaders_for_gids_batch: (
+		gids: string[],
+		replicaCounts: number[],
+		roleAgeMs: number,
+		now: string,
+		peerFilter: string[] | undefined,
+		expandPeerFilter: boolean,
+		selfHash: string,
+		includeSelf: boolean,
+		fullReplicaFallback: boolean,
+		includeStrictFullReplica: boolean,
+	) => unknown[];
 	get_full_replica_leaders: (
 		replicas: number,
 		roleAgeMs: number,
@@ -257,14 +291,17 @@ export class SharedLogRangePlanner {
 		return rowsToSamples(rows);
 	}
 
-	findLeaders(
-		cursors: Iterable<bigint | number | string>,
-		replicas: number,
-		options?: FindLeaderOptions,
-	): Map<string, LeaderSample> {
-		const rows = this.native.find_leaders(
-			[...cursors].map(asIntegerString),
-			replicas,
+	private findLeaderArguments(options?: FindLeaderOptions): [
+		number,
+		string,
+		string[] | undefined,
+		boolean,
+		string,
+		boolean,
+		boolean,
+		boolean,
+	] {
+		return [
 			options?.roleAge ?? 0,
 			asIntegerString(options?.now ?? Date.now()),
 			options?.peerFilter ? [...options.peerFilter] : undefined,
@@ -273,8 +310,39 @@ export class SharedLogRangePlanner {
 			options?.selfReplicating === true,
 			options?.fullReplicaFallback === true,
 			options?.includeStrictFullReplica !== false,
+		];
+	}
+
+	findLeaders(
+		cursors: Iterable<bigint | number | string>,
+		replicas: number,
+		options?: FindLeaderOptions,
+	): Map<string, LeaderSample> {
+		const rows = this.native.find_leaders(
+			[...cursors].map(asIntegerString),
+			replicas,
+			...this.findLeaderArguments(options),
 		);
 		return rowsToSamples(rows);
+	}
+
+	findLeadersBatch(
+		items: Iterable<LeaderBatchInput>,
+		options?: FindLeaderOptions,
+	): Array<Map<string, LeaderSample>> {
+		const cursorBatches: string[][] = [];
+		const replicaCounts: number[] = [];
+		for (const item of items) {
+			cursorBatches.push([...item.cursors].map(asIntegerString));
+			replicaCounts.push(item.replicas);
+		}
+
+		const rows = this.native.find_leaders_batch(
+			cursorBatches,
+			replicaCounts,
+			...this.findLeaderArguments(options),
+		);
+		return rows.map((row) => rowsToSamples(row as unknown[]));
 	}
 
 	findLeadersForGid(
@@ -285,14 +353,7 @@ export class SharedLogRangePlanner {
 		const rows = this.native.find_leaders_for_gid(
 			gid,
 			replicas,
-			options?.roleAge ?? 0,
-			asIntegerString(options?.now ?? Date.now()),
-			options?.peerFilter ? [...options.peerFilter] : undefined,
-			options?.expandPeerFilter === true,
-			options?.selfHash ?? "",
-			options?.selfReplicating === true,
-			options?.fullReplicaFallback === true,
-			options?.includeStrictFullReplica !== false,
+			...this.findLeaderArguments(options),
 		);
 		return rowsToSamples(rows);
 	}
@@ -305,19 +366,37 @@ export class SharedLogRangePlanner {
 		const [coordinateRows, leaderRows] = this.native.plan_leaders_for_gid(
 			gid,
 			replicas,
-			options?.roleAge ?? 0,
-			asIntegerString(options?.now ?? Date.now()),
-			options?.peerFilter ? [...options.peerFilter] : undefined,
-			options?.expandPeerFilter === true,
-			options?.selfHash ?? "",
-			options?.selfReplicating === true,
-			options?.fullReplicaFallback === true,
-			options?.includeStrictFullReplica !== false,
+			...this.findLeaderArguments(options),
 		);
 		return {
 			coordinates: rowsToNumbers(this.resolution, coordinateRows),
 			leaders: rowsToSamples(leaderRows),
 		};
+	}
+
+	planLeadersForGidsBatch(
+		items: Iterable<LeaderGidBatchInput>,
+		options?: FindLeaderOptions,
+	): LeaderPlan[] {
+		const gids: string[] = [];
+		const replicaCounts: number[] = [];
+		for (const item of items) {
+			gids.push(item.gid);
+			replicaCounts.push(item.replicas);
+		}
+
+		const rows = this.native.plan_leaders_for_gids_batch(
+			gids,
+			replicaCounts,
+			...this.findLeaderArguments(options),
+		);
+		return rows.map((row) => {
+			const [coordinateRows, leaderRows] = row as [unknown[], unknown[]];
+			return {
+				coordinates: rowsToNumbers(this.resolution, coordinateRows),
+				leaders: rowsToSamples(leaderRows),
+			};
+		});
 	}
 
 	getFullReplicaLeaders(

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -2,7 +2,7 @@ use indexmap::{IndexMap, IndexSet};
 use js_sys::Array;
 use sha2::{Digest, Sha256};
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use wasm_bindgen::prelude::*;
 
 const MODE_NON_STRICT: u8 = 0;
@@ -381,37 +381,22 @@ impl RangePlanner {
         full_replica_fallback: bool,
         include_strict_full_replica: bool,
     ) -> Vec<LeaderSample> {
-        let mut options = options.clone();
-
-        if expand_peer_filter {
-            options.peer_filter = self
-                .include_matured_peers(
-                    options
-                        .peer_filter
-                        .as_ref()
-                        .map(|peers| IndexSet::from_iter(peers.iter().cloned())),
-                    replicas,
-                    &options,
-                    self_hash,
-                    include_self,
-                )
-                .map(HashSet::from_iter);
-        }
-
-        if full_replica_fallback {
-            if let Some(leaders) =
-                self.get_full_replica_leaders(replicas, &options, include_strict_full_replica)
-            {
-                return leaders;
-            }
-        }
-
-        options.unique_replicators = options
-            .peer_filter
-            .as_ref()
-            .map(|peers| IndexSet::from_iter(peers.iter().cloned()));
-
-        self.get_samples(cursors, &options)
+        let options = prepare_find_leader_options(
+            self,
+            options,
+            replicas,
+            expand_peer_filter,
+            self_hash,
+            include_self,
+        );
+        find_leaders_with_prepared_options(
+            self,
+            cursors,
+            replicas,
+            &options,
+            full_replica_fallback,
+            include_strict_full_replica,
+        )
     }
 
     pub fn get_grid(&self, from: u64, count: usize) -> Vec<u64> {
@@ -740,6 +725,105 @@ fn circular_distance(from: u64, to: u64, max_value: u64) -> u64 {
     diff.min(max_value.saturating_sub(diff))
 }
 
+fn prepare_find_leader_options(
+    planner: &RangePlanner,
+    options: &SampleOptions,
+    replicas: usize,
+    expand_peer_filter: bool,
+    self_hash: &str,
+    include_self: bool,
+) -> SampleOptions {
+    let mut options = options.clone();
+
+    if expand_peer_filter {
+        options.peer_filter = planner
+            .include_matured_peers(
+                options
+                    .peer_filter
+                    .as_ref()
+                    .map(|peers| IndexSet::from_iter(peers.iter().cloned())),
+                replicas,
+                &options,
+                self_hash,
+                include_self,
+            )
+            .map(HashSet::from_iter);
+    }
+
+    options
+}
+
+fn find_leaders_with_prepared_options(
+    planner: &RangePlanner,
+    cursors: &[u64],
+    replicas: usize,
+    options: &SampleOptions,
+    full_replica_fallback: bool,
+    include_strict_full_replica: bool,
+) -> Vec<LeaderSample> {
+    if full_replica_fallback {
+        if let Some(leaders) =
+            planner.get_full_replica_leaders(replicas, options, include_strict_full_replica)
+        {
+            return leaders;
+        }
+    }
+
+    let mut options = options.clone();
+    options.unique_replicators = options
+        .peer_filter
+        .as_ref()
+        .map(|peers| IndexSet::from_iter(peers.iter().cloned()));
+
+    planner.get_samples(cursors, &options)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn find_leaders_with_batch_caches(
+    planner: &RangePlanner,
+    cursors: &[u64],
+    replicas: usize,
+    base_options: &SampleOptions,
+    prepared_options_by_replicas: &mut HashMap<usize, SampleOptions>,
+    full_replica_leaders_by_replicas: &mut HashMap<usize, Option<Vec<LeaderSample>>>,
+    expand_peer_filter: bool,
+    self_hash: &str,
+    include_self: bool,
+    full_replica_fallback: bool,
+    include_strict_full_replica: bool,
+) -> Vec<LeaderSample> {
+    let prepared_options = prepared_options_by_replicas
+        .entry(replicas)
+        .or_insert_with(|| {
+            prepare_find_leader_options(
+                planner,
+                base_options,
+                replicas,
+                expand_peer_filter,
+                self_hash,
+                include_self,
+            )
+        });
+
+    if full_replica_fallback {
+        if let Some(leaders) = full_replica_leaders_by_replicas
+            .entry(replicas)
+            .or_insert_with(|| {
+                planner.get_full_replica_leaders(
+                    replicas,
+                    prepared_options,
+                    include_strict_full_replica,
+                )
+            })
+            .clone()
+        {
+            return leaders;
+        }
+    }
+
+    find_leaders_with_prepared_options(planner, cursors, replicas, prepared_options, false, true)
+}
+
 #[wasm_bindgen]
 pub struct NativeRangePlanner {
     inner: RangePlanner,
@@ -849,6 +933,48 @@ impl NativeRangePlanner {
     }
 
     #[allow(clippy::too_many_arguments)]
+    pub fn find_leaders_batch(
+        &self,
+        cursor_batches: Array,
+        replica_counts: Array,
+        role_age_ms: f64,
+        now: String,
+        peer_filter: JsValue,
+        expand_peer_filter: bool,
+        self_hash: String,
+        include_self: bool,
+        full_replica_fallback: bool,
+        include_strict_full_replica: bool,
+    ) -> Result<Array, JsValue> {
+        let cursor_batches = cursor_batches_from_array(cursor_batches)?;
+        let replica_counts = usize_from_array(replica_counts)?;
+        ensure_same_len(cursor_batches.len(), replica_counts.len(), "leader batch")?;
+        let options = find_leader_options(role_age_ms, &now, peer_filter)?;
+        let mut prepared_options_by_replicas = HashMap::new();
+        let mut full_replica_leaders_by_replicas = HashMap::new();
+        let out = Array::new();
+
+        for (cursors, replicas) in cursor_batches.into_iter().zip(replica_counts) {
+            let leaders = find_leaders_with_batch_caches(
+                &self.inner,
+                &cursors,
+                replicas,
+                &options,
+                &mut prepared_options_by_replicas,
+                &mut full_replica_leaders_by_replicas,
+                expand_peer_filter,
+                &self_hash,
+                include_self,
+                full_replica_fallback,
+                include_strict_full_replica,
+            );
+            out.push(&samples_to_rows(leaders));
+        }
+
+        Ok(out)
+    }
+
+    #[allow(clippy::too_many_arguments)]
     pub fn find_leaders_for_gid(
         &self,
         gid: String,
@@ -905,6 +1031,52 @@ impl NativeRangePlanner {
         let out = Array::new();
         out.push(&numbers_to_rows(coordinates, self.inner.resolution));
         out.push(&samples_to_rows(leaders));
+        Ok(out)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn plan_leaders_for_gids_batch(
+        &self,
+        gids: Array,
+        replica_counts: Array,
+        role_age_ms: f64,
+        now: String,
+        peer_filter: JsValue,
+        expand_peer_filter: bool,
+        self_hash: String,
+        include_self: bool,
+        full_replica_fallback: bool,
+        include_strict_full_replica: bool,
+    ) -> Result<Array, JsValue> {
+        let gids = strings_from_array(gids)?;
+        let replica_counts = usize_from_array(replica_counts)?;
+        ensure_same_len(gids.len(), replica_counts.len(), "gid leader batch")?;
+        let options = find_leader_options(role_age_ms, &now, peer_filter)?;
+        let mut prepared_options_by_replicas = HashMap::new();
+        let mut full_replica_leaders_by_replicas = HashMap::new();
+        let out = Array::new();
+
+        for (gid, replicas) in gids.into_iter().zip(replica_counts) {
+            let coordinates = self.inner.get_gid_coordinates(&gid, replicas);
+            let leaders = find_leaders_with_batch_caches(
+                &self.inner,
+                &coordinates,
+                replicas,
+                &options,
+                &mut prepared_options_by_replicas,
+                &mut full_replica_leaders_by_replicas,
+                expand_peer_filter,
+                &self_hash,
+                include_self,
+                full_replica_fallback,
+                include_strict_full_replica,
+            );
+            let row = Array::new();
+            row.push(&numbers_to_rows(coordinates, self.inner.resolution));
+            row.push(&samples_to_rows(leaders));
+            out.push(&row);
+        }
+
         Ok(out)
     }
 
@@ -1013,6 +1185,46 @@ fn strings_from_array(values: Array) -> Result<Vec<String>, JsValue> {
         out.push(value);
     }
     Ok(out)
+}
+
+fn usize_from_array(values: Array) -> Result<Vec<usize>, JsValue> {
+    let mut out = Vec::with_capacity(values.length() as usize);
+    for value in values.iter() {
+        let Some(value) = value.as_f64() else {
+            return Err(JsValue::from_str("Expected number array"));
+        };
+        if !value.is_finite() || value < 0.0 || value.fract() != 0.0 {
+            return Err(JsValue::from_str("Expected unsigned integer array"));
+        }
+        out.push(value as usize);
+    }
+    Ok(out)
+}
+
+fn cursor_batches_from_array(values: Array) -> Result<Vec<Vec<u64>>, JsValue> {
+    let mut out = Vec::with_capacity(values.length() as usize);
+    for value in values.iter() {
+        if !Array::is_array(&value) {
+            return Err(JsValue::from_str("Expected cursor batch array"));
+        }
+        out.push(
+            strings_from_array(Array::from(&value))?
+                .into_iter()
+                .map(|value| parse_u64(&value))
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+    }
+    Ok(out)
+}
+
+fn ensure_same_len(left: usize, right: usize, label: &str) -> Result<(), JsValue> {
+    if left == right {
+        Ok(())
+    } else {
+        Err(JsValue::from_str(&format!(
+            "Mismatched {label} input lengths"
+        )))
+    }
 }
 
 fn optional_string_set(value: JsValue) -> Result<Option<Vec<String>>, JsValue> {

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -222,6 +222,58 @@ describe("native shared-log range planner", () => {
 		});
 	});
 
+	it("finds persisted-coordinate leaders in one native batch", async () => {
+		const planner = await createRangePlanner("u32");
+		planner.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));
+		planner.put(range({ id: "b", hash: "peer-b", start1: 20, end1: 30 }));
+		planner.put(range({ id: "c", hash: "peer-c", start1: 80, end1: 90 }));
+
+		const items = [
+			{ cursors: [5], replicas: 1 },
+			{ cursors: [50, 75], replicas: 2 },
+		];
+
+		expect(
+			planner.findLeadersBatch(items, {
+				now: 1_000,
+				fullReplicaFallback: true,
+			}),
+		).to.deep.equal(
+			items.map((item) =>
+				planner.findLeaders(item.cursors, item.replicas, {
+					now: 1_000,
+					fullReplicaFallback: true,
+				}),
+			),
+		);
+	});
+
+	it("plans hash gid coordinates and leaders in one native batch", async () => {
+		const planner = await createRangePlanner("u32");
+		planner.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));
+		planner.put(range({ id: "b", hash: "peer-b", start1: 20, end1: 30 }));
+		planner.put(range({ id: "c", hash: "peer-c", start1: 80, end1: 90 }));
+
+		const items = [
+			{ gid: "entry-gid-a", replicas: 1 },
+			{ gid: "entry-gid-b", replicas: 2 },
+		];
+
+		expect(
+			planner.planLeadersForGidsBatch(items, {
+				now: 1_000,
+				fullReplicaFallback: true,
+			}),
+		).to.deep.equal(
+			items.map((item) =>
+				planner.planLeadersForGid(item.gid, item.replicas, {
+					now: 1_000,
+					fullReplicaFallback: true,
+				}),
+			),
+		);
+	});
+
 	it("expands peer filters through the combined native path", async () => {
 		const planner = await createRangePlanner("u32");
 		planner.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -3491,17 +3491,18 @@ export class SharedLog<
 				try {
 					while (!this.closed && !iterator.done()) {
 						const entries = await iterator.next(REPAIR_SWEEP_ENTRY_BATCH_SIZE);
-						for (const entry of entries) {
-							const entryReplicated = entry.value;
+						const entryReplicatedBatch = entries.map((entry) => entry.value);
+						const currentPeersBatch =
+							await this.findEntryReplicatedLeaderBatch(entryReplicatedBatch, {
+								roleAge: 0,
+						});
+						for (let i = 0; i < entryReplicatedBatch.length; i++) {
+							const entryReplicated = entryReplicatedBatch[i]!;
+							const currentPeers = currentPeersBatch[i]!;
 							const gid = entryReplicated.gid;
 							const knownPeers = this._gidPeersHistory.get(gid);
 							const requestedReplicas =
 								decodeReplicas(entryReplicated).getValue(this);
-							const currentPeers = await this.findLeaders(
-								entryReplicated.coordinates,
-								entryReplicated,
-								{ roleAge: 0 },
-							);
 
 							if (pendingModes.has("churn")) {
 								for (const [currentPeer] of currentPeers) {
@@ -6867,6 +6868,28 @@ export class SharedLog<
 		return set;
 	}
 
+	private canPlanNativeEntryLeaderBatch(
+		items: EntryLeaderBatchItem<R>[],
+	): boolean {
+		if (!this._nativeRangePlanner || items.length === 0) {
+			return false;
+		}
+
+		const first = items[0]!;
+		const firstRoleAge = first.options?.roleAge;
+		for (const item of items) {
+			if (
+				!this.canPlanNativeHashGid(item.entry) ||
+				item.options?.candidates ||
+				item.options?.onLeader ||
+				item.options?.roleAge !== firstRoleAge
+			) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 	private canPlanNativeHashGid(
 		entry: ShallowOrFullEntry<any> | EntryReplicated<R>,
 	): entry is ShallowOrFullEntry<any> | EntryReplicated<R> {
@@ -6954,8 +6977,40 @@ export class SharedLog<
 	private async planEntryLeaderBatch(
 		items: Iterable<EntryLeaderBatchItem<R>>,
 	): Promise<EntryLeaderPlan<R>[]> {
+		const itemArray = [...items];
+		const firstItem = itemArray[0];
+		if (!firstItem) {
+			return [];
+		}
+
+		if (this.canPlanNativeEntryLeaderBatch(itemArray)) {
+			const context = await this.createLeaderSelectionContext(firstItem.options);
+			const nativePlans = this._nativeRangePlanner!.planLeadersForGidsBatch(
+				itemArray.map((item) => ({
+					gid: item.entry.meta.gid as string,
+					replicas: item.replicas,
+				})),
+				this.createNativeLeaderOptions(context, firstItem.options),
+			);
+			const plans: EntryLeaderPlan<R>[] = [];
+			for (let i = 0; i < itemArray.length; i++) {
+				const item = itemArray[i]!;
+				const nativePlan = nativePlans[i]!;
+				const coordinates = nativePlan.coordinates as NumberFromType<R>[];
+				const leaders = nativePlan.leaders;
+				const isLeader = await this.applyLeaderSelection(
+					coordinates,
+					item.entry,
+					leaders,
+					item.options,
+				);
+				plans.push({ coordinates, leaders, isLeader });
+			}
+			return plans;
+		}
+
 		const plans: EntryLeaderPlan<R>[] = [];
-		for (const item of items) {
+		for (const item of itemArray) {
 			plans.push(
 				await this.planEntryLeaders(item.entry, item.replicas, item.options),
 			);
@@ -7215,6 +7270,35 @@ export class SharedLog<
 		}
 
 		return leaders.size > 0 ? leaders : undefined;
+	}
+
+	private async findEntryReplicatedLeaderBatch(
+		entries: EntryReplicated<R>[],
+		options?: {
+			roleAge?: number;
+			candidates?: Iterable<string>;
+		},
+	): Promise<LeaderMap[]> {
+		if (entries.length === 0) {
+			return [];
+		}
+
+		if (this._nativeRangePlanner) {
+			const context = await this.createLeaderSelectionContext(options);
+			return this._nativeRangePlanner.findLeadersBatch(
+				entries.map((entry) => ({
+					cursors: entry.coordinates,
+					replicas: entry.coordinates.length,
+				})),
+				this.createNativeLeaderOptions(context, options),
+			);
+		}
+
+		const leaders: LeaderMap[] = [];
+		for (const entry of entries) {
+			leaders.push(await this._findLeaders(entry.coordinates, options));
+		}
+		return leaders;
 	}
 
 	private async _findLeadersFromHashGid(


### PR DESCRIPTION
## Summary
- add Rust/WASM batch leader APIs for persisted coordinates and hash gid coordinate+leader plans
- cache derived native leader inputs per replica count within each batch
- wire shared-log repair sweeps through the persisted-coordinate batch API
- upgrade the internal entry leader batch abstraction to use the native gid batch path when options are safe to batch

## Validation
- pnpm --filter @peerbit/shared-log-rust run test
- pnpm --filter @peerbit/shared-log-rust run lint
- pnpm --filter @peerbit/shared-log run build
- pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/index.ts
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "leader are selected from 1 replicating peer"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "settles towards the current replicators"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "will prune on put 300 after join"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "pending IHave|shallow-only entry"

## Benchmark Signal
Local Node microbench through WASM, 256-entry batches, 512 native ranges:
- persisted-coordinate leader plan: single 38,255 entries/sec, batch 38,782 entries/sec, 1.01x
- gid coordinate+leader plan: single 312,155 entries/sec, batch 376,269 entries/sec, 1.21x

Small-index call-boundary microbench, 512-entry batches, 2 native ranges:
- persisted-coordinate leader plan: single 833,013 entries/sec, batch 940,125 entries/sec, 1.13x
- gid coordinate+leader plan: single 682,253 entries/sec, batch 757,561 entries/sec, 1.11x

Note: package-wide `pnpm --filter @peerbit/shared-log run lint` still fails on existing unrelated style debt in files such as blocks.ts, cpu.ts, and exchange-heads.ts; changed shared-log index.ts passes direct eslint.