### PR TITLE
Reuse native append hash number in coordinate persistence

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -286,6 +286,7 @@ type EntryLeaderPlan<R extends "u32" | "u64"> = {
 };
 
 type NativeAppendEntryPlan<R extends "u32" | "u64"> = EntryLeaderPlan<R> & {
+	hashNumber: NumberFromType<R>;
 	delivery?: AppendDeliveryPlan;
 };
 
@@ -4370,6 +4371,7 @@ export class SharedLog<
 					entry,
 					assignedToRangeBoundary: plan.assignedToRangeBoundary,
 					commitNative: false,
+					hashNumber: plan.hashNumber,
 				};
 			}),
 		);
@@ -4447,11 +4449,12 @@ export class SharedLog<
 			});
 		const { delivery, reliability, requireRecipients, minAcks } =
 			this._parseDeliveryOptions(deliveryArg);
+		const hashNumber = this.getEntryHashNumber(entry);
 		const plan = this._nativeSharedLogState.planAppendForGid(
 			{
 				entryHash: entry.hash,
 				gid: entry.meta.gid,
-				hashNumber: this.getEntryHashNumber(entry),
+				hashNumber,
 				nextHashes: entry.meta.next,
 				replicas,
 				fullReplicaCandidates: fullReplicaDeliveryCandidates,
@@ -4468,6 +4471,7 @@ export class SharedLog<
 			leaders: plan.leaders,
 			isLeader: plan.isLeader,
 			assignedToRangeBoundary: plan.assignedToRangeBoundary,
+			hashNumber,
 			delivery: plan.delivery,
 		};
 	}
@@ -4481,11 +4485,12 @@ export class SharedLog<
 		}
 
 		const context = await this.createLeaderSelectionContext();
+		const hashNumber = this.getEntryHashNumber(entry);
 		const plan = this._nativeSharedLogState.planLocalAppendForGid(
 			{
 				entryHash: entry.hash,
 				gid: entry.meta.gid,
-				hashNumber: this.getEntryHashNumber(entry),
+				hashNumber,
 				nextHashes: entry.meta.next,
 				replicas,
 				selfHash: context.selfHash,
@@ -4497,6 +4502,7 @@ export class SharedLog<
 			leaders: plan.leaders,
 			isLeader: plan.isLeader,
 			assignedToRangeBoundary: plan.assignedToRangeBoundary,
+			hashNumber,
 		};
 	}
 
@@ -4513,12 +4519,16 @@ export class SharedLog<
 		}
 
 		const context = await this.createLeaderSelectionContext();
+		const entriesWithHashNumbers = entries.map((entry) => ({
+			entry,
+			hashNumber: this.getEntryHashNumber(entry),
+		}));
 		const plans = this._nativeSharedLogState.planAppendForGidsBatch(
 			{
-				entries: entries.map((entry) => ({
+				entries: entriesWithHashNumbers.map(({ entry, hashNumber }) => ({
 					entryHash: entry.hash,
 					gid: entry.meta.gid,
-					hashNumber: this.getEntryHashNumber(entry),
+					hashNumber,
 					nextHashes: entry.meta.next,
 					replicas,
 				})),
@@ -4530,11 +4540,12 @@ export class SharedLog<
 			},
 			this.createNativeLeaderOptions(context),
 		);
-		return plans.map((plan) => ({
+		return plans.map((plan, index) => ({
 			coordinates: plan.coordinates as NumberFromType<R>[],
 			leaders: plan.leaders,
 			isLeader: plan.isLeader,
 			assignedToRangeBoundary: plan.assignedToRangeBoundary,
+			hashNumber: entriesWithHashNumbers[index]!.hashNumber,
 		}));
 	}
 
@@ -4562,12 +4573,16 @@ export class SharedLog<
 			});
 		const { delivery, reliability, requireRecipients, minAcks } =
 			this._parseDeliveryOptions(deliveryArg);
+		const entriesWithHashNumbers = entries.map((entry) => ({
+			entry,
+			hashNumber: this.getEntryHashNumber(entry),
+		}));
 		const plans = this._nativeSharedLogState.planAppendForGidsBatch(
 			{
-				entries: entries.map((entry) => ({
+				entries: entriesWithHashNumbers.map(({ entry, hashNumber }) => ({
 					entryHash: entry.hash,
 					gid: entry.meta.gid,
-					hashNumber: this.getEntryHashNumber(entry),
+					hashNumber,
 					nextHashes: entry.meta.next,
 					replicas,
 				})),
@@ -4580,11 +4595,12 @@ export class SharedLog<
 			},
 			this.createNativeLeaderOptions(context),
 		);
-		return plans.map((plan) => ({
+		return plans.map((plan, index) => ({
 			coordinates: plan.coordinates as NumberFromType<R>[],
 			leaders: plan.leaders,
 			isLeader: plan.isLeader,
 			assignedToRangeBoundary: plan.assignedToRangeBoundary,
+			hashNumber: entriesWithHashNumbers[index]!.hashNumber,
 			delivery: plan.delivery,
 		}));
 	}
@@ -4651,6 +4667,7 @@ export class SharedLog<
 				assignedToRangeBoundary: nativeAppendPlan.assignedToRangeBoundary,
 				commitNative: false,
 				deleteHashes: properties.extraCoordinateDeleteHashes,
+				hashNumber: nativeAppendPlan.hashNumber,
 			});
 		} else {
 			({ coordinates, leaders, isLeader } = await this.planEntryLeaders(
@@ -7607,6 +7624,7 @@ export class SharedLog<
 		replicas: number;
 		prev?: EntryReplicated<R>;
 		assignedToRangeBoundary?: boolean;
+		hashNumber?: NumberFromType<R>;
 	}): { coordinateEntry: EntryReplicated<R>; assignedToRangeBoundary: boolean } | false {
 		const assignedToRangeBoundary =
 			properties.assignedToRangeBoundary ??
@@ -7626,7 +7644,7 @@ export class SharedLog<
 			meta: properties.entry.meta,
 			metaBytes,
 			hash: properties.entry.hash,
-			hashNumber: this.getEntryHashNumber(properties.entry),
+			hashNumber: properties.hashNumber ?? this.getEntryHashNumber(properties.entry),
 		});
 		return { coordinateEntry, assignedToRangeBoundary };
 	}
@@ -7647,6 +7665,7 @@ export class SharedLog<
 		assignedToRangeBoundary?: boolean;
 		commitNative?: boolean;
 		deleteHashes?: string[];
+		hashNumber?: NumberFromType<R>;
 	}) {
 		const prepared = this.createCoordinatePersistenceEntry(properties);
 		if (!prepared) {
@@ -7746,6 +7765,7 @@ export class SharedLog<
 			prev?: EntryReplicated<R>;
 			assignedToRangeBoundary?: boolean;
 			commitNative?: boolean;
+			hashNumber?: NumberFromType<R>;
 		}>,
 	): Promise<boolean[]> {
 		if (items.length === 0) {

--- a/packages/programs/data/shared-log/test/append.spec.ts
+++ b/packages/programs/data/shared-log/test/append.spec.ts
@@ -160,6 +160,31 @@ describe("append", () => {
 		}
 	});
 
+	it("reuses native append plan hash number for coordinate persistence", async () => {
+		session = await TestSession.disconnected(1);
+		const store = await session.peers[0].open(new EventStore<string, any>(), {
+			args: {
+				replicate: { factor: 1 },
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		expect((store.log as any)._nativeSharedLogState).to.exist;
+		const hashNumberSpy = sinon.spy(store.log as any, "getEntryHashNumber");
+		try {
+			await store.log.appendLocallyPrepared(
+				{ op: "ADD", value: "a" },
+				{
+					replicate: false,
+					target: "none",
+				},
+			);
+
+			expect(hashNumberSpy.callCount).equal(1);
+		} finally {
+			hashNumberSpy.restore();
+		}
+	});
+
 	it("coalesces prepared append trim coordinate deletes into the coordinate put", async () => {
 		session = await TestSession.disconnected(1, {
 			indexer: (directory) => createRustIndexer(directory),


### PR DESCRIPTION
## Summary
- stack on #908 and carry the prepared native append `hashNumber` through the shared-log append plan
- use that prepared value when building coordinate persistence rows, including batch persistence
- add focused coverage proving the prepared local append path derives the hash number once instead of recomputing it for coordinate persistence

## Why
Native append planning already computes the entry hash number before calling into the Rust shared-log planner. Coordinate persistence then built the `EntryReplicated` row by deriving the same value again. This removes that duplicate work and keeps the prepared plan as the single source for native append metadata.

## Bench signal
Quick local 500-op document-put profile after the change:
- rust-peerbit-nonunique: 2839 ops/sec, total 176.13 ms
- rust-peerbit-transient-index-nonunique: 3881 ops/sec, total 128.84 ms

This is expected to be noisy at product level; the deterministic improvement is one fewer hash-number derivation per native-planned append persistence.

## Validation
- pnpm --filter @peerbit/shared-log run build
- pnpm --filter @peerbit/document run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "reuses native append plan hash number|coalesces prepared append trim coordinate deletes|appendMany plans target-none local assignments"
- pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/index.ts packages/programs/data/shared-log/test/append.spec.ts
- git diff --check