### PR TITLE
Use indexed context for document put nexts

### DIFF
--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -17,7 +17,11 @@ import {
 	type Change,
 	Entry,
 	EntryType,
+	LamportClock,
+	ShallowEntry,
+	ShallowMeta,
 	type ShallowOrFullEntry,
+	Timestamp,
 	type TrimOptions,
 } from "@peerbit/log";
 import { logger as loggerFn } from "@peerbit/logger";
@@ -742,12 +746,20 @@ export class Documents<
 			  })
 			| undefined,
 	) {
+		const indexedContextNext = existingHead
+			? this.nextFromIndexedContext(existingHead, existingLocalContext)
+			: undefined;
+		const next = existingHead
+			? indexedContextNext
+				? [indexedContextNext]
+				: [await this._resolveEntry(existingHead)]
+			: [];
 		const appended = await this.log.appendLocallyPrepared(
 			operation,
 			{
 				...options,
 				meta: {
-					next: existingHead ? [await this._resolveEntry(existingHead)] : [],
+					next,
 					...options?.meta,
 				},
 				replicate: options?.replicate,
@@ -782,6 +794,36 @@ export class Documents<
 		}
 		this.keepCache?.add(appended.entry.hash);
 		return appended;
+	}
+
+	private nextFromIndexedContext(
+		existingHead: string,
+		existing:
+			| indexerTypes.IndexedResult<IndexedContextOnly<I>>
+			| null
+			| undefined,
+	): ShallowEntry | undefined {
+		const context = existing?.value.__context;
+		if (!context || context.head !== existingHead) {
+			return;
+		}
+		return new ShallowEntry({
+			hash: context.head,
+			head: false,
+			payloadSize: context.size,
+			meta: new ShallowMeta({
+				gid: context.gid,
+				clock: new LamportClock({
+					id: this.log.log.identity.publicKey.bytes,
+					timestamp: new Timestamp({
+						wallTime: context.modified,
+						logical: 0,
+					}),
+				}),
+				next: [],
+				type: EntryType.APPEND,
+			}),
+		});
 	}
 
 	private async handlePreparedPlainPutCommit(properties: {

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -236,6 +236,7 @@ describe("index", () => {
 					store.docs as any,
 					"getLocalIndexedContext",
 				);
+				const lowerLogGetSpy = sinon.spy(store.docs.log.log, "get");
 
 				try {
 					const id = uuid();
@@ -258,10 +259,12 @@ describe("index", () => {
 					expect(validatedAppendSpy.callCount).equal(0);
 					expect(appendSpy.callCount).equal(0);
 					expect(localLookupSpy.callCount).equal(2);
+					expect(lowerLogGetSpy.callCount).equal(0);
 					expect(second.entry.meta.next).to.deep.equal([first.entry.hash]);
 					expect((await store.docs.get(id))?.name).equal("second");
 				} finally {
 					localLookupSpy.restore();
+					lowerLogGetSpy.restore();
 					preparedAppendSpy.restore();
 					validatedAppendSpy.restore();
 					appendSpy.restore();


### PR DESCRIPTION
## Summary
- start the native document put kernel work by feeding update appends from known indexed context instead of resolving the previous full log entry
- construct a lightweight `ShallowEntry` from `{ head, gid, modified, size }` for eligible non-unique plain local puts
- keep the existing `_resolveEntry(existingHead)` fallback when a matching local indexed context is not available
- assert the update fast path no longer calls lower-log `get` for the previous head

## Benchmark
Command from `packages/programs/data/document/document`:

```bash
DOC_WARMUP=20 DOC_ITERATIONS=200 DOC_SCENARIOS=hybrid-anystore-nonunique,rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique,simple-index-nonunique BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Results:
- `hybrid-anystore-nonunique`: 1327 ops/sec, total 150.73 ms, shared append 121.32 ms, log append 85.08 ms
- `rust-peerbit-nonunique`: 2136 ops/sec, total 93.64 ms, shared append 70.98 ms, log append 51.24 ms
- `rust-peerbit-transient-index-nonunique`: 2425 ops/sec, total 82.49 ms, shared append 61.65 ms, log append 45.50 ms
- `simple-index-nonunique`: 4264 ops/sec, total 46.91 ms, shared append 40.81 ms, log append 33.29 ms

## Validation
- `pnpm --filter @peerbit/document run build`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/test/index.spec.ts` (passes with one existing warning in `index.spec.ts`)
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "validated local append path"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "trim deduplicate changes"`

## Notes
This is not the full Rust-owned document put endpoint yet. It is the first kernel-input cleanup: eligible document updates no longer materialize the previous JS log entry before the native append commit. The next step should add a native document index commit hook for identity-transform Rust indexes.