### PR TITLE
Add native independent entry batch commit

### DIFF
--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -171,6 +171,17 @@ type NativeLogIndexHandle = {
 		metaData: Uint8Array | undefined,
 		payloadData: Uint8Array,
 	) => EntryV0CommittedPlainEntryRow;
+	prepare_entry_v0_plain_entries_commit_blocks_and_put_with_builder: (
+		builder: NativeEntryV0PlainBuilderHandle,
+		blockStore: NativeLogBlockStoreHandle,
+		wallTimes: BigUint64Array,
+		logicals: Uint32Array,
+		gids: string[],
+		nexts: string[][],
+		type: number,
+		metaDatas: Array<Uint8Array | undefined>,
+		payloadDatas: Uint8Array[],
+	) => EntryV0CommittedPlainEntryRow[];
 	delete: (hash: string) => boolean;
 	heads: (gid?: string) => string[];
 	has_head: (gid?: string) => boolean;
@@ -641,6 +652,34 @@ export class LogGraphIndex {
 		);
 	}
 
+	prepareEntryV0PlainEntriesCommit(
+		input: EntryV0PlainEntriesInput,
+		blockStore: unknown,
+	): EntryV0CommittedPlainEntry[] | undefined {
+		const nativeBlockStore = nativeLogBlockStoreHandle(blockStore);
+		if (!nativeBlockStore) {
+			return undefined;
+		}
+		const columns = plainEntriesInputColumns(input);
+		if (!columns) {
+			return [];
+		}
+		const builder = this.getPlainEntryBuilder(input);
+		return committedPlainEntryRows(
+			this.native.prepare_entry_v0_plain_entries_commit_blocks_and_put_with_builder(
+				builder,
+				nativeBlockStore,
+				columns.wallTimes,
+				columns.logicals,
+				input.gids,
+				input.nexts,
+				input.type ?? 0,
+				columns.metaDatas,
+				input.payloadDatas,
+			),
+		);
+	}
+
 	delete(hash: string): boolean {
 		return this.native.delete(hash);
 	}
@@ -982,6 +1021,19 @@ export type EntryV0PlainEntryInput = {
 	payloadData: Uint8Array;
 };
 
+export type EntryV0PlainEntriesInput = {
+	clockId: Uint8Array;
+	privateKey: Uint8Array;
+	publicKey: Uint8Array;
+	wallTimes: Array<bigint | number | string>;
+	logicals?: number[];
+	gids: string[];
+	nexts: string[][];
+	type?: number;
+	metaDatas?: Array<Uint8Array | undefined>;
+	payloadDatas: Uint8Array[];
+};
+
 export type EntryV0PreparedPlainEntry = EntryV0EncodedStorage & {
 	byteLength: number;
 	signature: Uint8Array;
@@ -1026,6 +1078,30 @@ const plainChainInputColumns = (input: EntryV0PlainChainInput) => {
 		return undefined;
 	}
 	if (input.wallTimes.length !== input.payloadDatas.length) {
+		throw new Error("Expected equal column lengths");
+	}
+	const wallTimes = new BigUint64Array(input.wallTimes.length);
+	const logicals = new Uint32Array(input.payloadDatas.length);
+	const metaDatas = new Array<Uint8Array | undefined>(
+		input.payloadDatas.length,
+	);
+	for (let i = 0; i < input.payloadDatas.length; i++) {
+		wallTimes[i] = BigInt(input.wallTimes[i]!);
+		logicals[i] = input.logicals?.[i] ?? 0;
+		metaDatas[i] = input.metaDatas?.[i];
+	}
+	return { wallTimes, logicals, metaDatas };
+};
+
+const plainEntriesInputColumns = (input: EntryV0PlainEntriesInput) => {
+	if (input.payloadDatas.length === 0) {
+		return undefined;
+	}
+	if (
+		input.wallTimes.length !== input.payloadDatas.length ||
+		input.gids.length !== input.payloadDatas.length ||
+		input.nexts.length !== input.payloadDatas.length
+	) {
 		throw new Error("Expected equal column lengths");
 	}
 	const wallTimes = new BigUint64Array(input.wallTimes.length);

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -1037,6 +1037,36 @@ impl NativeLogIndex {
         Ok(row)
     }
 
+    pub fn prepare_entry_v0_plain_entries_commit_blocks_and_put_with_builder(
+        &mut self,
+        builder: &NativeEntryV0PlainBuilder,
+        block_store: &mut NativeLogBlockStore,
+        wall_times: BigUint64Array,
+        logicals: Uint32Array,
+        gids: Array,
+        nexts: Array,
+        entry_type: u8,
+        meta_datas: Array,
+        payload_datas: Array,
+    ) -> Result<Array, JsValue> {
+        let (rows, entries, blocks) = prepare_entry_v0_plain_entries_rows_with_signer(
+            &builder.clock_id,
+            &builder.public_key,
+            &builder.signing_key,
+            wall_times,
+            logicals,
+            gids,
+            nexts,
+            entry_type,
+            meta_datas,
+            payload_datas,
+            false,
+        )?;
+        block_store.put_entries(blocks);
+        self.inner.put_many(entries);
+        Ok(rows)
+    }
+
     pub fn delete(&mut self, hash: &str) -> bool {
         self.inner.delete(hash).is_some()
     }
@@ -1595,6 +1625,55 @@ fn prepare_entry_v0_plain_entry_row_with_signer(
         input.meta_data.clone(),
     );
     Ok((row, entry, next, (cid, storage)))
+}
+
+fn prepare_entry_v0_plain_entries_rows_with_signer(
+    clock_id: &[u8],
+    public_key: &[u8],
+    signing_key: &SigningKey,
+    wall_times: BigUint64Array,
+    logicals: Uint32Array,
+    gids: Array,
+    nexts: Array,
+    entry_type: u8,
+    meta_datas: Array,
+    payload_datas: Array,
+    include_storage_bytes: bool,
+) -> Result<(Array, Vec<LogIndexEntry>, Vec<(String, Vec<u8>)>), JsValue> {
+    let len = payload_datas.length();
+    if gids.length() != len || nexts.length() != len || meta_datas.length() != len {
+        return Err(JsValue::from_str("Expected equal column lengths"));
+    }
+    for numeric_len in [wall_times.length(), logicals.length()] {
+        if numeric_len != len {
+            return Err(JsValue::from_str("Expected equal column lengths"));
+        }
+    }
+
+    let out = Array::new();
+    let mut entries = Vec::with_capacity(len as usize);
+    let mut blocks = Vec::with_capacity(len as usize);
+    for i in 0..len {
+        let payload_data = required_bytes_from_array(&payload_datas, i, "payload")?;
+        let (row, entry, _initial_nexts, block) = prepare_entry_v0_plain_entry_row_with_signer(
+            clock_id,
+            public_key,
+            signing_key,
+            wall_times.get_index(i),
+            logicals.get_index(i),
+            required_string_from_array(&gids, i)?,
+            required_array_from_array(&nexts, i)?,
+            entry_type,
+            meta_datas.get(i),
+            Uint8Array::from(payload_data.as_slice()),
+            include_storage_bytes,
+        )?;
+        out.push(&row);
+        entries.push(entry);
+        blocks.push(block);
+    }
+
+    Ok((out, entries, blocks))
 }
 
 #[wasm_bindgen]

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -615,4 +615,48 @@ describe("native EntryV0 encoding", () => {
 			chain!.reduce((sum, prepared) => sum + prepared.byteLength, 0),
 		);
 	});
+
+	it("commits independent prepared plain entry batches natively", async () => {
+		const privateKey = fromHex(
+			"9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+		);
+		const publicKey = fromHex(
+			"d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+		);
+		const index = await createLogGraphIndex();
+		const blockStore = await createNativeLogBlockStore();
+
+		const entries = await index.prepareEntryV0PlainEntriesCommit(
+			{
+				clockId: publicKey,
+				privateKey,
+				publicKey,
+				wallTimes: [11n, 12n, 13n],
+				gids: ["gid-a", "gid-b", "gid-c"],
+				nexts: [[], [], []],
+				payloadDatas: [
+					new Uint8Array([1]),
+					new Uint8Array([2]),
+					new Uint8Array([3]),
+				],
+			},
+			blockStore,
+		);
+
+		expect(entries).to.have.length(3);
+		expect(index.heads().sort()).to.deep.equal(
+			entries!.map((entry) => entry.cid).sort(),
+		);
+		expect(index.heads("gid-a")).to.deep.equal([entries![0]!.cid]);
+		expect(index.heads("gid-b")).to.deep.equal([entries![1]!.cid]);
+		expect(index.heads("gid-c")).to.deep.equal([entries![2]!.cid]);
+		expect(await blockStore.size()).to.equal(
+			entries!.reduce((sum, prepared) => sum + prepared.byteLength, 0),
+		);
+		for (const prepared of entries!) {
+			const stored = await blockStore.get(prepared.cid);
+			expect(stored?.byteLength).equal(prepared.byteLength);
+			expect(await calculateRawCidV1(stored!)).equal(prepared.cid);
+		}
+	});
 });

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -169,6 +169,33 @@ export type NativeLogGraph = {
 		  }
 		| undefined
 	>;
+	prepareEntryV0PlainEntriesCommit?: (
+		input: {
+			clockId: Uint8Array;
+			privateKey: Uint8Array;
+			publicKey: Uint8Array;
+			wallTimes: Array<bigint | number | string>;
+			logicals?: number[];
+			gids: string[];
+			nexts: string[][];
+			type?: number;
+			metaDatas?: Array<Uint8Array | undefined>;
+			payloadDatas: Uint8Array[];
+		},
+		blockStore: unknown,
+	) => MaybePromise<
+		| Array<{
+				bytes?: Uint8Array;
+				cid: string;
+				byteLength: number;
+				signature: Uint8Array;
+				next: string[];
+				metaBytes: Uint8Array;
+				payloadBytes: Uint8Array;
+				signatureBytes: Uint8Array;
+		  }>
+		| undefined
+	>;
 	delete: (hash: string) => boolean;
 	clear: () => void;
 	heads: (gid?: string) => string[];

--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -93,6 +93,21 @@ type NativeEntryV0Graph = {
 		input: NativePlainEntryInput,
 		blockStore: unknown,
 	): MaybePromise<NativePreparedPlainEntry | undefined>;
+	prepareEntryV0PlainEntriesCommit?(
+		input: {
+			clockId: Uint8Array;
+			privateKey: Uint8Array;
+			publicKey: Uint8Array;
+			wallTimes: Array<bigint | number | string>;
+			logicals?: number[];
+			gids: string[];
+			nexts: string[][];
+			type?: number;
+			metaDatas?: Array<Uint8Array | undefined>;
+			payloadDatas: Uint8Array[];
+		},
+		blockStore: unknown,
+	): MaybePromise<NativePreparedPlainEntry[] | undefined>;
 };
 
 type NativeEntryV0Encoder = {


### PR DESCRIPTION
## Summary
- add a native graph/block-store API for committing many independent EntryV0 plain append entries in one native call
- keep each entry's gid and next list input-aligned, so future document batch puts do not collapse independent documents into one append chain/gid
- expose the native graph typing through `@peerbit/log` for the next document-layer fast path
- add coverage proving independent entries commit as independent heads with valid native block storage

## Benchmark
Local node microbench, 2026-05-11: 1000 independent entries, 20 repeated runs, native graph and native block store.

- scalar loop using cached native builder: 789.17 ms for 20k entries, ~25.3k entries/sec
- new independent batch API: 779.28 ms for 20k entries, ~25.7k entries/sec
- speedup: effectively neutral at this layer because Ed25519 signing dominates

This PR is mainly a correctness/foundation step for high-throughput document `putMany`: lower-log `appendMany` currently creates one causal chain with one gid, which is not the right primitive for independent document puts.

## Test Plan
- `pnpm --filter @peerbit/log-rust run build`
- `pnpm --filter @peerbit/log run build`
- `cargo test --manifest-path packages/log/rust/Cargo.toml`
- `pnpm --filter @peerbit/log-rust exec aegir test -t node --grep "commits independent prepared plain entry batches"`
- targeted eslint
- `cargo fmt --manifest-path packages/log/rust/Cargo.toml --check`
- `git diff --check`