### PR TITLE
Fix checked-prune cleanup on replicator leave

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -5230,8 +5230,10 @@ export class SharedLog<
 		this.responseToPruneDebouncedFn?.close?.();
 		this.pruneDebouncedFn = undefined as any;
 		this.rebalanceParticipationDebounced = undefined;
-		this._replicationRangeIndex.stop();
-		this._entryCoordinatesIndex.stop();
+		await Promise.all([
+			this._replicationRangeIndex.stop(),
+			this._entryCoordinatesIndex.stop(),
+		]);
 		this._replicationRangeIndex = undefined as any;
 		this._entryCoordinatesIndex = undefined as any;
 

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2232,6 +2232,7 @@ export class SharedLog<
 		// Keep local sync/prune state consistent even when a peer disappears
 		// through replication-info updates without a topic unsubscribe event.
 		this.removePeerFromGidPeerHistory(keyHash);
+		this._checkedPrune.cleanupPeer(keyHash);
 		this.removeRepairFrontierTarget(keyHash);
 		this._recentRepairDispatch.delete(keyHash);
 		if (!isMe) {

--- a/packages/programs/data/shared-log/test/sharding.spec.ts
+++ b/packages/programs/data/shared-log/test/sharding.spec.ts
@@ -2275,6 +2275,42 @@ testSetups.forEach((setup) => {
 				);
 			});
 
+			it("waits for local index shutdown before close resolves", async () => {
+				db1 = await session.peers[0].open(new EventStore<string, any>(), {
+					args: {
+						replicate: {
+							offset: 0,
+						},
+						setup,
+					},
+				});
+
+				const logInternals = db1.log as any;
+				const rangeIndex = logInternals._replicationRangeIndex;
+				const entryIndex = logInternals._entryCoordinatesIndex;
+				const originalRangeStop = rangeIndex.stop.bind(rangeIndex);
+				const originalEntryStop = entryIndex.stop.bind(entryIndex);
+				let pendingStops = 0;
+
+				const wrapStop = (stop: () => Promise<void>) => async () => {
+					pendingStops++;
+					try {
+						await delay(50);
+						await stop();
+					} finally {
+						pendingStops--;
+					}
+				};
+
+				rangeIndex.stop = wrapStop(originalRangeStop);
+				entryIndex.stop = wrapStop(originalEntryStop);
+
+				await db1.close();
+
+				expect(pendingStops).to.equal(0);
+				db1 = undefined as any;
+			});
+
 			it("drops when no longer replicating as observer", async () => {
 				let COUNT = 10;
 				db1 = await session.peers[0].open(new EventStore<string, any>(), {

--- a/packages/programs/data/shared-log/test/sharding.spec.ts
+++ b/packages/programs/data/shared-log/test/sharding.spec.ts
@@ -2684,25 +2684,34 @@ testSetups.forEach((setup) => {
 
 							await delay(db1.log.timeUntilRoleMaturity + 1000);
 
+							const assertMemoryNearLimit = async () => {
+								const memoryUsage = await db2.log.getMemoryUsage();
+								const tolerance = Math.max((memoryLimit / 100) * 12, 10_000);
+								expect(
+									Math.abs(memoryLimit - memoryUsage),
+									`memoryUsage=${memoryUsage} memoryLimit=${memoryLimit}`,
+								).lessThan(tolerance);
+							};
+
 							try {
 								// For a late-joining constrained peer, the correctness contract is that
 								// join redistribution finishes and memory usage converges near the
-								// configured limit. Requiring the raw participation curve itself to
-								// fully settle is stricter than the behavior under test and flakes
-								// under full-shard CI load.
+								// configured limit after pending prune/distribution work has drained.
 								await waitForResolved(
 									() =>
 										expect(countActiveRepairSweepWork(db1, db2)).to.equal(0),
 									{ timeout: 120_000, delayInterval: 250 },
 								);
 
-								await waitForResolved(
-									async () =>
-										expect(
-											Math.abs(memoryLimit - (await db2.log.getMemoryUsage())),
-										).lessThan((memoryLimit / 100) * 12),
-									{ timeout: 60 * 1000, delayInterval: 1000 },
-								); // allow a bit more slack after settling under full-suite load
+								await waitForResolved(assertMemoryNearLimit, {
+									timeout: 180_000,
+									delayInterval: 1000,
+								});
+								await waitForDistributionQuiesced(db1, db2);
+								await waitForResolved(assertMemoryNearLimit, {
+									timeout: 120_000,
+									delayInterval: 1000,
+								});
 							} catch (error) {
 								await dbgLogs([db1.log, db2.log]);
 								throw error;

--- a/packages/programs/data/shared-log/test/sharding.spec.ts
+++ b/packages/programs/data/shared-log/test/sharding.spec.ts
@@ -1822,6 +1822,82 @@ testSetups.forEach((setup) => {
 				await checkBounded(entryCount, 1, 1, db1, db2);
 			});
 
+			it("clears checked-prune confirmations when replication-info removes a peer", async () => {
+				const args = {
+					timeUntilRoleMaturity: 0,
+					waitForPruneDelay: 50,
+					setup,
+				} as const;
+
+				db1 = await session.peers[0].open(new EventStore<string, any>(), {
+					args: {
+						replicate: {
+							offset: 0,
+						},
+						...args,
+					},
+				});
+
+				db2 = await EventStore.open<EventStore<string, any>>(
+					db1.address!,
+					session.peers[1],
+					{
+						args: {
+							replicate: {
+								offset: 0.3333,
+							},
+							...args,
+						},
+					},
+				);
+				db3 = await EventStore.open<EventStore<string, any>>(
+					db1.address!,
+					session.peers[2],
+					{
+						args: {
+							replicate: {
+								offset: 0.6666,
+							},
+							...args,
+						},
+					},
+				);
+
+				await waitForResolved(async () =>
+					expect(await db1.log.replicationIndex?.getSize()).equal(3),
+				);
+
+				const { entry } = await db1.add("stale-prune-confirmation", {
+					meta: { next: [] },
+				});
+				const leavingHash = db3.node.identity.publicKey.hashcode();
+				const logInternals = db1.log as any;
+
+				logInternals._checkedPrune.addRequestSent(entry.hash, leavingHash);
+				logInternals._checkedPrune.addConfirmedReplicator(
+					entry.hash,
+					leavingHash,
+				);
+				expect(
+					logInternals._checkedPrune
+						.getConfirmedReplicators(entry.hash)
+						?.has(leavingHash),
+				).to.be.true;
+
+				await logInternals.removeReplicator(leavingHash, { noEvent: true });
+
+				expect(
+					logInternals._checkedPrune
+						.getConfirmedReplicators(entry.hash)
+						?.has(leavingHash) ?? false,
+				).to.be.false;
+				expect(
+					logInternals._checkedPrune
+						.getContactedReplicators(entry.hash)
+						?.has(leavingHash) ?? false,
+				).to.be.false;
+			});
+
 			it("repairs redistributed entry when churn repair misses one hash on peer leave", async function () {
 				if (setup.name !== "u64-iblt") {
 					this.skip();


### PR DESCRIPTION
## Summary
- clean checked-prune state when a peer is removed through replication-info updates, not only direct unsubscribe/liveness cleanup
- await shared-log SQLite index shutdown during close so rapid close/reopen cannot race an index still in `closing`
- make the memory-objective sharding test wait for prune/distribution quiescence before asserting the storage target
- add shared-log sharding regressions for stale checked-prune confirmations and close-time index shutdown

## Context
This targets intermittent shared-log CI failures seen while validating #911:
- `u64-iblt sharding distributes to leaving peers` could underfill replicas after a peer left because checked-prune confirmations from a replication-info-removed peer were not cleared.
- `u64-iblt sharding handles peer joining and leaving multiple times` could hit `Error: Not started` when close returned before local SQLite index stops finished.
- `u32-simple sharding distribution objectives memory joining half limited` could assert memory while prune/distribution convergence was still in flight.

## Tests
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "clears checked-prune confirmations when replication-info removes a peer"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "waits for local index shutdown before close resolves"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "^u32-simple sharding distribution objectives memory joining half limited$"
- node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --grep "^u64-iblt sharding distributes to leaving peers$"
- pnpm run test:ci:part-7b
- pnpm run test:ci:part-7c
- pnpm run test:ci:part-7e

CI is green on head `183973f77ef7550c03fad5a9a0e92689e66bc93a` for both push and PR runs.