### PR TITLE
fix(indexer): keep iterators stable across mutations

### DIFF
--- a/.changeset/mutable-index-iterators.md
+++ b/.changeset/mutable-index-iterators.md
@@ -3,4 +3,6 @@
 "@peerbit/indexer-sqlite3": patch
 ---
 
-Keep paginated sorted iterators complete and duplicate-free when indexed rows are inserted or deleted between pages.
+Keep paginated sorted iterators complete and duplicate-free when indexed rows are inserted, updated, or deleted between pages.
+
+After observing a mutation, an iterator keeps the ids it has already yielded and rescans the current result set. This costs O(N) query work per subsequent page and O(yielded ids) memory; consuming a large changing result set in many small pages can therefore approach O(N²) work.

--- a/.changeset/mutable-index-iterators.md
+++ b/.changeset/mutable-index-iterators.md
@@ -1,0 +1,6 @@
+---
+"@peerbit/indexer-rust": patch
+"@peerbit/indexer-sqlite3": patch
+---
+
+Keep paginated sorted iterators complete and duplicate-free when indexed rows are inserted or deleted between pages.

--- a/.changeset/mutable-index-iterators.md
+++ b/.changeset/mutable-index-iterators.md
@@ -1,8 +1,13 @@
 ---
 "@peerbit/indexer-rust": patch
 "@peerbit/indexer-sqlite3": patch
+"@peerbit/indexer-interface": patch
+"@peerbit/indexer-cache": patch
+"@peerbit/document": patch
 ---
 
 Keep paginated sorted iterators complete and duplicate-free when indexed rows are inserted, updated, or deleted between pages.
 
 After observing a mutation, an iterator keeps the ids it has already yielded and rescans the current result set. This costs O(N) query work per subsequent page and O(yielded ids) memory; consuming a large changing result set in many small pages can therefore approach O(N²) work.
+
+Allow live-query layers to mark externally delivered ids as yielded so mutable index iterators do not count or emit the same update twice.

--- a/packages/programs/data/document/document/src/resumable-iterator.ts
+++ b/packages/programs/data/document/document/src/resumable-iterator.ts
@@ -11,6 +11,11 @@ import { logger as loggerFn } from "@peerbit/logger";
 const iteratorLogger = loggerFn("peerbit:document:index:iterate");
 
 export class ResumableIterators<T extends Record<string, any>> {
+	private readonly pendingMarks = new Map<
+		string,
+		Map<string, indexerTypes.IdKey>
+	>();
+
 	constructor(
 		readonly index: indexerTypes.Index<T>,
 		readonly queues = new Cache<{
@@ -22,6 +27,36 @@ export class ResumableIterators<T extends Record<string, any>> {
 		// TODO choose upper limit better
 	}
 
+	private markKey(id: indexerTypes.IdKey) {
+		return `${id.key instanceof Uint8Array ? "bytes" : typeof id.key}:${String(id.primitive)}`;
+	}
+
+	private retainMarks(id: string, ids: Iterable<indexerTypes.IdKey>) {
+		let retained = this.pendingMarks.get(id);
+		for (const mark of ids) {
+			if (!retained) {
+				retained = new Map();
+				this.pendingMarks.set(id, retained);
+			}
+			retained.set(this.markKey(mark), mark);
+		}
+	}
+
+	private async applyPendingMarks(
+		id: string,
+		iterator: indexerTypes.IndexIterator<T, undefined>,
+	) {
+		while (true) {
+			const retained = this.pendingMarks.get(id);
+			if (!retained?.size) {
+				this.pendingMarks.delete(id);
+				return;
+			}
+			this.pendingMarks.delete(id);
+			await iterator.markYielded?.(retained.values());
+		}
+	}
+
 	async iterateAndFetch(
 		request: SearchRequest | SearchRequestIndexed | IterationRequest,
 		options?: { keepAlive?: boolean },
@@ -31,29 +66,32 @@ export class ResumableIterators<T extends Record<string, any>> {
 			fetch: request.fetch,
 			keepAlive: Boolean(options?.keepAlive),
 		});
-		const iterator = this.index.iterate(request);
-		const firstResult = await iterator.next(request.fetch);
 		const keepAlive = options?.keepAlive === true;
-		if (keepAlive || iterator.done() !== true) {
-			const cachedIterator = {
-				iterator,
-				request,
+		const iterator = this.index.iterate(request);
+		this.queues.add(request.idString, { iterator, request, keepAlive });
+		try {
+			await this.applyPendingMarks(request.idString, iterator);
+			const firstResult = await iterator.next(request.fetch);
+			if (!keepAlive && iterator.done() === true) {
+				this.queues.del(request.idString);
+				this.pendingMarks.delete(request.idString);
+			}
+			iteratorLogger("iterate:queued", {
+				id: request.idString,
 				keepAlive,
-			};
-			this.queues.add(request.idString, cachedIterator);
+				done: iterator.done() === true,
+				batch: firstResult.length,
+			});
+			/* console.debug(
+				"[ResumableIterators] iterateAndFetch",
+				request.idString,
+				{ keepAlive },
+			); */
+			return firstResult;
+		} catch (error) {
+			this.clear(request.idString);
+			throw error;
 		}
-		iteratorLogger("iterate:queued", {
-			id: request.idString,
-			keepAlive,
-			done: iterator.done() === true,
-			batch: firstResult.length,
-		});
-		/* console.debug(
-			"[ResumableIterators] iterateAndFetch",
-			request.idString,
-			{ keepAlive },
-		); */
-		return firstResult;
 	}
 
 	async next(
@@ -138,6 +176,7 @@ export class ResumableIterators<T extends Record<string, any>> {
 			}
 		}
 		this.queues.del(id);
+		this.pendingMarks.delete(id);
 	}
 
 	async clearAll() {
@@ -155,6 +194,7 @@ export class ResumableIterators<T extends Record<string, any>> {
 			),
 		);
 		this.queues.clear();
+		this.pendingMarks.clear();
 	}
 
 	has(id: string) {
@@ -178,5 +218,13 @@ export class ResumableIterators<T extends Record<string, any>> {
 			keepAlive: iterator.keepAlive,
 		});
 		return pending;
+	}
+
+	async markYielded(id: string, ids: Iterable<indexerTypes.IdKey>) {
+		this.retainMarks(id, ids);
+		const iterator = this.queues.get(id);
+		if (iterator) {
+			await this.applyPendingMarks(id, iterator.iterator);
+		}
 	}
 }

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -1429,6 +1429,7 @@ export class DocumentIndex<
 				let pendingAdded = added;
 				do {
 					const batches: types.Result[] = [];
+					let claimedIds: indexerTypes.IdKey[] = [];
 					const queued = await this.drainQueuedResults(
 						queue.queue,
 						resolveFlag,
@@ -1450,6 +1451,21 @@ export class DocumentIndex<
 						const wrapped = await this.wrapPushResults(matches, resolveFlag);
 						if (wrapped.length) {
 							batches.push(...wrapped);
+							claimedIds = wrapped
+								.map((result) =>
+									result instanceof types.ResultValue && result.indexed
+										? indexerTypes.toId(
+												this.indexByResolver(result.indexed),
+											)
+										: result instanceof types.ResultIndexedValue
+											? indexerTypes.toId(
+													this.indexByResolver(result.value),
+												)
+											: undefined,
+								)
+								.filter(
+									(id): id is indexerTypes.IdKey => id !== undefined,
+								);
 						}
 					}
 					if (batches.length) {
@@ -1467,6 +1483,12 @@ export class DocumentIndex<
 								redundancy: 1,
 							}),
 						});
+						if (claimedIds.length) {
+							await this._resumableIterators.markYielded(
+								_iteratorId,
+								claimedIds,
+							);
+						}
 					}
 					pendingAdded = queue.pendingAdded ?? [];
 					queue.pendingAdded = undefined;
@@ -6240,9 +6262,10 @@ export class DocumentIndex<
 									continue;
 								}
 							}
-							const id = indexerTypes.toId(
+							const indexId = indexerTypes.toId(
 								this.indexByResolver(indexedCandidate),
-							).primitive;
+							);
+							const id = indexId.primitive;
 							const existingIndexed = indexedPlaceholders?.get(id);
 							if (existingIndexed) {
 								if (resolve) {
@@ -6283,6 +6306,10 @@ export class DocumentIndex<
 							if (!resolve) {
 								ensureIndexedPlaceholders().set(id, placeholder);
 							}
+							await this._resumableIterators.markYielded(
+								queryRequestCoerced.idString,
+								[indexId],
+							);
 							hasRelevantChange = true;
 						}
 					}

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -15860,12 +15860,31 @@ describe("index", () => {
 						if (push) {
 							await notificationPromise!.promise;
 							await waitForResolved(
+								async () => {
+									const serverIndex = replicator.docs.index as any;
+									const serverIteratorIds = [
+										...serverIndex._resultQueue.keys(),
+									];
+									expect(serverIteratorIds).to.have.length(1);
+									expect(
+										await serverIndex._resumableIterators.getPending(
+											serverIteratorIds[0],
+										),
+									).to.equal(0);
+								},
+								{ timeout: 30_000 },
+							);
+							await waitForResolved(
 								async () => expect(await iterator.pending()).to.equal(1),
 								{ timeout: 30_000 },
 							);
 							const batch = await iterator.next(1);
 							expect(batch).to.have.length(1);
 							expect(batch[0].id).to.equal(docId);
+							await waitForResolved(
+								async () => expect(await iterator.pending()).to.equal(0),
+								{ timeout: 30_000 },
+							);
 						} else {
 							await delay(5_000); // ensure we didn't receive a pushed batch
 							expect(await iterator.pending()).to.equal(1);

--- a/packages/programs/data/document/document/test/resumable-iterator.spec.ts
+++ b/packages/programs/data/document/document/test/resumable-iterator.spec.ts
@@ -1,0 +1,41 @@
+import { IterationRequest } from "@peerbit/document-interface";
+import {
+	type Index,
+	type IndexIterator,
+	toId,
+} from "@peerbit/indexer-interface";
+import { expect } from "chai";
+import { ResumableIterators } from "../src/resumable-iterator.js";
+
+describe("ResumableIterators", () => {
+	it("applies deduplicated marks retained before the first fetch", async () => {
+		type Row = { id: string };
+		const events: string[] = [];
+		const iterator: IndexIterator<Row, undefined> = {
+			next: () => {
+				events.push("next");
+				return [];
+			},
+			all: () => [],
+			done: () => false,
+			pending: () => 0,
+			close: () => undefined,
+			markYielded: (ids) => {
+				events.push(`mark:${[...ids].map((id) => id.primitive).join(",")}`);
+			},
+		};
+		const index = {
+			iterate: () => iterator,
+		} as unknown as Index<Row>;
+		const resumable = new ResumableIterators(index);
+		const request = new IterationRequest({ fetch: 1 });
+		const claimed = toId("claimed");
+
+		await resumable.markYielded(request.idString, [claimed, claimed]);
+		await resumable.iterateAndFetch(request, { keepAlive: true });
+
+		expect(events).to.deep.equal(["mark:claimed", "next"]);
+		expect(resumable.has(request.idString)).to.be.true;
+		resumable.close(request);
+	});
+});

--- a/packages/utils/indexer/cached-index/src/cache.ts
+++ b/packages/utils/indexer/cached-index/src/cache.ts
@@ -2,6 +2,7 @@
 import { field, serialize, vec } from "@dao-xyz/borsh";
 import { toBase64 } from "@peerbit/crypto";
 import {
+	type IdKey,
 	type IndexIterator,
 	type IndexedResults,
 	type IterateOptions,
@@ -9,6 +10,9 @@ import {
 	Sort,
 } from "@peerbit/indexer-interface";
 import { toQuery, toSort } from "@peerbit/indexer-interface";
+
+const idKey = (id: IdKey) =>
+	`${id.key instanceof Uint8Array ? "bytes" : typeof id.key}:${String(id.primitive)}`;
 
 /* -------------------------------------------------------- key helpers */
 class KeyableIterate {
@@ -63,6 +67,16 @@ function wrapWithBuffer<T extends Record<string, any>>(
 		done: () => (buf.length ? false : (src.done?.() ?? false)),
 		pending: async () => (buf.length ? buf.length : (src.pending?.() ?? 0)),
 		close: () => src.close(),
+		markYielded: (ids) => {
+			const claimed = [...ids];
+			const claimedKeys = new Set(claimed.map(idKey));
+			for (let i = buf.length - 1; i >= 0; i--) {
+				if (claimedKeys.has(idKey(buf[i].id))) {
+					buf.splice(i, 1);
+				}
+			}
+			return src.markYielded?.(claimed);
+		},
 	};
 }
 

--- a/packages/utils/indexer/cached-index/test/index.spec.ts
+++ b/packages/utils/indexer/cached-index/test/index.spec.ts
@@ -1,12 +1,17 @@
 /* eslint-env mocha */
 import { field } from "@dao-xyz/borsh";
 import { ready } from "@peerbit/crypto";
-import { Compare, IntegerCompare, id } from "@peerbit/indexer-interface";
+import {
+	Compare,
+	IntegerCompare,
+	id,
+	toId,
+} from "@peerbit/indexer-interface";
 import type { IterateOptions } from "@peerbit/indexer-interface";
 import { HashmapIndex } from "@peerbit/indexer-simple";
 import { delay, waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
-import type { QueryCacheOptions } from "../src/cache.js";
+import { IteratorCache, type QueryCacheOptions } from "../src/cache.js";
 import { CachedIndex } from "../src/index.js";
 
 /* ---------------------------------------------------------------- model */
@@ -86,6 +91,60 @@ describe("CachedIndex iterator cache", () => {
 		const b1 = await it.next(50);
 		const b2 = await it.next(160);
 		expect(b1.length + b2.length).to.equal(size);
+	});
+
+	it("removes marked rows from a warm buffer before forwarding", async () => {
+		const rows = ["0", "1", "2"].map((value) => ({
+			id: toId(value),
+			value: new Document({ id: value, content: value, number: +value }),
+		}));
+		const forwarded: string[] = [];
+		const cache = new IteratorCache<Document>(
+			{
+				strategy: "auto",
+				maxSize: rows.length,
+				maxTotalSize: rows.length,
+				prefetchThreshold: 1,
+			},
+			() => {
+				let offset = 0;
+				return {
+					next: (amount) => {
+						const next = rows.slice(offset, offset + amount);
+						offset += next.length;
+						return next;
+					},
+					all: () => {
+						const rest = rows.slice(offset);
+						offset = rows.length;
+						return rest;
+					},
+					done: () => offset >= rows.length,
+					pending: () => Math.max(0, rows.length - offset),
+					close: () => undefined,
+					markYielded: async (ids) => {
+						forwarded.push(...[...ids].map((id) => String(id.primitive)));
+					},
+				};
+			},
+		);
+
+		const cold = cache.acquire();
+		await cold.close();
+		await waitForResolved(() =>
+			expect(cache._debugStats.activeQueries).to.have.length(1),
+		);
+
+		const warm = cache.acquire();
+		const marking = warm.markYielded!([toId("1")]);
+		expect(forwarded).to.deep.equal(["1"]);
+		expect(await warm.pending()).to.equal(2);
+		expect((await warm.next(rows.length)).map((row) => row.value.id)).to.deep.equal(
+			["0", "2"],
+		);
+		await marking;
+		await warm.close();
+		await cache.clear();
 	});
 
 	it("does not prefetch until query used N times", async () => {

--- a/packages/utils/indexer/interface/src/index-engine.ts
+++ b/packages/utils/indexer/interface/src/index-engine.ts
@@ -89,6 +89,17 @@ export type IndexIterator<
 	done: () => boolean | undefined;
 	pending: () => MaybePromise<number>;
 	close: () => MaybePromise<void>;
+	/**
+	 * Mark results claimed or enqueued by a higher-level live-update path as
+	 * consumed by this iterator.
+	 *
+	 * Mutable iterators can implement this hook to keep subsequent pages and
+	 * pending counts from returning those same ids again. Callers must only mark
+	 * ids once another delivery path owns them (for example, after enqueueing a
+	 * local result or successfully sending a remote push). Snapshot iterators may
+	 * omit this hook.
+	 */
+	markYielded?: (ids: Iterable<IdKey>) => MaybePromise<void>;
 };
 
 /**

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -2479,6 +2479,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 						entry.value,
 						this.fieldEncoder(entry.value),
 					);
+					this.markMutationVisible();
 				}
 			}
 			return;
@@ -2534,6 +2535,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 						item.value,
 						this.fieldEncoder(item.value),
 					);
+					this.markMutationVisible();
 				}
 			}
 			await this.compactIfNeeded();
@@ -2601,9 +2603,15 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			});
 		}
 		if (!this.snapshotFile) {
-			const deleted = this.getNative()
-				.put_and_delete_matching(storeKey, id, value, fields, queryBytes)
-				.map((entry) => entry[0]);
+			const deletedEntries = this.getNative().put_and_delete_matching(
+				storeKey,
+				id,
+				value,
+				fields,
+				queryBytes,
+			);
+			this.markMutationVisible();
+			const deleted = deletedEntries.map((entry) => entry[0]);
 			this.mutationVersion++;
 			return deleted;
 		}
@@ -2611,6 +2619,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		return this.enqueueMutation(async () => {
 			await this.appendPut(storeKey, value);
 			this.getNative().put(storeKey, id, value, fields);
+			this.markMutationVisible();
 			const deletedEntries = this.getNativeCandidatesForPlan({
 				compiled,
 				sort: [],
@@ -2621,6 +2630,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 					deletedEntries.map((entry) => keyToStoreKey(entry.id)),
 				);
 				this.getNative().delete_matching(queryBytes);
+				this.markMutationVisible();
 			}
 			await this.compactIfNeeded();
 			this.mutationVersion++;
@@ -2934,30 +2944,32 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		}>,
 	): MaybePromise<types.IdKey[]> {
 		if (!this.snapshotFile) {
-			return prepared.flatMap((entry) =>
-				this.getNative()
-					.put_and_delete_keys(
-						entry.storeKey,
-						entry.id,
-						entry.value,
-						entry.fields,
-						entry.deleteKeys,
-					)
-					.map((deleted) => deleted[0]),
-			);
-		}
-
-		return this.enqueueMutation(async () => {
-			await this.appendPutAndDeletesBatch(prepared);
-			const deletedEntries = prepared.flatMap((entry) =>
-				this.getNative().put_and_delete_keys(
+			return prepared.flatMap((entry) => {
+				const deleted = this.getNative().put_and_delete_keys(
 					entry.storeKey,
 					entry.id,
 					entry.value,
 					entry.fields,
 					entry.deleteKeys,
-				),
-			);
+				);
+				this.markMutationVisible();
+				return deleted.map((item) => item[0]);
+			});
+		}
+
+		return this.enqueueMutation(async () => {
+			await this.appendPutAndDeletesBatch(prepared);
+			const deletedEntries = prepared.flatMap((entry) => {
+				const deleted = this.getNative().put_and_delete_keys(
+					entry.storeKey,
+					entry.id,
+					entry.value,
+					entry.fields,
+					entry.deleteKeys,
+				);
+				this.markMutationVisible();
+				return deleted;
+			});
 			await this.compactIfNeeded();
 			return deletedEntries.map((entry) => entry[0]);
 		});
@@ -3009,6 +3021,9 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		}
 		if (!this.snapshotFile) {
 			const deletedEntries = this.getNative().delete_keys(deleteKeys);
+			if (deletedEntries.length > 0) {
+				this.markMutationVisible();
+			}
 			this.deleteNativeBackboneDocumentKeys(deleteKeys);
 			return this.trackMutationIf(
 				deletedEntries.map((entry) => entry[0]),
@@ -3019,6 +3034,9 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			this.enqueueMutation(async () => {
 				await this.appendDeletes(deleteKeys);
 				const deletedEntries = this.getNative().delete_keys(deleteKeys);
+				if (deletedEntries.length > 0) {
+					this.markMutationVisible();
+				}
 				this.deleteNativeBackboneDocumentKeys(deleteKeys);
 				await this.compactIfNeeded();
 				return deletedEntries.map((entry) => entry[0]);
@@ -3051,11 +3069,15 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		const native = this.getNative();
 		if (!this.snapshotFile && native.delete_keys_void) {
 			native.delete_keys_void(deleteKeys);
+			this.markMutationVisible();
 			this.deleteNativeBackboneDocumentKeys(deleteKeys);
 			return this.trackMutation(undefined);
 		}
 		if (!this.snapshotFile) {
-			native.delete_keys(deleteKeys);
+			const deleted = native.delete_keys(deleteKeys);
+			if (deleted.length > 0) {
+				this.markMutationVisible();
+			}
 			this.deleteNativeBackboneDocumentKeys(deleteKeys);
 			return this.trackMutation(undefined);
 		}
@@ -3064,8 +3086,12 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				await this.appendDeletes(deleteKeys);
 				if (native.delete_keys_void) {
 					native.delete_keys_void(deleteKeys);
+					this.markMutationVisible();
 				} else {
-					native.delete_keys(deleteKeys);
+					const deleted = native.delete_keys(deleteKeys);
+					if (deleted.length > 0) {
+						this.markMutationVisible();
+					}
 				}
 				this.deleteNativeBackboneDocumentKeys(deleteKeys);
 				await this.compactIfNeeded();
@@ -3085,11 +3111,17 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		const native = this.getNative();
 		if (!this.snapshotFile && native.delete_keys_count) {
 			const deleted = native.delete_keys_count(deleteKeys);
+			if (deleted > 0) {
+				this.markMutationVisible();
+			}
 			this.deleteNativeBackboneDocumentKeys(deleteKeys);
 			return this.trackMutationIf(deleted, (count) => count > 0);
 		}
 		if (!this.snapshotFile) {
 			const deleted = native.delete_keys(deleteKeys);
+			if (deleted.length > 0) {
+				this.markMutationVisible();
+			}
 			this.deleteNativeBackboneDocumentKeys(deleteKeys);
 			return this.trackMutationIf(deleted.length, (count) => count > 0);
 		}
@@ -3099,6 +3131,9 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				const deleted = native.delete_keys_count
 					? native.delete_keys_count(deleteKeys)
 					: native.delete_keys(deleteKeys).length;
+				if (deleted > 0) {
+					this.markMutationVisible();
+				}
 				this.deleteNativeBackboneDocumentKeys(deleteKeys);
 				await this.compactIfNeeded();
 				return deleted;
@@ -3129,6 +3164,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 					this.getNative().delete_matching(
 						encodeNativeQuerySpec(compiled.spec),
 					);
+					this.markMutationVisible();
 				}
 				this.mutationVersion++;
 			}
@@ -3153,6 +3189,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 					this.getNative().delete_matching(
 						encodeNativeQuerySpec(compiled.spec),
 					);
+					this.markMutationVisible();
 				}
 				await this.compactIfNeeded();
 				this.mutationVersion++;
@@ -3299,6 +3336,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			>;
 		let mutationMode = false;
 		let iteratorMutationVersion = this.mutationVersion;
+		let explicitlyClosed = false;
 		const yielded = new Set<string>();
 		const idKey = (id: types.IdKey) => keyToStoreKey(id);
 		const markYielded = (
@@ -3357,6 +3395,9 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		const next = async (
 			n: number,
 		): Promise<types.IndexedResults<types.ReturnTypeFromShape<T, S>>> => {
+			if (explicitlyClosed) {
+				return [] as types.IndexedResults<types.ReturnTypeFromShape<T, S>>;
+			}
 			if (n <= 0) {
 				return [] as types.IndexedResults<types.ReturnTypeFromShape<T, S>>;
 			}
@@ -3431,6 +3472,9 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 
 		return {
 			all: async () => {
+				if (explicitlyClosed) {
+					return [];
+				}
 				const results: types.IndexedResults<types.ReturnTypeFromShape<T, S>> =
 					[];
 				while (true) {
@@ -3443,8 +3487,11 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				return results;
 			},
 			next,
-			done: () => (this.isClosing() ? true : done),
+			done: () => (explicitlyClosed || this.isClosing() ? true : done),
 			pending: async () => {
+				if (explicitlyClosed) {
+					return 0;
+				}
 				if (this.isClosing()) {
 					done = true;
 					return 0;
@@ -3458,6 +3505,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				return done ? 0 : Math.max(0, getTotal() - offset);
 			},
 			close: () => {
+				explicitlyClosed = true;
 				done = true;
 			},
 		};
@@ -3629,11 +3677,13 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		}
 		if (!this.snapshotFile) {
 			this.getNative().put(storeKey, id, value, fields);
+			this.markMutationVisible();
 			return;
 		}
 		return this.enqueueMutation(async () => {
 			await this.appendPut(storeKey, value, encodedValue);
 			this.getNative().put(storeKey, id, value, fields);
+			this.markMutationVisible();
 			await this.compactIfNeeded();
 		});
 	}
@@ -3673,6 +3723,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				return;
 			}
 			this.getNative().put(storeKey, id, value, this.fieldEncoder(value));
+			this.markMutationVisible();
 			return;
 		}
 		return this.enqueueMutation(async () => {
@@ -3686,6 +3737,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				)
 			) {
 				this.getNative().put(storeKey, id, value, this.fieldEncoder(value));
+				this.markMutationVisible();
 			}
 			await this.compactIfNeeded();
 		});
@@ -3730,6 +3782,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				return;
 			}
 			this.getNative().put(storeKey, id, value, this.fieldEncoder(value));
+			this.markMutationVisible();
 			return;
 		}
 		return this.enqueueMutation(async () => {
@@ -3745,6 +3798,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				)
 			) {
 				this.getNative().put(storeKey, id, value, this.fieldEncoder(value));
+				this.markMutationVisible();
 			}
 			await this.compactIfNeeded();
 		});
@@ -3797,9 +3851,15 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			});
 		}
 		if (!this.snapshotFile) {
-			return this.getNative()
-				.put_and_delete_keys(storeKey, id, value, fields, deleteKeys)
-				.map((entry) => entry[0]);
+			const deleted = this.getNative().put_and_delete_keys(
+				storeKey,
+				id,
+				value,
+				fields,
+				deleteKeys,
+			);
+			this.markMutationVisible();
+			return deleted.map((entry) => entry[0]);
 		}
 
 		return this.enqueueMutation(async () => {
@@ -3811,6 +3871,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				fields,
 				deleteKeys,
 			);
+			this.markMutationVisible();
 			await this.compactIfNeeded();
 			return deletedEntries.map((entry) => entry[0]);
 		});
@@ -3960,19 +4021,20 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 					value,
 					...this.getSharedLogCoordinateNativePutArgs(fields),
 				);
+				this.markMutationVisible();
 				return [];
 			}
 		}
-		return nativePutCoordinate
-			.call(
-				native,
-				storeKey,
-				id,
-				value,
-				...this.getSharedLogCoordinateNativePutArgs(fields),
-				deleteKeys,
-			)
-			.map((entry) => entry[0]);
+		const deleted = nativePutCoordinate.call(
+			native,
+			storeKey,
+			id,
+			value,
+			...this.getSharedLogCoordinateNativePutArgs(fields),
+			deleteKeys,
+		);
+		this.markMutationVisible();
+		return deleted.map((entry) => entry[0]);
 	}
 
 	private putSharedLogCoordinateNativeValueAndDeleteKeysNoReturn(
@@ -3993,6 +4055,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 					value,
 					...this.getSharedLogCoordinateNativePutArgs(fields),
 				);
+				this.markMutationVisible();
 				return;
 			}
 		}
@@ -4016,6 +4079,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			...this.getSharedLogCoordinateNativePutArgs(fields),
 			deleteKeys,
 		);
+		this.markMutationVisible();
 	}
 
 	private putSharedLogCoordinateNativeValuesAndDeleteKeysBatchNoReturn(
@@ -4077,6 +4141,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			this.byteElementIndexLimit,
 			entries.map((entry) => entry.deleteKeys),
 		);
+		this.markMutationVisible();
 	}
 
 	private putSharedLogCoordinateNativeEncodedValueAndDeleteKeysNoReturn(
@@ -4101,6 +4166,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			...this.getSharedLogCoordinateNativePutArgs(fields),
 			deleteKeys,
 		);
+		this.markMutationVisible();
 	}
 
 	private getSharedLogCoordinateFieldIds(): NonNullable<
@@ -4259,6 +4325,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			return;
 		}
 		this.getNative().put(storeKey, id, value, this.fieldEncoder(value));
+		this.markMutationVisible();
 	}
 
 	private putNativeDocumentEncodedPartsBatch(
@@ -4304,6 +4371,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				suffixes,
 				this.nativeByteElementIndexLimit,
 			);
+			this.markMutationVisible();
 			return true;
 		} catch {
 			// Fall back to the per-entry native call, which already falls back again
@@ -4331,6 +4399,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				encodedValueParts.suffix,
 				this.nativeByteElementIndexLimit,
 			);
+			this.markMutationVisible();
 			return true;
 		} catch {
 			return false;
@@ -4345,6 +4414,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		if (!backbone?.putDocumentEncodedPartsStored) {
 			return false;
 		}
+		const previousValue = this.nativeBackboneStoredBytes(storeKey);
 		try {
 			backbone.putDocumentEncodedPartsStored(
 				storeKey,
@@ -4352,10 +4422,49 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				encodedValueParts.suffix,
 				this.nativeByteElementIndexLimit,
 			);
+			this.markMutationVisible();
 			return true;
 		} catch {
+			if (
+				!this.nativeBackboneBytesEqual(
+					previousValue,
+					this.nativeBackboneStoredBytes(storeKey),
+				)
+			) {
+				this.markMutationVisible();
+			}
 			return false;
 		}
+	}
+
+	private nativeBackboneStoredBytes(storeKey: string): Uint8Array | undefined {
+		try {
+			const backbone = this.nativeBackboneDocumentIndex;
+			const bytes =
+				backbone?.documentValueBytes?.(storeKey) ??
+				backbone?.documentEntry?.(storeKey)?.[1];
+			return bytes?.slice();
+		} catch {
+			return;
+		}
+	}
+
+	private nativeBackboneBytesEqual(
+		a: Uint8Array | undefined,
+		b: Uint8Array | undefined,
+	): boolean {
+		if (!a || !b) {
+			return a === b;
+		}
+		if (a.length !== b.length) {
+			return false;
+		}
+		for (let i = 0; i < a.length; i++) {
+			if (a[i] !== b[i]) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	private putNativeBackboneDocumentEncodedValueStored(
@@ -4451,6 +4560,10 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 	): boolean {
 		const backbone = this.nativeBackboneDocumentIndex;
 		if (backbone?.putDocumentEncodedPartsStoredBatch && values.length > 0) {
+			const previousValues = values.map((entry) => {
+				const key = entry.storeKey ?? keyToStoreKey(entry.id);
+				return [key, this.nativeBackboneStoredBytes(key)] as const;
+			});
 			try {
 				backbone.putDocumentEncodedPartsStoredBatch(
 					values.map((entry) => ({
@@ -4460,8 +4573,20 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 					})),
 					this.nativeByteElementIndexLimit,
 				);
+				this.markMutationVisible();
 				return true;
 			} catch {
+				if (
+					previousValues.some(
+						([key, previous]) =>
+							!this.nativeBackboneBytesEqual(
+								previous,
+								this.nativeBackboneStoredBytes(key),
+							),
+					)
+				) {
+					this.markMutationVisible();
+				}
 				// Fall back to single puts so older native-backbone objects remain usable.
 			}
 		}
@@ -4518,6 +4643,9 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				this.nativeBackboneDocumentIndex,
 				storeKeys,
 			);
+			if (deleted.some((value) => value !== 0)) {
+				this.markMutationVisible();
+			}
 			const deletedIds: types.IdKey[] = [];
 			for (let i = 0; i < storeKeys.length; i++) {
 				if (deleted[i] !== 0) {
@@ -4536,6 +4664,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		const deletedIds: types.IdKey[] = [];
 		for (const key of storeKeys) {
 			if (deleteDocument.call(this.nativeBackboneDocumentIndex, key)) {
+				this.markMutationVisible();
 				const id = storeKeyToIdKey(key);
 				if (id) {
 					deletedIds.push(id);
@@ -4549,6 +4678,9 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		const deleteDocuments = this.nativeBackboneDocumentIndex?.deleteDocuments;
 		if (deleteDocuments) {
 			deleteDocuments.call(this.nativeBackboneDocumentIndex, storeKeys);
+			if (storeKeys.length > 0) {
+				this.markMutationVisible();
+			}
 			return;
 		}
 		const deleteDocument = this.nativeBackboneDocumentIndex?.deleteDocument;
@@ -4556,7 +4688,9 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			return;
 		}
 		for (const key of storeKeys) {
-			deleteDocument.call(this.nativeBackboneDocumentIndex, key);
+			if (deleteDocument.call(this.nativeBackboneDocumentIndex, key)) {
+				this.markMutationVisible();
+			}
 		}
 	}
 
@@ -4935,6 +5069,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 					encodedValueParts.suffix,
 					this.nativeByteElementIndexLimit,
 				);
+				this.markMutationVisible();
 				return true;
 			} catch {
 				// Fall back to the proven TypeScript fact encoder for schemas whose
@@ -4950,6 +5085,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 					encodedValue,
 					this.nativeByteElementIndexLimit,
 				);
+				this.markMutationVisible();
 				return true;
 			} catch {
 				// Fall back to the proven TypeScript fact encoder for schemas whose
@@ -4958,6 +5094,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		}
 		if (fields) {
 			this.getNative().put(storeKey, id, value, fields);
+			this.markMutationVisible();
 			return true;
 		}
 		return false;
@@ -5041,6 +5178,10 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			throw new Error("Index has not been initialized");
 		}
 		return this.native;
+	}
+
+	private markMutationVisible(): void {
+		this.mutationVersion++;
 	}
 
 	private trackMutation<R>(result: MaybePromise<R>): MaybePromise<R> {

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -1950,6 +1950,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 	private persistQueue: Promise<void> = Promise.resolve();
 	private mutationQueue: Promise<void> = Promise.resolve();
 	private state: "closed" | "open" | "closing" = "closed";
+	private mutationVersion = 0;
 
 	constructor(
 		private readonly directory?: string,
@@ -2293,13 +2294,17 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		id = id ?? types.toId(types.extractFieldValue(value, this.indexByArr));
 		const encodedValue = this.tryNativeEncodedValue(value);
 		if (encodedValue) {
-			return this.putWithEncodedValue(value, id, encodedValue);
+			return this.trackMutation(
+				this.putWithEncodedValue(value, id, encodedValue),
+			);
 		}
 		if (!this.snapshotFile) {
 			this.putNativeDocument(keyToStoreKey(id), id, value);
-			return;
+			return this.trackMutation(undefined);
 		}
-		return this.putWithEncodedFields(value, id, this.fieldEncoder(value));
+		return this.trackMutation(
+			this.putWithEncodedFields(value, id, this.fieldEncoder(value)),
+		);
 	}
 
 	putWithContext(
@@ -2314,15 +2319,17 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				options.encodedValueParts,
 			);
 			if (storedPut !== false) {
-				return storedPut;
+				return this.trackMutation(storedPut);
 			}
 		}
 		const contextualValue = this.asContextualValue(value, context);
 		if (options?.encodedValue) {
-			return this.putWithEncodedValue(
-				contextualValue,
-				id,
-				options.encodedValue,
+			return this.trackMutation(
+				this.putWithEncodedValue(
+					contextualValue,
+					id,
+					options.encodedValue,
+				),
 			);
 		}
 		return this.put(contextualValue, id, options);
@@ -2346,8 +2353,9 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 					id: entry.id,
 					encodedValueParts: entry.options!.encodedValueParts!,
 				})),
-			))
+				))
 		) {
+			this.mutationVersion++;
 			return;
 		}
 		if (values.some((entry) => entry.options?.replace === true)) {
@@ -2369,6 +2377,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				encodedValueParts: entry.options?.encodedValueParts,
 			})),
 		);
+		this.mutationVersion++;
 	}
 
 	async putBatch(values: T[]): Promise<void> {
@@ -2381,6 +2390,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				id: types.toId(types.extractFieldValue(value, this.indexByArr)),
 			})),
 		);
+		this.mutationVersion++;
 	}
 
 	private async putPreparedBatch(
@@ -2562,6 +2572,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				this.deleteNativeBackboneDocumentKeys(
 					deletedEntries.map((entry) => keyToStoreKey(entry.id)),
 				);
+				this.mutationVersion++;
 				return deletedEntries.map((entry) => entry.id);
 			}
 
@@ -2585,13 +2596,16 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 					);
 				}
 				await this.compactIfNeeded();
+				this.mutationVersion++;
 				return deletedEntries.map((entry) => entry.id);
 			});
 		}
 		if (!this.snapshotFile) {
-			return this.getNative()
+			const deleted = this.getNative()
 				.put_and_delete_matching(storeKey, id, value, fields, queryBytes)
 				.map((entry) => entry[0]);
+			this.mutationVersion++;
+			return deleted;
 		}
 
 		return this.enqueueMutation(async () => {
@@ -2609,6 +2623,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				this.getNative().delete_matching(queryBytes);
 			}
 			await this.compactIfNeeded();
+			this.mutationVersion++;
 			return deletedEntries.map((entry) => entry.id);
 		});
 	}
@@ -2618,11 +2633,13 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		deleteIds: Array<types.IdKey | types.Ideable>,
 		id = types.toId(types.extractFieldValue(value, this.indexByArr)),
 	): Promise<types.IdKey[]> {
-		return this.putWithEncodedFieldsAndDeleteKeys(
-			value,
-			id,
-			this.fieldEncoder(value),
-			deleteIds.map(keyToStoreKey),
+		return this.trackMutation(
+			this.putWithEncodedFieldsAndDeleteKeys(
+				value,
+				id,
+				this.fieldEncoder(value),
+				deleteIds.map(keyToStoreKey),
+			),
 		);
 	}
 
@@ -2632,11 +2649,13 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		deleteIds: Array<types.IdKey | types.Ideable> = [],
 		id = types.toId(types.extractFieldValue(value, this.indexByArr)),
 	): MaybePromise<types.IdKey[]> {
-		return this.putSharedLogCoordinateValueAndDeleteKeys(
-			value,
-			id,
-			deleteIds.map(keyToStoreKey),
-			fields,
+		return this.trackMutation(
+			this.putSharedLogCoordinateValueAndDeleteKeys(
+				value,
+				id,
+				deleteIds.map(keyToStoreKey),
+				fields,
+			),
 		);
 	}
 
@@ -2645,11 +2664,13 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		deleteIds: Array<types.IdKey | types.Ideable> = [],
 		id = types.toId(fields.hash),
 	): MaybePromise<types.IdKey[]> {
-		return this.putSharedLogCoordinateValueAndDeleteKeys(
-			this.createSharedLogCoordinateValue(fields),
-			id,
-			deleteIds.map(keyToStoreKey),
-			fields,
+		return this.trackMutation(
+			this.putSharedLogCoordinateValueAndDeleteKeys(
+				this.createSharedLogCoordinateValue(fields),
+				id,
+				deleteIds.map(keyToStoreKey),
+				fields,
+			),
 		);
 	}
 
@@ -2658,14 +2679,16 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		deleteHashes: string[] = [],
 		id = types.toId(fields.hash),
 	): MaybePromise<types.IdKey[]> {
-		return this.putSharedLogCoordinateValueAndDeleteKeys(
-			this.createSharedLogCoordinateValue(fields),
-			id,
-			deleteHashes.map(stringToStoreKey),
-			fields,
-			id.primitive === fields.hash
-				? stringToStoreKey(fields.hash)
-				: keyToStoreKey(id),
+		return this.trackMutation(
+			this.putSharedLogCoordinateValueAndDeleteKeys(
+				this.createSharedLogCoordinateValue(fields),
+				id,
+				deleteHashes.map(stringToStoreKey),
+				fields,
+				id.primitive === fields.hash
+					? stringToStoreKey(fields.hash)
+					: keyToStoreKey(id),
+			),
 		);
 	}
 
@@ -2674,14 +2697,16 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		deleteHashes: string[] = [],
 		id = types.toId(fields.hash),
 	): MaybePromise<void> {
-		return this.putSharedLogCoordinateValueAndDeleteKeysNoReturn(
-			this.createSharedLogCoordinateValue(fields),
-			id,
-			deleteHashes.map(stringToStoreKey),
-			fields,
-			id.primitive === fields.hash
-				? stringToStoreKey(fields.hash)
-				: keyToStoreKey(id),
+		return this.trackMutation(
+			this.putSharedLogCoordinateValueAndDeleteKeysNoReturn(
+				this.createSharedLogCoordinateValue(fields),
+				id,
+				deleteHashes.map(stringToStoreKey),
+				fields,
+				id.primitive === fields.hash
+					? stringToStoreKey(fields.hash)
+					: keyToStoreKey(id),
+			),
 		);
 	}
 
@@ -2714,28 +2739,30 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				fields,
 				storeKey,
 			);
-			return;
+			return this.trackMutation(undefined);
 		}
-		return this.enqueueMutation(async () => {
-			if (deleteKeys.length === 0) {
-				await this.appendPut(storeKey, undefined, encodedValue);
-			} else {
-				await this.appendPutAndDeletes(
-					storeKey,
-					undefined,
-					deleteKeys,
+		return this.trackMutation(
+			this.enqueueMutation(async () => {
+				if (deleteKeys.length === 0) {
+					await this.appendPut(storeKey, undefined, encodedValue);
+				} else {
+					await this.appendPutAndDeletes(
+						storeKey,
+						undefined,
+						deleteKeys,
+						encodedValue,
+					);
+				}
+				this.putSharedLogCoordinateNativeEncodedValueAndDeleteKeysNoReturn(
 					encodedValue,
+					id,
+					deleteKeys,
+					fields,
+					storeKey,
 				);
-			}
-			this.putSharedLogCoordinateNativeEncodedValueAndDeleteKeysNoReturn(
-				encodedValue,
-				id,
-				deleteKeys,
-				fields,
-				storeKey,
-			);
-			await this.compactIfNeeded();
-		});
+				await this.compactIfNeeded();
+			}),
+		);
 	}
 
 	putSharedLogCoordinatesAndDeleteIdsBatch(
@@ -2766,7 +2793,9 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			};
 		});
 
-		return this.putSharedLogCoordinatePreparedBatch(prepared);
+		return this.trackMutation(
+			this.putSharedLogCoordinatePreparedBatch(prepared),
+		);
 	}
 
 	putSharedLogCoordinateFieldsAndDeleteHashesBatch(
@@ -2808,31 +2837,35 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		});
 
 		if (!this.snapshotFile) {
-			return prepared.flatMap((entry) =>
-				this.putSharedLogCoordinateNativeValueAndDeleteKeys(
-					entry.value,
-					entry.id,
-					entry.deleteKeys,
-					entry.nativeFields,
-					entry.storeKey,
+			return this.trackMutation(
+				prepared.flatMap((entry) =>
+					this.putSharedLogCoordinateNativeValueAndDeleteKeys(
+						entry.value,
+						entry.id,
+						entry.deleteKeys,
+						entry.nativeFields,
+						entry.storeKey,
+					),
 				),
 			);
 		}
 
-		return this.enqueueMutation(async () => {
-			await this.appendPutAndDeletesBatch(prepared);
-			const deletedEntries = prepared.flatMap((entry) =>
-				this.putSharedLogCoordinateNativeValueAndDeleteKeys(
-					entry.value,
-					entry.id,
-					entry.deleteKeys,
-					entry.nativeFields,
-					entry.storeKey,
-				),
-			);
-			await this.compactIfNeeded();
-			return deletedEntries;
-		});
+		return this.trackMutation(
+			this.enqueueMutation(async () => {
+				await this.appendPutAndDeletesBatch(prepared);
+				const deletedEntries = prepared.flatMap((entry) =>
+					this.putSharedLogCoordinateNativeValueAndDeleteKeys(
+						entry.value,
+						entry.id,
+						entry.deleteKeys,
+						entry.nativeFields,
+						entry.storeKey,
+					),
+				);
+				await this.compactIfNeeded();
+				return deletedEntries;
+			}),
+		);
 	}
 
 	putSharedLogCoordinateFieldsAndDeleteHashesBatchNoReturn(
@@ -2876,16 +2909,18 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			this.putSharedLogCoordinateNativeValuesAndDeleteKeysBatchNoReturn(
 				prepared,
 			);
-			return;
+			return this.trackMutation(undefined);
 		}
 
-		return this.enqueueMutation(async () => {
-			await this.appendPutAndDeletesBatch(prepared);
-			this.putSharedLogCoordinateNativeValuesAndDeleteKeysBatchNoReturn(
-				prepared,
-			);
-			await this.compactIfNeeded();
-		});
+		return this.trackMutation(
+			this.enqueueMutation(async () => {
+				await this.appendPutAndDeletesBatch(prepared);
+				this.putSharedLogCoordinateNativeValuesAndDeleteKeysBatchNoReturn(
+					prepared,
+				);
+				await this.compactIfNeeded();
+			}),
+		);
 	}
 
 	private putSharedLogCoordinatePreparedBatch(
@@ -2954,31 +2989,42 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		}
 		if (this.nativeBackboneDocumentIndexPrimary) {
 			if (!this.snapshotFile) {
-				return this.deleteNativeBackboneDocumentKeys(deleteKeys);
+				return this.trackMutationIf(
+					this.deleteNativeBackboneDocumentKeys(deleteKeys),
+					(deleted) => deleted.length > 0,
+				);
 			}
 			const deletedIds = this.getNativeBackboneExistingIds(deleteKeys);
 			if (deletedIds.length === 0) {
 				return [];
 			}
-			return this.enqueueMutation(async () => {
-				await this.appendDeletes(deleteKeys);
-				this.deleteNativeBackboneDocumentKeys(deleteKeys);
-				await this.compactIfNeeded();
-				return deletedIds;
-			});
+			return this.trackMutation(
+				this.enqueueMutation(async () => {
+					await this.appendDeletes(deleteKeys);
+					this.deleteNativeBackboneDocumentKeys(deleteKeys);
+					await this.compactIfNeeded();
+					return deletedIds;
+				}),
+			);
 		}
 		if (!this.snapshotFile) {
 			const deletedEntries = this.getNative().delete_keys(deleteKeys);
 			this.deleteNativeBackboneDocumentKeys(deleteKeys);
-			return deletedEntries.map((entry) => entry[0]);
+			return this.trackMutationIf(
+				deletedEntries.map((entry) => entry[0]),
+				(deleted) => deleted.length > 0,
+			);
 		}
-		return this.enqueueMutation(async () => {
-			await this.appendDeletes(deleteKeys);
-			const deletedEntries = this.getNative().delete_keys(deleteKeys);
-			this.deleteNativeBackboneDocumentKeys(deleteKeys);
-			await this.compactIfNeeded();
-			return deletedEntries.map((entry) => entry[0]);
-		});
+		return this.trackMutationIf(
+			this.enqueueMutation(async () => {
+				await this.appendDeletes(deleteKeys);
+				const deletedEntries = this.getNative().delete_keys(deleteKeys);
+				this.deleteNativeBackboneDocumentKeys(deleteKeys);
+				await this.compactIfNeeded();
+				return deletedEntries.map((entry) => entry[0]);
+			}),
+			(deleted) => deleted.length > 0,
+		);
 	}
 
 	delIdsNoReturn(deleteIds: Array<types.IdKey | types.Ideable>): MaybePromise<void> {
@@ -2989,38 +3035,42 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		if (this.nativeBackboneDocumentIndexPrimary) {
 			if (!this.snapshotFile) {
 				this.deleteNativeBackboneDocumentKeysNoReturn(deleteKeys);
-				return;
+				return this.trackMutation(undefined);
 			}
 			if (!this.hasNativeBackboneDocumentKeys(deleteKeys)) {
 				return;
 			}
-			return this.enqueueMutation(async () => {
-				await this.appendDeletes(deleteKeys);
-				this.deleteNativeBackboneDocumentKeysNoReturn(deleteKeys);
-				await this.compactIfNeeded();
-			});
+			return this.trackMutation(
+				this.enqueueMutation(async () => {
+					await this.appendDeletes(deleteKeys);
+					this.deleteNativeBackboneDocumentKeysNoReturn(deleteKeys);
+					await this.compactIfNeeded();
+				}),
+			);
 		}
 		const native = this.getNative();
 		if (!this.snapshotFile && native.delete_keys_void) {
 			native.delete_keys_void(deleteKeys);
 			this.deleteNativeBackboneDocumentKeys(deleteKeys);
-			return;
+			return this.trackMutation(undefined);
 		}
 		if (!this.snapshotFile) {
 			native.delete_keys(deleteKeys);
 			this.deleteNativeBackboneDocumentKeys(deleteKeys);
-			return;
+			return this.trackMutation(undefined);
 		}
-		return this.enqueueMutation(async () => {
-			await this.appendDeletes(deleteKeys);
-			if (native.delete_keys_void) {
-				native.delete_keys_void(deleteKeys);
-			} else {
-				native.delete_keys(deleteKeys);
-			}
-			this.deleteNativeBackboneDocumentKeys(deleteKeys);
-			await this.compactIfNeeded();
-		});
+		return this.trackMutation(
+			this.enqueueMutation(async () => {
+				await this.appendDeletes(deleteKeys);
+				if (native.delete_keys_void) {
+					native.delete_keys_void(deleteKeys);
+				} else {
+					native.delete_keys(deleteKeys);
+				}
+				this.deleteNativeBackboneDocumentKeys(deleteKeys);
+				await this.compactIfNeeded();
+			}),
+		);
 	}
 
 	delIdsCount(deleteIds: Array<types.IdKey | types.Ideable>): MaybePromise<number> {
@@ -3036,22 +3086,25 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 		if (!this.snapshotFile && native.delete_keys_count) {
 			const deleted = native.delete_keys_count(deleteKeys);
 			this.deleteNativeBackboneDocumentKeys(deleteKeys);
-			return deleted;
+			return this.trackMutationIf(deleted, (count) => count > 0);
 		}
 		if (!this.snapshotFile) {
 			const deleted = native.delete_keys(deleteKeys);
 			this.deleteNativeBackboneDocumentKeys(deleteKeys);
-			return deleted.length;
+			return this.trackMutationIf(deleted.length, (count) => count > 0);
 		}
-		return this.enqueueMutation(async () => {
-			await this.appendDeletes(deleteKeys);
-			const deleted = native.delete_keys_count
-				? native.delete_keys_count(deleteKeys)
-				: native.delete_keys(deleteKeys).length;
-			this.deleteNativeBackboneDocumentKeys(deleteKeys);
-			await this.compactIfNeeded();
-			return deleted;
-		});
+		return this.trackMutationIf(
+			this.enqueueMutation(async () => {
+				await this.appendDeletes(deleteKeys);
+				const deleted = native.delete_keys_count
+					? native.delete_keys_count(deleteKeys)
+					: native.delete_keys(deleteKeys).length;
+				this.deleteNativeBackboneDocumentKeys(deleteKeys);
+				await this.compactIfNeeded();
+				return deleted;
+			}),
+			(count) => count > 0,
+		);
 	}
 
 	async del(query: types.DeleteOptions): Promise<types.IdKey[]> {
@@ -3077,6 +3130,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 						encodeNativeQuerySpec(compiled.spec),
 					);
 				}
+				this.mutationVersion++;
 			}
 			return deletedEntries.map((entry) => entry.id);
 		}
@@ -3101,6 +3155,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 					);
 				}
 				await this.compactIfNeeded();
+				this.mutationVersion++;
 			}
 			return deletedEntries.map((entry) => entry.id);
 		});
@@ -3242,9 +3297,26 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				: cloneResults(batch, this.properties.schema)) as types.IndexedResults<
 				types.ReturnTypeFromShape<T, S>
 			>;
+		let mutationMode = false;
+		let iteratorMutationVersion = this.mutationVersion;
+		const yielded = new Set<string>();
+		const idKey = (id: types.IdKey) => keyToStoreKey(id);
+		const markYielded = (
+			results: types.IndexedResults<types.ReturnTypeFromShape<T, S>>,
+		) => {
+			for (const result of results) {
+				yielded.add(idKey(result.id));
+			}
+		};
 
 		const fetch = async (
 			n: number,
+			options?: {
+				offset?: number;
+				advance?: boolean;
+				ignoreDone?: boolean;
+				liveLimit?: boolean;
+			},
 		): Promise<types.IndexedResults<types.ReturnTypeFromShape<T, S>>> => {
 			const closeAsDone = () => {
 				done = true;
@@ -3254,14 +3326,18 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				return closeAsDone();
 			}
 			this.assertOpen();
-			if (done) {
+			if (done && !options?.ignoreDone) {
 				return [];
 			}
-			const remaining = getTotal() - offset;
-			const wanted = Math.max(
+			const pageOffset = options?.offset ?? offset;
+			const requested = Math.max(
 				0,
-				Math.min(Number.isFinite(n) ? Math.floor(n) : remaining, remaining),
+				Number.isFinite(n) ? Math.floor(n) : getTotal(),
 			);
+			const remaining = options?.liveLimit
+				? requested
+				: Math.max(0, getTotal() - pageOffset);
+			const wanted = Math.max(0, Math.min(requested, remaining));
 			if (wanted === 0) {
 				done = remaining === 0;
 				return [];
@@ -3269,17 +3345,104 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			const batch = this.getNativeCandidatesForPlan({
 				compiled: nativePagePlan.compiled,
 				sort: nativePagePlan.sort,
-				offset,
+				offset: pageOffset,
 				limit: wanted,
 			});
-			offset += batch.length;
-			done = offset >= getTotal();
+			if (options?.advance !== false) {
+				offset += batch.length;
+				done = offset >= getTotal();
+			}
 			return clonePage(batch);
+		};
+		const next = async (
+			n: number,
+		): Promise<types.IndexedResults<types.ReturnTypeFromShape<T, S>>> => {
+			if (n <= 0) {
+				return [] as types.IndexedResults<types.ReturnTypeFromShape<T, S>>;
+			}
+			if (!mutationMode && this.mutationVersion === iteratorMutationVersion) {
+				const results = await fetch(n);
+				markYielded(results);
+				return results;
+			}
+
+			mutationMode = true;
+			iteratorMutationVersion = this.mutationVersion;
+			const results: types.IndexedResults<types.ReturnTypeFromShape<T, S>> =
+				[];
+			const pageSize = Number.isFinite(n) ? Math.max(Math.floor(n), 128) : 1024;
+			let scanOffset = 0;
+			let exhausted = false;
+			let hasAdditionalUnseen = false;
+			while (results.length < n) {
+				const page = await fetch(pageSize, {
+					offset: scanOffset,
+					advance: false,
+					ignoreDone: true,
+					liveLimit: true,
+				});
+				scanOffset += page.length;
+				if (page.length < pageSize) {
+					exhausted = true;
+				}
+				for (const result of page) {
+					const key = idKey(result.id);
+					if (yielded.has(key)) {
+						continue;
+					}
+					if (results.length < n) {
+						yielded.add(key);
+						results.push(result);
+					} else {
+						hasAdditionalUnseen = true;
+					}
+				}
+				if (page.length === 0 || exhausted) {
+					break;
+				}
+			}
+			done = exhausted && !hasAdditionalUnseen;
+			return results;
+		};
+		const pendingUnseen = async () => {
+			let count = 0;
+			const pageSize = 128;
+			let scanOffset = 0;
+			while (true) {
+				const page = await fetch(pageSize, {
+					offset: scanOffset,
+					advance: false,
+					ignoreDone: true,
+					liveLimit: true,
+				});
+				scanOffset += page.length;
+				for (const result of page) {
+					if (!yielded.has(idKey(result.id))) {
+						count++;
+					}
+				}
+				if (page.length < pageSize) {
+					break;
+				}
+			}
+			done = count === 0;
+			return count;
 		};
 
 		return {
-			all: async () => fetch(Infinity),
-			next: (n: number) => fetch(n),
+			all: async () => {
+				const results: types.IndexedResults<types.ReturnTypeFromShape<T, S>> =
+					[];
+				while (true) {
+					const batch = await next(1024);
+					results.push(...batch);
+					if (batch.length === 0 || done === true) {
+						break;
+					}
+				}
+				return results;
+			},
+			next,
 			done: () => (this.isClosing() ? true : done),
 			pending: async () => {
 				if (this.isClosing()) {
@@ -3287,6 +3450,11 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 					return 0;
 				}
 				this.assertOpen();
+				if (mutationMode || this.mutationVersion !== iteratorMutationVersion) {
+					mutationMode = true;
+					iteratorMutationVersion = this.mutationVersion;
+					return pendingUnseen();
+				}
 				return done ? 0 : Math.max(0, getTotal() - offset);
 			},
 			close: () => {
@@ -4658,7 +4826,8 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			return;
 		}
 		this.assertOpen();
-		return this.putWithEncodedValuePartsStored(id, encodedValueParts);
+		const result = this.putWithEncodedValuePartsStored(id, encodedValueParts);
+		return result === false ? false : this.trackMutation(result);
 	}
 
 	persistStoredContextualEncodedValue(
@@ -4683,7 +4852,12 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			return Promise.resolve(true);
 		}
 		this.assertOpen();
-		return this.putWithEncodedValuePartsStoredBatch(values);
+		return this.putWithEncodedValuePartsStoredBatch(values).then((stored) => {
+			if (stored) {
+				this.mutationVersion++;
+			}
+			return stored;
+		});
 	}
 
 	private async putWithEncodedValuePartsStoredBatch(
@@ -4867,6 +5041,35 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 			throw new Error("Index has not been initialized");
 		}
 		return this.native;
+	}
+
+	private trackMutation<R>(result: MaybePromise<R>): MaybePromise<R> {
+		if (isPromiseLike(result)) {
+			return result.then((value) => {
+				this.mutationVersion++;
+				return value;
+			});
+		}
+		this.mutationVersion++;
+		return result;
+	}
+
+	private trackMutationIf<R>(
+		result: MaybePromise<R>,
+		didMutate: (value: R) => boolean,
+	): MaybePromise<R> {
+		if (isPromiseLike(result)) {
+			return result.then((value) => {
+				if (didMutate(value)) {
+					this.mutationVersion++;
+				}
+				return value;
+			});
+		}
+		if (didMutate(result)) {
+			this.mutationVersion++;
+		}
+		return result;
 	}
 
 	private enqueueMutation<R>(work: () => Promise<R>): Promise<R> {

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -4545,6 +4545,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				suffixes,
 				this.nativeByteElementIndexLimit,
 			);
+			this.markMutationVisible();
 			return true;
 		} catch {
 			return false;

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -3346,6 +3346,12 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				yielded.add(idKey(result.id));
 			}
 		};
+		const markYieldedIds = (ids: Iterable<types.IdKey>) => {
+			for (const id of ids) {
+				yielded.add(idKey(id));
+			}
+			mutationMode = true;
+		};
 
 		const fetch = async (
 			n: number,
@@ -3487,6 +3493,7 @@ export class RustIndex<T extends Record<string, any>, NestedType = any>
 				return results;
 			},
 			next,
+			markYielded: markYieldedIds,
 			done: () => (explicitlyClosed || this.isClosing() ? true : done),
 			pending: async () => {
 				if (explicitlyClosed) {

--- a/packages/utils/indexer/rust/src/lib.rs
+++ b/packages/utils/indexer/rust/src/lib.rs
@@ -656,6 +656,7 @@ impl NativeRustIndex {
             return Err(js_error("Mismatched shared-log coordinate batch lengths"));
         }
 
+        let mut prepared = Vec::with_capacity(len as usize);
         for index in 0..len {
             let key = required_array_string(&keys, index, "shared-log coordinate key")?;
             let fields = shared_log_coordinate_fields(SharedLogCoordinateFieldsInput {
@@ -694,13 +695,21 @@ impl NativeRustIndex {
                 .iter()
                 .filter_map(|key| key.as_string())
                 .collect();
+            prepared.push((
+                key,
+                ids.get(index),
+                values.get(index),
+                fields,
+                keys_to_delete,
+            ));
+        }
 
-            self.store
-                .put(key.clone(), ids.get(index), values.get(index));
+        for (key, id, value, fields, keys_to_delete) in prepared {
+            self.store.put(key.clone(), id, value);
             self.planner.index.put(key, fields);
-            for key in &keys_to_delete {
-                self.planner.index.delete(key);
-                self.store.delete(key);
+            for key in keys_to_delete {
+                self.planner.index.delete(&key);
+                self.store.delete(&key);
             }
         }
         Ok(())

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -1414,6 +1414,97 @@ describe("native planner bridge", () => {
 		await indices.drop();
 	});
 
+	it("keeps a persisted stored batch visible after trailing compaction rejects", async () => {
+		const directory = createPersistenceDirectory();
+		const indices = create(directory);
+		try {
+			await indices.start();
+			const index = await indices.init({ schema: BridgeDocumentWithContext });
+			const contextualIndex = index as typeof index & {
+				putStoredContextualEncodedValueBatch: (
+					values: Array<{
+						id: ReturnType<typeof toId>;
+						encodedValueParts: {
+							prefix: Uint8Array;
+							suffix: Uint8Array;
+						};
+					}>,
+				) => Promise<boolean>;
+			};
+			await index.put(
+				new BridgeDocumentWithContext(
+					new BridgeDocument("b", "peerbit", "second"),
+					new BridgeContext("head-b"),
+				),
+			);
+			await index.put(
+				new BridgeDocumentWithContext(
+					new BridgeDocument("d", "peerbit", "fourth"),
+					new BridgeContext("head-d"),
+				),
+			);
+
+			const iterator = index.iterate({
+				sort: [new Sort({ key: "id", direction: SortDirection.ASC })],
+			});
+			const first = (await iterator.next(1)).map((result) => result.value.id);
+			expect(first).to.deep.equal(["b"]);
+
+			const internal = index as unknown as {
+				compactIfNeeded: () => Promise<void>;
+				mutationVersion: number;
+			};
+			const compactIfNeeded = internal.compactIfNeeded.bind(index);
+			const versionBeforeBatch = internal.mutationVersion;
+			internal.compactIfNeeded = async () => {
+				throw new Error("forced trailing batch compaction failure");
+			};
+			let rejected = false;
+			try {
+				await contextualIndex.putStoredContextualEncodedValueBatch([
+					{
+						id: toId("a"),
+						encodedValueParts: {
+							prefix: serialize(
+								new BridgeDocument("a", "peerbit", "first"),
+							),
+							suffix: serialize(new BridgeContext("head-a")),
+						},
+					},
+					{
+						id: toId("c"),
+						encodedValueParts: {
+							prefix: serialize(
+								new BridgeDocument("c", "peerbit", "third"),
+							),
+							suffix: serialize(new BridgeContext("head-c")),
+						},
+					},
+				]);
+				expect.fail("stored batch should reject after the native mutation");
+			} catch (error) {
+				rejected = true;
+				expect((error as Error).message).to.equal(
+					"forced trailing batch compaction failure",
+				);
+			} finally {
+				internal.compactIfNeeded = compactIfNeeded;
+			}
+			expect(rejected).to.be.true;
+			expect(internal.mutationVersion).to.be.greaterThan(versionBeforeBatch);
+
+			const remaining = (await iterator.all()).map(
+				(result) => result.value.id,
+			);
+			expect(remaining).to.deep.equal(["a", "c", "d"]);
+			expect(new Set([...first, ...remaining]).size).to.equal(4);
+			iterator.close();
+		} finally {
+			await indices.drop();
+			await removeNodeDirectoryIfNeeded(directory);
+		}
+	});
+
 	it("coalesces native-backbone exact deletes with result flags", async () => {
 		const directory = createPersistenceDirectory();
 		const indices = create(directory);

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -241,12 +241,12 @@ describe("all", () => {
 	tests(create, "persist", {
 		shapingSupported: false,
 		u64SumSupported: true,
-		iteratorsMutable: false,
+		iteratorsMutable: true,
 	});
 	tests(create, "transient", {
 		shapingSupported: false,
 		u64SumSupported: true,
-		iteratorsMutable: false,
+		iteratorsMutable: true,
 	});
 });
 
@@ -417,6 +417,34 @@ describe("native planner bridge", () => {
 		await indices.drop();
 	});
 
+	it("keeps a sorted iterator stable across a native put batch", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeDocument });
+		const batchIndex = index as typeof index & {
+			putBatch: (values: BridgeDocument[]) => Promise<void>;
+		};
+
+		await index.put(new BridgeDocument("a", "peerbit", "first"));
+		await index.put(new BridgeDocument("c", "peerbit", "third"));
+		const iterator = index.iterate({
+			sort: [new Sort({ key: "id", direction: SortDirection.ASC })],
+		});
+		expect(
+			(await iterator.next(1)).map((result) => result.value.id),
+		).to.deep.equal(["a"]);
+
+		await batchIndex.putBatch([
+			new BridgeDocument("b", "peerbit", "second"),
+			new BridgeDocument("d", "peerbit", "fourth"),
+		]);
+
+		expect(
+			(await iterator.all()).map((result) => result.value.id),
+		).to.deep.equal(["b", "c", "d"]);
+		await indices.drop();
+	});
+
 	it("coalesces a put and matching deletes through the native index", async () => {
 		const indices = create();
 		await indices.start();
@@ -491,6 +519,32 @@ describe("native planner bridge", () => {
 		const results = await index.iterate().all();
 		expect(results.map((result) => result.value.id)).to.deep.equal(["b"]);
 
+		await indices.drop();
+	});
+
+	it("does not skip after exact-id deletion of an already yielded row", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BridgeDocument });
+		const exactDeleteIndex = index as typeof index & {
+			delIds: (deleteIds: string[]) => Promise<ReturnType<typeof toId>[]>;
+		};
+
+		await index.put(new BridgeDocument("a", "stale", "first"));
+		await index.put(new BridgeDocument("b", "keep", "second"));
+		await index.put(new BridgeDocument("c", "keep", "third"));
+		const iterator = index.iterate({
+			sort: [new Sort({ key: "id", direction: SortDirection.ASC })],
+		});
+		expect(
+			(await iterator.next(1)).map((result) => result.value.id),
+		).to.deep.equal(["a"]);
+
+		await exactDeleteIndex.delIds(["a"]);
+
+		expect(
+			(await iterator.all()).map((result) => result.value.id),
+		).to.deep.equal(["b", "c"]);
 		await indices.drop();
 	});
 

--- a/packages/utils/indexer/rust/test/index.spec.ts
+++ b/packages/utils/indexer/rust/test/index.spec.ts
@@ -445,6 +445,72 @@ describe("native planner bridge", () => {
 		await indices.drop();
 	});
 
+	it("invalidates iterators after a visible put even when trailing compaction fails", async () => {
+		const directory = createPersistenceDirectory();
+		const indices = create(directory);
+		try {
+			await indices.start();
+			const index = await indices.init({ schema: BridgeDocument });
+			await index.put(new BridgeDocument("b", "peerbit", "second"));
+			await index.put(new BridgeDocument("c", "peerbit", "third"));
+			const internal = index as unknown as {
+				appendPut: (...args: unknown[]) => Promise<void>;
+				compactIfNeeded: () => Promise<void>;
+				mutationVersion: number;
+			};
+			const appendPut = internal.appendPut.bind(index);
+			const versionBeforeAppendFailure = internal.mutationVersion;
+			internal.appendPut = async () => {
+				throw new Error("forced pre-mutation append failure");
+			};
+			try {
+				await index.put(new BridgeDocument("z", "peerbit", "not visible"));
+				expect.fail("put should reject before the native mutation");
+			} catch (error) {
+				expect((error as Error).message).to.equal(
+					"forced pre-mutation append failure",
+				);
+			} finally {
+				internal.appendPut = appendPut;
+			}
+			expect(internal.mutationVersion).to.equal(versionBeforeAppendFailure);
+
+			const iterator = index.iterate({
+				sort: [new Sort({ key: "id", direction: SortDirection.ASC })],
+			});
+			expect(
+				(await iterator.next(1)).map((result) => result.value.id),
+			).to.deep.equal(["b"]);
+
+			const compactIfNeeded = internal.compactIfNeeded.bind(index);
+			internal.compactIfNeeded = async () => {
+				throw new Error("forced trailing compaction failure");
+			};
+			let rejected = false;
+			try {
+				await index.put(new BridgeDocument("a", "peerbit", "first"));
+			} catch (error) {
+				rejected = true;
+				expect((error as Error).message).to.equal(
+					"forced trailing compaction failure",
+				);
+			} finally {
+				internal.compactIfNeeded = compactIfNeeded;
+			}
+			expect(rejected).to.be.true;
+
+			expect(
+				(await iterator.next(1)).map((result) => result.value.id),
+			).to.deep.equal(["a"]);
+			expect(
+				(await iterator.all()).map((result) => result.value.id),
+			).to.deep.equal(["c"]);
+		} finally {
+			await indices.drop();
+			await removeNodeDirectoryIfNeeded(directory);
+		}
+	});
+
 	it("coalesces a put and matching deletes through the native index", async () => {
 		const indices = create();
 		await indices.start();

--- a/packages/utils/indexer/sqlite3/src/engine.ts
+++ b/packages/utils/indexer/sqlite3/src/engine.ts
@@ -763,6 +763,13 @@ export class SQLiteIndex<T extends Record<string, any>>
 		let kept: number | undefined = undefined;
 		let bindable: any[] = [];
 		let sqlFetch: string | undefined = undefined;
+		const markYieldedIds = (ids: Iterable<types.IdKey>) => {
+			for (const id of ids) {
+				yielded.add(idKey(id));
+			}
+			mutationMode = true;
+			kept = undefined;
+		};
 
 		const normalizedQuery = new PlannableQuery({
 			query: coerceLocalQueries(request?.query),
@@ -1081,6 +1088,7 @@ export class SQLiteIndex<T extends Record<string, any>>
 				this.clearupIterator(requestId);
 			},
 			next,
+			markYielded: markYieldedIds,
 			pending: async () => {
 				if (explicitlyClosed) {
 					return 0;

--- a/packages/utils/indexer/sqlite3/src/engine.ts
+++ b/packages/utils/indexer/sqlite3/src/engine.ts
@@ -173,6 +173,7 @@ export class SQLiteIndex<T extends Record<string, any>>
 	closed: boolean = true;
 	private state: "closed" | "open" | "closing" = "closed";
 	private fkMode: FKMode;
+	private mutationVersion = 0;
 
 	id: string;
 	constructor(
@@ -629,7 +630,7 @@ export class SQLiteIndex<T extends Record<string, any>>
 	): Promise<void> {
 		return this.withWriteIfOpen(undefined, async () => {
 			const classOfValue = value.constructor as Constructor<T>;
-			return insert(
+			await insert(
 				async (values, table) => {
 					let preId = values[table.primaryIndex];
 					let statement: Statement | undefined = undefined;
@@ -719,6 +720,7 @@ export class SQLiteIndex<T extends Record<string, any>>
 					},
 				},
 			);
+			this.mutationVersion++;
 		});
 	}
 
@@ -742,6 +744,18 @@ export class SQLiteIndex<T extends Record<string, any>>
 		let once = false;
 		let requestId = uuid();
 		let hasMore = true;
+		let mutationMode = false;
+		let iteratorMutationVersion = this.mutationVersion;
+		const yielded = new Set<string>();
+		const idKey = (id: types.IdKey) =>
+			`${typeof id.key}:${String(id.primitive)}`;
+		const markYielded = (
+			results: IndexedResult<types.ReturnTypeFromShape<T, S>>[],
+		) => {
+			for (const result of results) {
+				yielded.add(idKey(result.id));
+			}
+		};
 
 		let stmt: Statement;
 		let kept: number | undefined = undefined;
@@ -755,7 +769,10 @@ export class SQLiteIndex<T extends Record<string, any>>
 		let planningScope: ReturnType<QueryPlanner["scope"]>;
 
 		/* let totalCount: undefined | number = undefined; */
-		const fetch = async (amount: number | "all") => {
+		const fetch = async (
+			amount: number,
+			pageOptions?: { offset?: number; advance?: boolean },
+		) => {
 			const closeAsDone = () => {
 				once = true;
 				hasMore = false;
@@ -778,7 +795,7 @@ export class SQLiteIndex<T extends Record<string, any>>
 						{
 							planner: planningScope,
 							shape: options?.shape,
-							fetchAll: amount === "all", // if we are to fetch all, we dont need stable sorting
+							fetchAll: false,
 						},
 					);
 
@@ -798,7 +815,8 @@ export class SQLiteIndex<T extends Record<string, any>>
 				const allResults = await planningScope.perform(async () => {
 					const allResults: Record<string, any>[] = await stmt.all([
 						...bindable,
-						...(amount !== "all" ? [amount, offset] : []),
+						amount,
+						pageOptions?.offset ?? offset,
 					]);
 					return allResults;
 				});
@@ -844,14 +862,16 @@ export class SQLiteIndex<T extends Record<string, any>>
 						}),
 					);
 
-				offset += results.length;
+				if (pageOptions?.advance !== false) {
+					offset += results.length;
+				}
 
 				/* const uniqueIds = new Set(results.map((x) => x.id.primitive));
 				if (uniqueIds.size !== results.length) {
 					throw new Error("Duplicate ids in result set");
 				} */
 
-				if (amount === "all" || results.length < amount) {
+				if (results.length < amount) {
 					hasMore = false;
 					await this.clearupIterator(requestId);
 				}
@@ -873,13 +893,172 @@ export class SQLiteIndex<T extends Record<string, any>>
 		this.cursor.set(requestId, iterator);
 		let totalCount: number | undefined = undefined;
 		/* 			return fetch(request.fetch); */
+		const fetchAllFresh = async () => {
+			const closeAsDone = () => {
+				once = true;
+				hasMore = false;
+				kept = 0;
+				return [] as IndexedResult<types.ReturnTypeFromShape<T, S>>[];
+			};
+			if (this.isClosing()) {
+				return closeAsDone();
+			}
+			this.assertOpen();
+			try {
+				planningScope = this.planner.scope(normalizedQuery);
+				let { sql, bindable: toBind } = convertSearchRequestToQuery(
+					normalizedQuery,
+					this.tables,
+					this._rootTables,
+					{
+						planner: planningScope,
+						shape: options?.shape,
+						fetchAll: true,
+					},
+				);
+				await planningScope.beforePrepare();
+				const stmt = await this.properties.db.prepare(sql, sql);
+				iterator.expire = Date.now() + this.iteratorTimeout;
+				const allResults: Record<string, any>[] = await planningScope.perform(
+					async () => stmt.all(toBind),
+				);
+				const results: IndexedResult<types.ReturnTypeFromShape<T, S>>[] =
+					await Promise.all(
+						allResults.map(async (row: any) => {
+							let selectedTable = this._rootTables.find(
+								(table) =>
+									row[getTablePrefixedField(table, this.primaryKeyString)] !=
+									null,
+							)!;
+
+							const value = await resolveInstanceFromValue<T, S>(
+								row,
+								this.tables,
+								selectedTable,
+								this.resolveDependencies.bind(this),
+								true,
+								options?.shape,
+							);
+
+							return {
+								value,
+								id: types.toId(
+									convertFromSQLType(
+										row[
+											getTablePrefixedField(
+												selectedTable,
+												this.primaryKeyString,
+											)
+										],
+										selectedTable.primaryField!.from!.type,
+									),
+								),
+							};
+						}),
+					);
+				once = true;
+				hasMore = false;
+				kept = 0;
+				offset += results.length;
+				await this.clearupIterator(requestId);
+				markYielded(results);
+				return results;
+			} catch (error) {
+				if (this.isClosing()) {
+					return closeAsDone();
+				}
+				throw error;
+			}
+		};
+		const next = async (
+			amount: number,
+		): Promise<IndexedResult<types.ReturnTypeFromShape<T, S>>[]> => {
+			if (amount <= 0) {
+				return [];
+			}
+			if (!mutationMode && this.mutationVersion === iteratorMutationVersion) {
+				const results = await fetch(amount);
+				markYielded(results);
+				return results;
+			}
+
+			mutationMode = true;
+			iteratorMutationVersion = this.mutationVersion;
+			kept = undefined;
+
+			const results: IndexedResult<types.ReturnTypeFromShape<T, S>>[] = [];
+			const pageSize = Number.isFinite(amount)
+				? Math.max(Math.floor(amount), 128)
+				: 1024;
+			let scanOffset = 0;
+			let exhausted = false;
+			let hasAdditionalUnseen = false;
+			while (results.length < amount) {
+				const page = await fetch(pageSize, {
+					offset: scanOffset,
+					advance: false,
+				});
+				scanOffset += page.length;
+				if (page.length < pageSize) {
+					exhausted = true;
+				}
+				for (const result of page) {
+					const key = idKey(result.id);
+					if (yielded.has(key)) {
+						continue;
+					}
+					if (results.length < amount) {
+						yielded.add(key);
+						results.push(result);
+					} else {
+						hasAdditionalUnseen = true;
+					}
+				}
+				if (page.length === 0 || exhausted) {
+					break;
+				}
+			}
+			hasMore = !exhausted || hasAdditionalUnseen;
+			return results;
+		};
+		const pendingUnseen = async () => {
+			let count = 0;
+			const pageSize = 128;
+			let scanOffset = 0;
+			while (true) {
+				const page = await fetch(pageSize, {
+					offset: scanOffset,
+					advance: false,
+				});
+				scanOffset += page.length;
+				for (const result of page) {
+					if (!yielded.has(idKey(result.id))) {
+						count++;
+					}
+				}
+				if (page.length < pageSize) {
+					break;
+				}
+			}
+			hasMore = count > 0;
+			kept = count;
+			return count;
+		};
 		return {
 			all: async () => {
+				if (
+					!once &&
+					offset === 0 &&
+					!mutationMode &&
+					this.mutationVersion === iteratorMutationVersion
+				) {
+					return fetchAllFresh();
+				}
 				const results: IndexedResult<types.ReturnTypeFromShape<T, S>>[] = [];
 				while (true) {
-					const res = await fetch("all");
+					const res = await next(1024);
 					results.push(...res);
-					if (hasMore === false) {
+					if (res.length === 0 || hasMore === false) {
 						break;
 					}
 				}
@@ -891,7 +1070,7 @@ export class SQLiteIndex<T extends Record<string, any>>
 				kept = 0;
 				this.clearupIterator(requestId);
 			},
-			next: (amount: number) => fetch(amount),
+			next,
 			pending: async () => {
 				if (this.isClosing()) {
 					once = true;
@@ -902,6 +1081,11 @@ export class SQLiteIndex<T extends Record<string, any>>
 				this.assertOpen();
 				if (!hasMore) {
 					return 0;
+				}
+				if (mutationMode || this.mutationVersion !== iteratorMutationVersion) {
+					mutationMode = true;
+					iteratorMutationVersion = this.mutationVersion;
+					return pendingUnseen();
 				}
 				if (kept != null) {
 					return kept;
@@ -995,6 +1179,10 @@ export class SQLiteIndex<T extends Record<string, any>>
 
 			if (!once) {
 				throw lastError!;
+			}
+
+			if (ret.length > 0) {
+				this.mutationVersion++;
 			}
 
 			return ret;

--- a/packages/utils/indexer/sqlite3/src/engine.ts
+++ b/packages/utils/indexer/sqlite3/src/engine.ts
@@ -741,7 +741,9 @@ export class SQLiteIndex<T extends Record<string, any>>
 		const countStmt = await this.properties.db.prepare(sqlTotalCount); */
 
 		let offset = 0;
-		let once = false;
+		let started = false;
+		let pagedInitialized = false;
+		let explicitlyClosed = false;
 		let requestId = uuid();
 		let hasMore = true;
 		let mutationMode = false;
@@ -774,7 +776,7 @@ export class SQLiteIndex<T extends Record<string, any>>
 			pageOptions?: { offset?: number; advance?: boolean },
 		) => {
 			const closeAsDone = () => {
-				once = true;
+				started = true;
 				hasMore = false;
 				kept = 0;
 				return [] as IndexedResult<types.ReturnTypeFromShape<T, S>>[];
@@ -785,7 +787,7 @@ export class SQLiteIndex<T extends Record<string, any>>
 			this.assertOpen();
 			try {
 				kept = undefined;
-				if (!once) {
+				if (!pagedInitialized) {
 					planningScope = this.planner.scope(normalizedQuery);
 
 					let { sql, bindable: toBind } = convertSearchRequestToQuery(
@@ -808,9 +810,10 @@ export class SQLiteIndex<T extends Record<string, any>>
 
 					// Bump timeout timer
 					iterator.expire = Date.now() + this.iteratorTimeout;
+					pagedInitialized = true;
 				}
 
-				once = true;
+				started = true;
 
 				const allResults = await planningScope.perform(async () => {
 					const allResults: Record<string, any>[] = await stmt.all([
@@ -895,7 +898,7 @@ export class SQLiteIndex<T extends Record<string, any>>
 		/* 			return fetch(request.fetch); */
 		const fetchAllFresh = async () => {
 			const closeAsDone = () => {
-				once = true;
+				started = true;
 				hasMore = false;
 				kept = 0;
 				return [] as IndexedResult<types.ReturnTypeFromShape<T, S>>[];
@@ -905,22 +908,22 @@ export class SQLiteIndex<T extends Record<string, any>>
 			}
 			this.assertOpen();
 			try {
-				planningScope = this.planner.scope(normalizedQuery);
+				const freshPlanningScope = this.planner.scope(normalizedQuery);
 				let { sql, bindable: toBind } = convertSearchRequestToQuery(
 					normalizedQuery,
 					this.tables,
 					this._rootTables,
 					{
-						planner: planningScope,
+						planner: freshPlanningScope,
 						shape: options?.shape,
 						fetchAll: true,
 					},
 				);
-				await planningScope.beforePrepare();
-				const stmt = await this.properties.db.prepare(sql, sql);
+				await freshPlanningScope.beforePrepare();
+				const freshStatement = await this.properties.db.prepare(sql, sql);
 				iterator.expire = Date.now() + this.iteratorTimeout;
-				const allResults: Record<string, any>[] = await planningScope.perform(
-					async () => stmt.all(toBind),
+				const allResults: Record<string, any>[] = await freshPlanningScope.perform(
+					async () => freshStatement.all(toBind),
 				);
 				const results: IndexedResult<types.ReturnTypeFromShape<T, S>>[] =
 					await Promise.all(
@@ -956,7 +959,7 @@ export class SQLiteIndex<T extends Record<string, any>>
 							};
 						}),
 					);
-				once = true;
+				started = true;
 				hasMore = false;
 				kept = 0;
 				offset += results.length;
@@ -973,6 +976,9 @@ export class SQLiteIndex<T extends Record<string, any>>
 		const next = async (
 			amount: number,
 		): Promise<IndexedResult<types.ReturnTypeFromShape<T, S>>[]> => {
+			if (explicitlyClosed) {
+				return [];
+			}
 			if (amount <= 0) {
 				return [];
 			}
@@ -1046,8 +1052,11 @@ export class SQLiteIndex<T extends Record<string, any>>
 		};
 		return {
 			all: async () => {
+				if (explicitlyClosed) {
+					return [];
+				}
 				if (
-					!once &&
+					!started &&
 					offset === 0 &&
 					!mutationMode &&
 					this.mutationVersion === iteratorMutationVersion
@@ -1065,27 +1074,31 @@ export class SQLiteIndex<T extends Record<string, any>>
 				return results;
 			},
 			close: () => {
-				once = true;
+				explicitlyClosed = true;
+				started = true;
 				hasMore = false;
 				kept = 0;
 				this.clearupIterator(requestId);
 			},
 			next,
 			pending: async () => {
+				if (explicitlyClosed) {
+					return 0;
+				}
 				if (this.isClosing()) {
-					once = true;
+					started = true;
 					hasMore = false;
 					kept = 0;
 					return 0;
 				}
 				this.assertOpen();
-				if (!hasMore) {
-					return 0;
-				}
 				if (mutationMode || this.mutationVersion !== iteratorMutationVersion) {
 					mutationMode = true;
 					iteratorMutationVersion = this.mutationVersion;
 					return pendingUnseen();
+				}
+				if (!hasMore) {
+					return 0;
 				}
 				if (kept != null) {
 					return kept;
@@ -1097,10 +1110,10 @@ export class SQLiteIndex<T extends Record<string, any>>
 				return kept;
 			},
 			done: () => {
-				if (this.isClosing()) {
+				if (explicitlyClosed || this.isClosing()) {
 					return true;
 				}
-				return once ? !hasMore : undefined;
+				return started ? !hasMore : undefined;
 			},
 		};
 	}

--- a/packages/utils/indexer/tests/src/tests.ts
+++ b/packages/utils/indexer/tests/src/tests.ts
@@ -4048,6 +4048,118 @@ export const tests = (
 				expect(await iterator.pending()).to.eq(0);
 			});
 
+			it("all after partial next returns only remaining sorted results", async () => {
+				await put(0);
+				await put(1);
+				await put(2);
+
+				const iterator = store.iterate({
+					query: [],
+					sort: [new Sort({ direction: SortDirection.ASC, key: "name" })],
+				});
+
+				expect((await iterator.next(1)).map((x) => x.value.name)).to.deep.equal(
+					["0"],
+				);
+				expect((await iterator.all()).map((x) => x.value.name)).to.deep.equal([
+					"1",
+					"2",
+				]);
+				expect(iterator.done()).to.be.true;
+			});
+
+			it("deleting an already yielded sorted result does not skip the next result", async () => {
+				await put(0);
+				await put(1);
+				await put(2);
+
+				const iterator = store.iterate({
+					query: [],
+					sort: [new Sort({ direction: SortDirection.ASC, key: "name" })],
+				});
+
+				expect((await iterator.next(1)).map((x) => x.value.name)).to.deep.equal(
+					["0"],
+				);
+				await store.del({
+					query: new StringMatch({
+						key: "id",
+						value: "0",
+						method: StringMatchMethod.exact,
+						caseInsensitive: false,
+					}),
+				});
+
+				expect((await iterator.next(2)).map((x) => x.value.name)).to.deep.equal(
+					["1", "2"],
+				);
+				expect(iterator.done()).to.be.true;
+			});
+
+			it("inserting before an already yielded sorted result does not duplicate it", async () => {
+				await put(1);
+				await put(2);
+
+				const iterator = store.iterate({
+					query: [],
+					sort: [new Sort({ direction: SortDirection.ASC, key: "name" })],
+				});
+
+				expect((await iterator.next(1)).map((x) => x.value.name)).to.deep.equal(
+					["1"],
+				);
+				await put(0);
+
+				const rest = (await iterator.next(3)).map((x) => x.value.name);
+				expect(new Set(rest).size).to.equal(rest.length);
+				expect(rest).to.not.include("1");
+				expect(rest).to.include("2");
+			});
+
+			it("keeps a mutated iterator open while unseen sorted results remain", async () => {
+				await put(0);
+				await put(2);
+
+				const iterator = store.iterate({
+					query: [],
+					sort: [new Sort({ direction: SortDirection.ASC, key: "name" })],
+				});
+
+				expect((await iterator.next(1)).map((x) => x.value.name)).to.deep.equal(
+					["0"],
+				);
+				await put(1);
+
+				if (properties.iteratorsMutable) {
+					expect(
+						(await iterator.next(1)).map((x) => x.value.name),
+					).to.deep.equal(["1"]);
+					expect(iterator.done()).to.be.false;
+					expect(await iterator.pending()).to.equal(1);
+					expect(
+						(await iterator.next(1)).map((x) => x.value.name),
+					).to.deep.equal(["2"]);
+				} else {
+					expect(
+						(await iterator.next(1)).map((x) => x.value.name),
+					).to.deep.equal(["2"]);
+				}
+				expect(iterator.done()).to.be.true;
+			});
+
+			it("next Infinity sees inserts after an initially empty page", async () => {
+				const iterator = store.iterate({
+					query: [],
+					sort: [new Sort({ direction: SortDirection.ASC, key: "name" })],
+				});
+
+				expect(await iterator.next(1)).to.deep.equal([]);
+				await put(0);
+
+				const rest = (await iterator.next(Infinity)).map((x) => x.value.name);
+				expect(rest).to.deep.equal(properties.iteratorsMutable ? ["0"] : []);
+			});
+
 			describe("close", () => {
 				it("by invoking close()", async () => {
 					await put(0);

--- a/packages/utils/indexer/tests/src/tests.ts
+++ b/packages/utils/indexer/tests/src/tests.ts
@@ -4213,6 +4213,33 @@ export const tests = (
 				}
 			});
 
+			it("can mark live results delivered outside the iterator as yielded", async () => {
+				if (!properties.iteratorsMutable) {
+					return;
+				}
+
+				await put(0);
+				await put(1);
+				const iterator = store.iterate({
+					query: [],
+					sort: [new Sort({ direction: SortDirection.ASC, key: "name" })],
+				});
+
+				expect((await iterator.next(1)).map((x) => x.value.id)).to.deep.equal([
+					"0",
+				]);
+				await put(2);
+				expect(iterator.markYielded).to.be.a("function");
+				await iterator.markYielded!([toId("2")]);
+
+				expect(await iterator.pending()).to.equal(1);
+				expect((await iterator.next(2)).map((x) => x.value.id)).to.deep.equal([
+					"1",
+				]);
+				expect(await iterator.pending()).to.equal(0);
+				expect(iterator.done()).to.be.true;
+			});
+
 			it("tracks filtered updates without duplicates", async () => {
 				if (!properties.iteratorsMutable) {
 					return;

--- a/packages/utils/indexer/tests/src/tests.ts
+++ b/packages/utils/indexer/tests/src/tests.ts
@@ -4160,6 +4160,134 @@ export const tests = (
 				expect(rest).to.deep.equal(properties.iteratorsMutable ? ["0"] : []);
 			});
 
+			it("keeps an explicitly closed iterator terminal across mutations", async () => {
+				await put(0);
+				const iterator = store.iterate({
+					query: [],
+					sort: [new Sort({ direction: SortDirection.ASC, key: "name" })],
+				});
+
+				await iterator.close();
+				await put(1);
+
+				expect(await iterator.next(1)).to.deep.equal([]);
+				expect(await iterator.all()).to.deep.equal([]);
+				expect(await iterator.pending()).to.equal(0);
+				expect(iterator.done()).to.be.true;
+			});
+
+			it("can continue a mutable iterator after all and a later insert", async () => {
+				await put(0);
+				const iterator = store.iterate({
+					query: [],
+					sort: [new Sort({ direction: SortDirection.ASC, key: "name" })],
+				});
+
+				expect((await iterator.all()).map((x) => x.value.name)).to.deep.equal([
+					"0",
+				]);
+				await put(1);
+
+				expect((await iterator.next(1)).map((x) => x.value.name)).to.deep.equal(
+					properties.iteratorsMutable ? ["1"] : [],
+				);
+			});
+
+			it("refreshes pending after an exhausted mutable iterator mutates", async () => {
+				const iterator = store.iterate({
+					query: [],
+					sort: [new Sort({ direction: SortDirection.ASC, key: "name" })],
+				});
+
+				expect(await iterator.next(1)).to.deep.equal([]);
+				await put(0);
+
+				expect(await iterator.pending()).to.equal(
+					properties.iteratorsMutable ? 1 : 0,
+				);
+				if (properties.iteratorsMutable) {
+					expect(iterator.done()).to.be.false;
+					expect(
+						(await iterator.next(1)).map((x) => x.value.name),
+					).to.deep.equal(["0"]);
+				}
+			});
+
+			it("tracks filtered updates without duplicates", async () => {
+				if (!properties.iteratorsMutable) {
+					return;
+				}
+
+				await put(0, { name: "match" });
+				await put(1, { name: "miss" });
+				await put(2, { name: "match" });
+				const iterator = store.iterate({
+					query: new StringMatch({
+						key: "name",
+						value: "match",
+						method: StringMatchMethod.exact,
+						caseInsensitive: false,
+					}),
+					sort: [new Sort({ direction: SortDirection.ASC, key: "number" })],
+				});
+
+				expect((await iterator.next(1)).map((x) => x.value.id)).to.deep.equal([
+					"0",
+				]);
+				await put(1, { name: "match" });
+				await put(2, { name: "miss" });
+				await put(0, { name: "match" });
+				await put(3, { name: "match" });
+
+				expect((await iterator.all()).map((x) => x.value.id)).to.deep.equal([
+					"1",
+					"3",
+				]);
+			});
+
+			it("rescans beyond 128 yielded rows after a mutation", async () => {
+				if (!properties.iteratorsMutable) {
+					return;
+				}
+
+				for (let i = 0; i < 140; i++) {
+					await put(i);
+				}
+				const iterator = store.iterate({
+					query: [],
+					sort: [new Sort({ direction: SortDirection.ASC, key: "number" })],
+				});
+				expect(await iterator.next(130)).to.have.length(130);
+
+				await store.del({
+					query: new StringMatch({
+						key: "id",
+						value: "0",
+						method: StringMatchMethod.exact,
+						caseInsensitive: false,
+					}),
+				});
+				await put(200);
+
+				expect((await iterator.next(1)).map((x) => x.value.id)).to.deep.equal([
+					"130",
+				]);
+				const remaining = (await iterator.all()).map((x) => x.value.id);
+				expect(remaining).to.deep.equal([
+					"131",
+					"132",
+					"133",
+					"134",
+					"135",
+					"136",
+					"137",
+					"138",
+					"139",
+					"200",
+				]);
+				expect(new Set(remaining).size).to.equal(remaining.length);
+			});
+
 			describe("close", () => {
 				it("by invoking close()", async () => {
 					await put(0);


### PR DESCRIPTION
## Summary

- make Rust and SQLite paginated iterators rescan the current result set after inserts, updates, and deletes while suppressing IDs already yielded
- keep explicit close terminal, preserve all/exhausted iterator reuse, and advance Rust mutation epochs at the exact native visibility boundary
- let document live-update paths claim IDs delivered outside the raw cursor so pending counts and later pages cannot surface the same row twice
- forward claims through warm query-cache buffers, retain claims that arrive before cursor creation, and reconcile serving-peer cursors only after successful remote pushes
- validate native shared-log batches completely before their infallible mutation phase
- add patch changesets for document, indexer interface/cache, Rust, and SQLite packages

## Validation

- full workspace build: passing
- full document Node suite: 362 passing
- focused document overlap/race/push regressions: passing
- mutable iterator hook regressions: SQLite 2/2 and Rust 2/2; Rust cargo tests passing
- warm query-cache claim regression: passing
- full SQLite Node suite: exit 0; full Rust Node suite: 293 passing (earlier branch validation)
- changed SQLite and Rust iterator specs: passing in Chromium
- independent reviews covered terminal close, iterator reuse, mutation visibility, warm cache forwarding, pre-cursor claims, and remote push ownership

## Complexity

After a mutation, each later page rescans the current query in O(N) work and retains O(yielded IDs) memory. Consuming a large changing result set through many small pages can therefore approach O(N²). This tradeoff is documented in the changeset; keyset or snapshot-aware pagination remains a future optimization.

The repository-wide SQLite browser harness still fails before test execution because an existing statement test imports node:path/node:url; the changed iterator spec itself passes directly in Chromium.