### PR TITLE
fix(blocks): cancel proxy reads on shutdown

### DIFF
--- a/.changeset/cancel-block-proxy-on-close.md
+++ b/.changeset/cancel-block-proxy-on-close.md
@@ -2,4 +2,4 @@
 "@peerbit/blocks": patch
 ---
 
-Cancel active relay proxy lookups when the block transport stops so shutdown does not wait for the request timeout.
+Cancel active relay proxy lookups when the block transport stops, and reject late provider results before they can start a timeout-backed remote read, so shutdown does not wait for the request timeout.

--- a/.changeset/cancel-block-proxy-on-close.md
+++ b/.changeset/cancel-block-proxy-on-close.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/blocks": patch
+---
+
+Cancel active relay proxy lookups when the block transport stops so shutdown does not wait for the request timeout.

--- a/packages/transport/blocks/src/remote.ts
+++ b/packages/transport/blocks/src/remote.ts
@@ -679,6 +679,13 @@ export class RemoteBlocks implements IBlocks {
 						? Math.max(1, Math.min(60_000, inheritedTimeoutMs))
 						: Math.max(10_000, Math.floor(localTimeout) || 0);
 				const controller = new AbortController();
+				const abortOnClose = () => controller.abort();
+				this.closeController.signal.addEventListener("abort", abortOnClose, {
+					once: true,
+				});
+				if (this.closeController.signal.aborted) {
+					abortOnClose();
+				}
 				const timer = setTimeout(() => controller.abort(), proxyTimeoutMs);
 				try {
 					const candidates = await this.resolveRemoteProviders(cid, {
@@ -697,6 +704,10 @@ export class RemoteBlocks implements IBlocks {
 					}
 				} finally {
 					clearTimeout(timer);
+					this.closeController.signal.removeEventListener(
+						"abort",
+						abortOnClose,
+					);
 				}
 			} catch {
 				// ignore proxy failures

--- a/packages/transport/blocks/src/remote.ts
+++ b/packages/transport/blocks/src/remote.ts
@@ -728,6 +728,18 @@ export class RemoteBlocks implements IBlocks {
 		cidObject: CID,
 		options: RemoteReadOptions = {},
 	): Promise<Uint8Array | undefined> {
+		// Capture the controller for this open/close generation. start() replaces the
+		// field, so cleanup must remove listeners from the signal it registered on.
+		const closeSignal = this.closeController.signal;
+		const readWasAborted = () =>
+			closeSignal.aborted || options.signal?.aborted === true;
+		const throwIfReadWasAborted = () => {
+			if (readWasAborted()) {
+				throw new AbortError();
+			}
+		};
+		throwIfReadWasAborted();
+
 		const codec = codecCodes[cidObject.code as keyof typeof codecCodes];
 
 		const tryDecode = async (bytes: Uint8Array) => {
@@ -756,6 +768,9 @@ export class RemoteBlocks implements IBlocks {
 			explicitFrom.length > 0
 				? explicitFrom
 				: await this.resolveRemoteProviders(cidString, { signal: options.signal });
+		// A resolver may observe abort and still complete normally. Do not create a
+		// timeout-backed read from the candidates it returns after shutdown.
+		throwIfReadWasAborted();
 		const canResolveLater = typeof this.options.resolveProviders === "function";
 		if (providers.length === 0 && !canResolveLater) {
 			// Without an explicit provider set (or a resolver), we intentionally do not
@@ -773,34 +788,52 @@ export class RemoteBlocks implements IBlocks {
 			const promise = new Promise<Block<any, any, any, 1> | undefined>(
 				(resolve, reject) => {
 					let timeoutCallback: ReturnType<typeof setTimeout> | undefined;
+					let resolver:
+						| ((bytes: Uint8Array) => Promise<void>)
+						| undefined;
+					let settled = false;
 					const abortHandler = () => {
 						cleanup();
+						if (settled) return;
+						settled = true;
 						reject(new AbortError());
 					};
 
 					const cleanup = () => {
 						if (timeoutCallback) clearTimeout(timeoutCallback);
-						this._resolvers.delete(cidString);
-						this.closeController.signal.removeEventListener(
-							"abort",
-							abortHandler,
-						);
+						if (resolver && this._resolvers.get(cidString) === resolver) {
+							this._resolvers.delete(cidString);
+						}
+						closeSignal.removeEventListener("abort", abortHandler);
 						options?.signal?.removeEventListener("abort", abortHandler);
 					};
 
+					// Register first, then re-check. This closes the check/listener window and
+					// makes repeated stop() calls harmless through the settled guard.
+					closeSignal.addEventListener("abort", abortHandler, { once: true });
+					options?.signal?.addEventListener("abort", abortHandler, {
+						once: true,
+					});
+					if (readWasAborted()) {
+						abortHandler();
+						return;
+					}
+
 					timeoutCallback = setTimeout(() => {
 						cleanup();
+						if (settled) return;
+						settled = true;
 						resolve(undefined);
 					}, options.timeout || 30 * 1000);
 
-					this.closeController.signal.addEventListener("abort", abortHandler);
-					options?.signal?.addEventListener("abort", abortHandler);
-
-					this._resolvers.set(cidString, async (bytes: Uint8Array) => {
+					resolver = async (bytes: Uint8Array) => {
 						const value = await tryDecode(bytes);
+						if (settled) return;
+						settled = true;
 						cleanup();
 						resolve(value);
-					});
+					};
+					this._resolvers.set(cidString, resolver);
 				},
 			);
 

--- a/packages/transport/blocks/test/libp2p.spec.ts
+++ b/packages/transport/blocks/test/libp2p.spec.ts
@@ -748,6 +748,50 @@ describe("transport", function () {
 		expect(new Uint8Array(readData!)).to.deep.equal(data);
 	});
 
+	it("cancels an active relay proxy lookup when stopping", async () => {
+		const proxyStarted = pDefer<AbortSignal | undefined>();
+		const releaseProxy = pDefer<void>();
+		session = await TestSession.disconnected(1, {
+			services: {
+				blocks: (components) =>
+					new DirectBlock(components, {
+						resolveProviders: async (_cid, options) => {
+							const signal = options?.signal;
+							proxyStarted.resolve(signal);
+							await Promise.race([
+								releaseProxy.promise,
+								new Promise<void>((resolve) =>
+									signal?.addEventListener("abort", () => resolve(), {
+										once: true,
+									}),
+								),
+							]);
+							return [];
+						},
+					}),
+			},
+		});
+		await store(session, 0).start();
+
+		const remoteBlocks = (store(session, 0) as any)[
+			"remoteBlocks"
+		] as RemoteBlocks;
+		remoteBlocks.onMessage(
+			new BlockRequest("zb3we1BmfxpFg6bCXmrsuEo8JuQrGEf7RyFBdRxEHLuqc4CSr"),
+			{ from: "requester" },
+		);
+		const proxySignal = await proxyStarted.promise;
+
+		const stopPromise = remoteBlocks.stop();
+		const abortedOnStop = proxySignal?.aborted === true;
+		if (!abortedOnStop) {
+			releaseProxy.resolve();
+		}
+		await stopPromise;
+
+		expect(abortedOnStop).to.equal(true);
+	});
+
 	it("retries after a dropped block response", async () => {
 		session = await TestSession.connected(2, {
 			services: { blocks: (c) => new DirectBlock(c) },

--- a/packages/transport/blocks/test/libp2p.spec.ts
+++ b/packages/transport/blocks/test/libp2p.spec.ts
@@ -748,9 +748,9 @@ describe("transport", function () {
 		expect(new Uint8Array(readData!)).to.deep.equal(data);
 	});
 
-	it("cancels an active relay proxy lookup when stopping", async () => {
+	it("cancels a relay proxy read when its provider lookup outlives stop", async () => {
 		const proxyStarted = pDefer<AbortSignal | undefined>();
-		const releaseProxy = pDefer<void>();
+		const releaseDownstreamRead = pDefer<void>();
 		session = await TestSession.disconnected(1, {
 			services: {
 				blocks: (components) =>
@@ -758,15 +758,16 @@ describe("transport", function () {
 						resolveProviders: async (_cid, options) => {
 							const signal = options?.signal;
 							proxyStarted.resolve(signal);
-							await Promise.race([
-								releaseProxy.promise,
-								new Promise<void>((resolve) =>
+							if (!signal?.aborted) {
+								await new Promise<void>((resolve) =>
 									signal?.addEventListener("abort", () => resolve(), {
 										once: true,
 									}),
-								),
-							]);
-							return [];
+								);
+							}
+							// A resolver is allowed to finish normally despite cancellation. Returning
+							// a candidate here exercises the downstream read's pre-aborted path.
+							return ["upstream-provider"];
 						},
 					}),
 			},
@@ -776,20 +777,45 @@ describe("transport", function () {
 		const remoteBlocks = (store(session, 0) as any)[
 			"remoteBlocks"
 		] as RemoteBlocks;
+		let downstreamReadCalls = 0;
+		remoteBlocks.options.publish = async (message) => {
+			if (message instanceof BlockRequest) {
+				downstreamReadCalls += 1;
+				// Without the pre-aborted check, the proxy read reaches this point and
+				// stop() remains queued behind this deliberately stalled request.
+				await releaseDownstreamRead.promise;
+			}
+		};
 		remoteBlocks.onMessage(
 			new BlockRequest("zb3we1BmfxpFg6bCXmrsuEo8JuQrGEf7RyFBdRxEHLuqc4CSr"),
 			{ from: "requester" },
 		);
 		const proxySignal = await proxyStarted.promise;
 
-		const stopPromise = remoteBlocks.stop();
-		const abortedOnStop = proxySignal?.aborted === true;
-		if (!abortedOnStop) {
-			releaseProxy.resolve();
+		const stopPromises = [remoteBlocks.stop(), remoteBlocks.stop()];
+		let deadline: ReturnType<typeof setTimeout> | undefined;
+		try {
+			await Promise.race([
+				Promise.all(stopPromises),
+				new Promise<never>((_resolve, reject) => {
+					deadline = setTimeout(
+						() => reject(new Error("relay proxy stop did not settle promptly")),
+						2_000,
+					);
+				}),
+			]);
+		} finally {
+			if (deadline) clearTimeout(deadline);
+			releaseDownstreamRead.resolve();
+			await Promise.all(stopPromises);
 		}
-		await stopPromise;
 
-		expect(abortedOnStop).to.equal(true);
+		expect(proxySignal?.aborted).to.equal(true);
+		expect(downstreamReadCalls).to.equal(0);
+		expect((remoteBlocks as any)._loadFetchQueue.pending).to.equal(0);
+		expect((remoteBlocks as any)._loadFetchQueue.size).to.equal(0);
+		expect((remoteBlocks as any)._readFromPeersPromises.size).to.equal(0);
+		expect((remoteBlocks as any)._resolvers.size).to.equal(0);
 	});
 
 	it("retries after a dropped block response", async () => {


### PR DESCRIPTION
## Summary

- abort an active relay/provider lookup when `RemoteBlocks.stop()` closes the service instead of waiting for the inherited request timeout
- reject an already-aborted late provider result before it can enter peer-read, timeout, resolver, or publish state
- close the listener-registration race with register-then-recheck cleanup and idempotent settlement, including concurrent `stop()` calls
- add a patch changeset for `@peerbit/blocks`

## Root cause

`stop()` awaited the fetch queue, but proxy lookups used a timeout-only controller. Even after connecting that controller to service close, a resolver could observe the abort and still return connected candidates; `_readFromPeers` then registered listeners on an already-aborted signal and waited up to 60 seconds.

## Validation

- strengthened regression: timed out on the previous patch, passes in 31–33 ms after the fix
- regression returns a provider after abort, stalls downstream publish if reached, calls `stop()` twice, and asserts empty queue/read/resolver state
- full `@peerbit/blocks` suite: 38 passing
- eight additional concurrent `load after prune` runs: passing
- full workspace build: passing
- changed-file ESLint and diff checks: clean