### PR TITLE
Use native graph for exchange head refs

### DIFF
--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -81,6 +81,7 @@ type NativeLogIndexHandle = {
 	max_head_data_u32: (gid?: string) => number | undefined;
 	head_join_entries: (gid?: string) => unknown[];
 	child_join_entries: (hash: string) => unknown[];
+	unique_reference_gids: (hash: string) => string[] | undefined;
 	plan_delete_recursively: (hashes: string[], skipFirst: boolean) => string[];
 	children: (hash: string) => string[];
 	count_has_next: (next: string, excludeHash?: string) => number;
@@ -295,6 +296,10 @@ export class LogGraphIndex {
 				},
 			};
 		});
+	}
+
+	uniqueReferenceGids(hash: string): string[] | undefined {
+		return this.native.unique_reference_gids(hash);
 	}
 
 	planDeleteRecursively(hashes: Iterable<string>, skipFirst = false): string[] {

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -3,7 +3,7 @@ use js_sys::{Array, Uint8Array};
 use peerbit_indexer_rust::planner::{
     DocumentFields, FieldValue, NativeQueryIndex, Query, SortDirection, SortField,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use wasm_bindgen::prelude::*;
 
 const FIELD_HASH: u32 = 1;
@@ -239,6 +239,34 @@ impl LogGraphIndex {
             .into_iter()
             .filter_map(|child_hash| self.entries.get(&child_hash).cloned())
             .collect()
+    }
+
+    pub fn unique_reference_gids(&self, hash: &str) -> Option<Vec<String>> {
+        let entry = self.entries.get(hash)?;
+        if entry.entry_type == ENTRY_TYPE_CUT {
+            return Some(Vec::new());
+        }
+
+        let mut visited_gids = IndexSet::new();
+        visited_gids.insert(entry.gid.clone());
+        let mut out = Vec::new();
+        let mut queue: VecDeque<String> = entry.next.iter().cloned().collect();
+
+        while let Some(next_hash) = queue.pop_front() {
+            let Some(next_entry) = self.entries.get(&next_hash) else {
+                return None;
+            };
+            if !visited_gids.insert(next_entry.gid.clone()) {
+                continue;
+            }
+            out.push(next_entry.gid.clone());
+            if next_entry.entry_type == ENTRY_TYPE_CUT {
+                continue;
+            }
+            queue.extend(next_entry.next.iter().cloned());
+        }
+
+        Some(out)
     }
 
     pub fn plan_delete_recursively(&self, from: &[String], skip_first: bool) -> Vec<String> {
@@ -555,6 +583,13 @@ impl NativeLogIndex {
 
     pub fn child_join_entries(&self, hash: &str) -> Array {
         log_join_entries_to_rows(self.inner.child_join_entries(hash))
+    }
+
+    pub fn unique_reference_gids(&self, hash: &str) -> JsValue {
+        self.inner
+            .unique_reference_gids(hash)
+            .map(|gids| strings_to_array(gids).into())
+            .unwrap_or(JsValue::UNDEFINED)
     }
 
     pub fn plan_delete_recursively(&self, from: Array, skip_first: bool) -> Result<Array, JsValue> {

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -206,6 +206,28 @@ describe("native log graph index", () => {
 		]);
 	});
 
+	it("plans unique reference gids for exchange heads", async () => {
+		const index = await createLogGraphIndex();
+		index.put(entry("root", "root-gid", [], 1n));
+		index.put(entry("same-gid-parent", "root-gid", [], 2n));
+		index.put(entry("side", "side-gid", [], 3n));
+		index.put(entry("branch", "branch-gid", ["root", "side"], 4n));
+		index.put(entry("head", "head-gid", ["branch", "same-gid-parent"], 5n));
+
+		expect(index.uniqueReferenceGids("head")).to.deep.equal([
+			"branch-gid",
+			"root-gid",
+			"side-gid",
+		]);
+		expect(index.uniqueReferenceGids("missing")).to.equal(undefined);
+
+		index.put(entry("cut", "cut-gid", ["head"], 6n, CUT));
+		expect(index.uniqueReferenceGids("cut")).to.deep.equal([]);
+
+		index.put(entry("incomplete", "incomplete-gid", ["not-indexed"], 7n));
+		expect(index.uniqueReferenceGids("incomplete")).to.equal(undefined);
+	});
+
 	it("plans recursive cut deletes", async () => {
 		const index = await createLogGraphIndex();
 		index.put(entry("root", "g", [], 1n));

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -80,6 +80,7 @@ export type NativeLogGraph = {
 	headEntries: (gid?: string) => SortableEntry[];
 	joinHeadEntries: (gid?: string) => NativeLogJoinEntry[];
 	childJoinEntries: (hash: string) => NativeLogJoinEntry[];
+	uniqueReferenceGids: (hash: string) => string[] | undefined;
 	planDeleteRecursively: (
 		hashes: Iterable<string>,
 		skipFirst?: boolean,
@@ -399,6 +400,13 @@ export class EntryIndex<T> {
 				meta: { type: true, next: true, gid: true, clock: true },
 			},
 		}).all() as Promise<NativeLogJoinEntry[]>;
+	}
+
+	getUniqueReferenceGids(hash: string): string[] | undefined {
+		if (!this.properties.nativeGraph) {
+			return undefined;
+		}
+		return this.properties.nativeGraph.graph.uniqueReferenceGids(hash);
 	}
 
 	planDeleteRecursively(

--- a/packages/programs/data/shared-log/benchmark/native-graph.ts
+++ b/packages/programs/data/shared-log/benchmark/native-graph.ts
@@ -1,12 +1,14 @@
 import { deserialize, field, option, serialize, variant } from "@dao-xyz/borsh";
 import { create as createRustIndexer } from "@peerbit/indexer-rust";
-import { type ProgramClient, Program } from "@peerbit/program";
+import { type Entry } from "@peerbit/log";
+import { Program, type ProgramClient } from "@peerbit/program";
 import { TestSession } from "@peerbit/test-utils";
 import crypto from "crypto";
 import { performance } from "node:perf_hooks";
+import { createExchangeHeadsMessages } from "../src/exchange-heads.js";
 import { type Args, SharedLog } from "../src/index.js";
 
-type Scenario = "auto-next" | "explicit-root-next";
+type Scenario = "auto-next" | "explicit-root-next" | "exchange-head-refs";
 type IndexerMode = "default" | "rust";
 
 type BenchRow = {
@@ -32,14 +34,18 @@ const parsePositiveInteger = (value: string | undefined, fallback: number) => {
 
 const parseScenarios = (value: string | undefined): Scenario[] => {
 	if (!value) {
-		return ["auto-next", "explicit-root-next"];
+		return ["auto-next", "explicit-root-next", "exchange-head-refs"];
 	}
 	const scenarios = value
 		.split(",")
 		.map((x) => x.trim())
 		.filter(Boolean);
 	for (const scenario of scenarios) {
-		if (scenario !== "auto-next" && scenario !== "explicit-root-next") {
+		if (
+			scenario !== "auto-next" &&
+			scenario !== "explicit-root-next" &&
+			scenario !== "exchange-head-refs"
+		) {
 			throw new Error(`Unknown scenario '${scenario}'`);
 		}
 	}
@@ -159,6 +165,50 @@ const runScenario = async (
 	const { session, store } = await openStore(nativeGraph, indexer);
 	const bytes = crypto.randomBytes(payloadBytes);
 	try {
+		if (scenario === "exchange-head-refs") {
+			const parents: Entry<BenchDocument>[] = [];
+			for (let i = 0; i < entries; i++) {
+				parents.push(
+					(
+						await store.logs.append(createDocument(i, bytes), {
+							meta: { next: [] },
+							replicate: false,
+							target: "none",
+						})
+					).entry,
+				);
+			}
+			const { entry: head } = await store.logs.append(
+				createDocument(entries, bytes),
+				{
+					meta: { next: parents },
+					replicate: false,
+					target: "none",
+				},
+			);
+
+			let emittedHeads = 0;
+			const started = performance.now();
+			for await (const message of createExchangeHeadsMessages(store.logs.log, [
+				head,
+			])) {
+				emittedHeads += message.heads.length;
+			}
+			if (emittedHeads === 0) {
+				throw new Error("Expected at least one exchange head message");
+			}
+			const elapsed = performance.now() - started;
+			return {
+				scenario,
+				indexer,
+				nativeGraph,
+				entries,
+				run,
+				elapsedMs: Math.round(elapsed),
+				opsPerSecond: Math.round((entries / elapsed) * 1000),
+			};
+		}
+
 		const started = performance.now();
 		for (let i = 0; i < entries; i++) {
 			await store.logs.append(createDocument(i, bytes), {
@@ -205,8 +255,7 @@ const aggregateRows = [...new Set(rows.map((row) => row.scenario))].flatMap(
 						row.nativeGraph === nativeGraph,
 				);
 				const meanMs =
-					samples.reduce((sum, row) => sum + row.elapsedMs, 0) /
-					samples.length;
+					samples.reduce((sum, row) => sum + row.elapsedMs, 0) / samples.length;
 				const meanOps =
 					samples.reduce((sum, row) => sum + row.opsPerSecond, 0) /
 					samples.length;

--- a/packages/programs/data/shared-log/src/exchange-heads.ts
+++ b/packages/programs/data/shared-log/src/exchange-heads.ts
@@ -76,13 +76,39 @@ export const createExchangeHeadsMessages = async function* (
 	let size = 0;
 	let current: EntryWithRefs<any>[] = [];
 	const visitedHeads = new Set<string>();
-	for (const fromHead of heads) {
+	const headArray = Array.isArray(heads) ? heads : [...heads];
+	const canUseNativeReferenceGids = headArray.length === 1;
+	for (const fromHead of headArray) {
 		let entry = fromHead instanceof Entry ? fromHead : await log.get(fromHead);
 		if (!entry) {
 			continue; // missing this entry, could be deleted while iterating
 		}
 
 		visitedHeads.add(entry.hash);
+
+		const nativeGidReferences = canUseNativeReferenceGids
+			? log.entryIndex.getUniqueReferenceGids(entry.hash)
+			: undefined;
+		if (nativeGidReferences) {
+			if (nativeGidReferences.length > 1000) {
+				warn("Large refs count: ", nativeGidReferences.length);
+			}
+			current.push(
+				new EntryWithRefs({
+					entry,
+					gidRefrences: nativeGidReferences,
+				}),
+			);
+			size += entry.size;
+			if (size > MAX_EXCHANGE_MESSAGE_SIZE) {
+				size = 0;
+				yield new ExchangeHeadsMessage({
+					heads: current,
+				});
+				current = [];
+			}
+			continue;
+		}
 
 		// TODO eventually we don't want to load all refs
 		// since majority of the old leader would not be interested in these anymore

--- a/packages/programs/data/shared-log/test/exchange-heads.spec.ts
+++ b/packages/programs/data/shared-log/test/exchange-heads.spec.ts
@@ -1,0 +1,69 @@
+import { AnyBlockStore } from "@peerbit/blocks";
+import { Ed25519Keypair } from "@peerbit/crypto";
+import { Log } from "@peerbit/log";
+import { expect } from "chai";
+import sinon from "sinon";
+import { createExchangeHeadsMessages } from "../src/exchange-heads.js";
+
+describe("exchange heads", () => {
+	let store: AnyBlockStore;
+	let signKey: Ed25519Keypair;
+
+	before(async () => {
+		store = new AnyBlockStore();
+		signKey = await Ed25519Keypair.create();
+		await store.start();
+	});
+
+	after(async () => {
+		await store.stop();
+	});
+
+	it("uses native graph reference gids for single-head messages", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			appendDurability: "strict",
+			nativeGraph: true,
+		});
+
+		const { entry: left } = await log.append(new Uint8Array([1]), {
+			meta: { next: [], gidSeed: new Uint8Array([1]) },
+		});
+		const { entry: right } = await log.append(new Uint8Array([2]), {
+			meta: { next: [], gidSeed: new Uint8Array([2]) },
+		});
+		const { entry: head } = await log.append(new Uint8Array([3]), {
+			meta: { next: [left, right] },
+		});
+		const expectedReferenceGids = [left, right]
+			.filter((entry) => entry.meta.gid !== head.meta.gid)
+			.map((entry) => entry.meta.gid);
+
+		const nativeGraph = log.entryIndex.properties.nativeGraph!.graph;
+		const uniqueReferenceGidsSpy = sinon.spy(
+			nativeGraph,
+			"uniqueReferenceGids",
+		);
+		const getShallowSpy = sinon.spy(log.entryIndex, "getShallow");
+		try {
+			const messages = [];
+			for await (const message of createExchangeHeadsMessages(log, [head])) {
+				messages.push(message);
+			}
+
+			expect(messages).to.have.length(1);
+			expect(messages[0]!.heads).to.have.length(1);
+			expect(messages[0]!.heads[0]!.entry.hash).equal(head.hash);
+			expect(messages[0]!.heads[0]!.gidRefrences).to.deep.equal(
+				expectedReferenceGids,
+			);
+			expect(uniqueReferenceGidsSpy.calledOnceWithExactly(head.hash)).to.be
+				.true;
+			expect(getShallowSpy.callCount).equal(0);
+		} finally {
+			getShallowSpy.restore();
+			uniqueReferenceGidsSpy.restore();
+			await log.close();
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- add a Rust log-graph planner for unique exchange-head reference gids
- route single-head shared-log exchange messages through the native graph when available
- fall back to the existing TypeScript/index walk if the native graph cannot fully resolve the ancestry
- add focused shared-log coverage plus an `exchange-head-refs` native graph benchmark scenario

## Why
This removes the JS `allEntriesWithUniqueGids` shallow-parent walk from the common single-head exchange-head path used during append/join delivery. The old path repeatedly crosses through the TS index API; the new path plans gid refs inside the resident native log graph and only returns the compact gid list.

## Local verification
- `cargo fmt --check` in `packages/log/rust`
- `pnpm exec prettier --check packages/log/rust/test/index.spec.ts packages/programs/data/shared-log/src/exchange-heads.ts`
- `pnpm --filter @peerbit/log-rust run test`
- `pnpm --filter @peerbit/shared-log run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "uses native graph reference gids"`
- `pnpm exec eslint --config eslint.config.js packages/log/src/entry-index.ts packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/programs/data/shared-log/src/exchange-heads.ts packages/programs/data/shared-log/test/exchange-heads.spec.ts packages/programs/data/shared-log/benchmark/native-graph.ts`

## Benchmark signal
`PEERBIT_SHARED_LOG_NATIVE_GRAPH_ENTRIES=1000 PEERBIT_SHARED_LOG_NATIVE_GRAPH_RUNS=1 PEERBIT_SHARED_LOG_NATIVE_GRAPH_INDEXERS=rust PEERBIT_SHARED_LOG_NATIVE_GRAPH_SCENARIOS=exchange-head-refs pnpm --filter @peerbit/shared-log run benchmark:native-graph`

- nativeGraph=false: 13 ms, ~74.6k refs/sec
- nativeGraph=true: 1 ms, ~701k refs/sec
