### PR TITLE
fix(document): preserve caller-provided remote.from on the iterator's first fetch

### DIFF
--- a/.changeset/document-preserve-remote-from.md
+++ b/.changeset/document-preserve-remote-from.md
@@ -1,0 +1,16 @@
+---
+"@peerbit/document": patch
+---
+
+Preserve caller-provided `remote.from` targeting on the iterator's first fetch
+
+`fetchFirst` spread `options.remote` but then overwrote `from` with
+`fetchOptions?.from ?? initialRemoteTargets`, both of which are undefined on
+the first fetch unless `reach.discover` is used. The explicit
+`from: undefined` clobbered the caller's targeting hint, so `queryCommence`
+fell through to `getCover` and the cold-start fallback, querying connected
+peers that may never respond (e.g. a relay that does not run the program) and
+stalling the first batch until the full remote timeout. Caller-provided
+`remote.from` is now used as the fallback; internal callers passing
+`fetchOptions.from` (missing-response retries, late-join refetches) and
+`reach.discover` targets keep precedence.

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -403,6 +403,7 @@ export type ReachScope = {
 
 export type RemoteQueryOptions<Q, R, D> = RPCRequestAllOptions<Q, R> & {
 	replicate?: boolean;
+	from?: string[]; // if specified, only query these peers
 	minAge?: number;
 	throwOnMissing?: boolean;
 	retryMissingResponses?: boolean;
@@ -4907,7 +4908,12 @@ export class DocumentIndex<
 									...(typeof options?.remote === "object"
 										? options.remote
 										: {}),
-									from: fetchOptions?.from ?? initialRemoteTargets,
+									from:
+										fetchOptions?.from ??
+										initialRemoteTargets ??
+										(typeof options?.remote === "object"
+											? options.remote.from
+											: undefined),
 								}
 							: false,
 					resolve,

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -15265,6 +15265,63 @@ describe("index", () => {
 						});
 					});
 				});
+
+				describe("from", () => {
+					let session: TestSession;
+
+					afterEach(async () => {
+						await session.stop();
+					});
+
+					it("only queries targeted peers on the first fetch", async () => {
+						session = await TestSession.connected(3);
+
+						const store = new TestStore({
+							docs: new Documents<Document>(),
+						});
+
+						// the writer holds the document but does not replicate, so it
+						// never becomes part of the cover set and is only reachable
+						// through explicit 'remote.from' targeting
+						const writer = await session.peers[0].open(store, {
+							args: {
+								replicate: false,
+							},
+						});
+
+						const reader = await session.peers[1].open<TestStore>(
+							store.clone(),
+							{
+								args: {
+									replicate: false,
+								},
+							},
+						);
+
+						// session.peers[2] never opens the program (a stand-in for a
+						// connected peer, e.g. a relay, that will never respond to
+						// queries). If the 'from' hint is dropped, the cold-start
+						// fallback queries it and the search stalls until the full
+						// remote timeout
+						await writer.docs.put(new Document({ id: "1" }));
+						await reader.docs.waitFor(writer.node.identity.publicKey);
+
+						const t0 = +new Date();
+						const results = await reader.docs.index.search(
+							{},
+							{
+								remote: {
+									from: [writer.node.identity.publicKey.hashcode()],
+									timeout: 10_000,
+								},
+							},
+						);
+						const t1 = +new Date();
+
+						expect(results.map((x) => x.id)).to.deep.equal(["1"]);
+						expect(t1 - t0).to.be.lessThan(3000); // and not the full remote timeout
+					});
+				});
 			});
 
 			describe("signal", () => {


### PR DESCRIPTION
## Summary

Preserve a caller-provided `remote.from` targeting hint on the query iterator's first fetch.

Fixes #1011

## Mechanism

`fetchFirst` spreads `options.remote` but then overwrites `from` with `fetchOptions?.from ?? initialRemoteTargets`, both of which are `undefined` on the first fetch unless `reach.discover` is used — so the explicit `from: undefined` clobbers the caller's hint. `queryCommence` then falls through to `getCover` and the cold-start fallback that queries up to 8 connected pubsub peers; if one of them never opened the program (e.g. a relay), `rpc.request` (no `amount`) only resolves at the full `remote.timeout`, returning data that had already arrived. This PR makes the caller's `remote.from` the final fallback, so internal callers that deliberately pass `fetchOptions.from` (missing-response retry, late-join refetch) and `reach.discover` targets keep precedence. `from` is also declared on `RemoteQueryOptions` (with the existing "if specified, only query these peers" doc), matching what `queryCommence` already reads.

## Test

`index.spec.ts` → `iterate` → `remote` → `from` → "only queries targeted peers on the first fetch": 3 peers, all connected; a non-replicating writer puts one document, a third peer never opens the program (silent-peer stand-in). The reader searches with `remote: { from: [writerHash], timeout: 10_000 }` and asserts the document is returned in well under the timeout.

- On `master`: fails with `expected 10007 to be below 3000` (first batch stalls to the full timeout; measured 10,019 ms in the originating app with the data available in ~15 ms).
- With the fix: passes (whole 3-peer test ~2.2 s including session setup).
- Regression check: all 43 `remote`-grepped document tests pass (`--grep "remote"`, includes the wait/policy/scope/discover suites and the missing-response retry paths).

A changeset (`patch` for `@peerbit/document`) is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
