### PR TITLE
Batch native log graph writes

### DIFF
--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -71,6 +71,17 @@ type NativeLogIndexHandle = {
 		head: boolean,
 		data?: Uint8Array,
 	) => void;
+	put_many: (
+		hashes: string[],
+		gids: string[],
+		nexts: string[][],
+		types: Uint8Array,
+		wallTimes: BigUint64Array,
+		logicals: Uint32Array,
+		payloadSizes: Uint32Array,
+		heads: Uint8Array,
+		datas: Array<Uint8Array | undefined>,
+	) => void;
 	delete: (hash: string) => boolean;
 	heads: (gid?: string) => string[];
 	has_head: (gid?: string) => boolean;
@@ -180,6 +191,44 @@ export class LogGraphIndex {
 			entry.payloadSize ?? 0,
 			entry.head ?? true,
 			entry.data,
+		);
+	}
+
+	putBatch(entries: NativeLogEntry[]): void {
+		if (entries.length === 0) {
+			return;
+		}
+		const hashes = new Array<string>(entries.length);
+		const gids = new Array<string>(entries.length);
+		const nexts = new Array<string[]>(entries.length);
+		const types = new Uint8Array(entries.length);
+		const wallTimes = new BigUint64Array(entries.length);
+		const logicals = new Uint32Array(entries.length);
+		const payloadSizes = new Uint32Array(entries.length);
+		const heads = new Uint8Array(entries.length);
+		const datas = new Array<Uint8Array | undefined>(entries.length);
+		for (let i = 0; i < entries.length; i++) {
+			const entry = entries[i]!;
+			hashes[i] = entry.hash;
+			gids[i] = entry.gid;
+			nexts[i] = entry.next;
+			types[i] = entry.type;
+			wallTimes[i] = BigInt(entry.clock.timestamp.wallTime);
+			logicals[i] = entry.clock.timestamp.logical ?? 0;
+			payloadSizes[i] = entry.payloadSize ?? 0;
+			heads[i] = entry.head === false ? 0 : 1;
+			datas[i] = entry.data;
+		}
+		this.native.put_many(
+			hashes,
+			gids,
+			nexts,
+			types,
+			wallTimes,
+			logicals,
+			payloadSizes,
+			heads,
+			datas,
 		);
 	}
 

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -1,5 +1,5 @@
 use indexmap::{IndexMap, IndexSet};
-use js_sys::{Array, Uint8Array};
+use js_sys::{Array, BigUint64Array, Uint32Array, Uint8Array};
 use peerbit_indexer_rust::planner::{
     DocumentFields, FieldValue, NativeQueryIndex, Query, SortDirection, SortField,
 };
@@ -157,6 +157,12 @@ impl LogGraphIndex {
             if demotes_nexts {
                 self.set_head(&next, false);
             }
+        }
+    }
+
+    pub fn put_many(&mut self, entries: Vec<LogIndexEntry>) {
+        for entry in entries {
+            self.put(entry);
         }
     }
 
@@ -536,6 +542,54 @@ impl NativeLogIndex {
         Ok(())
     }
 
+    pub fn put_many(
+        &mut self,
+        hashes: Array,
+        gids: Array,
+        nexts: Array,
+        entry_types: Uint8Array,
+        wall_times: BigUint64Array,
+        logicals: Uint32Array,
+        payload_sizes: Uint32Array,
+        heads: Uint8Array,
+        datas: Array,
+    ) -> Result<(), JsValue> {
+        let len = hashes.length();
+        for values in [&gids, &nexts, &datas] {
+            if values.length() != len {
+                return Err(JsValue::from_str("Expected equal column lengths"));
+            }
+        }
+        for numeric_len in [
+            entry_types.length(),
+            wall_times.length(),
+            logicals.length(),
+            payload_sizes.length(),
+            heads.length(),
+        ] {
+            if numeric_len != len {
+                return Err(JsValue::from_str("Expected equal column lengths"));
+            }
+        }
+
+        let mut entries = Vec::with_capacity(len as usize);
+        for i in 0..len {
+            entries.push(LogIndexEntry::new_with_data(
+                required_string_from_array(&hashes, i)?,
+                required_string_from_array(&gids, i)?,
+                strings_from_array(required_array_from_array(&nexts, i)?)?,
+                entry_types.get_index(i),
+                wall_times.get_index(i),
+                logicals.get_index(i),
+                payload_sizes.get_index(i),
+                heads.get_index(i) != 0,
+                optional_bytes_from_js(datas.get(i)),
+            ));
+        }
+        self.inner.put_many(entries);
+        Ok(())
+    }
+
     pub fn delete(&mut self, hash: &str) -> bool {
         self.inner.delete(hash).is_some()
     }
@@ -685,6 +739,21 @@ fn optional_bytes_from_js(value: JsValue) -> Option<Vec<u8>> {
         return None;
     }
     Some(Uint8Array::new(&value).to_vec())
+}
+
+fn required_string_from_array(values: &Array, index: u32) -> Result<String, JsValue> {
+    values
+        .get(index)
+        .as_string()
+        .ok_or_else(|| JsValue::from_str("Expected string field"))
+}
+
+fn required_array_from_array(values: &Array, index: u32) -> Result<Array, JsValue> {
+    let value = values.get(index);
+    if !Array::is_array(&value) {
+        return Err(JsValue::from_str("Expected array field"));
+    }
+    Ok(Array::from(&value))
 }
 
 fn decode_absolute_replica_data_u32(data: Option<&[u8]>) -> Option<u32> {

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -53,6 +53,20 @@ describe("native log graph index", () => {
 		expect(index.countHasNext("a")).to.equal(0);
 	});
 
+	it("tracks heads and next adjacency in native batches", async () => {
+		const index = await createLogGraphIndex();
+		index.putBatch([
+			entry("a", "g", [], 1n),
+			entry("b", "g", ["a"], 2n),
+			entry("c", "g", ["b"], 3n),
+		]);
+
+		expect(index.heads()).to.deep.equal(["c"]);
+		expect(index.children("a")).to.deep.equal(["b"]);
+		expect(index.children("b")).to.deep.equal(["c"]);
+		expect(index.payloadSizeSum()).to.equal(3);
+	});
+
 	it("filters heads by gid and clock order", async () => {
 		const index = await createLogGraphIndex();
 		index.put(entry("b", "one", [], 2n));

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -73,6 +73,7 @@ export type NativeLogGraph = {
 	has: (hash: string) => boolean;
 	hasMany: (hashes: Iterable<string>) => Set<string>;
 	put: (entry: NativeLogEntry) => void;
+	putBatch?: (entries: NativeLogEntry[]) => void;
 	delete: (hash: string) => boolean;
 	clear: () => void;
 	heads: (gid?: string) => string[];
@@ -954,6 +955,13 @@ export class EntryIndex<T> {
 				!this.properties.onGidRemoved &&
 				(this.properties.index as IndexWithPutBatch<ShallowEntry>).putBatch;
 			const shallowEntries: ShallowEntry[] = [];
+			const nativeGraphPutBatch =
+				!this.properties.onGidRemoved && this.properties.nativeGraph?.graph.putBatch
+					? this.properties.nativeGraph.graph.putBatch.bind(
+							this.properties.nativeGraph.graph,
+						)
+					: undefined;
+			const nativeEntries: NativeLogEntry[] = [];
 			for (let i = 0; i < entries.length; i++) {
 				const entry = entries[i];
 				const isHead = i === entries.length - 1;
@@ -967,10 +975,13 @@ export class EntryIndex<T> {
 					shallowEntries.push(shallowEntry);
 				} else {
 					await this.properties.index.put(shallowEntry);
-					this.properties.nativeGraph?.graph.put(
-						toNativeLogEntry(shallowEntry),
-					);
-					await this.notifyShadowedGids(entry);
+					const nativeEntry = toNativeLogEntry(shallowEntry);
+					if (nativeGraphPutBatch) {
+						nativeEntries.push(nativeEntry);
+					} else {
+						this.properties.nativeGraph?.graph.put(nativeEntry);
+						await this.notifyShadowedGids(entry);
+					}
 				}
 
 				for (const next of entry.meta.next) {
@@ -982,11 +993,16 @@ export class EntryIndex<T> {
 
 			if (putBatch) {
 				await putBatch.call(this.properties.index, shallowEntries);
-				for (const shallowEntry of shallowEntries) {
-					this.properties.nativeGraph?.graph.put(
-						toNativeLogEntry(shallowEntry),
-					);
+				const batchedNativeEntries = shallowEntries.map(toNativeLogEntry);
+				if (nativeGraphPutBatch) {
+					nativeGraphPutBatch(batchedNativeEntries);
+				} else {
+					for (const nativeEntry of batchedNativeEntries) {
+						this.properties.nativeGraph?.graph.put(nativeEntry);
+					}
 				}
+			} else if (nativeGraphPutBatch && nativeEntries.length > 0) {
+				nativeGraphPutBatch(nativeEntries);
 			}
 
 			if (externalNexts.size > 0) {

--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -533,14 +533,14 @@ export class EntryV0<T>
 			createdLocally: true,
 		});
 
-		const signers = properties.signers || [
-			properties.identity.sign.bind(properties.identity),
-		];
-
 		const signableBytes = entry.getSignableBytes();
-		let signatures = await Promise.all(
-			signers.map((signer) => signer(signableBytes)),
-		);
+		let signatures = properties.signers
+			? properties.signers.length === 1
+				? [await properties.signers[0]!(signableBytes)]
+				: await Promise.all(
+						properties.signers.map((signer) => signer(signableBytes)),
+					)
+			: [await properties.identity.sign(signableBytes)];
 		signatures = signatures.sort((a, b) => compare(a.signature, b.signature));
 
 		const encryptedSignatures: MaybeEncrypted<SignatureWithKey>[] = [];


### PR DESCRIPTION
## Summary\n- add a columnar native log graph put_many bridge backed by typed arrays\n- use native graph batch writes from append batch ingestion when gid-removal callbacks are not installed\n- keep the existing per-entry path for gid-removal callback semantics\n- avoid Promise.all/bind overhead for the default single-signer entry path\n\n## Benchmarks\n\nLocal shared-log native graph benchmark, Rust indexer, 1000 entries, 5 runs:\n- auto-next nativeGraph=false: 3218 ops/sec\n- auto-next nativeGraph=true: 3425 ops/sec\n- append-many nativeGraph=false: 11405 ops/sec\n- append-many nativeGraph=true: 11379 ops/sec\n\nCompared with the previous stack's 1000-entry signal (~3319 auto-next nativeGraph=true and ~11068 append-many nativeGraph=true), this is a small append-path improvement and mostly a cleaner native coalescing foundation.\n\n## Test plan\n- pnpm --filter @peerbit/log-rust run test\n- pnpm --filter @peerbit/log run test\n- pnpm --filter @peerbit/shared-log run build\n- pnpm exec eslint --config eslint.config.js packages/log/src/entry-index.ts packages/log/src/entry-v0.ts packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts\n- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "appendMany (plans local append assignments in one native batch|coalesces a local chain)"