### PR TITLE
fix(pubsub): eliminate fanout route-resolution storm under group subscribe

### DIFF
--- a/.github/workflows/nightly-sims.yml
+++ b/.github/workflows/nightly-sims.yml
@@ -58,13 +58,11 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p sim-results
-          # 60 subscribers fits the shard root's child capacity: joins are
-          # deterministic and delivery is 100% across seeds. Raising the
-          # subscriber count is gated on the fanout route-proxy storm fix
-          # (see issue #983) — at 120+ subscribers route resolution floods
-          # the tree superlinearly and the sim OOMs before subscribe ends.
+          # Full 400-subscriber gate, unblocked by the #983 fix (subscribe-
+          # response batching + route-proxy coalescing): before it, route
+          # resolution flooded the tree superlinearly and OOMed a 4GB heap.
           pnpm -C packages/transport/pubsub run bench -- topic-sim \
-            --nodes 500 --degree 6 --subscribers 60 \
+            --nodes 500 --degree 6 --subscribers 400 \
             --messages 50 --msgSize 256 --intervalMs 0 \
             --seed 1 --subscribeModel preseed --silent 1 \
             --settleMs 3000 --minDeliveredPct 99 \
@@ -75,9 +73,10 @@ jobs:
           pnpm -C packages/clients/test-utils run bench -- fanout-peerbit-sim --preset ci-small --seed 1 > sim-results/fanout-peerbit-ci-small.txt
       - name: Run fanout-peerbit-sim (ci-loss)
         run: |
-          # scale-1k (1000 clients, 999 group subscribers) OOMs a 4GB heap in
-          # ~15 min via the fanout route-proxy storm — it is the second
-          # acceptance test for issue #983 and returns here once that lands.
+          # scale-1k (1000 full Peerbit clients in one process) still OOMs a
+          # 4GB heap even after the #983 route-proxy storm fix — the residual
+          # is footprint/state in other layers and needs its own memory
+          # profile (tracked in #983) before it can gate here.
           set -euo pipefail
           pnpm -C packages/clients/test-utils run bench -- fanout-peerbit-sim --preset ci-loss --seed 1 > sim-results/fanout-peerbit-ci-loss.txt
       - name: Run fanout-tree-sim (scale-5k, trend evidence)

--- a/packages/transport/pubsub/src/fanout-tree.ts
+++ b/packages/transport/pubsub/src/fanout-tree.ts
@@ -833,6 +833,8 @@ export type FanoutTreeChannelMetrics = {
 	routeProxyQueries: number;
 	routeProxyTimeouts: number;
 	routeProxyFanout: number;
+	routeProxyCoalesced: number;
+	routeProxyRejected: number;
 };
 
 export interface FanoutTreeEvents extends StreamEvents {
@@ -854,6 +856,10 @@ export interface FanoutTreeEvents extends StreamEvents {
 const CONTROL_PRIORITY = 10;
 const DATA_PRIORITY = 1;
 const ROUTE_PROXY_TIMEOUT_MS = 10_000;
+// Backstop bounds for the route-proxy machinery under query storms (#983):
+// each pending entry retains a live timer closure and a Set of child hashes.
+const ROUTE_PROXY_MAX_PENDING = 2_048;
+const ROUTE_PROXY_MAX_WAITERS = 512;
 const ROUTE_CACHE_MAX_ENTRIES_HARD_CAP = 100_000;
 const PEER_HINT_MAX_ENTRIES_HARD_CAP = 100_000;
 // Best-effort address cache for join candidates learned via trackers/redirects.
@@ -1164,6 +1170,17 @@ type ChannelState = {
 			downstreamReqId: number;
 			timer: ReturnType<typeof setTimeout>;
 			expectedReplies: Set<string>;
+			targetHash: string;
+			direction: "up" | "down";
+			/**
+			 * Additional requesters coalesced onto this in-flight search; all are
+			 * answered from its single result. Without this, S concurrent lookups
+			 * for the same cold target each launch an independent subtree flood.
+			 */
+			waiters?: Array<
+				| { requester: string; downstreamReqId: number }
+				| { localResolve: (route?: string[]) => void }
+			>;
 			/**
 			 * Optional local completion callback (used when the root resolves a route token
 			 * for itself by fanning out queries to children).
@@ -1171,6 +1188,8 @@ type ChannelState = {
 			localResolve?: (route?: string[]) => void;
 		}
 	>;
+	/** `${direction}:${targetHash}` -> in-flight proxyReqId, for coalescing. */
+	routeProxyByTarget: Map<string, number>;
 
 	bootstrapOverride?: Multiaddr[];
 	bootstrapDialTimeoutMs: number;
@@ -1310,6 +1329,8 @@ const createEmptyMetrics = (): FanoutTreeChannelMetrics => ({
 	routeProxyQueries: 0,
 	routeProxyTimeouts: 0,
 	routeProxyFanout: 0,
+	routeProxyCoalesced: 0,
+	routeProxyRejected: 0,
 });
 
 const isDataId = (id: Uint8Array) =>
@@ -2328,6 +2349,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			pendingRouteQuery: new Map(),
 			pendingUnicastAck: new Map(),
 			pendingRouteProxy: new Map(),
+			routeProxyByTarget: new Map(),
 			bootstrapOverride: undefined,
 			bootstrapDialTimeoutMs: 10_000,
 			bootstrapMaxPeers: 0,
@@ -2539,10 +2561,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		ch.parentProbeRejectBackoffMsByHash.clear();
 		ch.pendingRouteQuery.clear();
 		this.abortPendingUnicastAcks(ch, new AbortError("fanout channel detached"));
-		for (const pending of ch.pendingRouteProxy.values()) {
-			clearTimeout(pending.timer);
-		}
-		ch.pendingRouteProxy.clear();
+		this.clearRouteProxies(ch);
 	}
 
 	private onPeerDisconnectedFromUnderlay(peerHash: string) {
@@ -2632,10 +2651,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		}
 		ch.pendingRouteQuery.clear();
 		this.abortPendingUnicastAcks(ch, new AbortError("fanout channel closed"));
-		for (const pending of ch.pendingRouteProxy.values()) {
-			clearTimeout(pending.timer);
-		}
-		ch.pendingRouteProxy.clear();
+		this.clearRouteProxies(ch);
 
 		ch.parent = undefined;
 		ch.children.clear();
@@ -2833,7 +2849,9 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			};
 		}
 
-		const route = this.getCachedRoute(ch, targetHash);
+		// Speculative probe: a miss here says nothing about cache quality (the
+		// caller falls through to resolveRouteToken, which counts its own miss).
+		const route = this.getCachedRoute(ch, targetHash, { recordMiss: false });
 		if (!route) return undefined;
 		const entry = ch.routeByPeer.get(targetHash);
 		const updatedAt = entry?.updatedAt ?? Date.now();
@@ -2961,23 +2979,25 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 	private getCachedRoute(
 		ch: ChannelState,
 		targetHash: string,
+		opts?: { recordMiss?: boolean },
 	): string[] | undefined {
+		const recordMiss = opts?.recordMiss !== false;
 		this.pruneRouteCache(ch);
 		const entry = ch.routeByPeer.get(targetHash);
 		if (!entry) {
-			ch.metrics.routeCacheMisses += 1;
+			if (recordMiss) ch.metrics.routeCacheMisses += 1;
 			return undefined;
 		}
 		const now = Date.now();
 		if (ch.routeCacheTtlMs > 0 && now - entry.updatedAt > ch.routeCacheTtlMs) {
 			ch.routeByPeer.delete(targetHash);
-			ch.metrics.routeCacheMisses += 1;
+			if (recordMiss) ch.metrics.routeCacheMisses += 1;
 			ch.metrics.routeCacheExpirations += 1;
 			return undefined;
 		}
 		if (!this.isRouteValidForChannel(ch, entry.route)) {
 			ch.routeByPeer.delete(targetHash);
-			ch.metrics.routeCacheMisses += 1;
+			if (recordMiss) ch.metrics.routeCacheMisses += 1;
 			return undefined;
 		}
 		// LRU touch
@@ -3017,15 +3037,89 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		const proxy = ch.pendingRouteProxy.get(proxyReqId);
 		if (!proxy) return;
 		ch.pendingRouteProxy.delete(proxyReqId);
+		const targetKey = `${proxy.direction}:${proxy.targetHash}`;
+		if (ch.routeProxyByTarget.get(targetKey) === proxyReqId) {
+			ch.routeProxyByTarget.delete(targetKey);
+		}
 		clearTimeout(proxy.timer);
+		const reply = (requester: string, downstreamReqId: number): void => {
+			void this._sendControl(
+				requester,
+				encodeRouteReply(ch.id.key, downstreamReqId, route),
+			).catch(() => {});
+		};
 		if (proxy.localResolve) {
 			proxy.localResolve(route);
-			return;
+		} else {
+			reply(proxy.requester, proxy.downstreamReqId);
 		}
-		void this._sendControl(
-			proxy.requester,
-			encodeRouteReply(ch.id.key, proxy.downstreamReqId, route),
-		).catch(() => {});
+		if (proxy.waiters) {
+			for (const w of proxy.waiters) {
+				if ("localResolve" in w) {
+					w.localResolve(route);
+				} else {
+					reply(w.requester, w.downstreamReqId);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Coalesce onto an in-flight same-target/same-direction proxy search, if one
+	 * exists. Returns true when the requester was attached as a waiter (or
+	 * answered empty on waiter overflow) and no new search should start.
+	 */
+	private coalesceRouteProxy(
+		ch: ChannelState,
+		targetHash: string,
+		direction: "up" | "down",
+		waiter:
+			| { requester: string; downstreamReqId: number }
+			| { localResolve: (route?: string[]) => void },
+	): boolean {
+		const targetKey = `${direction}:${targetHash}`;
+		const existingId = ch.routeProxyByTarget.get(targetKey);
+		if (existingId == null) return false;
+		const existing = ch.pendingRouteProxy.get(existingId);
+		if (!existing) {
+			ch.routeProxyByTarget.delete(targetKey);
+			return false;
+		}
+		if ((existing.waiters?.length ?? 0) >= ROUTE_PROXY_MAX_WAITERS) {
+			ch.metrics.routeProxyRejected += 1;
+			if ("localResolve" in waiter) {
+				waiter.localResolve(undefined);
+			} else {
+				void this._sendControl(
+					waiter.requester,
+					encodeRouteReply(ch.id.key, waiter.downstreamReqId),
+				).catch(() => {});
+			}
+			return true;
+		}
+		(existing.waiters ??= []).push(waiter);
+		ch.metrics.routeProxyCoalesced += 1;
+		return true;
+	}
+
+	/**
+	 * Drop all in-flight route-proxy state for a channel (detach/kick/close).
+	 * Local resolvers are settled with `undefined` so root-origin
+	 * `resolveRouteToken()` callers never hang; remote requesters time out on
+	 * their own deadlines, as before.
+	 */
+	private clearRouteProxies(ch: ChannelState) {
+		for (const pending of ch.pendingRouteProxy.values()) {
+			clearTimeout(pending.timer);
+			pending.localResolve?.(undefined);
+			if (pending.waiters) {
+				for (const w of pending.waiters) {
+					if ("localResolve" in w) w.localResolve(undefined);
+				}
+			}
+		}
+		ch.pendingRouteProxy.clear();
+		ch.routeProxyByTarget.clear();
 	}
 
 	private proxyRouteQuery(
@@ -3036,6 +3130,21 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		candidates: string[],
 		timeoutMs = ROUTE_PROXY_TIMEOUT_MS,
 	) {
+		// Direction matters for coalescing correctness: an upstream lookup and the
+		// root's downstream flood for the same target may legitimately transit the
+		// same node concurrently (e.g. the target lives in the requester's own
+		// branch), and merging them would make them wait on each other.
+		const direction: "up" | "down" =
+			candidates.length === 1 && candidates[0] === ch.parent ? "up" : "down";
+		if (
+			this.coalesceRouteProxy(ch, targetHash, direction, {
+				requester,
+				downstreamReqId,
+			})
+		) {
+			return;
+		}
+
 		const unique: string[] = [];
 		const seen = new Set<string>();
 		for (const candidate of candidates) {
@@ -3047,6 +3156,15 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		}
 
 		if (unique.length === 0) {
+			void this._sendControl(
+				requester,
+				encodeRouteReply(ch.id.key, downstreamReqId),
+			).catch(() => {});
+			return;
+		}
+
+		if (ch.pendingRouteProxy.size >= ROUTE_PROXY_MAX_PENDING) {
+			ch.metrics.routeProxyRejected += 1;
 			void this._sendControl(
 				requester,
 				encodeRouteReply(ch.id.key, downstreamReqId),
@@ -3069,7 +3187,10 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			downstreamReqId,
 			timer,
 			expectedReplies: new Set(unique),
+			targetHash,
+			direction,
 		});
+		ch.routeProxyByTarget.set(`${direction}:${targetHash}`, proxyReqId);
 
 		void this._sendControlMany(
 			unique,
@@ -3111,13 +3232,46 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			const timeoutMs = Math.max(1, Math.floor(options?.timeoutMs ?? 3_000));
 			return await new Promise<string[] | undefined>((resolve, reject) => {
 				let settled = false;
+				let proxyReqId: number | undefined;
 				const onAbort = () => {
 					if (settled) return;
 					settled = true;
-					ch.pendingRouteProxy.delete(proxyReqId);
-					clearTimeout(timer);
+					clearTimeout(backstop);
+					if (proxyReqId != null) {
+						// Tear the search down only if nobody else coalesced onto it;
+						// otherwise let it finish for the waiters (our localResolve
+						// is a no-op once settled).
+						const entry = ch.pendingRouteProxy.get(proxyReqId);
+						if (entry && (!entry.waiters || entry.waiters.length === 0)) {
+							this.completeRouteProxy(ch, proxyReqId);
+						}
+					}
 					reject(new AbortError());
 				};
+				const localResolve = (route?: string[]) => {
+					if (settled) return;
+					settled = true;
+					clearTimeout(backstop);
+					if (options?.signal) {
+						options.signal.removeEventListener("abort", onAbort);
+					}
+					if (this.isRouteValidForChannel(ch, route)) {
+						this.cacheRoute(ch, route!);
+						resolve([...route!]);
+						return;
+					}
+					resolve(undefined);
+				};
+				// Per-caller timeout: when coalesced, the shared in-flight search
+				// may outlive this caller's own deadline.
+				const backstop = setTimeout(() => localResolve(undefined), timeoutMs);
+				if (options?.signal) {
+					options.signal.addEventListener("abort", onAbort, { once: true });
+				}
+
+				if (this.coalesceRouteProxy(ch, targetHash, "down", { localResolve })) {
+					return;
+				}
 
 				const unique: string[] = [];
 				const seen = new Set<string>();
@@ -3130,49 +3284,41 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 				}
 
 				if (unique.length === 0) {
-					resolve(undefined);
+					localResolve(undefined);
+					return;
+				}
+
+				if (ch.pendingRouteProxy.size >= ROUTE_PROXY_MAX_PENDING) {
+					ch.metrics.routeProxyRejected += 1;
+					localResolve(undefined);
 					return;
 				}
 
 				ch.metrics.routeProxyQueries += 1;
 				ch.metrics.routeProxyFanout += unique.length;
 
-				const proxyReqId = this.nextReqId(ch);
+				proxyReqId = this.nextReqId(ch);
 				const timer = setTimeout(() => {
 					ch.metrics.routeProxyTimeouts += 1;
-					this.completeRouteProxy(ch, proxyReqId);
+					this.completeRouteProxy(ch, proxyReqId!);
 				}, timeoutMs);
-
-				if (options?.signal) {
-					options.signal.addEventListener("abort", onAbort, { once: true });
-				}
 
 				ch.pendingRouteProxy.set(proxyReqId, {
 					requester: this.publicKeyHash,
 					downstreamReqId: 0,
 					timer,
 					expectedReplies: new Set(unique),
-					localResolve: (route?: string[]) => {
-						if (settled) return;
-						settled = true;
-						clearTimeout(timer);
-						if (options?.signal) {
-							options.signal.removeEventListener("abort", onAbort);
-						}
-						if (this.isRouteValidForChannel(ch, route)) {
-							this.cacheRoute(ch, route!);
-							resolve([...route!]);
-							return;
-						}
-						resolve(undefined);
-					},
+					targetHash,
+					direction: "down",
+					localResolve,
 				});
+				ch.routeProxyByTarget.set(`down:${targetHash}`, proxyReqId);
 
 				void this._sendControlMany(
 					unique,
 					encodeRouteQuery(ch.id.key, proxyReqId, targetHash),
 				).catch(() => {
-					this.completeRouteProxy(ch, proxyReqId);
+					this.completeRouteProxy(ch, proxyReqId!);
 				});
 			});
 		}
@@ -5662,10 +5808,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 						nextParentUpgradeCheckAt = 0;
 						resetParentUpgradeActiveGuardBackoff();
 						ch.pendingRouteQuery.clear();
-						for (const pending of ch.pendingRouteProxy.values()) {
-							clearTimeout(pending.timer);
-						}
-						ch.pendingRouteProxy.clear();
+						this.clearRouteProxies(ch);
 						void this.kickChildren(ch).catch(() => {});
 						await delay(retryMs, { signal });
 						continue;
@@ -8694,6 +8837,10 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 					if (!nextHop || !ch.children.has(nextHop)) return true;
 					const stream = this.peers.get(nextHop);
 					if (!stream) return true;
+					// A validated source route is passing through: learn it (and the
+					// reply route) so subsequent unicasts skip route discovery.
+					this.cacheRoute(ch, route);
+					if (replyRoute) this.cacheRoute(ch, replyRoute);
 					void stream
 						.waitForWrite(
 							message.bytes(),
@@ -8744,6 +8891,8 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 					if (!nextHop || !ch.children.has(nextHop)) return true;
 					const stream = this.peers.get(nextHop);
 					if (!stream) return true;
+					this.cacheRoute(ch, route);
+					if (replyRoute) this.cacheRoute(ch, replyRoute);
 					void stream
 						.waitForWrite(
 							message.bytes(),
@@ -8791,10 +8940,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 					ch,
 					new AbortError("fanout channel kicked"),
 				);
-				for (const pending of ch.pendingRouteProxy.values()) {
-					clearTimeout(pending.timer);
-				}
-				ch.pendingRouteProxy.clear();
+				this.clearRouteProxies(ch);
 				void this.kickChildren(ch).catch(() => {});
 				this.dispatchEvent(
 					new CustomEvent("fanout:kicked", {

--- a/packages/transport/pubsub/src/index.ts
+++ b/packages/transport/pubsub/src/index.ts
@@ -238,6 +238,21 @@ export class TopicControlPlane
 	public subscriptions: Map<string, { counter: number }>;
 	// Local topics requested via debounced subscribe, not yet applied in `subscriptions`.
 	private pendingSubscriptions: Set<string>;
+	/**
+	 * Per-shard batching of Subscribe{requestSubscribers} responses. When many
+	 * peers announce subscriptions in a burst (group subscribe), answering each
+	 * announcer with a routed unicast is quadratic in subscriber count and
+	 * melts the fanout route-resolution machinery (#983); a short window lets
+	 * one broadcast answer all concurrent announcers instead.
+	 */
+	private pendingSubscriberResponses: Map<
+		string,
+		{
+			targets: Set<string>;
+			topics: Set<string>;
+			timer: ReturnType<typeof setTimeout>;
+		}
+	> = new Map();
 	public lastSubscriptionMessages: Map<
 		string,
 		Map<string, { session: bigint; timestamp: bigint }>
@@ -500,6 +515,10 @@ export class TopicControlPlane
 
 		this.subscriptions.clear();
 		this.pendingSubscriptions.clear();
+		for (const entry of this.pendingSubscriberResponses.values()) {
+			clearTimeout(entry.timer);
+		}
+		this.pendingSubscriberResponses.clear();
 		this.topics.clear();
 		this.peerToTopic.clear();
 		this.lastSubscriptionMessages.clear();
@@ -2050,6 +2069,68 @@ export class TopicControlPlane
 		);
 	}
 
+	/**
+	 * Batch Subscribe{requestSubscribers} responses per shard over a short
+	 * jittered window. A single announcer still gets a targeted unicast; when
+	 * several peers announce concurrently (group subscribe), one broadcast
+	 * answers them all — avoiding S(S-1) routed unicasts whose cold route
+	 * resolutions flood the shard tree (#983).
+	 */
+	private queueSubscriberResponse(
+		shardTopic: string,
+		targetHash: string,
+		topics: string[],
+	) {
+		let entry = this.pendingSubscriberResponses.get(shardTopic);
+		if (!entry) {
+			const created = {
+				targets: new Set<string>(),
+				topics: new Set<string>(),
+				timer: setTimeout(
+					() => {
+						this.pendingSubscriberResponses.delete(shardTopic);
+						void this.flushSubscriberResponses(shardTopic, created).catch(
+							logErrorIfStarted,
+						);
+					},
+					150 + Math.floor(Math.random() * 150),
+				),
+			};
+			entry = created;
+			this.pendingSubscriberResponses.set(shardTopic, entry);
+		}
+		entry.targets.add(targetHash);
+		for (const t of topics) entry.topics.add(t);
+	}
+
+	private async flushSubscriberResponses(
+		shardTopic: string,
+		entry: { targets: Set<string>; topics: Set<string> },
+	) {
+		if (!this.started) return;
+		// Re-filter: our subscriptions may have changed within the window.
+		const topics = this.getSubscriptionOverlap([...entry.topics]);
+		if (topics.length === 0) return;
+		const response = new Subscribe({
+			topics,
+			requestSubscribers: false,
+		});
+		const embedded = await this.createMessage(toUint8Array(response.bytes()), {
+			mode: new AnyWhere(),
+			priority: 1,
+			skipRecipientValidation: true,
+		} as any);
+		const payload = toUint8Array(embedded.bytes());
+		const [firstTarget] = entry.targets;
+		if (entry.targets.size === 1 && firstTarget) {
+			await this.sendFanoutUnicastOrBroadcast(shardTopic, firstTarget, payload);
+			return;
+		}
+		const st = this.fanoutChannels.get(shardTopic);
+		if (!st) return;
+		await st.channel.publishMaybe(payload);
+	}
+
 	private async sendFanoutUnicastOrBroadcast(
 		shardTopic: string,
 		targetHash: string,
@@ -2274,24 +2355,7 @@ export class TopicControlPlane
 			if (pubsubMessage.requestSubscribers) {
 				const overlap = this.getSubscriptionOverlap(pubsubMessage.topics);
 				if (overlap.length > 0) {
-					const response = new Subscribe({
-						topics: overlap,
-						requestSubscribers: false,
-					});
-					const embedded = await this.createMessage(
-						toUint8Array(response.bytes()),
-						{
-							mode: new AnyWhere(),
-							priority: 1,
-							skipRecipientValidation: true,
-						} as any,
-					);
-					const payload = toUint8Array(embedded.bytes());
-					await this.sendFanoutUnicastOrBroadcast(
-						shardTopic,
-						senderKey,
-						payload,
-					);
+					this.queueSubscriberResponse(shardTopic, senderKey, overlap);
 				}
 			}
 			return;

--- a/packages/transport/pubsub/test/route-proxy-coalescing.spec.ts
+++ b/packages/transport/pubsub/test/route-proxy-coalescing.spec.ts
@@ -1,0 +1,159 @@
+import { TestSession } from "@peerbit/libp2p-test-utils";
+import { expect } from "chai";
+import { FanoutChannel, FanoutTree } from "../src/index.js";
+
+type FanoutServices = { fanout: FanoutTree };
+
+const createFanoutService = (components: any) =>
+	new FanoutTree(components, { connectionManager: false });
+
+const createFanoutTestSession = (n: number) =>
+	TestSession.disconnected<FanoutServices>(n, {
+		services: {
+			fanout: createFanoutService,
+		},
+	});
+
+describe("fanout-tree (route proxy coalescing)", () => {
+	it("coalesces concurrent same-target resolutions into a single subtree search", async () => {
+		const session: TestSession<FanoutServices> =
+			await createFanoutTestSession(3);
+
+		try {
+			await session.connect([
+				[session.peers[0], session.peers[1]],
+				[session.peers[1], session.peers[2]],
+			]);
+
+			const root = session.peers[0].services.fanout;
+			const relay = session.peers[1].services.fanout;
+			const leaf = session.peers[2].services.fanout;
+
+			const topic = "route-proxy-coalescing";
+			const rootId = root.publicKeyHash;
+
+			const rootChannel = FanoutChannel.fromSelf(root, topic);
+			rootChannel.openAsRoot({
+				msgRate: 10,
+				msgSize: 64,
+				uploadLimitBps: 1_000_000,
+				maxChildren: 8,
+				repair: false,
+			});
+
+			await relay.joinChannel(
+				topic,
+				rootId,
+				{
+					msgRate: 10,
+					msgSize: 64,
+					uploadLimitBps: 1_000_000,
+					maxChildren: 8,
+					repair: false,
+				},
+				{ timeoutMs: 10_000 },
+			);
+			await leaf.joinChannel(
+				topic,
+				rootId,
+				{
+					msgRate: 10,
+					msgSize: 64,
+					uploadLimitBps: 0,
+					maxChildren: 0,
+					repair: false,
+				},
+				{ timeoutMs: 10_000 },
+			);
+
+			// Cold cache at the root: N concurrent lookups for the same target
+			// must launch exactly one subtree search and all resolve from it.
+			const attempts = 5;
+			const routes = await Promise.all(
+				Array.from({ length: attempts }, () =>
+					root.resolveRouteToken(topic, rootId, leaf.publicKeyHash, {
+						timeoutMs: 4_000,
+					}),
+				),
+			);
+
+			for (const route of routes) {
+				expect(route).to.exist;
+				expect(route?.[0]).to.equal(rootId);
+				expect(route?.[route.length - 1]).to.equal(leaf.publicKeyHash);
+			}
+
+			const metrics = root.getChannelMetrics(topic, rootId);
+			expect(metrics.routeProxyQueries).to.equal(1);
+			expect(metrics.routeProxyCoalesced).to.equal(attempts - 1);
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("settles coalesced waiters instead of hanging when the channel closes", async () => {
+		const session: TestSession<FanoutServices> =
+			await createFanoutTestSession(2);
+
+		try {
+			await session.connect([[session.peers[0], session.peers[1]]]);
+
+			const root = session.peers[0].services.fanout;
+			const relay = session.peers[1].services.fanout;
+
+			const topic = "route-proxy-close-settles";
+			const rootId = root.publicKeyHash;
+
+			const rootChannel = FanoutChannel.fromSelf(root, topic);
+			rootChannel.openAsRoot({
+				msgRate: 10,
+				msgSize: 64,
+				uploadLimitBps: 1_000_000,
+				maxChildren: 8,
+				repair: false,
+			});
+
+			await relay.joinChannel(
+				topic,
+				rootId,
+				{
+					msgRate: 10,
+					msgSize: 64,
+					uploadLimitBps: 1_000_000,
+					maxChildren: 8,
+					repair: false,
+				},
+				{ timeoutMs: 10_000 },
+			);
+
+			// Lookups for a target that does not exist keep a search in flight
+			// (the relay proxies onward and nothing answers before the timeout).
+			const pending = Promise.all(
+				Array.from({ length: 3 }, () =>
+					root.resolveRouteToken(topic, rootId, "does-not-exist", {
+						timeoutMs: 8_000,
+					}),
+				),
+			);
+			// Give the queries a beat to register as in-flight state.
+			await new Promise((r) => setTimeout(r, 100));
+
+			rootChannel.close();
+
+			// All callers must settle promptly (undefined), well before their
+			// 8s timeouts — closing used to strand localResolve callers.
+			const routes = await Promise.race([
+				pending,
+				new Promise<undefined>((_, reject) =>
+					setTimeout(() => reject(new Error("waiters left hanging")), 4_000),
+				),
+			]);
+			expect(routes).to.have.length(3);
+			for (const route of routes!) {
+				expect(route).to.equal(undefined);
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #983 — group subscribe melted the fanout control plane with O(S³) traffic and OOM'd at scale. Two multiplication points, both verified by instrumented runs before and after:

1. **Application-level quadratic**: every one of S concurrent subscribers unicast-replied to every other subscriber's `Subscribe{requestSubscribers}` announce — S(S−1) routed unicasts (14,280 at S=120), each triggering a cold fanout route resolution. Responses are now **batched per shard over a 150–300 ms jittered window**: a lone announcer still gets today's targeted unicast; a concurrent burst is answered with one broadcast `Subscribe`.
2. **Protocol-level amplifier**: concurrent `ROUTE_QUERY` searches for the same target each launched an independent full-subtree flood (~97 duplicate floods per target measured). In-flight proxy searches are now **coalesced per (direction, target)** — later lookups attach as waiters and are all answered from the single search's result. Direction-awareness is load-bearing: an upstream lookup and the root's downstream flood for the same target can legitimately transit the same node concurrently, and merging them would deadlock them against each other.

Hardening in the same paths:
- `pendingRouteProxy` bounded (2,048 entries / 512 waiters) with a `routeProxyRejected` metric — this map's live timer closures were the storm's OOM retention path.
- Relaying hops learn validated source routes (and reply routes) passing through `MSG_UNICAST`, so repeat unicasts skip discovery.
- detach/kick/close now settle local resolvers — previously a root-side `resolveRouteToken()` caller was stranded forever (pre-existing hang, now covered by a test).
- `getRouteHint`'s speculative probe no longer counts a `routeCacheMiss` (it double-counted every send attempt).

Wire format unchanged; no new message kinds.

## Measurements (topic-sim, 500 nodes, in-memory transport, seed 1)

| | before | after |
|---|---|---|
| 120 subs: subscribe phase | 37–44 s | **2.9 s** |
| 120 subs: controlSends | 539,920 | **5,498** |
| 120 subs: route-proxy floods | 241,949 | **0** |
| 120 subs: publish 50 msgs | 23 s | 1.2 s |
| 120 subs: heap | 830 MiB+ | 336 MiB |
| 400 subs | **OOM (4 GB), subscribe never completes** | 13.7 s subscribe, **100.00%** of 20,000 msgs delivered, 889 MiB heap |

Control traffic now scales ~linearly (5.5k sends @ 120 subs → 14.4k @ 400).

## Testing

- New `route-proxy-coalescing.spec.ts`: N concurrent same-target resolutions produce exactly one subtree search (`routeProxyQueries === 1`, waiters coalesced); channel close settles coalesced waiters instead of hanging.
- pubsub suite: 141 passing. stream suite: green. `fanout-peerbit-sim` `ci-small`/`ci-loss`: 100% join and delivery (ci-loss under 10% frame loss + churn).
- topic-sim seeds 1–3 at 120 subs and seed 1 at 400 subs pass locally.
- CI gate raised to the full **400-subscriber** design point (was 60, capped by this bug).
- `fanout-peerbit-sim scale-1k` still OOMs — the residual is full-client footprint in other layers, not the route storm; it stays tracked in #983 pending its own memory profile.
