### PR TITLE
Reuse prepared single document put payloads

### DIFF
--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -687,6 +687,7 @@ export class Log<T> {
 		properties?: {
 			skipMissingNextJoin?: boolean;
 			resolveTrimmedEntries?: boolean;
+			payloadData?: Uint8Array;
 		},
 	): Promise<{
 		entry: Entry<T>;
@@ -715,6 +716,7 @@ export class Log<T> {
 					appendOptions,
 					nexts,
 					deferBlockStore,
+					properties?.payloadData ? [properties.payloadData] : undefined,
 				)
 			: undefined;
 		let entry: Entry<T>;
@@ -939,6 +941,7 @@ export class Log<T> {
 		options: AppendOptions<T>,
 		nexts: Sorting.SortableEntry[],
 		deferBlockStore: boolean,
+		payloadDatas?: Uint8Array[],
 	): Promise<PreparedAppendChain<T> | undefined> {
 		const canAppendAlreadyValidated =
 			options.__peerbitCanAppendAlreadyValidated === true;
@@ -983,6 +986,7 @@ export class Log<T> {
 				next: nexts,
 			},
 			encoding: this._encoding,
+			payloadDatas,
 			identity: options.identity || this._identity,
 			deferStore: deferBlockStore,
 			cachePreparedEntries: false,

--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -107,8 +107,7 @@ export type CanPerform<T> = (
 ) => MaybePromise<boolean>;
 
 const PUT_OPERATION_PREFIX_LENGTH = 6;
-const encodePutOperationPayload = (operation: PutOperation): Uint8Array => {
-	const data = operation.data;
+const encodePutOperationPayload = (data: Uint8Array): Uint8Array => {
 	const encoded = new Uint8Array(PUT_OPERATION_PREFIX_LENGTH + data.byteLength);
 	encoded[0] = 0;
 	encoded[1] = 3;
@@ -138,6 +137,7 @@ type DocumentPutOptions = SharedAppendOptions<Operation> & {
 type PreparedPut<T> = {
 	document: T;
 	encodedDocument: Uint8Array;
+	encodedOperation?: Uint8Array;
 	keyValue: indexerTypes.IdPrimitive;
 	key: indexerTypes.IdKey;
 	operation: PutOperation | PutWithKeyOperation;
@@ -636,32 +636,42 @@ export class Documents<
 	private preparePut(doc: T): PreparedPut<T> {
 		const keyValue = this.idResolver(doc);
 		indexerTypes.checkId(keyValue);
-		const ser = serialize(doc);
-		if (ser.length > MAX_BATCH_SIZE) {
+		let encodedDocument = serialize(doc);
+		if (encodedDocument.length > MAX_BATCH_SIZE) {
 			throw new Error(
 				`Document is too large (${
-					ser.length * 1e-6
+					encodedDocument.length * 1e-6
 				}) mb). Needs to be less than ${MAX_BATCH_SIZE * 1e-6} mb`,
 			);
 		}
 
 		const key = indexerTypes.toId(keyValue);
 		let operation: PutOperation | PutWithKeyOperation;
+		let encodedOperation: Uint8Array | undefined;
 		if (this.compatibility === 6) {
 			if (typeof keyValue === "string") {
 				operation = new PutWithKeyOperation({
 					key: keyValue,
-					data: ser,
+					data: encodedDocument,
 				});
 			} else {
 				throw new Error("Key must be a string in compatibility mode v6");
 			}
 		} else {
+			encodedOperation = encodePutOperationPayload(encodedDocument);
+			encodedDocument = encodedOperation.subarray(PUT_OPERATION_PREFIX_LENGTH);
 			operation = new PutOperation({
-				data: ser,
+				data: encodedDocument,
 			});
 		}
-		return { document: doc, encodedDocument: ser, keyValue, key, operation };
+		return {
+			document: doc,
+			encodedDocument,
+			encodedOperation,
+			keyValue,
+			key,
+			operation,
+		};
 	}
 
 	public async put(doc: T, options?: DocumentPutOptions) {
@@ -694,6 +704,7 @@ export class Documents<
 			return this.putPlainFastPath(
 				prepared.document,
 				prepared.encodedDocument,
+				prepared.encodedOperation,
 				prepared.key,
 				prepared.operation,
 				existingHead,
@@ -760,7 +771,8 @@ export class Documents<
 			{
 				resolveTrimmedEntries: !this._index.canGetIdentityIndexedByHead(),
 				payloadDatas: prepared.map((item) =>
-					encodePutOperationPayload(item.operation as PutOperation),
+					item.encodedOperation ??
+					encodePutOperationPayload((item.operation as PutOperation).data),
 				),
 			},
 		);
@@ -845,6 +857,7 @@ export class Documents<
 	private async putPlainFastPath(
 		doc: T,
 		encodedDocument: Uint8Array,
+		encodedOperation: Uint8Array | undefined,
 		key: indexerTypes.IdKey,
 		operation: PutOperation,
 		existingHead: string | undefined,
@@ -877,6 +890,8 @@ export class Documents<
 			{
 				skipMissingNextJoin: !options?.checkRemote,
 				resolveTrimmedEntries: !this._index.canGetIdentityIndexedByHead(),
+				payloadData:
+					encodedOperation ?? encodePutOperationPayload(operation.data),
 			},
 		);
 		if (!options?.unique && existingLocalContext === undefined) {

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -224,6 +224,21 @@ describe("index", () => {
 					expect(appendSpy.callCount).equal(0);
 					expect(localLookupSpy.callCount).equal(0);
 					expect(backendContextPutSpy.callCount).equal(1);
+					const encodedDocument = serialize(doc);
+					const expectedPayloadData = new Uint8Array(
+						6 + encodedDocument.byteLength,
+					);
+					expectedPayloadData[0] = 0;
+					expectedPayloadData[1] = 3;
+					new DataView(
+						expectedPayloadData.buffer,
+						expectedPayloadData.byteOffset,
+						expectedPayloadData.byteLength,
+					).setUint32(2, encodedDocument.byteLength, true);
+					expectedPayloadData.set(encodedDocument, 6);
+					expect(preparedAppendSpy.getCall(0).args[2]?.payloadData).to.deep.equal(
+						expectedPayloadData,
+					);
 					const backendOptions = backendContextPutSpy.getCall(0).args[3] as
 						| {
 								encodedValue?: Uint8Array;
@@ -232,7 +247,6 @@ describe("index", () => {
 						| undefined;
 					const backendContext = backendContextPutSpy.getCall(0)
 						.args[2] as Context;
-					const encodedDocument = serialize(doc);
 					expect(backendOptions?.encodedValue).equal(undefined);
 					expect(backendOptions?.encodedValueParts?.prefix).to.deep.equal(
 						encodedDocument,

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -4061,6 +4061,7 @@ export class SharedLog<
 		properties?: {
 			skipMissingNextJoin?: boolean;
 			resolveTrimmedEntries?: boolean;
+			payloadData?: Uint8Array;
 		},
 	): Promise<{
 		entry: Entry<T>;
@@ -4081,6 +4082,7 @@ export class SharedLog<
 		const result = await this.log.appendLocallyPrepared(data, appendOptions, {
 			skipMissingNextJoin: properties?.skipMissingNextJoin,
 			resolveTrimmedEntries: properties?.resolveTrimmedEntries,
+			payloadData: properties?.payloadData,
 		});
 		await this.onChange(result.change);
 		await this.processLocalAppend(result.entry, result.removed, options, {


### PR DESCRIPTION
## Summary
- stack on #904 and extend the single-document native fast path with prepared PutOperation payload bytes
- prepare the compatibility-v7 PutOperation payload once in Documents.preparePut() and use the document bytes as a view into that payload
- forward payloadData through Documents -> SharedLog -> Log -> EntryV0 so the native append builder can skip generic operation encoding
- add focused coverage that the single prepared append path receives the exact Borsh PutOperation payload

## Benchmarks
Command: `DOC_WARMUP=20 DOC_ITERATIONS=200 DOC_SCENARIOS=rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts`

- `rust-peerbit-nonunique`: 2757 ops/sec, total 72.55 ms
- `rust-peerbit-transient-index-nonunique`: 3252 ops/sec, total 61.50 ms

Command: `DOC_WARMUP=100 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts`

- `rust-peerbit-nonunique`: 3171 ops/sec, total 315.36 ms
- `rust-peerbit-transient-index-nonunique`: 4196 ops/sec, total 238.35 ms

Read: this is a foundation cleanup that removes duplicate payload encoding/copying. The document put path remains append-bound, so this is not the big throughput jump by itself.

## Validation
- `pnpm --filter @peerbit/log run build && pnpm --filter @peerbit/shared-log run build && pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses the validated local append path|batches rust index and coordinate writes"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "append commits one block and graph in one native call when storage is native"`
- `pnpm exec eslint --config eslint.config.js packages/log/src/log.ts packages/programs/data/shared-log/src/index.ts packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/test/index.spec.ts` (one existing unrelated warning)
- `git diff --check`