### PR TITLE
Use exact id deletes for lower-log trim

### DIFF
--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -62,6 +62,15 @@ type BlocksWithRmMany = Blocks & {
 const hasRmMany = (store: Blocks): store is BlocksWithRmMany =>
 	typeof (store as BlocksWithRmMany).rmMany === "function";
 
+type IndexWithExactDelete = Index<any> & {
+	delIds: (
+		deleteIds: string[],
+	) => Promise<ReturnType<typeof toId>[]> | ReturnType<typeof toId>[];
+};
+
+const hasExactDelete = (index: Index<any>): index is IndexWithExactDelete =>
+	typeof (index as IndexWithExactDelete).delIds === "function";
+
 type NativeLogEntry = PreparedNativeLogEntry;
 
 type NativeJoinCutCheck = {
@@ -1460,12 +1469,13 @@ export class EntryIndex<T> {
 			}
 		}
 
-		const batchSize = 64;
-		for (let i = 0; i < indexedHashes.length; i += batchSize) {
-			const hashes = indexedHashes.slice(i, i + batchSize);
-			const deleted = await this.properties.index.del({
-				query: createHashMatchQuery(hashes),
-			});
+		const exactDeleteIndex: IndexWithExactDelete | undefined = hasExactDelete(
+			this.properties.index,
+		)
+			? (this.properties.index as IndexWithExactDelete)
+			: undefined;
+		if (indexedHashes.length > 0 && exactDeleteIndex) {
+			const deleted = await exactDeleteIndex.delIds(indexedHashes);
 			for (const id of deleted) {
 				const hash = String(id.primitive);
 				const node = indexedByHash.get(hash);
@@ -1474,6 +1484,23 @@ export class EntryIndex<T> {
 				}
 				deletedByHash.set(hash, node);
 				storeHashes.push(hash);
+			}
+		} else {
+			const batchSize = 64;
+			for (let i = 0; i < indexedHashes.length; i += batchSize) {
+				const hashes = indexedHashes.slice(i, i + batchSize);
+				const deleted = await this.properties.index.del({
+					query: createHashMatchQuery(hashes),
+				});
+				for (const id of deleted) {
+					const hash = String(id.primitive);
+					const node = indexedByHash.get(hash);
+					if (!node || deletedByHash.has(hash)) {
+						continue;
+					}
+					deletedByHash.set(hash, node);
+					storeHashes.push(hash);
+				}
 			}
 		}
 

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -585,6 +585,10 @@ describe("index", () => {
 
 				const lowerLogGetSpy = sinon.spy(store.docs.log.log, "get");
 				const entryIndexGetSpy = sinon.spy(store.docs.log.log.entryIndex, "get");
+				const entryIndexBackend = store.docs.log.log.entryIndex.properties
+					.index as any;
+				const entryIndexDelIdsSpy = sinon.spy(entryIndexBackend, "delIds");
+				const entryIndexDelSpy = sinon.spy(entryIndexBackend, "del");
 
 				try {
 					await store.docs.put(
@@ -600,12 +604,16 @@ describe("index", () => {
 					expect(entryIndexGetSpy.withArgs(first.entry.hash).callCount).equal(
 						0,
 					);
+					expect(entryIndexDelIdsSpy.callCount).greaterThan(0);
+					expect(entryIndexDelSpy.callCount).equal(0);
 					expect(await store.docs.get(firstId)).to.be.undefined;
 					expect(changes).to.have.length(2);
 					expect(changes[1].removed.map((doc) => doc.id)).to.deep.equal([
 						firstId,
 					]);
 				} finally {
+					entryIndexDelSpy.restore();
+					entryIndexDelIdsSpy.restore();
 					entryIndexGetSpy.restore();
 					lowerLogGetSpy.restore();
 					await store.close();


### PR DESCRIPTION
## Summary
- lets `EntryIndex.deleteMany` use an internal exact-id `delIds(...)` backend hook when available
- preserves the existing hash-match query delete fallback for indexers without exact deletes
- extends the Rust-backed document trim coverage to prove prepared document trim uses exact-id lower-log entry deletes

## Benchmark
Command:
`DOC_WARMUP=100 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts`

Baseline on #915:
- `rust-peerbit-nonunique`: 3309 ops/sec, total 302.23 ms, log trim 58.25 ms
- `rust-peerbit-transient-index-nonunique`: 4136 ops/sec, total 241.79 ms, log trim 43.20 ms

After this PR:
- `rust-peerbit-nonunique`: 3454 ops/sec, total 289.49 ms, log trim 44.13 ms
- `rust-peerbit-transient-index-nonunique`: 4209 ops/sec, total 237.61 ms, log trim 34.66 ms

The targeted trim column dropped about 24% persisted and 20% transient in this local run.

## Validation
- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "removes trimmed prepared puts"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "native length trim|uses the native graph to plan unfiltered length trim"`
- `pnpm exec eslint --config eslint.config.js packages/log/src/entry-index.ts packages/programs/data/document/document/test/index.spec.ts` (passes with one existing unrelated warning in `index.spec.ts`)
- `git diff --check`

## Next
The remaining pure-native document put work should move lower-log append commit, coordinate persistence, and document index projection behind `commitNativeDocumentAppend(...)` rather than continuing to shave generic JS wrapper calls.