### PR TITLE
Use native graph for trim victim batches

### DIFF
--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -68,6 +68,7 @@ type NativeLogIndexHandle = {
 	has_many: (hashes: string[]) => string[];
 	oldest_hash: () => string | undefined;
 	newest_hash: () => string | undefined;
+	oldest_entries: (limit: number) => unknown[];
 	delete_many: (hashes: string[]) => number;
 	put: (
 		hash: string,
@@ -471,6 +472,38 @@ export class LogGraphIndex {
 
 	newestHash(): string | undefined {
 		return this.native.newest_hash();
+	}
+
+	oldestEntries(limit: number): NativeLogEntry[] {
+		return this.native.oldest_entries(limit).map((row) => {
+			const [hash, gid, wallTime, logical, type, next, payloadSize, head, data] =
+				row as [
+					string,
+					string,
+					string,
+					number,
+					number,
+					string[],
+					number,
+					boolean,
+					Uint8Array | undefined,
+				];
+			return {
+				hash,
+				gid,
+				next,
+				type,
+				head,
+				payloadSize,
+				data,
+				clock: {
+					timestamp: {
+						wallTime: BigInt(wallTime),
+						logical,
+					},
+				},
+			};
+		});
 	}
 
 	hasMany(hashes: Iterable<string>): Set<string> {

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -135,6 +135,16 @@ impl LogGraphIndex {
             .map(|entry| entry.hash.clone())
     }
 
+    pub fn oldest_entries(&self, limit: usize) -> Vec<LogIndexEntry> {
+        if limit == 0 {
+            return Vec::new();
+        }
+        let mut entries: Vec<LogIndexEntry> = self.entries.values().cloned().collect();
+        entries.sort_by(compare_entry_order);
+        entries.truncate(limit);
+        entries
+    }
+
     pub fn get(&self, hash: &str) -> Option<&LogIndexEntry> {
         self.entries.get(hash)
     }
@@ -736,6 +746,10 @@ impl NativeLogIndex {
             .newest_hash()
             .map(|hash| JsValue::from_str(&hash))
             .unwrap_or(JsValue::UNDEFINED)
+    }
+
+    pub fn oldest_entries(&self, limit: usize) -> Array {
+        log_trim_entries_to_rows(self.inner.oldest_entries(limit))
     }
 
     pub fn has_many(&self, hashes: Array) -> Result<Array, JsValue> {
@@ -2168,6 +2182,27 @@ fn log_join_entries_to_rows(values: Vec<LogIndexEntry>) -> Array {
     out
 }
 
+fn log_trim_entries_to_rows(values: Vec<LogIndexEntry>) -> Array {
+    let out = Array::new();
+    for entry in values {
+        let row = Array::new();
+        row.push(&JsValue::from_str(&entry.hash));
+        row.push(&JsValue::from_str(&entry.gid));
+        row.push(&JsValue::from_str(&entry.wall_time.to_string()));
+        row.push(&JsValue::from_f64(entry.logical as f64));
+        row.push(&JsValue::from_f64(entry.entry_type as f64));
+        row.push(&strings_to_array(entry.next));
+        row.push(&JsValue::from_f64(entry.payload_size as f64));
+        row.push(&JsValue::from_bool(entry.head));
+        match entry.data {
+            Some(data) => row.push(&Uint8Array::from(data.as_slice())),
+            None => row.push(&JsValue::UNDEFINED),
+        };
+        out.push(&row);
+    }
+    out
+}
+
 fn log_optional_entry_metadata_to_rows(
     values: Vec<Option<(String, String, Option<Vec<u8>>)>>,
 ) -> Array {
@@ -2313,6 +2348,23 @@ mod tests {
 
         index.delete("c");
         assert_eq!(index.oldest_hash(), Some("a".to_string()));
+    }
+
+    #[test]
+    fn returns_oldest_entries_by_clock_order() {
+        let mut index = LogGraphIndex::new();
+        index.put(LogIndexEntry::new("b", "g", vec![], APPEND, 2, 0, 1, true));
+        index.put(LogIndexEntry::new("a", "g", vec![], APPEND, 1, 1, 1, true));
+        index.put(LogIndexEntry::new("c", "g", vec![], APPEND, 1, 0, 1, true));
+
+        assert_eq!(
+            index
+                .oldest_entries(2)
+                .into_iter()
+                .map(|entry| entry.hash)
+                .collect::<Vec<_>>(),
+            vec!["c", "a"]
+        );
     }
 
     #[test]

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -101,6 +101,20 @@ describe("native log graph index", () => {
 		expect(index.payloadSizeSum()).to.equal(3);
 	});
 
+	it("returns oldest entries by clock order", async () => {
+		const index = await createLogGraphIndex();
+		index.putBatch([
+			entry("b", "g", [], 2n),
+			entry("a", "g", [], 1n),
+			entry("c", "g", [], 1n),
+		]);
+
+		expect(index.oldestEntries(2).map((entry) => entry.hash)).to.deep.equal([
+			"a",
+			"c",
+		]);
+	});
+
 	it("tracks heads and next adjacency in native append chains", async () => {
 		const index = await createLogGraphIndex();
 		index.put(entry("root", "g", [], 1n));

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -16,7 +16,8 @@ import {
 	StringMatchMethod,
 	toId,
 } from "@peerbit/indexer-interface";
-import type { ShallowEntry } from "./entry-shallow.js";
+import { LamportClock as Clock, Timestamp } from "./clock.js";
+import { ShallowEntry, ShallowMeta } from "./entry-shallow.js";
 import { EntryType } from "./entry-type.js";
 import {
 	Entry,
@@ -205,6 +206,7 @@ export type NativeLogGraph = {
 	>;
 	delete: (hash: string) => boolean;
 	deleteMany?: (hashes: Iterable<string>) => number;
+	oldestEntries?: (limit: number) => NativeLogEntry[];
 	clear: () => void;
 	heads: (gid?: string) => string[];
 	hasHead: (gid?: string) => boolean;
@@ -890,12 +892,36 @@ export class EntryIndex<T> {
 		if (limit <= 0) {
 			return [];
 		}
+		const nativeEntries = this.getNativeOldestEntries(limit, resolve);
+		if (nativeEntries) {
+			return nativeEntries as R[];
+		}
 		const iterator = this.iterate([], this.properties.sort.sort, resolve);
 		try {
 			return (await iterator.next(limit)) as R[];
 		} finally {
 			await iterator.close();
 		}
+	}
+
+	private getNativeOldestEntries<T extends boolean>(
+		limit: number,
+		resolve?: T,
+	): ShallowEntry[] | undefined {
+		if (resolve || limit <= 0) {
+			return;
+		}
+		const graph = this.properties.nativeGraph?.graph;
+		if (!graph?.oldestEntries) {
+			return;
+		}
+		const direction = timestampSortDirection(this.properties.sort.sort);
+		if (direction !== SortDirection.ASC) {
+			return;
+		}
+		return graph
+			.oldestEntries(limit)
+			.map((entry) => this.nativeLogEntryToShallowEntry(entry));
 	}
 
 	async getNewest<
@@ -1478,6 +1504,27 @@ export class EntryIndex<T> {
 			await this.privateUpdateNextHeadProperty(node, true);
 		}
 		return deleted;
+	}
+
+	private nativeLogEntryToShallowEntry(entry: NativeLogEntry): ShallowEntry {
+		return new ShallowEntry({
+			hash: entry.hash,
+			head: entry.head ?? false,
+			payloadSize: entry.payloadSize ?? 0,
+			meta: new ShallowMeta({
+				gid: entry.gid,
+				next: entry.next,
+				type: entry.type,
+				data: entry.data,
+				clock: new Clock({
+					id: this.properties.publicKey.bytes,
+					timestamp: new Timestamp({
+						wallTime: BigInt(entry.clock.timestamp.wallTime),
+						logical: entry.clock.timestamp.logical ?? 0,
+					}),
+				}),
+			}),
+		});
 	}
 
 	async getMemoryUsage() {

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -412,7 +412,7 @@ describe("native graph", () => {
 			trim: { type: "length", to: 2 },
 		});
 		const nativeGraph = log.entryIndex.properties.nativeGraph!.graph;
-		const oldestHashSpy = sinon.spy(nativeGraph, "oldestHash");
+		const oldestEntriesSpy = sinon.spy(nativeGraph, "oldestEntries");
 		const iterateSpy = sinon.spy(log.entryIndex.properties.index, "iterate");
 		try {
 			const first = (await log.append(new Uint8Array([1]), { meta: { next: [] } }))
@@ -420,13 +420,13 @@ describe("native graph", () => {
 			await log.append(new Uint8Array([2]));
 			await log.append(new Uint8Array([3]));
 
-			expect(oldestHashSpy.callCount).greaterThan(0);
+			expect(oldestEntriesSpy.callCount).greaterThan(0);
 			expect(iterateSpy.callCount).equal(0);
 			expect(await log.has(first.hash)).equal(false);
 			expect(await log.entryIndex.getOldest()).to.exist;
 		} finally {
 			iterateSpy.restore();
-			oldestHashSpy.restore();
+			oldestEntriesSpy.restore();
 			await log.close();
 		}
 	});


### PR DESCRIPTION
## Summary
- add native log graph `oldest_entries(limit)` and expose it as `LogGraphIndex.oldestEntries(limit)`
- route `EntryIndex.getOldestMany(limit, false)` through the native graph for timestamp-ascending native graphs
- keep lower-log length trim victim selection out of the generic TS/index iterator path when native graph state is available
- update native graph trim coverage and add Rust/TS wrapper coverage for oldest-entry ordering

## Benchmark signal
Local, 2026-05-11:

```bash
cd packages/programs/data/document/document
DOC_WARMUP=20 DOC_ITERATIONS=200 DOC_SCENARIOS=rust-peerbit-putmany,native-graph-putmany,simple-index-putmany DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Results:
- `rust-peerbit-putmany`: 4636 ops/sec, total 43.14 ms, log trim 5.98 ms
- `native-graph-putmany`: 3890 ops/sec, total 51.41 ms, log trim 4.56 ms
- `simple-index-putmany`: 6820 ops/sec, total 29.33 ms, log trim 7.81 ms

Compared with #897's recorded 200-op run:
- `rust-peerbit-putmany`: 4355 -> 4636 ops/sec
- `native-graph-putmany`: 3395 -> 3890 ops/sec
- `simple-index-putmany`: effectively unchanged, as intended

Additional 1000-op run with `DOC_WARMUP=100 DOC_ITERATIONS=1000`:
- `rust-peerbit-putmany`: 5470 ops/sec
- `native-graph-putmany`: 4000 ops/sec
- `simple-index-putmany`: 4912 ops/sec

## Validation
- `cargo test --manifest-path packages/log/rust/Cargo.toml`
- `pnpm --filter @peerbit/log-rust run build`
- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `pnpm --filter @peerbit/log-rust exec aegir test -t node --grep "returns oldest entries"`
- `pnpm --filter @peerbit/log exec aegir test -t node --grep "uses the native graph to plan unfiltered length trim"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses the independent native prepared batch path|batches rust index and coordinate writes|removes trimmed prepared puts"`
- `cargo fmt --manifest-path packages/log/rust/Cargo.toml --check`
- `pnpm exec eslint packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/log/src/entry-index.ts packages/log/src/log.ts packages/log/src/trim.ts packages/log/test/native-graph.spec.ts packages/programs/data/shared-log/src/index.ts packages/programs/data/document/document/benchmark/document-put.ts`
- `git diff --check`
