### PR TITLE
Use native append bytes without default canAppend

### DIFF
--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -755,7 +755,9 @@ export class Log<T> {
 						},
 					}
 				: undefined,
-			canAppend: options.canAppend || this._canAppend,
+			canAppend:
+				options.canAppend ||
+				(this._hasCustomCanAppend ? this._canAppend : undefined),
 			deferStore: storeOptions?.deferStore,
 		});
 


### PR DESCRIPTION
## Summary
- stop passing the default no-op log canAppend wrapper into local EntryV0 creation
- preserve custom append policies from per-append options or log open options
- let ordinary appends and fallback appendMany loops use the native EntryV0 storage-byte/CID fast path from the lower stack

## Validation
- pnpm --filter @peerbit/log run build
- pnpm exec eslint --config eslint.config.js packages/log/src/log.ts
- git diff --check
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "appendMany appends a local chain with one coalesced change|returns an Entry|plans auto-next append from the native graph"
- local probe: two ordinary appends had 0 EntryV0.getStorageBytes() calls, confirming the native prepared-byte path is active

## Performance Note
The full append-loop benchmark remains dominated by storage/index work; this PR mainly removes an accidental blocker so the native byte/CID primitive is actually used by default appends.