### PR TITLE
Prepare document put commit projection

### DIFF
--- a/packages/programs/data/document/document/benchmark/document-put.ts
+++ b/packages/programs/data/document/document/benchmark/document-put.ts
@@ -252,7 +252,12 @@ const runScenario = async (name: string): Promise<BenchRow> => {
 				profile,
 				"documentBackendIndexPutMs",
 			),
-			patchAsyncMethod(store.docs.index, "put", profile, "documentIndexPutMs"),
+			patchAsyncMethod(
+				store.docs.index,
+				"putWithContext",
+				profile,
+				"documentIndexPutMs",
+			),
 		];
 
 		const serializeStarted = performance.now();

--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -7,6 +7,7 @@ import {
 } from "@dao-xyz/borsh";
 import { AccessError, SignatureWithKey } from "@peerbit/crypto";
 import {
+	Context,
 	NotFoundError,
 	type ResultIndexedValue,
 } from "@peerbit/document-interface";
@@ -104,6 +105,7 @@ export type CanPerform<T> = (
 type PutChangeReference<T, I extends Record<string, any>> = {
 	document: T;
 	operation: PutOperation;
+	key: indexerTypes.IdKey;
 	unique?: boolean;
 	existing?:
 		| indexerTypes.IndexedResult<IndexedContextOnly<I>>
@@ -666,6 +668,7 @@ export class Documents<
 		) {
 			return this.putPlainFastPath(
 				doc,
+				key,
 				operation,
 				existingHead,
 				existingLocalContext,
@@ -686,6 +689,7 @@ export class Documents<
 				return this.handleChanges(change, {
 					document: doc,
 					operation,
+					key,
 					unique: options?.unique,
 					existing: existingLocalContext,
 				});
@@ -723,6 +727,7 @@ export class Documents<
 
 	private async putPlainFastPath(
 		doc: T,
+		key: indexerTypes.IdKey,
 		operation: PutOperation,
 		existingHead: string | undefined,
 		existingLocalContext:
@@ -745,20 +750,172 @@ export class Documents<
 			},
 			replicate: options?.replicate,
 		});
-		await this.handleChanges(
-			{
-				added: [{ head: true, entry: appended.entry }],
-				removed: appended.removed,
-			},
-			{
+		if (!options?.unique && existingLocalContext === undefined) {
+			await this.handleChanges(
+				{
+					added: [{ head: true, entry: appended.entry }],
+					removed: appended.removed,
+				},
+				{
+					document: doc,
+					operation,
+					key,
+					unique: options?.unique,
+					existing: existingLocalContext,
+				},
+			);
+		} else {
+			await this.handlePreparedPlainPutCommit({
 				document: doc,
-				operation,
+				key,
+				entry: appended.entry,
+				removed: appended.removed,
 				unique: options?.unique,
 				existing: existingLocalContext,
-			},
-		);
+			});
+		}
 		this.keepCache?.add(appended.entry.hash);
 		return appended;
+	}
+
+	private async handlePreparedPlainPutCommit(properties: {
+		document: T;
+		key: indexerTypes.IdKey;
+		entry: Entry<Operation>;
+		removed: ShallowOrFullEntry<Operation>[];
+		unique?: boolean;
+		existing?:
+			| indexerTypes.IndexedResult<IndexedContextOnly<I>>
+			| null
+			| undefined;
+	}): Promise<void> {
+		const documentsChanged: DocumentsChange<T, I> = {
+			added: [],
+			removed: [],
+		};
+		const modified: Set<string | number | bigint> = new Set();
+		const existing =
+			properties.unique || properties.existing === null
+				? null
+				: properties.existing;
+
+		if (!this.strictHistory && existing) {
+			const shouldIgnoreChange = this.immutable
+				? existing.value.__context.modified <
+					properties.entry.meta.clock.timestamp.wallTime
+				: existing.value.__context.modified >
+					properties.entry.meta.clock.timestamp.wallTime;
+			if (shouldIgnoreChange) {
+				modified.add(properties.key.primitive);
+			}
+		}
+
+		if (!modified.has(properties.key.primitive)) {
+			const context = new Context({
+				created:
+					existing?.value.__context.created ||
+					properties.entry.meta.clock.timestamp.wallTime,
+				modified: properties.entry.meta.clock.timestamp.wallTime,
+				head: properties.entry.hash,
+				gid: properties.entry.meta.gid,
+				size: properties.entry.payload.byteLength,
+			});
+			const { indexable } = await this._index.putWithContext(
+				properties.document,
+				properties.key,
+				context,
+				{
+					replace: existing != null,
+				},
+			);
+			documentsChanged.added.push(
+				coerceWithIndexed(
+					coerceWithContext(properties.document, context),
+					indexable,
+				),
+			);
+			modified.add(properties.key.primitive);
+		}
+
+		for (const removed of properties.removed) {
+			const entry =
+				removed instanceof Entry
+					? removed
+					: await this.log.log.entryIndex.get(removed.hash);
+			if (!entry) {
+				continue;
+			}
+			try {
+				await this.collectRemovedDocumentChange(
+					await entry.getPayloadValue(),
+					modified,
+					documentsChanged,
+				);
+			} catch (error) {
+				if (error instanceof AccessError) {
+					continue;
+				}
+				throw error;
+			}
+		}
+
+		this.events.dispatchEvent(
+			new CustomEvent("change", { detail: documentsChanged }),
+		);
+	}
+
+	private async collectRemovedDocumentChange(
+		payload: Operation,
+		modified: Set<string | number | bigint>,
+		documentsChanged: DocumentsChange<T, I>,
+	) {
+		let value: WithIndexedContext<T, I>;
+		let key: indexerTypes.IdKey;
+
+		if (isPutOperation(payload)) {
+			const valueWithoutContext = this.index.valueEncoding.decoder(payload.data);
+			key = indexerTypes.toId(this.idResolver(valueWithoutContext));
+			if (modified.has(key.primitive)) {
+				return;
+			}
+
+			const document = await this._index.get(key, {
+				local: true,
+				remote: false,
+			});
+			if (!document) {
+				return;
+			}
+			value = document;
+		} else if (isDeleteOperation(payload)) {
+			key = coerceDeleteOperation(payload).key;
+			if (modified.has(key.primitive)) {
+				return;
+			}
+			const document = await this._index.get(key, {
+				local: true,
+				remote: false,
+			});
+			if (!document) {
+				return;
+			}
+			value = document;
+		} else {
+			throw new Error("Unexpected");
+		}
+
+		documentsChanged.removed.push(value);
+
+		if (
+			value instanceof Program &&
+			value.closed !== true &&
+			value.parents.includes(this)
+		) {
+			await value.drop(this);
+		}
+
+		await this._index.del(key);
+		modified.add(key.primitive);
 	}
 
 	public async get(
@@ -867,8 +1024,10 @@ export class Documents<
 						this.index.valueEncoding.decoder(payload.data);
 
 					// get index key from value
-					const keyObject = this.idResolver(value);
-					const key = indexerTypes.toId(keyObject);
+					const key =
+						isReferencedAppendEntry && reference?.key
+							? reference.key
+							: indexerTypes.toId(this.idResolver(value));
 
 					// document is already updated with more recent entry
 					if (modified.has(key.primitive)) {
@@ -915,59 +1074,11 @@ export class Documents<
 					isPutOperation(payload) ||
 					removedSet.has(item.hash)
 				) {
-					let value: WithIndexedContext<T, I>;
-					let key: indexerTypes.IdKey;
-
-					if (isPutOperation(payload)) {
-						const valueWithoutContext = this.index.valueEncoding.decoder(
-							payload.data,
-						);
-						key = indexerTypes.toId(this.idResolver(valueWithoutContext));
-						// document is already updated with more recent entry
-						if (modified.has(key.primitive)) {
-							continue;
-						}
-
-						// we try to fetch it anyway, because we need the context for the events
-						const document = await this._index.get(key, {
-							local: true,
-							remote: false,
-						});
-						if (!document) {
-							continue;
-						}
-						value = document;
-					} else if (isDeleteOperation(payload)) {
-						key = coerceDeleteOperation(payload).key;
-						// document is already updated with more recent entry
-						if (modified.has(key.primitive)) {
-							continue;
-						}
-						const document = await this._index.get(key, {
-							local: true,
-							remote: false,
-						});
-						if (!document) {
-							continue;
-						}
-						value = document;
-					} else {
-						throw new Error("Unexpected");
-					}
-
-					documentsChanged.removed.push(value);
-
-					if (
-						value instanceof Program &&
-						value.closed !== true &&
-						value.parents.includes(this)
-					) {
-						await value.drop(this);
-					}
-
-					// update index
-					await this._index.del(key);
-					modified.add(key.primitive);
+					await this.collectRemovedDocumentChange(
+						payload,
+						modified,
+						documentsChanged,
+					);
 				} else {
 					// Unknown operation
 					throw new OperationError("Unknown operation");


### PR DESCRIPTION
## Summary
- add an internal prepared projection path for eligible local document puts after validated append
- index the known document/key/context directly with DocumentIndex.putWithContext instead of walking the added entry through the generic change handler
- share removed-document projection so trimmed removals keep the existing event/index behavior
- update the document-put benchmark profiler to time putWithContext for the new path

## Benchmark
Command:
`DOC_WARMUP=20 DOC_ITERATIONS=200 DOC_SCENARIOS=hybrid-anystore-nonunique,rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique,simple-index-nonunique BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts`

Rows:
- hybrid-anystore-nonunique: 859 ops/sec, total 232.94 ms
- rust-peerbit-nonunique: 1579 ops/sec, total 126.68 ms
- rust-peerbit-transient-index-nonunique: 1802 ops/sec, total 110.97 ms
- simple-index-nonunique: 2854 ops/sec, total 70.07 ms

## Test Plan
- `pnpm --filter @peerbit/document run build`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/benchmark/document-put.ts`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "validated local append path"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "trim deduplicate changes"`