### PR TITLE
Fix shared-log observer unreplicate pruning

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2153,6 +2153,12 @@ export class SharedLog<
 			this._isReplicating = false;
 			this._isAdaptiveReplicating = false;
 			await this.removeReplicator(this.node.identity.publicKey);
+			await this.pruneIndexedEntriesNoLongerLed({
+				useDefaultRoleAge: true,
+			});
+			await this.pruneCurrentHeadsNoLongerLed({
+				useDefaultRoleAge: true,
+			});
 			return;
 		}
 

--- a/packages/programs/data/shared-log/test/sharding.spec.ts
+++ b/packages/programs/data/shared-log/test/sharding.spec.ts
@@ -2373,8 +2373,7 @@ testSetups.forEach((setup) => {
 				db1 = undefined as any;
 			});
 
-			it("drops when no longer replicating as observer", async () => {
-				let COUNT = 10;
+			const openFullReplicatorTriad = async (count: number) => {
 				db1 = await session.peers[0].open(new EventStore<string, any>(), {
 					args: {
 						replicate: {
@@ -2397,11 +2396,11 @@ testSetups.forEach((setup) => {
 					},
 				);
 
-				for (let i = 0; i < COUNT; i++) {
+				for (let i = 0; i < count; i++) {
 					await db1.add(toBase64(new Uint8Array([i])), { meta: { next: [] } });
 				}
 
-				await waitForResolved(() => expect(db2.log.log.length).equal(COUNT));
+				await waitForResolved(() => expect(db2.log.log.length).equal(count));
 
 				db3 = await EventStore.open<EventStore<string, any>>(
 					db1.address!,
@@ -2430,11 +2429,35 @@ testSetups.forEach((setup) => {
 						timeout: 30_000,
 					}),
 				]);
+			};
+
+			it("drops when no longer replicating as observer", async () => {
+				const COUNT = 10;
+				await openFullReplicatorTriad(COUNT);
 
 				await db2.log.replicate(false);
 
 				await waitForResolved(() => expect(db3.log.log.length).equal(COUNT));
 				await waitForResolved(() => expect(db2.log.log.length).equal(0));
+			});
+
+			it("drops observer entries when unreplicate rebalance debounce is delayed", async () => {
+				const COUNT = 10;
+				await openFullReplicatorTriad(COUNT);
+
+				const replicationChangeAdd = sinon
+					.stub((db2.log as any).replicationChangeDebounceFn, "add")
+					.callsFake(() => undefined);
+
+				try {
+					await db2.log.replicate(false);
+					expect(replicationChangeAdd.callCount).to.be.greaterThan(0);
+
+					await waitForResolved(() => expect(db3.log.log.length).equal(COUNT));
+					await waitForResolved(() => expect(db2.log.log.length).equal(0));
+				} finally {
+					replicationChangeAdd.restore();
+				}
 			});
 
 			it("drops when no longer replicating with factor 0", async () => {


### PR DESCRIPTION
## Summary

- prune already-indexed entries and current heads immediately after local `replicate(false)` removes this peer's replication ranges
- keep the actual deletion path checked-prune gated; this only starts candidate discovery instead of waiting for the debounced rebalance path
- add a regression test that simulates a delayed/no-op `replicationChangeDebounceFn.add` and verifies observer entries still drain

## Context

This targets the remaining `test:ci:part-7c` observer-prune flake seen on master after #973 merged.

Observed master CI signal:

- run: https://github.com/dao-xyz/peerbit/actions/runs/27528292679
- attempt 1 failed `test:ci:part-7c`
- failing test: `u64-iblt sharding drops when no longer replicating as observer`
- failure: `AssertionError: expected 10 to equal +0`
- failed-only rerun attempt 2 passed

The failure pattern suggests local unreplicate could remove the local replication range, but rely on the delayed replication-change rebalance machinery to discover locally resident entries that are now only observer copies. Under CI timing, the test could reach the assertion while those entries were still present.

## Validation

- `git diff --check`
- `pnpm --filter @peerbit/shared-log run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --no-build --grep "drops .*observer"` -> 4 passing
- `pnpm run test:ci:part-7c` -> 111 passing, 2 pending
