### PR TITLE
Carry native append commit facts through putMany

### DIFF
--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -846,6 +846,7 @@ export class Documents<
 				encodedDocument: item.encodedDocument,
 				key: item.key,
 				entry: appended.entries[index]!,
+				append: appended.appendCommits[index]!,
 			})),
 			removed: appended.removed,
 		});
@@ -1175,6 +1176,7 @@ export class Documents<
 			encodedDocument?: Uint8Array;
 			key: indexerTypes.IdKey;
 			entry: Entry<Operation>;
+			append: LocalAppendCommitFacts;
 		}[];
 		removed: ShallowOrFullEntry<Operation>[];
 	}): Promise<void> {
@@ -1195,11 +1197,11 @@ export class Documents<
 				continue;
 			}
 			const context = new Context({
-				created: put.entry.meta.clock.timestamp.wallTime,
-				modified: put.entry.meta.clock.timestamp.wallTime,
-				head: put.entry.hash,
-				gid: put.entry.meta.gid,
-				size: put.entry.payload.byteLength,
+				created: put.append.wallTime,
+				modified: put.append.wallTime,
+				head: put.append.hash,
+				gid: put.append.gid,
+				size: put.append.payloadSize,
 			});
 			putsToIndex.push({
 				document: put.document,

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -4173,11 +4173,12 @@ export class SharedLog<
 		| {
 				entries: Entry<T>[];
 				removed: ShallowOrFullEntry<T>[];
+				appendCommits: PreparedLocalAppendCommit<R>[];
 		  }
 		| undefined
 	> {
 		if (data.length === 0) {
-			return { entries: [], removed: [] };
+			return { entries: [], removed: [], appendCommits: [] };
 		}
 		if (options?.canAppend || options?.onChange) {
 			throw new Error(
@@ -4212,10 +4213,14 @@ export class SharedLog<
 				...result.entries.flatMap((entry) => entry.meta.next),
 				...result.removed.map((entry) => entry.hash),
 			]);
-			return { entries: result.entries, removed: result.removed };
+			return {
+				entries: result.entries,
+				removed: result.removed,
+				appendCommits: this.createPreparedLocalAppendCommits(result.entries),
+			};
 		}
 
-		const nativeAppendPlans =
+		let nativeAppendPlans =
 			options?.replicate === true
 				? undefined
 				: options?.target === "none"
@@ -4239,10 +4244,17 @@ export class SharedLog<
 				},
 			))
 		) {
-			return { entries: result.entries, removed: result.removed };
+			return {
+				entries: result.entries,
+				removed: result.removed,
+				appendCommits: this.createPreparedLocalAppendCommits(
+					result.entries,
+					nativeAppendPlans,
+				),
+			};
 		}
 		for (let i = 0; i < result.entries.length; i++) {
-			await this.processLocalAppend(
+			const processedPlan = await this.processLocalAppend(
 				result.entries[i]!,
 				i === result.entries.length - 1 ? result.removed : [],
 				options,
@@ -4252,9 +4264,20 @@ export class SharedLog<
 					nativeAppendPlan: nativeAppendPlans?.[i],
 				},
 			);
+			if (processedPlan) {
+				nativeAppendPlans ??= [];
+				nativeAppendPlans[i] = processedPlan;
+			}
 		}
 
-		return { entries: result.entries, removed: result.removed };
+		return {
+			entries: result.entries,
+			removed: result.removed,
+			appendCommits: this.createPreparedLocalAppendCommits(
+				result.entries,
+				nativeAppendPlans,
+			),
+		};
 	}
 
 	async appendMany(
@@ -4816,6 +4839,15 @@ export class SharedLog<
 			hashNumber: nativeAppendPlan?.hashNumber,
 			coordinateFields: nativeAppendPlan?.preparedCoordinate.fields,
 		};
+	}
+
+	private createPreparedLocalAppendCommits(
+		entries: Entry<T>[],
+		nativeAppendPlans?: Array<NativeAppendEntryPlan<R> | undefined>,
+	): PreparedLocalAppendCommit<R>[] {
+		return entries.map((entry, index) =>
+			this.createPreparedLocalAppendCommit(entry, nativeAppendPlans?.[index]),
+		);
 	}
 
 	async open(options?: Args<T, D, R>): Promise<void> {


### PR DESCRIPTION
## Summary
- return prepared append commit facts from shared-log batch local appends
- preserve native-planned and fallback append facts through the batch path
- use those facts in document putMany prepared indexing instead of reading lower-log entry internals for context

## Performance
Local document putMany benchmark, 2026-05-11:

```
DOC_WARMUP=20 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-putmany,rust-peerbit-transient-index-putmany DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

- parent #918 `rust-peerbit-putmany`: 5856 ops/sec, total 170.76 ms
- this branch `rust-peerbit-putmany`: 5746 ops/sec, total 174.02 ms
- parent #918 `rust-peerbit-transient-index-putmany`: 7345 ops/sec, total 136.15 ms
- this branch `rust-peerbit-transient-index-putmany`: 7210 ops/sec, total 138.71 ms

This is intentionally a boundary/foundation PR rather than a throughput PR. The profiler still points at lower-log append-chain creation/commit and trim orchestration as the next throughput target.

## Test Plan
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/index.ts packages/programs/data/document/document/src/program.ts`
- `git diff --check`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "independent native prepared batch path|batches rust index"`