### PR TITLE
Reuse prepared shallow entries for native appends

### DIFF
--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -889,7 +889,9 @@ export class EntryIndex<T> {
 
 				// add cache after .has check before .has uses the cache
 				this.cache.add(entry.hash, entry);
-				const shallowEntry = entry.toShallow(properties.isHead);
+				const shallowEntry =
+					Entry.takePreparedShallowEntry(entry, properties.isHead) ??
+					entry.toShallow(properties.isHead);
 				const shouldDeferIndexWrite =
 					properties.deferIndexWrite === true &&
 					properties.isHead &&
@@ -970,7 +972,8 @@ export class EntryIndex<T> {
 				}
 
 				this.cache.add(entry.hash, entry);
-				const shallowEntry = entry.toShallow(isHead);
+				const shallowEntry =
+					Entry.takePreparedShallowEntry(entry, isHead) ?? entry.toShallow(isHead);
 				if (putBatch) {
 					shallowEntries.push(shallowEntry);
 				} else {

--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -636,6 +636,21 @@ export class EntryV0<T>
 				preparedEntry.bytes,
 				preparedEntry.cid,
 			);
+			Entry.prepareShallowEntry(
+				entry,
+				new ShallowEntry({
+					hash: entry.hash,
+					payloadSize: payload.byteLength,
+					head: index === prepared.length - 1,
+					meta: new ShallowMeta({
+						gid: meta.gid,
+						data: meta.data,
+						clock: meta.clock,
+						next: meta.next,
+						type: meta.type,
+					}),
+				}),
+			);
 			entry.init({ encoding: properties.encoding });
 			return entry;
 		});

--- a/packages/log/src/entry.ts
+++ b/packages/log/src/entry.ts
@@ -18,6 +18,7 @@ export type ShallowOrFullEntry<T> = ShallowEntry | Entry<T>;
 export type PreparedEntryBlock = Awaited<ReturnType<typeof calculateRawCid>>;
 
 const preparedEntryBlocks = new WeakMap<object, PreparedEntryBlock>();
+const preparedShallowEntries = new WeakMap<object, ShallowEntry>();
 
 const preparedEntryBlockFromBytes = (
 	bytes: Uint8Array,
@@ -153,6 +154,22 @@ export abstract class Entry<T> {
 		const prepared = preparedEntryBlocks.get(entry);
 		if (prepared) {
 			preparedEntryBlocks.delete(entry);
+		}
+		return prepared;
+	}
+
+	static prepareShallowEntry<T>(entry: Entry<T>, shallow: ShallowEntry): void {
+		preparedShallowEntries.set(entry, shallow);
+	}
+
+	static takePreparedShallowEntry<T>(
+		entry: Entry<T>,
+		isHead: boolean,
+	): ShallowEntry | undefined {
+		const prepared = preparedShallowEntries.get(entry);
+		if (prepared) {
+			preparedShallowEntries.delete(entry);
+			prepared.head = isHead;
 		}
 		return prepared;
 	}

--- a/packages/log/test/append.spec.ts
+++ b/packages/log/test/append.spec.ts
@@ -3,6 +3,7 @@ import { Ed25519Keypair } from "@peerbit/crypto";
 import { HashmapIndices } from "@peerbit/indexer-simple";
 import { expect } from "chai";
 import sinon from "sinon";
+import { EntryV0 } from "../src/entry-v0.js";
 import { EntryType } from "../src/entry-type.js";
 import { Log } from "../src/log.js";
 
@@ -163,6 +164,7 @@ describe("append", function () {
 		const putSpy = sinon.spy(log.entryIndex.properties.index, "put");
 		const blockPutSpy = sinon.spy(store, "put");
 		const blockPutManySpy = sinon.spy(store, "putMany");
+		const shallowSpy = sinon.spy(EntryV0.prototype, "toShallow");
 
 		try {
 			const result = await log.appendMany([
@@ -198,11 +200,13 @@ describe("append", function () {
 			expect(blockPutManySpy.firstCall.args[0]).to.have.length(
 				result.entries.length,
 			);
+			expect(shallowSpy.callCount).equal(0);
 		} finally {
 			iterateSpy.restore();
 			putSpy.restore();
 			blockPutSpy.restore();
 			blockPutManySpy.restore();
+			shallowSpy.restore();
 			await log.close();
 		}
 	});


### PR DESCRIPTION
## Summary
- cache prepared ShallowEntry rows on Entry objects, mirroring the existing prepared block cache
- have EntryIndex.put and putAppendBatch consume prepared shallow rows when available
- prepare shallow rows during native plain append-chain creation so the native appendMany path does not rebuild them through EntryV0.toShallow()

## Validation
- pnpm --filter @peerbit/log run build
- pnpm exec eslint --config eslint.config.js packages/log/src/entry.ts packages/log/src/entry-v0.ts packages/log/src/entry-index.ts packages/log/test/append.spec.ts
- git diff --check
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "appendMany appends a local chain with one coalesced change|returns an Entry|plans auto-next append from the native graph"

## Performance / Signal
- The focused appendMany test now asserts EntryV0.toShallow() is not called on the native plain-chain path.
- Local native graph benchmark stays roughly neutral for appendMany because this PR moves the shallow-row construction point rather than removing index/storage work yet; the next useful step is pushing the append-batch index transaction itself further native.