### PR TITLE
fix(indexer-sqlite3): settle colliding index-creation scopes

### DIFF
--- a/packages/utils/indexer/sqlite3/src/query-planner.ts
+++ b/packages/utils/indexer/sqlite3/src/query-planner.ts
@@ -251,9 +251,21 @@ export class QueryPlanner {
 				if (indexCreateCommands != null) {
 					const commandsToCreate: typeof indexCreateCommands = [];
 					for (const command of indexCreateCommands) {
-						if (this.pendingIndexCreation.has(command.key)) {
-							// TODO is this kind of debouncing needed? how do we end up here?
-							await this.pendingIndexCreation.get(command.key);
+						const pending = this.pendingIndexCreation.get(command.key);
+						if (pending) {
+							// Another plan key with the same column set is already creating
+							// this index ("create index if not exists ..."). Settle THIS
+							// scope's deferred from the in-flight creation: leaving it
+							// pending keeps created() === false for the lifetime of the
+							// process and every later query for this plan key awaits a
+							// promise nobody will ever resolve.
+							try {
+								await pending;
+								command.deferred.resolve();
+							} catch (error) {
+								command.deferred.reject(error);
+								throw error;
+							}
 							continue;
 						}
 						commandsToCreate.push(command);
@@ -323,9 +335,16 @@ export class QueryPlanner {
 						});
 
 						let created = false;
-						deferred.promise.then(() => {
-							created = true;
-						});
+						deferred.promise.then(
+							() => {
+								created = true;
+							},
+							() => {
+								// Rejections are observed by the scopes awaiting this
+								// creation; without this handler a rejected creation turns
+								// into an unhandled rejection through this side channel.
+							},
+						);
 						indexStats.results.push({
 							used: 0,
 							times: [],

--- a/packages/utils/indexer/sqlite3/test/query-planner.spec.ts
+++ b/packages/utils/indexer/sqlite3/test/query-planner.spec.ts
@@ -16,6 +16,67 @@ import {
 	flattenQuery,
 } from "../src/query-planner.js";
 
+describe("QueryPlanner", () => {
+	it("settles scopes whose index creation collides across plan keys", async () => {
+		// Two plan keys (values nullified to different anchors) that share one
+		// index key (same table + columns). The scope that loses the creation
+		// race must still settle its own deferred, otherwise every later query
+		// for its plan key awaits a promise nobody resolves (#967).
+		let releaseExec: () => void = () => {};
+		const execGate = new Promise<void>((resolve) => {
+			releaseExec = resolve;
+		});
+		let execCalls = 0;
+		const planner = new QueryPlanner({
+			exec: async () => {
+				execCalls += 1;
+				await execGate;
+			},
+		});
+		const table = "t";
+		const columns = ["key"];
+		const plannable = (value: bigint) =>
+			new PlannableQuery({
+				query: [
+					new IntegerCompare({
+						compare: Compare.Greater,
+						key: "key",
+						value,
+					}),
+				],
+			});
+		const low = plannable(1n);
+		const high = plannable((1n << 63n) + 2n);
+		expect(low.key).to.not.eq(high.key);
+
+		const scope1 = planner.scope(low);
+		scope1.resolveIndex(table, columns);
+		const first = scope1.beforePrepare();
+
+		const scope2 = planner.scope(high);
+		scope2.resolveIndex(table, columns);
+		const second = scope2.beforePrepare();
+
+		releaseExec();
+		await first;
+
+		const timeout = (label: string) =>
+			delay(2000).then(() => {
+				throw new Error(label + " never settled");
+			});
+		await Promise.race([second, timeout("colliding scope")]);
+
+		// a fresh scope for the previously-collided plan key must settle too
+		const scope3 = planner.scope(high);
+		scope3.resolveIndex(table, columns);
+		await Promise.race([
+			scope3.beforePrepare(),
+			timeout("fresh scope for collided plan key"),
+		]);
+		expect(execCalls).to.eq(1);
+	});
+});
+
 describe("PlannableQuery", () => {
 	describe("IntegerCompare", () => {
 		it("key same for small change", async () => {


### PR DESCRIPTION
## Summary

Fixes a silent, permanent, per-process hang in the SQLite query planner that is the root cause of #967 (shared-log entries left under-replicated after churn in the u64 domain).

When two query-plan keys with the same column set race their **first** execution, the losing scope's `beforePrepare` hits the `pendingIndexCreation` collision branch and returns without ever settling its own deferred. That index candidate then stays `created() === false` for the lifetime of the process, and **every later query for that plan key awaits the orphaned promise forever** — a pending await, no rejection, zero CPU, event loop healthy.

In the u64 domain the colliding pair exists by construction: `reduceResolution` nullifies values to `0` or `HALF_MAX`, so the same structural query (e.g. the `getClosest` walk in shared-log's `getSamples`) produces **two plan keys sharing one index key**. Whichever peer loses the startup race on a slow runner wedges; its `_findLeaders` never resolves for affected coordinates, so it drops every entry delivered to it as "not leader" while re-requesting the same entries forever.

The fix settles the colliding command's deferred from the in-flight creation (`create index if not exists` makes the other scope's success equivalent), propagates failures, and observes deferred rejections in the `created()` side channel so they cannot become unhandled rejections.

## Evidence trail (#967)

- 13 instrumented CI rounds on the chaos seed branch narrowed the failure: no prunes ever fire → the starved peer requests the missing hashes every retry window and the holder responds → the starved peer drops the arriving entries as "not leader" thousands of times → its composed `_findLeaders` never resolves (5 s/8 s probes) while **every dependency answers in 0–4 ms** (the probes bypass the planner; the wedged path goes through it).
- Static + dynamic analysis isolated the orphaned-deferred branch; a scripted repro against the shipped dist showed the poisoned plan key timing out minutes later while healthy keys resolve, and resolving with this one-branch fix.

## Testing

- New red-green regression test (`query-planner.spec.ts`): two plan keys with a shared index key and a gated `exec` stub — fails with `colliding scope never settled` on the unfixed code, passes with the fix; also asserts fresh scopes for the previously-collided key settle and the index is created exactly once.
- Full `@peerbit/indexer-sqlite3` suite: 290 passing.
- System-level validation on the #967 hunt branch (chaos seed 13331 × 20 on CI runners, baseline 4–7 failures per round) is running and will be posted to #967.

Fixes #967 (pending the system-level validation round).
