### PR TITLE
refactor(native-backbone): typed native error paths (part 2)

### DIFF
--- a/.changeset/native-backbone-typed-errors-2.md
+++ b/.changeset/native-backbone-typed-errors-2.md
@@ -1,0 +1,38 @@
+---
+"@peerbit/native-backbone": patch
+---
+
+Typed native error paths for the backbone core (part 2)
+
+Completes the JsValue→typed-error refactor started in the previous release:
+the append transaction modules (append_tx/storage, facts, committed_no_next,
+committed_latest, mod), the document projection/query/index paths
+(documents.rs) and the raw-receive verify/commit hot path (raw_receive.rs)
+now report a typed `BackboneError` internally instead of constructing
+`JsValue`s, so the crate no longer aborts on error when consumed as a native
+rlib. Every `#[wasm_bindgen]` export keeps its exact signature and every
+error message string is reproduced byte-for-byte.
+
+Notable non-mechanical changes, each behavior-preserving:
+
+- Four append dispatch paths now call log-rust's typed `_core` builders
+  directly instead of its JsValue wrappers, rebuilding the frozen result-row
+  layouts locally (facts rows via the pre-existing `committed_entry_facts_to_row`,
+  trim rows via a byte-identical replica of `log_trim_entries_to_rows` fed by
+  the same `trim_oldest_log_entries_core`).
+- The pending latest-batch append state no longer captures `js_sys::Array`
+  handles: it holds owned facts and trimmed entries, and the JS rows are built
+  at the emit boundary. The log append/commit/trim side effects still happen at
+  the same point; only row construction is deferred (skipped entirely when a
+  later fallible planning step aborts the append).
+- Two `expect()` calls that trapped the whole wasm instance (in wire-sync, and
+  a partial-verify-hashes invariant in raw-receive) became typed errors.
+- The duplicate `js_error`/`decode_error` funnels in documents.rs were deleted
+  once all their call sites were typed.
+
+The two Ed25519 verification `.ok()` fallbacks in raw-receive are intentionally
+preserved as documented, control-flow-unchanged swallows: their only error is a
+signature-slice parse failure (a non-Ed25519 scheme or malformed bytes), and
+deferring to the TypeScript verification fallback is correct for mixed-scheme
+verification. The swallow is now explicit and commented rather than a bare
+`.ok()`.

--- a/packages/utils/native-backbone/src/append_tx/committed_latest.rs
+++ b/packages/utils/native-backbone/src/append_tx/committed_latest.rs
@@ -1654,16 +1654,25 @@ impl NativePeerbitBackbone {
                 self.append_profile.coordinate_core_ms += crate::time::now_ms() - started;
             }
 
+            // Rebuild the frozen JS entry/trim rows from the owned pending state
+            // at the emit boundary, timed against the same entry_row/trim_rows
+            // profile counters the pre-lift inline build used.
+            let entry_row = self.committed_entry_facts_to_row_profiled(&pending.entry_facts);
+            let trim_rows = self.native_backbone_trim_entries_to_rows_profiled(
+                pending.trimmed_entries,
+                pending.resolve_trimmed_entries,
+            );
+
             let result_row_started = profile_enabled.then(crate::time::now_ms);
             let row = Array::new();
-            row.push(&pending.entry_row);
+            row.push(&entry_row);
             row.push(&leader_samples_to_optional_rows(&coordinate_facts.leaders));
             row.push(&JsValue::from_bool(coordinate_facts.is_leader));
             row.push(&JsValue::from_bool(
                 coordinate_facts.assigned_to_range_boundary,
             ));
             row.push(&coordinate_plan_to_row(&self.resolution, &coordinate_facts));
-            row.push(&pending.trim_rows);
+            row.push(&trim_rows);
             row.push(&strings_to_array(pending.trim_hashes));
             row.push(&JsValue::from_bool(
                 pending.document_trimmed_heads_processed,
@@ -1731,8 +1740,8 @@ impl NativePeerbitBackbone {
             self.copy_append_inputs_profiled(meta_datas.get(index), &payload_data)?;
 
         let wall_time = wall_times.get_index(index);
-        let (entry_facts, trim_hashes, entry_row, trim_rows) = self
-            .prepare_committed_log_append_rows_profiled(
+        let (entry_facts, trimmed_entries, trim_hashes) = self
+            .prepare_committed_log_append_owned_profiled(
                 wall_time,
                 logicals.get_index(index),
                 gid.clone(),
@@ -1769,13 +1778,18 @@ impl NativePeerbitBackbone {
             next_hashes: next_hashes.clone(),
             delete_hashes: trim_hashes.clone(),
         });
+        // Keep the entry hash for the document-index put; `entry_facts` itself
+        // moves into the pending state so the JS entry row is rebuilt only when
+        // the batch is emitted.
+        let entry_hash = entry_facts.hash.clone();
         let mut pending_append = LatestBatchPendingAppend {
             wall_time,
             next_hashes,
             meta_bytes: entry_facts.meta_bytes.clone(),
             trim_hashes,
-            entry_row,
-            trim_rows,
+            entry_facts,
+            trimmed_entries,
+            resolve_trimmed_entries,
             document_trimmed_heads_processed: false,
             previous_document_context,
         };
@@ -1784,7 +1798,7 @@ impl NativePeerbitBackbone {
         let prepared_document_put = match self.prepare_document_index_append_put(
             document_index_commit,
             wall_time,
-            &entry_facts.hash,
+            &entry_hash,
             &gid,
             payload_size,
             None,

--- a/packages/utils/native-backbone/src/append_tx/committed_latest.rs
+++ b/packages/utils/native-backbone/src/append_tx/committed_latest.rs
@@ -17,12 +17,26 @@ use crate::documents::{
     document_index_plain_put_payload_append_commit, DocumentIndexAppendCommit,
     DocumentIndexValuePrefix,
 };
+use crate::error::BackboneError;
 use crate::js_interop::{
     ensure_same_len, has_duplicate_strings, optional_usize_from_js, required_bytes_from_array,
     strings_from_array, strings_to_array,
 };
 use crate::shared_log_plan::leader_samples_to_optional_rows;
 use crate::NativePeerbitBackbone;
+
+/// Forward a JsValue error from an untyped documents-layer helper without
+/// altering its message. The document-commit builders and the
+/// required-previous-signer validator construct every error via
+/// `JsValue::from_str`, so `as_string()` recovers the exact string they would
+/// have thrown; the fallback only guards the theoretically-non-string case.
+fn js_wrapper_error(error: JsValue) -> BackboneError {
+    BackboneError::Message(
+        error
+            .as_string()
+            .unwrap_or_else(|| "Invalid document index append input".to_string()),
+    )
+}
 
 #[wasm_bindgen]
 impl NativePeerbitBackbone {
@@ -191,21 +205,23 @@ impl NativePeerbitBackbone {
             document_projection_encoded_document,
             document_projection_signer,
         )?;
-        self.prepare_plain_committed_storage_append_document_index_latest_transaction_inner(
-            wall_time,
-            logical,
-            fallback_gid,
-            entry_type,
-            meta_data,
-            payload_data,
-            replicas,
-            role_age_ms,
-            now,
-            self_hash,
-            self_replicating,
-            resolve_trimmed_entries,
-            trim_length_to,
-            document_index_commit,
+        Ok(
+            self.prepare_plain_committed_storage_append_document_index_latest_transaction_inner(
+                wall_time,
+                logical,
+                fallback_gid,
+                entry_type,
+                meta_data,
+                payload_data,
+                replicas,
+                role_age_ms,
+                now,
+                self_hash,
+                self_replicating,
+                resolve_trimmed_entries,
+                trim_length_to,
+                document_index_commit,
+            )?,
         )
     }
 
@@ -246,21 +262,23 @@ impl NativePeerbitBackbone {
         )?;
         document_index_commit.required_previous_signer_public_key =
             Some(required_previous_signer_public_key.to_vec());
-        self.prepare_plain_committed_storage_append_document_index_latest_transaction_inner(
-            wall_time,
-            logical,
-            fallback_gid,
-            entry_type,
-            meta_data,
-            payload_data,
-            replicas,
-            role_age_ms,
-            now,
-            self_hash,
-            self_replicating,
-            resolve_trimmed_entries,
-            trim_length_to,
-            document_index_commit,
+        Ok(
+            self.prepare_plain_committed_storage_append_document_index_latest_transaction_inner(
+                wall_time,
+                logical,
+                fallback_gid,
+                entry_type,
+                meta_data,
+                payload_data,
+                replicas,
+                role_age_ms,
+                now,
+                self_hash,
+                self_replicating,
+                resolve_trimmed_entries,
+                trim_length_to,
+                document_index_commit,
+            )?,
         )
     }
 
@@ -296,21 +314,23 @@ impl NativePeerbitBackbone {
             document_projection_encoded_document,
             document_projection_signer,
         )?;
-        self.prepare_plain_committed_storage_append_document_index_latest_transaction_inner(
-            wall_time,
-            logical,
-            fallback_gid,
-            entry_type,
-            meta_data,
-            payload_data,
-            replicas,
-            role_age_ms,
-            now,
-            self_hash,
-            self_replicating,
-            resolve_trimmed_entries,
-            trim_length_to,
-            document_index_commit,
+        Ok(
+            self.prepare_plain_committed_storage_append_document_index_latest_transaction_inner(
+                wall_time,
+                logical,
+                fallback_gid,
+                entry_type,
+                meta_data,
+                payload_data,
+                replicas,
+                role_age_ms,
+                now,
+                self_hash,
+                self_replicating,
+                resolve_trimmed_entries,
+                trim_length_to,
+                document_index_commit,
+            )?,
         )
     }
 
@@ -348,21 +368,22 @@ impl NativePeerbitBackbone {
             document_projection_encoded_document,
             document_projection_signer,
         )?;
-        self.prepare_plain_committed_storage_append_document_index_latest_compact_transaction_inner(
-            wall_time,
-            logical,
-            fallback_gid,
-            entry_type,
-            meta_data,
-            payload_data,
-            replicas,
-            role_age_ms,
-            now,
-            self_hash,
-            self_replicating,
-            trim_length_to,
-            document_index_commit,
-        )
+        Ok(self
+            .prepare_plain_committed_storage_append_document_index_latest_compact_transaction_inner(
+                wall_time,
+                logical,
+                fallback_gid,
+                entry_type,
+                meta_data,
+                payload_data,
+                replicas,
+                role_age_ms,
+                now,
+                self_hash,
+                self_replicating,
+                trim_length_to,
+                document_index_commit,
+            )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -391,21 +412,22 @@ impl NativePeerbitBackbone {
             document_byte_element_index_limit,
             document_delete_trimmed_heads,
         )?;
-        self.prepare_plain_committed_storage_append_document_index_latest_compact_transaction_inner(
-            wall_time,
-            logical,
-            fallback_gid,
-            entry_type,
-            meta_data,
-            payload_data,
-            replicas,
-            role_age_ms,
-            now,
-            self_hash,
-            self_replicating,
-            trim_length_to,
-            document_index_commit,
-        )
+        Ok(self
+            .prepare_plain_committed_storage_append_document_index_latest_compact_transaction_inner(
+                wall_time,
+                logical,
+                fallback_gid,
+                entry_type,
+                meta_data,
+                payload_data,
+                replicas,
+                role_age_ms,
+                now,
+                self_hash,
+                self_replicating,
+                trim_length_to,
+                document_index_commit,
+            )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -445,21 +467,22 @@ impl NativePeerbitBackbone {
         )?;
         document_index_commit.required_previous_signer_public_key =
             Some(required_previous_signer_public_key.to_vec());
-        self.prepare_plain_committed_storage_append_document_index_latest_compact_transaction_inner(
-            wall_time,
-            logical,
-            fallback_gid,
-            entry_type,
-            meta_data,
-            payload_data,
-            replicas,
-            role_age_ms,
-            now,
-            self_hash,
-            self_replicating,
-            trim_length_to,
-            document_index_commit,
-        )
+        Ok(self
+            .prepare_plain_committed_storage_append_document_index_latest_compact_transaction_inner(
+                wall_time,
+                logical,
+                fallback_gid,
+                entry_type,
+                meta_data,
+                payload_data,
+                replicas,
+                role_age_ms,
+                now,
+                self_hash,
+                self_replicating,
+                trim_length_to,
+                document_index_commit,
+            )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -494,21 +517,22 @@ impl NativePeerbitBackbone {
             document_projection_encoded_document,
             document_projection_signer,
         )?;
-        self.prepare_plain_committed_storage_append_document_index_latest_compact_transaction_inner(
-            wall_time,
-            logical,
-            fallback_gid,
-            entry_type,
-            meta_data,
-            payload_data,
-            replicas,
-            role_age_ms,
-            now,
-            self_hash,
-            self_replicating,
-            trim_length_to,
-            document_index_commit,
-        )
+        Ok(self
+            .prepare_plain_committed_storage_append_document_index_latest_compact_transaction_inner(
+                wall_time,
+                logical,
+                fallback_gid,
+                entry_type,
+                meta_data,
+                payload_data,
+                replicas,
+                role_age_ms,
+                now,
+                self_hash,
+                self_replicating,
+                trim_length_to,
+                document_index_commit,
+            )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -542,21 +566,22 @@ impl NativePeerbitBackbone {
                 document_projection_plan_id,
                 document_projection_signer,
             )?;
-        self.prepare_plain_committed_storage_append_document_index_latest_compact_transaction_inner(
-            wall_time,
-            logical,
-            fallback_gid,
-            entry_type,
-            meta_data,
-            payload_data,
-            replicas,
-            role_age_ms,
-            now,
-            self_hash,
-            self_replicating,
-            trim_length_to,
-            document_index_commit,
-        )
+        Ok(self
+            .prepare_plain_committed_storage_append_document_index_latest_compact_transaction_inner(
+                wall_time,
+                logical,
+                fallback_gid,
+                entry_type,
+                meta_data,
+                payload_data,
+                replicas,
+                role_age_ms,
+                now,
+                self_hash,
+                self_replicating,
+                trim_length_to,
+                document_index_commit,
+            )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -596,38 +621,39 @@ impl NativePeerbitBackbone {
             "batch document value prefixes",
         )?;
         let document_keys = strings_from_array(document_keys)?;
-        self.prepare_plain_committed_storage_append_document_index_latest_batch_transaction_inner(
-            wall_times,
-            logicals,
-            fallback_gids,
-            entry_type,
-            meta_datas,
-            payload_datas,
-            replicas,
-            role_age_ms,
-            now,
-            self_hash,
-            self_replicating,
-            resolve_trimmed_entries,
-            trim_length_to,
-            &mut |index| {
-                document_index_append_commit(
-                    document_keys[index as usize].clone(),
-                    required_bytes_from_array(
-                        &document_value_prefix_bytes,
-                        index,
-                        "document value prefix",
-                    )?
-                    .to_vec(),
-                    String::new(),
-                    document_byte_element_index_limit,
-                    document_delete_trimmed_heads,
-                    JsValue::UNDEFINED,
-                    JsValue::UNDEFINED,
-                    JsValue::UNDEFINED,
-                )
-            },
-        )
+        Ok(self
+            .prepare_plain_committed_storage_append_document_index_latest_batch_transaction_inner(
+                wall_times,
+                logicals,
+                fallback_gids,
+                entry_type,
+                meta_datas,
+                payload_datas,
+                replicas,
+                role_age_ms,
+                now,
+                self_hash,
+                self_replicating,
+                resolve_trimmed_entries,
+                trim_length_to,
+                &mut |index| {
+                    document_index_append_commit(
+                        document_keys[index as usize].clone(),
+                        required_bytes_from_array(
+                            &document_value_prefix_bytes,
+                            index,
+                            "document value prefix",
+                        )?
+                        .to_vec(),
+                        String::new(),
+                        document_byte_element_index_limit,
+                        document_delete_trimmed_heads,
+                        JsValue::UNDEFINED,
+                        JsValue::UNDEFINED,
+                        JsValue::UNDEFINED,
+                    )
+                },
+            )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -669,41 +695,42 @@ impl NativePeerbitBackbone {
         )?;
         let required_previous_signer_public_key = required_previous_signer_public_key.to_vec();
         let document_keys = strings_from_array(document_keys)?;
-        self.prepare_plain_committed_storage_append_document_index_latest_batch_transaction_inner(
-            wall_times,
-            logicals,
-            fallback_gids,
-            entry_type,
-            meta_datas,
-            payload_datas,
-            replicas,
-            role_age_ms,
-            now,
-            self_hash,
-            self_replicating,
-            resolve_trimmed_entries,
-            trim_length_to,
-            &mut |index| {
-                let mut document_index_commit = document_index_append_commit(
-                    document_keys[index as usize].clone(),
-                    required_bytes_from_array(
-                        &document_value_prefix_bytes,
-                        index,
-                        "document value prefix",
-                    )?
-                    .to_vec(),
-                    String::new(),
-                    document_byte_element_index_limit,
-                    document_delete_trimmed_heads,
-                    JsValue::UNDEFINED,
-                    JsValue::UNDEFINED,
-                    JsValue::UNDEFINED,
-                )?;
-                document_index_commit.required_previous_signer_public_key =
-                    Some(required_previous_signer_public_key.clone());
-                Ok(document_index_commit)
-            },
-        )
+        Ok(self
+            .prepare_plain_committed_storage_append_document_index_latest_batch_transaction_inner(
+                wall_times,
+                logicals,
+                fallback_gids,
+                entry_type,
+                meta_datas,
+                payload_datas,
+                replicas,
+                role_age_ms,
+                now,
+                self_hash,
+                self_replicating,
+                resolve_trimmed_entries,
+                trim_length_to,
+                &mut |index| {
+                    let mut document_index_commit = document_index_append_commit(
+                        document_keys[index as usize].clone(),
+                        required_bytes_from_array(
+                            &document_value_prefix_bytes,
+                            index,
+                            "document value prefix",
+                        )?
+                        .to_vec(),
+                        String::new(),
+                        document_byte_element_index_limit,
+                        document_delete_trimmed_heads,
+                        JsValue::UNDEFINED,
+                        JsValue::UNDEFINED,
+                        JsValue::UNDEFINED,
+                    )?;
+                    document_index_commit.required_previous_signer_public_key =
+                        Some(required_previous_signer_public_key.clone());
+                    Ok(document_index_commit)
+                },
+            )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -762,7 +789,7 @@ impl NativePeerbitBackbone {
                 JsValue::UNDEFINED,
             )?);
         }
-        self.prepare_plain_committed_storage_append_document_index_latest_compact_batch_transaction_dispatch(
+        Ok(self.prepare_plain_committed_storage_append_document_index_latest_compact_batch_transaction_dispatch(
             wall_times,
             logicals,
             fallback_gids,
@@ -777,7 +804,7 @@ impl NativePeerbitBackbone {
             trim_length_to,
             &document_keys,
             document_index_commits,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -820,7 +847,7 @@ impl NativePeerbitBackbone {
                 document_delete_trimmed_heads,
             )?);
         }
-        self.prepare_plain_committed_storage_append_document_index_latest_compact_batch_transaction_dispatch(
+        Ok(self.prepare_plain_committed_storage_append_document_index_latest_compact_batch_transaction_dispatch(
             wall_times,
             logicals,
             fallback_gids,
@@ -835,7 +862,7 @@ impl NativePeerbitBackbone {
             trim_length_to,
             &document_keys,
             document_index_commits,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -899,7 +926,7 @@ impl NativePeerbitBackbone {
                 Some(required_previous_signer_public_key.clone());
             document_index_commits.push(document_index_commit);
         }
-        self.prepare_plain_committed_storage_append_document_index_latest_compact_batch_transaction_dispatch(
+        Ok(self.prepare_plain_committed_storage_append_document_index_latest_compact_batch_transaction_dispatch(
             wall_times,
             logicals,
             fallback_gids,
@@ -914,7 +941,7 @@ impl NativePeerbitBackbone {
             trim_length_to,
             &document_keys,
             document_index_commits,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -957,36 +984,37 @@ impl NativePeerbitBackbone {
             &document_projection_signers,
         )?;
         let document_keys = strings_from_array(document_keys)?;
-        self.prepare_plain_committed_storage_append_document_index_latest_batch_transaction_inner(
-            wall_times,
-            logicals,
-            fallback_gids,
-            entry_type,
-            meta_datas,
-            payload_datas,
-            replicas,
-            role_age_ms,
-            now,
-            self_hash,
-            self_replicating,
-            resolve_trimmed_entries,
-            trim_length_to,
-            &mut |index| {
-                let encoded_document = required_projection_encoded_document(
-                    &document_projection_encoded_documents,
-                    index,
-                )?;
-                document_index_cached_projection_append_commit(
-                    document_keys[index as usize].clone(),
-                    String::new(),
-                    document_byte_element_index_limit,
-                    document_delete_trimmed_heads,
-                    document_projection_plan_ids.get_index(index),
-                    encoded_document,
-                    document_projection_signers.get(index),
-                )
-            },
-        )
+        Ok(self
+            .prepare_plain_committed_storage_append_document_index_latest_batch_transaction_inner(
+                wall_times,
+                logicals,
+                fallback_gids,
+                entry_type,
+                meta_datas,
+                payload_datas,
+                replicas,
+                role_age_ms,
+                now,
+                self_hash,
+                self_replicating,
+                resolve_trimmed_entries,
+                trim_length_to,
+                &mut |index| {
+                    let encoded_document = required_projection_encoded_document(
+                        &document_projection_encoded_documents,
+                        index,
+                    )?;
+                    document_index_cached_projection_append_commit(
+                        document_keys[index as usize].clone(),
+                        String::new(),
+                        document_byte_element_index_limit,
+                        document_delete_trimmed_heads,
+                        document_projection_plan_ids.get_index(index),
+                        encoded_document,
+                        document_projection_signers.get(index),
+                    )
+                },
+            )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1031,39 +1059,40 @@ impl NativePeerbitBackbone {
         )?;
         let required_previous_signer_public_key = required_previous_signer_public_key.to_vec();
         let document_keys = strings_from_array(document_keys)?;
-        self.prepare_plain_committed_storage_append_document_index_latest_batch_transaction_inner(
-            wall_times,
-            logicals,
-            fallback_gids,
-            entry_type,
-            meta_datas,
-            payload_datas,
-            replicas,
-            role_age_ms,
-            now,
-            self_hash,
-            self_replicating,
-            resolve_trimmed_entries,
-            trim_length_to,
-            &mut |index| {
-                let encoded_document = required_projection_encoded_document(
-                    &document_projection_encoded_documents,
-                    index,
-                )?;
-                let mut document_index_commit = document_index_cached_projection_append_commit(
-                    document_keys[index as usize].clone(),
-                    String::new(),
-                    document_byte_element_index_limit,
-                    document_delete_trimmed_heads,
-                    document_projection_plan_ids.get_index(index),
-                    encoded_document,
-                    document_projection_signers.get(index),
-                )?;
-                document_index_commit.required_previous_signer_public_key =
-                    Some(required_previous_signer_public_key.clone());
-                Ok(document_index_commit)
-            },
-        )
+        Ok(self
+            .prepare_plain_committed_storage_append_document_index_latest_batch_transaction_inner(
+                wall_times,
+                logicals,
+                fallback_gids,
+                entry_type,
+                meta_datas,
+                payload_datas,
+                replicas,
+                role_age_ms,
+                now,
+                self_hash,
+                self_replicating,
+                resolve_trimmed_entries,
+                trim_length_to,
+                &mut |index| {
+                    let encoded_document = required_projection_encoded_document(
+                        &document_projection_encoded_documents,
+                        index,
+                    )?;
+                    let mut document_index_commit = document_index_cached_projection_append_commit(
+                        document_keys[index as usize].clone(),
+                        String::new(),
+                        document_byte_element_index_limit,
+                        document_delete_trimmed_heads,
+                        document_projection_plan_ids.get_index(index),
+                        encoded_document,
+                        document_projection_signers.get(index),
+                    )?;
+                    document_index_commit.required_previous_signer_public_key =
+                        Some(required_previous_signer_public_key.clone());
+                    Ok(document_index_commit)
+                },
+            )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1123,7 +1152,7 @@ impl NativePeerbitBackbone {
                 document_projection_signers.get(index_u32),
             )?);
         }
-        self.prepare_plain_committed_storage_append_document_index_latest_compact_batch_transaction_dispatch(
+        Ok(self.prepare_plain_committed_storage_append_document_index_latest_compact_batch_transaction_dispatch(
             wall_times,
             logicals,
             fallback_gids,
@@ -1138,7 +1167,7 @@ impl NativePeerbitBackbone {
             trim_length_to,
             &document_keys,
             document_index_commits,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1203,7 +1232,7 @@ impl NativePeerbitBackbone {
                 Some(required_previous_signer_public_key.clone());
             document_index_commits.push(document_index_commit);
         }
-        self.prepare_plain_committed_storage_append_document_index_latest_compact_batch_transaction_dispatch(
+        Ok(self.prepare_plain_committed_storage_append_document_index_latest_compact_batch_transaction_dispatch(
             wall_times,
             logicals,
             fallback_gids,
@@ -1218,7 +1247,7 @@ impl NativePeerbitBackbone {
             trim_length_to,
             &document_keys,
             document_index_commits,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1274,7 +1303,7 @@ impl NativePeerbitBackbone {
                 )?,
             );
         }
-        self.prepare_plain_committed_storage_append_document_index_latest_compact_batch_transaction_dispatch(
+        Ok(self.prepare_plain_committed_storage_append_document_index_latest_compact_batch_transaction_dispatch(
             wall_times,
             logicals,
             fallback_gids,
@@ -1289,7 +1318,7 @@ impl NativePeerbitBackbone {
             trim_length_to,
             &document_keys,
             document_index_commits,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1445,7 +1474,7 @@ impl NativePeerbitBackbone {
         trim_length_to: Option<usize>,
         document_keys: &[String],
         document_index_commits: Vec<DocumentIndexAppendCommit>,
-    ) -> Result<Array, JsValue> {
+    ) -> Result<Array, BackboneError> {
         if has_duplicate_strings(document_keys) {
             let out = Array::new();
             for (index, document_index_commit) in document_index_commits.into_iter().enumerate() {
@@ -1453,7 +1482,7 @@ impl NativePeerbitBackbone {
                 let fallback_gid = fallback_gids
                     .get(index_u32)
                     .as_string()
-                    .ok_or_else(|| JsValue::from_str("Expected batch fallback gid string"))?;
+                    .ok_or(BackboneError::ExpectedString("batch fallback gid"))?;
                 let row = self
                     .prepare_plain_committed_storage_append_document_index_latest_compact_transaction_inner(
                         wall_times.get_index(index_u32),
@@ -1508,12 +1537,13 @@ impl NativePeerbitBackbone {
         resolve_trimmed_entries: bool,
         trim_length_to: JsValue,
         mut document_index_commit: DocumentIndexAppendCommit,
-    ) -> Result<Array, JsValue> {
+    ) -> Result<Array, BackboneError> {
         let trim_length_to = optional_usize_from_js(trim_length_to, "trimLengthTo")?;
         let (_, gid, next_hashes) =
             self.resolve_latest_document_append_context(&mut document_index_commit, fallback_gid)?;
-        self.validate_document_index_required_previous_signer(&document_index_commit)?;
-        Ok(self.prepare_plain_storage_append_transaction_inner(
+        self.validate_document_index_required_previous_signer(&document_index_commit)
+            .map_err(js_wrapper_error)?;
+        self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -1530,7 +1560,7 @@ impl NativePeerbitBackbone {
             trim_length_to,
             true,
             Some(document_index_commit),
-        )?)
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1553,7 +1583,7 @@ impl NativePeerbitBackbone {
             u32,
         )
             -> Result<DocumentIndexAppendCommit, JsValue>,
-    ) -> Result<Array, JsValue> {
+    ) -> Result<Array, BackboneError> {
         let batch_len = payload_datas.length() as usize;
         if batch_len == 0 {
             return Ok(Array::new());
@@ -1680,20 +1710,22 @@ impl NativePeerbitBackbone {
             -> Result<DocumentIndexAppendCommit, JsValue>,
         pending_appends: &mut Vec<LatestBatchPendingAppend>,
         coordinate_inputs: &mut Vec<NativeLocalAppendCompactInput>,
-    ) -> Result<(), JsValue> {
+    ) -> Result<(), BackboneError> {
         let profile_enabled = self.append_profile_enabled;
         let fallback_gid = fallback_gids
             .get(index)
             .as_string()
-            .ok_or_else(|| JsValue::from_str("Expected batch fallback gid string"))?;
-        let mut document_index_commit = make_document_index_commit(index)?;
+            .ok_or(BackboneError::ExpectedString("batch fallback gid"))?;
+        let mut document_index_commit =
+            make_document_index_commit(index).map_err(js_wrapper_error)?;
         let payload_data = required_bytes_from_array(payload_datas, index, "payload")?;
         let trim_length_to = optional_usize_from_js(trim_length_to.clone(), "trimLengthTo")?;
         let payload_size = payload_data.length();
         let delete_trimmed_document_heads = document_index_commit.delete_trimmed_heads;
         let (previous_document_context, gid, next_hashes) =
             self.resolve_latest_document_append_context(&mut document_index_commit, fallback_gid)?;
-        self.validate_document_index_required_previous_signer(&document_index_commit)?;
+        self.validate_document_index_required_previous_signer(&document_index_commit)
+            .map_err(js_wrapper_error)?;
 
         let (meta_data, payload_data) =
             self.copy_append_inputs_profiled(meta_datas.get(index), &payload_data)?;
@@ -1762,7 +1794,7 @@ impl NativePeerbitBackbone {
                 // The per-item path commits the coordinate before the document
                 // index write can fail, so leave this entry coordinate-flushable.
                 pending_appends.push(pending_append);
-                return Err(error.into());
+                return Err(error);
             }
         };
         self.commit_prepared_document_index_append_put(prepared_document_put);
@@ -1786,7 +1818,7 @@ impl NativePeerbitBackbone {
         now: &str,
         self_hash: &str,
         self_replicating: bool,
-    ) -> Result<(), JsValue> {
+    ) -> Result<(), BackboneError> {
         if coordinate_inputs.is_empty() {
             return Ok(());
         }
@@ -1829,7 +1861,7 @@ impl NativePeerbitBackbone {
         self_replicating: bool,
         trim_length_to: Option<usize>,
         document_index_commits: Vec<DocumentIndexAppendCommit>,
-    ) -> Result<Array, JsValue> {
+    ) -> Result<Array, BackboneError> {
         let profile_enabled = self.append_profile_enabled;
         let storage_append_started = profile_enabled.then(crate::time::now_ms);
         let batch_len = document_index_commits.len();
@@ -1842,13 +1874,14 @@ impl NativePeerbitBackbone {
             let fallback_gid = fallback_gids
                 .get(index_u32)
                 .as_string()
-                .ok_or_else(|| JsValue::from_str("Expected batch fallback gid string"))?;
+                .ok_or(BackboneError::ExpectedString("batch fallback gid"))?;
             let payload_bytes = required_bytes_from_array(&payload_datas, index_u32, "payload")?;
             let payload_size = payload_bytes.length();
             let delete_trimmed_document_heads = document_index_commit.delete_trimmed_heads;
             let (previous_document_context, gid, next_hashes) = self
                 .resolve_latest_document_append_context(&mut document_index_commit, fallback_gid)?;
-            self.validate_document_index_required_previous_signer(&document_index_commit)?;
+            self.validate_document_index_required_previous_signer(&document_index_commit)
+                .map_err(js_wrapper_error)?;
 
             let (meta_data, payload_data) =
                 self.copy_append_inputs_profiled(meta_datas.get(index_u32), &payload_bytes)?;
@@ -1976,14 +2009,15 @@ impl NativePeerbitBackbone {
         self_replicating: bool,
         trim_length_to: Option<usize>,
         mut document_index_commit: DocumentIndexAppendCommit,
-    ) -> Result<Array, JsValue> {
+    ) -> Result<Array, BackboneError> {
         let profile_enabled = self.append_profile_enabled;
         let storage_append_started = profile_enabled.then(crate::time::now_ms);
         let payload_size = payload_data.length();
         let delete_trimmed_document_heads = document_index_commit.delete_trimmed_heads;
         let (previous_document_context, gid, next_hashes) =
             self.resolve_latest_document_append_context(&mut document_index_commit, fallback_gid)?;
-        self.validate_document_index_required_previous_signer(&document_index_commit)?;
+        self.validate_document_index_required_previous_signer(&document_index_commit)
+            .map_err(js_wrapper_error)?;
 
         let (meta_data, payload_data) =
             self.copy_append_inputs_profiled(meta_data, &payload_data)?;
@@ -2060,5 +2094,29 @@ impl NativePeerbitBackbone {
             self.append_profile.storage_append_inner_ms += crate::time::now_ms() - started;
         }
         Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::error::BackboneError;
+
+    // `js_wrapper_error` forwards the untyped documents-layer JsValue messages
+    // verbatim through `BackboneError::Message`. These are the exact strings
+    // the required-previous-signer validator throws; pin their Display so the
+    // forwarded messages stay byte-for-byte with master. (The `JsValue` recovery
+    // itself is exercised on wasm by the TS suite; host `cargo test` cannot
+    // construct a round-tripping `JsValue`, so it pins the Message rendering.)
+    #[test]
+    fn forwarded_document_signer_messages_render_verbatim() {
+        for message in [
+            "Previous document signer public key unavailable",
+            "Previous document signer public key did not match native policy",
+        ] {
+            assert_eq!(
+                BackboneError::Message(message.to_string()).to_string(),
+                message
+            );
+        }
     }
 }

--- a/packages/utils/native-backbone/src/append_tx/committed_latest.rs
+++ b/packages/utils/native-backbone/src/append_tx/committed_latest.rs
@@ -43,7 +43,7 @@ impl NativePeerbitBackbone {
         self_replicating: bool,
         resolve_trimmed_entries: bool,
     ) -> Result<Array, JsValue> {
-        self.prepare_plain_storage_append_transaction_inner(
+        Ok(self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -60,7 +60,7 @@ impl NativePeerbitBackbone {
             None,
             true,
             None,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -128,7 +128,7 @@ impl NativePeerbitBackbone {
         document_projection_encoded_document: JsValue,
         document_projection_signer: JsValue,
     ) -> Result<Array, JsValue> {
-        self.prepare_plain_storage_append_transaction_inner(
+        Ok(self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -154,7 +154,7 @@ impl NativePeerbitBackbone {
                 document_projection_encoded_document,
                 document_projection_signer,
             )?),
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1310,7 +1310,7 @@ impl NativePeerbitBackbone {
         resolve_trimmed_entries: bool,
         trim_length_to: usize,
     ) -> Result<Array, JsValue> {
-        self.prepare_plain_storage_append_transaction_inner(
+        Ok(self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -1327,7 +1327,7 @@ impl NativePeerbitBackbone {
             Some(trim_length_to),
             true,
             None,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1397,7 +1397,7 @@ impl NativePeerbitBackbone {
         document_projection_signer: JsValue,
         trim_length_to: usize,
     ) -> Result<Array, JsValue> {
-        self.prepare_plain_storage_append_transaction_inner(
+        Ok(self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -1423,7 +1423,7 @@ impl NativePeerbitBackbone {
                 document_projection_encoded_document,
                 document_projection_signer,
             )?),
-        )
+        )?)
     }
 }
 
@@ -1513,7 +1513,7 @@ impl NativePeerbitBackbone {
         let (_, gid, next_hashes) =
             self.resolve_latest_document_append_context(&mut document_index_commit, fallback_gid)?;
         self.validate_document_index_required_previous_signer(&document_index_commit)?;
-        self.prepare_plain_storage_append_transaction_inner(
+        Ok(self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -1530,7 +1530,7 @@ impl NativePeerbitBackbone {
             trim_length_to,
             true,
             Some(document_index_commit),
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1762,7 +1762,7 @@ impl NativePeerbitBackbone {
                 // The per-item path commits the coordinate before the document
                 // index write can fail, so leave this entry coordinate-flushable.
                 pending_appends.push(pending_append);
-                return Err(error);
+                return Err(error.into());
             }
         };
         self.commit_prepared_document_index_append_put(prepared_document_put);

--- a/packages/utils/native-backbone/src/append_tx/committed_no_next.rs
+++ b/packages/utils/native-backbone/src/append_tx/committed_no_next.rs
@@ -16,6 +16,7 @@ use crate::documents::{
     document_index_plain_put_payload_append_commit, DocumentIndexAppendCommit,
     DocumentIndexValuePrefix,
 };
+use crate::error::BackboneError;
 use crate::js_interop::{
     ensure_same_len, optional_usize_from_js, required_bytes_from_array, strings_from_array,
     strings_to_array,
@@ -463,7 +464,7 @@ impl NativePeerbitBackbone {
             JsValue::UNDEFINED,
             JsValue::UNDEFINED,
         )?;
-        self.prepare_plain_committed_no_next_storage_append_document_index_compact_transaction_inner(
+        Ok(self.prepare_plain_committed_no_next_storage_append_document_index_compact_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -477,7 +478,7 @@ impl NativePeerbitBackbone {
             self_replicating,
             document_index_commit,
             trim_length_to,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -507,7 +508,7 @@ impl NativePeerbitBackbone {
             document_byte_element_index_limit,
             document_delete_trimmed_heads,
         )?;
-        self.prepare_plain_committed_no_next_storage_append_document_index_compact_transaction_inner(
+        Ok(self.prepare_plain_committed_no_next_storage_append_document_index_compact_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -521,7 +522,7 @@ impl NativePeerbitBackbone {
             self_replicating,
             document_index_commit,
             trim_length_to,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -587,7 +588,7 @@ impl NativePeerbitBackbone {
                 JsValue::UNDEFINED,
             )?);
         }
-        self.prepare_plain_committed_no_next_storage_append_document_index_compact_batch_transaction_inner(
+        Ok(self.prepare_plain_committed_no_next_storage_append_document_index_compact_batch_transaction_inner(
             wall_times,
             logicals,
             gids,
@@ -601,7 +602,7 @@ impl NativePeerbitBackbone {
             self_replicating,
             trim_length_to,
             document_index_commits,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -651,7 +652,7 @@ impl NativePeerbitBackbone {
                 document_delete_trimmed_heads,
             )?);
         }
-        self.prepare_plain_committed_no_next_storage_append_document_index_compact_batch_transaction_inner(
+        Ok(self.prepare_plain_committed_no_next_storage_append_document_index_compact_batch_transaction_inner(
             wall_times,
             logicals,
             gids,
@@ -665,7 +666,7 @@ impl NativePeerbitBackbone {
             self_replicating,
             trim_length_to,
             document_index_commits,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -732,7 +733,7 @@ impl NativePeerbitBackbone {
                 document_projection_signers.get(index_u32),
             )?);
         }
-        self.prepare_plain_committed_no_next_storage_append_document_index_compact_batch_transaction_inner(
+        Ok(self.prepare_plain_committed_no_next_storage_append_document_index_compact_batch_transaction_inner(
             wall_times,
             logicals,
             gids,
@@ -746,7 +747,7 @@ impl NativePeerbitBackbone {
             self_replicating,
             trim_length_to,
             document_index_commits,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -809,7 +810,7 @@ impl NativePeerbitBackbone {
                 )?,
             );
         }
-        self.prepare_plain_committed_no_next_storage_append_document_index_compact_batch_transaction_inner(
+        Ok(self.prepare_plain_committed_no_next_storage_append_document_index_compact_batch_transaction_inner(
             wall_times,
             logicals,
             gids,
@@ -823,7 +824,7 @@ impl NativePeerbitBackbone {
             self_replicating,
             trim_length_to,
             document_index_commits,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -859,7 +860,7 @@ impl NativePeerbitBackbone {
             document_projection_encoded_document,
             document_projection_signer,
         )?;
-        self.prepare_plain_committed_no_next_storage_append_document_index_compact_transaction_inner(
+        Ok(self.prepare_plain_committed_no_next_storage_append_document_index_compact_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -872,8 +873,8 @@ impl NativePeerbitBackbone {
             self_hash,
             self_replicating,
             document_index_commit,
-			trim_length_to,
-		)
+            trim_length_to,
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -908,7 +909,7 @@ impl NativePeerbitBackbone {
                 document_projection_plan_id,
                 document_projection_signer,
             )?;
-        self.prepare_plain_committed_no_next_storage_append_document_index_compact_transaction_inner(
+        Ok(self.prepare_plain_committed_no_next_storage_append_document_index_compact_transaction_inner(
 			wall_time,
 			logical,
 			gid,
@@ -922,7 +923,7 @@ impl NativePeerbitBackbone {
 			self_replicating,
 			document_index_commit,
 			trim_length_to,
-        )
+        )?)
     }
 }
 
@@ -943,7 +944,7 @@ impl NativePeerbitBackbone {
         self_replicating: bool,
         trim_length_to: Option<usize>,
         document_index_commits: Vec<DocumentIndexAppendCommit>,
-    ) -> Result<Array, JsValue> {
+    ) -> Result<Array, BackboneError> {
         let profile_enabled = self.append_profile_enabled;
         let storage_append_started = profile_enabled.then(crate::time::now_ms);
         let batch_len = document_index_commits.len();
@@ -956,7 +957,7 @@ impl NativePeerbitBackbone {
             let gid = gids
                 .get(index_u32)
                 .as_string()
-                .ok_or_else(|| JsValue::from_str("Expected batch gid string"))?;
+                .ok_or(BackboneError::ExpectedString("batch gid"))?;
             let payload_bytes = required_bytes_from_array(&payload_datas, index_u32, "payload")?;
             let payload_size = payload_bytes.length();
             let delete_trimmed_document_heads = document_index_commit.delete_trimmed_heads;
@@ -1088,7 +1089,7 @@ impl NativePeerbitBackbone {
         self_replicating: bool,
         document_index_commit: DocumentIndexAppendCommit,
         trim_length_to: Option<usize>,
-    ) -> Result<Array, JsValue> {
+    ) -> Result<Array, BackboneError> {
         let profile_enabled = self.append_profile_enabled;
         let storage_append_started = profile_enabled.then(crate::time::now_ms);
         let payload_size = payload_data.length();

--- a/packages/utils/native-backbone/src/append_tx/committed_no_next.rs
+++ b/packages/utils/native-backbone/src/append_tx/committed_no_next.rs
@@ -40,7 +40,7 @@ impl NativePeerbitBackbone {
         self_replicating: bool,
         resolve_trimmed_entries: bool,
     ) -> Result<Array, JsValue> {
-        self.prepare_plain_storage_append_transaction_inner(
+        Ok(self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -57,7 +57,7 @@ impl NativePeerbitBackbone {
             None,
             true,
             None,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -77,7 +77,7 @@ impl NativePeerbitBackbone {
         resolve_trimmed_entries: bool,
         trim_length_to: usize,
     ) -> Result<Array, JsValue> {
-        self.prepare_plain_storage_append_transaction_inner(
+        Ok(self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -94,7 +94,7 @@ impl NativePeerbitBackbone {
             Some(trim_length_to),
             true,
             None,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -245,7 +245,7 @@ impl NativePeerbitBackbone {
         document_projection_encoded_document: JsValue,
         document_projection_signer: JsValue,
     ) -> Result<Array, JsValue> {
-        self.prepare_plain_storage_append_transaction_inner(
+        Ok(self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -271,7 +271,7 @@ impl NativePeerbitBackbone {
                 document_projection_encoded_document,
                 document_projection_signer,
             )?),
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -299,7 +299,7 @@ impl NativePeerbitBackbone {
         document_projection_signer: JsValue,
         trim_length_to: usize,
     ) -> Result<Array, JsValue> {
-        self.prepare_plain_storage_append_transaction_inner(
+        Ok(self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -325,7 +325,7 @@ impl NativePeerbitBackbone {
                 document_projection_encoded_document,
                 document_projection_signer,
             )?),
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -351,7 +351,7 @@ impl NativePeerbitBackbone {
         document_projection_encoded_document: JsValue,
         document_projection_signer: JsValue,
     ) -> Result<Array, JsValue> {
-        self.prepare_plain_storage_append_transaction_inner(
+        Ok(self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -376,7 +376,7 @@ impl NativePeerbitBackbone {
                 document_projection_encoded_document,
                 document_projection_signer,
             )?),
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -403,7 +403,7 @@ impl NativePeerbitBackbone {
         document_projection_signer: JsValue,
         trim_length_to: usize,
     ) -> Result<Array, JsValue> {
-        self.prepare_plain_storage_append_transaction_inner(
+        Ok(self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -428,7 +428,7 @@ impl NativePeerbitBackbone {
                 document_projection_encoded_document,
                 document_projection_signer,
             )?),
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/packages/utils/native-backbone/src/append_tx/facts.rs
+++ b/packages/utils/native-backbone/src/append_tx/facts.rs
@@ -1,4 +1,5 @@
 use js_sys::{Array, Uint8Array};
+use peerbit_log_rust::LogIndexEntry;
 use wasm_bindgen::prelude::*;
 
 use crate::append_tx::{
@@ -9,8 +10,36 @@ use crate::documents::{
     document_index_cached_projection_append_commit,
     document_index_cached_projection_plain_put_payload_append_commit, DocumentIndexAppendCommit,
 };
-use crate::js_interop::{optional_bytes_from_js, optional_usize_from_js, strings_to_array};
+use crate::error::BackboneError;
+use crate::js_interop::{
+    optional_bytes_from_js, optional_usize_from_js, strings_from_array, strings_to_array,
+};
 use crate::NativePeerbitBackbone;
+
+/// Trim rows in the exact shape the log-rust
+/// `prepare_entry_v0_plain_entry_commit_[no_next_]facts_trim_and_put_with_builder`
+/// wrappers returned (`log_trim_entries_to_rows`), so the re-pointed typed
+/// cores keep the frozen row layout byte-for-byte.
+fn log_trim_entries_to_rows(values: Vec<LogIndexEntry>) -> Array {
+    let out = Array::new();
+    for entry in values {
+        let row = Array::new();
+        row.push(&JsValue::from_str(&entry.hash));
+        row.push(&JsValue::from_str(&entry.gid));
+        row.push(&JsValue::from_str(&entry.wall_time.to_string()));
+        row.push(&JsValue::from_f64(entry.logical as f64));
+        row.push(&JsValue::from_f64(entry.entry_type as f64));
+        row.push(&strings_to_array(entry.next));
+        row.push(&JsValue::from_f64(entry.payload_size as f64));
+        row.push(&JsValue::from_bool(entry.head));
+        match entry.data {
+            Some(data) => row.push(&Uint8Array::from(data.as_slice())),
+            None => row.push(&JsValue::UNDEFINED),
+        };
+        out.push(&row);
+    }
+    out
+}
 
 #[wasm_bindgen]
 impl NativePeerbitBackbone {
@@ -29,58 +58,79 @@ impl NativePeerbitBackbone {
         let trim_length_to = optional_usize_from_js(trim_length_to, "trimLengthTo")?;
         let has_no_next = next.length() == 0;
         match (has_no_next, trim_length_to) {
-            (true, Some(trim_length_to)) => self
-                .log
-                .prepare_entry_v0_plain_entry_commit_no_next_facts_trim_and_put_with_builder(
-                    &self.builder,
-                    &mut self.blocks,
-                    wall_time,
-                    logical,
-                    gid,
-                    entry_type,
-                    meta_data,
-                    payload_data,
-                    trim_length_to,
-                ),
-            (true, None) => self
-                .log
-                .prepare_entry_v0_plain_entry_commit_no_next_facts_and_put_with_builder(
-                    &self.builder,
-                    &mut self.blocks,
-                    wall_time,
-                    logical,
-                    gid,
-                    entry_type,
-                    meta_data,
-                    payload_data,
-                ),
-            (false, Some(trim_length_to)) => self
-                .log
-                .prepare_entry_v0_plain_entry_commit_facts_trim_and_put_with_builder(
-                    &self.builder,
-                    &mut self.blocks,
-                    wall_time,
-                    logical,
-                    gid,
-                    next,
-                    entry_type,
-                    meta_data,
-                    payload_data,
-                    trim_length_to,
-                ),
-            (false, None) => self
-                .log
-                .prepare_entry_v0_plain_entry_commit_facts_and_put_with_builder(
-                    &self.builder,
-                    &mut self.blocks,
-                    wall_time,
-                    logical,
-                    gid,
-                    next,
-                    entry_type,
-                    meta_data,
-                    payload_data,
-                ),
+            (true, Some(trim_length_to)) => {
+                let (entry_facts, trimmed_entries) = self
+                    .log
+                    .prepare_entry_v0_plain_entry_commit_no_next_facts_core_profiled_and_put_with_builder_trim(
+                        &self.builder,
+                        &mut self.blocks,
+                        wall_time,
+                        logical,
+                        gid,
+                        entry_type,
+                        optional_bytes_from_js(meta_data, "meta data")?,
+                        payload_data.to_vec(),
+                        trim_length_to,
+                        None,
+                    )?;
+                let out = Array::new();
+                out.push(&committed_entry_facts_to_row(&entry_facts, false));
+                out.push(&log_trim_entries_to_rows(trimmed_entries));
+                Ok(out)
+            }
+            (true, None) => {
+                let entry_facts = self
+                    .log
+                    .prepare_entry_v0_plain_entry_commit_no_next_facts_core_profiled_and_put_with_builder(
+                        &self.builder,
+                        &mut self.blocks,
+                        wall_time,
+                        logical,
+                        gid,
+                        entry_type,
+                        optional_bytes_from_js(meta_data, "meta data")?,
+                        payload_data.to_vec(),
+                        None,
+                    )?;
+                Ok(committed_entry_facts_to_row(&entry_facts, false))
+            }
+            (false, Some(trim_length_to)) => {
+                let (entry_facts, trimmed_entries) = self
+                    .log
+                    .prepare_entry_v0_plain_entry_commit_facts_core_and_put_with_builder(
+                        &self.builder,
+                        &mut self.blocks,
+                        wall_time,
+                        logical,
+                        gid,
+                        strings_from_array(next)?,
+                        entry_type,
+                        optional_bytes_from_js(meta_data, "meta data")?,
+                        payload_data.to_vec(),
+                        Some(trim_length_to),
+                    )?;
+                let out = Array::new();
+                out.push(&committed_entry_facts_to_row(&entry_facts, true));
+                out.push(&log_trim_entries_to_rows(trimmed_entries));
+                Ok(out)
+            }
+            (false, None) => {
+                let (entry_facts, _trimmed_entries) = self
+                    .log
+                    .prepare_entry_v0_plain_entry_commit_facts_core_and_put_with_builder(
+                        &self.builder,
+                        &mut self.blocks,
+                        wall_time,
+                        logical,
+                        gid,
+                        strings_from_array(next)?,
+                        entry_type,
+                        optional_bytes_from_js(meta_data, "meta data")?,
+                        payload_data.to_vec(),
+                        None,
+                    )?;
+                Ok(committed_entry_facts_to_row(&entry_facts, true))
+            }
         }
     }
 
@@ -216,16 +266,18 @@ impl NativePeerbitBackbone {
             document_projection_encoded_document,
             document_projection_signer,
         )?;
-        self.prepare_plain_entry_commit_no_next_document_index_compact(
-            wall_time,
-            logical,
-            gid,
-            entry_type,
-            meta_data,
-            payload_data,
-            document_gid,
-            payload_size,
-            document_index_commit,
+        Ok(
+            self.prepare_plain_entry_commit_no_next_document_index_compact(
+                wall_time,
+                logical,
+                gid,
+                entry_type,
+                meta_data,
+                payload_data,
+                document_gid,
+                payload_size,
+                document_index_commit,
+            )?,
         )
     }
 
@@ -257,16 +309,18 @@ impl NativePeerbitBackbone {
             document_projection_encoded_document,
             document_projection_signer,
         )?;
-        self.prepare_plain_entry_commit_no_next_document_index_compact(
-            wall_time,
-            logical,
-            gid,
-            entry_type,
-            meta_data,
-            payload_data,
-            document_gid,
-            payload_size,
-            document_index_commit,
+        Ok(
+            self.prepare_plain_entry_commit_no_next_document_index_compact(
+                wall_time,
+                logical,
+                gid,
+                entry_type,
+                meta_data,
+                payload_data,
+                document_gid,
+                payload_size,
+                document_index_commit,
+            )?,
         )
     }
 
@@ -353,18 +407,20 @@ impl NativePeerbitBackbone {
             document_projection_encoded_document,
             document_projection_signer,
         )?;
-        self.prepare_plain_entry_commit_no_next_document_index_compact_trim_hashes(
-            wall_time,
-            logical,
-            gid,
-            entry_type,
-            meta_data,
-            payload_data,
-            trim_length_to,
-            document_gid,
-            payload_size,
-            document_index_commit,
-            false,
+        Ok(
+            self.prepare_plain_entry_commit_no_next_document_index_compact_trim_hashes(
+                wall_time,
+                logical,
+                gid,
+                entry_type,
+                meta_data,
+                payload_data,
+                trim_length_to,
+                document_gid,
+                payload_size,
+                document_index_commit,
+                false,
+            )?,
         )
     }
 
@@ -399,18 +455,20 @@ impl NativePeerbitBackbone {
             document_projection_encoded_document,
             document_projection_signer,
         )?;
-        self.prepare_plain_entry_commit_no_next_document_index_compact_trim_hashes(
-            wall_time,
-            logical,
-            gid,
-            entry_type,
-            meta_data,
-            payload_data,
-            trim_length_to,
-            document_gid,
-            payload_size,
-            document_index_commit,
-            true,
+        Ok(
+            self.prepare_plain_entry_commit_no_next_document_index_compact_trim_hashes(
+                wall_time,
+                logical,
+                gid,
+                entry_type,
+                meta_data,
+                payload_data,
+                trim_length_to,
+                document_gid,
+                payload_size,
+                document_index_commit,
+                true,
+            )?,
         )
     }
 
@@ -443,18 +501,20 @@ impl NativePeerbitBackbone {
             document_projection_encoded_document,
             document_projection_signer,
         )?;
-        self.prepare_plain_entry_commit_no_next_document_index_compact_trim_hashes(
-            wall_time,
-            logical,
-            gid,
-            entry_type,
-            meta_data,
-            payload_data,
-            trim_length_to,
-            document_gid,
-            payload_size,
-            document_index_commit,
-            false,
+        Ok(
+            self.prepare_plain_entry_commit_no_next_document_index_compact_trim_hashes(
+                wall_time,
+                logical,
+                gid,
+                entry_type,
+                meta_data,
+                payload_data,
+                trim_length_to,
+                document_gid,
+                payload_size,
+                document_index_commit,
+                false,
+            )?,
         )
     }
 
@@ -486,15 +546,17 @@ impl NativePeerbitBackbone {
             document_projection_encoded_document,
             document_projection_signer,
         )?;
-        self.prepare_plain_entry_commit_latest_document_index_trim_hashes_inner(
-            wall_time,
-            logical,
-            fallback_gid,
-            entry_type,
-            meta_data,
-            payload_data,
-            trim_length_to,
-            document_index_commit,
+        Ok(
+            self.prepare_plain_entry_commit_latest_document_index_trim_hashes_inner(
+                wall_time,
+                logical,
+                fallback_gid,
+                entry_type,
+                meta_data,
+                payload_data,
+                trim_length_to,
+                document_index_commit,
+            )?,
         )
     }
 
@@ -524,15 +586,17 @@ impl NativePeerbitBackbone {
             document_projection_encoded_document,
             document_projection_signer,
         )?;
-        self.prepare_plain_entry_commit_latest_document_index_trim_hashes_inner(
-            wall_time,
-            logical,
-            fallback_gid,
-            entry_type,
-            meta_data,
-            payload_data,
-            trim_length_to,
-            document_index_commit,
+        Ok(
+            self.prepare_plain_entry_commit_latest_document_index_trim_hashes_inner(
+                wall_time,
+                logical,
+                fallback_gid,
+                entry_type,
+                meta_data,
+                payload_data,
+                trim_length_to,
+                document_index_commit,
+            )?,
         )
     }
 
@@ -565,18 +629,20 @@ impl NativePeerbitBackbone {
             document_projection_encoded_document,
             document_projection_signer,
         )?;
-        self.prepare_plain_entry_commit_no_next_document_index_compact_trim_hashes(
-            wall_time,
-            logical,
-            gid,
-            entry_type,
-            meta_data,
-            payload_data,
-            trim_length_to,
-            document_gid,
-            payload_size,
-            document_index_commit,
-            true,
+        Ok(
+            self.prepare_plain_entry_commit_no_next_document_index_compact_trim_hashes(
+                wall_time,
+                logical,
+                gid,
+                entry_type,
+                meta_data,
+                payload_data,
+                trim_length_to,
+                document_gid,
+                payload_size,
+                document_index_commit,
+                true,
+            )?,
         )
     }
 
@@ -655,7 +721,7 @@ impl NativePeerbitBackbone {
         document_gid: String,
         payload_size: u32,
         document_index_commit: DocumentIndexAppendCommit,
-    ) -> Result<Array, JsValue> {
+    ) -> Result<Array, BackboneError> {
         let entry_facts = self
             .log
             .prepare_entry_v0_plain_entry_commit_no_next_facts_core_profiled_and_put_with_builder(
@@ -693,7 +759,7 @@ impl NativePeerbitBackbone {
         payload_size: u32,
         document_index_commit: DocumentIndexAppendCommit,
         compact_row: bool,
-    ) -> Result<Array, JsValue> {
+    ) -> Result<Array, BackboneError> {
         let delete_trimmed_document_heads = document_index_commit.delete_trimmed_heads;
         let (entry_facts, trim_hashes) = self
             .log
@@ -743,7 +809,7 @@ impl NativePeerbitBackbone {
         payload_data: Uint8Array,
         trim_length_to: JsValue,
         mut document_index_commit: DocumentIndexAppendCommit,
-    ) -> Result<Array, JsValue> {
+    ) -> Result<Array, BackboneError> {
         let trim_length_to = optional_usize_from_js(trim_length_to, "trimLengthTo")?;
         let (previous_context, gid, next_hashes) =
             self.resolve_latest_document_append_context(&mut document_index_commit, fallback_gid)?;

--- a/packages/utils/native-backbone/src/append_tx/mod.rs
+++ b/packages/utils/native-backbone/src/append_tx/mod.rs
@@ -322,7 +322,7 @@ impl NativePeerbitBackbone {
         meta_data: Option<Vec<u8>>,
         payload_data: &[u8],
         trim_length_to: Option<usize>,
-    ) -> Result<(NativeCommittedEntryFacts, Vec<String>), JsValue> {
+    ) -> Result<(NativeCommittedEntryFacts, Vec<String>), BackboneError> {
         let profile_enabled = self.append_profile_enabled;
         let log_started = profile_enabled.then(crate::time::now_ms);
         let mut log_profile = NativeLogAppendProfile::default();

--- a/packages/utils/native-backbone/src/append_tx/mod.rs
+++ b/packages/utils/native-backbone/src/append_tx/mod.rs
@@ -13,6 +13,7 @@ use crate::documents::{
     DocumentContextFacts, DocumentIndexAppendCommit, DocumentIndexProjectionPlan,
     DocumentIndexValuePrefix, PreparedDocumentIndexAppendPut,
 };
+use crate::error::BackboneError;
 use crate::js_interop::{
     array_from_value, ensure_same_len, hash_number_u64, number_to_row, numbers_to_rows,
     optional_bytes_from_js, string_field, strings_to_array,
@@ -239,7 +240,7 @@ impl NativePeerbitBackbone {
         &mut self,
         meta_data: JsValue,
         payload_data: &Uint8Array,
-    ) -> Result<(Option<Vec<u8>>, Vec<u8>), JsValue> {
+    ) -> Result<(Option<Vec<u8>>, Vec<u8>), BackboneError> {
         let input_copy_started = self.append_profile_enabled.then(crate::time::now_ms);
         let meta_data = optional_bytes_from_js(meta_data, "meta data")?;
         let payload_data = payload_data.to_vec();
@@ -249,7 +250,7 @@ impl NativePeerbitBackbone {
         Ok((meta_data, payload_data))
     }
 
-    fn hash_number_profiled(&mut self, hash_digest_bytes: &[u8]) -> Result<u64, JsValue> {
+    fn hash_number_profiled(&mut self, hash_digest_bytes: &[u8]) -> Result<u64, BackboneError> {
         let hash_number_started = self.append_profile_enabled.then(crate::time::now_ms);
         let hash_number = hash_number_u64(&self.resolution, hash_digest_bytes)?;
         if let Some(started) = hash_number_started {
@@ -359,7 +360,7 @@ impl NativePeerbitBackbone {
         payload_data: Vec<u8>,
         trim_length_to: Option<usize>,
         resolve_trimmed_entries: bool,
-    ) -> Result<(NativeCommittedEntryFacts, Vec<String>, Array, Array), JsValue> {
+    ) -> Result<(NativeCommittedEntryFacts, Vec<String>, Array, Array), BackboneError> {
         let profile_enabled = self.append_profile_enabled;
         let log_started = profile_enabled.then(crate::time::now_ms);
         let mut log_profile = NativeLogAppendProfile::default();
@@ -467,7 +468,7 @@ impl NativePeerbitBackbone {
         plain_put_payload_data: Option<&[u8]>,
         delete_trimmed_document_heads: bool,
         trim_hashes: &[String],
-    ) -> Result<bool, JsValue> {
+    ) -> Result<bool, BackboneError> {
         let document_index_started = self.append_profile_enabled.then(crate::time::now_ms);
         self.put_document_index_for_append_with_plain_put_payload(
             document_index_commit,
@@ -523,13 +524,13 @@ impl NativePeerbitBackbone {
             row.clone()
         };
         let document_hash = string_field(&entry_row, 0, "document index entry hash")?;
-        self.put_document_index_for_append(
+        Ok(self.put_document_index_for_append(
             Some(document_index_commit),
             wall_time,
             &document_hash,
             document_gid,
             payload_size,
-        )
+        )?)
     }
 
     fn put_document_index_for_append(
@@ -539,7 +540,7 @@ impl NativePeerbitBackbone {
         hash: &str,
         gid: &str,
         payload_size: u32,
-    ) -> Result<(), JsValue> {
+    ) -> Result<(), BackboneError> {
         self.put_document_index_for_append_with_plain_put_payload(
             document_index_commit,
             wall_time,
@@ -558,7 +559,7 @@ impl NativePeerbitBackbone {
         gid: &str,
         payload_size: u32,
         plain_put_payload_data: Option<&[u8]>,
-    ) -> Result<(), JsValue> {
+    ) -> Result<(), BackboneError> {
         let Some(document_index_commit) = document_index_commit else {
             return Ok(());
         };
@@ -583,7 +584,7 @@ impl NativePeerbitBackbone {
         gid: &str,
         payload_size: u32,
         plain_put_payload_data: Option<&[u8]>,
-    ) -> Result<PreparedDocumentIndexAppendPut, JsValue> {
+    ) -> Result<PreparedDocumentIndexAppendPut, BackboneError> {
         let record_previous_signer = document_index_commit
             .required_previous_signer_public_key
             .is_some();
@@ -626,9 +627,10 @@ impl NativePeerbitBackbone {
                     )?
                 }
                 DocumentIndexProjectionPlan::Cached(index) => {
-                    let plan = self.document_projection_plans.get(index).ok_or_else(|| {
-                        JsValue::from_str("Missing cached document projection plan")
-                    })?;
+                    let plan = self
+                        .document_projection_plans
+                        .get(index)
+                        .ok_or(BackboneError::MissingCachedDocumentProjectionPlan)?;
                     project_document_index_simple_bytes_with_plan(
                         &encoded_document,
                         plan,
@@ -644,15 +646,13 @@ impl NativePeerbitBackbone {
             DocumentIndexValuePrefix::PlainPutPayloadIdentity => plain_put_payload_data
                 .map(plain_put_document_bytes_from_payload)
                 .transpose()?
-                .ok_or_else(|| JsValue::from_str("Missing plain put payload for document index"))?
+                .ok_or(BackboneError::MissingPlainPutPayloadForDocumentIndex)?
                 .to_vec(),
             DocumentIndexValuePrefix::PlainPutPayloadProjection { plan, signer } => {
                 let encoded_document = plain_put_payload_data
                     .map(plain_put_document_bytes_from_payload)
                     .transpose()?
-                    .ok_or_else(|| {
-                        JsValue::from_str("Missing plain put payload for document projection")
-                    })?;
+                    .ok_or(BackboneError::MissingPlainPutPayloadForDocumentProjection)?;
                 match plan {
                     DocumentIndexProjectionPlan::Inline(plan) => {
                         project_document_index_simple_bytes_with_plan(
@@ -667,9 +667,10 @@ impl NativePeerbitBackbone {
                         )?
                     }
                     DocumentIndexProjectionPlan::Cached(index) => {
-                        let plan = self.document_projection_plans.get(index).ok_or_else(|| {
-                            JsValue::from_str("Missing cached document projection plan")
-                        })?;
+                        let plan = self
+                            .document_projection_plans
+                            .get(index)
+                            .ok_or(BackboneError::MissingCachedDocumentProjectionPlan)?;
                         project_document_index_simple_bytes_with_plan(
                             encoded_document,
                             plan,

--- a/packages/utils/native-backbone/src/append_tx/mod.rs
+++ b/packages/utils/native-backbone/src/append_tx/mod.rs
@@ -269,7 +269,7 @@ impl NativePeerbitBackbone {
         meta_data: Option<Vec<u8>>,
         payload_data: &[u8],
         trim_length_to: Option<usize>,
-    ) -> Result<(NativeCommittedEntryFacts, Vec<String>), JsValue> {
+    ) -> Result<(NativeCommittedEntryFacts, Vec<String>), BackboneError> {
         let profile_enabled = self.append_profile_enabled;
         let log_started = profile_enabled.then(crate::time::now_ms);
         let mut log_profile = NativeLogAppendProfile::default();
@@ -434,8 +434,8 @@ impl NativePeerbitBackbone {
         self_hash: &str,
         self_replicating: bool,
         expected_len: usize,
-        mismatch_label: &str,
-    ) -> Result<Vec<NativeLocalAppendCompactFacts>, JsValue> {
+        mismatch_label: &'static str,
+    ) -> Result<Vec<NativeLocalAppendCompactFacts>, BackboneError> {
         let coordinate_plan_started = self.append_profile_enabled.then(crate::time::now_ms);
         let coordinate_facts = commit_local_appends_for_gids_compact_core(
             &mut self.shared_log,
@@ -452,7 +452,9 @@ impl NativePeerbitBackbone {
             self.append_profile.coordinate_plan_ms += crate::time::now_ms() - started;
         }
         if coordinate_facts.len() != expected_len {
-            return Err(JsValue::from_str(mismatch_label));
+            return Err(BackboneError::MismatchedCompactCoordinateFacts(
+                mismatch_label,
+            ));
         }
         Ok(coordinate_facts)
     }
@@ -748,5 +750,36 @@ impl NativePeerbitBackbone {
             }
         }
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::error::BackboneError;
+
+    #[test]
+    fn compact_coordinate_mismatch_variant_renders_exact_message() {
+        for label in [
+            "Native no-next compact batch returned mismatched coordinate facts",
+            "Native latest batch returned mismatched coordinate facts",
+            "Native compact batch returned mismatched coordinate facts",
+        ] {
+            assert_eq!(
+                BackboneError::MismatchedCompactCoordinateFacts(label).to_string(),
+                label
+            );
+        }
+    }
+
+    #[test]
+    fn batch_gid_variants_render_exact_messages() {
+        assert_eq!(
+            BackboneError::ExpectedString("batch gid").to_string(),
+            "Expected batch gid string"
+        );
+        assert_eq!(
+            BackboneError::ExpectedString("batch fallback gid").to_string(),
+            "Expected batch fallback gid string"
+        );
     }
 }

--- a/packages/utils/native-backbone/src/append_tx/mod.rs
+++ b/packages/utils/native-backbone/src/append_tx/mod.rs
@@ -44,8 +44,15 @@ struct LatestBatchPendingAppend {
     next_hashes: Vec<String>,
     meta_bytes: Vec<u8>,
     trim_hashes: Vec<String>,
-    entry_row: Array,
-    trim_rows: Array,
+    // Owned committed-append facts and resolved trimmed entries; the frozen JS
+    // `entry_row`/`trim_rows` layouts are rebuilt at the consume boundary so
+    // this pending state stays JS-free (no `js_sys::Array` captured in core
+    // state). `resolve_trimmed_entries` records which trim-row mode produced
+    // `trimmed_entries` so the empty-resolved and unresolved cases stay
+    // distinct, matching the pre-lift behaviour byte-for-byte.
+    entry_facts: NativeCommittedEntryFacts,
+    trimmed_entries: Vec<LogIndexEntry>,
+    resolve_trimmed_entries: bool,
     document_trimmed_heads_processed: bool,
     previous_document_context: Option<DocumentContextFacts>,
 }
@@ -187,7 +194,7 @@ fn ensure_batch_append_lens(
     gids_label: &'static str,
     meta_datas: &Array,
     document_keys: &Array,
-) -> Result<(), JsValue> {
+) -> Result<(), BackboneError> {
     ensure_same_len(len, wall_times.length() as usize, "batch wall times")?;
     ensure_same_len(len, logicals.length() as usize, "batch logicals")?;
     ensure_same_len(len, gids.length() as usize, gids_label)?;
@@ -201,7 +208,7 @@ fn ensure_batch_projection_lens(
     plan_ids: &Uint32Array,
     encoded_documents: Option<&Array>,
     signers: &Array,
-) -> Result<(), JsValue> {
+) -> Result<(), BackboneError> {
     ensure_same_len(
         len,
         plan_ids.length() as usize,
@@ -225,11 +232,11 @@ fn ensure_batch_projection_lens(
 fn required_projection_encoded_document(
     encoded_documents: &Array,
     index: u32,
-) -> Result<JsValue, JsValue> {
+) -> Result<JsValue, BackboneError> {
     let encoded_document = encoded_documents.get(index);
     if encoded_document.is_undefined() || encoded_document.is_null() {
-        return Err(JsValue::from_str(
-            "Expected batch document projection encoded document",
+        return Err(BackboneError::Expected(
+            "batch document projection encoded document",
         ));
     }
     Ok(encoded_document)
@@ -348,8 +355,14 @@ impl NativePeerbitBackbone {
         Ok(result)
     }
 
+    /// JS-free committed-log append: performs the log append and (optionally)
+    /// resolves the trimmed entries, returning owned Rust data only. Callers
+    /// that need the frozen JS result-row layouts build them at their own
+    /// boundary via [`committed_entry_facts_to_row`] and
+    /// [`native_backbone_trim_entries_to_rows`], keeping the pending-append
+    /// state JS-free until the row is emitted.
     #[allow(clippy::too_many_arguments)]
-    fn prepare_committed_log_append_rows_profiled(
+    fn prepare_committed_log_append_owned_profiled(
         &mut self,
         wall_time: u64,
         logical: u32,
@@ -360,7 +373,7 @@ impl NativePeerbitBackbone {
         payload_data: Vec<u8>,
         trim_length_to: Option<usize>,
         resolve_trimmed_entries: bool,
-    ) -> Result<(NativeCommittedEntryFacts, Vec<String>, Array, Array), BackboneError> {
+    ) -> Result<(NativeCommittedEntryFacts, Vec<LogIndexEntry>, Vec<String>), BackboneError> {
         let profile_enabled = self.append_profile_enabled;
         let log_started = profile_enabled.then(crate::time::now_ms);
         let mut log_profile = NativeLogAppendProfile::default();
@@ -407,12 +420,34 @@ impl NativePeerbitBackbone {
             self.append_profile.log_total_ms += crate::time::now_ms() - started;
             self.append_profile.add_log_profile(&log_profile);
         }
-        let entry_row_started = profile_enabled.then(crate::time::now_ms);
-        let entry_row = committed_entry_facts_to_row(&entry_facts, !entry_facts.next.is_empty());
+        Ok((entry_facts, trimmed_entries, trim_hashes))
+    }
+
+    /// Build the frozen committed-append entry row from owned facts, timing the
+    /// build against the `entry_row` profile counter exactly as the inline
+    /// row build did.
+    fn committed_entry_facts_to_row_profiled(
+        &mut self,
+        entry_facts: &NativeCommittedEntryFacts,
+    ) -> Array {
+        let entry_row_started = self.append_profile_enabled.then(crate::time::now_ms);
+        let entry_row = committed_entry_facts_to_row(entry_facts, !entry_facts.next.is_empty());
         if let Some(started) = entry_row_started {
             self.append_profile.entry_row_ms += crate::time::now_ms() - started;
         }
-        let trim_rows_started = profile_enabled.then(crate::time::now_ms);
+        entry_row
+    }
+
+    /// Build the frozen trimmed-entries rows from owned entries, timing the
+    /// build against the `trim_rows` profile counter exactly as the inline
+    /// row build did. `resolve_trimmed_entries` distinguishes an empty resolved
+    /// set from the unresolved mode (which always emits an empty array).
+    fn native_backbone_trim_entries_to_rows_profiled(
+        &mut self,
+        trimmed_entries: Vec<LogIndexEntry>,
+        resolve_trimmed_entries: bool,
+    ) -> Array {
+        let trim_rows_started = self.append_profile_enabled.then(crate::time::now_ms);
         let trim_rows = if resolve_trimmed_entries {
             native_backbone_trim_entries_to_rows(trimmed_entries)
         } else {
@@ -421,6 +456,39 @@ impl NativePeerbitBackbone {
         if let Some(started) = trim_rows_started {
             self.append_profile.trim_rows_ms += crate::time::now_ms() - started;
         }
+        trim_rows
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn prepare_committed_log_append_rows_profiled(
+        &mut self,
+        wall_time: u64,
+        logical: u32,
+        gid: String,
+        next_hashes: Vec<String>,
+        entry_type: u8,
+        meta_data: Option<Vec<u8>>,
+        payload_data: Vec<u8>,
+        trim_length_to: Option<usize>,
+        resolve_trimmed_entries: bool,
+    ) -> Result<(NativeCommittedEntryFacts, Vec<String>, Array, Array), BackboneError> {
+        let (entry_facts, trimmed_entries, trim_hashes) = self
+            .prepare_committed_log_append_owned_profiled(
+                wall_time,
+                logical,
+                gid,
+                next_hashes,
+                entry_type,
+                meta_data,
+                payload_data,
+                trim_length_to,
+                resolve_trimmed_entries,
+            )?;
+        let entry_row = self.committed_entry_facts_to_row_profiled(&entry_facts);
+        let trim_rows = self.native_backbone_trim_entries_to_rows_profiled(
+            trimmed_entries,
+            resolve_trimmed_entries,
+        );
         Ok((entry_facts, trim_hashes, entry_row, trim_rows))
     }
 

--- a/packages/utils/native-backbone/src/append_tx/mod.rs
+++ b/packages/utils/native-backbone/src/append_tx/mod.rs
@@ -490,7 +490,7 @@ impl NativePeerbitBackbone {
         &self,
         document_index_commit: &mut DocumentIndexAppendCommit,
         fallback_gid: String,
-    ) -> Result<(Option<DocumentContextFacts>, String, Vec<String>), JsValue> {
+    ) -> Result<(Option<DocumentContextFacts>, String, Vec<String>), BackboneError> {
         let previous_context = self.document_context_facts_by_key(&document_index_commit.key)?;
         let known_existing = previous_context.is_some();
         let gid = previous_context
@@ -517,20 +517,20 @@ impl NativePeerbitBackbone {
         wall_time: u64,
         document_gid: &str,
         payload_size: u32,
-    ) -> Result<(), JsValue> {
+    ) -> Result<(), BackboneError> {
         let entry_row = if row.length() == 2 && Array::is_array(&row.get(0)) {
             array_from_value(row.get(0), "native trim document index entry row")?
         } else {
             row.clone()
         };
         let document_hash = string_field(&entry_row, 0, "document index entry hash")?;
-        Ok(self.put_document_index_for_append(
+        self.put_document_index_for_append(
             Some(document_index_commit),
             wall_time,
             &document_hash,
             document_gid,
             payload_size,
-        )?)
+        )
     }
 
     fn put_document_index_for_append(

--- a/packages/utils/native-backbone/src/append_tx/storage.rs
+++ b/packages/utils/native-backbone/src/append_tx/storage.rs
@@ -6,6 +6,7 @@ use crate::append_tx::coordinate_plan_to_row;
 use crate::documents::{
     document_context_facts_to_row, document_index_append_commit, DocumentIndexAppendCommit,
 };
+use crate::error::BackboneError;
 use crate::js_interop::{
     array_from_value, bytes_field, string_field, strings_from_array, strings_to_array,
     trim_hashes_vec,
@@ -81,7 +82,7 @@ impl NativePeerbitBackbone {
         self_replicating: bool,
         resolve_trimmed_entries: bool,
     ) -> Result<Array, JsValue> {
-        self.prepare_plain_storage_append_transaction_inner(
+        Ok(self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -98,7 +99,7 @@ impl NativePeerbitBackbone {
             None,
             false,
             None,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -118,7 +119,7 @@ impl NativePeerbitBackbone {
         resolve_trimmed_entries: bool,
         trim_length_to: usize,
     ) -> Result<Array, JsValue> {
-        self.prepare_plain_storage_append_transaction_inner(
+        Ok(self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -135,7 +136,7 @@ impl NativePeerbitBackbone {
             Some(trim_length_to),
             false,
             None,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -162,7 +163,7 @@ impl NativePeerbitBackbone {
         document_projection_encoded_document: JsValue,
         document_projection_signer: JsValue,
     ) -> Result<Array, JsValue> {
-        self.prepare_plain_storage_append_transaction_inner(
+        Ok(self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -188,7 +189,7 @@ impl NativePeerbitBackbone {
                 document_projection_encoded_document,
                 document_projection_signer,
             )?),
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -216,7 +217,7 @@ impl NativePeerbitBackbone {
         document_projection_signer: JsValue,
         trim_length_to: usize,
     ) -> Result<Array, JsValue> {
-        self.prepare_plain_storage_append_transaction_inner(
+        Ok(self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -242,7 +243,7 @@ impl NativePeerbitBackbone {
                 document_projection_encoded_document,
                 document_projection_signer,
             )?),
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -262,7 +263,7 @@ impl NativePeerbitBackbone {
         self_replicating: bool,
         resolve_trimmed_entries: bool,
     ) -> Result<Array, JsValue> {
-        self.prepare_plain_storage_append_transaction_inner(
+        Ok(self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -279,7 +280,7 @@ impl NativePeerbitBackbone {
             None,
             false,
             None,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -300,7 +301,7 @@ impl NativePeerbitBackbone {
         resolve_trimmed_entries: bool,
         trim_length_to: usize,
     ) -> Result<Array, JsValue> {
-        self.prepare_plain_storage_append_transaction_inner(
+        Ok(self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -317,7 +318,7 @@ impl NativePeerbitBackbone {
             Some(trim_length_to),
             false,
             None,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -345,7 +346,7 @@ impl NativePeerbitBackbone {
         document_projection_encoded_document: JsValue,
         document_projection_signer: JsValue,
     ) -> Result<Array, JsValue> {
-        self.prepare_plain_storage_append_transaction_inner(
+        Ok(self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -371,7 +372,7 @@ impl NativePeerbitBackbone {
                 document_projection_encoded_document,
                 document_projection_signer,
             )?),
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -400,7 +401,7 @@ impl NativePeerbitBackbone {
         document_projection_signer: JsValue,
         trim_length_to: usize,
     ) -> Result<Array, JsValue> {
-        self.prepare_plain_storage_append_transaction_inner(
+        Ok(self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
             gid,
@@ -426,7 +427,7 @@ impl NativePeerbitBackbone {
                 document_projection_encoded_document,
                 document_projection_signer,
             )?),
-        )
+        )?)
     }
 }
 
@@ -450,7 +451,7 @@ impl NativePeerbitBackbone {
         trim_length_to: Option<usize>,
         commit_blocks: bool,
         document_index_commit: Option<DocumentIndexAppendCommit>,
-    ) -> Result<Array, JsValue> {
+    ) -> Result<Array, BackboneError> {
         let profile_enabled = self.append_profile_enabled;
         let storage_append_started = profile_enabled.then(crate::time::now_ms);
         let payload_size = payload_data.length();
@@ -485,6 +486,12 @@ impl NativePeerbitBackbone {
             )
         } else if let Some(trim_length_to) = trim_length_to {
             let next_hashes_array = strings_to_array(next_hashes.clone());
+            // No typed log-rust equivalent exists for the storage-facts mode
+            // (it hands the storage bytes back to JS instead of committing
+            // them to a native block store). The wrapper's only fallible step
+            // is strings_from_array over the string array built just above,
+            // so the (unreachable) error maps to the variant rendering the
+            // identical "Expected string array" message.
             let row = self
                 .log
                 .prepare_entry_v0_plain_entry_storage_facts_trim_and_put_with_builder(
@@ -497,7 +504,8 @@ impl NativePeerbitBackbone {
                     meta_data,
                     payload_data,
                     trim_length_to,
-                )?;
+                )
+                .map_err(|_| BackboneError::ExpectedStringArray)?;
             let row = array_from_value(row.into(), "native storage trim append row")?;
             let entry_row = array_from_value(row.get(0), "native storage trim append entry row")?;
             let trim_rows = array_from_value(row.get(1), "native storage trim append trim rows")?;
@@ -508,6 +516,8 @@ impl NativePeerbitBackbone {
             (entry_row, trim_rows, trim_hashes, hash, digest, meta_bytes)
         } else {
             let next_hashes_array = strings_to_array(next_hashes.clone());
+            // Same untyped storage-facts wrapper seam as the trim branch
+            // above; the mapped error is unreachable by construction.
             let row = self
                 .log
                 .prepare_entry_v0_plain_entry_storage_facts_and_put_with_builder(
@@ -519,7 +529,8 @@ impl NativePeerbitBackbone {
                     entry_type,
                     meta_data,
                     payload_data,
-                )?;
+                )
+                .map_err(|_| BackboneError::ExpectedStringArray)?;
             let hash = string_field(&row, 1, "storage entry hash")?;
             let digest = bytes_field(&row, 5, "storage entry hash digest")?;
             let meta_bytes = bytes_field(&row, 4, "storage entry meta bytes")?;

--- a/packages/utils/native-backbone/src/append_tx/storage.rs
+++ b/packages/utils/native-backbone/src/append_tx/storage.rs
@@ -14,6 +14,18 @@ use crate::js_interop::{
 use crate::shared_log_plan::leader_samples_to_optional_rows;
 use crate::NativePeerbitBackbone;
 
+/// Forward a JsValue error from an untyped log-rust wrapper without altering
+/// its message. These wrappers construct every error via `JsValue::from_str`,
+/// so `as_string()` recovers the exact string the wrapper would have thrown;
+/// the fallback only guards the theoretically-non-string case.
+fn js_wrapper_error(error: JsValue) -> BackboneError {
+    BackboneError::Message(
+        error
+            .as_string()
+            .unwrap_or_else(|| "Expected string array".to_string()),
+    )
+}
+
 #[wasm_bindgen]
 impl NativePeerbitBackbone {
     #[allow(clippy::too_many_arguments)]
@@ -488,10 +500,11 @@ impl NativePeerbitBackbone {
             let next_hashes_array = strings_to_array(next_hashes.clone());
             // No typed log-rust equivalent exists for the storage-facts mode
             // (it hands the storage bytes back to JS instead of committing
-            // them to a native block store). The wrapper's only fallible step
-            // is strings_from_array over the string array built just above,
-            // so the (unreachable) error maps to the variant rendering the
-            // identical "Expected string array" message.
+            // them to a native block store). It is the one append path with
+            // no typed core to re-point to, so its JsValue error is forwarded
+            // verbatim through BackboneError::Message, preserving whatever
+            // string the wrapper produced (the dominant reachable case is
+            // strings_from_array over the array built just above).
             let row = self
                 .log
                 .prepare_entry_v0_plain_entry_storage_facts_trim_and_put_with_builder(
@@ -505,7 +518,7 @@ impl NativePeerbitBackbone {
                     payload_data,
                     trim_length_to,
                 )
-                .map_err(|_| BackboneError::ExpectedStringArray)?;
+                .map_err(js_wrapper_error)?;
             let row = array_from_value(row.into(), "native storage trim append row")?;
             let entry_row = array_from_value(row.get(0), "native storage trim append entry row")?;
             let trim_rows = array_from_value(row.get(1), "native storage trim append trim rows")?;
@@ -517,7 +530,7 @@ impl NativePeerbitBackbone {
         } else {
             let next_hashes_array = strings_to_array(next_hashes.clone());
             // Same untyped storage-facts wrapper seam as the trim branch
-            // above; the mapped error is unreachable by construction.
+            // above; its JsValue error is forwarded verbatim.
             let row = self
                 .log
                 .prepare_entry_v0_plain_entry_storage_facts_and_put_with_builder(
@@ -530,7 +543,7 @@ impl NativePeerbitBackbone {
                     meta_data,
                     payload_data,
                 )
-                .map_err(|_| BackboneError::ExpectedStringArray)?;
+                .map_err(js_wrapper_error)?;
             let hash = string_field(&row, 1, "storage entry hash")?;
             let digest = bytes_field(&row, 5, "storage entry hash digest")?;
             let meta_bytes = bytes_field(&row, 4, "storage entry meta bytes")?;

--- a/packages/utils/native-backbone/src/documents.rs
+++ b/packages/utils/native-backbone/src/documents.rs
@@ -13,6 +13,7 @@ use peerbit_log_rust::entry_v0_signature_public_key_from_storage_bytes;
 use std::collections::HashMap;
 use wasm_bindgen::prelude::*;
 
+use crate::error::BackboneError;
 use crate::js_interop::{
     append_journal_delete_record, append_journal_put_record, array_strings, bytes_vec_from_array,
     clear_journal_prefix, decode_error, ensure_same_len, js_error, js_get, optional_string,
@@ -224,13 +225,15 @@ pub(crate) fn document_index_cached_projection_plain_put_payload_append_commit(
     })
 }
 
-pub(crate) fn plain_put_document_bytes_from_payload(payload_data: &[u8]) -> Result<&[u8], JsValue> {
+pub(crate) fn plain_put_document_bytes_from_payload(
+    payload_data: &[u8],
+) -> Result<&[u8], BackboneError> {
     const PLAIN_PUT_OPERATION_PREFIX_LENGTH: usize = 6;
     if payload_data.len() < PLAIN_PUT_OPERATION_PREFIX_LENGTH {
-        return Err(JsValue::from_str("Plain put payload is too short"));
+        return Err(BackboneError::PlainPutPayloadTooShort);
     }
     if payload_data[0] != 0 || payload_data[1] != 3 {
-        return Err(JsValue::from_str("Expected native plain put payload"));
+        return Err(BackboneError::Expected("native plain put payload"));
     }
     let declared_len = u32::from_le_bytes([
         payload_data[2],
@@ -240,7 +243,7 @@ pub(crate) fn plain_put_document_bytes_from_payload(payload_data: &[u8]) -> Resu
     ]) as usize;
     let document_bytes = &payload_data[PLAIN_PUT_OPERATION_PREFIX_LENGTH..];
     if document_bytes.len() != declared_len {
-        return Err(JsValue::from_str("Plain put payload length mismatch"));
+        return Err(BackboneError::PlainPutPayloadLengthMismatch);
     }
     Ok(document_bytes)
 }
@@ -346,7 +349,7 @@ pub(crate) fn encode_document_context_suffix(
     head: &str,
     gid: &str,
     size: u32,
-) -> Result<Vec<u8>, JsValue> {
+) -> Result<Vec<u8>, BackboneError> {
     let capacity = 1usize
         .checked_add(8)
         .and_then(|value| value.checked_add(8))
@@ -355,7 +358,7 @@ pub(crate) fn encode_document_context_suffix(
         .and_then(|value| value.checked_add(4))
         .and_then(|value| value.checked_add(gid.len()))
         .and_then(|value| value.checked_add(4))
-        .ok_or_else(|| JsValue::from_str("Document context suffix capacity overflow"))?;
+        .ok_or(BackboneError::DocumentContextSuffixCapacityOverflow)?;
     let mut out = Vec::with_capacity(capacity);
     // Context is @variant(0); keep this byte-for-byte aligned with Borsh.
     out.push(0);
@@ -376,24 +379,36 @@ enum ProjectionValue {
     None,
 }
 
-fn read_u8_projection(bytes: &[u8], offset: &mut usize, label: &str) -> Result<u8, JsValue> {
+fn read_u8_projection(
+    bytes: &[u8],
+    offset: &mut usize,
+    label: &'static str,
+) -> Result<u8, BackboneError> {
     if *offset >= bytes.len() {
-        return Err(JsValue::from_str(&format!("Truncated {label}")));
+        return Err(BackboneError::Truncated(label));
     }
     let value = bytes[*offset];
     *offset += 1;
     Ok(value)
 }
 
-fn read_bool_projection(bytes: &[u8], offset: &mut usize, label: &str) -> Result<bool, JsValue> {
+fn read_bool_projection(
+    bytes: &[u8],
+    offset: &mut usize,
+    label: &'static str,
+) -> Result<bool, BackboneError> {
     match read_u8_projection(bytes, offset, label)? {
         0 => Ok(false),
         1 => Ok(true),
-        _ => Err(JsValue::from_str(&format!("Invalid bool {label}"))),
+        _ => Err(BackboneError::InvalidBool(label)),
     }
 }
 
-fn skip_projection_value(bytes: &[u8], offset: &mut usize, kind: &str) -> Result<(), JsValue> {
+fn skip_projection_value(
+    bytes: &[u8],
+    offset: &mut usize,
+    kind: &str,
+) -> Result<(), BackboneError> {
     match kind {
         "string" => {
             read_encoded_string(bytes, offset, "projected string")?;
@@ -419,7 +434,7 @@ fn skip_projection_value(bytes: &[u8], offset: &mut usize, kind: &str) -> Result
             if has_value == 1 {
                 skip_projection_value(bytes, offset, &kind["option:".len()..])?;
             } else if has_value != 0 {
-                return Err(JsValue::from_str("Invalid projection option marker"));
+                return Err(BackboneError::InvalidProjectionOptionMarker);
             }
         }
         "vec:string" => {
@@ -435,9 +450,7 @@ fn skip_projection_value(bytes: &[u8], offset: &mut usize, kind: &str) -> Result
             }
         }
         _ => {
-            return Err(JsValue::from_str(
-                "Unsupported document projection field type",
-            ))
+            return Err(BackboneError::UnsupportedDocumentProjectionFieldType);
         }
     }
     Ok(())
@@ -447,7 +460,7 @@ fn read_projection_value(
     bytes: &[u8],
     offset: &mut usize,
     kind: &str,
-) -> Result<ProjectionValue, JsValue> {
+) -> Result<ProjectionValue, BackboneError> {
     match kind {
         "string" => Ok(ProjectionValue::String(read_encoded_string(
             bytes,
@@ -486,7 +499,7 @@ fn read_projection_value(
                     "projection option string",
                 )?))
             } else {
-                Err(JsValue::from_str("Invalid projection option marker"))
+                Err(BackboneError::InvalidProjectionOptionMarker)
             }
         }
         "option:u8" => {
@@ -498,7 +511,7 @@ fn read_projection_value(
                     read_u8_projection(bytes, offset, "projection option u8")? as u64,
                 ))
             } else {
-                Err(JsValue::from_str("Invalid projection option marker"))
+                Err(BackboneError::InvalidProjectionOptionMarker)
             }
         }
         "option:u32" => {
@@ -510,7 +523,7 @@ fn read_projection_value(
                     read_u32(bytes, offset, "projection option u32")? as u64,
                 ))
             } else {
-                Err(JsValue::from_str("Invalid projection option marker"))
+                Err(BackboneError::InvalidProjectionOptionMarker)
             }
         }
         "option:u64" => {
@@ -524,7 +537,7 @@ fn read_projection_value(
                     "projection option u64",
                 )?))
             } else {
-                Err(JsValue::from_str("Invalid projection option marker"))
+                Err(BackboneError::InvalidProjectionOptionMarker)
             }
         }
         "option:bool" => {
@@ -538,7 +551,7 @@ fn read_projection_value(
                     "projection option bool",
                 )?))
             } else {
-                Err(JsValue::from_str("Invalid projection option marker"))
+                Err(BackboneError::InvalidProjectionOptionMarker)
             }
         }
         "option:bytes" => {
@@ -552,12 +565,10 @@ fn read_projection_value(
                     "projection option bytes",
                 )?))
             } else {
-                Err(JsValue::from_str("Invalid projection option marker"))
+                Err(BackboneError::InvalidProjectionOptionMarker)
             }
         }
-        _ => Err(JsValue::from_str(
-            "Unsupported projected document field type",
-        )),
+        _ => Err(BackboneError::UnsupportedProjectedDocumentFieldType),
     }
 }
 
@@ -565,7 +576,7 @@ fn write_projection_value(
     out: &mut Vec<u8>,
     kind: &str,
     value: &ProjectionValue,
-) -> Result<(), JsValue> {
+) -> Result<(), BackboneError> {
     match (kind, value) {
         ("string", ProjectionValue::String(value)) => write_string(out, value),
         ("u8", ProjectionValue::U64(value)) => write_u8(out, *value as u8),
@@ -604,9 +615,7 @@ fn write_projection_value(
             write_bytes(out, value);
         }
         _ => {
-            return Err(JsValue::from_str(
-                "Projection value does not match output type",
-            ))
+            return Err(BackboneError::ProjectionValueOutputTypeMismatch);
         }
     }
     Ok(())
@@ -618,32 +627,29 @@ fn read_projected_document_fields(
     variant_value: Option<&str>,
     names: &[String],
     types: &[String],
-) -> Result<HashMap<String, ProjectionValue>, JsValue> {
+) -> Result<HashMap<String, ProjectionValue>, BackboneError> {
     if names.len() != types.len() {
-        return Err(JsValue::from_str(
-            "Document projection plan length mismatch",
-        ));
+        return Err(BackboneError::DocumentProjectionPlanLengthMismatch);
     }
     let mut offset = 0usize;
     match variant_type {
         Some("u8") => {
             let expected = variant_value
-                .ok_or_else(|| JsValue::from_str("Missing document variant"))?
+                .ok_or(BackboneError::MissingDocumentVariant)?
                 .parse::<u8>()
-                .map_err(|_| JsValue::from_str("Invalid document variant"))?;
+                .map_err(|_| BackboneError::InvalidDocumentVariant)?;
             if read_u8_projection(encoded_document, &mut offset, "document variant")? != expected {
-                return Err(JsValue::from_str("Document variant mismatch"));
+                return Err(BackboneError::DocumentVariantMismatch);
             }
         }
         Some("string") => {
-            let expected =
-                variant_value.ok_or_else(|| JsValue::from_str("Missing document variant"))?;
+            let expected = variant_value.ok_or(BackboneError::MissingDocumentVariant)?;
             if read_encoded_string(encoded_document, &mut offset, "document variant")? != expected {
-                return Err(JsValue::from_str("Document variant mismatch"));
+                return Err(BackboneError::DocumentVariantMismatch);
             }
         }
         Some("") | None => {}
-        _ => return Err(JsValue::from_str("Unsupported document variant type")),
+        _ => return Err(BackboneError::UnsupportedDocumentVariantType),
     }
     let mut out = HashMap::with_capacity(names.len());
     for (name, kind) in names.iter().zip(types.iter()) {
@@ -666,21 +672,21 @@ fn write_projection_variant(
     out: &mut Vec<u8>,
     variant_type: Option<&str>,
     variant_value: Option<&str>,
-) -> Result<(), JsValue> {
+) -> Result<(), BackboneError> {
     match variant_type {
         Some("u8") => {
             let value = variant_value
-                .ok_or_else(|| JsValue::from_str("Missing output variant"))?
+                .ok_or(BackboneError::MissingOutputVariant)?
                 .parse::<u8>()
-                .map_err(|_| JsValue::from_str("Invalid output variant"))?;
+                .map_err(|_| BackboneError::InvalidOutputVariant)?;
             write_u8(out, value);
         }
         Some("string") => {
-            let value = variant_value.ok_or_else(|| JsValue::from_str("Missing output variant"))?;
+            let value = variant_value.ok_or(BackboneError::MissingOutputVariant)?;
             write_string(out, value);
         }
         Some("") | None => {}
-        _ => return Err(JsValue::from_str("Unsupported output variant type")),
+        _ => return Err(BackboneError::UnsupportedOutputVariantType),
     }
     Ok(())
 }
@@ -730,7 +736,7 @@ pub(crate) fn project_document_index_simple_bytes_with_plan(
     gid: &str,
     size: u32,
     signer: Option<&[u8]>,
-) -> Result<Vec<u8>, JsValue> {
+) -> Result<Vec<u8>, BackboneError> {
     let document_values = read_projected_document_fields(
         encoded_document,
         plan.document_variant_type.as_deref(),
@@ -758,12 +764,12 @@ pub(crate) fn project_document_index_simple_bytes_with_plan(
                 "head" => ProjectionValue::String(head.to_string()),
                 "gid" => ProjectionValue::String(gid.to_string()),
                 "size" => ProjectionValue::U64(size as u64),
-                _ => return Err(JsValue::from_str("Unsupported context projection source")),
+                _ => return Err(BackboneError::UnsupportedContextProjectionSource),
             },
             "entryFirstSignerPublicKey" => signer
                 .map(|bytes| ProjectionValue::Bytes(bytes.to_vec()))
                 .unwrap_or(ProjectionValue::None),
-            _ => return Err(JsValue::from_str("Unsupported projection source kind")),
+            _ => return Err(BackboneError::UnsupportedProjectionSourceKind),
         };
         write_projection_value(&mut out, &plan.output_field_types[index], &value)?;
     }
@@ -789,7 +795,7 @@ fn project_document_index_simple_bytes(
     } else {
         Some(Uint8Array::new(&signer).to_vec())
     };
-    project_document_index_simple_bytes_with_plan(
+    Ok(project_document_index_simple_bytes_with_plan(
         encoded_document,
         &plan,
         created,
@@ -798,7 +804,7 @@ fn project_document_index_simple_bytes(
         gid,
         size,
         signer.as_deref(),
-    )
+    )?)
 }
 
 #[wasm_bindgen]
@@ -1428,22 +1434,22 @@ impl NativePeerbitBackbone {
         new_head: Option<&str>,
         previous_head: Option<&str>,
         record_document_journal: bool,
-    ) -> Result<PreparedDocumentEncodedPartsPut, JsValue> {
+    ) -> Result<PreparedDocumentEncodedPartsPut, BackboneError> {
         self.document_byte_element_index_limit = byte_element_index_limit;
         let profile_enabled = self.append_profile_enabled;
         let extract_started = profile_enabled.then(crate::time::now_ms);
         let fields = {
-            let schema_ir = self.document_schema_ir.as_ref().ok_or_else(|| {
-                js_error("Native backbone document schema IR has not been configured")
-            })?;
+            let schema_ir = self
+                .document_schema_ir
+                .as_ref()
+                .ok_or(BackboneError::DocumentSchemaIrNotConfigured)?;
             extract_encoded_document_fields_from_parts_with_byte_limits(
                 &schema_ir,
                 &value_prefix_bytes,
                 &value_suffix_bytes,
                 byte_element_index_limit,
                 NATIVE_BACKBONE_BYTE_EXACT_INDEX_LIMIT,
-            )
-            .map_err(js_error)?
+            )?
         };
         if let Some(started) = extract_started {
             self.append_profile.document_index_extract_ms += crate::time::now_ms() - started;
@@ -1706,5 +1712,175 @@ impl NativePeerbitBackbone {
         self.document_values.reserve(batch_len);
         self.document_index.reserve_documents(batch_len);
         self.document_key_by_head.reserve(batch_len);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn projection_plan(
+        source_kinds: &[&str],
+        source_values: &[&str],
+        output_field_types: &[&str],
+    ) -> ParsedProjectionPlan {
+        ParsedProjectionPlan {
+            document_variant_type: None,
+            document_variant_value: None,
+            output_variant_type: None,
+            output_variant_value: None,
+            document_field_names: Vec::new(),
+            document_field_types: Vec::new(),
+            output_field_types: output_field_types.iter().map(|s| s.to_string()).collect(),
+            source_kinds: source_kinds.iter().map(|s| s.to_string()).collect(),
+            source_values: source_values.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn plain_put_payload_reports_typed_errors() {
+        let error = plain_put_document_bytes_from_payload(&[0, 3]).unwrap_err();
+        assert_eq!(error, BackboneError::PlainPutPayloadTooShort);
+        assert_eq!(error.to_string(), "Plain put payload is too short");
+
+        let error = plain_put_document_bytes_from_payload(&[1, 3, 0, 0, 0, 0]).unwrap_err();
+        assert_eq!(error, BackboneError::Expected("native plain put payload"));
+        assert_eq!(error.to_string(), "Expected native plain put payload");
+
+        let error = plain_put_document_bytes_from_payload(&[0, 3, 2, 0, 0, 0, 9]).unwrap_err();
+        assert_eq!(error, BackboneError::PlainPutPayloadLengthMismatch);
+        assert_eq!(error.to_string(), "Plain put payload length mismatch");
+    }
+
+    #[test]
+    fn projected_document_fields_report_typed_errors() {
+        let error =
+            read_projected_document_fields(&[], None, None, &["a".to_string()], &[]).unwrap_err();
+        assert_eq!(error, BackboneError::DocumentProjectionPlanLengthMismatch);
+        assert_eq!(
+            error.to_string(),
+            "Document projection plan length mismatch"
+        );
+
+        let error =
+            read_projected_document_fields(&[], Some("u16"), Some("1"), &[], &[]).unwrap_err();
+        assert_eq!(error, BackboneError::UnsupportedDocumentVariantType);
+        assert_eq!(error.to_string(), "Unsupported document variant type");
+
+        let error = read_projected_document_fields(&[], Some("u8"), None, &[], &[]).unwrap_err();
+        assert_eq!(error, BackboneError::MissingDocumentVariant);
+        assert_eq!(error.to_string(), "Missing document variant");
+
+        let error =
+            read_projected_document_fields(&[], Some("u8"), Some("abc"), &[], &[]).unwrap_err();
+        assert_eq!(error, BackboneError::InvalidDocumentVariant);
+        assert_eq!(error.to_string(), "Invalid document variant");
+
+        let error =
+            read_projected_document_fields(&[], Some("u8"), Some("1"), &[], &[]).unwrap_err();
+        assert_eq!(error, BackboneError::Truncated("document variant"));
+        assert_eq!(error.to_string(), "Truncated document variant");
+
+        let error =
+            read_projected_document_fields(&[0], Some("u8"), Some("1"), &[], &[]).unwrap_err();
+        assert_eq!(error, BackboneError::DocumentVariantMismatch);
+        assert_eq!(error.to_string(), "Document variant mismatch");
+    }
+
+    #[test]
+    fn projection_variant_and_value_writers_report_typed_errors() {
+        let mut out = Vec::new();
+        let error = write_projection_variant(&mut out, Some("u8"), None).unwrap_err();
+        assert_eq!(error, BackboneError::MissingOutputVariant);
+        assert_eq!(error.to_string(), "Missing output variant");
+
+        let error = write_projection_variant(&mut out, Some("u8"), Some("abc")).unwrap_err();
+        assert_eq!(error, BackboneError::InvalidOutputVariant);
+        assert_eq!(error.to_string(), "Invalid output variant");
+
+        let error = write_projection_variant(&mut out, Some("u16"), Some("1")).unwrap_err();
+        assert_eq!(error, BackboneError::UnsupportedOutputVariantType);
+        assert_eq!(error.to_string(), "Unsupported output variant type");
+
+        let error = write_projection_value(&mut out, "string", &ProjectionValue::None).unwrap_err();
+        assert_eq!(error, BackboneError::ProjectionValueOutputTypeMismatch);
+        assert_eq!(
+            error.to_string(),
+            "Projection value does not match output type"
+        );
+    }
+
+    #[test]
+    fn projection_value_readers_report_typed_errors() {
+        let mut offset = 0usize;
+        let error = read_projection_value(&[2], &mut offset, "bool").unwrap_err();
+        assert_eq!(error, BackboneError::InvalidBool("projection bool"));
+        assert_eq!(error.to_string(), "Invalid bool projection bool");
+
+        let mut offset = 0usize;
+        let error = read_projection_value(&[2], &mut offset, "option:u8").unwrap_err();
+        assert_eq!(error, BackboneError::InvalidProjectionOptionMarker);
+        assert_eq!(error.to_string(), "Invalid projection option marker");
+
+        let mut offset = 0usize;
+        let error = read_projection_value(&[], &mut offset, "u128").unwrap_err();
+        assert_eq!(error, BackboneError::UnsupportedProjectedDocumentFieldType);
+        assert_eq!(
+            error.to_string(),
+            "Unsupported projected document field type"
+        );
+
+        let mut offset = 0usize;
+        let error = skip_projection_value(&[], &mut offset, "u128").unwrap_err();
+        assert_eq!(error, BackboneError::UnsupportedDocumentProjectionFieldType);
+        assert_eq!(
+            error.to_string(),
+            "Unsupported document projection field type"
+        );
+    }
+
+    #[test]
+    fn projection_sources_report_typed_errors() {
+        let plan = projection_plan(&["context"], &["bogus"], &["u64"]);
+        let error =
+            project_document_index_simple_bytes_with_plan(&[], &plan, 0, 0, "h", "g", 0, None)
+                .unwrap_err();
+        assert_eq!(error, BackboneError::UnsupportedContextProjectionSource);
+        assert_eq!(error.to_string(), "Unsupported context projection source");
+
+        let plan = projection_plan(&["bogus"], &["x"], &["u64"]);
+        let error =
+            project_document_index_simple_bytes_with_plan(&[], &plan, 0, 0, "h", "g", 0, None)
+                .unwrap_err();
+        assert_eq!(error, BackboneError::UnsupportedProjectionSourceKind);
+        assert_eq!(error.to_string(), "Unsupported projection source kind");
+    }
+
+    #[test]
+    fn document_index_put_chain_variants_render_exact_messages() {
+        for (error, message) in [
+            (
+                BackboneError::DocumentContextSuffixCapacityOverflow,
+                "Document context suffix capacity overflow",
+            ),
+            (
+                BackboneError::DocumentSchemaIrNotConfigured,
+                "Native backbone document schema IR has not been configured",
+            ),
+            (
+                BackboneError::MissingCachedDocumentProjectionPlan,
+                "Missing cached document projection plan",
+            ),
+            (
+                BackboneError::MissingPlainPutPayloadForDocumentIndex,
+                "Missing plain put payload for document index",
+            ),
+            (
+                BackboneError::MissingPlainPutPayloadForDocumentProjection,
+                "Missing plain put payload for document projection",
+            ),
+        ] {
+            assert_eq!(error.to_string(), message);
+        }
     }
 }

--- a/packages/utils/native-backbone/src/documents.rs
+++ b/packages/utils/native-backbone/src/documents.rs
@@ -333,12 +333,12 @@ fn encode_document_signer_fact(fact: &DocumentPreviousSignerFact) -> Vec<u8> {
     out
 }
 
-fn decode_document_signer_fact(bytes: &[u8]) -> Result<DocumentPreviousSignerFact, JsValue> {
+fn decode_document_signer_fact(bytes: &[u8]) -> Result<DocumentPreviousSignerFact, BackboneError> {
     let mut offset = 0usize;
     let head = read_encoded_string(bytes, &mut offset, "document signer head")?;
     let public_key = read_bytes(bytes, &mut offset, "document signer public key")?;
     if offset != bytes.len() {
-        return Err(JsValue::from_str("Trailing document signer fact bytes"));
+        return Err(BackboneError::TrailingDocumentSignerFactBytes);
     }
     Ok(DocumentPreviousSignerFact { head, public_key })
 }
@@ -691,7 +691,7 @@ fn write_projection_variant(
     Ok(())
 }
 
-fn parse_projection_plan(plan: &JsValue) -> Result<ParsedProjectionPlan, JsValue> {
+fn parse_projection_plan(plan: &JsValue) -> Result<ParsedProjectionPlan, BackboneError> {
     let document_field_names =
         array_strings(js_get(plan, "documentFieldNames"), "documentFieldNames")?;
     let document_field_types =
@@ -700,7 +700,7 @@ fn parse_projection_plan(plan: &JsValue) -> Result<ParsedProjectionPlan, JsValue
     let source_kinds = array_strings(js_get(plan, "sourceKinds"), "sourceKinds")?;
     let source_values = array_strings(js_get(plan, "sourceValues"), "sourceValues")?;
     if output_field_types.len() != source_kinds.len() || source_kinds.len() != source_values.len() {
-        return Err(JsValue::from_str("Projection plan length mismatch"));
+        return Err(BackboneError::ProjectionPlanLengthMismatch);
     }
     Ok(ParsedProjectionPlan {
         document_variant_type: optional_string(
@@ -786,7 +786,7 @@ fn project_document_index_simple_bytes(
     gid: &str,
     size: u32,
     signer: JsValue,
-) -> Result<Vec<u8>, JsValue> {
+) -> Result<Vec<u8>, BackboneError> {
     let plan = parse_projection_plan(plan)?;
     let created = parse_u64_string(created, "created")?;
     let modified = parse_u64_string(modified, "modified")?;
@@ -795,7 +795,7 @@ fn project_document_index_simple_bytes(
     } else {
         Some(Uint8Array::new(&signer).to_vec())
     };
-    Ok(project_document_index_simple_bytes_with_plan(
+    project_document_index_simple_bytes_with_plan(
         encoded_document,
         &plan,
         created,
@@ -804,7 +804,7 @@ fn project_document_index_simple_bytes(
         gid,
         size,
         signer.as_deref(),
-    )?)
+    )
 }
 
 #[wasm_bindgen]
@@ -1750,6 +1750,35 @@ mod tests {
         let error = plain_put_document_bytes_from_payload(&[0, 3, 2, 0, 0, 0, 9]).unwrap_err();
         assert_eq!(error, BackboneError::PlainPutPayloadLengthMismatch);
         assert_eq!(error.to_string(), "Plain put payload length mismatch");
+    }
+
+    #[test]
+    fn document_signer_fact_decode_reports_typed_errors() {
+        let fact = DocumentPreviousSignerFact {
+            head: "head".to_string(),
+            public_key: vec![1, 2, 3],
+        };
+        let encoded = encode_document_signer_fact(&fact);
+        let decoded = decode_document_signer_fact(&encoded).unwrap();
+        assert_eq!(decoded.head, fact.head);
+        assert_eq!(decoded.public_key, fact.public_key);
+
+        let mut trailing = encoded.clone();
+        trailing.push(0);
+        let error = match decode_document_signer_fact(&trailing) {
+            Ok(_) => panic!("expected trailing-bytes error"),
+            Err(error) => error,
+        };
+        assert_eq!(error, BackboneError::TrailingDocumentSignerFactBytes);
+        assert_eq!(error.to_string(), "Trailing document signer fact bytes");
+    }
+
+    #[test]
+    fn projection_plan_length_mismatch_renders_historical_string() {
+        assert_eq!(
+            BackboneError::ProjectionPlanLengthMismatch.to_string(),
+            "Projection plan length mismatch"
+        );
     }
 
     #[test]

--- a/packages/utils/native-backbone/src/documents.rs
+++ b/packages/utils/native-backbone/src/documents.rs
@@ -16,10 +16,9 @@ use wasm_bindgen::prelude::*;
 use crate::error::BackboneError;
 use crate::js_interop::{
     append_journal_delete_record, append_journal_put_record, array_strings, bytes_vec_from_array,
-    clear_journal_prefix, decode_error, ensure_same_len, js_error, js_get, optional_string,
-    parse_optional_u64_string, parse_u64_string, read_bytes, read_encoded_string, read_u32,
-    read_u64, strings_from_array, write_bool, write_bytes, write_string, write_u32, write_u64,
-    write_u8,
+    clear_journal_prefix, ensure_same_len, js_get, optional_string, parse_optional_u64_string,
+    parse_u64_string, read_bytes, read_encoded_string, read_u32, read_u64, strings_from_array,
+    write_bool, write_bytes, write_string, write_u32, write_u64, write_u8,
 };
 use crate::{NativePeerbitBackbone, NATIVE_BACKBONE_BYTE_EXACT_INDEX_LIMIT};
 
@@ -813,7 +812,7 @@ impl NativePeerbitBackbone {
         &mut self,
         schema_ir_bytes: Vec<u8>,
     ) -> Result<Array, JsValue> {
-        let schema_ir = decode_native_schema_ir(&schema_ir_bytes).map_err(js_error)?;
+        let schema_ir = decode_native_schema_ir(&schema_ir_bytes).map_err(BackboneError::from)?;
         let stats = schema_ir.stats();
         self.document_schema_ir = Some(schema_ir);
         self.rebuild_document_index_from_values()?;
@@ -829,7 +828,7 @@ impl NativePeerbitBackbone {
             return Ok(());
         }
         self.document_byte_element_index_limit = limit;
-        self.rebuild_document_index_from_values()
+        Ok(self.rebuild_document_index_from_values()?)
     }
 
     pub fn set_document_context_head_field(&mut self, field: u32) {
@@ -998,8 +997,8 @@ impl NativePeerbitBackbone {
         query_bytes: Vec<u8>,
         sort_bytes: Vec<u8>,
     ) -> Result<Array, JsValue> {
-        let query = decode_query(&query_bytes).map_err(js_error)?;
-        let sort = decode_sort(&sort_bytes).map_err(js_error)?;
+        let query = decode_query(&query_bytes).map_err(BackboneError::Message)?;
+        let sort = decode_sort(&sort_bytes).map_err(BackboneError::Message)?;
         let keys = self.document_index.search(&query, &sort, None);
         Ok(self.document_entries_for_keys(&keys))
     }
@@ -1011,8 +1010,8 @@ impl NativePeerbitBackbone {
         offset: usize,
         limit: usize,
     ) -> Result<Array, JsValue> {
-        let query = decode_query(&query_bytes).map_err(js_error)?;
-        let sort = decode_sort(&sort_bytes).map_err(js_error)?;
+        let query = decode_query(&query_bytes).map_err(BackboneError::Message)?;
+        let sort = decode_sort(&sort_bytes).map_err(BackboneError::Message)?;
         let keys = self
             .document_index
             .search_page(&query, &sort, offset, Some(limit));
@@ -1020,16 +1019,16 @@ impl NativePeerbitBackbone {
     }
 
     pub fn document_count(&self, query_bytes: Vec<u8>) -> Result<usize, JsValue> {
-        let query = decode_query(&query_bytes).map_err(js_error)?;
+        let query = decode_query(&query_bytes).map_err(BackboneError::Message)?;
         Ok(self.document_index.count(&query) as usize)
     }
 
     pub fn document_sum(&self, query_bytes: Vec<u8>, field: u32) -> Result<Array, JsValue> {
-        let query = decode_query(&query_bytes).map_err(js_error)?;
+        let query = decode_query(&query_bytes).map_err(BackboneError::Message)?;
         let sum = self
             .document_index
             .sum(&query, FieldPath::Id(field))
-            .map_err(js_error)?;
+            .map_err(BackboneError::Message)?;
         Ok(sum_to_js(sum))
     }
 
@@ -1199,12 +1198,12 @@ impl NativePeerbitBackbone {
         let mut entries = if snapshot.length() == 0 {
             Default::default()
         } else {
-            decode_key_value_snapshot(&snapshot.to_vec()).map_err(decode_error)?
+            decode_key_value_snapshot(&snapshot.to_vec()).map_err(BackboneError::from)?
         };
         let journal_records = if journal.length() == 0 {
             Vec::new()
         } else {
-            decode_journal(&journal.to_vec()).map_err(decode_error)?
+            decode_journal(&journal.to_vec()).map_err(BackboneError::from)?
         };
         let operations = journal_records.len();
         for record in journal_records {
@@ -1286,12 +1285,12 @@ impl NativePeerbitBackbone {
         let mut entries = if snapshot.length() == 0 {
             Default::default()
         } else {
-            decode_key_value_snapshot(&snapshot.to_vec()).map_err(decode_error)?
+            decode_key_value_snapshot(&snapshot.to_vec()).map_err(BackboneError::from)?
         };
         let journal_records = if journal.length() == 0 {
             Vec::new()
         } else {
-            decode_journal(&journal.to_vec()).map_err(decode_error)?
+            decode_journal(&journal.to_vec()).map_err(BackboneError::from)?
         };
         let operations = journal_records.len();
         for record in journal_records {
@@ -1544,7 +1543,7 @@ impl NativePeerbitBackbone {
             .insert(new_head.to_string(), key.to_string());
     }
 
-    fn refresh_document_previous_signer_fact(&mut self, key: &str) -> Result<(), JsValue> {
+    fn refresh_document_previous_signer_fact(&mut self, key: &str) -> Result<(), BackboneError> {
         let Some(context) = self.document_context_facts_by_key(key)? else {
             self.delete_document_previous_signer_fact(key, true);
             return Ok(());
@@ -1596,7 +1595,7 @@ impl NativePeerbitBackbone {
         self.document_signer_journal_record_count = 0;
     }
 
-    fn rebuild_document_index_from_values(&mut self) -> Result<(), JsValue> {
+    fn rebuild_document_index_from_values(&mut self) -> Result<(), BackboneError> {
         let Some(schema_ir) = self.document_schema_ir.clone() else {
             self.document_index.clear();
             self.document_key_by_head.clear();
@@ -1618,8 +1617,7 @@ impl NativePeerbitBackbone {
                 &[],
                 self.document_byte_element_index_limit,
                 NATIVE_BACKBONE_BYTE_EXACT_INDEX_LIMIT,
-            )
-            .map_err(js_error)?;
+            )?;
             if let Some(context) = self.document_context_facts_from_fields(&fields)? {
                 self.document_key_by_head.insert(context.head, key.clone());
             }
@@ -1779,6 +1777,17 @@ mod tests {
             BackboneError::ProjectionPlanLengthMismatch.to_string(),
             "Projection plan length mismatch"
         );
+    }
+
+    #[test]
+    fn query_decode_errors_forward_the_indexer_string_verbatim() {
+        // decode_query/decode_sort have no typed core error; the document
+        // query/count/sum boundaries forward their String verbatim through
+        // BackboneError::Message. Assert the rendered message is byte-for-byte
+        // the string the indexer core produced (matching the old js_error
+        // funnel that also built Message(error.to_string())).
+        let raw = decode_query(&[0xff]).unwrap_err();
+        assert_eq!(BackboneError::Message(raw.clone()).to_string(), raw);
     }
 
     #[test]

--- a/packages/utils/native-backbone/src/documents.rs
+++ b/packages/utils/native-backbone/src/documents.rs
@@ -1340,7 +1340,7 @@ impl NativePeerbitBackbone {
     pub(crate) fn document_context_facts_by_key(
         &self,
         key: &str,
-    ) -> Result<Option<DocumentContextFacts>, JsValue> {
+    ) -> Result<Option<DocumentContextFacts>, BackboneError> {
         let Some(document_fields) = self.document_index.document_fields_by_id(key) else {
             return Ok(None);
         };
@@ -1350,21 +1350,21 @@ impl NativePeerbitBackbone {
     fn document_context_facts_from_fields(
         &self,
         document_fields: &DocumentFields,
-    ) -> Result<Option<DocumentContextFacts>, JsValue> {
+    ) -> Result<Option<DocumentContextFacts>, BackboneError> {
         let Some(fields) = self.document_context_fields else {
             return Ok(None);
         };
         let created = document_u64_field(document_fields, fields.created)
-            .ok_or_else(|| JsValue::from_str("Missing document context created field"))?;
+            .ok_or(BackboneError::MissingDocumentContextField("created"))?;
         let modified = document_u64_field(document_fields, fields.modified)
-            .ok_or_else(|| JsValue::from_str("Missing document context modified field"))?;
+            .ok_or(BackboneError::MissingDocumentContextField("modified"))?;
         let head = document_string_field(document_fields, fields.head)
-            .ok_or_else(|| JsValue::from_str("Missing document context head field"))?;
+            .ok_or(BackboneError::MissingDocumentContextField("head"))?;
         let gid = document_string_field(document_fields, fields.gid)
-            .ok_or_else(|| JsValue::from_str("Missing document context gid field"))?;
+            .ok_or(BackboneError::MissingDocumentContextField("gid"))?;
         let size = document_u64_field(document_fields, fields.size)
             .and_then(|value| u32::try_from(value).ok())
-            .ok_or_else(|| JsValue::from_str("Missing document context size field"))?;
+            .ok_or(BackboneError::MissingDocumentContextField("size"))?;
         Ok(Some(DocumentContextFacts {
             created,
             modified,
@@ -1854,6 +1854,20 @@ mod tests {
                 .unwrap_err();
         assert_eq!(error, BackboneError::UnsupportedProjectionSourceKind);
         assert_eq!(error.to_string(), "Unsupported projection source kind");
+    }
+
+    #[test]
+    fn document_context_field_variants_render_exact_messages() {
+        for label in ["created", "modified", "head", "gid", "size"] {
+            assert_eq!(
+                BackboneError::MissingDocumentContextField(label).to_string(),
+                format!("Missing document context {label} field")
+            );
+        }
+        assert_eq!(
+            BackboneError::MissingDocumentContextField("created").to_string(),
+            "Missing document context created field"
+        );
     }
 
     #[test]

--- a/packages/utils/native-backbone/src/documents.rs
+++ b/packages/utils/native-backbone/src/documents.rs
@@ -1407,7 +1407,7 @@ impl NativePeerbitBackbone {
         new_head: Option<&str>,
         previous_head: Option<&str>,
         record_document_journal: bool,
-    ) -> Result<(), JsValue> {
+    ) -> Result<(), BackboneError> {
         let prepared = self.prepare_document_encoded_parts_put(
             key,
             value_prefix_bytes,

--- a/packages/utils/native-backbone/src/error.rs
+++ b/packages/utils/native-backbone/src/error.rs
@@ -23,6 +23,7 @@ pub enum BackboneError {
     ExpectedBytesArray,
     ExpectedUnsignedIntegerArray,
     MismatchedInputLengths(&'static str),
+    MismatchedCompactCoordinateFacts(&'static str),
     MustBeNumber(&'static str),
     MustBeArray(&'static str),
     MissingOrInvalid(&'static str),
@@ -85,6 +86,7 @@ impl std::fmt::Display for BackboneError {
             BackboneError::MismatchedInputLengths(label) => {
                 write!(f, "Mismatched {label} input lengths")
             }
+            BackboneError::MismatchedCompactCoordinateFacts(label) => f.write_str(label),
             BackboneError::MustBeNumber(label) => write!(f, "{label} must be a number"),
             BackboneError::MustBeArray(field) => write!(f, "{field} must be an array"),
             BackboneError::MissingOrInvalid(field) => write!(f, "Missing or invalid {field}"),

--- a/packages/utils/native-backbone/src/error.rs
+++ b/packages/utils/native-backbone/src/error.rs
@@ -41,6 +41,8 @@ pub enum BackboneError {
     UnsupportedProjectedDocumentFieldType,
     ProjectionValueOutputTypeMismatch,
     DocumentProjectionPlanLengthMismatch,
+    ProjectionPlanLengthMismatch,
+    TrailingDocumentSignerFactBytes,
     MissingDocumentVariant,
     InvalidDocumentVariant,
     DocumentVariantMismatch,
@@ -121,6 +123,12 @@ impl std::fmt::Display for BackboneError {
             }
             BackboneError::DocumentProjectionPlanLengthMismatch => {
                 f.write_str("Document projection plan length mismatch")
+            }
+            BackboneError::ProjectionPlanLengthMismatch => {
+                f.write_str("Projection plan length mismatch")
+            }
+            BackboneError::TrailingDocumentSignerFactBytes => {
+                f.write_str("Trailing document signer fact bytes")
             }
             BackboneError::MissingDocumentVariant => f.write_str("Missing document variant"),
             BackboneError::InvalidDocumentVariant => f.write_str("Invalid document variant"),

--- a/packages/utils/native-backbone/src/error.rs
+++ b/packages/utils/native-backbone/src/error.rs
@@ -64,6 +64,9 @@ pub enum BackboneError {
     RawReceiveOriginalIndexOverflow,
     RawReceiveSelectedIndexOverflow,
     RawReceiveGroupIndexOverflow,
+    MissingPreparedRawReceiveEntry,
+    MismatchedPreparedRawReceiveVerifyLengths,
+    MissingPartialVerifyHashes,
     Wire(WireError),
     SharedLog(SharedLogError),
     Schema(SchemaError),
@@ -182,6 +185,15 @@ impl std::fmt::Display for BackboneError {
             }
             BackboneError::RawReceiveGroupIndexOverflow => {
                 f.write_str("Raw receive group index overflow")
+            }
+            BackboneError::MissingPreparedRawReceiveEntry => {
+                f.write_str("Missing prepared raw receive entry")
+            }
+            BackboneError::MismatchedPreparedRawReceiveVerifyLengths => {
+                f.write_str("Expected equal prepared raw receive verify lengths")
+            }
+            BackboneError::MissingPartialVerifyHashes => {
+                f.write_str("Missing partial verify hashes")
             }
             BackboneError::Wire(error) => write!(f, "{error}"),
             BackboneError::SharedLog(error) => write!(f, "{error}"),

--- a/packages/utils/native-backbone/src/error.rs
+++ b/packages/utils/native-backbone/src/error.rs
@@ -56,6 +56,7 @@ pub enum BackboneError {
     MissingCachedDocumentProjectionPlan,
     MissingPlainPutPayloadForDocumentIndex,
     MissingPlainPutPayloadForDocumentProjection,
+    MissingDocumentContextField(&'static str),
     Wire(WireError),
     SharedLog(SharedLogError),
     Schema(SchemaError),
@@ -154,6 +155,9 @@ impl std::fmt::Display for BackboneError {
             }
             BackboneError::MissingPlainPutPayloadForDocumentProjection => {
                 f.write_str("Missing plain put payload for document projection")
+            }
+            BackboneError::MissingDocumentContextField(label) => {
+                write!(f, "Missing document context {label} field")
             }
             BackboneError::Wire(error) => write!(f, "{error}"),
             BackboneError::SharedLog(error) => write!(f, "{error}"),

--- a/packages/utils/native-backbone/src/error.rs
+++ b/packages/utils/native-backbone/src/error.rs
@@ -33,6 +33,29 @@ pub enum BackboneError {
     WireSyncStashFrameTaken,
     WireSyncPinnedEntryMissing,
     CoordinateCountOverflow,
+    Truncated(&'static str),
+    InvalidBool(&'static str),
+    InvalidProjectionOptionMarker,
+    UnsupportedDocumentProjectionFieldType,
+    UnsupportedProjectedDocumentFieldType,
+    ProjectionValueOutputTypeMismatch,
+    DocumentProjectionPlanLengthMismatch,
+    MissingDocumentVariant,
+    InvalidDocumentVariant,
+    DocumentVariantMismatch,
+    UnsupportedDocumentVariantType,
+    MissingOutputVariant,
+    InvalidOutputVariant,
+    UnsupportedOutputVariantType,
+    UnsupportedContextProjectionSource,
+    UnsupportedProjectionSourceKind,
+    PlainPutPayloadTooShort,
+    PlainPutPayloadLengthMismatch,
+    DocumentContextSuffixCapacityOverflow,
+    DocumentSchemaIrNotConfigured,
+    MissingCachedDocumentProjectionPlan,
+    MissingPlainPutPayloadForDocumentIndex,
+    MissingPlainPutPayloadForDocumentProjection,
     Wire(WireError),
     SharedLog(SharedLogError),
     Schema(SchemaError),
@@ -79,6 +102,59 @@ impl std::fmt::Display for BackboneError {
                 f.write_str("wire sync pinned stash entry missing")
             }
             BackboneError::CoordinateCountOverflow => f.write_str("Coordinate count overflow"),
+            BackboneError::Truncated(label) => write!(f, "Truncated {label}"),
+            BackboneError::InvalidBool(label) => write!(f, "Invalid bool {label}"),
+            BackboneError::InvalidProjectionOptionMarker => {
+                f.write_str("Invalid projection option marker")
+            }
+            BackboneError::UnsupportedDocumentProjectionFieldType => {
+                f.write_str("Unsupported document projection field type")
+            }
+            BackboneError::UnsupportedProjectedDocumentFieldType => {
+                f.write_str("Unsupported projected document field type")
+            }
+            BackboneError::ProjectionValueOutputTypeMismatch => {
+                f.write_str("Projection value does not match output type")
+            }
+            BackboneError::DocumentProjectionPlanLengthMismatch => {
+                f.write_str("Document projection plan length mismatch")
+            }
+            BackboneError::MissingDocumentVariant => f.write_str("Missing document variant"),
+            BackboneError::InvalidDocumentVariant => f.write_str("Invalid document variant"),
+            BackboneError::DocumentVariantMismatch => f.write_str("Document variant mismatch"),
+            BackboneError::UnsupportedDocumentVariantType => {
+                f.write_str("Unsupported document variant type")
+            }
+            BackboneError::MissingOutputVariant => f.write_str("Missing output variant"),
+            BackboneError::InvalidOutputVariant => f.write_str("Invalid output variant"),
+            BackboneError::UnsupportedOutputVariantType => {
+                f.write_str("Unsupported output variant type")
+            }
+            BackboneError::UnsupportedContextProjectionSource => {
+                f.write_str("Unsupported context projection source")
+            }
+            BackboneError::UnsupportedProjectionSourceKind => {
+                f.write_str("Unsupported projection source kind")
+            }
+            BackboneError::PlainPutPayloadTooShort => f.write_str("Plain put payload is too short"),
+            BackboneError::PlainPutPayloadLengthMismatch => {
+                f.write_str("Plain put payload length mismatch")
+            }
+            BackboneError::DocumentContextSuffixCapacityOverflow => {
+                f.write_str("Document context suffix capacity overflow")
+            }
+            BackboneError::DocumentSchemaIrNotConfigured => {
+                f.write_str("Native backbone document schema IR has not been configured")
+            }
+            BackboneError::MissingCachedDocumentProjectionPlan => {
+                f.write_str("Missing cached document projection plan")
+            }
+            BackboneError::MissingPlainPutPayloadForDocumentIndex => {
+                f.write_str("Missing plain put payload for document index")
+            }
+            BackboneError::MissingPlainPutPayloadForDocumentProjection => {
+                f.write_str("Missing plain put payload for document projection")
+            }
             BackboneError::Wire(error) => write!(f, "{error}"),
             BackboneError::SharedLog(error) => write!(f, "{error}"),
             BackboneError::Schema(error) => write!(f, "{error}"),

--- a/packages/utils/native-backbone/src/error.rs
+++ b/packages/utils/native-backbone/src/error.rs
@@ -60,6 +60,10 @@ pub enum BackboneError {
     MissingPlainPutPayloadForDocumentIndex,
     MissingPlainPutPayloadForDocumentProjection,
     MissingDocumentContextField(&'static str),
+    MaxReplicasMustBeNumber,
+    RawReceiveOriginalIndexOverflow,
+    RawReceiveSelectedIndexOverflow,
+    RawReceiveGroupIndexOverflow,
     Wire(WireError),
     SharedLog(SharedLogError),
     Schema(SchemaError),
@@ -168,6 +172,16 @@ impl std::fmt::Display for BackboneError {
             }
             BackboneError::MissingDocumentContextField(label) => {
                 write!(f, "Missing document context {label} field")
+            }
+            BackboneError::MaxReplicasMustBeNumber => f.write_str("maxReplicas must be a number"),
+            BackboneError::RawReceiveOriginalIndexOverflow => {
+                f.write_str("Raw receive original index overflow")
+            }
+            BackboneError::RawReceiveSelectedIndexOverflow => {
+                f.write_str("Raw receive selected index overflow")
+            }
+            BackboneError::RawReceiveGroupIndexOverflow => {
+                f.write_str("Raw receive group index overflow")
             }
             BackboneError::Wire(error) => write!(f, "{error}"),
             BackboneError::SharedLog(error) => write!(f, "{error}"),

--- a/packages/utils/native-backbone/src/js_interop.rs
+++ b/packages/utils/native-backbone/src/js_interop.rs
@@ -444,14 +444,6 @@ pub(crate) fn write_bool(out: &mut Vec<u8>, value: bool) {
     out.push(if value { 1 } else { 0 });
 }
 
-pub(crate) fn js_error(error: impl std::fmt::Display) -> JsValue {
-    JsValue::from(BackboneError::Message(error.to_string()))
-}
-
-pub(crate) fn decode_error(error: impl std::fmt::Display) -> JsValue {
-    JsValue::from(BackboneError::Message(error.to_string()))
-}
-
 pub(crate) fn hash_number_u64(resolution: &str, digest: &[u8]) -> Result<u64, BackboneError> {
     match resolution {
         "u32" => {

--- a/packages/utils/native-backbone/src/raw_receive.rs
+++ b/packages/utils/native-backbone/src/raw_receive.rs
@@ -9,6 +9,7 @@ use peerbit_shared_log_rust::{EntryCoordinateCommit, GidLeaderPlan};
 use std::collections::{HashMap, HashSet};
 use wasm_bindgen::prelude::*;
 
+use crate::error::BackboneError;
 use crate::js_interop::{
     bytes_vec_from_array, ensure_same_len, hash_number_u64, numbers_to_rows, strings_from_array,
     strings_slice_to_array, strings_to_array,
@@ -101,7 +102,7 @@ fn prepared_raw_receive_selection_from_leader_plans(
     leader_plans: &[GidLeaderPlan],
     self_hash: &str,
     used_leader_sample_plans: bool,
-) -> Result<JsValue, JsValue> {
+) -> Result<JsValue, BackboneError> {
     if leader_plans.len() != groups.len() {
         return Ok(JsValue::UNDEFINED);
     }
@@ -130,7 +131,7 @@ fn prepared_raw_receive_selection_from_leader_plans(
     let mut dropped_indexes = Vec::new();
     for (original_index, retained) in retained_original_indexes.iter().enumerate() {
         let original_index = u32::try_from(original_index)
-            .map_err(|_| JsValue::from_str("Raw receive original index overflow"))?;
+            .map_err(|_| BackboneError::RawReceiveOriginalIndexOverflow)?;
         if *retained {
             retained_indexes.push(original_index);
         } else {
@@ -148,7 +149,7 @@ fn prepared_raw_receive_selection_from_leader_plans(
                 selected_index_by_original[original_index] = Some(selected_index);
                 selected_index = selected_index
                     .checked_add(1)
-                    .ok_or_else(|| JsValue::from_str("Raw receive selected index overflow"))?;
+                    .ok_or(BackboneError::RawReceiveSelectedIndexOverflow)?;
             }
         }
         for (index, (group, leader_plan)) in groups.iter().zip(leader_plans).enumerate() {
@@ -611,7 +612,7 @@ impl NativePeerbitBackbone {
         include_strict_full_replica: bool,
         _from_hash: String,
     ) -> Result<JsValue, JsValue> {
-        self.plan_prepared_raw_receive_selection_core(
+        Ok(self.plan_prepared_raw_receive_selection_core(
             strings_from_array(hashes)?,
             min_replicas,
             max_replicas,
@@ -623,7 +624,7 @@ impl NativePeerbitBackbone {
             include_self,
             full_replica_fallback,
             include_strict_full_replica,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -757,7 +758,7 @@ impl NativePeerbitBackbone {
             return Ok(JsValue::UNDEFINED);
         }
 
-        prepared_raw_receive_selection_from_leader_plans(
+        Ok(prepared_raw_receive_selection_from_leader_plans(
             &self.resolution,
             &groups,
             expected_hash_count,
@@ -765,7 +766,7 @@ impl NativePeerbitBackbone {
             &leader_plans,
             &self_hash,
             false,
-        )
+        )?)
     }
 
     pub fn verify_prepared_raw_receive_entries(
@@ -1156,7 +1157,7 @@ impl NativePeerbitBackbone {
         include_self: bool,
         full_replica_fallback: bool,
         include_strict_full_replica: bool,
-    ) -> Result<JsValue, JsValue> {
+    ) -> Result<JsValue, BackboneError> {
         let expected_hash_count = hashes.len();
         if expected_hash_count == 0 {
             return Ok(JsValue::UNDEFINED);
@@ -1193,7 +1194,7 @@ impl NativePeerbitBackbone {
         include_self: bool,
         full_replica_fallback: bool,
         include_strict_full_replica: bool,
-    ) -> Result<JsValue, JsValue> {
+    ) -> Result<JsValue, BackboneError> {
         let expected_hash_count = hashes.len();
         let mut planned_hash_count = 0usize;
         let mut gids = Vec::with_capacity(groups.len());
@@ -1250,7 +1251,7 @@ impl NativePeerbitBackbone {
         hashes: Vec<String>,
         min_replicas: u32,
         max_replicas: JsValue,
-    ) -> Result<Option<Vec<ResolvedPendingRawReceiveGroupPlan>>, JsValue> {
+    ) -> Result<Option<Vec<ResolvedPendingRawReceiveGroupPlan>>, BackboneError> {
         if hashes.is_empty() {
             return Ok(Some(Vec::new()));
         }
@@ -1261,7 +1262,7 @@ impl NativePeerbitBackbone {
         } else {
             max_replicas
                 .as_f64()
-                .ok_or_else(|| JsValue::from_str("maxReplicas must be a number"))?
+                .ok_or(BackboneError::MaxReplicasMustBeNumber)?
                 .max(0.0)
                 .min(u32::MAX as f64) as u32
         };
@@ -1277,7 +1278,7 @@ impl NativePeerbitBackbone {
                 return Ok(None);
             };
             let input_index = u32::try_from(input_index)
-                .map_err(|_| JsValue::from_str("Raw receive group index overflow"))?;
+                .map_err(|_| BackboneError::RawReceiveGroupIndexOverflow)?;
 
             let group_index = if let Some(index) = group_indexes.get(&pending.entry.gid) {
                 *index
@@ -1720,5 +1721,34 @@ impl NativePeerbitBackbone {
             }
         }
         Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::error::BackboneError;
+
+    #[test]
+    fn raw_receive_selection_variants_render_exact_messages() {
+        for (error, message) in [
+            (
+                BackboneError::MaxReplicasMustBeNumber,
+                "maxReplicas must be a number",
+            ),
+            (
+                BackboneError::RawReceiveOriginalIndexOverflow,
+                "Raw receive original index overflow",
+            ),
+            (
+                BackboneError::RawReceiveSelectedIndexOverflow,
+                "Raw receive selected index overflow",
+            ),
+            (
+                BackboneError::RawReceiveGroupIndexOverflow,
+                "Raw receive group index overflow",
+            ),
+        ] {
+            assert_eq!(error.to_string(), message);
+        }
     }
 }

--- a/packages/utils/native-backbone/src/raw_receive.rs
+++ b/packages/utils/native-backbone/src/raw_receive.rs
@@ -273,7 +273,7 @@ impl NativePeerbitBackbone {
             self.append_profile.raw_receive_input_copy_ms += crate::time::now_ms() - started;
         }
         let prepared = self.prepare_raw_receive_entries(blocks, None, true)?;
-        self.prepare_raw_receive_columns_from_entries(prepared, true, true)
+        Ok(self.prepare_raw_receive_columns_from_entries(prepared, true, true)?)
     }
 
     pub fn prepare_raw_receive_unverified_columns_batch(
@@ -287,7 +287,7 @@ impl NativePeerbitBackbone {
             self.append_profile.raw_receive_input_copy_ms += crate::time::now_ms() - started;
         }
         let prepared = self.prepare_raw_receive_entries(blocks, None, false)?;
-        self.prepare_raw_receive_columns_from_entries(prepared, true, true)
+        Ok(self.prepare_raw_receive_columns_from_entries(prepared, true, true)?)
     }
 
     pub fn prepare_raw_receive_expected_columns_batch(
@@ -303,7 +303,7 @@ impl NativePeerbitBackbone {
             self.append_profile.raw_receive_input_copy_ms += crate::time::now_ms() - started;
         }
         let prepared = self.prepare_raw_receive_entries(blocks, Some(hashes), true)?;
-        self.prepare_raw_receive_columns_from_entries(prepared, true, true)
+        Ok(self.prepare_raw_receive_columns_from_entries(prepared, true, true)?)
     }
 
     pub fn prepare_raw_receive_unverified_expected_columns_batch(
@@ -319,7 +319,7 @@ impl NativePeerbitBackbone {
             self.append_profile.raw_receive_input_copy_ms += crate::time::now_ms() - started;
         }
         let prepared = self.prepare_raw_receive_entries(blocks, Some(hashes), false)?;
-        self.prepare_raw_receive_columns_from_entries(prepared, true, true)
+        Ok(self.prepare_raw_receive_columns_from_entries(prepared, true, true)?)
     }
 
     pub fn prepare_raw_receive_expected_compact_columns_batch(
@@ -335,7 +335,7 @@ impl NativePeerbitBackbone {
             self.append_profile.raw_receive_input_copy_ms += crate::time::now_ms() - started;
         }
         let prepared = self.prepare_raw_receive_entries(blocks, Some(hashes), true)?;
-        self.prepare_raw_receive_columns_from_entries(prepared, false, false)
+        Ok(self.prepare_raw_receive_columns_from_entries(prepared, false, false)?)
     }
 
     pub fn prepare_raw_receive_unverified_expected_compact_columns_batch(
@@ -351,7 +351,7 @@ impl NativePeerbitBackbone {
             self.append_profile.raw_receive_input_copy_ms += crate::time::now_ms() - started;
         }
         let prepared = self.prepare_raw_receive_entries(blocks, Some(hashes), false)?;
-        self.prepare_raw_receive_columns_from_entries(prepared, false, false)
+        Ok(self.prepare_raw_receive_columns_from_entries(prepared, false, false)?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -803,7 +803,7 @@ impl NativePeerbitBackbone {
             coordinate_assigned_to_range_boundaries,
             coordinate_requested_replicas,
         )?;
-        self.commit_prepared_raw_receive_batch_core(hashes, &heads, coordinate_commits)
+        Ok(self.commit_prepared_raw_receive_batch_core(hashes, &heads, coordinate_commits)?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -831,7 +831,7 @@ impl NativePeerbitBackbone {
             coordinate_assigned_to_range_boundaries,
             coordinate_requested_replicas,
         )?;
-        self.commit_prepared_raw_receive_batch_core(hashes, &heads, coordinate_commits)
+        Ok(self.commit_prepared_raw_receive_batch_core(hashes, &heads, coordinate_commits)?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -857,7 +857,7 @@ impl NativePeerbitBackbone {
             coordinate_assigned_to_range_boundaries,
             coordinate_requested_replicas,
         )?;
-        self.commit_prepared_raw_receive_join_batch_core(hashes, &heads, coordinate_commits)
+        Ok(self.commit_prepared_raw_receive_join_batch_core(hashes, &heads, coordinate_commits)?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -885,7 +885,7 @@ impl NativePeerbitBackbone {
             coordinate_assigned_to_range_boundaries,
             coordinate_requested_replicas,
         )?;
-        self.commit_prepared_raw_receive_join_batch_core(hashes, &heads, coordinate_commits)
+        Ok(self.commit_prepared_raw_receive_join_batch_core(hashes, &heads, coordinate_commits)?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -913,12 +913,12 @@ impl NativePeerbitBackbone {
             coordinate_assigned_to_range_boundaries,
             coordinate_requested_replicas,
         )?;
-        self.commit_verified_prepared_raw_receive_join_batch_core(
+        Ok(self.commit_verified_prepared_raw_receive_join_batch_core(
             hashes,
             &heads,
             Some(verify_hashes),
             coordinate_commits,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -948,12 +948,12 @@ impl NativePeerbitBackbone {
             coordinate_assigned_to_range_boundaries,
             coordinate_requested_replicas,
         )?;
-        self.commit_verified_prepared_raw_receive_join_batch_core(
+        Ok(self.commit_verified_prepared_raw_receive_join_batch_core(
             hashes,
             &heads,
             Some(verify_hashes),
             coordinate_commits,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -979,12 +979,12 @@ impl NativePeerbitBackbone {
             coordinate_assigned_to_range_boundaries,
             coordinate_requested_replicas,
         )?;
-        self.commit_verified_prepared_raw_receive_join_batch_core(
+        Ok(self.commit_verified_prepared_raw_receive_join_batch_core(
             hashes,
             &heads,
             None,
             coordinate_commits,
-        )
+        )?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1012,12 +1012,12 @@ impl NativePeerbitBackbone {
             coordinate_assigned_to_range_boundaries,
             coordinate_requested_replicas,
         )?;
-        self.commit_verified_prepared_raw_receive_join_batch_core(
+        Ok(self.commit_verified_prepared_raw_receive_join_batch_core(
             hashes,
             &heads,
             None,
             coordinate_commits,
-        )
+        )?)
     }
 
     pub fn clear_prepared_raw_receive_entries(&mut self, hashes: Array) -> Result<usize, JsValue> {
@@ -1037,7 +1037,7 @@ impl NativePeerbitBackbone {
         blocks: Vec<Vec<u8>>,
         expected_cids: Option<Vec<String>>,
         verify_signatures: bool,
-    ) -> Result<Vec<PreparedRawEntryV0>, JsValue> {
+    ) -> Result<Vec<PreparedRawEntryV0>, BackboneError> {
         let profile_enabled = self.append_profile_enabled;
         let prepare_started = profile_enabled.then(crate::time::now_ms);
         let mut raw_profile = profile_enabled.then(RawEntryV0PrepareProfile::default);
@@ -1061,7 +1061,7 @@ impl NativePeerbitBackbone {
         prepared: Vec<PreparedRawEntryV0>,
         include_hash_digest_bytes: bool,
         include_cids: bool,
-    ) -> Result<Array, JsValue> {
+    ) -> Result<Array, BackboneError> {
         let profile_enabled = self.append_profile_enabled;
         let columns_started = profile_enabled.then(crate::time::now_ms);
         let len = prepared.len();
@@ -1346,7 +1346,7 @@ impl NativePeerbitBackbone {
     fn verify_pending_raw_receive_entries(
         &mut self,
         hashes: &[String],
-    ) -> Result<Option<Vec<u8>>, JsValue> {
+    ) -> Result<Option<Vec<u8>>, BackboneError> {
         if hashes.is_empty() {
             return Ok(Some(Vec::new()));
         }
@@ -1367,7 +1367,18 @@ impl NativePeerbitBackbone {
             if entries.is_empty() {
                 Some(Vec::new())
             } else {
-                verify_prepared_entry_v0_ed25519_storage_slices(&entries).ok()
+                // Deliberate, documented swallow. This returns Err only when
+                // the signature slices are not parseable as Ed25519 — i.e. a
+                // non-Ed25519 signature scheme or malformed bytes. That is the
+                // load-bearing "native cannot natively verify these slices ->
+                // defer to the caller's TS fallback" path: mapping the parse
+                // error to None (and thence Ok(None) below) is correct for
+                // mixed-scheme verification, so the bound LogError is
+                // intentionally discarded rather than propagated.
+                match verify_prepared_entry_v0_ed25519_storage_slices(&entries) {
+                    Ok(flags) => Some(flags),
+                    Err(_parse_error) => None,
+                }
             }
         };
 
@@ -1375,9 +1386,7 @@ impl NativePeerbitBackbone {
             return Ok(None);
         };
         if verified.len() != verify_positions.len() {
-            return Err(JsValue::from_str(
-                "Expected equal prepared raw receive verify lengths",
-            ));
+            return Err(BackboneError::MismatchedPreparedRawReceiveVerifyLengths);
         }
         for (index, flag) in verify_positions.iter().zip(verified.iter()) {
             out[*index] = *flag;
@@ -1394,7 +1403,7 @@ impl NativePeerbitBackbone {
     fn verify_pending_raw_receive_entries_all(
         &mut self,
         hashes: &[String],
-    ) -> Result<Option<bool>, JsValue> {
+    ) -> Result<Option<bool>, BackboneError> {
         if hashes.is_empty() {
             return Ok(Some(true));
         }
@@ -1414,7 +1423,17 @@ impl NativePeerbitBackbone {
             if entries.is_empty() {
                 Some(true)
             } else {
-                verify_prepared_entry_v0_ed25519_storage_slices_all(&entries).ok()
+                // Deliberate, documented swallow (see the per-entry twin
+                // verify_pending_raw_receive_entries above). Err here means the
+                // signature slices are not parseable as Ed25519 — a non-Ed25519
+                // scheme or malformed bytes — so native cannot natively verify
+                // them and we defer to the caller's TS fallback by resolving to
+                // None -> Ok(None). The bound LogError is intentionally
+                // discarded to preserve that mixed-scheme fallback control flow.
+                match verify_prepared_entry_v0_ed25519_storage_slices_all(&entries) {
+                    Ok(all_verified) => Some(all_verified),
+                    Err(_parse_error) => None,
+                }
             }
         };
 
@@ -1437,7 +1456,7 @@ impl NativePeerbitBackbone {
         hashes: Vec<String>,
         heads: &Uint8Array,
         coordinate_commits: Vec<EntryCoordinateCommit>,
-    ) -> Result<bool, JsValue> {
+    ) -> Result<bool, BackboneError> {
         ensure_same_len(hashes.len(), heads.length() as usize, "raw receive heads")?;
         let profile_enabled = self.append_profile_enabled;
         let pending_check_started = profile_enabled.then(crate::time::now_ms);
@@ -1458,7 +1477,7 @@ impl NativePeerbitBackbone {
             let pending = self
                 .pending_raw_receive_entries
                 .remove(&hash)
-                .ok_or_else(|| JsValue::from_str("Missing prepared raw receive entry"))?;
+                .ok_or(BackboneError::MissingPreparedRawReceiveEntry)?;
             block_entries.push((hash, pending.storage_bytes));
             let mut graph_entry = pending.entry;
             graph_entry.head = heads.get_index(index as u32) != 0;
@@ -1494,7 +1513,7 @@ impl NativePeerbitBackbone {
         hashes: Vec<String>,
         heads: &Uint8Array,
         coordinate_commits: Vec<EntryCoordinateCommit>,
-    ) -> Result<bool, JsValue> {
+    ) -> Result<bool, BackboneError> {
         ensure_same_len(hashes.len(), heads.length() as usize, "raw receive heads")?;
         let profile_enabled = self.append_profile_enabled;
         let pending_check_started = profile_enabled.then(crate::time::now_ms);
@@ -1515,7 +1534,7 @@ impl NativePeerbitBackbone {
                 let pending = self
                     .pending_raw_receive_entries
                     .get(hash)
-                    .ok_or_else(|| JsValue::from_str("Missing prepared raw receive entry"))?;
+                    .ok_or(BackboneError::MissingPreparedRawReceiveEntry)?;
                 graph_entries.push(&pending.entry);
             }
             let join_plans = self
@@ -1550,7 +1569,7 @@ impl NativePeerbitBackbone {
             let pending = self
                 .pending_raw_receive_entries
                 .remove(&hash)
-                .ok_or_else(|| JsValue::from_str("Missing prepared raw receive entry"))?;
+                .ok_or(BackboneError::MissingPreparedRawReceiveEntry)?;
             block_entries.push((hash, pending.storage_bytes));
             let mut graph_entry = pending.entry;
             graph_entry.head = heads.get_index(index as u32) != 0;
@@ -1587,7 +1606,7 @@ impl NativePeerbitBackbone {
         heads: &Uint8Array,
         verify_hashes: Option<Vec<String>>,
         coordinate_commits: Vec<EntryCoordinateCommit>,
-    ) -> Result<bool, JsValue> {
+    ) -> Result<bool, BackboneError> {
         ensure_same_len(hashes.len(), heads.length() as usize, "raw receive heads")?;
         let profile_enabled = self.append_profile_enabled;
         let verify_hashes_cover_commit = match verify_hashes.as_ref() {
@@ -1625,7 +1644,13 @@ impl NativePeerbitBackbone {
                 return Ok(false);
             }
         } else {
-            let verify_hashes = verify_hashes.expect("partial verify hashes");
+            // Unreachable by construction: verify_hashes_cover_commit is `true`
+            // whenever verify_hashes is None (the match arm above), so reaching
+            // this !verify_hashes_cover_commit branch guarantees Some. The
+            // former `.expect("partial verify hashes")` trapped the whole wasm
+            // instance on a breach; return a typed error instead so a breach
+            // surfaces as a normal thrown value rather than a process abort.
+            let verify_hashes = verify_hashes.ok_or(BackboneError::MissingPartialVerifyHashes)?;
             let Some(verified) = self.verify_pending_raw_receive_entries(&verify_hashes)? else {
                 return Ok(false);
             };
@@ -1657,7 +1682,7 @@ impl NativePeerbitBackbone {
                 let pending = self
                     .pending_raw_receive_entries
                     .get(hash)
-                    .ok_or_else(|| JsValue::from_str("Missing prepared raw receive entry"))?;
+                    .ok_or(BackboneError::MissingPreparedRawReceiveEntry)?;
                 graph_entries.push(&pending.entry);
             }
             let join_plans = self
@@ -1692,7 +1717,7 @@ impl NativePeerbitBackbone {
             let pending = self
                 .pending_raw_receive_entries
                 .remove(&hash)
-                .ok_or_else(|| JsValue::from_str("Missing prepared raw receive entry"))?;
+                .ok_or(BackboneError::MissingPreparedRawReceiveEntry)?;
             block_entries.push((hash, pending.storage_bytes));
             let mut graph_entry = pending.entry;
             graph_entry.head = heads.get_index(index as u32) != 0;
@@ -1746,6 +1771,26 @@ mod tests {
             (
                 BackboneError::RawReceiveGroupIndexOverflow,
                 "Raw receive group index overflow",
+            ),
+        ] {
+            assert_eq!(error.to_string(), message);
+        }
+    }
+
+    #[test]
+    fn raw_receive_verify_and_commit_variants_render_exact_messages() {
+        for (error, message) in [
+            (
+                BackboneError::MissingPreparedRawReceiveEntry,
+                "Missing prepared raw receive entry",
+            ),
+            (
+                BackboneError::MismatchedPreparedRawReceiveVerifyLengths,
+                "Expected equal prepared raw receive verify lengths",
+            ),
+            (
+                BackboneError::MissingPartialVerifyHashes,
+                "Missing partial verify hashes",
             ),
         ] {
             assert_eq!(error.to_string(), message);


### PR DESCRIPTION
## What

Part 2 (final) of the native-backbone typed-error refactor, following the pattern PR #998 established for log-rust and continuing PR #1008 (part 1). The remaining three module groups now report a typed `BackboneError` internally instead of constructing `JsValue`s — so no error path aborts the process when the crate is consumed as a native rlib — while every `#[wasm_bindgen]` export keeps its exact signature and every error message string is reproduced byte-for-byte.

Scope: `@peerbit/native-backbone` only, 9 files, +1340/−664. `packages/log` is byte-untouched.

### Slices in this PR (each an independently-gated commit or two)

- **5a** `append_tx/storage.rs`, `facts.rs` — plus re-pointing four append dispatch calls from log-rust's JsValue wrappers to its typed `_core` builders (rebuilding the frozen result rows locally; see verification below).
- **5b** `append_tx/committed_no_next.rs`, `committed_latest.rs`, `mod.rs` — plus lifting the pending latest-batch append state off `js_sys::Array` handles onto owned Rust data.
- **6** `documents.rs` — projection/signer/query/sort/snapshot decode paths; deletes the now-dead `js_error`/`decode_error` funnels.
- **7** `raw_receive.rs` — the receive/verify/commit hot path (the largest module).

## Non-mechanical changes (each behavior-preserving)

**Dispatch re-point (5a).** The old log-rust facts wrappers built their result row inside log-rust; the new path calls the typed core and rebuilds the row in native-backbone. Verified equivalent: the facts-row builder (`committed_entry_facts_to_row`) pre-existed with two callers on master, and its `CommitFactsOnly`/`NoNext` shapes match the old rows byte-for-byte with correct `include_next` polarity; the trim rows use a byte-identical replica of log-rust's `log_trim_entries_to_rows` fed by the same `trim_oldest_log_entries_core` the old wrapper called.

**Pending-state struct lift (5b).** `LatestBatchPendingAppend` no longer captures `Array` handles — it holds owned `entry_facts` + `trimmed_entries` + a `resolve_trimmed_entries` flag, and the JS rows are built at the emit boundary via profiled builders that keep the exact timing counters. The log append / block commit / trim side effects still happen at the same create-time point; only row construction is deferred (and skipped when a later fallible planning step aborts the append — a small win, identical observable behavior). One field (`materialization_bytes`) is deliberately kept as `Uint8Array`: lifting it would force a second copy on the hot success path.

**`expect()` → typed errors.** Two `expect()` calls that trapped the whole wasm instance became typed errors (the wire-sync stash invariants in part 1, and a partial-verify-hashes invariant here). Both are unreachable by construction; a typed error is strictly safer than an abort.

**The two Ed25519 `.ok()` fallbacks (raw-receive) are intentionally preserved.** Their only error is a signature-slice *parse* failure — a non-Ed25519 signature scheme or malformed bytes — and the resulting deferral to the TypeScript verification fallback is *correct* for mixed-scheme verification. Turning it into a hard error would break that. The change makes the swallow explicit and commented (binding the error, documenting the intent) rather than a bare `.ok()`. Observability via a counter was considered and declined: the only candidate feeds a positional JS wire row, so adding a field is not zero-surface.

**Error forwarding.** Where an error comes from an untyped source with no typed core (a few document/signer validation helpers pinned by frozen append_tx closure contracts), the JsValue message is forwarded verbatim through `BackboneError::Message` — never collapsed to a single wrong variant.

## Verification

- Per commit: `cargo test` (grew 35→43, new tests pin every new variant to its exact rendered message), `cargo fmt --check`, `cargo check --target wasm32-unknown-unknown`.
- Wasm API surface vs a pristine-master baseline, per commit: public declaration section byte-identical, whole `.d.ts` a pure line-permutation (the auto-generated `InitOutput` raw-export table reorders when modules change), export names identical.
- Package suite: 59 passing per commit.
- Downstream battery (the specs that exercise the append and receive/verify/commit hot paths, byte-exact cross-peer sync): document `native-replicate-sync`, `native-network-e2e`, `native-runtime-coverage`, `raw-exchange-sync`; shared-log `network-e2e-native`, `sync-raw-exchange-heads` (33) — all passing, no verify/commit regression.

## Follow-up

A few document-index builders and one signer-validation helper still return `Result<_, JsValue>` because their type is pinned by a frozen `make_document_index_commit` closure contract in `committed_latest`; typing them is a small dedicated follow-up that re-touches that contract. This is the only remaining JsValue error surface in the crate.
