### PR TITLE
Batch native shared log append planning

### DIFF
--- a/packages/programs/data/shared-log/benchmark/native-graph.ts
+++ b/packages/programs/data/shared-log/benchmark/native-graph.ts
@@ -8,7 +8,11 @@ import { performance } from "node:perf_hooks";
 import { createExchangeHeadsMessages } from "../src/exchange-heads.js";
 import { type Args, SharedLog } from "../src/index.js";
 
-type Scenario = "auto-next" | "explicit-root-next" | "exchange-head-refs";
+type Scenario =
+	| "auto-next"
+	| "append-many"
+	| "explicit-root-next"
+	| "exchange-head-refs";
 type IndexerMode = "default" | "rust";
 
 type BenchRow = {
@@ -34,7 +38,12 @@ const parsePositiveInteger = (value: string | undefined, fallback: number) => {
 
 const parseScenarios = (value: string | undefined): Scenario[] => {
 	if (!value) {
-		return ["auto-next", "explicit-root-next", "exchange-head-refs"];
+		return [
+			"auto-next",
+			"append-many",
+			"explicit-root-next",
+			"exchange-head-refs",
+		];
 	}
 	const scenarios = value
 		.split(",")
@@ -43,6 +52,7 @@ const parseScenarios = (value: string | undefined): Scenario[] => {
 	for (const scenario of scenarios) {
 		if (
 			scenario !== "auto-next" &&
+			scenario !== "append-many" &&
 			scenario !== "explicit-root-next" &&
 			scenario !== "exchange-head-refs"
 		) {
@@ -210,12 +220,20 @@ const runScenario = async (
 		}
 
 		const started = performance.now();
-		for (let i = 0; i < entries; i++) {
-			await store.logs.append(createDocument(i, bytes), {
-				...(scenario === "explicit-root-next"
-					? { meta: { next: [] } }
-					: undefined),
-			});
+		if (scenario === "append-many") {
+			await store.logs.appendMany(
+				Array.from({ length: entries }, (_, index) =>
+					createDocument(index, bytes),
+				),
+			);
+		} else {
+			for (let i = 0; i < entries; i++) {
+				await store.logs.append(createDocument(i, bytes), {
+					...(scenario === "explicit-root-next"
+						? { meta: { next: [] } }
+						: undefined),
+				});
+			}
 		}
 		const elapsed = performance.now() - started;
 		return {

--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -74,6 +74,13 @@ export type AppendEntryPlan = EntryAssignmentPlan & {
 	delivery: AppendDeliveryPlan;
 };
 
+export type AppendEntryBatchInput = {
+	entryHash: string;
+	gid: string;
+	nextHashes?: Iterable<string>;
+	replicas: number;
+};
+
 export type LeaderBatchInput = {
 	cursors: Iterable<bigint | number | string>;
 	replicas: number;
@@ -340,6 +347,33 @@ type NativeSharedLogStateHandle = {
 		boolean,
 		[boolean, boolean, boolean, string[], string[], string[], string[], string[]],
 	];
+	plan_append_for_gids_batch: (
+		entryHashes: string[],
+		gids: string[],
+		nextHashBatches: string[][],
+		replicaCounts: number[],
+		fullReplicaCandidates: string[],
+		fallbackRecipients: string[],
+		deliverySelfHash: string,
+		deliveryEnabled: boolean,
+		reliabilityAck: boolean,
+		minAcks: number | undefined,
+		requireRecipients: boolean,
+		roleAgeMs: number,
+		now: string,
+		peerFilter: string[] | undefined,
+		expandPeerFilter: boolean,
+		selfHash: string,
+		includeSelf: boolean,
+		fullReplicaFallback: boolean,
+		includeStrictFullReplica: boolean,
+	) => [
+		unknown[],
+		unknown[],
+		boolean,
+		boolean,
+		[boolean, boolean, boolean, string[], string[], string[], string[], string[]],
+	][];
 	plan_repair_dispatch_for_entries: (
 		entryHashes: string[],
 		entryGids: string[],
@@ -982,6 +1016,54 @@ export class SharedLogNativeState {
 			assignedToRangeBoundary,
 			delivery: appendDeliveryPlanFromRow(delivery),
 		};
+	}
+
+	planAppendForGidsBatch(
+		input: {
+			entries: Iterable<AppendEntryBatchInput>;
+			fullReplicaCandidates?: Iterable<string>;
+			fallbackRecipients?: Iterable<string>;
+			selfHash: string;
+			deliveryEnabled: boolean;
+			reliabilityAck: boolean;
+			minAcks?: number;
+			requireRecipients: boolean;
+		},
+		options?: FindLeaderOptions,
+	): AppendEntryPlan[] {
+		const entries = [...input.entries];
+		const rows = this.native.plan_append_for_gids_batch(
+			entries.map((entry) => entry.entryHash),
+			entries.map((entry) => entry.gid),
+			entries.map((entry) => (entry.nextHashes ? [...entry.nextHashes] : [])),
+			entries.map((entry) => entry.replicas),
+			input.fullReplicaCandidates ? [...input.fullReplicaCandidates] : [],
+			input.fallbackRecipients ? [...input.fallbackRecipients] : [],
+			input.selfHash,
+			input.deliveryEnabled,
+			input.reliabilityAck,
+			input.minAcks,
+			input.requireRecipients,
+			...findLeaderArguments({
+				...options,
+				selfHash: input.selfHash,
+			}),
+		);
+		return rows.map(
+			([
+				coordinateRows,
+				leaderRows,
+				isLeader,
+				assignedToRangeBoundary,
+				delivery,
+			]) => ({
+				coordinates: rowsToNumbers(this.resolution, coordinateRows),
+				leaders: rowsToSamples(leaderRows),
+				isLeader,
+				assignedToRangeBoundary,
+				delivery: appendDeliveryPlanFromRow(delivery),
+			}),
+		);
 	}
 
 	planRepairDispatchForEntries(

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -1970,6 +1970,108 @@ impl NativeSharedLogState {
     }
 
     #[allow(clippy::too_many_arguments)]
+    pub fn plan_append_for_gids_batch(
+        &mut self,
+        entry_hashes: Array,
+        gids: Array,
+        next_hash_batches: Array,
+        replica_counts: Array,
+        full_replica_candidates: Array,
+        fallback_recipients: Array,
+        delivery_self_hash: String,
+        delivery_enabled: bool,
+        reliability_ack: bool,
+        min_acks: JsValue,
+        require_recipients: bool,
+        role_age_ms: f64,
+        now: String,
+        peer_filter: JsValue,
+        expand_peer_filter: bool,
+        self_hash: String,
+        include_self: bool,
+        full_replica_fallback: bool,
+        include_strict_full_replica: bool,
+    ) -> Result<Array, JsValue> {
+        let entry_hashes = strings_from_array(entry_hashes)?;
+        let gids = strings_from_array(gids)?;
+        let next_hash_batches =
+            string_batches_from_array(next_hash_batches, "append next hash batch array")?;
+        let replica_counts = usize_from_array(replica_counts)?;
+        ensure_same_len(entry_hashes.len(), gids.len(), "append entry gid")?;
+        ensure_same_len(
+            entry_hashes.len(),
+            next_hash_batches.len(),
+            "append next hash",
+        )?;
+        ensure_same_len(entry_hashes.len(), replica_counts.len(), "append replica")?;
+
+        let full_replica_candidates = strings_from_array(full_replica_candidates)?;
+        let fallback_recipients = strings_from_array(fallback_recipients)?;
+        let min_acks = optional_usize(min_acks)?;
+        let options = find_leader_options(role_age_ms, &now, peer_filter)?;
+        let mut prepared_options_by_replicas = HashMap::new();
+        let mut full_replica_leaders_by_replicas = HashMap::new();
+        let out = Array::new();
+
+        for (((entry_hash, gid), next_hashes), replicas) in entry_hashes
+            .into_iter()
+            .zip(gids)
+            .zip(next_hash_batches)
+            .zip(replica_counts)
+        {
+            let coordinates = self.inner.range_planner.get_gid_coordinates(&gid, replicas);
+            let leaders = find_leaders_with_batch_caches(
+                &self.inner.range_planner,
+                &coordinates,
+                replicas,
+                &options,
+                &mut prepared_options_by_replicas,
+                &mut full_replica_leaders_by_replicas,
+                expand_peer_filter,
+                &self_hash,
+                include_self,
+                full_replica_fallback,
+                include_strict_full_replica,
+            );
+            let is_leader = leaders.iter().any(|leader| leader.hash == self_hash);
+            let assigned_to_range_boundary = should_assign_to_range_boundary(&leaders, replicas);
+
+            self.inner
+                .entry_coordinates
+                .insert(entry_hash, coordinates.clone());
+            for next_hash in next_hashes {
+                self.inner.entry_coordinates.remove(&next_hash);
+            }
+
+            let delivery_leaders =
+                expand_append_leaders(leaders, full_replica_candidates.clone(), replicas);
+            let delivery = plan_append_delivery(
+                delivery_leaders.clone(),
+                fallback_recipients.clone(),
+                replicas,
+                delivery_self_hash.clone(),
+                is_leader,
+                delivery_enabled,
+                reliability_ack,
+                min_acks,
+                require_recipients,
+            );
+            out.push(&append_entry_plan_to_row(
+                AppendEntryPlan {
+                    coordinates,
+                    leaders: delivery_leaders,
+                    is_leader,
+                    assigned_to_range_boundary,
+                    delivery,
+                },
+                self.inner.range_planner.resolution,
+            ));
+        }
+
+        Ok(out)
+    }
+
+    #[allow(clippy::too_many_arguments)]
     pub fn plan_repair_dispatch_for_entries(
         &self,
         entry_hashes: Array,

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -497,6 +497,75 @@ describe("native shared-log range planner", () => {
 		expect(state.getEntryCoordinates("old-head")).to.equal(undefined);
 	});
 
+	it("plans append assignments and delivery in one native state batch", async () => {
+		const singleState = await createSharedLogState("u32");
+		const batchState = await createSharedLogState("u32");
+		const ranges = [
+			range({ id: "a", hash: "peer-self", start1: 0, end1: 10 }),
+			range({ id: "b", hash: "peer-a", start1: 20, end1: 30 }),
+		];
+		for (const item of ranges) {
+			singleState.put(item);
+			batchState.put(item);
+		}
+		singleState.putEntryCoordinates("old-head", [1, 2]);
+		batchState.putEntryCoordinates("old-head", [1, 2]);
+
+		const leaderOptions = {
+			now: 1_000,
+			selfHash: "peer-self",
+			selfReplicating: true,
+			fullReplicaFallback: true,
+		};
+		const entries = [
+			{
+				entryHash: "new-head-a",
+				gid: "entry-gid-a",
+				nextHashes: ["old-head"],
+				replicas: 2,
+			},
+			{
+				entryHash: "new-head-b",
+				gid: "entry-gid-b",
+				nextHashes: ["new-head-a"],
+				replicas: 2,
+			},
+		];
+		const commonInput = {
+			fullReplicaCandidates: ["peer-self", "peer-c"],
+			fallbackRecipients: ["peer-fallback"],
+			selfHash: "peer-self",
+			deliveryEnabled: true,
+			reliabilityAck: true,
+			minAcks: 1,
+			requireRecipients: true,
+		};
+
+		const expected = entries.map((entry) =>
+			singleState.planAppendForGid(
+				{
+					...entry,
+					...commonInput,
+				},
+				leaderOptions,
+			),
+		);
+		const actual = batchState.planAppendForGidsBatch(
+			{
+				entries,
+				...commonInput,
+			},
+			leaderOptions,
+		);
+
+		expect(actual).to.deep.equal(expected);
+		expect(batchState.getEntryCoordinates("old-head")).to.equal(undefined);
+		expect(batchState.getEntryCoordinates("new-head-a")).to.equal(undefined);
+		expect(batchState.getEntryCoordinates("new-head-b")).to.deep.equal(
+			actual[1]!.coordinates,
+		);
+	});
+
 	it("plans repair dispatch targets in one native batch", async () => {
 		const planner = await createRangePlanner("u32");
 

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -3965,10 +3965,21 @@ export class SharedLog<
 			return result;
 		}
 
-		for (const entry of result.entries) {
+		const nativeAppendPlans =
+			options?.replicate === true
+				? undefined
+				: await this.planNativeAppendEntries(
+						result.entries,
+						minReplicasValue,
+						options?.delivery,
+						options,
+					);
+		for (let i = 0; i < result.entries.length; i++) {
+			const entry = result.entries[i]!;
 			await this.processLocalAppend(entry, [], options, {
 				minReplicasValue,
 				deferHeadCoordinatePersistence: false,
+				nativeAppendPlan: nativeAppendPlans?.[i],
 			});
 		}
 		return result;
@@ -4056,6 +4067,56 @@ export class SharedLog<
 		};
 	}
 
+	private async planNativeAppendEntries(
+		entries: Entry<T>[],
+		replicas: number,
+		deliveryArg: false | true | DeliveryOptions | undefined,
+		options: SharedAppendOptions<T> | undefined,
+	): Promise<NativeAppendEntryPlan<R>[] | undefined> {
+		const target = options?.target;
+		if (
+			target === "all" ||
+			target === "none" ||
+			!this._nativeSharedLogState ||
+			entries.length === 0 ||
+			!entries.every((entry) => this.canPlanNativeHashGid(entry))
+		) {
+			return undefined;
+		}
+
+		const context = await this.createLeaderSelectionContext();
+		const fullReplicaDeliveryCandidates =
+			await this.getFullReplicaRepairCandidates(undefined, {
+				includeSubscribers: false,
+			});
+		const { delivery, reliability, requireRecipients, minAcks } =
+			this._parseDeliveryOptions(deliveryArg);
+		const plans = this._nativeSharedLogState.planAppendForGidsBatch(
+			{
+				entries: entries.map((entry) => ({
+					entryHash: entry.hash,
+					gid: entry.meta.gid,
+					nextHashes: entry.meta.next,
+					replicas,
+				})),
+				fullReplicaCandidates: fullReplicaDeliveryCandidates,
+				selfHash: context.selfHash,
+				deliveryEnabled: !!delivery,
+				reliabilityAck: reliability === "ack",
+				minAcks,
+				requireRecipients,
+			},
+			this.createNativeLeaderOptions(context),
+		);
+		return plans.map((plan) => ({
+			coordinates: plan.coordinates as NumberFromType<R>[],
+			leaders: plan.leaders,
+			isLeader: plan.isLeader,
+			assignedToRangeBoundary: plan.assignedToRangeBoundary,
+			delivery: plan.delivery,
+		}));
+	}
+
 	private async processLocalAppend(
 		entry: Entry<T>,
 		removed: ShallowOrFullEntry<T>[],
@@ -4063,6 +4124,7 @@ export class SharedLog<
 		properties: {
 			minReplicasValue: number;
 			deferHeadCoordinatePersistence?: boolean;
+			nativeAppendPlan?: NativeAppendEntryPlan<R>;
 		},
 	) {
 		const deferHeadCoordinatePersistence =
@@ -4086,13 +4148,14 @@ export class SharedLog<
 		const target = options?.target;
 		const deliveryArg = options?.delivery;
 		const nativeAppendPlan =
-			target !== "all" && target !== "none"
+			properties.nativeAppendPlan ??
+			(target !== "all" && target !== "none"
 				? await this.planNativeAppendEntry(
 						entry,
 						properties.minReplicasValue,
 						deliveryArg,
 					)
-				: undefined;
+				: undefined);
 		let coordinates: NumberFromType<R>[];
 		let leaders: LeaderMap;
 		let isLeader: boolean;

--- a/packages/programs/data/shared-log/test/append.spec.ts
+++ b/packages/programs/data/shared-log/test/append.spec.ts
@@ -74,4 +74,30 @@ describe("append", () => {
 			true,
 		]);
 	});
+
+	it("appendMany plans local append assignments in one native batch", async () => {
+		session = await TestSession.disconnected(1);
+		const store = await session.peers[0].open(new EventStore<string, any>(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const nativeState = (store.log as any)._nativeSharedLogState;
+		expect(nativeState).to.exist;
+		const batchSpy = sinon.spy(nativeState, "planAppendForGidsBatch");
+		const singleSpy = sinon.spy(nativeState, "planAppendForGid");
+		try {
+			await store.addMany(["a", "b", "c"], {
+				delivery: false,
+				replicate: false,
+			});
+
+			expect(batchSpy.callCount).equal(1);
+			expect(singleSpy.callCount).equal(0);
+		} finally {
+			batchSpy.restore();
+			singleSpy.restore();
+		}
+	});
 });


### PR DESCRIPTION
## Summary
- add `planAppendForGidsBatch` to the resident native shared-log state
- wire `SharedLog.appendMany` to batch native append assignment/delivery planning for normal hash/gid append paths
- preserve existing fallback behavior for target=`all`, target=`none`, explicit replicate, missing native state, and non-hash domains
- add native-state parity coverage plus a shared-log test proving `appendMany` uses one batch native call and zero per-entry native append plan calls
- add an `append-many` scenario to the shared-log native graph benchmark

## Why
`appendMany` previously entered `processLocalAppend` once per entry and each iteration could rebuild the same leader-selection context and call into native planning separately. This PR coalesces that planning into one JS -> native call while keeping delivery/prune processing in the existing TypeScript loop.

## Local verification
- `cargo fmt --check` in `packages/programs/data/shared-log/rust`
- `pnpm --filter @peerbit/shared-log-rust run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/shared-log-rust run test`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "appendMany plans local append assignments in one native batch"`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/benchmark/native-graph.ts packages/programs/data/shared-log/rust/src/index.ts packages/programs/data/shared-log/rust/test/index.spec.ts packages/programs/data/shared-log/src/index.ts packages/programs/data/shared-log/test/append.spec.ts`

## Benchmark signal
`PEERBIT_SHARED_LOG_NATIVE_GRAPH_ENTRIES=500 PEERBIT_SHARED_LOG_NATIVE_GRAPH_RUNS=1 PEERBIT_SHARED_LOG_NATIVE_GRAPH_INDEXERS=rust PEERBIT_SHARED_LOG_NATIVE_GRAPH_SCENARIOS=append-many pnpm --filter @peerbit/shared-log run benchmark:native-graph`

- nativeGraph=false: 150 ms, ~3.3k entries/sec
- nativeGraph=true: 133 ms, ~3.8k entries/sec
