### PR TITLE
Extract native index facts from Borsh bytes

### DIFF
--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -29,23 +29,30 @@ describe("native graph", () => {
 		await store.stop();
 	});
 
-	it("serves heads while preserving buffered index flush behavior", async () => {
+	it("serves heads from the native graph without forcing buffered index flush", async () => {
 		const log = new Log<Uint8Array>();
 		await log.open(store, signKey, {
 			indexer: new HashmapIndices(),
 			nativeGraph: true,
 		});
 		const putSpy = sinon.spy(log.entryIndex.properties.index, "put");
+		const putBatchSpy = sinon.spy(
+			log.entryIndex.properties.index,
+			"putBatch",
+		);
 		const { entry } = await log.append(new Uint8Array([1]), {
 			meta: { next: [] },
 		});
 
 		expect(putSpy.callCount).equal(0);
+		const batchWritesBeforeHeads = putBatchSpy.callCount;
 		expect((await log.getHeads().all()).map((head) => head.hash)).to.deep.equal(
 			[entry.hash],
 		);
-		expect(putSpy.callCount).equal(1);
+		expect(putSpy.callCount).equal(0);
+		expect(putBatchSpy.callCount).equal(batchWritesBeforeHeads);
 
+		putBatchSpy.restore();
 		putSpy.restore();
 		await log.close();
 	});

--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -137,6 +137,7 @@ type DocumentPutOptions = SharedAppendOptions<Operation> & {
 
 type PreparedPut<T> = {
 	document: T;
+	encodedDocument: Uint8Array;
 	keyValue: indexerTypes.IdPrimitive;
 	key: indexerTypes.IdKey;
 	operation: PutOperation | PutWithKeyOperation;
@@ -660,7 +661,7 @@ export class Documents<
 				data: ser,
 			});
 		}
-		return { document: doc, keyValue, key, operation };
+		return { document: doc, encodedDocument: ser, keyValue, key, operation };
 	}
 
 	public async put(doc: T, options?: DocumentPutOptions) {
@@ -692,6 +693,7 @@ export class Documents<
 		) {
 			return this.putPlainFastPath(
 				prepared.document,
+				prepared.encodedDocument,
 				prepared.key,
 				prepared.operation,
 				existingHead,
@@ -769,6 +771,7 @@ export class Documents<
 		await this.handlePreparedPlainPutManyCommit({
 			puts: prepared.map((item, index) => ({
 				document: item.document,
+				encodedDocument: item.encodedDocument,
 				key: item.key,
 				entry: appended.entries[index]!,
 			})),
@@ -841,6 +844,7 @@ export class Documents<
 
 	private async putPlainFastPath(
 		doc: T,
+		encodedDocument: Uint8Array,
 		key: indexerTypes.IdKey,
 		operation: PutOperation,
 		existingHead: string | undefined,
@@ -892,6 +896,7 @@ export class Documents<
 		} else {
 			await this.handlePreparedPlainPutCommit({
 				document: doc,
+				encodedDocument,
 				key,
 				entry: appended.entry,
 				removed: appended.removed,
@@ -935,6 +940,7 @@ export class Documents<
 
 	private async handlePreparedPlainPutCommit(properties: {
 		document: T;
+		encodedDocument?: Uint8Array;
 		key: indexerTypes.IdKey;
 		entry: Entry<Operation>;
 		removed: ShallowOrFullEntry<Operation>[];
@@ -981,6 +987,7 @@ export class Documents<
 				context,
 				{
 					replace: existing != null,
+					encodedValue: properties.encodedDocument,
 				},
 			);
 			documentsChanged.added.push(
@@ -1032,6 +1039,7 @@ export class Documents<
 	private async handlePreparedPlainPutManyCommit(properties: {
 		puts: {
 			document: T;
+			encodedDocument?: Uint8Array;
 			key: indexerTypes.IdKey;
 			entry: Entry<Operation>;
 		}[];
@@ -1045,6 +1053,7 @@ export class Documents<
 
 		const putsToIndex: Array<{
 			document: T;
+			encodedDocument?: Uint8Array;
 			key: indexerTypes.IdKey;
 			context: Context;
 		}> = [];
@@ -1059,7 +1068,12 @@ export class Documents<
 				gid: put.entry.meta.gid,
 				size: put.entry.payload.byteLength,
 			});
-			putsToIndex.push({ document: put.document, key: put.key, context });
+			putsToIndex.push({
+				document: put.document,
+				encodedDocument: put.encodedDocument,
+				key: put.key,
+				context,
+			});
 			modified.add(put.key.primitive);
 		}
 		const indexed = await this._index.putManyWithContext(
@@ -1067,7 +1081,10 @@ export class Documents<
 				value: put.document,
 				id: put.key,
 				context: put.context,
-				options: { replace: false },
+				options: {
+					replace: false,
+					encodedValue: put.encodedDocument,
+				},
 			})),
 		);
 		for (let i = 0; i < putsToIndex.length; i++) {

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -656,12 +656,18 @@ type IndexableClass<I> = new (
 type ContextualPutOptions = {
 	replace?: boolean;
 	encodedValue?: Uint8Array;
+	encodedValueParts?: {
+		prefix: Uint8Array;
+		suffix: Uint8Array;
+	};
 };
 
 const stripEncodedValue = (
 	options: ContextualPutOptions | undefined,
 ): { replace?: boolean } | undefined =>
-	options?.encodedValue ? { replace: options.replace } : options;
+	options?.encodedValue || options?.encodedValueParts
+		? { replace: options.replace }
+		: options;
 
 type ContextualIndexPut<I> = {
 	putWithContext?: (
@@ -1749,7 +1755,7 @@ export class DocumentIndex<
 				? (this.index as ContextualIndexPut<I>).putWithContext
 				: undefined;
 			if (contextualPut) {
-				const encodedValue = this.encodeContextualIndexedValue(
+				const encodedValueParts = this.encodeContextualIndexedValueParts(
 					options?.encodedValue,
 					context,
 				);
@@ -1758,8 +1764,8 @@ export class DocumentIndex<
 					valueToIndex,
 					id,
 					context,
-					encodedValue
-						? { ...options, encodedValue }
+					encodedValueParts
+						? { ...options, encodedValue: undefined, encodedValueParts }
 						: options?.encodedValue
 							? { ...options, encodedValue: undefined }
 							: options,
@@ -1908,17 +1914,19 @@ export class DocumentIndex<
 		if (!options?.encodedValue) {
 			return options;
 		}
-		const encodedValue = this.encodeContextualIndexedValue(
+		const encodedValueParts = this.encodeContextualIndexedValueParts(
 			options.encodedValue,
 			context,
 		);
-		return { ...options, encodedValue };
+		return encodedValueParts
+			? { ...options, encodedValue: undefined, encodedValueParts }
+			: options;
 	}
 
-	private encodeContextualIndexedValue(
+	private encodeContextualIndexedValueParts(
 		encodedValue: Uint8Array | undefined,
 		context: types.Context,
-	): Uint8Array | undefined {
+	): ContextualPutOptions["encodedValueParts"] | undefined {
 		if (
 			!encodedValue ||
 			!this.transformerIsIdentity ||
@@ -1926,7 +1934,10 @@ export class DocumentIndex<
 		) {
 			return;
 		}
-		return concat([encodedValue, serialize(context)]);
+		return {
+			prefix: encodedValue,
+			suffix: serialize(context),
+		};
 	}
 
 	public del(key: indexerTypes.IdKey) {

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -669,6 +669,44 @@ const stripEncodedValue = (
 		? { replace: options.replace }
 		: options;
 
+const writeU32Le = (target: Uint8Array, offset: number, value: number) => {
+	target[offset] = value & 0xff;
+	target[offset + 1] = (value >>> 8) & 0xff;
+	target[offset + 2] = (value >>> 16) & 0xff;
+	target[offset + 3] = (value >>> 24) & 0xff;
+	return offset + 4;
+};
+
+const writeU64Le = (target: Uint8Array, offset: number, value: bigint) => {
+	let remaining = value;
+	for (let i = 0; i < 8; i++) {
+		target[offset + i] = Number(remaining & 0xffn);
+		remaining >>= 8n;
+	}
+	return offset + 8;
+};
+
+const encodeContextSuffix = (context: types.Context): Uint8Array => {
+	const head = fromString(context.head);
+	const gid = fromString(context.gid);
+	const encoded = new Uint8Array(
+		1 + 8 + 8 + 4 + head.byteLength + 4 + gid.byteLength + 4,
+	);
+	let offset = 0;
+	// Context is @variant(0); keep this byte-for-byte aligned with Borsh.
+	encoded[offset++] = 0;
+	offset = writeU64Le(encoded, offset, context.created);
+	offset = writeU64Le(encoded, offset, context.modified);
+	offset = writeU32Le(encoded, offset, head.byteLength);
+	encoded.set(head, offset);
+	offset += head.byteLength;
+	offset = writeU32Le(encoded, offset, gid.byteLength);
+	encoded.set(gid, offset);
+	offset += gid.byteLength;
+	writeU32Le(encoded, offset, context.size);
+	return encoded;
+};
+
 type ContextualIndexPut<I> = {
 	putWithContext?: (
 		value: I,
@@ -1936,7 +1974,7 @@ export class DocumentIndex<
 		}
 		return {
 			prefix: encodedValue,
-			suffix: serialize(context),
+			suffix: encodeContextSuffix(context),
 		};
 	}
 

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -653,19 +653,29 @@ type IndexableClass<I> = new (
 	context: types.Context,
 ) => WithContext<I>;
 
+type ContextualPutOptions = {
+	replace?: boolean;
+	encodedValue?: Uint8Array;
+};
+
+const stripEncodedValue = (
+	options: ContextualPutOptions | undefined,
+): { replace?: boolean } | undefined =>
+	options?.encodedValue ? { replace: options.replace } : options;
+
 type ContextualIndexPut<I> = {
 	putWithContext?: (
 		value: I,
 		id: indexerTypes.IdKey,
 		context: types.Context,
-		options?: { replace?: boolean },
+		options?: ContextualPutOptions,
 	) => Promise<void> | void;
 	putWithContextBatch?: (
 		values: Array<{
 			value: I;
 			id: indexerTypes.IdKey;
 			context: types.Context;
-			options?: { replace?: boolean };
+			options?: ContextualPutOptions;
 		}>,
 	) => Promise<void> | void;
 };
@@ -1707,7 +1717,7 @@ export class DocumentIndex<
 		value: T,
 		id: indexerTypes.IdKey,
 		context: types.Context,
-		options?: { replace?: boolean },
+		options?: ContextualPutOptions,
 	): Promise<{ context: types.Context; indexable: I }> {
 		const idString = id.primitive;
 		if (
@@ -1739,13 +1749,31 @@ export class DocumentIndex<
 				? (this.index as ContextualIndexPut<I>).putWithContext
 				: undefined;
 			if (contextualPut) {
-				await contextualPut.call(this.index, valueToIndex, id, context, options);
+				const encodedValue = this.encodeContextualIndexedValue(
+					options?.encodedValue,
+					context,
+				);
+				await contextualPut.call(
+					this.index,
+					valueToIndex,
+					id,
+					context,
+					encodedValue
+						? { ...options, encodedValue }
+						: options?.encodedValue
+							? { ...options, encodedValue: undefined }
+							: options,
+				);
 			} else {
 				const wrappedValueToIndex = new this.wrappedIndexedType(
 					valueToIndex as I,
 					context,
 				);
-				await this.index.put(wrappedValueToIndex, id, options);
+				await this.index.put(
+					wrappedValueToIndex,
+					id,
+					stripEncodedValue(options),
+				);
 			}
 		} catch (error) {
 			if (error instanceof indexerTypes.NotStartedError && this.closed) {
@@ -1761,7 +1789,7 @@ export class DocumentIndex<
 			value: T;
 			id: indexerTypes.IdKey;
 			context: types.Context;
-			options?: { replace?: boolean };
+			options?: ContextualPutOptions;
 		}>,
 	): Promise<Array<{ context: types.Context; indexable: I }>> {
 		if (values.length === 0) {
@@ -1819,7 +1847,10 @@ export class DocumentIndex<
 						value: item.indexable,
 						id: item.id,
 						context: item.context,
-						options: item.options,
+						options: this.withContextualEncodedValue(
+							item.options,
+							item.context,
+						),
 					})),
 				);
 			} else if (
@@ -1843,13 +1874,13 @@ export class DocumentIndex<
 							item.indexable,
 							item.id,
 							item.context,
-							item.options,
+							this.withContextualEncodedValue(item.options, item.context),
 						);
 					} else {
 						await this.index.put(
 							new this.wrappedIndexedType(item.indexable, item.context),
 							item.id,
-							item.options,
+							stripEncodedValue(item.options),
 						);
 					}
 				}
@@ -1868,6 +1899,34 @@ export class DocumentIndex<
 			context: item.context,
 			indexable: item.indexable,
 		}));
+	}
+
+	private withContextualEncodedValue(
+		options: ContextualPutOptions | undefined,
+		context: types.Context,
+	): ContextualPutOptions | undefined {
+		if (!options?.encodedValue) {
+			return options;
+		}
+		const encodedValue = this.encodeContextualIndexedValue(
+			options.encodedValue,
+			context,
+		);
+		return { ...options, encodedValue };
+	}
+
+	private encodeContextualIndexedValue(
+		encodedValue: Uint8Array | undefined,
+		context: types.Context,
+	): Uint8Array | undefined {
+		if (
+			!encodedValue ||
+			!this.transformerIsIdentity ||
+			!this.indexedTypeIsDocumentType
+		) {
+			return;
+		}
+		return concat([encodedValue, serialize(context)]);
 	}
 
 	public del(key: indexerTypes.IdKey) {

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -225,16 +225,22 @@ describe("index", () => {
 					expect(localLookupSpy.callCount).equal(0);
 					expect(backendContextPutSpy.callCount).equal(1);
 					const backendOptions = backendContextPutSpy.getCall(0).args[3] as
-						| { encodedValue?: Uint8Array }
+						| {
+								encodedValue?: Uint8Array;
+								encodedValueParts?: { prefix: Uint8Array; suffix: Uint8Array };
+						  }
 						| undefined;
 					const encodedDocument = serialize(doc);
-					expect(backendOptions?.encodedValue).instanceOf(Uint8Array);
-					expect(backendOptions!.encodedValue!.byteLength).greaterThan(
-						encodedDocument.byteLength,
+					expect(backendOptions?.encodedValue).equal(undefined);
+					expect(backendOptions?.encodedValueParts?.prefix).to.deep.equal(
+						encodedDocument,
 					);
-					expect(
-						backendOptions!.encodedValue!.slice(0, encodedDocument.byteLength),
-					).to.deep.equal(encodedDocument);
+					expect(backendOptions?.encodedValueParts?.suffix).instanceOf(
+						Uint8Array,
+					);
+					expect(backendOptions!.encodedValueParts!.suffix.byteLength).greaterThan(
+						0,
+					);
 					expect((await store.docs.get(doc.id))?.name).equal("fast");
 					expect(changes).to.have.length(1);
 					expect(changes[0].added[0].__context.head).equal(put.entry.hash);
@@ -406,21 +412,24 @@ describe("index", () => {
 					expect(appended.entries).to.have.length(3);
 					expect(documentBackendBatchSpy.callCount).equal(1);
 					const batchValues = documentBackendBatchSpy.getCall(0).args[0] as Array<{
-						options?: { encodedValue?: Uint8Array };
+						options?: {
+							encodedValue?: Uint8Array;
+							encodedValueParts?: { prefix: Uint8Array; suffix: Uint8Array };
+						};
 					}>;
 					expect(batchValues).to.have.length(3);
 					for (let i = 0; i < docs.length; i++) {
 						const encodedDocument = serialize(docs[i]!);
-						expect(batchValues[i]!.options?.encodedValue).instanceOf(Uint8Array);
-						expect(batchValues[i]!.options!.encodedValue!.byteLength).greaterThan(
-							encodedDocument.byteLength,
-						);
+						expect(batchValues[i]!.options?.encodedValue).equal(undefined);
 						expect(
-							batchValues[i]!.options!.encodedValue!.slice(
-								0,
-								encodedDocument.byteLength,
-							),
+							batchValues[i]!.options?.encodedValueParts?.prefix,
 						).to.deep.equal(encodedDocument);
+						expect(
+							batchValues[i]!.options?.encodedValueParts?.suffix,
+						).instanceOf(Uint8Array);
+						expect(
+							batchValues[i]!.options!.encodedValueParts!.suffix.byteLength,
+						).greaterThan(0);
 					}
 					expect(coordinateBatchSpy.callCount).equal(1);
 					expect(coordinatePutSpy.callCount).equal(0);

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -224,6 +224,17 @@ describe("index", () => {
 					expect(appendSpy.callCount).equal(0);
 					expect(localLookupSpy.callCount).equal(0);
 					expect(backendContextPutSpy.callCount).equal(1);
+					const backendOptions = backendContextPutSpy.getCall(0).args[3] as
+						| { encodedValue?: Uint8Array }
+						| undefined;
+					const encodedDocument = serialize(doc);
+					expect(backendOptions?.encodedValue).instanceOf(Uint8Array);
+					expect(backendOptions!.encodedValue!.byteLength).greaterThan(
+						encodedDocument.byteLength,
+					);
+					expect(
+						backendOptions!.encodedValue!.slice(0, encodedDocument.byteLength),
+					).to.deep.equal(encodedDocument);
 					expect((await store.docs.get(doc.id))?.name).equal("fast");
 					expect(changes).to.have.length(1);
 					expect(changes[0].added[0].__context.head).equal(put.entry.hash);
@@ -394,6 +405,23 @@ describe("index", () => {
 
 					expect(appended.entries).to.have.length(3);
 					expect(documentBackendBatchSpy.callCount).equal(1);
+					const batchValues = documentBackendBatchSpy.getCall(0).args[0] as Array<{
+						options?: { encodedValue?: Uint8Array };
+					}>;
+					expect(batchValues).to.have.length(3);
+					for (let i = 0; i < docs.length; i++) {
+						const encodedDocument = serialize(docs[i]!);
+						expect(batchValues[i]!.options?.encodedValue).instanceOf(Uint8Array);
+						expect(batchValues[i]!.options!.encodedValue!.byteLength).greaterThan(
+							encodedDocument.byteLength,
+						);
+						expect(
+							batchValues[i]!.options!.encodedValue!.slice(
+								0,
+								encodedDocument.byteLength,
+							),
+						).to.deep.equal(encodedDocument);
+					}
 					expect(coordinateBatchSpy.callCount).equal(1);
 					expect(coordinatePutSpy.callCount).equal(0);
 					expect(changes).to.have.length(1);

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -230,6 +230,8 @@ describe("index", () => {
 								encodedValueParts?: { prefix: Uint8Array; suffix: Uint8Array };
 						  }
 						| undefined;
+					const backendContext = backendContextPutSpy.getCall(0)
+						.args[2] as Context;
 					const encodedDocument = serialize(doc);
 					expect(backendOptions?.encodedValue).equal(undefined);
 					expect(backendOptions?.encodedValueParts?.prefix).to.deep.equal(
@@ -237,6 +239,9 @@ describe("index", () => {
 					);
 					expect(backendOptions?.encodedValueParts?.suffix).instanceOf(
 						Uint8Array,
+					);
+					expect(backendOptions?.encodedValueParts?.suffix).to.deep.equal(
+						serialize(backendContext),
 					);
 					expect(backendOptions!.encodedValueParts!.suffix.byteLength).greaterThan(
 						0,
@@ -412,6 +417,7 @@ describe("index", () => {
 					expect(appended.entries).to.have.length(3);
 					expect(documentBackendBatchSpy.callCount).equal(1);
 					const batchValues = documentBackendBatchSpy.getCall(0).args[0] as Array<{
+						context: Context;
 						options?: {
 							encodedValue?: Uint8Array;
 							encodedValueParts?: { prefix: Uint8Array; suffix: Uint8Array };
@@ -427,6 +433,9 @@ describe("index", () => {
 						expect(
 							batchValues[i]!.options?.encodedValueParts?.suffix,
 						).instanceOf(Uint8Array);
+						expect(
+							batchValues[i]!.options?.encodedValueParts?.suffix,
+						).to.deep.equal(serialize(batchValues[i]!.context));
 						expect(
 							batchValues[i]!.options!.encodedValueParts!.suffix.byteLength,
 						).greaterThan(0);

--- a/packages/programs/data/shared-log/src/sync/simple.ts
+++ b/packages/programs/data/shared-log/src/sync/simple.ts
@@ -365,11 +365,26 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			return;
 		}
 		for (const state of session.targets.values()) {
-			const resolved = await this.log.hasMany(state.unresolved);
+			const resolved =
+				typeof this.log.hasMany === "function"
+					? await this.log.hasMany(state.unresolved)
+					: await this.getExistingRepairHashes(state.unresolved);
 			for (const hash of resolved) {
 				state.unresolved.delete(hash);
 			}
 		}
+	}
+
+	private async getExistingRepairHashes(
+		hashes: Iterable<string>,
+	): Promise<Set<string>> {
+		const resolved = new Set<string>();
+		for (const hash of hashes) {
+			if (await this.log.has(hash)) {
+				resolved.add(hash);
+			}
+		}
+		return resolved;
 	}
 
 	private markRepairSessionResolvedHashes(hashes: string[]): void {

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -28,12 +28,19 @@ export type RustIndexerOptions = {
 };
 
 type NativeRustIndex<T extends Record<string, any>> = {
-	configure_schema_ir: (schemaIr: Uint8Array) => [number, number];
+	configure_schema_ir: (schemaIr: Uint8Array) => [number, number, number];
 	put: (
 		key: string,
 		id: types.IdKey,
 		value: T,
 		fields: Uint8Array,
+	) => void;
+	put_encoded: (
+		key: string,
+		id: types.IdKey,
+		value: T,
+		valueBytes: Uint8Array,
+		byteElementIndexLimit: number,
 	) => void;
 	put_and_delete_matching: (
 		key: string,
@@ -135,6 +142,7 @@ type NativeCandidatePage = {
 const BRIDGE_VERSION = 1;
 const DEFAULT_JOURNAL_COMPACT_AFTER_OPERATIONS = 64 * 1024;
 const DEFAULT_BYTE_ELEMENT_INDEX_LIMIT = 0;
+const MAX_NATIVE_BYTE_ELEMENT_INDEX_LIMIT = 0xffffffff;
 
 // Keep bridge enum tags in sync with the Rust Borsh DTO declaration order.
 const enum NativeValueTag {
@@ -686,7 +694,11 @@ class NativeSchemaIrWriter {
 }
 
 type NativeFieldEncoder<T extends Record<string, any>> = (value: T) => Uint8Array;
-type NativeSchemaIrStats = { rootFields: number; nodeCount: number };
+type NativeSchemaIrStats = {
+	rootFields: number;
+	nodeCount: number;
+	genericNodes: number;
+};
 type SharedLogCoordinateNativeFields = {
 	hash: string;
 	hashNumber: number | bigint;
@@ -917,6 +929,13 @@ const encodeNativeSchemaIr = (
 	writer.u8(BRIDGE_VERSION);
 	writeNativeSchemaNode(writer, schema, dictionary, undefined, new Set());
 	return writer.finish();
+};
+
+const normalizeNativeByteElementIndexLimit = (limit: number): number => {
+	if (!Number.isFinite(limit)) {
+		return MAX_NATIVE_BYTE_ELEMENT_INDEX_LIMIT;
+	}
+	return Math.max(0, Math.min(MAX_NATIVE_BYTE_ELEMENT_INDEX_LIMIT, Math.floor(limit)));
 };
 
 const writeNativeSchemaObjectNode = (
@@ -1458,8 +1477,10 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 	private properties!: types.IndexEngineInitProperties<T, NestedType>;
 	private fieldDictionary!: NativeFieldDictionary;
 	private fieldEncoder!: NativeFieldEncoder<T>;
+	private nativeEncodedValueEncoder?: NativeFieldEncoder<T>;
 	private nativeSchemaIrStats?: NativeSchemaIrStats;
 	private byteElementIndexLimit!: number;
+	private nativeByteElementIndexLimit!: number;
 	private sharedLogCoordinateFieldIds?: {
 		hash: number;
 		hashNumber: number;
@@ -1502,15 +1523,21 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		this.fieldDictionary = createNativeFieldDictionary();
 		this.byteElementIndexLimit =
 			this.options.byteElementIndexLimit ?? DEFAULT_BYTE_ELEMENT_INDEX_LIMIT;
+		this.nativeByteElementIndexLimit = normalizeNativeByteElementIndexLimit(
+			this.byteElementIndexLimit,
+		);
 		this.fieldEncoder = compileNativeFieldEncoder(
 			properties.schema,
 			this.fieldDictionary,
 			this.options,
 		);
-		const [rootFields, nodeCount] = this.native.configure_schema_ir(
+		const [rootFields, nodeCount, genericNodes] = this.native.configure_schema_ir(
 			encodeNativeSchemaIr(properties.schema, this.fieldDictionary),
 		);
-		this.nativeSchemaIrStats = { rootFields, nodeCount };
+		this.nativeSchemaIrStats = { rootFields, nodeCount, genericNodes };
+		if (genericNodes === 0) {
+			this.nativeEncodedValueEncoder = (value) => serialize(value);
+		}
 		this.snapshotFile = await createSnapshotFile(
 			this.directory,
 			this.path,
@@ -1560,6 +1587,11 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		id = types.toId(types.extractFieldValue(value, this.indexByArr)),
 		_options?: { replace?: boolean },
 	): Promise<void> {
+		const encodedValue = this.tryNativeEncodedValue(value);
+		if (encodedValue) {
+			await this.putWithEncodedValue(value, id, encodedValue);
+			return;
+		}
 		await this.putWithEncodedFields(value, id, this.fieldEncoder(value));
 	}
 
@@ -1616,8 +1648,10 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		await this.enqueueMutation(async () => {
 			const prepared = values.map((value) => {
 				const id = types.toId(types.extractFieldValue(value, this.indexByArr));
+				const encodedValue = this.tryNativeEncodedValue(value);
 				return {
-					fields: this.fieldEncoder(value),
+					encodedValue,
+					fields: encodedValue ? undefined : this.fieldEncoder(value),
 					id,
 					storeKey: keyToStoreKey(id),
 					value,
@@ -1633,7 +1667,13 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				}
 			});
 			for (const item of prepared) {
-				this.getNative().put(item.storeKey, item.id, item.value, item.fields);
+				this.putNativeDocumentWithPreparedFields(
+					item.storeKey,
+					item.id,
+					item.value,
+					item.encodedValue,
+					item.fields,
+				);
 			}
 			await this.compactIfNeeded();
 		});
@@ -2016,6 +2056,42 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		});
 	}
 
+	private async putWithEncodedValue(
+		value: T,
+		id: types.IdKey,
+		encodedValue: Uint8Array,
+	): Promise<void> {
+		const storeKey = keyToStoreKey(id);
+		if (!this.snapshotFile) {
+			if (
+				this.putNativeDocumentWithPreparedFields(
+					storeKey,
+					id,
+					value,
+					encodedValue,
+				)
+			) {
+				return;
+			}
+			this.getNative().put(storeKey, id, value, this.fieldEncoder(value));
+			return;
+		}
+		await this.enqueueMutation(async () => {
+			await this.appendPut(storeKey, value);
+			if (
+				!this.putNativeDocumentWithPreparedFields(
+					storeKey,
+					id,
+					value,
+					encodedValue,
+				)
+			) {
+				this.getNative().put(storeKey, id, value, this.fieldEncoder(value));
+			}
+			await this.compactIfNeeded();
+		});
+	}
+
 	private async putWithEncodedFieldsAndDeleteKeys(
 		value: T,
 		id: types.IdKey,
@@ -2099,12 +2175,55 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 	}
 
 	private putNativeDocument(storeKey: string, id: types.IdKey, value: T): void {
-		this.getNative().put(
-			storeKey,
-			id,
-			value,
-			this.fieldEncoder(value),
-		);
+		const encodedValue = this.tryNativeEncodedValue(value);
+		if (
+			this.putNativeDocumentWithPreparedFields(
+				storeKey,
+				id,
+				value,
+				encodedValue,
+			)
+		) {
+			return;
+		}
+		this.getNative().put(storeKey, id, value, this.fieldEncoder(value));
+	}
+
+	private putNativeDocumentWithPreparedFields(
+		storeKey: string,
+		id: types.IdKey,
+		value: T,
+		encodedValue?: Uint8Array,
+		fields?: Uint8Array,
+	): boolean {
+		if (encodedValue) {
+			try {
+				this.getNative().put_encoded(
+					storeKey,
+					id,
+					value,
+					encodedValue,
+					this.nativeByteElementIndexLimit,
+				);
+				return true;
+			} catch {
+				// Fall back to the proven TypeScript fact encoder for schemas whose
+				// Borsh bytes are not covered by the native extractor yet.
+			}
+		}
+		if (fields) {
+			this.getNative().put(storeKey, id, value, fields);
+			return true;
+		}
+		return false;
+	}
+
+	private tryNativeEncodedValue(value: T): Uint8Array | undefined {
+		try {
+			return this.nativeEncodedValueEncoder?.(value);
+		} catch {
+			return;
+		}
 	}
 
 	private createContextualValue(

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -668,6 +668,10 @@ class NativeSchemaIrWriter {
 	string(value: string): void {
 		const bytes = textEncoder.encode(value);
 		this.u32(bytes.byteLength);
+		this.raw(bytes);
+	}
+
+	raw(bytes: Uint8Array): void {
 		this.ensure(bytes.byteLength);
 		this.output.set(bytes, this.offset);
 		this.offset += bytes.byteLength;
@@ -931,6 +935,32 @@ const encodeNativeSchemaIr = (
 	return writer.finish();
 };
 
+const encodeNativeSchemaVariantPrefix = (
+	schemas: ReturnType<typeof getSchemasBottomUp>,
+): Uint8Array => {
+	const writer = new NativeSchemaIrWriter();
+	for (const schema of schemas) {
+		const variant = schema.variant;
+		if (variant == null) {
+			continue;
+		}
+		if (typeof variant === "string") {
+			writer.string(variant);
+			continue;
+		}
+		if (typeof variant === "number") {
+			writer.u8(variant);
+			continue;
+		}
+		if (Array.isArray(variant)) {
+			for (const part of variant) {
+				writer.u8(part);
+			}
+		}
+	}
+	return writer.finish();
+};
+
 const normalizeNativeByteElementIndexLimit = (limit: number): number => {
 	if (!Number.isFinite(limit)) {
 		return MAX_NATIVE_BYTE_ELEMENT_INDEX_LIMIT;
@@ -963,7 +993,10 @@ const writeNativeSchemaObjectNode = (
 
 	active.add(ctor);
 	const fields = schemas.flatMap((nextSchema) => nextSchema.fields);
+	const variantPrefix = encodeNativeSchemaVariantPrefix(schemas);
 	writer.u8(NativeSchemaNodeTag.Object);
+	writer.u32(variantPrefix.byteLength);
+	writer.raw(variantPrefix);
 	writer.u32(fields.length);
 	for (const field of fields) {
 		const fieldCursor = appendNativeFieldCursor(dictionary, cursor, field.key);
@@ -1599,9 +1632,14 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		value: Record<string, any>,
 		id: types.IdKey,
 		context: Record<string, any>,
-		options?: { replace?: boolean },
+		options?: { replace?: boolean; encodedValue?: Uint8Array },
 	): Promise<void> {
-		await this.put(this.asContextualValue(value, context), id, options);
+		const contextualValue = this.asContextualValue(value, context);
+		if (options?.encodedValue) {
+			await this.putWithEncodedValue(contextualValue, id, options.encodedValue);
+			return;
+		}
+		await this.put(contextualValue, id, options);
 	}
 
 	async putWithContextBatch(
@@ -1609,7 +1647,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			value: Record<string, any>;
 			id: types.IdKey;
 			context: Record<string, any>;
-			options?: { replace?: boolean };
+			options?: { replace?: boolean; encodedValue?: Uint8Array };
 		}>,
 	): Promise<void> {
 		if (values.length === 0) {
@@ -1626,10 +1664,12 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			}
 			return;
 		}
-		await this.putBatch(
-			values.map((entry) =>
-				this.asContextualValue(entry.value, entry.context),
-			),
+		await this.putPreparedBatch(
+			values.map((entry) => ({
+				value: this.asContextualValue(entry.value, entry.context),
+				id: entry.id,
+				encodedValue: entry.options?.encodedValue,
+			})),
 		);
 	}
 
@@ -1637,24 +1677,55 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		if (values.length === 0) {
 			return;
 		}
+		await this.putPreparedBatch(
+			values.map((value) => ({
+				value,
+				id: types.toId(types.extractFieldValue(value, this.indexByArr)),
+			})),
+		);
+	}
+
+	private async putPreparedBatch(
+		values: Array<{
+			value: T;
+			id: types.IdKey;
+			encodedValue?: Uint8Array;
+		}>,
+	): Promise<void> {
 		if (!this.snapshotFile) {
-			for (const value of values) {
-				const id = types.toId(types.extractFieldValue(value, this.indexByArr));
-				this.putNativeDocument(keyToStoreKey(id), id, value);
+			for (const entry of values) {
+				const storeKey = keyToStoreKey(entry.id);
+				const encodedValue =
+					entry.encodedValue ?? this.tryNativeEncodedValue(entry.value);
+				if (
+					!this.putNativeDocumentWithPreparedFields(
+						storeKey,
+						entry.id,
+						entry.value,
+						encodedValue,
+					)
+				) {
+					this.getNative().put(
+						storeKey,
+						entry.id,
+						entry.value,
+						this.fieldEncoder(entry.value),
+					);
+				}
 			}
 			return;
 		}
 
 		await this.enqueueMutation(async () => {
-			const prepared = values.map((value) => {
-				const id = types.toId(types.extractFieldValue(value, this.indexByArr));
-				const encodedValue = this.tryNativeEncodedValue(value);
+			const prepared = values.map((entry) => {
+				const encodedValue =
+					entry.encodedValue ?? this.tryNativeEncodedValue(entry.value);
 				return {
 					encodedValue,
-					fields: encodedValue ? undefined : this.fieldEncoder(value),
-					id,
-					storeKey: keyToStoreKey(id),
-					value,
+					fields: encodedValue ? undefined : this.fieldEncoder(entry.value),
+					id: entry.id,
+					storeKey: keyToStoreKey(entry.id),
+					value: entry.value,
 				};
 			});
 			await this.enqueuePersistence(async () => {
@@ -1667,13 +1738,22 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				}
 			});
 			for (const item of prepared) {
-				this.putNativeDocumentWithPreparedFields(
-					item.storeKey,
-					item.id,
-					item.value,
-					item.encodedValue,
-					item.fields,
-				);
+				if (
+					!this.putNativeDocumentWithPreparedFields(
+						item.storeKey,
+						item.id,
+						item.value,
+						item.encodedValue,
+						item.fields,
+					)
+				) {
+					this.getNative().put(
+						item.storeKey,
+						item.id,
+						item.value,
+						this.fieldEncoder(item.value),
+					);
+				}
 			}
 			await this.compactIfNeeded();
 		});

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -42,6 +42,14 @@ type NativeRustIndex<T extends Record<string, any>> = {
 		valueBytes: Uint8Array,
 		byteElementIndexLimit: number,
 	) => void;
+	put_encoded_parts?: (
+		key: string,
+		id: types.IdKey,
+		value: T,
+		valuePrefixBytes: Uint8Array,
+		valueSuffixBytes: Uint8Array,
+		byteElementIndexLimit: number,
+	) => void;
 	put_and_delete_matching: (
 		key: string,
 		id: types.IdKey,
@@ -711,6 +719,17 @@ type SharedLogCoordinateNativeFields = {
 	wallTime: number | bigint;
 	assignedToRangeBoundary: boolean;
 	metaBytes: Uint8Array;
+};
+
+type NativeEncodedValueParts = {
+	prefix: Uint8Array;
+	suffix: Uint8Array;
+};
+
+type NativeEncodedPutOptions = {
+	replace?: boolean;
+	encodedValue?: Uint8Array;
+	encodedValueParts?: NativeEncodedValueParts;
 };
 type NativeFieldValueWriterFn = (
 	value: any,
@@ -1632,9 +1651,17 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		value: Record<string, any>,
 		id: types.IdKey,
 		context: Record<string, any>,
-		options?: { replace?: boolean; encodedValue?: Uint8Array },
+		options?: NativeEncodedPutOptions,
 	): Promise<void> {
 		const contextualValue = this.asContextualValue(value, context);
+		if (options?.encodedValueParts) {
+			await this.putWithEncodedValueParts(
+				contextualValue,
+				id,
+				options.encodedValueParts,
+			);
+			return;
+		}
 		if (options?.encodedValue) {
 			await this.putWithEncodedValue(contextualValue, id, options.encodedValue);
 			return;
@@ -1647,7 +1674,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			value: Record<string, any>;
 			id: types.IdKey;
 			context: Record<string, any>;
-			options?: { replace?: boolean; encodedValue?: Uint8Array };
+			options?: NativeEncodedPutOptions;
 		}>,
 	): Promise<void> {
 		if (values.length === 0) {
@@ -1669,6 +1696,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				value: this.asContextualValue(entry.value, entry.context),
 				id: entry.id,
 				encodedValue: entry.options?.encodedValue,
+				encodedValueParts: entry.options?.encodedValueParts,
 			})),
 		);
 	}
@@ -1690,19 +1718,25 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			value: T;
 			id: types.IdKey;
 			encodedValue?: Uint8Array;
+			encodedValueParts?: NativeEncodedValueParts;
 		}>,
 	): Promise<void> {
 		if (!this.snapshotFile) {
 			for (const entry of values) {
 				const storeKey = keyToStoreKey(entry.id);
 				const encodedValue =
-					entry.encodedValue ?? this.tryNativeEncodedValue(entry.value);
+					entry.encodedValue ??
+					(entry.encodedValueParts
+						? undefined
+						: this.tryNativeEncodedValue(entry.value));
 				if (
 					!this.putNativeDocumentWithPreparedFields(
 						storeKey,
 						entry.id,
 						entry.value,
 						encodedValue,
+						undefined,
+						entry.encodedValueParts,
 					)
 				) {
 					this.getNative().put(
@@ -1719,10 +1753,17 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		await this.enqueueMutation(async () => {
 			const prepared = values.map((entry) => {
 				const encodedValue =
-					entry.encodedValue ?? this.tryNativeEncodedValue(entry.value);
+					entry.encodedValue ??
+					(entry.encodedValueParts
+						? undefined
+						: this.tryNativeEncodedValue(entry.value));
 				return {
 					encodedValue,
-					fields: encodedValue ? undefined : this.fieldEncoder(entry.value),
+					encodedValueParts: entry.encodedValueParts,
+					fields:
+						encodedValue || entry.encodedValueParts
+							? undefined
+							: this.fieldEncoder(entry.value),
 					id: entry.id,
 					storeKey: keyToStoreKey(entry.id),
 					value: entry.value,
@@ -1745,6 +1786,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 						item.value,
 						item.encodedValue,
 						item.fields,
+						item.encodedValueParts,
 					)
 				) {
 					this.getNative().put(
@@ -2172,6 +2214,46 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		});
 	}
 
+	private async putWithEncodedValueParts(
+		value: T,
+		id: types.IdKey,
+		encodedValueParts: NativeEncodedValueParts,
+	): Promise<void> {
+		const storeKey = keyToStoreKey(id);
+		if (!this.snapshotFile) {
+			if (
+				this.putNativeDocumentWithPreparedFields(
+					storeKey,
+					id,
+					value,
+					undefined,
+					undefined,
+					encodedValueParts,
+				)
+			) {
+				return;
+			}
+			this.getNative().put(storeKey, id, value, this.fieldEncoder(value));
+			return;
+		}
+		await this.enqueueMutation(async () => {
+			await this.appendPut(storeKey, value);
+			if (
+				!this.putNativeDocumentWithPreparedFields(
+					storeKey,
+					id,
+					value,
+					undefined,
+					undefined,
+					encodedValueParts,
+				)
+			) {
+				this.getNative().put(storeKey, id, value, this.fieldEncoder(value));
+			}
+			await this.compactIfNeeded();
+		});
+	}
+
 	private async putWithEncodedFieldsAndDeleteKeys(
 		value: T,
 		id: types.IdKey,
@@ -2275,7 +2357,30 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		value: T,
 		encodedValue?: Uint8Array,
 		fields?: Uint8Array,
+		encodedValueParts?: NativeEncodedValueParts,
 	): boolean {
+		if (encodedValueParts) {
+			const native = this.getNative();
+			const putEncodedParts = native.put_encoded_parts;
+			try {
+				if (!putEncodedParts) {
+					return false;
+				}
+				putEncodedParts.call(
+					native,
+					storeKey,
+					id,
+					value,
+					encodedValueParts.prefix,
+					encodedValueParts.suffix,
+					this.nativeByteElementIndexLimit,
+				);
+				return true;
+			} catch {
+				// Fall back to the proven TypeScript fact encoder for schemas whose
+				// Borsh bytes are not covered by the native extractor yet.
+			}
+		}
 		if (encodedValue) {
 			try {
 				this.getNative().put_encoded(

--- a/packages/utils/indexer/rust/src/lib.rs
+++ b/packages/utils/indexer/rust/src/lib.rs
@@ -206,6 +206,7 @@ impl NativeRustIndex {
         let out = Array::new();
         out.push(&JsValue::from_f64(stats.root_fields as f64));
         out.push(&JsValue::from_f64(stats.node_count as f64));
+        out.push(&JsValue::from_f64(stats.generic_nodes as f64));
         Ok(out)
     }
 
@@ -221,6 +222,21 @@ impl NativeRustIndex {
         fields_bytes: Vec<u8>,
     ) -> Result<(), JsValue> {
         let fields = decode_document_fields(&fields_bytes)?;
+        self.store.put(key.clone(), id, value);
+        self.planner.index.put(key, fields);
+        Ok(())
+    }
+
+    pub fn put_encoded(
+        &mut self,
+        key: String,
+        id: JsValue,
+        value: JsValue,
+        value_bytes: Vec<u8>,
+        byte_element_index_limit: usize,
+    ) -> Result<(), JsValue> {
+        let fields =
+            self.extract_encoded_document_fields(&value_bytes, byte_element_index_limit)?;
         self.store.put(key.clone(), id, value);
         self.planner.index.put(key, fields);
         Ok(())
@@ -311,6 +327,20 @@ impl NativeRustIndex {
         let query = decode_query(&query_bytes)?;
         let keys = self.planner.index.delete_matching(&query);
         Ok(self.store.delete_keys(&keys))
+    }
+}
+
+impl NativeRustIndex {
+    fn extract_encoded_document_fields(
+        &self,
+        value_bytes: &[u8],
+        byte_element_index_limit: usize,
+    ) -> Result<DocumentFields, JsValue> {
+        let schema_ir = self
+            .schema_ir
+            .as_ref()
+            .ok_or_else(|| js_error("Native schema IR has not been configured"))?;
+        extract_encoded_document_fields(schema_ir, value_bytes, byte_element_index_limit)
     }
 }
 
@@ -471,6 +501,7 @@ enum NativeSchemaNode {
 struct NativeSchemaIrStats {
     root_fields: usize,
     node_count: usize,
+    generic_nodes: usize,
 }
 
 impl NativeSchemaIr {
@@ -481,6 +512,7 @@ impl NativeSchemaIr {
                 _ => 0,
             },
             node_count: self.root.node_count(),
+            generic_nodes: self.root.generic_count(),
         }
     }
 }
@@ -517,6 +549,32 @@ impl NativeSchemaNode {
             | NativeSchemaNode::String
             | NativeSchemaNode::Uint8Array
             | NativeSchemaNode::Generic => 1,
+        }
+    }
+
+    fn generic_count(&self) -> usize {
+        match self {
+            NativeSchemaNode::Object(fields) => fields
+                .iter()
+                .map(|field| field.node.generic_count())
+                .sum::<usize>(),
+            NativeSchemaNode::Option(node) | NativeSchemaNode::Vec(node) => node.generic_count(),
+            NativeSchemaNode::FixedArray { element, .. } => element.generic_count(),
+            NativeSchemaNode::Generic => 1,
+            NativeSchemaNode::Bool
+            | NativeSchemaNode::U8
+            | NativeSchemaNode::U16
+            | NativeSchemaNode::U32
+            | NativeSchemaNode::U64
+            | NativeSchemaNode::U128
+            | NativeSchemaNode::U256
+            | NativeSchemaNode::U512
+            | NativeSchemaNode::I8
+            | NativeSchemaNode::I16
+            | NativeSchemaNode::I32
+            | NativeSchemaNode::I64
+            | NativeSchemaNode::String
+            | NativeSchemaNode::Uint8Array => 0,
         }
     }
 }
@@ -644,6 +702,299 @@ fn read_native_schema_node(reader: &mut BridgeReader) -> Result<NativeSchemaNode
         18 => NativeSchemaNode::Generic,
         tag => return Err(js_error(format!("Unknown native schema node tag {tag}"))),
     })
+}
+
+struct NativeExtractState {
+    next_scope: u32,
+    byte_element_index_limit: usize,
+}
+
+impl NativeExtractState {
+    fn next_scope(&mut self) -> Result<u32, JsValue> {
+        let scope = self.next_scope;
+        self.next_scope = self
+            .next_scope
+            .checked_add(1)
+            .ok_or_else(|| js_error("Native schema extraction scope overflow"))?;
+        Ok(scope)
+    }
+}
+
+fn extract_encoded_document_fields(
+    schema_ir: &NativeSchemaIr,
+    value_bytes: &[u8],
+    byte_element_index_limit: usize,
+) -> Result<DocumentFields, JsValue> {
+    let mut reader = BridgeReader::new(value_bytes);
+    let mut fields = DocumentFields::new();
+    let mut state = NativeExtractState {
+        next_scope: 1,
+        byte_element_index_limit,
+    };
+    extract_schema_node(
+        &schema_ir.root,
+        &mut reader,
+        &mut fields,
+        0,
+        &mut state,
+        None,
+    )?;
+    reader.finish()?;
+    Ok(fields)
+}
+
+fn extract_schema_node(
+    node: &NativeSchemaNode,
+    reader: &mut BridgeReader,
+    fields: &mut DocumentFields,
+    scope: u32,
+    state: &mut NativeExtractState,
+    field: Option<&NativeSchemaField>,
+) -> Result<(), JsValue> {
+    match node {
+        NativeSchemaNode::Bool => {
+            let value = match reader.read_u8()? {
+                0 => false,
+                1 => true,
+                value => return Err(js_error(format!("Invalid Borsh bool value {value}"))),
+            };
+            insert_scalar(
+                fields,
+                scope,
+                required_field(field)?,
+                FieldValue::Bool(value),
+            );
+        }
+        NativeSchemaNode::U8 => {
+            insert_scalar(
+                fields,
+                scope,
+                required_field(field)?,
+                FieldValue::U64(reader.read_u8()? as u64),
+            );
+        }
+        NativeSchemaNode::U16 => {
+            insert_scalar(
+                fields,
+                scope,
+                required_field(field)?,
+                FieldValue::U64(read_le_u64_with_width(reader, 2)?.unwrap_or_default()),
+            );
+        }
+        NativeSchemaNode::U32 => {
+            insert_scalar(
+                fields,
+                scope,
+                required_field(field)?,
+                FieldValue::U64(reader.read_u32()? as u64),
+            );
+        }
+        NativeSchemaNode::U64 => {
+            insert_scalar(
+                fields,
+                scope,
+                required_field(field)?,
+                FieldValue::U64(reader.read_u64()?),
+            );
+        }
+        NativeSchemaNode::U128 => {
+            if let Some(value) = read_le_u64_with_width(reader, 16)? {
+                insert_scalar(
+                    fields,
+                    scope,
+                    required_field(field)?,
+                    FieldValue::U64(value),
+                );
+            }
+        }
+        NativeSchemaNode::U256 => {
+            if let Some(value) = read_le_u64_with_width(reader, 32)? {
+                insert_scalar(
+                    fields,
+                    scope,
+                    required_field(field)?,
+                    FieldValue::U64(value),
+                );
+            }
+        }
+        NativeSchemaNode::U512 => {
+            if let Some(value) = read_le_u64_with_width(reader, 64)? {
+                insert_scalar(
+                    fields,
+                    scope,
+                    required_field(field)?,
+                    FieldValue::U64(value),
+                );
+            }
+        }
+        NativeSchemaNode::I8 => {
+            insert_scalar(
+                fields,
+                scope,
+                required_field(field)?,
+                FieldValue::I64((reader.read_u8()? as i8) as i64),
+            );
+        }
+        NativeSchemaNode::I16 => {
+            insert_scalar(
+                fields,
+                scope,
+                required_field(field)?,
+                FieldValue::I64(read_le_i64_with_width(reader, 2)?),
+            );
+        }
+        NativeSchemaNode::I32 => {
+            insert_scalar(
+                fields,
+                scope,
+                required_field(field)?,
+                FieldValue::I64(read_le_i64_with_width(reader, 4)?),
+            );
+        }
+        NativeSchemaNode::I64 => {
+            insert_scalar(
+                fields,
+                scope,
+                required_field(field)?,
+                FieldValue::I64(reader.read_i64()?),
+            );
+        }
+        NativeSchemaNode::String => {
+            let value = reader.read_string()?;
+            insert_scalar(
+                fields,
+                scope,
+                required_field(field)?,
+                FieldValue::String(value),
+            );
+        }
+        NativeSchemaNode::Uint8Array => {
+            let len = reader.read_u32()? as usize;
+            let bytes = reader.read_exact(len)?.to_vec();
+            insert_bytes_facts(fields, state, scope, required_field(field)?, bytes)?;
+        }
+        NativeSchemaNode::Object(schema_fields) => {
+            for schema_field in schema_fields {
+                extract_schema_node(
+                    &schema_field.node,
+                    reader,
+                    fields,
+                    scope,
+                    state,
+                    Some(schema_field),
+                )?;
+            }
+        }
+        NativeSchemaNode::Option(child) => match reader.read_u8()? {
+            0 => {}
+            1 => extract_schema_node(child, reader, fields, scope, state, field)?,
+            tag => return Err(js_error(format!("Invalid Borsh option tag {tag}"))),
+        },
+        NativeSchemaNode::Vec(child) if matches!(child.as_ref(), NativeSchemaNode::U8) => {
+            let len = reader.read_u32()? as usize;
+            let bytes = reader.read_exact(len)?.to_vec();
+            insert_bytes_facts(fields, state, scope, required_field(field)?, bytes)?;
+        }
+        NativeSchemaNode::Vec(child) => {
+            let len = reader.read_u32()? as usize;
+            let field = required_schema_field(field)?;
+            for _ in 0..len {
+                let item_scope = state.next_scope()?;
+                insert_scalar(
+                    fields,
+                    item_scope,
+                    field.array_field,
+                    FieldValue::Bool(true),
+                );
+                extract_schema_node(child, reader, fields, item_scope, state, Some(field))?;
+            }
+        }
+        NativeSchemaNode::FixedArray { length, element }
+            if matches!(element.as_ref(), NativeSchemaNode::U8) =>
+        {
+            let bytes = reader.read_exact(*length as usize)?.to_vec();
+            insert_bytes_facts(fields, state, scope, required_field(field)?, bytes)?;
+        }
+        NativeSchemaNode::FixedArray { length, element } => {
+            let field = required_schema_field(field)?;
+            for _ in 0..*length {
+                let item_scope = state.next_scope()?;
+                insert_scalar(
+                    fields,
+                    item_scope,
+                    field.array_field,
+                    FieldValue::Bool(true),
+                );
+                extract_schema_node(element, reader, fields, item_scope, state, Some(field))?;
+            }
+        }
+        NativeSchemaNode::Generic => {
+            return Err(js_error(
+                "Native schema IR contains a generic node that cannot be extracted from Borsh",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn required_schema_field(field: Option<&NativeSchemaField>) -> Result<&NativeSchemaField, JsValue> {
+    field.ok_or_else(|| js_error("Native schema scalar node is missing field metadata"))
+}
+
+fn required_field(field: Option<&NativeSchemaField>) -> Result<u32, JsValue> {
+    Ok(required_schema_field(field)?.field)
+}
+
+fn insert_scalar(fields: &mut DocumentFields, scope: u32, field: u32, value: FieldValue) {
+    fields.insert_scoped_scalar(scope, FieldPath::Id(field), value);
+}
+
+fn insert_bytes_facts(
+    fields: &mut DocumentFields,
+    state: &mut NativeExtractState,
+    scope: u32,
+    field: u32,
+    bytes: Vec<u8>,
+) -> Result<(), JsValue> {
+    fields.insert_scoped_scalar(
+        scope,
+        FieldPath::Id(field),
+        FieldValue::Bytes(bytes.clone()),
+    );
+    if bytes.len() > state.byte_element_index_limit {
+        return Ok(());
+    }
+    for byte in bytes {
+        let byte_scope = state.next_scope()?;
+        fields.insert_scoped_scalar(
+            byte_scope,
+            FieldPath::Id(field),
+            FieldValue::U64(byte as u64),
+        );
+    }
+    Ok(())
+}
+
+fn read_le_u64_with_width(reader: &mut BridgeReader, width: usize) -> Result<Option<u64>, JsValue> {
+    let bytes = reader.read_exact(width)?;
+    let low_width = width.min(8);
+    let mut low = [0u8; 8];
+    low[..low_width].copy_from_slice(&bytes[..low_width]);
+    if bytes.iter().skip(8).any(|byte| *byte != 0) {
+        return Ok(None);
+    }
+    Ok(Some(u64::from_le_bytes(low)))
+}
+
+fn read_le_i64_with_width(reader: &mut BridgeReader, width: usize) -> Result<i64, JsValue> {
+    let bytes = reader.read_exact(width)?;
+    let mut out = if bytes.last().is_some_and(|byte| byte & 0x80 != 0) {
+        [0xffu8; 8]
+    } else {
+        [0u8; 8]
+    };
+    out[..width].copy_from_slice(bytes);
+    Ok(i64::from_le_bytes(out))
 }
 
 fn decode_document_fields(fields_bytes: &[u8]) -> Result<DocumentFields, JsValue> {

--- a/packages/utils/indexer/rust/src/lib.rs
+++ b/packages/utils/indexer/rust/src/lib.rs
@@ -488,7 +488,10 @@ enum NativeSchemaNode {
     I64,
     String,
     Uint8Array,
-    Object(Vec<NativeSchemaField>),
+    Object {
+        variant_prefix: Vec<u8>,
+        fields: Vec<NativeSchemaField>,
+    },
     Option(Box<NativeSchemaNode>),
     Vec(Box<NativeSchemaNode>),
     FixedArray {
@@ -508,7 +511,7 @@ impl NativeSchemaIr {
     fn stats(&self) -> NativeSchemaIrStats {
         NativeSchemaIrStats {
             root_fields: match &self.root {
-                NativeSchemaNode::Object(fields) => fields.len(),
+                NativeSchemaNode::Object { fields, .. } => fields.len(),
                 _ => 0,
             },
             node_count: self.root.node_count(),
@@ -520,7 +523,7 @@ impl NativeSchemaIr {
 impl NativeSchemaNode {
     fn node_count(&self) -> usize {
         match self {
-            NativeSchemaNode::Object(fields) => {
+            NativeSchemaNode::Object { fields, .. } => {
                 1 + fields
                     .iter()
                     .map(|field| {
@@ -554,7 +557,7 @@ impl NativeSchemaNode {
 
     fn generic_count(&self) -> usize {
         match self {
-            NativeSchemaNode::Object(fields) => fields
+            NativeSchemaNode::Object { fields, .. } => fields
                 .iter()
                 .map(|field| field.node.generic_count())
                 .sum::<usize>(),
@@ -681,6 +684,8 @@ fn read_native_schema_node(reader: &mut BridgeReader) -> Result<NativeSchemaNode
         12 => NativeSchemaNode::String,
         13 => NativeSchemaNode::Uint8Array,
         14 => {
+            let variant_prefix_len = reader.read_u32()? as usize;
+            let variant_prefix = reader.read_exact(variant_prefix_len)?.to_vec();
             let field_count = reader.read_u32()? as usize;
             let mut fields = Vec::with_capacity(field_count);
             for _ in 0..field_count {
@@ -691,7 +696,10 @@ fn read_native_schema_node(reader: &mut BridgeReader) -> Result<NativeSchemaNode
                     node: read_native_schema_node(reader)?,
                 });
             }
-            NativeSchemaNode::Object(fields)
+            NativeSchemaNode::Object {
+                variant_prefix,
+                fields,
+            }
         }
         15 => NativeSchemaNode::Option(Box::new(read_native_schema_node(reader)?)),
         16 => NativeSchemaNode::Vec(Box::new(read_native_schema_node(reader)?)),
@@ -873,7 +881,16 @@ fn extract_schema_node(
             let bytes = reader.read_exact(len)?.to_vec();
             insert_bytes_facts(fields, state, scope, required_field(field)?, bytes)?;
         }
-        NativeSchemaNode::Object(schema_fields) => {
+        NativeSchemaNode::Object {
+            variant_prefix,
+            fields: schema_fields,
+        } => {
+            if !variant_prefix.is_empty() {
+                let actual = reader.read_exact(variant_prefix.len())?;
+                if actual != variant_prefix.as_slice() {
+                    return Err(js_error("Borsh variant prefix did not match native schema"));
+                }
+            }
             for schema_field in schema_fields {
                 extract_schema_node(
                     &schema_field.node,

--- a/packages/utils/indexer/rust/src/lib.rs
+++ b/packages/utils/indexer/rust/src/lib.rs
@@ -242,6 +242,24 @@ impl NativeRustIndex {
         Ok(())
     }
 
+    pub fn put_encoded_parts(
+        &mut self,
+        key: String,
+        id: JsValue,
+        value: JsValue,
+        value_prefix_bytes: Vec<u8>,
+        value_suffix_bytes: Vec<u8>,
+        byte_element_index_limit: usize,
+    ) -> Result<(), JsValue> {
+        let fields = self.extract_encoded_document_fields_from_reader(
+            BridgeReader::from_parts(&value_prefix_bytes, &value_suffix_bytes),
+            byte_element_index_limit,
+        )?;
+        self.store.put(key.clone(), id, value);
+        self.planner.index.put(key, fields);
+        Ok(())
+    }
+
     pub fn put_and_delete_matching(
         &mut self,
         key: String,
@@ -336,11 +354,22 @@ impl NativeRustIndex {
         value_bytes: &[u8],
         byte_element_index_limit: usize,
     ) -> Result<DocumentFields, JsValue> {
+        self.extract_encoded_document_fields_from_reader(
+            BridgeReader::new(value_bytes),
+            byte_element_index_limit,
+        )
+    }
+
+    fn extract_encoded_document_fields_from_reader(
+        &self,
+        reader: BridgeReader,
+        byte_element_index_limit: usize,
+    ) -> Result<DocumentFields, JsValue> {
         let schema_ir = self
             .schema_ir
             .as_ref()
             .ok_or_else(|| js_error("Native schema IR has not been configured"))?;
-        extract_encoded_document_fields(schema_ir, value_bytes, byte_element_index_limit)
+        extract_encoded_document_fields_from_reader(schema_ir, reader, byte_element_index_limit)
     }
 }
 
@@ -583,17 +612,30 @@ impl NativeSchemaNode {
 }
 
 struct BridgeReader<'a> {
-    bytes: &'a [u8],
+    first: &'a [u8],
+    second: &'a [u8],
+    len: usize,
     offset: usize,
+    scratch: Vec<u8>,
 }
 
 impl<'a> BridgeReader<'a> {
     fn new(bytes: &'a [u8]) -> Self {
-        Self { bytes, offset: 0 }
+        Self::from_parts(bytes, &[])
+    }
+
+    fn from_parts(first: &'a [u8], second: &'a [u8]) -> Self {
+        Self {
+            first,
+            second,
+            len: first.len() + second.len(),
+            offset: 0,
+            scratch: Vec::new(),
+        }
     }
 
     fn finish(&self) -> Result<(), JsValue> {
-        if self.offset == self.bytes.len() {
+        if self.offset == self.len {
             Ok(())
         } else {
             Err(js_error("Trailing bytes in bridge payload"))
@@ -647,16 +689,59 @@ impl<'a> BridgeReader<'a> {
         })
     }
 
-    fn read_exact(&mut self, len: usize) -> Result<&'a [u8], JsValue> {
+    fn read_exact(&mut self, len: usize) -> Result<&[u8], JsValue> {
         let Some(end) = self.offset.checked_add(len) else {
             return Err(js_error("Bridge payload offset overflow"));
         };
-        let Some(bytes) = self.bytes.get(self.offset..end) else {
+        if end > self.len {
             return Err(js_error("Unexpected end of bridge payload"));
-        };
+        }
+        if len == 0 {
+            return Ok(&[]);
+        }
+        if self.offset < self.first.len() {
+            if end <= self.first.len() {
+                let bytes = &self.first[self.offset..end];
+                self.offset = end;
+                return Ok(bytes);
+            }
+        } else {
+            let start = self.offset - self.first.len();
+            let second_end = end - self.first.len();
+            let bytes = &self.second[start..second_end];
+            self.offset = end;
+            return Ok(bytes);
+        }
+
+        self.scratch.clear();
+        self.scratch.extend_from_slice(&self.first[self.offset..]);
+        self.scratch
+            .extend_from_slice(&self.second[..end - self.first.len()]);
         self.offset = end;
-        Ok(bytes)
+        Ok(&self.scratch)
     }
+}
+
+fn extract_encoded_document_fields_from_reader(
+    schema_ir: &NativeSchemaIr,
+    mut reader: BridgeReader,
+    byte_element_index_limit: usize,
+) -> Result<DocumentFields, JsValue> {
+    let mut fields = DocumentFields::new();
+    let mut state = NativeExtractState {
+        next_scope: 1,
+        byte_element_index_limit,
+    };
+    extract_schema_node(
+        &schema_ir.root,
+        &mut reader,
+        &mut fields,
+        0,
+        &mut state,
+        None,
+    )?;
+    reader.finish()?;
+    Ok(fields)
 }
 
 fn decode_native_schema_ir(schema_ir_bytes: &[u8]) -> Result<NativeSchemaIr, JsValue> {
@@ -726,29 +811,6 @@ impl NativeExtractState {
             .ok_or_else(|| js_error("Native schema extraction scope overflow"))?;
         Ok(scope)
     }
-}
-
-fn extract_encoded_document_fields(
-    schema_ir: &NativeSchemaIr,
-    value_bytes: &[u8],
-    byte_element_index_limit: usize,
-) -> Result<DocumentFields, JsValue> {
-    let mut reader = BridgeReader::new(value_bytes);
-    let mut fields = DocumentFields::new();
-    let mut state = NativeExtractState {
-        next_scope: 1,
-        byte_element_index_limit,
-    };
-    extract_schema_node(
-        &schema_ir.root,
-        &mut reader,
-        &mut fields,
-        0,
-        &mut state,
-        None,
-    )?;
-    reader.finish()?;
-    Ok(fields)
 }
 
 fn extract_schema_node(

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -1,4 +1,4 @@
-import { field, variant, vec } from "@dao-xyz/borsh";
+import { field, serialize, variant, vec } from "@dao-xyz/borsh";
 import {
 	And,
 	BoolQuery,
@@ -591,15 +591,29 @@ describe("native planner bridge", () => {
 				value: BridgeDocument,
 				id: ReturnType<typeof toId>,
 				context: BridgeContext,
-				options?: { replace?: boolean },
+				options?: {
+					replace?: boolean;
+					encodedValueParts?: { prefix: Uint8Array; suffix: Uint8Array };
+				},
 			) => Promise<void>;
 		};
+		(index as unknown as { fieldEncoder: () => never }).fieldEncoder = () => {
+			throw new Error("TypeScript field encoder should not run");
+		};
+		const document = new BridgeDocument("a", "peerbit", "native index");
+		const context = new BridgeContext("head-a");
 
 		await contextualIndex.putWithContext(
-			new BridgeDocument("a", "peerbit", "native index"),
+			document,
 			toId("a"),
-			new BridgeContext("head-a"),
-			{ replace: false },
+			context,
+			{
+				replace: false,
+				encodedValueParts: {
+					prefix: serialize(document),
+					suffix: serialize(context),
+				},
+			},
 		);
 
 		const result = await index.get(toId("a"));

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -1,4 +1,4 @@
-import { field, vec } from "@dao-xyz/borsh";
+import { field, variant, vec } from "@dao-xyz/borsh";
 import {
 	And,
 	BoolQuery,
@@ -175,6 +175,34 @@ class BridgeNestedDocument {
 	}
 }
 
+@variant("bridge_variant_item")
+class BridgeVariantNestedItem {
+	@field({ type: "string" })
+	tag: string;
+
+	@field({ type: "u32" })
+	score: number;
+
+	constructor(tag: string, score: number) {
+		this.tag = tag;
+		this.score = score;
+	}
+}
+
+@variant("bridge_variant_document")
+class BridgeVariantNestedDocument {
+	@id({ type: "string" })
+	id: string;
+
+	@field({ type: vec(BridgeVariantNestedItem) })
+	items: BridgeVariantNestedItem[];
+
+	constructor(id: string, items: BridgeVariantNestedItem[]) {
+		this.id = id;
+		this.items = items;
+	}
+}
+
 const isNodeRuntime = () =>
 	Boolean(
 		(
@@ -259,6 +287,45 @@ describe("native planner bridge", () => {
 		);
 		await index.put(
 			new BridgeNestedDocument("b", [new BridgeNestedItem("left", 4)]),
+		);
+
+		const results = await index
+			.iterate({
+				query: new Nested({
+					path: "items",
+					query: [
+						new StringMatch({ key: "tag", value: "left" }),
+						new IntegerCompare({
+							key: "score",
+							compare: Compare.Greater,
+							value: 2,
+						}),
+					],
+				}),
+			})
+			.all();
+
+		expect(results.map((result) => result.value.id)).to.deep.equal(["b"]);
+		await indices.drop();
+	});
+
+	it("indexes borsh variant-prefixed document bytes in native rust", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeVariantNestedDocument });
+		(index as unknown as { fieldEncoder: () => never }).fieldEncoder = () => {
+			throw new Error("TypeScript field encoder should not run");
+		};
+		await index.put(
+			new BridgeVariantNestedDocument("a", [
+				new BridgeVariantNestedItem("left", 1),
+				new BridgeVariantNestedItem("right", 3),
+			]),
+		);
+		await index.put(
+			new BridgeVariantNestedDocument("b", [
+				new BridgeVariantNestedItem("left", 4),
+			]),
 		);
 
 		const results = await index

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -228,11 +228,56 @@ describe("native planner bridge", () => {
 		await indices.start();
 		const index = await indices.init({ schema: BridgeNestedDocument });
 		const { nativeSchemaIrStats: stats } = index as unknown as {
-			nativeSchemaIrStats?: { rootFields: number; nodeCount: number };
+			nativeSchemaIrStats?: {
+				rootFields: number;
+				nodeCount: number;
+				genericNodes: number;
+			};
 		};
 
-		expect(stats).to.deep.equal({ rootFields: 2, nodeCount: 6 });
+		expect(stats).to.deep.equal({
+			rootFields: 2,
+			nodeCount: 6,
+			genericNodes: 0,
+		});
 
+		await indices.drop();
+	});
+
+	it("indexes borsh-encoded document bytes in native rust", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeNestedDocument });
+		(index as unknown as { fieldEncoder: () => never }).fieldEncoder = () => {
+			throw new Error("TypeScript field encoder should not run");
+		};
+		await index.put(
+			new BridgeNestedDocument("a", [
+				new BridgeNestedItem("left", 1),
+				new BridgeNestedItem("right", 3),
+			]),
+		);
+		await index.put(
+			new BridgeNestedDocument("b", [new BridgeNestedItem("left", 4)]),
+		);
+
+		const results = await index
+			.iterate({
+				query: new Nested({
+					path: "items",
+					query: [
+						new StringMatch({ key: "tag", value: "left" }),
+						new IntegerCompare({
+							key: "score",
+							compare: Compare.Greater,
+							value: 2,
+						}),
+					],
+				}),
+			})
+			.all();
+
+		expect(results.map((result) => result.value.id)).to.deep.equal(["b"]);
 		await indices.drop();
 	});
 


### PR DESCRIPTION
## Summary
- add a Rust-side Borsh schema extractor for native index facts using the schema IR from #903
- carry Borsh variant prefixes through the native schema IR, so normal variant-decorated Peerbit documents and nested variant objects extract correctly in Rust
- add `NativeRustIndex.put_encoded(...)` and wire `RustIndex.put()` / `putBatch()` / contextual document puts to use serialized-value extraction for supported schemas
- reuse the already-serialized document bytes from `Documents.put()` and prepared `putMany()` when committing into the contextual document index
- add `NativeRustIndex.put_encoded_parts(...)` so contextual document indexing passes document bytes and context bytes separately, avoiding a JS-side concat/copy of the full wrapped value
- keep the existing TypeScript fact encoder as fallback for unsupported/generic schema edges
- add focused Rust-indexer and document fast-path tests proving native Borsh byte extraction and prepared-byte propagation

## Benchmark
Local document-put signal with 200 non-unique puts:

```bash
DOC_WARMUP=20 DOC_ITERATIONS=200 DOC_SCENARIOS=rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Latest run after two-part contextual encoded bytes:
- `rust-peerbit-nonunique`: 2651 ops/sec, total 75.45 ms, document index put 5.10 ms, backend index put 3.81 ms
- `rust-peerbit-transient-index-nonunique`: 3143 ops/sec, total 63.63 ms, document index put 4.11 ms, backend index put 2.78 ms

Earlier run before prepared-byte reuse:
- `rust-peerbit-nonunique`: 2606 ops/sec, total 76.75 ms, backend index put 6.70 ms
- `rust-peerbit-transient-index-nonunique`: 3088 ops/sec, total 64.77 ms, backend index put 5.14 ms

Read: backend index projection cost dropped materially. Total throughput is now mostly constrained by shared-log/log append orchestration.

## Test Plan
- cargo test --manifest-path packages/utils/indexer/rust/Cargo.toml
- pnpm --filter @peerbit/indexer-rust run build
- pnpm --filter @peerbit/indexer-rust exec aegir test -t node --grep "contextual document puts|indexes borsh"
- pnpm --filter @peerbit/indexer-rust test
- pnpm --filter @peerbit/document run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "validated local append path|batches rust index"
- pnpm exec eslint --config eslint.config.js packages/utils/indexer/rust/src/index.ts packages/utils/indexer/rust/test/index.spec.ts packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/src/search.ts packages/programs/data/document/document/test/index.spec.ts
- cargo fmt --manifest-path packages/utils/indexer/rust/Cargo.toml
- git diff --check