### PR TITLE
Return light rows from native append commits

### DIFF
--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -116,7 +116,7 @@ type NativeLogIndexHandle = {
 		type: number,
 		metaDatas: Array<Uint8Array | undefined>,
 		payloadDatas: Uint8Array[],
-	) => EntryV0PreparedPlainEntryRow[];
+	) => EntryV0CommittedPlainEntryRow[];
 	delete: (hash: string) => boolean;
 	heads: (gid?: string) => string[];
 	has_head: (gid?: string) => boolean;
@@ -436,7 +436,7 @@ export class LogGraphIndex {
 	prepareEntryV0PlainChainCommit(
 		input: EntryV0PlainChainInput,
 		blockStore: unknown,
-	): Promise<EntryV0PreparedPlainEntry[] | undefined> {
+	): Promise<EntryV0CommittedPlainEntry[] | undefined> {
 		const nativeBlockStore = nativeLogBlockStoreHandle(blockStore);
 		if (!nativeBlockStore) {
 			return Promise.resolve(undefined);
@@ -446,7 +446,7 @@ export class LogGraphIndex {
 			return Promise.resolve([]);
 		}
 		return Promise.resolve(
-			preparedPlainEntryRows(
+			committedPlainEntryRows(
 				this.native.prepare_entry_v0_plain_chain_commit_blocks_and_put(
 					nativeBlockStore,
 					input.clockId,
@@ -754,11 +754,19 @@ export type EntryV0PlainChainInput = {
 };
 
 export type EntryV0PreparedPlainEntry = EntryV0EncodedStorage & {
+	byteLength: number;
 	signature: Uint8Array;
 	next: string[];
 	metaBytes: Uint8Array;
 	payloadBytes: Uint8Array;
 	signatureBytes: Uint8Array;
+};
+
+export type EntryV0CommittedPlainEntry = Omit<
+	EntryV0PreparedPlainEntry,
+	"bytes"
+> & {
+	bytes?: undefined;
 };
 
 type EntryV0PreparedPlainEntryRow = [
@@ -769,6 +777,16 @@ type EntryV0PreparedPlainEntryRow = [
 	Uint8Array,
 	Uint8Array,
 	Uint8Array,
+];
+
+type EntryV0CommittedPlainEntryRow = [
+	string,
+	Uint8Array,
+	string[],
+	Uint8Array,
+	Uint8Array,
+	Uint8Array,
+	number,
 ];
 
 const plainChainInputColumns = (input: EntryV0PlainChainInput) => {
@@ -806,6 +824,30 @@ const preparedPlainEntryRows = (
 		]) => ({
 			bytes,
 			cid,
+			byteLength: bytes.byteLength,
+			signature,
+			next,
+			metaBytes,
+			payloadBytes,
+			signatureBytes,
+		}),
+	);
+
+const committedPlainEntryRows = (
+	rows: EntryV0CommittedPlainEntryRow[],
+): EntryV0CommittedPlainEntry[] =>
+	rows.map(
+		([
+			cid,
+			signature,
+			next,
+			metaBytes,
+			payloadBytes,
+			signatureBytes,
+			byteLength,
+		]) => ({
+			cid,
+			byteLength,
 			signature,
 			next,
 			metaBytes,

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -754,6 +754,7 @@ impl NativeLogIndex {
             entry_type,
             meta_datas,
             payload_datas,
+            true,
         )?;
         self.inner.put_append_chain(entries, &initial_nexts);
         Ok(rows)
@@ -784,6 +785,7 @@ impl NativeLogIndex {
             entry_type,
             meta_datas,
             payload_datas,
+            false,
         )?;
         block_store.put_entries(blocks);
         self.inner.put_append_chain(entries, &initial_nexts);
@@ -1118,6 +1120,7 @@ fn prepare_entry_v0_plain_chain_rows(
     entry_type: u8,
     meta_datas: Array,
     payload_datas: Array,
+    include_storage_bytes: bool,
 ) -> Result<
     (
         Array,
@@ -1165,16 +1168,27 @@ fn prepare_entry_v0_plain_chain_rows(
         };
         let signature_with_key = encode_signature_with_key(&signature_input);
         let storage = encode_entry_v0_parts(&meta, &payload, Some(signature_input));
+        let storage_len = storage.len();
         let cid = calculate_raw_cid_v1_from_bytes(&storage);
 
         let row = Array::new();
-        row.push(&Uint8Array::from(storage.as_slice()));
-        row.push(&JsValue::from_str(&cid));
-        row.push(&Uint8Array::from(signature.as_slice()));
-        row.push(&strings_to_array(next.clone()));
-        row.push(&Uint8Array::from(meta.as_slice()));
-        row.push(&Uint8Array::from(payload.as_slice()));
-        row.push(&Uint8Array::from(signature_with_key.as_slice()));
+        if include_storage_bytes {
+            row.push(&Uint8Array::from(storage.as_slice()));
+            row.push(&JsValue::from_str(&cid));
+            row.push(&Uint8Array::from(signature.as_slice()));
+            row.push(&strings_to_array(next.clone()));
+            row.push(&Uint8Array::from(meta.as_slice()));
+            row.push(&Uint8Array::from(payload.as_slice()));
+            row.push(&Uint8Array::from(signature_with_key.as_slice()));
+        } else {
+            row.push(&JsValue::from_str(&cid));
+            row.push(&Uint8Array::from(signature.as_slice()));
+            row.push(&strings_to_array(next.clone()));
+            row.push(&Uint8Array::from(meta.as_slice()));
+            row.push(&Uint8Array::from(payload.as_slice()));
+            row.push(&Uint8Array::from(signature_with_key.as_slice()));
+            row.push(&JsValue::from_f64(storage_len as f64));
+        }
         out.push(&row);
         entries.push(LogIndexEntry::new_with_data(
             cid.clone(),
@@ -1218,6 +1232,7 @@ pub fn prepare_entry_v0_plain_chain(
         entry_type,
         meta_datas,
         payload_datas,
+        true,
     )?
     .0)
 }

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -580,11 +580,14 @@ describe("native EntryV0 encoding", () => {
 		expect(chain).to.have.length(3);
 		expect(index.heads()).to.deep.equal([chain![2]!.cid]);
 		expect(index.children("root")).to.deep.equal([chain![0]!.cid]);
-		expect(await blockStore.get(chain![0]!.cid)).to.deep.equal(chain![0]!.bytes);
-		expect(await blockStore.get(chain![1]!.cid)).to.deep.equal(chain![1]!.bytes);
-		expect(await blockStore.get(chain![2]!.cid)).to.deep.equal(chain![2]!.bytes);
+		for (const prepared of chain!) {
+			expect(prepared.bytes).equal(undefined);
+			const stored = await blockStore.get(prepared.cid);
+			expect(stored?.byteLength).equal(prepared.byteLength);
+			expect(await calculateRawCidV1(stored!)).equal(prepared.cid);
+		}
 		expect(await blockStore.size()).to.equal(
-			chain!.reduce((sum, prepared) => sum + prepared.bytes.byteLength, 0),
+			chain!.reduce((sum, prepared) => sum + prepared.byteLength, 0),
 		);
 	});
 });

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -77,6 +77,7 @@ export type NativeLogGraph = {
 		Array<{
 			bytes: Uint8Array;
 			cid: string;
+			byteLength: number;
 			signature: Uint8Array;
 			next: string[];
 			metaBytes: Uint8Array;
@@ -100,8 +101,9 @@ export type NativeLogGraph = {
 		blockStore: unknown,
 	) => Promise<
 		| Array<{
-				bytes: Uint8Array;
+				bytes?: Uint8Array;
 				cid: string;
+				byteLength: number;
 				signature: Uint8Array;
 				next: string[];
 				metaBytes: Uint8Array;

--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -52,8 +52,9 @@ type NativePlainChainInput = {
 };
 
 type NativePreparedPlainEntry = {
-	bytes: Uint8Array;
+	bytes?: Uint8Array;
 	cid: string;
+	byteLength: number;
 	signature: Uint8Array;
 	next: string[];
 	metaBytes: Uint8Array;
@@ -614,25 +615,28 @@ export class EntryV0<T>
 		}
 
 		const entryType = properties.meta?.type ?? EntryType.APPEND;
-		const payloads = properties.data.map(
-			(data) =>
-				new Payload<T>({
-					data: properties.encoding.encoder(data),
-					value: data,
-					encoding: properties.encoding,
-				}),
-		);
+		const wallTimes = new Array<bigint | number | string>(properties.data.length);
+		const logicals = new Array<number>(properties.data.length);
+		const metaDatas = new Array<Uint8Array | undefined>(properties.data.length);
+		const payloadDatas = new Array<Uint8Array>(properties.data.length);
+		for (let i = 0; i < properties.data.length; i++) {
+			const clock = clocks[i]!;
+			wallTimes[i] = clock.timestamp.wallTime;
+			logicals[i] = clock.timestamp.logical;
+			metaDatas[i] = properties.meta?.data;
+			payloadDatas[i] = properties.encoding.encoder(properties.data[i]!);
+		}
 		const nativePlainChainInput: NativePlainChainInput = {
 			clockId: properties.identity.publicKey.bytes,
 			privateKey: properties.identity.privateKey.privateKey,
 			publicKey: properties.identity.publicKey.publicKey,
-			wallTimes: clocks.map((clock) => clock.timestamp.wallTime),
-			logicals: clocks.map((clock) => clock.timestamp.logical),
+			wallTimes,
+			logicals,
 			gid: gid!,
 			initialNext: nextHashes,
 			type: entryType,
-			metaDatas: payloads.map(() => properties.meta?.data),
-			payloadDatas: payloads.map((payload) => payload.data),
+			metaDatas,
+			payloadDatas,
 		};
 		const nativeCommit = properties.nativeGraph?.prepareEntryV0PlainChainCommit;
 		let nativeBlocksCommitted = false;
@@ -657,7 +661,7 @@ export class EntryV0<T>
 			!!properties.nativeGraph?.prepareEntryV0PlainChainAndPut;
 
 		const entries: PreparedAppendChain<T>["entries"] = [];
-		const blocks: PreparedAppendChain<T>["blocks"] = [];
+		const blocks: NonNullable<PreparedAppendChain<T>["blocks"]> = [];
 		const shallowEntries: PreparedAppendChain<T>["shallowEntries"] = [];
 		const nativeEntries: NonNullable<PreparedAppendChain<T>["nativeEntries"]> =
 			[];
@@ -671,7 +675,11 @@ export class EntryV0<T>
 				data: properties.meta?.data,
 				next: preparedEntry.next,
 			});
-			const payload = payloads[index]!;
+			const payload = new Payload<T>({
+				data: payloadDatas[index]!,
+				value: properties.data[index],
+				encoding: properties.encoding,
+			});
 			const signature = new SignatureWithKey({
 				signature: preparedEntry.signature,
 				publicKey: properties.identity.publicKey,
@@ -696,14 +704,17 @@ export class EntryV0<T>
 				}),
 				createdLocally: true,
 			});
-			const preparedBlock = Entry.preparedBlockFromBytes(
-				preparedEntry.bytes,
-				preparedEntry.cid,
-			);
+			const preparedBlock =
+				preparedEntry.bytes && !nativeBlocksCommitted
+					? Entry.preparedBlockFromBytes(preparedEntry.bytes, preparedEntry.cid)
+					: undefined;
 			if (properties.cachePreparedEntries === false) {
 				entry.hash = preparedEntry.cid;
-				entry.size = preparedEntry.bytes.length;
+				entry.size = preparedEntry.byteLength;
 			} else {
+				if (!preparedEntry.bytes) {
+					throw new Error("Missing prepared entry bytes");
+				}
 				entry.hash = Entry.prepareMultihashBytes(
 					entry,
 					preparedEntry.bytes,
@@ -748,7 +759,9 @@ export class EntryV0<T>
 				entry.init({ encoding: properties.encoding });
 			}
 			entries.push(entry);
-			blocks.push(preparedBlock);
+			if (preparedBlock) {
+				blocks.push(preparedBlock);
+			}
 			shallowEntries.push(shallowEntry);
 			if (nativeEntry) {
 				nativeEntries.push(nativeEntry);
@@ -756,7 +769,7 @@ export class EntryV0<T>
 		}
 		return {
 			entries,
-			blocks,
+			blocks: blocks.length > 0 ? blocks : undefined,
 			shallowEntries,
 			nativeEntries,
 			nativeGraphUpdated,

--- a/packages/log/src/entry.ts
+++ b/packages/log/src/entry.ts
@@ -33,7 +33,7 @@ export type PreparedNativeLogEntry = {
 };
 export type PreparedAppendChain<T> = {
 	entries: Entry<T>[];
-	blocks: PreparedEntryBlock[];
+	blocks?: PreparedEntryBlock[];
 	shallowEntries: ShallowEntry[];
 	nativeEntries?: PreparedNativeLogEntry[];
 	nativeGraphUpdated?: boolean;

--- a/packages/log/test/append.spec.ts
+++ b/packages/log/test/append.spec.ts
@@ -260,6 +260,7 @@ describe("append", function () {
 			log.entryIndex.properties.index,
 			"putBatch",
 		);
+		const preparedBlockFromBytesSpy = sinon.spy(Entry, "preparedBlockFromBytes");
 		const nativeCommitSpy = sinon.spy(
 			log.entryIndex.properties.nativeGraph!.graph,
 			"prepareEntryV0PlainChainCommit",
@@ -290,6 +291,7 @@ describe("append", function () {
 				result.entries.length,
 			);
 			expect(blockPutManySpy.callCount).equal(0);
+			expect(preparedBlockFromBytesSpy.callCount).equal(0);
 			expect(indexPutBatchSpy.callCount).equal(0);
 			expect(indexPutSpy.callCount).equal(1);
 			expect(nativePrepareAndPutSpy.callCount).equal(0);
@@ -305,6 +307,7 @@ describe("append", function () {
 			blockPutManySpy.restore();
 			indexPutSpy.restore();
 			indexPutBatchSpy.restore();
+			preparedBlockFromBytesSpy.restore();
 			nativeCommitSpy.restore();
 			nativePrepareAndPutSpy.restore();
 			nativeAppendChainSpy.restore();


### PR DESCRIPTION
## Summary
- change native append block commits to return lightweight rows instead of copying full serialized block bytes back into JS after Rust has already written them
- skip PreparedEntryBlock construction for native-committed appendMany chains
- build native append input columns in one pass and create Payload objects only while assembling returned Entry objects

## Validation
- cargo test --manifest-path packages/log/rust/Cargo.toml
- cargo fmt --manifest-path packages/log/rust/Cargo.toml --check
- pnpm --filter @peerbit/log-rust run build
- pnpm --filter @peerbit/log run build
- pnpm exec eslint --config eslint.config.js packages/log/src/entry-v0.ts packages/log/src/entry.ts packages/log/src/entry-index.ts packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/test/append.spec.ts
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log/rust -- -t node --grep "prepares a hash-linked plain entry chain|commits prepared plain entry blocks"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "appendMany commits blocks and graph|appendMany appends a local chain|rolls back native graph"
- git diff --check

## Local benchmark signal
- packages/log/benchmark/native-graph.ts: appendMany native block commit improved to 23.5k ops/sec locally; previous #858 signal was about 22.0k ops/sec
- 10k entry sanity sample: normal block store + native graph median 22.1k ops/sec; native log block store + light commit rows median 22.7k ops/sec

Stacked on #858 / feat/native-append-index-defer.