### PR TITLE
Avoid resolving trimmed prepared document puts

### DIFF
--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -318,11 +318,18 @@ export class Log<T> {
 		this._trim = new Trim(
 			{
 				index: this._entryIndex,
-				deleteNode: async (node: ShallowEntry) => {
-					const resolved = await this.get(node.hash);
-					await this._entryIndex.delete(node.hash, node);
+				deleteNode: async (
+					node: ShallowEntry,
+					options?: { resolveDeletedEntry?: boolean },
+				) => {
+					const shouldResolve = options?.resolveDeletedEntry !== false;
+					const resolved = shouldResolve ? await this.get(node.hash) : undefined;
+					const deleted = await this._entryIndex.delete(node.hash, node);
 					await this._storage.rm(node.hash);
-					return resolved;
+					if (!deleted) {
+						return resolved;
+					}
+					return shouldResolve ? resolved : deleted;
 				},
 				sortFn: this._sortFn,
 				getLength: () => this.length,
@@ -618,7 +625,7 @@ export class Log<T> {
 
 		const pendingDeletes: (
 			| PendingDelete<T>
-			| { entry: Entry<T>; fn: undefined }
+			| { entry: ShallowOrFullEntry<T>; fn: undefined }
 		)[] = await this.processEntry(entry);
 
 		entry.init({ encoding: this._encoding, keychain: this._keychain });
@@ -648,7 +655,10 @@ export class Log<T> {
 	async appendLocallyPrepared(
 		data: T,
 		options: AppendOptions<T> = {},
-		properties?: { skipMissingNextJoin?: boolean },
+		properties?: {
+			skipMissingNextJoin?: boolean;
+			resolveTrimmedEntries?: boolean;
+		},
 	): Promise<{
 		entry: Entry<T>;
 		removed: ShallowOrFullEntry<T>[];
@@ -713,7 +723,9 @@ export class Log<T> {
 
 		entry.init({ encoding: this._encoding, keychain: this._keychain });
 
-		const trimmed = await this.trim(appendOptions.trim);
+		const trimmed = await this.trim(appendOptions.trim, {
+			resolveDeletedEntries: properties?.resolveTrimmedEntries,
+		});
 		const removed = trimmed ?? [];
 		const change: Change<T> = {
 			added: [{ head: true, entry }],
@@ -739,7 +751,7 @@ export class Log<T> {
 		const entries: Entry<T>[] = [];
 		const pendingDeletes: (
 			| PendingDelete<T>
-			| { entry: Entry<T>; fn: undefined }
+			| { entry: ShallowOrFullEntry<T>; fn: undefined }
 		)[] = [];
 		const deferBlockStore = hasPutMany(this._storage);
 		const nativeAppendChain = await this.createNativePlainAppendChain(
@@ -1097,8 +1109,11 @@ export class Log<T> {
 		return change;
 	}
 
-	async trim(option: TrimOptions | undefined = this._trim.options) {
-		return this._trim.trim(option);
+	async trim(
+		option: TrimOptions | undefined = this._trim.options,
+		properties?: { resolveDeletedEntries?: boolean },
+	) {
+		return this._trim.trim(option, properties);
 	}
 
 	async join(
@@ -1430,7 +1445,7 @@ export class Log<T> {
 
 		const pendingDeletes: (
 			| PendingDelete<T>
-			| { entry: Entry<T>; fn: undefined }
+			| { entry: ShallowOrFullEntry<T>; fn: undefined }
 		)[] = await this.processEntry(entry);
 		const trimmed = await this.trim(options.trim);
 

--- a/packages/log/src/trim.ts
+++ b/packages/log/src/trim.ts
@@ -82,7 +82,10 @@ export type TrimOptions = TrimCanAppendOption & TrimCondition;
 interface Log<T> {
 	index: EntryIndex<T>;
 	sortFn: SortFn;
-	deleteNode: (node: ShallowEntry) => Promise<Entry<T> | undefined>;
+	deleteNode: (
+		node: ShallowEntry,
+		options?: { resolveDeletedEntry?: boolean },
+	) => Promise<Entry<T> | ShallowEntry | undefined>;
 	getLength(): number;
 }
 export class Trim<T> {
@@ -120,15 +123,16 @@ export class Trim<T> {
 
 	private async trimTask(
 		option: TrimOptions | undefined = this._trim,
-	): Promise<Entry<T>[]> {
+		options?: { resolveDeletedEntries?: boolean },
+	): Promise<(Entry<T> | ShallowEntry)[]> {
 		if (!option) {
 			return [];
 		}
 		if (option.type === "length" && !option.filter?.canTrim) {
-			return this.trimUnfilteredLength(option);
+			return this.trimUnfilteredLength(option, options);
 		}
 		///  TODO Make this method less ugly
-		const deleted: Entry<T>[] = [];
+		const deleted: (Entry<T> | ShallowEntry)[] = [];
 
 		let done: () => Promise<boolean> | boolean;
 		/* 		const valueIterator = this._log.index.query([], this._log.sortFn.sort, false); */
@@ -255,7 +259,9 @@ export class Trim<T> {
 					false,
 				);
 
-				const entry = await this._log.deleteNode(node);
+				const entry = await this._log.deleteNode(node, {
+					resolveDeletedEntry: options?.resolveDeletedEntries,
+				});
 				if (entry) {
 					deleted.push(entry);
 				}
@@ -292,14 +298,15 @@ export class Trim<T> {
 
 	private async trimUnfilteredLength(
 		option: TrimToLengthOption,
-	): Promise<Entry<T>[]> {
+		options?: { resolveDeletedEntries?: boolean },
+	): Promise<(Entry<T> | ShallowEntry)[]> {
 		const to = option.to;
 		const from = option.from ?? to;
 		if (this._log.getLength() < from) {
 			return [];
 		}
 
-		const deleted: Entry<T>[] = [];
+		const deleted: (Entry<T> | ShallowEntry)[] = [];
 		this._canTrimCacheHashBreakpoint.clear();
 		this._canTrimCacheLastNode = undefined;
 		this._trimLastHead = undefined;
@@ -311,7 +318,9 @@ export class Trim<T> {
 			if (!node) {
 				break;
 			}
-			const entry = await this._log.deleteNode(node);
+			const entry = await this._log.deleteNode(node, {
+				resolveDeletedEntry: options?.resolveDeletedEntries,
+			});
 			if (entry) {
 				deleted.push(entry);
 			}
@@ -328,11 +337,14 @@ export class Trim<T> {
 	 */
 	async trim(
 		options: TrimOptions | undefined = this._trim,
-	): Promise<Entry<T>[] | undefined> {
+		properties?: { resolveDeletedEntries?: boolean },
+	): Promise<(Entry<T> | ShallowEntry)[] | undefined> {
 		if (!options) {
 			return;
 		}
-		const result = await this._queue.add(() => this.trimTask(options));
+		const result = await this._queue.add(() =>
+			this.trimTask(options, properties),
+		);
 		if (result instanceof Object) {
 			return result;
 		}

--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -766,6 +766,7 @@ export class Documents<
 			},
 			{
 				skipMissingNextJoin: !options?.checkRemote,
+				resolveTrimmedEntries: !this._index.canGetIdentityIndexedByHead(),
 			},
 		);
 		if (!options?.unique && existingLocalContext === undefined) {
@@ -886,6 +887,16 @@ export class Documents<
 		}
 
 		for (const removed of properties.removed) {
+			if (
+				!(removed instanceof Entry) &&
+				(await this.collectRemovedDocumentChangeFromIndexedHead(
+					removed.hash,
+					modified,
+					documentsChanged,
+				))
+			) {
+				continue;
+			}
 			const entry =
 				removed instanceof Entry
 					? removed
@@ -910,6 +921,32 @@ export class Documents<
 		this.events.dispatchEvent(
 			new CustomEvent("change", { detail: documentsChanged }),
 		);
+	}
+
+	private async collectRemovedDocumentChangeFromIndexedHead(
+		head: string,
+		modified: Set<string | number | bigint>,
+		documentsChanged: DocumentsChange<T, I>,
+	): Promise<boolean> {
+		const indexed = await this._index.getIdentityIndexedByHead(head);
+		if (!indexed) {
+			return false;
+		}
+
+		const key = indexed.id;
+		if (modified.has(key.primitive)) {
+			return true;
+		}
+
+		const value = coerceWithIndexed(
+			indexed.value as unknown as WithIndexedContext<T, I>,
+			indexed.value as unknown as I,
+		);
+		documentsChanged.removed.push(value);
+
+		await this._index.del(key);
+		modified.add(key.primitive);
+		return true;
 	}
 
 	private async collectRemovedDocumentChange(

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -662,6 +662,12 @@ type ContextualIndexPut<I> = {
 	) => Promise<void> | void;
 };
 
+type ContextHeadIndex<I> = {
+	getByContextHead?: (
+		head: string,
+	) => indexerTypes.IndexedResult<WithContext<I>> | undefined;
+};
+
 export const coerceWithContext = <T>(
 	value: T | WithContext<T>,
 	context: types.Context,
@@ -1640,6 +1646,25 @@ export class DocumentIndex<
 		await iterator.close();
 		return one[0];
 	}
+
+	public async getIdentityIndexedByHead(
+		head: string,
+	): Promise<indexerTypes.IndexedResult<WithContext<I>> | undefined> {
+		if (!this.canGetIdentityIndexedByHead()) {
+			return;
+		}
+		return (this.index as ContextHeadIndex<I>).getByContextHead?.(head);
+	}
+
+	public canGetIdentityIndexedByHead(): boolean {
+		return (
+			this.transformerIsIdentity &&
+			this.indexedTypeIsDocumentType &&
+			!this.isProgramValued &&
+			typeof (this.index as ContextHeadIndex<I>).getByContextHead === "function"
+		);
+	}
+
 	public async put(
 		value: T,
 		id: indexerTypes.IdKey,

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -54,6 +54,7 @@ import {
 import { SilentDelivery } from "@peerbit/stream-interface";
 import { TestSession } from "@peerbit/test-utils";
 import { waitFor as _waitForFn, delay, waitForResolved } from "@peerbit/time";
+import { createRustPeerbitOptions } from "peerbit/rust";
 import { expect } from "chai";
 import pDefer, { type DeferredPromise } from "p-defer";
 import sinon from "sinon";
@@ -269,6 +270,68 @@ describe("index", () => {
 				} finally {
 					planEntryLeadersSpy.restore();
 					nativePlanSpy.restore();
+				}
+			});
+
+			it("removes trimmed prepared puts from the document index by head", async () => {
+				const rustSession = await TestSession.connected(
+					1,
+					createRustPeerbitOptions(),
+				);
+				store = new TestStore({
+					docs: new Documents<Document>(),
+				});
+				await rustSession.peers[0].open(store, {
+					args: {
+						replicate: false,
+						log: {
+							trim: { type: "length", to: 1 },
+						},
+					},
+				});
+				const changes: DocumentsChange<Document, Document>[] = [];
+				store.docs.events.addEventListener("change", (evt) => {
+					changes.push(evt.detail);
+				});
+
+				const firstId = uuid();
+				const first = await store.docs.put(
+					new Document({ id: firstId, name: "trimmed" }),
+					{
+						unique: true,
+						replicate: false,
+						target: "none",
+					},
+				);
+
+				const lowerLogGetSpy = sinon.spy(store.docs.log.log, "get");
+				const entryIndexGetSpy = sinon.spy(store.docs.log.log.entryIndex, "get");
+
+				try {
+					await store.docs.put(
+						new Document({ id: uuid(), name: "remaining" }),
+						{
+							unique: true,
+							replicate: false,
+							target: "none",
+						},
+					);
+
+					expect(lowerLogGetSpy.withArgs(first.entry.hash).callCount).equal(0);
+					expect(entryIndexGetSpy.withArgs(first.entry.hash).callCount).equal(
+						0,
+					);
+					expect(await store.docs.get(firstId)).to.be.undefined;
+					expect(changes).to.have.length(2);
+					expect(changes[1].removed.map((doc) => doc.id)).to.deep.equal([
+						firstId,
+					]);
+				} finally {
+					entryIndexGetSpy.restore();
+					lowerLogGetSpy.restore();
+					await store.close();
+					store = undefined;
+					await rustSession.stop();
 				}
 			});
 

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -3969,7 +3969,10 @@ export class SharedLog<
 	async appendLocallyPrepared(
 		data: T,
 		options?: SharedAppendOptions<T> | undefined,
-		properties?: { skipMissingNextJoin?: boolean },
+		properties?: {
+			skipMissingNextJoin?: boolean;
+			resolveTrimmedEntries?: boolean;
+		},
 	): Promise<{
 		entry: Entry<T>;
 		removed: ShallowOrFullEntry<T>[];
@@ -3988,6 +3991,7 @@ export class SharedLog<
 		appendOptions.__peerbitCanAppendAlreadyValidated = true;
 		const result = await this.log.appendLocallyPrepared(data, appendOptions, {
 			skipMissingNextJoin: properties?.skipMissingNextJoin,
+			resolveTrimmedEntries: properties?.resolveTrimmedEntries,
 		});
 		await this.onChange(result.change);
 		await this.processLocalAppend(result.entry, result.removed, options, {

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -1273,6 +1273,20 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		};
 	}
 
+	getByContextHead(head: string): types.IndexedResult<T> | undefined {
+		const result = this.getNative().query_page(
+			encodeNativeQuerySpec({
+				op: "exact",
+				field: nativeFieldId(this.fieldDictionary, ["__context", "head"]),
+				value: { type: "string", value: head },
+			}),
+			encodeNativeSort(),
+			0,
+			1,
+		)[0];
+		return result ? { id: result[0], value: result[1] } : undefined;
+	}
+
 	async put(
 		value: T,
 		id = types.toId(types.extractFieldValue(value, this.indexByArr)),


### PR DESCRIPTION
## Summary
- allow the internal prepared append path to receive shallow trim removals
- add a Rust index hook for direct `__context.head` lookup
- remove trimmed identity-transform document puts through the document index head path when that native hook is available
- keep simple/SQLite/custom-transform paths resolving removed log entries as before

## Why
For rolling document logs, every append after the trim window fills removes an older lower-log entry. The prepared document put path already has enough indexed context to remove identity-transform documents by `__context.head`; resolving the old lower-log block just to decode the old put operation is avoidable when the native Rust index can do that head lookup directly.

## Benchmark
Local node deep profile:

```bash
DOC_WARMUP=50 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique,simple-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Baseline from #872, same command:

- `rust-peerbit-nonunique`: 2452 ops/sec, total 407.83 ms, log trim 58.69 ms, document index put 24.22 ms
- `rust-peerbit-transient-index-nonunique`: 3108 ops/sec, total 321.70 ms, log trim 45.26 ms, document index put 15.75 ms
- `simple-index-nonunique`: 5129 ops/sec, total 194.97 ms, log trim 20.08 ms, document index put 2.02 ms

After this PR:

- `rust-peerbit-nonunique`: 2664 ops/sec, total 375.40 ms, log trim 45.26 ms, document index put 22.99 ms
- `rust-peerbit-transient-index-nonunique`: 3848 ops/sec, total 259.88 ms, log trim 25.93 ms, document index put 14.86 ms
- `simple-index-nonunique`: 5034 ops/sec, total 198.66 ms, log trim 23.99 ms, document index put 2.15 ms

## Validation
- `pnpm --filter @peerbit/indexer-rust run build`
- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `pnpm exec eslint --config eslint.config.js packages/utils/indexer/rust/src/index.ts packages/log/src/log.ts packages/log/src/trim.ts packages/programs/data/shared-log/src/index.ts packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/src/search.ts packages/programs/data/document/document/test/index.spec.ts` (one existing unrelated warning in `index.spec.ts`)
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "removes trimmed prepared puts"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "validated local append path"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "trim"`
- `git diff --check`
