### PR TITLE
Reuse entry meta bytes for coordinate rows

### DIFF
--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -389,6 +389,14 @@ export class EntryV0<T>
 		return this.meta;
 	}
 
+	getMetaBytes(): Uint8Array | undefined {
+		try {
+			return this._meta.decrypted._data;
+		} catch {
+			return undefined;
+		}
+	}
+
 	async getClock(): Promise<Clock> {
 		return (await this.getMeta()).clock;
 	}

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -459,6 +459,7 @@ interface IndexableDomain<R extends "u32" | "u64"> {
 		coordinates: NumberFromType<R>[];
 		hash: string;
 		meta: Meta;
+		metaBytes?: Uint8Array;
 		assignedToRangeBoundary: boolean;
 		hashNumber: NumberFromType<R>;
 	}) => EntryReplicated<R>;
@@ -478,6 +479,10 @@ type PutAndDeleteIndex<T extends Record<string, any>> = Index<T> & {
 		value: T,
 		deleteOptions: DeleteOptions,
 	) => Promise<unknown> | unknown;
+};
+
+type EntryWithMetaBytes = {
+	getMetaBytes?: () => Uint8Array | undefined;
 };
 
 const createIndexableDomainFromResolution = <R extends "u32" | "u64">(
@@ -2937,6 +2942,7 @@ export class SharedLog<
 			assignedToRangeBoundary,
 			coordinates: properties.coordinates,
 			meta: properties.entry.meta,
+			metaBytes: (properties.entry as EntryWithMetaBytes).getMetaBytes?.(),
 			hash: properties.entry.hash,
 			hashNumber,
 		});
@@ -7161,6 +7167,7 @@ export class SharedLog<
 			assignedToRangeBoundary,
 			coordinates: properties.coordinates,
 			meta: properties.entry.meta,
+			metaBytes: (properties.entry as EntryWithMetaBytes).getMetaBytes?.(),
 			hash: properties.entry.hash,
 			hashNumber,
 		});

--- a/packages/programs/data/shared-log/src/ranges.ts
+++ b/packages/programs/data/shared-log/src/ranges.ts
@@ -131,6 +131,7 @@ export class EntryReplicatedU32 implements EntryReplicated<"u32"> {
 		coordinates: number[];
 		hash: string;
 		meta: Meta;
+		metaBytes?: Uint8Array;
 		assignedToRangeBoundary: boolean;
 		hashNumber: number;
 	}) {
@@ -139,11 +140,13 @@ export class EntryReplicatedU32 implements EntryReplicated<"u32"> {
 		this.gid = properties.meta.gid;
 		this.wallTime = properties.meta.clock.timestamp.wallTime;
 		this.hashNumber = properties.hashNumber;
-		const shallow =
-			properties.meta instanceof Meta
-				? new ShallowMeta(properties.meta)
-				: properties.meta;
-		this._meta = serialize(shallow);
+		this._meta =
+			properties.metaBytes ??
+			serialize(
+				properties.meta instanceof Meta
+					? new ShallowMeta(properties.meta)
+					: properties.meta,
+			);
 		this._metaResolved = properties.meta;
 		this.assignedToRangeBoundary = properties.assignedToRangeBoundary;
 	}
@@ -185,6 +188,7 @@ export class EntryReplicatedU64 implements EntryReplicated<"u64"> {
 		coordinates: bigint[];
 		hash: string;
 		meta: Meta;
+		metaBytes?: Uint8Array;
 		assignedToRangeBoundary: boolean;
 		hashNumber: bigint;
 	}) {
@@ -193,11 +197,13 @@ export class EntryReplicatedU64 implements EntryReplicated<"u64"> {
 		this.hashNumber = properties.hashNumber;
 		this.gid = properties.meta.gid;
 		this.wallTime = properties.meta.clock.timestamp.wallTime;
-		const shallow =
-			properties.meta instanceof Meta
-				? new ShallowMeta(properties.meta)
-				: properties.meta;
-		this._meta = serialize(shallow);
+		this._meta =
+			properties.metaBytes ??
+			serialize(
+				properties.meta instanceof Meta
+					? new ShallowMeta(properties.meta)
+					: properties.meta,
+			);
 		this._metaResolved = properties.meta;
 		this.assignedToRangeBoundary = properties.assignedToRangeBoundary;
 	}


### PR DESCRIPTION
## Summary
- expose already-decoded EntryV0 meta bytes for local plain entries
- let shared-log EntryReplicated coordinate rows accept pre-encoded meta bytes
- reuse prepared lower-log meta bytes during coordinate persistence instead of reconstructing ShallowMeta and serializing it again

## Benchmark
Command:
```bash
DOC_WARMUP=50 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique,simple-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Baseline from #875:
- rust-peerbit-nonunique: 3385 ops/sec, total 295.38 ms, sharedPersistCoordinateMs 29.78 ms
- rust-peerbit-transient-index-nonunique: 4295 ops/sec, total 232.84 ms, sharedPersistCoordinateMs 25.52 ms
- simple-index-nonunique: 6058 ops/sec, total 165.07 ms, sharedPersistCoordinateMs 10.57 ms

After this PR:
- rust-peerbit-nonunique: 3611 ops/sec, total 276.92 ms, sharedPersistCoordinateMs 24.13 ms
- rust-peerbit-transient-index-nonunique: 4617 ops/sec, total 216.60 ms, sharedPersistCoordinateMs 22.21 ms
- simple-index-nonunique: 6274 ops/sec, total 159.39 ms, sharedPersistCoordinateMs 6.63 ms

## Validation
- pnpm --filter @peerbit/log run build
- pnpm --filter @peerbit/shared-log run build
- pnpm --filter @peerbit/document run build
- pnpm exec eslint packages/log/src/entry-v0.ts packages/programs/data/shared-log/src/index.ts packages/programs/data/shared-log/src/ranges.ts
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "append commits one block and graph in one native call when storage is native"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "validated local append path"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "leader are selected from 1 replicating peer"
- git diff --check
