### PR TITLE
Use native byte facts in the Rust indexer

### DIFF
--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -63,7 +63,8 @@ type NativeValue =
 	| { type: "bool"; value: boolean }
 	| { type: "i64"; value: number | bigint }
 	| { type: "u64"; value: number | bigint }
-	| { type: "string"; value: string };
+	| { type: "string"; value: string }
+	| { type: "bytes"; value: Uint8Array };
 type NativeIntegerValue = Extract<
 	NativeValue,
 	{ type: "i64" } | { type: "u64" }
@@ -125,6 +126,7 @@ const enum NativeValueTag {
 	I64 = 1,
 	U64 = 2,
 	String = 3,
+	Bytes = 4,
 }
 
 const enum NativeQueryTag {
@@ -264,14 +266,6 @@ const appendNativeFieldCursor = (
 ): NativeFieldCursor =>
 	nativeFieldCursor(dictionary, appendNativeFieldKey(parent?.field, key));
 
-const bytesToNativeString = (bytes: Uint8Array): string => {
-	let hex = "";
-	for (const byte of bytes) {
-		hex += byte.toString(16).padStart(2, "0");
-	}
-	return `\u0000bytes:${hex}`;
-};
-
 const nativeIntegerValue = (
 	value: number | bigint,
 ): NativeIntegerValue | undefined => {
@@ -382,6 +376,13 @@ const writeNativeValue = (writer: BinaryWriter, value: NativeValue): void => {
 		case "string":
 			writer.u8(NativeValueTag.String);
 			writer.string(value.value);
+			return;
+		case "bytes":
+			writer.u8(NativeValueTag.Bytes);
+			writer.u32(value.value.byteLength);
+			for (const byte of value.value) {
+				writer.u8(byte);
+			}
 			return;
 	}
 };
@@ -553,6 +554,16 @@ class NativeFieldWriter {
 		this.offset = writeBytes(this.output, this.view, this.offset, valueBytes);
 	}
 
+	writeBytesValue(scope: number, fieldId: number, valueBytes: Uint8Array): void {
+		this.writeHeader(
+			scope,
+			fieldId,
+			NativeValueTag.Bytes,
+			4 + valueBytes.byteLength,
+		);
+		this.offset = writeBytes(this.output, this.view, this.offset, valueBytes);
+	}
+
 	finish(): Uint8Array {
 		this.view.setUint32(1, this.facts, true);
 		return this.output.subarray(0, this.offset);
@@ -652,7 +663,7 @@ const writeNativeBytesFacts = (
 		value instanceof Uint8Array
 			? value
 			: new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
-	writer.writeString(scope, fieldId, bytesToNativeString(bytes));
+	writer.writeBytesValue(scope, fieldId, bytes);
 	if (bytes.byteLength > byteElementIndexLimit) {
 		return;
 	}
@@ -1134,7 +1145,7 @@ const compileNativeQuery = (
 			spec: {
 				op: "exact",
 				field: nativeFieldId(dictionary, [...prefix, ...query.key]),
-				value: { type: "string", value: bytesToNativeString(query.value) },
+				value: { type: "bytes", value: query.value },
 			},
 			exact: true,
 		};

--- a/packages/utils/indexer/rust/src/lib.rs
+++ b/packages/utils/indexer/rust/src/lib.rs
@@ -296,6 +296,7 @@ enum FieldValueDto {
     I64(i64),
     U64(u64),
     String(String),
+    Bytes(Vec<u8>),
 }
 
 #[derive(BorshDeserialize)]
@@ -431,6 +432,10 @@ impl<'a> BridgeReader<'a> {
             1 => FieldValue::I64(self.read_i64()?),
             2 => FieldValue::U64(self.read_u64()?),
             3 => FieldValue::String(self.read_string()?),
+            4 => {
+                let len = self.read_u32()? as usize;
+                FieldValue::Bytes(self.read_exact(len)?.to_vec())
+            }
             tag => return Err(js_error(format!("Unknown bridge field value tag {tag}"))),
         })
     }
@@ -528,6 +533,7 @@ impl From<FieldValueDto> for FieldValue {
             FieldValueDto::I64(value) => FieldValue::I64(value),
             FieldValueDto::U64(value) => FieldValue::U64(value),
             FieldValueDto::String(value) => FieldValue::String(value),
+            FieldValueDto::Bytes(value) => FieldValue::Bytes(value),
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend the TS/Rust index bridge with a native `bytes` scalar value
- encode `Uint8Array` fields as byte facts instead of hex-encoded strings
- send `ByteMatchQuery` values to Rust as raw bytes
- preserve exact byte matching and keep per-byte integer facts controlled by `byteElementIndexLimit`

## Why
Document put benchmarks use a 1200-byte field. The Rust indexer was still converting every byte field into a hex string for exact `ByteMatchQuery` support, even though the Rust planner already supports `FieldValue::Bytes`. This keeps the same exact-query behavior while removing that avoidable JS expansion and string allocation.

## Benchmark
Local node deep profile:

```bash
DOC_WARMUP=50 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique,simple-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Baseline from #871, same command:

- `rust-peerbit-nonunique`: 2394 ops/sec, total 417.66 ms, document index put 55.54 ms, backend index put 53.51 ms
- `rust-peerbit-transient-index-nonunique`: 2888 ops/sec, total 346.28 ms, document index put 42.01 ms, backend index put 40.48 ms
- `simple-index-nonunique`: 5333 ops/sec, total 187.52 ms, document index put 2.02 ms, backend index put 0.27 ms

After this PR:

- `rust-peerbit-nonunique`: 2452 ops/sec, total 407.83 ms, document index put 24.22 ms, backend index put 21.98 ms
- `rust-peerbit-transient-index-nonunique`: 3108 ops/sec, total 321.70 ms, document index put 15.75 ms, backend index put 14.07 ms
- `simple-index-nonunique`: 5129 ops/sec, total 194.97 ms, document index put 2.02 ms, backend index put 0.27 ms

## Validation
- `cargo fmt --manifest-path packages/utils/indexer/rust/Cargo.toml`
- `cargo test --manifest-path packages/utils/indexer/rust/Cargo.toml`
- `pnpm --filter @peerbit/indexer-rust run build`
- `pnpm exec eslint --config eslint.config.js packages/utils/indexer/rust/src/index.ts`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/utils/indexer/rust -- -t node --grep "byte"`
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "validated local append path"`
- `git diff --check`
