### PR TITLE
Fast path unfiltered length trim

### DIFF
--- a/packages/log/src/trim.ts
+++ b/packages/log/src/trim.ts
@@ -124,6 +124,9 @@ export class Trim<T> {
 		if (!option) {
 			return [];
 		}
+		if (option.type === "length" && !option.filter?.canTrim) {
+			return this.trimUnfilteredLength(option);
+		}
 		///  TODO Make this method less ugly
 		const deleted: Entry<T>[] = [];
 
@@ -286,6 +289,39 @@ export class Trim<T> {
 
 		return deleted;
 	}
+
+	private async trimUnfilteredLength(
+		option: TrimToLengthOption,
+	): Promise<Entry<T>[]> {
+		const to = option.to;
+		const from = option.from ?? to;
+		if (this._log.getLength() < from) {
+			return [];
+		}
+
+		const deleted: Entry<T>[] = [];
+		this._canTrimCacheHashBreakpoint.clear();
+		this._canTrimCacheLastNode = undefined;
+		this._trimLastHead = undefined;
+		this._trimLastTail = undefined;
+		this._trimLastSeed = undefined;
+
+		while (this._log.getLength() > to) {
+			const node = await this._log.index.getOldest(false);
+			if (!node) {
+				break;
+			}
+			const entry = await this._log.deleteNode(node);
+			if (entry) {
+				deleted.push(entry);
+			}
+		}
+
+		this._trimLastLength = this._log.getLength();
+		this._trimLastOptions = option;
+		return deleted;
+	}
+
 	/**
 	 * @param options
 	 * @returns deleted entries

--- a/packages/programs/data/document/document/benchmark/document-put.ts
+++ b/packages/programs/data/document/document/benchmark/document-put.ts
@@ -16,6 +16,7 @@ import { Documents, type SetupOptions } from "../src/program.js";
 // - DOC_BYTES=1200
 // - DOC_SCENARIOS=compat-path,hybrid-anystore,simple-index,sqlite-index,native-graph,native-block-store,rust-peerbit,rust-peerbit-transient-index
 //   Add "-nonunique" to any scenario name to use default update-safe put semantics.
+// - DOC_PROFILE_DEEP=1 reports lower shared-log/log phase timings.
 // - BENCH_JSON=1
 
 const payloadBytes = Math.max(
@@ -41,6 +42,7 @@ const scenarioNames = (
 
 const scenarioBaseName = (name: string) => name.replace(/-nonunique$/, "");
 const scenarioUsesUniquePuts = (name: string) => !name.endsWith("-nonunique");
+const profileDeep = process.env.DOC_PROFILE_DEEP === "1";
 
 @variant("document")
 class Document {
@@ -85,7 +87,13 @@ type Profile = {
 	serializeMs: number;
 	existingHeadLookupMs: number;
 	sharedAppendMs: number;
+	sharedProcessLocalAppendMs: number;
+	sharedPlanEntryLeadersMs: number;
+	sharedPersistCoordinateMs: number;
 	logAppendMs: number;
+	logCreateNativeAppendChainMs: number;
+	logPutAppendEntriesMs: number;
+	logTrimMs: number;
 	documentIndexPutMs: number;
 	documentIndexTransformMs: number;
 	documentBackendIndexPutMs: number;
@@ -99,11 +107,26 @@ type BenchRow = Profile & {
 	opsPerSecond: number;
 };
 
+const deepProfileKeys = new Set<keyof Profile>([
+	"sharedProcessLocalAppendMs",
+	"sharedPlanEntryLeadersMs",
+	"sharedPersistCoordinateMs",
+	"logCreateNativeAppendChainMs",
+	"logPutAppendEntriesMs",
+	"logTrimMs",
+]);
+
 const emptyProfile = (): Profile => ({
 	serializeMs: 0,
 	existingHeadLookupMs: 0,
 	sharedAppendMs: 0,
+	sharedProcessLocalAppendMs: 0,
+	sharedPlanEntryLeadersMs: 0,
+	sharedPersistCoordinateMs: 0,
 	logAppendMs: 0,
+	logCreateNativeAppendChainMs: 0,
+	logPutAppendEntriesMs: 0,
+	logTrimMs: 0,
 	documentIndexPutMs: 0,
 	documentIndexTransformMs: 0,
 	documentBackendIndexPutMs: 0,
@@ -259,6 +282,41 @@ const runScenario = async (name: string): Promise<BenchRow> => {
 				"documentIndexPutMs",
 			),
 		];
+		if (profileDeep) {
+			restores.push(
+				patchAsyncMethod(
+					store.docs.log as any,
+					"processLocalAppend",
+					profile,
+					"sharedProcessLocalAppendMs",
+				),
+				patchAsyncMethod(
+					store.docs.log as any,
+					"planEntryLeaders",
+					profile,
+					"sharedPlanEntryLeadersMs",
+				),
+				patchAsyncMethod(
+					store.docs.log as any,
+					"persistCoordinate",
+					profile,
+					"sharedPersistCoordinateMs",
+				),
+				patchAsyncMethod(
+					store.docs.log.log as any,
+					"createNativePlainAppendChain",
+					profile,
+					"logCreateNativeAppendChainMs",
+				),
+				patchAsyncMethod(
+					store.docs.log.log as any,
+					"putAppendEntries",
+					profile,
+					"logPutAppendEntriesMs",
+				),
+				patchAsyncMethod(store.docs.log.log, "trim", profile, "logTrimMs"),
+			);
+		}
 
 		const serializeStarted = performance.now();
 		for (let i = 0; i < iterations; i++) {
@@ -280,10 +338,12 @@ const runScenario = async (name: string): Promise<BenchRow> => {
 			payloadBytes,
 			opsPerSecond: Math.round((iterations / profile.totalPutMs) * 1000),
 			...Object.fromEntries(
-				Object.entries(profile).map(([key, value]) => [
-					key,
-					Math.round(value * 100) / 100,
-				]),
+				Object.entries(profile)
+					.filter(
+						([key]) =>
+							profileDeep || !deepProfileKeys.has(key as keyof Profile),
+					)
+					.map(([key, value]) => [key, Math.round(value * 100) / 100]),
 			),
 		} as BenchRow;
 	} finally {
@@ -307,6 +367,7 @@ if (process.env.BENCH_JSON === "1") {
 					payloadBytes,
 					warmupIterations,
 					iterations,
+					profileDeep,
 				},
 			},
 			null,


### PR DESCRIPTION
## Summary
- add a lower-log fast path for unfiltered length trim
- avoid the generic trim cache/progress traversal when no canTrim filter exists
- keep filtered length trim, byte-length trim, time trim, and trim queue semantics on the existing path
- add optional deep document-put profiling with DOC_PROFILE_DEEP=1 for shared-log/log phase timings

## Benchmark
Default profiler command:
`DOC_WARMUP=20 DOC_ITERATIONS=200 DOC_SCENARIOS=hybrid-anystore-nonunique,rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique,simple-index-nonunique BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts`

Rows:
- hybrid-anystore-nonunique: 1313 ops/sec, total 152.32 ms, shared append 121.45 ms, log append 98.1 ms
- rust-peerbit-nonunique: 2035 ops/sec, total 98.27 ms, shared append 73.59 ms, log append 57.45 ms
- rust-peerbit-transient-index-nonunique: 2356 ops/sec, total 84.9 ms, shared append 63.7 ms, log append 50.29 ms
- simple-index-nonunique: 4005 ops/sec, total 49.94 ms, shared append 41.78 ms, log append 34.6 ms

## Test Plan
- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/document run build`
- `pnpm exec eslint --config eslint.config.js packages/log/src/trim.ts packages/programs/data/document/document/benchmark/document-put.ts`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "trim"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "trim deduplicate changes"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "validated local append path"`