### PR TITLE
chore: version packages

### DIFF
--- a/.changeset/curly-pianos-refuse.md
+++ b/.changeset/curly-pianos-refuse.md
@@ -1,5 +1,0 @@
----
-"@peerbit/document": patch
----
-
-fix: prevent stale local results from shadowing newer remote versions of the same document in the search iterator. The iterator dedupes merged results by document id, which let a first-seen stale head (e.g. a local write still propagating) permanently suppress a newer version returned by a remote peer. Now, when a strictly newer version (different head, later modified timestamp) arrives for an id whose result is still buffered, the stale buffered entry is evicted and replaced. Same-version duplicates from multiple sources still dedupe, and results already delivered to the consumer are unaffected. The eviction direction follows the store's conflict rule: newest wins for mutable stores, oldest wins for `immutable: true` stores.

--- a/.changeset/lucky-pandas-brush.md
+++ b/.changeset/lucky-pandas-brush.md
@@ -1,5 +1,0 @@
----
-"@peerbit/native-backbone": patch
----
-
-Use non-literal specifiers for the node-only fs/path dynamic imports so browser bundlers (esbuild `--platform=browser`) no longer fail resolving `node:fs/promises` and `node:path` when bundling the package

--- a/.changeset/tidy-moons-attack.md
+++ b/.changeset/tidy-moons-attack.md
@@ -1,5 +1,0 @@
----
-"@peerbit/log-rust": patch
----
-
-Refactor the crate into native-safe cores with a thin wasm surface: core logic now returns a real `LogError` type instead of `Result<_, JsValue>`, so error paths (malformed entries, CID mismatches, bad signatures) return catchable errors on native targets instead of aborting the process. The published wasm API and all error messages reaching JS are byte-identical.

--- a/packages/clients/canonical/host/CHANGELOG.md
+++ b/packages/clients/canonical/host/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.42
+
+### Patch Changes
+
+- Updated dependencies []:
+  - peerbit@5.3.1
+
 ## 1.0.41
 
 ### Patch Changes

--- a/packages/clients/canonical/host/package.json
+++ b/packages/clients/canonical/host/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@peerbit/canonical-host",
-	"version": "1.0.41",
+	"version": "1.0.42",
 	"description": "Peerbit canonical runtime host implementation (worker/server)",
 	"author": "dao.xyz",
 	"license": "MIT",

--- a/packages/clients/peerbit-react/CHANGELOG.md
+++ b/packages/clients/peerbit-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.1.25
+
+### Patch Changes
+
+- Updated dependencies []:
+  - peerbit@5.3.1
+
 ## 1.1.24
 
 ### Patch Changes

--- a/packages/clients/peerbit-react/package.json
+++ b/packages/clients/peerbit-react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@peerbit/react",
-	"version": "1.1.24",
+	"version": "1.1.25",
 	"description": "React bindings for Peerbit clients",
 	"sideEffects": false,
 	"type": "module",

--- a/packages/clients/peerbit-server/node/CHANGELOG.md
+++ b/packages/clients/peerbit-server/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 6.0.37
+
+### Patch Changes
+
+- Updated dependencies []:
+  - peerbit@5.3.1
+
 ## 6.0.36
 
 ### Patch Changes

--- a/packages/clients/peerbit-server/node/package.json
+++ b/packages/clients/peerbit-server/node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@peerbit/server",
-	"version": "6.0.36",
+	"version": "6.0.37",
 	"author": "dao.xyz",
 	"repository": {
 		"type": "git",

--- a/packages/clients/peerbit/CHANGELOG.md
+++ b/packages/clients/peerbit/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 5.3.1
+
 ## 5.3.0
 
 ### Minor Changes

--- a/packages/clients/peerbit/package.json
+++ b/packages/clients/peerbit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "peerbit",
-	"version": "5.3.0",
+	"version": "5.3.1",
 	"description": "Peerbit client",
 	"author": "dao.xyz",
 	"license": "MIT",

--- a/packages/clients/test-utils/CHANGELOG.md
+++ b/packages/clients/test-utils/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.1.1
+
+### Patch Changes
+
+- Updated dependencies []:
+  - peerbit@5.3.1
+
 ## 3.1.0
 
 ### Minor Changes

--- a/packages/clients/test-utils/package.json
+++ b/packages/clients/test-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@peerbit/test-utils",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"description": "Test utils for Peerbit",
 	"sideEffects": false,
 	"type": "module",

--- a/packages/log/CHANGELOG.md
+++ b/packages/log/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 6.2.1
+
 ## 6.2.0
 
 ### Minor Changes

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@peerbit/log",
-	"version": "6.2.0",
+	"version": "6.2.1",
 	"description": "Append-only log CRDT",
 	"author": "dao.xyz",
 	"license": "MIT",

--- a/packages/log/rust/CHANGELOG.md
+++ b/packages/log/rust/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.1
+
+### Patch Changes
+
+- [#998](https://github.com/dao-xyz/peerbit/pull/998) [`6646c8b`](https://github.com/dao-xyz/peerbit/commit/6646c8b43c8f9b919c333a6c93a462bac55cc4b1) Thanks [@peerbit-org](https://github.com/peerbit-org)! - Refactor the crate into native-safe cores with a thin wasm surface: core logic now returns a real `LogError` type instead of `Result<_, JsValue>`, so error paths (malformed entries, CID mismatches, bad signatures) return catchable errors on native targets instead of aborting the process. The published wasm API and all error messages reaching JS are byte-identical.
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/log/rust/package.json
+++ b/packages/log/rust/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@peerbit/log-rust",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Rust-backed log graph index for Peerbit",
 	"sideEffects": [
 		"./dist/wasm/log_rust.js"

--- a/packages/programs/acl/identity-access-controller/CHANGELOG.md
+++ b/packages/programs/acl/identity-access-controller/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 6.0.46
+
+### Patch Changes
+
+- Updated dependencies [[`33ae356`](https://github.com/dao-xyz/peerbit/commit/33ae35657bfd93b0c4770dbb4f4c3456c6befe78)]:
+  - @peerbit/document@13.1.1
+  - @peerbit/trusted-network@6.0.46
+  - @peerbit/shared-log@13.2.1
+
 ## 6.0.45
 
 ### Patch Changes

--- a/packages/programs/acl/identity-access-controller/package.json
+++ b/packages/programs/acl/identity-access-controller/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@peerbit/identity-access-controller",
-	"version": "6.0.45",
+	"version": "6.0.46",
 	"description": "Access controller that operates on a DB",
 	"sideEffects": false,
 	"type": "module",

--- a/packages/programs/acl/trusted-network/CHANGELOG.md
+++ b/packages/programs/acl/trusted-network/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 6.0.46
+
+### Patch Changes
+
+- Updated dependencies [[`33ae356`](https://github.com/dao-xyz/peerbit/commit/33ae35657bfd93b0c4770dbb4f4c3456c6befe78)]:
+  - @peerbit/document@13.1.1
+  - @peerbit/shared-log@13.2.1
+  - @peerbit/log@6.2.1
+
 ## 6.0.45
 
 ### Patch Changes

--- a/packages/programs/acl/trusted-network/package.json
+++ b/packages/programs/acl/trusted-network/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@peerbit/trusted-network",
-	"version": "6.0.45",
+	"version": "6.0.46",
 	"description": "Access controller that operates on a DB",
 	"sideEffects": false,
 	"type": "module",

--- a/packages/programs/clock-service/CHANGELOG.md
+++ b/packages/programs/clock-service/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.2.70
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @peerbit/trusted-network@6.0.46
+  - @peerbit/shared-log@13.2.1
+  - @peerbit/log@6.2.1
+  - @peerbit/rpc@6.1.0
+
 ## 3.2.69
 
 ### Patch Changes

--- a/packages/programs/clock-service/package.json
+++ b/packages/programs/clock-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@peerbit/clock-service",
-	"version": "3.2.69",
+	"version": "3.2.70",
 	"description": "Clock signing",
 	"type": "module",
 	"sideEffects": false,

--- a/packages/programs/data/document/document/CHANGELOG.md
+++ b/packages/programs/data/document/document/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 13.1.1
+
+### Patch Changes
+
+- [#999](https://github.com/dao-xyz/peerbit/pull/999) [`33ae356`](https://github.com/dao-xyz/peerbit/commit/33ae35657bfd93b0c4770dbb4f4c3456c6befe78) Thanks [@peerbit-org](https://github.com/peerbit-org)! - fix: prevent stale local results from shadowing newer remote versions of the same document in the search iterator. The iterator dedupes merged results by document id, which let a first-seen stale head (e.g. a local write still propagating) permanently suppress a newer version returned by a remote peer. Now, when a strictly newer version (different head, later modified timestamp) arrives for an id whose result is still buffered, the stale buffered entry is evicted and replaced. Same-version duplicates from multiple sources still dedupe, and results already delivered to the consumer are unaffected. The eviction direction follows the store's conflict rule: newest wins for mutable stores, oldest wins for `immutable: true` stores.
+
+- Updated dependencies []:
+  - @peerbit/shared-log@13.2.1
+  - @peerbit/log@6.2.1
+  - @peerbit/document-interface@3.2.44
+  - @peerbit/rpc@6.1.0
+
 ## 13.1.0
 
 ### Minor Changes

--- a/packages/programs/data/document/document/package.json
+++ b/packages/programs/data/document/document/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@peerbit/document",
-	"version": "13.1.0",
+	"version": "13.1.1",
 	"description": "Document store implementation",
 	"type": "module",
 	"sideEffects": false,

--- a/packages/programs/data/document/interface/CHANGELOG.md
+++ b/packages/programs/data/document/interface/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.2.44
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @peerbit/log@6.2.1
+
 ## 3.2.43
 
 ### Patch Changes

--- a/packages/programs/data/document/interface/package.json
+++ b/packages/programs/data/document/interface/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@peerbit/document-interface",
-	"version": "3.2.43",
+	"version": "3.2.44",
 	"description": "Document store interface",
 	"sideEffects": false,
 	"type": "module",

--- a/packages/programs/data/document/proxy/CHANGELOG.md
+++ b/packages/programs/data/document/proxy/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.0.46
+
+### Patch Changes
+
+- Updated dependencies [[`33ae356`](https://github.com/dao-xyz/peerbit/commit/33ae35657bfd93b0c4770dbb4f4c3456c6befe78)]:
+  - @peerbit/document@13.1.1
+  - @peerbit/canonical-host@1.0.42
+  - @peerbit/shared-log-proxy@2.0.45
+  - @peerbit/document-interface@3.2.44
+
 ## 2.0.45
 
 ### Patch Changes

--- a/packages/programs/data/document/proxy/package.json
+++ b/packages/programs/data/document/proxy/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@peerbit/document-proxy",
-	"version": "2.0.45",
+	"version": "2.0.46",
 	"description": "RPC/proxy adapter for @peerbit/document (canonical runtime)",
 	"author": "dao.xyz",
 	"license": "MIT",

--- a/packages/programs/data/document/react/CHANGELOG.md
+++ b/packages/programs/data/document/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @peerbit/document-react
 
+## 1.0.46
+
+### Patch Changes
+
+- Updated dependencies [[`33ae356`](https://github.com/dao-xyz/peerbit/commit/33ae35657bfd93b0c4770dbb4f4c3456c6befe78)]:
+  - @peerbit/document@13.1.1
+  - @peerbit/react@1.1.25
+
 ## 1.0.45
 
 ### Patch Changes

--- a/packages/programs/data/document/react/package.json
+++ b/packages/programs/data/document/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@peerbit/document-react",
-	"version": "1.0.45",
+	"version": "1.0.46",
 	"description": "React hooks for @peerbit/document",
 	"sideEffects": false,
 	"type": "module",

--- a/packages/programs/data/shared-log/CHANGELOG.md
+++ b/packages/programs/data/shared-log/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 13.2.1
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @peerbit/log@6.2.1
+  - @peerbit/rpc@6.1.0
+
 ## 13.2.0
 
 ### Minor Changes

--- a/packages/programs/data/shared-log/package.json
+++ b/packages/programs/data/shared-log/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@peerbit/shared-log",
-	"version": "13.2.0",
+	"version": "13.2.1",
 	"description": "Shared log",
 	"sideEffects": false,
 	"type": "module",

--- a/packages/programs/data/shared-log/proxy/CHANGELOG.md
+++ b/packages/programs/data/shared-log/proxy/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.0.45
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @peerbit/shared-log@13.2.1
+  - @peerbit/log@6.2.1
+  - @peerbit/canonical-host@1.0.42
+
 ## 2.0.44
 
 ### Patch Changes

--- a/packages/programs/data/shared-log/proxy/package.json
+++ b/packages/programs/data/shared-log/proxy/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@peerbit/shared-log-proxy",
-	"version": "2.0.44",
+	"version": "2.0.45",
 	"description": "RPC/proxy adapter for @peerbit/shared-log (canonical runtime)",
 	"author": "dao.xyz",
 	"license": "MIT",

--- a/packages/programs/data/string/CHANGELOG.md
+++ b/packages/programs/data/string/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 5.1.68
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @peerbit/shared-log@13.2.1
+  - @peerbit/log@6.2.1
+  - @peerbit/rpc@6.1.0
+
 ## 5.1.67
 
 ### Patch Changes

--- a/packages/programs/data/string/package.json
+++ b/packages/programs/data/string/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@peerbit/string",
-	"version": "5.1.67",
+	"version": "5.1.68",
 	"description": "String store",
 	"sideEffects": false,
 	"type": "module",

--- a/packages/utils/any-store/proxy/CHANGELOG.md
+++ b/packages/utils/any-store/proxy/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.42
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @peerbit/canonical-host@1.0.42
+
 ## 1.0.41
 
 ### Patch Changes

--- a/packages/utils/any-store/proxy/package.json
+++ b/packages/utils/any-store/proxy/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@peerbit/any-store-proxy",
-	"version": "1.0.41",
+	"version": "1.0.42",
 	"description": "Canonical module adapters for @peerbit/any-store",
 	"author": "dao.xyz",
 	"license": "MIT",

--- a/packages/utils/native-backbone/CHANGELOG.md
+++ b/packages/utils/native-backbone/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @peerbit/native-backbone
 
+## 0.1.1
+
+### Patch Changes
+
+- [#1000](https://github.com/dao-xyz/peerbit/pull/1000) [`81b5a4c`](https://github.com/dao-xyz/peerbit/commit/81b5a4c60813e49986663e8dbe3718a11937f8c3) Thanks [@peerbit-org](https://github.com/peerbit-org)! - Use non-literal specifiers for the node-only fs/path dynamic imports so browser bundlers (esbuild `--platform=browser`) no longer fail resolving `node:fs/promises` and `node:path` when bundling the package
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/utils/native-backbone/package.json
+++ b/packages/utils/native-backbone/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@peerbit/native-backbone",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Native transaction backbone for Peerbit",
 	"sideEffects": [
 		"./dist/wasm/native_backbone.js"


### PR DESCRIPTION
This PR was opened manually with the peerbit-org bot to release the changesets from #998, #999, and #1000, because the automated release run failed to create it (see note below).

## Releases

- `@peerbit/log-rust` 1.1.0 → **1.1.1** — native-safe error paths (#998)
- `@peerbit/document` 13.1.0 → **13.1.1** — iterator stale-shadowing fix (#999)
- `@peerbit/native-backbone` 0.1.0 → **0.1.1** — browser-bundle fix (#1000)
- plus the internal-dependency patch cascade (41 files total)

Merging this publishes the above to npm via the existing `release:publish` script (which, since #997, verifies each version landed on the registry).

## Why this is manual

The `Release` workflow's automated version-PR step is currently failing: the `changesets/action` git push runs as `RELEASE_PR_TOKEN` (peerbit-org), which returns `403 Permission denied` — that token lacks push access to this repo. `RELEASE_PR_TOKEN` needs to be regenerated as a token with write/`repo` scope (the account has write access; the token does not). Until then the automated version PR cannot be created, so this one was produced by running `pnpm run version-packages` directly.