### PR TITLE
feat: plan shared log append natively

### DIFF
--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -69,6 +69,11 @@ export type AppendDeliveryPlan = {
 	authoritativeRecipients: string[];
 };
 
+export type AppendEntryPlan = EntryAssignmentPlan & {
+	isLeader: boolean;
+	delivery: AppendDeliveryPlan;
+};
+
 export type LeaderBatchInput = {
 	cursors: Iterable<bigint | number | string>;
 	replicas: number;
@@ -308,6 +313,33 @@ type NativeSharedLogStateHandle = {
 		minAcks: number | undefined,
 		requireRecipients: boolean,
 	) => [boolean, boolean, boolean, string[], string[], string[], string[], string[]];
+	plan_append_for_gid: (
+		entryHash: string,
+		gid: string,
+		nextHashes: string[],
+		replicas: number,
+		fullReplicaCandidates: string[],
+		fallbackRecipients: string[],
+		deliverySelfHash: string,
+		deliveryEnabled: boolean,
+		reliabilityAck: boolean,
+		minAcks: number | undefined,
+		requireRecipients: boolean,
+		roleAgeMs: number,
+		now: string,
+		peerFilter: string[] | undefined,
+		expandPeerFilter: boolean,
+		selfHash: string,
+		includeSelf: boolean,
+		fullReplicaFallback: boolean,
+		includeStrictFullReplica: boolean,
+	) => [
+		unknown[],
+		unknown[],
+		boolean,
+		boolean,
+		[boolean, boolean, boolean, string[], string[], string[], string[], string[]],
+	];
 	plan_repair_dispatch_for_entries: (
 		entryHashes: string[],
 		entryGids: string[],
@@ -907,6 +939,49 @@ export class SharedLogNativeState {
 				input.requireRecipients,
 			),
 		);
+	}
+
+	planAppendForGid(
+		input: {
+			entryHash: string;
+			gid: string;
+			nextHashes?: Iterable<string>;
+			replicas: number;
+			fullReplicaCandidates?: Iterable<string>;
+			fallbackRecipients?: Iterable<string>;
+			selfHash: string;
+			deliveryEnabled: boolean;
+			reliabilityAck: boolean;
+			minAcks?: number;
+			requireRecipients: boolean;
+		},
+		options?: FindLeaderOptions,
+	): AppendEntryPlan {
+		const [coordinateRows, leaderRows, isLeader, assignedToRangeBoundary, delivery] =
+			this.native.plan_append_for_gid(
+				input.entryHash,
+				input.gid,
+				input.nextHashes ? [...input.nextHashes] : [],
+				input.replicas,
+				input.fullReplicaCandidates ? [...input.fullReplicaCandidates] : [],
+				input.fallbackRecipients ? [...input.fallbackRecipients] : [],
+				input.selfHash,
+				input.deliveryEnabled,
+				input.reliabilityAck,
+				input.minAcks,
+				input.requireRecipients,
+				...findLeaderArguments({
+					...options,
+					selfHash: input.selfHash,
+				}),
+			);
+		return {
+			coordinates: rowsToNumbers(this.resolution, coordinateRows),
+			leaders: rowsToSamples(leaderRows),
+			isLeader,
+			assignedToRangeBoundary,
+			delivery: appendDeliveryPlanFromRow(delivery),
+		};
 	}
 
 	planRepairDispatchForEntries(

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -850,6 +850,14 @@ struct AppendDeliveryPlan {
     authoritative_recipients: Vec<String>,
 }
 
+struct AppendEntryPlan {
+    coordinates: Vec<u64>,
+    leaders: Vec<LeaderSample>,
+    is_leader: bool,
+    assigned_to_range_boundary: bool,
+    delivery: AppendDeliveryPlan,
+}
+
 fn expand_append_leaders(
     leaders: Vec<LeaderSample>,
     full_replica_candidates: Vec<String>,
@@ -975,6 +983,16 @@ fn append_delivery_plan_to_row(plan: AppendDeliveryPlan) -> Array {
     out.push(&strings_to_array(plan.silent_to));
     out.push(&strings_to_array(plan.repair_targets));
     out.push(&strings_to_array(plan.authoritative_recipients));
+    out
+}
+
+fn append_entry_plan_to_row(plan: AppendEntryPlan, resolution: Resolution) -> Array {
+    let out = Array::new();
+    out.push(&numbers_to_rows(plan.coordinates, resolution));
+    out.push(&samples_to_rows(plan.leaders));
+    out.push(&JsValue::from_bool(plan.is_leader));
+    out.push(&JsValue::from_bool(plan.assigned_to_range_boundary));
+    out.push(&append_delivery_plan_to_row(plan.delivery));
     out
 }
 
@@ -1876,6 +1894,79 @@ impl NativeSharedLogState {
             optional_usize(min_acks)?,
             require_recipients,
         )))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn plan_append_for_gid(
+        &mut self,
+        entry_hash: String,
+        gid: String,
+        next_hashes: Array,
+        replicas: usize,
+        full_replica_candidates: Array,
+        fallback_recipients: Array,
+        delivery_self_hash: String,
+        delivery_enabled: bool,
+        reliability_ack: bool,
+        min_acks: JsValue,
+        require_recipients: bool,
+        role_age_ms: f64,
+        now: String,
+        peer_filter: JsValue,
+        expand_peer_filter: bool,
+        self_hash: String,
+        include_self: bool,
+        full_replica_fallback: bool,
+        include_strict_full_replica: bool,
+    ) -> Result<Array, JsValue> {
+        let next_hashes = strings_from_array(next_hashes)?;
+        let full_replica_candidates = strings_from_array(full_replica_candidates)?;
+        let fallback_recipients = strings_from_array(fallback_recipients)?;
+        let min_acks = optional_usize(min_acks)?;
+        let coordinates = self.inner.range_planner.get_gid_coordinates(&gid, replicas);
+        let options = find_leader_options(role_age_ms, &now, peer_filter)?;
+        let leaders = self.inner.range_planner.find_leaders(
+            &coordinates,
+            replicas,
+            &options,
+            expand_peer_filter,
+            &self_hash,
+            include_self,
+            full_replica_fallback,
+            include_strict_full_replica,
+        );
+        let is_leader = leaders.iter().any(|leader| leader.hash == self_hash);
+        let assigned_to_range_boundary = should_assign_to_range_boundary(&leaders, replicas);
+
+        self.inner
+            .entry_coordinates
+            .insert(entry_hash, coordinates.clone());
+        for next_hash in next_hashes {
+            self.inner.entry_coordinates.remove(&next_hash);
+        }
+
+        let delivery_leaders = expand_append_leaders(leaders, full_replica_candidates, replicas);
+        let delivery = plan_append_delivery(
+            delivery_leaders.clone(),
+            fallback_recipients,
+            replicas,
+            delivery_self_hash,
+            is_leader,
+            delivery_enabled,
+            reliability_ack,
+            min_acks,
+            require_recipients,
+        );
+        Ok(append_entry_plan_to_row(
+            AppendEntryPlan {
+                coordinates,
+                leaders: delivery_leaders,
+                is_leader,
+                assigned_to_range_boundary,
+                delivery,
+            },
+            self.inner.range_planner.resolution,
+        ))
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -428,6 +428,75 @@ describe("native shared-log range planner", () => {
 		).to.equal(true);
 	});
 
+	it("plans append assignment and delivery in one native state call", async () => {
+		const state = await createSharedLogState("u32");
+		const ranges = [
+			range({ id: "a", hash: "peer-self", start1: 0, end1: 10 }),
+			range({ id: "b", hash: "peer-a", start1: 20, end1: 30 }),
+		];
+		for (const item of ranges) {
+			state.put(item);
+		}
+		state.putEntryCoordinates("old-head", [1, 2]);
+
+		const leaderOptions = {
+			now: 1_000,
+			selfHash: "peer-self",
+			selfReplicating: true,
+			fullReplicaFallback: true,
+		};
+		const assignment = state.planEntryAssignmentForGid(
+			"entry-gid",
+			2,
+			leaderOptions,
+		);
+		const expandedLeaders = state.planAppendLeadersForDelivery(
+			assignment.leaders,
+			["peer-self", "peer-c"],
+			2,
+		);
+		const delivery = state.planAppendDelivery({
+			leaders: expandedLeaders,
+			fallbackRecipients: ["peer-fallback"],
+			minReplicas: 2,
+			selfHash: "peer-self",
+			isLeader: assignment.leaders.has("peer-self"),
+			deliveryEnabled: true,
+			reliabilityAck: true,
+			minAcks: 1,
+			requireRecipients: true,
+		});
+
+		const plan = state.planAppendForGid(
+			{
+				entryHash: "new-head",
+				gid: "entry-gid",
+				nextHashes: ["old-head"],
+				replicas: 2,
+				fullReplicaCandidates: ["peer-self", "peer-c"],
+				fallbackRecipients: ["peer-fallback"],
+				selfHash: "peer-self",
+				deliveryEnabled: true,
+				reliabilityAck: true,
+				minAcks: 1,
+				requireRecipients: true,
+			},
+			leaderOptions,
+		);
+
+		expect(plan).to.deep.equal({
+			coordinates: assignment.coordinates,
+			leaders: expandedLeaders,
+			isLeader: assignment.leaders.has("peer-self"),
+			assignedToRangeBoundary: assignment.assignedToRangeBoundary,
+			delivery,
+		});
+		expect(state.getEntryCoordinates("new-head")).to.deep.equal(
+			assignment.coordinates,
+		);
+		expect(state.getEntryCoordinates("old-head")).to.equal(undefined);
+	});
+
 	it("plans repair dispatch targets in one native batch", async () => {
 		const planner = await createRangePlanner("u32");
 

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -22,6 +22,7 @@ import {
 	toId,
 } from "@peerbit/indexer-interface";
 import {
+	type AppendDeliveryPlan,
 	type NativeReplicationRange,
 	type SharedLogNativeState,
 	type SharedLogRangePlanner,
@@ -279,6 +280,10 @@ type EntryLeaderPlan<R extends "u32" | "u64"> = {
 	leaders: LeaderMap;
 	isLeader: boolean;
 	assignedToRangeBoundary?: boolean;
+};
+
+type NativeAppendEntryPlan<R extends "u32" | "u64"> = EntryLeaderPlan<R> & {
+	delivery: AppendDeliveryPlan;
 };
 
 type EntryLeaderBatchItem<R extends "u32" | "u64"> = {
@@ -1394,6 +1399,7 @@ export class SharedLog<
 			selfHash: string,
 			isLeader: boolean,
 			deliveryArg: false | true | DeliveryOptions | undefined,
+			nativeDeliveryPlan?: AppendDeliveryPlan,
 		) {
 			const { delivery, reliability, requireRecipients, minAcks, wrap } =
 				this._parseDeliveryOptions(deliveryArg);
@@ -1406,14 +1412,16 @@ export class SharedLog<
 					? { timeoutMs: delivery.timeout, signal: delivery.signal }
 					: undefined;
 
-			const fullReplicaDeliveryCandidates =
-				await this.getFullReplicaRepairCandidates(undefined, {
-					includeSubscribers: false,
-				});
-			if (minReplicasValue >= Math.max(1, fullReplicaDeliveryCandidates.size)) {
-				for (const peer of fullReplicaDeliveryCandidates) {
-					if (!leaders.has(peer)) {
-						leaders.set(peer, { intersecting: true });
+			if (!nativeDeliveryPlan) {
+				const fullReplicaDeliveryCandidates =
+					await this.getFullReplicaRepairCandidates(undefined, {
+						includeSubscribers: false,
+					});
+				if (minReplicasValue >= Math.max(1, fullReplicaDeliveryCandidates.size)) {
+					for (const peer of fullReplicaDeliveryCandidates) {
+						if (!leaders.has(peer)) {
+							leaders.set(peer, { intersecting: true });
+						}
 					}
 				}
 			}
@@ -1425,7 +1433,69 @@ export class SharedLog<
 				replicas: minReplicasValue,
 			});
 			for await (const message of createExchangeHeadsMessages(this.log, [entry])) {
+				const leaderCountBeforeReferenceMerge = leaders.size;
 				await this._mergeLeadersFromGidReferences(message, minReplicasValue, leaders);
+				const canUseNativeDeliveryPlan =
+					!!nativeDeliveryPlan &&
+					nativeDeliveryPlan.hasRemoteRecipients &&
+					leaders.size === leaderCountBeforeReferenceMerge;
+				if (canUseNativeDeliveryPlan) {
+					if (!delivery) {
+						for (const peer of nativeDeliveryPlan.repairTargets) {
+							this.queueAppendBackfill(peer, entryReplicatedForRepair);
+						}
+						this.rpc
+							.send(message, {
+								mode: nativeDeliveryPlan.defaultSendSilent
+									? new SilentDelivery({
+											redundancy: 1,
+											to: nativeDeliveryPlan.sendTo,
+										})
+									: new AcknowledgeDelivery({
+											redundancy: 1,
+											to: nativeDeliveryPlan.sendTo,
+										}),
+							})
+							.catch((error) => logger.error(error));
+						continue;
+					}
+
+					if (requireRecipients && nativeDeliveryPlan.noPeerError) {
+						throw new NoPeersError(this.rpc.topic);
+					}
+
+					if (nativeDeliveryPlan.ackTo.length > 0) {
+						const payload = serialize(message);
+						for (const peer of nativeDeliveryPlan.ackTo) {
+							track(
+								(async () => {
+									await this._sendAckWithUnifiedHints({
+										peer,
+										message,
+										payload,
+										fanoutUnicastOptions,
+									});
+								})(),
+							);
+						}
+					}
+
+					if (nativeDeliveryPlan.silentTo.length > 0) {
+						this.rpc
+							.send(message, {
+								mode: new SilentDelivery({
+									redundancy: 1,
+									to: nativeDeliveryPlan.silentTo,
+								}),
+							})
+							.catch((error) => logger.error(error));
+					}
+					for (const peer of nativeDeliveryPlan.repairTargets) {
+						this.queueAppendBackfill(peer, entryReplicatedForRepair);
+					}
+					continue;
+				}
+
 				const authoritativeRecipients = new Set(leaders.keys());
 				const leadersForDelivery = delivery
 					? new Set(authoritativeRecipients)
@@ -3946,6 +4016,46 @@ export class SharedLog<
 		return { appendOptions, minReplicasValue };
 	}
 
+	private async planNativeAppendEntry(
+		entry: Entry<T>,
+		replicas: number,
+		deliveryArg: false | true | DeliveryOptions | undefined,
+	): Promise<NativeAppendEntryPlan<R> | undefined> {
+		if (!this._nativeSharedLogState || !this.canPlanNativeHashGid(entry)) {
+			return undefined;
+		}
+
+		const context = await this.createLeaderSelectionContext();
+		const fullReplicaDeliveryCandidates =
+			await this.getFullReplicaRepairCandidates(undefined, {
+				includeSubscribers: false,
+			});
+		const { delivery, reliability, requireRecipients, minAcks } =
+			this._parseDeliveryOptions(deliveryArg);
+		const plan = this._nativeSharedLogState.planAppendForGid(
+			{
+				entryHash: entry.hash,
+				gid: entry.meta.gid,
+				nextHashes: entry.meta.next,
+				replicas,
+				fullReplicaCandidates: fullReplicaDeliveryCandidates,
+				selfHash: context.selfHash,
+				deliveryEnabled: !!delivery,
+				reliabilityAck: reliability === "ack",
+				minAcks,
+				requireRecipients,
+			},
+			this.createNativeLeaderOptions(context),
+		);
+		return {
+			coordinates: plan.coordinates as NumberFromType<R>[],
+			leaders: plan.leaders,
+			isLeader: plan.isLeader,
+			assignedToRangeBoundary: plan.assignedToRangeBoundary,
+			delivery: plan.delivery,
+		};
+	}
+
 	private async processLocalAppend(
 		entry: Entry<T>,
 		removed: ShallowOrFullEntry<T>[],
@@ -3973,17 +4083,44 @@ export class SharedLog<
 		}
 
 		const selfHash = this.node.identity.publicKey.hashcode();
-		const {
-			coordinates,
-			leaders,
-			isLeader,
-		} = await this.planEntryLeaders(entry, properties.minReplicasValue, {
-			persist: {},
-		});
+		const target = options?.target;
+		const deliveryArg = options?.delivery;
+		const nativeAppendPlan =
+			target !== "all" && target !== "none"
+				? await this.planNativeAppendEntry(
+						entry,
+						properties.minReplicasValue,
+						deliveryArg,
+					)
+				: undefined;
+		let coordinates: NumberFromType<R>[];
+		let leaders: LeaderMap;
+		let isLeader: boolean;
+		let nativeDeliveryPlan: AppendDeliveryPlan | undefined;
+		if (nativeAppendPlan) {
+			coordinates = nativeAppendPlan.coordinates;
+			leaders = nativeAppendPlan.leaders;
+			isLeader = nativeAppendPlan.isLeader;
+			nativeDeliveryPlan = nativeAppendPlan.delivery;
+			await this.persistCoordinate({
+				leaders,
+				coordinates,
+				replicas: coordinates.length,
+				entry,
+				assignedToRangeBoundary: nativeAppendPlan.assignedToRangeBoundary,
+				commitNative: false,
+			});
+		} else {
+			({ coordinates, leaders, isLeader } = await this.planEntryLeaders(
+				entry,
+				properties.minReplicasValue,
+				{
+					persist: {},
+				},
+			));
+		}
 
 		if (options?.target !== "none") {
-			const target = options?.target;
-			const deliveryArg = options?.delivery;
 			const hasDelivery = !(deliveryArg === undefined || deliveryArg === false);
 
 			if (target === "all" && hasDelivery) {
@@ -4008,6 +4145,7 @@ export class SharedLog<
 					selfHash,
 					isLeader,
 					deliveryArg,
+					nativeDeliveryPlan,
 				);
 			}
 		}
@@ -6778,6 +6916,7 @@ export class SharedLog<
 		replicas: number;
 		prev?: EntryReplicated<R>;
 		assignedToRangeBoundary?: boolean;
+		commitNative?: boolean;
 	}) {
 		const assignedToRangeBoundary =
 			properties.assignedToRangeBoundary ??
@@ -6804,11 +6943,13 @@ export class SharedLog<
 				hashNumber,
 			}),
 		);
-		this._nativeSharedLogState?.commitEntryCoordinates(
-			properties.entry.hash,
-			properties.coordinates,
-			properties.entry.meta.next,
-		);
+		if (properties.commitNative !== false) {
+			this._nativeSharedLogState?.commitEntryCoordinates(
+				properties.entry.hash,
+				properties.coordinates,
+				properties.entry.meta.next,
+			);
+		}
 
 		for (const coordinate of properties.coordinates) {
 			this.coordinateToHash.add(coordinate, properties.entry.hash);


### PR DESCRIPTION
## Summary
- add a resident native shared-log append transaction planner for hash-gid entries
- combine gid coordinate planning, leader selection, full-replica delivery expansion, delivery recipient planning, and native coordinate commit into one wasm call
- wire the default shared-log append-to-replicators path to use the combined native plan when native state and hash gids are available
- keep existing JS fallback behavior for target=all, target=none, missing native state, missing hash gid, no-recipient subscriber fallback, and gid-reference leader merges

## Perf note
Local microbench, 100k iterations, comparing the previous separated native calls (`planEntryAssignmentForGid` + `commitEntryCoordinates` + `planAppendLeadersForDelivery` + `planAppendDelivery`) against the new combined native append plan:

- previous separated calls: ~112k ops/sec
- combined native append plan: ~195k ops/sec
- speedup: ~1.74x

This is the first append-side step that beats the boundary-only approach because it removes multiple JS/native crossings instead of moving just one tiny set operation.

## Test Plan
- git diff --check
- pnpm --filter @peerbit/shared-log-rust run build
- pnpm --filter @peerbit/shared-log-rust run lint
- pnpm --filter @peerbit/shared-log-rust run test
- pnpm --filter @peerbit/shared-log run build
- pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/index.ts
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "awaits transport acks when delivery is set for target=replicators"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "uses best-effort delivery when reliability is set to best-effort"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "throws when requireRecipients is true and there are no remotes"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "settles towards the current replicators"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "will prune on put 300 after join"