### PR TITLE
Batch native encoded-parts index writes

### DIFF
--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -505,6 +505,10 @@ describe("index", () => {
 					backendIndex,
 					"putWithContextBatch",
 				);
+				const nativeEncodedPartsBatchSpy = sinon.spy(
+					backendIndex.native,
+					"put_encoded_parts_batch",
+				);
 				const encodeContextualPartsSpy = sinon.spy(
 					store.docs.index as any,
 					"encodeContextualIndexedValueParts",
@@ -554,6 +558,7 @@ describe("index", () => {
 						).greaterThan(0);
 					}
 					expect(encodeContextualPartsSpy.callCount).equal(0);
+					expect(nativeEncodedPartsBatchSpy.callCount).equal(1);
 					expect(coordinateBatchSpy.callCount).equal(1);
 					expect(coordinatePutSpy.callCount).equal(0);
 					expect(changes).to.have.length(1);
@@ -564,6 +569,7 @@ describe("index", () => {
 					coordinatePutSpy.restore();
 					coordinateBatchSpy.restore();
 					encodeContextualPartsSpy.restore();
+					nativeEncodedPartsBatchSpy.restore();
 					documentBackendBatchSpy.restore();
 					await store.close();
 					store = undefined;

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -51,6 +51,14 @@ type NativeRustIndex<T extends Record<string, any>> = {
 		valueSuffixBytes: Uint8Array,
 		byteElementIndexLimit: number,
 	) => void;
+	put_encoded_parts_batch?: (
+		keys: string[],
+		ids: types.IdKey[],
+		values: T[],
+		valuePrefixBytes: Uint8Array[],
+		valueSuffixBytes: Uint8Array[],
+		byteElementIndexLimit: number,
+	) => void;
 	put_and_delete_matching: (
 		key: string,
 		id: types.IdKey,
@@ -1748,6 +1756,9 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		}>,
 	): Promise<void> {
 		if (!this.snapshotFile) {
+			if (this.putNativeDocumentEncodedPartsBatch(values)) {
+				return;
+			}
 			for (const entry of values) {
 				const storeKey = keyToStoreKey(entry.id);
 				const encodedValue =
@@ -1805,6 +1816,10 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 					this.properties.schema,
 				);
 			});
+			if (this.putNativeDocumentEncodedPartsBatch(prepared)) {
+				await this.compactIfNeeded();
+				return;
+			}
 			for (const item of prepared) {
 				if (
 					!this.putNativeDocumentWithPreparedFields(
@@ -2376,6 +2391,57 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			return;
 		}
 		this.getNative().put(storeKey, id, value, this.fieldEncoder(value));
+	}
+
+	private putNativeDocumentEncodedPartsBatch(
+		values: Array<{
+			value: T;
+			id: types.IdKey;
+			storeKey?: string;
+			encodedValue?: Uint8Array;
+			encodedValueParts?: NativeEncodedValueParts;
+		}>,
+	): boolean {
+		if (values.length === 0) {
+			return false;
+		}
+		const native = this.getNative();
+		const putEncodedPartsBatch = native.put_encoded_parts_batch;
+		if (!putEncodedPartsBatch) {
+			return false;
+		}
+		const keys = new Array<string>(values.length);
+		const ids = new Array<types.IdKey>(values.length);
+		const storedValues = new Array<T>(values.length);
+		const prefixes = new Array<Uint8Array>(values.length);
+		const suffixes = new Array<Uint8Array>(values.length);
+		for (let i = 0; i < values.length; i++) {
+			const entry = values[i]!;
+			if (entry.encodedValue || !entry.encodedValueParts) {
+				return false;
+			}
+			keys[i] = entry.storeKey ?? keyToStoreKey(entry.id);
+			ids[i] = entry.id;
+			storedValues[i] = entry.value;
+			prefixes[i] = entry.encodedValueParts.prefix;
+			suffixes[i] = entry.encodedValueParts.suffix;
+		}
+		try {
+			putEncodedPartsBatch.call(
+				native,
+				keys,
+				ids,
+				storedValues,
+				prefixes,
+				suffixes,
+				this.nativeByteElementIndexLimit,
+			);
+			return true;
+		} catch {
+			// Fall back to the per-entry native call, which already falls back again
+			// to TypeScript field encoding for schemas outside the native extractor.
+			return false;
+		}
 	}
 
 	private putNativeDocumentWithPreparedFields(

--- a/packages/utils/indexer/rust/src/lib.rs
+++ b/packages/utils/indexer/rust/src/lib.rs
@@ -1,6 +1,6 @@
 use borsh::BorshDeserialize;
 use indexmap::IndexMap;
-use js_sys::Array;
+use js_sys::{Array, Uint8Array};
 use planner::{
     Compare, DocumentFields, FieldPath, FieldValue, NativeQueryIndex, Query, SortDirection,
     SortField, StringMatchMethod, SumResult,
@@ -257,6 +257,46 @@ impl NativeRustIndex {
         )?;
         self.store.put(key.clone(), id, value);
         self.planner.index.put(key, fields);
+        Ok(())
+    }
+
+    pub fn put_encoded_parts_batch(
+        &mut self,
+        keys: Array,
+        ids: Array,
+        values: Array,
+        value_prefix_bytes: Array,
+        value_suffix_bytes: Array,
+        byte_element_index_limit: usize,
+    ) -> Result<(), JsValue> {
+        let len = keys.length();
+        if ids.length() != len
+            || values.length() != len
+            || value_prefix_bytes.length() != len
+            || value_suffix_bytes.length() != len
+        {
+            return Err(js_error("Mismatched encoded parts batch lengths"));
+        }
+
+        let mut prepared = Vec::with_capacity(len as usize);
+        for index in 0..len {
+            let key = keys
+                .get(index)
+                .as_string()
+                .ok_or_else(|| js_error("Invalid encoded parts batch key"))?;
+            let prefix = Uint8Array::new(&value_prefix_bytes.get(index)).to_vec();
+            let suffix = Uint8Array::new(&value_suffix_bytes.get(index)).to_vec();
+            let fields = self.extract_encoded_document_fields_from_reader(
+                BridgeReader::from_parts(&prefix, &suffix),
+                byte_element_index_limit,
+            )?;
+            prepared.push((key, ids.get(index), values.get(index), fields));
+        }
+
+        for (key, id, value, fields) in prepared {
+            self.store.put(key.clone(), id, value);
+            self.planner.index.put(key, fields);
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- add `NativeRustIndex.put_encoded_parts_batch(...)` so prepared contextual document index writes can cross JS -> Rust once per batch
- use that native batch entry point from `@peerbit/indexer-rust` when every prepared batch item has encoded prefix/suffix parts
- keep persistence behavior unchanged: append the WAL batch first, apply the native batch, then compact as before
- assert the document `putMany()` fast path uses the native encoded-parts batch call

## Benchmark
Command from `packages/programs/data/document/document`:

```bash
DOC_WARMUP=20 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit,rust-peerbit-transient-index,rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique,rust-peerbit-putmany,rust-peerbit-transient-index-putmany DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Rows:
- `rust-peerbit`: 3346 ops/sec, total 298.86 ms
- `rust-peerbit-transient-index`: 4047 ops/sec, total 247.10 ms
- `rust-peerbit-nonunique`: 4055 ops/sec, total 246.63 ms
- `rust-peerbit-transient-index-nonunique`: 4513 ops/sec, total 221.59 ms
- `rust-peerbit-putmany`: 7889 ops/sec, total 126.76 ms
- `rust-peerbit-transient-index-putmany`: 8057 ops/sec, total 124.11 ms

Additional larger batch check:

```bash
DOC_WARMUP=50 DOC_ITERATIONS=5000 DOC_SCENARIOS=rust-peerbit-putmany,rust-peerbit-transient-index-putmany DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Rows:
- `rust-peerbit-putmany`: 5261 ops/sec, total 950.36 ms, document index put 88.90 ms
- `rust-peerbit-transient-index-putmany`: 5982 ops/sec, total 835.88 ms, document index put 45.30 ms

## Validation
- `pnpm --filter @peerbit/indexer-rust run test`
- `pnpm --filter @peerbit/indexer-rust run build`
- `pnpm --filter @peerbit/document run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/log run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "independent native prepared batch path|batches rust index|uses the validated local append path for plain puts|uses the validated local append path for document updates"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "batches rust index and coordinate writes for unique putMany"`
- `pnpm exec eslint --config eslint.config.js packages/utils/indexer/rust/src/index.ts packages/programs/data/document/document/test/index.spec.ts` (passes with the existing unrelated unused-var warning in `document/test/index.spec.ts`)
- `cargo fmt --check` in `packages/utils/indexer/rust`
- `git diff --check`