### PR TITLE
Batch native append gid generation

### DIFF
--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -589,6 +589,19 @@ export class EntryV0<T>
 		return seed ? sha256Base64(seed) : toBase64(randomBytes(32));
 	}
 
+	static createGids(count: number): string[] {
+		if (count === 0) {
+			return [];
+		}
+		const bytes = randomBytes(count * 32);
+		const gids = new Array<string>(count);
+		for (let i = 0; i < count; i++) {
+			const offset = i * 32;
+			gids[i] = toBase64(bytes.subarray(offset, offset + 32));
+		}
+		return gids;
+	}
+
 	static async createPlainAppendChain<T>(properties: {
 		data: T[];
 		payloadDatas?: Uint8Array[];

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -1021,9 +1021,7 @@ export class Log<T> {
 				? this.entryIndex.properties.nativeGraph.graph
 				: undefined;
 
-		const gids = await Promise.all(
-			data.map(() => Promise.resolve(EntryV0.createGid())),
-		);
+		const gids = EntryV0.createGids(data.length);
 		const clocks = data.map(
 			() =>
 				new Clock({


### PR DESCRIPTION
## Summary
- add EntryV0.createGids(count) to draw one random buffer for native independent-entry batches
- switch Log.createNativePlainAppendEntriesBatch from one createGid call per entry to the batched helper
- keep existing public behavior: each independent entry still gets its own random gid

## Benchmark signal
Local document-put bench, 2026-05-11:
- DOC_WARMUP=100 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-putmany,native-graph-putmany,simple-index-putmany DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
- Run 1: rust-peerbit-putMany 5691 ops/sec, native-graph-putMany 3924 ops/sec, simple-index-putMany 5037 ops/sec
- Run 2: rust-peerbit-putMany 5677 ops/sec, native-graph-putMany 4350 ops/sec, simple-index-putMany 4966 ops/sec

Compared with #899's 1000-op note, rust moves from 5601 to about 5680 ops/sec. Native-graph is noisy but the repeat is slightly above #899's 4315 ops/sec. Simple-index is effectively neutral.

## Validation
- pnpm --filter @peerbit/log run build
- pnpm --filter @peerbit/shared-log run build
- pnpm --filter @peerbit/document run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses the independent native prepared batch path|batches rust index and coordinate writes|removes trimmed prepared puts"
- pnpm exec eslint packages/log/src/entry-v0.ts packages/log/src/log.ts
- git diff --check