### PR TITLE
Carry native append facts into shared-log planning

### DIFF
--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -2,7 +2,7 @@ use ed25519_dalek::{Signer, SigningKey};
 use indexmap::{IndexMap, IndexSet};
 use js_sys::{Array, BigUint64Array, Uint32Array, Uint8Array};
 use sha2::{Digest, Sha256};
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use wasm_bindgen::prelude::*;
 
 const ENTRY_TYPE_CUT: u8 = 1;
@@ -82,6 +82,7 @@ pub struct LogGraphIndex {
     entries: IndexMap<String, LogIndexEntry>,
     children: HashMap<String, IndexSet<String>>,
     heads: IndexSet<String>,
+    ordered_entries: BTreeSet<(u64, u32, String)>,
     payload_size_total: u64,
 }
 
@@ -106,6 +107,7 @@ impl LogGraphIndex {
         self.entries.clear();
         self.children.clear();
         self.heads.clear();
+        self.ordered_entries.clear();
         self.payload_size_total = 0;
     }
 
@@ -122,27 +124,28 @@ impl LogGraphIndex {
     }
 
     pub fn oldest_hash(&self) -> Option<String> {
-        self.entries
-            .values()
-            .min_by(|left, right| compare_entry_order(left, right))
-            .map(|entry| entry.hash.clone())
+        self.ordered_entries
+            .iter()
+            .next()
+            .map(|(_, _, hash)| hash.clone())
     }
 
     pub fn newest_hash(&self) -> Option<String> {
-        self.entries
-            .values()
-            .max_by(|left, right| compare_entry_order(left, right))
-            .map(|entry| entry.hash.clone())
+        self.ordered_entries
+            .iter()
+            .next_back()
+            .map(|(_, _, hash)| hash.clone())
     }
 
     pub fn oldest_entries(&self, limit: usize) -> Vec<LogIndexEntry> {
         if limit == 0 {
             return Vec::new();
         }
-        let mut entries: Vec<LogIndexEntry> = self.entries.values().cloned().collect();
-        entries.sort_by(compare_entry_order);
-        entries.truncate(limit);
-        entries
+        self.ordered_entries
+            .iter()
+            .take(limit)
+            .filter_map(|(_, _, hash)| self.entries.get(hash).cloned())
+            .collect()
     }
 
     pub fn get(&self, hash: &str) -> Option<&LogIndexEntry> {
@@ -159,8 +162,12 @@ impl LogGraphIndex {
         let nexts = entry.next.clone();
         let payload_size = entry.payload_size as u64;
         let head = entry.head;
+        let wall_time = entry.wall_time;
+        let logical = entry.logical;
 
         self.entries.insert(hash.clone(), entry);
+        self.ordered_entries
+            .insert((wall_time, logical, hash.clone()));
         self.payload_size_total += payload_size;
         if head {
             self.heads.insert(hash.clone());
@@ -197,8 +204,15 @@ impl LogGraphIndex {
             let nexts = entry.next.clone();
             let payload_size = entry.payload_size as u64;
             let head = entry.head;
+            let wall_time = entry.wall_time;
+            let logical = entry.logical;
 
+            if self.entries.contains_key(&hash) {
+                self.delete(&hash);
+            }
             self.entries.insert(hash.clone(), entry);
+            self.ordered_entries
+                .insert((wall_time, logical, hash.clone()));
             self.payload_size_total += payload_size;
             if head {
                 self.heads.insert(hash.clone());
@@ -221,6 +235,8 @@ impl LogGraphIndex {
     pub fn delete(&mut self, hash: &str) -> Option<LogIndexEntry> {
         let entry = self.entries.shift_remove(hash)?;
         self.heads.shift_remove(hash);
+        self.ordered_entries
+            .remove(&(entry.wall_time, entry.logical, entry.hash.clone()));
         self.payload_size_total = self
             .payload_size_total
             .saturating_sub(entry.payload_size as u64);
@@ -560,10 +576,6 @@ fn compare_clock(wall_time: u64, logical: u32, other: &LogIndexEntry) -> std::cm
     wall_time
         .cmp(&other.wall_time)
         .then_with(|| logical.cmp(&other.logical))
-}
-
-fn compare_entry_order(left: &LogIndexEntry, right: &LogIndexEntry) -> std::cmp::Ordering {
-    compare_clock(left.wall_time, left.logical, right).then_with(|| left.hash.cmp(&right.hash))
 }
 
 #[wasm_bindgen]

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -160,8 +160,12 @@ export type PreparedAppendFacts = {
 	next: string[];
 	wallTime: bigint;
 	logical: number;
+	clockId?: Uint8Array;
+	type?: EntryType;
+	metaData?: Uint8Array;
 	payloadSize: number;
 	metaBytes?: Uint8Array;
+	hashDigestBytes?: Uint8Array;
 };
 
 type OnChange<T> = (
@@ -193,6 +197,7 @@ type PendingDelete<T> = {
 
 type EntryWithMetaBytes = {
 	getMetaBytes?: () => Uint8Array | undefined;
+	getHashDigestBytes?: () => Uint8Array | undefined;
 };
 
 @variant(0)
@@ -707,6 +712,7 @@ export class Log<T> {
 		entry: Entry<T>;
 		removed: ShallowOrFullEntry<T>[];
 		change: Change<T>;
+		appendFacts: PreparedAppendFacts;
 	}> {
 		if (
 			options.canAppend ||
@@ -776,8 +782,12 @@ export class Log<T> {
 			added: [{ head: true, entry }],
 			removed,
 		};
+		const appendFacts = this.createPreparedAppendFacts(
+			[entry],
+			nativeAppendChain,
+		)[0]!;
 
-		return { entry, removed, change };
+		return { entry, removed, change, appendFacts };
 	}
 
 	async appendLocallyPreparedManyIndependent(
@@ -884,8 +894,12 @@ export class Log<T> {
 					next: shallowEntry.meta.next,
 					wallTime: shallowEntry.meta.clock.timestamp.wallTime,
 					logical: shallowEntry.meta.clock.timestamp.logical,
+					clockId: shallowEntry.meta.clock.id,
+					type: shallowEntry.meta.type,
+					metaData: shallowEntry.meta.data,
 					payloadSize: shallowEntry.payloadSize,
 					metaBytes: (entry as EntryWithMetaBytes).getMetaBytes?.(),
+					hashDigestBytes: (entry as EntryWithMetaBytes).getHashDigestBytes?.(),
 				};
 			}
 			return {
@@ -894,8 +908,12 @@ export class Log<T> {
 				next: entry.meta.next,
 				wallTime: entry.meta.clock.timestamp.wallTime,
 				logical: entry.meta.clock.timestamp.logical,
+				clockId: entry.meta.clock.id,
+				type: entry.meta.type,
+				metaData: entry.meta.data,
 				payloadSize: entry.payload.byteLength,
 				metaBytes: (entry as EntryWithMetaBytes).getMetaBytes?.(),
+				hashDigestBytes: (entry as EntryWithMetaBytes).getHashDigestBytes?.(),
 			};
 		});
 	}

--- a/packages/programs/data/document/document/benchmark/document-put.ts
+++ b/packages/programs/data/document/document/benchmark/document-put.ts
@@ -404,6 +404,12 @@ const runScenario = async (name: string): Promise<BenchRow> => {
 				),
 				patchAsyncMethod(
 					store.docs.log as any,
+					"persistPreparedCoordinate",
+					profile,
+					"sharedPersistCoordinateMs",
+				),
+				patchAsyncMethod(
+					store.docs.log as any,
 					"persistCoordinatesBatch",
 					profile,
 					"sharedPersistCoordinateMs",

--- a/packages/programs/data/document/document/benchmark/document-put.ts
+++ b/packages/programs/data/document/document/benchmark/document-put.ts
@@ -380,7 +380,19 @@ const runScenario = async (name: string): Promise<BenchRow> => {
 				),
 				patchAsyncMethod(
 					store.docs.log as any,
+					"planNativeLocalAppendFacts",
+					profile,
+					"sharedPlanEntryLeadersMs",
+				),
+				patchAsyncMethod(
+					store.docs.log as any,
 					"planNativeAppendEntry",
+					profile,
+					"sharedPlanEntryLeadersMs",
+				),
+				patchAsyncMethod(
+					store.docs.log as any,
+					"planNativeAppendFacts",
 					profile,
 					"sharedPlanEntryLeadersMs",
 				),

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -4973,18 +4973,29 @@ export class SharedLog<
 			leaders = nativeAppendPlan.leaders;
 			isLeader = nativeAppendPlan.isLeader;
 			nativeDeliveryPlan = nativeAppendPlan.delivery;
-			await this.persistCoordinate({
-				leaders,
-				coordinates,
-				replicas: coordinates.length,
-				entry,
-				assignedToRangeBoundary: nativeAppendPlan.assignedToRangeBoundary,
-				commitNative: false,
-				deleteHashes: properties.extraCoordinateDeleteHashes,
-				hashNumber: nativeAppendPlan.hashNumber,
-				nextHashes: properties.appendFacts?.next,
-				prepared: nativeAppendPlan.preparedCoordinate,
-			});
+			if (properties.appendFacts) {
+				await this.persistPreparedCoordinate({
+					prepared: nativeAppendPlan.preparedCoordinate,
+					hash: properties.appendFacts.hash,
+					nextHashes: properties.appendFacts.next,
+					deleteHashes: properties.extraCoordinateDeleteHashes,
+					coordinates,
+					replicas: coordinates.length,
+					commitNative: false,
+				});
+			} else {
+				await this.persistCoordinate({
+					leaders,
+					coordinates,
+					replicas: coordinates.length,
+					entry,
+					assignedToRangeBoundary: nativeAppendPlan.assignedToRangeBoundary,
+					commitNative: false,
+					deleteHashes: properties.extraCoordinateDeleteHashes,
+					hashNumber: nativeAppendPlan.hashNumber,
+					prepared: nativeAppendPlan.preparedCoordinate,
+				});
+			}
 		} else {
 			({ coordinates, leaders, isLeader } = await this.planEntryLeaders(
 				entry,
@@ -8083,37 +8094,21 @@ export class SharedLog<
 		};
 	}
 
-	private async persistCoordinate(properties: {
+	private async persistPreparedCoordinate(properties: {
+		prepared: PreparedCoordinatePersistence<R>;
+		hash: string;
+		nextHashes: string[];
 		coordinates: NumberFromType<R>[];
-		entry: ShallowOrFullEntry<any> | EntryReplicated<R>;
-		leaders:
-			| Map<
-					string,
-					{
-						intersecting: boolean;
-					}
-			  >
-			| false;
 		replicas: number;
-		prev?: EntryReplicated<R>;
-		assignedToRangeBoundary?: boolean;
 		commitNative?: boolean;
 		deleteHashes?: string[];
-		hashNumber?: NumberFromType<R>;
-		nextHashes?: string[];
-		prepared?: PreparedCoordinatePersistence<R>;
 	}) {
-		const prepared =
-			properties.prepared ?? this.createCoordinatePersistenceEntry(properties);
-		if (!prepared) {
-			return false;
-		}
-		const { coordinateEntry, assignedToRangeBoundary, fields } = prepared;
-		const nextHashes = properties.nextHashes ?? properties.entry.meta.next;
+		const { coordinateEntry, assignedToRangeBoundary, fields } =
+			properties.prepared;
 		const deleteHashes =
 			properties.deleteHashes && properties.deleteHashes.length > 0
-				? [...new Set([...nextHashes, ...properties.deleteHashes])]
-				: nextHashes;
+				? [...new Set([...properties.nextHashes, ...properties.deleteHashes])]
+				: properties.nextHashes;
 		const coordinateIndex = this.entryCoordinatesIndex as PutAndDeleteIndex<
 			EntryReplicated<R>
 		>;
@@ -8147,10 +8142,10 @@ export class SharedLog<
 		}
 		if (properties.commitNative !== false) {
 			this._nativeSharedLogState?.commitEntryCoordinates(
-				properties.entry.hash,
+				properties.hash,
 				coordinateEntry.gid,
 				properties.coordinates,
-				properties.entry.meta.next,
+				properties.nextHashes,
 				assignedToRangeBoundary,
 				properties.replicas,
 				coordinateEntry.hashNumber,
@@ -8158,16 +8153,16 @@ export class SharedLog<
 		}
 		if (this._residentEntryCoordinatesByHash) {
 			this._residentEntryCoordinatesByHash.set(
-				properties.entry.hash,
+				properties.hash,
 				coordinateEntry,
 			);
-			for (const nextHash of nextHashes) {
+			for (const nextHash of properties.nextHashes) {
 				this._residentEntryCoordinatesByHash.delete(nextHash);
 			}
 		}
 
 		for (const coordinate of properties.coordinates) {
-			this.coordinateToHash.add(coordinate, properties.entry.hash);
+			this.coordinateToHash.add(coordinate, properties.hash);
 		}
 
 		if (deleteNextOptions && !coordinateIndex.putAndDelete) {
@@ -8176,6 +8171,42 @@ export class SharedLog<
 			);
 		}
 		return true;
+	}
+
+	private async persistCoordinate(properties: {
+		coordinates: NumberFromType<R>[];
+		entry: ShallowOrFullEntry<any> | EntryReplicated<R>;
+		leaders:
+			| Map<
+					string,
+					{
+						intersecting: boolean;
+					}
+			  >
+			| false;
+		replicas: number;
+		prev?: EntryReplicated<R>;
+		assignedToRangeBoundary?: boolean;
+		commitNative?: boolean;
+		deleteHashes?: string[];
+		hashNumber?: NumberFromType<R>;
+		nextHashes?: string[];
+		prepared?: PreparedCoordinatePersistence<R>;
+	}) {
+		const prepared =
+			properties.prepared ?? this.createCoordinatePersistenceEntry(properties);
+		if (!prepared) {
+			return false;
+		}
+		return this.persistPreparedCoordinate({
+			prepared,
+			hash: properties.entry.hash,
+			nextHashes: properties.nextHashes ?? properties.entry.meta.next,
+			coordinates: properties.coordinates,
+			replicas: properties.replicas,
+			commitNative: properties.commitNative,
+			deleteHashes: properties.deleteHashes,
+		});
 	}
 
 	private async persistCoordinatesBatch(

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -44,6 +44,7 @@ import {
 	Meta,
 	type PreparedAppendFacts,
 	ShallowEntry,
+	ShallowMeta,
 	type ShallowOrFullEntry,
 } from "@peerbit/log";
 import { logger as loggerFn } from "@peerbit/logger";
@@ -492,8 +493,10 @@ interface IndexableDomain<R extends "u32" | "u64"> {
 	constructorEntry: new (properties: {
 		coordinates: NumberFromType<R>[];
 		hash: string;
-		meta: Meta;
+		meta?: Meta | ShallowMeta;
 		metaBytes?: Uint8Array;
+		gid?: string;
+		wallTime?: bigint;
 		assignedToRangeBoundary: boolean;
 		hashNumber: NumberFromType<R>;
 	}) => EntryReplicated<R>;
@@ -4116,8 +4119,8 @@ export class SharedLog<
 				(await this.applyChange(result.change, {
 					deferCoordinateIndexDeletes: true,
 				})) ?? [];
-			nativeAppendPlan = await this.planNativeLocalAppendEntry(
-				result.entry,
+			nativeAppendPlan = await this.planNativeLocalAppendFacts(
+				result.appendFacts,
 				minReplicasValue,
 			);
 			if (!nativeAppendPlan) {
@@ -4131,6 +4134,7 @@ export class SharedLog<
 			nativeAppendPlan =
 				(await this.processLocalAppend(result.entry, result.removed, options, {
 					minReplicasValue,
+					appendFacts: result.appendFacts,
 					nativeAppendPlan,
 					extraCoordinateDeleteHashes: deferredCoordinateDeleteHashes,
 				})) ?? nativeAppendPlan;
@@ -4143,8 +4147,8 @@ export class SharedLog<
 		return {
 			entry: result.entry,
 			removed: result.removed,
-			appendCommit: this.createPreparedLocalAppendCommit(
-				result.entry,
+			appendCommit: this.createPreparedLocalAppendCommitFromFacts(
+				result.appendFacts,
 				nativeAppendPlan,
 			),
 		};
@@ -4518,6 +4522,165 @@ export class SharedLog<
 		return { appendOptions, minReplicasValue };
 	}
 
+	private canPlanNativeAppendFacts(appendFacts: PreparedAppendFacts): boolean {
+		return this.domain.type === "hash" && typeof appendFacts.gid === "string";
+	}
+
+	private getAppendFactsHashNumber(
+		appendFacts: PreparedAppendFacts,
+	): NumberFromType<R> {
+		return this.indexableDomain.numbers.bytesToNumber(
+			appendFacts.hashDigestBytes ?? cidifyString(appendFacts.hash).multihash.digest,
+		);
+	}
+
+	private createCoordinatePersistenceEntryFromNativePlanFacts(properties: {
+		appendFacts: PreparedAppendFacts;
+		plan: NativeAppendCoordinatePlan;
+		prev?: EntryReplicated<R>;
+	}): PreparedCoordinatePersistence<R> | false {
+		if (
+			properties.plan.hash !== properties.appendFacts.hash ||
+			properties.plan.gid !== properties.appendFacts.gid
+		) {
+			return false;
+		}
+
+		const assignedToRangeBoundary = properties.plan.assignedToRangeBoundary;
+		if (
+			properties.prev &&
+			properties.prev.assignedToRangeBoundary === assignedToRangeBoundary
+		) {
+			return false;
+		}
+
+		const coordinates = properties.plan.coordinates as NumberFromType<R>[];
+		const hashNumber = properties.plan.hashNumber as NumberFromType<R>;
+		const coordinateEntry = new this.indexableDomain.constructorEntry({
+			assignedToRangeBoundary,
+			coordinates,
+			metaBytes: properties.appendFacts.metaBytes,
+			gid: properties.appendFacts.gid,
+			wallTime: properties.appendFacts.wallTime,
+			hash: properties.plan.hash,
+			hashNumber,
+		});
+		return {
+			coordinateEntry,
+			assignedToRangeBoundary,
+			fields: {
+				hash: properties.plan.hash,
+				hashNumber,
+				gid: properties.plan.gid,
+				coordinates,
+				wallTime: coordinateEntry.wallTime,
+				assignedToRangeBoundary,
+				metaBytes: coordinateEntry.getMetaBytes(),
+			},
+		};
+	}
+
+	private async planNativeAppendFacts(
+		appendFacts: PreparedAppendFacts,
+		replicas: number,
+		deliveryArg: false | true | DeliveryOptions | undefined,
+	): Promise<NativeAppendEntryPlan<R> | undefined> {
+		if (
+			!this._nativeSharedLogState ||
+			!this.canPlanNativeAppendFacts(appendFacts)
+		) {
+			return undefined;
+		}
+
+		const context = await this.createLeaderSelectionContext();
+		const fullReplicaDeliveryCandidates =
+			await this.getFullReplicaRepairCandidates(undefined, {
+				includeSubscribers: false,
+			});
+		const { delivery, reliability, requireRecipients, minAcks } =
+			this._parseDeliveryOptions(deliveryArg);
+		const hashNumber = this.getAppendFactsHashNumber(appendFacts);
+		const plan = this._nativeSharedLogState.planAppendForGid(
+			{
+				entryHash: appendFacts.hash,
+				gid: appendFacts.gid,
+				hashNumber,
+				nextHashes: appendFacts.next,
+				replicas,
+				fullReplicaCandidates: fullReplicaDeliveryCandidates,
+				selfHash: context.selfHash,
+				deliveryEnabled: !!delivery,
+				reliabilityAck: reliability === "ack",
+				minAcks,
+				requireRecipients,
+			},
+			this.createNativeLeaderOptions(context),
+		);
+		const coordinates = plan.coordinate.coordinates as NumberFromType<R>[];
+		const hashNumberFromPlan = plan.coordinate.hashNumber as NumberFromType<R>;
+		const preparedCoordinate =
+			this.createCoordinatePersistenceEntryFromNativePlanFacts({
+				appendFacts,
+				plan: plan.coordinate,
+			});
+		if (!preparedCoordinate) {
+			return undefined;
+		}
+		return {
+			coordinates,
+			leaders: plan.leaders,
+			isLeader: plan.isLeader,
+			assignedToRangeBoundary: plan.assignedToRangeBoundary,
+			hashNumber: hashNumberFromPlan,
+			preparedCoordinate,
+			delivery: plan.delivery,
+		};
+	}
+
+	private async planNativeLocalAppendFacts(
+		appendFacts: PreparedAppendFacts,
+		replicas: number,
+	): Promise<NativeAppendEntryPlan<R> | undefined> {
+		if (
+			!this._nativeSharedLogState ||
+			!this.canPlanNativeAppendFacts(appendFacts)
+		) {
+			return undefined;
+		}
+
+		const context = await this.createLeaderSelectionContext();
+		const hashNumber = this.getAppendFactsHashNumber(appendFacts);
+		const plan = this._nativeSharedLogState.planLocalAppendForGid(
+			{
+				entryHash: appendFacts.hash,
+				gid: appendFacts.gid,
+				hashNumber,
+				nextHashes: appendFacts.next,
+				replicas,
+				selfHash: context.selfHash,
+			},
+			this.createNativeLeaderOptions(context),
+		);
+		const coordinates = plan.coordinate.coordinates as NumberFromType<R>[];
+		const hashNumberFromPlan = plan.coordinate.hashNumber as NumberFromType<R>;
+		const preparedCoordinate =
+			this.createCoordinatePersistenceEntryFromNativePlanFacts({
+				appendFacts,
+				plan: plan.coordinate,
+			});
+		if (!preparedCoordinate) {
+			return undefined;
+		}
+		return {
+			coordinates,
+			leaders: plan.leaders,
+			isLeader: plan.isLeader,
+			assignedToRangeBoundary: plan.assignedToRangeBoundary,
+			hashNumber: hashNumberFromPlan,
+			preparedCoordinate,
+		};
+	}
+
 	private async planNativeAppendEntry(
 		entry: Entry<T>,
 		replicas: number,
@@ -4750,6 +4913,7 @@ export class SharedLog<
 		options: SharedAppendOptions<T> | undefined,
 		properties: {
 			minReplicasValue: number;
+			appendFacts?: PreparedAppendFacts;
 			deferHeadCoordinatePersistence?: boolean;
 			nativeAppendPlan?: NativeAppendEntryPlan<R>;
 			extraCoordinateDeleteHashes?: string[];
@@ -4766,7 +4930,7 @@ export class SharedLog<
 
 		if (deferHeadCoordinatePersistence) {
 			await this.deleteCoordinatesForHashes([
-				...entry.meta.next,
+				...(properties.appendFacts?.next ?? entry.meta.next),
 				...removed.map((entry) => entry.hash),
 			]);
 			return;
@@ -4779,15 +4943,26 @@ export class SharedLog<
 		if (!nativeAppendPlan && target !== "all") {
 			nativeAppendPlan =
 				target === "none"
-					? await this.planNativeLocalAppendEntry(
-							entry,
-							properties.minReplicasValue,
-						)
-					: await this.planNativeAppendEntry(
-						entry,
-						properties.minReplicasValue,
-						deliveryArg,
-					);
+					? properties.appendFacts
+						? await this.planNativeLocalAppendFacts(
+								properties.appendFacts,
+								properties.minReplicasValue,
+							)
+						: await this.planNativeLocalAppendEntry(
+								entry,
+								properties.minReplicasValue,
+							)
+					: properties.appendFacts
+						? await this.planNativeAppendFacts(
+								properties.appendFacts,
+								properties.minReplicasValue,
+								deliveryArg,
+							)
+						: await this.planNativeAppendEntry(
+								entry,
+								properties.minReplicasValue,
+								deliveryArg,
+							);
 		}
 		let coordinates: NumberFromType<R>[];
 		let leaders: LeaderMap;
@@ -4807,6 +4982,7 @@ export class SharedLog<
 				commitNative: false,
 				deleteHashes: properties.extraCoordinateDeleteHashes,
 				hashNumber: nativeAppendPlan.hashNumber,
+				nextHashes: properties.appendFacts?.next,
 				prepared: nativeAppendPlan.preparedCoordinate,
 			});
 		} else {
@@ -7924,6 +8100,7 @@ export class SharedLog<
 		commitNative?: boolean;
 		deleteHashes?: string[];
 		hashNumber?: NumberFromType<R>;
+		nextHashes?: string[];
 		prepared?: PreparedCoordinatePersistence<R>;
 	}) {
 		const prepared =
@@ -7932,7 +8109,7 @@ export class SharedLog<
 			return false;
 		}
 		const { coordinateEntry, assignedToRangeBoundary, fields } = prepared;
-		const nextHashes = properties.entry.meta.next;
+		const nextHashes = properties.nextHashes ?? properties.entry.meta.next;
 		const deleteHashes =
 			properties.deleteHashes && properties.deleteHashes.length > 0
 				? [...new Set([...nextHashes, ...properties.deleteHashes])]

--- a/packages/programs/data/shared-log/src/ranges.ts
+++ b/packages/programs/data/shared-log/src/ranges.ts
@@ -131,24 +131,33 @@ export class EntryReplicatedU32 implements EntryReplicated<"u32"> {
 	constructor(properties: {
 		coordinates: number[];
 		hash: string;
-		meta: Meta;
+		meta?: Meta | ShallowMeta;
 		metaBytes?: Uint8Array;
+		gid?: string;
+		wallTime?: bigint;
 		assignedToRangeBoundary: boolean;
 		hashNumber: number;
 	}) {
+		if (!properties.meta && !properties.metaBytes) {
+			throw new Error("Expected meta or metaBytes");
+		}
+		if (!properties.meta && (properties.gid == null || properties.wallTime == null)) {
+			throw new Error("Expected gid and wallTime with metaBytes");
+		}
 		this.coordinates = properties.coordinates;
 		this.hash = properties.hash;
-		this.gid = properties.meta.gid;
-		this.wallTime = properties.meta.clock.timestamp.wallTime;
+		this.gid = properties.meta?.gid ?? properties.gid!;
+		this.wallTime =
+			properties.meta?.clock.timestamp.wallTime ?? properties.wallTime!;
 		this.hashNumber = properties.hashNumber;
 		this._meta =
 			properties.metaBytes ??
 			serialize(
 				properties.meta instanceof Meta
 					? new ShallowMeta(properties.meta)
-					: properties.meta,
+					: properties.meta!,
 			);
-		this._metaResolved = properties.meta;
+		this._metaResolved = properties.meta as ShallowMeta;
 		this.assignedToRangeBoundary = properties.assignedToRangeBoundary;
 	}
 
@@ -192,24 +201,33 @@ export class EntryReplicatedU64 implements EntryReplicated<"u64"> {
 	constructor(properties: {
 		coordinates: bigint[];
 		hash: string;
-		meta: Meta;
+		meta?: Meta | ShallowMeta;
 		metaBytes?: Uint8Array;
+		gid?: string;
+		wallTime?: bigint;
 		assignedToRangeBoundary: boolean;
 		hashNumber: bigint;
 	}) {
+		if (!properties.meta && !properties.metaBytes) {
+			throw new Error("Expected meta or metaBytes");
+		}
+		if (!properties.meta && (properties.gid == null || properties.wallTime == null)) {
+			throw new Error("Expected gid and wallTime with metaBytes");
+		}
 		this.coordinates = properties.coordinates;
 		this.hash = properties.hash;
 		this.hashNumber = properties.hashNumber;
-		this.gid = properties.meta.gid;
-		this.wallTime = properties.meta.clock.timestamp.wallTime;
+		this.gid = properties.meta?.gid ?? properties.gid!;
+		this.wallTime =
+			properties.meta?.clock.timestamp.wallTime ?? properties.wallTime!;
 		this._meta =
 			properties.metaBytes ??
 			serialize(
 				properties.meta instanceof Meta
 					? new ShallowMeta(properties.meta)
-					: properties.meta,
+					: properties.meta!,
 			);
-		this._metaResolved = properties.meta;
+		this._metaResolved = properties.meta as ShallowMeta;
 		this.assignedToRangeBoundary = properties.assignedToRangeBoundary;
 	}
 

--- a/packages/programs/data/shared-log/test/append.spec.ts
+++ b/packages/programs/data/shared-log/test/append.spec.ts
@@ -216,6 +216,14 @@ describe("append", () => {
 			store.log as any,
 			"planNativeLocalAppendFacts",
 		);
+		const persistCoordinateSpy = sinon.spy(
+			store.log as any,
+			"persistCoordinate",
+		);
+		const persistPreparedSpy = sinon.spy(
+			store.log as any,
+			"persistPreparedCoordinate",
+		);
 		try {
 			const result = await store.log.appendLocallyPrepared(
 				{ op: "ADD", value: "a" },
@@ -229,6 +237,8 @@ describe("append", () => {
 			expect(createFactsSpy.callCount).equal(1);
 			expect(planEntrySpy.callCount).equal(0);
 			expect(planFactsSpy.callCount).equal(1);
+			expect(persistCoordinateSpy.callCount).equal(0);
+			expect(persistPreparedSpy.callCount).equal(1);
 			expect(putDeleteSpy.callCount).equal(1);
 			const fields = putDeleteSpy.firstCall.args[1];
 			expect(fields.hash).equal(result.entry.hash);
@@ -254,6 +264,8 @@ describe("append", () => {
 			);
 			expect(result.appendCommit.coordinateFields).to.deep.equal(fields);
 		} finally {
+			persistPreparedSpy.restore();
+			persistCoordinateSpy.restore();
 			planFactsSpy.restore();
 			planEntrySpy.restore();
 			createFactsSpy.restore();

--- a/packages/programs/data/shared-log/test/append.spec.ts
+++ b/packages/programs/data/shared-log/test/append.spec.ts
@@ -204,6 +204,18 @@ describe("append", () => {
 			store.log as any,
 			"createCoordinatePersistenceEntry",
 		);
+		const createFactsSpy = sinon.spy(
+			store.log as any,
+			"createCoordinatePersistenceEntryFromNativePlanFacts",
+		);
+		const planEntrySpy = sinon.spy(
+			store.log as any,
+			"planNativeLocalAppendEntry",
+		);
+		const planFactsSpy = sinon.spy(
+			store.log as any,
+			"planNativeLocalAppendFacts",
+		);
 		try {
 			const result = await store.log.appendLocallyPrepared(
 				{ op: "ADD", value: "a" },
@@ -214,6 +226,9 @@ describe("append", () => {
 			);
 
 			expect(createSpy.callCount).equal(0);
+			expect(createFactsSpy.callCount).equal(1);
+			expect(planEntrySpy.callCount).equal(0);
+			expect(planFactsSpy.callCount).equal(1);
 			expect(putDeleteSpy.callCount).equal(1);
 			const fields = putDeleteSpy.firstCall.args[1];
 			expect(fields.hash).equal(result.entry.hash);
@@ -239,6 +254,9 @@ describe("append", () => {
 			);
 			expect(result.appendCommit.coordinateFields).to.deep.equal(fields);
 		} finally {
+			planFactsSpy.restore();
+			planEntrySpy.restore();
+			createFactsSpy.restore();
 			createSpy.restore();
 			putDeleteSpy.restore();
 		}

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -1944,18 +1944,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		}
 
 		return this.enqueueMutation(async () => {
-			await this.enqueuePersistence(async () => {
-				for (const entry of prepared) {
-					await this.snapshotFile!.appendPut(
-						entry.storeKey,
-						entry.value,
-						this.properties.schema,
-					);
-					for (const deleteKey of entry.deleteKeys) {
-						await this.snapshotFile!.appendDelete(deleteKey);
-					}
-				}
-			});
+			await this.appendPutAndDeletesBatch(prepared);
 			const deletedEntries = prepared.flatMap((entry) =>
 				this.getNative().put_and_delete_keys(
 					entry.storeKey,
@@ -2314,8 +2303,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		}
 
 		return this.enqueueMutation(async () => {
-			await this.appendPut(storeKey, value);
-			await this.appendDeletes(deleteKeys);
+			await this.appendPutAndDeletes(storeKey, value, deleteKeys);
 			const deletedEntries = this.getNative().put_and_delete_keys(
 				storeKey,
 				id,
@@ -2577,12 +2565,42 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		);
 	}
 
+	private appendPutAndDeletes(
+		storeKey: string,
+		value: T,
+		deleteKeys: string[],
+		encodedValue?: EncodedValue,
+	): Promise<void> {
+		return this.appendPutAndDeletesBatch([
+			{ storeKey, value, deleteKeys, encodedValue },
+		]);
+	}
+
+	private appendPutAndDeletesBatch(
+		entries: Array<{
+			storeKey: string;
+			value: T;
+			deleteKeys: string[];
+			encodedValue?: EncodedValue;
+		}>,
+	): Promise<void> {
+		return this.enqueuePersistence(() =>
+			this.snapshotFile!.appendPutAndDeleteBatch(
+				entries.map((entry) => ({
+					key: entry.storeKey,
+					value: entry.value,
+					encodedValue: entry.encodedValue,
+					deleteKeys: entry.deleteKeys,
+				})),
+				this.properties.schema,
+			),
+		);
+	}
+
 	private appendDeletes(storeKeys: string[]): Promise<void> {
-		return this.enqueuePersistence(async () => {
-			for (const storeKey of storeKeys) {
-				await this.snapshotFile!.appendDelete(storeKey);
-			}
-		});
+		return this.enqueuePersistence(() =>
+			this.snapshotFile!.appendDeleteBatch(storeKeys),
+		);
 	}
 
 	private async compactIfNeeded(): Promise<void> {

--- a/packages/utils/indexer/rust/src/persistence.ts
+++ b/packages/utils/indexer/rust/src/persistence.ts
@@ -31,7 +31,17 @@ export type SnapshotFile = {
 		}>,
 		schema: AbstractType<T>,
 	): Promise<void>;
+	appendPutAndDeleteBatch<T extends Record<string, any>>(
+		values: Array<{
+			key: string;
+			value: T;
+			encodedValue?: EncodedValue;
+			deleteKeys?: string[];
+		}>,
+		schema: AbstractType<T>,
+	): Promise<void>;
 	appendDelete(key: string): Promise<void>;
+	appendDeleteBatch(keys: string[]): Promise<void>;
 	compact<T extends Record<string, any>>(
 		values: T[],
 		schema: AbstractType<T>,
@@ -298,6 +308,35 @@ const encodeJournalPayload = <T extends Record<string, any>>(
 	return output;
 };
 
+const encodePutAndDeleteRecords = <T extends Record<string, any>>(
+	values: Array<{
+		key: string;
+		value: T;
+		encodedValue?: EncodedValue;
+		deleteKeys?: string[];
+	}>,
+	schema: AbstractType<T>,
+): Uint8Array[] => {
+	const payloads: Uint8Array[] = [];
+	for (const entry of values) {
+		payloads.push(
+			encodeJournalPayload(
+				JournalOperation.Put,
+				entry.key,
+				schema,
+				entry.value,
+				entry.encodedValue,
+			),
+		);
+		for (const deleteKey of entry.deleteKeys ?? []) {
+			payloads.push(
+				encodeJournalPayload(JournalOperation.Delete, deleteKey),
+			);
+		}
+	}
+	return payloads;
+};
+
 const encodeJournalRecord = (payload: Uint8Array): Uint8Array => {
 	const output = new Uint8Array(8 + payload.byteLength);
 	let offset = 0;
@@ -465,8 +504,26 @@ class NativeSnapshotFile implements SnapshotFile {
 		);
 	}
 
+	async appendPutAndDeleteBatch<T extends Record<string, any>>(
+		values: Array<{
+			key: string;
+			value: T;
+			encodedValue?: EncodedValue;
+			deleteKeys?: string[];
+		}>,
+		schema: AbstractType<T>,
+	): Promise<void> {
+		await this.appendRecords(encodePutAndDeleteRecords(values, schema));
+	}
+
 	async appendDelete(key: string): Promise<void> {
 		await this.appendRecord(encodeJournalPayload(JournalOperation.Delete, key));
+	}
+
+	async appendDeleteBatch(keys: string[]): Promise<void> {
+		await this.appendRecords(
+			keys.map((key) => encodeJournalPayload(JournalOperation.Delete, key)),
+		);
 	}
 
 	async compact<T extends Record<string, any>>(
@@ -709,8 +766,26 @@ class OpfsSnapshotFile implements SnapshotFile {
 		);
 	}
 
+	async appendPutAndDeleteBatch<T extends Record<string, any>>(
+		values: Array<{
+			key: string;
+			value: T;
+			encodedValue?: EncodedValue;
+			deleteKeys?: string[];
+		}>,
+		schema: AbstractType<T>,
+	): Promise<void> {
+		await this.appendRecords(encodePutAndDeleteRecords(values, schema));
+	}
+
 	async appendDelete(key: string): Promise<void> {
 		await this.appendRecord(encodeJournalPayload(JournalOperation.Delete, key));
+	}
+
+	async appendDeleteBatch(keys: string[]): Promise<void> {
+		await this.appendRecords(
+			keys.map((key) => encodeJournalPayload(JournalOperation.Delete, key)),
+		);
 	}
 
 	async compact<T extends Record<string, any>>(


### PR DESCRIPTION
## Summary

Stacked on #930. This moves the single prepared append path one step further up the stack by carrying lower-log prepared append facts into shared-log native leader/coordinate planning.

- `Log.appendLocallyPrepared(...)` now returns a single `PreparedAppendFacts`, matching the existing batch append-facts boundary.
- Prepared append facts include clock id, entry type, metadata bytes, and prepared hash digest bytes when available.
- `SharedLog.appendLocallyPrepared(...)` uses facts-based native planning and facts-based prepared coordinate construction instead of re-reading equivalent metadata from `Entry`.
- Coordinate rows can be constructed directly from prepared meta bytes plus gid/wallTime, avoiding replacement `ShallowMeta` allocation in the facts path.
- `persistCoordinate(...)` can accept prepared next hashes, avoiding another entry-meta read when native append facts are available.
- The document-put deep benchmark now includes facts-based shared-log planners in `sharedPlanEntryLeadersMs`.

No public API change is intended; this is still the trusted/internal prepared append path.

## Benchmark

```bash
DOC_WARMUP=50 DOC_ITERATIONS=5000 DOC_SCENARIOS=rust-peerbit,rust-peerbit-transient-index,rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

#930 baseline:

- `rust-peerbit`: 4325 ops/sec, shared append 889.88 ms, shared coordinate persistence 152.17 ms, total 1156.04 ms
- `rust-peerbit-transient-index`: 5070 ops/sec, shared append 771.79 ms, total 986.28 ms
- `rust-peerbit-nonunique`: 5325 ops/sec, shared append 740.54 ms, total 938.98 ms
- `rust-peerbit-transient-index-nonunique`: 5685 ops/sec, shared append 697.98 ms, total 879.56 ms

This branch:

- `rust-peerbit`: 4472 ops/sec, shared append 863.19 ms, shared coordinate persistence 149.96 ms, total 1118.06 ms
- `rust-peerbit-transient-index`: 4857 ops/sec, shared append 804.22 ms, total 1029.46 ms
- `rust-peerbit-nonunique`: 5383 ops/sec, shared append 733.00 ms, total 928.88 ms
- `rust-peerbit-transient-index-nonunique`: 5676 ops/sec, shared append 697.02 ms, total 880.90 ms

Read: the clearest signal is the primary persistent `rust-peerbit` row, about +3.4% vs #930 and about +33.7% vs #929. Other rows are mixed/noisy; this PR is mainly a shared-log boundary cleanup that sets up deeper coalescence.

## Validation

- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "persists native append coordinate fields from the prepared plan|coalesces prepared append trim coordinate deletes into the coordinate put"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses the validated local append path for plain puts|uses the validated local append path for document updates|independent native prepared batch path|batches rust index"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "uses single native committed append bookkeeping"`
- `pnpm exec eslint --config eslint.config.js packages/log/src/log.ts packages/programs/data/shared-log/src/index.ts packages/programs/data/shared-log/src/ranges.ts packages/programs/data/shared-log/test/append.spec.ts packages/programs/data/document/document/benchmark/document-put.ts`
- `git diff --check`
