### PR TITLE
fix(log): prevent cache resurrection after delete

### DIFF
--- a/.changeset/quiet-cache-deletions.md
+++ b/.changeset/quiet-cache-deletions.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/log": patch
+---
+
+Prevent concurrent full-entry reads from restoring cache entries after deletion.

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -512,8 +512,12 @@ export type ReturnTypeFromResolveOptions<
 		? any
 		: Entry<T>;
 
+type CachePublicationGuard = { invalidated: boolean };
+
 export class EntryIndex<T> {
 	private cache: Cache<Entry<T>>;
+	private inFlightCachePublications: Map<string, Set<CachePublicationGuard>>;
+	private activeCacheInvalidations: Map<string, number>;
 	private sortReversed: Sort[];
 	private initialied = false;
 	private _length: number;
@@ -551,9 +555,92 @@ export class EntryIndex<T> {
 						: SortDirection.DESC),
 		);
 		this.cache = properties.cache ?? new Cache({ max: ENTRY_CACHE_MAX_SIZE });
+		this.inFlightCachePublications = new Map();
+		this.activeCacheInvalidations = new Map();
 		this._length = 0;
 		this.insertionPromises = new Map();
 		this.pendingIndexWrites = new Map();
+	}
+
+	/**
+	 * Cache publication is guarded separately from the storage read. Deletions
+	 * invalidate reads that were already in flight, while the active counter
+	 * makes reads started during the delete window invalid from the outset.
+	 */
+	private beginCachePublication(hash: string): CachePublicationGuard {
+		const guard: CachePublicationGuard = {
+			invalidated: this.activeCacheInvalidations.has(hash),
+		};
+		let guards = this.inFlightCachePublications.get(hash);
+		if (!guards) {
+			guards = new Set();
+			this.inFlightCachePublications.set(hash, guards);
+		}
+		guards.add(guard);
+		return guard;
+	}
+
+	private endCachePublication(hash: string, guard: CachePublicationGuard) {
+		const guards = this.inFlightCachePublications.get(hash);
+		if (!guards) {
+			return;
+		}
+		guards.delete(guard);
+		if (guards.size === 0) {
+			this.inFlightCachePublications.delete(hash);
+		}
+	}
+
+	private invalidateCachedEntry(hash: string) {
+		this.cache.del(hash);
+		for (const guard of this.inFlightCachePublications.get(hash) ?? []) {
+			guard.invalidated = true;
+		}
+	}
+
+	private beginCacheInvalidation(hash: string) {
+		this.activeCacheInvalidations.set(
+			hash,
+			(this.activeCacheInvalidations.get(hash) ?? 0) + 1,
+		);
+		this.invalidateCachedEntry(hash);
+	}
+
+	private endCacheInvalidation(hash: string) {
+		this.invalidateCachedEntry(hash);
+		const remaining = (this.activeCacheInvalidations.get(hash) ?? 1) - 1;
+		if (remaining === 0) {
+			this.activeCacheInvalidations.delete(hash);
+		} else {
+			this.activeCacheInvalidations.set(hash, remaining);
+		}
+	}
+
+	private withCacheInvalidation<R>(
+		hashes: Iterable<string>,
+		fn: () => MaybePromise<R>,
+	): MaybePromise<R> {
+		const uniqueHashes = [...new Set(hashes)];
+		for (const hash of uniqueHashes) {
+			this.beginCacheInvalidation(hash);
+		}
+		const finish = () => {
+			for (const hash of uniqueHashes) {
+				this.endCacheInvalidation(hash);
+			}
+		};
+		let result: MaybePromise<R>;
+		try {
+			result = fn();
+		} catch (error) {
+			finish();
+			throw error;
+		}
+		if (isPromiseLike(result)) {
+			return result.finally(finish);
+		}
+		finish();
+		return result;
 	}
 
 	private materializePendingIndexWrite(
@@ -2202,37 +2289,37 @@ export class EntryIndex<T> {
 	}
 
 	async delete(k: string, from?: Entry<any> | ShallowEntry) {
-		this.cache.del(k);
+		return this.withCacheInvalidation([k], async () => {
+			if (from && from.hash !== k) {
+				throw new Error("Shallow hash doesn't match the key");
+			}
 
-		if (from && from.hash !== k) {
-			throw new Error("Shallow hash doesn't match the key");
-		}
+			const pending = this.getPendingIndexWrite(k);
+			from = from || pending || (await this.getShallow(k))?.value;
+			if (!from) {
+				return; // already deleted
+			}
+			if (pending) {
+				this.pendingIndexWrites.delete(k);
+				await this.properties.store.rm(k);
+				this._length--;
+				this.properties.nativeGraph?.graph.delete(k);
+				await this.privateUpdateNextHeadProperty(from, true);
+				return from;
+			}
 
-		const pending = this.getPendingIndexWrite(k);
-		from = from || pending || (await this.getShallow(k))?.value;
-		if (!from) {
-			return; // already deleted
-		}
-		if (pending) {
-			this.pendingIndexWrites.delete(k);
+			let deleted = await this.properties.index.del({ query: { hash: k } });
 			await this.properties.store.rm(k);
-			this._length--;
-			this.properties.nativeGraph?.graph.delete(k);
-			await this.privateUpdateNextHeadProperty(from, true);
-			return from;
-		}
 
-		let deleted = await this.properties.index.del({ query: { hash: k } });
-		await this.properties.store.rm(k);
+			if (deleted.length > 0) {
+				this._length -= deleted.length;
+				this.properties.nativeGraph?.graph.delete(k);
 
-		if (deleted.length > 0) {
-			this._length -= deleted.length;
-			this.properties.nativeGraph?.graph.delete(k);
-
-			// mark all next entries as new heads
-			await this.privateUpdateNextHeadProperty(from, true);
-			return from;
-		}
+				// mark all next entries as new heads
+				await this.privateUpdateNextHeadProperty(from, true);
+				return from;
+			}
+		});
 	}
 
 	canDeleteMany(): boolean {
@@ -2256,6 +2343,16 @@ export class EntryIndex<T> {
 		if (from.length === 0) {
 			return [];
 		}
+		return this.withCacheInvalidation(
+			from.map((node) => node.hash),
+			() => this.deleteManyWithInvalidation(from, options),
+		);
+	}
+
+	private deleteManyWithInvalidation(
+		from: ShallowEntry[],
+		options?: { skipNextHeadUpdates?: boolean },
+	): MaybePromise<ShallowEntry[]> {
 		if (from.length === 1) {
 			return this.deleteSingleMaybe(from[0]!, options);
 		}
@@ -2275,7 +2372,6 @@ export class EntryIndex<T> {
 		const storeHashes: string[] = [];
 
 		for (const node of nodes) {
-			this.cache.del(node.hash);
 			const pending = this.getPendingIndexWrite(node.hash);
 			if (pending) {
 				this.pendingIndexWrites.delete(node.hash);
@@ -2379,7 +2475,14 @@ export class EntryIndex<T> {
 		) {
 			return undefined;
 		}
+		return this.withCacheInvalidation(hashes, () =>
+			this.consumeNativeTrimmedEntryHashesNoReturnWithInvalidation(hashes),
+		);
+	}
 
+	private consumeNativeTrimmedEntryHashesNoReturnWithInvalidation(
+		hashes: string[],
+	): MaybePromise<boolean> {
 		const indexedHashes: string[] = [];
 		let pendingDeleted = 0;
 		const seen = new Set<string>();
@@ -2388,7 +2491,6 @@ export class EntryIndex<T> {
 				continue;
 			}
 			seen.add(hash);
-			this.cache.del(hash);
 			if (this.pendingIndexWrites.delete(hash)) {
 				pendingDeleted++;
 			} else {
@@ -2447,11 +2549,20 @@ export class EntryIndex<T> {
 		nodes: ShallowEntry[],
 		options?: { skipNextHeadUpdates?: boolean; deleteBlocks?: boolean },
 	): MaybePromise<ShallowEntry[]> {
+		return this.withCacheInvalidation(
+			nodes.map((node) => node.hash),
+			() => this.consumeNativeTrimmedEntryNodesWithInvalidation(nodes, options),
+		);
+	}
+
+	private consumeNativeTrimmedEntryNodesWithInvalidation(
+		nodes: ShallowEntry[],
+		options?: { skipNextHeadUpdates?: boolean; deleteBlocks?: boolean },
+	): MaybePromise<ShallowEntry[]> {
 		const indexedByHash = new Map(nodes.map((node) => [node.hash, node]));
 		const deletedByHash = new Map<string, ShallowEntry>();
 		const indexedHashes: string[] = [];
 		for (const node of nodes) {
-			this.cache.del(node.hash);
 			const pending = this.getPendingIndexWrite(node.hash);
 			if (pending) {
 				this.pendingIndexWrites.delete(node.hash);
@@ -2501,7 +2612,6 @@ export class EntryIndex<T> {
 		node: ShallowEntry,
 		options?: { skipNextHeadUpdates?: boolean },
 	): MaybePromise<ShallowEntry[]> {
-		this.cache.del(node.hash);
 		const pending = this.getPendingIndexWrite(node.hash);
 		if (pending) {
 			this.pendingIndexWrites.delete(node.hash);
@@ -2976,18 +3086,23 @@ export class EntryIndex<T> {
 			mem = this.materializeCached(k, mem);
 		}
 		if (mem === undefined) {
-			mem = await this.resolveFromStore(k, coercedOptions);
-			if (mem) {
-				this.properties.init(mem);
-				mem.hash = k;
-				if (cached?.createdLocally !== undefined) {
-					mem.createdLocally = cached.createdLocally;
+			const cachePublication = this.beginCachePublication(k);
+			try {
+				mem = await this.resolveFromStore(k, coercedOptions);
+				if (mem) {
+					this.properties.init(mem);
+					mem.hash = k;
+					if (cached?.createdLocally !== undefined) {
+						mem.createdLocally = cached.createdLocally;
+					}
+				} else if (coercedOptions?.ignoreMissing !== true) {
+					throw new Error("Failed to load entry from head with hash: " + k);
 				}
-			} else if (coercedOptions?.ignoreMissing !== true) {
-				throw new Error("Failed to load entry from head with hash: " + k);
-			}
-			if (mem) {
-				this.cache.add(k, mem);
+				if (mem && !cachePublication.invalidated) {
+					this.cache.add(k, mem);
+				}
+			} finally {
+				this.endCachePublication(k, cachePublication);
 			}
 		}
 		return mem ? mem : undefined;
@@ -3037,29 +3152,42 @@ export class EntryIndex<T> {
 			return resolved;
 		}
 
-		const values = await this.properties.store.getMany!(
-			missingHashes,
-			withDefaultRemoteReadPriority(coercedOptions),
+		const cachePublications = missingHashes.map((hash) =>
+			this.beginCachePublication(hash),
 		);
-		for (let i = 0; i < values.length; i++) {
-			const hash = missingHashes[i]!;
-			const value = values[i];
-			if (!value) {
-				if (coercedOptions?.ignoreMissing !== true) {
-					throw new Error("Failed to load entry from head with hash: " + hash);
+		try {
+			const values = await this.properties.store.getMany!(
+				missingHashes,
+				withDefaultRemoteReadPriority(coercedOptions),
+			);
+			for (let i = 0; i < values.length; i++) {
+				const hash = missingHashes[i]!;
+				const value = values[i];
+				if (!value) {
+					if (coercedOptions?.ignoreMissing !== true) {
+						throw new Error(
+							"Failed to load entry from head with hash: " + hash,
+						);
+					}
+					continue;
 				}
-				continue;
-			}
 
-			const entry = deserialize(value, Entry) as Entry<T>;
-			this.properties.init(entry);
-			entry.hash = hash;
-			entry.size = value.length;
-			if (missingCreatedLocally[i] !== undefined) {
-				entry.createdLocally = missingCreatedLocally[i];
+				const entry = deserialize(value, Entry) as Entry<T>;
+				this.properties.init(entry);
+				entry.hash = hash;
+				entry.size = value.length;
+				if (missingCreatedLocally[i] !== undefined) {
+					entry.createdLocally = missingCreatedLocally[i];
+				}
+				if (!cachePublications[i]!.invalidated) {
+					this.cache.add(hash, entry);
+				}
+				resolved[missingPositions[i]!] = entry;
 			}
-			this.cache.add(hash, entry);
-			resolved[missingPositions[i]!] = entry;
+		} finally {
+			for (let i = 0; i < cachePublications.length; i++) {
+				this.endCachePublication(missingHashes[i]!, cachePublications[i]!);
+			}
 		}
 
 		return resolved;

--- a/packages/log/test/delete.spec.ts
+++ b/packages/log/test/delete.spec.ts
@@ -8,6 +8,13 @@ import { JSON_ENCODING } from "./utils/encoding.js";
 
 describe("delete", function () {
 	let store: BlockStore;
+	const deferred = () => {
+		let resolve!: () => void;
+		const promise = new Promise<void>((done) => {
+			resolve = done;
+		});
+		return { promise, resolve };
+	};
 
 	beforeEach(async () => {
 		store = new AnyBlockStore();
@@ -25,6 +32,187 @@ describe("delete", function () {
 			return false;
 		}
 	};
+
+	describe("in-flight reads", () => {
+		it("does not republish a deleted entry after a single store read", async () => {
+			const log = new Log<Uint8Array>();
+			await log.open(store, signKey);
+			const { entry } = await log.append(new Uint8Array([1]));
+			(log.entryIndex as any).cache.clear();
+
+			const readStarted = deferred();
+			const releaseRead = deferred();
+			const originalGet = store.get.bind(store);
+			let intercepted = false;
+			store.get = async (cid, options) => {
+				const value = await originalGet(cid, options);
+				if (cid === entry.hash && !intercepted) {
+					intercepted = true;
+					readStarted.resolve();
+					await releaseRead.promise;
+				}
+				return value;
+			};
+
+			let inFlight: Promise<Entry<Uint8Array> | undefined> | undefined;
+			try {
+				inFlight = log.get(entry.hash);
+				await readStarted.promise;
+				await log.delete(entry.hash);
+				releaseRead.resolve();
+				expect((await inFlight)?.hash).to.equal(entry.hash);
+			} finally {
+				releaseRead.resolve();
+				store.get = originalGet;
+				await inFlight;
+			}
+
+			expect(await log.get(entry.hash)).to.equal(undefined);
+		});
+
+		it("does not publish a store read started during deletion", async () => {
+			const log = new Log<Uint8Array>();
+			await log.open(store, signKey);
+			const { entry } = await log.append(new Uint8Array([1]));
+
+			const removeStarted = deferred();
+			const releaseRemove = deferred();
+			const originalRm = store.rm.bind(store);
+			let intercepted = false;
+			store.rm = async (cid) => {
+				if (cid === entry.hash && !intercepted) {
+					intercepted = true;
+					removeStarted.resolve();
+					await releaseRemove.promise;
+				}
+				return originalRm(cid);
+			};
+
+			let deletion: Promise<unknown> | undefined;
+			try {
+				deletion = log.delete(entry.hash);
+				await removeStarted.promise;
+				const resolvedDuringDelete = await log.get(entry.hash);
+				expect(resolvedDuringDelete?.hash).to.equal(entry.hash);
+				expect((log.entryIndex as any).cache.get(entry.hash)).to.equal(
+					undefined,
+				);
+				releaseRemove.resolve();
+				await deletion;
+			} finally {
+				releaseRemove.resolve();
+				store.rm = originalRm;
+				await deletion;
+			}
+
+			expect(await log.get(entry.hash)).to.equal(undefined);
+		});
+
+		it("does not publish batched reads started during bulk deletion", async () => {
+			const log = new Log<Uint8Array>();
+			await log.open(store, signKey);
+			const { entry: firstDeleted } = await log.append(new Uint8Array([1]));
+			const { entry: secondDeleted } = await log.append(new Uint8Array([2]));
+			const { entry: retained } = await log.append(new Uint8Array([3]));
+			const firstShallow = (await log.getShallow(firstDeleted.hash))!;
+			const secondShallow = (await log.getShallow(secondDeleted.hash))!;
+			(log.entryIndex as any).cache.clear();
+
+			const removeStarted = deferred();
+			const releaseRemove = deferred();
+			const originalRmMany = store.rmMany.bind(store);
+			let intercepted = false;
+			store.rmMany = async (cids) => {
+				if (cids.includes(firstDeleted.hash) && !intercepted) {
+					intercepted = true;
+					removeStarted.resolve();
+					await releaseRemove.promise;
+				}
+				return originalRmMany(cids);
+			};
+
+			let deletion: Promise<unknown> | undefined;
+			try {
+				deletion = log.entryIndex.deleteMany([firstShallow, secondShallow], {
+					skipNextHeadUpdates: true,
+				});
+				await removeStarted.promise;
+				const resolved = await log.entryIndex.getMany(
+					[firstDeleted.hash, secondDeleted.hash, retained.hash],
+					{ type: "full", ignoreMissing: true },
+				);
+				expect(resolved.map((entry) => entry?.hash)).to.deep.equal([
+					firstDeleted.hash,
+					secondDeleted.hash,
+					retained.hash,
+				]);
+				expect((log.entryIndex as any).cache.get(firstDeleted.hash)).to.equal(
+					undefined,
+				);
+				expect((log.entryIndex as any).cache.get(secondDeleted.hash)).to.equal(
+					undefined,
+				);
+				expect((log.entryIndex as any).cache.get(retained.hash)).to.equal(
+					resolved[2],
+				);
+				releaseRemove.resolve();
+				await deletion;
+			} finally {
+				releaseRemove.resolve();
+				store.rmMany = originalRmMany;
+				await deletion;
+			}
+
+			expect(await log.get(firstDeleted.hash)).to.equal(undefined);
+			expect(await log.get(secondDeleted.hash)).to.equal(undefined);
+			expect(await log.get(retained.hash)).to.exist;
+		});
+
+		it("only skips deleted entries when publishing a batched store read", async () => {
+			const log = new Log<Uint8Array>();
+			await log.open(store, signKey);
+			const { entry: deletedEntry } = await log.append(new Uint8Array([1]));
+			const { entry: retainedEntry } = await log.append(new Uint8Array([2]));
+			(log.entryIndex as any).cache.clear();
+
+			const readStarted = deferred();
+			const releaseRead = deferred();
+			const originalGetMany = store.getMany.bind(store);
+			let intercepted = false;
+			store.getMany = async (cids, options) => {
+				const values = await originalGetMany(cids, options);
+				if (cids.includes(deletedEntry.hash) && !intercepted) {
+					intercepted = true;
+					readStarted.resolve();
+					await releaseRead.promise;
+				}
+				return values;
+			};
+
+			let inFlight: Promise<Array<Entry<Uint8Array> | undefined>> | undefined;
+			try {
+				inFlight = log.entryIndex.getMany(
+					[deletedEntry.hash, retainedEntry.hash],
+					{ type: "full", ignoreMissing: true },
+				);
+				await readStarted.promise;
+				await log.delete(deletedEntry.hash);
+				releaseRead.resolve();
+				const resolved = await inFlight;
+				expect(resolved.map((entry) => entry?.hash)).to.deep.equal([
+					deletedEntry.hash,
+					retainedEntry.hash,
+				]);
+				expect(await log.get(retainedEntry.hash)).to.equal(resolved[1]);
+			} finally {
+				releaseRead.resolve();
+				store.getMany = originalGetMany;
+				await inFlight;
+			}
+
+			expect(await log.get(deletedEntry.hash)).to.equal(undefined);
+		});
+	});
 
 	describe("deleteRecursively", () => {
 		it("deleted unreferences", async () => {

--- a/packages/log/test/delete.spec.ts
+++ b/packages/log/test/delete.spec.ts
@@ -168,6 +168,126 @@ describe("delete", function () {
 			expect(await log.get(retained.hash)).to.exist;
 		});
 
+		it("does not publish a batched read invalidated by native trim", async () => {
+			const log = new Log<Uint8Array>();
+			await log.open(store, signKey);
+			const { entry: trimmedEntry } = await log.append(new Uint8Array([1]));
+			const { entry: retainedEntry } = await log.append(new Uint8Array([2]));
+			(log.entryIndex as any).cache.clear();
+
+			const readStarted = deferred();
+			const releaseRead = deferred();
+			const originalGetMany = store.getMany.bind(store);
+			let intercepted = false;
+			store.getMany = async (cids, options) => {
+				const values = await originalGetMany(cids, options);
+				if (cids.includes(trimmedEntry.hash) && !intercepted) {
+					intercepted = true;
+					readStarted.resolve();
+					await releaseRead.promise;
+				}
+				return values;
+			};
+
+			let inFlight: Promise<Array<Entry<Uint8Array> | undefined>> | undefined;
+			try {
+				inFlight = log.entryIndex.getMany(
+					[trimmedEntry.hash, retainedEntry.hash],
+					{ type: "full", ignoreMissing: true },
+				);
+				await readStarted.promise;
+				const consumed =
+					log.entryIndex.consumeNativeTrimmedEntryHashesNoReturnMaybe(
+						[trimmedEntry.hash],
+						{ skipNextHeadUpdates: true, deleteBlocks: false },
+					);
+				expect(consumed).not.to.equal(undefined);
+				expect(await consumed).to.equal(true);
+				releaseRead.resolve();
+				const resolved = await inFlight;
+				expect(resolved.map((entry) => entry?.hash)).to.deep.equal([
+					trimmedEntry.hash,
+					retainedEntry.hash,
+				]);
+				expect((log.entryIndex as any).cache.get(trimmedEntry.hash)).to.equal(
+					undefined,
+				);
+				expect((log.entryIndex as any).cache.get(retainedEntry.hash)).to.equal(
+					resolved[1],
+				);
+			} finally {
+				releaseRead.resolve();
+				store.getMany = originalGetMany;
+				await inFlight;
+			}
+
+			expect((log.entryIndex as any).activeCacheInvalidations.size).to.equal(0);
+			expect((log.entryIndex as any).inFlightCachePublications.size).to.equal(
+				0,
+			);
+		});
+
+		it("keeps overlapping deletion invalidations active until all settle", async () => {
+			const log = new Log<Uint8Array>();
+			await log.open(store, signKey);
+			const { entry } = await log.append(new Uint8Array([1]));
+			const shallow = (await log.getShallow(entry.hash))!;
+			(log.entryIndex as any).cache.clear();
+
+			const removeStarted = [deferred(), deferred()];
+			const releaseRemove = [deferred(), deferred()];
+			const originalRm = store.rm.bind(store);
+			let removeCalls = 0;
+			store.rm = async (cid) => {
+				if (cid !== entry.hash || removeCalls >= removeStarted.length) {
+					return originalRm(cid);
+				}
+				const call = removeCalls++;
+				removeStarted[call]!.resolve();
+				await releaseRemove[call]!.promise;
+				if (call === 1) {
+					return originalRm(cid);
+				}
+			};
+
+			let firstDeletion: Promise<unknown> | undefined;
+			let secondDeletion: Promise<unknown> | undefined;
+			try {
+				firstDeletion = log.entryIndex.delete(entry.hash, shallow);
+				await removeStarted[0]!.promise;
+				secondDeletion = log.entryIndex.delete(entry.hash, shallow);
+				await removeStarted[1]!.promise;
+
+				releaseRemove[0]!.resolve();
+				await firstDeletion;
+				expect(
+					(log.entryIndex as any).activeCacheInvalidations.get(entry.hash),
+				).to.equal(1);
+
+				const resolvedDuringDelete = await log.get(entry.hash);
+				expect(resolvedDuringDelete?.hash).to.equal(entry.hash);
+				expect((log.entryIndex as any).cache.get(entry.hash)).to.equal(
+					undefined,
+				);
+
+				releaseRemove[1]!.resolve();
+				await secondDeletion;
+			} finally {
+				for (const release of releaseRemove) {
+					release.resolve();
+				}
+				store.rm = originalRm;
+				await firstDeletion;
+				await secondDeletion;
+			}
+
+			expect((log.entryIndex as any).activeCacheInvalidations.size).to.equal(0);
+			expect((log.entryIndex as any).inFlightCachePublications.size).to.equal(
+				0,
+			);
+			expect(await log.get(entry.hash)).to.equal(undefined);
+		});
+
 		it("only skips deleted entries when publishing a batched store read", async () => {
 			const log = new Log<Uint8Array>();
 			await log.open(store, signKey);


### PR DESCRIPTION
## Summary

- guard full-entry cache publication so a read that began before deletion cannot restore the deleted cache entry when its storage read resolves
- keep a per-hash invalidation refcount across overlapping delete windows, including reads started while deletion is active
- apply the same invariant to single delete, deleteMany, and native-trim consumption paths while preserving duplicate/order behavior in batched reads
- add a patch changeset for `@peerbit/log`

## Validation

- deterministic in-flight cache race group: 6 passing
- complete delete suite: 14 passing
- native length-trim smoke test: passing
- full workspace build: passing
- targeted ESLint, Prettier, and diff checks: clean

The regressions include an in-flight `getMany` invalidated by native trim and two overlapping same-CID deletions, so a boolean invalidation flag would not pass the suite.