### PR TITLE
Use native EntryV0 bytes for plain appends

### DIFF
--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -37,6 +37,66 @@ import { equals } from "./utils.js";
 const log = baseLogger.newScope("entry-v0");
 const traceLogger = log.trace as typeof log & { enabled?: boolean };
 
+type NativeEntryV0Encoder = {
+	encodeEntryV0Signable(input: {
+		clockId: Uint8Array;
+		wallTime: bigint;
+		logical?: number;
+		gid: string;
+		next?: string[];
+		type?: number;
+		metaData?: Uint8Array;
+		payloadData: Uint8Array;
+	}): Promise<Uint8Array>;
+	encodeEntryV0Storage(input: {
+		clockId: Uint8Array;
+		wallTime: bigint;
+		logical?: number;
+		gid: string;
+		next?: string[];
+		type?: number;
+		metaData?: Uint8Array;
+		payloadData: Uint8Array;
+		signature: Uint8Array;
+		signaturePublicKey: Uint8Array;
+		prehash?: number;
+	}): Promise<Uint8Array>;
+	calculateRawCidV1(bytes: Uint8Array): Promise<string>;
+};
+
+let nativeEntryV0EncoderPromise:
+	| Promise<NativeEntryV0Encoder | undefined>
+	| undefined;
+
+const loadNativeEntryV0Encoder = async () => {
+	if (!nativeEntryV0EncoderPromise) {
+		nativeEntryV0EncoderPromise = (async () => {
+			try {
+				const mod = (await import(["@peerbit", "log-rust"].join("/"))) as {
+					encodeEntryV0Signable?: NativeEntryV0Encoder["encodeEntryV0Signable"];
+					encodeEntryV0Storage?: NativeEntryV0Encoder["encodeEntryV0Storage"];
+					calculateRawCidV1?: NativeEntryV0Encoder["calculateRawCidV1"];
+				};
+				if (
+					!mod.encodeEntryV0Signable ||
+					!mod.encodeEntryV0Storage ||
+					!mod.calculateRawCidV1
+				) {
+					return undefined;
+				}
+				return {
+					encodeEntryV0Signable: mod.encodeEntryV0Signable,
+					encodeEntryV0Storage: mod.encodeEntryV0Storage,
+					calculateRawCidV1: mod.calculateRawCidV1,
+				};
+			} catch {
+				return undefined;
+			}
+		})();
+	}
+	return nativeEntryV0EncoderPromise;
+};
+
 export type MaybeEncryptionPublicKey =
 	| X25519PublicKey
 	| X25519PublicKey[]
@@ -506,12 +566,13 @@ export class EntryV0<T>
 				properties.meta?.gid ||
 				(await EntryV0.createGid(properties.meta?.gidSeed));
 		}
+		const entryType = properties.meta?.type ?? EntryType.APPEND;
 
 		const metadataEncrypted = await maybeEncrypt(
 			new Meta({
 				clock,
 				gid: gid!,
-				type: properties.meta?.type ?? EntryType.APPEND,
+				type: entryType,
 				data: properties.meta?.data,
 				next: nextHashes,
 			}),
@@ -524,6 +585,21 @@ export class EntryV0<T>
 			properties.encryption?.keypair,
 			properties.encryption?.receiver.payload,
 		);
+		const nativeEncoder = properties.encryption
+			? undefined
+			: await loadNativeEntryV0Encoder();
+		const nativePlainInput = nativeEncoder
+			? {
+					clockId: clock.id,
+					wallTime: clock.timestamp.wallTime,
+					logical: clock.timestamp.logical,
+					gid: gid!,
+					next: nextHashes,
+					type: entryType,
+					metaData: properties.meta?.data,
+					payloadData: payloadToSave.data,
+				}
+			: undefined;
 
 		// Sign id, encrypted payload, clock, nexts, refs
 		const entry: EntryV0<T> = new EntryV0<T>({
@@ -533,7 +609,10 @@ export class EntryV0<T>
 			createdLocally: true,
 		});
 
-		const signableBytes = entry.getSignableBytes();
+		const signableBytes =
+			nativeEncoder && nativePlainInput
+				? await nativeEncoder.encodeEntryV0Signable(nativePlainInput)
+				: entry.getSignableBytes();
 		let signatures = properties.signers
 			? properties.signers.length === 1
 				? [await properties.signers[0]!(signableBytes)]
@@ -570,10 +649,48 @@ export class EntryV0<T>
 			throw new AccessError("Not allowed to append");
 		}
 
+		let nativeStorage:
+			| {
+					bytes: Uint8Array;
+					cid: string;
+			  }
+			| undefined;
+		if (
+			nativeEncoder &&
+			nativePlainInput &&
+			!properties.canAppend &&
+			signatures.length === 1 &&
+			signatures[0]!.publicKey instanceof Ed25519PublicKey
+		) {
+			const storageBytes = await nativeEncoder.encodeEntryV0Storage({
+				...nativePlainInput,
+				signature: signatures[0]!.signature,
+				signaturePublicKey: signatures[0]!.publicKey.publicKey,
+				prehash: signatures[0]!.prehash,
+			});
+			nativeStorage = {
+				bytes: storageBytes,
+				cid: await nativeEncoder.calculateRawCidV1(storageBytes),
+			};
+		}
+
 		// Append hash
 		entry.hash = properties.deferStore
-			? await Entry.prepareMultihash(entry)
-			: await Entry.toMultihash(properties.store, entry);
+			? nativeStorage
+				? Entry.prepareMultihashBytes(
+						entry,
+						nativeStorage.bytes,
+						nativeStorage.cid,
+					)
+				: await Entry.prepareMultihash(entry)
+			: nativeStorage
+				? await Entry.toMultihashBytes(
+						properties.store,
+						entry,
+						nativeStorage.bytes,
+						nativeStorage.cid,
+					)
+				: await Entry.toMultihash(properties.store, entry);
 
 		entry.init({ encoding: properties.encoding });
 

--- a/packages/log/src/entry.ts
+++ b/packages/log/src/entry.ts
@@ -3,6 +3,7 @@ import {
 	type Blocks,
 	type GetOptions,
 	calculateRawCid,
+	cidifyString,
 } from "@peerbit/blocks-interface";
 import type { PublicSignKey, SignatureWithKey } from "@peerbit/crypto";
 import type { CryptoKeychain } from "@peerbit/keychain";
@@ -17,6 +18,18 @@ export type ShallowOrFullEntry<T> = ShallowEntry | Entry<T>;
 export type PreparedEntryBlock = Awaited<ReturnType<typeof calculateRawCid>>;
 
 const preparedEntryBlocks = new WeakMap<object, PreparedEntryBlock>();
+
+const preparedEntryBlockFromBytes = (
+	bytes: Uint8Array,
+	cid: string,
+): PreparedEntryBlock => ({
+	block: {
+		bytes,
+		cid: cidifyString(cid),
+		value: bytes,
+	} as PreparedEntryBlock["block"],
+	cid,
+});
 
 interface Meta {
 	clock: Clock;
@@ -106,6 +119,34 @@ export abstract class Entry<T> {
 		const prepared = await calculateRawCid(bytes);
 		preparedEntryBlocks.set(entry, prepared);
 		return prepared.cid;
+	}
+
+	static prepareMultihashBytes<T>(
+		entry: Entry<T>,
+		bytes: Uint8Array,
+		cid: string,
+	): string {
+		if (entry.hash) {
+			throw new Error("Expected hash to be missing");
+		}
+
+		entry.size = bytes.length;
+		preparedEntryBlocks.set(entry, preparedEntryBlockFromBytes(bytes, cid));
+		return cid;
+	}
+
+	static toMultihashBytes<T>(
+		store: Blocks,
+		entry: Entry<T>,
+		bytes: Uint8Array,
+		cid: string,
+	): Promise<string> | string {
+		if (entry.hash) {
+			throw new Error("Expected hash to be missing");
+		}
+
+		entry.size = bytes.length;
+		return store.put(preparedEntryBlockFromBytes(bytes, cid));
 	}
 
 	static takePreparedBlock<T>(entry: Entry<T>): PreparedEntryBlock | undefined {


### PR DESCRIPTION
Stacked on #846.

## Summary
- uses @peerbit/log-rust EntryV0 encode/hash primitives for the default unencrypted append path when available
- adds Entry helpers for storing/preparing already-encoded entry bytes with a known CID
- preserves JS/Borsh fallback for encrypted entries, missing native module, canAppend mutation risk, and non-single-Ed25519 storage cases

## Why
This moves the first real append-path byte work onto the native side: signable bytes, storage bytes, and raw CID calculation can now avoid TS/Borsh serialization in the common plain local append case. The public Blocks storage and EntryIndex ownership still remain JS-managed in this PR.

## Local checks
- pnpm --filter @peerbit/log run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "returns an Entry"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "appendMany appends a local chain with one coalesced change"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "plans auto-next append from the native graph"
- pnpm --filter @peerbit/log exec eslint --config ../../eslint.config.js src/entry.ts src/entry-v0.ts
- git diff --check

## Local perf
PEERBIT_LOG_NATIVE_GRAPH_APPEND_ENTRIES=1000 PEERBIT_LOG_NATIVE_GRAPH_ENTRIES=1000 PEERBIT_LOG_NATIVE_GRAPH_ITERATIONS=1000 PEERBIT_LOG_NATIVE_GRAPH_JOIN_PARENTS=1000 node packages/log/dist/benchmark/native-graph.js

Append rows:
- append loop auto-next, nativeGraph=false: ~4.1k ops/sec
- append loop auto-next, nativeGraph=true: ~9.7k ops/sec
- appendMany auto-next, nativeGraph=false: ~15.8k ops/sec
- appendMany auto-next, nativeGraph=true: ~13.2k ops/sec

Note: full package lint still reports pre-existing style violations in unrelated files such as src/clock.ts/change.ts; changed-file eslint passed.
