### PR TITLE
fix(document): keep remote iteration reads foreground

### DIFF
--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -34,6 +34,7 @@ import {
 } from "@peerbit/shared-log";
 import {
 	DataMessage,
+	FOREGROUND_READ_MESSAGE_PRIORITY,
 	type PeerRefs,
 	SilentDelivery,
 } from "@peerbit/stream-interface";
@@ -217,6 +218,13 @@ export type RemoteQueryOptions<Q, R, D> = RPCRequestAllOptions<Q, R> & {
 	/** WHEN are we allowed to proceed? Quorum semantics over a chosen group. */
 	wait?: WaitPolicy;
 };
+
+const getRemoteQueryPriority = (
+	remote?: boolean | { priority?: number },
+): number =>
+	typeof remote === "object" && remote.priority != null
+		? remote.priority
+		: FOREGROUND_READ_MESSAGE_PRIORITY;
 
 export type QueryOptions<T, I, D, Resolve extends boolean | undefined> = {
 	remote?:
@@ -2438,7 +2446,7 @@ export class DocumentIndex<
 			// give queries higher priority than other "normal" data activities
 			// without this, we might have a scenario that a peer joina  network with large amount of data to be synced, but can not query anything before that is done
 			// this will lead to bad UX as you usually want to list/expore whats going on before doing any replication work
-			remote.priority = 2;
+			remote.priority = getRemoteQueryPriority(options?.remote);
 		}
 		if (remote && remote.timeout == null && options?.remote) {
 			const waitPolicy =
@@ -3622,7 +3630,7 @@ export class DocumentIndex<
 												ensureController().signal,
 											])
 										: ensureController().signal,
-									priority: 1,
+									priority: getRemoteQueryPriority(options?.remote),
 									mode: new SilentDelivery({ to: [peer], redundancy: 1 }),
 								})
 								.then((response) =>
@@ -3921,6 +3929,7 @@ export class DocumentIndex<
 				remotePeers.map((peer) =>
 					this._query.send(closeRequest, {
 						...options,
+						priority: getRemoteQueryPriority(options?.remote),
 						mode: new SilentDelivery({ to: [peer], redundancy: 1 }),
 					}),
 				),

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -51,7 +51,10 @@ import {
 	SharedLog,
 	decodeReplicas,
 } from "@peerbit/shared-log";
-import { SilentDelivery } from "@peerbit/stream-interface";
+import {
+	FOREGROUND_READ_MESSAGE_PRIORITY,
+	SilentDelivery,
+} from "@peerbit/stream-interface";
 import { TestSession } from "@peerbit/test-utils";
 import { waitFor as _waitForFn, delay, waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
@@ -1079,6 +1082,99 @@ describe("index", () => {
 						} finally {
 							await iterator?.close();
 							requestSpy.restore();
+						}
+					});
+
+					it("keeps remote iteration follow-up reads in the foreground lane", async () => {
+						stores[0] = await session.peers[0].open<TestStore>(
+							new TestStore({ docs: new Documents() }),
+							{
+								args: {
+									replicate: true,
+								},
+							},
+						);
+
+						const docCount = 12;
+						for (let i = 0; i < docCount; i++) {
+							await stores[0].docs.put(new Document({ id: String(i) }));
+						}
+
+						stores[1] = await session.peers[1].open<TestStore>(
+							stores[0].clone(),
+							{
+								args: {
+									replicate: false,
+								},
+							},
+						);
+
+						await stores[1].docs.index.waitFor(
+							stores[0].node.identity.publicKey,
+						);
+
+						const requestSpy = sinon.spy(
+							stores[1].docs.index._query,
+							"request",
+						);
+						const sendSpy = sinon.spy(stores[1].docs.index._query, "send");
+
+						let iterator: any;
+						try {
+							iterator = stores[1].docs.index.iterate(
+								{},
+								{
+									closePolicy: "manual",
+									remote: { replicate: true },
+								},
+							);
+
+							expect(await iterator.next(10)).to.have.length(10);
+							expect(await iterator.next(1)).to.have.length(1);
+							await iterator.close();
+							iterator = undefined;
+
+							const initialRequest = requestSpy
+								.getCalls()
+								.find((call) => call.args[0] instanceof IterationRequest);
+							const collectRequest = requestSpy
+								.getCalls()
+								.find((call) => call.args[0] instanceof CollectNextRequest);
+							const closeRequest = sendSpy
+								.getCalls()
+								.find((call) => call.args[0] instanceof CloseIteratorRequest);
+
+							if (!initialRequest) {
+								throw new Error("Missing initial remote iteration request");
+							}
+							if (!collectRequest) {
+								throw new Error("Missing remote collect request");
+							}
+							if (!closeRequest) {
+								throw new Error("Missing remote close request");
+							}
+							const initialOptions = initialRequest.args[1] as {
+								priority?: number;
+							};
+							const collectOptions = collectRequest.args[1] as {
+								priority?: number;
+							};
+							const closeOptions = closeRequest.args[1] as {
+								priority?: number;
+							};
+							expect(initialOptions.priority).equal(
+								FOREGROUND_READ_MESSAGE_PRIORITY,
+							);
+							expect(collectOptions.priority).equal(
+								FOREGROUND_READ_MESSAGE_PRIORITY,
+							);
+							expect(closeOptions.priority).equal(
+								FOREGROUND_READ_MESSAGE_PRIORITY,
+							);
+						} finally {
+							await iterator?.close();
+							requestSpy.restore();
+							sendSpy.restore();
 						}
 					});
 


### PR DESCRIPTION
Supersedes #782.

## Summary
- keep document remote query defaults tied to the shared foreground-read priority constant
- ensure remote iterator follow-up `CollectNextRequest`s stay in the same foreground lane instead of dropping to convergence priority
- send remote iterator close requests in the same lane so remote iterator state cleanup is not stranded behind background traffic
- add a regression that exercises the default v8 iterator path past the first remote batch and through close

## Why
This addresses the foreground-read starvation path directly instead of adding a public `waitForReplication`/background-cache escape hatch. `remote: { replicate: true }` keeps its existing semantics while the whole remote read lifecycle remains prioritized over sync/backfill traffic.

## Verification
- `pnpm --filter @peerbit/document-interface... run build`
- `pnpm --filter @peerbit/indexer-cache... run build`
- `pnpm --filter @peerbit/document run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --no-build --grep "keeps remote iteration follow-up reads in the foreground lane"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/document/document -- -t node --no-build --grep "search replicate"`