### PR TITLE
ci: make nightly sims wasm toolchain setup match CI

### DIFF
--- a/.github/workflows/nightly-sims.yml
+++ b/.github/workflows/nightly-sims.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       NODE_OPTIONS: --no-warnings
       PEERBIT_TEST_SESSION: mock
+      WASM_PACK_VERSION: 0.13.1
     steps:
       - uses: actions/checkout@v4
 
@@ -26,9 +27,17 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
+      - name: Cache wasm-pack
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/wasm-pack
+          key: ${{ runner.os }}-wasm-pack-${{ env.WASM_PACK_VERSION }}
+
       - name: Install deps
         run: |
-          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          export PATH="$HOME/.cargo/bin:$PATH"
+          ./scripts/ci/install-wasm-pack.sh
+          rustup target add wasm32-unknown-unknown
           pnpm install --frozen-lockfile=false
 
       - name: Build pubsub workspace
@@ -74,6 +83,7 @@ jobs:
     env:
       NODE_OPTIONS: --no-warnings
       PEERBIT_TEST_SESSION: mock
+      WASM_PACK_VERSION: 0.13.1
     steps:
       - uses: actions/checkout@v4
 
@@ -87,9 +97,17 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
+      - name: Cache wasm-pack
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/wasm-pack
+          key: ${{ runner.os }}-wasm-pack-${{ env.WASM_PACK_VERSION }}
+
       - name: Install deps
         run: |
-          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          export PATH="$HOME/.cargo/bin:$PATH"
+          ./scripts/ci/install-wasm-pack.sh
+          rustup target add wasm32-unknown-unknown
           pnpm install --frozen-lockfile=false
 
       - name: Build test-utils workspace


### PR DESCRIPTION
## Summary

Both nightly-sims jobs have been red since at least June 9 **without running any tests**: the build step fails with `Error: Adding the wasm32-unknown-unknown target with rustup` (see e.g. the SharedLog chaos jobs of runs 27261558199 and 27333666403). The jobs installed wasm-pack via the upstream curl installer and relied on wasm-pack implicitly adding the wasm32 target, which broke on recent runner images.

This switches both jobs to the exact setup the (green) CI workflow uses: the pinned `scripts/ci/install-wasm-pack.sh`, an explicit `rustup target add wasm32-unknown-unknown`, and the wasm-pack binary cache.

Note: the PubSub sims job has a second, independent issue — `fanout-tree-sim` makes progress (~1500/4800 joins) but exceeds its 20-minute `--timeoutMs`; that is a real performance signal, not infra, and is unaffected by this change.

## Testing

- `yaml` parses; steps are copied verbatim from the working `ci.yml` pattern.
- A manual `workflow_dispatch` after merge will verify the chaos job reaches its test phase again.