### PR TITLE
Carry native append chains through writes

### DIFF
--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -920,6 +920,10 @@ export class EntryIndex<T> {
 		properties: {
 			unique: boolean;
 			externalNextHashes?: string[];
+			prepared?: {
+				shallowEntries: ShallowEntry[];
+				nativeEntries?: NativeLogEntry[];
+			};
 			deferIndexWrite?: boolean;
 		},
 	) {
@@ -980,11 +984,22 @@ export class EntryIndex<T> {
 				}
 
 				this.cache.add(entry.hash, entry);
+				const preparedShallowEntry = properties.prepared?.shallowEntries[i];
+				if (preparedShallowEntry) {
+					preparedShallowEntry.head = isHead;
+				}
 				const shallowEntry =
-					Entry.takePreparedShallowEntry(entry, isHead) ?? entry.toShallow(isHead);
+					preparedShallowEntry ??
+					Entry.takePreparedShallowEntry(entry, isHead) ??
+					entry.toShallow(isHead);
+				const preparedNativeEntry = properties.prepared?.nativeEntries?.[i];
+				if (preparedNativeEntry) {
+					preparedNativeEntry.head = isHead;
+				}
 				const nativeEntry =
 					this.properties.nativeGraph &&
-					(Entry.takePreparedNativeLogEntry(entry, isHead) ??
+					(preparedNativeEntry ??
+						Entry.takePreparedNativeLogEntry(entry, isHead) ??
 						toNativeLogEntry(shallowEntry));
 				if (putBatch) {
 					shallowEntries.push(shallowEntry);

--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -29,7 +29,7 @@ import { LamportClock as Clock, HLC, Timestamp } from "./clock.js";
 import { type Encoding, NO_ENCODING } from "./encoding.js";
 import { ShallowEntry, ShallowMeta } from "./entry-shallow.js";
 import { EntryType } from "./entry-type.js";
-import { type CanAppend, Entry } from "./entry.js";
+import { type CanAppend, Entry, type PreparedAppendChain } from "./entry.js";
 import type { SortableEntry } from "./log-sorting.js";
 import { logger as baseLogger } from "./logger.js";
 import { Payload } from "./payload.js";
@@ -511,7 +511,26 @@ export class EntryV0<T>
 		encoding: Encoding<T>;
 		identity: Identity;
 		deferStore: boolean;
+		cachePreparedEntries?: boolean;
 	}): Promise<Entry<T>[] | undefined> {
+		return (await EntryV0.createPlainAppendChainBatch(properties))?.entries;
+	}
+
+	static async createPlainAppendChainBatch<T>(properties: {
+		data: T[];
+		meta?: {
+			clocks: () => Clock[];
+			gid?: string;
+			type?: EntryType;
+			gidSeed?: Uint8Array;
+			data?: Uint8Array;
+			next?: SortableEntry[];
+		};
+		encoding: Encoding<T>;
+		identity: Identity;
+		deferStore: boolean;
+		cachePreparedEntries?: boolean;
+	}): Promise<PreparedAppendChain<T> | undefined> {
 		if (!properties.deferStore) {
 			return undefined;
 		}
@@ -598,7 +617,13 @@ export class EntryV0<T>
 			payloadDatas: payloads.map((payload) => payload.data),
 		});
 
-		return prepared.map((preparedEntry, index) => {
+		const entries: PreparedAppendChain<T>["entries"] = [];
+		const blocks: PreparedAppendChain<T>["blocks"] = [];
+		const shallowEntries: PreparedAppendChain<T>["shallowEntries"] = [];
+		const nativeEntries: PreparedAppendChain<T>["nativeEntries"] = [];
+
+		for (let index = 0; index < prepared.length; index++) {
+			const preparedEntry = prepared[index]!;
 			const meta = new Meta({
 				clock: clocks[index]!,
 				gid: gid!,
@@ -631,27 +656,33 @@ export class EntryV0<T>
 				}),
 				createdLocally: true,
 			});
-			entry.hash = Entry.prepareMultihashBytes(
-				entry,
+			const preparedBlock = Entry.preparedBlockFromBytes(
 				preparedEntry.bytes,
 				preparedEntry.cid,
 			);
-			Entry.prepareShallowEntry(
-				entry,
-				new ShallowEntry({
-					hash: entry.hash,
-					payloadSize: payload.byteLength,
-					head: index === prepared.length - 1,
-					meta: new ShallowMeta({
-						gid: meta.gid,
-						data: meta.data,
-						clock: meta.clock,
-						next: meta.next,
-						type: meta.type,
-					}),
+			if (properties.cachePreparedEntries === false) {
+				entry.hash = preparedEntry.cid;
+				entry.size = preparedEntry.bytes.length;
+			} else {
+				entry.hash = Entry.prepareMultihashBytes(
+					entry,
+					preparedEntry.bytes,
+					preparedEntry.cid,
+				);
+			}
+			const shallowEntry = new ShallowEntry({
+				hash: entry.hash,
+				payloadSize: payload.byteLength,
+				head: index === prepared.length - 1,
+				meta: new ShallowMeta({
+					gid: meta.gid,
+					data: meta.data,
+					clock: meta.clock,
+					next: meta.next,
+					type: meta.type,
 				}),
-			);
-			Entry.prepareNativeLogEntry(entry, {
+			});
+			const nativeEntry = {
 				hash: entry.hash,
 				gid: meta.gid,
 				next: meta.next,
@@ -665,10 +696,18 @@ export class EntryV0<T>
 						logical: meta.clock.timestamp.logical,
 					},
 				},
-			});
+			};
+			if (properties.cachePreparedEntries !== false) {
+				Entry.prepareShallowEntry(entry, shallowEntry);
+				Entry.prepareNativeLogEntry(entry, nativeEntry);
+			}
 			entry.init({ encoding: properties.encoding });
-			return entry;
-		});
+			entries.push(entry);
+			blocks.push(preparedBlock);
+			shallowEntries.push(shallowEntry);
+			nativeEntries.push(nativeEntry);
+		}
+		return { entries, blocks, shallowEntries, nativeEntries };
 	}
 
 	static async create<T>(properties: {

--- a/packages/log/src/entry.ts
+++ b/packages/log/src/entry.ts
@@ -31,6 +31,12 @@ export type PreparedNativeLogEntry = {
 		};
 	};
 };
+export type PreparedAppendChain<T> = {
+	entries: Entry<T>[];
+	blocks: PreparedEntryBlock[];
+	shallowEntries: ShallowEntry[];
+	nativeEntries: PreparedNativeLogEntry[];
+};
 
 const preparedEntryBlocks = new WeakMap<object, PreparedEntryBlock>();
 const preparedShallowEntries = new WeakMap<object, ShallowEntry>();
@@ -150,6 +156,10 @@ export abstract class Entry<T> {
 		entry.size = bytes.length;
 		preparedEntryBlocks.set(entry, preparedEntryBlockFromBytes(bytes, cid));
 		return cid;
+	}
+
+	static preparedBlockFromBytes(bytes: Uint8Array, cid: string): PreparedEntryBlock {
+		return preparedEntryBlockFromBytes(bytes, cid);
 	}
 
 	static toMultihashBytes<T>(

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -36,6 +36,7 @@ import { type EntryWithRefs } from "./entry-with-refs.js";
 import {
 	type CanAppend,
 	Entry,
+	type PreparedAppendChain,
 	type PreparedEntryBlock,
 	type ShallowOrFullEntry,
 } from "./entry.js";
@@ -623,13 +624,13 @@ export class Log<T> {
 		)[] = [];
 		const deferBlockStore = hasPutMany(this._storage);
 
-		const nativeEntries =
+		const nativeAppendChain =
 			deferBlockStore &&
 			!options.encryption &&
 			!options.signers &&
 			!(options.canAppend || this._hasCustomCanAppend) &&
 			!options.meta?.timestamp
-				? await EntryV0.createPlainAppendChain<T>({
+				? await EntryV0.createPlainAppendChainBatch<T>({
 						data,
 						meta: {
 							clocks: () =>
@@ -648,11 +649,12 @@ export class Log<T> {
 						encoding: this._encoding,
 						identity: options.identity || this._identity,
 						deferStore: deferBlockStore,
+						cachePreparedEntries: false,
 					})
 				: undefined;
 
-		if (nativeEntries) {
-			entries.push(...nativeEntries);
+		if (nativeAppendChain) {
+			entries.push(...nativeAppendChain.entries);
 			nexts = [entries[entries.length - 1]!];
 		} else {
 			for (const item of data) {
@@ -666,12 +668,13 @@ export class Log<T> {
 
 		await this.joinMissingNexts(entries[0]!, initialNexts);
 		if (deferBlockStore) {
-			await this.putAppendEntryBlocks(entries);
+			await this.putAppendEntryBlocks(entries, nativeAppendChain?.blocks);
 		}
 		await this.putAppendEntries(
 			entries,
 			options,
 			initialNexts.map((entry) => entry.hash),
+			nativeAppendChain,
 		);
 
 		for (const entry of entries) {
@@ -815,10 +818,19 @@ export class Log<T> {
 		entries: Entry<T>[],
 		options: AppendOptions<T>,
 		externalNextHashes: string[],
+		preparedAppendChain?: PreparedAppendChain<T>,
 	) {
 		await this.entryIndex.putAppendBatch(entries, {
 			unique: true,
 			externalNextHashes,
+			prepared:
+				preparedAppendChain &&
+				entries.length === preparedAppendChain.entries.length
+					? {
+							shallowEntries: preparedAppendChain.shallowEntries,
+							nativeEntries: preparedAppendChain.nativeEntries,
+						}
+					: undefined,
 			deferIndexWrite:
 				options.deferIndexWrite ??
 				(options.durability
@@ -827,15 +839,20 @@ export class Log<T> {
 		});
 	}
 
-	private async putAppendEntryBlocks(entries: Entry<T>[]) {
-		const blocks: PreparedEntryBlock[] = [];
-		for (const entry of entries) {
-			const prepared = Entry.takePreparedBlock(entry);
-			if (!prepared) {
-				throw new Error("Missing prepared entry block");
-			}
-			blocks.push(prepared);
-		}
+	private async putAppendEntryBlocks(
+		entries: Entry<T>[],
+		preparedBlocks?: PreparedEntryBlock[],
+	) {
+		const blocks =
+			preparedBlocks && preparedBlocks.length === entries.length
+				? preparedBlocks
+				: entries.map((entry) => {
+						const prepared = Entry.takePreparedBlock(entry);
+						if (!prepared) {
+							throw new Error("Missing prepared entry block");
+						}
+						return prepared;
+					});
 
 		const cids = await (this._storage as BlocksWithPutMany).putMany!(blocks);
 		if (cids.length !== blocks.length) {

--- a/packages/log/test/append.spec.ts
+++ b/packages/log/test/append.spec.ts
@@ -3,6 +3,7 @@ import { Ed25519Keypair } from "@peerbit/crypto";
 import { HashmapIndices } from "@peerbit/indexer-simple";
 import { expect } from "chai";
 import sinon from "sinon";
+import { Entry } from "../src/entry.js";
 import { EntryV0 } from "../src/entry-v0.js";
 import { EntryType } from "../src/entry-type.js";
 import { Log } from "../src/log.js";
@@ -169,6 +170,9 @@ describe("append", function () {
 			log.entryIndex.properties.nativeGraph!.graph,
 			"putAppendChain",
 		);
+		const preparedBlockSpy = sinon.spy(Entry, "takePreparedBlock");
+		const preparedShallowSpy = sinon.spy(Entry, "takePreparedShallowEntry");
+		const preparedNativeSpy = sinon.spy(Entry, "takePreparedNativeLogEntry");
 
 		try {
 			const result = await log.appendMany([
@@ -209,6 +213,9 @@ describe("append", function () {
 			expect(nativeAppendChainSpy.firstCall.args[0]).to.have.length(
 				result.entries.length,
 			);
+			expect(preparedBlockSpy.callCount).equal(0);
+			expect(preparedShallowSpy.callCount).equal(0);
+			expect(preparedNativeSpy.callCount).equal(0);
 		} finally {
 			iterateSpy.restore();
 			putSpy.restore();
@@ -216,6 +223,9 @@ describe("append", function () {
 			blockPutManySpy.restore();
 			shallowSpy.restore();
 			nativeAppendChainSpy.restore();
+			preparedBlockSpy.restore();
+			preparedShallowSpy.restore();
+			preparedNativeSpy.restore();
 			await log.close();
 		}
 	});


### PR DESCRIPTION
## Summary
- add a prepared append-chain bundle that carries entries, prepared block writes, shallow index rows, and native graph rows together
- have the native plain appendMany path pass that bundle through block `putMany` and `EntryIndex.putAppendBatch`
- skip unused per-entry prepared WeakMap writes on the direct transaction path
- keep the old per-entry prepared caches for the public `EntryV0.createPlainAppendChain()` helper/fallback behavior

## Why
The previous stack made native preparation possible, but the write phase still rediscovered prepared blocks/shallow/native rows from each `Entry`. This PR carries the prepared append-chain transaction through the write pipeline directly, which is closer to the eventual native append transaction shape.

## Validation
- pnpm --filter @peerbit/log run build
- pnpm exec eslint --config eslint.config.js packages/log/src/entry.ts packages/log/src/entry-v0.ts packages/log/src/entry-index.ts packages/log/src/log.ts packages/log/test/append.spec.ts
- git diff --check
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "appendMany appends a local chain with one coalesced change|returns an Entry|plans auto-next append from the native graph"

## Performance / Signal
Local native graph benchmark, 1000 entries / 1000 iterations:
- append loop auto-next nativeGraph=true: ~10.8k ops/sec
- appendMany auto-next nativeGraph=false: ~17.6k ops/sec
- appendMany auto-next nativeGraph=true: ~18.5k ops/sec

The focused appendMany test now asserts the native transaction path does not call `Entry.takePreparedBlock`, `Entry.takePreparedShallowEntry`, or `Entry.takePreparedNativeLogEntry`.
