### PR TITLE
Use payload-only native document put

### DIFF
--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -157,7 +157,7 @@ type PlainPutCommitPlan<T, I extends Record<string, any>> = {
 	encodedDocument: Uint8Array;
 	payloadData: Uint8Array;
 	key: indexerTypes.IdKey;
-	operation: PutOperation;
+	operation?: PutOperation;
 	next: Entry<Operation>[] | ShallowEntry[];
 	skipMissingNextJoin: boolean;
 	resolveTrimmedEntries: boolean;
@@ -220,7 +220,6 @@ type NativeDocumentAppendCommitInput<
 	T,
 	I extends Record<string, any>,
 > = NativeDocumentAppendCommitFactsInput<T, I> & {
-	operation: PutOperation;
 	next: Entry<Operation>[] | ShallowEntry[];
 	skipMissingNextJoin: boolean;
 	resolveTrimmedEntries: boolean;
@@ -800,7 +799,9 @@ export class Documents<
 	}
 
 	public async put(doc: T, options?: DocumentPutOptions) {
-		const prepared = this.preparePut(doc);
+		const prepared = this.canUsePlainPutFastPath(options)
+			? this.preparePlainPut(doc)
+			: this.preparePut(doc);
 		let existingLocalContext:
 			| indexerTypes.IndexedResult<IndexedContextOnly<I>>
 			| null
@@ -832,7 +833,11 @@ export class Documents<
 			return this.commitPlainPutPlan(plainPutPlan, options);
 		}
 
-		const appended = await this.log.append(prepared.operation, {
+		const operation =
+			"operation" in prepared
+				? prepared.operation
+				: new PutOperation({ data: prepared.encodedDocument });
+		const appended = await this.log.append(operation, {
 			...options,
 			meta: {
 				next: existingHead ? [await this._resolveEntry(existingHead)] : [],
@@ -841,13 +846,13 @@ export class Documents<
 			canAppend: (entry) => {
 				return this.canAppend(entry, {
 					document: prepared.document,
-					operation: prepared.operation,
+					operation,
 				});
 			},
 			onChange: (change) => {
 				return this.handleChanges(change, {
 					document: prepared.document,
-					operation: prepared.operation,
+					operation,
 					key: prepared.key,
 					unique: options?.unique,
 					existing: existingLocalContext,
@@ -966,7 +971,7 @@ export class Documents<
 	}
 
 	private async createPlainPutCommitPlan(
-		prepared: PreparedPut<T>,
+		prepared: PreparedPut<T> | PreparedPlainPut<T>,
 		existingHead: string | undefined,
 		existingLocalContext:
 			| indexerTypes.IndexedResult<IndexedContextOnly<I>>
@@ -977,7 +982,8 @@ export class Documents<
 			| undefined,
 	): Promise<PlainPutCommitPlan<T, I> | undefined> {
 		if (
-			!(prepared.operation instanceof PutOperation) ||
+			("operation" in prepared &&
+				!(prepared.operation instanceof PutOperation)) ||
 			!this.canUsePlainPutFastPath(options)
 		) {
 			return;
@@ -994,10 +1000,12 @@ export class Documents<
 			document: prepared.document,
 			encodedDocument: prepared.encodedDocument,
 			payloadData:
-				prepared.encodedOperation ??
-				encodePutOperationPayload(prepared.operation.data),
+				"operationPayloadBytes" in prepared
+					? prepared.operationPayloadBytes
+					: (prepared.encodedOperation ??
+						encodePutOperationPayload(prepared.operation.data)),
 			key: prepared.key,
-			operation: prepared.operation,
+			operation: "operation" in prepared ? prepared.operation : undefined,
 			next,
 			skipMissingNextJoin: !options?.checkRemote,
 			resolveTrimmedEntries: !this._index.canGetIdentityIndexedByHead(),
@@ -1028,6 +1036,10 @@ export class Documents<
 			existing: plan.existing,
 		});
 		if (plan.useGenericChangeHandler) {
+			const operation =
+				documentAppendCommit.operation ??
+				plan.operation ??
+				new PutOperation({ data: plan.encodedDocument });
 			await this.handleChanges(
 				{
 					added: [{ head: true, entry: documentAppendCommit.entry }],
@@ -1035,7 +1047,7 @@ export class Documents<
 				},
 				{
 					document: plan.document,
-					operation: plan.operation,
+					operation,
 					key: plan.key,
 					unique: plan.unique,
 					existing: plan.existing,
@@ -1054,22 +1066,30 @@ export class Documents<
 	private async commitNativeDocumentAppend(
 		input: NativeDocumentAppendCommitInput<T, I>,
 	): Promise<DocumentAppendCommitFacts<T, I>> {
-		const appended = await this.log.appendLocallyPrepared(
-			input.operation,
-			{
-				...input.options,
-				meta: {
-					next: input.next,
-					...input.options?.meta,
-				},
-				replicate: input.options?.replicate,
+		const appendOptions = {
+			...input.options,
+			meta: {
+				next: input.next,
+				...input.options?.meta,
 			},
-			{
-				skipMissingNextJoin: input.skipMissingNextJoin,
-				resolveTrimmedEntries: input.resolveTrimmedEntries,
-				payloadData: input.operationPayloadBytes,
-			},
-		);
+			replicate: input.options?.replicate,
+		};
+		const appendProperties = {
+			skipMissingNextJoin: input.skipMissingNextJoin,
+			resolveTrimmedEntries: input.resolveTrimmedEntries,
+			payloadData: input.operationPayloadBytes,
+		};
+		const appended = input.operation
+			? await this.log.appendLocallyPrepared(
+					input.operation,
+					appendOptions,
+					appendProperties,
+				)
+			: await this.log.appendLocallyPreparedPayload(
+					input.operationPayloadBytes,
+					appendOptions,
+					appendProperties,
+				);
 		return this.createDocumentAppendCommitFacts(input, appended);
 	}
 

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -186,6 +186,10 @@ describe("index", () => {
 					store.docs.log,
 					"appendLocallyPrepared",
 				);
+				const preparedPayloadAppendSpy = sinon.spy(
+					store.docs.log,
+					"appendLocallyPreparedPayload",
+				);
 				const appendSpy = sinon.spy(store.docs.log, "append");
 				const localLookupSpy = sinon.spy(
 					store.docs as any,
@@ -232,6 +236,7 @@ describe("index", () => {
 					});
 
 					expect(preparedAppendSpy.callCount).equal(1);
+					expect(preparedPayloadAppendSpy.callCount).equal(1);
 					expect(validatedAppendSpy.callCount).equal(0);
 					expect(appendSpy.callCount).equal(0);
 					expect(localLookupSpy.callCount).equal(0);
@@ -254,13 +259,18 @@ describe("index", () => {
 					expect(preparedAppendSpy.getCall(0).args[2]?.payloadData).to.deep.equal(
 						expectedPayloadData,
 					);
+					expect(preparedPayloadAppendSpy.getCall(0).args[0]).to.deep.equal(
+						expectedPayloadData,
+					);
 					const commitPlan = await commitPlanSpy.getCall(0).returnValue;
 					expect(commitPlan.payloadData).to.deep.equal(expectedPayloadData);
+					expect(commitPlan.operation).equal(undefined);
 					const nativeInput = nativeCommitSpy.getCall(0).args[0];
 					expect(nativeInput.documentBytes).to.deep.equal(encodedDocument);
 					expect(nativeInput.operationPayloadBytes).to.deep.equal(
 						expectedPayloadData,
 					);
+					expect(nativeInput.operation).equal(undefined);
 					expect(nativeInput.key.primitive).equal(doc.id);
 					expect(nativeInput.next).to.be.empty;
 					const documentCommit = documentCommitSpy.getCall(0).returnValue;
@@ -319,6 +329,7 @@ describe("index", () => {
 					commitPlanSpy.restore();
 					nativeCommitSpy.restore();
 					documentCommitSpy.restore();
+					preparedPayloadAppendSpy.restore();
 					preparedAppendSpy.restore();
 					validatedAppendSpy.restore();
 					appendSpy.restore();

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -4150,6 +4150,21 @@ export class SharedLog<
 		};
 	}
 
+	async appendLocallyPreparedPayload(
+		payloadData: Uint8Array,
+		options?: SharedAppendOptions<T> | undefined,
+		properties?: {
+			skipMissingNextJoin?: boolean;
+			resolveTrimmedEntries?: boolean;
+		},
+	) {
+		return this.appendLocallyPrepared(undefined as T, options, {
+			skipMissingNextJoin: properties?.skipMissingNextJoin,
+			resolveTrimmedEntries: properties?.resolveTrimmedEntries,
+			payloadData,
+		});
+	}
+
 	private canCoalescePreparedAppendCoordinateDeletes(
 		result: { removed: ShallowOrFullEntry<T>[] },
 		options?: SharedAppendOptions<T>,


### PR DESCRIPTION
## Summary
- use `preparePlainPut(...)` for eligible single `Documents.put()` fast-path commits
- add `SharedLog.appendLocallyPreparedPayload(...)` as the single-entry payload-only append helper
- allow `commitNativeDocumentAppend(...)` to append from exact operation payload bytes without a preallocated `PutOperation`
- keep compatibility/custom-hook fallbacks on the existing materialized operation path
- extend focused coverage to prove single put enters the payload-only route and still indexes/emits correctly

## Benchmark
Command:
`DOC_WARMUP=20 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit,rust-peerbit-transient-index,rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts`

After this PR:
- `rust-peerbit`: 3317 ops/sec, total 301.44 ms, shared append 243.61 ms, log append 169.21 ms, document index put 18.30 ms
- `rust-peerbit-transient-index`: 4127 ops/sec, total 242.28 ms, shared append 197.05 ms, log append 141.55 ms, document index put 12.88 ms
- `rust-peerbit-nonunique`: 4132 ops/sec, total 241.99 ms, shared append 197.28 ms, log append 143.13 ms, document index put 12.34 ms
- `rust-peerbit-transient-index-nonunique`: 4607 ops/sec, total 217.04 ms, shared append 179.17 ms, log append 131.43 ms, document index put 11.39 ms

Read: this removes pre-append operation allocation on the single prepared path. Single-put throughput remains dominated by shared append leader/coordinate persistence plus lower-log append/trim.

## Validation
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses the validated local append path for plain puts|independent native prepared batch path|batches rust index"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses the validated local append path for document updates"`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/shared-log/src/index.ts packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/test/index.spec.ts` (passes with one existing unrelated warning at `document/test/index.spec.ts:4297`)
- `git diff --check`