### PR TITLE
Build rateless range symbols from native state

### DIFF
--- a/packages/programs/data/shared-log/benchmark/native-coordinate-symbol-lookup.ts
+++ b/packages/programs/data/shared-log/benchmark/native-coordinate-symbol-lookup.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "@peerbit/crypto";
-import { Compare, IntegerCompare, Or } from "@peerbit/indexer-interface";
+import { And, Compare, IntegerCompare, Or } from "@peerbit/indexer-interface";
 import { create as createIndex } from "@peerbit/indexer-sqlite3";
 import { LamportClock, Meta } from "@peerbit/log";
 import { createSharedLogState } from "@peerbit/shared-log-rust";
@@ -59,6 +59,14 @@ const symbols = Array.from(
 	{ length: symbolCount },
 	(_, i) => BigInt(((i * 17) % entryCount) + 1),
 );
+const rangeEnd = BigInt(Math.floor(entryCount / 2) + 1);
+const rangeHitCount = Math.floor(entryCount / 2);
+const symbolRange = {
+	start1: 1n,
+	end1: rangeEnd,
+	start2: 0n,
+	end2: 0n,
+};
 
 const lookupViaIndex = async () => {
 	let found = 0;
@@ -95,6 +103,42 @@ const lookupViaNativeState = () => {
 	}
 };
 
+const lookupRangeViaIndex = async () => {
+	const entries = await entryIndex
+		.iterate(
+			{
+				query: new And([
+					new IntegerCompare({
+						key: "hashNumber",
+						compare: Compare.GreaterOrEqual,
+						value: symbolRange.start1,
+					}),
+					new IntegerCompare({
+						key: "hashNumber",
+						compare: Compare.Less,
+						value: symbolRange.end1,
+					}),
+				]),
+			},
+			{ shape: { hash: true, hashNumber: true } },
+		)
+		.all();
+	if (entries.length !== rangeHitCount) {
+		throw new Error(
+			`Expected ${rangeHitCount} index range hits, got ${entries.length}`,
+		);
+	}
+};
+
+const lookupRangeViaNativeState = () => {
+	const result = nativeState.getEntryHashNumbersInRange(symbolRange);
+	if (result.length !== rangeHitCount) {
+		throw new Error(
+			`Expected ${rangeHitCount} native range hits, got ${result.length}`,
+		);
+	}
+};
+
 const suite = new Bench({
 	name: "native-coordinate-symbol-lookup",
 	warmupIterations,
@@ -103,6 +147,8 @@ const suite = new Bench({
 
 suite.add("generic index hashNumber lookup", lookupViaIndex);
 suite.add("native resident hashNumber lookup", lookupViaNativeState);
+suite.add("generic index hashNumber range lookup", lookupRangeViaIndex);
+suite.add("native resident hashNumber range lookup", lookupRangeViaNativeState);
 
 try {
 	await suite.run();
@@ -122,6 +168,7 @@ try {
 					meta: {
 						entryCount,
 						symbolCount,
+						rangeHitCount,
 						queryBatchSize,
 						warmupIterations,
 						iterations,

--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -290,6 +290,12 @@ type NativeSharedLogStateHandle = {
 	get_entry_coordinates: (hash: string) => unknown[] | undefined;
 	entry_coordinate_hashes: () => string[];
 	entry_hashes_for_hash_numbers: (hashNumbers: string[]) => unknown[];
+	entry_hash_numbers_in_range: (
+		start1: string,
+		end1: string,
+		start2: string,
+		end2: string,
+	) => unknown[];
 	commit_entry_coordinates: (
 		hash: string,
 		gid: string,
@@ -930,6 +936,23 @@ export class SharedLogNativeState {
 			out.set(BigInt(hashNumber), hashes);
 		}
 		return out;
+	}
+
+	getEntryHashNumbersInRange(range: {
+		start1: bigint | number | string;
+		end1: bigint | number | string;
+		start2: bigint | number | string;
+		end2: bigint | number | string;
+	}): bigint[] {
+		return rowsToNumbers(
+			"u64",
+			this.native.entry_hash_numbers_in_range(
+				asIntegerString(range.start1),
+				asIntegerString(range.end1),
+				asIntegerString(range.start2),
+				asIntegerString(range.end2),
+			),
+		) as bigint[];
 	}
 
 	commitEntryCoordinates(

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -1713,6 +1713,31 @@ impl NativeSharedLogState {
         Ok(out)
     }
 
+    pub fn entry_hash_numbers_in_range(
+        &self,
+        start1: String,
+        end1: String,
+        start2: String,
+        end2: String,
+    ) -> Result<Array, JsValue> {
+        let start1 = parse_u64(&start1)?;
+        let end1 = parse_u64(&end1)?;
+        let start2 = parse_u64(&start2)?;
+        let end2 = parse_u64(&end2)?;
+        let out = Array::new();
+        for (hash_number, hashes) in &self.inner.entry_hashes_by_hash_number {
+            if coordinate_in_segment(*hash_number, start1, end1)
+                || (start2 != end2 && coordinate_in_segment(*hash_number, start2, end2))
+            {
+                let value = JsValue::from_str(&hash_number.to_string());
+                for _ in hashes {
+                    out.push(&value);
+                }
+            }
+        }
+        Ok(out)
+    }
+
     pub fn commit_entry_coordinates(
         &mut self,
         hash: String,

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -366,6 +366,36 @@ describe("native shared-log range planner", () => {
 		]);
 	});
 
+	it("lists resident entry hash numbers in a requested range", async () => {
+		const state = await createSharedLogState("u64");
+		state.putEntryCoordinates("head-a", "gid-a", [1n], false, 1, 5n);
+		state.putEntryCoordinates("head-b", "gid-b", [2n], false, 1, 8n);
+		state.putEntryCoordinates("head-c", "gid-c", [3n], false, 1, 90n);
+		state.putEntryCoordinates("head-d", "gid-d", [4n], false, 1, 90n);
+
+		expect(
+			state
+				.getEntryHashNumbersInRange({
+					start1: 0n,
+					end1: 10n,
+					start2: 80n,
+					end2: 100n,
+				})
+				.map((value) => value.toString())
+				.sort(),
+		).to.deep.equal(["5", "8", "90", "90"]);
+
+		state.deleteEntryCoordinates("head-c");
+		expect(
+			state.getEntryHashNumbersInRange({
+				start1: 80n,
+				end1: 100n,
+				start2: 0n,
+				end2: 0n,
+			}),
+		).to.deep.equal([90n]);
+	});
+
 	it("counts resident entry coordinates in owned ranges", async () => {
 		const state = await createSharedLogState("u32");
 		state.putEntryCoordinates("head-a", "gid-a", [5, 100]);

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -4809,6 +4809,12 @@ export class SharedLog<
 		});
 		const resolveHashesForSymbols = (symbols: bigint[]) =>
 			this._nativeSharedLogState?.getEntryHashesForHashNumbers(symbols);
+		const resolveHashNumbersInRange = (range: {
+			start1: bigint | number;
+			end1: bigint | number;
+			start2: bigint | number;
+			end2: bigint | number;
+		}) => this._nativeSharedLogState?.getEntryHashNumbersInRange(range);
 
 		if (options?.syncronizer) {
 			this.syncronizer = new options.syncronizer({
@@ -4819,6 +4825,7 @@ export class SharedLog<
 				rpc: this.rpc,
 				coordinateToHash: this.coordinateToHash,
 				resolveHashesForSymbols,
+				resolveHashNumbersInRange,
 				sync: options?.sync,
 			});
 		} else {
@@ -4849,6 +4856,7 @@ export class SharedLog<
 					rpc: this.rpc,
 					coordinateToHash: this.coordinateToHash,
 					resolveHashesForSymbols,
+					resolveHashNumbersInRange,
 					sync: options?.sync,
 				}) as Syncronizer<R>;
 			}

--- a/packages/programs/data/shared-log/src/sync/index.ts
+++ b/packages/programs/data/shared-log/src/sync/index.ts
@@ -66,6 +66,16 @@ export type HashSymbolResolver = (
 	| undefined
 	| Promise<ReadonlyMap<bigint, Iterable<string>> | undefined>;
 
+export type HashSymbolRangeResolver = (range: {
+	start1: bigint | number;
+	end1: bigint | number;
+	start2: bigint | number;
+	end2: bigint | number;
+}) =>
+	| Iterable<bigint | number>
+	| undefined
+	| Promise<Iterable<bigint | number> | undefined>;
+
 export type SynchronizerComponents<R extends "u32" | "u64"> = {
 	rpc: RPC<TransportMessage, TransportMessage>;
 	rangeIndex: Index<ReplicationRangeIndexable<R>, any>;
@@ -74,6 +84,7 @@ export type SynchronizerComponents<R extends "u32" | "u64"> = {
 	coordinateToHash: Cache<string>;
 	numbers: Numbers<R>;
 	resolveHashesForSymbols?: HashSymbolResolver;
+	resolveHashNumbersInRange?: HashSymbolRangeResolver;
 	sync?: SyncOptions<R>;
 };
 export type SynchronizerConstructor<R extends "u32" | "u64"> = new (

--- a/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
+++ b/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
@@ -29,6 +29,7 @@ import type {
 	RepairSession,
 	RepairSessionMode,
 	RepairSessionResult,
+	HashSymbolRangeResolver,
 	SyncableKey,
 	SynchronizerComponents,
 	Syncronizer,
@@ -597,40 +598,58 @@ const buildEncoderOrDecoderFromRange = async <
 	entryIndex: Index<EntryReplicated<D>>,
 	type: T,
 	profile?: SyncProfileFn,
+	resolveHashNumbersInRange?: HashSymbolRangeResolver,
 ): Promise<E | false> => {
 	await ribltReady;
 	const encoder =
 		type === "encoder" ? new EncoderWrapper() : new DecoderWrapper();
 
 	const rangeQueryStartedAt = syncProfileStart(profile);
-	const entries = await entryIndex
-		.iterate(
-			{
-				// Range sync for IBLT is done in hashNumber space.
-				query: matchEntriesByHashNumberInRangeQuery({
-					end1: ranges.end1,
-					start1: ranges.start1,
-					end2: ranges.end2,
-					start2: ranges.start2,
-				}),
-			},
-			{
-				shape: {
-					hash: true,
-					hashNumber: true,
+	let hashNumbers: Array<bigint | number> | BigUint64Array | undefined;
+	let source = "index";
+	const resolved = await resolveHashNumbersInRange?.({
+		end1: ranges.end1,
+		start1: ranges.start1,
+		end2: ranges.end2,
+		start2: ranges.start2,
+	});
+	if (resolved) {
+		source = "native";
+		hashNumbers =
+			typeof BigUint64Array !== "undefined" && resolved instanceof BigUint64Array
+				? resolved
+				: [...resolved];
+	} else {
+		const entries = await entryIndex
+			.iterate(
+				{
+					// Range sync for IBLT is done in hashNumber space.
+					query: matchEntriesByHashNumberInRangeQuery({
+						end1: ranges.end1,
+						start1: ranges.start1,
+						end2: ranges.end2,
+						start2: ranges.start2,
+					}),
 				},
-			},
-		)
-		.all();
+				{
+					shape: {
+						hash: true,
+						hashNumber: true,
+					},
+				},
+			)
+			.all();
+		hashNumbers = entries.map((entry) => entry.value.hashNumber);
+	}
 	if (profile) {
 		emitSyncProfileDuration(profile, rangeQueryStartedAt, {
 			name: "rateless.rangeQuery",
-			entries: entries.length,
-			details: { type },
+			entries: hashNumbers.length,
+			details: { type, source },
 		});
 	}
 
-	if (entries.length === 0) {
+	if (hashNumbers.length === 0) {
 		return false;
 	}
 
@@ -639,21 +658,21 @@ const buildEncoderOrDecoderFromRange = async <
 		typeof BigUint64Array !== "undefined" &&
 		typeof (encoder as RibltSymbolAdder).add_symbols === "function"
 	) {
-		const symbols = new BigUint64Array(entries.length);
-		for (let i = 0; i < entries.length; i++) {
-			symbols[i] = coerceBigInt(entries[i].value.hashNumber);
-		}
+		const symbols =
+			hashNumbers instanceof BigUint64Array
+				? hashNumbers
+				: BigUint64Array.from(hashNumbers, coerceBigInt);
 		addSymbolsToRiblt(encoder as RibltSymbolAdder, symbols);
 	} else {
-		for (const entry of entries) {
-			encoder.add_symbol(coerceBigInt(entry.value.hashNumber));
+		for (const hashNumber of hashNumbers) {
+			encoder.add_symbol(coerceBigInt(hashNumber));
 		}
 	}
 	if (profile) {
 		emitSyncProfileDuration(profile, addSymbolsStartedAt, {
 			name: "rateless.rangeAddSymbols",
-			entries: entries.length,
-			symbols: entries.length,
+			entries: hashNumbers.length,
+			symbols: hashNumbers.length,
 			details: { type },
 		});
 	}
@@ -940,6 +959,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			this.properties.entryIndex,
 			"encoder",
 			profile,
+			this.properties.resolveHashNumbersInRange,
 		)) as EncoderWrapper | false;
 		if (!encoder) {
 			if (profile) {

--- a/packages/programs/data/shared-log/test/rateless-iblt-cache.spec.ts
+++ b/packages/programs/data/shared-log/test/rateless-iblt-cache.spec.ts
@@ -41,6 +41,39 @@ describe("rateless-iblt-syncronizer cache", () => {
 		await sync.close();
 	});
 
+	it("builds local range encoder from native hash-number resolver", async () => {
+		const iterate = sinon.stub().throws(new Error("entry index should not be used"));
+		const resolveHashNumbersInRange = sinon.stub().returns([1n, 2n]);
+		const send = sinon.stub().resolves();
+		const sync = new RatelessIBLTSynchronizer<"u64">({
+			rpc: { send } as any,
+			rangeIndex: {} as any,
+			entryIndex: { iterate } as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			numbers: { maxValue: 2n ** 64n - 1n } as any,
+			resolveHashNumbersInRange,
+		});
+
+		expect(
+			await sync.onMessage(
+				new StartSync({ from: 0n, to: 10n, symbols: [] }),
+				{ from: "p" } as any,
+			),
+		).to.equal(true);
+
+		expect(iterate.called).to.equal(false);
+		expect(resolveHashNumbersInRange.calledOnce).to.equal(true);
+		expect(resolveHashNumbersInRange.firstCall.args[0]).to.deep.equal({
+			start1: 0n,
+			end1: 10n,
+			start2: 0n,
+			end2: 0n,
+		});
+
+		await sync.close();
+	});
+
 	it("invalidates cached range encoder on entry removal", async () => {
 		const iterate = sinon.stub().returns({
 			all: async () => [


### PR DESCRIPTION
## Summary
- add a native resident hashNumber range lookup to shared-log rust state
- wire rateless StartSync local decoder construction through an optional native range-symbol resolver
- preserve the existing entryIndex range-query fallback when native state is absent
- extend the coordinate-symbol benchmark with generic index versus native resident range lookup

## Benchmark
Local node run from packages/programs/data/shared-log:

```
COORD_LOOKUP_ENTRIES=20000 COORD_LOOKUP_SYMBOLS=5000 COORD_LOOKUP_WARMUP=5 COORD_LOOKUP_ITERATIONS=30 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/native-coordinate-symbol-lookup.ts
```

- generic index hashNumber lookup: 30.5 ops/sec, mean 32.92 ms
- native resident hashNumber lookup: 260.6 ops/sec, mean 3.88 ms
- generic index hashNumber range lookup: 73.2 ops/sec, mean 13.70 ms
- native resident hashNumber range lookup: 436.2 ops/sec, mean 2.30 ms

## Test Plan
- cargo fmt --manifest-path packages/programs/data/shared-log/rust/Cargo.toml --check
- pnpm --filter @peerbit/shared-log-rust run build
- pnpm --filter @peerbit/shared-log run build
- pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/benchmark/native-coordinate-symbol-lookup.ts packages/programs/data/shared-log/test/rateless-iblt-cache.spec.ts packages/programs/data/shared-log/rust/src/index.ts packages/programs/data/shared-log/rust/test/index.spec.ts packages/programs/data/shared-log/src/index.ts packages/programs/data/shared-log/src/sync/index.ts packages/programs/data/shared-log/src/sync/rateless-iblt.ts
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log/rust -- -t node --grep "lists resident entry hash numbers"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "builds local range encoder from native"
- git diff --check