### PR TITLE
fix(indexer): converge sort tie-break ordering across native, simple and sqlite backends

### DIFF
--- a/packages/programs/data/document/document/test/sort-parity-conformance.spec.ts
+++ b/packages/programs/data/document/document/test/sort-parity-conformance.spec.ts
@@ -139,12 +139,15 @@ describe("sort parity (native vs default)", function () {
 		}
 	});
 
-	// String ids only exercise the UTF-8/BINARY tie-break. The numeric (bigint)
-	// and raw-byte (Uint8Array) id tie-breaks — the two id kinds that diverge
-	// between the native and default comparators — are covered end-to-end at the
-	// indexer level by the shared @peerbit/indexer-tests `tieParityTests` suite,
-	// which asserts @peerbit/indexer-simple == @peerbit/indexer-sqlite3 for real
-	// bigint and Uint8Array primary-key ids in both directions. The document layer
-	// itself only supports string/base64 primary keys through its put path, so the
-	// bigint/Uint8Array parity is asserted where those ids are natively indexable.
+	// This document-level case exercises string ids only. The numeric (bigint)
+	// and raw-byte (Uint8Array) tie-breaks — the two id kinds that diverge between
+	// the native and default comparators — are locked end-to-end at the indexer
+	// level by the shared @peerbit/indexer-tests `tieParityTests` suite, which
+	// asserts @peerbit/indexer-simple == @peerbit/indexer-sqlite3 for real bigint
+	// and Uint8Array primary-key ids in both directions.
+	//
+	// (Scope note: Uint8Array document primary keys are put-able here too — they
+	// map to a sqlite BLOB — but a bigint (u64) document primary key is not
+	// exercised anywhere in the document suite, so the non-string parity is pinned
+	// where every id kind is natively indexable rather than duplicated per kind.)
 });

--- a/packages/programs/data/document/document/test/sort-parity-conformance.spec.ts
+++ b/packages/programs/data/document/document/test/sort-parity-conformance.spec.ts
@@ -138,4 +138,13 @@ describe("sort parity (native vs default)", function () {
 			).to.deep.equal(defaultOrder);
 		}
 	});
+
+	// String ids only exercise the UTF-8/BINARY tie-break. The numeric (bigint)
+	// and raw-byte (Uint8Array) id tie-breaks — the two id kinds that diverge
+	// between the native and default comparators — are covered end-to-end at the
+	// indexer level by the shared @peerbit/indexer-tests `tieParityTests` suite,
+	// which asserts @peerbit/indexer-simple == @peerbit/indexer-sqlite3 for real
+	// bigint and Uint8Array primary-key ids in both directions. The document layer
+	// itself only supports string/base64 primary keys through its put path, so the
+	// bigint/Uint8Array parity is asserted where those ids are natively indexable.
 });

--- a/packages/programs/data/document/document/test/sort-parity-conformance.spec.ts
+++ b/packages/programs/data/document/document/test/sort-parity-conformance.spec.ts
@@ -1,0 +1,141 @@
+// Cross-backend SORT PARITY: given the SAME entries, a pure-native (rust) index
+// and an all-default (JS) index must return query results in the IDENTICAL
+// order — including how they break TIES between equal sort keys.
+//
+// Sort order (and especially tie-breaking on equal keys) is comparator-driven,
+// which is exactly where a native comparator can silently diverge from JS. The
+// existing sort tests are 100% default-only, so a native index that ordered
+// ties differently (e.g. by hash vs by clock, or a different byte comparison)
+// would pass every test while returning a different order in a real hybrid
+// deployment.
+//
+// This authors half the documents on each backend and syncs, so both peers hold
+// the identical set of content-addressed entries (identical clocks/heads =
+// identical tie-break inputs), then runs the same sorted query on both and
+// asserts the full result ORDER matches.
+import { policy, transform } from "../src/index.js";
+import { SearchRequest } from "@peerbit/document-interface";
+import { Sort, SortDirection } from "@peerbit/indexer-interface";
+import {
+	NativeBackboneCoordinatePersistence,
+	NativeBackboneMemoryCoordinatePersistenceStore,
+} from "@peerbit/native-backbone";
+import { waitForResolved } from "@peerbit/time";
+import { expect } from "chai";
+import { Peerbit } from "peerbit";
+import { createRustPeerbitOptions } from "peerbit/rust";
+import { Documents } from "../src/program.js";
+import { Document, TestStore } from "./data.js";
+
+const nativeBackboneDocumentIndexOptions = () => ({
+	optional: false,
+	documentIndex: true,
+	coordinatePersistence: new NativeBackboneCoordinatePersistence(
+		new NativeBackboneMemoryCoordinatePersistenceStore(),
+		{ flushOnAppend: false },
+	),
+});
+
+const nativeOpenArgs = () => ({
+	mode: "native" as const,
+	replicate: { factor: 1 },
+	nativeGraph: true,
+	nativeBackbone: nativeBackboneDocumentIndexOptions(),
+	canPerform: policy.allowAll<Document>(),
+	index: { type: Document, transform: transform.identity<Document>() },
+});
+
+const defaultOpenArgs = () => ({
+	replicate: { factor: 1 },
+	canPerform: policy.allowAll<Document>(),
+	index: { type: Document },
+});
+
+describe("sort parity (native vs default)", function () {
+	this.timeout(120_000);
+
+	let nativePeer: Peerbit;
+	let defaultPeer: Peerbit;
+
+	beforeEach(async () => {
+		nativePeer = await Peerbit.create({ ...createRustPeerbitOptions() });
+		defaultPeer = await Peerbit.create();
+	});
+
+	afterEach(async () => {
+		await nativePeer?.stop();
+		await defaultPeer?.stop();
+	});
+
+	it("orders sorted queries identically, including tie-breaks", async () => {
+		const store = new TestStore({ docs: new Documents<Document>() as any });
+		const nativeStore = await nativePeer.open(store.clone(), {
+			args: nativeOpenArgs() as any,
+		});
+		const defaultStore = await defaultPeer.open(store.clone(), {
+			args: defaultOpenArgs() as any,
+		});
+		await defaultPeer.dial(nativePeer.getMultiaddrs());
+
+		// Numbers with MANY duplicates force tie-breaking; interleaving
+		// authorship across backends makes the ties span both origins.
+		const nativeNumbers = [3n, 1n, 3n, 2n, 1n, 2n];
+		const defaultNumbers = [2n, 3n, 1n, 3n, 2n, 1n];
+		for (let i = 0; i < nativeNumbers.length; i++) {
+			await nativeStore.docs.put(
+				new Document({ id: `n-${i}`, name: `n-${i}`, number: nativeNumbers[i] }),
+			);
+		}
+		for (let i = 0; i < defaultNumbers.length; i++) {
+			await defaultStore.docs.put(
+				new Document({
+					id: `d-${i}`,
+					name: `d-${i}`,
+					number: defaultNumbers[i],
+				}),
+			);
+		}
+		const total = nativeNumbers.length + defaultNumbers.length;
+
+		await waitForResolved(
+			async () => {
+				expect(await nativeStore.docs.index.getSize()).to.equal(total);
+				expect(await defaultStore.docs.index.getSize()).to.equal(total);
+			},
+			{ timeout: 60_000, timeoutMessage: "sort-parity convergence" },
+		);
+
+		const collectOrder = async (store: TestStore, direction: SortDirection) => {
+			const iterator = store.docs.index.iterate(
+				new SearchRequest({
+					query: [],
+					sort: [new Sort({ direction, key: "number" })],
+				}),
+			);
+			const results = await iterator.next(total);
+			await iterator.close();
+			return results.map((doc: any) => ({ id: doc.id, number: doc.number }));
+		};
+
+		for (const direction of [SortDirection.ASC, SortDirection.DESC]) {
+			const nativeOrder = await collectOrder(nativeStore, direction);
+			const defaultOrder = await collectOrder(defaultStore, direction);
+
+			expect(nativeOrder.length, `${direction} count`).to.equal(total);
+			// The `number` sequences must be monotonic in the requested direction.
+			const nums = nativeOrder.map((r) => r.number as bigint);
+			for (let i = 1; i < nums.length; i++) {
+				if (direction === SortDirection.ASC) {
+					expect(nums[i] >= nums[i - 1], `${direction} monotonic`).to.equal(true);
+				} else {
+					expect(nums[i] <= nums[i - 1], `${direction} monotonic`).to.equal(true);
+				}
+			}
+			// THE parity assertion: identical full order, ties and all.
+			expect(
+				nativeOrder,
+				`native and default order identically (${direction}, incl. tie-breaks)`,
+			).to.deep.equal(defaultOrder);
+		}
+	});
+});

--- a/packages/utils/indexer/core/src/planner.rs
+++ b/packages/utils/indexer/core/src/planner.rs
@@ -1001,7 +1001,37 @@ impl NativeQueryIndex {
                 return ordering;
             }
         }
-        left.cmp(&right)
+        // Tie-break by external document id so equal-key results order identically
+        // across backends and peers. The default (JS/sqlite) index stores rows in
+        // primary-key (id) order (WITHOUT ROWID) and emits tied rows following the
+        // scan direction, i.e. the direction of the final sort field. Match that here
+        // instead of falling back to the local insertion counter (DocId), which is
+        // per-peer and not content-deterministic.
+        self.compare_external_ids(left, right, tie_break_direction(sort))
+    }
+
+    /// Compare two documents by their external id, honoring the tie-break
+    /// `direction` (ascending id for `Asc`, descending id for `Desc`). External
+    /// ids are compared as UTF-8 byte sequences, matching sqlite's BINARY
+    /// collation on the primary-key column. Falls back to the internal DocId only
+    /// if an external id is somehow missing (should not happen for live docs).
+    fn compare_external_ids(
+        &self,
+        left: DocId,
+        right: DocId,
+        direction: SortDirection,
+    ) -> Ordering {
+        let ordering = match (
+            self.internal_to_external.get(&left),
+            self.internal_to_external.get(&right),
+        ) {
+            (Some(left_id), Some(right_id)) => left_id.as_bytes().cmp(right_id.as_bytes()),
+            _ => left.cmp(&right),
+        };
+        match direction {
+            SortDirection::Asc => ordering,
+            SortDirection::Desc => ordering.reverse(),
+        }
     }
 
     fn first_scalar(&self, doc_id: DocId, path: &FieldPath) -> Option<&FieldValue> {
@@ -1043,6 +1073,7 @@ impl NativeQueryIndex {
         if sort.direction == SortDirection::Desc
             && !self.collect_missing_sorted_docs(
                 &sort.field,
+                true,
                 query,
                 offset,
                 limit,
@@ -1171,6 +1202,7 @@ impl NativeQueryIndex {
         if sort.direction == SortDirection::Asc {
             self.collect_missing_sorted_docs(
                 &sort.field,
+                false,
                 query,
                 offset,
                 limit,
@@ -1200,6 +1232,7 @@ impl NativeQueryIndex {
         if reverse {
             self.collect_index_sorted_docs(
                 index.values().rev(),
+                reverse,
                 query,
                 offset,
                 limit,
@@ -1210,6 +1243,7 @@ impl NativeQueryIndex {
         } else {
             self.collect_index_sorted_docs(
                 index.values(),
+                reverse,
                 query,
                 offset,
                 limit,
@@ -1224,6 +1258,7 @@ impl NativeQueryIndex {
     fn collect_index_sorted_docs<'a>(
         &self,
         bitmaps: impl Iterator<Item = &'a RoaringBitmap>,
+        reverse: bool,
         query: &Query,
         offset: usize,
         limit: usize,
@@ -1232,7 +1267,11 @@ impl NativeQueryIndex {
         result: &mut Vec<String>,
     ) -> bool {
         for bitmap in bitmaps {
-            for doc_id in bitmap.iter() {
+            // Docs sharing the same sort value are a tie group. `bitmap.iter()`
+            // yields them in DocId (local insertion) order, which is not
+            // content-deterministic across peers. Re-order each tie group by
+            // external id in the scan direction to match the default backend.
+            for doc_id in self.tie_ordered_doc_ids(bitmap, reverse) {
                 if !self.collect_sorted_doc(doc_id, query, offset, limit, skipped, seen, result) {
                     return false;
                 }
@@ -1241,9 +1280,27 @@ impl NativeQueryIndex {
         true
     }
 
+    /// Return the doc ids of a tie group ordered by external id (ascending for a
+    /// forward scan, descending when `reverse`), so equal-sort-key results match
+    /// the default backend's primary-key ordering. Single-element groups skip the
+    /// allocation/sort entirely.
+    fn tie_ordered_doc_ids(&self, bitmap: &RoaringBitmap, reverse: bool) -> Vec<DocId> {
+        let mut doc_ids: Vec<DocId> = bitmap.iter().collect();
+        if doc_ids.len() > 1 {
+            let direction = if reverse {
+                SortDirection::Desc
+            } else {
+                SortDirection::Asc
+            };
+            doc_ids.sort_by(|left, right| self.compare_external_ids(*left, *right, direction));
+        }
+        doc_ids
+    }
+
     fn collect_missing_sorted_docs(
         &self,
         field: &FieldPath,
+        reverse: bool,
         query: &Query,
         offset: usize,
         limit: usize,
@@ -1251,10 +1308,23 @@ impl NativeQueryIndex {
         seen: &mut RoaringBitmap,
         result: &mut Vec<String>,
     ) -> bool {
-        for doc_id in self.all_docs.iter() {
-            if self.first_scalar(doc_id, field).is_some() {
-                continue;
-            }
+        // Docs without a value for the sort field form one tie group (all "null").
+        // Emit them ordered by external id in the scan direction, matching the
+        // default backend, instead of raw DocId (local insertion) order.
+        let mut missing: Vec<DocId> = self
+            .all_docs
+            .iter()
+            .filter(|doc_id| self.first_scalar(*doc_id, field).is_none())
+            .collect();
+        if missing.len() > 1 {
+            let direction = if reverse {
+                SortDirection::Desc
+            } else {
+                SortDirection::Asc
+            };
+            missing.sort_by(|left, right| self.compare_external_ids(*left, *right, direction));
+        }
+        for doc_id in missing {
             if !self.collect_sorted_doc(doc_id, query, offset, limit, skipped, seen, result) {
                 return false;
             }
@@ -1714,6 +1784,16 @@ fn compare_optional_values(left: Option<&FieldValue>, right: Option<&FieldValue>
     }
 }
 
+/// Direction used to break sort ties by external document id. The default
+/// (sqlite WITHOUT ROWID) index scans the primary key in the direction of the
+/// final ORDER BY term, so tied rows follow that direction. With no explicit
+/// sort fields we fall back to ascending id order.
+fn tie_break_direction(sort: &[SortField]) -> SortDirection {
+    sort.last()
+        .map(|field| field.direction)
+        .unwrap_or(SortDirection::Asc)
+}
+
 fn compare_field_values(left: &FieldValue, right: &FieldValue) -> Ordering {
     match (left, right) {
         (FieldValue::Bool(left), FieldValue::Bool(right)) => left.cmp(right),
@@ -1983,6 +2063,111 @@ mod tests {
                 Some(3),
             ),
             vec!["bytes", "string", "u64"]
+        );
+    }
+
+    #[test]
+    fn ties_break_by_external_id_not_insertion_order() {
+        // Insert in an order where the local insertion counter (DocId) is the
+        // REVERSE of external-id order, and give every doc the same sort value so
+        // the whole result set is one tie group. The tie-break must follow external
+        // id (matching the default sqlite backend's primary-key order), not the
+        // per-peer DocId, so the emitted order is independent of insertion order.
+        let mut index = NativeQueryIndex::new();
+        for id in ["d", "c", "b", "a"] {
+            index.put(id, DocumentFields::new().with_scalar("number", 1_u64));
+        }
+
+        // Fast path (single-field sort backed by the ordered index).
+        assert_eq!(
+            index.search(
+                &Query::All,
+                &[SortField {
+                    field: "number".into(),
+                    direction: SortDirection::Asc,
+                }],
+                None,
+            ),
+            vec!["a", "b", "c", "d"],
+            "ASC ties order by external id ascending"
+        );
+        assert_eq!(
+            index.search(
+                &Query::All,
+                &[SortField {
+                    field: "number".into(),
+                    direction: SortDirection::Desc,
+                }],
+                None,
+            ),
+            vec!["d", "c", "b", "a"],
+            "DESC ties order by external id descending"
+        );
+    }
+
+    #[test]
+    fn generic_sort_ties_break_by_external_id() {
+        // A multi-field sort forces the generic `compare_docs` slow path. Docs with
+        // equal keys on every sort field must still tie-break by external id.
+        let mut index = NativeQueryIndex::new();
+        for id in ["d", "c", "b", "a"] {
+            index.put(
+                id,
+                DocumentFields::new()
+                    .with_scalar("primary", 1_u64)
+                    .with_scalar("secondary", "same"),
+            );
+        }
+
+        let sort = [
+            SortField {
+                field: "primary".into(),
+                direction: SortDirection::Asc,
+            },
+            SortField {
+                field: "secondary".into(),
+                direction: SortDirection::Desc,
+            },
+        ];
+        // Tie-break direction follows the final sort field (Desc here).
+        assert_eq!(
+            index.search(&Query::All, &sort, None),
+            vec!["d", "c", "b", "a"]
+        );
+    }
+
+    #[test]
+    fn missing_sort_value_ties_break_by_external_id() {
+        // Docs lacking the sort field form a single "null" tie group. They too must
+        // order by external id, in the scan direction.
+        let mut index = NativeQueryIndex::new();
+        for id in ["d", "c", "b", "a"] {
+            index.put(id, DocumentFields::new().with_scalar("other", 1_u64));
+        }
+
+        assert_eq!(
+            index.search(
+                &Query::All,
+                &[SortField {
+                    field: "number".into(),
+                    direction: SortDirection::Asc,
+                }],
+                None,
+            ),
+            vec!["a", "b", "c", "d"],
+            "ASC missing-value ties order by external id ascending"
+        );
+        assert_eq!(
+            index.search(
+                &Query::All,
+                &[SortField {
+                    field: "number".into(),
+                    direction: SortDirection::Desc,
+                }],
+                None,
+            ),
+            vec!["d", "c", "b", "a"],
+            "DESC missing-value ties order by external id descending"
         );
     }
 

--- a/packages/utils/indexer/core/src/planner.rs
+++ b/packages/utils/indexer/core/src/planner.rs
@@ -7,6 +7,124 @@ use std::sync::Arc;
 pub type DocId = u32;
 const MAX_EXACT_INDEXED_BYTE_FIELD_LENGTH: usize = 128;
 
+/// A document's primary-key id parsed into a typed, canonically-comparable form.
+///
+/// External ids reach the native index as type-prefixed store-keys (see
+/// `keyToStoreKey` in `packages/utils/indexer/rust/src/index.ts`):
+///   `string:<utf8>` | `number:<decimal>` | `bigint:<decimal>` | `bytes:<base64>`
+///
+/// The raw store-key string is load-bearing for identity (it is the persistence,
+/// lookup, and delete key and round-trips back to an `IdKey`), so it must not be
+/// reformatted. Instead we parse it once at insert into this typed key and order
+/// tied documents by it, matching the default sqlite backend's per-id-kind
+/// primary-key order:
+///   - string ids compare as UTF-8 bytes   (sqlite TEXT / BINARY collation)
+///   - integer ids compare numerically     (sqlite INTEGER: 2 < 10, not "10" < "2")
+///   - byte ids compare by raw memcmp       (sqlite BLOB: decoded bytes, not base64)
+///
+/// Unrecognized prefixes fall back to comparing the whole store-key as UTF-8 so
+/// ordering stays deterministic even if a new id kind is added upstream.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum IdSortKey {
+    Int(u128),
+    Bytes(Vec<u8>),
+    Str(String),
+}
+
+impl IdSortKey {
+    fn from_store_key(store_key: &str) -> Self {
+        if let Some(rest) = store_key.strip_prefix("number:") {
+            if let Ok(value) = rest.parse::<u128>() {
+                return IdSortKey::Int(value);
+            }
+        } else if let Some(rest) = store_key.strip_prefix("bigint:") {
+            if let Ok(value) = rest.parse::<u128>() {
+                return IdSortKey::Int(value);
+            }
+        } else if let Some(rest) = store_key.strip_prefix("bytes:") {
+            if let Some(bytes) = decode_base64(rest) {
+                return IdSortKey::Bytes(bytes);
+            }
+        }
+        // `string:` values and any unrecognized/malformed prefix order by the raw
+        // UTF-8 bytes of the whole store-key, matching sqlite's BINARY collation.
+        IdSortKey::Str(store_key.to_string())
+    }
+
+    /// Order id kinds relative to one another when a tie group somehow mixes
+    /// types (a single index only ever holds one id kind, so this is a
+    /// defensive tie-breaker rather than an expected path).
+    fn kind_rank(&self) -> u8 {
+        match self {
+            IdSortKey::Int(_) => 0,
+            IdSortKey::Bytes(_) => 1,
+            IdSortKey::Str(_) => 2,
+        }
+    }
+}
+
+impl Ord for IdSortKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (IdSortKey::Int(left), IdSortKey::Int(right)) => left.cmp(right),
+            (IdSortKey::Bytes(left), IdSortKey::Bytes(right)) => left.cmp(right),
+            (IdSortKey::Str(left), IdSortKey::Str(right)) => left.as_bytes().cmp(right.as_bytes()),
+            _ => self.kind_rank().cmp(&other.kind_rank()),
+        }
+    }
+}
+
+impl PartialOrd for IdSortKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Decode a standard (RFC 4648) base64 string with optional `=` padding into raw
+/// bytes. The byte store-key suffix is produced by `IdKey.primitive` via
+/// libsodium's ORIGINAL variant (alphabet `A-Za-z0-9+/`, padded), so a small
+/// hand-rolled decoder avoids pulling in a base64 crate for this one call site.
+/// Returns `None` on any invalid character or length so the caller can fall back
+/// to string ordering rather than panic.
+fn decode_base64(input: &str) -> Option<Vec<u8>> {
+    fn value(byte: u8) -> Option<u32> {
+        match byte {
+            b'A'..=b'Z' => Some((byte - b'A') as u32),
+            b'a'..=b'z' => Some((byte - b'a' + 26) as u32),
+            b'0'..=b'9' => Some((byte - b'0' + 52) as u32),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            _ => None,
+        }
+    }
+
+    let bytes = input.as_bytes();
+    // Strip trailing '=' padding.
+    let mut end = bytes.len();
+    while end > 0 && bytes[end - 1] == b'=' {
+        end -= 1;
+    }
+    let bytes = &bytes[..end];
+
+    let mut out = Vec::with_capacity(bytes.len() * 3 / 4);
+    let mut chunk = 0_u32;
+    let mut chunk_len = 0_u32;
+    for &byte in bytes {
+        let value = value(byte)?;
+        chunk = (chunk << 6) | value;
+        chunk_len += 6;
+        if chunk_len >= 8 {
+            chunk_len -= 8;
+            out.push((chunk >> chunk_len) as u8);
+        }
+    }
+    // A single leftover base64 symbol (2 bits) is not a valid encoding.
+    if chunk_len >= 6 {
+        return None;
+    }
+    Some(out)
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum FieldPath {
     Id(u32),
@@ -302,6 +420,10 @@ pub struct NativeQueryIndex {
     all_docs: RoaringBitmap,
     external_to_internal: HashMap<String, DocId>,
     internal_to_external: HashMap<DocId, String>,
+    // Typed, canonically-comparable form of each document's store-key id, parsed
+    // once at insert. Kept parallel to `internal_to_external` (never reformats the
+    // stored string) purely so tie-breaks order by the id's natural typed order.
+    internal_to_sort_key: HashMap<DocId, IdSortKey>,
     documents: HashMap<DocId, DocumentFields>,
     exact: HashMap<FieldPath, HashMap<FieldValue, RoaringBitmap>>,
     range_i64: HashMap<FieldPath, BTreeMap<i64, RoaringBitmap>>,
@@ -339,6 +461,7 @@ impl NativeQueryIndex {
     pub fn reserve_documents(&mut self, additional: usize) {
         self.external_to_internal.reserve(additional);
         self.internal_to_external.reserve(additional);
+        self.internal_to_sort_key.reserve(additional);
         self.documents.reserve(additional);
     }
 
@@ -700,6 +823,7 @@ impl NativeQueryIndex {
             Some(doc_id) => {
                 debug_assert!(
                     !self.internal_to_external.contains_key(&doc_id)
+                        && !self.internal_to_sort_key.contains_key(&doc_id)
                         && !self.documents.contains_key(&doc_id)
                         && !self.all_docs.contains(doc_id),
                     "recycled doc id is still referenced by live structures"
@@ -718,6 +842,8 @@ impl NativeQueryIndex {
                 doc_id
             }
         };
+        self.internal_to_sort_key
+            .insert(doc_id, IdSortKey::from_store_key(&external_id));
         self.external_to_internal
             .insert(external_id.clone(), doc_id);
         self.internal_to_external.insert(doc_id, external_id);
@@ -729,6 +855,7 @@ impl NativeQueryIndex {
             return false;
         };
         self.internal_to_external.remove(&doc_id);
+        self.internal_to_sort_key.remove(&doc_id);
         self.remove_document_fields(doc_id);
         self.all_docs.remove(doc_id);
         self.free_doc_ids.push(doc_id);
@@ -1001,20 +1128,25 @@ impl NativeQueryIndex {
                 return ordering;
             }
         }
-        // Tie-break by external document id so equal-key results order identically
-        // across backends and peers. The default (JS/sqlite) index stores rows in
-        // primary-key (id) order (WITHOUT ROWID) and emits tied rows following the
-        // scan direction, i.e. the direction of the final sort field. Match that here
-        // instead of falling back to the local insertion counter (DocId), which is
-        // per-peer and not content-deterministic.
+        // Tie-break by primary-key id so equal-key results order identically across
+        // backends and peers. The default (JS/sqlite) index stores rows in
+        // primary-key order and emits tied rows following the scan direction, i.e.
+        // the direction of the final sort field. Match that here — using the id's
+        // natural typed order per id kind — instead of falling back to the local
+        // insertion counter (DocId), which is per-peer and not content-deterministic.
         self.compare_external_ids(left, right, tie_break_direction(sort))
     }
 
-    /// Compare two documents by their external id, honoring the tie-break
-    /// `direction` (ascending id for `Asc`, descending id for `Desc`). External
-    /// ids are compared as UTF-8 byte sequences, matching sqlite's BINARY
-    /// collation on the primary-key column. Falls back to the internal DocId only
-    /// if an external id is somehow missing (should not happen for live docs).
+    /// Compare two documents by their primary-key id, honoring the tie-break
+    /// `direction` (ascending id for `Asc`, descending id for `Desc`). Ids are
+    /// compared in the id's natural typed order so ties match the default sqlite
+    /// backend for EVERY id kind, not only strings:
+    ///   - integer ids compare numerically   (sqlite INTEGER: 2 < 10)
+    ///   - byte ids compare by raw memcmp     (sqlite BLOB: decoded bytes)
+    ///   - string ids compare as UTF-8 bytes  (sqlite TEXT / BINARY collation)
+    /// The typed key is parsed once at insert (see `IdSortKey`). Falls back to the
+    /// internal DocId only if a sort key is somehow missing (should not happen for
+    /// live docs).
     fn compare_external_ids(
         &self,
         left: DocId,
@@ -1022,10 +1154,10 @@ impl NativeQueryIndex {
         direction: SortDirection,
     ) -> Ordering {
         let ordering = match (
-            self.internal_to_external.get(&left),
-            self.internal_to_external.get(&right),
+            self.internal_to_sort_key.get(&left),
+            self.internal_to_sort_key.get(&right),
         ) {
-            (Some(left_id), Some(right_id)) => left_id.as_bytes().cmp(right_id.as_bytes()),
+            (Some(left_key), Some(right_key)) => left_key.cmp(right_key),
             _ => left.cmp(&right),
         };
         match direction {
@@ -1270,7 +1402,8 @@ impl NativeQueryIndex {
             // Docs sharing the same sort value are a tie group. `bitmap.iter()`
             // yields them in DocId (local insertion) order, which is not
             // content-deterministic across peers. Re-order each tie group by
-            // external id in the scan direction to match the default backend.
+            // primary-key id (in its natural typed order) in the scan direction to
+            // match the default backend.
             for doc_id in self.tie_ordered_doc_ids(bitmap, reverse) {
                 if !self.collect_sorted_doc(doc_id, query, offset, limit, skipped, seen, result) {
                     return false;
@@ -1280,10 +1413,10 @@ impl NativeQueryIndex {
         true
     }
 
-    /// Return the doc ids of a tie group ordered by external id (ascending for a
-    /// forward scan, descending when `reverse`), so equal-sort-key results match
-    /// the default backend's primary-key ordering. Single-element groups skip the
-    /// allocation/sort entirely.
+    /// Return the doc ids of a tie group ordered by primary-key id in its natural
+    /// typed order (ascending for a forward scan, descending when `reverse`), so
+    /// equal-sort-key results match the default backend's primary-key ordering for
+    /// every id kind. Single-element groups skip the allocation/sort entirely.
     fn tie_ordered_doc_ids(&self, bitmap: &RoaringBitmap, reverse: bool) -> Vec<DocId> {
         let mut doc_ids: Vec<DocId> = bitmap.iter().collect();
         if doc_ids.len() > 1 {
@@ -1309,8 +1442,9 @@ impl NativeQueryIndex {
         result: &mut Vec<String>,
     ) -> bool {
         // Docs without a value for the sort field form one tie group (all "null").
-        // Emit them ordered by external id in the scan direction, matching the
-        // default backend, instead of raw DocId (local insertion) order.
+        // Emit them ordered by primary-key id (in its natural typed order) in the
+        // scan direction, matching the default backend, instead of raw DocId (local
+        // insertion) order.
         let mut missing: Vec<DocId> = self
             .all_docs
             .iter()
@@ -2102,6 +2236,137 @@ mod tests {
             ),
             vec!["d", "c", "b", "a"],
             "DESC ties order by external id descending"
+        );
+    }
+
+    #[test]
+    fn base64_decoder_round_trips_store_key_bytes() {
+        use super::decode_base64;
+        // Standard-alphabet base64 with padding, exactly as produced by
+        // IdKey.primitive (libsodium ORIGINAL variant).
+        assert_eq!(decode_base64("AA=="), Some(vec![0x00]));
+        assert_eq!(decode_base64("Cg=="), Some(vec![0x0a]));
+        assert_eq!(decode_base64("Pg=="), Some(vec![0x3e]));
+        assert_eq!(decode_base64("+A=="), Some(vec![0xf8]));
+        assert_eq!(decode_base64("+w=="), Some(vec![0xfb]));
+        assert_eq!(decode_base64("/w=="), Some(vec![0xff]));
+        assert_eq!(decode_base64("/wAQ"), Some(vec![0xff, 0x00, 0x10]));
+        assert_eq!(decode_base64("AQID"), Some(vec![0x01, 0x02, 0x03]));
+        assert_eq!(decode_base64(""), Some(vec![]));
+        // Invalid characters / lengths fall back to None.
+        assert_eq!(decode_base64("*"), None);
+        assert_eq!(decode_base64("A"), None);
+    }
+
+    #[test]
+    fn integer_ids_tie_break_numerically_not_lexically() {
+        // number:/bigint: store-keys must order numerically (2 < 10 < 21 < 100),
+        // matching sqlite's INTEGER primary key, NOT lexically ("10" < "2").
+        let mut index = NativeQueryIndex::new();
+        for id in [
+            "bigint:10",
+            "bigint:2",
+            "bigint:21",
+            "bigint:9",
+            "bigint:100",
+            "bigint:300",
+        ] {
+            index.put(id, DocumentFields::new().with_scalar("sort", 1_u64));
+        }
+        assert_eq!(
+            index.search(
+                &Query::All,
+                &[SortField {
+                    field: "sort".into(),
+                    direction: SortDirection::Asc,
+                }],
+                None,
+            ),
+            vec![
+                "bigint:2",
+                "bigint:9",
+                "bigint:10",
+                "bigint:21",
+                "bigint:100",
+                "bigint:300"
+            ],
+            "ASC integer ties order numerically"
+        );
+        assert_eq!(
+            index.search(
+                &Query::All,
+                &[SortField {
+                    field: "sort".into(),
+                    direction: SortDirection::Desc,
+                }],
+                None,
+            ),
+            vec![
+                "bigint:300",
+                "bigint:100",
+                "bigint:21",
+                "bigint:10",
+                "bigint:9",
+                "bigint:2"
+            ],
+            "DESC integer ties order reverse-numerically"
+        );
+    }
+
+    #[test]
+    fn byte_ids_tie_break_by_raw_bytes_not_base64() {
+        // bytes: store-keys must order by the DECODED raw bytes (0x00 < .. < 0xff),
+        // matching sqlite's BLOB memcmp. Lexically the base64 suffix would sort
+        // 0xf8/0xfb/0xff (leading '+'/'/') BEFORE 0x00 ('A'), which is the bug.
+        // base64: 0x00=AA==, 0x0a=Cg==, 0x3e=Pg==, 0xf8=+A==, 0xfb=+w==, 0xff=/w==
+        let mut index = NativeQueryIndex::new();
+        for id in [
+            "bytes:/w==",
+            "bytes:AA==",
+            "bytes:Cg==",
+            "bytes:Pg==",
+            "bytes:+A==",
+            "bytes:+w==",
+        ] {
+            index.put(id, DocumentFields::new().with_scalar("sort", 1_u64));
+        }
+        assert_eq!(
+            index.search(
+                &Query::All,
+                &[SortField {
+                    field: "sort".into(),
+                    direction: SortDirection::Asc,
+                }],
+                None,
+            ),
+            vec![
+                "bytes:AA==",
+                "bytes:Cg==",
+                "bytes:Pg==",
+                "bytes:+A==",
+                "bytes:+w==",
+                "bytes:/w=="
+            ],
+            "ASC byte ties order by decoded raw bytes"
+        );
+        assert_eq!(
+            index.search(
+                &Query::All,
+                &[SortField {
+                    field: "sort".into(),
+                    direction: SortDirection::Desc,
+                }],
+                None,
+            ),
+            vec![
+                "bytes:/w==",
+                "bytes:+w==",
+                "bytes:+A==",
+                "bytes:Pg==",
+                "bytes:Cg==",
+                "bytes:AA=="
+            ],
+            "DESC byte ties order by reverse decoded raw bytes"
         );
     }
 

--- a/packages/utils/indexer/interface/src/utils.ts
+++ b/packages/utils/indexer/interface/src/utils.ts
@@ -5,7 +5,69 @@ import {
 	field,
 	getSchema,
 } from "@dao-xyz/borsh";
+import { type IdKey } from "./id.js";
 import { type Sort, SortDirection } from "./query.js";
+
+const idByteEncoder = new TextEncoder();
+
+const compareBytes = (a: Uint8Array, b: Uint8Array): number => {
+	const length = Math.min(a.length, b.length);
+	for (let i = 0; i < length; i++) {
+		if (a[i] !== b[i]) {
+			return a[i] < b[i] ? -1 : 1;
+		}
+	}
+	return a.length - b.length;
+};
+
+const idKindRank = (key: string | number | bigint | Uint8Array): number => {
+	if (typeof key === "number" || typeof key === "bigint") {
+		return 0;
+	}
+	if (key instanceof Uint8Array) {
+		return 1;
+	}
+	return 2;
+};
+
+/**
+ * Break sort ties by the document primary-key id using the id's NATURAL TYPED
+ * order, so equal-sort-key results order identically to the default sqlite3
+ * backend (which scans its primary-key index):
+ *   - integer ids (number/bigint) compare NUMERICALLY   (sqlite INTEGER: 2 < 10)
+ *   - byte ids (Uint8Array)       compare by raw memcmp  (sqlite BLOB)
+ *   - string ids                  compare as UTF-8 bytes (sqlite TEXT / BINARY
+ *                                 collation) — deliberately NOT localeCompare,
+ *                                 whose locale-aware order diverges from sqlite.
+ * A single index only ever holds one id kind; the kind-rank fallback is a
+ * defensive tie-breaker for mixed kinds. Returns a negative/zero/positive number
+ * suitable for Array.prototype.sort. Callers reverse the result when the primary
+ * (last) sort field is DESC so ties follow the scan direction.
+ */
+export const compareIds = (a: IdKey, b: IdKey): number => {
+	const ak = a.key;
+	const bk = b.key;
+	if (
+		(typeof ak === "number" || typeof ak === "bigint") &&
+		(typeof bk === "number" || typeof bk === "bigint")
+	) {
+		// Compare as bigint so a mixed number/bigint pair (u32 IntegerKey vs u64
+		// LargeIntegerKey) still orders by true numeric value.
+		const an = BigInt(ak);
+		const bn = BigInt(bk);
+		return an < bn ? -1 : an > bn ? 1 : 0;
+	}
+	if (ak instanceof Uint8Array && bk instanceof Uint8Array) {
+		return compareBytes(ak, bk);
+	}
+	if (typeof ak === "string" && typeof bk === "string") {
+		return compareBytes(
+			idByteEncoder.encode(ak),
+			idByteEncoder.encode(bk),
+		);
+	}
+	return idKindRank(ak) - idKindRank(bk);
+};
 
 export const stringArraysEquals = (
 	a: string[] | string,
@@ -38,6 +100,7 @@ export const extractSortCompare = (
 	b: Record<string, any>,
 	sorts: Sort[],
 	aliases?: Map<string, string>,
+	ids?: { a: IdKey; b: IdKey },
 ) => {
 	for (const sort of sorts) {
 		const av = extractFieldValue(a, sort.key, aliases);
@@ -49,6 +112,20 @@ export const extractSortCompare = (
 			} else {
 				return -cmp;
 			}
+		}
+	}
+	// All sort fields compared equal: break the tie deterministically by the
+	// document primary-key id in its natural typed order, so the result order is
+	// content-deterministic and matches the default sqlite3 backend instead of
+	// depending on insertion order. The default backend scans its primary-key
+	// index in the sort direction, so reverse the id order when the primary (last)
+	// sort field is DESC.
+	if (ids) {
+		const idCmp = compareIds(ids.a, ids.b);
+		if (idCmp !== 0) {
+			const primaryDirection =
+				sorts.length > 0 ? sorts[sorts.length - 1].direction : SortDirection.ASC;
+			return primaryDirection === SortDirection.DESC ? -idCmp : idCmp;
 		}
 	}
 	return 0;

--- a/packages/utils/indexer/simple/src/index.ts
+++ b/packages/utils/indexer/simple/src/index.ts
@@ -297,7 +297,10 @@ export class HashmapIndex<T extends Record<string, any>, NestedType = any>
 							: [query.sort];
 						sortArr.length > 0 &&
 							indexedDocuments.sort((a, b) =>
-								types.extractSortCompare(a.value, b.value, sortArr),
+								types.extractSortCompare(a.value, b.value, sortArr, undefined, {
+									a: a.id,
+									b: b.id,
+								}),
 							);
 					}
 				}

--- a/packages/utils/indexer/simple/test/index.spec.ts
+++ b/packages/utils/indexer/simple/test/index.spec.ts
@@ -6,7 +6,7 @@ import {
 	StringMatchMethod,
 	id,
 } from "@peerbit/indexer-interface";
-import { tests } from "@peerbit/indexer-tests";
+import { tests, tieParityTests } from "@peerbit/indexer-tests";
 import { expect } from "chai";
 import { create } from "../src/index.js";
 
@@ -29,6 +29,8 @@ describe("all", () => {
 		u64SumSupported: true,
 		iteratorsMutable: false,
 	});
+
+	tieParityTests(create);
 
 	it("applies puts in a batch", async () => {
 		const indices = create();

--- a/packages/utils/indexer/sqlite3/test/index.spec.ts
+++ b/packages/utils/indexer/sqlite3/test/index.spec.ts
@@ -1,4 +1,4 @@
-import { tests } from "@peerbit/indexer-tests";
+import { tests, tieParityTests } from "@peerbit/indexer-tests";
 import { create } from "../src/index.js";
 
 describe("all", () => {
@@ -12,4 +12,5 @@ describe("all", () => {
 		u64SumSupported: false,
 		iteratorsMutable: true,
 	});
+	tieParityTests(create);
 });

--- a/packages/utils/indexer/tests/src/index.ts
+++ b/packages/utils/indexer/tests/src/index.ts
@@ -1,2 +1,3 @@
 export { tests } from "./tests.js";
+export { tieParityTests } from "./tie-parity.js";
 export { benchmarks } from "./benchmarks.js";

--- a/packages/utils/indexer/tests/src/tie-parity.ts
+++ b/packages/utils/indexer/tests/src/tie-parity.ts
@@ -1,0 +1,138 @@
+import { field, variant } from "@dao-xyz/borsh";
+import {
+	type Indices,
+	Sort,
+	SortDirection,
+	getIdProperty,
+	id,
+} from "@peerbit/indexer-interface";
+import { expect } from "chai";
+
+// Cross-backend SORT TIE-BREAK parity: @peerbit/indexer-simple (HashmapIndex) and
+// @peerbit/indexer-sqlite3 must break ties on equal sort keys IDENTICALLY, in the
+// document primary-key id's natural typed order:
+//   - string ids    -> UTF-8 byte order   (sqlite TEXT / BINARY collation)
+//   - integer ids    -> NUMERIC order       (sqlite INTEGER: 2 < 10, not "10" < "2")
+//   - Uint8Array ids -> raw-byte memcmp     (sqlite BLOB: 0x00 < 0xff, not base64)
+// and REVERSE that id order when the (single) sort field is DESC.
+//
+// Every document shares sortKey=1 so the whole result set is one tie group, which
+// forces the id tie-break for every row. Simple historically ordered ties by
+// INSERTION order (direction-independent), matching neither sqlite nor a stable
+// content order; this suite locks simple == sqlite.
+
+@variant("tie_str")
+class StringIdDoc {
+	@id({ type: "string" })
+	id: string;
+
+	@field({ type: "u32" })
+	sortKey: number;
+
+	constructor(id: string) {
+		this.id = id;
+		this.sortKey = 1;
+	}
+}
+
+@variant("tie_bigint")
+class BigIntIdDoc {
+	@id({ type: "u64" })
+	id: bigint;
+
+	@field({ type: "u32" })
+	sortKey: number;
+
+	constructor(id: bigint) {
+		this.id = id;
+		this.sortKey = 1;
+	}
+}
+
+@variant("tie_bytes")
+class BytesIdDoc {
+	@id({ type: Uint8Array })
+	id: Uint8Array;
+
+	@field({ type: "u32" })
+	sortKey: number;
+
+	constructor(id: Uint8Array) {
+		this.id = id;
+		this.sortKey = 1;
+	}
+}
+
+const fmt = (value: string | number | bigint | Uint8Array): string =>
+	value instanceof Uint8Array
+		? Array.from(value)
+				.map((x) => x.toString(16).padStart(2, "0"))
+				.join("")
+		: String(value);
+
+export const tieParityTests = (
+	createIndicies: (directory?: string) => Indices | Promise<Indices>,
+) => {
+	return describe("sort tie-break parity", () => {
+		let indices: Indices | undefined;
+
+		afterEach(async () => {
+			await indices?.stop?.();
+			await indices?.drop?.();
+			indices = undefined;
+		});
+
+		const collect = async (schema: any, docs: any[]) => {
+			indices = await createIndicies();
+			await indices.start();
+			const store = await indices.init({
+				schema,
+				indexBy: getIdProperty(schema) || ["id"],
+			});
+			for (const doc of docs) {
+				await store.put(doc);
+			}
+			const order = async (direction: SortDirection) => {
+				const results = await store
+					.iterate({
+						query: [],
+						sort: [new Sort({ key: "sortKey", direction })],
+					})
+					.all();
+				return results.map((r) => fmt(r.value.id));
+			};
+			const asc = await order(SortDirection.ASC);
+			const desc = await order(SortDirection.DESC);
+			await store.stop?.();
+			await indices.stop?.();
+			await indices.drop?.();
+			indices = undefined;
+			return { asc, desc };
+		};
+
+		it("orders string-id ties by UTF-8 bytes, both directions", async () => {
+			const docs = ["c", "a", "b", "aa", "A", "Z"].map((s) => new StringIdDoc(s));
+			const { asc, desc } = await collect(StringIdDoc, docs);
+			// UTF-8 byte order: uppercase (A, Z) before lowercase (a, aa, b, c).
+			expect(asc).to.deep.equal(["A", "Z", "a", "aa", "b", "c"]);
+			expect(desc).to.deep.equal(["c", "b", "aa", "a", "Z", "A"]);
+		});
+
+		it("orders bigint-id ties numerically, both directions", async () => {
+			const docs = [10n, 2n, 21n, 9n, 100n, 300n].map((n) => new BigIntIdDoc(n));
+			const { asc, desc } = await collect(BigIntIdDoc, docs);
+			expect(asc).to.deep.equal(["2", "9", "10", "21", "100", "300"]);
+			expect(desc).to.deep.equal(["300", "100", "21", "10", "9", "2"]);
+		});
+
+		it("orders Uint8Array-id ties by raw bytes, both directions", async () => {
+			const docs = [[0xff], [0x00], [0x0a], [0x3e], [0xf8], [0xfb]].map(
+				(b) => new BytesIdDoc(new Uint8Array(b)),
+			);
+			const { asc, desc } = await collect(BytesIdDoc, docs);
+			// Raw-byte memcmp: 0x00 < 0x0a < 0x3e < 0xf8 < 0xfb < 0xff.
+			expect(asc).to.deep.equal(["00", "0a", "3e", "f8", "fb", "ff"]);
+			expect(desc).to.deep.equal(["ff", "fb", "f8", "3e", "0a", "00"]);
+		});
+	});
+};


### PR DESCRIPTION
## Problem

Documents with **equal sort keys** were ordered differently depending on which index backend answered the query. A cross-backend conformance test (native rust peer vs default JS peer, identical synced entries, sort by a duplicate-heavy field) found that tied documents came back in a different order on each backend — which breaks stable pagination and consistent results across a mixed fleet.

The divergence was three-way:

| Backend | Tie order | Reproducible across peers? | Reverses under DESC? |
|---|---|---|---|
| `@peerbit/indexer-sqlite3` (default) | by primary-key **id** | yes | yes |
| `@peerbit/indexer-core` (native) | by id **stringified** — only matched sqlite for string ids | strings only | yes |
| `@peerbit/indexer-simple` | by **insertion order** | **no** | no |

- **native** compared the type-prefixed store-key *as a string*, so `bigint` ids ordered lexically (`"10" < "2"`) instead of numerically, and `Uint8Array` ids ordered by their base64 (`0xff` first) instead of raw bytes.
- **indexer-simple** broke ties by `put()` insertion order, which is not reproducible across peers (two replicas that applied the same entries in a different order returned tied rows in a different order) and ignored sort direction. `HashmapIndex` is a live in-band fallback inside every `DocumentIndex`, so this could surface on real nodes, not just tests.

## Fix

Converge all three backends on the same canonical tie-break, which is **sqlite's existing behavior** (the reference — `@peerbit/indexer-sqlite3` is unchanged): when all sort fields compare equal, order tied documents by their primary-key **id in natural typed order** — string = UTF-8 bytes (BINARY), integer = numeric, `Uint8Array` = raw-byte memcmp — reversed when the primary (last) sort field is `DESC`.

- **native** (`packages/utils/indexer/core/src/planner.rs`): parse the store-key into a typed `IdSortKey { Int(u128) | Bytes(Vec<u8>) | Str(String) }` once at insert (dispatching on the `number:`/`bigint:`/`bytes:` prefix; a small standard-alphabet base64 decoder handles the `bytes:` case), and compare that in all three ORDER BY tie-break paths instead of the raw store-key string. The store-key format is load-bearing for identity (persistence/lookup/delete round-trip) and is **not** changed.
- **indexer-simple** (`packages/utils/indexer/interface/src/utils.ts`, `simple/src/index.ts`): add `compareIds` (numeric for int, memcmp for `Uint8Array`, UTF-8 bytes for string — not `localeCompare`) as a direction-aware id tie-break, applied when the value comparison ties.

## Scope (explicit)

- **Indexer level — all id kinds.** `string`, `bigint` (`u64`) and `Uint8Array` primary keys, both directions, are locked by a new shared `tieParityTests` suite (`@peerbit/indexer-tests`) asserting `indexer-simple == indexer-sqlite3`, plus native rust unit tests.
- **Document level — string ids** end-to-end (native peer == default peer). `Uint8Array` document PKs are supported (BLOB) but their tie ordering is covered at the indexer level; a `bigint` document PK is not exercised anywhere in the document suite.
- **Deliberately out of scope** (pre-existing, not regressed by this change): the cross-peer client-side merge-sort in `search.ts` does not apply the id tie-break (a partial-replication query merging tied rows contributed by different peers still uses collection order); the `vector_search` scored-result tie-break still compares the raw store-key; and multi-field `DESC` tie ordering is proven equal between native and simple but not pinned against sqlite (single-field is).

## Testing

- New shared `tieParityTests` — `indexer-simple` and `indexer-sqlite3` assert identical order for string/bigint/bytes, ASC+DESC.
- New document `sort-parity-conformance.spec.ts` — native rust peer and default JS peer sync duplicate-heavy docs and return byte-identical order including ties, ASC+DESC.
- Native rust unit tests: numeric-not-lexical, raw-bytes-not-base64, missing-value group, generic slow path, base64 round-trip.
- Adversarial edge-value check across all three backends (`u64` boundaries incl. `2^63`/`2^64-1`, empty and mixed-length byte ids, non-ASCII UTF-8 strings) — all three agree exactly.
- Full `@peerbit/indexer-simple` and `@peerbit/indexer-sqlite3` suites pass (shared comparator change, no regressions).
