### PR TITLE
Resolve sync coordinate symbols from native state

### DIFF
--- a/packages/programs/data/shared-log/benchmark/native-coordinate-symbol-lookup.ts
+++ b/packages/programs/data/shared-log/benchmark/native-coordinate-symbol-lookup.ts
@@ -1,0 +1,139 @@
+import { randomBytes } from "@peerbit/crypto";
+import { Compare, IntegerCompare, Or } from "@peerbit/indexer-interface";
+import { create as createIndex } from "@peerbit/indexer-sqlite3";
+import { LamportClock, Meta } from "@peerbit/log";
+import { createSharedLogState } from "@peerbit/shared-log-rust";
+import { Bench } from "tinybench";
+import { EntryReplicatedU64 } from "../src/ranges.js";
+
+// Run with:
+//   cd packages/programs/data/shared-log
+//   COORD_LOOKUP_ENTRIES=20000 COORD_LOOKUP_SYMBOLS=5000 COORD_LOOKUP_ITERATIONS=30 \
+//     BENCH_JSON=1 node --loader ts-node/esm ./benchmark/native-coordinate-symbol-lookup.ts
+
+const parsePositiveInt = (value: string | undefined, fallback: number) => {
+	const parsed = Number.parseInt(value ?? "", 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const entryCount = parsePositiveInt(process.env.COORD_LOOKUP_ENTRIES, 20_000);
+const symbolCount = parsePositiveInt(process.env.COORD_LOOKUP_SYMBOLS, 5_000);
+const warmupIterations = parsePositiveInt(process.env.COORD_LOOKUP_WARMUP, 5);
+const iterations = parsePositiveInt(process.env.COORD_LOOKUP_ITERATIONS, 30);
+const queryBatchSize = parsePositiveInt(process.env.COORD_LOOKUP_BATCH, 128);
+
+const indices = await createIndex();
+const entryIndex = await indices.init({ schema: EntryReplicatedU64 });
+await indices.start();
+const nativeState = await createSharedLogState("u64");
+
+const meta = new Meta({
+	clock: new LamportClock({ id: randomBytes(32) }),
+	gid: "entry-gid",
+	next: [],
+	type: 0,
+	data: undefined,
+});
+
+for (let i = 0; i < entryCount; i++) {
+	const hashNumber = BigInt(i + 1);
+	const entry = new EntryReplicatedU64({
+		hash: `entry-${i}`,
+		hashNumber,
+		coordinates: [hashNumber],
+		meta,
+		assignedToRangeBoundary: false,
+	});
+	await entryIndex.put(entry);
+	nativeState.putEntryCoordinates(
+		entry.hash,
+		entry.gid,
+		entry.coordinates,
+		false,
+		1,
+		entry.hashNumber,
+	);
+}
+
+const symbols = Array.from(
+	{ length: symbolCount },
+	(_, i) => BigInt(((i * 17) % entryCount) + 1),
+);
+
+const lookupViaIndex = async () => {
+	let found = 0;
+	for (let i = 0; i < symbols.length; i += queryBatchSize) {
+		const queries = symbols.slice(i, i + queryBatchSize).map(
+			(value) =>
+				new IntegerCompare({
+					key: "hashNumber",
+					compare: Compare.Equal,
+					value,
+				}),
+		);
+		const entries = await entryIndex
+			.iterate(
+				{ query: queries.length > 1 ? new Or(queries) : queries },
+				{ shape: { hash: true, hashNumber: true } },
+			)
+			.all();
+		found += entries.length;
+	}
+	if (found !== symbols.length) {
+		throw new Error(`Expected ${symbols.length} index hits, got ${found}`);
+	}
+};
+
+const lookupViaNativeState = () => {
+	const result = nativeState.getEntryHashesForHashNumbers(symbols);
+	let found = 0;
+	for (const hashes of result.values()) {
+		found += hashes.length;
+	}
+	if (found !== symbols.length) {
+		throw new Error(`Expected ${symbols.length} native hits, got ${found}`);
+	}
+};
+
+const suite = new Bench({
+	name: "native-coordinate-symbol-lookup",
+	warmupIterations,
+	iterations,
+});
+
+suite.add("generic index hashNumber lookup", lookupViaIndex);
+suite.add("native resident hashNumber lookup", lookupViaNativeState);
+
+try {
+	await suite.run();
+	if (process.env.BENCH_JSON === "1") {
+		const tasks = suite.tasks.map((task) => ({
+			name: task.name,
+			hz: task.result?.hz ?? null,
+			mean_ms: task.result?.mean ?? null,
+			rme: task.result?.rme ?? null,
+			samples: task.result?.samples?.length ?? null,
+		}));
+		process.stdout.write(
+			JSON.stringify(
+				{
+					name: suite.name,
+					tasks,
+					meta: {
+						entryCount,
+						symbolCount,
+						queryBatchSize,
+						warmupIterations,
+						iterations,
+					},
+				},
+				null,
+				2,
+			),
+		);
+	} else {
+		console.table(suite.table());
+	}
+} finally {
+	await indices.stop();
+}

--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -77,6 +77,7 @@ export type AppendEntryPlan = EntryAssignmentPlan & {
 export type AppendEntryBatchInput = {
 	entryHash: string;
 	gid: string;
+	hashNumber?: bigint | number | string;
 	nextHashes?: Iterable<string>;
 	replicas: number;
 };
@@ -280,6 +281,7 @@ type NativeSharedLogStateHandle = {
 	put_entry_coordinates: (
 		hash: string,
 		gid: string,
+		hashNumber: string,
 		coordinates: string[],
 		assignedToRangeBoundary: boolean,
 		requestedReplicas: number,
@@ -287,9 +289,11 @@ type NativeSharedLogStateHandle = {
 	delete_entry_coordinates: (hash: string) => boolean;
 	get_entry_coordinates: (hash: string) => unknown[] | undefined;
 	entry_coordinate_hashes: () => string[];
+	entry_hashes_for_hash_numbers: (hashNumbers: string[]) => unknown[];
 	commit_entry_coordinates: (
 		hash: string,
 		gid: string,
+		hashNumber: string,
 		coordinates: string[],
 		nextHashes: string[],
 		assignedToRangeBoundary: boolean,
@@ -328,6 +332,7 @@ type NativeSharedLogStateHandle = {
 	plan_local_append_for_gid: (
 		entryHash: string,
 		gid: string,
+		hashNumber: string,
 		nextHashes: string[],
 		replicas: number,
 		roleAgeMs: number,
@@ -358,6 +363,7 @@ type NativeSharedLogStateHandle = {
 	plan_append_for_gid: (
 		entryHash: string,
 		gid: string,
+		hashNumber: string,
 		nextHashes: string[],
 		replicas: number,
 		fullReplicaCandidates: string[],
@@ -385,6 +391,7 @@ type NativeSharedLogStateHandle = {
 	plan_append_for_gids_batch: (
 		entryHashes: string[],
 		gids: string[],
+		hashNumbers: string[],
 		nextHashBatches: string[][],
 		replicaCounts: number[],
 		fullReplicaCandidates: string[],
@@ -885,11 +892,13 @@ export class SharedLogNativeState {
 		coordinates: Iterable<bigint | number | string>,
 		assignedToRangeBoundary = false,
 		requestedReplicas?: number,
+		hashNumber: bigint | number | string = 0,
 	): void {
 		const coordinateRows = [...coordinates].map(asIntegerString);
 		this.native.put_entry_coordinates(
 			hash,
 			gid,
+			asIntegerString(hashNumber),
 			coordinateRows,
 			assignedToRangeBoundary,
 			requestedReplicas ?? coordinateRows.length,
@@ -909,6 +918,20 @@ export class SharedLogNativeState {
 		return this.native.entry_coordinate_hashes();
 	}
 
+	getEntryHashesForHashNumbers(
+		hashNumbers: Iterable<bigint | number | string>,
+	): Map<bigint, string[]> {
+		const out = new Map<bigint, string[]>();
+		const rows = this.native.entry_hashes_for_hash_numbers(
+			[...hashNumbers].map(asIntegerString),
+		);
+		for (const row of rows) {
+			const [hashNumber, hashes] = row as [string, string[]];
+			out.set(BigInt(hashNumber), hashes);
+		}
+		return out;
+	}
+
 	commitEntryCoordinates(
 		hash: string,
 		gid: string,
@@ -916,11 +939,13 @@ export class SharedLogNativeState {
 		nextHashes: Iterable<string>,
 		assignedToRangeBoundary = false,
 		requestedReplicas?: number,
+		hashNumber: bigint | number | string = 0,
 	): void {
 		const coordinateRows = [...coordinates].map(asIntegerString);
 		this.native.commit_entry_coordinates(
 			hash,
 			gid,
+			asIntegerString(hashNumber),
 			coordinateRows,
 			[...nextHashes],
 			assignedToRangeBoundary,
@@ -1039,6 +1064,7 @@ export class SharedLogNativeState {
 		input: {
 			entryHash: string;
 			gid: string;
+			hashNumber?: bigint | number | string;
 			nextHashes?: Iterable<string>;
 			replicas: number;
 			selfHash: string;
@@ -1049,6 +1075,7 @@ export class SharedLogNativeState {
 			this.native.plan_local_append_for_gid(
 				input.entryHash,
 				input.gid,
+				asIntegerString(input.hashNumber ?? 0),
 				input.nextHashes ? [...input.nextHashes] : [],
 				input.replicas,
 				...findLeaderArguments({
@@ -1108,6 +1135,7 @@ export class SharedLogNativeState {
 		input: {
 			entryHash: string;
 			gid: string;
+			hashNumber?: bigint | number | string;
 			nextHashes?: Iterable<string>;
 			replicas: number;
 			fullReplicaCandidates?: Iterable<string>;
@@ -1124,6 +1152,7 @@ export class SharedLogNativeState {
 			this.native.plan_append_for_gid(
 				input.entryHash,
 				input.gid,
+				asIntegerString(input.hashNumber ?? 0),
 				input.nextHashes ? [...input.nextHashes] : [],
 				input.replicas,
 				input.fullReplicaCandidates ? [...input.fullReplicaCandidates] : [],
@@ -1164,6 +1193,7 @@ export class SharedLogNativeState {
 		const rows = this.native.plan_append_for_gids_batch(
 			entries.map((entry) => entry.entryHash),
 			entries.map((entry) => entry.gid),
+			entries.map((entry) => asIntegerString(entry.hashNumber ?? 0)),
 			entries.map((entry) => (entry.nextHashes ? [...entry.nextHashes] : [])),
 			entries.map((entry) => entry.replicas),
 			input.fullReplicaCandidates ? [...input.fullReplicaCandidates] : [],

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -1101,6 +1101,7 @@ pub struct NativeRangePlanner {
 pub struct SharedLogStateInner {
     range_planner: RangePlanner,
     entry_coordinates: IndexMap<String, EntryCoordinateState>,
+    entry_hashes_by_hash_number: HashMap<u64, IndexSet<String>>,
     gid_peers: HashMap<String, IndexSet<String>>,
     entry_known_peers: HashMap<String, IndexSet<String>>,
 }
@@ -1108,6 +1109,7 @@ pub struct SharedLogStateInner {
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct EntryCoordinateState {
     gid: String,
+    hash_number: u64,
     coordinates: Vec<u64>,
     assigned_to_range_boundary: bool,
     requested_replicas: usize,
@@ -1118,6 +1120,7 @@ impl SharedLogStateInner {
         Self {
             range_planner: RangePlanner::new(&resolution),
             entry_coordinates: IndexMap::new(),
+            entry_hashes_by_hash_number: HashMap::new(),
             gid_peers: HashMap::new(),
             entry_known_peers: HashMap::new(),
         }
@@ -1126,6 +1129,7 @@ impl SharedLogStateInner {
     fn clear_all(&mut self) {
         self.range_planner.clear();
         self.entry_coordinates.clear();
+        self.entry_hashes_by_hash_number.clear();
         self.gid_peers.clear();
         self.entry_known_peers.clear();
     }
@@ -1136,6 +1140,28 @@ impl SharedLogStateInner {
 
     fn delete_range(&mut self, id: &str) -> bool {
         self.range_planner.delete(id)
+    }
+
+    fn put_entry_coordinate_state(&mut self, hash: String, entry: EntryCoordinateState) {
+        self.delete_entry_coordinate_state(&hash);
+        self.entry_hashes_by_hash_number
+            .entry(entry.hash_number)
+            .or_default()
+            .insert(hash.clone());
+        self.entry_coordinates.insert(hash, entry);
+    }
+
+    fn delete_entry_coordinate_state(&mut self, hash: &str) -> bool {
+        let Some(entry) = self.entry_coordinates.shift_remove(hash) else {
+            return false;
+        };
+        if let Some(hashes) = self.entry_hashes_by_hash_number.get_mut(&entry.hash_number) {
+            hashes.shift_remove(hash);
+            if hashes.is_empty() {
+                self.entry_hashes_by_hash_number.remove(&entry.hash_number);
+            }
+        }
+        true
     }
 }
 
@@ -1635,24 +1661,24 @@ impl NativeSharedLogState {
         &mut self,
         hash: String,
         gid: String,
+        hash_number: String,
         coordinates: Array,
         assigned_to_range_boundary: bool,
         requested_replicas: usize,
     ) -> Result<(), JsValue> {
-        self.inner.entry_coordinates.insert(
-            hash,
-            EntryCoordinateState {
-                gid,
-                coordinates: cursor_values_from_array(coordinates)?,
-                assigned_to_range_boundary,
-                requested_replicas,
-            },
-        );
+        let entry = EntryCoordinateState {
+            gid,
+            hash_number: parse_u64(&hash_number)?,
+            coordinates: cursor_values_from_array(coordinates)?,
+            assigned_to_range_boundary,
+            requested_replicas,
+        };
+        self.inner.put_entry_coordinate_state(hash, entry);
         Ok(())
     }
 
     pub fn delete_entry_coordinates(&mut self, hash: &str) -> bool {
-        self.inner.entry_coordinates.shift_remove(hash).is_some()
+        self.inner.delete_entry_coordinate_state(hash)
     }
 
     pub fn get_entry_coordinates(&self, hash: &str) -> JsValue {
@@ -1673,10 +1699,25 @@ impl NativeSharedLogState {
         strings_to_array(self.inner.entry_coordinates.keys().cloned().collect())
     }
 
+    pub fn entry_hashes_for_hash_numbers(&self, hash_numbers: Array) -> Result<Array, JsValue> {
+        let hash_numbers = cursor_values_from_array(hash_numbers)?;
+        let out = Array::new();
+        for hash_number in hash_numbers {
+            if let Some(hashes) = self.inner.entry_hashes_by_hash_number.get(&hash_number) {
+                let row = Array::new();
+                row.push(&JsValue::from_str(&hash_number.to_string()));
+                row.push(&strings_to_array(hashes.iter().cloned().collect()));
+                out.push(&row);
+            }
+        }
+        Ok(out)
+    }
+
     pub fn commit_entry_coordinates(
         &mut self,
         hash: String,
         gid: String,
+        hash_number: String,
         coordinates: Array,
         next_hashes: Array,
         assigned_to_range_boundary: bool,
@@ -1684,17 +1725,16 @@ impl NativeSharedLogState {
     ) -> Result<(), JsValue> {
         let coordinates = cursor_values_from_array(coordinates)?;
         let next_hashes = strings_from_array(next_hashes)?;
-        self.inner.entry_coordinates.insert(
-            hash,
-            EntryCoordinateState {
-                gid,
-                coordinates,
-                assigned_to_range_boundary,
-                requested_replicas,
-            },
-        );
+        let entry = EntryCoordinateState {
+            gid,
+            hash_number: parse_u64(&hash_number)?,
+            coordinates,
+            assigned_to_range_boundary,
+            requested_replicas,
+        };
+        self.inner.put_entry_coordinate_state(hash, entry);
         for next_hash in next_hashes {
-            self.inner.entry_coordinates.shift_remove(&next_hash);
+            self.inner.delete_entry_coordinate_state(&next_hash);
         }
         Ok(())
     }
@@ -1740,13 +1780,14 @@ impl NativeSharedLogState {
 
     pub fn delete_entry_coordinates_batch(&mut self, hashes: Array) -> Result<(), JsValue> {
         for hash in strings_from_array(hashes)? {
-            self.inner.entry_coordinates.shift_remove(&hash);
+            self.inner.delete_entry_coordinate_state(&hash);
         }
         Ok(())
     }
 
     pub fn clear_entry_coordinates(&mut self) {
         self.inner.entry_coordinates.clear();
+        self.inner.entry_hashes_by_hash_number.clear();
     }
 
     pub fn add_gid_peers(
@@ -1937,6 +1978,7 @@ impl NativeSharedLogState {
         &mut self,
         entry_hash: String,
         gid: String,
+        entry_hash_number: String,
         next_hashes: Array,
         replicas: usize,
         role_age_ms: f64,
@@ -1948,6 +1990,7 @@ impl NativeSharedLogState {
         full_replica_fallback: bool,
         include_strict_full_replica: bool,
     ) -> Result<Array, JsValue> {
+        let entry_hash_number = parse_u64(&entry_hash_number)?;
         let next_hashes = strings_from_array(next_hashes)?;
         let coordinates = self.inner.range_planner.get_gid_coordinates(&gid, replicas);
         let options = find_leader_options(role_age_ms, &now, peer_filter)?;
@@ -1964,17 +2007,18 @@ impl NativeSharedLogState {
         let is_leader = leaders.iter().any(|leader| leader.hash == self_hash);
         let assigned_to_range_boundary = should_assign_to_range_boundary(&leaders, replicas);
 
-        self.inner.entry_coordinates.insert(
+        self.inner.put_entry_coordinate_state(
             entry_hash,
             EntryCoordinateState {
                 gid,
+                hash_number: entry_hash_number,
                 coordinates: coordinates.clone(),
                 assigned_to_range_boundary,
                 requested_replicas: replicas,
             },
         );
         for next_hash in next_hashes {
-            self.inner.entry_coordinates.shift_remove(&next_hash);
+            self.inner.delete_entry_coordinate_state(&next_hash);
         }
 
         let out = Array::new();
@@ -2032,6 +2076,7 @@ impl NativeSharedLogState {
         &mut self,
         entry_hash: String,
         gid: String,
+        entry_hash_number: String,
         next_hashes: Array,
         replicas: usize,
         full_replica_candidates: Array,
@@ -2050,6 +2095,7 @@ impl NativeSharedLogState {
         full_replica_fallback: bool,
         include_strict_full_replica: bool,
     ) -> Result<Array, JsValue> {
+        let entry_hash_number = parse_u64(&entry_hash_number)?;
         let next_hashes = strings_from_array(next_hashes)?;
         let full_replica_candidates = strings_from_array(full_replica_candidates)?;
         let fallback_recipients = strings_from_array(fallback_recipients)?;
@@ -2069,17 +2115,18 @@ impl NativeSharedLogState {
         let is_leader = leaders.iter().any(|leader| leader.hash == self_hash);
         let assigned_to_range_boundary = should_assign_to_range_boundary(&leaders, replicas);
 
-        self.inner.entry_coordinates.insert(
+        self.inner.put_entry_coordinate_state(
             entry_hash,
             EntryCoordinateState {
                 gid,
+                hash_number: entry_hash_number,
                 coordinates: coordinates.clone(),
                 assigned_to_range_boundary,
                 requested_replicas: replicas,
             },
         );
         for next_hash in next_hashes {
-            self.inner.entry_coordinates.shift_remove(&next_hash);
+            self.inner.delete_entry_coordinate_state(&next_hash);
         }
 
         let delivery_leaders = expand_append_leaders(leaders, full_replica_candidates, replicas);
@@ -2111,6 +2158,7 @@ impl NativeSharedLogState {
         &mut self,
         entry_hashes: Array,
         gids: Array,
+        entry_hash_numbers: Array,
         next_hash_batches: Array,
         replica_counts: Array,
         full_replica_candidates: Array,
@@ -2131,10 +2179,16 @@ impl NativeSharedLogState {
     ) -> Result<Array, JsValue> {
         let entry_hashes = strings_from_array(entry_hashes)?;
         let gids = strings_from_array(gids)?;
+        let entry_hash_numbers = cursor_values_from_array(entry_hash_numbers)?;
         let next_hash_batches =
             string_batches_from_array(next_hash_batches, "append next hash batch array")?;
         let replica_counts = usize_from_array(replica_counts)?;
         ensure_same_len(entry_hashes.len(), gids.len(), "append entry gid")?;
+        ensure_same_len(
+            entry_hashes.len(),
+            entry_hash_numbers.len(),
+            "append entry hash number",
+        )?;
         ensure_same_len(
             entry_hashes.len(),
             next_hash_batches.len(),
@@ -2150,9 +2204,10 @@ impl NativeSharedLogState {
         let mut full_replica_leaders_by_replicas = HashMap::new();
         let out = Array::new();
 
-        for (((entry_hash, gid), next_hashes), replicas) in entry_hashes
+        for ((((entry_hash, gid), entry_hash_number), next_hashes), replicas) in entry_hashes
             .into_iter()
             .zip(gids)
+            .zip(entry_hash_numbers)
             .zip(next_hash_batches)
             .zip(replica_counts)
         {
@@ -2173,17 +2228,18 @@ impl NativeSharedLogState {
             let is_leader = leaders.iter().any(|leader| leader.hash == self_hash);
             let assigned_to_range_boundary = should_assign_to_range_boundary(&leaders, replicas);
 
-            self.inner.entry_coordinates.insert(
+            self.inner.put_entry_coordinate_state(
                 entry_hash,
                 EntryCoordinateState {
                     gid,
+                    hash_number: entry_hash_number,
                     coordinates: coordinates.clone(),
                     assigned_to_range_boundary,
                     requested_replicas: replicas,
                 },
             );
             for next_hash in next_hashes {
-                self.inner.entry_coordinates.shift_remove(&next_hash);
+                self.inner.delete_entry_coordinate_state(&next_hash);
             }
 
             let delivery_leaders =

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -346,6 +346,26 @@ describe("native shared-log range planner", () => {
 		expect(state.getEntryCoordinateHashes()).to.deep.equal(["head-b"]);
 	});
 
+	it("looks up resident entry hashes by hash number", async () => {
+		const state = await createSharedLogState("u32");
+		state.putEntryCoordinates("head-a", "gid-a", [1], false, 1, 42);
+		state.putEntryCoordinates("head-b", "gid-b", [2], false, 1, 42);
+		state.putEntryCoordinates("head-c", "gid-c", [3], false, 1, 7);
+
+		expect([...state.getEntryHashesForHashNumbers([42, 7, 9])]).to.deep.equal([
+			[42n, ["head-a", "head-b"]],
+			[7n, ["head-c"]],
+		]);
+
+		state.deleteEntryCoordinates("head-a");
+		state.commitEntryCoordinates("head-d", "gid-d", [4], ["head-c"], false, 1, 7);
+
+		expect([...state.getEntryHashesForHashNumbers([42, 7])]).to.deep.equal([
+			[42n, ["head-b"]],
+			[7n, ["head-d"]],
+		]);
+	});
+
 	it("counts resident entry coordinates in owned ranges", async () => {
 		const state = await createSharedLogState("u32");
 		state.putEntryCoordinates("head-a", "gid-a", [5, 100]);

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2974,10 +2974,7 @@ export class SharedLog<
 			properties.leaders,
 			properties.replicas,
 		);
-		const hashNumber = this.indexableDomain.numbers.bytesToNumber(
-			(properties.entry as EntryWithMetaBytes).getHashDigestBytes?.() ??
-				cidifyString(properties.entry.hash).multihash.digest,
-		);
+		const hashNumber = this.getEntryHashNumber(properties.entry);
 		return new this.indexableDomain.constructorEntry({
 			assignedToRangeBoundary,
 			coordinates: properties.coordinates,
@@ -4243,6 +4240,7 @@ export class SharedLog<
 			{
 				entryHash: entry.hash,
 				gid: entry.meta.gid,
+				hashNumber: this.getEntryHashNumber(entry),
 				nextHashes: entry.meta.next,
 				replicas,
 				fullReplicaCandidates: fullReplicaDeliveryCandidates,
@@ -4276,6 +4274,7 @@ export class SharedLog<
 			{
 				entryHash: entry.hash,
 				gid: entry.meta.gid,
+				hashNumber: this.getEntryHashNumber(entry),
 				nextHashes: entry.meta.next,
 				replicas,
 				selfHash: context.selfHash,
@@ -4319,6 +4318,7 @@ export class SharedLog<
 				entries: entries.map((entry) => ({
 					entryHash: entry.hash,
 					gid: entry.meta.gid,
+					hashNumber: this.getEntryHashNumber(entry),
 					nextHashes: entry.meta.next,
 					replicas,
 				})),
@@ -4807,6 +4807,9 @@ export class SharedLog<
 			},
 			indexer: logIndex,
 		});
+		const resolveHashesForSymbols = (symbols: bigint[]) =>
+			this._nativeSharedLogState?.getEntryHashesForHashNumbers(symbols);
+
 		if (options?.syncronizer) {
 			this.syncronizer = new options.syncronizer({
 				numbers: this.indexableDomain.numbers,
@@ -4815,6 +4818,7 @@ export class SharedLog<
 				rangeIndex: this._replicationRangeIndex,
 				rpc: this.rpc,
 				coordinateToHash: this.coordinateToHash,
+				resolveHashesForSymbols,
 				sync: options?.sync,
 			});
 		} else {
@@ -4827,6 +4831,7 @@ export class SharedLog<
 					rpc: this.rpc,
 					entryIndex: this.entryCoordinatesIndex,
 					coordinateToHash: this.coordinateToHash,
+					resolveHashesForSymbols,
 					sync: options?.sync,
 				});
 			} else {
@@ -4843,6 +4848,7 @@ export class SharedLog<
 					rangeIndex: this._replicationRangeIndex,
 					rpc: this.rpc,
 					coordinateToHash: this.coordinateToHash,
+					resolveHashesForSymbols,
 					sync: options?.sync,
 				}) as Syncronizer<R>;
 			}
@@ -4978,6 +4984,7 @@ export class SharedLog<
 						result.value.coordinates,
 						result.value.assignedToRangeBoundary,
 						requestedReplicas,
+						result.value.hashNumber,
 					);
 					this._residentEntryCoordinatesByHash.set(
 						result.value.hash,
@@ -7247,10 +7254,7 @@ export class SharedLog<
 			return false; // no change
 		}
 
-		const hashNumber = this.indexableDomain.numbers.bytesToNumber(
-			(properties.entry as EntryWithMetaBytes).getHashDigestBytes?.() ??
-				cidifyString(properties.entry.hash).multihash.digest,
-		);
+		const hashNumber = this.getEntryHashNumber(properties.entry);
 
 		const metaBytes = (properties.entry as EntryWithMetaBytes).getMetaBytes?.();
 		const coordinateEntry = new this.indexableDomain.constructorEntry({
@@ -7309,6 +7313,7 @@ export class SharedLog<
 				properties.entry.meta.next,
 				assignedToRangeBoundary,
 				properties.replicas,
+				coordinateEntry.hashNumber,
 			);
 		}
 		if (this._residentEntryCoordinatesByHash) {
@@ -7446,6 +7451,18 @@ export class SharedLog<
 		entry: ShallowOrFullEntry<any> | EntryReplicated<R>,
 	): entry is ShallowOrFullEntry<any> | EntryReplicated<R> {
 		return this.domain.type === "hash" && typeof entry.meta.gid === "string";
+	}
+
+	private getEntryHashNumber(
+		entry: Entry<T> | ShallowOrFullEntry<any> | EntryReplicated<R>,
+	): NumberFromType<R> {
+		if ("hashNumber" in entry && entry.hashNumber != null) {
+			return entry.hashNumber as NumberFromType<R>;
+		}
+		return this.indexableDomain.numbers.bytesToNumber(
+			(entry as EntryWithMetaBytes).getHashDigestBytes?.() ??
+				cidifyString(entry.hash).multihash.digest,
+		);
 	}
 
 	private async applyLeaderSelection(

--- a/packages/programs/data/shared-log/src/sync/index.ts
+++ b/packages/programs/data/shared-log/src/sync/index.ts
@@ -59,6 +59,13 @@ export type SyncOptions<R extends "u32" | "u64"> = {
 	profile?: SyncProfileFn;
 };
 
+export type HashSymbolResolver = (
+	symbols: bigint[],
+) =>
+	| ReadonlyMap<bigint, Iterable<string>>
+	| undefined
+	| Promise<ReadonlyMap<bigint, Iterable<string>> | undefined>;
+
 export type SynchronizerComponents<R extends "u32" | "u64"> = {
 	rpc: RPC<TransportMessage, TransportMessage>;
 	rangeIndex: Index<ReplicationRangeIndexable<R>, any>;
@@ -66,6 +73,7 @@ export type SynchronizerComponents<R extends "u32" | "u64"> = {
 	log: Log<any>;
 	coordinateToHash: Cache<string>;
 	numbers: Numbers<R>;
+	resolveHashesForSymbols?: HashSymbolResolver;
 	sync?: SyncOptions<R>;
 };
 export type SynchronizerConstructor<R extends "u32" | "u64"> = new (

--- a/packages/programs/data/shared-log/src/sync/simple.ts
+++ b/packages/programs/data/shared-log/src/sync/simple.ts
@@ -20,6 +20,7 @@ import type {
 	RepairSession,
 	RepairSessionMode,
 	RepairSessionResult,
+	HashSymbolResolver,
 	SyncOptions,
 	SyncableKey,
 	Syncronizer,
@@ -74,10 +75,20 @@ const getHashesFromSymbols = async (
 	symbols: bigint[],
 	entryIndex: Index<EntryReplicated<any>, any>,
 	coordinateToHash: Cache<string>,
+	resolveHashesForSymbols?: HashSymbolResolver,
 ) => {
 	let queries: IntegerCompare[] = [];
 	let batchSize = 128; // TODO arg
 	let results = new Set<string>();
+	let missingSymbols: bigint[] = [];
+	const addMissingUnlessCached = (symbol: bigint) => {
+		const fromCache = coordinateToHash.get(symbol);
+		if (fromCache) {
+			results.add(fromCache);
+			return;
+		}
+		missingSymbols.push(symbol);
+	};
 	const handleBatch = async (end = false) => {
 		if (queries.length >= batchSize || (end && queries.length > 0)) {
 			const entries = await entryIndex
@@ -94,16 +105,45 @@ const getHashesFromSymbols = async (
 			}
 		}
 	};
-	for (let i = 0; i < symbols.length; i++) {
-		const fromCache = coordinateToHash.get(symbols[i]);
-		if (fromCache) {
-			results.add(fromCache);
-			continue;
+
+	if (resolveHashesForSymbols) {
+		const resolved = await resolveHashesForSymbols(symbols);
+		if (resolved) {
+			for (const symbol of symbols) {
+				const hashes = resolved.get(symbol);
+				if (!hashes) {
+					addMissingUnlessCached(symbol);
+					continue;
+				}
+				let singleHash: string | undefined;
+				let count = 0;
+				for (const hash of hashes) {
+					results.add(hash);
+					singleHash = hash;
+					count += 1;
+				}
+				if (count === 0) {
+					addMissingUnlessCached(symbol);
+				} else if (count === 1) {
+					coordinateToHash.add(symbol, singleHash!);
+				}
+			}
+		} else {
+			for (const symbol of symbols) {
+				addMissingUnlessCached(symbol);
+			}
 		}
+	} else {
+		for (const symbol of symbols) {
+			addMissingUnlessCached(symbol);
+		}
+	}
+
+	for (const symbol of missingSymbols) {
 		const matchQuery = new IntegerCompare({
 			key: "hashNumber",
 			compare: Compare.Equal,
-			value: symbols[i],
+			value: symbol,
 		});
 
 		queries.push(matchQuery);
@@ -170,6 +210,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 	log: Log<any>;
 	entryIndex: Index<EntryReplicated<R>, any>;
 	coordinateToHash: Cache<string>;
+	private resolveHashesForSymbols?: HashSymbolResolver;
 	private syncOptions?: SyncOptions<R>;
 	private repairSessionCounter: number;
 	private repairSessions: Map<string, RepairSessionState>;
@@ -184,6 +225,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		entryIndex: Index<EntryReplicated<R>, any>;
 		log: Log<any>;
 		coordinateToHash: Cache<string>;
+		resolveHashesForSymbols?: HashSymbolResolver;
 		sync?: SyncOptions<R>;
 	}) {
 		this.syncInFlightQueue = new Map();
@@ -193,6 +235,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		this.log = properties.log;
 		this.entryIndex = properties.entryIndex;
 		this.coordinateToHash = properties.coordinateToHash;
+		this.resolveHashesForSymbols = properties.resolveHashesForSymbols;
 		this.syncOptions = properties.sync;
 		this.repairSessionCounter = 0;
 		this.repairSessions = new Map();
@@ -601,6 +644,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				msg.hashNumbers,
 				this.entryIndex,
 				this.coordinateToHash,
+				this.resolveHashesForSymbols,
 			);
 			if (profile) {
 				emitSyncProfileDuration(profile, lookupStartedAt, {

--- a/packages/programs/data/shared-log/test/sync-chunking.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-chunking.spec.ts
@@ -74,6 +74,40 @@ describe("sync-chunking", () => {
 		expect(sentCoordinates.map((x) => x.length)).to.deep.equal([2, 2, 1]);
 	});
 
+	it("uses native coordinate symbol resolver before index lookup", async () => {
+		const send = sinon.stub().resolves();
+		const iterate = sinon.stub().throws(new Error("entry index should not be used"));
+		const rpc = { send } as any;
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc,
+			entryIndex: { iterate } as any,
+			log: {
+				get: async (hash: string) => ({
+					hash,
+					size: 1,
+					meta: { gid: `gid-${hash}` },
+				}),
+				entryIndex: { getUniqueReferenceGids: () => [] },
+			} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			resolveHashesForSymbols: (symbols) => {
+				expect(symbols).to.deep.equal([42n]);
+				return new Map([[42n, ["head-a"]]]);
+			},
+		});
+
+		await sync.onMessage(
+			new RequestMaybeSyncCoordinate({ hashNumbers: [42n] }),
+			{ from: "peer-a" } as any,
+		);
+
+		expect(iterate.called).to.equal(false);
+		expect(send.callCount).to.equal(1);
+		expect(send.firstCall.args[0].heads.map((x: any) => x.entry.hash)).to.deep.equal([
+			"head-a",
+		]);
+	});
+
 	it("splits mixed hash and coordinate maybe-sync batches by type", async () => {
 		const send = sinon.stub().resolves();
 		const rpc = { send } as any;


### PR DESCRIPTION
## Summary
- maintain a resident native hashNumber -> entry hashes map alongside shared-log entry coordinates
- pass real entry hash numbers through native append/commit planning so resident state can answer coordinate-symbol lookups
- let simple/rateless sync resolve RequestMaybeSyncCoordinate symbols from native state before falling back to the existing cache/index path
- add a focused benchmark for generic index hashNumber lookup versus native resident lookup

## Benchmark
Local node run from packages/programs/data/shared-log:

```
COORD_LOOKUP_ENTRIES=20000 COORD_LOOKUP_SYMBOLS=5000 COORD_LOOKUP_WARMUP=5 COORD_LOOKUP_ITERATIONS=30 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/native-coordinate-symbol-lookup.ts
```

- generic index hashNumber lookup: 30.7 ops/sec, mean 32.70 ms
- native resident hashNumber lookup: 259.8 ops/sec, mean 3.89 ms
- native path is about 8.4x faster for this coordinate-symbol response shape

## Test Plan
- cargo fmt --manifest-path packages/programs/data/shared-log/rust/Cargo.toml --check
- pnpm --filter @peerbit/shared-log-rust run build
- pnpm --filter @peerbit/shared-log run build
- pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/benchmark/native-coordinate-symbol-lookup.ts packages/programs/data/shared-log/test/sync-chunking.spec.ts packages/programs/data/shared-log/rust/src/index.ts packages/programs/data/shared-log/rust/test/index.spec.ts packages/programs/data/shared-log/src/index.ts packages/programs/data/shared-log/src/sync/index.ts packages/programs/data/shared-log/src/sync/simple.ts
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log/rust -- -t node --grep "looks up resident entry hashes by hash number"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "uses native coordinate symbol resolver"
- git diff --check