### PR TITLE
feat: reuse document put index context

### DIFF
--- a/packages/programs/data/document/document/benchmark/document-put.ts
+++ b/packages/programs/data/document/document/benchmark/document-put.ts
@@ -15,6 +15,7 @@ import { Documents, type SetupOptions } from "../src/program.js";
 // - DOC_ITERATIONS=1000
 // - DOC_BYTES=1200
 // - DOC_SCENARIOS=compat-path,hybrid-anystore,simple-index,sqlite-index,native-graph,native-block-store,rust-peerbit,rust-peerbit-transient-index
+//   Add "-nonunique" to any scenario name to use default update-safe put semantics.
 // - BENCH_JSON=1
 
 const payloadBytes = Math.max(
@@ -37,6 +38,9 @@ const scenarioNames = (
 	.split(",")
 	.map((x) => x.trim())
 	.filter(Boolean);
+
+const scenarioBaseName = (name: string) => name.replace(/-nonunique$/, "");
+const scenarioUsesUniquePuts = (name: string) => !name.endsWith("-nonunique");
 
 @variant("document")
 class Document {
@@ -149,22 +153,23 @@ const patchAsyncMethod = (
 };
 
 const openScenario = async (name: string) => {
+	const baseName = scenarioBaseName(name);
 	const rustOptions =
-		name === "native-block-store" ||
-		name === "rust-peerbit" ||
-		name === "rust-peerbit-transient-index"
+		baseName === "native-block-store" ||
+		baseName === "rust-peerbit" ||
+		baseName === "rust-peerbit-transient-index"
 			? createRustPeerbitOptions()
 			: undefined;
 	const session = await TestSession.connected(1, {
 		...(rustOptions ? { storage: rustOptions.storage } : {}),
 		indexer:
-			name === "simple-index"
+			baseName === "simple-index"
 				? createSimpleIndexer
-				: name === "sqlite-index"
+				: baseName === "sqlite-index"
 					? createSqliteIndexer
-					: name === "rust-peerbit"
+					: baseName === "rust-peerbit"
 						? rustOptions?.indexer
-						: name === "rust-peerbit-transient-index"
+						: baseName === "rust-peerbit-transient-index"
 							? () => rustOptions!.indexer(undefined)
 						: undefined,
 	});
@@ -178,9 +183,9 @@ const openScenario = async (name: string) => {
 				factor: 1,
 			},
 			nativeGraph:
-				name === "native-graph" ||
-				name === "rust-peerbit" ||
-				name === "rust-peerbit-transient-index",
+				baseName === "native-graph" ||
+				baseName === "rust-peerbit" ||
+				baseName === "rust-peerbit-transient-index",
 			log: {
 				trim: { type: "length" as const, to: 100 },
 			},
@@ -197,10 +202,10 @@ const runPuts = async (
 ) => {
 	const canAppend = () => true;
 	const appendOptions = {
-		unique: true,
 		replicate: false,
 		target: "none" as const,
-		...(scenario === "compat-path" ? { canAppend } : {}),
+		...(scenarioUsesUniquePuts(scenario) ? { unique: true } : {}),
+		...(scenarioBaseName(scenario) === "compat-path" ? { canAppend } : {}),
 	};
 	for (let i = 0; i < count; i++) {
 		const doc = createDocument();

--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -101,6 +101,16 @@ export type CanPerform<T> = (
 	properties: CanPerformOperations<T>,
 ) => MaybePromise<boolean>;
 
+type PutChangeReference<T, I extends Record<string, any>> = {
+	document: T;
+	operation: PutOperation;
+	unique?: boolean;
+	existing?:
+		| indexerTypes.IndexedResult<IndexedContextOnly<I>>
+		| null
+		| undefined;
+};
+
 type InferR<D> = D extends ReplicationDomain<any, any, infer I> ? I : "u32";
 
 export type SetupOptions<
@@ -612,18 +622,27 @@ export class Documents<
 			);
 		}
 
-		const existingHead = options?.unique
-			? undefined
-			: options?.checkRemote
-				? (
-						await this._index.getDetailed(keyValue, {
-							resolve: false,
-							local: true,
-							remote: { replicate: options?.replicate },
-						})
-					)?.[0]?.results[0]?.context.head
-				: (await this.getLocalIndexedContext(indexerTypes.toId(keyValue)))
-						?.value.__context.head;
+		const key = indexerTypes.toId(keyValue);
+		let existingLocalContext:
+			| indexerTypes.IndexedResult<IndexedContextOnly<I>>
+			| null
+			| undefined;
+		let existingHead: string | undefined;
+		if (!options?.unique) {
+			if (options?.checkRemote) {
+				existingHead = (
+					await this._index.getDetailed(keyValue, {
+						resolve: false,
+						local: true,
+						remote: { replicate: options?.replicate },
+					})
+				)?.[0]?.results[0]?.context.head;
+			} else {
+				existingLocalContext =
+					(await this.getLocalIndexedContext(key)) || null;
+				existingHead = existingLocalContext?.value.__context.head;
+			}
+		}
 
 		let operation: PutOperation | PutWithKeyOperation;
 		if (this.compatibility === 6) {
@@ -645,7 +664,13 @@ export class Documents<
 			operation instanceof PutOperation &&
 			this.canUsePlainPutFastPath(options)
 		) {
-			return this.putPlainFastPath(doc, operation, existingHead, options);
+			return this.putPlainFastPath(
+				doc,
+				operation,
+				existingHead,
+				existingLocalContext,
+				options,
+			);
 		}
 
 		const appended = await this.log.append(operation, {
@@ -662,6 +687,7 @@ export class Documents<
 					document: doc,
 					operation,
 					unique: options?.unique,
+					existing: existingLocalContext,
 				});
 			},
 			replicate: options?.replicate,
@@ -699,6 +725,10 @@ export class Documents<
 		doc: T,
 		operation: PutOperation,
 		existingHead: string | undefined,
+		existingLocalContext:
+			| indexerTypes.IndexedResult<IndexedContextOnly<I>>
+			| null
+			| undefined,
 		options:
 			| (SharedAppendOptions<Operation> & {
 					unique?: boolean;
@@ -720,7 +750,12 @@ export class Documents<
 				added: [{ head: true, entry: appended.entry }],
 				removed: appended.removed,
 			},
-			{ document: doc, operation, unique: options?.unique },
+			{
+				document: doc,
+				operation,
+				unique: options?.unique,
+				existing: existingLocalContext,
+			},
 		);
 		this.keepCache?.add(appended.entry.hash);
 		return appended;
@@ -778,7 +813,7 @@ export class Documents<
 
 	async handleChanges(
 		change: Change<Operation>,
-		reference?: { document: T; operation: PutOperation; unique?: boolean },
+		reference?: PutChangeReference<T, I>,
 	): Promise<void> {
 		logger.trace("handleChanges called", change);
 		const isAppendOperation =
@@ -841,9 +876,12 @@ export class Documents<
 					}
 
 					// if no casual ordering is used, use timestamps to order docs
-					let existing = reference?.unique
-						? null
-						: (await this.getLocalIndexedContext(key)) || null;
+					let existing =
+						reference?.unique || reference?.existing === null
+							? null
+							: isReferencedAppendEntry && reference?.existing !== undefined
+								? reference.existing
+								: (await this.getLocalIndexedContext(key)) || null;
 					if (!this.strictHistory && existing) {
 						// if immutable use oldest, else use newest
 						let shouldIgnoreChange = this.immutable

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -222,6 +222,10 @@ describe("index", () => {
 					"appendLocallyValidated",
 				);
 				const appendSpy = sinon.spy(store.docs.log, "append");
+				const localLookupSpy = sinon.spy(
+					store.docs as any,
+					"getLocalIndexedContext",
+				);
 
 				try {
 					const id = uuid();
@@ -242,9 +246,11 @@ describe("index", () => {
 
 					expect(validatedAppendSpy.callCount).equal(2);
 					expect(appendSpy.callCount).equal(0);
+					expect(localLookupSpy.callCount).equal(2);
 					expect(second.entry.meta.next).to.deep.equal([first.entry.hash]);
 					expect((await store.docs.get(id))?.name).equal("second");
 				} finally {
+					localLookupSpy.restore();
 					validatedAppendSpy.restore();
 					appendSpy.restore();
 				}


### PR DESCRIPTION
## Summary
- reuse the local indexed context already fetched by `Documents.put()` for non-unique local writes
- avoid the duplicate post-append `getLocalIndexedContext()` lookup during document change indexing
- extend the document-put benchmark so any scenario can add `-nonunique` to measure default update-safe put semantics

This is stacked on #861 and keeps the same compatibility boundaries. It does not change public API.

## Benchmarks
Command:
`DOC_WARMUP=20 DOC_ITERATIONS=200 DOC_SCENARIOS=hybrid-anystore-nonunique,rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique,simple-index-nonunique BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts`

Local node results, 1200-byte docs:
- hybrid-anystore-nonunique: 864 ops/sec; total 231.47 ms; existing lookup 3.78 ms
- rust-peerbit-nonunique: 1625 ops/sec; total 123.04 ms; existing lookup 0.42 ms
- rust-peerbit-transient-index-nonunique: 1764 ops/sec; total 113.36 ms; existing lookup 0.41 ms
- simple-index-nonunique: 2657 ops/sec; total 75.27 ms; existing lookup 0.15 ms

## Test Plan
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "validated local append path for document updates"`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/test/index.spec.ts packages/programs/data/document/document/benchmark/document-put.ts` (0 errors; existing unrelated warning in `index.spec.ts`)
