### PR TITLE
Pass append batch boundary hints to entry index

### DIFF
--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -925,6 +925,7 @@ export class EntryIndex<T> {
 		entries: Entry<any>[],
 		properties: {
 			unique: boolean;
+			externalNextHashes?: string[];
 			deferIndexWrite?: boolean;
 		},
 	) {
@@ -951,8 +952,13 @@ export class EntryIndex<T> {
 		}
 
 		const promise = (async () => {
-			const batchHashes = new Set(entries.map((entry) => entry.hash));
-			const externalNexts = new Set<string>();
+			const externalNexts = new Set<string>(
+				properties.externalNextHashes ?? [],
+			);
+			const shouldDiscoverExternalNexts = !properties.externalNextHashes;
+			const batchHashes = shouldDiscoverExternalNexts
+				? new Set(entries.map((entry) => entry.hash))
+				: undefined;
 			const putBatch =
 				!this.properties.onGidRemoved &&
 				(this.properties.index as IndexWithPutBatch<ShallowEntry>).putBatch;
@@ -987,9 +993,11 @@ export class EntryIndex<T> {
 					}
 				}
 
-				for (const next of entry.meta.next) {
-					if (!batchHashes.has(next)) {
-						externalNexts.add(next);
+				if (batchHashes) {
+					for (const next of entry.meta.next) {
+						if (!batchHashes.has(next)) {
+							externalNexts.add(next);
+						}
 					}
 				}
 			}

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -668,7 +668,11 @@ export class Log<T> {
 		if (deferBlockStore) {
 			await this.putAppendEntryBlocks(entries);
 		}
-		await this.putAppendEntries(entries, options);
+		await this.putAppendEntries(
+			entries,
+			options,
+			initialNexts.map((entry) => entry.hash),
+		);
 
 		for (const entry of entries) {
 			entry.init({ encoding: this._encoding, keychain: this._keychain });
@@ -810,9 +814,11 @@ export class Log<T> {
 	private async putAppendEntries(
 		entries: Entry<T>[],
 		options: AppendOptions<T>,
+		externalNextHashes: string[],
 	) {
 		await this.entryIndex.putAppendBatch(entries, {
 			unique: true,
+			externalNextHashes,
 			deferIndexWrite:
 				options.deferIndexWrite ??
 				(options.durability


### PR DESCRIPTION
## Summary
- pass appendMany's known initial next hashes into the append-batch index write
- let EntryIndex.putAppendBatch skip the generic batch-hash set and next-pointer scan when the caller provides those boundary hints
- preserve the old discovery path for arbitrary putAppendBatch callers

## Validation
- pnpm --filter @peerbit/log run build
- pnpm exec eslint --config eslint.config.js packages/log/src/log.ts packages/log/src/entry-index.ts
- git diff --check
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "appendMany appends a local chain with one coalesced change|returns an Entry|plans auto-next append from the native graph"

## Performance / Signal
- Local 1000-entry native graph benchmark remains in the same range; this removes a generic O(batch) scan from appendMany's index handoff, but the measured appendMany path is still dominated by storage/index writes and native WASM signing.