### PR TITLE
Avoid eager prepared payload materialization

### DIFF
--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -729,11 +729,15 @@ export class EntryV0<T>
 				data: metaData,
 				next: preparedEntry.next,
 			});
-			const payload = new Payload<T>({
-				data: payloadDatas[index]!,
-				value: properties.data[index],
-				encoding: properties.encoding,
-			});
+			const payloadSize = payloadDatas[index]!.byteLength;
+			const payload =
+				properties.cachePreparedEntries === false
+					? undefined
+					: new Payload<T>({
+							data: payloadDatas[index]!,
+							value: properties.data[index],
+							encoding: properties.encoding,
+						});
 			const signature =
 				properties.cachePreparedEntries === false
 					? undefined
@@ -777,7 +781,7 @@ export class EntryV0<T>
 			entry._hashDigestBytes = preparedEntry.hashDigestBytes;
 			const shallowEntry = new ShallowEntry({
 				hash: entry.hash,
-				payloadSize: payload.byteLength,
+				payloadSize,
 				head: true,
 				meta: new ShallowMeta({
 					gid: entryGid,
@@ -796,7 +800,7 @@ export class EntryV0<T>
 							next: preparedEntry.next,
 							type: entryType,
 							head: true,
-							payloadSize: payload.byteLength,
+							payloadSize,
 							data: metaData,
 							clock: {
 								timestamp: {
@@ -1055,11 +1059,15 @@ export class EntryV0<T>
 				data: properties.meta?.data,
 				next: preparedEntry.next,
 			});
-			const payload = new Payload<T>({
-				data: payloadDatas[index]!,
-				value: properties.data[index],
-				encoding: properties.encoding,
-			});
+			const payloadSize = payloadDatas[index]!.byteLength;
+			const payload =
+				properties.cachePreparedEntries === false
+					? undefined
+					: new Payload<T>({
+							data: payloadDatas[index]!,
+							value: properties.data[index],
+							encoding: properties.encoding,
+						});
 			const signature =
 				properties.cachePreparedEntries === false
 					? undefined
@@ -1107,7 +1115,7 @@ export class EntryV0<T>
 			entry._hashDigestBytes = preparedEntry.hashDigestBytes;
 			const shallowEntry = new ShallowEntry({
 				hash: entry.hash,
-				payloadSize: payload.byteLength,
+				payloadSize,
 				head: index === prepared.length - 1,
 				meta: new ShallowMeta({
 					gid: gid!,
@@ -1126,7 +1134,7 @@ export class EntryV0<T>
 							next: preparedEntry.next,
 							type: entryType,
 							head: index === prepared.length - 1,
-							payloadSize: payload.byteLength,
+							payloadSize,
 							data: properties.meta?.data,
 							clock: {
 								timestamp: {

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -154,6 +154,16 @@ export type AppendOptions<T> = {
 	canAppend?: CanAppend<T>;
 };
 
+export type PreparedAppendFacts = {
+	hash: string;
+	gid: string;
+	next: string[];
+	wallTime: bigint;
+	logical: number;
+	payloadSize: number;
+	metaBytes?: Uint8Array;
+};
+
 type OnChange<T> = (
 	change: Change<T>,
 	reference?: undefined,
@@ -179,6 +189,10 @@ export const ENTRY_JOIN_SHAPE = {
 type PendingDelete<T> = {
 	entry: ShallowOrFullEntry<T>;
 	fn: () => Promise<ShallowEntry | undefined>;
+};
+
+type EntryWithMetaBytes = {
+	getMetaBytes?: () => Uint8Array | undefined;
 };
 
 @variant(0)
@@ -778,6 +792,7 @@ export class Log<T> {
 				entries: Entry<T>[];
 				removed: ShallowOrFullEntry<T>[];
 				change: Change<T>;
+				appendFacts: PreparedAppendFacts[];
 		  }
 		| undefined
 	> {
@@ -786,6 +801,7 @@ export class Log<T> {
 				entries: [],
 				removed: [],
 				change: { added: [], removed: [] },
+				appendFacts: [],
 			};
 		}
 		if (
@@ -847,8 +863,41 @@ export class Log<T> {
 			added: entries.map((entry) => ({ head: true, entry })),
 			removed,
 		};
+		const appendFacts = this.createPreparedAppendFacts(
+			entries,
+			nativeAppendBatch,
+		);
 
-		return { entries, removed, change };
+		return { entries, removed, change, appendFacts };
+	}
+
+	private createPreparedAppendFacts(
+		entries: Entry<T>[],
+		prepared?: PreparedAppendChain<T>,
+	): PreparedAppendFacts[] {
+		return entries.map((entry, index) => {
+			const shallowEntry = prepared?.shallowEntries[index];
+			if (shallowEntry) {
+				return {
+					hash: shallowEntry.hash,
+					gid: shallowEntry.meta.gid,
+					next: shallowEntry.meta.next,
+					wallTime: shallowEntry.meta.clock.timestamp.wallTime,
+					logical: shallowEntry.meta.clock.timestamp.logical,
+					payloadSize: shallowEntry.payloadSize,
+					metaBytes: (entry as EntryWithMetaBytes).getMetaBytes?.(),
+				};
+			}
+			return {
+				hash: entry.hash,
+				gid: entry.meta.gid,
+				next: entry.meta.next,
+				wallTime: entry.meta.clock.timestamp.wallTime,
+				logical: entry.meta.clock.timestamp.logical,
+				payloadSize: entry.payload.byteLength,
+				metaBytes: (entry as EntryWithMetaBytes).getMetaBytes?.(),
+			};
+		});
 	}
 
 	async appendMany(

--- a/packages/log/test/append.spec.ts
+++ b/packages/log/test/append.spec.ts
@@ -283,6 +283,9 @@ describe("append", function () {
 
 			expect(result.entries).to.have.length(3);
 			expect(result.entries[0].meta.next).to.deep.equal([root.hash]);
+			expect(await result.entries[0].getPayloadValue()).to.deep.equal(
+				new Uint8Array([1]),
+			);
 			expect(
 				(await log.getHeads().all()).map((head) => head.hash),
 			).to.deep.equal([result.entries[2].hash]);
@@ -357,6 +360,7 @@ describe("append", function () {
 			expect(blockPutSpy.callCount).equal(0);
 			expect(blockPutManySpy.callCount).equal(0);
 			expect(preparedBlockFromBytesSpy.callCount).equal(0);
+			expect(await entry.getPayloadValue()).to.deep.equal(new Uint8Array([1]));
 			expect(await nativeStore.has(entry.hash)).to.equal(true);
 			expect((await log.getHeads().all()).map((head) => head.hash)).to.deep.equal([
 				entry.hash,

--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -1191,6 +1191,7 @@ export class Documents<
 			encodedDocument?: Uint8Array;
 			key: indexerTypes.IdKey;
 			context: Context;
+			contextualEncodedValueParts?: ContextualEncodedValueParts;
 		}> = [];
 		for (const put of properties.puts) {
 			if (modified.has(put.key.primitive)) {
@@ -1203,11 +1204,18 @@ export class Documents<
 				gid: put.append.gid,
 				size: put.append.payloadSize,
 			});
+			const contextBytes = encodeContextSuffix(context);
 			putsToIndex.push({
 				document: put.document,
 				encodedDocument: put.encodedDocument,
 				key: put.key,
 				context,
+				contextualEncodedValueParts: put.encodedDocument
+					? {
+							prefix: put.encodedDocument,
+							suffix: contextBytes,
+						}
+					: undefined,
 			});
 			modified.add(put.key.primitive);
 		}
@@ -1218,7 +1226,7 @@ export class Documents<
 				context: put.context,
 				options: {
 					replace: false,
-					encodedValue: put.encodedDocument,
+					encodedValueParts: put.contextualEncodedValueParts,
 				},
 			})),
 		);

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -460,6 +460,10 @@ describe("index", () => {
 					backendIndex,
 					"putWithContextBatch",
 				);
+				const encodeContextualPartsSpy = sinon.spy(
+					store.docs.index as any,
+					"encodeContextualIndexedValueParts",
+				);
 				const coordinateIndex = store.docs.log.entryCoordinatesIndex as any;
 				const coordinateBatchSpy = sinon.spy(
 					coordinateIndex,
@@ -504,6 +508,7 @@ describe("index", () => {
 							batchValues[i]!.options!.encodedValueParts!.suffix.byteLength,
 						).greaterThan(0);
 					}
+					expect(encodeContextualPartsSpy.callCount).equal(0);
 					expect(coordinateBatchSpy.callCount).equal(1);
 					expect(coordinatePutSpy.callCount).equal(0);
 					expect(changes).to.have.length(1);
@@ -513,6 +518,7 @@ describe("index", () => {
 				} finally {
 					coordinatePutSpy.restore();
 					coordinateBatchSpy.restore();
+					encodeContextualPartsSpy.restore();
 					documentBackendBatchSpy.restore();
 					await store.close();
 					store = undefined;

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -42,6 +42,7 @@ import {
 	type LogEvents,
 	type LogProperties,
 	Meta,
+	type PreparedAppendFacts,
 	ShallowEntry,
 	type ShallowOrFullEntry,
 } from "@peerbit/log";
@@ -4216,7 +4217,10 @@ export class SharedLog<
 			return {
 				entries: result.entries,
 				removed: result.removed,
-				appendCommits: this.createPreparedLocalAppendCommits(result.entries),
+				appendCommits: this.createPreparedLocalAppendCommitsFromFacts(
+					result.appendFacts,
+					result.entries,
+				),
 			};
 		}
 
@@ -4247,7 +4251,8 @@ export class SharedLog<
 			return {
 				entries: result.entries,
 				removed: result.removed,
-				appendCommits: this.createPreparedLocalAppendCommits(
+				appendCommits: this.createPreparedLocalAppendCommitsFromFacts(
+					result.appendFacts,
 					result.entries,
 					nativeAppendPlans,
 				),
@@ -4273,7 +4278,8 @@ export class SharedLog<
 		return {
 			entries: result.entries,
 			removed: result.removed,
-			appendCommits: this.createPreparedLocalAppendCommits(
+			appendCommits: this.createPreparedLocalAppendCommitsFromFacts(
+				result.appendFacts,
 				result.entries,
 				nativeAppendPlans,
 			),
@@ -4841,6 +4847,23 @@ export class SharedLog<
 		};
 	}
 
+	private createPreparedLocalAppendCommitFromFacts(
+		appendFacts: PreparedAppendFacts,
+		nativeAppendPlan?: NativeAppendEntryPlan<R>,
+	): PreparedLocalAppendCommit<R> {
+		return {
+			hash: appendFacts.hash,
+			gid: appendFacts.gid,
+			next: appendFacts.next,
+			wallTime: appendFacts.wallTime,
+			logical: appendFacts.logical,
+			payloadSize: appendFacts.payloadSize,
+			metaBytes: appendFacts.metaBytes,
+			hashNumber: nativeAppendPlan?.hashNumber,
+			coordinateFields: nativeAppendPlan?.preparedCoordinate.fields,
+		};
+	}
+
 	private createPreparedLocalAppendCommits(
 		entries: Entry<T>[],
 		nativeAppendPlans?: Array<NativeAppendEntryPlan<R> | undefined>,
@@ -4848,6 +4871,22 @@ export class SharedLog<
 		return entries.map((entry, index) =>
 			this.createPreparedLocalAppendCommit(entry, nativeAppendPlans?.[index]),
 		);
+	}
+
+	private createPreparedLocalAppendCommitsFromFacts(
+		appendFacts: PreparedAppendFacts[] | undefined,
+		entries: Entry<T>[],
+		nativeAppendPlans?: Array<NativeAppendEntryPlan<R> | undefined>,
+	): PreparedLocalAppendCommit<R>[] {
+		if (appendFacts && appendFacts.length === entries.length) {
+			return appendFacts.map((facts, index) =>
+				this.createPreparedLocalAppendCommitFromFacts(
+					facts,
+					nativeAppendPlans?.[index],
+				),
+			);
+		}
+		return this.createPreparedLocalAppendCommits(entries, nativeAppendPlans);
 	}
 
 	async open(options?: Args<T, D, R>): Promise<void> {


### PR DESCRIPTION
## Summary
- add lower-log prepared batch append facts and let shared-log build batch append commits from those facts
- avoid constructing/caching decoded `Payload<T>` objects for no-cache native prepared entries
- prebuild document batch contextual encoded value parts before `DocumentIndex.putManyWithContext(...)`
- assert native prepared entries still lazily decode payload values through `getPayloadValue()` and batch document indexing no longer recomputes contextual parts

## Benchmark
Command:
`DOC_WARMUP=20 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-putmany,rust-peerbit-transient-index-putmany DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts`

After lazy prepared payloads:
- `rust-peerbit-putmany`: 5938 ops/sec, total 168.40 ms, shared append 150.23 ms, log append 117.42 ms, log create native append chain 67.31 ms, document index put 12.37 ms
- `rust-peerbit-transient-index-putmany`: 7420 ops/sec, total 134.78 ms, shared append 120.95 ms, log append 99.76 ms, log create native append chain 64.62 ms, document index put 8.75 ms

After also prebuilding document batch contextual value parts:
- `rust-peerbit-putmany`: 5639 ops/sec, total 177.33 ms, shared append 159.89 ms, log append 123.44 ms, log create native append chain 68.89 ms, document index put 10.40 ms
- `rust-peerbit-transient-index-putmany`: 7351 ops/sec, total 136.03 ms, shared append 121.30 ms, log append 99.20 ms, log create native append chain 65.02 ms, document index put 8.02 ms

Reference #922 local run:
- `rust-peerbit-putmany`: 5747 ops/sec, total 174.00 ms
- `rust-peerbit-transient-index-putmany`: 7346 ops/sec, total 136.13 ms

Read: total throughput is noisy run-to-run, but the targeted document index put column improved after prebuilt contextual parts. The deterministic wins are less JS payload materialization on the native no-cache path and no contextual byte-part recomputation inside the prepared putMany index path.

## Validation
- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "independent native prepared batch path|batches rust index"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "appendMany commits blocks and graph|append commits one block and graph"`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/test/index.spec.ts packages/log/src/log.ts packages/log/src/entry-v0.ts packages/log/test/append.spec.ts packages/programs/data/shared-log/src/index.ts` (passes with one existing unrelated warning at `document/test/index.spec.ts:4252`)
- `git diff --check`