### PR TITLE
fix(indexer): restart cached indices on reopen (close→reopen lifecycle)

### DIFF
--- a/.changeset/rust-indexer-reopen-restart.md
+++ b/.changeset/rust-indexer-reopen-restart.md
@@ -1,0 +1,12 @@
+---
+"@peerbit/indexer-rust": patch
+"@peerbit/indexer-simple": patch
+---
+
+Restart cached indices on reopen (close -> reopen lifecycle fix)
+
+The node-level indexer `Indices` scope is cached per node and outlives a program close. When a program closed it stopped its own indices (state -> "closed") while the scope stayed alive; on reopen, `Indices.init` hit the existing-index early-return branch and handed back the still-stopped index without restarting it. The next synchronous read on open (e.g. shared-log's `replicationIndex.count(...)` / `iterate(...)` during hydrate) then threw `NotStartedError`.
+
+`init`'s existing-index branch now calls `index.start()` (idempotent; no-op when already open) before returning the cached index whenever the scope is open, mirroring the restart the freshly-created path already performs. This matches the sqlite3 backend, which already recovers because its `scope()` restarts cached indices via a start cascade before `init` runs.
+
+Fixes `@peerbit/indexer-rust` (`RustIndices`) and the same latent gap in `@peerbit/indexer-simple` (`HashmapIndices`); sqlite3 was already correct and is unchanged.

--- a/packages/programs/data/shared-log/test/reopen-native-lifecycle.spec.ts
+++ b/packages/programs/data/shared-log/test/reopen-native-lifecycle.spec.ts
@@ -1,0 +1,84 @@
+// Regression proof for the rust-indexer close -> reopen lifecycle bug.
+//
+// The node-level indexer `Indices` scope is cached per node and outlives a
+// program close. When a native (rust) shared-log program closes it stops its
+// own rust indices (state -> "closed") but leaves the cached scope alive. On
+// reopen the shared-log re-inits through the cached scope and reads
+// synchronously on open (`replicationIndex.count(...)` for
+// `hasIndexedReplicationInfo`). Before the fix, `RustIndices.init` returned the
+// stopped cached index without restarting it, so that first read threw
+// `NotStartedError`. This test opens a genuine native peer, writes, closes, and
+// reopens the SAME address on the SAME still-running peer and asserts the
+// reopen does not throw and the native backbone is re-attached.
+import { waitForResolved } from "@peerbit/time";
+import { expect } from "chai";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { Peerbit } from "peerbit";
+import { createRustPeerbitOptions } from "peerbit/rust";
+import { EventStore } from "./utils/stores/event-store.js";
+
+describe("reopen native lifecycle", function () {
+	this.timeout(120_000);
+
+	let peer: Peerbit;
+	let directory: string;
+
+	beforeEach(async () => {
+		// A genuine native peer: the rust indexer + native backbone preset. An
+		// on-disk directory keeps the block store across a program close so the
+		// reopen can resolve its heads — the peer itself is NOT stopped, so the
+		// node-cached indexer scope survives (the bug's precondition).
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-reopen-native-"),
+		);
+		peer = await Peerbit.create({ directory, ...createRustPeerbitOptions() });
+	});
+
+	afterEach(async () => {
+		await peer?.stop();
+		if (directory) {
+			await fs.rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("reopens a closed store on the same running peer without NotStartedError", async () => {
+		// --- Open #1: plain open, write a few entries -----------------------
+		const db1 = await peer.open(new EventStore<string, any>(), {
+			args: { replicate: { factor: 1 } },
+		});
+
+		// Native backbone is attached on the first open.
+		expect((db1.log as any)._nativeBackbone, "open #1 native backbone").to
+			.exist;
+
+		const address = db1.address!;
+		for (let i = 0; i < 5; i++) {
+			await db1.add(`entry-${i}`, { meta: { next: [] } });
+		}
+		await waitForResolved(async () =>
+			expect(db1.log.log.length).to.equal(5),
+		);
+
+		// --- Close: stops the program's rust indices; the node-cached indexer
+		// scope stays alive. ---------------------------------------------------
+		await db1.close();
+
+		// --- Open #2: reopen the SAME address on the SAME running peer. The
+		// reopen re-inits through the cached rust indexer scope and reads
+		// synchronously on open. Before the fix this threw `NotStartedError`. ---
+		const db2 = (await EventStore.open(address, peer, {
+			args: { replicate: { factor: 1 } },
+		})) as EventStore<string, any>;
+
+		// The reopen resolved without throwing and re-attached the native path.
+		expect((db2.log as any)._nativeBackbone, "reopen native backbone").to
+			.exist;
+
+		// Sanity: the reopened log is usable (a read on open succeeded above).
+		expect(await db2.log.replicationIndex.count()).to.be.a("number");
+
+		await db2.close();
+	});
+});

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -4990,6 +4990,13 @@ export class RustIndices implements types.Indices {
 			(i) => i.schema === properties.schema,
 		);
 		if (existingIndex) {
+			// This scope is node-cached and outlives a program close, so a prior
+			// close may have stopped the cached index. Restart it before handing
+			// it back so the next read does not hit assertOpen -> NotStartedError.
+			// start() is idempotent (no-op when already open).
+			if (!this.closed) {
+				await existingIndex.index.start();
+			}
 			return existingIndex.index as RustIndex<T, NestedType>;
 		}
 		const index = new RustIndex<T, NestedType>(

--- a/packages/utils/indexer/simple/src/index.ts
+++ b/packages/utils/indexer/simple/src/index.ts
@@ -627,6 +627,13 @@ export class HashmapIndices implements types.Indices {
 			(i) => i.schema === properties.schema,
 		);
 		if (existingIndex) {
+			// This scope is node-cached and outlives a program close, so a prior
+			// close may have stopped the cached index. Restart it before handing
+			// it back so the next read does not hit assertOpen -> NotStartedError.
+			// start() is idempotent (no-op when already open).
+			if (!this.closed) {
+				await existingIndex.index.start();
+			}
 			return existingIndex.index as HashmapIndex<T, NestedType>;
 		}
 		const index = new HashmapIndex<T, NestedType>();


### PR DESCRIPTION
## Problem

Closing a shared-log program and reopening it on the **same running node** throws `NotStartedError` when the node uses the **rust** indexer (`@peerbit/indexer-rust`) — but works on the default sqlite3 backend. This is a rust-vs-sqlite3 lifecycle-contract divergence.

Root cause: the node-level indexer `Indices` scope is cached per node and outlives a program close. A program close stops its own indices (`state -> "closed"`) while the cached scope stays alive. On reopen, `Indices.init` hits the existing-index early-return branch and hands back the still-stopped index **without restarting it**, so the next synchronous read on open (shared-log's `replicationIndex.count(...)`/`iterate(...)` during hydrate) throws `NotStartedError`.

sqlite3 escapes this because its `scope()` restarts cached indices via a `start()` cascade *before* `init` runs; rust (`RustIndices`) and simple (`HashmapIndices`) do not.

## Fix

In the existing-index branch of `Indices.init`, restart the cached index (`start()` is idempotent — a no-op when already open) when the scope is open, mirroring the restart the freshly-created path already performs. Applied to `@peerbit/indexer-rust` and the same latent gap in `@peerbit/indexer-simple`. sqlite3 was already correct and is unchanged.

## How it was found

Surfaced by a new `[default, native]` conformance auto-matrix that re-runs the existing shared-log suite against the native backend — the close→reopen tests (e.g. `leader.spec.ts`) failed only on native. Reproduced independently with a genuine native peer (no test harness involved) and A/B-confirmed (revert → `NotStartedError`, reapply → passes).

## Testing

- New regression test `reopen-native-lifecycle.spec.ts`: a genuine native peer opens a store, adds entries, closes, and reopens the same address on the same running peer — asserts no throw and native backbone present. Fails without the fix, passes with it.
- No regressions: indexer-rust `cargo test` clean; indexer-rust TS **270 passing**; indexer-simple **117 passing** (incl. existing `can restart` / `starts on init if scope is started`); shared-log `network-e2e-native` **3 passing**, `durable-restart-conformance` **2 passing**.
