### PR TITLE
Add scalar native append entry path

### DIFF
--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -104,6 +104,18 @@ type NativeLogIndexHandle = {
 		metaDatas: Array<Uint8Array | undefined>,
 		payloadDatas: Uint8Array[],
 	) => EntryV0PreparedPlainEntryRow[];
+	prepare_entry_v0_plain_entry_and_put: (
+		clockId: Uint8Array,
+		privateKey: Uint8Array,
+		publicKey: Uint8Array,
+		wallTime: bigint,
+		logical: number,
+		gid: string,
+		next: string[],
+		type: number,
+		metaData: Uint8Array | undefined,
+		payloadData: Uint8Array,
+	) => EntryV0PreparedPlainEntryRow;
 	prepare_entry_v0_plain_chain_commit_blocks_and_put: (
 		blockStore: NativeLogBlockStoreHandle,
 		clockId: Uint8Array,
@@ -117,6 +129,19 @@ type NativeLogIndexHandle = {
 		metaDatas: Array<Uint8Array | undefined>,
 		payloadDatas: Uint8Array[],
 	) => EntryV0CommittedPlainEntryRow[];
+	prepare_entry_v0_plain_entry_commit_block_and_put: (
+		blockStore: NativeLogBlockStoreHandle,
+		clockId: Uint8Array,
+		privateKey: Uint8Array,
+		publicKey: Uint8Array,
+		wallTime: bigint,
+		logical: number,
+		gid: string,
+		next: string[],
+		type: number,
+		metaData: Uint8Array | undefined,
+		payloadData: Uint8Array,
+	) => EntryV0CommittedPlainEntryRow;
 	delete: (hash: string) => boolean;
 	heads: (gid?: string) => string[];
 	has_head: (gid?: string) => boolean;
@@ -242,6 +267,18 @@ type WasmModule = {
 		metaDatas: Array<Uint8Array | undefined>,
 		payloadDatas: Uint8Array[],
 	) => EntryV0PreparedPlainEntryRow[];
+	prepare_entry_v0_plain_entry: (
+		clockId: Uint8Array,
+		privateKey: Uint8Array,
+		publicKey: Uint8Array,
+		wallTime: bigint,
+		logical: number,
+		gid: string,
+		next: string[],
+		type: number,
+		metaData: Uint8Array | undefined,
+		payloadData: Uint8Array,
+	) => EntryV0PreparedPlainEntryRow;
 	calculate_raw_cid_v1: (bytes: Uint8Array) => string;
 };
 
@@ -433,6 +470,27 @@ export class LogGraphIndex {
 		);
 	}
 
+	prepareEntryV0PlainEntryAndPut(
+		input: EntryV0PlainEntryInput,
+	): Promise<EntryV0PreparedPlainEntry> {
+		return Promise.resolve(
+			preparedPlainEntryRow(
+				this.native.prepare_entry_v0_plain_entry_and_put(
+					input.clockId,
+					input.privateKey,
+					input.publicKey,
+					BigInt(input.wallTime),
+					input.logical ?? 0,
+					input.gid,
+					input.next ?? [],
+					input.type ?? 0,
+					input.metaData,
+					input.payloadData,
+				),
+			),
+		);
+	}
+
 	prepareEntryV0PlainChainCommit(
 		input: EntryV0PlainChainInput,
 		blockStore: unknown,
@@ -459,6 +517,33 @@ export class LogGraphIndex {
 					input.type ?? 0,
 					columns.metaDatas,
 					input.payloadDatas,
+				),
+			),
+		);
+	}
+
+	prepareEntryV0PlainEntryCommit(
+		input: EntryV0PlainEntryInput,
+		blockStore: unknown,
+	): Promise<EntryV0CommittedPlainEntry | undefined> {
+		const nativeBlockStore = nativeLogBlockStoreHandle(blockStore);
+		if (!nativeBlockStore) {
+			return Promise.resolve(undefined);
+		}
+		return Promise.resolve(
+			committedPlainEntryRow(
+				this.native.prepare_entry_v0_plain_entry_commit_block_and_put(
+					nativeBlockStore,
+					input.clockId,
+					input.privateKey,
+					input.publicKey,
+					BigInt(input.wallTime),
+					input.logical ?? 0,
+					input.gid,
+					input.next ?? [],
+					input.type ?? 0,
+					input.metaData,
+					input.payloadData,
 				),
 			),
 		);
@@ -753,6 +838,19 @@ export type EntryV0PlainChainInput = {
 	payloadDatas: Uint8Array[];
 };
 
+export type EntryV0PlainEntryInput = {
+	clockId: Uint8Array;
+	privateKey: Uint8Array;
+	publicKey: Uint8Array;
+	wallTime: bigint | number | string;
+	logical?: number;
+	gid: string;
+	next?: string[];
+	type?: number;
+	metaData?: Uint8Array;
+	payloadData: Uint8Array;
+};
+
 export type EntryV0PreparedPlainEntry = EntryV0EncodedStorage & {
 	byteLength: number;
 	signature: Uint8Array;
@@ -809,52 +907,50 @@ const plainChainInputColumns = (input: EntryV0PlainChainInput) => {
 	return { wallTimes, logicals, metaDatas };
 };
 
+const preparedPlainEntryRow = ([
+	bytes,
+	cid,
+	signature,
+	next,
+	metaBytes,
+	payloadBytes,
+	signatureBytes,
+]: EntryV0PreparedPlainEntryRow): EntryV0PreparedPlainEntry => ({
+	bytes,
+	cid,
+	byteLength: bytes.byteLength,
+	signature,
+	next,
+	metaBytes,
+	payloadBytes,
+	signatureBytes,
+});
+
 const preparedPlainEntryRows = (
 	rows: EntryV0PreparedPlainEntryRow[],
-): EntryV0PreparedPlainEntry[] =>
-	rows.map(
-		([
-			bytes,
-			cid,
-			signature,
-			next,
-			metaBytes,
-			payloadBytes,
-			signatureBytes,
-		]) => ({
-			bytes,
-			cid,
-			byteLength: bytes.byteLength,
-			signature,
-			next,
-			metaBytes,
-			payloadBytes,
-			signatureBytes,
-		}),
-	);
+): EntryV0PreparedPlainEntry[] => rows.map(preparedPlainEntryRow);
+
+const committedPlainEntryRow = ([
+	cid,
+	signature,
+	next,
+	metaBytes,
+	payloadBytes,
+	signatureBytes,
+	byteLength,
+]: EntryV0CommittedPlainEntryRow): EntryV0CommittedPlainEntry => ({
+	cid,
+	byteLength,
+	signature,
+	next,
+	metaBytes,
+	payloadBytes,
+	signatureBytes,
+});
 
 const committedPlainEntryRows = (
 	rows: EntryV0CommittedPlainEntryRow[],
-): EntryV0CommittedPlainEntry[] =>
-	rows.map(
-		([
-			cid,
-			signature,
-			next,
-			metaBytes,
-			payloadBytes,
-			signatureBytes,
-			byteLength,
-		]) => ({
-			cid,
-			byteLength,
-			signature,
-			next,
-			metaBytes,
-			payloadBytes,
-			signatureBytes,
-		}),
-	);
+): EntryV0CommittedPlainEntry[] => rows.map(committedPlainEntryRow);
 
 const entryColumns = (inputs: EntryV0EncodeInput[]) => {
 	const clockIds = new Array<Uint8Array>(inputs.length);
@@ -1026,6 +1122,26 @@ export const prepareEntryV0PlainChain = async (
 			input.type ?? 0,
 			columns.metaDatas,
 			input.payloadDatas,
+		),
+	);
+};
+
+export const prepareEntryV0PlainEntry = async (
+	input: EntryV0PlainEntryInput,
+): Promise<EntryV0PreparedPlainEntry> => {
+	const wasm = await loadWasm();
+	return preparedPlainEntryRow(
+		wasm.prepare_entry_v0_plain_entry(
+			input.clockId,
+			input.privateKey,
+			input.publicKey,
+			BigInt(input.wallTime),
+			input.logical ?? 0,
+			input.gid,
+			input.next ?? [],
+			input.type ?? 0,
+			input.metaData,
+			input.payloadData,
 		),
 	);
 };

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -760,6 +760,36 @@ impl NativeLogIndex {
         Ok(rows)
     }
 
+    pub fn prepare_entry_v0_plain_entry_and_put(
+        &mut self,
+        clock_id: Uint8Array,
+        private_key: Uint8Array,
+        public_key: Uint8Array,
+        wall_time: u64,
+        logical: u32,
+        gid: String,
+        next: Array,
+        entry_type: u8,
+        meta_data: JsValue,
+        payload_data: Uint8Array,
+    ) -> Result<Array, JsValue> {
+        let (row, entry, initial_nexts, _block) = prepare_entry_v0_plain_entry_row(
+            clock_id,
+            private_key,
+            public_key,
+            wall_time,
+            logical,
+            gid,
+            next,
+            entry_type,
+            meta_data,
+            payload_data,
+            true,
+        )?;
+        self.inner.put_append_chain(vec![entry], &initial_nexts);
+        Ok(row)
+    }
+
     pub fn prepare_entry_v0_plain_chain_commit_blocks_and_put(
         &mut self,
         block_store: &mut NativeLogBlockStore,
@@ -790,6 +820,38 @@ impl NativeLogIndex {
         block_store.put_entries(blocks);
         self.inner.put_append_chain(entries, &initial_nexts);
         Ok(rows)
+    }
+
+    pub fn prepare_entry_v0_plain_entry_commit_block_and_put(
+        &mut self,
+        block_store: &mut NativeLogBlockStore,
+        clock_id: Uint8Array,
+        private_key: Uint8Array,
+        public_key: Uint8Array,
+        wall_time: u64,
+        logical: u32,
+        gid: String,
+        next: Array,
+        entry_type: u8,
+        meta_data: JsValue,
+        payload_data: Uint8Array,
+    ) -> Result<Array, JsValue> {
+        let (row, entry, initial_nexts, block) = prepare_entry_v0_plain_entry_row(
+            clock_id,
+            private_key,
+            public_key,
+            wall_time,
+            logical,
+            gid,
+            next,
+            entry_type,
+            meta_data,
+            payload_data,
+            false,
+        )?;
+        block_store.put_entries(vec![block]);
+        self.inner.put_append_chain(vec![entry], &initial_nexts);
+        Ok(row)
     }
 
     pub fn delete(&mut self, hash: &str) -> bool {
@@ -1208,6 +1270,85 @@ fn prepare_entry_v0_plain_chain_rows(
     Ok((out, entries, initial_nexts, blocks))
 }
 
+fn prepare_entry_v0_plain_entry_row(
+    clock_id: Uint8Array,
+    private_key: Uint8Array,
+    public_key: Uint8Array,
+    wall_time: u64,
+    logical: u32,
+    gid: String,
+    next: Array,
+    entry_type: u8,
+    meta_data: JsValue,
+    payload_data: Uint8Array,
+    include_storage_bytes: bool,
+) -> Result<(Array, LogIndexEntry, Vec<String>, (String, Vec<u8>)), JsValue> {
+    let clock_id = clock_id.to_vec();
+    let private_key = private_key.to_vec();
+    let public_key = public_key.to_vec();
+    let signing_key = validate_ed25519_keypair(&private_key, &public_key)?;
+    let next = strings_from_array(next)?;
+    let payload_data = payload_data.to_vec();
+    let meta_data = optional_bytes_from_js(meta_data);
+    let payload_size = payload_data.len() as u32;
+
+    let input = EntryV0EncodeInput {
+        clock_id,
+        wall_time,
+        logical,
+        gid: gid.clone(),
+        next: next.clone(),
+        entry_type,
+        meta_data,
+        payload_data,
+    };
+    let meta = encode_meta(&input);
+    let payload = encode_payload(&input.payload_data);
+    let signable = encode_entry_v0_parts(&meta, &payload, None);
+    let signature = sign_ed25519_with_key(&signing_key, &signable);
+    let signature_input = SignatureInput {
+        signature: signature.clone(),
+        public_key: public_key.clone(),
+        prehash: 0,
+    };
+    let signature_with_key = encode_signature_with_key(&signature_input);
+    let storage = encode_entry_v0_parts(&meta, &payload, Some(signature_input));
+    let storage_len = storage.len();
+    let cid = calculate_raw_cid_v1_from_bytes(&storage);
+
+    let row = Array::new();
+    if include_storage_bytes {
+        row.push(&Uint8Array::from(storage.as_slice()));
+        row.push(&JsValue::from_str(&cid));
+        row.push(&Uint8Array::from(signature.as_slice()));
+        row.push(&strings_to_array(next.clone()));
+        row.push(&Uint8Array::from(meta.as_slice()));
+        row.push(&Uint8Array::from(payload.as_slice()));
+        row.push(&Uint8Array::from(signature_with_key.as_slice()));
+    } else {
+        row.push(&JsValue::from_str(&cid));
+        row.push(&Uint8Array::from(signature.as_slice()));
+        row.push(&strings_to_array(next.clone()));
+        row.push(&Uint8Array::from(meta.as_slice()));
+        row.push(&Uint8Array::from(payload.as_slice()));
+        row.push(&Uint8Array::from(signature_with_key.as_slice()));
+        row.push(&JsValue::from_f64(storage_len as f64));
+    }
+
+    let entry = LogIndexEntry::new_with_data(
+        cid.clone(),
+        gid,
+        next.clone(),
+        entry_type,
+        input.wall_time,
+        input.logical,
+        payload_size,
+        true,
+        input.meta_data.clone(),
+    );
+    Ok((row, entry, next, (cid, storage)))
+}
+
 #[wasm_bindgen]
 pub fn prepare_entry_v0_plain_chain(
     clock_id: Uint8Array,
@@ -1235,6 +1376,35 @@ pub fn prepare_entry_v0_plain_chain(
         true,
     )?
     .0)
+}
+
+#[wasm_bindgen]
+pub fn prepare_entry_v0_plain_entry(
+    clock_id: Uint8Array,
+    private_key: Uint8Array,
+    public_key: Uint8Array,
+    wall_time: u64,
+    logical: u32,
+    gid: String,
+    next: Array,
+    entry_type: u8,
+    meta_data: JsValue,
+    payload_data: Uint8Array,
+) -> Result<Array, JsValue> {
+    let (row, _entry, _initial_nexts, _block) = prepare_entry_v0_plain_entry_row(
+        clock_id,
+        private_key,
+        public_key,
+        wall_time,
+        logical,
+        gid,
+        next,
+        entry_type,
+        meta_data,
+        payload_data,
+        true,
+    )?;
+    Ok(row)
 }
 
 #[wasm_bindgen]

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -85,6 +85,27 @@ export type NativeLogGraph = {
 			signatureBytes: Uint8Array;
 		}>
 	>;
+	prepareEntryV0PlainEntryAndPut?: (input: {
+		clockId: Uint8Array;
+		privateKey: Uint8Array;
+		publicKey: Uint8Array;
+		wallTime: bigint | number | string;
+		logical?: number;
+		gid: string;
+		next?: string[];
+		type?: number;
+		metaData?: Uint8Array;
+		payloadData: Uint8Array;
+	}) => Promise<{
+		bytes: Uint8Array;
+		cid: string;
+		byteLength: number;
+		signature: Uint8Array;
+		next: string[];
+		metaBytes: Uint8Array;
+		payloadBytes: Uint8Array;
+		signatureBytes: Uint8Array;
+	}>;
 	prepareEntryV0PlainChainCommit?: (
 		input: {
 			clockId: Uint8Array;
@@ -110,6 +131,33 @@ export type NativeLogGraph = {
 				payloadBytes: Uint8Array;
 				signatureBytes: Uint8Array;
 		  }>
+		| undefined
+	>;
+	prepareEntryV0PlainEntryCommit?: (
+		input: {
+			clockId: Uint8Array;
+			privateKey: Uint8Array;
+			publicKey: Uint8Array;
+			wallTime: bigint | number | string;
+			logical?: number;
+			gid: string;
+			next?: string[];
+			type?: number;
+			metaData?: Uint8Array;
+			payloadData: Uint8Array;
+		},
+		blockStore: unknown,
+	) => Promise<
+		| {
+				bytes?: Uint8Array;
+				cid: string;
+				byteLength: number;
+				signature: Uint8Array;
+				next: string[];
+				metaBytes: Uint8Array;
+				payloadBytes: Uint8Array;
+				signatureBytes: Uint8Array;
+		  }
 		| undefined
 	>;
 	delete: (hash: string) => boolean;

--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -51,6 +51,19 @@ type NativePlainChainInput = {
 	payloadDatas: Uint8Array[];
 };
 
+type NativePlainEntryInput = {
+	clockId: Uint8Array;
+	privateKey: Uint8Array;
+	publicKey: Uint8Array;
+	wallTime: bigint | number | string;
+	logical?: number;
+	gid: string;
+	next?: string[];
+	type?: number;
+	metaData?: Uint8Array;
+	payloadData: Uint8Array;
+};
+
 type NativePreparedPlainEntry = {
 	bytes?: Uint8Array;
 	cid: string;
@@ -66,10 +79,17 @@ type NativeEntryV0Graph = {
 	prepareEntryV0PlainChainAndPut?(
 		input: NativePlainChainInput,
 	): Promise<NativePreparedPlainEntry[]>;
+	prepareEntryV0PlainEntryAndPut?(
+		input: NativePlainEntryInput,
+	): Promise<NativePreparedPlainEntry>;
 	prepareEntryV0PlainChainCommit?(
 		input: NativePlainChainInput,
 		blockStore: unknown,
 	): Promise<NativePreparedPlainEntry[] | undefined>;
+	prepareEntryV0PlainEntryCommit?(
+		input: NativePlainEntryInput,
+		blockStore: unknown,
+	): Promise<NativePreparedPlainEntry | undefined>;
 };
 
 type NativeEntryV0Encoder = {
@@ -112,6 +132,9 @@ type NativeEntryV0Encoder = {
 	prepareEntryV0PlainChain?(
 		input: NativePlainChainInput,
 	): Promise<NativePreparedPlainEntry[]>;
+	prepareEntryV0PlainEntry?(
+		input: NativePlainEntryInput,
+	): Promise<NativePreparedPlainEntry>;
 	calculateRawCidV1(bytes: Uint8Array): Promise<string>;
 };
 
@@ -128,6 +151,7 @@ const loadNativeEntryV0Encoder = async () => {
 					encodeEntryV0Storage?: NativeEntryV0Encoder["encodeEntryV0Storage"];
 					encodeEntryV0StorageWithCid?: NativeEntryV0Encoder["encodeEntryV0StorageWithCid"];
 					prepareEntryV0PlainChain?: NativeEntryV0Encoder["prepareEntryV0PlainChain"];
+					prepareEntryV0PlainEntry?: NativeEntryV0Encoder["prepareEntryV0PlainEntry"];
 					calculateRawCidV1?: NativeEntryV0Encoder["calculateRawCidV1"];
 				};
 				if (
@@ -142,6 +166,7 @@ const loadNativeEntryV0Encoder = async () => {
 					encodeEntryV0Storage: mod.encodeEntryV0Storage,
 					encodeEntryV0StorageWithCid: mod.encodeEntryV0StorageWithCid,
 					prepareEntryV0PlainChain: mod.prepareEntryV0PlainChain,
+					prepareEntryV0PlainEntry: mod.prepareEntryV0PlainEntry,
 					calculateRawCidV1: mod.calculateRawCidV1,
 				};
 			} catch {
@@ -615,56 +640,118 @@ export class EntryV0<T>
 		}
 
 		const entryType = properties.meta?.type ?? EntryType.APPEND;
-		const wallTimes = new Array<bigint | number | string>(properties.data.length);
-		const logicals = new Array<number>(properties.data.length);
-		const metaDatas = new Array<Uint8Array | undefined>(properties.data.length);
-		const payloadDatas = new Array<Uint8Array>(properties.data.length);
-		for (let i = 0; i < properties.data.length; i++) {
-			const clock = clocks[i]!;
-			wallTimes[i] = clock.timestamp.wallTime;
-			logicals[i] = clock.timestamp.logical;
-			metaDatas[i] = properties.meta?.data;
-			payloadDatas[i] = properties.encoding.encoder(properties.data[i]!);
-		}
-		const nativePlainChainInput: NativePlainChainInput = {
-			clockId: properties.identity.publicKey.bytes,
-			privateKey: properties.identity.privateKey.privateKey,
-			publicKey: properties.identity.publicKey.publicKey,
-			wallTimes,
-			logicals,
-			gid: gid!,
-			initialNext: nextHashes,
-			type: entryType,
-			metaDatas,
-			payloadDatas,
-		};
-		const nativeCommit = properties.nativeGraph?.prepareEntryV0PlainChainCommit;
+		const clockId = properties.identity.publicKey.bytes;
+		const privateKey = properties.identity.privateKey.privateKey;
+		const publicKey = properties.identity.publicKey.publicKey;
 		let nativeBlocksCommitted = false;
-		let prepared = nativeCommit
-			? await nativeCommit.call(
-					properties.nativeGraph,
-					nativePlainChainInput,
-					properties.nativeBlockStore,
-				)
-			: undefined;
-		if (prepared) {
-			nativeBlocksCommitted = true;
-		} else {
-			const nativePrepareAndPut =
-				properties.nativeGraph?.prepareEntryV0PlainChainAndPut;
-			prepared = await (nativePrepareAndPut
-				? nativePrepareAndPut.call(properties.nativeGraph, nativePlainChainInput)
-				: nativeEncoder.prepareEntryV0PlainChain(nativePlainChainInput));
+		let nativeGraphUpdated = false;
+		let prepared: NativePreparedPlainEntry[] | undefined;
+		let payloadDatas: Uint8Array[] | undefined;
+		if (properties.data.length === 1) {
+			const clock = clocks[0]!;
+			const payloadData = properties.encoding.encoder(properties.data[0]!);
+			const singleInput: NativePlainEntryInput = {
+				clockId,
+				privateKey,
+				publicKey,
+				wallTime: clock.timestamp.wallTime,
+				logical: clock.timestamp.logical,
+				gid: gid!,
+				next: nextHashes,
+				type: entryType,
+				metaData: properties.meta?.data,
+				payloadData,
+			};
+			const nativeCommit =
+				properties.nativeGraph?.prepareEntryV0PlainEntryCommit;
+			const preparedEntry = nativeCommit
+				? await nativeCommit.call(
+						properties.nativeGraph,
+						singleInput,
+						properties.nativeBlockStore,
+					)
+				: undefined;
+			if (preparedEntry) {
+				nativeBlocksCommitted = true;
+				nativeGraphUpdated = true;
+				prepared = [preparedEntry];
+				payloadDatas = [payloadData];
+			} else {
+				const nativePrepareAndPut =
+					properties.nativeGraph?.prepareEntryV0PlainEntryAndPut;
+				const scalarPreparedEntry = nativePrepareAndPut
+					? await nativePrepareAndPut.call(properties.nativeGraph, singleInput)
+					: nativeEncoder.prepareEntryV0PlainEntry
+						? await nativeEncoder.prepareEntryV0PlainEntry(singleInput)
+						: undefined;
+				if (scalarPreparedEntry) {
+					nativeGraphUpdated = !!nativePrepareAndPut;
+					prepared = [scalarPreparedEntry];
+					payloadDatas = [payloadData];
+				}
+			}
 		}
-		const nativeGraphUpdated =
-			nativeBlocksCommitted ||
-			!!properties.nativeGraph?.prepareEntryV0PlainChainAndPut;
+
+		if (!prepared) {
+			const wallTimes = new Array<bigint | number | string>(
+				properties.data.length,
+			);
+			const logicals = new Array<number>(properties.data.length);
+			const metaDatas = new Array<Uint8Array | undefined>(
+				properties.data.length,
+			);
+			payloadDatas = new Array<Uint8Array>(properties.data.length);
+			for (let i = 0; i < properties.data.length; i++) {
+				const clock = clocks[i]!;
+				wallTimes[i] = clock.timestamp.wallTime;
+				logicals[i] = clock.timestamp.logical;
+				metaDatas[i] = properties.meta?.data;
+				payloadDatas[i] = properties.encoding.encoder(properties.data[i]!);
+			}
+			const nativePlainChainInput: NativePlainChainInput = {
+				clockId,
+				privateKey,
+				publicKey,
+				wallTimes,
+				logicals,
+				gid: gid!,
+				initialNext: nextHashes,
+				type: entryType,
+				metaDatas,
+				payloadDatas,
+			};
+			const nativeCommit = properties.nativeGraph?.prepareEntryV0PlainChainCommit;
+			prepared = nativeCommit
+				? await nativeCommit.call(
+						properties.nativeGraph,
+						nativePlainChainInput,
+						properties.nativeBlockStore,
+					)
+				: undefined;
+			if (prepared) {
+				nativeBlocksCommitted = true;
+				nativeGraphUpdated = true;
+			} else {
+				const nativePrepareAndPut =
+					properties.nativeGraph?.prepareEntryV0PlainChainAndPut;
+				prepared = await (nativePrepareAndPut
+					? nativePrepareAndPut.call(
+							properties.nativeGraph,
+							nativePlainChainInput,
+						)
+					: nativeEncoder.prepareEntryV0PlainChain(nativePlainChainInput));
+				nativeGraphUpdated = !!nativePrepareAndPut;
+			}
+		}
 
 		const entries: PreparedAppendChain<T>["entries"] = [];
 		const blocks: NonNullable<PreparedAppendChain<T>["blocks"]> = [];
 		const shallowEntries: PreparedAppendChain<T>["shallowEntries"] = [];
 		const nativeEntries: NonNullable<PreparedAppendChain<T>["nativeEntries"]> =
 			[];
+		if (!payloadDatas) {
+			throw new Error("Expected payload data for prepared append chain");
+		}
 
 		for (let index = 0; index < prepared.length; index++) {
 			const preparedEntry = prepared[index]!;

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -750,7 +750,12 @@ export class Log<T> {
 			!this.entryIndex.properties.onGidRemoved &&
 			(this.entryIndex.properties.nativeGraph?.graph
 				.prepareEntryV0PlainChainCommit ||
-				this.entryIndex.properties.nativeGraph?.graph.prepareEntryV0PlainChainAndPut)
+				this.entryIndex.properties.nativeGraph?.graph
+					.prepareEntryV0PlainEntryCommit ||
+				this.entryIndex.properties.nativeGraph?.graph
+					.prepareEntryV0PlainChainAndPut ||
+				this.entryIndex.properties.nativeGraph?.graph
+					.prepareEntryV0PlainEntryAndPut)
 				? this.entryIndex.properties.nativeGraph.graph
 				: undefined;
 		return EntryV0.createPlainAppendChainBatch<T>({

--- a/packages/log/test/append.spec.ts
+++ b/packages/log/test/append.spec.ts
@@ -334,6 +334,10 @@ describe("append", function () {
 			log.entryIndex.properties.nativeGraph!.graph,
 			"prepareEntryV0PlainChainCommit",
 		);
+		const nativeEntryCommitSpy = sinon.spy(
+			log.entryIndex.properties.nativeGraph!.graph,
+			"prepareEntryV0PlainEntryCommit",
+		);
 		const nativePrepareAndPutSpy = sinon.spy(
 			log.entryIndex.properties.nativeGraph!.graph,
 			"prepareEntryV0PlainChainAndPut",
@@ -344,8 +348,11 @@ describe("append", function () {
 				meta: { next: [] },
 			});
 
-			expect(nativeCommitSpy.callCount).equal(1);
-			expect(nativeCommitSpy.firstCall.args[0].payloadDatas).to.have.length(1);
+			expect(nativeEntryCommitSpy.callCount).equal(1);
+			expect(nativeEntryCommitSpy.firstCall.args[0].payloadData).to.deep.equal(
+				new Uint8Array([1]),
+			);
+			expect(nativeCommitSpy.callCount).equal(0);
 			expect(nativePrepareAndPutSpy.callCount).equal(0);
 			expect(blockPutSpy.callCount).equal(0);
 			expect(blockPutManySpy.callCount).equal(0);
@@ -360,6 +367,7 @@ describe("append", function () {
 			blockPutManySpy.restore();
 			preparedBlockFromBytesSpy.restore();
 			nativeCommitSpy.restore();
+			nativeEntryCommitSpy.restore();
 			nativePrepareAndPutSpy.restore();
 			await log.close();
 			await nativeStore.stop();


### PR DESCRIPTION
## Summary
- add scalar Rust/WASM EntryV0 plain append preparation and graph commit helpers
- use the scalar helper for eligible single-entry append paths while keeping appendMany on the native batch path
- update native graph typing/selection and focused append assertions for the new single-entry native commit path

## Benchmark
Command from `packages/programs/data/document/document`:

```bash
DOC_WARMUP=20 DOC_ITERATIONS=200 DOC_SCENARIOS=hybrid-anystore-nonunique,rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique,simple-index-nonunique BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Results:
- `hybrid-anystore-nonunique`: 1374 ops/sec, total 145.60 ms, shared append 116.45 ms, log append 95.26 ms
- `rust-peerbit-nonunique`: 2087 ops/sec, total 95.82 ms, shared append 71.76 ms, log append 55.80 ms
- `rust-peerbit-transient-index-nonunique`: 2344 ops/sec, total 85.33 ms, shared append 64.94 ms, log append 49.79 ms
- `simple-index-nonunique`: 3998 ops/sec, total 50.02 ms, shared append 43.22 ms, log append 35.31 ms

## Validation
- `cargo fmt --manifest-path packages/log/rust/Cargo.toml`
- `pnpm exec eslint --config eslint.config.js packages/log/src/entry-v0.ts packages/log/src/entry-index.ts packages/log/src/log.ts packages/log/rust/src/index.ts packages/log/test/append.spec.ts`
- `pnpm --filter @peerbit/log-rust run build`
- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "append commits one block and graph in one native call when storage is native"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "appendMany commits blocks and graph in one native call when storage is native"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "appendMany appends a local chain with one coalesced change"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "validated local append path"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "trim deduplicate changes"`