### PR TITLE
feat: use native commit for single append

### DIFF
--- a/packages/log/benchmark/native-graph.ts
+++ b/packages/log/benchmark/native-graph.ts
@@ -232,6 +232,19 @@ for (const nativeGraph of [false, true]) {
 	);
 }
 
+rows.push(
+	await measureAppend(
+		"append loop native block commit",
+		true,
+		async (log) => {
+			for (let i = 0; i < appendEntries; i++) {
+				await log.append(new Uint8Array([i & 0xff]));
+			}
+		},
+		createNativeLogBlockStore,
+	),
+);
+
 for (const nativeGraph of [false, true]) {
 	rows.push(
 		await measureAppend("appendMany auto-next", nativeGraph, async (log) => {

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -988,7 +988,10 @@ export class EntryIndex<T> {
 		if (entries.length === 0) {
 			return;
 		}
-		if (entries.length === 1) {
+		if (
+			entries.length === 1 &&
+			properties.prepared?.nativeGraphUpdated !== true
+		) {
 			return this.put(entries[0], {
 				unique: properties.unique,
 				isHead: true,

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -576,9 +576,43 @@ export class Log<T> {
 		options: AppendOptions<T> = {},
 	): Promise<{ entry: Entry<T>; removed: ShallowOrFullEntry<T>[] }> {
 		const nexts = await this.getNextsForAppend(options);
-		const entry = await this.createAppendEntry(data, options, nexts);
-		await this.joinMissingNexts(entry, nexts);
-		await this.putAppendEntry(entry, options);
+		const deferBlockStore = hasPutMany(this._storage);
+		const nativeAppendChain = this.entryIndex.properties.nativeGraph
+			? await this.createNativePlainAppendChain(
+					[data],
+					options,
+					nexts,
+					deferBlockStore,
+				)
+			: undefined;
+		let entry: Entry<T>;
+		if (nativeAppendChain) {
+			entry = nativeAppendChain.entries[0]!;
+			try {
+				await this.joinMissingNexts(entry, nexts);
+				if (deferBlockStore && !nativeAppendChain.nativeBlocksCommitted) {
+					await this.putAppendEntryBlocks([entry], nativeAppendChain.blocks);
+				}
+				await this.putAppendEntries(
+					[entry],
+					options,
+					nexts.map((next) => next.hash),
+					nativeAppendChain,
+				);
+			} catch (error) {
+				if (nativeAppendChain.nativeGraphUpdated) {
+					this.rollbackNativeAppendGraph([entry]);
+				}
+				if (nativeAppendChain.nativeBlocksCommitted) {
+					await this.rollbackNativeAppendBlocks([entry]);
+				}
+				throw error;
+			}
+		} else {
+			entry = await this.createAppendEntry(data, options, nexts);
+			await this.joinMissingNexts(entry, nexts);
+			await this.putAppendEntry(entry, options);
+		}
 
 		const pendingDeletes: (
 			| PendingDelete<T>
@@ -703,8 +737,7 @@ export class Log<T> {
 			options.canAppend ||
 			this._hasCustomCanAppend ||
 			options.meta?.timestamp ||
-			options.meta?.type === EntryType.CUT ||
-			data.length < 2
+			options.meta?.type === EntryType.CUT
 		) {
 			return Promise.resolve(undefined);
 		}

--- a/packages/log/test/append.spec.ts
+++ b/packages/log/test/append.spec.ts
@@ -293,7 +293,7 @@ describe("append", function () {
 			expect(blockPutManySpy.callCount).equal(0);
 			expect(preparedBlockFromBytesSpy.callCount).equal(0);
 			expect(indexPutBatchSpy.callCount).equal(0);
-			expect(indexPutSpy.callCount).equal(1);
+			expect(indexPutSpy.callCount).equal(0);
 			expect(nativePrepareAndPutSpy.callCount).equal(0);
 			expect(nativeAppendChainSpy.callCount).equal(0);
 			for (const entry of result.entries) {
@@ -301,7 +301,7 @@ describe("append", function () {
 				expect((await log.get(entry.hash))?.hash).equal(entry.hash);
 			}
 			expect(await log.toArray()).to.have.length(4);
-			expect(indexPutSpy.callCount).equal(1);
+			expect(indexPutSpy.callCount).equal(0);
 			expect(indexPutBatchSpy.callCount).equal(1);
 		} finally {
 			blockPutManySpy.restore();
@@ -311,6 +311,56 @@ describe("append", function () {
 			nativeCommitSpy.restore();
 			nativePrepareAndPutSpy.restore();
 			nativeAppendChainSpy.restore();
+			await log.close();
+			await nativeStore.stop();
+		}
+	});
+
+	it("append commits one block and graph in one native call when storage is native", async () => {
+		const { createNativeLogBlockStore } = await import("@peerbit/log-rust");
+		const nativeStore = await createNativeLogBlockStore();
+		await nativeStore.start();
+		const log = new Log<Uint8Array>();
+		await log.open(nativeStore, signKey, {
+			appendDurability: "strict",
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+		});
+
+		const blockPutSpy = sinon.spy(nativeStore, "put");
+		const blockPutManySpy = sinon.spy(nativeStore, "putMany");
+		const preparedBlockFromBytesSpy = sinon.spy(Entry, "preparedBlockFromBytes");
+		const nativeCommitSpy = sinon.spy(
+			log.entryIndex.properties.nativeGraph!.graph,
+			"prepareEntryV0PlainChainCommit",
+		);
+		const nativePrepareAndPutSpy = sinon.spy(
+			log.entryIndex.properties.nativeGraph!.graph,
+			"prepareEntryV0PlainChainAndPut",
+		);
+
+		try {
+			const { entry } = await log.append(new Uint8Array([1]), {
+				meta: { next: [] },
+			});
+
+			expect(nativeCommitSpy.callCount).equal(1);
+			expect(nativeCommitSpy.firstCall.args[0].payloadDatas).to.have.length(1);
+			expect(nativePrepareAndPutSpy.callCount).equal(0);
+			expect(blockPutSpy.callCount).equal(0);
+			expect(blockPutManySpy.callCount).equal(0);
+			expect(preparedBlockFromBytesSpy.callCount).equal(0);
+			expect(await nativeStore.has(entry.hash)).to.equal(true);
+			expect((await log.getHeads().all()).map((head) => head.hash)).to.deep.equal([
+				entry.hash,
+			]);
+			expect((await log.get(entry.hash))?.hash).equal(entry.hash);
+		} finally {
+			blockPutSpy.restore();
+			blockPutManySpy.restore();
+			preparedBlockFromBytesSpy.restore();
+			nativeCommitSpy.restore();
+			nativePrepareAndPutSpy.restore();
 			await log.close();
 			await nativeStore.stop();
 		}


### PR DESCRIPTION
## Summary
- route eligible single append calls through the native plain-chain commit path when native graph is active
- let one-entry native-updated batches keep prepared/native metadata instead of falling back to the generic put path
- add a native single-append regression test and benchmark row

## Test Plan
- pnpm --filter @peerbit/log run build
- pnpm exec eslint --config eslint.config.js packages/log/src/log.ts packages/log/src/entry-index.ts packages/log/test/append.spec.ts packages/log/benchmark/native-graph.ts
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "append commits one block and graph|appendMany commits blocks and graph|appendMany appends a local chain|buffers head index writes"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "append"
- PEERBIT_LOG_NATIVE_GRAPH_APPEND_ENTRIES=10000 node --loader ts-node/esm ./benchmark/native-graph.ts