### PR TITLE
Add exact-id Rust index mutations

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -15,6 +15,8 @@ import {
 	And,
 	ByteMatchQuery,
 	type DeleteOptions,
+	type IdKey,
+	type Ideable,
 	type Index,
 	NotStartedError as IndexNotStartedError,
 	Or,
@@ -479,6 +481,12 @@ type PutAndDeleteIndex<T extends Record<string, any>> = Index<T> & {
 		value: T,
 		deleteOptions: DeleteOptions,
 	) => Promise<unknown> | unknown;
+	putAndDeleteIds?: (
+		value: T,
+		deleteIds: Array<IdKey | Ideable>,
+		id?: IdKey,
+	) => Promise<unknown> | unknown;
+	delIds?: (deleteIds: Array<IdKey | Ideable>) => Promise<unknown> | unknown;
 };
 
 type EntryWithMetaBytes = {
@@ -1900,6 +1908,13 @@ export class SharedLog<
 			return;
 		}
 		this._nativeSharedLogState?.deleteEntryCoordinatesBatch(values);
+		const coordinateIndex = this.entryCoordinatesIndex as PutAndDeleteIndex<
+			EntryReplicated<R>
+		>;
+		if (coordinateIndex.delIds) {
+			await coordinateIndex.delIds(values);
+			return;
+		}
 		await this.entryCoordinatesIndex.del({
 			query:
 				values.length === 1
@@ -7172,23 +7187,30 @@ export class SharedLog<
 			hashNumber,
 		});
 		const nextHashes = properties.entry.meta.next;
-		const deleteNextOptions: DeleteOptions | undefined =
-			nextHashes.length === 0
-				? undefined
-				: nextHashes.length === 1
-					? { query: { hash: nextHashes[0] } }
-					: {
-							query: new Or(
-								nextHashes.map((x) => new StringMatch({ key: "hash", value: x })),
-							),
-						};
 		const coordinateIndex = this.entryCoordinatesIndex as PutAndDeleteIndex<
 			EntryReplicated<R>
 		>;
-		if (deleteNextOptions && coordinateIndex.putAndDelete) {
-			await coordinateIndex.putAndDelete(coordinateEntry, deleteNextOptions);
+		let deleteNextOptions: DeleteOptions | undefined;
+		if (nextHashes.length > 0 && coordinateIndex.putAndDeleteIds) {
+			await coordinateIndex.putAndDeleteIds(coordinateEntry, nextHashes);
 		} else {
-			await this.entryCoordinatesIndex.put(coordinateEntry);
+			deleteNextOptions =
+				nextHashes.length === 0
+					? undefined
+					: nextHashes.length === 1
+						? { query: { hash: nextHashes[0] } }
+						: {
+								query: new Or(
+									nextHashes.map(
+										(x) => new StringMatch({ key: "hash", value: x }),
+									),
+								),
+							};
+			if (deleteNextOptions && coordinateIndex.putAndDelete) {
+				await coordinateIndex.putAndDelete(coordinateEntry, deleteNextOptions);
+			} else {
+				await this.entryCoordinatesIndex.put(coordinateEntry);
+			}
 		}
 		if (properties.commitNative !== false) {
 			this._nativeSharedLogState?.commitEntryCoordinates(
@@ -7212,7 +7234,14 @@ export class SharedLog<
 
 	private async deleteCoordinates(properties: { hash: string }) {
 		this._nativeSharedLogState?.deleteEntryCoordinates(properties.hash);
-		await this.entryCoordinatesIndex.del({ query: properties });
+		const coordinateIndex = this.entryCoordinatesIndex as PutAndDeleteIndex<
+			EntryReplicated<R>
+		>;
+		if (coordinateIndex.delIds) {
+			await coordinateIndex.delIds([properties.hash]);
+		} else {
+			await this.entryCoordinatesIndex.del({ query: properties });
+		}
 	}
 
 	async getDefaultMinRoleAge(): Promise<number> {

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -41,6 +41,13 @@ type NativeRustIndex<T extends Record<string, any>> = {
 		fields: Uint8Array,
 		query: Uint8Array,
 	) => Array<[types.IdKey, T]>;
+	put_and_delete_keys: (
+		key: string,
+		id: types.IdKey,
+		value: T,
+		fields: Uint8Array,
+		keys: string[],
+	) => Array<[types.IdKey, T]>;
 	get: (key: string) => [types.IdKey, T] | undefined;
 	clear: () => void;
 	len: () => number;
@@ -58,6 +65,7 @@ type NativeRustIndex<T extends Record<string, any>> = {
 	count: (query: Uint8Array) => number;
 	sum: (query: Uint8Array, field: number) => [NativeSumKind, string];
 	delete_matching: (query: Uint8Array) => Array<[types.IdKey, T]>;
+	delete_keys: (keys: string[]) => Array<[types.IdKey, T]>;
 };
 
 type WasmModule = {
@@ -199,10 +207,11 @@ const loadWasm = async (): Promise<WasmModule> => {
 	return wasm;
 };
 
-const keyToStoreKey = (id: types.IdKey): string => {
-	const key = types.toIdeable(id);
+const keyToStoreKey = (id: types.IdKey | types.Ideable): string => {
+	const idKey = id instanceof types.IdKey ? id : types.toId(id);
+	const key = types.toIdeable(idKey);
 	if (key instanceof Uint8Array || ArrayBuffer.isView(key)) {
-		return `bytes:${id.primitive.toString()}`;
+		return `bytes:${idKey.primitive.toString()}`;
 	}
 	return `${typeof key}:${key.toString()}`;
 };
@@ -1392,6 +1401,55 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			}
 			await this.compactIfNeeded();
 			return deletedEntries.map((entry) => entry.id);
+		});
+	}
+
+	async putAndDeleteIds(
+		value: T,
+		deleteIds: Array<types.IdKey | types.Ideable>,
+		id = types.toId(types.extractFieldValue(value, this.indexByArr)),
+	): Promise<types.IdKey[]> {
+		const storeKey = keyToStoreKey(id);
+		const fields = this.fieldEncoder(value);
+		const deleteKeys = deleteIds.map(keyToStoreKey);
+		if (!this.snapshotFile) {
+			return this.getNative()
+				.put_and_delete_keys(storeKey, id, value, fields, deleteKeys)
+				.map((entry) => entry[0]);
+		}
+
+		return this.enqueueMutation(async () => {
+			await this.appendPut(storeKey, value);
+			if (deleteKeys.length > 0) {
+				await this.appendDeletes(deleteKeys);
+			}
+			const deletedEntries = this.getNative().put_and_delete_keys(
+				storeKey,
+				id,
+				value,
+				fields,
+				deleteKeys,
+			);
+			await this.compactIfNeeded();
+			return deletedEntries.map((entry) => entry[0]);
+		});
+	}
+
+	async delIds(deleteIds: Array<types.IdKey | types.Ideable>): Promise<types.IdKey[]> {
+		const deleteKeys = deleteIds.map(keyToStoreKey);
+		if (deleteKeys.length === 0) {
+			return [];
+		}
+		if (!this.snapshotFile) {
+			return this.getNative()
+				.delete_keys(deleteKeys)
+				.map((entry) => entry[0]);
+		}
+		return this.enqueueMutation(async () => {
+			await this.appendDeletes(deleteKeys);
+			const deletedEntries = this.getNative().delete_keys(deleteKeys);
+			await this.compactIfNeeded();
+			return deletedEntries.map((entry) => entry[0]);
 		});
 	}
 

--- a/packages/utils/indexer/rust/src/lib.rs
+++ b/packages/utils/indexer/rust/src/lib.rs
@@ -230,6 +230,32 @@ impl NativeRustIndex {
         Ok(self.store.delete_keys(&keys))
     }
 
+    pub fn put_and_delete_keys(
+        &mut self,
+        key: String,
+        id: JsValue,
+        value: JsValue,
+        fields_bytes: Vec<u8>,
+        keys: Array,
+    ) -> Result<Array, JsValue> {
+        let fields = decode_document_fields(&fields_bytes)?;
+        let keys: Vec<_> = keys.iter().filter_map(|key| key.as_string()).collect();
+        self.store.put(key.clone(), id, value);
+        self.planner.index.put(key, fields);
+        for key in &keys {
+            self.planner.index.delete(key);
+        }
+        Ok(self.store.delete_keys(&keys))
+    }
+
+    pub fn delete_keys(&mut self, keys: Array) -> Array {
+        let keys: Vec<_> = keys.iter().filter_map(|key| key.as_string()).collect();
+        for key in &keys {
+            self.planner.index.delete(key);
+        }
+        self.store.delete_keys(&keys)
+    }
+
     pub fn get(&self, key: &str) -> JsValue {
         self.store.get(key)
     }

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -279,6 +279,54 @@ describe("native planner bridge", () => {
 		await indices.drop();
 	});
 
+	it("coalesces a put and exact id deletes through the native index", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeDocument });
+		const coalescedIndex = index as typeof index & {
+			putAndDeleteIds: (
+				value: BridgeDocument,
+				deleteIds: string[],
+			) => Promise<ReturnType<typeof toId>[]>;
+		};
+
+		await index.put(new BridgeDocument("a", "stale", "old"));
+		await index.put(new BridgeDocument("b", "keep", "current"));
+		const deleted = await coalescedIndex.putAndDeleteIds(
+			new BridgeDocument("c", "fresh", "new"),
+			["a"],
+		);
+
+		expect(deleted.map((id) => id.primitive)).to.deep.equal(["a"]);
+		const results = await index
+			.iterate({
+				sort: [new Sort({ key: "id", direction: SortDirection.ASC })],
+			})
+			.all();
+		expect(results.map((result) => result.value.id)).to.deep.equal(["b", "c"]);
+
+		await indices.drop();
+	});
+
+	it("deletes exact ids through the native index", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeDocument });
+		const exactDeleteIndex = index as typeof index & {
+			delIds: (deleteIds: string[]) => Promise<ReturnType<typeof toId>[]>;
+		};
+
+		await index.put(new BridgeDocument("a", "stale", "old"));
+		await index.put(new BridgeDocument("b", "keep", "current"));
+		const deleted = await exactDeleteIndex.delIds(["a"]);
+
+		expect(deleted.map((id) => id.primitive)).to.deep.equal(["a"]);
+		const results = await index.iterate().all();
+		expect(results.map((result) => result.value.id)).to.deep.equal(["b"]);
+
+		await indices.drop();
+	});
+
 	it("accepts contextual document puts through the native index hook", async () => {
 		const indices = create();
 		await indices.start();
@@ -681,6 +729,68 @@ describe("native planner bridge", () => {
 				.all();
 
 			expect(result.map((entry) => entry.value.id)).to.deep.equal(["b", "c"]);
+		} finally {
+			await writer.drop();
+			await reader.drop();
+			await removeNodeDirectoryIfNeeded(directory);
+		}
+	});
+
+	it("replays durable coalesced put and exact id deletes before the writer is stopped", async () => {
+		const directory = createPersistenceDirectory();
+		const writer = create(directory);
+		const reader = create(directory);
+		try {
+			await writer.start();
+			const writerIndex = await writer.init({ schema: BridgeDocument });
+			const coalescedIndex = writerIndex as typeof writerIndex & {
+				putAndDeleteIds: (
+					value: BridgeDocument,
+					deleteIds: string[],
+				) => Promise<ReturnType<typeof toId>[]>;
+			};
+			await writerIndex.put(new BridgeDocument("a", "stale", "delete me"));
+			await writerIndex.put(new BridgeDocument("b", "other", "keep me"));
+			await coalescedIndex.putAndDeleteIds(
+				new BridgeDocument("c", "fresh", "new"),
+				["a"],
+			);
+
+			await reader.start();
+			const readerIndex = await reader.init({ schema: BridgeDocument });
+			const result = await readerIndex
+				.iterate({
+					sort: [new Sort({ key: "id", direction: SortDirection.ASC })],
+				})
+				.all();
+
+			expect(result.map((entry) => entry.value.id)).to.deep.equal(["b", "c"]);
+		} finally {
+			await writer.drop();
+			await reader.drop();
+			await removeNodeDirectoryIfNeeded(directory);
+		}
+	});
+
+	it("replays durable exact id deletes before the writer is stopped", async () => {
+		const directory = createPersistenceDirectory();
+		const writer = create(directory);
+		const reader = create(directory);
+		try {
+			await writer.start();
+			const writerIndex = await writer.init({ schema: BridgeDocument });
+			const exactDeleteIndex = writerIndex as typeof writerIndex & {
+				delIds: (deleteIds: string[]) => Promise<ReturnType<typeof toId>[]>;
+			};
+			await writerIndex.put(new BridgeDocument("a", "stale", "delete me"));
+			await writerIndex.put(new BridgeDocument("b", "other", "keep me"));
+			await exactDeleteIndex.delIds(["a"]);
+
+			await reader.start();
+			const readerIndex = await reader.init({ schema: BridgeDocument });
+			const result = await readerIndex.iterate().all();
+
+			expect(result.map((entry) => entry.value.id)).to.deep.equal(["b"]);
 		} finally {
 			await writer.drop();
 			await reader.drop();


### PR DESCRIPTION
## Summary
- add exact-id `putAndDeleteIds` and `delIds` capabilities to the Rust index bridge
- wire shared-log coordinate replacement/deletion to use exact ids when the coordinate index supports it
- keep existing query-based fallbacks for non-Rust indexers
- add transient and durable replay tests for exact-id put/delete and delete

## Performance
Local document-put deep profile, 1000 ops, compared with #876 baseline:
- `rust-peerbit-transient-index-nonunique` coordinate persistence improved from 22.21 ms to 20.61 ms
- `rust-peerbit-nonunique` was flat/noisy in this single-chain benchmark, 24.13 ms to 24.68 ms
- expected bigger payoff is in multi-head replacement and coordinate deletion batches, where the old path allocated query objects and ran native matching despite already knowing ids

## Test Plan
- `pnpm exec eslint packages/utils/indexer/rust/src/index.ts packages/utils/indexer/rust/test/index.spec.ts packages/programs/data/shared-log/src/index.ts`
- `pnpm --filter @peerbit/indexer-rust run build`
- `pnpm --filter @peerbit/shared-log run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/utils/indexer/rust -- -t node --grep "exact id"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "leader are selected from 1 replicating peer"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "validated local append path"`
- `cargo fmt --manifest-path packages/utils/indexer/rust/Cargo.toml --check`
- `git diff --check`