### PR TITLE
Bridge native indexer schema IR

### DIFF
--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -28,6 +28,7 @@ export type RustIndexerOptions = {
 };
 
 type NativeRustIndex<T extends Record<string, any>> = {
+	configure_schema_ir: (schemaIr: Uint8Array) => [number, number];
 	put: (
 		key: string,
 		id: types.IdKey,
@@ -172,6 +173,28 @@ const enum NativeStringMatchMethodTag {
 const enum NativeSortDirectionTag {
 	Asc = 0,
 	Desc = 1,
+}
+
+const enum NativeSchemaNodeTag {
+	Bool = 0,
+	U8 = 1,
+	U16 = 2,
+	U32 = 3,
+	U64 = 4,
+	U128 = 5,
+	U256 = 6,
+	U512 = 7,
+	I8 = 8,
+	I16 = 9,
+	I32 = 10,
+	I64 = 11,
+	String = 12,
+	Uint8Array = 13,
+	Object = 14,
+	Option = 15,
+	Vec = 16,
+	FixedArray = 17,
+	Generic = 18,
 }
 
 const textEncoder = new TextEncoder();
@@ -614,7 +637,56 @@ class NativeFieldWriter {
 	}
 }
 
+class NativeSchemaIrWriter {
+	private output: Uint8Array;
+	private view: DataView;
+	private offset = 0;
+
+	constructor(initialSize = 256) {
+		this.output = new Uint8Array(initialSize);
+		this.view = new DataView(this.output.buffer);
+	}
+
+	u8(value: number): void {
+		this.ensure(1);
+		this.output[this.offset++] = value;
+	}
+
+	u32(value: number): void {
+		this.ensure(4);
+		this.offset = writeUint32(this.view, this.offset, value);
+	}
+
+	string(value: string): void {
+		const bytes = textEncoder.encode(value);
+		this.u32(bytes.byteLength);
+		this.ensure(bytes.byteLength);
+		this.output.set(bytes, this.offset);
+		this.offset += bytes.byteLength;
+	}
+
+	finish(): Uint8Array {
+		return this.output.subarray(0, this.offset);
+	}
+
+	private ensure(extra: number): void {
+		const needed = this.offset + extra;
+		if (needed <= this.output.byteLength) {
+			return;
+		}
+		let nextSize = this.output.byteLength;
+		while (nextSize < needed) {
+			nextSize *= 2;
+		}
+		const next = new Uint8Array(nextSize);
+		next.set(this.output);
+		this.output = next;
+		this.view = new DataView(this.output.buffer);
+	}
+}
+
 type NativeFieldEncoder<T extends Record<string, any>> = (value: T) => Uint8Array;
+type NativeSchemaIrStats = { rootFields: number; nodeCount: number };
 type SharedLogCoordinateNativeFields = {
 	hash: string;
 	hashNumber: number | bigint;
@@ -805,6 +877,159 @@ const integerFieldTypes = new Set([
 	"i32",
 	"i64",
 ]);
+
+const nativeSchemaIntegerNodeTag = (
+	fieldType: string,
+): NativeSchemaNodeTag | undefined => {
+	switch (fieldType) {
+		case "u8":
+			return NativeSchemaNodeTag.U8;
+		case "u16":
+			return NativeSchemaNodeTag.U16;
+		case "u32":
+			return NativeSchemaNodeTag.U32;
+		case "u64":
+			return NativeSchemaNodeTag.U64;
+		case "u128":
+			return NativeSchemaNodeTag.U128;
+		case "u256":
+			return NativeSchemaNodeTag.U256;
+		case "u512":
+			return NativeSchemaNodeTag.U512;
+		case "i8":
+			return NativeSchemaNodeTag.I8;
+		case "i16":
+			return NativeSchemaNodeTag.I16;
+		case "i32":
+			return NativeSchemaNodeTag.I32;
+		case "i64":
+			return NativeSchemaNodeTag.I64;
+		default:
+			return undefined;
+	}
+};
+
+const encodeNativeSchemaIr = (
+	schema: Function,
+	dictionary: NativeFieldDictionary,
+): Uint8Array => {
+	const writer = new NativeSchemaIrWriter();
+	writer.u8(BRIDGE_VERSION);
+	writeNativeSchemaNode(writer, schema, dictionary, undefined, new Set());
+	return writer.finish();
+};
+
+const writeNativeSchemaObjectNode = (
+	writer: NativeSchemaIrWriter,
+	ctor: Function,
+	dictionary: NativeFieldDictionary,
+	cursor: NativeFieldCursor | undefined,
+	active: Set<Function>,
+): void => {
+	if (active.has(ctor)) {
+		writer.u8(NativeSchemaNodeTag.Generic);
+		return;
+	}
+	let schemas: ReturnType<typeof getSchemasBottomUp>;
+	try {
+		schemas = getSchemasBottomUp(ctor);
+	} catch {
+		writer.u8(NativeSchemaNodeTag.Generic);
+		return;
+	}
+	if (!schemas?.length) {
+		writer.u8(NativeSchemaNodeTag.Generic);
+		return;
+	}
+
+	active.add(ctor);
+	const fields = schemas.flatMap((nextSchema) => nextSchema.fields);
+	writer.u8(NativeSchemaNodeTag.Object);
+	writer.u32(fields.length);
+	for (const field of fields) {
+		const fieldCursor = appendNativeFieldCursor(dictionary, cursor, field.key);
+		writer.string(field.key);
+		writer.u32(fieldCursor.fieldId);
+		writer.u32(fieldCursor.arrayFieldId);
+		writeNativeSchemaNode(
+			writer,
+			field.type,
+			dictionary,
+			fieldCursor,
+			active,
+		);
+	}
+	active.delete(ctor);
+};
+
+const writeNativeSchemaNode = (
+	writer: NativeSchemaIrWriter,
+	fieldType: FieldType | Function,
+	dictionary: NativeFieldDictionary,
+	cursor: NativeFieldCursor | undefined,
+	active: Set<Function>,
+): void => {
+	if (fieldType instanceof OptionKind) {
+		writer.u8(NativeSchemaNodeTag.Option);
+		writeNativeSchemaNode(
+			writer,
+			fieldType.elementType,
+			dictionary,
+			cursor,
+			active,
+		);
+		return;
+	}
+
+	if (fieldType instanceof VecKind || fieldType instanceof FixedArrayKind) {
+		if (fieldType instanceof FixedArrayKind) {
+			writer.u8(NativeSchemaNodeTag.FixedArray);
+			writer.u32(fieldType.length);
+		} else {
+			writer.u8(NativeSchemaNodeTag.Vec);
+		}
+		writeNativeSchemaNode(
+			writer,
+			fieldType.elementType,
+			dictionary,
+			cursor,
+			active,
+		);
+		return;
+	}
+
+	if (fieldType === Uint8Array) {
+		writer.u8(NativeSchemaNodeTag.Uint8Array);
+		return;
+	}
+
+	if (fieldType instanceof StringType) {
+		writer.u8(NativeSchemaNodeTag.String);
+		return;
+	}
+
+	if (typeof fieldType === "string") {
+		if (fieldType === "bool") {
+			writer.u8(NativeSchemaNodeTag.Bool);
+			return;
+		}
+		if (fieldType === "string") {
+			writer.u8(NativeSchemaNodeTag.String);
+			return;
+		}
+		writer.u8(
+			nativeSchemaIntegerNodeTag(fieldType) ?? NativeSchemaNodeTag.Generic,
+		);
+		return;
+	}
+
+	if (typeof fieldType === "function") {
+		writeNativeSchemaObjectNode(writer, fieldType, dictionary, cursor, active);
+		return;
+	}
+
+	writer.u8(NativeSchemaNodeTag.Generic);
+};
 
 const compileNativeFieldEncoder = <T extends Record<string, any>>(
 	schema: Function,
@@ -1233,6 +1458,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 	private properties!: types.IndexEngineInitProperties<T, NestedType>;
 	private fieldDictionary!: NativeFieldDictionary;
 	private fieldEncoder!: NativeFieldEncoder<T>;
+	private nativeSchemaIrStats?: NativeSchemaIrStats;
 	private byteElementIndexLimit!: number;
 	private sharedLogCoordinateFieldIds?: {
 		hash: number;
@@ -1281,6 +1507,10 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			this.fieldDictionary,
 			this.options,
 		);
+		const [rootFields, nodeCount] = this.native.configure_schema_ir(
+			encodeNativeSchemaIr(properties.schema, this.fieldDictionary),
+		);
+		this.nativeSchemaIrStats = { rootFields, nodeCount };
 		this.snapshotFile = await createSnapshotFile(
 			this.directory,
 			this.path,

--- a/packages/utils/indexer/rust/src/lib.rs
+++ b/packages/utils/indexer/rust/src/lib.rs
@@ -180,6 +180,7 @@ impl NativeQueryPlanner {
 pub struct NativeRustIndex {
     store: NativeIndexStore,
     planner: NativeQueryPlanner,
+    schema_ir: Option<NativeSchemaIr>,
 }
 
 #[wasm_bindgen]
@@ -189,12 +190,23 @@ impl NativeRustIndex {
         NativeRustIndex {
             store: NativeIndexStore::new(),
             planner: NativeQueryPlanner::new(),
+            schema_ir: None,
         }
     }
 
     pub fn clear(&mut self) {
         self.store.clear();
         self.planner.clear();
+    }
+
+    pub fn configure_schema_ir(&mut self, schema_ir_bytes: Vec<u8>) -> Result<Array, JsValue> {
+        let schema_ir = decode_native_schema_ir(&schema_ir_bytes)?;
+        let stats = schema_ir.stats();
+        self.schema_ir = Some(schema_ir);
+        let out = Array::new();
+        out.push(&JsValue::from_f64(stats.root_fields as f64));
+        out.push(&JsValue::from_f64(stats.node_count as f64));
+        Ok(out)
     }
 
     pub fn len(&self) -> usize {
@@ -417,6 +429,98 @@ enum StringMatchMethodDto {
     Contains,
 }
 
+#[derive(Clone, Debug)]
+struct NativeSchemaIr {
+    root: NativeSchemaNode,
+}
+
+#[derive(Clone, Debug)]
+struct NativeSchemaField {
+    key: String,
+    field: u32,
+    array_field: u32,
+    node: NativeSchemaNode,
+}
+
+#[derive(Clone, Debug)]
+enum NativeSchemaNode {
+    Bool,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    U256,
+    U512,
+    I8,
+    I16,
+    I32,
+    I64,
+    String,
+    Uint8Array,
+    Object(Vec<NativeSchemaField>),
+    Option(Box<NativeSchemaNode>),
+    Vec(Box<NativeSchemaNode>),
+    FixedArray {
+        length: u32,
+        element: Box<NativeSchemaNode>,
+    },
+    Generic,
+}
+
+struct NativeSchemaIrStats {
+    root_fields: usize,
+    node_count: usize,
+}
+
+impl NativeSchemaIr {
+    fn stats(&self) -> NativeSchemaIrStats {
+        NativeSchemaIrStats {
+            root_fields: match &self.root {
+                NativeSchemaNode::Object(fields) => fields.len(),
+                _ => 0,
+            },
+            node_count: self.root.node_count(),
+        }
+    }
+}
+
+impl NativeSchemaNode {
+    fn node_count(&self) -> usize {
+        match self {
+            NativeSchemaNode::Object(fields) => {
+                1 + fields
+                    .iter()
+                    .map(|field| {
+                        let _ = (&field.key, field.field, field.array_field);
+                        field.node.node_count()
+                    })
+                    .sum::<usize>()
+            }
+            NativeSchemaNode::Option(node) | NativeSchemaNode::Vec(node) => 1 + node.node_count(),
+            NativeSchemaNode::FixedArray { length, element } => {
+                let _ = length;
+                1 + element.node_count()
+            }
+            NativeSchemaNode::Bool
+            | NativeSchemaNode::U8
+            | NativeSchemaNode::U16
+            | NativeSchemaNode::U32
+            | NativeSchemaNode::U64
+            | NativeSchemaNode::U128
+            | NativeSchemaNode::U256
+            | NativeSchemaNode::U512
+            | NativeSchemaNode::I8
+            | NativeSchemaNode::I16
+            | NativeSchemaNode::I32
+            | NativeSchemaNode::I64
+            | NativeSchemaNode::String
+            | NativeSchemaNode::Uint8Array
+            | NativeSchemaNode::Generic => 1,
+        }
+    }
+}
+
 struct BridgeReader<'a> {
     bytes: &'a [u8],
     offset: usize,
@@ -492,6 +596,54 @@ impl<'a> BridgeReader<'a> {
         self.offset = end;
         Ok(bytes)
     }
+}
+
+fn decode_native_schema_ir(schema_ir_bytes: &[u8]) -> Result<NativeSchemaIr, JsValue> {
+    let mut reader = BridgeReader::new(schema_ir_bytes);
+    ensure_bridge_version(reader.read_u8()?)?;
+    let root = read_native_schema_node(&mut reader)?;
+    reader.finish()?;
+    Ok(NativeSchemaIr { root })
+}
+
+fn read_native_schema_node(reader: &mut BridgeReader) -> Result<NativeSchemaNode, JsValue> {
+    Ok(match reader.read_u8()? {
+        0 => NativeSchemaNode::Bool,
+        1 => NativeSchemaNode::U8,
+        2 => NativeSchemaNode::U16,
+        3 => NativeSchemaNode::U32,
+        4 => NativeSchemaNode::U64,
+        5 => NativeSchemaNode::U128,
+        6 => NativeSchemaNode::U256,
+        7 => NativeSchemaNode::U512,
+        8 => NativeSchemaNode::I8,
+        9 => NativeSchemaNode::I16,
+        10 => NativeSchemaNode::I32,
+        11 => NativeSchemaNode::I64,
+        12 => NativeSchemaNode::String,
+        13 => NativeSchemaNode::Uint8Array,
+        14 => {
+            let field_count = reader.read_u32()? as usize;
+            let mut fields = Vec::with_capacity(field_count);
+            for _ in 0..field_count {
+                fields.push(NativeSchemaField {
+                    key: reader.read_string()?,
+                    field: reader.read_u32()?,
+                    array_field: reader.read_u32()?,
+                    node: read_native_schema_node(reader)?,
+                });
+            }
+            NativeSchemaNode::Object(fields)
+        }
+        15 => NativeSchemaNode::Option(Box::new(read_native_schema_node(reader)?)),
+        16 => NativeSchemaNode::Vec(Box::new(read_native_schema_node(reader)?)),
+        17 => NativeSchemaNode::FixedArray {
+            length: reader.read_u32()?,
+            element: Box::new(read_native_schema_node(reader)?),
+        },
+        18 => NativeSchemaNode::Generic,
+        tag => return Err(js_error(format!("Unknown native schema node tag {tag}"))),
+    })
 }
 
 fn decode_document_fields(fields_bytes: &[u8]) -> Result<DocumentFields, JsValue> {

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -223,6 +223,19 @@ describe("all", () => {
 });
 
 describe("native planner bridge", () => {
+	it("hands compiled borsh schema ir to native rust", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeNestedDocument });
+		const { nativeSchemaIrStats: stats } = index as unknown as {
+			nativeSchemaIrStats?: { rootFields: number; nodeCount: number };
+		};
+
+		expect(stats).to.deep.equal({ rootFields: 2, nodeCount: 6 });
+
+		await indices.drop();
+	});
+
 	it("does not expose the previous typescript query fallback evaluator", async () => {
 		const indices = create();
 		await indices.start();


### PR DESCRIPTION
## Summary
- compile the existing TypeScript/Borsh index schema into a compact internal schema IR at RustIndex init
- pass the schema IR into the Rust wasm indexer and decode/store it natively
- add a focused native planner bridge test for nested schema handoff

## Notes
This does not flip document/index fact extraction yet. It is the next foundation step for moving extraction from JS into Rust, then coalescing document put/index transactions around native schema knowledge.

## Test Plan
- cargo test --manifest-path packages/utils/indexer/rust/Cargo.toml
- pnpm --filter @peerbit/indexer-rust run build
- pnpm --filter @peerbit/indexer-rust exec aegir test -t node --grep "hands compiled borsh schema ir"
- pnpm exec eslint --config eslint.config.js packages/utils/indexer/rust/src/index.ts packages/utils/indexer/rust/test/index.spec.ts
- pnpm --filter @peerbit/indexer-rust test
- git diff --check