### PR TITLE
test(shared-log): make getReceivedHeads native-aware to widen conformance leg

### DIFF
--- a/.changeset/native-aware-received-heads.md
+++ b/.changeset/native-aware-received-heads.md
@@ -1,0 +1,14 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Make the `getReceivedHeads` test helper backend-agnostic so the native
+`[default, native]` conformance leg (`PEERBIT_SHARED_LOG_RUST_CORE=1`) folds in
+the `redundancy > only sends entries once` family (4 variants × 2 setups). The
+helper now counts heads from both `ExchangeHeadsMessage` (JS wire) and
+`RawExchangeHeadsMessage` (native raw exchange) at the same per-entry
+granularity, and the companion repair-hint exclusion filter these tests use was
+made backend-agnostic (`isRepairHintExchangeHeadsMessage`) so native repair
+hints do not leak into the no-redundancy count. Both changes are no-ops for the
+default (JS) count; the native leg goes from 139 to 147 passing, 0 failing.
+Test-only.

--- a/packages/programs/data/shared-log/package.json
+++ b/packages/programs/data/shared-log/package.json
@@ -61,7 +61,7 @@
 		"benchmark:sync-catchup": "node --loader ts-node/esm ./benchmark/sync-catchup.ts",
 		"benchmark:sync-phase-profile": "node --loader ts-node/esm ./benchmark/sync-phase-profile.ts",
 		"test": "aegir test --target node",
-		"test:shared-log-rust-core": "npm run build && PEERBIT_SHARED_LOG_RUST_CORE=1 aegir test -t node --grep '^(?!.*(does not fetch missing entries from remotes|will prune once reaching max replicas|repairs when joiner request responses are dropped|time out when pending IHave are never resolved|does not confirm checked prune from a shallow-only entry|replication degree update ))(append delivery options |join |replicate |(u32-simple|u64-iblt) (replication references |replication replication (one way|two way) |canReplicate |replication degree |start/stop replicate on connect|sync ))'",
+		"test:shared-log-rust-core": "npm run build && PEERBIT_SHARED_LOG_RUST_CORE=1 aegir test -t node --grep '^(?!.*(does not fetch missing entries from remotes|will prune once reaching max replicas|repairs when joiner request responses are dropped|time out when pending IHave are never resolved|does not confirm checked prune from a shallow-only entry|replication degree update ))(append delivery options |join |replicate |(u32-simple|u64-iblt) (replication references |replication replication (one way|two way) |redundancy only sends entries once|canReplicate |replication degree |start/stop replicate on connect|sync ))'",
 		"lint": "aegir lint",
 		"test:cov": "aegir test -t node --cov"
 	},

--- a/packages/programs/data/shared-log/test/NATIVE_CONFORMANCE.md
+++ b/packages/programs/data/shared-log/test/NATIVE_CONFORMANCE.md
@@ -49,6 +49,7 @@ backend:
 | `<setup> replication references` (joins-by-ref, next-blocks)  | green         |
 | `<setup> replication replication one way` (1/1000/large/…)    | green*        |
 | `<setup> replication replication two way` (partial synced)    | 6/6           |
+| `<setup> redundancy only sends entries once` (2/3 peers)      | 8/8           |
 | `<setup> canReplicate`                                        | 4/4           |
 | `<setup> replication degree` (prune-family + commit options)  | green*        |
 | `<setup> start/stop replicate on connect`                     | 2/2           |
@@ -57,6 +58,18 @@ backend:
 `<setup>` is `u32-simple` or `u64-iblt` (the active `testSetups`). `replicate`'s
 `persistance` block includes the close→reopen restart cases, which pass thanks to
 the rust-indexer reopen fix (#1019).
+
+The `redundancy only sends entries once` family (2 peers dynamic/fixed/write-after-
+open, 3 peers) was folded in by making the `getReceivedHeads` test helper
+backend-agnostic (see the Class-B root-cause note below): it now counts heads
+from both `ExchangeHeadsMessage` (JS wire) and `RawExchangeHeadsMessage` (native
+raw exchange), at the same per-entry granularity, so the "each head received
+once" assertion measures the same thing on both backends. The companion
+repair-hint filter these tests use to exclude legitimate re-sends was likewise
+made backend-agnostic (`isRepairHintExchangeHeadsMessage`, recognizing the
+`EXCHANGE_HEADS_REPAIR_HINT` reserved bit on both message types), since the
+product tags that bit identically on both paths (`pushRepairEntries` in
+`src/index.ts`). Both changes are test-only and no-ops for the default (JS) count.
 
 `start/stop replicate on connect` is the single test lifted from the otherwise
 memory-only `start/stop` describe: it was native-red because a live-replicated
@@ -82,16 +95,31 @@ convergence. The native path converges to the same state but moves a different
 number of frames (e.g. via authoritative push / different sync batching), so the
 counters differ. Convergence is correct; only the counter assertion fails.
 
-- `redundancy > only sends entries once …` (2 peers dynamic/fixed/write-after-open, 3 peers)
 - `one way > it does not fetch missing entries from remotes when exchanging heads to remote`
 - `replication > retries simple sync when first response is dropped`
 - `leader > will consider in flight` (leader.spec — not in the allowlist describes)
 
-**Root cause for the future widening:** `getReceivedHeads` (and the per-message
-counters layered on it) is backend-coupled — it counts JS-wire receive events
-that the native raw-exchange path does not emit the same way. Making these
-counters backend-agnostic (or asserting on convergence instead of counts) is the
-next widening step, which would fold most of Class-B into the leg.
+**`redundancy > only sends entries once …` — RESOLVED and now covered.** These
+were excluded because `getReceivedHeads` only recognized the JS-wire
+`ExchangeHeadsMessage`; under native, heads arrive via `RawExchangeHeadsMessage`,
+so the helper counted 0 heads and the assertion failed even though the log
+converged correctly. **Root cause fixed:** `getReceivedHeads` now counts heads
+from both message types at the same per-entry granularity (see "What the leg
+covers" above), and the tests' repair-hint exclusion filter was made
+backend-agnostic (`isRepairHintExchangeHeadsMessage`) so native repair hints —
+which carry the same `EXCHANGE_HEADS_REPAIR_HINT` reserved bit over
+`RawExchangeHeadsMessage` — do not leak into the no-redundancy count. The "sends
+once" property genuinely holds on native (each head is re-sent only via the same
+repair-hint mechanism, tagged identically), so this was a helper/filter artifact,
+not a behavioral divergence. The 8 tests (4 variants × 2 setups) are now in the
+allowlist, 8/8 green.
+
+**Root cause for the remaining Class-B entries:** the per-message counters layered
+on the JS wire (e.g. fetch-event counts, dropped-response retry counts) are still
+backend-coupled — they count JS-wire receive events that the native raw-exchange
+path does not emit the same way. Making those counters backend-agnostic (or
+asserting on convergence instead of counts) is the next widening step for the
+still-excluded Class-B tests above.
 
 ### Class-C — over-nativization
 

--- a/packages/programs/data/shared-log/test/replication.spec.ts
+++ b/packages/programs/data/shared-log/test/replication.spec.ts
@@ -14,7 +14,6 @@ import mapSeries from "p-each-series";
 import sinon from "sinon";
 import { BlocksMessage } from "../src/blocks.js";
 import {
-	EXCHANGE_HEADS_REPAIR_HINT,
 	ExchangeHeadsMessage,
 	RequestIPrune,
 	ResponseIPrune,
@@ -54,6 +53,7 @@ import {
 	getDeterministicTestSeed,
 	getReceivedHeads,
 	getUnionSize,
+	isRepairHintExchangeHeadsMessage,
 	slowDownMessage,
 	slowDownMessagesWithSeed,
 	slowDownPubSubWritesWithSeed,
@@ -1053,11 +1053,7 @@ testSetups.forEach((setup) => {
 
 					const dataMessages1 = getReceivedHeads(
 						message1.filter(
-							([msg]) =>
-								!(
-									msg instanceof ExchangeHeadsMessage &&
-									(msg.reserved[0] & EXCHANGE_HEADS_REPAIR_HINT) !== 0
-								),
+							([msg]) => !isRepairHintExchangeHeadsMessage(msg),
 						),
 					);
 					const uniqueBounceBack = new Set(

--- a/packages/programs/data/shared-log/test/utils.ts
+++ b/packages/programs/data/shared-log/test/utils.ts
@@ -6,8 +6,10 @@ import type { TopicControlPlane } from "@peerbit/pubsub";
 import { delay, waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
 import {
+	EXCHANGE_HEADS_REPAIR_HINT,
 	type EntryWithRefs,
 	ExchangeHeadsMessage,
+	RawExchangeHeadsMessage,
 } from "../src/exchange-heads.js";
 import {
 	type ReplicationDomainHash,
@@ -241,17 +243,59 @@ export const slowDownPubSubWritesWithSeed = (
 	};
 };
 
+/**
+ * Collect the heads received across a captured message stream, one returned
+ * entry per received head. Consumers only read `.entry.hash` and the array
+ * length, so this counts heads at the ENTRY granularity — "sent once" means
+ * each head hash appears exactly as many times as it was received, regardless
+ * of how a backend batches heads into messages.
+ *
+ * The JS backend delivers heads via {@link ExchangeHeadsMessage} (heads are
+ * {@link EntryWithRefs} with a real `.entry.hash`). The native backend delivers
+ * the same heads via {@link RawExchangeHeadsMessage}, where each head is a
+ * `RawEntryWithRefs`/`StashBackedRawEntryWithRefs` carrying its `.hash` string
+ * directly (and its block bytes lazily). Reading `.hash` never forces block
+ * materialization, so counting stays cheap on both paths. Making the helper
+ * count both message types folds the redundancy ("only sends entries once")
+ * tests into the native conformance leg without changing JS counting.
+ */
 export const getReceivedHeads = (
 	messages: [TransportMessage, PublicSignKey][],
 ): EntryWithRefs<any>[] => {
 	const heads: EntryWithRefs<any>[] = [];
-	for (const message of messages.filter(
-		(x) => x[0] instanceof ExchangeHeadsMessage,
-	) as [ExchangeHeadsMessage<any>, PublicSignKey][]) {
-		heads.push(...message[0].heads);
+	for (const [message] of messages) {
+		if (message instanceof ExchangeHeadsMessage) {
+			// JS path: preserve exact prior behaviour (real EntryWithRefs objects).
+			heads.push(...(message.heads as EntryWithRefs<any>[]));
+		} else if (message instanceof RawExchangeHeadsMessage) {
+			// Native path: expose the same `.entry.hash` shape per raw head. Only
+			// the hash identity is read; `.hash` does not materialize block bytes.
+			for (const rawHead of message.heads) {
+				heads.push({ entry: { hash: rawHead.hash } } as EntryWithRefs<any>);
+			}
+		}
 	}
 	return heads;
 };
+
+/**
+ * Whether a captured message is an exchange-heads message carrying the
+ * repair-hint reserved bit. Repair hints are legitimate re-sends (not
+ * redundancy), so the "only sends entries once" tests exclude them before
+ * asserting no head was sent twice.
+ *
+ * The product tags the bit identically on both backends' message types
+ * ({@link ExchangeHeadsMessage} on JS, {@link RawExchangeHeadsMessage} on
+ * native — see `pushRepairEntries` in src/index.ts), so this predicate must
+ * recognize both; a JS-only check lets native repair hints leak into the
+ * count and flake the no-redundancy assertion.
+ */
+export const isRepairHintExchangeHeadsMessage = (
+	message: TransportMessage,
+): boolean =>
+	(message instanceof ExchangeHeadsMessage ||
+		message instanceof RawExchangeHeadsMessage) &&
+	(message.reserved[0]! & EXCHANGE_HEADS_REPAIR_HINT) !== 0;
 
 export const waitForConverged = async (
 	fn: () => any,


### PR DESCRIPTION
## What & why

Widens the opt-in `[default, native]` conformance leg (#1020) by folding in the `redundancy > only sends entries once` test family (8 instances), which was excluded only because of a **backend-coupled test helper** — not a real divergence.

`getReceivedHeads` (test helper) counted heads by recognizing the JS-wire `ExchangeHeadsMessage` only. The native backend delivers the same heads via `RawExchangeHeadsMessage`, so under native the helper counted **0** heads and the "only sends once" assertions failed *even though the log converged correctly and each head was in fact sent once*.

**Test-only — zero product `src/` changes.**

## Changes

- **`getReceivedHeads`**: count heads from both `ExchangeHeadsMessage` and `RawExchangeHeadsMessage` at the same per-entry granularity (reading each raw head's `.hash`, which does not force block materialization). JS counting is byte-for-byte unchanged.
- **Repair-hint filter**: a second backend-coupled artifact surfaced — the "no redundancy" tests exclude legitimate repair-hint re-sends via the `EXCHANGE_HEADS_REPAIR_HINT` reserved bit, but the filter only recognized `ExchangeHeadsMessage`. The product (`pushRepairEntries`) sets that same bit on `RawExchangeHeadsMessage` too, so native repair hints leaked into the count and flaked the assertion. Added a backend-agnostic `isRepairHintExchangeHeadsMessage`. **Verified this is a helper artifact, not a divergence: the "sent once" property holds identically on both backends** (re-sends occur only via the same repair-hint mechanism, tagged identically).
- Widened the `test:shared-log-rust-core` allowlist grep to include the redundancy tests, and moved them from Class-B EXCLUDED to COVERED in `NATIVE_CONFORMANCE.md`.

## Verification

- Native leg: **139 → 147 passing, 0 failing** (two full-leg runs).
- JS: the 8 folded tests pass; full `redundancy` describe 14/14 — no regression. All `getReceivedHeads` consumers (all in `replication.spec.ts`) green on both backends.
