### PR TITLE
Use payload-only native document putMany

### DIFF
--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -144,6 +144,14 @@ type PreparedPut<T> = {
 	operation: PutOperation | PutWithKeyOperation;
 };
 
+type PreparedPlainPut<T> = {
+	document: T;
+	encodedDocument: Uint8Array;
+	operationPayloadBytes: Uint8Array;
+	keyValue: indexerTypes.IdPrimitive;
+	key: indexerTypes.IdKey;
+};
+
 type PlainPutCommitPlan<T, I extends Record<string, any>> = {
 	document: T;
 	encodedDocument: Uint8Array;
@@ -176,7 +184,7 @@ type ContextualEncodedValueParts = {
 type DocumentAppendCommitFacts<T, I extends Record<string, any>> = {
 	document: T;
 	key: indexerTypes.IdKey;
-	operation: PutOperation;
+	operation?: PutOperation;
 	encodedDocument: Uint8Array;
 	operationPayloadBytes: Uint8Array;
 	entry: Entry<Operation>;
@@ -198,9 +206,9 @@ type NativeDocumentAppendCommitFactsInput<
 > = {
 	document: T;
 	key: indexerTypes.IdKey;
-	operation: PutOperation;
 	documentBytes: Uint8Array;
 	operationPayloadBytes: Uint8Array;
+	operation?: PutOperation;
 	unique?: boolean;
 	existing?:
 		| indexerTypes.IndexedResult<IndexedContextOnly<I>>
@@ -212,6 +220,7 @@ type NativeDocumentAppendCommitInput<
 	T,
 	I extends Record<string, any>,
 > = NativeDocumentAppendCommitFactsInput<T, I> & {
+	operation: PutOperation;
 	next: Entry<Operation>[] | ShallowEntry[];
 	skipMissingNextJoin: boolean;
 	resolveTrimmedEntries: boolean;
@@ -764,6 +773,32 @@ export class Documents<
 		};
 	}
 
+	private preparePlainPut(doc: T): PreparedPlainPut<T> {
+		if (this.compatibility === 6) {
+			throw new Error("Plain put preparation is not supported in v6 mode");
+		}
+		const keyValue = this.idResolver(doc);
+		indexerTypes.checkId(keyValue);
+		const documentBytes = serialize(doc);
+		if (documentBytes.length > MAX_BATCH_SIZE) {
+			throw new Error(
+				`Document is too large (${
+					documentBytes.length * 1e-6
+				}) mb). Needs to be less than ${MAX_BATCH_SIZE * 1e-6} mb`,
+			);
+		}
+		const operationPayloadBytes = encodePutOperationPayload(documentBytes);
+		return {
+			document: doc,
+			encodedDocument: operationPayloadBytes.subarray(
+				PUT_OPERATION_PREFIX_LENGTH,
+			),
+			operationPayloadBytes,
+			keyValue,
+			key: indexerTypes.toId(keyValue),
+		};
+	}
+
 	public async put(doc: T, options?: DocumentPutOptions) {
 		const prepared = this.preparePut(doc);
 		let existingLocalContext:
@@ -838,11 +873,8 @@ export class Documents<
 			return this.putManySequential(docs, options);
 		}
 
-		const prepared = docs.map((doc) => this.preparePut(doc));
-		if (
-			prepared.some((item) => !(item.operation instanceof PutOperation)) ||
-			this.hasDuplicatePreparedPutKeys(prepared)
-		) {
+		const prepared = docs.map((doc) => this.preparePlainPut(doc));
+		if (this.hasDuplicatePreparedPutKeys(prepared)) {
 			return this.putManySequential(docs, options);
 		}
 
@@ -850,11 +882,8 @@ export class Documents<
 			puts: prepared.map((item) => ({
 				document: item.document,
 				key: item.key,
-				operation: item.operation as PutOperation,
 				documentBytes: item.encodedDocument,
-				operationPayloadBytes:
-					item.encodedOperation ??
-					encodePutOperationPayload((item.operation as PutOperation).data),
+				operationPayloadBytes: item.operationPayloadBytes,
 				unique: options?.unique,
 				existing: null,
 			})),
@@ -892,7 +921,9 @@ export class Documents<
 		return { entries, removed };
 	}
 
-	private hasDuplicatePreparedPutKeys(prepared: PreparedPut<T>[]): boolean {
+	private hasDuplicatePreparedPutKeys(
+		prepared: Array<{ key: indexerTypes.IdKey }>,
+	): boolean {
 		const keys = new Set<string | number | bigint>();
 		for (const item of prepared) {
 			if (keys.has(item.key.primitive)) {
@@ -1045,15 +1076,14 @@ export class Documents<
 	private async commitNativeDocumentAppendMany(
 		input: NativeDocumentAppendManyCommitInput<T, I>,
 	): Promise<DocumentAppendManyCommitFacts<T, I> | undefined> {
-		const appended = await this.log.appendLocallyPreparedManyIndependent(
-			input.puts.map((put) => put.operation),
+		const appended = await this.log.appendLocallyPreparedPayloadsManyIndependent(
+			input.puts.map((put) => put.operationPayloadBytes),
 			{
 				...input.options,
 				replicate: input.options?.replicate,
 			},
 			{
 				resolveTrimmedEntries: input.resolveTrimmedEntries,
-				payloadDatas: input.puts.map((put) => put.operationPayloadBytes),
 			},
 		);
 		if (!appended) {

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -348,6 +348,10 @@ describe("index", () => {
 					store.docs.log,
 					"appendLocallyPreparedManyIndependent",
 				);
+				const sharedPayloadBatchAppendSpy = sinon.spy(
+					store.docs.log,
+					"appendLocallyPreparedPayloadsManyIndependent",
+				);
 				const lowerBatchAppendSpy = sinon.spy(
 					store.docs.log.log,
 					"appendLocallyPreparedManyIndependent",
@@ -391,6 +395,7 @@ describe("index", () => {
 					});
 
 					expect(sharedBatchAppendSpy.callCount).equal(1);
+					expect(sharedPayloadBatchAppendSpy.callCount).equal(1);
 					expect(lowerBatchAppendSpy.callCount).equal(1);
 					expect(preparedAppendSpy.callCount).equal(0);
 					expect(appendSpy.callCount).equal(0);
@@ -458,6 +463,7 @@ describe("index", () => {
 					appendSpy.restore();
 					preparedAppendSpy.restore();
 					lowerBatchAppendSpy.restore();
+					sharedPayloadBatchAppendSpy.restore();
 					sharedBatchAppendSpy.restore();
 					await store.close();
 					store = undefined;

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -4286,6 +4286,23 @@ export class SharedLog<
 		};
 	}
 
+	async appendLocallyPreparedPayloadsManyIndependent(
+		payloadDatas: Uint8Array[],
+		options?: SharedAppendOptions<T> | undefined,
+		properties?: {
+			resolveTrimmedEntries?: boolean;
+		},
+	) {
+		return this.appendLocallyPreparedManyIndependent(
+			new Array(payloadDatas.length) as T[],
+			options,
+			{
+				resolveTrimmedEntries: properties?.resolveTrimmedEntries,
+				payloadDatas,
+			},
+		);
+	}
+
 	async appendMany(
 		data: T[],
 		options?: SharedAppendOptions<T> | undefined,


### PR DESCRIPTION
## Summary
- add a payload-only prepared append helper for shared-log independent batch appends
- prepare eligible native `Documents.putMany()` rows as document bytes + operation payload bytes without allocating `PutOperation` objects
- route `commitNativeDocumentAppendMany(...)` through the payload-only append path
- keep returned entries lazily decodable from the stored payload bytes and extend focused coverage for the new route

## Benchmark
Command:
`DOC_WARMUP=20 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-putmany,rust-peerbit-transient-index-putmany DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts`

After this PR:
- `rust-peerbit-putmany`: 5853 ops/sec, total 170.84 ms, shared append 152.71 ms, log append 120.38 ms, log create native append chain 68.34 ms, document index put 10.60 ms
- `rust-peerbit-transient-index-putmany`: 7560 ops/sec, total 132.28 ms, shared append 118.19 ms, log append 95.68 ms, log create native append chain 62.93 ms, document index put 7.77 ms

Read: persisted remains in the same band as #924. Transient improves versus #924 and #923, consistent with less JS allocation before the native append and less downstream payload object work.

## Validation
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "independent native prepared batch path|batches rust index"`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/index.ts packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/test/index.spec.ts` (passes with one existing unrelated warning at `document/test/index.spec.ts:4286`)
- `git diff --check`