### PR TITLE
Defer TS index writes after native append commits

### DIFF
--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -307,13 +307,26 @@ export class EntryIndex<T> {
 			return;
 		}
 		this.clearPendingIndexFlushTimer();
+		const writes: ShallowEntry[] = [];
 		for (const hash of keys) {
 			const pending = this.pendingIndexWrites.get(hash);
 			if (!pending) {
 				continue;
 			}
-			await this.properties.index.put(pending);
-			this.pendingIndexWrites.delete(hash);
+			writes.push(pending);
+		}
+		if (writes.length === 0) {
+			return;
+		}
+		if (writes.length > 1 && this.properties.index.putBatch) {
+			await this.properties.index.putBatch(writes);
+		} else {
+			for (const write of writes) {
+				await this.properties.index.put(write);
+			}
+		}
+		for (const write of writes) {
+			this.pendingIndexWrites.delete(write.hash);
 		}
 		if (this.pendingIndexWrites.size > 0) {
 			this.schedulePendingIndexWriteFlush();
@@ -373,7 +386,6 @@ export class EntryIndex<T> {
 		if (!this.properties.nativeGraph?.useHeads) {
 			return undefined;
 		}
-		await this.flushPendingWrites();
 		return this.properties.nativeGraph.graph.hasHead(gid);
 	}
 
@@ -385,7 +397,6 @@ export class EntryIndex<T> {
 		if (uniqueGids.size === 0) {
 			return false;
 		}
-		await this.flushPendingWrites();
 		return this.properties.nativeGraph.graph.hasAnyHead(uniqueGids);
 	}
 
@@ -401,7 +412,6 @@ export class EntryIndex<T> {
 		if (normalized.length === 0) {
 			return [];
 		}
-		await this.flushPendingWrites();
 		return this.properties.nativeGraph.graph.hasAnyHeadBatch(normalized);
 	}
 
@@ -409,7 +419,6 @@ export class EntryIndex<T> {
 		if (!this.properties.nativeGraph?.useHeads) {
 			return undefined;
 		}
-		await this.flushPendingWrites();
 		return this.properties.nativeGraph.graph.maxHeadDataU32(gid);
 	}
 
@@ -486,10 +495,10 @@ export class EntryIndex<T> {
 		next: string,
 		excludeHash: string | undefined = undefined,
 	) {
-		await this.flushPendingWrites();
 		if (this.properties.nativeGraph) {
 			return this.properties.nativeGraph.graph.countHasNext(next, excludeHash);
 		}
+		await this.flushPendingWrites();
 		const query: Query[] = [
 			new StringMatch({
 				key: ["meta", "next"],
@@ -535,7 +544,7 @@ export class EntryIndex<T> {
 
 		const getHashes = async () => {
 			if (!hashPromise) {
-				hashPromise = this.flushPendingWrites().then(() => hashes());
+				hashPromise = Promise.resolve(hashes());
 			}
 			return hashPromise;
 		};
@@ -590,7 +599,7 @@ export class EntryIndex<T> {
 
 		const getValues = async () => {
 			if (!valuesPromise) {
-				valuesPromise = this.flushPendingWrites().then(() => values());
+				valuesPromise = Promise.resolve(values());
 			}
 			return valuesPromise;
 		};
@@ -969,6 +978,7 @@ export class EntryIndex<T> {
 				shallowEntries: ShallowEntry[];
 				nativeEntries?: NativeLogEntry[];
 				nativeGraphUpdated?: boolean;
+				nativeBlocksCommitted?: boolean;
 			};
 			deferIndexWrite?: boolean;
 		},
@@ -1007,6 +1017,10 @@ export class EntryIndex<T> {
 				!this.properties.onGidRemoved && this.properties.index.putBatch;
 			const shallowEntries: ShallowEntry[] = [];
 			const nativeGraphUpdated = properties.prepared?.nativeGraphUpdated === true;
+			const nativeCommitOwnsHotIndex =
+				nativeGraphUpdated &&
+				properties.prepared?.nativeBlocksCommitted === true &&
+				!this.properties.onGidRemoved;
 			const nativeGraphPutAppendChain =
 				!nativeGraphUpdated &&
 				!this.properties.onGidRemoved &&
@@ -1040,6 +1054,17 @@ export class EntryIndex<T> {
 					preparedShallowEntry ??
 					Entry.takePreparedShallowEntry(entry, isHead) ??
 					entry.toShallow(isHead);
+				if (nativeCommitOwnsHotIndex) {
+					this.pendingIndexWrites.set(entry.hash, shallowEntry);
+					if (batchHashes) {
+						for (const next of entry.meta.next) {
+							if (!batchHashes.has(next)) {
+								externalNexts.add(next);
+							}
+						}
+					}
+					continue;
+				}
 				const preparedNativeEntry = properties.prepared?.nativeEntries?.[i];
 				if (preparedNativeEntry) {
 					preparedNativeEntry.head = isHead;
@@ -1074,7 +1099,9 @@ export class EntryIndex<T> {
 				}
 			}
 
-			if (putBatch) {
+			if (nativeCommitOwnsHotIndex) {
+				this.schedulePendingIndexWriteFlush();
+			} else if (putBatch) {
 				await putBatch.call(this.properties.index, shallowEntries);
 				if (nativeGraphPutAppendChain) {
 					nativeGraphPutAppendChain(nativeEntries);

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -889,6 +889,7 @@ export class Log<T> {
 							shallowEntries: preparedAppendChain.shallowEntries,
 							nativeEntries: preparedAppendChain.nativeEntries,
 							nativeGraphUpdated: preparedAppendChain.nativeGraphUpdated,
+							nativeBlocksCommitted: preparedAppendChain.nativeBlocksCommitted,
 						}
 					: undefined,
 			deferIndexWrite:

--- a/packages/log/test/append.spec.ts
+++ b/packages/log/test/append.spec.ts
@@ -255,6 +255,11 @@ describe("append", function () {
 		).entry;
 
 		const blockPutManySpy = sinon.spy(nativeStore, "putMany");
+		const indexPutSpy = sinon.spy(log.entryIndex.properties.index, "put");
+		const indexPutBatchSpy = sinon.spy(
+			log.entryIndex.properties.index,
+			"putBatch",
+		);
 		const nativeCommitSpy = sinon.spy(
 			log.entryIndex.properties.nativeGraph!.graph,
 			"prepareEntryV0PlainChainCommit",
@@ -285,14 +290,21 @@ describe("append", function () {
 				result.entries.length,
 			);
 			expect(blockPutManySpy.callCount).equal(0);
+			expect(indexPutBatchSpy.callCount).equal(0);
+			expect(indexPutSpy.callCount).equal(1);
 			expect(nativePrepareAndPutSpy.callCount).equal(0);
 			expect(nativeAppendChainSpy.callCount).equal(0);
 			for (const entry of result.entries) {
 				expect(await nativeStore.has(entry.hash)).to.equal(true);
 				expect((await log.get(entry.hash))?.hash).equal(entry.hash);
 			}
+			expect(await log.toArray()).to.have.length(4);
+			expect(indexPutSpy.callCount).equal(1);
+			expect(indexPutBatchSpy.callCount).equal(1);
 		} finally {
 			blockPutManySpy.restore();
+			indexPutSpy.restore();
+			indexPutBatchSpy.restore();
 			nativeCommitSpy.restore();
 			nativePrepareAndPutSpy.restore();
 			nativeAppendChainSpy.restore();


### PR DESCRIPTION
## Summary
- for native block+graph append commits, queue shallow TS index rows instead of awaiting TS index putBatch in the append transaction
- keep the native graph authoritative for heads, membership, head data, and next-count reads without flushing pending TS index writes first
- batch deferred TS index flushes with putBatch when available so compatibility flushes stay cheap

## Validation
- pnpm --filter @peerbit/log run build
- pnpm exec eslint --config eslint.config.js packages/log/src/entry-index.ts packages/log/src/log.ts packages/log/test/append.spec.ts packages/log/benchmark/native-graph.ts
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "appendMany commits blocks and graph|appendMany appends a local chain|rolls back native graph"
- git diff --check

## Local benchmark signal
- node --loader ts-node/esm ./benchmark/native-graph.ts from packages/log
- appendMany auto-next with nativeGraph + normal block store: 20.6k ops/sec
- appendMany native block commit with deferred TS index writes: 22.0k ops/sec

This is mostly a transaction-shape improvement: it removes the awaited TS index putBatch from the eligible native append path. The benchmark is roughly flat, which suggests the next larger wins are above this boundary: fewer JS Entry object allocations/init work and more native change/result construction.

Stacked on #857 / feat/native-append-block-commit.