### PR TITLE
Skip missing next lookups during native trim

### DIFF
--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -1500,9 +1500,13 @@ export class EntryIndex<T> {
 				graph?.delete(hash);
 			}
 		}
+		const deletedNexts: string[] = [];
 		for (const node of deleted) {
-			await this.privateUpdateNextHeadProperty(node, true);
+			if (node.meta.type !== EntryType.CUT) {
+				deletedNexts.push(...node.meta.next);
+			}
 		}
+		await this.privateUpdateNextHeadHashes(deletedNexts, true);
 		return deleted;
 	}
 
@@ -1555,8 +1559,19 @@ export class EntryIndex<T> {
 	}
 
 	private async privateUpdateNextHeadHashes(nexts: string[], isHead: boolean) {
-		for (const next of nexts) {
+		const hashes = [...new Set(nexts.filter(Boolean))];
+		if (hashes.length === 0) {
+			return;
+		}
+		const existingNexts =
+			isHead && this.properties.nativeGraph
+				? this.properties.nativeGraph.graph.hasMany(hashes)
+				: undefined;
+		for (const next of hashes) {
 			const pending = this.pendingIndexWrites.get(next);
+			if (!pending && existingNexts && !existingNexts.has(next)) {
+				continue;
+			}
 			const indexedEntry = pending
 				? { id: toId(next), value: pending }
 				: await this.properties.index.get(toId(next));

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -438,6 +438,42 @@ describe("native graph", () => {
 		}
 	});
 
+	it("skips missing next index lookups during native length trim", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			appendDurability: "strict",
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+		});
+		const first = (
+			await log.append(new Uint8Array([1]), { meta: { next: [] } })
+		).entry;
+		const second = (await log.append(new Uint8Array([2]))).entry;
+		await log.append(new Uint8Array([3]));
+
+		const nativeGraph = log.entryIndex.properties.nativeGraph!.graph;
+		const hasManySpy = sinon.spy(nativeGraph, "hasMany");
+		const indexGetSpy = sinon.spy(log.entryIndex.properties.index, "get");
+		try {
+			const removed = await log.trim(
+				{ type: "length", to: 1 },
+				{ resolveDeletedEntries: false },
+			);
+
+			expect(removed?.map((entry) => entry.hash)).to.deep.equal([
+				first.hash,
+				second.hash,
+			]);
+			expect(log.length).equal(1);
+			expect(hasManySpy.callCount).greaterThan(0);
+			expect(indexGetSpy.callCount).equal(0);
+		} finally {
+			indexGetSpy.restore();
+			hasManySpy.restore();
+			await log.close();
+		}
+	});
+
 	it("plans cut recursion deletes in the native graph", async () => {
 		const log = new Log<Uint8Array>();
 		await log.open(store, signKey, {


### PR DESCRIPTION
## Summary
- stack on #905 and tighten native graph length trim
- batch deleted next hashes into one head-restore pass after `EntryIndex.deleteMany()`
- use native graph `hasMany()` to skip TS index `get()` calls for next hashes that are already gone
- add focused coverage for chain-like trim where deleted entries point to already-trimmed predecessors

## Benchmarks
Command: `DOC_WARMUP=100 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts`

- `rust-peerbit-nonunique`: 3344 ops/sec, total 299.01 ms, log trim 57.01 ms
- `rust-peerbit-transient-index-nonunique`: 4232 ops/sec, total 236.28 ms, log trim 45.66 ms

Read: product-level signal is noisy/neutral for persistent mode and positive for transient mode. The targeted invariant is still useful: native graph trim avoids TS index misses for already-removed chain predecessors.

## Validation
- `pnpm --filter @peerbit/log run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "native length trim|uses the native graph to plan unfiltered length trim"`
- `pnpm exec eslint --config eslint.config.js packages/log/src/entry-index.ts packages/log/test/native-graph.spec.ts`
- `git diff --check`