### PR TITLE
Coalesce local document put append path

### DIFF
--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -641,6 +641,88 @@ export class Log<T> {
 		return { entry, removed };
 	}
 
+	/**
+	 * Internal trusted local append path for callers that already handled validation
+	 * and want to apply change observers themselves.
+	 */
+	async appendLocallyPrepared(
+		data: T,
+		options: AppendOptions<T> = {},
+		properties?: { skipMissingNextJoin?: boolean },
+	): Promise<{
+		entry: Entry<T>;
+		removed: ShallowOrFullEntry<T>[];
+		change: Change<T>;
+	}> {
+		if (
+			options.canAppend ||
+			options.onChange ||
+			options.meta?.type === EntryType.CUT
+		) {
+			throw new Error(
+				"appendLocallyPrepared only supports trusted plain local appends",
+			);
+		}
+
+		const appendOptions: AppendOptions<T> = {
+			...options,
+			__peerbitCanAppendAlreadyValidated: true,
+		};
+		const nexts = await this.getNextsForAppend(appendOptions);
+		const deferBlockStore = hasPutMany(this._storage);
+		const nativeAppendChain = this.entryIndex.properties.nativeGraph
+			? await this.createNativePlainAppendChain(
+					[data],
+					appendOptions,
+					nexts,
+					deferBlockStore,
+				)
+			: undefined;
+		let entry: Entry<T>;
+		if (nativeAppendChain) {
+			entry = nativeAppendChain.entries[0]!;
+			try {
+				if (!properties?.skipMissingNextJoin) {
+					await this.joinMissingNexts(entry, nexts);
+				}
+				if (deferBlockStore && !nativeAppendChain.nativeBlocksCommitted) {
+					await this.putAppendEntryBlocks([entry], nativeAppendChain.blocks);
+				}
+				await this.putAppendEntries(
+					[entry],
+					appendOptions,
+					nexts.map((next) => next.hash),
+					nativeAppendChain,
+				);
+			} catch (error) {
+				if (nativeAppendChain.nativeGraphUpdated) {
+					this.rollbackNativeAppendGraph([entry]);
+				}
+				if (nativeAppendChain.nativeBlocksCommitted) {
+					await this.rollbackNativeAppendBlocks([entry]);
+				}
+				throw error;
+			}
+		} else {
+			entry = await this.createAppendEntry(data, appendOptions, nexts);
+			if (!properties?.skipMissingNextJoin) {
+				await this.joinMissingNexts(entry, nexts);
+			}
+			await this.putAppendEntry(entry, appendOptions);
+		}
+
+		entry.init({ encoding: this._encoding, keychain: this._keychain });
+
+		const trimmed = await this.trim(appendOptions.trim);
+		const removed = trimmed ?? [];
+		const change: Change<T> = {
+			added: [{ head: true, entry }],
+			removed,
+		};
+
+		return { entry, removed, change };
+	}
+
 	async appendMany(
 		data: T[],
 		options: AppendOptions<T> = {},

--- a/packages/programs/data/document/document/benchmark/document-put.ts
+++ b/packages/programs/data/document/document/benchmark/document-put.ts
@@ -262,7 +262,19 @@ const runScenario = async (name: string): Promise<BenchRow> => {
 				profile,
 				"sharedAppendMs",
 			),
+			patchAsyncMethod(
+				store.docs.log,
+				"appendLocallyPrepared",
+				profile,
+				"sharedAppendMs",
+			),
 			patchAsyncMethod(store.docs.log.log, "append", profile, "logAppendMs"),
+			patchAsyncMethod(
+				store.docs.log.log as any,
+				"appendLocallyPrepared",
+				profile,
+				"logAppendMs",
+			),
 			patchAsyncMethod(
 				store.docs.index,
 				"transformer",

--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -742,14 +742,20 @@ export class Documents<
 			  })
 			| undefined,
 	) {
-		const appended = await this.log.appendLocallyValidated(operation, {
-			...options,
-			meta: {
-				next: existingHead ? [await this._resolveEntry(existingHead)] : [],
-				...options?.meta,
+		const appended = await this.log.appendLocallyPrepared(
+			operation,
+			{
+				...options,
+				meta: {
+					next: existingHead ? [await this._resolveEntry(existingHead)] : [],
+					...options?.meta,
+				},
+				replicate: options?.replicate,
 			},
-			replicate: options?.replicate,
-		});
+			{
+				skipMissingNextJoin: !options?.checkRemote,
+			},
+		);
 		if (!options?.unique && existingLocalContext === undefined) {
 			await this.handleChanges(
 				{

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -181,6 +181,10 @@ describe("index", () => {
 					store.docs.log,
 					"appendLocallyValidated",
 				);
+				const preparedAppendSpy = sinon.spy(
+					store.docs.log,
+					"appendLocallyPrepared",
+				);
 				const appendSpy = sinon.spy(store.docs.log, "append");
 				const localLookupSpy = sinon.spy(
 					store.docs as any,
@@ -195,7 +199,8 @@ describe("index", () => {
 						target: "none",
 					});
 
-					expect(validatedAppendSpy.callCount).equal(1);
+					expect(preparedAppendSpy.callCount).equal(1);
+					expect(validatedAppendSpy.callCount).equal(0);
 					expect(appendSpy.callCount).equal(0);
 					expect(localLookupSpy.callCount).equal(0);
 					expect((await store.docs.get(doc.id))?.name).equal("fast");
@@ -203,6 +208,7 @@ describe("index", () => {
 					expect(changes[0].added[0].__context.head).equal(put.entry.hash);
 				} finally {
 					localLookupSpy.restore();
+					preparedAppendSpy.restore();
 					validatedAppendSpy.restore();
 					appendSpy.restore();
 				}
@@ -220,6 +226,10 @@ describe("index", () => {
 				const validatedAppendSpy = sinon.spy(
 					store.docs.log,
 					"appendLocallyValidated",
+				);
+				const preparedAppendSpy = sinon.spy(
+					store.docs.log,
+					"appendLocallyPrepared",
 				);
 				const appendSpy = sinon.spy(store.docs.log, "append");
 				const localLookupSpy = sinon.spy(
@@ -244,13 +254,15 @@ describe("index", () => {
 						},
 					);
 
-					expect(validatedAppendSpy.callCount).equal(2);
+					expect(preparedAppendSpy.callCount).equal(2);
+					expect(validatedAppendSpy.callCount).equal(0);
 					expect(appendSpy.callCount).equal(0);
 					expect(localLookupSpy.callCount).equal(2);
 					expect(second.entry.meta.next).to.deep.equal([first.entry.hash]);
 					expect((await store.docs.get(id))?.name).equal("second");
 				} finally {
 					localLookupSpy.restore();
+					preparedAppendSpy.restore();
 					validatedAppendSpy.restore();
 					appendSpy.restore();
 				}
@@ -271,6 +283,10 @@ describe("index", () => {
 					store.docs.log,
 					"appendLocallyValidated",
 				);
+				const preparedAppendSpy = sinon.spy(
+					store.docs.log,
+					"appendLocallyPrepared",
+				);
 				const appendSpy = sinon.spy(store.docs.log, "append");
 
 				try {
@@ -281,9 +297,11 @@ describe("index", () => {
 					});
 
 					expect(validatedAppendSpy.callCount).equal(0);
+					expect(preparedAppendSpy.callCount).equal(0);
 					expect(appendSpy.callCount).equal(1);
 					expect(canPerform.callCount).equal(1);
 				} finally {
+					preparedAppendSpy.restore();
 					validatedAppendSpy.restore();
 					appendSpy.restore();
 				}

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -3965,6 +3965,37 @@ export class SharedLog<
 		return result;
 	}
 
+	/** Trusted local append path that lets the shared log own change application. */
+	async appendLocallyPrepared(
+		data: T,
+		options?: SharedAppendOptions<T> | undefined,
+		properties?: { skipMissingNextJoin?: boolean },
+	): Promise<{
+		entry: Entry<T>;
+		removed: ShallowOrFullEntry<T>[];
+	}> {
+		if (options?.canAppend || options?.onChange) {
+			throw new Error(
+				"appendLocallyPrepared does not accept canAppend or onChange hooks",
+			);
+		}
+		if (this._isAdaptiveReplicating) {
+			this.markLocalAppendActivity();
+		}
+
+		const { appendOptions, minReplicasValue } =
+			this.createLogAppendOptions(options);
+		appendOptions.__peerbitCanAppendAlreadyValidated = true;
+		const result = await this.log.appendLocallyPrepared(data, appendOptions, {
+			skipMissingNextJoin: properties?.skipMissingNextJoin,
+		});
+		await this.onChange(result.change);
+		await this.processLocalAppend(result.entry, result.removed, options, {
+			minReplicasValue,
+		});
+		return { entry: result.entry, removed: result.removed };
+	}
+
 	async appendMany(
 		data: T[],
 		options?: SharedAppendOptions<T> | undefined,


### PR DESCRIPTION
## Summary
- add an internal trusted lower-log `appendLocallyPrepared` path that returns a prepared change instead of dispatching lower-log observers
- add `SharedLog.appendLocallyPrepared` so shared-log bookkeeping owns the returned lower-log change directly
- route eligible plain local `Documents.put` writes through the prepared append path while keeping custom hooks/options on the compatibility path
- extend the document-put profiler and focused tests for the new coalesced path

## Benchmark
Command from `packages/programs/data/document/document`:

```bash
DOC_WARMUP=20 DOC_ITERATIONS=200 DOC_SCENARIOS=hybrid-anystore-nonunique,rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique,simple-index-nonunique BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Results:
- `hybrid-anystore-nonunique`: 1348 ops/sec, total 148.34 ms, shared append 118.24 ms, log append 86.19 ms
- `rust-peerbit-nonunique`: 2046 ops/sec, total 97.75 ms, shared append 71.64 ms, log append 52.14 ms
- `rust-peerbit-transient-index-nonunique`: 2455 ops/sec, total 81.46 ms, shared append 61.32 ms, log append 45.25 ms
- `simple-index-nonunique`: 4188 ops/sec, total 47.75 ms, shared append 41.57 ms, log append 33.40 ms

Deep-profile note: a local experiment allowing `target: "none"` through the native shared append planner was slower, so this PR keeps the existing planner selection and only coalesces the prepared append/change boundary.

## Validation
- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `pnpm exec eslint --config eslint.config.js packages/log/src/log.ts packages/programs/data/shared-log/src/index.ts packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/benchmark/document-put.ts packages/programs/data/document/document/test/index.spec.ts` (passes with one existing warning in `index.spec.ts`)
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "validated local append path"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "trim deduplicate changes"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "append commits one block and graph in one native call when storage is native"`