### PR TITLE
fix(native-backbone): avoid literal node builtin dynamic imports for browser bundlers

### DIFF
--- a/.changeset/lucky-pandas-brush.md
+++ b/.changeset/lucky-pandas-brush.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/native-backbone": patch
+---
+
+Use non-literal specifiers for the node-only fs/path dynamic imports so browser bundlers (esbuild `--platform=browser`) no longer fail resolving `node:fs/promises` and `node:path` when bundling the package

--- a/packages/utils/native-backbone/src/index.ts
+++ b/packages/utils/native-backbone/src/index.ts
@@ -3082,13 +3082,30 @@ const isNotFoundError = (error: unknown): boolean => {
 	return maybeError?.code === "ENOENT" || maybeError?.name === "NotFoundError";
 };
 
+// Non-literal specifiers keep browser bundlers (esbuild statically resolves
+// literal dynamic imports and hard-fails on node builtins) from following
+// these node-only imports; they are only reached on node runtimes.
 let nodeFsModule: Promise<NativeBackboneNodeFs> | undefined;
-const importNodeFs = (): Promise<NativeBackboneNodeFs> =>
-	(nodeFsModule ??= import("node:fs/promises"));
+const importNodeFs = (): Promise<NativeBackboneNodeFs> => {
+	if (!nodeFsModule) {
+		const fsPromises = "node:fs/promises";
+		nodeFsModule = import(
+			/* @vite-ignore */ fsPromises
+		) as Promise<NativeBackboneNodeFs>;
+	}
+	return nodeFsModule;
+};
 
 let nodePathJoin: Promise<(...parts: string[]) => string> | undefined;
-const importNodePathJoin = (): Promise<(...parts: string[]) => string> =>
-	(nodePathJoin ??= import("node:path").then((mod) => mod.join));
+const importNodePathJoin = (): Promise<(...parts: string[]) => string> => {
+	if (!nodePathJoin) {
+		const pathModule = "node:path";
+		nodePathJoin = (
+			import(/* @vite-ignore */ pathModule) as Promise<typeof import("path")>
+		).then((mod) => mod.join);
+	}
+	return nodePathJoin;
+};
 
 const validateCoordinatePersistenceName = (name: string): string => {
 	if (


### PR DESCRIPTION
## The bug

`@peerbit/native-backbone`'s compiled `dist/src/index.js` contained literal dynamic imports `import("node:fs/promises")` and `import("node:path")` (the coordinate-persistence node adapter). esbuild with `--platform=browser` statically resolves literal dynamic-import specifiers and hard-fails on node builtins, breaking any browser bundle whose import chain reaches native-backbone. Confirmed real-world against aegir/esbuild browser builds in a downstream app (distributed-backup-v2's `database` package); Vite-based apps happened to survive.

## The fix

Switch both imports to the pattern the sibling rust packages (any-store/rust, log/rust, indexer/rust, document/rust, shared-log/rust) already use: a non-literal specifier held in a const plus the `/* @vite-ignore */` hint, so bundlers treat the import as an opaque runtime expression. Specifiers, lazy memoization, and node behavior are unchanged — the imports are only reached on node runtimes.

## Verification

- esbuild repro (entry importing the built package, `--bundle --platform=browser --format=esm`): exactly the two reported errors pre-fix; clean 221.9kb bundle post-fix.
- Vite build probe: clean. Webpack probe: compiles with the same class of "critical dependency" warnings the existing wasm loader already emits (warnings only, exit 0).
- Package suite: cargo 13 passed, mocha 59 passing; eslint clean.
- Sibling audit: no other published dist carries a literal `import("node:...")` — only test/benchmark files, which don't ship.

Changeset: `@peerbit/native-backbone` patch.