### PR TITLE
Batch Rust index journal puts

### DIFF
--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -1771,14 +1771,14 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				};
 			});
 			await this.enqueuePersistence(async () => {
-				for (const item of prepared) {
-					await this.snapshotFile!.appendPut(
-						item.storeKey,
-						item.value,
-						this.properties.schema,
-						item.encodedValueParts ?? item.encodedValue,
-					);
-				}
+				await this.snapshotFile!.appendPutBatch(
+					prepared.map((item) => ({
+						key: item.storeKey,
+						value: item.value,
+						encodedValue: item.encodedValueParts ?? item.encodedValue,
+					})),
+					this.properties.schema,
+				);
 			});
 			for (const item of prepared) {
 				if (

--- a/packages/utils/indexer/rust/src/persistence.ts
+++ b/packages/utils/indexer/rust/src/persistence.ts
@@ -23,6 +23,14 @@ export type SnapshotFile = {
 		schema: AbstractType<T>,
 		encodedValue?: EncodedValue,
 	): Promise<void>;
+	appendPutBatch<T extends Record<string, any>>(
+		values: Array<{
+			key: string;
+			value: T;
+			encodedValue?: EncodedValue;
+		}>,
+		schema: AbstractType<T>,
+	): Promise<void>;
 	appendDelete(key: string): Promise<void>;
 	compact<T extends Record<string, any>>(
 		values: T[],
@@ -436,6 +444,27 @@ class NativeSnapshotFile implements SnapshotFile {
 		);
 	}
 
+	async appendPutBatch<T extends Record<string, any>>(
+		values: Array<{
+			key: string;
+			value: T;
+			encodedValue?: EncodedValue;
+		}>,
+		schema: AbstractType<T>,
+	): Promise<void> {
+		await this.appendRecords(
+			values.map((entry) =>
+				encodeJournalPayload(
+					JournalOperation.Put,
+					entry.key,
+					schema,
+					entry.value,
+					entry.encodedValue,
+				),
+			),
+		);
+	}
+
 	async appendDelete(key: string): Promise<void> {
 		await this.appendRecord(encodeJournalPayload(JournalOperation.Delete, key));
 	}
@@ -534,16 +563,25 @@ class NativeSnapshotFile implements SnapshotFile {
 	}
 
 	private async appendRecord(payload: Uint8Array): Promise<void> {
+		await this.appendRecords([payload]);
+	}
+
+	private async appendRecords(payloads: Uint8Array[]): Promise<void> {
+		if (payloads.length === 0) {
+			return;
+		}
 		const handle = await this.getJournalHandle();
 		if (!this.journalInitialized) {
 			this.writeAllSync(handle, JOURNAL_MAGIC);
 			this.journalInitialized = true;
 		}
-		this.writeAllSync(handle, encodeJournalRecord(payload));
+		for (const payload of payloads) {
+			this.writeAllSync(handle, encodeJournalRecord(payload));
+		}
 		if (this.durability === "strict") {
 			this.fs.fsyncSync(handle);
 		}
-		this.operations++;
+		this.operations += payloads.length;
 	}
 
 	private async getJournalHandle(): Promise<number> {
@@ -646,6 +684,27 @@ class OpfsSnapshotFile implements SnapshotFile {
 				schema,
 				value,
 				encodedValue,
+			),
+		);
+	}
+
+	async appendPutBatch<T extends Record<string, any>>(
+		values: Array<{
+			key: string;
+			value: T;
+			encodedValue?: EncodedValue;
+		}>,
+		schema: AbstractType<T>,
+	): Promise<void> {
+		await this.appendRecords(
+			values.map((entry) =>
+				encodeJournalPayload(
+					JournalOperation.Put,
+					entry.key,
+					schema,
+					entry.value,
+					entry.encodedValue,
+				),
 			),
 		);
 	}
@@ -759,11 +818,18 @@ class OpfsSnapshotFile implements SnapshotFile {
 	}
 
 	private async appendRecord(payload: Uint8Array): Promise<void> {
+		await this.appendRecords([payload]);
+	}
+
+	private async appendRecords(payloads: Uint8Array[]): Promise<void> {
+		if (payloads.length === 0) {
+			return;
+		}
 		const directory = await this.getDirectory(true);
 		const fileHandle = (await directory.getFileHandle(this.journalFileName, {
 			create: true,
 		})) as SyncFileHandle;
-		const record = encodeJournalRecord(payload);
+		const records = payloads.map(encodeJournalRecord);
 
 		if (fileHandle.createSyncAccessHandle) {
 			const access = await fileHandle.createSyncAccessHandle();
@@ -775,19 +841,22 @@ class OpfsSnapshotFile implements SnapshotFile {
 					access.write(JOURNAL_MAGIC, { at: offset });
 					offset += JOURNAL_MAGIC.byteLength;
 				}
-				access.write(record, { at: offset });
+				for (const record of records) {
+					access.write(record, { at: offset });
+					offset += record.byteLength;
+				}
 				if (this.durability === "strict") {
 					access.flush();
 				}
 			} finally {
 				access.close();
 			}
-			this.operations++;
+			this.operations += payloads.length;
 			return;
 		}
 
-		if (await this.tryAppendWithWritableStream(fileHandle, record)) {
-			this.operations++;
+		if (await this.tryAppendWithWritableStream(fileHandle, records)) {
+			this.operations += payloads.length;
 			return;
 		}
 
@@ -796,15 +865,15 @@ class OpfsSnapshotFile implements SnapshotFile {
 			this.journalFileName,
 			concatBytes([
 				existing.byteLength === 0 ? JOURNAL_MAGIC : existing,
-				record,
+				...records,
 			]),
 		);
-		this.operations++;
+		this.operations += payloads.length;
 	}
 
 	private async tryAppendWithWritableStream(
 		fileHandle: FileSystemFileHandle,
-		record: Uint8Array,
+		records: Uint8Array[],
 	): Promise<boolean> {
 		let writable: FileSystemWritableFileStream | undefined;
 		try {
@@ -819,7 +888,10 @@ class OpfsSnapshotFile implements SnapshotFile {
 				});
 				offset += JOURNAL_MAGIC.byteLength;
 			}
-			await writable.write({ type: "write", position: offset, data: record });
+			for (const record of records) {
+				await writable.write({ type: "write", position: offset, data: record });
+				offset += record.byteLength;
+			}
 			await writable.close();
 			return true;
 		} catch (error: any) {

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -1026,6 +1026,115 @@ describe("native planner bridge", () => {
 		}
 	});
 
+	it("replays durable contextual encoded put batches from prepared bytes", async () => {
+		const directory = createPersistenceDirectory();
+		const writer = create(directory, {
+			persistence: { compactAfterOperations: 1000 },
+		});
+		const reader = create(directory, {
+			persistence: { compactAfterOperations: 1000 },
+		});
+		try {
+			await writer.start();
+			const writerIndex = await writer.init({ schema: BridgeDocumentWithContext });
+			const contextualWriter = writerIndex as typeof writerIndex & {
+				putWithContextBatch: (
+					values: Array<{
+						value: BridgeDocument & { __context?: BridgeContext };
+						id: ReturnType<typeof toId>;
+						context: BridgeContext;
+						options?: {
+							replace?: boolean;
+							encodedValueParts?: { prefix: Uint8Array; suffix: Uint8Array };
+						};
+					}>,
+				) => Promise<void>;
+			};
+			(writerIndex as unknown as { fieldEncoder: () => never }).fieldEncoder =
+				() => {
+					throw new Error("TypeScript field encoder should not run");
+				};
+
+			const createJournalValue = (id: string, context: BridgeContext) => {
+				const value = Object.create(
+					BridgeDocumentWithContext.prototype,
+				) as BridgeDocument & { __context?: BridgeContext };
+				Object.defineProperties(value, {
+					id: { value: id, enumerable: true },
+					tag: {
+						get() {
+							throw new Error("journal batch should use prepared bytes");
+						},
+						enumerable: true,
+					},
+					title: {
+						get() {
+							throw new Error("journal batch should use prepared bytes");
+						},
+						enumerable: true,
+					},
+					__context: { value: context, enumerable: true },
+				});
+				return value;
+			};
+
+			const firstContext = new BridgeContext("head-a");
+			const secondContext = new BridgeContext("head-b");
+			await contextualWriter.putWithContextBatch([
+				{
+					value: createJournalValue("a", firstContext),
+					id: toId("a"),
+					context: firstContext,
+					options: {
+						replace: false,
+						encodedValueParts: {
+							prefix: serialize(
+								new BridgeDocument("a", "peerbit", "first durable batch"),
+							),
+							suffix: serialize(firstContext),
+						},
+					},
+				},
+				{
+					value: createJournalValue("b", secondContext),
+					id: toId("b"),
+					context: secondContext,
+					options: {
+						replace: false,
+						encodedValueParts: {
+							prefix: serialize(
+								new BridgeDocument("b", "peerbit", "second durable batch"),
+							),
+							suffix: serialize(secondContext),
+						},
+					},
+				},
+			]);
+
+			await reader.start();
+			const readerIndex = await reader.init({ schema: BridgeDocumentWithContext });
+			const result = await readerIndex
+				.iterate({
+					query: new StringMatch({ key: "tag", value: "peerbit" }),
+					sort: new Sort({ key: "title" }),
+				})
+				.all();
+
+			expect(result.map((entry) => entry.value.title)).to.deep.equal([
+				"first durable batch",
+				"second durable batch",
+			]);
+			expect(result.map((entry) => entry.value.__context.head)).to.deep.equal([
+				"head-a",
+				"head-b",
+			]);
+		} finally {
+			await writer.drop();
+			await reader.drop();
+			await removeNodeDirectoryIfNeeded(directory);
+		}
+	});
+
 	it("replays durable deletes before the writer is stopped", async () => {
 		const directory = createPersistenceDirectory();
 		const writer = create(directory);


### PR DESCRIPTION
Stacked on #917.

## Summary
- add a durable `appendPutBatch` path for `@peerbit/indexer-rust` snapshots
- make prepared Rust index batches write the WAL in one batch operation scope
- reuse one Node journal handle / one OPFS sync access handle or writable stream for the batch
- add durable contextual encoded batch replay coverage

## Performance
Direct Rust index microbench for 1000 prepared contextual batch puts after building each branch:

- parent #917 normal durability: 9151 ops/sec, 109.27 ms
- this branch normal durability: 54792 ops/sec, 18.25 ms
- parent #917 strict durability: 219 ops/sec, 4566.21 ms
- this branch strict durability: 32746 ops/sec, 30.54 ms

Document putMany remains dominated by shared-log/log append, so top-line product throughput is nearly unchanged in this specific local run:

- parent #917 `rust-peerbit-putmany`: 5814 ops/sec, total 171.99 ms
- this branch `rust-peerbit-putmany`: 5856 ops/sec, total 170.76 ms
- parent #917 `rust-peerbit-transient-index-putmany`: 7278 ops/sec, total 137.40 ms
- this branch `rust-peerbit-transient-index-putmany`: 7345 ops/sec, total 136.15 ms

## Validation
- `pnpm --filter @peerbit/indexer-rust run build`
- `pnpm exec eslint --config eslint.config.js packages/utils/indexer/rust/src/index.ts packages/utils/indexer/rust/src/persistence.ts packages/utils/indexer/rust/test/index.spec.ts`
- `git diff --check`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/utils/indexer/rust -- -t node --grep "replays durable contextual encoded put batches from prepared bytes"`
- `pnpm --filter @peerbit/indexer-rust test`
- `pnpm --filter @peerbit/document run build`
- `cargo fmt --manifest-path packages/utils/indexer/rust/Cargo.toml --check`