### PR TITLE
fix(log-rust): bound hostile length prefixes in the entry codec

### DIFF
--- a/.changeset/tame-rabbits-wonder.md
+++ b/.changeset/tame-rabbits-wonder.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/log-rust": patch
+---
+
+Harden the entry codec against hostile length prefixes: bound the next-hash count read from untrusted `EntryV0` meta bytes against the input actually remaining before allocating. Previously a malformed entry declaring a huge count could trigger a multi-gigabyte allocation and abort a native node (remote DoS); it now returns a catchable error. No change to valid decoding and the wasm API is byte-identical.

--- a/packages/log/rust/src/codec.rs
+++ b/packages/log/rust/src/codec.rs
@@ -565,3 +565,105 @@ pub(crate) fn write_u32(out: &mut Vec<u8>, value: u32) {
 pub(crate) fn write_u64(out: &mut Vec<u8>, value: u64) {
     out.extend_from_slice(&value.to_le_bytes());
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::LogError;
+
+    // Build a well-formed EntryV0 meta prefix (variant + clock + gid) up to but
+    // not including the `next` string-vector count, so a test can append a
+    // hostile count of its choosing.
+    fn meta_prefix_before_next(gid: &str) -> Vec<u8> {
+        let mut out = Vec::new();
+        write_u8(&mut out, 0); // Meta variant
+        write_clock(&mut out, &[1u8; 4], 1, 0);
+        write_string(&mut out, gid);
+        out
+    }
+
+    #[test]
+    fn read_string_vec_rejects_length_prefix_exceeding_input() {
+        // A count of 0xFFFF_FFFF strings would drive `Vec::with_capacity` to
+        // pre-allocate ~103 GB (len * size_of::<String>()) before any element
+        // is read, aborting the process. The bound must reject it up front.
+        let mut bytes = Vec::new();
+        write_u32(&mut bytes, u32::MAX); // hostile declared count, no bodies follow
+        let mut reader = BorshReader::new(&bytes);
+        let error = read_string_vec(&mut reader, "meta next").unwrap_err();
+        assert_eq!(error, LogError::UnexpectedEndOfStorage("meta next"));
+        assert_eq!(
+            error.to_string(),
+            "Unexpected end of EntryV0 storage while reading meta next"
+        );
+        // Reaching this assertion at all proves no multi-GB allocation happened.
+    }
+
+    #[test]
+    fn parse_raw_entry_v0_meta_rejects_hostile_next_count() {
+        // Same attack via the public meta-parsing entry point, exercising the
+        // full read path a hostile peer's EntryV0 storage would take.
+        let mut bytes = meta_prefix_before_next("gid");
+        // Hostile `next` count; no string bodies follow, so 0 bytes remain for
+        // u32::MAX elements. `ParsedRawEntryV0Meta` is not `Debug`, so match
+        // rather than unwrap_err.
+        write_u32(&mut bytes, u32::MAX);
+        match parse_raw_entry_v0_meta(&bytes) {
+            Err(error) => assert_eq!(error, LogError::UnexpectedEndOfStorage("meta next")),
+            Ok(_) => panic!("expected hostile next count to be rejected"),
+        }
+        // Process staying alive is the assertion; pre-fix this aborts.
+    }
+
+    #[test]
+    fn parse_raw_entry_v0_meta_rejects_partially_backed_next_count() {
+        // A count that is backed by *some* but not all of the required bytes
+        // must still be rejected before pre-allocation. Declare 1000 strings
+        // but supply only a few trailing bytes.
+        let mut bytes = meta_prefix_before_next("gid");
+        write_u32(&mut bytes, 1000); // needs >= 4000 bytes
+        bytes.extend_from_slice(&[0u8; 8]); // only 8 bytes remain
+        match parse_raw_entry_v0_meta(&bytes) {
+            Err(error) => assert_eq!(error, LogError::UnexpectedEndOfStorage("meta next")),
+            Ok(_) => panic!("expected partially-backed next count to be rejected"),
+        }
+    }
+
+    #[test]
+    fn read_string_vec_accepts_valid_next_strings() {
+        // Regression: a truthfully backed count still decodes identically.
+        let next = vec!["a".to_string(), "bb".to_string()];
+        let mut bytes = Vec::new();
+        write_u32(&mut bytes, next.len() as u32);
+        for value in &next {
+            write_string(&mut bytes, value);
+        }
+        let mut reader = BorshReader::new(&bytes);
+        let values = read_string_vec(&mut reader, "meta next").unwrap();
+        assert_eq!(values, next);
+        assert!(reader.is_done());
+    }
+
+    #[test]
+    fn read_string_vec_accepts_empty_next() {
+        let mut bytes = Vec::new();
+        write_u32(&mut bytes, 0);
+        let mut reader = BorshReader::new(&bytes);
+        let values = read_string_vec(&mut reader, "meta next").unwrap();
+        assert!(values.is_empty());
+    }
+
+    #[test]
+    fn parse_raw_entry_v0_meta_round_trips_valid_meta() {
+        // Full round-trip through the public path proves valid input is
+        // unchanged by the bound: a meta with real `next` hashes decodes to the
+        // same values it was encoded from.
+        let next = vec!["hashA".to_string(), "hashB".to_string()];
+        let bytes = encode_meta_parts(&[1u8; 4], 42, 7, "gid-1", &next, 0, None);
+        let parsed = parse_raw_entry_v0_meta(&bytes).unwrap();
+        assert_eq!(parsed.gid, "gid-1");
+        assert_eq!(parsed.next, next);
+        assert_eq!(parsed.wall_time, 42);
+        assert_eq!(parsed.logical, 7);
+    }
+}

--- a/packages/log/rust/src/codec.rs
+++ b/packages/log/rust/src/codec.rs
@@ -72,6 +72,12 @@ impl<'a> BorshReader<'a> {
         self.offset == self.bytes.len()
     }
 
+    /// Bytes left to read. `offset` is only ever advanced to a value validated
+    /// as `<= bytes.len()` by `read_exact`, so the subtraction never underflows.
+    pub(crate) fn remaining(&self) -> usize {
+        self.bytes.len() - self.offset
+    }
+
     pub(crate) fn read_exact(
         &mut self,
         len: usize,
@@ -244,6 +250,14 @@ pub(crate) fn read_string_vec(
     label: &'static str,
 ) -> Result<Vec<String>, LogError> {
     let len = reader.read_u32(label)? as usize;
+    // Each declared string is read via `read_string`, which first consumes a
+    // 4-byte u32 length prefix. A count of `len` strings therefore needs at
+    // least `len * 4` bytes to remain; if it does not, the declared vector
+    // cannot be backed by the input, so reject before pre-allocating rather
+    // than letting an attacker-controlled `len` drive a huge `with_capacity`.
+    if len.saturating_mul(4) > reader.remaining() {
+        return Err(LogError::UnexpectedEndOfStorage(label));
+    }
     let mut values = Vec::with_capacity(len);
     for _ in 0..len {
         values.push(reader.read_string(label)?);


### PR DESCRIPTION
## Why

Follow-up to #998, which flagged (and deliberately left out of a no-behavior-change refactor) a remote-DoS in the entry codec. `read_string_vec` reads a u32 element count straight from untrusted `EntryV0` meta bytes and calls `Vec::with_capacity(len)` before reading any element — a hostile peer can declare `len = 0xFFFFFFFF` and force a ~100GB allocation, aborting a native node via the allocator. Same bug class as the pnet and document-iterator issues found this cycle: trusting a length field from a remote peer.

## What

- New `BorshReader::remaining()` helper (bytes left in the input).
- Before the only input-derived preallocation (`read_string_vec`, reached via `prepare_raw_entry_v0_blocks → parse_plain_entry_v0_storage → parse_raw_entry_v0_meta`), reject when `len.saturating_mul(4) > reader.remaining()` — each declared next-hash string needs at least its own 4-byte length prefix, so a count that can't be backed by the remaining bytes is rejected with `LogError::UnexpectedEndOfStorage` instead of allocating. `saturating_mul` avoids overflow on 32-bit wasm.
- Audit confirmed this is the **only** attacker-reachable preallocation: the signatures-length field is compared `!= 1` and rejected before allocating, and every other `with_capacity` derives from trusted caller-owned encode data (left untouched — over-bounding those would break valid input).

## Tests

Six new codec tests: hostile `u32::MAX` count via both `read_string_vec` and the public `parse_raw_entry_v0_meta` path returns `Err` with the process alive (pre-fix this aborts); a partially-backed count (1000 declared, 8 bytes present) is also rejected before allocation; and regression tests proving valid/empty/tightest-packed metas still decode identically.

## Guarantees

- Wasm API **byte-identical** (`.d.ts`, `.js`, and `.wasm.d.ts` all sha256-identical to master; independently re-verified).
- Zero behavior change for valid input — the bound uses strict `>`, and a valid N-string vector always has ≥ N×4 bytes remaining, so it can never fire on a real entry (boundary case `remaining == N×4` verified to decode).
- cargo test 38/38, package TS suite green.

Changeset: `@peerbit/log-rust` patch.