### PR TITLE
fix(shared-log): park replicators with a zero storage budget

### DIFF
--- a/packages/programs/data/shared-log/src/pid.ts
+++ b/packages/programs/data/shared-log/src/pid.ts
@@ -56,19 +56,27 @@ export class PIDReplicationController {
 			// prunes from repeatedly settling just above the hard budget.
 			const effectiveMemoryLimit =
 				this.maxMemoryLimit > 0 ? this.maxMemoryLimit * 0.95 : 0;
-			errorMemory =
-				currentFactor > 0 && memoryUsage > 0
-					? Math.max(
-							Math.min(1, effectiveMemoryLimit / estimatedTotalSize),
-							0,
-						) - currentFactor
-					: 0;
+			if (effectiveMemoryLimit <= 0) {
+				// A zero storage budget can never hold data; drive the factor to zero
+				// instead of leaving the memory term neutral.
+				errorMemory = -currentFactor;
+			} else if (currentFactor > 0 && memoryUsage > 0) {
+				errorMemory =
+					Math.max(Math.min(1, effectiveMemoryLimit / estimatedTotalSize), 0) -
+					currentFactor;
+			} else {
+				errorMemory = 0;
+			}
 			// Math.max(Math.min((this.maxMemoryLimit - memoryUsage) / 100e5, 1), -1)// Math.min(Math.max((this.maxMemoryLimit - memoryUsage, 0) / 10e5, 0), 1);
 		}
 
 		const errorCoverageUnmodified = Math.min(1 - totalFactor, 1);
 		let errorCoverage =
-			(this.maxMemoryLimit ? 1 - Math.sqrt(Math.abs(errorMemory)) : 1) *
+			(this.maxMemoryLimit != null
+				? this.maxMemoryLimit > 0
+					? 1 - Math.sqrt(Math.abs(errorMemory))
+					: 0
+				: 1) *
 			errorCoverageUnmodified;
 
 		const errorFromEven = 1 / peerCount - currentFactor;
@@ -96,7 +104,7 @@ export class PIDReplicationController {
 			errorCoverage = Math.max(errorCoverage, 0);
 		}
 
-		const balanceErrorScaler = this.maxMemoryLimit
+		const balanceErrorScaler = this.maxMemoryLimit != null
 			? hasMemoryHeadroom
 				? Math.max(
 						Math.abs(errorMemory),
@@ -108,7 +116,7 @@ export class PIDReplicationController {
 		// Balance should be symmetric (allow negative error) so a peer can *reduce*
 		// participation when peerCount increases. Otherwise early joiners can get
 		// "stuck" over-replicating even after new peers join (no memory/CPU limits).
-		const errorBalance = this.maxMemoryLimit
+		const errorBalance = this.maxMemoryLimit != null
 			? // Only balance when we have spare memory headroom. When memory is
 				// constrained (`errorMemory < 0`) the memory term will dominate anyway.
 				errorMemory > 0

--- a/packages/programs/data/shared-log/test/pid.spec.ts
+++ b/packages/programs/data/shared-log/test/pid.spec.ts
@@ -208,5 +208,55 @@ describe("PIDReplicationController", () => {
 			expect(f).to.be.greaterThan(0.91);
 			expect(f).to.be.at.most(1);
 		});
+
+
+
+
+
+		it("keeps a zero-width peer stopped when storage budget is zero", () => {
+			const controller = new PIDReplicationController("", {
+				storage: { max: 0 },
+			});
+			const f = controller.step({
+				currentFactor: 0,
+				memoryUsage: 0,
+				totalFactor: 1,
+				peerCount: 2,
+				cpuUsage: undefined,
+			});
+
+			expect(f).to.equal(0);
+		});
+
+		it("allows coverage repair to restart an over-target zero-width peer", () => {
+			const controller = new PIDReplicationController("", {
+				storage: { max: 100_000 },
+			});
+			const f = controller.step({
+				currentFactor: 0,
+				memoryUsage: 200_000,
+				totalFactor: 0,
+				peerCount: 2,
+				cpuUsage: undefined,
+			});
+
+			expect(f).to.be.greaterThan(0);
+			expect(f).to.be.lessThan(0.5);
+		});
+
+		it("keeps a zero-budget peer stopped even when coverage is underfilled", () => {
+			const controller = new PIDReplicationController("", {
+				storage: { max: 0 },
+			});
+			const f = controller.step({
+				currentFactor: 0,
+				memoryUsage: 0,
+				totalFactor: 0,
+				peerCount: 2,
+				cpuUsage: undefined,
+			});
+
+			expect(f).to.equal(0);
+		});
 	});
 });


### PR DESCRIPTION
## Summary

The PID controller used truthiness checks on `maxMemoryLimit` in three places, so a replicator configured with `storage: { max: 0 }` was treated as if it had **no** memory limit: the acceleration term, the balance scaler, and the balance error all took the unlimited-peer branches, pushing the peer toward an even participation share it can never store.

This PR treats `maxMemoryLimit != null` as memory-limited in those three terms and drives the memory error to `-currentFactor` when the effective limit is zero, so zero-budget peers park at zero width — also while coverage is underfilled — instead of oscillating. Behavior for peers with positive limits and for peers without limits is unchanged (the modified branches are only reachable with `max: 0`).

Adds 3 unit tests (parking with full and empty coverage, over-target zero-width restart).

## Context

Extracted from the investigation of #952 and deliberately **descoped**: an earlier revision of this PR also reworked headroom/coverage coupling for memory-limited peers, but that shifted the participation equilibrium in `sharding distribution objectives memory evenly if limited when not constrained` (~0.57–0.62 vs the 0.45–0.55 bound, reproducible locally in both u32 and u64 variants while master holds 8/8 green). Those control-law changes need their own design pass; only the unambiguous zero-budget fix lands here.

## Testing (Node 22, clean worktree from master)

- `--grep "PIDReplicationController"` → 14 passing (11 existing + 3 new)
- `--grep "evenly if limited when not constrained"` → 4/4 repeat runs green (the previous full-scope revision failed 1 of 3)
- `--grep "^u32-simple sharding distribution objectives memory"` → 6 passing (2m)
