### PR TITLE
Return coordinate plan fields from native append planner

### DIFF
--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -69,9 +69,19 @@ export type AppendDeliveryPlan = {
 	authoritativeRecipients: string[];
 };
 
+export type NativeAppendCoordinatePlan = {
+	hash: string;
+	hashNumber: number | bigint;
+	gid: string;
+	coordinates: Array<number | bigint>;
+	assignedToRangeBoundary: boolean;
+	requestedReplicas: number;
+};
+
 export type AppendEntryPlan = EntryAssignmentPlan & {
 	isLeader: boolean;
 	delivery: AppendDeliveryPlan;
+	coordinate: NativeAppendCoordinatePlan;
 };
 
 export type AppendEntryBatchInput = {
@@ -349,7 +359,7 @@ type NativeSharedLogStateHandle = {
 		includeSelf: boolean,
 		fullReplicaFallback: boolean,
 		includeStrictFullReplica: boolean,
-	) => [unknown[], unknown[], boolean, boolean];
+	) => [unknown[], unknown[], boolean, boolean, unknown[]];
 	plan_append_leaders_for_delivery: (
 		leaders: unknown[],
 		fullReplicaCandidates: string[],
@@ -393,6 +403,7 @@ type NativeSharedLogStateHandle = {
 		boolean,
 		boolean,
 		[boolean, boolean, boolean, string[], string[], string[], string[], string[]],
+		unknown[],
 	];
 	plan_append_for_gids_batch: (
 		entryHashes: string[],
@@ -421,6 +432,7 @@ type NativeSharedLogStateHandle = {
 		boolean,
 		boolean,
 		[boolean, boolean, boolean, string[], string[], string[], string[], string[]],
+		unknown[],
 	][];
 	plan_repair_dispatch_for_entries: (
 		entryHashes: string[],
@@ -527,6 +539,28 @@ const rowsToNumbers = (
 		const value = row as string;
 		return resolution === "u64" ? BigInt(value) : Number(value);
 	});
+
+const appendCoordinatePlanFromRow = (
+	resolution: RangeResolution,
+	row: unknown[],
+): NativeAppendCoordinatePlan => {
+	const [
+		hash,
+		hashNumber,
+		gid,
+		coordinateRows,
+		assignedToRangeBoundary,
+		requestedReplicas,
+	] = row as [string, unknown, string, unknown[], boolean, number];
+	return {
+		hash,
+		hashNumber: rowsToNumbers(resolution, [hashNumber])[0]!,
+		gid,
+		coordinates: rowsToNumbers(resolution, coordinateRows),
+		assignedToRangeBoundary,
+		requestedReplicas,
+	};
+};
 
 const findLeaderArguments = (options?: FindLeaderOptions): [
 	number,
@@ -1093,24 +1127,36 @@ export class SharedLogNativeState {
 			selfHash: string;
 		},
 		options?: FindLeaderOptions,
-	): EntryAssignmentPlan & { isLeader: boolean } {
-		const [coordinateRows, leaderRows, isLeader, assignedToRangeBoundary] =
-			this.native.plan_local_append_for_gid(
-				input.entryHash,
-				input.gid,
-				asIntegerString(input.hashNumber ?? 0),
-				input.nextHashes ? [...input.nextHashes] : [],
-				input.replicas,
-				...findLeaderArguments({
-					...options,
-					selfHash: input.selfHash,
-				}),
-			);
+	): EntryAssignmentPlan & {
+		isLeader: boolean;
+		coordinate: NativeAppendCoordinatePlan;
+	} {
+		const [
+			coordinateRows,
+			leaderRows,
+			isLeader,
+			assignedToRangeBoundary,
+			coordinatePlanRow,
+		] = this.native.plan_local_append_for_gid(
+			input.entryHash,
+			input.gid,
+			asIntegerString(input.hashNumber ?? 0),
+			input.nextHashes ? [...input.nextHashes] : [],
+			input.replicas,
+			...findLeaderArguments({
+				...options,
+				selfHash: input.selfHash,
+			}),
+		);
 		return {
 			coordinates: rowsToNumbers(this.resolution, coordinateRows),
 			leaders: rowsToSamples(leaderRows),
 			isLeader,
 			assignedToRangeBoundary,
+			coordinate: appendCoordinatePlanFromRow(
+				this.resolution,
+				coordinatePlanRow,
+			),
 		};
 	}
 
@@ -1171,31 +1217,41 @@ export class SharedLogNativeState {
 		},
 		options?: FindLeaderOptions,
 	): AppendEntryPlan {
-		const [coordinateRows, leaderRows, isLeader, assignedToRangeBoundary, delivery] =
-			this.native.plan_append_for_gid(
-				input.entryHash,
-				input.gid,
-				asIntegerString(input.hashNumber ?? 0),
-				input.nextHashes ? [...input.nextHashes] : [],
-				input.replicas,
-				input.fullReplicaCandidates ? [...input.fullReplicaCandidates] : [],
-				input.fallbackRecipients ? [...input.fallbackRecipients] : [],
-				input.selfHash,
-				input.deliveryEnabled,
-				input.reliabilityAck,
-				input.minAcks,
-				input.requireRecipients,
-				...findLeaderArguments({
-					...options,
-					selfHash: input.selfHash,
-				}),
-			);
+		const [
+			coordinateRows,
+			leaderRows,
+			isLeader,
+			assignedToRangeBoundary,
+			delivery,
+			coordinatePlanRow,
+		] = this.native.plan_append_for_gid(
+			input.entryHash,
+			input.gid,
+			asIntegerString(input.hashNumber ?? 0),
+			input.nextHashes ? [...input.nextHashes] : [],
+			input.replicas,
+			input.fullReplicaCandidates ? [...input.fullReplicaCandidates] : [],
+			input.fallbackRecipients ? [...input.fallbackRecipients] : [],
+			input.selfHash,
+			input.deliveryEnabled,
+			input.reliabilityAck,
+			input.minAcks,
+			input.requireRecipients,
+			...findLeaderArguments({
+				...options,
+				selfHash: input.selfHash,
+			}),
+		);
 		return {
 			coordinates: rowsToNumbers(this.resolution, coordinateRows),
 			leaders: rowsToSamples(leaderRows),
 			isLeader,
 			assignedToRangeBoundary,
 			delivery: appendDeliveryPlanFromRow(delivery),
+			coordinate: appendCoordinatePlanFromRow(
+				this.resolution,
+				coordinatePlanRow,
+			),
 		};
 	}
 
@@ -1238,12 +1294,17 @@ export class SharedLogNativeState {
 				isLeader,
 				assignedToRangeBoundary,
 				delivery,
+				coordinatePlanRow,
 			]) => ({
 				coordinates: rowsToNumbers(this.resolution, coordinateRows),
 				leaders: rowsToSamples(leaderRows),
 				isLeader,
 				assignedToRangeBoundary,
 				delivery: appendDeliveryPlanFromRow(delivery),
+				coordinate: appendCoordinatePlanFromRow(
+					this.resolution,
+					coordinatePlanRow,
+				),
 			}),
 		);
 	}

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -851,10 +851,14 @@ struct AppendDeliveryPlan {
 }
 
 struct AppendEntryPlan {
+    hash: String,
+    hash_number: u64,
+    gid: String,
     coordinates: Vec<u64>,
     leaders: Vec<LeaderSample>,
     is_leader: bool,
     assigned_to_range_boundary: bool,
+    requested_replicas: usize,
     delivery: AppendDeliveryPlan,
 }
 
@@ -986,13 +990,41 @@ fn append_delivery_plan_to_row(plan: AppendDeliveryPlan) -> Array {
     out
 }
 
+fn append_coordinate_plan_to_row(
+    hash: &str,
+    hash_number: u64,
+    gid: &str,
+    coordinates: Vec<u64>,
+    assigned_to_range_boundary: bool,
+    requested_replicas: usize,
+    resolution: Resolution,
+) -> Array {
+    let out = Array::new();
+    out.push(&JsValue::from_str(hash));
+    out.push(&number_to_row(hash_number, resolution));
+    out.push(&JsValue::from_str(gid));
+    out.push(&numbers_to_rows(coordinates, resolution));
+    out.push(&JsValue::from_bool(assigned_to_range_boundary));
+    out.push(&JsValue::from_f64(requested_replicas as f64));
+    out
+}
+
 fn append_entry_plan_to_row(plan: AppendEntryPlan, resolution: Resolution) -> Array {
     let out = Array::new();
-    out.push(&numbers_to_rows(plan.coordinates, resolution));
+    out.push(&numbers_to_rows(plan.coordinates.clone(), resolution));
     out.push(&samples_to_rows(plan.leaders));
     out.push(&JsValue::from_bool(plan.is_leader));
     out.push(&JsValue::from_bool(plan.assigned_to_range_boundary));
     out.push(&append_delivery_plan_to_row(plan.delivery));
+    out.push(&append_coordinate_plan_to_row(
+        &plan.hash,
+        plan.hash_number,
+        &plan.gid,
+        plan.coordinates,
+        plan.assigned_to_range_boundary,
+        plan.requested_replicas,
+        resolution,
+    ));
     out
 }
 
@@ -2037,11 +2069,20 @@ impl NativeSharedLogState {
         );
         let is_leader = leaders.iter().any(|leader| leader.hash == self_hash);
         let assigned_to_range_boundary = should_assign_to_range_boundary(&leaders, replicas);
+        let coordinate_plan_row = append_coordinate_plan_to_row(
+            &entry_hash,
+            entry_hash_number,
+            &gid,
+            coordinates.clone(),
+            assigned_to_range_boundary,
+            replicas,
+            self.inner.range_planner.resolution,
+        );
 
         self.inner.put_entry_coordinate_state(
-            entry_hash,
+            entry_hash.clone(),
             EntryCoordinateState {
-                gid,
+                gid: gid.clone(),
                 hash_number: entry_hash_number,
                 coordinates: coordinates.clone(),
                 assigned_to_range_boundary,
@@ -2060,6 +2101,7 @@ impl NativeSharedLogState {
         out.push(&samples_to_rows(leaders));
         out.push(&JsValue::from_bool(is_leader));
         out.push(&JsValue::from_bool(assigned_to_range_boundary));
+        out.push(&coordinate_plan_row);
         Ok(out)
     }
 
@@ -2147,9 +2189,9 @@ impl NativeSharedLogState {
         let assigned_to_range_boundary = should_assign_to_range_boundary(&leaders, replicas);
 
         self.inner.put_entry_coordinate_state(
-            entry_hash,
+            entry_hash.clone(),
             EntryCoordinateState {
-                gid,
+                gid: gid.clone(),
                 hash_number: entry_hash_number,
                 coordinates: coordinates.clone(),
                 assigned_to_range_boundary,
@@ -2174,10 +2216,14 @@ impl NativeSharedLogState {
         );
         Ok(append_entry_plan_to_row(
             AppendEntryPlan {
+                hash: entry_hash,
+                hash_number: entry_hash_number,
+                gid,
                 coordinates,
                 leaders: delivery_leaders,
                 is_leader,
                 assigned_to_range_boundary,
+                requested_replicas: replicas,
                 delivery,
             },
             self.inner.range_planner.resolution,
@@ -2260,9 +2306,9 @@ impl NativeSharedLogState {
             let assigned_to_range_boundary = should_assign_to_range_boundary(&leaders, replicas);
 
             self.inner.put_entry_coordinate_state(
-                entry_hash,
+                entry_hash.clone(),
                 EntryCoordinateState {
-                    gid,
+                    gid: gid.clone(),
                     hash_number: entry_hash_number,
                     coordinates: coordinates.clone(),
                     assigned_to_range_boundary,
@@ -2288,10 +2334,14 @@ impl NativeSharedLogState {
             );
             out.push(&append_entry_plan_to_row(
                 AppendEntryPlan {
+                    hash: entry_hash,
+                    hash_number: entry_hash_number,
+                    gid,
                     coordinates,
                     leaders: delivery_leaders,
                     is_leader,
                     assigned_to_range_boundary,
+                    requested_replicas: replicas,
                     delivery,
                 },
                 self.inner.range_planner.resolution,
@@ -2722,13 +2772,17 @@ fn leader_samples_from_rows(rows: Array) -> Result<Vec<LeaderSample>, JsValue> {
     Ok(out)
 }
 
+fn number_to_row(value: u64, resolution: Resolution) -> JsValue {
+    match resolution {
+        Resolution::U32 => JsValue::from_f64(value as f64),
+        Resolution::U64 => JsValue::from_str(&value.to_string()),
+    }
+}
+
 fn numbers_to_rows(values: Vec<u64>, resolution: Resolution) -> Array {
     let out = Array::new();
     for value in values {
-        match resolution {
-            Resolution::U32 => out.push(&JsValue::from_f64(value as f64)),
-            Resolution::U64 => out.push(&JsValue::from_str(&value.to_string())),
-        };
+        out.push(&number_to_row(value, resolution));
     }
     out
 }

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -592,6 +592,14 @@ describe("native shared-log range planner", () => {
 			isLeader: assignment.leaders.has("peer-self"),
 			assignedToRangeBoundary: assignment.assignedToRangeBoundary,
 			delivery,
+			coordinate: {
+				hash: "new-head",
+				hashNumber: 0,
+				gid: "entry-gid",
+				coordinates: assignment.coordinates,
+				assignedToRangeBoundary: assignment.assignedToRangeBoundary,
+				requestedReplicas: 2,
+			},
 		});
 		expect(state.getEntryCoordinates("new-head")).to.deep.equal(
 			assignment.coordinates,

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -26,6 +26,7 @@ import {
 } from "@peerbit/indexer-interface";
 import {
 	type AppendDeliveryPlan,
+	type NativeAppendCoordinatePlan,
 	type NativeReplicationRange,
 	type SharedLogNativeState,
 	type SharedLogRangePlanner,
@@ -4468,14 +4469,11 @@ export class SharedLog<
 			},
 			this.createNativeLeaderOptions(context),
 		);
-		const coordinates = plan.coordinates as NumberFromType<R>[];
-		const preparedCoordinate = this.createCoordinatePersistenceEntry({
-			leaders: plan.leaders,
-			coordinates,
-			replicas: coordinates.length,
+		const coordinates = plan.coordinate.coordinates as NumberFromType<R>[];
+		const hashNumberFromPlan = plan.coordinate.hashNumber as NumberFromType<R>;
+		const preparedCoordinate = this.createCoordinatePersistenceEntryFromNativePlan({
 			entry,
-			assignedToRangeBoundary: plan.assignedToRangeBoundary,
-			hashNumber,
+			plan: plan.coordinate,
 		});
 		if (!preparedCoordinate) {
 			return undefined;
@@ -4485,7 +4483,7 @@ export class SharedLog<
 			leaders: plan.leaders,
 			isLeader: plan.isLeader,
 			assignedToRangeBoundary: plan.assignedToRangeBoundary,
-			hashNumber,
+			hashNumber: hashNumberFromPlan,
 			preparedCoordinate,
 			delivery: plan.delivery,
 		};
@@ -4512,14 +4510,11 @@ export class SharedLog<
 			},
 			this.createNativeLeaderOptions(context),
 		);
-		const coordinates = plan.coordinates as NumberFromType<R>[];
-		const preparedCoordinate = this.createCoordinatePersistenceEntry({
-			leaders: plan.leaders,
-			coordinates,
-			replicas: coordinates.length,
+		const coordinates = plan.coordinate.coordinates as NumberFromType<R>[];
+		const hashNumberFromPlan = plan.coordinate.hashNumber as NumberFromType<R>;
+		const preparedCoordinate = this.createCoordinatePersistenceEntryFromNativePlan({
 			entry,
-			assignedToRangeBoundary: plan.assignedToRangeBoundary,
-			hashNumber,
+			plan: plan.coordinate,
 		});
 		if (!preparedCoordinate) {
 			return undefined;
@@ -4529,7 +4524,7 @@ export class SharedLog<
 			leaders: plan.leaders,
 			isLeader: plan.isLeader,
 			assignedToRangeBoundary: plan.assignedToRangeBoundary,
-			hashNumber,
+			hashNumber: hashNumberFromPlan,
 			preparedCoordinate,
 		};
 	}
@@ -4571,16 +4566,14 @@ export class SharedLog<
 		const out: NativeAppendEntryPlan<R>[] = [];
 		for (let index = 0; index < plans.length; index++) {
 			const plan = plans[index]!;
-			const { entry, hashNumber } = entriesWithHashNumbers[index]!;
-			const coordinates = plan.coordinates as NumberFromType<R>[];
-			const preparedCoordinate = this.createCoordinatePersistenceEntry({
-				leaders: plan.leaders,
-				coordinates,
-				replicas: coordinates.length,
-				entry,
-				assignedToRangeBoundary: plan.assignedToRangeBoundary,
-				hashNumber,
-			});
+			const { entry } = entriesWithHashNumbers[index]!;
+			const coordinates = plan.coordinate.coordinates as NumberFromType<R>[];
+			const hashNumberFromPlan = plan.coordinate.hashNumber as NumberFromType<R>;
+			const preparedCoordinate =
+				this.createCoordinatePersistenceEntryFromNativePlan({
+					entry,
+					plan: plan.coordinate,
+				});
 			if (!preparedCoordinate) {
 				return undefined;
 			}
@@ -4589,7 +4582,7 @@ export class SharedLog<
 				leaders: plan.leaders,
 				isLeader: plan.isLeader,
 				assignedToRangeBoundary: plan.assignedToRangeBoundary,
-				hashNumber,
+				hashNumber: hashNumberFromPlan,
 				preparedCoordinate,
 			});
 		}
@@ -4645,16 +4638,14 @@ export class SharedLog<
 		const out: NativeAppendEntryPlan<R>[] = [];
 		for (let index = 0; index < plans.length; index++) {
 			const plan = plans[index]!;
-			const { entry, hashNumber } = entriesWithHashNumbers[index]!;
-			const coordinates = plan.coordinates as NumberFromType<R>[];
-			const preparedCoordinate = this.createCoordinatePersistenceEntry({
-				leaders: plan.leaders,
-				coordinates,
-				replicas: coordinates.length,
-				entry,
-				assignedToRangeBoundary: plan.assignedToRangeBoundary,
-				hashNumber,
-			});
+			const { entry } = entriesWithHashNumbers[index]!;
+			const coordinates = plan.coordinate.coordinates as NumberFromType<R>[];
+			const hashNumberFromPlan = plan.coordinate.hashNumber as NumberFromType<R>;
+			const preparedCoordinate =
+				this.createCoordinatePersistenceEntryFromNativePlan({
+					entry,
+					plan: plan.coordinate,
+				});
 			if (!preparedCoordinate) {
 				return undefined;
 			}
@@ -4663,7 +4654,7 @@ export class SharedLog<
 				leaders: plan.leaders,
 				isLeader: plan.isLeader,
 				assignedToRangeBoundary: plan.assignedToRangeBoundary,
-				hashNumber,
+				hashNumber: hashNumberFromPlan,
 				preparedCoordinate,
 				delivery: plan.delivery,
 			});
@@ -7723,6 +7714,52 @@ export class SharedLog<
 				coordinates: coordinateEntry.coordinates,
 				wallTime: coordinateEntry.wallTime,
 				assignedToRangeBoundary: coordinateEntry.assignedToRangeBoundary,
+				metaBytes: coordinateEntry.getMetaBytes(),
+			},
+		};
+	}
+
+	private createCoordinatePersistenceEntryFromNativePlan(properties: {
+		entry: ShallowOrFullEntry<any> | EntryReplicated<R>;
+		plan: NativeAppendCoordinatePlan;
+		prev?: EntryReplicated<R>;
+	}): PreparedCoordinatePersistence<R> | false {
+		if (
+			properties.plan.hash !== properties.entry.hash ||
+			properties.plan.gid !== properties.entry.meta.gid
+		) {
+			return false;
+		}
+
+		const assignedToRangeBoundary = properties.plan.assignedToRangeBoundary;
+		if (
+			properties.prev &&
+			properties.prev.assignedToRangeBoundary === assignedToRangeBoundary
+		) {
+			return false;
+		}
+
+		const coordinates = properties.plan.coordinates as NumberFromType<R>[];
+		const hashNumber = properties.plan.hashNumber as NumberFromType<R>;
+		const metaBytes = (properties.entry as EntryWithMetaBytes).getMetaBytes?.();
+		const coordinateEntry = new this.indexableDomain.constructorEntry({
+			assignedToRangeBoundary,
+			coordinates,
+			meta: properties.entry.meta,
+			metaBytes,
+			hash: properties.plan.hash,
+			hashNumber,
+		});
+		return {
+			coordinateEntry,
+			assignedToRangeBoundary,
+			fields: {
+				hash: properties.plan.hash,
+				hashNumber,
+				gid: properties.plan.gid,
+				coordinates,
+				wallTime: coordinateEntry.wallTime,
+				assignedToRangeBoundary,
 				metaBytes: coordinateEntry.getMetaBytes(),
 			},
 		};

--- a/packages/programs/data/shared-log/test/append.spec.ts
+++ b/packages/programs/data/shared-log/test/append.spec.ts
@@ -200,24 +200,12 @@ describe("append", () => {
 			coordinateIndex,
 			"putSharedLogCoordinateAndDeleteIds",
 		);
-		const originalCreate = (store.log as any).createCoordinatePersistenceEntry;
-		const sentinelMetaBytes = new Uint8Array([7, 8, 9]);
-		const createStub = sinon
-			.stub(store.log as any, "createCoordinatePersistenceEntry")
-			.callsFake(function (this: unknown, properties: unknown) {
-				const prepared = originalCreate.call(this, properties);
-				return prepared
-					? {
-							...prepared,
-							fields: {
-								...prepared.fields,
-								metaBytes: sentinelMetaBytes,
-							},
-						}
-					: prepared;
-			});
+		const createSpy = sinon.spy(
+			store.log as any,
+			"createCoordinatePersistenceEntry",
+		);
 		try {
-			await store.log.appendLocallyPrepared(
+			const result = await store.log.appendLocallyPrepared(
 				{ op: "ADD", value: "a" },
 				{
 					replicate: false,
@@ -225,11 +213,24 @@ describe("append", () => {
 				},
 			);
 
-			expect(createStub.callCount).equal(1);
+			expect(createSpy.callCount).equal(0);
 			expect(putDeleteSpy.callCount).equal(1);
-			expect(putDeleteSpy.firstCall.args[1].metaBytes).equal(sentinelMetaBytes);
+			const fields = putDeleteSpy.firstCall.args[1];
+			expect(fields.hash).equal(result.entry.hash);
+			expect(fields.gid).equal(result.entry.meta.gid);
+			expect(fields.hashNumber).equal(
+				(store.log as any).getEntryHashNumber(result.entry),
+			);
+			expect(fields.coordinates).to.deep.equal(
+				(store.log as any)._nativeSharedLogState.getEntryCoordinates(
+					result.entry.hash,
+				),
+			);
+			expect(fields.metaBytes).to.deep.equal(
+				(result.entry as any).getMetaBytes(),
+			);
 		} finally {
-			createStub.restore();
+			createSpy.restore();
 			putDeleteSpy.restore();
 		}
 	});


### PR DESCRIPTION
## Summary
- extend @peerbit/shared-log-rust append planning to return a NativeAppendCoordinatePlan with hash/hashNumber/gid/coordinates/assigned/requested replica metadata
- feed that Rust-returned coordinate plan into shared-log prepared coordinate persistence
- keep TS responsible only for entry meta bytes/wall time that come from the log entry serialization layer

## Why
This moves the #910 prepared coordinate persistence payload one layer deeper into native output. Product-level document-put throughput is expected to be mostly neutral here, but it removes another TS reconstruction step and sets up the next wider native append transaction boundary.

## Benchmark
Local node document-put, 2026-05-11:

```bash
DOC_WARMUP=50 DOC_ITERATIONS=500 DOC_SCENARIOS=rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

- rust-peerbit-nonunique: 2814 ops/sec, total 177.71 ms, shared plan 17.71 ms, shared persist coordinate 16.03 ms
- rust-peerbit-transient-index-nonunique: 3631 ops/sec, total 137.70 ms, shared plan 13.02 ms, shared persist coordinate 13.07 ms

Signal is neutral/noisy versus #910; this is mainly a native boundary improvement.

## Test Plan
- pnpm --filter @peerbit/shared-log-rust run build
- pnpm --filter @peerbit/shared-log run build
- pnpm --filter @peerbit/document run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log/rust -- -t node --grep "plans append assignment and delivery in one native state call|plans append assignments and delivery in one native state batch"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "persists native append coordinate fields|reuses native append plan hash number|coalesces prepared append trim coordinate deletes"
- pnpm --filter @peerbit/shared-log-rust run lint
- pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/index.ts packages/programs/data/shared-log/test/append.spec.ts
- git diff --check