### PR TITLE
Add identity document index commit path

### DIFF
--- a/packages/programs/data/document/document/benchmark/document-put.ts
+++ b/packages/programs/data/document/document/benchmark/document-put.ts
@@ -347,7 +347,19 @@ const runScenario = async (name: string): Promise<BenchRow> => {
 			),
 			patchAsyncMethod(
 				store.docs.index,
+				"_putIdentityWithContext",
+				profile,
+				"documentIndexPutMs",
+			),
+			patchAsyncMethod(
+				store.docs.index,
 				"putManyWithContext",
+				profile,
+				"documentIndexPutMs",
+			),
+			patchAsyncMethod(
+				store.docs.index,
+				"_putManyIdentityWithContext",
 				profile,
 				"documentIndexPutMs",
 			),

--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -1282,7 +1282,7 @@ export class Documents<
 		}
 
 		if (!modified.has(commit.key.primitive)) {
-			const { indexable } = await this._index.putWithContext(
+			const indexedDocument = await this._index._putIdentityWithContext(
 				commit.document,
 				commit.key,
 				commit.context,
@@ -1291,12 +1291,25 @@ export class Documents<
 					encodedValueParts: commit.contextualEncodedValueParts,
 				},
 			);
-			documentsChanged.added.push(
-				coerceWithIndexed(
-					coerceWithContext(commit.document, commit.context),
-					indexable,
-				),
-			);
+			if (indexedDocument) {
+				documentsChanged.added.push(indexedDocument);
+			} else {
+				const { indexable } = await this._index.putWithContext(
+					commit.document,
+					commit.key,
+					commit.context,
+					{
+						replace: existing != null,
+						encodedValueParts: commit.contextualEncodedValueParts,
+					},
+				);
+				documentsChanged.added.push(
+					coerceWithIndexed(
+						coerceWithContext(commit.document, commit.context),
+						indexable,
+					),
+				);
+			}
 			modified.add(commit.key.primitive);
 		}
 
@@ -1366,7 +1379,7 @@ export class Documents<
 			});
 			modified.add(put.key.primitive);
 		}
-		const indexed = await this._index.putManyWithContext(
+		const indexedDocuments = await this._index._putManyIdentityWithContext(
 			putsToIndex.map((put) => ({
 				value: put.document,
 				id: put.key,
@@ -1377,12 +1390,30 @@ export class Documents<
 				},
 			})),
 		);
-		for (let i = 0; i < putsToIndex.length; i++) {
-			const put = putsToIndex[i]!;
-			const { indexable } = indexed[i]!;
-			documentsChanged.added.push(
-				coerceWithIndexed(coerceWithContext(put.document, put.context), indexable),
+		if (indexedDocuments) {
+			documentsChanged.added.push(...indexedDocuments);
+		} else {
+			const indexed = await this._index.putManyWithContext(
+				putsToIndex.map((put) => ({
+					value: put.document,
+					id: put.key,
+					context: put.context,
+					options: {
+						replace: false,
+						encodedValueParts: put.contextualEncodedValueParts,
+					},
+				})),
 			);
+			for (let i = 0; i < putsToIndex.length; i++) {
+				const put = putsToIndex[i]!;
+				const { indexable } = indexed[i]!;
+				documentsChanged.added.push(
+					coerceWithIndexed(
+						coerceWithContext(put.document, put.context),
+						indexable,
+					),
+				);
+			}
 		}
 
 		const handledRemovedHeads =

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -1751,6 +1751,109 @@ export class DocumentIndex<
 		);
 	}
 
+	public async _putIdentityWithContext(
+		value: T,
+		id: indexerTypes.IdKey,
+		context: types.Context,
+		options?: ContextualPutOptions,
+	): Promise<WithIndexedContext<T, I> | undefined> {
+		const contextualPut = this.transformerIsIdentity
+			? (this.index as ContextualIndexPut<I>).putWithContext
+			: undefined;
+		if (!contextualPut || this.isProgramValued) {
+			return;
+		}
+		const indexable = value as any as I;
+		const indexedValue = coerceWithIndexed(
+			coerceWithContext(value, context),
+			indexable,
+		);
+		this.cacheResolvedValue(id.primitive, value);
+		try {
+			await contextualPut.call(
+				this.index,
+				indexable,
+				id,
+				context,
+				this.withContextualEncodedValue(options, context),
+			);
+		} catch (error) {
+			if (error instanceof indexerTypes.NotStartedError && this.closed) {
+				return indexedValue;
+			}
+			throw error;
+		}
+		return indexedValue;
+	}
+
+	public async _putManyIdentityWithContext(
+		values: Array<{
+			value: T;
+			id: indexerTypes.IdKey;
+			context: types.Context;
+			options?: ContextualPutOptions;
+		}>,
+	): Promise<WithIndexedContext<T, I>[] | undefined> {
+		if (values.length === 0) {
+			return [];
+		}
+		const contextualPut = this.transformerIsIdentity
+			? (this.index as ContextualIndexPut<I>).putWithContext
+			: undefined;
+		const contextualBatchPut = this.transformerIsIdentity
+			? (this.index as ContextualIndexPut<I>).putWithContextBatch
+			: undefined;
+		if ((!contextualBatchPut && !contextualPut) || this.isProgramValued) {
+			return;
+		}
+
+		const indexedValues = values.map((item) => {
+			const indexable = item.value as any as I;
+			this.cacheResolvedValue(item.id.primitive, item.value);
+			return {
+				indexable,
+				value: coerceWithIndexed(
+					coerceWithContext(item.value, item.context),
+					indexable,
+				),
+			};
+		});
+
+		try {
+			if (contextualBatchPut) {
+				await contextualBatchPut.call(
+					this.index,
+					values.map((item, index) => ({
+						value: indexedValues[index]!.indexable,
+						id: item.id,
+						context: item.context,
+						options: this.withContextualEncodedValue(
+							item.options,
+							item.context,
+						),
+					})),
+				);
+			} else {
+				for (let i = 0; i < values.length; i++) {
+					const item = values[i]!;
+					await contextualPut!.call(
+						this.index,
+						indexedValues[i]!.indexable,
+						item.id,
+						item.context,
+						this.withContextualEncodedValue(item.options, item.context),
+					);
+				}
+			}
+		} catch (error) {
+			if (error instanceof indexerTypes.NotStartedError && this.closed) {
+				return indexedValues.map((item) => item.value);
+			}
+			throw error;
+		}
+		return indexedValues.map((item) => item.value);
+	}
+
 	public async put(
 		value: T,
 		id: indexerTypes.IdKey,
@@ -1788,22 +1891,7 @@ export class DocumentIndex<
 		options?: ContextualPutOptions,
 	): Promise<{ context: types.Context; indexable: I }> {
 		const idString = id.primitive;
-		if (
-			this.isProgramValued /*
-			TODO should we skip caching program value if they are not openend through this db?
-			&&
-			(value as Program).closed === false &&
-			(value as Program).parents.includes(this._log) */
-		) {
-			// TODO make last condition more efficient if there are many docs
-			this._resolverProgramCache!.set(idString, value);
-			indexCacheLogger("cache:set:program", { id: idString });
-		} else {
-			if (this._resolverCache) {
-				this._resolverCache.add(idString, value);
-				indexCacheLogger("cache:set:value", { id: idString });
-			}
-		}
+		this.cacheResolvedValue(idString, value);
 		const valueToIndex = this.transformerIsIdentity
 			? (value as any as I)
 			: await this.transformer(value, context);
@@ -1872,14 +1960,7 @@ export class DocumentIndex<
 			transformed = new Array(values.length);
 			for (let i = 0; i < values.length; i++) {
 				const item = values[i]!;
-				const idString = item.id.primitive;
-				if (this.isProgramValued) {
-					this._resolverProgramCache!.set(idString, item.value);
-					indexCacheLogger("cache:set:program", { id: idString });
-				} else if (this._resolverCache) {
-					this._resolverCache.add(idString, item.value);
-					indexCacheLogger("cache:set:value", { id: idString });
-				}
+				this.cacheResolvedValue(item.id.primitive, item.value);
 				const indexable = item.value as any as I;
 				coerceWithIndexed(item.value, indexable);
 				coerceWithContext(item.value, item.context);
@@ -1888,14 +1969,7 @@ export class DocumentIndex<
 		} else {
 			transformed = await Promise.all(
 				values.map(async (item) => {
-					const idString = item.id.primitive;
-					if (this.isProgramValued) {
-						this._resolverProgramCache!.set(idString, item.value);
-						indexCacheLogger("cache:set:program", { id: idString });
-					} else if (this._resolverCache) {
-						this._resolverCache.add(idString, item.value);
-						indexCacheLogger("cache:set:value", { id: idString });
-					}
+					this.cacheResolvedValue(item.id.primitive, item.value);
 					const indexable = await this.transformer(item.value, item.context);
 					coerceWithIndexed(item.value, indexable);
 					coerceWithContext(item.value, item.context);
@@ -1967,6 +2041,25 @@ export class DocumentIndex<
 			context: item.context,
 			indexable: item.indexable,
 		}));
+	}
+
+	private cacheResolvedValue(
+		id: string | number | bigint,
+		value: T,
+	): void {
+		if (
+			this.isProgramValued /*
+			TODO should we skip caching program value if they are not openend through this db?
+			&&
+			(value as Program).closed === false &&
+			(value as Program).parents.includes(this._log) */
+		) {
+			this._resolverProgramCache!.set(id, value);
+			indexCacheLogger("cache:set:program", { id });
+		} else if (this._resolverCache) {
+			this._resolverCache.add(id, value);
+			indexCacheLogger("cache:set:value", { id });
+		}
 	}
 
 	private withContextualEncodedValue(

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -207,6 +207,11 @@ describe("index", () => {
 					store.docs as any,
 					"createDocumentAppendCommitFacts",
 				);
+				const documentIdentityPutSpy = sinon.spy(
+					store.docs.index,
+					"_putIdentityWithContext",
+				);
+				const documentPutSpy = sinon.spy(store.docs.index, "putWithContext");
 				const backendIndex = store.docs.index.index as any;
 				const originalBackendPutWithContext = backendIndex.putWithContext;
 				const originalBackendPut = backendIndex.put;
@@ -240,10 +245,12 @@ describe("index", () => {
 					expect(validatedAppendSpy.callCount).equal(0);
 					expect(appendSpy.callCount).equal(0);
 					expect(localLookupSpy.callCount).equal(0);
-					expect(commitPlanSpy.callCount).equal(1);
-					expect(nativeCommitSpy.callCount).equal(1);
-					expect(documentCommitSpy.callCount).equal(1);
-					expect(backendContextPutSpy.callCount).equal(1);
+				expect(commitPlanSpy.callCount).equal(1);
+				expect(nativeCommitSpy.callCount).equal(1);
+				expect(documentCommitSpy.callCount).equal(1);
+				expect(documentIdentityPutSpy.callCount).equal(1);
+				expect(documentPutSpy.callCount).equal(0);
+				expect(backendContextPutSpy.callCount).equal(1);
 					const encodedDocument = serialize(doc);
 					const expectedPayloadData = new Uint8Array(
 						6 + encodedDocument.byteLength,
@@ -326,11 +333,13 @@ describe("index", () => {
 						delete backendIndex.putWithContext;
 					}
 					localLookupSpy.restore();
-					commitPlanSpy.restore();
-					nativeCommitSpy.restore();
-					documentCommitSpy.restore();
-					preparedPayloadAppendSpy.restore();
-					preparedAppendSpy.restore();
+				commitPlanSpy.restore();
+				nativeCommitSpy.restore();
+				documentCommitSpy.restore();
+				documentPutSpy.restore();
+				documentIdentityPutSpy.restore();
+				preparedPayloadAppendSpy.restore();
+				preparedAppendSpy.restore();
 					validatedAppendSpy.restore();
 					appendSpy.restore();
 				}
@@ -374,6 +383,10 @@ describe("index", () => {
 				const appendSpy = sinon.spy(store.docs.log, "append");
 				const documentBatchIndexSpy = sinon.spy(
 					store.docs.index,
+					"_putManyIdentityWithContext",
+				);
+				const documentGenericBatchIndexSpy = sinon.spy(
+					store.docs.index,
 					"putManyWithContext",
 				);
 				const documentIndexPutSpy = sinon.spy(
@@ -412,6 +425,7 @@ describe("index", () => {
 					expect(appendSpy.callCount).equal(0);
 					expect(nativeBatchCommitSpy.callCount).equal(1);
 					expect(documentBatchIndexSpy.callCount).equal(1);
+					expect(documentGenericBatchIndexSpy.callCount).equal(1);
 					expect(documentIndexPutSpy.callCount).equal(0);
 					expect(nativeBatchPlanSpy.callCount).equal(1);
 					expect(nativeLocalPlanSpy.callCount).equal(0);
@@ -467,10 +481,11 @@ describe("index", () => {
 					}
 				} finally {
 					nativeBatchPlanSpy.restore();
-					nativeLocalPlanSpy.restore();
-					nativeBatchCommitSpy.restore();
-					documentIndexPutSpy.restore();
-					documentBatchIndexSpy.restore();
+				nativeLocalPlanSpy.restore();
+				nativeBatchCommitSpy.restore();
+				documentIndexPutSpy.restore();
+				documentGenericBatchIndexSpy.restore();
+				documentBatchIndexSpy.restore();
 					appendSpy.restore();
 					preparedAppendSpy.restore();
 					lowerBatchAppendSpy.restore();


### PR DESCRIPTION
## Summary

Stacked on #933. This gives the prepared document fast path an internal identity-context indexing boundary instead of always routing through the generic `putWithContext` / `putManyWithContext` wrappers.

Changes:
- Adds internal `DocumentIndex._putIdentityWithContext(...)` for identity-transform, non-program document commits with contextual backend support.
- Adds internal `DocumentIndex._putManyIdentityWithContext(...)` for the same batch path, using backend `putWithContextBatch` when available and falling back to per-entry contextual puts.
- Factors resolver-cache writes into one helper so generic and identity paths keep the same cache behavior.
- Prepared single and batch document commits try the identity-context helper first, then fall back to existing generic paths for custom transformers, program-valued documents, or legacy backends.
- Updates the document-put benchmark instrumentation to include the new identity-context helpers under `documentIndexPutMs`.

No public API change is intended; the helpers are internal fast-path hooks on the existing class.

## Benchmark

Single-put command from `packages/programs/data/document/document`:

```bash
DOC_WARMUP=50 DOC_ITERATIONS=5000 DOC_SCENARIOS=rust-peerbit,rust-peerbit-transient-index,rust-peerbit-nonunique,rust-peerbit-transient-index-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Rows:
- `rust-peerbit`: 4724 ops/sec, total 1058.35 ms, document index put 86.57 ms, backend index put 79.00 ms.
- `rust-peerbit-transient-index`: 5646 ops/sec, total 885.62 ms, document index put 57.04 ms, backend index put 50.79 ms.
- `rust-peerbit-nonunique`: 5388 ops/sec, total 928.01 ms, document index put 60.38 ms, backend index put 53.95 ms.
- `rust-peerbit-transient-index-nonunique`: 6032 ops/sec, total 828.85 ms, document index put 54.80 ms, backend index put 49.40 ms.

Batch command:

```bash
DOC_WARMUP=20 DOC_ITERATIONS=1000 DOC_SCENARIOS=rust-peerbit-putmany,rust-peerbit-transient-index-putmany DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Rows:
- `rust-peerbit-putmany`: 5829 ops/sec, total 171.56 ms, document index put 11.33 ms.
- `rust-peerbit-transient-index-putmany`: 7368 ops/sec, total 135.73 ms, document index put 8.49 ms.

Read: this removes generic wrapper work from eligible identity document commits, but product-level single put is still dominated by shared/lower-log append and coordinate persistence. Batch stays in the established healthy band.

## Validation

- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses the validated local append path for plain puts|uses the independent native prepared batch path for unique putMany|batches rust index and coordinate writes for unique putMany|uses the validated local append path for document updates"`
- `pnpm exec eslint --config eslint.config.js packages/programs/data/document/document/src/program.ts packages/programs/data/document/document/src/search.ts packages/programs/data/document/document/test/index.spec.ts packages/programs/data/document/document/benchmark/document-put.ts` (passes with one pre-existing warning in `test/index.spec.ts`)
- `git diff --check`