### PR TITLE
Update native graph from append chains

### DIFF
--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -82,6 +82,16 @@ type NativeLogIndexHandle = {
 		heads: Uint8Array,
 		datas: Array<Uint8Array | undefined>,
 	) => void;
+	put_append_chain: (
+		hashes: string[],
+		gid: string,
+		initialNext: string[],
+		type: number,
+		wallTimes: BigUint64Array,
+		logicals: Uint32Array,
+		payloadSizes: Uint32Array,
+		datas: Array<Uint8Array | undefined>,
+	) => void;
 	delete: (hash: string) => boolean;
 	heads: (gid?: string) => string[];
 	has_head: (gid?: string) => boolean;
@@ -315,6 +325,36 @@ export class LogGraphIndex {
 			logicals,
 			payloadSizes,
 			heads,
+			datas,
+		);
+	}
+
+	putAppendChain(entries: NativeLogEntry[]): void {
+		if (entries.length === 0) {
+			return;
+		}
+		const first = entries[0]!;
+		const hashes = new Array<string>(entries.length);
+		const wallTimes = new BigUint64Array(entries.length);
+		const logicals = new Uint32Array(entries.length);
+		const payloadSizes = new Uint32Array(entries.length);
+		const datas = new Array<Uint8Array | undefined>(entries.length);
+		for (let i = 0; i < entries.length; i++) {
+			const entry = entries[i]!;
+			hashes[i] = entry.hash;
+			wallTimes[i] = BigInt(entry.clock.timestamp.wallTime);
+			logicals[i] = entry.clock.timestamp.logical ?? 0;
+			payloadSizes[i] = entry.payloadSize ?? 0;
+			datas[i] = entry.data;
+		}
+		this.native.put_append_chain(
+			hashes,
+			first.gid,
+			first.next,
+			first.type,
+			wallTimes,
+			logicals,
+			payloadSizes,
 			datas,
 		);
 	}

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -592,6 +592,52 @@ impl NativeLogIndex {
         Ok(())
     }
 
+    pub fn put_append_chain(
+        &mut self,
+        hashes: Array,
+        gid: String,
+        initial_next: Array,
+        entry_type: u8,
+        wall_times: BigUint64Array,
+        logicals: Uint32Array,
+        payload_sizes: Uint32Array,
+        datas: Array,
+    ) -> Result<(), JsValue> {
+        let len = hashes.length();
+        if datas.length() != len {
+            return Err(JsValue::from_str("Expected equal column lengths"));
+        }
+        for numeric_len in [
+            wall_times.length(),
+            logicals.length(),
+            payload_sizes.length(),
+        ] {
+            if numeric_len != len {
+                return Err(JsValue::from_str("Expected equal column lengths"));
+            }
+        }
+
+        let mut next = strings_from_array(initial_next)?;
+        let mut entries = Vec::with_capacity(len as usize);
+        for i in 0..len {
+            let hash = required_string_from_array(&hashes, i)?;
+            entries.push(LogIndexEntry::new_with_data(
+                hash.clone(),
+                gid.clone(),
+                next.clone(),
+                entry_type,
+                wall_times.get_index(i),
+                logicals.get_index(i),
+                payload_sizes.get_index(i),
+                i + 1 == len,
+                optional_bytes_from_js(datas.get(i)),
+            ));
+            next = vec![hash];
+        }
+        self.inner.put_many(entries);
+        Ok(())
+    }
+
     pub fn delete(&mut self, hash: &str) -> bool {
         self.inner.delete(hash).is_some()
     }

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -100,6 +100,22 @@ describe("native log graph index", () => {
 		expect(index.payloadSizeSum()).to.equal(3);
 	});
 
+	it("tracks heads and next adjacency in native append chains", async () => {
+		const index = await createLogGraphIndex();
+		index.put(entry("root", "g", [], 1n));
+		index.putAppendChain([
+			entry("a", "g", ["root"], 2n),
+			entry("b", "g", ["a"], 3n),
+			entry("c", "g", ["b"], 4n),
+		]);
+
+		expect(index.heads()).to.deep.equal(["c"]);
+		expect(index.children("root")).to.deep.equal(["a"]);
+		expect(index.children("a")).to.deep.equal(["b"]);
+		expect(index.children("b")).to.deep.equal(["c"]);
+		expect(index.payloadSizeSum()).to.equal(4);
+	});
+
 	it("filters heads by gid and clock order", async () => {
 		const index = await createLogGraphIndex();
 		index.put(entry("b", "one", [], 2n));

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -18,7 +18,11 @@ import {
 } from "@peerbit/indexer-interface";
 import type { ShallowEntry } from "./entry-shallow.js";
 import { EntryType } from "./entry-type.js";
-import { Entry, type ShallowOrFullEntry } from "./entry.js";
+import {
+	Entry,
+	type PreparedNativeLogEntry,
+	type ShallowOrFullEntry,
+} from "./entry.js";
 import type { SortFn, SortableEntry } from "./log-sorting.js";
 import { logger as baseLogger } from "./logger.js";
 
@@ -47,21 +51,7 @@ type IndexWithPutBatch<T extends Record<string, any>> = Index<T> & {
 	putBatch?: (values: T[]) => Promise<void> | void;
 };
 
-type NativeLogEntry = {
-	hash: string;
-	gid: string;
-	next: string[];
-	type: number;
-	head?: boolean;
-	payloadSize?: number;
-	data?: Uint8Array;
-	clock: {
-		timestamp: {
-			wallTime: bigint | number | string;
-			logical?: number;
-		};
-	};
-};
+type NativeLogEntry = PreparedNativeLogEntry;
 
 type NativeJoinCutCheck = {
 	gid: string;
@@ -74,6 +64,7 @@ export type NativeLogGraph = {
 	hasMany: (hashes: Iterable<string>) => Set<string>;
 	put: (entry: NativeLogEntry) => void;
 	putBatch?: (entries: NativeLogEntry[]) => void;
+	putAppendChain?: (entries: NativeLogEntry[]) => void;
 	delete: (hash: string) => boolean;
 	clear: () => void;
 	heads: (gid?: string) => string[];
@@ -892,6 +883,9 @@ export class EntryIndex<T> {
 				const shallowEntry =
 					Entry.takePreparedShallowEntry(entry, properties.isHead) ??
 					entry.toShallow(properties.isHead);
+				const nativeEntry =
+					Entry.takePreparedNativeLogEntry(entry, properties.isHead) ??
+					toNativeLogEntry(shallowEntry);
 				const shouldDeferIndexWrite =
 					properties.deferIndexWrite === true &&
 					properties.isHead &&
@@ -905,7 +899,7 @@ export class EntryIndex<T> {
 					await this.flushPendingWrites(entry.meta.next);
 					await this.properties.index.put(shallowEntry);
 				}
-				this.properties.nativeGraph?.graph.put(toNativeLogEntry(shallowEntry));
+				this.properties.nativeGraph?.graph.put(nativeEntry);
 
 				// check if gids has been shadowed, by query all nexts that have a different gid
 				await this.notifyShadowedGids(entry);
@@ -963,6 +957,14 @@ export class EntryIndex<T> {
 				!this.properties.onGidRemoved &&
 				(this.properties.index as IndexWithPutBatch<ShallowEntry>).putBatch;
 			const shallowEntries: ShallowEntry[] = [];
+			const nativeGraphPutAppendChain =
+				!this.properties.onGidRemoved &&
+				properties.externalNextHashes &&
+				this.properties.nativeGraph?.graph.putAppendChain
+					? this.properties.nativeGraph.graph.putAppendChain.bind(
+							this.properties.nativeGraph.graph,
+						)
+					: undefined;
 			const nativeGraphPutBatch =
 				!this.properties.onGidRemoved && this.properties.nativeGraph?.graph.putBatch
 					? this.properties.nativeGraph.graph.putBatch.bind(
@@ -980,16 +982,22 @@ export class EntryIndex<T> {
 				this.cache.add(entry.hash, entry);
 				const shallowEntry =
 					Entry.takePreparedShallowEntry(entry, isHead) ?? entry.toShallow(isHead);
+				const nativeEntry =
+					this.properties.nativeGraph &&
+					(Entry.takePreparedNativeLogEntry(entry, isHead) ??
+						toNativeLogEntry(shallowEntry));
 				if (putBatch) {
 					shallowEntries.push(shallowEntry);
+					nativeEntry && nativeEntries.push(nativeEntry);
 				} else {
 					await this.properties.index.put(shallowEntry);
-					const nativeEntry = toNativeLogEntry(shallowEntry);
-					if (nativeGraphPutBatch) {
-						nativeEntries.push(nativeEntry);
+					if (nativeGraphPutAppendChain || nativeGraphPutBatch) {
+						nativeEntry && nativeEntries.push(nativeEntry);
 					} else {
-						this.properties.nativeGraph?.graph.put(nativeEntry);
-						await this.notifyShadowedGids(entry);
+						if (nativeEntry) {
+							this.properties.nativeGraph?.graph.put(nativeEntry);
+							await this.notifyShadowedGids(entry);
+						}
 					}
 				}
 
@@ -1004,16 +1012,21 @@ export class EntryIndex<T> {
 
 			if (putBatch) {
 				await putBatch.call(this.properties.index, shallowEntries);
-				const batchedNativeEntries = shallowEntries.map(toNativeLogEntry);
-				if (nativeGraphPutBatch) {
-					nativeGraphPutBatch(batchedNativeEntries);
+				if (nativeGraphPutAppendChain) {
+					nativeGraphPutAppendChain(nativeEntries);
+				} else if (nativeGraphPutBatch) {
+					nativeGraphPutBatch(nativeEntries);
 				} else {
-					for (const nativeEntry of batchedNativeEntries) {
+					for (const nativeEntry of nativeEntries) {
 						this.properties.nativeGraph?.graph.put(nativeEntry);
 					}
 				}
-			} else if (nativeGraphPutBatch && nativeEntries.length > 0) {
-				nativeGraphPutBatch(nativeEntries);
+			} else if (nativeEntries.length > 0) {
+				if (nativeGraphPutAppendChain) {
+					nativeGraphPutAppendChain(nativeEntries);
+				} else if (nativeGraphPutBatch) {
+					nativeGraphPutBatch(nativeEntries);
+				}
 			}
 
 			if (externalNexts.size > 0) {

--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -651,6 +651,21 @@ export class EntryV0<T>
 					}),
 				}),
 			);
+			Entry.prepareNativeLogEntry(entry, {
+				hash: entry.hash,
+				gid: meta.gid,
+				next: meta.next,
+				type: meta.type,
+				head: index === prepared.length - 1,
+				payloadSize: payload.byteLength,
+				data: meta.data,
+				clock: {
+					timestamp: {
+						wallTime: meta.clock.timestamp.wallTime,
+						logical: meta.clock.timestamp.logical,
+					},
+				},
+			});
 			entry.init({ encoding: properties.encoding });
 			return entry;
 		});

--- a/packages/log/src/entry.ts
+++ b/packages/log/src/entry.ts
@@ -16,9 +16,25 @@ import type { Payload } from "./payload.js";
 export type CanAppend<T> = (canAppend: Entry<T>) => Promise<boolean> | boolean;
 export type ShallowOrFullEntry<T> = ShallowEntry | Entry<T>;
 export type PreparedEntryBlock = Awaited<ReturnType<typeof calculateRawCid>>;
+export type PreparedNativeLogEntry = {
+	hash: string;
+	gid: string;
+	next: string[];
+	type: number;
+	head?: boolean;
+	payloadSize?: number;
+	data?: Uint8Array;
+	clock: {
+		timestamp: {
+			wallTime: bigint | number | string;
+			logical?: number;
+		};
+	};
+};
 
 const preparedEntryBlocks = new WeakMap<object, PreparedEntryBlock>();
 const preparedShallowEntries = new WeakMap<object, ShallowEntry>();
+const preparedNativeLogEntries = new WeakMap<object, PreparedNativeLogEntry>();
 
 const preparedEntryBlockFromBytes = (
 	bytes: Uint8Array,
@@ -169,6 +185,25 @@ export abstract class Entry<T> {
 		const prepared = preparedShallowEntries.get(entry);
 		if (prepared) {
 			preparedShallowEntries.delete(entry);
+			prepared.head = isHead;
+		}
+		return prepared;
+	}
+
+	static prepareNativeLogEntry<T>(
+		entry: Entry<T>,
+		nativeEntry: PreparedNativeLogEntry,
+	): void {
+		preparedNativeLogEntries.set(entry, nativeEntry);
+	}
+
+	static takePreparedNativeLogEntry<T>(
+		entry: Entry<T>,
+		isHead: boolean,
+	): PreparedNativeLogEntry | undefined {
+		const prepared = preparedNativeLogEntries.get(entry);
+		if (prepared) {
+			preparedNativeLogEntries.delete(entry);
 			prepared.head = isHead;
 		}
 		return prepared;

--- a/packages/log/test/append.spec.ts
+++ b/packages/log/test/append.spec.ts
@@ -165,6 +165,10 @@ describe("append", function () {
 		const blockPutSpy = sinon.spy(store, "put");
 		const blockPutManySpy = sinon.spy(store, "putMany");
 		const shallowSpy = sinon.spy(EntryV0.prototype, "toShallow");
+		const nativeAppendChainSpy = sinon.spy(
+			log.entryIndex.properties.nativeGraph!.graph,
+			"putAppendChain",
+		);
 
 		try {
 			const result = await log.appendMany([
@@ -201,12 +205,17 @@ describe("append", function () {
 				result.entries.length,
 			);
 			expect(shallowSpy.callCount).equal(0);
+			expect(nativeAppendChainSpy.callCount).equal(1);
+			expect(nativeAppendChainSpy.firstCall.args[0]).to.have.length(
+				result.entries.length,
+			);
 		} finally {
 			iterateSpy.restore();
 			putSpy.restore();
 			blockPutSpy.restore();
 			blockPutManySpy.restore();
 			shallowSpy.restore();
+			nativeAppendChainSpy.restore();
 			await log.close();
 		}
 	});


### PR DESCRIPTION
## Summary
- add a Rust-backed `put_append_chain` API for native log graph updates
- expose `LogGraphIndex.putAppendChain()` through the TS wrapper
- prepare native graph rows alongside native EntryV0 plain-chain appends
- have `EntryIndex.putAppendBatch()` use the append-chain graph update when appendMany provides boundary hints

## Why
For local appendMany chains, the graph mirror no longer needs to receive a fully expanded per-entry JS graph row with precomputed `next` and `head` fields. The Rust graph update now reconstructs the chain links and final head flag from compact append-chain input.

## Validation
- pnpm --filter @peerbit/log-rust run build
- pnpm --filter @peerbit/log-rust run test
- pnpm --filter @peerbit/log-rust run lint
- pnpm --filter @peerbit/log run build
- pnpm exec eslint --config eslint.config.js packages/log/src/entry.ts packages/log/src/entry-v0.ts packages/log/src/entry-index.ts packages/log/test/append.spec.ts packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts
- git diff --check
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "appendMany appends a local chain with one coalesced change|returns an Entry|plans auto-next append from the native graph"

## Performance / Signal
Local native graph benchmark, 1000 entries / 1000 iterations:
- append loop auto-next nativeGraph=true: ~10.6k ops/sec
- appendMany auto-next nativeGraph=false: ~18.0k ops/sec
- appendMany auto-next nativeGraph=true: ~18.0k ops/sec

The appendMany path now uses `putAppendChain` in the focused test. The remaining larger cost is still block/index storage plus WASM signing, so the next bigger native move should coalesce storage/index writes more deeply instead of just reshaping graph metadata.
