### PR TITLE
fix(rust-loaders): serialize wasm init to close a double-init race

### DIFF
--- a/.changeset/serialize-any-store-rust-wasm-init.md
+++ b/.changeset/serialize-any-store-rust-wasm-init.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/any-store-rust": patch
+---
+
+Serialize wasm init to fix a double-init race under concurrent loads (browser use-after-free).

--- a/.changeset/serialize-document-rust-wasm-init.md
+++ b/.changeset/serialize-document-rust-wasm-init.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/document-rust": patch
+---
+
+Serialize wasm init to fix a double-init race under concurrent loads (browser use-after-free).

--- a/.changeset/serialize-indexer-rust-wasm-init.md
+++ b/.changeset/serialize-indexer-rust-wasm-init.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/indexer-rust": patch
+---
+
+Serialize wasm init to fix a double-init race under concurrent loads (browser use-after-free).

--- a/.changeset/serialize-log-rust-wasm-init.md
+++ b/.changeset/serialize-log-rust-wasm-init.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/log-rust": patch
+---
+
+Serialize wasm init to fix a double-init race under concurrent loads (browser use-after-free).

--- a/.changeset/serialize-native-backbone-wasm-init.md
+++ b/.changeset/serialize-native-backbone-wasm-init.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/native-backbone": patch
+---
+
+Serialize wasm init to fix a double-init race under concurrent loads (browser use-after-free).

--- a/.changeset/serialize-network-rust-wasm-init.md
+++ b/.changeset/serialize-network-rust-wasm-init.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/network-rust": patch
+---
+
+Serialize wasm init to fix a double-init race under concurrent loads (browser use-after-free).

--- a/.changeset/serialize-shared-log-rust-wasm-init.md
+++ b/.changeset/serialize-shared-log-rust-wasm-init.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log-rust": patch
+---
+
+Serialize wasm init to fix a double-init race under concurrent loads (browser use-after-free).

--- a/packages/log/rust/src/wasm.ts
+++ b/packages/log/rust/src/wasm.ts
@@ -5,6 +5,7 @@ type WasmInitModule = {
 
 let wasmModulePromise: Promise<WasmInitModule> | undefined;
 let wasmInitialized = false;
+let wasmInitPromise: Promise<void> | undefined;
 
 export const loadWasm = async <
 	T extends WasmInitModule = WasmInitModule,
@@ -18,25 +19,28 @@ export const loadWasm = async <
 
 	const wasm = await wasmModulePromise;
 	if (!wasmInitialized) {
-		const processLike = (
-			globalThis as { process?: { versions?: { node?: string } } }
-		).process;
-		if (processLike?.versions?.node) {
-			const fsPromises = "fs/promises";
-			const { readFile } = (await import(
-				/* @vite-ignore */ fsPromises
-			)) as typeof import("fs/promises");
-			const bytes = await readFile(
-				new URL("../wasm/log_rust_bg.wasm", import.meta.url),
-			);
-			wasm.initSync({ module: bytes });
-		} else {
-			await wasm.default({
-				module_or_path: new URL("../wasm/log_rust_bg.wasm", import.meta.url),
-			});
-		}
-		wasmInitialized = true;
+		wasmInitPromise ??= (async () => {
+			const processLike = (
+				globalThis as { process?: { versions?: { node?: string } } }
+			).process;
+			if (processLike?.versions?.node) {
+				const fsPromises = "fs/promises";
+				const { readFile } = (await import(
+					/* @vite-ignore */ fsPromises
+				)) as typeof import("fs/promises");
+				const bytes = await readFile(
+					new URL("../wasm/log_rust_bg.wasm", import.meta.url),
+				);
+				wasm.initSync({ module: bytes });
+			} else {
+				await wasm.default({
+					module_or_path: new URL("../wasm/log_rust_bg.wasm", import.meta.url),
+				});
+			}
+			wasmInitialized = true;
+		})();
 	}
+	await wasmInitPromise;
 
 	return wasm as T;
 };

--- a/packages/programs/data/document/rust/src/index.ts
+++ b/packages/programs/data/document/rust/src/index.ts
@@ -80,6 +80,7 @@ type WasmModule = {
 let wasmModulePromise: Promise<WasmModule> | undefined;
 let wasmModule: WasmModule | undefined;
 let wasmInitialized = false;
+let wasmInitPromise: Promise<void> | undefined;
 
 const loadWasm = async (): Promise<WasmModule> => {
 	if (!wasmModulePromise) {
@@ -91,28 +92,31 @@ const loadWasm = async (): Promise<WasmModule> => {
 
 	const wasm = await wasmModulePromise;
 	if (!wasmInitialized) {
-		const processLike = (
-			globalThis as { process?: { versions?: { node?: string } } }
-		).process;
-		if (processLike?.versions?.node) {
-			const fsPromises = "fs/promises";
-			const { readFile } = (await import(
-				/* @vite-ignore */ fsPromises
-			)) as typeof import("fs/promises");
-			const bytes = await readFile(
-				new URL("../wasm/document_rust_bg.wasm", import.meta.url),
-			);
-			wasm.initSync({ module: bytes });
-		} else {
-			await wasm.default({
-				module_or_path: new URL(
-					"../wasm/document_rust_bg.wasm",
-					import.meta.url,
-				),
-			});
-		}
-		wasmInitialized = true;
+		wasmInitPromise ??= (async () => {
+			const processLike = (
+				globalThis as { process?: { versions?: { node?: string } } }
+			).process;
+			if (processLike?.versions?.node) {
+				const fsPromises = "fs/promises";
+				const { readFile } = (await import(
+					/* @vite-ignore */ fsPromises
+				)) as typeof import("fs/promises");
+				const bytes = await readFile(
+					new URL("../wasm/document_rust_bg.wasm", import.meta.url),
+				);
+				wasm.initSync({ module: bytes });
+			} else {
+				await wasm.default({
+					module_or_path: new URL(
+						"../wasm/document_rust_bg.wasm",
+						import.meta.url,
+					),
+				});
+			}
+			wasmInitialized = true;
+		})();
 	}
+	await wasmInitPromise;
 	wasmModule = wasm;
 
 	return wasm;

--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -572,6 +572,7 @@ type WasmModule = {
 
 let wasmModulePromise: Promise<WasmModule> | undefined;
 let wasmInitialized = false;
+let wasmInitPromise: Promise<void> | undefined;
 
 const loadWasm = async (): Promise<WasmModule> => {
 	if (!wasmModulePromise) {
@@ -583,28 +584,31 @@ const loadWasm = async (): Promise<WasmModule> => {
 
 	const wasm = await wasmModulePromise;
 	if (!wasmInitialized) {
-		const processLike = (
-			globalThis as { process?: { versions?: { node?: string } } }
-		).process;
-		if (processLike?.versions?.node) {
-			const fsPromises = "fs/promises";
-			const { readFile } = (await import(
-				/* @vite-ignore */ fsPromises
-			)) as typeof import("fs/promises");
-			const bytes = await readFile(
-				new URL("../wasm/shared_log_rust_bg.wasm", import.meta.url),
-			);
-			wasm.initSync({ module: bytes });
-		} else {
-			await wasm.default({
-				module_or_path: new URL(
-					"../wasm/shared_log_rust_bg.wasm",
-					import.meta.url,
-				),
-			});
-		}
-		wasmInitialized = true;
+		wasmInitPromise ??= (async () => {
+			const processLike = (
+				globalThis as { process?: { versions?: { node?: string } } }
+			).process;
+			if (processLike?.versions?.node) {
+				const fsPromises = "fs/promises";
+				const { readFile } = (await import(
+					/* @vite-ignore */ fsPromises
+				)) as typeof import("fs/promises");
+				const bytes = await readFile(
+					new URL("../wasm/shared_log_rust_bg.wasm", import.meta.url),
+				);
+				wasm.initSync({ module: bytes });
+			} else {
+				await wasm.default({
+					module_or_path: new URL(
+						"../wasm/shared_log_rust_bg.wasm",
+						import.meta.url,
+					),
+				});
+			}
+			wasmInitialized = true;
+		})();
 	}
+	await wasmInitPromise;
 
 	return wasm;
 };

--- a/packages/transport/network-rust/src/wasm.ts
+++ b/packages/transport/network-rust/src/wasm.ts
@@ -5,6 +5,7 @@ type WasmInitModule = {
 
 let wasmModulePromise: Promise<WasmInitModule> | undefined;
 let wasmInitialized = false;
+let wasmInitPromise: Promise<void> | undefined;
 
 export const loadWasm = async <
 	T extends WasmInitModule = WasmInitModule,
@@ -18,28 +19,31 @@ export const loadWasm = async <
 
 	const wasm = await wasmModulePromise;
 	if (!wasmInitialized) {
-		const processLike = (
-			globalThis as { process?: { versions?: { node?: string } } }
-		).process;
-		if (processLike?.versions?.node) {
-			const fsPromises = "fs/promises";
-			const { readFile } = (await import(
-				/* @vite-ignore */ fsPromises
-			)) as typeof import("fs/promises");
-			const bytes = await readFile(
-				new URL("../wasm/peerbit_wire_bg.wasm", import.meta.url),
-			);
-			wasm.initSync({ module: bytes });
-		} else {
-			await wasm.default({
-				module_or_path: new URL(
-					"../wasm/peerbit_wire_bg.wasm",
-					import.meta.url,
-				),
-			});
-		}
-		wasmInitialized = true;
+		wasmInitPromise ??= (async () => {
+			const processLike = (
+				globalThis as { process?: { versions?: { node?: string } } }
+			).process;
+			if (processLike?.versions?.node) {
+				const fsPromises = "fs/promises";
+				const { readFile } = (await import(
+					/* @vite-ignore */ fsPromises
+				)) as typeof import("fs/promises");
+				const bytes = await readFile(
+					new URL("../wasm/peerbit_wire_bg.wasm", import.meta.url),
+				);
+				wasm.initSync({ module: bytes });
+			} else {
+				await wasm.default({
+					module_or_path: new URL(
+						"../wasm/peerbit_wire_bg.wasm",
+						import.meta.url,
+					),
+				});
+			}
+			wasmInitialized = true;
+		})();
 	}
+	await wasmInitPromise;
 
 	return wasm as T;
 };

--- a/packages/utils/any-store/rust/src/index.ts
+++ b/packages/utils/any-store/rust/src/index.ts
@@ -44,6 +44,7 @@ type StoreStatus = "opening" | "open" | "closing" | "closed";
 
 let wasmModulePromise: Promise<WasmModule> | undefined;
 let wasmInitialized = false;
+let wasmInitPromise: Promise<void> | undefined;
 
 const loadWasm = async (): Promise<WasmModule> => {
 	if (!wasmModulePromise) {
@@ -53,24 +54,27 @@ const loadWasm = async (): Promise<WasmModule> => {
 
 	const wasm = await wasmModulePromise;
 	if (!wasmInitialized) {
-		const processLike = (globalThis as { process?: { versions?: { node?: string } } })
-			.process;
-		if (processLike?.versions?.node) {
-			const fsPromises = "fs/promises";
-			const { readFile } = (await import(
-				/* @vite-ignore */ fsPromises
-			)) as typeof import("fs/promises");
-			const bytes = await readFile(
-				new URL("../wasm/any_store_rust_bg.wasm", import.meta.url),
-			);
-			wasm.initSync({ module: bytes });
-		} else {
-			await wasm.default({
-				module_or_path: new URL("../wasm/any_store_rust_bg.wasm", import.meta.url),
-			});
-		}
-		wasmInitialized = true;
+		wasmInitPromise ??= (async () => {
+			const processLike = (globalThis as { process?: { versions?: { node?: string } } })
+				.process;
+			if (processLike?.versions?.node) {
+				const fsPromises = "fs/promises";
+				const { readFile } = (await import(
+					/* @vite-ignore */ fsPromises
+				)) as typeof import("fs/promises");
+				const bytes = await readFile(
+					new URL("../wasm/any_store_rust_bg.wasm", import.meta.url),
+				);
+				wasm.initSync({ module: bytes });
+			} else {
+				await wasm.default({
+					module_or_path: new URL("../wasm/any_store_rust_bg.wasm", import.meta.url),
+				});
+			}
+			wasmInitialized = true;
+		})();
 	}
+	await wasmInitPromise;
 
 	return wasm;
 };

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -434,6 +434,7 @@ const textEncoder = new TextEncoder();
 
 let wasmModulePromise: Promise<WasmModule> | undefined;
 let wasmInitialized = false;
+let wasmInitPromise: Promise<void> | undefined;
 
 const loadWasm = async (): Promise<WasmModule> => {
 	if (!wasmModulePromise) {
@@ -445,28 +446,31 @@ const loadWasm = async (): Promise<WasmModule> => {
 
 	const wasm = await wasmModulePromise;
 	if (!wasmInitialized) {
-		const processLike = (
-			globalThis as { process?: { versions?: { node?: string } } }
-		).process;
-		if (processLike?.versions?.node) {
-			const fsPromises = "fs/promises";
-			const { readFile } = (await import(
-				/* @vite-ignore */ fsPromises
-			)) as typeof import("fs/promises");
-			const bytes = await readFile(
-				new URL("../wasm/indexer_rust_bg.wasm", import.meta.url),
-			);
-			wasm.initSync({ module: bytes });
-		} else {
-			await wasm.default({
-				module_or_path: new URL(
-					"../wasm/indexer_rust_bg.wasm",
-					import.meta.url,
-				),
-			});
-		}
-		wasmInitialized = true;
+		wasmInitPromise ??= (async () => {
+			const processLike = (
+				globalThis as { process?: { versions?: { node?: string } } }
+			).process;
+			if (processLike?.versions?.node) {
+				const fsPromises = "fs/promises";
+				const { readFile } = (await import(
+					/* @vite-ignore */ fsPromises
+				)) as typeof import("fs/promises");
+				const bytes = await readFile(
+					new URL("../wasm/indexer_rust_bg.wasm", import.meta.url),
+				);
+				wasm.initSync({ module: bytes });
+			} else {
+				await wasm.default({
+					module_or_path: new URL(
+						"../wasm/indexer_rust_bg.wasm",
+						import.meta.url,
+					),
+				});
+			}
+			wasmInitialized = true;
+		})();
 	}
+	await wasmInitPromise;
 
 	return wasm;
 };

--- a/packages/utils/native-backbone/src/index.ts
+++ b/packages/utils/native-backbone/src/index.ts
@@ -2116,6 +2116,7 @@ type WasmModule = {
 
 let wasmModulePromise: Promise<WasmModule> | undefined;
 let wasmInitialized = false;
+let wasmInitPromise: Promise<void> | undefined;
 
 const loadWasm = async (): Promise<WasmModule> => {
 	if (!wasmModulePromise) {
@@ -2127,28 +2128,31 @@ const loadWasm = async (): Promise<WasmModule> => {
 
 	const wasm = await wasmModulePromise;
 	if (!wasmInitialized) {
-		const processLike = (
-			globalThis as { process?: { versions?: { node?: string } } }
-		).process;
-		if (processLike?.versions?.node) {
-			const fsPromises = "fs/promises";
-			const { readFile } = (await import(
-				/* @vite-ignore */ fsPromises
-			)) as typeof import("fs/promises");
-			const bytes = await readFile(
-				new URL("../wasm/native_backbone_bg.wasm", import.meta.url),
-			);
-			wasm.initSync({ module: bytes });
-		} else {
-			await wasm.default({
-				module_or_path: new URL(
-					"../wasm/native_backbone_bg.wasm",
-					import.meta.url,
-				),
-			});
-		}
-		wasmInitialized = true;
+		wasmInitPromise ??= (async () => {
+			const processLike = (
+				globalThis as { process?: { versions?: { node?: string } } }
+			).process;
+			if (processLike?.versions?.node) {
+				const fsPromises = "fs/promises";
+				const { readFile } = (await import(
+					/* @vite-ignore */ fsPromises
+				)) as typeof import("fs/promises");
+				const bytes = await readFile(
+					new URL("../wasm/native_backbone_bg.wasm", import.meta.url),
+				);
+				wasm.initSync({ module: bytes });
+			} else {
+				await wasm.default({
+					module_or_path: new URL(
+						"../wasm/native_backbone_bg.wasm",
+						import.meta.url,
+					),
+				});
+			}
+			wasmInitialized = true;
+		})();
 	}
+	await wasmInitPromise;
 
 	return wasm;
 };


### PR DESCRIPTION
## The bug

The `@peerbit/*-rust` JS wasm loaders — `loadWasm` in shared-log/document/any-store/indexer rust and `native-backbone`, plus the shared `wasm.ts` in `log/rust` and `transport/network-rust` — guard wasm-bindgen initialization with a module-level `let wasmInitialized = false;` that is set only **after** the async browser init `await wasm.default(...)`.

That guard is non-atomic under concurrency. Two loader calls racing during the async fetch/compile window — e.g. shared-log opening `createSharedLogState()` and `createRangePlanner()` at the same time, or two programs opening at startup — both observe `wasmInitialized === false` and both run init. wasm-bindgen's `__wbg_finalize_init` then runs twice, and the second run **swaps the module-level `wasm` binding** under every wrapper object already created against the first instance. Because the two instances hand out identical allocation sequences, a wrapper from init #1 ends up pointing at a *live* object in init #2. When either wrapper is dropped, its `FinalizationRegistry` callback frees that shared pointer via the current instance → use-after-free → the wasm-bindgen borrow-guard panic:

> recursive use of an object detected which would lead to unsafe aliasing in rust

(also surfaces as `RuntimeError: memory access out of bounds` / `unreachable` from the allocator).

Node runtimes are immune because the loader's node branch uses the synchronous `wasm.initSync`, whose guard is effective. So the crash is **browser-only and intermittent** — it needs ≥2 loader calls racing during init — which is why it slipped past the node test suites.

## The fix

Serialize init behind a single cached promise, so concurrent callers share one `wasm.default(...)` / `initSync(...)` instead of double-initializing:

```ts
let wasmInitialized = false;
let wasmInitPromise: Promise<void> | undefined;

const loadWasm = async () => {
	if (!wasmModulePromise) wasmModulePromise = import(/* @vite-ignore */ …);
	const wasm = await wasmModulePromise;
	wasmInitPromise ??= (async () => {
		/* the existing node initSync / browser default init body, unchanged */
		wasmInitialized = true;
	})();
	await wasmInitPromise;
	return wasm;
};
```

The init body (both branches) is byte-identical — only wrapped in the single-flight IIFE + `await`. Applied to all seven loaders.

One deliberate behavior change: a **rejected** init is now cached rather than retried on the next `loadWasm()`. This is intentional — re-running init after a partially-completed `finalize_init` is exactly the double-init this fixes — and it mirrors `wasmModulePromise` (the dynamic import), which was already cached-on-rejection.

## Verification

- **Deterministic Node repro** against the built `shared-log-rust` glue: two concurrent `glue.default(...)` inits, then observe pointer reuse and the use-after-free. Fails 100% on `master`; the pointer-reuse assertion (`first.__wbg_ptr === second.__wbg_ptr`) shows the aliasing directly.

  <details><summary>repro script (build the wasm first: <code>cd packages/programs/data/shared-log/rust &amp;&amp; wasm-pack build --target web --out-dir dist/wasm --out-name shared_log_rust</code>)</summary>

  ```js
  import assert from "node:assert/strict";
  import { readFile } from "node:fs/promises";

  const wasmDir = new URL("./packages/programs/data/shared-log/rust/dist/wasm/", import.meta.url);
  const glueUrl = new URL("shared_log_rust.js", wasmDir);
  const wasmUrl = new URL("shared_log_rust_bg.wasm", wasmDir);
  const delay = (ms) => new Promise((r) => setTimeout(r, ms));
  const bytes = new Uint8Array(await readFile(wasmUrl));
  const glue = await import(`${glueUrl.href}?bust=${Date.now()}`);

  // Two concurrent async inits — both pass the loader's `!wasmInitialized` guard.
  const init1 = glue.default({ module_or_path: delay(1).then(() => bytes.slice()) });
  const init2 = glue.default({ module_or_path: delay(10).then(() => bytes.slice()) });

  await init1;
  const a = new glue.NativeSharedLogState("u32");
  await init2; // finalize_init runs again -> module `wasm` instance swapped
  const b = new glue.NativeSharedLogState("u32");

  assert.equal(a.__wbg_ptr, b.__wbg_ptr); // same ptr: b aliases a's slot in instance #2
  a.free();        // finalizer-equivalent free of caller #1
  b.clear();       // use caller #2 -> use-after-free -> panic:
  // "recursive use of an object detected which would lead to unsafe aliasing in rust"
  ```
  </details>

- Post-fix the loaders never double-init (each now serializes init behind one cached promise).
- Verified end-to-end in a downstream browser application: the crash — which reliably hit a flow that opens two programs concurrently at startup — no longer occurs across repeated runs.
- Per-package `lint` (`cargo fmt --check` + eslint) passes for all seven affected packages.

Happy to add a browser-mode `aegir` regression spec (only the browser `wasm.default` path races; Node's `initSync` is immune, so a node-only spec wouldn't prove anything) against one of the packages that exports `loadWasm` (`log/rust`, `transport/network-rust`) if you'd prefer a shipped test.

## Changesets

Patch bump for each affected package: `@peerbit/shared-log-rust`, `@peerbit/document-rust`, `@peerbit/any-store-rust`, `@peerbit/indexer-rust`, `@peerbit/native-backbone`, `@peerbit/log-rust`, `@peerbit/network-rust`.
