### PR TITLE
Preencode document putMany payloads

### DIFF
--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -591,6 +591,7 @@ export class EntryV0<T>
 
 	static async createPlainAppendChain<T>(properties: {
 		data: T[];
+		payloadDatas?: Uint8Array[];
 		meta?: {
 			clocks: () => Clock[];
 			gid?: string;
@@ -611,6 +612,7 @@ export class EntryV0<T>
 
 	static async createPlainAppendEntriesBatch<T>(properties: {
 		data: T[];
+		payloadDatas?: Uint8Array[];
 		meta: {
 			clocks: () => Clock[];
 			gids: string[];
@@ -637,7 +639,9 @@ export class EntryV0<T>
 		}
 		if (
 			properties.meta.gids.length !== properties.data.length ||
-			properties.meta.nexts.length !== properties.data.length
+			properties.meta.nexts.length !== properties.data.length ||
+			(properties.payloadDatas &&
+				properties.payloadDatas.length !== properties.data.length)
 		) {
 			throw new Error("Expected one gid and next list per entry");
 		}
@@ -662,10 +666,9 @@ export class EntryV0<T>
 			}
 		}
 
-		const payloadDatas = new Array<Uint8Array>(properties.data.length);
-		for (let i = 0; i < properties.data.length; i++) {
-			payloadDatas[i] = properties.encoding.encoder(properties.data[i]!);
-		}
+		const payloadDatas =
+			properties.payloadDatas ??
+			properties.data.map((data) => properties.encoding.encoder(data));
 		const input: NativePlainEntriesInput = {
 			clockId: properties.identity.publicKey.bytes,
 			privateKey: properties.identity.privateKey.privateKey,
@@ -805,6 +808,7 @@ export class EntryV0<T>
 
 	static async createPlainAppendChainBatch<T>(properties: {
 		data: T[];
+		payloadDatas?: Uint8Array[];
 		meta?: {
 			clocks: () => Clock[];
 			gid?: string;
@@ -897,7 +901,9 @@ export class EntryV0<T>
 		let payloadDatas: Uint8Array[] | undefined;
 		if (properties.data.length === 1) {
 			const clock = clocks[0]!;
-			const payloadData = properties.encoding.encoder(properties.data[0]!);
+			const payloadData =
+				properties.payloadDatas?.[0] ??
+				properties.encoding.encoder(properties.data[0]!);
 			const singleInput: NativePlainEntryInput = {
 				clockId,
 				privateKey,
@@ -952,13 +958,21 @@ export class EntryV0<T>
 			const metaDatas = new Array<Uint8Array | undefined>(
 				properties.data.length,
 			);
-			payloadDatas = new Array<Uint8Array>(properties.data.length);
+			if (
+				properties.payloadDatas &&
+				properties.payloadDatas.length !== properties.data.length
+			) {
+				throw new Error("Expected one payload data value per entry");
+			}
+			payloadDatas = properties.payloadDatas
+				? [...properties.payloadDatas]
+				: new Array<Uint8Array>(properties.data.length);
 			for (let i = 0; i < properties.data.length; i++) {
 				const clock = clocks[i]!;
 				wallTimes[i] = clock.timestamp.wallTime;
 				logicals[i] = clock.timestamp.logical;
 				metaDatas[i] = properties.meta?.data;
-				payloadDatas[i] = properties.encoding.encoder(properties.data[i]!);
+				payloadDatas[i] ??= properties.encoding.encoder(properties.data[i]!);
 			}
 			const nativePlainChainInput: NativePlainChainInput = {
 				clockId,

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -769,6 +769,7 @@ export class Log<T> {
 		options: AppendOptions<T> = {},
 		properties?: {
 			resolveTrimmedEntries?: boolean;
+			payloadDatas?: Uint8Array[];
 		},
 	): Promise<
 		| {
@@ -804,6 +805,7 @@ export class Log<T> {
 			data,
 			appendOptions,
 			deferBlockStore,
+			properties?.payloadDatas,
 		);
 		if (!nativeAppendBatch) {
 			return undefined;
@@ -993,6 +995,7 @@ export class Log<T> {
 		data: T[],
 		options: AppendOptions<T>,
 		deferBlockStore: boolean,
+		payloadDatas?: Uint8Array[],
 	): Promise<PreparedAppendChain<T> | undefined> {
 		const canAppendAlreadyValidated =
 			options.__peerbitCanAppendAlreadyValidated === true;
@@ -1006,7 +1009,8 @@ export class Log<T> {
 			options.meta?.timestamp ||
 			options.meta?.type === EntryType.CUT ||
 			options.meta?.gidSeed ||
-			options.meta?.next
+			options.meta?.next ||
+			(payloadDatas && payloadDatas.length !== data.length)
 		) {
 			return undefined;
 		}
@@ -1031,6 +1035,7 @@ export class Log<T> {
 		const directBatch = nativeGraph?.prepareEntryV0PlainEntriesCommit
 			? await EntryV0.createPlainAppendEntriesBatch<T>({
 					data,
+					payloadDatas,
 					meta: {
 						clocks: () => clocks,
 						gids,
@@ -1060,6 +1065,7 @@ export class Log<T> {
 		for (let i = 0; i < data.length; i++) {
 			const prepared = await EntryV0.createPlainAppendChainBatch<T>({
 				data: [data[i]!],
+				payloadDatas: payloadDatas ? [payloadDatas[i]!] : undefined,
 				meta: {
 					clocks: () => [clocks[i]!],
 					gid: gids[i]!,

--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -106,6 +106,18 @@ export type CanPerform<T> = (
 	properties: CanPerformOperations<T>,
 ) => MaybePromise<boolean>;
 
+const PUT_OPERATION_PREFIX_LENGTH = 6;
+const encodePutOperationPayload = (operation: PutOperation): Uint8Array => {
+	const data = operation.data;
+	const encoded = new Uint8Array(PUT_OPERATION_PREFIX_LENGTH + data.byteLength);
+	encoded[0] = 0;
+	encoded[1] = 3;
+	const view = new DataView(encoded.buffer, encoded.byteOffset, encoded.byteLength);
+	view.setUint32(2, data.byteLength, true);
+	encoded.set(data, PUT_OPERATION_PREFIX_LENGTH);
+	return encoded;
+};
+
 type PutChangeReference<T, I extends Record<string, any>> = {
 	document: T;
 	operation: PutOperation | PutWithKeyOperation;
@@ -745,6 +757,9 @@ export class Documents<
 			},
 			{
 				resolveTrimmedEntries: !this._index.canGetIdentityIndexedByHead(),
+				payloadDatas: prepared.map((item) =>
+					encodePutOperationPayload(item.operation as PutOperation),
+				),
 			},
 		);
 		if (!appended) {

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -314,6 +314,21 @@ describe("index", () => {
 						.equal(3);
 					expect(appended.entries.every((entry) => entry.meta.next.length === 0))
 						.equal(true);
+					const reloaded = await Entry.fromMultihash<Operation>(
+						store.docs.log.log.blocks,
+						appended.entries[0]!.hash,
+					);
+					reloaded.init({
+						encoding: store.docs.log.log.encoding,
+						keychain: store.docs.log.log.keychain,
+					});
+					const payload = await reloaded.getPayloadValue();
+					expect(payload).instanceOf(PutOperation);
+					expect(
+						store.docs.index.valueEncoding.decoder(
+							(payload as PutOperation).data,
+						).id,
+					).equal(docs[0]!.id);
 					expect(changes).to.have.length(1);
 					expect(changes[0].added.map((doc) => doc.id)).to.deep.equal(
 						docs.map((doc) => doc.id),

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -4094,6 +4094,7 @@ export class SharedLog<
 		options?: SharedAppendOptions<T> | undefined,
 		properties?: {
 			resolveTrimmedEntries?: boolean;
+			payloadDatas?: Uint8Array[];
 		},
 	): Promise<
 		| {
@@ -4122,6 +4123,7 @@ export class SharedLog<
 			appendOptions,
 			{
 				resolveTrimmedEntries: properties?.resolveTrimmedEntries,
+				payloadDatas: properties?.payloadDatas,
 			},
 		);
 		if (!result) {


### PR DESCRIPTION
## Summary
- plumb preencoded document put payload bytes through SharedLog/Log/EntryV0 native batch preparation
- use the eligible Documents.putMany fast path to pass preencoded PutOperation payloads instead of re-encoding operations in lower-log entry creation
- add a regression assertion that the stored lower-log entry still decodes as a PutOperation

## Benchmark signal
Local document-put bench, 2026-05-11:
- 1000-op: rust-peerbit-putMany 5470 -> 5601 ops/sec, native-graph-putMany 4000 -> 4315 ops/sec, simple-index-putMany 4912 -> 5009 ops/sec versus #898 notes
- 200-op run was noisy and not the primary signal: rust-peerbit-putMany 4113 ops/sec, native-graph-putMany 3860 ops/sec, simple-index-putMany 6193 ops/sec

## Validation
- pnpm --filter @peerbit/log run build
- pnpm --filter @peerbit/shared-log run build
- pnpm --filter @peerbit/document run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses the independent native prepared batch path|batches rust index and coordinate writes|removes trimmed prepared puts"
- pnpm exec eslint packages/log/src/entry-v0.ts packages/log/src/log.ts packages/programs/data/shared-log/src/index.ts packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/test/index.spec.ts
- git diff --check

Note: eslint reports one existing unrelated warning in document/test/index.spec.ts for an unused variable named second.