### PR TITLE
Batch document head removals through native index

### DIFF
--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -1230,7 +1230,16 @@ export class Documents<
 			);
 		}
 
+		const handledRemovedHeads =
+			await this.collectRemovedDocumentChangesFromIndexedHeads(
+				properties.removed,
+				modified,
+				documentsChanged,
+			);
 		for (const removed of properties.removed) {
+			if (handledRemovedHeads.has(removed.hash)) {
+				continue;
+			}
 			if (
 				!(removed instanceof Entry) &&
 				(await this.collectRemovedDocumentChangeFromIndexedHead(
@@ -1291,6 +1300,48 @@ export class Documents<
 		await this._index.del(key);
 		modified.add(key.primitive);
 		return true;
+	}
+
+	private async collectRemovedDocumentChangesFromIndexedHeads(
+		removed: ShallowOrFullEntry<Operation>[],
+		modified: Set<string | number | bigint>,
+		documentsChanged: DocumentsChange<T, I>,
+	): Promise<Set<string>> {
+		const shallowRemoved = removed.filter(
+			(entry): entry is ShallowEntry => !(entry instanceof Entry),
+		);
+		if (shallowRemoved.length === 0) {
+			return new Set();
+		}
+		const indexedByHead = await this._index.getIdentityIndexedByHeads(
+			shallowRemoved.map((entry) => entry.hash),
+		);
+		if (!indexedByHead) {
+			return new Set();
+		}
+
+		const handled = new Set<string>();
+		const deleteKeys: indexerTypes.IdKey[] = [];
+		for (let i = 0; i < shallowRemoved.length; i++) {
+			const indexed = indexedByHead[i];
+			if (!indexed) {
+				continue;
+			}
+			const key = indexed.id;
+			handled.add(shallowRemoved[i]!.hash);
+			if (modified.has(key.primitive)) {
+				continue;
+			}
+			const value = coerceWithIndexed(
+				indexed.value as unknown as WithIndexedContext<T, I>,
+				indexed.value as unknown as I,
+			);
+			documentsChanged.removed.push(value);
+			deleteKeys.push(key);
+			modified.add(key.primitive);
+		}
+		await this._index.delMany(deleteKeys);
+		return handled;
 	}
 
 	private async collectRemovedDocumentChange(

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -728,6 +728,15 @@ type ContextHeadIndex<I> = {
 	getByContextHead?: (
 		head: string,
 	) => indexerTypes.IndexedResult<WithContext<I>> | undefined;
+	getByContextHeadBatch?: (
+		heads: string[],
+	) => Array<indexerTypes.IndexedResult<WithContext<I>> | undefined>;
+};
+
+type ExactDeleteIndex = {
+	delIds?: (
+		deleteIds: Array<indexerTypes.IdKey | indexerTypes.Ideable>,
+	) => Promise<indexerTypes.IdKey[]> | indexerTypes.IdKey[];
 };
 
 export const coerceWithContext = <T>(
@@ -1718,6 +1727,21 @@ export class DocumentIndex<
 		return (this.index as ContextHeadIndex<I>).getByContextHead?.(head);
 	}
 
+	public async getIdentityIndexedByHeads(
+		heads: string[],
+	): Promise<
+		Array<indexerTypes.IndexedResult<WithContext<I>> | undefined> | undefined
+	> {
+		if (!this.canGetIdentityIndexedByHead()) {
+			return;
+		}
+		const batch = (this.index as ContextHeadIndex<I>).getByContextHeadBatch;
+		if (batch) {
+			return batch.call(this.index, heads);
+		}
+		return Promise.all(heads.map((head) => this.getIdentityIndexedByHead(head)));
+	}
+
 	public canGetIdentityIndexedByHead(): boolean {
 		return (
 			this.transformerIsIdentity &&
@@ -1990,6 +2014,26 @@ export class DocumentIndex<
 		return this.index.del({
 			query: [indexerTypes.getMatcher(this.indexBy, key.key)],
 		});
+	}
+
+	public async delMany(keys: indexerTypes.IdKey[]): Promise<void> {
+		if (keys.length === 0) {
+			return;
+		}
+		for (const key of keys) {
+			if (this.isProgramValued) {
+				this._resolverProgramCache!.delete(key.primitive);
+				indexCacheLogger("cache:del:program", { id: key.primitive });
+			} else if (this._resolverCache?.del(key.primitive)) {
+				indexCacheLogger("cache:del:value", { id: key.primitive });
+			}
+		}
+		const delIds = (this.index as ExactDeleteIndex).delIds;
+		if (delIds) {
+			await delIds.call(this.index, keys);
+			return;
+		}
+		await Promise.all(keys.map((key) => this.del(key)));
 	}
 
 	public async getDetailed<

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -79,6 +79,10 @@ type NativeRustIndex<T extends Record<string, any>> = {
 		offset: number,
 		limit: number,
 	) => Array<[types.IdKey, T]>;
+	query_exact_string_first_batch?: (
+		field: number,
+		values: string[],
+	) => Array<[types.IdKey, T] | undefined>;
 	count: (query: Uint8Array) => number;
 	sum: (query: Uint8Array, field: number) => [NativeSumKind, string];
 	delete_matching: (query: Uint8Array) => Array<[types.IdKey, T]>;
@@ -1633,6 +1637,27 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			1,
 		)[0];
 		return result ? { id: result[0], value: result[1] } : undefined;
+	}
+
+	getByContextHeadBatch(
+		heads: string[],
+	): Array<types.IndexedResult<T> | undefined> {
+		if (heads.length === 0) {
+			return [];
+		}
+		const native = this.getNative();
+		const nativeBatch = native.query_exact_string_first_batch;
+		if (!nativeBatch) {
+			return heads.map((head) => this.getByContextHead(head));
+		}
+		const rows = nativeBatch.call(
+			native,
+			nativeFieldId(this.fieldDictionary, ["__context", "head"]),
+			heads,
+		);
+		return rows.map((result) =>
+			result ? { id: result[0], value: result[1] } : undefined,
+		);
 	}
 
 	async put(

--- a/packages/utils/indexer/rust/src/lib.rs
+++ b/packages/utils/indexer/rust/src/lib.rs
@@ -333,6 +333,24 @@ impl NativeRustIndex {
         Ok(self.store.entries_for_keys(&keys))
     }
 
+    pub fn query_exact_string_first_batch(&self, field: u32, values: Array) -> Array {
+        let out = Array::new();
+        let field = FieldPath::Id(field);
+        for value in values.iter() {
+            let entry = value
+                .as_string()
+                .and_then(|value| {
+                    self.planner
+                        .index
+                        .exact_first(&field, &FieldValue::String(value))
+                })
+                .map(|key| self.store.get(&key))
+                .unwrap_or(JsValue::UNDEFINED);
+            out.push(&entry);
+        }
+        out
+    }
+
     pub fn count(&self, query_bytes: Vec<u8>) -> Result<usize, JsValue> {
         self.planner.count(query_bytes)
     }

--- a/packages/utils/indexer/rust/src/planner.rs
+++ b/packages/utils/indexer/rust/src/planner.rs
@@ -438,6 +438,17 @@ impl NativeQueryIndex {
         self.search_page(query, sort, 0, limit)
     }
 
+    pub fn exact_first(&self, field: &FieldPath, value: &FieldValue) -> Option<String> {
+        self.exact
+            .get(field)
+            .and_then(|values| values.get(value))
+            .and_then(|matches| {
+                matches
+                    .iter()
+                    .find_map(|doc_id| self.internal_to_external.get(&doc_id).cloned())
+            })
+    }
+
     pub fn search_page(
         &self,
         query: &Query,

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -632,6 +632,72 @@ describe("native planner bridge", () => {
 		await indices.drop();
 	});
 
+	it("batch resolves contextual documents by head through the native index hook", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeDocumentWithContext });
+		const contextualIndex = index as typeof index & {
+			putWithContextBatch: (
+				values: Array<{
+					value: BridgeDocument;
+					id: ReturnType<typeof toId>;
+					context: BridgeContext;
+					options?: {
+						replace?: boolean;
+						encodedValueParts?: { prefix: Uint8Array; suffix: Uint8Array };
+					};
+				}>,
+			) => Promise<void>;
+			getByContextHeadBatch: (
+				heads: string[],
+			) => Array<
+				| { id: ReturnType<typeof toId>; value: BridgeDocumentWithContext }
+				| undefined
+			>;
+		};
+		const first = new BridgeDocument("a", "peerbit", "first");
+		const second = new BridgeDocument("b", "peerbit", "second");
+		const firstContext = new BridgeContext("head-a");
+		const secondContext = new BridgeContext("head-b");
+		await contextualIndex.putWithContextBatch([
+			{
+				value: first,
+				id: toId("a"),
+				context: firstContext,
+				options: {
+					encodedValueParts: {
+						prefix: serialize(first),
+						suffix: serialize(firstContext),
+					},
+				},
+			},
+			{
+				value: second,
+				id: toId("b"),
+				context: secondContext,
+				options: {
+					encodedValueParts: {
+						prefix: serialize(second),
+						suffix: serialize(secondContext),
+					},
+				},
+			},
+		]);
+
+		const resolved = contextualIndex.getByContextHeadBatch([
+			"head-b",
+			"missing",
+			"head-a",
+		]);
+		expect(resolved.map((entry) => entry?.id.primitive)).to.deep.equal([
+			"b",
+			undefined,
+			"a",
+		]);
+
+		await indices.drop();
+	});
+
 	it("keeps exact byte matching for large byte arrays without indexing every byte by default", async () => {
 		const indices = create();
 		await indices.start();


### PR DESCRIPTION
## Summary
- add a native batch exact-string lookup bridge for Rust index fields
- expose `RustIndex.getByContextHeadBatch` for contextual document indexes
- add `DocumentIndex.getIdentityIndexedByHeads` and exact-id-backed `delMany`
- use the batch contextual-head path when prepared document putMany handles shallow trimmed removals

## Performance
Local document putMany benchmark, 2026-05-11:

```
DOC_WARMUP=20 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-putmany,rust-peerbit-transient-index-putmany DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

- parent #920 `rust-peerbit-putmany`: 5670 ops/sec, total 176.38 ms
- this branch run 1 `rust-peerbit-putmany`: 5811 ops/sec, total 172.10 ms
- this branch run 2 `rust-peerbit-putmany`: 5657 ops/sec, total 176.79 ms
- parent #920 `rust-peerbit-transient-index-putmany`: 6855 ops/sec, total 145.87 ms
- this branch run 1 `rust-peerbit-transient-index-putmany`: 7470 ops/sec, total 133.87 ms
- this branch run 2 `rust-peerbit-transient-index-putmany`: 7197 ops/sec, total 138.95 ms

Persistent is roughly neutral/noisy. Transient-index improves in both local runs, which is consistent with fewer JS calls around trim/removal handling.

## Test Plan
- `pnpm --filter @peerbit/indexer-rust run build`
- `cargo test --manifest-path packages/utils/indexer/rust/Cargo.toml`
- `pnpm --filter @peerbit/indexer-rust exec aegir test -t node --grep "batch resolves contextual documents by head"`
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "independent native prepared batch path|batches rust index"`
- `pnpm exec eslint --config eslint.config.js packages/utils/indexer/rust/src/index.ts packages/utils/indexer/rust/test/index.spec.ts packages/programs/data/document/document/src/search.ts packages/programs/data/document/document/src/program.ts`
- `cargo fmt --manifest-path packages/utils/indexer/rust/Cargo.toml --check`
- `git diff --check`