### PR TITLE
feat: add native append delivery planner

### DIFF
--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -58,6 +58,17 @@ export type EntryAssignmentPlan = LeaderPlan & {
 	assignedToRangeBoundary: boolean;
 };
 
+export type AppendDeliveryPlan = {
+	hasRemoteRecipients: boolean;
+	noPeerError: boolean;
+	defaultSendSilent: boolean;
+	sendTo: string[];
+	ackTo: string[];
+	silentTo: string[];
+	repairTargets: string[];
+	authoritativeRecipients: string[];
+};
+
 export type LeaderBatchInput = {
 	cursors: Iterable<bigint | number | string>;
 	replicas: number;
@@ -281,6 +292,22 @@ type NativeSharedLogStateHandle = {
 		fullReplicaFallback: boolean,
 		includeStrictFullReplica: boolean,
 	) => [unknown[], unknown[], boolean];
+	plan_append_leaders_for_delivery: (
+		leaders: unknown[],
+		fullReplicaCandidates: string[],
+		minReplicas: number,
+	) => unknown[];
+	plan_append_delivery: (
+		leaders: unknown[],
+		fallbackRecipients: string[],
+		minReplicas: number,
+		selfHash: string,
+		isLeader: boolean,
+		deliveryEnabled: boolean,
+		reliabilityAck: boolean,
+		minAcks: number | undefined,
+		requireRecipients: boolean,
+	) => [boolean, boolean, boolean, string[], string[], string[], string[], string[]];
 	plan_repair_dispatch_for_entries: (
 		entryHashes: string[],
 		entryGids: string[],
@@ -404,6 +431,31 @@ const rowsToRepairDispatchPlan = (rows: unknown[]): RepairDispatchPlan => {
 	}
 	return plan;
 };
+
+const samplesToRows = (leaders: ReadonlyMap<string, LeaderSample>): unknown[] =>
+	[...leaders].map(([hash, sample]) => [hash, sample.intersecting]);
+
+const appendDeliveryPlanFromRow = (
+	row: [
+		boolean,
+		boolean,
+		boolean,
+		string[],
+		string[],
+		string[],
+		string[],
+		string[],
+	],
+): AppendDeliveryPlan => ({
+	hasRemoteRecipients: row[0],
+	noPeerError: row[1],
+	defaultSendSilent: row[2],
+	sendTo: row[3],
+	ackTo: row[4],
+	silentTo: row[5],
+	repairTargets: row[6],
+	authoritativeRecipients: row[7],
+});
 
 export class SharedLogRangePlanner {
 	private constructor(
@@ -815,6 +867,46 @@ export class SharedLogNativeState {
 			leaders: rowsToSamples(leaderRows),
 			assignedToRangeBoundary,
 		};
+	}
+
+	planAppendLeadersForDelivery(
+		leaders: ReadonlyMap<string, LeaderSample>,
+		fullReplicaCandidates: Iterable<string>,
+		minReplicas: number,
+	): Map<string, LeaderSample> {
+		return rowsToSamples(
+			this.native.plan_append_leaders_for_delivery(
+				samplesToRows(leaders),
+				[...fullReplicaCandidates],
+				minReplicas,
+			),
+		);
+	}
+
+	planAppendDelivery(input: {
+		leaders: ReadonlyMap<string, LeaderSample>;
+		fallbackRecipients?: Iterable<string>;
+		minReplicas: number;
+		selfHash: string;
+		isLeader: boolean;
+		deliveryEnabled: boolean;
+		reliabilityAck: boolean;
+		minAcks?: number;
+		requireRecipients: boolean;
+	}): AppendDeliveryPlan {
+		return appendDeliveryPlanFromRow(
+			this.native.plan_append_delivery(
+				samplesToRows(input.leaders),
+				input.fallbackRecipients ? [...input.fallbackRecipients] : [],
+				input.minReplicas,
+				input.selfHash,
+				input.isLeader,
+				input.deliveryEnabled,
+				input.reliabilityAck,
+				input.minAcks,
+				input.requireRecipients,
+			),
+		);
 	}
 
 	planRepairDispatchForEntries(

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -839,6 +839,145 @@ struct RepairDispatchBatch {
     self_hash: String,
 }
 
+struct AppendDeliveryPlan {
+    has_remote_recipients: bool,
+    no_peer_error: bool,
+    default_send_silent: bool,
+    send_to: Vec<String>,
+    ack_to: Vec<String>,
+    silent_to: Vec<String>,
+    repair_targets: Vec<String>,
+    authoritative_recipients: Vec<String>,
+}
+
+fn expand_append_leaders(
+    leaders: Vec<LeaderSample>,
+    full_replica_candidates: Vec<String>,
+    min_replicas: usize,
+) -> Vec<LeaderSample> {
+    let mut expanded = IndexMap::new();
+    for leader in leaders {
+        expanded.insert(leader.hash, leader.intersecting);
+    }
+    if min_replicas >= full_replica_candidates.len().max(1) {
+        for peer in full_replica_candidates {
+            expanded.entry(peer).or_insert(true);
+        }
+    }
+    expanded
+        .into_iter()
+        .map(|(hash, intersecting)| LeaderSample { hash, intersecting })
+        .collect()
+}
+
+fn plan_append_delivery(
+    leaders: Vec<LeaderSample>,
+    fallback_recipients: Vec<String>,
+    min_replicas: usize,
+    self_hash: String,
+    is_leader: bool,
+    delivery_enabled: bool,
+    reliability_ack: bool,
+    min_acks: Option<usize>,
+    require_recipients: bool,
+) -> AppendDeliveryPlan {
+    let authoritative_recipients: Vec<String> =
+        leaders.into_iter().map(|leader| leader.hash).collect();
+    let mut send_set = IndexSet::new();
+    for peer in &authoritative_recipients {
+        send_set.insert(peer.clone());
+    }
+    for peer in fallback_recipients {
+        if peer != self_hash {
+            send_set.insert(peer);
+        }
+    }
+
+    let has_remote_recipients = send_set.iter().any(|peer| peer != &self_hash);
+    if !has_remote_recipients {
+        return AppendDeliveryPlan {
+            has_remote_recipients,
+            no_peer_error: require_recipients,
+            default_send_silent: is_leader,
+            send_to: Vec::new(),
+            ack_to: Vec::new(),
+            silent_to: Vec::new(),
+            repair_targets: Vec::new(),
+            authoritative_recipients,
+        };
+    }
+
+    if !delivery_enabled {
+        let repair_targets = authoritative_recipients
+            .iter()
+            .filter(|peer| *peer != &self_hash)
+            .cloned()
+            .collect();
+        return AppendDeliveryPlan {
+            has_remote_recipients,
+            no_peer_error: false,
+            default_send_silent: is_leader,
+            send_to: send_set.into_iter().collect(),
+            ack_to: Vec::new(),
+            silent_to: Vec::new(),
+            repair_targets,
+            authoritative_recipients,
+        };
+    }
+
+    let authoritative_set: IndexSet<String> = authoritative_recipients.iter().cloned().collect();
+    let ordered_remote_recipients: Vec<String> = send_set
+        .into_iter()
+        .filter(|peer| peer != &self_hash)
+        .collect();
+    let default_min_acks = min_replicas.saturating_sub(1);
+    let ack_limit = if reliability_ack {
+        min_acks.unwrap_or(default_min_acks)
+    } else {
+        0
+    }
+    .min(ordered_remote_recipients.len());
+
+    let mut ack_to = Vec::with_capacity(ack_limit);
+    let mut silent_to =
+        Vec::with_capacity(ordered_remote_recipients.len().saturating_sub(ack_limit));
+    let mut repair_targets = Vec::new();
+    for (index, peer) in ordered_remote_recipients.into_iter().enumerate() {
+        if authoritative_set.contains(&peer) {
+            repair_targets.push(peer.clone());
+        }
+        if index < ack_limit {
+            ack_to.push(peer);
+        } else {
+            silent_to.push(peer);
+        }
+    }
+    let no_peer_error = require_recipients && ack_to.is_empty() && silent_to.is_empty();
+    AppendDeliveryPlan {
+        has_remote_recipients,
+        no_peer_error,
+        default_send_silent: is_leader,
+        send_to: Vec::new(),
+        ack_to,
+        silent_to,
+        repair_targets,
+        authoritative_recipients,
+    }
+}
+
+fn append_delivery_plan_to_row(plan: AppendDeliveryPlan) -> Array {
+    let out = Array::new();
+    out.push(&JsValue::from_bool(plan.has_remote_recipients));
+    out.push(&JsValue::from_bool(plan.no_peer_error));
+    out.push(&JsValue::from_bool(plan.default_send_silent));
+    out.push(&strings_to_array(plan.send_to));
+    out.push(&strings_to_array(plan.ack_to));
+    out.push(&strings_to_array(plan.silent_to));
+    out.push(&strings_to_array(plan.repair_targets));
+    out.push(&strings_to_array(plan.authoritative_recipients));
+    out
+}
+
 fn plan_repair_dispatch_rows(batch: RepairDispatchBatch) -> Result<Array, JsValue> {
     let entry_count = batch.entry_hashes.len();
 
@@ -1700,6 +1839,45 @@ impl NativeSharedLogState {
         Ok(out)
     }
 
+    pub fn plan_append_leaders_for_delivery(
+        &self,
+        leaders: Array,
+        full_replica_candidates: Array,
+        min_replicas: usize,
+    ) -> Result<Array, JsValue> {
+        Ok(samples_to_rows(expand_append_leaders(
+            leader_samples_from_rows(leaders)?,
+            strings_from_array(full_replica_candidates)?,
+            min_replicas,
+        )))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn plan_append_delivery(
+        &self,
+        leaders: Array,
+        fallback_recipients: Array,
+        min_replicas: usize,
+        self_hash: String,
+        is_leader: bool,
+        delivery_enabled: bool,
+        reliability_ack: bool,
+        min_acks: JsValue,
+        require_recipients: bool,
+    ) -> Result<Array, JsValue> {
+        Ok(append_delivery_plan_to_row(plan_append_delivery(
+            leader_samples_from_rows(leaders)?,
+            strings_from_array(fallback_recipients)?,
+            min_replicas,
+            self_hash,
+            is_leader,
+            delivery_enabled,
+            reliability_ack,
+            optional_usize(min_acks)?,
+            require_recipients,
+        )))
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn plan_repair_dispatch_for_entries(
         &self,
@@ -1886,6 +2064,19 @@ fn usize_from_array(values: Array) -> Result<Vec<usize>, JsValue> {
     Ok(out)
 }
 
+fn optional_usize(value: JsValue) -> Result<Option<usize>, JsValue> {
+    if value.is_undefined() || value.is_null() {
+        return Ok(None);
+    }
+    let Some(value) = value.as_f64() else {
+        return Err(JsValue::from_str("Expected optional unsigned integer"));
+    };
+    if !value.is_finite() || value < 0.0 || value.fract() != 0.0 {
+        return Err(JsValue::from_str("Expected optional unsigned integer"));
+    }
+    Ok(Some(value as usize))
+}
+
 fn cursor_batches_from_array(values: Array) -> Result<Vec<Vec<u64>>, JsValue> {
     let batches = string_batches_from_array(values, "cursor batch array")?;
     let mut out = Vec::with_capacity(batches.len());
@@ -1950,6 +2141,24 @@ fn strings_to_array(values: Vec<String>) -> Array {
         out.push(&JsValue::from_str(&value));
     }
     out
+}
+
+fn leader_samples_from_rows(rows: Array) -> Result<Vec<LeaderSample>, JsValue> {
+    let mut out = Vec::with_capacity(rows.length() as usize);
+    for row in rows.iter() {
+        if !Array::is_array(&row) {
+            return Err(JsValue::from_str("Expected leader sample row"));
+        }
+        let row = Array::from(&row);
+        let Some(hash) = row.get(0).as_string() else {
+            return Err(JsValue::from_str("Expected leader hash string"));
+        };
+        let Some(intersecting) = row.get(1).as_bool() else {
+            return Err(JsValue::from_str("Expected leader intersecting bool"));
+        };
+        out.push(LeaderSample { hash, intersecting });
+    }
+    Ok(out)
 }
 
 fn numbers_to_rows(values: Vec<u64>, resolution: Resolution) -> Array {

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -337,6 +337,97 @@ describe("native shared-log range planner", () => {
 		expect(state.getEntryCoordinates("old-head")).to.equal(undefined);
 	});
 
+	it("expands append leaders with full-replica delivery candidates", async () => {
+		const state = await createSharedLogState("u32");
+		const leaders = new Map([["peer-a", { intersecting: false }]]);
+
+		expect(
+			state.planAppendLeadersForDelivery(
+				leaders,
+				["peer-b", "peer-c"],
+				2,
+			),
+		).to.deep.equal(
+			new Map([
+				["peer-a", { intersecting: false }],
+				["peer-b", { intersecting: true }],
+				["peer-c", { intersecting: true }],
+			]),
+		);
+		expect(
+			state.planAppendLeadersForDelivery(
+				leaders,
+				["peer-b", "peer-c"],
+				1,
+			),
+		).to.deep.equal(leaders);
+	});
+
+	it("plans append delivery recipients from native state", async () => {
+		const state = await createSharedLogState("u32");
+		const leaders = new Map([
+			["peer-self", { intersecting: true }],
+			["peer-a", { intersecting: true }],
+		]);
+
+		expect(
+			state.planAppendDelivery({
+				leaders,
+				fallbackRecipients: ["peer-b"],
+				minReplicas: 3,
+				selfHash: "peer-self",
+				isLeader: true,
+				deliveryEnabled: false,
+				reliabilityAck: false,
+				requireRecipients: false,
+			}),
+		).to.deep.equal({
+			hasRemoteRecipients: true,
+			noPeerError: false,
+			defaultSendSilent: true,
+			sendTo: ["peer-self", "peer-a", "peer-b"],
+			ackTo: [],
+			silentTo: [],
+			repairTargets: ["peer-a"],
+			authoritativeRecipients: ["peer-self", "peer-a"],
+		});
+
+		expect(
+			state.planAppendDelivery({
+				leaders,
+				fallbackRecipients: ["peer-b"],
+				minReplicas: 3,
+				selfHash: "peer-self",
+				isLeader: true,
+				deliveryEnabled: true,
+				reliabilityAck: true,
+				minAcks: 1,
+				requireRecipients: true,
+			}),
+		).to.deep.equal({
+			hasRemoteRecipients: true,
+			noPeerError: false,
+			defaultSendSilent: true,
+			sendTo: [],
+			ackTo: ["peer-a"],
+			silentTo: ["peer-b"],
+			repairTargets: ["peer-a"],
+			authoritativeRecipients: ["peer-self", "peer-a"],
+		});
+
+		expect(
+			state.planAppendDelivery({
+				leaders: new Map([["peer-self", { intersecting: true }]]),
+				minReplicas: 1,
+				selfHash: "peer-self",
+				isLeader: true,
+				deliveryEnabled: true,
+				reliabilityAck: true,
+				requireRecipients: true,
+			}).noPeerError,
+		).to.equal(true);
+	});
+
 	it("plans repair dispatch targets in one native batch", async () => {
 		const planner = await createRangePlanner("u32");
 


### PR DESCRIPTION
## Summary
- add native shared-log APIs for full-replica append leader expansion and append delivery planning
- expose typed TS wrappers for the internal native append delivery plan
- cover delivery expansion, ack/silent split, repair targets, and no-recipient behavior in the shared-log-rust test matrix

## Notes
This intentionally does not route the hot @peerbit/shared-log append path through the new planner yet. Local microbenching showed the boundary-only set-math call is slower than the JS path (roughly 1.76M ops/sec in JS vs 115k ops/sec through wasm for the small recipient case), so wiring it directly would regress single append. The value here is the native API shape and test coverage for the next larger native-owned append transaction where leader/delivery data can stay resident instead of round-tripping as JS Maps.

## Test Plan
- git diff --check
- pnpm --filter @peerbit/shared-log-rust run build
- pnpm --filter @peerbit/shared-log-rust run lint
- pnpm --filter @peerbit/shared-log-rust run test