### PR TITLE
Carry prepared coordinate fields in native append plans

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -285,8 +285,25 @@ type EntryLeaderPlan<R extends "u32" | "u64"> = {
 	assignedToRangeBoundary?: boolean;
 };
 
+type SharedLogCoordinateNativeFields<R extends "u32" | "u64"> = {
+	hash: string;
+	hashNumber: NumberFromType<R>;
+	gid: string;
+	coordinates: NumberFromType<R>[];
+	wallTime: bigint;
+	assignedToRangeBoundary: boolean;
+	metaBytes: Uint8Array;
+};
+
+type PreparedCoordinatePersistence<R extends "u32" | "u64"> = {
+	coordinateEntry: EntryReplicated<R>;
+	assignedToRangeBoundary: boolean;
+	fields: SharedLogCoordinateNativeFields<R>;
+};
+
 type NativeAppendEntryPlan<R extends "u32" | "u64"> = EntryLeaderPlan<R> & {
 	hashNumber: NumberFromType<R>;
+	preparedCoordinate: PreparedCoordinatePersistence<R>;
 	delivery?: AppendDeliveryPlan;
 };
 
@@ -490,30 +507,14 @@ type PutAndDeleteIndex<T extends Record<string, any>> = Index<T> & {
 	delIds?: (deleteIds: Array<IdKey | Ideable>) => Promise<unknown> | unknown;
 	putSharedLogCoordinateAndDeleteIds?: (
 		value: T,
-		fields: {
-			hash: string;
-			hashNumber: NumberFromType<any>;
-			gid: string;
-			coordinates: NumberFromType<any>[];
-			wallTime: bigint;
-			assignedToRangeBoundary: boolean;
-			metaBytes: Uint8Array;
-		},
+		fields: SharedLogCoordinateNativeFields<any>,
 		deleteIds?: Array<IdKey | Ideable>,
 		id?: IdKey,
 	) => Promise<unknown> | unknown;
 	putSharedLogCoordinatesAndDeleteIdsBatch?: (
 		values: Array<{
 			value: T;
-			fields: {
-				hash: string;
-				hashNumber: NumberFromType<any>;
-				gid: string;
-				coordinates: NumberFromType<any>[];
-				wallTime: bigint;
-				assignedToRangeBoundary: boolean;
-				metaBytes: Uint8Array;
-			};
+			fields: SharedLogCoordinateNativeFields<any>;
 			deleteIds?: Array<IdKey | Ideable>;
 			id?: IdKey;
 		}>,
@@ -4372,6 +4373,7 @@ export class SharedLog<
 					assignedToRangeBoundary: plan.assignedToRangeBoundary,
 					commitNative: false,
 					hashNumber: plan.hashNumber,
+					prepared: plan.preparedCoordinate,
 				};
 			}),
 		);
@@ -4466,12 +4468,25 @@ export class SharedLog<
 			},
 			this.createNativeLeaderOptions(context),
 		);
+		const coordinates = plan.coordinates as NumberFromType<R>[];
+		const preparedCoordinate = this.createCoordinatePersistenceEntry({
+			leaders: plan.leaders,
+			coordinates,
+			replicas: coordinates.length,
+			entry,
+			assignedToRangeBoundary: plan.assignedToRangeBoundary,
+			hashNumber,
+		});
+		if (!preparedCoordinate) {
+			return undefined;
+		}
 		return {
-			coordinates: plan.coordinates as NumberFromType<R>[],
+			coordinates,
 			leaders: plan.leaders,
 			isLeader: plan.isLeader,
 			assignedToRangeBoundary: plan.assignedToRangeBoundary,
 			hashNumber,
+			preparedCoordinate,
 			delivery: plan.delivery,
 		};
 	}
@@ -4497,12 +4512,25 @@ export class SharedLog<
 			},
 			this.createNativeLeaderOptions(context),
 		);
+		const coordinates = plan.coordinates as NumberFromType<R>[];
+		const preparedCoordinate = this.createCoordinatePersistenceEntry({
+			leaders: plan.leaders,
+			coordinates,
+			replicas: coordinates.length,
+			entry,
+			assignedToRangeBoundary: plan.assignedToRangeBoundary,
+			hashNumber,
+		});
+		if (!preparedCoordinate) {
+			return undefined;
+		}
 		return {
-			coordinates: plan.coordinates as NumberFromType<R>[],
+			coordinates,
 			leaders: plan.leaders,
 			isLeader: plan.isLeader,
 			assignedToRangeBoundary: plan.assignedToRangeBoundary,
 			hashNumber,
+			preparedCoordinate,
 		};
 	}
 
@@ -4540,13 +4568,32 @@ export class SharedLog<
 			},
 			this.createNativeLeaderOptions(context),
 		);
-		return plans.map((plan, index) => ({
-			coordinates: plan.coordinates as NumberFromType<R>[],
-			leaders: plan.leaders,
-			isLeader: plan.isLeader,
-			assignedToRangeBoundary: plan.assignedToRangeBoundary,
-			hashNumber: entriesWithHashNumbers[index]!.hashNumber,
-		}));
+		const out: NativeAppendEntryPlan<R>[] = [];
+		for (let index = 0; index < plans.length; index++) {
+			const plan = plans[index]!;
+			const { entry, hashNumber } = entriesWithHashNumbers[index]!;
+			const coordinates = plan.coordinates as NumberFromType<R>[];
+			const preparedCoordinate = this.createCoordinatePersistenceEntry({
+				leaders: plan.leaders,
+				coordinates,
+				replicas: coordinates.length,
+				entry,
+				assignedToRangeBoundary: plan.assignedToRangeBoundary,
+				hashNumber,
+			});
+			if (!preparedCoordinate) {
+				return undefined;
+			}
+			out.push({
+				coordinates,
+				leaders: plan.leaders,
+				isLeader: plan.isLeader,
+				assignedToRangeBoundary: plan.assignedToRangeBoundary,
+				hashNumber,
+				preparedCoordinate,
+			});
+		}
+		return out;
 	}
 
 	private async planNativeAppendEntries(
@@ -4595,14 +4642,33 @@ export class SharedLog<
 			},
 			this.createNativeLeaderOptions(context),
 		);
-		return plans.map((plan, index) => ({
-			coordinates: plan.coordinates as NumberFromType<R>[],
-			leaders: plan.leaders,
-			isLeader: plan.isLeader,
-			assignedToRangeBoundary: plan.assignedToRangeBoundary,
-			hashNumber: entriesWithHashNumbers[index]!.hashNumber,
-			delivery: plan.delivery,
-		}));
+		const out: NativeAppendEntryPlan<R>[] = [];
+		for (let index = 0; index < plans.length; index++) {
+			const plan = plans[index]!;
+			const { entry, hashNumber } = entriesWithHashNumbers[index]!;
+			const coordinates = plan.coordinates as NumberFromType<R>[];
+			const preparedCoordinate = this.createCoordinatePersistenceEntry({
+				leaders: plan.leaders,
+				coordinates,
+				replicas: coordinates.length,
+				entry,
+				assignedToRangeBoundary: plan.assignedToRangeBoundary,
+				hashNumber,
+			});
+			if (!preparedCoordinate) {
+				return undefined;
+			}
+			out.push({
+				coordinates,
+				leaders: plan.leaders,
+				isLeader: plan.isLeader,
+				assignedToRangeBoundary: plan.assignedToRangeBoundary,
+				hashNumber,
+				preparedCoordinate,
+				delivery: plan.delivery,
+			});
+		}
+		return out;
 	}
 
 	private async processLocalAppend(
@@ -4668,6 +4734,7 @@ export class SharedLog<
 				commitNative: false,
 				deleteHashes: properties.extraCoordinateDeleteHashes,
 				hashNumber: nativeAppendPlan.hashNumber,
+				prepared: nativeAppendPlan.preparedCoordinate,
 			});
 		} else {
 			({ coordinates, leaders, isLeader } = await this.planEntryLeaders(
@@ -7625,7 +7692,7 @@ export class SharedLog<
 		prev?: EntryReplicated<R>;
 		assignedToRangeBoundary?: boolean;
 		hashNumber?: NumberFromType<R>;
-	}): { coordinateEntry: EntryReplicated<R>; assignedToRangeBoundary: boolean } | false {
+	}): PreparedCoordinatePersistence<R> | false {
 		const assignedToRangeBoundary =
 			properties.assignedToRangeBoundary ??
 			shouldAssignToRangeBoundary(properties.leaders, properties.replicas);
@@ -7646,7 +7713,19 @@ export class SharedLog<
 			hash: properties.entry.hash,
 			hashNumber: properties.hashNumber ?? this.getEntryHashNumber(properties.entry),
 		});
-		return { coordinateEntry, assignedToRangeBoundary };
+		return {
+			coordinateEntry,
+			assignedToRangeBoundary,
+			fields: {
+				hash: coordinateEntry.hash,
+				hashNumber: coordinateEntry.hashNumber,
+				gid: coordinateEntry.gid,
+				coordinates: coordinateEntry.coordinates,
+				wallTime: coordinateEntry.wallTime,
+				assignedToRangeBoundary: coordinateEntry.assignedToRangeBoundary,
+				metaBytes: coordinateEntry.getMetaBytes(),
+			},
+		};
 	}
 
 	private async persistCoordinate(properties: {
@@ -7666,12 +7745,14 @@ export class SharedLog<
 		commitNative?: boolean;
 		deleteHashes?: string[];
 		hashNumber?: NumberFromType<R>;
+		prepared?: PreparedCoordinatePersistence<R>;
 	}) {
-		const prepared = this.createCoordinatePersistenceEntry(properties);
+		const prepared =
+			properties.prepared ?? this.createCoordinatePersistenceEntry(properties);
 		if (!prepared) {
 			return false;
 		}
-		const { coordinateEntry, assignedToRangeBoundary } = prepared;
+		const { coordinateEntry, assignedToRangeBoundary, fields } = prepared;
 		const nextHashes = properties.entry.meta.next;
 		const deleteHashes =
 			properties.deleteHashes && properties.deleteHashes.length > 0
@@ -7684,15 +7765,7 @@ export class SharedLog<
 		if (coordinateIndex.putSharedLogCoordinateAndDeleteIds) {
 			await coordinateIndex.putSharedLogCoordinateAndDeleteIds(
 				coordinateEntry,
-				{
-					hash: coordinateEntry.hash,
-					hashNumber: coordinateEntry.hashNumber,
-					gid: coordinateEntry.gid,
-					coordinates: coordinateEntry.coordinates,
-					wallTime: coordinateEntry.wallTime,
-					assignedToRangeBoundary: coordinateEntry.assignedToRangeBoundary,
-					metaBytes: coordinateEntry.getMetaBytes(),
-				},
+				fields,
 				deleteHashes,
 			);
 		} else if (deleteHashes.length > 0 && coordinateIndex.putAndDeleteIds) {
@@ -7766,6 +7839,7 @@ export class SharedLog<
 			assignedToRangeBoundary?: boolean;
 			commitNative?: boolean;
 			hashNumber?: NumberFromType<R>;
+			prepared?: PreparedCoordinatePersistence<R>;
 		}>,
 	): Promise<boolean[]> {
 		if (items.length === 0) {
@@ -7774,17 +7848,14 @@ export class SharedLog<
 
 		const prepared = items.map((item) => ({
 			item,
-			prepared: this.createCoordinatePersistenceEntry(item),
+			prepared: item.prepared ?? this.createCoordinatePersistenceEntry(item),
 		}));
 		const changed = prepared.filter(
 			(
 				entry,
 			): entry is {
 				item: (typeof items)[number];
-				prepared: {
-					coordinateEntry: EntryReplicated<R>;
-					assignedToRangeBoundary: boolean;
-				};
+				prepared: PreparedCoordinatePersistence<R>;
 			} => entry.prepared !== false,
 		);
 		if (changed.length === 0) {
@@ -7802,16 +7873,7 @@ export class SharedLog<
 			await coordinateIndex.putSharedLogCoordinatesAndDeleteIdsBatch(
 				changed.map(({ item, prepared }) => ({
 					value: prepared.coordinateEntry,
-					fields: {
-						hash: prepared.coordinateEntry.hash,
-						hashNumber: prepared.coordinateEntry.hashNumber,
-						gid: prepared.coordinateEntry.gid,
-						coordinates: prepared.coordinateEntry.coordinates,
-						wallTime: prepared.coordinateEntry.wallTime,
-						assignedToRangeBoundary:
-							prepared.coordinateEntry.assignedToRangeBoundary,
-						metaBytes: prepared.coordinateEntry.getMetaBytes(),
-					},
+					fields: prepared.fields,
 					deleteIds: item.entry.meta.next,
 				})),
 			);

--- a/packages/programs/data/shared-log/test/append.spec.ts
+++ b/packages/programs/data/shared-log/test/append.spec.ts
@@ -185,6 +185,55 @@ describe("append", () => {
 		}
 	});
 
+	it("persists native append coordinate fields from the prepared plan", async () => {
+		session = await TestSession.disconnected(1, {
+			indexer: (directory) => createRustIndexer(directory),
+		});
+		const store = await session.peers[0].open(new EventStore<string, any>(), {
+			args: {
+				replicate: { factor: 1 },
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const coordinateIndex = store.log.entryCoordinatesIndex as any;
+		const putDeleteSpy = sinon.spy(
+			coordinateIndex,
+			"putSharedLogCoordinateAndDeleteIds",
+		);
+		const originalCreate = (store.log as any).createCoordinatePersistenceEntry;
+		const sentinelMetaBytes = new Uint8Array([7, 8, 9]);
+		const createStub = sinon
+			.stub(store.log as any, "createCoordinatePersistenceEntry")
+			.callsFake(function (this: unknown, properties: unknown) {
+				const prepared = originalCreate.call(this, properties);
+				return prepared
+					? {
+							...prepared,
+							fields: {
+								...prepared.fields,
+								metaBytes: sentinelMetaBytes,
+							},
+						}
+					: prepared;
+			});
+		try {
+			await store.log.appendLocallyPrepared(
+				{ op: "ADD", value: "a" },
+				{
+					replicate: false,
+					target: "none",
+				},
+			);
+
+			expect(createStub.callCount).equal(1);
+			expect(putDeleteSpy.callCount).equal(1);
+			expect(putDeleteSpy.firstCall.args[1].metaBytes).equal(sentinelMetaBytes);
+		} finally {
+			createStub.restore();
+			putDeleteSpy.restore();
+		}
+	});
+
 	it("coalesces prepared append trim coordinate deletes into the coordinate put", async () => {
 		session = await TestSession.disconnected(1, {
 			indexer: (directory) => createRustIndexer(directory),


### PR DESCRIPTION
## Summary
- stack on #909 and widen `NativeAppendEntryPlan` to carry a prepared coordinate persistence payload
- prepare the `EntryReplicated` row and native coordinate field object immediately after native append planning
- let `persistCoordinate` / `persistCoordinatesBatch` consume the prepared payload instead of reconstructing coordinate fields later
- add focused coverage proving persistence uses the prepared native field payload from the append plan

## Why
This is another step toward a wider native append/coordinate transaction boundary. The shared-log planner now hands the persistence stage a complete coordinate write payload, so the JS layer has less scattered reconstruction work and a clearer place for future Rust-returned coordinate fields.

## Bench signal
Quick local 500-op document-put profile after the change:
- rust-peerbit-nonunique: 2872 ops/sec, total 174.10 ms
- rust-peerbit-transient-index-nonunique: 3999 ops/sec, total 125.04 ms

Product-level numbers remain noisy; the structural win is that native-planned appends carry the coordinate persistence payload through to the write stage.

## Validation
- pnpm --filter @peerbit/shared-log run build
- pnpm --filter @peerbit/document run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "persists native append coordinate fields|reuses native append plan hash number|coalesces prepared append trim coordinate deletes"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "appendMany plans target-none local assignments|appendMany plans local append assignments|appendMany coalesces a local chain"
- pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/index.ts packages/programs/data/shared-log/test/append.spec.ts
- git diff --check