### PR TITLE
Coalesce shared log appendMany processing

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -3965,6 +3965,13 @@ export class SharedLog<
 			return result;
 		}
 
+		if (this.canCoalesceLocalAppendMany(result.entries, options)) {
+			await this.processLocalAppendManyCoalesced(result, options, {
+				minReplicasValue,
+			});
+			return result;
+		}
+
 		const nativeAppendPlans =
 			options?.replicate === true
 				? undefined
@@ -3983,6 +3990,56 @@ export class SharedLog<
 			});
 		}
 		return result;
+	}
+
+	private canCoalesceLocalAppendMany(
+		entries: Entry<T>[],
+		options?: SharedAppendOptions<T>,
+	): boolean {
+		if (
+			entries.length <= 1 ||
+			options?.target === "all" ||
+			options?.target === "none" ||
+			options?.replicate === true ||
+			(options?.delivery !== undefined && options.delivery !== false)
+		) {
+			return false;
+		}
+
+		for (let i = 1; i < entries.length; i++) {
+			const previous = entries[i - 1]!;
+			const entry = entries[i]!;
+			if (
+				entry.meta.next.length !== 1 ||
+				entry.meta.next[0] !== previous.hash ||
+				entry.meta.gid !== previous.meta.gid
+			) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private async processLocalAppendManyCoalesced(
+		result: {
+			entries: Entry<T>[];
+			removed: ShallowOrFullEntry<T>[];
+		},
+		options: SharedAppendOptions<T> | undefined,
+		properties: {
+			minReplicasValue: number;
+		},
+	): Promise<void> {
+		const head = result.entries[result.entries.length - 1]!;
+		await this.deleteCoordinatesForHashes([
+			...result.entries[0]!.meta.next,
+			...result.entries.slice(0, -1).map((entry) => entry.hash),
+			...result.removed.map((entry) => entry.hash),
+		]);
+		await this.processLocalAppend(head, result.removed, options, {
+			minReplicasValue: properties.minReplicasValue,
+			deferHeadCoordinatePersistence: false,
+		});
 	}
 
 	private createLogAppendOptions(options?: SharedAppendOptions<T>): {

--- a/packages/programs/data/shared-log/test/append.spec.ts
+++ b/packages/programs/data/shared-log/test/append.spec.ts
@@ -89,12 +89,42 @@ describe("append", () => {
 		const singleSpy = sinon.spy(nativeState, "planAppendForGid");
 		try {
 			await store.addMany(["a", "b", "c"], {
-				delivery: false,
+				delivery: true,
 				replicate: false,
 			});
 
 			expect(batchSpy.callCount).equal(1);
 			expect(singleSpy.callCount).equal(0);
+		} finally {
+			batchSpy.restore();
+			singleSpy.restore();
+		}
+	});
+
+	it("appendMany coalesces a local chain to the final shared-log head", async () => {
+		session = await TestSession.disconnected(1);
+		const store = await session.peers[0].open(new EventStore<string, any>(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const nativeState = (store.log as any)._nativeSharedLogState;
+		expect(nativeState).to.exist;
+		const batchSpy = sinon.spy(nativeState, "planAppendForGidsBatch");
+		const singleSpy = sinon.spy(nativeState, "planAppendForGid");
+		try {
+			const result = await store.addMany(["a", "b", "c"], {
+				replicate: false,
+			});
+
+			expect(batchSpy.callCount).equal(0);
+			expect(singleSpy.callCount).equal(1);
+			const coordinateRows = await store.log.entryCoordinatesIndex
+				.iterate({}, { shape: { hash: true } })
+				.all();
+			expect(coordinateRows).to.have.length(1);
+			expect(coordinateRows[0]!.value.hash).equal(result.entries[2]!.hash);
 		} finally {
 			batchSpy.restore();
 			singleSpy.restore();


### PR DESCRIPTION
## Summary
- coalesce normal local `SharedLog.appendMany` chains to one shared-log final-head processing step
- clean stale coordinate rows for the initial old heads and intermediate chain entries in one batch
- preserve the existing per-entry path for target=`all`, target=`none`, explicit replication, and explicit ack delivery
- keep explicit delivery appendMany on the native batch planner path from the previous PR
- add focused coverage for both the explicit-delivery native batch path and the normal coalesced final-head path

## Why
After native batch planning, the normal appendMany path was still paying most of the shared-log cost once per intermediate entry. For a local appendMany chain, the final head represents the chain and intermediate entries should not remain shared-log heads. This PR removes the repeated shared-log delivery/persist/prune work for those intermediates.

## Local verification
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/index.ts packages/programs/data/shared-log/test/append.spec.ts`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "appendMany (plans local append assignments in one native batch|coalesces a local chain)"`

## Benchmark signal
`PEERBIT_SHARED_LOG_NATIVE_GRAPH_ENTRIES=500 PEERBIT_SHARED_LOG_NATIVE_GRAPH_RUNS=3 PEERBIT_SHARED_LOG_NATIVE_GRAPH_INDEXERS=rust PEERBIT_SHARED_LOG_NATIVE_GRAPH_SCENARIOS=append-many pnpm --filter @peerbit/shared-log run benchmark:native-graph`

- nativeGraph=false: 62 ms, ~8.3k entries/sec
- nativeGraph=true: 61 ms, ~8.2k entries/sec

Previous local run on the parent PR was roughly ~4.8k to ~4.9k entries/sec for this same scenario, so this is about a 1.7x improvement for normal appendMany.
