### PR TITLE
fix(log): tolerate block-less native graph head in getHeads(true)

### DIFF
--- a/.changeset/native-getheads-block-less-tolerance.md
+++ b/.changeset/native-getheads-block-less-tolerance.md
@@ -1,0 +1,11 @@
+---
+"@peerbit/log": patch
+"@peerbit/shared-log": patch
+---
+
+Tolerate a block-less native graph head in `getHeads(true)` instead of crashing.
+
+The native log graph can list a HEAD whose block is not materialized in the store: pruning a child promotes its (possibly block-less) parent to a head (rust `LogGraphIndex.delete` -> `set_head`, which only consults the graph's entry map, never the block store). Resolving that head in full (`EntryIndex.getHeads(true)`, reached from `SharedLog.startAnnounceReplicating` -> `ensureCurrentHeadCoordinatesIndexed`) threw `Failed to load entry from head with hash: <h>` on the native backbone, where the JS path already tolerates a missing block. This was a hybrid-fleet robustness gap.
+
+- `@peerbit/log`: the native-graph head-resolution path (`EntryIndex.iterateNativeHashes`, the resolve-in-full branch) now defaults `ignoreMissing` to `true`, mirroring `resolveMany`'s own `ignoreMissing` branch and the shallow (`getShallow`) fallback the non-full path already uses. A block-less head is skipped (left non-authoritative, not force-materialized) rather than crashing. Callers that explicitly pass `ignoreMissing: false` still opt out. The change is confined to the native-graph branch and is a no-op for the default (JS) backend, which never enters it.
+- `@peerbit/shared-log`: make the native-backbone write-through block store's `has()` consistent with `getMany()`/`hasMany()` by falling back to the durable store on a native (wasm-map) miss, so presence checks and resolves agree. `Blocks.has` is declared `MaybePromise<boolean>`, so returning a promise is contract-compatible.

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -868,8 +868,24 @@ export class EntryIndex<T> {
 				? true
 				: options.type === "full"
 			: false;
+		const requestedResolveOptions: ResolveFullyOptions | undefined =
+			resolveInFull ? (options as ResolveFullyOptions) : undefined;
+		// The native graph can list a HEAD whose block is not materialized in the
+		// store: pruning a child promotes its (possibly block-less) parent to a head
+		// (rust `LogGraphIndex.delete` -> `set_head`, which only consults the graph's
+		// entry map, never the block store). Resolving such a head in full would
+		// otherwise throw "Failed to load entry from head". Mirror the tolerance the
+		// non-full path already has (a block-less head yields no shallow entry and is
+		// filtered out) and `resolveMany`'s own `ignoreMissing` branch: default
+		// `ignoreMissing` to true here so a block-less head is SKIPPED rather than
+		// crashing. A block-less head is left non-authoritative (not materialized);
+		// callers that explicitly set `ignoreMissing: false` still opt out.
 		const resolveInFullOptions: ResolveFullyOptions | undefined = resolveInFull
-			? (options as ResolveFullyOptions)
+			? typeof requestedResolveOptions === "object"
+				? requestedResolveOptions.ignoreMissing === undefined
+					? { ...requestedResolveOptions, ignoreMissing: true }
+					: requestedResolveOptions
+				: { type: "full", ignoreMissing: true }
 			: undefined;
 		const shape = !resolveInFull
 			? ((options as { shape?: Shape } | undefined)?.shape as Shape | undefined)

--- a/packages/log/test/native-graph.spec.ts
+++ b/packages/log/test/native-graph.spec.ts
@@ -127,6 +127,59 @@ describe("native graph", () => {
 		}
 	});
 
+	it("tolerates a block-less native graph head in getHeads(true)", async () => {
+		// The native graph can list a HEAD whose block is not materialized in the
+		// store: pruning a child promotes its parent to a head (rust
+		// `LogGraphIndex.delete` -> `set_head`, which only consults the graph's
+		// entry map, never the block store). Resolving that head in full must NOT
+		// throw "Failed to load entry from head" — it should skip the block-less
+		// head, matching the tolerance the JS path already has.
+		const blockLessStore = new AnyBlockStore();
+		await blockLessStore.start();
+		const log = new Log<Uint8Array>();
+		await log.open(blockLessStore, signKey, {
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+		});
+		try {
+			const present = (
+				await log.append(new Uint8Array([1]), { meta: { next: [] } })
+			).entry;
+			const child = (
+				await log.append(new Uint8Array([2]), { meta: { next: [present] } })
+			).entry;
+
+			// Drop the parent's block from the store AND from the entry-index resolve
+			// cache so a full resolve must hit the (now missing) block.
+			await blockLessStore.rm(present.hash);
+			expect(await blockLessStore.has(present.hash)).equal(false);
+			(log.entryIndex as any).cache.del(present.hash);
+
+			// Pruning the child from the graph promotes the block-less parent to a head.
+			const graph = log.entryIndex.properties.nativeGraph!.graph;
+			graph.delete(child.hash);
+			expect(graph.heads(undefined)).to.include(present.hash);
+
+			// getHeads(true) must NOT throw; the block-less head is skipped.
+			let heads: Array<{ hash: string }> | undefined;
+			let error: Error | undefined;
+			try {
+				heads = (await log.getHeads(true).all()) as Array<{ hash: string }>;
+			} catch (e) {
+				error = e as Error;
+			}
+			expect(error, error?.message).to.equal(undefined);
+			expect(heads!.map((head) => head.hash)).to.not.include(present.hash);
+
+			// The block-less head stays non-authoritative (skipped), so a getHeads(true)
+			// that resolves in full returns only fully-materialized heads.
+			expect(heads).to.deep.equal([]);
+		} finally {
+			await log.close();
+			await blockLessStore.stop();
+		}
+	});
+
 	it("serves shaped native graph heads without index reads", async () => {
 		const log = new Log<Uint8Array>();
 		await log.open(store, signKey, {

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -631,8 +631,17 @@ class NativeBackboneWriteThroughBlockStore {
 		return results;
 	}
 
-	has(cid: string): boolean {
-		return this.native.has(cid);
+	async has(cid: string): Promise<boolean> {
+		if (this.native.has(cid)) {
+			return true;
+		}
+		// Mirror getMany/hasMany: a block absent from the native wasm map may still
+		// be present in the durable store (e.g. persisted on disk but not yet
+		// repopulated into wasm). Consult durable on a native miss so presence
+		// checks agree with the resolves that getMany/hasMany already durable-fall
+		// back on. `Blocks.has` is declared `MaybePromise<boolean>`, so returning a
+		// promise here is contract-compatible.
+		return this.durable.has(cid);
 	}
 
 	async hasMany(cids: string[]): Promise<boolean[]> {

--- a/packages/programs/data/shared-log/test/NATIVE_CONFORMANCE.md
+++ b/packages/programs/data/shared-log/test/NATIVE_CONFORMANCE.md
@@ -146,16 +146,63 @@ classes below. They are **not** addressed by the S1 fix and remain excluded:
   **Class-B / Finding-B (converge-vs-timeout)**. The native path converges via
   authoritative push rather than sitting on the pending-IHave timeout the test
   asserts; final state is correct, the timing/counter assertion is not backend-
-  agnostic.
+  agnostic. Verified unaffected by the S2b crash fix (below): still fails only on
+  the `expected promise to be rejected with 'Timeout' but it was fulfilled`
+  assertion, no crash. Stays excluded.
 - `replication degree > does not confirm checked prune from a shallow-only entry`
   → **Class-B / Finding-B (converge-vs-timeout)**. Same class: the native
   raw-exchange path confirms/converges differently than the JS wire-event counter
   the test asserts on; convergence is correct, the counter/confirmation assertion
-  is backend-coupled.
+  is backend-coupled. Verified against the S2b crash fix (below): it does **not**
+  crash — it fails only on `expected promise to be rejected with 'Timeout' but it
+  was fulfilled`. The crash class is gone, but the converge-vs-timeout divergence
+  remains, so it **stays excluded** (not folded into the allowlist).
 
 Both prune divergences (the Class-D durability one and the two converge-vs-count
 ones) are tracked as separate follow-ups (the S2a durability and S2b prune
 issues); they are out of scope for the S1 fix.
+
+### S2b — block-less native graph head tolerance (FIXED)
+
+A native-vs-JS robustness divergence: native `getHeads(true)` **crashed** on a
+block-less graph head where the JS path tolerates it.
+
+The native log graph can list a HEAD whose block is not materialized in the
+store: pruning a child promotes its (possibly block-less) parent to a head (rust
+`LogGraphIndex.delete` -> `set_head`, which only consults the graph's entry map,
+never the block store). Resolving that head in full
+(`EntryIndex.getHeads(true)`, reached from `SharedLog.startAnnounceReplicating`
+-> `ensureCurrentHeadCoordinatesIndexed`) went through the native-hashes
+resolve-in-full path and threw `Failed to load entry from head with hash: <h>`
+on the native backbone. The JS path already tolerates a missing block (the
+`getShallow` fallback on the non-full path, and `resolveMany`'s own
+`ignoreMissing` branch). This was a hybrid-fleet robustness gap.
+
+**Fix (JS tolerance — no rust change):**
+
+- `@peerbit/log`: `EntryIndex.iterateNativeHashes`' resolve-in-full branch now
+  defaults `ignoreMissing` to `true`, so a block-less head is **skipped** (left
+  non-authoritative, not force-materialized) rather than crashing. The change is
+  confined to the native-graph branch and is a no-op for the default (JS)
+  backend, which never enters it. A focused regression test in
+  `@peerbit/log`'s `native-graph.spec.ts` (`tolerates a block-less native graph
+  head in getHeads(true)`) constructs a block-less head via the natural
+  prune-promotes-parent path and asserts `getHeads(true)` does not throw and
+  skips the head. A/B confirmed: revert the fix → `Failed to load entry from
+  head`; apply → no throw.
+- `@peerbit/shared-log`: the native-backbone write-through block store's `has()`
+  now falls back to the durable store on a native (wasm-map) miss, matching
+  `getMany()`/`hasMany()`, so presence checks and resolves agree.
+
+**Impact on the two S2b-tracked prune tests:** neither is folded into the
+allowlist. Both **stop being a crash class** but still fail on the
+converge-vs-timeout (Class-B / Finding-B) assertion — the native path converges
+(prune fulfilled) where the test asserts `Timeout`. They stay excluded; see the
+S1 "mis-bucket" catalog above for the per-test verdict. (In practice these
+specific shared-log tests never surfaced the crash — their `index.put(shallow)`
+construction does not seed a block-less head into the native graph's head list;
+the crash is exercised by the natural prune-promotes-parent path, covered by the
+`@peerbit/log` focused test.)
 
 ### A2 — memory-only durability (Class-D), NOT a bug
 


### PR DESCRIPTION
## Problem

The native log graph can list a **head whose block is not materialized** in the store: pruning a child promotes its (possibly block-less) parent to a head (rust `LogGraphIndex.delete` → `set_head`, which only consults the graph's entry map, never the block store). Resolving that head *in full* — `EntryIndex.getHeads(true)`, reached from `SharedLog.startAnnounceReplicating` → `ensureCurrentHeadCoordinatesIndexed` — threw `Failed to load entry from head with hash: <h>` on the native backbone, where **the JS path already tolerates a missing block**. A native-only crash in a scenario JS handles gracefully — a hybrid-fleet robustness gap.

## Fix (JS-side tolerance; no rust change needed)

- **`@peerbit/log`:** the native-graph head-resolution path (`EntryIndex.iterateNativeHashes`, resolve-in-full branch) now defaults `ignoreMissing` to `true`, mirroring `resolveMany`'s own `ignoreMissing` branch and the `getShallow` fallback the non-full path already uses. A block-less head is **skipped** (left non-authoritative — not force-materialized) rather than crashing. Callers that explicitly pass `ignoreMissing: false` still opt out. The change is confined to the native-graph branch and is a **provable no-op for the default (JS) backend**, which never enters it.
- **`@peerbit/shared-log`:** make the native write-through block store's `has()` consistent with `getMany()`/`hasMany()` — fall back to the durable store on a native (wasm-map) miss, so presence checks and resolves agree. (`Blocks.has` is `MaybePromise<boolean>`, so returning a promise is contract-compatible.)

## Scope note

The two prune tests previously bucketed under this symptom (`shallow-only`, `IHave timeout`) turned out **not** to exercise this crash on master — their `toShallow` construction seeds the native *index* but not the graph head-list. The crash is a genuine `@peerbit/log`-layer gap, reproduced here via the natural prune-promotes-parent path. Those two tests stop being a crash class but still fail on a separate converge-vs-timeout (Class-B) assertion, so they remain excluded from the native matrix leg — documented in `NATIVE_CONFORMANCE.md`.

## Testing

- **New focused regression** (`packages/log/test/native-graph.spec.ts`): constructs a block-less head via the natural prune path, asserts `getHeads(true)` does not throw and skips the head. **A/B confirmed:** fails (`Failed to load entry from head`) with the fix reverted, passes with it applied.
- **No regression:** `@peerbit/log` full suite 232/0; native matrix allowlist stays 139/0; JS `replication degree` describe 95/0; both prune tests still 4/4 on the JS backend (the `has()` change preserves their `blocks.has === false` precondition).
- **JS parity:** the log change is inside `iterateNativeHashes` (only reached when `nativeGraph.useHeads`); the default JS backend never enters it.
- Changeset added (`@peerbit/log` + `@peerbit/shared-log`, patch).
