### PR TITLE
Add native-shaped document append boundary

### DIFF
--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -192,6 +192,23 @@ type DocumentAppendCommitFacts<T, I extends Record<string, any>> = {
 		| undefined;
 };
 
+type NativeDocumentAppendCommitInput<T, I extends Record<string, any>> = {
+	document: T;
+	key: indexerTypes.IdKey;
+	operation: PutOperation;
+	documentBytes: Uint8Array;
+	operationPayloadBytes: Uint8Array;
+	next: Entry<Operation>[] | ShallowEntry[];
+	skipMissingNextJoin: boolean;
+	resolveTrimmedEntries: boolean;
+	options?: DocumentPutOptions;
+	unique?: boolean;
+	existing?:
+		| indexerTypes.IndexedResult<IndexedContextOnly<I>>
+		| null
+		| undefined;
+};
+
 type InferR<D> = D extends ReplicationDomain<any, any, infer I> ? I : "u32";
 
 export type SetupOptions<
@@ -946,31 +963,24 @@ export class Documents<
 			| DocumentPutOptions
 			| undefined,
 	) {
-		const appended = await this.log.appendLocallyPrepared(
-			plan.operation,
-			{
-				...options,
-				meta: {
-					next: plan.next,
-					...options?.meta,
-				},
-				replicate: options?.replicate,
-			},
-			{
-				skipMissingNextJoin: plan.skipMissingNextJoin,
-				resolveTrimmedEntries: plan.resolveTrimmedEntries,
-				payloadData: plan.payloadData,
-			},
-		);
-		const documentAppendCommit = this.createDocumentAppendCommitFacts(
-			plan,
-			appended,
-		);
+		const documentAppendCommit = await this.commitNativeDocumentAppend({
+			document: plan.document,
+			key: plan.key,
+			operation: plan.operation,
+			documentBytes: plan.encodedDocument,
+			operationPayloadBytes: plan.payloadData,
+			next: plan.next,
+			skipMissingNextJoin: plan.skipMissingNextJoin,
+			resolveTrimmedEntries: plan.resolveTrimmedEntries,
+			options,
+			unique: plan.unique,
+			existing: plan.existing,
+		});
 		if (plan.useGenericChangeHandler) {
 			await this.handleChanges(
 				{
-					added: [{ head: true, entry: appended.entry }],
-					removed: appended.removed,
+					added: [{ head: true, entry: documentAppendCommit.entry }],
+					removed: documentAppendCommit.removed,
 				},
 				{
 					document: plan.document,
@@ -983,12 +993,37 @@ export class Documents<
 		} else {
 			await this.handlePreparedPlainPutCommit(documentAppendCommit);
 		}
-		this.keepCache?.add(appended.entry.hash);
-		return { entry: appended.entry, removed: appended.removed };
+		this.keepCache?.add(documentAppendCommit.entry.hash);
+		return {
+			entry: documentAppendCommit.entry,
+			removed: documentAppendCommit.removed,
+		};
+	}
+
+	private async commitNativeDocumentAppend(
+		input: NativeDocumentAppendCommitInput<T, I>,
+	): Promise<DocumentAppendCommitFacts<T, I>> {
+		const appended = await this.log.appendLocallyPrepared(
+			input.operation,
+			{
+				...input.options,
+				meta: {
+					next: input.next,
+					...input.options?.meta,
+				},
+				replicate: input.options?.replicate,
+			},
+			{
+				skipMissingNextJoin: input.skipMissingNextJoin,
+				resolveTrimmedEntries: input.resolveTrimmedEntries,
+				payloadData: input.operationPayloadBytes,
+			},
+		);
+		return this.createDocumentAppendCommitFacts(input, appended);
 	}
 
 	private createDocumentAppendCommitFacts(
-		plan: PlainPutCommitPlan<T, I>,
+		input: NativeDocumentAppendCommitInput<T, I>,
 		appended: {
 			entry: Entry<Operation>;
 			removed: ShallowOrFullEntry<Operation>[];
@@ -997,7 +1032,7 @@ export class Documents<
 	): DocumentAppendCommitFacts<T, I> {
 		const append = appended.appendCommit;
 		const existing =
-			plan.unique || plan.existing === null ? null : plan.existing;
+			input.unique || input.existing === null ? null : input.existing;
 		const context = new Context({
 			created: existing?.value.__context.created || append.wallTime,
 			modified: append.wallTime,
@@ -1007,22 +1042,22 @@ export class Documents<
 		});
 		const contextBytes = encodeContextSuffix(context);
 		return {
-			document: plan.document,
-			key: plan.key,
-			operation: plan.operation,
-			encodedDocument: plan.encodedDocument,
-			operationPayloadBytes: plan.payloadData,
+			document: input.document,
+			key: input.key,
+			operation: input.operation,
+			encodedDocument: input.documentBytes,
+			operationPayloadBytes: input.operationPayloadBytes,
 			entry: appended.entry,
 			removed: appended.removed,
 			append,
 			context,
 			contextBytes,
 			contextualEncodedValueParts: {
-				prefix: plan.encodedDocument,
+				prefix: input.documentBytes,
 				suffix: contextBytes,
 			},
-			unique: plan.unique,
-			existing: plan.existing,
+			unique: input.unique,
+			existing: input.existing,
 		};
 	}
 

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -195,6 +195,10 @@ describe("index", () => {
 					store.docs as any,
 					"createPlainPutCommitPlan",
 				);
+				const nativeCommitSpy = sinon.spy(
+					store.docs as any,
+					"commitNativeDocumentAppend",
+				);
 				const documentCommitSpy = sinon.spy(
 					store.docs as any,
 					"createDocumentAppendCommitFacts",
@@ -232,6 +236,7 @@ describe("index", () => {
 					expect(appendSpy.callCount).equal(0);
 					expect(localLookupSpy.callCount).equal(0);
 					expect(commitPlanSpy.callCount).equal(1);
+					expect(nativeCommitSpy.callCount).equal(1);
 					expect(documentCommitSpy.callCount).equal(1);
 					expect(backendContextPutSpy.callCount).equal(1);
 					const encodedDocument = serialize(doc);
@@ -251,6 +256,13 @@ describe("index", () => {
 					);
 					const commitPlan = await commitPlanSpy.getCall(0).returnValue;
 					expect(commitPlan.payloadData).to.deep.equal(expectedPayloadData);
+					const nativeInput = nativeCommitSpy.getCall(0).args[0];
+					expect(nativeInput.documentBytes).to.deep.equal(encodedDocument);
+					expect(nativeInput.operationPayloadBytes).to.deep.equal(
+						expectedPayloadData,
+					);
+					expect(nativeInput.key.primitive).equal(doc.id);
+					expect(nativeInput.next).to.be.empty;
 					const documentCommit = documentCommitSpy.getCall(0).returnValue;
 					expect(documentCommit.operationPayloadBytes).to.deep.equal(
 						expectedPayloadData,
@@ -305,6 +317,7 @@ describe("index", () => {
 					}
 					localLookupSpy.restore();
 					commitPlanSpy.restore();
+					nativeCommitSpy.restore();
 					documentCommitSpy.restore();
 					preparedAppendSpy.restore();
 					validatedAppendSpy.restore();


### PR DESCRIPTION
## Summary
- adds an internal `NativeDocumentAppendCommitInput` for the prepared document put path
- routes `commitPlainPutPlan` through `commitNativeDocumentAppend`, the future native/Rust handoff point
- keeps public `Documents.put()` behavior unchanged while making the append/facts boundary explicit
- extends focused coverage to assert the boundary receives prepared document bytes, operation payload bytes, key, and next entries

## Benchmark
Command:
`DOC_WARMUP=50 DOC_ITERATIONS=500 DOC_SCENARIOS=rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts`

Results:
- `rust-peerbit-nonunique`: 2539 ops/sec, total 196.91 ms, shared append 159.80 ms, log append 113.44 ms, document index put 10.65 ms
- `rust-peerbit-transient-index-nonunique`: 3849 ops/sec, total 129.90 ms, shared append 103.24 ms, log append 75.62 ms, document index put 6.57 ms

This PR is structural, so throughput is expected to be neutral/noisy. The value is a narrow replaceable boundary for the next native-owned document append transaction.

## Validation
- `pnpm --filter @peerbit/document run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/log run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses the validated local append path for plain puts|uses the validated local append path for document updates"`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/test/index.spec.ts` (passes with one existing unrelated warning in `index.spec.ts`)
- `git diff --check`

## Next
Implement a native/Rust owner behind `commitNativeDocumentAppend(...)`, starting with append facts + context bytes/index facts, then folding lower-log/native graph/block commit and coordinate persistence into that boundary.