### PR TITLE
Batch rust index writes during appendMany

### DIFF
--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -43,6 +43,10 @@ type BlocksWithGetMany = Blocks & {
 	) => Promise<Array<Uint8Array | undefined>> | Array<Uint8Array | undefined>;
 };
 
+type IndexWithPutBatch<T extends Record<string, any>> = Index<T> & {
+	putBatch?: (values: T[]) => Promise<void> | void;
+};
+
 type NativeLogEntry = {
 	hash: string;
 	gid: string;
@@ -946,6 +950,10 @@ export class EntryIndex<T> {
 		const promise = (async () => {
 			const batchHashes = new Set(entries.map((entry) => entry.hash));
 			const externalNexts = new Set<string>();
+			const putBatch =
+				!this.properties.onGidRemoved &&
+				(this.properties.index as IndexWithPutBatch<ShallowEntry>).putBatch;
+			const shallowEntries: ShallowEntry[] = [];
 			for (let i = 0; i < entries.length; i++) {
 				const entry = entries[i];
 				const isHead = i === entries.length - 1;
@@ -955,14 +963,29 @@ export class EntryIndex<T> {
 
 				this.cache.add(entry.hash, entry);
 				const shallowEntry = entry.toShallow(isHead);
-				await this.properties.index.put(shallowEntry);
-				this.properties.nativeGraph?.graph.put(toNativeLogEntry(shallowEntry));
-				await this.notifyShadowedGids(entry);
+				if (putBatch) {
+					shallowEntries.push(shallowEntry);
+				} else {
+					await this.properties.index.put(shallowEntry);
+					this.properties.nativeGraph?.graph.put(
+						toNativeLogEntry(shallowEntry),
+					);
+					await this.notifyShadowedGids(entry);
+				}
 
 				for (const next of entry.meta.next) {
 					if (!batchHashes.has(next)) {
 						externalNexts.add(next);
 					}
+				}
+			}
+
+			if (putBatch) {
+				await putBatch.call(this.properties.index, shallowEntries);
+				for (const shallowEntry of shallowEntries) {
+					this.properties.nativeGraph?.graph.put(
+						toNativeLogEntry(shallowEntry),
+					);
 				}
 			}
 

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -636,7 +636,6 @@ export class Log<T> {
 		await this.putAppendEntries(entries, options);
 
 		for (const entry of entries) {
-			pendingDeletes.push(...(await this.processEntry(entry)));
 			entry.init({ encoding: this._encoding, keychain: this._keychain });
 		}
 

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -1210,6 +1210,44 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		});
 	}
 
+	async putBatch(values: T[]): Promise<void> {
+		if (values.length === 0) {
+			return;
+		}
+		if (!this.snapshotFile) {
+			for (const value of values) {
+				const id = types.toId(types.extractFieldValue(value, this.indexByArr));
+				this.putNativeDocument(keyToStoreKey(id), id, value);
+			}
+			return;
+		}
+
+		await this.enqueueMutation(async () => {
+			const prepared = values.map((value) => {
+				const id = types.toId(types.extractFieldValue(value, this.indexByArr));
+				return {
+					fields: this.fieldEncoder(value),
+					id,
+					storeKey: keyToStoreKey(id),
+					value,
+				};
+			});
+			await this.enqueuePersistence(async () => {
+				for (const item of prepared) {
+					await this.snapshotFile!.appendPut(
+						item.storeKey,
+						item.value,
+						this.properties.schema,
+					);
+				}
+			});
+			for (const item of prepared) {
+				this.getNative().put(item.storeKey, item.id, item.value, item.fields);
+			}
+			await this.compactIfNeeded();
+		});
+	}
+
 	async del(query: types.DeleteOptions): Promise<types.IdKey[]> {
 		if (!this.snapshotFile) {
 			const compiled = this.requireNativePlan(types.toQuery(query.query), {

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -176,6 +176,35 @@ describe("native planner bridge", () => {
 		await indices.drop();
 	});
 
+	it("applies puts in a native batch", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeDocument });
+		const batchIndex = index as typeof index & {
+			putBatch: (values: BridgeDocument[]) => Promise<void>;
+		};
+
+		await batchIndex.putBatch([
+			new BridgeDocument("a", "peerbit", "native index"),
+			new BridgeDocument("b", "peerbit", "batch put"),
+			new BridgeDocument("c", "other", "separate"),
+		]);
+
+		const results = await index
+			.iterate({
+				query: new StringMatch({
+					key: "tag",
+					value: "peerbit",
+					method: StringMatchMethod.exact,
+				}),
+				sort: [new Sort({ key: "id", direction: SortDirection.ASC })],
+			})
+			.all();
+		expect(results.map((result) => result.value.id)).to.deep.equal(["a", "b"]);
+
+		await indices.drop();
+	});
+
 	it("evaluates explicit nested queries in native rust", async () => {
 		const indices = create();
 		await indices.start();


### PR DESCRIPTION
## Summary\n- add internal RustIndex.putBatch for grouped native index mutations\n- use putBatch from log append batch ingestion when gid-removal callbacks are not installed\n- skip the per-entry appendMany processEntry await for non-CUT appendMany entries\n\n## Benchmarks\n\nLocal 1000-entry shared-log native graph benchmark, rust indexer, 3 runs:\n- auto-next nativeGraph=false: 2989 ops/sec\n- auto-next nativeGraph=true: 3319 ops/sec\n- append-many nativeGraph=false: 11361 ops/sec\n- append-many nativeGraph=true: 11068 ops/sec\n\nLocal 500-entry append-many, rust indexer, 5 runs after this PR:\n- nativeGraph=false: 9060 ops/sec\n- nativeGraph=true: 9826 ops/sec\n\nPrior parent branch was about 8250 ops/sec on the same 500-entry append-many benchmark, so this is about a 19% improvement for nativeGraph=true.\n\n## Test plan\n- pnpm --filter @peerbit/log run build\n- pnpm --filter @peerbit/shared-log run build\n- pnpm --filter @peerbit/indexer-rust run test\n- pnpm exec eslint --config eslint.config.js packages/log/src/log.ts packages/log/src/entry-index.ts packages/utils/indexer/rust/src/index.ts packages/utils/indexer/rust/test/index.spec.ts\n- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "appendMany (plans local append assignments in one native batch|coalesces a local chain)"