### PR TITLE
Avoid no-next marshalling in native log batches

### DIFF
--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -184,6 +184,16 @@ type NativeLogIndexHandle = {
 		metaDatas: Array<Uint8Array | undefined>,
 		payloadDatas: Uint8Array[],
 	) => EntryV0CommittedPlainEntryRow[];
+	prepare_entry_v0_plain_entries_no_next_commit_blocks_and_put_with_builder?: (
+		builder: NativeEntryV0PlainBuilderHandle,
+		blockStore: NativeLogBlockStoreHandle,
+		wallTimes: BigUint64Array,
+		logicals: Uint32Array,
+		gids: string[],
+		type: number,
+		metaDatas: Array<Uint8Array | undefined>,
+		payloadDatas: Uint8Array[],
+	) => EntryV0CommittedPlainEntryRow[];
 	delete: (hash: string) => boolean;
 	heads: (gid?: string) => string[];
 	has_head: (gid?: string) => boolean;
@@ -699,6 +709,26 @@ export class LogGraphIndex {
 			return [];
 		}
 		const builder = this.getPlainEntryBuilder(input);
+		if (!input.nexts) {
+			const noNextCommit =
+				this.native
+					.prepare_entry_v0_plain_entries_no_next_commit_blocks_and_put_with_builder;
+			if (noNextCommit) {
+				return committedPlainEntryRows(
+					noNextCommit.call(
+						this.native,
+						builder,
+						nativeBlockStore,
+						columns.wallTimes,
+						columns.logicals,
+						input.gids,
+						input.type ?? 0,
+						columns.metaDatas,
+						input.payloadDatas,
+					),
+				);
+			}
+		}
 		return committedPlainEntryRows(
 			this.native.prepare_entry_v0_plain_entries_commit_blocks_and_put_with_builder(
 				builder,
@@ -706,7 +736,7 @@ export class LogGraphIndex {
 				columns.wallTimes,
 				columns.logicals,
 				input.gids,
-				input.nexts,
+				input.nexts ?? input.payloadDatas.map(() => []),
 				input.type ?? 0,
 				columns.metaDatas,
 				input.payloadDatas,
@@ -1066,7 +1096,7 @@ export type EntryV0PlainEntriesInput = {
 	wallTimes: Array<bigint | number | string>;
 	logicals?: number[];
 	gids: string[];
-	nexts: string[][];
+	nexts?: string[][];
 	type?: number;
 	metaDatas?: Array<Uint8Array | undefined>;
 	payloadDatas: Uint8Array[];
@@ -1138,7 +1168,7 @@ const plainEntriesInputColumns = (input: EntryV0PlainEntriesInput) => {
 	if (
 		input.wallTimes.length !== input.payloadDatas.length ||
 		input.gids.length !== input.payloadDatas.length ||
-		input.nexts.length !== input.payloadDatas.length
+		(input.nexts && input.nexts.length !== input.payloadDatas.length)
 	) {
 		throw new Error("Expected equal column lengths");
 	}

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -1091,6 +1091,35 @@ impl NativeLogIndex {
         Ok(rows)
     }
 
+    pub fn prepare_entry_v0_plain_entries_no_next_commit_blocks_and_put_with_builder(
+        &mut self,
+        builder: &NativeEntryV0PlainBuilder,
+        block_store: &mut NativeLogBlockStore,
+        wall_times: BigUint64Array,
+        logicals: Uint32Array,
+        gids: Array,
+        entry_type: u8,
+        meta_datas: Array,
+        payload_datas: Array,
+    ) -> Result<Array, JsValue> {
+        let (rows, entries, blocks) = prepare_entry_v0_plain_entries_rows_with_signer_inner(
+            &builder.clock_id,
+            &builder.public_key,
+            &builder.signing_key,
+            wall_times,
+            logicals,
+            gids,
+            None,
+            entry_type,
+            meta_datas,
+            payload_datas,
+            false,
+        )?;
+        block_store.put_entries(blocks);
+        self.inner.put_many(entries);
+        Ok(rows)
+    }
+
     pub fn delete(&mut self, hash: &str) -> bool {
         self.inner.delete(hash).is_some()
     }
@@ -1595,6 +1624,34 @@ fn prepare_entry_v0_plain_entry_row_with_signer(
     let next = strings_from_array(next)?;
     let payload_data = payload_data.to_vec();
     let meta_data = optional_bytes_from_js(meta_data);
+    prepare_entry_v0_plain_entry_row_with_signer_parts(
+        clock_id,
+        public_key,
+        signing_key,
+        wall_time,
+        logical,
+        gid,
+        next,
+        entry_type,
+        meta_data,
+        payload_data,
+        include_storage_bytes,
+    )
+}
+
+fn prepare_entry_v0_plain_entry_row_with_signer_parts(
+    clock_id: &[u8],
+    public_key: &[u8],
+    signing_key: &SigningKey,
+    wall_time: u64,
+    logical: u32,
+    gid: String,
+    next: Vec<String>,
+    entry_type: u8,
+    meta_data: Option<Vec<u8>>,
+    payload_data: Vec<u8>,
+    include_storage_bytes: bool,
+) -> Result<(Array, LogIndexEntry, Vec<String>, (String, Vec<u8>)), JsValue> {
     let payload_size = payload_data.len() as u32;
 
     let input = EntryV0EncodeInput {
@@ -1669,9 +1726,42 @@ fn prepare_entry_v0_plain_entries_rows_with_signer(
     payload_datas: Array,
     include_storage_bytes: bool,
 ) -> Result<(Array, Vec<LogIndexEntry>, Vec<(String, Vec<u8>)>), JsValue> {
+    prepare_entry_v0_plain_entries_rows_with_signer_inner(
+        clock_id,
+        public_key,
+        signing_key,
+        wall_times,
+        logicals,
+        gids,
+        Some(nexts),
+        entry_type,
+        meta_datas,
+        payload_datas,
+        include_storage_bytes,
+    )
+}
+
+fn prepare_entry_v0_plain_entries_rows_with_signer_inner(
+    clock_id: &[u8],
+    public_key: &[u8],
+    signing_key: &SigningKey,
+    wall_times: BigUint64Array,
+    logicals: Uint32Array,
+    gids: Array,
+    nexts: Option<Array>,
+    entry_type: u8,
+    meta_datas: Array,
+    payload_datas: Array,
+    include_storage_bytes: bool,
+) -> Result<(Array, Vec<LogIndexEntry>, Vec<(String, Vec<u8>)>), JsValue> {
     let len = payload_datas.length();
-    if gids.length() != len || nexts.length() != len || meta_datas.length() != len {
+    if gids.length() != len || meta_datas.length() != len {
         return Err(JsValue::from_str("Expected equal column lengths"));
+    }
+    if let Some(nexts) = &nexts {
+        if nexts.length() != len {
+            return Err(JsValue::from_str("Expected equal column lengths"));
+        }
     }
     for numeric_len in [wall_times.length(), logicals.length()] {
         if numeric_len != len {
@@ -1684,19 +1774,24 @@ fn prepare_entry_v0_plain_entries_rows_with_signer(
     let mut blocks = Vec::with_capacity(len as usize);
     for i in 0..len {
         let payload_data = required_bytes_from_array(&payload_datas, i, "payload")?;
-        let (row, entry, _initial_nexts, block) = prepare_entry_v0_plain_entry_row_with_signer(
-            clock_id,
-            public_key,
-            signing_key,
-            wall_times.get_index(i),
-            logicals.get_index(i),
-            required_string_from_array(&gids, i)?,
-            required_array_from_array(&nexts, i)?,
-            entry_type,
-            meta_datas.get(i),
-            Uint8Array::from(payload_data.as_slice()),
-            include_storage_bytes,
-        )?;
+        let next = match &nexts {
+            Some(nexts) => strings_from_array(required_array_from_array(nexts, i)?)?,
+            None => Vec::new(),
+        };
+        let (row, entry, _initial_nexts, block) =
+            prepare_entry_v0_plain_entry_row_with_signer_parts(
+                clock_id,
+                public_key,
+                signing_key,
+                wall_times.get_index(i),
+                logicals.get_index(i),
+                required_string_from_array(&gids, i)?,
+                next,
+                entry_type,
+                optional_bytes_from_js(meta_datas.get(i)),
+                payload_data,
+                include_storage_bytes,
+            )?;
         out.push(&row);
         entries.push(entry);
         blocks.push(block);

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -647,7 +647,6 @@ describe("native EntryV0 encoding", () => {
 				publicKey,
 				wallTimes: [11n, 12n, 13n],
 				gids: ["gid-a", "gid-b", "gid-c"],
-				nexts: [[], [], []],
 				payloadDatas: [
 					new Uint8Array([1]),
 					new Uint8Array([2]),

--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -71,7 +71,7 @@ type NativePlainEntriesInput = {
 	wallTimes: Array<bigint | number | string>;
 	logicals?: number[];
 	gids: string[];
-	nexts: string[][];
+	nexts?: string[][];
 	type?: number;
 	metaDatas?: Array<Uint8Array | undefined>;
 	payloadDatas: Uint8Array[];
@@ -629,7 +629,7 @@ export class EntryV0<T>
 		meta: {
 			clocks: () => Clock[];
 			gids: string[];
-			nexts: SortableEntry[][];
+			nexts?: SortableEntry[][];
 			type?: EntryType;
 			datas?: Array<Uint8Array | undefined>;
 		};
@@ -652,7 +652,8 @@ export class EntryV0<T>
 		}
 		if (
 			properties.meta.gids.length !== properties.data.length ||
-			properties.meta.nexts.length !== properties.data.length ||
+			(properties.meta.nexts &&
+				properties.meta.nexts.length !== properties.data.length) ||
 			(properties.payloadDatas &&
 				properties.payloadDatas.length !== properties.data.length)
 		) {
@@ -664,7 +665,7 @@ export class EntryV0<T>
 			throw new Error("Expected one clock per entry");
 		}
 		for (let i = 0; i < clocks.length; i++) {
-			for (const next of properties.meta.nexts[i]!) {
+			for (const next of properties.meta.nexts?.[i] ?? []) {
 				if (
 					Timestamp.compare(next.meta.clock.timestamp, clocks[i]!.timestamp) >=
 					0
@@ -689,7 +690,7 @@ export class EntryV0<T>
 			wallTimes: clocks.map((clock) => clock.timestamp.wallTime),
 			logicals: clocks.map((clock) => clock.timestamp.logical),
 			gids: properties.meta.gids,
-			nexts: properties.meta.nexts.map((nexts) =>
+			nexts: properties.meta.nexts?.map((nexts) =>
 				nexts.map((next) => next.hash),
 			),
 			type: properties.meta.type,

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -1042,7 +1042,6 @@ export class Log<T> {
 					meta: {
 						clocks: () => clocks,
 						gids,
-						nexts: data.map(() => []),
 						type: options.meta?.type,
 						datas: metaDatas,
 					},


### PR DESCRIPTION
## Summary
- keep independent batch payload bytes in Rust instead of bouncing them through a JS Uint8Array before encoding/signing
- add a native no-next independent batch commit entrypoint for batches where every appended entry has no parent
- let the internal plain independent batch append shape omit `nexts`, avoiding `data.map(() => [])` and per-entry empty-array parsing
- update log-rust coverage so the independent batch test exercises the no-next path

## Performance
Local document putMany benchmark, 2026-05-11:

```
DOC_WARMUP=20 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-putmany,rust-peerbit-transient-index-putmany DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

- parent #919 `rust-peerbit-putmany`: 5746 ops/sec, total 174.02 ms, `logCreateNativeAppendChainMs` 71.57 ms
- this branch `rust-peerbit-putmany`: 5670 ops/sec, total 176.38 ms, `logCreateNativeAppendChainMs` 68.33 ms
- parent #919 `rust-peerbit-transient-index-putmany`: 7210 ops/sec, total 138.71 ms, `logCreateNativeAppendChainMs` 63.47 ms
- this branch `rust-peerbit-transient-index-putmany`: 6855 ops/sec, total 145.87 ms, `logCreateNativeAppendChainMs` 63.92 ms

The targeted append-chain metric improves in the persistent run, but document-level throughput is still noisy and not clearly improved. The remaining cost is mostly signing/encoding/block commit plus TS Entry materialization required by the current public return shape.

## Test Plan
- `pnpm --filter @peerbit/log-rust run build`
- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `cargo test --manifest-path packages/log/rust/Cargo.toml`
- `cargo fmt --manifest-path packages/log/rust/Cargo.toml --check`
- `pnpm --filter @peerbit/log-rust exec aegir test -t node --grep "commits independent prepared plain entry batches natively"`
- `pnpm exec eslint --config eslint.config.js packages/log/src/entry-v0.ts packages/log/src/log.ts packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts`
- `git diff --check`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "independent native prepared batch path|batches rust index"`