### PR TITLE
feat: plan shared-log repair dispatch natively

### DIFF
--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -64,6 +64,46 @@ export type LeaderGidBatchInput = {
 	replicas: number;
 };
 
+export type RepairDispatchBatchEntry = {
+	hash: string;
+	gid: string;
+	requestedReplicas: number;
+	currentLeaders: Iterable<string>;
+	knownGidPeers?: Iterable<string>;
+	knownEntryPeers?: Iterable<string>;
+};
+
+export type RepairDispatchEntryPlanBatchEntry = {
+	hash: string;
+	gid: string;
+	requestedReplicas: number;
+	coordinates: Iterable<bigint | number | string>;
+	knownGidPeers?: Iterable<string>;
+	knownEntryPeers?: Iterable<string>;
+};
+
+export type RepairDispatchPlanInput = {
+	entries: Iterable<RepairDispatchBatchEntry>;
+	pendingModes: Iterable<string>;
+	pendingPeersByMode: ReadonlyMap<string, Iterable<string>>;
+	optimisticPeersByMode?: ReadonlyMap<
+		string,
+		ReadonlyMap<string, Iterable<string>>
+	>;
+	fullReplicaRepairCandidates?: Iterable<string>;
+	fullReplicaRepairCandidateCount: number;
+	selfHash: string;
+};
+
+export type RepairDispatchEntryPlanInput = Omit<
+	RepairDispatchPlanInput,
+	"entries"
+> & {
+	entries: Iterable<RepairDispatchEntryPlanBatchEntry>;
+};
+
+export type RepairDispatchPlan = Map<string, Map<string, string[]>>;
+
 type NativeRangePlannerHandle = {
 	len: () => number;
 	clear: () => void;
@@ -138,6 +178,41 @@ type NativeRangePlannerHandle = {
 	plan_leaders_for_gids_batch: (
 		gids: string[],
 		replicaCounts: number[],
+		roleAgeMs: number,
+		now: string,
+		peerFilter: string[] | undefined,
+		expandPeerFilter: boolean,
+		selfHash: string,
+		includeSelf: boolean,
+		fullReplicaFallback: boolean,
+		includeStrictFullReplica: boolean,
+	) => unknown[];
+	plan_repair_dispatch: (
+		entryHashes: string[],
+		entryGids: string[],
+		entryRequestedReplicas: number[],
+		currentLeaderBatches: string[][],
+		knownGidPeerBatches: string[][],
+		knownEntryPeerBatches: string[][],
+		pendingModes: string[],
+		pendingPeersByMode: string[][],
+		optimisticPeersByMode: string[][][],
+		fullReplicaRepairCandidates: string[],
+		fullReplicaRepairCandidateCount: number,
+		selfHash: string,
+	) => unknown[];
+	plan_repair_dispatch_for_entries: (
+		entryHashes: string[],
+		entryGids: string[],
+		entryRequestedReplicas: number[],
+		entryCoordinateBatches: string[][],
+		knownGidPeerBatches: string[][],
+		knownEntryPeerBatches: string[][],
+		pendingModes: string[],
+		pendingPeersByMode: string[][],
+		optimisticPeersByMode: string[][][],
+		fullReplicaRepairCandidates: string[],
+		fullReplicaRepairCandidateCount: number,
 		roleAgeMs: number,
 		now: string,
 		peerFilter: string[] | undefined,
@@ -397,6 +472,100 @@ export class SharedLogRangePlanner {
 				leaders: rowsToSamples(leaderRows),
 			};
 		});
+	}
+
+	planRepairDispatchBatch(input: RepairDispatchPlanInput): RepairDispatchPlan {
+		const entries = [...input.entries];
+		const pendingModes = [...input.pendingModes];
+		const rows = this.native.plan_repair_dispatch(
+			entries.map((entry) => entry.hash),
+			entries.map((entry) => entry.gid),
+			entries.map((entry) => entry.requestedReplicas),
+			entries.map((entry) => [...entry.currentLeaders]),
+			entries.map((entry) =>
+				entry.knownGidPeers ? [...entry.knownGidPeers] : [],
+			),
+			entries.map((entry) =>
+				entry.knownEntryPeers ? [...entry.knownEntryPeers] : [],
+			),
+			pendingModes,
+			pendingModes.map((mode) => [
+				...(input.pendingPeersByMode.get(mode) ?? []),
+			]),
+			pendingModes.map((mode) => {
+				const optimisticByGid = input.optimisticPeersByMode?.get(mode);
+				return entries.map((entry) => [
+					...(optimisticByGid?.get(entry.gid) ?? []),
+				]);
+			}),
+			input.fullReplicaRepairCandidates
+				? [...input.fullReplicaRepairCandidates]
+				: [],
+			input.fullReplicaRepairCandidateCount,
+			input.selfHash,
+		);
+
+		const plan: RepairDispatchPlan = new Map();
+		for (const row of rows) {
+			const [mode, target, hashes] = row as [string, string, string[]];
+			let targets = plan.get(mode);
+			if (!targets) {
+				targets = new Map();
+				plan.set(mode, targets);
+			}
+			targets.set(target, hashes);
+		}
+		return plan;
+	}
+
+	planRepairDispatchForEntries(
+		input: RepairDispatchEntryPlanInput,
+		options?: FindLeaderOptions,
+	): RepairDispatchPlan {
+		const entries = [...input.entries];
+		const pendingModes = [...input.pendingModes];
+		const rows = this.native.plan_repair_dispatch_for_entries(
+			entries.map((entry) => entry.hash),
+			entries.map((entry) => entry.gid),
+			entries.map((entry) => entry.requestedReplicas),
+			entries.map((entry) => [...entry.coordinates].map(asIntegerString)),
+			entries.map((entry) =>
+				entry.knownGidPeers ? [...entry.knownGidPeers] : [],
+			),
+			entries.map((entry) =>
+				entry.knownEntryPeers ? [...entry.knownEntryPeers] : [],
+			),
+			pendingModes,
+			pendingModes.map((mode) => [
+				...(input.pendingPeersByMode.get(mode) ?? []),
+			]),
+			pendingModes.map((mode) => {
+				const optimisticByGid = input.optimisticPeersByMode?.get(mode);
+				return entries.map((entry) => [
+					...(optimisticByGid?.get(entry.gid) ?? []),
+				]);
+			}),
+			input.fullReplicaRepairCandidates
+				? [...input.fullReplicaRepairCandidates]
+				: [],
+			input.fullReplicaRepairCandidateCount,
+			...this.findLeaderArguments({
+				...options,
+				selfHash: input.selfHash,
+			}),
+		);
+
+		const plan: RepairDispatchPlan = new Map();
+		for (const row of rows) {
+			const [mode, target, hashes] = row as [string, string, string[]];
+			let targets = plan.get(mode);
+			if (!targets) {
+				targets = new Map();
+				plan.set(mode, targets);
+			}
+			targets.set(target, hashes);
+		}
+		return plan;
 	}
 
 	getFullReplicaLeaders(

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -824,6 +824,118 @@ fn find_leaders_with_batch_caches(
     find_leaders_with_prepared_options(planner, cursors, replicas, prepared_options, false, true)
 }
 
+struct RepairDispatchBatch {
+    entry_hashes: Vec<String>,
+    entry_gids: Vec<String>,
+    entry_requested_replicas: Vec<usize>,
+    current_leader_batches: Vec<Vec<String>>,
+    known_gid_peer_batches: Vec<Vec<String>>,
+    known_entry_peer_batches: Vec<Vec<String>>,
+    pending_modes: Vec<String>,
+    pending_peers_by_mode: Vec<Vec<String>>,
+    optimistic_peers_by_mode: Vec<Vec<Vec<String>>>,
+    full_replica_repair_candidates: HashSet<String>,
+    full_replica_repair_candidate_count: usize,
+    self_hash: String,
+}
+
+fn plan_repair_dispatch_rows(batch: RepairDispatchBatch) -> Result<Array, JsValue> {
+    let entry_count = batch.entry_hashes.len();
+
+    ensure_same_len(entry_count, batch.entry_gids.len(), "repair entry gid")?;
+    ensure_same_len(
+        entry_count,
+        batch.entry_requested_replicas.len(),
+        "repair entry replica",
+    )?;
+    ensure_same_len(
+        entry_count,
+        batch.current_leader_batches.len(),
+        "repair current leader",
+    )?;
+    ensure_same_len(
+        entry_count,
+        batch.known_gid_peer_batches.len(),
+        "repair known gid peer",
+    )?;
+    ensure_same_len(
+        entry_count,
+        batch.known_entry_peer_batches.len(),
+        "repair known entry peer",
+    )?;
+    ensure_same_len(
+        batch.pending_modes.len(),
+        batch.pending_peers_by_mode.len(),
+        "repair pending peer mode",
+    )?;
+    ensure_same_len(
+        batch.pending_modes.len(),
+        batch.optimistic_peers_by_mode.len(),
+        "repair optimistic mode",
+    )?;
+    for optimistic_entries in &batch.optimistic_peers_by_mode {
+        ensure_same_len(
+            entry_count,
+            optimistic_entries.len(),
+            "repair optimistic entry",
+        )?;
+    }
+
+    let has_churn = batch.pending_modes.iter().any(|mode| mode == "churn");
+    let mut planned: IndexMap<(String, String), IndexSet<String>> = IndexMap::new();
+
+    for i in 0..entry_count {
+        let hash = &batch.entry_hashes[i];
+        let current_leaders = &batch.current_leader_batches[i];
+        let known_gid_peers = &batch.known_gid_peer_batches[i];
+        let known_entry_peers = &batch.known_entry_peer_batches[i];
+
+        if has_churn {
+            for peer in current_leaders {
+                if peer == &batch.self_hash {
+                    continue;
+                }
+                add_repair_dispatch(&mut planned, "churn", peer, hash);
+            }
+        }
+
+        for (mode_index, mode) in batch.pending_modes.iter().enumerate() {
+            let optimistic_peers = &batch.optimistic_peers_by_mode[mode_index][i];
+            for peer in &batch.pending_peers_by_mode[mode_index] {
+                if contains_string(known_entry_peers, peer) {
+                    continue;
+                }
+                let is_current_leader = contains_string(current_leaders, peer);
+                let was_optimistically_assigned = contains_string(optimistic_peers, peer);
+                let is_covered_by_full_replica_repair = mode == "join-authoritative"
+                    && batch.entry_requested_replicas[i]
+                        >= batch.full_replica_repair_candidate_count
+                    && batch.full_replica_repair_candidates.contains(peer.as_str());
+                let should_queue = if mode == "join-authoritative" {
+                    is_current_leader || is_covered_by_full_replica_repair
+                } else {
+                    was_optimistically_assigned
+                        || (is_current_leader && !contains_string(known_gid_peers, peer))
+                };
+
+                if should_queue {
+                    add_repair_dispatch(&mut planned, mode, peer, hash);
+                }
+            }
+        }
+    }
+
+    let out = Array::new();
+    for ((mode, target), hashes) in planned {
+        let row = Array::new();
+        row.push(&JsValue::from_str(&mode));
+        row.push(&JsValue::from_str(&target));
+        row.push(&strings_to_array(hashes.into_iter().collect()));
+        out.push(&row);
+    }
+    Ok(out)
+}
+
 #[wasm_bindgen]
 pub struct NativeRangePlanner {
     inner: RangePlanner,
@@ -1080,6 +1192,131 @@ impl NativeRangePlanner {
         Ok(out)
     }
 
+    pub fn plan_repair_dispatch(
+        &self,
+        entry_hashes: Array,
+        entry_gids: Array,
+        entry_requested_replicas: Array,
+        current_leader_batches: Array,
+        known_gid_peer_batches: Array,
+        known_entry_peer_batches: Array,
+        pending_modes: Array,
+        pending_peers_by_mode: Array,
+        optimistic_peers_by_mode: Array,
+        full_replica_repair_candidates: Array,
+        full_replica_repair_candidate_count: usize,
+        self_hash: String,
+    ) -> Result<Array, JsValue> {
+        plan_repair_dispatch_rows(RepairDispatchBatch {
+            entry_hashes: strings_from_array(entry_hashes)?,
+            entry_gids: strings_from_array(entry_gids)?,
+            entry_requested_replicas: usize_from_array(entry_requested_replicas)?,
+            current_leader_batches: string_batches_from_array(
+                current_leader_batches,
+                "current leader batches",
+            )?,
+            known_gid_peer_batches: string_batches_from_array(
+                known_gid_peer_batches,
+                "known gid peer batches",
+            )?,
+            known_entry_peer_batches: string_batches_from_array(
+                known_entry_peer_batches,
+                "known entry peer batches",
+            )?,
+            pending_modes: strings_from_array(pending_modes)?,
+            pending_peers_by_mode: string_batches_from_array(
+                pending_peers_by_mode,
+                "pending peers by mode",
+            )?,
+            optimistic_peers_by_mode: string_matrix_from_array(
+                optimistic_peers_by_mode,
+                "optimistic peers by mode",
+            )?,
+            full_replica_repair_candidates: HashSet::<String>::from_iter(strings_from_array(
+                full_replica_repair_candidates,
+            )?),
+            full_replica_repair_candidate_count,
+            self_hash,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn plan_repair_dispatch_for_entries(
+        &self,
+        entry_hashes: Array,
+        entry_gids: Array,
+        entry_requested_replicas: Array,
+        entry_coordinate_batches: Array,
+        known_gid_peer_batches: Array,
+        known_entry_peer_batches: Array,
+        pending_modes: Array,
+        pending_peers_by_mode: Array,
+        optimistic_peers_by_mode: Array,
+        full_replica_repair_candidates: Array,
+        full_replica_repair_candidate_count: usize,
+        role_age_ms: f64,
+        now: String,
+        peer_filter: JsValue,
+        expand_peer_filter: bool,
+        self_hash: String,
+        include_self: bool,
+        full_replica_fallback: bool,
+        include_strict_full_replica: bool,
+    ) -> Result<Array, JsValue> {
+        let entry_coordinate_batches = cursor_batches_from_array(entry_coordinate_batches)?;
+        let options = find_leader_options(role_age_ms, &now, peer_filter)?;
+        let mut prepared_options_by_replicas = HashMap::new();
+        let mut full_replica_leaders_by_replicas = HashMap::new();
+        let mut current_leader_batches = Vec::with_capacity(entry_coordinate_batches.len());
+
+        for coordinates in &entry_coordinate_batches {
+            let replicas = coordinates.len();
+            let leaders = find_leaders_with_batch_caches(
+                &self.inner,
+                coordinates,
+                replicas,
+                &options,
+                &mut prepared_options_by_replicas,
+                &mut full_replica_leaders_by_replicas,
+                expand_peer_filter,
+                &self_hash,
+                include_self,
+                full_replica_fallback,
+                include_strict_full_replica,
+            );
+            current_leader_batches.push(leaders.into_iter().map(|leader| leader.hash).collect());
+        }
+
+        plan_repair_dispatch_rows(RepairDispatchBatch {
+            entry_hashes: strings_from_array(entry_hashes)?,
+            entry_gids: strings_from_array(entry_gids)?,
+            entry_requested_replicas: usize_from_array(entry_requested_replicas)?,
+            current_leader_batches,
+            known_gid_peer_batches: string_batches_from_array(
+                known_gid_peer_batches,
+                "known gid peer batches",
+            )?,
+            known_entry_peer_batches: string_batches_from_array(
+                known_entry_peer_batches,
+                "known entry peer batches",
+            )?,
+            pending_modes: strings_from_array(pending_modes)?,
+            pending_peers_by_mode: string_batches_from_array(
+                pending_peers_by_mode,
+                "pending peers by mode",
+            )?,
+            optimistic_peers_by_mode: string_matrix_from_array(
+                optimistic_peers_by_mode,
+                "optimistic peers by mode",
+            )?,
+            full_replica_repair_candidates: HashSet::<String>::from_iter(strings_from_array(
+                full_replica_repair_candidates,
+            )?),
+            full_replica_repair_candidate_count,
+            self_hash,
+        })
+    }
+
     pub fn get_grid(&self, from: String, count: usize) -> Result<Array, JsValue> {
         Ok(numbers_to_rows(
             self.inner.get_grid(parse_u64(&from)?, count),
@@ -1187,6 +1424,28 @@ fn strings_from_array(values: Array) -> Result<Vec<String>, JsValue> {
     Ok(out)
 }
 
+fn string_batches_from_array(values: Array, label: &str) -> Result<Vec<Vec<String>>, JsValue> {
+    let mut out = Vec::with_capacity(values.length() as usize);
+    for value in values.iter() {
+        if !Array::is_array(&value) {
+            return Err(JsValue::from_str(&format!("Expected {label}")));
+        }
+        out.push(strings_from_array(Array::from(&value))?);
+    }
+    Ok(out)
+}
+
+fn string_matrix_from_array(values: Array, label: &str) -> Result<Vec<Vec<Vec<String>>>, JsValue> {
+    let mut out = Vec::with_capacity(values.length() as usize);
+    for value in values.iter() {
+        if !Array::is_array(&value) {
+            return Err(JsValue::from_str(&format!("Expected {label}")));
+        }
+        out.push(string_batches_from_array(Array::from(&value), label)?);
+    }
+    Ok(out)
+}
+
 fn usize_from_array(values: Array) -> Result<Vec<usize>, JsValue> {
     let mut out = Vec::with_capacity(values.length() as usize);
     for value in values.iter() {
@@ -1202,13 +1461,11 @@ fn usize_from_array(values: Array) -> Result<Vec<usize>, JsValue> {
 }
 
 fn cursor_batches_from_array(values: Array) -> Result<Vec<Vec<u64>>, JsValue> {
-    let mut out = Vec::with_capacity(values.length() as usize);
-    for value in values.iter() {
-        if !Array::is_array(&value) {
-            return Err(JsValue::from_str("Expected cursor batch array"));
-        }
+    let batches = string_batches_from_array(values, "cursor batch array")?;
+    let mut out = Vec::with_capacity(batches.len());
+    for batch in batches {
         out.push(
-            strings_from_array(Array::from(&value))?
+            batch
                 .into_iter()
                 .map(|value| parse_u64(&value))
                 .collect::<Result<Vec<_>, _>>()?,
@@ -1225,6 +1482,22 @@ fn ensure_same_len(left: usize, right: usize, label: &str) -> Result<(), JsValue
             "Mismatched {label} input lengths"
         )))
     }
+}
+
+fn add_repair_dispatch(
+    planned: &mut IndexMap<(String, String), IndexSet<String>>,
+    mode: &str,
+    target: &str,
+    hash: &str,
+) {
+    planned
+        .entry((mode.to_string(), target.to_string()))
+        .or_default()
+        .insert(hash.to_string());
+}
+
+fn contains_string(values: &[String], target: &str) -> bool {
+    values.iter().any(|value| value == target)
 }
 
 fn optional_string_set(value: JsValue) -> Result<Option<Vec<String>>, JsValue> {

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -274,6 +274,101 @@ describe("native shared-log range planner", () => {
 		);
 	});
 
+	it("plans repair dispatch targets in one native batch", async () => {
+		const planner = await createRangePlanner("u32");
+
+		expect(
+			planner.planRepairDispatchBatch({
+				entries: [
+					{
+						hash: "entry-a",
+						gid: "gid-a",
+						requestedReplicas: 2,
+						currentLeaders: ["peer-a", "peer-b"],
+						knownGidPeers: ["peer-b"],
+						knownEntryPeers: ["peer-known"],
+					},
+					{
+						hash: "entry-b",
+						gid: "gid-b",
+						requestedReplicas: 1,
+						currentLeaders: ["peer-self", "peer-c"],
+					},
+				],
+				pendingModes: ["churn", "join-authoritative"],
+				pendingPeersByMode: new Map([
+					["churn", ["peer-a", "peer-c", "peer-optimistic"]],
+					["join-authoritative", ["peer-a", "peer-full", "peer-known"]],
+				]),
+				optimisticPeersByMode: new Map([
+					[
+						"churn",
+						new Map([
+							["gid-a", ["peer-optimistic"]],
+							["gid-b", []],
+						]),
+					],
+				]),
+				fullReplicaRepairCandidates: ["peer-full"],
+				fullReplicaRepairCandidateCount: 2,
+				selfHash: "peer-self",
+			}),
+		).to.deep.equal(
+			new Map([
+				[
+					"churn",
+					new Map([
+						["peer-a", ["entry-a"]],
+						["peer-b", ["entry-a"]],
+						["peer-optimistic", ["entry-a"]],
+						["peer-c", ["entry-b"]],
+					]),
+				],
+				[
+					"join-authoritative",
+					new Map([
+						["peer-a", ["entry-a"]],
+						["peer-full", ["entry-a"]],
+					]),
+				],
+			]),
+		);
+	});
+
+	it("plans repair dispatch from native leader selection", async () => {
+		const planner = await createRangePlanner("u32");
+		planner.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));
+		planner.put(range({ id: "b", hash: "peer-b", start1: 20, end1: 30 }));
+
+		expect(
+			planner.planRepairDispatchForEntries(
+				{
+					entries: [
+						{
+							hash: "entry-a",
+							gid: "gid-a",
+							requestedReplicas: 1,
+							coordinates: [5],
+						},
+					],
+					pendingModes: ["churn", "join-authoritative"],
+					pendingPeersByMode: new Map([
+						["churn", ["peer-a"]],
+						["join-authoritative", ["peer-a", "peer-b"]],
+					]),
+					fullReplicaRepairCandidateCount: 1,
+					selfHash: "peer-self",
+				},
+				{ now: 1_000 },
+			),
+		).to.deep.equal(
+			new Map([
+				["churn", new Map([["peer-a", ["entry-a"]]])],
+				["join-authoritative", new Map([["peer-a", ["entry-a"]]])],
+			]),
+		);
+	});
+
 	it("expands peer filters through the combined native path", async () => {
 		const planner = await createRangePlanner("u32");
 		planner.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -3492,54 +3492,28 @@ export class SharedLog<
 					while (!this.closed && !iterator.done()) {
 						const entries = await iterator.next(REPAIR_SWEEP_ENTRY_BATCH_SIZE);
 						const entryReplicatedBatch = entries.map((entry) => entry.value);
-						const currentPeersBatch =
-							await this.findEntryReplicatedLeaderBatch(entryReplicatedBatch, {
-								roleAge: 0,
+						const requestedReplicasBatch = entryReplicatedBatch.map((entry) =>
+							decodeReplicas(entry).getValue(this),
+						);
+						const repairDispatchPlan = await this.planRepairDispatchBatch({
+							entries: entryReplicatedBatch,
+							requestedReplicasBatch,
+							pendingModes,
+							pendingPeersByMode,
+							optimisticGidPeersByMode,
+							fullReplicaRepairCandidates,
+							fullReplicaRepairCandidateCount,
+							selfHash: this.node.identity.publicKey.hashcode(),
 						});
-						for (let i = 0; i < entryReplicatedBatch.length; i++) {
-							const entryReplicated = entryReplicatedBatch[i]!;
-							const currentPeers = currentPeersBatch[i]!;
-							const gid = entryReplicated.gid;
-							const knownPeers = this._gidPeersHistory.get(gid);
-							const requestedReplicas =
-								decodeReplicas(entryReplicated).getValue(this);
-
-							if (pendingModes.has("churn")) {
-								for (const [currentPeer] of currentPeers) {
-									if (currentPeer === this.node.identity.publicKey.hashcode()) {
-										continue;
-									}
-									queueEntryForTarget("churn", currentPeer, entryReplicated);
-								}
-							}
-
-							for (const mode of pendingModes) {
-								const modePeers = pendingPeersByMode.get(mode);
-								if (!modePeers || modePeers.size === 0) {
-									continue;
-								}
-								const optimisticPeers = optimisticGidPeersByMode.get(mode)?.get(gid);
-								for (const peer of modePeers) {
-									if (this.isEntryKnownByPeer(entryReplicated.hash, peer)) {
-										continue;
-									}
-									const wasOptimisticallyAssigned =
-										optimisticPeers?.has(peer) === true;
-									const isCoveredByFullReplicaRepair =
-										mode === "join-authoritative" &&
-										fullReplicaRepairCandidates.has(peer) &&
-										requestedReplicas >= fullReplicaRepairCandidateCount;
-									const shouldQueue =
-										mode === "join-authoritative"
-											? currentPeers.has(peer) || isCoveredByFullReplicaRepair
-											: wasOptimisticallyAssigned ||
-											  (currentPeers.has(peer) && !knownPeers?.has(peer));
-									if (shouldQueue) {
-										// Authoritative join repair must not trust partial gid peer history,
-										// otherwise a late joiner can get stuck with a partial historical
-										// backfill forever. Once we enter the authoritative pass, queue every
-										// entry whose current leader set still includes the added peer.
-										queueEntryForTarget(mode, peer, entryReplicated);
+						const entriesByHash = new Map(
+							entryReplicatedBatch.map((entry) => [entry.hash, entry]),
+						);
+						for (const [mode, targets] of repairDispatchPlan) {
+							for (const [target, hashes] of targets) {
+								for (const hash of hashes) {
+									const entry = entriesByHash.get(hash);
+									if (entry) {
+										queueEntryForTarget(mode, target, entry);
 									}
 								}
 							}
@@ -7299,6 +7273,138 @@ export class SharedLog<
 			leaders.push(await this._findLeaders(entry.coordinates, options));
 		}
 		return leaders;
+	}
+
+	private async planRepairDispatchBatch(properties: {
+		entries: EntryReplicated<R>[];
+		requestedReplicasBatch: number[];
+		pendingModes: Set<RepairDispatchMode>;
+		pendingPeersByMode: Map<RepairDispatchMode, Set<string>>;
+		optimisticGidPeersByMode: Map<RepairDispatchMode, Map<string, Set<string>>>;
+		fullReplicaRepairCandidates: Set<string>;
+		fullReplicaRepairCandidateCount: number;
+		selfHash: string;
+	}): Promise<Map<RepairDispatchMode, Map<string, string[]>>> {
+		const add = (
+			plan: Map<RepairDispatchMode, Map<string, string[]>>,
+			mode: RepairDispatchMode,
+			target: string,
+			hash: string,
+		) => {
+			let targets = plan.get(mode);
+			if (!targets) {
+				targets = new Map();
+				plan.set(mode, targets);
+			}
+			let hashes = targets.get(target);
+			if (!hashes) {
+				hashes = [];
+				targets.set(target, hashes);
+			}
+			if (!hashes.includes(hash)) {
+				hashes.push(hash);
+			}
+		};
+
+		if (this._nativeRangePlanner) {
+			const pendingPeersByMode = new Map<string, Iterable<string>>();
+			const optimisticPeersByMode = new Map<
+				string,
+				Map<string, Iterable<string>>
+			>();
+			for (const mode of properties.pendingModes) {
+				pendingPeersByMode.set(
+					mode,
+					properties.pendingPeersByMode.get(mode) ?? [],
+				);
+				const optimisticByGid = properties.optimisticGidPeersByMode.get(mode);
+				if (optimisticByGid) {
+					const optimisticEntries = new Map<string, Iterable<string>>();
+					for (const [gid, peers] of optimisticByGid) {
+						optimisticEntries.set(gid, peers);
+					}
+					optimisticPeersByMode.set(mode, optimisticEntries);
+				}
+			}
+
+			const context = await this.createLeaderSelectionContext({ roleAge: 0 });
+			const nativePlan = this._nativeRangePlanner.planRepairDispatchForEntries(
+				{
+					entries: properties.entries.map((entry, i) => ({
+						hash: entry.hash,
+						gid: entry.gid,
+						requestedReplicas: properties.requestedReplicasBatch[i]!,
+						coordinates: entry.coordinates,
+						knownGidPeers: this._gidPeersHistory.get(entry.gid),
+						knownEntryPeers: this._entryKnownPeers.get(entry.hash),
+					})),
+					pendingModes: properties.pendingModes,
+					pendingPeersByMode,
+					optimisticPeersByMode,
+					fullReplicaRepairCandidates: properties.fullReplicaRepairCandidates,
+					fullReplicaRepairCandidateCount:
+						properties.fullReplicaRepairCandidateCount,
+					selfHash: properties.selfHash,
+				},
+				this.createNativeLeaderOptions(context),
+			);
+
+			const plan = new Map<RepairDispatchMode, Map<string, string[]>>();
+			for (const [mode, targets] of nativePlan) {
+				plan.set(mode as RepairDispatchMode, targets);
+			}
+			return plan;
+		}
+
+		const currentPeersBatch = await this.findEntryReplicatedLeaderBatch(
+			properties.entries,
+			{ roleAge: 0 },
+		);
+		const plan = new Map<RepairDispatchMode, Map<string, string[]>>();
+		for (let i = 0; i < properties.entries.length; i++) {
+			const entry = properties.entries[i]!;
+			const currentPeers = currentPeersBatch[i]!;
+			const requestedReplicas = properties.requestedReplicasBatch[i]!;
+			const knownPeers = this._gidPeersHistory.get(entry.gid);
+
+			if (properties.pendingModes.has("churn")) {
+				for (const [currentPeer] of currentPeers) {
+					if (currentPeer !== properties.selfHash) {
+						add(plan, "churn", currentPeer, entry.hash);
+					}
+				}
+			}
+
+			for (const mode of properties.pendingModes) {
+				const modePeers = properties.pendingPeersByMode.get(mode);
+				if (!modePeers || modePeers.size === 0) {
+					continue;
+				}
+				const optimisticPeers = properties.optimisticGidPeersByMode
+					.get(mode)
+					?.get(entry.gid);
+				for (const peer of modePeers) {
+					if (this.isEntryKnownByPeer(entry.hash, peer)) {
+						continue;
+					}
+					const wasOptimisticallyAssigned =
+						optimisticPeers?.has(peer) === true;
+					const isCoveredByFullReplicaRepair =
+						mode === "join-authoritative" &&
+						properties.fullReplicaRepairCandidates.has(peer) &&
+						requestedReplicas >= properties.fullReplicaRepairCandidateCount;
+					const shouldQueue =
+						mode === "join-authoritative"
+							? currentPeers.has(peer) || isCoveredByFullReplicaRepair
+							: wasOptimisticallyAssigned ||
+							  (currentPeers.has(peer) && !knownPeers?.has(peer));
+					if (shouldQueue) {
+						add(plan, mode, peer, entry.hash);
+					}
+				}
+			}
+		}
+		return plan;
 	}
 
 	private async _findLeadersFromHashGid(


### PR DESCRIPTION
## Summary
- add Rust/WASM repair dispatch planning APIs
- add a combined native repair path that computes leaders and dispatch targets in one Rust call
- wire shared-log repair sweeps through the combined native planner when the range planner is available
- keep the existing TypeScript fallback for non-native execution

## Validation
- pnpm --filter @peerbit/shared-log-rust run test
- pnpm --filter @peerbit/shared-log-rust run lint
- pnpm --filter @peerbit/shared-log run build
- pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/index.ts
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "settles towards the current replicators"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "will prune on put 300 after join"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "pending IHave|shallow-only entry"

## Benchmark Signal
Local Node synthetic repair planner bench through WASM, comparing the previous #835 shape (native leader batch + JS repair dispatch) against this PR (native leader+dispatch in one call):
- 512 entries / 96 peers / 3 modes: previous 21,224 entries/sec, native 20,879 entries/sec, 0.98x
- 512 entries / 12 peers / 2 modes: previous 134,105 entries/sec, native 131,668 entries/sec, 0.98x

So this is a structural native-path PR rather than a standalone throughput win. The repair sweep no longer round-trips leader maps through JS before dispatch planning, but the current WASM string-marshalling cost keeps the microbench at roughly parity.