### PR TITLE
Fix shared-log checked prune control message delivery

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -4349,14 +4349,17 @@ export class SharedLog<
 					hashes.push(hash);
 				}
 
-				hashes.length > 0 &&
-					this.rpc.send(new ResponseIPrune({ hashes }), {
-						mode: new SilentDelivery({
-							to: allRequestingPeers,
-							redundancy: 1,
-						}),
-						priority: CONVERGENCE_MESSAGE_PRIORITY,
-					});
+				if (hashes.length > 0 && allRequestingPeers.size > 0) {
+					this.rpc
+						.send(new ResponseIPrune({ hashes }), {
+							mode: new AcknowledgeDelivery({
+								to: allRequestingPeers,
+								redundancy: 1,
+							}),
+							priority: CONVERGENCE_MESSAGE_PRIORITY,
+						})
+						.catch(() => {});
+				}
 			},
 			() => {
 				let accumulator = new Map<string, Set<string>>();
@@ -7431,7 +7434,7 @@ export class SharedLog<
 						hashes: filteredSet,
 					}),
 					{
-						mode: new SilentDelivery({
+						mode: new AcknowledgeDelivery({
 							to: [to], // TODO group by peers?
 							redundancy: 1,
 						}),
@@ -7442,7 +7445,7 @@ export class SharedLog<
 		};
 
 			for (const [k, v] of peerToEntries) {
-				emitMessages(v, k);
+				emitMessages(v, k).catch(() => {});
 			}
 
 			// Keep remote `_pendingIHave` alive in the common "leader doesn't have entry yet"


### PR DESCRIPTION
## Summary
- Use acknowledged delivery for checked-prune request/response control messages.
- Catch fire-and-forget send failures so transient route failures are retried by the existing checked-prune retry path instead of becoming unhandled rejections.
- Keep this fix separate from #911; current master reproduced the replication-degree flake without #911 changes.

## Reproduction
On current master (be47a17ad), the focused test failed locally on iteration 4 before this change:

```bash
node ./node_modules/aegir/src/index.js run test \
  --roots ./packages/programs/data/shared-log -- -t node \
  --grep "^u32-simple replication degree update to smaller then to larger$" \
  --no-build
```

The observed failure was `expected 100 to be close to 50 +/- 30`, matching the intermittent CI failure. Diagnostics showed both peers knew the final split ranges, but one peer still retained all entries, pointing at checked-prune convergence rather than missing range propagation.

## Verification
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "^u32-simple replication degree update to smaller then to larger$"`
- 30x focused loop of `^u32-simple replication degree update to smaller then to larger$` with `--no-build`
- `pnpm run test:ci:part-7d`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "^u32-simple sharding 2 peers write while joining$" --no-build`
- `pnpm run test:ci:part-7e`