### PR TITLE
Coalesce native append graph updates

### DIFF
--- a/packages/log/rust/Cargo.lock
+++ b/packages/log/rust/Cargo.lock
@@ -12,30 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
-dependencies = [
- "borsh-derive",
- "bytes",
- "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
-dependencies = [
- "once_cell",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,34 +27,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cpufeatures"
@@ -237,27 +189,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "memchr"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "peerbit_indexer_rust"
-version = "0.0.0"
-dependencies = [
- "borsh",
- "indexmap",
- "js-sys",
- "roaring",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "peerbit_log_rust"
@@ -267,7 +202,6 @@ dependencies = [
  "ed25519-dalek",
  "indexmap",
  "js-sys",
- "peerbit_indexer_rust",
  "sha2",
  "wasm-bindgen",
 ]
@@ -277,15 +211,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -303,16 +228,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "roaring"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
-dependencies = [
- "bytemuck",
- "byteorder",
 ]
 
 [[package]]
@@ -335,26 +250,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
-name = "serde_core"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "sha2"
@@ -410,36 +305,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "toml_parser",
- "winnow",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
-dependencies = [
- "winnow",
-]
 
 [[package]]
 name = "typenum"
@@ -502,13 +367,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "winnow"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
-dependencies = [
- "memchr",
 ]

--- a/packages/log/rust/Cargo.toml
+++ b/packages/log/rust/Cargo.toml
@@ -12,7 +12,6 @@ crate-type = ["cdylib", "rlib"]
 ed25519-dalek = { version = "2.1.1", default-features = false, features = ["fast"] }
 indexmap = "2.7.1"
 js-sys = "0.3.80"
-peerbit_indexer_rust = { path = "../../utils/indexer/rust" }
 bs58 = "0.5.1"
 sha2 = "0.10.8"
 wasm-bindgen = "0.2.103"

--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -92,6 +92,18 @@ type NativeLogIndexHandle = {
 		payloadSizes: Uint32Array,
 		datas: Array<Uint8Array | undefined>,
 	) => void;
+	prepare_entry_v0_plain_chain_and_put: (
+		clockId: Uint8Array,
+		privateKey: Uint8Array,
+		publicKey: Uint8Array,
+		wallTimes: BigUint64Array,
+		logicals: Uint32Array,
+		gid: string,
+		initialNext: string[],
+		type: number,
+		metaDatas: Array<Uint8Array | undefined>,
+		payloadDatas: Uint8Array[],
+	) => EntryV0PreparedPlainEntryRow[];
 	delete: (hash: string) => boolean;
 	heads: (gid?: string) => string[];
 	has_head: (gid?: string) => boolean;
@@ -201,17 +213,7 @@ type WasmModule = {
 		type: number,
 		metaDatas: Array<Uint8Array | undefined>,
 		payloadDatas: Uint8Array[],
-	) => Array<
-		[
-			Uint8Array,
-			string,
-			Uint8Array,
-			string[],
-			Uint8Array,
-			Uint8Array,
-			Uint8Array,
-		]
-	>;
+	) => EntryV0PreparedPlainEntryRow[];
 	calculate_raw_cid_v1: (bytes: Uint8Array) => string;
 };
 
@@ -356,6 +358,31 @@ export class LogGraphIndex {
 			logicals,
 			payloadSizes,
 			datas,
+		);
+	}
+
+	prepareEntryV0PlainChainAndPut(
+		input: EntryV0PlainChainInput,
+	): Promise<EntryV0PreparedPlainEntry[]> {
+		const columns = plainChainInputColumns(input);
+		if (!columns) {
+			return Promise.resolve([]);
+		}
+		return Promise.resolve(
+			preparedPlainEntryRows(
+				this.native.prepare_entry_v0_plain_chain_and_put(
+					input.clockId,
+					input.privateKey,
+					input.publicKey,
+					columns.wallTimes,
+					columns.logicals,
+					input.gid,
+					input.initialNext ?? [],
+					input.type ?? 0,
+					columns.metaDatas,
+					input.payloadDatas,
+				),
+			),
 		);
 	}
 
@@ -558,6 +585,59 @@ export type EntryV0PreparedPlainEntry = EntryV0EncodedStorage & {
 	signatureBytes: Uint8Array;
 };
 
+type EntryV0PreparedPlainEntryRow = [
+	Uint8Array,
+	string,
+	Uint8Array,
+	string[],
+	Uint8Array,
+	Uint8Array,
+	Uint8Array,
+];
+
+const plainChainInputColumns = (input: EntryV0PlainChainInput) => {
+	if (input.payloadDatas.length === 0) {
+		return undefined;
+	}
+	if (input.wallTimes.length !== input.payloadDatas.length) {
+		throw new Error("Expected equal column lengths");
+	}
+	const wallTimes = new BigUint64Array(input.wallTimes.length);
+	const logicals = new Uint32Array(input.payloadDatas.length);
+	const metaDatas = new Array<Uint8Array | undefined>(
+		input.payloadDatas.length,
+	);
+	for (let i = 0; i < input.payloadDatas.length; i++) {
+		wallTimes[i] = BigInt(input.wallTimes[i]!);
+		logicals[i] = input.logicals?.[i] ?? 0;
+		metaDatas[i] = input.metaDatas?.[i];
+	}
+	return { wallTimes, logicals, metaDatas };
+};
+
+const preparedPlainEntryRows = (
+	rows: EntryV0PreparedPlainEntryRow[],
+): EntryV0PreparedPlainEntry[] =>
+	rows.map(
+		([
+			bytes,
+			cid,
+			signature,
+			next,
+			metaBytes,
+			payloadBytes,
+			signatureBytes,
+		]) => ({
+			bytes,
+			cid,
+			signature,
+			next,
+			metaBytes,
+			payloadBytes,
+			signatureBytes,
+		}),
+	);
+
 const entryColumns = (inputs: EntryV0EncodeInput[]) => {
 	const clockIds = new Array<Uint8Array>(inputs.length);
 	const wallTimes = new BigUint64Array(inputs.length);
@@ -711,55 +791,25 @@ export const encodeEntryV0StorageBatchWithCids = async (
 export const prepareEntryV0PlainChain = async (
 	input: EntryV0PlainChainInput,
 ): Promise<EntryV0PreparedPlainEntry[]> => {
-	if (input.payloadDatas.length === 0) {
+	const columns = plainChainInputColumns(input);
+	if (!columns) {
 		return [];
 	}
-	if (input.wallTimes.length !== input.payloadDatas.length) {
-		throw new Error("Expected equal column lengths");
-	}
 	const wasm = await loadWasm();
-	const wallTimes = new BigUint64Array(input.wallTimes.length);
-	const logicals = new Uint32Array(input.payloadDatas.length);
-	const metaDatas = new Array<Uint8Array | undefined>(
-		input.payloadDatas.length,
-	);
-	for (let i = 0; i < input.payloadDatas.length; i++) {
-		wallTimes[i] = BigInt(input.wallTimes[i]!);
-		logicals[i] = input.logicals?.[i] ?? 0;
-		metaDatas[i] = input.metaDatas?.[i];
-	}
-	return wasm
-		.prepare_entry_v0_plain_chain(
+	return preparedPlainEntryRows(
+		wasm.prepare_entry_v0_plain_chain(
 			input.clockId,
 			input.privateKey,
 			input.publicKey,
-			wallTimes,
-			logicals,
+			columns.wallTimes,
+			columns.logicals,
 			input.gid,
 			input.initialNext ?? [],
 			input.type ?? 0,
-			metaDatas,
+			columns.metaDatas,
 			input.payloadDatas,
-		)
-		.map(
-			([
-				bytes,
-				cid,
-				signature,
-				next,
-				metaBytes,
-				payloadBytes,
-				signatureBytes,
-			]) => ({
-				bytes,
-				cid,
-				signature,
-				next,
-				metaBytes,
-				payloadBytes,
-				signatureBytes,
-			}),
-		);
+		),
+	);
 };
 
 export const calculateRawCidV1 = async (bytes: Uint8Array): Promise<string> => {

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -1,21 +1,10 @@
 use ed25519_dalek::{Signer, SigningKey};
 use indexmap::{IndexMap, IndexSet};
 use js_sys::{Array, BigUint64Array, Uint32Array, Uint8Array};
-use peerbit_indexer_rust::planner::{
-    DocumentFields, FieldValue, NativeQueryIndex, Query, SortDirection, SortField,
-};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, VecDeque};
 use wasm_bindgen::prelude::*;
 
-const FIELD_HASH: u32 = 1;
-const FIELD_GID: u32 = 2;
-const FIELD_HEAD: u32 = 3;
-const FIELD_TYPE: u32 = 4;
-const FIELD_NEXT: u32 = 5;
-const FIELD_WALL_TIME: u32 = 6;
-const FIELD_LOGICAL: u32 = 7;
-const FIELD_PAYLOAD_SIZE: u32 = 8;
 const ENTRY_TYPE_CUT: u8 = 1;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -92,7 +81,7 @@ pub struct JoinPlan {
 pub struct LogGraphIndex {
     entries: IndexMap<String, LogIndexEntry>,
     children: HashMap<String, IndexSet<String>>,
-    query: NativeQueryIndex,
+    heads: IndexSet<String>,
     payload_size_total: u64,
 }
 
@@ -116,7 +105,7 @@ impl LogGraphIndex {
     pub fn clear(&mut self) {
         self.entries.clear();
         self.children.clear();
-        self.query.clear();
+        self.heads.clear();
         self.payload_size_total = 0;
     }
 
@@ -145,10 +134,15 @@ impl LogGraphIndex {
         let demotes_nexts = entry.entry_type != ENTRY_TYPE_CUT;
         let nexts = entry.next.clone();
         let payload_size = entry.payload_size as u64;
+        let head = entry.head;
 
         self.entries.insert(hash.clone(), entry);
         self.payload_size_total += payload_size;
-        self.reindex(&hash);
+        if head {
+            self.heads.insert(hash.clone());
+        } else {
+            self.heads.shift_remove(&hash);
+        }
 
         for next in nexts {
             self.children
@@ -168,9 +162,41 @@ impl LogGraphIndex {
         }
     }
 
+    pub fn put_append_chain(&mut self, entries: Vec<LogIndexEntry>, initial_next: &[String]) {
+        let Some(first) = entries.first() else {
+            return;
+        };
+        let demotes_initial_nexts = first.entry_type != ENTRY_TYPE_CUT;
+
+        for entry in entries {
+            let hash = entry.hash.clone();
+            let nexts = entry.next.clone();
+            let payload_size = entry.payload_size as u64;
+            let head = entry.head;
+
+            self.entries.insert(hash.clone(), entry);
+            self.payload_size_total += payload_size;
+            if head {
+                self.heads.insert(hash.clone());
+            } else {
+                self.heads.shift_remove(&hash);
+            }
+
+            for next in nexts {
+                self.children.entry(next).or_default().insert(hash.clone());
+            }
+        }
+
+        if demotes_initial_nexts {
+            for next in initial_next {
+                self.set_head(next, false);
+            }
+        }
+    }
+
     pub fn delete(&mut self, hash: &str) -> Option<LogIndexEntry> {
         let entry = self.entries.shift_remove(hash)?;
-        self.query.delete(hash);
+        self.heads.shift_remove(hash);
         self.payload_size_total = self
             .payload_size_total
             .saturating_sub(entry.payload_size as u64);
@@ -192,19 +218,21 @@ impl LogGraphIndex {
     }
 
     pub fn heads(&self, gid: Option<&str>) -> Vec<String> {
-        let query = match gid {
-            Some(gid) => Query::And(vec![head_query(), gid_query(gid)]),
-            None => head_query(),
-        };
-        self.query.search(&query, &head_sort(), None)
+        self.head_entries(gid)
+            .into_iter()
+            .map(|entry| entry.hash)
+            .collect()
     }
 
     pub fn has_head(&self, gid: Option<&str>) -> bool {
-        let query = match gid {
-            Some(gid) => Query::And(vec![head_query(), gid_query(gid)]),
-            None => head_query(),
-        };
-        self.query.count(&query) > 0
+        match gid {
+            Some(gid) => self
+                .heads
+                .iter()
+                .filter_map(|hash| self.entries.get(hash))
+                .any(|entry| entry.gid == gid),
+            None => !self.heads.is_empty(),
+        }
     }
 
     pub fn has_any_head(&self, gids: &[String]) -> bool {
@@ -219,10 +247,21 @@ impl LogGraphIndex {
     }
 
     pub fn head_entries(&self, gid: Option<&str>) -> Vec<LogIndexEntry> {
-        self.heads(gid)
-            .into_iter()
-            .filter_map(|hash| self.entries.get(&hash).cloned())
-            .collect()
+        let mut entries: Vec<_> = self
+            .heads
+            .iter()
+            .filter_map(|hash| self.entries.get(hash))
+            .filter(|entry| match gid {
+                Some(gid) => entry.gid == gid,
+                None => true,
+            })
+            .cloned()
+            .collect();
+        entries.sort_by(|left, right| {
+            compare_clock(left.wall_time, left.logical, right)
+                .then_with(|| left.hash.cmp(&right.hash))
+        });
+        entries
     }
 
     pub fn head_data_entries(&self, gid: Option<&str>) -> Vec<LogIndexEntry> {
@@ -416,64 +455,12 @@ impl LogGraphIndex {
             return;
         }
         entry.head = head;
-        self.reindex(hash);
+        if head {
+            self.heads.insert(hash.to_string());
+        } else {
+            self.heads.shift_remove(hash);
+        }
     }
-
-    fn reindex(&mut self, hash: &str) {
-        let Some(entry) = self.entries.get(hash) else {
-            return;
-        };
-        self.query.put(hash.to_string(), fields_for_entry(entry));
-    }
-}
-
-fn fields_for_entry(entry: &LogIndexEntry) -> DocumentFields {
-    let mut fields = DocumentFields::with_scalar_capacity(8 + entry.next.len());
-    fields.insert_scalar(FIELD_HASH, FieldValue::String(entry.hash.clone()));
-    fields.insert_scalar(FIELD_GID, FieldValue::String(entry.gid.clone()));
-    fields.insert_scalar(FIELD_HEAD, FieldValue::Bool(entry.head));
-    fields.insert_scalar(FIELD_TYPE, FieldValue::U64(entry.entry_type as u64));
-    fields.insert_scalar(FIELD_WALL_TIME, FieldValue::U64(entry.wall_time));
-    fields.insert_scalar(FIELD_LOGICAL, FieldValue::U64(entry.logical as u64));
-    fields.insert_scalar(
-        FIELD_PAYLOAD_SIZE,
-        FieldValue::U64(entry.payload_size as u64),
-    );
-    for next in &entry.next {
-        fields.insert_scalar(FIELD_NEXT, FieldValue::String(next.clone()));
-    }
-    fields
-}
-
-fn head_query() -> Query {
-    Query::Exact {
-        field: FIELD_HEAD.into(),
-        value: FieldValue::Bool(true),
-    }
-}
-
-fn gid_query(gid: &str) -> Query {
-    Query::Exact {
-        field: FIELD_GID.into(),
-        value: FieldValue::String(gid.to_string()),
-    }
-}
-
-fn head_sort() -> [SortField; 3] {
-    [
-        SortField {
-            field: FIELD_WALL_TIME.into(),
-            direction: SortDirection::Asc,
-        },
-        SortField {
-            field: FIELD_LOGICAL.into(),
-            direction: SortDirection::Asc,
-        },
-        SortField {
-            field: FIELD_HASH.into(),
-            direction: SortDirection::Asc,
-        },
-    ]
 }
 
 fn compare_clock(wall_time: u64, logical: u32, other: &LogIndexEntry) -> std::cmp::Ordering {
@@ -617,7 +604,8 @@ impl NativeLogIndex {
             }
         }
 
-        let mut next = strings_from_array(initial_next)?;
+        let initial_nexts = strings_from_array(initial_next)?;
+        let mut next = initial_nexts.clone();
         let mut entries = Vec::with_capacity(len as usize);
         for i in 0..len {
             let hash = required_string_from_array(&hashes, i)?;
@@ -634,8 +622,37 @@ impl NativeLogIndex {
             ));
             next = vec![hash];
         }
-        self.inner.put_many(entries);
+        self.inner.put_append_chain(entries, &initial_nexts);
         Ok(())
+    }
+
+    pub fn prepare_entry_v0_plain_chain_and_put(
+        &mut self,
+        clock_id: Uint8Array,
+        private_key: Uint8Array,
+        public_key: Uint8Array,
+        wall_times: BigUint64Array,
+        logicals: Uint32Array,
+        gid: String,
+        initial_next: Array,
+        entry_type: u8,
+        meta_datas: Array,
+        payload_datas: Array,
+    ) -> Result<Array, JsValue> {
+        let (rows, entries, initial_nexts) = prepare_entry_v0_plain_chain_rows(
+            clock_id,
+            private_key,
+            public_key,
+            wall_times,
+            logicals,
+            gid,
+            initial_next,
+            entry_type,
+            meta_datas,
+            payload_datas,
+        )?;
+        self.inner.put_append_chain(entries, &initial_nexts);
+        Ok(rows)
     }
 
     pub fn delete(&mut self, hash: &str) -> bool {
@@ -955,8 +972,7 @@ pub fn encode_entry_v0_storage_batch_with_cids(
     Ok(out)
 }
 
-#[wasm_bindgen]
-pub fn prepare_entry_v0_plain_chain(
+fn prepare_entry_v0_plain_chain_rows(
     clock_id: Uint8Array,
     private_key: Uint8Array,
     public_key: Uint8Array,
@@ -967,7 +983,7 @@ pub fn prepare_entry_v0_plain_chain(
     entry_type: u8,
     meta_datas: Array,
     payload_datas: Array,
-) -> Result<Array, JsValue> {
+) -> Result<(Array, Vec<LogIndexEntry>, Vec<String>), JsValue> {
     let len = payload_datas.length();
     if meta_datas.length() != len || wall_times.length() != len || logicals.length() != len {
         return Err(JsValue::from_str("Expected equal column lengths"));
@@ -978,9 +994,12 @@ pub fn prepare_entry_v0_plain_chain(
     let public_key = public_key.to_vec();
     let signing_key = validate_ed25519_keypair(&private_key, &public_key)?;
 
-    let mut next = strings_from_array(initial_next)?;
+    let initial_nexts = strings_from_array(initial_next)?;
+    let mut next = initial_nexts.clone();
     let out = Array::new();
+    let mut entries = Vec::with_capacity(len as usize);
     for i in 0..len {
+        let payload_data = required_bytes_from_array(&payload_datas, i, "payload")?;
         let input = EntryV0EncodeInput {
             clock_id: clock_id.clone(),
             wall_time: wall_times.get_index(i),
@@ -989,7 +1008,7 @@ pub fn prepare_entry_v0_plain_chain(
             next: next.clone(),
             entry_type,
             meta_data: optional_bytes_from_js(meta_datas.get(i)),
-            payload_data: required_bytes_from_array(&payload_datas, i, "payload")?,
+            payload_data,
         };
         let meta = encode_meta(&input);
         let payload = encode_payload(&input.payload_data);
@@ -1008,15 +1027,54 @@ pub fn prepare_entry_v0_plain_chain(
         row.push(&Uint8Array::from(storage.as_slice()));
         row.push(&JsValue::from_str(&cid));
         row.push(&Uint8Array::from(signature.as_slice()));
-        row.push(&strings_to_array(next));
+        row.push(&strings_to_array(next.clone()));
         row.push(&Uint8Array::from(meta.as_slice()));
         row.push(&Uint8Array::from(payload.as_slice()));
         row.push(&Uint8Array::from(signature_with_key.as_slice()));
         out.push(&row);
+        entries.push(LogIndexEntry::new_with_data(
+            cid.clone(),
+            gid.clone(),
+            next.clone(),
+            entry_type,
+            input.wall_time,
+            input.logical,
+            input.payload_data.len() as u32,
+            i + 1 == len,
+            input.meta_data.clone(),
+        ));
 
         next = vec![cid];
     }
-    Ok(out)
+    Ok((out, entries, initial_nexts))
+}
+
+#[wasm_bindgen]
+pub fn prepare_entry_v0_plain_chain(
+    clock_id: Uint8Array,
+    private_key: Uint8Array,
+    public_key: Uint8Array,
+    wall_times: BigUint64Array,
+    logicals: Uint32Array,
+    gid: String,
+    initial_next: Array,
+    entry_type: u8,
+    meta_datas: Array,
+    payload_datas: Array,
+) -> Result<Array, JsValue> {
+    Ok(prepare_entry_v0_plain_chain_rows(
+        clock_id,
+        private_key,
+        public_key,
+        wall_times,
+        logicals,
+        gid,
+        initial_next,
+        entry_type,
+        meta_datas,
+        payload_datas,
+    )?
+    .0)
 }
 
 #[wasm_bindgen]
@@ -1453,6 +1511,25 @@ mod tests {
         assert!(index.delete("c").is_some());
         assert_eq!(index.heads(None), vec!["a"]);
         assert_eq!(index.count_has_next("a", None), 0);
+    }
+
+    #[test]
+    fn puts_append_chain_without_promoting_internal_heads() {
+        let mut index = LogGraphIndex::new();
+        index.put(entry("root", "g", &[], 1));
+        index.put_append_chain(
+            vec![
+                LogIndexEntry::new("a", "g", vec!["root".to_string()], APPEND, 2, 0, 1, false),
+                LogIndexEntry::new("b", "g", vec!["a".to_string()], APPEND, 3, 0, 1, false),
+                LogIndexEntry::new("c", "g", vec!["b".to_string()], APPEND, 4, 0, 1, true),
+            ],
+            &["root".to_string()],
+        );
+
+        assert_eq!(index.heads(None), vec!["c"]);
+        assert_eq!(index.children("root"), vec!["a"]);
+        assert_eq!(index.children("a"), vec!["b"]);
+        assert_eq!(index.children("b"), vec!["c"]);
     }
 
     #[test]

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -56,11 +56,34 @@ type NativeJoinCutCheck = {
 };
 
 export type NativeLogGraph = {
+	readonly length: number;
 	has: (hash: string) => boolean;
 	hasMany: (hashes: Iterable<string>) => Set<string>;
 	put: (entry: NativeLogEntry) => void;
 	putBatch?: (entries: NativeLogEntry[]) => void;
 	putAppendChain?: (entries: NativeLogEntry[]) => void;
+	prepareEntryV0PlainChainAndPut?: (input: {
+		clockId: Uint8Array;
+		privateKey: Uint8Array;
+		publicKey: Uint8Array;
+		wallTimes: Array<bigint | number | string>;
+		logicals?: number[];
+		gid: string;
+		initialNext?: string[];
+		type?: number;
+		metaDatas?: Array<Uint8Array | undefined>;
+		payloadDatas: Uint8Array[];
+	}) => Promise<
+		Array<{
+			bytes: Uint8Array;
+			cid: string;
+			signature: Uint8Array;
+			next: string[];
+			metaBytes: Uint8Array;
+			payloadBytes: Uint8Array;
+			signatureBytes: Uint8Array;
+		}>
+	>;
 	delete: (hash: string) => boolean;
 	clear: () => void;
 	heads: (gid?: string) => string[];
@@ -919,6 +942,7 @@ export class EntryIndex<T> {
 			prepared?: {
 				shallowEntries: ShallowEntry[];
 				nativeEntries?: NativeLogEntry[];
+				nativeGraphUpdated?: boolean;
 			};
 			deferIndexWrite?: boolean;
 		},
@@ -956,7 +980,9 @@ export class EntryIndex<T> {
 			const putBatch =
 				!this.properties.onGidRemoved && this.properties.index.putBatch;
 			const shallowEntries: ShallowEntry[] = [];
+			const nativeGraphUpdated = properties.prepared?.nativeGraphUpdated === true;
 			const nativeGraphPutAppendChain =
+				!nativeGraphUpdated &&
 				!this.properties.onGidRemoved &&
 				properties.externalNextHashes &&
 				this.properties.nativeGraph?.graph.putAppendChain
@@ -965,6 +991,7 @@ export class EntryIndex<T> {
 						)
 					: undefined;
 			const nativeGraphPutBatch =
+				!nativeGraphUpdated &&
 				!this.properties.onGidRemoved && this.properties.nativeGraph?.graph.putBatch
 					? this.properties.nativeGraph.graph.putBatch.bind(
 							this.properties.nativeGraph.graph,
@@ -992,6 +1019,7 @@ export class EntryIndex<T> {
 					preparedNativeEntry.head = isHead;
 				}
 				const nativeEntry =
+					!nativeGraphUpdated &&
 					this.properties.nativeGraph &&
 					(preparedNativeEntry ??
 						Entry.takePreparedNativeLogEntry(entry, isHead) ??

--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -38,6 +38,35 @@ import { equals } from "./utils.js";
 const log = baseLogger.newScope("entry-v0");
 const traceLogger = log.trace as typeof log & { enabled?: boolean };
 
+type NativePlainChainInput = {
+	clockId: Uint8Array;
+	privateKey: Uint8Array;
+	publicKey: Uint8Array;
+	wallTimes: Array<bigint | number | string>;
+	logicals?: number[];
+	gid: string;
+	initialNext?: string[];
+	type?: number;
+	metaDatas?: Array<Uint8Array | undefined>;
+	payloadDatas: Uint8Array[];
+};
+
+type NativePreparedPlainEntry = {
+	bytes: Uint8Array;
+	cid: string;
+	signature: Uint8Array;
+	next: string[];
+	metaBytes: Uint8Array;
+	payloadBytes: Uint8Array;
+	signatureBytes: Uint8Array;
+};
+
+type NativeEntryV0Graph = {
+	prepareEntryV0PlainChainAndPut?(
+		input: NativePlainChainInput,
+	): Promise<NativePreparedPlainEntry[]>;
+};
+
 type NativeEntryV0Encoder = {
 	encodeEntryV0Signable(input: {
 		clockId: Uint8Array;
@@ -75,28 +104,9 @@ type NativeEntryV0Encoder = {
 		signaturePublicKey: Uint8Array;
 		prehash?: number;
 	}): Promise<{ bytes: Uint8Array; cid: string }>;
-	prepareEntryV0PlainChain?(input: {
-		clockId: Uint8Array;
-		privateKey: Uint8Array;
-		publicKey: Uint8Array;
-		wallTimes: Array<bigint | number | string>;
-		logicals?: number[];
-		gid: string;
-		initialNext?: string[];
-		type?: number;
-		metaDatas?: Array<Uint8Array | undefined>;
-		payloadDatas: Uint8Array[];
-	}): Promise<
-		Array<{
-			bytes: Uint8Array;
-			cid: string;
-			signature: Uint8Array;
-			next: string[];
-			metaBytes: Uint8Array;
-			payloadBytes: Uint8Array;
-			signatureBytes: Uint8Array;
-		}>
-	>;
+	prepareEntryV0PlainChain?(
+		input: NativePlainChainInput,
+	): Promise<NativePreparedPlainEntry[]>;
 	calculateRawCidV1(bytes: Uint8Array): Promise<string>;
 };
 
@@ -512,6 +522,7 @@ export class EntryV0<T>
 		identity: Identity;
 		deferStore: boolean;
 		cachePreparedEntries?: boolean;
+		nativeGraph?: NativeEntryV0Graph;
 	}): Promise<Entry<T>[] | undefined> {
 		return (await EntryV0.createPlainAppendChainBatch(properties))?.entries;
 	}
@@ -530,6 +541,7 @@ export class EntryV0<T>
 		identity: Identity;
 		deferStore: boolean;
 		cachePreparedEntries?: boolean;
+		nativeGraph?: NativeEntryV0Graph;
 	}): Promise<PreparedAppendChain<T> | undefined> {
 		if (!properties.deferStore) {
 			return undefined;
@@ -604,7 +616,9 @@ export class EntryV0<T>
 					encoding: properties.encoding,
 				}),
 		);
-		const prepared = await nativeEncoder.prepareEntryV0PlainChain({
+		const nativePrepareAndPut =
+			properties.nativeGraph?.prepareEntryV0PlainChainAndPut;
+		const nativePlainChainInput: NativePlainChainInput = {
 			clockId: properties.identity.publicKey.bytes,
 			privateKey: properties.identity.privateKey.privateKey,
 			publicKey: properties.identity.publicKey.publicKey,
@@ -615,12 +629,17 @@ export class EntryV0<T>
 			type: entryType,
 			metaDatas: payloads.map(() => properties.meta?.data),
 			payloadDatas: payloads.map((payload) => payload.data),
-		});
+		};
+		const prepared = await (nativePrepareAndPut
+			? nativePrepareAndPut.call(properties.nativeGraph, nativePlainChainInput)
+			: nativeEncoder.prepareEntryV0PlainChain(nativePlainChainInput));
+		const nativeGraphUpdated = !!nativePrepareAndPut;
 
 		const entries: PreparedAppendChain<T>["entries"] = [];
 		const blocks: PreparedAppendChain<T>["blocks"] = [];
 		const shallowEntries: PreparedAppendChain<T>["shallowEntries"] = [];
-		const nativeEntries: PreparedAppendChain<T>["nativeEntries"] = [];
+		const nativeEntries: NonNullable<PreparedAppendChain<T>["nativeEntries"]> =
+			[];
 
 		for (let index = 0; index < prepared.length; index++) {
 			const preparedEntry = prepared[index]!;
@@ -682,32 +701,45 @@ export class EntryV0<T>
 					type: meta.type,
 				}),
 			});
-			const nativeEntry = {
-				hash: entry.hash,
-				gid: meta.gid,
-				next: meta.next,
-				type: meta.type,
-				head: index === prepared.length - 1,
-				payloadSize: payload.byteLength,
-				data: meta.data,
-				clock: {
-					timestamp: {
-						wallTime: meta.clock.timestamp.wallTime,
-						logical: meta.clock.timestamp.logical,
-					},
-				},
-			};
+			const nativeEntry =
+				nativeGraphUpdated && properties.cachePreparedEntries === false
+					? undefined
+					: {
+							hash: entry.hash,
+							gid: meta.gid,
+							next: meta.next,
+							type: meta.type,
+							head: index === prepared.length - 1,
+							payloadSize: payload.byteLength,
+							data: meta.data,
+							clock: {
+								timestamp: {
+									wallTime: meta.clock.timestamp.wallTime,
+									logical: meta.clock.timestamp.logical,
+								},
+							},
+						};
 			if (properties.cachePreparedEntries !== false) {
 				Entry.prepareShallowEntry(entry, shallowEntry);
-				Entry.prepareNativeLogEntry(entry, nativeEntry);
+				Entry.prepareNativeLogEntry(entry, nativeEntry!);
 			}
-			entry.init({ encoding: properties.encoding });
+			if (properties.cachePreparedEntries !== false) {
+				entry.init({ encoding: properties.encoding });
+			}
 			entries.push(entry);
 			blocks.push(preparedBlock);
 			shallowEntries.push(shallowEntry);
-			nativeEntries.push(nativeEntry);
+			if (nativeEntry) {
+				nativeEntries.push(nativeEntry);
+			}
 		}
-		return { entries, blocks, shallowEntries, nativeEntries };
+		return {
+			entries,
+			blocks,
+			shallowEntries,
+			nativeEntries,
+			nativeGraphUpdated,
+		};
 	}
 
 	static async create<T>(properties: {

--- a/packages/log/src/entry.ts
+++ b/packages/log/src/entry.ts
@@ -35,7 +35,8 @@ export type PreparedAppendChain<T> = {
 	entries: Entry<T>[];
 	blocks: PreparedEntryBlock[];
 	shallowEntries: ShallowEntry[];
-	nativeEntries: PreparedNativeLogEntry[];
+	nativeEntries?: PreparedNativeLogEntry[];
+	nativeGraphUpdated?: boolean;
 };
 
 const preparedEntryBlocks = new WeakMap<object, PreparedEntryBlock>();

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -623,35 +623,12 @@ export class Log<T> {
 			| { entry: Entry<T>; fn: undefined }
 		)[] = [];
 		const deferBlockStore = hasPutMany(this._storage);
-
-		const nativeAppendChain =
-			deferBlockStore &&
-			!options.encryption &&
-			!options.signers &&
-			!(options.canAppend || this._hasCustomCanAppend) &&
-			!options.meta?.timestamp
-				? await EntryV0.createPlainAppendChainBatch<T>({
-						data,
-						meta: {
-							clocks: () =>
-								data.map(
-									() =>
-										new Clock({
-											id: this._identity.publicKey.bytes,
-											timestamp: this._hlc.now(),
-										}),
-								),
-							type: options.meta?.type,
-							gidSeed: options.meta?.gidSeed,
-							data: options.meta?.data,
-							next: nexts,
-						},
-						encoding: this._encoding,
-						identity: options.identity || this._identity,
-						deferStore: deferBlockStore,
-						cachePreparedEntries: false,
-					})
-				: undefined;
+		const nativeAppendChain = await this.createNativePlainAppendChain(
+			data,
+			options,
+			nexts,
+			deferBlockStore,
+		);
 
 		if (nativeAppendChain) {
 			entries.push(...nativeAppendChain.entries);
@@ -666,16 +643,23 @@ export class Log<T> {
 			}
 		}
 
-		await this.joinMissingNexts(entries[0]!, initialNexts);
-		if (deferBlockStore) {
-			await this.putAppendEntryBlocks(entries, nativeAppendChain?.blocks);
+		try {
+			await this.joinMissingNexts(entries[0]!, initialNexts);
+			if (deferBlockStore) {
+				await this.putAppendEntryBlocks(entries, nativeAppendChain?.blocks);
+			}
+			await this.putAppendEntries(
+				entries,
+				options,
+				initialNexts.map((entry) => entry.hash),
+				nativeAppendChain,
+			);
+		} catch (error) {
+			if (nativeAppendChain?.nativeGraphUpdated) {
+				this.rollbackNativeAppendGraph(entries);
+			}
+			throw error;
 		}
-		await this.putAppendEntries(
-			entries,
-			options,
-			initialNexts.map((entry) => entry.hash),
-			nativeAppendChain,
-		);
 
 		for (const entry of entries) {
 			entry.init({ encoding: this._encoding, keychain: this._keychain });
@@ -700,6 +684,64 @@ export class Log<T> {
 		await (options?.onChange || this._onChange)?.(changes);
 		await Promise.all(pendingDeletes.map((x) => x.fn?.()));
 		return { entries, removed };
+	}
+
+	private createNativePlainAppendChain(
+		data: T[],
+		options: AppendOptions<T>,
+		nexts: Sorting.SortableEntry[],
+		deferBlockStore: boolean,
+	): Promise<PreparedAppendChain<T> | undefined> {
+		if (
+			!deferBlockStore ||
+			options.encryption ||
+			options.signers ||
+			options.canAppend ||
+			this._hasCustomCanAppend ||
+			options.meta?.timestamp ||
+			options.meta?.type === EntryType.CUT ||
+			data.length < 2
+		) {
+			return Promise.resolve(undefined);
+		}
+
+		const nativeGraph =
+			!this.entryIndex.properties.onGidRemoved &&
+			this.entryIndex.properties.nativeGraph?.graph.prepareEntryV0PlainChainAndPut
+				? this.entryIndex.properties.nativeGraph.graph
+				: undefined;
+		return EntryV0.createPlainAppendChainBatch<T>({
+			data,
+			meta: {
+				clocks: () =>
+					data.map(
+						() =>
+							new Clock({
+								id: this._identity.publicKey.bytes,
+								timestamp: this._hlc.now(),
+							}),
+					),
+				type: options.meta?.type,
+				gidSeed: options.meta?.gidSeed,
+				data: options.meta?.data,
+				next: nexts,
+			},
+			encoding: this._encoding,
+			identity: options.identity || this._identity,
+			deferStore: deferBlockStore,
+			cachePreparedEntries: false,
+			nativeGraph,
+		});
+	}
+
+	private rollbackNativeAppendGraph(entries: Entry<T>[]) {
+		const graph = this.entryIndex.properties.nativeGraph?.graph;
+		if (!graph) {
+			return;
+		}
+		for (let i = entries.length - 1; i >= 0; i--) {
+			graph.delete(entries[i]!.hash);
+		}
 	}
 
 	private validateExplicitNexts(options: AppendOptions<T>) {
@@ -829,6 +871,7 @@ export class Log<T> {
 					? {
 							shallowEntries: preparedAppendChain.shallowEntries,
 							nativeEntries: preparedAppendChain.nativeEntries,
+							nativeGraphUpdated: preparedAppendChain.nativeGraphUpdated,
 						}
 					: undefined,
 			deferIndexWrite:

--- a/packages/log/test/append.spec.ts
+++ b/packages/log/test/append.spec.ts
@@ -171,6 +171,10 @@ describe("append", function () {
 			log.entryIndex.properties.nativeGraph!.graph,
 			"putAppendChain",
 		);
+		const nativePrepareAndPutSpy = sinon.spy(
+			log.entryIndex.properties.nativeGraph!.graph,
+			"prepareEntryV0PlainChainAndPut",
+		);
 		const preparedBlockSpy = sinon.spy(Entry, "takePreparedBlock");
 		const preparedShallowSpy = sinon.spy(Entry, "takePreparedShallowEntry");
 		const preparedNativeSpy = sinon.spy(Entry, "takePreparedNativeLogEntry");
@@ -212,10 +216,11 @@ describe("append", function () {
 				result.entries.length,
 			);
 			expect(shallowSpy.callCount).equal(0);
-			expect(nativeAppendChainSpy.callCount).equal(1);
-			expect(nativeAppendChainSpy.firstCall.args[0]).to.have.length(
+			expect(nativePrepareAndPutSpy.callCount).equal(1);
+			expect(nativePrepareAndPutSpy.firstCall.args[0].payloadDatas).to.have.length(
 				result.entries.length,
 			);
+			expect(nativeAppendChainSpy.callCount).equal(0);
 			expect(preparedBlockSpy.callCount).equal(0);
 			expect(preparedShallowSpy.callCount).equal(0);
 			expect(preparedNativeSpy.callCount).equal(0);
@@ -227,9 +232,40 @@ describe("append", function () {
 			blockPutManySpy.restore();
 			shallowSpy.restore();
 			nativeAppendChainSpy.restore();
+			nativePrepareAndPutSpy.restore();
 			preparedBlockSpy.restore();
 			preparedShallowSpy.restore();
 			preparedNativeSpy.restore();
+			await log.close();
+		}
+	});
+
+	it("rolls back native graph when prepared appendMany block write fails", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			appendDurability: "strict",
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+		});
+		const root = (
+			await log.append(new Uint8Array([0]), { meta: { next: [] } })
+		).entry;
+		const graph = log.entryIndex.properties.nativeGraph!.graph;
+		const blockPutManyStub = sinon
+			.stub(store, "putMany")
+			.rejects(new Error("boom"));
+
+		try {
+			await expect(
+				log.appendMany([new Uint8Array([1]), new Uint8Array([2])]),
+			).rejectedWith("boom");
+			expect(blockPutManyStub.callCount).equal(1);
+			expect((await log.getHeads().all()).map((head) => head.hash)).to.deep.equal(
+				[root.hash],
+			);
+			expect(graph.length).equal(1);
+		} finally {
+			blockPutManyStub.restore();
 			await log.close();
 		}
 	});


### PR DESCRIPTION
## Summary
- replace the log-rust head query index with a dedicated native head set, removing the log-rust dependency on the generic Rust indexer planner
- add a combined native appendMany path that prepares EntryV0 bytes/signatures/CIDs and mutates the native graph in one WASM call
- skip redundant JS-side native graph row construction when the native graph was already updated, and roll it back if the deferred block batch write fails

## Validation
- cargo test --manifest-path packages/log/rust/Cargo.toml
- pnpm --filter @peerbit/log-rust run build
- pnpm --filter @peerbit/log run build
- pnpm exec eslint --config eslint.config.js packages/log/src/log.ts packages/log/src/entry-index.ts packages/log/src/entry-v0.ts packages/log/src/entry.ts packages/log/rust/src/index.ts packages/log/test/append.spec.ts
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "appendMany appends a local chain|rolls back native graph"
- git diff --check

## Local benchmark signal
- packages/log/benchmark/native-graph.ts, 1k entries / 1k iterations
- appendMany auto-next: nativeGraph=false 18.3k ops/sec, nativeGraph=true 21.4k ops/sec
- append loop auto-next: nativeGraph=false 3.7k ops/sec, nativeGraph=true 14.5k ops/sec
- getHeads().all(): nativeGraph=false 302 ops/sec, nativeGraph=true 2.0k ops/sec
- hasHead(): nativeGraph=false 313 ops/sec, nativeGraph=true 1.76M ops/sec

Stacked on #855 / feat/simple-index-put-batch.