### PR TITLE
fix(program): keep libp2p test utils dev-only

### DIFF
--- a/packages/programs/program/program/package.json
+++ b/packages/programs/program/program/package.json
@@ -68,7 +68,6 @@
 		"@peerbit/crypto": "workspace:*",
 		"@peerbit/indexer-interface": "workspace:*",
 		"@peerbit/keychain": "workspace:*",
-		"@peerbit/libp2p-test-utils": "workspace:*",
 		"@peerbit/logger": "workspace:*",
 		"@peerbit/pubsub": "workspace:*",
 		"@peerbit/pubsub-interface": "workspace:*",
@@ -76,6 +75,9 @@
 		"@peerbit/time": "workspace:*",
 		"multiformats": "^13.4.2",
 		"p-queue": "^8.0.1"
+	},
+	"devDependencies": {
+		"@peerbit/libp2p-test-utils": "workspace:*"
 	},
 	"repository": {
 		"type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1858,9 +1858,6 @@ importers:
       '@peerbit/keychain':
         specifier: workspace:*
         version: link:../../../utils/keychain
-      '@peerbit/libp2p-test-utils':
-        specifier: workspace:*
-        version: link:../../../transport/libp2p-test-utils
       '@peerbit/logger':
         specifier: workspace:*
         version: link:../../../utils/logger
@@ -1882,6 +1879,10 @@ importers:
       p-queue:
         specifier: ^8.0.1
         version: 8.1.1
+    devDependencies:
+      '@peerbit/libp2p-test-utils':
+        specifier: workspace:*
+        version: link:../../../transport/libp2p-test-utils
 
   packages/programs/program/react:
     dependencies:


### PR DESCRIPTION
## Summary
- move @peerbit/libp2p-test-utils out of @peerbit/program production dependencies
- keep it available as a dev dependency for @peerbit/program tests
- reduce downstream production installs that consume @peerbit/program without test helpers

## Install impact
Measured with clean npm installs and scripts disabled:
- published @peerbit/program@6.0.30: 255 MB node_modules, 500 packages, includes @peerbit/libp2p-test-utils and react-native
- local packed @peerbit/program with this fix: 75 MB node_modules, 206 packages, no @peerbit/libp2p-test-utils and no react-native

## Test Plan
- pnpm install --frozen-lockfile
- pnpm --filter @peerbit/program build
- pnpm --filter @peerbit/program test
- git diff --check
- packed local @peerbit/program and installed it in a clean npm project