### PR TITLE
feat: add native-aware document put fast path

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"packages/programs/clock-service",
 		"packages/programs/transport",
 		"packages/programs/data/*",
+		"packages/programs/data/shared-log/rust",
 		"packages/programs/data/document/*",
 		"packages/programs/data/document/react/e2e/party",
 		"packages/programs/data/document/react/e2e/party/shared",

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -130,6 +130,8 @@ export type AppendDurability = "strict" | "buffered";
 export type AppendOptions<T> = {
 	durability?: AppendDurability;
 	deferIndexWrite?: boolean;
+	/** Internal: set only by trusted Peerbit append paths after validation. */
+	__peerbitCanAppendAlreadyValidated?: boolean;
 	meta?: {
 		type?: EntryType;
 		gidSeed?: Uint8Array;
@@ -730,12 +732,14 @@ export class Log<T> {
 		nexts: Sorting.SortableEntry[],
 		deferBlockStore: boolean,
 	): Promise<PreparedAppendChain<T> | undefined> {
+		const canAppendAlreadyValidated =
+			options.__peerbitCanAppendAlreadyValidated === true;
 		if (
 			!deferBlockStore ||
 			options.encryption ||
 			options.signers ||
 			options.canAppend ||
-			this._hasCustomCanAppend ||
+			(this._hasCustomCanAppend && !canAppendAlreadyValidated) ||
 			options.meta?.timestamp ||
 			options.meta?.type === EntryType.CUT
 		) {
@@ -855,8 +859,10 @@ export class Log<T> {
 					}
 				: undefined,
 			canAppend:
-				options.canAppend ||
-				(this._hasCustomCanAppend ? this._canAppend : undefined),
+				options.__peerbitCanAppendAlreadyValidated === true
+					? undefined
+					: options.canAppend ||
+						(this._hasCustomCanAppend ? this._canAppend : undefined),
 			deferStore: storeOptions?.deferStore,
 		});
 

--- a/packages/programs/data/document/document/benchmark/document-put.ts
+++ b/packages/programs/data/document/document/benchmark/document-put.ts
@@ -1,7 +1,9 @@
-import { field, option, variant } from "@dao-xyz/borsh";
+import { field, option, serialize, variant } from "@dao-xyz/borsh";
+import { create as createSimpleIndexer } from "@peerbit/indexer-simple";
+import { create as createSqliteIndexer } from "@peerbit/indexer-sqlite3";
 import { Program, type ProgramClient } from "@peerbit/program";
 import { TestSession } from "@peerbit/test-utils";
-import { Bench } from "tinybench";
+import { createRustPeerbitOptions } from "peerbit/rust";
 import { Documents, type SetupOptions } from "../src/program.js";
 
 // Run with:
@@ -9,20 +11,32 @@ import { Documents, type SetupOptions } from "../src/program.js";
 //   node --loader ts-node/esm ./benchmark/document-put.ts
 //
 // Env:
-// - DOC_WARMUP=1000
-// - DOC_ITERATIONS=200
+// - DOC_WARMUP=100
+// - DOC_ITERATIONS=1000
 // - DOC_BYTES=1200
-// - BENCH_JSON=1 (emit machine-readable JSON)
+// - DOC_SCENARIOS=compat-path,hybrid-anystore,simple-index,sqlite-index,native-graph,native-block-store,rust-peerbit,rust-peerbit-transient-index
+// - BENCH_JSON=1
 
 const payloadBytes = Math.max(
 	1,
 	Number.parseInt(process.env.DOC_BYTES || "1200", 10) || 1200,
 );
+const warmupIterations = Math.max(
+	0,
+	Number.parseInt(process.env.DOC_WARMUP || "100", 10) || 0,
+);
+const iterations = Math.max(
+	1,
+	Number.parseInt(process.env.DOC_ITERATIONS || "1000", 10) || 1000,
+);
 
-const warmupIterations = Number.parseInt(process.env.DOC_WARMUP || "1000", 10);
-const iterations = process.env.DOC_ITERATIONS
-	? Number.parseInt(process.env.DOC_ITERATIONS, 10)
-	: undefined;
+const scenarioNames = (
+	process.env.DOC_SCENARIOS ||
+	"compat-path,hybrid-anystore,simple-index,sqlite-index,native-graph,native-block-store,rust-peerbit,rust-peerbit-transient-index"
+)
+	.split(",")
+	.map((x) => x.trim())
+	.filter(Boolean);
 
 @variant("document")
 class Document {
@@ -63,23 +77,33 @@ class TestStore extends Program<Partial<SetupOptions<Document>>> {
 	}
 }
 
-const peersCount = 1;
-const session = await TestSession.connected(peersCount);
+type Profile = {
+	serializeMs: number;
+	existingHeadLookupMs: number;
+	sharedAppendMs: number;
+	logAppendMs: number;
+	documentIndexPutMs: number;
+	documentIndexTransformMs: number;
+	documentBackendIndexPutMs: number;
+	totalPutMs: number;
+};
 
-const store = new TestStore({
-	docs: new Documents<Document>(),
-});
+type BenchRow = Profile & {
+	name: string;
+	iterations: number;
+	payloadBytes: number;
+	opsPerSecond: number;
+};
 
-const client: ProgramClient = session.peers[0];
-await client.open(store, {
-	args: {
-		replicate: {
-			factor: 1,
-		},
-		log: {
-			trim: { type: "length" as const, to: 100 },
-		},
-	},
+const emptyProfile = (): Profile => ({
+	serializeMs: 0,
+	existingHeadLookupMs: 0,
+	sharedAppendMs: 0,
+	logAppendMs: 0,
+	documentIndexPutMs: 0,
+	documentIndexTransformMs: 0,
+	documentBackendIndexPutMs: 0,
+	totalPutMs: 0,
 });
 
 const payload = new Uint8Array(payloadBytes);
@@ -88,55 +112,199 @@ for (let i = 0; i < payload.length; i++) {
 }
 
 let idCounter = 0;
-const suite = new Bench({
-	name: "document-put",
-	warmupIterations: Number.isFinite(warmupIterations) ? warmupIterations : 0,
-	iterations:
-		typeof iterations === "number" && Number.isFinite(iterations)
-			? iterations
-			: undefined,
-});
-
-suite.add("put (unique)", async () => {
-	const doc = new Document({
+const createDocument = () =>
+	new Document({
 		id: String(idCounter++),
 		name: "hello",
 		number: 1n,
 		bytes: payload,
 	});
-	await store.docs.put(doc, { unique: true });
-});
 
-try {
-	await suite.run();
-
-	if (process.env.BENCH_JSON === "1") {
-		const tasks = suite.tasks.map((task) => ({
-			name: task.name,
-			hz: task.result?.hz ?? null,
-			mean_ms: task.result?.mean ?? null,
-			rme: task.result?.rme ?? null,
-			samples: task.result?.samples?.length ?? null,
-		}));
-		process.stdout.write(
-			JSON.stringify(
-				{
-					name: suite.name,
-					tasks,
-					meta: {
-						payloadBytes,
-						warmupIterations,
-						iterations: iterations ?? null,
-					},
-				},
-				null,
-				2,
-			),
-		);
-	} else {
-		console.table(suite.table());
+const time = async <T>(
+	profile: Profile,
+	key: keyof Profile,
+	fn: () => Promise<T>,
+): Promise<T> => {
+	const started = performance.now();
+	try {
+		return await fn();
+	} finally {
+		profile[key] += performance.now() - started;
 	}
-} finally {
-	await store.drop();
-	await session.stop();
+};
+
+const patchAsyncMethod = (
+	target: any,
+	key: string,
+	profile: Profile,
+	profileKey: keyof Profile,
+) => {
+	const original = target[key];
+	target[key] = async function patched(this: unknown, ...args: unknown[]) {
+		return time(profile, profileKey, () => original.apply(this, args));
+	};
+	return () => {
+		target[key] = original;
+	};
+};
+
+const openScenario = async (name: string) => {
+	const rustOptions =
+		name === "native-block-store" ||
+		name === "rust-peerbit" ||
+		name === "rust-peerbit-transient-index"
+			? createRustPeerbitOptions()
+			: undefined;
+	const session = await TestSession.connected(1, {
+		...(rustOptions ? { storage: rustOptions.storage } : {}),
+		indexer:
+			name === "simple-index"
+				? createSimpleIndexer
+				: name === "sqlite-index"
+					? createSqliteIndexer
+					: name === "rust-peerbit"
+						? rustOptions?.indexer
+						: name === "rust-peerbit-transient-index"
+							? () => rustOptions!.indexer(undefined)
+						: undefined,
+	});
+	const store = new TestStore({
+		docs: new Documents<Document>(),
+	});
+	const client: ProgramClient = session.peers[0];
+	await client.open(store, {
+		args: {
+			replicate: {
+				factor: 1,
+			},
+			nativeGraph:
+				name === "native-graph" ||
+				name === "rust-peerbit" ||
+				name === "rust-peerbit-transient-index",
+			log: {
+				trim: { type: "length" as const, to: 100 },
+			},
+		},
+	});
+	return { session, store };
+};
+
+const runPuts = async (
+	store: TestStore,
+	count: number,
+	scenario: string,
+	profile?: Profile,
+) => {
+	const canAppend = () => true;
+	const appendOptions = {
+		unique: true,
+		replicate: false,
+		target: "none" as const,
+		...(scenario === "compat-path" ? { canAppend } : {}),
+	};
+	for (let i = 0; i < count; i++) {
+		const doc = createDocument();
+		if (profile) {
+			await time(profile, "totalPutMs", () =>
+				store.docs.put(doc, appendOptions),
+			);
+		} else {
+			await store.docs.put(doc, appendOptions);
+		}
+	}
+};
+
+const runScenario = async (name: string): Promise<BenchRow> => {
+	const { session, store } = await openScenario(name);
+	try {
+		await runPuts(store, warmupIterations, name);
+
+		const profile = emptyProfile();
+		const restores = [
+			patchAsyncMethod(
+				store.docs as any,
+				"getLocalIndexedContext",
+				profile,
+				"existingHeadLookupMs",
+			),
+			patchAsyncMethod(store.docs.log, "append", profile, "sharedAppendMs"),
+			patchAsyncMethod(
+				store.docs.log,
+				"appendLocallyValidated",
+				profile,
+				"sharedAppendMs",
+			),
+			patchAsyncMethod(store.docs.log.log, "append", profile, "logAppendMs"),
+			patchAsyncMethod(
+				store.docs.index,
+				"transformer",
+				profile,
+				"documentIndexTransformMs",
+			),
+			patchAsyncMethod(
+				store.docs.index.index,
+				"put",
+				profile,
+				"documentBackendIndexPutMs",
+			),
+			patchAsyncMethod(store.docs.index, "put", profile, "documentIndexPutMs"),
+		];
+
+		const serializeStarted = performance.now();
+		for (let i = 0; i < iterations; i++) {
+			serialize(createDocument());
+		}
+		profile.serializeMs = performance.now() - serializeStarted;
+
+		try {
+			await runPuts(store, iterations, name, profile);
+		} finally {
+			for (const restore of restores.reverse()) {
+				restore();
+			}
+		}
+
+		return {
+			name,
+			iterations,
+			payloadBytes,
+			opsPerSecond: Math.round((iterations / profile.totalPutMs) * 1000),
+			...Object.fromEntries(
+				Object.entries(profile).map(([key, value]) => [
+					key,
+					Math.round(value * 100) / 100,
+				]),
+			),
+		} as BenchRow;
+	} finally {
+		await store.drop();
+		await session.stop();
+	}
+};
+
+const rows: BenchRow[] = [];
+for (const name of scenarioNames) {
+	rows.push(await runScenario(name));
 }
+
+if (process.env.BENCH_JSON === "1") {
+	process.stdout.write(
+		JSON.stringify(
+			{
+				name: "document-put",
+				rows,
+				meta: {
+					payloadBytes,
+					warmupIterations,
+					iterations,
+				},
+			},
+			null,
+			2,
+		),
+	);
+} else {
+	console.table(rows);
+}
+
+process.exit(process.exitCode ?? 0);

--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -641,6 +641,13 @@ export class Documents<
 			});
 		}
 
+		if (
+			operation instanceof PutOperation &&
+			this.canUsePlainPutFastPath(options)
+		) {
+			return this.putPlainFastPath(doc, operation, existingHead, options);
+		}
+
 		const appended = await this.log.append(operation, {
 			...options,
 			meta: {
@@ -651,10 +658,70 @@ export class Documents<
 				return this.canAppend(entry, { document: doc, operation });
 			},
 			onChange: (change) => {
-				return this.handleChanges(change, { document: doc, operation });
+				return this.handleChanges(change, {
+					document: doc,
+					operation,
+					unique: options?.unique,
+				});
 			},
 			replicate: options?.replicate,
 		});
+		this.keepCache?.add(appended.entry.hash);
+		return appended;
+	}
+
+	private canUsePlainPutFastPath(
+		options?: SharedAppendOptions<Operation> & {
+			unique?: boolean;
+			replicate?: boolean;
+			checkRemote?: boolean;
+		},
+	): boolean {
+		return (
+			!this._optionCanPerform &&
+			!this.immutable &&
+			!this.strictHistory &&
+			this.compatibility !== 6 &&
+			!Program.isPrototypeOf(this._clazz) &&
+			!options?.canAppend &&
+			!options?.onChange &&
+			!options?.signers &&
+			!options?.identity &&
+			!options?.encryption &&
+			!options?.trim &&
+			!options?.meta?.type &&
+			!options?.meta?.next &&
+			!options?.meta?.timestamp
+		);
+	}
+
+	private async putPlainFastPath(
+		doc: T,
+		operation: PutOperation,
+		existingHead: string | undefined,
+		options:
+			| (SharedAppendOptions<Operation> & {
+					unique?: boolean;
+					replicate?: boolean;
+					checkRemote?: boolean;
+			  })
+			| undefined,
+	) {
+		const appended = await this.log.appendLocallyValidated(operation, {
+			...options,
+			meta: {
+				next: existingHead ? [await this._resolveEntry(existingHead)] : [],
+				...options?.meta,
+			},
+			replicate: options?.replicate,
+		});
+		await this.handleChanges(
+			{
+				added: [{ head: true, entry: appended.entry }],
+				removed: appended.removed,
+			},
+			{ document: doc, operation, unique: options?.unique },
+		);
 		this.keepCache?.add(appended.entry.hash);
 		return appended;
 	}
@@ -749,16 +816,19 @@ export class Documents<
 			}
 
 			try {
-				const payload =
-					/* item._payload instanceof DecryptedThing
-						? item.payload.getValue(item.encoding)
-						:  */ await item.getPayloadValue(); // TODO implement sync api for resolving entries that does not deep decryption
+				const isReferencedAppendEntry =
+					isAppendOperation &&
+					reference?.operation &&
+					change.added[0]?.entry.hash === item.hash;
+				const payload = isReferencedAppendEntry
+					? reference.operation
+					: /* item._payload instanceof DecryptedThing
+							? item.payload.getValue(item.encoding)
+							:  */ await item.getPayloadValue(); // TODO implement sync api for resolving entries that does not deep decryption
 
 				if (isPutOperation(payload) && !removedSet.has(item.hash)) {
 					let value =
-						(isAppendOperation &&
-							reference?.operation === payload &&
-							reference?.document) ||
+						(isReferencedAppendEntry && reference?.document) ||
 						this.index.valueEncoding.decoder(payload.data);
 
 					// get index key from value

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -685,6 +685,7 @@ export class DocumentIndex<
 
 	// transform options
 	transformer: Transformer<T, I>;
+	private transformerIsIdentity = false;
 
 	// The indexed document wrapped in a context
 	wrappedIndexedType: IndexableClass<I>;
@@ -1085,8 +1086,13 @@ export class DocumentIndex<
 		};
 
 		const transformOptions = properties.transform;
+		const hasTransformFunction =
+			transformOptions != null && isTransformerWithFunction(transformOptions);
+		this.transformerIsIdentity =
+			transformOptions == null ||
+			(!hasTransformFunction && transformOptions.type == null);
 		this.transformer = transformOptions
-			? isTransformerWithFunction(transformOptions)
+			? hasTransformFunction
 				? (obj, context) => transformOptions.transform(obj, context)
 				: transformOptions.type
 					? (obj, context) => new transformOptions.type!(obj, context)
@@ -1678,7 +1684,9 @@ export class DocumentIndex<
 				indexCacheLogger("cache:set:value", { id: idString });
 			}
 		}
-		const valueToIndex = await this.transformer(value, context);
+		const valueToIndex = this.transformerIsIdentity
+			? (value as any as I)
+			: await this.transformer(value, context);
 		const wrappedValueToIndex = new this.wrappedIndexedType(
 			valueToIndex as I,
 			context,
@@ -1689,7 +1697,7 @@ export class DocumentIndex<
 		coerceWithContext(value, context);
 
 		try {
-			await this.index.put(wrappedValueToIndex, undefined, options);
+			await this.index.put(wrappedValueToIndex, id, options);
 		} catch (error) {
 			if (error instanceof indexerTypes.NotStartedError && this.closed) {
 				return { context, indexable: valueToIndex };

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -164,6 +164,125 @@ describe("index", () => {
 				expect(changes[2].removed[0].__indexed).to.exist;
 			});
 
+			it("uses the validated local append path for plain puts", async () => {
+				store = new TestStore({
+					docs: new Documents<Document>(),
+				});
+				await session.peers[0].open(store, {
+					args: {
+						replicate: false,
+					},
+				});
+				const changes: DocumentsChange<Document, Document>[] = [];
+				store.docs.events.addEventListener("change", (evt) => {
+					changes.push(evt.detail);
+				});
+				const validatedAppendSpy = sinon.spy(
+					store.docs.log,
+					"appendLocallyValidated",
+				);
+				const appendSpy = sinon.spy(store.docs.log, "append");
+				const localLookupSpy = sinon.spy(
+					store.docs as any,
+					"getLocalIndexedContext",
+				);
+
+				try {
+					const doc = new Document({ id: uuid(), name: "fast" });
+					const put = await store.docs.put(doc, {
+						unique: true,
+						replicate: false,
+						target: "none",
+					});
+
+					expect(validatedAppendSpy.callCount).equal(1);
+					expect(appendSpy.callCount).equal(0);
+					expect(localLookupSpy.callCount).equal(0);
+					expect((await store.docs.get(doc.id))?.name).equal("fast");
+					expect(changes).to.have.length(1);
+					expect(changes[0].added[0].__context.head).equal(put.entry.hash);
+				} finally {
+					localLookupSpy.restore();
+					validatedAppendSpy.restore();
+					appendSpy.restore();
+				}
+			});
+
+			it("uses the validated local append path for document updates", async () => {
+				store = new TestStore({
+					docs: new Documents<Document>(),
+				});
+				await session.peers[0].open(store, {
+					args: {
+						replicate: false,
+					},
+				});
+				const validatedAppendSpy = sinon.spy(
+					store.docs.log,
+					"appendLocallyValidated",
+				);
+				const appendSpy = sinon.spy(store.docs.log, "append");
+
+				try {
+					const id = uuid();
+					const first = await store.docs.put(
+						new Document({ id, name: "first" }),
+						{
+							replicate: false,
+							target: "none",
+						},
+					);
+					const second = await store.docs.put(
+						new Document({ id, name: "second" }),
+						{
+							replicate: false,
+							target: "none",
+						},
+					);
+
+					expect(validatedAppendSpy.callCount).equal(2);
+					expect(appendSpy.callCount).equal(0);
+					expect(second.entry.meta.next).to.deep.equal([first.entry.hash]);
+					expect((await store.docs.get(id))?.name).equal("second");
+				} finally {
+					validatedAppendSpy.restore();
+					appendSpy.restore();
+				}
+			});
+
+			it("keeps custom canPerform puts on the compatibility path", async () => {
+				store = new TestStore({
+					docs: new Documents<Document>(),
+				});
+				const canPerform = sinon.stub().returns(true);
+				await session.peers[0].open(store, {
+					args: {
+						replicate: false,
+						canPerform,
+					},
+				});
+				const validatedAppendSpy = sinon.spy(
+					store.docs.log,
+					"appendLocallyValidated",
+				);
+				const appendSpy = sinon.spy(store.docs.log, "append");
+
+				try {
+					await store.docs.put(new Document({ id: uuid(), name: "compat" }), {
+						unique: true,
+						replicate: false,
+						target: "none",
+					});
+
+					expect(validatedAppendSpy.callCount).equal(0);
+					expect(appendSpy.callCount).equal(1);
+					expect(canPerform.callCount).equal(1);
+				} finally {
+					validatedAppendSpy.restore();
+					appendSpy.restore();
+				}
+			});
+
 			it("replication degree", async () => {
 				store = new TestStore({
 					docs: new Documents<Document>(),

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -3937,6 +3937,34 @@ export class SharedLog<
 		return result;
 	}
 
+	/** Trusted local append path for callers that already validated the entry. */
+	async appendLocallyValidated(
+		data: T,
+		options?: SharedAppendOptions<T> | undefined,
+	): Promise<{
+		entry: Entry<T>;
+		removed: ShallowOrFullEntry<T>[];
+	}> {
+		if (options?.canAppend || options?.onChange) {
+			throw new Error(
+				"appendLocallyValidated does not accept canAppend or onChange hooks",
+			);
+		}
+		if (this._isAdaptiveReplicating) {
+			this.markLocalAppendActivity();
+		}
+
+		const { appendOptions, minReplicasValue } =
+			this.createLogAppendOptions(options);
+		appendOptions.__peerbitCanAppendAlreadyValidated = true;
+		appendOptions.onChange = (change) => this.onChange(change);
+		const result = await this.log.append(data, appendOptions);
+		await this.processLocalAppend(result.entry, result.removed, options, {
+			minReplicasValue,
+		});
+		return result;
+	}
+
 	async appendMany(
 		data: T[],
 		options?: SharedAppendOptions<T> | undefined,

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -18,6 +18,13 @@ import {
 
 export type RustIndexerOptions = {
 	persistence?: PersistenceOptions;
+	/**
+	 * Byte fields always support exact ByteMatch queries. Individual byte facts are
+	 * only indexed up to this length to avoid exploding large blob-like fields.
+	 * Defaults to 0, which disables per-byte facts while preserving exact byte
+	 * matching.
+	 */
+	byteElementIndexLimit?: number;
 };
 
 type NativeRustIndex<T extends Record<string, any>> = {
@@ -110,6 +117,7 @@ type NativeCandidatePage = {
 
 const BRIDGE_VERSION = 1;
 const DEFAULT_JOURNAL_COMPACT_AFTER_OPERATIONS = 64 * 1024;
+const DEFAULT_BYTE_ELEMENT_INDEX_LIMIT = 0;
 
 // Keep bridge enum tags in sync with the Rust Borsh DTO declaration order.
 const enum NativeValueTag {
@@ -635,6 +643,7 @@ const writeNativeBytesFacts = (
 	scope: number,
 	fieldId: number,
 	value: any,
+	byteElementIndexLimit: number,
 ): void => {
 	if (!(value instanceof Uint8Array || ArrayBuffer.isView(value))) {
 		return;
@@ -644,6 +653,9 @@ const writeNativeBytesFacts = (
 			? value
 			: new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
 	writer.writeString(scope, fieldId, bytesToNativeString(bytes));
+	if (bytes.byteLength > byteElementIndexLimit) {
+		return;
+	}
 	for (const byte of bytes) {
 		writer.writeU64(state.nextScope++, fieldId, byte);
 	}
@@ -656,10 +668,18 @@ const writeNativeFieldsGeneric = (
 	writer: NativeFieldWriter,
 	state: NativeFactCollectorState,
 	scope: number,
+	byteElementIndexLimit: number,
 ): void => {
 	if (value instanceof Uint8Array || ArrayBuffer.isView(value)) {
 		if (cursor) {
-			writeNativeBytesFacts(writer, state, scope, cursor.fieldId, value);
+			writeNativeBytesFacts(
+				writer,
+				state,
+				scope,
+				cursor.fieldId,
+				value,
+				byteElementIndexLimit,
+			);
 		}
 		return;
 	}
@@ -689,7 +709,15 @@ const writeNativeFieldsGeneric = (
 			if (cursor) {
 				writer.writeBool(itemScope, cursor.arrayFieldId, true);
 			}
-			writeNativeFieldsGeneric(item, cursor, dictionary, writer, state, itemScope);
+			writeNativeFieldsGeneric(
+				item,
+				cursor,
+				dictionary,
+				writer,
+				state,
+				itemScope,
+				byteElementIndexLimit,
+			);
 		}
 		return;
 	}
@@ -705,6 +733,7 @@ const writeNativeFieldsGeneric = (
 			writer,
 			state,
 			scope,
+			byteElementIndexLimit,
 		);
 	}
 };
@@ -712,6 +741,7 @@ const writeNativeFieldsGeneric = (
 const encodeNativeFieldsGeneric = <T extends Record<string, any>>(
 	value: T,
 	dictionary: NativeFieldDictionary,
+	byteElementIndexLimit: number,
 ): Uint8Array => {
 	const writer = new NativeFieldWriter();
 	writeNativeFieldsGeneric(
@@ -721,6 +751,7 @@ const encodeNativeFieldsGeneric = <T extends Record<string, any>>(
 		writer,
 		{ nextScope: 1 },
 		0,
+		byteElementIndexLimit,
 	);
 	return writer.finish();
 };
@@ -742,7 +773,10 @@ const integerFieldTypes = new Set([
 const compileNativeFieldEncoder = <T extends Record<string, any>>(
 	schema: Function,
 	dictionary: NativeFieldDictionary,
+	options: RustIndexerOptions,
 ): NativeFieldEncoder<T> => {
+	const byteElementIndexLimit =
+		options.byteElementIndexLimit ?? DEFAULT_BYTE_ELEMENT_INDEX_LIMIT;
 	const objectWriterCache = new WeakMap<
 		Function,
 		Map<string, NativeFieldValueWriter | undefined>
@@ -788,6 +822,7 @@ const compileNativeFieldEncoder = <T extends Record<string, any>>(
 						appendNativeFieldCursor(dictionary, cursor, field.key),
 						getObjectWriter,
 						dictionary,
+						byteElementIndexLimit,
 					),
 				});
 			}
@@ -811,7 +846,8 @@ const compileNativeFieldEncoder = <T extends Record<string, any>>(
 
 	const rootWriter = getObjectWriter(schema, undefined);
 	if (!rootWriter) {
-		return (value: T) => encodeNativeFieldsGeneric(value, dictionary);
+		return (value: T) =>
+			encodeNativeFieldsGeneric(value, dictionary, byteElementIndexLimit);
 	}
 
 	return (value: T) => {
@@ -829,6 +865,7 @@ const compileFieldValueWriter = (
 		cursor: NativeFieldCursor | undefined,
 	) => NativeFieldValueWriter | undefined,
 	dictionary: NativeFieldDictionary,
+	byteElementIndexLimit: number,
 ): NativeFieldValueWriter => {
 	if (fieldType instanceof OptionKind) {
 		const writeElement = compileFieldValueWriter(
@@ -836,6 +873,7 @@ const compileFieldValueWriter = (
 			cursor,
 			getObjectWriter,
 			dictionary,
+			byteElementIndexLimit,
 		);
 		return nativeFieldValueWriter((value, writer, state, scope) => {
 			if (value != null) {
@@ -847,7 +885,14 @@ const compileFieldValueWriter = (
 	if (fieldType instanceof VecKind || fieldType instanceof FixedArrayKind) {
 		if (fieldType.elementType === "u8") {
 			return nativeFieldValueWriter((value, writer, state, scope) =>
-				writeNativeBytesFacts(writer, state, scope, cursor.fieldId, value),
+				writeNativeBytesFacts(
+					writer,
+					state,
+					scope,
+					cursor.fieldId,
+					value,
+					byteElementIndexLimit,
+				),
 			);
 		}
 		const writeElement = compileFieldValueWriter(
@@ -855,6 +900,7 @@ const compileFieldValueWriter = (
 			cursor,
 			getObjectWriter,
 			dictionary,
+			byteElementIndexLimit,
 		);
 		return nativeFieldValueWriter((value, writer, state, scope) => {
 			if (!Array.isArray(value)) {
@@ -873,7 +919,14 @@ const compileFieldValueWriter = (
 
 	if (fieldType === Uint8Array) {
 		return nativeFieldValueWriter((value, writer, state, scope) =>
-			writeNativeBytesFacts(writer, state, scope, cursor.fieldId, value),
+			writeNativeBytesFacts(
+				writer,
+				state,
+				scope,
+				cursor.fieldId,
+				value,
+				byteElementIndexLimit,
+			),
 		);
 	}
 
@@ -927,14 +980,30 @@ const compileFieldValueWriter = (
 			if (objectWriter) {
 				objectWriter(value, writer, state, scope);
 			} else {
-				writeNativeFieldsGeneric(value, cursor, dictionary, writer, state, scope);
+				writeNativeFieldsGeneric(
+					value,
+					cursor,
+					dictionary,
+					writer,
+					state,
+					scope,
+					byteElementIndexLimit,
+				);
 			}
 		}, true);
 	}
 
 	return nativeFieldValueWriter(
 		(value, writer, state, scope) =>
-			writeNativeFieldsGeneric(value, cursor, dictionary, writer, state, scope),
+			writeNativeFieldsGeneric(
+				value,
+				cursor,
+				dictionary,
+				writer,
+				state,
+				scope,
+				byteElementIndexLimit,
+			),
 		true,
 	);
 };
@@ -1161,6 +1230,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		this.fieldEncoder = compileNativeFieldEncoder(
 			properties.schema,
 			this.fieldDictionary,
+			this.options,
 		);
 		this.snapshotFile = await createSnapshotFile(
 			this.directory,

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -1,6 +1,7 @@
 import { field, vec } from "@dao-xyz/borsh";
 import {
 	And,
+	ByteMatchQuery,
 	Compare,
 	IntegerCompare,
 	Nested,
@@ -59,6 +60,19 @@ class BridgeMetricDocument {
 		this.id = id;
 		this.tag = tag;
 		this.value = value;
+	}
+}
+
+class BridgeBytesDocument {
+	@id({ type: "string" })
+	id: string;
+
+	@field({ type: Uint8Array })
+	payload: Uint8Array;
+
+	constructor(id: string, payload: Uint8Array) {
+		this.id = id;
+		this.payload = payload;
 	}
 }
 
@@ -201,6 +215,97 @@ describe("native planner bridge", () => {
 			})
 			.all();
 		expect(results.map((result) => result.value.id)).to.deep.equal(["a", "b"]);
+
+		await indices.drop();
+	});
+
+	it("keeps exact byte matching for large byte arrays without indexing every byte by default", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeBytesDocument });
+		const payload = new Uint8Array(300).fill(7);
+		await index.put(new BridgeBytesDocument("large", payload));
+
+		const exactMatches = await index
+			.iterate({
+				query: new ByteMatchQuery({
+					key: "payload",
+					value: payload,
+				}),
+			})
+			.all();
+		expect(exactMatches.map((result) => result.value.id)).to.deep.equal([
+			"large",
+		]);
+
+		const byteElementMatches = await index
+			.iterate({
+				query: new IntegerCompare({
+					key: "payload",
+					compare: Compare.Equal,
+					value: 7,
+				}),
+			})
+			.all();
+		expect(byteElementMatches).to.be.empty;
+
+		await indices.drop();
+	});
+
+	it("can opt into per-byte indexing for large byte arrays", async () => {
+		const indices = create(undefined, {
+			byteElementIndexLimit: Number.POSITIVE_INFINITY,
+		});
+		await indices.start();
+		const index = await indices.init({ schema: BridgeBytesDocument });
+		const payload = new Uint8Array(300).fill(7);
+		await index.put(new BridgeBytesDocument("large", payload));
+
+		const byteElementMatches = await index
+			.iterate({
+				query: new IntegerCompare({
+					key: "payload",
+					compare: Compare.Equal,
+					value: 7,
+				}),
+			})
+			.all();
+		expect(byteElementMatches.map((result) => result.value.id)).to.deep.equal([
+			"large",
+		]);
+
+		await indices.drop();
+	});
+
+	it("can opt out of per-byte indexing while keeping exact byte matching", async () => {
+		const indices = create(undefined, { byteElementIndexLimit: 0 });
+		await indices.start();
+		const index = await indices.init({ schema: BridgeBytesDocument });
+		const payload = new Uint8Array([7]);
+		await index.put(new BridgeBytesDocument("small", payload));
+
+		const exactMatches = await index
+			.iterate({
+				query: new ByteMatchQuery({
+					key: "payload",
+					value: payload,
+				}),
+			})
+			.all();
+		expect(exactMatches.map((result) => result.value.id)).to.deep.equal([
+			"small",
+		]);
+
+		const byteElementMatches = await index
+			.iterate({
+				query: new IntegerCompare({
+					key: "payload",
+					compare: Compare.Equal,
+					value: 7,
+				}),
+			})
+			.all();
+		expect(byteElementMatches).to.be.empty;
 
 		await indices.drop();
 	});

--- a/packages/utils/indexer/tests/src/tests.ts
+++ b/packages/utils/indexer/tests/src/tests.ts
@@ -756,40 +756,6 @@ export const tests = (
 								expect(responses).to.be.empty;
 							});
 						});
-						describe("integer", () => {
-							it("exists", async () => {
-								await setupDefault();
-
-								const responses = await search(store, {
-									query: [
-										new IntegerCompare({
-											key: "data",
-											compare: Compare.Equal,
-											value: 1,
-										}),
-									],
-								});
-								expect(responses).to.have.length(1);
-								expect(responses.map((x) => x.id.primitive)).to.deep.equal([
-									"1",
-								]);
-							});
-
-							it("does not exist", async () => {
-								await setupDefault();
-
-								const responses = await search(store, {
-									query: [
-										new IntegerCompare({
-											key: "data",
-											compare: Compare.Equal,
-											value: 199,
-										}),
-									],
-								});
-								expect(responses).to.be.empty;
-							});
-						});
 					});
 
 					describe("fixed", () => {
@@ -818,40 +784,6 @@ export const tests = (
 										new ByteMatchQuery({
 											key: "data",
 											value: new Uint8Array(32).fill(99),
-										}),
-									],
-								});
-								expect(responses).to.be.empty;
-							});
-						});
-						describe("integer", () => {
-							it("exists", async () => {
-								await setupDefault();
-
-								const responses = await search(store, {
-									query: [
-										new IntegerCompare({
-											key: "data",
-											compare: Compare.Equal,
-											value: 1,
-										}),
-									],
-								});
-								expect(responses).to.have.length(1);
-								expect(responses.map((x) => x.id.primitive)).to.deep.equal([
-									"1",
-								]);
-							});
-
-							it("does not exist", async () => {
-								await setupDefault();
-
-								const responses = await search(store, {
-									query: [
-										new IntegerCompare({
-											key: "data",
-											compare: Compare.Equal,
-											value: 199,
 										}),
 									],
 								});


### PR DESCRIPTION
## Summary
- add a trusted local append path through shared-log/log for entries already validated by Peerbit internals
- route eligible plain local `Documents.put()` calls through that path and explicitly update the document index/change events after commit
- remove extra local-put overhead by propagating `unique`, reusing the known local `PutOperation`, passing the precomputed document id into the index backend, and skipping the async identity transformer
- make Rust byte-element indexing opt-in: `Uint8Array` fields still support exact `ByteMatchQuery` by default, but per-byte `IntegerCompare` facts are no longer written unless `byteElementIndexLimit` is set above `0`
- update shared indexer conformance so `Uint8Array` requires exact byte matching, not byte-element `IntegerCompare` semantics
- keep compatibility fallback for custom `canPerform`, per-call append hooks, strict/immutable/legacy/encrypted/signed/trimmed/program-valued cases
- replace the document-put benchmark with staged profiling rows for compat, AnyStore, SQLite, native graph, native block store, and full Rust Peerbit options

## Benchmarks
Command:
`DOC_WARMUP=20 DOC_ITERATIONS=200 DOC_SCENARIOS=compat-path,hybrid-anystore,simple-index,sqlite-index,native-graph,native-block-store,rust-peerbit,rust-peerbit-transient-index BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts`

Local node results, 1200-byte docs, latest run:
- compat-path: 895 ops/sec; total 223.4 ms; document index put 5.95 ms
- hybrid-anystore: 965 ops/sec; total 207.36 ms; document index put 4.87 ms
- simple-index: 2703 ops/sec; total 73.99 ms; document index put 0.76 ms
- sqlite-index: 1075 ops/sec; total 186.05 ms; document index put 4.25 ms
- native-graph: 1079 ops/sec; total 185.35 ms; document index put 4.19 ms
- native-block-store: 1104 ops/sec; total 181.2 ms; document index put 4.05 ms
- rust-peerbit: 1511 ops/sec; total 132.37 ms; document index put 11.01 ms
- rust-peerbit-transient-index: 1280 ops/sec; total 156.19 ms; document index put 13.55 ms

The first profiler pass showed `rust-peerbit` was spending about 66-68 ms per 200 puts inside backend document index writes. Making byte-element facts opt-in drops that backend index cost to about 10-12 ms per 200 puts while exact byte matching still works.

## Test Plan
- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `pnpm --filter @peerbit/indexer-tests run build`
- `pnpm --filter @peerbit/indexer-rust test`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "validated local append path|custom canPerform puts"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "can add and delete|can use different acl on load|reject entries with unexpected payloads|does not query remote when canAppend check"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/utils/indexer/rust -- -t node --grep "large byte arrays|per-byte indexing|opt out of per-byte"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/utils/indexer/rust -- -t node --grep "uint8arrays"`
- `pnpm exec eslint --config eslint.config.js packages/log/src/log.ts packages/programs/data/shared-log/src/index.ts packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/src/search.ts packages/programs/data/document/document/test/index.spec.ts packages/programs/data/document/document/benchmark/document-put.ts packages/utils/indexer/rust/src/index.ts packages/utils/indexer/rust/test/index.spec.ts packages/utils/indexer/tests/src/tests.ts`
