### PR TITLE
refactor(native-backbone): type the document-index-commit builders (final slice)

### DIFF
--- a/.changeset/native-backbone-typed-errors-3.md
+++ b/.changeset/native-backbone-typed-errors-3.md
@@ -1,0 +1,23 @@
+---
+"@peerbit/native-backbone": patch
+---
+
+Typed native error paths for the backbone core (final slice)
+
+Eliminates the last `Result<_, JsValue>` error surface in the crate: the four
+`document_index_*_append_commit` builders and
+`validate_document_index_required_previous_signer` in documents.rs now report a
+typed `BackboneError` instead of constructing `JsValue`s. These were the only
+paths still pinned to `JsValue` by the frozen
+`make_document_index_commit` closure contract in
+`append_tx/committed_latest`; that contract is retyped to
+`-> Result<DocumentIndexAppendCommit, BackboneError>` in the same change, so the
+builders and their closures now type-check end to end without a JsValue seam.
+
+The required-previous-signer validator's two error literals become dedicated
+variants (`PreviousDocumentSignerPublicKeyUnavailable` and
+`PreviousDocumentSignerPublicKeyPolicyMismatch`) rendering their historical
+strings byte-for-byte. With every caller now typed, the local
+`js_wrapper_error` verbatim-forward seam in committed_latest.rs is dead and is
+removed. Every `#[wasm_bindgen]` export keeps its exact signature and reaches JS
+only through the single `From<BackboneError> for JsValue` conversion.

--- a/packages/utils/native-backbone/src/append_tx/committed_latest.rs
+++ b/packages/utils/native-backbone/src/append_tx/committed_latest.rs
@@ -25,19 +25,6 @@ use crate::js_interop::{
 use crate::shared_log_plan::leader_samples_to_optional_rows;
 use crate::NativePeerbitBackbone;
 
-/// Forward a JsValue error from an untyped documents-layer helper without
-/// altering its message. The document-commit builders and the
-/// required-previous-signer validator construct every error via
-/// `JsValue::from_str`, so `as_string()` recovers the exact string they would
-/// have thrown; the fallback only guards the theoretically-non-string case.
-fn js_wrapper_error(error: JsValue) -> BackboneError {
-    BackboneError::Message(
-        error
-            .as_string()
-            .unwrap_or_else(|| "Invalid document index append input".to_string()),
-    )
-}
-
 #[wasm_bindgen]
 impl NativePeerbitBackbone {
     #[allow(clippy::too_many_arguments)]
@@ -1541,8 +1528,7 @@ impl NativePeerbitBackbone {
         let trim_length_to = optional_usize_from_js(trim_length_to, "trimLengthTo")?;
         let (_, gid, next_hashes) =
             self.resolve_latest_document_append_context(&mut document_index_commit, fallback_gid)?;
-        self.validate_document_index_required_previous_signer(&document_index_commit)
-            .map_err(js_wrapper_error)?;
+        self.validate_document_index_required_previous_signer(&document_index_commit)?;
         self.prepare_plain_storage_append_transaction_inner(
             wall_time,
             logical,
@@ -1581,8 +1567,10 @@ impl NativePeerbitBackbone {
         trim_length_to: JsValue,
         make_document_index_commit: &mut dyn FnMut(
             u32,
-        )
-            -> Result<DocumentIndexAppendCommit, JsValue>,
+        ) -> Result<
+            DocumentIndexAppendCommit,
+            BackboneError,
+        >,
     ) -> Result<Array, BackboneError> {
         let batch_len = payload_datas.length() as usize;
         if batch_len == 0 {
@@ -1715,8 +1703,10 @@ impl NativePeerbitBackbone {
         trim_length_to: &JsValue,
         make_document_index_commit: &mut dyn FnMut(
             u32,
-        )
-            -> Result<DocumentIndexAppendCommit, JsValue>,
+        ) -> Result<
+            DocumentIndexAppendCommit,
+            BackboneError,
+        >,
         pending_appends: &mut Vec<LatestBatchPendingAppend>,
         coordinate_inputs: &mut Vec<NativeLocalAppendCompactInput>,
     ) -> Result<(), BackboneError> {
@@ -1725,16 +1715,14 @@ impl NativePeerbitBackbone {
             .get(index)
             .as_string()
             .ok_or(BackboneError::ExpectedString("batch fallback gid"))?;
-        let mut document_index_commit =
-            make_document_index_commit(index).map_err(js_wrapper_error)?;
+        let mut document_index_commit = make_document_index_commit(index)?;
         let payload_data = required_bytes_from_array(payload_datas, index, "payload")?;
         let trim_length_to = optional_usize_from_js(trim_length_to.clone(), "trimLengthTo")?;
         let payload_size = payload_data.length();
         let delete_trimmed_document_heads = document_index_commit.delete_trimmed_heads;
         let (previous_document_context, gid, next_hashes) =
             self.resolve_latest_document_append_context(&mut document_index_commit, fallback_gid)?;
-        self.validate_document_index_required_previous_signer(&document_index_commit)
-            .map_err(js_wrapper_error)?;
+        self.validate_document_index_required_previous_signer(&document_index_commit)?;
 
         let (meta_data, payload_data) =
             self.copy_append_inputs_profiled(meta_datas.get(index), &payload_data)?;
@@ -1894,8 +1882,7 @@ impl NativePeerbitBackbone {
             let delete_trimmed_document_heads = document_index_commit.delete_trimmed_heads;
             let (previous_document_context, gid, next_hashes) = self
                 .resolve_latest_document_append_context(&mut document_index_commit, fallback_gid)?;
-            self.validate_document_index_required_previous_signer(&document_index_commit)
-                .map_err(js_wrapper_error)?;
+            self.validate_document_index_required_previous_signer(&document_index_commit)?;
 
             let (meta_data, payload_data) =
                 self.copy_append_inputs_profiled(meta_datas.get(index_u32), &payload_bytes)?;
@@ -2030,8 +2017,7 @@ impl NativePeerbitBackbone {
         let delete_trimmed_document_heads = document_index_commit.delete_trimmed_heads;
         let (previous_document_context, gid, next_hashes) =
             self.resolve_latest_document_append_context(&mut document_index_commit, fallback_gid)?;
-        self.validate_document_index_required_previous_signer(&document_index_commit)
-            .map_err(js_wrapper_error)?;
+        self.validate_document_index_required_previous_signer(&document_index_commit)?;
 
         let (meta_data, payload_data) =
             self.copy_append_inputs_profiled(meta_data, &payload_data)?;
@@ -2115,22 +2101,17 @@ impl NativePeerbitBackbone {
 mod tests {
     use crate::error::BackboneError;
 
-    // `js_wrapper_error` forwards the untyped documents-layer JsValue messages
-    // verbatim through `BackboneError::Message`. These are the exact strings
-    // the required-previous-signer validator throws; pin their Display so the
-    // forwarded messages stay byte-for-byte with master. (The `JsValue` recovery
-    // itself is exercised on wasm by the TS suite; host `cargo test` cannot
-    // construct a round-tripping `JsValue`, so it pins the Message rendering.)
+    // The required-previous-signer validator now reports typed variants. Pin
+    // their Display so the thrown strings stay byte-for-byte with master.
     #[test]
-    fn forwarded_document_signer_messages_render_verbatim() {
-        for message in [
-            "Previous document signer public key unavailable",
-            "Previous document signer public key did not match native policy",
-        ] {
-            assert_eq!(
-                BackboneError::Message(message.to_string()).to_string(),
-                message
-            );
-        }
+    fn document_signer_variants_render_verbatim() {
+        assert_eq!(
+            BackboneError::PreviousDocumentSignerPublicKeyUnavailable.to_string(),
+            "Previous document signer public key unavailable"
+        );
+        assert_eq!(
+            BackboneError::PreviousDocumentSignerPublicKeyPolicyMismatch.to_string(),
+            "Previous document signer public key did not match native policy"
+        );
     }
 }

--- a/packages/utils/native-backbone/src/documents.rs
+++ b/packages/utils/native-backbone/src/documents.rs
@@ -112,7 +112,7 @@ pub(crate) fn document_index_append_commit(
     projection_plan: JsValue,
     projection_encoded_document: JsValue,
     projection_signer: JsValue,
-) -> Result<DocumentIndexAppendCommit, JsValue> {
+) -> Result<DocumentIndexAppendCommit, BackboneError> {
     let value_prefix = if projection_plan.is_null() || projection_plan.is_undefined() {
         DocumentIndexValuePrefix::Bytes(value_prefix_bytes)
     } else {
@@ -149,7 +149,7 @@ pub(crate) fn document_index_cached_projection_append_commit(
     projection_plan_id: u32,
     projection_encoded_document: JsValue,
     projection_signer: JsValue,
-) -> Result<DocumentIndexAppendCommit, JsValue> {
+) -> Result<DocumentIndexAppendCommit, BackboneError> {
     Ok(DocumentIndexAppendCommit {
         key,
         value_prefix: DocumentIndexValuePrefix::Projection {
@@ -178,7 +178,7 @@ pub(crate) fn document_index_plain_put_payload_append_commit(
     existing_created: String,
     byte_element_index_limit: usize,
     delete_trimmed_heads: bool,
-) -> Result<DocumentIndexAppendCommit, JsValue> {
+) -> Result<DocumentIndexAppendCommit, BackboneError> {
     Ok(DocumentIndexAppendCommit {
         key,
         value_prefix: DocumentIndexValuePrefix::PlainPutPayloadIdentity,
@@ -201,7 +201,7 @@ pub(crate) fn document_index_cached_projection_plain_put_payload_append_commit(
     delete_trimmed_heads: bool,
     projection_plan_id: u32,
     projection_signer: JsValue,
-) -> Result<DocumentIndexAppendCommit, JsValue> {
+) -> Result<DocumentIndexAppendCommit, BackboneError> {
     Ok(DocumentIndexAppendCommit {
         key,
         value_prefix: DocumentIndexValuePrefix::PlainPutPayloadProjection {
@@ -1376,7 +1376,7 @@ impl NativePeerbitBackbone {
     pub(crate) fn validate_document_index_required_previous_signer(
         &self,
         document_index_commit: &DocumentIndexAppendCommit,
-    ) -> Result<(), JsValue> {
+    ) -> Result<(), BackboneError> {
         let Some(required_public_key) = document_index_commit
             .required_previous_signer_public_key
             .as_ref()
@@ -1388,11 +1388,9 @@ impl NativePeerbitBackbone {
         };
         let previous_public_key = self
             .document_previous_signer_public_key(&document_index_commit.key, previous_context)
-            .ok_or_else(|| JsValue::from_str("Previous document signer public key unavailable"))?;
+            .ok_or(BackboneError::PreviousDocumentSignerPublicKeyUnavailable)?;
         if previous_public_key.as_slice() != required_public_key.as_slice() {
-            return Err(JsValue::from_str(
-                "Previous document signer public key did not match native policy",
-            ));
+            return Err(BackboneError::PreviousDocumentSignerPublicKeyPolicyMismatch);
         }
         Ok(())
     }

--- a/packages/utils/native-backbone/src/error.rs
+++ b/packages/utils/native-backbone/src/error.rs
@@ -67,6 +67,8 @@ pub enum BackboneError {
     MissingPreparedRawReceiveEntry,
     MismatchedPreparedRawReceiveVerifyLengths,
     MissingPartialVerifyHashes,
+    PreviousDocumentSignerPublicKeyUnavailable,
+    PreviousDocumentSignerPublicKeyPolicyMismatch,
     Wire(WireError),
     SharedLog(SharedLogError),
     Schema(SchemaError),
@@ -194,6 +196,12 @@ impl std::fmt::Display for BackboneError {
             }
             BackboneError::MissingPartialVerifyHashes => {
                 f.write_str("Missing partial verify hashes")
+            }
+            BackboneError::PreviousDocumentSignerPublicKeyUnavailable => {
+                f.write_str("Previous document signer public key unavailable")
+            }
+            BackboneError::PreviousDocumentSignerPublicKeyPolicyMismatch => {
+                f.write_str("Previous document signer public key did not match native policy")
             }
             BackboneError::Wire(error) => write!(f, "{error}"),
             BackboneError::SharedLog(error) => write!(f, "{error}"),


### PR DESCRIPTION
## What

The last `Result<_, JsValue>` **error** surface in the native-backbone crate. The four `document_index_*_append_commit` builders and `validate_document_index_required_previous_signer` were pinned to `Result<_, JsValue>` by the frozen `make_document_index_commit` closure contract in `committed_latest`; this retypes the contract and the builders to `BackboneError`, completing the typed-error refactor (parts 1 #1008, 2 #1010).

## Changes

- `committed_latest.rs`: retype the `make_document_index_commit` closure contract at both sites to return `BackboneError`; drop the 5 `.map_err(js_wrapper_error)` forwards (the `?` now converts directly) and remove the now-dead `js_wrapper_error` helper. (storage.rs keeps its own separate helper for the untyped storage-facts wrappers.)
- `documents.rs`: retype the 4 builders + `validate_document_index_required_previous_signer` to `BackboneError`. Two error literals become variants; the builders needed no new variants (their fallible calls already return `BackboneError`, so `?` converts as identity instead of via `From<BackboneError> for JsValue`).
- 2 new `BackboneError` variants, Display reproduced byte-for-byte from the old literals: `PreviousDocumentSignerPublicKeyUnavailable`, `PreviousDocumentSignerPublicKeyPolicyMismatch`.

Every `#[wasm_bindgen]` export keeps its exact signature (data-return `Result<Array/…, JsValue>` on the boundary is correct and stays). Errors reach JS only via the single `From<BackboneError> for JsValue`.

## Verification

- cargo test 43/43 (a test pins both new variants to their exact messages), cargo fmt, cargo check wasm32.
- Wasm surface vs pristine-master baseline: public declaration section byte-identical, whole `.d.ts` a pure line-permutation, export names identical.
- Package suite 59 passing; downstream native specs (replicate-sync, network-e2e, runtime-coverage) passing.
- `grep` confirms **no** document-index-commit-builder `Result<_, JsValue>` error signatures remain.