### PR TITLE
refactor(shared-log): centralize priority semantics

### DIFF
--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -16,6 +16,7 @@ import {
 	StringMatchMethod,
 	toId,
 } from "@peerbit/indexer-interface";
+import { FOREGROUND_READ_MESSAGE_PRIORITY } from "@peerbit/stream-interface";
 import type { ShallowEntry } from "./entry-shallow.js";
 import { EntryType } from "./entry-type.js";
 import { Entry, type ShallowOrFullEntry } from "./entry.js";
@@ -23,7 +24,7 @@ import type { SortFn } from "./log-sorting.js";
 import { logger as baseLogger } from "./logger.js";
 
 const log = baseLogger.newScope("entry-index");
-const LOG_ENTRY_REMOTE_READ_PRIORITY = 2;
+const LOG_ENTRY_REMOTE_READ_PRIORITY = FOREGROUND_READ_MESSAGE_PRIORITY;
 
 export type ResultsIterator<T> = {
 	close: () => void | Promise<void>;

--- a/packages/log/test/log.spec.ts
+++ b/packages/log/test/log.spec.ts
@@ -1,5 +1,9 @@
 import { AnyBlockStore, type BlockStore } from "@peerbit/blocks";
 import { HashmapIndices } from "@peerbit/indexer-simple";
+import {
+	CONVERGENCE_MESSAGE_PRIORITY,
+	FOREGROUND_READ_MESSAGE_PRIORITY,
+} from "@peerbit/stream-interface";
 import assert from "assert";
 import { expect } from "chai";
 import { Timestamp } from "../src/clock.js";
@@ -195,7 +199,7 @@ describe("properties", function () {
 				{ remote: true },
 			);
 			assert.deepStrictEqual(entry, undefined);
-			expect(priority).to.eq(2);
+			expect(priority).to.eq(FOREGROUND_READ_MESSAGE_PRIORITY);
 		});
 
 		it("preserves explicit remote entry priority", async () => {
@@ -211,10 +215,10 @@ describe("properties", function () {
 
 			const entry = await log.get(
 				"zb2rhbnwihVVVVEGAPf9EwTZBsQz9fszCnM4Y8mJmBFgiyN7J",
-				{ remote: { timeout: 123, priority: 1 } },
+				{ remote: { timeout: 123, priority: CONVERGENCE_MESSAGE_PRIORITY } },
 			);
 			assert.deepStrictEqual(entry, undefined);
-			expect(priority).to.eq(1);
+			expect(priority).to.eq(CONVERGENCE_MESSAGE_PRIORITY);
 		});
 
 		it("injects remote.from when resolveRemotePeers is configured", async () => {
@@ -245,7 +249,7 @@ describe("properties", function () {
 			);
 			assert.deepStrictEqual(entry, undefined);
 			expect(observedFrom).to.deep.equal(fromPeers);
-			expect(observedPriority).to.eq(2);
+			expect(observedPriority).to.eq(FOREGROUND_READ_MESSAGE_PRIORITY);
 		});
 	});
 

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -54,6 +54,8 @@ import {
 	ACK_CONTROL_PRIORITY,
 	AcknowledgeDelivery,
 	AnyWhere,
+	BACKGROUND_MESSAGE_PRIORITY,
+	CONVERGENCE_MESSAGE_PRIORITY,
 	createRequestTransportContext,
 	DataMessage,
 	MessageHeader,
@@ -1085,7 +1087,7 @@ export class SharedLog<
 			header: new MessageHeader({
 				session: 0,
 				mode: new AnyWhere(),
-				priority: 0,
+				priority: BACKGROUND_MESSAGE_PRIORITY,
 			}),
 		});
 		contextMessage.header.timestamp = envelope.timestamp;
@@ -1117,7 +1119,7 @@ export class SharedLog<
 			header: new MessageHeader({
 				session: 0,
 				mode: new AnyWhere(),
-				priority: 0,
+				priority: BACKGROUND_MESSAGE_PRIORITY,
 			}),
 		});
 		contextMessage.header.timestamp = detail.timestamp;
@@ -2019,7 +2021,7 @@ export class SharedLog<
 					segmentIds: rangesToUnreplicate.map((x) => x.id),
 				}),
 				{
-					priority: 1,
+					priority: CONVERGENCE_MESSAGE_PRIORITY,
 				},
 			);
 		}
@@ -2167,7 +2169,7 @@ export class SharedLog<
 			this.node.identity.publicKey,
 		);
 		await this.rpc.send(new StoppedReplicating({ segmentIds }), {
-			priority: 1,
+			priority: CONVERGENCE_MESSAGE_PRIORITY,
 		});
 	}
 
@@ -2193,7 +2195,7 @@ export class SharedLog<
 			// announce that we are no longer replicating
 
 			await this.rpc.send(new AllReplicatingSegmentsMessage({ segments: [] }), {
-				priority: 1,
+				priority: CONVERGENCE_MESSAGE_PRIORITY,
 			});
 		}
 
@@ -2677,7 +2679,7 @@ export class SharedLog<
 					return options.announce(message);
 				} else {
 					await this.rpc.send(message, {
-						priority: 1,
+						priority: CONVERGENCE_MESSAGE_PRIORITY,
 					});
 				}
 			}
@@ -2906,7 +2908,7 @@ export class SharedLog<
 				i + REPAIR_CONFIRMATION_HASH_BATCH_SIZE,
 			);
 			await this.rpc.send(new ConfirmEntriesMessage({ hashes: chunk }), {
-				priority: 1,
+				priority: CONVERGENCE_MESSAGE_PRIORITY,
 				mode: new SilentDelivery({ to: [target], redundancy: 1 }),
 			});
 		}
@@ -4353,7 +4355,7 @@ export class SharedLog<
 							to: allRequestingPeers,
 							redundancy: 1,
 						}),
-						priority: 1,
+						priority: CONVERGENCE_MESSAGE_PRIORITY,
 					});
 			},
 			() => {
@@ -5271,7 +5273,7 @@ export class SharedLog<
 						try {
 							await this.rpc
 								.send(new AllReplicatingSegmentsMessage({ segments: [] }), {
-									priority: 1,
+									priority: CONVERGENCE_MESSAGE_PRIORITY,
 									signal: abort.signal,
 								})
 								.catch(() => {});
@@ -5318,7 +5320,7 @@ export class SharedLog<
 					try {
 						await this.rpc
 							.send(new AllReplicatingSegmentsMessage({ segments: [] }), {
-								priority: 1,
+								priority: CONVERGENCE_MESSAGE_PRIORITY,
 								signal: abort.signal,
 							})
 							.catch(() => {});
@@ -6237,7 +6239,7 @@ export class SharedLog<
 
 			if (messageToSend) {
 				await this.rpc.send(messageToSend, {
-					priority: 1,
+					priority: CONVERGENCE_MESSAGE_PRIORITY,
 				});
 			}
 		}
@@ -7433,7 +7435,7 @@ export class SharedLog<
 							to: [to], // TODO group by peers?
 							redundancy: 1,
 						}),
-						priority: 1,
+						priority: CONVERGENCE_MESSAGE_PRIORITY,
 					},
 				);
 			}

--- a/packages/programs/data/shared-log/src/sync/index.ts
+++ b/packages/programs/data/shared-log/src/sync/index.ts
@@ -17,7 +17,8 @@ export type SyncPriorityFn<R extends "u32" | "u64"> = (
 
 export type SyncOptions<R extends "u32" | "u64"> = {
 	/**
-	 * Higher numbers are synced first.
+	 * Orders entries inside a sync batch; higher numbers are selected first.
+	 * This does not change the transport message priority/lane.
 	 * The callback should be fast and side-effect free.
 	 */
 	priority?: SyncPriorityFn<R>;

--- a/packages/programs/data/shared-log/src/sync/simple.ts
+++ b/packages/programs/data/shared-log/src/sync/simple.ts
@@ -9,7 +9,10 @@ import {
 } from "@peerbit/indexer-interface";
 import { Entry, Log } from "@peerbit/log";
 import type { RPC, RequestContext } from "@peerbit/rpc";
-import { SilentDelivery } from "@peerbit/stream-interface";
+import {
+	CONVERGENCE_MESSAGE_PRIORITY,
+	SilentDelivery,
+} from "@peerbit/stream-interface";
 import {
 	EntryWithRefs,
 	createExchangeHeadsMessages,
@@ -121,9 +124,9 @@ const SESSION_POLL_INTERVAL_MS = 100;
 const DEFAULT_MAX_HASHES_PER_MESSAGE = 1_024;
 const DEFAULT_MAX_COORDINATES_PER_MESSAGE = 1_024;
 const DEFAULT_MAX_CONVERGENT_TRACKED_HASHES = 4_096;
-// Keep convergence sync above the default/background lane. Dropping it to
-// priority 0 lets repair traffic starve behind foreground work and breaks liveness.
-export const SYNC_MESSAGE_PRIORITY = 1;
+// Keep convergence sync above the default/background lane. Dropping it to the
+// background priority lets repair traffic starve behind foreground work.
+export const SYNC_MESSAGE_PRIORITY = CONVERGENCE_MESSAGE_PRIORITY;
 // Retry missing entry requests when the first response was lost (for example, due to
 // pubsub stream warmup). Keep it coarse-grained so we do not hammer the network under
 // large historical backfills.

--- a/packages/programs/data/shared-log/test/sync-chunking.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-chunking.spec.ts
@@ -1,4 +1,5 @@
 import { Cache } from "@peerbit/cache";
+import { CONVERGENCE_MESSAGE_PRIORITY } from "@peerbit/stream-interface";
 import { expect } from "chai";
 import sinon from "sinon";
 import {
@@ -10,6 +11,10 @@ import {
 } from "../src/sync/simple.js";
 
 describe("sync-chunking", () => {
+	it("uses the convergence transport priority for sync messages", () => {
+		expect(SYNC_MESSAGE_PRIORITY).to.equal(CONVERGENCE_MESSAGE_PRIORITY);
+	});
+
 	it("chunks hash maybe-sync messages", async () => {
 		const send = sinon.stub().resolves();
 		const rpc = { send } as any;

--- a/packages/programs/rpc/test/index.spec.ts
+++ b/packages/programs/rpc/test/index.spec.ts
@@ -6,7 +6,11 @@ import {
 } from "@peerbit/crypto";
 import { Program } from "@peerbit/program";
 import { type PeerId } from "@peerbit/pubsub";
-import { SilentDelivery } from "@peerbit/stream-interface";
+import {
+	CONVERGENCE_MESSAGE_PRIORITY,
+	FOREGROUND_READ_MESSAGE_PRIORITY,
+	SilentDelivery,
+} from "@peerbit/stream-interface";
 import { TestSession } from "@peerbit/test-utils";
 import { AbortError, delay, waitFor, waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
@@ -180,8 +184,8 @@ describe("rpc", () => {
 				}),
 				{
 					amount: 1,
-					priority: 1,
-					responsePriority: 2,
+					priority: CONVERGENCE_MESSAGE_PRIORITY,
+					responsePriority: FOREGROUND_READ_MESSAGE_PRIORITY,
 					expiresAt: Date.now() + 5_000,
 				},
 			);
@@ -193,9 +197,15 @@ describe("rpc", () => {
 
 			const requestMessage = requestEventFromResponder[0]!.detail.message;
 			const responseMessage = responseEventsFromRequester[0]!.detail.message;
-			expect(requestMessage.header.priority).to.equal(1);
-			expect(requestMessage.header.responsePriority).to.equal(2);
-			expect(responseMessage.header.priority).to.equal(2);
+			expect(requestMessage.header.priority).to.equal(
+				CONVERGENCE_MESSAGE_PRIORITY,
+			);
+			expect(requestMessage.header.responsePriority).to.equal(
+				FOREGROUND_READ_MESSAGE_PRIORITY,
+			);
+			expect(responseMessage.header.priority).to.equal(
+				FOREGROUND_READ_MESSAGE_PRIORITY,
+			);
 			expect(Number(responseMessage.header.expires)).to.equal(
 				Number(requestMessage.header.expires),
 			);

--- a/packages/transport/blocks/test/libp2p.spec.ts
+++ b/packages/transport/blocks/test/libp2p.spec.ts
@@ -1,6 +1,7 @@
 import { serialize } from "@dao-xyz/borsh";
 import { TestSession } from "@peerbit/libp2p-test-utils";
 import { waitForNeighbour } from "@peerbit/stream";
+import { CONVERGENCE_MESSAGE_PRIORITY } from "@peerbit/stream-interface";
 import { delay } from "@peerbit/time";
 import { expect } from "chai";
 import pDefer from "p-defer";
@@ -581,7 +582,7 @@ describe("transport", function () {
 					remote: {
 						timeout: 5_000,
 						from: [store(session, 0).publicKeyHash],
-						priority: 1,
+						priority: CONVERGENCE_MESSAGE_PRIORITY,
 					},
 				}))!,
 			),
@@ -591,15 +592,21 @@ describe("transport", function () {
 			.getCalls()
 			.find((call) => call.args[0] instanceof BlockRequest);
 		expect(requestCall, "expected block request publish").to.exist;
-		expect(requestCall!.args[1]?.priority).to.equal(1);
-		expect(requestCall!.args[1]?.responsePriority).to.equal(1);
+		expect(requestCall!.args[1]?.priority).to.equal(
+			CONVERGENCE_MESSAGE_PRIORITY,
+		);
+		expect(requestCall!.args[1]?.responsePriority).to.equal(
+			CONVERGENCE_MESSAGE_PRIORITY,
+		);
 		expect(requestCall!.args[1]?.expiresAt).to.be.a("number");
 
 		const responseCall = responsePublish
 			.getCalls()
 			.find((call) => call.args[0] instanceof BlockResponse);
 		expect(responseCall, "expected block response publish").to.exist;
-		expect(responseCall!.args[1]?.priority).to.equal(1);
+		expect(responseCall!.args[1]?.priority).to.equal(
+			CONVERGENCE_MESSAGE_PRIORITY,
+		);
 		expect(responseCall!.args[1]?.expiresAt).to.equal(
 			requestCall!.args[1]?.expiresAt,
 		);
@@ -641,7 +648,7 @@ describe("transport", function () {
 			remote: {
 				timeout: 5_000,
 				from: [store(session, 1).publicKeyHash],
-				priority: 1,
+				priority: CONVERGENCE_MESSAGE_PRIORITY,
 			},
 		});
 		expect(new Uint8Array(readData!)).to.deep.equal(data);
@@ -674,7 +681,7 @@ describe("transport", function () {
 			remote: {
 				timeout: 5_000,
 				from: [store(session, 0).publicKeyHash],
-				priority: 1,
+				priority: CONVERGENCE_MESSAGE_PRIORITY,
 			},
 		});
 		expect(droppedResponses).to.equal(1);

--- a/packages/transport/stream-interface/src/messages.ts
+++ b/packages/transport/stream-interface/src/messages.ts
@@ -262,22 +262,27 @@ export type WithExtraSigners = {
 	) => Promise<SignatureWithKey> | SignatureWithKey)[];
 };
 
+// Application traffic classes. Keep these values wire-compatible; priorities
+// are serialized as numbers and higher values map to higher-priority lanes.
+export const BACKGROUND_MESSAGE_PRIORITY = 0;
+export const CONVERGENCE_MESSAGE_PRIORITY = 1;
+export const FOREGROUND_READ_MESSAGE_PRIORITY = 2;
 // Control-path responses like ACKs should be able to cut through congested data lanes.
 export const ACK_CONTROL_PRIORITY = 3;
 
 const getDefaultPriorityFromMode = (mode: DeliveryMode) => {
 	if (mode instanceof SilentDelivery) {
-		return 0;
+		return BACKGROUND_MESSAGE_PRIORITY;
 	}
 	if (mode instanceof AnyWhere) {
-		return 0;
+		return BACKGROUND_MESSAGE_PRIORITY;
 	}
 	if (mode instanceof AcknowledgeAnyWhere) {
-		return 1;
+		return CONVERGENCE_MESSAGE_PRIORITY;
 	}
 
 	if (mode instanceof AcknowledgeDelivery) {
-		return 1;
+		return CONVERGENCE_MESSAGE_PRIORITY;
 	}
 	if (mode instanceof TracedDelivery) {
 		return ACK_CONTROL_PRIORITY;

--- a/packages/transport/stream/src/index.ts
+++ b/packages/transport/stream/src/index.ts
@@ -34,6 +34,7 @@ import {
 	AcknowledgeAnyWhere,
 	AcknowledgeDelivery,
 	AnyWhere,
+	BACKGROUND_MESSAGE_PRIORITY,
 	DataMessage,
 	DeliveryError,
 	Goodbye,
@@ -500,7 +501,7 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 		if (!this.outboundQueue) {
 			return undefined;
 		}
-		if (lane === getLaneFromPriority(0)) {
+		if (lane === getLaneFromPriority(BACKGROUND_MESSAGE_PRIORITY)) {
 			return Math.max(
 				0,
 				this.outboundQueue.maxBufferedBytes -
@@ -3528,7 +3529,10 @@ export abstract class DirectStream<
 		if (limitBytes == null) {
 			return undefined;
 		}
-		if (getLaneFromPriority(priority) === getLaneFromPriority(0)) {
+		if (
+			getLaneFromPriority(priority) ===
+			getLaneFromPriority(BACKGROUND_MESSAGE_PRIORITY)
+		) {
 			return Math.max(
 				0,
 				limitBytes - this.outboundQueueOptions.reservedTotalPriorityBytes,

--- a/packages/transport/stream/test/messages-signing.spec.ts
+++ b/packages/transport/stream/test/messages-signing.spec.ts
@@ -4,7 +4,11 @@ import { PreHash, SignatureWithKey, sha256 } from "@peerbit/crypto";
 import {
 	ACK_CONTROL_PRIORITY,
 	AcknowledgeDelivery,
+	AnyWhere,
+	BACKGROUND_MESSAGE_PRIORITY,
+	CONVERGENCE_MESSAGE_PRIORITY,
 	DataMessage,
+	FOREGROUND_READ_MESSAGE_PRIORITY,
 	MessageHeader,
 	SilentDelivery,
 	Signatures,
@@ -54,6 +58,30 @@ const importForeignCrypto = async () => {
 };
 
 describe("message signing", () => {
+	it("defines the transport priority lane mapping", () => {
+		expect(BACKGROUND_MESSAGE_PRIORITY).to.equal(0);
+		expect(CONVERGENCE_MESSAGE_PRIORITY).to.equal(1);
+		expect(FOREGROUND_READ_MESSAGE_PRIORITY).to.equal(2);
+		expect(ACK_CONTROL_PRIORITY).to.equal(3);
+	});
+
+	it("defaults background delivery modes onto the background lane", () => {
+		const silent = new MessageHeader({
+			session: 1,
+			mode: new SilentDelivery({
+				to: ["peer-a"],
+				redundancy: 1,
+			}),
+		});
+		const anywhere = new MessageHeader({
+			session: 1,
+			mode: new AnyWhere(),
+		});
+
+		expect(silent.priority).to.equal(BACKGROUND_MESSAGE_PRIORITY);
+		expect(anywhere.priority).to.equal(BACKGROUND_MESSAGE_PRIORITY);
+	});
+
 	it("normalizes foreign crypto signatures before serializing data-messages", async () => {
 		const { foreign, cleanup } = await importForeignCrypto();
 		try {
@@ -237,7 +265,7 @@ describe("message signing", () => {
 			mode: new TracedDelivery(["peer-a"]),
 		});
 
-		expect(request.priority).to.equal(1);
+		expect(request.priority).to.equal(CONVERGENCE_MESSAGE_PRIORITY);
 		expect(request.responsePriority).to.equal(ACK_CONTROL_PRIORITY);
 		expect(ack.priority).to.equal(ACK_CONTROL_PRIORITY);
 	});


### PR DESCRIPTION
## Summary
- Adds named transport priority constants for background, convergence, foreground reads, and ACK/control lanes while keeping the wire format numeric.
- Replaces shared-log/log raw priority numbers in sync, repair, replication, read, and queue-admission call sites with the named constants.
- Clarifies that `sync.priority` orders entries inside sync batches and is not the transport priority lane.

## Stacking
- Stacked on #797 (`fix/shared-log-foreground-sync-priority`).
- Intended merge order remains #795, then #797, then this cleanup PR.

## Test Plan
- `pnpm --filter @peerbit/stream-interface --filter @peerbit/stream --filter @peerbit/log --filter @peerbit/shared-log --filter @peerbit/rpc --filter @peerbit/blocks run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/stream -- -t node --grep "transport priority lane mapping|background delivery modes|acknowledged responses"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/log -- -t node --grep "remote entries with metadata priority|explicit remote entry priority|injects remote.from"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/rpc -- -t node --grep "inherits response transport hints"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/blocks -- -t node --grep "inherits response transport options"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "sync-chunking"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "u32-simple replication degree update to smaller will need transfer|^u32-simple sharding distribution objectives memory"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "^u64-iblt"`

## Notes
- The targeted lint command is currently blocked by existing unrelated lint errors in `packages/programs/rpc/src/controller.ts`. This branch does not touch that file.
- This PR does not change transport fairness mode or message serialization.