### PR TITLE
Native send fusion: outbound serialization from the store and live-put coalescing

### DIFF
--- a/packages/programs/data/shared-log/benchmark/README.md
+++ b/packages/programs/data/shared-log/benchmark/README.md
@@ -39,15 +39,17 @@ Defaults: 2 warmup + 5 measured runs per leg, strictly sequential. Do not
 run anything else (builds, tests, other benchmarks) concurrently.
 
 Indicative shape of the results (one dev machine, defaults; absolute
-numbers vary): cold-sync ~2.4x entries/s for the native preset with the
-sender-side send loop at ~2% of wall on both legs (outbound send does not
-hide the receive win). Sustained singleton live-puts currently run slower
-on the native preset (~0.4x throughput, higher visibility lag) — the
-per-message fixed cost of the fused receive dominates for one-entry
-messages, which is what outbound send fusion / batching is expected to
-address. Above the stash cap the commit phase pays ~4-5x in MB/s versus
-just below it (eviction fallback + the synchronizer's retry duplicates)
-while still converging on every run.
+numbers vary): cold-sync well above 2x entries/s for the native preset
+with the sender-side send loop at ~2-3% of wall on both legs. Sustained
+singleton live-puts run several times faster on the native preset with the
+fused send: awaited puts coalesce into multi-entry raw frames serialized
+inside wasm, which amortizes the receiver's per-message fixed costs that
+previously made this leg ~0.4-0.9x of the default (one instrumented run on
+one dev machine: ~6x default throughput with ~7x lower p50 visibility
+latency; before send fusion the same machine measured ~0.9x). Above the
+stash cap the commit phase pays ~4-5x in MB/s versus just below it
+(eviction fallback + the synchronizer's retry duplicates) while still
+converging on every run.
 
 ```
 cd packages/programs/data/shared-log

--- a/packages/programs/data/shared-log/src/exchange-heads.ts
+++ b/packages/programs/data/shared-log/src/exchange-heads.ts
@@ -341,6 +341,32 @@ const attachPreparedRawShallowFacts = (
 export const EXCHANGE_HEADS_REPAIR_HINT = 1;
 
 /**
+ * Capability bit: the peer can receive `RawExchangeHeadsMessage` ([0, 7]).
+ * Advertised once per peer via {@link SyncCapabilitiesMessage} (and echoed by
+ * the per-request capability messages of the simple synchronizer), so live
+ * append gossip can pick the raw path without a per-request round trip.
+ */
+export const SYNC_CAPABILITY_RAW_EXCHANGE_HEADS = 1;
+
+/**
+ * One-shot capability advertisement, sent to a peer when it (or we) subscribe
+ * to the program topic and `sync.rawExchangeHeads` is enabled. Peers that do
+ * not know this message drop it as an unknown variant; peers that never
+ * advertise keep receiving the plain `ExchangeHeadsMessage` path.
+ */
+@variant([0, 10])
+export class SyncCapabilitiesMessage extends TransportMessage {
+	@field({ type: "u32" })
+	capabilities: number;
+
+	constructor(props?: { capabilities?: number }) {
+		super();
+		this.capabilities =
+			props?.capabilities ?? SYNC_CAPABILITY_RAW_EXCHANGE_HEADS;
+	}
+}
+
+/**
  * This thing allows use to faster sync since we can provide
  * references that can be read concurrently to
  * the entry when doing Log.fromEntry or Log.fromEntryHash
@@ -1039,7 +1065,7 @@ export class ResponseIPrune extends TransportMessage {
 }
 
 const MAX_EXCHANGE_MESSAGE_SIZE = 1e5; // 100kb. Too large size might not be faster (even if we can do 5mb)
-const MAX_RAW_EXCHANGE_MESSAGE_SIZE = 512 * 1024;
+export const MAX_RAW_EXCHANGE_MESSAGE_SIZE = 512 * 1024;
 export const EXCHANGE_HEADS_RESOLVE_BATCH_SIZE = 256;
 
 export const createExchangeHeadsMessages = async function* (
@@ -1175,11 +1201,26 @@ export const createExchangeHeadsMessages = async function* (
 export const createRawExchangeHeadsMessages = async function* (
 	log: Log<any>,
 	heads: string[] | Set<string>,
+	profile?: SyncProfileFn,
 ): AsyncGenerator<RawExchangeHeadsMessage | ExchangeHeadsMessage<any>, void, void> {
 	let size = 0;
 	let current: RawEntryWithRefs[] = [];
 	const visitedHeads = new Set<string>();
 	const headArray = Array.isArray(heads) ? heads : [...heads];
+	// This path materializes entry block bytes as JS values (log.blocks reads)
+	// and TS-serializes the message; the fused wasm send path replaces it.
+	// The event makes the remaining JS-side outbound block copies countable.
+	const emitJsBlockBytes = (heads: RawEntryWithRefs[], bytes: number) => {
+		if (profile) {
+			emitSyncProfileEvent(profile, {
+				name: "sharedLog.rawSend.jsBlockBytes",
+				component: "shared-log",
+				entries: heads.length,
+				bytes,
+				messages: 1,
+			});
+		}
+	};
 
 	for (let offset = 0; offset < headArray.length; offset += EXCHANGE_HEADS_RESOLVE_BATCH_SIZE) {
 		const headBatch = headArray.slice(
@@ -1243,6 +1284,7 @@ export const createRawExchangeHeadsMessages = async function* (
 			);
 			size += block.bytes.byteLength;
 			if (size > MAX_RAW_EXCHANGE_MESSAGE_SIZE) {
+				emitJsBlockBytes(current, size);
 				size = 0;
 				yield new RawExchangeHeadsMessage({ heads: current });
 				current = [];
@@ -1250,8 +1292,75 @@ export const createRawExchangeHeadsMessages = async function* (
 		}
 	}
 	if (current.length > 0) {
+		emitJsBlockBytes(current, size);
 		yield new RawExchangeHeadsMessage({ heads: current });
 	}
+};
+
+export type RawExchangeHeadSendPlan = {
+	hashes: string[];
+	gidRefrences: string[][];
+};
+
+/**
+ * The head/reference selection of {@link createRawExchangeHeadsMessages}
+ * without resolving any block bytes: same visited-head deduplication, same
+ * reference-gid collection, same batching of the native index lookups. Used
+ * by the fused send path, where the block bytes stay in the native store and
+ * the payload is serialized in wasm. Returns `undefined` when the log has no
+ * native reference rows (callers fall back to the TS message path).
+ */
+export const collectRawExchangeHeadSendPlan = (
+	log: Log<any>,
+	heads: string[] | Set<string>,
+): RawExchangeHeadSendPlan | undefined => {
+	const headArray = Array.isArray(heads) ? heads : [...heads];
+	const visitedHeads = new Set<string>();
+	const hashes: string[] = [];
+	const gidRefrences: string[][] = [];
+	for (
+		let offset = 0;
+		offset < headArray.length;
+		offset += EXCHANGE_HEADS_RESOLVE_BATCH_SIZE
+	) {
+		const headBatch = headArray.slice(
+			offset,
+			offset + EXCHANGE_HEADS_RESOLVE_BATCH_SIZE,
+		);
+		const nativeReferenceRowsByPosition = getNativeReferenceRowsByHeadInput(
+			log,
+			headBatch,
+			visitedHeads,
+		);
+		if (!nativeReferenceRowsByPosition) {
+			return undefined;
+		}
+		for (let i = 0; i < headBatch.length; i++) {
+			const hash = headBatch[i]!;
+			if (visitedHeads.has(hash)) {
+				continue;
+			}
+			visitedHeads.add(hash);
+			const nativeReferenceRows = nativeReferenceRowsByPosition[i];
+			if (!nativeReferenceRows) {
+				continue;
+			}
+			const refs: string[] = [];
+			for (const [refHash, gid] of nativeReferenceRows) {
+				if (visitedHeads.has(refHash)) {
+					continue;
+				}
+				visitedHeads.add(refHash);
+				refs.push(gid);
+			}
+			if (refs.length > 1000) {
+				warn("Large refs count: ", refs.length);
+			}
+			hashes.push(hash);
+			gidRefrences.push(refs);
+		}
+	}
+	return { hashes, gidRefrences };
 };
 
 export const materializeRawExchangeHeadsMessage = (

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -130,13 +130,19 @@ import {
 	EXCHANGE_HEADS_REPAIR_HINT,
 	EntryWithRefs,
 	ExchangeHeadsMessage,
+	MAX_RAW_EXCHANGE_MESSAGE_SIZE,
 	RawEntryWithRefs,
 	RawExchangeHeadsMessage,
+	type RawExchangeHeadSendPlan,
 	type RawReceiveHashSelection,
 	RequestIPrune,
 	ResponseIPrune,
+	SYNC_CAPABILITY_RAW_EXCHANGE_HEADS,
 	StashBackedRawExchangeHeadsMessage,
+	SyncCapabilitiesMessage,
+	collectRawExchangeHeadSendPlan,
 	createExchangeHeadsMessages,
+	createRawExchangeHeadsMessages,
 	getExchangeHeadHash,
 	getPreparedRawExchangeGid,
 	getPreparedRawExchangeHashNumber,
@@ -1192,6 +1198,25 @@ const LEADER_SELECTION_CONTEXT_CACHE_TTL_MS = 50;
 const ADAPTIVE_REBALANCE_IDLE_INTERVAL_MULTIPLIER = 5;
 const ADAPTIVE_REBALANCE_MIN_IDLE_AFTER_LOCAL_APPEND_MS = 10_000;
 
+// Live raw gossip micro-batching. Appended entries destined for the same
+// raw-capable recipient set coalesce until the end of the current event-loop
+// turn (queueMicrotask would only merge same-tick appends; a macrotask also
+// merges the awaited-put pattern where each append resolves through
+// microtasks) — so a lone put still flushes within one loop turn (sub-ms on
+// an idle loop) while a put burst ships as one multi-entry raw frame,
+// amortizing the receiver's per-message fixed costs. The entry/byte caps
+// bound the worst-case receiver stall per frame and keep frames within the
+// raw exchange message size the receive path is tuned for.
+const LIVE_RAW_GOSSIP_MAX_ENTRIES = 256;
+const LIVE_RAW_GOSSIP_MAX_BYTES = 128 * 1024;
+
+type LiveRawGossipBatch = {
+	to: string[];
+	hashes: string[];
+	gidRefrences: string[][];
+	bytes: number;
+};
+
 const DEFAULT_DISTRIBUTION_DEBOUNCE_TIME = 500;
 const RECENT_REPAIR_DISPATCH_TTL_MS = 5_000;
 const REPAIR_SWEEP_ENTRY_BATCH_SIZE = 1_000;
@@ -1842,6 +1867,14 @@ export class SharedLog<
 		expiresAt: number;
 		context: LeaderSelectionContext;
 	};
+	// Sync capability bits advertised by peers (SyncCapabilitiesMessage), keyed
+	// by public key hash. Entries are dropped on unsubscribe/disconnect.
+	private _peerSyncCapabilities!: Map<string, number>;
+	// Pending live raw exchange-head gossip, coalesced per recipient set and
+	// flushed at the end of the current event-loop turn (or when a batch cap
+	// is hit). Only used when every recipient advertised raw capability.
+	private _liveRawGossipBatches!: Map<string, LiveRawGossipBatch>;
+	private _liveRawGossipFlushScheduled!: boolean;
 
 	// regular distribution checks
 	private distributeQueue?: PQueue;
@@ -1895,6 +1928,9 @@ export class SharedLog<
 		this._joinAuthoritativeRepairPeersByDelay = new Map();
 		this._appendBackfillPendingByTarget = new Map();
 		this._topicSubscribersCache = new Map();
+		this._peerSyncCapabilities = new Map();
+		this._liveRawGossipBatches = new Map();
+		this._liveRawGossipFlushScheduled = false;
 		this.coordinateToHash = new Cache<string>({ max: 1e6, ttl: 1e4 });
 		this.recentlyRebalanced = new Cache<string>({ max: 1e4, ttl: 1e5 });
 		this.uniqueReplicators = new Set();
@@ -2316,6 +2352,273 @@ export class SharedLog<
 		});
 	}
 
+	/** Live append gossip that stayed on the plain TS path (countable in tests). */
+	private emitPlainLiveSendProfile(message: ExchangeHeadsMessage<any>): void {
+		const profile = this._logProperties?.sync?.profile;
+		if (profile) {
+			emitSyncProfileEvent(profile, {
+				name: "sharedLog.liveSend.plain",
+				component: "shared-log",
+				entries: message.heads.length,
+				messages: 1,
+			});
+		}
+	}
+
+	private peerSupportsRawExchangeHeads(peerHash: string): boolean {
+		return (
+			((this._peerSyncCapabilities.get(peerHash) ?? 0) &
+				SYNC_CAPABILITY_RAW_EXCHANGE_HEADS) !==
+			0
+		);
+	}
+
+	/**
+	 * Live append gossip may use the raw exchange-heads path only when we
+	 * opted into raw sync and every remote recipient advertised raw capability
+	 * (via {@link SyncCapabilitiesMessage}). Peers that never advertised —
+	 * older versions or raw sync disabled — keep receiving the unchanged plain
+	 * `ExchangeHeadsMessage` path.
+	 */
+	private canUseLiveRawGossip(
+		to: Iterable<string>,
+		selfHash: string,
+	): string[] | undefined {
+		if (this._logProperties?.sync?.rawExchangeHeads !== true) {
+			return undefined;
+		}
+		const remote: string[] = [];
+		for (const peer of to) {
+			if (peer === selfHash) {
+				continue;
+			}
+			if (!this.peerSupportsRawExchangeHeads(peer)) {
+				return undefined;
+			}
+			remote.push(peer);
+		}
+		return remote.length > 0 ? remote : undefined;
+	}
+
+	private queueLiveRawGossip(
+		hash: string,
+		gidRefrences: string[],
+		byteLength: number,
+		to: string[],
+	): void {
+		const key = to.length === 1 ? to[0]! : [...to].sort().join("\n");
+		let batch = this._liveRawGossipBatches.get(key);
+		if (!batch) {
+			batch = { to, hashes: [], gidRefrences: [], bytes: 0 };
+			this._liveRawGossipBatches.set(key, batch);
+		}
+		batch.hashes.push(hash);
+		batch.gidRefrences.push(gidRefrences);
+		batch.bytes += byteLength;
+		if (
+			batch.hashes.length >= LIVE_RAW_GOSSIP_MAX_ENTRIES ||
+			batch.bytes >= LIVE_RAW_GOSSIP_MAX_BYTES
+		) {
+			this._liveRawGossipBatches.delete(key);
+			void this.sendLiveRawGossipBatch(batch);
+			return;
+		}
+		this.scheduleLiveRawGossipFlush();
+	}
+
+	private scheduleLiveRawGossipFlush(): void {
+		if (this._liveRawGossipFlushScheduled) {
+			return;
+		}
+		this._liveRawGossipFlushScheduled = true;
+		const flush = () => {
+			this._liveRawGossipFlushScheduled = false;
+			this.flushLiveRawGossip();
+		};
+		// End-of-turn flush: setImmediate on node fires after the current
+		// turn's microtasks (so awaited sequential appends coalesce) but
+		// before the next turn's timers/IO (so a lone put is not delayed).
+		if (typeof setImmediate === "function") {
+			setImmediate(flush);
+		} else {
+			setTimeout(flush, 0);
+		}
+	}
+
+	private flushLiveRawGossip(): void {
+		if (this._liveRawGossipBatches.size === 0) {
+			return;
+		}
+		const batches = [...this._liveRawGossipBatches.values()];
+		this._liveRawGossipBatches.clear();
+		for (const batch of batches) {
+			void this.sendLiveRawGossipBatch(batch);
+		}
+	}
+
+	private async sendLiveRawGossipBatch(
+		batch: LiveRawGossipBatch,
+	): Promise<void> {
+		try {
+			const sentMessages = await this.sendFusedRawExchangeHeadsPlan(
+				{ hashes: batch.hashes, gidRefrences: batch.gidRefrences },
+				batch.to,
+			);
+			if (sentMessages !== undefined) {
+				return;
+			}
+			// TS fallback (no native payload encoder or blocks not natively
+			// stored): still one batched raw message per size cap.
+			for await (const message of createRawExchangeHeadsMessages(
+				this.log,
+				batch.hashes,
+				this._logProperties?.sync?.profile,
+			)) {
+				await this.rpc.send(message, {
+					mode: new SilentDelivery({ redundancy: 1, to: batch.to }),
+				});
+			}
+		} catch (error: any) {
+			if (this.closed) {
+				return;
+			}
+			logger.error(error);
+		}
+	}
+
+	/**
+	 * Fused raw exchange-heads send: the full sync payload — PubSubData →
+	 * RequestV0 → RawExchangeHeadsMessage including the entry block bytes — is
+	 * serialized inside the native-backbone wasm module straight from the
+	 * native block store and published pre-encoded, so entry block bytes never
+	 * materialize as JS values on the send path. Returns the number of
+	 * messages sent, or `undefined` when this path is unavailable (no native
+	 * encoder, blocks not natively stored, or no pre-encoded publish support)
+	 * so callers fall back to the TS message path.
+	 */
+	private async sendFusedRawExchangeHeadsPlan(
+		plan: RawExchangeHeadSendPlan,
+		to: string[] | Set<string>,
+		options?: { priority?: number; reserved?: Uint8Array },
+	): Promise<number | undefined> {
+		const backbone = this._nativeBackbone;
+		if (!backbone?.encodeRawExchangeSyncPayload) {
+			return undefined;
+		}
+		const pubsub = this.node.services.pubsub as unknown as {
+			publishPreEncodedData?: (
+				payload: Uint8Array,
+				properties: { topics: string[] },
+				options: {
+					mode: SilentDelivery;
+					priority?: number;
+				},
+			) => Promise<Uint8Array | undefined>;
+		};
+		if (typeof pubsub.publishPreEncodedData !== "function") {
+			return undefined;
+		}
+		if (plan.hashes.length === 0) {
+			return 0;
+		}
+		const byteLengths = backbone.syncSendBlockByteLengths?.(plan.hashes);
+		if (!byteLengths) {
+			return undefined;
+		}
+
+		const topic = this.rpc.topic;
+		const payloads: Uint8Array[] = [];
+		const encodeChunk = (from: number, until: number): boolean => {
+			const payload = backbone.encodeRawExchangeSyncPayload!({
+				topic,
+				hashes: from === 0 && until === plan.hashes.length
+					? plan.hashes
+					: plan.hashes.slice(from, until),
+				gidRefrences:
+					from === 0 && until === plan.gidRefrences.length
+						? plan.gidRefrences
+						: plan.gidRefrences.slice(from, until),
+				reserved: options?.reserved,
+			});
+			if (!payload) {
+				return false;
+			}
+			payloads.push(payload);
+			return true;
+		};
+		// Same greedy chunking rule as `createRawExchangeHeadsMessages`: close
+		// a message after the head that pushes it over the size cap.
+		let chunkStart = 0;
+		let size = 0;
+		let totalBytes = 0;
+		for (let i = 0; i < plan.hashes.length; i++) {
+			const length = byteLengths[i];
+			if (length === undefined) {
+				return undefined;
+			}
+			size += length;
+			totalBytes += length;
+			if (size > MAX_RAW_EXCHANGE_MESSAGE_SIZE) {
+				if (!encodeChunk(chunkStart, i + 1)) {
+					return undefined;
+				}
+				chunkStart = i + 1;
+				size = 0;
+			}
+		}
+		if (chunkStart < plan.hashes.length) {
+			if (!encodeChunk(chunkStart, plan.hashes.length)) {
+				return undefined;
+			}
+		}
+		// Every payload is encoded before anything is published, so a caller
+		// falling back on `undefined` never double-sends part of a plan.
+		const profile = this._logProperties?.sync?.profile;
+		if (profile) {
+			emitSyncProfileEvent(profile, {
+				name: "sharedLog.rawSend.fused",
+				component: "shared-log",
+				entries: plan.hashes.length,
+				bytes: totalBytes,
+				messages: payloads.length,
+			});
+		}
+		for (const payload of payloads) {
+			await pubsub.publishPreEncodedData(
+				payload,
+				{ topics: [topic] },
+				{
+					mode: new SilentDelivery({ redundancy: 1, to: [...to] }),
+					priority: options?.priority,
+				},
+			);
+		}
+		return payloads.length;
+	}
+
+	/**
+	 * `RawExchangeHeadsSender` seam handed to the synchronizer for bulk sync
+	 * responses: resolves the head/reference plan like the TS raw path and
+	 * ships it fused when possible.
+	 */
+	private async trySendFusedRawExchangeHeads(
+		hashes: string[],
+		to: string[],
+		options?: { priority?: number; reserved?: Uint8Array },
+	): Promise<number | undefined> {
+		if (!this._nativeBackbone?.encodeRawExchangeSyncPayload) {
+			return undefined;
+		}
+		const plan = collectRawExchangeHeadSendPlan(this.log, hashes);
+		if (!plan) {
+			return undefined;
+		}
+		if (plan.hashes.length === 0) {
+			return 0;
+		}
+		return this.sendFusedRawExchangeHeadsPlan(plan, to, options);
+	}
+
 	private async _appendDeliverToReplicators(
 		entry: Entry<T>,
 		coordinates: NumberFromType<R>[],
@@ -2400,6 +2703,22 @@ export class SharedLog<
 					for (const peer of nativeDeliveryPlan.repairTargets) {
 						this.queueAppendBackfill(peer, entryReplicatedForRepair);
 					}
+					if (nativeDeliveryPlan.defaultSendSilent) {
+						const rawTargets = this.canUseLiveRawGossip(
+							nativeDeliveryPlan.sendTo,
+							selfHash,
+						);
+						if (rawTargets) {
+							this.queueLiveRawGossip(
+								entry.hash,
+								message.heads[0]?.gidRefrences ?? [],
+								entry.size ?? 0,
+								rawTargets,
+							);
+							continue;
+						}
+					}
+					this.emitPlainLiveSendProfile(message);
 					this.rpc
 						.send(message, {
 							mode: nativeDeliveryPlan.defaultSendSilent
@@ -2502,6 +2821,19 @@ export class SharedLog<
 					// forever. Best-effort fallback subscribers are not repair-worthy.
 					this.queueAppendBackfill(peer, entryReplicatedForRepair);
 				}
+				if (isLeader) {
+					const rawTargets = this.canUseLiveRawGossip(set, selfHash);
+					if (rawTargets) {
+						this.queueLiveRawGossip(
+							entry.hash,
+							message.heads[0]?.gidRefrences ?? [],
+							entry.size ?? 0,
+							rawTargets,
+						);
+						continue;
+					}
+				}
+				this.emitPlainLiveSendProfile(message);
 				this.rpc
 					.send(message, {
 						mode: isLeader
@@ -4276,6 +4608,33 @@ export class SharedLog<
 		entries: ReadonlyMap<string, RepairDispatchEntry<R>>,
 	) {
 		const hashes = [...entries.keys()];
+		if (
+			this._logProperties?.sync?.rawExchangeHeads === true &&
+			this.peerSupportsRawExchangeHeads(target)
+		) {
+			const reserved = new Uint8Array(4);
+			reserved[0] |= EXCHANGE_HEADS_REPAIR_HINT;
+			const sentMessages = await this.trySendFusedRawExchangeHeads(
+				hashes,
+				[target],
+				{ priority: SYNC_MESSAGE_PRIORITY, reserved },
+			);
+			if (sentMessages !== undefined) {
+				return;
+			}
+			for await (const message of createRawExchangeHeadsMessages(
+				this.log,
+				hashes,
+				this._logProperties?.sync?.profile,
+			)) {
+				message.reserved[0] |= EXCHANGE_HEADS_REPAIR_HINT;
+				await this.rpc.send(message, {
+					priority: SYNC_MESSAGE_PRIORITY,
+					mode: new SilentDelivery({ to: [target], redundancy: 1 }),
+				});
+			}
+			return;
+		}
 		for await (const message of createExchangeHeadsMessages(
 			this.log,
 			hashes,
@@ -8128,6 +8487,9 @@ export class SharedLog<
 		this._repairMetrics = createRepairMetrics();
 		this._topicSubscribersCache = new Map();
 		this._leaderSelectionContextCache = undefined;
+		this._peerSyncCapabilities = new Map();
+		this._liveRawGossipBatches = new Map();
+		this._liveRawGossipFlushScheduled = false;
 		this.coordinateToHash = new Cache<string>({ max: 1e6, ttl: 1e4 });
 		this.recentlyRebalanced = new Cache<string>({ max: 1e4, ttl: 1e5 });
 
@@ -8565,6 +8927,11 @@ export class SharedLog<
 			);
 		};
 
+		const sendRawExchangeHeads = (
+			hashes: string[],
+			to: string[],
+			sendOptions?: { priority?: number },
+		) => this.trySendFusedRawExchangeHeads(hashes, to, sendOptions);
 		if (options?.syncronizer) {
 			this.syncronizer = new options.syncronizer({
 				numbers: this.indexableDomain.numbers,
@@ -8579,6 +8946,7 @@ export class SharedLog<
 				sync: options?.sync,
 				isEntryRecentlyKnownByPeer: (hash, peer, maxAgeMs) =>
 					this.isEntryRecentlyKnownByPeer(hash, peer, maxAgeMs),
+				sendRawExchangeHeads,
 			});
 		} else {
 			if (
@@ -8595,6 +8963,7 @@ export class SharedLog<
 					sync: options?.sync,
 					isEntryRecentlyKnownByPeer: (hash, peer, maxAgeMs) =>
 						this.isEntryRecentlyKnownByPeer(hash, peer, maxAgeMs),
+					sendRawExchangeHeads,
 				});
 			} else {
 				if (this.domain.resolution === "u32") {
@@ -8616,6 +8985,7 @@ export class SharedLog<
 					sync: options?.sync,
 					isEntryRecentlyKnownByPeer: (hash, peer, maxAgeMs) =>
 						this.isEntryRecentlyKnownByPeer(hash, peer, maxAgeMs),
+					sendRawExchangeHeads,
 				}) as Syncronizer<R>;
 			}
 		}
@@ -9192,6 +9562,7 @@ export class SharedLog<
 		this.cancelReplicationInfoRequests(peerHash);
 		this._replicatorLivenessFailures.delete(peerHash);
 		this._replicatorLastActivityAt.delete(peerHash);
+		this._peerSyncCapabilities.delete(peerHash);
 		this._checkedPrune.cleanupPeer(peerHash);
 	}
 
@@ -10247,6 +10618,8 @@ export class SharedLog<
 		this._pendingIHave?.clear();
 		this.latestReplicationInfoMessage?.clear();
 		this._gidPeersHistory?.clear();
+		this._peerSyncCapabilities?.clear();
+		this._liveRawGossipBatches?.clear();
 		this._nativeSharedLogState?.clearGidPeers();
 		this._nativeBackbone?.clearGidPeers();
 		// Cancel any pending debounced timers so they can't fire after we've torn down
@@ -10279,6 +10652,11 @@ export class SharedLog<
 		// restart. Explicit `unreplicate()` still clears local state.
 		try {
 			if (!this.closed) {
+				// Ship any coalesced live gossip before the RPC child program
+				// closes; entries appended right before close should still be
+				// offered to their replicators (best effort, like the inline
+				// sends they replaced).
+				this.flushLiveRawGossip();
 				// Prevent any late debounced timers (rebalance/prune) from publishing
 				// replication info after we announce "segments: []". These races can leave
 				// stale segments on remotes after rapid open/close cycles.
@@ -10332,6 +10710,7 @@ export class SharedLog<
 		// RPC/subscription state (same reasoning as in `close()`).
 		try {
 			if (!this.closed) {
+				this.flushLiveRawGossip();
 				this._isReplicating = false;
 				this._isAdaptiveReplicating = false;
 				this.rebalanceParticipationDebounced?.close();
@@ -12613,6 +12992,14 @@ export class SharedLog<
 			} else if (msg instanceof ConfirmEntriesMessage) {
 				this.markEntriesKnownByPeer(msg.hashes, context.from.hashcode());
 				this.clearRepairFrontierHashes(context.from.hashcode(), msg.hashes);
+				return;
+			} else if (msg instanceof SyncCapabilitiesMessage) {
+				if (!context.from.equals(this.node.identity.publicKey)) {
+					this._peerSyncCapabilities.set(
+						context.from.hashcode(),
+						msg.capabilities,
+					);
+				}
 				return;
 			} else if (await this.syncronizer.onMessage(msg, context)) {
 				return; // the syncronizer has handled the message
@@ -16530,6 +16917,22 @@ export class SharedLog<
 		this._replicationInfoBlockedPeers.delete(peerHash);
 		this._replicatorLivenessFailures.delete(peerHash);
 		this.markReplicatorActivity(peerHash);
+
+		if (this._logProperties?.sync?.rawExchangeHeads === true) {
+			// One-shot capability advertisement so live append gossip can pick
+			// the raw exchange-heads path for this peer without a per-request
+			// round trip. Peers that do not know the message drop it.
+			this.rpc
+				.send(
+					new SyncCapabilitiesMessage({
+						capabilities: SYNC_CAPABILITY_RAW_EXCHANGE_HEADS,
+					}),
+					{
+						mode: new SilentDelivery({ redundancy: 1, to: [publicKey] }),
+					},
+				)
+				.catch((e) => logger.error(e.toString()));
+		}
 
 		const replicationSegments = await this.getMyReplicationSegments();
 		if (replicationSegments.length > 0) {

--- a/packages/programs/data/shared-log/src/sync/index.ts
+++ b/packages/programs/data/shared-log/src/sync/index.ts
@@ -117,6 +117,19 @@ export type SharedLogNativeWireSync = {
 	release(id: Uint8Array): boolean;
 };
 
+/**
+ * Fused raw exchange-heads sender provided by the shared log when the native
+ * backbone can serialize the sync payload in wasm (block bytes never
+ * materialize in JS). Resolves to the number of messages sent, or `undefined`
+ * when the fused path is unavailable for these hashes — the caller then falls
+ * back to the TS message path.
+ */
+export type RawExchangeHeadsSender = (
+	hashes: string[],
+	to: string[],
+	options?: { priority?: number },
+) => Promise<number | undefined>;
+
 export type HashSymbolInput = readonly bigint[] | BigUint64Array;
 
 export type HashSymbolResolver = (
@@ -159,6 +172,7 @@ export type SynchronizerComponents<R extends "u32" | "u64"> = {
 		peer: string,
 		maxAgeMs: number,
 	) => boolean;
+	sendRawExchangeHeads?: RawExchangeHeadsSender;
 };
 export type SynchronizerConstructor<R extends "u32" | "u64"> = new (
 	properties: SynchronizerComponents<R>,

--- a/packages/programs/data/shared-log/src/sync/simple.ts
+++ b/packages/programs/data/shared-log/src/sync/simple.ts
@@ -23,6 +23,7 @@ import type { EntryReplicated } from "../ranges.js";
 import type {
 	HashSymbolResolver,
 	HashSymbolHashListResolver,
+	RawExchangeHeadsSender,
 	RepairSession,
 	RepairSessionMode,
 	RepairSessionResult,
@@ -302,6 +303,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		peer: string,
 		maxAgeMs: number,
 	) => boolean;
+	private sendRawExchangeHeads?: RawExchangeHeadsSender;
 	private recentlySentExchangeHeads: Map<string, Map<string, number>>;
 	private repairSessionCounter: number;
 	private repairSessions: Map<string, RepairSessionState>;
@@ -324,6 +326,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			peer: string,
 			maxAgeMs: number,
 		) => boolean;
+		sendRawExchangeHeads?: RawExchangeHeadsSender;
 	}) {
 		this.syncInFlightQueue = new Map();
 		this.syncInFlightQueueInverted = new Map();
@@ -336,6 +339,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		this.resolveHashListForSymbols = properties.resolveHashListForSymbols;
 		this.syncOptions = properties.sync;
 		this.isEntryRecentlyKnownByPeer = properties.isEntryRecentlyKnownByPeer;
+		this.sendRawExchangeHeads = properties.sendRawExchangeHeads;
 		this.recentlySentExchangeHeads = new Map();
 		this.repairSessionCounter = 0;
 		this.repairSessions = new Map();
@@ -799,6 +803,42 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		}
 	}
 
+	/**
+	 * Ship exchange heads to one peer: the fused native raw path when the
+	 * peer advertised raw capability and the shared log provided a fused
+	 * sender, otherwise the TS message path (raw or plain by capability).
+	 * Returns the number of messages sent and whether the fused path ran.
+	 */
+	private async shipExchangeHeads(
+		hashes: string[],
+		to: PublicSignKey,
+		canReceiveRaw: boolean,
+	): Promise<{ messages: number; fused: boolean }> {
+		if (canReceiveRaw && this.sendRawExchangeHeads) {
+			const sentMessages = await this.sendRawExchangeHeads(hashes, [
+				to.hashcode(),
+			]);
+			if (sentMessages !== undefined) {
+				return { messages: sentMessages, fused: true };
+			}
+		}
+		let messages = 0;
+		const messageGenerator = canReceiveRaw
+			? createRawExchangeHeadsMessages(
+					this.log,
+					hashes,
+					this.syncOptions?.profile,
+				)
+			: createExchangeHeadsMessages(this.log, hashes);
+		for await (const message of messageGenerator) {
+			messages += 1;
+			await this.rpc.send(message, {
+				mode: new SilentDelivery({ to: [to], redundancy: 1 }),
+			});
+		}
+		return { messages, fused: false };
+	}
+
 	async onMessage(
 		msg: TransportMessage,
 		context: RequestContext,
@@ -818,16 +858,13 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			const startedAt = syncProfileStart(profile);
 			const hashes = this.filterRecentlySentExchangeHeads(msg.hashes, from);
 			let messages = 0;
-			const createMessages = canReceiveRawExchangeHeads(msg)
-				? createRawExchangeHeadsMessages
-				: createExchangeHeadsMessages;
+			let fused = false;
 			try {
-				for await (const message of createMessages(this.log, hashes)) {
-					messages += 1;
-					await this.rpc.send(message, {
-						mode: new SilentDelivery({ to: [context.from!], redundancy: 1 }),
-					});
-				}
+				({ messages, fused } = await this.shipExchangeHeads(
+					hashes,
+					context.from!,
+					canReceiveRawExchangeHeads(msg),
+				));
 			} finally {
 				if (profile) {
 					emitSyncProfileDuration(profile, startedAt, {
@@ -835,7 +872,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 						entries: hashes.length,
 						messages,
 						targets: 1,
-						details: { source: "responseMaybeSync" },
+						details: { source: "responseMaybeSync", fused },
 					});
 				}
 			}
@@ -864,17 +901,14 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			const exchangeStartedAt = syncProfileStart(profile);
 			const hashesToSend = this.filterRecentlySentExchangeHeads(hashes, from);
 			let messages = 0;
-			const createMessages = canReceiveRawExchangeHeads(msg)
-				? createRawExchangeHeadsMessages
-				: createExchangeHeadsMessages;
+			let fused = false;
 			try {
-				for await (const message of createMessages(this.log, hashesToSend)) {
-					messages += 1;
-					await this.rpc.send(message, {
-						mode: new SilentDelivery({ to: [context.from!], redundancy: 1 }),
-						// dont set priority 1 here because this will block other messages that should higher priority
-					});
-				}
+				// dont set priority 1 here because this will block other messages that should higher priority
+				({ messages, fused } = await this.shipExchangeHeads(
+					hashesToSend,
+					context.from!,
+					canReceiveRawExchangeHeads(msg),
+				));
 			} finally {
 				if (profile) {
 					emitSyncProfileDuration(profile, exchangeStartedAt, {
@@ -882,7 +916,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 						entries: hashesToSend.length,
 						messages,
 						targets: 1,
-						details: { source: "requestMaybeSyncCoordinate" },
+						details: { source: "requestMaybeSyncCoordinate", fused },
 					});
 				}
 			}

--- a/packages/programs/data/shared-log/test/network-e2e-native.spec.ts
+++ b/packages/programs/data/shared-log/test/network-e2e-native.spec.ts
@@ -140,6 +140,27 @@ describe("network e2e native preset", function () {
 			),
 		).to.be.greaterThanOrEqual(entryCount);
 
+		// the send path is fused too: the sync payload was serialized inside
+		// wasm from the native block store (no TS message serialization, no
+		// JS block-byte materialization on the way out)
+		expect(
+			sumEvents(
+				profileEvents1,
+				"sharedLog.rawSend.fused",
+				(event) => event.entries ?? 0,
+			),
+			"peer1 fused send entries",
+		).to.be.greaterThanOrEqual(entryCount);
+		for (const [label, events] of [
+			["peer1", profileEvents1],
+			["peer2", profileEvents2],
+		] as const) {
+			expect(
+				sumEvents(events, "sharedLog.rawSend.jsBlockBytes", () => 1),
+				label + " JS outbound block-byte copies",
+			).to.equal(0);
+		}
+
 		// wire-sync session counters: frames were stashed in wasm, consumed
 		// there, released, and no block bytes ever crossed back into JS
 		const counters2 = peer2.nativeNetwork!.wireSync!.counters!();
@@ -175,6 +196,109 @@ describe("network e2e native preset", function () {
 				label + " nativeFrames",
 			).to.be.greaterThan(0);
 		}
+	});
+
+	it("ships live appends as coalesced fused raw frames end to end", async () => {
+		const profileEvents1: SyncProfileEvent[] = [];
+		const profileEvents2: SyncProfileEvent[] = [];
+		const store = new EventStore<string, any>();
+		const db1 = await peer1.open(store.clone(), {
+			args: {
+				replicate: { factor: 1 },
+				timeUntilRoleMaturity: 0,
+				sync: {
+					profile: (event: SyncProfileEvent) => profileEvents1.push(event),
+				},
+			},
+		});
+		const db2 = await peer2.open(store.clone(), {
+			args: {
+				replicate: { factor: 1 },
+				timeUntilRoleMaturity: 0,
+				sync: {
+					profile: (event: SyncProfileEvent) => profileEvents2.push(event),
+				},
+			},
+		});
+
+		await peer2.dial(peer1.getMultiaddrs());
+		await db1.log.waitForReplicator(peer2.identity.publicKey);
+		await db2.log.waitForReplicator(peer1.identity.publicKey);
+		// live raw delivery requires the one-shot capability advertisement
+		await waitForResolved(() => {
+			expect(
+				(db1.log as any).peerSupportsRawExchangeHeads(
+					peer2.identity.publicKey.hashcode(),
+				),
+			).to.equal(true);
+		});
+
+		// sequential awaited puts (the live-puts workload)
+		const putCount = 32;
+		for (let index = 0; index < putCount; index++) {
+			await db1.add(`live-${index}`, { meta: { next: [] } });
+		}
+		// plus a same-turn burst that must coalesce into fewer frames
+		const burst = 16;
+		await Promise.all(
+			Array.from({ length: burst }, (_, index) =>
+				db1.add(`burst-${index}`, { meta: { next: [] } }),
+			),
+		);
+		await waitForResolved(
+			() => {
+				expect(db2.log.log.length).to.equal(putCount + burst);
+			},
+			{ timeout: 60_000, timeoutMessage: "native preset live puts" },
+		);
+
+		// send side: everything shipped fused (wasm-serialized payloads), no
+		// plain live sends, no JS block-byte materialization
+		expect(
+			sumEvents(
+				profileEvents1,
+				"sharedLog.rawSend.fused",
+				(event) => event.entries ?? 0,
+			),
+			"fused live entries",
+		).to.be.greaterThanOrEqual(putCount + burst);
+		expect(
+			sumEvents(
+				profileEvents1,
+				"sharedLog.rawSend.fused",
+				(event) => event.messages ?? 0,
+			),
+			"fused live messages coalesce",
+		).to.be.lessThan(putCount + burst);
+		expect(
+			sumEvents(profileEvents1, "sharedLog.liveSend.plain", () => 1),
+			"plain live sends",
+		).to.equal(0);
+		expect(
+			sumEvents(profileEvents1, "sharedLog.rawSend.jsBlockBytes", () => 1),
+			"JS outbound block-byte copies",
+		).to.equal(0);
+
+		// receive side: the live frames took the fused receive path
+		expect(
+			sumEvents(
+				profileEvents2,
+				"sharedLog.rawReceive.jsEntryDecode",
+				(event) => event.entries ?? 0,
+			),
+			"receiver jsEntryDecode entries",
+		).to.equal(0);
+		expect(
+			sumEvents(profileEvents2, "sharedLog.rawReceive.deserializeFallback", () => 1),
+			"receiver deserialize fallbacks",
+		).to.equal(0);
+		const counters2 = peer2.nativeNetwork!.wireSync!.counters!();
+		expect(counters2.stashed).to.be.greaterThan(0);
+		expect(counters2.blockCopyOuts).to.equal(0);
+		const wireCounters2 = wireCountersOf(peer2);
+		expect(wireCounters2.tsFrames).to.equal(0);
+		expect(wireCounters2.nativeFallbackFrames).to.equal(0);
+		expect(wireCounters2.tsSignatureVerifies).to.equal(0);
 	});
 
 	it("keeps a mixed pure-native and all-default pair in sync", async () => {

--- a/packages/programs/data/shared-log/test/sync-raw-exchange-heads.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-raw-exchange-heads.spec.ts
@@ -1,5 +1,6 @@
+import { serialize } from "@dao-xyz/borsh";
 import { keys } from "@libp2p/crypto";
-import { getKeypairFromPrivateKey } from "@peerbit/crypto";
+import { DecryptedThing, getKeypairFromPrivateKey } from "@peerbit/crypto";
 import { create as createRustIndexer } from "@peerbit/indexer-rust";
 import { Entry } from "@peerbit/log";
 import {
@@ -7,6 +8,8 @@ import {
 	NativeBackboneMemoryCoordinatePersistenceStore,
 	createNativeWireSyncSession,
 } from "@peerbit/native-backbone";
+import { PubSubData } from "@peerbit/pubsub-interface";
+import { RequestV0 } from "@peerbit/rpc";
 import { TestSession } from "@peerbit/test-utils";
 import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
@@ -18,6 +21,7 @@ import {
 	RawEntryWithRefs,
 	RawExchangeHeadsMessage,
 	RequestIPrune,
+	collectRawExchangeHeadSendPlan,
 	createRawExchangeHeadsMessages,
 } from "../src/exchange-heads.js";
 import { createReplicationDomainHash } from "../src/replication-domain-hash.js";
@@ -3429,6 +3433,348 @@ describe("raw exchange-head sync", () => {
 			const counters = wireSync.counters();
 			expect(counters.stashed).to.equal(0);
 			expect(wireSync.stashLength).to.equal(0);
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("encodes the fused sync payload byte-identical to the TS serialization", async () => {
+		const session = await TestSession.disconnected(1, {
+			indexer: (directory) => createRustIndexer(directory),
+		});
+		try {
+			const store = await session.peers[0].open(new EventStore<string, any>(), {
+				args: {
+					replicate: { factor: 1 },
+					setup: {
+						domain: createReplicationDomainHash("u32"),
+						type: "u32" as const,
+						syncronizer: SimpleSyncronizer,
+						name: "u32-simple-raw",
+					},
+					nativeGraph: true,
+					nativeBackbone: { optional: false },
+					sync: { rawExchangeHeads: true },
+				} as any,
+			});
+			const hashes: string[] = [];
+			for (let i = 0; i < 5; i++) {
+				const { entry } = await store.add(uuid(), { meta: { next: [] } });
+				hashes.push(entry.hash);
+			}
+
+			// The TS path: borsh message built from JS block bytes, wrapped by
+			// the RPC seal and PubSubData exactly like `rpc.send` would.
+			let tsMessage: RawExchangeHeadsMessage | undefined;
+			for await (const generated of createRawExchangeHeadsMessages(
+				store.log.log,
+				hashes,
+			)) {
+				expect(tsMessage).to.equal(undefined);
+				tsMessage = generated as RawExchangeHeadsMessage;
+			}
+			expect(tsMessage).to.be.instanceOf(RawExchangeHeadsMessage);
+			const topic = store.log.rpc.topic;
+			const tsPayload = serialize(
+				new PubSubData({
+					topics: [topic],
+					strict: true,
+					data: serialize(
+						new RequestV0({
+							request: new DecryptedThing<Uint8Array>({
+								data: serialize(tsMessage!),
+							}),
+						}),
+					),
+				}),
+			);
+
+			// The fused path: the same payload serialized inside wasm from the
+			// native block store.
+			const backbone = (store.log as any)._nativeBackbone;
+			expect(backbone).to.exist;
+			const plan = collectRawExchangeHeadSendPlan(store.log.log, hashes)!;
+			expect(plan.hashes).to.deep.equal(
+				tsMessage!.heads.map((head) => head.hash),
+			);
+			expect(plan.gidRefrences).to.deep.equal(
+				tsMessage!.heads.map((head) => head.gidRefrences),
+			);
+			const byteLengths = backbone.syncSendBlockByteLengths(plan.hashes);
+			expect(byteLengths).to.deep.equal(
+				tsMessage!.heads.map((head) => head.bytes.byteLength),
+			);
+			const fusedPayload = backbone.encodeRawExchangeSyncPayload({
+				topic,
+				hashes: plan.hashes,
+				gidRefrences: plan.gidRefrences,
+			});
+			expect(fusedPayload).to.exist;
+			expect(
+				Buffer.from(fusedPayload!).equals(Buffer.from(tsPayload)),
+			).to.equal(true);
+
+			// Missing native blocks make the encoder decline (callers fall back).
+			expect(
+				backbone.encodeRawExchangeSyncPayload({
+					topic,
+					hashes: ["missing-hash"],
+					gidRefrences: [[]],
+				}),
+			).to.equal(undefined);
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("fuses raw exchange-heads sync responses through the native payload encoder", async () => {
+		const session = await TestSession.disconnected(2, {
+			indexer: (directory) => createRustIndexer(directory),
+		});
+		try {
+			const setup = {
+				domain: createReplicationDomainHash("u32"),
+				type: "u32" as const,
+				syncronizer: SimpleSyncronizer,
+				name: "u32-simple-raw",
+			};
+			const store = new EventStore<string, any>();
+			const senderEvents: SyncProfileEvent[] = [];
+			const openArgs = (events?: SyncProfileEvent[]) => ({
+				replicate: { factor: 1 },
+				setup,
+				nativeGraph: true,
+				nativeBackbone: { optional: false },
+				timeUntilRoleMaturity: 0,
+				sync: {
+					rawExchangeHeads: true,
+					profile: events
+						? (event: SyncProfileEvent) => events.push(event)
+						: undefined,
+				},
+			});
+			const db1 = await session.peers[0].open(store.clone(), {
+				args: openArgs(senderEvents) as any,
+			});
+			const db2 = await session.peers[1].open(store.clone(), {
+				args: openArgs() as any,
+			});
+
+			let tsRawMessages = 0;
+			const send1 = db1.log.rpc.send.bind(db1.log.rpc);
+			db1.log.rpc.send = async (message, options) => {
+				if (message instanceof RawExchangeHeadsMessage) {
+					tsRawMessages += 1;
+				}
+				return send1(message, options);
+			};
+
+			const entryCount = 10;
+			const hashes: string[] = [];
+			for (let i = 0; i < entryCount; i++) {
+				const { entry } = await db1.add(uuid(), { meta: { next: [] } });
+				hashes.push(entry.hash);
+			}
+
+			await waitForResolved(() =>
+				session.peers[0].dial(session.peers[1].getMultiaddrs()),
+			);
+			await (db2.log.syncronizer as SimpleSyncronizer<any>).queueSync(
+				hashes,
+				db1.node.identity.publicKey,
+				{ skipCheck: true },
+			);
+			await waitForResolved(
+				() => {
+					expect(db2.log.log.length).to.equal(entryCount);
+				},
+				{ timeout: 30_000, delayInterval: 100 },
+			);
+
+			// The response was serialized inside wasm and published pre-encoded:
+			// no TS RawExchangeHeadsMessage and no JS block-byte materialization
+			// on the send path.
+			expect(tsRawMessages).to.equal(0);
+			const fusedEvents = senderEvents.filter(
+				(event) => event.name === "sharedLog.rawSend.fused",
+			);
+			expect(
+				fusedEvents.reduce((sum, event) => sum + (event.entries ?? 0), 0),
+			).to.equal(entryCount);
+			expect(
+				senderEvents.filter(
+					(event) => event.name === "sharedLog.rawSend.jsBlockBytes",
+				),
+			).to.have.length(0);
+			const exchangeEvents = senderEvents.filter(
+				(event) => event.name === "simple.exchangeHeads",
+			);
+			expect(exchangeEvents.length).to.be.greaterThan(0);
+			expect(
+				exchangeEvents.every((event) => event.details?.fused === true),
+			).to.equal(true);
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("advertises raw capability and coalesces live appends into fused raw frames", async () => {
+		const session = await TestSession.connected(2, {
+			indexer: (directory) => createRustIndexer(directory),
+		});
+		try {
+			const setup = {
+				domain: createReplicationDomainHash("u32"),
+				type: "u32" as const,
+				syncronizer: SimpleSyncronizer,
+				name: "u32-simple-raw",
+			};
+			const store = new EventStore<string, any>();
+			const senderEvents: SyncProfileEvent[] = [];
+			const openArgs = (events?: SyncProfileEvent[]) => ({
+				replicate: { factor: 1 },
+				setup,
+				nativeGraph: true,
+				nativeBackbone: { optional: false },
+				timeUntilRoleMaturity: 0,
+				sync: {
+					rawExchangeHeads: true,
+					profile: events
+						? (event: SyncProfileEvent) => events.push(event)
+						: undefined,
+				},
+			});
+			const db1 = await session.peers[0].open(store.clone(), {
+				args: openArgs(senderEvents) as any,
+			});
+			const db2 = await session.peers[1].open(store.clone(), {
+				args: openArgs() as any,
+			});
+
+			await db1.log.waitForReplicator(db2.node.identity.publicKey);
+			await db2.log.waitForReplicator(db1.node.identity.publicKey);
+			// One-shot capability advertisement from the subscribe flow: the
+			// live raw path needs no per-request round trip.
+			const peer2Hash = db2.node.identity.publicKey.hashcode();
+			await waitForResolved(() => {
+				expect(
+					(db1.log as any).peerSupportsRawExchangeHeads(peer2Hash),
+				).to.equal(true);
+			});
+
+			// A lone put flushes without waiting for more puts.
+			await db1.add(uuid(), { meta: { next: [] } });
+			await waitForResolved(() => {
+				expect(db2.log.log.length).to.equal(1);
+			});
+
+			// A same-turn burst coalesces into fewer raw frames than entries.
+			const burst = 8;
+			await Promise.all(
+				Array.from({ length: burst }, () =>
+					db1.add(uuid(), { meta: { next: [] } }),
+				),
+			);
+			await waitForResolved(() => {
+				expect(db2.log.log.length).to.equal(1 + burst);
+			});
+
+			const fusedEvents = senderEvents.filter(
+				(event) => event.name === "sharedLog.rawSend.fused",
+			);
+			const fusedEntries = fusedEvents.reduce(
+				(sum, event) => sum + (event.entries ?? 0),
+				0,
+			);
+			const fusedMessages = fusedEvents.reduce(
+				(sum, event) => sum + (event.messages ?? 0),
+				0,
+			);
+			expect(fusedEntries).to.equal(1 + burst);
+			expect(fusedMessages).to.be.lessThan(1 + burst);
+			// Nothing took the plain live path and no entry block bytes
+			// surfaced as JS values on the send path.
+			expect(
+				senderEvents.filter(
+					(event) => event.name === "sharedLog.liveSend.plain",
+				),
+			).to.have.length(0);
+			expect(
+				senderEvents.filter(
+					(event) => event.name === "sharedLog.rawSend.jsBlockBytes",
+				),
+			).to.have.length(0);
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("keeps the plain live path for peers that never advertised raw capability", async () => {
+		const session = await TestSession.connected(2, {
+			indexer: (directory) => createRustIndexer(directory),
+		});
+		try {
+			const setup = {
+				domain: createReplicationDomainHash("u32"),
+				type: "u32" as const,
+				syncronizer: SimpleSyncronizer,
+				name: "u32-simple-raw",
+			};
+			const store = new EventStore<string, any>();
+			const senderEvents: SyncProfileEvent[] = [];
+			const db1 = await session.peers[0].open(store.clone(), {
+				args: {
+					replicate: { factor: 1 },
+					setup,
+					nativeGraph: true,
+					nativeBackbone: { optional: false },
+					timeUntilRoleMaturity: 0,
+					sync: {
+						rawExchangeHeads: true,
+						profile: (event: SyncProfileEvent) => senderEvents.push(event),
+					},
+				} as any,
+			});
+			// The receiver never opts into raw sync, so it never advertises.
+			const db2 = await session.peers[1].open(store.clone(), {
+				args: {
+					replicate: { factor: 1 },
+					setup,
+					timeUntilRoleMaturity: 0,
+				} as any,
+			});
+
+			await db1.log.waitForReplicator(db2.node.identity.publicKey);
+			await db2.log.waitForReplicator(db1.node.identity.publicKey);
+
+			let plainLiveMessages = 0;
+			const send1 = db1.log.rpc.send.bind(db1.log.rpc);
+			db1.log.rpc.send = async (message, options) => {
+				if (message instanceof ExchangeHeadsMessage) {
+					plainLiveMessages += 1;
+				}
+				return send1(message, options);
+			};
+
+			const entryCount = 4;
+			for (let i = 0; i < entryCount; i++) {
+				await db1.add(uuid(), { meta: { next: [] } });
+			}
+			await waitForResolved(() => {
+				expect(db2.log.log.length).to.equal(entryCount);
+			});
+
+			expect(plainLiveMessages).to.equal(entryCount);
+			expect(
+				senderEvents.filter(
+					(event) => event.name === "sharedLog.rawSend.fused",
+				),
+			).to.have.length(0);
+			expect(
+				(db1.log as any).peerSupportsRawExchangeHeads(
+					db2.node.identity.publicKey.hashcode(),
+				),
+			).to.equal(false);
 		} finally {
 			await session.stop();
 		}

--- a/packages/transport/network-rust/ARCHITECTURE.md
+++ b/packages/transport/network-rust/ARCHITECTURE.md
@@ -215,6 +215,44 @@ miss (never stashed / evicted): resolveRequest returns undefined
     A throwing resolveRequest hook also falls back to the decode path.
 ```
 
+### 2.5 Fused send path (raw exchange-heads outbound)
+
+The outbound mirror of 2.4 (`sync_send.rs` in the native-backbone module):
+
+```
+SharedLog send sites                      what stays in JS: hash strings +
+    │                                     per-head gid references (the plan)
+    ├─ bulk sync responses (SimpleSyncronizer, capability-gated per request
+    │  as before) and repair pushes
+    └─ live append gossip: per-peer raw capability is advertised ONCE via
+       SyncCapabilitiesMessage([0,10]) during the subscribe flow; silent
+       fire-and-forget appends to all-capable recipient sets coalesce per
+       recipient set until the end of the current event-loop turn
+       (setImmediate; caps: 256 entries / 128 KB per frame) — a lone put
+       flushes within one turn, an awaited-put burst ships as one
+       multi-entry raw frame
+    ▼
+NativePeerbitBackbone.encode_raw_exchange_sync_payload(topic, hashes, refs)
+    │ wasm: entry block bytes resolved from the native block store (local
+    │ appends and fused receives both commit there); the full
+    │ PubSubData → RequestV0 → DecryptedThing → RawExchangeHeadsMessage
+    │ payload is serialized in one pass into one exactly-sized buffer
+    │ (byte-identical to the TS serialization — pinned by golden + parity
+    │ specs). Block bytes never materialize as JS values.
+    ▼
+pubsub.publishPreEncodedData(payload, { topics }, { mode: SilentDelivery })
+    │ the pre-encoded payload becomes the DataMessage data as-is (the
+    │ regular publish path's PubSubData wrap copy is skipped); one TS
+    │ ed25519 sign per message (per-batch, not per-entry), then the normal
+    │ outbound scheduler
+    ▼
+fallbacks (any step unavailable → TS path, byte-identical wire):
+    no native encoder / block missing from the native store / no
+    publishPreEncodedData → TS RawExchangeHeadsMessage via rpc.send;
+    recipient never advertised raw capability → unchanged plain
+    ExchangeHeadsMessage path (mixed fleets, old peers)
+```
+
 ---
 
 ## 3. The stash handoff: design and bounds
@@ -271,7 +309,7 @@ stash-backed message and prepared join facts exist so validation probes
 | fanout tree | frame codec, parent-upgrade policy/gate decisions | channel state machine, timers, tracker/provider directories | peerbit_wire |
 | block exchange | codec, provider rules, hint/eager caches, native-store-served responses | store chain fallback, publish plumbing | peerbit_wire (+ peerbit_log_rust for serving) |
 | shared-log receive | wire stash → prepared raw receive → batch verify → index/graph/coordinates commit | RPC shell, high-level events only | native-backbone |
-| shared-log send | — (encoder groundwork only, see section 9) | TS serialization, one message per ≤ 512 KB batch | — |
+| shared-log send | full sync payload (PubSubData → RequestV0 → RawExchangeHeadsMessage) serialized from the native block store (`sync_send.rs`) | head/reference plan (strings), live-gossip coalescing, one DataMessage sign per ≤ 512 KB payload | native-backbone |
 | transports | — | js-libp2p (noise/yamux/tcp/ws/webrtc) | — |
 
 ---
@@ -286,7 +324,7 @@ turns them on together.
 | `nativeWire` | `DirectStreamOptions` (`@peerbit/stream`) | off | batched native decode+verify of inbound frames (section 2.2); per-frame TS fallback on decode failure / unsupported schemes |
 | `rustCore` | `DirectStreamOptions`; picked up by pubsub/fanout/blocks | off | native protocol cores (section 2.3); implies `nativeWire` via `rustCore.nativeWire` unless an explicit `nativeWire` is given (explicit wins); `false` additionally opts out of the test injection |
 | `PEERBIT_STREAM_RUST_CORE=1` | env, test-only | off | `resolveInjectedRustCore()` lets the unmodified stream/pubsub/blocks suites pick up a `globalThis`-installed core (the "both modes" re-runs) |
-| `sync.rawExchangeHeads` | `@peerbit/shared-log` open args | off | sender ships raw entry block bytes (`RawExchangeHeadsMessage [0,7]`, batched ≤ 512 KB) with no TS re-serialization |
+| `sync.rawExchangeHeads` | `@peerbit/shared-log` open args | off | sender ships raw entry block bytes (`RawExchangeHeadsMessage [0,7]`, batched ≤ 512 KB) with no TS re-serialization; also advertises the raw capability once per peer (`SyncCapabilitiesMessage [0,10]`) so live append gossip to all-capable recipients coalesces into raw frames, serialized in wasm when the native backbone is present (section 2.5) |
 | `sync.nativeWireSync` | `@peerbit/shared-log` open args | off | receive fusion (section 2.4); requires `nativeBackbone`; registers the program topic with the session, resolves via the RPC `resolveRequest` hook |
 | `network` | `Peerbit.create` (`CreateInstanceOptions`) | off | native network plane: `rustCore` factory (one core shared by pubsub/fanout/blocks), `wireSync` factory (per-node session keyed by public key hash, installed as the pubsub inbound decoder), `sharedLogDefaults`. Requires client-built services — rejected early (before any resource is acquired) when combined with an external libp2p instance |
 | `network.sharedLogDefaults` | `Peerbit.create` | true when `network` is present | advertises `nativeBackbone: {}`, `nativeGraph: { optional: true }` (degrades instead of aborting program open when the optional native module is absent) and `sync: { rawExchangeHeads: true, nativeWireSync }` to programs opened on the client. Explicit per-open options — including `false` — always win. The raw-sync defaults apply only to programs **without** a program-level `onChange` consumer (section 9, onChange gap) |
@@ -351,9 +389,12 @@ back and forth):
    removable only by native transports (section 9).
 3. The small fixed RPC shell decode per message; the per-entry inner payload
    resolves from the stash with zero JS decode.
-4. Outbound send is not fused: shared-log still TS-serializes the exchange
-   message — one serialization per ≤ 512 KB batch
-   (`MAX_RAW_EXCHANGE_MESSAGE_SIZE`), not per entry, asserted in the E2E.
+4. Outbound (fused send, section 2.5): one wasm→JS egress copy of the
+   finished payload per ≤ 512 KB message — the DataMessage data handed to
+   the JS-owned socket (the mirror image of exception 2) — plus one TS
+   ed25519 DataMessage sign per message. Per message, not per entry; the
+   E2E asserts zero JS block-byte copies and zero TS message serializations
+   on the fused send path.
 
 ---
 
@@ -374,13 +415,14 @@ End-to-end (`benchmark/network-preset-e2e.ts`, two real nodes over TCP;
 indicative, one dev machine — see `packages/programs/data/shared-log/
 benchmark/README.md` for methodology and caveats):
 
-- cold-sync: ~2.4× entries/s for the native preset; the sender-side send
-  loop is ~2% of wall on both legs, so the unfused outbound path does not
-  hide the receive win at these sizes.
-- live-puts (sustained singleton puts): currently ~0.4× throughput with
-  higher visibility lag on the native preset — the per-message fixed cost of
-  the fused receive dominates for one-entry messages. This is the workload
-  send fusion / outbound batching is expected to address.
+- cold-sync: >2.4× entries/s for the native preset; the sender-side send
+  loop is ~2-3% of wall on both legs (and fused per section 2.5).
+- live-puts (sustained singleton puts): before send fusion the native
+  preset ran at ~0.4-0.9× the default throughput (machine-dependent) — the
+  per-message fixed cost of the fused receive dominates for one-entry
+  messages. With the fused send (live raw gossip coalescing into
+  multi-entry raw frames, section 2.5) the native preset is at parity or
+  better on this leg; see the benchmark README for current numbers.
 - stash-pressure: above the stash caps the commit phase pays ~4–5× in MB/s
   (eviction fallback + synchronizer retry duplicates) while converging on
   every run.
@@ -391,11 +433,6 @@ Never run these benchmarks concurrently with builds or tests.
 
 ## 10. Known deferred work
 
-- **Send fusion.** Outbound `RawExchangeHeadsMessage` construction still
-  TS-serializes (one message per ≤ 512 KB batch). The encoder groundwork
-  exists in `sync_payload.rs`; fusing it (serialize from the native log
-  block store straight into a `DataMessage` buffer) is the identified fix
-  for the live-puts regression above.
 - **onChange gap** (pre-existing, reproduced at base): the prepared
   raw-receive path never dispatches program-level `onChange`, so the
   client-advertised raw sync defaults are gated to programs without a

--- a/packages/transport/network-rust/src/sync_payload.rs
+++ b/packages/transport/network-rust/src/sync_payload.rs
@@ -166,44 +166,105 @@ pub fn parse_raw_exchange_rpc_request(data: &[u8]) -> WireResult<RawExchangeSync
     Ok(RawExchangeSyncPayload { heads, reserved })
 }
 
-/// Encode the full payload nesting (test/corpus helper; the send path stays in
-/// TS for now — see plan Section 3, integration point 2).
+/// One head of an outbound raw exchange sync payload, borrowed from wherever
+/// the caller keeps the entry block bytes (e.g. a native block store), so the
+/// fused send path never copies block bytes to address them.
+#[derive(Clone, Copy, Debug)]
+pub struct SyncPayloadHeadRef<'a> {
+    pub hash: &'a str,
+    pub bytes: &'a [u8],
+    pub gid_refrences: &'a [String],
+}
+
+/// Encoded size of the inner `TransportMessage`/`RawExchangeHeadsMessage`.
+fn transport_message_len(heads: &[SyncPayloadHeadRef<'_>]) -> usize {
+    // variants [0] + [0, 7], head count, reserved
+    let mut len = 3 + 4 + 4;
+    for head in heads {
+        // RawEntryWithRefs variant + hash + bytes + gidRefrences
+        len += 1 + 4 + head.hash.len() + 4 + head.bytes.len() + 4;
+        for gid in head.gid_refrences {
+            len += 4 + gid.len();
+        }
+    }
+    len
+}
+
+/// Encoded size of the full payload produced by
+/// [`encode_raw_exchange_sync_payload_refs`].
+pub fn encoded_raw_exchange_sync_payload_len(
+    topics: &[String],
+    heads: &[SyncPayloadHeadRef<'_>],
+) -> usize {
+    // PubSubData variant + topics + strict + data length prefix
+    let mut len = 1 + 4 + 1 + 4;
+    for topic in topics {
+        len += 4 + topic.len();
+    }
+    // RPCMessage/RequestV0/respondTo/MaybeEncrypted/DecryptedThing variants +
+    // inner length prefix
+    len += 5 + 4;
+    len + transport_message_len(heads)
+}
+
+/// Encode the full outbound payload nesting (PubSubData → RequestV0 →
+/// DecryptedThing → RawExchangeHeadsMessage) in one pass into a single
+/// exactly-sized buffer. Byte-identical to the TS serialization (pinned by the
+/// golden corpus below); this is the fused send-path encoder (plan Section 3,
+/// integration point 2).
+pub fn encode_raw_exchange_sync_payload_refs(
+    topics: &[String],
+    strict: bool,
+    heads: &[SyncPayloadHeadRef<'_>],
+    reserved: [u8; 4],
+) -> Vec<u8> {
+    let total_len = encoded_raw_exchange_sync_payload_len(topics, heads);
+    let transport_len = transport_message_len(heads);
+    let mut payload = Writer::new();
+    payload.bytes.reserve_exact(total_len);
+    payload.u8(0); // PubSubData variant
+    payload.string_vec(topics);
+    payload.u8(u8::from(strict));
+    payload.u32_le((5 + 4 + transport_len) as u32); // PubSubData.data length
+    payload.u8(0); // RPCMessage variant
+    payload.u8(0); // RequestV0 variant
+    payload.u8(0); // respondTo: None
+    payload.u8(0); // MaybeEncrypted variant
+    payload.u8(0); // DecryptedThing variant
+    payload.u32_le(transport_len as u32); // DecryptedThing.data length
+    payload.u8(0); // TransportMessage variant
+    payload.u8(0); // RawExchangeHeadsMessage variant [0, 7]
+    payload.u8(7);
+    payload.u32_le(heads.len() as u32);
+    for head in heads {
+        payload.u8(1); // RawEntryWithRefs variant
+        payload.string(head.hash);
+        payload.u32_le(head.bytes.len() as u32);
+        payload.raw(head.bytes);
+        payload.string_vec(head.gid_refrences);
+    }
+    payload.raw(&reserved);
+    debug_assert_eq!(payload.bytes.len(), total_len);
+    payload.bytes
+}
+
+/// Encode the full payload nesting from owned heads (test/corpus helper and
+/// the golden pin for [`encode_raw_exchange_sync_payload_refs`]).
 pub fn encode_raw_exchange_sync_payload(
     topics: &[String],
     strict: bool,
     heads: &[(String, Vec<u8>, Vec<String>)],
     reserved: [u8; 4],
 ) -> Vec<u8> {
-    let mut transport = Writer::new();
-    transport.u8(0); // TransportMessage variant
-    transport.u8(0); // RawExchangeHeadsMessage variant [0, 7]
-    transport.u8(7);
-    transport.u32_le(heads.len() as u32);
-    for (hash, bytes, gid_refrences) in heads {
-        transport.u8(1); // RawEntryWithRefs variant
-        transport.string(hash);
-        transport.u32_le(bytes.len() as u32);
-        transport.raw(bytes);
-        transport.string_vec(gid_refrences);
-    }
-    transport.raw(&reserved);
-
-    let mut rpc = Writer::new();
-    rpc.u8(0); // RPCMessage variant
-    rpc.u8(0); // RequestV0 variant
-    rpc.u8(0); // respondTo: None
-    rpc.u8(0); // MaybeEncrypted variant
-    rpc.u8(0); // DecryptedThing variant
-    rpc.u32_le(transport.bytes.len() as u32);
-    rpc.raw(&transport.bytes);
-
-    let mut payload = Writer::new();
-    payload.u8(0); // PubSubData variant
-    payload.string_vec(topics);
-    payload.u8(u8::from(strict));
-    payload.u32_le(rpc.bytes.len() as u32);
-    payload.raw(&rpc.bytes);
-    payload.bytes
+    let head_refs: Vec<SyncPayloadHeadRef<'_>> = heads
+        .iter()
+        .map(|(hash, bytes, gid_refrences)| SyncPayloadHeadRef {
+            hash,
+            bytes,
+            gid_refrences,
+        })
+        .collect();
+    encode_raw_exchange_sync_payload_refs(topics, strict, &head_refs, reserved)
 }
 
 #[cfg(test)]
@@ -301,6 +362,62 @@ mod tests {
                     [parsed_head.bytes_offset..parsed_head.bytes_offset + parsed_head.bytes_length],
                 bytes.as_slice()
             );
+        }
+    }
+
+    #[test]
+    fn encoded_len_matches_encoder_output() {
+        for (topics, strict, heads, reserved) in [
+            (
+                vec!["topicA".to_string()],
+                true,
+                corpus_heads(),
+                [1, 0, 0, 0],
+            ),
+            (
+                vec!["a".to_string(), "b".to_string()],
+                false,
+                Vec::new(),
+                [0, 0, 0, 0],
+            ),
+            (
+                vec![String::new()],
+                true,
+                vec![(String::new(), Vec::new(), vec![String::new()])],
+                [255, 254, 253, 252],
+            ),
+        ] {
+            let head_refs: Vec<SyncPayloadHeadRef<'_>> = heads
+                .iter()
+                .map(|(hash, bytes, gid_refrences)| SyncPayloadHeadRef {
+                    hash,
+                    bytes,
+                    gid_refrences,
+                })
+                .collect();
+            let encoded =
+                encode_raw_exchange_sync_payload_refs(&topics, strict, &head_refs, reserved);
+            assert_eq!(
+                encoded.len(),
+                encoded_raw_exchange_sync_payload_len(&topics, &head_refs)
+            );
+            // The single-pass encoder parses back to the same content.
+            let pubsub = parse_pubsub_data(&encoded).unwrap();
+            assert_eq!(pubsub.topics, topics);
+            assert_eq!(pubsub.strict, strict);
+            let data = &encoded[pubsub.data_offset..pubsub.data_offset + pubsub.data_length];
+            let parsed = parse_raw_exchange_rpc_request(data).unwrap();
+            assert_eq!(parsed.reserved, reserved);
+            assert_eq!(parsed.heads.len(), heads.len());
+            for (parsed_head, (hash, bytes, gid_refrences)) in parsed.heads.iter().zip(&heads) {
+                assert_eq!(&parsed_head.hash, hash);
+                assert_eq!(&parsed_head.gid_refrences, gid_refrences);
+                assert_eq!(
+                    &data[parsed_head.bytes_offset
+                        ..parsed_head.bytes_offset + parsed_head.bytes_length],
+                    bytes.as_slice()
+                );
+            }
         }
     }
 

--- a/packages/transport/pubsub/src/index.ts
+++ b/packages/transport/pubsub/src/index.ts
@@ -76,6 +76,19 @@ export { toUint8Array } from "./bytes.js";
 
 export const logger = loggerFn("peerbit:transport:topic-control-plane");
 const warn = logger.newScope("warn");
+
+const utf8Encoder = new TextEncoder();
+/**
+ * Offset of the `data` bytes inside a borsh-serialized `PubSubData`
+ * (variant byte + topics vec + strict bool + data length prefix).
+ */
+const preEncodedPubSubDataOffset = (topics: string[]): number => {
+	let offset = 1 + 4; // variant + topics vec length
+	for (const topic of topics) {
+		offset += 4 + utf8Encoder.encode(topic).byteLength;
+	}
+	return offset + 1 + 4; // strict + data length prefix
+};
 const logError = (e?: { message: string }) => {
 	logger.error(e?.message);
 };
@@ -1995,6 +2008,76 @@ export class TopicControlPlane
 		}
 
 		return embedded.id;
+	}
+
+	/**
+	 * Publish a pre-encoded `PubSubData` payload to explicit recipients.
+	 *
+	 * `payload` must be the exact borsh serialization of
+	 * `new PubSubData({ topics, data, strict: true })` — callers that encode
+	 * the payload elsewhere (e.g. the shared-log fused send path serializing
+	 * inside wasm) hand the finished bytes here so the wrapping `PubSubData`
+	 * copy of the regular `publish` path is skipped. Everything else matches
+	 * the explicit-recipient branch of {@link publish}: the payload becomes a
+	 * signed `DataMessage` delivered over DirectStream.
+	 */
+	async publishPreEncodedData(
+		payload: Uint8Array,
+		properties: {
+			topics: string[];
+		},
+		options: {
+			mode: SilentDelivery | AcknowledgeDelivery;
+		} & { client?: string } & PriorityOptions &
+			ResponsePriorityOptions &
+			ExpiresAtOptions &
+			IdOptions &
+			WithExtraSigners & { signal?: AbortSignal },
+	): Promise<Uint8Array | undefined> {
+		if (!this.started) throw new NotStartedError();
+		if (!options?.mode || !deliveryModeHasReceiver(options.mode)) {
+			throw new Error(
+				"publishPreEncodedData requires a delivery mode with explicit recipients",
+			);
+		}
+
+		const message = await this.createMessage(payload, {
+			...options,
+			skipRecipientValidation: this.dispatchEventOnSelfPublish,
+		});
+
+		this.dispatchEvent(
+			new CustomEvent("publish", {
+				detail: new PublishEvent({
+					client: options?.client,
+					data: new PubSubData({
+						topics: properties.topics,
+						data: payload.subarray(
+							preEncodedPubSubDataOffset(properties.topics),
+						),
+						strict: true,
+					}),
+					message,
+				}),
+			}),
+		);
+
+		const silentDelivery = options.mode instanceof SilentDelivery;
+		try {
+			await this.publishMessage(
+				this.publicKey,
+				message,
+				undefined,
+				undefined,
+				options?.signal,
+			);
+		} catch (error) {
+			if (error instanceof DeliveryError && silentDelivery !== false) {
+				return message.id;
+			}
+			throw error;
+		}
+		return message.id;
 	}
 
 	public onPeerSession(key: PublicSignKey, _session: number): void {

--- a/packages/utils/native-backbone/src/index.ts
+++ b/packages/utils/native-backbone/src/index.ts
@@ -581,6 +581,14 @@ type NativePeerbitBackboneHandle = {
 	block_delete_many: (keys: string[]) => number;
 	block_entries: () => Array<[string, Uint8Array]>;
 	block_size: () => number;
+	sync_send_block_byte_lengths?: (hashes: string[]) => Uint32Array;
+	encode_raw_exchange_sync_payload?: (
+		topic: string,
+		strict: boolean,
+		hashes: string[],
+		gidRefrences: string[][],
+		reserved: Uint8Array,
+	) => Uint8Array | undefined;
 	clear: () => void;
 	clear_shared_log: () => void;
 	clear_entry_coordinates: () => void;
@@ -5392,6 +5400,7 @@ const iterableToArray = <T>(values?: Iterable<T>): T[] => {
 };
 
 const EMPTY_UINT8_ARRAY = new Uint8Array(0);
+const SYNC_SEND_DEFAULT_RESERVED = new Uint8Array(4);
 
 type NativeBackboneDocumentIndexArgs = readonly [
 	string,
@@ -5584,6 +5593,51 @@ export class NativePeerbitBackbone {
 
 	hasBlock(hash: string): boolean {
 		return this.native.has_block(hash);
+	}
+
+	/**
+	 * Byte lengths of natively stored entry blocks (`undefined` marks a
+	 * missing block), used by the fused send path to plan raw exchange-head
+	 * message chunking without materializing block bytes in JS.
+	 */
+	syncSendBlockByteLengths(
+		hashes: string[],
+	): Array<number | undefined> | undefined {
+		if (!this.native.sync_send_block_byte_lengths) {
+			return undefined;
+		}
+		const lengths = this.native.sync_send_block_byte_lengths(hashes);
+		const out = new Array<number | undefined>(lengths.length);
+		for (let i = 0; i < lengths.length; i++) {
+			const length = lengths[i]!;
+			out[i] = length === 0xffffffff ? undefined : length;
+		}
+		return out;
+	}
+
+	/**
+	 * Serialize one outbound raw exchange sync payload (the full
+	 * PubSubData → RequestV0 → DecryptedThing → RawExchangeHeadsMessage
+	 * nesting) from the native block store. Returns `undefined` when the
+	 * encoder is unavailable or any head's block is not natively stored.
+	 */
+	encodeRawExchangeSyncPayload(properties: {
+		topic: string;
+		strict?: boolean;
+		hashes: string[];
+		gidRefrences: string[][];
+		reserved?: Uint8Array;
+	}): Uint8Array | undefined {
+		if (!this.native.encode_raw_exchange_sync_payload) {
+			return undefined;
+		}
+		return this.native.encode_raw_exchange_sync_payload(
+			properties.topic,
+			properties.strict ?? true,
+			properties.hashes,
+			properties.gidRefrences,
+			properties.reserved ?? SYNC_SEND_DEFAULT_RESERVED,
+		);
 	}
 
 	prepareRawReceiveBatch(

--- a/packages/utils/native-backbone/src/lib.rs
+++ b/packages/utils/native-backbone/src/lib.rs
@@ -15,6 +15,7 @@ mod js_interop;
 mod profile;
 mod raw_receive;
 mod shared_log_plan;
+mod sync_send;
 mod wire_sync;
 
 use crate::documents::{DocumentContextFields, DocumentPreviousSignerFact, ParsedProjectionPlan};

--- a/packages/utils/native-backbone/src/sync_send.rs
+++ b/packages/utils/native-backbone/src/sync_send.rs
@@ -1,0 +1,180 @@
+//! Send fusion for shared-log raw exchange-heads sync.
+//!
+//! The outbound counterpart of `wire_sync.rs`: the full
+//! `PubSubData → RequestV0 → DecryptedThing → RawExchangeHeadsMessage` payload
+//! is serialized inside this wasm module by `peerbit_wire::sync_payload`,
+//! reading the entry block bytes straight from the native block store the
+//! append/receive paths already committed them to. The only boundary crossing
+//! is the single finished payload buffer handed to JS to become the
+//! `DataMessage` payload — entry block bytes never materialize as JS values on
+//! the send path.
+//!
+//! The store-reading core is `JsValue`-free so host `cargo test` covers it.
+
+use js_sys::{Array, Uint32Array, Uint8Array};
+use peerbit_log_rust::NativeLogBlockStore;
+use peerbit_wire::sync_payload::{encode_raw_exchange_sync_payload_refs, SyncPayloadHeadRef};
+use wasm_bindgen::prelude::*;
+
+use crate::js_interop::{ensure_same_len, string_batches_from_array, strings_from_array};
+use crate::NativePeerbitBackbone;
+
+/// Marks a missing block in `block_byte_lengths` results (a real entry block
+/// cannot reach this size: message payloads are bounded far below it).
+pub(crate) const SYNC_SEND_MISSING_BLOCK: u32 = u32::MAX;
+
+/// Encode the outbound raw exchange sync payload for `hashes`, resolving each
+/// head's block bytes from `blocks`. Returns `None` when any block is missing
+/// (callers fall back to the TS send path).
+pub(crate) fn encode_sync_payload_from_store(
+    blocks: &NativeLogBlockStore,
+    topic: &str,
+    strict: bool,
+    hashes: &[String],
+    gid_refrences: &[Vec<String>],
+    reserved: [u8; 4],
+) -> Option<Vec<u8>> {
+    const EMPTY_REFS: &[String] = &[];
+    let mut heads = Vec::with_capacity(hashes.len());
+    for (index, hash) in hashes.iter().enumerate() {
+        let bytes = blocks.get_ref(hash)?;
+        heads.push(SyncPayloadHeadRef {
+            hash,
+            bytes,
+            gid_refrences: gid_refrences
+                .get(index)
+                .map(Vec::as_slice)
+                .unwrap_or(EMPTY_REFS),
+        });
+    }
+    Some(encode_raw_exchange_sync_payload_refs(
+        &[topic.to_string()],
+        strict,
+        &heads,
+        reserved,
+    ))
+}
+
+pub(crate) fn block_byte_lengths_core(blocks: &NativeLogBlockStore, hashes: &[String]) -> Vec<u32> {
+    hashes
+        .iter()
+        .map(|hash| {
+            blocks
+                .get_ref(hash)
+                .map(|bytes| bytes.len() as u32)
+                .unwrap_or(SYNC_SEND_MISSING_BLOCK)
+        })
+        .collect()
+}
+
+#[wasm_bindgen]
+impl NativePeerbitBackbone {
+    /// Byte lengths of natively stored entry blocks for `hashes`;
+    /// `u32::MAX` marks a missing block. Used by the fused send path to plan
+    /// message chunking without materializing block bytes in JS.
+    pub fn sync_send_block_byte_lengths(&self, hashes: Array) -> Result<Uint32Array, JsValue> {
+        let hashes = strings_from_array(hashes)?;
+        Ok(Uint32Array::from(
+            block_byte_lengths_core(&self.blocks, &hashes).as_slice(),
+        ))
+    }
+
+    /// Serialize one outbound raw exchange sync payload (the full PubSubData
+    /// nesting) from the native block store. Returns `undefined` when any
+    /// head's block is not natively stored (the caller falls back to the TS
+    /// serialization path).
+    pub fn encode_raw_exchange_sync_payload(
+        &self,
+        topic: &str,
+        strict: bool,
+        hashes: Array,
+        gid_refrences: Array,
+        reserved: &[u8],
+    ) -> Result<JsValue, JsValue> {
+        let hashes = strings_from_array(hashes)?;
+        let gid_refrences = string_batches_from_array(gid_refrences, "sync send gid references")?;
+        ensure_same_len(hashes.len(), gid_refrences.len(), "sync send heads")?;
+        let reserved: [u8; 4] = reserved
+            .try_into()
+            .map_err(|_| JsValue::from_str("expected 4 reserved bytes"))?;
+        match encode_sync_payload_from_store(
+            &self.blocks,
+            topic,
+            strict,
+            &hashes,
+            &gid_refrences,
+            reserved,
+        ) {
+            Some(payload) => Ok(Uint8Array::from(payload.as_slice()).into()),
+            None => Ok(JsValue::UNDEFINED),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use peerbit_wire::sync_payload::{
+        encode_raw_exchange_sync_payload, parse_pubsub_data, parse_raw_exchange_rpc_request,
+    };
+
+    fn store_with(entries: &[(&str, Vec<u8>)]) -> NativeLogBlockStore {
+        let mut store = NativeLogBlockStore::new();
+        store.put_entries_core(
+            entries
+                .iter()
+                .map(|(hash, bytes)| (hash.to_string(), bytes.clone()))
+                .collect(),
+        );
+        store
+    }
+
+    #[test]
+    fn encodes_store_blocks_byte_identical_to_owned_encoder() {
+        let store = store_with(&[("zb2AA", vec![0xde, 0xad]), ("zb2BB", vec![1, 2, 3])]);
+        let hashes = vec!["zb2AA".to_string(), "zb2BB".to_string()];
+        let gid_refrences = vec![vec!["g1".to_string()], Vec::new()];
+        let payload = encode_sync_payload_from_store(
+            &store,
+            "topic",
+            true,
+            &hashes,
+            &gid_refrences,
+            [1, 0, 0, 0],
+        )
+        .unwrap();
+        let expected = encode_raw_exchange_sync_payload(
+            &["topic".to_string()],
+            true,
+            &[
+                (
+                    "zb2AA".to_string(),
+                    vec![0xde, 0xad],
+                    vec!["g1".to_string()],
+                ),
+                ("zb2BB".to_string(), vec![1, 2, 3], Vec::new()),
+            ],
+            [1, 0, 0, 0],
+        );
+        assert_eq!(payload, expected);
+
+        let pubsub = parse_pubsub_data(&payload).unwrap();
+        let data = &payload[pubsub.data_offset..pubsub.data_offset + pubsub.data_length];
+        let parsed = parse_raw_exchange_rpc_request(data).unwrap();
+        assert_eq!(parsed.heads.len(), 2);
+    }
+
+    #[test]
+    fn missing_blocks_fall_back() {
+        let store = store_with(&[("zb2AA", vec![0xde])]);
+        let hashes = vec!["zb2AA".to_string(), "zb2MISSING".to_string()];
+        let refs = vec![Vec::new(), Vec::new()];
+        assert!(
+            encode_sync_payload_from_store(&store, "t", true, &hashes, &refs, [0; 4]).is_none()
+        );
+        assert_eq!(
+            block_byte_lengths_core(&store, &hashes),
+            vec![1, SYNC_SEND_MISSING_BLOCK]
+        );
+    }
+}


### PR DESCRIPTION
Completes the outbound half of the native network plane (stacked on #988). With this, the message hot path is JS-free in **both** directions: receive was fused in #988; send now serializes inside wasm straight from the native block store, and live-put gossip coalesces into multi-entry raw frames that take the receiver's fused stash path.

## What's here

- **Native outbound serialization**: `peerbit_wire::sync_payload` gained a single-pass, exactly-sized, borrowed-heads encoder (golden-pinned byte-identical to the TS `serialize(PubSubData(RequestV0(DecryptedThing(RawExchangeHeadsMessage))))` layout); native-backbone's `sync_send.rs` builds the complete payload in wasm from the native block store — entry block bytes never surface as JS values on the send path. Pubsub gained `publishPreEncodedData()` so the finished payload becomes a signed `DataMessage` without the re-wrap copy. One TS ed25519 sign per ≤512KB message remains (per-batch, not per-entry; the node identity key stays out of wasm).
- **Raw-capability negotiation + live-put coalescing**: peers with `sync.rawExchangeHeads` advertise a one-shot `SyncCapabilitiesMessage([0,10])` in the existing subscribe flow (opt-in-only variant; unknown-variant receivers drop it via the existing namespace guard — default wire behavior byte-for-byte unchanged). Silent fire-and-forget append gossip to all-capable recipient sets coalesces per recipient set until end of the current event-loop turn (caps: 256 entries / 128KiB, under the 512KiB raw cap) — a lone put flushes within one turn; awaited-put bursts ship as multi-entry raw frames. Non-advertising peers keep the byte-identical plain path. Bulk sync responses and repair pushes route through the same fused seam.
- **The "3× slower native append" from the #988 bench was a measurement artifact**: isolated, the native singleton append is ~1.2× *faster* than default (0.139 vs 0.158–0.183 ms); the old figure was receiver-side per-message work interleaving into the shared benchmark thread — which the coalescing removes.
- E2E counter specs extended: cold sync asserts fused-send entries ≥ N and zero JS outbound block-byte copies; a new live-puts leg asserts zero plain live sends, coalescing (messages < entries), and fused receive of live frames (`jsEntryDecode=0`, `blockCopyOuts=0`, `tsFrames=0`). Irreducible send-path exceptions documented in ARCHITECTURE.md §8: one wasm→JS egress copy of the finished payload per message (mirror of the receive ingress copy) and one TS sign per message.

## Measured (`benchmark:network-preset-e2e`, 2 warmups + 5 measured runs, mean ± stdev, TCP loopback, arm64 mac)

| leg | default | native | ratio |
| --- | --- | --- | --- |
| live puts (2000 × 256B awaited), puts/s | 553 ± 67 | 2247 ± 958 | **4.06×** |
| live puts p50 visibility | 2024 ms | 623 ms | 3.2× lower |
| cold sync (8000 × 1KB), entries/s | 923 ± 32 | 2385 ± 564 | **2.58×** |

The #988 baseline for live puts was **0.44×** (279 vs 630 puts/s) — this PR flips the native preset's one regression into its largest win. Native live-put variance is high (~43% CV); the ratio holds with wide margin across all runs. Stash-pressure legs (128KB payloads): below-cap 101 MB/s commit; forced above the 64MB FIFO cap (2434 evictions/run, stash pinned at 127 frames) throughput degrades ~6.3× but converges on every run with zero deserialize fallbacks — evicted frames recover through the synchronizer retry path.

## Verification

shared-log part-4 mock run 120 passing (incl. 6 new send-fusion specs); native-backbone cargo 13 + JS 59; network-rust cargo 94 + JS 92 default + 428 under `PEERBIT_STREAM_RUST_CORE=1`; log 231; peerbit client 66; rpc 26; pubsub 141; cargo fmt + root eslint clean on the diff. Adversarial review: no blockers or majors; two minors noted for follow-up — the capability handshake extends the (pre-existing) onChange gap to live appends for explicitly-configured programs (dissolves when the onChange-dispatch PR merges), and repair-hinted raw frames deserve dedicated coverage.
