### PR TITLE
Read resident coordinates from native shared-log state

### DIFF
--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -280,6 +280,7 @@ type NativeSharedLogStateHandle = {
 	) => void;
 	delete_entry_coordinates: (hash: string) => boolean;
 	get_entry_coordinates: (hash: string) => unknown[] | undefined;
+	entry_coordinate_hashes: () => string[];
 	commit_entry_coordinates: (
 		hash: string,
 		coordinates: string[],
@@ -873,6 +874,10 @@ export class SharedLogNativeState {
 	getEntryCoordinates(hash: string): Array<number | bigint> | undefined {
 		const coordinates = this.native.get_entry_coordinates(hash);
 		return coordinates ? rowsToNumbers(this.resolution, coordinates) : undefined;
+	}
+
+	getEntryCoordinateHashes(): string[] {
+		return this.native.entry_coordinate_hashes();
 	}
 
 	commitEntryCoordinates(

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -1663,6 +1663,10 @@ impl NativeSharedLogState {
             .unwrap_or(JsValue::UNDEFINED)
     }
 
+    pub fn entry_coordinate_hashes(&self) -> Array {
+        strings_to_array(self.inner.entry_coordinates.keys().cloned().collect())
+    }
+
     pub fn commit_entry_coordinates(
         &mut self,
         hash: String,

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -337,6 +337,15 @@ describe("native shared-log range planner", () => {
 		expect(state.getEntryCoordinates("old-head")).to.equal(undefined);
 	});
 
+	it("lists resident entry coordinate hashes", async () => {
+		const state = await createSharedLogState("u32");
+		state.putEntryCoordinates("head-a", [1]);
+		state.putEntryCoordinates("head-b", [2]);
+		state.deleteEntryCoordinates("head-a");
+
+		expect(state.getEntryCoordinateHashes()).to.deep.equal(["head-b"]);
+	});
+
 	it("counts resident entry coordinates in owned ranges", async () => {
 		const state = await createSharedLogState("u32");
 		state.putEntryCoordinates("head-a", [5, 100]);

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -1943,13 +1943,17 @@ export class SharedLog<
 	private async ensureCurrentHeadCoordinatesIndexed() {
 		const heads = await this.log.getHeads(true).all();
 		const headsByHash = new Map(heads.map((head) => [head.hash, head]));
-		const indexedHeads = await this.entryCoordinatesIndex
-			.iterate({}, { shape: { hash: true } })
-			.all();
-		const indexedHashes = new Set(indexedHeads.map((entry) => entry.value.hash));
-		const staleHashes = indexedHeads
-			.map((entry) => entry.value.hash)
-			.filter((hash) => !headsByHash.has(hash));
+		const nativeHashes = this._nativeSharedLogState?.getEntryCoordinateHashes();
+		const indexedHashes = nativeHashes
+			? new Set(nativeHashes)
+			: new Set(
+					(
+						await this.entryCoordinatesIndex
+							.iterate({}, { shape: { hash: true } })
+							.all()
+					).map((entry) => entry.value.hash),
+				);
+		const staleHashes = [...indexedHashes].filter((hash) => !headsByHash.has(hash));
 
 		if (staleHashes.length > 0) {
 			await this.deleteCoordinatesForHashes(staleHashes);
@@ -7165,6 +7169,12 @@ export class SharedLog<
 	}
 
 	private async getCoordinates(entry: { hash: string }) {
+		const nativeCoordinates = this._nativeSharedLogState?.getEntryCoordinates(
+			entry.hash,
+		);
+		if (nativeCoordinates) {
+			return nativeCoordinates as NumberFromType<R>[];
+		}
 		const result = await this.entryCoordinatesIndex
 			.iterate({ query: { hash: entry.hash } })
 			.all();


### PR DESCRIPTION
## Summary
- expose resident native entry-coordinate hashes from `@peerbit/shared-log-rust`
- use native resident hashes in `ensureCurrentHeadCoordinatesIndexed()` when available, with the existing shaped index iteration as fallback
- use native resident coordinate lookup in `getCoordinates(entry)` before falling back to the generic coordinate-index hash query
- add shared-log-rust coverage for resident hash listing after delete

## Benchmark
Local microbench with 20k `EntryReplicatedU64` coordinate rows:

Hash list, 100 loops:
- generic index shaped iterate: 3920.51 ms total, about 25.5 lists/sec
- native resident hash list: 389.78 ms total, about 256.6 lists/sec

Single coordinate lookup, 10k loops:
- generic index hash query: 55.03 ms total, about 181.7k lookups/sec
- native resident lookup: 10.92 ms total, about 916.1k lookups/sec

## Test Plan
- `cargo fmt --manifest-path packages/programs/data/shared-log/rust/Cargo.toml --check`
- `pnpm exec eslint packages/programs/data/shared-log/rust/src/index.ts packages/programs/data/shared-log/rust/test/index.spec.ts packages/programs/data/shared-log/src/index.ts`
- `pnpm --filter @peerbit/shared-log-rust run build`
- `pnpm --filter @peerbit/shared-log run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log/rust -- -t node --grep "lists resident entry coordinate hashes"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "backfills deferred head coordinates"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "leader are selected from 1 replicating peer"`
- `git diff --check`