### PR TITLE
fix(shared-log): keep uniqueReplicators when announcements dedupe to empty

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2481,11 +2481,18 @@ export class SharedLog<
 			const fromHash = from.hashcode();
 			// Track replicator membership transitions synchronously so join/leave events are
 			// idempotent even if we process concurrent reset messages/unsubscribes.
-			const stoppedTransition =
-				ranges.length === 0 ? this.uniqueReplicators.delete(fromHash) : false;
-			if (ranges.length === 0) {
+			// Only a full-state (reset) announcement can signal that a peer stopped
+			// replicating: a non-reset message whose segments deduplicate to nothing
+			// means "nothing new", not "stopped". Removing the peer here would let
+			// uniqueReplicators diverge from replicationIndex while the peer's
+			// ranges stay indexed.
+			const announcedStopped = reset === true && ranges.length === 0;
+			const stoppedTransition = announcedStopped
+				? this.uniqueReplicators.delete(fromHash)
+				: false;
+			if (announcedStopped) {
 				this._replicatorJoinEmitted.delete(fromHash);
-			} else {
+			} else if (ranges.length > 0) {
 				this.uniqueReplicators.add(fromHash);
 			}
 

--- a/packages/programs/data/shared-log/test/sharding.spec.ts
+++ b/packages/programs/data/shared-log/test/sharding.spec.ts
@@ -639,6 +639,65 @@ testSetups.forEach((setup) => {
 				}
 			});
 
+			it("keeps uniqueReplicators when a duplicate announcement dedupes to empty", async () => {
+				db1 = await session.peers[0].open(new EventStore<string, any>(), {
+					args: {
+						replicate: { offset: 0, factor: 0.5 },
+						setup,
+						timeUntilRoleMaturity: 0,
+					},
+				});
+				db2 = await EventStore.open<EventStore<string, any>>(
+					db1.address!,
+					session.peers[1],
+					{
+						args: {
+							replicate: { offset: 0.5, factor: 0.5 },
+							setup,
+							timeUntilRoleMaturity: 0,
+						},
+					},
+				);
+				const db2Key = db2.log.node.identity.publicKey;
+				const db2Hash = db2Key.hashcode();
+				await waitForResolved(() =>
+					expect((db1.log as any).uniqueReplicators.has(db2Hash)).to.be.true,
+				);
+				await waitForResolved(async () =>
+					expect(
+						await db1.log.replicationIndex.count({
+							query: { hash: db2Hash },
+						}),
+					).to.equal(1),
+				);
+
+				// A re-announce of an already-covered span under a fresh id dedupes
+				// to an empty insert list. That must not be mistaken for the peer
+				// stopping replication.
+				const segment = (await db2.log.getMyReplicationSegments())[0];
+				const replicationRange = segment.toReplicationRange();
+				(replicationRange as any).id = randomBytes(32);
+				const covered = (replicationRange as any).toReplicationRangeIndexable(
+					db2Key,
+				);
+				await (db1.log as any).addReplicationRange([covered], db2Key, {
+					reset: false,
+					checkDuplicates: true,
+				});
+
+				expect((db1.log as any).uniqueReplicators.has(db2Hash)).to.be.true;
+				expect(
+					await db1.log.replicationIndex.count({ query: { hash: db2Hash } }),
+				).to.equal(1);
+
+				// A full-state announcement with no segments still removes the peer.
+				await (db1.log as any).addReplicationRange([], db2Key, {
+					reset: true,
+					checkDuplicates: true,
+				});
+				expect((db1.log as any).uniqueReplicators.has(db2Hash)).to.be.false;
+			});
+
 			it("keeps requesting replication info through the replicator wait window", async () => {
 				db1 = await session.peers[0].open(new EventStore<string, any>(), {
 					args: {


### PR DESCRIPTION
## Summary

Fixes #969: `addReplicationRange` conflated "no segments left to insert" with "peer stopped replicating". The non-reset branch reassigns `ranges` after deduplicating against already-covered same-owner spans; the membership block then deleted the sender from `uniqueReplicators` (and cleared its join-emitted flag) on `ranges.length === 0` — even though the peer's ranges remain fully indexed. The set silently diverged from `replicationIndex`, which skews leader computation (`_findLeaders` builds its peer filter from this set) and `getSamples`' early-exit accounting under churn. A live instance was captured in the #967 instrumented post-mortems (a peer's set holding 4 entries against 3 indexed ranges).

The fix gates the stop transition on an actual full-state announcement (`reset === true` with zero segments). A non-reset message that dedupes to nothing now leaves membership untouched. Leave-event emission was already reset-gated (`isStoppedReplicating` is only set in the reset branch), so event semantics are unchanged.

## Testing

- New red-green regression test (u32 + u64 variants): a covered re-announce under a fresh id must not evict the peer (fails on master with `expected false to be true`); a reset announcement with zero segments still removes it.
- `replicate|join|lifecycle` suites: 59 passing; `events|waitForReplicator|network|observer` suites: 33 passing (Node 22, clean worktree).
