### PR TITLE
fix(document): materialize hollow head entry for remote-indexed RPC responses

### DIFF
--- a/.changeset/native-remote-indexed-head-serialize.md
+++ b/.changeset/native-remote-indexed-head-serialize.md
@@ -1,0 +1,9 @@
+---
+"@peerbit/document": patch
+---
+
+Fix a remote `resolve: false` / `SearchRequestIndexed` query timing out (requester `get`/`iterate` returns `undefined`) on a peer with a native block store.
+
+When answering an indexed remote query, the responder embeds the head log entry into the RPC response via `ResultIndexedValue.entries` (a borsh `vec(Entry)` field). Under a native block store, `this._log.log.get(hash)` can return a hollow entry whose payload bytes were never materialized on the JS side; serializing it throws "Trying to serialize a null value to field _data", aborting the whole `Results` serialization so the response is never sent and the non-replicating requester times out.
+
+`DocumentIndex` now routes those head lookups through a `getSerializableHead` helper: it keeps the in-memory entry when it serializes cleanly (the JS case) and, only when serialization would throw, recovers the complete entry from the block store by hash (`Entry.fromMultihash`) so a wire-serializable, joinable entry is sent. The pure-JS backend is unchanged — the serialize probe succeeds and the recovery never runs. This covers all five head sites that feed `entries` (the `processQuery` indexed branch, both `wrapPushResults` sites, and both `drainQueuedResults` sites); the unrelated `resolveDocument` payload path is untouched.

--- a/packages/programs/data/document/document/package.json
+++ b/packages/programs/data/document/document/package.json
@@ -53,7 +53,7 @@
 		"clean": "aegir clean",
 		"build": "aegir build --no-bundle",
 		"test": "aegir test --target node",
-		"test:document-rust-core": "npm run build && PEERBIT_SHARED_LOG_RUST_CORE=1 aegir test -t node --grep '^(?!.*(uses the validated local append path|uses the independent native prepared batch path|uses native shared-log planning for replicated target-none puts|uses commit-only local puts when coordinate persistence is deferred|can delete without being replicator)).*(native conformance guard |operations basic |operations get |operations index |operations search |iterate sort |count approximate |query distribution |returnIndexed |caching )'",
+		"test:document-rust-core": "npm run build && PEERBIT_SHARED_LOG_RUST_CORE=1 aegir test -t node --grep '^(?!.*(uses the validated local append path|uses the independent native prepared batch path|uses native shared-log planning for replicated target-none puts|uses commit-only local puts when coordinate persistence is deferred|can delete without being replicator)).*(native conformance guard |operations basic |operations get |operations index |operations search |iterate sort |count approximate |query distribution |returnIndexed |caching |custom index |prefetch )'",
 		"lint": "aegir lint",
 		"test:cov": "aegir test -t node --cov"
 	},

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -1179,6 +1179,28 @@ export class DocumentIndex<
 		}
 	}
 
+	/** Head entry safe to borsh-serialize into ResultIndexedValue.entries over the
+	 * document RPC. Under the native block store, this._log.log.get can return a
+	 * hollow entry whose payload bytes were never materialized on the JS side;
+	 * serializing it throws and aborts the whole RPC response. The complete entry is
+	 * in the block store keyed by hash, so recover it there. No-op for pure JS. */
+	private async getSerializableHead(
+		hash: string,
+	): Promise<Entry<any> | undefined> {
+		const head = await this._log.log.get(hash);
+		if (!head?.hash) return head ?? undefined;
+		try {
+			head.getStorageBytes(); // = serialize(head); throws on a hollow native entry
+			return head;
+		} catch {
+			try {
+				return await Entry.fromMultihash(this._log.log.blocks, head.hash);
+			} catch {
+				return head; // block absent (e.g. pruned) — preserve today's behavior
+			}
+		}
+	}
+
 	private async wrapPushResults(
 		matches: Array<WithContext<T> | WithContext<I>>,
 		resolve: boolean,
@@ -1220,7 +1242,7 @@ export class DocumentIndex<
 					continue;
 				}
 
-				const head = await this._log.log.get(indexed.__context.head);
+				const head = await this.getSerializableHead(indexed.__context.head);
 				results.push(
 					new types.ResultIndexedValue({
 						context: indexed.__context,
@@ -1231,7 +1253,7 @@ export class DocumentIndex<
 				);
 			} else {
 				const indexed = match as WithContext<I>;
-				const head = await this._log.log.get(indexed.__context.head);
+				const head = await this.getSerializableHead(indexed.__context.head);
 				results.push(
 					new types.ResultIndexedValue({
 						context: indexed.__context,
@@ -1276,7 +1298,7 @@ export class DocumentIndex<
 					continue;
 				}
 
-				const head = await this._log.log.get(entry.value.__context.head);
+				const head = await this.getSerializableHead(entry.value.__context.head);
 				results.push(
 					new types.ResultIndexedValue({
 						context: entry.value.__context,
@@ -1286,7 +1308,7 @@ export class DocumentIndex<
 					}),
 				);
 			} else {
-				const head = await this._log.log.get(entry.value.__context.head);
+				const head = await this.getSerializableHead(entry.value.__context.head);
 				results.push(
 					new types.ResultIndexedValue({
 						context: entry.value.__context,
@@ -3653,7 +3675,7 @@ export class DocumentIndex<
 				);
 			} else {
 				const context = result.value.__context;
-				const head = await this._log.log.get(context.head);
+				const head = await this.getSerializableHead(context.head);
 				if (replicateIndexFlag) {
 					if (!head) {
 						continue;

--- a/packages/programs/data/document/document/test/NATIVE_CONFORMANCE.md
+++ b/packages/programs/data/document/document/test/NATIVE_CONFORMANCE.md
@@ -2,9 +2,10 @@
 
 This document is the PR body / reference for the opt-in `[default, native]`
 conformance leg that re-runs a curated allowlist of the **existing** document
-suites against the native (Rust) data plane. It is test-infra only — no
-`@peerbit/document` `src/` product code is changed. It is a mechanical clone of
-the shared-log conformance leg (see
+suites against the native (Rust) data plane. The leg scaffolding is test-infra;
+the real native-vs-JS divergences it uncovers are fixed in `src/` as the
+corresponding describes are folded in (see the FIXED classes below). It is a
+mechanical clone of the shared-log conformance leg (see
 `packages/programs/data/shared-log/test/NATIVE_CONFORMANCE.md`), reusing the same
 env switch.
 
@@ -64,7 +65,7 @@ The leg is wired as `@peerbit/document`'s `test:document-rust-core` script and a
 shared-log rust-core step. The allowlist is a mocha `--grep` anchored to the
 describe titles confirmed **byte-for-byte green** under the native backend
 (comparator / sort / paging / query surface), with negative-lookahead exclusions
-for the native-internal, remote-indexed, and 2-peer sync cases documented below.
+for the native-internal and 2-peer sync cases documented below.
 
 | Describe (mocha title path)                        | Native  | Default |
 | -------------------------------------------------- | ------- | ------- |
@@ -78,9 +79,11 @@ for the native-internal, remote-indexed, and 2-peer sync cases documented below.
 | `query distribution`                               | 7/7     | 7/7     |
 | `returnIndexed`                                     | 1/1     | 1/1     |
 | `caching`                                          | 1/1     | 1/1     |
-| **Total (allowlist grep)**                         | **192** | **192** |
+| `custom index` (whole describe)                    | 10/10   | 10/10   |
+| `prefetch` (3 active tests)                         | 3/3     | 3/3     |
+| **Total (allowlist grep)**                         | **205** | **205** |
 
-Native and default each run **192 passing / 0 failing** under the allowlist grep.
+Native and default each run **205 passing / 0 failing** under the allowlist grep.
 
 The leg is **opt-in and non-blocking** initially (`continue-on-error: true`). It
 widens as the excluded classes below are made backend-agnostic or fixed.
@@ -127,8 +130,9 @@ Still excluded — a **separate** divergence, not the read-back bug:
 
 - `operations > basic > can delete without being replicator` — the
   non-replicating peer never indexes the doc, so the delete resolves to a
-  `No entry with key` miss. This is a 2-peer remote/sync path issue (same family
-  as Class-E below); it fails identically with and without the #1025 fix.
+  `No entry with key` miss. This is a 2-peer remote/sync path issue distinct from
+  the Class-E head-serialization fix below (the requester never indexes the row in
+  the first place); it fails identically with and without the #1025 fix.
 
 ### Class-C — over-nativization (native-internal append-path assertions)
 
@@ -154,30 +158,58 @@ shared-log Class-C over-nativization block. Excluded tests:
 - `operations > basic > uses commit-only local puts when coordinate persistence is deferred`
   (`expected +0 to equal 1`)
 
-### Class-E — remote-indexed (`resolve:false`) over the native wire
+### Class-E — remote-indexed (`resolve:false`) head serialization — FIXED
 
 The **local** `get(id, { resolve: false })` and custom-transform indexed shape
-are correct under native (single-peer probe: `RustIndex` returns
+were already correct under native (single-peer probe: `RustIndex` returns
 `{ id, nameTransformed, __context, __indexed }` identically to `SQLiteIndex`). It
-is only the **2-peer remote** indexed fetch — a non-replicating peer querying the
-replicator for the *indexed* (non-resolved) row over the native raw-exchange
-wire — that returns `undefined`, so `.nameTransformed` / `.name` reads throw.
-This is a remote-query / sync path divergence, not a local index-comparator one.
-Because the affected `custom index` and `prefetch` describes are remote-heavy and
-mix green local tests with red remote-indexed ones, they are **excluded whole**
-(not partially cherry-picked) to keep the allowlist to cleanly-green describes:
+was only the **2-peer remote** indexed fetch — a non-replicating peer querying
+the replicator for the *indexed* (non-resolved) row over the native raw-exchange
+wire — that returned `undefined`, so `.nameTransformed` / `.name` reads threw.
 
-- `custom index` (whole describe) — `get > get indexed`,
-  `get > uses indexed requests for replicated resolved remote get`,
-  `iterate > iterate indexed`, `iterate > iterate replicate indexed` are
-  native-red; the plain (resolved) `get` / `iterate` / `get local first` tests
-  are native-green.
-- `prefetch` (whole describe) — `can prefetch search results` is native-red on
-  the 2-peer remote prefetch (`Cannot read properties of undefined (reading
-  'name')`).
+Root cause: on a `resolve:false` / `SearchRequestIndexed` query the responder
+(replicator) embeds the head log entry into the RPC response.
+`DocumentIndex.processQuery` builds a `ResultIndexedValue` whose `entries` field
+is a borsh `@field(vec(Entry))` (`document-interface/src/query.ts`), so the head
+`Entry` is serialized over the document RPC. Under the native block store,
+`this._log.log.get(hash)` returns a **hollow** `EntryV0` whose payload `_data` is
+`null` (the bytes live only in the block store); `_payload` is a **required**
+borsh field (`log/src/entry-v0.ts`), so serialize throws
+`Trying to serialize a null value to field _data`, aborting the whole `Results`
+serialization. The response is never sent, the non-replicating requester times
+out (~10s), `get()` / `iterate()` resolve to `undefined`, and the read of
+`.name` / `.nameTransformed` throws `Cannot read properties of undefined`. The
+block itself **is present** in the block store keyed by hash.
 
-Follow-up: make the remote-indexed (`SearchRequestIndexed`) fetch resolve the
-indexed row over the native raw-exchange path, then fold these describes in.
+Isolation proved the culprit is the native **log / sync** boundary, not the rust
+indexer (rust-indexer + JS-log passes; sqlite-indexer + native-log fails
+identically). This was a real native-vs-JS divergence in the **block-store /
+wire-serialization** path (the same hollow-entry family as Class-A #1025 and the
+shared-log #1021), **not** an index-comparator divergence.
+
+**Fixed**: `DocumentIndex` now routes every head lookup that feeds
+`ResultIndexedValue.entries` through a private `getSerializableHead(hash)` helper
+(`src/search.ts`). It keeps the in-memory entry when it serializes cleanly (the
+JS case — a `getStorageBytes()` probe) and, only when serialization would throw,
+recovers the complete entry from the block store by hash
+(`Entry.fromMultihash(this._log.log.blocks, hash)`), which reconstructs a full,
+wire-serializable, joinable `EntryV0`. The pure-JS backend is unchanged (the
+probe succeeds; recovery never runs). Materialization — not "omit `entries` under
+native" — is the correct fix because the requester joins the returned entry in
+its replicate path (`program.ts`, `this.log.join(entries[0]…)`). The helper
+replaces the raw `this._log.log.get(...)` at all **five** sites that feed
+`entries`: the `processQuery` indexed / `resolve:false` branch, both
+`wrapPushResults` sites, and both `drainQueuedResults` sites. The unrelated
+`resolveDocument` payload read-back is untouched (a latent, no-failing-test site
+left for a separate general-fix follow-up).
+
+The `custom index` and `prefetch` describes are now **covered** (folded into the
+allowlist, 192 → 205): the previously native-red `custom index > get > get
+indexed`, `custom index > get > uses indexed requests for replicated resolved
+remote get`, `custom index > iterate > iterate indexed`,
+`custom index > iterate > iterate replicate indexed`, and
+`prefetch > can prefetch search results` now pass, and the rest of both describes
+(already green) come with them.
 
 ### Not yet catalogued (deferred, out of scope for this leg)
 
@@ -185,19 +217,21 @@ The `updates`, `replication`, `remote`, `acl`, `program as value`, `migration`,
 `updateIndex`, and `most-common-query-predictor` describes were not run
 exhaustively for this initial leg — they are replication / sync / lifecycle
 heavy rather than pure query-surface, and are the natural next widening step once
-the Class-A/C/E follow-ups above land. They are neither claimed green nor
-silently capped.
+the Class-C follow-up above lands (Class-A and Class-E are fixed and folded in).
+They are neither claimed green nor silently capped.
 
 ## Verification summary
 
-- **Native (env set):** allowlist grep GREEN — **192 passing, 0 failing**.
-- **Default (env unset):** same allowlist grep GREEN — **192 passing, 0
+- **Native (env set):** allowlist grep GREEN — **205 passing, 0 failing**.
+- **Default (env unset):** same allowlist grep GREEN — **205 passing, 0
   failing** (baseline unchanged).
 - **Guard:** `docs.index.index` is asserted `RustIndex` under the env and
   `SQLiteIndex` without it; flipping the expected class makes the guard fail with
   the real `RustIndex` value, so a missing/disengaged native build cannot
   false-green.
-- **No product `src/` change:** only the test helper (backend-agnostic sync
-  suppression in `iterate > sort`), the new guard spec, `package.json`
-  (`test:document-rust-core` script), `ci.yml` (one `continue-on-error` step),
-  and this doc.
+- **Product `src/` change is the Class-E fix only:** `src/search.ts`
+  (`getSerializableHead`, folding in the `custom index` / `prefetch` describes).
+  The leg scaffolding itself remains test-only — the test helper
+  (backend-agnostic sync suppression in `iterate > sort`), the guard spec,
+  `package.json` (`test:document-rust-core` script), `ci.yml` (one
+  `continue-on-error` step), and this doc.


### PR DESCRIPTION
## Problem

A remote `resolve:false` / `SearchRequestIndexed` query (a non-replicating peer fetching an *indexed* row from a replicator) **times out and returns `undefined`** when the responder runs on a native block store.

Root cause — the same hollow-entry family as #1021 and #1025, on a third surface: to answer an indexed query the responder embeds the head log `Entry` into `ResultIndexedValue.entries` (a borsh `vec(Entry)` field), which is serialized over the document RPC. Under the native block store `this._log.log.get(hash)` returns a **hollow** `EntryV0` (payload `_data` is null — the bytes live only in the block store), and `_payload` is a required borsh field, so serialization throws `Trying to serialize a null value to field _data`. That aborts the entire `Results` serialization → the response is never sent → the requester waits out the ~10s timeout → `get()`/`iterate()` returns `undefined` → `.name`/`.nameTransformed` throws.

Isolation proved the culprit is the native **log/sync**, not the rust indexer (rust-indexer + JS-log passes; sqlite-indexer + native-log fails identically), and the block is present in the store keyed by hash.

## Fix (contained to `@peerbit/document`, no-op for JS)

New `DocumentIndex.getSerializableHead(hash)`: probe the head with `getStorageBytes()` (the exact serialize op that fails on the wire) and, **only on the hollow-entry throw**, recover the complete entry from the block store via `Entry.fromMultihash` (which the block store holds keyed by hash); fall back to the original entry if the block is genuinely absent (pruned). This mirrors the merged #1025 del read-back fix one layer over.

Applied at the **five** sites that feed `ResultIndexedValue.entries` — the `processQuery` indexed branch, both `wrapPushResults` sites, and both `drainQueuedResults` sites. The unrelated `resolveDocument` payload path is left untouched (it's the latent 4th hollow-entry site, reserved for a separate general log-layer fix).

Materializing (rather than omitting `entries`) is required because the requester joins the head in the replicate path (`remote:{replicate:true}`), and it keeps the JS wire bytes byte-identical.

## Testing

- Folds the `custom index` and `prefetch` describes into the document conformance leg (#1024): **192 → 205**, verified **0 failing on both backends**. The five previously-red tests are green native (`get indexed`, `uses indexed requests for replicated resolved remote get`, `iterate indexed`, `iterate replicate indexed`, `can prefetch search results`) and now return in <1s instead of a ~10s timeout.
- Full `@peerbit/document` JS suite: **360 passing, 0 failing** — no regression (the helper is a no-op for JS: the serialize probe succeeds, recovery never runs).
- Changeset added (`@peerbit/document`, patch). `NATIVE_CONFORMANCE.md` updated (Class-E → FIXED).

## Note

This is the **third** occurrence of the hollow-entry family (#1021 reads, #1025 delete read-back, now remote-indexed responses). The general root fix — making native `Log.get(type:"full")` truly materialize the payload — would collapse all of these plus the latent `resolveDocument` site, and is tracked as a separate follow-up.
