### PR TITLE
Prepare native EntryV0 storage bytes with CIDs

### DIFF
--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -139,6 +139,42 @@ type WasmModule = {
 		signaturePublicKey: Uint8Array,
 		prehash: number,
 	) => Uint8Array;
+	encode_entry_v0_storage_with_cid: (
+		clockId: Uint8Array,
+		wallTime: bigint,
+		logical: number,
+		gid: string,
+		next: string[],
+		type: number,
+		metaData: Uint8Array | undefined,
+		payloadData: Uint8Array,
+		signature: Uint8Array,
+		signaturePublicKey: Uint8Array,
+		prehash: number,
+	) => [Uint8Array, string];
+	encode_entry_v0_signable_batch: (
+		clockIds: Uint8Array[],
+		wallTimes: BigUint64Array,
+		logicals: Uint32Array,
+		gids: string[],
+		nexts: string[][],
+		types: Uint8Array,
+		metaDatas: Array<Uint8Array | undefined>,
+		payloadDatas: Uint8Array[],
+	) => Uint8Array[];
+	encode_entry_v0_storage_batch_with_cids: (
+		clockIds: Uint8Array[],
+		wallTimes: BigUint64Array,
+		logicals: Uint32Array,
+		gids: string[],
+		nexts: string[][],
+		types: Uint8Array,
+		metaDatas: Array<Uint8Array | undefined>,
+		payloadDatas: Uint8Array[],
+		signatures: Uint8Array[],
+		signaturePublicKeys: Uint8Array[],
+		prehashes: Uint8Array,
+	) => Array<[Uint8Array, string]>;
 	calculate_raw_cid_v1: (bytes: Uint8Array) => string;
 };
 
@@ -429,6 +465,43 @@ export type EntryV0StorageEncodeInput = EntryV0EncodeInput & {
 	prehash?: number;
 };
 
+export type EntryV0EncodedStorage = {
+	bytes: Uint8Array;
+	cid: string;
+};
+
+const entryColumns = (inputs: EntryV0EncodeInput[]) => {
+	const clockIds = new Array<Uint8Array>(inputs.length);
+	const wallTimes = new BigUint64Array(inputs.length);
+	const logicals = new Uint32Array(inputs.length);
+	const gids = new Array<string>(inputs.length);
+	const nexts = new Array<string[]>(inputs.length);
+	const types = new Uint8Array(inputs.length);
+	const metaDatas = new Array<Uint8Array | undefined>(inputs.length);
+	const payloadDatas = new Array<Uint8Array>(inputs.length);
+	for (let i = 0; i < inputs.length; i++) {
+		const input = inputs[i]!;
+		clockIds[i] = input.clockId;
+		wallTimes[i] = BigInt(input.wallTime);
+		logicals[i] = input.logical ?? 0;
+		gids[i] = input.gid;
+		nexts[i] = input.next ?? [];
+		types[i] = input.type ?? 0;
+		metaDatas[i] = input.metaData;
+		payloadDatas[i] = input.payloadData;
+	}
+	return {
+		clockIds,
+		wallTimes,
+		logicals,
+		gids,
+		nexts,
+		types,
+		metaDatas,
+		payloadDatas,
+	};
+};
+
 export const encodeEntryV0Signable = async (
 	input: EntryV0EncodeInput,
 ): Promise<Uint8Array> => {
@@ -442,6 +515,26 @@ export const encodeEntryV0Signable = async (
 		input.type ?? 0,
 		input.metaData,
 		input.payloadData,
+	);
+};
+
+export const encodeEntryV0SignableBatch = async (
+	inputs: EntryV0EncodeInput[],
+): Promise<Uint8Array[]> => {
+	if (inputs.length === 0) {
+		return [];
+	}
+	const wasm = await loadWasm();
+	const columns = entryColumns(inputs);
+	return wasm.encode_entry_v0_signable_batch(
+		columns.clockIds,
+		columns.wallTimes,
+		columns.logicals,
+		columns.gids,
+		columns.nexts,
+		columns.types,
+		columns.metaDatas,
+		columns.payloadDatas,
 	);
 };
 
@@ -462,6 +555,60 @@ export const encodeEntryV0Storage = async (
 		input.signaturePublicKey,
 		input.prehash ?? 0,
 	);
+};
+
+export const encodeEntryV0StorageWithCid = async (
+	input: EntryV0StorageEncodeInput,
+): Promise<EntryV0EncodedStorage> => {
+	const wasm = await loadWasm();
+	const [bytes, cid] = wasm.encode_entry_v0_storage_with_cid(
+		input.clockId,
+		BigInt(input.wallTime),
+		input.logical ?? 0,
+		input.gid,
+		input.next ?? [],
+		input.type ?? 0,
+		input.metaData,
+		input.payloadData,
+		input.signature,
+		input.signaturePublicKey,
+		input.prehash ?? 0,
+	);
+	return { bytes, cid };
+};
+
+export const encodeEntryV0StorageBatchWithCids = async (
+	inputs: EntryV0StorageEncodeInput[],
+): Promise<EntryV0EncodedStorage[]> => {
+	if (inputs.length === 0) {
+		return [];
+	}
+	const wasm = await loadWasm();
+	const columns = entryColumns(inputs);
+	const signatures = new Array<Uint8Array>(inputs.length);
+	const signaturePublicKeys = new Array<Uint8Array>(inputs.length);
+	const prehashes = new Uint8Array(inputs.length);
+	for (let i = 0; i < inputs.length; i++) {
+		const input = inputs[i]!;
+		signatures[i] = input.signature;
+		signaturePublicKeys[i] = input.signaturePublicKey;
+		prehashes[i] = input.prehash ?? 0;
+	}
+	return wasm
+		.encode_entry_v0_storage_batch_with_cids(
+			columns.clockIds,
+			columns.wallTimes,
+			columns.logicals,
+			columns.gids,
+			columns.nexts,
+			columns.types,
+			columns.metaDatas,
+			columns.payloadDatas,
+			signatures,
+			signaturePublicKeys,
+			prehashes,
+		)
+		.map(([bytes, cid]) => ({ bytes, cid }));
 };
 
 export const calculateRawCidV1 = async (bytes: Uint8Array): Promise<string> => {

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -747,14 +747,191 @@ pub fn encode_entry_v0_storage(
     signature_public_key: Uint8Array,
     prehash: u8,
 ) -> Result<Uint8Array, JsValue> {
-    if signature.length() != 64 {
-        return Err(JsValue::from_str("Expected Ed25519 signature length 64"));
+    let bytes = encode_entry_v0_storage_vec(
+        clock_id,
+        wall_time,
+        logical,
+        gid,
+        next,
+        entry_type,
+        meta_data,
+        payload_data,
+        signature,
+        signature_public_key,
+        prehash,
+    )?;
+    Ok(Uint8Array::from(bytes.as_slice()))
+}
+
+#[wasm_bindgen]
+pub fn encode_entry_v0_storage_with_cid(
+    clock_id: Uint8Array,
+    wall_time: u64,
+    logical: u32,
+    gid: String,
+    next: Array,
+    entry_type: u8,
+    meta_data: JsValue,
+    payload_data: Uint8Array,
+    signature: Uint8Array,
+    signature_public_key: Uint8Array,
+    prehash: u8,
+) -> Result<Array, JsValue> {
+    let bytes = encode_entry_v0_storage_vec(
+        clock_id,
+        wall_time,
+        logical,
+        gid,
+        next,
+        entry_type,
+        meta_data,
+        payload_data,
+        signature,
+        signature_public_key,
+        prehash,
+    )?;
+    Ok(storage_with_cid_to_row(bytes))
+}
+
+#[wasm_bindgen]
+pub fn encode_entry_v0_signable_batch(
+    clock_ids: Array,
+    wall_times: BigUint64Array,
+    logicals: Uint32Array,
+    gids: Array,
+    nexts: Array,
+    entry_types: Uint8Array,
+    meta_datas: Array,
+    payload_datas: Array,
+) -> Result<Array, JsValue> {
+    let len = clock_ids.length();
+    validate_entry_batch_lengths(
+        len,
+        &gids,
+        &nexts,
+        &meta_datas,
+        &payload_datas,
+        &wall_times,
+        &logicals,
+        &entry_types,
+    )?;
+
+    let out = Array::new();
+    for i in 0..len {
+        let input = entry_input_from_batch(
+            i,
+            &clock_ids,
+            &wall_times,
+            &logicals,
+            &gids,
+            &nexts,
+            &entry_types,
+            &meta_datas,
+            &payload_datas,
+        )?;
+        let bytes = encode_entry_v0(input, None);
+        out.push(&Uint8Array::from(bytes.as_slice()));
     }
-    if signature_public_key.length() != 32 {
-        return Err(JsValue::from_str("Expected Ed25519 public key length 32"));
+    Ok(out)
+}
+
+#[wasm_bindgen]
+pub fn encode_entry_v0_storage_batch_with_cids(
+    clock_ids: Array,
+    wall_times: BigUint64Array,
+    logicals: Uint32Array,
+    gids: Array,
+    nexts: Array,
+    entry_types: Uint8Array,
+    meta_datas: Array,
+    payload_datas: Array,
+    signatures: Array,
+    signature_public_keys: Array,
+    prehashes: Uint8Array,
+) -> Result<Array, JsValue> {
+    let len = clock_ids.length();
+    validate_entry_batch_lengths(
+        len,
+        &gids,
+        &nexts,
+        &meta_datas,
+        &payload_datas,
+        &wall_times,
+        &logicals,
+        &entry_types,
+    )?;
+    for values in [&signatures, &signature_public_keys] {
+        if values.length() != len {
+            return Err(JsValue::from_str("Expected equal column lengths"));
+        }
     }
+    if prehashes.length() != len {
+        return Err(JsValue::from_str("Expected equal column lengths"));
+    }
+
+    let out = Array::new();
+    for i in 0..len {
+        let input = entry_input_from_batch(
+            i,
+            &clock_ids,
+            &wall_times,
+            &logicals,
+            &gids,
+            &nexts,
+            &entry_types,
+            &meta_datas,
+            &payload_datas,
+        )?;
+        let signature = required_bytes_from_array(&signatures, i, "signature")?;
+        let public_key = required_bytes_from_array(&signature_public_keys, i, "public key")?;
+        validate_signature_lengths(&signature, &public_key)?;
+        let bytes = encode_entry_v0(
+            input,
+            Some(SignatureInput {
+                signature,
+                public_key,
+                prehash: prehashes.get_index(i),
+            }),
+        );
+        out.push(&storage_with_cid_to_row(bytes));
+    }
+    Ok(out)
+}
+
+#[wasm_bindgen]
+pub fn calculate_raw_cid_v1(bytes: Uint8Array) -> String {
+    calculate_raw_cid_v1_from_bytes(&bytes.to_vec())
+}
+
+fn calculate_raw_cid_v1_from_bytes(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut cid = Vec::with_capacity(36);
+    cid.push(0x01); // CIDv1
+    cid.push(0x55); // raw codec
+    cid.push(0x12); // sha2-256 multihash code
+    cid.push(0x20); // 32 byte digest
+    cid.extend_from_slice(&digest);
+    format!("z{}", bs58::encode(cid).into_string())
+}
+
+fn encode_entry_v0_storage_vec(
+    clock_id: Uint8Array,
+    wall_time: u64,
+    logical: u32,
+    gid: String,
+    next: Array,
+    entry_type: u8,
+    meta_data: JsValue,
+    payload_data: Uint8Array,
+    signature: Uint8Array,
+    signature_public_key: Uint8Array,
+    prehash: u8,
+) -> Result<Vec<u8>, JsValue> {
+    let signature = signature.to_vec();
+    let public_key = signature_public_key.to_vec();
+    validate_signature_lengths(&signature, &public_key)?;
     let next = strings_from_array(next)?;
-    let bytes = encode_entry_v0(
+    Ok(encode_entry_v0(
         EntryV0EncodeInput {
             clock_id: clock_id.to_vec(),
             wall_time,
@@ -766,24 +943,28 @@ pub fn encode_entry_v0_storage(
             payload_data: payload_data.to_vec(),
         },
         Some(SignatureInput {
-            signature: signature.to_vec(),
-            public_key: signature_public_key.to_vec(),
+            signature,
+            public_key,
             prehash,
         }),
-    );
-    Ok(Uint8Array::from(bytes.as_slice()))
+    ))
 }
 
-#[wasm_bindgen]
-pub fn calculate_raw_cid_v1(bytes: Uint8Array) -> String {
-    let digest = Sha256::digest(bytes.to_vec());
-    let mut cid = Vec::with_capacity(36);
-    cid.push(0x01); // CIDv1
-    cid.push(0x55); // raw codec
-    cid.push(0x12); // sha2-256 multihash code
-    cid.push(0x20); // 32 byte digest
-    cid.extend_from_slice(&digest);
-    format!("z{}", bs58::encode(cid).into_string())
+fn validate_signature_lengths(signature: &[u8], public_key: &[u8]) -> Result<(), JsValue> {
+    if signature.len() != 64 {
+        return Err(JsValue::from_str("Expected Ed25519 signature length 64"));
+    }
+    if public_key.len() != 32 {
+        return Err(JsValue::from_str("Expected Ed25519 public key length 32"));
+    }
+    Ok(())
+}
+
+fn storage_with_cid_to_row(bytes: Vec<u8>) -> Array {
+    let row = Array::new();
+    row.push(&Uint8Array::from(bytes.as_slice()));
+    row.push(&JsValue::from_str(&calculate_raw_cid_v1_from_bytes(&bytes)));
+    row
 }
 
 struct EntryV0EncodeInput {
@@ -923,6 +1104,54 @@ fn string_arrays_from_array(values: Array) -> Result<Vec<Vec<String>>, JsValue> 
     Ok(out)
 }
 
+#[allow(clippy::too_many_arguments)]
+fn validate_entry_batch_lengths(
+    len: u32,
+    gids: &Array,
+    nexts: &Array,
+    meta_datas: &Array,
+    payload_datas: &Array,
+    wall_times: &BigUint64Array,
+    logicals: &Uint32Array,
+    entry_types: &Uint8Array,
+) -> Result<(), JsValue> {
+    for values in [gids, nexts, meta_datas, payload_datas] {
+        if values.length() != len {
+            return Err(JsValue::from_str("Expected equal column lengths"));
+        }
+    }
+    for numeric_len in [wall_times.length(), logicals.length(), entry_types.length()] {
+        if numeric_len != len {
+            return Err(JsValue::from_str("Expected equal column lengths"));
+        }
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn entry_input_from_batch(
+    index: u32,
+    clock_ids: &Array,
+    wall_times: &BigUint64Array,
+    logicals: &Uint32Array,
+    gids: &Array,
+    nexts: &Array,
+    entry_types: &Uint8Array,
+    meta_datas: &Array,
+    payload_datas: &Array,
+) -> Result<EntryV0EncodeInput, JsValue> {
+    Ok(EntryV0EncodeInput {
+        clock_id: required_bytes_from_array(clock_ids, index, "clock id")?,
+        wall_time: wall_times.get_index(index),
+        logical: logicals.get_index(index),
+        gid: required_string_from_array(gids, index)?,
+        next: strings_from_array(required_array_from_array(nexts, index)?)?,
+        entry_type: entry_types.get_index(index),
+        meta_data: optional_bytes_from_js(meta_datas.get(index)),
+        payload_data: required_bytes_from_array(payload_datas, index, "payload")?,
+    })
+}
+
 fn strings_to_array(values: Vec<String>) -> Array {
     let out = Array::new();
     for value in values {
@@ -943,6 +1172,14 @@ fn required_string_from_array(values: &Array, index: u32) -> Result<String, JsVa
         .get(index)
         .as_string()
         .ok_or_else(|| JsValue::from_str("Expected string field"))
+}
+
+fn required_bytes_from_array(values: &Array, index: u32, field: &str) -> Result<Vec<u8>, JsValue> {
+    let value = values.get(index);
+    if value.is_undefined() || value.is_null() {
+        return Err(JsValue::from_str(&format!("Expected {field} bytes")));
+    }
+    Ok(Uint8Array::new(&value).to_vec())
 }
 
 fn required_array_from_array(values: &Array, index: u32) -> Result<Array, JsValue> {

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -4,7 +4,10 @@ import {
 	calculateRawCidV1,
 	createLogGraphIndex,
 	encodeEntryV0Signable,
+	encodeEntryV0SignableBatch,
 	encodeEntryV0Storage,
+	encodeEntryV0StorageBatchWithCids,
+	encodeEntryV0StorageWithCid,
 } from "../src/index.js";
 
 const APPEND = 0;
@@ -400,6 +403,24 @@ describe("native EntryV0 encoding", () => {
 		expect(await calculateRawCidV1(nativeStorage)).to.equal(
 			TS_BORSH_ENTRY_V0_FIXTURE.withMeta.cid,
 		);
+		expect(
+			await encodeEntryV0StorageWithCid({
+				clockId,
+				wallTime,
+				logical,
+				gid,
+				next,
+				type: APPEND,
+				metaData,
+				payloadData,
+				signature: signatureBytes,
+				signaturePublicKey: publicKeyBytes,
+				prehash: 0,
+			}),
+		).to.deep.equal({
+			bytes: nativeStorage,
+			cid: TS_BORSH_ENTRY_V0_FIXTURE.withMeta.cid,
+		});
 	});
 
 	it("matches TS/Borsh encoding without optional entry metadata", async () => {
@@ -416,5 +437,44 @@ describe("native EntryV0 encoding", () => {
 				payloadData,
 			})),
 		]).to.deep.equal([...fromHex(TS_BORSH_ENTRY_V0_FIXTURE.noMeta.signable)]);
+	});
+
+	it("batches independent TS/Borsh-compatible encodes", async () => {
+		const withMeta = {
+			clockId: bytes(33, 1),
+			wallTime: 123456789n,
+			logical: 7,
+			gid: "gid-a",
+			next: ["next-a", "next-b"],
+			type: APPEND,
+			metaData: new Uint8Array([9, 8, 7]),
+			payloadData: new Uint8Array([1, 2, 3, 4]),
+		};
+		const noMeta = {
+			clockId: bytes(33, 11),
+			wallTime: 987654321n,
+			gid: "gid-no-meta",
+			payloadData: new Uint8Array([5, 4, 3, 2, 1]),
+		};
+
+		const signables = await encodeEntryV0SignableBatch([withMeta, noMeta]);
+		expect(signables.map((bytes) => [...bytes])).to.deep.equal([
+			[...fromHex(TS_BORSH_ENTRY_V0_FIXTURE.withMeta.signable)],
+			[...fromHex(TS_BORSH_ENTRY_V0_FIXTURE.noMeta.signable)],
+		]);
+
+		const storage = await encodeEntryV0StorageBatchWithCids([
+			{
+				...withMeta,
+				signature: bytes(64, 96),
+				signaturePublicKey: bytes(32, 64),
+				prehash: 0,
+			},
+		]);
+		expect(storage).to.have.length(1);
+		expect([...storage[0]!.bytes]).to.deep.equal([
+			...fromHex(TS_BORSH_ENTRY_V0_FIXTURE.withMeta.storage),
+		]);
+		expect(storage[0]!.cid).to.equal(TS_BORSH_ENTRY_V0_FIXTURE.withMeta.cid);
 	});
 });

--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -61,6 +61,19 @@ type NativeEntryV0Encoder = {
 		signaturePublicKey: Uint8Array;
 		prehash?: number;
 	}): Promise<Uint8Array>;
+	encodeEntryV0StorageWithCid?(input: {
+		clockId: Uint8Array;
+		wallTime: bigint;
+		logical?: number;
+		gid: string;
+		next?: string[];
+		type?: number;
+		metaData?: Uint8Array;
+		payloadData: Uint8Array;
+		signature: Uint8Array;
+		signaturePublicKey: Uint8Array;
+		prehash?: number;
+	}): Promise<{ bytes: Uint8Array; cid: string }>;
 	calculateRawCidV1(bytes: Uint8Array): Promise<string>;
 };
 
@@ -75,6 +88,7 @@ const loadNativeEntryV0Encoder = async () => {
 				const mod = (await import(["@peerbit", "log-rust"].join("/"))) as {
 					encodeEntryV0Signable?: NativeEntryV0Encoder["encodeEntryV0Signable"];
 					encodeEntryV0Storage?: NativeEntryV0Encoder["encodeEntryV0Storage"];
+					encodeEntryV0StorageWithCid?: NativeEntryV0Encoder["encodeEntryV0StorageWithCid"];
 					calculateRawCidV1?: NativeEntryV0Encoder["calculateRawCidV1"];
 				};
 				if (
@@ -87,6 +101,7 @@ const loadNativeEntryV0Encoder = async () => {
 				return {
 					encodeEntryV0Signable: mod.encodeEntryV0Signable,
 					encodeEntryV0Storage: mod.encodeEntryV0Storage,
+					encodeEntryV0StorageWithCid: mod.encodeEntryV0StorageWithCid,
 					calculateRawCidV1: mod.calculateRawCidV1,
 				};
 			} catch {
@@ -662,16 +677,22 @@ export class EntryV0<T>
 			signatures.length === 1 &&
 			signatures[0]!.publicKey instanceof Ed25519PublicKey
 		) {
-			const storageBytes = await nativeEncoder.encodeEntryV0Storage({
+			const storageInput = {
 				...nativePlainInput,
 				signature: signatures[0]!.signature,
 				signaturePublicKey: signatures[0]!.publicKey.publicKey,
 				prehash: signatures[0]!.prehash,
-			});
-			nativeStorage = {
-				bytes: storageBytes,
-				cid: await nativeEncoder.calculateRawCidV1(storageBytes),
 			};
+			nativeStorage = nativeEncoder.encodeEntryV0StorageWithCid
+				? await nativeEncoder.encodeEntryV0StorageWithCid(storageInput)
+				: await (async () => {
+						const storageBytes =
+							await nativeEncoder.encodeEntryV0Storage(storageInput);
+						return {
+							bytes: storageBytes,
+							cid: await nativeEncoder.calculateRawCidV1(storageBytes),
+						};
+					})();
 		}
 
 		// Append hash


### PR DESCRIPTION
Stacked on #847.

## Summary
- adds native EntryV0 storage-byte + CID preparation in one WASM call
- adds internal batch wrappers for independent EntryV0 signable/storage preparation where all next hashes are already known
- wires plain EntryV0.create to prefer the combined storage+CID helper, preserving the old separate encode/hash fallback
- keeps encrypted, canAppend, and non-single-Ed25519 paths on existing fallbacks

## Important constraint
Default appendMany is a hash chain: entry N+1 needs entry N's CID in its next array before its signable bytes can be built. So this PR does not pretend to batch the full auto-next chain. Full batching there requires native signing/key handling or a larger native append transaction.

## Local checks
- pnpm --filter @peerbit/log-rust run test
- pnpm --filter @peerbit/log-rust run lint
- pnpm --filter @peerbit/log run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "appendMany appends a local chain with one coalesced change|returns an Entry|plans auto-next append from the native graph"
- pnpm --filter @peerbit/log exec eslint --config ../../eslint.config.js src/entry-v0.ts
- git diff --check

## Local perf
PEERBIT_LOG_NATIVE_GRAPH_APPEND_ENTRIES=1000 PEERBIT_LOG_NATIVE_GRAPH_ENTRIES=1000 PEERBIT_LOG_NATIVE_GRAPH_ITERATIONS=1000 PEERBIT_LOG_NATIVE_GRAPH_JOIN_PARENTS=1000 node packages/log/dist/benchmark/native-graph.js

Append rows on this branch:
- append loop auto-next, nativeGraph=false: ~4.5k ops/sec
- append loop auto-next, nativeGraph=true: ~10.6k ops/sec
- appendMany auto-next, nativeGraph=false: ~16.9k ops/sec
- appendMany auto-next, nativeGraph=true: ~14.1k ops/sec

Compared with #847 local signal, nativeGraph append loop moved ~9.7k -> ~10.6k ops/sec and nativeGraph appendMany moved ~13.2k -> ~14.1k ops/sec.
