### PR TITLE
Reduce shared-log coordinate persistence overhead

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -7166,14 +7166,17 @@ export class SharedLog<
 			this.coordinateToHash.add(coordinate, properties.entry.hash);
 		}
 
-		if (properties.entry.meta.next.length > 0) {
-			await this.entryCoordinatesIndex.del({
-				query: new Or(
-					properties.entry.meta.next.map(
-						(x) => new StringMatch({ key: "hash", value: x }),
-					),
-				),
-			});
+		const nextHashes = properties.entry.meta.next;
+		if (nextHashes.length > 0) {
+			await this.entryCoordinatesIndex.del(
+				nextHashes.length === 1
+					? { query: { hash: nextHashes[0] } }
+					: {
+							query: new Or(
+								nextHashes.map((x) => new StringMatch({ key: "hash", value: x })),
+							),
+						},
+			);
 		}
 		return true;
 	}

--- a/packages/programs/data/shared-log/src/ranges.ts
+++ b/packages/programs/data/shared-log/src/ranges.ts
@@ -144,7 +144,6 @@ export class EntryReplicatedU32 implements EntryReplicated<"u32"> {
 				? new ShallowMeta(properties.meta)
 				: properties.meta;
 		this._meta = serialize(shallow);
-		this._metaResolved = deserialize(this._meta, ShallowMeta);
 		this._metaResolved = properties.meta;
 		this.assignedToRangeBoundary = properties.assignedToRangeBoundary;
 	}
@@ -199,7 +198,6 @@ export class EntryReplicatedU64 implements EntryReplicated<"u64"> {
 				? new ShallowMeta(properties.meta)
 				: properties.meta;
 		this._meta = serialize(shallow);
-		this._metaResolved = deserialize(this._meta, ShallowMeta);
 		this._metaResolved = properties.meta;
 		this.assignedToRangeBoundary = properties.assignedToRangeBoundary;
 	}


### PR DESCRIPTION
## Summary
- remove an immediately-discarded `ShallowMeta` deserialize from `EntryReplicatedU32` / `EntryReplicatedU64` construction
- delete the common single-next coordinate row with a direct `{ hash }` query instead of building an `Or(StringMatch(...))` query
- keep the existing multi-next deletion behavior unchanged

## Benchmark
Local node deep profile:

```bash
DOC_WARMUP=50 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique,simple-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Baseline from #870, same command:

- `rust-peerbit-nonunique`: 2088 ops/sec, total 478.83 ms, shared persist coordinate 42.42 ms, shared append 334.09 ms
- `rust-peerbit-transient-index-nonunique`: 2895 ops/sec, total 345.44 ms, shared persist coordinate 31.52 ms, shared append 244.29 ms
- `simple-index-nonunique`: 5294 ops/sec, total 188.89 ms, shared persist coordinate 12.02 ms, shared append 162.82 ms

After this PR:

- `rust-peerbit-nonunique`: 2394 ops/sec, total 417.66 ms, shared persist coordinate 34.27 ms, shared append 290.79 ms
- `rust-peerbit-transient-index-nonunique`: 2888 ops/sec, total 346.28 ms, shared persist coordinate 28.18 ms, shared append 245.97 ms
- `simple-index-nonunique`: 5333 ops/sec, total 187.52 ms, shared persist coordinate 10.20 ms, shared append 159.96 ms

## Validation
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/index.ts packages/programs/data/shared-log/src/ranges.ts`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "leader are selected from 1 replicating peer"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "validated local append path"`
- `git diff --check`
