### PR TITLE
Batch simple index writes

### DIFF
--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -47,10 +47,6 @@ type BlocksWithGetMany = Blocks & {
 	) => Promise<Array<Uint8Array | undefined>> | Array<Uint8Array | undefined>;
 };
 
-type IndexWithPutBatch<T extends Record<string, any>> = Index<T> & {
-	putBatch?: (values: T[]) => Promise<void> | void;
-};
-
 type NativeLogEntry = PreparedNativeLogEntry;
 
 type NativeJoinCutCheck = {
@@ -958,8 +954,7 @@ export class EntryIndex<T> {
 				? new Set(entries.map((entry) => entry.hash))
 				: undefined;
 			const putBatch =
-				!this.properties.onGidRemoved &&
-				(this.properties.index as IndexWithPutBatch<ShallowEntry>).putBatch;
+				!this.properties.onGidRemoved && this.properties.index.putBatch;
 			const shallowEntries: ShallowEntry[] = [];
 			const nativeGraphPutAppendChain =
 				!this.properties.onGidRemoved &&

--- a/packages/log/test/append.spec.ts
+++ b/packages/log/test/append.spec.ts
@@ -163,6 +163,7 @@ describe("append", function () {
 
 		const iterateSpy = sinon.spy(log.entryIndex.properties.index, "iterate");
 		const putSpy = sinon.spy(log.entryIndex.properties.index, "put");
+		const putBatchSpy = sinon.spy(log.entryIndex.properties.index, "putBatch");
 		const blockPutSpy = sinon.spy(store, "put");
 		const blockPutManySpy = sinon.spy(store, "putMany");
 		const shallowSpy = sinon.spy(EntryV0.prototype, "toShallow");
@@ -202,7 +203,9 @@ describe("append", function () {
 				true,
 			]);
 			expect(iterateSpy.callCount).equal(0);
-			expect(putSpy.callCount).equal(result.entries.length + 1);
+			expect(putSpy.callCount).equal(1);
+			expect(putBatchSpy.callCount).equal(1);
+			expect(putBatchSpy.firstCall.args[0]).to.have.length(result.entries.length);
 			expect(blockPutSpy.callCount).equal(0);
 			expect(blockPutManySpy.callCount).equal(1);
 			expect(blockPutManySpy.firstCall.args[0]).to.have.length(
@@ -219,6 +222,7 @@ describe("append", function () {
 		} finally {
 			iterateSpy.restore();
 			putSpy.restore();
+			putBatchSpy.restore();
 			blockPutSpy.restore();
 			blockPutManySpy.restore();
 			shallowSpy.restore();

--- a/packages/utils/indexer/cached-index/src/index.ts
+++ b/packages/utils/indexer/cached-index/src/index.ts
@@ -75,6 +75,17 @@ export class CachedIndex<T extends Record<string, any>, Nested = unknown>
 		await this._cache.refresh();
 	}
 
+	async putBatch(values: T[]) {
+		if (this.origin.putBatch) {
+			await this.origin.putBatch(values);
+		} else {
+			for (const value of values) {
+				await this.origin.put(value);
+			}
+		}
+		await this._cache.refresh();
+	}
+
 	async del(q: DeleteOptions) {
 		const res = await this.origin.del(q);
 		await this._cache.refresh();

--- a/packages/utils/indexer/interface/src/index-engine.ts
+++ b/packages/utils/indexer/interface/src/index-engine.ts
@@ -107,6 +107,7 @@ export interface Index<T extends Record<string, any>, NestedType = any> {
 			replace?: boolean;
 		},
 	): MaybePromise<void>;
+	putBatch?(values: T[]): MaybePromise<void>;
 	del(query: DeleteOptions): MaybePromise<IdKey[]>;
 	sum(query: SumOptions): MaybePromise<bigint | number>;
 	count(query?: CountOptions): MaybePromise<number>;

--- a/packages/utils/indexer/simple/src/index.ts
+++ b/packages/utils/indexer/simple/src/index.ts
@@ -87,6 +87,13 @@ export class HashmapIndex<T extends Record<string, any>, NestedType = any>
 		this._index.set(id.primitive, { id, value });
 	}
 
+	putBatch(values: T[]): void {
+		for (const value of values) {
+			const id = types.toId(types.extractFieldValue(value, this.indexByArr));
+			this._index.set(id.primitive, { id, value });
+		}
+	}
+
 	async del(query: types.DeleteOptions): Promise<types.IdKey[]> {
 		let deleted: types.IdKey[] = [];
 		for (const doc of await this.queryAll(query)) {

--- a/packages/utils/indexer/simple/test/index.spec.ts
+++ b/packages/utils/indexer/simple/test/index.spec.ts
@@ -1,10 +1,58 @@
+import { field } from "@dao-xyz/borsh";
+import {
+	Sort,
+	SortDirection,
+	StringMatch,
+	StringMatchMethod,
+	id,
+} from "@peerbit/indexer-interface";
 import { tests } from "@peerbit/indexer-tests";
+import { expect } from "chai";
 import { create } from "../src/index.js";
+
+class BatchDocument {
+	@id({ type: "string" })
+	id: string;
+
+	@field({ type: "string" })
+	tag: string;
+
+	constructor(id: string, tag: string) {
+		this.id = id;
+		this.tag = tag;
+	}
+}
 
 describe("all", () => {
 	tests(create, "transient", {
 		shapingSupported: false,
 		u64SumSupported: true,
 		iteratorsMutable: false,
+	});
+
+	it("applies puts in a batch", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BatchDocument });
+
+		await index.putBatch?.([
+			new BatchDocument("a", "peerbit"),
+			new BatchDocument("b", "peerbit"),
+			new BatchDocument("c", "other"),
+		]);
+
+		const results = await index
+			.iterate({
+				query: new StringMatch({
+					key: "tag",
+					value: "peerbit",
+					method: StringMatchMethod.exact,
+				}),
+				sort: [new Sort({ key: "id", direction: SortDirection.ASC })],
+			})
+			.all();
+		expect(results.map((result) => result.value.id)).to.deep.equal(["a", "b"]);
+
+		await indices.drop();
 	});
 });


### PR DESCRIPTION
## Summary
- add optional `putBatch(values)` to the index interface
- implement batch writes for `HashmapIndex`
- forward batch writes through `CachedIndex` with a single cache refresh
- remove the local `EntryIndex` cast now that the interface exposes the optional batch API
- update the appendMany focused test to assert `HashmapIndex.putBatch` is used once instead of per-entry `put`

## Why
The native append-chain transaction is now prepared and carried through the log write path, but transient logs using the default simple index were still doing one JS index `put` per appended entry. This gives that write phase an actual batch API so appendMany can coalesce the index write side too.

## Validation
- pnpm --filter @peerbit/indexer-interface run build
- pnpm --filter @peerbit/indexer-simple run build
- pnpm --filter @peerbit/indexer-cache run build
- pnpm --filter @peerbit/log run build
- pnpm --filter @peerbit/indexer-simple run test -- --grep "applies puts in a batch" -t node
- pnpm exec eslint --config eslint.config.js packages/log/src/entry-index.ts packages/log/test/append.spec.ts packages/utils/indexer/interface/src/index-engine.ts packages/utils/indexer/simple/src/index.ts packages/utils/indexer/simple/test/index.spec.ts packages/utils/indexer/cached-index/src/index.ts
- git diff --check
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "appendMany appends a local chain with one coalesced change"

## Performance / Signal
Local native graph benchmark, 1000 entries / 1000 iterations:
- append loop auto-next nativeGraph=true: ~10.7k ops/sec
- appendMany auto-next nativeGraph=false: ~18.7k ops/sec
- appendMany auto-next nativeGraph=true: ~17.6k ops/sec in this run

The focused appendMany test now proves the simple index uses one `putBatch` call for the appended entries and only the initial root append uses single `put`.
