### PR TITLE
Coalesce native document batch trim path

### DIFF
--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -68,6 +68,7 @@ type NativeLogIndexHandle = {
 	has_many: (hashes: string[]) => string[];
 	oldest_hash: () => string | undefined;
 	newest_hash: () => string | undefined;
+	delete_many: (hashes: string[]) => number;
 	put: (
 		hash: string,
 		gid: string,
@@ -682,6 +683,10 @@ export class LogGraphIndex {
 
 	delete(hash: string): boolean {
 		return this.native.delete(hash);
+	}
+
+	deleteMany(hashes: Iterable<string>): number {
+		return this.native.delete_many([...hashes]);
 	}
 
 	heads(gid?: string): string[] {

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -231,6 +231,16 @@ impl LogGraphIndex {
         Some(entry)
     }
 
+    pub fn delete_many(&mut self, hashes: &[String]) -> usize {
+        let mut deleted = 0;
+        for hash in hashes {
+            if self.delete(hash).is_some() {
+                deleted += 1;
+            }
+        }
+        deleted
+    }
+
     pub fn heads(&self, gid: Option<&str>) -> Vec<String> {
         self.head_entries(gid)
             .into_iter()
@@ -1069,6 +1079,11 @@ impl NativeLogIndex {
 
     pub fn delete(&mut self, hash: &str) -> bool {
         self.inner.delete(hash).is_some()
+    }
+
+    pub fn delete_many(&mut self, hashes: Array) -> Result<usize, JsValue> {
+        let hashes = strings_from_array(hashes)?;
+        Ok(self.inner.delete_many(&hashes))
     }
 
     pub fn heads(&self, gid: Option<String>) -> Array {
@@ -2223,6 +2238,20 @@ mod tests {
         assert_eq!(index.count_has_next("a", None), 1);
 
         assert!(index.delete("c").is_some());
+        assert_eq!(index.heads(None), vec!["a"]);
+        assert_eq!(index.count_has_next("a", None), 0);
+    }
+
+    #[test]
+    fn deletes_many_entries() {
+        let mut index = LogGraphIndex::new();
+        index.put(entry("a", "g", &[], 1));
+        index.put(entry("b", "g", &["a"], 2));
+        index.put(entry("c", "g", &["b"], 3));
+
+        assert_eq!(index.delete_many(&["b".to_string(), "c".to_string()]), 2);
+        assert!(!index.has("b"));
+        assert!(!index.has("c"));
         assert_eq!(index.heads(None), vec!["a"]);
         assert_eq!(index.count_has_next("a", None), 0);
     }

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -54,6 +54,13 @@ type BlocksWithGetMany = Blocks & {
 	) => Promise<Array<Uint8Array | undefined>> | Array<Uint8Array | undefined>;
 };
 
+type BlocksWithRmMany = Blocks & {
+	rmMany?: (cids: string[]) => Promise<number | void> | number | void;
+};
+
+const hasRmMany = (store: Blocks): store is BlocksWithRmMany =>
+	typeof (store as BlocksWithRmMany).rmMany === "function";
+
 type NativeLogEntry = PreparedNativeLogEntry;
 
 type NativeJoinCutCheck = {
@@ -197,6 +204,7 @@ export type NativeLogGraph = {
 		| undefined
 	>;
 	delete: (hash: string) => boolean;
+	deleteMany?: (hashes: Iterable<string>) => number;
 	clear: () => void;
 	heads: (gid?: string) => string[];
 	hasHead: (gid?: string) => boolean;
@@ -875,6 +883,21 @@ export class EntryIndex<T> {
 		return results[0] as R;
 	}
 
+	async getOldestMany<
+		T extends boolean,
+		R = T extends true ? Entry<any> : ShallowEntry,
+	>(limit: number, resolve?: T): Promise<R[]> {
+		if (limit <= 0) {
+			return [];
+		}
+		const iterator = this.iterate([], this.properties.sort.sort, resolve);
+		try {
+			return (await iterator.next(limit)) as R[];
+		} finally {
+			await iterator.close();
+		}
+	}
+
 	async getNewest<
 		T extends boolean,
 		R = T extends true ? Entry<any> : ShallowEntry,
@@ -1373,6 +1396,90 @@ export class EntryIndex<T> {
 		}
 	}
 
+	canDeleteMany(): boolean {
+		return (
+			!!this.properties.nativeGraph?.graph.deleteMany ||
+			hasRmMany(this.properties.store)
+		);
+	}
+
+	async deleteMany(from: ShallowEntry[]): Promise<ShallowEntry[]> {
+		if (from.length === 0) {
+			return [];
+		}
+		const nodes: ShallowEntry[] = [];
+		const seen = new Set<string>();
+		for (const node of from) {
+			if (seen.has(node.hash)) {
+				continue;
+			}
+			seen.add(node.hash);
+			nodes.push(node);
+		}
+
+		const indexedByHash = new Map(nodes.map((node) => [node.hash, node]));
+		const deletedByHash = new Map<string, ShallowEntry>();
+		const indexedHashes: string[] = [];
+		const storeHashes: string[] = [];
+
+		for (const node of nodes) {
+			this.cache.del(node.hash);
+			const pending = this.pendingIndexWrites.get(node.hash);
+			if (pending) {
+				this.pendingIndexWrites.delete(node.hash);
+				deletedByHash.set(node.hash, pending);
+				storeHashes.push(node.hash);
+			} else {
+				indexedHashes.push(node.hash);
+			}
+		}
+
+		const batchSize = 64;
+		for (let i = 0; i < indexedHashes.length; i += batchSize) {
+			const hashes = indexedHashes.slice(i, i + batchSize);
+			const deleted = await this.properties.index.del({
+				query: createHashMatchQuery(hashes),
+			});
+			for (const id of deleted) {
+				const hash = String(id.primitive);
+				const node = indexedByHash.get(hash);
+				if (!node || deletedByHash.has(hash)) {
+					continue;
+				}
+				deletedByHash.set(hash, node);
+				storeHashes.push(hash);
+			}
+		}
+
+		const deleted = nodes
+			.map((node) => deletedByHash.get(node.hash))
+			.filter((node): node is ShallowEntry => !!node);
+		if (deleted.length === 0) {
+			return [];
+		}
+
+		const store = this.properties.store;
+		if (hasRmMany(store) && store.rmMany) {
+			await store.rmMany(storeHashes);
+		} else {
+			await Promise.all(storeHashes.map((hash) => store.rm(hash)));
+		}
+
+		this._length -= deleted.length;
+		const graph = this.properties.nativeGraph?.graph;
+		if (graph?.deleteMany) {
+			graph.deleteMany(storeHashes);
+		} else {
+			for (const hash of storeHashes) {
+				graph?.delete(hash);
+			}
+		}
+		for (const node of deleted) {
+			await this.privateUpdateNextHeadProperty(node, true);
+		}
+		return deleted;
+	}
+
 	async getMemoryUsage() {
 		if (this.properties.nativeGraph) {
 			return this.properties.nativeGraph.graph.payloadSizeSum();
@@ -1693,6 +1800,26 @@ export class EntryIndex<T> {
 		return null;
 	}
 }
+
+const createHashMatchQuery = (hashes: string[]): Query =>
+	hashes.length === 1
+		? new StringMatch({
+				key: "hash",
+				value: hashes[0]!,
+				caseInsensitive: false,
+				method: StringMatchMethod.exact,
+			})
+		: new Or(
+				hashes.map(
+					(hash) =>
+						new StringMatch({
+							key: "hash",
+							value: hash,
+							caseInsensitive: false,
+							method: StringMatchMethod.exact,
+						}),
+				),
+			);
 
 const toNativeLogEntry = (entry: ShallowEntry): NativeLogEntry => ({
 	hash: entry.hash,

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -331,6 +331,35 @@ export class Log<T> {
 					}
 					return shouldResolve ? resolved : deleted;
 				},
+				deleteNodes: this._entryIndex.canDeleteMany()
+					? async (
+							nodes: ShallowEntry[],
+							options?: { resolveDeletedEntry?: boolean },
+						) => {
+							if (nodes.length === 0) {
+								return [];
+							}
+							const shouldResolve = options?.resolveDeletedEntry !== false;
+							const resolvedByHash = new Map<string, Entry<T>>();
+							if (shouldResolve) {
+								const resolved = await this._entryIndex.getMany(
+									nodes.map((node) => node.hash),
+									{ type: "full", ignoreMissing: true },
+								);
+								for (const entry of resolved) {
+									if (entry) {
+										resolvedByHash.set(entry.hash, entry);
+									}
+								}
+							}
+							const deleted = await this._entryIndex.deleteMany(nodes);
+							return shouldResolve
+								? deleted
+										.map((node) => resolvedByHash.get(node.hash))
+										.filter((entry): entry is Entry<T> => !!entry)
+								: deleted;
+						}
+					: undefined,
 				sortFn: this._sortFn,
 				getLength: () => this.length,
 			},

--- a/packages/log/src/trim.ts
+++ b/packages/log/src/trim.ts
@@ -86,6 +86,10 @@ interface Log<T> {
 		node: ShallowEntry,
 		options?: { resolveDeletedEntry?: boolean },
 	) => Promise<Entry<T> | ShallowEntry | undefined>;
+	deleteNodes?: (
+		nodes: ShallowEntry[],
+		options?: { resolveDeletedEntry?: boolean },
+	) => Promise<(Entry<T> | ShallowEntry)[]>;
 	getLength(): number;
 }
 export class Trim<T> {
@@ -313,16 +317,33 @@ export class Trim<T> {
 		this._trimLastTail = undefined;
 		this._trimLastSeed = undefined;
 
-		while (this._log.getLength() > to) {
-			const node = await this._log.index.getOldest(false);
-			if (!node) {
-				break;
+		if (this._log.deleteNodes) {
+			while (this._log.getLength() > to) {
+				const nodes = await this._log.index.getOldestMany(
+					Math.min(this._log.getLength() - to, 512),
+					false,
+				);
+				if (nodes.length === 0) {
+					break;
+				}
+				deleted.push(
+					...(await this._log.deleteNodes(nodes, {
+						resolveDeletedEntry: options?.resolveDeletedEntries,
+					})),
+				);
 			}
-			const entry = await this._log.deleteNode(node, {
-				resolveDeletedEntry: options?.resolveDeletedEntries,
-			});
-			if (entry) {
-				deleted.push(entry);
+		} else {
+			while (this._log.getLength() > to) {
+				const node = await this._log.index.getOldest(false);
+				if (!node) {
+					break;
+				}
+				const entry = await this._log.deleteNode(node, {
+					resolveDeletedEntry: options?.resolveDeletedEntries,
+				});
+				if (entry) {
+					deleted.push(entry);
+				}
 			}
 		}
 

--- a/packages/programs/data/document/document/benchmark/document-put.ts
+++ b/packages/programs/data/document/document/benchmark/document-put.ts
@@ -91,6 +91,7 @@ type Profile = {
 	existingHeadLookupMs: number;
 	sharedAppendMs: number;
 	sharedProcessLocalAppendMs: number;
+	sharedProcessLocalAppendBatchMs: number;
 	sharedPlanEntryLeadersMs: number;
 	sharedPersistCoordinateMs: number;
 	logAppendMs: number;
@@ -112,6 +113,7 @@ type BenchRow = Profile & {
 
 const deepProfileKeys = new Set<keyof Profile>([
 	"sharedProcessLocalAppendMs",
+	"sharedProcessLocalAppendBatchMs",
 	"sharedPlanEntryLeadersMs",
 	"sharedPersistCoordinateMs",
 	"logCreateNativeAppendChainMs",
@@ -124,6 +126,7 @@ const emptyProfile = (): Profile => ({
 	existingHeadLookupMs: 0,
 	sharedAppendMs: 0,
 	sharedProcessLocalAppendMs: 0,
+	sharedProcessLocalAppendBatchMs: 0,
 	sharedPlanEntryLeadersMs: 0,
 	sharedPersistCoordinateMs: 0,
 	logAppendMs: 0,
@@ -350,6 +353,12 @@ const runScenario = async (name: string): Promise<BenchRow> => {
 				),
 				patchAsyncMethod(
 					store.docs.log as any,
+					"processLocalAppendManyNativePlanned",
+					profile,
+					"sharedProcessLocalAppendBatchMs",
+				),
+				patchAsyncMethod(
+					store.docs.log as any,
 					"planEntryLeaders",
 					profile,
 					"sharedPlanEntryLeadersMs",
@@ -369,6 +378,12 @@ const runScenario = async (name: string): Promise<BenchRow> => {
 				patchAsyncMethod(
 					store.docs.log as any,
 					"persistCoordinate",
+					profile,
+					"sharedPersistCoordinateMs",
+				),
+				patchAsyncMethod(
+					store.docs.log as any,
+					"persistCoordinatesBatch",
 					profile,
 					"sharedPersistCoordinateMs",
 				),

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -4156,7 +4156,6 @@ export class SharedLog<
 						);
 		if (
 			nativeAppendPlans &&
-			result.removed.length === 0 &&
 			(await this.processLocalAppendManyNativePlanned(
 				result.entries,
 				options,


### PR DESCRIPTION
## Summary
- keep independent document `putMany(unique,target:"none")` appends on the native shared-log batch path even when lower-log length trim reports removed entries
- add batch lower-log trim plumbing for native/rust-backed logs, including native log graph `delete_many`
- extend the document-put benchmark profile to show scalar vs native batch shared-log processing and direct coordinate batch time

## Benchmark signal
Local, 2026-05-11:

```bash
cd packages/programs/data/document/document
DOC_WARMUP=20 DOC_ITERATIONS=200 DOC_SCENARIOS=rust-peerbit-putmany,native-graph-putmany,simple-index-putmany DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Results:
- `rust-peerbit-putmany`: 4355 ops/sec, total 45.93 ms, scalar shared processing 0 ms, batch shared processing 3.70 ms, log trim 7.57 ms
- `native-graph-putmany`: 3395 ops/sec, total 58.91 ms, scalar shared processing 0 ms, batch shared processing 5.63 ms, log trim 11.09 ms
- `simple-index-putmany`: 6825 ops/sec, total 29.31 ms, scalar shared processing 0 ms, batch shared processing 0.51 ms, log trim 7.51 ms

Additional 1000-op run with `DOC_WARMUP=100 DOC_ITERATIONS=1000`:
- `rust-peerbit-putmany`: 5261 ops/sec
- `native-graph-putmany`: 3710 ops/sec
- `simple-index-putmany`: 4756 ops/sec

## Validation
- `cargo test` in `packages/log/rust`
- `pnpm --filter @peerbit/log-rust run build`
- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses the independent native prepared batch path|batches rust index and coordinate writes|removes trimmed prepared puts"`
- `cargo fmt --manifest-path packages/log/rust/Cargo.toml --check`
- `pnpm exec eslint packages/log/rust/src/index.ts packages/log/src/entry-index.ts packages/log/src/log.ts packages/log/src/trim.ts packages/programs/data/shared-log/src/index.ts packages/programs/data/document/document/benchmark/document-put.ts`
- `git diff --check`
