### PR TITLE
Cache native plain entry append builder

### DIFF
--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -118,6 +118,16 @@ type NativeLogIndexHandle = {
 		metaData: Uint8Array | undefined,
 		payloadData: Uint8Array,
 	) => EntryV0PreparedPlainEntryRow;
+	prepare_entry_v0_plain_entry_and_put_with_builder: (
+		builder: NativeEntryV0PlainBuilderHandle,
+		wallTime: bigint,
+		logical: number,
+		gid: string,
+		next: string[],
+		type: number,
+		metaData: Uint8Array | undefined,
+		payloadData: Uint8Array,
+	) => EntryV0PreparedPlainEntryRow;
 	prepare_entry_v0_plain_chain_commit_blocks_and_put: (
 		blockStore: NativeLogBlockStoreHandle,
 		clockId: Uint8Array,
@@ -136,6 +146,17 @@ type NativeLogIndexHandle = {
 		clockId: Uint8Array,
 		privateKey: Uint8Array,
 		publicKey: Uint8Array,
+		wallTime: bigint,
+		logical: number,
+		gid: string,
+		next: string[],
+		type: number,
+		metaData: Uint8Array | undefined,
+		payloadData: Uint8Array,
+	) => EntryV0CommittedPlainEntryRow;
+	prepare_entry_v0_plain_entry_commit_block_and_put_with_builder: (
+		builder: NativeEntryV0PlainBuilderHandle,
+		blockStore: NativeLogBlockStoreHandle,
 		wallTime: bigint,
 		logical: number,
 		gid: string,
@@ -188,11 +209,18 @@ type NativeLogBlockStoreHandle = {
 	entries: () => Array<[string, Uint8Array]>;
 };
 
+type NativeEntryV0PlainBuilderHandle = unknown;
+
 type WasmModule = {
 	default: (input?: unknown) => Promise<unknown>;
 	initSync: (input?: unknown) => unknown;
 	NativeLogIndex: new () => NativeLogIndexHandle;
 	NativeLogBlockStore: new () => NativeLogBlockStoreHandle;
+	NativeEntryV0PlainBuilder: new (
+		clockId: Uint8Array,
+		privateKey: Uint8Array,
+		publicKey: Uint8Array,
+	) => NativeEntryV0PlainBuilderHandle;
 	sign_ed25519: (
 		privateKey: Uint8Array,
 		publicKey: Uint8Array,
@@ -325,6 +353,21 @@ const copyBytes = (bytes: Uint8Array): Uint8Array =>
 			: bytes.slice(),
 	);
 
+const bytesEqual = (left: Uint8Array, right: Uint8Array): boolean => {
+	if (left === right) {
+		return true;
+	}
+	if (left.byteLength !== right.byteLength) {
+		return false;
+	}
+	for (let i = 0; i < left.byteLength; i++) {
+		if (left[i] !== right[i]) {
+			return false;
+		}
+	}
+	return true;
+};
+
 type BlockInput = Uint8Array | { block: { bytes: Uint8Array }; cid: string };
 
 type NativeLogBlockStoreCarrier = {
@@ -338,11 +381,48 @@ const nativeLogBlockStoreHandle = (
 		?.getNativeLogBlockStoreHandle?.();
 
 export class LogGraphIndex {
-	private constructor(private readonly native: NativeLogIndexHandle) {}
+	private plainEntryBuilder:
+		| {
+				clockId: Uint8Array;
+				publicKey: Uint8Array;
+				native: NativeEntryV0PlainBuilderHandle;
+		  }
+		| undefined;
+
+	private constructor(
+		private readonly native: NativeLogIndexHandle,
+		private readonly wasm: WasmModule,
+	) {}
 
 	static async create(): Promise<LogGraphIndex> {
 		const wasm = await loadWasm();
-		return new LogGraphIndex(new wasm.NativeLogIndex());
+		return new LogGraphIndex(new wasm.NativeLogIndex(), wasm);
+	}
+
+	private getPlainEntryBuilder(input: {
+		clockId: Uint8Array;
+		privateKey: Uint8Array;
+		publicKey: Uint8Array;
+	}): NativeEntryV0PlainBuilderHandle {
+		const builder = this.plainEntryBuilder;
+		if (
+			builder &&
+			bytesEqual(builder.clockId, input.clockId) &&
+			bytesEqual(builder.publicKey, input.publicKey)
+		) {
+			return builder.native;
+		}
+		const native = new this.wasm.NativeEntryV0PlainBuilder(
+			input.clockId,
+			input.privateKey,
+			input.publicKey,
+		);
+		this.plainEntryBuilder = {
+			clockId: copyBytes(input.clockId),
+			publicKey: copyBytes(input.publicKey),
+			native,
+		};
+		return native;
 	}
 
 	clear(): void {
@@ -457,46 +537,41 @@ export class LogGraphIndex {
 
 	prepareEntryV0PlainChainAndPut(
 		input: EntryV0PlainChainInput,
-	): Promise<EntryV0PreparedPlainEntry[]> {
+	): EntryV0PreparedPlainEntry[] {
 		const columns = plainChainInputColumns(input);
 		if (!columns) {
-			return Promise.resolve([]);
+			return [];
 		}
-		return Promise.resolve(
-			preparedPlainEntryRows(
-				this.native.prepare_entry_v0_plain_chain_and_put(
-					input.clockId,
-					input.privateKey,
-					input.publicKey,
-					columns.wallTimes,
-					columns.logicals,
-					input.gid,
-					input.initialNext ?? [],
-					input.type ?? 0,
-					columns.metaDatas,
-					input.payloadDatas,
-				),
+		return preparedPlainEntryRows(
+			this.native.prepare_entry_v0_plain_chain_and_put(
+				input.clockId,
+				input.privateKey,
+				input.publicKey,
+				columns.wallTimes,
+				columns.logicals,
+				input.gid,
+				input.initialNext ?? [],
+				input.type ?? 0,
+				columns.metaDatas,
+				input.payloadDatas,
 			),
 		);
 	}
 
 	prepareEntryV0PlainEntryAndPut(
 		input: EntryV0PlainEntryInput,
-	): Promise<EntryV0PreparedPlainEntry> {
-		return Promise.resolve(
-			preparedPlainEntryRow(
-				this.native.prepare_entry_v0_plain_entry_and_put(
-					input.clockId,
-					input.privateKey,
-					input.publicKey,
-					BigInt(input.wallTime),
-					input.logical ?? 0,
-					input.gid,
-					input.next ?? [],
-					input.type ?? 0,
-					input.metaData,
-					input.payloadData,
-				),
+	): EntryV0PreparedPlainEntry {
+		const builder = this.getPlainEntryBuilder(input);
+		return preparedPlainEntryRow(
+			this.native.prepare_entry_v0_plain_entry_and_put_with_builder(
+				builder,
+				BigInt(input.wallTime),
+				input.logical ?? 0,
+				input.gid,
+				input.next ?? [],
+				input.type ?? 0,
+				input.metaData,
+				input.payloadData,
 			),
 		);
 	}
@@ -504,30 +579,28 @@ export class LogGraphIndex {
 	prepareEntryV0PlainChainCommit(
 		input: EntryV0PlainChainInput,
 		blockStore: unknown,
-	): Promise<EntryV0CommittedPlainEntry[] | undefined> {
+	): EntryV0CommittedPlainEntry[] | undefined {
 		const nativeBlockStore = nativeLogBlockStoreHandle(blockStore);
 		if (!nativeBlockStore) {
-			return Promise.resolve(undefined);
+			return undefined;
 		}
 		const columns = plainChainInputColumns(input);
 		if (!columns) {
-			return Promise.resolve([]);
+			return [];
 		}
-		return Promise.resolve(
-			committedPlainEntryRows(
-				this.native.prepare_entry_v0_plain_chain_commit_blocks_and_put(
-					nativeBlockStore,
-					input.clockId,
-					input.privateKey,
-					input.publicKey,
-					columns.wallTimes,
-					columns.logicals,
-					input.gid,
-					input.initialNext ?? [],
-					input.type ?? 0,
-					columns.metaDatas,
-					input.payloadDatas,
-				),
+		return committedPlainEntryRows(
+			this.native.prepare_entry_v0_plain_chain_commit_blocks_and_put(
+				nativeBlockStore,
+				input.clockId,
+				input.privateKey,
+				input.publicKey,
+				columns.wallTimes,
+				columns.logicals,
+				input.gid,
+				input.initialNext ?? [],
+				input.type ?? 0,
+				columns.metaDatas,
+				input.payloadDatas,
 			),
 		);
 	}
@@ -535,26 +608,23 @@ export class LogGraphIndex {
 	prepareEntryV0PlainEntryCommit(
 		input: EntryV0PlainEntryInput,
 		blockStore: unknown,
-	): Promise<EntryV0CommittedPlainEntry | undefined> {
+	): EntryV0CommittedPlainEntry | undefined {
 		const nativeBlockStore = nativeLogBlockStoreHandle(blockStore);
 		if (!nativeBlockStore) {
-			return Promise.resolve(undefined);
+			return undefined;
 		}
-		return Promise.resolve(
-			committedPlainEntryRow(
-				this.native.prepare_entry_v0_plain_entry_commit_block_and_put(
-					nativeBlockStore,
-					input.clockId,
-					input.privateKey,
-					input.publicKey,
-					BigInt(input.wallTime),
-					input.logical ?? 0,
-					input.gid,
-					input.next ?? [],
-					input.type ?? 0,
-					input.metaData,
-					input.payloadData,
-				),
+		const builder = this.getPlainEntryBuilder(input);
+		return committedPlainEntryRow(
+			this.native.prepare_entry_v0_plain_entry_commit_block_and_put_with_builder(
+				builder,
+				nativeBlockStore,
+				BigInt(input.wallTime),
+				input.logical ?? 0,
+				input.gid,
+				input.next ?? [],
+				input.type ?? 0,
+				input.metaData,
+				input.payloadData,
 			),
 		);
 	}

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -499,6 +499,13 @@ pub struct NativeLogBlockStore {
 }
 
 #[wasm_bindgen]
+pub struct NativeEntryV0PlainBuilder {
+    clock_id: Vec<u8>,
+    public_key: Vec<u8>,
+    signing_key: SigningKey,
+}
+
+#[wasm_bindgen]
 impl NativeLogBlockStore {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
@@ -593,6 +600,25 @@ impl NativeLogBlockStore {
         for (key, value) in entries {
             self.put_entry(key, value);
         }
+    }
+}
+
+#[wasm_bindgen]
+impl NativeEntryV0PlainBuilder {
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        clock_id: Uint8Array,
+        private_key: Uint8Array,
+        public_key: Uint8Array,
+    ) -> Result<Self, JsValue> {
+        let private_key = private_key.to_vec();
+        let public_key = public_key.to_vec();
+        let signing_key = validate_ed25519_keypair(&private_key, &public_key)?;
+        Ok(Self {
+            clock_id: clock_id.to_vec(),
+            public_key,
+            signing_key,
+        })
     }
 }
 
@@ -822,6 +848,34 @@ impl NativeLogIndex {
         Ok(row)
     }
 
+    pub fn prepare_entry_v0_plain_entry_and_put_with_builder(
+        &mut self,
+        builder: &NativeEntryV0PlainBuilder,
+        wall_time: u64,
+        logical: u32,
+        gid: String,
+        next: Array,
+        entry_type: u8,
+        meta_data: JsValue,
+        payload_data: Uint8Array,
+    ) -> Result<Array, JsValue> {
+        let (row, entry, initial_nexts, _block) = prepare_entry_v0_plain_entry_row_with_signer(
+            &builder.clock_id,
+            &builder.public_key,
+            &builder.signing_key,
+            wall_time,
+            logical,
+            gid,
+            next,
+            entry_type,
+            meta_data,
+            payload_data,
+            true,
+        )?;
+        self.inner.put_append_chain(vec![entry], &initial_nexts);
+        Ok(row)
+    }
+
     pub fn prepare_entry_v0_plain_chain_commit_blocks_and_put(
         &mut self,
         block_store: &mut NativeLogBlockStore,
@@ -872,6 +926,36 @@ impl NativeLogIndex {
             clock_id,
             private_key,
             public_key,
+            wall_time,
+            logical,
+            gid,
+            next,
+            entry_type,
+            meta_data,
+            payload_data,
+            false,
+        )?;
+        block_store.put_entries(vec![block]);
+        self.inner.put_append_chain(vec![entry], &initial_nexts);
+        Ok(row)
+    }
+
+    pub fn prepare_entry_v0_plain_entry_commit_block_and_put_with_builder(
+        &mut self,
+        builder: &NativeEntryV0PlainBuilder,
+        block_store: &mut NativeLogBlockStore,
+        wall_time: u64,
+        logical: u32,
+        gid: String,
+        next: Array,
+        entry_type: u8,
+        meta_data: JsValue,
+        payload_data: Uint8Array,
+    ) -> Result<Array, JsValue> {
+        let (row, entry, initial_nexts, block) = prepare_entry_v0_plain_entry_row_with_signer(
+            &builder.clock_id,
+            &builder.public_key,
+            &builder.signing_key,
             wall_time,
             logical,
             gid,
@@ -1319,13 +1403,41 @@ fn prepare_entry_v0_plain_entry_row(
     let private_key = private_key.to_vec();
     let public_key = public_key.to_vec();
     let signing_key = validate_ed25519_keypair(&private_key, &public_key)?;
+    prepare_entry_v0_plain_entry_row_with_signer(
+        &clock_id,
+        &public_key,
+        &signing_key,
+        wall_time,
+        logical,
+        gid,
+        next,
+        entry_type,
+        meta_data,
+        payload_data,
+        include_storage_bytes,
+    )
+}
+
+fn prepare_entry_v0_plain_entry_row_with_signer(
+    clock_id: &[u8],
+    public_key: &[u8],
+    signing_key: &SigningKey,
+    wall_time: u64,
+    logical: u32,
+    gid: String,
+    next: Array,
+    entry_type: u8,
+    meta_data: JsValue,
+    payload_data: Uint8Array,
+    include_storage_bytes: bool,
+) -> Result<(Array, LogIndexEntry, Vec<String>, (String, Vec<u8>)), JsValue> {
     let next = strings_from_array(next)?;
     let payload_data = payload_data.to_vec();
     let meta_data = optional_bytes_from_js(meta_data);
     let payload_size = payload_data.len() as u32;
 
     let input = EntryV0EncodeInput {
-        clock_id,
+        clock_id: clock_id.to_vec(),
         wall_time,
         logical,
         gid: gid.clone(),
@@ -1340,7 +1452,7 @@ fn prepare_entry_v0_plain_entry_row(
     let signature = sign_ed25519_with_key(&signing_key, &signable);
     let signature_input = SignatureInput {
         signature: signature.clone(),
-        public_key: public_key.clone(),
+        public_key: public_key.to_vec(),
         prehash: 0,
     };
     let signature_with_key = encode_signature_with_key(&signature_input);

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -62,6 +62,8 @@ type NativeJoinCutCheck = {
 	logical?: number;
 };
 
+type MaybePromise<T> = T | Promise<T>;
+
 export type NativeLogGraph = {
 	readonly length: number;
 	has: (hash: string) => boolean;
@@ -80,7 +82,7 @@ export type NativeLogGraph = {
 		type?: number;
 		metaDatas?: Array<Uint8Array | undefined>;
 		payloadDatas: Uint8Array[];
-	}) => Promise<
+	}) => MaybePromise<
 		Array<{
 			bytes: Uint8Array;
 			cid: string;
@@ -103,7 +105,7 @@ export type NativeLogGraph = {
 		type?: number;
 		metaData?: Uint8Array;
 		payloadData: Uint8Array;
-	}) => Promise<{
+	}) => MaybePromise<{
 		bytes: Uint8Array;
 		cid: string;
 		byteLength: number;
@@ -127,7 +129,7 @@ export type NativeLogGraph = {
 			payloadDatas: Uint8Array[];
 		},
 		blockStore: unknown,
-	) => Promise<
+	) => MaybePromise<
 		| Array<{
 				bytes?: Uint8Array;
 				cid: string;
@@ -154,7 +156,7 @@ export type NativeLogGraph = {
 			payloadData: Uint8Array;
 		},
 		blockStore: unknown,
-	) => Promise<
+	) => MaybePromise<
 		| {
 				bytes?: Uint8Array;
 				cid: string;

--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -75,21 +75,23 @@ type NativePreparedPlainEntry = {
 	signatureBytes: Uint8Array;
 };
 
+type MaybePromise<T> = T | Promise<T>;
+
 type NativeEntryV0Graph = {
 	prepareEntryV0PlainChainAndPut?(
 		input: NativePlainChainInput,
-	): Promise<NativePreparedPlainEntry[]>;
+	): MaybePromise<NativePreparedPlainEntry[]>;
 	prepareEntryV0PlainEntryAndPut?(
 		input: NativePlainEntryInput,
-	): Promise<NativePreparedPlainEntry>;
+	): MaybePromise<NativePreparedPlainEntry>;
 	prepareEntryV0PlainChainCommit?(
 		input: NativePlainChainInput,
 		blockStore: unknown,
-	): Promise<NativePreparedPlainEntry[] | undefined>;
+	): MaybePromise<NativePreparedPlainEntry[] | undefined>;
 	prepareEntryV0PlainEntryCommit?(
 		input: NativePlainEntryInput,
 		blockStore: unknown,
-	): Promise<NativePreparedPlainEntry | undefined>;
+	): MaybePromise<NativePreparedPlainEntry | undefined>;
 };
 
 type NativeEntryV0Encoder = {
@@ -141,38 +143,56 @@ type NativeEntryV0Encoder = {
 let nativeEntryV0EncoderPromise:
 	| Promise<NativeEntryV0Encoder | undefined>
 	| undefined;
+let nativeEntryV0EncoderLoaded = false;
+let nativeEntryV0Encoder: NativeEntryV0Encoder | undefined;
 
-const loadNativeEntryV0Encoder = async () => {
+const isPromiseLike = <T>(value: MaybePromise<T>): value is Promise<T> =>
+	!!value && typeof (value as Promise<T>).then === "function";
+
+const nativeEntryV0EncoderFromModule = (mod: {
+	encodeEntryV0Signable?: NativeEntryV0Encoder["encodeEntryV0Signable"];
+	encodeEntryV0Storage?: NativeEntryV0Encoder["encodeEntryV0Storage"];
+	encodeEntryV0StorageWithCid?: NativeEntryV0Encoder["encodeEntryV0StorageWithCid"];
+	prepareEntryV0PlainChain?: NativeEntryV0Encoder["prepareEntryV0PlainChain"];
+	prepareEntryV0PlainEntry?: NativeEntryV0Encoder["prepareEntryV0PlainEntry"];
+	calculateRawCidV1?: NativeEntryV0Encoder["calculateRawCidV1"];
+}): NativeEntryV0Encoder | undefined => {
+	if (
+		!mod.encodeEntryV0Signable ||
+		!mod.encodeEntryV0Storage ||
+		!mod.calculateRawCidV1
+	) {
+		return undefined;
+	}
+	return {
+		encodeEntryV0Signable: mod.encodeEntryV0Signable,
+		encodeEntryV0Storage: mod.encodeEntryV0Storage,
+		encodeEntryV0StorageWithCid: mod.encodeEntryV0StorageWithCid,
+		prepareEntryV0PlainChain: mod.prepareEntryV0PlainChain,
+		prepareEntryV0PlainEntry: mod.prepareEntryV0PlainEntry,
+		calculateRawCidV1: mod.calculateRawCidV1,
+	};
+};
+
+const loadNativeEntryV0Encoder = ():
+	| NativeEntryV0Encoder
+	| undefined
+	| Promise<NativeEntryV0Encoder | undefined> => {
+	if (nativeEntryV0EncoderLoaded) {
+		return nativeEntryV0Encoder;
+	}
 	if (!nativeEntryV0EncoderPromise) {
-		nativeEntryV0EncoderPromise = (async () => {
-			try {
-				const mod = (await import(["@peerbit", "log-rust"].join("/"))) as {
-					encodeEntryV0Signable?: NativeEntryV0Encoder["encodeEntryV0Signable"];
-					encodeEntryV0Storage?: NativeEntryV0Encoder["encodeEntryV0Storage"];
-					encodeEntryV0StorageWithCid?: NativeEntryV0Encoder["encodeEntryV0StorageWithCid"];
-					prepareEntryV0PlainChain?: NativeEntryV0Encoder["prepareEntryV0PlainChain"];
-					prepareEntryV0PlainEntry?: NativeEntryV0Encoder["prepareEntryV0PlainEntry"];
-					calculateRawCidV1?: NativeEntryV0Encoder["calculateRawCidV1"];
-				};
-				if (
-					!mod.encodeEntryV0Signable ||
-					!mod.encodeEntryV0Storage ||
-					!mod.calculateRawCidV1
-				) {
-					return undefined;
-				}
-				return {
-					encodeEntryV0Signable: mod.encodeEntryV0Signable,
-					encodeEntryV0Storage: mod.encodeEntryV0Storage,
-					encodeEntryV0StorageWithCid: mod.encodeEntryV0StorageWithCid,
-					prepareEntryV0PlainChain: mod.prepareEntryV0PlainChain,
-					prepareEntryV0PlainEntry: mod.prepareEntryV0PlainEntry,
-					calculateRawCidV1: mod.calculateRawCidV1,
-				};
-			} catch {
+		nativeEntryV0EncoderPromise = import(["@peerbit", "log-rust"].join("/"))
+			.then((mod) => {
+				nativeEntryV0Encoder = nativeEntryV0EncoderFromModule(mod);
+				nativeEntryV0EncoderLoaded = true;
+				return nativeEntryV0Encoder;
+			})
+			.catch(() => {
+				nativeEntryV0Encoder = undefined;
+				nativeEntryV0EncoderLoaded = true;
 				return undefined;
-			}
-		})();
+			});
 	}
 	return nativeEntryV0EncoderPromise;
 };
@@ -581,7 +601,10 @@ export class EntryV0<T>
 		if (!(properties.identity instanceof Ed25519Keypair)) {
 			return undefined;
 		}
-		const nativeEncoder = await loadNativeEntryV0Encoder();
+		const nativeEncoderValue = loadNativeEntryV0Encoder();
+		const nativeEncoder = isPromiseLike(nativeEncoderValue)
+			? await nativeEncoderValue
+			: nativeEncoderValue;
 		if (!nativeEncoder?.prepareEntryV0PlainChain) {
 			return undefined;
 		}
@@ -664,13 +687,16 @@ export class EntryV0<T>
 			};
 			const nativeCommit =
 				properties.nativeGraph?.prepareEntryV0PlainEntryCommit;
-			const preparedEntry = nativeCommit
-				? await nativeCommit.call(
+			const preparedEntryValue = nativeCommit
+				? nativeCommit.call(
 						properties.nativeGraph,
 						singleInput,
 						properties.nativeBlockStore,
 					)
 				: undefined;
+			const preparedEntry = isPromiseLike(preparedEntryValue)
+				? await preparedEntryValue
+				: preparedEntryValue;
 			if (preparedEntry) {
 				nativeBlocksCommitted = true;
 				nativeGraphUpdated = true;
@@ -679,11 +705,12 @@ export class EntryV0<T>
 			} else {
 				const nativePrepareAndPut =
 					properties.nativeGraph?.prepareEntryV0PlainEntryAndPut;
-				const scalarPreparedEntry = nativePrepareAndPut
-					? await nativePrepareAndPut.call(properties.nativeGraph, singleInput)
-					: nativeEncoder.prepareEntryV0PlainEntry
-						? await nativeEncoder.prepareEntryV0PlainEntry(singleInput)
-						: undefined;
+				const scalarPreparedEntryValue = nativePrepareAndPut
+					? nativePrepareAndPut.call(properties.nativeGraph, singleInput)
+					: nativeEncoder.prepareEntryV0PlainEntry?.(singleInput);
+				const scalarPreparedEntry = isPromiseLike(scalarPreparedEntryValue)
+					? await scalarPreparedEntryValue
+					: scalarPreparedEntryValue;
 				if (scalarPreparedEntry) {
 					nativeGraphUpdated = !!nativePrepareAndPut;
 					prepared = [scalarPreparedEntry];
@@ -721,25 +748,31 @@ export class EntryV0<T>
 				payloadDatas,
 			};
 			const nativeCommit = properties.nativeGraph?.prepareEntryV0PlainChainCommit;
-			prepared = nativeCommit
-				? await nativeCommit.call(
+			const preparedValue = nativeCommit
+				? nativeCommit.call(
 						properties.nativeGraph,
 						nativePlainChainInput,
 						properties.nativeBlockStore,
 					)
 				: undefined;
+			prepared = isPromiseLike(preparedValue)
+				? await preparedValue
+				: preparedValue;
 			if (prepared) {
 				nativeBlocksCommitted = true;
 				nativeGraphUpdated = true;
 			} else {
 				const nativePrepareAndPut =
 					properties.nativeGraph?.prepareEntryV0PlainChainAndPut;
-				prepared = await (nativePrepareAndPut
+				const preparedFallbackValue = nativePrepareAndPut
 					? nativePrepareAndPut.call(
 							properties.nativeGraph,
 							nativePlainChainInput,
 						)
-					: nativeEncoder.prepareEntryV0PlainChain(nativePlainChainInput));
+					: nativeEncoder.prepareEntryV0PlainChain(nativePlainChainInput);
+				prepared = isPromiseLike(preparedFallbackValue)
+					? await preparedFallbackValue
+					: preparedFallbackValue;
 				nativeGraphUpdated = !!nativePrepareAndPut;
 			}
 		}


### PR DESCRIPTION
## Summary
- add a Rust NativeEntryV0PlainBuilder that owns the validated Ed25519 signing key for plain local entry appends
- cache the native builder in LogGraphIndex and use it for single-entry graph/block commit paths
- let native graph prepare methods return synchronous results and avoid extra await boundaries in the hot entry builder path

## Benchmark
Command:
```bash
DOC_WARMUP=50 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique,simple-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Baseline from #873 rerun:
- rust-peerbit-nonunique: 3147 ops/sec, total 317.73 ms, logCreateNativeAppendChainMs 111.51 ms
- rust-peerbit-transient-index-nonunique: 3745 ops/sec, total 267.00 ms, logCreateNativeAppendChainMs 105.71 ms
- simple-index-nonunique: 5016 ops/sec, total 199.38 ms, logCreateNativeAppendChainMs 99.62 ms

After this PR:
- rust-peerbit-nonunique: 3625 ops/sec, total 275.86 ms, logCreateNativeAppendChainMs 77.16 ms
- rust-peerbit-transient-index-nonunique: 4448 ops/sec, total 224.82 ms, logCreateNativeAppendChainMs 69.20 ms
- simple-index-nonunique: 5975 ops/sec, total 167.36 ms, logCreateNativeAppendChainMs 67.73 ms

## Validation
- cargo fmt --manifest-path packages/log/rust/Cargo.toml --check
- pnpm --filter @peerbit/log-rust run build
- pnpm --filter @peerbit/log run build
- pnpm --filter @peerbit/document run build
- pnpm exec eslint packages/log/src/entry-v0.ts packages/log/src/entry-index.ts packages/log/rust/src/index.ts
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "append commits one block and graph in one native call when storage is native"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log/rust -- -t node --grep "commits prepared plain entry blocks and graph rows natively"
- git diff --check
