### PR TITLE
fix(log): materialize native full reads

### DIFF
--- a/.changeset/native-full-entry-materialization.md
+++ b/.changeset/native-full-entry-materialization.md
@@ -1,0 +1,9 @@
+---
+"@peerbit/log": patch
+---
+
+Materialize storage-hollow native local entries when callers request a full log entry.
+
+Native local append can keep payload and signature bytes exclusively in the native block store while caching a lightweight concrete `EntryV0` in JavaScript. A later `Log.get()` cache hit returned that hollow object because the existing read-boundary materialization only recognized the lazy raw-exchange wrapper. Payload reads and serialization could therefore fail with `Missing data` even though the complete block was present.
+
+The entry index now detects this concrete hollow state without serializing healthy entries and routes it through the existing block-store resolution path. Batched reads continue to use `getMany`, the materialized entry replaces the cache value, and local-origin metadata is preserved. Raw-exchange send and receive remain lazy because they do not resolve entries through this full-read boundary.

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -1,7 +1,7 @@
 import { deserialize, serialize } from "@dao-xyz/borsh";
 import { type Blocks, type GetOptions } from "@peerbit/blocks-interface";
 import { Cache } from "@peerbit/cache";
-import type { PublicSignKey } from "@peerbit/crypto";
+import { DecryptedThing, type PublicSignKey } from "@peerbit/crypto";
 import {
 	BoolQuery,
 	type Index,
@@ -20,6 +20,7 @@ import { FOREGROUND_READ_MESSAGE_PRIORITY } from "@peerbit/stream-interface";
 import { LamportClock as Clock, Timestamp } from "./clock.js";
 import { ShallowEntry, ShallowMeta } from "./entry-shallow.js";
 import { EntryType } from "./entry-type.js";
+import { EntryV0 } from "./entry-v0.js";
 import {
 	Entry,
 	type PreparedEntryBlock,
@@ -31,6 +32,21 @@ import { logger as baseLogger } from "./logger.js";
 
 const log = baseLogger.newScope("entry-index");
 const LOG_ENTRY_REMOTE_READ_PRIORITY = FOREGROUND_READ_MESSAGE_PRIORITY;
+
+/**
+ * Native local append can cache a concrete EntryV0 whose payload/signature
+ * bytes stay only in the native block store. Unlike the lazy wire wrapper,
+ * that EntryV0 inherits Entry.toMaterialized() as a no-op. Detect the missing
+ * required borsh bytes without serializing the healthy/common case.
+ */
+const isStorageHollowDecryptedThing = (value: unknown): boolean =>
+	value instanceof DecryptedThing && value._data == null;
+
+const isStorageHollowEntryV0 = <T>(entry: Entry<T>): boolean =>
+	entry instanceof EntryV0 &&
+	(isStorageHollowDecryptedThing(entry._meta) ||
+		isStorageHollowDecryptedThing(entry._payload) ||
+		entry._signatures?.signatures.some(isStorageHollowDecryptedThing) === true);
 
 export type ResultsIterator<T> = {
 	close: () => void | Promise<void>;
@@ -2924,15 +2940,24 @@ export class EntryIndex<T> {
 	 * stash-backed head, whose fields stay hollow and whose `instanceof
 	 * EntryV0` is false) must be replaced by their fully-materialized entry
 	 * here so field consumers and `EntryV0.equals` see the canonical entry.
+	 * Native local append can also cache a concrete EntryV0 whose required
+	 * storage bytes remain only in the block store; returning undefined for that
+	 * case makes resolve/resolveMany reuse their existing store-backed path.
 	 * The materialized entry is written back into the cache so the hot head is
-	 * not re-decoded on subsequent reads. Concrete entries return `this` at
-	 * zero cost, so the default backend is unaffected. This runs only on the
-	 * read path — never on the wire/sync fusion path, which caches heads via
-	 * `put` but never resolves them — so entry laziness on the wire is
+	 * not re-decoded on subsequent reads. Complete concrete entries return
+	 * `this` at zero cost, so the default backend is unaffected. This runs only
+	 * on the read path — never on the wire/sync fusion path, which caches heads
+	 * via `put` but never resolves them — so entry laziness on the wire is
 	 * preserved.
 	 */
-	private materializeCached(k: string, mem: Entry<T>): Entry<T> {
+	private materializeCached(k: string, mem: Entry<T>): Entry<T> | undefined {
 		const materialized = mem.toMaterialized();
+		if (isStorageHollowEntryV0(materialized)) {
+			// Signal resolve/resolveMany to use their existing store-backed path.
+			// Cache misses already deserialize a complete entry, and resolveMany
+			// keeps these reloads batched through store.getMany.
+			return undefined;
+		}
 		if (materialized !== mem) {
 			this.cache.add(k, materialized);
 		}
@@ -2945,20 +2970,25 @@ export class EntryIndex<T> {
 	): Promise<Entry<T> | undefined> {
 		let coercedOptions = typeof options === "object" ? options : undefined;
 		/* if (await this.has(k)) { */
-		let mem = this.cache.get(k);
+		const cached = this.cache.get(k);
+		let mem = cached;
+		if (mem) {
+			mem = this.materializeCached(k, mem);
+		}
 		if (mem === undefined) {
 			mem = await this.resolveFromStore(k, coercedOptions);
 			if (mem) {
 				this.properties.init(mem);
 				mem.hash = k;
+				if (cached?.createdLocally !== undefined) {
+					mem.createdLocally = cached.createdLocally;
+				}
 			} else if (coercedOptions?.ignoreMissing !== true) {
 				throw new Error("Failed to load entry from head with hash: " + k);
 			}
 			if (mem) {
 				this.cache.add(k, mem);
 			}
-		} else if (mem) {
-			mem = this.materializeCached(k, mem);
 		}
 		return mem ? mem : undefined;
 		/* }
@@ -2980,13 +3010,24 @@ export class EntryIndex<T> {
 		const resolved: Array<Entry<T> | undefined> = new Array(hashes.length);
 		const missingHashes: string[] = [];
 		const missingPositions: number[] = [];
+		const missingCreatedLocally: Array<boolean | undefined> = [];
 
 		for (let i = 0; i < hashes.length; i++) {
 			const hash = hashes[i]!;
 			const mem = this.cache.get(hash);
 			if (mem !== undefined) {
-				resolved[i] = mem ? this.materializeCached(hash, mem) : undefined;
-				continue;
+				if (!mem) {
+					resolved[i] = undefined;
+					continue;
+				}
+				const materialized = this.materializeCached(hash, mem);
+				if (materialized) {
+					resolved[i] = materialized;
+					continue;
+				}
+				missingCreatedLocally.push(mem.createdLocally);
+			} else {
+				missingCreatedLocally.push(undefined);
 			}
 			missingHashes.push(hash);
 			missingPositions.push(i);
@@ -3014,6 +3055,9 @@ export class EntryIndex<T> {
 			this.properties.init(entry);
 			entry.hash = hash;
 			entry.size = value.length;
+			if (missingCreatedLocally[i] !== undefined) {
+				entry.createdLocally = missingCreatedLocally[i];
+			}
 			this.cache.add(hash, entry);
 			resolved[missingPositions[i]!] = entry;
 		}

--- a/packages/programs/data/document/document/test/native-full-entry-materialization.spec.ts
+++ b/packages/programs/data/document/document/test/native-full-entry-materialization.spec.ts
@@ -1,0 +1,155 @@
+import { field, variant } from "@dao-xyz/borsh";
+import { expect } from "chai";
+import { Peerbit } from "peerbit";
+import { createRustPeerbitOptions } from "peerbit/rust";
+import sinon from "sinon";
+import { Documents } from "../src/program.js";
+import { Document, TestStore } from "./data.js";
+
+@variant("native_full_entry_materialization_indexable")
+class MaterializedIndexable {
+	@field({ type: "string" })
+	id: string;
+
+	@field({ type: "string" })
+	name: string;
+
+	constructor(document?: Document) {
+		this.id = document?.id ?? "";
+		this.name = document?.name ?? "";
+	}
+}
+
+describe("native full-entry materialization", () => {
+	let peer: Peerbit;
+
+	beforeEach(async () => {
+		peer = await Peerbit.create({
+			...createRustPeerbitOptions({ network: false }),
+			libp2p: { addresses: { listen: [] } },
+		});
+	});
+
+	afterEach(async () => {
+		await peer.stop();
+	});
+
+	const openStore = async () => {
+		const store = new TestStore<MaterializedIndexable>({
+			docs: new Documents<Document, MaterializedIndexable>(),
+		});
+		await peer.open(store, {
+			args: {
+				nativeGraph: true,
+				nativeBackbone: { optional: false },
+				index: {
+					type: MaterializedIndexable,
+					cache: { resolver: 0 },
+				},
+			},
+		});
+		expect((store.docs.log as any)._nativeBackbone).to.exist;
+		return store;
+	};
+
+	it("materializes a full read of a native local append", async () => {
+		const store = new TestStore({
+			docs: new Documents<Document>({ immutable: false }),
+		});
+		await peer.open(store, {
+			args: {
+				nativeGraph: true,
+				nativeBackbone: { optional: false },
+			},
+		});
+		expect((store.docs.log as any)._nativeBackbone).to.exist;
+
+		const document = new Document({ id: "materialize-log", name: "log value" });
+		const put = await store.docs.put(document);
+
+		const entry = await store.docs.log.log.get(put.entry.hash);
+		expect(entry).to.exist;
+		expect(entry).not.equal(put.entry);
+		expect(entry?.createdLocally).equal(true);
+		expect(entry!.getStorageBytes()).to.exist;
+		expect(await entry!.getPayloadValue()).to.exist;
+		expect(await store.docs.log.log.get(put.entry.hash)).equal(entry);
+	});
+
+	it("batch-materializes mixed cache states with one block read", async () => {
+		const store = new TestStore({
+			docs: new Documents<Document>({ immutable: false }),
+		});
+		await peer.open(store, {
+			args: {
+				nativeGraph: true,
+				nativeBackbone: { optional: false },
+			},
+		});
+		expect((store.docs.log as any)._nativeBackbone).to.exist;
+
+		const puts = [
+			await store.docs.put(
+				new Document({ id: "materialize-batch-1", name: "one" }),
+			),
+			await store.docs.put(
+				new Document({ id: "materialize-batch-2", name: "two" }),
+			),
+			await store.docs.put(
+				new Document({ id: "materialize-batch-3", name: "three" }),
+			),
+		];
+		const full = await store.docs.log.log.get(puts[0].entry.hash);
+		expect(full).to.exist;
+		await store.docs.log.log.blocks.rm(puts[2].entry.hash);
+
+		const getManySpy = sinon.spy(store.docs.log.log.blocks, "getMany");
+
+		try {
+			const entries = await store.docs.log.log.entryIndex.getMany(
+				puts.map((put) => put.entry.hash),
+				{ type: "full", ignoreMissing: true },
+			);
+			expect(entries).to.have.length(3);
+			expect(entries[0]).equal(full);
+			expect(entries[1]).not.equal(puts[1].entry);
+			expect(entries[1]?.createdLocally).equal(true);
+			expect(entries[1]!.getStorageBytes()).to.exist;
+			expect(await entries[1]!.getPayloadValue()).to.exist;
+			expect(entries[2]).equal(undefined);
+			expect(getManySpy.callCount).equal(1);
+			expect(getManySpy.firstCall.args[0]).to.deep.equal([
+				puts[1].entry.hash,
+				puts[2].entry.hash,
+			]);
+
+			const cached = await store.docs.log.log.entryIndex.getMany(
+				puts.slice(0, 2).map((put) => put.entry.hash),
+			);
+			expect(cached).to.deep.equal(entries.slice(0, 2));
+			expect(getManySpy.callCount).equal(1);
+		} finally {
+			getManySpy.restore();
+		}
+	});
+
+	it("resolves a local document from a storage-hollow native entry", async () => {
+		const store = await openStore();
+
+		const document = new Document({
+			id: "materialize-1",
+			name: "materialized",
+		});
+		await store.docs.put(document);
+
+		// With the resolver cache disabled and a non-identity index, this reaches
+		// resolveDocument -> Log.get(type:"full") -> getPayloadValue. The cached
+		// native local-append EntryV0 used to be hollow and throw "Missing data".
+		const resolved = await store.docs.index.get(document.id, {
+			local: true,
+			remote: false,
+		});
+		expect(resolved).to.be.instanceOf(Document);
+		expect(resolved?.name).equal(document.name);
+	});
+});


### PR DESCRIPTION
## Summary

- detect concrete native `EntryV0` cache values whose required `DecryptedThing` storage bytes are still hollow
- route full reads through the existing block-store resolution path and preserve `createdLocally`
- keep mixed `getMany` reads batched, replace hollow cache values after materialization, and leave raw-exchange fusion lazy

## Regression coverage

- direct `Log.get()` of a native local append returns a complete, serializable entry and caches it
- mixed batch reads preserve ordering across a complete hit, a hollow hit, and a removed block while issuing one `getMany`
- document index resolution reaches `resolveDocument -> Log.get -> getPayloadValue` with the resolver cache disabled

## Validation

- `pnpm run build`
- `@peerbit/log`: 232 passing
- `@peerbit/document`: 357 passing; focused final regression: 3 passing
- native shared-log conformance: 147 passing, 1 pending
- native document conformance: 205 passing
- native fusion hard-veto suite: 3 passing
- shared-log remainder: 1904 passing, 10 pending
- changed-file ESLint and formatting checks

The unfiltered shared-log suite also reproduces the existing `adaptive ingest burst control` failure on an untouched `origin/master` worktree. The full remainder passes with that describe block excluded.
