### PR TITLE
Carry document commit facts through prepared puts

### DIFF
--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -61,6 +61,7 @@ import {
 	type WithIndexedContext,
 	coerceWithContext,
 	coerceWithIndexed,
+	encodeContextSuffix,
 } from "./search.js";
 
 const logger = loggerFn("peerbit:program:document");
@@ -165,6 +166,30 @@ type LocalAppendCommitFacts = {
 	gid: string;
 	wallTime: bigint;
 	payloadSize: number;
+};
+
+type ContextualEncodedValueParts = {
+	prefix: Uint8Array;
+	suffix: Uint8Array;
+};
+
+type DocumentAppendCommitFacts<T, I extends Record<string, any>> = {
+	document: T;
+	key: indexerTypes.IdKey;
+	operation: PutOperation;
+	encodedDocument: Uint8Array;
+	operationPayloadBytes: Uint8Array;
+	entry: Entry<Operation>;
+	removed: ShallowOrFullEntry<Operation>[];
+	append: LocalAppendCommitFacts;
+	context: Context;
+	contextBytes: Uint8Array;
+	contextualEncodedValueParts: ContextualEncodedValueParts;
+	unique?: boolean;
+	existing?:
+		| indexerTypes.IndexedResult<IndexedContextOnly<I>>
+		| null
+		| undefined;
 };
 
 type InferR<D> = D extends ReplicationDomain<any, any, infer I> ? I : "u32";
@@ -937,6 +962,10 @@ export class Documents<
 				payloadData: plan.payloadData,
 			},
 		);
+		const documentAppendCommit = this.createDocumentAppendCommitFacts(
+			plan,
+			appended,
+		);
 		if (plan.useGenericChangeHandler) {
 			await this.handleChanges(
 				{
@@ -952,19 +981,49 @@ export class Documents<
 				},
 			);
 		} else {
-			await this.handlePreparedPlainPutCommit({
-				document: plan.document,
-				encodedDocument: plan.encodedDocument,
-				key: plan.key,
-				entry: appended.entry,
-				removed: appended.removed,
-				appendCommit: appended.appendCommit,
-				unique: plan.unique,
-				existing: plan.existing,
-			});
+			await this.handlePreparedPlainPutCommit(documentAppendCommit);
 		}
 		this.keepCache?.add(appended.entry.hash);
 		return { entry: appended.entry, removed: appended.removed };
+	}
+
+	private createDocumentAppendCommitFacts(
+		plan: PlainPutCommitPlan<T, I>,
+		appended: {
+			entry: Entry<Operation>;
+			removed: ShallowOrFullEntry<Operation>[];
+			appendCommit: LocalAppendCommitFacts;
+		},
+	): DocumentAppendCommitFacts<T, I> {
+		const append = appended.appendCommit;
+		const existing =
+			plan.unique || plan.existing === null ? null : plan.existing;
+		const context = new Context({
+			created: existing?.value.__context.created || append.wallTime,
+			modified: append.wallTime,
+			head: append.hash,
+			gid: append.gid,
+			size: append.payloadSize,
+		});
+		const contextBytes = encodeContextSuffix(context);
+		return {
+			document: plan.document,
+			key: plan.key,
+			operation: plan.operation,
+			encodedDocument: plan.encodedDocument,
+			operationPayloadBytes: plan.payloadData,
+			entry: appended.entry,
+			removed: appended.removed,
+			append,
+			context,
+			contextBytes,
+			contextualEncodedValueParts: {
+				prefix: plan.encodedDocument,
+				suffix: contextBytes,
+			},
+			unique: plan.unique,
+			existing: plan.existing,
+		};
 	}
 
 	private nextFromIndexedContext(
@@ -997,73 +1056,48 @@ export class Documents<
 		});
 	}
 
-	private async handlePreparedPlainPutCommit(properties: {
-		document: T;
-		encodedDocument?: Uint8Array;
-		key: indexerTypes.IdKey;
-		entry: Entry<Operation>;
-		removed: ShallowOrFullEntry<Operation>[];
-		appendCommit?: LocalAppendCommitFacts;
-		unique?: boolean;
-		existing?:
-			| indexerTypes.IndexedResult<IndexedContextOnly<I>>
-			| null
-			| undefined;
-	}): Promise<void> {
+	private async handlePreparedPlainPutCommit(
+		commit: DocumentAppendCommitFacts<T, I>,
+	): Promise<void> {
 		const documentsChanged: DocumentsChange<T, I> = {
 			added: [],
 			removed: [],
 		};
 		const modified: Set<string | number | bigint> = new Set();
 		const existing =
-			properties.unique || properties.existing === null
-				? null
-				: properties.existing;
+			commit.unique || commit.existing === null ? null : commit.existing;
 
 		if (!this.strictHistory && existing) {
 			const shouldIgnoreChange = this.immutable
 				? existing.value.__context.modified <
-					properties.entry.meta.clock.timestamp.wallTime
+					commit.append.wallTime
 				: existing.value.__context.modified >
-					properties.entry.meta.clock.timestamp.wallTime;
+					commit.append.wallTime;
 			if (shouldIgnoreChange) {
-				modified.add(properties.key.primitive);
+				modified.add(commit.key.primitive);
 			}
 		}
 
-		if (!modified.has(properties.key.primitive)) {
-			const appendCommit = properties.appendCommit;
-			const context = new Context({
-				created:
-					existing?.value.__context.created ||
-					appendCommit?.wallTime ||
-					properties.entry.meta.clock.timestamp.wallTime,
-				modified:
-					appendCommit?.wallTime ||
-					properties.entry.meta.clock.timestamp.wallTime,
-				head: appendCommit?.hash || properties.entry.hash,
-				gid: appendCommit?.gid || properties.entry.meta.gid,
-				size: appendCommit?.payloadSize ?? properties.entry.payload.byteLength,
-			});
+		if (!modified.has(commit.key.primitive)) {
 			const { indexable } = await this._index.putWithContext(
-				properties.document,
-				properties.key,
-				context,
+				commit.document,
+				commit.key,
+				commit.context,
 				{
 					replace: existing != null,
-					encodedValue: properties.encodedDocument,
+					encodedValueParts: commit.contextualEncodedValueParts,
 				},
 			);
 			documentsChanged.added.push(
 				coerceWithIndexed(
-					coerceWithContext(properties.document, context),
+					coerceWithContext(commit.document, commit.context),
 					indexable,
 				),
 			);
-			modified.add(properties.key.primitive);
+			modified.add(commit.key.primitive);
 		}
 
-		for (const removed of properties.removed) {
+		for (const removed of commit.removed) {
 			if (
 				!(removed instanceof Entry) &&
 				(await this.collectRemovedDocumentChangeFromIndexedHead(

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -686,7 +686,7 @@ const writeU64Le = (target: Uint8Array, offset: number, value: bigint) => {
 	return offset + 8;
 };
 
-const encodeContextSuffix = (context: types.Context): Uint8Array => {
+export const encodeContextSuffix = (context: types.Context): Uint8Array => {
 	const head = fromString(context.head);
 	const gid = fromString(context.gid);
 	const encoded = new Uint8Array(

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -195,6 +195,10 @@ describe("index", () => {
 					store.docs as any,
 					"createPlainPutCommitPlan",
 				);
+				const documentCommitSpy = sinon.spy(
+					store.docs as any,
+					"createDocumentAppendCommitFacts",
+				);
 				const backendIndex = store.docs.index.index as any;
 				const originalBackendPutWithContext = backendIndex.putWithContext;
 				const originalBackendPut = backendIndex.put;
@@ -228,6 +232,7 @@ describe("index", () => {
 					expect(appendSpy.callCount).equal(0);
 					expect(localLookupSpy.callCount).equal(0);
 					expect(commitPlanSpy.callCount).equal(1);
+					expect(documentCommitSpy.callCount).equal(1);
 					expect(backendContextPutSpy.callCount).equal(1);
 					const encodedDocument = serialize(doc);
 					const expectedPayloadData = new Uint8Array(
@@ -246,6 +251,10 @@ describe("index", () => {
 					);
 					const commitPlan = await commitPlanSpy.getCall(0).returnValue;
 					expect(commitPlan.payloadData).to.deep.equal(expectedPayloadData);
+					const documentCommit = documentCommitSpy.getCall(0).returnValue;
+					expect(documentCommit.operationPayloadBytes).to.deep.equal(
+						expectedPayloadData,
+					);
 					const backendOptions = backendContextPutSpy.getCall(0).args[3] as
 						| {
 								encodedValue?: Uint8Array;
@@ -276,6 +285,12 @@ describe("index", () => {
 					expect(backendOptions?.encodedValueParts?.suffix).to.deep.equal(
 						serialize(backendContext),
 					);
+					expect(documentCommit.contextBytes).to.deep.equal(
+						backendOptions?.encodedValueParts?.suffix,
+					);
+					expect(documentCommit.contextualEncodedValueParts).to.deep.equal(
+						backendOptions?.encodedValueParts,
+					);
 					expect(backendOptions!.encodedValueParts!.suffix.byteLength).greaterThan(
 						0,
 					);
@@ -290,6 +305,7 @@ describe("index", () => {
 					}
 					localLookupSpy.restore();
 					commitPlanSpy.restore();
+					documentCommitSpy.restore();
 					preparedAppendSpy.restore();
 					validatedAppendSpy.restore();
 					appendSpy.restore();


### PR DESCRIPTION
## Summary
- add an internal DocumentAppendCommitFacts object for prepared plain document puts
- carry document bytes, operation payload bytes, append facts, Context, context bytes, and contextual encoded value parts through the prepared put path
- index with encodedValueParts directly instead of passing encodedValue and asking DocumentIndex.putWithContext to recreate the context suffix
- keep Documents.put public return shape unchanged

## Why
This is the next step after #913: shared-log already returns append facts, and this PR makes Documents.put consume a single commit facts object that includes the context/index bytes a future native document append helper can return directly.

## Benchmark
Local node document-put, 2026-05-11:

```bash
DOC_WARMUP=50 DOC_ITERATIONS=500 DOC_SCENARIOS=rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

- rust-peerbit-nonunique: 2822 ops/sec, total 177.18 ms, document index put 9.58 ms, backend index put 8.38 ms
- rust-peerbit-transient-index-nonunique: 3849 ops/sec, total 129.91 ms, document index put 6.74 ms, backend index put 5.87 ms

Signal is slightly positive versus #913 locally but still noisy; the deterministic improvement is that context bytes are built once and carried in the commit facts object.

## Test Plan
- pnpm --filter @peerbit/document run build
- pnpm --filter @peerbit/shared-log run build
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses the validated local append path for plain puts|uses the validated local append path for document updates"
- pnpm exec eslint --config eslint.config.js packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/src/search.ts packages/programs/data/document/document/test/index.spec.ts
  - passes with one existing unrelated warning at document/test/index.spec.ts:4224
- git diff --check