### PR TITLE
Batch sync coordinate preflight in native state

### DIFF
--- a/packages/programs/data/shared-log/benchmark/native-coordinate-symbol-lookup.ts
+++ b/packages/programs/data/shared-log/benchmark/native-coordinate-symbol-lookup.ts
@@ -18,6 +18,10 @@ const parsePositiveInt = (value: string | undefined, fallback: number) => {
 
 const entryCount = parsePositiveInt(process.env.COORD_LOOKUP_ENTRIES, 20_000);
 const symbolCount = parsePositiveInt(process.env.COORD_LOOKUP_SYMBOLS, 5_000);
+const preflightSymbolCount = Math.min(
+	symbolCount,
+	parsePositiveInt(process.env.COORD_LOOKUP_PREFLIGHT_SYMBOLS, 500),
+);
 const warmupIterations = parsePositiveInt(process.env.COORD_LOOKUP_WARMUP, 5);
 const iterations = parsePositiveInt(process.env.COORD_LOOKUP_ITERATIONS, 30);
 const queryBatchSize = parsePositiveInt(process.env.COORD_LOOKUP_BATCH, 128);
@@ -59,6 +63,7 @@ const symbols = Array.from(
 	{ length: symbolCount },
 	(_, i) => BigInt(((i * 17) % entryCount) + 1),
 );
+const preflightSymbols = symbols.slice(0, preflightSymbolCount);
 const rangeEnd = BigInt(Math.floor(entryCount / 2) + 1);
 const rangeHitCount = Math.floor(entryCount / 2);
 const symbolRange = {
@@ -139,6 +144,36 @@ const lookupRangeViaNativeState = () => {
 	}
 };
 
+const preflightViaIndexCount = async () => {
+	let found = 0;
+	for (const symbol of preflightSymbols) {
+		if ((await entryIndex.count({ query: { hashNumber: symbol } })) > 0) {
+			found += 1;
+		}
+	}
+	if (found !== preflightSymbols.length) {
+		throw new Error(
+			`Expected ${preflightSymbols.length} index preflight hits, got ${found}`,
+		);
+	}
+};
+
+const preflightViaNativeBatch = () => {
+	const result = nativeState.getEntryHashesForHashNumbers(preflightSymbols);
+	let found = 0;
+	for (const symbol of preflightSymbols) {
+		const hashes = result.get(symbol);
+		if (hashes && hashes.length > 0) {
+			found += 1;
+		}
+	}
+	if (found !== preflightSymbols.length) {
+		throw new Error(
+			`Expected ${preflightSymbols.length} native preflight hits, got ${found}`,
+		);
+	}
+};
+
 const suite = new Bench({
 	name: "native-coordinate-symbol-lookup",
 	warmupIterations,
@@ -149,6 +184,8 @@ suite.add("generic index hashNumber lookup", lookupViaIndex);
 suite.add("native resident hashNumber lookup", lookupViaNativeState);
 suite.add("generic index hashNumber range lookup", lookupRangeViaIndex);
 suite.add("native resident hashNumber range lookup", lookupRangeViaNativeState);
+suite.add("generic index hashNumber preflight count", preflightViaIndexCount);
+suite.add("native resident hashNumber preflight batch", preflightViaNativeBatch);
 
 try {
 	await suite.run();
@@ -168,6 +205,7 @@ try {
 					meta: {
 						entryCount,
 						symbolCount,
+						preflightSymbolCount,
 						rangeHitCount,
 						queryBatchSize,
 						warmupIterations,

--- a/packages/programs/data/shared-log/src/sync/simple.ts
+++ b/packages/programs/data/shared-log/src/sync/simple.ts
@@ -711,6 +711,10 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		const requestHashes: SyncableKey[] = [];
 		const profile = this.syncOptions?.profile;
 		const startedAt = syncProfileStart(profile);
+		const knownCoordinates =
+			options?.skipCheck === true
+				? undefined
+				: await this.resolveKnownCoordinateKeys(keys);
 
 		try {
 			for (const coordinateOrHash of keys) {
@@ -727,7 +731,10 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 					}
 				} else if (
 					options?.skipCheck ||
-					!(await this.checkHasCoordinateOrHash(coordinateOrHash))
+					!(await this.checkHasCoordinateOrHash(
+						coordinateOrHash,
+						knownCoordinates,
+					))
 				) {
 					// Track the initial sender so we can retry if the first request is lost.
 					this.syncInFlightQueue.set(coordinateOrHash, [from]);
@@ -835,7 +842,41 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			}
 		}
 	}
-	private async checkHasCoordinateOrHash(key: string | bigint) {
+	private async resolveKnownCoordinateKeys(keys: SyncableKey[]) {
+		if (!this.resolveHashesForSymbols) {
+			return undefined;
+		}
+		const coordinates = keys.filter(
+			(key): key is bigint => typeof key === "bigint",
+		);
+		if (coordinates.length === 0) {
+			return undefined;
+		}
+		const resolved = await this.resolveHashesForSymbols(coordinates);
+		if (!resolved) {
+			return undefined;
+		}
+		const known = new Set<bigint>();
+		for (const coordinate of coordinates) {
+			const hashes = resolved.get(coordinate);
+			if (!hashes) {
+				continue;
+			}
+			for (const _hash of hashes) {
+				known.add(coordinate);
+				break;
+			}
+		}
+		return known;
+	}
+
+	private async checkHasCoordinateOrHash(
+		key: string | bigint,
+		knownCoordinates?: Set<bigint>,
+	) {
+		if (typeof key === "bigint" && knownCoordinates) {
+			return knownCoordinates.has(key);
+		}
 		return typeof key === "bigint"
 			? (await this.entryIndex.count({ query: { hashNumber: key } })) > 0
 			: this.log.has(key);

--- a/packages/programs/data/shared-log/test/sync-chunking.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-chunking.spec.ts
@@ -74,6 +74,35 @@ describe("sync-chunking", () => {
 		expect(sentCoordinates.map((x) => x.length)).to.deep.equal([2, 2, 1]);
 	});
 
+	it("uses native resolver for coordinate queue preflight", async () => {
+		const send = sinon.stub().resolves();
+		const count = sinon.stub().throws(new Error("entry index should not be used"));
+		const resolveHashesForSymbols = sinon
+			.stub()
+			.returns(new Map([[42n, ["head-a"]]]));
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: { count } as any,
+			log: { has: async () => false } as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			resolveHashesForSymbols,
+		});
+
+		await sync.queueSync(
+			[42n, 7n],
+			{
+				hashcode: () => "peer-a",
+				equals: () => false,
+			} as any,
+		);
+
+		expect(count.called).to.equal(false);
+		expect(resolveHashesForSymbols.firstCall.args[0]).to.deep.equal([42n, 7n]);
+		expect(send.callCount).to.equal(1);
+		expect(send.firstCall.args[0]).to.be.instanceOf(RequestMaybeSyncCoordinate);
+		expect(send.firstCall.args[0].hashNumbers).to.deep.equal([7n]);
+	});
+
 	it("uses native coordinate symbol resolver before index lookup", async () => {
 		const send = sinon.stub().resolves();
 		const iterate = sinon.stub().throws(new Error("entry index should not be used"));


### PR DESCRIPTION
## Summary
- batch SimpleSyncronizer.queueSync coordinate preflight through the native hashNumber resolver
- avoid per-coordinate entryIndex.count({ hashNumber }) when native shared-log state is available
- keep the existing index/log fallback when the native resolver is absent
- extend the coordinate-symbol benchmark with the old preflight count path versus the native batch path

## Benchmark
Local node run from packages/programs/data/shared-log:

```
COORD_LOOKUP_ENTRIES=20000 COORD_LOOKUP_SYMBOLS=5000 COORD_LOOKUP_PREFLIGHT_SYMBOLS=500 COORD_LOOKUP_WARMUP=5 COORD_LOOKUP_ITERATIONS=30 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/native-coordinate-symbol-lookup.ts
```

- generic index hashNumber lookup: 31.5 ops/sec, mean 31.95 ms
- native resident hashNumber lookup: 257.3 ops/sec, mean 3.94 ms
- generic index hashNumber range lookup: 74.1 ops/sec, mean 13.64 ms
- native resident hashNumber range lookup: 444.2 ops/sec, mean 2.25 ms
- generic index hashNumber preflight count: 92.6 ops/sec, mean 10.80 ms
- native resident hashNumber preflight batch: 2892.1 ops/sec, mean 0.35 ms

## Test Plan
- pnpm --filter @peerbit/shared-log run build
- pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/sync/simple.ts packages/programs/data/shared-log/test/sync-chunking.spec.ts packages/programs/data/shared-log/benchmark/native-coordinate-symbol-lookup.ts
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "uses native resolver for coordinate queue preflight"
- git diff --check