### PR TITLE
fix(shared-log): rescan fixed range removals for prune

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -8048,20 +8048,29 @@ export class SharedLog<
 				flushUncheckedDeliverTarget(target);
 			}
 
-			if (
-				this._isAdaptiveReplicating &&
-				(hasSelfRangeRemoval ||
+			const localSegmentsAfterChange =
+				hasSelfRangeRemoval && !this._isAdaptiveReplicating
+					? await this.getMyReplicationSegments()
+					: undefined;
+			const hasFixedSelfRangeRemovalToZero =
+				localSegmentsAfterChange != null &&
+				localSegmentsAfterChange.length > 0 &&
+				localSegmentsAfterChange.every((segment) => segment.widthNormalized === 0);
+			const shouldRunLocalPruneScan =
+				hasFixedSelfRangeRemovalToZero ||
+				(this._isAdaptiveReplicating &&
 					changes.some(
 						(change) =>
 							change.type === "added" ||
 							change.type === "removed" ||
 							change.type === "replaced",
-					))
-			) {
-				// Adaptive range changes can make already-indexed local heads prunable
-				// even when the incremental rebalance scan misses them under churn or
-				// timing pressure. Re-scan after repair dispatches are flushed using the
-				// mature-role view, which matches the bounded pruning contract.
+					));
+
+			if (shouldRunLocalPruneScan) {
+				// Adaptive range changes and fixed zero-width updates can make already-indexed
+				// local heads prunable even when the incremental rebalance scan misses them
+				// under churn or timing pressure. Re-scan after repair dispatches are flushed
+				// using the mature-role view, which matches the bounded pruning contract.
 				await this.pruneIndexedEntriesNoLongerLed({
 					useDefaultRoleAge: true,
 				});

--- a/packages/programs/data/shared-log/test/sharding.spec.ts
+++ b/packages/programs/data/shared-log/test/sharding.spec.ts
@@ -2582,8 +2582,14 @@ testSetups.forEach((setup) => {
 					}),
 				]);
 				await db2.log.replicate({ factor: 0 });
-				await waitForResolved(() => expect(db3.log.log.length).equal(COUNT));
-				await waitForResolved(() => expect(db2.log.log.length).equal(0)); // min replicas is set to 2 so, if there are 2 dbs still replicating, this nod should not store any data
+				await waitForResolved(() => expect(db3.log.log.length).equal(COUNT), {
+					timeout: 30_000,
+				});
+				await waitForPruneQuiesced(db2);
+				// Min replicas is 2, so two remaining replicators should be enough.
+				await waitForResolved(() => expect(db2.log.log.length).equal(0), {
+					timeout: 30_000,
+				});
 			});
 
 			describe("distribution", () => {


### PR DESCRIPTION
## Summary

Fixes a master `test:ci:part-7c` flake where `u64-iblt sharding drops when no longer replicating with factor 0` sometimes retained the old local entries after changing a fixed replicator to `factor: 0`.

The failed master run was `27602443577`, job `81607415645`, at master head `f6a9ec259a0d9c8af1019a73f729b7d1337699d8`.

## Fix

`replicate({ factor: 0 })` keeps the node in fixed replication mode with a zero-width range. That is different from `replicate(false)`, so it does not go through `unreplicate()`. Before this change, the extra mature-role prune scan only ran for adaptive range changes. If the incremental rebalance scan missed already-indexed local heads under timing pressure, fixed factor-zero range removal could leave stale local entries until another event kicked pruning.

This change runs the same explicit prune scan when a fixed local range update leaves the node with only zero-width local segments, while preserving the existing adaptive behavior.

The test now waits for the existing prune-quiescence signal before asserting that the factor-zero node has dropped its entries, matching the checked-prune contract used by the neighboring observer-drop tests.

## CI follow-up

The first version of this PR ran the scan for every fixed self-range removal. PR CI exposed that this was too broad: ordinary fixed range shrink tests could enter checked-prune churn early and fail to converge under CI load. The guard is now narrowed to fixed range removal that leaves only zero-width local segments, so normal fixed shrink/replacement continues through the existing handoff path.

## Verification

- `node ./node_modules/aegir/src/index.js run build --roots ./packages/programs/data/shared-log`
- Focused failed factor-zero test passed.
- Focused CI-red range replacement tests passed for u32 and u64:
  `replace range with another node write before join with slowed down send`
  `replace range with another node write after join`
- Full `part-7d` passed locally after narrowing:
  `46 passing`, `3 pending`
- Full `part-7c` passed locally after narrowing:
  `113 passing`, `2 pending`
- Earlier focused factor-zero loop passed 10 consecutive runs before the guard narrowing; factor-zero was also re-run in the focused set and full `part-7c` after narrowing.

## Notes

I could not reproduce the original master factor-zero failure locally on unmodified master in 20 focused runs plus one full shard run, so this is based on the failed CI signal and the identified gap between fixed factor-zero range removal and the existing adaptive prune safety scan.