### PR TITLE
Use sync native document context planning

### DIFF
--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -14,6 +14,8 @@ import {
 import {
 	planDocumentContext,
 	planDocumentContextBatch,
+	tryPlanDocumentContext,
+	tryPlanDocumentContextBatch,
 } from "@peerbit/document-rust";
 import type { QueryCacheOptions } from "@peerbit/indexer-cache";
 import * as indexerTypes from "@peerbit/indexer-interface";
@@ -1138,13 +1140,16 @@ export class Documents<
 		const append = appended.appendCommit;
 		const existing =
 			input.unique || input.existing === null ? null : input.existing;
-		const contextPlan = await planDocumentContext({
+		const contextInput = {
 			existingCreated: existing?.value.__context.created,
 			modified: append.wallTime,
 			head: append.hash,
 			gid: append.gid,
 			size: append.payloadSize,
-		});
+		};
+		const contextPlan =
+			tryPlanDocumentContext(contextInput) ??
+			(await planDocumentContext(contextInput));
 		return this.createDocumentAppendCommitFactsWithContext(
 			input,
 			appended,
@@ -1162,20 +1167,21 @@ export class Documents<
 			};
 		}>,
 	): Promise<DocumentAppendCommitFacts<T, I>[]> {
-		const contextPlans = await planDocumentContextBatch(
-			rows.map(({ input, appended }) => {
-				const append = appended.appendCommit;
-				const existing =
-					input.unique || input.existing === null ? null : input.existing;
-				return {
-					existingCreated: existing?.value.__context.created,
-					modified: append.wallTime,
-					head: append.hash,
-					gid: append.gid,
-					size: append.payloadSize,
-				};
-			}),
-		);
+		const contextInputs = rows.map(({ input, appended }) => {
+			const append = appended.appendCommit;
+			const existing =
+				input.unique || input.existing === null ? null : input.existing;
+			return {
+				existingCreated: existing?.value.__context.created,
+				modified: append.wallTime,
+				head: append.hash,
+				gid: append.gid,
+				size: append.payloadSize,
+			};
+		});
+		const contextPlans =
+			tryPlanDocumentContextBatch(contextInputs) ??
+			(await planDocumentContextBatch(contextInputs));
 		return rows.map((row, index) =>
 			this.createDocumentAppendCommitFactsWithContext(
 				row.input,

--- a/packages/programs/data/document/rust/src/index.ts
+++ b/packages/programs/data/document/rust/src/index.ts
@@ -57,6 +57,7 @@ type WasmModule = {
 };
 
 let wasmModulePromise: Promise<WasmModule> | undefined;
+let wasmModule: WasmModule | undefined;
 let wasmInitialized = false;
 
 const loadWasm = async (): Promise<WasmModule> => {
@@ -89,6 +90,7 @@ const loadWasm = async (): Promise<WasmModule> => {
 		}
 		wasmInitialized = true;
 	}
+	wasmModule = wasm;
 
 	return wasm;
 };
@@ -152,10 +154,10 @@ const toContextPlan = (
 	contextBytes: copyBytes(row[1]),
 });
 
-export const planDocumentContext = async (
+const planDocumentContextWithWasm = (
+	wasm: WasmModule,
 	input: DocumentCommitContextInput,
-): Promise<DocumentCommitContextPlan> => {
-	const wasm = await loadWasm();
+): DocumentCommitContextPlan => {
 	const row = wasm.plan_document_context(
 		asOptionalU64String(input.existingCreated),
 		asU64String(input.modified),
@@ -166,13 +168,13 @@ export const planDocumentContext = async (
 	return toContextPlan(input, row);
 };
 
-export const planDocumentContextBatch = async (
+const planDocumentContextBatchWithWasm = (
+	wasm: WasmModule,
 	inputs: DocumentCommitContextInput[],
-): Promise<DocumentCommitContextPlan[]> => {
+): DocumentCommitContextPlan[] => {
 	if (inputs.length === 0) {
 		return [];
 	}
-	const wasm = await loadWasm();
 	const rows = wasm.plan_document_context_batch(
 		inputs.map((input) => asOptionalU64String(input.existingCreated)),
 		inputs.map((input) => asU64String(input.modified)),
@@ -181,4 +183,37 @@ export const planDocumentContextBatch = async (
 		Uint32Array.from(inputs.map((input) => input.size)),
 	);
 	return rows.map((row, index) => toContextPlan(inputs[index]!, row));
+};
+
+export const tryPlanDocumentContext = (
+	input: DocumentCommitContextInput,
+): DocumentCommitContextPlan | undefined => {
+	return wasmInitialized && wasmModule
+		? planDocumentContextWithWasm(wasmModule, input)
+		: undefined;
+};
+
+export const tryPlanDocumentContextBatch = (
+	inputs: DocumentCommitContextInput[],
+): DocumentCommitContextPlan[] | undefined => {
+	return wasmInitialized && wasmModule
+		? planDocumentContextBatchWithWasm(wasmModule, inputs)
+		: undefined;
+};
+
+export const planDocumentContext = async (
+	input: DocumentCommitContextInput,
+): Promise<DocumentCommitContextPlan> => {
+	const wasm = await loadWasm();
+	return planDocumentContextWithWasm(wasm, input);
+};
+
+export const planDocumentContextBatch = async (
+	inputs: DocumentCommitContextInput[],
+): Promise<DocumentCommitContextPlan[]> => {
+	if (inputs.length === 0) {
+		return [];
+	}
+	const wasm = await loadWasm();
+	return planDocumentContextBatchWithWasm(wasm, inputs);
 };


### PR DESCRIPTION
## Summary

Stacked on #932. This removes one steady-state async boundary from the plain document put fast path while keeping the context planner in Rust.

Changes:
- `@peerbit/document-rust` caches the initialized WASM module.
- Adds `tryPlanDocumentContext(...)` and `tryPlanDocumentContextBatch(...)` for the already-initialized case.
- `Documents` uses the sync Rust planner when available and falls back to the existing async planner on cold start.

This preserves the same Rust-generated context bytes and does not change public APIs.

## Benchmark

Local node command from `packages/programs/data/document/document`:

```bash
DOC_WARMUP=50 DOC_ITERATIONS=5000 DOC_SCENARIOS=rust-peerbit,rust-peerbit-transient-index,rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Run 1:
- `rust-peerbit`: 4826 ops/sec, total 1036.11 ms
- `rust-peerbit-transient-index`: 5613 ops/sec, total 890.78 ms
- `rust-peerbit-nonunique`: 5245 ops/sec, total 953.37 ms
- `rust-peerbit-transient-index-nonunique`: 6055 ops/sec, total 825.78 ms

Run 2:
- `rust-peerbit`: 4710 ops/sec, total 1061.49 ms
- `rust-peerbit-transient-index`: 5217 ops/sec, total 958.49 ms
- `rust-peerbit-nonunique`: 5793 ops/sec, total 863.08 ms
- `rust-peerbit-transient-index-nonunique`: 5880 ops/sec, total 850.29 ms

Read: this is a steady-state boundary cleanup, not a major throughput headline. The full product benchmark remains noisy, but the branch removes a real resolved-promise hop from the document commit context planner.

## Validation

- `pnpm --filter @peerbit/document-rust run build`
- `pnpm --filter @peerbit/document run build`
- `cargo test --manifest-path packages/programs/data/document/rust/Cargo.toml`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/document/document/src/program.ts packages/programs/data/document/rust/src/index.ts`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses the validated local append path for plain puts|uses the independent native prepared batch path for unique putMany|batches rust index and coordinate writes for unique putMany|uses the validated local append path for document updates"`
- `git diff --check`