### PR TITLE
fix(pubsub): answer first subscriber announce immediately, batch only the burst

### DIFF
--- a/packages/transport/pubsub/src/index.ts
+++ b/packages/transport/pubsub/src/index.ts
@@ -2070,11 +2070,12 @@ export class TopicControlPlane
 	}
 
 	/**
-	 * Batch Subscribe{requestSubscribers} responses per shard over a short
-	 * jittered window. A single announcer still gets a targeted unicast; when
-	 * several peers announce concurrently (group subscribe), one broadcast
-	 * answers them all — avoiding S(S-1) routed unicasts whose cold route
-	 * resolutions flood the shard tree (#983).
+	 * Answer Subscribe{requestSubscribers} announces without letting bursts go
+	 * quadratic (#983). Leading edge: the first announcer is answered
+	 * immediately with a targeted unicast — a lone joiner sees no added
+	 * latency. Announcers arriving within the trailing window that this opens
+	 * are batched and answered with ONE broadcast, instead of S(S-1) routed
+	 * unicasts whose cold route resolutions flood the shard tree.
 	 */
 	private queueSubscriberResponse(
 		shardTopic: string,
@@ -2089,6 +2090,7 @@ export class TopicControlPlane
 				timer: setTimeout(
 					() => {
 						this.pendingSubscriberResponses.delete(shardTopic);
+						if (created.targets.size === 0) return;
 						void this.flushSubscriberResponses(shardTopic, created).catch(
 							logErrorIfStarted,
 						);
@@ -2096,8 +2098,13 @@ export class TopicControlPlane
 					150 + Math.floor(Math.random() * 150),
 				),
 			};
-			entry = created;
-			this.pendingSubscriberResponses.set(shardTopic, entry);
+			this.pendingSubscriberResponses.set(shardTopic, created);
+			// Leading edge: respond to the burst opener right away.
+			void this.flushSubscriberResponses(shardTopic, {
+				targets: new Set([targetHash]),
+				topics: new Set(topics),
+			}).catch(logErrorIfStarted);
+			return;
 		}
 		entry.targets.add(targetHash);
 		for (const t of topics) entry.topics.add(t);


### PR DESCRIPTION
## Summary

Follow-up to #984, which introduced a regression: the per-shard batching window delayed **every** `Subscribe{requestSubscribers}` response by 150–300 ms — including the common single-joiner case that used to be answered instantly. Every consumer that opens a database and waits on subscriber discovery paid that delay, and the shared-log u64-iblt convergence suite noticed: **part-7 CI failure rate jumped from 4/41 runs (9.8%) pre-#984 to 4/13 (30.8%) in the hours after the merge** (all four: `checkBounded`/reorg-counter convergence assertions in `u64-iblt` sharding & replication-degree tests).

This switches the responder to **leading edge + trailing batch**: the first announcer is answered immediately with a targeted unicast (bit-identical latency to pre-#984), and only announcers arriving within the trailing window behind it are batched into the single broadcast.

The #983 storm fix is preserved — a concurrent burst still costs ~one unicast + one broadcast per responder instead of S(S−1) unicasts, and the route-proxy coalescing layer absorbs the leading unicasts' route resolutions.

## Measurements (topic-sim, 500 nodes, seed 1, this branch)

| | 120 subs | 400 subs |
|---|---|---|
| subscribe phase | 2.9 s | 12.8 s |
| delivery | 100.00% | 100.00% (20,000 msgs) |
| controlSends | 7,234 | 15,742 |
| routeProxyQueries | 0 | **1** |

(vs. 539,920 controlSends / OOM before #984.)

## Testing
- pubsub suite: 143 passing (incl. the #984 coalescing specs).
- topic-sim 120/400 re-validated above; CI proof via `only=pubsub_sims` dispatch from this branch.
- The real acceptance signal is the part-7 failure rate returning to its ~10% pre-#984 baseline over the next runs (the residual ~10% is a pre-existing flake family, tracked separately).