### PR TITLE
Batch native append clock generation

### DIFF
--- a/packages/log/src/clock.ts
+++ b/packages/log/src/clock.ts
@@ -130,6 +130,40 @@ export class HLC {
 		return this.update(this.last);
 	}
 
+	nowBatch(count: number): Timestamp[] {
+		if (count <= 0) {
+			return [];
+		}
+		const last = this.last;
+		let wallTime = this.wallTime();
+		const offset = last.wallTime - wallTime;
+		this.validateOffset(offset);
+		let logical: number;
+		if (offset < 0n) {
+			logical = 0;
+		} else {
+			wallTime = last.wallTime;
+			logical = last.logical + 1;
+		}
+
+		const maxWallTime =
+			this.wallTimeUpperBound > 0n ? this.wallTimeUpperBound : UINT64_MAX;
+		const timestamps = new Array<Timestamp>(count);
+		for (let i = 0; i < count; i++) {
+			if (logical > UINT32_MAX) {
+				wallTime += 1n;
+				logical = 0;
+			}
+			if (wallTime > maxWallTime) {
+				throw new WallTimeOverflowError(wallTime, maxWallTime);
+			}
+			timestamps[i] = new Timestamp({ wallTime, logical });
+			logical += 1;
+		}
+		this.last = timestamps[timestamps.length - 1]!;
+		return timestamps;
+	}
+
 	validateOffset(offset: bigint) {
 		if (
 			this.toleratedForwardClockJump > 0n &&

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -1022,11 +1022,12 @@ export class Log<T> {
 				: undefined;
 
 		const gids = EntryV0.createGids(data.length);
-		const clocks = data.map(
-			() =>
+		const clockId = this._identity.publicKey.bytes;
+		const clocks = this._hlc.nowBatch(data.length).map(
+			(timestamp) =>
 				new Clock({
-					id: this._identity.publicKey.bytes,
-					timestamp: this._hlc.now(),
+					id: clockId,
+					timestamp,
 				}),
 		);
 		const metaDatas = data.map(() => options.meta?.data);

--- a/packages/log/test/clock.spec.ts
+++ b/packages/log/test/clock.spec.ts
@@ -85,6 +85,26 @@ describe("hlc", () => {
 		t.equals(time2.logical, 2);
 		t.equals(time3.logical, 3);
 	});
+	it(".nowBatch() returns ordered timestamps from one walltime sample", () => {
+		let samples = 0;
+		const wallTimes = [10n, 11n, 11n];
+		const clock = new HLC({
+			wallTime: () => wallTimes[Math.min(samples++, wallTimes.length - 1)]!,
+		});
+
+		const timestamps = clock.nowBatch(3);
+
+		t.equals(samples, 2); // constructor + batch
+		t.deepEquals(timestamps, [
+			new Timestamp({ wallTime: 11n, logical: 0 }),
+			new Timestamp({ wallTime: 11n, logical: 1 }),
+			new Timestamp({ wallTime: 11n, logical: 2 }),
+		]);
+		t.deepEquals(
+			clock.now(),
+			new Timestamp({ wallTime: 11n, logical: 3 }),
+		);
+	});
 	it("Timestamp comparison", () => {
 		const a = new Timestamp({ wallTime: 0n, logical: 0 });
 		const b = new Timestamp({ wallTime: 0n, logical: 1 });


### PR DESCRIPTION
## Summary
- add HLC.nowBatch(count) to generate ordered timestamps from one wall-clock sample
- use the batch timestamp helper when preparing independent native append entries
- cover ordered batch timestamps and post-batch monotonicity in the HLC tests

## Performance signal
Focused HLC microbench, 2026-05-11, 2,000,000 timestamps:
- scalar now(): 81.35 ms, about 24.6M timestamps/sec
- nowBatch(100000): 41.61 ms, about 48.1M timestamps/sec

Document putMany bench is noisy/mostly neutral, but not negative enough to indicate a regression:
- Run 1: rust-peerbit-putMany 5769 ops/sec, native-graph-putMany 4278 ops/sec, simple-index-putMany 4994 ops/sec
- Run 2: rust-peerbit-putMany 5400 ops/sec, native-graph-putMany 4274 ops/sec, simple-index-putMany 5104 ops/sec

I also tried a native resident coordinate commit batch before this, but dropped it because the focused microbench was slower than scalar resident commits due TS/Rust marshaling cost.

## Validation
- pnpm --filter @peerbit/log run build
- pnpm --filter @peerbit/shared-log run build
- pnpm --filter @peerbit/document run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "nowBatch|append commits one block and graph in one native call when storage is native|appendMany commits blocks and graph in one native call when storage is native"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses the independent native prepared batch path|batches rust index and coordinate writes|removes trimmed prepared puts"
- pnpm exec eslint packages/log/src/clock.ts packages/log/src/log.ts packages/log/test/clock.spec.ts
- git diff --check