### PR TITLE
Optimize native single append bookkeeping

### DIFF
--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -1397,6 +1397,53 @@ export class EntryIndex<T> {
 		return promise;
 	}
 
+	/** @internal */
+	async putNativeCommittedAppend(
+		entry: Entry<any>,
+		properties: {
+			unique: boolean;
+			externalNextHashes: string[];
+			shallowEntry?: ShallowEntry;
+			isHead?: boolean;
+		},
+	) {
+		if (!entry.hash) {
+			throw new Error("Missing hash");
+		}
+		const existingPromise = this.insertionPromises.get(entry.hash);
+		if (existingPromise) {
+			await existingPromise;
+		}
+
+		const promise = (async () => {
+			const isHead = properties.isHead ?? true;
+			if (properties.unique === true || !(await this.has(entry.hash))) {
+				this._length++;
+			}
+
+			this.cache.add(entry.hash, entry);
+			const shallowEntry =
+				properties.shallowEntry ??
+				Entry.takePreparedShallowEntry(entry, isHead) ??
+				entry.toShallow(isHead);
+			shallowEntry.head = isHead;
+			this.pendingIndexWrites.set(entry.hash, shallowEntry);
+			this.schedulePendingIndexWriteFlush();
+
+			if (properties.externalNextHashes.length > 0) {
+				await this.privateUpdateNextHeadHashes(
+					properties.externalNextHashes,
+					false,
+				);
+			}
+		})().finally(() => {
+			this.insertionPromises.delete(entry.hash);
+		});
+
+		this.insertionPromises.set(entry.hash, promise);
+		return promise;
+	}
+
 	async delete(k: string, from?: Entry<any> | ShallowEntry) {
 		this.cache.del(k);
 

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -1300,20 +1300,34 @@ export class Log<T> {
 		preparedAppendChain?: PreparedAppendChain<T>,
 		heads?: boolean[],
 	) {
+		const prepared =
+			preparedAppendChain && entries.length === preparedAppendChain.entries.length
+				? {
+						shallowEntries: preparedAppendChain.shallowEntries,
+						nativeEntries: preparedAppendChain.nativeEntries,
+						nativeGraphUpdated: preparedAppendChain.nativeGraphUpdated,
+						nativeBlocksCommitted: preparedAppendChain.nativeBlocksCommitted,
+					}
+				: undefined;
+		if (
+			entries.length === 1 &&
+			prepared?.nativeGraphUpdated === true &&
+			!this.entryIndex.properties.onGidRemoved
+		) {
+			await this.entryIndex.putNativeCommittedAppend(entries[0]!, {
+				unique: true,
+				externalNextHashes,
+				shallowEntry: prepared.shallowEntries[0],
+				isHead: heads?.[0] ?? true,
+			});
+			return;
+		}
+
 		await this.entryIndex.putAppendBatch(entries, {
 			unique: true,
 			externalNextHashes,
 			heads,
-			prepared:
-				preparedAppendChain &&
-				entries.length === preparedAppendChain.entries.length
-					? {
-							shallowEntries: preparedAppendChain.shallowEntries,
-							nativeEntries: preparedAppendChain.nativeEntries,
-							nativeGraphUpdated: preparedAppendChain.nativeGraphUpdated,
-							nativeBlocksCommitted: preparedAppendChain.nativeBlocksCommitted,
-						}
-					: undefined,
+			prepared,
 			deferIndexWrite:
 				options.deferIndexWrite ??
 				(options.durability

--- a/packages/log/src/trim.ts
+++ b/packages/log/src/trim.ts
@@ -318,6 +318,17 @@ export class Trim<T> {
 		this._trimLastSeed = undefined;
 
 		if (this._log.deleteNodes) {
+			const overage = this._log.getLength() - to;
+			if (overage > 0) {
+				const nodes = await this._log.index.getOldestMany(overage, false);
+				if (nodes.length > 0) {
+					deleted.push(
+						...(await this._log.deleteNodes(nodes, {
+							resolveDeletedEntry: options?.resolveDeletedEntries,
+						})),
+					);
+				}
+			}
 			while (this._log.getLength() > to) {
 				const nodes = await this._log.index.getOldestMany(
 					Math.min(this._log.getLength() - to, 512),

--- a/packages/log/test/append.spec.ts
+++ b/packages/log/test/append.spec.ts
@@ -378,6 +378,93 @@ describe("append", function () {
 		}
 	});
 
+	it("uses single native committed append bookkeeping for prepared append", async () => {
+		const { createNativeLogBlockStore } = await import("@peerbit/log-rust");
+		const nativeStore = await createNativeLogBlockStore();
+		await nativeStore.start();
+		const log = new Log<Uint8Array>();
+		await log.open(nativeStore, signKey, {
+			appendDurability: "strict",
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+		});
+
+		const singleNativeAppendSpy = sinon.spy(
+			log.entryIndex as any,
+			"putNativeCommittedAppend",
+		);
+		const appendBatchSpy = sinon.spy(log.entryIndex, "putAppendBatch");
+
+		try {
+			const { entry, removed } = await log.appendLocallyPrepared(
+				new Uint8Array([1]),
+				{
+					meta: { next: [] },
+				},
+			);
+
+			expect(removed).to.be.empty;
+			expect(singleNativeAppendSpy.callCount).equal(1);
+			expect(appendBatchSpy.callCount).equal(0);
+			expect(await nativeStore.has(entry.hash)).to.equal(true);
+			expect((await log.getHeads().all()).map((head) => head.hash)).to.deep.equal([
+				entry.hash,
+			]);
+			expect((await log.get(entry.hash))?.hash).equal(entry.hash);
+		} finally {
+			appendBatchSpy.restore();
+			singleNativeAppendSpy.restore();
+			await log.close();
+			await nativeStore.stop();
+		}
+	});
+
+	it("uses single native committed append bookkeeping after js block commit", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			appendDurability: "strict",
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+		});
+
+		const singleNativeAppendSpy = sinon.spy(
+			log.entryIndex as any,
+			"putNativeCommittedAppend",
+		);
+		const appendBatchSpy = sinon.spy(log.entryIndex, "putAppendBatch");
+		const blockPutManySpy = sinon.spy(store, "putMany");
+		const nativePrepareAndPutSpy = sinon.spy(
+			log.entryIndex.properties.nativeGraph!.graph,
+			"prepareEntryV0PlainEntryAndPut",
+		);
+
+		try {
+			const { entry, removed } = await log.appendLocallyPrepared(
+				new Uint8Array([1]),
+				{
+					meta: { next: [] },
+				},
+			);
+
+			expect(removed).to.be.empty;
+			expect(nativePrepareAndPutSpy.callCount).equal(1);
+			expect(blockPutManySpy.callCount).equal(1);
+			expect(singleNativeAppendSpy.callCount).equal(1);
+			expect(appendBatchSpy.callCount).equal(0);
+			expect(await blockExists(entry.hash)).to.be.true;
+			expect((await log.getHeads().all()).map((head) => head.hash)).to.deep.equal([
+				entry.hash,
+			]);
+			expect((await log.get(entry.hash))?.hash).equal(entry.hash);
+		} finally {
+			nativePrepareAndPutSpy.restore();
+			blockPutManySpy.restore();
+			appendBatchSpy.restore();
+			singleNativeAppendSpy.restore();
+			await log.close();
+		}
+	});
+
 	it("rolls back native graph when prepared appendMany block write fails", async () => {
 		const log = new Log<Uint8Array>();
 		await log.open(store, signKey, {

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -452,6 +452,7 @@ describe("native graph", () => {
 		await log.append(new Uint8Array([3]));
 
 		const nativeGraph = log.entryIndex.properties.nativeGraph!.graph;
+		const oldestEntriesSpy = sinon.spy(nativeGraph, "oldestEntries");
 		const hasManySpy = sinon.spy(nativeGraph, "hasMany");
 		const indexGetSpy = sinon.spy(log.entryIndex.properties.index, "get");
 		try {
@@ -464,12 +465,15 @@ describe("native graph", () => {
 				first.hash,
 				second.hash,
 			]);
+			expect(oldestEntriesSpy.callCount).equal(1);
+			expect(oldestEntriesSpy.firstCall.args[0]).equal(2);
 			expect(log.length).equal(1);
 			expect(hasManySpy.callCount).greaterThan(0);
 			expect(indexGetSpy.callCount).equal(0);
 		} finally {
 			indexGetSpy.restore();
 			hasManySpy.restore();
+			oldestEntriesSpy.restore();
 			await log.close();
 		}
 	});

--- a/packages/programs/data/document/document/benchmark/document-put.ts
+++ b/packages/programs/data/document/document/benchmark/document-put.ts
@@ -95,9 +95,12 @@ type Profile = {
 	sharedPlanEntryLeadersMs: number;
 	sharedPersistCoordinateMs: number;
 	logAppendMs: number;
+	logGetNextsForAppendMs: number;
 	logCreateNativeAppendChainMs: number;
+	logPutNativeCommittedAppendMs: number;
 	logPutAppendEntriesMs: number;
 	logTrimMs: number;
+	logTrimUnfilteredLengthMs: number;
 	documentIndexPutMs: number;
 	documentIndexTransformMs: number;
 	documentBackendIndexPutMs: number;
@@ -116,9 +119,12 @@ const deepProfileKeys = new Set<keyof Profile>([
 	"sharedProcessLocalAppendBatchMs",
 	"sharedPlanEntryLeadersMs",
 	"sharedPersistCoordinateMs",
+	"logGetNextsForAppendMs",
 	"logCreateNativeAppendChainMs",
+	"logPutNativeCommittedAppendMs",
 	"logPutAppendEntriesMs",
 	"logTrimMs",
+	"logTrimUnfilteredLengthMs",
 ]);
 
 const emptyProfile = (): Profile => ({
@@ -130,9 +136,12 @@ const emptyProfile = (): Profile => ({
 	sharedPlanEntryLeadersMs: 0,
 	sharedPersistCoordinateMs: 0,
 	logAppendMs: 0,
+	logGetNextsForAppendMs: 0,
 	logCreateNativeAppendChainMs: 0,
+	logPutNativeCommittedAppendMs: 0,
 	logPutAppendEntriesMs: 0,
 	logTrimMs: 0,
+	logTrimUnfilteredLengthMs: 0,
 	documentIndexPutMs: 0,
 	documentIndexTransformMs: 0,
 	documentBackendIndexPutMs: 0,
@@ -389,6 +398,12 @@ const runScenario = async (name: string): Promise<BenchRow> => {
 				),
 				patchAsyncMethod(
 					store.docs.log.log as any,
+					"getNextsForAppend",
+					profile,
+					"logGetNextsForAppendMs",
+				),
+				patchAsyncMethod(
+					store.docs.log.log as any,
 					"createNativePlainAppendChain",
 					profile,
 					"logCreateNativeAppendChainMs",
@@ -400,12 +415,24 @@ const runScenario = async (name: string): Promise<BenchRow> => {
 					"logCreateNativeAppendChainMs",
 				),
 				patchAsyncMethod(
+					store.docs.log.log.entryIndex as any,
+					"putNativeCommittedAppend",
+					profile,
+					"logPutNativeCommittedAppendMs",
+				),
+				patchAsyncMethod(
 					store.docs.log.log as any,
 					"putAppendEntries",
 					profile,
 					"logPutAppendEntriesMs",
 				),
 				patchAsyncMethod(store.docs.log.log, "trim", profile, "logTrimMs"),
+				patchAsyncMethod(
+					(store.docs.log.log as any)._trim,
+					"trimUnfilteredLength",
+					profile,
+					"logTrimUnfilteredLengthMs",
+				),
 			);
 		}
 


### PR DESCRIPTION
## Summary

This stacked PR targets single `Documents.put()` performance on top of #929.

- Add an internal `EntryIndex.putNativeCommittedAppend(...)` helper for single native-prepared lower-log appends.
- Route single native-graph-prepared `Log.putAppendEntries(...)` through the helper once the block write has completed, including the current Peerbit path where blocks are still committed through the JS block store.
- Specialize unfiltered length trim to fetch the full overage with one native `getOldestMany(...)` and delete it with one `deleteNodes(...)` batch before falling back to the existing loop if needed.
- Extend the document-put benchmark deep profile with lower-log split timings: next lookup, native append creation, single append bookkeeping, generic append entries, trim, and unfiltered trim.

No public API changes and no storage default flip. Compatibility fallback remains unchanged.

## Benchmark

Primary single-put run:

```bash
DOC_WARMUP=50 DOC_ITERATIONS=5000 DOC_SCENARIOS=rust-peerbit,rust-peerbit-transient-index,rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

#929 local baseline from the planning note:

- `rust-peerbit`: 3346 ops/sec
- `rust-peerbit-transient-index`: 4047 ops/sec
- `rust-peerbit-nonunique`: 4055 ops/sec
- `rust-peerbit-transient-index-nonunique`: 4513 ops/sec

This branch:

- `rust-peerbit`: 4325 ops/sec
- `rust-peerbit-transient-index`: 5070 ops/sec
- `rust-peerbit-nonunique`: 5325 ops/sec
- `rust-peerbit-transient-index-nonunique`: 5685 ops/sec

Read: primary `rust-peerbit` single put is about +29% by ops/sec vs the #929 baseline. Same-run trim-only intermediate before enabling the helper for JS block commits was 3791 ops/sec, so the final helper wiring accounts for another useful step.

The deep profile now confirms the real document path hits the single helper: in the 5000-op `rust-peerbit` run, `logPutAppendEntriesMs` was 15.74 ms total and `logPutNativeCommittedAppendMs` was 13.51 ms total, instead of spending ~96.65 ms in generic append entries in the trim-only intermediate.

Short putMany regression matrix stayed in the same rough band (`rust-peerbit-putmany` 7609 ops/sec, transient 7540 ops/sec for 1000 docs). Longer 5000-doc putMany runs are dominated by trimming thousands of entries and should not be compared directly to prior 1000-doc numbers.

## Validation

- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/log-rust run test`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "uses single native committed append bookkeeping|append commits one block and graph in one native call when storage is native"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "uses the native graph to plan unfiltered length trim|skips missing next index lookups during native length trim"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "coalesces prepared append trim coordinate deletes into the coordinate put|persists native append coordinate fields from the prepared plan"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses the validated local append path for plain puts|uses the validated local append path for document updates|independent native prepared batch path|batches rust index"`
- `pnpm exec eslint --config eslint.config.js packages/log/src/log.ts packages/log/src/entry-index.ts packages/log/src/trim.ts packages/log/test/append.spec.ts packages/log/test/native-graph.spec.ts packages/programs/data/document/document/benchmark/document-put.ts`
- `git diff --check`
