### PR TITLE
Slim native commit-only log append

### DIFF
--- a/packages/log/rust/src/index.ts
+++ b/packages/log/rust/src/index.ts
@@ -136,6 +136,16 @@ type NativeLogIndexHandle = {
 		metaData: Uint8Array | undefined,
 		payloadData: Uint8Array,
 	) => EntryV0PreparedPlainEntryRow;
+	prepare_entry_v0_plain_entry_storage_and_put_with_builder?: (
+		builder: NativeEntryV0PlainBuilderHandle,
+		wallTime: bigint,
+		logical: number,
+		gid: string,
+		next: string[],
+		type: number,
+		metaData: Uint8Array | undefined,
+		payloadData: Uint8Array,
+	) => EntryV0PreparedPlainEntryStorageRow;
 	prepare_entry_v0_plain_chain_commit_blocks_and_put: (
 		blockStore: NativeLogBlockStoreHandle,
 		clockId: Uint8Array,
@@ -631,6 +641,25 @@ export class LogGraphIndex {
 		input: EntryV0PlainEntryInput,
 	): EntryV0PreparedPlainEntry {
 		const builder = this.getPlainEntryBuilder(input);
+		const storageOnly =
+			input.includeMaterializationBytes === false
+				? this.native.prepare_entry_v0_plain_entry_storage_and_put_with_builder
+				: undefined;
+		if (storageOnly) {
+			return preparedPlainEntryStorageRow(
+				storageOnly.call(
+					this.native,
+					builder,
+					BigInt(input.wallTime),
+					input.logical ?? 0,
+					input.gid,
+					input.next ?? [],
+					input.type ?? 0,
+					input.metaData,
+					input.payloadData,
+				),
+			);
+		}
 		return preparedPlainEntryRow(
 			this.native.prepare_entry_v0_plain_entry_and_put_with_builder(
 				builder,
@@ -1089,6 +1118,7 @@ export type EntryV0PlainEntryInput = {
 	type?: number;
 	metaData?: Uint8Array;
 	payloadData: Uint8Array;
+	includeMaterializationBytes?: boolean;
 };
 
 export type EntryV0PlainEntriesInput = {
@@ -1106,11 +1136,11 @@ export type EntryV0PlainEntriesInput = {
 
 export type EntryV0PreparedPlainEntry = EntryV0EncodedStorage & {
 	byteLength: number;
-	signature: Uint8Array;
+	signature?: Uint8Array;
 	next: string[];
-	metaBytes: Uint8Array;
-	payloadBytes: Uint8Array;
-	signatureBytes: Uint8Array;
+	metaBytes?: Uint8Array;
+	payloadBytes?: Uint8Array;
+	signatureBytes?: Uint8Array;
 	hashDigestBytes?: Uint8Array;
 };
 
@@ -1130,6 +1160,13 @@ type EntryV0PreparedPlainEntryRow = [
 	Uint8Array,
 	Uint8Array,
 	Uint8Array?,
+];
+
+type EntryV0PreparedPlainEntryStorageRow = [
+	Uint8Array,
+	string,
+	string[],
+	number,
 ];
 
 type EntryV0CommittedPlainEntryRow = [
@@ -1206,6 +1243,18 @@ const preparedPlainEntryRow = ([
 	payloadBytes,
 	signatureBytes,
 	hashDigestBytes,
+});
+
+const preparedPlainEntryStorageRow = ([
+	bytes,
+	cid,
+	next,
+	byteLength,
+]: EntryV0PreparedPlainEntryStorageRow): EntryV0PreparedPlainEntry => ({
+	bytes,
+	cid,
+	byteLength,
+	next,
 });
 
 const preparedPlainEntryRows = (

--- a/packages/log/rust/src/lib.rs
+++ b/packages/log/rust/src/lib.rs
@@ -979,6 +979,34 @@ impl NativeLogIndex {
         Ok(row)
     }
 
+    pub fn prepare_entry_v0_plain_entry_storage_and_put_with_builder(
+        &mut self,
+        builder: &NativeEntryV0PlainBuilder,
+        wall_time: u64,
+        logical: u32,
+        gid: String,
+        next: Array,
+        entry_type: u8,
+        meta_data: JsValue,
+        payload_data: Uint8Array,
+    ) -> Result<Array, JsValue> {
+        let (row, entry, initial_nexts, _block) =
+            prepare_entry_v0_plain_entry_storage_row_with_signer(
+                &builder.clock_id,
+                &builder.public_key,
+                &builder.signing_key,
+                wall_time,
+                logical,
+                gid,
+                next,
+                entry_type,
+                meta_data,
+                payload_data,
+            )?;
+        self.inner.put_append_chain(vec![entry], &initial_nexts);
+        Ok(row)
+    }
+
     pub fn prepare_entry_v0_plain_chain_commit_blocks_and_put(
         &mut self,
         block_store: &mut NativeLogBlockStore,
@@ -1650,6 +1678,68 @@ fn prepare_entry_v0_plain_entry_row_with_signer(
         payload_data,
         include_storage_bytes,
     )
+}
+
+fn prepare_entry_v0_plain_entry_storage_row_with_signer(
+    clock_id: &[u8],
+    public_key: &[u8],
+    signing_key: &SigningKey,
+    wall_time: u64,
+    logical: u32,
+    gid: String,
+    next: Array,
+    entry_type: u8,
+    meta_data: JsValue,
+    payload_data: Uint8Array,
+) -> Result<(Array, LogIndexEntry, Vec<String>, (String, Vec<u8>)), JsValue> {
+    let next = strings_from_array(next)?;
+    let payload_data = payload_data.to_vec();
+    let meta_data = optional_bytes_from_js(meta_data);
+    let payload_size = payload_data.len() as u32;
+
+    let input = EntryV0EncodeInput {
+        clock_id: clock_id.to_vec(),
+        wall_time,
+        logical,
+        gid: gid.clone(),
+        next: next.clone(),
+        entry_type,
+        meta_data,
+        payload_data,
+    };
+    let meta = encode_meta(&input);
+    let payload = encode_payload(&input.payload_data);
+    let signable = encode_entry_v0_parts(&meta, &payload, None);
+    let signature = sign_ed25519_with_key(signing_key, &signable);
+    let signature_input = SignatureInput {
+        signature,
+        public_key: public_key.to_vec(),
+        prehash: 0,
+    };
+    let signature_with_key = encode_signature_with_key(&signature_input);
+    let storage =
+        encode_entry_v0_parts_with_signature_bytes(&meta, &payload, Some(&signature_with_key));
+    let storage_len = storage.len();
+    let (cid, _hash_digest) = calculate_raw_cid_v1_parts(&storage);
+
+    let row = Array::new();
+    row.push(&Uint8Array::from(storage.as_slice()));
+    row.push(&JsValue::from_str(&cid));
+    row.push(&strings_to_array(next.clone()));
+    row.push(&JsValue::from_f64(storage_len as f64));
+
+    let entry = LogIndexEntry::new_with_data(
+        cid.clone(),
+        gid,
+        next.clone(),
+        entry_type,
+        input.wall_time,
+        input.logical,
+        payload_size,
+        true,
+        input.meta_data.clone(),
+    );
+    Ok((row, entry, next, (cid, storage)))
 }
 
 fn prepare_entry_v0_plain_entry_row_with_signer_parts(

--- a/packages/log/rust/test/index.spec.ts
+++ b/packages/log/rust/test/index.spec.ts
@@ -573,16 +573,16 @@ describe("native EntryV0 encoding", () => {
 
 		expect(chain).to.have.length(3);
 		expect(chain[0]!.next).to.deep.equal(["root"]);
-		expect(chain[1]!.next).to.deep.equal([chain[0]!.cid]);
-		expect(chain[2]!.next).to.deep.equal([chain[1]!.cid]);
-		for (const prepared of chain) {
-			expect(prepared.cid).to.equal(await calculateRawCidV1(prepared.bytes));
-			expect(prepared.signature).to.have.length(64);
-			expect(prepared.metaBytes.byteLength).greaterThan(0);
-			expect(prepared.payloadBytes.byteLength).greaterThan(0);
-			expect(prepared.signatureBytes.byteLength).greaterThan(0);
-		}
-	});
+			expect(chain[1]!.next).to.deep.equal([chain[0]!.cid]);
+			expect(chain[2]!.next).to.deep.equal([chain[1]!.cid]);
+			for (const prepared of chain) {
+				expect(prepared.cid).to.equal(await calculateRawCidV1(prepared.bytes));
+				expect(prepared.signature).to.have.length(64);
+				expect(prepared.metaBytes!.byteLength).greaterThan(0);
+				expect(prepared.payloadBytes!.byteLength).greaterThan(0);
+				expect(prepared.signatureBytes!.byteLength).greaterThan(0);
+			}
+		});
 
 	it("commits prepared plain entry blocks and graph rows natively", async () => {
 		const privateKey = fromHex(

--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -1,4 +1,5 @@
 import {
+	deserialize,
 	field,
 	fixedArray,
 	option,
@@ -67,6 +68,7 @@ type NativePlainEntryInput = {
 	type?: number;
 	metaData?: Uint8Array;
 	payloadData: Uint8Array;
+	includeMaterializationBytes?: boolean;
 };
 
 type NativePlainEntriesInput = {
@@ -86,11 +88,11 @@ type NativePreparedPlainEntry = {
 	bytes?: Uint8Array;
 	cid: string;
 	byteLength: number;
-	signature: Uint8Array;
+	signature?: Uint8Array;
 	next: string[];
-	metaBytes: Uint8Array;
-	payloadBytes: Uint8Array;
-	signatureBytes: Uint8Array;
+	metaBytes?: Uint8Array;
+	payloadBytes?: Uint8Array;
+	signatureBytes?: Uint8Array;
 	hashDigestBytes?: Uint8Array;
 };
 
@@ -755,7 +757,7 @@ export class EntryV0<T>
 				properties.cachePreparedEntries === false
 					? undefined
 					: new SignatureWithKey({
-							signature: preparedEntry.signature,
+							signature: preparedEntry.signature!,
 							publicKey: properties.identity.publicKey,
 							prehash: 0,
 						});
@@ -873,6 +875,7 @@ export class EntryV0<T>
 		deferStore: boolean;
 		nativeGraph?: NativeEntryV0Graph;
 		nativeBlockStore?: unknown;
+		includeMaterializationBytes?: boolean;
 	}): Promise<PreparedAppendCommitOnlyChain<T> | undefined> {
 		if (!properties.deferStore || properties.data.length !== 1) {
 			return undefined;
@@ -946,6 +949,7 @@ export class EntryV0<T>
 			type: entryType,
 			metaData: properties.meta?.data,
 			payloadData,
+			includeMaterializationBytes: properties.includeMaterializationBytes,
 		};
 		let nativeBlocksCommitted = false;
 		let nativeGraphUpdated = false;
@@ -1026,6 +1030,25 @@ export class EntryV0<T>
 				value: properties.data[0],
 				encoding: properties.encoding,
 			});
+			if (
+				!preparedEntry.metaBytes ||
+				!preparedEntry.payloadBytes ||
+				!preparedEntry.signature ||
+				!preparedEntry.signatureBytes
+			) {
+				if (!preparedEntry.bytes) {
+					throw new Error("Missing prepared entry bytes");
+				}
+				const entry = deserialize(preparedEntry.bytes, Entry) as EntryV0<T>;
+				entry.hash = preparedEntry.cid;
+				entry.size = preparedEntry.byteLength;
+				entry.createdLocally = true;
+				entry._hashDigestBytes = preparedEntry.hashDigestBytes;
+				Entry.prepareShallowEntry(entry, shallowEntry);
+				entry.init({ encoding: properties.encoding });
+				materialized = entry;
+				return entry;
+			}
 			const signature = new SignatureWithKey({
 				signature: preparedEntry.signature,
 				publicKey: properties.identity.publicKey,
@@ -1321,7 +1344,7 @@ export class EntryV0<T>
 				properties.cachePreparedEntries === false
 					? undefined
 					: new SignatureWithKey({
-							signature: preparedEntry.signature,
+							signature: preparedEntry.signature!,
 							publicKey: properties.identity.publicKey,
 							prehash: 0,
 						});

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -55,8 +55,17 @@ type BlocksWithPutMany = Blocks & {
 	rmMany?: (cids: string[]) => Promise<number | void> | number | void;
 };
 
+type BlocksWithPutKnownMany = Blocks & {
+	putKnownMany: (
+		blocks: Array<readonly [cid: string, bytes: Uint8Array]>,
+	) => Promise<string[]> | string[];
+};
+
 const hasPutMany = (storage: Blocks): storage is BlocksWithPutMany =>
 	typeof (storage as BlocksWithPutMany).putMany === "function";
+
+const hasPutKnownMany = (storage: Blocks): storage is BlocksWithPutKnownMany =>
+	typeof (storage as BlocksWithPutKnownMany).putKnownMany === "function";
 
 const getErrorName = (error: unknown) =>
 	typeof (error as { name?: unknown })?.name === "string"
@@ -702,6 +711,7 @@ export class Log<T> {
 			skipMissingNextJoin?: boolean;
 			resolveTrimmedEntries?: boolean;
 			payloadData?: Uint8Array;
+			includeMaterializationBytes?: boolean;
 		},
 	): Promise<{
 		entry: Entry<T>;
@@ -801,6 +811,7 @@ export class Log<T> {
 			skipMissingNextJoin?: boolean;
 			resolveTrimmedEntries?: boolean;
 			payloadData?: Uint8Array;
+			includeMaterializationBytes?: boolean;
 		},
 	): Promise<
 		| {
@@ -834,6 +845,7 @@ export class Log<T> {
 			nexts,
 			deferBlockStore,
 			properties?.payloadData ? [properties.payloadData] : undefined,
+			properties?.includeMaterializationBytes,
 		);
 		if (!nativeAppendChain) {
 			return undefined;
@@ -1170,6 +1182,7 @@ export class Log<T> {
 		nexts: Sorting.SortableEntry[],
 		deferBlockStore: boolean,
 		payloadDatas?: Uint8Array[],
+		includeMaterializationBytes?: boolean,
 	): Promise<PreparedAppendCommitOnlyChain<T> | undefined> {
 		const canAppendAlreadyValidated =
 			options.__peerbitCanAppendAlreadyValidated === true;
@@ -1217,6 +1230,7 @@ export class Log<T> {
 			deferStore: deferBlockStore,
 			nativeGraph,
 			nativeBlockStore: this._storage,
+			includeMaterializationBytes,
 		});
 	}
 
@@ -1532,8 +1546,22 @@ export class Log<T> {
 							throw new Error("Missing prepared entry block");
 						}
 						return prepared;
-					});
+				});
 
+		if (hasPutKnownMany(this._storage)) {
+			const cids = await this._storage.putKnownMany(
+				blocks.map((block) => [block.cid, block.block.bytes] as const),
+			);
+			if (cids.length !== blocks.length) {
+				throw new Error("Unexpected block batch result length");
+			}
+			for (let i = 0; i < cids.length; i++) {
+				if (cids[i] !== blocks[i]!.cid) {
+					throw new Error("Unexpected block batch cid");
+				}
+			}
+			return;
+		}
 		const cids = await (this._storage as BlocksWithPutMany).putMany!(blocks);
 		if (cids.length !== blocks.length) {
 			throw new Error("Unexpected block batch result length");
@@ -1548,6 +1576,20 @@ export class Log<T> {
 	private async putPreparedAppendBlocks(preparedBlocks?: PreparedEntryBlock[]) {
 		if (!preparedBlocks || preparedBlocks.length === 0) {
 			throw new Error("Missing prepared entry block");
+		}
+		if (hasPutKnownMany(this._storage)) {
+			const cids = await this._storage.putKnownMany(
+				preparedBlocks.map((block) => [block.cid, block.block.bytes] as const),
+			);
+			if (cids.length !== preparedBlocks.length) {
+				throw new Error("Unexpected block batch result length");
+			}
+			for (let i = 0; i < cids.length; i++) {
+				if (cids[i] !== preparedBlocks[i]!.cid) {
+					throw new Error("Unexpected block batch cid");
+				}
+			}
+			return;
 		}
 		const cids = await (this._storage as BlocksWithPutMany).putMany!(
 			preparedBlocks,

--- a/packages/log/test/append.spec.ts
+++ b/packages/log/test/append.spec.ts
@@ -433,6 +433,7 @@ describe("append", function () {
 		);
 		const appendBatchSpy = sinon.spy(log.entryIndex, "putAppendBatch");
 		const blockPutManySpy = sinon.spy(store, "putMany");
+		const blockPutKnownManySpy = sinon.spy(store as any, "putKnownMany");
 		const nativePrepareAndPutSpy = sinon.spy(
 			log.entryIndex.properties.nativeGraph!.graph,
 			"prepareEntryV0PlainEntryAndPut",
@@ -448,7 +449,8 @@ describe("append", function () {
 
 			expect(removed).to.be.empty;
 			expect(nativePrepareAndPutSpy.callCount).equal(1);
-			expect(blockPutManySpy.callCount).equal(1);
+			expect(blockPutManySpy.callCount).equal(0);
+			expect(blockPutKnownManySpy.callCount).equal(1);
 			expect(singleNativeAppendSpy.callCount).equal(1);
 			expect(appendBatchSpy.callCount).equal(0);
 			expect(await blockExists(entry.hash)).to.be.true;
@@ -458,6 +460,7 @@ describe("append", function () {
 			expect((await log.get(entry.hash))?.hash).equal(entry.hash);
 		} finally {
 			nativePrepareAndPutSpy.restore();
+			blockPutKnownManySpy.restore();
 			blockPutManySpy.restore();
 			appendBatchSpy.restore();
 			singleNativeAppendSpy.restore();
@@ -485,10 +488,12 @@ describe("append", function () {
 			const result = await (log as any).appendLocallyPreparedCommitOnly(
 				new Uint8Array([1]),
 				{ meta: { next: [] } },
-				{ skipMissingNextJoin: true },
+				{ skipMissingNextJoin: true, includeMaterializationBytes: false },
 			);
 
 			expect(result).to.exist;
+			expect(result.appendFacts.metaBytes).equal(undefined);
+			expect(result.appendFacts.hashDigestBytes).equal(undefined);
 			expect(commitOnlySpy.callCount).equal(1);
 			expect(appendBatchSpy.callCount).equal(0);
 			expect(trimSpy.callCount).equal(0);

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -4358,6 +4358,8 @@ export class SharedLog<
 				skipMissingNextJoin: properties?.skipMissingNextJoin,
 				resolveTrimmedEntries: properties?.resolveTrimmedEntries,
 				payloadData,
+				includeMaterializationBytes:
+					!this.shouldDeferHeadCoordinatePersistence(options),
 			},
 		);
 		if (!result) {

--- a/packages/transport/blocks/src/any-blockstore.ts
+++ b/packages/transport/blocks/src/any-blockstore.ts
@@ -154,6 +154,29 @@ export class AnyBlockStore implements Blocks {
 		return puts.map((put) => put.cid);
 	}
 
+	async putKnownMany(
+		blocks: Array<readonly [cid: string, bytes: Uint8Array]>,
+	): Promise<string[]> {
+		const store = this._store as AnyStore & {
+			putMany?: (entries: Iterable<readonly [string, Uint8Array]>) => Promise<void>;
+		};
+		try {
+			if (typeof store.putMany === "function") {
+				await store.putMany(blocks);
+			} else {
+				for (const [cid, bytes] of blocks) {
+					await this._store.put(cid, bytes);
+				}
+			}
+		} catch (error: any) {
+			if (await this.isClosingStorePutError(error)) {
+				return blocks.map(([cid]) => cid);
+			}
+			throw error;
+		}
+		return blocks.map(([cid]) => cid);
+	}
+
 	private async isClosingStorePutError(error: any): Promise<boolean> {
 		const status = await this._store.status();
 		return (

--- a/packages/transport/blocks/test/level.spec.ts
+++ b/packages/transport/blocks/test/level.spec.ts
@@ -54,6 +54,17 @@ describe(`level`, function () {
 		expect(await store.get(cids[1])).to.deep.equal(datas[1]);
 	});
 
+	it("puts known cid blocks through store batch helpers", async () => {
+		store = new AnyBlockStore(createRustStore());
+		await store.start();
+		const data = new Uint8Array([1, 2, 3]);
+		const cid = "zb2rhWtC5SY6zV1y2SVN119ofpxsbEtpwiqSoK77bWVzHqeWU";
+		const cids = await store.putKnownMany([[cid, data]]);
+
+		expect(cids).to.deep.equal([cid]);
+		expect(await store.get(cid)).to.deep.equal(data);
+	});
+
 	it("gets and removes many blocks through store batch helpers", async () => {
 		store = new AnyBlockStore(createRustStore());
 		await store.start();


### PR DESCRIPTION
## Summary
- Add a storage-only native prepared-entry row for commit-only local appends.
- Let deferred-coordinate shared-log puts avoid returning meta/payload/signature/hash materialization bytes from Rust until the public Entry is touched.
- Add `AnyBlockStore.putKnownMany(...)` and route prepared lower-log block commits by known CID.

## Benchmark
Command:
`DOC_WARMUP=50 DOC_ITERATIONS=5000 DOC_SCENARIOS=rust-peerbit-local,rust-peerbit DOC_PROFILE_DEEP=1 BENCH_JSON=1 node --loader ts-node/esm ./packages/programs/data/document/document/benchmark/document-put.ts`

Rows:
- `rust-peerbit-local`: 8910 ops/sec, total 561.15 ms / 5000, `logCreateNativeAppendChainMs` 318.09 ms.
- `rust-peerbit`: 5271 ops/sec, total 948.61 ms / 5000.

Compared to the #937 local note (`rust-peerbit-local` 8194 ops/sec, `logCreateNativeAppendChainMs` ~337 ms), this is about +8.7% on pure local puts in this local run.

## Validation
- `pnpm --filter @peerbit/blocks run build`
- `pnpm --filter @peerbit/log-rust run build`
- `pnpm --filter @peerbit/log run build`
- `pnpm --filter @peerbit/shared-log run build`
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "uses commit-only prepared append facts before entry materialization|uses single native committed append bookkeeping|append commits one block and graph in one native call when storage is native"`
- `pnpm --filter @peerbit/log-rust exec aegir test -t node --grep "tracks heads and next adjacency in native append chains|commits prepared plain entry blocks and graph rows natively"`
- `cargo test --manifest-path packages/log/rust/Cargo.toml`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/blocks -- -t node --grep "puts known cid blocks|puts many blocks"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "uses cached self replicator state|persists native append coordinate fields from the prepared plan|coalesces prepared append trim coordinate deletes into the coordinate put|uses append facts hash number for coordinate persistence"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --grep "uses commit-only local puts when coordinate persistence is deferred|uses native shared-log planning for replicated target-none puts|removes trimmed prepared puts from the document index by head"`
- `pnpm exec eslint --config eslint.config.js packages/log/src/entry-v0.ts packages/log/src/log.ts packages/log/test/append.spec.ts packages/log/rust/src/index.ts packages/log/rust/test/index.spec.ts packages/programs/data/shared-log/src/index.ts packages/transport/blocks/src/any-blockstore.ts packages/transport/blocks/test/level.spec.ts`
- `cargo fmt --manifest-path packages/log/rust/Cargo.toml --check`
- `git diff --check`