### PR TITLE
Batch native head replica metadata lookups

### DIFF
--- a/packages/log/benchmark/native-graph.ts
+++ b/packages/log/benchmark/native-graph.ts
@@ -79,12 +79,14 @@ const createReplicaHeadsLog = async (nativeGraph: boolean) => {
 		indexer: new HashmapIndices(),
 		nativeGraph,
 	});
+	const gids: string[] = [];
 	for (let i = 0; i < entries; i++) {
-		await log.append(new Uint8Array([i & 0xff]), {
+		const { entry } = await log.append(new Uint8Array([i & 0xff]), {
 			meta: { next: [], data: absoluteReplicaData((i % 8) + 1) },
 		});
+		gids.push(entry.meta.gid);
 	}
-	return { log, store };
+	return { log, store, gids };
 };
 
 const createChainLog = async (nativeGraph: boolean) => {
@@ -171,13 +173,13 @@ const hasAnyHeadBatch = async (log: Log<Uint8Array>, gidSets: string[][]) => {
 	return out;
 };
 
-const getMaxHeadDataU32 = async (log: Log<Uint8Array>) => {
-	const nativeMax = await log.entryIndex.getMaxHeadDataU32();
+const getMaxHeadDataU32 = async (log: Log<Uint8Array>, gid?: string) => {
+	const nativeMax = await log.entryIndex.getMaxHeadDataU32(gid);
 	if (nativeMax != null) {
 		return nativeMax;
 	}
 	const heads = (await log.entryIndex
-		.getHeads(undefined, {
+		.getHeads(gid, {
 			type: "shape",
 			shape: { meta: { data: true } },
 		})
@@ -190,6 +192,21 @@ const getMaxHeadDataU32 = async (log: Log<Uint8Array>) => {
 		}
 	}
 	return max;
+};
+
+const getMaxHeadDataU32Batch = async (
+	log: Log<Uint8Array>,
+	gids: string[],
+) => {
+	const nativeMaxes = await log.entryIndex.getMaxHeadDataU32Batch(gids);
+	if (nativeMaxes != null) {
+		return nativeMaxes;
+	}
+	const out: Array<number | undefined> = [];
+	for (const gid of gids) {
+		out.push(await getMaxHeadDataU32(log, gid));
+	}
+	return out;
 };
 
 const measureAppend = async (
@@ -543,11 +560,35 @@ for (const nativeGraph of [false, true]) {
 }
 
 for (const nativeGraph of [false, true]) {
-	const { log, store } = await createReplicaHeadsLog(nativeGraph);
+	const { log, store, gids } = await createReplicaHeadsLog(nativeGraph);
 	rows.push(
 		await measure("getMaxHeadDataU32()", nativeGraph, async () => {
 			await getMaxHeadDataU32(log);
 		}),
+	);
+	const batchGids = gids.slice(0, Math.min(gids.length, nativeGraph ? 1_000 : 100));
+	const batchIterations = Math.min(iterations, nativeGraph ? 100 : 10);
+	rows.push(
+		await measure(
+			"getMaxHeadDataU32(gids loop)",
+			nativeGraph,
+			async () => {
+				for (const gid of batchGids) {
+					await getMaxHeadDataU32(log, gid);
+				}
+			},
+			batchIterations,
+		),
+	);
+	rows.push(
+		await measure(
+			"getMaxHeadDataU32Batch(gids)",
+			nativeGraph,
+			async () => {
+				await getMaxHeadDataU32Batch(log, batchGids);
+			},
+			batchIterations,
+		),
 	);
 	await log.close();
 	await store.stop();

--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -173,6 +173,7 @@ type NativeLogIndexHandle = {
 	head_entries: (gid?: string) => unknown[];
 	head_data_entries: (gid?: string) => unknown[];
 	max_head_data_u32: (gid?: string) => number | undefined;
+	max_head_data_u32_batch: (gids: string[]) => Array<number | undefined>;
 	head_join_entries: (gid?: string) => unknown[];
 	child_join_entries: (hash: string) => unknown[];
 	unique_reference_gids: (hash: string) => string[] | undefined;
@@ -688,6 +689,10 @@ export class LogGraphIndex {
 
 	maxHeadDataU32(gid?: string): number | undefined {
 		return this.native.max_head_data_u32(gid);
+	}
+
+	maxHeadDataU32Batch(gids: Iterable<string>): Array<number | undefined> {
+		return this.native.max_head_data_u32_batch([...gids]);
 	}
 
 	joinHeadEntries(gid?: string): NativeLogJoinEntry[] {

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -2,7 +2,7 @@ use ed25519_dalek::{Signer, SigningKey};
 use indexmap::{IndexMap, IndexSet};
 use js_sys::{Array, BigUint64Array, Uint32Array, Uint8Array};
 use sha2::{Digest, Sha256};
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use wasm_bindgen::prelude::*;
 
 const ENTRY_TYPE_CUT: u8 = 1;
@@ -289,6 +289,36 @@ impl LogGraphIndex {
             max = Some(max.map_or(value, |current: u32| current.max(value)));
         }
         max
+    }
+
+    pub fn max_head_data_u32_batch(&self, gids: &[String]) -> Vec<Option<u32>> {
+        if gids.is_empty() {
+            return Vec::new();
+        }
+
+        let requested: HashSet<&str> = gids.iter().map(String::as_str).collect();
+        let mut max_by_gid: HashMap<&str, u32> = HashMap::with_capacity(requested.len());
+
+        for hash in &self.heads {
+            let Some(entry) = self.entries.get(hash) else {
+                continue;
+            };
+            let gid = entry.gid.as_str();
+            if !requested.contains(gid) {
+                continue;
+            }
+            let Some(value) = decode_absolute_replica_data_u32(entry.data.as_deref()) else {
+                continue;
+            };
+            max_by_gid
+                .entry(gid)
+                .and_modify(|current| *current = (*current).max(value))
+                .or_insert(value);
+        }
+
+        gids.iter()
+            .map(|gid| max_by_gid.get(gid.as_str()).copied())
+            .collect()
     }
 
     pub fn head_join_entries(&self, gid: Option<&str>) -> Vec<LogIndexEntry> {
@@ -1009,6 +1039,19 @@ impl NativeLogIndex {
             .max_head_data_u32(gid.as_deref())
             .map(|value| JsValue::from_f64(value as f64))
             .unwrap_or(JsValue::UNDEFINED)
+    }
+
+    pub fn max_head_data_u32_batch(&self, gids: Array) -> Result<Array, JsValue> {
+        let gids = strings_from_array(gids)?;
+        let out = Array::new();
+        for value in self.inner.max_head_data_u32_batch(&gids) {
+            out.push(
+                &value
+                    .map(|value| JsValue::from_f64(value as f64))
+                    .unwrap_or(JsValue::UNDEFINED),
+            );
+        }
+        Ok(out)
     }
 
     pub fn head_join_entries(&self, gid: Option<String>) -> Array {

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -213,6 +213,11 @@ describe("native log graph index", () => {
 		expect(index.maxHeadDataU32("one")).equal(5);
 		expect(index.maxHeadDataU32("two")).equal(9);
 		expect(index.maxHeadDataU32("missing")).equal(undefined);
+		expect(index.maxHeadDataU32Batch(["one", "two", "missing"])).to.deep.equal([
+			5,
+			9,
+			undefined,
+		]);
 	});
 
 	it("does not demote nexts for cut entries", async () => {

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -177,6 +177,7 @@ export type NativeLogGraph = {
 	hasAnyHeadBatch: (gidSets: Iterable<Iterable<string>>) => boolean[];
 	headDataEntries: (gid?: string) => NativeLogHeadDataEntry[];
 	maxHeadDataU32: (gid?: string) => number | undefined;
+	maxHeadDataU32Batch?: (gids: Iterable<string>) => Array<number | undefined>;
 	headEntries: (gid?: string) => SortableEntry[];
 	joinHeadEntries: (gid?: string) => NativeLogJoinEntry[];
 	childJoinEntries: (hash: string) => NativeLogJoinEntry[];
@@ -501,6 +502,19 @@ export class EntryIndex<T> {
 			return undefined;
 		}
 		return this.properties.nativeGraph.graph.maxHeadDataU32(gid);
+	}
+
+	async getMaxHeadDataU32Batch(
+		gids: Iterable<string>,
+	): Promise<Array<number | undefined> | undefined> {
+		if (!this.properties.nativeGraph?.useHeads) {
+			return undefined;
+		}
+		const normalized = [...gids];
+		if (normalized.length === 0) {
+			return [];
+		}
+		return this.properties.nativeGraph.graph.maxHeadDataU32Batch?.(normalized);
 	}
 
 	getJoinHeads(gid?: string): Promise<NativeLogJoinEntry[]> {

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -174,10 +174,10 @@ describe("native graph", () => {
 			indexer: new HashmapIndices(),
 			nativeGraph: true,
 		});
-		await log.append(new Uint8Array([1]), {
+		const first = await log.append(new Uint8Array([1]), {
 			meta: { next: [], data: absoluteReplicaData(2) },
 		});
-		await log.append(new Uint8Array([2]), {
+		const second = await log.append(new Uint8Array([2]), {
 			meta: { next: [], data: absoluteReplicaData(5) },
 		});
 
@@ -187,11 +187,21 @@ describe("native graph", () => {
 		);
 		const nativeGraph = log.entryIndex.properties.nativeGraph!.graph;
 		const maxHeadDataU32Spy = sinon.spy(nativeGraph, "maxHeadDataU32");
+		const maxHeadDataU32BatchSpy = sinon.spy(nativeGraph, "maxHeadDataU32Batch");
 		try {
 			expect(await log.entryIndex.getMaxHeadDataU32()).equal(5);
+			expect(
+				await log.entryIndex.getMaxHeadDataU32Batch([
+					first.entry.meta.gid,
+					second.entry.meta.gid,
+					"missing",
+				]),
+			).to.deep.equal([2, 5, undefined]);
 			expect(maxHeadDataU32Spy.callCount).equal(1);
+			expect(maxHeadDataU32BatchSpy.callCount).equal(1);
 			expect(indexIterateSpy.callCount).equal(0);
 		} finally {
+			maxHeadDataU32BatchSpy.restore();
 			maxHeadDataU32Spy.restore();
 			indexIterateSpy.restore();
 			await log.close();

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -5541,6 +5541,35 @@ export class SharedLog<
 		return maxReplicas(this, headsWithGid.values());
 	}
 
+	private async getMaxReplicasFromHeadsBatch(gids: Iterable<string>) {
+		const uniqueGids = [...new Set([...gids].filter(Boolean))];
+		const out = new Map<string, number | undefined>();
+		if (uniqueGids.length === 0) {
+			return out;
+		}
+
+		const nativeMaxes =
+			await this.log.entryIndex.getMaxHeadDataU32Batch(uniqueGids);
+		if (nativeMaxes != null) {
+			for (let i = 0; i < uniqueGids.length; i++) {
+				const gid = uniqueGids[i]!;
+				const nativeMax = nativeMaxes[i];
+				out.set(
+					gid,
+					nativeMax == null ? undefined : this.clampReplicas(nativeMax),
+				);
+			}
+			return out;
+		}
+
+		await Promise.all(
+			uniqueGids.map(async (gid) => {
+				out.set(gid, await this.getMaxReplicasFromHeads(gid));
+			}),
+		);
+		return out;
+	}
+
 	private async hasHeadForGid(gid: string) {
 		const nativeHasHead = await this.log.entryIndex.hasHead(gid);
 		if (nativeHasHead != null) {
@@ -6033,6 +6062,8 @@ export class SharedLog<
 						return;
 					}
 					const groupedByGid = await groupByGid(filteredHeads);
+					const maxReplicasFromHeadsByGid =
+						await this.getMaxReplicasFromHeadsBatch(groupedByGid.keys());
 					const promises: Promise<void>[] = [];
 
 					for (const [gid, entries] of groupedByGid) {
@@ -6046,7 +6077,7 @@ export class SharedLog<
 							const latestEntry = getLatestEntry(entries)!;
 
 							const maxReplicasFromHead =
-								(await this.getMaxReplicasFromHeads(gid)) ??
+								maxReplicasFromHeadsByGid.get(gid) ??
 								this.replicas.min.getValue(this);
 
 							const maxReplicasFromNewEntries = maxReplicas(


### PR DESCRIPTION
## Summary
- add a native log graph batch API for max head replica metadata by gid
- expose it through @peerbit/log-rust and EntryIndex as an optional native graph fast path
- prefetch exchange-head receive max replica metadata for all grouped gids in one native call
- extend the native graph benchmark with per-gid loop versus batch rows

## Benchmark
Local focused node microbench, 2026-05-11:
- setup: 1000 independent native graph heads with absolute replica data, 50 repeated passes
- old per-gid native loop: 2940.74 ms for 50k gid lookups, about 17.0k gid lookups/sec
- new native batch: 28.35 ms for the same 50k gid results, about 1.76M gid results/sec
- effect: about 104x faster for this metadata shape, with JS->native calls dropping from 50,000 to 50

## Test Plan
- cargo test (packages/log/rust)
- pnpm --filter @peerbit/log-rust run build
- pnpm --filter @peerbit/log-rust exec aegir test -t node --grep "native log graph index"
- pnpm --filter @peerbit/log run build
- pnpm --filter @peerbit/log exec aegir test -t node --grep "computes max head data u32"
- pnpm --filter @peerbit/shared-log run build
- pnpm --filter @peerbit/shared-log exec aegir test -t node --grep "resolves multiple hash heads"
- pnpm --filter @peerbit/shared-log exec aegir test -t node --grep "settles towards the current replicators"
- pnpm --filter @peerbit/shared-log exec aegir test -t node --grep "will prune on put 300 after join"
- pnpm exec eslint packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/src/entry-index.ts packages/log/test/native-graph.spec.ts packages/log/benchmark/native-graph.ts packages/programs/data/shared-log/src/index.ts
- cargo fmt --manifest-path packages/log/rust/Cargo.toml --check
- git diff --check