### PR TITLE
Carry native append commit facts into document puts

### DIFF
--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -160,6 +160,13 @@ type PlainPutCommitPlan<T, I extends Record<string, any>> = {
 		| undefined;
 };
 
+type LocalAppendCommitFacts = {
+	hash: string;
+	gid: string;
+	wallTime: bigint;
+	payloadSize: number;
+};
+
 type InferR<D> = D extends ReplicationDomain<any, any, infer I> ? I : "u32";
 
 export type SetupOptions<
@@ -951,12 +958,13 @@ export class Documents<
 				key: plan.key,
 				entry: appended.entry,
 				removed: appended.removed,
+				appendCommit: appended.appendCommit,
 				unique: plan.unique,
 				existing: plan.existing,
 			});
 		}
 		this.keepCache?.add(appended.entry.hash);
-		return appended;
+		return { entry: appended.entry, removed: appended.removed };
 	}
 
 	private nextFromIndexedContext(
@@ -995,6 +1003,7 @@ export class Documents<
 		key: indexerTypes.IdKey;
 		entry: Entry<Operation>;
 		removed: ShallowOrFullEntry<Operation>[];
+		appendCommit?: LocalAppendCommitFacts;
 		unique?: boolean;
 		existing?:
 			| indexerTypes.IndexedResult<IndexedContextOnly<I>>
@@ -1023,14 +1032,18 @@ export class Documents<
 		}
 
 		if (!modified.has(properties.key.primitive)) {
+			const appendCommit = properties.appendCommit;
 			const context = new Context({
 				created:
 					existing?.value.__context.created ||
+					appendCommit?.wallTime ||
 					properties.entry.meta.clock.timestamp.wallTime,
-				modified: properties.entry.meta.clock.timestamp.wallTime,
-				head: properties.entry.hash,
-				gid: properties.entry.meta.gid,
-				size: properties.entry.payload.byteLength,
+				modified:
+					appendCommit?.wallTime ||
+					properties.entry.meta.clock.timestamp.wallTime,
+				head: appendCommit?.hash || properties.entry.hash,
+				gid: appendCommit?.gid || properties.entry.meta.gid,
+				size: appendCommit?.payloadSize ?? properties.entry.payload.byteLength,
 			});
 			const { indexable } = await this._index.putWithContext(
 				properties.document,

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -254,6 +254,18 @@ describe("index", () => {
 						| undefined;
 					const backendContext = backendContextPutSpy.getCall(0)
 						.args[2] as Context;
+					const appendResult = await preparedAppendSpy.getCall(0).returnValue;
+					const appendCommit = appendResult.appendCommit;
+					expect(appendCommit.hash).equal(put.entry.hash);
+					expect(appendCommit.gid).equal(put.entry.meta.gid);
+					expect(appendCommit.wallTime).equal(
+						put.entry.meta.clock.timestamp.wallTime,
+					);
+					expect(appendCommit.payloadSize).equal(put.entry.payload.byteLength);
+					expect(backendContext.head).equal(appendCommit.hash);
+					expect(backendContext.gid).equal(appendCommit.gid);
+					expect(backendContext.modified).equal(appendCommit.wallTime);
+					expect(backendContext.size).equal(appendCommit.payloadSize);
 					expect(backendOptions?.encodedValue).equal(undefined);
 					expect(backendOptions?.encodedValueParts?.prefix).to.deep.equal(
 						encodedDocument,

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -302,6 +302,18 @@ type PreparedCoordinatePersistence<R extends "u32" | "u64"> = {
 	fields: SharedLogCoordinateNativeFields<R>;
 };
 
+type PreparedLocalAppendCommit<R extends "u32" | "u64"> = {
+	hash: string;
+	gid: string;
+	next: string[];
+	wallTime: bigint;
+	logical: number;
+	payloadSize: number;
+	metaBytes?: Uint8Array;
+	hashNumber?: NumberFromType<R>;
+	coordinateFields?: SharedLogCoordinateNativeFields<R>;
+};
+
 type NativeAppendEntryPlan<R extends "u32" | "u64"> = EntryLeaderPlan<R> & {
 	hashNumber: NumberFromType<R>;
 	preparedCoordinate: PreparedCoordinatePersistence<R>;
@@ -4077,6 +4089,7 @@ export class SharedLog<
 	): Promise<{
 		entry: Entry<T>;
 		removed: ShallowOrFullEntry<T>[];
+		appendCommit: PreparedLocalAppendCommit<R>;
 	}> {
 		if (options?.canAppend || options?.onChange) {
 			throw new Error(
@@ -4114,18 +4127,26 @@ export class SharedLog<
 			await this.onChange(result.change);
 		}
 		try {
-			await this.processLocalAppend(result.entry, result.removed, options, {
-				minReplicasValue,
-				nativeAppendPlan,
-				extraCoordinateDeleteHashes: deferredCoordinateDeleteHashes,
-			});
+			nativeAppendPlan =
+				(await this.processLocalAppend(result.entry, result.removed, options, {
+					minReplicasValue,
+					nativeAppendPlan,
+					extraCoordinateDeleteHashes: deferredCoordinateDeleteHashes,
+				})) ?? nativeAppendPlan;
 		} catch (error) {
 			if (deferredCoordinateDeleteHashes) {
 				await this.deleteCoordinatesForHashes(deferredCoordinateDeleteHashes);
 			}
 			throw error;
 		}
-		return { entry: result.entry, removed: result.removed };
+		return {
+			entry: result.entry,
+			removed: result.removed,
+			appendCommit: this.createPreparedLocalAppendCommit(
+				result.entry,
+				nativeAppendPlan,
+			),
+		};
 	}
 
 	private canCoalescePreparedAppendCoordinateDeletes(
@@ -4672,7 +4693,7 @@ export class SharedLog<
 			nativeAppendPlan?: NativeAppendEntryPlan<R>;
 			extraCoordinateDeleteHashes?: string[];
 		},
-	) {
+	): Promise<NativeAppendEntryPlan<R> | undefined> {
 		const deferHeadCoordinatePersistence =
 			properties.deferHeadCoordinatePersistence ??
 			(entry.meta.type !== EntryType.CUT &&
@@ -4777,6 +4798,24 @@ export class SharedLog<
 		if (!delayAdaptiveRebalance) {
 			this.rebalanceParticipationDebounced?.call();
 		}
+		return nativeAppendPlan;
+	}
+
+	private createPreparedLocalAppendCommit(
+		entry: Entry<T>,
+		nativeAppendPlan?: NativeAppendEntryPlan<R>,
+	): PreparedLocalAppendCommit<R> {
+		return {
+			hash: entry.hash,
+			gid: entry.meta.gid,
+			next: entry.meta.next,
+			wallTime: entry.meta.clock.timestamp.wallTime,
+			logical: entry.meta.clock.timestamp.logical,
+			payloadSize: entry.payload.byteLength,
+			metaBytes: (entry as EntryWithMetaBytes).getMetaBytes?.(),
+			hashNumber: nativeAppendPlan?.hashNumber,
+			coordinateFields: nativeAppendPlan?.preparedCoordinate.fields,
+		};
 	}
 
 	async open(options?: Args<T, D, R>): Promise<void> {

--- a/packages/programs/data/shared-log/test/append.spec.ts
+++ b/packages/programs/data/shared-log/test/append.spec.ts
@@ -229,6 +229,15 @@ describe("append", () => {
 			expect(fields.metaBytes).to.deep.equal(
 				(result.entry as any).getMetaBytes(),
 			);
+			expect(result.appendCommit.hash).equal(result.entry.hash);
+			expect(result.appendCommit.gid).equal(result.entry.meta.gid);
+			expect(result.appendCommit.wallTime).equal(
+				result.entry.meta.clock.timestamp.wallTime,
+			);
+			expect(result.appendCommit.payloadSize).equal(
+				result.entry.payload.byteLength,
+			);
+			expect(result.appendCommit.coordinateFields).to.deep.equal(fields);
 		} finally {
 			createSpy.restore();
 			putDeleteSpy.restore();


### PR DESCRIPTION
## Summary
- make SharedLog.appendLocallyPrepared return an internal appendCommit facts object with lower-log metadata and native coordinate fields when the native append planner was used
- have Documents.put consume appendCommit to construct document Context for the prepared plain put path
- keep Documents.put public return shape as { entry, removed }

## Why
This is the next boundary step after #912. It does not try to force the full native document transaction yet; it creates the transaction facts shape that a future native document append API can fill directly.

## Benchmark
Local node document-put, 2026-05-11:

```bash
DOC_WARMUP=50 DOC_ITERATIONS=500 DOC_SCENARIOS=rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

- rust-peerbit-nonunique: 2656 ops/sec, total 188.23 ms, shared plan 23.01 ms, shared persist coordinate 17.55 ms
- rust-peerbit-transient-index-nonunique: 3629 ops/sec, total 137.76 ms, shared plan 12.55 ms, shared persist coordinate 13.53 ms

Signal is neutral/noisy; this is mainly a native transaction boundary/facts-shape improvement.

## Test Plan
- pnpm --filter @peerbit/shared-log run build
- pnpm --filter @peerbit/document run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "persists native append coordinate fields|reuses native append plan hash number|coalesces prepared append trim coordinate deletes"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses the validated local append path for plain puts|uses the validated local append path for document updates"
- pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/index.ts packages/programs/data/shared-log/test/append.spec.ts packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/test/index.spec.ts
  - passes with one existing unrelated warning at document/test/index.spec.ts:4208
- git diff --check