### PR TITLE
Count boundary assigned heads in native shared-log state

### DIFF
--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -273,19 +273,25 @@ type NativeSharedLogStateHandle = {
 	clear: () => void;
 	put: NativeRangePlannerHandle["put"];
 	delete: NativeRangePlannerHandle["delete"];
-	put_entry_coordinates: (hash: string, coordinates: string[]) => void;
+	put_entry_coordinates: (
+		hash: string,
+		coordinates: string[],
+		assignedToRangeBoundary: boolean,
+	) => void;
 	delete_entry_coordinates: (hash: string) => boolean;
 	get_entry_coordinates: (hash: string) => unknown[] | undefined;
 	commit_entry_coordinates: (
 		hash: string,
 		coordinates: string[],
 		nextHashes: string[],
+		assignedToRangeBoundary: boolean,
 	) => void;
 	count_entry_coordinates_in_ranges: (
 		start1: string[],
 		end1: string[],
 		start2: string[],
 		end2: string[],
+		includeAssignedToRangeBoundary: boolean,
 	) => number;
 	delete_entry_coordinates_batch: (hashes: string[]) => void;
 	clear_entry_coordinates: () => void;
@@ -851,8 +857,13 @@ export class SharedLogNativeState {
 	putEntryCoordinates(
 		hash: string,
 		coordinates: Iterable<bigint | number | string>,
+		assignedToRangeBoundary = false,
 	): void {
-		this.native.put_entry_coordinates(hash, [...coordinates].map(asIntegerString));
+		this.native.put_entry_coordinates(
+			hash,
+			[...coordinates].map(asIntegerString),
+			assignedToRangeBoundary,
+		);
 	}
 
 	deleteEntryCoordinates(hash: string): boolean {
@@ -868,11 +879,13 @@ export class SharedLogNativeState {
 		hash: string,
 		coordinates: Iterable<bigint | number | string>,
 		nextHashes: Iterable<string>,
+		assignedToRangeBoundary = false,
 	): void {
 		this.native.commit_entry_coordinates(
 			hash,
 			[...coordinates].map(asIntegerString),
 			[...nextHashes],
+			assignedToRangeBoundary,
 		);
 	}
 
@@ -883,6 +896,7 @@ export class SharedLogNativeState {
 			start2: bigint | number | string;
 			end2: bigint | number | string;
 		}>,
+		options?: { includeAssignedToRangeBoundary?: boolean },
 	): number {
 		const start1: string[] = [];
 		const end1: string[] = [];
@@ -899,6 +913,7 @@ export class SharedLogNativeState {
 			end1,
 			start2,
 			end2,
+			options?.includeAssignedToRangeBoundary === true,
 		);
 	}
 

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -1100,9 +1100,15 @@ pub struct NativeRangePlanner {
 
 pub struct SharedLogStateInner {
     range_planner: RangePlanner,
-    entry_coordinates: HashMap<String, Vec<u64>>,
+    entry_coordinates: HashMap<String, EntryCoordinateState>,
     gid_peers: HashMap<String, IndexSet<String>>,
     entry_known_peers: HashMap<String, IndexSet<String>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct EntryCoordinateState {
+    coordinates: Vec<u64>,
+    assigned_to_range_boundary: bool,
 }
 
 impl SharedLogStateInner {
@@ -1627,10 +1633,15 @@ impl NativeSharedLogState {
         &mut self,
         hash: String,
         coordinates: Array,
+        assigned_to_range_boundary: bool,
     ) -> Result<(), JsValue> {
-        self.inner
-            .entry_coordinates
-            .insert(hash, cursor_values_from_array(coordinates)?);
+        self.inner.entry_coordinates.insert(
+            hash,
+            EntryCoordinateState {
+                coordinates: cursor_values_from_array(coordinates)?,
+                assigned_to_range_boundary,
+            },
+        );
         Ok(())
     }
 
@@ -1642,8 +1653,12 @@ impl NativeSharedLogState {
         self.inner
             .entry_coordinates
             .get(hash)
-            .map(|coordinates| {
-                numbers_to_rows(coordinates.clone(), self.inner.range_planner.resolution).into()
+            .map(|entry| {
+                numbers_to_rows(
+                    entry.coordinates.clone(),
+                    self.inner.range_planner.resolution,
+                )
+                .into()
             })
             .unwrap_or(JsValue::UNDEFINED)
     }
@@ -1653,10 +1668,17 @@ impl NativeSharedLogState {
         hash: String,
         coordinates: Array,
         next_hashes: Array,
+        assigned_to_range_boundary: bool,
     ) -> Result<(), JsValue> {
         let coordinates = cursor_values_from_array(coordinates)?;
         let next_hashes = strings_from_array(next_hashes)?;
-        self.inner.entry_coordinates.insert(hash, coordinates);
+        self.inner.entry_coordinates.insert(
+            hash,
+            EntryCoordinateState {
+                coordinates,
+                assigned_to_range_boundary,
+            },
+        );
         for next_hash in next_hashes {
             self.inner.entry_coordinates.remove(&next_hash);
         }
@@ -1669,6 +1691,7 @@ impl NativeSharedLogState {
         end1: Array,
         start2: Array,
         end2: Array,
+        include_assigned_to_range_boundary: bool,
     ) -> Result<usize, JsValue> {
         let start1 = cursor_values_from_array(start1)?;
         let end1 = cursor_values_from_array(end1)?;
@@ -1679,16 +1702,22 @@ impl NativeSharedLogState {
         ensure_same_len(start1.len(), end2.len(), "coordinate range")?;
 
         let mut count = 0usize;
-        for coordinates in self.inner.entry_coordinates.values() {
-            if coordinates.iter().any(|coordinate| {
-                start1.iter().zip(&end1).zip(start2.iter().zip(&end2)).any(
-                    |((range_start1, range_end1), (range_start2, range_end2))| {
-                        coordinate_in_segment(*coordinate, *range_start1, *range_end1)
-                            || ((*range_start2 != *range_end2)
-                                && coordinate_in_segment(*coordinate, *range_start2, *range_end2))
-                    },
-                )
-            }) {
+        for entry in self.inner.entry_coordinates.values() {
+            if (include_assigned_to_range_boundary && entry.assigned_to_range_boundary)
+                || entry.coordinates.iter().any(|coordinate| {
+                    start1.iter().zip(&end1).zip(start2.iter().zip(&end2)).any(
+                        |((range_start1, range_end1), (range_start2, range_end2))| {
+                            coordinate_in_segment(*coordinate, *range_start1, *range_end1)
+                                || ((*range_start2 != *range_end2)
+                                    && coordinate_in_segment(
+                                        *coordinate,
+                                        *range_start2,
+                                        *range_end2,
+                                    ))
+                        },
+                    )
+                })
+            {
                 count += 1;
             }
         }
@@ -1921,9 +1950,13 @@ impl NativeSharedLogState {
         let is_leader = leaders.iter().any(|leader| leader.hash == self_hash);
         let assigned_to_range_boundary = should_assign_to_range_boundary(&leaders, replicas);
 
-        self.inner
-            .entry_coordinates
-            .insert(entry_hash, coordinates.clone());
+        self.inner.entry_coordinates.insert(
+            entry_hash,
+            EntryCoordinateState {
+                coordinates: coordinates.clone(),
+                assigned_to_range_boundary,
+            },
+        );
         for next_hash in next_hashes {
             self.inner.entry_coordinates.remove(&next_hash);
         }
@@ -2020,9 +2053,13 @@ impl NativeSharedLogState {
         let is_leader = leaders.iter().any(|leader| leader.hash == self_hash);
         let assigned_to_range_boundary = should_assign_to_range_boundary(&leaders, replicas);
 
-        self.inner
-            .entry_coordinates
-            .insert(entry_hash, coordinates.clone());
+        self.inner.entry_coordinates.insert(
+            entry_hash,
+            EntryCoordinateState {
+                coordinates: coordinates.clone(),
+                assigned_to_range_boundary,
+            },
+        );
         for next_hash in next_hashes {
             self.inner.entry_coordinates.remove(&next_hash);
         }
@@ -2118,9 +2155,13 @@ impl NativeSharedLogState {
             let is_leader = leaders.iter().any(|leader| leader.hash == self_hash);
             let assigned_to_range_boundary = should_assign_to_range_boundary(&leaders, replicas);
 
-            self.inner
-                .entry_coordinates
-                .insert(entry_hash, coordinates.clone());
+            self.inner.entry_coordinates.insert(
+                entry_hash,
+                EntryCoordinateState {
+                    coordinates: coordinates.clone(),
+                    assigned_to_range_boundary,
+                },
+            );
             for next_hash in next_hashes {
                 self.inner.entry_coordinates.remove(&next_hash);
             }

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -331,7 +331,7 @@ describe("native shared-log range planner", () => {
 		const state = await createSharedLogState("u32");
 		state.putEntryCoordinates("old-head", [1, 2]);
 
-		state.commitEntryCoordinates("new-head", [3, 4], ["old-head"]);
+		state.commitEntryCoordinates("new-head", [3, 4], ["old-head"], true);
 
 		expect(state.getEntryCoordinates("new-head")).to.deep.equal([3, 4]);
 		expect(state.getEntryCoordinates("old-head")).to.equal(undefined);
@@ -362,6 +362,21 @@ describe("native shared-log range planner", () => {
 					end2: 10,
 				}),
 			]),
+		).to.equal(2);
+	});
+
+	it("counts resident boundary-assigned entries on request", async () => {
+		const state = await createSharedLogState("u32");
+		state.putEntryCoordinates("inside", [5], false);
+		state.putEntryCoordinates("outside", [50], false);
+		state.putEntryCoordinates("boundary", [80], true);
+
+		const owned = [range({ id: "a", hash: "peer-a", start1: 0, end1: 10 })];
+		expect(state.countEntryCoordinatesInRanges(owned)).to.equal(1);
+		expect(
+			state.countEntryCoordinatesInRanges(owned, {
+				includeAssignedToRangeBoundary: true,
+			}),
 		).to.equal(2);
 	});
 

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -4941,6 +4941,7 @@ export class SharedLog<
 					state.putEntryCoordinates(
 						result.value.hash,
 						result.value.coordinates,
+						result.value.assignedToRangeBoundary,
 					);
 				}
 			}
@@ -6539,8 +6540,14 @@ export class SharedLog<
 
 	async countAssignedHeads(options?: { strict: boolean }): Promise<number> {
 		const myRanges = await this.getMyReplicationSegments();
-		if (options?.strict && this._nativeSharedLogState) {
-			return this._nativeSharedLogState.countEntryCoordinatesInRanges(myRanges);
+		if (this._nativeSharedLogState) {
+			const includeAssignedToRangeBoundary =
+				options?.strict !== true &&
+				(myRanges.length === 0 ||
+					myRanges.some((range) => range.mode === ReplicationIntent.NonStrict));
+			return this._nativeSharedLogState.countEntryCoordinatesInRanges(myRanges, {
+				includeAssignedToRangeBoundary,
+			});
 		}
 		const query = createAssignedRangesQuery(
 			myRanges.map((x) => {
@@ -7250,6 +7257,7 @@ export class SharedLog<
 				properties.entry.hash,
 				properties.coordinates,
 				properties.entry.meta.next,
+				assignedToRangeBoundary,
 			);
 		}
 


### PR DESCRIPTION
## Summary
- store `assignedToRangeBoundary` with resident native shared-log entry coordinates
- hydrate the boundary bit from the coordinate index and preserve it in native append/commit paths
- route both strict and default `SharedLog.countAssignedHeads()` through native resident state when available
- keep the existing generic index query as fallback when native shared-log state is unavailable

## Benchmark
Local microbench with 20k `EntryReplicatedU64` coordinate rows, mixed strict/non-strict ranges, and 200 repeated non-strict counts including boundary-assigned rows:
- generic Rust coordinate index count: 729.86 ms total, about 274 counts/sec
- native resident coordinate count: 47.37 ms total, about 4222 counts/sec
- results matched exactly at 4000 heads

## Test Plan
- `cargo fmt --manifest-path packages/programs/data/shared-log/rust/Cargo.toml --check`
- `pnpm exec eslint packages/programs/data/shared-log/rust/src/index.ts packages/programs/data/shared-log/rust/test/index.spec.ts packages/programs/data/shared-log/src/index.ts`
- `pnpm --filter @peerbit/shared-log-rust run build`
- `pnpm --filter @peerbit/shared-log run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log/rust -- -t node --grep "boundary-assigned"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "countAssignedHeads"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "countHeads"`
- `git diff --check`