### PR TITLE
Batch native exchange reference planning

### DIFF
--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -177,6 +177,9 @@ type NativeLogIndexHandle = {
 	head_join_entries: (gid?: string) => unknown[];
 	child_join_entries: (hash: string) => unknown[];
 	unique_reference_gids: (hash: string) => string[] | undefined;
+	unique_reference_gid_rows_batch: (
+		hashes: string[],
+	) => Array<Array<[string, string]> | undefined>;
 	plan_delete_recursively: (hashes: string[], skipFirst: boolean) => string[];
 	children: (hash: string) => string[];
 	count_has_next: (next: string, excludeHash?: string) => number;
@@ -751,6 +754,17 @@ export class LogGraphIndex {
 
 	uniqueReferenceGids(hash: string): string[] | undefined {
 		return this.native.unique_reference_gids(hash);
+	}
+
+	uniqueReferenceGidRowsBatch(
+		hashes: Iterable<string>,
+	): Array<Array<[string, string]> | undefined> {
+		return this.native.unique_reference_gid_rows_batch([...hashes]).map((rows) =>
+			rows?.map((row) => {
+				const [hash, gid] = row;
+				return [hash, gid] as [string, string];
+			}),
+		);
 	}
 
 	planDeleteRecursively(hashes: Iterable<string>, skipFirst = false): string[] {

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -332,7 +332,7 @@ impl LogGraphIndex {
             .collect()
     }
 
-    pub fn unique_reference_gids(&self, hash: &str) -> Option<Vec<String>> {
+    pub fn unique_reference_gid_rows(&self, hash: &str) -> Option<Vec<(String, String)>> {
         let entry = self.entries.get(hash)?;
         if entry.entry_type == ENTRY_TYPE_CUT {
             return Some(Vec::new());
@@ -350,7 +350,7 @@ impl LogGraphIndex {
             if !visited_gids.insert(next_entry.gid.clone()) {
                 continue;
             }
-            out.push(next_entry.gid.clone());
+            out.push((next_hash, next_entry.gid.clone()));
             if next_entry.entry_type == ENTRY_TYPE_CUT {
                 continue;
             }
@@ -358,6 +358,21 @@ impl LogGraphIndex {
         }
 
         Some(out)
+    }
+
+    pub fn unique_reference_gids(&self, hash: &str) -> Option<Vec<String>> {
+        self.unique_reference_gid_rows(hash)
+            .map(|rows| rows.into_iter().map(|(_, gid)| gid).collect())
+    }
+
+    pub fn unique_reference_gid_rows_batch(
+        &self,
+        hashes: &[String],
+    ) -> Vec<Option<Vec<(String, String)>>> {
+        hashes
+            .iter()
+            .map(|hash| self.unique_reference_gid_rows(hash))
+            .collect()
     }
 
     pub fn plan_delete_recursively(&self, from: &[String], skip_first: bool) -> Vec<String> {
@@ -1067,6 +1082,19 @@ impl NativeLogIndex {
             .unique_reference_gids(hash)
             .map(|gids| strings_to_array(gids).into())
             .unwrap_or(JsValue::UNDEFINED)
+    }
+
+    pub fn unique_reference_gid_rows_batch(&self, hashes: Array) -> Result<Array, JsValue> {
+        let hashes = strings_from_array(hashes)?;
+        let out = Array::new();
+        for rows in self.inner.unique_reference_gid_rows_batch(&hashes) {
+            out.push(
+                &rows
+                    .map(|rows| reference_gid_rows_to_array(rows).into())
+                    .unwrap_or(JsValue::UNDEFINED),
+            );
+        }
+        Ok(out)
     }
 
     pub fn plan_delete_recursively(&self, from: Array, skip_first: bool) -> Result<Array, JsValue> {
@@ -1922,6 +1950,17 @@ fn strings_to_array(values: Vec<String>) -> Array {
     let out = Array::new();
     for value in values {
         out.push(&JsValue::from_str(&value));
+    }
+    out
+}
+
+fn reference_gid_rows_to_array(values: Vec<(String, String)>) -> Array {
+    let out = Array::new();
+    for (hash, gid) in values {
+        let row = Array::new();
+        row.push(&JsValue::from_str(&hash));
+        row.push(&JsValue::from_str(&gid));
+        out.push(&row);
     }
     out
 }

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -288,6 +288,14 @@ describe("native log graph index", () => {
 			"root-gid",
 			"side-gid",
 		]);
+		expect(index.uniqueReferenceGidRowsBatch(["head", "missing"])).to.deep.equal([
+			[
+				["branch", "branch-gid"],
+				["same-gid-parent", "root-gid"],
+				["side", "side-gid"],
+			],
+			undefined,
+		]);
 		expect(index.uniqueReferenceGids("missing")).to.equal(undefined);
 
 		index.put(entry("cut", "cut-gid", ["head"], 6n, CUT));

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -182,6 +182,9 @@ export type NativeLogGraph = {
 	joinHeadEntries: (gid?: string) => NativeLogJoinEntry[];
 	childJoinEntries: (hash: string) => NativeLogJoinEntry[];
 	uniqueReferenceGids: (hash: string) => string[] | undefined;
+	uniqueReferenceGidRowsBatch?: (
+		hashes: Iterable<string>,
+	) => Array<Array<[string, string]> | undefined>;
 	planDeleteRecursively: (
 		hashes: Iterable<string>,
 		skipFirst?: boolean,
@@ -552,6 +555,21 @@ export class EntryIndex<T> {
 			return undefined;
 		}
 		return this.properties.nativeGraph.graph.uniqueReferenceGids(hash);
+	}
+
+	getUniqueReferenceGidRowsBatch(
+		hashes: Iterable<string>,
+	): Array<Array<[string, string]> | undefined> | undefined {
+		if (!this.properties.nativeGraph) {
+			return undefined;
+		}
+		const normalized = [...hashes];
+		if (normalized.length === 0) {
+			return [];
+		}
+		return this.properties.nativeGraph.graph.uniqueReferenceGidRowsBatch?.(
+			normalized,
+		);
 	}
 
 	planDeleteRecursively(

--- a/packages/programs/data/shared-log/src/exchange-heads.ts
+++ b/packages/programs/data/shared-log/src/exchange-heads.ts
@@ -79,7 +79,12 @@ export const createExchangeHeadsMessages = async function* (
 	const headArray = Array.isArray(heads) ? heads : [...heads];
 	const resolvedHeads = await resolveExchangeHeadEntries(log, headArray);
 	const canUseNativeReferenceGids = headArray.length === 1;
-	for (const entry of resolvedHeads) {
+	const nativeReferenceRowsByPosition =
+		canUseNativeReferenceGids === false
+			? getNativeReferenceRowsByPosition(log, resolvedHeads)
+			: undefined;
+	for (let i = 0; i < resolvedHeads.length; i++) {
+		const entry = resolvedHeads[i];
 		if (!entry) {
 			continue; // missing this entry, could be deleted while iterating
 		}
@@ -97,6 +102,36 @@ export const createExchangeHeadsMessages = async function* (
 				new EntryWithRefs({
 					entry,
 					gidRefrences: nativeGidReferences,
+				}),
+			);
+			size += entry.size;
+			if (size > MAX_EXCHANGE_MESSAGE_SIZE) {
+				size = 0;
+				yield new ExchangeHeadsMessage({
+					heads: current,
+				});
+				current = [];
+			}
+			continue;
+		}
+
+		const nativeReferenceRows = nativeReferenceRowsByPosition?.get(i);
+		if (nativeReferenceRows) {
+			const gidRefrences: string[] = [];
+			for (const [hash, gid] of nativeReferenceRows) {
+				if (visitedHeads.has(hash)) {
+					continue;
+				}
+				visitedHeads.add(hash);
+				gidRefrences.push(gid);
+			}
+			if (gidRefrences.length > 1000) {
+				warn("Large refs count: ", gidRefrences.length);
+			}
+			current.push(
+				new EntryWithRefs({
+					entry,
+					gidRefrences,
 				}),
 			);
 			size += entry.size;
@@ -145,6 +180,31 @@ export const createExchangeHeadsMessages = async function* (
 			heads: current,
 		});
 	}
+};
+
+const getNativeReferenceRowsByPosition = (
+	log: Log<any>,
+	resolvedHeads: Array<Entry<any> | undefined>,
+) => {
+	const positions: number[] = [];
+	const hashes: string[] = [];
+	for (let i = 0; i < resolvedHeads.length; i++) {
+		const entry = resolvedHeads[i];
+		if (!entry) {
+			continue;
+		}
+		positions.push(i);
+		hashes.push(entry.hash);
+	}
+	const rows = log.entryIndex.getUniqueReferenceGidRowsBatch(hashes);
+	if (!rows) {
+		return undefined;
+	}
+	const byPosition = new Map<number, Array<[string, string]> | undefined>();
+	for (let i = 0; i < rows.length; i++) {
+		byPosition.set(positions[i]!, rows[i]);
+	}
+	return byPosition;
 };
 
 const resolveExchangeHeadEntries = async (

--- a/packages/programs/data/shared-log/test/exchange-heads.spec.ts
+++ b/packages/programs/data/shared-log/test/exchange-heads.spec.ts
@@ -109,4 +109,77 @@ describe("exchange heads", () => {
 			await log.close();
 		}
 	});
+
+	it("uses native graph reference gids for multi-head messages", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			appendDurability: "strict",
+			nativeGraph: true,
+		});
+
+		const { entry: leftRoot } = await log.append(new Uint8Array([1]), {
+			meta: { next: [], gidSeed: new Uint8Array([1]) },
+		});
+		const { entry: leftSide } = await log.append(new Uint8Array([2]), {
+			meta: { next: [], gidSeed: new Uint8Array([2]) },
+		});
+		const { entry: rightRoot } = await log.append(new Uint8Array([3]), {
+			meta: { next: [], gidSeed: new Uint8Array([3]) },
+		});
+		const { entry: rightSide } = await log.append(new Uint8Array([4]), {
+			meta: { next: [], gidSeed: new Uint8Array([4]) },
+		});
+		const { entry: leftHead } = await log.append(new Uint8Array([5]), {
+			meta: { next: [leftRoot, leftSide] },
+		});
+		const { entry: rightHead } = await log.append(new Uint8Array([6]), {
+			meta: { next: [rightRoot, rightSide] },
+		});
+
+		const nativeGraph = log.entryIndex.properties.nativeGraph!.graph;
+		const expectedLeftReferences =
+			nativeGraph.uniqueReferenceGids(leftHead.hash) ?? [];
+		const expectedRightReferences =
+			nativeGraph.uniqueReferenceGids(rightHead.hash) ?? [];
+		expect(expectedLeftReferences).to.not.be.empty;
+		expect(expectedRightReferences).to.not.be.empty;
+		const uniqueReferenceGidRowsBatchSpy = sinon.spy(
+			nativeGraph,
+			"uniqueReferenceGidRowsBatch",
+		);
+		const getShallowSpy = sinon.spy(log.entryIndex, "getShallow");
+		try {
+			const messages = [];
+			for await (const message of createExchangeHeadsMessages(log, [
+				leftHead,
+				rightHead,
+			])) {
+				messages.push(message);
+			}
+
+			expect(messages).to.have.length(1);
+			expect(messages[0]!.heads).to.have.length(2);
+			expect(messages[0]!.heads.map((head) => head.entry.hash)).to.deep.equal([
+				leftHead.hash,
+				rightHead.hash,
+			]);
+			expect(messages[0]!.heads[0]!.gidRefrences).to.deep.equal(
+				expectedLeftReferences,
+			);
+			expect(messages[0]!.heads[1]!.gidRefrences).to.deep.equal(
+				expectedRightReferences,
+			);
+			expect(
+				uniqueReferenceGidRowsBatchSpy.calledOnceWithExactly([
+					leftHead.hash,
+					rightHead.hash,
+				]),
+			).to.equal(true);
+			expect(getShallowSpy.callCount).equal(0);
+		} finally {
+			getShallowSpy.restore();
+			uniqueReferenceGidRowsBatchSpy.restore();
+			await log.close();
+		}
+	});
 });


### PR DESCRIPTION
## Summary
- add native log graph batch rows for exchange reference planning
- expose `uniqueReferenceGidRowsBatch()` through @peerbit/log-rust and EntryIndex
- use the native batch row path for multi-head `createExchangeHeadsMessages()` while preserving visited-hash filtering
- keep the existing single-head `uniqueReferenceGids()` path unchanged

## Benchmark
Local focused node microbench, 2026-05-11:
- setup: 1000 two-parent exchange heads, 50 repeated message-building passes
- native reference row batch: 87.21 ms total, about 573k heads/sec
- forced fallback `allEntriesWithUniqueGids`: 2424.75 ms total, about 20.6k heads/sec
- effect: about 27.8x faster for this multi-head reference-planning shape

## Test Plan
- cargo test (packages/log/rust)
- pnpm --filter @peerbit/log-rust run build
- pnpm --filter @peerbit/log-rust exec aegir test -t node --grep "plans unique reference gids"
- pnpm --filter @peerbit/log run build
- pnpm --filter @peerbit/shared-log run build
- pnpm --filter @peerbit/shared-log exec aegir test -t node --grep "uses native graph reference gids for multi-head messages"
- pnpm --filter @peerbit/shared-log exec aegir test -t node --grep "exchange heads"
- pnpm exec eslint packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/src/entry-index.ts packages/programs/data/shared-log/src/exchange-heads.ts packages/programs/data/shared-log/test/exchange-heads.spec.ts
- cargo fmt --manifest-path packages/log/rust/Cargo.toml --check
- git diff --check