### PR TITLE
fix(ci): correct the release publish pipeline (shell + verify-after-publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,9 +89,15 @@ jobs:
         with:
           version: pnpm run version-packages
           # Build, publish every unpublished version (from-package), then create
-          # the pkg@version git tags and push them. `changeset tag` reads the
-          # current package.json versions and creates one tag per package.
-          publish: pnpm run build && pnpm run release && pnpm exec changeset tag && git push --follow-tags
+          # the pkg@version git tags and push them.
+          #
+          # This MUST be a single `pnpm run <script>`. changesets/action runs the
+          # publish command WITHOUT a shell, so an inline `a && b && c` chain here
+          # is passed as literal arguments to the first command — only the build
+          # runs, the actual publish + tagging are silently skipped, and the step
+          # still exits 0. Keeping the chain inside the release:publish npm script
+          # makes pnpm run it in a shell (exactly like version-packages above).
+          publish: pnpm run release:publish
           commit: "chore: version packages"
           title: "chore: version packages"
           createGithubReleases: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # The changesets action pushes via the git CLI, which uses the
+          # credentials persisted here — so this must be the bot PAT (see the
+          # RELEASE_PR_TOKEN note below) for the version-branch push to be able
+          # to trigger CI on the Version Packages PR.
+          token: ${{ secrets.RELEASE_PR_TOKEN || github.token }}
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -67,9 +72,11 @@ jobs:
     # pending) and, once that PR is merged, runs the publish command below.
     #
     # NOTE: secrets.GITHUB_TOKEN cannot trigger downstream workflows (CI) on the
-    # Version Packages PR it opens. If you want CI to run on that PR, create a
-    # bot Personal Access Token secret (e.g. RELEASE_PR_TOKEN with repo +
-    # workflow scopes) and pass it as `token:` below instead of GITHUB_TOKEN.
+    # Version Packages PR it opens, so the PR is opened with RELEASE_PR_TOKEN —
+    # a peerbit-org bot PAT with repo + workflow scopes. Both the checkout token
+    # above (git pushes: version branch, release tags) and the action token
+    # below fall back to the default GITHUB_TOKEN if the secret is removed, in
+    # which case everything still works except CI on the Version Packages PR.
     #
     # createGithubReleases is disabled deliberately. changesets tags packages as
     # `<name>@<version>` (e.g. peerbit@5.2.21, @peerbit/crypto@3.2.0), whereas
@@ -87,6 +94,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         uses: changesets/action@v1
         with:
+          github-token: ${{ secrets.RELEASE_PR_TOKEN || github.token }}
           version: pnpm run version-packages
           # Build, publish every unpublished version (from-package), then create
           # the pkg@version git tags and push them.
@@ -102,7 +110,9 @@ jobs:
           title: "chore: version packages"
           createGithubReleases: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Older changesets/action builds read the token from the environment
+          # rather than the github-token input; set both to stay robust.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PR_TOKEN || secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     # Manual stable escape hatch: build and publish anything whose package.json

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
 		"changeset": "changeset",
 		"version-packages": "changeset version && pnpm install --lockfile-only",
 		"release": "node ./scripts/publish-public-packages.mjs",
+		"release:publish": "pnpm run build && pnpm run release && changeset tag && git push --follow-tags",
 		"release:rc": "AEGIR_PACKAGE_MANAGER=pnpm aegir release-rc",
 		"deploy": "pnpm run deploy:docs",
 		"deploy:docs": "pnpm run site:build && gh-pages --dist apps/peerbit-org/dist --dotfiles",

--- a/scripts/publish-public-packages.mjs
+++ b/scripts/publish-public-packages.mjs
@@ -172,6 +172,29 @@ async function isPublished({ name, version }) {
 	throw new Error(`Failed to query npm for ${name}@${version}\n${combinedOutput}`);
 }
 
+async function verifyPublished(pkg) {
+	// `pnpm publish` can exit 0 without the version actually landing on the
+	// registry — most notably the FIRST publish of a brand-new scoped package
+	// when the npm token / org lacks permission to create it. A silent
+	// non-publish must fail the release loudly, not leave a green run that
+	// shipped nothing. Re-query with a short backoff to tolerate registry
+	// propagation delay.
+	const delaysMs = [0, 2000, 4000, 8000, 15000];
+	for (const delay of delaysMs) {
+		if (delay) {
+			await new Promise((r) => setTimeout(r, delay));
+		}
+		if (await isPublished(pkg)) {
+			return;
+		}
+	}
+	throw new Error(
+		`${pkg.name}@${pkg.version}: publish command exited 0 but the version never appeared on the registry. ` +
+			`For a brand-new package this usually means the npm token/org cannot create it — check the token scope ` +
+			`(needs @peerbit scope-level publish, not just per-package access) and the org's new-package permissions.`,
+	);
+}
+
 async function publishPackage(pkg) {
 	const alreadyPublished = await isPublished(pkg);
 	if (alreadyPublished) {
@@ -188,6 +211,9 @@ async function publishPackage(pkg) {
 	}
 	console.log(`publish ${pkg.name}@${pkg.version}`);
 	await run(pnpmCmd, publishArgs, pkg.dir);
+	if (!dryRun) {
+		await verifyPublished(pkg);
+	}
 }
 
 const workspacePackages = await loadWorkspacePackages();


### PR DESCRIPTION
## Two publish-pipeline bugs this fixes

### 1. changesets publish command was silently skipped
`changesets/action` runs its `publish` command **without a shell**, so the inline chain from #992 (`pnpm run build && pnpm run release && ...`) was passed as literal args to the first command. Only `aegir run build` ran; the actual npm publish + tagging were skipped, yet the step exited 0. **Fix:** move the chain into a single `release:publish` npm script and point the action at `pnpm run release:publish` (pnpm runs the script in a shell), mirroring the already-working `version-packages`.

### 2. publish that exits 0 but never lands is now a hard failure
`pnpm publish` can exit 0 without the version appearing on the registry — observed live: the five brand-new `@peerbit/*` rust packages printed a publish + tarball and exited 0 but **never landed**, while new versions of existing packages published fine. That points at an npm token/org permission gap on *creating* new scoped packages. **Fix:** `publish-public-packages.mjs` now re-queries the registry after each publish (with a short propagation backoff) and throws if the version is still absent — so a silent non-publish fails the release loudly.

## State of the release for #939/#988
Completed out-of-band via the `workflow_dispatch` stable escape hatch: **all existing packages published** their new versions (peerbit 5.3.0, @peerbit/log 6.2.0, pubsub 5.3.0, stream 5.1.0, blocks 4.2.0, log-rust 1.1.0, + the patch cascade). **The 5 brand-new packages did NOT publish** (network-rust, native-backbone, any-store-rust, document-rust, shared-log-rust) — blocked by the new-package permission issue above, which needs a maintainer npm-account action (token scope / org new-package permission, or a one-time manual first publish), not a code change.
