### PR TITLE
feat: add resident native shared-log state

### DIFF
--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -241,10 +241,50 @@ type NativeRangePlannerHandle = {
 	get_gid_coordinates: (gid: string, count: number) => unknown[];
 };
 
+type NativeSharedLogStateHandle = {
+	len: () => number;
+	clear: () => void;
+	put: NativeRangePlannerHandle["put"];
+	delete: NativeRangePlannerHandle["delete"];
+	put_entry_coordinates: (hash: string, coordinates: string[]) => void;
+	delete_entry_coordinates: (hash: string) => boolean;
+	delete_entry_coordinates_batch: (hashes: string[]) => void;
+	clear_entry_coordinates: () => void;
+	add_gid_peers: (gid: string, peers: string[], reset: boolean) => number;
+	remove_gid_peer: (peer: string, gid?: string) => void;
+	delete_gid_peers: (gid: string) => boolean;
+	clear_gid_peers: () => void;
+	mark_entries_known_by_peer: (hashes: string[], peer: string) => void;
+	remove_entries_known_by_peer: (hashes: string[], peer: string) => void;
+	remove_peer_from_entry_known_peers: (peer: string) => void;
+	clear_entry_known_peers: () => void;
+	plan_entry_leaders_for_gid: NativeRangePlannerHandle["plan_leaders_for_gid"];
+	plan_repair_dispatch_for_entries: (
+		entryHashes: string[],
+		entryGids: string[],
+		entryRequestedReplicas: number[],
+		entryCoordinateBatches: string[][],
+		pendingModes: string[],
+		pendingPeersByMode: string[][],
+		optimisticPeersByMode: string[][][],
+		fullReplicaRepairCandidates: string[],
+		fullReplicaRepairCandidateCount: number,
+		roleAgeMs: number,
+		now: string,
+		peerFilter: string[] | undefined,
+		expandPeerFilter: boolean,
+		selfHash: string,
+		includeSelf: boolean,
+		fullReplicaFallback: boolean,
+		includeStrictFullReplica: boolean,
+	) => unknown[];
+};
+
 type WasmModule = {
 	default: (input?: unknown) => Promise<unknown>;
 	initSync: (input?: unknown) => unknown;
 	NativeRangePlanner: new (resolution: string) => NativeRangePlannerHandle;
+	NativeSharedLogState: new (resolution: string) => NativeSharedLogStateHandle;
 };
 
 let wasmModulePromise: Promise<WasmModule> | undefined;
@@ -309,6 +349,40 @@ const rowsToNumbers = (
 		return resolution === "u64" ? BigInt(value) : Number(value);
 	});
 
+const findLeaderArguments = (options?: FindLeaderOptions): [
+	number,
+	string,
+	string[] | undefined,
+	boolean,
+	string,
+	boolean,
+	boolean,
+	boolean,
+] => [
+	options?.roleAge ?? 0,
+	asIntegerString(options?.now ?? Date.now()),
+	options?.peerFilter ? [...options.peerFilter] : undefined,
+	options?.expandPeerFilter === true,
+	options?.selfHash ?? "",
+	options?.selfReplicating === true,
+	options?.fullReplicaFallback === true,
+	options?.includeStrictFullReplica !== false,
+];
+
+const rowsToRepairDispatchPlan = (rows: unknown[]): RepairDispatchPlan => {
+	const plan: RepairDispatchPlan = new Map();
+	for (const row of rows) {
+		const [mode, target, hashes] = row as [string, string, string[]];
+		let targets = plan.get(mode);
+		if (!targets) {
+			targets = new Map();
+			plan.set(mode, targets);
+		}
+		targets.set(target, hashes);
+	}
+	return plan;
+};
+
 export class SharedLogRangePlanner {
 	private constructor(
 		private readonly native: NativeRangePlannerHandle,
@@ -366,28 +440,6 @@ export class SharedLogRangePlanner {
 		return rowsToSamples(rows);
 	}
 
-	private findLeaderArguments(options?: FindLeaderOptions): [
-		number,
-		string,
-		string[] | undefined,
-		boolean,
-		string,
-		boolean,
-		boolean,
-		boolean,
-	] {
-		return [
-			options?.roleAge ?? 0,
-			asIntegerString(options?.now ?? Date.now()),
-			options?.peerFilter ? [...options.peerFilter] : undefined,
-			options?.expandPeerFilter === true,
-			options?.selfHash ?? "",
-			options?.selfReplicating === true,
-			options?.fullReplicaFallback === true,
-			options?.includeStrictFullReplica !== false,
-		];
-	}
-
 	findLeaders(
 		cursors: Iterable<bigint | number | string>,
 		replicas: number,
@@ -396,7 +448,7 @@ export class SharedLogRangePlanner {
 		const rows = this.native.find_leaders(
 			[...cursors].map(asIntegerString),
 			replicas,
-			...this.findLeaderArguments(options),
+			...findLeaderArguments(options),
 		);
 		return rowsToSamples(rows);
 	}
@@ -415,7 +467,7 @@ export class SharedLogRangePlanner {
 		const rows = this.native.find_leaders_batch(
 			cursorBatches,
 			replicaCounts,
-			...this.findLeaderArguments(options),
+			...findLeaderArguments(options),
 		);
 		return rows.map((row) => rowsToSamples(row as unknown[]));
 	}
@@ -428,7 +480,7 @@ export class SharedLogRangePlanner {
 		const rows = this.native.find_leaders_for_gid(
 			gid,
 			replicas,
-			...this.findLeaderArguments(options),
+			...findLeaderArguments(options),
 		);
 		return rowsToSamples(rows);
 	}
@@ -441,7 +493,7 @@ export class SharedLogRangePlanner {
 		const [coordinateRows, leaderRows] = this.native.plan_leaders_for_gid(
 			gid,
 			replicas,
-			...this.findLeaderArguments(options),
+			...findLeaderArguments(options),
 		);
 		return {
 			coordinates: rowsToNumbers(this.resolution, coordinateRows),
@@ -463,7 +515,7 @@ export class SharedLogRangePlanner {
 		const rows = this.native.plan_leaders_for_gids_batch(
 			gids,
 			replicaCounts,
-			...this.findLeaderArguments(options),
+			...findLeaderArguments(options),
 		);
 		return rows.map((row) => {
 			const [coordinateRows, leaderRows] = row as [unknown[], unknown[]];
@@ -505,17 +557,7 @@ export class SharedLogRangePlanner {
 			input.selfHash,
 		);
 
-		const plan: RepairDispatchPlan = new Map();
-		for (const row of rows) {
-			const [mode, target, hashes] = row as [string, string, string[]];
-			let targets = plan.get(mode);
-			if (!targets) {
-				targets = new Map();
-				plan.set(mode, targets);
-			}
-			targets.set(target, hashes);
-		}
-		return plan;
+		return rowsToRepairDispatchPlan(rows);
 	}
 
 	planRepairDispatchForEntries(
@@ -549,23 +591,13 @@ export class SharedLogRangePlanner {
 				? [...input.fullReplicaRepairCandidates]
 				: [],
 			input.fullReplicaRepairCandidateCount,
-			...this.findLeaderArguments({
+			...findLeaderArguments({
 				...options,
 				selfHash: input.selfHash,
 			}),
 		);
 
-		const plan: RepairDispatchPlan = new Map();
-		for (const row of rows) {
-			const [mode, target, hashes] = row as [string, string, string[]];
-			let targets = plan.get(mode);
-			if (!targets) {
-				targets = new Map();
-				plan.set(mode, targets);
-			}
-			targets.set(target, hashes);
-		}
-		return plan;
+		return rowsToRepairDispatchPlan(rows);
 	}
 
 	getFullReplicaLeaders(
@@ -616,4 +648,151 @@ export class SharedLogRangePlanner {
 	}
 }
 
+export class SharedLogNativeState {
+	private constructor(
+		private readonly native: NativeSharedLogStateHandle,
+		private readonly resolution: RangeResolution,
+	) {}
+
+	static async create(resolution: RangeResolution): Promise<SharedLogNativeState> {
+		const wasm = await loadWasm();
+		return new SharedLogNativeState(
+			new wasm.NativeSharedLogState(resolution),
+			resolution,
+		);
+	}
+
+	get length(): number {
+		return this.native.len();
+	}
+
+	clear(): void {
+		this.native.clear();
+	}
+
+	put(range: NativeReplicationRange): void {
+		this.native.put(
+			range.id,
+			range.hash,
+			asIntegerString(range.timestamp),
+			asIntegerString(range.start1),
+			asIntegerString(range.end1),
+			asIntegerString(range.start2),
+			asIntegerString(range.end2),
+			asIntegerString(range.width),
+			range.mode,
+		);
+	}
+
+	delete(id: string): boolean {
+		return this.native.delete(id);
+	}
+
+	putEntryCoordinates(
+		hash: string,
+		coordinates: Iterable<bigint | number | string>,
+	): void {
+		this.native.put_entry_coordinates(hash, [...coordinates].map(asIntegerString));
+	}
+
+	deleteEntryCoordinates(hash: string): boolean {
+		return this.native.delete_entry_coordinates(hash);
+	}
+
+	deleteEntryCoordinatesBatch(hashes: Iterable<string>): void {
+		this.native.delete_entry_coordinates_batch([...hashes]);
+	}
+
+	clearEntryCoordinates(): void {
+		this.native.clear_entry_coordinates();
+	}
+
+	addGidPeers(
+		gid: string,
+		peers: Iterable<string>,
+		reset = false,
+	): number {
+		return this.native.add_gid_peers(gid, [...peers], reset);
+	}
+
+	removeGidPeer(peer: string, gid?: string): void {
+		this.native.remove_gid_peer(peer, gid);
+	}
+
+	deleteGidPeers(gid: string): boolean {
+		return this.native.delete_gid_peers(gid);
+	}
+
+	clearGidPeers(): void {
+		this.native.clear_gid_peers();
+	}
+
+	markEntriesKnownByPeer(hashes: Iterable<string>, peer: string): void {
+		this.native.mark_entries_known_by_peer([...hashes], peer);
+	}
+
+	removeEntriesKnownByPeer(hashes: Iterable<string>, peer: string): void {
+		this.native.remove_entries_known_by_peer([...hashes], peer);
+	}
+
+	removePeerFromEntryKnownPeers(peer: string): void {
+		this.native.remove_peer_from_entry_known_peers(peer);
+	}
+
+	clearEntryKnownPeers(): void {
+		this.native.clear_entry_known_peers();
+	}
+
+	planLeadersForGid(
+		gid: string,
+		replicas: number,
+		options?: FindLeaderOptions,
+	): LeaderPlan {
+		const [coordinateRows, leaderRows] =
+			this.native.plan_entry_leaders_for_gid(
+				gid,
+				replicas,
+				...findLeaderArguments(options),
+			);
+		return {
+			coordinates: rowsToNumbers(this.resolution, coordinateRows),
+			leaders: rowsToSamples(leaderRows),
+		};
+	}
+
+	planRepairDispatchForEntries(
+		input: RepairDispatchEntryPlanInput,
+		options?: FindLeaderOptions,
+	): RepairDispatchPlan {
+		const entries = [...input.entries];
+		const pendingModes = [...input.pendingModes];
+		const rows = this.native.plan_repair_dispatch_for_entries(
+			entries.map((entry) => entry.hash),
+			entries.map((entry) => entry.gid),
+			entries.map((entry) => entry.requestedReplicas),
+			entries.map((entry) => [...entry.coordinates].map(asIntegerString)),
+			pendingModes,
+			pendingModes.map((mode) => [
+				...(input.pendingPeersByMode.get(mode) ?? []),
+			]),
+			pendingModes.map((mode) => {
+				const optimisticByGid = input.optimisticPeersByMode?.get(mode);
+				return entries.map((entry) => [
+					...(optimisticByGid?.get(entry.gid) ?? []),
+				]);
+			}),
+			input.fullReplicaRepairCandidates
+				? [...input.fullReplicaRepairCandidates]
+				: [],
+			input.fullReplicaRepairCandidateCount,
+			...findLeaderArguments({
+				...options,
+				selfHash: input.selfHash,
+			}),
+		);
+		return rowsToRepairDispatchPlan(rows);
+	}
+}
+
 export const createRangePlanner = SharedLogRangePlanner.create;
+export const createSharedLogState = SharedLogNativeState.create;

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -941,6 +941,44 @@ pub struct NativeRangePlanner {
     inner: RangePlanner,
 }
 
+pub struct SharedLogStateInner {
+    range_planner: RangePlanner,
+    entry_coordinates: HashMap<String, Vec<u64>>,
+    gid_peers: HashMap<String, IndexSet<String>>,
+    entry_known_peers: HashMap<String, IndexSet<String>>,
+}
+
+impl SharedLogStateInner {
+    fn new(resolution: String) -> Self {
+        Self {
+            range_planner: RangePlanner::new(&resolution),
+            entry_coordinates: HashMap::new(),
+            gid_peers: HashMap::new(),
+            entry_known_peers: HashMap::new(),
+        }
+    }
+
+    fn clear_all(&mut self) {
+        self.range_planner.clear();
+        self.entry_coordinates.clear();
+        self.gid_peers.clear();
+        self.entry_known_peers.clear();
+    }
+
+    fn put_range(&mut self, range: ReplicationRange) {
+        self.range_planner.put(range);
+    }
+
+    fn delete_range(&mut self, id: &str) -> bool {
+        self.range_planner.delete(id)
+    }
+}
+
+#[wasm_bindgen]
+pub struct NativeSharedLogState {
+    inner: SharedLogStateInner,
+}
+
 #[wasm_bindgen]
 impl NativeRangePlanner {
     #[wasm_bindgen(constructor)]
@@ -1380,7 +1418,326 @@ impl NativeRangePlanner {
     }
 }
 
+#[wasm_bindgen]
+impl NativeSharedLogState {
+    #[wasm_bindgen(constructor)]
+    pub fn new(resolution: String) -> Self {
+        Self {
+            inner: SharedLogStateInner::new(resolution),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.range_planner.len()
+    }
+
+    pub fn clear(&mut self) {
+        self.inner.clear_all();
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn put(
+        &mut self,
+        id: String,
+        hash: String,
+        timestamp: String,
+        start1: String,
+        end1: String,
+        start2: String,
+        end2: String,
+        width: String,
+        mode: u8,
+    ) -> Result<(), JsValue> {
+        self.inner.put_range(ReplicationRange::new(
+            id,
+            hash,
+            parse_u64(&timestamp)?,
+            parse_u64(&start1)?,
+            parse_u64(&end1)?,
+            parse_u64(&start2)?,
+            parse_u64(&end2)?,
+            parse_u64(&width)?,
+            mode,
+        ));
+        Ok(())
+    }
+
+    pub fn delete(&mut self, id: &str) -> bool {
+        self.inner.delete_range(id)
+    }
+
+    pub fn put_entry_coordinates(
+        &mut self,
+        hash: String,
+        coordinates: Array,
+    ) -> Result<(), JsValue> {
+        self.inner
+            .entry_coordinates
+            .insert(hash, cursor_values_from_array(coordinates)?);
+        Ok(())
+    }
+
+    pub fn delete_entry_coordinates(&mut self, hash: &str) -> bool {
+        self.inner.entry_coordinates.remove(hash).is_some()
+    }
+
+    pub fn delete_entry_coordinates_batch(&mut self, hashes: Array) -> Result<(), JsValue> {
+        for hash in strings_from_array(hashes)? {
+            self.inner.entry_coordinates.remove(&hash);
+        }
+        Ok(())
+    }
+
+    pub fn clear_entry_coordinates(&mut self) {
+        self.inner.entry_coordinates.clear();
+    }
+
+    pub fn add_gid_peers(
+        &mut self,
+        gid: String,
+        peers: Array,
+        reset: bool,
+    ) -> Result<usize, JsValue> {
+        let entry = self.inner.gid_peers.entry(gid).or_default();
+        if reset {
+            entry.clear();
+        }
+        for peer in strings_from_array(peers)? {
+            entry.insert(peer);
+        }
+        Ok(entry.len())
+    }
+
+    pub fn remove_gid_peer(&mut self, peer: &str, gid: JsValue) -> Result<(), JsValue> {
+        if gid.is_undefined() || gid.is_null() {
+            let empty_gids: Vec<String> = self
+                .inner
+                .gid_peers
+                .iter_mut()
+                .filter_map(|(gid, peers)| {
+                    peers.shift_remove(peer);
+                    if peers.is_empty() {
+                        Some(gid.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            for gid in empty_gids {
+                self.inner.gid_peers.remove(&gid);
+            }
+            return Ok(());
+        }
+
+        let Some(gid) = gid.as_string() else {
+            return Err(JsValue::from_str("Expected optional gid string"));
+        };
+        if let Some(peers) = self.inner.gid_peers.get_mut(&gid) {
+            peers.shift_remove(peer);
+            if peers.is_empty() {
+                self.inner.gid_peers.remove(&gid);
+            }
+        }
+        Ok(())
+    }
+
+    pub fn delete_gid_peers(&mut self, gid: &str) -> bool {
+        self.inner.gid_peers.remove(gid).is_some()
+    }
+
+    pub fn clear_gid_peers(&mut self) {
+        self.inner.gid_peers.clear();
+    }
+
+    pub fn mark_entries_known_by_peer(
+        &mut self,
+        hashes: Array,
+        peer: String,
+    ) -> Result<(), JsValue> {
+        for hash in strings_from_array(hashes)? {
+            self.inner
+                .entry_known_peers
+                .entry(hash)
+                .or_default()
+                .insert(peer.clone());
+        }
+        Ok(())
+    }
+
+    pub fn remove_entries_known_by_peer(
+        &mut self,
+        hashes: Array,
+        peer: &str,
+    ) -> Result<(), JsValue> {
+        for hash in strings_from_array(hashes)? {
+            if let Some(peers) = self.inner.entry_known_peers.get_mut(&hash) {
+                peers.shift_remove(peer);
+                if peers.is_empty() {
+                    self.inner.entry_known_peers.remove(&hash);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn remove_peer_from_entry_known_peers(&mut self, peer: &str) {
+        let empty_hashes: Vec<String> = self
+            .inner
+            .entry_known_peers
+            .iter_mut()
+            .filter_map(|(hash, peers)| {
+                peers.shift_remove(peer);
+                if peers.is_empty() {
+                    Some(hash.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for hash in empty_hashes {
+            self.inner.entry_known_peers.remove(&hash);
+        }
+    }
+
+    pub fn clear_entry_known_peers(&mut self) {
+        self.inner.entry_known_peers.clear();
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn plan_entry_leaders_for_gid(
+        &self,
+        gid: String,
+        replicas: usize,
+        role_age_ms: f64,
+        now: String,
+        peer_filter: JsValue,
+        expand_peer_filter: bool,
+        self_hash: String,
+        include_self: bool,
+        full_replica_fallback: bool,
+        include_strict_full_replica: bool,
+    ) -> Result<Array, JsValue> {
+        let coordinates = self.inner.range_planner.get_gid_coordinates(&gid, replicas);
+        let options = find_leader_options(role_age_ms, &now, peer_filter)?;
+        let leaders = self.inner.range_planner.find_leaders(
+            &coordinates,
+            replicas,
+            &options,
+            expand_peer_filter,
+            &self_hash,
+            include_self,
+            full_replica_fallback,
+            include_strict_full_replica,
+        );
+        let out = Array::new();
+        out.push(&numbers_to_rows(
+            coordinates,
+            self.inner.range_planner.resolution,
+        ));
+        out.push(&samples_to_rows(leaders));
+        Ok(out)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn plan_repair_dispatch_for_entries(
+        &self,
+        entry_hashes: Array,
+        entry_gids: Array,
+        entry_requested_replicas: Array,
+        entry_coordinate_batches: Array,
+        pending_modes: Array,
+        pending_peers_by_mode: Array,
+        optimistic_peers_by_mode: Array,
+        full_replica_repair_candidates: Array,
+        full_replica_repair_candidate_count: usize,
+        role_age_ms: f64,
+        now: String,
+        peer_filter: JsValue,
+        expand_peer_filter: bool,
+        self_hash: String,
+        include_self: bool,
+        full_replica_fallback: bool,
+        include_strict_full_replica: bool,
+    ) -> Result<Array, JsValue> {
+        let entry_hashes = strings_from_array(entry_hashes)?;
+        let entry_gids = strings_from_array(entry_gids)?;
+        let entry_coordinate_batches = cursor_batches_from_array(entry_coordinate_batches)?;
+        let options = find_leader_options(role_age_ms, &now, peer_filter)?;
+        let mut prepared_options_by_replicas = HashMap::new();
+        let mut full_replica_leaders_by_replicas = HashMap::new();
+        let mut current_leader_batches = Vec::with_capacity(entry_coordinate_batches.len());
+
+        for coordinates in &entry_coordinate_batches {
+            let replicas = coordinates.len();
+            let leaders = find_leaders_with_batch_caches(
+                &self.inner.range_planner,
+                coordinates,
+                replicas,
+                &options,
+                &mut prepared_options_by_replicas,
+                &mut full_replica_leaders_by_replicas,
+                expand_peer_filter,
+                &self_hash,
+                include_self,
+                full_replica_fallback,
+                include_strict_full_replica,
+            );
+            current_leader_batches.push(leaders.into_iter().map(|leader| leader.hash).collect());
+        }
+
+        let known_gid_peer_batches = entry_gids
+            .iter()
+            .map(|gid| {
+                self.inner
+                    .gid_peers
+                    .get(gid)
+                    .map(index_set_to_vec)
+                    .unwrap_or_default()
+            })
+            .collect();
+        let known_entry_peer_batches = entry_hashes
+            .iter()
+            .map(|hash| {
+                self.inner
+                    .entry_known_peers
+                    .get(hash)
+                    .map(index_set_to_vec)
+                    .unwrap_or_default()
+            })
+            .collect();
+
+        plan_repair_dispatch_rows(RepairDispatchBatch {
+            entry_hashes,
+            entry_gids,
+            entry_requested_replicas: usize_from_array(entry_requested_replicas)?,
+            current_leader_batches,
+            known_gid_peer_batches,
+            known_entry_peer_batches,
+            pending_modes: strings_from_array(pending_modes)?,
+            pending_peers_by_mode: string_batches_from_array(
+                pending_peers_by_mode,
+                "pending peers by mode",
+            )?,
+            optimistic_peers_by_mode: string_matrix_from_array(
+                optimistic_peers_by_mode,
+                "optimistic peers by mode",
+            )?,
+            full_replica_repair_candidates: HashSet::<String>::from_iter(strings_from_array(
+                full_replica_repair_candidates,
+            )?),
+            full_replica_repair_candidate_count,
+            self_hash,
+        })
+    }
+}
+
 impl Default for NativeRangePlanner {
+    fn default() -> Self {
+        Self::new("u32".to_string())
+    }
+}
+
+impl Default for NativeSharedLogState {
     fn default() -> Self {
         Self::new("u32".to_string())
     }
@@ -1446,6 +1803,13 @@ fn string_matrix_from_array(values: Array, label: &str) -> Result<Vec<Vec<Vec<St
     Ok(out)
 }
 
+fn cursor_values_from_array(values: Array) -> Result<Vec<u64>, JsValue> {
+    strings_from_array(values)?
+        .into_iter()
+        .map(|value| parse_u64(&value))
+        .collect::<Result<Vec<_>, _>>()
+}
+
 fn usize_from_array(values: Array) -> Result<Vec<usize>, JsValue> {
     let mut out = Vec::with_capacity(values.length() as usize);
     for value in values.iter() {
@@ -1498,6 +1862,10 @@ fn add_repair_dispatch(
 
 fn contains_string(values: &[String], target: &str) -> bool {
     values.iter().any(|value| value == target)
+}
+
+fn index_set_to_vec(values: &IndexSet<String>) -> Vec<String> {
+    values.iter().cloned().collect()
 }
 
 fn optional_string_set(value: JsValue) -> Result<Option<Vec<String>>, JsValue> {

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { createRangePlanner } from "../src/index.js";
+import { createRangePlanner, createSharedLogState } from "../src/index.js";
 
 const range = (properties: {
 	id: string;
@@ -274,6 +274,31 @@ describe("native shared-log range planner", () => {
 		);
 	});
 
+	it("plans hash gid leaders from resident shared-log state", async () => {
+		const planner = await createRangePlanner("u32");
+		const state = await createSharedLogState("u32");
+		const ranges = [
+			range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }),
+			range({ id: "b", hash: "peer-b", start1: 20, end1: 30 }),
+		];
+		for (const item of ranges) {
+			planner.put(item);
+			state.put(item);
+		}
+
+		expect(
+			state.planLeadersForGid("entry-gid", 2, {
+				now: 1_000,
+				fullReplicaFallback: true,
+			}),
+		).to.deep.equal(
+			planner.planLeadersForGid("entry-gid", 2, {
+				now: 1_000,
+				fullReplicaFallback: true,
+			}),
+		);
+	});
+
 	it("plans repair dispatch targets in one native batch", async () => {
 		const planner = await createRangePlanner("u32");
 
@@ -330,6 +355,56 @@ describe("native shared-log range planner", () => {
 						["peer-a", ["entry-a"]],
 						["peer-full", ["entry-a"]],
 					]),
+				],
+			]),
+		);
+	});
+
+	it("plans repair dispatch from resident shared-log state", async () => {
+		const state = await createSharedLogState("u32");
+		state.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));
+		state.addGidPeers("gid-known", ["peer-a"]);
+		state.markEntriesKnownByPeer(["entry-known"], "peer-a");
+
+		expect(
+			state.planRepairDispatchForEntries(
+				{
+					entries: [
+						{
+							hash: "entry-known",
+							gid: "gid-fresh",
+							requestedReplicas: 1,
+							coordinates: [5],
+						},
+						{
+							hash: "entry-gid",
+							gid: "gid-known",
+							requestedReplicas: 1,
+							coordinates: [5],
+						},
+						{
+							hash: "entry-fresh",
+							gid: "gid-fresh",
+							requestedReplicas: 1,
+							coordinates: [5],
+						},
+					],
+					pendingModes: ["join-warmup", "join-authoritative"],
+					pendingPeersByMode: new Map([
+						["join-warmup", ["peer-a"]],
+						["join-authoritative", ["peer-a"]],
+					]),
+					fullReplicaRepairCandidateCount: 1,
+					selfHash: "peer-self",
+				},
+				{ now: 1_000 },
+			),
+		).to.deep.equal(
+			new Map([
+				["join-warmup", new Map([["peer-a", ["entry-fresh"]]])],
+				[
+					"join-authoritative",
+					new Map([["peer-a", ["entry-gid", "entry-fresh"]]]),
 				],
 			]),
 		);

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -23,8 +23,10 @@ import {
 } from "@peerbit/indexer-interface";
 import {
 	type NativeReplicationRange,
+	type SharedLogNativeState,
 	type SharedLogRangePlanner,
 	createRangePlanner,
+	createSharedLogState,
 } from "@peerbit/shared-log-rust";
 import {
 	type AppendOptions,
@@ -811,12 +813,13 @@ export class SharedLog<
 	private _replicationRangeIndex!: Index<ReplicationRangeIndexable<R>>;
 	private _entryCoordinatesIndex!: Index<EntryReplicated<R>>;
 	private _nativeRangePlanner?: SharedLogRangePlanner;
-		private coordinateToHash!: Cache<string>;
-		private recentlyRebalanced!: Cache<string>;
+	private _nativeSharedLogState?: SharedLogNativeState;
+	private coordinateToHash!: Cache<string>;
+	private recentlyRebalanced!: Cache<string>;
 
-		uniqueReplicators!: Set<string>;
-		private _replicatorJoinEmitted!: Set<string>;
-		private _replicatorsReconciled!: boolean;
+	uniqueReplicators!: Set<string>;
+	private _replicatorJoinEmitted!: Set<string>;
+	private _replicatorsReconciled!: boolean;
 
 	/* private _totalParticipation!: number; */
 
@@ -1812,6 +1815,7 @@ export class SharedLog<
 		if (values.length === 0) {
 			return;
 		}
+		this._nativeSharedLogState?.deleteEntryCoordinatesBatch(values);
 		await this.entryCoordinatesIndex.del({
 			query:
 				values.length === 1
@@ -2735,6 +2739,7 @@ export class SharedLog<
 	}
 
 	private removePeerFromGidPeerHistory(publicKeyHash: string, gid?: string) {
+		this._nativeSharedLogState?.removeGidPeer(publicKeyHash, gid);
 		if (gid) {
 			const gidMap = this._gidPeersHistory.get(gid);
 			if (gidMap) {
@@ -2752,11 +2757,18 @@ export class SharedLog<
 		}
 	}
 
+	private deleteGidPeerHistory(gid: string) {
+		this._nativeSharedLogState?.deleteGidPeers(gid);
+		this._gidPeersHistory.delete(gid);
+	}
+
 	addPeersToGidPeerHistory(
 		gid: string,
 		publicKeys: Iterable<string>,
 		reset?: boolean,
 	) {
+		const publicKeyArray = [...publicKeys];
+		this._nativeSharedLogState?.addGidPeers(gid, publicKeyArray, reset === true);
 		let set = this._gidPeersHistory.get(gid);
 		if (!set) {
 			set = new Set();
@@ -2767,14 +2779,16 @@ export class SharedLog<
 			}
 		}
 
-		for (const key of publicKeys) {
+		for (const key of publicKeyArray) {
 			set.add(key);
 		}
 		return set;
 	}
 
 	private markEntriesKnownByPeer(hashes: Iterable<string>, peer: string) {
-		for (const hash of hashes) {
+		const hashArray = [...hashes];
+		this._nativeSharedLogState?.markEntriesKnownByPeer(hashArray, peer);
+		for (const hash of hashArray) {
 			let peers = this._entryKnownPeers.get(hash);
 			if (!peers) {
 				peers = new Set();
@@ -2785,7 +2799,9 @@ export class SharedLog<
 	}
 
 	private removeEntriesKnownByPeer(hashes: Iterable<string>, peer: string) {
-		for (const hash of hashes) {
+		const hashArray = [...hashes];
+		this._nativeSharedLogState?.removeEntriesKnownByPeer(hashArray, peer);
+		for (const hash of hashArray) {
 			const peers = this._entryKnownPeers.get(hash);
 			if (!peers) {
 				continue;
@@ -2798,6 +2814,7 @@ export class SharedLog<
 	}
 
 	private removePeerFromEntryKnownPeers(peer: string) {
+		this._nativeSharedLogState?.removePeerFromEntryKnownPeers(peer);
 		for (const [hash, peers] of this._entryKnownPeers) {
 			peers.delete(peer);
 			if (peers.size === 0) {
@@ -4481,15 +4498,18 @@ export class SharedLog<
 	}
 
 	private putNativeReplicationRange(range: ReplicationRangeIndexable<R>): void {
-		this._nativeRangePlanner?.put(this.toNativeReplicationRange(range));
+		const nativeRange = this.toNativeReplicationRange(range);
+		this._nativeRangePlanner?.put(nativeRange);
+		this._nativeSharedLogState?.put(nativeRange);
 	}
 
 	private deleteNativeReplicationRange(range: ReplicationRangeIndexable<R>): void {
 		this._nativeRangePlanner?.delete(range.idString);
+		this._nativeSharedLogState?.delete(range.idString);
 	}
 
 	private async hydrateNativeRangePlanner(
-		planner: SharedLogRangePlanner,
+		planner: Pick<SharedLogRangePlanner, "clear" | "put">,
 	): Promise<void> {
 		planner.clear();
 		const iterator = this.replicationIndex.iterate();
@@ -4508,18 +4528,50 @@ export class SharedLog<
 		}
 	}
 
+	private async hydrateNativeSharedLogState(
+		state: SharedLogNativeState,
+	): Promise<void> {
+		state.clearEntryCoordinates();
+		const iterator = this.entryCoordinatesIndex.iterate({});
+		try {
+			for (;;) {
+				const batch = await iterator.next(256);
+				if (batch.length === 0) {
+					break;
+				}
+				for (const result of batch) {
+					state.putEntryCoordinates(
+						result.value.hash,
+						result.value.coordinates,
+					);
+				}
+			}
+		} finally {
+			await iterator.close();
+		}
+	}
+
 	private async openNativeRangePlanner(
 		options: SharedLogOptions<T, D, R>["nativeRangePlanner"],
 	): Promise<void> {
 		this._nativeRangePlanner = undefined;
+		this._nativeSharedLogState = undefined;
 		if (options === false) {
 			return;
 		}
 
 		try {
-			const planner = await createRangePlanner(this.domain.resolution);
-			await this.hydrateNativeRangePlanner(planner);
+			const [planner, state] = await Promise.all([
+				createRangePlanner(this.domain.resolution),
+				createSharedLogState(this.domain.resolution),
+			]);
+			await Promise.all([
+				this.hydrateNativeRangePlanner(planner),
+				this.hydrateNativeRangePlanner(state),
+			]);
+			await this.hydrateNativeSharedLogState(state);
 			this._nativeRangePlanner = planner;
+			this._nativeSharedLogState = state;
 		} catch (error) {
 			if (options?.optional === false) {
 				throw error;
@@ -5289,6 +5341,7 @@ export class SharedLog<
 		}
 		this._repairSweepOptimisticGidPeersPending.clear();
 		this._entryKnownPeers.clear();
+		this._nativeSharedLogState?.clearEntryKnownPeers();
 		for (const timer of this._joinAuthoritativeRepairTimersByDelay.values()) {
 			clearTimeout(timer);
 		}
@@ -5323,6 +5376,7 @@ export class SharedLog<
 		this._checkedPruneRetries.clear();
 		this.latestReplicationInfoMessage.clear();
 		this._gidPeersHistory.clear();
+		this._nativeSharedLogState?.clearGidPeers();
 		this._requestIPruneSent.clear();
 		this._requestIPruneResponseReplicatorSet.clear();
 		// Cancel any pending debounced timers so they can't fire after we've torn down
@@ -5338,6 +5392,7 @@ export class SharedLog<
 		this._replicationRangeIndex = undefined as any;
 		this._entryCoordinatesIndex = undefined as any;
 		this._nativeRangePlanner = undefined;
+		this._nativeSharedLogState = undefined;
 
 		this.cpuUsage?.stop?.();
 		/* this._totalParticipation = 0; */
@@ -6748,12 +6803,19 @@ export class SharedLog<
 				hashNumber,
 			}),
 		);
+		this._nativeSharedLogState?.putEntryCoordinates(
+			properties.entry.hash,
+			properties.coordinates,
+		);
 
 		for (const coordinate of properties.coordinates) {
 			this.coordinateToHash.add(coordinate, properties.entry.hash);
 		}
 
 		if (properties.entry.meta.next.length > 0) {
+			this._nativeSharedLogState?.deleteEntryCoordinatesBatch(
+				properties.entry.meta.next,
+			);
 			await this.entryCoordinatesIndex.del({
 				query: new Or(
 					properties.entry.meta.next.map(
@@ -6765,6 +6827,7 @@ export class SharedLog<
 	}
 
 	private async deleteCoordinates(properties: { hash: string }) {
+		this._nativeSharedLogState?.deleteEntryCoordinates(properties.hash);
 		await this.entryCoordinatesIndex.del({ query: properties });
 	}
 
@@ -7306,7 +7369,7 @@ export class SharedLog<
 			}
 		};
 
-		if (this._nativeRangePlanner) {
+		if (this._nativeSharedLogState) {
 			const pendingPeersByMode = new Map<string, Iterable<string>>();
 			const optimisticPeersByMode = new Map<
 				string,
@@ -7328,15 +7391,13 @@ export class SharedLog<
 			}
 
 			const context = await this.createLeaderSelectionContext({ roleAge: 0 });
-			const nativePlan = this._nativeRangePlanner.planRepairDispatchForEntries(
+			const nativePlan = this._nativeSharedLogState.planRepairDispatchForEntries(
 				{
 					entries: properties.entries.map((entry, i) => ({
 						hash: entry.hash,
 						gid: entry.gid,
 						requestedReplicas: properties.requestedReplicasBatch[i]!,
 						coordinates: entry.coordinates,
-						knownGidPeers: this._gidPeersHistory.get(entry.gid),
-						knownEntryPeers: this._entryKnownPeers.get(entry.hash),
 					})),
 					pendingModes: properties.pendingModes,
 					pendingPeersByMode,
@@ -7415,11 +7476,23 @@ export class SharedLog<
 			candidates?: Iterable<string>;
 		},
 	): Promise<Map<string, { intersecting: boolean }> | undefined> {
-		if (!this._nativeRangePlanner) {
+		if (!this._nativeSharedLogState && !this._nativeRangePlanner) {
 			return undefined;
 		}
 
 		const context = await this.createLeaderSelectionContext(options);
+		if (this._nativeSharedLogState) {
+			return this._nativeSharedLogState.planLeadersForGid(
+				gid,
+				replicas,
+				this.createNativeLeaderOptions(context, options),
+			).leaders;
+		}
+
+		if (!this._nativeRangePlanner) {
+			return undefined;
+		}
+
 		return this._nativeRangePlanner.findLeadersForGid(
 			gid,
 			replicas,
@@ -7441,12 +7514,12 @@ export class SharedLog<
 		  }
 		| undefined
 	> {
-		if (!this._nativeRangePlanner) {
+		const planner = this._nativeSharedLogState ?? this._nativeRangePlanner;
+		if (!planner) {
 			return undefined;
 		}
-
 		const context = await this.createLeaderSelectionContext(options);
-		return this._nativeRangePlanner.planLeadersForGid(
+		return planner.planLeadersForGid(
 			gid,
 			replicas,
 			this.createNativeLeaderOptions(context, options),
@@ -7684,10 +7757,10 @@ export class SharedLog<
 			}
 		>,
 			options?: { timeout?: number; unchecked?: boolean },
-		): Promise<any>[] {
+			): Promise<any>[] {
 		if (options?.unchecked) {
 			return [...entries.values()].map((x) => {
-				this._gidPeersHistory.delete(x.entry.meta.gid);
+				this.deleteGidPeerHistory(x.entry.meta.gid);
 				this.removePruneRequestSent(x.entry.hash);
 				this._requestIPruneResponseReplicatorSet.delete(x.entry.hash);
 				return this.log.remove(x.entry, {
@@ -7769,14 +7842,14 @@ export class SharedLog<
 				clearTimeout(timeout);
 			};
 
-				const resolve = () => {
-					clear();
-					this.clearCheckedPruneRetry(entry.hash);
-					cleanupTimer.push(
-						setTimeout(async () => {
-							this._gidPeersHistory.delete(entry.meta.gid);
-							this.removePruneRequestSent(entry.hash);
-						this._requestIPruneResponseReplicatorSet.delete(entry.hash);
+					const resolve = () => {
+						clear();
+						this.clearCheckedPruneRetry(entry.hash);
+						cleanupTimer.push(
+							setTimeout(async () => {
+								this.deleteGidPeerHistory(entry.meta.gid);
+								this.removePruneRequestSent(entry.hash);
+							this._requestIPruneResponseReplicatorSet.delete(entry.hash);
 
 						if (
 							await this.isLeader({
@@ -7797,13 +7870,13 @@ export class SharedLog<
 							.then(() => {
 								deferredPromise.resolve();
 							})
-							.catch((e) => {
-								deferredPromise.reject(e);
-							})
-							.finally(async () => {
-								this._gidPeersHistory.delete(entry.meta.gid);
-								this.removePruneRequestSent(entry.hash);
-								this._requestIPruneResponseReplicatorSet.delete(entry.hash);
+								.catch((e) => {
+									deferredPromise.reject(e);
+								})
+								.finally(async () => {
+									this.deleteGidPeerHistory(entry.meta.gid);
+									this.removePruneRequestSent(entry.hash);
+									this._requestIPruneResponseReplicatorSet.delete(entry.hash);
 								// TODO in the case we become leader again here we need to re-add the entry
 
 								if (
@@ -8038,6 +8111,7 @@ export class SharedLog<
 	async rebalanceAll(options?: { clearCache?: boolean }) {
 		if (options?.clearCache) {
 			this._gidPeersHistory.clear();
+			this._nativeSharedLogState?.clearGidPeers();
 		}
 
 		const timestamp = BigInt(+new Date());


### PR DESCRIPTION
## Summary
- add a `NativeSharedLogState` wasm object that owns the range planner plus mirrored entry coordinates, gid peer history, and known-entry peers
- wire `SharedLog` mutations to keep that resident native state in sync with existing TS maps/indexes
- route hash-gid leader planning and repair dispatch through the resident state when available, with existing fallback behavior preserved

## Local benchmark
100 rounds over 1,000 repair entries with known gid/entry peer metadata:
- range planner with JS known-map marshalling: ~173,564 entries/sec
- resident shared-log state: ~203,132 entries/sec

This is a repair-dispatch/native-state win, not yet a full pure-native append transaction.

## Test plan
- `pnpm --filter @peerbit/shared-log-rust run test`
- `pnpm --filter @peerbit/shared-log-rust run lint`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/index.ts`
- `git diff --check`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "leader are selected from 1 replicating peer"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "settles towards the current replicators"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "will prune on put 300 after join"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "does not confirm checked prune from a shallow-only entry"`
