### PR TITLE
Fix shared-log memory-limited coverage balancing

### DIFF
--- a/packages/programs/data/shared-log/src/pid.ts
+++ b/packages/programs/data/shared-log/src/pid.ts
@@ -72,6 +72,8 @@ export class PIDReplicationController {
 			errorCoverageUnmodified;
 
 		const errorFromEven = 1 / peerCount - currentFactor;
+		const hasMemoryHeadroom =
+			this.maxMemoryLimit != null && this.maxMemoryLimit > 0 && errorMemory > 0;
 		// When the network is under-covered (`totalFactor < 1`) balancing "down" (negative
 		// error) can further reduce coverage and force constrained peers (memory/CPU limited)
 		// to take boundary assignments that exceed their budgets.
@@ -81,11 +83,12 @@ export class PIDReplicationController {
 		const coverageDeficit = Math.max(0, errorCoverageUnmodified); // ~= max(0, 1 - totalFactor)
 		const negativeBalanceScale =
 			coverageDeficit <= 0 ? 1 : 1 - Math.min(1, coverageDeficit / 0.1); // full clamp at 10% deficit
-		const errorFromEvenForBalance =
+		let errorFromEvenForBalance =
 			errorFromEven >= 0 ? errorFromEven : errorFromEven * negativeBalanceScale;
+		if (hasMemoryHeadroom && coverageDeficit > 0 && errorFromEvenForBalance < 0) {
+			errorFromEvenForBalance = 0;
+		}
 
-		const hasMemoryHeadroom =
-			this.maxMemoryLimit != null && this.maxMemoryLimit > 0 && errorMemory > 0;
 		if (hasMemoryHeadroom && errorFromEvenForBalance > 0) {
 			// Coverage surplus often means another peer has not pruned yet. Do not let
 			// that transient surplus cancel a constrained peer that is still below an

--- a/packages/programs/data/shared-log/test/pid.spec.ts
+++ b/packages/programs/data/shared-log/test/pid.spec.ts
@@ -163,5 +163,21 @@ describe("PIDReplicationController", () => {
 
 			expect(f).to.be.within(0.49, 0.51);
 		});
+
+		it("uses storage headroom to fill coverage gaps above an even share", () => {
+			const controller = new PIDReplicationController("", {
+				storage: { max: 100_000 },
+			});
+			const f = controller.step({
+				currentFactor: 0.91,
+				memoryUsage: 69_828,
+				totalFactor: 0.94,
+				peerCount: 2,
+				cpuUsage: undefined,
+			});
+
+			expect(f).to.be.greaterThan(0.91);
+			expect(f).to.be.at.most(1);
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- Prevent the memory-limit PID balance term from shrinking a peer with storage headroom while total ring coverage is below 1.
- Add a deterministic PID regression test for the part-7b failure shape where the storage-limited peer is above an even share but still needs to fill a coverage gap.

## Context
A #947 CI run exposed an intermittent failure in `test:ci:part-7b`:

```
u32-simple sharding distribution objectives memory greatly limited
 db2 memory=69828
 expected abs(100000 - memory) < 12000
```

That is separate from the checked-prune delivery bug fixed by #947. The failed state implies the storage-limited peer still had headroom, but total participation was under-covered. The controller could let the even-share balancing term offset coverage recovery, so the peer did not grow enough to fill the gap.

## Verification
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "PIDReplicationController"`
- 5x focused loop of `^u32-simple sharding distribution objectives memory greatly limited$` with `--no-build`
- `pnpm run test:ci:part-7b`