### PR TITLE
Fix shared-log authoritative join repair hints

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -620,6 +620,11 @@ const createRepairActiveTargetsByMode = () =>
 		REPAIR_DISPATCH_MODES.map((mode) => [mode, new Set()]),
 	);
 
+const createRepairFrontierBypassKnownPeersByMode = () =>
+	new Map<RepairDispatchMode, Set<string>>(
+		REPAIR_DISPATCH_MODES.map((mode) => [mode, new Set()]),
+	);
+
 const getRepairRetrySchedule = (mode: RepairDispatchMode) => {
 	switch (mode) {
 		case "join-warmup":
@@ -906,6 +911,10 @@ export class SharedLog<
 		Map<string, Map<string, EntryReplicated<R>>>
 	>;
 	private _repairFrontierActiveTargetsByMode!: Map<RepairDispatchMode, Set<string>>;
+	private _repairFrontierBypassKnownPeersByMode!: Map<
+		RepairDispatchMode,
+		Set<string>
+	>;
 	private _repairSweepOptimisticGidPeersPending!: Map<string, Map<string, number>>;
 	private _entryKnownPeers!: Map<string, Set<string>>;
 	private _entryKnownPeerObservedAt!: Map<string, Map<string, number>>;
@@ -2859,6 +2868,17 @@ export class SharedLog<
 		return mode !== "join-warmup";
 	}
 
+	private isReceiptDrivenRepairMode(mode: RepairDispatchMode) {
+		return mode === "join-authoritative" || mode === "churn";
+	}
+
+	private shouldBypassKnownPeerHints(
+		mode: RepairDispatchMode,
+		bypassKnownPeerHints?: boolean,
+	) {
+		return mode === "churn" || bypassKnownPeerHints === true;
+	}
+
 	private async sleepTracked(delayMs: number) {
 		if (delayMs <= 0) {
 			return;
@@ -2877,6 +2897,7 @@ export class SharedLog<
 		mode: RepairDispatchMode,
 		target: string,
 		entries: Map<string, EntryReplicated<R>>,
+		options?: { bypassKnownPeerHints?: boolean },
 	) {
 		let targets = this._repairFrontierByMode.get(mode);
 		if (!targets) {
@@ -2890,6 +2911,9 @@ export class SharedLog<
 		}
 		for (const [hash, entry] of entries) {
 			pending.set(hash, entry);
+		}
+		if (options?.bypassKnownPeerHints === true) {
+			this._repairFrontierBypassKnownPeersByMode.get(mode)?.add(target);
 		}
 	}
 
@@ -2908,6 +2932,7 @@ export class SharedLog<
 			}
 			if (pending.size === 0) {
 				this._repairFrontierByMode.get(mode)?.delete(target);
+				this._repairFrontierBypassKnownPeersByMode.get(mode)?.delete(target);
 			}
 		}
 	}
@@ -2947,6 +2972,7 @@ export class SharedLog<
 		for (const mode of REPAIR_DISPATCH_MODES) {
 			this._repairFrontierByMode.get(mode)?.delete(target);
 			this._repairFrontierActiveTargetsByMode.get(mode)?.delete(target);
+			this._repairFrontierBypassKnownPeersByMode.get(mode)?.delete(target);
 		}
 	}
 
@@ -3031,6 +3057,7 @@ export class SharedLog<
 			mode: RepairDispatchMode;
 			transport: RepairTransportMode;
 			bypassRecentDedupe?: boolean;
+			bypassKnownPeerHints?: boolean;
 		},
 	) {
 		if (entries.size === 0) {
@@ -3079,6 +3106,10 @@ export class SharedLog<
 		} else {
 			bucket.ratelessFirstPasses += 1;
 		}
+		const bypassKnownPeerHints = this.shouldBypassKnownPeerHints(
+			options.mode,
+			options.bypassKnownPeerHints,
+		);
 
 		await Promise.resolve(
 			this.sendRepairEntriesWithTransport(
@@ -3086,8 +3117,8 @@ export class SharedLog<
 				filteredEntries,
 				options.transport,
 				{
-					bypassKnownPeers: options.mode === "churn",
-					bypassRecentKnownPeers: options.mode === "churn",
+					bypassKnownPeers: bypassKnownPeerHints,
+					bypassRecentKnownPeers: bypassKnownPeerHints,
 				},
 			),
 		).catch((error: any) => logger.error(error));
@@ -3122,6 +3153,9 @@ export class SharedLog<
 					}
 					const pending = this._repairFrontierByMode.get(mode)?.get(target);
 					if (!pending || pending.size === 0) {
+						this._repairFrontierBypassKnownPeersByMode
+							.get(mode)
+							?.delete(target);
 						return;
 					}
 
@@ -3139,6 +3173,10 @@ export class SharedLog<
 						mode,
 						transport: getRepairTransportForAttempt(mode, attemptIndex),
 						bypassRecentDedupe: true,
+						bypassKnownPeerHints:
+							this._repairFrontierBypassKnownPeersByMode
+								.get(mode)
+								?.has(target) === true,
 					});
 
 					const remaining = this._repairFrontierByMode.get(mode)?.get(target);
@@ -3216,6 +3254,7 @@ export class SharedLog<
 		options: {
 			mode: RepairDispatchMode;
 			bypassRecentDedupe?: boolean;
+			bypassKnownPeerHints?: boolean;
 			retryScheduleMs?: number[];
 		},
 	) {
@@ -3224,7 +3263,12 @@ export class SharedLog<
 		}
 
 		if (this.isFrontierTrackedRepairMode(options.mode)) {
-			this.queueRepairFrontierEntries(options.mode, target, entries);
+			this.queueRepairFrontierEntries(options.mode, target, entries, {
+				bypassKnownPeerHints: this.shouldBypassKnownPeerHints(
+					options.mode,
+					options.bypassKnownPeerHints,
+				),
+			});
 			this.ensureRepairFrontierRunner(
 				options.mode,
 				target,
@@ -3290,6 +3334,10 @@ export class SharedLog<
 			} else {
 				bucket.ratelessFirstPasses += 1;
 			}
+			const bypassKnownPeerHints = this.shouldBypassKnownPeerHints(
+				options.mode,
+				options.bypassKnownPeerHints,
+			);
 
 			return Promise.resolve(
 				this.sendRepairEntriesWithTransport(
@@ -3297,8 +3345,8 @@ export class SharedLog<
 					filteredEntries,
 					transport,
 					{
-						bypassKnownPeers: options.mode === "churn",
-						bypassRecentKnownPeers: options.mode === "churn",
+						bypassKnownPeers: bypassKnownPeerHints,
+						bypassRecentKnownPeers: bypassKnownPeerHints,
 					},
 				),
 			).catch((error: any) => logger.error(error));
@@ -3474,6 +3522,7 @@ export class SharedLog<
 					}
 					this.dispatchMaybeMissingEntries(target, entries, {
 						bypassRecentDedupe: true,
+						bypassKnownPeerHints: this.isReceiptDrivenRepairMode(mode),
 						mode,
 					});
 					targets?.delete(target);
@@ -3537,9 +3586,14 @@ export class SharedLog<
 								if (!modePeers || modePeers.size === 0) {
 									continue;
 								}
+								const bypassKnownPeerHints =
+									this.isReceiptDrivenRepairMode(mode);
 								const optimisticPeers = optimisticGidPeersByMode.get(mode)?.get(gid);
 								for (const peer of modePeers) {
-									if (this.isEntryKnownByPeer(entryReplicated.hash, peer)) {
+									if (
+										!bypassKnownPeerHints &&
+										this.isEntryKnownByPeer(entryReplicated.hash, peer)
+									) {
 										continue;
 									}
 									const wasOptimisticallyAssigned =
@@ -4164,6 +4218,8 @@ export class SharedLog<
 			Map<string, Map<string, EntryReplicated<R>>>
 		>;
 		this._repairFrontierActiveTargetsByMode = createRepairActiveTargetsByMode();
+		this._repairFrontierBypassKnownPeersByMode =
+			createRepairFrontierBypassKnownPeersByMode();
 		this._repairSweepOptimisticGidPeersPending = new Map();
 		this._entryKnownPeers = new Map();
 		this._entryKnownPeerObservedAt = new Map();
@@ -5288,6 +5344,9 @@ export class SharedLog<
 			targets.clear();
 		}
 		for (const targets of this._repairFrontierActiveTargetsByMode.values()) {
+			targets.clear();
+		}
+		for (const targets of this._repairFrontierBypassKnownPeersByMode.values()) {
 			targets.clear();
 		}
 		if (this._appendBackfillTimer) {
@@ -7762,6 +7821,9 @@ export class SharedLog<
 							: "join-authoritative";
 					this.dispatchMaybeMissingEntries(target, entries, {
 						bypassRecentDedupe: isWarmupTarget || forceFreshDelivery,
+						bypassKnownPeerHints:
+							forceFreshDelivery ||
+							(mode === "join-authoritative" && addedPeers.has(target)),
 						mode,
 						retryScheduleMs:
 							mode === "join-warmup"

--- a/packages/programs/data/shared-log/test/replication.spec.ts
+++ b/packages/programs/data/shared-log/test/replication.spec.ts
@@ -2783,6 +2783,108 @@ testSetups.forEach((setup) => {
 							},
 						);
 
+						it("control per commmit put before join uses receipts instead of known-peer hints for authoritative repair", async () => {
+							const entryCount = 12;
+							let dispatchStub: sinon.SinonStub | undefined;
+							let pushStub: sinon.SinonStub | undefined;
+							let sendNowStub: sinon.SinonStub | undefined;
+
+							try {
+								await init({
+									min: 1,
+									beforeOther: async () => {
+										const value = "hello";
+										for (let i = 0; i < entryCount; i++) {
+											await db1.add(value, {
+												replicas: new AbsoluteReplicas(3),
+												meta: { next: [] },
+											});
+										}
+									},
+									beforeOpenJoiners: () => {
+										const originalDispatch = (db1.log as any).dispatchMaybeMissingEntries.bind(db1.log);
+										dispatchStub = sinon
+											.stub(db1.log as any, "dispatchMaybeMissingEntries")
+											.callsFake((...args: any[]) => {
+												const [_target, _entries, options] = args as [string, Map<string, any>, { mode?: string }];
+												if (
+													options?.mode === "join-warmup" ||
+													options?.mode === "join-authoritative"
+												) {
+													return;
+												}
+												return originalDispatch(...args);
+											});
+									},
+								});
+
+								await waitForDb1Replicators();
+								dispatchStub?.restore();
+								dispatchStub = undefined;
+
+								const target =
+									session.peers[1].identity.publicKey.hashcode();
+								const log = db1.log as any;
+								const entries = new Map(
+									(await db1.log.log.toArray()).map((entry) => [
+										entry.hash,
+										entry,
+									]),
+								);
+								expect(entries.size).equal(entryCount);
+
+								// A local known-peer hint is only an optimization. Authoritative
+								// join repair is receipt-driven and must still send until the target
+								// confirms the hashes.
+								log.markEntriesKnownByPeer(entries.keys(), target);
+
+								const pushed = new Set<string>();
+								pushStub = sinon
+									.stub(log, "pushRepairEntries")
+									.callsFake(async (...args: any[]) => {
+										const [sentTarget, sentEntries] = args as [
+											string,
+											Map<string, any>,
+										];
+										if (sentTarget !== target) {
+											return;
+										}
+										for (const hash of sentEntries.keys()) {
+											pushed.add(hash);
+										}
+									});
+								await log.sendMaybeMissingEntriesNow(target, entries, {
+									bypassKnownPeerHints: true,
+									bypassRecentDedupe: true,
+									mode: "join-authoritative",
+									transport: "simple",
+								});
+								expect(pushed.size).equal(entryCount);
+								pushStub.restore();
+								pushStub = undefined;
+
+								const frontier = log._repairFrontierByMode.get(
+									"join-authoritative",
+								);
+								frontier.delete(target);
+								sendNowStub = sinon
+									.stub(log, "sendMaybeMissingEntriesNow")
+									.callsFake(() => Promise.resolve());
+								log.scheduleRepairSweep({
+									mode: "join-authoritative",
+									peers: new Set([target]),
+								});
+
+								await waitForResolved(async () => {
+									expect(frontier.get(target)?.size ?? 0).equal(entryCount);
+								}, commitReplicationWait);
+							} finally {
+								sendNowStub?.restore();
+								pushStub?.restore();
+								dispatchStub?.restore();
+							}
+						});
+
 						it("control per commmit put before join keeps the full authoritative repair frontier across sweep flushes", async () => {
 							const entryCount = 40;
 							const repairSweepTargetBufferSize = 8;

--- a/packages/programs/data/shared-log/test/sharding.spec.ts
+++ b/packages/programs/data/shared-log/test/sharding.spec.ts
@@ -2435,10 +2435,21 @@ testSetups.forEach((setup) => {
 				const COUNT = 10;
 				await openFullReplicatorTriad(COUNT);
 
-				await db2.log.replicate(false);
+				try {
+					await db2.log.replicate(false);
 
-				await waitForResolved(() => expect(db3.log.log.length).equal(COUNT));
-				await waitForResolved(() => expect(db2.log.log.length).equal(0));
+					await waitForResolved(() => expect(db3.log.log.length).equal(COUNT), {
+						timeout: 30_000,
+					});
+					await waitForPruneQuiesced(db2);
+					await waitForResolved(() => expect(db2.log.log.length).equal(0), {
+						timeout: 30_000,
+					});
+				} catch (error) {
+					await printShardingPruneDiagnostics("observer-unreplicate", db1, db2, db3);
+					await dbgLogs([db1.log, db2.log, db3.log]);
+					throw error;
+				}
 			});
 
 			it("drops observer entries when unreplicate rebalance debounce is delayed", async () => {


### PR DESCRIPTION
## Summary
- make receipt-driven repair frontiers bypass stale known-peer hints only for targets that must be confirmed by receipt
- keep authoritative repair sweeps from skipping entries solely because local known-peer state says the joiner may have them
- preserve known-peer suppression for existing peers so join repair does not resend data back to peers that already confirmed it
- add a regression covering stale known-peer hints for authoritative pre-join repair
- align the older observer-unreplicate sharding assertion with the checked-prune drain point already used by the stricter neighboring observer tests

## Context
After #975 merged, master CI run 27542881140 still failed `test:ci:part-7e` on `u32-simple sharding write while joining peers` with an underfill (`expected >= 50`, got 45). The failure shape points at join repair liveness: a donor had extra/prunable entries, while the joiner stayed below the lower bound.

The bug is that authoritative join repair is receipt-driven, but parts of the repair path still trusted local known-peer hints. A stale hint could suppress or clear repair work before the target actually confirmed receipt.

The first #976 push CI also exposed an older `u64-iblt sharding drops when no longer replicating as observer` timing failure in `part-7c`: the simple observer test used the default 10s `waitForResolved`, while the adjacent observer tests already wait for checked-prune quiescence. This PR now uses the same drain point there.

A later push showed why the bypass must be targeted: applying it to every `join-authoritative` send caused `u64-iblt redundancy only sends entries once, 3 peers` to receive duplicate heads on an existing peer. The final version stores the bypass flag on the repair frontier target, preserving the redundancy contract for already-known peers.

## Validation
- `PATH=/tmp/node22/node-v22.22.3-darwin-arm64/bin:$PATH pnpm --filter @peerbit/shared-log run build`
- `PATH=/tmp/node22/node-v22.22.3-darwin-arm64/bin:$PATH PEERBIT_MOCHA_LOG_TEST_START=1 PEERBIT_MOCHA_LOG_INTERVAL_MS=10000 node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --no-build --grep "uses receipts instead of known-peer hints"`
- `PATH=/tmp/node22/node-v22.22.3-darwin-arm64/bin:$PATH PEERBIT_MOCHA_LOG_TEST_START=1 PEERBIT_MOCHA_LOG_INTERVAL_MS=10000 node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --no-build --grep "^u32-simple sharding write while joining peers$"`
- `PATH=/tmp/node22/node-v22.22.3-darwin-arm64/bin:$PATH PEERBIT_MOCHA_LOG_TEST_START=1 PEERBIT_MOCHA_LOG_INTERVAL_MS=10000 node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --no-build --grep "^u64-iblt sharding drops when no longer replicating as observer$"`
- `PATH=/tmp/node22/node-v22.22.3-darwin-arm64/bin:$PATH PEERBIT_MOCHA_LOG_TEST_START=1 PEERBIT_MOCHA_LOG_INTERVAL_MS=10000 node ./node_modules/aegir/src/index.js run test --roots ./packages/programs/data/shared-log -- -t node --no-build --grep "^u64-iblt redundancy only sends entries once, 3 peers$"`
- `PATH=/tmp/node22/node-v22.22.3-darwin-arm64/bin:$PATH PEERBIT_MOCHA_LOG_TEST_START=1 PEERBIT_MOCHA_LOG_INTERVAL_MS=10000 pnpm run test:ci:part-7e`
- `PATH=/tmp/node22/node-v22.22.3-darwin-arm64/bin:$PATH PEERBIT_MOCHA_LOG_TEST_START=1 PEERBIT_MOCHA_LOG_INTERVAL_MS=10000 pnpm run test:ci:part-7d`
- `PATH=/tmp/node22/node-v22.22.3-darwin-arm64/bin:$PATH PEERBIT_MOCHA_LOG_TEST_START=1 PEERBIT_MOCHA_LOG_INTERVAL_MS=10000 pnpm run test:ci:part-7c`