### PR TITLE
Add native-shaped document batch commit boundary

### DIFF
--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -192,21 +192,45 @@ type DocumentAppendCommitFacts<T, I extends Record<string, any>> = {
 		| undefined;
 };
 
-type NativeDocumentAppendCommitInput<T, I extends Record<string, any>> = {
+type NativeDocumentAppendCommitFactsInput<
+	T,
+	I extends Record<string, any>,
+> = {
 	document: T;
 	key: indexerTypes.IdKey;
 	operation: PutOperation;
 	documentBytes: Uint8Array;
 	operationPayloadBytes: Uint8Array;
-	next: Entry<Operation>[] | ShallowEntry[];
-	skipMissingNextJoin: boolean;
-	resolveTrimmedEntries: boolean;
-	options?: DocumentPutOptions;
 	unique?: boolean;
 	existing?:
 		| indexerTypes.IndexedResult<IndexedContextOnly<I>>
 		| null
 		| undefined;
+};
+
+type NativeDocumentAppendCommitInput<
+	T,
+	I extends Record<string, any>,
+> = NativeDocumentAppendCommitFactsInput<T, I> & {
+	next: Entry<Operation>[] | ShallowEntry[];
+	skipMissingNextJoin: boolean;
+	resolveTrimmedEntries: boolean;
+	options?: DocumentPutOptions;
+};
+
+type NativeDocumentAppendManyCommitInput<
+	T,
+	I extends Record<string, any>,
+> = {
+	puts: NativeDocumentAppendCommitFactsInput<T, I>[];
+	resolveTrimmedEntries: boolean;
+	options?: DocumentPutOptions;
+};
+
+type DocumentAppendManyCommitFacts<T, I extends Record<string, any>> = {
+	entries: Entry<Operation>[];
+	removed: ShallowOrFullEntry<Operation>[];
+	commits: DocumentAppendCommitFacts<T, I>[];
 };
 
 type InferR<D> = D extends ReplicationDomain<any, any, infer I> ? I : "u32";
@@ -822,38 +846,33 @@ export class Documents<
 			return this.putManySequential(docs, options);
 		}
 
-		const appended = await this.log.appendLocallyPreparedManyIndependent(
-			prepared.map((item) => item.operation as PutOperation),
-			{
-				...options,
-				replicate: options?.replicate,
-			},
-			{
-				resolveTrimmedEntries: !this._index.canGetIdentityIndexedByHead(),
-				payloadDatas: prepared.map((item) =>
+		const documentAppendCommit = await this.commitNativeDocumentAppendMany({
+			puts: prepared.map((item) => ({
+				document: item.document,
+				key: item.key,
+				operation: item.operation as PutOperation,
+				documentBytes: item.encodedDocument,
+				operationPayloadBytes:
 					item.encodedOperation ??
 					encodePutOperationPayload((item.operation as PutOperation).data),
-				),
-			},
-		);
-		if (!appended) {
+				unique: options?.unique,
+				existing: null,
+			})),
+			resolveTrimmedEntries: !this._index.canGetIdentityIndexedByHead(),
+			options,
+		});
+		if (!documentAppendCommit) {
 			return this.putManySequential(docs, options);
 		}
 
-		await this.handlePreparedPlainPutManyCommit({
-			puts: prepared.map((item, index) => ({
-				document: item.document,
-				encodedDocument: item.encodedDocument,
-				key: item.key,
-				entry: appended.entries[index]!,
-				append: appended.appendCommits[index]!,
-			})),
-			removed: appended.removed,
-		});
-		for (const entry of appended.entries) {
+		await this.handlePreparedPlainPutManyCommit(documentAppendCommit);
+		for (const entry of documentAppendCommit.entries) {
 			this.keepCache?.add(entry.hash);
 		}
-		return appended;
+		return {
+			entries: documentAppendCommit.entries,
+			removed: documentAppendCommit.removed,
+		};
 	}
 
 	private async putManySequential(
@@ -1023,8 +1042,38 @@ export class Documents<
 		return this.createDocumentAppendCommitFacts(input, appended);
 	}
 
+	private async commitNativeDocumentAppendMany(
+		input: NativeDocumentAppendManyCommitInput<T, I>,
+	): Promise<DocumentAppendManyCommitFacts<T, I> | undefined> {
+		const appended = await this.log.appendLocallyPreparedManyIndependent(
+			input.puts.map((put) => put.operation),
+			{
+				...input.options,
+				replicate: input.options?.replicate,
+			},
+			{
+				resolveTrimmedEntries: input.resolveTrimmedEntries,
+				payloadDatas: input.puts.map((put) => put.operationPayloadBytes),
+			},
+		);
+		if (!appended) {
+			return undefined;
+		}
+		return {
+			entries: appended.entries,
+			removed: appended.removed,
+			commits: input.puts.map((put, index) =>
+				this.createDocumentAppendCommitFacts(put, {
+					entry: appended.entries[index]!,
+					removed: [],
+					appendCommit: appended.appendCommits[index]!,
+				}),
+			),
+		};
+	}
+
 	private createDocumentAppendCommitFacts(
-		input: NativeDocumentAppendCommitInput<T, I>,
+		input: NativeDocumentAppendCommitFactsInput<T, I>,
 		appended: {
 			entry: Entry<Operation>;
 			removed: ShallowOrFullEntry<Operation>[];
@@ -1170,16 +1219,9 @@ export class Documents<
 		);
 	}
 
-	private async handlePreparedPlainPutManyCommit(properties: {
-		puts: {
-			document: T;
-			encodedDocument?: Uint8Array;
-			key: indexerTypes.IdKey;
-			entry: Entry<Operation>;
-			append: LocalAppendCommitFacts;
-		}[];
-		removed: ShallowOrFullEntry<Operation>[];
-	}): Promise<void> {
+	private async handlePreparedPlainPutManyCommit(
+		commit: DocumentAppendManyCommitFacts<T, I>,
+	): Promise<void> {
 		const documentsChanged: DocumentsChange<T, I> = {
 			added: [],
 			removed: [],
@@ -1193,29 +1235,16 @@ export class Documents<
 			context: Context;
 			contextualEncodedValueParts?: ContextualEncodedValueParts;
 		}> = [];
-		for (const put of properties.puts) {
+		for (const put of commit.commits) {
 			if (modified.has(put.key.primitive)) {
 				continue;
 			}
-			const context = new Context({
-				created: put.append.wallTime,
-				modified: put.append.wallTime,
-				head: put.append.hash,
-				gid: put.append.gid,
-				size: put.append.payloadSize,
-			});
-			const contextBytes = encodeContextSuffix(context);
 			putsToIndex.push({
 				document: put.document,
 				encodedDocument: put.encodedDocument,
 				key: put.key,
-				context,
-				contextualEncodedValueParts: put.encodedDocument
-					? {
-							prefix: put.encodedDocument,
-							suffix: contextBytes,
-						}
-					: undefined,
+				context: put.context,
+				contextualEncodedValueParts: put.contextualEncodedValueParts,
 			});
 			modified.add(put.key.primitive);
 		}
@@ -1240,11 +1269,11 @@ export class Documents<
 
 		const handledRemovedHeads =
 			await this.collectRemovedDocumentChangesFromIndexedHeads(
-				properties.removed,
+				commit.removed,
 				modified,
 				documentsChanged,
 			);
-		for (const removed of properties.removed) {
+		for (const removed of commit.removed) {
 			if (handledRemovedHeads.has(removed.hash)) {
 				continue;
 			}

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -365,6 +365,10 @@ describe("index", () => {
 					store.docs.index,
 					"putWithContext",
 				);
+				const nativeBatchCommitSpy = sinon.spy(
+					store.docs as any,
+					"commitNativeDocumentAppendMany",
+				);
 				const nativeState = (store.docs.log as any)._nativeSharedLogState;
 				const nativeLocalPlanSpy = sinon.spy(
 					nativeState,
@@ -390,6 +394,7 @@ describe("index", () => {
 					expect(lowerBatchAppendSpy.callCount).equal(1);
 					expect(preparedAppendSpy.callCount).equal(0);
 					expect(appendSpy.callCount).equal(0);
+					expect(nativeBatchCommitSpy.callCount).equal(1);
 					expect(documentBatchIndexSpy.callCount).equal(1);
 					expect(documentIndexPutSpy.callCount).equal(0);
 					expect(nativeBatchPlanSpy.callCount).equal(1);
@@ -400,6 +405,28 @@ describe("index", () => {
 					expect(appended.entries.every((entry) => entry.meta.next.length === 0))
 						.equal(true);
 					expect(await appended.entries[0]!.verifySignatures()).equal(true);
+					const nativeBatchInput = nativeBatchCommitSpy.getCall(0).args[0];
+					expect(nativeBatchInput.puts).to.have.length(docs.length);
+					for (let i = 0; i < docs.length; i++) {
+						const encodedDocument = serialize(docs[i]!);
+						expect(nativeBatchInput.puts[i].documentBytes).to.deep.equal(
+							encodedDocument,
+						);
+						const expectedPayloadData = new Uint8Array(
+							6 + encodedDocument.byteLength,
+						);
+						expectedPayloadData[0] = 0;
+						expectedPayloadData[1] = 3;
+						new DataView(
+							expectedPayloadData.buffer,
+							expectedPayloadData.byteOffset,
+							expectedPayloadData.byteLength,
+						).setUint32(2, encodedDocument.byteLength, true);
+						expectedPayloadData.set(encodedDocument, 6);
+						expect(
+							nativeBatchInput.puts[i].operationPayloadBytes,
+						).to.deep.equal(expectedPayloadData);
+					}
 					const reloaded = await Entry.fromMultihash<Operation>(
 						store.docs.log.log.blocks,
 						appended.entries[0]!.hash,
@@ -425,6 +452,7 @@ describe("index", () => {
 				} finally {
 					nativeBatchPlanSpy.restore();
 					nativeLocalPlanSpy.restore();
+					nativeBatchCommitSpy.restore();
 					documentIndexPutSpy.restore();
 					documentBatchIndexSpy.restore();
 					appendSpy.restore();


### PR DESCRIPTION
## Summary
- add `commitNativeDocumentAppendMany(...)` as the batch equivalent of the existing single-document append commit boundary
- route eligible `Documents.putMany()` through that boundary with document bytes, prepared operation payload bytes, keys, operations, options, and trim behavior
- have `handlePreparedPlainPutManyCommit(...)` consume `DocumentAppendCommitFacts[]` directly instead of reconstructing context/index byte facts from append facts
- extend focused coverage to prove the batch boundary receives exact document bytes and prepared operation payload bytes

## Benchmark
Command:
`DOC_WARMUP=20 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-putmany,rust-peerbit-transient-index-putmany DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts`

After this PR:
- `rust-peerbit-putmany`: 5934 ops/sec, total 168.53 ms, shared append 151.38 ms, shared process batch 12.08 ms, shared persist coordinate 11.89 ms, log append 121.82 ms, document index put 10.18 ms
- `rust-peerbit-transient-index-putmany`: 7350 ops/sec, total 136.06 ms, shared append 120.61 ms, shared process batch 10.11 ms, shared persist coordinate 9.95 ms, log append 98.26 ms, document index put 8.60 ms

Read: this is mainly a boundary/coalescence PR, but it stayed performance-neutral to slightly positive versus #923 final run. It makes the next native transaction implementation more direct.

## Validation
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "independent native prepared batch path|batches rust index"`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/test/index.spec.ts` (passes with one existing unrelated warning at `document/test/index.spec.ts:4280`)
- `git diff --check`