### PR TITLE
Prepare plain append chains natively

### DIFF
--- a/packages/log/rust/Cargo.lock
+++ b/packages/log/rust/Cargo.lock
@@ -100,6 +100,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,10 +136,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2",
+ "subtle",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "futures-core"
@@ -211,6 +264,7 @@ name = "peerbit_log_rust"
 version = "0.0.0"
 dependencies = [
  "bs58",
+ "ed25519-dalek",
  "indexmap",
  "js-sys",
  "peerbit_indexer_rust",
@@ -262,10 +316,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde_core"
@@ -299,10 +368,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/packages/log/rust/Cargo.toml
+++ b/packages/log/rust/Cargo.toml
@@ -9,6 +9,7 @@ description = "Rust-backed log graph index for Peerbit"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+ed25519-dalek = { version = "2.1.1", default-features = false, features = ["fast"] }
 indexmap = "2.7.1"
 js-sys = "0.3.80"
 peerbit_indexer_rust = { path = "../../utils/indexer/rust" }

--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -116,6 +116,11 @@ type WasmModule = {
 	default: (input?: unknown) => Promise<unknown>;
 	initSync: (input?: unknown) => unknown;
 	NativeLogIndex: new () => NativeLogIndexHandle;
+	sign_ed25519: (
+		privateKey: Uint8Array,
+		publicKey: Uint8Array,
+		data: Uint8Array,
+	) => Uint8Array;
 	encode_entry_v0_signable: (
 		clockId: Uint8Array,
 		wallTime: bigint,
@@ -175,6 +180,28 @@ type WasmModule = {
 		signaturePublicKeys: Uint8Array[],
 		prehashes: Uint8Array,
 	) => Array<[Uint8Array, string]>;
+	prepare_entry_v0_plain_chain: (
+		clockId: Uint8Array,
+		privateKey: Uint8Array,
+		publicKey: Uint8Array,
+		wallTimes: BigUint64Array,
+		logicals: Uint32Array,
+		gid: string,
+		initialNext: string[],
+		type: number,
+		metaDatas: Array<Uint8Array | undefined>,
+		payloadDatas: Uint8Array[],
+	) => Array<
+		[
+			Uint8Array,
+			string,
+			Uint8Array,
+			string[],
+			Uint8Array,
+			Uint8Array,
+			Uint8Array,
+		]
+	>;
 	calculate_raw_cid_v1: (bytes: Uint8Array) => string;
 };
 
@@ -470,6 +497,27 @@ export type EntryV0EncodedStorage = {
 	cid: string;
 };
 
+export type EntryV0PlainChainInput = {
+	clockId: Uint8Array;
+	privateKey: Uint8Array;
+	publicKey: Uint8Array;
+	wallTimes: Array<bigint | number | string>;
+	logicals?: number[];
+	gid: string;
+	initialNext?: string[];
+	type?: number;
+	metaDatas?: Array<Uint8Array | undefined>;
+	payloadDatas: Uint8Array[];
+};
+
+export type EntryV0PreparedPlainEntry = EntryV0EncodedStorage & {
+	signature: Uint8Array;
+	next: string[];
+	metaBytes: Uint8Array;
+	payloadBytes: Uint8Array;
+	signatureBytes: Uint8Array;
+};
+
 const entryColumns = (inputs: EntryV0EncodeInput[]) => {
 	const clockIds = new Array<Uint8Array>(inputs.length);
 	const wallTimes = new BigUint64Array(inputs.length);
@@ -500,6 +548,15 @@ const entryColumns = (inputs: EntryV0EncodeInput[]) => {
 		metaDatas,
 		payloadDatas,
 	};
+};
+
+export const signEd25519 = async (input: {
+	privateKey: Uint8Array;
+	publicKey: Uint8Array;
+	data: Uint8Array;
+}): Promise<Uint8Array> => {
+	const wasm = await loadWasm();
+	return wasm.sign_ed25519(input.privateKey, input.publicKey, input.data);
 };
 
 export const encodeEntryV0Signable = async (
@@ -609,6 +666,60 @@ export const encodeEntryV0StorageBatchWithCids = async (
 			prehashes,
 		)
 		.map(([bytes, cid]) => ({ bytes, cid }));
+};
+
+export const prepareEntryV0PlainChain = async (
+	input: EntryV0PlainChainInput,
+): Promise<EntryV0PreparedPlainEntry[]> => {
+	if (input.payloadDatas.length === 0) {
+		return [];
+	}
+	if (input.wallTimes.length !== input.payloadDatas.length) {
+		throw new Error("Expected equal column lengths");
+	}
+	const wasm = await loadWasm();
+	const wallTimes = new BigUint64Array(input.wallTimes.length);
+	const logicals = new Uint32Array(input.payloadDatas.length);
+	const metaDatas = new Array<Uint8Array | undefined>(
+		input.payloadDatas.length,
+	);
+	for (let i = 0; i < input.payloadDatas.length; i++) {
+		wallTimes[i] = BigInt(input.wallTimes[i]!);
+		logicals[i] = input.logicals?.[i] ?? 0;
+		metaDatas[i] = input.metaDatas?.[i];
+	}
+	return wasm
+		.prepare_entry_v0_plain_chain(
+			input.clockId,
+			input.privateKey,
+			input.publicKey,
+			wallTimes,
+			logicals,
+			input.gid,
+			input.initialNext ?? [],
+			input.type ?? 0,
+			metaDatas,
+			input.payloadDatas,
+		)
+		.map(
+			([
+				bytes,
+				cid,
+				signature,
+				next,
+				metaBytes,
+				payloadBytes,
+				signatureBytes,
+			]) => ({
+				bytes,
+				cid,
+				signature,
+				next,
+				metaBytes,
+				payloadBytes,
+				signatureBytes,
+			}),
+		);
 };
 
 export const calculateRawCidV1 = async (bytes: Uint8Array): Promise<string> => {

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -1,3 +1,4 @@
+use ed25519_dalek::{Signer, SigningKey};
 use indexmap::{IndexMap, IndexSet};
 use js_sys::{Array, BigUint64Array, Uint32Array, Uint8Array};
 use peerbit_indexer_rust::planner::{
@@ -734,6 +735,16 @@ pub fn encode_entry_v0_signable(
 }
 
 #[wasm_bindgen]
+pub fn sign_ed25519(
+    private_key: Uint8Array,
+    public_key: Uint8Array,
+    data: Uint8Array,
+) -> Result<Uint8Array, JsValue> {
+    let signature = sign_ed25519_raw(&private_key.to_vec(), &public_key.to_vec(), &data.to_vec())?;
+    Ok(Uint8Array::from(signature.as_slice()))
+}
+
+#[wasm_bindgen]
 pub fn encode_entry_v0_storage(
     clock_id: Uint8Array,
     wall_time: u64,
@@ -899,6 +910,70 @@ pub fn encode_entry_v0_storage_batch_with_cids(
 }
 
 #[wasm_bindgen]
+pub fn prepare_entry_v0_plain_chain(
+    clock_id: Uint8Array,
+    private_key: Uint8Array,
+    public_key: Uint8Array,
+    wall_times: BigUint64Array,
+    logicals: Uint32Array,
+    gid: String,
+    initial_next: Array,
+    entry_type: u8,
+    meta_datas: Array,
+    payload_datas: Array,
+) -> Result<Array, JsValue> {
+    let len = payload_datas.length();
+    if meta_datas.length() != len || wall_times.length() != len || logicals.length() != len {
+        return Err(JsValue::from_str("Expected equal column lengths"));
+    }
+
+    let clock_id = clock_id.to_vec();
+    let private_key = private_key.to_vec();
+    let public_key = public_key.to_vec();
+    let signing_key = validate_ed25519_keypair(&private_key, &public_key)?;
+
+    let mut next = strings_from_array(initial_next)?;
+    let out = Array::new();
+    for i in 0..len {
+        let input = EntryV0EncodeInput {
+            clock_id: clock_id.clone(),
+            wall_time: wall_times.get_index(i),
+            logical: logicals.get_index(i),
+            gid: gid.clone(),
+            next: next.clone(),
+            entry_type,
+            meta_data: optional_bytes_from_js(meta_datas.get(i)),
+            payload_data: required_bytes_from_array(&payload_datas, i, "payload")?,
+        };
+        let meta = encode_meta(&input);
+        let payload = encode_payload(&input.payload_data);
+        let signable = encode_entry_v0_parts(&meta, &payload, None);
+        let signature = sign_ed25519_with_key(&signing_key, &signable);
+        let signature_input = SignatureInput {
+            signature: signature.clone(),
+            public_key: public_key.clone(),
+            prehash: 0,
+        };
+        let signature_with_key = encode_signature_with_key(&signature_input);
+        let storage = encode_entry_v0_parts(&meta, &payload, Some(signature_input));
+        let cid = calculate_raw_cid_v1_from_bytes(&storage);
+
+        let row = Array::new();
+        row.push(&Uint8Array::from(storage.as_slice()));
+        row.push(&JsValue::from_str(&cid));
+        row.push(&Uint8Array::from(signature.as_slice()));
+        row.push(&strings_to_array(next));
+        row.push(&Uint8Array::from(meta.as_slice()));
+        row.push(&Uint8Array::from(payload.as_slice()));
+        row.push(&Uint8Array::from(signature_with_key.as_slice()));
+        out.push(&row);
+
+        next = vec![cid];
+    }
+    Ok(out)
+}
+
+#[wasm_bindgen]
 pub fn calculate_raw_cid_v1(bytes: Uint8Array) -> String {
     calculate_raw_cid_v1_from_bytes(&bytes.to_vec())
 }
@@ -987,10 +1062,18 @@ struct SignatureInput {
 fn encode_entry_v0(input: EntryV0EncodeInput, signature: Option<SignatureInput>) -> Vec<u8> {
     let meta = encode_meta(&input);
     let payload = encode_payload(&input.payload_data);
+    encode_entry_v0_parts(&meta, &payload, signature)
+}
+
+fn encode_entry_v0_parts(
+    meta: &[u8],
+    payload: &[u8],
+    signature: Option<SignatureInput>,
+) -> Vec<u8> {
     let mut out = Vec::new();
     write_u8(&mut out, 0); // EntryV0 variant
-    write_decrypted_thing(&mut out, &meta);
-    write_decrypted_thing(&mut out, &payload);
+    write_decrypted_thing(&mut out, meta);
+    write_decrypted_thing(&mut out, payload);
     out.extend_from_slice(&[0, 0, 0, 0]); // reserved
     match signature {
         Some(signature) => {
@@ -1041,11 +1124,11 @@ fn encode_payload(data: &[u8]) -> Vec<u8> {
 fn write_signatures(out: &mut Vec<u8>, signature: SignatureInput) {
     write_u8(out, 0); // Signatures variant
     write_u32(out, 1);
-    let signature_with_key = encode_signature_with_key(signature);
+    let signature_with_key = encode_signature_with_key(&signature);
     write_decrypted_thing(out, &signature_with_key);
 }
 
-fn encode_signature_with_key(signature: SignatureInput) -> Vec<u8> {
+fn encode_signature_with_key(signature: &SignatureInput) -> Vec<u8> {
     let mut out = Vec::new();
     write_u8(&mut out, 0); // SignatureWithKey variant
     write_bytes(&mut out, &signature.signature);
@@ -1053,6 +1136,39 @@ fn encode_signature_with_key(signature: SignatureInput) -> Vec<u8> {
     out.extend_from_slice(&signature.public_key);
     write_u8(&mut out, signature.prehash);
     out
+}
+
+fn sign_ed25519_raw(
+    private_key: &[u8],
+    public_key: &[u8],
+    data: &[u8],
+) -> Result<Vec<u8>, JsValue> {
+    let signing_key = validate_ed25519_keypair(private_key, public_key)?;
+    Ok(sign_ed25519_with_key(&signing_key, data))
+}
+
+fn sign_ed25519_with_key(signing_key: &SigningKey, data: &[u8]) -> Vec<u8> {
+    signing_key.sign(data).to_bytes().to_vec()
+}
+
+fn validate_ed25519_keypair(private_key: &[u8], public_key: &[u8]) -> Result<SigningKey, JsValue> {
+    if private_key.len() != 32 {
+        return Err(JsValue::from_str("Expected Ed25519 private key length 32"));
+    }
+    if public_key.len() != 32 {
+        return Err(JsValue::from_str("Expected Ed25519 public key length 32"));
+    }
+    let signing_key = SigningKey::from_bytes(
+        private_key
+            .try_into()
+            .map_err(|_| JsValue::from_str("Expected Ed25519 private key length 32"))?,
+    );
+    if signing_key.verifying_key().to_bytes().as_slice() != public_key {
+        return Err(JsValue::from_str(
+            "Ed25519 public key does not match private key",
+        ));
+    }
+    Ok(signing_key)
 }
 
 fn write_decrypted_thing(out: &mut Vec<u8>, data: &[u8]) {

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -8,6 +8,8 @@ import {
 	encodeEntryV0Storage,
 	encodeEntryV0StorageBatchWithCids,
 	encodeEntryV0StorageWithCid,
+	prepareEntryV0PlainChain,
+	signEd25519,
 } from "../src/index.js";
 
 const APPEND = 0;
@@ -357,6 +359,24 @@ describe("native log graph index", () => {
 });
 
 describe("native EntryV0 encoding", () => {
+	it("signs Ed25519 bytes with the expected RFC 8032 test vector", async () => {
+		expect([
+			...(await signEd25519({
+				privateKey: fromHex(
+					"9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+				),
+				publicKey: fromHex(
+					"d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+				),
+				data: new Uint8Array(),
+			})),
+		]).to.deep.equal([
+			...fromHex(
+				"e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b",
+			),
+		]);
+	});
+
 	it("matches TS/Borsh signable, storage, and raw CID bytes", async () => {
 		const clockId = bytes(33, 1);
 		const publicKeyBytes = bytes(32, 64);
@@ -476,5 +496,39 @@ describe("native EntryV0 encoding", () => {
 			...fromHex(TS_BORSH_ENTRY_V0_FIXTURE.withMeta.storage),
 		]);
 		expect(storage[0]!.cid).to.equal(TS_BORSH_ENTRY_V0_FIXTURE.withMeta.cid);
+	});
+
+	it("prepares a hash-linked plain entry chain natively", async () => {
+		const privateKey = fromHex(
+			"9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+		);
+		const publicKey = fromHex(
+			"d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+		);
+		const chain = await prepareEntryV0PlainChain({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
+			wallTimes: [11n, 12n, 13n],
+			gid: "chain-gid",
+			initialNext: ["root"],
+			payloadDatas: [
+				new Uint8Array([1]),
+				new Uint8Array([2]),
+				new Uint8Array([3]),
+			],
+		});
+
+		expect(chain).to.have.length(3);
+		expect(chain[0]!.next).to.deep.equal(["root"]);
+		expect(chain[1]!.next).to.deep.equal([chain[0]!.cid]);
+		expect(chain[2]!.next).to.deep.equal([chain[1]!.cid]);
+		for (const prepared of chain) {
+			expect(prepared.cid).to.equal(await calculateRawCidV1(prepared.bytes));
+			expect(prepared.signature).to.have.length(64);
+			expect(prepared.metaBytes.byteLength).greaterThan(0);
+			expect(prepared.payloadBytes.byteLength).greaterThan(0);
+			expect(prepared.signatureBytes.byteLength).greaterThan(0);
+		}
 	});
 });

--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -10,6 +10,7 @@ import { type Blocks } from "@peerbit/blocks-interface";
 import {
 	AccessError,
 	DecryptedThing,
+	Ed25519Keypair,
 	Ed25519PublicKey,
 	type Identity,
 	MaybeEncrypted,
@@ -74,6 +75,28 @@ type NativeEntryV0Encoder = {
 		signaturePublicKey: Uint8Array;
 		prehash?: number;
 	}): Promise<{ bytes: Uint8Array; cid: string }>;
+	prepareEntryV0PlainChain?(input: {
+		clockId: Uint8Array;
+		privateKey: Uint8Array;
+		publicKey: Uint8Array;
+		wallTimes: Array<bigint | number | string>;
+		logicals?: number[];
+		gid: string;
+		initialNext?: string[];
+		type?: number;
+		metaDatas?: Array<Uint8Array | undefined>;
+		payloadDatas: Uint8Array[];
+	}): Promise<
+		Array<{
+			bytes: Uint8Array;
+			cid: string;
+			signature: Uint8Array;
+			next: string[];
+			metaBytes: Uint8Array;
+			payloadBytes: Uint8Array;
+			signatureBytes: Uint8Array;
+		}>
+	>;
 	calculateRawCidV1(bytes: Uint8Array): Promise<string>;
 };
 
@@ -89,6 +112,7 @@ const loadNativeEntryV0Encoder = async () => {
 					encodeEntryV0Signable?: NativeEntryV0Encoder["encodeEntryV0Signable"];
 					encodeEntryV0Storage?: NativeEntryV0Encoder["encodeEntryV0Storage"];
 					encodeEntryV0StorageWithCid?: NativeEntryV0Encoder["encodeEntryV0StorageWithCid"];
+					prepareEntryV0PlainChain?: NativeEntryV0Encoder["prepareEntryV0PlainChain"];
 					calculateRawCidV1?: NativeEntryV0Encoder["calculateRawCidV1"];
 				};
 				if (
@@ -102,6 +126,7 @@ const loadNativeEntryV0Encoder = async () => {
 					encodeEntryV0Signable: mod.encodeEntryV0Signable,
 					encodeEntryV0Storage: mod.encodeEntryV0Storage,
 					encodeEntryV0StorageWithCid: mod.encodeEntryV0StorageWithCid,
+					prepareEntryV0PlainChain: mod.prepareEntryV0PlainChain,
 					calculateRawCidV1: mod.calculateRawCidV1,
 				};
 			} catch {
@@ -471,6 +496,149 @@ export class EntryV0<T>
 
 	static createGid(seed?: Uint8Array): Promise<string> | string {
 		return seed ? sha256Base64(seed) : toBase64(randomBytes(32));
+	}
+
+	static async createPlainAppendChain<T>(properties: {
+		data: T[];
+		meta?: {
+			clocks: () => Clock[];
+			gid?: string;
+			type?: EntryType;
+			gidSeed?: Uint8Array;
+			data?: Uint8Array;
+			next?: SortableEntry[];
+		};
+		encoding: Encoding<T>;
+		identity: Identity;
+		deferStore: boolean;
+	}): Promise<Entry<T>[] | undefined> {
+		if (!properties.deferStore) {
+			return undefined;
+		}
+		if (!(properties.identity instanceof Ed25519Keypair)) {
+			return undefined;
+		}
+		const nativeEncoder = await loadNativeEntryV0Encoder();
+		if (!nativeEncoder?.prepareEntryV0PlainChain) {
+			return undefined;
+		}
+
+		const nexts = properties.meta?.next ?? [];
+		const nextHashes: string[] = [];
+		let gid: string | null = null;
+		if (nexts.length > 0) {
+			if (properties.meta?.gid) {
+				throw new Error(
+					"Expecting '.meta.gid' property to be undefined if '.meta.next' is provided",
+				);
+			}
+			for (const next of nexts) {
+				if (!next.hash) {
+					throw new Error("Expecting hash to be defined to next entries");
+				}
+				nextHashes.push(next.hash);
+				gid =
+					gid == null
+						? next.meta.gid
+						: next.meta.gid < (gid as string)
+							? next.meta.gid
+							: gid;
+			}
+		} else {
+			gid =
+				properties.meta?.gid ||
+				(await EntryV0.createGid(properties.meta?.gidSeed));
+		}
+
+		const clocks = properties.meta?.clocks();
+		if (!clocks || clocks.length !== properties.data.length) {
+			throw new Error("Expected one clock per entry");
+		}
+		for (const next of nexts) {
+			if (
+				Timestamp.compare(next.meta.clock.timestamp, clocks[0]!.timestamp) >= 0
+			) {
+				throw new Error(
+					"Expecting next(s) to happen before entry, got: " +
+						next.meta.clock.timestamp +
+						" > " +
+						clocks[0]!.timestamp,
+				);
+			}
+		}
+		for (let i = 1; i < clocks.length; i++) {
+			if (
+				Timestamp.compare(clocks[i - 1]!.timestamp, clocks[i]!.timestamp) >= 0
+			) {
+				throw new Error(
+					"Expecting generated clocks to increase across appendMany",
+				);
+			}
+		}
+
+		const entryType = properties.meta?.type ?? EntryType.APPEND;
+		const payloads = properties.data.map(
+			(data) =>
+				new Payload<T>({
+					data: properties.encoding.encoder(data),
+					value: data,
+					encoding: properties.encoding,
+				}),
+		);
+		const prepared = await nativeEncoder.prepareEntryV0PlainChain({
+			clockId: properties.identity.publicKey.bytes,
+			privateKey: properties.identity.privateKey.privateKey,
+			publicKey: properties.identity.publicKey.publicKey,
+			wallTimes: clocks.map((clock) => clock.timestamp.wallTime),
+			logicals: clocks.map((clock) => clock.timestamp.logical),
+			gid: gid!,
+			initialNext: nextHashes,
+			type: entryType,
+			metaDatas: payloads.map(() => properties.meta?.data),
+			payloadDatas: payloads.map((payload) => payload.data),
+		});
+
+		return prepared.map((preparedEntry, index) => {
+			const meta = new Meta({
+				clock: clocks[index]!,
+				gid: gid!,
+				type: entryType,
+				data: properties.meta?.data,
+				next: preparedEntry.next,
+			});
+			const payload = payloads[index]!;
+			const signature = new SignatureWithKey({
+				signature: preparedEntry.signature,
+				publicKey: properties.identity.publicKey,
+				prehash: 0,
+			});
+			const entry = new EntryV0<T>({
+				meta: new DecryptedThing({
+					data: preparedEntry.metaBytes,
+					value: meta,
+				}),
+				payload: new DecryptedThing({
+					data: preparedEntry.payloadBytes,
+					value: payload,
+				}),
+				signatures: new Signatures({
+					signatures: [
+						new DecryptedThing({
+							data: preparedEntry.signatureBytes,
+							value: signature,
+						}),
+					],
+				}),
+				createdLocally: true,
+			});
+			entry.hash = Entry.prepareMultihashBytes(
+				entry,
+				preparedEntry.bytes,
+				preparedEntry.cid,
+			);
+			entry.init({ encoding: properties.encoding });
+			return entry;
+		});
 	}
 
 	static async create<T>(properties: {

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -208,6 +208,7 @@ export class Log<T> {
 	private _appendDurability!: AppendDurability;
 	private _joining!: Map<string, Promise<any>>; // entry hashes that are currently joining into this log
 	private _sortFn!: Sorting.SortFn;
+	private _hasCustomCanAppend = false;
 
 	constructor(properties?: { id?: Uint8Array }) {
 		this._id = properties?.id || randomBytes(32);
@@ -333,6 +334,7 @@ export class Log<T> {
 			}
 			return true;
 		};
+		this._hasCustomCanAppend = !!options?.canAppend;
 
 		this._onChange = options?.onChange;
 		this._closed = false;
@@ -621,12 +623,45 @@ export class Log<T> {
 		)[] = [];
 		const deferBlockStore = hasPutMany(this._storage);
 
-		for (const item of data) {
-			const entry = await this.createAppendEntry(item, options, nexts, {
-				deferStore: deferBlockStore,
-			});
-			entries.push(entry);
-			nexts = [entry];
+		const nativeEntries =
+			deferBlockStore &&
+			!options.encryption &&
+			!options.signers &&
+			!(options.canAppend || this._hasCustomCanAppend) &&
+			!options.meta?.timestamp
+				? await EntryV0.createPlainAppendChain<T>({
+						data,
+						meta: {
+							clocks: () =>
+								data.map(
+									() =>
+										new Clock({
+											id: this._identity.publicKey.bytes,
+											timestamp: this._hlc.now(),
+										}),
+								),
+							type: options.meta?.type,
+							gidSeed: options.meta?.gidSeed,
+							data: options.meta?.data,
+							next: nexts,
+						},
+						encoding: this._encoding,
+						identity: options.identity || this._identity,
+						deferStore: deferBlockStore,
+					})
+				: undefined;
+
+		if (nativeEntries) {
+			entries.push(...nativeEntries);
+			nexts = [entries[entries.length - 1]!];
+		} else {
+			for (const item of data) {
+				const entry = await this.createAppendEntry(item, options, nexts, {
+					deferStore: deferBlockStore,
+				});
+				entries.push(entry);
+				nexts = [entry];
+			}
 		}
 
 		await this.joinMissingNexts(entries[0]!, initialNexts);


### PR DESCRIPTION
## Summary
- add native Ed25519 signing and hash-linked EntryV0 plain-chain preparation in @peerbit/log-rust
- expose the plain-chain helper through the TS WASM wrapper and EntryV0
- use the native plain-chain path for appendMany when the append is unencrypted, single Ed25519 identity signed, has no custom canAppend/signers/timestamp, and can still fall back to the existing JS path

## Performance
Local native graph benchmark with 1000 entries / 1000 iterations after one-time key validation reuse:
- appendMany auto-next fallback: ~15.9k ops/sec
- appendMany auto-next nativeGraph: ~17.8k ops/sec
- append loop auto-next nativeGraph remains ~10.6k ops/sec

## Test Plan
- pnpm --filter @peerbit/log-rust run build
- pnpm --filter @peerbit/log-rust run test
- pnpm --filter @peerbit/log-rust run lint
- pnpm --filter @peerbit/log run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "appendMany appends a local chain with one coalesced change|returns an Entry|plans auto-next append from the native graph"
- pnpm exec eslint --config eslint.config.js packages/log/src/entry-v0.ts packages/log/src/log.ts
- git diff --check

Note: full pnpm --filter @peerbit/log run lint still fails on pre-existing style errors in unchanged files such as packages/log/src/clock.ts.