### PR TITLE
fix(document): recover del read-back from block store on native storage (auto mode)

### DIFF
--- a/.changeset/native-document-del-readback.md
+++ b/.changeset/native-document-del-readback.md
@@ -1,0 +1,9 @@
+---
+"@peerbit/document": patch
+---
+
+Fix `del` throwing "Missing data" on a peer with a native block store but a Documents store in the default `mode: "auto"` (not `mode: "native"`).
+
+On such a peer the delete read-back path (`handleChanges` -> `getAppendOperation`) resolved the prior put's operation via the in-memory JS entry (`Entry.getPayloadValue`). Under a native block store the entry materialized in the entry index is a hollow shell whose payload bytes were never loaded onto the JS object, so `getPayloadValue` threw `Error("Missing data")` even though the block itself is present in the store.
+
+Auto mode now falls back to the storage-bytes / block-store read path when (and only when) the in-memory payload is unavailable: it recovers the entry's raw block from the block store by hash and extracts the plain operation payload from those bytes. The pure-JS backend is unchanged — there `getPayloadValue` succeeds and the fallback never runs. Document mode semantics and the `isNativeMode()` gate are untouched.

--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -112,6 +112,16 @@ export class NativeDocumentModeError extends Error {
 
 type MaybePromise<T> = Promise<T> | T;
 
+/**
+ * True when an error signals that an entry's payload bytes were never
+ * materialized on the JS side (a hollow entry backed by a native block store).
+ * `DecryptedThing.getValue` throws `Error("Missing data")` in that case. Used to
+ * decide whether the auto-mode append/delete read-back should recover the
+ * operation from the storage-bytes / block-store path instead.
+ */
+const isMissingPayloadDataError = (error: unknown): boolean =>
+	error instanceof Error && error.message === "Missing data";
+
 const isPromiseLike = <T>(value: MaybePromise<T>): value is Promise<T> =>
 	!!value && typeof (value as Promise<T>).then === "function";
 
@@ -2837,17 +2847,44 @@ export class Documents<
 			return;
 		}
 		ensureInitialized?.();
-		return entry.getPayloadValue();
+		try {
+			return await entry.getPayloadValue();
+		} catch (error) {
+			// Auto (non-native document) mode with a native block store: the entry
+			// materialized in the entry index can be a hollow shell whose in-memory
+			// payload bytes were never loaded (the native store keeps the block
+			// bytes at the storage layer, not on the JS entry). `getPayloadValue`
+			// then throws "Missing data". The block itself is present, so recover
+			// the operation via the storage-bytes / block-store read path. This is
+			// a no-op for the pure-JS backend, where `getPayloadValue` succeeds.
+			if (!isMissingPayloadDataError(error)) {
+				throw error;
+			}
+			const operation = await this.getPlainEntryOperationFromStorage(entry);
+			if (operation) {
+				return operation;
+			}
+			throw error;
+		}
 	}
 
 	private async getPlainEntryOperationFromStorage(
 		entry: Entry<Operation>,
 	): Promise<Operation | undefined> {
-		let storageBytes: Uint8Array;
+		let storageBytes: Uint8Array | undefined;
 		try {
 			storageBytes =
 				Entry.getPreparedStorageBytes(entry) ?? entry.getStorageBytes();
 		} catch {
+			// The entry object is hollow (its payload bytes never materialized on
+			// the JS side), so it cannot re-serialize itself. Fall through to the
+			// block-store fallback below.
+			storageBytes = undefined;
+		}
+		// Fall back to the raw block held by the block store, keyed by the entry
+		// hash, whenever the entry could not (or did not) yield its own bytes.
+		storageBytes ??= await this.getEntryStorageBytesFromBlocks(entry);
+		if (!storageBytes) {
 			return;
 		}
 		try {
@@ -2866,6 +2903,21 @@ export class Documents<
 			} catch {
 				return;
 			}
+		}
+	}
+
+	private async getEntryStorageBytesFromBlocks(
+		entry: Entry<Operation>,
+	): Promise<Uint8Array | undefined> {
+		const hash = entry.hash;
+		if (!hash) {
+			return;
+		}
+		try {
+			const bytes = await this.log.log.blocks.get(hash);
+			return bytes ?? undefined;
+		} catch {
+			return;
 		}
 	}
 

--- a/packages/programs/data/document/document/test/NATIVE_DEL_READBACK_FIX.md
+++ b/packages/programs/data/document/document/test/NATIVE_DEL_READBACK_FIX.md
@@ -1,0 +1,74 @@
+# Native block-store `del` read-back fix (Class-A conformance)
+
+This note documents a real `@peerbit/document` product fix and how it relates to
+the opt-in document `[default, native]` conformance leg (introduced separately by
+#1024, not yet on `master`).
+
+## The bug (Class-A: `del` read-back)
+
+On a peer with a **native block store + native rust indexer** but a `Documents`
+store opened in the DEFAULT `mode: "auto"` (i.e. NOT `mode: "native"` and no
+`nativeBackbone`), calling `del` threw `Error("Missing data")`.
+
+This is a real configuration: any peer built with
+`createRustPeerbitOptions()` (or a `TestSession` peer under
+`PEERBIT_SHARED_LOG_RUST_CORE=1`) that opens a plain `Documents` store hits it.
+Minimal repro: single peer, `put(doc)` then `del(doc.id)`.
+
+### Root cause (read-path incompatibility, not a missing block)
+
+The delete read-back runs through
+`Documents.handleChanges` -> `Documents.getAppendOperation`
+(`src/program.ts`). In auto mode `getAppendOperation` resolved the prior put's
+operation via the in-memory JS entry (`Entry.getPayloadValue`).
+
+Under a native block store the `EntryV0` materialized in the entry index is a
+**hollow shell**: its `_payload` is a `DecryptedThing` whose `_data` was never
+loaded onto the JS object (the native store keeps the block bytes at the storage
+layer). `getPayloadValue` -> `DecryptedThing.getValue` then throws
+`"Missing data"`. Crucially the block **is** present — `blocks.get(hash)` returns
+the full raw block — so this is a read-path incompatibility, not a missing block.
+`entry.getStorageBytes()` (`serialize(this)`) also fails on the hollow entry, so
+the payload can only be recovered from the raw block held by the block store.
+
+## The fix
+
+`getAppendOperation` (auto mode) now tries `getPayloadValue()` first (unchanged
+JS behaviour) and, only when it throws the hollow-payload `"Missing data"` error,
+falls back to `getPlainEntryOperationFromStorage`. That helper now reads the raw
+block from the block store by the entry hash
+(`getEntryStorageBytesFromBlocks`) whenever the entry object cannot yield its own
+storage bytes, then extracts the plain operation payload from those bytes via the
+native `entryV0PlainPayloadDataFromStorage` path.
+
+- **Pure-JS backend: unchanged.** `getPayloadValue` succeeds there, so the
+  fallback never runs.
+- **Native-storage auto mode: fixed.** The hollow-entry read-back now resolves
+  the operation from the block store.
+- Document mode semantics and the `isNativeMode()` gate are untouched. The fix is
+  contained to `@peerbit/document`'s read path — no native-backbone change.
+
+Regression coverage: `test/native-del-readback.spec.ts` (native-storage peer,
+auto mode, put -> del asserts deleted + no throw). A/B confirmed: revert the fix
+=> `"Missing data"`; apply => pass.
+
+## Fold-in follow-up for the document conformance leg (#1024)
+
+The document `[default, native]` conformance leg (#1024) currently excludes the
+Class-A `del`-path tests from its `test:document-rust-core` allowlist grep:
+
+- `can add and delete`
+- `delete permanently`
+- `reload after delete`
+- `returns approximate count with deletions`
+
+With this fix these four are green under `PEERBIT_SHARED_LOG_RUST_CORE=1` and are
+ready to fold into the leg allowlist once both #1024 and this PR land. The grep is
+intentionally **not** edited here because #1024 is not yet on `master` (there is
+no leg grep on this PR's base to widen); the allowlist widening is a follow-up.
+
+Note: a fifth title the leg lists under the del exclusions,
+`can delete without being replicator`, is **not** a Class-A read-back failure. It
+is a separate 2-peer native-wire sync divergence (the non-replicator peer never
+receives/indexes the doc, so `del` raises `NotFoundError` — "No entry with key").
+That failure is identical with and without this fix and is out of scope here.

--- a/packages/programs/data/document/document/test/native-del-readback.spec.ts
+++ b/packages/programs/data/document/document/test/native-del-readback.spec.ts
@@ -1,0 +1,68 @@
+import { TestSession } from "@peerbit/test-utils";
+import { expect } from "chai";
+import { createRustPeerbitOptions } from "peerbit/rust";
+import { v4 as uuid } from "uuid";
+import { Documents } from "../src/program.js";
+import { Document, TestStore } from "./data.js";
+
+// Regression coverage for the "Class-A" native-vs-JS divergence surfaced by the
+// document conformance matrix: a peer with a NATIVE block store + native rust
+// indexer, but a Documents store opened in the DEFAULT mode:"auto" (NOT
+// mode:"native"), used to throw "Missing data" from `del` because the delete
+// read-back resolved the prior put's payload through the in-memory JS-entry path
+// (`Entry.getPayloadValue`) instead of a storage-level block read.
+describe("native del read-back (auto mode)", () => {
+	let session: TestSession;
+
+	beforeEach(async () => {
+		// Single native-storage + native-indexer peer, no native network plane.
+		session = await TestSession.connected(1, createRustPeerbitOptions({ network: false }));
+	});
+
+	afterEach(async () => {
+		await session.stop();
+	});
+
+	it("put then del does not throw and actually deletes", async () => {
+		const store = new TestStore({
+			docs: new Documents<Document>({ immutable: false }),
+		});
+		// Plain args: auto document mode (no mode:"native", no nativeBackbone).
+		await session.peers[0].open(store);
+
+		const doc = new Document({ id: uuid(), name: "Hello world" });
+		await store.docs.put(doc);
+		expect(await store.docs.index.getSize()).equal(1);
+
+		const deleteOperation = (await store.docs.del(doc.id)).entry;
+		expect(await store.docs.index.getSize()).equal(0);
+		expect((await store.docs.index.get(doc.id)) ?? undefined).to.equal(
+			undefined,
+		);
+		// The delete operation is the only remaining head (prior put was cut).
+		expect(
+			(await store.docs.log.log.toArray()).map((x) => x.hash),
+		).to.deep.equal([deleteOperation.hash]);
+	});
+
+	it("put, edit, then del permanently", async () => {
+		const store = new TestStore({
+			docs: new Documents<Document>({ immutable: false }),
+		});
+		await session.peers[0].open(store);
+
+		const doc = new Document({ id: uuid(), name: "Hello world" });
+		const editDoc = new Document({ id: doc.id, name: "Hello world 2" });
+
+		await store.docs.put(doc);
+		const putOperation2 = (await store.docs.put(editDoc)).entry;
+		expect(await store.docs.index.getSize()).equal(1);
+		expect(putOperation2.meta.next).to.have.length(1);
+
+		const deleteOperation = (await store.docs.del(doc.id)).entry;
+		expect(await store.docs.index.getSize()).equal(0);
+		expect(
+			(await store.docs.log.log.toArray()).map((x) => x.hash),
+		).to.deep.equal([deleteOperation.hash]);
+	});
+});


### PR DESCRIPTION
## Problem

On a peer with a **native block store + native rust indexer** but a `Documents` store opened in the default `mode:"auto"` (not `mode:"native"`), `del` threw `Error("Missing data")`.

Root cause — a read-path incompatibility, **not** a missing block: the delete read-back (`handleChanges` → `getAppendOperation`) resolves the prior put's operation via the in-memory JS entry (`Entry.getPayloadValue`). Under a native block store the `EntryV0` in the entry index is a **hollow shell** whose payload `_data` was never loaded onto the JS object, so `getPayloadValue` → `DecryptedThing.getValue` throws `"Missing data"` — even though the block itself is present (verified: `blocks.get(hash)` returns the full raw block and decodes to the `PutOperation`).

This is a real config: any `createRustPeerbitOptions()` peer that opens a plain `Documents` store (native storage + auto document mode). Minimal repro: `put` → `del` on a single peer.

This is the same "hollow native entry" family as #1021 (which fixed hollow *head* entries on the read cache boundary); this is the *delete read-back* surface for non-head entries.

## Fix (contained to `@peerbit/document`)

`getAppendOperation` now tries `getPayloadValue()` first (unchanged JS behaviour) and, **only on the hollow-payload `"Missing data"` error**, falls back to reading the raw block from the block store by entry hash (`getEntryStorageBytesFromBlocks`) and extracting the plain operation payload from those bytes.

- Correct for both backends: on pure JS `getPayloadValue` succeeds and the fallback never runs.
- The guard matches *only* `message === "Missing data"`, so `AccessError` ("Access denied") is never caught — encrypted/undecryptable entries still short-circuit exactly as before. If the block is genuinely absent, the fallback yields nothing and the original error is rethrown (no masking).
- `isNativeMode()` gate and document mode semantics are untouched.

## Testing

- **A/B confirmed:** the 4 Class-A del tests (`can add and delete`, `delete permanently`, `reload after delete`, `count with deletions`) throw `"Missing data"` under the native switch with the fix reverted, and pass with it applied. New regression spec `native-del-readback.spec.ts` (native-storage peer put→del) confirms the same.
- **No regression:** full `@peerbit/document` JS suite **357/0** (all 321 `index.spec.ts` tests); `operations` describe 260/260; native `mode:"native"` coverage unchanged.
- Changeset added (`@peerbit/document`, patch).

## Follow-up

Once this lands, the 4 del tests fold into the #1024 document conformance leg allowlist (documented). A separate test (`can delete without being replicator`) is a distinct 2-peer native-wire sync divergence, out of scope here and left excluded.
