### PR TITLE
fix(shared-log): dispatch program onChange from the prepared raw receive

### DIFF
--- a/packages/log/src/entry.ts
+++ b/packages/log/src/entry.ts
@@ -89,6 +89,29 @@ const preparedEntryBlockFromBytes = (
 	};
 };
 
+const preparedEntryBlockFromBytesSource = (
+	bytesSource: () => Uint8Array,
+	cid: string,
+): PreparedEntryBlock => {
+	let cidObject: ReturnType<typeof cidifyString> | undefined;
+	let bytesValue: Uint8Array | undefined;
+	return {
+		block: {
+			get bytes() {
+				return (bytesValue ??= bytesSource());
+			},
+			get cid() {
+				cidObject ??= cidifyString(cid);
+				return cidObject;
+			},
+			get value() {
+				return (bytesValue ??= bytesSource());
+			},
+		} as PreparedEntryBlock["block"],
+		cid,
+	};
+};
+
 interface Meta {
 	clock: Clock;
 	gid: string; // graph id
@@ -190,6 +213,31 @@ export abstract class Entry<T> {
 
 		entry.size = bytes.length;
 		preparedEntryBlocks.set(entry, preparedEntryBlockFromBytes(bytes, cid));
+		return cid;
+	}
+
+	/**
+	 * Like {@link Entry.prepareMultihashBytes} but defers pulling the block
+	 * bytes until a consumer actually reads them (block store put, storage
+	 * bytes). Callers that keep entry bytes in an external store (e.g. the
+	 * native wire stash) use this so entries handed to change consumers do
+	 * not copy bytes they may never touch.
+	 */
+	static prepareMultihashBytesLazy<T>(
+		entry: Entry<T>,
+		cid: string,
+		size: number,
+		bytesSource: () => Uint8Array,
+	): string {
+		if (entry.hash) {
+			throw new Error("Expected hash to be missing");
+		}
+
+		entry.size = size;
+		preparedEntryBlocks.set(
+			entry,
+			preparedEntryBlockFromBytesSource(bytesSource, cid),
+		);
 		return cid;
 	}
 

--- a/packages/programs/data/document/document/test/native-network-e2e.spec.ts
+++ b/packages/programs/data/document/document/test/native-network-e2e.spec.ts
@@ -115,12 +115,13 @@ describe("native network e2e", function () {
 
 			await peer2.open(target, { args: nativeOpenArgs() });
 
-			// documents consume per-entry change events, so the raw receive
-			// fusion is gated off for them: no topic registration expected
+			// the client preset raw-sync defaults apply to document stores:
+			// the program topic is registered on the wire-sync session and
+			// raw exchange-head payloads get stashed in wasm
 			const wireSync2 = peer2.nativeNetwork!.wireSync! as unknown as {
 				topicCount: number;
 			};
-			expect(wireSync2.topicCount).to.equal(0);
+			expect(wireSync2.topicCount).to.equal(1);
 
 			const documentPutSpy = sinon.spy(documentsOf(target).index, "put");
 			const decoderSpy = sinon.spy(
@@ -164,18 +165,18 @@ describe("native network e2e", function () {
 				{ timeout: 30_000, timeoutMessage: "native e2e live puts" },
 			);
 
-			// wire-sync session counters: no stashed block bytes ever crossed
-			// back into JS. (Documents consume per-entry change events, so the
-			// raw exchange-head defaults are gated off for them and nothing is
-			// expected to be stashed; the fused zero-JS sync leg is covered by
-			// the shared-log network e2e.)
-			for (const [label, client] of [
-				["peer1", peer1],
-				["peer2", peer2],
-			] as const) {
-				const counters = client.nativeNetwork!.wireSync!.counters!();
-				expect(counters.blockCopyOuts, label + " blockCopyOuts").to.equal(0);
-			}
+			// wire-sync session counters: document syncs ride the raw path
+			// (payloads stashed in wasm), and the per-entry change consumer
+			// (the document store's handleChanges) is what pulls entry bytes
+			// back into JS — counted as blockCopyOuts. The zero-copy invariant
+			// for programs without a per-entry consumer is covered by the
+			// shared-log network e2e.
+			const targetCounters = peer2.nativeNetwork!.wireSync!.counters!();
+			expect(targetCounters.stashed, "peer2 stashed").to.be.greaterThan(0);
+			expect(
+				targetCounters.blockCopyOuts,
+				"peer2 blockCopyOuts",
+			).to.be.greaterThan(0);
 
 			// DirectStream wire counters: every inbound frame was decoded and
 			// signature-verified natively; no frame fell back to the TS path

--- a/packages/programs/data/document/document/test/raw-exchange-sync.spec.ts
+++ b/packages/programs/data/document/document/test/raw-exchange-sync.spec.ts
@@ -1,0 +1,102 @@
+// Reproduces the raw exchange-head onChange gap: a document store syncing
+// under sync.rawExchangeHeads must land its index commits AND fire its
+// program-level change consumers for every received entry. Before the raw
+// receive dispatched change events, the log filled while the document index
+// stayed empty.
+import {
+	ExchangeHeadsMessage,
+	RawExchangeHeadsMessage,
+} from "@peerbit/shared-log";
+import { TestSession } from "@peerbit/test-utils";
+import { waitForResolved } from "@peerbit/time";
+import { expect } from "chai";
+import type { DocumentsChange } from "../src/events.js";
+import { Documents } from "../src/program.js";
+import { Document, TestStore } from "./data.js";
+
+describe("raw exchange-head document sync", () => {
+	let session: TestSession;
+
+	beforeEach(async () => {
+		session = await TestSession.connected(2);
+	});
+
+	afterEach(async () => {
+		await session.stop();
+	});
+
+	it("indexes documents and fires change events on the raw receive path", async () => {
+		const entryCount = 32;
+		const store = new TestStore({ docs: new Documents<Document>() });
+		const store2 = store.clone();
+
+		await session.peers[0].open(store, {
+			args: {
+				replicate: { factor: 1 },
+				sync: { rawExchangeHeads: true },
+			},
+		});
+
+		// count raw vs plain exchange messages leaving peer 1 so the test
+		// proves the raw path was actually exercised
+		let rawExchangeHeads = 0;
+		let plainExchangeHeads = 0;
+		const send = store.docs.log.rpc.send.bind(store.docs.log.rpc);
+		store.docs.log.rpc.send = async (message, options) => {
+			if (message instanceof RawExchangeHeadsMessage) {
+				rawExchangeHeads += 1;
+			} else if (message instanceof ExchangeHeadsMessage) {
+				plainExchangeHeads += 1;
+			}
+			return send(message, options);
+		};
+
+		const documents = Array.from(
+			{ length: entryCount },
+			(_, index) =>
+				new Document({
+					id: `raw-sync-${index}`,
+					name: `raw-sync-name-${index}`,
+				}),
+		);
+		await store.docs.putMany(documents, { unique: true });
+		expect(store.docs.log.log.length).to.equal(entryCount);
+
+		await session.peers[1].open(store2, {
+			args: {
+				replicate: { factor: 1 },
+				sync: { rawExchangeHeads: true },
+			},
+		});
+		const changes: DocumentsChange<Document, Document>[] = [];
+		store2.docs.events.addEventListener("change", (evt) => {
+			changes.push(evt.detail);
+		});
+
+		await waitForResolved(
+			async () => {
+				expect(await store2.docs.index.getSize()).to.equal(entryCount);
+			},
+			{ timeout: 30_000, timeoutMessage: "raw sync document index" },
+		);
+		expect(store2.docs.log.log.length).to.equal(entryCount);
+		expect(rawExchangeHeads).to.be.greaterThan(0);
+		expect(plainExchangeHeads).to.equal(0);
+
+		// the change consumer observed every received document exactly once
+		await waitForResolved(() => {
+			const addedIds = changes.flatMap((change) =>
+				change.added.map((doc) => doc.id),
+			);
+			expect(addedIds).to.have.members(documents.map((doc) => doc.id));
+		});
+		expect(changes.flatMap((change) => change.removed)).to.have.length(0);
+
+		// documents are resolvable through the index
+		const resolved = await store2.docs.get("raw-sync-7", {
+			local: true,
+			remote: false,
+		});
+		expect(resolved?.name).to.equal("raw-sync-name-7");
+	});
+});

--- a/packages/programs/data/shared-log/src/exchange-heads.ts
+++ b/packages/programs/data/shared-log/src/exchange-heads.ts
@@ -603,14 +603,25 @@ class PreparedRawExchangeEntry<T> extends Entry<T> {
 	private shallowHeadValue?: ShallowEntry;
 	private keychain?: unknown;
 	private encodingValue?: Log<T>["encoding"];
+	private bytesValue?: Uint8Array;
 
 	constructor(
-		private readonly bytes: Uint8Array,
+		private readonly bytesSource: () => Uint8Array,
 		private readonly facts: PreparedRawEntryV0FactsSource,
 		private readonly factsIndex = 0,
+		private readonly onJsEntryDecode?: () => void,
 	) {
 		super();
 		this.size = preparedRawByteLength(facts, factsIndex);
+	}
+
+	/**
+	 * Lazy: stash-backed heads keep the block bytes in wasm memory; they are
+	 * copied out only when a consumer actually needs them (payload/signature
+	 * materialization, storage bytes).
+	 */
+	private get bytes(): Uint8Array {
+		return (this.bytesValue ??= this.bytesSource());
 	}
 
 	get meta(): Meta {
@@ -780,9 +791,15 @@ class PreparedRawExchangeEntry<T> extends Entry<T> {
 
 	toPreparedAppendJoinFacts(): PreparedAppendJoinFacts {
 		const shallow = this.toShallow(true);
+		// eslint-disable-next-line @typescript-eslint/no-this-alias
+		const self = this;
 		return {
 			hash: this.hash,
-			bytes: this.bytes,
+			// Lazy: stash-backed heads keep entry bytes in wasm memory and the
+			// native prepared-join commit never reads them in JS.
+			get bytes() {
+				return self.bytes;
+			},
 			byteLength: this.size,
 			meta: shallow.meta,
 			getShallowEntry: (isHead = true) => this.toShallow(isHead),
@@ -794,6 +811,7 @@ class PreparedRawExchangeEntry<T> extends Entry<T> {
 		if (this.materialized) {
 			return this.materialized;
 		}
+		this.onJsEntryDecode?.();
 		const entry = materializeRawExchangeEntry<T>({
 			hash: this.hash,
 			bytes: this.bytes,
@@ -818,19 +836,30 @@ class PreparedRawEntryWithRefs<T> {
 		private readonly head: RawEntryWithRefs,
 		private readonly facts: PreparedRawEntryV0FactsSource,
 		private readonly factsIndex = 0,
+		private readonly onJsEntryDecode?: () => void,
 	) {
 		this.gidRefrences = head.gidRefrences;
 	}
 
 	get entry(): Entry<T> {
 		if (!this.entryValue) {
+			const head = this.head;
 			const entry = new PreparedRawExchangeEntry<T>(
-				this.head.bytes,
+				() => head.bytes,
 				this.facts,
 				this.factsIndex,
+				this.onJsEntryDecode,
 			);
-			Entry.prepareMultihashBytes(entry, this.head.bytes, this.head.hash);
-			entry.hash = this.head.hash;
+			// Lazy block registration: stash-backed heads keep the bytes in
+			// wasm memory until a consumer (block store put, payload
+			// materialization) actually pulls them.
+			Entry.prepareMultihashBytesLazy(
+				entry,
+				head.hash,
+				preparedRawByteLength(this.facts, this.factsIndex),
+				() => head.bytes,
+			);
+			entry.hash = head.hash;
 			entry.size = preparedRawByteLength(this.facts, this.factsIndex);
 			if (this.keychain || this.encodingValue) {
 				entry.init({
@@ -1698,6 +1727,19 @@ export const materializeVerifiedRawExchangeHeadsMessage = async (
 			const hashesToWrap = selectedHashes;
 			const indexesToWrap = selectedIndexes;
 			const wrapStartedAt = syncProfileStart(profile);
+			// Lazy per-entry JS materialization (a change consumer reading
+			// payload/signatures) is counted on the existing counter so the
+			// fused no-consumer path stays assertable at zero.
+			const onJsEntryDecode = profile
+				? () =>
+						emitSyncProfileEvent(profile, {
+							name: "sharedLog.rawReceive.jsEntryDecode",
+							component: "shared-log",
+							entries: 1,
+							messages: 0,
+							details: { lazy: true },
+						})
+				: undefined;
 			let materializedHeads: EntryWithRefs<any>[];
 			try {
 				const rowFacts = preparedFacts!;
@@ -1708,6 +1750,7 @@ export const materializeVerifiedRawExchangeHeadsMessage = async (
 						head,
 						facts,
 						factsIndex,
+						onJsEntryDecode,
 					);
 					preparedHead.initEntry({
 						keychain: log.keychain,

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -340,6 +340,7 @@ export type {
 	SyncProfileEvent,
 	SyncProfileFn,
 } from "./sync/index.js";
+export { ExchangeHeadsMessage, RawExchangeHeadsMessage };
 export const logger = loggerFn("peerbit:shared-log");
 const warn = logger.newScope("warn");
 const traceLogger = logger.trace as typeof logger.trace & { enabled?: boolean };
@@ -1131,7 +1132,6 @@ const applySharedLogNativeDefaults = <
 		nativeBackbone?: SharedLogOptions<any, any, any>["nativeBackbone"];
 		nativeGraph?: LogProperties<any>["nativeGraph"];
 		sync?: SyncOptions<any>;
-		onChange?: unknown;
 	},
 >(
 	options: O | undefined,
@@ -1140,21 +1140,14 @@ const applySharedLogNativeDefaults = <
 	if (!defaults) {
 		return options;
 	}
-	// The prepared raw receive commits entries without dispatching the
-	// program-level change event (entries never materialize in JS), so the
-	// raw sync defaults only apply to programs that do not consume
-	// per-entry changes. Programs can still opt in explicitly.
-	const applySyncDefaults = options?.onChange == null;
 	const sync =
-		(applySyncDefaults && defaults.sync) || options?.sync
+		defaults.sync || options?.sync
 			? {
 					...options?.sync,
 					rawExchangeHeads:
-						options?.sync?.rawExchangeHeads ??
-						(applySyncDefaults ? defaults.sync?.rawExchangeHeads : undefined),
+						options?.sync?.rawExchangeHeads ?? defaults.sync?.rawExchangeHeads,
 					nativeWireSync:
-						options?.sync?.nativeWireSync ??
-						(applySyncDefaults ? defaults.sync?.nativeWireSync : undefined),
+						options?.sync?.nativeWireSync ?? defaults.sync?.nativeWireSync,
 				}
 			: undefined;
 	return {
@@ -10506,7 +10499,14 @@ export class SharedLog<
 				const rawPrepareVerifySetting =
 					this._logProperties?.sync
 						?.rawExchangeHeadsVerifySignaturesDuringPrepare;
+				// A program-level canAppend hook must observe every entry before
+				// it commits, so the native join commit (which validates and
+				// commits entirely in wasm) is not used for programs that
+				// register one; those joins run through the lower-log batch
+				// join where the hook fires per entry.
+				const programCanAppend = !!this._logProperties?.canAppend;
 				const canVerifyPreparedRawReceiveOnCommit =
+					!programCanAppend &&
 					!!this._nativeBackbone?.graph
 						.commitVerifiedPreparedRawReceiveJoinBatch;
 				const canDeferRawReceiveVerificationUntilNativeSelection =
@@ -10529,6 +10529,7 @@ export class SharedLog<
 					canDeferRawReceiveVerificationUntilNativeSelection;
 				const deferNativeBackboneSignatureVerificationUntilCommit =
 					deferNativeBackboneSignatureVerificationUntilSelection &&
+					!programCanAppend &&
 					!!this._nativeBackbone?.graph
 						.commitVerifiedPreparedRawReceiveJoinBatch;
 				let rawPreparedReceiveSelection:
@@ -11788,12 +11789,21 @@ export class SharedLog<
 					let nativePreparedCommittedHashes: Set<string> | undefined;
 					if (allToMerge.length > 0) {
 						const validateStartedAt = syncProfileStart(syncProfile);
-						const nativeBackboneCommitValidation =
-							this.validatePreparedRawReceiveHeadsMetadataWithNativeBackbone(
-								allToMerge,
-								syncProfile,
-								{ decodedReplicaCounts: receiveReplicaCounts },
-							);
+						// Program-level hooks must observe the joined entries:
+						// a canAppend hook disables the native-validated commit
+						// (the lower-log join runs the hook per entry instead),
+						// and an onChange consumer disables the hash-only sink
+						// so the join dispatches the change event with lazy
+						// entry views.
+						const programCanAppend = !!this._logProperties?.canAppend;
+						const programOnChange = !!this._logProperties?.onChange;
+						const nativeBackboneCommitValidation = programCanAppend
+							? undefined
+							: this.validatePreparedRawReceiveHeadsMetadataWithNativeBackbone(
+									allToMerge,
+									syncProfile,
+									{ decodedReplicaCounts: receiveReplicaCounts },
+								);
 						let canAppendAlreadyValidated = false;
 						let fallbackCanAppendAlreadyValidated = false;
 						let nativeCommitVerifyHashes: string[] | undefined;
@@ -11834,9 +11844,11 @@ export class SharedLog<
 						}
 						const lowerLogJoinStartedAt = syncProfileStart(syncProfile);
 						const hashOnlyEntryAdded =
+							!programOnChange &&
 							!!this.syncronizer.onEntryAddedHash &&
 							this._pendingIHave.size === 0;
 						const batchHashOnlyEntryAdded =
+							!programOnChange &&
 							!!this.syncronizer.onEntryAddedHashes &&
 							this._pendingIHave.size === 0;
 						let mergeEntryByHash:
@@ -11977,6 +11989,13 @@ export class SharedLog<
 								: !!this._nativeBackbone?.graph
 										.commitPreparedRawReceiveJoinBatch);
 						const trustedLowerLog = this.log as unknown as TrustedLowerLog<T>;
+						// With a program-level onChange consumer the hash-only
+						// sink is not used: the lower-log join dispatches the
+						// change event (lazy entry views over the prepared raw
+						// facts) so per-entry consumers observe every commit.
+						const joinOnAppendHashes = programOnChange
+							? undefined
+							: onAppendHashes;
 						const joinedPreparedFacts =
 							canUsePreparedAppendFacts &&
 							(await trustedLowerLog.joinPreparedAppendFactsBatch(
@@ -11985,7 +12004,7 @@ export class SharedLog<
 									__peerbitEntriesAlreadyMissing: true,
 									__peerbitCanAppendAlreadyValidated: true,
 									__peerbitDeferIndexWrite: true,
-									__peerbitOnAppendHashes: onAppendHashes,
+									__peerbitOnAppendHashes: joinOnAppendHashes,
 									__peerbitProfile: syncProfile,
 									__peerbitNativePreparedJoinCommit: nativePreparedJoinCommit,
 									__peerbitNativePreparedJoinCommitValidatesPlan:
@@ -12003,7 +12022,7 @@ export class SharedLog<
 								__peerbitCanAppendAlreadyValidated:
 									fallbackCanAppendAlreadyValidated,
 								__peerbitDeferIndexWrite: true,
-								__peerbitOnAppendHashes: onAppendHashes,
+								__peerbitOnAppendHashes: joinOnAppendHashes,
 								__peerbitProfile: syncProfile,
 							});
 						}
@@ -12016,6 +12035,7 @@ export class SharedLog<
 								details: {
 									hashOnlyEntryAdded,
 									batchHashOnlyEntryAdded,
+									programOnChange,
 									joinedPreparedFacts,
 									nativePreparedCoordinatesFinished,
 								},

--- a/packages/programs/data/shared-log/test/sync-raw-exchange-heads.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-raw-exchange-heads.spec.ts
@@ -3433,4 +3433,266 @@ describe("raw exchange-head sync", () => {
 			await session.stop();
 		}
 	});
+
+	it("dispatches program onChange with lazy entries from the prepared raw receive", async () => {
+		const session = await TestSession.disconnected(2, {
+			indexer: (directory) => createRustIndexer(directory),
+		});
+
+		try {
+			const setup = {
+				domain: createReplicationDomainHash("u32"),
+				type: "u32" as const,
+				syncronizer: SimpleSyncronizer,
+				name: "u32-simple-raw",
+			};
+			const store = new EventStore<string, any>();
+			const profileEvents: any[] = [];
+			const changes: any[] = [];
+			const source = await session.peers[0].open(store.clone(), {
+				args: {
+					replicate: false,
+					setup,
+					nativeGraph: true,
+					nativeBackbone: { optional: false },
+					sync: { rawExchangeHeads: true },
+					keep: () => true,
+					timeUntilRoleMaturity: 0,
+				},
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: {
+					replicate: { factor: 1 },
+					setup,
+					nativeGraph: true,
+					nativeBackbone: { optional: false },
+					onChange: (change) => {
+						changes.push(change);
+					},
+					sync: {
+						rawExchangeHeads: true,
+						profile: (event: any) => profileEvents.push(event),
+					},
+					timeUntilRoleMaturity: 0,
+				},
+			});
+
+			const entryCount = 3;
+			const hashes: string[] = [];
+			for (let i = 0; i < entryCount; i++) {
+				const { entry } = await source.add(uuid(), { meta: { next: [] } });
+				hashes.push(entry.hash);
+			}
+			let message: RawExchangeHeadsMessage | undefined;
+			for await (const generated of createRawExchangeHeadsMessages(
+				source.log.log,
+				hashes,
+			)) {
+				message = generated as RawExchangeHeadsMessage;
+				break;
+			}
+			expect(message).to.be.instanceOf(RawExchangeHeadsMessage);
+
+			const sharedLog = target.log as any;
+			const backbone = sharedLog._nativeBackbone;
+			const nativePreparedJoinCommitSpy = sinon.spy(
+				backbone.graph,
+				"commitPreparedRawReceiveJoinBatch",
+			);
+			const nativeVerifiedPreparedJoinCommitSpy =
+				backbone.graph.commitVerifiedPreparedRawReceiveJoinBatch
+					? sinon.spy(
+							backbone.graph,
+							"commitVerifiedPreparedRawReceiveJoinBatch",
+						)
+					: undefined;
+			const nativeVerifiedAllPreparedJoinCommitSpy =
+				backbone.graph.commitVerifiedAllPreparedRawReceiveJoinBatch
+					? sinon.spy(
+							backbone.graph,
+							"commitVerifiedAllPreparedRawReceiveJoinBatch",
+						)
+					: undefined;
+			const entryAddedHashesSpy = sinon.spy(
+				target.log.syncronizer as any,
+				"onEntryAddedHashes",
+			);
+			try {
+				await target.log.onMessage(message!, {
+					from: source.node.identity.publicKey,
+				} as any);
+
+				expect(target.log.log.length).to.equal(entryCount);
+				// the program-level change consumer observed every commit
+				const added = changes.flatMap((change) => change.added);
+				expect(changes.length).to.be.greaterThan(0);
+				expect(added.map((a: any) => a.entry.hash)).to.have.members(hashes);
+				expect(added.every((a: any) => a.head === true)).to.equal(true);
+				expect(changes.flatMap((change) => change.removed)).to.have.length(
+					0,
+				);
+				// the hash-only synchronizer sink was replaced by the change
+				// dispatch, not run in addition to it
+				expect(entryAddedHashesSpy.callCount).to.equal(0);
+				// the native prepared join commit still ran: the consumer does
+				// not force the join off the native path
+				expect(
+					nativePreparedJoinCommitSpy.callCount +
+						(nativeVerifiedPreparedJoinCommitSpy?.callCount ?? 0) +
+						(nativeVerifiedAllPreparedJoinCommitSpy?.callCount ?? 0),
+				).to.equal(1);
+				// entries handed to the consumer are lazy views: nothing was
+				// borsh-decoded in JS yet
+				expect(
+					profileEvents.filter(
+						(event) =>
+							event.name === "sharedLog.rawReceive.jsEntryDecode" &&
+							event.details?.lazy === true,
+					),
+				).to.have.length(0);
+				// reading a payload materializes exactly that entry and counts it
+				await added[0]!.entry.getPayloadValue();
+				const lazyDecodes = profileEvents.filter(
+					(event) =>
+						event.name === "sharedLog.rawReceive.jsEntryDecode" &&
+						event.details?.lazy === true,
+				);
+				expect(lazyDecodes).to.have.length(1);
+				expect(lazyDecodes[0].entries).to.equal(1);
+			} finally {
+				entryAddedHashesSpy.restore();
+				nativeVerifiedAllPreparedJoinCommitSpy?.restore();
+				nativeVerifiedPreparedJoinCommitSpy?.restore();
+				nativePreparedJoinCommitSpy.restore();
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("runs the program canAppend hook on the raw receive path", async () => {
+		const session = await TestSession.disconnected(2, {
+			indexer: (directory) => createRustIndexer(directory),
+		});
+
+		try {
+			const setup = {
+				domain: createReplicationDomainHash("u32"),
+				type: "u32" as const,
+				syncronizer: SimpleSyncronizer,
+				name: "u32-simple-raw",
+			};
+			const store = new EventStore<string, any>();
+			const changes: any[] = [];
+			let allowAppends = true;
+			const canAppendHashes: string[] = [];
+			const source = await session.peers[0].open(store.clone(), {
+				args: {
+					replicate: false,
+					setup,
+					nativeGraph: true,
+					nativeBackbone: { optional: false },
+					sync: { rawExchangeHeads: true },
+					keep: () => true,
+					timeUntilRoleMaturity: 0,
+				},
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: {
+					replicate: { factor: 1 },
+					setup,
+					nativeGraph: true,
+					nativeBackbone: { optional: false },
+					canAppend: (entry) => {
+						canAppendHashes.push(entry.hash);
+						return allowAppends;
+					},
+					onChange: (change) => {
+						changes.push(change);
+					},
+					sync: { rawExchangeHeads: true },
+					timeUntilRoleMaturity: 0,
+				},
+			});
+
+			const entryCount = 3;
+			const hashes: string[] = [];
+			for (let i = 0; i < entryCount; i++) {
+				const { entry } = await source.add(uuid(), { meta: { next: [] } });
+				hashes.push(entry.hash);
+			}
+			const collectRawMessage = async (forHashes: string[]) => {
+				for await (const generated of createRawExchangeHeadsMessages(
+					source.log.log,
+					forHashes,
+				)) {
+					return generated as RawExchangeHeadsMessage;
+				}
+				throw new Error("Missing raw exchange heads message");
+			};
+
+			const sharedLog = target.log as any;
+			const backbone = sharedLog._nativeBackbone;
+			const nativePreparedJoinCommitSpy = sinon.spy(
+				backbone.graph,
+				"commitPreparedRawReceiveJoinBatch",
+			);
+			const nativeVerifiedPreparedJoinCommitSpy =
+				backbone.graph.commitVerifiedPreparedRawReceiveJoinBatch
+					? sinon.spy(
+							backbone.graph,
+							"commitVerifiedPreparedRawReceiveJoinBatch",
+						)
+					: undefined;
+			const nativeVerifiedAllPreparedJoinCommitSpy =
+				backbone.graph.commitVerifiedAllPreparedRawReceiveJoinBatch
+					? sinon.spy(
+							backbone.graph,
+							"commitVerifiedAllPreparedRawReceiveJoinBatch",
+						)
+					: undefined;
+			try {
+				await target.log.onMessage(await collectRawMessage(hashes), {
+					from: source.node.identity.publicKey,
+				} as any);
+
+				// the hook observed every entry and the entries committed
+				expect(canAppendHashes).to.have.members(hashes);
+				expect(target.log.log.length).to.equal(entryCount);
+				const added = changes.flatMap((change) => change.added);
+				expect(added.map((a: any) => a.entry.hash)).to.have.members(hashes);
+				// the native join commit (which cannot run the hook) was not used
+				expect(nativePreparedJoinCommitSpy.callCount).to.equal(0);
+				expect(nativeVerifiedPreparedJoinCommitSpy?.callCount ?? 0).to.equal(
+					0,
+				);
+				expect(
+					nativeVerifiedAllPreparedJoinCommitSpy?.callCount ?? 0,
+				).to.equal(0);
+
+				// a rejecting hook keeps entries out of the log
+				allowAppends = false;
+				const rejectedHashes: string[] = [];
+				for (let i = 0; i < entryCount; i++) {
+					const { entry } = await source.add(uuid(), {
+						meta: { next: [] },
+					});
+					rejectedHashes.push(entry.hash);
+				}
+				await target.log.onMessage(await collectRawMessage(rejectedHashes), {
+					from: source.node.identity.publicKey,
+				} as any);
+				expect(target.log.log.length).to.equal(entryCount);
+				for (const hash of rejectedHashes) {
+					expect(canAppendHashes).to.include(hash);
+				}
+			} finally {
+				nativeVerifiedAllPreparedJoinCommitSpy?.restore();
+				nativeVerifiedPreparedJoinCommitSpy?.restore();
+				nativePreparedJoinCommitSpy.restore();
+			}
+		} finally {
+			await session.stop();
+		}
+	});
 });

--- a/packages/transport/network-rust/ARCHITECTURE.md
+++ b/packages/transport/network-rust/ARCHITECTURE.md
@@ -289,7 +289,7 @@ turns them on together.
 | `sync.rawExchangeHeads` | `@peerbit/shared-log` open args | off | sender ships raw entry block bytes (`RawExchangeHeadsMessage [0,7]`, batched ≤ 512 KB) with no TS re-serialization |
 | `sync.nativeWireSync` | `@peerbit/shared-log` open args | off | receive fusion (section 2.4); requires `nativeBackbone`; registers the program topic with the session, resolves via the RPC `resolveRequest` hook |
 | `network` | `Peerbit.create` (`CreateInstanceOptions`) | off | native network plane: `rustCore` factory (one core shared by pubsub/fanout/blocks), `wireSync` factory (per-node session keyed by public key hash, installed as the pubsub inbound decoder), `sharedLogDefaults`. Requires client-built services — rejected early (before any resource is acquired) when combined with an external libp2p instance |
-| `network.sharedLogDefaults` | `Peerbit.create` | true when `network` is present | advertises `nativeBackbone: {}`, `nativeGraph: { optional: true }` (degrades instead of aborting program open when the optional native module is absent) and `sync: { rawExchangeHeads: true, nativeWireSync }` to programs opened on the client. Explicit per-open options — including `false` — always win. The raw-sync defaults apply only to programs **without** a program-level `onChange` consumer (section 9, onChange gap) |
+| `network.sharedLogDefaults` | `Peerbit.create` | true when `network` is present | advertises `nativeBackbone: {}`, `nativeGraph: { optional: true }` (degrades instead of aborting program open when the optional native module is absent) and `sync: { rawExchangeHeads: true, nativeWireSync }` to programs opened on the client. Explicit per-open options — including `false` — always win. Programs with a program-level `onChange` consumer (e.g. document stores) receive change events from the raw path as lazy entry views: entry bytes/decodes materialize only when the consumer reads them, and every materialization is counted (`sharedLog.rawReceive.jsEntryDecode`, stash `blockCopyOuts`). Programs with a `canAppend` hook run the lower-log batch join (hook fires per entry) instead of the native-validated commit |
 | `network` in `createRustPeerbitOptions()` | `peerbit/rust` preset | **on** inside the preset; `network: false` opts out | composes the chain: `rustCore → createRustCoreStream()` (`@peerbit/network-rust`), `wireSync → createNativeWireSyncSession({ selfHash })` (`@peerbit/native-backbone`), `sharedLogDefaults`; each individually toggleable (`rustCore` / `wireSync` / `sharedLogDefaults`, default true) |
 | `storage.nativeLogBlocks` | `peerbit/rust` preset (predates this plane) | off | native log block store for blocks; with `rustCore` set, stored blocks are served via `getBlockResponsePayload` straight from wasm. Memory-only: an error is logged when a `directory` is configured alongside it, since blocks (including program manifests) do not survive a restart |
 
@@ -396,12 +396,15 @@ Never run these benchmarks concurrently with builds or tests.
   exists in `sync_payload.rs`; fusing it (serialize from the native log
   block store straight into a `DataMessage` buffer) is the identified fix
   for the live-puts regression above.
-- **onChange gap** (pre-existing, reproduced at base): the prepared
-  raw-receive path never dispatches program-level `onChange`, so the
-  client-advertised raw sync defaults are gated to programs without a
-  per-entry `onChange` consumer. Document stores keep the plain exchange
-  path (still native wire + native index commit). The real fix is tracked
-  separately.
+- **Native document projection in raw receive.** The raw-receive path now
+  dispatches program-level `onChange` with lazy entry views (see the flag
+  matrix), so document stores take the raw path — but their per-entry
+  consumer materializes payload bytes and decodes in JS. Committing the
+  document index inside the wasm raw-receive pipeline (composing
+  `documents.rs` with the prepared join commit) and synthesizing the change
+  set from prepared-join facts would remove that per-entry JS work; the
+  strict-native document append path already commits natively and is the
+  starting point.
 - **Module unification.** `peerbit_wire` ships compiled into two wasm
   modules (section 1). Collapsing to one module — or sharing a memory —
   would drop the duplicate code weight and let the fanout/blocks streams


### PR DESCRIPTION
Fixes the raw-receive onChange gap (stacked on #988) and removes the workaround that routed document stores around the raw sync path.

## The bug

The prepared raw-receive path committed entries via a hash-only sink and never dispatched program-level `onChange` events — a document store syncing under `rawExchangeHeads` silently missed index commits (log filled, index stayed empty). Pre-existing at the #939 base; #988 mitigated it by gating raw sync defaults to programs without a per-entry onChange consumer.

## The fix

Change-event dispatch from prepared joins (design (b); native document projection inside wasm remains the follow-up recorded in ARCHITECTURE.md §10 — it only covers strict-native document stores, so it cannot replace the generic contract restored here):

- When a program registers an onChange consumer, `SharedLog.onMessage` no longer passes the hash-only sink, so the lower log dispatches the program-level change event. Dispatched entries are **lazy views** (`PreparedRawExchangeEntry`): meta reads come from prepared raw facts; block bytes and the borsh decode materialize only when the consumer touches payload/signatures/storage bytes (`Entry.prepareMultihashBytesLazy` keeps even prepared-block registration lazy over the wire stash). Materialization is counted (`jsEntryDecode` with `details.lazy`, stash `blockCopyOuts`/`bytesMaterialized`) — the fused no-consumer path stays assertable at zero.
- **Found and fixed while removing the gating**: the native-validated join commit bypassed program-level `canAppend` hooks (pre-existing at the #939 base, masked for document stores only by the gating). Programs with a hook now take the lower-log batch join where the hook fires per entry, with signatures still verified natively during prepare — without this, removing the gating would have silently bypassed document `canPerform` ACLs.
- The onChange-consumer gating is removed from the client-advertised native defaults; document stores inherit `rawExchangeHeads`+`nativeWireSync` from the preset.

## Verification

Bug-shape repro spec verified both directions (dispatch disabled: log fills, index stays 0; with fix: index commits land, change sets correct, raw wire path asserted). Full gate green: workspace build; shared-log part-4 mock run 117 passing (zero-decode invariants intact); document part-2a suites 344 + 3 passing — including the rewritten native E2E exercised end to end (program topic registers on the wire-sync session, consumer-driven lazy materialization is exactly what surfaces as stash copy-outs, index still commits natively); native-backbone cargo 11 + JS 59; log 231 (covers the lazy prepared-block API); peerbit client 66 (covers the default changes); eslint clean on the diff. No spec or source adjustments were needed during final verification.
