### PR TITLE
Add native-aware document index commit hook

### DIFF
--- a/packages/programs/data/document/document/benchmark/document-put.ts
+++ b/packages/programs/data/document/document/benchmark/document-put.ts
@@ -167,6 +167,9 @@ const patchAsyncMethod = (
 	profileKey: keyof Profile,
 ) => {
 	const original = target[key];
+	if (typeof original !== "function") {
+		return () => {};
+	}
 	target[key] = async function patched(this: unknown, ...args: unknown[]) {
 		return time(profile, profileKey, () => original.apply(this, args));
 	};
@@ -248,6 +251,7 @@ const runScenario = async (name: string): Promise<BenchRow> => {
 		await runPuts(store, warmupIterations, name);
 
 		const profile = emptyProfile();
+		const backendIndex = store.docs.index.index as any;
 		const restores = [
 			patchAsyncMethod(
 				store.docs as any,
@@ -282,8 +286,10 @@ const runScenario = async (name: string): Promise<BenchRow> => {
 				"documentIndexTransformMs",
 			),
 			patchAsyncMethod(
-				store.docs.index.index,
-				"put",
+				backendIndex,
+				typeof backendIndex.putWithContext === "function"
+					? "putWithContext"
+					: "put",
 				profile,
 				"documentBackendIndexPutMs",
 			),

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -653,6 +653,15 @@ type IndexableClass<I> = new (
 	context: types.Context,
 ) => WithContext<I>;
 
+type ContextualIndexPut<I> = {
+	putWithContext?: (
+		value: I,
+		id: indexerTypes.IdKey,
+		context: types.Context,
+		options?: { replace?: boolean },
+	) => Promise<void> | void;
+};
+
 export const coerceWithContext = <T>(
 	value: T | WithContext<T>,
 	context: types.Context,
@@ -1687,17 +1696,24 @@ export class DocumentIndex<
 		const valueToIndex = this.transformerIsIdentity
 			? (value as any as I)
 			: await this.transformer(value, context);
-		const wrappedValueToIndex = new this.wrappedIndexedType(
-			valueToIndex as I,
-			context,
-		);
 
 		coerceWithIndexed(value, valueToIndex);
 
 		coerceWithContext(value, context);
 
 		try {
-			await this.index.put(wrappedValueToIndex, id, options);
+			const contextualPut = this.transformerIsIdentity
+				? (this.index as ContextualIndexPut<I>).putWithContext
+				: undefined;
+			if (contextualPut) {
+				await contextualPut.call(this.index, valueToIndex, id, context, options);
+			} else {
+				const wrappedValueToIndex = new this.wrappedIndexedType(
+					valueToIndex as I,
+					context,
+				);
+				await this.index.put(wrappedValueToIndex, id, options);
+			}
 		} catch (error) {
 			if (error instanceof indexerTypes.NotStartedError && this.closed) {
 				return { context, indexable: valueToIndex };

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -190,6 +190,25 @@ describe("index", () => {
 					store.docs as any,
 					"getLocalIndexedContext",
 				);
+				const backendIndex = store.docs.index.index as any;
+				const originalBackendPutWithContext = backendIndex.putWithContext;
+				const originalBackendPut = backendIndex.put;
+				const WrappedIndexedType = store.docs.index.wrappedIndexedType;
+				const backendContextPutSpy = sinon.spy(
+					async (
+						value: Document,
+						id: unknown,
+						context: Context,
+						options: unknown,
+					) =>
+						originalBackendPut.call(
+							backendIndex,
+							new WrappedIndexedType(value, context),
+							id,
+							options,
+						),
+				);
+				backendIndex.putWithContext = backendContextPutSpy;
 
 				try {
 					const doc = new Document({ id: uuid(), name: "fast" });
@@ -203,10 +222,16 @@ describe("index", () => {
 					expect(validatedAppendSpy.callCount).equal(0);
 					expect(appendSpy.callCount).equal(0);
 					expect(localLookupSpy.callCount).equal(0);
+					expect(backendContextPutSpy.callCount).equal(1);
 					expect((await store.docs.get(doc.id))?.name).equal("fast");
 					expect(changes).to.have.length(1);
 					expect(changes[0].added[0].__context.head).equal(put.entry.hash);
 				} finally {
+					if (originalBackendPutWithContext) {
+						backendIndex.putWithContext = originalBackendPutWithContext;
+					} else {
+						delete backendIndex.putWithContext;
+					}
 					localLookupSpy.restore();
 					preparedAppendSpy.restore();
 					validatedAppendSpy.restore();

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -1280,6 +1280,15 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		});
 	}
 
+	async putWithContext(
+		value: Record<string, any>,
+		id: types.IdKey,
+		context: Record<string, any>,
+		options?: { replace?: boolean },
+	): Promise<void> {
+		await this.put(this.createContextualValue(value, context), id, options);
+	}
+
 	async putBatch(values: T[]): Promise<void> {
 		if (values.length === 0) {
 			return;
@@ -1540,6 +1549,18 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			value,
 			this.fieldEncoder(value),
 		);
+	}
+
+	private createContextualValue(
+		value: Record<string, any>,
+		context: Record<string, any>,
+	): T {
+		const wrapped = Object.assign(
+			Object.create((this.properties.schema as any).prototype),
+			value,
+		);
+		wrapped.__context = context;
+		return wrapped as T;
 	}
 
 	private snapshot(): types.IndexedValue<T>[] {

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -11,6 +11,7 @@ import {
 	StringMatch,
 	StringMatchMethod,
 	id,
+	toId,
 } from "@peerbit/indexer-interface";
 import { tests } from "@peerbit/indexer-tests";
 import { expect } from "chai";
@@ -60,6 +61,36 @@ class BridgeMetricDocument {
 		this.id = id;
 		this.tag = tag;
 		this.value = value;
+	}
+}
+
+class BridgeContext {
+	@field({ type: "string" })
+	head: string;
+
+	constructor(head: string) {
+		this.head = head;
+	}
+}
+
+class BridgeDocumentWithContext {
+	@id({ type: "string" })
+	id: string;
+
+	@field({ type: "string" })
+	tag: string;
+
+	@field({ type: "string" })
+	title: string;
+
+	@field({ type: BridgeContext })
+	__context: BridgeContext;
+
+	constructor(value: BridgeDocument, context: BridgeContext) {
+		this.id = value.id;
+		this.tag = value.tag;
+		this.title = value.title;
+		this.__context = context;
 	}
 }
 
@@ -215,6 +246,42 @@ describe("native planner bridge", () => {
 			})
 			.all();
 		expect(results.map((result) => result.value.id)).to.deep.equal(["a", "b"]);
+
+		await indices.drop();
+	});
+
+	it("accepts contextual document puts through the native index hook", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeDocumentWithContext });
+		const contextualIndex = index as typeof index & {
+			putWithContext: (
+				value: BridgeDocument,
+				id: ReturnType<typeof toId>,
+				context: BridgeContext,
+				options?: { replace?: boolean },
+			) => Promise<void>;
+		};
+
+		await contextualIndex.putWithContext(
+			new BridgeDocument("a", "peerbit", "native index"),
+			toId("a"),
+			new BridgeContext("head-a"),
+			{ replace: false },
+		);
+
+		const result = await index.get(toId("a"));
+		expect(result?.value.__context.head).equal("head-a");
+		expect(result?.value.title).equal("native index");
+
+		const indexed = await index
+			.iterate({
+				query: new StringMatch({ key: "tag", value: "peerbit" }),
+			})
+			.all();
+		expect(indexed.map((entry) => entry.value.__context.head)).to.deep.equal([
+			"head-a",
+		]);
 
 		await indices.drop();
 	});


### PR DESCRIPTION
## Summary
- add a structural `putWithContext` hook to `RustIndex` for contextual document index commits
- let `DocumentIndex.putWithContext` use backend contextual puts for identity transformers while preserving fallback behavior
- update the document put benchmark profiler so backend index timing patches `putWithContext` when present instead of double-counting delegated `put`

## Benchmark
Local node run from `packages/programs/data/document/document`:

`DOC_WARMUP=20 DOC_ITERATIONS=200 DOC_SCENARIOS=hybrid-anystore-nonunique,rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique,simple-index-nonunique BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts`

- `hybrid-anystore-nonunique`: 1343 ops/sec, total 148.97 ms, shared append 117.53 ms, log append 82.30 ms, document index put 4.78 ms, backend index put 3.93 ms
- `rust-peerbit-nonunique`: 2112 ops/sec, total 94.72 ms, shared append 72.12 ms, log append 52.89 ms, document index put 10.88 ms, backend index put 10.40 ms
- `rust-peerbit-transient-index-nonunique`: 2443 ops/sec, total 81.88 ms, shared append 61.74 ms, log append 45.51 ms, document index put 9.79 ms, backend index put 9.32 ms
- `simple-index-nonunique`: 3983 ops/sec, total 50.21 ms, shared append 43.53 ms, log append 35.11 ms, document index put 0.54 ms, backend index put 0.09 ms

This PR is mostly foundation for the next deeper native document projection/index commit. The measured signal is roughly neutral versus #867 because the new Rust hook still delegates to the generic `put` path.

## Validation
- `pnpm --filter @peerbit/indexer-rust run build`
- `pnpm --filter @peerbit/document run build`
- `pnpm exec eslint --config eslint.config.js packages/utils/indexer/rust/src/index.ts packages/utils/indexer/rust/test/index.spec.ts packages/programs/data/document/document/src/search.ts packages/programs/data/document/document/benchmark/document-put.ts packages/programs/data/document/document/test/index.spec.ts` (passes with one existing document test warning)
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/utils/indexer/rust -- -t node --grep "contextual document puts"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "validated local append path"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "trim deduplicate changes"`
- `git diff --check`