### PR TITLE
Add native document putMany fast path

### DIFF
--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -1179,6 +1179,7 @@ export class EntryIndex<T> {
 				nativeGraphUpdated?: boolean;
 				nativeBlocksCommitted?: boolean;
 			};
+			heads?: boolean[];
 			deferIndexWrite?: boolean;
 		},
 	) {
@@ -1242,7 +1243,7 @@ export class EntryIndex<T> {
 			const nativeEntries: NativeLogEntry[] = [];
 			for (let i = 0; i < entries.length; i++) {
 				const entry = entries[i];
-				const isHead = i === entries.length - 1;
+				const isHead = properties.heads?.[i] ?? i === entries.length - 1;
 				if (properties.unique === true || !(await this.has(entry.hash))) {
 					this._length++;
 				}

--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -64,6 +64,19 @@ type NativePlainEntryInput = {
 	payloadData: Uint8Array;
 };
 
+type NativePlainEntriesInput = {
+	clockId: Uint8Array;
+	privateKey: Uint8Array;
+	publicKey: Uint8Array;
+	wallTimes: Array<bigint | number | string>;
+	logicals?: number[];
+	gids: string[];
+	nexts: string[][];
+	type?: number;
+	metaDatas?: Array<Uint8Array | undefined>;
+	payloadDatas: Uint8Array[];
+};
+
 type NativePreparedPlainEntry = {
 	bytes?: Uint8Array;
 	cid: string;
@@ -94,18 +107,7 @@ type NativeEntryV0Graph = {
 		blockStore: unknown,
 	): MaybePromise<NativePreparedPlainEntry | undefined>;
 	prepareEntryV0PlainEntriesCommit?(
-		input: {
-			clockId: Uint8Array;
-			privateKey: Uint8Array;
-			publicKey: Uint8Array;
-			wallTimes: Array<bigint | number | string>;
-			logicals?: number[];
-			gids: string[];
-			nexts: string[][];
-			type?: number;
-			metaDatas?: Array<Uint8Array | undefined>;
-			payloadDatas: Uint8Array[];
-		},
+		input: NativePlainEntriesInput,
 		blockStore: unknown,
 	): MaybePromise<NativePreparedPlainEntry[] | undefined>;
 };
@@ -605,6 +607,200 @@ export class EntryV0<T>
 		nativeBlockStore?: unknown;
 	}): Promise<Entry<T>[] | undefined> {
 		return (await EntryV0.createPlainAppendChainBatch(properties))?.entries;
+	}
+
+	static async createPlainAppendEntriesBatch<T>(properties: {
+		data: T[];
+		meta: {
+			clocks: () => Clock[];
+			gids: string[];
+			nexts: SortableEntry[][];
+			type?: EntryType;
+			datas?: Array<Uint8Array | undefined>;
+		};
+		encoding: Encoding<T>;
+		identity: Identity;
+		deferStore: boolean;
+		cachePreparedEntries?: boolean;
+		nativeGraph?: NativeEntryV0Graph;
+		nativeBlockStore?: unknown;
+	}): Promise<PreparedAppendChain<T> | undefined> {
+		if (!properties.deferStore) {
+			return undefined;
+		}
+		if (!(properties.identity instanceof Ed25519Keypair)) {
+			return undefined;
+		}
+		const nativeCommit = properties.nativeGraph?.prepareEntryV0PlainEntriesCommit;
+		if (!nativeCommit) {
+			return undefined;
+		}
+		if (
+			properties.meta.gids.length !== properties.data.length ||
+			properties.meta.nexts.length !== properties.data.length
+		) {
+			throw new Error("Expected one gid and next list per entry");
+		}
+
+		const clocks = properties.meta.clocks();
+		if (clocks.length !== properties.data.length) {
+			throw new Error("Expected one clock per entry");
+		}
+		for (let i = 0; i < clocks.length; i++) {
+			for (const next of properties.meta.nexts[i]!) {
+				if (
+					Timestamp.compare(next.meta.clock.timestamp, clocks[i]!.timestamp) >=
+					0
+				) {
+					throw new Error(
+						"Expecting next(s) to happen before entry, got: " +
+							next.meta.clock.timestamp +
+							" > " +
+							clocks[i]!.timestamp,
+					);
+				}
+			}
+		}
+
+		const payloadDatas = new Array<Uint8Array>(properties.data.length);
+		for (let i = 0; i < properties.data.length; i++) {
+			payloadDatas[i] = properties.encoding.encoder(properties.data[i]!);
+		}
+		const input: NativePlainEntriesInput = {
+			clockId: properties.identity.publicKey.bytes,
+			privateKey: properties.identity.privateKey.privateKey,
+			publicKey: properties.identity.publicKey.publicKey,
+			wallTimes: clocks.map((clock) => clock.timestamp.wallTime),
+			logicals: clocks.map((clock) => clock.timestamp.logical),
+			gids: properties.meta.gids,
+			nexts: properties.meta.nexts.map((nexts) =>
+				nexts.map((next) => next.hash),
+			),
+			type: properties.meta.type,
+			metaDatas: properties.meta.datas,
+			payloadDatas,
+		};
+		const preparedValue = nativeCommit.call(
+			properties.nativeGraph,
+			input,
+			properties.nativeBlockStore,
+		);
+		const prepared = isPromiseLike(preparedValue)
+			? await preparedValue
+			: preparedValue;
+		if (!prepared) {
+			return undefined;
+		}
+		if (prepared.length !== properties.data.length) {
+			throw new Error("Unexpected prepared entry batch length");
+		}
+
+		const entries: PreparedAppendChain<T>["entries"] = [];
+		const shallowEntries: PreparedAppendChain<T>["shallowEntries"] = [];
+		const nativeEntries: NonNullable<PreparedAppendChain<T>["nativeEntries"]> =
+			[];
+		const entryType = properties.meta.type ?? EntryType.APPEND;
+		for (let index = 0; index < prepared.length; index++) {
+			const preparedEntry = prepared[index]!;
+			const meta = new Meta({
+				clock: clocks[index]!,
+				gid: properties.meta.gids[index]!,
+				type: entryType,
+				data: properties.meta.datas?.[index],
+				next: preparedEntry.next,
+			});
+			const payload = new Payload<T>({
+				data: payloadDatas[index]!,
+				value: properties.data[index],
+				encoding: properties.encoding,
+			});
+			const signature = new SignatureWithKey({
+				signature: preparedEntry.signature,
+				publicKey: properties.identity.publicKey,
+				prehash: 0,
+			});
+			const entry = new EntryV0<T>({
+				meta: new DecryptedThing({
+					data: preparedEntry.metaBytes,
+					value: meta,
+				}),
+				payload: new DecryptedThing({
+					data: preparedEntry.payloadBytes,
+					value: payload,
+				}),
+				signatures: new Signatures({
+					signatures: [
+						new DecryptedThing({
+							data: preparedEntry.signatureBytes,
+							value: signature,
+						}),
+					],
+				}),
+				createdLocally: true,
+			});
+			if (properties.cachePreparedEntries === false) {
+				entry.hash = preparedEntry.cid;
+				entry.size = preparedEntry.byteLength;
+			} else {
+				if (!preparedEntry.bytes) {
+					throw new Error("Missing prepared entry bytes");
+				}
+				entry.hash = Entry.prepareMultihashBytes(
+					entry,
+					preparedEntry.bytes,
+					preparedEntry.cid,
+				);
+			}
+			entry._hashDigestBytes = preparedEntry.hashDigestBytes;
+			const shallowEntry = new ShallowEntry({
+				hash: entry.hash,
+				payloadSize: payload.byteLength,
+				head: true,
+				meta: new ShallowMeta({
+					gid: meta.gid,
+					data: meta.data,
+					clock: meta.clock,
+					next: meta.next,
+					type: meta.type,
+				}),
+			});
+			const nativeEntry =
+				properties.cachePreparedEntries === false
+					? undefined
+					: {
+							hash: entry.hash,
+							gid: meta.gid,
+							next: meta.next,
+							type: meta.type,
+							head: true,
+							payloadSize: payload.byteLength,
+							data: meta.data,
+							clock: {
+								timestamp: {
+									wallTime: meta.clock.timestamp.wallTime,
+									logical: meta.clock.timestamp.logical,
+								},
+							},
+						};
+			if (properties.cachePreparedEntries !== false) {
+				Entry.prepareShallowEntry(entry, shallowEntry);
+				Entry.prepareNativeLogEntry(entry, nativeEntry!);
+				entry.init({ encoding: properties.encoding });
+			}
+			entries.push(entry);
+			shallowEntries.push(shallowEntry);
+			if (nativeEntry) {
+				nativeEntries.push(nativeEntry);
+			}
+		}
+
+		return {
+			entries,
+			shallowEntries,
+			nativeEntries,
+			nativeGraphUpdated: true,
+			nativeBlocksCommitted: true,
+		};
 	}
 
 	static async createPlainAppendChainBatch<T>(properties: {

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -735,6 +735,89 @@ export class Log<T> {
 		return { entry, removed, change };
 	}
 
+	async appendLocallyPreparedManyIndependent(
+		data: T[],
+		options: AppendOptions<T> = {},
+		properties?: {
+			resolveTrimmedEntries?: boolean;
+		},
+	): Promise<
+		| {
+				entries: Entry<T>[];
+				removed: ShallowOrFullEntry<T>[];
+				change: Change<T>;
+		  }
+		| undefined
+	> {
+		if (data.length === 0) {
+			return {
+				entries: [],
+				removed: [],
+				change: { added: [], removed: [] },
+			};
+		}
+		if (
+			options.canAppend ||
+			options.onChange ||
+			options.meta?.type === EntryType.CUT
+		) {
+			throw new Error(
+				"appendLocallyPreparedManyIndependent only supports trusted plain local appends",
+			);
+		}
+
+		const appendOptions: AppendOptions<T> = {
+			...options,
+			__peerbitCanAppendAlreadyValidated: true,
+		};
+		const deferBlockStore = hasPutMany(this._storage);
+		const nativeAppendBatch = await this.createNativePlainAppendEntriesBatch(
+			data,
+			appendOptions,
+			deferBlockStore,
+		);
+		if (!nativeAppendBatch) {
+			return undefined;
+		}
+
+		const entries = nativeAppendBatch.entries;
+		try {
+			if (deferBlockStore && !nativeAppendBatch.nativeBlocksCommitted) {
+				await this.putAppendEntryBlocks(entries, nativeAppendBatch.blocks);
+			}
+			await this.putAppendEntries(
+				entries,
+				appendOptions,
+				[],
+				nativeAppendBatch,
+				entries.map(() => true),
+			);
+		} catch (error) {
+			if (nativeAppendBatch.nativeGraphUpdated) {
+				this.rollbackNativeAppendGraph(entries);
+			}
+			if (nativeAppendBatch.nativeBlocksCommitted) {
+				await this.rollbackNativeAppendBlocks(entries);
+			}
+			throw error;
+		}
+
+		for (const entry of entries) {
+			entry.init({ encoding: this._encoding, keychain: this._keychain });
+		}
+
+		const trimmed = await this.trim(appendOptions.trim, {
+			resolveDeletedEntries: properties?.resolveTrimmedEntries,
+		});
+		const removed = trimmed ?? [];
+		const change: Change<T> = {
+			added: entries.map((entry) => ({ head: true, entry })),
+			removed,
+		};
+
+		return { entries, removed, change };
+	}
+
 	async appendMany(
 		data: T[],
 		options: AppendOptions<T> = {},
@@ -877,6 +960,119 @@ export class Log<T> {
 		});
 	}
 
+	private async createNativePlainAppendEntriesBatch(
+		data: T[],
+		options: AppendOptions<T>,
+		deferBlockStore: boolean,
+	): Promise<PreparedAppendChain<T> | undefined> {
+		const canAppendAlreadyValidated =
+			options.__peerbitCanAppendAlreadyValidated === true;
+		if (
+			!deferBlockStore ||
+			data.length === 0 ||
+			options.encryption ||
+			options.signers ||
+			options.canAppend ||
+			(this._hasCustomCanAppend && !canAppendAlreadyValidated) ||
+			options.meta?.timestamp ||
+			options.meta?.type === EntryType.CUT ||
+			options.meta?.gidSeed ||
+			options.meta?.next
+		) {
+			return undefined;
+		}
+
+		const nativeGraph =
+			!this.entryIndex.properties.onGidRemoved &&
+			this.entryIndex.properties.nativeGraph?.graph
+				? this.entryIndex.properties.nativeGraph.graph
+				: undefined;
+
+		const gids = await Promise.all(
+			data.map(() => Promise.resolve(EntryV0.createGid())),
+		);
+		const clocks = data.map(
+			() =>
+				new Clock({
+					id: this._identity.publicKey.bytes,
+					timestamp: this._hlc.now(),
+				}),
+		);
+		const metaDatas = data.map(() => options.meta?.data);
+		const directBatch = nativeGraph?.prepareEntryV0PlainEntriesCommit
+			? await EntryV0.createPlainAppendEntriesBatch<T>({
+					data,
+					meta: {
+						clocks: () => clocks,
+						gids,
+						nexts: data.map(() => []),
+						type: options.meta?.type,
+						datas: metaDatas,
+					},
+					encoding: this._encoding,
+					identity: options.identity || this._identity,
+					deferStore: deferBlockStore,
+					cachePreparedEntries: false,
+					nativeGraph,
+					nativeBlockStore: this._storage,
+				})
+			: undefined;
+		if (directBatch) {
+			return directBatch;
+		}
+
+		const entries: Entry<T>[] = [];
+		const blocks: PreparedEntryBlock[] = [];
+		const shallowEntries: PreparedAppendChain<T>["shallowEntries"] = [];
+		const nativeEntries: NonNullable<PreparedAppendChain<T>["nativeEntries"]> =
+			[];
+		let nativeGraphUpdated = false;
+		let nativeBlocksCommitted = true;
+		for (let i = 0; i < data.length; i++) {
+			const prepared = await EntryV0.createPlainAppendChainBatch<T>({
+				data: [data[i]!],
+				meta: {
+					clocks: () => [clocks[i]!],
+					gid: gids[i]!,
+					type: options.meta?.type,
+					data: metaDatas[i],
+					next: [],
+				},
+				encoding: this._encoding,
+				identity: options.identity || this._identity,
+				deferStore: deferBlockStore,
+				cachePreparedEntries: false,
+				nativeGraph,
+				nativeBlockStore: this._storage,
+			});
+			if (!prepared) {
+				return undefined;
+			}
+			entries.push(prepared.entries[0]!);
+			if (prepared.blocks) {
+				blocks.push(...prepared.blocks);
+			}
+			shallowEntries.push(...prepared.shallowEntries);
+			if (prepared.nativeEntries) {
+				nativeEntries.push(...prepared.nativeEntries);
+			}
+			nativeGraphUpdated ||= prepared.nativeGraphUpdated === true;
+			nativeBlocksCommitted &&= prepared.nativeBlocksCommitted === true;
+		}
+
+		if (!nativeBlocksCommitted && blocks.length !== entries.length) {
+			return undefined;
+		}
+		return {
+			entries,
+			blocks: blocks.length > 0 ? blocks : undefined,
+			shallowEntries,
+			nativeEntries,
+			nativeGraphUpdated,
+			nativeBlocksCommitted,
+		};
+	}
+
 	private rollbackNativeAppendGraph(entries: Entry<T>[]) {
 		const graph = this.entryIndex.properties.nativeGraph?.graph;
 		if (!graph) {
@@ -1016,10 +1212,12 @@ export class Log<T> {
 		options: AppendOptions<T>,
 		externalNextHashes: string[],
 		preparedAppendChain?: PreparedAppendChain<T>,
+		heads?: boolean[],
 	) {
 		await this.entryIndex.putAppendBatch(entries, {
 			unique: true,
 			externalNextHashes,
+			heads,
 			prepared:
 				preparedAppendChain &&
 				entries.length === preparedAppendChain.entries.length

--- a/packages/programs/data/document/document/benchmark/document-put.ts
+++ b/packages/programs/data/document/document/benchmark/document-put.ts
@@ -16,6 +16,7 @@ import { Documents, type SetupOptions } from "../src/program.js";
 // - DOC_BYTES=1200
 // - DOC_SCENARIOS=compat-path,hybrid-anystore,simple-index,sqlite-index,native-graph,native-block-store,rust-peerbit,rust-peerbit-transient-index
 //   Add "-nonunique" to any scenario name to use default update-safe put semantics.
+//   Add "-putmany" to any unique scenario name to use one putMany call per measured batch.
 // - DOC_PROFILE_DEEP=1 reports lower shared-log/log phase timings.
 // - BENCH_JSON=1
 
@@ -40,8 +41,10 @@ const scenarioNames = (
 	.map((x) => x.trim())
 	.filter(Boolean);
 
-const scenarioBaseName = (name: string) => name.replace(/-nonunique$/, "");
-const scenarioUsesUniquePuts = (name: string) => !name.endsWith("-nonunique");
+const scenarioBaseName = (name: string) =>
+	name.replace(/-putmany$/, "").replace(/-nonunique$/, "");
+const scenarioUsesUniquePuts = (name: string) => !name.includes("-nonunique");
+const scenarioUsesPutMany = (name: string) => name.endsWith("-putmany");
 const profileDeep = process.env.DOC_PROFILE_DEEP === "1";
 
 @variant("document")
@@ -233,6 +236,17 @@ const runPuts = async (
 		...(scenarioUsesUniquePuts(scenario) ? { unique: true } : {}),
 		...(scenarioBaseName(scenario) === "compat-path" ? { canAppend } : {}),
 	};
+	if (scenarioUsesPutMany(scenario)) {
+		const docs = Array.from({ length: count }, () => createDocument());
+		if (profile) {
+			await time(profile, "totalPutMs", () =>
+				store.docs.putMany(docs, appendOptions),
+			);
+		} else {
+			await store.docs.putMany(docs, appendOptions);
+		}
+		return;
+	}
 	for (let i = 0; i < count; i++) {
 		const doc = createDocument();
 		if (profile) {
@@ -272,10 +286,22 @@ const runScenario = async (name: string): Promise<BenchRow> => {
 				profile,
 				"sharedAppendMs",
 			),
+			patchAsyncMethod(
+				store.docs.log as any,
+				"appendLocallyPreparedManyIndependent",
+				profile,
+				"sharedAppendMs",
+			),
 			patchAsyncMethod(store.docs.log.log, "append", profile, "logAppendMs"),
 			patchAsyncMethod(
 				store.docs.log.log as any,
 				"appendLocallyPrepared",
+				profile,
+				"logAppendMs",
+			),
+			patchAsyncMethod(
+				store.docs.log.log as any,
+				"appendLocallyPreparedManyIndependent",
 				profile,
 				"logAppendMs",
 			),
@@ -335,6 +361,12 @@ const runScenario = async (name: string): Promise<BenchRow> => {
 				patchAsyncMethod(
 					store.docs.log.log as any,
 					"createNativePlainAppendChain",
+					profile,
+					"logCreateNativeAppendChainMs",
+				),
+				patchAsyncMethod(
+					store.docs.log.log as any,
+					"createNativePlainAppendEntriesBatch",
 					profile,
 					"logCreateNativeAppendChainMs",
 				),

--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -108,13 +108,26 @@ export type CanPerform<T> = (
 
 type PutChangeReference<T, I extends Record<string, any>> = {
 	document: T;
-	operation: PutOperation;
+	operation: PutOperation | PutWithKeyOperation;
 	key: indexerTypes.IdKey;
 	unique?: boolean;
 	existing?:
 		| indexerTypes.IndexedResult<IndexedContextOnly<I>>
 		| null
 		| undefined;
+};
+
+type DocumentPutOptions = SharedAppendOptions<Operation> & {
+	unique?: boolean;
+	replicate?: boolean;
+	checkRemote?: boolean;
+};
+
+type PreparedPut<T> = {
+	document: T;
+	keyValue: indexerTypes.IdPrimitive;
+	key: indexerTypes.IdKey;
+	operation: PutOperation | PutWithKeyOperation;
 };
 
 type InferR<D> = D extends ReplicationDomain<any, any, infer I> ? I : "u32";
@@ -607,17 +620,8 @@ export class Documents<
 		}
 	}
 
-	public async put(
-		doc: T,
-		options?: SharedAppendOptions<Operation> & {
-			unique?: boolean;
-			replicate?: boolean;
-			checkRemote?: boolean;
-		},
-	) {
+	private preparePut(doc: T): PreparedPut<T> {
 		const keyValue = this.idResolver(doc);
-
-		// type check the key
 		indexerTypes.checkId(keyValue);
 		const ser = serialize(doc);
 		if (ser.length > MAX_BATCH_SIZE) {
@@ -629,27 +633,6 @@ export class Documents<
 		}
 
 		const key = indexerTypes.toId(keyValue);
-		let existingLocalContext:
-			| indexerTypes.IndexedResult<IndexedContextOnly<I>>
-			| null
-			| undefined;
-		let existingHead: string | undefined;
-		if (!options?.unique) {
-			if (options?.checkRemote) {
-				existingHead = (
-					await this._index.getDetailed(keyValue, {
-						resolve: false,
-						local: true,
-						remote: { replicate: options?.replicate },
-					})
-				)?.[0]?.results[0]?.context.head;
-			} else {
-				existingLocalContext =
-					(await this.getLocalIndexedContext(key)) || null;
-				existingHead = existingLocalContext?.value.__context.head;
-			}
-		}
-
 		let operation: PutOperation | PutWithKeyOperation;
 		if (this.compatibility === 6) {
 			if (typeof keyValue === "string") {
@@ -665,35 +648,63 @@ export class Documents<
 				data: ser,
 			});
 		}
+		return { document: doc, keyValue, key, operation };
+	}
+
+	public async put(doc: T, options?: DocumentPutOptions) {
+		const prepared = this.preparePut(doc);
+		let existingLocalContext:
+			| indexerTypes.IndexedResult<IndexedContextOnly<I>>
+			| null
+			| undefined;
+		let existingHead: string | undefined;
+		if (!options?.unique) {
+			if (options?.checkRemote) {
+				existingHead = (
+					await this._index.getDetailed(prepared.keyValue, {
+						resolve: false,
+						local: true,
+						remote: { replicate: options?.replicate },
+					})
+				)?.[0]?.results[0]?.context.head;
+			} else {
+				existingLocalContext =
+					(await this.getLocalIndexedContext(prepared.key)) || null;
+				existingHead = existingLocalContext?.value.__context.head;
+			}
+		}
 
 		if (
-			operation instanceof PutOperation &&
+			prepared.operation instanceof PutOperation &&
 			this.canUsePlainPutFastPath(options)
 		) {
 			return this.putPlainFastPath(
-				doc,
-				key,
-				operation,
+				prepared.document,
+				prepared.key,
+				prepared.operation,
 				existingHead,
 				existingLocalContext,
 				options,
 			);
 		}
 
-		const appended = await this.log.append(operation, {
+		const appended = await this.log.append(prepared.operation, {
 			...options,
 			meta: {
 				next: existingHead ? [await this._resolveEntry(existingHead)] : [],
 				...options?.meta,
 			},
 			canAppend: (entry) => {
-				return this.canAppend(entry, { document: doc, operation });
+				return this.canAppend(entry, {
+					document: prepared.document,
+					operation: prepared.operation,
+				});
 			},
 			onChange: (change) => {
 				return this.handleChanges(change, {
-					document: doc,
-					operation,
-					key,
+					document: prepared.document,
+					operation: prepared.operation,
+					key: prepared.key,
 					unique: options?.unique,
 					existing: existingLocalContext,
 				});
@@ -704,12 +715,86 @@ export class Documents<
 		return appended;
 	}
 
+	public async putMany(
+		docs: T[],
+		options?: DocumentPutOptions,
+	): Promise<{
+		entries: Entry<Operation>[];
+		removed: ShallowOrFullEntry<Operation>[];
+	}> {
+		if (docs.length === 0) {
+			return { entries: [], removed: [] };
+		}
+		if (!this.canUsePlainPutManyFastPath(options)) {
+			return this.putManySequential(docs, options);
+		}
+
+		const prepared = docs.map((doc) => this.preparePut(doc));
+		if (
+			prepared.some((item) => !(item.operation instanceof PutOperation)) ||
+			this.hasDuplicatePreparedPutKeys(prepared)
+		) {
+			return this.putManySequential(docs, options);
+		}
+
+		const appended = await this.log.appendLocallyPreparedManyIndependent(
+			prepared.map((item) => item.operation as PutOperation),
+			{
+				...options,
+				replicate: options?.replicate,
+			},
+			{
+				resolveTrimmedEntries: !this._index.canGetIdentityIndexedByHead(),
+			},
+		);
+		if (!appended) {
+			return this.putManySequential(docs, options);
+		}
+
+		await this.handlePreparedPlainPutManyCommit({
+			puts: prepared.map((item, index) => ({
+				document: item.document,
+				key: item.key,
+				entry: appended.entries[index]!,
+			})),
+			removed: appended.removed,
+		});
+		for (const entry of appended.entries) {
+			this.keepCache?.add(entry.hash);
+		}
+		return appended;
+	}
+
+	private async putManySequential(
+		docs: T[],
+		options?: DocumentPutOptions,
+	): Promise<{
+		entries: Entry<Operation>[];
+		removed: ShallowOrFullEntry<Operation>[];
+	}> {
+		const entries: Entry<Operation>[] = [];
+		const removed: ShallowOrFullEntry<Operation>[] = [];
+		for (const doc of docs) {
+			const appended = await this.put(doc, options);
+			entries.push(appended.entry);
+			removed.push(...appended.removed);
+		}
+		return { entries, removed };
+	}
+
+	private hasDuplicatePreparedPutKeys(prepared: PreparedPut<T>[]): boolean {
+		const keys = new Set<string | number | bigint>();
+		for (const item of prepared) {
+			if (keys.has(item.key.primitive)) {
+				return true;
+			}
+			keys.add(item.key.primitive);
+		}
+		return false;
+	}
+
 	private canUsePlainPutFastPath(
-		options?: SharedAppendOptions<Operation> & {
-			unique?: boolean;
-			replicate?: boolean;
-			checkRemote?: boolean;
-		},
+		options?: DocumentPutOptions,
 	): boolean {
 		return (
 			!this._optionCanPerform &&
@@ -729,6 +814,16 @@ export class Documents<
 		);
 	}
 
+	private canUsePlainPutManyFastPath(options?: DocumentPutOptions): boolean {
+		return (
+			options?.unique === true &&
+			options?.replicate !== true &&
+			options?.target === "none" &&
+			(options?.delivery === undefined || options.delivery === false) &&
+			this.canUsePlainPutFastPath(options)
+		);
+	}
+
 	private async putPlainFastPath(
 		doc: T,
 		key: indexerTypes.IdKey,
@@ -739,11 +834,7 @@ export class Documents<
 			| null
 			| undefined,
 		options:
-			| (SharedAppendOptions<Operation> & {
-					unique?: boolean;
-					replicate?: boolean;
-					checkRemote?: boolean;
-			  })
+			| DocumentPutOptions
 			| undefined,
 	) {
 		const indexedContextNext = existingHead
@@ -884,6 +975,82 @@ export class Documents<
 				),
 			);
 			modified.add(properties.key.primitive);
+		}
+
+		for (const removed of properties.removed) {
+			if (
+				!(removed instanceof Entry) &&
+				(await this.collectRemovedDocumentChangeFromIndexedHead(
+					removed.hash,
+					modified,
+					documentsChanged,
+				))
+			) {
+				continue;
+			}
+			const entry =
+				removed instanceof Entry
+					? removed
+					: await this.log.log.entryIndex.get(removed.hash);
+			if (!entry) {
+				continue;
+			}
+			try {
+				await this.collectRemovedDocumentChange(
+					await entry.getPayloadValue(),
+					modified,
+					documentsChanged,
+				);
+			} catch (error) {
+				if (error instanceof AccessError) {
+					continue;
+				}
+				throw error;
+			}
+		}
+
+		this.events.dispatchEvent(
+			new CustomEvent("change", { detail: documentsChanged }),
+		);
+	}
+
+	private async handlePreparedPlainPutManyCommit(properties: {
+		puts: {
+			document: T;
+			key: indexerTypes.IdKey;
+			entry: Entry<Operation>;
+		}[];
+		removed: ShallowOrFullEntry<Operation>[];
+	}): Promise<void> {
+		const documentsChanged: DocumentsChange<T, I> = {
+			added: [],
+			removed: [],
+		};
+		const modified: Set<string | number | bigint> = new Set();
+
+		for (const put of properties.puts) {
+			if (modified.has(put.key.primitive)) {
+				continue;
+			}
+			const context = new Context({
+				created: put.entry.meta.clock.timestamp.wallTime,
+				modified: put.entry.meta.clock.timestamp.wallTime,
+				head: put.entry.hash,
+				gid: put.entry.meta.gid,
+				size: put.entry.payload.byteLength,
+			});
+			const { indexable } = await this._index.putWithContext(
+				put.document,
+				put.key,
+				context,
+				{
+					replace: false,
+				},
+			);
+			documentsChanged.added.push(
+				coerceWithIndexed(coerceWithContext(put.document, context), indexable),
+			);
+			modified.add(put.key.primitive);
 		}
 
 		for (const removed of properties.removed) {

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -240,6 +240,78 @@ describe("index", () => {
 				}
 			});
 
+			it("uses the independent native prepared batch path for unique putMany", async () => {
+				const rustOptions = createRustPeerbitOptions();
+				const rustSession = await TestSession.connected(
+					1,
+					{ storage: rustOptions.storage },
+				);
+				store = new TestStore({
+					docs: new Documents<Document>(),
+				});
+				await rustSession.peers[0].open(store, {
+					args: {
+						replicate: false,
+						nativeGraph: true,
+					},
+				});
+				const changes: DocumentsChange<Document, Document>[] = [];
+				store.docs.events.addEventListener("change", (evt) => {
+					changes.push(evt.detail);
+				});
+				const sharedBatchAppendSpy = sinon.spy(
+					store.docs.log,
+					"appendLocallyPreparedManyIndependent",
+				);
+				const lowerBatchAppendSpy = sinon.spy(
+					store.docs.log.log,
+					"appendLocallyPreparedManyIndependent",
+				);
+				const preparedAppendSpy = sinon.spy(
+					store.docs.log,
+					"appendLocallyPrepared",
+				);
+				const appendSpy = sinon.spy(store.docs.log, "append");
+
+				try {
+					const docs = [
+						new Document({ id: uuid(), name: "batch-1" }),
+						new Document({ id: uuid(), name: "batch-2" }),
+						new Document({ id: uuid(), name: "batch-3" }),
+					];
+					const appended = await store.docs.putMany(docs, {
+						unique: true,
+						replicate: false,
+						target: "none",
+					});
+
+					expect(sharedBatchAppendSpy.callCount).equal(1);
+					expect(lowerBatchAppendSpy.callCount).equal(1);
+					expect(preparedAppendSpy.callCount).equal(0);
+					expect(appendSpy.callCount).equal(0);
+					expect(appended.entries).to.have.length(3);
+					expect(new Set(appended.entries.map((entry) => entry.meta.gid)).size)
+						.equal(3);
+					expect(appended.entries.every((entry) => entry.meta.next.length === 0))
+						.equal(true);
+					expect(changes).to.have.length(1);
+					expect(changes[0].added.map((doc) => doc.id)).to.deep.equal(
+						docs.map((doc) => doc.id),
+					);
+					for (const doc of docs) {
+						expect((await store.docs.get(doc.id))?.name).equal(doc.name);
+					}
+				} finally {
+					appendSpy.restore();
+					preparedAppendSpy.restore();
+					lowerBatchAppendSpy.restore();
+					sharedBatchAppendSpy.restore();
+					await store.close();
+					store = undefined;
+					await rustSession.stop();
+				}
+			});
+
 			it("uses native shared-log planning for replicated target-none puts", async () => {
 				store = new TestStore({
 					docs: new Documents<Document>(),
@@ -428,6 +500,45 @@ describe("index", () => {
 					preparedAppendSpy.restore();
 					validatedAppendSpy.restore();
 					appendSpy.restore();
+				}
+			});
+
+			it("keeps custom canPerform putMany on the compatibility path", async () => {
+				store = new TestStore({
+					docs: new Documents<Document>(),
+				});
+				const canPerform = sinon.stub().returns(true);
+				await session.peers[0].open(store, {
+					args: {
+						replicate: false,
+						canPerform,
+					},
+				});
+				const batchAppendSpy = sinon.spy(
+					store.docs.log,
+					"appendLocallyPreparedManyIndependent",
+				);
+				const appendSpy = sinon.spy(store.docs.log, "append");
+
+				try {
+					await store.docs.putMany(
+						[
+							new Document({ id: uuid(), name: "compat-1" }),
+							new Document({ id: uuid(), name: "compat-2" }),
+						],
+						{
+							unique: true,
+							replicate: false,
+							target: "none",
+						},
+					);
+
+					expect(batchAppendSpy.callCount).equal(0);
+					expect(appendSpy.callCount).equal(2);
+					expect(canPerform.callCount).equal(2);
+				} finally {
+					appendSpy.restore();
+					batchAppendSpy.restore();
 				}
 			});
 

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -4073,6 +4073,82 @@ export class SharedLog<
 		return { entry: result.entry, removed: result.removed };
 	}
 
+	async appendLocallyPreparedManyIndependent(
+		data: T[],
+		options?: SharedAppendOptions<T> | undefined,
+		properties?: {
+			resolveTrimmedEntries?: boolean;
+		},
+	): Promise<
+		| {
+				entries: Entry<T>[];
+				removed: ShallowOrFullEntry<T>[];
+		  }
+		| undefined
+	> {
+		if (data.length === 0) {
+			return { entries: [], removed: [] };
+		}
+		if (options?.canAppend || options?.onChange) {
+			throw new Error(
+				"appendLocallyPreparedManyIndependent does not accept canAppend or onChange hooks",
+			);
+		}
+		if (this._isAdaptiveReplicating) {
+			this.markLocalAppendActivity();
+		}
+
+		const { appendOptions, minReplicasValue } =
+			this.createLogAppendOptions(options);
+		appendOptions.__peerbitCanAppendAlreadyValidated = true;
+		const result = await this.log.appendLocallyPreparedManyIndependent(
+			data,
+			appendOptions,
+			{
+				resolveTrimmedEntries: properties?.resolveTrimmedEntries,
+			},
+		);
+		if (!result) {
+			return undefined;
+		}
+
+		await this.onChange(result.change);
+		const deferHeadCoordinatePersistence =
+			this.shouldDeferHeadCoordinatePersistence(options);
+
+		if (deferHeadCoordinatePersistence) {
+			await this.deleteCoordinatesForHashes([
+				...result.entries.flatMap((entry) => entry.meta.next),
+				...result.removed.map((entry) => entry.hash),
+			]);
+			return { entries: result.entries, removed: result.removed };
+		}
+
+		const nativeAppendPlans =
+			options?.replicate === true
+				? undefined
+				: await this.planNativeAppendEntries(
+						result.entries,
+						minReplicasValue,
+						options?.delivery,
+						options,
+					);
+		for (let i = 0; i < result.entries.length; i++) {
+			await this.processLocalAppend(
+				result.entries[i]!,
+				i === result.entries.length - 1 ? result.removed : [],
+				options,
+				{
+					minReplicasValue,
+					deferHeadCoordinatePersistence: false,
+					nativeAppendPlan: nativeAppendPlans?.[i],
+				},
+			);
+		}
+
+		return { entries: result.entries, removed: result.removed };
+	}
+
 	async appendMany(
 		data: T[],
 		options?: SharedAppendOptions<T> | undefined,


### PR DESCRIPTION
## Summary
- add independent prepared batch append plumbing through `@peerbit/log` and `@peerbit/shared-log`
- add a narrow `Documents.putMany()` fast path for local unique plain puts with `target: "none"`
- keep unsupported shapes/options on the existing sequential `put()` fallback
- extend the document-put benchmark with a `-putmany` scenario suffix

## Benchmark
Local node run from `packages/programs/data/document/document`:

```bash
DOC_WARMUP=20 DOC_ITERATIONS=200 DOC_SCENARIOS=rust-peerbit,rust-peerbit-putmany,native-graph,native-graph-putmany,simple-index,simple-index-putmany BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Results:
- `rust-peerbit`: 3075 ops/sec, total 65.05 ms
- `rust-peerbit-putmany`: 4828 ops/sec, total 41.43 ms
- `native-graph`: 2074 ops/sec, total 96.42 ms
- `native-graph-putmany`: 3552 ops/sec, total 56.31 ms
- `simple-index`: 5313 ops/sec, total 37.65 ms
- `simple-index-putmany`: 7339 ops/sec, total 27.25 ms

## Test Plan
- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "putMany"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "validated local append path"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "appendMany commits blocks and graph in one native call when storage is native|append commits one block and graph in one native call when storage is native"`
- `pnpm exec eslint --config eslint.config.js packages/log/src/log.ts packages/log/src/entry-index.ts packages/log/src/entry-v0.ts packages/programs/data/shared-log/src/index.ts packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/test/index.spec.ts packages/programs/data/document/document/benchmark/document-put.ts` (passes with one existing unrelated warning in `index.spec.ts`)
- `git diff --check`