### PR TITLE
Bound shared-log rebalance iteration

### DIFF
--- a/packages/programs/data/shared-log/src/ranges.ts
+++ b/packages/programs/data/shared-log/src/ranges.ts
@@ -2709,6 +2709,8 @@ export const mergeReplicationChanges = <R extends NumericType>(
 	return all;
 };
 
+const REBALANCE_ITERATOR_BATCH_SIZE = 1048;
+
 export const toRebalance = <R extends "u32" | "u64">(
 	changeOrChanges:
 		| ReplicationChanges<ReplicationRangeIndexable<R>>
@@ -2718,22 +2720,29 @@ export const toRebalance = <R extends "u32" | "u64">(
 	options?: { forceFresh?: boolean },
 ): AsyncIterable<EntryReplicated<R>> => {
 	const change = options?.forceFresh
-		? (Array.isArray(changeOrChanges[0])
-				? (changeOrChanges as ReplicationChanges<ReplicationRangeIndexable<R>>[])
-						.flat()
-				: (changeOrChanges as ReplicationChanges<ReplicationRangeIndexable<R>>))
+		? Array.isArray(changeOrChanges[0])
+			? (
+					changeOrChanges as ReplicationChanges<ReplicationRangeIndexable<R>>[]
+				).flat()
+			: (changeOrChanges as ReplicationChanges<ReplicationRangeIndexable<R>>)
 		: mergeReplicationChanges(changeOrChanges, rebalanceHistory);
 	return {
 		[Symbol.asyncIterator]: async function* () {
 			const iterator = index.iterate({
 				query: createAssignedRangesQuery(change),
 			});
-
-			while (iterator.done() !== true) {
-				const entries = await iterator.all(); // TODO choose right batch sizes here for optimal memory usage / speed
-				for (const entry of entries) {
-					yield entry.value;
+			try {
+				while (iterator.done() !== true) {
+					const entries = await iterator.next(REBALANCE_ITERATOR_BATCH_SIZE);
+					if (entries.length === 0) {
+						break;
+					}
+					for (const entry of entries) {
+						yield entry.value;
+					}
 				}
+			} finally {
+				await iterator.close();
 			}
 		},
 	};

--- a/packages/programs/data/shared-log/test/ranges.spec.ts
+++ b/packages/programs/data/shared-log/test/ranges.spec.ts
@@ -18,8 +18,8 @@ import {
 	type EntryReplicated,
 	EntryReplicatedU32,
 	EntryReplicatedU64,
-	ReplicationIntent,
 	type ReplicationChange,
+	ReplicationIntent,
 	type ReplicationRangeIndexable,
 	ReplicationRangeIndexableU32,
 	ReplicationRangeIndexableU64,
@@ -2649,7 +2649,8 @@ resolutions.forEach((resolution) => {
 				const rotations = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1];
 
 				it("preserves multiple replaced ranges in one debounce window", async () => {
-					const emitted: ReplicationChange<ReplicationRangeIndexable<R>>[][] = [];
+					const emitted: ReplicationChange<ReplicationRangeIndexable<R>>[][] =
+						[];
 					let releaseFirstRun: () => void = undefined!;
 					const firstRunStarted = new Promise<void>((resolve) => {
 						releaseFirstRun = resolve;
@@ -2756,6 +2757,59 @@ resolutions.forEach((resolution) => {
 						meta: properties.meta,
 					} as any);
 				};
+
+				it("uses bounded batches and closes the rebalance iterator", async () => {
+					const entries = Array.from({ length: 1049 }, (_, i) =>
+						createEntryReplicated({
+							coordinate: denormalizeFn(i / 1049),
+							assignedToRangeBoundary: true,
+							hash: i.toString(),
+							meta: new Meta({
+								clock: new LamportClock({ id: randomBytes(32) }),
+								gid: i.toString(),
+								next: [],
+								type: 0,
+								data: undefined,
+							}),
+						}),
+					);
+					let offset = 0;
+					let closeCalls = 0;
+					let allCalls = 0;
+					const nextCalls: number[] = [];
+					const iterator = {
+						next: async (amount: number) => {
+							nextCalls.push(amount);
+							const batch = entries.slice(offset, offset + amount);
+							offset += batch.length;
+							return batch.map((value) => ({ value })) as any;
+						},
+						all: async () => {
+							allCalls++;
+							throw new Error("unbounded iterator drain should not be used");
+						},
+						done: () => offset >= entries.length,
+						close: async () => {
+							closeCalls++;
+						},
+						pending: async () => entries.length - offset,
+					};
+					const fakeIndex = {
+						iterate: () => iterator,
+					} as unknown as Index<EntryReplicated<R>>;
+					const cache = new Cache<string>({ max: 1000, ttl: 1e5 });
+
+					const result = await consumeAllFromAsyncIterator(
+						toRebalance([], fakeIndex, cache),
+					);
+
+					expect(result.map((entry) => entry.hash)).to.deep.equal(
+						entries.map((entry) => entry.hash),
+					);
+					expect(nextCalls).to.deep.equal([1048, 1048]);
+					expect(allCalls).to.equal(0);
+					expect(closeCalls).to.equal(1);
+				});
 
 				rotations.forEach((rotation) => {
 					const rotate = (from: number) => (from + rotation) % 1;


### PR DESCRIPTION
## Summary

- Replace the rebalance scan's unbounded `iterator.all()` drain with bounded `iterator.next(1048)` batches.
- Close the rebalance iterator in a `finally` block.
- Add focused `toRebalance` coverage that fails if the path goes back to `all()` and verifies the bounded batch size plus iterator cleanup.

## Why

The rebalance scan runs while shared-log repair, prune, and membership work may update the coordinate index. `iterator.all()` is a drain-to-end helper, not an incremental progress API; on some indexers it maps to an effectively unbounded fetch. Using it inside a `while (!done)` loop can monopolize rebalance work and makes completion depend on mutable iterator state.

Bounded `next(1048)` batches keep the scan finite per await, give other work a chance to progress, and ensure the iterator is explicitly closed even if the consumer stops early or an error is thrown.

## Underlying Iterator Follow-Up

This PR fixes the shared-log caller-side misuse. The related lower-level question is still worth investigating separately: whether `all()` and `done()` semantics are too sharp for mutable index iterators. Current observations:

- Native/simple indexers implement `all()` as an unbounded fetch (`fetch(Infinity)`).
- SQLite drains until no more results are reported.
- `iteratorInSeries.all()` is safer because it loops with bounded `next(100)` calls.

A follow-up should add lower-level iterator tests for mutation during iteration and clarify when `all()` is appropriate versus when callers must use bounded `next(n)` batches.

## Validation

- `pnpm exec prettier --check packages/programs/data/shared-log/src/ranges.ts packages/programs/data/shared-log/test/ranges.spec.ts`
- `PATH=/tmp/node22/node-v22.22.3-darwin-arm64/bin:$PATH pnpm --filter @peerbit/shared-log build`
- `PATH=/tmp/node22/node-v22.22.3-darwin-arm64/bin:$PATH node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --no-build --grep "uses bounded batches and closes the rebalance iterator"`
- `PATH=/tmp/node22/node-v22.22.3-darwin-arm64/bin:$PATH node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --no-build --grep "to smaller will need transfer|replication degree update distribute"`
