### PR TITLE
Add document put commit plan boundary

### DIFF
--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -143,6 +143,23 @@ type PreparedPut<T> = {
 	operation: PutOperation | PutWithKeyOperation;
 };
 
+type PlainPutCommitPlan<T, I extends Record<string, any>> = {
+	document: T;
+	encodedDocument: Uint8Array;
+	payloadData: Uint8Array;
+	key: indexerTypes.IdKey;
+	operation: PutOperation;
+	next: Entry<Operation>[] | ShallowEntry[];
+	skipMissingNextJoin: boolean;
+	resolveTrimmedEntries: boolean;
+	useGenericChangeHandler: boolean;
+	unique?: boolean;
+	existing?:
+		| indexerTypes.IndexedResult<IndexedContextOnly<I>>
+		| null
+		| undefined;
+};
+
 type InferR<D> = D extends ReplicationDomain<any, any, infer I> ? I : "u32";
 
 export type SetupOptions<
@@ -697,20 +714,14 @@ export class Documents<
 			}
 		}
 
-		if (
-			prepared.operation instanceof PutOperation &&
-			this.canUsePlainPutFastPath(options)
-		) {
-			return this.putPlainFastPath(
-				prepared.document,
-				prepared.encodedDocument,
-				prepared.encodedOperation,
-				prepared.key,
-				prepared.operation,
-				existingHead,
-				existingLocalContext,
-				options,
-			);
+		const plainPutPlan = await this.createPlainPutCommitPlan(
+			prepared,
+			existingHead,
+			existingLocalContext,
+			options,
+		);
+		if (plainPutPlan) {
+			return this.commitPlainPutPlan(plainPutPlan, options);
 		}
 
 		const appended = await this.log.append(prepared.operation, {
@@ -854,12 +865,8 @@ export class Documents<
 		);
 	}
 
-	private async putPlainFastPath(
-		doc: T,
-		encodedDocument: Uint8Array,
-		encodedOperation: Uint8Array | undefined,
-		key: indexerTypes.IdKey,
-		operation: PutOperation,
+	private async createPlainPutCommitPlan(
+		prepared: PreparedPut<T>,
 		existingHead: string | undefined,
 		existingLocalContext:
 			| indexerTypes.IndexedResult<IndexedContextOnly<I>>
@@ -868,7 +875,13 @@ export class Documents<
 		options:
 			| DocumentPutOptions
 			| undefined,
-	) {
+	): Promise<PlainPutCommitPlan<T, I> | undefined> {
+		if (
+			!(prepared.operation instanceof PutOperation) ||
+			!this.canUsePlainPutFastPath(options)
+		) {
+			return;
+		}
 		const indexedContextNext = existingHead
 			? this.nextFromIndexedContext(existingHead, existingLocalContext)
 			: undefined;
@@ -877,46 +890,69 @@ export class Documents<
 				? [indexedContextNext]
 				: [await this._resolveEntry(existingHead)]
 			: [];
+		return {
+			document: prepared.document,
+			encodedDocument: prepared.encodedDocument,
+			payloadData:
+				prepared.encodedOperation ??
+				encodePutOperationPayload(prepared.operation.data),
+			key: prepared.key,
+			operation: prepared.operation,
+			next,
+			skipMissingNextJoin: !options?.checkRemote,
+			resolveTrimmedEntries: !this._index.canGetIdentityIndexedByHead(),
+			useGenericChangeHandler:
+				!options?.unique && existingLocalContext === undefined,
+			unique: options?.unique,
+			existing: existingLocalContext,
+		};
+	}
+
+	private async commitPlainPutPlan(
+		plan: PlainPutCommitPlan<T, I>,
+		options:
+			| DocumentPutOptions
+			| undefined,
+	) {
 		const appended = await this.log.appendLocallyPrepared(
-			operation,
+			plan.operation,
 			{
 				...options,
 				meta: {
-					next,
+					next: plan.next,
 					...options?.meta,
 				},
 				replicate: options?.replicate,
 			},
 			{
-				skipMissingNextJoin: !options?.checkRemote,
-				resolveTrimmedEntries: !this._index.canGetIdentityIndexedByHead(),
-				payloadData:
-					encodedOperation ?? encodePutOperationPayload(operation.data),
+				skipMissingNextJoin: plan.skipMissingNextJoin,
+				resolveTrimmedEntries: plan.resolveTrimmedEntries,
+				payloadData: plan.payloadData,
 			},
 		);
-		if (!options?.unique && existingLocalContext === undefined) {
+		if (plan.useGenericChangeHandler) {
 			await this.handleChanges(
 				{
 					added: [{ head: true, entry: appended.entry }],
 					removed: appended.removed,
 				},
 				{
-					document: doc,
-					operation,
-					key,
-					unique: options?.unique,
-					existing: existingLocalContext,
+					document: plan.document,
+					operation: plan.operation,
+					key: plan.key,
+					unique: plan.unique,
+					existing: plan.existing,
 				},
 			);
 		} else {
 			await this.handlePreparedPlainPutCommit({
-				document: doc,
-				encodedDocument,
-				key,
+				document: plan.document,
+				encodedDocument: plan.encodedDocument,
+				key: plan.key,
 				entry: appended.entry,
 				removed: appended.removed,
-				unique: options?.unique,
-				existing: existingLocalContext,
+				unique: plan.unique,
+				existing: plan.existing,
 			});
 		}
 		this.keepCache?.add(appended.entry.hash);

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -191,6 +191,10 @@ describe("index", () => {
 					store.docs as any,
 					"getLocalIndexedContext",
 				);
+				const commitPlanSpy = sinon.spy(
+					store.docs as any,
+					"createPlainPutCommitPlan",
+				);
 				const backendIndex = store.docs.index.index as any;
 				const originalBackendPutWithContext = backendIndex.putWithContext;
 				const originalBackendPut = backendIndex.put;
@@ -223,6 +227,7 @@ describe("index", () => {
 					expect(validatedAppendSpy.callCount).equal(0);
 					expect(appendSpy.callCount).equal(0);
 					expect(localLookupSpy.callCount).equal(0);
+					expect(commitPlanSpy.callCount).equal(1);
 					expect(backendContextPutSpy.callCount).equal(1);
 					const encodedDocument = serialize(doc);
 					const expectedPayloadData = new Uint8Array(
@@ -239,6 +244,8 @@ describe("index", () => {
 					expect(preparedAppendSpy.getCall(0).args[2]?.payloadData).to.deep.equal(
 						expectedPayloadData,
 					);
+					const commitPlan = await commitPlanSpy.getCall(0).returnValue;
+					expect(commitPlan.payloadData).to.deep.equal(expectedPayloadData);
 					const backendOptions = backendContextPutSpy.getCall(0).args[3] as
 						| {
 								encodedValue?: Uint8Array;
@@ -270,6 +277,7 @@ describe("index", () => {
 						delete backendIndex.putWithContext;
 					}
 					localLookupSpy.restore();
+					commitPlanSpy.restore();
 					preparedAppendSpy.restore();
 					validatedAppendSpy.restore();
 					appendSpy.restore();


### PR DESCRIPTION
## Summary
- stack on #906 and split plain local document put into a create/commit plan boundary
- carry prepared document bytes and prepared operation payload bytes through the plan so the commit side can later become a native transaction call
- keep all current compatibility fallback behavior unchanged for hooks, remote validation, custom options, and unsupported document shapes

## Why
This is a structural step toward a JS -> native document transaction boundary. It does not claim a large direct speedup yet; it makes the eligible plain put path explicit enough that the next PR can replace the commit body with a coalesced native operation.

## Bench signal
Quick local 200-op benchmark after the change:
- rust-peerbit-nonunique: 2715 ops/sec, total 73.67 ms
- rust-peerbit-transient-index-nonunique: 3441 ops/sec, total 58.12 ms

## Validation
- pnpm --filter @peerbit/document run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses the validated local append path|batches rust index and coordinate writes|document updates"
- pnpm exec eslint --config eslint.config.js packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/test/index.spec.ts
- git diff --check

Note: eslint still reports the existing unrelated unused variable warning at document/test/index.spec.ts:4196.