### PR TITLE
perf(document): batch result head reads

### DIFF
--- a/.changeset/batch-document-head-reads.md
+++ b/.changeset/batch-document-head-reads.md
@@ -1,0 +1,8 @@
+---
+"@peerbit/document": patch
+"@peerbit/log": patch
+---
+
+Batch document result head reads through a new ordered `Log.getMany()` API.
+
+Document search, queued iterator, and pushed-update result construction now resolve each result page's log heads in one block-store batch while preserving result order, duplicate hashes, missing/pruned entries, and resolved-versus-indexed behavior. Full log reads already materialize native entries at the entry-index boundary, so result construction no longer probes serialization or retries the same block through a second decode path.

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -784,6 +784,26 @@ export class Log<T> {
 	}
 
 	/**
+	 * Get entries while preserving the order and duplicates in `hashes`.
+	 * Missing entries are returned as `undefined`.
+	 */
+	getMany(
+		hashes: string[],
+		options?: GetOptions,
+	): Promise<Array<Entry<T> | undefined>> {
+		return this._entryIndex.getMany(
+			hashes,
+			options
+				? {
+						type: "full",
+						remote: options.remote,
+						ignoreMissing: true,
+					}
+				: { type: "full", ignoreMissing: true },
+		);
+	}
+
+	/**
 	 * Get a entry with shallow representation
 	 * @param {string} [hash] The hashes of the entry
 	 */

--- a/packages/log/test/log.spec.ts
+++ b/packages/log/test/log.spec.ts
@@ -6,6 +6,7 @@ import {
 } from "@peerbit/stream-interface";
 import assert from "assert";
 import { expect } from "chai";
+import sinon from "sinon";
 import { Timestamp } from "../src/clock.js";
 import { Log } from "../src/log.js";
 import { signKey, signKey2, signKey3 } from "./fixtures/privateKey.js";
@@ -250,6 +251,107 @@ describe("properties", function () {
 			assert.deepStrictEqual(entry, undefined);
 			expect(observedFrom).to.deep.equal(fromPeers);
 			expect(observedPriority).to.eq(FOREGROUND_READ_MESSAGE_PRIORITY);
+		});
+
+		it("gets ordered entries, duplicates, and misses with one block batch read", async () => {
+			const localStore = new AnyBlockStore();
+			await localStore.start();
+			const source = new Log<string>();
+			const reader = new Log<string>();
+			await source.open(localStore, signKey, { encoding: JSON_ENCODING });
+			await reader.open(localStore, signKey2, { encoding: JSON_ENCODING });
+
+			let getManyStub: sinon.SinonStub | undefined;
+			let getSpy: sinon.SinonSpy | undefined;
+			try {
+				const { entry: first } = await source.append("first", {
+					meta: { next: [] },
+				});
+				const { entry: second } = await source.append("second", {
+					meta: { next: [] },
+				});
+				const missing = "zb2rhbnwihVVVVEGAPf9EwTZBsQz9fszCnM4Y8mJmBFgiyN7J";
+				const stored = new Map([
+					[first.hash, await localStore.get(first.hash)],
+					[second.hash, await localStore.get(second.hash)],
+				]);
+				getManyStub = sinon
+					.stub(localStore, "getMany")
+					.callsFake(async (hashes) => hashes.map((hash) => stored.get(hash)));
+				getSpy = sinon.spy(localStore, "get");
+
+				const entries = await reader.getMany([
+					first.hash,
+					missing,
+					second.hash,
+					first.hash,
+				]);
+
+				expect(entries.map((entry) => entry?.hash)).to.deep.equal([
+					first.hash,
+					undefined,
+					second.hash,
+					first.hash,
+				]);
+				expect(await entries[0]!.getPayloadValue()).to.equal("first");
+				expect(await entries[2]!.getPayloadValue()).to.equal("second");
+				expect(getManyStub.callCount).to.equal(1);
+				expect(getManyStub.firstCall.args[0]).to.deep.equal([
+					first.hash,
+					missing,
+					second.hash,
+					first.hash,
+				]);
+				expect(getSpy.callCount).to.equal(0);
+			} finally {
+				getManyStub?.restore();
+				getSpy?.restore();
+				await Promise.all([source.close(), reader.close()]);
+				await localStore.stop();
+			}
+		});
+
+		it("preserves remote options when getMany falls back to per-entry reads", async () => {
+			const localStore = new AnyBlockStore();
+			await localStore.start();
+			const reader = new Log<string>();
+			await reader.open(localStore, signKey, { encoding: JSON_ENCODING });
+			const getManySpy = sinon.spy(localStore, "getMany");
+			const observedOptions: any[] = [];
+			const getStub = sinon
+				.stub(localStore, "get")
+				.callsFake(async (_hash, options) => {
+					observedOptions.push(options);
+					return undefined;
+				});
+
+			try {
+				const entries = await reader.getMany(
+					[
+						"zb2rhbnwihVVVVEGAPf9EwTZBsQz9fszCnM4Y8mJmBFgiyN7J",
+						"zb2rhYpDDgijHQyZRYovg3mKpgLDCBb89uFGFrRbYoiVCKGiX",
+					],
+					{ remote: { timeout: 123 } },
+				);
+
+				expect(entries).to.deep.equal([undefined, undefined]);
+				expect(getManySpy.callCount).to.equal(0);
+				expect(getStub.callCount).to.equal(2);
+				expect(
+					observedOptions.map((options) => options.remote.timeout),
+				).to.deep.equal([123, 123]);
+				expect(
+					observedOptions.map((options) => options.remote.priority),
+				).to.deep.equal([
+					FOREGROUND_READ_MESSAGE_PRIORITY,
+					FOREGROUND_READ_MESSAGE_PRIORITY,
+				]);
+			} finally {
+				getManySpy.restore();
+				getStub.restore();
+				await reader.close();
+				await localStore.stop();
+			}
 		});
 	});
 

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -24,7 +24,7 @@ import {
 import { CachedIndex, type QueryCacheOptions } from "@peerbit/indexer-cache";
 import * as indexerTypes from "@peerbit/indexer-interface";
 import { HashmapIndex } from "@peerbit/indexer-simple";
-import { BORSH_ENCODING, type Encoding, Entry } from "@peerbit/log";
+import { BORSH_ENCODING, type Encoding, type Entry } from "@peerbit/log";
 import { logger as loggerFn } from "@peerbit/logger";
 import { ClosedError, Program } from "@peerbit/program";
 import {
@@ -1179,35 +1179,42 @@ export class DocumentIndex<
 		}
 	}
 
-	/** Head entry safe to borsh-serialize into ResultIndexedValue.entries over the
-	 * document RPC. Under the native block store, this._log.log.get can return a
-	 * hollow entry whose payload bytes were never materialized on the JS side;
-	 * serializing it throws and aborts the whole RPC response. The complete entry is
-	 * in the block store keyed by hash, so recover it there. No-op for pure JS. */
-	private async getSerializableHead(
-		hash: string,
-	): Promise<Entry<any> | undefined> {
-		const head = await this._log.log.get(hash);
-		if (!head?.hash) return head ?? undefined;
-		try {
-			head.getStorageBytes(); // = serialize(head); throws on a hollow native entry
-			return head;
-		} catch {
-			try {
-				return await Entry.fromMultihash(this._log.log.blocks, head.hash);
-			} catch {
-				return head; // block absent (e.g. pruned) — preserve today's behavior
-			}
-		}
-	}
-
 	private async wrapPushResults(
 		matches: Array<WithContext<T> | WithContext<I>>,
 		resolve: boolean,
 	): Promise<types.Result[]> {
 		if (!matches.length) return [];
+		const headsByMatch: Array<Entry<Operation> | undefined> = [];
+		const preloadedHeadPositions = new Set<number>();
+		if (!resolve) {
+			headsByMatch.push(
+				...(await this._log.log.getMany(
+					matches.map((match) => match.__context.head),
+				)),
+			);
+		} else if (!this.indexedTypeIsDocumentType) {
+			const indexedPositions: number[] = [];
+			for (let i = 0; i < matches.length; i++) {
+				if (!(matches[i] instanceof this.documentType)) {
+					indexedPositions.push(i);
+				}
+			}
+			const indexedHeads = indexedPositions.length
+				? await this._log.log.getMany(
+						indexedPositions.map(
+							(position) => matches[position]!.__context.head,
+						),
+					)
+				: [];
+			for (let i = 0; i < indexedPositions.length; i++) {
+				const position = indexedPositions[i]!;
+				headsByMatch[position] = indexedHeads[i];
+				preloadedHeadPositions.add(position);
+			}
+		}
 		const results: types.Result[] = [];
-		for (const match of matches) {
+		for (let i = 0; i < matches.length; i++) {
+			const match = matches[i]!;
 			if (resolve) {
 				if (match instanceof this.documentType) {
 					const doc = match as WithContext<T>;
@@ -1225,10 +1232,19 @@ export class DocumentIndex<
 				}
 
 				const indexed = match as WithContext<I>;
-				const resolved = await this.resolveDocument({
+				const headWasPreloaded = preloadedHeadPositions.has(i);
+				const resolveInput: {
+					indexed: I;
+					head: string;
+					headEntry?: Entry<Operation> | null;
+				} = {
 					indexed,
 					head: indexed.__context.head,
-				});
+				};
+				if (headWasPreloaded) {
+					resolveInput.headEntry = headsByMatch[i] ?? null;
+				}
+				const resolved = await this.resolveDocument(resolveInput);
 
 				if (resolved) {
 					results.push(
@@ -1242,7 +1258,9 @@ export class DocumentIndex<
 					continue;
 				}
 
-				const head = await this.getSerializableHead(indexed.__context.head);
+				const head = headWasPreloaded
+					? headsByMatch[i]
+					: await this._log.log.get(indexed.__context.head);
 				results.push(
 					new types.ResultIndexedValue({
 						context: indexed.__context,
@@ -1253,7 +1271,7 @@ export class DocumentIndex<
 				);
 			} else {
 				const indexed = match as WithContext<I>;
-				const head = await this.getSerializableHead(indexed.__context.head);
+				const head = headsByMatch[i];
 				results.push(
 					new types.ResultIndexedValue({
 						context: indexed.__context,
@@ -1275,17 +1293,32 @@ export class DocumentIndex<
 			return [];
 		}
 		const drained = queueEntries.splice(0);
+		const headsWerePreloaded = !resolve || !this.indexedTypeIsDocumentType;
+		const heads = headsWerePreloaded
+			? await this._log.log.getMany(
+					drained.map((entry) => entry.value.__context.head),
+				)
+			: [];
 		const results: types.Result[] = [];
-		for (const entry of drained) {
+		for (let i = 0; i < drained.length; i++) {
+			const entry = drained[i]!;
 			const indexedUnwrapped = Object.assign(
 				Object.create(this.indexedType.prototype),
 				entry.value,
 			);
 			if (resolve) {
-				const value = await this.resolveDocument({
+				const resolveInput: {
+					indexed: I;
+					head: string;
+					headEntry?: Entry<Operation> | null;
+				} = {
 					indexed: entry.value,
 					head: entry.value.__context.head,
-				});
+				};
+				if (headsWerePreloaded) {
+					resolveInput.headEntry = heads[i] ?? null;
+				}
+				const value = await this.resolveDocument(resolveInput);
 				if (value) {
 					results.push(
 						new types.ResultValue({
@@ -1298,7 +1331,9 @@ export class DocumentIndex<
 					continue;
 				}
 
-				const head = await this.getSerializableHead(entry.value.__context.head);
+				const head = headsWerePreloaded
+					? heads[i]
+					: await this._log.log.get(entry.value.__context.head);
 				results.push(
 					new types.ResultIndexedValue({
 						context: entry.value.__context,
@@ -1308,7 +1343,7 @@ export class DocumentIndex<
 					}),
 				);
 			} else {
-				const head = await this.getSerializableHead(entry.value.__context.head);
+				const head = heads[i];
 				results.push(
 					new types.ResultIndexedValue({
 						context: entry.value.__context,
@@ -3474,6 +3509,7 @@ export class DocumentIndex<
 		id?: indexerTypes.IdPrimitive;
 		indexed: I;
 		head: string;
+		headEntry?: Entry<Operation> | null;
 	}): Promise<{ value: T } | undefined> {
 		const id =
 			value.id ??
@@ -3495,7 +3531,10 @@ export class DocumentIndex<
 			return { value: obj as T };
 		}
 
-		const head = await this._log.log.get(value.head);
+		const head =
+			value.headEntry === undefined
+				? await this._log.log.get(value.head)
+				: (value.headEntry ?? undefined);
 		if (!head) {
 			return undefined; // we could end up here if we recently pruned the document and other peers never persisted the entry
 			// TODO update changes in index before removing entries from log entry storage
@@ -3633,7 +3672,10 @@ export class DocumentIndex<
 			this._resultQueue.set(query.idString, prevQueued);
 		}
 
-		const filteredResults: types.Result[] = [];
+		const candidates: Array<{
+			result: indexerTypes.IndexedResult<WithContext<I>>;
+			indexed: I;
+		}> = [];
 		const resolveDocumentsFlag = resolvesDocuments(fromQuery);
 		const replicateIndexFlag = replicatesIndex(fromQuery);
 		for (const result of toIterate) {
@@ -3655,11 +3697,33 @@ export class DocumentIndex<
 			) {
 				continue;
 			}
+			candidates.push({ result, indexed: indexedUnwrapped });
+		}
+
+		const headsWerePreloaded =
+			candidates.length > 0 &&
+			(!resolveDocumentsFlag || !this.indexedTypeIsDocumentType);
+		const heads = headsWerePreloaded
+			? await this._log.log.getMany(
+					candidates.map(({ result }) => result.value.__context.head),
+				)
+			: [];
+		const filteredResults: types.Result[] = [];
+		for (let i = 0; i < candidates.length; i++) {
+			const { result, indexed: indexedUnwrapped } = candidates[i]!;
 			if (resolveDocumentsFlag) {
-				const value = await this.resolveDocument({
+				const resolveInput: {
+					indexed: I;
+					head: string;
+					headEntry?: Entry<Operation> | null;
+				} = {
 					indexed: result.value,
 					head: result.value.__context.head,
-				});
+				};
+				if (headsWerePreloaded) {
+					resolveInput.headEntry = heads[i] ?? null;
+				}
+				const value = await this.resolveDocument(resolveInput);
 
 				if (!value) {
 					continue;
@@ -3675,7 +3739,7 @@ export class DocumentIndex<
 				);
 			} else {
 				const context = result.value.__context;
-				const head = await this.getSerializableHead(context.head);
+				const head = heads[i];
 				if (replicateIndexFlag) {
 					if (!head) {
 						continue;

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -1179,37 +1179,93 @@ export class DocumentIndex<
 		}
 	}
 
+	/**
+	 * Resolve documents without bypassing the resolver/program caches. Cache and
+	 * identity-index hits are collected first; only the remaining heads cross the
+	 * log read boundary, and those reads stay aligned in one batch.
+	 */
+	private async resolveDocumentsWithBatchedHeads(
+		values: Array<{
+			id?: indexerTypes.IdPrimitive;
+			indexed: I;
+			head: string;
+		}>,
+	): Promise<{
+		resolved: Array<{ value: T } | undefined>;
+		heads: Array<Entry<Operation> | undefined>;
+	}> {
+		const resolved: Array<{ value: T } | undefined> = new Array(values.length);
+		const heads: Array<Entry<Operation> | undefined> = new Array(values.length);
+		const unresolvedPositions: number[] = [];
+
+		for (let i = 0; i < values.length; i++) {
+			const value = values[i]!;
+			const cached = await this.resolveDocument({
+				...value,
+				headEntry: null,
+			});
+			if (cached) {
+				resolved[i] = cached;
+			} else {
+				unresolvedPositions.push(i);
+			}
+		}
+
+		if (unresolvedPositions.length === 0) {
+			return { resolved, heads };
+		}
+
+		const unresolvedHeads = await this._log.log.getMany(
+			unresolvedPositions.map((position) => values[position]!.head),
+		);
+		for (let i = 0; i < unresolvedPositions.length; i++) {
+			const position = unresolvedPositions[i]!;
+			const head = unresolvedHeads[i];
+			heads[position] = head;
+			resolved[position] = await this.resolveDocument({
+				...values[position]!,
+				headEntry: head ?? null,
+			});
+		}
+
+		return { resolved, heads };
+	}
+
 	private async wrapPushResults(
 		matches: Array<WithContext<T> | WithContext<I>>,
 		resolve: boolean,
 	): Promise<types.Result[]> {
 		if (!matches.length) return [];
 		const headsByMatch: Array<Entry<Operation> | undefined> = [];
-		const preloadedHeadPositions = new Set<number>();
+		const resolvedByMatch: Array<{ value: T } | undefined> = [];
 		if (!resolve) {
 			headsByMatch.push(
 				...(await this._log.log.getMany(
 					matches.map((match) => match.__context.head),
 				)),
 			);
-		} else if (!this.indexedTypeIsDocumentType) {
+		} else {
 			const indexedPositions: number[] = [];
 			for (let i = 0; i < matches.length; i++) {
 				if (!(matches[i] instanceof this.documentType)) {
 					indexedPositions.push(i);
 				}
 			}
-			const indexedHeads = indexedPositions.length
-				? await this._log.log.getMany(
-						indexedPositions.map(
-							(position) => matches[position]!.__context.head,
-						),
+			const indexedBatch = indexedPositions.length
+				? await this.resolveDocumentsWithBatchedHeads(
+						indexedPositions.map((position) => {
+							const indexed = matches[position] as WithContext<I>;
+							return {
+								indexed,
+								head: indexed.__context.head,
+							};
+						}),
 					)
-				: [];
+				: { resolved: [], heads: [] };
 			for (let i = 0; i < indexedPositions.length; i++) {
 				const position = indexedPositions[i]!;
-				headsByMatch[position] = indexedHeads[i];
-				preloadedHeadPositions.add(position);
+				resolvedByMatch[position] = indexedBatch.resolved[i];
+				headsByMatch[position] = indexedBatch.heads[i];
 			}
 		}
 		const results: types.Result[] = [];
@@ -1232,19 +1288,7 @@ export class DocumentIndex<
 				}
 
 				const indexed = match as WithContext<I>;
-				const headWasPreloaded = preloadedHeadPositions.has(i);
-				const resolveInput: {
-					indexed: I;
-					head: string;
-					headEntry?: Entry<Operation> | null;
-				} = {
-					indexed,
-					head: indexed.__context.head,
-				};
-				if (headWasPreloaded) {
-					resolveInput.headEntry = headsByMatch[i] ?? null;
-				}
-				const resolved = await this.resolveDocument(resolveInput);
+				const resolved = resolvedByMatch[i];
 
 				if (resolved) {
 					results.push(
@@ -1258,9 +1302,7 @@ export class DocumentIndex<
 					continue;
 				}
 
-				const head = headWasPreloaded
-					? headsByMatch[i]
-					: await this._log.log.get(indexed.__context.head);
+				const head = headsByMatch[i];
 				results.push(
 					new types.ResultIndexedValue({
 						context: indexed.__context,
@@ -1293,12 +1335,19 @@ export class DocumentIndex<
 			return [];
 		}
 		const drained = queueEntries.splice(0);
-		const headsWerePreloaded = !resolve || !this.indexedTypeIsDocumentType;
-		const heads = headsWerePreloaded
-			? await this._log.log.getMany(
-					drained.map((entry) => entry.value.__context.head),
+		const resolvedBatch = resolve
+			? await this.resolveDocumentsWithBatchedHeads(
+					drained.map((entry) => ({
+						indexed: entry.value,
+						head: entry.value.__context.head,
+					})),
 				)
-			: [];
+			: undefined;
+		const heads = resolvedBatch
+			? resolvedBatch.heads
+			: await this._log.log.getMany(
+					drained.map((entry) => entry.value.__context.head),
+				);
 		const results: types.Result[] = [];
 		for (let i = 0; i < drained.length; i++) {
 			const entry = drained[i]!;
@@ -1307,18 +1356,7 @@ export class DocumentIndex<
 				entry.value,
 			);
 			if (resolve) {
-				const resolveInput: {
-					indexed: I;
-					head: string;
-					headEntry?: Entry<Operation> | null;
-				} = {
-					indexed: entry.value,
-					head: entry.value.__context.head,
-				};
-				if (headsWerePreloaded) {
-					resolveInput.headEntry = heads[i] ?? null;
-				}
-				const value = await this.resolveDocument(resolveInput);
+				const value = resolvedBatch!.resolved[i];
 				if (value) {
 					results.push(
 						new types.ResultValue({
@@ -1331,9 +1369,7 @@ export class DocumentIndex<
 					continue;
 				}
 
-				const head = headsWerePreloaded
-					? heads[i]
-					: await this._log.log.get(entry.value.__context.head);
+				const head = heads[i];
 				results.push(
 					new types.ResultIndexedValue({
 						context: entry.value.__context,
@@ -3700,30 +3736,26 @@ export class DocumentIndex<
 			candidates.push({ result, indexed: indexedUnwrapped });
 		}
 
-		const headsWerePreloaded =
-			candidates.length > 0 &&
-			(!resolveDocumentsFlag || !this.indexedTypeIsDocumentType);
-		const heads = headsWerePreloaded
-			? await this._log.log.getMany(
-					candidates.map(({ result }) => result.value.__context.head),
+		const resolvedBatch = resolveDocumentsFlag
+			? await this.resolveDocumentsWithBatchedHeads(
+					candidates.map(({ result }) => ({
+						indexed: result.value,
+						head: result.value.__context.head,
+					})),
 				)
-			: [];
+			: undefined;
+		const heads = resolvedBatch
+			? resolvedBatch.heads
+			: candidates.length > 0
+				? await this._log.log.getMany(
+						candidates.map(({ result }) => result.value.__context.head),
+					)
+				: [];
 		const filteredResults: types.Result[] = [];
 		for (let i = 0; i < candidates.length; i++) {
 			const { result, indexed: indexedUnwrapped } = candidates[i]!;
 			if (resolveDocumentsFlag) {
-				const resolveInput: {
-					indexed: I;
-					head: string;
-					headEntry?: Entry<Operation> | null;
-				} = {
-					indexed: result.value,
-					head: result.value.__context.head,
-				};
-				if (headsWerePreloaded) {
-					resolveInput.headEntry = heads[i] ?? null;
-				}
-				const value = await this.resolveDocument(resolveInput);
+				const value = resolvedBatch!.resolved[i];
 
 				if (!value) {
 					continue;

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -17542,31 +17542,50 @@ describe("index", () => {
 						},
 					});
 
-					const doc = new Document({ id: "fallback-wrap", name: "theta" });
-					await store.docs.put(doc);
-					const context = (doc as any).__context;
-					const indexed = Object.assign(new Indexable(doc), {
-						__context: context,
-					});
+					const docs = [
+						new Document({ id: "fallback-wrap-1", name: "theta" }),
+						new Document({ id: "fallback-wrap-2", name: "iota" }),
+					];
+					for (const doc of docs) {
+						await store.docs.put(doc);
+					}
+					const indexed = docs.map((doc) =>
+						Object.assign(new Indexable(doc), {
+							__context: (doc as any).__context,
+						}),
+					);
 					const resolveStub = sinon
 						.stub(store.docs.index as any, "resolveDocument")
 						.resolves(undefined);
+					const getManySpy = sinon.spy(store.docs.log.log, "getMany");
+					const getSpy = sinon.spy(store.docs.log.log, "get");
 
 					try {
 						const results = await (store.docs.index as any).wrapPushResults(
-							[indexed],
+							indexed,
 							true,
 						);
-						expect(results).to.have.length(1);
-						expect(results[0]).to.be.instanceOf(ResultIndexedValue);
+						expect(results).to.have.length(2);
 						expect(
-							(results[0] as ResultIndexedValue<Indexable>).indexed,
-						).to.equal(indexed);
+							results.map(
+								(result: ResultIndexedValue<Indexable>) => result.indexed,
+							),
+						).to.deep.equal(indexed);
 						expect(
-							(results[0] as ResultIndexedValue<Indexable>).entries,
-						).to.have.length(1);
+							results.every(
+								(result: ResultIndexedValue<Indexable>) =>
+									result.entries.length === 1,
+							),
+						).to.be.true;
+						expect(getManySpy.callCount).to.equal(1);
+						expect(getManySpy.firstCall.args[0]).to.deep.equal(
+							indexed.map((value) => value.__context.head),
+						);
+						expect(getSpy.callCount).to.equal(0);
 					} finally {
 						resolveStub.restore();
+						getManySpy.restore();
+						getSpy.restore();
 						await session.stop();
 					}
 				});
@@ -17589,16 +17608,27 @@ describe("index", () => {
 						},
 					});
 
-					const doc = new Document({ id: "fallback-queue", name: "lambda" });
-					await store.docs.put(doc);
-					const context = (doc as any).__context;
-					const indexed = Object.assign(new Indexable(doc), {
-						__context: context,
-					});
+					const docs = [
+						new Document({ id: "fallback-queue-1", name: "lambda" }),
+						new Document({ id: "fallback-queue-2", name: "mu" }),
+					];
+					for (const doc of docs) {
+						await store.docs.put(doc);
+					}
+					const indexed = docs.map((doc) =>
+						Object.assign(new Indexable(doc), {
+							__context: (doc as any).__context,
+						}),
+					);
 					const resolveStub = sinon
 						.stub(store.docs.index as any, "resolveDocument")
 						.resolves(undefined);
-					const queue = [{ id: doc.id, value: indexed }];
+					const getManySpy = sinon.spy(store.docs.log.log, "getMany");
+					const getSpy = sinon.spy(store.docs.log.log, "get");
+					const queue = docs.map((doc, index) => ({
+						id: doc.id,
+						value: indexed[index],
+					}));
 
 					try {
 						const results = await (store.docs.index as any).drainQueuedResults(
@@ -17606,16 +17636,28 @@ describe("index", () => {
 							true,
 						);
 						expect(queue).to.have.length(0);
-						expect(results).to.have.length(1);
-						expect(results[0]).to.be.instanceOf(ResultIndexedValue);
+						expect(results).to.have.length(2);
 						expect(
-							(results[0] as ResultIndexedValue<Indexable>).indexed,
-						).to.be.instanceOf(Indexable);
+							results.every(
+								(result: ResultIndexedValue<Indexable>) =>
+									result.indexed instanceof Indexable,
+							),
+						).to.be.true;
 						expect(
-							(results[0] as ResultIndexedValue<Indexable>).entries,
-						).to.have.length(1);
+							results.every(
+								(result: ResultIndexedValue<Indexable>) =>
+									result.entries.length === 1,
+							),
+						).to.be.true;
+						expect(getManySpy.callCount).to.equal(1);
+						expect(getManySpy.firstCall.args[0]).to.deep.equal(
+							indexed.map((value) => value.__context.head),
+						);
+						expect(getSpy.callCount).to.equal(0);
 					} finally {
 						resolveStub.restore();
+						getManySpy.restore();
+						getSpy.restore();
 						await session.stop();
 					}
 				});

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -17387,6 +17387,127 @@ describe("index", () => {
 					await check(store, undefined, true);
 				});
 
+				it("keeps resolver-cached custom-index queries off block storage", async () => {
+					session = await TestSession.connected(1);
+
+					const store = new TestStore<Indexable>({
+						docs: new Documents<Document, Indexable>(),
+					});
+
+					await session.peers[0].open(store, {
+						args: {
+							replicate: { factor: 1 },
+							index: {
+								type: Indexable,
+								transform: (doc) => new Indexable(doc),
+							},
+						},
+					});
+
+					const docs = Array.from(
+						{ length: 12 },
+						(_, index) =>
+							new Document({
+								id: `resolver-cache-${index}`,
+								name: `value-${index}`,
+							}),
+					);
+					for (const doc of docs) {
+						await store.docs.put(doc);
+					}
+
+					const logGetManySpy = sinon.spy(store.docs.log.log, "getMany");
+					const logGetSpy = sinon.spy(store.docs.log.log, "get");
+					const blocks = store.docs.log.log.blocks;
+					const blocksGetManyStub = sinon
+						.stub(blocks as any, "getMany")
+						.rejects(new Error("resolver cache must avoid block getMany"));
+					const blocksGetStub = sinon
+						.stub(blocks, "get")
+						.rejects(new Error("resolver cache must avoid block get"));
+
+					try {
+						const response = await store.docs.index.processQuery(
+							new SearchRequest({ query: [], fetch: docs.length }),
+							store.node.identity.publicKey,
+							true,
+						);
+
+						expect(response.results).to.have.length(docs.length);
+						expect(
+							response.results.map((result) => result.value.id),
+						).to.have.members(docs.map((doc) => doc.id));
+						expect(logGetManySpy.callCount).to.equal(0);
+						expect(logGetSpy.callCount).to.equal(0);
+						expect(blocksGetManyStub.callCount).to.equal(0);
+						expect(blocksGetStub.callCount).to.equal(0);
+					} finally {
+						logGetManySpy.restore();
+						logGetSpy.restore();
+						blocksGetManyStub.restore();
+						blocksGetStub.restore();
+					}
+				});
+
+				it("filters unreadable heads before batched result reads", async () => {
+					session = await TestSession.connected(1);
+
+					const store = new TestStore<Indexable>({
+						docs: new Documents<Document, Indexable>(),
+					});
+
+					await session.peers[0].open(store, {
+						args: {
+							replicate: { factor: 1 },
+							index: {
+								type: Indexable,
+								transform: (doc) => new Indexable(doc),
+							},
+						},
+					});
+
+					const docs = [
+						new Document({ id: "readable-1", name: "one" }),
+						new Document({ id: "unreadable", name: "two" }),
+						new Document({ id: "readable-2", name: "three" }),
+					];
+					const puts = [];
+					for (const doc of docs) {
+						puts.push(await store.docs.put(doc));
+					}
+
+					const getManySpy = sinon.spy(store.docs.log.log, "getMany");
+					const canReadIds: string[] = [];
+					try {
+						const response = await store.docs.index.processQuery(
+							new SearchRequestIndexed({ query: [], fetch: docs.length }),
+							store.node.identity.publicKey,
+							true,
+							{
+								canRead: (indexed) => {
+									canReadIds.push(indexed.id);
+									return indexed.id !== "unreadable";
+								},
+							},
+						);
+
+						expect(
+							response.results.map((result) => result.value.id),
+						).to.have.members(["readable-1", "readable-2"]);
+						expect(canReadIds).to.have.members(docs.map((doc) => doc.id));
+						expect(getManySpy.callCount).to.equal(1);
+						expect(getManySpy.firstCall.args[0]).to.have.members([
+							puts[0].entry.hash,
+							puts[2].entry.hash,
+						]);
+						expect(getManySpy.firstCall.args[0]).not.to.include(
+							puts[1].entry.hash,
+						);
+					} finally {
+						getManySpy.restore();
+					}
+				});
+
 				it("drops unresolved indexed placeholders when resolving iterator batches", async () => {
 					session = await TestSession.connected(1);
 

--- a/packages/programs/data/document/document/test/native-full-entry-materialization.spec.ts
+++ b/packages/programs/data/document/document/test/native-full-entry-materialization.spec.ts
@@ -1,4 +1,5 @@
-import { field, variant } from "@dao-xyz/borsh";
+import { field, serialize, variant } from "@dao-xyz/borsh";
+import { SearchRequestIndexed } from "@peerbit/document-interface";
 import { expect } from "chai";
 import { Peerbit } from "peerbit";
 import { createRustPeerbitOptions } from "peerbit/rust";
@@ -106,9 +107,8 @@ describe("native full-entry materialization", () => {
 		const getManySpy = sinon.spy(store.docs.log.log.blocks, "getMany");
 
 		try {
-			const entries = await store.docs.log.log.entryIndex.getMany(
+			const entries = await store.docs.log.log.getMany(
 				puts.map((put) => put.entry.hash),
-				{ type: "full", ignoreMissing: true },
 			);
 			expect(entries).to.have.length(3);
 			expect(entries[0]).equal(full);
@@ -123,13 +123,50 @@ describe("native full-entry materialization", () => {
 				puts[2].entry.hash,
 			]);
 
-			const cached = await store.docs.log.log.entryIndex.getMany(
+			const cached = await store.docs.log.log.getMany(
 				puts.slice(0, 2).map((put) => put.entry.hash),
 			);
 			expect(cached).to.deep.equal(entries.slice(0, 2));
 			expect(getManySpy.callCount).equal(1);
 		} finally {
 			getManySpy.restore();
+		}
+	});
+
+	it("batch-materializes serializable indexed RPC result heads", async () => {
+		const store = await openStore();
+		const puts = [];
+		for (const [index, name] of ["one", "two", "three"].entries()) {
+			puts.push(
+				await store.docs.put(
+					new Document({ id: `materialize-rpc-${index}`, name }),
+				),
+			);
+		}
+		const blocks = store.docs.log.log.blocks;
+		const getManySpy = sinon.spy(blocks, "getMany");
+		const getSpy = sinon.spy(blocks, "get");
+
+		try {
+			const response = await store.docs.index.processQuery(
+				new SearchRequestIndexed({ query: [], fetch: puts.length }),
+				store.node.identity.publicKey,
+				false,
+			);
+
+			expect(response.results).to.have.length(puts.length);
+			expect(
+				response.results.map((result) => result.context.head),
+			).to.have.members(puts.map((put) => put.entry.hash));
+			expect(() => serialize(response)).not.to.throw();
+			expect(getManySpy.callCount).to.equal(1);
+			expect(getManySpy.firstCall.args[0]).to.have.members(
+				puts.map((put) => put.entry.hash),
+			);
+			expect(getSpy.callCount).to.equal(0);
+		} finally {
+			getManySpy.restore();
+			getSpy.restore();
 		}
 	});
 


### PR DESCRIPTION
## Summary

- add ordered `Log.getMany()` support that preserves duplicates, misses, input positions, and remote-read options
- resolve document search pages, push results, and queued iterator results with one block-store head batch instead of one read per result
- probe resolver/program/identity caches first, then batch only unresolved readable positions so hot cached queries retain zero block reads
- materialize native full entries at the entry-index boundary and remove the former serialization-probe/redecode path
- add patch changesets for `@peerbit/log` and `@peerbit/document`

## Validation

- full `@peerbit/document` suite: 361 passing
- focused document default/rust-core batching and cache tests: passing
- `@peerbit/log` batching API tests: passing
- 12-document custom-index cache regression succeeds with block reads forced to throw and records zero `get`/`getMany` calls
- permission regression proves unreadable heads never enter the batch
- native RPC result serialization regression: passing
- full workspace build and diff checks: green

Result order, duplicate hashes, missing/pruned entries, indexed fallbacks, and resolved-vs-indexed behavior are preserved. The cache-first correction was independently reviewed after implementation.