### PR TITLE
Batch local block presence checks

### DIFF
--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -210,6 +210,7 @@ type NativeLogBlockStoreHandle = {
 	get: (key: string) => Uint8Array | undefined;
 	get_many: (keys: string[]) => Array<Uint8Array | undefined>;
 	has: (key: string) => boolean;
+	has_many: (keys: string[]) => boolean[];
 	put: (key: string, value: Uint8Array) => void;
 	put_many: (keys: string[], values: Uint8Array[]) => void;
 	delete: (key: string) => boolean;
@@ -897,6 +898,10 @@ export class NativeLogBlockStore {
 
 	async has(cid: string): Promise<boolean> {
 		return this.native.has(cid);
+	}
+
+	async hasMany(cids: string[]): Promise<boolean[]> {
+		return this.native.has_many(cids);
 	}
 
 	async rm(cid: string): Promise<void> {

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -593,6 +593,14 @@ impl NativeLogBlockStore {
         self.entries.contains_key(key)
     }
 
+    pub fn has_many(&self, keys: Array) -> Result<Array, JsValue> {
+        let present = Array::new();
+        for key in strings_from_array(keys)? {
+            present.push(&JsValue::from_bool(self.entries.contains_key(&key)));
+        }
+        Ok(present)
+    }
+
     pub fn put(&mut self, key: String, value: Vec<u8>) {
         self.put_entry(key, value);
     }

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -601,6 +601,10 @@ describe("native EntryV0 encoding", () => {
 		expect(chain).to.have.length(3);
 		expect(index.heads()).to.deep.equal([chain![2]!.cid]);
 		expect(index.children("root")).to.deep.equal([chain![0]!.cid]);
+		expect(await blockStore.hasMany([chain![1]!.cid, "missing"])).to.deep.equal([
+			true,
+			false,
+		]);
 		for (const prepared of chain!) {
 			expect(prepared.bytes).equal(undefined);
 			const stored = await blockStore.get(prepared.cid);

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -6266,6 +6266,7 @@ export class SharedLog<
 				const nativeEntryMetadata = this._nativeRangePlanner
 					? this.log.entryIndex.getNativeEntryMetadataBatch(msg.hashes)
 					: undefined;
+				const presentBlocks = await this.log.blocks.hasMany?.(msg.hashes);
 
 				for (let i = 0; i < msg.hashes.length; i++) {
 					const hash = msg.hashes[i]!;
@@ -6289,7 +6290,9 @@ export class SharedLog<
 					if (
 						(nativeEntry || indexedEntry) &&
 						!this._pendingDeletes.has(hash) &&
-						(await this.log.blocks.has(hash))
+						(presentBlocks
+							? presentBlocks[i] === true
+							: await this.log.blocks.has(hash))
 					) {
 						const gid = nativeEntry?.gid ?? indexedEntry!.value.meta.gid;
 						const replicas = decodeReplicas({

--- a/packages/transport/blocks-interface/src/index.ts
+++ b/packages/transport/blocks-interface/src/index.ts
@@ -26,6 +26,13 @@ export interface Blocks extends WaitForPeer {
 		data: Array<Uint8Array | { block: Block<any, any, any, any>; cid: string }>,
 	): MaybePromise<string[]>;
 	has(cid: string): MaybePromise<boolean>;
+	/**
+	 * Return local-storage presence flags aligned with the input CIDs.
+	 *
+	 * This must not perform remote reads; callers use it to replace repeated
+	 * `has(...)` probes without changing block-fetch semantics.
+	 */
+	hasMany?(cids: string[]): MaybePromise<boolean[]>;
 	get(cid: string, options?: GetOptions): MaybePromise<Uint8Array | undefined>;
 	getMany?(
 		cids: string[],

--- a/packages/transport/blocks/src/any-blockstore.ts
+++ b/packages/transport/blocks/src/any-blockstore.ts
@@ -186,7 +186,35 @@ export class AnyBlockStore implements Blocks {
 	}
 
 	async has(cid: string) {
-		return !!(await this._store.get(cid));
+		try {
+			return !!(await this._store.get(cid));
+		} catch (error: any) {
+			if (
+				typeof error?.code === "string" &&
+				error?.code?.indexOf("LEVEL_NOT_FOUND") !== -1
+			) {
+				return false;
+			}
+			throw error;
+		}
+	}
+
+	async hasMany(cids: string[]): Promise<boolean[]> {
+		const store = this._store as AnyStore & {
+			getMany?: (
+				keys: string[],
+			) => Promise<Array<Uint8Array | undefined>> | Array<Uint8Array | undefined>;
+			hasMany?: (keys: string[]) => Promise<boolean[]> | boolean[];
+		};
+		if (typeof store.hasMany === "function") {
+			return store.hasMany(cids);
+		}
+		if (typeof store.getMany === "function") {
+			const values = await store.getMany(cids);
+			return values.map((value) => value != null);
+		}
+
+		return Promise.all(cids.map((cid) => this.has(cid)));
 	}
 
 	async start(): Promise<void> {

--- a/packages/transport/blocks/src/interface.ts
+++ b/packages/transport/blocks/src/interface.ts
@@ -13,6 +13,7 @@ export interface BlockStore extends IBlockStore {
 		cids: string[],
 		options?: GetOptions,
 	): Promise<Array<Uint8Array | undefined>>;
+	hasMany(cids: string[]): Promise<boolean[]>;
 	rmMany(cids: string[]): Promise<number | void>;
 	start(): Promise<void>;
 	stop(): Promise<void>;

--- a/packages/transport/blocks/src/libp2p.ts
+++ b/packages/transport/blocks/src/libp2p.ts
@@ -144,6 +144,9 @@ export class DirectBlock extends DirectStream implements IBlocks {
 	async has(cid: string) {
 		return this.remoteBlocks.has(cid);
 	}
+	async hasMany(cids: string[]): Promise<boolean[]> {
+		return this.remoteBlocks.hasMany(cids);
+	}
 	async get(
 		cid: string,
 		options?: GetOptions | undefined,

--- a/packages/transport/blocks/src/remote.ts
+++ b/packages/transport/blocks/src/remote.ts
@@ -347,6 +347,10 @@ export class RemoteBlocks implements IBlocks {
 		return this.localStore.has(cid);
 	}
 
+	async hasMany(cids: string[]): Promise<boolean[]> {
+		return this.localStore.hasMany(cids);
+	}
+
 	async get(
 		cid: string,
 		options?: GetOptions | undefined,

--- a/packages/transport/blocks/test/level.spec.ts
+++ b/packages/transport/blocks/test/level.spec.ts
@@ -65,7 +65,13 @@ describe(`level`, function () {
 			datas[1],
 			undefined,
 		]);
+		expect(await store.hasMany(["missing", ...cids])).to.deep.equal([
+			false,
+			true,
+			true,
+		]);
 		expect(await store.rmMany([cids[0], "missing"])).to.equal(1);
 		expect(await store.getMany(cids)).to.deep.equal([undefined, datas[1]]);
+		expect(await store.hasMany(cids)).to.deep.equal([false, true]);
 	});
 });

--- a/packages/utils/any-store/interface/src/index.ts
+++ b/packages/utils/any-store/interface/src/index.ts
@@ -5,6 +5,7 @@ export interface AnyStore {
 	close(): MaybePromise<void>;
 	open(): MaybePromise<void>;
 	get(key: string): MaybePromise<Uint8Array | undefined>;
+	hasMany?(keys: string[]): MaybePromise<boolean[]>;
 	put(key: string, value: Uint8Array): MaybePromise<void>;
 	del(key: string): MaybePromise<void>;
 	sublevel(name: string): MaybePromise<AnyStore>;

--- a/packages/utils/any-store/rust/src/index.ts
+++ b/packages/utils/any-store/rust/src/index.ts
@@ -6,6 +6,7 @@ import {
 
 type NativeAnyStore = {
 	get(key: string): Uint8Array | undefined;
+	has_many(keys: string[]): boolean[];
 	put(key: string, value: Uint8Array): void;
 	delete(key: string): boolean;
 	put_many(keys: string[], values: Uint8Array[]): void;
@@ -212,6 +213,11 @@ export class RustAnyStore implements AnyStore {
 		return native
 			.get_many(Array.from(keys))
 			.map((value) => (value == null ? undefined : copyBytes(value)));
+	}
+
+	async hasMany(keys: string[]): Promise<boolean[]> {
+		const native = await this.ensureOpen();
+		return native.has_many(keys);
 	}
 
 	async sublevel(name: string): Promise<AnyStore> {

--- a/packages/utils/any-store/rust/src/lib.rs
+++ b/packages/utils/any-store/rust/src/lib.rs
@@ -38,6 +38,14 @@ impl NativeAnyStore {
         self.entries.get(key).cloned()
     }
 
+    pub fn has_many(&self, keys: Array) -> Result<Array, JsValue> {
+        let present = Array::new();
+        for key in parse_keys(&keys).map_err(js_error)? {
+            present.push(&JsValue::from_bool(self.entries.contains_key(&key)));
+        }
+        Ok(present)
+    }
+
     pub fn put(&mut self, key: String, value: Vec<u8>) {
         let value_len = value.len();
         if let Some(previous) = self.entries.insert(key, value) {
@@ -382,6 +390,19 @@ impl NativeRedbAnyStore {
             };
         }
         Ok(values)
+    }
+
+    pub fn has_many(&self, keys: Array) -> Result<Array, JsValue> {
+        let keys = parse_keys(&keys).map_err(js_error)?;
+        let txn = self.db.begin_read().map_err(external_error)?;
+        let table = txn.open_table(REDB_TABLE).map_err(external_error)?;
+        let present = Array::new();
+        for key in keys {
+            present.push(&JsValue::from_bool(
+                table.get(key.as_str()).map_err(external_error)?.is_some(),
+            ));
+        }
+        Ok(present)
     }
 
     pub fn put(&mut self, key: String, value: Vec<u8>) -> Result<(), JsValue> {

--- a/packages/utils/any-store/rust/test/index.spec.ts
+++ b/packages/utils/any-store/rust/test/index.spec.ts
@@ -67,6 +67,11 @@ describe("@peerbit/any-store-rust", () => {
 			new Uint8Array([2, 3]),
 			undefined,
 		]);
+		expect(await store.hasMany(["c", "a", "b"])).to.deep.equal([
+			false,
+			true,
+			true,
+		]);
 		expect(await store.size()).to.equal(3);
 		expect(await store.delMany(["a", "missing"])).to.equal(1);
 		expect(await collectKeys(store)).to.deep.equal(["b"]);


### PR DESCRIPTION
## Summary
- add optional local-only `hasMany` presence APIs to AnyStore and block stores
- implement native boolean-vector `has_many` for `@peerbit/any-store-rust` and `@peerbit/log-rust` block stores
- use batch block presence in `RequestIPrune`, falling back to scalar `blocks.has()` when unavailable
- make `AnyBlockStore.has()` treat Level not-found as false, matching `get()` missing-block behavior

## Benchmark
Local node microbench, 2026-05-11: 1000 present blocks + 1000 missing CIDs, 100 repeated passes, 200k presence probes total.

- `AnyBlockStore(RustAnyStore)` sequential `has`: 105.11 ms, ~1.90M probes/sec
- `AnyBlockStore(RustAnyStore)` `hasMany`: 47.46 ms, ~4.21M probes/sec
- speedup: ~2.2x for Rust AnyStore-backed block presence
- `NativeLogBlockStore` sequential `has`: 45.49 ms, ~4.40M probes/sec
- `NativeLogBlockStore` `hasMany`: 46.43 ms, ~4.31M probes/sec, effectively neutral because scalar native `has` is already cheap

## Test Plan
- `pnpm --filter @peerbit/any-store-interface run build`
- `pnpm --filter @peerbit/any-store-rust run build`
- `pnpm --filter @peerbit/blocks-interface run build`
- `pnpm --filter @peerbit/blocks run build`
- `pnpm --filter @peerbit/log-rust run build`
- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/shared-log run build`
- `cargo test --manifest-path packages/utils/any-store/rust/Cargo.toml`
- `cargo test --manifest-path packages/log/rust/Cargo.toml`
- `pnpm --filter @peerbit/any-store-rust exec aegir test -t node --grep "applies batched mutations"`
- `pnpm --filter @peerbit/blocks exec aegir test -t node --grep "gets and removes many blocks"`
- `pnpm --filter @peerbit/log-rust exec aegir test -t node --grep "commits prepared plain entry blocks"`
- `pnpm --filter @peerbit/shared-log exec aegir test -t node --grep "will prune on put 300 after join"`
- `pnpm --filter @peerbit/shared-log exec aegir test -t node --grep "does not confirm checked prune from a shallow-only entry"`
- targeted eslint
- rust fmt checks
- `git diff --check`