### PR TITLE
Lighten native single append transaction path

### DIFF
--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -884,9 +884,12 @@ export class EntryV0<T>
 							: gid;
 			}
 		} else {
-			gid =
-				properties.meta?.gid ||
-				(await EntryV0.createGid(properties.meta?.gidSeed));
+			if (properties.meta?.gid) {
+				gid = properties.meta.gid;
+			} else {
+				const createdGid = EntryV0.createGid(properties.meta?.gidSeed);
+				gid = isPromiseLike(createdGid) ? await createdGid : createdGid;
+			}
 		}
 
 		const clocks = properties.meta?.clocks();

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -101,6 +101,11 @@ const getSharedLogFanoutService = (
 	services: unknown,
 ): FanoutTree | undefined =>
 	(services as SharedLogServicesWithFanout).fanout;
+
+type MaybePromise<T> = T | Promise<T>;
+
+const isPromiseLike = <T>(value: MaybePromise<T>): value is Promise<T> =>
+	!!value && typeof (value as Promise<T>).then === "function";
 import {
 	EXCHANGE_HEADS_REPAIR_HINT,
 	EntryWithRefs,
@@ -4115,10 +4120,11 @@ export class SharedLog<
 		let nativeAppendPlan: NativeAppendEntryPlan<R> | undefined;
 		let deferredCoordinateDeleteHashes: string[] | undefined;
 		if (this.canCoalescePreparedAppendCoordinateDeletes(result, options)) {
+			const changeResult = this.applyChange(result.change, {
+				deferCoordinateIndexDeletes: true,
+			});
 			deferredCoordinateDeleteHashes =
-				(await this.applyChange(result.change, {
-					deferCoordinateIndexDeletes: true,
-				})) ?? [];
+				(isPromiseLike(changeResult) ? await changeResult : changeResult) ?? [];
 			nativeAppendPlan = await this.planNativeLocalAppendFacts(
 				result.appendFacts,
 				minReplicasValue,
@@ -4128,7 +4134,10 @@ export class SharedLog<
 				deferredCoordinateDeleteHashes = undefined;
 			}
 		} else {
-			await this.onChange(result.change);
+			const changeResult = this.applyChange(result.change);
+			if (isPromiseLike(changeResult)) {
+				await changeResult;
+			}
 		}
 		try {
 			nativeAppendPlan =
@@ -4224,7 +4233,10 @@ export class SharedLog<
 			return undefined;
 		}
 
-		await this.onChange(result.change);
+		const changeResult = this.applyChange(result.change);
+		if (isPromiseLike(changeResult)) {
+			await changeResult;
+		}
 		const deferHeadCoordinatePersistence =
 			this.shouldDeferHeadCoordinatePersistence(options);
 
@@ -6273,18 +6285,38 @@ export class SharedLog<
 	}
 
 	async onChange(change: Change<T>): Promise<void> {
-		await this.applyChange(change);
+		const result = this.applyChange(change);
+		if (isPromiseLike(result)) {
+			await result;
+		}
 	}
 
-	private async applyChange(
+	private applyChange(
 		change: Change<T>,
 		options?: { deferCoordinateIndexDeletes?: boolean },
-	): Promise<string[] | undefined> {
+	): MaybePromise<string[] | undefined> {
 		const deferredCoordinateDeleteHashes: string[] = [];
 		for (const added of change.added) {
 			this.onEntryAdded(added.entry);
 		}
-		for (const removed of change.removed) {
+		if (change.removed.length === 0) {
+			return options?.deferCoordinateIndexDeletes
+				? deferredCoordinateDeleteHashes
+				: undefined;
+		}
+		return this.applyRemovedChange(
+			change.removed,
+			deferredCoordinateDeleteHashes,
+			options,
+		);
+	}
+
+	private async applyRemovedChange(
+		removedEntries: ShallowOrFullEntry<T>[],
+		deferredCoordinateDeleteHashes: string[],
+		options?: { deferCoordinateIndexDeletes?: boolean },
+	): Promise<string[] | undefined> {
+		for (const removed of removedEntries) {
 			if (options?.deferCoordinateIndexDeletes) {
 				deferredCoordinateDeleteHashes.push(removed.hash);
 			} else {
@@ -10313,7 +10345,7 @@ export class SharedLog<
 		return range;
 	}
 
-	private async onEntryAdded(entry: Entry<any>) {
+	private onEntryAdded(entry: Entry<any>) {
 		const ih = this._pendingIHave.get(entry.hash);
 
 		if (ih) {

--- a/packages/utils/indexer/rust/src/lib.rs
+++ b/packages/utils/indexer/rust/src/lib.rs
@@ -1093,22 +1093,18 @@ fn insert_bytes_facts(
     field: u32,
     bytes: Vec<u8>,
 ) -> Result<(), JsValue> {
-    fields.insert_scoped_scalar(
-        scope,
-        FieldPath::Id(field),
-        FieldValue::Bytes(bytes.clone()),
-    );
-    if bytes.len() > state.byte_element_index_limit {
-        return Ok(());
+    let index_byte_elements = bytes.len() <= state.byte_element_index_limit;
+    if index_byte_elements {
+        for byte in bytes.iter().copied() {
+            let byte_scope = state.next_scope()?;
+            fields.insert_scoped_scalar(
+                byte_scope,
+                FieldPath::Id(field),
+                FieldValue::U64(byte as u64),
+            );
+        }
     }
-    for byte in bytes {
-        let byte_scope = state.next_scope()?;
-        fields.insert_scoped_scalar(
-            byte_scope,
-            FieldPath::Id(field),
-            FieldValue::U64(byte as u64),
-        );
-    }
+    fields.insert_scoped_scalar(scope, FieldPath::Id(field), FieldValue::Bytes(bytes));
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Stacked on #931. This continues the single `Documents.put()` native path work without waiting on slow CI by trimming avoidable JS orchestration around the existing native append/index boundaries.

Changes:
- Avoid an unconditional `await` during lower-log gid generation when the gid is generated synchronously from random bytes.
- Let shared-log prepared append apply local change bookkeeping synchronously when there is no real async coordinate delete work.
- Remove an unnecessary `async` promise allocation from `onEntryAdded`.
- In the Rust indexer, keep exact byte matching while moving the byte vector into the exact `Bytes` fact instead of cloning it before optional per-byte indexing.

## Benchmark

Local node run from `packages/programs/data/document/document`:

```bash
DOC_WARMUP=50 DOC_ITERATIONS=5000 DOC_SCENARIOS=rust-peerbit,rust-peerbit-transient-index,rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Rows:
- `rust-peerbit`: 4748 ops/sec, total 1053.17 ms, shared append 801.92 ms, log append 521.32 ms, log create native append chain 346.03 ms.
- `rust-peerbit-transient-index`: 5308 ops/sec, total 941.95 ms.
- `rust-peerbit-nonunique`: 5692 ops/sec, total 878.35 ms.
- `rust-peerbit-transient-index-nonunique`: 5696 ops/sec, total 877.83 ms.

Read: useful but still mixed/noisy total signal. Persistent single-put and nonunique improve locally; transient rows remain in the normal noise band. This is a cleanup/foundation PR, not a major throughput-claim PR.

## Validation

- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `cargo fmt --manifest-path packages/utils/indexer/rust/Cargo.toml --check`
- `cargo test --manifest-path packages/utils/indexer/rust/Cargo.toml`
- `pnpm exec eslint --config eslint.config.js packages/log/src/entry-v0.ts packages/programs/data/shared-log/src/index.ts packages/utils/indexer/rust/src/index.ts`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "uses single native committed append bookkeeping|append commits one block and graph in one native call when storage is native"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "persists native append coordinate fields from the prepared plan|coalesces prepared append trim coordinate deletes into the coordinate put"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses the validated local append path for plain puts|uses the independent native prepared batch path for unique putMany|batches rust index and coordinate writes for unique putMany|uses the validated local append path for document updates"`
- `pnpm --filter @peerbit/indexer-rust exec aegir test -t node --grep "ByteMatchQuery|byte|IntegerCompare"`