### PR TITLE
Count assigned heads in native shared-log state

### DIFF
--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -281,6 +281,12 @@ type NativeSharedLogStateHandle = {
 		coordinates: string[],
 		nextHashes: string[],
 	) => void;
+	count_entry_coordinates_in_ranges: (
+		start1: string[],
+		end1: string[],
+		start2: string[],
+		end2: string[],
+	) => number;
 	delete_entry_coordinates_batch: (hashes: string[]) => void;
 	clear_entry_coordinates: () => void;
 	add_gid_peers: (gid: string, peers: string[], reset: boolean) => number;
@@ -867,6 +873,32 @@ export class SharedLogNativeState {
 			hash,
 			[...coordinates].map(asIntegerString),
 			[...nextHashes],
+		);
+	}
+
+	countEntryCoordinatesInRanges(
+		ranges: Iterable<{
+			start1: bigint | number | string;
+			end1: bigint | number | string;
+			start2: bigint | number | string;
+			end2: bigint | number | string;
+		}>,
+	): number {
+		const start1: string[] = [];
+		const end1: string[] = [];
+		const start2: string[] = [];
+		const end2: string[] = [];
+		for (const range of ranges) {
+			start1.push(asIntegerString(range.start1));
+			end1.push(asIntegerString(range.end1));
+			start2.push(asIntegerString(range.start2));
+			end2.push(asIntegerString(range.end2));
+		}
+		return this.native.count_entry_coordinates_in_ranges(
+			start1,
+			end1,
+			start2,
+			end2,
 		);
 	}
 

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -1663,6 +1663,38 @@ impl NativeSharedLogState {
         Ok(())
     }
 
+    pub fn count_entry_coordinates_in_ranges(
+        &self,
+        start1: Array,
+        end1: Array,
+        start2: Array,
+        end2: Array,
+    ) -> Result<usize, JsValue> {
+        let start1 = cursor_values_from_array(start1)?;
+        let end1 = cursor_values_from_array(end1)?;
+        let start2 = cursor_values_from_array(start2)?;
+        let end2 = cursor_values_from_array(end2)?;
+        ensure_same_len(start1.len(), end1.len(), "coordinate range")?;
+        ensure_same_len(start1.len(), start2.len(), "coordinate range")?;
+        ensure_same_len(start1.len(), end2.len(), "coordinate range")?;
+
+        let mut count = 0usize;
+        for coordinates in self.inner.entry_coordinates.values() {
+            if coordinates.iter().any(|coordinate| {
+                start1.iter().zip(&end1).zip(start2.iter().zip(&end2)).any(
+                    |((range_start1, range_end1), (range_start2, range_end2))| {
+                        coordinate_in_segment(*coordinate, *range_start1, *range_end1)
+                            || ((*range_start2 != *range_end2)
+                                && coordinate_in_segment(*coordinate, *range_start2, *range_end2))
+                    },
+                )
+            }) {
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
     pub fn delete_entry_coordinates_batch(&mut self, hashes: Array) -> Result<(), JsValue> {
         for hash in strings_from_array(hashes)? {
             self.inner.entry_coordinates.remove(&hash);
@@ -2291,6 +2323,10 @@ fn cursor_values_from_array(values: Array) -> Result<Vec<u64>, JsValue> {
         .into_iter()
         .map(|value| parse_u64(&value))
         .collect::<Result<Vec<_>, _>>()
+}
+
+fn coordinate_in_segment(coordinate: u64, start: u64, end: u64) -> bool {
+    coordinate >= start && coordinate < end
 }
 
 fn usize_from_array(values: Array) -> Result<Vec<usize>, JsValue> {

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -337,6 +337,34 @@ describe("native shared-log range planner", () => {
 		expect(state.getEntryCoordinates("old-head")).to.equal(undefined);
 	});
 
+	it("counts resident entry coordinates in owned ranges", async () => {
+		const state = await createSharedLogState("u32");
+		state.putEntryCoordinates("head-a", [5, 100]);
+		state.putEntryCoordinates("head-b", [25]);
+		state.putEntryCoordinates("head-c", [80]);
+		state.putEntryCoordinates("head-d", [95]);
+
+		expect(
+			state.countEntryCoordinatesInRanges([
+				range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }),
+				range({ id: "b", hash: "peer-b", start1: 90, end1: 100 }),
+			]),
+		).to.equal(2);
+
+		expect(
+			state.countEntryCoordinatesInRanges([
+				range({
+					id: "wrap",
+					hash: "peer-wrap",
+					start1: 90,
+					end1: 100,
+					start2: 0,
+					end2: 10,
+				}),
+			]),
+		).to.equal(2);
+	});
+
 	it("expands append leaders with full-replica delivery candidates", async () => {
 		const state = await createSharedLogState("u32");
 		const leaders = new Map([["peer-a", { intersecting: false }]]);

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -6539,6 +6539,9 @@ export class SharedLog<
 
 	async countAssignedHeads(options?: { strict: boolean }): Promise<number> {
 		const myRanges = await this.getMyReplicationSegments();
+		if (options?.strict && this._nativeSharedLogState) {
+			return this._nativeSharedLogState.countEntryCoordinatesInRanges(myRanges);
+		}
 		const query = createAssignedRangesQuery(
 			myRanges.map((x) => {
 				return { range: x };


### PR DESCRIPTION
## Summary
- route strict `SharedLog.countAssignedHeads()` through resident native shared-log coordinate state
- keep non-strict counts on the existing coordinate index path because boundary-assigned heads are not resident-native yet
- add native shared-log state coverage for normal and wrapped owned ranges

## Benchmark
Local microbench with 20k `EntryReplicatedU64` coordinate rows and 200 repeated strict counts:
- generic Rust coordinate index count: 4890.63 ms total, about 41 counts/sec
- native resident coordinate count: 106.27 ms total, about 1882 counts/sec
- results matched exactly at 6000 heads

## Test Plan
- `cargo fmt --manifest-path packages/programs/data/shared-log/rust/Cargo.toml --check`
- `pnpm --filter @peerbit/shared-log-rust run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm exec eslint packages/programs/data/shared-log/rust/src/index.ts packages/programs/data/shared-log/rust/test/index.spec.ts packages/programs/data/shared-log/src/index.ts`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log/rust -- -t node --grep "counts resident entry coordinates"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "leader are selected from 1 replicating peer"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "countHeads"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "countAssignedHeads"`
- `git diff --check`