### PR TITLE
Batch native document putMany projection

### DIFF
--- a/packages/programs/data/document/document/benchmark/document-put.ts
+++ b/packages/programs/data/document/document/benchmark/document-put.ts
@@ -320,8 +320,22 @@ const runScenario = async (name: string): Promise<BenchRow> => {
 				"documentBackendIndexPutMs",
 			),
 			patchAsyncMethod(
+				backendIndex,
+				typeof backendIndex.putWithContextBatch === "function"
+					? "putWithContextBatch"
+					: "putBatch",
+				profile,
+				"documentBackendIndexPutMs",
+			),
+			patchAsyncMethod(
 				store.docs.index,
 				"putWithContext",
+				profile,
+				"documentIndexPutMs",
+			),
+			patchAsyncMethod(
+				store.docs.index,
+				"putManyWithContext",
 				profile,
 				"documentIndexPutMs",
 			),

--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -1028,6 +1028,11 @@ export class Documents<
 		};
 		const modified: Set<string | number | bigint> = new Set();
 
+		const putsToIndex: Array<{
+			document: T;
+			key: indexerTypes.IdKey;
+			context: Context;
+		}> = [];
 		for (const put of properties.puts) {
 			if (modified.has(put.key.primitive)) {
 				continue;
@@ -1039,18 +1044,23 @@ export class Documents<
 				gid: put.entry.meta.gid,
 				size: put.entry.payload.byteLength,
 			});
-			const { indexable } = await this._index.putWithContext(
-				put.document,
-				put.key,
-				context,
-				{
-					replace: false,
-				},
-			);
-			documentsChanged.added.push(
-				coerceWithIndexed(coerceWithContext(put.document, context), indexable),
-			);
+			putsToIndex.push({ document: put.document, key: put.key, context });
 			modified.add(put.key.primitive);
+		}
+		const indexed = await this._index.putManyWithContext(
+			putsToIndex.map((put) => ({
+				value: put.document,
+				id: put.key,
+				context: put.context,
+				options: { replace: false },
+			})),
+		);
+		for (let i = 0; i < putsToIndex.length; i++) {
+			const put = putsToIndex[i]!;
+			const { indexable } = indexed[i]!;
+			documentsChanged.added.push(
+				coerceWithIndexed(coerceWithContext(put.document, put.context), indexable),
+			);
 		}
 
 		for (const removed of properties.removed) {

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -660,6 +660,14 @@ type ContextualIndexPut<I> = {
 		context: types.Context,
 		options?: { replace?: boolean },
 	) => Promise<void> | void;
+	putWithContextBatch?: (
+		values: Array<{
+			value: I;
+			id: indexerTypes.IdKey;
+			context: types.Context;
+			options?: { replace?: boolean };
+		}>,
+	) => Promise<void> | void;
 };
 
 type ContextHeadIndex<I> = {
@@ -1746,6 +1754,98 @@ export class DocumentIndex<
 			throw error;
 		}
 		return { context, indexable: valueToIndex };
+	}
+
+	public async putManyWithContext(
+		values: Array<{
+			value: T;
+			id: indexerTypes.IdKey;
+			context: types.Context;
+			options?: { replace?: boolean };
+		}>,
+	): Promise<Array<{ context: types.Context; indexable: I }>> {
+		if (values.length === 0) {
+			return [];
+		}
+		const transformed = await Promise.all(
+			values.map(async (item) => {
+				const idString = item.id.primitive;
+				if (this.isProgramValued) {
+					this._resolverProgramCache!.set(idString, item.value);
+					indexCacheLogger("cache:set:program", { id: idString });
+				} else if (this._resolverCache) {
+					this._resolverCache.add(idString, item.value);
+					indexCacheLogger("cache:set:value", { id: idString });
+				}
+				const indexable = this.transformerIsIdentity
+					? (item.value as any as I)
+					: await this.transformer(item.value, item.context);
+				coerceWithIndexed(item.value, indexable);
+				coerceWithContext(item.value, item.context);
+				return { ...item, indexable };
+			}),
+		);
+
+		try {
+			const contextualBatchPut = this.transformerIsIdentity
+				? (this.index as ContextualIndexPut<I>).putWithContextBatch
+				: undefined;
+			if (contextualBatchPut) {
+				await contextualBatchPut.call(
+					this.index,
+					transformed.map((item) => ({
+						value: item.indexable,
+						id: item.id,
+						context: item.context,
+						options: item.options,
+					})),
+				);
+			} else if (
+				transformed.every((item) => item.options?.replace !== true) &&
+				this.index.putBatch
+			) {
+				await this.index.putBatch(
+					transformed.map(
+						(item) =>
+							new this.wrappedIndexedType(item.indexable, item.context),
+					),
+				);
+			} else {
+				const contextualPut = this.transformerIsIdentity
+					? (this.index as ContextualIndexPut<I>).putWithContext
+					: undefined;
+				for (const item of transformed) {
+					if (contextualPut) {
+						await contextualPut.call(
+							this.index,
+							item.indexable,
+							item.id,
+							item.context,
+							item.options,
+						);
+					} else {
+						await this.index.put(
+							new this.wrappedIndexedType(item.indexable, item.context),
+							item.id,
+							item.options,
+						);
+					}
+				}
+			}
+		} catch (error) {
+			if (error instanceof indexerTypes.NotStartedError && this.closed) {
+				return transformed.map((item) => ({
+					context: item.context,
+					indexable: item.indexable,
+				}));
+			}
+			throw error;
+		}
+
+		return transformed.map((item) => ({
+			context: item.context,
+			indexable: item.indexable,
+		}));
 	}
 
 	public del(key: indexerTypes.IdKey) {

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -272,6 +272,23 @@ describe("index", () => {
 					"appendLocallyPrepared",
 				);
 				const appendSpy = sinon.spy(store.docs.log, "append");
+				const documentBatchIndexSpy = sinon.spy(
+					store.docs.index,
+					"putManyWithContext",
+				);
+				const documentIndexPutSpy = sinon.spy(
+					store.docs.index,
+					"putWithContext",
+				);
+				const nativeState = (store.docs.log as any)._nativeSharedLogState;
+				const nativeLocalPlanSpy = sinon.spy(
+					nativeState,
+					"planLocalAppendForGid",
+				);
+				const nativeBatchPlanSpy = sinon.spy(
+					nativeState,
+					"planAppendForGidsBatch",
+				);
 
 				try {
 					const docs = [
@@ -281,7 +298,6 @@ describe("index", () => {
 					];
 					const appended = await store.docs.putMany(docs, {
 						unique: true,
-						replicate: false,
 						target: "none",
 					});
 
@@ -289,6 +305,10 @@ describe("index", () => {
 					expect(lowerBatchAppendSpy.callCount).equal(1);
 					expect(preparedAppendSpy.callCount).equal(0);
 					expect(appendSpy.callCount).equal(0);
+					expect(documentBatchIndexSpy.callCount).equal(1);
+					expect(documentIndexPutSpy.callCount).equal(0);
+					expect(nativeBatchPlanSpy.callCount).equal(1);
+					expect(nativeLocalPlanSpy.callCount).equal(0);
 					expect(appended.entries).to.have.length(3);
 					expect(new Set(appended.entries.map((entry) => entry.meta.gid)).size)
 						.equal(3);
@@ -302,6 +322,10 @@ describe("index", () => {
 						expect((await store.docs.get(doc.id))?.name).equal(doc.name);
 					}
 				} finally {
+					nativeBatchPlanSpy.restore();
+					nativeLocalPlanSpy.restore();
+					documentIndexPutSpy.restore();
+					documentBatchIndexSpy.restore();
 					appendSpy.restore();
 					preparedAppendSpy.restore();
 					lowerBatchAppendSpy.restore();

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -4127,12 +4127,17 @@ export class SharedLog<
 		const nativeAppendPlans =
 			options?.replicate === true
 				? undefined
-				: await this.planNativeAppendEntries(
-						result.entries,
-						minReplicasValue,
-						options?.delivery,
-						options,
-					);
+				: options?.target === "none"
+					? await this.planNativeLocalAppendEntries(
+							result.entries,
+							minReplicasValue,
+						)
+					: await this.planNativeAppendEntries(
+							result.entries,
+							minReplicasValue,
+							options?.delivery,
+							options,
+						);
 		for (let i = 0; i < result.entries.length; i++) {
 			await this.processLocalAppend(
 				result.entries[i]!,
@@ -4187,12 +4192,17 @@ export class SharedLog<
 		const nativeAppendPlans =
 			options?.replicate === true
 				? undefined
-				: await this.planNativeAppendEntries(
-						result.entries,
-						minReplicasValue,
-						options?.delivery,
-						options,
-					);
+				: options?.target === "none"
+					? await this.planNativeLocalAppendEntries(
+							result.entries,
+							minReplicasValue,
+						)
+					: await this.planNativeAppendEntries(
+							result.entries,
+							minReplicasValue,
+							options?.delivery,
+							options,
+						);
 		for (let i = 0; i < result.entries.length; i++) {
 			const entry = result.entries[i]!;
 			await this.processLocalAppend(entry, [], options, {
@@ -4363,6 +4373,44 @@ export class SharedLog<
 			isLeader: plan.isLeader,
 			assignedToRangeBoundary: plan.assignedToRangeBoundary,
 		};
+	}
+
+	private async planNativeLocalAppendEntries(
+		entries: Entry<T>[],
+		replicas: number,
+	): Promise<NativeAppendEntryPlan<R>[] | undefined> {
+		if (
+			!this._nativeSharedLogState ||
+			entries.length === 0 ||
+			!entries.every((entry) => this.canPlanNativeHashGid(entry))
+		) {
+			return undefined;
+		}
+
+		const context = await this.createLeaderSelectionContext();
+		const plans = this._nativeSharedLogState.planAppendForGidsBatch(
+			{
+				entries: entries.map((entry) => ({
+					entryHash: entry.hash,
+					gid: entry.meta.gid,
+					hashNumber: this.getEntryHashNumber(entry),
+					nextHashes: entry.meta.next,
+					replicas,
+				})),
+				fullReplicaCandidates: [],
+				selfHash: context.selfHash,
+				deliveryEnabled: false,
+				reliabilityAck: false,
+				requireRecipients: false,
+			},
+			this.createNativeLeaderOptions(context),
+		);
+		return plans.map((plan) => ({
+			coordinates: plan.coordinates as NumberFromType<R>[],
+			leaders: plan.leaders,
+			isLeader: plan.isLeader,
+			assignedToRangeBoundary: plan.assignedToRangeBoundary,
+		}));
 	}
 
 	private async planNativeAppendEntries(

--- a/packages/programs/data/shared-log/test/append.spec.ts
+++ b/packages/programs/data/shared-log/test/append.spec.ts
@@ -101,6 +101,34 @@ describe("append", () => {
 		}
 	});
 
+	it("appendMany plans target-none local assignments in one native batch", async () => {
+		session = await TestSession.disconnected(1);
+		const store = await session.peers[0].open(new EventStore<string, any>(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const nativeState = (store.log as any)._nativeSharedLogState;
+		expect(nativeState).to.exist;
+		const batchSpy = sinon.spy(nativeState, "planAppendForGidsBatch");
+		const localSingleSpy = sinon.spy(nativeState, "planLocalAppendForGid");
+		const deliverySingleSpy = sinon.spy(nativeState, "planAppendForGid");
+		try {
+			await store.addMany(["a", "b", "c"], {
+				target: "none",
+			});
+
+			expect(batchSpy.callCount).equal(1);
+			expect(localSingleSpy.callCount).equal(0);
+			expect(deliverySingleSpy.callCount).equal(0);
+		} finally {
+			deliverySingleSpy.restore();
+			localSingleSpy.restore();
+			batchSpy.restore();
+		}
+	});
+
 	it("appendMany coalesces a local chain to the final shared-log head", async () => {
 		session = await TestSession.disconnected(1);
 		const store = await session.peers[0].open(new EventStore<string, any>(), {

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -1342,6 +1342,35 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		await this.put(this.asContextualValue(value, context), id, options);
 	}
 
+	async putWithContextBatch(
+		values: Array<{
+			value: Record<string, any>;
+			id: types.IdKey;
+			context: Record<string, any>;
+			options?: { replace?: boolean };
+		}>,
+	): Promise<void> {
+		if (values.length === 0) {
+			return;
+		}
+		if (values.some((entry) => entry.options?.replace === true)) {
+			for (const entry of values) {
+				await this.putWithContext(
+					entry.value,
+					entry.id,
+					entry.context,
+					entry.options,
+				);
+			}
+			return;
+		}
+		await this.putBatch(
+			values.map((entry) =>
+				this.asContextualValue(entry.value, entry.context),
+			),
+		);
+	}
+
 	async putBatch(values: T[]): Promise<void> {
 		if (values.length === 0) {
 			return;


### PR DESCRIPTION
## Summary
- add `DocumentIndex.putManyWithContext(...)` so prepared document puts can project/index a batch through one document-index call
- add `RustIndex.putWithContextBatch(...)`, backed by the existing native `putBatch` path for contextual values
- wire `Documents.putMany()` to use one batched document index projection
- batch target-none native local append planning through shared-log Rust `planAppendForGidsBatch`

## Benchmark
Local node run from `packages/programs/data/document/document`:

```bash
DOC_WARMUP=20 DOC_ITERATIONS=200 DOC_SCENARIOS=rust-peerbit,rust-peerbit-putmany,native-graph,native-graph-putmany,simple-index,simple-index-putmany BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Results:
- `rust-peerbit`: 2861 ops/sec, total 69.90 ms, document index put 5.58 ms
- `rust-peerbit-putmany`: 4887 ops/sec, total 40.93 ms, document index put 2.54 ms
- `native-graph`: 1992 ops/sec, total 100.39 ms, document index put 6.77 ms
- `native-graph-putmany`: 3270 ops/sec, total 61.17 ms, document index put 2.96 ms
- `simple-index`: 5276 ops/sec, total 37.91 ms, document index put 0.66 ms
- `simple-index-putmany`: 8288 ops/sec, total 24.13 ms, document index put 0.20 ms

## Test Plan
- `pnpm --filter @peerbit/indexer-rust run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "putMany"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "target-none local assignments"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "appendMany plans local append assignments"`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/index.ts packages/programs/data/shared-log/test/append.spec.ts packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/src/search.ts packages/programs/data/document/document/test/index.spec.ts packages/programs/data/document/document/benchmark/document-put.ts packages/utils/indexer/rust/src/index.ts` (passes with one existing unrelated warning in `index.spec.ts`)
- `git diff --check`