### PR TITLE
test(document): opt-in [default,native] conformance matrix leg

### DIFF
--- a/.changeset/document-native-conformance-matrix.md
+++ b/.changeset/document-native-conformance-matrix.md
@@ -1,0 +1,23 @@
+---
+"@peerbit/document": patch
+---
+
+Add an opt-in `[default, native]` conformance matrix leg for the document layer,
+a mechanical clone of the merged shared-log leg. It re-runs an allowlist of the
+existing document suites against the native (Rust) data plane via the shared-log
+env switch (`PEERBIT_SHARED_LOG_RUST_CORE=1`), under which a store opened in the
+default `mode:"auto"` builds its generic index on `@peerbit/indexer-rust` — so
+`docs.index.index` is a `RustIndex` on the switch peer where it is a
+`SQLiteIndex` on the default backend. A hard in-suite guard asserts this so the
+leg cannot false-green as JS.
+
+Test-only: no `@peerbit/document` `src/` product code changes. The single
+test-helper fix makes the `iterate > sort` sync-suppression HACK backend-agnostic
+(it drops both `ExchangeHeadsMessage` and `RawExchangeHeadsMessage`), a no-op for
+the default (JS) suite. Wire-up mirrors the shared-log leg: a
+`test:document-rust-core` script (grep anchored to the confirmed native-green
+comparator/sort/paging/query describes) and a `continue-on-error` step in the
+`test_native` job. Native and default each run 188 passing / 0 failing under the
+allowlist grep. The excluded set (del-path block-store read-back, native-internal
+append-path assertions, remote-indexed `resolve:false` fetch) is documented in
+`test/NATIVE_CONFORMANCE.md`; none is an index comparator/sort/paging divergence.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,6 +513,23 @@ jobs:
         # soft signal while the excluded set is driven down.
         continue-on-error: true
         run: pnpm --filter @peerbit/shared-log run test:shared-log-rust-core
+      - name: Test @peerbit/document conformance in rust-core mode
+        # Opt-in [default,native] conformance leg for the DOCUMENT layer: re-runs
+        # an allowlist of the EXISTING document suites with the native (rust) data
+        # plane engaged via PEERBIT_SHARED_LOG_RUST_CORE=1 (the same switch as the
+        # shared-log leg above; see test:document-rust-core and the switch in
+        # packages/clients/test-utils/src/session.ts). A store opened in the
+        # DEFAULT mode:"auto" builds its generic index on @peerbit/indexer-rust,
+        # so docs.index.index is a RustIndex on the switch peer (a hard in-suite
+        # guard asserts this so the leg cannot false-green as JS). The allowlist
+        # is anchored to the describes confirmed byte-for-byte green native
+        # (comparator / sort / paging / query surface); del-path block-store,
+        # native-internal append-path, and remote-indexed divergences are excluded
+        # (see test/NATIVE_CONFORMANCE.md) and this leg widens as they are made
+        # backend-agnostic. Non-blocking initially: a soft signal while the
+        # excluded set is driven down.
+        continue-on-error: true
+        run: pnpm --filter @peerbit/document run test:document-rust-core
       - name: Test @peerbit/network-rust in the browser
         # Runs the browser-compatible subset (wire/topic-control/fanout codec
         # parity) under headless Chromium, proving the wasm module loads and

--- a/packages/programs/data/document/document/package.json
+++ b/packages/programs/data/document/document/package.json
@@ -53,6 +53,7 @@
 		"clean": "aegir clean",
 		"build": "aegir build --no-bundle",
 		"test": "aegir test --target node",
+		"test:document-rust-core": "npm run build && PEERBIT_SHARED_LOG_RUST_CORE=1 aegir test -t node --grep '^(?!.*(can add and delete|uses the validated local append path|uses the independent native prepared batch path|uses native shared-log planning for replicated target-none puts|uses commit-only local puts when coordinate persistence is deferred|delete permanently|can delete without being replicator|reload after delete|returns approximate count with deletions)).*(native conformance guard |operations basic |operations get |operations index |operations search |iterate sort |count approximate |query distribution |returnIndexed |caching )'",
 		"lint": "aegir lint",
 		"test:cov": "aegir test -t node --cov"
 	},

--- a/packages/programs/data/document/document/test/NATIVE_CONFORMANCE.md
+++ b/packages/programs/data/document/document/test/NATIVE_CONFORMANCE.md
@@ -1,0 +1,201 @@
+# document `[default, native]` conformance matrix (opt-in CI leg)
+
+This document is the PR body / reference for the opt-in `[default, native]`
+conformance leg that re-runs a curated allowlist of the **existing** document
+suites against the native (Rust) data plane. It is test-infra only — no
+`@peerbit/document` `src/` product code is changed. It is a mechanical clone of
+the shared-log conformance leg (see
+`packages/programs/data/shared-log/test/NATIVE_CONFORMANCE.md`), reusing the same
+env switch.
+
+## Mechanism
+
+The document leg **reuses the shared-log env switch**,
+`PEERBIT_SHARED_LOG_RUST_CORE=1`, which flips `TestSession`
+(`packages/clients/test-utils/src/session.ts`) so that every real (non
+in-memory, non-external-libp2p) peer is created with the native data plane —
+native block/any-store storage **and the native rust indexer** (via
+`createRustPeerbitOptions({ network: false })`, merged fill-only-undefined so a
+spec that sets `storage`/`indexer` explicitly is never clobbered).
+
+The document-specific consequence: a `Documents` store opened in the **default**
+`mode:"auto"` (plain args — **no** `mode:"native"`, **no** `nativeBackbone`)
+builds its generic index on `@peerbit/indexer-rust`. `DocumentIndex.init`
+(`src/search.ts`) constructs the index unconditionally via
+`node.indexer.scope(...).init(...)`, so on the switch peer `docs.index.index` is
+a **`RustIndex`** where on the default backend it is a **`SQLiteIndex`**. The
+pure comparator / sort / paging / query surface is byte-identical between the two
+backends, which is exactly what this leg exercises.
+
+A **hard in-suite guard** (`test/native-conformance-guard.spec.ts`, included in
+the allowlist grep) asserts `docs.index.index.constructor.name === "RustIndex"`
+when the env is set and `=== "SQLiteIndex"` when it is unset. If the native build
+is missing or the switch fails to engage, the leg **refuses to false-green** on
+the JS backend — the document analog of the shared-log leg's hard native-present
+guard. (A/B verified: flipping the expected class makes the guard fail with the
+actual `RustIndex` value under the env, proving the native backend genuinely
+engages.)
+
+**Default (env-unset) runs are byte-for-byte unchanged:** the switch code in
+`session.ts` is a no-op when the env is not `1`/`true`, and the guard asserts the
+SQLite backend on the baseline leg.
+
+### One test-helper fix (backend-agnostic sync suppression)
+
+`iterate > sort` (index.spec.ts) monkey-patches
+`store.docs.log.rpc._responseHandler` to DROP the exchange-heads message as a
+"omit synchronization so results are always the same (HACKY)" setup step. It
+keyed the drop on `msg.constructor.name === "ExchangeHeadsMessage"` (the JS
+wire). Under the switch the native backend syncs via `RawExchangeHeadsMessage`,
+so the class-name-keyed drop no longer suppressed sync and the setup's
+`waitForReplicator` produced non-deterministic results. The suppression is now
+**backend-agnostic** — it drops **both** `ExchangeHeadsMessage` and
+`RawExchangeHeadsMessage` (imported from `@peerbit/shared-log`, the same pattern
+the shared-log `getReceivedHeads` / `isRepairHintExchangeHeadsMessage` fix used).
+This is a **no-op for the JS suite** (`RawExchangeHeadsMessage` does not occur on
+the JS wire). It is the only message-type-coupled suppression HACK in the whole
+document test dir (grep-confirmed). With it, `iterate > sort` runs 17/17 green on
+both backends.
+
+## What the leg covers (allowlist)
+
+The leg is wired as `@peerbit/document`'s `test:document-rust-core` script and a
+`continue-on-error` CI step in the `test_native` job, immediately after the
+shared-log rust-core step. The allowlist is a mocha `--grep` anchored to the
+describe titles confirmed **byte-for-byte green** under the native backend
+(comparator / sort / paging / query surface), with negative-lookahead exclusions
+for the del-path and native-internal cases documented below.
+
+| Describe (mocha title path)                        | Native  | Default |
+| -------------------------------------------------- | ------- | ------- |
+| `native conformance guard` (leg guard)             | 1/1     | 1/1     |
+| `operations > basic` (minus 8 excluded)            | 132/132 | 132/132 |
+| `operations > get`                                 | 6/6     | 6/6     |
+| `operations > index`                               | 3/3     | 3/3     |
+| `operations > search` (incl `fields`)              | 15/15   | 15/15   |
+| `iterate > sort` (incl `close`)                    | 17/17   | 17/17   |
+| `count > approximate` (minus deletions)            | 6/6     | 6/6     |
+| `query distribution`                               | 7/7     | 7/7     |
+| `returnIndexed`                                     | 1/1     | 1/1     |
+| `caching`                                          | 1/1     | 1/1     |
+| **Total (allowlist grep)**                         | **188** | **188** |
+
+Native and default each run **188 passing / 0 failing** under the allowlist grep.
+
+The leg is **opt-in and non-blocking** initially (`continue-on-error: true`). It
+widens as the excluded classes below are made backend-agnostic or fixed.
+
+## What is EXCLUDED, and why (honest catalog — no silent caps)
+
+Every native-only failure below was triaged. **None is an index
+comparator / sort / paging / query-result divergence** — the pure query surface
+is byte-identical between `RustIndex` and `SQLiteIndex`, exactly as the spike
+predicted (`operations search` 15/15 and `iterate sort` 17/17 pass native). The
+native-only failures all live in the **write / delete / block-store** path or in
+**native-internal append-path plumbing**, or in the **remote-indexed
+(`resolve:false` over the wire)** path — not in query ordering. Class labels
+mirror the shared-log doc.
+
+### Class-A — del-path block-store read-back (`Missing data`)
+
+The default `mode:"auto"` delete path reads the prior PUT entry's payload to
+determine which document was removed: `Documents.handleChanges` ->
+`getAppendOperation(entry)` -> `entry.getPayloadValue()`
+(`src/program.ts`). `getAppendOperation` has an `isNativeMode()` branch that
+reads from storage bytes instead, but under this switch the `Documents` program
+is in **auto mode** (`isNativeMode()` is `false` — only the *indexer* is
+nativized, not the document mode), so it falls through to `getPayloadValue()`,
+which loads the payload block from the **native** block store and throws
+`Error: Missing data` (`DecryptedThing.getValue`, `EntryV0.getPayloadValue`).
+A minimal repro: single-peer `put` then `del` — the `put` succeeds, the `del`
+throws. Plain `put` (no del) and query-only paths are unaffected, which is why
+the query-surface describes pass.
+
+This is a real native-vs-JS divergence, but in the **block-store / payload
+read-back** path (the document analog of the shared-log A1 / S2b hollow-entry /
+block-less class), **not** an index-comparator divergence. Excluded tests:
+
+- `operations > basic > can add and delete`
+- `operations > basic > delete permanently`
+- `operations > basic > reload after delete`
+- `operations > basic > can delete without being replicator`
+  (fails one step further as `No entry with key '…' in the database`, same
+  del-path family)
+- `count > approximate > returns approximate count with deletions`
+  (1000 puts with 25% deletes — throws on the first `del`)
+
+Follow-up: route the auto-mode delete read-back through the storage-bytes path
+(as `isNativeMode()` already does) or make the native block store materialize the
+just-appended payload so `getPayloadValue()` resolves.
+
+### Class-C — over-nativization (native-internal append-path assertions)
+
+These tests `sinon.spy` **internal append-planning methods** and assert *which*
+code path a put took (`appendLocallyValidated`, `appendLocallyPrepared`,
+`commitNativeDocumentAppend`, `planLocalAppendForGid`,
+`createPlainPutCommitPlan`, …). Under the switch the store runs the native
+indexer but in JS *append mode* (auto, not `mode:"native"`), so these
+mode-internal path assertions do not hold — a smaller/different set of the
+planning methods is called, or a native-only helper (`planLocalAppendForGid`) is
+`undefined` on the JS-mode log. Convergence and query results are correct; only
+the "which internal path ran" assertion fails. This is the document analog of the
+shared-log Class-C over-nativization block. Excluded tests:
+
+- `operations > basic > uses the validated local append path for plain puts`
+  (`expected +0 to equal 1`)
+- `operations > basic > uses the validated local append path for document updates`
+  (`expected +0 to equal 2`)
+- `operations > basic > uses the independent native prepared batch path for unique putMany`
+  (`Cannot read properties of undefined (reading 'planLocalAppendForGid')`)
+- `operations > basic > uses native shared-log planning for replicated target-none puts`
+  (`expected undefined to exist`)
+- `operations > basic > uses commit-only local puts when coordinate persistence is deferred`
+  (`expected +0 to equal 1`)
+
+### Class-E — remote-indexed (`resolve:false`) over the native wire
+
+The **local** `get(id, { resolve: false })` and custom-transform indexed shape
+are correct under native (single-peer probe: `RustIndex` returns
+`{ id, nameTransformed, __context, __indexed }` identically to `SQLiteIndex`). It
+is only the **2-peer remote** indexed fetch — a non-replicating peer querying the
+replicator for the *indexed* (non-resolved) row over the native raw-exchange
+wire — that returns `undefined`, so `.nameTransformed` / `.name` reads throw.
+This is a remote-query / sync path divergence, not a local index-comparator one.
+Because the affected `custom index` and `prefetch` describes are remote-heavy and
+mix green local tests with red remote-indexed ones, they are **excluded whole**
+(not partially cherry-picked) to keep the allowlist to cleanly-green describes:
+
+- `custom index` (whole describe) — `get > get indexed`,
+  `get > uses indexed requests for replicated resolved remote get`,
+  `iterate > iterate indexed`, `iterate > iterate replicate indexed` are
+  native-red; the plain (resolved) `get` / `iterate` / `get local first` tests
+  are native-green.
+- `prefetch` (whole describe) — `can prefetch search results` is native-red on
+  the 2-peer remote prefetch (`Cannot read properties of undefined (reading
+  'name')`).
+
+Follow-up: make the remote-indexed (`SearchRequestIndexed`) fetch resolve the
+indexed row over the native raw-exchange path, then fold these describes in.
+
+### Not yet catalogued (deferred, out of scope for this leg)
+
+The `updates`, `replication`, `remote`, `acl`, `program as value`, `migration`,
+`updateIndex`, and `most-common-query-predictor` describes were not run
+exhaustively for this initial leg — they are replication / sync / lifecycle
+heavy rather than pure query-surface, and are the natural next widening step once
+the Class-A/C/E follow-ups above land. They are neither claimed green nor
+silently capped.
+
+## Verification summary
+
+- **Native (env set):** allowlist grep GREEN — **188 passing, 0 failing**.
+- **Default (env unset):** same allowlist grep GREEN — **188 passing, 0
+  failing** (baseline unchanged).
+- **Guard:** `docs.index.index` is asserted `RustIndex` under the env and
+  `SQLiteIndex` without it; flipping the expected class makes the guard fail with
+  the real `RustIndex` value, so a missing/disengaged native build cannot
+  false-green.
+- **No product `src/` change:** only the test helper (backend-agnostic sync
+  suppression in `iterate > sort`), the new guard spec, `package.json`
+  (`test:document-rust-core` script), `ci.yml` (one `continue-on-error` step),
+  and this doc.

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -62,6 +62,7 @@ import type { FanoutTree, TopicControlPlane } from "@peerbit/pubsub";
 import { MissingResponsesError, RPCMessage, ResponseV0 } from "@peerbit/rpc";
 import {
 	AbsoluteReplicas,
+	RawExchangeHeadsMessage,
 	SharedLog,
 	decodeReplicas,
 } from "@peerbit/shared-log";
@@ -13318,11 +13319,19 @@ describe("index", () => {
 							},
 						});
 
-						// Omit synchronization so results are always the same (HACKY)
+						// Omit synchronization so results are always the same (HACKY).
+						// Drop the exchange-heads message on BOTH backends: the JS wire
+						// sends ExchangeHeadsMessage, while the native (rust-core) backend
+						// syncs via RawExchangeHeadsMessage. Keying only on the JS class
+						// name would let native sync leak through and make the results
+						// non-deterministic under PEERBIT_SHARED_LOG_RUST_CORE=1.
 						// TODO types
 						const onMessage = store.docs.log.rpc["_responseHandler"];
 						store.docs.log.rpc["_responseHandler"] = (msg: any, ctx: any) => {
-							if (msg.constructor.name === "ExchangeHeadsMessage") {
+							if (
+								msg.constructor.name === "ExchangeHeadsMessage" ||
+								msg instanceof RawExchangeHeadsMessage
+							) {
 								return;
 							}
 							return onMessage(msg, ctx);

--- a/packages/programs/data/document/document/test/native-conformance-guard.spec.ts
+++ b/packages/programs/data/document/document/test/native-conformance-guard.spec.ts
@@ -1,0 +1,57 @@
+import { TestSession } from "@peerbit/test-utils";
+import { expect } from "chai";
+import { Documents } from "../src/index.js";
+import { Document, TestStore } from "./data.js";
+
+/**
+ * Hard guard for the opt-in `[default, native]` document conformance leg
+ * (`PEERBIT_SHARED_LOG_RUST_CORE=1`, wired as `test:document-rust-core`).
+ *
+ * The switch (packages/clients/test-utils/src/session.ts) attaches the native
+ * Rust data plane to every TestSession peer, so a Documents store opened in the
+ * DEFAULT `mode:"auto"` (plain args, no `mode:"native"`) builds its generic
+ * index on `@peerbit/indexer-rust` — i.e. `docs.index.index` is a `RustIndex`
+ * on the switch peer where it is a `SQLiteIndex` on the default backend.
+ *
+ * This test asserts that fact so the leg can never false-green by silently
+ * running the allowlist on the JS (SQLite) backend when the native build is
+ * missing or the switch failed to engage — the document analog of the
+ * shared-log leg's hard native-present guard. When the env is unset (default /
+ * JS baseline run) the same assertion confirms the backend is SQLite, so the
+ * guard is a no-op on the baseline leg.
+ */
+describe("native conformance guard", () => {
+	let session: TestSession;
+
+	afterEach(async () => {
+		await session?.stop();
+	});
+
+	it("document generic index is the expected backend for this leg", async () => {
+		session = await TestSession.connected(1);
+		const store = new TestStore({ docs: new Documents<Document>() });
+		await session.peers[0].open(store);
+
+		const inner = (store.docs.index as unknown as { index?: unknown }).index;
+		const backend = (inner as { constructor?: { name?: string } })?.constructor
+			?.name;
+
+		const nativeLeg =
+			process.env.PEERBIT_SHARED_LOG_RUST_CORE === "1" ||
+			process.env.PEERBIT_SHARED_LOG_RUST_CORE === "true";
+
+		if (nativeLeg) {
+			// If this fails, the leg is running the allowlist against the JS
+			// (SQLite) backend — a false-green. Refuse it loudly.
+			expect(
+				backend,
+				`Expected docs.index.index to be a RustIndex under the native ` +
+					`conformance leg but it was "${backend}". The native Rust data ` +
+					`plane did not engage — refusing to false-green on the JS backend.`,
+			).to.eq("RustIndex");
+		} else {
+			// Baseline (env unset): confirm we are on the JS backend.
+			expect(backend).to.eq("SQLiteIndex");
+		}
+	});
+});


### PR DESCRIPTION
## What this is

Extends the `[default, native]` conformance matrix to a **second data-layer surface** — the document index — as an opt-in, non-blocking CI leg. **Test-infrastructure only: no `@peerbit/document` `src/` changes.**

It reuses the *same* env switch as the shared-log leg (`PEERBIT_SHARED_LOG_RUST_CORE=1`), which attaches the native rust indexer to TestSession peers. A `Documents` store opened in the default `mode:"auto"` builds its generic index on `@peerbit/indexer-rust` — so `docs.index.index` is a **`RustIndex`** on the switch peer vs a `SQLiteIndex` on the default backend, **without** any `mode:"native"` / `nativeBackbone` opt-in or its 26 blockers. A hard in-suite guard asserts this, so a disengaged native build can't false-green as JS.

## Result: the index surface is clean

The comparator / sort / paging / query surface is **byte-identical** between `RustIndex` and `SQLiteIndex` — no repeat of the #1018 sort tie-break class. Native and default each run **188 passing / 0 failing** under the allowlist (`operations` basic/get/index/search, `iterate sort`, `count approximate`, `query distribution`, `returnIndexed`, `caching`, plus the guard).

One test-helper fix: the `iterate > sort` sync-suppression hack dropped only `ExchangeHeadsMessage` (JS class name); made it backend-agnostic (drops `RawExchangeHeadsMessage` too) — a no-op for the JS suite.

## What it surfaced (honestly catalogued in `test/NATIVE_CONFORMANCE.md`, no silent caps)

All native-only failures are **outside** the query surface:
- **Class-A — a real candidate bug (excluded, to fix separately):** auto-mode `del` throws `Missing data` reading the prior put's payload (`getPayloadValue`) from the native block store, because only the *indexer* is nativized (document `mode` stays `auto`, so `getAppendOperation` takes the JS read-back path). Minimal repro: single-peer put→del. A genuine native/block-store divergence in the delete path, not index ordering.
- **Class-C** — over-nativization (tests that `sinon.spy` internal append-planning methods; results/convergence correct).
- **Class-E** — remote-indexed `resolve:false` fetch over the native wire (local indexed get is correct; only the 2-peer remote fetch diverges).

The leg widens as these are made backend-agnostic / fixed. Skipped-for-now describes (replication/sync/lifecycle-heavy: `updates`, `replication`, `remote`, `acl`, `program as value`, `migration`) are documented as the next widening step.
