### PR TITLE
Fix shared-log local unreplicate handoff retry

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2153,6 +2153,13 @@ export class SharedLog<
 			this._isReplicating = false;
 			this._isAdaptiveReplicating = false;
 			await this.removeReplicator(this.node.identity.publicKey);
+			try {
+				await this.replicationChangeDebounceFn.flush?.();
+			} catch (error: any) {
+				if (!isNotStartedError(error)) {
+					throw error;
+				}
+			}
 			await this.pruneIndexedEntriesNoLongerLed({
 				useDefaultRoleAge: true,
 			});
@@ -7662,7 +7669,7 @@ export class SharedLog<
 		// On removed ranges (peer leaves / shrink), gid-level history can hide
 		// per-entry gaps. Force a fresh delivery pass for reassigned entries.
 		const forceFreshDelivery = changes.some(
-			(change) => change.type === "removed" && change.range.hash !== selfHash,
+			(change) => change.type === "removed",
 		);
 		const gidPeersHistorySnapshot = new Map<string, Set<string> | undefined>();
 		const dedupeCutoff = Date.now() - RECENT_REPAIR_DISPATCH_TTL_MS;

--- a/packages/programs/data/shared-log/test/sharding.spec.ts
+++ b/packages/programs/data/shared-log/test/sharding.spec.ts
@@ -1147,9 +1147,9 @@ testSetups.forEach((setup) => {
 					db3.log.rebalanceAll({ clearCache: true }),
 				]);
 				await waitForParticipationToSettle(db1, db2, db3);
-				// The contract here is the settled replica floor and bounded split after the join,
-				// not that every prune/repair timer has gone fully idle. Waiting on full internal
-				// quiescence was the source of CI-only 5 minute hangs on slower runners.
+				await waitForDistributionQuiesced(db1, db2, db3);
+				// The final bound is meaningful after the ownership, checked-prune, and
+				// repair work kicked off by the join has drained.
 				await waitForResolved(
 					async () => {
 						await checkBounded(
@@ -2445,6 +2445,10 @@ testSetups.forEach((setup) => {
 				const COUNT = 10;
 				await openFullReplicatorTriad(COUNT);
 
+				await waitForResolved(() => expect(db3.log.log.length).equal(COUNT), {
+					timeout: 30_000,
+				});
+				await (db2.log as any).replicationChangeDebounceFn.flush?.();
 				const replicationChangeAdd = sinon
 					.stub((db2.log as any).replicationChangeDebounceFn, "add")
 					.callsFake(() => undefined);
@@ -2453,10 +2457,59 @@ testSetups.forEach((setup) => {
 					await db2.log.replicate(false);
 					expect(replicationChangeAdd.callCount).to.be.greaterThan(0);
 
-					await waitForResolved(() => expect(db3.log.log.length).equal(COUNT));
-					await waitForResolved(() => expect(db2.log.log.length).equal(0));
+					await waitForResolved(() => expect(db3.log.log.length).equal(COUNT), {
+						timeout: 30_000,
+					});
+					await waitForPruneQuiesced(db2);
+					await waitForResolved(() => expect(db2.log.log.length).equal(0), {
+						timeout: 30_000,
+					});
+				} catch (error) {
+					await printShardingPruneDiagnostics(
+						"observer-delayed-unreplicate",
+						db1,
+						db2,
+						db3,
+					);
+					await dbgLogs([db1.log, db2.log, db3.log]);
+					throw error;
 				} finally {
 					replicationChangeAdd.restore();
+				}
+			});
+
+			it("retries observer handoff when initial unreplicate delivery is dropped", async () => {
+				const COUNT = 10;
+				await openFullReplicatorTriad(COUNT);
+
+				await (db2.log as any).replicationChangeDebounceFn.flush?.();
+				const db3Hash = db3.log.node.identity.publicKey.hashcode();
+				const log = db2.log as any;
+				const originalDispatch = log.dispatchMaybeMissingEntries.bind(log);
+				let droppedInitialHandoff = false;
+				const dispatchMaybeMissingEntries = sinon
+					.stub(log, "dispatchMaybeMissingEntries")
+					.callsFake((...args: unknown[]) => {
+						const [target, entries, options] = args as [string, any, any];
+						if (!droppedInitialHandoff && target === db3Hash) {
+							droppedInitialHandoff = true;
+							return;
+						}
+						return originalDispatch(target, entries, options);
+					});
+
+				try {
+					await db2.log.replicate(false);
+					expect(droppedInitialHandoff).to.be.true;
+
+					await waitForResolved(() => expect(db3.log.log.length).equal(COUNT), {
+						timeout: 30_000,
+					});
+					await waitForResolved(() => expect(db2.log.log.length).equal(0), {
+						timeout: 30_000,
+					});
+				} finally {
+					dispatchMaybeMissingEntries.restore();
 				}
 			});
 


### PR DESCRIPTION
## Summary

- flush local replication-change work during explicit `replicate(false)` before the final prune scan
- treat local self-range removals as churn so reassigned entries get fresh delivery and repair retry treatment
- add a regression that drops the initial unreplicate handoff delivery and verifies the replacement replica still receives entries before the old observer prunes
- tighten shared-log sharding assertions so final bounded-layout checks wait for prune/repair quiescence, and the delayed observer debounce regression first establishes that the replacement peer already has the entries

## Context

Follow-up to #974. After #974 merged, master CI run https://github.com/dao-xyz/peerbit/actions/runs/27537118794 failed `test:ci:part-7c` in:

`u64-iblt sharding drops when no longer replicating as observer`

Failure:

`AssertionError: expected 10 to equal +0` at `packages/programs/data/shared-log/test/sharding.spec.ts:2441`

The new delayed-debounce regression from #974 passed in that same job, so the missing case was not just delayed prune discovery. The failing shape is: local unreplicate can start prune/handoff while the replacement replica is still catching up, and local self-removal was not using the same fresh churn repair/retry path as remote leave/shrink churn.

While validating this PR, the branch push run https://github.com/dao-xyz/peerbit/actions/runs/27539341911 also exposed a separate `test:ci:part-7e` timing failure in:

`u32-simple sharding write while joining peers`

Failure:

`Error: Log did not conform to upper bound length of 90 got 98`

That run showed the overfull peer already had prunable entries, so the test was asserting final bounded layout before checked-prune/repair work had drained. The test now waits for distribution quiescence before the final bound assertion. The delayed observer debounce test also now makes its intended precondition explicit: if the rebalance debounce is suppressed, the replacement peer must already have the entries; the separate handoff-drop regression covers the missing-delivery case.

## Validation

- `git diff --check`
- `pnpm --filter @peerbit/shared-log run build`
- `node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --no-build --grep "drops observer entries when unreplicate rebalance debounce is delayed"` -> 2 passing
- `pnpm run test:ci:part-7e` -> 26 passing, 3 pending
- `pnpm run test:ci:part-7c` -> 112 passing, 2 pending