### PR TITLE
Add native append block commit path

### DIFF
--- a/packages/log/benchmark/native-graph.ts
+++ b/packages/log/benchmark/native-graph.ts
@@ -1,6 +1,7 @@
 import { AnyBlockStore } from "@peerbit/blocks";
 import { Ed25519Keypair } from "@peerbit/crypto";
 import { HashmapIndices } from "@peerbit/indexer-simple";
+import { createNativeLogBlockStore } from "@peerbit/log-rust";
 import { EntryType } from "../src/entry-type.js";
 import { type Entry } from "../src/entry.js";
 import { Log } from "../src/log.js";
@@ -26,6 +27,9 @@ const joinParents = Number(
 );
 
 const key = await Ed25519Keypair.create();
+type AppendStore =
+	| AnyBlockStore
+	| Awaited<ReturnType<typeof createNativeLogBlockStore>>;
 
 const absoluteReplicaData = (value: number) =>
 	new Uint8Array([
@@ -192,8 +196,9 @@ const measureAppend = async (
 	name: string,
 	nativeGraph: boolean,
 	fn: (log: Log<Uint8Array>) => Promise<void>,
+	createStore: () => Promise<AppendStore> = async () => new AnyBlockStore(),
 ): Promise<BenchRow> => {
-	const store = new AnyBlockStore();
+	const store = await createStore();
 	await store.start();
 	const log = new Log<Uint8Array>();
 	await log.open(store, key, {
@@ -239,6 +244,22 @@ for (const nativeGraph of [false, true]) {
 		}),
 	);
 }
+
+rows.push(
+	await measureAppend(
+		"appendMany native block commit",
+		true,
+		async (log) => {
+			await log.appendMany(
+				Array.from(
+					{ length: appendEntries },
+					(_, index) => new Uint8Array([index & 0xff]),
+				),
+			);
+		},
+		createNativeLogBlockStore,
+	),
+);
 
 const measureWideJoin = async (nativeGraph: boolean): Promise<BenchRow> => {
 	const store = new AnyBlockStore();

--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -104,6 +104,19 @@ type NativeLogIndexHandle = {
 		metaDatas: Array<Uint8Array | undefined>,
 		payloadDatas: Uint8Array[],
 	) => EntryV0PreparedPlainEntryRow[];
+	prepare_entry_v0_plain_chain_commit_blocks_and_put: (
+		blockStore: NativeLogBlockStoreHandle,
+		clockId: Uint8Array,
+		privateKey: Uint8Array,
+		publicKey: Uint8Array,
+		wallTimes: BigUint64Array,
+		logicals: Uint32Array,
+		gid: string,
+		initialNext: string[],
+		type: number,
+		metaDatas: Array<Uint8Array | undefined>,
+		payloadDatas: Uint8Array[],
+	) => EntryV0PreparedPlainEntryRow[];
 	delete: (hash: string) => boolean;
 	heads: (gid?: string) => string[];
 	has_head: (gid?: string) => boolean;
@@ -134,10 +147,25 @@ type NativeLogIndexHandle = {
 	) => [boolean, string[], boolean, boolean];
 };
 
+type NativeLogBlockStoreHandle = {
+	get: (key: string) => Uint8Array | undefined;
+	get_many: (keys: string[]) => Array<Uint8Array | undefined>;
+	has: (key: string) => boolean;
+	put: (key: string, value: Uint8Array) => void;
+	put_many: (keys: string[], values: Uint8Array[]) => void;
+	delete: (key: string) => boolean;
+	delete_many: (keys: string[]) => number;
+	clear: () => void;
+	len: () => number;
+	size: () => number;
+	entries: () => Array<[string, Uint8Array]>;
+};
+
 type WasmModule = {
 	default: (input?: unknown) => Promise<unknown>;
 	initSync: (input?: unknown) => unknown;
 	NativeLogIndex: new () => NativeLogIndexHandle;
+	NativeLogBlockStore: new () => NativeLogBlockStoreHandle;
 	sign_ed25519: (
 		privateKey: Uint8Array,
 		publicKey: Uint8Array,
@@ -250,6 +278,25 @@ const loadWasm = async (): Promise<WasmModule> => {
 
 	return wasm;
 };
+
+const copyBytes = (bytes: Uint8Array): Uint8Array =>
+	new Uint8Array(
+		bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength
+			? bytes
+			: bytes.slice(),
+	);
+
+type BlockInput = Uint8Array | { block: { bytes: Uint8Array }; cid: string };
+
+type NativeLogBlockStoreCarrier = {
+	getNativeLogBlockStoreHandle?: () => NativeLogBlockStoreHandle;
+};
+
+const nativeLogBlockStoreHandle = (
+	store: unknown,
+): NativeLogBlockStoreHandle | undefined =>
+	(store as NativeLogBlockStoreCarrier | undefined)
+		?.getNativeLogBlockStoreHandle?.();
 
 export class LogGraphIndex {
 	private constructor(private readonly native: NativeLogIndexHandle) {}
@@ -371,6 +418,37 @@ export class LogGraphIndex {
 		return Promise.resolve(
 			preparedPlainEntryRows(
 				this.native.prepare_entry_v0_plain_chain_and_put(
+					input.clockId,
+					input.privateKey,
+					input.publicKey,
+					columns.wallTimes,
+					columns.logicals,
+					input.gid,
+					input.initialNext ?? [],
+					input.type ?? 0,
+					columns.metaDatas,
+					input.payloadDatas,
+				),
+			),
+		);
+	}
+
+	prepareEntryV0PlainChainCommit(
+		input: EntryV0PlainChainInput,
+		blockStore: unknown,
+	): Promise<EntryV0PreparedPlainEntry[] | undefined> {
+		const nativeBlockStore = nativeLogBlockStoreHandle(blockStore);
+		if (!nativeBlockStore) {
+			return Promise.resolve(undefined);
+		}
+		const columns = plainChainInputColumns(input);
+		if (!columns) {
+			return Promise.resolve([]);
+		}
+		return Promise.resolve(
+			preparedPlainEntryRows(
+				this.native.prepare_entry_v0_plain_chain_commit_blocks_and_put(
+					nativeBlockStore,
 					input.clockId,
 					input.privateKey,
 					input.publicKey,
@@ -541,6 +619,104 @@ export class LogGraphIndex {
 		return { skip, missingParents, cutChecked, coveredByCut };
 	}
 }
+
+export class NativeLogBlockStore {
+	private statusValue: "open" | "opening" | "closed" | "closing" = "closed";
+
+	private constructor(private readonly native: NativeLogBlockStoreHandle) {}
+
+	static async create(): Promise<NativeLogBlockStore> {
+		const wasm = await loadWasm();
+		return new NativeLogBlockStore(new wasm.NativeLogBlockStore());
+	}
+
+	getNativeLogBlockStoreHandle(): NativeLogBlockStoreHandle {
+		return this.native;
+	}
+
+	async start(): Promise<void> {
+		this.statusValue = "open";
+	}
+
+	async stop(): Promise<void> {
+		this.statusValue = "closed";
+	}
+
+	status(): "open" | "opening" | "closed" | "closing" {
+		return this.statusValue;
+	}
+
+	async put(block: BlockInput): Promise<string> {
+		const cid =
+			block instanceof Uint8Array ? await calculateRawCidV1(block) : block.cid;
+		const bytes = block instanceof Uint8Array ? block : block.block.bytes;
+		this.native.put(cid, copyBytes(bytes));
+		return cid;
+	}
+
+	async putMany(blocks: BlockInput[]): Promise<string[]> {
+		if (blocks.length === 0) {
+			return [];
+		}
+		const cids = new Array<string>(blocks.length);
+		const values = new Array<Uint8Array>(blocks.length);
+		await Promise.all(
+			blocks.map(async (block, index) => {
+				cids[index] =
+					block instanceof Uint8Array ? await calculateRawCidV1(block) : block.cid;
+				values[index] = copyBytes(
+					block instanceof Uint8Array ? block : block.block.bytes,
+				);
+			}),
+		);
+		this.native.put_many(cids, values);
+		return cids;
+	}
+
+	async get(cid: string): Promise<Uint8Array | undefined> {
+		const value = this.native.get(cid);
+		return value == null ? undefined : copyBytes(value);
+	}
+
+	async getMany(cids: string[]): Promise<Array<Uint8Array | undefined>> {
+		return this.native
+			.get_many(cids)
+			.map((value) => (value == null ? undefined : copyBytes(value)));
+	}
+
+	async has(cid: string): Promise<boolean> {
+		return this.native.has(cid);
+	}
+
+	async rm(cid: string): Promise<void> {
+		this.native.delete(cid);
+	}
+
+	async rmMany(cids: string[]): Promise<number> {
+		return this.native.delete_many(cids);
+	}
+
+	async *iterator(): AsyncGenerator<[string, Uint8Array], void, void> {
+		for (const [key, value] of this.native.entries()) {
+			yield [key, copyBytes(value)];
+		}
+	}
+
+	async size(): Promise<number> {
+		return this.native.size();
+	}
+
+	persisted(): boolean {
+		return false;
+	}
+
+	waitFor(): Promise<string[]> {
+		return Promise.resolve([]);
+	}
+}
+
+export const createNativeLogBlockStore =
+	async (): Promise<NativeLogBlockStore> => NativeLogBlockStore.create();
 
 export type EntryV0EncodeInput = {
 	clockId: Uint8Array;

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -475,6 +475,110 @@ pub struct NativeLogIndex {
 }
 
 #[wasm_bindgen]
+pub struct NativeLogBlockStore {
+    entries: IndexMap<String, Vec<u8>>,
+    total_size: u64,
+}
+
+#[wasm_bindgen]
+impl NativeLogBlockStore {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            entries: IndexMap::new(),
+            total_size: 0,
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Option<Vec<u8>> {
+        self.entries.get(key).cloned()
+    }
+
+    pub fn get_many(&self, keys: Array) -> Result<Array, JsValue> {
+        let values = Array::new();
+        for key in strings_from_array(keys)? {
+            match self.entries.get(&key) {
+                Some(value) => values.push(&Uint8Array::from(value.as_slice())),
+                None => values.push(&JsValue::UNDEFINED),
+            };
+        }
+        Ok(values)
+    }
+
+    pub fn has(&self, key: &str) -> bool {
+        self.entries.contains_key(key)
+    }
+
+    pub fn put(&mut self, key: String, value: Vec<u8>) {
+        self.put_entry(key, value);
+    }
+
+    pub fn put_many(&mut self, keys: Array, values: Array) -> Result<(), JsValue> {
+        self.put_entries(block_key_values_from_arrays(&keys, &values)?);
+        Ok(())
+    }
+
+    pub fn delete(&mut self, key: &str) -> bool {
+        if let Some((_key, previous)) = self.entries.shift_remove_entry(key) {
+            self.total_size = self.total_size.saturating_sub(previous.len() as u64);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn delete_many(&mut self, keys: Array) -> Result<usize, JsValue> {
+        let mut deleted = 0;
+        for key in strings_from_array(keys)? {
+            if self.delete(&key) {
+                deleted += 1;
+            }
+        }
+        Ok(deleted)
+    }
+
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.total_size = 0;
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn size(&self) -> f64 {
+        self.total_size as f64
+    }
+
+    pub fn entries(&self) -> Array {
+        let entries = Array::new();
+        for (key, value) in &self.entries {
+            let pair = Array::new();
+            pair.push(&JsValue::from_str(key));
+            pair.push(&Uint8Array::from(value.as_slice()));
+            entries.push(&pair);
+        }
+        entries
+    }
+}
+
+impl NativeLogBlockStore {
+    fn put_entry(&mut self, key: String, value: Vec<u8>) {
+        let value_len = value.len() as u64;
+        if let Some(previous) = self.entries.insert(key, value) {
+            self.total_size = self.total_size.saturating_sub(previous.len() as u64);
+        }
+        self.total_size += value_len;
+    }
+
+    fn put_entries(&mut self, entries: Vec<(String, Vec<u8>)>) {
+        for (key, value) in entries {
+            self.put_entry(key, value);
+        }
+    }
+}
+
+#[wasm_bindgen]
 impl NativeLogIndex {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
@@ -639,7 +743,7 @@ impl NativeLogIndex {
         meta_datas: Array,
         payload_datas: Array,
     ) -> Result<Array, JsValue> {
-        let (rows, entries, initial_nexts) = prepare_entry_v0_plain_chain_rows(
+        let (rows, entries, initial_nexts, _blocks) = prepare_entry_v0_plain_chain_rows(
             clock_id,
             private_key,
             public_key,
@@ -651,6 +755,37 @@ impl NativeLogIndex {
             meta_datas,
             payload_datas,
         )?;
+        self.inner.put_append_chain(entries, &initial_nexts);
+        Ok(rows)
+    }
+
+    pub fn prepare_entry_v0_plain_chain_commit_blocks_and_put(
+        &mut self,
+        block_store: &mut NativeLogBlockStore,
+        clock_id: Uint8Array,
+        private_key: Uint8Array,
+        public_key: Uint8Array,
+        wall_times: BigUint64Array,
+        logicals: Uint32Array,
+        gid: String,
+        initial_next: Array,
+        entry_type: u8,
+        meta_datas: Array,
+        payload_datas: Array,
+    ) -> Result<Array, JsValue> {
+        let (rows, entries, initial_nexts, blocks) = prepare_entry_v0_plain_chain_rows(
+            clock_id,
+            private_key,
+            public_key,
+            wall_times,
+            logicals,
+            gid,
+            initial_next,
+            entry_type,
+            meta_datas,
+            payload_datas,
+        )?;
+        block_store.put_entries(blocks);
         self.inner.put_append_chain(entries, &initial_nexts);
         Ok(rows)
     }
@@ -983,7 +1118,15 @@ fn prepare_entry_v0_plain_chain_rows(
     entry_type: u8,
     meta_datas: Array,
     payload_datas: Array,
-) -> Result<(Array, Vec<LogIndexEntry>, Vec<String>), JsValue> {
+) -> Result<
+    (
+        Array,
+        Vec<LogIndexEntry>,
+        Vec<String>,
+        Vec<(String, Vec<u8>)>,
+    ),
+    JsValue,
+> {
     let len = payload_datas.length();
     if meta_datas.length() != len || wall_times.length() != len || logicals.length() != len {
         return Err(JsValue::from_str("Expected equal column lengths"));
@@ -998,6 +1141,7 @@ fn prepare_entry_v0_plain_chain_rows(
     let mut next = initial_nexts.clone();
     let out = Array::new();
     let mut entries = Vec::with_capacity(len as usize);
+    let mut blocks = Vec::with_capacity(len as usize);
     for i in 0..len {
         let payload_data = required_bytes_from_array(&payload_datas, i, "payload")?;
         let input = EntryV0EncodeInput {
@@ -1043,10 +1187,11 @@ fn prepare_entry_v0_plain_chain_rows(
             i + 1 == len,
             input.meta_data.clone(),
         ));
+        blocks.push((cid.clone(), storage));
 
         next = vec![cid];
     }
-    Ok((out, entries, initial_nexts))
+    Ok((out, entries, initial_nexts, blocks))
 }
 
 #[wasm_bindgen]
@@ -1322,6 +1467,23 @@ fn string_arrays_from_array(values: Array) -> Result<Vec<Vec<String>>, JsValue> 
         out.push(strings_from_array(Array::from(&value))?);
     }
     Ok(out)
+}
+
+fn block_key_values_from_arrays(
+    keys: &Array,
+    values: &Array,
+) -> Result<Vec<(String, Vec<u8>)>, JsValue> {
+    if keys.length() != values.length() {
+        return Err(JsValue::from_str("Expected equal column lengths"));
+    }
+    let mut entries = Vec::with_capacity(keys.length() as usize);
+    for index in 0..keys.length() {
+        entries.push((
+            required_string_from_array(keys, index)?,
+            required_bytes_from_array(values, index, "block")?,
+        ));
+    }
+    Ok(entries)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -3,6 +3,7 @@ import {
 	type NativeLogEntry,
 	calculateRawCidV1,
 	createLogGraphIndex,
+	createNativeLogBlockStore,
 	encodeEntryV0Signable,
 	encodeEntryV0SignableBatch,
 	encodeEntryV0Storage,
@@ -546,5 +547,44 @@ describe("native EntryV0 encoding", () => {
 			expect(prepared.payloadBytes.byteLength).greaterThan(0);
 			expect(prepared.signatureBytes.byteLength).greaterThan(0);
 		}
+	});
+
+	it("commits prepared plain entry blocks and graph rows natively", async () => {
+		const privateKey = fromHex(
+			"9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+		);
+		const publicKey = fromHex(
+			"d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+		);
+		const index = await createLogGraphIndex();
+		const blockStore = await createNativeLogBlockStore();
+		index.put(entry("root", "chain-gid", [], 10n));
+
+		const chain = await index.prepareEntryV0PlainChainCommit(
+			{
+				clockId: publicKey,
+				privateKey,
+				publicKey,
+				wallTimes: [11n, 12n, 13n],
+				gid: "chain-gid",
+				initialNext: ["root"],
+				payloadDatas: [
+					new Uint8Array([1]),
+					new Uint8Array([2]),
+					new Uint8Array([3]),
+				],
+			},
+			blockStore,
+		);
+
+		expect(chain).to.have.length(3);
+		expect(index.heads()).to.deep.equal([chain![2]!.cid]);
+		expect(index.children("root")).to.deep.equal([chain![0]!.cid]);
+		expect(await blockStore.get(chain![0]!.cid)).to.deep.equal(chain![0]!.bytes);
+		expect(await blockStore.get(chain![1]!.cid)).to.deep.equal(chain![1]!.bytes);
+		expect(await blockStore.get(chain![2]!.cid)).to.deep.equal(chain![2]!.bytes);
+		expect(await blockStore.size()).to.equal(
+			chain!.reduce((sum, prepared) => sum + prepared.bytes.byteLength, 0),
+		);
 	});
 });

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -84,6 +84,32 @@ export type NativeLogGraph = {
 			signatureBytes: Uint8Array;
 		}>
 	>;
+	prepareEntryV0PlainChainCommit?: (
+		input: {
+			clockId: Uint8Array;
+			privateKey: Uint8Array;
+			publicKey: Uint8Array;
+			wallTimes: Array<bigint | number | string>;
+			logicals?: number[];
+			gid: string;
+			initialNext?: string[];
+			type?: number;
+			metaDatas?: Array<Uint8Array | undefined>;
+			payloadDatas: Uint8Array[];
+		},
+		blockStore: unknown,
+	) => Promise<
+		| Array<{
+				bytes: Uint8Array;
+				cid: string;
+				signature: Uint8Array;
+				next: string[];
+				metaBytes: Uint8Array;
+				payloadBytes: Uint8Array;
+				signatureBytes: Uint8Array;
+		  }>
+		| undefined
+	>;
 	delete: (hash: string) => boolean;
 	clear: () => void;
 	heads: (gid?: string) => string[];

--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -65,6 +65,10 @@ type NativeEntryV0Graph = {
 	prepareEntryV0PlainChainAndPut?(
 		input: NativePlainChainInput,
 	): Promise<NativePreparedPlainEntry[]>;
+	prepareEntryV0PlainChainCommit?(
+		input: NativePlainChainInput,
+		blockStore: unknown,
+	): Promise<NativePreparedPlainEntry[] | undefined>;
 };
 
 type NativeEntryV0Encoder = {
@@ -523,6 +527,7 @@ export class EntryV0<T>
 		deferStore: boolean;
 		cachePreparedEntries?: boolean;
 		nativeGraph?: NativeEntryV0Graph;
+		nativeBlockStore?: unknown;
 	}): Promise<Entry<T>[] | undefined> {
 		return (await EntryV0.createPlainAppendChainBatch(properties))?.entries;
 	}
@@ -542,6 +547,7 @@ export class EntryV0<T>
 		deferStore: boolean;
 		cachePreparedEntries?: boolean;
 		nativeGraph?: NativeEntryV0Graph;
+		nativeBlockStore?: unknown;
 	}): Promise<PreparedAppendChain<T> | undefined> {
 		if (!properties.deferStore) {
 			return undefined;
@@ -616,8 +622,6 @@ export class EntryV0<T>
 					encoding: properties.encoding,
 				}),
 		);
-		const nativePrepareAndPut =
-			properties.nativeGraph?.prepareEntryV0PlainChainAndPut;
 		const nativePlainChainInput: NativePlainChainInput = {
 			clockId: properties.identity.publicKey.bytes,
 			privateKey: properties.identity.privateKey.privateKey,
@@ -630,10 +634,27 @@ export class EntryV0<T>
 			metaDatas: payloads.map(() => properties.meta?.data),
 			payloadDatas: payloads.map((payload) => payload.data),
 		};
-		const prepared = await (nativePrepareAndPut
-			? nativePrepareAndPut.call(properties.nativeGraph, nativePlainChainInput)
-			: nativeEncoder.prepareEntryV0PlainChain(nativePlainChainInput));
-		const nativeGraphUpdated = !!nativePrepareAndPut;
+		const nativeCommit = properties.nativeGraph?.prepareEntryV0PlainChainCommit;
+		let nativeBlocksCommitted = false;
+		let prepared = nativeCommit
+			? await nativeCommit.call(
+					properties.nativeGraph,
+					nativePlainChainInput,
+					properties.nativeBlockStore,
+				)
+			: undefined;
+		if (prepared) {
+			nativeBlocksCommitted = true;
+		} else {
+			const nativePrepareAndPut =
+				properties.nativeGraph?.prepareEntryV0PlainChainAndPut;
+			prepared = await (nativePrepareAndPut
+				? nativePrepareAndPut.call(properties.nativeGraph, nativePlainChainInput)
+				: nativeEncoder.prepareEntryV0PlainChain(nativePlainChainInput));
+		}
+		const nativeGraphUpdated =
+			nativeBlocksCommitted ||
+			!!properties.nativeGraph?.prepareEntryV0PlainChainAndPut;
 
 		const entries: PreparedAppendChain<T>["entries"] = [];
 		const blocks: PreparedAppendChain<T>["blocks"] = [];
@@ -739,6 +760,7 @@ export class EntryV0<T>
 			shallowEntries,
 			nativeEntries,
 			nativeGraphUpdated,
+			nativeBlocksCommitted,
 		};
 	}
 

--- a/packages/log/src/entry.ts
+++ b/packages/log/src/entry.ts
@@ -37,6 +37,7 @@ export type PreparedAppendChain<T> = {
 	shallowEntries: ShallowEntry[];
 	nativeEntries?: PreparedNativeLogEntry[];
 	nativeGraphUpdated?: boolean;
+	nativeBlocksCommitted?: boolean;
 };
 
 const preparedEntryBlocks = new WeakMap<object, PreparedEntryBlock>();

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -50,6 +50,7 @@ const { LastWriteWins } = Sorting;
 
 type BlocksWithPutMany = Blocks & {
 	putMany?: (blocks: PreparedEntryBlock[]) => Promise<string[]> | string[];
+	rmMany?: (cids: string[]) => Promise<number | void> | number | void;
 };
 
 const hasPutMany = (storage: Blocks): storage is BlocksWithPutMany =>
@@ -645,7 +646,7 @@ export class Log<T> {
 
 		try {
 			await this.joinMissingNexts(entries[0]!, initialNexts);
-			if (deferBlockStore) {
+			if (deferBlockStore && !nativeAppendChain?.nativeBlocksCommitted) {
 				await this.putAppendEntryBlocks(entries, nativeAppendChain?.blocks);
 			}
 			await this.putAppendEntries(
@@ -657,6 +658,9 @@ export class Log<T> {
 		} catch (error) {
 			if (nativeAppendChain?.nativeGraphUpdated) {
 				this.rollbackNativeAppendGraph(entries);
+			}
+			if (nativeAppendChain?.nativeBlocksCommitted) {
+				await this.rollbackNativeAppendBlocks(entries);
 			}
 			throw error;
 		}
@@ -707,7 +711,9 @@ export class Log<T> {
 
 		const nativeGraph =
 			!this.entryIndex.properties.onGidRemoved &&
-			this.entryIndex.properties.nativeGraph?.graph.prepareEntryV0PlainChainAndPut
+			(this.entryIndex.properties.nativeGraph?.graph
+				.prepareEntryV0PlainChainCommit ||
+				this.entryIndex.properties.nativeGraph?.graph.prepareEntryV0PlainChainAndPut)
 				? this.entryIndex.properties.nativeGraph.graph
 				: undefined;
 		return EntryV0.createPlainAppendChainBatch<T>({
@@ -731,6 +737,7 @@ export class Log<T> {
 			deferStore: deferBlockStore,
 			cachePreparedEntries: false,
 			nativeGraph,
+			nativeBlockStore: this._storage,
 		});
 	}
 
@@ -742,6 +749,16 @@ export class Log<T> {
 		for (let i = entries.length - 1; i >= 0; i--) {
 			graph.delete(entries[i]!.hash);
 		}
+	}
+
+	private async rollbackNativeAppendBlocks(entries: Entry<T>[]) {
+		const hashes = entries.map((entry) => entry.hash);
+		const storage = this._storage as BlocksWithPutMany;
+		if (typeof storage.rmMany === "function") {
+			await storage.rmMany(hashes);
+			return;
+		}
+		await Promise.all(hashes.map((hash) => this._storage.rm(hash)));
 	}
 
 	private validateExplicitNexts(options: AppendOptions<T>) {

--- a/packages/log/test/append.spec.ts
+++ b/packages/log/test/append.spec.ts
@@ -240,6 +240,67 @@ describe("append", function () {
 		}
 	});
 
+	it("appendMany commits blocks and graph in one native call when storage is native", async () => {
+		const { createNativeLogBlockStore } = await import("@peerbit/log-rust");
+		const nativeStore = await createNativeLogBlockStore();
+		await nativeStore.start();
+		const log = new Log<Uint8Array>();
+		await log.open(nativeStore, signKey, {
+			appendDurability: "strict",
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+		});
+		const root = (
+			await log.append(new Uint8Array([0]), { meta: { next: [] } })
+		).entry;
+
+		const blockPutManySpy = sinon.spy(nativeStore, "putMany");
+		const nativeCommitSpy = sinon.spy(
+			log.entryIndex.properties.nativeGraph!.graph,
+			"prepareEntryV0PlainChainCommit",
+		);
+		const nativePrepareAndPutSpy = sinon.spy(
+			log.entryIndex.properties.nativeGraph!.graph,
+			"prepareEntryV0PlainChainAndPut",
+		);
+		const nativeAppendChainSpy = sinon.spy(
+			log.entryIndex.properties.nativeGraph!.graph,
+			"putAppendChain",
+		);
+
+		try {
+			const result = await log.appendMany([
+				new Uint8Array([1]),
+				new Uint8Array([2]),
+				new Uint8Array([3]),
+			]);
+
+			expect(result.entries).to.have.length(3);
+			expect(result.entries[0].meta.next).to.deep.equal([root.hash]);
+			expect(
+				(await log.getHeads().all()).map((head) => head.hash),
+			).to.deep.equal([result.entries[2].hash]);
+			expect(nativeCommitSpy.callCount).equal(1);
+			expect(nativeCommitSpy.firstCall.args[0].payloadDatas).to.have.length(
+				result.entries.length,
+			);
+			expect(blockPutManySpy.callCount).equal(0);
+			expect(nativePrepareAndPutSpy.callCount).equal(0);
+			expect(nativeAppendChainSpy.callCount).equal(0);
+			for (const entry of result.entries) {
+				expect(await nativeStore.has(entry.hash)).to.equal(true);
+				expect((await log.get(entry.hash))?.hash).equal(entry.hash);
+			}
+		} finally {
+			blockPutManySpy.restore();
+			nativeCommitSpy.restore();
+			nativePrepareAndPutSpy.restore();
+			nativeAppendChainSpy.restore();
+			await log.close();
+			await nativeStore.stop();
+		}
+	});
+
 	it("rolls back native graph when prepared appendMany block write fails", async () => {
 		const log = new Log<Uint8Array>();
 		await log.open(store, signKey, {


### PR DESCRIPTION
## Summary
- add a transient NativeLogBlockStore in @peerbit/log-rust so the log graph and block store can live in the same WASM module for the fast path
- add a native appendMany commit method that prepares EntryV0 bytes/signatures/CIDs, writes entry blocks, and updates the native graph in one Rust call
- route @peerbit/log appendMany through the stronger native commit when the storage exposes the native log block handle, while preserving the existing JS block-store fallback
- add benchmark coverage for the native block commit row

## Validation
- cargo test --manifest-path packages/log/rust/Cargo.toml
- cargo fmt --manifest-path packages/log/rust/Cargo.toml --check
- pnpm --filter @peerbit/log-rust run build
- pnpm --filter @peerbit/log run build
- pnpm exec eslint --config eslint.config.js packages/log/src/log.ts packages/log/src/entry-index.ts packages/log/src/entry-v0.ts packages/log/src/entry.ts packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/test/append.spec.ts packages/log/benchmark/native-graph.ts
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "appendMany commits blocks and graph|appendMany appends a local chain|rolls back native graph"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log/rust -- -t node --grep "commits prepared plain entry blocks"
- git diff --check

## Local benchmark signal
- node --loader ts-node/esm ./benchmark/native-graph.ts from packages/log
- appendMany auto-next with nativeGraph + normal block store: 20.6k ops/sec
- appendMany native block commit: 22.1k ops/sec

Stacked on #856 / feat/native-single-append-transaction.