### PR TITLE
feat: plan append entry assignment natively

### DIFF
--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -54,6 +54,10 @@ export type LeaderPlan = {
 	leaders: Map<string, LeaderSample>;
 };
 
+export type EntryAssignmentPlan = LeaderPlan & {
+	assignedToRangeBoundary: boolean;
+};
+
 export type LeaderBatchInput = {
 	cursors: Iterable<bigint | number | string>;
 	replicas: number;
@@ -248,6 +252,12 @@ type NativeSharedLogStateHandle = {
 	delete: NativeRangePlannerHandle["delete"];
 	put_entry_coordinates: (hash: string, coordinates: string[]) => void;
 	delete_entry_coordinates: (hash: string) => boolean;
+	get_entry_coordinates: (hash: string) => unknown[] | undefined;
+	commit_entry_coordinates: (
+		hash: string,
+		coordinates: string[],
+		nextHashes: string[],
+	) => void;
 	delete_entry_coordinates_batch: (hashes: string[]) => void;
 	clear_entry_coordinates: () => void;
 	add_gid_peers: (gid: string, peers: string[], reset: boolean) => number;
@@ -259,6 +269,18 @@ type NativeSharedLogStateHandle = {
 	remove_peer_from_entry_known_peers: (peer: string) => void;
 	clear_entry_known_peers: () => void;
 	plan_entry_leaders_for_gid: NativeRangePlannerHandle["plan_leaders_for_gid"];
+	plan_entry_assignment_for_gid: (
+		gid: string,
+		replicas: number,
+		roleAgeMs: number,
+		now: string,
+		peerFilter: string[] | undefined,
+		expandPeerFilter: boolean,
+		selfHash: string,
+		includeSelf: boolean,
+		fullReplicaFallback: boolean,
+		includeStrictFullReplica: boolean,
+	) => [unknown[], unknown[], boolean];
 	plan_repair_dispatch_for_entries: (
 		entryHashes: string[],
 		entryGids: string[],
@@ -699,6 +721,23 @@ export class SharedLogNativeState {
 		return this.native.delete_entry_coordinates(hash);
 	}
 
+	getEntryCoordinates(hash: string): Array<number | bigint> | undefined {
+		const coordinates = this.native.get_entry_coordinates(hash);
+		return coordinates ? rowsToNumbers(this.resolution, coordinates) : undefined;
+	}
+
+	commitEntryCoordinates(
+		hash: string,
+		coordinates: Iterable<bigint | number | string>,
+		nextHashes: Iterable<string>,
+	): void {
+		this.native.commit_entry_coordinates(
+			hash,
+			[...coordinates].map(asIntegerString),
+			[...nextHashes],
+		);
+	}
+
 	deleteEntryCoordinatesBatch(hashes: Iterable<string>): void {
 		this.native.delete_entry_coordinates_batch([...hashes]);
 	}
@@ -757,6 +796,24 @@ export class SharedLogNativeState {
 		return {
 			coordinates: rowsToNumbers(this.resolution, coordinateRows),
 			leaders: rowsToSamples(leaderRows),
+		};
+	}
+
+	planEntryAssignmentForGid(
+		gid: string,
+		replicas: number,
+		options?: FindLeaderOptions,
+	): EntryAssignmentPlan {
+		const [coordinateRows, leaderRows, assignedToRangeBoundary] =
+			this.native.plan_entry_assignment_for_gid(
+				gid,
+				replicas,
+				...findLeaderArguments(options),
+			);
+		return {
+			coordinates: rowsToNumbers(this.resolution, coordinateRows),
+			leaders: rowsToSamples(leaderRows),
+			assignedToRangeBoundary,
 		};
 	}
 

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -1481,6 +1481,31 @@ impl NativeSharedLogState {
         self.inner.entry_coordinates.remove(hash).is_some()
     }
 
+    pub fn get_entry_coordinates(&self, hash: &str) -> JsValue {
+        self.inner
+            .entry_coordinates
+            .get(hash)
+            .map(|coordinates| {
+                numbers_to_rows(coordinates.clone(), self.inner.range_planner.resolution).into()
+            })
+            .unwrap_or(JsValue::UNDEFINED)
+    }
+
+    pub fn commit_entry_coordinates(
+        &mut self,
+        hash: String,
+        coordinates: Array,
+        next_hashes: Array,
+    ) -> Result<(), JsValue> {
+        let coordinates = cursor_values_from_array(coordinates)?;
+        let next_hashes = strings_from_array(next_hashes)?;
+        self.inner.entry_coordinates.insert(hash, coordinates);
+        for next_hash in next_hashes {
+            self.inner.entry_coordinates.remove(&next_hash);
+        }
+        Ok(())
+    }
+
     pub fn delete_entry_coordinates_batch(&mut self, hashes: Array) -> Result<(), JsValue> {
         for hash in strings_from_array(hashes)? {
             self.inner.entry_coordinates.remove(&hash);
@@ -1635,6 +1660,43 @@ impl NativeSharedLogState {
             self.inner.range_planner.resolution,
         ));
         out.push(&samples_to_rows(leaders));
+        Ok(out)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn plan_entry_assignment_for_gid(
+        &self,
+        gid: String,
+        replicas: usize,
+        role_age_ms: f64,
+        now: String,
+        peer_filter: JsValue,
+        expand_peer_filter: bool,
+        self_hash: String,
+        include_self: bool,
+        full_replica_fallback: bool,
+        include_strict_full_replica: bool,
+    ) -> Result<Array, JsValue> {
+        let coordinates = self.inner.range_planner.get_gid_coordinates(&gid, replicas);
+        let options = find_leader_options(role_age_ms, &now, peer_filter)?;
+        let leaders = self.inner.range_planner.find_leaders(
+            &coordinates,
+            replicas,
+            &options,
+            expand_peer_filter,
+            &self_hash,
+            include_self,
+            full_replica_fallback,
+            include_strict_full_replica,
+        );
+        let assigned_to_range_boundary = should_assign_to_range_boundary(&leaders, replicas);
+        let out = Array::new();
+        out.push(&numbers_to_rows(
+            coordinates,
+            self.inner.range_planner.resolution,
+        ));
+        out.push(&samples_to_rows(leaders));
+        out.push(&JsValue::from_bool(assigned_to_range_boundary));
         Ok(out)
     }
 
@@ -1862,6 +1924,10 @@ fn add_repair_dispatch(
 
 fn contains_string(values: &[String], target: &str) -> bool {
     values.iter().any(|value| value == target)
+}
+
+fn should_assign_to_range_boundary(leaders: &[LeaderSample], min_replicas: usize) -> bool {
+    leaders.len() < min_replicas || leaders.iter().any(|leader| !leader.intersecting)
 }
 
 fn index_set_to_vec(values: &IndexSet<String>) -> Vec<String> {

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -299,6 +299,44 @@ describe("native shared-log range planner", () => {
 		);
 	});
 
+	it("plans entry assignment metadata from resident shared-log state", async () => {
+		const planner = await createRangePlanner("u32");
+		const state = await createSharedLogState("u32");
+		const ranges = [
+			range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }),
+			range({ id: "b", hash: "peer-b", start1: 20, end1: 30 }),
+		];
+		for (const item of ranges) {
+			planner.put(item);
+			state.put(item);
+		}
+
+		const plan = state.planEntryAssignmentForGid("entry-gid", 2, {
+			now: 1_000,
+			fullReplicaFallback: true,
+		});
+
+		expect(plan).to.deep.equal({
+			...planner.planLeadersForGid("entry-gid", 2, {
+				now: 1_000,
+				fullReplicaFallback: true,
+			}),
+			assignedToRangeBoundary:
+				plan.leaders.size < 2 ||
+				[...plan.leaders.values()].some((leader) => !leader.intersecting),
+		});
+	});
+
+	it("commits entry coordinates to resident shared-log state", async () => {
+		const state = await createSharedLogState("u32");
+		state.putEntryCoordinates("old-head", [1, 2]);
+
+		state.commitEntryCoordinates("new-head", [3, 4], ["old-head"]);
+
+		expect(state.getEntryCoordinates("new-head")).to.deep.equal([3, 4]);
+		expect(state.getEntryCoordinates("old-head")).to.equal(undefined);
+	});
+
 	it("plans repair dispatch targets in one native batch", async () => {
 		const planner = await createRangePlanner("u32");
 

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -278,6 +278,7 @@ type EntryLeaderPlan<R extends "u32" | "u64"> = {
 	coordinates: NumberFromType<R>[];
 	leaders: LeaderMap;
 	isLeader: boolean;
+	assignedToRangeBoundary?: boolean;
 };
 
 type EntryLeaderBatchItem<R extends "u32" | "u64"> = {
@@ -6776,17 +6777,17 @@ export class SharedLog<
 			| false;
 		replicas: number;
 		prev?: EntryReplicated<R>;
+		assignedToRangeBoundary?: boolean;
 	}) {
-		let assignedToRangeBoundary = shouldAssignToRangeBoundary(
-			properties.leaders,
-			properties.replicas,
-		);
+		const assignedToRangeBoundary =
+			properties.assignedToRangeBoundary ??
+			shouldAssignToRangeBoundary(properties.leaders, properties.replicas);
 
 		if (
 			properties.prev &&
 			properties.prev.assignedToRangeBoundary === assignedToRangeBoundary
 		) {
-			return; // no change
+			return false; // no change
 		}
 
 		const cidObject = cidifyString(properties.entry.hash);
@@ -6803,9 +6804,10 @@ export class SharedLog<
 				hashNumber,
 			}),
 		);
-		this._nativeSharedLogState?.putEntryCoordinates(
+		this._nativeSharedLogState?.commitEntryCoordinates(
 			properties.entry.hash,
 			properties.coordinates,
+			properties.entry.meta.next,
 		);
 
 		for (const coordinate of properties.coordinates) {
@@ -6813,9 +6815,6 @@ export class SharedLog<
 		}
 
 		if (properties.entry.meta.next.length > 0) {
-			this._nativeSharedLogState?.deleteEntryCoordinatesBatch(
-				properties.entry.meta.next,
-			);
 			await this.entryCoordinatesIndex.del({
 				query: new Or(
 					properties.entry.meta.next.map(
@@ -6824,6 +6823,7 @@ export class SharedLog<
 				),
 			});
 		}
+		return true;
 	}
 
 	private async deleteCoordinates(properties: { hash: string }) {
@@ -6945,6 +6945,7 @@ export class SharedLog<
 				  }
 				| false;
 		},
+		assignedToRangeBoundary?: boolean,
 	): Promise<boolean> {
 		const selfHash = this.node.identity.publicKey.hashcode();
 		const isLeader = leaders.has(selfHash);
@@ -6967,6 +6968,7 @@ export class SharedLog<
 					replicas: cursors.length,
 					entry,
 					prev: options?.persist?.prev,
+					assignedToRangeBoundary,
 				}));
 		}
 
@@ -6980,23 +6982,40 @@ export class SharedLog<
 	): Promise<EntryLeaderPlan<R>> {
 		let coordinates: NumberFromType<R>[];
 		let leaders: LeaderMap;
+		let assignedToRangeBoundary: boolean | undefined;
 
 		if (this.canPlanNativeHashGid(entry)) {
-			const plan = await this._findLeaderPlanFromHashGid(
-				entry.meta.gid,
-				replicas,
-				options,
-			);
+			const plan =
+				(await this._findEntryAssignmentPlanFromHashGid(
+					entry.meta.gid,
+					replicas,
+					options,
+				)) ??
+				(await this._findLeaderPlanFromHashGid(
+					entry.meta.gid,
+					replicas,
+					options,
+				));
 			if (plan) {
 				coordinates = plan.coordinates as NumberFromType<R>[];
 				leaders = plan.leaders;
+				assignedToRangeBoundary =
+					"assignedToRangeBoundary" in plan
+						? (plan.assignedToRangeBoundary as boolean)
+						: undefined;
 				const isLeader = await this.applyLeaderSelection(
 					coordinates,
 					entry,
 					leaders,
 					options,
+					assignedToRangeBoundary,
 				);
-				return { coordinates, leaders, isLeader };
+				return {
+					coordinates,
+					leaders,
+					isLeader,
+					assignedToRangeBoundary,
+				};
 			}
 		}
 
@@ -7520,6 +7539,32 @@ export class SharedLog<
 		}
 		const context = await this.createLeaderSelectionContext(options);
 		return planner.planLeadersForGid(
+			gid,
+			replicas,
+			this.createNativeLeaderOptions(context, options),
+		);
+	}
+
+	private async _findEntryAssignmentPlanFromHashGid(
+		gid: string,
+		replicas: number,
+		options?: {
+			roleAge?: number;
+			candidates?: Iterable<string>;
+		},
+	): Promise<
+		| {
+				coordinates: Array<number | bigint>;
+				leaders: Map<string, { intersecting: boolean }>;
+				assignedToRangeBoundary: boolean;
+		  }
+		| undefined
+	> {
+		if (!this._nativeSharedLogState) {
+			return undefined;
+		}
+		const context = await this.createLeaderSelectionContext(options);
+		return this._nativeSharedLogState.planEntryAssignmentForGid(
 			gid,
 			replicas,
 			this.createNativeLeaderOptions(context, options),


### PR DESCRIPTION
## Summary
- add resident native shared-log APIs for entry assignment planning and coordinate commits
- compute `assignedToRangeBoundary` in Rust alongside gid coordinates and leader selection
- update shared-log coordinate persistence to commit the resident native coordinate mirror in one call after the durable index write

## Local benchmark
100k local planning+coordinate mirror operations:
- old path (`planLeadersForGid` + JS assignment + native put + native delete): ~141,905 ops/sec
- new path (`planEntryAssignmentForGid` + native coordinate commit): ~183,456 ops/sec

This is still not the final pure append path because the durable entry-coordinate index write is still in TS. It reduces native boundary crossings and moves one more append planning decision into Rust while preserving the persistent index as the source of truth.

## Test plan
- `pnpm --filter @peerbit/shared-log-rust run test`
- `pnpm --filter @peerbit/shared-log-rust run lint`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/index.ts`
- `git diff --check`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "leader are selected from 1 replicating peer"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "settles towards the current replicators"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "will prune on put 300 after join"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "does not confirm checked prune from a shallow-only entry"`
