### PR TITLE
feat(shared-log): durable persistence for native-backbone nodes (clean restart)

### DIFF
--- a/.changeset/durable-native-persistence.md
+++ b/.changeset/durable-native-persistence.md
@@ -1,0 +1,12 @@
+---
+"@peerbit/shared-log": patch
+"@peerbit/program": patch
+---
+
+Durable persistence for native-backbone nodes: a native node started with a storage directory now survives a clean stop/restart with its replication coordinates and entry blocks intact.
+
+- Auto-derive per-program coordinate persistence from the client `directory` (previously only active if a caller passed `coordinatePersistence` explicitly). Namespaced per program under `<directory>/coordinates/<hex(log.id)>`; Node fs and browser OPFS backends. Backward-compatible: an explicitly-passed config still wins, and memory-only nodes are unchanged.
+- Make the native-backbone block store durable via a write-through wrapper over the wasm hot store and a durable `AnyBlockStore` (the same per-program `storage.sublevel("blocks")` the non-native path uses), rehydrating the wasm store from disk on open before the log walks the DAG. This closes the gap where entry blocks lived only in wasm memory when the native backbone was active, so a native node could not reopen its program after restart.
+- `@peerbit/program`: expose the optional `directory` on the `Client` interface (already set by `Peerbit`), so shared-log can derive durable per-program paths type-safely.
+
+Scope note: covers clean stop/restart. Hard-kill crash-consistency (flush ordering across the block store, heads index, and coordinate WAL) is a follow-up.

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
 		"test:part-3": "aegir run test --roots ./packages/transport/** -- -t node",
 		"test:ci:part-3": "aegir run test:cov --roots ./packages/transport/** -- --no-build",
 		"test:part-4": "aegir run test --roots ./packages/programs/data/shared-log ./packages/programs/data/shared-log/proxy -- -t node",
-		"test:ci:part-4": "aegir run test:cov --roots ./packages/programs/data/shared-log -- --no-build --grep \"^(append delivery options|ReplicationDomainTime|join|lifecycle( - getCover)?|network|observer|raw exchange-head sync|replicate|sync-repair-session)\"",
+		"test:ci:part-4": "aegir run test:cov --roots ./packages/programs/data/shared-log -- --no-build --grep \"^(append delivery options|ReplicationDomainTime|coordinate persistence auto-wire|durable native block store restart|durable restart conformance|join|lifecycle( - getCover)?|network|observer|raw exchange-head sync|replicate|sync-repair-session)\"",
 		"test:part-4:mock": "PEERBIT_TEST_SESSION=mock aegir run test --roots ./packages/programs/data/shared-log ./packages/programs/data/shared-log/proxy -- -t node",
 		"test:part-5": "aegir run test --roots ./packages/programs/rpc ./packages/programs/acl/** ./packages/programs/program/** ./packages/programs/clock-service ./packages/programs/data/string ./docs -- -t node",
 		"test:ci:part-5a": "aegir run test:cov --roots ./packages/programs/rpc ./packages/programs/acl/** ./packages/programs/program/program ./packages/programs/clock-service ./packages/programs/data/string ./docs -- --no-build",

--- a/packages/programs/data/document/document/test/durable-native-nonreplicating-restart.spec.ts
+++ b/packages/programs/data/document/document/test/durable-native-nonreplicating-restart.spec.ts
@@ -1,0 +1,196 @@
+// Durable-native restart gate for a NON-REPLICATING native document store.
+//
+// This is the case the replicating gate in shared-log's
+// durable-native-restart.spec.ts cannot reach: a non-replicating native node
+// (`replicate: false`) whose default document put options are
+// `{ replicate: false, target: "none" }` (NATIVE_LOCAL_PUT_OPTIONS). Those
+// options make `shouldDeferHeadCoordinatePersistence` true, which routes the
+// append through the native commit-only fast path
+// (`appendLocallyPreparedPayloadNativeBackboneCommitOnly` ->
+// `prepareEntryV0PlainEntryCommit`).
+//
+// That fast path commits the entry block into the in-wasm block map ONLY. When
+// the durable write-through wrapper is active (native backbone + on-disk
+// directory) the block must instead be written through to the durable `blocks`
+// sublevel, or it is lost on restart and the reopened program fails to load its
+// heads / documents.
+//
+// Regression note: before the FIX-1 guard, this path took the wasm-commit-only
+// route even with the wrapper active, so the blocks never reached durable. On
+// reopen with no peers the documents were gone (index size 0 / undefined docs)
+// and resolving heads walked an empty block store. This test pins the fix:
+// a non-replicating native node reopens from disk with ALL documents intact.
+import { NativeBackboneNodeCoordinatePersistence } from "@peerbit/native-backbone";
+import { expect } from "chai";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { Peerbit } from "peerbit";
+import { createRustPeerbitOptions } from "peerbit/rust";
+import sinon from "sinon";
+import { policy, transform } from "../src/index.js";
+import { Documents } from "../src/program.js";
+import { Document, TestStore } from "./data.js";
+
+describe("durable native block store restart (non-replicating)", function () {
+	this.timeout(120_000);
+
+	let client: Peerbit | undefined;
+	let directory: string | undefined;
+
+	afterEach(async () => {
+		await client?.stop();
+		client = undefined;
+		if (directory) {
+			await fs.rm(directory, { recursive: true, force: true });
+			directory = undefined;
+		}
+	});
+
+	it("reopens a non-replicating native document store from disk with all docs restored", async () => {
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-durable-native-nonrepl-"),
+		);
+
+		// Deterministic program id keeps the on-disk layout predictable across the
+		// two sessions (TestStore randomizes its id by default).
+		const storeId = new Uint8Array(32);
+		for (let index = 0; index < storeId.length; index++) {
+			storeId[index] = (index * 7 + 3) & 0xff;
+		}
+
+		const entryCount = 8;
+		const docId = (index: number) => `nonrepl-doc-${index}`;
+
+		// Native mode + non-replicating: default document puts use
+		// NATIVE_LOCAL_PUT_OPTIONS { replicate:false, target:"none" }, which makes
+		// shouldDeferHeadCoordinatePersistence true and routes the append through
+		// appendLocallyPreparedPayloadNativeBackboneCommitOnly (the native
+		// commit-only fast path that contains the wasm-commit-only
+		// prepareEntryV0PlainEntryCommit branch FIX-1 guards). The coordinate
+		// persistence is a durable on-disk store rooted under the same test
+		// directory, so both sessions read/write the same coordinate journal
+		// (mirrors the durable block wrapper, which is auto-derived from the node
+		// directory).
+		const coordinateDir = path.join(directory, "coordinate-wal");
+		const nativeOpenArgs = () => ({
+			mode: "native" as const,
+			replicate: false as const,
+			nativeGraph: true,
+			nativeBackbone: {
+				optional: false,
+				documentIndex: true,
+				coordinatePersistence: new NativeBackboneNodeCoordinatePersistence(
+					coordinateDir,
+					{ flushOnAppend: true },
+				),
+			},
+			canPerform: policy.allowAll<Document>(),
+			index: {
+				type: Document,
+				transform: transform.identity<Document>(),
+			},
+		});
+
+		// --- Session 1: on-disk native client, NON-REPLICATING put N docs -------
+		// No peer is ever dialed, so disk is the only block source on reopen.
+		client = await Peerbit.create({
+			directory,
+			...createRustPeerbitOptions(),
+		});
+
+		// Deterministic log id (passed through Documents -> SharedLog) so the
+		// per-program durable `blocks` sublevel resolves to the SAME on-disk
+		// location on reopen.
+		const store1 = new TestStore<Document>({
+			docs: new Documents<Document>({ id: storeId }),
+		});
+		store1.id = storeId;
+		await client.open(store1, { args: nativeOpenArgs() });
+
+		// Clone the (deserializable) program tree now, while it is open, so the
+		// reopened session opens an identical program (same ids/addresses).
+		const clone = store1.clone();
+
+		const log1 = store1.docs.log as any;
+		expect(log1._nativeBackbone, "session 1 native backbone").to.exist;
+		// The write-through wrapper is active: the log's block store is NOT the raw
+		// native wasm block map. This is precisely the condition the FIX-1 guard
+		// keys on.
+		expect(
+			log1.remoteBlocks?.localStore,
+			"session 1 write-through wrapper active (localStore !== backbone.blocks)",
+		).to.not.equal(log1._nativeBackbone.blocks);
+
+		// Force the append through the pure wasm-commit-only fast path
+		// (prepareEntryV0PlainEntryCommit at index.ts:~6656). A healthy native node
+		// with resident coordinate state normally diverts document-index puts to the
+		// storage-transaction path (which already writes blocks through the wrapper);
+		// the wasm-commit-only branch is the fallback taken when resident coordinate
+		// state is unavailable. Stubbing canUseNativeBackboneResidentCoordinateState
+		// to false makes every put take that exact branch, so this test exercises the
+		// FIX-1 code path. It is the branch that, before FIX-1, committed the block to
+		// the wasm map only and never wrote it through to durable.
+		const residentStub = sinon
+			.stub(log1, "canUseNativeBackboneResidentCoordinateState")
+			.returns(false);
+
+		const entryHashes: string[] = [];
+		try {
+			for (let index = 0; index < entryCount; index++) {
+				// Default options -> NATIVE_LOCAL_PUT_OPTIONS { replicate:false, target:"none" }.
+				const put = await store1.docs.put(
+					new Document({ id: docId(index), name: `v-${index}` }),
+				);
+				entryHashes.push(put.entry.hash);
+			}
+		} finally {
+			residentStub.restore();
+		}
+
+		expect(
+			await store1.docs.index.getSize(),
+			"session 1 document count",
+		).to.equal(entryCount);
+
+		const identity = client.identity;
+
+		// Clean stop flushes the durable block sublevel to disk.
+		await client.stop();
+		client = undefined;
+
+		// --- Session 2: FRESH client on the SAME directory, NO peers ------------
+		client = await Peerbit.create({
+			directory,
+			...createRustPeerbitOptions(),
+		});
+		expect(client.identity.publicKey.equals(identity.publicKey)).to.equal(
+			true,
+			"same identity restored from disk",
+		);
+
+		// Reopen the identical program clone. Must NOT throw
+		// "Failed to load entry from head".
+		const store2 = await client.open(clone, { args: nativeOpenArgs() });
+		const log2 = store2.docs.log as any;
+		expect(log2._nativeBackbone, "session 2 native backbone").to.exist;
+
+		// The core durable guarantee of FIX-1: every entry block a non-replicating
+		// native node committed is present in the reopened block store (durable +
+		// rehydrated into the native wasm map). Before FIX-1 the native commit-only
+		// fast path committed the block into the wasm map ONLY, bypassing the
+		// write-through wrapper, so after a restart these blocks were gone and
+		// remoteBlocks.get returned undefined (falling through to a remote read
+		// that never resolves on a peerless node).
+		for (const hash of entryHashes) {
+			const block = await log2.remoteBlocks.get(hash, { remote: false });
+			expect(block, `restored block ${hash}`).to.exist;
+		}
+
+		// And the entries themselves materialize from those blocks.
+		for (const hash of entryHashes) {
+			const entry = await store2.docs.log.log.get(hash);
+			expect(entry, `restored entry ${hash}`).to.exist;
+		}
+	});
+});

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -17,6 +17,7 @@ import {
 	getPublicKeyFromPeerId,
 	sha256Base64Sync,
 	sha256Sync,
+	toHexString,
 } from "@peerbit/crypto";
 import {
 	And,
@@ -367,6 +368,19 @@ const canUseOptionalNativeModuleImports = (): boolean => {
 			typeof scope.skipWaiting === "function")
 	);
 };
+
+/**
+ * Build the per-program coordinate persistence directory under a node's
+ * durable storage root: `<nodeDirectory>/coordinates/<fsSafeLogId>`. Uses
+ * forward-slash joining (accepted by Node's `fs` on every platform) so
+ * shared-log does not need to statically import `node:path`, which is not
+ * available in browser bundles. Trailing separators on the root are trimmed
+ * to avoid doubled slashes.
+ */
+const joinNativeCoordinateDirectory = (
+	nodeDirectory: string,
+	fsSafeLogId: string,
+): string => `${nodeDirectory.replace(/[/\\]+$/, "")}/coordinates/${fsSafeLogId}`;
 
 type LeaderMap = Map<string, { intersecting: boolean }>;
 
@@ -9318,21 +9332,36 @@ export class SharedLog<
 			return undefined;
 		}
 		try {
+			const nativeBackboneModule = await import(
+				/* @vite-ignore */ "@peerbit/native-backbone"
+			);
 			const {
 				createNativeBackboneCoordinatePersistence,
 				createNativePeerbitBackbone,
-			} = await import(/* @vite-ignore */ "@peerbit/native-backbone");
+			} = nativeBackboneModule;
 			const backbone = await createNativePeerbitBackbone({
 				resolution: this.domain.resolution,
 				clockId: this.node.identity.publicKey.bytes,
 				privateKey: this.node.identity.privateKey.privateKey,
 				publicKey: this.node.identity.publicKey.publicKey,
 			});
-			this._nativeBackboneCoordinatePersistence = options.coordinatePersistence
-				? createNativeBackboneCoordinatePersistence(
+			// Backward compatible: an explicitly supplied coordinate persistence
+			// config always wins and is used unchanged. Otherwise, when the node
+			// runs on durable on-disk storage, auto-derive a per-program store so
+			// replication coordinates survive a clean stop -> restart without a
+			// peer to re-derive from. Memory-only nodes (no directory) keep the
+			// previous in-memory behavior.
+			if (options.coordinatePersistence) {
+				this._nativeBackboneCoordinatePersistence =
+					createNativeBackboneCoordinatePersistence(
 						options.coordinatePersistence as RuntimeNativeBackboneCoordinatePersistenceConfig,
-					)
-				: undefined;
+					);
+			} else {
+				this._nativeBackboneCoordinatePersistence =
+					await this.createAutoDerivedCoordinatePersistence(
+						nativeBackboneModule,
+					);
+			}
 			return backbone;
 		} catch (error) {
 			if (options.optional === false) {
@@ -9345,6 +9374,65 @@ export class SharedLog<
 			);
 			return undefined;
 		}
+	}
+
+	/**
+	 * When the node has a durable on-disk storage directory, build a
+	 * per-program coordinate persistence store rooted under it so replication
+	 * coordinates auto-persist and survive a clean stop -> restart. Returns
+	 * `undefined` for memory-only nodes (no directory), preserving the prior
+	 * in-memory behavior.
+	 *
+	 * Namespacing: `<nodeDirectory>/coordinates/<fsSafe(log.id)>`. The log id
+	 * is the same identity used for `storage.sublevel`/`indexer.scope`
+	 * (see the `sha256Base64Sync(this.log.id)` above), but that base64 form is
+	 * not filesystem-path-safe, so the directory segment uses the hex encoding
+	 * of `this.log.id` (only `[0-9a-f]`, no `/`, `+`, or padding).
+	 *
+	 * Node vs OPFS is chosen with the same signal native-backbone uses to load
+	 * its wasm (`globalThis.process?.versions?.node`): Node gets the on-disk
+	 * store, browsers get the OPFS store.
+	 */
+	private async createAutoDerivedCoordinatePersistence(
+		nativeBackboneModule: typeof import("@peerbit/native-backbone"),
+	): Promise<NativeBackboneCoordinatePersistenceAdapter | undefined> {
+		const directory = this.node.directory;
+		if (directory == null) {
+			// Memory-only node: keep prior in-memory behavior.
+			return undefined;
+		}
+		const {
+			createNativeBackboneCoordinatePersistence,
+			NativeBackboneNodeCoordinatePersistenceStore,
+			NativeBackboneOPFSCoordinatePersistenceStore,
+		} = nativeBackboneModule;
+		const namespace = toHexString(this.log.id);
+		const isNode = !!(
+			globalThis as { process?: { versions?: { node?: string } } }
+		).process?.versions?.node;
+		let store: NativeBackboneCoordinatePersistenceStore;
+		if (isNode) {
+			const coordinateDirectory = joinNativeCoordinateDirectory(
+				directory,
+				namespace,
+			);
+			store = new NativeBackboneNodeCoordinatePersistenceStore(
+				coordinateDirectory,
+			);
+		} else {
+			// OPFS stores address by directory parts relative to the OPFS root,
+			// not by an absolute filesystem path, so the node `directory` only
+			// gates activation; the per-program namespace segments keep programs
+			// isolated within the browser's origin-private file system.
+			store = await NativeBackboneOPFSCoordinatePersistenceStore.create({
+				directory: ["coordinates", namespace],
+			});
+		}
+		return createNativeBackboneCoordinatePersistence({
+			store,
+			buffered: true,
+			flushOnAppend: true,
+		});
 	}
 
 	private async updateTimestampOfOwnedReplicationRanges(

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -416,6 +416,52 @@ class NativeBackboneWriteThroughBlockStore {
 		private readonly durable: AnyBlockStore,
 	) {}
 
+	// A durable mirror write that cannot be awaited at its call site (the
+	// columnar putKnownManyColumns fast path must return a synchronous string[]
+	// because RemoteBlocks.putKnownManyColumns treats the result as sync) is
+	// tracked here instead of being silently `void`ed. Its rejection is stored
+	// and re-thrown on the next awaited wrapper method (and on stop()), so a
+	// failed durable write (IO/disk-full) surfaces as an error rather than
+	// vanishing and leaving the block out of durable while native/log report
+	// success. `.catch` also prevents unhandled-rejection noise.
+	private readonly pendingDurableWrites = new Set<Promise<unknown>>();
+	private durableWriteError: unknown;
+
+	private trackDurable(result: unknown): void {
+		// The durable store may answer synchronously (an in-memory or already
+		// resolved store); only a real pending promise needs tracking. A sync
+		// success is already durable; a sync throw would have propagated already.
+		if (!isPromiseLike(result)) {
+			return;
+		}
+		const tracked = Promise.resolve(result).then(
+			() => {
+				this.pendingDurableWrites.delete(tracked);
+			},
+			(error) => {
+				this.pendingDurableWrites.delete(tracked);
+				if (this.durableWriteError === undefined) {
+					this.durableWriteError = error;
+				}
+			},
+		);
+		this.pendingDurableWrites.add(tracked);
+	}
+
+	// Wait for every tracked (sync-path) durable write to settle, then surface
+	// the first failure. Awaited methods call this so a prior columnar durable
+	// failure propagates as back-pressure to the next caller.
+	private async drainDurable(): Promise<void> {
+		while (this.pendingDurableWrites.size > 0) {
+			await Promise.allSettled([...this.pendingDurableWrites]);
+		}
+		if (this.durableWriteError !== undefined) {
+			const error = this.durableWriteError;
+			this.durableWriteError = undefined;
+			throw error;
+		}
+	}
+
 	// --- lifecycle -------------------------------------------------------
 	// The native store's lifecycle hooks are no-ops; only the durable store
 	// needs starting/stopping. Rehydration of the wasm map from disk happens in
@@ -427,6 +473,9 @@ class NativeBackboneWriteThroughBlockStore {
 	}
 
 	async stop(): Promise<void> {
+		// Surface any tracked (sync-path) durable write failure and ensure all
+		// mirror writes have settled before the durable store is torn down.
+		await this.drainDurable();
 		await this.durable.stop();
 	}
 
@@ -470,6 +519,7 @@ class NativeBackboneWriteThroughBlockStore {
 	async put(
 		data: Uint8Array | { block: { bytes: Uint8Array }; cid: string },
 	): Promise<string> {
+		await this.drainDurable();
 		const cid = await this.native.put(data as any);
 		// The native store computes a raw-codec CID for a `Uint8Array`, storing
 		// the bytes verbatim (raw codec is identity), and stores `block.bytes`
@@ -486,6 +536,7 @@ class NativeBackboneWriteThroughBlockStore {
 	async putMany(
 		blocks: Array<Uint8Array | { block: { bytes: Uint8Array }; cid: string }>,
 	): Promise<string[]> {
+		await this.drainDurable();
 		const cids = await this.native.putMany(blocks as any);
 		const durableBlocks: Array<readonly [string, Uint8Array]> = cids.map(
 			(cid, index) => {
@@ -501,17 +552,24 @@ class NativeBackboneWriteThroughBlockStore {
 		return cids;
 	}
 
-	putKnown(cid: string, bytes: Uint8Array): string {
+	// Native put is synchronous (the authoritative hot store); the durable mirror
+	// is awaited so the returned promise resolves only after BOTH native and
+	// durable succeed and a durable IO/disk-full failure rejects here instead of
+	// being swallowed. RemoteBlocks.putKnown and the log's putKnownEntryBytesBatch
+	// both await this method, so returning a promise is compatible.
+	async putKnown(cid: string, bytes: Uint8Array): Promise<string> {
+		await this.drainDurable();
 		const stored = this.native.putKnown(cid, bytes);
-		void this.durable.putKnown(cid, bytes);
+		await this.durable.putKnown(cid, bytes);
 		return stored;
 	}
 
-	putKnownMany(
+	async putKnownMany(
 		blocks: Array<readonly [cid: string, bytes: Uint8Array]>,
-	): string[] {
+	): Promise<string[]> {
+		await this.drainDurable();
 		const cids = this.native.putKnownMany(blocks);
-		void this.durable.putKnownMany(blocks);
+		await this.durable.putKnownMany(blocks);
 		return cids;
 	}
 
@@ -519,27 +577,34 @@ class NativeBackboneWriteThroughBlockStore {
 		const stored = this.native.putKnownManyColumns(cids, bytes);
 		// AnyBlockStore has no columnar method; mirror via putKnownMany, which
 		// takes [cid, bytes] tuples and hits the same batched store path.
+		// This method must return a synchronous string[] (RemoteBlocks.putKnownManyColumns
+		// consumes the result synchronously), so the durable write cannot be awaited
+		// inline. Track it instead of `void`ing it so a durable rejection surfaces
+		// on the next awaited wrapper method / stop() rather than being swallowed.
 		const durableBlocks = cids.map(
 			(cid, index) => [cid, bytes[index]!] as const,
 		);
-		void this.durable.putKnownMany(durableBlocks);
+		this.trackDurable(this.durable.putKnownMany(durableBlocks));
 		return stored;
 	}
 
 	// --- reads (native/wasm first; on miss, durable fallback + repopulate) ---
-	get(cid: string): Uint8Array | undefined {
+	// RemoteBlocks.get awaits this single-get, so on a native miss consult the
+	// durable store (like getMany does) and repopulate the native map, rather
+	// than returning undefined and only scheduling a background repopulate. That
+	// avoids a spurious miss (which would otherwise fall through to a remote
+	// read) for a block that is present on disk.
+	async get(cid: string, _options?: unknown): Promise<Uint8Array | undefined> {
 		const local = this.native.get(cid);
 		if (local != null) {
 			return local;
 		}
-		// Synchronous native miss. Fall back to durable asynchronously and
-		// repopulate the native map so the native graph can read it next time.
-		// The synchronous contract can only answer with what native has, so a
-		// miss here still returns undefined; the async repopulation is
-		// best-effort for subsequent reads. RemoteBlocks always calls the async
-		// getMany path for DAG walks, so this rarely matters, but keep the
-		// side-effect for parity with getMany's fallback.
-		void this.repopulateFromDurable([cid]);
+		const durableValue = await this.durable.get(cid);
+		if (durableValue != null) {
+			// Repopulate the native map so the native graph reads it next time.
+			this.native.putKnownManyColumns([cid], [durableValue]);
+			return durableValue;
+		}
 		return undefined;
 	}
 
@@ -601,37 +666,22 @@ class NativeBackboneWriteThroughBlockStore {
 		return nativeHas;
 	}
 
-	private async repopulateFromDurable(cids: string[]): Promise<void> {
-		try {
-			const values = await this.durable.getMany(cids);
-			const repopulateCids: string[] = [];
-			const repopulateBytes: Uint8Array[] = [];
-			for (let i = 0; i < values.length; i++) {
-				const value = values[i];
-				if (value != null) {
-					repopulateCids.push(cids[i]!);
-					repopulateBytes.push(value);
-				}
-			}
-			if (repopulateCids.length > 0) {
-				this.native.putKnownManyColumns(repopulateCids, repopulateBytes);
-			}
-		} catch {
-			// Best-effort background repopulation; ignore failures.
-		}
-	}
-
 	// --- removes (apply to BOTH) ----------------------------------------
-	rm(cid: string): void {
+	// Native rm is synchronous; the durable rm is awaited so the returned promise
+	// resolves only after both succeed and a durable failure rejects here rather
+	// than being swallowed. All rm callers (RemoteBlocks.rm, the log) await it.
+	async rm(cid: string): Promise<void> {
+		await this.drainDurable();
 		this.native.rm(cid);
-		void this.durable.rm(cid);
+		await this.durable.rm(cid);
 	}
 
 	del(cid: string): void {
-		this.rm(cid);
+		void this.rm(cid);
 	}
 
 	async rmMany(cids: string[]): Promise<number> {
+		await this.drainDurable();
 		const removed = await this.native.rmMany(cids);
 		await this.durable.rmMany(cids);
 		return removed;
@@ -6605,6 +6655,13 @@ export class SharedLog<
 			return undefined;
 		}
 		const backbone = this._nativeBackbone;
+		// When the durable write-through wrapper is active the log's block store
+		// (this.remoteBlocks.localStore) is the wrapper, NOT the raw wasm block map
+		// (backbone.blocks), so this comparison is false. In that case the block
+		// must be written through to durable; see the guarded handling in the
+		// prepare callback below.
+		const durableWrapperActive =
+			this.remoteBlocks?.localStore !== backbone.blocks;
 		let nativeBackboneDocumentIndexCommitted = false;
 		let committedNativeBackboneDocumentIndex:
 			| NativeBackboneDocumentIndexCommitInput
@@ -6673,11 +6730,36 @@ export class SharedLog<
 					},
 					backbone.blocks,
 				);
-				if (
-					prepared &&
-					!prepared.bytes &&
-					this.remoteBlocks?.localStore === backbone.blocks
-				) {
+				if (prepared && !prepared.bytes) {
+					if (durableWrapperActive) {
+						// The durable write-through wrapper is active, so the block store
+						// the log writes through (this.remoteBlocks.localStore) is the
+						// wrapper, NOT the raw wasm block map. prepareEntryV0PlainEntryCommit
+						// committed the block into the wasm map ONLY and returned no raw
+						// bytes, so on its own the block would never reach durable (log's
+						// finishBlocks only calls putKnown* when prepared.bytes is set) and
+						// a non-replicating native node would lose it on restart.
+						//
+						// Attach the just-committed block's bytes (read back from the wasm
+						// store) as prepared.bytes so the log's finishBlocks writes them
+						// through: putPreparedAppendBlocks -> this._storage.putKnown* ->
+						// wrapper -> durable. This mirrors how the sibling storage-transaction
+						// path defers block storage to the JS store when commitBlocksInBackbone
+						// is false, and keeps strict-native mode working (it still returns a
+						// valid prepared result rather than bailing).
+						const preparedHash = prepared.cid ?? prepared.hash;
+						const committedBytes = preparedHash
+							? backbone.blocks.get(preparedHash)
+							: undefined;
+						if (committedBytes) {
+							return {
+								...prepared,
+								bytes: committedBytes,
+							};
+						}
+					}
+					// No wrapper (memory-only native node): the block lives in the wasm
+					// map and needs no durable mirror; expose getBytes for materialization.
 					return {
 						...prepared,
 						getBytes: (hash: string) => backbone.blocks.get(hash),

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -464,12 +464,16 @@ class NativeBackboneWriteThroughBlockStore {
 
 	// --- lifecycle -------------------------------------------------------
 	// The native store's lifecycle hooks are no-ops; only the durable store
-	// needs starting/stopping. Rehydration of the wasm map from disk happens in
-	// start(), i.e. before RemoteBlocks resolves its own start() and therefore
-	// before the log opens and walks the DAG.
+	// needs starting/stopping. The wasm map is NOT eagerly rehydrated from disk:
+	// entry blocks are pulled back lazily on demand through the read fallback in
+	// getMany()/get() (durable hit -> repopulate the wasm map), which is what the
+	// log's DAG walk (EntryIndex.resolveMany -> store.getMany) exercises. Keeping
+	// the wasm map cold on open is required by the strict-native resident
+	// coordinate-state optimization: a reopened non-replicating native node must
+	// report hasBlock(head) === false and answer a same-signer append from the
+	// persisted coordinate + signer facts without resolving the entry block.
 	async start(): Promise<void> {
 		await this.durable.start();
-		await this.rehydrateNativeFromDurable();
 	}
 
 	async stop(): Promise<void> {
@@ -487,32 +491,18 @@ class NativeBackboneWriteThroughBlockStore {
 		return Promise.resolve([]);
 	}
 
-	/**
-	 * Copy every durable block into the native wasm block map so the native
-	 * graph can read entry blocks after a restart. Uses the columnar
-	 * `putKnownManyColumns` fast path in bounded batches. Idempotent and cheap
-	 * when durable is empty (fresh program).
-	 */
-	private async rehydrateNativeFromDurable(): Promise<void> {
-		const BATCH = 256;
-		let cids: string[] = [];
-		let bytes: Uint8Array[] = [];
-		const flush = () => {
-			if (cids.length === 0) {
-				return;
-			}
-			this.native.putKnownManyColumns(cids, bytes);
-			cids = [];
-			bytes = [];
-		};
-		for await (const [cid, value] of this.durable.iterator()) {
-			cids.push(cid);
-			bytes.push(value);
-			if (cids.length >= BATCH) {
-				flush();
-			}
-		}
-		flush();
+	// Mirror a single already-committed block (present in the wasm map) to the
+	// durable store ONLY. Used by the native commit-only append fast path: the
+	// native prepare commits the entry block into the wasm map and returns no raw
+	// bytes, and the strict-native resident-coordinate path deliberately does NOT
+	// route the block through the log's finishBlocks/putKnown* (that would disturb
+	// the commit-only append path the RCS optimization depends on). Instead the
+	// caller reads the committed bytes back and calls this so the block lands in
+	// durable directly. Like putKnownManyColumns' durable mirror, the write is
+	// tracked (not fire-and-forget) so an IO/disk-full failure surfaces on the
+	// next awaited wrapper method / stop() rather than being swallowed.
+	mirrorToDurable(cid: string, bytes: Uint8Array): void {
+		this.trackDurable(this.durable.putKnown(cid, bytes));
 	}
 
 	// --- writes (apply to BOTH: native first for the hot path, then durable) ---
@@ -6658,10 +6648,20 @@ export class SharedLog<
 		// When the durable write-through wrapper is active the log's block store
 		// (this.remoteBlocks.localStore) is the wrapper, NOT the raw wasm block map
 		// (backbone.blocks), so this comparison is false. In that case the block
-		// must be written through to durable; see the guarded handling in the
+		// must be mirrored to durable directly; see the guarded handling in the
 		// prepare callback below.
 		const durableWrapperActive =
 			this.remoteBlocks?.localStore !== backbone.blocks;
+		// The write-through wrapper instance, captured only when active, so the
+		// commit-only block can be mirrored to durable WITHOUT routing it through
+		// the log's finishBlocks/putKnown* (which would disturb the strict-native
+		// resident-coordinate append path). `mirrorToDurable` writes to the durable
+		// side only and tracks the write for error-surfacing.
+		const durableWrapper = durableWrapperActive
+			? (this.remoteBlocks?.localStore as unknown as {
+					mirrorToDurable?: (cid: string, bytes: Uint8Array) => void;
+				})
+			: undefined;
 		let nativeBackboneDocumentIndexCommitted = false;
 		let committedNativeBackboneDocumentIndex:
 			| NativeBackboneDocumentIndexCommitInput
@@ -6731,7 +6731,7 @@ export class SharedLog<
 					backbone.blocks,
 				);
 				if (prepared && !prepared.bytes) {
-					if (durableWrapperActive) {
+					if (durableWrapper) {
 						// The durable write-through wrapper is active, so the block store
 						// the log writes through (this.remoteBlocks.localStore) is the
 						// wrapper, NOT the raw wasm block map. prepareEntryV0PlainEntryCommit
@@ -6740,26 +6740,28 @@ export class SharedLog<
 						// finishBlocks only calls putKnown* when prepared.bytes is set) and
 						// a non-replicating native node would lose it on restart.
 						//
-						// Attach the just-committed block's bytes (read back from the wasm
-						// store) as prepared.bytes so the log's finishBlocks writes them
-						// through: putPreparedAppendBlocks -> this._storage.putKnown* ->
-						// wrapper -> durable. This mirrors how the sibling storage-transaction
-						// path defers block storage to the JS store when commitBlocksInBackbone
-						// is false, and keeps strict-native mode working (it still returns a
-						// valid prepared result rather than bailing).
+						// Mirror the just-committed block (read back from the wasm store)
+						// straight to the DURABLE side of the wrapper. Crucially we do NOT
+						// attach prepared.bytes: doing so would make the log's finishBlocks
+						// call putKnown*, which changes the commit-only append path and
+						// breaks the strict-native resident-coordinate optimization (the
+						// reopen tests assert the append stays native and resolves no entry
+						// block). Instead the prepared result is returned exactly as the
+						// memory-only branch below (getBytes only, no bytes), so the log's
+						// finishBlocks path is UNCHANGED, and the block is made durable
+						// out-of-band here. mirrorToDurable tracks the write so an IO/
+						// disk-full failure surfaces on a later awaited wrapper method.
 						const preparedHash = prepared.cid ?? prepared.hash;
 						const committedBytes = preparedHash
 							? backbone.blocks.get(preparedHash)
 							: undefined;
-						if (committedBytes) {
-							return {
-								...prepared,
-								bytes: committedBytes,
-							};
+						if (committedBytes && durableWrapper.mirrorToDurable) {
+							durableWrapper.mirrorToDurable(preparedHash!, committedBytes);
 						}
 					}
-					// No wrapper (memory-only native node): the block lives in the wasm
-					// map and needs no durable mirror; expose getBytes for materialization.
+					// The block lives in the wasm map; expose getBytes for materialization
+					// (identical to the memory-only native node path). When the durable
+					// wrapper is active the durable copy was mirrored just above.
 					return {
 						...prepared,
 						getBytes: (hash: string) => backbone.blocks.get(hash),
@@ -6858,8 +6860,26 @@ export class SharedLog<
 						NativePeerbitBackbone["preparePlainCommittedNoNextStorageAppendTransaction"]
 				  >
 				| undefined;
+			// The write-through durable wrapper, when active, is captured here so a
+			// just-committed block can be mirrored to durable without disturbing the
+			// strict-native commit path. When the wrapper is active the log's block
+			// store is the wrapper (not the raw wasm map), so `localStore ===
+			// backbone.blocks` is false — but the store is still native-backed, so we
+			// must commit blocks in the backbone (the committed native prepare variant
+			// is the one that emits the document-signer journal record; the
+			// block-deferring variant does not, which would otherwise leave
+			// document-signers.wal unwritten and break same-signer facts after
+			// reopen). The block is then mirrored to durable out-of-band below.
+			const durableWrapperActive =
+				this.remoteBlocks?.localStore !== backbone.blocks;
+			const durableWrapper = durableWrapperActive
+				? (this.remoteBlocks?.localStore as unknown as {
+						mirrorToDurable?: (cid: string, bytes: Uint8Array) => void;
+					})
+				: undefined;
 			const commitBlocksInBackbone =
-				this.remoteBlocks?.localStore === backbone.blocks;
+				this.remoteBlocks?.localStore === backbone.blocks ||
+				durableWrapperActive;
 			let nativeBackboneDocumentIndexCommitted = false;
 			let nativeBackboneDocumentDeleteCommitted = false;
 			let committedNativeBackboneDocumentIndex:
@@ -6983,6 +7003,23 @@ export class SharedLog<
 					!!nativeBackboneDocumentDeleteKey;
 				const useTrimmedHashesOnly =
 					properties?.resolveTrimmedEntries === false;
+				if (durableWrapper?.mirrorToDurable) {
+					// The block was committed into the wasm map (commitBlocksInBackbone is
+					// true) but not into durable, because the log's finishBlocks path is
+					// left UNCHANGED for strict-native mode (getBytes only, no bytes, so
+					// no putKnown* through the wrapper). Mirror the just-committed block
+					// straight to the durable side so a non-replicating native node keeps
+					// it across a restart. mirrorToDurable tracks the write for
+					// error-surfacing.
+					const committedHash =
+						backboneAppend.entry.cid ?? backboneAppend.entry.hash;
+					const committedBytes = committedHash
+						? backbone.blocks.get(committedHash)
+						: undefined;
+					if (committedBytes) {
+						durableWrapper.mirrorToDurable(committedHash!, committedBytes);
+					}
+				}
 				return {
 					...backboneAppend.entry,
 					gid: backboneAppend.coordinate.gid,
@@ -7545,12 +7582,25 @@ export class SharedLog<
 			options?.target !== "none" ||
 			options?.replicate === true ||
 			(options?.delivery !== undefined && options.delivery !== false) ||
-			this.remoteBlocks?.localStore !== backbone.blocks ||
 			!this.canUseNativeBackboneResidentCoordinateState() ||
 			properties?.nexts?.some((nexts) => nexts.length > 0)
 		) {
 			return undefined;
 		}
+		// When the durable write-through wrapper is active the log's block store is
+		// the wrapper, not the raw wasm map, so `localStore === backbone.blocks` is
+		// false. This batch path always commits blocks in the backbone (the
+		// committed native batch prepare variants), so it is safe with the wrapper:
+		// the blocks land in wasm and are mirrored to durable per-entry below. This
+		// preserves the resident-coordinate fast batch path (and its meta.next
+		// linking) after a reopen instead of bailing to a slow generic path.
+		const durableWrapperActive =
+			this.remoteBlocks?.localStore !== backbone.blocks;
+		const durableWrapper = durableWrapperActive
+			? (this.remoteBlocks?.localStore as unknown as {
+					mirrorToDurable?: (cid: string, bytes: Uint8Array) => void;
+				})
+			: undefined;
 		const usesLatestDocumentContext = documentIndexes.every(
 			(index) => index.useLatestContext === true,
 		);
@@ -7677,6 +7727,21 @@ export class SharedLog<
 		for (let i = 0; i < appended.appendFacts.length; i++) {
 			const facts = appended.appendFacts[i]!;
 			const backboneAppend = backboneAppends[i]!;
+			if (durableWrapper?.mirrorToDurable) {
+				// The batch prepare committed each block into the wasm map; the log's
+				// finishBlocks path is left unchanged (getBytes only) to preserve
+				// strict-native mode, so mirror the committed block straight to durable
+				// so a non-replicating native node keeps it across a restart. Tracked
+				// for error-surfacing by mirrorToDurable.
+				const committedHash =
+					backboneAppend.entry.cid ?? backboneAppend.entry.hash;
+				const committedBytes = committedHash
+					? backbone.blocks.get(committedHash)
+					: undefined;
+				if (committedBytes) {
+					durableWrapper.mirrorToDurable(committedHash!, committedBytes);
+				}
+			}
 			const coordinateFields = this.createCoordinateFieldsFromNativePlanFacts({
 				appendFacts: facts,
 				plan: backboneAppend.coordinate,

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -382,6 +382,277 @@ const joinNativeCoordinateDirectory = (
 	fsSafeLogId: string,
 ): string => `${nodeDirectory.replace(/[/\\]+$/, "")}/coordinates/${fsSafeLogId}`;
 
+/** The native backbone's in-wasm-memory block store. */
+type NativeBackboneBlocks = NativePeerbitBackbone["blocks"];
+
+/**
+ * Write-through block store bridging the native backbone's in-wasm-memory block
+ * store to a durable per-program {@link AnyBlockStore}.
+ *
+ * WHY: when the native backbone is active the log's entry blocks live only in
+ * the native wasm block map (`NativeBackboneBlockStore.persisted() === false`).
+ * On a restart that map is empty, so the native graph cannot reload heads the
+ * durable heads index still lists ("Failed to load entry from head"). This
+ * wrapper mirrors every write into the same durable `blocks` sublevel the
+ * non-native path uses, and on open rehydrates the wasm map from disk so the
+ * native graph can walk the DAG again.
+ *
+ * The native store stays the authoritative hot store the native graph reads
+ * from: reads hit native first and only fall back to durable (repopulating
+ * native on a hit so subsequent native-graph reads succeed).
+ *
+ * METHOD SURFACE (see #1006): `RemoteBlocks` and the log feature-detect the
+ * optional batch methods (`putMany`/`putKnown`/`putKnownMany`/
+ * `putKnownManyColumns`/`rmMany`). To keep the receive-fusion / columnar fast
+ * paths engaged this wrapper exposes EXACTLY the methods the native store
+ * exposes — including `putKnownManyColumns`, which `AnyBlockStore` does not have
+ * — and delegates each. It deliberately does not add methods the native store
+ * lacks (`getBlockResponsePayload`/`getNativeLogBlockStoreHandle` stay absent so
+ * the optional-chained probes in `RemoteBlocks` behave exactly as today).
+ */
+class NativeBackboneWriteThroughBlockStore {
+	constructor(
+		private readonly native: NativeBackboneBlocks,
+		private readonly durable: AnyBlockStore,
+	) {}
+
+	// --- lifecycle -------------------------------------------------------
+	// The native store's lifecycle hooks are no-ops; only the durable store
+	// needs starting/stopping. Rehydration of the wasm map from disk happens in
+	// start(), i.e. before RemoteBlocks resolves its own start() and therefore
+	// before the log opens and walks the DAG.
+	async start(): Promise<void> {
+		await this.durable.start();
+		await this.rehydrateNativeFromDurable();
+	}
+
+	async stop(): Promise<void> {
+		await this.durable.stop();
+	}
+
+	status() {
+		return this.durable.status();
+	}
+
+	waitFor(): Promise<string[]> {
+		return Promise.resolve([]);
+	}
+
+	/**
+	 * Copy every durable block into the native wasm block map so the native
+	 * graph can read entry blocks after a restart. Uses the columnar
+	 * `putKnownManyColumns` fast path in bounded batches. Idempotent and cheap
+	 * when durable is empty (fresh program).
+	 */
+	private async rehydrateNativeFromDurable(): Promise<void> {
+		const BATCH = 256;
+		let cids: string[] = [];
+		let bytes: Uint8Array[] = [];
+		const flush = () => {
+			if (cids.length === 0) {
+				return;
+			}
+			this.native.putKnownManyColumns(cids, bytes);
+			cids = [];
+			bytes = [];
+		};
+		for await (const [cid, value] of this.durable.iterator()) {
+			cids.push(cid);
+			bytes.push(value);
+			if (cids.length >= BATCH) {
+				flush();
+			}
+		}
+		flush();
+	}
+
+	// --- writes (apply to BOTH: native first for the hot path, then durable) ---
+	async put(
+		data: Uint8Array | { block: { bytes: Uint8Array }; cid: string },
+	): Promise<string> {
+		const cid = await this.native.put(data as any);
+		// The native store computes a raw-codec CID for a `Uint8Array`, storing
+		// the bytes verbatim (raw codec is identity), and stores `block.bytes`
+		// for the pre-CIDed object form. Either way the input bytes match what
+		// native stored, so feed durable the known cid+bytes without recomputing.
+		const value =
+			data instanceof Uint8Array
+				? data
+				: (data as { block: { bytes: Uint8Array } }).block.bytes;
+		await this.durable.putKnown(cid, value);
+		return cid;
+	}
+
+	async putMany(
+		blocks: Array<Uint8Array | { block: { bytes: Uint8Array }; cid: string }>,
+	): Promise<string[]> {
+		const cids = await this.native.putMany(blocks as any);
+		const durableBlocks: Array<readonly [string, Uint8Array]> = cids.map(
+			(cid, index) => {
+				const block = blocks[index]!;
+				const value =
+					block instanceof Uint8Array
+						? block
+						: (block as { block: { bytes: Uint8Array } }).block.bytes;
+				return [cid, value] as const;
+			},
+		);
+		await this.durable.putKnownMany(durableBlocks);
+		return cids;
+	}
+
+	putKnown(cid: string, bytes: Uint8Array): string {
+		const stored = this.native.putKnown(cid, bytes);
+		void this.durable.putKnown(cid, bytes);
+		return stored;
+	}
+
+	putKnownMany(
+		blocks: Array<readonly [cid: string, bytes: Uint8Array]>,
+	): string[] {
+		const cids = this.native.putKnownMany(blocks);
+		void this.durable.putKnownMany(blocks);
+		return cids;
+	}
+
+	putKnownManyColumns(cids: string[], bytes: Uint8Array[]): string[] {
+		const stored = this.native.putKnownManyColumns(cids, bytes);
+		// AnyBlockStore has no columnar method; mirror via putKnownMany, which
+		// takes [cid, bytes] tuples and hits the same batched store path.
+		const durableBlocks = cids.map(
+			(cid, index) => [cid, bytes[index]!] as const,
+		);
+		void this.durable.putKnownMany(durableBlocks);
+		return stored;
+	}
+
+	// --- reads (native/wasm first; on miss, durable fallback + repopulate) ---
+	get(cid: string): Uint8Array | undefined {
+		const local = this.native.get(cid);
+		if (local != null) {
+			return local;
+		}
+		// Synchronous native miss. Fall back to durable asynchronously and
+		// repopulate the native map so the native graph can read it next time.
+		// The synchronous contract can only answer with what native has, so a
+		// miss here still returns undefined; the async repopulation is
+		// best-effort for subsequent reads. RemoteBlocks always calls the async
+		// getMany path for DAG walks, so this rarely matters, but keep the
+		// side-effect for parity with getMany's fallback.
+		void this.repopulateFromDurable([cid]);
+		return undefined;
+	}
+
+	async getMany(cids: string[]): Promise<Array<Uint8Array | undefined>> {
+		const results = await this.native.getMany(cids);
+		const missing: string[] = [];
+		for (let i = 0; i < results.length; i++) {
+			if (results[i] == null) {
+				missing.push(cids[i]!);
+			}
+		}
+		if (missing.length === 0) {
+			return results;
+		}
+		const durableValues = await this.durable.getMany(missing);
+		const repopulateCids: string[] = [];
+		const repopulateBytes: Uint8Array[] = [];
+		let missingIndex = 0;
+		for (let i = 0; i < results.length; i++) {
+			if (results[i] != null) {
+				continue;
+			}
+			const value = durableValues[missingIndex++];
+			if (value != null) {
+				results[i] = value;
+				repopulateCids.push(cids[i]!);
+				repopulateBytes.push(value);
+			}
+		}
+		if (repopulateCids.length > 0) {
+			// Repopulate the native map so the native graph sees these blocks.
+			this.native.putKnownManyColumns(repopulateCids, repopulateBytes);
+		}
+		return results;
+	}
+
+	has(cid: string): boolean {
+		return this.native.has(cid);
+	}
+
+	async hasMany(cids: string[]): Promise<boolean[]> {
+		const nativeHas = await this.native.hasMany(cids);
+		const missing: string[] = [];
+		for (let i = 0; i < nativeHas.length; i++) {
+			if (!nativeHas[i]) {
+				missing.push(cids[i]!);
+			}
+		}
+		if (missing.length === 0) {
+			return nativeHas;
+		}
+		const durableHas = await this.durable.hasMany(missing);
+		let missingIndex = 0;
+		for (let i = 0; i < nativeHas.length; i++) {
+			if (!nativeHas[i]) {
+				nativeHas[i] = durableHas[missingIndex++]!;
+			}
+		}
+		return nativeHas;
+	}
+
+	private async repopulateFromDurable(cids: string[]): Promise<void> {
+		try {
+			const values = await this.durable.getMany(cids);
+			const repopulateCids: string[] = [];
+			const repopulateBytes: Uint8Array[] = [];
+			for (let i = 0; i < values.length; i++) {
+				const value = values[i];
+				if (value != null) {
+					repopulateCids.push(cids[i]!);
+					repopulateBytes.push(value);
+				}
+			}
+			if (repopulateCids.length > 0) {
+				this.native.putKnownManyColumns(repopulateCids, repopulateBytes);
+			}
+		} catch {
+			// Best-effort background repopulation; ignore failures.
+		}
+	}
+
+	// --- removes (apply to BOTH) ----------------------------------------
+	rm(cid: string): void {
+		this.native.rm(cid);
+		void this.durable.rm(cid);
+	}
+
+	del(cid: string): void {
+		this.rm(cid);
+	}
+
+	async rmMany(cids: string[]): Promise<number> {
+		const removed = await this.native.rmMany(cids);
+		await this.durable.rmMany(cids);
+		return removed;
+	}
+
+	// --- misc ------------------------------------------------------------
+	async *iterator(): AsyncGenerator<[string, Uint8Array], void, void> {
+		yield* this.native.iterator();
+	}
+
+	size(): number {
+		return this.native.size();
+	}
+
+	persisted(): boolean {
+		// The blocks are now mirrored to a durable store, so report persisted so
+		// callers that gate durable-only behavior on this flag behave correctly.
+		return true;
+	}
+}
+
 type LeaderMap = Map<string, { intersecting: boolean }>;
 
 type LeaderSelectionOptions<R extends "u32" | "u64"> = {
@@ -8643,9 +8914,28 @@ export class SharedLog<
 			this._wireSyncSession = wireSyncSession;
 			wireSyncSession.registerTopic(this.topic);
 		}
-		const localBlocks = this._nativeBackbone
-			? this._nativeBackbone.blocks
-			: new AnyBlockStore(await storage.sublevel("blocks"));
+		// Block store selection:
+		// - No native backbone: durable per-program cache (unchanged default).
+		// - Native backbone WITHOUT a durable directory (memory-only node): the
+		//   wasm-memory native store only (unchanged prior behavior).
+		// - Native backbone WITH a durable directory: a write-through wrapper that
+		//   mirrors the native wasm store to the SAME durable `blocks` sublevel the
+		//   default path uses, and rehydrates the wasm map from disk on open. This
+		//   is what makes native entry blocks survive a restart so heads reload.
+		let localBlocks: NonNullable<RemoteBlocks["localStore"]>;
+		if (this._nativeBackbone) {
+			if (this.node.directory != null) {
+				const durable = new AnyBlockStore(await storage.sublevel("blocks"));
+				localBlocks = new NativeBackboneWriteThroughBlockStore(
+					this._nativeBackbone.blocks,
+					durable,
+				) as unknown as NonNullable<RemoteBlocks["localStore"]>;
+			} else {
+				localBlocks = this._nativeBackbone.blocks;
+			}
+		} else {
+			localBlocks = new AnyBlockStore(await storage.sublevel("blocks"));
+		}
 		this.remoteBlocks = new RemoteBlocks({
 			local: localBlocks,
 			publish: (message, options) =>

--- a/packages/programs/data/shared-log/test/coordinate-persistence-restart.spec.ts
+++ b/packages/programs/data/shared-log/test/coordinate-persistence-restart.spec.ts
@@ -1,0 +1,173 @@
+// Gate for the "durable persistence — first slice": a native node started with
+// an on-disk storage `directory` AUTO-PERSISTS its shared-log replication
+// coordinates per-program, rooted at `<directory>/coordinates/<hex(log.id)>`,
+// so the coordinates survive a clean stop and can be re-hydrated from disk
+// WITHOUT any peer to re-derive them from.
+//
+// Before this slice, the coordinate-persistence machinery
+// (NativeBackboneCoordinatePersistence + the Node coordinate store +
+// hydrate/flush) was only activated when a caller passed an explicit
+// `options.coordinatePersistence`. Nothing derived it from the client
+// directory. This test exercises the auto-wire: a `peerbit/rust` client with a
+// `directory` derives the store itself.
+//
+// SCOPE / KNOWN BLOCKER (verified, see the PR notes): a *full* program reopen
+// on the same directory does NOT yet resurrect the log, because when the native
+// backbone is active the log's entry blocks are held in the backbone's
+// wasm-memory block store rather than the durable program block cache
+// (`shared-log/src/index.ts`: `localBlocks = this._nativeBackbone.blocks : new
+// AnyBlockStore(await storage.sublevel("blocks"))`). On restart the heads index
+// still lists the head hashes but the entry blocks backing them are gone, so
+// `log.getHeads(true).all()` fails with "Failed to load entry from head".
+// Making native-backbone entry blocks durable is a separate, upstream piece of
+// work (flush ordering across the block store) and is intentionally out of
+// scope for this slice. This test therefore proves the coordinate layer that
+// this slice adds — WAL written under the auto-derived namespace on clean stop,
+// and those coordinates restored from that same directory into a fresh
+// backbone — which is exactly the gap this slice closes.
+import { toHexString } from "@peerbit/crypto";
+import {
+	NativeBackboneCoordinatePersistence,
+	NativeBackboneNodeCoordinatePersistenceStore,
+	createNativePeerbitBackbone,
+} from "@peerbit/native-backbone";
+import { expect } from "chai";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { Peerbit } from "peerbit";
+import { createRustPeerbitOptions } from "peerbit/rust";
+import { EventStore } from "./utils/stores/event-store.js";
+
+const fileExists = async (target: string): Promise<boolean> => {
+	try {
+		await fs.stat(target);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+describe("coordinate persistence auto-wire", function () {
+	this.timeout(120_000);
+
+	let client: Peerbit | undefined;
+	let directory: string | undefined;
+
+	afterEach(async () => {
+		await client?.stop();
+		client = undefined;
+		if (directory) {
+			await fs.rm(directory, { recursive: true, force: true });
+			directory = undefined;
+		}
+	});
+
+	it("auto-persists coordinates to disk and restores them from that directory with no peer", async () => {
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-coordinate-persist-"),
+		);
+
+		// A deterministic program id keeps the log.id (coordinate namespace)
+		// stable and makes the on-disk directory predictable.
+		const storeId = new Uint8Array(32);
+		for (let index = 0; index < storeId.length; index++) {
+			storeId[index] = (index * 7 + 3) & 0xff;
+		}
+		const coordinateNamespace = toHexString(storeId);
+		const coordinateDir = path.join(
+			directory,
+			"coordinates",
+			coordinateNamespace,
+		);
+
+		const entryCount = 8;
+
+		// --- Session 1: on-disk client, append + commit, capture coordinates ---
+		// Network is enabled so the native backbone activates; no peer is ever
+		// dialed, so the only source of coordinates on the next open is disk.
+		client = await Peerbit.create({
+			directory,
+			...createRustPeerbitOptions(),
+		});
+
+		const store1 = await client.open(
+			new EventStore<string, any>({ id: storeId }),
+			{
+				args: { replicate: { factor: 1 } },
+			},
+		);
+
+		const log1 = store1.log as any;
+		// The auto-wire only makes sense with the native backbone present, and
+		// must have derived a coordinate persistence adapter (no explicit config
+		// was passed) because the node has an on-disk directory.
+		expect(log1._nativeBackbone, "session 1 native backbone").to.exist;
+		expect(
+			log1._nativeBackboneCoordinatePersistence,
+			"session 1 auto-derived coordinate persistence",
+		).to.exist;
+
+		// Independent heads so each entry produces its own coordinate.
+		for (let index = 0; index < entryCount; index++) {
+			await store1.add(`entry-${index}`, { meta: { next: [] } });
+		}
+
+		const preRestartHashes = [
+			...(log1._nativeBackbone.getEntryCoordinateHashes() as string[]),
+		].sort();
+		expect(
+			preRestartHashes.length,
+			"session 1 should have coordinates for every entry",
+		).to.equal(entryCount);
+
+		const identity = client.identity;
+
+		// A clean close flushes the coordinate WAL and closes the store.
+		await client.stop();
+		client = undefined;
+
+		// The per-program coordinate directory and its WAL/snapshot must be on
+		// disk under the auto-derived `<dir>/coordinates/<hex(id)>` namespace.
+		expect(
+			await fileExists(coordinateDir),
+			`coordinate directory ${coordinateDir}`,
+		).to.equal(true);
+		const walOnDisk = await fileExists(
+			path.join(coordinateDir, "coordinates.wal"),
+		);
+		const snapshotOnDisk = await fileExists(
+			path.join(coordinateDir, "coordinates.bin"),
+		);
+		expect(
+			walOnDisk || snapshotOnDisk,
+			`coordinates.wal or coordinates.bin under ${coordinateDir}`,
+		).to.equal(true);
+
+		// --- Restore: hydrate a fresh backbone straight from that directory ---
+		// This mirrors what shared-log's auto-wire does on reopen (construct the
+		// same Node store rooted at the per-program directory and hydrate), but
+		// isolated from the separate native block-store durability gap noted at
+		// the top of this file. No peer exists; the coordinates come from disk.
+		const store = new NativeBackboneNodeCoordinatePersistenceStore(
+			coordinateDir,
+		);
+		const persistence = new NativeBackboneCoordinatePersistence(store);
+		const restored = await createNativePeerbitBackbone({
+			clockId: identity.publicKey.bytes,
+			privateKey: identity.privateKey.privateKey,
+			publicKey: identity.publicKey.publicKey,
+		});
+		await persistence.hydrate(restored);
+
+		const restoredHashes = [
+			...(restored.getEntryCoordinateHashes() as string[]),
+		].sort();
+
+		expect(
+			restoredHashes,
+			"restored coordinates match the pre-restart coordinates",
+		).to.deep.equal(preRestartHashes);
+		expect(restoredHashes.length).to.equal(entryCount);
+	});
+});

--- a/packages/programs/data/shared-log/test/durable-native-restart.spec.ts
+++ b/packages/programs/data/shared-log/test/durable-native-restart.spec.ts
@@ -1,0 +1,174 @@
+// Full end-to-end gate for the "durable native block store" slice: a native
+// `peerbit/rust` client on an on-disk `directory` must be able to REOPEN a
+// program after a clean stop -> restart WITHOUT any peer, with its entry blocks,
+// heads and coordinates all restored from disk.
+//
+// Background: when the native backbone is active the log's entry blocks live in
+// the backbone's in-wasm-memory block store (`NativeBackboneBlockStore`,
+// `persisted() === false`). Before this slice, on restart that map was empty, so
+// even though the durable heads index still listed the head hashes, the entry
+// blocks backing them were gone and `log.getHeads(true).all()` failed with
+// "Failed to load entry from head" (see entry-index.ts `resolveMany`). The
+// coordinate-persistence slice already restores replication coordinates; this
+// slice makes the entry blocks durable via a write-through wrapper over the
+// native wasm store and a durable per-program `blocks` sublevel, and rehydrates
+// the wasm map from that sublevel on open.
+//
+// This test proves the real durable native restart:
+//   (i)  the program reopens WITHOUT "Failed to load entry from head",
+//   (ii) all N documents are queryable locally (blocks survived),
+//   (iii) the log length / heads match pre-restart,
+//   (iv) coordinates are restored (kept green here; the isolated coordinate
+//        proof lives in coordinate-persistence-restart.spec.ts).
+import { expect } from "chai";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { Peerbit } from "peerbit";
+import { createRustPeerbitOptions } from "peerbit/rust";
+import { EventStore } from "./utils/stores/event-store.js";
+
+describe("durable native block store restart", function () {
+	this.timeout(120_000);
+
+	let client: Peerbit | undefined;
+	let directory: string | undefined;
+
+	afterEach(async () => {
+		await client?.stop();
+		client = undefined;
+		if (directory) {
+			await fs.rm(directory, { recursive: true, force: true });
+			directory = undefined;
+		}
+	});
+
+	it("reopens a native program from disk with blocks, heads and coordinates restored", async () => {
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-durable-native-restart-"),
+		);
+
+		// Deterministic program id keeps the on-disk layout predictable.
+		const storeId = new Uint8Array(32);
+		for (let index = 0; index < storeId.length; index++) {
+			storeId[index] = (index * 11 + 5) & 0xff;
+		}
+
+		const entryCount = 8;
+
+		// --- Session 1: on-disk native client, append + commit N docs ---------
+		// Network is enabled so the native backbone activates; no peer is ever
+		// dialed, so the only source of blocks/heads/coordinates on the next open
+		// is disk.
+		client = await Peerbit.create({
+			directory,
+			...createRustPeerbitOptions(),
+		});
+
+		const store1 = await client.open(
+			new EventStore<string, any>({ id: storeId }),
+			{ args: { replicate: { factor: 1 } } },
+		);
+
+		const log1 = store1.log as any;
+		expect(log1._nativeBackbone, "session 1 native backbone").to.exist;
+		expect(
+			log1._nativeBackboneCoordinatePersistence,
+			"session 1 auto-derived coordinate persistence",
+		).to.exist;
+
+		for (let index = 0; index < entryCount; index++) {
+			await store1.add(`entry-${index}`, { meta: { next: [] } });
+		}
+
+		const preRestartValues = (await store1.iterator({ limit: entryCount }))
+			.collect()
+			.map((entry: any) => entry.payload.getValue().value)
+			.sort();
+		expect(preRestartValues.length, "session 1 document count").to.equal(
+			entryCount,
+		);
+
+		const preRestartLength = store1.log.log.length;
+		const preRestartHeads = (await store1.log.log.getHeads(true).all())
+			.map((entry: any) => entry.hash)
+			.sort();
+		const preRestartCoordinateHashes = [
+			...(log1._nativeBackbone.getEntryCoordinateHashes() as string[]),
+		].sort();
+		expect(preRestartCoordinateHashes.length).to.equal(entryCount);
+
+		const identity = client.identity;
+
+		// A clean stop flushes the durable block sublevel + coordinate WAL.
+		await client.stop();
+		client = undefined;
+
+		// The node storage lives in a single LevelDB at `<directory>/cache`; the
+		// per-program `blocks` sublevel is a key-prefix inside it (LevelDB
+		// sublevels are logical, not separate directories). After a clean stop
+		// that LevelDB directory must exist and hold data files, i.e. the blocks
+		// written through the wrapper were flushed to disk.
+		const cacheDir = path.join(directory, "cache");
+		const cacheExists = await fs
+			.stat(cacheDir)
+			.then(() => true)
+			.catch(() => false);
+		expect(cacheExists, `durable node storage ${cacheDir}`).to.equal(true);
+		const cacheEntries = await fs.readdir(cacheDir);
+		expect(
+			cacheEntries.length,
+			`durable node storage ${cacheDir} is non-empty`,
+		).to.be.greaterThan(0);
+
+		// --- Session 2: FRESH client on the SAME directory, NO peers ----------
+		client = await Peerbit.create({
+			directory,
+			...createRustPeerbitOptions(),
+		});
+		expect(client.identity.publicKey.equals(identity.publicKey)).to.equal(
+			true,
+			"same identity restored from disk",
+		);
+
+		// (i) Reopen must NOT throw "Failed to load entry from head".
+		const store2 = await client.open(
+			new EventStore<string, any>({ id: storeId }),
+			{ args: { replicate: { factor: 1 } } },
+		);
+		const log2 = store2.log as any;
+		expect(log2._nativeBackbone, "session 2 native backbone").to.exist;
+
+		// This is the exact call that previously failed: resolving the heads
+		// walks the DAG through the block store, which was empty after restart.
+		const restoredHeads = (await store2.log.log.getHeads(true).all())
+			.map((entry: any) => entry.hash)
+			.sort();
+
+		// (iii) heads + length match pre-restart.
+		expect(restoredHeads, "restored heads match pre-restart").to.deep.equal(
+			preRestartHeads,
+		);
+		expect(store2.log.log.length, "restored log length").to.equal(
+			preRestartLength,
+		);
+
+		// (ii) all N documents queryable locally (blocks survived).
+		const restoredValues = (await store2.iterator({ limit: entryCount }))
+			.collect()
+			.map((entry: any) => entry.payload.getValue().value)
+			.sort();
+		expect(restoredValues, "restored documents match pre-restart").to.deep.equal(
+			preRestartValues,
+		);
+
+		// (iv) coordinates restored (coordinate slice; kept green here).
+		const restoredCoordinateHashes = [
+			...(log2._nativeBackbone.getEntryCoordinateHashes() as string[]),
+		].sort();
+		expect(
+			restoredCoordinateHashes,
+			"restored coordinates match pre-restart",
+		).to.deep.equal(preRestartCoordinateHashes);
+	});
+});

--- a/packages/programs/data/shared-log/test/durable-restart-conformance.spec.ts
+++ b/packages/programs/data/shared-log/test/durable-restart-conformance.spec.ts
@@ -1,0 +1,119 @@
+// Cross-backend LIFECYCLE CONFORMANCE: a client opened on an on-disk `directory`
+// must be able to REOPEN a program after a clean stop -> restart WITHOUT any
+// peer, with its entry heads, log length and documents all restored from disk —
+// and the DEFAULT (JS) and NATIVE (rust) backends must behave IDENTICALLY.
+//
+// Why this exists: the native backend has peerless from-disk restart gates
+// (durable-native-restart.spec.ts, coordinate-persistence-restart.spec.ts), but
+// the default backend had NO equivalent from-disk-no-peers restart baseline, so
+// there was nothing to say "native restart matches default restart" against.
+// This parametrizes the SAME sequence and the SAME core assertions over both
+// backends: it both establishes the default baseline and asserts conformance.
+import { expect } from "chai";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { Peerbit } from "peerbit";
+import { createRustPeerbitOptions } from "peerbit/rust";
+import { EventStore } from "./utils/stores/event-store.js";
+
+const BACKENDS = ["default", "native"] as const;
+type Backend = (typeof BACKENDS)[number];
+
+for (const backend of BACKENDS) {
+	describe(`durable restart conformance (${backend})`, function () {
+		this.timeout(120_000);
+
+		let client: Peerbit | undefined;
+		let directory: string | undefined;
+
+		const createClient = (dir: string) =>
+			backend === "native"
+				? Peerbit.create({ directory: dir, ...createRustPeerbitOptions() })
+				: Peerbit.create({ directory: dir });
+
+		afterEach(async () => {
+			await client?.stop();
+			client = undefined;
+			if (directory) {
+				await fs.rm(directory, { recursive: true, force: true });
+				directory = undefined;
+			}
+		});
+
+		it("reopens a program from disk with heads, length and documents restored (no peers)", async () => {
+			directory = await fs.mkdtemp(
+				path.join(os.tmpdir(), `peerbit-durable-restart-${backend}-`),
+			);
+
+			const storeId = new Uint8Array(32);
+			for (let index = 0; index < storeId.length; index++) {
+				storeId[index] = (index * 11 + 5) & 0xff;
+			}
+			const entryCount = 8;
+
+			// --- Session 1: on-disk client, append N docs, no peer ever dialed ---
+			client = await createClient(directory);
+			const store1 = await client.open(
+				new EventStore<string, any>({ id: storeId }),
+				{ args: { replicate: { factor: 1 } } },
+			);
+			for (let index = 0; index < entryCount; index++) {
+				await store1.add(`entry-${index}`, { meta: { next: [] } });
+			}
+
+			const preRestartValues = (await store1.iterator({ limit: entryCount }))
+				.collect()
+				.map((entry: any) => entry.payload.getValue().value)
+				.sort();
+			expect(preRestartValues.length, "session 1 document count").to.equal(
+				entryCount,
+			);
+			const preRestartLength = store1.log.log.length;
+			const preRestartHeads = (await store1.log.log.getHeads(true).all())
+				.map((entry: any) => entry.hash)
+				.sort();
+
+			const identity = client.identity;
+
+			// Clean stop flushes durable storage (both backends).
+			await client.stop();
+			client = undefined;
+
+			// --- Session 2: FRESH client, SAME directory, NO peers ---------------
+			client = await createClient(directory);
+			expect(
+				client.identity.publicKey.equals(identity.publicKey),
+				"same identity restored from disk",
+			).to.equal(true);
+
+			// The core conformance invariant, IDENTICAL for both backends: reopening
+			// resolves the heads (walks the DAG through the block store) without
+			// throwing, and heads/length/documents all match pre-restart purely
+			// from disk.
+			const store2 = await client.open(
+				new EventStore<string, any>({ id: storeId }),
+				{ args: { replicate: { factor: 1 } } },
+			);
+
+			const restoredHeads = (await store2.log.log.getHeads(true).all())
+				.map((entry: any) => entry.hash)
+				.sort();
+			expect(restoredHeads, "restored heads match pre-restart").to.deep.equal(
+				preRestartHeads,
+			);
+			expect(store2.log.log.length, "restored log length").to.equal(
+				preRestartLength,
+			);
+
+			const restoredValues = (await store2.iterator({ limit: entryCount }))
+				.collect()
+				.map((entry: any) => entry.payload.getValue().value)
+				.sort();
+			expect(
+				restoredValues,
+				"restored documents match pre-restart",
+			).to.deep.equal(preRestartValues);
+		});
+	});
+}

--- a/packages/programs/program/program/src/client.ts
+++ b/packages/programs/program/program/src/client.ts
@@ -21,6 +21,15 @@ import type {
 export interface Client<T extends Manageable<ExtractArgs<T>>> {
 	peerId: Libp2pPeerId;
 	identity: Identity<Ed25519PublicKey>;
+	/**
+	 * Root directory backing this client's durable storage, when it runs
+	 * on-disk. `undefined` for memory-only clients. Programs opened on the
+	 * client may derive per-program persistence locations under it (e.g.
+	 * shared-log auto-persists its replication coordinates here). The
+	 * concrete client (`Peerbit`) already exposes this; declaring it on the
+	 * interface lets programs read it without depending on the client package.
+	 */
+	directory?: string;
 	getMultiaddrs: () => Multiaddr[];
 	dial(
 		address: string | Multiaddr | Multiaddr[],


### PR DESCRIPTION
## What

Durable persistence for native-backbone nodes. Today a node running the native backbone keeps its replication **coordinates** in a WAL that isn't auto-wired, and its entry **blocks** live only in wasm memory — so a native node cannot cleanly stop and restart with its data intact. This makes it durable end-to-end: **a native node started with a storage directory reopens its program after restart with all documents, blocks, heads, and coordinates present, with no peers available.**

## Changes

**1. Auto-wire per-program coordinate persistence from the client directory** (`shared-log`, `program`)
The coordinate persistence machinery already existed and was tested, but only activated when a caller explicitly passed `coordinatePersistence`. Shared-log now derives it from the node's storage `directory` when the native backbone is active, namespaced per program under `<directory>/coordinates/<hex(log.id)>` (the log id is base64 → hex-encoded for a filesystem-safe path segment). Node fs and browser OPFS backends, selected by environment. `@peerbit/program`'s `Client` interface exposes the optional `directory` (already set by `Peerbit`) so this is type-safe. **Backward-compatible:** an explicit config still wins; memory-only nodes are unchanged.

**2. Durable write-through block store** (`shared-log`)
When the native backbone is active + a durable directory is present, the log's local block store is a write-through wrapper over `(native wasm hot store, durable AnyBlockStore(storage.sublevel("blocks")))` — the same durable store the non-native path uses, so the on-disk layout matches. Writes mirror native→durable; reads are native-first with a durable fallback + repopulate; and on `start()` the wrapper **rehydrates the wasm store from durable before the log walks the DAG**, so the native graph can resolve heads after a restart. The wrapper preserves the exact feature-detected method surface (`putKnownManyColumns` etc.) the log and `RemoteBlocks` probe, so the columnar receive-fusion path keeps engaging.

## Correctness — the bug the review caught

An adversarial review of the write-through store found a **critical bypass**: the native *commit-only* append path (used by default for **non-replicating** `replicate: false` puts — the document store's `NATIVE_LOCAL_PUT_OPTIONS`) commits blocks straight to wasm, missing the durable mirror. It was the one native block-writing path without the guard its four siblings have. The first end-to-end restart test passed only because it used a *replicating* config, which takes a different (already-correct) path — a green-but-wrong test. Fixed: when the wrapper is active, the commit-only path reads the just-committed bytes back from the wasm store and attaches them so they persist through the wrapper to durable (memory-only nodes keep the unchanged fast path; strict-native mode is preserved). Also hardened: the durable mirror writes are now awaited / error-surfaced (they were fire-and-forget `void`, which could silently drop a block on an IO error) and the single-cid `get()` gained a durable fallback.

## Tests

- `shared-log/test/durable-native-restart.spec.ts` — full restart for a **replicating** native node (append → close → reopen, no peers → docs/heads/coordinates intact).
- `document/test/durable-native-nonreplicating-restart.spec.ts` — the **non-replicating** case that pins the critical fix. Verified it **fails without the fix** (blocks `undefined` after restart) and passes with it.
- `shared-log/test/coordinate-persistence-restart.spec.ts` — coordinate WAL persists + hydrates from directory.
- Regression: native-backbone (59), shared-log native e2e (3) + `sync-raw-exchange-heads` receive/columnar (33), memory-only `append` backward-compat, document native-replicate-sync (3) + native-network-e2e (3) — all green.

## Scope

Covers **clean** stop/restart. Hard-kill crash-consistency (flush ordering across the block store, SQLite heads index, and the coordinate WAL) is a deliberate follow-up.

## Known limitations (the deferred crash-consistency follow-up)

An adversarial review confirmed durable coverage is complete across every native block-write path on the clean-restart path (commit-only, storage-transaction, batch put-many; the receive/join path stays disabled-and-falls-back-to-JS-puts). It surfaced three items that all belong to the crash-consistency follow-up this PR scopes out:

- **Durable block mirrors are drained on `stop()`, not awaited on the append hot path.** The three committed native paths mirror the block to durable via a tracked write (errors surface on the next awaited wrapper call and on `stop()`). So the durability guarantee is "durable across a clean stop/restart" — a hard crash between an append resolving and the mirror draining can lose that block. Making these writes ordered/awaited is the crash-consistency follow-up. (Awaiting them in place would require making the synchronous native-commit prepare mappers async, which is deliberately out of scope here.)
- **Trimmed blocks are removed from the wasm store but not from durable** — a bounded durable-space leak under trimming (safe direction: never data loss). Follow-up: plumb trimmed hashes into `durable.rmMany`.
- **The `committedBytes === undefined` guard silently skips the mirror.** Unreachable today (a just-committed head is always resident in wasm), but a future native change that defers the head block would produce a silent durable miss rather than an error. Follow-up: assert instead of skip.