### PR TITLE
ci: cache wasm-pack and workspace builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
       - "docs/**"
   pull_request:
     types: ["opened", "reopened", "synchronize"]
+env:
+  WASM_PACK_VERSION: 0.13.1
 jobs:
   build_workspace:
     name: Build Workspace
@@ -17,23 +19,41 @@ jobs:
       PEERBIT_TEST_SESSION: mock
     steps:
       - uses: actions/checkout@v4
+      - name: Restore cached workspace build
+        id: workspace_dist_cache
+        uses: actions/cache@v4
+        with:
+          path: workspace-dist.tar.gz
+          key: ${{ runner.os }}-workspace-dist-${{ github.sha }}
       - uses: pnpm/action-setup@v4
+        if: steps.workspace_dist_cache.outputs.cache-hit != 'true'
         with:
           run_install: false
       - uses: actions/setup-node@v4
+        if: steps.workspace_dist_cache.outputs.cache-hit != 'true'
         with:
           node-version: 22.x
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
+      - name: Cache wasm-pack
+        if: steps.workspace_dist_cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/wasm-pack
+          key: ${{ runner.os }}-wasm-pack-${{ env.WASM_PACK_VERSION }}
       - name: Install deps
+        if: steps.workspace_dist_cache.outputs.cache-hit != 'true'
         run: |
-          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          export PATH="$HOME/.cargo/bin:$PATH"
+          ./scripts/ci/install-wasm-pack.sh
           rustup target add wasm32-unknown-unknown
           pnpm install --frozen-lockfile=false
       - name: Build
+        if: steps.workspace_dist_cache.outputs.cache-hit != 'true'
         run: |
           pnpm run build
       - name: Pack build outputs
+        if: steps.workspace_dist_cache.outputs.cache-hit != 'true'
         run: |
           find . \
             \( -path '*/node_modules' -o -path '*/.git' \) -prune -o \
@@ -84,9 +104,15 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
+      - name: Cache wasm-pack
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/wasm-pack
+          key: ${{ runner.os }}-wasm-pack-${{ env.WASM_PACK_VERSION }}
       - name: Install deps
         run: |
-          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          export PATH="$HOME/.cargo/bin:$PATH"
+          ./scripts/ci/install-wasm-pack.sh
           rustup target add wasm32-unknown-unknown
           pnpm install --frozen-lockfile=false
           # NOTE: CI runs node-only tests (`-t node`). Playwright system deps are not required
@@ -193,9 +219,15 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
+      - name: Cache wasm-pack
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/wasm-pack
+          key: ${{ runner.os }}-wasm-pack-${{ env.WASM_PACK_VERSION }}
       - name: Install deps
         run: |
-          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          export PATH="$HOME/.cargo/bin:$PATH"
+          ./scripts/ci/install-wasm-pack.sh
           rustup target add wasm32-unknown-unknown
           pnpm install --frozen-lockfile=false
           # NOTE: CI runs node-only tests (`-t node`). Playwright system deps are not required
@@ -280,9 +312,15 @@ jobs:
           node-version: 22.x
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
+      - name: Cache wasm-pack
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/wasm-pack
+          key: ${{ runner.os }}-wasm-pack-${{ env.WASM_PACK_VERSION }}
       - name: Install deps
         run: |
-          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          export PATH="$HOME/.cargo/bin:$PATH"
+          ./scripts/ci/install-wasm-pack.sh
           rustup target add wasm32-unknown-unknown
           pnpm install --frozen-lockfile=false
       - name: Build pubsub workspace
@@ -367,9 +405,15 @@ jobs:
           node-version: 22.x
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
+      - name: Cache wasm-pack
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/wasm-pack
+          key: ${{ runner.os }}-wasm-pack-${{ env.WASM_PACK_VERSION }}
       - name: Install deps
         run: |
-          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          export PATH="$HOME/.cargo/bin:$PATH"
+          ./scripts/ci/install-wasm-pack.sh
           rustup target add wasm32-unknown-unknown
           pnpm install --frozen-lockfile=false
       - name: Build shared-log workspace

--- a/scripts/ci/install-wasm-pack.sh
+++ b/scripts/ci/install-wasm-pack.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${WASM_PACK_VERSION:-0.13.1}"
+install_dir="${WASM_PACK_INSTALL_DIR:-$HOME/.cargo/bin}"
+
+case "$(uname -s)-$(uname -m)" in
+	Linux-x86_64)
+		target="x86_64-unknown-linux-musl"
+		;;
+	*)
+		echo "Unsupported wasm-pack platform: $(uname -s)-$(uname -m)" >&2
+		exit 1
+		;;
+esac
+
+mkdir -p "$install_dir"
+if [ -n "${GITHUB_PATH:-}" ]; then
+	echo "$install_dir" >> "$GITHUB_PATH"
+fi
+
+if [ -x "$install_dir/wasm-pack" ]; then
+	"$install_dir/wasm-pack" --version
+	exit 0
+fi
+
+archive="wasm-pack-v${version}-${target}.tar.gz"
+url="https://github.com/rustwasm/wasm-pack/releases/download/v${version}/${archive}"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+curl \
+	--fail \
+	--location \
+	--show-error \
+	--retry 5 \
+	--retry-all-errors \
+	--retry-delay 2 \
+	--connect-timeout 20 \
+	--max-time 180 \
+	"$url" \
+	-o "$tmpdir/$archive"
+
+tar -xzf "$tmpdir/$archive" -C "$tmpdir"
+cp "$tmpdir/wasm-pack-v${version}-${target}/wasm-pack" "$install_dir/wasm-pack"
+chmod +x "$install_dir/wasm-pack"
+"$install_dir/wasm-pack" --version


### PR DESCRIPTION
## Summary
- cache the pinned wasm-pack binary in CI jobs
- replace the pipe-to-shell wasm-pack installer with a small retried installer script
- cache the packed workspace build by SHA so reruns can skip install/build and still upload the dist artifact

## Why
Repeated CI reruns currently redo expensive setup and are exposed to transient wasm-pack release download failures, like the 504 seen while checking #952.

## Validation
- bash -n scripts/ci/install-wasm-pack.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'\n- git diff --check