### PR TITLE
Batch native prune request metadata

### DIFF
--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -41,6 +41,12 @@ export type NativeLogHeadDataEntry = {
 	};
 };
 
+export type NativeLogEntryMetadata = {
+	hash: string;
+	gid: string;
+	data?: Uint8Array;
+};
+
 export type NativeJoinPlan = {
 	skip: boolean;
 	missingParents: string[];
@@ -176,6 +182,7 @@ type NativeLogIndexHandle = {
 	max_head_data_u32_batch: (gids: string[]) => Array<number | undefined>;
 	head_join_entries: (gid?: string) => unknown[];
 	child_join_entries: (hash: string) => unknown[];
+	entry_metadata_batch: (hashes: string[]) => unknown[];
 	unique_reference_gids: (hash: string) => string[] | undefined;
 	unique_reference_gid_rows_batch: (
 		hashes: string[],
@@ -748,6 +755,26 @@ export class LogGraphIndex {
 						},
 					},
 				},
+			};
+		});
+	}
+
+	entryMetadataBatch(
+		hashes: Iterable<string>,
+	): Array<NativeLogEntryMetadata | undefined> {
+		return this.native.entry_metadata_batch([...hashes]).map((row) => {
+			if (!row) {
+				return undefined;
+			}
+			const [hash, gid, data] = row as [
+				string,
+				string,
+				Uint8Array | undefined,
+			];
+			return {
+				hash,
+				gid,
+				data,
 			};
 		});
 	}

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -332,6 +332,20 @@ impl LogGraphIndex {
             .collect()
     }
 
+    pub fn entry_metadata_batch(
+        &self,
+        hashes: &[String],
+    ) -> Vec<Option<(String, String, Option<Vec<u8>>)>> {
+        hashes
+            .iter()
+            .map(|hash| {
+                self.entries
+                    .get(hash)
+                    .map(|entry| (entry.hash.clone(), entry.gid.clone(), entry.data.clone()))
+            })
+            .collect()
+    }
+
     pub fn unique_reference_gid_rows(&self, hash: &str) -> Option<Vec<(String, String)>> {
         let entry = self.entries.get(hash)?;
         if entry.entry_type == ENTRY_TYPE_CUT {
@@ -1075,6 +1089,13 @@ impl NativeLogIndex {
 
     pub fn child_join_entries(&self, hash: &str) -> Array {
         log_join_entries_to_rows(self.inner.child_join_entries(hash))
+    }
+
+    pub fn entry_metadata_batch(&self, hashes: Array) -> Result<Array, JsValue> {
+        let hashes = strings_from_array(hashes)?;
+        Ok(log_optional_entry_metadata_to_rows(
+            self.inner.entry_metadata_batch(&hashes),
+        ))
     }
 
     pub fn unique_reference_gids(&self, hash: &str) -> JsValue {
@@ -2040,6 +2061,27 @@ fn log_join_entries_to_rows(values: Vec<LogIndexEntry>) -> Array {
         row.push(&JsValue::from_f64(entry.logical as f64));
         row.push(&JsValue::from_f64(entry.entry_type as f64));
         row.push(&strings_to_array(entry.next));
+        out.push(&row);
+    }
+    out
+}
+
+fn log_optional_entry_metadata_to_rows(
+    values: Vec<Option<(String, String, Option<Vec<u8>>)>>,
+) -> Array {
+    let out = Array::new();
+    for value in values {
+        let Some((hash, gid, data)) = value else {
+            out.push(&JsValue::UNDEFINED);
+            continue;
+        };
+        let row = Array::new();
+        row.push(&JsValue::from_str(&hash));
+        row.push(&JsValue::from_str(&gid));
+        match data {
+            Some(data) => row.push(&Uint8Array::from(data.as_slice())),
+            None => row.push(&JsValue::UNDEFINED),
+        };
         out.push(&row);
     }
     out

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -248,6 +248,14 @@ describe("native log graph index", () => {
 		index.put(entry("c", "g", [], 3n));
 
 		expect([...index.hasMany(["missing", "a", "c"])]).to.deep.equal(["a", "c"]);
+		expect(index.entryMetadataBatch(["missing", "a"])).to.deep.equal([
+			undefined,
+			{
+				hash: "a",
+				gid: "g",
+				data: undefined,
+			},
+		]);
 	});
 
 	it("sums payload sizes", async () => {

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -181,6 +181,9 @@ export type NativeLogGraph = {
 	headEntries: (gid?: string) => SortableEntry[];
 	joinHeadEntries: (gid?: string) => NativeLogJoinEntry[];
 	childJoinEntries: (hash: string) => NativeLogJoinEntry[];
+	entryMetadataBatch?: (
+		hashes: Iterable<string>,
+	) => Array<NativeLogEntryMetadata | undefined>;
 	uniqueReferenceGids: (hash: string) => string[] | undefined;
 	uniqueReferenceGidRowsBatch?: (
 		hashes: Iterable<string>,
@@ -224,6 +227,12 @@ export type NativeLogHeadDataEntry = {
 	};
 };
 
+export type NativeLogEntryMetadata = {
+	hash: string;
+	gid: string;
+	data?: Uint8Array;
+};
+
 type ResolveFullyOptions =
 	| true
 	| {
@@ -239,6 +248,7 @@ type ResolveFullyOptions =
 				| boolean;
 			ignoreMissing?: boolean;
 	  };
+
 type ResolveShapeOptions = { type: "shape"; shape: Shape };
 export type MaybeResolveOptions =
 	| false
@@ -968,6 +978,19 @@ export class EntryIndex<T> {
 			return { id: toId(k), value: pending };
 		}
 		return this.properties.index.get(toId(k));
+	}
+
+	getNativeEntryMetadataBatch(
+		hashes: Iterable<string>,
+	): Array<NativeLogEntryMetadata | undefined> | undefined {
+		if (!this.properties.nativeGraph) {
+			return undefined;
+		}
+		const normalized = [...hashes];
+		if (normalized.length === 0) {
+			return [];
+		}
+		return this.properties.nativeGraph.graph.entryMetadataBatch?.(normalized);
 	}
 
 	async has(k: string) {

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -348,6 +348,39 @@ describe("native graph", () => {
 		}
 	});
 
+	it("batches entry metadata lookups from the native graph", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			appendDurability: "strict",
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+		});
+		const { entry } = await log.append(new Uint8Array([1]), {
+			meta: { next: [], data: absoluteReplicaData(3) },
+		});
+
+		const nativeGraph = log.entryIndex.properties.nativeGraph!.graph;
+		const entryMetadataBatchSpy = sinon.spy(nativeGraph, "entryMetadataBatch");
+		const indexGetSpy = sinon.spy(log.entryIndex.properties.index, "get");
+		try {
+			const rows = log.entryIndex.getNativeEntryMetadataBatch([
+				"missing",
+				entry.hash,
+			]);
+			expect(rows).to.not.equal(undefined);
+			expect(rows![0]).equal(undefined);
+			expect(rows![1]!.hash).equal(entry.hash);
+			expect(rows![1]!.gid).equal(entry.meta.gid);
+			expect([...(rows![1]!.data ?? [])]).to.deep.equal([0, 3, 0, 0, 0]);
+			expect(entryMetadataBatchSpy.callCount).equal(1);
+			expect(indexGetSpy.callCount).equal(0);
+		} finally {
+			indexGetSpy.restore();
+			entryMetadataBatchSpy.restore();
+			await log.close();
+		}
+	});
+
 	it("reads memory usage from the native graph", async () => {
 		const log = new Log<Uint8Array>();
 		await log.open(store, signKey, {

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -6263,8 +6263,12 @@ export class SharedLog<
 			} else if (msg instanceof RequestIPrune) {
 				const hasAndIsLeader: string[] = [];
 				const from = context.from.hashcode();
+				const nativeEntryMetadata = this._nativeRangePlanner
+					? this.log.entryIndex.getNativeEntryMetadataBatch(msg.hashes)
+					: undefined;
 
-				for (const hash of msg.hashes) {
+				for (let i = 0; i < msg.hashes.length; i++) {
+					const hash = msg.hashes[i]!;
 					this.removePruneRequestSent(hash, from);
 					this.removeEntriesKnownByPeer([hash], from);
 
@@ -6276,35 +6280,57 @@ export class SharedLog<
 						outGoingPrunes.delete(from);
 					}
 
-					const indexedEntry = await this.log.entryIndex.getShallow(hash);
+					const nativeEntry = nativeEntryMetadata?.[i];
+					const indexedEntry = nativeEntry
+						? undefined
+						: await this.log.entryIndex.getShallow(hash);
 					let isLeader = false;
 
 					if (
-						indexedEntry &&
+						(nativeEntry || indexedEntry) &&
 						!this._pendingDeletes.has(hash) &&
 						(await this.log.blocks.has(hash))
 					) {
+						const gid = nativeEntry?.gid ?? indexedEntry!.value.meta.gid;
+						const replicas = decodeReplicas({
+							meta: {
+								data: nativeEntry?.data ?? indexedEntry!.value.meta.data,
+							},
+						}).getValue(this);
+
 						this.removePeerFromGidPeerHistory(
 							context.from!.hashcode(),
-							indexedEntry!.value.meta.gid,
+							gid,
 						);
 
-						await this._waitForEntryReplicators(
-							indexedEntry.value,
-							decodeReplicas(indexedEntry.value).getValue(this),
-							[
-								{
-									key: this.node.identity.publicKey.hashcode(),
-									replicator: true,
-								},
-							],
+						const waitFor: WaitForReplicator[] = [
 							{
-								onLeader: (key) => {
-									isLeader =
-										isLeader || key === this.node.identity.publicKey.hashcode();
-								},
+								key: this.node.identity.publicKey.hashcode(),
+								replicator: true,
 							},
-						);
+						];
+						const waitOptions: WaitForReplicatorsOptions<R> = {
+							onLeader: (key) => {
+								isLeader =
+									isLeader || key === this.node.identity.publicKey.hashcode();
+							},
+						};
+
+						if (nativeEntry) {
+							await this._waitForGidReplicators(
+								gid,
+								replicas,
+								waitFor,
+								waitOptions,
+							);
+						} else {
+							await this._waitForEntryReplicators(
+								indexedEntry!.value,
+								replicas,
+								waitFor,
+								waitOptions,
+							);
+						}
 					}
 
 					if (isLeader) {
@@ -7141,6 +7167,35 @@ export class SharedLog<
 			waitFor,
 			options,
 		);
+	}
+
+	private async _waitForGidReplicators(
+		gid: string,
+		replicas: number,
+		waitFor: WaitForReplicator[],
+		options: WaitForReplicatorsOptions<R> = {
+			timeout: this.waitForReplicatorTimeout,
+		},
+	): Promise<LeaderMap | false> {
+		if (!this._nativeRangePlanner) {
+			return false;
+		}
+		return this.waitForLeaderSelection(waitFor, options, async (checkOptions) => {
+			const plan =
+				(await this._findEntryAssignmentPlanFromHashGid(
+					gid,
+					replicas,
+					checkOptions,
+				)) ??
+				(await this._findLeaderPlanFromHashGid(gid, replicas, checkOptions));
+			if (!plan) {
+				return new Map();
+			}
+			for (const key of plan.leaders.keys()) {
+				checkOptions.onLeader?.(key);
+			}
+			return plan.leaders;
+		});
 	}
 
 	private async waitForLeaderSelection(


### PR DESCRIPTION
## Summary
- add native log graph `entryMetadataBatch()` for hash -> `{ gid, data }` metadata preflight
- expose it through @peerbit/log-rust and EntryIndex
- add a shared-log gid-native replicator wait helper
- use native metadata + gid-native leader confirmation in `RequestIPrune` when native graph/range planning is available
- keep per-hash `blocks.has()` unchanged; batch block presence needs a separate storage-aware API

## Benchmark
Local focused node microbench, 2026-05-11:
- setup: 1000 native graph entries, SQLite entry index, 30 repeated metadata passes
- old SQLite-backed sequential `getShallow` metadata reads: 530.43 ms for 30k metadata results, about 56.6k entries/sec
- new native `entryMetadataBatch`: 33.41 ms for the same 30k metadata results, about 897.8k entries/sec
- effect: about 15.9x faster for this persistent-index metadata preflight shape

## Notes
During exploration, a transparent `getShallowMany()` replacement was both unsafe for `RequestIPrune` and slower against the in-memory Hashmap index. This PR intentionally uses a prune-specific native metadata shape instead of fabricating shallow entries.

## Test Plan
- cargo test (packages/log/rust)
- pnpm --filter @peerbit/log-rust run build
- pnpm --filter @peerbit/log-rust exec aegir test -t node --grep "batches membership checks"
- pnpm --filter @peerbit/log run build
- pnpm --filter @peerbit/log exec aegir test -t node --grep "batches entry metadata lookups"
- pnpm --filter @peerbit/shared-log run build
- pnpm --filter @peerbit/shared-log exec aegir test -t node --grep "will prune on put 300 after join"
- pnpm --filter @peerbit/shared-log exec aegir test -t node --grep "does not confirm checked prune from a shallow-only entry"
- pnpm exec eslint packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/src/entry-index.ts packages/log/test/native-graph.spec.ts packages/programs/data/shared-log/src/index.ts
- cargo fmt --manifest-path packages/log/rust/Cargo.toml --check
- git diff --check