### PR TITLE
fix(native): persist next-chained heads and surface RPC codec errors

### DIFF
--- a/.changeset/native-chained-head-persist.md
+++ b/.changeset/native-chained-head-persist.md
@@ -1,0 +1,13 @@
+---
+"@peerbit/log": patch
+"@peerbit/rpc": patch
+"@peerbit/shared-log": patch
+"@peerbit/document": patch
+---
+
+Fix native-backbone handling of entries with next-dependencies and surface RPC codec failures
+
+- shared-log: always open the log on RemoteBlocks (whose local layer already is the native block store when the backbone is active). A replicate:false observer previously got the raw native store, which drops the remote options joins rely on — syncing a head whose parents were not local reported "sync OK" while persisting nothing, so a subsequent `log.get(head)` missed and document resolution returned null (hit by any `remote: { replicate: true }` document query for a head with `meta.next`, e.g. file-share ready-manifests).
+- log: prepared native entries built with `cachePreparedEntries: false` now remember their signer, so `entry.publicKeys` works even while payload/signature bytes live only in the native store. Chained puts (`meta: { next: [...] }`) previously crashed with "Missing data" when the document index commit read the hollow entry's public keys.
+- document: the `keep: "self"` predicate now resolves signer keys via `getPublicKeys` (tolerant of prepared native entries) instead of the throwing `signatures` getter, and treats an unknowable signer as not-ours instead of failing the prune evaluation.
+- rpc: BorshErrors past the envelope decode are no longer swallowed as "message for a different namespace" — they are logged with their stage (request decode, response encode/decode) and dispatched as a typed `codecError` event, so payloads that fail to (de)serialize no longer disappear into silent request timeouts.

--- a/.changeset/native-chained-head-persist.md
+++ b/.changeset/native-chained-head-persist.md
@@ -1,4 +1,5 @@
 ---
+"@peerbit/blocks": patch
 "@peerbit/log": patch
 "@peerbit/rpc": patch
 "@peerbit/shared-log": patch
@@ -7,6 +8,7 @@
 
 Fix native-backbone handling of entries with next-dependencies and surface RPC codec failures
 
+- blocks: RemoteBlocks exposes `putKnownManyColumns` (delegating to its local store) when the local store supports it, so the log's columnar raw-receive fast path keeps engaging through the wrapper.
 - shared-log: always open the log on RemoteBlocks (whose local layer already is the native block store when the backbone is active). A replicate:false observer previously got the raw native store, which drops the remote options joins rely on — syncing a head whose parents were not local reported "sync OK" while persisting nothing, so a subsequent `log.get(head)` missed and document resolution returned null (hit by any `remote: { replicate: true }` document query for a head with `meta.next`, e.g. file-share ready-manifests).
 - log: prepared native entries built with `cachePreparedEntries: false` now remember their signer, so `entry.publicKeys` works even while payload/signature bytes live only in the native store. Chained puts (`meta: { next: [...] }`) previously crashed with "Missing data" when the document index commit read the hollow entry's public keys.
 - document: the `keep: "self"` predicate now resolves signer keys via `getPublicKeys` (tolerant of prepared native entries) instead of the throwing `signatures` getter, and treats an unknowable signer as not-ours instead of failing the prune evaluation.

--- a/packages/log/src/entry-v0.ts
+++ b/packages/log/src/entry-v0.ts
@@ -666,6 +666,10 @@ export class EntryV0<T>
 	private _keychain?: CryptoKeychain;
 	private _encoding?: Encoding<T>;
 	private _hashDigestBytes?: Uint8Array;
+	// Set for locally-created prepared entries whose signature value and bytes
+	// stay in the native store (cachePreparedEntries: false): the signer is
+	// known at construction, so publicKeys can be answered without them.
+	_preparedSignerPublicKey?: PublicSignKey;
 
 	constructor(obj: {
 		payload: MaybeEncrypted<Payload<T>>;
@@ -762,7 +766,17 @@ export class EntryV0<T>
 	}
 
 	get publicKeys(): PublicSignKey[] {
+		if (this._preparedSignerPublicKey) {
+			return [this._preparedSignerPublicKey];
+		}
 		return this.signatures.map((x) => x.publicKey);
+	}
+
+	override async getPublicKeys(): Promise<PublicSignKey[]> {
+		if (this._preparedSignerPublicKey) {
+			return [this._preparedSignerPublicKey];
+		}
+		return super.getPublicKeys();
 	}
 
 	get next(): string[] {
@@ -1081,6 +1095,9 @@ export class EntryV0<T>
 			if (properties.cachePreparedEntries === false) {
 				entry.hash = preparedEntry.cid;
 				entry.size = preparedEntry.byteLength;
+				if (!preparedEntry.signatureBytes) {
+					entry._preparedSignerPublicKey = properties.identity.publicKey;
+				}
 			} else {
 				if (!preparedEntry.bytes) {
 					throw new Error("Missing prepared entry bytes");
@@ -1726,6 +1743,9 @@ export class EntryV0<T>
 			if (properties.cachePreparedEntries === false) {
 				entry.hash = preparedEntry.cid;
 				entry.size = preparedEntry.byteLength;
+				if (!preparedEntry.signatureBytes) {
+					entry._preparedSignerPublicKey = properties.identity.publicKey;
+				}
 			} else {
 				if (!preparedEntry.bytes) {
 					throw new Error("Missing prepared entry bytes");

--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -5,11 +5,7 @@ import {
 	serialize,
 	variant,
 } from "@dao-xyz/borsh";
-import {
-	AccessError,
-	type PublicSignKey,
-	SignatureWithKey,
-} from "@peerbit/crypto";
+import { AccessError, type PublicSignKey } from "@peerbit/crypto";
 import {
 	Context,
 	NotFoundError,
@@ -2333,20 +2329,31 @@ export class Documents<
 				if (this.keepCache?.has(e.hash)) {
 					return true;
 				}
-				let signatures: SignatureWithKey[] | undefined = undefined;
+				// Only the signer identity matters here. Use getPublicKeys so
+				// prepared native entries (hollow in JS, signature bytes in the
+				// native store) can still answer; if the signer is genuinely
+				// unknowable we cannot prove the entry is ours, so do not keep.
+				const resolveKeys = async (entry: Entry<Operation>) => {
+					try {
+						return await entry.getPublicKeys();
+					} catch {
+						return undefined;
+					}
+				};
+				let publicKeys: PublicSignKey[] | undefined = undefined;
 				if (e instanceof Entry) {
-					signatures = e.signatures;
+					publicKeys = await resolveKeys(e);
 				} else {
 					const entry = await this.log.log.get(e.hash);
-					signatures = entry?.signatures;
+					publicKeys = entry ? await resolveKeys(entry) : undefined;
 				}
 
-				if (!signatures) {
+				if (!publicKeys) {
 					return false;
 				}
 
-				for (const signature of signatures) {
-					if (signature.publicKey.equals(this.node.identity.publicKey)) {
+				for (const publicKey of publicKeys) {
+					if (publicKey.equals(this.node.identity.publicKey)) {
 						this.keepCache?.add(e.hash);
 						return true;
 					}

--- a/packages/programs/data/document/document/test/native-replicate-sync.spec.ts
+++ b/packages/programs/data/document/document/test/native-replicate-sync.spec.ts
@@ -1,0 +1,150 @@
+// Regression coverage for native-backbone entries with `meta.next` chains
+// (the file-share ready-manifest pattern: put v1, then put v2 with
+// meta.next = [v1.entry]).
+//
+// Two defects are pinned here, both only reproducible on peers created with
+// `createRustPeerbitOptions()` (TestSession does not activate the backbone):
+//
+// 1. The chained put itself crashed with "Missing data": prepared native
+//    entries are hollow in JS (payload/signature bytes stay in the native
+//    store) and the document index commit read `entry.publicKeys` eagerly.
+// 2. A replicate:false observer syncing the chained head with
+//    remote:{replicate:true} got "sync OK" while nothing persisted: the
+//    shared-log opened its log on the raw native block store, which drops
+//    the remote options joins need to resolve the head's parents, and
+//    Log.join treats the failed resolve as recoverable and silently skips.
+import { field, option, variant } from "@dao-xyz/borsh";
+import { expect } from "chai";
+import { Peerbit } from "peerbit";
+import { createRustPeerbitOptions } from "peerbit/rust";
+import { Documents } from "../src/program.js";
+import { Document, TestStore } from "./data.js";
+
+@variant("native_replicate_sync_indexable")
+class ChainedIndexable {
+	@field({ type: "string" })
+	id: string;
+
+	@field({ type: option("string") })
+	name?: string;
+
+	constructor(doc?: Document) {
+		this.id = doc?.id ?? "";
+		this.name = doc?.name;
+	}
+}
+
+describe("native replicate sync", function () {
+	this.timeout(120_000);
+
+	let writer: Peerbit;
+	let reader: Peerbit;
+	let writerStore: TestStore<ChainedIndexable>;
+	let readerStore: TestStore<ChainedIndexable>;
+
+	const indexArgs = () => ({
+		type: ChainedIndexable,
+	});
+
+	beforeEach(async () => {
+		writer = await Peerbit.create({ ...createRustPeerbitOptions() });
+		reader = await Peerbit.create({ ...createRustPeerbitOptions() });
+		await writer.dial(reader);
+	});
+
+	afterEach(async () => {
+		await writerStore?.close();
+		await readerStore?.close();
+		await writer?.stop();
+		await reader?.stop();
+	});
+
+	const openStores = async (options?: { canPerform?: boolean }) => {
+		writerStore = new TestStore<ChainedIndexable>({
+			docs: new Documents<Document, ChainedIndexable>(),
+		});
+		readerStore = writerStore.clone();
+		await writer.open(writerStore, {
+			args: {
+				replicate: { factor: 1 },
+				index: indexArgs(),
+				...(options?.canPerform
+					? {
+							canPerform: async (operation: any) => {
+								for (const key of await operation.entry.getPublicKeys()) {
+									if (key.equals(writer.identity.publicKey)) {
+										return true;
+									}
+								}
+								return false;
+							},
+						}
+					: {}),
+			},
+		});
+		await reader.open(readerStore, {
+			args: {
+				replicate: false,
+				index: indexArgs(),
+			},
+		});
+		expect((writerStore.docs.log as any)._nativeBackbone, "writer backbone")
+			.to.exist;
+		expect((readerStore.docs.log as any)._nativeBackbone, "reader backbone")
+			.to.exist;
+		await readerStore.docs.log.waitForReplicator(writer.identity.publicKey);
+	};
+
+	const putChained = async (id: string) => {
+		const pending = await writerStore.docs.put(
+			new Document({ id, name: "v1" }),
+		);
+		const appended = await writerStore.docs.put(
+			new Document({ id, name: "v2" }),
+			{
+				meta: { next: [pending.entry] },
+			},
+		);
+		return appended.entry.hash;
+	};
+
+	it("puts a chained head natively without crashing on hollow entries", async () => {
+		await openStores();
+		await putChained("chained-put");
+		const local = await writerStore.docs.index.get("chained-put", {
+			local: true,
+			remote: false,
+		});
+		expect(local?.name).to.equal("v2");
+	});
+
+	it("persists a chained head on the reader for remote replicate get", async () => {
+		await openStores({ canPerform: true });
+		const headHash = await putChained("chained-sync");
+
+		const resolved = await readerStore.docs.index.get("chained-sync", {
+			local: true,
+			remote: { timeout: 10_000, replicate: true },
+		});
+		expect(resolved?.name, "resolved document").to.equal("v2");
+
+		// The synced head must actually be materializable from the reader's
+		// own log afterwards — "sync OK" without persistence regresses this.
+		const entry = await readerStore.docs.log.log.get(headHash);
+		expect(entry, `reader entry for head ${headHash}`).to.exist;
+	});
+
+	it("resolves a chained head with remote replicate without canPerform", async () => {
+		await openStores();
+		await putChained("chained-sync-no-policy");
+
+		const resolved = await readerStore.docs.index.get(
+			"chained-sync-no-policy",
+			{
+				local: true,
+				remote: { timeout: 10_000, replicate: true },
+			},
+		);
+		expect(resolved?.name).to.equal("v2");
+	});
+});

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -8833,11 +8833,14 @@ export class SharedLog<
 				? this._nativeBackbone.graph
 				: this._nativeBackbone.storageBackedGraph
 			: undefined;
-		const nativeBackboneLogStore = useNativeBackboneBlocks
-			? this._nativeBackbone?.blocks
-			: undefined;
+		// The log always opens on RemoteBlocks, whose local layer is the native
+		// block store when the backbone is active (see localBlocks above). Opening
+		// it on the raw native store instead would drop the remote-fetch options
+		// joins rely on: a replicate:false observer syncing a head whose parents
+		// are not local would fail block resolution, and Log.join treats that as
+		// recoverable and skips the entry without persisting anything.
 		await this.log.open(
-			nativeBackboneLogStore ?? this.remoteBlocks,
+			this.remoteBlocks,
 			this.node.identity,
 			{
 				keychain: this.node.services.keychain,

--- a/packages/programs/rpc/src/controller.ts
+++ b/packages/programs/rpc/src/controller.ts
@@ -97,9 +97,22 @@ export type RequestEvent<R> = {
 	from?: PublicSignKey;
 };
 
+export type CodecErrorEvent = {
+	error: Error;
+	stage:
+		| "decode-request"
+		| "handle-request"
+		| "encode-response"
+		| "publish-response"
+		| "dispatch-response"
+		| "decode-response";
+	message: DataMessage;
+};
+
 export interface RPCEvents<Q, R> extends ProgramEvents {
 	request: CustomEvent<RequestEvent<Q>>;
 	response: CustomEvent<ResponseEvent<R>>;
+	codecError: CustomEvent<CodecErrorEvent>;
 }
 
 @variant("rpc")
@@ -178,8 +191,25 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 		const { data, message } = evt.detail;
 
 		if (data?.topics.find((x) => x === this.topic) != null) {
+			let rpcMessage: RPCMessage;
 			try {
-				const rpcMessage = deserialize(data.data, RPCMessage);
+				rpcMessage = deserialize(data.data, RPCMessage);
+			} catch (error: any) {
+				if (error instanceof BorshError) {
+					// The envelope itself is not an RPCMessage: another protocol
+					// sharing the topic. This is the only BorshError that is safe
+					// to treat as "not for us".
+					logger.trace("Got message for a different namespace");
+					return;
+				}
+				logger.error(
+					"Error decoding RPC message: " +
+						(error?.message ? error?.message?.toString() : error),
+				);
+				return;
+			}
+			let stage: CodecErrorEvent["stage"] = "decode-request";
+			try {
 				if (rpcMessage instanceof RequestV0) {
 					if (this._responseHandler) {
 						let request: Q | undefined;
@@ -202,6 +232,7 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 							);
 							request = this._getRequestValueFn(decrypted);
 						}
+						stage = "handle-request";
 						let from = message.header.signatures!.publicKeys[0];
 
 						this.events.dispatchEvent(
@@ -224,7 +255,9 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 
 						if (response && rpcMessage.respondTo) {
 							// send query and wait for replies in a generator like behaviour
+							stage = "encode-response";
 							const serializedResponse = serialize(response);
+							stage = "publish-response";
 
 							// we use the peerId/libp2p identity for signatures, since we want to be able to send a message
 							// with pubsub with a certain receiver. If we use (this.identity) we are going to use an identity
@@ -262,6 +295,7 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 						}
 					}
 				} else if (rpcMessage instanceof ResponseV0) {
+					stage = "dispatch-response";
 					const id = toBase64(rpcMessage.requestId);
 					const handler = this._responseResolver.get(id);
 					// TODO evaluate when and how handler can be missing
@@ -277,7 +311,21 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 				}
 
 				if (error instanceof BorshError) {
-					logger.error("Got message for a different namespace");
+					// Past the envelope decode this is OUR payload failing to
+					// (de)serialize — e.g. a response embedding entries that
+					// cannot be re-serialized. Swallowing it silently makes the
+					// requester time out with no trace, so surface it.
+					logger.error(
+						"RPC serialization failed at stage " +
+							stage +
+							": " +
+							error.message,
+					);
+					this.events.dispatchEvent(
+						new CustomEvent<CodecErrorEvent>("codecError", {
+							detail: { error, stage, message },
+						}),
+					);
 					return;
 				}
 
@@ -430,6 +478,7 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 			response: ResponseV0;
 			message: DataMessage;
 		}) => {
+			let decoded = false;
 			try {
 				const { response, message } = properties;
 				const from = message.header.signatures!.publicKeys[0];
@@ -441,6 +490,7 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 				const maybeEncrypted = response.response;
 				const decrypted = await maybeEncrypted.decrypt(keypair);
 				const resultData = this._getResponseValueFn(decrypted);
+				decoded = true;
 
 				this.handleDecodedResponse(
 					{
@@ -460,8 +510,32 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 				}
 
 				if (error instanceof BorshError) {
-					logger.trace("Namespace error");
-					return; // Name space conflict most likely
+					if (decoded) {
+						// The response decoded fine; the error came from a
+						// consumer callback afterwards. Don't misreport it as
+						// a codec failure (control flow matches other swallows).
+						logger.error(
+							"Error handling decoded RPC response: " + error.message,
+						);
+						return;
+					}
+					// The response was addressed to us (encrypted to this
+					// request's keypair) but its payload failed to decode —
+					// that is a codec bug, not a namespace conflict. Keep the
+					// request alive for other responders, but surface it.
+					logger.error(
+						"Failed to decode RPC response: " + error.message,
+					);
+					this.events.dispatchEvent(
+						new CustomEvent<CodecErrorEvent>("codecError", {
+							detail: {
+								error,
+								stage: "decode-response",
+								message: properties.message,
+							},
+						}),
+					);
+					return;
 				}
 
 				logger.error("failed ot deserialize query response: " + error?.message);

--- a/packages/programs/rpc/test/index.spec.ts
+++ b/packages/programs/rpc/test/index.spec.ts
@@ -1,4 +1,11 @@
-import { deserialize, field, serialize, variant, vec } from "@dao-xyz/borsh";
+import {
+	BorshError,
+	deserialize,
+	field,
+	serialize,
+	variant,
+	vec,
+} from "@dao-xyz/borsh";
 import {
 	Ed25519Keypair,
 	PublicSignKey,
@@ -16,6 +23,7 @@ import { AbortError, delay, waitFor, waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
 import sinon from "sinon";
 import {
+	type CodecErrorEvent,
 	MissingResponsesError,
 	RPC,
 	type RPCResponse,
@@ -165,6 +173,39 @@ describe("rpc", () => {
 			expect(from.hashcode()).equal(
 				responder.node.identity.publicKey.hashcode(),
 			);
+		});
+
+		it("surfaces response serialization failures as codecError", async () => {
+			const codecErrors: CustomEvent<CodecErrorEvent>[] = [];
+			responder.query.events.addEventListener("codecError", (e) => {
+				codecErrors.push(e as CustomEvent<CodecErrorEvent>);
+			});
+
+			// Make the responder produce a response borsh cannot serialize.
+			// This used to be swallowed as "message for a different namespace"
+			// and the requester would just time out with no trace anywhere.
+			(responder.query as any)._responseHandler = async () => {
+				const broken = new Body({ arr: new Uint8Array([1]) });
+				(broken as any).arr = undefined; // violates the borsh schema
+				return broken;
+			};
+
+			const results = await reader.query.request(
+				new Body({ arr: new Uint8Array([0]) }),
+				{ timeout: 2_000 },
+			);
+			expect(results).to.have.length(0);
+			await waitForResolved(() => expect(codecErrors).to.have.length(1));
+			expect(codecErrors[0].detail.stage).to.equal("encode-response");
+			expect(codecErrors[0].detail.error).to.be.instanceOf(BorshError);
+
+			// The responder must stay usable after the failure.
+			(responder.query as any)._responseHandler = async (q: Body) => q;
+			const ok = await reader.query.request(
+				new Body({ arr: new Uint8Array([7]) }),
+				{ amount: 1 },
+			);
+			expect(ok).to.have.length(1);
 		});
 
 		it("falls back to the decode path when resolveRequest throws", async () => {

--- a/packages/transport/blocks/src/remote.ts
+++ b/packages/transport/blocks/src/remote.ts
@@ -90,6 +90,11 @@ type EagerBlockCache = {
 export class RemoteBlocks implements IBlocks {
 	localStore: BlockStore;
 
+	// Assigned in the constructor only when the local store supports it:
+	// callers feature-detect this method (the log's columnar raw-receive
+	// fast path), so it must not exist without a delegation target.
+	putKnownManyColumns?: (cids: string[], bytes: Uint8Array[]) => string[];
+
 	private _responseHandler?: (
 		data: BlockMessage,
 		context?: BlockMessageContext,
@@ -200,6 +205,25 @@ export class RemoteBlocks implements IBlocks {
 			concurrency: options?.messageProcessingConcurrency || 10,
 		});
 		this.localStore = options?.local;
+		const localPutKnownManyColumns = (
+			this.localStore as {
+				putKnownManyColumns?: (
+					cids: string[],
+					bytes: Uint8Array[],
+				) => string[];
+			}
+		)?.putKnownManyColumns;
+		if (typeof localPutKnownManyColumns === "function") {
+			this.putKnownManyColumns = (cids, bytes) => {
+				const stored = localPutKnownManyColumns.call(
+					this.localStore,
+					cids,
+					bytes,
+				);
+				void this.notifyPuts(stored);
+				return stored;
+			};
+		}
 		this._resolvers = new Map();
 		this._readFromPeersPromises = new Map();
 		if (options?.eagerBlocks) {


### PR DESCRIPTION
## Problem

On the native backend (`createRustPeerbitOptions()`), any `@peerbit/document` interaction involving an entry with `meta.next` dependencies breaks. The file-share ready-manifest pattern (`put(readyManifest, { meta: { next: [pendingManifest.entry] } })`) hits both manifestations:

1. **Chained puts crash** with `Error: Missing data` when no `canPerform` is configured: prepared native entries are hollow in JS (payload/signature bytes live only in the native store), and the document index commit reads `entry.publicKeys` eagerly, which throws.
2. **`remote: { replicate: true }` queries return null** for chained heads: the reader's sync reports OK, but nothing is persisted — the follow-up `resolveDocument` → `log.get(head)` misses, so the query yields null. A 16MB file-share `resolveById` with `replicate: true` reproduces this 100%.

## Root causes

- **shared-log**: with the native backbone active and `replicate: false`, the log was opened directly on the raw `NativeBackboneBlockStore` instead of `RemoteBlocks`. That store's `get(cid)` takes no options, so the remote-fetch options `Log.join` passes when resolving a head's parents are dropped, the resolve fails, and `Log.join` classifies it as recoverable and silently skips the entry. `RemoteBlocks`' local layer already *is* the native block store, so the raw wiring only removed the remote-fetch capability.
- **log**: entries built from prepared native appends with `cachePreparedEntries: false` had signature `DecryptedThing`s with neither value nor data, so the `publicKeys` getter threw. The signer is statically known at construction (the prepared native append is single-signer: JS hands exactly one keypair into the wasm encoder).

## Fix

- **shared-log**: always open the log on `this.remoteBlocks`; the `graph` vs `storageBackedGraph` selection is unchanged.
- **log**: stamp `_preparedSignerPublicKey` on prepared entries whose signature bytes are absent; `publicKeys`/`getPublicKeys` answer from it. The field is not part of the borsh schema.
- **document**: the `keep: "self"` predicate resolved signer keys via the throwing `signatures` getter, so a hollow prepared native entry failed the prune evaluation with the same "Missing data" crash class. It now uses `getPublicKeys` (which prepared entries can answer) and treats a genuinely unknowable signer as not-ours.

Reviewed and deliberately **not** included: making `getDetailed` set `SearchRequestIndexed.replicate = true` like `iterate()` does. It is not needed for this fix (responders include entries regardless), and it has secondary effects worth deciding separately — the responder-side `replicate` branch skips results whose head entry is missing instead of returning the indexed record, and the prefetch predictor replays flagged requests against newly-joined peers, marking them in gid peer history for results they never asked for.
- **rpc**: a `BorshError` thrown past the envelope decode is no longer swallowed with the misleading "message for a different namespace" log. It is logged with the stage it occurred in (request decode / response encode / response decode / dispatch) and emitted as a typed `codecError` event on `rpc.events`. This is the silent swallow that hid this whole bug class — a response that failed to serialize just looked like a request timeout. Control flow is unchanged: malformed remote payloads still never crash the node, and a bad response from one peer doesn't fail the request for the others.

## Tests

- `document/test/native-replicate-sync.spec.ts` (new): chained put without crash, chained-head `replicate: true` get with persistence assertion on the reader's log, and the same without `canPerform`. All three fail on master, pass with this change. They run on `Peerbit.create({ ...createRustPeerbitOptions() })` peers — note that `TestSession.connected(n, createRustPeerbitOptions())` does **not** activate the native backbone, which is why earlier repro attempts went inert.
- `rpc/test/index.spec.ts`: new test asserting a response that fails borsh serialization emits `codecError` with stage `encode-response` and leaves the responder usable.
- Local runs: log 231 passing, rpc 27 passing, shared-log `join` 15 + native e2e 3 passing, document native e2e/runtime-coverage/raw-exchange passing.
- End-to-end: the original failing 16MB file-share harness (LargeFile manifest, `replicate: true`) resolves correctly with these builds and the reader can materialize the head from its own log afterwards.
