### PR TITLE
Batch native shared-log coordinate persistence

### DIFF
--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -336,6 +336,65 @@ describe("index", () => {
 				}
 			});
 
+			it("batches rust index and coordinate writes for unique putMany", async () => {
+				const rustSession = await TestSession.connected(
+					1,
+					createRustPeerbitOptions(),
+				);
+				store = new TestStore({
+					docs: new Documents<Document>(),
+				});
+				await rustSession.peers[0].open(store, {
+					args: {
+						replicate: false,
+						nativeGraph: true,
+					},
+				});
+				const changes: DocumentsChange<Document, Document>[] = [];
+				store.docs.events.addEventListener("change", (evt) => {
+					changes.push(evt.detail);
+				});
+				const backendIndex = store.docs.index.index as any;
+				const documentBackendBatchSpy = sinon.spy(
+					backendIndex,
+					"putWithContextBatch",
+				);
+				const coordinateIndex = store.docs.log.entryCoordinatesIndex as any;
+				const coordinateBatchSpy = sinon.spy(
+					coordinateIndex,
+					"putSharedLogCoordinatesAndDeleteIdsBatch",
+				);
+				const coordinatePutSpy = sinon.spy(coordinateIndex, "put");
+
+				try {
+					const docs = [
+						new Document({ id: uuid(), name: "rust-batch-1" }),
+						new Document({ id: uuid(), name: "rust-batch-2" }),
+						new Document({ id: uuid(), name: "rust-batch-3" }),
+					];
+					const appended = await store.docs.putMany(docs, {
+						unique: true,
+						target: "none",
+					});
+
+					expect(appended.entries).to.have.length(3);
+					expect(documentBackendBatchSpy.callCount).equal(1);
+					expect(coordinateBatchSpy.callCount).equal(1);
+					expect(coordinatePutSpy.callCount).equal(0);
+					expect(changes).to.have.length(1);
+					expect(changes[0].added.map((doc) => doc.id)).to.deep.equal(
+						docs.map((doc) => doc.id),
+					);
+				} finally {
+					coordinatePutSpy.restore();
+					coordinateBatchSpy.restore();
+					documentBackendBatchSpy.restore();
+					await store.close();
+					store = undefined;
+					await rustSession.stop();
+				}
+			});
+
 			it("uses native shared-log planning for replicated target-none puts", async () => {
 				store = new TestStore({
 					docs: new Documents<Document>(),

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -501,6 +501,22 @@ type PutAndDeleteIndex<T extends Record<string, any>> = Index<T> & {
 		deleteIds?: Array<IdKey | Ideable>,
 		id?: IdKey,
 	) => Promise<unknown> | unknown;
+	putSharedLogCoordinatesAndDeleteIdsBatch?: (
+		values: Array<{
+			value: T;
+			fields: {
+				hash: string;
+				hashNumber: NumberFromType<any>;
+				gid: string;
+				coordinates: NumberFromType<any>[];
+				wallTime: bigint;
+				assignedToRangeBoundary: boolean;
+				metaBytes: Uint8Array;
+			};
+			deleteIds?: Array<IdKey | Ideable>;
+			id?: IdKey;
+		}>,
+	) => Promise<unknown> | unknown;
 };
 
 type EntryWithMetaBytes = {
@@ -4138,6 +4154,19 @@ export class SharedLog<
 							options?.delivery,
 							options,
 						);
+		if (
+			nativeAppendPlans &&
+			result.removed.length === 0 &&
+			(await this.processLocalAppendManyNativePlanned(
+				result.entries,
+				options,
+				{
+					nativeAppendPlans,
+				},
+			))
+		) {
+			return { entries: result.entries, removed: result.removed };
+		}
 		for (let i = 0; i < result.entries.length; i++) {
 			await this.processLocalAppend(
 				result.entries[i]!,
@@ -4262,6 +4291,52 @@ export class SharedLog<
 			minReplicasValue: properties.minReplicasValue,
 			deferHeadCoordinatePersistence: false,
 		});
+	}
+
+	private async processLocalAppendManyNativePlanned(
+		entries: Entry<T>[],
+		options: SharedAppendOptions<T> | undefined,
+		properties: {
+			nativeAppendPlans: NativeAppendEntryPlan<R>[];
+		},
+	): Promise<boolean> {
+		if (
+			entries.length === 0 ||
+			options?.target !== "none" ||
+			options?.replicate === true ||
+			properties.nativeAppendPlans.length !== entries.length
+		) {
+			return false;
+		}
+
+		const delayAdaptiveRebalance = this.shouldDelayAdaptiveRebalance();
+		await this.persistCoordinatesBatch(
+			entries.map((entry, index) => {
+				const plan = properties.nativeAppendPlans[index]!;
+				return {
+					leaders: plan.leaders,
+					coordinates: plan.coordinates,
+					replicas: plan.coordinates.length,
+					entry,
+					assignedToRangeBoundary: plan.assignedToRangeBoundary,
+					commitNative: false,
+				};
+			}),
+		);
+
+		if (!delayAdaptiveRebalance) {
+			for (let i = 0; i < entries.length; i++) {
+				const plan = properties.nativeAppendPlans[i]!;
+				if (!plan.isLeader) {
+					this.pruneDebouncedFnAddIfNotKeeping({
+						key: entries[i]!.hash,
+						value: { entry: entries[i]!, leaders: plan.leaders },
+					});
+				}
+			}
+			this.rebalanceParticipationDebounced?.call();
+		}
+		return true;
 	}
 
 	private createLogAppendOptions(options?: SharedAppendOptions<T>): {
@@ -7448,6 +7523,44 @@ export class SharedLog<
 		return result[0].value.coordinates;
 	}
 
+	private createCoordinatePersistenceEntry(properties: {
+		coordinates: NumberFromType<R>[];
+		entry: ShallowOrFullEntry<any> | EntryReplicated<R>;
+		leaders:
+			| Map<
+					string,
+					{
+						intersecting: boolean;
+					}
+			  >
+			| false;
+		replicas: number;
+		prev?: EntryReplicated<R>;
+		assignedToRangeBoundary?: boolean;
+	}): { coordinateEntry: EntryReplicated<R>; assignedToRangeBoundary: boolean } | false {
+		const assignedToRangeBoundary =
+			properties.assignedToRangeBoundary ??
+			shouldAssignToRangeBoundary(properties.leaders, properties.replicas);
+
+		if (
+			properties.prev &&
+			properties.prev.assignedToRangeBoundary === assignedToRangeBoundary
+		) {
+			return false;
+		}
+
+		const metaBytes = (properties.entry as EntryWithMetaBytes).getMetaBytes?.();
+		const coordinateEntry = new this.indexableDomain.constructorEntry({
+			assignedToRangeBoundary,
+			coordinates: properties.coordinates,
+			meta: properties.entry.meta,
+			metaBytes,
+			hash: properties.entry.hash,
+			hashNumber: this.getEntryHashNumber(properties.entry),
+		});
+		return { coordinateEntry, assignedToRangeBoundary };
+	}
+
 	private async persistCoordinate(properties: {
 		coordinates: NumberFromType<R>[];
 		entry: ShallowOrFullEntry<any> | EntryReplicated<R>;
@@ -7464,28 +7577,11 @@ export class SharedLog<
 		assignedToRangeBoundary?: boolean;
 		commitNative?: boolean;
 	}) {
-		const assignedToRangeBoundary =
-			properties.assignedToRangeBoundary ??
-			shouldAssignToRangeBoundary(properties.leaders, properties.replicas);
-
-		if (
-			properties.prev &&
-			properties.prev.assignedToRangeBoundary === assignedToRangeBoundary
-		) {
-			return false; // no change
+		const prepared = this.createCoordinatePersistenceEntry(properties);
+		if (!prepared) {
+			return false;
 		}
-
-		const hashNumber = this.getEntryHashNumber(properties.entry);
-
-		const metaBytes = (properties.entry as EntryWithMetaBytes).getMetaBytes?.();
-		const coordinateEntry = new this.indexableDomain.constructorEntry({
-			assignedToRangeBoundary,
-			coordinates: properties.coordinates,
-			meta: properties.entry.meta,
-			metaBytes,
-			hash: properties.entry.hash,
-			hashNumber,
-		});
+		const { coordinateEntry, assignedToRangeBoundary } = prepared;
 		const nextHashes = properties.entry.meta.next;
 		const coordinateIndex = this.entryCoordinatesIndex as PutAndDeleteIndex<
 			EntryReplicated<R>
@@ -7557,6 +7653,115 @@ export class SharedLog<
 			);
 		}
 		return true;
+	}
+
+	private async persistCoordinatesBatch(
+		items: Array<{
+			coordinates: NumberFromType<R>[];
+			entry: ShallowOrFullEntry<any> | EntryReplicated<R>;
+			leaders:
+				| Map<
+						string,
+						{
+							intersecting: boolean;
+						}
+				  >
+				| false;
+			replicas: number;
+			prev?: EntryReplicated<R>;
+			assignedToRangeBoundary?: boolean;
+			commitNative?: boolean;
+		}>,
+	): Promise<boolean[]> {
+		if (items.length === 0) {
+			return [];
+		}
+
+		const prepared = items.map((item) => ({
+			item,
+			prepared: this.createCoordinatePersistenceEntry(item),
+		}));
+		const changed = prepared.filter(
+			(
+				entry,
+			): entry is {
+				item: (typeof items)[number];
+				prepared: {
+					coordinateEntry: EntryReplicated<R>;
+					assignedToRangeBoundary: boolean;
+				};
+			} => entry.prepared !== false,
+		);
+		if (changed.length === 0) {
+			return items.map(() => false);
+		}
+
+		const coordinateIndex = this.entryCoordinatesIndex as PutAndDeleteIndex<
+			EntryReplicated<R>
+		>;
+		const canUseGenericPutBatch =
+			typeof coordinateIndex.putBatch === "function" &&
+			changed.every(({ item }) => item.entry.meta.next.length === 0);
+
+		if (coordinateIndex.putSharedLogCoordinatesAndDeleteIdsBatch) {
+			await coordinateIndex.putSharedLogCoordinatesAndDeleteIdsBatch(
+				changed.map(({ item, prepared }) => ({
+					value: prepared.coordinateEntry,
+					fields: {
+						hash: prepared.coordinateEntry.hash,
+						hashNumber: prepared.coordinateEntry.hashNumber,
+						gid: prepared.coordinateEntry.gid,
+						coordinates: prepared.coordinateEntry.coordinates,
+						wallTime: prepared.coordinateEntry.wallTime,
+						assignedToRangeBoundary:
+							prepared.coordinateEntry.assignedToRangeBoundary,
+						metaBytes: prepared.coordinateEntry.getMetaBytes(),
+					},
+					deleteIds: item.entry.meta.next,
+				})),
+			);
+		} else if (canUseGenericPutBatch) {
+			await coordinateIndex.putBatch!(
+				changed.map(({ prepared }) => prepared.coordinateEntry),
+			);
+		} else {
+			const results: boolean[] = [];
+			for (const item of items) {
+				results.push(await this.persistCoordinate(item));
+			}
+			return results;
+		}
+
+		for (const { item, prepared } of changed) {
+			if (item.commitNative !== false) {
+				this._nativeSharedLogState?.commitEntryCoordinates(
+					item.entry.hash,
+					prepared.coordinateEntry.gid,
+					item.coordinates,
+					item.entry.meta.next,
+					prepared.assignedToRangeBoundary,
+					item.replicas,
+					prepared.coordinateEntry.hashNumber,
+				);
+			}
+			if (this._residentEntryCoordinatesByHash) {
+				this._residentEntryCoordinatesByHash.set(
+					item.entry.hash,
+					prepared.coordinateEntry,
+				);
+				for (const nextHash of item.entry.meta.next) {
+					this._residentEntryCoordinatesByHash.delete(nextHash);
+				}
+			}
+			for (const coordinate of item.coordinates) {
+				this.coordinateToHash.add(coordinate, item.entry.hash);
+			}
+		}
+
+		const changedHashes = new Set(
+			changed.map(({ prepared }) => prepared.coordinateEntry.hash),
+		);
+		return items.map((item) => changedHashes.has(item.entry.hash));
 	}
 
 	private async deleteCoordinates(properties: { hash: string }) {

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -1472,6 +1472,70 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		);
 	}
 
+	async putSharedLogCoordinatesAndDeleteIdsBatch(
+		values: Array<{
+			value: T;
+			fields: SharedLogCoordinateNativeFields;
+			deleteIds?: Array<types.IdKey | types.Ideable>;
+			id?: types.IdKey;
+		}>,
+	): Promise<types.IdKey[]> {
+		if (values.length === 0) {
+			return [];
+		}
+		const prepared = values.map((entry) => {
+			const id =
+				entry.id ?? types.toId(types.extractFieldValue(entry.value, this.indexByArr));
+			return {
+				value: entry.value,
+				id,
+				storeKey: keyToStoreKey(id),
+				fields: this.encodeSharedLogCoordinateFields(entry.fields),
+				deleteKeys: (entry.deleteIds ?? []).map(keyToStoreKey),
+			};
+		});
+
+		if (!this.snapshotFile) {
+			return prepared.flatMap((entry) =>
+				this.getNative()
+					.put_and_delete_keys(
+						entry.storeKey,
+						entry.id,
+						entry.value,
+						entry.fields,
+						entry.deleteKeys,
+					)
+					.map((deleted) => deleted[0]),
+			);
+		}
+
+		return this.enqueueMutation(async () => {
+			await this.enqueuePersistence(async () => {
+				for (const entry of prepared) {
+					await this.snapshotFile!.appendPut(
+						entry.storeKey,
+						entry.value,
+						this.properties.schema,
+					);
+					for (const deleteKey of entry.deleteKeys) {
+						await this.snapshotFile!.appendDelete(deleteKey);
+					}
+				}
+			});
+			const deletedEntries = prepared.flatMap((entry) =>
+				this.getNative().put_and_delete_keys(
+					entry.storeKey,
+					entry.id,
+					entry.value,
+					entry.fields,
+					entry.deleteKeys,
+				),
+			);
+			await this.compactIfNeeded();
+			return deletedEntries.map((entry) => entry[0]);
+		});
+	}
+
 	async delIds(deleteIds: Array<types.IdKey | types.Ideable>): Promise<types.IdKey[]> {
 		const deleteKeys = deleteIds.map(keyToStoreKey);
 		if (deleteKeys.length === 0) {


### PR DESCRIPTION
## Summary
- add a shared-log coordinate batch persistence path for independent native-planned local append batches
- add `RustIndex.putSharedLogCoordinatesAndDeleteIdsBatch(...)` so Rust coordinate puts/deletes happen in one mutation/persistence section
- route `appendLocallyPreparedManyIndependent` through the batch coordinate path for `target: "none"` when native append plans are already available
- add a focused document test that verifies full Rust options use both document batch indexing and coordinate batch persistence

## Benchmark
Local node run from `packages/programs/data/document/document`:

```bash
DOC_WARMUP=20 DOC_ITERATIONS=200 DOC_SCENARIOS=rust-peerbit,rust-peerbit-putmany,native-graph,native-graph-putmany,simple-index,simple-index-putmany BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Results:
- `rust-peerbit`: 2709 ops/sec, total 73.82 ms, shared append 60.37 ms
- `rust-peerbit-putmany`: 5354 ops/sec, total 37.35 ms, shared append 32.74 ms
- `native-graph`: 2011 ops/sec, total 99.44 ms
- `native-graph-putmany`: 3624 ops/sec, total 55.19 ms
- `simple-index`: 5201 ops/sec, total 38.46 ms
- `simple-index-putmany`: 7595 ops/sec, total 26.33 ms

## Test Plan
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/indexer-rust run build`
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "putMany"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "target-none local assignments"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "appendMany plans local append assignments"`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/index.ts packages/programs/data/document/document/test/index.spec.ts packages/utils/indexer/rust/src/index.ts` (passes with one existing unrelated warning in `index.spec.ts`)
- `git diff --check`