### PR TITLE
fix(release): push tags only from release:publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,12 @@ jobs:
           github-token: ${{ secrets.RELEASE_PR_TOKEN || github.token }}
           version: pnpm run version-packages
           # Build, publish every unpublished version (from-package), then create
-          # the pkg@version git tags and push them.
+          # the pkg@version git tags and push them. The push is tags-only
+          # (`git push origin --tags`, not `--follow-tags`): the version commit
+          # always reaches master via the merged Version Packages PR, so pushing
+          # the branch ref here is redundant — and it rejects non-fast-forward
+          # if anything merges to master while the publish run is live, turning
+          # a successful publish red.
           #
           # This MUST be a single `pnpm run <script>`. changesets/action runs the
           # publish command WITHOUT a shell, so an inline `a && b && c` chain here

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
 		"changeset": "changeset",
 		"version-packages": "changeset version && pnpm install --lockfile-only",
 		"release": "node ./scripts/publish-public-packages.mjs",
-		"release:publish": "pnpm run build && pnpm run release && changeset tag && git push --follow-tags",
+		"release:publish": "pnpm run build && pnpm run release && changeset tag && git push origin --tags",
 		"release:rc": "AEGIR_PACKAGE_MANAGER=pnpm aegir release-rc",
 		"deploy": "pnpm run deploy:docs",
 		"deploy:docs": "pnpm run site:build && gh-pages --dist apps/peerbit-org/dist --dotfiles",


### PR DESCRIPTION
## Problem

`release:publish` ends with `git push --follow-tags`, which pushes the current **branch ref** in addition to the tags. If anything merges to master while a publish run is live, that branch push rejects non-fast-forward and the workflow goes red — even though the npm publish and tagging succeeded. This happened on the 5.3.1 publish (2026-07-06) when a PR merged mid-run.

## Fix

Push tags only (`git push origin --tags`). The version commit always reaches master via the merged Version Packages PR, so the branch push was redundant. Also documents the rationale next to the publish step in `release.yml`.

## Notes

- No package changes, so no changeset.
- Already-upstream tags are a no-op on push; `changeset tag` only creates the new `pkg@version` tags in the fresh CI checkout.