### PR TITLE
Reuse native entry hash digest for coordinates

### DIFF
--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -938,6 +938,7 @@ export type EntryV0PreparedPlainEntry = EntryV0EncodedStorage & {
 	metaBytes: Uint8Array;
 	payloadBytes: Uint8Array;
 	signatureBytes: Uint8Array;
+	hashDigestBytes?: Uint8Array;
 };
 
 export type EntryV0CommittedPlainEntry = Omit<
@@ -955,6 +956,7 @@ type EntryV0PreparedPlainEntryRow = [
 	Uint8Array,
 	Uint8Array,
 	Uint8Array,
+	Uint8Array?,
 ];
 
 type EntryV0CommittedPlainEntryRow = [
@@ -965,6 +967,7 @@ type EntryV0CommittedPlainEntryRow = [
 	Uint8Array,
 	Uint8Array,
 	number,
+	Uint8Array?,
 ];
 
 const plainChainInputColumns = (input: EntryV0PlainChainInput) => {
@@ -995,6 +998,7 @@ const preparedPlainEntryRow = ([
 	metaBytes,
 	payloadBytes,
 	signatureBytes,
+	hashDigestBytes,
 ]: EntryV0PreparedPlainEntryRow): EntryV0PreparedPlainEntry => ({
 	bytes,
 	cid,
@@ -1004,6 +1008,7 @@ const preparedPlainEntryRow = ([
 	metaBytes,
 	payloadBytes,
 	signatureBytes,
+	hashDigestBytes,
 });
 
 const preparedPlainEntryRows = (
@@ -1018,6 +1023,7 @@ const committedPlainEntryRow = ([
 	payloadBytes,
 	signatureBytes,
 	byteLength,
+	hashDigestBytes,
 ]: EntryV0CommittedPlainEntryRow): EntryV0CommittedPlainEntry => ({
 	cid,
 	byteLength,
@@ -1026,6 +1032,7 @@ const committedPlainEntryRow = ([
 	metaBytes,
 	payloadBytes,
 	signatureBytes,
+	hashDigestBytes,
 });
 
 const committedPlainEntryRows = (

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -1347,7 +1347,7 @@ fn prepare_entry_v0_plain_chain_rows(
         let signature_with_key = encode_signature_with_key(&signature_input);
         let storage = encode_entry_v0_parts(&meta, &payload, Some(signature_input));
         let storage_len = storage.len();
-        let cid = calculate_raw_cid_v1_from_bytes(&storage);
+        let (cid, hash_digest) = calculate_raw_cid_v1_parts(&storage);
 
         let row = Array::new();
         if include_storage_bytes {
@@ -1358,6 +1358,7 @@ fn prepare_entry_v0_plain_chain_rows(
             row.push(&Uint8Array::from(meta.as_slice()));
             row.push(&Uint8Array::from(payload.as_slice()));
             row.push(&Uint8Array::from(signature_with_key.as_slice()));
+            row.push(&Uint8Array::from(hash_digest.as_slice()));
         } else {
             row.push(&JsValue::from_str(&cid));
             row.push(&Uint8Array::from(signature.as_slice()));
@@ -1366,6 +1367,7 @@ fn prepare_entry_v0_plain_chain_rows(
             row.push(&Uint8Array::from(payload.as_slice()));
             row.push(&Uint8Array::from(signature_with_key.as_slice()));
             row.push(&JsValue::from_f64(storage_len as f64));
+            row.push(&Uint8Array::from(hash_digest.as_slice()));
         }
         out.push(&row);
         entries.push(LogIndexEntry::new_with_data(
@@ -1458,7 +1460,7 @@ fn prepare_entry_v0_plain_entry_row_with_signer(
     let signature_with_key = encode_signature_with_key(&signature_input);
     let storage = encode_entry_v0_parts(&meta, &payload, Some(signature_input));
     let storage_len = storage.len();
-    let cid = calculate_raw_cid_v1_from_bytes(&storage);
+    let (cid, hash_digest) = calculate_raw_cid_v1_parts(&storage);
 
     let row = Array::new();
     if include_storage_bytes {
@@ -1469,6 +1471,7 @@ fn prepare_entry_v0_plain_entry_row_with_signer(
         row.push(&Uint8Array::from(meta.as_slice()));
         row.push(&Uint8Array::from(payload.as_slice()));
         row.push(&Uint8Array::from(signature_with_key.as_slice()));
+        row.push(&Uint8Array::from(hash_digest.as_slice()));
     } else {
         row.push(&JsValue::from_str(&cid));
         row.push(&Uint8Array::from(signature.as_slice()));
@@ -1477,6 +1480,7 @@ fn prepare_entry_v0_plain_entry_row_with_signer(
         row.push(&Uint8Array::from(payload.as_slice()));
         row.push(&Uint8Array::from(signature_with_key.as_slice()));
         row.push(&JsValue::from_f64(storage_len as f64));
+        row.push(&Uint8Array::from(hash_digest.as_slice()));
     }
 
     let entry = LogIndexEntry::new_with_data(
@@ -1557,14 +1561,22 @@ pub fn calculate_raw_cid_v1(bytes: Uint8Array) -> String {
 }
 
 fn calculate_raw_cid_v1_from_bytes(bytes: &[u8]) -> String {
+    calculate_raw_cid_v1_parts(bytes).0
+}
+
+fn calculate_raw_cid_v1_parts(bytes: &[u8]) -> (String, [u8; 32]) {
     let digest = Sha256::digest(bytes);
+    let digest_bytes: [u8; 32] = digest.into();
     let mut cid = Vec::with_capacity(36);
     cid.push(0x01); // CIDv1
     cid.push(0x55); // raw codec
     cid.push(0x12); // sha2-256 multihash code
     cid.push(0x20); // 32 byte digest
-    cid.extend_from_slice(&digest);
-    format!("z{}", bs58::encode(cid).into_string())
+    cid.extend_from_slice(&digest_bytes);
+    (
+        format!("z{}", bs58::encode(cid).into_string()),
+        digest_bytes,
+    )
 }
 
 fn encode_entry_v0_storage_vec(

--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -73,6 +73,7 @@ type NativePreparedPlainEntry = {
 	metaBytes: Uint8Array;
 	payloadBytes: Uint8Array;
 	signatureBytes: Uint8Array;
+	hashDigestBytes?: Uint8Array;
 };
 
 type MaybePromise<T> = T | Promise<T>;
@@ -338,6 +339,7 @@ export class EntryV0<T>
 
 	private _keychain?: CryptoKeychain;
 	private _encoding?: Encoding<T>;
+	private _hashDigestBytes?: Uint8Array;
 
 	constructor(obj: {
 		payload: MaybeEncrypted<Payload<T>>;
@@ -395,6 +397,10 @@ export class EntryV0<T>
 		} catch {
 			return undefined;
 		}
+	}
+
+	getHashDigestBytes(): Uint8Array | undefined {
+		return this._hashDigestBytes;
 	}
 
 	async getClock(): Promise<Clock> {
@@ -849,6 +855,7 @@ export class EntryV0<T>
 					preparedEntry.cid,
 				);
 			}
+			entry._hashDigestBytes = preparedEntry.hashDigestBytes;
 			const shallowEntry = new ShallowEntry({
 				hash: entry.hash,
 				payloadSize: payload.byteLength,

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -491,6 +491,7 @@ type PutAndDeleteIndex<T extends Record<string, any>> = Index<T> & {
 
 type EntryWithMetaBytes = {
 	getMetaBytes?: () => Uint8Array | undefined;
+	getHashDigestBytes?: () => Uint8Array | undefined;
 };
 
 const createIndexableDomainFromResolution = <R extends "u32" | "u64">(
@@ -2949,9 +2950,9 @@ export class SharedLog<
 			properties.leaders,
 			properties.replicas,
 		);
-		const cidObject = cidifyString(properties.entry.hash);
 		const hashNumber = this.indexableDomain.numbers.bytesToNumber(
-			cidObject.multihash.digest,
+			(properties.entry as EntryWithMetaBytes).getHashDigestBytes?.() ??
+				cidifyString(properties.entry.hash).multihash.digest,
 		);
 		return new this.indexableDomain.constructorEntry({
 			assignedToRangeBoundary,
@@ -7173,9 +7174,9 @@ export class SharedLog<
 			return false; // no change
 		}
 
-		const cidObject = cidifyString(properties.entry.hash);
 		const hashNumber = this.indexableDomain.numbers.bytesToNumber(
-			cidObject.multihash.digest,
+			(properties.entry as EntryWithMetaBytes).getHashDigestBytes?.() ??
+				cidifyString(properties.entry.hash).multihash.digest,
 		);
 
 		const coordinateEntry = new this.indexableDomain.constructorEntry({


### PR DESCRIPTION
## Summary
- carry the native log builder's 32-byte entry hash digest alongside prepared entry CIDs
- store the optional digest on `EntryV0` and expose it internally with `getHashDigestBytes()`
- use the digest in shared-log coordinate persistence before falling back to CID parsing
- keep row decoding compatible by making the new prepared-row column optional

## Performance
Local document-put deep profile, 1000 ops, compared with #877 baseline:
- `rust-peerbit-nonunique`: 3516 -> 3703 ops/sec; shared coordinate persistence 24.68 ms -> 18.95 ms
- `rust-peerbit-transient-index-nonunique`: shared coordinate persistence 20.61 ms -> 16.21 ms; total was noisy at 223.58 ms -> 228.28 ms
- `simple-index-nonunique`: 5933 -> 6516 ops/sec; shared coordinate persistence 7.02 ms -> 2.49 ms

## Test Plan
- `cargo fmt --manifest-path packages/log/rust/Cargo.toml --check`
- `pnpm exec eslint packages/log/src/entry-v0.ts packages/log/rust/src/index.ts packages/programs/data/shared-log/src/index.ts`
- `pnpm --filter @peerbit/log-rust run build`
- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "append commits one block and graph in one native call when storage is native"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "validated local append path"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "leader are selected from 1 replicating peer"`
- `git diff --check`