### PR TITLE
fix(release): preinstall wasm target before package build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' || steps.release.outputs.releases_created == 'true' }}
         run: |
           curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          rustup target add wasm32-unknown-unknown
           pnpm install --frozen-lockfile=false
 
       - name: Build Packages


### PR DESCRIPTION
## Summary
- preinstall the wasm32 Rust target in the release workflow before the parallel package build
- match CI setup so wasm-pack does not race while installing the same target from multiple packages

## Why
The Release Please publish run failed before npm publishing because @peerbit/riblt and @peerbit/log-rust attempted to add `wasm32-unknown-unknown` concurrently, causing rustup component conflicts.

## Verification
- inspected failed Release Please job 77831604839
- CI Build Workspace already uses this setup and passed on master