### PR TITLE
test(shared-log): opt-in [default,native] conformance matrix leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,6 +501,18 @@ jobs:
         run: pnpm --filter @peerbit/network-rust run test
       - name: Test @peerbit/stream suite in rust-core mode
         run: pnpm --filter @peerbit/network-rust run test:stream-rust-core
+      - name: Test @peerbit/shared-log conformance in rust-core mode
+        # Opt-in [default,native] conformance leg: re-runs an allowlist of the
+        # EXISTING shared-log suites with the native (rust) data plane engaged
+        # via PEERBIT_SHARED_LOG_RUST_CORE=1 (see test:shared-log-rust-core and
+        # the switch in packages/clients/test-utils/src/session.ts). The
+        # allowlist is anchored to the describes confirmed byte-for-byte green
+        # native; Class-B message-counter / over-nativization / A1-hollow-entry
+        # divergences are excluded (see the PR body) and this leg widens as they
+        # are made backend-agnostic. Non-blocking initially: allowed to be a
+        # soft signal while the excluded set is driven down.
+        continue-on-error: true
+        run: pnpm --filter @peerbit/shared-log run test:shared-log-rust-core
       - name: Test @peerbit/network-rust in the browser
         # Runs the browser-compatible subset (wire/topic-control/fanout codec
         # parity) under headless Chromium, proving the wasm module loads and

--- a/packages/clients/test-utils/src/session.ts
+++ b/packages/clients/test-utils/src/session.ts
@@ -26,6 +26,148 @@ import {
 import { Peerbit } from "peerbit";
 import { InMemoryNetwork, InMemorySession } from "./inmemory-libp2p.js";
 
+// ---------------------------------------------------------------------------
+// [default,native] conformance auto-matrix switch
+// ---------------------------------------------------------------------------
+// When PEERBIT_SHARED_LOG_RUST_CORE=1 is set, every real (non in-memory,
+// non-external-libp2p) TestSession peer is created with the native Rust data
+// plane: native block/any-store storage, the native (rust) indexer, and the
+// `sharedLogNativeDefaults` preset so a PLAIN `shared-log.open()` auto-nativizes
+// (native backbone + native graph + raw exchange-heads sync). This lets the
+// EXISTING shared-log suites run unmodified against the native backend so we can
+// diff native-vs-JS behaviour.
+//
+// We deliberately DO NOT engage the native network/transport core here
+// (rustCore:false, wireSync:false): TestSession builds its own JS libp2p
+// services (DirectBlock/TopicControlPlane/FanoutTree) and hands the finished
+// instance to `Peerbit.create({ libp2p })`. `Peerbit.create` refuses the
+// `network` option together with an external libp2p instance, and running a
+// second (native) DirectStream over the same node would conflict. So the switch
+// injects the storage + indexer via the normal create options and stamps
+// `sharedLogNativeDefaults` onto the instance AFTER create (with
+// `nativeWireSync: undefined`, i.e. raw exchange-heads over the JS wire).
+//
+// Default (env-unset) runs are byte-for-byte unchanged: `nativeMatrixConfig()`
+// returns undefined and none of the injection code runs.
+
+const SHARED_LOG_RUST_CORE_ENV = "PEERBIT_SHARED_LOG_RUST_CORE";
+
+const isSharedLogRustCoreEnabled = (): boolean =>
+	process.env[SHARED_LOG_RUST_CORE_ENV] === "1" ||
+	process.env[SHARED_LOG_RUST_CORE_ENV] === "true";
+
+type NativeMatrixConfig = {
+	storage: CreateOptions["storage"];
+	indexer: NonNullable<CreateOptions["indexer"]>;
+	sharedLogNativeDefaults: unknown;
+};
+
+let nativeMatrixConfigPromise: Promise<NativeMatrixConfig> | undefined;
+
+/**
+ * Build the native storage + indexer + shared-log defaults for the matrix.
+ * Hard-fails (throws) if the native modules are not present, so a broken/omitted
+ * native build surfaces as a loud error rather than a silent false-green
+ * default-backend run.
+ */
+const buildNativeMatrixConfig = async (): Promise<NativeMatrixConfig> => {
+	// Storage + indexer presets from the `peerbit/rust` client preset, but with
+	// the native network core explicitly disabled (see the block comment above).
+	// `network: false` yields `{ storage, indexer }` only — no native transport
+	// runtime, no `sharedLogDefaults` wire-sync session.
+	const { createRustPeerbitOptions } = await import("peerbit/rust");
+
+	// Native-present guard: importing must yield a real callable. If the native
+	// package is stubbed/absent this throws here (loud), never false-green.
+	if (typeof createRustPeerbitOptions !== "function") {
+		throw new Error(
+			`${SHARED_LOG_RUST_CORE_ENV} is set but the native Rust data-plane module ` +
+				`(peerbit/rust) is not available. Refusing to run the "native" matrix ` +
+				`leg on the default backend (would be a false green).`,
+		);
+	}
+
+	const preset = createRustPeerbitOptions({ network: false });
+	const storage = preset.storage as CreateOptions["storage"];
+	const indexer = preset.indexer as NonNullable<CreateOptions["indexer"]>;
+
+	// Sanity-probe the native indexer once so an unbuildable wasm module fails
+	// here (loud) instead of mid-suite.
+	const probe = await indexer();
+	await (probe as { start?: () => Promise<void> }).start?.();
+	await (probe as { stop?: () => Promise<void> }).stop?.();
+
+	// Mirrors the `sharedLogNativeDefaults` shape produced by peer.ts for the
+	// `peerbit/rust` preset, but WITHOUT a native wire-sync session (no native
+	// transport in the matrix — raw exchange-heads travel over the JS wire).
+	const sharedLogNativeDefaults = {
+		nativeBackbone: {},
+		nativeGraph: { optional: true },
+		sync: {
+			rawExchangeHeads: true,
+			nativeWireSync: undefined as unknown,
+		},
+	};
+
+	return { storage, indexer, sharedLogNativeDefaults };
+};
+
+const nativeMatrixConfig = (): Promise<NativeMatrixConfig> | undefined => {
+	if (!isSharedLogRustCoreEnabled()) {
+		return undefined;
+	}
+	nativeMatrixConfigPromise ??= buildNativeMatrixConfig();
+	return nativeMatrixConfigPromise;
+};
+
+/**
+ * Merge the native matrix storage/indexer into a peer's create options WITHOUT
+ * clobbering options a spec set explicitly (fill-only-undefined). Returns the
+ * options unchanged when the matrix is off.
+ */
+const applyNativeMatrixCreateOptions = <
+	O extends {
+		indexer?: CreateOptions["indexer"];
+		storage?: CreateOptions["storage"];
+	},
+>(
+	config: NativeMatrixConfig | undefined,
+	options: O,
+): O => {
+	if (!config) {
+		return options;
+	}
+	return {
+		...options,
+		indexer: options.indexer ?? config.indexer,
+		storage: options.storage ?? config.storage,
+	};
+};
+
+/**
+ * Post-create injection of `sharedLogNativeDefaults` so a plain
+ * `shared-log.open()` on this peer auto-nativizes. `sharedLogNativeDefaults` is
+ * declared readonly on Peerbit (it is normally set by the `network` create
+ * option, which is incompatible with the external libp2p instance TestSession
+ * builds), so we assign it here after the instance exists.
+ */
+const injectNativeMatrixDefaults = (
+	config: NativeMatrixConfig | undefined,
+	peer: Peerbit,
+): Peerbit => {
+	if (!config) {
+		return peer;
+	}
+	if ((peer as { sharedLogNativeDefaults?: unknown }).sharedLogNativeDefaults) {
+		// Respect a peer that already advertises native defaults (e.g. a
+		// `peerbit/rust` client); do not override its chosen preset.
+		return peer;
+	}
+	(peer as { sharedLogNativeDefaults?: unknown }).sharedLogNativeDefaults =
+		config.sharedLogNativeDefaults;
+	return peer;
+};
+
 export type LibP2POptions = Libp2pOptions<Libp2pExtendServices>;
 
 type CreateOptions = {
@@ -824,23 +966,29 @@ export class TestSession {
 			: m(options);
 
 		const session = await SSession.disconnected(n, optionsWithServices);
+		const matrix = await nativeMatrixConfig();
 		return new TestSession(
 			session,
 			(await Promise.all(
 				session.peers.map((x, ix) =>
-					Array.isArray(options)
-						? Peerbit.create({
-								libp2p: x,
-								directory: options[ix]?.directory,
-								indexer: options[ix]?.indexer,
-								storage: options[ix]?.storage,
-							})
-						: Peerbit.create({
-								libp2p: x,
-								directory: options?.directory,
-								indexer: options?.indexer,
-								storage: options?.storage,
-							}),
+					(Array.isArray(options)
+						? Peerbit.create(
+								applyNativeMatrixCreateOptions(matrix, {
+									libp2p: x,
+									directory: options[ix]?.directory,
+									indexer: options[ix]?.indexer,
+									storage: options[ix]?.storage,
+								}),
+							)
+						: Peerbit.create(
+								applyNativeMatrixCreateOptions(matrix, {
+									libp2p: x,
+									directory: options?.directory,
+									indexer: options?.indexer,
+									storage: options?.storage,
+								}),
+							)
+					).then((peer) => injectNativeMatrixDefaults(matrix, peer)),
 				),
 			)) as Peerbit[],
 		);

--- a/packages/programs/data/shared-log/package.json
+++ b/packages/programs/data/shared-log/package.json
@@ -61,6 +61,7 @@
 		"benchmark:sync-catchup": "node --loader ts-node/esm ./benchmark/sync-catchup.ts",
 		"benchmark:sync-phase-profile": "node --loader ts-node/esm ./benchmark/sync-phase-profile.ts",
 		"test": "aegir test --target node",
+		"test:shared-log-rust-core": "npm run build && PEERBIT_SHARED_LOG_RUST_CORE=1 aegir test -t node --grep '^(?!.*(does not fetch missing entries from remotes|will prune once reaching max replicas|repairs when joiner request responses are dropped|time out when pending IHave are never resolved|does not confirm checked prune from a shallow-only entry|replication degree update ))(append delivery options |join |replicate |(u32-simple|u64-iblt) (replication references |replication replication (one way|two way) |canReplicate |replication degree |sync ))'",
 		"lint": "aegir lint",
 		"test:cov": "aegir test -t node --cov"
 	},

--- a/packages/programs/data/shared-log/test/NATIVE_CONFORMANCE.md
+++ b/packages/programs/data/shared-log/test/NATIVE_CONFORMANCE.md
@@ -1,0 +1,142 @@
+# shared-log `[default, native]` conformance matrix (opt-in CI leg)
+
+This document is the PR body / reference for the opt-in `[default, native]`
+conformance leg that re-runs a curated allowlist of the **existing** shared-log
+suites against the native (Rust) data plane. It is test-infra only.
+
+## Mechanism
+
+An env switch, `PEERBIT_SHARED_LOG_RUST_CORE=1`, flips `TestSession`
+(`packages/clients/test-utils/src/session.ts`) so that every real (non
+in-memory, non-external-libp2p) peer is created with the native data plane:
+
+- **Storage + indexer** come from `createRustPeerbitOptions({ network: false })`
+  (native block/any-store storage + native rust indexer), merged into the peer's
+  create options **fill-only-undefined** so a spec that sets `storage`/`indexer`
+  explicitly is never clobbered.
+- **`sharedLogNativeDefaults`** is stamped onto the instance **after**
+  `Peerbit.create`, with `nativeWireSync: undefined`. This makes a plain
+  `shared-log.open()` auto-nativize the backbone + graph and use raw
+  exchange-heads over the **existing JS wire** — no second (native) transport
+  core. `Peerbit.create` refuses `network` together with an external libp2p, and
+  a second native `DirectStream` over the same node would conflict, so the switch
+  deliberately does **not** engage the native network/transport core.
+
+A **hard native-present guard** throws (loud) if `peerbit/rust` does not resolve
+to a real callable, and it sanity-probes the native indexer once (start/stop).
+A missing or stubbed native build therefore surfaces as a loud error rather than
+a silent false-green run on the default backend.
+
+**Default (env-unset) runs are byte-for-byte unchanged:** `nativeMatrixConfig()`
+returns `undefined` and none of the injection code executes.
+
+The only product-ish file touched is `session.ts`, which is test infrastructure.
+No shared-log `src/` product code is changed by this PR.
+
+## What the leg covers (allowlist)
+
+The leg is wired as `@peerbit/shared-log`'s `test:shared-log-rust-core` script
+and a CI step in the `test_native` job, mirroring the stream layer's
+`test:stream-rust-core`. The allowlist is a mocha `--grep` anchored to the
+top-level describe titles confirmed **byte-for-byte green** under the native
+backend:
+
+| Describe (mocha title path)                                   | Native result |
+| ------------------------------------------------------------- | ------------- |
+| `append delivery options` (delivery.spec)                     | 11/11         |
+| `join` (+ `mergeSegments`, `already but not replicated`)      | 15/15         |
+| `replicate` (+ observer/replicator/mode/entry/persistance)    | 28/28         |
+| `<setup> replication references` (joins-by-ref, next-blocks)  | green         |
+| `<setup> replication replication one way` (1/1000/large/…)    | green*        |
+| `<setup> replication replication two way` (partial synced)    | 6/6           |
+| `<setup> canReplicate`                                        | 4/4           |
+| `<setup> replication degree` (prune-family + commit options)  | green*        |
+| `<setup> sync` (manually synced entries)                      | 2/2           |
+
+`<setup>` is `u32-simple` or `u64-iblt` (the active `testSetups`). `replicate`'s
+`persistance` block includes the close→reopen restart cases, which pass thanks to
+the rust-indexer reopen fix (#1019).
+
+`*` = the describe is green **except** the specifically excluded tests below,
+which are removed from the grep via negative lookahead (the whole
+`replication degree update` sub-block is excluded as one unit).
+
+The leg is **opt-in and non-blocking** initially (`continue-on-error: true`). It
+widens as the Class-B tests below are made backend-agnostic.
+
+## What is EXCLUDED, and why (honest catalog — no silent caps)
+
+### Class-B — message-counter artifacts (convergence is correct)
+
+These assert on *how many* wire messages/fetches happened, not on final
+convergence. The native path converges to the same state but moves a different
+number of frames (e.g. via authoritative push / different sync batching), so the
+counters differ. Convergence is correct; only the counter assertion fails.
+
+- `redundancy > only sends entries once …` (2 peers dynamic/fixed/write-after-open, 3 peers)
+- `one way > it does not fetch missing entries from remotes when exchanging heads to remote`
+- `replication > retries simple sync when first response is dropped`
+- `leader > will consider in flight` (leader.spec — not in the allowlist describes)
+
+**Root cause for the future widening:** `getReceivedHeads` (and the per-message
+counters layered on it) is backend-coupled — it counts JS-wire receive events
+that the native raw-exchange path does not emit the same way. Making these
+counters backend-agnostic (or asserting on convergence instead of counts) is the
+next widening step, which would fold most of Class-B into the leg.
+
+### Class-C — over-nativization
+
+- `replication degree > update > …` sub-block (range-rotation / prune-delay
+  integration tests, e.g. `a smaller replicator join leave joins`). Under the
+  full native backbone these exercise code paths the narrower native modes do not,
+  and diverge. Excluded as a unit (`replication degree update`).
+
+### Finding-B — scoping (native converges via authoritative push)
+
+- `commit options > control per commmit put before join repairs when joiner
+  request responses are dropped` (u64-iblt only). The JS path repairs by
+  re-requesting dropped joiner responses; the native path instead converges via
+  authoritative push, so the "responses were re-requested" assertion does not
+  hold. Final state converges. All the other authoritative-repair tests in
+  `commit options` are **green** and are covered by the leg.
+
+### A1 — hollow-entry divergence (real, deferred)
+
+- `replication degree > will prune once reaching max replicas`
+- `replication degree > time out when pending IHave are never resolved`
+- `replication degree > does not confirm checked prune from a shallow-only entry`
+
+These fail native with `Failed to load entry from head …` / prune-count
+divergences rooted in how the native backbone materializes shallow/hollow
+entries during prune bookkeeping. This is a **real** divergence, deferred out of
+this test-infra PR; it should be tracked and fixed in the native backbone, then
+folded into the leg.
+
+### A2 — memory-only durability (Class-D), NOT a bug
+
+- `start/stop > can restart replicate` fails native on reopen with
+  `Failed to load entry from head`. Its `TestSession.connected(3)` session has
+  **no directory** → a memory-only native block store, which loses entries when a
+  store is closed and reopened.
+
+  **Verdict (verified):** a directory-backed native analog — two peers, `db1`
+  live, `db2` closed and REOPENED from an on-disk native store
+  (`Peerbit.create({ directory, ...createRustPeerbitOptions() })`, the
+  `durable-restart-conformance.spec.ts` pattern), then re-replicating the entry
+  appended while closed (length 1→2) — **PASSES**. So the original failure is
+  **expected Class-D memory-only durability**, not a real bug. Excluded from the
+  allowlist and documented here.
+
+### Also excluded
+
+- `sync-raw` "keeps the plain live path for peers that never advertised raw" and
+  restart-without-directory cases — memory-only / narrower-native-mode scope,
+  same Class-C/Class-D rationale.
+
+## Verification summary
+
+- **Native (env set):** allowlist grep GREEN (0 failing) — see below.
+- **Default (env unset):** same allowlist grep GREEN (baseline unchanged).
+- **Guard:** with the native import stubbed to a non-function, the leg throws
+  loudly (`… is set but the native Rust data-plane module (peerbit/rust) is not
+  available. Refusing to run the "native" matrix leg …`) instead of false-green.


### PR DESCRIPTION
## What this is

An **opt-in, non-blocking** CI leg that re-runs a curated allowlist of the **existing** shared-log test suites against the native (Rust) data plane, to diff native-vs-JS behaviour continuously. It mirrors the stream layer's `test:stream-rust-core` pattern. **Test-infrastructure only — no shared-log `src/` product code is changed.**

Flip `PEERBIT_SHARED_LOG_RUST_CORE=1` and `TestSession` creates every real peer with the native storage + rust indexer and stamps `sharedLogNativeDefaults` so plain `shared-log.open()` auto-nativizes the backbone/graph over the existing JS wire (no second transport core). A hard guard throws loudly if the native build is absent, so a missing wasm can never false-green as JS. Default (env-unset) runs are byte-for-byte unchanged.

## Why — it already pays for itself

This matrix, on its first runs, surfaced a real native lifecycle bug the entire hand-written suite missed — the rust-indexer close→reopen `NotStartedError`, fixed in #1019 (now on master, and its regression case passes green under this leg). Continuously re-running the JS suite against native is the force multiplier for catching native/JS divergence in the hybrid fleet.

## Coverage & honesty

- **Allowlist (native + default: 137 passing / 0 failing each):** `append delivery options`, `join`, `replicate` (incl. close→reopen restart), `replication references` / `one way` / `two way`, `canReplicate`, `replication degree` (prune-family + commit-options authoritative-repair), `sync`.
- **The excluded set is fully documented** in [`test/NATIVE_CONFORMANCE.md`](packages/programs/data/shared-log/test/NATIVE_CONFORMANCE.md) — no silent caps. Summary:
  - **Class-B message-counter artifacts** (~convergence is correct; tests count JS-specific wire messages/fetches). One shared root cause (`getReceivedHeads` is backend-coupled) — making it backend-agnostic is the next widening step and folds most of these back in.
  - **Finding B** (joiner-response repair): native converges via a one-way authoritative push instead of re-requesting dropped responses — verified to reach correct state; scoping, not a bug.
  - **A1 — a real divergence, deferred:** native backbone materializes shallow/hollow entries incompletely during prune bookkeeping (`Failed to load entry from head`). Should be fixed in the native backbone, then folded in. This is the recommended next target.
  - **A2:** memory-only durability — a directory-backed native restart passes, so it's expected Class-D behaviour, not a bug.

## Verification

Native leg green (0 failing), default baseline unchanged, and the hard native-present guard verified to throw (no false-green). The leg is `continue-on-error: true` initially (soft signal) and is intended to be promoted to blocking once the excluded Class-B set is driven down.
