### PR TITLE
Lazily materialize native prepared entry signatures

### DIFF
--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -719,11 +719,14 @@ export class EntryV0<T>
 		const entryType = properties.meta.type ?? EntryType.APPEND;
 		for (let index = 0; index < prepared.length; index++) {
 			const preparedEntry = prepared[index]!;
+			const clock = clocks[index]!;
+			const entryGid = properties.meta.gids[index]!;
+			const metaData = properties.meta.datas?.[index];
 			const meta = new Meta({
-				clock: clocks[index]!,
-				gid: properties.meta.gids[index]!,
+				clock,
+				gid: entryGid,
 				type: entryType,
-				data: properties.meta.datas?.[index],
+				data: metaData,
 				next: preparedEntry.next,
 			});
 			const payload = new Payload<T>({
@@ -731,11 +734,14 @@ export class EntryV0<T>
 				value: properties.data[index],
 				encoding: properties.encoding,
 			});
-			const signature = new SignatureWithKey({
-				signature: preparedEntry.signature,
-				publicKey: properties.identity.publicKey,
-				prehash: 0,
-			});
+			const signature =
+				properties.cachePreparedEntries === false
+					? undefined
+					: new SignatureWithKey({
+							signature: preparedEntry.signature,
+							publicKey: properties.identity.publicKey,
+							prehash: 0,
+						});
 			const entry = new EntryV0<T>({
 				meta: new DecryptedThing({
 					data: preparedEntry.metaBytes,
@@ -774,11 +780,11 @@ export class EntryV0<T>
 				payloadSize: payload.byteLength,
 				head: true,
 				meta: new ShallowMeta({
-					gid: meta.gid,
-					data: meta.data,
-					clock: meta.clock,
-					next: meta.next,
-					type: meta.type,
+					gid: entryGid,
+					data: metaData,
+					clock,
+					next: preparedEntry.next,
+					type: entryType,
 				}),
 			});
 			const nativeEntry =
@@ -786,16 +792,16 @@ export class EntryV0<T>
 					? undefined
 					: {
 							hash: entry.hash,
-							gid: meta.gid,
-							next: meta.next,
-							type: meta.type,
+							gid: entryGid,
+							next: preparedEntry.next,
+							type: entryType,
 							head: true,
 							payloadSize: payload.byteLength,
-							data: meta.data,
+							data: metaData,
 							clock: {
 								timestamp: {
-									wallTime: meta.clock.timestamp.wallTime,
-									logical: meta.clock.timestamp.logical,
+									wallTime: clock.timestamp.wallTime,
+									logical: clock.timestamp.logical,
 								},
 							},
 						};
@@ -1041,8 +1047,9 @@ export class EntryV0<T>
 
 		for (let index = 0; index < prepared.length; index++) {
 			const preparedEntry = prepared[index]!;
+			const clock = clocks[index]!;
 			const meta = new Meta({
-				clock: clocks[index]!,
+				clock,
 				gid: gid!,
 				type: entryType,
 				data: properties.meta?.data,
@@ -1053,11 +1060,14 @@ export class EntryV0<T>
 				value: properties.data[index],
 				encoding: properties.encoding,
 			});
-			const signature = new SignatureWithKey({
-				signature: preparedEntry.signature,
-				publicKey: properties.identity.publicKey,
-				prehash: 0,
-			});
+			const signature =
+				properties.cachePreparedEntries === false
+					? undefined
+					: new SignatureWithKey({
+							signature: preparedEntry.signature,
+							publicKey: properties.identity.publicKey,
+							prehash: 0,
+						});
 			const entry = new EntryV0<T>({
 				meta: new DecryptedThing({
 					data: preparedEntry.metaBytes,
@@ -1100,11 +1110,11 @@ export class EntryV0<T>
 				payloadSize: payload.byteLength,
 				head: index === prepared.length - 1,
 				meta: new ShallowMeta({
-					gid: meta.gid,
-					data: meta.data,
-					clock: meta.clock,
-					next: meta.next,
-					type: meta.type,
+					gid: gid!,
+					data: properties.meta?.data,
+					clock,
+					next: preparedEntry.next,
+					type: entryType,
 				}),
 			});
 			const nativeEntry =
@@ -1112,16 +1122,16 @@ export class EntryV0<T>
 					? undefined
 					: {
 							hash: entry.hash,
-							gid: meta.gid,
-							next: meta.next,
-							type: meta.type,
+							gid: gid!,
+							next: preparedEntry.next,
+							type: entryType,
 							head: index === prepared.length - 1,
 							payloadSize: payload.byteLength,
-							data: meta.data,
+							data: properties.meta?.data,
 							clock: {
 								timestamp: {
-									wallTime: meta.clock.timestamp.wallTime,
-									logical: meta.clock.timestamp.logical,
+									wallTime: clock.timestamp.wallTime,
+									logical: clock.timestamp.logical,
 								},
 							},
 						};

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -399,6 +399,7 @@ describe("index", () => {
 						.equal(3);
 					expect(appended.entries.every((entry) => entry.meta.next.length === 0))
 						.equal(true);
+					expect(await appended.entries[0]!.verifySignatures()).equal(true);
 					const reloaded = await Entry.fromMultihash<Operation>(
 						store.docs.log.log.blocks,
 						appended.entries[0]!.hash,


### PR DESCRIPTION
## Summary
- avoid constructing `SignatureWithKey` objects for native-prepared entries when `cachePreparedEntries: false`
- keep encoded signature bytes and deserialize signatures lazily when public `Entry.signatures` / `verifySignatures()` is used
- keep `Meta` and `Payload` materialized because shared-log still uses them on the hot path
- add document fast-path coverage proving returned native-prepared batch entries still verify signatures

## Performance
Local document putMany benchmark, 2026-05-11:

```
DOC_WARMUP=20 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-putmany,rust-peerbit-transient-index-putmany DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

- parent #921 reference `rust-peerbit-putmany`: 5657-5811 ops/sec, total 172.10-176.79 ms
- this branch `rust-peerbit-putmany`: 5747 ops/sec, total 174.00 ms
- parent #921 reference `rust-peerbit-transient-index-putmany`: 7197-7470 ops/sec, total 133.87-138.95 ms
- this branch `rust-peerbit-transient-index-putmany`: 7346 ops/sec, total 136.13 ms

This is neutral in the product benchmark, but removes unnecessary signature object allocation from the native-prepared append path.

## Test Plan
- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "independent native prepared batch path"`
- `pnpm exec eslint --config eslint.config.js packages/log/src/entry-v0.ts packages/programs/data/document/document/test/index.spec.ts` (passes with one pre-existing unrelated warning in document test)
- `git diff --check`