### PR TITLE
Optimize native coordinate facts and trim

### DIFF
--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -1485,7 +1485,10 @@ export class EntryIndex<T> {
 		);
 	}
 
-	async deleteMany(from: ShallowEntry[]): Promise<ShallowEntry[]> {
+	async deleteMany(
+		from: ShallowEntry[],
+		options?: { skipNextHeadUpdates?: boolean },
+	): Promise<ShallowEntry[]> {
 		if (from.length === 0) {
 			return [];
 		}
@@ -1574,13 +1577,15 @@ export class EntryIndex<T> {
 				graph?.delete(hash);
 			}
 		}
-		const deletedNexts: string[] = [];
-		for (const node of deleted) {
-			if (node.meta.type !== EntryType.CUT) {
-				deletedNexts.push(...node.meta.next);
+		if (!options?.skipNextHeadUpdates) {
+			const deletedNexts: string[] = [];
+			for (const node of deleted) {
+				if (node.meta.type !== EntryType.CUT) {
+					deletedNexts.push(...node.meta.next);
+				}
 			}
+			await this.privateUpdateNextHeadHashes(deletedNexts, true);
 		}
-		await this.privateUpdateNextHeadHashes(deletedNexts, true);
 		return deleted;
 	}
 

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -353,7 +353,10 @@ export class Log<T> {
 				deleteNodes: this._entryIndex.canDeleteMany()
 					? async (
 							nodes: ShallowEntry[],
-							options?: { resolveDeletedEntry?: boolean },
+							options?: {
+								resolveDeletedEntry?: boolean;
+								skipNextHeadUpdates?: boolean;
+							},
 						) => {
 							if (nodes.length === 0) {
 								return [];
@@ -371,7 +374,9 @@ export class Log<T> {
 									}
 								}
 							}
-							const deleted = await this._entryIndex.deleteMany(nodes);
+							const deleted = await this._entryIndex.deleteMany(nodes, {
+								skipNextHeadUpdates: options?.skipNextHeadUpdates,
+							});
 							return shouldResolve
 								? deleted
 										.map((node) => resolvedByHash.get(node.hash))

--- a/packages/log/src/trim.ts
+++ b/packages/log/src/trim.ts
@@ -88,7 +88,7 @@ interface Log<T> {
 	) => Promise<Entry<T> | ShallowEntry | undefined>;
 	deleteNodes?: (
 		nodes: ShallowEntry[],
-		options?: { resolveDeletedEntry?: boolean },
+		options?: { resolveDeletedEntry?: boolean; skipNextHeadUpdates?: boolean },
 	) => Promise<(Entry<T> | ShallowEntry)[]>;
 	getLength(): number;
 }
@@ -325,6 +325,9 @@ export class Trim<T> {
 					deleted.push(
 						...(await this._log.deleteNodes(nodes, {
 							resolveDeletedEntry: options?.resolveDeletedEntries,
+							// Oldest-first trim only removes entries whose next links point
+							// further back into the same deleted prefix.
+							skipNextHeadUpdates: true,
 						})),
 					);
 				}
@@ -340,6 +343,9 @@ export class Trim<T> {
 				deleted.push(
 					...(await this._log.deleteNodes(nodes, {
 						resolveDeletedEntry: options?.resolveDeletedEntries,
+						// Oldest-first trim only removes entries whose next links point
+						// further back into the same deleted prefix.
+						skipNextHeadUpdates: true,
 					})),
 				);
 			}

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -438,7 +438,7 @@ describe("native graph", () => {
 		}
 	});
 
-	it("skips missing next index lookups during native length trim", async () => {
+	it("skips next-head lookups during native length trim", async () => {
 		const log = new Log<Uint8Array>();
 		await log.open(store, signKey, {
 			appendDurability: "strict",
@@ -468,7 +468,7 @@ describe("native graph", () => {
 			expect(oldestEntriesSpy.callCount).equal(1);
 			expect(oldestEntriesSpy.firstCall.args[0]).equal(2);
 			expect(log.length).equal(1);
-			expect(hasManySpy.callCount).greaterThan(0);
+			expect(hasManySpy.callCount).equal(0);
 			expect(indexGetSpy.callCount).equal(0);
 		} finally {
 			indexGetSpy.restore();

--- a/packages/programs/data/document/document/benchmark/document-put.ts
+++ b/packages/programs/data/document/document/benchmark/document-put.ts
@@ -93,6 +93,8 @@ type Profile = {
 	sharedProcessLocalAppendMs: number;
 	sharedProcessLocalAppendBatchMs: number;
 	sharedPlanEntryLeadersMs: number;
+	sharedLeaderContextMs: number;
+	sharedCoordinatePrepareMs: number;
 	sharedPersistCoordinateMs: number;
 	logAppendMs: number;
 	logGetNextsForAppendMs: number;
@@ -118,6 +120,8 @@ const deepProfileKeys = new Set<keyof Profile>([
 	"sharedProcessLocalAppendMs",
 	"sharedProcessLocalAppendBatchMs",
 	"sharedPlanEntryLeadersMs",
+	"sharedLeaderContextMs",
+	"sharedCoordinatePrepareMs",
 	"sharedPersistCoordinateMs",
 	"logGetNextsForAppendMs",
 	"logCreateNativeAppendChainMs",
@@ -134,6 +138,8 @@ const emptyProfile = (): Profile => ({
 	sharedProcessLocalAppendMs: 0,
 	sharedProcessLocalAppendBatchMs: 0,
 	sharedPlanEntryLeadersMs: 0,
+	sharedLeaderContextMs: 0,
+	sharedCoordinatePrepareMs: 0,
 	sharedPersistCoordinateMs: 0,
 	logAppendMs: 0,
 	logGetNextsForAppendMs: 0,
@@ -187,6 +193,37 @@ const patchAsyncMethod = (
 	}
 	target[key] = async function patched(this: unknown, ...args: unknown[]) {
 		return time(profile, profileKey, () => original.apply(this, args));
+	};
+	return () => {
+		target[key] = original;
+	};
+};
+
+const timeSync = <T>(
+	profile: Profile,
+	key: keyof Profile,
+	fn: () => T,
+): T => {
+	const started = performance.now();
+	try {
+		return fn();
+	} finally {
+		profile[key] += performance.now() - started;
+	}
+};
+
+const patchSyncMethod = (
+	target: any,
+	key: string,
+	profile: Profile,
+	profileKey: keyof Profile,
+) => {
+	const original = target[key];
+	if (typeof original !== "function") {
+		return () => {};
+	}
+	target[key] = function patched(this: unknown, ...args: unknown[]) {
+		return timeSync(profile, profileKey, () => original.apply(this, args));
 	};
 	return () => {
 		target[key] = original;
@@ -386,6 +423,12 @@ const runScenario = async (name: string): Promise<BenchRow> => {
 				),
 				patchAsyncMethod(
 					store.docs.log as any,
+					"createLeaderSelectionContext",
+					profile,
+					"sharedLeaderContextMs",
+				),
+				patchAsyncMethod(
+					store.docs.log as any,
 					"planNativeLocalAppendEntry",
 					profile,
 					"sharedPlanEntryLeadersMs",
@@ -407,6 +450,18 @@ const runScenario = async (name: string): Promise<BenchRow> => {
 					"planNativeAppendFacts",
 					profile,
 					"sharedPlanEntryLeadersMs",
+				),
+				patchSyncMethod(
+					store.docs.log as any,
+					"createCoordinatePersistenceEntryFromNativePlanFacts",
+					profile,
+					"sharedCoordinatePrepareMs",
+				),
+				patchSyncMethod(
+					store.docs.log as any,
+					"createCoordinatePersistenceEntryFromNativePlan",
+					profile,
+					"sharedCoordinatePrepareMs",
 				),
 				patchAsyncMethod(
 					store.docs.log as any,

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -4568,15 +4568,18 @@ export class SharedLog<
 
 		const coordinates = properties.plan.coordinates as NumberFromType<R>[];
 		const hashNumber = properties.plan.hashNumber as NumberFromType<R>;
+		const wallTime = properties.appendFacts.wallTime;
 		const coordinateEntry = new this.indexableDomain.constructorEntry({
 			assignedToRangeBoundary,
 			coordinates,
 			metaBytes: properties.appendFacts.metaBytes,
 			gid: properties.appendFacts.gid,
-			wallTime: properties.appendFacts.wallTime,
+			wallTime,
 			hash: properties.plan.hash,
 			hashNumber,
 		});
+		const metaBytes =
+			properties.appendFacts.metaBytes ?? coordinateEntry.getMetaBytes();
 		return {
 			coordinateEntry,
 			assignedToRangeBoundary,
@@ -4585,9 +4588,9 @@ export class SharedLog<
 				hashNumber,
 				gid: properties.plan.gid,
 				coordinates,
-				wallTime: coordinateEntry.wallTime,
+				wallTime,
 				assignedToRangeBoundary,
-				metaBytes: coordinateEntry.getMetaBytes(),
+				metaBytes,
 			},
 		};
 	}

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -734,6 +734,99 @@ type SharedLogCoordinateNativeFields = {
 	metaBytes: Uint8Array;
 };
 
+const sharedLogCoordinateTextEncoder = new TextEncoder();
+const sharedLogCoordinateU32Variant =
+	sharedLogCoordinateTextEncoder.encode("entry-u32");
+const sharedLogCoordinateU64Variant =
+	sharedLogCoordinateTextEncoder.encode("entry-u64");
+
+const sharedLogCoordinateSetU32 = (
+	view: DataView,
+	offset: number,
+	value: number,
+): number => {
+	view.setUint32(offset, value, true);
+	return offset + 4;
+};
+
+const sharedLogCoordinateSetU64 = (
+	view: DataView,
+	offset: number,
+	value: number | bigint,
+): number => {
+	view.setBigUint64(offset, BigInt(value), true);
+	return offset + 8;
+};
+
+const sharedLogCoordinateWriteBytes = (
+	output: Uint8Array,
+	view: DataView,
+	offset: number,
+	bytes: Uint8Array,
+): number => {
+	offset = sharedLogCoordinateSetU32(view, offset, bytes.byteLength);
+	output.set(bytes, offset);
+	return offset + bytes.byteLength;
+};
+
+const encodeSharedLogCoordinateValue = (
+	fields: SharedLogCoordinateNativeFields,
+	useU64: boolean,
+): Uint8Array => {
+	const variantBytes = useU64
+		? sharedLogCoordinateU64Variant
+		: sharedLogCoordinateU32Variant;
+	const hashBytes = sharedLogCoordinateTextEncoder.encode(fields.hash);
+	const gidBytes = sharedLogCoordinateTextEncoder.encode(fields.gid);
+	const numberBytes = useU64 ? 8 : 4;
+	const output = new Uint8Array(
+		4 +
+			variantBytes.byteLength +
+			4 +
+			hashBytes.byteLength +
+			numberBytes +
+			4 +
+			gidBytes.byteLength +
+			4 +
+			numberBytes * fields.coordinates.length +
+			8 +
+			1 +
+			4 +
+			fields.metaBytes.byteLength,
+	);
+	const view = new DataView(output.buffer, output.byteOffset, output.byteLength);
+	let offset = 0;
+	offset = sharedLogCoordinateWriteBytes(output, view, offset, variantBytes);
+	offset = sharedLogCoordinateWriteBytes(output, view, offset, hashBytes);
+	if (useU64) {
+		offset = sharedLogCoordinateSetU64(view, offset, fields.hashNumber);
+	} else {
+		offset = sharedLogCoordinateSetU32(view, offset, Number(fields.hashNumber));
+	}
+	offset = sharedLogCoordinateWriteBytes(output, view, offset, gidBytes);
+	offset = sharedLogCoordinateSetU32(
+		view,
+		offset,
+		fields.coordinates.length,
+	);
+	for (const coordinate of fields.coordinates) {
+		if (useU64) {
+			offset = sharedLogCoordinateSetU64(view, offset, coordinate);
+		} else {
+			offset = sharedLogCoordinateSetU32(view, offset, Number(coordinate));
+		}
+	}
+	offset = sharedLogCoordinateSetU64(view, offset, fields.wallTime);
+	output[offset++] = fields.assignedToRangeBoundary ? 1 : 0;
+	offset = sharedLogCoordinateWriteBytes(
+		output,
+		view,
+		offset,
+		fields.metaBytes,
+	);
+	return output;
+};
+
 type NativeEncodedValueParts = {
 	prefix: Uint8Array;
 	suffix: Uint8Array;
@@ -1903,6 +1996,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			id,
 			this.encodeSharedLogCoordinateFields(fields),
 			deleteIds.map(keyToStoreKey),
+			this.encodeSharedLogCoordinatePersistenceValue(fields),
 		);
 	}
 
@@ -1926,6 +2020,9 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				storeKey: keyToStoreKey(id),
 				fields: this.encodeSharedLogCoordinateFields(entry.fields),
 				deleteKeys: (entry.deleteIds ?? []).map(keyToStoreKey),
+				encodedValue: this.encodeSharedLogCoordinatePersistenceValue(
+					entry.fields,
+				),
 			};
 		});
 
@@ -2196,6 +2293,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		value: T,
 		id: types.IdKey,
 		fields: Uint8Array,
+		encodedValue?: EncodedValue,
 	): Promise<void> {
 		const storeKey = keyToStoreKey(id);
 		if (!this.snapshotFile) {
@@ -2203,7 +2301,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			return;
 		}
 		await this.enqueueMutation(async () => {
-			await this.appendPut(storeKey, value);
+			await this.appendPut(storeKey, value, encodedValue);
 			this.getNative().put(storeKey, id, value, fields);
 			await this.compactIfNeeded();
 		});
@@ -2290,9 +2388,10 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		id: types.IdKey,
 		fields: Uint8Array,
 		deleteKeys: string[],
+		encodedValue?: EncodedValue,
 	): Promise<types.IdKey[]> {
 		if (deleteKeys.length === 0) {
-			await this.putWithEncodedFields(value, id, fields);
+			await this.putWithEncodedFields(value, id, fields, encodedValue);
 			return [];
 		}
 		const storeKey = keyToStoreKey(id);
@@ -2303,7 +2402,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		}
 
 		return this.enqueueMutation(async () => {
-			await this.appendPutAndDeletes(storeKey, value, deleteKeys);
+			await this.appendPutAndDeletes(storeKey, value, deleteKeys, encodedValue);
 			const deletedEntries = this.getNative().put_and_delete_keys(
 				storeKey,
 				id,
@@ -2333,6 +2432,25 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			]),
 			meta: nativeFieldId(this.fieldDictionary, ["_meta"]),
 		});
+	}
+
+	private encodeSharedLogCoordinatePersistenceValue(
+		fields: SharedLogCoordinateNativeFields,
+	): Uint8Array | undefined {
+		const schemaName = (this.properties.schema as { name?: string }).name;
+		if (
+			schemaName === "EntryReplicatedU32" &&
+			typeof fields.hashNumber !== "bigint"
+		) {
+			return encodeSharedLogCoordinateValue(fields, false);
+		}
+		if (
+			schemaName === "EntryReplicatedU64" &&
+			typeof fields.hashNumber === "bigint"
+		) {
+			return encodeSharedLogCoordinateValue(fields, true);
+		}
+		return undefined;
 	}
 
 	private encodeSharedLogCoordinateFields(


### PR DESCRIPTION
## Summary

This continues the native single-put performance stack on top of #934.

Changes:
- Reuse prepared append-fact `wallTime`/`metaBytes` when building shared-log coordinate persistence fields.
- Add a real `EntryReplicatedU32/U64` coordinate WAL encoder in `@peerbit/indexer-rust` so the hot shared-log coordinate path avoids generic `serialize(value)` during durable coordinate put/delete writes.
- Keep compatible schemas on the existing generic persistence fallback.
- Split document-put deep profile output into `sharedLeaderContextMs` and `sharedCoordinatePrepareMs`.
- Skip next-head update lookups during unfiltered oldest-prefix length trim.

## Benchmarks

Local single put, Node, 2026-05-11:

```bash
DOC_WARMUP=100 DOC_ITERATIONS=10000 DOC_SCENARIOS=rust-peerbit,rust-peerbit-nonunique DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./benchmark/document-put.ts
```

Before the trim skip on this branch:
- `rust-peerbit`: 4839 ops/sec, `logTrimMs` 158.39 ms, `logTrimUnfilteredLengthMs` 134.97 ms
- `rust-peerbit-nonunique`: 5469 ops/sec, `logTrimMs` 120.71 ms, `logTrimUnfilteredLengthMs` 103.78 ms

After:
- `rust-peerbit`: 4830 ops/sec, `logTrimMs` 141.93 ms, `logTrimUnfilteredLengthMs` 118.52 ms
- `rust-peerbit-nonunique`: 5692 ops/sec, `logTrimMs` 110.69 ms, `logTrimUnfilteredLengthMs` 94.82 ms

5k matrix after:
- `rust-peerbit`: 4693 ops/sec
- `rust-peerbit-transient-index`: 5383 ops/sec
- `rust-peerbit-nonunique`: 5805 ops/sec
- `rust-peerbit-transient-index-nonunique`: 6121 ops/sec

Read: trim has a clear local improvement; total single-put remains noisy because lower-log native entry creation and shared-coordinate persistence still dominate.

## Validation

- Manual byte check: direct coordinate WAL encoder matches `@dao-xyz/borsh` for `EntryReplicatedU32` and `EntryReplicatedU64`.
- `pnpm --filter @peerbit/indexer-rust run build`
- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/utils/indexer/rust -- -t node --grep "indexes shared-log coordinate fields through the typed native path|replays durable shared-log coordinate fields from the typed native path|compacts the journal"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "trim"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "persists native append coordinate fields from the prepared plan|coalesces prepared append trim coordinate deletes into the coordinate put"`
- `pnpm exec eslint --config eslint.config.js packages/utils/indexer/rust/src/index.ts packages/programs/data/shared-log/src/index.ts packages/programs/data/document/document/benchmark/document-put.ts packages/log/src/trim.ts packages/log/src/log.ts packages/log/src/entry-index.ts packages/log/test/native-graph.spec.ts`
- `git diff --check`
