### PR TITLE
fix(release): enforce Peerbit Bot identity

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -16,10 +16,28 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' && vars.ENABLE_WORKSPACE_RESTORE == 'true' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Verify Peerbit Bot restore authentication
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "RELEASE_PR_TOKEN is required for workspace restore pull requests" >&2
+            exit 1
+          fi
+          if ! authenticated_login=$(gh api user --jq .login); then
+            echo "RELEASE_PR_TOKEN could not authenticate with GitHub" >&2
+            exit 1
+          fi
+          if [ "$authenticated_login" != "peerbit-org" ]; then
+            echo "RELEASE_PR_TOKEN must authenticate as peerbit-org (got: $authenticated_login)" >&2
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PR_TOKEN }}
 
       - name: Use Node.js
         uses: actions/setup-node@v4
@@ -32,7 +50,9 @@ jobs:
       - name: Create workspace restore pull request
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PR_TOKEN }}
+          author: "Peerbit Bot <273107789+peerbit-org@users.noreply.github.com>"
+          committer: "Peerbit Bot <273107789+peerbit-org@users.noreply.github.com>"
           commit-message: "chore: restore workspace dependency protocol"
           title: "chore: restore workspace dependency protocol"
           body: |
@@ -77,10 +97,18 @@ jobs:
         if: ${{ steps.server.outputs.changed == 'true' }}
         id: auth
         env:
-          BOOTSTRAP_PR_TOKEN: ${{ secrets.PEERBIT_BOOTSTRAP_PR_TOKEN }}
+          GH_TOKEN: ${{ secrets.PEERBIT_BOOTSTRAP_PR_TOKEN }}
         run: |
-          if [ -z "$BOOTSTRAP_PR_TOKEN" ]; then
+          if [ -z "${GH_TOKEN:-}" ]; then
             echo "PEERBIT_BOOTSTRAP_PR_TOKEN is required when @peerbit/server changes" >&2
+            exit 1
+          fi
+          if ! authenticated_login=$(gh api user --jq .login); then
+            echo "PEERBIT_BOOTSTRAP_PR_TOKEN could not authenticate with GitHub" >&2
+            exit 1
+          fi
+          if [ "$authenticated_login" != "peerbit-org" ]; then
+            echo "PEERBIT_BOOTSTRAP_PR_TOKEN must authenticate as peerbit-org (got: $authenticated_login)" >&2
             exit 1
           fi
           echo "enabled=true" >> "$GITHUB_OUTPUT"
@@ -104,6 +132,8 @@ jobs:
         with:
           token: ${{ secrets.PEERBIT_BOOTSTRAP_PR_TOKEN }}
           path: peerbit-bootstrap
+          author: "Peerbit Bot <273107789+peerbit-org@users.noreply.github.com>"
+          committer: "Peerbit Bot <273107789+peerbit-org@users.noreply.github.com>"
           commit-message: "chore: roll bootstrap-5 to @peerbit/server@${{ steps.server.outputs.version }}"
           title: "chore: roll bootstrap-5 to @peerbit/server@${{ steps.server.outputs.version }}"
           body: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,23 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
+      - name: Verify Peerbit Bot release authentication
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "RELEASE_PR_TOKEN is required for stable releases" >&2
+            exit 1
+          fi
+          if ! authenticated_login=$(gh api user --jq .login); then
+            echo "RELEASE_PR_TOKEN could not authenticate with GitHub" >&2
+            exit 1
+          fi
+          if [ "$authenticated_login" != "peerbit-org" ]; then
+            echo "RELEASE_PR_TOKEN must authenticate as peerbit-org (got: $authenticated_login)" >&2
+            exit 1
+          fi
+
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
@@ -50,7 +67,7 @@ jobs:
           # credentials persisted here — so this must be the bot PAT (see the
           # RELEASE_PR_TOKEN note below) for the version-branch push to be able
           # to trigger CI on the Version Packages PR.
-          token: ${{ secrets.RELEASE_PR_TOKEN || github.token }}
+          token: ${{ secrets.RELEASE_PR_TOKEN }}
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -76,12 +93,12 @@ jobs:
     # changesets/action opens the Version Packages PR (when changesets are
     # pending) and, once that PR is merged, runs the publish command below.
     #
-    # NOTE: secrets.GITHUB_TOKEN cannot trigger downstream workflows (CI) on the
+    # NOTE: the default workflow token cannot trigger downstream workflows (CI) on the
     # Version Packages PR it opens, so the PR is opened with RELEASE_PR_TOKEN —
-    # a peerbit-org bot PAT with repo + workflow scopes. Both the checkout token
-    # above (git pushes: version branch, release tags) and the action token
-    # below fall back to the default GITHUB_TOKEN if the secret is removed, in
-    # which case everything still works except CI on the Version Packages PR.
+    # a peerbit-org bot PAT with repo + workflow scopes. The authentication
+    # preflight above deliberately fails closed if the secret is missing or does
+    # not belong to peerbit-org. The checkout token (git pushes: version branch,
+    # release tags), action token, and environment token below all use that PAT.
     #
     # createGithubReleases is disabled deliberately. changesets tags packages as
     # `<name>@<version>` (e.g. peerbit@5.2.21, @peerbit/crypto@3.2.0), whereas
@@ -97,9 +114,9 @@ jobs:
     # once the CHANGELOGs are migrated to the changesets `## <version>` format.
       - name: Create Release PR or Publish
         if: ${{ github.event_name == 'push' }}
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
-          github-token: ${{ secrets.RELEASE_PR_TOKEN || github.token }}
+          github-token: ${{ secrets.RELEASE_PR_TOKEN }}
           # Keep the repository-local Peerbit Bot identity configured above.
           # Otherwise the action replaces it with github-actions[bot].
           setupGitUser: false
@@ -125,7 +142,7 @@ jobs:
         env:
           # Older changesets/action builds read the token from the environment
           # rather than the github-token input; set both to stay robust.
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     # Manual stable escape hatch: build and publish anything whose package.json
@@ -139,8 +156,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm run --if-present release
 
-  # Release candidate flow, unchanged in behavior: manual dispatch only, builds
-  # and runs `aegir release-rc` to publish prerelease versions to npm.
+  # Release candidate flow: manual dispatch only, builds and runs
+  # `aegir release-rc` to publish prerelease versions to npm.
   release-rc:
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.publish_mode == 'rc' }}
     runs-on: ubuntu-latest
@@ -150,10 +167,28 @@ jobs:
       contents: write
       id-token: write
     steps:
+      - name: Verify Peerbit Bot release authentication
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "RELEASE_PR_TOKEN is required for release candidates" >&2
+            exit 1
+          fi
+          if ! authenticated_login=$(gh api user --jq .login); then
+            echo "RELEASE_PR_TOKEN could not authenticate with GitHub" >&2
+            exit 1
+          fi
+          if [ "$authenticated_login" != "peerbit-org" ]; then
+            echo "RELEASE_PR_TOKEN must authenticate as peerbit-org (got: $authenticated_login)" >&2
+            exit 1
+          fi
+
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PR_TOKEN }}
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -169,11 +204,18 @@ jobs:
           rustup target add wasm32-unknown-unknown
           pnpm install --frozen-lockfile=false
 
+      - name: Configure Peerbit Bot git identity
+        run: |
+          git config --local user.name "Peerbit Bot"
+          git config --local user.email "273107789+peerbit-org@users.noreply.github.com"
+
       - name: Build Packages
         run: pnpm run build
 
       - name: Publish RC to NPM
         env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
           NPM_CONFIG_GIT_CHECKS: "false"
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm run --if-present release:rc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,8 +93,8 @@ jobs:
     # changesets/action opens the Version Packages PR (when changesets are
     # pending) and, once that PR is merged, runs the publish command below.
     #
-    # NOTE: the default workflow token cannot trigger downstream workflows (CI) on the
-    # Version Packages PR it opens, so the PR is opened with RELEASE_PR_TOKEN —
+    # NOTE: the default workflow token cannot trigger downstream workflows (CI)
+    # on the Version Packages PR it opens, so the PR uses RELEASE_PR_TOKEN —
     # a peerbit-org bot PAT with repo + workflow scopes. The authentication
     # preflight above deliberately fails closed if the secret is missing or does
     # not belong to peerbit-org. The checkout token (git pushes: version branch,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,11 @@ jobs:
           rustup target add wasm32-unknown-unknown
           pnpm install --frozen-lockfile=false
 
+      - name: Configure Peerbit Bot git identity
+        run: |
+          git config --local user.name "Peerbit Bot"
+          git config --local user.email "273107789+peerbit-org@users.noreply.github.com"
+
     # changesets/action opens the Version Packages PR (when changesets are
     # pending) and, once that PR is merged, runs the publish command below.
     #
@@ -95,6 +100,9 @@ jobs:
         uses: changesets/action@v1
         with:
           github-token: ${{ secrets.RELEASE_PR_TOKEN || github.token }}
+          # Keep the repository-local Peerbit Bot identity configured above.
+          # Otherwise the action replaces it with github-actions[bot].
+          setupGitUser: false
           version: pnpm run version-packages
           # Build, publish every unpublished version (from-package), then create
           # the pkg@version git tags and push them. The push is tags-only


### PR DESCRIPTION
## Summary

- preserve `Peerbit Bot <273107789+peerbit-org@users.noreply.github.com>` for Changesets version commits, tags, stable releases, and release candidates
- fail closed unless `RELEASE_PR_TOKEN` authenticates as exactly `peerbit-org`; remove GitHub Actions token fallbacks from release writes
- pin the audited Changesets action v1.9.0 commit and disable its default git-user override
- require the workspace-restore and bootstrap-rollout PR paths to authenticate as `peerbit-org`, with explicit bot author and committer values

## Validation

- both workflow files parse as YAML 1.2
- Changesets `setupGitUser` behavior and create-pull-request `author`/`committer` inputs verified against their action definitions
- semantic assertions confirm no release-token fallback remains and every write path carries the bot identity
- `git diff --check` is clean

## Operational requirement

Stable/RC release jobs now intentionally fail if `RELEASE_PR_TOKEN` is absent or belongs to another account. Bootstrap rollout creation likewise fails if `PEERBIT_BOOTSTRAP_PR_TOKEN` is absent or is not owned by `peerbit-org`.

No changeset is included because this changes release automation only.