### PR TITLE
Batch exchange head hash resolution

### DIFF
--- a/packages/programs/data/shared-log/benchmark/exchange-head-resolution.ts
+++ b/packages/programs/data/shared-log/benchmark/exchange-head-resolution.ts
@@ -1,0 +1,94 @@
+import { AnyBlockStore } from "@peerbit/blocks";
+import { Ed25519Keypair } from "@peerbit/crypto";
+import { Log } from "@peerbit/log";
+import { Bench } from "tinybench";
+
+// Run with:
+//   cd packages/programs/data/shared-log
+//   EXCHANGE_HEADS=1000 EXCHANGE_HEAD_WARMUP=5 EXCHANGE_HEAD_ITERATIONS=30 \
+//     BENCH_JSON=1 node --loader ts-node/esm ./benchmark/exchange-head-resolution.ts
+
+const parsePositiveInt = (value: string | undefined, fallback: number) => {
+	const parsed = Number.parseInt(value ?? "", 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const headCount = parsePositiveInt(process.env.EXCHANGE_HEADS, 1_000);
+const warmupIterations = parsePositiveInt(process.env.EXCHANGE_HEAD_WARMUP, 5);
+const iterations = parsePositiveInt(process.env.EXCHANGE_HEAD_ITERATIONS, 30);
+
+const store = new AnyBlockStore();
+await store.start();
+const key = await Ed25519Keypair.create();
+const log = new Log<Uint8Array>();
+await log.open(store, key, {
+	appendDurability: "strict",
+	nativeGraph: true,
+});
+
+const hashes: string[] = [];
+for (let i = 0; i < headCount; i++) {
+	const { entry } = await log.append(new Uint8Array([i & 0xff]), {
+		meta: { next: [], gidSeed: new Uint8Array([i & 0xff, (i >> 8) & 0xff]) },
+	});
+	hashes.push(entry.hash);
+}
+
+const suite = new Bench({
+	name: "exchange-head-resolution",
+	warmupIterations,
+	iterations,
+});
+
+suite.add("sequential log.get heads", async () => {
+	(log.entryIndex as any).cache.clear();
+	let found = 0;
+	for (const hash of hashes) {
+		if (await log.get(hash)) {
+			found += 1;
+		}
+	}
+	if (found !== hashes.length) {
+		throw new Error(`Expected ${hashes.length} heads, got ${found}`);
+	}
+});
+
+suite.add("batched entryIndex.getMany heads", async () => {
+	(log.entryIndex as any).cache.clear();
+	const entries = await log.entryIndex.getMany(hashes, {
+		type: "full",
+		ignoreMissing: true,
+	});
+	if (entries.filter(Boolean).length !== hashes.length) {
+		throw new Error(`Expected ${hashes.length} heads, got ${entries.length}`);
+	}
+});
+
+try {
+	await suite.run();
+	if (process.env.BENCH_JSON === "1") {
+		const tasks = suite.tasks.map((task) => ({
+			name: task.name,
+			hz: task.result?.hz ?? null,
+			mean_ms: task.result?.mean ?? null,
+			rme: task.result?.rme ?? null,
+			samples: task.result?.samples?.length ?? null,
+		}));
+		process.stdout.write(
+			JSON.stringify(
+				{
+					name: suite.name,
+					tasks,
+					meta: { headCount, warmupIterations, iterations },
+				},
+				null,
+				2,
+			),
+		);
+	} else {
+		console.table(suite.table());
+	}
+} finally {
+	await log.close();
+	await store.stop();
+}

--- a/packages/programs/data/shared-log/src/exchange-heads.ts
+++ b/packages/programs/data/shared-log/src/exchange-heads.ts
@@ -77,9 +77,9 @@ export const createExchangeHeadsMessages = async function* (
 	let current: EntryWithRefs<any>[] = [];
 	const visitedHeads = new Set<string>();
 	const headArray = Array.isArray(heads) ? heads : [...heads];
+	const resolvedHeads = await resolveExchangeHeadEntries(log, headArray);
 	const canUseNativeReferenceGids = headArray.length === 1;
-	for (const fromHead of headArray) {
-		let entry = fromHead instanceof Entry ? fromHead : await log.get(fromHead);
+	for (const entry of resolvedHeads) {
 		if (!entry) {
 			continue; // missing this entry, could be deleted while iterating
 		}
@@ -145,6 +145,38 @@ export const createExchangeHeadsMessages = async function* (
 			heads: current,
 		});
 	}
+};
+
+const resolveExchangeHeadEntries = async (
+	log: Log<any>,
+	headArray: Array<Entry<any> | string>,
+): Promise<Array<Entry<any> | undefined>> => {
+	const resolved: Array<Entry<any> | undefined> = new Array(headArray.length);
+	const hashes: string[] = [];
+	const positions: number[] = [];
+	for (let i = 0; i < headArray.length; i++) {
+		const head = headArray[i]!;
+		if (head instanceof Entry) {
+			resolved[i] = head;
+			continue;
+		}
+		hashes.push(head);
+		positions.push(i);
+	}
+	if (hashes.length === 0) {
+		return resolved;
+	}
+	const entries =
+		hashes.length === 1
+			? [await log.get(hashes[0]!)]
+			: await log.entryIndex.getMany(hashes, {
+					type: "full",
+					ignoreMissing: true,
+				});
+	for (let i = 0; i < entries.length; i++) {
+		resolved[positions[i]!] = entries[i];
+	}
+	return resolved;
 };
 
 export const allEntriesWithUniqueGids = async (

--- a/packages/programs/data/shared-log/test/exchange-heads.spec.ts
+++ b/packages/programs/data/shared-log/test/exchange-heads.spec.ts
@@ -66,4 +66,47 @@ describe("exchange heads", () => {
 			await log.close();
 		}
 	});
+
+	it("resolves multiple hash heads in one entry-index batch", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			appendDurability: "strict",
+			nativeGraph: true,
+		});
+
+		const { entry: left } = await log.append(new Uint8Array([1]), {
+			meta: { next: [], gidSeed: new Uint8Array([1]) },
+		});
+		const { entry: right } = await log.append(new Uint8Array([2]), {
+			meta: { next: [], gidSeed: new Uint8Array([2]) },
+		});
+
+		const getManySpy = sinon.spy(log.entryIndex, "getMany");
+		const getSpy = sinon.spy(log, "get");
+		try {
+			const messages = [];
+			for await (const message of createExchangeHeadsMessages(log, [
+				left.hash,
+				right.hash,
+			])) {
+				messages.push(message);
+			}
+
+			expect(messages).to.have.length(1);
+			expect(messages[0]!.heads.map((head) => head.entry.hash)).to.deep.equal([
+				left.hash,
+				right.hash,
+			]);
+			expect(getManySpy.calledOnce).to.equal(true);
+			expect(getManySpy.firstCall.args[0]).to.deep.equal([
+				left.hash,
+				right.hash,
+			]);
+			expect(getSpy.callCount).to.equal(0);
+		} finally {
+			getSpy.restore();
+			getManySpy.restore();
+			await log.close();
+		}
+	});
 });


### PR DESCRIPTION
## Summary
- resolve multiple exchange-head hash inputs through one entryIndex.getMany call
- preserve the existing single-head path so native unique-reference-gid lookup still applies
- add a focused test proving multi-hash exchange heads avoid per-head log.get calls
- add a lightweight benchmark for sequential log.get versus batched entryIndex.getMany head resolution

## Benchmark
Local node run from packages/programs/data/shared-log:

```
EXCHANGE_HEADS=1000 EXCHANGE_HEAD_WARMUP=5 EXCHANGE_HEAD_ITERATIONS=30 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/exchange-head-resolution.ts
```

- sequential log.get heads: 178.9 ops/sec, mean 5.64 ms (warm-cache run)
- batched entryIndex.getMany heads: 195.3 ops/sec, mean 5.18 ms (warm-cache run)
- with explicit cold cache in the benchmark: sequential 5.72 ms, batched 5.41 ms locally

The local in-memory store delta is modest, but this changes the sync response path from N individual entry loads to one getMany call, allowing native/block-store batch reads when hashes are missing from cache.

## Test Plan
- pnpm --filter @peerbit/shared-log run build
- pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/exchange-heads.ts packages/programs/data/shared-log/test/exchange-heads.spec.ts packages/programs/data/shared-log/benchmark/exchange-head-resolution.ts
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "resolves multiple hash heads"
- git diff --check