### PR TITLE
Fast path identity document batch projection

### DIFF
--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -1767,8 +1767,15 @@ export class DocumentIndex<
 		if (values.length === 0) {
 			return [];
 		}
-		const transformed = await Promise.all(
-			values.map(async (item) => {
+		let transformed: Array<
+			(typeof values)[number] & {
+				indexable: I;
+			}
+		>;
+		if (this.transformerIsIdentity) {
+			transformed = new Array(values.length);
+			for (let i = 0; i < values.length; i++) {
+				const item = values[i]!;
 				const idString = item.id.primitive;
 				if (this.isProgramValued) {
 					this._resolverProgramCache!.set(idString, item.value);
@@ -1777,14 +1784,29 @@ export class DocumentIndex<
 					this._resolverCache.add(idString, item.value);
 					indexCacheLogger("cache:set:value", { id: idString });
 				}
-				const indexable = this.transformerIsIdentity
-					? (item.value as any as I)
-					: await this.transformer(item.value, item.context);
+				const indexable = item.value as any as I;
 				coerceWithIndexed(item.value, indexable);
 				coerceWithContext(item.value, item.context);
-				return { ...item, indexable };
-			}),
-		);
+				transformed[i] = { ...item, indexable };
+			}
+		} else {
+			transformed = await Promise.all(
+				values.map(async (item) => {
+					const idString = item.id.primitive;
+					if (this.isProgramValued) {
+						this._resolverProgramCache!.set(idString, item.value);
+						indexCacheLogger("cache:set:program", { id: idString });
+					} else if (this._resolverCache) {
+						this._resolverCache.add(idString, item.value);
+						indexCacheLogger("cache:set:value", { id: idString });
+					}
+					const indexable = await this.transformer(item.value, item.context);
+					coerceWithIndexed(item.value, indexable);
+					coerceWithContext(item.value, item.context);
+					return { ...item, indexable };
+				}),
+			);
+		}
 
 		try {
 			const contextualBatchPut = this.transformerIsIdentity


### PR DESCRIPTION
## Summary
- make DocumentIndex.putManyWithContext synchronous for identity-transform batches
- keep resolver cache updates plus __indexed/__context coercion unchanged
- leave custom transformer batches on the existing async Promise.all path

## Benchmark signal
Local document-put bench, 2026-05-11:
- DOC_WARMUP=100 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-putmany,native-graph-putmany,simple-index-putmany DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
- Run 1: rust-peerbit-putMany 5637 ops/sec, native-graph-putMany 4252 ops/sec, simple-index-putMany 4861 ops/sec
- Run 2: rust-peerbit-putMany 5764 ops/sec, native-graph-putMany 4238 ops/sec, simple-index-putMany 4950 ops/sec

Signal is modest/noisy. The value is removing async projection overhead for the plain fast path without touching custom transforms.

## Validation
- pnpm --filter @peerbit/document run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses the independent native prepared batch path|batches rust index and coordinate writes|removes trimmed prepared puts"
- pnpm exec eslint packages/programs/data/document/document/src/search.ts
- git diff --check