### PR TITLE
Add native EntryV0 encoding primitives

### DIFF
--- a/packages/log/rust/Cargo.lock
+++ b/packages/log/rust/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "borsh"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,6 +33,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -63,6 +81,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +137,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -121,6 +178,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,9 +210,11 @@ dependencies = [
 name = "peerbit_log_rust"
 version = "0.0.0"
 dependencies = [
+ "bs58",
  "indexmap",
  "js-sys",
  "peerbit_indexer_rust",
+ "sha2",
  "wasm-bindgen",
 ]
 
@@ -223,6 +288,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +314,21 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml_datetime"
@@ -270,10 +361,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasm-bindgen"

--- a/packages/log/rust/Cargo.toml
+++ b/packages/log/rust/Cargo.toml
@@ -12,6 +12,8 @@ crate-type = ["cdylib", "rlib"]
 indexmap = "2.7.1"
 js-sys = "0.3.80"
 peerbit_indexer_rust = { path = "../../utils/indexer/rust" }
+bs58 = "0.5.1"
+sha2 = "0.10.8"
 wasm-bindgen = "0.2.103"
 
 [package.metadata.wasm-pack.profile.release]

--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -116,6 +116,30 @@ type WasmModule = {
 	default: (input?: unknown) => Promise<unknown>;
 	initSync: (input?: unknown) => unknown;
 	NativeLogIndex: new () => NativeLogIndexHandle;
+	encode_entry_v0_signable: (
+		clockId: Uint8Array,
+		wallTime: bigint,
+		logical: number,
+		gid: string,
+		next: string[],
+		type: number,
+		metaData: Uint8Array | undefined,
+		payloadData: Uint8Array,
+	) => Uint8Array;
+	encode_entry_v0_storage: (
+		clockId: Uint8Array,
+		wallTime: bigint,
+		logical: number,
+		gid: string,
+		next: string[],
+		type: number,
+		metaData: Uint8Array | undefined,
+		payloadData: Uint8Array,
+		signature: Uint8Array,
+		signaturePublicKey: Uint8Array,
+		prehash: number,
+	) => Uint8Array;
+	calculate_raw_cid_v1: (bytes: Uint8Array) => string;
 };
 
 let wasmModulePromise: Promise<WasmModule> | undefined;
@@ -387,5 +411,62 @@ export class LogGraphIndex {
 		return { skip, missingParents, cutChecked, coveredByCut };
 	}
 }
+
+export type EntryV0EncodeInput = {
+	clockId: Uint8Array;
+	wallTime: bigint | number | string;
+	logical?: number;
+	gid: string;
+	next?: string[];
+	type?: number;
+	metaData?: Uint8Array;
+	payloadData: Uint8Array;
+};
+
+export type EntryV0StorageEncodeInput = EntryV0EncodeInput & {
+	signature: Uint8Array;
+	signaturePublicKey: Uint8Array;
+	prehash?: number;
+};
+
+export const encodeEntryV0Signable = async (
+	input: EntryV0EncodeInput,
+): Promise<Uint8Array> => {
+	const wasm = await loadWasm();
+	return wasm.encode_entry_v0_signable(
+		input.clockId,
+		BigInt(input.wallTime),
+		input.logical ?? 0,
+		input.gid,
+		input.next ?? [],
+		input.type ?? 0,
+		input.metaData,
+		input.payloadData,
+	);
+};
+
+export const encodeEntryV0Storage = async (
+	input: EntryV0StorageEncodeInput,
+): Promise<Uint8Array> => {
+	const wasm = await loadWasm();
+	return wasm.encode_entry_v0_storage(
+		input.clockId,
+		BigInt(input.wallTime),
+		input.logical ?? 0,
+		input.gid,
+		input.next ?? [],
+		input.type ?? 0,
+		input.metaData,
+		input.payloadData,
+		input.signature,
+		input.signaturePublicKey,
+		input.prehash ?? 0,
+	);
+};
+
+export const calculateRawCidV1 = async (bytes: Uint8Array): Promise<string> => {
+	const wasm = await loadWasm();
+	return wasm.calculate_raw_cid_v1(bytes);
+};
 
 export const createLogGraphIndex = () => LogGraphIndex.create();

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -3,6 +3,7 @@ use js_sys::{Array, BigUint64Array, Uint32Array, Uint8Array};
 use peerbit_indexer_rust::planner::{
     DocumentFields, FieldValue, NativeQueryIndex, Query, SortDirection, SortField,
 };
+use sha2::{Digest, Sha256};
 use std::collections::{HashMap, VecDeque};
 use wasm_bindgen::prelude::*;
 
@@ -702,6 +703,202 @@ impl Default for NativeLogIndex {
     fn default() -> Self {
         Self::new()
     }
+}
+
+#[wasm_bindgen]
+pub fn encode_entry_v0_signable(
+    clock_id: Uint8Array,
+    wall_time: u64,
+    logical: u32,
+    gid: String,
+    next: Array,
+    entry_type: u8,
+    meta_data: JsValue,
+    payload_data: Uint8Array,
+) -> Result<Uint8Array, JsValue> {
+    let next = strings_from_array(next)?;
+    let bytes = encode_entry_v0(
+        EntryV0EncodeInput {
+            clock_id: clock_id.to_vec(),
+            wall_time,
+            logical,
+            gid,
+            next,
+            entry_type,
+            meta_data: optional_bytes_from_js(meta_data),
+            payload_data: payload_data.to_vec(),
+        },
+        None,
+    );
+    Ok(Uint8Array::from(bytes.as_slice()))
+}
+
+#[wasm_bindgen]
+pub fn encode_entry_v0_storage(
+    clock_id: Uint8Array,
+    wall_time: u64,
+    logical: u32,
+    gid: String,
+    next: Array,
+    entry_type: u8,
+    meta_data: JsValue,
+    payload_data: Uint8Array,
+    signature: Uint8Array,
+    signature_public_key: Uint8Array,
+    prehash: u8,
+) -> Result<Uint8Array, JsValue> {
+    if signature.length() != 64 {
+        return Err(JsValue::from_str("Expected Ed25519 signature length 64"));
+    }
+    if signature_public_key.length() != 32 {
+        return Err(JsValue::from_str("Expected Ed25519 public key length 32"));
+    }
+    let next = strings_from_array(next)?;
+    let bytes = encode_entry_v0(
+        EntryV0EncodeInput {
+            clock_id: clock_id.to_vec(),
+            wall_time,
+            logical,
+            gid,
+            next,
+            entry_type,
+            meta_data: optional_bytes_from_js(meta_data),
+            payload_data: payload_data.to_vec(),
+        },
+        Some(SignatureInput {
+            signature: signature.to_vec(),
+            public_key: signature_public_key.to_vec(),
+            prehash,
+        }),
+    );
+    Ok(Uint8Array::from(bytes.as_slice()))
+}
+
+#[wasm_bindgen]
+pub fn calculate_raw_cid_v1(bytes: Uint8Array) -> String {
+    let digest = Sha256::digest(bytes.to_vec());
+    let mut cid = Vec::with_capacity(36);
+    cid.push(0x01); // CIDv1
+    cid.push(0x55); // raw codec
+    cid.push(0x12); // sha2-256 multihash code
+    cid.push(0x20); // 32 byte digest
+    cid.extend_from_slice(&digest);
+    format!("z{}", bs58::encode(cid).into_string())
+}
+
+struct EntryV0EncodeInput {
+    clock_id: Vec<u8>,
+    wall_time: u64,
+    logical: u32,
+    gid: String,
+    next: Vec<String>,
+    entry_type: u8,
+    meta_data: Option<Vec<u8>>,
+    payload_data: Vec<u8>,
+}
+
+struct SignatureInput {
+    signature: Vec<u8>,
+    public_key: Vec<u8>,
+    prehash: u8,
+}
+
+fn encode_entry_v0(input: EntryV0EncodeInput, signature: Option<SignatureInput>) -> Vec<u8> {
+    let meta = encode_meta(&input);
+    let payload = encode_payload(&input.payload_data);
+    let mut out = Vec::new();
+    write_u8(&mut out, 0); // EntryV0 variant
+    write_decrypted_thing(&mut out, &meta);
+    write_decrypted_thing(&mut out, &payload);
+    out.extend_from_slice(&[0, 0, 0, 0]); // reserved
+    match signature {
+        Some(signature) => {
+            write_u8(&mut out, 1);
+            write_signatures(&mut out, signature);
+        }
+        None => write_u8(&mut out, 0),
+    }
+    write_u8(&mut out, 0); // hash option
+    out
+}
+
+fn encode_meta(input: &EntryV0EncodeInput) -> Vec<u8> {
+    let mut out = Vec::new();
+    write_u8(&mut out, 0); // Meta variant
+    write_clock(&mut out, &input.clock_id, input.wall_time, input.logical);
+    write_string(&mut out, &input.gid);
+    write_u32(&mut out, input.next.len() as u32);
+    for next in &input.next {
+        write_string(&mut out, next);
+    }
+    write_u8(&mut out, input.entry_type);
+    match input.meta_data.as_ref() {
+        Some(data) => {
+            write_u8(&mut out, 1);
+            write_bytes(&mut out, data);
+        }
+        None => write_u8(&mut out, 0),
+    }
+    out
+}
+
+fn write_clock(out: &mut Vec<u8>, clock_id: &[u8], wall_time: u64, logical: u32) {
+    write_u8(out, 0); // LamportClock variant
+    write_bytes(out, clock_id);
+    write_u8(out, 0); // Timestamp variant
+    write_u64(out, wall_time);
+    write_u32(out, logical);
+}
+
+fn encode_payload(data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    write_u8(&mut out, 0); // Payload variant
+    write_bytes(&mut out, data);
+    out
+}
+
+fn write_signatures(out: &mut Vec<u8>, signature: SignatureInput) {
+    write_u8(out, 0); // Signatures variant
+    write_u32(out, 1);
+    let signature_with_key = encode_signature_with_key(signature);
+    write_decrypted_thing(out, &signature_with_key);
+}
+
+fn encode_signature_with_key(signature: SignatureInput) -> Vec<u8> {
+    let mut out = Vec::new();
+    write_u8(&mut out, 0); // SignatureWithKey variant
+    write_bytes(&mut out, &signature.signature);
+    write_u8(&mut out, 0); // Ed25519PublicKey variant
+    out.extend_from_slice(&signature.public_key);
+    write_u8(&mut out, signature.prehash);
+    out
+}
+
+fn write_decrypted_thing(out: &mut Vec<u8>, data: &[u8]) {
+    write_u8(out, 0); // MaybeEncrypted variant
+    write_u8(out, 0); // DecryptedThing variant
+    write_bytes(out, data);
+}
+
+fn write_string(out: &mut Vec<u8>, value: &str) {
+    write_bytes(out, value.as_bytes());
+}
+
+fn write_bytes(out: &mut Vec<u8>, value: &[u8]) {
+    write_u32(out, value.len() as u32);
+    out.extend_from_slice(value);
+}
+
+fn write_u8(out: &mut Vec<u8>, value: u8) {
+    out.push(value);
+}
+
+fn write_u32(out: &mut Vec<u8>, value: u32) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+fn write_u64(out: &mut Vec<u8>, value: u64) {
+    out.extend_from_slice(&value.to_le_bytes());
 }
 
 fn strings_from_array(values: Array) -> Result<Vec<String>, JsValue> {

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -1,5 +1,11 @@
 import { expect } from "chai";
-import { type NativeLogEntry, createLogGraphIndex } from "../src/index.js";
+import {
+	type NativeLogEntry,
+	calculateRawCidV1,
+	createLogGraphIndex,
+	encodeEntryV0Signable,
+	encodeEntryV0Storage,
+} from "../src/index.js";
 
 const APPEND = 0;
 const CUT = 1;
@@ -28,6 +34,28 @@ const absoluteReplicaData = (value: number) =>
 		(value >>> 16) & 0xff,
 		(value >>> 24) & 0xff,
 	]);
+
+const bytes = (length: number, offset = 0) =>
+	Uint8Array.from({ length }, (_, index) => (index + offset) & 0xff);
+
+const fromHex = (hex: string) =>
+	Uint8Array.from(
+		hex.match(/.{2}/g)?.map((byte) => Number.parseInt(byte, 16)) ?? [],
+	);
+
+const TS_BORSH_ENTRY_V0_FIXTURE = {
+	withMeta: {
+		signable:
+			"0000005e0000000000210000000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20210015cd5b070000000007000000050000006769642d6102000000060000006e6578742d61060000006e6578742d62000103000000090807000009000000000400000001020304000000000000",
+		storage:
+			"0000005e0000000000210000000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20210015cd5b070000000007000000050000006769642d6102000000060000006e6578742d61060000006e6578742d62000103000000090807000009000000000400000001020304000000000100010000000000670000000040000000606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f00404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f0000",
+		cid: "zb2rhXpjPn9fDgku56mickZTNbZDfiWmZRy5WDnHjAeLB8Yqa",
+	},
+	noMeta: {
+		signable:
+			"000000490000000000210000000b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b00b168de3a00000000000000000b0000006769642d6e6f2d6d65746100000000000000000a00000000050000000504030201000000000000",
+	},
+};
 
 describe("native log graph index", () => {
 	it("tracks heads and next adjacency", async () => {
@@ -322,5 +350,71 @@ describe("native log graph index", () => {
 			cutChecked: true,
 			coveredByCut: false,
 		});
+	});
+});
+
+describe("native EntryV0 encoding", () => {
+	it("matches TS/Borsh signable, storage, and raw CID bytes", async () => {
+		const clockId = bytes(33, 1);
+		const publicKeyBytes = bytes(32, 64);
+		const signatureBytes = bytes(64, 96);
+		const metaData = new Uint8Array([9, 8, 7]);
+		const payloadData = new Uint8Array([1, 2, 3, 4]);
+		const wallTime = 123456789n;
+		const logical = 7;
+		const gid = "gid-a";
+		const next = ["next-a", "next-b"];
+
+		const nativeSignable = await encodeEntryV0Signable({
+			clockId,
+			wallTime,
+			logical,
+			gid,
+			next,
+			type: APPEND,
+			metaData,
+			payloadData,
+		});
+
+		expect([...nativeSignable]).to.deep.equal([
+			...fromHex(TS_BORSH_ENTRY_V0_FIXTURE.withMeta.signable),
+		]);
+
+		const nativeStorage = await encodeEntryV0Storage({
+			clockId,
+			wallTime,
+			logical,
+			gid,
+			next,
+			type: APPEND,
+			metaData,
+			payloadData,
+			signature: signatureBytes,
+			signaturePublicKey: publicKeyBytes,
+			prehash: 0,
+		});
+
+		expect([...nativeStorage]).to.deep.equal([
+			...fromHex(TS_BORSH_ENTRY_V0_FIXTURE.withMeta.storage),
+		]);
+		expect(await calculateRawCidV1(nativeStorage)).to.equal(
+			TS_BORSH_ENTRY_V0_FIXTURE.withMeta.cid,
+		);
+	});
+
+	it("matches TS/Borsh encoding without optional entry metadata", async () => {
+		const clockId = bytes(33, 11);
+		const payloadData = new Uint8Array([5, 4, 3, 2, 1]);
+		const wallTime = 987654321n;
+		const gid = "gid-no-meta";
+
+		expect([
+			...(await encodeEntryV0Signable({
+				clockId,
+				wallTime,
+				gid,
+				payloadData,
+			})),
+		]).to.deep.equal([...fromHex(TS_BORSH_ENTRY_V0_FIXTURE.noMeta.signable)]);
 	});
 });


### PR DESCRIPTION
Stacked on #845.

## Summary
- adds Rust/WASM primitives for plain EntryV0 signable-byte encoding, storage-byte encoding, and raw CIDv1 calculation
- exposes typed TS wrappers from @peerbit/log-rust
- pins parity tests against TS/Borsh EntryV0 fixtures, including optional metadata and no-metadata cases

## Why
This is the next bottom-up step before moving the append transaction boundary: native append can now generate the exact bytes that existing JS/Borsh EntryV0 expects, then hash them natively. Storage/index orchestration still stays in JS until a follow-up PR wires this into the append path.

## Local checks
- pnpm --filter @peerbit/log-rust run test
- pnpm --filter @peerbit/log-rust run lint
- git diff --check

## Local microbench
On a 20k signable / 5k storage+CID loop:
- TS/Borsh signable construction: ~175k ops/sec
- native signable encode wrapper: ~472k ops/sec
- TS storage bytes + raw CID: ~69k ops/sec
- native storage bytes + raw CID: ~167k ops/sec
