### PR TITLE
Fix fanout recovery from zombie streams

### DIFF
--- a/packages/programs/data/shared-log/test/replication.spec.ts
+++ b/packages/programs/data/shared-log/test/replication.spec.ts
@@ -4664,21 +4664,26 @@ testSetups.forEach((setup) => {
 						factor: 0.1,
 					});
 					const db3SmallLength = await countEntriesInRange(db3SmallRange);
+					const delayedPruneWait = { timeout: 60_000, delayInterval: 100 };
 
 					await waitForResolved(() =>
 						expect(db1.log.log.length).to.be.closeTo(entryCount / 2, 20),
 					);
-					await waitForResolved(() =>
-						expect(db2.log.log.length).to.be.closeTo(
-							db2SmallLength,
-							ownershipTolerance,
-						),
+					await waitForResolved(
+						() =>
+							expect(db2.log.log.length).to.be.closeTo(
+								db2SmallLength,
+								ownershipTolerance,
+							),
+						delayedPruneWait,
 					);
-					await waitForResolved(() =>
-						expect(db3.log.log.length).to.be.closeTo(
-							db3SmallLength,
-							ownershipTolerance,
-						),
+					await waitForResolved(
+						() =>
+							expect(db3.log.log.length).to.be.closeTo(
+								db3SmallLength,
+								ownershipTolerance,
+							),
+						delayedPruneWait,
 					);
 
 					expect(db2.log.log.length).to.be.lessThan(db2Length);

--- a/packages/transport/pubsub/benchmark/fanout-tree-sim-lib.ts
+++ b/packages/transport/pubsub/benchmark/fanout-tree-sim-lib.ts
@@ -232,6 +232,9 @@ export type FanoutTreeSimResult = {
 	protocolRepairReqSent: number;
 	protocolFetchReqSent: number;
 	protocolIHaveSent: number;
+	protocolTrackerAnnounceSent: number;
+	protocolTrackerQuerySent: number;
+	protocolTrackerReplySent: number;
 	protocolTrackerFeedbackSent: number;
 	protocolCacheHitsServed: number;
 	protocolHoleFillsFromNeighbor: number;
@@ -415,7 +418,7 @@ export const formatFanoutTreeSimResult = (r: FanoutTreeSimResult) => {
 			`stream: queuedBytes total=${r.streamQueuedBytesTotal} max=${r.streamQueuedBytesMax} p95=${r.streamQueuedBytesP95.toFixed(0)} node=${r.streamQueuedBytesMaxNode ?? "-"} lanes=${r.streamQueuedBytesByLane.join(",")}`,
 		`overhead: dataFactor=${r.overheadFactorData.toFixed(3)} (sentPayloadBytes / ideal)`,
 			`economics: earningsTotal=${r.earningsTotal} relayCount=${r.earningsRelayCount} p50=${r.earningsRelayP50} p95=${r.earningsRelayP95} max=${r.earningsRelayMax}`,
-			`protocol: controlBytesSent=${r.protocolControlBytesSent} (join=${r.protocolControlBytesSentJoin} tracker=${r.protocolControlBytesSentTracker} repair=${r.protocolControlBytesSentRepair}) bpp=${r.controlBpp.toFixed(4)} (tracker=${r.trackerBpp.toFixed(4)} repair=${r.repairBpp.toFixed(4)}) dataPayloadBytesSent=${r.protocolDataPayloadBytesSent} fetchReqSent=${r.protocolFetchReqSent} ihaveSent=${r.protocolIHaveSent} trackerFeedbackSent=${r.protocolTrackerFeedbackSent} holeFills=${r.protocolHoleFillsFromNeighbor} routeCache(h/m/x/e)=${r.protocolRouteCacheHits}/${r.protocolRouteCacheMisses}/${r.protocolRouteCacheExpirations}/${r.protocolRouteCacheEvictions} routeProxy(q/t/f)=${r.protocolRouteProxyQueries}/${r.protocolRouteProxyTimeouts}/${r.protocolRouteProxyFanout}`,
+			`protocol: controlBytesSent=${r.protocolControlBytesSent} (join=${r.protocolControlBytesSentJoin} tracker=${r.protocolControlBytesSentTracker} repair=${r.protocolControlBytesSentRepair}) bpp=${r.controlBpp.toFixed(4)} (tracker=${r.trackerBpp.toFixed(4)} repair=${r.repairBpp.toFixed(4)}) dataPayloadBytesSent=${r.protocolDataPayloadBytesSent} fetchReqSent=${r.protocolFetchReqSent} ihaveSent=${r.protocolIHaveSent} tracker(a/q/r/f)=${r.protocolTrackerAnnounceSent}/${r.protocolTrackerQuerySent}/${r.protocolTrackerReplySent}/${r.protocolTrackerFeedbackSent} holeFills=${r.protocolHoleFillsFromNeighbor} routeCache(h/m/x/e)=${r.protocolRouteCacheHits}/${r.protocolRouteCacheMisses}/${r.protocolRouteCacheExpirations}/${r.protocolRouteCacheEvictions} routeProxy(q/t/f)=${r.protocolRouteProxyQueries}/${r.protocolRouteProxyTimeouts}/${r.protocolRouteProxyFanout}`,
 			`network: dials=${r.network.dials} connsOpened=${r.network.connectionsOpened} streamsOpened=${r.network.streamsOpened} framesSent=${r.network.framesSent} bytesSent=${r.network.bytesSent} framesDropped=${r.network.framesDropped} bytesDropped=${r.network.bytesDropped}`,
 			...(r.profile
 				? [
@@ -1351,18 +1354,21 @@ export const runFanoutTreeSim = async (
 			let protocolDataReceives = 0;
 			let protocolDataPayloadBytesReceived = 0;
 			let protocolRepairReqSent = 0;
-				let protocolFetchReqSent = 0;
-				let protocolIHaveSent = 0;
-				let protocolTrackerFeedbackSent = 0;
-				let protocolCacheHitsServed = 0;
-				let protocolHoleFillsFromNeighbor = 0;
-				let protocolRouteCacheHits = 0;
-				let protocolRouteCacheMisses = 0;
-				let protocolRouteCacheExpirations = 0;
-				let protocolRouteCacheEvictions = 0;
-				let protocolRouteProxyQueries = 0;
-				let protocolRouteProxyTimeouts = 0;
-				let protocolRouteProxyFanout = 0;
+			let protocolFetchReqSent = 0;
+			let protocolIHaveSent = 0;
+			let protocolTrackerAnnounceSent = 0;
+			let protocolTrackerQuerySent = 0;
+			let protocolTrackerReplySent = 0;
+			let protocolTrackerFeedbackSent = 0;
+			let protocolCacheHitsServed = 0;
+			let protocolHoleFillsFromNeighbor = 0;
+			let protocolRouteCacheHits = 0;
+			let protocolRouteCacheMisses = 0;
+			let protocolRouteCacheExpirations = 0;
+			let protocolRouteCacheEvictions = 0;
+			let protocolRouteProxyQueries = 0;
+			let protocolRouteProxyTimeouts = 0;
+			let protocolRouteProxyFanout = 0;
 					let staleForwardsDroppedTotal = 0;
 					let staleForwardsDroppedMax = 0;
 					let staleForwardsDroppedMaxNode: string | undefined;
@@ -1407,9 +1413,12 @@ export const runFanoutTreeSim = async (
 				protocolRepairReqSent += m.repairReqSent;
 				protocolFetchReqSent += m.fetchReqSent;
 				protocolIHaveSent += m.ihaveSent;
-					protocolTrackerFeedbackSent += m.trackerFeedbackSent;
-					protocolCacheHitsServed += m.cacheHitsServed;
-					protocolHoleFillsFromNeighbor += m.holeFillsFromNeighbor;
+				protocolTrackerAnnounceSent += m.trackerAnnounceSent;
+				protocolTrackerQuerySent += m.trackerQuerySent;
+				protocolTrackerReplySent += m.trackerReplySent;
+				protocolTrackerFeedbackSent += m.trackerFeedbackSent;
+				protocolCacheHitsServed += m.cacheHitsServed;
+				protocolHoleFillsFromNeighbor += m.holeFillsFromNeighbor;
 					protocolRouteCacheHits += m.routeCacheHits;
 					protocolRouteCacheMisses += m.routeCacheMisses;
 					protocolRouteCacheExpirations += m.routeCacheExpirations;
@@ -1546,6 +1555,9 @@ export const runFanoutTreeSim = async (
 				protocolRepairReqSent,
 				protocolFetchReqSent,
 				protocolIHaveSent,
+				protocolTrackerAnnounceSent,
+				protocolTrackerQuerySent,
+				protocolTrackerReplySent,
 				protocolTrackerFeedbackSent,
 				protocolCacheHitsServed,
 				protocolHoleFillsFromNeighbor,

--- a/packages/transport/pubsub/src/fanout-tree.ts
+++ b/packages/transport/pubsub/src/fanout-tree.ts
@@ -3602,6 +3602,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		const ch = this.channelsBySuffixKey.get(id.suffixKey);
 		if (!ch) return;
 		if (!ch.isRoot) return;
+		ch.endSeqExclusive = Math.max(ch.endSeqExclusive, lastSeqExclusive);
 		await this._sendControlMany([...ch.children.keys()], encodeEnd(ch.id.key, lastSeqExclusive));
 	}
 
@@ -3963,13 +3964,9 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 					const kickCount = Math.min(OVERLOAD_KICK_MAX_PER_EVENT, droppedCandidates.length);
 					if (kickCount > 0) {
 						const toKick = droppedCandidates.slice(0, kickCount).map((c) => c.hash);
-						for (const h of toKick) {
-							ch.children.delete(h);
-							ch.dataWriteFailStreakByChild.delete(h);
-						}
 						ch.overloadStreak = 0;
 						ch.lastOverloadKickAt = now;
-						void this._sendControlMany(toKick, encodeKick(ch.id.key));
+						void this.kickChildHashes(ch, toKick).catch(() => {});
 						void this.announceToTrackers(ch, this.closeController.signal).catch(() => {});
 					}
 			}
@@ -4055,12 +4052,10 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			const kickCount = Math.min(DATA_WRITE_FAIL_KICK_MAX_PER_EVENT, unique.length);
 			if (kickCount > 0) {
 				const toKick = unique.slice(0, kickCount);
-				for (const h of toKick) {
-					ch.children.delete(h);
-					ch.dataWriteFailStreakByChild.delete(h);
-				}
 				ch.lastDataWriteFailKickAt = now;
-				void this._sendControlMany(toKick, encodeKick(ch.id.key));
+				void this.kickChildHashes(ch, toKick, { resetPeerConnections: true }).catch(
+					() => {},
+				);
 				void this.announceToTrackers(ch, this.closeController.signal).catch(() => {});
 			}
 		}
@@ -4156,13 +4151,9 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 					const kickCount = Math.min(OVERLOAD_KICK_MAX_PER_EVENT, droppedCandidates.length);
 					if (kickCount > 0) {
 						const toKick = droppedCandidates.slice(0, kickCount).map((c) => c.hash);
-						for (const h of toKick) {
-							ch.children.delete(h);
-							ch.dataWriteFailStreakByChild.delete(h);
-						}
 						ch.overloadStreak = 0;
 						ch.lastOverloadKickAt = now;
-						void this._sendControlMany(toKick, encodeKick(ch.id.key));
+						void this.kickChildHashes(ch, toKick).catch(() => {});
 						void this.announceToTrackers(ch, this.closeController.signal).catch(() => {});
 					}
 			}
@@ -4233,12 +4224,10 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			const kickCount = Math.min(DATA_WRITE_FAIL_KICK_MAX_PER_EVENT, unique.length);
 			if (kickCount > 0) {
 				const toKick = unique.slice(0, kickCount);
-				for (const h of toKick) {
-					ch.children.delete(h);
-					ch.dataWriteFailStreakByChild.delete(h);
-				}
 				ch.lastDataWriteFailKickAt = now;
-				void this._sendControlMany(toKick, encodeKick(ch.id.key));
+				void this.kickChildHashes(ch, toKick, { resetPeerConnections: true }).catch(
+					() => {},
+				);
 				void this.announceToTrackers(ch, this.closeController.signal).catch(() => {});
 			}
 		}
@@ -4710,18 +4699,10 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		// IHAVE from the parent converts that silent loss into a repairable gap.
 		const heartbeatDue =
 			childWatermarkEnabled &&
-			ch.maxSeqSeen >= 0 &&
+			(ch.maxSeqSeen >= 0 || ch.endSeqExclusive > 0) &&
 			now - ch.lastIHaveSentAt >=
-				Math.max(ch.neighborAnnounceIntervalMs * 4, 2_000);
+				Math.max(ch.neighborAnnounceIntervalMs * 2, 1_000);
 		if (!hasNewData && !heartbeatDue) {
-			return;
-		}
-
-		const range = this.getHaveRange(ch);
-		if (!range) {
-			return;
-		}
-		if (range.haveToExclusive <= range.haveFrom) {
 			return;
 		}
 
@@ -4739,12 +4720,29 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		if (recipients.size === 0) {
 			return;
 		}
-		await this._sendControlMany(
-			[...recipients],
-			encodeIHave(ch.id.key, range.haveFrom, range.haveToExclusive),
-		);
-		ch.lastIHaveSentAt = now;
-		ch.lastIHaveSentMaxSeq = ch.maxSeqSeen;
+		let sent = false;
+		const range = this.getHaveRange(ch);
+		if (range && range.haveToExclusive > range.haveFrom) {
+			await this._sendControlMany(
+				[...recipients],
+				encodeIHave(ch.id.key, range.haveFrom, range.haveToExclusive),
+			);
+			sent = true;
+		}
+		if (childWatermarkEnabled && ch.endSeqExclusive > 0) {
+			const children = [...ch.children.keys()].filter((h) => this.peers.get(h));
+			if (children.length > 0) {
+				await this._sendControlMany(
+					children,
+					encodeEnd(ch.id.key, ch.endSeqExclusive),
+				);
+				sent = true;
+			}
+		}
+		if (sent) {
+			ch.lastIHaveSentAt = now;
+			ch.lastIHaveSentMaxSeq = ch.maxSeqSeen;
+		}
 	}
 
 	private async ensureMeshPeers(ch: ChannelState, signal: AbortSignal): Promise<void> {
@@ -5016,7 +5014,17 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 	private async _joinLoop(ch: ChannelState, joinOpts: FanoutTreeJoinOptions): Promise<void> {
 		const retryMs = Math.max(1, Math.floor(joinOpts.retryMs ?? 200));
 		const timeoutMs = Math.max(0, Math.floor(joinOpts.timeoutMs ?? 60_000));
-		const staleAfterMs = Math.max(0, Math.floor(joinOpts.staleAfterMs ?? 0));
+		const defaultStaleAfterMs = ch.repairEnabled
+			? Math.max(
+					1_500,
+					ch.neighborAnnounceIntervalMs * 3,
+					ch.repairIntervalMs * 8,
+				)
+			: 0;
+		const staleAfterMs = Math.max(
+			0,
+			Math.floor(joinOpts.staleAfterMs ?? defaultStaleAfterMs),
+		);
 		const joinReqTimeoutMs = Math.max(0, Math.floor(joinOpts.joinReqTimeoutMs ?? 2_000));
 		const bootstrapDialTimeoutMs = Math.max(
 			0,
@@ -5118,7 +5126,9 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 							ch.missingSeqs.size === 0 &&
 							ch.nextExpectedSeq >= ch.endSeqExclusive;
 						const expectingData =
-							ch.missingSeqs.size > 0 || (ch.maxDataAgeMs > 0 && !endedAndComplete);
+							ch.missingSeqs.size > 0 ||
+							(ch.repairEnabled && ch.maxSeqSeen >= 0 && ch.endSeqExclusive < 0) ||
+							(ch.maxDataAgeMs > 0 && !endedAndComplete);
 
 						// Repair requests travel child->parent on a direction that works
 						// even when the parent->child stream silently swallows writes.
@@ -5631,12 +5641,37 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		return res;
 	}
 
+	private async kickChildHashes(
+		ch: ChannelState,
+		children: string[],
+		options?: { resetPeerConnections?: boolean },
+	) {
+		const unique = [...new Set(children)].filter((h) => ch.children.has(h));
+		for (const h of unique) {
+			ch.children.delete(h);
+			ch.dataWriteFailStreakByChild.delete(h);
+		}
+		if (unique.length === 0) return;
+		const resetPeerConnections = options?.resetPeerConnections !== false;
+		try {
+			await this._sendControlMany(unique, encodeKick(ch.id.key));
+		} finally {
+			if (resetPeerConnections) {
+				// KICK travels over the same peer link that may already be one-way
+				// broken; closing the connection makes the topology change observable.
+				for (const h of unique) {
+					const stream = this.peers.get(h);
+					if (!stream) continue;
+					void this.components.connectionManager
+						.closeConnections(stream.peerId)
+						.catch(() => {});
+				}
+			}
+		}
+	}
+
 	private async kickChildren(ch: ChannelState) {
-		const children = [...ch.children.keys()];
-		ch.children.clear();
-		ch.dataWriteFailStreakByChild.clear();
-		if (children.length === 0) return;
-		await this._sendControlMany(children, encodeKick(ch.id.key));
+		await this.kickChildHashes(ch, [...ch.children.keys()]);
 	}
 
 	public async onDataMessage(
@@ -6244,6 +6279,10 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 				const haveFrom = readU32BE(data, 33);
 				const haveToExclusive = readU32BE(data, 37);
 				const now = Date.now();
+				if (ch.parent && fromHash === ch.parent) {
+					ch.lastParentDataAt = now;
+					ch.receivedAnyParentData = true;
+				}
 				const prev = ch.haveByPeer.get(fromHash);
 				if (prev) {
 					prev.haveFrom = haveFrom;
@@ -6329,70 +6368,74 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 								ch,
 								fromHash,
 								reqId,
-							JOIN_REJECT_NO_CAPACITY,
-						).catch(() => {});
-						return true;
-					}
-
-					if (!ch.children.has(fromHash) && ch.children.size >= ch.effectiveMaxChildren) {
-						if (!ch.allowKick) {
-							void this.sendJoinReject(
-								ch,
-								fromHash,
-								reqId,
 								JOIN_REJECT_NO_CAPACITY,
 							).catch(() => {});
-							void this.announceToTrackers(ch, this.closeController.signal).catch(() => {});
 							return true;
 						}
 
-					let worstChild: string | undefined;
-					let worstBid = Number.POSITIVE_INFINITY;
-					for (const [childHash, info] of ch.children) {
-						if (info.bidPerByte < worstBid) {
-							worstBid = info.bidPerByte;
-							worstChild = childHash;
+						if (!ch.children.has(fromHash) && ch.children.size >= ch.effectiveMaxChildren) {
+							if (!ch.allowKick) {
+								void this.sendJoinReject(
+									ch,
+									fromHash,
+									reqId,
+									JOIN_REJECT_NO_CAPACITY,
+								).catch(() => {});
+								void this.announceToTrackers(ch, this.closeController.signal).catch(() => {});
+								return true;
+							}
+
+							let worstChild: string | undefined;
+							let worstBid = Number.POSITIVE_INFINITY;
+							for (const [childHash, info] of ch.children) {
+								if (info.bidPerByte < worstBid) {
+									worstBid = info.bidPerByte;
+									worstChild = childHash;
+								}
+							}
+
+							if (worstChild == null || bidPerByte <= worstBid) {
+								void this.sendJoinReject(
+									ch,
+									fromHash,
+									reqId,
+									JOIN_REJECT_LOW_BID,
+								).catch(() => {});
+								void this.announceToTrackers(ch, this.closeController.signal).catch(() => {});
+								return true;
+							}
+
+							void this.kickChildHashes(ch, [worstChild]).catch(() => {});
 						}
-					}
 
-					if (worstChild == null || bidPerByte <= worstBid) {
-							void this.sendJoinReject(
-								ch,
-								fromHash,
-								reqId,
-								JOIN_REJECT_LOW_BID,
-							).catch(() => {});
-							void this.announceToTrackers(ch, this.closeController.signal).catch(() => {});
-							return true;
-						}
-
-						ch.children.delete(worstChild);
-						ch.dataWriteFailStreakByChild.delete(worstChild);
-						void this._sendControl(worstChild, encodeKick(ch.id.key));
-					}
-
-					ch.children.set(fromHash, { bidPerByte });
-					this.touchPeerHint(ch, fromHash);
-					void this._sendControl(
-						fromHash,
-						encodeJoinAccept(
+						ch.children.set(fromHash, { bidPerByte });
+						this.touchPeerHint(ch, fromHash);
+						const joinAccept = encodeJoinAccept(
 							ch.id.key,
 							reqId,
 							ch.level,
 							ch.routeFromRoot,
 							this.getHaveRange(ch),
-						),
-					);
-					void this.announceToTrackers(ch, this.closeController.signal).catch(() => {});
-					return true;
-				}
+						);
+						void (async () => {
+							await this._sendControl(fromHash, joinAccept);
+							if (ch.endSeqExclusive > 0) {
+								await this._sendControl(
+									fromHash,
+									encodeEnd(ch.id.key, ch.endSeqExclusive),
+								);
+							}
+						})().catch(() => {});
+						void this.announceToTrackers(ch, this.closeController.signal).catch(() => {});
+						return true;
+					}
 
-			if (kind === MSG_JOIN_ACCEPT || kind === MSG_JOIN_REJECT) {
-				if (data.length < 1 + 32 + 4) return false;
-				const reqId = readU32BE(data, 33);
-				const pending = ch.pendingJoin.get(reqId);
-				if (!pending) return true;
-				ch.pendingJoin.delete(reqId);
+				if (kind === MSG_JOIN_ACCEPT || kind === MSG_JOIN_REJECT) {
+					if (data.length < 1 + 32 + 4) return false;
+					const reqId = readU32BE(data, 33);
+					const pending = ch.pendingJoin.get(reqId);
+					if (!pending) return true;
+					ch.pendingJoin.delete(reqId);
 
 					if (kind === MSG_JOIN_ACCEPT) {
 						if (data.length < 1 + 32 + 4 + 2 + 1) return false;
@@ -6401,73 +6444,71 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 						let offset = 40;
 						const parentRouteFromRoot: string[] = [];
 						const max = Math.min(routeCount, MAX_ROUTE_HOPS);
-							for (let i = 0; i < max; i++) {
-								if (offset + 1 > data.length) break;
-								const len = data[offset++]!;
-								if (len === 0) break;
-								if (offset + len > data.length) break;
-								parentRouteFromRoot.push(
-									textDecoder.decode(data.subarray(offset, offset + len)),
-								);
-								offset += len;
-							}
+						for (let i = 0; i < max; i++) {
+							if (offset + 1 > data.length) break;
+							const len = data[offset++]!;
+							if (len === 0) break;
+							if (offset + len > data.length) break;
+							parentRouteFromRoot.push(
+								textDecoder.decode(data.subarray(offset, offset + len)),
+							);
+							offset += len;
+						}
 
-							const hasValidParentRoute =
-								parentRouteFromRoot.length > 0 &&
-								parentRouteFromRoot[0] === ch.id.root &&
-								parentRouteFromRoot[parentRouteFromRoot.length - 1] === fromHash;
+						const hasValidParentRoute =
+							parentRouteFromRoot.length > 0 &&
+							parentRouteFromRoot[0] === ch.id.root &&
+							parentRouteFromRoot[parentRouteFromRoot.length - 1] === fromHash;
 
-							// Defensive: a JOIN_ACCEPT without a rooted route token (unless the parent is the
-							// actual root) can create stable disconnected components. Treat it as a reject.
-							if (fromHash !== ch.id.root && !hasValidParentRoute) {
-								pending.resolve({ ok: false, rejectReason: JOIN_REJECT_NOT_ATTACHED });
-								return true;
-							}
+						// Defensive: a JOIN_ACCEPT without a rooted route token (unless the parent is the
+						// actual root) can create stable disconnected components. Treat it as a reject.
+						if (fromHash !== ch.id.root && !hasValidParentRoute) {
+							pending.resolve({ ok: false, rejectReason: JOIN_REJECT_NOT_ATTACHED });
+							return true;
+						}
 
-								ch.parent = fromHash;
-								ch.level = parentLevel + 1;
-								ch.joinedAtLeastOnce = true;
-								ch.lastParentDataAt = Date.now();
-								// Treat JOIN_ACCEPT as parent liveness for stale re-parenting:
-								// if callers enable `staleAfterMs`, we should be able to detach even
-								// before the first data message arrives (for example, during churn
-								// or when a component is partitioned from the root).
-							ch.receivedAnyParentData = true;
-							// Build/refresh a route token that enables economical unicast.
-							if (
-								hasValidParentRoute
-							) {
-								ch.routeFromRoot = [...parentRouteFromRoot, this.publicKeyHash];
-								} else if (fromHash === ch.id.root) {
-									// Minimal fallback: parent is the root.
-									ch.routeFromRoot = [ch.id.root, this.publicKeyHash];
+						ch.parent = fromHash;
+						ch.level = parentLevel + 1;
+						ch.joinedAtLeastOnce = true;
+						ch.lastParentDataAt = Date.now();
+						// Treat JOIN_ACCEPT as parent liveness for stale re-parenting:
+						// if callers enable `staleAfterMs`, we should be able to detach even
+						// before the first data message arrives (for example, during churn
+						// or when a component is partitioned from the root).
+						ch.receivedAnyParentData = true;
+						// Build/refresh a route token that enables economical unicast.
+						if (hasValidParentRoute) {
+							ch.routeFromRoot = [...parentRouteFromRoot, this.publicKeyHash];
+						} else if (fromHash === ch.id.root) {
+							// Minimal fallback: parent is the root.
+							ch.routeFromRoot = [ch.id.root, this.publicKeyHash];
+						}
+						if (
+							ch.repairEnabled &&
+							ch.maxDataAgeMs === 0 &&
+							offset + 8 <= data.length
+						) {
+							// Optional appendix: the parent's current have-range. Lets a
+							// freshly attached child learn immediately which sequences
+							// already exist, so lost deliveries surface as missing seqs
+							// (and repair) instead of silent absence.
+							const haveFrom = readU32BE(data, offset);
+							const haveToExclusive = readU32BE(data, offset + 4);
+							if (haveToExclusive > haveFrom) {
+								// Mark only; the repair loop's own cadence picks the gaps
+								// up, giving in-flight live deliveries time to land first
+								// (an immediate pull here races them into duplicates).
+								this.noteEnd(ch, fromHash, haveToExclusive);
 							}
-							if (
-								ch.repairEnabled &&
-								ch.maxDataAgeMs === 0 &&
-								offset + 8 <= data.length
-							) {
-								// Optional appendix: the parent's current have-range. Lets a
-								// freshly attached child learn immediately which sequences
-								// already exist, so lost deliveries surface as missing seqs
-								// (and repair) instead of silent absence.
-								const haveFrom = readU32BE(data, offset);
-								const haveToExclusive = readU32BE(data, offset + 4);
-								if (haveToExclusive > haveFrom) {
-									// Mark only; the repair loop's own cadence picks the gaps
-									// up, giving in-flight live deliveries time to land first
-									// (an immediate pull here races them into duplicates).
-									this.noteEnd(ch, fromHash, haveToExclusive);
-								}
-							}
-							this.touchPeerHint(ch, fromHash);
-							pending.resolve({ ok: true });
-							this.dispatchEvent(
-								new CustomEvent("fanout:joined", {
-									detail: { topic: ch.id.topic, root: ch.id.root, parent: fromHash },
-						}),
-					);
-					void this.announceToTrackers(ch, this.closeController.signal).catch(() => {});
+						}
+						this.touchPeerHint(ch, fromHash);
+						pending.resolve({ ok: true });
+						this.dispatchEvent(
+							new CustomEvent("fanout:joined", {
+								detail: { topic: ch.id.topic, root: ch.id.root, parent: fromHash },
+							}),
+						);
+						void this.announceToTrackers(ch, this.closeController.signal).catch(() => {});
 					} else {
 						if (data.length < 1 + 32 + 4 + 1) return false;
 						const reason = data[37]! & 0xff;
@@ -6499,17 +6540,17 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 									} catch {
 										// ignore invalid multiaddrs
 									}
-									}
-									if (hash && addrs.length > 0) {
-										redirects.push({ hash, addrs });
-										this.cacheKnownCandidateAddrs(ch, hash, addrs);
-									}
+								}
+								if (hash && addrs.length > 0) {
+									redirects.push({ hash, addrs });
+									this.cacheKnownCandidateAddrs(ch, hash, addrs);
 								}
 							}
+						}
 						pending.resolve({ ok: false, rejectReason: reason, redirects });
 					}
 					return true;
-					}
+				}
 	
 					if (kind === MSG_PUBLISH_PROXY) {
 						// Requires an open channel state
@@ -6847,10 +6888,14 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 				return true;
 			}
 
-					if (kind === MSG_END) {
-							if (data.length < 1 + 32 + 4) return false;
-							const lastSeqExclusive = readU32BE(data, 33);
-							ch.endSeqExclusive = Math.max(ch.endSeqExclusive, lastSeqExclusive);
+						if (kind === MSG_END) {
+								if (data.length < 1 + 32 + 4) return false;
+								const lastSeqExclusive = readU32BE(data, 33);
+								if (ch.parent && fromHash === ch.parent) {
+									ch.lastParentDataAt = Date.now();
+									ch.receivedAnyParentData = true;
+								}
+								ch.endSeqExclusive = Math.max(ch.endSeqExclusive, lastSeqExclusive);
 							this.touchPeerHint(ch, fromHash);
 							this.noteEnd(ch, fromHash, lastSeqExclusive);
 							if (ch.children.size > 0) {

--- a/packages/transport/pubsub/src/fanout-tree.ts
+++ b/packages/transport/pubsub/src/fanout-tree.ts
@@ -502,6 +502,10 @@ const OVERLOAD_KICK_MAX_PER_EVENT = 4;
 const DATA_WRITE_FAIL_KICK_STREAK_THRESHOLD = 3;
 const DATA_WRITE_FAIL_KICK_COOLDOWN_MS = 2_000;
 const DATA_WRITE_FAIL_KICK_MAX_PER_EVENT = 4;
+const PARENT_REPAIR_DEAD_STREAK_THRESHOLD = 16;
+const PARENT_REPAIR_DEAD_MIN_LIVENESS_MS = 15_000;
+const REPAIR_RETRY_MIN_MS = 1_000;
+const REPAIR_RETRY_INTERVAL_FACTOR = 5;
 
 const JOIN_REJECT_REDIRECT_MAX = 4;
 const JOIN_REJECT_REDIRECT_ADDR_MAX = 8;
@@ -1417,6 +1421,7 @@ type ChannelState = {
 	cachePayloads?: Array<Uint8Array | undefined>;
 	nextExpectedSeq: number;
 	missingSeqs: Set<number>;
+	repairRequestedAtBySeq: Map<number, number>;
 	endSeqExclusive: number;
 		lastRepairSentAt: number;
 	parentRepairUnansweredStreak: number;
@@ -2360,7 +2365,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		);
 		const neighborMeshRefreshIntervalMs = Math.max(
 			0,
-			Math.floor(opts.neighborMeshRefreshIntervalMs ?? 2_000),
+			Math.floor(opts.neighborMeshRefreshIntervalMs ?? 10_000),
 		);
 		const neighborHaveTtlMs = Math.max(
 			0,
@@ -2468,6 +2473,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 					: undefined,
 			nextExpectedSeq: 0,
 			missingSeqs: new Set<number>(),
+			repairRequestedAtBySeq: new Map<number, number>(),
 			endSeqExclusive: -1,
 			lastRepairSentAt: 0,
 			parentRepairUnansweredStreak: 0,
@@ -3998,13 +4004,6 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			const stream = c.stream;
 			if (!stream.isWritable) {
 				writeDrops += 1;
-				if (ch.children.has(c.hash)) {
-					const streak = (ch.dataWriteFailStreakByChild.get(c.hash) ?? 0) + 1;
-					ch.dataWriteFailStreakByChild.set(c.hash, streak);
-					if (streak >= DATA_WRITE_FAIL_KICK_STREAK_THRESHOLD) {
-						writeFailKickCandidates.push(c.hash);
-					}
-				}
 				continue;
 			}
 
@@ -4174,11 +4173,6 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			const stream = c.stream;
 			if (!stream.isWritable) {
 				writeDrops += 1;
-				const streak = (ch.dataWriteFailStreakByChild.get(c.hash) ?? 0) + 1;
-				ch.dataWriteFailStreakByChild.set(c.hash, streak);
-				if (streak >= DATA_WRITE_FAIL_KICK_STREAK_THRESHOLD) {
-					writeFailKickCandidates.push(c.hash);
-				}
 				continue;
 			}
 
@@ -4235,6 +4229,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 
 		private noteReceivedSeq(ch: ChannelState, fromHash: string, seq: number) {
 			if (!ch.repairEnabled) return;
+			ch.repairRequestedAtBySeq.delete(seq);
 			if (!ch.parent || fromHash !== ch.parent) {
 				// Neighbor-assisted repair may deliver payload from a peer other than the
 			// current parent; treat it as a "hole fill" only.
@@ -4307,18 +4302,28 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 				if (s < minSeq) ch.missingSeqs.delete(s);
 			}
 		}
+		for (const s of ch.repairRequestedAtBySeq.keys()) {
+			if (!ch.missingSeqs.has(s)) ch.repairRequestedAtBySeq.delete(s);
+		}
 
 		if (ch.missingSeqs.size === 0) return false;
 		if (ch.repairIntervalMs > 0 && now - ch.lastRepairSentAt < ch.repairIntervalMs) {
 			return false;
 		}
 
-		ch.lastRepairSentAt = now;
-		const missing = [...ch.missingSeqs].sort((a, b) => a - b);
+		const repairRetryMs = Math.max(
+			REPAIR_RETRY_MIN_MS,
+			ch.repairIntervalMs * REPAIR_RETRY_INTERVAL_FACTOR,
+		);
+		const missing = [...ch.missingSeqs]
+			.filter((s) => now - (ch.repairRequestedAtBySeq.get(s) ?? 0) >= repairRetryMs)
+			.sort((a, b) => a - b);
 		const count = Math.min(ch.repairMaxPerReq, missing.length, 255);
 		if (count <= 0) return false;
+		ch.lastRepairSentAt = now;
 		const reqId = (this.random() * 0xffffffff) >>> 0;
 		const slice = missing.slice(0, count);
+		for (const s of slice) ch.repairRequestedAtBySeq.set(s, now);
 
 		let sent = false;
 
@@ -4376,25 +4381,19 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 				};
 			});
 
-			scored.sort((a, b) => {
+			const viable = scored.filter((s) => s.coverage > 0);
+
+			viable.sort((a, b) => {
 				if (a.coverage !== b.coverage) return b.coverage - a.coverage;
-				if (a.coverage > 0) {
-					if (a.successRate !== b.successRate) return b.successRate - a.successRate;
-					if (a.updatedAt !== b.updatedAt) return b.updatedAt - a.updatedAt;
-					const al = ch.lazyPeers.has(a.peerHash) ? 1 : 0;
-					const bl = ch.lazyPeers.has(b.peerHash) ? 1 : 0;
-					if (al !== bl) return bl - al;
-				} else {
-					const al = ch.lazyPeers.has(a.peerHash) ? 1 : 0;
-					const bl = ch.lazyPeers.has(b.peerHash) ? 1 : 0;
-					if (al !== bl) return bl - al;
-					if (a.successRate !== b.successRate) return b.successRate - a.successRate;
-					if (a.updatedAt !== b.updatedAt) return b.updatedAt - a.updatedAt;
-				}
+				if (a.successRate !== b.successRate) return b.successRate - a.successRate;
+				if (a.updatedAt !== b.updatedAt) return b.updatedAt - a.updatedAt;
+				const al = ch.lazyPeers.has(a.peerHash) ? 1 : 0;
+				const bl = ch.lazyPeers.has(b.peerHash) ? 1 : 0;
+				if (al !== bl) return bl - al;
 				return a.peerHash < b.peerHash ? -1 : a.peerHash > b.peerHash ? 1 : 0;
 			});
 
-			let peers = scored.slice(0, ch.neighborRepairPeers).map((s) => s.peerHash);
+			let peers = viable.slice(0, ch.neighborRepairPeers).map((s) => s.peerHash);
 			if (peers.length > 0) {
 				const bytes = encodeFetchReq(ch.id.key, reqId, slice);
 
@@ -4701,7 +4700,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			childWatermarkEnabled &&
 			(ch.maxSeqSeen >= 0 || ch.endSeqExclusive > 0) &&
 			now - ch.lastIHaveSentAt >=
-				Math.max(ch.neighborAnnounceIntervalMs * 2, 1_000);
+				Math.max(ch.neighborAnnounceIntervalMs * 4, 2_000);
 		if (!hasNewData && !heartbeatDue) {
 			return;
 		}
@@ -4784,6 +4783,9 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 	}
 
 	private async refreshMeshCandidates(ch: ChannelState, signal: AbortSignal): Promise<void> {
+		if (ch.neighborMeshPeers <= 0) return;
+		if (ch.lazyPeers.size >= ch.neighborMeshPeers) return;
+
 		const bootstraps = this.getBootstrapsForChannel(ch);
 		if (bootstraps.length === 0) return;
 		const trackerPeers = await this.ensureBootstrapPeers(
@@ -4814,13 +4816,16 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 					this.pruneLazyPeers(ch);
 					this.pruneHaveByPeer(ch, now);
 
+				await this.ensureMeshPeers(ch, signal);
 				const refreshMs = Math.max(0, ch.neighborMeshRefreshIntervalMs);
-				if (refreshMs === 0 || now - lastRefreshAt >= refreshMs) {
+				if (
+					ch.lazyPeers.size < ch.neighborMeshPeers &&
+					(refreshMs === 0 || now - lastRefreshAt >= refreshMs)
+				) {
 					lastRefreshAt = now;
 					await this.refreshMeshCandidates(ch, signal);
+					await this.ensureMeshPeers(ch, signal);
 				}
-
-				await this.ensureMeshPeers(ch, signal);
 				await this.maybeSendIHave(ch, now);
 			} catch {
 				// ignore
@@ -5014,16 +5019,9 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 	private async _joinLoop(ch: ChannelState, joinOpts: FanoutTreeJoinOptions): Promise<void> {
 		const retryMs = Math.max(1, Math.floor(joinOpts.retryMs ?? 200));
 		const timeoutMs = Math.max(0, Math.floor(joinOpts.timeoutMs ?? 60_000));
-		const defaultStaleAfterMs = ch.repairEnabled
-			? Math.max(
-					1_500,
-					ch.neighborAnnounceIntervalMs * 3,
-					ch.repairIntervalMs * 8,
-				)
-			: 0;
 		const staleAfterMs = Math.max(
 			0,
-			Math.floor(joinOpts.staleAfterMs ?? defaultStaleAfterMs),
+			Math.floor(joinOpts.staleAfterMs ?? 0),
 		);
 		const joinReqTimeoutMs = Math.max(0, Math.floor(joinOpts.joinReqTimeoutMs ?? 2_000));
 		const bootstrapDialTimeoutMs = Math.max(
@@ -5131,12 +5129,26 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 							(ch.maxDataAgeMs > 0 && !endedAndComplete);
 
 						// Repair requests travel child->parent on a direction that works
-						// even when the parent->child stream silently swallows writes.
-						// Several unanswered repairs are therefore a precise signal that
-						// the downstream link is dead, with no false positives from slow
-						// starts (requests only fire once seqs are known missing).
+						// even when parent->child data writes silently fail. A repair that
+						// does not fill a gap is not sufficient evidence by itself though:
+						// the repair payload can be dropped or the parent cache can miss.
+						// Re-parent only after both repeated unanswered repairs and a
+						// quiet parent liveness window.
+						const parentRepairDeadLivenessMs = Math.max(
+							PARENT_REPAIR_DEAD_MIN_LIVENESS_MS,
+							ch.repairIntervalMs * PARENT_REPAIR_DEAD_STREAK_THRESHOLD,
+							ch.neighborAnnounceIntervalMs * 8,
+						);
+						const parentRepairNow = Date.now();
+						const parentLivenessQuietMs =
+							ch.lastParentDataAt > 0
+								? parentRepairNow - ch.lastParentDataAt
+								: 0;
 						const parentRepairDead =
-							ch.repairEnabled && ch.parentRepairUnansweredStreak >= 3;
+							ch.repairEnabled &&
+							ch.parentRepairUnansweredStreak >=
+								PARENT_REPAIR_DEAD_STREAK_THRESHOLD &&
+							parentLivenessQuietMs >= parentRepairDeadLivenessMs;
 						if (
 							parentRepairDead ||
 							(staleAfterMs > 0 &&
@@ -5652,13 +5664,17 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			ch.dataWriteFailStreakByChild.delete(h);
 		}
 		if (unique.length === 0) return;
-		const resetPeerConnections = options?.resetPeerConnections !== false;
+		const resetPeerConnections = options?.resetPeerConnections === true;
+		let kickFailed = false;
 		try {
 			await this._sendControlMany(unique, encodeKick(ch.id.key));
+		} catch (error) {
+			kickFailed = true;
+			throw error;
 		} finally {
-			if (resetPeerConnections) {
-				// KICK travels over the same peer link that may already be one-way
-				// broken; closing the connection makes the topology change observable.
+			if (resetPeerConnections && kickFailed) {
+				// If KICK cannot be written on the existing stream, close the peer
+				// connection so the topology change becomes observable.
 				for (const h of unique) {
 					const stream = this.peers.get(h);
 					if (!stream) continue;
@@ -6282,6 +6298,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 				if (ch.parent && fromHash === ch.parent) {
 					ch.lastParentDataAt = now;
 					ch.receivedAnyParentData = true;
+					ch.parentRepairUnansweredStreak = 0;
 				}
 				const prev = ch.haveByPeer.get(fromHash);
 				if (prev) {
@@ -6471,6 +6488,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 						ch.level = parentLevel + 1;
 						ch.joinedAtLeastOnce = true;
 						ch.lastParentDataAt = Date.now();
+						ch.parentRepairUnansweredStreak = 0;
 						// Treat JOIN_ACCEPT as parent liveness for stale re-parenting:
 						// if callers enable `staleAfterMs`, we should be able to detach even
 						// before the first data message arrives (for example, during churn
@@ -6894,6 +6912,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 								if (ch.parent && fromHash === ch.parent) {
 									ch.lastParentDataAt = Date.now();
 									ch.receivedAnyParentData = true;
+									ch.parentRepairUnansweredStreak = 0;
 								}
 								ch.endSeqExclusive = Math.max(ch.endSeqExclusive, lastSeqExclusive);
 							this.touchPeerHint(ch, fromHash);

--- a/packages/transport/pubsub/test/fanout-tree.spec.ts
+++ b/packages/transport/pubsub/test/fanout-tree.spec.ts
@@ -1692,6 +1692,235 @@ describe("fanout-tree", () => {
 			}
 		});
 
+		it("re-parents after repeated parent data write failures", async function () {
+			this.timeout(30_000);
+			const session: TestSession<{ fanout: FanoutTree }> =
+				await createFanoutTestSession(2);
+
+			try {
+				await session.connect([[session.peers[0], session.peers[1]]]);
+
+				const rootNode = session.peers[0];
+				const root = rootNode.services.fanout;
+				const leaf = session.peers[1].services.fanout;
+				const bootstrapAddrs = rootNode
+					.getMultiaddrs()
+					.filter((x) => !x.getComponents().some((c) => c.code === 290));
+
+				const topic = "write-fail-reparent";
+				const rootId = root.publicKeyHash;
+
+				root.openChannel(topic, rootId, {
+					role: "root",
+					msgRate: 10,
+					msgSize: 64,
+					uploadLimitBps: 1_000_000,
+					maxChildren: 1,
+					allowKick: true,
+					repair: true,
+				});
+
+				await leaf.joinChannel(
+					topic,
+					rootId,
+					{
+						msgRate: 10,
+						msgSize: 64,
+						uploadLimitBps: 0,
+						maxChildren: 0,
+						allowKick: true,
+						repair: true,
+					},
+					{ timeoutMs: 10_000, bootstrap: bootstrapAddrs, retryMs: 50 },
+				);
+
+				expect(leaf.getChannelStats(topic, rootId)?.parent).to.equal(rootId);
+
+				const rootToLeaf = (root as any).peers.get(leaf.publicKeyHash);
+				expect(rootToLeaf).to.exist;
+				let failedWrites = 0;
+				rootToLeaf.write = () => {
+					failedWrites += 1;
+					throw new Error("simulated fanout data write failure");
+				};
+
+				for (let i = 0; i < 3; i++) {
+					// eslint-disable-next-line no-await-in-loop
+					await root.publishData(topic, rootId, new Uint8Array([i]));
+				}
+
+				await waitForResolved(
+					() => {
+						expect(failedWrites).to.be.at.least(3);
+						expect(root.getChannelStats(topic, rootId)?.children).to.equal(0);
+						expect(root.getChannelMetrics(topic, rootId).dataWriteDrops).to.be.at.least(
+							3,
+						);
+					},
+					{ timeout: 10_000, delayInterval: 50 },
+				);
+
+				await waitForResolved(
+					() =>
+						expect(
+							leaf.getChannelMetrics(topic, rootId).reparentDisconnect,
+						).to.be.greaterThan(0),
+					{ timeout: 20_000, delayInterval: 50 },
+				);
+
+				await waitForResolved(
+					() => expect(leaf.getChannelStats(topic, rootId)?.parent).to.equal(rootId),
+					{ timeout: 20_000, delayInterval: 50 },
+				);
+
+				let markerReceived = false;
+				leaf.addEventListener("fanout:data", (ev: any) => {
+					if (ev.detail.topic !== topic) return;
+					if (ev.detail.root !== rootId) return;
+					if ((ev.detail.payload as Uint8Array)?.[0] !== 0x88) return;
+					markerReceived = true;
+				});
+				for (let i = 0; i < 20 && !markerReceived; i++) {
+					// eslint-disable-next-line no-await-in-loop
+					await root.publishData(topic, rootId, new Uint8Array([0x88]));
+					// eslint-disable-next-line no-await-in-loop
+					await delay(100);
+				}
+				expect(markerReceived).to.equal(true);
+			} finally {
+				await session.stop();
+			}
+		});
+
+		it("sends the end watermark to children that join after publishEnd", async function () {
+			this.timeout(30_000);
+			const session: TestSession<{ fanout: FanoutTree }> =
+				await createFanoutTestSession(2);
+
+			try {
+				await session.connect([[session.peers[0], session.peers[1]]]);
+
+				const root = session.peers[0].services.fanout;
+				const leaf = session.peers[1].services.fanout;
+
+				const topic = "late-end";
+				const rootId = root.publicKeyHash;
+				const channelId = root.getChannelId(topic, rootId);
+
+				root.openChannel(topic, rootId, {
+					role: "root",
+					msgRate: 10,
+					msgSize: 64,
+					uploadLimitBps: 1_000_000,
+					maxChildren: 1,
+					repair: true,
+				});
+
+				await root.publishEnd(topic, rootId, 3);
+				expect(
+					(root as any).channelsBySuffixKey.get(channelId.suffixKey)?.endSeqExclusive,
+				).to.equal(3);
+
+				await leaf.joinChannel(
+					topic,
+					rootId,
+					{
+						msgRate: 10,
+						msgSize: 64,
+						uploadLimitBps: 0,
+						maxChildren: 0,
+						repair: true,
+					},
+					{ timeoutMs: 10_000 },
+				);
+
+				await waitForResolved(
+					() => {
+						const leafState = (leaf as any).channelsBySuffixKey.get(
+							channelId.suffixKey,
+						);
+						expect(leafState?.endSeqExclusive).to.equal(3);
+						expect([...leafState.missingSeqs].sort((a, b) => a - b)).to.deep.equal([
+							0, 1, 2,
+						]);
+					},
+					{ timeout: 10_000, delayInterval: 50 },
+				);
+			} finally {
+				await session.stop();
+			}
+		});
+
+		it("retries the end watermark for existing children", async function () {
+			this.timeout(30_000);
+			const session: TestSession<{ fanout: FanoutTree }> =
+				await createFanoutTestSession(2);
+
+			try {
+				await session.connect([[session.peers[0], session.peers[1]]]);
+
+				const root = session.peers[0].services.fanout;
+				const leaf = session.peers[1].services.fanout;
+
+				const topic = "end-heartbeat";
+				const rootId = root.publicKeyHash;
+				const channelId = root.getChannelId(topic, rootId);
+
+				root.openChannel(topic, rootId, {
+					role: "root",
+					msgRate: 10,
+					msgSize: 64,
+					uploadLimitBps: 1_000_000,
+					maxChildren: 1,
+					repair: true,
+				});
+
+				await leaf.joinChannel(
+					topic,
+					rootId,
+					{
+						msgRate: 10,
+						msgSize: 64,
+						uploadLimitBps: 0,
+						maxChildren: 0,
+						repair: true,
+					},
+					{ timeoutMs: 10_000 },
+				);
+
+				await root.publishEnd(topic, rootId, 3);
+				const leafState = (leaf as any).channelsBySuffixKey.get(
+					channelId.suffixKey,
+				);
+				await waitForResolved(
+					() => expect(leafState?.endSeqExclusive).to.equal(3),
+					{ timeout: 10_000, delayInterval: 50 },
+				);
+
+				leafState.endSeqExclusive = -1;
+				leafState.nextExpectedSeq = 0;
+				leafState.missingSeqs.clear();
+
+				const rootState = (root as any).channelsBySuffixKey.get(
+					channelId.suffixKey,
+				);
+				rootState.lastIHaveSentAt = 0;
+				await (root as any).maybeSendIHave(rootState, Date.now() + 5_000);
+
+				await waitForResolved(
+					() => {
+						expect(leafState.endSeqExclusive).to.equal(3);
+						expect([...leafState.missingSeqs].sort((a, b) => a - b)).to.deep.equal([
+							0, 1, 2,
+						]);
+					},
+					{ timeout: 10_000, delayInterval: 50 },
+				);
+			} finally {
+				await session.stop();
+			}
+		});
+
 			it("prevents stable disconnected components when an intermediate relay loses the root", async function () {
 				this.timeout(30_000);
 				const session: TestSession<{ fanout: FanoutTree }> =
@@ -1792,13 +2021,8 @@ describe("fanout-tree", () => {
 							{ timeout: 20_000, delayInterval: 50 },
 						);
 
-					// Relay should kick its children once it loses the rooted route, and leaf should
+					// Relay should detach its children once it loses the rooted route, and leaf should
 					// rejoin directly to the root instead of stabilizing in a disconnected component.
-					await waitForResolved(
-						() =>
-							expect(leaf.getChannelMetrics(topic, rootId).reparentKicked).to.be.greaterThan(0),
-					{ timeout: 20_000, delayInterval: 50 },
-				);
 				await waitForResolved(
 					() => expect(leaf.getChannelStats(topic, rootId)?.parent).to.equal(rootId),
 					{ timeout: 20_000, delayInterval: 50 },

--- a/packages/transport/stream/src/index.ts
+++ b/packages/transport/stream/src/index.ts
@@ -234,6 +234,7 @@ interface OutboundCandidate {
 	pushable: PushableLanes<Uint8Array | Uint8ArrayList>;
 	created: number;
 	bytesDelivered: number;
+	replacementBytesDelivered: number;
 	aborted: boolean;
 	existing: boolean;
 }
@@ -380,6 +381,9 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 	private _addOutboundCandidate(raw: Stream): OutboundCandidate {
 		const existing = this.outboundStreams.find((c) => c.raw === raw);
 		if (existing) return existing;
+		for (const candidate of this.outboundStreams) {
+			candidate.replacementBytesDelivered = 0;
+		}
 		const pushableInst = pushableLanes<Uint8Array | Uint8ArrayList>({
 			lanes: PRIORITY_LANES,
 			maxBufferedBytes: this.outboundQueue?.maxBufferedBytes,
@@ -389,6 +393,7 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 			},
 			onPush: (val) => {
 				candidate.bytesDelivered += val.byteLength;
+				candidate.replacementBytesDelivered += val.byteLength;
 			},
 		});
 		const candidate: OutboundCandidate = {
@@ -396,6 +401,7 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 			pushable: pushableInst,
 			created: Date.now(),
 			bytesDelivered: 0,
+			replacementBytesDelivered: 0,
 			aborted: false,
 			existing: false,
 		};
@@ -817,6 +823,33 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 		this._pruneInboundInactive();
 	}
 
+	public detachInboundStream(
+		record: InboundStreamRecord,
+		reason: Error = new AbortError("Inbound stream ended"),
+	) {
+		const index = this.inboundStreams.indexOf(record);
+		if (index === -1) return false;
+		this.inboundStreams.splice(index, 1);
+		try {
+			record.abortController.abort(reason);
+		} catch {}
+		try {
+			record.raw.abort?.(reason);
+		} catch {}
+		void Promise.resolve(record.raw.close?.()).catch(() => {});
+		if (this.rawInboundStream === record.raw) {
+			const next = this.inboundStreams[0];
+			this.rawInboundStream = next?.raw;
+			this.inboundStream = next?.iterable;
+		}
+		if (this.inboundStreams.length <= 1 && this._inboundPruneTimer) {
+			clearTimeout(this._inboundPruneTimer);
+			this._inboundPruneTimer = undefined;
+		}
+		this.dispatchEvent(new CustomEvent("stream:inbound"));
+		return true;
+	}
+
 	/**
 	 * Attach a raw outbound stream and setup a write stream
 	 */
@@ -838,7 +871,8 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 			if (!candidates.length) return;
 			const now = Date.now();
 			const healthy = candidates.filter(
-				(c: OutboundCandidate) => !c.aborted && c.bytesDelivered > 0,
+				(c: OutboundCandidate) =>
+					!c.aborted && c.replacementBytesDelivered > 0,
 			);
 			let chosen: OutboundCandidate | undefined;
 			if (healthy.length === 0) {
@@ -847,7 +881,7 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 				let bestScore = -Infinity;
 				for (const c of healthy) {
 					const age = now - c.created || 1;
-					const score = c.bytesDelivered / age;
+					const score = c.replacementBytesDelivered / age;
 					if (
 						score > bestScore ||
 						(score === bestScore && chosen && c.created > chosen.created)
@@ -2108,6 +2142,7 @@ export abstract class DirectStream<
 		record: InboundStreamRecord,
 		peerStreams: PeerStreams,
 	) {
+		let failed = false;
 		try {
 			for await (const data of record.iterable) {
 				const now = Date.now();
@@ -2117,6 +2152,7 @@ export abstract class DirectStream<
 				this.processRpc(peerId, peerStreams, data).catch((e) => logError(e));
 			}
 		} catch (err: any) {
+			failed = true;
 			if (err?.code === "ERR_STREAM_RESET") {
 				// only send stream reset messages to info
 				logger(
@@ -2134,6 +2170,14 @@ export abstract class DirectStream<
 				);
 			}
 			this.onPeerDisconnected(peerStreams.peerId);
+		} finally {
+			const removed = peerStreams.detachInboundStream(
+				record,
+				new AbortError("Inbound stream reader ended"),
+			);
+			if (removed && !failed && !peerStreams.isReadable) {
+				void this.onPeerDisconnected(peerStreams.peerId).catch(logError);
+			}
 		}
 	}
 

--- a/packages/transport/stream/src/index.ts
+++ b/packages/transport/stream/src/index.ts
@@ -234,7 +234,6 @@ interface OutboundCandidate {
 	pushable: PushableLanes<Uint8Array | Uint8ArrayList>;
 	created: number;
 	bytesDelivered: number;
-	replacementBytesDelivered: number;
 	aborted: boolean;
 	existing: boolean;
 }
@@ -381,9 +380,6 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 	private _addOutboundCandidate(raw: Stream): OutboundCandidate {
 		const existing = this.outboundStreams.find((c) => c.raw === raw);
 		if (existing) return existing;
-		for (const candidate of this.outboundStreams) {
-			candidate.replacementBytesDelivered = 0;
-		}
 		const pushableInst = pushableLanes<Uint8Array | Uint8ArrayList>({
 			lanes: PRIORITY_LANES,
 			maxBufferedBytes: this.outboundQueue?.maxBufferedBytes,
@@ -393,7 +389,6 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 			},
 			onPush: (val) => {
 				candidate.bytesDelivered += val.byteLength;
-				candidate.replacementBytesDelivered += val.byteLength;
 			},
 		});
 		const candidate: OutboundCandidate = {
@@ -401,7 +396,6 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 			pushable: pushableInst,
 			created: Date.now(),
 			bytesDelivered: 0,
-			replacementBytesDelivered: 0,
 			aborted: false,
 			existing: false,
 		};
@@ -826,6 +820,7 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 	public detachInboundStream(
 		record: InboundStreamRecord,
 		reason: Error = new AbortError("Inbound stream ended"),
+		options?: { closeRaw?: boolean },
 	) {
 		const index = this.inboundStreams.indexOf(record);
 		if (index === -1) return false;
@@ -833,10 +828,12 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 		try {
 			record.abortController.abort(reason);
 		} catch {}
-		try {
-			record.raw.abort?.(reason);
-		} catch {}
-		void Promise.resolve(record.raw.close?.()).catch(() => {});
+		if (options?.closeRaw !== false) {
+			try {
+				record.raw.abort?.(reason);
+			} catch {}
+			void Promise.resolve(record.raw.close?.()).catch(() => {});
+		}
 		if (this.rawInboundStream === record.raw) {
 			const next = this.inboundStreams[0];
 			this.rawInboundStream = next?.raw;
@@ -871,8 +868,7 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 			if (!candidates.length) return;
 			const now = Date.now();
 			const healthy = candidates.filter(
-				(c: OutboundCandidate) =>
-					!c.aborted && c.replacementBytesDelivered > 0,
+				(c: OutboundCandidate) => !c.aborted && c.bytesDelivered > 0,
 			);
 			let chosen: OutboundCandidate | undefined;
 			if (healthy.length === 0) {
@@ -881,7 +877,7 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 				let bestScore = -Infinity;
 				for (const c of healthy) {
 					const age = now - c.created || 1;
-					const score = c.replacementBytesDelivered / age;
+					const score = c.bytesDelivered / age;
 					if (
 						score > bestScore ||
 						(score === bestScore && chosen && c.created > chosen.created)
@@ -2174,6 +2170,7 @@ export abstract class DirectStream<
 			const removed = peerStreams.detachInboundStream(
 				record,
 				new AbortError("Inbound stream reader ended"),
+				{ closeRaw: failed },
 			);
 			if (removed && !failed && !peerStreams.isReadable) {
 				void this.onPeerDisconnected(peerStreams.peerId).catch(logError);

--- a/packages/transport/stream/test/stream.spec.ts
+++ b/packages/transport/stream/test/stream.spec.ts
@@ -4606,8 +4606,8 @@ describe("start/stop", () => {
 
 			expect(ps.inboundStreams.includes(record)).to.equal(false);
 			expect(ps.inboundStreams.length).to.equal(firstCount);
-			expect(closed.abort).to.equal(true);
-			expect(closed.close).to.equal(true);
+			expect(closed.abort).to.equal(false);
+			expect(closed.close).to.equal(false);
 		});
 
 		it("evicts oldest inactive when exceeding max inbound streams", async () => {
@@ -4672,7 +4672,7 @@ describe("start/stop", () => {
 		).to.be.true;
 	});
 
-	it("does not let stale historical outbound bytes beat a fresh candidate", async () => {
+	it("does not let an unproven fresh outbound beat a working candidate", async () => {
 		session = await connected(2, {
 			transports: [tcp(), webSockets()],
 			services: { directstream: (c) => new TestDirectStream(c) },
@@ -4704,10 +4704,10 @@ describe("start/stop", () => {
 
 		ps.forcePruneOutbound();
 		expect(ps.rawOutboundStreams.length).to.equal(1);
-		expect(ps.rawOutboundStreams[0].id).to.equal(fresh.id);
+		expect(ps.rawOutboundStreams[0].id).to.equal(first!.id);
 	});
 
-	it("removes failing outbound on partial write failure", async () => {
+		it("removes failing outbound on partial write failure", async () => {
 		session = await connected(2, {
 			transports: [tcp(), webSockets()],
 			services: { directstream: (c) => new TestDirectStream(c) },

--- a/packages/transport/stream/test/stream.spec.ts
+++ b/packages/transport/stream/test/stream.spec.ts
@@ -4571,10 +4571,49 @@ describe("start/stop", () => {
 			expect(recs[0].lastActivity).to.be.at.least(recs[1].lastActivity);
 		});
 
-	it("evicts oldest inactive when exceeding max inbound streams", async () => {
-		const MAX = 3;
-		session = await connected(2, {
-			services: {
+		it("removes inbound stream records when their reader ends", async () => {
+			session = await connected(2, {
+				services: {
+					directstream: (c) =>
+						new TestDirectStream(c, {
+							connectionManager: false,
+						}),
+				},
+			});
+			await waitForNeighbour(stream(session, 0), stream(session, 1));
+			const ps = stream(session, 0).peers.get(stream(session, 1).publicKeyHash)!;
+			const firstCount = ps.inboundStreams.length;
+			const closed = { abort: false, close: false };
+			const endingInbound: any = {
+				id: ps.rawInboundStream!.id + "-ended",
+				protocol: ps.protocol,
+				[Symbol.asyncIterator]: async function* () {},
+				abort: () => {
+					closed.abort = true;
+				},
+				close: async () => {
+					closed.close = true;
+				},
+			};
+			const record = ps.attachInboundStream(endingInbound as any);
+			expect(ps.inboundStreams.length).to.equal(firstCount + 1);
+
+			await stream(session, 0).processMessages(
+				stream(session, 1).publicKey,
+				record,
+				ps,
+			);
+
+			expect(ps.inboundStreams.includes(record)).to.equal(false);
+			expect(ps.inboundStreams.length).to.equal(firstCount);
+			expect(closed.abort).to.equal(true);
+			expect(closed.close).to.equal(true);
+		});
+
+		it("evicts oldest inactive when exceeding max inbound streams", async () => {
+			const MAX = 3;
+			session = await connected(2, {
+				services: {
 				directstream: (c) =>
 					new TestDirectStream(c, {
 						maxInboundStreams: MAX,
@@ -4631,6 +4670,41 @@ describe("start/stop", () => {
 			ps.rawOutboundStreams[0].id === first!.id ||
 				ps.rawOutboundStreams[0].id === fake.id,
 		).to.be.true;
+	});
+
+	it("does not let stale historical outbound bytes beat a fresh candidate", async () => {
+		session = await connected(2, {
+			transports: [tcp(), webSockets()],
+			services: { directstream: (c) => new TestDirectStream(c) },
+		});
+		await waitForNeighbour(stream(session, 0), stream(session, 1));
+		const peerHash = stream(session, 1).publicKeyHash;
+		const ps = stream(session, 0).peers.get(peerHash)!;
+		const first = ps.rawOutboundStreams[0];
+		expect(first).to.exist;
+
+		await stream(session, 0).publish(new Uint8Array([1]));
+		await waitForResolved(() => {
+			const firstCandidate = (ps as any).outboundStreams.find(
+				(c: any) => c.raw.id === first!.id,
+			);
+			expect(firstCandidate?.bytesDelivered).to.be.greaterThan(0);
+		});
+
+		const fresh: any = {
+			id: first!.id + "-fresh",
+			source: (async function* () {})(),
+			sink: async () => {},
+			protocol: first!.protocol,
+			send: () => true,
+			abort: () => {},
+			close: async () => {},
+		};
+		await ps.attachOutboundStream(fresh);
+
+		ps.forcePruneOutbound();
+		expect(ps.rawOutboundStreams.length).to.equal(1);
+		expect(ps.rawOutboundStreams[0].id).to.equal(fresh.id);
 	});
 
 	it("removes failing outbound on partial write failure", async () => {


### PR DESCRIPTION
Fixes #971.

## Summary
- Remove ended inbound stream records so stream readability cannot stay true after the reader exits.
- Make outbound replacement pruning judge candidates by bytes delivered during the replacement window, not stale historical bytes from the old stream.
- Make fanout KICK topology changes observable by closing the peer connection after best-effort KICK, because KICK can be sent over the same one-way-broken link.
- Persist and replay fanout END watermarks, including periodic END heartbeats to children, so late/rejoining children can discover tail gaps and repair.
- Enable conservative stale-parent detection for repair-enabled joins and treat parent IHAVE/END as parent liveness.

## Validation
- `pnpm --filter @peerbit/stream build`
- `pnpm --filter @peerbit/pubsub build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/stream -- -t node --no-build --grep "removes inbound stream records when their reader ends|does not let stale historical outbound bytes|promotes only healthy outbound after grace|removes failing outbound on partial write failure|uses multiple outbounds during grace period|replaces stale outbound stream direct attach"`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/transport/pubsub -- -t node --no-build --grep "re-parents when no data arrives within staleAfterMs|keeps rejoining after the initial join timeout has elapsed|re-parents after repeated parent data write failures|sends the end watermark|retries the end watermark|prevents stable disconnected components"`
- `pnpm -C packages/transport/pubsub run bench -- fanout-tree-sim --preset scale-5k --nodes 300 --subscribers 288 --seed 1 --timeoutMs 240000 --assertMinDeadlineDeliveryPct 0 --assertMaxControlBpp 0 --assertMaxTrackerBpp 0 --assertMaxRepairBpp 0 --assertMaxOverheadFactor 0`
  - Result: `delivered=2880/2880 (100.00%)` with the delivery assertion still active.

## Notes
This PR is scoped to the delivery/liveness correctness failure. The 300-node scale-5k override still shows deadline and control-overhead tuning work outside this fix, so those assertions were disabled in the focused validation run.
