### PR TITLE
Coalesce rust index coordinate put deletes

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -14,6 +14,7 @@ import {
 import {
 	And,
 	ByteMatchQuery,
+	type DeleteOptions,
 	type Index,
 	NotStartedError as IndexNotStartedError,
 	Or,
@@ -471,6 +472,13 @@ interface IndexableDomain<R extends "u32" | "u64"> {
 		} & ({ publicKeyHash: string } | { publicKey: PublicSignKey }),
 	) => ReplicationRangeIndexable<R>;
 }
+
+type PutAndDeleteIndex<T extends Record<string, any>> = Index<T> & {
+	putAndDelete?: (
+		value: T,
+		deleteOptions: DeleteOptions,
+	) => Promise<unknown> | unknown;
+};
 
 const createIndexableDomainFromResolution = <R extends "u32" | "u64">(
 	resolution: R,
@@ -7149,15 +7157,32 @@ export class SharedLog<
 			cidObject.multihash.digest,
 		);
 
-		await this.entryCoordinatesIndex.put(
-			new this.indexableDomain.constructorEntry({
-				assignedToRangeBoundary,
-				coordinates: properties.coordinates,
-				meta: properties.entry.meta,
-				hash: properties.entry.hash,
-				hashNumber,
-			}),
-		);
+		const coordinateEntry = new this.indexableDomain.constructorEntry({
+			assignedToRangeBoundary,
+			coordinates: properties.coordinates,
+			meta: properties.entry.meta,
+			hash: properties.entry.hash,
+			hashNumber,
+		});
+		const nextHashes = properties.entry.meta.next;
+		const deleteNextOptions: DeleteOptions | undefined =
+			nextHashes.length === 0
+				? undefined
+				: nextHashes.length === 1
+					? { query: { hash: nextHashes[0] } }
+					: {
+							query: new Or(
+								nextHashes.map((x) => new StringMatch({ key: "hash", value: x })),
+							),
+						};
+		const coordinateIndex = this.entryCoordinatesIndex as PutAndDeleteIndex<
+			EntryReplicated<R>
+		>;
+		if (deleteNextOptions && coordinateIndex.putAndDelete) {
+			await coordinateIndex.putAndDelete(coordinateEntry, deleteNextOptions);
+		} else {
+			await this.entryCoordinatesIndex.put(coordinateEntry);
+		}
 		if (properties.commitNative !== false) {
 			this._nativeSharedLogState?.commitEntryCoordinates(
 				properties.entry.hash,
@@ -7170,16 +7195,9 @@ export class SharedLog<
 			this.coordinateToHash.add(coordinate, properties.entry.hash);
 		}
 
-		const nextHashes = properties.entry.meta.next;
-		if (nextHashes.length > 0) {
+		if (deleteNextOptions && !coordinateIndex.putAndDelete) {
 			await this.entryCoordinatesIndex.del(
-				nextHashes.length === 1
-					? { query: { hash: nextHashes[0] } }
-					: {
-							query: new Or(
-								nextHashes.map((x) => new StringMatch({ key: "hash", value: x })),
-							),
-						},
+				deleteNextOptions,
 			);
 		}
 		return true;

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -34,6 +34,13 @@ type NativeRustIndex<T extends Record<string, any>> = {
 		value: T,
 		fields: Uint8Array,
 	) => void;
+	put_and_delete_matching: (
+		key: string,
+		id: types.IdKey,
+		value: T,
+		fields: Uint8Array,
+		query: Uint8Array,
+	) => Array<[types.IdKey, T]>;
 	get: (key: string) => [types.IdKey, T] | undefined;
 	clear: () => void;
 	len: () => number;
@@ -1311,7 +1318,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		context: Record<string, any>,
 		options?: { replace?: boolean },
 	): Promise<void> {
-		await this.put(this.createContextualValue(value, context), id, options);
+		await this.put(this.asContextualValue(value, context), id, options);
 	}
 
 	async putBatch(values: T[]): Promise<void> {
@@ -1349,6 +1356,42 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				this.getNative().put(item.storeKey, item.id, item.value, item.fields);
 			}
 			await this.compactIfNeeded();
+		});
+	}
+
+	async putAndDelete(
+		value: T,
+		deleteOptions: types.DeleteOptions,
+		id = types.toId(types.extractFieldValue(value, this.indexByArr)),
+	): Promise<types.IdKey[]> {
+		const compiled = this.requireNativePlan(types.toQuery(deleteOptions.query), {
+			allowAll: true,
+		});
+		const storeKey = keyToStoreKey(id);
+		const fields = this.fieldEncoder(value);
+		const queryBytes = encodeNativeQuerySpec(compiled.spec);
+		if (!this.snapshotFile) {
+			return this.getNative()
+				.put_and_delete_matching(storeKey, id, value, fields, queryBytes)
+				.map((entry) => entry[0]);
+		}
+
+		return this.enqueueMutation(async () => {
+			await this.appendPut(storeKey, value);
+			this.getNative().put(storeKey, id, value, fields);
+			const deletedEntries = this.getNativeCandidatesForPlan({
+				compiled,
+				sort: [],
+				offset: 0,
+			});
+			if (deletedEntries.length > 0) {
+				await this.appendDeletes(
+					deletedEntries.map((entry) => keyToStoreKey(entry.id)),
+				);
+				this.getNative().delete_matching(queryBytes);
+			}
+			await this.compactIfNeeded();
+			return deletedEntries.map((entry) => entry.id);
 		});
 	}
 
@@ -1586,6 +1629,16 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		);
 		wrapped.__context = context;
 		return wrapped as T;
+	}
+
+	private asContextualValue(
+		value: Record<string, any>,
+		context: Record<string, any>,
+	): T {
+		if (value.__context === context) {
+			return value as T;
+		}
+		return this.createContextualValue(value, context);
 	}
 
 	private snapshot(): types.IndexedValue<T>[] {

--- a/packages/utils/indexer/rust/src/lib.rs
+++ b/packages/utils/indexer/rust/src/lib.rs
@@ -214,6 +214,22 @@ impl NativeRustIndex {
         Ok(())
     }
 
+    pub fn put_and_delete_matching(
+        &mut self,
+        key: String,
+        id: JsValue,
+        value: JsValue,
+        fields_bytes: Vec<u8>,
+        query_bytes: Vec<u8>,
+    ) -> Result<Array, JsValue> {
+        let fields = decode_document_fields(&fields_bytes)?;
+        let query = decode_query(&query_bytes)?;
+        self.store.put(key.clone(), id, value);
+        self.planner.index.put(key, fields);
+        let keys = self.planner.index.delete_matching(&query);
+        Ok(self.store.delete_keys(&keys))
+    }
+
     pub fn get(&self, key: &str) -> JsValue {
         self.store.get(key)
     }

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -250,6 +250,35 @@ describe("native planner bridge", () => {
 		await indices.drop();
 	});
 
+	it("coalesces a put and matching deletes through the native index", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeDocument });
+		const coalescedIndex = index as typeof index & {
+			putAndDelete: (
+				value: BridgeDocument,
+				deleteOptions: { query: StringMatch },
+			) => Promise<ReturnType<typeof toId>[]>;
+		};
+
+		await index.put(new BridgeDocument("a", "stale", "old"));
+		await index.put(new BridgeDocument("b", "keep", "current"));
+		const deleted = await coalescedIndex.putAndDelete(
+			new BridgeDocument("c", "fresh", "new"),
+			{ query: new StringMatch({ key: "tag", value: "stale" }) },
+		);
+
+		expect(deleted.map((id) => id.primitive)).to.deep.equal(["a"]);
+		const results = await index
+			.iterate({
+				sort: [new Sort({ key: "id", direction: SortDirection.ASC })],
+			})
+			.all();
+		expect(results.map((result) => result.value.id)).to.deep.equal(["b", "c"]);
+
+		await indices.drop();
+	});
+
 	it("accepts contextual document puts through the native index hook", async () => {
 		const indices = create();
 		await indices.start();
@@ -616,6 +645,42 @@ describe("native planner bridge", () => {
 			const result = await readerIndex.iterate().all();
 
 			expect(result.map((entry) => entry.value.id)).to.deep.equal(["b"]);
+		} finally {
+			await writer.drop();
+			await reader.drop();
+			await removeNodeDirectoryIfNeeded(directory);
+		}
+	});
+
+	it("replays durable coalesced put and deletes before the writer is stopped", async () => {
+		const directory = createPersistenceDirectory();
+		const writer = create(directory);
+		const reader = create(directory);
+		try {
+			await writer.start();
+			const writerIndex = await writer.init({ schema: BridgeDocument });
+			const coalescedIndex = writerIndex as typeof writerIndex & {
+				putAndDelete: (
+					value: BridgeDocument,
+					deleteOptions: { query: StringMatch },
+				) => Promise<ReturnType<typeof toId>[]>;
+			};
+			await writerIndex.put(new BridgeDocument("a", "stale", "delete me"));
+			await writerIndex.put(new BridgeDocument("b", "other", "keep me"));
+			await coalescedIndex.putAndDelete(
+				new BridgeDocument("c", "fresh", "new"),
+				{ query: new StringMatch({ key: "tag", value: "stale" }) },
+			);
+
+			await reader.start();
+			const readerIndex = await reader.init({ schema: BridgeDocument });
+			const result = await readerIndex
+				.iterate({
+					sort: [new Sort({ key: "id", direction: SortDirection.ASC })],
+				})
+				.all();
+
+			expect(result.map((entry) => entry.value.id)).to.deep.equal(["b", "c"]);
 		} finally {
 			await writer.drop();
 			await reader.drop();


### PR DESCRIPTION
## Summary
- add an internal RustIndex.putAndDelete capability for put-new-row + delete-matching-rows flows
- implement a transient native WASM call that coalesces put and delete_matching in NativeRustIndex
- use the capability from SharedLog.persistCoordinate when the coordinate index supports it, with the existing generic put-then-del fallback kept for other indexers
- avoid copying contextual document values in RustIndex.putWithContext when the exact context is already attached

## Benchmark
Command:
```bash
DOC_WARMUP=50 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique,simple-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

A/B baseline from #874 in the same workspace after stashing this patch:
- rust-peerbit-nonunique: 3089 ops/sec, total 323.72 ms, sharedPersistCoordinateMs 33.74 ms, documentBackendIndexPutMs 20.77 ms
- rust-peerbit-transient-index-nonunique: 4366 ops/sec, total 229.06 ms, sharedPersistCoordinateMs 28.46 ms, documentBackendIndexPutMs 13.14 ms
- simple-index-nonunique: 6020 ops/sec, total 166.11 ms, sharedPersistCoordinateMs 10.25 ms, documentBackendIndexPutMs 0.28 ms

After this PR:
- rust-peerbit-nonunique: 3385 ops/sec, total 295.38 ms, sharedPersistCoordinateMs 29.78 ms, documentBackendIndexPutMs 19.33 ms
- rust-peerbit-transient-index-nonunique: 4295 ops/sec, total 232.84 ms, sharedPersistCoordinateMs 25.52 ms, documentBackendIndexPutMs 13.14 ms
- simple-index-nonunique: 6058 ops/sec, total 165.07 ms, sharedPersistCoordinateMs 10.57 ms, documentBackendIndexPutMs 0.27 ms

## Validation
- cargo fmt --manifest-path packages/utils/indexer/rust/Cargo.toml --check
- pnpm --filter @peerbit/indexer-rust run build
- pnpm --filter @peerbit/shared-log run build
- pnpm --filter @peerbit/document run build
- pnpm exec eslint packages/utils/indexer/rust/src/index.ts packages/utils/indexer/rust/test/index.spec.ts packages/programs/data/shared-log/src/index.ts
- node ./node_modules/aegir/src/index.js run test --roots ./packages/utils/indexer/rust -- -t node --grep "coalesc"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "validated local append path"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "leader are selected from 1 replicating peer"
- git diff --check
