### PR TITLE
Use ordered native hash-number range index

### DIFF
--- a/packages/programs/data/shared-log/benchmark/native-coordinate-symbol-lookup.ts
+++ b/packages/programs/data/shared-log/benchmark/native-coordinate-symbol-lookup.ts
@@ -22,6 +22,13 @@ const preflightSymbolCount = Math.min(
 	symbolCount,
 	parsePositiveInt(process.env.COORD_LOOKUP_PREFLIGHT_SYMBOLS, 500),
 );
+const rangeHitCount = Math.min(
+	entryCount,
+	parsePositiveInt(
+		process.env.COORD_LOOKUP_RANGE_HITS,
+		Math.floor(entryCount / 2),
+	),
+);
 const warmupIterations = parsePositiveInt(process.env.COORD_LOOKUP_WARMUP, 5);
 const iterations = parsePositiveInt(process.env.COORD_LOOKUP_ITERATIONS, 30);
 const queryBatchSize = parsePositiveInt(process.env.COORD_LOOKUP_BATCH, 128);
@@ -64,8 +71,7 @@ const symbols = Array.from(
 	(_, i) => BigInt(((i * 17) % entryCount) + 1),
 );
 const preflightSymbols = symbols.slice(0, preflightSymbolCount);
-const rangeEnd = BigInt(Math.floor(entryCount / 2) + 1);
-const rangeHitCount = Math.floor(entryCount / 2);
+const rangeEnd = BigInt(rangeHitCount + 1);
 const symbolRange = {
 	start1: 1n,
 	end1: rangeEnd,

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -2,7 +2,7 @@ use indexmap::{IndexMap, IndexSet};
 use js_sys::Array;
 use sha2::{Digest, Sha256};
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use wasm_bindgen::prelude::*;
 
 const MODE_NON_STRICT: u8 = 0;
@@ -1101,7 +1101,7 @@ pub struct NativeRangePlanner {
 pub struct SharedLogStateInner {
     range_planner: RangePlanner,
     entry_coordinates: IndexMap<String, EntryCoordinateState>,
-    entry_hashes_by_hash_number: HashMap<u64, IndexSet<String>>,
+    entry_hashes_by_hash_number: BTreeMap<u64, IndexSet<String>>,
     gid_peers: HashMap<String, IndexSet<String>>,
     entry_known_peers: HashMap<String, IndexSet<String>>,
 }
@@ -1120,7 +1120,7 @@ impl SharedLogStateInner {
         Self {
             range_planner: RangePlanner::new(&resolution),
             entry_coordinates: IndexMap::new(),
-            entry_hashes_by_hash_number: HashMap::new(),
+            entry_hashes_by_hash_number: BTreeMap::new(),
             gid_peers: HashMap::new(),
             entry_known_peers: HashMap::new(),
         }
@@ -1725,17 +1725,23 @@ impl NativeSharedLogState {
         let start2 = parse_u64(&start2)?;
         let end2 = parse_u64(&end2)?;
         let out = Array::new();
-        for (hash_number, hashes) in &self.inner.entry_hashes_by_hash_number {
-            if coordinate_in_segment(*hash_number, start1, end1)
-                || (start2 != end2 && coordinate_in_segment(*hash_number, start2, end2))
-            {
-                let value = JsValue::from_str(&hash_number.to_string());
-                for _ in hashes {
-                    out.push(&value);
-                }
-            }
+        self.push_entry_hash_numbers_in_segment(&out, start1, end1);
+        if start2 != end2 {
+            self.push_entry_hash_numbers_in_segment(&out, start2, end2);
         }
         Ok(out)
+    }
+
+    fn push_entry_hash_numbers_in_segment(&self, out: &Array, start: u64, end: u64) {
+        if start >= end {
+            return;
+        }
+        for (hash_number, hashes) in self.inner.entry_hashes_by_hash_number.range(start..end) {
+            let value = JsValue::from_str(&hash_number.to_string());
+            for _ in hashes {
+                out.push(&value);
+            }
+        }
     }
 
     pub fn commit_entry_coordinates(


### PR DESCRIPTION
## Summary
- store resident shared-log hashNumber -> hashes in an ordered native map
- make native hash-number range lookup use ordered range iteration instead of scanning all resident hash numbers
- keep direct hashNumber lookups and collision handling intact
- make the coordinate-symbol benchmark range size configurable

## Benchmark
Local node run from packages/programs/data/shared-log:

```
COORD_LOOKUP_ENTRIES=20000 COORD_LOOKUP_SYMBOLS=5000 COORD_LOOKUP_RANGE_HITS=1000 COORD_LOOKUP_PREFLIGHT_SYMBOLS=500 COORD_LOOKUP_WARMUP=5 COORD_LOOKUP_ITERATIONS=30 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/native-coordinate-symbol-lookup.ts
```

- generic index hashNumber range lookup: 868.8 ops/sec, mean 1.16 ms
- native resident hashNumber range lookup: 4902.8 ops/sec, mean 0.21 ms
- generic index hashNumber preflight count: 93.1 ops/sec, mean 10.75 ms
- native resident hashNumber preflight batch: 2750.9 ops/sec, mean 0.38 ms

## Test Plan
- cargo fmt --manifest-path packages/programs/data/shared-log/rust/Cargo.toml --check
- pnpm --filter @peerbit/shared-log-rust run build
- pnpm --filter @peerbit/shared-log run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log/rust -- -t node --grep "lists resident entry hash numbers"
- git diff --check