### PR TITLE
Plan target-none appends with native shared-log state

### DIFF
--- a/packages/programs/data/document/document/benchmark/document-put.ts
+++ b/packages/programs/data/document/document/benchmark/document-put.ts
@@ -316,6 +316,18 @@ const runScenario = async (name: string): Promise<BenchRow> => {
 				),
 				patchAsyncMethod(
 					store.docs.log as any,
+					"planNativeLocalAppendEntry",
+					profile,
+					"sharedPlanEntryLeadersMs",
+				),
+				patchAsyncMethod(
+					store.docs.log as any,
+					"planNativeAppendEntry",
+					profile,
+					"sharedPlanEntryLeadersMs",
+				),
+				patchAsyncMethod(
+					store.docs.log as any,
 					"persistCoordinate",
 					profile,
 					"sharedPersistCoordinateMs",

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -239,6 +239,39 @@ describe("index", () => {
 				}
 			});
 
+			it("uses native shared-log planning for replicated target-none puts", async () => {
+				store = new TestStore({
+					docs: new Documents<Document>(),
+				});
+				await session.peers[0].open(store, {
+					args: {
+						replicate: { factor: 1 },
+						timeUntilRoleMaturity: 0,
+					},
+				});
+				const nativeState = (store.docs.log as any)._nativeSharedLogState;
+				expect(nativeState).to.exist;
+				const nativePlanSpy = sinon.spy(nativeState, "planLocalAppendForGid");
+				const planEntryLeadersSpy = sinon.spy(
+					store.docs.log as any,
+					"planEntryLeaders",
+				);
+
+				try {
+					await store.docs.put(new Document({ id: uuid(), name: "native" }), {
+						unique: true,
+						replicate: false,
+						target: "none",
+					});
+
+					expect(nativePlanSpy.callCount).equal(1);
+					expect(planEntryLeadersSpy.callCount).equal(0);
+				} finally {
+					planEntryLeadersSpy.restore();
+					nativePlanSpy.restore();
+				}
+			});
+
 			it("uses the validated local append path for document updates", async () => {
 				store = new TestStore({
 					docs: new Documents<Document>(),

--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -304,6 +304,20 @@ type NativeSharedLogStateHandle = {
 		fullReplicaFallback: boolean,
 		includeStrictFullReplica: boolean,
 	) => [unknown[], unknown[], boolean];
+	plan_local_append_for_gid: (
+		entryHash: string,
+		gid: string,
+		nextHashes: string[],
+		replicas: number,
+		roleAgeMs: number,
+		now: string,
+		peerFilter: string[] | undefined,
+		expandPeerFilter: boolean,
+		selfHash: string,
+		includeSelf: boolean,
+		fullReplicaFallback: boolean,
+		includeStrictFullReplica: boolean,
+	) => [unknown[], unknown[], boolean, boolean];
 	plan_append_leaders_for_delivery: (
 		leaders: unknown[],
 		fullReplicaCandidates: string[],
@@ -931,6 +945,35 @@ export class SharedLogNativeState {
 		return {
 			coordinates: rowsToNumbers(this.resolution, coordinateRows),
 			leaders: rowsToSamples(leaderRows),
+			assignedToRangeBoundary,
+		};
+	}
+
+	planLocalAppendForGid(
+		input: {
+			entryHash: string;
+			gid: string;
+			nextHashes?: Iterable<string>;
+			replicas: number;
+			selfHash: string;
+		},
+		options?: FindLeaderOptions,
+	): EntryAssignmentPlan & { isLeader: boolean } {
+		const [coordinateRows, leaderRows, isLeader, assignedToRangeBoundary] =
+			this.native.plan_local_append_for_gid(
+				input.entryHash,
+				input.gid,
+				input.nextHashes ? [...input.nextHashes] : [],
+				input.replicas,
+				...findLeaderArguments({
+					...options,
+					selfHash: input.selfHash,
+				}),
+			);
+		return {
+			coordinates: rowsToNumbers(this.resolution, coordinateRows),
+			leaders: rowsToSamples(leaderRows),
+			isLeader,
 			assignedToRangeBoundary,
 		};
 	}

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -1857,6 +1857,56 @@ impl NativeSharedLogState {
         Ok(out)
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn plan_local_append_for_gid(
+        &mut self,
+        entry_hash: String,
+        gid: String,
+        next_hashes: Array,
+        replicas: usize,
+        role_age_ms: f64,
+        now: String,
+        peer_filter: JsValue,
+        expand_peer_filter: bool,
+        self_hash: String,
+        include_self: bool,
+        full_replica_fallback: bool,
+        include_strict_full_replica: bool,
+    ) -> Result<Array, JsValue> {
+        let next_hashes = strings_from_array(next_hashes)?;
+        let coordinates = self.inner.range_planner.get_gid_coordinates(&gid, replicas);
+        let options = find_leader_options(role_age_ms, &now, peer_filter)?;
+        let leaders = self.inner.range_planner.find_leaders(
+            &coordinates,
+            replicas,
+            &options,
+            expand_peer_filter,
+            &self_hash,
+            include_self,
+            full_replica_fallback,
+            include_strict_full_replica,
+        );
+        let is_leader = leaders.iter().any(|leader| leader.hash == self_hash);
+        let assigned_to_range_boundary = should_assign_to_range_boundary(&leaders, replicas);
+
+        self.inner
+            .entry_coordinates
+            .insert(entry_hash, coordinates.clone());
+        for next_hash in next_hashes {
+            self.inner.entry_coordinates.remove(&next_hash);
+        }
+
+        let out = Array::new();
+        out.push(&numbers_to_rows(
+            coordinates,
+            self.inner.range_planner.resolution,
+        ));
+        out.push(&samples_to_rows(leaders));
+        out.push(&JsValue::from_bool(is_leader));
+        out.push(&JsValue::from_bool(assigned_to_range_boundary));
+        Ok(out)
+    }
+
     pub fn plan_append_leaders_for_delivery(
         &self,
         leaders: Array,

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -283,7 +283,7 @@ type EntryLeaderPlan<R extends "u32" | "u64"> = {
 };
 
 type NativeAppendEntryPlan<R extends "u32" | "u64"> = EntryLeaderPlan<R> & {
-	delivery: AppendDeliveryPlan;
+	delivery?: AppendDeliveryPlan;
 };
 
 type EntryLeaderBatchItem<R extends "u32" | "u64"> = {
@@ -4183,6 +4183,33 @@ export class SharedLog<
 		};
 	}
 
+	private async planNativeLocalAppendEntry(
+		entry: Entry<T>,
+		replicas: number,
+	): Promise<NativeAppendEntryPlan<R> | undefined> {
+		if (!this._nativeSharedLogState || !this.canPlanNativeHashGid(entry)) {
+			return undefined;
+		}
+
+		const context = await this.createLeaderSelectionContext();
+		const plan = this._nativeSharedLogState.planLocalAppendForGid(
+			{
+				entryHash: entry.hash,
+				gid: entry.meta.gid,
+				nextHashes: entry.meta.next,
+				replicas,
+				selfHash: context.selfHash,
+			},
+			this.createNativeLeaderOptions(context),
+		);
+		return {
+			coordinates: plan.coordinates as NumberFromType<R>[],
+			leaders: plan.leaders,
+			isLeader: plan.isLeader,
+			assignedToRangeBoundary: plan.assignedToRangeBoundary,
+		};
+	}
+
 	private async planNativeAppendEntries(
 		entries: Entry<T>[],
 		replicas: number,
@@ -4263,15 +4290,20 @@ export class SharedLog<
 		const selfHash = this.node.identity.publicKey.hashcode();
 		const target = options?.target;
 		const deliveryArg = options?.delivery;
-		const nativeAppendPlan =
-			properties.nativeAppendPlan ??
-			(target !== "all" && target !== "none"
-				? await this.planNativeAppendEntry(
+		let nativeAppendPlan = properties.nativeAppendPlan;
+		if (!nativeAppendPlan && target !== "all") {
+			nativeAppendPlan =
+				target === "none"
+					? await this.planNativeLocalAppendEntry(
+							entry,
+							properties.minReplicasValue,
+						)
+					: await this.planNativeAppendEntry(
 						entry,
 						properties.minReplicasValue,
 						deliveryArg,
-					)
-				: undefined);
+					);
+		}
 		let coordinates: NumberFromType<R>[];
 		let leaders: LeaderMap;
 		let isLeader: boolean;


### PR DESCRIPTION
## Summary
- add a true native shared-log local append planner for hash-domain `target: "none"` appends
- route eligible local appends through the native local planner instead of the cursor-based `planEntryLeaders` fallback
- keep delivery-oriented append planning unchanged for replicated sends, and keep all custom-domain fallbacks intact
- extend document-put profiling so native local planning is included in the leader-planning timing column

## Benchmark
Local node deep profile:

```bash
DOC_WARMUP=50 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique,simple-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Results:

- `rust-peerbit-nonunique`: 2088 ops/sec, total 478.83 ms, shared append 334.09 ms, shared process 73.94 ms, shared plan 26.32 ms, coordinate persist 42.42 ms, log append 232.46 ms, log trim 60.33 ms, document index put 59.62 ms
- `rust-peerbit-transient-index-nonunique`: 2895 ops/sec, total 345.44 ms, shared append 244.29 ms, shared process 48.28 ms, shared plan 15.78 ms, coordinate persist 31.52 ms, log append 176.55 ms, log trim 41.03 ms, document index put 46.41 ms
- `simple-index-nonunique`: 5294 ops/sec, total 188.89 ms, shared append 162.82 ms, shared process 24.86 ms, shared plan 12.04 ms, coordinate persist 12.02 ms, log append 134.32 ms, log trim 18.91 ms, document index put 1.81 ms

This is mainly a structural native-path step. Total document-put throughput is roughly neutral versus the previous stacked PR in local runs; the remaining hot columns are lower-log append, coordinate persistence, trim, and document index commit.

## Validation
- `cargo fmt --manifest-path packages/programs/data/shared-log/rust/Cargo.toml`
- `pnpm --filter @peerbit/shared-log-rust run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/rust/src/index.ts packages/programs/data/shared-log/src/index.ts packages/programs/data/document/document/benchmark/document-put.ts packages/programs/data/document/document/test/index.spec.ts`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "native shared-log planning"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "validated local append path"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "leader are selected from 1 replicating peer"`
- `git diff --check`
