### PR TITLE
Coalesce prepared append coordinate deletes

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -1939,12 +1939,7 @@ export class SharedLog<
 		if (values.length === 0) {
 			return;
 		}
-		this._nativeSharedLogState?.deleteEntryCoordinatesBatch(values);
-		if (this._residentEntryCoordinatesByHash) {
-			for (const hash of values) {
-				this._residentEntryCoordinatesByHash.delete(hash);
-			}
-		}
+		this.forgetCoordinateStateForHashes(values);
 		const coordinateIndex = this.entryCoordinatesIndex as PutAndDeleteIndex<
 			EntryReplicated<R>
 		>;
@@ -1960,6 +1955,19 @@ export class SharedLog<
 							values.map((hash) => new StringMatch({ key: "hash", value: hash })),
 						),
 		});
+	}
+
+	private forgetCoordinateStateForHashes(hashes: Iterable<string>) {
+		const values = [...new Set([...hashes].filter(Boolean))];
+		if (values.length === 0) {
+			return;
+		}
+		this._nativeSharedLogState?.deleteEntryCoordinatesBatch(values);
+		if (this._residentEntryCoordinatesByHash) {
+			for (const hash of values) {
+				this._residentEntryCoordinatesByHash.delete(hash);
+			}
+		}
 	}
 
 	private async ensureCurrentHeadCoordinatesIndexed() {
@@ -4084,11 +4092,50 @@ export class SharedLog<
 			resolveTrimmedEntries: properties?.resolveTrimmedEntries,
 			payloadData: properties?.payloadData,
 		});
-		await this.onChange(result.change);
-		await this.processLocalAppend(result.entry, result.removed, options, {
-			minReplicasValue,
-		});
+		let nativeAppendPlan: NativeAppendEntryPlan<R> | undefined;
+		let deferredCoordinateDeleteHashes: string[] | undefined;
+		if (this.canCoalescePreparedAppendCoordinateDeletes(result, options)) {
+			deferredCoordinateDeleteHashes =
+				(await this.applyChange(result.change, {
+					deferCoordinateIndexDeletes: true,
+				})) ?? [];
+			nativeAppendPlan = await this.planNativeLocalAppendEntry(
+				result.entry,
+				minReplicasValue,
+			);
+			if (!nativeAppendPlan) {
+				await this.deleteCoordinatesForHashes(deferredCoordinateDeleteHashes);
+				deferredCoordinateDeleteHashes = undefined;
+			}
+		} else {
+			await this.onChange(result.change);
+		}
+		try {
+			await this.processLocalAppend(result.entry, result.removed, options, {
+				minReplicasValue,
+				nativeAppendPlan,
+				extraCoordinateDeleteHashes: deferredCoordinateDeleteHashes,
+			});
+		} catch (error) {
+			if (deferredCoordinateDeleteHashes) {
+				await this.deleteCoordinatesForHashes(deferredCoordinateDeleteHashes);
+			}
+			throw error;
+		}
 		return { entry: result.entry, removed: result.removed };
+	}
+
+	private canCoalescePreparedAppendCoordinateDeletes(
+		result: { removed: ShallowOrFullEntry<T>[] },
+		options?: SharedAppendOptions<T>,
+	): boolean {
+		return (
+			result.removed.length > 0 &&
+			options?.target === "none" &&
+			options?.replicate !== true &&
+			!this.shouldDeferHeadCoordinatePersistence(options) &&
+			!!this._nativeSharedLogState
+		);
 	}
 
 	async appendLocallyPreparedManyIndependent(
@@ -4550,6 +4597,7 @@ export class SharedLog<
 			minReplicasValue: number;
 			deferHeadCoordinatePersistence?: boolean;
 			nativeAppendPlan?: NativeAppendEntryPlan<R>;
+			extraCoordinateDeleteHashes?: string[];
 		},
 	) {
 		const deferHeadCoordinatePersistence =
@@ -4602,6 +4650,7 @@ export class SharedLog<
 				entry,
 				assignedToRangeBoundary: nativeAppendPlan.assignedToRangeBoundary,
 				commitNative: false,
+				deleteHashes: properties.extraCoordinateDeleteHashes,
 			});
 		} else {
 			({ coordinates, leaders, isLeader } = await this.planEntryLeaders(
@@ -5819,14 +5868,32 @@ export class SharedLog<
 		return this.log.idString;
 	}
 
-	async onChange(change: Change<T>) {
+	async onChange(change: Change<T>): Promise<void> {
+		await this.applyChange(change);
+	}
+
+	private async applyChange(
+		change: Change<T>,
+		options?: { deferCoordinateIndexDeletes?: boolean },
+	): Promise<string[] | undefined> {
+		const deferredCoordinateDeleteHashes: string[] = [];
 		for (const added of change.added) {
 			this.onEntryAdded(added.entry);
 		}
 		for (const removed of change.removed) {
-			await this.deleteCoordinates({ hash: removed.hash });
+			if (options?.deferCoordinateIndexDeletes) {
+				deferredCoordinateDeleteHashes.push(removed.hash);
+			} else {
+				await this.deleteCoordinates({ hash: removed.hash });
+			}
 			this.onEntryRemoved(removed.hash);
 		}
+		if (options?.deferCoordinateIndexDeletes) {
+			this.forgetCoordinateStateForHashes(deferredCoordinateDeleteHashes);
+		}
+		return options?.deferCoordinateIndexDeletes
+			? deferredCoordinateDeleteHashes
+			: undefined;
 	}
 
 	async canAppend(entry: Entry<T>) {
@@ -7579,6 +7646,7 @@ export class SharedLog<
 		prev?: EntryReplicated<R>;
 		assignedToRangeBoundary?: boolean;
 		commitNative?: boolean;
+		deleteHashes?: string[];
 	}) {
 		const prepared = this.createCoordinatePersistenceEntry(properties);
 		if (!prepared) {
@@ -7586,6 +7654,10 @@ export class SharedLog<
 		}
 		const { coordinateEntry, assignedToRangeBoundary } = prepared;
 		const nextHashes = properties.entry.meta.next;
+		const deleteHashes =
+			properties.deleteHashes && properties.deleteHashes.length > 0
+				? [...new Set([...nextHashes, ...properties.deleteHashes])]
+				: nextHashes;
 		const coordinateIndex = this.entryCoordinatesIndex as PutAndDeleteIndex<
 			EntryReplicated<R>
 		>;
@@ -7602,19 +7674,19 @@ export class SharedLog<
 					assignedToRangeBoundary: coordinateEntry.assignedToRangeBoundary,
 					metaBytes: coordinateEntry.getMetaBytes(),
 				},
-				nextHashes,
+				deleteHashes,
 			);
-		} else if (nextHashes.length > 0 && coordinateIndex.putAndDeleteIds) {
-			await coordinateIndex.putAndDeleteIds(coordinateEntry, nextHashes);
+		} else if (deleteHashes.length > 0 && coordinateIndex.putAndDeleteIds) {
+			await coordinateIndex.putAndDeleteIds(coordinateEntry, deleteHashes);
 		} else {
 			deleteNextOptions =
-				nextHashes.length === 0
+				deleteHashes.length === 0
 					? undefined
-					: nextHashes.length === 1
-						? { query: { hash: nextHashes[0] } }
+					: deleteHashes.length === 1
+						? { query: { hash: deleteHashes[0] } }
 						: {
 								query: new Or(
-									nextHashes.map(
+									deleteHashes.map(
 										(x) => new StringMatch({ key: "hash", value: x }),
 									),
 								),

--- a/packages/programs/data/shared-log/test/append.spec.ts
+++ b/packages/programs/data/shared-log/test/append.spec.ts
@@ -1,4 +1,5 @@
 import { TestSession } from "@peerbit/test-utils";
+import { create as createRustIndexer } from "@peerbit/indexer-rust";
 import { expect } from "chai";
 import sinon from "sinon";
 import { EventStore } from "./utils/stores/index.js";
@@ -156,6 +157,51 @@ describe("append", () => {
 		} finally {
 			batchSpy.restore();
 			singleSpy.restore();
+		}
+	});
+
+	it("coalesces prepared append trim coordinate deletes into the coordinate put", async () => {
+		session = await TestSession.disconnected(1, {
+			indexer: (directory) => createRustIndexer(directory),
+		});
+		const store = await session.peers[0].open(new EventStore<string, any>(), {
+			args: {
+				replicate: { factor: 1 },
+				timeUntilRoleMaturity: 0,
+				trim: { type: "length", to: 1 },
+			},
+		});
+		const coordinateIndex = store.log.entryCoordinatesIndex as any;
+		const putDeleteSpy = sinon.spy(
+			coordinateIndex,
+			"putSharedLogCoordinateAndDeleteIds",
+		);
+		const delIdsSpy = sinon.spy(coordinateIndex, "delIds");
+		try {
+			const first = await store.log.appendLocallyPrepared(
+				{ op: "ADD", value: "a" },
+				{
+					replicate: false,
+					target: "none",
+				},
+			);
+			putDeleteSpy.resetHistory();
+			delIdsSpy.resetHistory();
+
+			await store.log.appendLocallyPrepared(
+				{ op: "ADD", value: "b" },
+				{
+					replicate: false,
+					target: "none",
+				},
+			);
+
+			expect(delIdsSpy.callCount).equal(0);
+			expect(putDeleteSpy.callCount).equal(1);
+			expect(putDeleteSpy.firstCall.args[2]).to.deep.equal([first.entry.hash]);
+		} finally {
+			delIdsSpy.restore();
+			putDeleteSpy.restore();
 		}
 	});
 });


### PR DESCRIPTION
## Summary
- stack on #907 and reduce coordinate-index write orchestration for trusted prepared local appends
- when a prepared target-none append trims/removes old entries, defer the coordinate-index deletes and fold them into the new coordinate put-and-delete write
- keep native shared-log state cleanup, resident coordinate cache cleanup, and shared-log removal notifications intact
- add focused shared-log coverage proving the trimmed coordinate delete is coalesced into `putSharedLogCoordinateAndDeleteIds` instead of a separate `delIds` call

## Why
The document put profile is now mostly lower-log/shared-log append work, not document index projection. This reduces one persistent coordinate-index mutation on the trimmed prepared append path, which is especially relevant for persistent/native/OPFS-style storage.

## Bench signal
Quick local 500-op document-put profile after the change:
- rust-peerbit: 2869 ops/sec, total 174.27 ms
- rust-peerbit-transient-index: 2656 ops/sec, total 188.29 ms
- rust-peerbit-nonunique: 3796 ops/sec, total 131.73 ms
- rust-peerbit-transient-index-nonunique: 4354 ops/sec, total 114.83 ms

The product-level numbers are noisy at this size; the deterministic win is fewer coordinate-index mutations under trim.

## Validation
- pnpm --filter @peerbit/shared-log run build
- pnpm --filter @peerbit/document run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "coalesces prepared append trim coordinate deletes|appendMany plans target-none local assignments|appendMany coalesces a local chain"
- pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/index.ts packages/programs/data/shared-log/test/append.spec.ts
- git diff --check