### PR TITLE
Plan repair sweeps from native shared-log state

### DIFF
--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -128,6 +128,10 @@ export type RepairDispatchEntryPlanInput = Omit<
 > & {
 	entries: Iterable<RepairDispatchEntryPlanBatchEntry>;
 };
+export type ResidentRepairDispatchPlanInput = Omit<
+	RepairDispatchEntryPlanInput,
+	"entries"
+>;
 
 export type RepairDispatchPlan = Map<string, Map<string, string[]>>;
 
@@ -275,17 +279,21 @@ type NativeSharedLogStateHandle = {
 	delete: NativeRangePlannerHandle["delete"];
 	put_entry_coordinates: (
 		hash: string,
+		gid: string,
 		coordinates: string[],
 		assignedToRangeBoundary: boolean,
+		requestedReplicas: number,
 	) => void;
 	delete_entry_coordinates: (hash: string) => boolean;
 	get_entry_coordinates: (hash: string) => unknown[] | undefined;
 	entry_coordinate_hashes: () => string[];
 	commit_entry_coordinates: (
 		hash: string,
+		gid: string,
 		coordinates: string[],
 		nextHashes: string[],
 		assignedToRangeBoundary: boolean,
+		requestedReplicas: number,
 	) => void;
 	count_entry_coordinates_in_ranges: (
 		start1: string[],
@@ -409,6 +417,22 @@ type NativeSharedLogStateHandle = {
 		pendingModes: string[],
 		pendingPeersByMode: string[][],
 		optimisticPeersByMode: string[][][],
+		fullReplicaRepairCandidates: string[],
+		fullReplicaRepairCandidateCount: number,
+		roleAgeMs: number,
+		now: string,
+		peerFilter: string[] | undefined,
+		expandPeerFilter: boolean,
+		selfHash: string,
+		includeSelf: boolean,
+		fullReplicaFallback: boolean,
+		includeStrictFullReplica: boolean,
+	) => unknown[];
+	plan_repair_dispatch_for_resident_entries: (
+		pendingModes: string[],
+		pendingPeersByMode: string[][],
+		optimisticGidsByMode: string[][],
+		optimisticPeersByGidByMode: string[][][],
 		fullReplicaRepairCandidates: string[],
 		fullReplicaRepairCandidateCount: number,
 		roleAgeMs: number,
@@ -857,13 +881,18 @@ export class SharedLogNativeState {
 
 	putEntryCoordinates(
 		hash: string,
+		gid: string,
 		coordinates: Iterable<bigint | number | string>,
 		assignedToRangeBoundary = false,
+		requestedReplicas?: number,
 	): void {
+		const coordinateRows = [...coordinates].map(asIntegerString);
 		this.native.put_entry_coordinates(
 			hash,
-			[...coordinates].map(asIntegerString),
+			gid,
+			coordinateRows,
 			assignedToRangeBoundary,
+			requestedReplicas ?? coordinateRows.length,
 		);
 	}
 
@@ -882,15 +911,20 @@ export class SharedLogNativeState {
 
 	commitEntryCoordinates(
 		hash: string,
+		gid: string,
 		coordinates: Iterable<bigint | number | string>,
 		nextHashes: Iterable<string>,
 		assignedToRangeBoundary = false,
+		requestedReplicas?: number,
 	): void {
+		const coordinateRows = [...coordinates].map(asIntegerString);
 		this.native.commit_entry_coordinates(
 			hash,
-			[...coordinates].map(asIntegerString),
+			gid,
+			coordinateRows,
 			[...nextHashes],
 			assignedToRangeBoundary,
+			requestedReplicas ?? coordinateRows.length,
 		);
 	}
 
@@ -1182,6 +1216,46 @@ export class SharedLogNativeState {
 					...(optimisticByGid?.get(entry.gid) ?? []),
 				]);
 			}),
+			input.fullReplicaRepairCandidates
+				? [...input.fullReplicaRepairCandidates]
+				: [],
+			input.fullReplicaRepairCandidateCount,
+			...findLeaderArguments({
+				...options,
+				selfHash: input.selfHash,
+			}),
+		);
+		return rowsToRepairDispatchPlan(rows);
+	}
+
+	planRepairDispatchForResidentEntries(
+		input: ResidentRepairDispatchPlanInput,
+		options?: FindLeaderOptions,
+	): RepairDispatchPlan {
+		const pendingModes = [...input.pendingModes];
+		const optimisticGidsByMode: string[][] = [];
+		const optimisticPeersByGidByMode: string[][][] = [];
+		for (const mode of pendingModes) {
+			const optimisticByGid = input.optimisticPeersByMode?.get(mode);
+			const gids: string[] = [];
+			const peersByGid: string[][] = [];
+			if (optimisticByGid) {
+				for (const [gid, peers] of optimisticByGid) {
+					gids.push(gid);
+					peersByGid.push([...peers]);
+				}
+			}
+			optimisticGidsByMode.push(gids);
+			optimisticPeersByGidByMode.push(peersByGid);
+		}
+
+		const rows = this.native.plan_repair_dispatch_for_resident_entries(
+			pendingModes,
+			pendingModes.map((mode) => [
+				...(input.pendingPeersByMode.get(mode) ?? []),
+			]),
+			optimisticGidsByMode,
+			optimisticPeersByGidByMode,
 			input.fullReplicaRepairCandidates
 				? [...input.fullReplicaRepairCandidates]
 				: [],

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -1100,22 +1100,24 @@ pub struct NativeRangePlanner {
 
 pub struct SharedLogStateInner {
     range_planner: RangePlanner,
-    entry_coordinates: HashMap<String, EntryCoordinateState>,
+    entry_coordinates: IndexMap<String, EntryCoordinateState>,
     gid_peers: HashMap<String, IndexSet<String>>,
     entry_known_peers: HashMap<String, IndexSet<String>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct EntryCoordinateState {
+    gid: String,
     coordinates: Vec<u64>,
     assigned_to_range_boundary: bool,
+    requested_replicas: usize,
 }
 
 impl SharedLogStateInner {
     fn new(resolution: String) -> Self {
         Self {
             range_planner: RangePlanner::new(&resolution),
-            entry_coordinates: HashMap::new(),
+            entry_coordinates: IndexMap::new(),
             gid_peers: HashMap::new(),
             entry_known_peers: HashMap::new(),
         }
@@ -1632,21 +1634,25 @@ impl NativeSharedLogState {
     pub fn put_entry_coordinates(
         &mut self,
         hash: String,
+        gid: String,
         coordinates: Array,
         assigned_to_range_boundary: bool,
+        requested_replicas: usize,
     ) -> Result<(), JsValue> {
         self.inner.entry_coordinates.insert(
             hash,
             EntryCoordinateState {
+                gid,
                 coordinates: cursor_values_from_array(coordinates)?,
                 assigned_to_range_boundary,
+                requested_replicas,
             },
         );
         Ok(())
     }
 
     pub fn delete_entry_coordinates(&mut self, hash: &str) -> bool {
-        self.inner.entry_coordinates.remove(hash).is_some()
+        self.inner.entry_coordinates.shift_remove(hash).is_some()
     }
 
     pub fn get_entry_coordinates(&self, hash: &str) -> JsValue {
@@ -1670,21 +1676,25 @@ impl NativeSharedLogState {
     pub fn commit_entry_coordinates(
         &mut self,
         hash: String,
+        gid: String,
         coordinates: Array,
         next_hashes: Array,
         assigned_to_range_boundary: bool,
+        requested_replicas: usize,
     ) -> Result<(), JsValue> {
         let coordinates = cursor_values_from_array(coordinates)?;
         let next_hashes = strings_from_array(next_hashes)?;
         self.inner.entry_coordinates.insert(
             hash,
             EntryCoordinateState {
+                gid,
                 coordinates,
                 assigned_to_range_boundary,
+                requested_replicas,
             },
         );
         for next_hash in next_hashes {
-            self.inner.entry_coordinates.remove(&next_hash);
+            self.inner.entry_coordinates.shift_remove(&next_hash);
         }
         Ok(())
     }
@@ -1730,7 +1740,7 @@ impl NativeSharedLogState {
 
     pub fn delete_entry_coordinates_batch(&mut self, hashes: Array) -> Result<(), JsValue> {
         for hash in strings_from_array(hashes)? {
-            self.inner.entry_coordinates.remove(&hash);
+            self.inner.entry_coordinates.shift_remove(&hash);
         }
         Ok(())
     }
@@ -1957,12 +1967,14 @@ impl NativeSharedLogState {
         self.inner.entry_coordinates.insert(
             entry_hash,
             EntryCoordinateState {
+                gid,
                 coordinates: coordinates.clone(),
                 assigned_to_range_boundary,
+                requested_replicas: replicas,
             },
         );
         for next_hash in next_hashes {
-            self.inner.entry_coordinates.remove(&next_hash);
+            self.inner.entry_coordinates.shift_remove(&next_hash);
         }
 
         let out = Array::new();
@@ -2060,12 +2072,14 @@ impl NativeSharedLogState {
         self.inner.entry_coordinates.insert(
             entry_hash,
             EntryCoordinateState {
+                gid,
                 coordinates: coordinates.clone(),
                 assigned_to_range_boundary,
+                requested_replicas: replicas,
             },
         );
         for next_hash in next_hashes {
-            self.inner.entry_coordinates.remove(&next_hash);
+            self.inner.entry_coordinates.shift_remove(&next_hash);
         }
 
         let delivery_leaders = expand_append_leaders(leaders, full_replica_candidates, replicas);
@@ -2162,12 +2176,14 @@ impl NativeSharedLogState {
             self.inner.entry_coordinates.insert(
                 entry_hash,
                 EntryCoordinateState {
+                    gid,
                     coordinates: coordinates.clone(),
                     assigned_to_range_boundary,
+                    requested_replicas: replicas,
                 },
             );
             for next_hash in next_hashes {
-                self.inner.entry_coordinates.remove(&next_hash);
+                self.inner.entry_coordinates.shift_remove(&next_hash);
             }
 
             let delivery_leaders =
@@ -2282,6 +2298,140 @@ impl NativeSharedLogState {
                 optimistic_peers_by_mode,
                 "optimistic peers by mode",
             )?,
+            full_replica_repair_candidates: HashSet::<String>::from_iter(strings_from_array(
+                full_replica_repair_candidates,
+            )?),
+            full_replica_repair_candidate_count,
+            self_hash,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn plan_repair_dispatch_for_resident_entries(
+        &self,
+        pending_modes: Array,
+        pending_peers_by_mode: Array,
+        optimistic_gids_by_mode: Array,
+        optimistic_peers_by_gid_by_mode: Array,
+        full_replica_repair_candidates: Array,
+        full_replica_repair_candidate_count: usize,
+        role_age_ms: f64,
+        now: String,
+        peer_filter: JsValue,
+        expand_peer_filter: bool,
+        self_hash: String,
+        include_self: bool,
+        full_replica_fallback: bool,
+        include_strict_full_replica: bool,
+    ) -> Result<Array, JsValue> {
+        let pending_modes = strings_from_array(pending_modes)?;
+        let pending_peers_by_mode =
+            string_batches_from_array(pending_peers_by_mode, "pending peers by mode")?;
+        let optimistic_gids_by_mode =
+            string_batches_from_array(optimistic_gids_by_mode, "optimistic gids by mode")?;
+        let optimistic_peers_by_gid_by_mode =
+            string_matrix_from_array(optimistic_peers_by_gid_by_mode, "optimistic peers by gid")?;
+        ensure_same_len(
+            pending_modes.len(),
+            pending_peers_by_mode.len(),
+            "resident repair pending mode",
+        )?;
+        ensure_same_len(
+            pending_modes.len(),
+            optimistic_gids_by_mode.len(),
+            "resident repair optimistic gid mode",
+        )?;
+        ensure_same_len(
+            pending_modes.len(),
+            optimistic_peers_by_gid_by_mode.len(),
+            "resident repair optimistic peer mode",
+        )?;
+
+        let options = find_leader_options(role_age_ms, &now, peer_filter)?;
+        let mut prepared_options_by_replicas = HashMap::new();
+        let mut full_replica_leaders_by_replicas = HashMap::new();
+        let entry_count = self.inner.entry_coordinates.len();
+        let mut entry_hashes = Vec::with_capacity(entry_count);
+        let mut entry_gids = Vec::with_capacity(entry_count);
+        let mut entry_requested_replicas = Vec::with_capacity(entry_count);
+        let mut current_leader_batches = Vec::with_capacity(entry_count);
+        let mut known_gid_peer_batches = Vec::with_capacity(entry_count);
+        let mut known_entry_peer_batches = Vec::with_capacity(entry_count);
+        let mut optimistic_by_gid_by_mode = Vec::with_capacity(pending_modes.len());
+
+        for (mode_index, gids) in optimistic_gids_by_mode.iter().enumerate() {
+            let peer_batches = &optimistic_peers_by_gid_by_mode[mode_index];
+            ensure_same_len(
+                gids.len(),
+                peer_batches.len(),
+                "resident repair optimistic gid peer",
+            )?;
+            optimistic_by_gid_by_mode.push(
+                gids.iter()
+                    .cloned()
+                    .zip(peer_batches.iter().cloned())
+                    .collect::<HashMap<_, _>>(),
+            );
+        }
+
+        let mut optimistic_peers_by_mode: Vec<Vec<Vec<String>>> = pending_modes
+            .iter()
+            .map(|_| Vec::with_capacity(entry_count))
+            .collect();
+
+        for (hash, entry) in &self.inner.entry_coordinates {
+            entry_hashes.push(hash.clone());
+            entry_gids.push(entry.gid.clone());
+            entry_requested_replicas.push(entry.requested_replicas);
+
+            let leaders = find_leaders_with_batch_caches(
+                &self.inner.range_planner,
+                &entry.coordinates,
+                entry.coordinates.len(),
+                &options,
+                &mut prepared_options_by_replicas,
+                &mut full_replica_leaders_by_replicas,
+                expand_peer_filter,
+                &self_hash,
+                include_self,
+                full_replica_fallback,
+                include_strict_full_replica,
+            );
+            current_leader_batches.push(leaders.into_iter().map(|leader| leader.hash).collect());
+            known_gid_peer_batches.push(
+                self.inner
+                    .gid_peers
+                    .get(&entry.gid)
+                    .map(index_set_to_vec)
+                    .unwrap_or_default(),
+            );
+            known_entry_peer_batches.push(
+                self.inner
+                    .entry_known_peers
+                    .get(hash)
+                    .map(index_set_to_vec)
+                    .unwrap_or_default(),
+            );
+            for (mode_index, optimistic_by_gid) in optimistic_by_gid_by_mode.iter().enumerate() {
+                optimistic_peers_by_mode[mode_index].push(
+                    optimistic_by_gid
+                        .get(&entry.gid)
+                        .cloned()
+                        .unwrap_or_default(),
+                );
+            }
+        }
+
+        plan_repair_dispatch_rows(RepairDispatchBatch {
+            entry_hashes,
+            entry_gids,
+            entry_requested_replicas,
+            current_leader_batches,
+            known_gid_peer_batches,
+            known_entry_peer_batches,
+            pending_modes,
+            pending_peers_by_mode,
+            optimistic_peers_by_mode,
             full_replica_repair_candidates: HashSet::<String>::from_iter(strings_from_array(
                 full_replica_repair_candidates,
             )?),

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -329,9 +329,9 @@ describe("native shared-log range planner", () => {
 
 	it("commits entry coordinates to resident shared-log state", async () => {
 		const state = await createSharedLogState("u32");
-		state.putEntryCoordinates("old-head", [1, 2]);
+		state.putEntryCoordinates("old-head", "old-gid", [1, 2]);
 
-		state.commitEntryCoordinates("new-head", [3, 4], ["old-head"], true);
+		state.commitEntryCoordinates("new-head", "new-gid", [3, 4], ["old-head"], true);
 
 		expect(state.getEntryCoordinates("new-head")).to.deep.equal([3, 4]);
 		expect(state.getEntryCoordinates("old-head")).to.equal(undefined);
@@ -339,8 +339,8 @@ describe("native shared-log range planner", () => {
 
 	it("lists resident entry coordinate hashes", async () => {
 		const state = await createSharedLogState("u32");
-		state.putEntryCoordinates("head-a", [1]);
-		state.putEntryCoordinates("head-b", [2]);
+		state.putEntryCoordinates("head-a", "gid-a", [1]);
+		state.putEntryCoordinates("head-b", "gid-b", [2]);
 		state.deleteEntryCoordinates("head-a");
 
 		expect(state.getEntryCoordinateHashes()).to.deep.equal(["head-b"]);
@@ -348,10 +348,10 @@ describe("native shared-log range planner", () => {
 
 	it("counts resident entry coordinates in owned ranges", async () => {
 		const state = await createSharedLogState("u32");
-		state.putEntryCoordinates("head-a", [5, 100]);
-		state.putEntryCoordinates("head-b", [25]);
-		state.putEntryCoordinates("head-c", [80]);
-		state.putEntryCoordinates("head-d", [95]);
+		state.putEntryCoordinates("head-a", "gid-a", [5, 100]);
+		state.putEntryCoordinates("head-b", "gid-b", [25]);
+		state.putEntryCoordinates("head-c", "gid-c", [80]);
+		state.putEntryCoordinates("head-d", "gid-d", [95]);
 
 		expect(
 			state.countEntryCoordinatesInRanges([
@@ -376,9 +376,9 @@ describe("native shared-log range planner", () => {
 
 	it("counts resident boundary-assigned entries on request", async () => {
 		const state = await createSharedLogState("u32");
-		state.putEntryCoordinates("inside", [5], false);
-		state.putEntryCoordinates("outside", [50], false);
-		state.putEntryCoordinates("boundary", [80], true);
+		state.putEntryCoordinates("inside", "gid-inside", [5], false);
+		state.putEntryCoordinates("outside", "gid-outside", [50], false);
+		state.putEntryCoordinates("boundary", "gid-boundary", [80], true);
 
 		const owned = [range({ id: "a", hash: "peer-a", start1: 0, end1: 10 })];
 		expect(state.countEntryCoordinatesInRanges(owned)).to.equal(1);
@@ -489,7 +489,7 @@ describe("native shared-log range planner", () => {
 		for (const item of ranges) {
 			state.put(item);
 		}
-		state.putEntryCoordinates("old-head", [1, 2]);
+		state.putEntryCoordinates("old-head", "old-gid", [1, 2]);
 
 		const leaderOptions = {
 			now: 1_000,
@@ -560,8 +560,8 @@ describe("native shared-log range planner", () => {
 			singleState.put(item);
 			batchState.put(item);
 		}
-		singleState.putEntryCoordinates("old-head", [1, 2]);
-		batchState.putEntryCoordinates("old-head", [1, 2]);
+		singleState.putEntryCoordinates("old-head", "old-gid", [1, 2]);
+		batchState.putEntryCoordinates("old-head", "old-gid", [1, 2]);
 
 		const leaderOptions = {
 			now: 1_000,
@@ -684,49 +684,64 @@ describe("native shared-log range planner", () => {
 		state.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));
 		state.addGidPeers("gid-known", ["peer-a"]);
 		state.markEntriesKnownByPeer(["entry-known"], "peer-a");
+		const entries = [
+			{
+				hash: "entry-known",
+				gid: "gid-fresh",
+				requestedReplicas: 1,
+				coordinates: [5],
+			},
+			{
+				hash: "entry-gid",
+				gid: "gid-known",
+				requestedReplicas: 1,
+				coordinates: [5],
+			},
+			{
+				hash: "entry-fresh",
+				gid: "gid-fresh",
+				requestedReplicas: 1,
+				coordinates: [5],
+			},
+		];
+		for (const entry of entries) {
+			state.putEntryCoordinates(
+				entry.hash,
+				entry.gid,
+				entry.coordinates,
+				false,
+				entry.requestedReplicas,
+			);
+		}
+		const input = {
+			pendingModes: ["join-warmup", "join-authoritative"],
+			pendingPeersByMode: new Map([
+				["join-warmup", ["peer-a"]],
+				["join-authoritative", ["peer-a"]],
+			]),
+			fullReplicaRepairCandidateCount: 1,
+			selfHash: "peer-self",
+		};
+		const expected = new Map([
+			["join-warmup", new Map([["peer-a", ["entry-fresh"]]])],
+			[
+				"join-authoritative",
+				new Map([["peer-a", ["entry-gid", "entry-fresh"]]]),
+			],
+		]);
 
 		expect(
 			state.planRepairDispatchForEntries(
 				{
-					entries: [
-						{
-							hash: "entry-known",
-							gid: "gid-fresh",
-							requestedReplicas: 1,
-							coordinates: [5],
-						},
-						{
-							hash: "entry-gid",
-							gid: "gid-known",
-							requestedReplicas: 1,
-							coordinates: [5],
-						},
-						{
-							hash: "entry-fresh",
-							gid: "gid-fresh",
-							requestedReplicas: 1,
-							coordinates: [5],
-						},
-					],
-					pendingModes: ["join-warmup", "join-authoritative"],
-					pendingPeersByMode: new Map([
-						["join-warmup", ["peer-a"]],
-						["join-authoritative", ["peer-a"]],
-					]),
-					fullReplicaRepairCandidateCount: 1,
-					selfHash: "peer-self",
+					entries,
+					...input,
 				},
 				{ now: 1_000 },
 			),
-		).to.deep.equal(
-			new Map([
-				["join-warmup", new Map([["peer-a", ["entry-fresh"]]])],
-				[
-					"join-authoritative",
-					new Map([["peer-a", ["entry-gid", "entry-fresh"]]]),
-				],
-			]),
-		);
+		).to.deep.equal(expected);
+		expect(
+			state.planRepairDispatchForResidentEntries(input, { now: 1_000 }),
+		).to.deep.equal(expected);
 	});
 
 	it("plans repair dispatch from native leader selection", async () => {

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -856,6 +856,7 @@ export class SharedLog<
 	private _entryCoordinatesIndex!: Index<EntryReplicated<R>>;
 	private _nativeRangePlanner?: SharedLogRangePlanner;
 	private _nativeSharedLogState?: SharedLogNativeState;
+	private _residentEntryCoordinatesByHash?: Map<string, EntryReplicated<R>>;
 	private coordinateToHash!: Cache<string>;
 	private recentlyRebalanced!: Cache<string>;
 
@@ -1923,6 +1924,11 @@ export class SharedLog<
 			return;
 		}
 		this._nativeSharedLogState?.deleteEntryCoordinatesBatch(values);
+		if (this._residentEntryCoordinatesByHash) {
+			for (const hash of values) {
+				this._residentEntryCoordinatesByHash.delete(hash);
+			}
+		}
 		const coordinateIndex = this.entryCoordinatesIndex as PutAndDeleteIndex<
 			EntryReplicated<R>
 		>;
@@ -3623,40 +3629,62 @@ export class SharedLog<
 					}
 				};
 
-				const iterator = this.entryCoordinatesIndex.iterate({});
-				try {
-					while (!this.closed && !iterator.done()) {
-						const entries = await iterator.next(REPAIR_SWEEP_ENTRY_BATCH_SIZE);
-						const entryReplicatedBatch = entries.map((entry) => entry.value);
-						const requestedReplicasBatch = entryReplicatedBatch.map((entry) =>
-							decodeReplicas(entry).getValue(this),
-						);
-						const repairDispatchPlan = await this.planRepairDispatchBatch({
-							entries: entryReplicatedBatch,
-							requestedReplicasBatch,
-							pendingModes,
-							pendingPeersByMode,
-							optimisticGidPeersByMode,
-							fullReplicaRepairCandidates,
-							fullReplicaRepairCandidateCount,
-							selfHash: this.node.identity.publicKey.hashcode(),
-						});
-						const entriesByHash = new Map(
-							entryReplicatedBatch.map((entry) => [entry.hash, entry]),
-						);
-						for (const [mode, targets] of repairDispatchPlan) {
-							for (const [target, hashes] of targets) {
-								for (const hash of hashes) {
-									const entry = entriesByHash.get(hash);
-									if (entry) {
-										queueEntryForTarget(mode, target, entry);
-									}
+				const residentEntriesByHash = this._residentEntryCoordinatesByHash;
+				if (this._nativeSharedLogState && residentEntriesByHash) {
+					const repairDispatchPlan = await this.planResidentRepairDispatchBatch({
+						pendingModes,
+						pendingPeersByMode,
+						optimisticGidPeersByMode,
+						fullReplicaRepairCandidates,
+						fullReplicaRepairCandidateCount,
+						selfHash: this.node.identity.publicKey.hashcode(),
+					});
+					for (const [mode, targets] of repairDispatchPlan) {
+						for (const [target, hashes] of targets) {
+							for (const hash of hashes) {
+								const entry = residentEntriesByHash.get(hash);
+								if (entry) {
+									queueEntryForTarget(mode, target, entry);
 								}
 							}
 						}
 					}
-				} finally {
-					await iterator.close();
+				} else {
+					const iterator = this.entryCoordinatesIndex.iterate({});
+					try {
+						while (!this.closed && !iterator.done()) {
+							const entries = await iterator.next(REPAIR_SWEEP_ENTRY_BATCH_SIZE);
+							const entryReplicatedBatch = entries.map((entry) => entry.value);
+							const requestedReplicasBatch = entryReplicatedBatch.map((entry) =>
+								decodeReplicas(entry).getValue(this),
+							);
+							const repairDispatchPlan = await this.planRepairDispatchBatch({
+								entries: entryReplicatedBatch,
+								requestedReplicasBatch,
+								pendingModes,
+								pendingPeersByMode,
+								optimisticGidPeersByMode,
+								fullReplicaRepairCandidates,
+								fullReplicaRepairCandidateCount,
+								selfHash: this.node.identity.publicKey.hashcode(),
+							});
+							const entriesByHash = new Map(
+								entryReplicatedBatch.map((entry) => [entry.hash, entry]),
+							);
+							for (const [mode, targets] of repairDispatchPlan) {
+								for (const [target, hashes] of targets) {
+									for (const hash of hashes) {
+										const entry = entriesByHash.get(hash);
+										if (entry) {
+											queueEntryForTarget(mode, target, entry);
+										}
+									}
+								}
+							}
+						}
+					} finally {
+						await iterator.close();
+					}
 				}
 
 				for (const [, optimisticGidPeersConsumed] of optimisticGidPeersConsumedByMode) {
@@ -4934,6 +4962,7 @@ export class SharedLog<
 		state: SharedLogNativeState,
 	): Promise<void> {
 		state.clearEntryCoordinates();
+		this._residentEntryCoordinatesByHash = new Map();
 		const iterator = this.entryCoordinatesIndex.iterate({});
 		try {
 			for (;;) {
@@ -4942,10 +4971,17 @@ export class SharedLog<
 					break;
 				}
 				for (const result of batch) {
+					const requestedReplicas = decodeReplicas(result.value).getValue(this);
 					state.putEntryCoordinates(
 						result.value.hash,
+						result.value.gid,
 						result.value.coordinates,
 						result.value.assignedToRangeBoundary,
+						requestedReplicas,
+					);
+					this._residentEntryCoordinatesByHash.set(
+						result.value.hash,
+						result.value,
 					);
 				}
 			}
@@ -4959,6 +4995,7 @@ export class SharedLog<
 	): Promise<void> {
 		this._nativeRangePlanner = undefined;
 		this._nativeSharedLogState = undefined;
+		this._residentEntryCoordinatesByHash = undefined;
 		if (options === false) {
 			return;
 		}
@@ -4976,6 +5013,7 @@ export class SharedLog<
 			this._nativeRangePlanner = planner;
 			this._nativeSharedLogState = state;
 		} catch (error) {
+			this._residentEntryCoordinatesByHash = undefined;
 			if (options?.optional === false) {
 				throw error;
 			}
@@ -5796,6 +5834,7 @@ export class SharedLog<
 		this._entryCoordinatesIndex = undefined as any;
 		this._nativeRangePlanner = undefined;
 		this._nativeSharedLogState = undefined;
+		this._residentEntryCoordinatesByHash = undefined;
 
 		this.cpuUsage?.stop?.();
 		/* this._totalParticipation = 0; */
@@ -7265,10 +7304,21 @@ export class SharedLog<
 		if (properties.commitNative !== false) {
 			this._nativeSharedLogState?.commitEntryCoordinates(
 				properties.entry.hash,
+				coordinateEntry.gid,
 				properties.coordinates,
 				properties.entry.meta.next,
 				assignedToRangeBoundary,
+				properties.replicas,
 			);
+		}
+		if (this._residentEntryCoordinatesByHash) {
+			this._residentEntryCoordinatesByHash.set(
+				properties.entry.hash,
+				coordinateEntry,
+			);
+			for (const nextHash of nextHashes) {
+				this._residentEntryCoordinatesByHash.delete(nextHash);
+			}
 		}
 
 		for (const coordinate of properties.coordinates) {
@@ -7285,6 +7335,7 @@ export class SharedLog<
 
 	private async deleteCoordinates(properties: { hash: string }) {
 		this._nativeSharedLogState?.deleteEntryCoordinates(properties.hash);
+		this._residentEntryCoordinatesByHash?.delete(properties.hash);
 		const coordinateIndex = this.entryCoordinatesIndex as PutAndDeleteIndex<
 			EntryReplicated<R>
 		>;
@@ -7819,6 +7870,56 @@ export class SharedLog<
 			leaders.push(await this._findLeaders(entry.coordinates, options));
 		}
 		return leaders;
+	}
+
+	private async planResidentRepairDispatchBatch(properties: {
+		pendingModes: Set<RepairDispatchMode>;
+		pendingPeersByMode: Map<RepairDispatchMode, Set<string>>;
+		optimisticGidPeersByMode: Map<RepairDispatchMode, Map<string, Set<string>>>;
+		fullReplicaRepairCandidates: Set<string>;
+		fullReplicaRepairCandidateCount: number;
+		selfHash: string;
+	}): Promise<Map<RepairDispatchMode, Map<string, string[]>>> {
+		const pendingPeersByMode = new Map<string, Iterable<string>>();
+		const optimisticPeersByMode = new Map<
+			string,
+			Map<string, Iterable<string>>
+		>();
+		for (const mode of properties.pendingModes) {
+			pendingPeersByMode.set(
+				mode,
+				properties.pendingPeersByMode.get(mode) ?? [],
+			);
+			const optimisticByGid = properties.optimisticGidPeersByMode.get(mode);
+			if (optimisticByGid) {
+				const optimisticEntries = new Map<string, Iterable<string>>();
+				for (const [gid, peers] of optimisticByGid) {
+					optimisticEntries.set(gid, peers);
+				}
+				optimisticPeersByMode.set(mode, optimisticEntries);
+			}
+		}
+
+		const context = await this.createLeaderSelectionContext({ roleAge: 0 });
+		const nativePlan =
+			this._nativeSharedLogState!.planRepairDispatchForResidentEntries(
+				{
+					pendingModes: properties.pendingModes,
+					pendingPeersByMode,
+					optimisticPeersByMode,
+					fullReplicaRepairCandidates: properties.fullReplicaRepairCandidates,
+					fullReplicaRepairCandidateCount:
+						properties.fullReplicaRepairCandidateCount,
+					selfHash: properties.selfHash,
+				},
+				this.createNativeLeaderOptions(context),
+			);
+
+		const plan = new Map<RepairDispatchMode, Map<string, string[]>>();
+		for (const [mode, targets] of nativePlan) {
+			plan.set(mode as RepairDispatchMode, targets);
+		}
+		return plan;
 	}
 
 	private async planRepairDispatchBatch(properties: {


### PR DESCRIPTION
## Summary
- store `gid` and `requestedReplicas` in resident native shared-log entry-coordinate state
- switch resident coordinates to deterministic `IndexMap` ordering
- add `planRepairDispatchForResidentEntries()` so repair sweep planning can scan native resident state directly
- maintain a resident hash-to-`EntryReplicated` map for existing transport/synchronizer code while native owns the planning input
- route `runRepairSweep()` through one native resident-plan call when native state is available, preserving the existing index-iteration fallback

## Benchmark
Local microbench with 20k resident `EntryReplicatedU64` coordinate rows, one authoritative target, and 20 repeated sweeps:
- previous native-assisted path (`entryCoordinatesIndex.iterate({})` + JS decode + native per-entry batch plan): 1912.18 ms total, about 10.46 sweeps/sec
- native resident repair plan: 203.37 ms total, about 98.34 sweeps/sec
- both planned the same 20k hashes

## Test Plan
- `cargo fmt --manifest-path packages/programs/data/shared-log/rust/Cargo.toml --check`
- `pnpm exec eslint packages/programs/data/shared-log/rust/src/index.ts packages/programs/data/shared-log/rust/test/index.spec.ts packages/programs/data/shared-log/src/index.ts`
- `pnpm --filter @peerbit/shared-log-rust run build`
- `pnpm --filter @peerbit/shared-log run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log/rust -- -t node --grep "plans repair dispatch from resident shared-log state"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log/rust -- -t node --grep "repair dispatch"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "leader are selected from 1 replicating peer"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "repairs redistributed entry when churn repair misses one hash on peer leave"` (pass for `u64-iblt`; `u32-simple` pending)
- `git diff --check`