### PR TITLE
Add typed Rust coordinate field path

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -487,6 +487,20 @@ type PutAndDeleteIndex<T extends Record<string, any>> = Index<T> & {
 		id?: IdKey,
 	) => Promise<unknown> | unknown;
 	delIds?: (deleteIds: Array<IdKey | Ideable>) => Promise<unknown> | unknown;
+	putSharedLogCoordinateAndDeleteIds?: (
+		value: T,
+		fields: {
+			hash: string;
+			hashNumber: NumberFromType<any>;
+			gid: string;
+			coordinates: NumberFromType<any>[];
+			wallTime: bigint;
+			assignedToRangeBoundary: boolean;
+			metaBytes: Uint8Array;
+		},
+		deleteIds?: Array<IdKey | Ideable>,
+		id?: IdKey,
+	) => Promise<unknown> | unknown;
 };
 
 type EntryWithMetaBytes = {
@@ -7179,11 +7193,12 @@ export class SharedLog<
 				cidifyString(properties.entry.hash).multihash.digest,
 		);
 
+		const metaBytes = (properties.entry as EntryWithMetaBytes).getMetaBytes?.();
 		const coordinateEntry = new this.indexableDomain.constructorEntry({
 			assignedToRangeBoundary,
 			coordinates: properties.coordinates,
 			meta: properties.entry.meta,
-			metaBytes: (properties.entry as EntryWithMetaBytes).getMetaBytes?.(),
+			metaBytes,
 			hash: properties.entry.hash,
 			hashNumber,
 		});
@@ -7192,7 +7207,21 @@ export class SharedLog<
 			EntryReplicated<R>
 		>;
 		let deleteNextOptions: DeleteOptions | undefined;
-		if (nextHashes.length > 0 && coordinateIndex.putAndDeleteIds) {
+		if (coordinateIndex.putSharedLogCoordinateAndDeleteIds) {
+			await coordinateIndex.putSharedLogCoordinateAndDeleteIds(
+				coordinateEntry,
+				{
+					hash: coordinateEntry.hash,
+					hashNumber: coordinateEntry.hashNumber,
+					gid: coordinateEntry.gid,
+					coordinates: coordinateEntry.coordinates,
+					wallTime: coordinateEntry.wallTime,
+					assignedToRangeBoundary: coordinateEntry.assignedToRangeBoundary,
+					metaBytes: coordinateEntry.getMetaBytes(),
+				},
+				nextHashes,
+			);
+		} else if (nextHashes.length > 0 && coordinateIndex.putAndDeleteIds) {
 			await coordinateIndex.putAndDeleteIds(coordinateEntry, nextHashes);
 		} else {
 			deleteNextOptions =

--- a/packages/programs/data/shared-log/src/ranges.ts
+++ b/packages/programs/data/shared-log/src/ranges.ts
@@ -96,6 +96,7 @@ export interface EntryReplicated<R extends "u32" | "u64"> {
 	wallTime: bigint;
 	assignedToRangeBoundary: boolean;
 	get meta(): ShallowMeta;
+	getMetaBytes(): Uint8Array;
 }
 
 export const isEntryReplicated = (x: any): x is EntryReplicated<any> => {
@@ -157,6 +158,10 @@ export class EntryReplicatedU32 implements EntryReplicated<"u32"> {
 		}
 		return this._metaResolved;
 	}
+
+	getMetaBytes(): Uint8Array {
+		return this._meta;
+	}
 }
 
 @variant("entry-u64")
@@ -213,6 +218,10 @@ export class EntryReplicatedU64 implements EntryReplicated<"u64"> {
 			this._metaResolved = deserialize(this._meta, ShallowMeta);
 		}
 		return this._metaResolved;
+	}
+
+	getMetaBytes(): Uint8Array {
+		return this._meta;
 	}
 }
 

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -615,6 +615,15 @@ class NativeFieldWriter {
 }
 
 type NativeFieldEncoder<T extends Record<string, any>> = (value: T) => Uint8Array;
+type SharedLogCoordinateNativeFields = {
+	hash: string;
+	hashNumber: number | bigint;
+	gid: string;
+	coordinates: Array<number | bigint>;
+	wallTime: number | bigint;
+	assignedToRangeBoundary: boolean;
+	metaBytes: Uint8Array;
+};
 type NativeFieldValueWriterFn = (
 	value: any,
 	writer: NativeFieldWriter,
@@ -1224,6 +1233,17 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 	private properties!: types.IndexEngineInitProperties<T, NestedType>;
 	private fieldDictionary!: NativeFieldDictionary;
 	private fieldEncoder!: NativeFieldEncoder<T>;
+	private byteElementIndexLimit!: number;
+	private sharedLogCoordinateFieldIds?: {
+		hash: number;
+		hashNumber: number;
+		gid: number;
+		coordinates: number;
+		coordinatesArray: number;
+		wallTime: number;
+		assignedToRangeBoundary: number;
+		meta: number;
+	};
 	private persistQueue: Promise<void> = Promise.resolve();
 	private mutationQueue: Promise<void> = Promise.resolve();
 
@@ -1254,6 +1274,8 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		const wasm = await loadWasm();
 		this.native = new wasm.NativeRustIndex<T>();
 		this.fieldDictionary = createNativeFieldDictionary();
+		this.byteElementIndexLimit =
+			this.options.byteElementIndexLimit ?? DEFAULT_BYTE_ELEMENT_INDEX_LIMIT;
 		this.fieldEncoder = compileNativeFieldEncoder(
 			properties.schema,
 			this.fieldDictionary,
@@ -1308,17 +1330,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		id = types.toId(types.extractFieldValue(value, this.indexByArr)),
 		_options?: { replace?: boolean },
 	): Promise<void> {
-		if (!this.snapshotFile) {
-			this.putNativeDocument(keyToStoreKey(id), id, value);
-			return;
-		}
-		await this.enqueueMutation(async () => {
-			const storeKey = keyToStoreKey(id);
-			const fields = this.fieldEncoder(value);
-			await this.appendPut(storeKey, value);
-			this.getNative().put(storeKey, id, value, fields);
-			await this.compactIfNeeded();
-		});
+		await this.putWithEncodedFields(value, id, this.fieldEncoder(value));
 	}
 
 	async putWithContext(
@@ -1409,30 +1421,26 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		deleteIds: Array<types.IdKey | types.Ideable>,
 		id = types.toId(types.extractFieldValue(value, this.indexByArr)),
 	): Promise<types.IdKey[]> {
-		const storeKey = keyToStoreKey(id);
-		const fields = this.fieldEncoder(value);
-		const deleteKeys = deleteIds.map(keyToStoreKey);
-		if (!this.snapshotFile) {
-			return this.getNative()
-				.put_and_delete_keys(storeKey, id, value, fields, deleteKeys)
-				.map((entry) => entry[0]);
-		}
+		return this.putWithEncodedFieldsAndDeleteKeys(
+			value,
+			id,
+			this.fieldEncoder(value),
+			deleteIds.map(keyToStoreKey),
+		);
+	}
 
-		return this.enqueueMutation(async () => {
-			await this.appendPut(storeKey, value);
-			if (deleteKeys.length > 0) {
-				await this.appendDeletes(deleteKeys);
-			}
-			const deletedEntries = this.getNative().put_and_delete_keys(
-				storeKey,
-				id,
-				value,
-				fields,
-				deleteKeys,
-			);
-			await this.compactIfNeeded();
-			return deletedEntries.map((entry) => entry[0]);
-		});
+	async putSharedLogCoordinateAndDeleteIds(
+		value: T,
+		fields: SharedLogCoordinateNativeFields,
+		deleteIds: Array<types.IdKey | types.Ideable> = [],
+		id = types.toId(types.extractFieldValue(value, this.indexByArr)),
+	): Promise<types.IdKey[]> {
+		return this.putWithEncodedFieldsAndDeleteKeys(
+			value,
+			id,
+			this.encodeSharedLogCoordinateFields(fields),
+			deleteIds.map(keyToStoreKey),
+		);
 	}
 
 	async delIds(deleteIds: Array<types.IdKey | types.Ideable>): Promise<types.IdKey[]> {
@@ -1666,6 +1674,105 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 						page.limit,
 					);
 		return results.map((value) => ({ id: value[0], value: value[1] }));
+	}
+
+	private async putWithEncodedFields(
+		value: T,
+		id: types.IdKey,
+		fields: Uint8Array,
+	): Promise<void> {
+		const storeKey = keyToStoreKey(id);
+		if (!this.snapshotFile) {
+			this.getNative().put(storeKey, id, value, fields);
+			return;
+		}
+		await this.enqueueMutation(async () => {
+			await this.appendPut(storeKey, value);
+			this.getNative().put(storeKey, id, value, fields);
+			await this.compactIfNeeded();
+		});
+	}
+
+	private async putWithEncodedFieldsAndDeleteKeys(
+		value: T,
+		id: types.IdKey,
+		fields: Uint8Array,
+		deleteKeys: string[],
+	): Promise<types.IdKey[]> {
+		if (deleteKeys.length === 0) {
+			await this.putWithEncodedFields(value, id, fields);
+			return [];
+		}
+		const storeKey = keyToStoreKey(id);
+		if (!this.snapshotFile) {
+			return this.getNative()
+				.put_and_delete_keys(storeKey, id, value, fields, deleteKeys)
+				.map((entry) => entry[0]);
+		}
+
+		return this.enqueueMutation(async () => {
+			await this.appendPut(storeKey, value);
+			await this.appendDeletes(deleteKeys);
+			const deletedEntries = this.getNative().put_and_delete_keys(
+				storeKey,
+				id,
+				value,
+				fields,
+				deleteKeys,
+			);
+			await this.compactIfNeeded();
+			return deletedEntries.map((entry) => entry[0]);
+		});
+	}
+
+	private getSharedLogCoordinateFieldIds(): NonNullable<
+		RustIndex<T, NestedType>["sharedLogCoordinateFieldIds"]
+	> {
+		return (this.sharedLogCoordinateFieldIds ??= {
+			hash: nativeFieldId(this.fieldDictionary, ["hash"]),
+			hashNumber: nativeFieldId(this.fieldDictionary, ["hashNumber"]),
+			gid: nativeFieldId(this.fieldDictionary, ["gid"]),
+			coordinates: nativeFieldId(this.fieldDictionary, ["coordinates"]),
+			coordinatesArray: nativeArrayElementFieldId(this.fieldDictionary, [
+				"coordinates",
+			]),
+			wallTime: nativeFieldId(this.fieldDictionary, ["wallTime"]),
+			assignedToRangeBoundary: nativeFieldId(this.fieldDictionary, [
+				"assignedToRangeBoundary",
+			]),
+			meta: nativeFieldId(this.fieldDictionary, ["_meta"]),
+		});
+	}
+
+	private encodeSharedLogCoordinateFields(
+		fields: SharedLogCoordinateNativeFields,
+	): Uint8Array {
+		const ids = this.getSharedLogCoordinateFieldIds();
+		const writer = new NativeFieldWriter();
+		const state = { nextScope: 1 };
+		writer.writeString(0, ids.hash, fields.hash);
+		writer.writeU64(0, ids.hashNumber, fields.hashNumber);
+		writer.writeString(0, ids.gid, fields.gid);
+		for (const coordinate of fields.coordinates) {
+			const scope = state.nextScope++;
+			writer.writeBool(scope, ids.coordinatesArray, true);
+			writer.writeU64(scope, ids.coordinates, coordinate);
+		}
+		writer.writeU64(0, ids.wallTime, fields.wallTime);
+		writer.writeBool(
+			0,
+			ids.assignedToRangeBoundary,
+			fields.assignedToRangeBoundary,
+		);
+		writeNativeBytesFacts(
+			writer,
+			state,
+			0,
+			ids.meta,
+			fields.metaBytes,
+			this.byteElementIndexLimit,
+		);
+		return writer.finish();
 	}
 
 	private putNativeDocument(storeKey: string, id: types.IdKey, value: T): void {

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -1,6 +1,7 @@
 import { field, vec } from "@dao-xyz/borsh";
 import {
 	And,
+	BoolQuery,
 	ByteMatchQuery,
 	Compare,
 	IntegerCompare,
@@ -104,6 +105,47 @@ class BridgeBytesDocument {
 	constructor(id: string, payload: Uint8Array) {
 		this.id = id;
 		this.payload = payload;
+	}
+}
+
+class BridgeCoordinateDocument {
+	@id({ type: "string" })
+	hash: string;
+
+	@field({ type: "u64" })
+	hashNumber: bigint;
+
+	@field({ type: "string" })
+	gid: string;
+
+	@field({ type: vec("u64") })
+	coordinates: bigint[];
+
+	@field({ type: "u64" })
+	wallTime: bigint;
+
+	@field({ type: "bool" })
+	assignedToRangeBoundary: boolean;
+
+	@field({ type: Uint8Array })
+	_meta: Uint8Array;
+
+	constructor(
+		hash: string,
+		hashNumber: bigint,
+		gid: string,
+		coordinates: bigint[],
+		wallTime: bigint,
+		assignedToRangeBoundary: boolean,
+		meta: Uint8Array,
+	) {
+		this.hash = hash;
+		this.hashNumber = hashNumber;
+		this.gid = gid;
+		this.coordinates = coordinates;
+		this.wallTime = wallTime;
+		this.assignedToRangeBoundary = assignedToRangeBoundary;
+		this._meta = meta;
 	}
 }
 
@@ -323,6 +365,94 @@ describe("native planner bridge", () => {
 		expect(deleted.map((id) => id.primitive)).to.deep.equal(["a"]);
 		const results = await index.iterate().all();
 		expect(results.map((result) => result.value.id)).to.deep.equal(["b"]);
+
+		await indices.drop();
+	});
+
+	it("indexes shared-log coordinate fields through the typed native path", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeCoordinateDocument });
+		const coordinateIndex = index as typeof index & {
+			putSharedLogCoordinateAndDeleteIds: (
+				value: BridgeCoordinateDocument,
+				fields: {
+					hash: string;
+					hashNumber: bigint;
+					gid: string;
+					coordinates: bigint[];
+					wallTime: bigint;
+					assignedToRangeBoundary: boolean;
+					metaBytes: Uint8Array;
+				},
+				deleteIds?: string[],
+			) => Promise<ReturnType<typeof toId>[]>;
+		};
+		const meta = new Uint8Array([1, 2, 3]);
+		const first = new BridgeCoordinateDocument(
+			"a",
+			10n,
+			"gid-a",
+			[4n, 8n],
+			12n,
+			true,
+			meta,
+		);
+		await coordinateIndex.putSharedLogCoordinateAndDeleteIds(first, {
+			hash: first.hash,
+			hashNumber: first.hashNumber,
+			gid: first.gid,
+			coordinates: first.coordinates,
+			wallTime: first.wallTime,
+			assignedToRangeBoundary: first.assignedToRangeBoundary,
+			metaBytes: first._meta,
+		});
+
+		const matches = await index
+			.iterate({
+				query: new And([
+					new StringMatch({ key: "gid", value: "gid-a" }),
+					new IntegerCompare({
+						key: "coordinates",
+						compare: Compare.Equal,
+						value: 8n,
+					}),
+					new BoolQuery({
+						key: "assignedToRangeBoundary",
+						value: true,
+					}),
+					new ByteMatchQuery({ key: "_meta", value: meta }),
+				]),
+			})
+			.all();
+		expect(matches.map((entry) => entry.value.hash)).to.deep.equal(["a"]);
+
+		const second = new BridgeCoordinateDocument(
+			"b",
+			11n,
+			"gid-b",
+			[16n],
+			13n,
+			false,
+			new Uint8Array([4]),
+		);
+		const deleted = await coordinateIndex.putSharedLogCoordinateAndDeleteIds(
+			second,
+			{
+				hash: second.hash,
+				hashNumber: second.hashNumber,
+				gid: second.gid,
+				coordinates: second.coordinates,
+				wallTime: second.wallTime,
+				assignedToRangeBoundary: second.assignedToRangeBoundary,
+				metaBytes: second._meta,
+			},
+			["a"],
+		);
+
+		expect(deleted.map((id) => id.primitive)).to.deep.equal(["a"]);
+		const remaining = await index.iterate().all();
+		expect(remaining.map((entry) => entry.value.hash)).to.deep.equal(["b"]);
 
 		await indices.drop();
 	});
@@ -791,6 +921,67 @@ describe("native planner bridge", () => {
 			const result = await readerIndex.iterate().all();
 
 			expect(result.map((entry) => entry.value.id)).to.deep.equal(["b"]);
+		} finally {
+			await writer.drop();
+			await reader.drop();
+			await removeNodeDirectoryIfNeeded(directory);
+		}
+	});
+
+	it("replays durable shared-log coordinate fields from the typed native path", async () => {
+		const directory = createPersistenceDirectory();
+		const writer = create(directory);
+		const reader = create(directory);
+		try {
+			await writer.start();
+			const writerIndex = await writer.init({ schema: BridgeCoordinateDocument });
+			const coordinateIndex = writerIndex as typeof writerIndex & {
+				putSharedLogCoordinateAndDeleteIds: (
+					value: BridgeCoordinateDocument,
+					fields: {
+						hash: string;
+						hashNumber: bigint;
+						gid: string;
+						coordinates: bigint[];
+						wallTime: bigint;
+						assignedToRangeBoundary: boolean;
+						metaBytes: Uint8Array;
+					},
+					deleteIds?: string[],
+				) => Promise<ReturnType<typeof toId>[]>;
+			};
+			const value = new BridgeCoordinateDocument(
+				"a",
+				10n,
+				"gid-a",
+				[4n, 8n],
+				12n,
+				true,
+				new Uint8Array([1, 2, 3]),
+			);
+			await coordinateIndex.putSharedLogCoordinateAndDeleteIds(value, {
+				hash: value.hash,
+				hashNumber: value.hashNumber,
+				gid: value.gid,
+				coordinates: value.coordinates,
+				wallTime: value.wallTime,
+				assignedToRangeBoundary: value.assignedToRangeBoundary,
+				metaBytes: value._meta,
+			});
+
+			await reader.start();
+			const readerIndex = await reader.init({ schema: BridgeCoordinateDocument });
+			const result = await readerIndex
+				.iterate({
+					query: new IntegerCompare({
+						key: "coordinates",
+						compare: Compare.Equal,
+						value: 8n,
+					}),
+				})
+				.all();
+
+			expect(result.map((entry) => entry.value.hash)).to.deep.equal(["a"]);
 		} finally {
 			await writer.drop();
 			await reader.drop();


### PR DESCRIPTION
## Summary
- add an internal typed shared-log coordinate field path to `@peerbit/indexer-rust`
- write coordinate row facts directly with cached native field ids instead of using the generic schema/object walker
- wire shared-log coordinate persistence to use the typed path when available, preserving exact-id and generic fallbacks
- expose `EntryReplicated*.getMetaBytes()` so the typed path reuses materialized metadata bytes
- add transient and durable replay coverage for the typed coordinate path

## Performance
Local document-put deep profile, 1000 ops, compared with #878 baseline:
- `rust-peerbit-nonunique`: coordinate persistence 18.95 ms -> 18.66 ms; total 270.06 ms -> 272.83 ms
- `rust-peerbit-transient-index-nonunique`: coordinate persistence 16.21 ms -> 15.27 ms; total 228.28 ms -> 215.31 ms
- `simple-index-nonunique`: total 153.48 ms -> 151.89 ms, mostly noise/control

This is a modest coalescence step, but it gives us a typed coordinate-fact bridge for the later native coordinate-head store work.

## Test Plan
- `pnpm --filter @peerbit/indexer-rust run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `pnpm exec eslint packages/utils/indexer/rust/src/index.ts packages/utils/indexer/rust/test/index.spec.ts packages/programs/data/shared-log/src/index.ts packages/programs/data/shared-log/src/ranges.ts`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/utils/indexer/rust -- -t node --grep "shared-log coordinate"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/utils/indexer/rust -- -t node --grep "exact id"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "leader are selected from 1 replicating peer"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "validated local append path"`
- `git diff --check`