### PR TITLE
Persist preencoded Rust index journal puts

### DIFF
--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -12,6 +12,7 @@ import {
 import * as types from "@peerbit/indexer-interface";
 import {
 	createSnapshotFile,
+	type EncodedValue,
 	type PersistenceOptions,
 	type SnapshotFile,
 } from "./persistence.js";
@@ -1775,6 +1776,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 						item.storeKey,
 						item.value,
 						this.properties.schema,
+						item.encodedValueParts ?? item.encodedValue,
 					);
 				}
 			});
@@ -2199,7 +2201,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			return;
 		}
 		await this.enqueueMutation(async () => {
-			await this.appendPut(storeKey, value);
+			await this.appendPut(storeKey, value, encodedValue);
 			if (
 				!this.putNativeDocumentWithPreparedFields(
 					storeKey,
@@ -2237,7 +2239,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			return;
 		}
 		await this.enqueueMutation(async () => {
-			await this.appendPut(storeKey, value);
+			await this.appendPut(storeKey, value, encodedValueParts);
 			if (
 				!this.putNativeDocumentWithPreparedFields(
 					storeKey,
@@ -2469,9 +2471,18 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		return next;
 	}
 
-	private appendPut(storeKey: string, value: T): Promise<void> {
+	private appendPut(
+		storeKey: string,
+		value: T,
+		encodedValue?: EncodedValue,
+	): Promise<void> {
 		return this.enqueuePersistence(() =>
-			this.snapshotFile!.appendPut(storeKey, value, this.properties.schema),
+			this.snapshotFile!.appendPut(
+				storeKey,
+				value,
+				this.properties.schema,
+				encodedValue,
+			),
 		);
 	}
 

--- a/packages/utils/indexer/rust/src/persistence.ts
+++ b/packages/utils/indexer/rust/src/persistence.ts
@@ -21,6 +21,7 @@ export type SnapshotFile = {
 		key: string,
 		value: T,
 		schema: AbstractType<T>,
+		encodedValue?: EncodedValue,
 	): Promise<void>;
 	appendDelete(key: string): Promise<void>;
 	compact<T extends Record<string, any>>(
@@ -31,6 +32,13 @@ export type SnapshotFile = {
 	remove(): Promise<void>;
 	persisted: true;
 };
+
+export type EncodedValue =
+	| Uint8Array
+	| {
+			prefix: Uint8Array;
+			suffix: Uint8Array;
+	  };
 
 export type PersistenceDurability = "normal" | "strict";
 
@@ -113,6 +121,27 @@ const writeBytes = (
 	offset = setUint32(output, offset, bytes.byteLength);
 	output.set(bytes, offset);
 	return offset + bytes.byteLength;
+};
+
+const encodedValueLength = (value: EncodedValue): number =>
+	value instanceof Uint8Array
+		? value.byteLength
+		: value.prefix.byteLength + value.suffix.byteLength;
+
+const writeEncodedValue = (
+	output: Uint8Array,
+	offset: number,
+	value: EncodedValue,
+): number => {
+	offset = setUint32(output, offset, encodedValueLength(value));
+	if (value instanceof Uint8Array) {
+		output.set(value, offset);
+		return offset + value.byteLength;
+	}
+	output.set(value.prefix, offset);
+	offset += value.prefix.byteLength;
+	output.set(value.suffix, offset);
+	return offset + value.suffix.byteLength;
 };
 
 const readBytes = (
@@ -239,20 +268,24 @@ const encodeJournalPayload = <T extends Record<string, any>>(
 	key: string,
 	schema?: AbstractType<T>,
 	value?: T,
+	encodedValue?: EncodedValue,
 ): Uint8Array => {
 	const keyBytes = encodeString(key);
-	const valueBytes = value && schema ? serialize(value) : new Uint8Array();
+	const valueBytes =
+		encodedValue ?? (value && schema ? serialize(value) : new Uint8Array());
 	const output = new Uint8Array(
 		1 +
 			4 +
 			keyBytes.byteLength +
-			(operation === JournalOperation.Put ? 4 + valueBytes.byteLength : 0),
+			(operation === JournalOperation.Put
+				? 4 + encodedValueLength(valueBytes)
+				: 0),
 	);
 	let offset = 0;
 	output[offset++] = operation;
 	offset = writeBytes(output, offset, keyBytes);
 	if (operation === JournalOperation.Put) {
-		offset = writeBytes(output, offset, valueBytes);
+		offset = writeEncodedValue(output, offset, valueBytes);
 	}
 	return output;
 };
@@ -390,8 +423,17 @@ class NativeSnapshotFile implements SnapshotFile {
 		key: string,
 		value: T,
 		schema: AbstractType<T>,
+		encodedValue?: EncodedValue,
 	): Promise<void> {
-		await this.appendRecord(encodeJournalPayload(JournalOperation.Put, key, schema, value));
+		await this.appendRecord(
+			encodeJournalPayload(
+				JournalOperation.Put,
+				key,
+				schema,
+				value,
+				encodedValue,
+			),
+		);
 	}
 
 	async appendDelete(key: string): Promise<void> {
@@ -595,8 +637,17 @@ class OpfsSnapshotFile implements SnapshotFile {
 		key: string,
 		value: T,
 		schema: AbstractType<T>,
+		encodedValue?: EncodedValue,
 	): Promise<void> {
-		await this.appendRecord(encodeJournalPayload(JournalOperation.Put, key, schema, value));
+		await this.appendRecord(
+			encodeJournalPayload(
+				JournalOperation.Put,
+				key,
+				schema,
+				value,
+				encodedValue,
+			),
+		);
 	}
 
 	async appendDelete(key: string): Promise<void> {

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -944,6 +944,88 @@ describe("native planner bridge", () => {
 		}
 	});
 
+	it("replays durable contextual encoded puts from prepared bytes", async () => {
+		const directory = createPersistenceDirectory();
+		const writer = create(directory, {
+			persistence: { compactAfterOperations: 1000 },
+		});
+		const reader = create(directory, {
+			persistence: { compactAfterOperations: 1000 },
+		});
+		try {
+			await writer.start();
+			const writerIndex = await writer.init({ schema: BridgeDocumentWithContext });
+			const contextualWriter = writerIndex as typeof writerIndex & {
+				putWithContext: (
+					value: BridgeDocument & { __context?: BridgeContext },
+					id: ReturnType<typeof toId>,
+					context: BridgeContext,
+					options?: {
+						replace?: boolean;
+						encodedValueParts?: { prefix: Uint8Array; suffix: Uint8Array };
+					},
+				) => Promise<void>;
+			};
+			(writerIndex as unknown as { fieldEncoder: () => never }).fieldEncoder =
+				() => {
+					throw new Error("TypeScript field encoder should not run");
+				};
+
+			const encodedDocument = new BridgeDocument(
+				"a",
+				"peerbit",
+				"prepared durable",
+			);
+			const context = new BridgeContext("head-a");
+			const journalValue = Object.create(
+				BridgeDocumentWithContext.prototype,
+			) as BridgeDocument & { __context?: BridgeContext };
+			Object.defineProperties(journalValue, {
+				id: { value: "a", enumerable: true },
+				tag: {
+					get() {
+						throw new Error("journal should use prepared bytes");
+					},
+					enumerable: true,
+				},
+				title: {
+					get() {
+						throw new Error("journal should use prepared bytes");
+					},
+					enumerable: true,
+				},
+				__context: { value: context, enumerable: true },
+			});
+
+			await contextualWriter.putWithContext(journalValue, toId("a"), context, {
+				replace: false,
+				encodedValueParts: {
+					prefix: serialize(encodedDocument),
+					suffix: serialize(context),
+				},
+			});
+
+			await reader.start();
+			const readerIndex = await reader.init({ schema: BridgeDocumentWithContext });
+			const result = await readerIndex.get(toId("a"));
+			expect(result?.value.title).equal("prepared durable");
+			expect(result?.value.__context.head).equal("head-a");
+
+			const indexed = await readerIndex
+				.iterate({
+					query: new StringMatch({ key: "tag", value: "peerbit" }),
+				})
+				.all();
+			expect(indexed.map((entry) => entry.value.__context.head)).to.deep.equal([
+				"head-a",
+			]);
+		} finally {
+			await writer.drop();
+			await reader.drop();
+			await removeNodeDirectoryIfNeeded(directory);
+		}
+	});
+
 	it("replays durable deletes before the writer is stopped", async () => {
 		const directory = createPersistenceDirectory();
 		const writer = create(directory);


### PR DESCRIPTION
Stacked on #916.

## Summary
- let Rust index persistence write already-prepared encoded values into the journal
- pass contextual document encoded prefix/suffix bytes through durable `appendPut`
- add a durable replay regression test proving the journal does not reserialize the JS value

## Benchmark
Local node run from `packages/programs/data/document/document`:

`DOC_WARMUP=100 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts`

- `rust-peerbit-nonunique`: 3403 ops/sec, total 293.87 ms, backend index put 15.07 ms
- `rust-peerbit-transient-index-nonunique`: 4110 ops/sec, total 243.33 ms, backend index put 10.99 ms

This is a durable hot-path cleanup, not a clear top-line document-put throughput jump; transient movement looked like normal run noise.

## Validation
- `pnpm --filter @peerbit/indexer-rust run build`
- `pnpm exec eslint --config eslint.config.js packages/utils/indexer/rust/src/index.ts packages/utils/indexer/rust/src/persistence.ts packages/utils/indexer/rust/test/index.spec.ts`
- `git diff --check`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/utils/indexer/rust -- -t node --grep "replays durable contextual encoded puts from prepared bytes"`
- `pnpm --filter @peerbit/indexer-rust test`
- `pnpm --filter @peerbit/document run build`
- `cargo fmt --manifest-path packages/utils/indexer/rust/Cargo.toml --check`