### PR TITLE
fix(log): materialize hollow head entries at the read cache boundary

### DIFF
--- a/.changeset/native-hollow-head-entry.md
+++ b/.changeset/native-hollow-head-entry.md
@@ -1,0 +1,13 @@
+---
+"@peerbit/log": patch
+"@peerbit/shared-log": patch
+---
+
+Fix native-vs-default parity for live-replicated head entries.
+
+On the native shared-log path a live-replicated HEAD is cached in the entry index as a lazy `PreparedRawExchangeEntry` wrapper (it keeps the block bytes in wasm and only exposes generic getters). Its `_meta`/`_payload`/`_signatures` fields stay undefined, so a read of that head returned a hollow object: field consumers saw `undefined`, and because `EntryV0.equals` is gated on `other instanceof EntryV0`, comparisons were asymmetric (`jsEntry.equals(head)` was `false` while `head.equals(jsEntry)` was `true`). The default backend caches heads as full `EntryV0`, so this divergence was native-only. The underlying block was always fully present and decodable — only the cached JS object was hollow.
+
+- `@peerbit/log`: add a generic `Entry.toMaterialized()` capability (a no-op returning `this` on the concrete `EntryV0`, so the default backend is unchanged). The entry index calls it at the read/resolve cache boundary and writes the materialized entry back into the cache, so a resolved head is always a full entry and the hot head is not re-decoded on subsequent reads.
+- `@peerbit/shared-log`: `PreparedRawExchangeEntry` overrides `toMaterialized()` to decode itself into its full `EntryV0`.
+
+Materialization happens only at the read boundary; the wire/sync fusion path caches heads via `put` but never resolves them, so it stays lazy (no block-byte materialization on send/receive).

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -2902,6 +2902,27 @@ export class EntryIndex<T> {
 		return shadowedGids;
 	}
 
+	/**
+	 * A cache hit is a read boundary: the caller is about to consume the
+	 * entry's contents. Lazy wrapper entries (e.g. the native shared log's
+	 * stash-backed head, whose fields stay hollow and whose `instanceof
+	 * EntryV0` is false) must be replaced by their fully-materialized entry
+	 * here so field consumers and `EntryV0.equals` see the canonical entry.
+	 * The materialized entry is written back into the cache so the hot head is
+	 * not re-decoded on subsequent reads. Concrete entries return `this` at
+	 * zero cost, so the default backend is unaffected. This runs only on the
+	 * read path — never on the wire/sync fusion path, which caches heads via
+	 * `put` but never resolves them — so entry laziness on the wire is
+	 * preserved.
+	 */
+	private materializeCached(k: string, mem: Entry<T>): Entry<T> {
+		const materialized = mem.toMaterialized();
+		if (materialized !== mem) {
+			this.cache.add(k, materialized);
+		}
+		return materialized;
+	}
+
 	private async resolve(
 		k: string,
 		options?: ResolveFullyOptions,
@@ -2920,6 +2941,8 @@ export class EntryIndex<T> {
 			if (mem) {
 				this.cache.add(k, mem);
 			}
+		} else if (mem) {
+			mem = this.materializeCached(k, mem);
 		}
 		return mem ? mem : undefined;
 		/* }
@@ -2946,7 +2969,7 @@ export class EntryIndex<T> {
 			const hash = hashes[i]!;
 			const mem = this.cache.get(hash);
 			if (mem !== undefined) {
-				resolved[i] = mem ? mem : undefined;
+				resolved[i] = mem ? this.materializeCached(hash, mem) : undefined;
 				continue;
 			}
 			missingHashes.push(hash);

--- a/packages/log/src/entry.ts
+++ b/packages/log/src/entry.ts
@@ -158,6 +158,27 @@ export abstract class Entry<T> {
 		return serialize(this);
 	}
 
+	/**
+	 * Return a fully-materialized, read-oriented version of this entry: an
+	 * instance whose `meta`/`payload`/`signatures` fields are populated (i.e. a
+	 * concrete {@link EntryV0}), suitable for being cached and read many times.
+	 *
+	 * Concrete entries ({@link EntryV0}) are already fully materialized and
+	 * return `this` at zero cost. Lazy wrapper entries (e.g. the native shared
+	 * log's stash-backed head wrapper, which keeps the block bytes in wasm and
+	 * only exposes generic getters) override this to decode themselves into a
+	 * full entry so that consumers reading via field access or an
+	 * `instanceof EntryV0` gated comparison (see {@link EntryV0.equals}) see the
+	 * canonical entry rather than the hollow wrapper.
+	 *
+	 * This must only be called at a read boundary (where a consumer actually
+	 * needs the entry's contents), never on the wire/sync fusion path — a lazy
+	 * wrapper materializing here copies its block bytes out of native memory.
+	 */
+	toMaterialized(): Entry<T> {
+		return this;
+	}
+
 	async getPublicKeys(): Promise<PublicSignKey[]> {
 		const signatures = await this.getSignatures();
 		return signatures.map((s) => s.publicKey);

--- a/packages/programs/data/shared-log/package.json
+++ b/packages/programs/data/shared-log/package.json
@@ -61,7 +61,7 @@
 		"benchmark:sync-catchup": "node --loader ts-node/esm ./benchmark/sync-catchup.ts",
 		"benchmark:sync-phase-profile": "node --loader ts-node/esm ./benchmark/sync-phase-profile.ts",
 		"test": "aegir test --target node",
-		"test:shared-log-rust-core": "npm run build && PEERBIT_SHARED_LOG_RUST_CORE=1 aegir test -t node --grep '^(?!.*(does not fetch missing entries from remotes|will prune once reaching max replicas|repairs when joiner request responses are dropped|time out when pending IHave are never resolved|does not confirm checked prune from a shallow-only entry|replication degree update ))(append delivery options |join |replicate |(u32-simple|u64-iblt) (replication references |replication replication (one way|two way) |canReplicate |replication degree |sync ))'",
+		"test:shared-log-rust-core": "npm run build && PEERBIT_SHARED_LOG_RUST_CORE=1 aegir test -t node --grep '^(?!.*(does not fetch missing entries from remotes|will prune once reaching max replicas|repairs when joiner request responses are dropped|time out when pending IHave are never resolved|does not confirm checked prune from a shallow-only entry|replication degree update ))(append delivery options |join |replicate |(u32-simple|u64-iblt) (replication references |replication replication (one way|two way) |canReplicate |replication degree |start/stop replicate on connect|sync ))'",
 		"lint": "aegir lint",
 		"test:cov": "aegir test -t node --cov"
 	},

--- a/packages/programs/data/shared-log/src/exchange-heads.ts
+++ b/packages/programs/data/shared-log/src/exchange-heads.ts
@@ -779,6 +779,19 @@ class PreparedRawExchangeEntry<T> extends Entry<T> {
 		return this.hash === other.hash || this.materialize().equals(other);
 	}
 
+	/**
+	 * Read boundary: when this lazy head is resolved from the entry-index cache
+	 * a consumer is about to read it, so decode into a full {@link EntryV0}
+	 * whose meta/payload/signature fields are populated. The entry index caches
+	 * the returned entry, replacing this hollow wrapper, so subsequent reads and
+	 * `EntryV0.equals` see the canonical entry. Only reached on the read path;
+	 * the wire/sync fusion path never resolves cached heads, so laziness there
+	 * is preserved.
+	 */
+	override toMaterialized(): Entry<T> {
+		return this.materialize();
+	}
+
 	toSignable(): Entry<T> {
 		return this.materialize().toSignable();
 	}

--- a/packages/programs/data/shared-log/test/NATIVE_CONFORMANCE.md
+++ b/packages/programs/data/shared-log/test/NATIVE_CONFORMANCE.md
@@ -51,11 +51,20 @@ backend:
 | `<setup> replication replication two way` (partial synced)    | 6/6           |
 | `<setup> canReplicate`                                        | 4/4           |
 | `<setup> replication degree` (prune-family + commit options)  | green*        |
+| `<setup> start/stop replicate on connect`                     | 2/2           |
 | `<setup> sync` (manually synced entries)                      | 2/2           |
 
 `<setup>` is `u32-simple` or `u64-iblt` (the active `testSetups`). `replicate`'s
 `persistance` block includes the close→reopen restart cases, which pass thanks to
 the rust-indexer reopen fix (#1019).
+
+`start/stop replicate on connect` is the single test lifted from the otherwise
+memory-only `start/stop` describe: it was native-red because a live-replicated
+head was cached as a hollow lazy wrapper (its `_meta`/`_payload`/`_signatures`
+stayed undefined, and `EntryV0.equals` — gated on `instanceof EntryV0` — was
+asymmetric against it). Fixed by materializing the head at the entry-index read
+boundary (`Entry.toMaterialized()`); see the S1 entry below. The rest of the
+`start/stop` describe stays excluded for the memory-only Class-D reason (A2).
 
 `*` = the describe is green **except** the specifically excluded tests below,
 which are removed from the grep via negative lookahead (the whole
@@ -100,17 +109,53 @@ next widening step, which would fold most of Class-B into the leg.
   hold. Final state converges. All the other authoritative-repair tests in
   `commit options` are **green** and are covered by the leg.
 
-### A1 — hollow-entry divergence (real, deferred)
+### S1 — hollow-head parity (FIXED)
 
-- `replication degree > will prune once reaching max replicas`
-- `replication degree > time out when pending IHave are never resolved`
+- `start/stop > replicate on connect` — **fixed and now covered by the leg.**
+
+A HEAD entry that a native receiver live-replicates was cached in the entry
+index as a lazy `PreparedRawExchangeEntry` whose `_meta`/`_payload`/`_signatures`
+fields stay undefined. Reading that head (`iterator().collect()`, `getHeads(true)`,
+`toArray`) returned the hollow wrapper, and `EntryV0.equals` — gated on
+`other instanceof EntryV0` — was asymmetric against it (`jsEntry.equals(head)`
+was `false` while `head.equals(jsEntry)` was `true`). The block itself was always
+present and decodable; only the cached JS object was hollow, so the default
+backend (which caches heads as full `EntryV0`) never diverged.
+
+**Fix:** a generic `Entry.toMaterialized()` capability in `@peerbit/log` (no-op
+on `EntryV0`, overridden by `PreparedRawExchangeEntry` to decode itself into its
+full `EntryV0`). The entry index calls it at the read/resolve cache boundary and
+writes the materialized entry back into the cache. The wire/sync fusion path
+caches heads via `put` but never resolves them, so it stays lazy (the
+`network-e2e-native` fusion counters — `jsEntryDecode`/`blockCopyOuts` — remain
+0). The `start/stop replicate on connect` case is lifted into the allowlist; the
+rest of `start/stop` stays excluded for the memory-only Class-D reason (A2).
+
+The three prune-family tests previously lumped under this heading were a
+mis-bucket — they have distinct root causes and are catalogued in their proper
+classes below. They are **not** addressed by the S1 fix and remain excluded:
+
+- `replication degree > will prune once reaching max replicas` → **A2 /
+  Class-D (memory-only durability)**. See A2 below: its session
+  (`TestSession.disconnected(3, …)`, line 2280) is directory-less, so the native
+  block store is memory-only; the prune's durability bookkeeping cannot be
+  satisfied without a persistent store. Same class as the `start/stop > can
+  restart replicate` durability case, and expected to be addressed the same way
+  (a directory-backed native analog) — tracked as the S2a durability follow-up.
+- `replication degree > time out when pending IHave are never resolved` →
+  **Class-B / Finding-B (converge-vs-timeout)**. The native path converges via
+  authoritative push rather than sitting on the pending-IHave timeout the test
+  asserts; final state is correct, the timing/counter assertion is not backend-
+  agnostic.
 - `replication degree > does not confirm checked prune from a shallow-only entry`
+  → **Class-B / Finding-B (converge-vs-timeout)**. Same class: the native
+  raw-exchange path confirms/converges differently than the JS wire-event counter
+  the test asserts on; convergence is correct, the counter/confirmation assertion
+  is backend-coupled.
 
-These fail native with `Failed to load entry from head …` / prune-count
-divergences rooted in how the native backbone materializes shallow/hollow
-entries during prune bookkeeping. This is a **real** divergence, deferred out of
-this test-infra PR; it should be tracked and fixed in the native backbone, then
-folded into the leg.
+Both prune divergences (the Class-D durability one and the two converge-vs-count
+ones) are tracked as separate follow-ups (the S2a durability and S2b prune
+issues); they are out of scope for the S1 fix.
 
 ### A2 — memory-only durability (Class-D), NOT a bug
 

--- a/packages/programs/data/shared-log/test/replication.spec.ts
+++ b/packages/programs/data/shared-log/test/replication.spec.ts
@@ -1433,6 +1433,55 @@ testSetups.forEach((setup) => {
 				for (let i = 0; i < result1.length; i++) {
 					expect(result1[i].equals(result2[i])).to.be.true;
 				}
+
+				// A head that was live-replicated to the receiver is cached in the
+				// entry index as a lazy wrapper on the native path. Resolving it
+				// (any read) must return a fully-materialized entry so that field
+				// consumers and the `instanceof EntryV0` gated `equals` see the
+				// canonical head rather than a hollow object. This guards the
+				// native-vs-default parity regression (S1 / hollow head entry).
+				const receiverHeads = await db2.log.log.getHeads(true).all();
+				expect(receiverHeads.length).to.be.greaterThan(0);
+				for (const head of receiverHeads) {
+					const senderMatch = result1.find((e) => e.hash === head.hash)!;
+					expect(senderMatch, "sender has the head " + head.hash).to.exist;
+
+					// the cached head exposes populated fields, not a hollow wrapper
+					expect((head as any)._meta, "head._meta").to.not.be.undefined;
+					expect((head as any)._payload, "head._payload").to.not.be
+						.undefined;
+					expect((head as any)._signatures, "head._signatures").to.not.be
+						.undefined;
+
+					// equality is symmetric in both directions
+					expect(
+						senderMatch.equals(head),
+						"sender.equals(receiverHead)",
+					).to.be.true;
+					expect(
+						head.equals(senderMatch),
+						"receiverHead.equals(sender)",
+					).to.be.true;
+
+					// resolving the same head again returns the identical cached
+					// (materialized) entry - the hot head is not re-decoded
+					const receiverHeads2 = await db2.log.log.getHeads(true).all();
+					const headAgain = receiverHeads2.find(
+						(e) => e.hash === head.hash,
+					)!;
+					expect(headAgain).to.equal(head);
+
+					// the underlying block re-decodes to the same content (parity)
+					const block = await db2.log.log.blocks.get(head.hash);
+					expect(block, "receiver has the head block").to.not.be
+						.undefined;
+					const decoded = deserialize(block!, Entry);
+					decoded.init(head);
+					expect(
+						decoded.equals(senderMatch),
+						"re-decoded block equals sender head",
+					).to.be.true;
+				}
 			});
 
 			it("can restart replicate", async () => {


### PR DESCRIPTION
## Problem

When a native shared-log receiver live-replicates a **head** entry, that head was cached in the entry index as a lazy `PreparedRawExchangeEntry` wrapper (it keeps the block bytes in wasm and exposes only generic getters). Its `_meta`/`_payload`/`_signatures` **fields** stayed `undefined`, so reading that head returned a hollow object:

- direct field consumers (`.meta`/`.payload`/`.signatures`) saw `undefined`, and
- because `EntryV0.equals` is gated on `other instanceof EntryV0`, comparisons were **asymmetric** — `jsEntry.equals(head)` was `false` while `head.equals(jsEntry)` was `true`.

The default (JS) backend caches heads as full `EntryV0`, so this was a **native-only divergence**. The underlying block was always present and decodable — only the cached JS object was wrong.

## Fix

Add a generic `Entry.toMaterialized()` capability (a no-op returning `this` on `EntryV0`, so the default backend is byte-for-byte unchanged). `EntryIndex` calls it at the **read/resolve cache boundary** and writes the materialized entry back into the cache, so a resolved head is a full entry and the hot head is not re-decoded on later reads. `PreparedRawExchangeEntry` overrides it to decode itself into its full `EntryV0`.

Crucially, materialization happens **only at the read boundary** — never on the wire/sync fusion path, which caches heads via `put` but never resolves them. So entry laziness on the wire is preserved (verified: the `network-e2e-native` fusion counters `jsEntryDecode`/`blockCopyOuts` stay 0).

## How it was found

Surfaced by the `[default, native]` conformance auto-matrix (#1020). The investigation decomposed the original "A1" bucket into three unrelated issues; this PR fixes the one genuine data-integrity bug. The other two — memory-only durability on reopen, and a converge-vs-timeout behavioral divergence — are re-catalogued (not bundled) in `NATIVE_CONFORMANCE.md` as separate follow-ups.

## Testing

- **A/B confirmed:** `replicate on connect` fails native (`equals → false` at `:1434`) with the fix reverted, passes with it applied. The spec is extended to assert the receiver's cached head is fully materialized, equality is symmetric both directions, and the head block re-decodes to the sender's content.
- **No regression (`@peerbit/log` is core):** full `@peerbit/log` suite 231/0; shared-log JS `replication.spec` 153 passing / 0 failing; native matrix allowlist 139/0 (the 2 S1 tests folded in; `replicate` describe 28/28 native); wire-fusion counters 0; cross-consumer `@peerbit/document` `native-replicate-sync` 3/3 on both backends.
- Changeset added (`@peerbit/log` + `@peerbit/shared-log`, patch).
