### PR TITLE
Use native graph for trim oldest planning

### DIFF
--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -60,6 +60,8 @@ type NativeLogIndexHandle = {
 	payload_size_sum: () => number;
 	has: (hash: string) => boolean;
 	has_many: (hashes: string[]) => string[];
+	oldest_hash: () => string | undefined;
+	newest_hash: () => string | undefined;
 	put: (
 		hash: string,
 		gid: string,
@@ -357,6 +359,14 @@ export class LogGraphIndex {
 
 	has(hash: string): boolean {
 		return this.native.has(hash);
+	}
+
+	oldestHash(): string | undefined {
+		return this.native.oldest_hash();
+	}
+
+	newestHash(): string | undefined {
+		return this.native.newest_hash();
 	}
 
 	hasMany(hashes: Iterable<string>): Set<string> {

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -121,6 +121,20 @@ impl LogGraphIndex {
             .collect()
     }
 
+    pub fn oldest_hash(&self) -> Option<String> {
+        self.entries
+            .values()
+            .min_by(|left, right| compare_entry_order(left, right))
+            .map(|entry| entry.hash.clone())
+    }
+
+    pub fn newest_hash(&self) -> Option<String> {
+        self.entries
+            .values()
+            .max_by(|left, right| compare_entry_order(left, right))
+            .map(|entry| entry.hash.clone())
+    }
+
     pub fn get(&self, hash: &str) -> Option<&LogIndexEntry> {
         self.entries.get(hash)
     }
@@ -469,6 +483,10 @@ fn compare_clock(wall_time: u64, logical: u32, other: &LogIndexEntry) -> std::cm
         .then_with(|| logical.cmp(&other.logical))
 }
 
+fn compare_entry_order(left: &LogIndexEntry, right: &LogIndexEntry) -> std::cmp::Ordering {
+    compare_clock(left.wall_time, left.logical, right).then_with(|| left.hash.cmp(&right.hash))
+}
+
 #[wasm_bindgen]
 pub struct NativeLogIndex {
     inner: LogGraphIndex,
@@ -601,6 +619,20 @@ impl NativeLogIndex {
 
     pub fn has(&self, hash: &str) -> bool {
         self.inner.has(hash)
+    }
+
+    pub fn oldest_hash(&self) -> JsValue {
+        self.inner
+            .oldest_hash()
+            .map(|hash| JsValue::from_str(&hash))
+            .unwrap_or(JsValue::UNDEFINED)
+    }
+
+    pub fn newest_hash(&self) -> JsValue {
+        self.inner
+            .newest_hash()
+            .map(|hash| JsValue::from_str(&hash))
+            .unwrap_or(JsValue::UNDEFINED)
     }
 
     pub fn has_many(&self, hashes: Array) -> Result<Array, JsValue> {
@@ -1903,6 +1935,20 @@ mod tests {
             ]),
             vec![true, false, false],
         );
+    }
+
+    #[test]
+    fn returns_oldest_and_newest_hash_by_clock_order() {
+        let mut index = LogGraphIndex::new();
+        index.put(LogIndexEntry::new("b", "g", vec![], APPEND, 2, 0, 1, true));
+        index.put(LogIndexEntry::new("a", "g", vec![], APPEND, 1, 1, 1, true));
+        index.put(LogIndexEntry::new("c", "g", vec![], APPEND, 1, 0, 1, true));
+
+        assert_eq!(index.oldest_hash(), Some("c".to_string()));
+        assert_eq!(index.newest_hash(), Some("b".to_string()));
+
+        index.delete("c");
+        assert_eq!(index.oldest_hash(), Some("a".to_string()));
     }
 
     #[test]

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -39,6 +39,13 @@ export type ResultsIterator<T> = {
 const ENTRY_CACHE_MAX_SIZE = 10; // TODO as param for log
 const DEFERRED_INDEX_FLUSH_IDLE_MS = 250;
 const NATIVE_GRAPH_REBUILD_BATCH_SIZE = 512;
+const TIMESTAMP_WALL_TIME_KEY = [
+	"meta",
+	"clock",
+	"timestamp",
+	"wallTime",
+];
+const TIMESTAMP_LOGICAL_KEY = ["meta", "clock", "timestamp", "logical"];
 
 type BlocksWithGetMany = Blocks & {
 	getMany?: (
@@ -177,6 +184,8 @@ export type NativeLogGraph = {
 		skipFirst?: boolean,
 	) => string[];
 	payloadSizeSum: () => number;
+	oldestHash?: () => string | undefined;
+	newestHash?: () => string | undefined;
 	countHasNext: (next: string, excludeHash?: string) => number;
 	shadowedGids: (gid: string, next: string[], excludeHash?: string) => string[];
 	planJoin: (
@@ -276,6 +285,26 @@ const canBatchResolveFromStore = (
 		return false;
 	}
 	return typeof options !== "object" || !options.remote;
+};
+
+const sortKeyEquals = (sort: Sort | undefined, key: string[]) =>
+	Array.isArray(sort?.key) &&
+	sort.key.length === key.length &&
+	sort.key.every((part, index) => part === key[index]);
+
+const timestampSortDirection = (sort: Sort[]): SortDirection | undefined => {
+	if (sort.length < 2) {
+		return;
+	}
+	const [wallTime, logical] = sort;
+	if (
+		!sortKeyEquals(wallTime, TIMESTAMP_WALL_TIME_KEY) ||
+		!sortKeyEquals(logical, TIMESTAMP_LOGICAL_KEY) ||
+		wallTime.direction !== logical.direction
+	) {
+		return;
+	}
+	return wallTime.direction;
 };
 export type ReturnTypeFromResolveOptions<
 	R extends MaybeResolveOptions,
@@ -760,6 +789,15 @@ export class EntryIndex<T> {
 		T extends boolean,
 		R = T extends true ? Entry<any> : ShallowEntry,
 	>(resolve?: T): Promise<R | undefined> {
+		const nativeHash = this.getNativeTimestampOrderedHash("oldest");
+		if (nativeHash) {
+			const nativeResult = resolve
+				? await this.resolve(nativeHash)
+				: (await this.getShallow(nativeHash))?.value;
+			if (nativeResult) {
+				return nativeResult as R;
+			}
+		}
 		const iterator = this.iterate([], this.properties.sort.sort, resolve);
 		const results = await iterator.next(1);
 		await iterator.close();
@@ -770,10 +808,37 @@ export class EntryIndex<T> {
 		T extends boolean,
 		R = T extends true ? Entry<any> : ShallowEntry,
 	>(resolve?: T): Promise<R | undefined> {
+		const nativeHash = this.getNativeTimestampOrderedHash("newest");
+		if (nativeHash) {
+			const nativeResult = resolve
+				? await this.resolve(nativeHash)
+				: (await this.getShallow(nativeHash))?.value;
+			if (nativeResult) {
+				return nativeResult as R;
+			}
+		}
 		const iterator = this.iterate([], this.sortReversed, resolve);
 		const results = await iterator.next(1);
 		await iterator.close();
 		return results[0] as R;
+	}
+
+	private getNativeTimestampOrderedHash(
+		position: "oldest" | "newest",
+	): string | undefined {
+		const graph = this.properties.nativeGraph?.graph;
+		if (!graph?.oldestHash || !graph.newestHash) {
+			return;
+		}
+		const direction = timestampSortDirection(this.properties.sort.sort);
+		if (direction == null) {
+			return;
+		}
+		const useNewest =
+			direction === SortDirection.ASC
+				? position === "newest"
+				: position === "oldest";
+		return useNewest ? graph.newestHash() : graph.oldestHash();
 	}
 
 	async getBefore<

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -320,7 +320,7 @@ export class Log<T> {
 				index: this._entryIndex,
 				deleteNode: async (node: ShallowEntry) => {
 					const resolved = await this.get(node.hash);
-					await this._entryIndex.delete(node.hash);
+					await this._entryIndex.delete(node.hash, node);
 					await this._storage.rm(node.hash);
 					return resolved;
 				},

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -360,6 +360,34 @@ describe("native graph", () => {
 		}
 	});
 
+	it("uses the native graph to plan unfiltered length trim", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			appendDurability: "strict",
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+			trim: { type: "length", to: 2 },
+		});
+		const nativeGraph = log.entryIndex.properties.nativeGraph!.graph;
+		const oldestHashSpy = sinon.spy(nativeGraph, "oldestHash");
+		const iterateSpy = sinon.spy(log.entryIndex.properties.index, "iterate");
+		try {
+			const first = (await log.append(new Uint8Array([1]), { meta: { next: [] } }))
+				.entry;
+			await log.append(new Uint8Array([2]));
+			await log.append(new Uint8Array([3]));
+
+			expect(oldestHashSpy.callCount).greaterThan(0);
+			expect(iterateSpy.callCount).equal(0);
+			expect(await log.has(first.hash)).equal(false);
+			expect(await log.entryIndex.getOldest()).to.exist;
+		} finally {
+			iterateSpy.restore();
+			oldestHashSpy.restore();
+			await log.close();
+		}
+	});
+
 	it("plans cut recursion deletes in the native graph", async () => {
 		const log = new Log<Uint8Array>();
 		await log.open(store, signKey, {


### PR DESCRIPTION
## Summary
- expose native log graph `oldestHash()` / `newestHash()` from `@peerbit/log-rust`
- use native graph hashes for `EntryIndex.getOldest()` / `getNewest()` when the log uses timestamp ordering
- pass the already-known shallow trim node into `EntryIndex.delete()` to avoid a duplicate lookup during unfiltered length trim

## Benchmark
Local deep document-put profile:

`DOC_WARMUP=20 DOC_ITERATIONS=300 DOC_SCENARIOS=rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique,simple-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts`

Baseline from #868, same command:
- `rust-peerbit-nonunique`: 1833 ops/sec, total 163.64 ms, log append 86.13 ms, log trim 31.58 ms
- `rust-peerbit-transient-index-nonunique`: 2331 ops/sec, total 128.71 ms, log append 71.17 ms, log trim 23.44 ms
- `simple-index-nonunique`: 3820 ops/sec, total 78.54 ms, log append 55.66 ms, log trim 17.30 ms

After this PR:
- `rust-peerbit-nonunique`: 2090 ops/sec, total 143.57 ms, log append 71.21 ms, log trim 16.75 ms
- `rust-peerbit-transient-index-nonunique`: 2666 ops/sec, total 112.54 ms, log append 57.04 ms, log trim 11.86 ms
- `simple-index-nonunique`: 4602 ops/sec, total 65.18 ms, log append 43.45 ms, log trim 5.67 ms

## Validation
- `cargo fmt --manifest-path packages/log/rust/Cargo.toml`
- `cargo test --manifest-path packages/log/rust/Cargo.toml returns_oldest_and_newest_hash_by_clock_order`
- `pnpm --filter @peerbit/log-rust run build`
- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/document run build`
- `pnpm exec eslint --config eslint.config.js packages/log/src/entry-index.ts packages/log/src/log.ts packages/log/rust/src/index.ts packages/log/test/native-graph.spec.ts`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "uses the native graph to plan unfiltered length trim"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "append commits one block and graph in one native call when storage is native"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "trim"`
- `git diff --check`