### PR TITLE
feat(native-backbone): add durability journal primitives

### DIFF
--- a/.changeset/native-durability-journal-primitives.md
+++ b/.changeset/native-durability-journal-primitives.md
@@ -1,0 +1,8 @@
+---
+"@peerbit/native-backbone": minor
+---
+
+Add inert Node-first primitives for a crash-safe local transaction journal,
+including fail-closed frame validation, transaction-private staging, strictly
+synced checkpoint generations, typed barrier receipts, and a crash-released
+directory lease. Existing append and open behavior is unchanged.

--- a/packages/utils/native-backbone/Cargo.lock
+++ b/packages/utils/native-backbone/Cargo.lock
@@ -328,6 +328,7 @@ dependencies = [
  "peerbit_log_rust",
  "peerbit_shared_log_rust",
  "peerbit_wire",
+ "sha2",
  "wasm-bindgen",
 ]
 

--- a/packages/utils/native-backbone/Cargo.toml
+++ b/packages/utils/native-backbone/Cargo.toml
@@ -14,6 +14,7 @@ peerbit_indexer_core = { path = "../indexer/core" }
 peerbit_log_rust = { path = "../../log/rust" }
 peerbit_shared_log_rust = { path = "../../programs/data/shared-log/rust" }
 peerbit_wire = { path = "../../transport/network-rust" }
+sha2 = "0.10.8"
 wasm-bindgen = "0.2.103"
 
 [package.metadata.wasm-pack.profile.release]

--- a/packages/utils/native-backbone/README.md
+++ b/packages/utils/native-backbone/README.md
@@ -25,3 +25,34 @@ Buffered helpers also install a bounded checkpoint policy by default. When the
 coordinate journal reaches the checkpoint threshold, the adapter writes a compact
 snapshot and removes the replay WAL. This keeps high-throughput strict-native
 document writes from trading append speed for unbounded restart replay cost.
+
+The coordinate WAL supports clean stop/restart. It is not the recovery authority
+for a crash-atomic append across blocks, graph state, heads, coordinates,
+documents, and signer facts.
+
+## Local durability transaction primitives
+
+The package also exposes the first, intentionally unwired building blocks for
+the proposed local crash-safe transaction protocol. This is an on-disk recovery
+format for one program directory; it is not a peer-to-peer wire protocol.
+
+- a versioned, checksummed native journal codec that distinguishes a
+  structurally incomplete final frame from complete corruption;
+- transaction-private block staging and typed strict-barrier receipts;
+- immutable checkpoint generations with an A/B manifest switch; and
+- a Node directory lease backed by an OS-held LevelDB lock and a persistent
+  fencing epoch.
+
+These APIs do not change current append or open behavior. The Node filesystem
+adapter owns its official Rust codec and crash-released directory lease, and is
+the first supported strict physical backend on filesystems that support file and
+directory sync. Its first open creates a synced genesis only in an otherwise
+empty program directory; a nonempty legacy directory fails with
+`NativeDurabilityMigrationRequiredError` and is never adopted implicitly.
+
+Phase one retains the full journal and pins genesis as its scan base while newer
+A/B checkpoints prove staging coverage. Journal compaction is deliberately
+deferred until a later phase can switch the journal generation and its scan base
+together. Memory storage is a non-crash-safe reference adapter, and OPFS remains
+unsupported until its lifetime lease and worker-termination barriers have a
+dedicated conformance gate.

--- a/packages/utils/native-backbone/package.json
+++ b/packages/utils/native-backbone/package.json
@@ -57,7 +57,8 @@
 		"lint": "cargo fmt --check && pnpm exec eslint --config ../../../eslint.config.js \"src/**/*.ts\" \"test/**/*.ts\""
 	},
 	"dependencies": {
-		"@peerbit/blocks-interface": "workspace:*"
+		"@peerbit/blocks-interface": "workspace:*",
+		"classic-level": "^3.0.0"
 	},
 	"author": "dao.xyz",
 	"license": "MIT"

--- a/packages/utils/native-backbone/src/durability.rs
+++ b/packages/utils/native-backbone/src/durability.rs
@@ -1,0 +1,1872 @@
+//! Storage-independent framing and validation for the native durability journal.
+//!
+//! This module deliberately performs no I/O. Storage adapters append the bytes
+//! produced here and may truncate only the `incomplete_tail_offset` returned by
+//! [`scan_journal`]. Every fully present frame is either accepted or reported as
+//! corruption; a checksum mismatch is never treated as a torn tail.
+
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::fmt;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+
+use js_sys::{Array, Uint8Array};
+
+pub const JOURNAL_FORMAT_VERSION: u16 = 1;
+pub const MAX_JOURNAL_BODY_LENGTH: usize = 64 * 1024 * 1024;
+pub const MAX_PROGRAM_ID_LENGTH: usize = 4096;
+pub const MAX_TRANSACTION_ID_LENGTH: usize = 1024;
+pub const MAX_WRITER_OWNER_ID_LENGTH: usize = 1024;
+pub const MAX_WRITER_DOMAIN_ID_LENGTH: usize = 1024;
+
+const JOURNAL_MAGIC: &[u8; 8] = b"PBDURJ1\0";
+const JOURNAL_TRAILER_MAGIC: &[u8; 8] = b"PBDURE1\0";
+const CHECKSUM_LENGTH: usize = 32;
+const HEADER_PREFIX_LENGTH: usize = 20;
+const HEADER_CHECKSUM_OFFSET: usize = HEADER_PREFIX_LENGTH;
+const FRAME_CHECKSUM_OFFSET: usize = HEADER_CHECKSUM_OFFSET + CHECKSUM_LENGTH;
+const HEADER_LENGTH: usize = FRAME_CHECKSUM_OFFSET + CHECKSUM_LENGTH;
+const TRAILER_LENGTH: usize = JOURNAL_TRAILER_MAGIC.len() + 4;
+const FIXED_BODY_LENGTH: usize = 8 + 8 + 8 + 1 + 1 + 2 + 2 + 2 + 2 + 2 + 32 + 4;
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DurabilityPhase {
+    DurablePrepared = 1,
+    NativeApplied = 2,
+    Published = 3,
+    Committed = 4,
+    CleanupPending = 5,
+    Clean = 6,
+}
+
+impl TryFrom<u8> for DurabilityPhase {
+    type Error = DurabilityJournalError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::DurablePrepared),
+            2 => Ok(Self::NativeApplied),
+            3 => Ok(Self::Published),
+            4 => Ok(Self::Committed),
+            5 => Ok(Self::CleanupPending),
+            6 => Ok(Self::Clean),
+            value => Err(DurabilityJournalError::InvalidPhase(value)),
+        }
+    }
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DurabilityOperationKind {
+    Append = 1,
+    Batch = 2,
+    Document = 3,
+    Receive = 4,
+    Repair = 5,
+}
+
+impl TryFrom<u8> for DurabilityOperationKind {
+    type Error = DurabilityJournalError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Append),
+            2 => Ok(Self::Batch),
+            3 => Ok(Self::Document),
+            4 => Ok(Self::Receive),
+            5 => Ok(Self::Repair),
+            value => Err(DurabilityJournalError::InvalidOperationKind(value)),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DurabilityJournalRecord {
+    pub record_lsn: u64,
+    pub tx_sequence: u64,
+    pub writer_epoch: u64,
+    pub writer_owner_id: String,
+    pub writer_domain_id: String,
+    pub phase: DurabilityPhase,
+    pub operation_kind: DurabilityOperationKind,
+    pub program_id: Vec<u8>,
+    pub transaction_id: String,
+    pub plan_digest: [u8; 32],
+    pub payload: Vec<u8>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DurabilityJournalScan {
+    pub records: Vec<DurabilityJournalRecord>,
+    pub valid_length: usize,
+    pub incomplete_tail_offset: Option<usize>,
+    pub incomplete_tail_reason: Option<DurabilityIncompleteTailReason>,
+    pub last_record_lsn: u64,
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DurabilityIncompleteTailReason {
+    ShortHeader = 1,
+    ShortBody = 2,
+    ShortTrailer = 3,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DurabilityJournalValidationContext {
+    pub checkpoint_lsn: u64,
+    pub checkpoint_tx_sequence_highwater: u64,
+    pub expected_program_id: Vec<u8>,
+    pub expected_writer_domain_id: String,
+    pub checkpoint_writer_epoch: u64,
+    pub checkpoint_writer_owner_id: Option<String>,
+    pub current_writer_epoch: u64,
+    pub current_writer_owner_id: String,
+    pub retained_transactions: Vec<DurabilityCheckpointTransactionState>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DurabilityCheckpointTransactionState {
+    pub tx_sequence: u64,
+    pub transaction_id: String,
+    pub phase: DurabilityPhase,
+    pub operation_kind: DurabilityOperationKind,
+    pub plan_digest: [u8; 32],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DurabilityJournalError {
+    InvalidRecordLsn(u64),
+    InvalidTransactionSequence(u64),
+    InvalidWriterEpoch(u64),
+    InvalidDecimalU64(&'static str),
+    EmptyProgramId,
+    ProgramIdTooLong(usize),
+    EmptyTransactionId,
+    TransactionIdTooLong(usize),
+    EmptyWriterOwnerId,
+    WriterOwnerIdTooLong(usize),
+    EmptyWriterDomainId,
+    WriterDomainIdTooLong(usize),
+    InvalidPlanDigestLength(usize),
+    InvalidRetainedTransactionRow(usize),
+    PayloadTooLong(usize),
+    BodyTooLong(usize),
+    LengthOverflow,
+    InvalidMagic {
+        offset: usize,
+    },
+    UnsupportedVersion {
+        offset: usize,
+        version: u16,
+    },
+    InvalidHeaderLength {
+        offset: usize,
+        length: usize,
+    },
+    InvalidHeaderChecksum {
+        offset: usize,
+    },
+    InvalidFrameLength {
+        offset: usize,
+        length: usize,
+    },
+    InvalidBodyLength {
+        offset: usize,
+        length: usize,
+    },
+    InvalidFrameChecksum {
+        offset: usize,
+    },
+    InvalidTrailer {
+        offset: usize,
+    },
+    InvalidTrailerLength {
+        offset: usize,
+        length: usize,
+    },
+    InvalidPhase(u8),
+    InvalidOperationKind(u8),
+    InvalidReservedBits(u16),
+    InvalidUtf8TransactionId,
+    InvalidUtf8WriterOwnerId,
+    InvalidUtf8WriterDomainId,
+    TrailingBodyBytes,
+    RecordLsnOverflow(u64),
+    RecordLsnMismatch {
+        offset: usize,
+        expected: u64,
+        actual: u64,
+    },
+    ProgramIdMismatch {
+        offset: usize,
+    },
+    WriterDomainIdMismatch {
+        offset: usize,
+    },
+    WriterEpochRegression {
+        offset: usize,
+        previous: u64,
+        actual: u64,
+    },
+    WriterEpochAhead {
+        offset: usize,
+        current: u64,
+        actual: u64,
+    },
+    WriterOwnerIdConflict {
+        offset: usize,
+        epoch: u64,
+    },
+    NewTransactionSequenceNotIncreasing {
+        offset: usize,
+        previous: u64,
+        actual: u64,
+    },
+    TransactionSequenceConflict {
+        offset: usize,
+        sequence: u64,
+    },
+    TransactionIdConflict {
+        offset: usize,
+        transaction_id: String,
+    },
+    PlanDigestConflict {
+        offset: usize,
+        transaction_id: String,
+    },
+    OperationKindConflict {
+        offset: usize,
+        transaction_id: String,
+    },
+    InvalidPhaseTransition {
+        offset: usize,
+        transaction_id: String,
+        previous: Option<DurabilityPhase>,
+        next: DurabilityPhase,
+    },
+    TruncatedBodyField(&'static str),
+}
+
+impl fmt::Display for DurabilityJournalError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use DurabilityJournalError::*;
+        match self {
+            InvalidRecordLsn(value) => write!(formatter, "invalid record LSN {value}"),
+            InvalidTransactionSequence(value) => {
+                write!(formatter, "invalid transaction sequence {value}")
+            }
+            InvalidWriterEpoch(value) => write!(formatter, "invalid writer epoch {value}"),
+            InvalidDecimalU64(label) => write!(formatter, "invalid decimal u64 {label}"),
+            EmptyProgramId => formatter.write_str("program id must not be empty"),
+            ProgramIdTooLong(length) => write!(formatter, "program id too long: {length}"),
+            EmptyTransactionId => formatter.write_str("transaction id must not be empty"),
+            TransactionIdTooLong(length) => {
+                write!(formatter, "transaction id too long: {length}")
+            }
+            EmptyWriterOwnerId => formatter.write_str("writer owner id must not be empty"),
+            WriterOwnerIdTooLong(length) => {
+                write!(formatter, "writer owner id too long: {length}")
+            }
+            EmptyWriterDomainId => formatter.write_str("writer domain id must not be empty"),
+            WriterDomainIdTooLong(length) => {
+                write!(formatter, "writer domain id too long: {length}")
+            }
+            InvalidPlanDigestLength(length) => {
+                write!(formatter, "invalid plan digest length: {length}")
+            }
+            InvalidRetainedTransactionRow(index) => {
+                write!(formatter, "invalid retained transaction row at {index}")
+            }
+            PayloadTooLong(length) => write!(formatter, "journal payload too long: {length}"),
+            BodyTooLong(length) => write!(formatter, "journal body too long: {length}"),
+            LengthOverflow => formatter.write_str("journal frame length overflow"),
+            InvalidMagic { offset } => write!(formatter, "invalid journal magic at {offset}"),
+            UnsupportedVersion { offset, version } => {
+                write!(formatter, "unsupported journal version {version} at {offset}")
+            }
+            InvalidHeaderLength { offset, length } => {
+                write!(formatter, "invalid journal header length {length} at {offset}")
+            }
+            InvalidHeaderChecksum { offset } => {
+                write!(formatter, "invalid journal header checksum at {offset}")
+            }
+            InvalidFrameLength { offset, length } => {
+                write!(formatter, "invalid journal frame length {length} at {offset}")
+            }
+            InvalidBodyLength { offset, length } => {
+                write!(formatter, "invalid journal body length {length} at {offset}")
+            }
+            InvalidFrameChecksum { offset } => {
+                write!(formatter, "invalid journal frame checksum at {offset}")
+            }
+            InvalidTrailer { offset } => write!(formatter, "invalid journal trailer at {offset}"),
+            InvalidTrailerLength { offset, length } => {
+                write!(formatter, "invalid journal trailer length {length} at {offset}")
+            }
+            InvalidPhase(value) => write!(formatter, "invalid durability phase {value}"),
+            InvalidOperationKind(value) => {
+                write!(formatter, "invalid durability operation kind {value}")
+            }
+            InvalidReservedBits(value) => {
+                write!(formatter, "invalid journal reserved bits {value}")
+            }
+            InvalidUtf8TransactionId => formatter.write_str("invalid utf-8 transaction id"),
+            InvalidUtf8WriterOwnerId => formatter.write_str("invalid utf-8 writer owner id"),
+            InvalidUtf8WriterDomainId => formatter.write_str("invalid utf-8 writer domain id"),
+            TrailingBodyBytes => formatter.write_str("trailing journal body bytes"),
+            RecordLsnOverflow(value) => write!(formatter, "record LSN overflow after {value}"),
+            RecordLsnMismatch { offset, expected, actual } => write!(
+                formatter,
+                "record LSN mismatch at {offset}: expected {expected}, got {actual}"
+            ),
+            ProgramIdMismatch { offset } => {
+                write!(formatter, "program id mismatch at {offset}")
+            }
+            WriterDomainIdMismatch { offset } => {
+                write!(formatter, "writer domain id mismatch at {offset}")
+            }
+            WriterEpochRegression {
+                offset,
+                previous,
+                actual,
+            } => write!(
+                formatter,
+                "writer epoch regressed at {offset}: previous {previous}, got {actual}"
+            ),
+            WriterEpochAhead {
+                offset,
+                current,
+                actual,
+            } => write!(
+                formatter,
+                "writer epoch exceeds current fence at {offset}: current {current}, got {actual}"
+            ),
+            WriterOwnerIdConflict { offset, epoch } => write!(
+                formatter,
+                "writer owner id conflicts in epoch {epoch} at {offset}"
+            ),
+            NewTransactionSequenceNotIncreasing {
+                offset,
+                previous,
+                actual,
+            } => write!(
+                formatter,
+                "new transaction sequence did not increase at {offset}: previous {previous}, got {actual}"
+            ),
+            TransactionSequenceConflict { offset, sequence } => write!(
+                formatter,
+                "transaction sequence {sequence} conflicts at {offset}"
+            ),
+            TransactionIdConflict { offset, transaction_id } => write!(
+                formatter,
+                "transaction id {transaction_id} conflicts at {offset}"
+            ),
+            PlanDigestConflict { offset, transaction_id } => write!(
+                formatter,
+                "transaction id {transaction_id} changed plan digest at {offset}"
+            ),
+            OperationKindConflict { offset, transaction_id } => write!(
+                formatter,
+                "transaction id {transaction_id} changed operation kind at {offset}"
+            ),
+            InvalidPhaseTransition {
+                offset,
+                transaction_id,
+                previous,
+                next,
+            } => write!(
+                formatter,
+                "invalid phase transition for {transaction_id} at {offset}: {previous:?} -> {next:?}"
+            ),
+            TruncatedBodyField(label) => write!(formatter, "truncated journal body {label}"),
+        }
+    }
+}
+
+impl std::error::Error for DurabilityJournalError {}
+
+impl DurabilityJournalError {
+    pub fn code(&self) -> &'static str {
+        use DurabilityJournalError::*;
+        match self {
+            InvalidRecordLsn(_) => "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_RECORD_LSN",
+            InvalidTransactionSequence(_) => "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_TX_SEQUENCE",
+            InvalidWriterEpoch(_) => "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_WRITER_EPOCH",
+            InvalidDecimalU64(_) => "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_DECIMAL_U64",
+            EmptyProgramId => "ERR_NATIVE_DURABILITY_JOURNAL_EMPTY_PROGRAM_ID",
+            ProgramIdTooLong(_) => "ERR_NATIVE_DURABILITY_JOURNAL_PROGRAM_ID_TOO_LONG",
+            EmptyTransactionId => "ERR_NATIVE_DURABILITY_JOURNAL_EMPTY_TX_ID",
+            TransactionIdTooLong(_) => "ERR_NATIVE_DURABILITY_JOURNAL_TX_ID_TOO_LONG",
+            EmptyWriterOwnerId => "ERR_NATIVE_DURABILITY_JOURNAL_EMPTY_WRITER_OWNER_ID",
+            WriterOwnerIdTooLong(_) => "ERR_NATIVE_DURABILITY_JOURNAL_WRITER_OWNER_ID_TOO_LONG",
+            EmptyWriterDomainId => "ERR_NATIVE_DURABILITY_JOURNAL_EMPTY_WRITER_DOMAIN_ID",
+            WriterDomainIdTooLong(_) => "ERR_NATIVE_DURABILITY_JOURNAL_WRITER_DOMAIN_ID_TOO_LONG",
+            InvalidPlanDigestLength(_) => {
+                "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_PLAN_DIGEST_LENGTH"
+            }
+            InvalidRetainedTransactionRow(_) => "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_RETAINED_TX",
+            PayloadTooLong(_) => "ERR_NATIVE_DURABILITY_JOURNAL_PAYLOAD_TOO_LONG",
+            BodyTooLong(_) => "ERR_NATIVE_DURABILITY_JOURNAL_BODY_TOO_LONG",
+            LengthOverflow => "ERR_NATIVE_DURABILITY_JOURNAL_LENGTH_OVERFLOW",
+            InvalidMagic { .. } => "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_MAGIC",
+            UnsupportedVersion { .. } => "ERR_NATIVE_DURABILITY_JOURNAL_UNSUPPORTED_VERSION",
+            InvalidHeaderLength { .. } => "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_HEADER_LENGTH",
+            InvalidHeaderChecksum { .. } => "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_HEADER_CHECKSUM",
+            InvalidFrameLength { .. } => "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_FRAME_LENGTH",
+            InvalidBodyLength { .. } => "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_BODY_LENGTH",
+            InvalidFrameChecksum { .. } => "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_FRAME_CHECKSUM",
+            InvalidTrailer { .. } => "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_TRAILER",
+            InvalidTrailerLength { .. } => "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_TRAILER_LENGTH",
+            InvalidPhase(_) => "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_PHASE",
+            InvalidOperationKind(_) => "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_OPERATION_KIND",
+            InvalidReservedBits(_) => "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_RESERVED_BITS",
+            InvalidUtf8TransactionId => "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_TX_ID_UTF8",
+            InvalidUtf8WriterOwnerId => {
+                "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_WRITER_OWNER_ID_UTF8"
+            }
+            InvalidUtf8WriterDomainId => {
+                "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_WRITER_DOMAIN_ID_UTF8"
+            }
+            TrailingBodyBytes => "ERR_NATIVE_DURABILITY_JOURNAL_TRAILING_BODY_BYTES",
+            RecordLsnOverflow(_) => "ERR_NATIVE_DURABILITY_JOURNAL_RECORD_LSN_OVERFLOW",
+            RecordLsnMismatch { .. } => "ERR_NATIVE_DURABILITY_JOURNAL_RECORD_LSN_MISMATCH",
+            ProgramIdMismatch { .. } => "ERR_NATIVE_DURABILITY_JOURNAL_PROGRAM_ID_MISMATCH",
+            WriterDomainIdMismatch { .. } => {
+                "ERR_NATIVE_DURABILITY_JOURNAL_WRITER_DOMAIN_ID_MISMATCH"
+            }
+            WriterEpochRegression { .. } => "ERR_NATIVE_DURABILITY_JOURNAL_WRITER_EPOCH_REGRESSION",
+            WriterEpochAhead { .. } => "ERR_NATIVE_DURABILITY_JOURNAL_WRITER_EPOCH_AHEAD",
+            WriterOwnerIdConflict { .. } => {
+                "ERR_NATIVE_DURABILITY_JOURNAL_WRITER_OWNER_ID_CONFLICT"
+            }
+            NewTransactionSequenceNotIncreasing { .. } => {
+                "ERR_NATIVE_DURABILITY_JOURNAL_TX_SEQUENCE_NOT_INCREASING"
+            }
+            TransactionSequenceConflict { .. } => {
+                "ERR_NATIVE_DURABILITY_JOURNAL_TX_SEQUENCE_CONFLICT"
+            }
+            TransactionIdConflict { .. } => "ERR_NATIVE_DURABILITY_JOURNAL_TX_ID_CONFLICT",
+            PlanDigestConflict { .. } => "ERR_NATIVE_DURABILITY_JOURNAL_PLAN_DIGEST_CONFLICT",
+            OperationKindConflict { .. } => "ERR_NATIVE_DURABILITY_JOURNAL_OPERATION_KIND_CONFLICT",
+            InvalidPhaseTransition { .. } => {
+                "ERR_NATIVE_DURABILITY_JOURNAL_INVALID_PHASE_TRANSITION"
+            }
+            TruncatedBodyField(_) => "ERR_NATIVE_DURABILITY_JOURNAL_TRUNCATED_BODY_FIELD",
+        }
+    }
+
+    pub fn byte_offset(&self) -> Option<usize> {
+        use DurabilityJournalError::*;
+        match self {
+            InvalidMagic { offset }
+            | UnsupportedVersion { offset, .. }
+            | InvalidHeaderLength { offset, .. }
+            | InvalidHeaderChecksum { offset }
+            | InvalidFrameLength { offset, .. }
+            | InvalidBodyLength { offset, .. }
+            | InvalidFrameChecksum { offset }
+            | InvalidTrailer { offset }
+            | InvalidTrailerLength { offset, .. }
+            | RecordLsnMismatch { offset, .. }
+            | ProgramIdMismatch { offset }
+            | WriterDomainIdMismatch { offset }
+            | WriterEpochRegression { offset, .. }
+            | WriterEpochAhead { offset, .. }
+            | WriterOwnerIdConflict { offset, .. }
+            | NewTransactionSequenceNotIncreasing { offset, .. }
+            | TransactionSequenceConflict { offset, .. }
+            | TransactionIdConflict { offset, .. }
+            | PlanDigestConflict { offset, .. }
+            | OperationKindConflict { offset, .. }
+            | InvalidPhaseTransition { offset, .. } => Some(*offset),
+            _ => None,
+        }
+    }
+}
+
+/// Stateless Wasm boundary for the canonical journal codec. All u64 values are
+/// decimal strings so JavaScript never rounds an LSN, sequence, or fence epoch.
+#[wasm_bindgen]
+pub struct NativeDurabilityJournalCodec;
+
+#[wasm_bindgen]
+impl NativeDurabilityJournalCodec {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self
+    }
+
+    #[wasm_bindgen(js_name = encodeFrame)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn encode_frame_wasm(
+        &self,
+        record_lsn: String,
+        tx_sequence: String,
+        writer_epoch: String,
+        writer_owner_id: String,
+        writer_domain_id: String,
+        phase: u8,
+        operation_kind: u8,
+        program_id: Uint8Array,
+        transaction_id: String,
+        plan_digest: Uint8Array,
+        payload: Uint8Array,
+    ) -> Result<Vec<u8>, JsValue> {
+        let digest = plan_digest.to_vec();
+        if digest.len() != 32 {
+            return Err(journal_error_to_js(
+                DurabilityJournalError::InvalidPlanDigestLength(digest.len()),
+            ));
+        }
+        let mut fixed_digest = [0u8; 32];
+        fixed_digest.copy_from_slice(&digest);
+        let record = DurabilityJournalRecord {
+            record_lsn: parse_decimal_u64(&record_lsn, "record LSN")
+                .map_err(journal_error_to_js)?,
+            tx_sequence: parse_decimal_u64(&tx_sequence, "transaction sequence")
+                .map_err(journal_error_to_js)?,
+            writer_epoch: parse_decimal_u64(&writer_epoch, "writer epoch")
+                .map_err(journal_error_to_js)?,
+            writer_owner_id,
+            writer_domain_id,
+            phase: DurabilityPhase::try_from(phase).map_err(journal_error_to_js)?,
+            operation_kind: DurabilityOperationKind::try_from(operation_kind)
+                .map_err(journal_error_to_js)?,
+            program_id: program_id.to_vec(),
+            transaction_id,
+            plan_digest: fixed_digest,
+            payload: payload.to_vec(),
+        };
+        encode_journal_frame(&record).map_err(journal_error_to_js)
+    }
+
+    #[wasm_bindgen(js_name = scan)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn scan_wasm(
+        &self,
+        bytes: Uint8Array,
+        checkpoint_lsn: String,
+        checkpoint_tx_sequence_highwater: String,
+        expected_program_id: Uint8Array,
+        expected_writer_domain_id: String,
+        checkpoint_writer_epoch: String,
+        checkpoint_writer_owner_id: Option<String>,
+        current_writer_epoch: String,
+        current_writer_owner_id: String,
+        retained_transaction_rows: Array,
+    ) -> Result<Array, JsValue> {
+        let retained_transactions = parse_retained_transaction_rows(retained_transaction_rows)
+            .map_err(journal_error_to_js)?;
+        let context = DurabilityJournalValidationContext {
+            checkpoint_lsn: parse_decimal_u64(&checkpoint_lsn, "checkpoint LSN")
+                .map_err(journal_error_to_js)?,
+            checkpoint_tx_sequence_highwater: parse_decimal_u64(
+                &checkpoint_tx_sequence_highwater,
+                "checkpoint transaction sequence highwater",
+            )
+            .map_err(journal_error_to_js)?,
+            expected_program_id: expected_program_id.to_vec(),
+            expected_writer_domain_id,
+            checkpoint_writer_epoch: parse_decimal_u64(
+                &checkpoint_writer_epoch,
+                "checkpoint writer epoch",
+            )
+            .map_err(journal_error_to_js)?,
+            checkpoint_writer_owner_id,
+            current_writer_epoch: parse_decimal_u64(&current_writer_epoch, "current writer epoch")
+                .map_err(journal_error_to_js)?,
+            current_writer_owner_id,
+            retained_transactions,
+        };
+        let scan = scan_journal(&bytes.to_vec(), &context).map_err(journal_error_to_js)?;
+        Ok(scan_to_js(scan))
+    }
+}
+
+impl Default for NativeDurabilityJournalCodec {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn parse_decimal_u64(value: &str, label: &'static str) -> Result<u64, DurabilityJournalError> {
+    if value.is_empty()
+        || (value.len() > 1 && value.starts_with('0'))
+        || !value.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return Err(DurabilityJournalError::InvalidDecimalU64(label));
+    }
+    value
+        .parse::<u64>()
+        .map_err(|_| DurabilityJournalError::InvalidDecimalU64(label))
+}
+
+fn parse_retained_transaction_rows(
+    rows: Array,
+) -> Result<Vec<DurabilityCheckpointTransactionState>, DurabilityJournalError> {
+    let mut retained = Vec::with_capacity(rows.length() as usize);
+    for index in 0..rows.length() {
+        let row = rows
+            .get(index)
+            .dyn_into::<Array>()
+            .map_err(|_| DurabilityJournalError::InvalidRetainedTransactionRow(index as usize))?;
+        if row.length() != 5 {
+            return Err(DurabilityJournalError::InvalidRetainedTransactionRow(
+                index as usize,
+            ));
+        }
+        let tx_sequence =
+            row.get(0)
+                .as_string()
+                .ok_or(DurabilityJournalError::InvalidRetainedTransactionRow(
+                    index as usize,
+                ))?;
+        let transaction_id =
+            row.get(1)
+                .as_string()
+                .ok_or(DurabilityJournalError::InvalidRetainedTransactionRow(
+                    index as usize,
+                ))?;
+        let phase = js_u8(&row.get(2))
+            .and_then(DurabilityPhase::try_from)
+            .map_err(|_| DurabilityJournalError::InvalidRetainedTransactionRow(index as usize))?;
+        let operation_kind = js_u8(&row.get(3))
+            .and_then(DurabilityOperationKind::try_from)
+            .map_err(|_| DurabilityJournalError::InvalidRetainedTransactionRow(index as usize))?;
+        let digest = row
+            .get(4)
+            .dyn_into::<Uint8Array>()
+            .map_err(|_| DurabilityJournalError::InvalidRetainedTransactionRow(index as usize))?
+            .to_vec();
+        if digest.len() != 32 {
+            return Err(DurabilityJournalError::InvalidPlanDigestLength(
+                digest.len(),
+            ));
+        }
+        let mut plan_digest = [0u8; 32];
+        plan_digest.copy_from_slice(&digest);
+        retained.push(DurabilityCheckpointTransactionState {
+            tx_sequence: parse_decimal_u64(&tx_sequence, "retained transaction sequence")?,
+            transaction_id,
+            phase,
+            operation_kind,
+            plan_digest,
+        });
+    }
+    Ok(retained)
+}
+
+fn js_u8(value: &JsValue) -> Result<u8, DurabilityJournalError> {
+    let number = value
+        .as_f64()
+        .ok_or(DurabilityJournalError::InvalidRetainedTransactionRow(0))?;
+    if !number.is_finite() || number.fract() != 0.0 || !(0.0..=u8::MAX as f64).contains(&number) {
+        return Err(DurabilityJournalError::InvalidRetainedTransactionRow(0));
+    }
+    Ok(number as u8)
+}
+
+fn scan_to_js(scan: DurabilityJournalScan) -> Array {
+    let result = Array::new();
+    result.push(&JsValue::from_f64(scan.valid_length as f64));
+    result.push(
+        &scan
+            .incomplete_tail_offset
+            .map(|value| JsValue::from_f64(value as f64))
+            .unwrap_or(JsValue::UNDEFINED),
+    );
+    result.push(&JsValue::from_f64(
+        scan.incomplete_tail_reason
+            .map(|reason| reason as u8)
+            .unwrap_or(0) as f64,
+    ));
+    result.push(&JsValue::from_str(&scan.last_record_lsn.to_string()));
+    let records = Array::new();
+    for record in scan.records {
+        let row = Array::new();
+        row.push(&JsValue::from_str(&record.record_lsn.to_string()));
+        row.push(&JsValue::from_str(&record.tx_sequence.to_string()));
+        row.push(&JsValue::from_str(&record.writer_epoch.to_string()));
+        row.push(&JsValue::from_str(&record.writer_owner_id));
+        row.push(&JsValue::from_str(&record.writer_domain_id));
+        row.push(&JsValue::from_f64(record.phase as u8 as f64));
+        row.push(&JsValue::from_f64(record.operation_kind as u8 as f64));
+        row.push(&Uint8Array::from(record.program_id.as_slice()));
+        row.push(&JsValue::from_str(&record.transaction_id));
+        row.push(&Uint8Array::from(record.plan_digest.as_slice()));
+        row.push(&Uint8Array::from(record.payload.as_slice()));
+        records.push(&row);
+    }
+    result.push(&records);
+    result
+}
+
+fn journal_error_to_js(error: DurabilityJournalError) -> JsValue {
+    let row = Array::new();
+    row.push(&JsValue::from_str(error.code()));
+    row.push(&JsValue::from_str(&error.to_string()));
+    row.push(
+        &error
+            .byte_offset()
+            .map(|value| JsValue::from_f64(value as f64))
+            .unwrap_or(JsValue::UNDEFINED),
+    );
+    row.into()
+}
+
+pub fn encode_journal_frame(
+    record: &DurabilityJournalRecord,
+) -> Result<Vec<u8>, DurabilityJournalError> {
+    validate_record(record)?;
+
+    let transaction_id = record.transaction_id.as_bytes();
+    let writer_owner_id = record.writer_owner_id.as_bytes();
+    let writer_domain_id = record.writer_domain_id.as_bytes();
+    let body_length = FIXED_BODY_LENGTH
+        .checked_add(record.program_id.len())
+        .and_then(|value| value.checked_add(transaction_id.len()))
+        .and_then(|value| value.checked_add(writer_owner_id.len()))
+        .and_then(|value| value.checked_add(writer_domain_id.len()))
+        .and_then(|value| value.checked_add(record.payload.len()))
+        .ok_or(DurabilityJournalError::LengthOverflow)?;
+    if body_length > MAX_JOURNAL_BODY_LENGTH {
+        return Err(DurabilityJournalError::BodyTooLong(body_length));
+    }
+    let frame_length = HEADER_LENGTH
+        .checked_add(body_length)
+        .and_then(|value| value.checked_add(TRAILER_LENGTH))
+        .ok_or(DurabilityJournalError::LengthOverflow)?;
+    let body_length_u32 =
+        u32::try_from(body_length).map_err(|_| DurabilityJournalError::LengthOverflow)?;
+    let frame_length_u32 =
+        u32::try_from(frame_length).map_err(|_| DurabilityJournalError::LengthOverflow)?;
+
+    let mut frame = Vec::with_capacity(frame_length);
+    frame.extend_from_slice(JOURNAL_MAGIC);
+    frame.extend_from_slice(&JOURNAL_FORMAT_VERSION.to_le_bytes());
+    frame.extend_from_slice(&(HEADER_LENGTH as u16).to_le_bytes());
+    frame.extend_from_slice(&frame_length_u32.to_le_bytes());
+    frame.extend_from_slice(&body_length_u32.to_le_bytes());
+    let header_checksum = Sha256::digest(&frame[..HEADER_PREFIX_LENGTH]);
+    frame.extend_from_slice(&header_checksum);
+    frame.extend_from_slice(&[0; CHECKSUM_LENGTH]);
+
+    frame.extend_from_slice(&record.record_lsn.to_le_bytes());
+    frame.extend_from_slice(&record.tx_sequence.to_le_bytes());
+    frame.extend_from_slice(&record.writer_epoch.to_le_bytes());
+    frame.push(record.phase as u8);
+    frame.push(record.operation_kind as u8);
+    frame.extend_from_slice(&0u16.to_le_bytes());
+    frame.extend_from_slice(&(record.program_id.len() as u16).to_le_bytes());
+    frame.extend_from_slice(&(transaction_id.len() as u16).to_le_bytes());
+    frame.extend_from_slice(&(writer_owner_id.len() as u16).to_le_bytes());
+    frame.extend_from_slice(&(writer_domain_id.len() as u16).to_le_bytes());
+    frame.extend_from_slice(&record.plan_digest);
+    frame.extend_from_slice(&(record.payload.len() as u32).to_le_bytes());
+    frame.extend_from_slice(&record.program_id);
+    frame.extend_from_slice(transaction_id);
+    frame.extend_from_slice(writer_owner_id);
+    frame.extend_from_slice(writer_domain_id);
+    frame.extend_from_slice(&record.payload);
+    frame.extend_from_slice(JOURNAL_TRAILER_MAGIC);
+    frame.extend_from_slice(&frame_length_u32.to_le_bytes());
+
+    let frame_checksum = frame_checksum(&frame);
+    frame[FRAME_CHECKSUM_OFFSET..HEADER_LENGTH].copy_from_slice(&frame_checksum);
+    debug_assert_eq!(frame.len(), frame_length);
+    Ok(frame)
+}
+
+pub fn scan_journal(
+    bytes: &[u8],
+    context: &DurabilityJournalValidationContext,
+) -> Result<DurabilityJournalScan, DurabilityJournalError> {
+    validate_context(context)?;
+    let mut records = Vec::new();
+    let mut offset = 0usize;
+    let mut last_record_lsn = context.checkpoint_lsn;
+    let mut validator = TransactionValidator::new(context)?;
+
+    while offset < bytes.len() {
+        if last_record_lsn == u64::MAX {
+            return Err(DurabilityJournalError::RecordLsnOverflow(last_record_lsn));
+        }
+        if bytes.len() - offset < HEADER_LENGTH {
+            validate_incomplete_header_prefix(&bytes[offset..], offset)?;
+            return Ok(DurabilityJournalScan {
+                records,
+                valid_length: offset,
+                incomplete_tail_offset: Some(offset),
+                incomplete_tail_reason: Some(DurabilityIncompleteTailReason::ShortHeader),
+                last_record_lsn,
+            });
+        }
+
+        let header = &bytes[offset..offset + HEADER_LENGTH];
+        if &header[..JOURNAL_MAGIC.len()] != JOURNAL_MAGIC {
+            return Err(DurabilityJournalError::InvalidMagic { offset });
+        }
+        let version = read_u16_at(header, 8);
+        if version != JOURNAL_FORMAT_VERSION {
+            return Err(DurabilityJournalError::UnsupportedVersion { offset, version });
+        }
+        let header_length = read_u16_at(header, 10) as usize;
+        if header_length != HEADER_LENGTH {
+            return Err(DurabilityJournalError::InvalidHeaderLength {
+                offset,
+                length: header_length,
+            });
+        }
+        if Sha256::digest(&header[..HEADER_PREFIX_LENGTH]).as_slice()
+            != &header[HEADER_CHECKSUM_OFFSET..FRAME_CHECKSUM_OFFSET]
+        {
+            return Err(DurabilityJournalError::InvalidHeaderChecksum { offset });
+        }
+
+        let frame_length = read_u32_at(header, 12) as usize;
+        let body_length = read_u32_at(header, 16) as usize;
+        if body_length > MAX_JOURNAL_BODY_LENGTH {
+            return Err(DurabilityJournalError::InvalidBodyLength {
+                offset,
+                length: body_length,
+            });
+        }
+        let expected_frame_length = HEADER_LENGTH
+            .checked_add(body_length)
+            .and_then(|value| value.checked_add(TRAILER_LENGTH))
+            .ok_or(DurabilityJournalError::LengthOverflow)?;
+        if frame_length != expected_frame_length {
+            return Err(DurabilityJournalError::InvalidFrameLength {
+                offset,
+                length: frame_length,
+            });
+        }
+        let frame_end = offset
+            .checked_add(frame_length)
+            .ok_or(DurabilityJournalError::LengthOverflow)?;
+        if frame_end > bytes.len() {
+            let body_end = offset
+                .checked_add(HEADER_LENGTH)
+                .and_then(|value| value.checked_add(body_length))
+                .ok_or(DurabilityJournalError::LengthOverflow)?;
+            return Ok(DurabilityJournalScan {
+                records,
+                valid_length: offset,
+                incomplete_tail_offset: Some(offset),
+                incomplete_tail_reason: Some(if bytes.len() < body_end {
+                    DurabilityIncompleteTailReason::ShortBody
+                } else {
+                    DurabilityIncompleteTailReason::ShortTrailer
+                }),
+                last_record_lsn,
+            });
+        }
+
+        let frame = &bytes[offset..frame_end];
+        let trailer_offset = frame_length - TRAILER_LENGTH;
+        if &frame[trailer_offset..trailer_offset + JOURNAL_TRAILER_MAGIC.len()]
+            != JOURNAL_TRAILER_MAGIC
+        {
+            return Err(DurabilityJournalError::InvalidTrailer { offset });
+        }
+        let trailer_frame_length = read_u32_at(frame, trailer_offset + 8) as usize;
+        if trailer_frame_length != frame_length {
+            return Err(DurabilityJournalError::InvalidTrailerLength {
+                offset,
+                length: trailer_frame_length,
+            });
+        }
+        if frame_checksum(frame).as_slice() != &frame[FRAME_CHECKSUM_OFFSET..HEADER_LENGTH] {
+            return Err(DurabilityJournalError::InvalidFrameChecksum { offset });
+        }
+
+        let body = &frame[HEADER_LENGTH..trailer_offset];
+        let record = decode_record_body(body)?;
+        let expected_lsn = last_record_lsn
+            .checked_add(1)
+            .ok_or(DurabilityJournalError::RecordLsnOverflow(last_record_lsn))?;
+        if record.record_lsn != expected_lsn {
+            return Err(DurabilityJournalError::RecordLsnMismatch {
+                offset,
+                expected: expected_lsn,
+                actual: record.record_lsn,
+            });
+        }
+        validator.validate(&record, offset)?;
+        records.push(record);
+        offset = frame_end;
+        last_record_lsn = expected_lsn;
+    }
+
+    Ok(DurabilityJournalScan {
+        records,
+        valid_length: offset,
+        incomplete_tail_offset: None,
+        incomplete_tail_reason: None,
+        last_record_lsn,
+    })
+}
+
+fn validate_context(
+    context: &DurabilityJournalValidationContext,
+) -> Result<(), DurabilityJournalError> {
+    if context.expected_program_id.is_empty() {
+        return Err(DurabilityJournalError::EmptyProgramId);
+    }
+    if context.expected_program_id.len() > MAX_PROGRAM_ID_LENGTH {
+        return Err(DurabilityJournalError::ProgramIdTooLong(
+            context.expected_program_id.len(),
+        ));
+    }
+    if context.expected_writer_domain_id.is_empty() {
+        return Err(DurabilityJournalError::EmptyWriterDomainId);
+    }
+    if context.expected_writer_domain_id.len() > MAX_WRITER_DOMAIN_ID_LENGTH {
+        return Err(DurabilityJournalError::WriterDomainIdTooLong(
+            context.expected_writer_domain_id.len(),
+        ));
+    }
+    if context.current_writer_epoch == 0
+        || context.checkpoint_writer_epoch > context.current_writer_epoch
+    {
+        return Err(DurabilityJournalError::InvalidWriterEpoch(
+            context.current_writer_epoch,
+        ));
+    }
+    if context.checkpoint_writer_epoch > 0 && context.checkpoint_writer_owner_id.is_none() {
+        return Err(DurabilityJournalError::EmptyWriterOwnerId);
+    }
+    if let Some(owner_id) = &context.checkpoint_writer_owner_id {
+        if owner_id.is_empty() {
+            return Err(DurabilityJournalError::EmptyWriterOwnerId);
+        }
+        if owner_id.len() > MAX_WRITER_OWNER_ID_LENGTH {
+            return Err(DurabilityJournalError::WriterOwnerIdTooLong(owner_id.len()));
+        }
+    }
+    if context.current_writer_owner_id.is_empty() {
+        return Err(DurabilityJournalError::EmptyWriterOwnerId);
+    }
+    if context.current_writer_owner_id.len() > MAX_WRITER_OWNER_ID_LENGTH {
+        return Err(DurabilityJournalError::WriterOwnerIdTooLong(
+            context.current_writer_owner_id.len(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_incomplete_header_prefix(
+    bytes: &[u8],
+    offset: usize,
+) -> Result<(), DurabilityJournalError> {
+    let magic_prefix_length = bytes.len().min(JOURNAL_MAGIC.len());
+    if bytes[..magic_prefix_length] != JOURNAL_MAGIC[..magic_prefix_length] {
+        return Err(DurabilityJournalError::InvalidMagic { offset });
+    }
+    if bytes.len() > JOURNAL_MAGIC.len() {
+        let version_bytes = JOURNAL_FORMAT_VERSION.to_le_bytes();
+        let available = (bytes.len() - JOURNAL_MAGIC.len()).min(version_bytes.len());
+        if bytes[JOURNAL_MAGIC.len()..JOURNAL_MAGIC.len() + available] != version_bytes[..available]
+        {
+            let version = if available == 2 {
+                read_u16_at(bytes, JOURNAL_MAGIC.len())
+            } else {
+                bytes[JOURNAL_MAGIC.len()] as u16
+            };
+            return Err(DurabilityJournalError::UnsupportedVersion { offset, version });
+        }
+    }
+    if bytes.len() > JOURNAL_MAGIC.len() + 2 {
+        let header_length_bytes = (HEADER_LENGTH as u16).to_le_bytes();
+        let start = JOURNAL_MAGIC.len() + 2;
+        let available = (bytes.len() - start).min(header_length_bytes.len());
+        if bytes[start..start + available] != header_length_bytes[..available] {
+            let length = if available == 2 {
+                read_u16_at(bytes, start) as usize
+            } else {
+                bytes[start] as usize
+            };
+            return Err(DurabilityJournalError::InvalidHeaderLength { offset, length });
+        }
+    }
+    if bytes.len() >= HEADER_PREFIX_LENGTH {
+        let frame_length = read_u32_at(bytes, 12) as usize;
+        let body_length = read_u32_at(bytes, 16) as usize;
+        if body_length > MAX_JOURNAL_BODY_LENGTH {
+            return Err(DurabilityJournalError::InvalidBodyLength {
+                offset,
+                length: body_length,
+            });
+        }
+        let expected_frame_length = HEADER_LENGTH
+            .checked_add(body_length)
+            .and_then(|value| value.checked_add(TRAILER_LENGTH))
+            .ok_or(DurabilityJournalError::LengthOverflow)?;
+        if frame_length != expected_frame_length {
+            return Err(DurabilityJournalError::InvalidFrameLength {
+                offset,
+                length: frame_length,
+            });
+        }
+    }
+    if bytes.len() >= FRAME_CHECKSUM_OFFSET
+        && Sha256::digest(&bytes[..HEADER_PREFIX_LENGTH]).as_slice()
+            != &bytes[HEADER_CHECKSUM_OFFSET..FRAME_CHECKSUM_OFFSET]
+    {
+        return Err(DurabilityJournalError::InvalidHeaderChecksum { offset });
+    }
+    Ok(())
+}
+
+fn validate_record(record: &DurabilityJournalRecord) -> Result<(), DurabilityJournalError> {
+    if record.record_lsn == 0 {
+        return Err(DurabilityJournalError::InvalidRecordLsn(record.record_lsn));
+    }
+    if record.tx_sequence == 0 {
+        return Err(DurabilityJournalError::InvalidTransactionSequence(
+            record.tx_sequence,
+        ));
+    }
+    if record.writer_epoch == 0 {
+        return Err(DurabilityJournalError::InvalidWriterEpoch(
+            record.writer_epoch,
+        ));
+    }
+    if record.program_id.is_empty() {
+        return Err(DurabilityJournalError::EmptyProgramId);
+    }
+    if record.program_id.len() > MAX_PROGRAM_ID_LENGTH {
+        return Err(DurabilityJournalError::ProgramIdTooLong(
+            record.program_id.len(),
+        ));
+    }
+    if record.transaction_id.is_empty() {
+        return Err(DurabilityJournalError::EmptyTransactionId);
+    }
+    if record.transaction_id.len() > MAX_TRANSACTION_ID_LENGTH {
+        return Err(DurabilityJournalError::TransactionIdTooLong(
+            record.transaction_id.len(),
+        ));
+    }
+    if record.writer_owner_id.is_empty() {
+        return Err(DurabilityJournalError::EmptyWriterOwnerId);
+    }
+    if record.writer_owner_id.len() > MAX_WRITER_OWNER_ID_LENGTH {
+        return Err(DurabilityJournalError::WriterOwnerIdTooLong(
+            record.writer_owner_id.len(),
+        ));
+    }
+    if record.writer_domain_id.is_empty() {
+        return Err(DurabilityJournalError::EmptyWriterDomainId);
+    }
+    if record.writer_domain_id.len() > MAX_WRITER_DOMAIN_ID_LENGTH {
+        return Err(DurabilityJournalError::WriterDomainIdTooLong(
+            record.writer_domain_id.len(),
+        ));
+    }
+    if record.payload.len() > MAX_JOURNAL_BODY_LENGTH {
+        return Err(DurabilityJournalError::PayloadTooLong(record.payload.len()));
+    }
+    Ok(())
+}
+
+fn decode_record_body(body: &[u8]) -> Result<DurabilityJournalRecord, DurabilityJournalError> {
+    let mut offset = 0usize;
+    let record_lsn = read_u64(body, &mut offset, "record LSN")?;
+    let tx_sequence = read_u64(body, &mut offset, "transaction sequence")?;
+    let writer_epoch = read_u64(body, &mut offset, "writer epoch")?;
+    let phase = DurabilityPhase::try_from(read_u8(body, &mut offset, "phase")?)?;
+    let operation_kind =
+        DurabilityOperationKind::try_from(read_u8(body, &mut offset, "operation kind")?)?;
+    let reserved = read_u16(body, &mut offset, "reserved bits")?;
+    if reserved != 0 {
+        return Err(DurabilityJournalError::InvalidReservedBits(reserved));
+    }
+    let program_id_length = read_u16(body, &mut offset, "program id length")? as usize;
+    let transaction_id_length = read_u16(body, &mut offset, "transaction id length")? as usize;
+    let writer_owner_id_length = read_u16(body, &mut offset, "writer owner id length")? as usize;
+    let writer_domain_id_length = read_u16(body, &mut offset, "writer domain id length")? as usize;
+    if program_id_length == 0 {
+        return Err(DurabilityJournalError::EmptyProgramId);
+    }
+    if program_id_length > MAX_PROGRAM_ID_LENGTH {
+        return Err(DurabilityJournalError::ProgramIdTooLong(program_id_length));
+    }
+    if transaction_id_length == 0 {
+        return Err(DurabilityJournalError::EmptyTransactionId);
+    }
+    if transaction_id_length > MAX_TRANSACTION_ID_LENGTH {
+        return Err(DurabilityJournalError::TransactionIdTooLong(
+            transaction_id_length,
+        ));
+    }
+    if writer_owner_id_length == 0 {
+        return Err(DurabilityJournalError::EmptyWriterOwnerId);
+    }
+    if writer_owner_id_length > MAX_WRITER_OWNER_ID_LENGTH {
+        return Err(DurabilityJournalError::WriterOwnerIdTooLong(
+            writer_owner_id_length,
+        ));
+    }
+    if writer_domain_id_length == 0 {
+        return Err(DurabilityJournalError::EmptyWriterDomainId);
+    }
+    if writer_domain_id_length > MAX_WRITER_DOMAIN_ID_LENGTH {
+        return Err(DurabilityJournalError::WriterDomainIdTooLong(
+            writer_domain_id_length,
+        ));
+    }
+    let digest = take(body, &mut offset, 32, "plan digest")?;
+    let mut plan_digest = [0u8; 32];
+    plan_digest.copy_from_slice(digest);
+    let payload_length = read_u32(body, &mut offset, "payload length")? as usize;
+    if payload_length > MAX_JOURNAL_BODY_LENGTH {
+        return Err(DurabilityJournalError::PayloadTooLong(payload_length));
+    }
+    let program_id = take(body, &mut offset, program_id_length, "program id")?.to_vec();
+    let transaction_id = String::from_utf8(
+        take(body, &mut offset, transaction_id_length, "transaction id")?.to_vec(),
+    )
+    .map_err(|_| DurabilityJournalError::InvalidUtf8TransactionId)?;
+    let writer_owner_id = String::from_utf8(
+        take(body, &mut offset, writer_owner_id_length, "writer owner id")?.to_vec(),
+    )
+    .map_err(|_| DurabilityJournalError::InvalidUtf8WriterOwnerId)?;
+    let writer_domain_id = String::from_utf8(
+        take(
+            body,
+            &mut offset,
+            writer_domain_id_length,
+            "writer domain id",
+        )?
+        .to_vec(),
+    )
+    .map_err(|_| DurabilityJournalError::InvalidUtf8WriterDomainId)?;
+    let payload = take(body, &mut offset, payload_length, "payload")?.to_vec();
+    if offset != body.len() {
+        return Err(DurabilityJournalError::TrailingBodyBytes);
+    }
+    let record = DurabilityJournalRecord {
+        record_lsn,
+        tx_sequence,
+        writer_epoch,
+        writer_owner_id,
+        writer_domain_id,
+        phase,
+        operation_kind,
+        program_id,
+        transaction_id,
+        plan_digest,
+        payload,
+    };
+    validate_record(&record)?;
+    Ok(record)
+}
+
+#[derive(Clone)]
+struct TransactionState {
+    tx_sequence: u64,
+    phase: DurabilityPhase,
+    operation_kind: DurabilityOperationKind,
+    plan_digest: [u8; 32],
+}
+
+struct TransactionValidator {
+    program_id: Option<Vec<u8>>,
+    writer_domain_id: Option<String>,
+    writer_epoch: Option<u64>,
+    writer_owner_id: Option<String>,
+    current_writer_epoch: u64,
+    current_writer_owner_id: String,
+    last_new_tx_sequence: Option<u64>,
+    by_id: HashMap<String, TransactionState>,
+    id_by_sequence: HashMap<u64, String>,
+}
+
+impl TransactionValidator {
+    fn new(context: &DurabilityJournalValidationContext) -> Result<Self, DurabilityJournalError> {
+        let mut validator = Self {
+            program_id: Some(context.expected_program_id.clone()),
+            writer_domain_id: Some(context.expected_writer_domain_id.clone()),
+            writer_epoch: Some(context.checkpoint_writer_epoch),
+            writer_owner_id: context.checkpoint_writer_owner_id.clone(),
+            current_writer_epoch: context.current_writer_epoch,
+            current_writer_owner_id: context.current_writer_owner_id.clone(),
+            last_new_tx_sequence: Some(context.checkpoint_tx_sequence_highwater),
+            by_id: HashMap::new(),
+            id_by_sequence: HashMap::new(),
+        };
+        for retained in &context.retained_transactions {
+            if retained.tx_sequence == 0
+                || retained.tx_sequence > context.checkpoint_tx_sequence_highwater
+            {
+                return Err(DurabilityJournalError::InvalidTransactionSequence(
+                    retained.tx_sequence,
+                ));
+            }
+            if retained.transaction_id.is_empty() {
+                return Err(DurabilityJournalError::EmptyTransactionId);
+            }
+            if retained.transaction_id.len() > MAX_TRANSACTION_ID_LENGTH {
+                return Err(DurabilityJournalError::TransactionIdTooLong(
+                    retained.transaction_id.len(),
+                ));
+            }
+            if validator.by_id.contains_key(&retained.transaction_id) {
+                return Err(DurabilityJournalError::TransactionIdConflict {
+                    offset: 0,
+                    transaction_id: retained.transaction_id.clone(),
+                });
+            }
+            if validator.id_by_sequence.contains_key(&retained.tx_sequence) {
+                return Err(DurabilityJournalError::TransactionSequenceConflict {
+                    offset: 0,
+                    sequence: retained.tx_sequence,
+                });
+            }
+            validator
+                .id_by_sequence
+                .insert(retained.tx_sequence, retained.transaction_id.clone());
+            validator.by_id.insert(
+                retained.transaction_id.clone(),
+                TransactionState {
+                    tx_sequence: retained.tx_sequence,
+                    phase: retained.phase,
+                    operation_kind: retained.operation_kind,
+                    plan_digest: retained.plan_digest,
+                },
+            );
+        }
+        Ok(validator)
+    }
+
+    fn validate(
+        &mut self,
+        record: &DurabilityJournalRecord,
+        offset: usize,
+    ) -> Result<(), DurabilityJournalError> {
+        if let Some(program_id) = &self.program_id {
+            if program_id != &record.program_id {
+                return Err(DurabilityJournalError::ProgramIdMismatch { offset });
+            }
+        } else {
+            self.program_id = Some(record.program_id.clone());
+        }
+
+        if let Some(writer_domain_id) = &self.writer_domain_id {
+            if writer_domain_id != &record.writer_domain_id {
+                return Err(DurabilityJournalError::WriterDomainIdMismatch { offset });
+            }
+        } else {
+            self.writer_domain_id = Some(record.writer_domain_id.clone());
+        }
+
+        if record.writer_epoch > self.current_writer_epoch {
+            return Err(DurabilityJournalError::WriterEpochAhead {
+                offset,
+                current: self.current_writer_epoch,
+                actual: record.writer_epoch,
+            });
+        }
+        if record.writer_epoch == self.current_writer_epoch
+            && record.writer_owner_id != self.current_writer_owner_id
+        {
+            return Err(DurabilityJournalError::WriterOwnerIdConflict {
+                offset,
+                epoch: record.writer_epoch,
+            });
+        }
+        if let Some(previous_epoch) = self.writer_epoch {
+            if record.writer_epoch < previous_epoch {
+                return Err(DurabilityJournalError::WriterEpochRegression {
+                    offset,
+                    previous: previous_epoch,
+                    actual: record.writer_epoch,
+                });
+            }
+            if record.writer_epoch == previous_epoch {
+                if let Some(previous_owner_id) = &self.writer_owner_id {
+                    if previous_owner_id != &record.writer_owner_id {
+                        return Err(DurabilityJournalError::WriterOwnerIdConflict {
+                            offset,
+                            epoch: record.writer_epoch,
+                        });
+                    }
+                } else {
+                    self.writer_owner_id = Some(record.writer_owner_id.clone());
+                }
+            }
+            if record.writer_epoch > previous_epoch {
+                self.writer_epoch = Some(record.writer_epoch);
+                self.writer_owner_id = Some(record.writer_owner_id.clone());
+            }
+        } else {
+            self.writer_epoch = Some(record.writer_epoch);
+            self.writer_owner_id = Some(record.writer_owner_id.clone());
+        }
+
+        if let Some(existing_id) = self.id_by_sequence.get(&record.tx_sequence) {
+            if existing_id != &record.transaction_id {
+                return Err(DurabilityJournalError::TransactionSequenceConflict {
+                    offset,
+                    sequence: record.tx_sequence,
+                });
+            }
+        }
+
+        if let Some(previous) = self.by_id.get_mut(&record.transaction_id) {
+            if previous.tx_sequence != record.tx_sequence {
+                return Err(DurabilityJournalError::TransactionIdConflict {
+                    offset,
+                    transaction_id: record.transaction_id.clone(),
+                });
+            }
+            if previous.plan_digest != record.plan_digest {
+                return Err(DurabilityJournalError::PlanDigestConflict {
+                    offset,
+                    transaction_id: record.transaction_id.clone(),
+                });
+            }
+            if previous.operation_kind != record.operation_kind {
+                return Err(DurabilityJournalError::OperationKindConflict {
+                    offset,
+                    transaction_id: record.transaction_id.clone(),
+                });
+            }
+            if !valid_transition(previous.phase, record.phase) {
+                return Err(DurabilityJournalError::InvalidPhaseTransition {
+                    offset,
+                    transaction_id: record.transaction_id.clone(),
+                    previous: Some(previous.phase),
+                    next: record.phase,
+                });
+            }
+            previous.phase = record.phase;
+            return Ok(());
+        }
+
+        if record.phase != DurabilityPhase::DurablePrepared {
+            return Err(DurabilityJournalError::InvalidPhaseTransition {
+                offset,
+                transaction_id: record.transaction_id.clone(),
+                previous: None,
+                next: record.phase,
+            });
+        }
+        if let Some(previous_sequence) = self.last_new_tx_sequence {
+            if record.tx_sequence <= previous_sequence {
+                return Err(
+                    DurabilityJournalError::NewTransactionSequenceNotIncreasing {
+                        offset,
+                        previous: previous_sequence,
+                        actual: record.tx_sequence,
+                    },
+                );
+            }
+        }
+        self.last_new_tx_sequence = Some(record.tx_sequence);
+        self.id_by_sequence
+            .insert(record.tx_sequence, record.transaction_id.clone());
+        self.by_id.insert(
+            record.transaction_id.clone(),
+            TransactionState {
+                tx_sequence: record.tx_sequence,
+                phase: record.phase,
+                operation_kind: record.operation_kind,
+                plan_digest: record.plan_digest,
+            },
+        );
+        Ok(())
+    }
+}
+
+fn valid_transition(previous: DurabilityPhase, next: DurabilityPhase) -> bool {
+    matches!(
+        (previous, next),
+        (
+            DurabilityPhase::DurablePrepared,
+            DurabilityPhase::NativeApplied
+        ) | (DurabilityPhase::NativeApplied, DurabilityPhase::Published)
+            | (DurabilityPhase::Published, DurabilityPhase::Committed)
+            | (DurabilityPhase::Committed, DurabilityPhase::CleanupPending)
+            | (DurabilityPhase::Committed, DurabilityPhase::Clean)
+            | (DurabilityPhase::CleanupPending, DurabilityPhase::Clean)
+    )
+}
+
+fn frame_checksum(frame: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(&frame[..FRAME_CHECKSUM_OFFSET]);
+    hasher.update(&frame[HEADER_LENGTH..]);
+    hasher.finalize().into()
+}
+
+fn read_u16_at(bytes: &[u8], offset: usize) -> u16 {
+    u16::from_le_bytes(bytes[offset..offset + 2].try_into().expect("fixed header"))
+}
+
+fn read_u32_at(bytes: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes(bytes[offset..offset + 4].try_into().expect("fixed frame"))
+}
+
+fn read_u8(
+    bytes: &[u8],
+    offset: &mut usize,
+    label: &'static str,
+) -> Result<u8, DurabilityJournalError> {
+    Ok(*take(bytes, offset, 1, label)?
+        .first()
+        .expect("one byte requested"))
+}
+
+fn read_u16(
+    bytes: &[u8],
+    offset: &mut usize,
+    label: &'static str,
+) -> Result<u16, DurabilityJournalError> {
+    Ok(u16::from_le_bytes(
+        take(bytes, offset, 2, label)?
+            .try_into()
+            .expect("two bytes requested"),
+    ))
+}
+
+fn read_u32(
+    bytes: &[u8],
+    offset: &mut usize,
+    label: &'static str,
+) -> Result<u32, DurabilityJournalError> {
+    Ok(u32::from_le_bytes(
+        take(bytes, offset, 4, label)?
+            .try_into()
+            .expect("four bytes requested"),
+    ))
+}
+
+fn read_u64(
+    bytes: &[u8],
+    offset: &mut usize,
+    label: &'static str,
+) -> Result<u64, DurabilityJournalError> {
+    Ok(u64::from_le_bytes(
+        take(bytes, offset, 8, label)?
+            .try_into()
+            .expect("eight bytes requested"),
+    ))
+}
+
+fn take<'a>(
+    bytes: &'a [u8],
+    offset: &mut usize,
+    length: usize,
+    label: &'static str,
+) -> Result<&'a [u8], DurabilityJournalError> {
+    let end = offset
+        .checked_add(length)
+        .ok_or(DurabilityJournalError::LengthOverflow)?;
+    if end > bytes.len() {
+        return Err(DurabilityJournalError::TruncatedBodyField(label));
+    }
+    let value = &bytes[*offset..end];
+    *offset = end;
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(
+        record_lsn: u64,
+        tx_sequence: u64,
+        transaction_id: &str,
+        phase: DurabilityPhase,
+    ) -> DurabilityJournalRecord {
+        DurabilityJournalRecord {
+            record_lsn,
+            tx_sequence,
+            writer_epoch: 1,
+            writer_owner_id: "writer-1".to_string(),
+            writer_domain_id: "program-directory".to_string(),
+            phase,
+            operation_kind: DurabilityOperationKind::Append,
+            program_id: vec![7, 8, 9],
+            transaction_id: transaction_id.to_string(),
+            plan_digest: [tx_sequence as u8; 32],
+            payload: vec![phase as u8, 42],
+        }
+    }
+
+    fn encoded(records: &[DurabilityJournalRecord]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for record in records {
+            bytes.extend_from_slice(&encode_journal_frame(record).unwrap());
+        }
+        bytes
+    }
+
+    fn context(checkpoint_lsn: u64) -> DurabilityJournalValidationContext {
+        DurabilityJournalValidationContext {
+            checkpoint_lsn,
+            checkpoint_tx_sequence_highwater: 0,
+            expected_program_id: vec![7, 8, 9],
+            expected_writer_domain_id: "program-directory".to_string(),
+            checkpoint_writer_epoch: 0,
+            checkpoint_writer_owner_id: None,
+            current_writer_epoch: 1,
+            current_writer_owner_id: "writer-1".to_string(),
+            retained_transactions: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn round_trips_records_and_validates_transitions() {
+        let records = vec![
+            record(1, 1, "tx-1", DurabilityPhase::DurablePrepared),
+            record(2, 1, "tx-1", DurabilityPhase::NativeApplied),
+            record(3, 1, "tx-1", DurabilityPhase::Published),
+            record(4, 1, "tx-1", DurabilityPhase::Committed),
+            record(5, 1, "tx-1", DurabilityPhase::CleanupPending),
+            record(6, 2, "tx-2", DurabilityPhase::DurablePrepared),
+            record(7, 2, "tx-2", DurabilityPhase::NativeApplied),
+            record(8, 2, "tx-2", DurabilityPhase::Published),
+            record(9, 2, "tx-2", DurabilityPhase::Committed),
+            record(10, 2, "tx-2", DurabilityPhase::Clean),
+            record(11, 1, "tx-1", DurabilityPhase::Clean),
+        ];
+        let bytes = encoded(&records);
+        let scan = scan_journal(&bytes, &context(0)).unwrap();
+        assert_eq!(scan.records, records);
+        assert_eq!(scan.valid_length, bytes.len());
+        assert_eq!(scan.incomplete_tail_offset, None);
+        assert_eq!(scan.last_record_lsn, 11);
+    }
+
+    #[test]
+    fn every_short_final_frame_is_an_incomplete_tail() {
+        let first =
+            encode_journal_frame(&record(1, 1, "tx-1", DurabilityPhase::DurablePrepared)).unwrap();
+        let second =
+            encode_journal_frame(&record(2, 2, "tx-2", DurabilityPhase::DurablePrepared)).unwrap();
+        for cut in 0..second.len() {
+            let mut bytes = first.clone();
+            bytes.extend_from_slice(&second[..cut]);
+            let scan = scan_journal(&bytes, &context(0)).unwrap();
+            assert_eq!(scan.records.len(), 1, "cut={cut}");
+            if cut == 0 {
+                assert_eq!(scan.incomplete_tail_offset, None, "cut={cut}");
+            } else {
+                assert_eq!(scan.incomplete_tail_offset, Some(first.len()), "cut={cut}");
+            }
+            assert_eq!(scan.valid_length, first.len(), "cut={cut}");
+        }
+    }
+
+    #[test]
+    fn fully_framed_checksum_mismatch_fails_closed_even_at_tail() {
+        let mut bytes =
+            encode_journal_frame(&record(1, 1, "tx-1", DurabilityPhase::DurablePrepared)).unwrap();
+        bytes[HEADER_LENGTH + 1] ^= 0x80;
+        assert_eq!(
+            scan_journal(&bytes, &context(0)),
+            Err(DurabilityJournalError::InvalidFrameChecksum { offset: 0 })
+        );
+    }
+
+    #[test]
+    fn header_corruption_is_not_misclassified_as_a_torn_body() {
+        let mut bytes =
+            encode_journal_frame(&record(1, 1, "tx-1", DurabilityPhase::DurablePrepared)).unwrap();
+        bytes[16] ^= 0x01;
+        assert_eq!(
+            scan_journal(&bytes, &context(0)),
+            Err(DurabilityJournalError::InvalidHeaderChecksum { offset: 0 })
+        );
+    }
+
+    #[test]
+    fn lsn_gap_and_duplicate_fail_closed() {
+        let gap = encoded(&[
+            record(1, 1, "tx-1", DurabilityPhase::DurablePrepared),
+            record(3, 1, "tx-1", DurabilityPhase::NativeApplied),
+        ]);
+        assert!(matches!(
+            scan_journal(&gap, &context(0)),
+            Err(DurabilityJournalError::RecordLsnMismatch {
+                expected: 2,
+                actual: 3,
+                ..
+            })
+        ));
+
+        let duplicate = encoded(&[
+            record(1, 1, "tx-1", DurabilityPhase::DurablePrepared),
+            record(1, 1, "tx-1", DurabilityPhase::NativeApplied),
+        ]);
+        assert!(matches!(
+            scan_journal(&duplicate, &context(0)),
+            Err(DurabilityJournalError::RecordLsnMismatch {
+                expected: 2,
+                actual: 1,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn invalid_phase_transition_fails_closed() {
+        let bytes = encoded(&[
+            record(1, 1, "tx-1", DurabilityPhase::DurablePrepared),
+            record(2, 1, "tx-1", DurabilityPhase::Published),
+        ]);
+        assert!(matches!(
+            scan_journal(&bytes, &context(0)),
+            Err(DurabilityJournalError::InvalidPhaseTransition {
+                previous: Some(DurabilityPhase::DurablePrepared),
+                next: DurabilityPhase::Published,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn transaction_identity_and_digest_are_immutable() {
+        let sequence_conflict = encoded(&[
+            record(1, 1, "tx-1", DurabilityPhase::DurablePrepared),
+            record(2, 1, "tx-other", DurabilityPhase::DurablePrepared),
+        ]);
+        assert!(matches!(
+            scan_journal(&sequence_conflict, &context(0)),
+            Err(DurabilityJournalError::TransactionSequenceConflict { .. })
+        ));
+
+        let mut changed = record(2, 1, "tx-1", DurabilityPhase::NativeApplied);
+        changed.plan_digest = [99; 32];
+        let digest_conflict = encoded(&[
+            record(1, 1, "tx-1", DurabilityPhase::DurablePrepared),
+            changed,
+        ]);
+        assert!(matches!(
+            scan_journal(&digest_conflict, &context(0)),
+            Err(DurabilityJournalError::PlanDigestConflict { .. })
+        ));
+    }
+
+    #[test]
+    fn continues_lsn_after_checkpoint() {
+        let records = vec![record(
+            u64::MAX - 1,
+            1,
+            "tx-1",
+            DurabilityPhase::DurablePrepared,
+        )];
+        let scan = scan_journal(&encoded(&records), &context(u64::MAX - 2)).unwrap();
+        assert_eq!(scan.last_record_lsn, u64::MAX - 1);
+    }
+
+    #[test]
+    fn new_transaction_sequences_increase_but_late_clean_is_allowed() {
+        let decreasing = encoded(&[
+            record(1, 5, "tx-5", DurabilityPhase::DurablePrepared),
+            record(2, 3, "tx-3", DurabilityPhase::DurablePrepared),
+        ]);
+        assert!(matches!(
+            scan_journal(&decreasing, &context(0)),
+            Err(
+                DurabilityJournalError::NewTransactionSequenceNotIncreasing {
+                    previous: 5,
+                    actual: 3,
+                    ..
+                }
+            )
+        ));
+
+        let late_clean = encoded(&[
+            record(1, 1, "tx-1", DurabilityPhase::DurablePrepared),
+            record(2, 1, "tx-1", DurabilityPhase::NativeApplied),
+            record(3, 1, "tx-1", DurabilityPhase::Published),
+            record(4, 1, "tx-1", DurabilityPhase::Committed),
+            record(5, 1, "tx-1", DurabilityPhase::CleanupPending),
+            record(6, 2, "tx-2", DurabilityPhase::DurablePrepared),
+            record(7, 1, "tx-1", DurabilityPhase::Clean),
+        ]);
+        assert!(scan_journal(&late_clean, &context(0)).is_ok());
+    }
+
+    #[test]
+    fn checkpoint_context_fences_program_sequence_domain_and_writer_epoch() {
+        let bytes = encoded(&[record(11, 8, "tx-8", DurabilityPhase::DurablePrepared)]);
+        let mut valid = context(10);
+        valid.checkpoint_tx_sequence_highwater = 7;
+        valid.checkpoint_writer_epoch = 1;
+        valid.checkpoint_writer_owner_id = Some("writer-1".to_string());
+        assert!(scan_journal(&bytes, &valid).is_ok());
+
+        let mut stale_sequence = valid.clone();
+        stale_sequence.checkpoint_tx_sequence_highwater = 8;
+        assert!(matches!(
+            scan_journal(&bytes, &stale_sequence),
+            Err(DurabilityJournalError::NewTransactionSequenceNotIncreasing { .. })
+        ));
+
+        let mut wrong_program = valid.clone();
+        wrong_program.expected_program_id = vec![1, 2, 3];
+        assert!(matches!(
+            scan_journal(&bytes, &wrong_program),
+            Err(DurabilityJournalError::ProgramIdMismatch { .. })
+        ));
+
+        let mut wrong_domain = valid.clone();
+        wrong_domain.expected_writer_domain_id = "other-domain".to_string();
+        assert!(matches!(
+            scan_journal(&bytes, &wrong_domain),
+            Err(DurabilityJournalError::WriterDomainIdMismatch { .. })
+        ));
+
+        let mut ahead = record(11, 8, "tx-8", DurabilityPhase::DurablePrepared);
+        ahead.writer_epoch = 2;
+        assert!(matches!(
+            scan_journal(&encoded(&[ahead]), &valid),
+            Err(DurabilityJournalError::WriterEpochAhead { .. })
+        ));
+    }
+
+    #[test]
+    fn checkpoint_retained_transaction_can_finish_below_sequence_highwater() {
+        let mut scan_context = context(10);
+        scan_context.checkpoint_tx_sequence_highwater = 5;
+        scan_context.checkpoint_writer_epoch = 1;
+        scan_context.checkpoint_writer_owner_id = Some("writer-1".to_string());
+        scan_context.retained_transactions = vec![DurabilityCheckpointTransactionState {
+            tx_sequence: 1,
+            transaction_id: "tx-1".to_string(),
+            phase: DurabilityPhase::CleanupPending,
+            operation_kind: DurabilityOperationKind::Append,
+            plan_digest: [1; 32],
+        }];
+        let clean = record(11, 1, "tx-1", DurabilityPhase::Clean);
+        assert!(scan_journal(&encoded(&[clean]), &scan_context).is_ok());
+
+        let stale_new = record(11, 3, "tx-3", DurabilityPhase::DurablePrepared);
+        assert!(matches!(
+            scan_journal(&encoded(&[stale_new]), &scan_context),
+            Err(DurabilityJournalError::NewTransactionSequenceNotIncreasing { .. })
+        ));
+    }
+
+    #[test]
+    fn writer_epochs_may_advance_but_never_regress_or_change_owner_in_epoch() {
+        let mut old = record(1, 1, "tx-1", DurabilityPhase::DurablePrepared);
+        old.writer_owner_id = "old-writer".to_string();
+        let mut current = record(2, 1, "tx-1", DurabilityPhase::NativeApplied);
+        current.writer_epoch = 2;
+        current.writer_owner_id = "writer-2".to_string();
+        let mut scan_context = context(0);
+        scan_context.current_writer_epoch = 2;
+        scan_context.current_writer_owner_id = "writer-2".to_string();
+        assert!(scan_journal(&encoded(&[old.clone(), current.clone()]), &scan_context).is_ok());
+
+        let mut regressed = record(3, 1, "tx-1", DurabilityPhase::Published);
+        regressed.writer_owner_id = "old-writer".to_string();
+        assert!(matches!(
+            scan_journal(&encoded(&[old.clone(), current, regressed]), &scan_context),
+            Err(DurabilityJournalError::WriterEpochRegression { .. })
+        ));
+
+        let mut changed_owner = record(2, 1, "tx-1", DurabilityPhase::NativeApplied);
+        changed_owner.writer_owner_id = "different-writer".to_string();
+        assert!(matches!(
+            scan_journal(&encoded(&[old, changed_owner]), &scan_context),
+            Err(DurabilityJournalError::WriterOwnerIdConflict { .. })
+        ));
+    }
+
+    #[test]
+    fn incomplete_header_requires_the_fixed_prefix() {
+        let frame =
+            encode_journal_frame(&record(1, 1, "tx-1", DurabilityPhase::DurablePrepared)).unwrap();
+        for length in 1..HEADER_LENGTH {
+            assert!(
+                scan_journal(&frame[..length], &context(0)).is_ok(),
+                "length={length}"
+            );
+        }
+
+        assert!(matches!(
+            scan_journal(b"X", &context(0)),
+            Err(DurabilityJournalError::InvalidMagic { .. })
+        ));
+        let mut bad_version = JOURNAL_MAGIC.to_vec();
+        bad_version.extend_from_slice(&[2]);
+        assert!(matches!(
+            scan_journal(&bad_version, &context(0)),
+            Err(DurabilityJournalError::UnsupportedVersion { .. })
+        ));
+        let mut bad_header_length = JOURNAL_MAGIC.to_vec();
+        bad_header_length.extend_from_slice(&JOURNAL_FORMAT_VERSION.to_le_bytes());
+        bad_header_length.push(0);
+        assert!(matches!(
+            scan_journal(&bad_header_length, &context(0)),
+            Err(DurabilityJournalError::InvalidHeaderLength { .. })
+        ));
+
+        let mut inconsistent_lengths = frame[..HEADER_PREFIX_LENGTH].to_vec();
+        inconsistent_lengths[12] ^= 1;
+        assert!(matches!(
+            scan_journal(&inconsistent_lengths, &context(0)),
+            Err(DurabilityJournalError::InvalidFrameLength { .. })
+        ));
+
+        let mut stale_checksum = frame[..FRAME_CHECKSUM_OFFSET].to_vec();
+        let frame_length = read_u32_at(&stale_checksum, 12) + 1;
+        let body_length = read_u32_at(&stale_checksum, 16) + 1;
+        stale_checksum[12..16].copy_from_slice(&frame_length.to_le_bytes());
+        stale_checksum[16..20].copy_from_slice(&body_length.to_le_bytes());
+        assert!(matches!(
+            scan_journal(&stale_checksum, &context(0)),
+            Err(DurabilityJournalError::InvalidHeaderChecksum { .. })
+        ));
+    }
+
+    #[test]
+    fn every_full_frame_byte_flip_and_non_tail_corruption_fails_closed() {
+        let frame =
+            encode_journal_frame(&record(1, 1, "tx-1", DurabilityPhase::DurablePrepared)).unwrap();
+        for index in 0..frame.len() {
+            let mut corrupt = frame.clone();
+            corrupt[index] ^= 1;
+            assert!(
+                scan_journal(&corrupt, &context(0)).is_err(),
+                "byte flip at {index} was accepted"
+            );
+        }
+
+        let second =
+            encode_journal_frame(&record(2, 1, "tx-1", DurabilityPhase::NativeApplied)).unwrap();
+        let mut corrupt_non_tail = frame;
+        corrupt_non_tail[HEADER_LENGTH + 4] ^= 1;
+        corrupt_non_tail.extend_from_slice(&second);
+        assert!(matches!(
+            scan_journal(&corrupt_non_tail, &context(0)),
+            Err(DurabilityJournalError::InvalidFrameChecksum { offset: 0 })
+        ));
+    }
+
+    #[test]
+    fn max_lsn_is_valid_only_when_it_is_the_final_frame() {
+        let final_record = record(u64::MAX, 1, "tx-1", DurabilityPhase::DurablePrepared);
+        let scan = scan_journal(&encoded(&[final_record]), &context(u64::MAX - 1)).unwrap();
+        assert_eq!(scan.last_record_lsn, u64::MAX);
+
+        let empty = scan_journal(&[], &context(u64::MAX)).unwrap();
+        assert_eq!(empty.last_record_lsn, u64::MAX);
+
+        assert_eq!(
+            scan_journal(JOURNAL_MAGIC, &context(u64::MAX)),
+            Err(DurabilityJournalError::RecordLsnOverflow(u64::MAX))
+        );
+    }
+}

--- a/packages/utils/native-backbone/src/durability/codec.ts
+++ b/packages/utils/native-backbone/src/durability/codec.ts
@@ -1,0 +1,683 @@
+import type {
+	NativeDurabilityJournalClassification,
+	NativeDurabilityJournalClassifier,
+} from "./storage.js";
+
+export const NATIVE_DURABILITY_JOURNAL_FORMAT_VERSION = 1 as const;
+export const NATIVE_DURABILITY_JOURNAL_MAX_U64 = (1n << 64n) - 1n;
+export const NATIVE_DURABILITY_JOURNAL_MAX_BODY_LENGTH = 64 * 1024 * 1024;
+export const NATIVE_DURABILITY_JOURNAL_MAX_PROGRAM_ID_LENGTH = 4096;
+export const NATIVE_DURABILITY_JOURNAL_MAX_TRANSACTION_ID_LENGTH = 1024;
+export const NATIVE_DURABILITY_JOURNAL_MAX_WRITER_OWNER_ID_LENGTH = 1024;
+export const NATIVE_DURABILITY_JOURNAL_MAX_WRITER_DOMAIN_ID_LENGTH = 1024;
+export const NATIVE_DURABILITY_JOURNAL_CODEC_BRAND = Symbol.for(
+	"@peerbit/native-backbone/native-durability-journal-codec/v1",
+);
+
+export enum NativeDurabilityPhase {
+	DurablePrepared = 1,
+	NativeApplied = 2,
+	Published = 3,
+	Committed = 4,
+	CleanupPending = 5,
+	Clean = 6,
+}
+
+export enum NativeDurabilityOperationKind {
+	Append = 1,
+	Batch = 2,
+	Document = 3,
+	Receive = 4,
+	Repair = 5,
+}
+
+export type NativeDurabilityJournalRecord = {
+	recordLsn: bigint;
+	txSequence: bigint;
+	writerEpoch: bigint;
+	writerOwnerId: string;
+	writerDomainId: string;
+	phase: NativeDurabilityPhase;
+	operationKind: NativeDurabilityOperationKind;
+	programId: Uint8Array;
+	transactionId: string;
+	planDigest: Uint8Array;
+	payload: Uint8Array;
+};
+
+export type NativeDurabilityCheckpointTransactionState = Pick<
+	NativeDurabilityJournalRecord,
+	"txSequence" | "transactionId" | "phase" | "operationKind" | "planDigest"
+>;
+
+export type NativeDurabilityJournalValidationContext = {
+	checkpointLsn: bigint;
+	checkpointTxSequenceHighwater: bigint;
+	expectedProgramId: Uint8Array;
+	expectedWriterDomainId: string;
+	checkpointWriterEpoch: bigint;
+	checkpointWriterOwnerId?: string;
+	currentWriterEpoch: bigint;
+	currentWriterOwnerId: string;
+	retainedTransactions?: readonly NativeDurabilityCheckpointTransactionState[];
+};
+
+export type NativeDurabilityIncompleteTailReason =
+	| "short-header"
+	| "short-body"
+	| "short-trailer";
+
+export type NativeDurabilityJournalScan = {
+	records: NativeDurabilityJournalRecord[];
+	validLength: number;
+	incompleteTailOffset?: number;
+	incompleteTailReason?: NativeDurabilityIncompleteTailReason;
+	lastRecordLsn: bigint;
+};
+
+export type NativeDurabilityJournalErrorCode =
+	| "ERR_NATIVE_DURABILITY_JOURNAL_INPUT"
+	| `ERR_NATIVE_DURABILITY_JOURNAL_${string}`;
+
+export class NativeDurabilityJournalCodecError extends Error {
+	constructor(
+		readonly code: NativeDurabilityJournalErrorCode,
+		message: string,
+		readonly byteOffset?: number,
+		readonly cause?: unknown,
+	) {
+		super(message);
+		this.name = "NativeDurabilityJournalCodecError";
+	}
+}
+
+export class NativeDurabilityJournalInputError extends NativeDurabilityJournalCodecError {
+	constructor(readonly field: string, message: string) {
+		super("ERR_NATIVE_DURABILITY_JOURNAL_INPUT", message);
+		this.name = "NativeDurabilityJournalInputError";
+	}
+}
+
+export class NativeDurabilityJournalCorruptionError extends NativeDurabilityJournalCodecError {
+	constructor(
+		code: NativeDurabilityJournalErrorCode,
+		message: string,
+		byteOffset?: number,
+		cause?: unknown,
+	) {
+		super(code, message, byteOffset, cause);
+		this.name = "NativeDurabilityJournalCorruptionError";
+	}
+}
+
+type NativeDurabilityJournalCodecHandle = {
+	encodeFrame(
+		recordLsn: string,
+		txSequence: string,
+		writerEpoch: string,
+		writerOwnerId: string,
+		writerDomainId: string,
+		phase: number,
+		operationKind: number,
+		programId: Uint8Array,
+		transactionId: string,
+		planDigest: Uint8Array,
+		payload: Uint8Array,
+	): Uint8Array;
+	scan(
+		bytes: Uint8Array,
+		checkpointLsn: string,
+		checkpointTxSequenceHighwater: string,
+		expectedProgramId: Uint8Array,
+		expectedWriterDomainId: string,
+		checkpointWriterEpoch: string,
+		checkpointWriterOwnerId: string | undefined,
+		currentWriterEpoch: string,
+		currentWriterOwnerId: string,
+		retainedTransactions: unknown[],
+	): unknown[];
+};
+
+type NativeBackboneWasmModule = {
+	default(input?: unknown): Promise<unknown>;
+	initSync(input?: unknown): unknown;
+	NativeDurabilityJournalCodec: new () => NativeDurabilityJournalCodecHandle;
+};
+
+let wasmModulePromise: Promise<NativeBackboneWasmModule> | undefined;
+let wasmInitialization: Promise<NativeBackboneWasmModule> | undefined;
+const nativeDurabilityJournalCodecConstructionToken = Symbol();
+const trustedNativeDurabilityJournalCodecs = new WeakSet<object>();
+
+const loadWasm = async (): Promise<NativeBackboneWasmModule> => {
+	const wasmModulePath = "../../wasm/native_backbone.js";
+	wasmModulePromise ??= import(
+		/* @vite-ignore */ wasmModulePath
+	) as Promise<NativeBackboneWasmModule>;
+	wasmInitialization ??= wasmModulePromise.then(async (wasm) => {
+		const processLike = globalThis as {
+			process?: { versions?: { node?: string } };
+		};
+		if (processLike.process?.versions?.node) {
+			const fsPromises = "fs/promises";
+			const { readFile } = (await import(
+				/* @vite-ignore */ fsPromises
+			)) as typeof import("fs/promises");
+			const bytes = await readFile(
+				new URL("../../wasm/native_backbone_bg.wasm", import.meta.url),
+			);
+			wasm.initSync({ module: bytes });
+		} else {
+			await wasm.default({
+				module_or_path: new URL(
+					"../../wasm/native_backbone_bg.wasm",
+					import.meta.url,
+				),
+			});
+		}
+		return wasm;
+	});
+	return wasmInitialization;
+};
+
+let textEncoder: TextEncoder | undefined;
+
+const utf8ByteLength = (value: string): number => {
+	textEncoder ??= new TextEncoder();
+	return textEncoder.encode(value).byteLength;
+};
+
+const assertU64 = (
+	value: bigint,
+	field: string,
+	options: { nonzero?: boolean } = {},
+): void => {
+	if (
+		typeof value !== "bigint" ||
+		value < 0n ||
+		value > NATIVE_DURABILITY_JOURNAL_MAX_U64 ||
+		(options.nonzero === true && value === 0n)
+	) {
+		throw new NativeDurabilityJournalInputError(
+			field,
+			`${field} must be ${options.nonzero ? "a non-zero" : "an"} unsigned 64-bit bigint`,
+		);
+	}
+};
+
+const assertBytes = (
+	value: Uint8Array,
+	field: string,
+	options: { exact?: number; min?: number; max?: number } = {},
+): void => {
+	if (!(value instanceof Uint8Array)) {
+		throw new NativeDurabilityJournalInputError(field, `${field} must be Uint8Array`);
+	}
+	if (options.exact != null && value.byteLength !== options.exact) {
+		throw new NativeDurabilityJournalInputError(
+			field,
+			`${field} must contain exactly ${options.exact} bytes`,
+		);
+	}
+	if (options.min != null && value.byteLength < options.min) {
+		throw new NativeDurabilityJournalInputError(
+			field,
+			`${field} must contain at least ${options.min} bytes`,
+		);
+	}
+	if (options.max != null && value.byteLength > options.max) {
+		throw new NativeDurabilityJournalInputError(
+			field,
+			`${field} exceeds ${options.max} bytes`,
+		);
+	}
+};
+
+const assertBoundedString = (
+	value: string,
+	field: string,
+	maxBytes: number,
+): void => {
+	if (typeof value !== "string" || value.length === 0) {
+		throw new NativeDurabilityJournalInputError(field, `${field} must not be empty`);
+	}
+	const byteLength = utf8ByteLength(value);
+	if (byteLength > maxBytes) {
+		throw new NativeDurabilityJournalInputError(
+			field,
+			`${field} exceeds ${maxBytes} UTF-8 bytes`,
+		);
+	}
+};
+
+const assertPhase = (value: NativeDurabilityPhase, field: string): void => {
+	if (!Number.isInteger(value) || value < 1 || value > 6) {
+		throw new NativeDurabilityJournalInputError(field, `${field} is invalid`);
+	}
+};
+
+const assertOperationKind = (
+	value: NativeDurabilityOperationKind,
+	field: string,
+): void => {
+	if (!Number.isInteger(value) || value < 1 || value > 5) {
+		throw new NativeDurabilityJournalInputError(field, `${field} is invalid`);
+	}
+};
+
+const assertRecord = (record: NativeDurabilityJournalRecord): void => {
+	assertU64(record.recordLsn, "recordLsn", { nonzero: true });
+	assertU64(record.txSequence, "txSequence", { nonzero: true });
+	assertU64(record.writerEpoch, "writerEpoch", { nonzero: true });
+	assertBoundedString(
+		record.writerOwnerId,
+		"writerOwnerId",
+		NATIVE_DURABILITY_JOURNAL_MAX_WRITER_OWNER_ID_LENGTH,
+	);
+	assertBoundedString(
+		record.writerDomainId,
+		"writerDomainId",
+		NATIVE_DURABILITY_JOURNAL_MAX_WRITER_DOMAIN_ID_LENGTH,
+	);
+	assertPhase(record.phase, "phase");
+	assertOperationKind(record.operationKind, "operationKind");
+	assertBytes(record.programId, "programId", {
+		min: 1,
+		max: NATIVE_DURABILITY_JOURNAL_MAX_PROGRAM_ID_LENGTH,
+	});
+	assertBoundedString(
+		record.transactionId,
+		"transactionId",
+		NATIVE_DURABILITY_JOURNAL_MAX_TRANSACTION_ID_LENGTH,
+	);
+	assertBytes(record.planDigest, "planDigest", { exact: 32 });
+	assertBytes(record.payload, "payload", {
+		max: NATIVE_DURABILITY_JOURNAL_MAX_BODY_LENGTH,
+	});
+};
+
+const assertContext = (context: NativeDurabilityJournalValidationContext): void => {
+	assertU64(context.checkpointLsn, "checkpointLsn");
+	assertU64(
+		context.checkpointTxSequenceHighwater,
+		"checkpointTxSequenceHighwater",
+	);
+	assertBytes(context.expectedProgramId, "expectedProgramId", {
+		min: 1,
+		max: NATIVE_DURABILITY_JOURNAL_MAX_PROGRAM_ID_LENGTH,
+	});
+	assertBoundedString(
+		context.expectedWriterDomainId,
+		"expectedWriterDomainId",
+		NATIVE_DURABILITY_JOURNAL_MAX_WRITER_DOMAIN_ID_LENGTH,
+	);
+	assertU64(context.checkpointWriterEpoch, "checkpointWriterEpoch");
+	assertU64(context.currentWriterEpoch, "currentWriterEpoch", { nonzero: true });
+	if (context.checkpointWriterEpoch > context.currentWriterEpoch) {
+		throw new NativeDurabilityJournalInputError(
+			"checkpointWriterEpoch",
+			"checkpointWriterEpoch must not exceed currentWriterEpoch",
+		);
+	}
+	if (context.checkpointWriterEpoch > 0n && context.checkpointWriterOwnerId == null) {
+		throw new NativeDurabilityJournalInputError(
+			"checkpointWriterOwnerId",
+			"checkpointWriterOwnerId is required for a non-genesis checkpoint epoch",
+		);
+	}
+	if (context.checkpointWriterOwnerId != null) {
+		assertBoundedString(
+			context.checkpointWriterOwnerId,
+			"checkpointWriterOwnerId",
+			NATIVE_DURABILITY_JOURNAL_MAX_WRITER_OWNER_ID_LENGTH,
+		);
+	}
+	assertBoundedString(
+		context.currentWriterOwnerId,
+		"currentWriterOwnerId",
+		NATIVE_DURABILITY_JOURNAL_MAX_WRITER_OWNER_ID_LENGTH,
+	);
+	for (const [index, retained] of (context.retainedTransactions ?? []).entries()) {
+		assertU64(retained.txSequence, `retainedTransactions[${index}].txSequence`, {
+			nonzero: true,
+		});
+		if (retained.txSequence > context.checkpointTxSequenceHighwater) {
+			throw new NativeDurabilityJournalInputError(
+				`retainedTransactions[${index}].txSequence`,
+				"retained transaction sequence exceeds checkpoint highwater",
+			);
+		}
+		assertBoundedString(
+			retained.transactionId,
+			`retainedTransactions[${index}].transactionId`,
+			NATIVE_DURABILITY_JOURNAL_MAX_TRANSACTION_ID_LENGTH,
+		);
+		assertPhase(retained.phase, `retainedTransactions[${index}].phase`);
+		assertOperationKind(
+			retained.operationKind,
+			`retainedTransactions[${index}].operationKind`,
+		);
+		assertBytes(retained.planDigest, `retainedTransactions[${index}].planDigest`, {
+			exact: 32,
+		});
+	}
+};
+
+const copyContext = (
+	context: NativeDurabilityJournalValidationContext,
+): NativeDurabilityJournalValidationContext => ({
+	...context,
+	expectedProgramId: new Uint8Array(context.expectedProgramId),
+	retainedTransactions: (context.retainedTransactions ?? []).map((retained) => ({
+		...retained,
+		planDigest: new Uint8Array(retained.planDigest),
+	})),
+});
+
+const parseDecimalU64 = (value: unknown, field: string): bigint => {
+	if (typeof value !== "string" || !/^(0|[1-9][0-9]*)$/.test(value)) {
+		throw new NativeDurabilityJournalCorruptionError(
+			"ERR_NATIVE_DURABILITY_JOURNAL_INVALID_DECIMAL_U64",
+			`${field} is not a canonical decimal u64`,
+		);
+	}
+	const parsed = BigInt(value);
+	if (parsed > NATIVE_DURABILITY_JOURNAL_MAX_U64) {
+		throw new NativeDurabilityJournalCorruptionError(
+			"ERR_NATIVE_DURABILITY_JOURNAL_INVALID_DECIMAL_U64",
+			`${field} exceeds u64`,
+		);
+	}
+	return parsed;
+};
+
+const parseSafeOffset = (
+	value: unknown,
+	field: string,
+	maximum: number,
+): number => {
+	if (
+		typeof value !== "number" ||
+		!Number.isSafeInteger(value) ||
+		value < 0 ||
+		value > maximum
+	) {
+		throw new NativeDurabilityJournalCorruptionError(
+			"ERR_NATIVE_DURABILITY_JOURNAL_INVALID_SCAN_ROW",
+			`${field} is not a safe byte offset`,
+		);
+	}
+	return value;
+};
+
+const bytesFromRow = (value: unknown, field: string): Uint8Array => {
+	if (!(value instanceof Uint8Array)) {
+		throw new NativeDurabilityJournalCorruptionError(
+			"ERR_NATIVE_DURABILITY_JOURNAL_INVALID_SCAN_ROW",
+			`${field} is not bytes`,
+		);
+	}
+	return new Uint8Array(value);
+};
+
+const stringFromRow = (value: unknown, field: string): string => {
+	if (typeof value !== "string") {
+		throw new NativeDurabilityJournalCorruptionError(
+			"ERR_NATIVE_DURABILITY_JOURNAL_INVALID_SCAN_ROW",
+			`${field} is not a string`,
+		);
+	}
+	return value;
+};
+
+const enumFromRow = <T extends number>(
+	value: unknown,
+	field: string,
+	min: number,
+	max: number,
+): T => {
+	if (typeof value !== "number" || !Number.isInteger(value) || value < min || value > max) {
+		throw new NativeDurabilityJournalCorruptionError(
+			"ERR_NATIVE_DURABILITY_JOURNAL_INVALID_SCAN_ROW",
+			`${field} is invalid`,
+		);
+	}
+	return value as T;
+};
+
+const errorFromWasm = (
+	error: unknown,
+	kind: "input" | "corruption",
+): NativeDurabilityJournalCodecError => {
+	if (Array.isArray(error) && typeof error[0] === "string" && typeof error[1] === "string") {
+		const offset =
+			typeof error[2] === "number" && Number.isSafeInteger(error[2])
+				? error[2]
+				: undefined;
+		if (kind === "corruption") {
+			return new NativeDurabilityJournalCorruptionError(
+				error[0] as NativeDurabilityJournalErrorCode,
+				error[1],
+				offset,
+				error,
+			);
+		}
+		return new NativeDurabilityJournalCodecError(
+			error[0] as NativeDurabilityJournalErrorCode,
+			error[1],
+			offset,
+			error,
+		);
+	}
+	return kind === "corruption"
+		? new NativeDurabilityJournalCorruptionError(
+				"ERR_NATIVE_DURABILITY_JOURNAL_WASM",
+				"Native durability journal codec failed",
+				undefined,
+				error,
+			)
+		: new NativeDurabilityJournalCodecError(
+				"ERR_NATIVE_DURABILITY_JOURNAL_WASM",
+				"Native durability journal codec failed",
+				undefined,
+				error,
+			);
+};
+
+const parseScan = (raw: unknown, byteLength: number): NativeDurabilityJournalScan => {
+	if (!Array.isArray(raw) || raw.length !== 5 || !Array.isArray(raw[4])) {
+		throw new NativeDurabilityJournalCorruptionError(
+			"ERR_NATIVE_DURABILITY_JOURNAL_INVALID_SCAN_ROW",
+			"Native durability journal scan result is malformed",
+		);
+	}
+	const validLength = parseSafeOffset(raw[0], "validLength", byteLength);
+	const incompleteTailOffset =
+		raw[1] == null
+			? undefined
+			: parseSafeOffset(raw[1], "incompleteTailOffset", byteLength);
+	const reasonCode = enumFromRow<number>(raw[2], "incompleteTailReason", 0, 3);
+	const incompleteTailReason =
+		reasonCode === 0
+			? undefined
+			: reasonCode === 1
+				? "short-header"
+				: reasonCode === 2
+					? "short-body"
+					: "short-trailer";
+	if ((incompleteTailOffset == null) !== (incompleteTailReason == null)) {
+		throw new NativeDurabilityJournalCorruptionError(
+			"ERR_NATIVE_DURABILITY_JOURNAL_INVALID_SCAN_ROW",
+			"Incomplete-tail offset and reason disagree",
+		);
+	}
+	const records = (raw[4] as unknown[]).map((unknownRow, index) => {
+		if (!Array.isArray(unknownRow) || unknownRow.length !== 11) {
+			throw new NativeDurabilityJournalCorruptionError(
+				"ERR_NATIVE_DURABILITY_JOURNAL_INVALID_SCAN_ROW",
+				`Journal record row ${index} is malformed`,
+			);
+		}
+		const row = unknownRow;
+		return {
+			recordLsn: parseDecimalU64(row[0], `records[${index}].recordLsn`),
+			txSequence: parseDecimalU64(row[1], `records[${index}].txSequence`),
+			writerEpoch: parseDecimalU64(row[2], `records[${index}].writerEpoch`),
+			writerOwnerId: stringFromRow(row[3], `records[${index}].writerOwnerId`),
+			writerDomainId: stringFromRow(row[4], `records[${index}].writerDomainId`),
+			phase: enumFromRow<NativeDurabilityPhase>(
+				row[5],
+				`records[${index}].phase`,
+				1,
+				6,
+			),
+			operationKind: enumFromRow<NativeDurabilityOperationKind>(
+				row[6],
+				`records[${index}].operationKind`,
+				1,
+				5,
+			),
+			programId: bytesFromRow(row[7], `records[${index}].programId`),
+			transactionId: stringFromRow(row[8], `records[${index}].transactionId`),
+			planDigest: bytesFromRow(row[9], `records[${index}].planDigest`),
+			payload: bytesFromRow(row[10], `records[${index}].payload`),
+		} satisfies NativeDurabilityJournalRecord;
+	});
+	return {
+		records,
+		validLength,
+		incompleteTailOffset,
+		incompleteTailReason,
+		lastRecordLsn: parseDecimalU64(raw[3], "lastRecordLsn"),
+	};
+};
+
+export class NativeDurabilityJournalCodec implements NativeDurabilityJournalClassifier {
+	readonly formatVersion = NATIVE_DURABILITY_JOURNAL_FORMAT_VERSION;
+	readonly [NATIVE_DURABILITY_JOURNAL_CODEC_BRAND] = true as const;
+	private readonly validationContext: NativeDurabilityJournalValidationContext;
+
+	private constructor(
+		constructionToken: typeof nativeDurabilityJournalCodecConstructionToken,
+		private readonly native: NativeDurabilityJournalCodecHandle,
+		context: NativeDurabilityJournalValidationContext,
+	) {
+		if (constructionToken !== nativeDurabilityJournalCodecConstructionToken) {
+			throw new TypeError(
+				"NativeDurabilityJournalCodec must be created by createNativeDurabilityJournalCodec",
+			);
+		}
+		assertContext(context);
+		this.validationContext = copyContext(context);
+	}
+
+	static async create(
+		context: NativeDurabilityJournalValidationContext,
+	): Promise<NativeDurabilityJournalCodec> {
+		assertContext(context);
+		// Snapshot before the first await so caller mutation cannot change the
+		// validation authority while the Wasm module is loading.
+		const validationContext = copyContext(context);
+		const wasm = await loadWasm();
+		const codec = new NativeDurabilityJournalCodec(
+			nativeDurabilityJournalCodecConstructionToken,
+			new wasm.NativeDurabilityJournalCodec(),
+			validationContext,
+		);
+		trustedNativeDurabilityJournalCodecs.add(codec);
+		return codec;
+	}
+
+	get context(): NativeDurabilityJournalValidationContext {
+		return copyContext(this.validationContext);
+	}
+
+	encode(record: NativeDurabilityJournalRecord): Uint8Array {
+		assertRecord(record);
+		try {
+			return new Uint8Array(
+				this.native.encodeFrame(
+					record.recordLsn.toString(),
+					record.txSequence.toString(),
+					record.writerEpoch.toString(),
+					record.writerOwnerId,
+					record.writerDomainId,
+					record.phase,
+					record.operationKind,
+					record.programId,
+					record.transactionId,
+					record.planDigest,
+					record.payload,
+				),
+			);
+		} catch (error) {
+			throw errorFromWasm(error, "input");
+		}
+	}
+
+	scan(
+		bytes: Uint8Array,
+		context: NativeDurabilityJournalValidationContext = this.validationContext,
+	): NativeDurabilityJournalScan {
+		assertBytes(bytes, "journalBytes");
+		assertContext(context);
+		const retainedTransactions = (context.retainedTransactions ?? []).map(
+			(retained) => [
+				retained.txSequence.toString(),
+				retained.transactionId,
+				retained.phase,
+				retained.operationKind,
+				retained.planDigest,
+			],
+		);
+		try {
+			return parseScan(
+				this.native.scan(
+					bytes,
+					context.checkpointLsn.toString(),
+					context.checkpointTxSequenceHighwater.toString(),
+					context.expectedProgramId,
+					context.expectedWriterDomainId,
+					context.checkpointWriterEpoch.toString(),
+					context.checkpointWriterOwnerId,
+					context.currentWriterEpoch.toString(),
+					context.currentWriterOwnerId,
+					retainedTransactions,
+				),
+				bytes.byteLength,
+			);
+		} catch (error) {
+			if (error instanceof NativeDurabilityJournalCodecError) throw error;
+			throw errorFromWasm(error, "corruption");
+		}
+	}
+
+	classify(bytes: Uint8Array): NativeDurabilityJournalClassification {
+		const scan = this.scan(bytes);
+		if (scan.incompleteTailOffset != null && scan.incompleteTailReason != null) {
+			return {
+				kind: "incomplete-tail",
+				validLength: scan.validLength,
+				lastRecordLsn: scan.lastRecordLsn,
+				reason: scan.incompleteTailReason,
+			};
+		}
+		return {
+			kind: "complete",
+			validLength: scan.validLength,
+			lastRecordLsn: scan.lastRecordLsn,
+		};
+	}
+}
+
+export const isNativeDurabilityJournalCodec = (
+	value: unknown,
+): value is NativeDurabilityJournalCodec =>
+	(typeof value === "object" || typeof value === "function") &&
+	value !== null &&
+	trustedNativeDurabilityJournalCodecs.has(value);
+
+export const createNativeDurabilityJournalCodec = async (
+	context: NativeDurabilityJournalValidationContext,
+): Promise<NativeDurabilityJournalCodec> =>
+	NativeDurabilityJournalCodec.create(context);

--- a/packages/utils/native-backbone/src/durability/lease.ts
+++ b/packages/utils/native-backbone/src/durability/lease.ts
@@ -1,0 +1,87 @@
+export type NativeDurabilityFence = Readonly<{
+	epoch: bigint;
+	ownerId: string;
+	domainId: string;
+}>;
+
+export const NATIVE_DURABILITY_MAX_U64 = (1n << 64n) - 1n;
+export const NATIVE_DURABILITY_MAX_WRITER_ID_BYTES = 1024;
+
+/**
+ * Exclusive ownership capability for one native durability directory.
+ *
+ * Implementations keep the underlying ownership primitive alive until
+ * `close()` completes. Storage writers must wrap the complete asynchronous
+ * mutation and its barrier in `runWhileHeld()` and persist the accompanying
+ * fence with their records. `assertHeld()` is diagnostic only; it is not a
+ * lifecycle guard for an operation that later awaits I/O.
+ */
+export interface NativeDurabilityLease {
+	readonly fence: NativeDurabilityFence;
+	assertHeld(): Promise<void>;
+	/**
+	 * Keep the lease alive for the complete asynchronous operation. `close()`
+	 * starts rejecting new operations immediately and waits for operations that
+	 * already entered this guard before releasing the underlying OS lock.
+	 */
+	runWhileHeld<T>(operation: () => Promise<T>): Promise<T>;
+	close(): Promise<void>;
+}
+
+export class NativeDurabilityLeaseUnavailableError extends Error {
+	readonly code = "NATIVE_DURABILITY_LEASE_UNAVAILABLE";
+
+	constructor(
+		readonly directory: string,
+		options?: { cause?: unknown },
+	) {
+		super(`Native durability directory is already open: ${directory}`, options);
+		this.name = "NativeDurabilityLeaseUnavailableError";
+	}
+}
+
+export class NativeDurabilityLeaseClosedError extends Error {
+	readonly code = "NATIVE_DURABILITY_LEASE_CLOSED";
+
+	constructor(readonly fence: NativeDurabilityFence) {
+		super(`Native durability lease is no longer held: ${fence.domainId}`);
+		this.name = "NativeDurabilityLeaseClosedError";
+	}
+}
+
+export class NativeDurabilityLeaseStateError extends Error {
+	readonly code = "NATIVE_DURABILITY_LEASE_STATE_INVALID";
+
+	constructor(
+		readonly directory: string,
+		message: string,
+		options?: { cause?: unknown },
+	) {
+		super(message, options);
+		this.name = "NativeDurabilityLeaseStateError";
+	}
+}
+
+export class NativeDurabilityLeaseDirectorySyncError extends Error {
+	readonly code = "NATIVE_DURABILITY_LEASE_DIRECTORY_SYNC_FAILED";
+
+	constructor(
+		readonly directory: string,
+		options?: { cause?: unknown },
+	) {
+		super(
+			`Native durability requires directory fsync support: ${directory}`,
+			options,
+		);
+		this.name = "NativeDurabilityLeaseDirectorySyncError";
+	}
+}
+
+export class NativeDurabilityFenceExhaustedError extends Error {
+	readonly code = "NATIVE_DURABILITY_FENCE_EXHAUSTED";
+
+	constructor(readonly directory: string) {
+		super(`Native durability fence epoch is exhausted: ${directory}`);
+		this.name = "NativeDurabilityFenceExhaustedError";
+	}
+}

--- a/packages/utils/native-backbone/src/durability/memory-storage.ts
+++ b/packages/utils/native-backbone/src/durability/memory-storage.ts
@@ -1,0 +1,593 @@
+import {
+	NATIVE_DURABILITY_MAX_U64,
+	type NativeDurabilityLease,
+} from "./lease.js";
+import {
+	NATIVE_DURABILITY_STORAGE_VERSION,
+	type NativeDurabilityCheckpoint,
+	type NativeDurabilityCheckpointReceipt,
+	type NativeDurabilityCheckpointRequest,
+	type NativeDurabilityDeleteReceipt,
+	type NativeDurabilityDeleteRequest,
+	NativeDurabilityDigestMismatchError,
+	NativeDurabilityIncompleteTailMismatchError,
+	type NativeDurabilityIncompleteTailReconciliationRequest,
+	type NativeDurabilityJournalAppendRequest,
+	type NativeDurabilityJournalClassifier,
+	NativeDurabilityJournalOffsetConflictError,
+	type NativeDurabilityJournalReceipt,
+	type NativeDurabilityJournalReconciliationReceipt,
+	type NativeDurabilityStageReceipt,
+	type NativeDurabilityStageRequest,
+	type NativeDurabilityStagedBlockReference,
+	type NativeDurabilityStagingManifest,
+	type NativeDurabilityStorage,
+	NativeDurabilityStorageClosedError,
+	type NativeDurabilityStorageStats,
+	assertNativeDurabilityCheckpointRequest,
+	assertNativeDurabilityDeleteRequest,
+	assertNativeDurabilityFence,
+	assertNativeDurabilityJournalAppendRequest,
+	assertNativeDurabilityOperationScope,
+	assertNativeDurabilityStageRequest,
+	copyNativeDurabilityBytes,
+	nativeDurabilityBytesEqual,
+	nativeDurabilityScopeDigest,
+	sha256NativeDurability,
+} from "./storage.js";
+
+const cloneFence = (
+	fence: NativeDurabilityLease["fence"],
+): NativeDurabilityLease["fence"] => ({ ...fence });
+
+const cloneScope = <T extends { transactionId: string; txSequence: bigint }>(
+	scope: T,
+): T => ({ ...scope });
+
+const cloneRetainedTransactions = (
+	transactions: NativeDurabilityCheckpointRequest["retainedTransactions"],
+): NativeDurabilityCheckpoint["retainedTransactions"] =>
+	transactions.map((transaction) => ({
+		...transaction,
+		planDigest: copyNativeDurabilityBytes(transaction.planDigest),
+	}));
+
+const snapshotStageRequest = (
+	request: NativeDurabilityStageRequest,
+): NativeDurabilityStageRequest => {
+	assertNativeDurabilityStageRequest(request);
+	return {
+		scope: { ...request.scope },
+		blocks: [...request.blocks]
+			.sort((left, right) => left.ordinal - right.ordinal)
+			.map((block) => ({
+				...block,
+				bytes: copyNativeDurabilityBytes(block.bytes),
+				digest: copyNativeDurabilityBytes(block.digest),
+			})),
+	};
+};
+
+const snapshotJournalRequest = (
+	request: NativeDurabilityJournalAppendRequest,
+): NativeDurabilityJournalAppendRequest => {
+	assertNativeDurabilityJournalAppendRequest(request);
+	return {
+		...request,
+		frames: copyNativeDurabilityBytes(request.frames),
+		framesDigest: copyNativeDurabilityBytes(request.framesDigest),
+	};
+};
+
+const snapshotCheckpointRequest = (
+	request: NativeDurabilityCheckpointRequest,
+): NativeDurabilityCheckpointRequest => {
+	assertNativeDurabilityCheckpointRequest(request);
+	return {
+		...request,
+		scope: { ...request.scope },
+		bytes: copyNativeDurabilityBytes(request.bytes),
+		digest: copyNativeDurabilityBytes(request.digest),
+		stagingCoverage: request.stagingCoverage.map((coverage) => ({
+			...coverage,
+			stagingManifestDigest: copyNativeDurabilityBytes(
+				coverage.stagingManifestDigest,
+			),
+		})),
+		retainedTransactions: cloneRetainedTransactions(
+			request.retainedTransactions,
+		),
+	};
+};
+
+const snapshotDeleteRequest = (
+	request: NativeDurabilityDeleteRequest,
+): NativeDurabilityDeleteRequest => {
+	assertNativeDurabilityDeleteRequest(request);
+	return {
+		scope: { ...request.scope },
+		targets: request.targets.map((target) => ({ ...target })),
+	};
+};
+
+export class MemoryNativeDurabilityStorage implements NativeDurabilityStorage {
+	readonly version = NATIVE_DURABILITY_STORAGE_VERSION;
+	readonly kind = "memory" as const;
+	readonly crashSafe = false;
+	readonly domainId: string;
+	readonly fence: NativeDurabilityLease["fence"];
+
+	private barrierOrdinal = 0n;
+	private strictDeleteCount = 0n;
+	private journal = new Uint8Array();
+	private readonly staging = new Map<
+		string,
+		{
+			manifest: NativeDurabilityStagingManifest;
+			blocks: Map<number, Uint8Array>;
+		}
+	>();
+	private readonly checkpoints = new Map<bigint, NativeDurabilityCheckpoint>();
+	private generationHighwater = 0n;
+	private operationTail: Promise<void> = Promise.resolve();
+	private closing = false;
+	private closed = false;
+
+	constructor(
+		private readonly lease: NativeDurabilityLease,
+		private readonly journalClassifier: NativeDurabilityJournalClassifier,
+	) {
+		assertNativeDurabilityFence(lease.fence);
+		this.domainId = lease.fence.domainId;
+		this.fence = Object.freeze({ ...lease.fence });
+	}
+
+	private barrier(): bigint {
+		this.barrierOrdinal++;
+		return this.barrierOrdinal;
+	}
+
+	private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+		if (this.closing || this.closed) {
+			return Promise.reject(new NativeDurabilityStorageClosedError());
+		}
+		let resolveResult!: (value: T | PromiseLike<T>) => void;
+		let rejectResult!: (reason?: unknown) => void;
+		const result = new Promise<T>((resolve, reject) => {
+			resolveResult = resolve;
+			rejectResult = reject;
+		});
+		this.operationTail = this.operationTail.then(async () => {
+			try {
+				resolveResult(await this.lease.runWhileHeld(operation));
+			} catch (error) {
+				rejectResult(error);
+			}
+		});
+		return result;
+	}
+
+	async stageAndSync(
+		unsafeRequest: NativeDurabilityStageRequest,
+	): Promise<NativeDurabilityStageReceipt> {
+		const request = snapshotStageRequest(unsafeRequest);
+		return this.enqueue(async () => {
+			const references: NativeDurabilityStagedBlockReference[] = [];
+			const blocks = new Map<number, Uint8Array>();
+			const seenOrdinals = new Set<number>();
+			for (const block of request.blocks) {
+				if (!Number.isSafeInteger(block.ordinal) || block.ordinal < 0) {
+					throw new RangeError(
+						"Staging ordinal must be a non-negative safe integer",
+					);
+				}
+				if (seenOrdinals.has(block.ordinal)) {
+					throw new Error(`Duplicate staging ordinal ${block.ordinal}`);
+				}
+				seenOrdinals.add(block.ordinal);
+				const actual = await sha256NativeDurability(block.bytes);
+				if (!nativeDurabilityBytesEqual(actual, block.digest)) {
+					throw new NativeDurabilityDigestMismatchError(
+						`staged block ${block.ordinal}`,
+					);
+				}
+				blocks.set(block.ordinal, copyNativeDurabilityBytes(block.bytes));
+				references.push({
+					ordinal: block.ordinal,
+					cid: block.cid,
+					byteLength: block.bytes.byteLength,
+					digest: copyNativeDurabilityBytes(block.digest),
+				});
+			}
+			references.sort((left, right) => left.ordinal - right.ordinal);
+			const manifestPayload = {
+				version: this.version,
+				scope: request.scope,
+				fence: this.lease.fence,
+				blocks: references,
+			};
+			const manifestDigest = await nativeDurabilityScopeDigest(manifestPayload);
+			const manifest: NativeDurabilityStagingManifest = {
+				...manifestPayload,
+				scope: cloneScope(request.scope),
+				fence: cloneFence(this.lease.fence),
+				blocks: references,
+				manifestDigest,
+			};
+			const existing = this.staging.get(request.scope.transactionId);
+			if (
+				existing &&
+				!nativeDurabilityBytesEqual(
+					existing.manifest.manifestDigest,
+					manifest.manifestDigest,
+				)
+			) {
+				throw new Error(
+					`Staging transaction ${request.scope.transactionId} already has a different manifest`,
+				);
+			}
+			this.staging.set(request.scope.transactionId, { manifest, blocks });
+			const receipt: NativeDurabilityStageReceipt = {
+				version: this.version,
+				kind: "stage",
+				domainId: this.domainId,
+				fence: cloneFence(this.lease.fence),
+				transactionId: request.scope.transactionId,
+				txSequence: request.scope.txSequence,
+				firstRecordLsn: request.scope.recordLsn,
+				lastRecordLsn: request.scope.recordLsn,
+				scopeDigest: await nativeDurabilityScopeDigest(request),
+				barrierOrdinal: this.barrier(),
+				blocks: references.map((block) => ({
+					...block,
+					digest: copyNativeDurabilityBytes(block.digest),
+				})),
+				manifestDigest: copyNativeDurabilityBytes(manifestDigest),
+			};
+			return receipt;
+		});
+	}
+
+	async readStagingManifest(
+		transactionId: string,
+	): Promise<NativeDurabilityStagingManifest | undefined> {
+		return this.enqueue(async () => {
+			const manifest = this.staging.get(transactionId)?.manifest;
+			if (!manifest) return undefined;
+			return {
+				...manifest,
+				scope: cloneScope(manifest.scope),
+				fence: cloneFence(manifest.fence),
+				blocks: manifest.blocks.map((block) => ({
+					...block,
+					digest: copyNativeDurabilityBytes(block.digest),
+				})),
+				manifestDigest: copyNativeDurabilityBytes(manifest.manifestDigest),
+			};
+		});
+	}
+
+	async readStagedBlock(
+		transactionId: string,
+		ordinal: number,
+	): Promise<Uint8Array | undefined> {
+		return this.enqueue(async () => {
+			const bytes = this.staging.get(transactionId)?.blocks.get(ordinal);
+			return bytes && copyNativeDurabilityBytes(bytes);
+		});
+	}
+
+	async listStagingTransactionIds(): Promise<string[]> {
+		return this.enqueue(async () => [...this.staging.keys()].sort());
+	}
+
+	async appendJournalAndSync(
+		unsafeRequest: NativeDurabilityJournalAppendRequest,
+	): Promise<NativeDurabilityJournalReceipt> {
+		const request = snapshotJournalRequest(unsafeRequest);
+		return this.enqueue(async () => {
+			if (request.expectedOffset !== this.journal.byteLength) {
+				throw new NativeDurabilityJournalOffsetConflictError(
+					request.expectedOffset,
+					this.journal.byteLength,
+				);
+			}
+			const actual = await sha256NativeDurability(request.frames);
+			if (!nativeDurabilityBytesEqual(actual, request.framesDigest)) {
+				throw new NativeDurabilityDigestMismatchError("journal frames");
+			}
+			const next = new Uint8Array(
+				this.journal.byteLength + request.frames.byteLength,
+			);
+			next.set(this.journal);
+			next.set(request.frames, this.journal.byteLength);
+			this.journal = next;
+			return {
+				version: this.version,
+				kind: "journal-append",
+				domainId: this.domainId,
+				fence: cloneFence(this.lease.fence),
+				transactionId: request.transactionId,
+				txSequence: request.txSequence,
+				firstRecordLsn: request.firstRecordLsn,
+				lastRecordLsn: request.lastRecordLsn,
+				scopeDigest: await nativeDurabilityScopeDigest(request),
+				barrierOrdinal: this.barrier(),
+				offset: request.expectedOffset,
+				endOffset: this.journal.byteLength,
+				framesDigest: copyNativeDurabilityBytes(request.framesDigest),
+			};
+		});
+	}
+
+	async readJournal(): Promise<Uint8Array> {
+		return this.enqueue(async () => copyNativeDurabilityBytes(this.journal));
+	}
+
+	async reconcileIncompleteJournalTailAndSync(
+		unsafeRequest: NativeDurabilityIncompleteTailReconciliationRequest,
+	): Promise<NativeDurabilityJournalReconciliationReceipt> {
+		const request = { ...unsafeRequest };
+		try {
+			assertNativeDurabilityOperationScope({
+				...request,
+				recordLsn: 0n,
+			});
+		} catch (error) {
+			return Promise.reject(error);
+		}
+		if (request.txSequence === 0n) {
+			return Promise.reject(
+				new TypeError("Invalid incomplete-tail reconciliation request"),
+			);
+		}
+		return this.enqueue(async () => {
+			const observed = copyNativeDurabilityBytes(this.journal);
+			const observedDigest = await sha256NativeDurability(observed);
+			const classified = await this.journalClassifier.classify(
+				copyNativeDurabilityBytes(observed),
+			);
+			const classification = { ...classified };
+			if (
+				classification.kind !== "incomplete-tail" ||
+				!Number.isSafeInteger(classification.validLength) ||
+				classification.validLength < 0 ||
+				classification.validLength >= observed.byteLength ||
+				typeof classification.lastRecordLsn !== "bigint" ||
+				classification.lastRecordLsn < 0n ||
+				classification.lastRecordLsn > NATIVE_DURABILITY_MAX_U64 ||
+				(classification.reason !== "short-header" &&
+					classification.reason !== "short-body" &&
+					classification.reason !== "short-trailer")
+			) {
+				throw new NativeDurabilityIncompleteTailMismatchError(
+					"The exact current journal does not end in a structurally incomplete frame",
+				);
+			}
+			this.journal = observed.slice(0, classification.validLength);
+			return {
+				version: this.version,
+				kind: "journal-tail-reconciliation",
+				domainId: this.domainId,
+				fence: cloneFence(this.lease.fence),
+				transactionId: request.transactionId,
+				txSequence: request.txSequence,
+				firstRecordLsn: classification.lastRecordLsn,
+				lastRecordLsn: classification.lastRecordLsn,
+				scopeDigest: await nativeDurabilityScopeDigest({
+					...request,
+					classification,
+					observedDigest,
+				}),
+				barrierOrdinal: this.barrier(),
+				previousLength: observed.byteLength,
+				validLength: classification.validLength,
+				observedDigest,
+			};
+		});
+	}
+
+	async writeCheckpointAndSync(
+		unsafeRequest: NativeDurabilityCheckpointRequest,
+	): Promise<NativeDurabilityCheckpointReceipt> {
+		const request = snapshotCheckpointRequest(unsafeRequest);
+		return this.enqueue(async () => {
+			const actual = await sha256NativeDurability(request.bytes);
+			if (!nativeDurabilityBytesEqual(actual, request.digest)) {
+				throw new NativeDurabilityDigestMismatchError("checkpoint");
+			}
+			for (const coverage of request.stagingCoverage) {
+				const staged = this.staging.get(coverage.transactionId)?.manifest;
+				if (
+					!staged ||
+					staged.scope.txSequence !== coverage.txSequence ||
+					coverage.coveredThroughLsn < staged.scope.recordLsn ||
+					!nativeDurabilityBytesEqual(
+						staged.manifestDigest,
+						coverage.stagingManifestDigest,
+					)
+				) {
+					throw new Error(
+						`Checkpoint coverage does not match staging transaction ${coverage.transactionId}`,
+					);
+				}
+			}
+			const generation = ++this.generationHighwater;
+			const manifestSlot = generation % 2n === 1n ? "a" : "b";
+			this.checkpoints.set(generation, {
+				version: this.version,
+				generation,
+				checkpointLsn: request.checkpointLsn,
+				txSequenceHighwater: request.txSequenceHighwater,
+				bytes: copyNativeDurabilityBytes(request.bytes),
+				digest: copyNativeDurabilityBytes(request.digest),
+				originFence: cloneFence(this.lease.fence),
+				manifestSlot,
+				stagingCoverage: request.stagingCoverage.map((coverage) => ({
+					...coverage,
+					stagingManifestDigest: copyNativeDurabilityBytes(
+						coverage.stagingManifestDigest,
+					),
+				})),
+				retainedTransactions: cloneRetainedTransactions(
+					request.retainedTransactions,
+				),
+			});
+			return {
+				version: this.version,
+				kind: "checkpoint",
+				domainId: this.domainId,
+				fence: cloneFence(this.lease.fence),
+				transactionId: request.scope.transactionId,
+				txSequence: request.scope.txSequence,
+				firstRecordLsn: request.scope.recordLsn,
+				lastRecordLsn: request.scope.recordLsn,
+				scopeDigest: await nativeDurabilityScopeDigest(request),
+				barrierOrdinal: this.barrier(),
+				generation,
+				checkpointLsn: request.checkpointLsn,
+				checkpointDigest: copyNativeDurabilityBytes(request.digest),
+				manifestSlot,
+				stagingCoverageDigest: await nativeDurabilityScopeDigest(
+					request.stagingCoverage,
+				),
+			};
+		});
+	}
+
+	async readLatestCheckpoint(): Promise<
+		NativeDurabilityCheckpoint | undefined
+	> {
+		return this.enqueue(async () => {
+			const latest = [...this.checkpoints.keys()].sort((left, right) =>
+				left < right ? 1 : left > right ? -1 : 0,
+			)[0];
+			const checkpoint =
+				latest == null ? undefined : this.checkpoints.get(latest);
+			return (
+				checkpoint && {
+					...checkpoint,
+					bytes: copyNativeDurabilityBytes(checkpoint.bytes),
+					digest: copyNativeDurabilityBytes(checkpoint.digest),
+					originFence: cloneFence(checkpoint.originFence),
+					stagingCoverage: checkpoint.stagingCoverage.map((coverage) => ({
+						...coverage,
+						stagingManifestDigest: copyNativeDurabilityBytes(
+							coverage.stagingManifestDigest,
+						),
+					})),
+					retainedTransactions: cloneRetainedTransactions(
+						checkpoint.retainedTransactions,
+					),
+				}
+			);
+		});
+	}
+
+	async deleteAndSync(
+		unsafeRequest: NativeDurabilityDeleteRequest,
+	): Promise<NativeDurabilityDeleteReceipt> {
+		const request = snapshotDeleteRequest(unsafeRequest);
+		return this.enqueue(async () => {
+			const checkpointGenerations = [...this.checkpoints.keys()].sort(
+				(left, right) => (left < right ? 1 : left > right ? -1 : 0),
+			);
+			const active = checkpointGenerations[0];
+			const previous = checkpointGenerations[1];
+			const activeCheckpoint =
+				active == null ? undefined : this.checkpoints.get(active);
+			// Validate every target before applying any of them.
+			for (const target of request.targets) {
+				if (target.kind === "staging") {
+					const staged = this.staging.get(target.transactionId)?.manifest;
+					if (staged) {
+						const covered = activeCheckpoint?.stagingCoverage.some(
+							(coverage) =>
+								coverage.transactionId === staged.scope.transactionId &&
+								coverage.txSequence === staged.scope.txSequence &&
+								coverage.coveredThroughLsn >= staged.scope.recordLsn &&
+								nativeDurabilityBytesEqual(
+									coverage.stagingManifestDigest,
+									staged.manifestDigest,
+								),
+						);
+						if (!covered) {
+							throw new Error(
+								`Active checkpoint does not cover staging transaction ${target.transactionId}`,
+							);
+						}
+					}
+				} else {
+					if (target.generation === active || target.generation === previous) {
+						throw new Error(
+							`Cannot delete active or previous checkpoint generation ${target.generation}`,
+						);
+					}
+				}
+			}
+			for (const target of request.targets) {
+				if (target.kind === "staging") {
+					this.staging.delete(target.transactionId);
+				} else {
+					this.checkpoints.delete(target.generation);
+				}
+			}
+			this.strictDeleteCount++;
+			return {
+				version: this.version,
+				kind: "delete",
+				domainId: this.domainId,
+				fence: cloneFence(this.lease.fence),
+				transactionId: request.scope.transactionId,
+				txSequence: request.scope.txSequence,
+				firstRecordLsn: request.scope.recordLsn,
+				lastRecordLsn: request.scope.recordLsn,
+				scopeDigest: await nativeDurabilityScopeDigest(request),
+				barrierOrdinal: this.barrier(),
+				targets: request.targets.map((target) => ({ ...target })),
+			};
+		});
+	}
+
+	async stats(): Promise<NativeDurabilityStorageStats> {
+		return this.enqueue(async () => {
+			let stagedBlocks = 0;
+			let stagedBytes = 0;
+			for (const transaction of this.staging.values()) {
+				stagedBlocks += transaction.blocks.size;
+				for (const block of transaction.blocks.values()) {
+					stagedBytes += block.byteLength;
+				}
+			}
+			let checkpointBytes = 0;
+			for (const checkpoint of this.checkpoints.values()) {
+				checkpointBytes += checkpoint.bytes.byteLength;
+			}
+			return {
+				kind: this.kind,
+				domainId: this.domainId,
+				strictBarrierCount: this.barrierOrdinal,
+				strictDeleteCount: this.strictDeleteCount,
+				journalBytes: this.journal.byteLength,
+				stagingTransactions: this.staging.size,
+				stagedBlocks,
+				stagedBytes,
+				checkpointGenerations: this.checkpoints.size,
+				checkpointBytes,
+			};
+		});
+	}
+
+	async close(): Promise<void> {
+		if (this.closed) return;
+		this.closing = true;
+		await this.operationTail;
+		this.closed = true;
+	}
+}
+
+export const createMemoryNativeDurabilityStorage = (
+	lease: NativeDurabilityLease,
+	journalClassifier: NativeDurabilityJournalClassifier,
+): MemoryNativeDurabilityStorage =>
+	new MemoryNativeDurabilityStorage(lease, journalClassifier);

--- a/packages/utils/native-backbone/src/durability/node-lease.ts
+++ b/packages/utils/native-backbone/src/durability/node-lease.ts
@@ -1,0 +1,293 @@
+import {
+	NATIVE_DURABILITY_MAX_U64,
+	NATIVE_DURABILITY_MAX_WRITER_ID_BYTES,
+	type NativeDurabilityFence,
+	NativeDurabilityFenceExhaustedError,
+	type NativeDurabilityLease,
+	NativeDurabilityLeaseClosedError,
+	NativeDurabilityLeaseDirectorySyncError,
+	NativeDurabilityLeaseStateError,
+	NativeDurabilityLeaseUnavailableError,
+} from "./lease.js";
+
+export const NATIVE_DURABILITY_NODE_LEASE_DIRECTORY_NAME =
+	".peerbit-native-durability-lease";
+const LEASE_STATE_KEY = "fence";
+const LEASE_STATE_VERSION = 1;
+
+type PersistedLeaseState = {
+	version: typeof LEASE_STATE_VERSION;
+	epoch: string;
+	ownerId: string;
+	domainId: string;
+};
+
+type NativeLevelDatabase = {
+	readonly status: string;
+	open(): Promise<void>;
+	get(key: string): Promise<string | undefined>;
+	put(key: string, value: string, options: { sync: true }): Promise<void>;
+	close(): Promise<void>;
+};
+
+type ClassicLevelConstructor = new (
+	location: string,
+	options: { keyEncoding: "utf8"; valueEncoding: "utf8" },
+) => NativeLevelDatabase;
+
+type NodeFsPromises = {
+	realpath(path: string): Promise<string>;
+	open(
+		path: string,
+		flags: "r",
+	): Promise<{
+		sync(): Promise<void>;
+		close(): Promise<void>;
+	}>;
+};
+
+type NodePath = {
+	join(...parts: string[]): string;
+};
+
+type NodeCrypto = {
+	randomUUID(): string;
+};
+
+const dynamicImport = <T>(specifier: string): Promise<T> =>
+	import(/* @vite-ignore */ specifier) as Promise<T>;
+
+const importClassicLevel = async (): Promise<ClassicLevelConstructor> => {
+	const module = await dynamicImport<{ ClassicLevel: ClassicLevelConstructor }>(
+		"classic-level",
+	);
+	return module.ClassicLevel;
+};
+
+const hasErrorCode = (error: unknown, expected: string): boolean => {
+	const visited = new Set<unknown>();
+	let current = error;
+	while (
+		current != null &&
+		typeof current === "object" &&
+		!visited.has(current)
+	) {
+		visited.add(current);
+		if ((current as { code?: unknown }).code === expected) {
+			return true;
+		}
+		current = (current as { cause?: unknown }).cause;
+	}
+	return false;
+};
+
+const isMissingKeyError = (error: unknown): boolean =>
+	hasErrorCode(error, "LEVEL_NOT_FOUND");
+
+const decodeLeaseState = (
+	encoded: string,
+	directory: string,
+): PersistedLeaseState => {
+	let decoded: unknown;
+	try {
+		decoded = JSON.parse(encoded);
+	} catch (error) {
+		throw new NativeDurabilityLeaseStateError(
+			directory,
+			`Invalid native durability lease state in ${directory}`,
+			{ cause: error },
+		);
+	}
+	const value = decoded as Partial<PersistedLeaseState> | null;
+	if (
+		value?.version !== LEASE_STATE_VERSION ||
+		typeof value.epoch !== "string" ||
+		!/^(0|[1-9][0-9]*)$/.test(value.epoch) ||
+		BigInt(value.epoch) > NATIVE_DURABILITY_MAX_U64 ||
+		typeof value.ownerId !== "string" ||
+		value.ownerId.length === 0 ||
+		new TextEncoder().encode(value.ownerId).byteLength >
+			NATIVE_DURABILITY_MAX_WRITER_ID_BYTES ||
+		typeof value.domainId !== "string" ||
+		value.domainId.length === 0 ||
+		new TextEncoder().encode(value.domainId).byteLength >
+			NATIVE_DURABILITY_MAX_WRITER_ID_BYTES
+	) {
+		throw new NativeDurabilityLeaseStateError(
+			directory,
+			`Invalid native durability lease state in ${directory}`,
+		);
+	}
+	return value as PersistedLeaseState;
+};
+
+const readLeaseState = async (
+	database: NativeLevelDatabase,
+	directory: string,
+): Promise<PersistedLeaseState | undefined> => {
+	try {
+		const encoded = await database.get(LEASE_STATE_KEY);
+		return encoded == null ? undefined : decodeLeaseState(encoded, directory);
+	} catch (error) {
+		if (isMissingKeyError(error)) {
+			return undefined;
+		}
+		throw error;
+	}
+};
+
+const syncDirectory = async (
+	fs: NodeFsPromises,
+	directory: string,
+): Promise<void> => {
+	let handle: Awaited<ReturnType<NodeFsPromises["open"]>> | undefined;
+	try {
+		handle = await fs.open(directory, "r");
+		await handle.sync();
+	} catch (error) {
+		throw new NativeDurabilityLeaseDirectorySyncError(directory, {
+			cause: error,
+		});
+	} finally {
+		await handle?.close();
+	}
+};
+
+class NodeNativeDurabilityLease implements NativeDurabilityLease {
+	private state: "held" | "closing" | "closed" = "held";
+	private closePromise?: Promise<void>;
+	private activeOperations = 0;
+	private drainPromise?: Promise<void>;
+	private resolveDrain?: () => void;
+
+	constructor(
+		readonly fence: NativeDurabilityFence,
+		private readonly database: NativeLevelDatabase,
+	) {}
+
+	async assertHeld(): Promise<void> {
+		if (this.state !== "held" || this.database.status !== "open") {
+			throw new NativeDurabilityLeaseClosedError(this.fence);
+		}
+	}
+
+	async runWhileHeld<T>(operation: () => Promise<T>): Promise<T> {
+		if (this.state !== "held" || this.database.status !== "open") {
+			throw new NativeDurabilityLeaseClosedError(this.fence);
+		}
+		// The state check and increment are synchronous, so close() cannot release
+		// the database lock between them.
+		this.activeOperations++;
+		try {
+			return await operation();
+		} finally {
+			this.activeOperations--;
+			if (this.activeOperations === 0) {
+				this.resolveDrain?.();
+				this.resolveDrain = undefined;
+				this.drainPromise = undefined;
+			}
+		}
+	}
+
+	close(): Promise<void> {
+		if (this.closePromise) {
+			return this.closePromise;
+		}
+		this.state = "closing";
+		if (this.activeOperations > 0 && !this.drainPromise) {
+			this.drainPromise = new Promise<void>((resolve) => {
+				this.resolveDrain = resolve;
+			});
+		}
+		this.closePromise = (this.drainPromise ?? Promise.resolve())
+			.then(() => this.database.close())
+			.finally(() => {
+				this.state = "closed";
+			});
+		return this.closePromise;
+	}
+}
+
+/**
+ * Acquire the crash-released Node ownership lease for an existing program
+ * directory.
+ *
+ * The dedicated ClassicLevel database lives beside, rather than inside, the
+ * transaction namespace. Its native LevelDB `LOCK` is held for this object's
+ * lifetime and is released by the operating system when the process dies. The
+ * lock database itself is intentionally retained so fence epochs cannot be
+ * reused after a normal reopen.
+ */
+export const acquireNativeDurabilityNodeLease = async (
+	programDirectory: string,
+): Promise<NativeDurabilityLease> => {
+	const [fs, path, crypto, ClassicLevel] = await Promise.all([
+		dynamicImport<NodeFsPromises>("node:fs/promises"),
+		dynamicImport<NodePath>("node:path"),
+		dynamicImport<NodeCrypto>("node:crypto"),
+		importClassicLevel(),
+	]);
+	let canonicalDirectory: string;
+	try {
+		canonicalDirectory = await fs.realpath(programDirectory);
+	} catch (error) {
+		throw new NativeDurabilityLeaseStateError(
+			programDirectory,
+			`Native durability program directory must already exist: ${programDirectory}`,
+			{ cause: error },
+		);
+	}
+	const leaseDirectory = path.join(
+		canonicalDirectory,
+		NATIVE_DURABILITY_NODE_LEASE_DIRECTORY_NAME,
+	);
+	const database = new ClassicLevel(leaseDirectory, {
+		keyEncoding: "utf8",
+		valueEncoding: "utf8",
+	});
+
+	try {
+		await database.open();
+	} catch (error) {
+		if (hasErrorCode(error, "LEVEL_LOCKED")) {
+			throw new NativeDurabilityLeaseUnavailableError(canonicalDirectory, {
+				cause: error,
+			});
+		}
+		throw error;
+	}
+
+	try {
+		const previous = await readLeaseState(database, canonicalDirectory);
+		if (BigInt(previous?.epoch ?? "0") === NATIVE_DURABILITY_MAX_U64) {
+			throw new NativeDurabilityFenceExhaustedError(canonicalDirectory);
+		}
+		const fence: NativeDurabilityFence = Object.freeze({
+			epoch: BigInt(previous?.epoch ?? "0") + 1n,
+			ownerId: crypto.randomUUID(),
+			domainId: previous?.domainId ?? crypto.randomUUID(),
+		});
+		const next: PersistedLeaseState = {
+			version: LEASE_STATE_VERSION,
+			epoch: fence.epoch.toString(),
+			ownerId: fence.ownerId,
+			domainId: fence.domainId,
+		};
+		await database.put(LEASE_STATE_KEY, JSON.stringify(next), { sync: true });
+		// LevelDB's sync option covers its value/WAL. Explicit directory syncs
+		// additionally make creation of the lease database and its files durable
+		// before the fence is handed to a transaction writer.
+		await syncDirectory(fs, leaseDirectory);
+		await syncDirectory(fs, canonicalDirectory);
+		return new NodeNativeDurabilityLease(fence, database);
+	} catch (error) {
+		try {
+			await database.close();
+		} catch {
+			// The acquisition error is authoritative. A failed close must not make
+			// the partially initialized lease usable by this process.
+		}
+		throw error;
+	}
+};

--- a/packages/utils/native-backbone/src/durability/node-storage.ts
+++ b/packages/utils/native-backbone/src/durability/node-storage.ts
@@ -1,0 +1,2798 @@
+import {
+	NATIVE_DURABILITY_JOURNAL_MAX_PROGRAM_ID_LENGTH,
+	type NativeDurabilityCheckpointTransactionState,
+	NativeDurabilityJournalCodec,
+	type NativeDurabilityJournalRecord,
+	type NativeDurabilityJournalScan,
+	type NativeDurabilityJournalValidationContext,
+	NativeDurabilityPhase,
+	createNativeDurabilityJournalCodec,
+	isNativeDurabilityJournalCodec,
+} from "./codec.js";
+import {
+	NATIVE_DURABILITY_MAX_U64,
+	type NativeDurabilityLease,
+} from "./lease.js";
+import {
+	NATIVE_DURABILITY_NODE_LEASE_DIRECTORY_NAME,
+	acquireNativeDurabilityNodeLease,
+} from "./node-lease.js";
+import {
+	NATIVE_DURABILITY_MAX_TRANSACTION_ID_BYTES,
+	NATIVE_DURABILITY_STORAGE_VERSION,
+	type NativeDurabilityCheckpoint,
+	type NativeDurabilityCheckpointReceipt,
+	type NativeDurabilityCheckpointRequest,
+	type NativeDurabilityDeleteReceipt,
+	type NativeDurabilityDeleteRequest,
+	NativeDurabilityDigestMismatchError,
+	NativeDurabilityIncompleteTailMismatchError,
+	type NativeDurabilityIncompleteTailReconciliationRequest,
+	type NativeDurabilityJournalAppendRequest,
+	NativeDurabilityJournalOffsetConflictError,
+	type NativeDurabilityJournalReceipt,
+	type NativeDurabilityJournalReconciliationReceipt,
+	NativeDurabilityMigrationRequiredError,
+	type NativeDurabilityOperationScope,
+	NativeDurabilityOutcomeUnknownError,
+	type NativeDurabilityStageReceipt,
+	type NativeDurabilityStageRequest,
+	type NativeDurabilityStagedBlockReference,
+	type NativeDurabilityStagingManifest,
+	type NativeDurabilityStorage,
+	NativeDurabilityStorageClosedError,
+	NativeDurabilityStorageCorruptionError,
+	type NativeDurabilityStorageStats,
+	NativeDurabilityStorageUnsupportedError,
+	assertNativeDurabilityCheckpointRequest,
+	assertNativeDurabilityDeleteRequest,
+	assertNativeDurabilityFence,
+	assertNativeDurabilityJournalAppendRequest,
+	assertNativeDurabilityOperationScope,
+	assertNativeDurabilityStageRequest,
+	copyNativeDurabilityBytes,
+	encodeNativeDurabilityCanonical,
+	nativeDurabilityBytesEqual,
+	nativeDurabilityDigestFromHex,
+	nativeDurabilityDigestHex,
+} from "./storage.js";
+
+const STORAGE_DIRECTORY_NAME = "native-durability-v1";
+const STAGING_DIRECTORY_NAME = "staging";
+const CHECKPOINT_DIRECTORY_NAME = "checkpoints";
+const JOURNAL_FILE_NAME = "journal.bin";
+const STAGING_MANIFEST_FILE_NAME = "manifest.json";
+const CHECKPOINT_HIGHWATER_FILE_NAME = "generation-highwater.json";
+const CHECKPOINT_MANIFEST_A = "manifest-a.json";
+const CHECKPOINT_MANIFEST_B = "manifest-b.json";
+const JOURNAL_BASE_MANIFEST = "journal-base.json";
+
+type ManifestEnvelope = { payload: string; checksum: string };
+
+type NodeFs = typeof import("fs/promises");
+type NodePath = typeof import("path");
+type NodeCreateHash = (typeof import("crypto"))["createHash"];
+
+let nodeFs: NodeFs | undefined;
+let nodePath: NodePath | undefined;
+let nodeCreateHash: NodeCreateHash | undefined;
+
+const loadNodeModules = async (): Promise<void> => {
+	if (nodeFs && nodePath && nodeCreateHash) return;
+	const processLike = globalThis as {
+		process?: { versions?: { node?: string } };
+	};
+	if (!processLike.process?.versions?.node) {
+		throw new NativeDurabilityStorageUnsupportedError(
+			"Native durability strict storage is Node-only; OPFS is not supported",
+		);
+	}
+	const fsModule = "fs/promises";
+	const pathModule = "path";
+	const cryptoModule = "crypto";
+	const [fs, path, crypto] = await Promise.all([
+		import(/* @vite-ignore */ fsModule) as Promise<NodeFs>,
+		import(/* @vite-ignore */ pathModule) as Promise<NodePath>,
+		import(/* @vite-ignore */ cryptoModule) as Promise<typeof import("crypto")>,
+	]);
+	nodeFs = fs;
+	nodePath = path;
+	nodeCreateHash = crypto.createHash;
+};
+
+const requireNodeFs = (): NodeFs => {
+	if (!nodeFs) throw new Error("Node durability modules have not been loaded");
+	return nodeFs;
+};
+
+const requireNodePath = (): NodePath => {
+	if (!nodePath)
+		throw new Error("Node durability modules have not been loaded");
+	return nodePath;
+};
+
+type DiskFence = { epoch: string; ownerId: string; domainId: string };
+type DiskScope = {
+	transactionId: string;
+	txSequence: string;
+	recordLsn: string;
+};
+type DiskBlockReference = {
+	ordinal: number;
+	cid: string;
+	byteLength: number;
+	digest: string;
+};
+
+type DiskStagingManifest = {
+	version: typeof NATIVE_DURABILITY_STORAGE_VERSION;
+	scope: DiskScope;
+	fence: DiskFence;
+	blocks: DiskBlockReference[];
+};
+
+type DiskStagingCoverage = {
+	transactionId: string;
+	txSequence: string;
+	coveredThroughLsn: string;
+	stagingManifestDigest: string;
+};
+
+type DiskRetainedTransaction = {
+	txSequence: string;
+	transactionId: string;
+	phase: number;
+	operationKind: number;
+	planDigest: string;
+};
+
+type DiskCheckpointManifest = {
+	version: typeof NATIVE_DURABILITY_STORAGE_VERSION;
+	programId: string;
+	generation: string;
+	checkpointLsn: string;
+	txSequenceHighwater: string;
+	file: string;
+	byteLength: number;
+	digest: string;
+	originFence: DiskFence;
+	stagingCoverage: DiskStagingCoverage[];
+	retainedTransactions: DiskRetainedTransaction[];
+};
+
+type DiskGenerationIdentity = {
+	generation: string;
+	requestDigest: string;
+	transactionId: string;
+	txSequence: string;
+};
+
+type DiskGenerationHighwater = {
+	version: typeof NATIVE_DURABILITY_STORAGE_VERSION;
+	generation: string;
+	pending?: DiskGenerationIdentity;
+	completed?: DiskGenerationIdentity;
+};
+
+type GenerationIdentity = {
+	generation: bigint;
+	requestDigest: Uint8Array;
+	transactionId: string;
+	txSequence: bigint;
+};
+
+type GenerationState = {
+	generation: bigint;
+	pending?: GenerationIdentity;
+	completed?: GenerationIdentity;
+};
+
+export type NativeDurabilityNodeWritable = {
+	write: (
+		buffer: Uint8Array,
+		offset: number,
+		length: number,
+		position: number,
+	) => Promise<{ bytesWritten: number }>;
+};
+
+export type NativeDurabilityNodeReadable = {
+	read: (
+		buffer: Uint8Array,
+		offset: number,
+		length: number,
+		position: number,
+	) => Promise<{ bytesRead: number }>;
+};
+
+/** `FileHandle.write()` is allowed to complete with a short write. */
+export const writeNativeDurabilityBytesFully = async (
+	handle: NativeDurabilityNodeWritable,
+	bytes: Uint8Array,
+	position: number,
+): Promise<void> => {
+	let written = 0;
+	while (written < bytes.byteLength) {
+		const result = await handle.write(
+			bytes,
+			written,
+			bytes.byteLength - written,
+			position + written,
+		);
+		if (
+			!Number.isSafeInteger(result.bytesWritten) ||
+			result.bytesWritten <= 0
+		) {
+			throw new Error("Native durability write made no forward progress");
+		}
+		if (result.bytesWritten > bytes.byteLength - written) {
+			throw new Error(
+				"Native durability write exceeded the requested byte count",
+			);
+		}
+		written += result.bytesWritten;
+	}
+};
+
+export const readNativeDurabilityBytesFully = async (
+	handle: NativeDurabilityNodeReadable,
+	byteLength: number,
+): Promise<Uint8Array> => {
+	if (!Number.isSafeInteger(byteLength) || byteLength < 0) {
+		throw new RangeError("Native durability read length must be safe");
+	}
+	const bytes = new Uint8Array(byteLength);
+	let offset = 0;
+	while (offset < byteLength) {
+		const result = await handle.read(
+			bytes,
+			offset,
+			byteLength - offset,
+			offset,
+		);
+		if (
+			!Number.isSafeInteger(result.bytesRead) ||
+			result.bytesRead <= 0 ||
+			result.bytesRead > byteLength - offset
+		) {
+			throw new NativeDurabilityStorageCorruptionError(
+				"Native durability file changed during an exact read",
+			);
+		}
+		offset += result.bytesRead;
+	}
+	return bytes;
+};
+
+const sha256 = (bytes: Uint8Array): Uint8Array => {
+	if (!nodeCreateHash)
+		throw new Error("Node durability modules have not been loaded");
+	return new Uint8Array(nodeCreateHash("sha256").update(bytes).digest());
+};
+
+const sha256Hex = (bytes: Uint8Array): string =>
+	nativeDurabilityDigestHex(sha256(bytes));
+
+const bytesToHex = (bytes: Uint8Array): string =>
+	Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+
+const bytesFromHex = (value: unknown, subject: string): Uint8Array => {
+	if (
+		typeof value !== "string" ||
+		value.length % 2 !== 0 ||
+		!/^[0-9a-f]*$/.test(value)
+	) {
+		throw new NativeDurabilityStorageCorruptionError(
+			`${subject} must be canonical lowercase hexadecimal bytes`,
+		);
+	}
+	const bytes = new Uint8Array(value.length / 2);
+	for (let index = 0; index < bytes.byteLength; index++) {
+		bytes[index] = Number.parseInt(value.slice(index * 2, index * 2 + 2), 16);
+	}
+	return bytes;
+};
+
+const encodeManifest = (payload: unknown): Uint8Array => {
+	const payloadText = JSON.stringify(payload);
+	return new TextEncoder().encode(
+		JSON.stringify({
+			payload: payloadText,
+			checksum: sha256Hex(new TextEncoder().encode(payloadText)),
+		}),
+	);
+};
+
+const decodeManifest = <T>(bytes: Uint8Array, subject: string): T => {
+	try {
+		const envelope = JSON.parse(
+			new TextDecoder().decode(bytes),
+		) as ManifestEnvelope;
+		if (
+			typeof envelope.payload !== "string" ||
+			typeof envelope.checksum !== "string" ||
+			sha256Hex(new TextEncoder().encode(envelope.payload)) !==
+				envelope.checksum
+		) {
+			throw new Error("checksum mismatch");
+		}
+		return JSON.parse(envelope.payload) as T;
+	} catch (error) {
+		throw new NativeDurabilityStorageCorruptionError(
+			`Invalid ${subject} manifest`,
+			error,
+		);
+	}
+};
+
+const isNotFound = (error: unknown): boolean =>
+	(error as { code?: string })?.code === "ENOENT";
+
+const syncDirectory = async (path: string): Promise<void> => {
+	const handle = await requireNodeFs().open(path, "r");
+	try {
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+};
+
+const ensureDirectory = async (path: string, parent: string): Promise<void> => {
+	let created = false;
+	try {
+		await requireNodeFs().mkdir(path);
+		created = true;
+	} catch (error) {
+		if ((error as { code?: string }).code !== "EEXIST") throw error;
+		if (!(await requireNodeFs().stat(path)).isDirectory()) throw error;
+	}
+	if (created) await syncDirectory(parent);
+};
+
+const diskFence = (lease: NativeDurabilityLease): DiskFence => ({
+	epoch: lease.fence.epoch.toString(),
+	ownerId: lease.fence.ownerId,
+	domainId: lease.fence.domainId,
+});
+
+const diskScope = (scope: NativeDurabilityOperationScope): DiskScope => ({
+	transactionId: scope.transactionId,
+	txSequence: scope.txSequence.toString(),
+	recordLsn: scope.recordLsn.toString(),
+});
+
+const blockFileName = (ordinal: number): string =>
+	`${ordinal.toString().padStart(12, "0")}.block`;
+
+const checkpointFileName = (generation: bigint): string =>
+	`checkpoint-${generation}.bin`;
+
+const transactionDirectoryName = (transactionId: string): string =>
+	`tx-${sha256Hex(new TextEncoder().encode(transactionId))}`;
+
+export type NativeDurabilityNodeStorageOptions = {
+	directory: string;
+	programId: Uint8Array;
+};
+
+const readFileIfExists = async (
+	path: string,
+): Promise<Uint8Array | undefined> => {
+	try {
+		return new Uint8Array(await requireNodeFs().readFile(path));
+	} catch (error) {
+		if (isNotFound(error)) return undefined;
+		throw error;
+	}
+};
+
+const writeNewFileAndSync = async (
+	path: string,
+	bytes: Uint8Array,
+): Promise<void> => {
+	const handle = await requireNodeFs().open(path, "wx+");
+	try {
+		await writeNativeDurabilityBytesFully(handle, bytes, 0);
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+};
+
+const replaceFileAtomicallyAndSync = async (
+	path: string,
+	bytes: Uint8Array,
+	temporarySuffix: string,
+): Promise<void> => {
+	const parent = requireNodePath().dirname(path);
+	const temporary = `${path}.tmp-${temporarySuffix}`;
+	await requireNodeFs().rm(temporary, { force: true });
+	await writeNewFileAndSync(temporary, bytes);
+	await requireNodeFs().rename(temporary, path);
+	await syncDirectory(parent);
+};
+
+const writeImmutableFileAtomicallyAndSync = async (
+	path: string,
+	bytes: Uint8Array,
+	temporarySuffix: string,
+): Promise<void> => {
+	const parent = requireNodePath().dirname(path);
+	const temporary = `${path}.tmp-${temporarySuffix}`;
+	await requireNodeFs().rm(temporary, { force: true });
+	await writeNewFileAndSync(temporary, bytes);
+	await requireNodeFs().rename(temporary, path);
+	await syncDirectory(parent);
+};
+
+const parseUnsignedBigint = (value: unknown, subject: string): bigint => {
+	if (typeof value !== "string" || !/^(0|[1-9][0-9]*)$/.test(value)) {
+		throw new NativeDurabilityStorageCorruptionError(
+			`${subject} must be an unsigned decimal bigint`,
+		);
+	}
+	const parsed = BigInt(value);
+	if (parsed > NATIVE_DURABILITY_MAX_U64) {
+		throw new NativeDurabilityStorageCorruptionError(
+			`${subject} exceeds unsigned 64-bit range`,
+		);
+	}
+	return parsed;
+};
+
+const parseGenerationIdentity = (
+	value: DiskGenerationIdentity | undefined,
+	subject: string,
+): GenerationIdentity | undefined => {
+	if (value == null) return undefined;
+	if (
+		typeof value.transactionId !== "string" ||
+		!value.transactionId ||
+		new TextEncoder().encode(value.transactionId).byteLength >
+			NATIVE_DURABILITY_MAX_TRANSACTION_ID_BYTES ||
+		typeof value.requestDigest !== "string"
+	) {
+		throw new NativeDurabilityStorageCorruptionError(
+			`${subject} checkpoint identity fields are invalid`,
+		);
+	}
+	const identity = {
+		generation: parseUnsignedBigint(
+			value.generation,
+			`${subject} checkpoint generation`,
+		),
+		requestDigest: nativeDurabilityDigestFromHex(value.requestDigest),
+		transactionId: value.transactionId,
+		txSequence: parseUnsignedBigint(
+			value.txSequence,
+			`${subject} checkpoint transaction sequence`,
+		),
+	};
+	if (identity.txSequence === 0n) {
+		throw new NativeDurabilityStorageCorruptionError(
+			`${subject} checkpoint transaction sequence must be non-zero`,
+		);
+	}
+	return identity;
+};
+
+const diskGenerationIdentity = (
+	identity: GenerationIdentity,
+): DiskGenerationIdentity => ({
+	generation: identity.generation.toString(),
+	requestDigest: nativeDurabilityDigestHex(identity.requestDigest),
+	transactionId: identity.transactionId,
+	txSequence: identity.txSequence.toString(),
+});
+
+const generationIdentityMatches = (
+	identity: GenerationIdentity,
+	request: NativeDurabilityCheckpointRequest,
+	requestDigest: Uint8Array,
+): boolean =>
+	identity.transactionId === request.scope.transactionId &&
+	identity.txSequence === request.scope.txSequence &&
+	nativeDurabilityBytesEqual(identity.requestDigest, requestDigest);
+
+const parseStagingManifest = (
+	bytes: Uint8Array,
+	expectedTransactionId?: string,
+): NativeDurabilityStagingManifest => {
+	const disk = decodeManifest<DiskStagingManifest>(bytes, "staging");
+	if (
+		disk.version !== NATIVE_DURABILITY_STORAGE_VERSION ||
+		!disk.scope ||
+		typeof disk.scope.transactionId !== "string" ||
+		!disk.scope.transactionId ||
+		(expectedTransactionId != null &&
+			disk.scope.transactionId !== expectedTransactionId) ||
+		!disk.fence ||
+		typeof disk.fence.ownerId !== "string" ||
+		typeof disk.fence.domainId !== "string" ||
+		!Array.isArray(disk.blocks)
+	) {
+		throw new NativeDurabilityStorageCorruptionError(
+			"Staging manifest fields are invalid",
+		);
+	}
+	if (
+		new TextEncoder().encode(disk.scope.transactionId).byteLength >
+		NATIVE_DURABILITY_MAX_TRANSACTION_ID_BYTES
+	) {
+		throw new NativeDurabilityStorageCorruptionError(
+			"Staging transaction ID exceeds the journal format limit",
+		);
+	}
+	const blocks = disk.blocks.map((block, index) => {
+		if (
+			block.ordinal !== index ||
+			typeof block.cid !== "string" ||
+			!block.cid ||
+			!Number.isSafeInteger(block.byteLength) ||
+			block.byteLength < 0
+		) {
+			throw new NativeDurabilityStorageCorruptionError(
+				`Staging block reference ${index} is invalid`,
+			);
+		}
+		return {
+			ordinal: block.ordinal,
+			cid: block.cid,
+			byteLength: block.byteLength,
+			digest: nativeDurabilityDigestFromHex(block.digest),
+		};
+	});
+	const manifest: NativeDurabilityStagingManifest = {
+		version: NATIVE_DURABILITY_STORAGE_VERSION,
+		scope: {
+			transactionId: disk.scope.transactionId,
+			txSequence: parseUnsignedBigint(disk.scope.txSequence, "txSequence"),
+			recordLsn: parseUnsignedBigint(disk.scope.recordLsn, "recordLsn"),
+		},
+		fence: {
+			epoch: parseUnsignedBigint(disk.fence.epoch, "fence epoch"),
+			ownerId: disk.fence.ownerId,
+			domainId: disk.fence.domainId,
+		},
+		blocks,
+		manifestDigest: sha256(bytes),
+	};
+	if (manifest.scope.txSequence === 0n || manifest.scope.recordLsn === 0n) {
+		throw new NativeDurabilityStorageCorruptionError(
+			"Staging manifest sequence and LSN must be non-zero",
+		);
+	}
+	try {
+		assertNativeDurabilityFence(manifest.fence);
+	} catch (error) {
+		throw new NativeDurabilityStorageCorruptionError(
+			"Staging manifest fence is invalid",
+			error,
+		);
+	}
+	return manifest;
+};
+
+const parseDiskFence = (
+	value: DiskFence | undefined,
+	subject: string,
+): NativeDurabilityLease["fence"] => {
+	if (
+		!value ||
+		typeof value.ownerId !== "string" ||
+		typeof value.domainId !== "string"
+	) {
+		throw new NativeDurabilityStorageCorruptionError(
+			`${subject} fence is invalid`,
+		);
+	}
+	const fence = {
+		epoch: parseUnsignedBigint(value.epoch, `${subject} fence epoch`),
+		ownerId: value.ownerId,
+		domainId: value.domainId,
+	};
+	try {
+		assertNativeDurabilityFence(fence);
+	} catch (error) {
+		throw new NativeDurabilityStorageCorruptionError(
+			`${subject} fence is invalid`,
+			error,
+		);
+	}
+	return fence;
+};
+
+const parseDiskStagingCoverage = (
+	value: unknown,
+	checkpointLsn: bigint,
+): NativeDurabilityCheckpoint["stagingCoverage"] => {
+	if (!Array.isArray(value)) {
+		throw new NativeDurabilityStorageCorruptionError(
+			"Checkpoint staging coverage is invalid",
+		);
+	}
+	const transactionIds = new Set<string>();
+	return value.map((unknownCoverage, index) => {
+		const coverage = unknownCoverage as Partial<DiskStagingCoverage>;
+		if (
+			typeof coverage.transactionId !== "string" ||
+			!coverage.transactionId ||
+			new TextEncoder().encode(coverage.transactionId).byteLength >
+				NATIVE_DURABILITY_MAX_TRANSACTION_ID_BYTES ||
+			transactionIds.has(coverage.transactionId) ||
+			typeof coverage.stagingManifestDigest !== "string"
+		) {
+			throw new NativeDurabilityStorageCorruptionError(
+				`Checkpoint staging coverage ${index} is invalid`,
+			);
+		}
+		transactionIds.add(coverage.transactionId);
+		const txSequence = parseUnsignedBigint(
+			coverage.txSequence,
+			`checkpoint staging coverage ${index} transaction sequence`,
+		);
+		const coveredThroughLsn = parseUnsignedBigint(
+			coverage.coveredThroughLsn,
+			`checkpoint staging coverage ${index} LSN`,
+		);
+		if (
+			txSequence === 0n ||
+			coveredThroughLsn === 0n ||
+			coveredThroughLsn > checkpointLsn
+		) {
+			throw new NativeDurabilityStorageCorruptionError(
+				`Checkpoint staging coverage ${index} exceeds its checkpoint`,
+			);
+		}
+		return {
+			transactionId: coverage.transactionId,
+			txSequence,
+			coveredThroughLsn,
+			stagingManifestDigest: nativeDurabilityDigestFromHex(
+				coverage.stagingManifestDigest,
+			),
+		};
+	});
+};
+
+const parseDiskRetainedTransactions = (
+	value: unknown,
+	txSequenceHighwater: bigint,
+): NativeDurabilityCheckpointTransactionState[] => {
+	if (!Array.isArray(value)) {
+		throw new NativeDurabilityStorageCorruptionError(
+			"Checkpoint retained transactions are invalid",
+		);
+	}
+	const transactionIds = new Set<string>();
+	const transactionSequences = new Set<bigint>();
+	return value.map((unknownRetained, index) => {
+		const retained = unknownRetained as Partial<DiskRetainedTransaction>;
+		const txSequence = parseUnsignedBigint(
+			retained.txSequence,
+			`retained transaction ${index} sequence`,
+		);
+		if (
+			txSequence === 0n ||
+			txSequence > txSequenceHighwater ||
+			typeof retained.transactionId !== "string" ||
+			!retained.transactionId ||
+			new TextEncoder().encode(retained.transactionId).byteLength >
+				NATIVE_DURABILITY_MAX_TRANSACTION_ID_BYTES ||
+			transactionIds.has(retained.transactionId) ||
+			transactionSequences.has(txSequence) ||
+			!Number.isInteger(retained.phase) ||
+			(retained.phase as number) < 1 ||
+			(retained.phase as number) > 6 ||
+			!Number.isInteger(retained.operationKind) ||
+			(retained.operationKind as number) < 1 ||
+			(retained.operationKind as number) > 5 ||
+			typeof retained.planDigest !== "string"
+		) {
+			throw new NativeDurabilityStorageCorruptionError(
+				`Retained transaction ${index} is invalid`,
+			);
+		}
+		transactionIds.add(retained.transactionId);
+		transactionSequences.add(txSequence);
+		return {
+			txSequence,
+			transactionId: retained.transactionId,
+			phase: retained.phase,
+			operationKind: retained.operationKind,
+			planDigest: nativeDurabilityDigestFromHex(retained.planDigest),
+		} as NativeDurabilityCheckpointTransactionState;
+	});
+};
+
+const cloneCheckpoint = (
+	checkpoint: NativeDurabilityCheckpoint,
+): NativeDurabilityCheckpoint => ({
+	...checkpoint,
+	bytes: copyNativeDurabilityBytes(checkpoint.bytes),
+	digest: copyNativeDurabilityBytes(checkpoint.digest),
+	originFence: { ...checkpoint.originFence },
+	stagingCoverage: checkpoint.stagingCoverage.map((coverage) => ({
+		...coverage,
+		stagingManifestDigest: copyNativeDurabilityBytes(
+			coverage.stagingManifestDigest,
+		),
+	})),
+	retainedTransactions: checkpoint.retainedTransactions.map((retained) => ({
+		...retained,
+		planDigest: copyNativeDurabilityBytes(retained.planDigest),
+	})),
+});
+
+const snapshotStageRequest = (
+	request: NativeDurabilityStageRequest,
+): NativeDurabilityStageRequest => {
+	assertNativeDurabilityStageRequest(request);
+	return {
+		scope: { ...request.scope },
+		blocks: [...request.blocks]
+			.sort((left, right) => left.ordinal - right.ordinal)
+			.map((block) => ({
+				ordinal: block.ordinal,
+				cid: block.cid,
+				bytes: copyNativeDurabilityBytes(block.bytes),
+				digest: copyNativeDurabilityBytes(block.digest),
+			})),
+	};
+};
+
+const snapshotJournalRequest = (
+	request: NativeDurabilityJournalAppendRequest,
+): NativeDurabilityJournalAppendRequest => {
+	assertNativeDurabilityJournalAppendRequest(request);
+	return {
+		...request,
+		frames: copyNativeDurabilityBytes(request.frames),
+		framesDigest: copyNativeDurabilityBytes(request.framesDigest),
+	};
+};
+
+const snapshotCheckpointRequest = (
+	request: NativeDurabilityCheckpointRequest,
+): NativeDurabilityCheckpointRequest => {
+	assertNativeDurabilityCheckpointRequest(request);
+	return {
+		...request,
+		scope: { ...request.scope },
+		bytes: copyNativeDurabilityBytes(request.bytes),
+		digest: copyNativeDurabilityBytes(request.digest),
+		stagingCoverage: request.stagingCoverage.map((coverage) => ({
+			...coverage,
+			stagingManifestDigest: copyNativeDurabilityBytes(
+				coverage.stagingManifestDigest,
+			),
+		})),
+		retainedTransactions: request.retainedTransactions.map((retained) => ({
+			...retained,
+			planDigest: copyNativeDurabilityBytes(retained.planDigest),
+		})),
+	};
+};
+
+const snapshotDeleteRequest = (
+	request: NativeDurabilityDeleteRequest,
+): NativeDurabilityDeleteRequest => {
+	assertNativeDurabilityDeleteRequest(request);
+	return {
+		scope: { ...request.scope },
+		targets: request.targets.map((target) => ({ ...target })),
+	};
+};
+
+const nodeNativeDurabilityStorageConstructionToken = Symbol(
+	"NodeNativeDurabilityStorageConstructionToken",
+);
+
+export class NodeNativeDurabilityStorage implements NativeDurabilityStorage {
+	readonly version = NATIVE_DURABILITY_STORAGE_VERSION;
+	readonly kind = "node-fsync" as const;
+	readonly crashSafe = true;
+	readonly domainId: string;
+	readonly fence: NativeDurabilityLease["fence"];
+
+	private readonly rootDirectory: string;
+	private readonly namespaceDirectory: string;
+	private readonly stagingDirectory: string;
+	private readonly checkpointDirectory: string;
+	private readonly journalPath: string;
+	private operationTail: Promise<void> = Promise.resolve();
+	private closePromise?: Promise<void>;
+	private closing = false;
+	private closed = false;
+	private barrierOrdinal = 0n;
+	private strictDeleteCount = 0n;
+
+	private constructor(
+		constructionToken: typeof nodeNativeDurabilityStorageConstructionToken,
+		private readonly lease: NativeDurabilityLease,
+		private readonly journalCodec: NativeDurabilityJournalCodec,
+		private readonly programId: Uint8Array,
+		rootDirectory: string,
+	) {
+		if (constructionToken !== nodeNativeDurabilityStorageConstructionToken) {
+			throw new TypeError(
+				"NodeNativeDurabilityStorage must be created by createNodeNativeDurabilityStorage",
+			);
+		}
+		if (!isNativeDurabilityJournalCodec(journalCodec)) {
+			throw new TypeError(
+				"NodeNativeDurabilityStorage requires the official native durability journal codec",
+			);
+		}
+		assertNativeDurabilityFence(lease.fence);
+		this.domainId = lease.fence.domainId;
+		this.fence = Object.freeze({ ...lease.fence });
+		const path = requireNodePath();
+		const root = path.resolve(rootDirectory);
+		this.rootDirectory = root;
+		this.namespaceDirectory = path.join(root, STORAGE_DIRECTORY_NAME);
+		this.stagingDirectory = path.join(
+			this.namespaceDirectory,
+			STAGING_DIRECTORY_NAME,
+		);
+		this.checkpointDirectory = path.join(
+			this.namespaceDirectory,
+			CHECKPOINT_DIRECTORY_NAME,
+		);
+		this.journalPath = path.join(this.namespaceDirectory, JOURNAL_FILE_NAME);
+	}
+
+	static async create(
+		options: NativeDurabilityNodeStorageOptions,
+	): Promise<NodeNativeDurabilityStorage> {
+		if (
+			!(options?.programId instanceof Uint8Array) ||
+			options.programId.byteLength === 0 ||
+			options.programId.byteLength >
+				NATIVE_DURABILITY_JOURNAL_MAX_PROGRAM_ID_LENGTH
+		) {
+			throw new TypeError(
+				`programId must contain 1-${NATIVE_DURABILITY_JOURNAL_MAX_PROGRAM_ID_LENGTH} bytes`,
+			);
+		}
+		if (typeof options.directory !== "string" || !options.directory) {
+			throw new TypeError("directory must be a non-empty string");
+		}
+		const requestedDirectory = options.directory;
+		const programId = copyNativeDurabilityBytes(options.programId);
+		await loadNodeModules();
+		const fs = requireNodeFs();
+		const canonicalDirectory = await fs.realpath(requestedDirectory);
+		if (!(await fs.stat(canonicalDirectory)).isDirectory()) {
+			throw new NativeDurabilityStorageUnsupportedError(
+				`Native durability root is not a directory: ${canonicalDirectory}`,
+			);
+		}
+		const lease = await acquireNativeDurabilityNodeLease(canonicalDirectory);
+		try {
+			const initialContext: NativeDurabilityJournalValidationContext = {
+				checkpointLsn: 0n,
+				checkpointTxSequenceHighwater: 0n,
+				expectedProgramId: programId,
+				expectedWriterDomainId: lease.fence.domainId,
+				checkpointWriterEpoch: 0n,
+				currentWriterEpoch: lease.fence.epoch,
+				currentWriterOwnerId: lease.fence.ownerId,
+				retainedTransactions: [],
+			};
+			const codec = await createNativeDurabilityJournalCodec(initialContext);
+			const storage = new NodeNativeDurabilityStorage(
+				nodeNativeDurabilityStorageConstructionToken,
+				lease,
+				codec,
+				programId,
+				canonicalDirectory,
+			);
+			await storage.enqueue(async () => storage.initialize());
+			return storage;
+		} catch (error) {
+			await lease.close();
+			throw error;
+		}
+	}
+
+	private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+		if (this.closing || this.closed) {
+			return Promise.reject(new NativeDurabilityStorageClosedError());
+		}
+		const result = this.operationTail.then(() =>
+			this.lease.runWhileHeld(operation),
+		);
+		const settled = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		this.operationTail = settled;
+		return result;
+	}
+
+	private async initialize(): Promise<void> {
+		const fs = requireNodeFs();
+		const entries = await fs.readdir(this.rootDirectory);
+		const namespaceExists = entries.includes(STORAGE_DIRECTORY_NAME);
+		const legacyEntries = entries.filter(
+			(entry) =>
+				entry !== STORAGE_DIRECTORY_NAME &&
+				entry !== NATIVE_DURABILITY_NODE_LEASE_DIRECTORY_NAME,
+		);
+		if (!namespaceExists && legacyEntries.length > 0) {
+			throw new NativeDurabilityMigrationRequiredError(this.rootDirectory);
+		}
+		if (namespaceExists && legacyEntries.length > 0) {
+			const existingCheckpoints = await this.readValidCheckpointsInternal();
+			const existingJournalBase = await this.readJournalBaseCheckpoint();
+			if (existingCheckpoints.length === 0 || !existingJournalBase) {
+				throw new NativeDurabilityMigrationRequiredError(this.rootDirectory);
+			}
+		}
+		await ensureDirectory(this.namespaceDirectory, this.rootDirectory);
+		await ensureDirectory(this.stagingDirectory, this.namespaceDirectory);
+		await ensureDirectory(this.checkpointDirectory, this.namespaceDirectory);
+		const hasEstablishedAuthority = (
+			await Promise.all([
+				readFileIfExists(this.checkpointHighwaterPath()),
+				readFileIfExists(this.checkpointManifestPath("a")),
+				readFileIfExists(this.checkpointManifestPath("b")),
+				readFileIfExists(
+					requireNodePath().join(
+						this.checkpointDirectory,
+						JOURNAL_BASE_MANIFEST,
+					),
+				),
+			])
+		).some((bytes) => bytes != null);
+		let journalExists = false;
+		try {
+			journalExists = (await fs.stat(this.journalPath)).isFile();
+		} catch (error) {
+			if (!isNotFound(error)) throw error;
+		}
+		if (!journalExists) {
+			if (hasEstablishedAuthority) {
+				throw new NativeDurabilityStorageCorruptionError(
+					"Established native durability authority is missing journal.bin",
+				);
+			}
+			const handle = await fs.open(this.journalPath, "wx+");
+			try {
+				await handle.sync();
+			} finally {
+				await handle.close();
+			}
+			await syncDirectory(this.namespaceDirectory);
+		}
+		// This is also a feature probe: crash-safe mode is unavailable when the
+		// platform/filesystem cannot fsync a directory.
+		await syncDirectory(this.namespaceDirectory);
+		await this.ensureGenesisCheckpoint(legacyEntries.length === 0);
+		await this.reconcileCheckpointGenerationState();
+		const journalBase = await this.readJournalBaseCheckpoint();
+		if (!journalBase) {
+			throw new NativeDurabilityStorageCorruptionError(
+				"Native durability journal base is missing after initialization",
+			);
+		}
+		const journalHandle = await fs.open(this.journalPath, "r+");
+		let journalScan: NativeDurabilityJournalScan;
+		try {
+			const journalLength = Number((await journalHandle.stat()).size);
+			if (!Number.isSafeInteger(journalLength) || journalLength < 0) {
+				throw new NativeDurabilityStorageCorruptionError(
+					"Native durability journal size is not a safe byte offset",
+				);
+			}
+			journalScan = this.journalCodec.scan(
+				await readNativeDurabilityBytesFully(journalHandle, journalLength),
+				this.checkpointValidationContext(journalBase),
+			);
+			// A reopen that observes complete prepared frames must cross a fresh
+			// barrier before recovery can classify them as durable. This also makes
+			// a complete-write/before-sync process death recoverable without the
+			// original caller retaining its append request.
+			await journalHandle.sync();
+		} finally {
+			await journalHandle.close();
+		}
+		const activeCheckpoint = (await this.readValidCheckpointsInternal())[0];
+		if (
+			!activeCheckpoint ||
+			journalScan.lastRecordLsn < activeCheckpoint.checkpointLsn
+		) {
+			throw new NativeDurabilityStorageCorruptionError(
+				"Journal authority ends before the active checkpoint watermark",
+			);
+		}
+		await this.reconcileStagingOrphans(journalScan.records);
+	}
+
+	private checkpointManifestPath(slot: "a" | "b"): string {
+		return requireNodePath().join(
+			this.checkpointDirectory,
+			slot === "a" ? CHECKPOINT_MANIFEST_A : CHECKPOINT_MANIFEST_B,
+		);
+	}
+
+	private checkpointHighwaterPath(): string {
+		return requireNodePath().join(
+			this.checkpointDirectory,
+			CHECKPOINT_HIGHWATER_FILE_NAME,
+		);
+	}
+
+	private async readGenerationState(): Promise<GenerationState | undefined> {
+		const bytes = await readFileIfExists(this.checkpointHighwaterPath());
+		if (!bytes) return undefined;
+		const disk = decodeManifest<DiskGenerationHighwater>(
+			bytes,
+			"checkpoint generation highwater",
+		);
+		if (disk.version !== this.version) {
+			throw new NativeDurabilityStorageCorruptionError(
+				"Checkpoint generation highwater version is invalid",
+			);
+		}
+		const generation = parseUnsignedBigint(
+			disk.generation,
+			"checkpoint generation highwater",
+		);
+		const pending = parseGenerationIdentity(disk.pending, "pending");
+		const completed = parseGenerationIdentity(disk.completed, "completed");
+		if (
+			(pending &&
+				(pending.generation !== generation || pending.generation === 0n)) ||
+			(completed &&
+				(completed.generation > generation || completed.generation === 0n)) ||
+			(pending && completed && completed.generation >= pending.generation)
+		) {
+			throw new NativeDurabilityStorageCorruptionError(
+				"Checkpoint request identity exceeds its generation highwater",
+			);
+		}
+		return { generation, pending, completed };
+	}
+
+	private async writeGenerationState(state: GenerationState): Promise<void> {
+		await replaceFileAtomicallyAndSync(
+			this.checkpointHighwaterPath(),
+			encodeManifest({
+				version: this.version,
+				generation: state.generation.toString(),
+				pending: state.pending
+					? diskGenerationIdentity(state.pending)
+					: undefined,
+				completed: state.completed
+					? diskGenerationIdentity(state.completed)
+					: undefined,
+			} satisfies DiskGenerationHighwater),
+			`${this.lease.fence.epoch}-${this.lease.fence.ownerId}`,
+		);
+	}
+
+	private async readCheckpointSlot(
+		slot: "a" | "b",
+	): Promise<NativeDurabilityCheckpoint | undefined> {
+		return this.readCheckpointManifest(
+			this.checkpointManifestPath(slot),
+			slot,
+			`checkpoint manifest ${slot}`,
+		);
+	}
+
+	private async readCheckpointManifest(
+		path: string,
+		manifestSlot: "a" | "b",
+		subject: string,
+	): Promise<NativeDurabilityCheckpoint | undefined> {
+		const manifestBytes = await readFileIfExists(path);
+		if (!manifestBytes) return undefined;
+		const disk = decodeManifest<DiskCheckpointManifest>(manifestBytes, subject);
+		if (
+			disk.version !== this.version ||
+			typeof disk.file !== "string" ||
+			!Number.isSafeInteger(disk.byteLength) ||
+			disk.byteLength < 0 ||
+			typeof disk.digest !== "string"
+		) {
+			throw new NativeDurabilityStorageCorruptionError(
+				`${subject} fields are invalid`,
+			);
+		}
+		const persistedProgramId = bytesFromHex(
+			disk.programId,
+			`${subject} program ID`,
+		);
+		if (!nativeDurabilityBytesEqual(persistedProgramId, this.programId)) {
+			throw new NativeDurabilityStorageCorruptionError(
+				`${subject} belongs to another program`,
+			);
+		}
+		const generation = parseUnsignedBigint(
+			disk.generation,
+			`${subject} generation`,
+		);
+		const checkpointLsn = parseUnsignedBigint(
+			disk.checkpointLsn,
+			`${subject} LSN`,
+		);
+		const txSequenceHighwater = parseUnsignedBigint(
+			disk.txSequenceHighwater,
+			`${subject} transaction highwater`,
+		);
+		if (disk.file !== checkpointFileName(generation)) {
+			throw new NativeDurabilityStorageCorruptionError(
+				`${subject} has a noncanonical generation file`,
+			);
+		}
+		const originFence = parseDiskFence(disk.originFence, subject);
+		if (
+			originFence.domainId !== this.domainId ||
+			originFence.epoch > this.lease.fence.epoch ||
+			(originFence.epoch === this.lease.fence.epoch &&
+				originFence.ownerId !== this.lease.fence.ownerId)
+		) {
+			throw new NativeDurabilityStorageCorruptionError(
+				`${subject} has an invalid durability fence`,
+			);
+		}
+		const stagingCoverage = parseDiskStagingCoverage(
+			disk.stagingCoverage,
+			checkpointLsn,
+		);
+		const retainedTransactions = parseDiskRetainedTransactions(
+			disk.retainedTransactions,
+			txSequenceHighwater,
+		);
+		if (
+			(generation === 0n &&
+				(checkpointLsn !== 0n ||
+					txSequenceHighwater !== 0n ||
+					stagingCoverage.length !== 0 ||
+					retainedTransactions.length !== 0 ||
+					disk.byteLength !== 0)) ||
+			(generation > 0n &&
+				(checkpointLsn === 0n || txSequenceHighwater === 0n)) ||
+			stagingCoverage.some(
+				(coverage) => coverage.txSequence > txSequenceHighwater,
+			)
+		) {
+			throw new NativeDurabilityStorageCorruptionError(
+				`${subject} checkpoint watermarks are inconsistent`,
+			);
+		}
+		for (const coverage of stagingCoverage) {
+			const retained = retainedTransactions.find(
+				(candidate) => candidate.transactionId === coverage.transactionId,
+			);
+			if (
+				!retained ||
+				retained.txSequence !== coverage.txSequence ||
+				retained.phase !== NativeDurabilityPhase.Clean
+			) {
+				throw new NativeDurabilityStorageCorruptionError(
+					`${subject} staging coverage lacks an exact retained CLEAN transaction`,
+				);
+			}
+		}
+		const checkpointBytes = await readFileIfExists(
+			requireNodePath().join(this.checkpointDirectory, disk.file),
+		);
+		const digest = nativeDurabilityDigestFromHex(disk.digest);
+		if (
+			!checkpointBytes ||
+			checkpointBytes.byteLength !== disk.byteLength ||
+			!nativeDurabilityBytesEqual(sha256(checkpointBytes), digest)
+		) {
+			throw new NativeDurabilityStorageCorruptionError(
+				`Checkpoint generation ${generation} is missing or corrupt`,
+			);
+		}
+		return {
+			version: this.version,
+			generation,
+			checkpointLsn,
+			txSequenceHighwater,
+			bytes: checkpointBytes,
+			digest,
+			originFence,
+			manifestSlot,
+			stagingCoverage,
+			retainedTransactions,
+		};
+	}
+
+	private readJournalBaseCheckpoint(): Promise<
+		NativeDurabilityCheckpoint | undefined
+	> {
+		return this.readCheckpointManifest(
+			requireNodePath().join(this.checkpointDirectory, JOURNAL_BASE_MANIFEST),
+			"a",
+			"journal base manifest",
+		);
+	}
+
+	private async readValidCheckpointsInternal(): Promise<
+		NativeDurabilityCheckpoint[]
+	> {
+		const checkpoints = (
+			await Promise.all([
+				this.readCheckpointSlot("a"),
+				this.readCheckpointSlot("b"),
+			])
+		).filter(
+			(checkpoint): checkpoint is NativeDurabilityCheckpoint =>
+				checkpoint != null,
+		);
+		if (
+			checkpoints.length === 2 &&
+			checkpoints[0].generation === checkpoints[1].generation
+		) {
+			throw new NativeDurabilityStorageCorruptionError(
+				"Checkpoint manifest slots select the same generation",
+			);
+		}
+		return checkpoints.sort((left, right) =>
+			left.generation < right.generation
+				? 1
+				: left.generation > right.generation
+					? -1
+					: 0,
+		);
+	}
+
+	private async ensureGenesisCheckpoint(mayCreate: boolean): Promise<void> {
+		const checkpoints = await this.readValidCheckpointsInternal();
+		if (checkpoints.length > 0) {
+			const state = await this.readGenerationState();
+			if (state == null || state.generation < checkpoints[0].generation) {
+				throw new NativeDurabilityStorageCorruptionError(
+					"Checkpoint generation highwater is missing or regressed",
+				);
+			}
+			const selectedPending = state.pending
+				? checkpoints.find(
+						(checkpoint) => checkpoint.generation === state.pending?.generation,
+					)
+				: undefined;
+			const expectedActiveGeneration =
+				selectedPending?.generation ?? state.completed?.generation ?? 0n;
+			if (checkpoints[0].generation !== expectedActiveGeneration) {
+				throw new NativeDurabilityStorageCorruptionError(
+					`Active checkpoint generation ${checkpoints[0].generation} does not match completed generation ${expectedActiveGeneration}`,
+				);
+			}
+			const journalBase = await this.readJournalBaseCheckpoint();
+			if (!journalBase || journalBase.generation !== 0n) {
+				throw new NativeDurabilityStorageCorruptionError(
+					"Journal base checkpoint is missing or unsupported",
+				);
+			}
+			return;
+		}
+		if (!mayCreate) {
+			throw new NativeDurabilityMigrationRequiredError(this.rootDirectory);
+		}
+		const journal = await readFileIfExists(this.journalPath);
+		if (journal && journal.byteLength !== 0) {
+			throw new NativeDurabilityStorageCorruptionError(
+				"Cannot create genesis for a nonempty durability journal",
+			);
+		}
+		const existingState = await this.readGenerationState();
+		if (
+			existingState != null &&
+			(existingState.generation !== 0n ||
+				existingState.pending != null ||
+				existingState.completed != null)
+		) {
+			throw new NativeDurabilityStorageCorruptionError(
+				"Incomplete genesis has a nonzero checkpoint generation highwater",
+			);
+		}
+		if (existingState == null)
+			await this.writeGenerationState({ generation: 0n });
+		const genesisBytes = new Uint8Array();
+		const genesisPath = requireNodePath().join(
+			this.checkpointDirectory,
+			checkpointFileName(0n),
+		);
+		const existingGenesis = await readFileIfExists(genesisPath);
+		if (existingGenesis) {
+			if (existingGenesis.byteLength !== 0) {
+				throw new NativeDurabilityStorageCorruptionError(
+					"Incomplete genesis checkpoint conflicts with the canonical empty checkpoint",
+				);
+			}
+			const handle = await requireNodeFs().open(genesisPath, "r+");
+			try {
+				await handle.sync();
+			} finally {
+				await handle.close();
+			}
+			await syncDirectory(this.checkpointDirectory);
+		} else {
+			await writeImmutableFileAtomicallyAndSync(
+				genesisPath,
+				genesisBytes,
+				`${this.lease.fence.epoch}-${this.lease.fence.ownerId}`,
+			);
+		}
+		const manifest: DiskCheckpointManifest = {
+			version: this.version,
+			programId: bytesToHex(this.programId),
+			generation: "0",
+			checkpointLsn: "0",
+			txSequenceHighwater: "0",
+			file: checkpointFileName(0n),
+			byteLength: 0,
+			digest: sha256Hex(genesisBytes),
+			originFence: diskFence(this.lease),
+			stagingCoverage: [],
+			retainedTransactions: [],
+		};
+		const journalBasePath = requireNodePath().join(
+			this.checkpointDirectory,
+			JOURNAL_BASE_MANIFEST,
+		);
+		const existingJournalBase = await this.readJournalBaseCheckpoint();
+		if (existingJournalBase) {
+			if (existingJournalBase.generation !== 0n) {
+				throw new NativeDurabilityStorageCorruptionError(
+					"Incomplete genesis has a nonzero journal base",
+				);
+			}
+		} else {
+			await replaceFileAtomicallyAndSync(
+				journalBasePath,
+				encodeManifest(manifest),
+				`${this.lease.fence.epoch}-${this.lease.fence.ownerId}`,
+			);
+		}
+		await replaceFileAtomicallyAndSync(
+			this.checkpointManifestPath("a"),
+			encodeManifest(manifest),
+			`${this.lease.fence.epoch}-${this.lease.fence.ownerId}`,
+		);
+	}
+
+	private async reconcileCheckpointGenerationState(): Promise<void> {
+		const state = await this.readGenerationState();
+		if (!state) {
+			throw new NativeDurabilityStorageCorruptionError(
+				"Checkpoint generation state is missing",
+			);
+		}
+		if (state.pending) {
+			const checkpoints = await this.readValidCheckpointsInternal();
+			const selected = checkpoints.find(
+				(checkpoint) => checkpoint.generation === state.pending?.generation,
+			);
+			if (selected) {
+				if (selected.generation !== checkpoints[0]?.generation) {
+					throw new NativeDurabilityStorageCorruptionError(
+						"Pending checkpoint generation is selected behind a newer manifest",
+					);
+				}
+				await this.writeGenerationState({
+					generation: state.generation,
+					completed: state.pending,
+				});
+			} else {
+				await requireNodeFs().rm(
+					requireNodePath().join(
+						this.checkpointDirectory,
+						checkpointFileName(state.pending.generation),
+					),
+					{ force: true },
+				);
+				await syncDirectory(this.checkpointDirectory);
+				await this.writeGenerationState({
+					generation: state.generation,
+					completed: state.completed,
+				});
+			}
+		}
+		const temporaryPrefixes = [
+			CHECKPOINT_HIGHWATER_FILE_NAME,
+			CHECKPOINT_MANIFEST_A,
+			CHECKPOINT_MANIFEST_B,
+			JOURNAL_BASE_MANIFEST,
+		].map((name) => `${name}.tmp-`);
+		let removedTemporary = false;
+		for (const entry of await requireNodeFs().readdir(
+			this.checkpointDirectory,
+			{ withFileTypes: true },
+		)) {
+			if (
+				entry.isFile() &&
+				(temporaryPrefixes.some((prefix) => entry.name.startsWith(prefix)) ||
+					/^checkpoint-(0|[1-9][0-9]*)\.bin\.tmp-/.test(entry.name))
+			) {
+				await requireNodeFs().rm(
+					requireNodePath().join(this.checkpointDirectory, entry.name),
+					{ force: true },
+				);
+				removedTemporary = true;
+			}
+		}
+		if (removedTemporary) await syncDirectory(this.checkpointDirectory);
+	}
+
+	private async reconcileStagingOrphans(
+		records: readonly NativeDurabilityJournalRecord[],
+	): Promise<void> {
+		const activeCheckpoint = (await this.readValidCheckpointsInternal())[0];
+		if (!activeCheckpoint) {
+			throw new NativeDurabilityStorageCorruptionError(
+				"Staging reconciliation requires an active checkpoint",
+			);
+		}
+		const journalTransactionDirectories = new Set(
+			records.map((record) => transactionDirectoryName(record.transactionId)),
+		);
+		let removed = false;
+		for (const entry of await requireNodeFs().readdir(this.stagingDirectory, {
+			withFileTypes: true,
+		})) {
+			if (!entry.isDirectory() || !/^tx-[0-9a-f]{64}$/.test(entry.name)) {
+				throw new NativeDurabilityStorageCorruptionError(
+					`Unexpected private staging entry ${entry.name}`,
+				);
+			}
+			const transactionDirectory = requireNodePath().join(
+				this.stagingDirectory,
+				entry.name,
+			);
+			if (!journalTransactionDirectories.has(entry.name)) {
+				await requireNodeFs().rm(transactionDirectory, {
+					recursive: true,
+					force: true,
+				});
+				removed = true;
+				continue;
+			}
+			const manifestBytes = await readFileIfExists(
+				requireNodePath().join(
+					transactionDirectory,
+					STAGING_MANIFEST_FILE_NAME,
+				),
+			);
+			if (!manifestBytes) {
+				const record = records.findLast(
+					(candidate) =>
+						transactionDirectoryName(candidate.transactionId) === entry.name,
+				);
+				if (
+					record &&
+					this.checkpointAuthorizesStagingDeletion(
+						activeCheckpoint,
+						record.transactionId,
+						records,
+					)
+				) {
+					await requireNodeFs().rm(transactionDirectory, {
+						recursive: true,
+						force: true,
+					});
+					removed = true;
+					continue;
+				}
+				throw new NativeDurabilityStorageCorruptionError(
+					`Journal-owned staging directory ${entry.name} has no manifest`,
+				);
+			}
+			const parsed = parseStagingManifest(manifestBytes);
+			if (entry.name !== transactionDirectoryName(parsed.scope.transactionId)) {
+				throw new NativeDurabilityStorageCorruptionError(
+					`Staging directory ${entry.name} does not match its manifest`,
+				);
+			}
+			await this.readStagingManifestInternal(parsed.scope.transactionId);
+			if (
+				this.checkpointAuthorizesStagingDeletion(
+					activeCheckpoint,
+					parsed.scope.transactionId,
+					records,
+					parsed,
+				)
+			) {
+				await requireNodeFs().rm(transactionDirectory, {
+					recursive: true,
+					force: true,
+				});
+				removed = true;
+				continue;
+			}
+			for (const block of parsed.blocks) {
+				const blockBytes = await readFileIfExists(
+					requireNodePath().join(
+						transactionDirectory,
+						blockFileName(block.ordinal),
+					),
+				);
+				if (
+					!blockBytes ||
+					blockBytes.byteLength !== block.byteLength ||
+					!nativeDurabilityBytesEqual(sha256(blockBytes), block.digest)
+				) {
+					throw new NativeDurabilityStorageCorruptionError(
+						`Journal-owned staged block ${block.ordinal} is missing or corrupt`,
+					);
+				}
+			}
+		}
+		if (removed) await syncDirectory(this.stagingDirectory);
+	}
+
+	private checkpointAuthorizesStagingDeletion(
+		checkpoint: NativeDurabilityCheckpoint,
+		transactionId: string,
+		records: readonly NativeDurabilityJournalRecord[],
+		staged?: NativeDurabilityStagingManifest,
+	): boolean {
+		const coverage = checkpoint.stagingCoverage.find(
+			(candidate) => candidate.transactionId === transactionId,
+		);
+		const retained = checkpoint.retainedTransactions.find(
+			(candidate) => candidate.transactionId === transactionId,
+		);
+		const record = records.findLast(
+			(candidate) => candidate.transactionId === transactionId,
+		);
+		return !!(
+			coverage &&
+			retained &&
+			record &&
+			retained.phase === NativeDurabilityPhase.Clean &&
+			record.phase === NativeDurabilityPhase.Clean &&
+			coverage.txSequence === retained.txSequence &&
+			coverage.txSequence === record.txSequence &&
+			retained.operationKind === record.operationKind &&
+			nativeDurabilityBytesEqual(retained.planDigest, record.planDigest) &&
+			coverage.coveredThroughLsn >= record.recordLsn &&
+			coverage.coveredThroughLsn <= checkpoint.checkpointLsn &&
+			(!staged ||
+				(staged.scope.txSequence === coverage.txSequence &&
+					coverage.coveredThroughLsn >= staged.scope.recordLsn &&
+					nativeDurabilityBytesEqual(
+						coverage.stagingManifestDigest,
+						staged.manifestDigest,
+					)))
+		);
+	}
+
+	private checkpointValidationContext(
+		checkpoint: NativeDurabilityCheckpoint,
+	): NativeDurabilityJournalValidationContext {
+		return {
+			checkpointLsn: checkpoint.checkpointLsn,
+			checkpointTxSequenceHighwater: checkpoint.txSequenceHighwater,
+			expectedProgramId: copyNativeDurabilityBytes(this.programId),
+			expectedWriterDomainId: this.domainId,
+			checkpointWriterEpoch: checkpoint.originFence.epoch,
+			checkpointWriterOwnerId: checkpoint.originFence.ownerId,
+			currentWriterEpoch: this.lease.fence.epoch,
+			currentWriterOwnerId: this.lease.fence.ownerId,
+			retainedTransactions: checkpoint.retainedTransactions.map((retained) => ({
+				...retained,
+				planDigest: copyNativeDurabilityBytes(retained.planDigest),
+			})),
+		};
+	}
+
+	private transactionDirectory(transactionId: string): string {
+		return requireNodePath().join(
+			this.stagingDirectory,
+			transactionDirectoryName(transactionId),
+		);
+	}
+
+	private async readStagingManifestInternal(
+		transactionId: string,
+	): Promise<NativeDurabilityStagingManifest | undefined> {
+		const bytes = await readFileIfExists(
+			requireNodePath().join(
+				this.transactionDirectory(transactionId),
+				STAGING_MANIFEST_FILE_NAME,
+			),
+		);
+		if (!bytes) return undefined;
+		const manifest = parseStagingManifest(bytes, transactionId);
+		if (
+			manifest.fence.domainId !== this.lease.fence.domainId ||
+			manifest.fence.epoch > this.lease.fence.epoch ||
+			(manifest.fence.epoch === this.lease.fence.epoch &&
+				manifest.fence.ownerId !== this.lease.fence.ownerId)
+		) {
+			throw new NativeDurabilityStorageCorruptionError(
+				`Staging transaction ${transactionId} has an invalid persisted fence`,
+			);
+		}
+		return manifest;
+	}
+
+	async stageAndSync(
+		unsafeRequest: NativeDurabilityStageRequest,
+	): Promise<NativeDurabilityStageReceipt> {
+		const request = snapshotStageRequest(unsafeRequest);
+		return this.enqueue(async () => {
+			for (const block of request.blocks) {
+				if (!nativeDurabilityBytesEqual(sha256(block.bytes), block.digest)) {
+					throw new NativeDurabilityDigestMismatchError(
+						`staged block ${block.ordinal}`,
+					);
+				}
+			}
+			const transactionDirectory = this.transactionDirectory(
+				request.scope.transactionId,
+			);
+			const references: NativeDurabilityStagedBlockReference[] =
+				request.blocks.map((block) => ({
+					ordinal: block.ordinal,
+					cid: block.cid,
+					byteLength: block.bytes.byteLength,
+					digest: copyNativeDurabilityBytes(block.digest),
+				}));
+			let started = false;
+			try {
+				let transactionDirectoryExists = false;
+				try {
+					transactionDirectoryExists = (
+						await requireNodeFs().stat(transactionDirectory)
+					).isDirectory();
+				} catch (error) {
+					if (!isNotFound(error)) throw error;
+				}
+				const existing = await this.readStagingManifestInternal(
+					request.scope.transactionId,
+				);
+				let manifest: NativeDurabilityStagingManifest;
+				if (existing) {
+					if (
+						existing.scope.txSequence !== request.scope.txSequence ||
+						existing.scope.recordLsn !== request.scope.recordLsn ||
+						existing.blocks.length !== references.length ||
+						existing.blocks.some(
+							(block, index) =>
+								block.ordinal !== references[index].ordinal ||
+								block.cid !== references[index].cid ||
+								block.byteLength !== references[index].byteLength ||
+								!nativeDurabilityBytesEqual(
+									block.digest,
+									references[index].digest,
+								),
+						)
+					) {
+						throw new NativeDurabilityStorageCorruptionError(
+							`Staging transaction ${request.scope.transactionId} conflicts with its durable manifest`,
+						);
+					}
+					for (const block of existing.blocks) {
+						const blockPath = requireNodePath().join(
+							transactionDirectory,
+							blockFileName(block.ordinal),
+						);
+						const bytes = await readFileIfExists(blockPath);
+						if (
+							!bytes ||
+							bytes.byteLength !== block.byteLength ||
+							!nativeDurabilityBytesEqual(sha256(bytes), block.digest)
+						) {
+							throw new NativeDurabilityStorageCorruptionError(
+								`Staged block ${block.ordinal} is missing or corrupt`,
+							);
+						}
+						const handle = await requireNodeFs().open(blockPath, "r+");
+						try {
+							await handle.sync();
+						} finally {
+							await handle.close();
+						}
+					}
+					await syncDirectory(transactionDirectory);
+					manifest = existing;
+				} else {
+					started = true;
+					if (!transactionDirectoryExists) {
+						await ensureDirectory(transactionDirectory, this.stagingDirectory);
+					} else {
+						const expectedFiles = new Set(
+							request.blocks.map((block) => blockFileName(block.ordinal)),
+						);
+						for (const entry of await requireNodeFs().readdir(
+							transactionDirectory,
+							{
+								withFileTypes: true,
+							},
+						)) {
+							const isManifestTemporary = entry.name.startsWith(
+								`${STAGING_MANIFEST_FILE_NAME}.tmp-`,
+							);
+							const isBlockTemporary = [...expectedFiles].some((name) =>
+								entry.name.startsWith(`${name}.tmp-`),
+							);
+							if (
+								!entry.isFile() ||
+								(!expectedFiles.has(entry.name) &&
+									!isManifestTemporary &&
+									!isBlockTemporary)
+							) {
+								throw new NativeDurabilityStorageCorruptionError(
+									`Unexpected private staging entry ${entry.name}`,
+								);
+							}
+							if (isManifestTemporary || isBlockTemporary) {
+								await requireNodeFs().rm(
+									requireNodePath().join(transactionDirectory, entry.name),
+									{ force: true },
+								);
+							}
+						}
+						await syncDirectory(transactionDirectory);
+					}
+					for (const block of request.blocks) {
+						const blockPath = requireNodePath().join(
+							transactionDirectory,
+							blockFileName(block.ordinal),
+						);
+						const existingBlock = await readFileIfExists(blockPath);
+						if (existingBlock) {
+							if (
+								existingBlock.byteLength !== block.bytes.byteLength ||
+								!nativeDurabilityBytesEqual(sha256(existingBlock), block.digest)
+							) {
+								throw new NativeDurabilityStorageCorruptionError(
+									`Orphan staged block ${block.ordinal} conflicts with retry`,
+								);
+							}
+							const handle = await requireNodeFs().open(blockPath, "r+");
+							try {
+								await handle.sync();
+							} finally {
+								await handle.close();
+							}
+						} else {
+							await writeImmutableFileAtomicallyAndSync(
+								blockPath,
+								block.bytes,
+								`${this.lease.fence.epoch}-${this.lease.fence.ownerId}`,
+							);
+						}
+					}
+					const payload: DiskStagingManifest = {
+						version: this.version,
+						scope: diskScope(request.scope),
+						fence: diskFence(this.lease),
+						blocks: references.map((block) => ({
+							ordinal: block.ordinal,
+							cid: block.cid,
+							byteLength: block.byteLength,
+							digest: nativeDurabilityDigestHex(block.digest),
+						})),
+					};
+					const manifestBytes = encodeManifest(payload);
+					await replaceFileAtomicallyAndSync(
+						requireNodePath().join(
+							transactionDirectory,
+							STAGING_MANIFEST_FILE_NAME,
+						),
+						manifestBytes,
+						`${this.lease.fence.epoch}-${this.lease.fence.ownerId}`,
+					);
+					manifest = parseStagingManifest(
+						manifestBytes,
+						request.scope.transactionId,
+					);
+				}
+				this.barrierOrdinal++;
+				return {
+					version: this.version,
+					kind: "stage",
+					domainId: this.domainId,
+					fence: { ...this.lease.fence },
+					transactionId: request.scope.transactionId,
+					txSequence: request.scope.txSequence,
+					firstRecordLsn: request.scope.recordLsn,
+					lastRecordLsn: request.scope.recordLsn,
+					scopeDigest: sha256(encodeNativeDurabilityCanonical(request)),
+					barrierOrdinal: this.barrierOrdinal,
+					blocks: manifest.blocks.map((block) => ({
+						...block,
+						digest: copyNativeDurabilityBytes(block.digest),
+					})),
+					manifestDigest: copyNativeDurabilityBytes(manifest.manifestDigest),
+				};
+			} catch (error) {
+				if (!started) throw error;
+				throw new NativeDurabilityOutcomeUnknownError(
+					"stage",
+					request.scope.transactionId,
+					request.scope.txSequence,
+					error,
+				);
+			}
+		});
+	}
+
+	async readStagingManifest(
+		transactionId: string,
+	): Promise<NativeDurabilityStagingManifest | undefined> {
+		assertNativeDurabilityOperationScope({
+			transactionId,
+			txSequence: 0n,
+			recordLsn: 0n,
+		});
+		return this.enqueue(async () => {
+			const manifest = await this.readStagingManifestInternal(transactionId);
+			return (
+				manifest && {
+					...manifest,
+					scope: { ...manifest.scope },
+					fence: { ...manifest.fence },
+					blocks: manifest.blocks.map((block) => ({
+						...block,
+						digest: copyNativeDurabilityBytes(block.digest),
+					})),
+					manifestDigest: copyNativeDurabilityBytes(manifest.manifestDigest),
+				}
+			);
+		});
+	}
+
+	async readStagedBlock(
+		transactionId: string,
+		ordinal: number,
+	): Promise<Uint8Array | undefined> {
+		assertNativeDurabilityOperationScope({
+			transactionId,
+			txSequence: 0n,
+			recordLsn: 0n,
+		});
+		if (!Number.isSafeInteger(ordinal) || ordinal < 0) {
+			return Promise.reject(new RangeError("Invalid staging ordinal"));
+		}
+		return this.enqueue(async () => {
+			const manifest = await this.readStagingManifestInternal(transactionId);
+			const reference = manifest?.blocks.find(
+				(block) => block.ordinal === ordinal,
+			);
+			if (!reference) return undefined;
+			const bytes = await readFileIfExists(
+				requireNodePath().join(
+					this.transactionDirectory(transactionId),
+					blockFileName(ordinal),
+				),
+			);
+			if (
+				!bytes ||
+				bytes.byteLength !== reference.byteLength ||
+				!nativeDurabilityBytesEqual(sha256(bytes), reference.digest)
+			) {
+				throw new NativeDurabilityStorageCorruptionError(
+					`Staged block ${ordinal} is missing or corrupt`,
+				);
+			}
+			return bytes;
+		});
+	}
+
+	private async listStagingTransactionIdsInternal(): Promise<string[]> {
+		const entries = await requireNodeFs().readdir(this.stagingDirectory, {
+			withFileTypes: true,
+		});
+		const transactionIds: string[] = [];
+		for (const entry of entries) {
+			if (!entry.isDirectory() || !entry.name.startsWith("tx-")) {
+				throw new NativeDurabilityStorageCorruptionError(
+					`Unexpected private staging entry ${entry.name}`,
+				);
+			}
+			const bytes = await readFileIfExists(
+				requireNodePath().join(
+					this.stagingDirectory,
+					entry.name,
+					STAGING_MANIFEST_FILE_NAME,
+				),
+			);
+			if (!bytes) {
+				throw new NativeDurabilityStorageCorruptionError(
+					`Incomplete private staging directory ${entry.name}`,
+				);
+			}
+			const transactionId = parseStagingManifest(bytes).scope.transactionId;
+			if (entry.name !== transactionDirectoryName(transactionId)) {
+				throw new NativeDurabilityStorageCorruptionError(
+					`Staging directory ${entry.name} does not match its transaction manifest`,
+				);
+			}
+			await this.readStagingManifestInternal(transactionId);
+			transactionIds.push(transactionId);
+		}
+		return transactionIds.sort();
+	}
+
+	async listStagingTransactionIds(): Promise<string[]> {
+		return this.enqueue(async () => this.listStagingTransactionIdsInternal());
+	}
+
+	async appendJournalAndSync(
+		unsafeRequest: NativeDurabilityJournalAppendRequest,
+	): Promise<NativeDurabilityJournalReceipt> {
+		const request = snapshotJournalRequest(unsafeRequest);
+		return this.enqueue(async () => {
+			if (
+				!nativeDurabilityBytesEqual(
+					sha256(request.frames),
+					request.framesDigest,
+				)
+			) {
+				throw new NativeDurabilityDigestMismatchError("journal frames");
+			}
+			const checkpoint = await this.readJournalBaseCheckpoint();
+			if (!checkpoint) {
+				throw new NativeDurabilityStorageCorruptionError(
+					"Native durability journal has no valid checkpoint authority",
+				);
+			}
+			const context = this.checkpointValidationContext(checkpoint);
+			const handle = await requireNodeFs().open(this.journalPath, "r+");
+			let started = false;
+			try {
+				const actualOffset = Number((await handle.stat()).size);
+				if (!Number.isSafeInteger(actualOffset) || actualOffset < 0) {
+					throw new NativeDurabilityStorageCorruptionError(
+						"Native durability journal size is not a safe byte offset",
+					);
+				}
+				const endOffset = request.expectedOffset + request.frames.byteLength;
+				if (!Number.isSafeInteger(endOffset)) {
+					throw new NativeDurabilityStorageCorruptionError(
+						"Candidate journal end offset is not safe",
+					);
+				}
+				const alreadyWritten = actualOffset === endOffset;
+				if (actualOffset < request.expectedOffset || actualOffset > endOffset) {
+					throw new NativeDurabilityJournalOffsetConflictError(
+						request.expectedOffset,
+						actualOffset,
+					);
+				}
+				const observed = await readNativeDurabilityBytesFully(
+					handle,
+					actualOffset,
+				);
+				const prefix = observed.slice(0, request.expectedOffset);
+				const existingRequestLength = actualOffset - request.expectedOffset;
+				if (
+					!nativeDurabilityBytesEqual(
+						observed.slice(request.expectedOffset),
+						request.frames.slice(0, existingRequestLength),
+					)
+				) {
+					throw new NativeDurabilityStorageCorruptionError(
+						"Existing journal suffix conflicts with the exact append retry",
+					);
+				}
+				const prefixScan = this.journalCodec.scan(prefix, context);
+				if (
+					prefixScan.incompleteTailOffset != null ||
+					prefixScan.validLength !== prefix.byteLength
+				) {
+					throw new NativeDurabilityIncompleteTailMismatchError(
+						"Journal must be reconciled before appending another frame",
+					);
+				}
+				const candidate = new Uint8Array(
+					prefix.byteLength + request.frames.byteLength,
+				);
+				candidate.set(prefix);
+				candidate.set(request.frames, prefix.byteLength);
+				const candidateScan = this.journalCodec.scan(candidate, context);
+				if (
+					candidateScan.incompleteTailOffset != null ||
+					candidateScan.validLength !== candidate.byteLength
+				) {
+					throw new NativeDurabilityStorageCorruptionError(
+						"Candidate journal append is not a complete canonical frame sequence",
+					);
+				}
+				const appendedRecords = candidateScan.records.slice(
+					prefixScan.records.length,
+				);
+				if (appendedRecords.length === 0) {
+					throw new NativeDurabilityStorageCorruptionError(
+						"Candidate journal append contains no records",
+					);
+				}
+				const firstRecord = appendedRecords[0];
+				const lastRecord = appendedRecords[appendedRecords.length - 1];
+				if (
+					firstRecord.recordLsn !== request.firstRecordLsn ||
+					lastRecord.recordLsn !== request.lastRecordLsn ||
+					appendedRecords.some(
+						(record) =>
+							record.transactionId !== request.transactionId ||
+							record.txSequence !== request.txSequence ||
+							record.writerDomainId !== this.lease.fence.domainId ||
+							(existingRequestLength === 0 &&
+								(record.writerEpoch !== this.lease.fence.epoch ||
+									record.writerOwnerId !== this.lease.fence.ownerId)),
+					)
+				) {
+					throw new NativeDurabilityStorageCorruptionError(
+						"Candidate journal metadata does not match the intended transaction or current fence",
+					);
+				}
+				started = true;
+				if (!alreadyWritten) {
+					await writeNativeDurabilityBytesFully(
+						handle,
+						request.frames.slice(existingRequestLength),
+						actualOffset,
+					);
+				}
+				await handle.sync();
+				this.barrierOrdinal++;
+				return {
+					version: this.version,
+					kind: "journal-append",
+					domainId: this.domainId,
+					fence: { ...this.lease.fence },
+					transactionId: firstRecord.transactionId,
+					txSequence: firstRecord.txSequence,
+					firstRecordLsn: firstRecord.recordLsn,
+					lastRecordLsn: lastRecord.recordLsn,
+					scopeDigest: sha256(encodeNativeDurabilityCanonical(request)),
+					barrierOrdinal: this.barrierOrdinal,
+					offset: request.expectedOffset,
+					endOffset,
+					framesDigest: copyNativeDurabilityBytes(request.framesDigest),
+				};
+			} catch (error) {
+				if (!started) throw error;
+				throw new NativeDurabilityOutcomeUnknownError(
+					"journal-append",
+					request.transactionId,
+					request.txSequence,
+					error,
+				);
+			} finally {
+				try {
+					await handle.close();
+				} catch {
+					// A completed strict barrier is authoritative. When the body failed,
+					// that typed failure is authoritative instead. Close cannot alter either.
+				}
+			}
+		});
+	}
+
+	async readJournal(): Promise<Uint8Array> {
+		return this.enqueue(
+			async () =>
+				new Uint8Array(await requireNodeFs().readFile(this.journalPath)),
+		);
+	}
+
+	async reconcileIncompleteJournalTailAndSync(
+		unsafeRequest: NativeDurabilityIncompleteTailReconciliationRequest,
+	): Promise<NativeDurabilityJournalReconciliationReceipt> {
+		const request = { ...unsafeRequest };
+		try {
+			assertNativeDurabilityOperationScope({
+				...request,
+				recordLsn: 0n,
+			});
+		} catch (error) {
+			return Promise.reject(error);
+		}
+		if (request.txSequence === 0n) {
+			return Promise.reject(
+				new TypeError("Invalid incomplete-tail reconciliation request"),
+			);
+		}
+		return this.enqueue(async () => {
+			const checkpoint = await this.readJournalBaseCheckpoint();
+			if (!checkpoint) {
+				throw new NativeDurabilityStorageCorruptionError(
+					"Native durability journal has no valid checkpoint authority",
+				);
+			}
+			const handle = await requireNodeFs().open(this.journalPath, "r+");
+			let started = false;
+			try {
+				const observedLength = Number((await handle.stat()).size);
+				if (!Number.isSafeInteger(observedLength) || observedLength < 0) {
+					throw new NativeDurabilityStorageCorruptionError(
+						"Native durability journal size is not a safe byte offset",
+					);
+				}
+				const observed = await readNativeDurabilityBytesFully(
+					handle,
+					observedLength,
+				);
+				const observedDigest = sha256(observed);
+				const scan = this.journalCodec.scan(
+					copyNativeDurabilityBytes(observed),
+					this.checkpointValidationContext(checkpoint),
+				);
+				const hasIncompleteTail =
+					scan.incompleteTailOffset != null &&
+					scan.incompleteTailReason != null &&
+					scan.validLength === scan.incompleteTailOffset &&
+					scan.validLength < observed.byteLength;
+				const isAlreadyComplete =
+					scan.incompleteTailOffset == null &&
+					scan.incompleteTailReason == null &&
+					scan.validLength === observed.byteLength;
+				if (!hasIncompleteTail && !isAlreadyComplete) {
+					throw new NativeDurabilityIncompleteTailMismatchError(
+						"The exact current journal is neither complete nor a structurally incomplete tail",
+					);
+				}
+				const rereadLength = Number((await handle.stat()).size);
+				const reread =
+					rereadLength === observedLength
+						? await readNativeDurabilityBytesFully(handle, rereadLength)
+						: new Uint8Array();
+				if (
+					reread.byteLength !== observed.byteLength ||
+					!nativeDurabilityBytesEqual(sha256(reread), observedDigest)
+				) {
+					throw new NativeDurabilityIncompleteTailMismatchError(
+						"Journal changed after incomplete-tail classification",
+					);
+				}
+				started = true;
+				if (hasIncompleteTail) await handle.truncate(scan.validLength);
+				await handle.sync();
+				this.barrierOrdinal++;
+				return {
+					version: this.version,
+					kind: "journal-tail-reconciliation",
+					domainId: this.domainId,
+					fence: { ...this.lease.fence },
+					transactionId: request.transactionId,
+					txSequence: request.txSequence,
+					firstRecordLsn: scan.lastRecordLsn,
+					lastRecordLsn: scan.lastRecordLsn,
+					scopeDigest: sha256(
+						encodeNativeDurabilityCanonical({
+							...request,
+							validLength: scan.validLength,
+							incompleteTailReason:
+								scan.incompleteTailReason ?? "already-complete",
+							observedDigest,
+						}),
+					),
+					barrierOrdinal: this.barrierOrdinal,
+					previousLength: observed.byteLength,
+					validLength: scan.validLength,
+					observedDigest,
+				};
+			} catch (error) {
+				if (!started) throw error;
+				throw new NativeDurabilityOutcomeUnknownError(
+					"journal-tail-reconciliation",
+					request.transactionId,
+					request.txSequence,
+					error,
+				);
+			} finally {
+				try {
+					await handle.close();
+				} catch {
+					// Preserve the strict barrier result or the typed operation failure.
+				}
+			}
+		});
+	}
+
+	private checkpointReceipt(
+		request: NativeDurabilityCheckpointRequest,
+		requestDigest: Uint8Array,
+		checkpoint: Pick<
+			NativeDurabilityCheckpoint,
+			"generation" | "checkpointLsn" | "digest" | "manifestSlot"
+		>,
+	): NativeDurabilityCheckpointReceipt {
+		this.barrierOrdinal++;
+		return {
+			version: this.version,
+			kind: "checkpoint",
+			domainId: this.domainId,
+			fence: { ...this.lease.fence },
+			transactionId: request.scope.transactionId,
+			txSequence: request.scope.txSequence,
+			firstRecordLsn: request.scope.recordLsn,
+			lastRecordLsn: request.scope.recordLsn,
+			scopeDigest: copyNativeDurabilityBytes(requestDigest),
+			barrierOrdinal: this.barrierOrdinal,
+			generation: checkpoint.generation,
+			checkpointLsn: checkpoint.checkpointLsn,
+			checkpointDigest: copyNativeDurabilityBytes(checkpoint.digest),
+			manifestSlot: checkpoint.manifestSlot,
+			stagingCoverageDigest: sha256(
+				encodeNativeDurabilityCanonical(request.stagingCoverage),
+			),
+		};
+	}
+
+	async writeCheckpointAndSync(
+		unsafeRequest: NativeDurabilityCheckpointRequest,
+	): Promise<NativeDurabilityCheckpointReceipt> {
+		const request = snapshotCheckpointRequest(unsafeRequest);
+		return this.enqueue(async () => {
+			if (!nativeDurabilityBytesEqual(sha256(request.bytes), request.digest)) {
+				throw new NativeDurabilityDigestMismatchError("checkpoint");
+			}
+			const journalBase = await this.readJournalBaseCheckpoint();
+			if (!journalBase) {
+				throw new NativeDurabilityStorageCorruptionError(
+					"Checkpoint write has no journal base authority",
+				);
+			}
+			const journalBytes = new Uint8Array(
+				await requireNodeFs().readFile(this.journalPath),
+			);
+			const journalScan = this.journalCodec.scan(
+				journalBytes,
+				this.checkpointValidationContext(journalBase),
+			);
+			if (
+				journalScan.incompleteTailOffset != null ||
+				journalScan.validLength !== journalBytes.byteLength ||
+				request.checkpointLsn > journalScan.lastRecordLsn
+			) {
+				throw new NativeDurabilityStorageCorruptionError(
+					"Checkpoint cannot cover an incomplete or shorter journal",
+				);
+			}
+			const checkpointScopeRecord = journalScan.records.find(
+				(record) => record.recordLsn === request.scope.recordLsn,
+			);
+			if (
+				!checkpointScopeRecord ||
+				checkpointScopeRecord.transactionId !== request.scope.transactionId ||
+				checkpointScopeRecord.txSequence !== request.scope.txSequence ||
+				checkpointScopeRecord.phase !== NativeDurabilityPhase.Clean
+			) {
+				throw new NativeDurabilityStorageCorruptionError(
+					"Checkpoint operation scope does not match the journal authority",
+				);
+			}
+			const latestRecords = new Map<string, NativeDurabilityJournalRecord>();
+			let coveredTxSequenceHighwater = journalBase.txSequenceHighwater;
+			for (const retained of journalBase.retainedTransactions) {
+				latestRecords.set(retained.transactionId, {
+					recordLsn: journalBase.checkpointLsn,
+					txSequence: retained.txSequence,
+					writerEpoch: journalBase.originFence.epoch,
+					writerOwnerId: journalBase.originFence.ownerId,
+					writerDomainId: journalBase.originFence.domainId,
+					phase: retained.phase,
+					operationKind: retained.operationKind,
+					programId: copyNativeDurabilityBytes(this.programId),
+					transactionId: retained.transactionId,
+					planDigest: copyNativeDurabilityBytes(retained.planDigest),
+					payload: new Uint8Array(),
+				});
+			}
+			for (const record of journalScan.records) {
+				if (record.recordLsn <= request.checkpointLsn) {
+					latestRecords.set(record.transactionId, record);
+					if (record.txSequence > coveredTxSequenceHighwater) {
+						coveredTxSequenceHighwater = record.txSequence;
+					}
+				}
+			}
+			if (request.txSequenceHighwater < coveredTxSequenceHighwater) {
+				throw new NativeDurabilityStorageCorruptionError(
+					"Checkpoint transaction highwater regresses below covered journal records",
+				);
+			}
+			for (const retained of request.retainedTransactions) {
+				const record = latestRecords.get(retained.transactionId);
+				if (
+					!record ||
+					record.txSequence !== retained.txSequence ||
+					record.phase !== retained.phase ||
+					record.operationKind !== retained.operationKind ||
+					!nativeDurabilityBytesEqual(record.planDigest, retained.planDigest)
+				) {
+					throw new NativeDurabilityStorageCorruptionError(
+						`Checkpoint retained transaction ${retained.transactionId} does not match the journal authority`,
+					);
+				}
+			}
+			const requestDigest = sha256(encodeNativeDurabilityCanonical(request));
+			let state = await this.readGenerationState();
+			if (!state) {
+				throw new NativeDurabilityStorageCorruptionError(
+					"Checkpoint generation state is missing",
+				);
+			}
+			const currentCheckpoints = await this.readValidCheckpointsInternal();
+			const activeCheckpoint = currentCheckpoints[0];
+			if (
+				!activeCheckpoint ||
+				request.checkpointLsn < activeCheckpoint.checkpointLsn ||
+				request.txSequenceHighwater < activeCheckpoint.txSequenceHighwater
+			) {
+				throw new NativeDurabilityStorageCorruptionError(
+					"Checkpoint generation cannot regress active checkpoint watermarks",
+				);
+			}
+			if (
+				!state.pending &&
+				state.completed &&
+				state.completed.transactionId === request.scope.transactionId &&
+				state.completed.txSequence === request.scope.txSequence
+			) {
+				if (
+					!generationIdentityMatches(state.completed, request, requestDigest)
+				) {
+					throw new NativeDurabilityStorageCorruptionError(
+						"Completed checkpoint scope was reused with different checkpoint content",
+					);
+				}
+				if (
+					activeCheckpoint.generation !== state.completed.generation ||
+					activeCheckpoint.checkpointLsn !== request.checkpointLsn ||
+					activeCheckpoint.txSequenceHighwater !==
+						request.txSequenceHighwater ||
+					!nativeDurabilityBytesEqual(activeCheckpoint.bytes, request.bytes) ||
+					!nativeDurabilityBytesEqual(
+						activeCheckpoint.digest,
+						request.digest,
+					) ||
+					activeCheckpoint.stagingCoverage.length !==
+						request.stagingCoverage.length ||
+					activeCheckpoint.stagingCoverage.some((coverage, index) => {
+						const expected = request.stagingCoverage[index];
+						return (
+							!expected ||
+							coverage.transactionId !== expected.transactionId ||
+							coverage.txSequence !== expected.txSequence ||
+							coverage.coveredThroughLsn !== expected.coveredThroughLsn ||
+							!nativeDurabilityBytesEqual(
+								coverage.stagingManifestDigest,
+								expected.stagingManifestDigest,
+							)
+						);
+					}) ||
+					activeCheckpoint.retainedTransactions.length !==
+						request.retainedTransactions.length ||
+					activeCheckpoint.retainedTransactions.some((retained, index) => {
+						const expected = request.retainedTransactions[index];
+						return (
+							!expected ||
+							retained.transactionId !== expected.transactionId ||
+							retained.txSequence !== expected.txSequence ||
+							retained.phase !== expected.phase ||
+							retained.operationKind !== expected.operationKind ||
+							!nativeDurabilityBytesEqual(
+								retained.planDigest,
+								expected.planDigest,
+							)
+						);
+					})
+				) {
+					throw new NativeDurabilityStorageCorruptionError(
+						"Completed checkpoint identity does not match the active generation",
+					);
+				}
+				await syncDirectory(this.checkpointDirectory);
+				return this.checkpointReceipt(request, requestDigest, activeCheckpoint);
+			}
+			for (const coverage of request.stagingCoverage) {
+				const staged = await this.readStagingManifestInternal(
+					coverage.transactionId,
+				);
+				const record = latestRecords.get(coverage.transactionId);
+				if (
+					!staged ||
+					!record ||
+					record.phase !== NativeDurabilityPhase.Clean ||
+					record.txSequence !== coverage.txSequence ||
+					staged.scope.txSequence !== coverage.txSequence ||
+					coverage.coveredThroughLsn < record.recordLsn ||
+					coverage.coveredThroughLsn < staged.scope.recordLsn ||
+					!nativeDurabilityBytesEqual(
+						staged.manifestDigest,
+						coverage.stagingManifestDigest,
+					)
+				) {
+					throw new NativeDurabilityStorageCorruptionError(
+						`Checkpoint coverage does not prove CLEAN staging transaction ${coverage.transactionId}`,
+					);
+				}
+			}
+
+			let generation: bigint;
+			let started = false;
+			try {
+				if (state.pending) {
+					if (
+						state.pending.transactionId !== request.scope.transactionId ||
+						state.pending.txSequence !== request.scope.txSequence ||
+						!nativeDurabilityBytesEqual(
+							state.pending.requestDigest,
+							requestDigest,
+						)
+					) {
+						throw new NativeDurabilityStorageCorruptionError(
+							`Checkpoint generation ${state.pending.generation} has an unresolved different owner`,
+						);
+					}
+					generation = state.pending.generation;
+				} else {
+					if (state.generation === NATIVE_DURABILITY_MAX_U64) {
+						throw new NativeDurabilityStorageCorruptionError(
+							"Checkpoint generation highwater is exhausted",
+						);
+					}
+					generation = state.generation + 1n;
+					const targetSlot = generation % 2n === 0n ? "a" : "b";
+					if (activeCheckpoint.manifestSlot === targetSlot) {
+						if (generation === NATIVE_DURABILITY_MAX_U64) {
+							throw new NativeDurabilityStorageCorruptionError(
+								"Checkpoint generation highwater is exhausted before a safe manifest slot",
+							);
+						}
+						generation++;
+					}
+					state = {
+						generation,
+						completed: state.completed,
+						pending: {
+							generation,
+							requestDigest,
+							transactionId: request.scope.transactionId,
+							txSequence: request.scope.txSequence,
+						},
+					};
+					started = true;
+					await this.writeGenerationState(state);
+				}
+				const generationPath = requireNodePath().join(
+					this.checkpointDirectory,
+					checkpointFileName(generation),
+				);
+				const existingGeneration = await readFileIfExists(generationPath);
+				let writeGeneration = existingGeneration == null;
+				if (existingGeneration) {
+					if (
+						existingGeneration.byteLength !== request.bytes.byteLength ||
+						!nativeDurabilityBytesEqual(
+							sha256(existingGeneration),
+							request.digest,
+						)
+					) {
+						started = true;
+						await requireNodeFs().rm(generationPath, { force: true });
+						await syncDirectory(this.checkpointDirectory);
+						writeGeneration = true;
+					} else {
+						const handle = await requireNodeFs().open(generationPath, "r+");
+						try {
+							await handle.sync();
+						} finally {
+							await handle.close();
+						}
+						await syncDirectory(this.checkpointDirectory);
+					}
+				}
+				if (writeGeneration) {
+					started = true;
+					await writeImmutableFileAtomicallyAndSync(
+						generationPath,
+						request.bytes,
+						`${this.lease.fence.epoch}-${this.lease.fence.ownerId}`,
+					);
+				}
+				const manifestSlot = generation % 2n === 0n ? "a" : "b";
+				const manifest: DiskCheckpointManifest = {
+					version: this.version,
+					programId: bytesToHex(this.programId),
+					generation: generation.toString(),
+					checkpointLsn: request.checkpointLsn.toString(),
+					txSequenceHighwater: request.txSequenceHighwater.toString(),
+					file: checkpointFileName(generation),
+					byteLength: request.bytes.byteLength,
+					digest: nativeDurabilityDigestHex(request.digest),
+					originFence: diskFence(this.lease),
+					stagingCoverage: request.stagingCoverage.map((coverage) => ({
+						transactionId: coverage.transactionId,
+						txSequence: coverage.txSequence.toString(),
+						coveredThroughLsn: coverage.coveredThroughLsn.toString(),
+						stagingManifestDigest: nativeDurabilityDigestHex(
+							coverage.stagingManifestDigest,
+						),
+					})),
+					retainedTransactions: request.retainedTransactions.map(
+						(retained) => ({
+							txSequence: retained.txSequence.toString(),
+							transactionId: retained.transactionId,
+							phase: retained.phase,
+							operationKind: retained.operationKind,
+							planDigest: nativeDurabilityDigestHex(retained.planDigest),
+						}),
+					),
+				};
+				started = true;
+				await replaceFileAtomicallyAndSync(
+					this.checkpointManifestPath(manifestSlot),
+					encodeManifest(manifest),
+					`${this.lease.fence.epoch}-${this.lease.fence.ownerId}`,
+				);
+				const completed: GenerationIdentity = {
+					generation,
+					requestDigest: copyNativeDurabilityBytes(requestDigest),
+					transactionId: request.scope.transactionId,
+					txSequence: request.scope.txSequence,
+				};
+				await this.writeGenerationState({ generation, completed });
+				return this.checkpointReceipt(request, requestDigest, {
+					generation,
+					checkpointLsn: request.checkpointLsn,
+					digest: request.digest,
+					manifestSlot,
+				});
+			} catch (error) {
+				if (!started) throw error;
+				throw new NativeDurabilityOutcomeUnknownError(
+					"checkpoint",
+					request.scope.transactionId,
+					request.scope.txSequence,
+					error,
+				);
+			}
+		});
+	}
+
+	async readLatestCheckpoint(): Promise<
+		NativeDurabilityCheckpoint | undefined
+	> {
+		return this.enqueue(async () => {
+			const checkpoint = (await this.readValidCheckpointsInternal())[0];
+			return checkpoint && cloneCheckpoint(checkpoint);
+		});
+	}
+
+	async deleteAndSync(
+		unsafeRequest: NativeDurabilityDeleteRequest,
+	): Promise<NativeDurabilityDeleteReceipt> {
+		const request = snapshotDeleteRequest(unsafeRequest);
+		return this.enqueue(async () => {
+			const checkpoints = await this.readValidCheckpointsInternal();
+			const active = checkpoints[0];
+			const previous = checkpoints[1];
+			const journalBase = await this.readJournalBaseCheckpoint();
+			const generationState = await this.readGenerationState();
+			if (!active || !journalBase || !generationState) {
+				throw new NativeDurabilityStorageCorruptionError(
+					"Strict deletion requires valid checkpoint authorities",
+				);
+			}
+			const journalBytes = new Uint8Array(
+				await requireNodeFs().readFile(this.journalPath),
+			);
+			const journalScan = this.journalCodec.scan(
+				journalBytes,
+				this.checkpointValidationContext(journalBase),
+			);
+			const scopeRecord = journalScan.records.find(
+				(record) => record.recordLsn === request.scope.recordLsn,
+			);
+			if (
+				journalScan.incompleteTailOffset != null ||
+				journalScan.validLength !== journalBytes.byteLength ||
+				!scopeRecord ||
+				scopeRecord.transactionId !== request.scope.transactionId ||
+				scopeRecord.txSequence !== request.scope.txSequence ||
+				(scopeRecord.phase !== NativeDurabilityPhase.CleanupPending &&
+					scopeRecord.phase !== NativeDurabilityPhase.Clean)
+			) {
+				throw new NativeDurabilityStorageCorruptionError(
+					"Delete operation scope does not match a complete journal authority",
+				);
+			}
+			if (generationState.pending) {
+				throw new NativeDurabilityStorageCorruptionError(
+					`Cannot delete while checkpoint generation ${generationState.pending.generation} is unresolved`,
+				);
+			}
+			const stagingToDelete: string[] = [];
+			const checkpointsToDelete: bigint[] = [];
+			for (const target of request.targets) {
+				if (target.kind === "staging") {
+					const transactionDirectory = this.transactionDirectory(
+						target.transactionId,
+					);
+					let directoryExists = false;
+					try {
+						directoryExists = (
+							await requireNodeFs().stat(transactionDirectory)
+						).isDirectory();
+					} catch (error) {
+						if (!isNotFound(error)) throw error;
+					}
+					const staged = await this.readStagingManifestInternal(
+						target.transactionId,
+					);
+					if (
+						directoryExists &&
+						!staged &&
+						!this.checkpointAuthorizesStagingDeletion(
+							active,
+							target.transactionId,
+							journalScan.records,
+						)
+					) {
+						throw new NativeDurabilityStorageCorruptionError(
+							`Cannot checkpoint-delete incomplete staging transaction ${target.transactionId}`,
+						);
+					}
+					if (
+						staged &&
+						!this.checkpointAuthorizesStagingDeletion(
+							active,
+							target.transactionId,
+							journalScan.records,
+							staged,
+						)
+					) {
+						throw new NativeDurabilityStorageCorruptionError(
+							`Active checkpoint does not exactly cover CLEAN staging transaction ${target.transactionId}`,
+						);
+					}
+					stagingToDelete.push(transactionDirectory);
+				} else {
+					if (
+						target.generation === active.generation ||
+						target.generation === previous?.generation ||
+						target.generation === journalBase.generation
+					) {
+						throw new NativeDurabilityStorageCorruptionError(
+							`Cannot delete active, previous, or journal-base checkpoint generation ${target.generation}`,
+						);
+					}
+					if (target.generation > generationState.generation) {
+						throw new NativeDurabilityStorageCorruptionError(
+							`Checkpoint generation ${target.generation} exceeds the permanent highwater`,
+						);
+					}
+					checkpointsToDelete.push(target.generation);
+				}
+			}
+			let started = false;
+			try {
+				for (const directory of stagingToDelete) {
+					started = true;
+					await requireNodeFs().rm(directory, {
+						recursive: true,
+						force: true,
+					});
+					await syncDirectory(this.stagingDirectory);
+				}
+				for (const generation of checkpointsToDelete) {
+					started = true;
+					await requireNodeFs().rm(
+						requireNodePath().join(
+							this.checkpointDirectory,
+							checkpointFileName(generation),
+						),
+						{ force: true },
+					);
+					await syncDirectory(this.checkpointDirectory);
+				}
+				this.strictDeleteCount++;
+				this.barrierOrdinal++;
+				return {
+					version: this.version,
+					kind: "delete",
+					domainId: this.domainId,
+					fence: { ...this.lease.fence },
+					transactionId: request.scope.transactionId,
+					txSequence: request.scope.txSequence,
+					firstRecordLsn: request.scope.recordLsn,
+					lastRecordLsn: request.scope.recordLsn,
+					scopeDigest: sha256(encodeNativeDurabilityCanonical(request)),
+					barrierOrdinal: this.barrierOrdinal,
+					targets: request.targets.map((target) => ({ ...target })),
+				};
+			} catch (error) {
+				if (!started) throw error;
+				throw new NativeDurabilityOutcomeUnknownError(
+					"delete",
+					request.scope.transactionId,
+					request.scope.txSequence,
+					error,
+				);
+			}
+		});
+	}
+
+	async stats(): Promise<NativeDurabilityStorageStats> {
+		return this.enqueue(async () => {
+			const transactionIds = await this.listStagingTransactionIdsInternal();
+			let stagedBlocks = 0;
+			let stagedBytes = 0;
+			for (const transactionId of transactionIds) {
+				const manifest = await this.readStagingManifestInternal(transactionId);
+				if (!manifest) continue;
+				stagedBlocks += manifest.blocks.length;
+				for (const block of manifest.blocks) stagedBytes += block.byteLength;
+			}
+			let checkpointGenerations = 0;
+			let checkpointBytes = 0;
+			for (const entry of await requireNodeFs().readdir(
+				this.checkpointDirectory,
+				{ withFileTypes: true },
+			)) {
+				if (
+					entry.isFile() &&
+					/^checkpoint-(0|[1-9][0-9]*)\.bin$/.test(entry.name)
+				) {
+					checkpointGenerations++;
+					checkpointBytes += Number(
+						(
+							await requireNodeFs().stat(
+								requireNodePath().join(this.checkpointDirectory, entry.name),
+							)
+						).size,
+					);
+				}
+			}
+			const journalBytes = Number(
+				(await requireNodeFs().stat(this.journalPath)).size,
+			);
+			return {
+				kind: this.kind,
+				domainId: this.domainId,
+				strictBarrierCount: this.barrierOrdinal,
+				strictDeleteCount: this.strictDeleteCount,
+				journalBytes,
+				stagingTransactions: transactionIds.length,
+				stagedBlocks,
+				stagedBytes,
+				checkpointGenerations,
+				checkpointBytes,
+			};
+		});
+	}
+
+	/** Drains admitted operations before releasing the owned OS lease. */
+	close(): Promise<void> {
+		if (this.closePromise) return this.closePromise;
+		this.closing = true;
+		this.closePromise = (async () => {
+			let operationError: unknown;
+			try {
+				await this.operationTail;
+			} catch (error) {
+				operationError = error;
+			}
+			let leaseError: unknown;
+			try {
+				await this.lease.close();
+			} catch (error) {
+				leaseError = error;
+			}
+			this.closed = true;
+			if (operationError) throw operationError;
+			if (leaseError) throw leaseError;
+		})();
+		return this.closePromise;
+	}
+}
+
+export const createNodeNativeDurabilityStorage = async (
+	options: NativeDurabilityNodeStorageOptions,
+): Promise<NodeNativeDurabilityStorage> =>
+	NodeNativeDurabilityStorage.create(options);

--- a/packages/utils/native-backbone/src/durability/storage.ts
+++ b/packages/utils/native-backbone/src/durability/storage.ts
@@ -1,0 +1,682 @@
+import type { NativeDurabilityCheckpointTransactionState } from "./codec.js";
+import {
+	NATIVE_DURABILITY_MAX_U64,
+	NATIVE_DURABILITY_MAX_WRITER_ID_BYTES,
+	type NativeDurabilityLease,
+} from "./lease.js";
+
+export const NATIVE_DURABILITY_STORAGE_VERSION = 1 as const;
+export const NATIVE_DURABILITY_MAX_TRANSACTION_ID_BYTES = 1024;
+
+export type NativeDurabilityStorageKind = "memory" | "node-fsync";
+
+export type NativeDurabilityOperationScope = {
+	transactionId: string;
+	txSequence: bigint;
+	recordLsn: bigint;
+};
+
+export type NativeDurabilityStagedBlock = {
+	ordinal: number;
+	cid: string;
+	bytes: Uint8Array;
+	digest: Uint8Array;
+};
+
+export type NativeDurabilityStagedBlockReference = Omit<
+	NativeDurabilityStagedBlock,
+	"bytes"
+> & {
+	byteLength: number;
+};
+
+export type NativeDurabilityStagingManifest = {
+	version: typeof NATIVE_DURABILITY_STORAGE_VERSION;
+	scope: NativeDurabilityOperationScope;
+	fence: NativeDurabilityLease["fence"];
+	blocks: NativeDurabilityStagedBlockReference[];
+	manifestDigest: Uint8Array;
+};
+
+export type NativeDurabilityStageRequest = {
+	scope: NativeDurabilityOperationScope;
+	blocks: readonly NativeDurabilityStagedBlock[];
+};
+
+export type NativeDurabilityJournalAppendRequest = {
+	transactionId: string;
+	txSequence: bigint;
+	firstRecordLsn: bigint;
+	lastRecordLsn: bigint;
+	expectedOffset: number;
+	frames: Uint8Array;
+	framesDigest: Uint8Array;
+};
+
+/**
+ * The storage adapter asks an injected journal codec to produce this result
+ * from the exact bytes it is about to truncate. Complete-frame corruption must
+ * throw from the classifier and can never be represented as `incomplete-tail`.
+ */
+export type NativeDurabilityJournalClassification =
+	| {
+			kind: "complete";
+			validLength: number;
+			lastRecordLsn: bigint;
+	  }
+	| {
+			kind: "incomplete-tail";
+			validLength: number;
+			lastRecordLsn: bigint;
+			reason: "short-header" | "short-body" | "short-trailer";
+	  };
+
+export interface NativeDurabilityJournalClassifier {
+	classify(
+		bytes: Uint8Array,
+	):
+		| NativeDurabilityJournalClassification
+		| Promise<NativeDurabilityJournalClassification>;
+}
+
+export type NativeDurabilityIncompleteTailReconciliationRequest = {
+	transactionId: string;
+	txSequence: bigint;
+};
+
+export type NativeDurabilityStagingCoverage = {
+	transactionId: string;
+	txSequence: bigint;
+	coveredThroughLsn: bigint;
+	stagingManifestDigest: Uint8Array;
+};
+
+export type NativeDurabilityCheckpointRequest = {
+	scope: NativeDurabilityOperationScope;
+	checkpointLsn: bigint;
+	txSequenceHighwater: bigint;
+	bytes: Uint8Array;
+	digest: Uint8Array;
+	stagingCoverage: readonly NativeDurabilityStagingCoverage[];
+	retainedTransactions: readonly NativeDurabilityCheckpointTransactionState[];
+};
+
+export type NativeDurabilityCheckpoint = {
+	version: typeof NATIVE_DURABILITY_STORAGE_VERSION;
+	generation: bigint;
+	checkpointLsn: bigint;
+	txSequenceHighwater: bigint;
+	bytes: Uint8Array;
+	digest: Uint8Array;
+	originFence: NativeDurabilityLease["fence"];
+	manifestSlot: "a" | "b";
+	stagingCoverage: NativeDurabilityStagingCoverage[];
+	retainedTransactions: NativeDurabilityCheckpointTransactionState[];
+};
+
+export type NativeDurabilityDeleteTarget =
+	| { kind: "staging"; transactionId: string }
+	| { kind: "checkpoint"; generation: bigint };
+
+export type NativeDurabilityDeleteRequest = {
+	scope: NativeDurabilityOperationScope;
+	targets: readonly NativeDurabilityDeleteTarget[];
+};
+
+type NativeDurabilityReceiptBase<TKind extends string> = {
+	version: typeof NATIVE_DURABILITY_STORAGE_VERSION;
+	kind: TKind;
+	domainId: string;
+	fence: NativeDurabilityLease["fence"];
+	transactionId: string;
+	txSequence: bigint;
+	firstRecordLsn: bigint;
+	lastRecordLsn: bigint;
+	scopeDigest: Uint8Array;
+	barrierOrdinal: bigint;
+};
+
+export type NativeDurabilityStageReceipt =
+	NativeDurabilityReceiptBase<"stage"> & {
+		blocks: NativeDurabilityStagedBlockReference[];
+		manifestDigest: Uint8Array;
+	};
+
+export type NativeDurabilityJournalReceipt =
+	NativeDurabilityReceiptBase<"journal-append"> & {
+		offset: number;
+		endOffset: number;
+		framesDigest: Uint8Array;
+	};
+
+export type NativeDurabilityJournalReconciliationReceipt =
+	NativeDurabilityReceiptBase<"journal-tail-reconciliation"> & {
+		previousLength: number;
+		validLength: number;
+		observedDigest: Uint8Array;
+	};
+
+export type NativeDurabilityCheckpointReceipt =
+	NativeDurabilityReceiptBase<"checkpoint"> & {
+		generation: bigint;
+		checkpointLsn: bigint;
+		checkpointDigest: Uint8Array;
+		manifestSlot: "a" | "b";
+		stagingCoverageDigest: Uint8Array;
+	};
+
+export type NativeDurabilityDeleteReceipt =
+	NativeDurabilityReceiptBase<"delete"> & {
+		targets: NativeDurabilityDeleteTarget[];
+	};
+
+export type NativeDurabilityStorageStats = {
+	kind: NativeDurabilityStorageKind;
+	domainId: string;
+	strictBarrierCount: bigint;
+	strictDeleteCount: bigint;
+	journalBytes: number;
+	stagingTransactions: number;
+	stagedBlocks: number;
+	stagedBytes: number;
+	checkpointGenerations: number;
+	checkpointBytes: number;
+};
+
+export interface NativeDurabilityStorage {
+	readonly version: typeof NATIVE_DURABILITY_STORAGE_VERSION;
+	readonly kind: NativeDurabilityStorageKind;
+	readonly domainId: string;
+	readonly fence: NativeDurabilityLease["fence"];
+	readonly crashSafe: boolean;
+
+	stageAndSync(
+		request: NativeDurabilityStageRequest,
+	): Promise<NativeDurabilityStageReceipt>;
+	readStagingManifest(
+		transactionId: string,
+	): Promise<NativeDurabilityStagingManifest | undefined>;
+	readStagedBlock(
+		transactionId: string,
+		ordinal: number,
+	): Promise<Uint8Array | undefined>;
+	listStagingTransactionIds(): Promise<string[]>;
+
+	appendJournalAndSync(
+		request: NativeDurabilityJournalAppendRequest,
+	): Promise<NativeDurabilityJournalReceipt>;
+	readJournal(): Promise<Uint8Array>;
+	reconcileIncompleteJournalTailAndSync(
+		request: NativeDurabilityIncompleteTailReconciliationRequest,
+	): Promise<NativeDurabilityJournalReconciliationReceipt>;
+
+	writeCheckpointAndSync(
+		request: NativeDurabilityCheckpointRequest,
+	): Promise<NativeDurabilityCheckpointReceipt>;
+	readLatestCheckpoint(): Promise<NativeDurabilityCheckpoint | undefined>;
+
+	deleteAndSync(
+		request: NativeDurabilityDeleteRequest,
+	): Promise<NativeDurabilityDeleteReceipt>;
+	stats(): Promise<NativeDurabilityStorageStats>;
+	close(): Promise<void>;
+}
+
+export class NativeDurabilityStorageUnsupportedError extends Error {
+	readonly code = "ERR_NATIVE_DURABILITY_STORAGE_UNSUPPORTED";
+
+	constructor(message: string) {
+		super(message);
+		this.name = "NativeDurabilityStorageUnsupportedError";
+	}
+}
+
+export class NativeDurabilityMigrationRequiredError extends Error {
+	readonly code = "ERR_NATIVE_DURABILITY_MIGRATION_REQUIRED";
+
+	constructor(readonly directory: string) {
+		super(
+			`Native crash-safe durability requires an explicit migration for nonempty program directory: ${directory}`,
+		);
+		this.name = "NativeDurabilityMigrationRequiredError";
+	}
+}
+
+export class NativeDurabilityStorageClosedError extends Error {
+	readonly code = "ERR_NATIVE_DURABILITY_STORAGE_CLOSED";
+
+	constructor() {
+		super("Native durability storage is closed");
+		this.name = "NativeDurabilityStorageClosedError";
+	}
+}
+
+export class NativeDurabilityStorageCorruptionError extends Error {
+	readonly code = "ERR_NATIVE_DURABILITY_STORAGE_CORRUPTION";
+
+	constructor(
+		message: string,
+		readonly cause?: unknown,
+	) {
+		super(message);
+		this.name = "NativeDurabilityStorageCorruptionError";
+	}
+}
+
+export class NativeDurabilityDigestMismatchError extends Error {
+	readonly code = "ERR_NATIVE_DURABILITY_DIGEST_MISMATCH";
+
+	constructor(readonly subject: string) {
+		super(`Native durability digest mismatch for ${subject}`);
+		this.name = "NativeDurabilityDigestMismatchError";
+	}
+}
+
+export class NativeDurabilityJournalOffsetConflictError extends Error {
+	readonly code = "ERR_NATIVE_DURABILITY_JOURNAL_OFFSET_CONFLICT";
+
+	constructor(
+		readonly expectedOffset: number,
+		readonly actualOffset: number,
+	) {
+		super(
+			`Native durability journal offset conflict: expected ${expectedOffset}, found ${actualOffset}`,
+		);
+		this.name = "NativeDurabilityJournalOffsetConflictError";
+	}
+}
+
+export class NativeDurabilityOutcomeUnknownError extends Error {
+	readonly code = "ERR_NATIVE_DURABILITY_OUTCOME_UNKNOWN";
+	readonly outcome = "unknown" as const;
+
+	constructor(
+		readonly operation:
+			| "stage"
+			| "journal-append"
+			| "journal-tail-reconciliation"
+			| "checkpoint"
+			| "delete",
+		readonly transactionId: string,
+		readonly txSequence: bigint,
+		readonly cause: unknown,
+	) {
+		super(
+			`Native durability ${operation} outcome is unknown for transaction ${transactionId}`,
+		);
+		this.name = "NativeDurabilityOutcomeUnknownError";
+	}
+}
+
+export class NativeDurabilityIncompleteTailMismatchError extends Error {
+	readonly code = "ERR_NATIVE_DURABILITY_INCOMPLETE_TAIL_MISMATCH";
+
+	constructor(message: string) {
+		super(message);
+		this.name = "NativeDurabilityIncompleteTailMismatchError";
+	}
+}
+
+export const copyNativeDurabilityBytes = (bytes: Uint8Array): Uint8Array =>
+	new Uint8Array(bytes);
+
+export const nativeDurabilityBytesEqual = (
+	left: Uint8Array,
+	right: Uint8Array,
+): boolean => {
+	if (left.byteLength !== right.byteLength) return false;
+	for (let i = 0; i < left.byteLength; i++) {
+		if (left[i] !== right[i]) return false;
+	}
+	return true;
+};
+
+export const nativeDurabilityDigestHex = (digest: Uint8Array): string =>
+	Array.from(digest, (byte) => byte.toString(16).padStart(2, "0")).join("");
+
+export const nativeDurabilityDigestFromHex = (value: string): Uint8Array => {
+	if (!/^[0-9a-f]{64}$/.test(value)) {
+		throw new NativeDurabilityStorageCorruptionError(
+			"Native durability digest must be 32 lowercase hexadecimal bytes",
+		);
+	}
+	const bytes = new Uint8Array(32);
+	for (let i = 0; i < bytes.byteLength; i++) {
+		bytes[i] = Number.parseInt(value.slice(i * 2, i * 2 + 2), 16);
+	}
+	return bytes;
+};
+
+const canonicalValue = (value: unknown): unknown => {
+	if (typeof value === "bigint") return { bigint: value.toString() };
+	if (value instanceof Uint8Array) {
+		return { bytes: nativeDurabilityDigestHex(value) };
+	}
+	if (Array.isArray(value)) return value.map(canonicalValue);
+	if (value && typeof value === "object") {
+		return Object.fromEntries(
+			Object.entries(value as Record<string, unknown>)
+				.sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+				.map(([key, entry]) => [key, canonicalValue(entry)]),
+		);
+	}
+	return value;
+};
+
+export const encodeNativeDurabilityCanonical = (value: unknown): Uint8Array =>
+	new TextEncoder().encode(JSON.stringify(canonicalValue(value)));
+
+export const sha256NativeDurability = async (
+	bytes: Uint8Array,
+): Promise<Uint8Array> => {
+	if (!globalThis.crypto?.subtle) {
+		throw new NativeDurabilityStorageUnsupportedError(
+			"SHA-256 requires Web Crypto in the memory durability adapter",
+		);
+	}
+	const input = new Uint8Array(bytes.byteLength);
+	input.set(bytes);
+	return new Uint8Array(
+		await globalThis.crypto.subtle.digest("SHA-256", input.buffer),
+	);
+};
+
+export const assertNativeDurabilityDigest = async (
+	subject: string,
+	bytes: Uint8Array,
+	expected: Uint8Array,
+): Promise<void> => {
+	if (expected.byteLength !== 32) {
+		throw new NativeDurabilityDigestMismatchError(subject);
+	}
+	const actual = await sha256NativeDurability(bytes);
+	if (!nativeDurabilityBytesEqual(actual, expected)) {
+		throw new NativeDurabilityDigestMismatchError(subject);
+	}
+};
+
+export const nativeDurabilityScopeDigest = async (
+	value: unknown,
+): Promise<Uint8Array> =>
+	sha256NativeDurability(encodeNativeDurabilityCanonical(value));
+
+const assertU64 = (name: string, value: bigint): void => {
+	if (
+		typeof value !== "bigint" ||
+		value < 0n ||
+		value > NATIVE_DURABILITY_MAX_U64
+	) {
+		throw new TypeError(`${name} must be an unsigned 64-bit bigint`);
+	}
+};
+
+export const assertNativeDurabilityOperationScope = (
+	scope: NativeDurabilityOperationScope,
+): void => {
+	if (
+		!scope ||
+		typeof scope.transactionId !== "string" ||
+		!scope.transactionId
+	) {
+		throw new TypeError("transactionId must be a non-empty string");
+	}
+	if (
+		new TextEncoder().encode(scope.transactionId).byteLength >
+		NATIVE_DURABILITY_MAX_TRANSACTION_ID_BYTES
+	) {
+		throw new TypeError("transactionId exceeds the journal format limit");
+	}
+	assertU64("txSequence", scope.txSequence);
+	assertU64("recordLsn", scope.recordLsn);
+};
+
+export const assertNativeDurabilityFence = (
+	fence: NativeDurabilityLease["fence"],
+): void => {
+	if (
+		!fence ||
+		typeof fence.ownerId !== "string" ||
+		!fence.ownerId ||
+		typeof fence.domainId !== "string" ||
+		!fence.domainId
+	) {
+		throw new TypeError("Durability fence ownerId/domainId must be non-empty");
+	}
+	if (
+		new TextEncoder().encode(fence.ownerId).byteLength >
+			NATIVE_DURABILITY_MAX_WRITER_ID_BYTES ||
+		new TextEncoder().encode(fence.domainId).byteLength >
+			NATIVE_DURABILITY_MAX_WRITER_ID_BYTES
+	) {
+		throw new TypeError(
+			"Durability fence ownerId/domainId exceeds format limit",
+		);
+	}
+	assertU64("fence.epoch", fence.epoch);
+	if (fence.epoch === 0n) {
+		throw new TypeError("Durability fence epoch must be non-zero");
+	}
+};
+
+export const assertNativeDurabilityStageRequest = (
+	request: NativeDurabilityStageRequest,
+): void => {
+	assertNativeDurabilityOperationScope(request?.scope);
+	if (request.scope.txSequence === 0n || request.scope.recordLsn === 0n) {
+		throw new RangeError("Staging txSequence and recordLsn must be non-zero");
+	}
+	if (!Array.isArray(request.blocks)) {
+		throw new TypeError("Staging blocks must be an array");
+	}
+	const sorted = [...request.blocks].sort(
+		(left, right) => left.ordinal - right.ordinal,
+	);
+	for (let index = 0; index < sorted.length; index++) {
+		const block = sorted[index];
+		if (block.ordinal !== index) {
+			throw new RangeError("Staging ordinals must be contiguous from zero");
+		}
+		if (typeof block.cid !== "string" || !block.cid) {
+			throw new TypeError(`Staging block ${index} has an invalid CID`);
+		}
+		if (!(block.bytes instanceof Uint8Array)) {
+			throw new TypeError(`Staging block ${index} bytes must be Uint8Array`);
+		}
+		if (
+			!(block.digest instanceof Uint8Array) ||
+			block.digest.byteLength !== 32
+		) {
+			throw new TypeError(`Staging block ${index} digest must be 32 bytes`);
+		}
+	}
+};
+
+export const assertNativeDurabilityJournalAppendRequest = (
+	request: NativeDurabilityJournalAppendRequest,
+): void => {
+	if (
+		!request ||
+		typeof request.transactionId !== "string" ||
+		!request.transactionId
+	) {
+		throw new TypeError("transactionId must be a non-empty string");
+	}
+	if (
+		new TextEncoder().encode(request.transactionId).byteLength >
+		NATIVE_DURABILITY_MAX_TRANSACTION_ID_BYTES
+	) {
+		throw new TypeError("transactionId exceeds the journal format limit");
+	}
+	assertU64("txSequence", request.txSequence);
+	assertU64("firstRecordLsn", request.firstRecordLsn);
+	assertU64("lastRecordLsn", request.lastRecordLsn);
+	if (
+		request.txSequence === 0n ||
+		request.firstRecordLsn === 0n ||
+		request.lastRecordLsn === 0n
+	) {
+		throw new RangeError("Journal sequence and LSN values must be non-zero");
+	}
+	if (request.lastRecordLsn < request.firstRecordLsn) {
+		throw new RangeError("lastRecordLsn must not precede firstRecordLsn");
+	}
+	if (
+		!Number.isSafeInteger(request.expectedOffset) ||
+		request.expectedOffset < 0
+	) {
+		throw new RangeError("expectedOffset must be a non-negative safe integer");
+	}
+	if (
+		!(request.frames instanceof Uint8Array) ||
+		request.frames.byteLength === 0
+	) {
+		throw new TypeError("Journal frames must be a non-empty Uint8Array");
+	}
+	if (
+		!(request.framesDigest instanceof Uint8Array) ||
+		request.framesDigest.byteLength !== 32
+	) {
+		throw new TypeError("framesDigest must be 32 bytes");
+	}
+};
+
+export const assertNativeDurabilityCheckpointRequest = (
+	request: NativeDurabilityCheckpointRequest,
+): void => {
+	assertNativeDurabilityOperationScope(request?.scope);
+	assertU64("checkpointLsn", request.checkpointLsn);
+	assertU64("txSequenceHighwater", request.txSequenceHighwater);
+	if (
+		request.scope.txSequence === 0n ||
+		request.scope.recordLsn === 0n ||
+		request.scope.recordLsn > request.checkpointLsn ||
+		request.scope.txSequence > request.txSequenceHighwater
+	) {
+		throw new RangeError(
+			"Checkpoint scope cannot exceed its LSN or transaction highwater",
+		);
+	}
+	if (!(request.bytes instanceof Uint8Array)) {
+		throw new TypeError("Checkpoint bytes must be Uint8Array");
+	}
+	if (
+		!(request.digest instanceof Uint8Array) ||
+		request.digest.byteLength !== 32
+	) {
+		throw new TypeError("Checkpoint digest must be 32 bytes");
+	}
+	if (!Array.isArray(request.stagingCoverage)) {
+		throw new TypeError("Checkpoint stagingCoverage must be an array");
+	}
+	const transactionIds = new Set<string>();
+	for (const coverage of request.stagingCoverage) {
+		if (
+			typeof coverage.transactionId !== "string" ||
+			!coverage.transactionId ||
+			transactionIds.has(coverage.transactionId)
+		) {
+			throw new TypeError(
+				"Checkpoint staging coverage transaction IDs must be unique",
+			);
+		}
+		transactionIds.add(coverage.transactionId);
+		assertU64("coverage.txSequence", coverage.txSequence);
+		assertU64("coverage.coveredThroughLsn", coverage.coveredThroughLsn);
+		if (coverage.coveredThroughLsn > request.checkpointLsn) {
+			throw new RangeError(
+				"Staging coverage cannot extend beyond checkpointLsn",
+			);
+		}
+		if (
+			new TextEncoder().encode(coverage.transactionId).byteLength >
+				NATIVE_DURABILITY_MAX_TRANSACTION_ID_BYTES ||
+			!(coverage.stagingManifestDigest instanceof Uint8Array) ||
+			coverage.stagingManifestDigest.byteLength !== 32
+		) {
+			throw new TypeError(
+				"Checkpoint staging coverage fields exceed their format limits",
+			);
+		}
+	}
+	if (!Array.isArray(request.retainedTransactions)) {
+		throw new TypeError("Checkpoint retainedTransactions must be an array");
+	}
+	const retainedIds = new Set<string>();
+	const retainedSequences = new Set<bigint>();
+	for (const retained of request.retainedTransactions) {
+		assertU64("retained transaction sequence", retained.txSequence);
+		if (
+			retained.txSequence === 0n ||
+			retained.txSequence > request.txSequenceHighwater ||
+			typeof retained.transactionId !== "string" ||
+			!retained.transactionId ||
+			new TextEncoder().encode(retained.transactionId).byteLength >
+				NATIVE_DURABILITY_MAX_TRANSACTION_ID_BYTES ||
+			retainedIds.has(retained.transactionId) ||
+			retainedSequences.has(retained.txSequence) ||
+			!Number.isInteger(retained.phase) ||
+			retained.phase < 1 ||
+			retained.phase > 6 ||
+			!Number.isInteger(retained.operationKind) ||
+			retained.operationKind < 1 ||
+			retained.operationKind > 5 ||
+			!(retained.planDigest instanceof Uint8Array) ||
+			retained.planDigest.byteLength !== 32
+		) {
+			throw new TypeError("Checkpoint retained transaction is invalid");
+		}
+		retainedIds.add(retained.transactionId);
+		retainedSequences.add(retained.txSequence);
+	}
+	for (const coverage of request.stagingCoverage) {
+		const retained = request.retainedTransactions.find(
+			(candidate) => candidate.transactionId === coverage.transactionId,
+		);
+		if (
+			!retained ||
+			retained.txSequence !== coverage.txSequence ||
+			retained.phase !== 6
+		) {
+			throw new TypeError(
+				"Checkpoint staging coverage requires the exact retained CLEAN transaction",
+			);
+		}
+	}
+};
+
+export const assertNativeDurabilityDeleteRequest = (
+	request: NativeDurabilityDeleteRequest,
+): void => {
+	assertNativeDurabilityOperationScope(request?.scope);
+	if (!Array.isArray(request.targets) || request.targets.length === 0) {
+		throw new TypeError("Delete targets must be a non-empty array");
+	}
+	if (request.scope.txSequence === 0n || request.scope.recordLsn === 0n) {
+		throw new RangeError("Delete scope sequence and LSN must be non-zero");
+	}
+	const targetKeys = new Set<string>();
+	for (const target of request.targets) {
+		if (target.kind === "staging") {
+			if (
+				typeof target.transactionId !== "string" ||
+				!target.transactionId ||
+				new TextEncoder().encode(target.transactionId).byteLength >
+					NATIVE_DURABILITY_MAX_TRANSACTION_ID_BYTES
+			) {
+				throw new TypeError("Staging delete transactionId must be non-empty");
+			}
+		} else if (target.kind === "checkpoint") {
+			assertU64("checkpoint generation", target.generation);
+		} else {
+			throw new TypeError("Unknown native durability delete target");
+		}
+		const key =
+			target.kind === "staging"
+				? `staging:${target.transactionId}`
+				: `checkpoint:${target.generation}`;
+		if (targetKeys.has(key)) {
+			throw new TypeError("Delete targets must be unique");
+		}
+		targetKeys.add(key);
+	}
+};

--- a/packages/utils/native-backbone/src/index.ts
+++ b/packages/utils/native-backbone/src/index.ts
@@ -1,5 +1,12 @@
 import { calculateRawCid, cidifyString } from "@peerbit/blocks-interface";
 
+export * from "./durability/codec.js";
+export * from "./durability/lease.js";
+export * from "./durability/memory-storage.js";
+export * from "./durability/node-lease.js";
+export * from "./durability/node-storage.js";
+export * from "./durability/storage.js";
+
 export type RangeResolution = "u32" | "u64";
 
 type NativePeerbitBackboneHandle = {

--- a/packages/utils/native-backbone/src/lib.rs
+++ b/packages/utils/native-backbone/src/lib.rs
@@ -10,6 +10,7 @@ use wasm_bindgen::prelude::*;
 mod append_tx;
 mod coordinates;
 mod documents;
+pub mod durability;
 mod error;
 mod graph_blocks;
 mod js_interop;

--- a/packages/utils/native-backbone/test/append-transaction.spec.ts
+++ b/packages/utils/native-backbone/test/append-transaction.spec.ts
@@ -1,0 +1,251 @@
+import { expect } from "chai";
+import {
+	NATIVE_DURABILITY_JOURNAL_CODEC_BRAND,
+	NATIVE_DURABILITY_JOURNAL_MAX_TRANSACTION_ID_LENGTH,
+	NATIVE_DURABILITY_JOURNAL_MAX_U64,
+	NativeDurabilityJournalCorruptionError,
+	NativeDurabilityJournalInputError,
+	NativeDurabilityOperationKind,
+	NativeDurabilityPhase,
+	createNativeDurabilityJournalCodec,
+	isNativeDurabilityJournalCodec,
+	type NativeDurabilityJournalRecord,
+	type NativeDurabilityJournalValidationContext,
+} from "../src/index.js";
+
+const concatBytes = (chunks: readonly Uint8Array[]): Uint8Array => {
+	const out = new Uint8Array(
+		chunks.reduce((length, chunk) => length + chunk.byteLength, 0),
+	);
+	let offset = 0;
+	for (const chunk of chunks) {
+		out.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return out;
+};
+
+const programId = new Uint8Array([7, 8, 9]);
+const digest = (value: number): Uint8Array => new Uint8Array(32).fill(value);
+
+const context = (
+	overrides: Partial<NativeDurabilityJournalValidationContext> = {},
+): NativeDurabilityJournalValidationContext => ({
+	checkpointLsn: 0n,
+	checkpointTxSequenceHighwater: 0n,
+	expectedProgramId: programId,
+	expectedWriterDomainId: "program-directory",
+	checkpointWriterEpoch: 0n,
+	currentWriterEpoch: 1n,
+	currentWriterOwnerId: "writer-1",
+	...overrides,
+});
+
+const record = (
+	recordLsn: bigint,
+	txSequence: bigint,
+	transactionId: string,
+	phase: NativeDurabilityPhase,
+): NativeDurabilityJournalRecord => ({
+	recordLsn,
+	txSequence,
+	writerEpoch: 1n,
+	writerOwnerId: "writer-1",
+	writerDomainId: "program-directory",
+	phase,
+	operationKind: NativeDurabilityOperationKind.Append,
+	programId,
+	transactionId,
+	planDigest: digest(Number(txSequence & 0xffn)),
+	payload: new Uint8Array([Number(phase), 42]),
+});
+
+describe("native durability transaction journal codec", function () {
+	this.timeout(120_000);
+
+	it("round-trips structured metadata without converting u64 values to numbers", async () => {
+		const codec = await createNativeDurabilityJournalCodec(context());
+		expect(isNativeDurabilityJournalCodec(codec)).to.equal(true);
+		const records = [
+			record(1n, 1n, "tx-1", NativeDurabilityPhase.DurablePrepared),
+			record(2n, 1n, "tx-1", NativeDurabilityPhase.NativeApplied),
+			record(3n, 1n, "tx-1", NativeDurabilityPhase.Published),
+			record(4n, 1n, "tx-1", NativeDurabilityPhase.Committed),
+			record(5n, 1n, "tx-1", NativeDurabilityPhase.Clean),
+		];
+		const bytes = concatBytes(records.map((value) => codec.encode(value)));
+		const scan = codec.scan(bytes);
+
+		expect(scan.validLength).to.equal(bytes.byteLength);
+		expect(scan.incompleteTailOffset).to.equal(undefined);
+		expect(scan.lastRecordLsn).to.equal(5n);
+		expect(typeof scan.records[0]!.recordLsn).to.equal("bigint");
+		expect(typeof scan.records[0]!.txSequence).to.equal("bigint");
+		expect(typeof scan.records[0]!.writerEpoch).to.equal("bigint");
+		expect(scan.records).to.deep.equal(records);
+	});
+
+	it("does not treat the public informational brand as codec authority", () => {
+		const forged = {
+			[NATIVE_DURABILITY_JOURNAL_CODEC_BRAND]: true,
+			classify: () => ({
+				kind: "incomplete-tail" as const,
+				validLength: 0,
+				lastRecordLsn: 0n,
+				reason: "short-header" as const,
+			}),
+		};
+		expect(isNativeDurabilityJournalCodec(forged)).to.equal(false);
+	});
+
+	it("snapshots validation context before asynchronous construction", async () => {
+		const mutableProgramId = new Uint8Array(programId);
+		const mutableRetainedDigest = digest(17);
+		const mutableContext = context({
+			checkpointTxSequenceHighwater: 1n,
+			expectedProgramId: mutableProgramId,
+			retainedTransactions: [
+				{
+					txSequence: 1n,
+					transactionId: "retained-tx",
+					phase: NativeDurabilityPhase.DurablePrepared,
+					operationKind: NativeDurabilityOperationKind.Append,
+					planDigest: mutableRetainedDigest,
+				},
+			],
+		});
+		const codecPromise = createNativeDurabilityJournalCodec(mutableContext);
+		mutableProgramId.fill(99);
+		mutableRetainedDigest.fill(88);
+		mutableContext.currentWriterOwnerId = "mutated-writer";
+		const codec = await codecPromise;
+
+		expect(codec.context.expectedProgramId).to.deep.equal(programId);
+		expect(codec.context.currentWriterOwnerId).to.equal("writer-1");
+		expect(codec.context.retainedTransactions?.[0]?.planDigest).to.deep.equal(
+			digest(17),
+		);
+		const exposedContext = codec.context;
+		exposedContext.expectedProgramId.fill(55);
+		exposedContext.retainedTransactions?.[0]?.planDigest.fill(44);
+		expect(codec.context.expectedProgramId).to.deep.equal(programId);
+		expect(codec.context.retainedTransactions?.[0]?.planDigest).to.deep.equal(
+			digest(17),
+		);
+
+		const frame = codec.encode(
+			record(1n, 2n, "tx-2", NativeDurabilityPhase.DurablePrepared),
+		);
+		expect(codec.classify(frame).kind).to.equal("complete");
+	});
+
+	it("is the storage classifier for short header, body, and trailer tails", async () => {
+		const codec = await createNativeDurabilityJournalCodec(context());
+		const frame = codec.encode(
+			record(1n, 1n, "tx-1", NativeDurabilityPhase.DurablePrepared),
+		);
+
+		expect(codec.classify(frame.subarray(0, 10))).to.deep.equal({
+			kind: "incomplete-tail",
+			validLength: 0,
+			lastRecordLsn: 0n,
+			reason: "short-header",
+		});
+		// The fixed trailer is 12 bytes; removing thirteen also removes one body byte.
+		expect(codec.classify(frame.subarray(0, frame.byteLength - 13))).to.deep.equal({
+			kind: "incomplete-tail",
+			validLength: 0,
+			lastRecordLsn: 0n,
+			reason: "short-body",
+		});
+		expect(codec.classify(frame.subarray(0, frame.byteLength - 1))).to.deep.equal({
+			kind: "incomplete-tail",
+			validLength: 0,
+			lastRecordLsn: 0n,
+			reason: "short-trailer",
+		});
+	});
+
+	it("throws a typed corruption error for a complete bad frame and non-tail corruption", async () => {
+		const codec = await createNativeDurabilityJournalCodec(context());
+		const first = codec.encode(
+			record(1n, 1n, "tx-1", NativeDurabilityPhase.DurablePrepared),
+		);
+		const second = codec.encode(
+			record(2n, 1n, "tx-1", NativeDurabilityPhase.NativeApplied),
+		);
+		const corrupt = new Uint8Array(first);
+		corrupt[corrupt.byteLength - 20] ^= 1;
+
+		for (const bytes of [corrupt, concatBytes([corrupt, second])]) {
+			let thrown: unknown;
+			try {
+				codec.classify(bytes);
+			} catch (error) {
+				thrown = error;
+			}
+			expect(thrown).to.be.instanceOf(NativeDurabilityJournalCorruptionError);
+			expect(
+				(thrown as NativeDurabilityJournalCorruptionError).code,
+			).to.equal("ERR_NATIVE_DURABILITY_JOURNAL_INVALID_FRAME_CHECKSUM");
+			expect(
+				(thrown as NativeDurabilityJournalCorruptionError).byteOffset,
+			).to.equal(0);
+		}
+	});
+
+	it("returns typed transition errors with decoded append metadata", async () => {
+		const codec = await createNativeDurabilityJournalCodec(context());
+		const bytes = concatBytes([
+			codec.encode(record(1n, 1n, "tx-1", NativeDurabilityPhase.DurablePrepared)),
+			codec.encode(record(2n, 1n, "tx-1", NativeDurabilityPhase.Published)),
+		]);
+		let thrown: unknown;
+		try {
+			codec.scan(bytes);
+		} catch (error) {
+			thrown = error;
+		}
+		expect(thrown).to.be.instanceOf(NativeDurabilityJournalCorruptionError);
+		expect((thrown as NativeDurabilityJournalCorruptionError).code).to.equal(
+			"ERR_NATIVE_DURABILITY_JOURNAL_INVALID_PHASE_TRANSITION",
+		);
+		expect((thrown as NativeDurabilityJournalCorruptionError).byteOffset).to.be.greaterThan(
+			0,
+		);
+	});
+
+	it("shares Rust u64 and UTF-8 bounds at the TypeScript boundary", async () => {
+		const codec = await createNativeDurabilityJournalCodec(context());
+		const tooLarge = record(
+			NATIVE_DURABILITY_JOURNAL_MAX_U64 + 1n,
+			1n,
+			"tx-1",
+			NativeDurabilityPhase.DurablePrepared,
+		);
+		expect(() => codec.encode(tooLarge)).to.throw(NativeDurabilityJournalInputError);
+
+		const tooLongId = record(
+			1n,
+			1n,
+			"é".repeat(NATIVE_DURABILITY_JOURNAL_MAX_TRANSACTION_ID_LENGTH),
+			NativeDurabilityPhase.DurablePrepared,
+		);
+		expect(() => codec.encode(tooLongId)).to.throw(NativeDurabilityJournalInputError);
+	});
+
+	it("round-trips the maximum LSN exactly", async () => {
+		const codec = await createNativeDurabilityJournalCodec(
+			context({ checkpointLsn: NATIVE_DURABILITY_JOURNAL_MAX_U64 - 1n }),
+		);
+		const maximum = record(
+			NATIVE_DURABILITY_JOURNAL_MAX_U64,
+			1n,
+			"tx-max",
+			NativeDurabilityPhase.DurablePrepared,
+		);
+		const scan = codec.scan(codec.encode(maximum));
+		expect(scan.lastRecordLsn).to.equal(NATIVE_DURABILITY_JOURNAL_MAX_U64);
+		expect(scan.records[0]!.recordLsn).to.equal(NATIVE_DURABILITY_JOURNAL_MAX_U64);
+	});
+});

--- a/packages/utils/native-backbone/test/directory-lease.spec.ts
+++ b/packages/utils/native-backbone/test/directory-lease.spec.ts
@@ -1,0 +1,193 @@
+import { expect } from "chai";
+import { type ChildProcess, fork } from "node:child_process";
+import { once } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	type NativeDurabilityLease,
+	NativeDurabilityLeaseClosedError,
+	NativeDurabilityLeaseUnavailableError,
+} from "../src/durability/lease.js";
+import { acquireNativeDurabilityNodeLease } from "../src/durability/node-lease.js";
+
+type WorkerFence = {
+	epoch: string;
+	ownerId: string;
+	domainId: string;
+};
+
+type WorkerMessage =
+	| { event: "held"; fence: WorkerFence }
+	| { event: "error"; name?: string; code?: string; message: string };
+
+const workerPath = fileURLToPath(
+	new URL("./fixtures/directory-lease-worker.js", import.meta.url),
+);
+
+const waitForWorkerMessage = async (
+	child: ChildProcess,
+): Promise<WorkerMessage> => {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			new Promise<WorkerMessage>((resolve, reject) => {
+				child.once("message", (message) => resolve(message as WorkerMessage));
+				child.once("error", reject);
+				child.once("exit", (code, signal) => {
+					reject(
+						new Error(
+							`Lease worker exited before replying (code=${String(code)}, signal=${String(signal)})`,
+						),
+					);
+				});
+			}),
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(
+					() => reject(new Error("Timed out waiting for lease worker")),
+					10_000,
+				);
+			}),
+		]);
+	} finally {
+		if (timer) {
+			clearTimeout(timer);
+		}
+	}
+};
+
+describe("native durability directory lease", () => {
+	const directories: string[] = [];
+	const children = new Set<ChildProcess>();
+	const leases = new Set<NativeDurabilityLease>();
+
+	beforeEach(function () {
+		if (process.platform === "win32") {
+			this.skip();
+		}
+	});
+
+	afterEach(async () => {
+		const childExits = [...children]
+			.filter((child) => child.exitCode === null && child.signalCode === null)
+			.map((child) => {
+				const exited = once(child, "exit");
+				child.kill("SIGKILL");
+				return exited;
+			});
+		await Promise.allSettled([...leases].map((lease) => lease.close()));
+		await Promise.allSettled(childExits);
+		children.clear();
+		leases.clear();
+		await Promise.all(
+			directories
+				.splice(0)
+				.map((directory) => rm(directory, { recursive: true, force: true })),
+		);
+	});
+
+	const temporaryDirectory = async (): Promise<string> => {
+		const directory = await mkdtemp(
+			join(tmpdir(), "peerbit-native-durability-lease-"),
+		);
+		directories.push(directory);
+		return directory;
+	};
+
+	it("rejects a second opener and advances its persistent fence", async () => {
+		const directory = await temporaryDirectory();
+		const first = await acquireNativeDurabilityNodeLease(directory);
+		leases.add(first);
+
+		let secondError: unknown;
+		try {
+			await acquireNativeDurabilityNodeLease(directory);
+		} catch (error) {
+			secondError = error;
+		}
+		expect(secondError).to.be.instanceOf(NativeDurabilityLeaseUnavailableError);
+
+		await first.close();
+		leases.delete(first);
+		let closedError: unknown;
+		try {
+			await first.assertHeld();
+		} catch (error) {
+			closedError = error;
+		}
+		expect(closedError).to.be.instanceOf(NativeDurabilityLeaseClosedError);
+
+		const reopened = await acquireNativeDurabilityNodeLease(directory);
+		leases.add(reopened);
+		expect(reopened.fence.epoch).to.equal(first.fence.epoch + 1n);
+		expect(reopened.fence.domainId).to.equal(first.fence.domainId);
+		expect(reopened.fence.ownerId).to.not.equal(first.fence.ownerId);
+	});
+
+	it("keeps the OS lock until guarded operations drain", async () => {
+		const directory = await temporaryDirectory();
+		const first = await acquireNativeDurabilityNodeLease(directory);
+		leases.add(first);
+		let releaseOperation!: () => void;
+		const operationGate = new Promise<void>((resolve) => {
+			releaseOperation = resolve;
+		});
+		const operation = first.runWhileHeld(() => operationGate);
+		const closing = first.close();
+
+		let concurrentError: unknown;
+		try {
+			await acquireNativeDurabilityNodeLease(directory);
+		} catch (error) {
+			concurrentError = error;
+		}
+		expect(concurrentError).to.be.instanceOf(
+			NativeDurabilityLeaseUnavailableError,
+		);
+
+		releaseOperation();
+		await operation;
+		await closing;
+		leases.delete(first);
+
+		const reopened = await acquireNativeDurabilityNodeLease(directory);
+		leases.add(reopened);
+		expect(reopened.fence.epoch).to.equal(first.fence.epoch + 1n);
+	});
+
+	it("reacquires immediately with a higher fence after SIGKILL", async function () {
+		const directory = await temporaryDirectory();
+		const child = fork(workerPath, ["hold", directory], {
+			stdio: ["ignore", "ignore", "pipe", "ipc"],
+		});
+		children.add(child);
+		const held = await waitForWorkerMessage(child);
+		if (held.event === "error") {
+			throw new Error(
+				`Lease worker failed (${held.code ?? held.name ?? "unknown"}): ${held.message}`,
+			);
+		}
+
+		let concurrentError: unknown;
+		try {
+			await acquireNativeDurabilityNodeLease(directory);
+		} catch (error) {
+			concurrentError = error;
+		}
+		expect(concurrentError).to.be.instanceOf(
+			NativeDurabilityLeaseUnavailableError,
+		);
+
+		const exited = once(child, "exit");
+		expect(child.kill("SIGKILL")).to.equal(true);
+		await exited;
+		children.delete(child);
+
+		const recovered = await acquireNativeDurabilityNodeLease(directory);
+		leases.add(recovered);
+		expect(recovered.fence.epoch).to.equal(BigInt(held.fence.epoch) + 1n);
+		expect(recovered.fence.domainId).to.equal(held.fence.domainId);
+		expect(recovered.fence.ownerId).to.not.equal(held.fence.ownerId);
+	});
+});

--- a/packages/utils/native-backbone/test/fixtures/directory-lease-worker.ts
+++ b/packages/utils/native-backbone/test/fixtures/directory-lease-worker.ts
@@ -1,0 +1,37 @@
+import { acquireNativeDurabilityNodeLease } from "../../src/durability/node-lease.js";
+
+const [mode, directory] = process.argv.slice(2);
+
+const send = (message: unknown): void => {
+	if (!process.send) {
+		throw new Error("Directory lease worker requires an IPC channel");
+	}
+	process.send(message);
+};
+
+try {
+	if (mode !== "hold" || !directory) {
+		throw new Error("Expected: directory-lease-worker hold <directory>");
+	}
+	const lease = await acquireNativeDurabilityNodeLease(directory);
+	send({
+		event: "held",
+		fence: {
+			epoch: lease.fence.epoch.toString(),
+			ownerId: lease.fence.ownerId,
+			domainId: lease.fence.domainId,
+		},
+	});
+	// The test parent deliberately terminates this process without calling
+	// close(), proving the operating-system lock is crash released.
+	setInterval(() => undefined, 60_000);
+} catch (error) {
+	const typed = error as { name?: string; code?: string; message?: string };
+	send({
+		event: "error",
+		name: typed?.name,
+		code: typed?.code,
+		message: typed?.message ?? String(error),
+	});
+	process.exitCode = 1;
+}

--- a/packages/utils/native-backbone/test/native-durability-node-storage.spec.ts
+++ b/packages/utils/native-backbone/test/native-durability-node-storage.spec.ts
@@ -1,0 +1,1189 @@
+import { expect } from "chai";
+import { createHash } from "node:crypto";
+import {
+	appendFile,
+	mkdir,
+	mkdtemp,
+	open,
+	readFile,
+	realpath,
+	rm,
+	stat,
+	writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+	type NativeDurabilityJournalCodec,
+	NativeDurabilityJournalCorruptionError,
+	type NativeDurabilityJournalRecord,
+	NativeDurabilityOperationKind,
+	NativeDurabilityPhase,
+	createNativeDurabilityJournalCodec,
+} from "../src/durability/codec.js";
+import { NativeDurabilityLeaseUnavailableError } from "../src/durability/lease.js";
+import {
+	NodeNativeDurabilityStorage,
+	createNodeNativeDurabilityStorage,
+} from "../src/durability/node-storage.js";
+import {
+	type NativeDurabilityCheckpointRequest,
+	NativeDurabilityDigestMismatchError,
+	type NativeDurabilityJournalAppendRequest,
+	NativeDurabilityMigrationRequiredError,
+	type NativeDurabilityStageRequest,
+	NativeDurabilityStorageClosedError,
+	NativeDurabilityStorageCorruptionError,
+	encodeNativeDurabilityCanonical,
+} from "../src/durability/storage.js";
+
+const PROGRAM_ID = new Uint8Array([0x70, 0x65, 0x65, 0x72, 0x62, 0x69, 0x74]);
+const NAMESPACE = "native-durability-v1";
+const CHECKPOINTS = "checkpoints";
+const STAGING = "staging";
+const JOURNAL = "journal.bin";
+
+const digest = (bytes: Uint8Array): Uint8Array =>
+	new Uint8Array(createHash("sha256").update(bytes).digest());
+
+const digestHex = (bytes: Uint8Array): string =>
+	createHash("sha256").update(bytes).digest("hex");
+
+const bytesEqual = (left: Uint8Array, right: Uint8Array): boolean =>
+	left.byteLength === right.byteLength &&
+	left.every((byte, index) => byte === right[index]);
+
+const concatBytes = (chunks: readonly Uint8Array[]): Uint8Array => {
+	const bytes = new Uint8Array(
+		chunks.reduce((length, chunk) => length + chunk.byteLength, 0),
+	);
+	let offset = 0;
+	for (const chunk of chunks) {
+		bytes.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return bytes;
+};
+
+const rejectedWith = async (promise: Promise<unknown>): Promise<unknown> => {
+	try {
+		await promise;
+	} catch (error) {
+		return error;
+	}
+	throw new Error("Expected promise to reject");
+};
+
+const pathExists = async (path: string): Promise<boolean> => {
+	try {
+		await stat(path);
+		return true;
+	} catch (error) {
+		if ((error as { code?: string }).code === "ENOENT") return false;
+		throw error;
+	}
+};
+
+const writeFileAndSync = async (
+	path: string,
+	bytes: Uint8Array,
+): Promise<void> => {
+	await writeFile(path, bytes);
+	const file = await open(path, "r+");
+	try {
+		await file.sync();
+	} finally {
+		await file.close();
+	}
+	const directory = await open(dirname(path), "r");
+	try {
+		await directory.sync();
+	} finally {
+		await directory.close();
+	}
+};
+
+const syncDirectoryPath = async (path: string): Promise<void> => {
+	const directory = await open(path, "r");
+	try {
+		await directory.sync();
+	} finally {
+		await directory.close();
+	}
+};
+
+const durabilityPath = (directory: string, ...parts: string[]): string =>
+	join(directory, NAMESPACE, ...parts);
+
+const transactionDirectory = (
+	directory: string,
+	transactionId: string,
+): string =>
+	durabilityPath(
+		directory,
+		STAGING,
+		`tx-${digestHex(new TextEncoder().encode(transactionId))}`,
+	);
+
+const encodeManifestEnvelope = (payload: unknown): Uint8Array => {
+	const payloadText = JSON.stringify(payload);
+	return new TextEncoder().encode(
+		JSON.stringify({
+			payload: payloadText,
+			checksum: digestHex(new TextEncoder().encode(payloadText)),
+		}),
+	);
+};
+
+type TransactionFrames = {
+	codec: NativeDurabilityJournalCodec;
+	frames: Uint8Array;
+	individualFrames: Uint8Array[];
+	records: NativeDurabilityJournalRecord[];
+	planDigest: Uint8Array;
+};
+
+const transactionFrames = async (
+	storage: NodeNativeDurabilityStorage,
+	transactionId: string,
+	txSequence: bigint,
+	phases: readonly NativeDurabilityPhase[],
+	firstRecordLsn = 1n,
+): Promise<TransactionFrames> => {
+	const checkpoint = await storage.readLatestCheckpoint();
+	if (!checkpoint) throw new Error("Storage has no checkpoint authority");
+	const codec = await createNativeDurabilityJournalCodec({
+		checkpointLsn: checkpoint.checkpointLsn,
+		checkpointTxSequenceHighwater: checkpoint.txSequenceHighwater,
+		expectedProgramId: PROGRAM_ID,
+		expectedWriterDomainId: storage.domainId,
+		checkpointWriterEpoch: checkpoint.originFence.epoch,
+		checkpointWriterOwnerId: checkpoint.originFence.ownerId,
+		currentWriterEpoch: storage.fence.epoch,
+		currentWriterOwnerId: storage.fence.ownerId,
+		retainedTransactions: checkpoint.retainedTransactions,
+	});
+	const planDigest = digest(new TextEncoder().encode(`plan:${transactionId}`));
+	const records = phases.map(
+		(phase, index): NativeDurabilityJournalRecord => ({
+			recordLsn: firstRecordLsn + BigInt(index),
+			txSequence,
+			writerEpoch: storage.fence.epoch,
+			writerOwnerId: storage.fence.ownerId,
+			writerDomainId: storage.domainId,
+			phase,
+			operationKind: NativeDurabilityOperationKind.Append,
+			programId: new Uint8Array(PROGRAM_ID),
+			transactionId,
+			planDigest: new Uint8Array(planDigest),
+			payload: new Uint8Array([Number(phase), index, 0xa5]),
+		}),
+	);
+	const individualFrames = records.map((record) => codec.encode(record));
+	return {
+		codec,
+		frames: concatBytes(individualFrames),
+		individualFrames,
+		records,
+		planDigest,
+	};
+};
+
+const appendRequest = (
+	transaction: TransactionFrames,
+	expectedOffset = 0,
+): NativeDurabilityJournalAppendRequest => ({
+	transactionId: transaction.records[0]!.transactionId,
+	txSequence: transaction.records[0]!.txSequence,
+	firstRecordLsn: transaction.records[0]!.recordLsn,
+	lastRecordLsn: transaction.records.at(-1)!.recordLsn,
+	expectedOffset,
+	frames: transaction.frames,
+	framesDigest: digest(transaction.frames),
+});
+
+describe("native durability Node storage", function () {
+	this.timeout(180_000);
+
+	const directories: string[] = [];
+	const storages = new Set<NodeNativeDurabilityStorage>();
+
+	const temporaryDirectory = async (): Promise<string> => {
+		const directory = await mkdtemp(
+			join(tmpdir(), "peerbit-native-durability-storage-"),
+		);
+		directories.push(directory);
+		return directory;
+	};
+
+	const openStorage = async (
+		directory: string,
+	): Promise<NodeNativeDurabilityStorage> => {
+		const storage = await createNodeNativeDurabilityStorage({
+			directory,
+			programId: PROGRAM_ID,
+		});
+		storages.add(storage);
+		return storage;
+	};
+
+	const closeStorage = async (
+		storage: NodeNativeDurabilityStorage,
+	): Promise<void> => {
+		await storage.close();
+		storages.delete(storage);
+	};
+
+	afterEach(async () => {
+		await Promise.allSettled([...storages].map((storage) => storage.close()));
+		storages.clear();
+		await Promise.all(
+			directories
+				.splice(0)
+				.map((directory) => rm(directory, { recursive: true, force: true })),
+		);
+	});
+
+	it("creates canonical empty genesis state and reopens under a higher fence", async () => {
+		const directory = await temporaryDirectory();
+		const first = await openStorage(directory);
+
+		expect(first.kind).to.equal("node-fsync");
+		expect(first.crashSafe).to.equal(true);
+		expect(first.version).to.equal(1);
+		const genesis = await first.readLatestCheckpoint();
+		expect(genesis?.generation).to.equal(0n);
+		expect(genesis?.checkpointLsn).to.equal(0n);
+		expect(genesis?.txSequenceHighwater).to.equal(0n);
+		expect(genesis?.manifestSlot).to.equal("a");
+		expect(genesis?.bytes).to.deep.equal(new Uint8Array());
+		expect(genesis?.stagingCoverage).to.deep.equal([]);
+		expect(genesis?.retainedTransactions).to.deep.equal([]);
+		expect(await first.readJournal()).to.deep.equal(new Uint8Array());
+		expect(await first.listStagingTransactionIds()).to.deep.equal([]);
+		expect(await first.stats()).to.deep.equal({
+			kind: "node-fsync",
+			domainId: first.domainId,
+			strictBarrierCount: 0n,
+			strictDeleteCount: 0n,
+			journalBytes: 0,
+			stagingTransactions: 0,
+			stagedBlocks: 0,
+			stagedBytes: 0,
+			checkpointGenerations: 1,
+			checkpointBytes: 0,
+		});
+
+		const firstFence = first.fence;
+		await closeStorage(first);
+		const reopened = await openStorage(directory);
+		const reopenedGenesis = await reopened.readLatestCheckpoint();
+		expect(reopened.domainId).to.equal(firstFence.domainId);
+		expect(reopened.fence.epoch).to.equal(firstFence.epoch + 1n);
+		expect(reopened.fence.ownerId).to.not.equal(firstFence.ownerId);
+		expect(reopenedGenesis?.generation).to.equal(0n);
+		expect(reopenedGenesis?.originFence).to.deep.equal(firstFence);
+	});
+
+	it("rejects direct JavaScript construction outside the production factory", () => {
+		const UnsafeStorage = NodeNativeDurabilityStorage as unknown as new (
+			...args: unknown[]
+		) => NodeNativeDurabilityStorage;
+		expect(() => new UnsafeStorage()).to.throw(
+			TypeError,
+			"must be created by createNodeNativeDurabilityStorage",
+		);
+	});
+
+	it("requires explicit migration for legacy data without creating a namespace", async () => {
+		const directory = await temporaryDirectory();
+		await writeFile(join(directory, "legacy-program.db"), new Uint8Array([1]));
+
+		const error = await rejectedWith(
+			createNodeNativeDurabilityStorage({ directory, programId: PROGRAM_ID }),
+		);
+		expect(error).to.be.instanceOf(NativeDurabilityMigrationRequiredError);
+		expect(
+			(error as NativeDurabilityMigrationRequiredError).directory,
+		).to.equal(await realpath(directory));
+		expect(await pathExists(durabilityPath(directory))).to.equal(false);
+
+		const retryError = await rejectedWith(
+			createNodeNativeDurabilityStorage({ directory, programId: PROGRAM_ID }),
+		);
+		expect(retryError).to.be.instanceOf(NativeDurabilityMigrationRequiredError);
+	});
+
+	it("rejects a second production factory while the first owns the directory", async () => {
+		const directory = await temporaryDirectory();
+		const first = await openStorage(directory);
+
+		const error = await rejectedWith(
+			createNodeNativeDurabilityStorage({ directory, programId: PROGRAM_ID }),
+		);
+		expect(error).to.be.instanceOf(NativeDurabilityLeaseUnavailableError);
+
+		const firstFence = first.fence;
+		await closeStorage(first);
+		const reopened = await openStorage(directory);
+		expect(reopened.fence.epoch).to.equal(firstFence.epoch + 1n);
+	});
+
+	it("stages isolated snapshots, rejects bad digests, and completes exact orphan retries", async () => {
+		const directory = await temporaryDirectory();
+		const storage = await openStorage(directory);
+		const originalA = new Uint8Array([1, 2, 3, 4]);
+		const digestA = digest(originalA);
+
+		const digestError = await rejectedWith(
+			storage.stageAndSync({
+				scope: { transactionId: "bad-digest", txSequence: 1n, recordLsn: 1n },
+				blocks: [
+					{
+						ordinal: 0,
+						cid: "cid-bad",
+						bytes: originalA,
+						digest: new Uint8Array(32),
+					},
+				],
+			}),
+		);
+		expect(digestError).to.be.instanceOf(NativeDurabilityDigestMismatchError);
+		expect(await storage.listStagingTransactionIds()).to.deep.equal([]);
+
+		const orphanDirectory = transactionDirectory(directory, "tx-a");
+		await mkdir(orphanDirectory);
+		await writeFile(join(orphanDirectory, "000000000000.block"), originalA);
+		await writeFile(
+			join(orphanDirectory, "000000000000.block.tmp-interrupted"),
+			originalA.slice(0, 1),
+		);
+
+		const requestA: NativeDurabilityStageRequest = {
+			scope: { transactionId: "tx-a", txSequence: 1n, recordLsn: 1n },
+			blocks: [
+				{
+					ordinal: 0,
+					cid: "cid-a",
+					bytes: originalA,
+					digest: new Uint8Array(digestA),
+				},
+			],
+		};
+		const stagedA = storage.stageAndSync(requestA);
+		requestA.scope.transactionId = "mutated-transaction";
+		requestA.blocks[0]!.cid = "mutated-cid";
+		requestA.blocks[0]!.bytes.fill(0xff);
+		requestA.blocks[0]!.digest.fill(0xee);
+		const receiptA = await stagedA;
+		expect(receiptA.transactionId).to.equal("tx-a");
+		expect(receiptA.blocks[0]?.cid).to.equal("cid-a");
+		expect(receiptA.blocks[0]?.digest).to.deep.equal(digestA);
+
+		const originalB = new Uint8Array([9, 8, 7]);
+		await storage.stageAndSync({
+			scope: { transactionId: "tx-b", txSequence: 2n, recordLsn: 2n },
+			blocks: [
+				{
+					ordinal: 0,
+					cid: "cid-b",
+					bytes: originalB,
+					digest: digest(originalB),
+				},
+			],
+		});
+
+		expect(await storage.listStagingTransactionIds()).to.deep.equal([
+			"tx-a",
+			"tx-b",
+		]);
+		expect(await storage.readStagedBlock("tx-a", 0)).to.deep.equal(
+			new Uint8Array([1, 2, 3, 4]),
+		);
+		expect(await storage.readStagedBlock("tx-b", 0)).to.deep.equal(originalB);
+		expect(await storage.readStagedBlock("tx-a", 1)).to.equal(undefined);
+		const stats = await storage.stats();
+		expect(stats.strictBarrierCount).to.equal(2n);
+		expect(stats.stagingTransactions).to.equal(2);
+		expect(stats.stagedBlocks).to.equal(2);
+		expect(stats.stagedBytes).to.equal(7);
+
+		await closeStorage(storage);
+		const reopened = await openStorage(directory);
+		expect(await reopened.listStagingTransactionIds()).to.deep.equal([]);
+	});
+
+	it("derives append receipts from official frames and rejects untrusted metadata before writing", async () => {
+		const directory = await temporaryDirectory();
+		const storage = await openStorage(directory);
+		const transaction = await transactionFrames(storage, "journal-tx", 1n, [
+			NativeDurabilityPhase.DurablePrepared,
+		]);
+		const request = appendRequest(transaction);
+
+		const digestError = await rejectedWith(
+			storage.appendJournalAndSync({
+				...request,
+				framesDigest: new Uint8Array(32),
+			}),
+		);
+		expect(digestError).to.be.instanceOf(NativeDurabilityDigestMismatchError);
+		expect(await storage.readJournal()).to.deep.equal(new Uint8Array());
+
+		const metadataError = await rejectedWith(
+			storage.appendJournalAndSync({
+				...request,
+				transactionId: "caller-lie",
+			}),
+		);
+		expect(metadataError).to.be.instanceOf(
+			NativeDurabilityStorageCorruptionError,
+		);
+		expect(await storage.readJournal()).to.deep.equal(new Uint8Array());
+
+		const originalFrames = new Uint8Array(request.frames);
+		const originalFramesDigest = new Uint8Array(request.framesDigest);
+		const append = storage.appendJournalAndSync(request);
+		request.transactionId = "mutated-after-admission";
+		request.txSequence = 99n;
+		request.firstRecordLsn = 99n;
+		request.lastRecordLsn = 99n;
+		request.frames.fill(0xcc);
+		request.framesDigest.fill(0xdd);
+		const receipt = await append;
+		const durable = await storage.readJournal();
+		const decoded = transaction.codec.scan(durable).records[0]!;
+
+		expect(durable).to.deep.equal(originalFrames);
+		expect(receipt.transactionId).to.equal(decoded.transactionId);
+		expect(receipt.txSequence).to.equal(decoded.txSequence);
+		expect(receipt.firstRecordLsn).to.equal(decoded.recordLsn);
+		expect(receipt.lastRecordLsn).to.equal(decoded.recordLsn);
+		expect(receipt.fence).to.deep.equal(storage.fence);
+		expect(receipt.framesDigest).to.deep.equal(originalFramesDigest);
+		expect(receipt.offset).to.equal(0);
+		expect(receipt.endOffset).to.equal(originalFrames.byteLength);
+		const stats = await storage.stats();
+		expect(stats.strictBarrierCount).to.equal(1n);
+		expect(stats.journalBytes).to.equal(originalFrames.byteLength);
+	});
+
+	it("strictly confirms complete retries and resumes exact multi-frame prefixes", async () => {
+		const completeDirectory = await temporaryDirectory();
+		const first = await openStorage(completeDirectory);
+		const completeTransaction = await transactionFrames(
+			first,
+			"complete-retry",
+			1n,
+			[
+				NativeDurabilityPhase.DurablePrepared,
+				NativeDurabilityPhase.NativeApplied,
+			],
+		);
+		const completeRequest = appendRequest(completeTransaction);
+		await writeFile(
+			durabilityPath(completeDirectory, JOURNAL),
+			completeTransaction.frames,
+		);
+		await closeStorage(first);
+
+		const completeRetry = await openStorage(completeDirectory);
+		const confirmed = await completeRetry.appendJournalAndSync(completeRequest);
+		expect(confirmed.firstRecordLsn).to.equal(1n);
+		expect(confirmed.lastRecordLsn).to.equal(2n);
+		expect(await completeRetry.readJournal()).to.deep.equal(
+			completeTransaction.frames,
+		);
+		await closeStorage(completeRetry);
+
+		const boundaryDirectory = await temporaryDirectory();
+		const boundaryFirst = await openStorage(boundaryDirectory);
+		const boundaryTransaction = await transactionFrames(
+			boundaryFirst,
+			"boundary-retry",
+			1n,
+			[
+				NativeDurabilityPhase.DurablePrepared,
+				NativeDurabilityPhase.NativeApplied,
+			],
+		);
+		await writeFile(
+			durabilityPath(boundaryDirectory, JOURNAL),
+			boundaryTransaction.individualFrames[0]!,
+		);
+		await closeStorage(boundaryFirst);
+		const boundaryRetry = await openStorage(boundaryDirectory);
+		await boundaryRetry.appendJournalAndSync(
+			appendRequest(boundaryTransaction),
+		);
+		expect(await boundaryRetry.readJournal()).to.deep.equal(
+			boundaryTransaction.frames,
+		);
+		await closeStorage(boundaryRetry);
+
+		const partialDirectory = await temporaryDirectory();
+		const partialFirst = await openStorage(partialDirectory);
+		const partialTransaction = await transactionFrames(
+			partialFirst,
+			"partial-retry",
+			1n,
+			[
+				NativeDurabilityPhase.DurablePrepared,
+				NativeDurabilityPhase.NativeApplied,
+			],
+		);
+		const firstFrame = partialTransaction.individualFrames[0]!;
+		const partialSecond = partialTransaction.individualFrames[1]!.slice(0, 17);
+		await writeFile(
+			durabilityPath(partialDirectory, JOURNAL),
+			concatBytes([firstFrame, partialSecond]),
+		);
+		await closeStorage(partialFirst);
+
+		const partialRetry = await openStorage(partialDirectory);
+		const truncated = await partialRetry.reconcileIncompleteJournalTailAndSync({
+			transactionId: "partial-retry",
+			txSequence: 1n,
+		});
+		expect(truncated.validLength).to.equal(firstFrame.byteLength);
+		const resumed = await partialRetry.appendJournalAndSync(
+			appendRequest(partialTransaction),
+		);
+		expect(resumed.lastRecordLsn).to.equal(2n);
+		expect(await partialRetry.readJournal()).to.deep.equal(
+			partialTransaction.frames,
+		);
+		const confirmedTruncation =
+			await partialRetry.reconcileIncompleteJournalTailAndSync({
+				transactionId: "partial-retry",
+				txSequence: 1n,
+			});
+		expect(confirmedTruncation.previousLength).to.equal(
+			partialTransaction.frames.byteLength,
+		);
+		expect(confirmedTruncation.validLength).to.equal(
+			partialTransaction.frames.byteLength,
+		);
+	});
+
+	it("reopens and reconciles only a structurally incomplete journal tail", async () => {
+		const directory = await temporaryDirectory();
+		const first = await openStorage(directory);
+		const transaction = await transactionFrames(first, "torn-tx", 1n, [
+			NativeDurabilityPhase.DurablePrepared,
+			NativeDurabilityPhase.NativeApplied,
+		]);
+		const firstFrame = transaction.individualFrames[0]!;
+		const secondFrame = transaction.individualFrames[1]!;
+		await first.appendJournalAndSync({
+			...appendRequest(transaction),
+			lastRecordLsn: 1n,
+			frames: firstFrame,
+			framesDigest: digest(firstFrame),
+		});
+		await closeStorage(first);
+
+		const journalPath = durabilityPath(directory, JOURNAL);
+		const tornPrefix = secondFrame.subarray(0, 10);
+		await appendFile(journalPath, tornPrefix);
+		const reopened = await openStorage(directory);
+		const receipt = await reopened.reconcileIncompleteJournalTailAndSync({
+			transactionId: "torn-tx",
+			txSequence: 1n,
+		});
+
+		expect(receipt.previousLength).to.equal(
+			firstFrame.byteLength + tornPrefix.byteLength,
+		);
+		expect(receipt.validLength).to.equal(firstFrame.byteLength);
+		expect(receipt.firstRecordLsn).to.equal(1n);
+		expect(receipt.lastRecordLsn).to.equal(1n);
+		expect(await reopened.readJournal()).to.deep.equal(firstFrame);
+		expect((await reopened.stats()).strictBarrierCount).to.equal(1n);
+	});
+
+	it("never truncates a complete frame with checksum corruption", async () => {
+		const directory = await temporaryDirectory();
+		const storage = await openStorage(directory);
+		const transaction = await transactionFrames(storage, "corrupt-tx", 1n, [
+			NativeDurabilityPhase.DurablePrepared,
+			NativeDurabilityPhase.NativeApplied,
+		]);
+		await storage.appendJournalAndSync(appendRequest(transaction));
+		await closeStorage(storage);
+
+		const journalPath = durabilityPath(directory, JOURNAL);
+		const corrupt = new Uint8Array(await readFile(journalPath));
+		corrupt[corrupt.byteLength - 20] ^= 1;
+		await writeFile(journalPath, corrupt);
+
+		const error = await rejectedWith(
+			createNodeNativeDurabilityStorage({ directory, programId: PROGRAM_ID }),
+		);
+		expect(error).to.be.instanceOf(NativeDurabilityJournalCorruptionError);
+		const after = new Uint8Array(await readFile(journalPath));
+		expect(bytesEqual(after, corrupt)).to.equal(true);
+		expect(after.byteLength).to.equal(corrupt.byteLength);
+	});
+
+	it("fails closed when an established journal is missing and preserves staging", async () => {
+		const directory = await temporaryDirectory();
+		const storage = await openStorage(directory);
+		const transactionId = "missing-journal";
+		const block = new Uint8Array([1, 4, 9]);
+		const stageReceipt = await storage.stageAndSync({
+			scope: { transactionId, txSequence: 1n, recordLsn: 1n },
+			blocks: [
+				{
+					ordinal: 0,
+					cid: "missing-journal-cid",
+					bytes: block,
+					digest: digest(block),
+				},
+			],
+		});
+		const transaction = await transactionFrames(storage, transactionId, 1n, [
+			NativeDurabilityPhase.DurablePrepared,
+			NativeDurabilityPhase.NativeApplied,
+			NativeDurabilityPhase.Published,
+			NativeDurabilityPhase.Committed,
+			NativeDurabilityPhase.Clean,
+		]);
+		await storage.appendJournalAndSync(appendRequest(transaction));
+		const checkpointBytes = new Uint8Array([5]);
+		await storage.writeCheckpointAndSync({
+			scope: { transactionId, txSequence: 1n, recordLsn: 5n },
+			checkpointLsn: 5n,
+			txSequenceHighwater: 1n,
+			bytes: checkpointBytes,
+			digest: digest(checkpointBytes),
+			stagingCoverage: [
+				{
+					transactionId,
+					txSequence: 1n,
+					coveredThroughLsn: 5n,
+					stagingManifestDigest: stageReceipt.manifestDigest,
+				},
+			],
+			retainedTransactions: [
+				{
+					txSequence: 1n,
+					transactionId,
+					phase: NativeDurabilityPhase.Clean,
+					operationKind: NativeDurabilityOperationKind.Append,
+					planDigest: transaction.planDigest,
+				},
+			],
+		});
+		await closeStorage(storage);
+
+		await rm(durabilityPath(directory, JOURNAL));
+		await syncDirectoryPath(durabilityPath(directory));
+		const error = await rejectedWith(openStorage(directory));
+		expect(error).to.be.instanceOf(NativeDurabilityStorageCorruptionError);
+		expect(
+			await pathExists(transactionDirectory(directory, transactionId)),
+		).to.equal(true);
+
+		await writeFileAndSync(
+			durabilityPath(directory, JOURNAL),
+			new Uint8Array(),
+		);
+		const shortenedError = await rejectedWith(openStorage(directory));
+		expect(shortenedError).to.be.instanceOf(
+			NativeDurabilityStorageCorruptionError,
+		);
+		expect(
+			await pathExists(transactionDirectory(directory, transactionId)),
+		).to.equal(true);
+	});
+
+	it("reconciles checkpoint cut points and protects CLEAN deletion authorities", async () => {
+		const directory = await temporaryDirectory();
+		let storage = await openStorage(directory);
+		const transactionId = "checkpoint-tx-1";
+		const stagedBytes = new Uint8Array([4, 5, 6]);
+		const stageReceipt = await storage.stageAndSync({
+			scope: { transactionId, txSequence: 1n, recordLsn: 1n },
+			blocks: [
+				{
+					ordinal: 0,
+					cid: "checkpoint-cid",
+					bytes: stagedBytes,
+					digest: digest(stagedBytes),
+				},
+			],
+		});
+		const transactionOne = await transactionFrames(storage, transactionId, 1n, [
+			NativeDurabilityPhase.DurablePrepared,
+			NativeDurabilityPhase.NativeApplied,
+			NativeDurabilityPhase.Published,
+			NativeDurabilityPhase.Committed,
+			NativeDurabilityPhase.Clean,
+		]);
+		await storage.appendJournalAndSync(appendRequest(transactionOne));
+
+		const checkpointBytesOne = new Uint8Array([0xc0, 0xff, 0x01]);
+		const retainedOne = {
+			txSequence: 1n,
+			transactionId,
+			phase: NativeDurabilityPhase.Clean,
+			operationKind: NativeDurabilityOperationKind.Append,
+			planDigest: transactionOne.planDigest,
+		};
+		const coverage = {
+			transactionId,
+			txSequence: 1n,
+			coveredThroughLsn: 5n,
+			stagingManifestDigest: stageReceipt.manifestDigest,
+		};
+		const checkpointRequestOne: NativeDurabilityCheckpointRequest = {
+			scope: { transactionId, txSequence: 1n, recordLsn: 5n },
+			checkpointLsn: 5n,
+			txSequenceHighwater: 1n,
+			bytes: checkpointBytesOne,
+			digest: digest(checkpointBytesOne),
+			stagingCoverage: [coverage],
+			retainedTransactions: [retainedOne],
+		};
+
+		const nonCleanError = await rejectedWith(
+			storage.writeCheckpointAndSync({
+				...checkpointRequestOne,
+				retainedTransactions: [],
+			}),
+		);
+		expect(nonCleanError).to.be.instanceOf(TypeError);
+		const generationOne =
+			await storage.writeCheckpointAndSync(checkpointRequestOne);
+		expect(generationOne.generation).to.equal(1n);
+		expect(
+			(await storage.writeCheckpointAndSync(checkpointRequestOne)).generation,
+		).to.equal(1n);
+		const sameScopeConflict = await rejectedWith(
+			storage.writeCheckpointAndSync({
+				...checkpointRequestOne,
+				bytes: new Uint8Array([9]),
+				digest: digest(new Uint8Array([9])),
+			}),
+		);
+		expect(sameScopeConflict).to.be.instanceOf(
+			NativeDurabilityStorageCorruptionError,
+		);
+
+		const transactionTwo = await transactionFrames(
+			storage,
+			"checkpoint-tx-2",
+			2n,
+			[
+				NativeDurabilityPhase.DurablePrepared,
+				NativeDurabilityPhase.NativeApplied,
+				NativeDurabilityPhase.Published,
+				NativeDurabilityPhase.Committed,
+				NativeDurabilityPhase.Clean,
+			],
+			6n,
+		);
+		await storage.appendJournalAndSync(
+			appendRequest(transactionTwo, (await storage.readJournal()).byteLength),
+		);
+		const retainedTwo = {
+			txSequence: 2n,
+			transactionId: "checkpoint-tx-2",
+			phase: NativeDurabilityPhase.Clean,
+			operationKind: NativeDurabilityOperationKind.Append,
+			planDigest: transactionTwo.planDigest,
+		};
+		const checkpointBytesTwo = new Uint8Array([0xc0, 0xff, 0x02]);
+		const checkpointRequestTwo: NativeDurabilityCheckpointRequest = {
+			scope: {
+				transactionId: "checkpoint-tx-2",
+				txSequence: 2n,
+				recordLsn: 10n,
+			},
+			checkpointLsn: 10n,
+			txSequenceHighwater: 2n,
+			bytes: checkpointBytesTwo,
+			digest: digest(checkpointBytesTwo),
+			stagingCoverage: [coverage],
+			retainedTransactions: [retainedOne, retainedTwo],
+		};
+		const checkpointDirectory = durabilityPath(directory, CHECKPOINTS);
+		const requestDigestOne = digest(
+			encodeNativeDurabilityCanonical(checkpointRequestOne),
+		);
+		const requestDigestTwo = digest(
+			encodeNativeDurabilityCanonical(checkpointRequestTwo),
+		);
+		const checkpointFence = storage.fence;
+		await closeStorage(storage);
+
+		await writeFileAndSync(
+			join(checkpointDirectory, "generation-highwater.json"),
+			encodeManifestEnvelope({
+				version: 1,
+				generation: "2",
+				pending: {
+					generation: "2",
+					requestDigest: Buffer.from(requestDigestTwo).toString("hex"),
+					transactionId: "checkpoint-tx-2",
+					txSequence: "2",
+				},
+				completed: {
+					generation: "1",
+					requestDigest: Buffer.from(requestDigestOne).toString("hex"),
+					transactionId,
+					txSequence: "1",
+				},
+			}),
+		);
+		await writeFileAndSync(
+			join(checkpointDirectory, "checkpoint-2.bin"),
+			checkpointBytesTwo,
+		);
+		await writeFileAndSync(
+			join(checkpointDirectory, "manifest-a.json"),
+			encodeManifestEnvelope({
+				version: 1,
+				programId: Buffer.from(PROGRAM_ID).toString("hex"),
+				generation: "2",
+				checkpointLsn: "10",
+				txSequenceHighwater: "2",
+				file: "checkpoint-2.bin",
+				byteLength: checkpointBytesTwo.byteLength,
+				digest: Buffer.from(digest(checkpointBytesTwo)).toString("hex"),
+				originFence: {
+					epoch: checkpointFence.epoch.toString(),
+					ownerId: checkpointFence.ownerId,
+					domainId: checkpointFence.domainId,
+				},
+				stagingCoverage: [
+					{
+						transactionId,
+						txSequence: "1",
+						coveredThroughLsn: "5",
+						stagingManifestDigest: Buffer.from(
+							coverage.stagingManifestDigest,
+						).toString("hex"),
+					},
+				],
+				retainedTransactions: [retainedOne, retainedTwo].map((retained) => ({
+					txSequence: retained.txSequence.toString(),
+					transactionId: retained.transactionId,
+					phase: retained.phase,
+					operationKind: retained.operationKind,
+					planDigest: Buffer.from(retained.planDigest).toString("hex"),
+				})),
+			}),
+		);
+		await rm(
+			join(transactionDirectory(directory, transactionId), "manifest.json"),
+		);
+		await syncDirectoryPath(transactionDirectory(directory, transactionId));
+
+		storage = await openStorage(directory);
+		expect(
+			await pathExists(transactionDirectory(directory, transactionId)),
+		).to.equal(false);
+		expect(
+			(await storage.writeCheckpointAndSync(checkpointRequestTwo)).generation,
+		).to.equal(2n);
+
+		const transactionThree = await transactionFrames(
+			storage,
+			"checkpoint-tx-3",
+			3n,
+			[
+				NativeDurabilityPhase.DurablePrepared,
+				NativeDurabilityPhase.NativeApplied,
+				NativeDurabilityPhase.Published,
+				NativeDurabilityPhase.Committed,
+				NativeDurabilityPhase.Clean,
+			],
+			11n,
+		);
+		await storage.appendJournalAndSync(
+			appendRequest(transactionThree, (await storage.readJournal()).byteLength),
+		);
+		const retainedThree = {
+			txSequence: 3n,
+			transactionId: "checkpoint-tx-3",
+			phase: NativeDurabilityPhase.Clean,
+			operationKind: NativeDurabilityOperationKind.Append,
+			planDigest: transactionThree.planDigest,
+		};
+		const checkpointBytesThree = new Uint8Array([0xc0, 0xff, 0x03]);
+		const generationThree = await storage.writeCheckpointAndSync({
+			scope: {
+				transactionId: "checkpoint-tx-3",
+				txSequence: 3n,
+				recordLsn: 15n,
+			},
+			checkpointLsn: 15n,
+			txSequenceHighwater: 3n,
+			bytes: checkpointBytesThree,
+			digest: digest(checkpointBytesThree),
+			stagingCoverage: [],
+			retainedTransactions: [retainedOne, retainedTwo, retainedThree],
+		});
+		expect(generationThree.generation).to.equal(3n);
+
+		for (const generation of [3n, 2n, 0n]) {
+			const error = await rejectedWith(
+				storage.deleteAndSync({
+					scope: {
+						transactionId: "checkpoint-tx-3",
+						txSequence: 3n,
+						recordLsn: 15n,
+					},
+					targets: [{ kind: "checkpoint", generation }],
+				}),
+			);
+			expect(error).to.be.instanceOf(NativeDurabilityStorageCorruptionError);
+		}
+		await storage.deleteAndSync({
+			scope: {
+				transactionId: "checkpoint-tx-3",
+				txSequence: 3n,
+				recordLsn: 15n,
+			},
+			targets: [{ kind: "checkpoint", generation: 1n }],
+		});
+		await storage.deleteAndSync({
+			scope: {
+				transactionId: "checkpoint-tx-3",
+				txSequence: 3n,
+				recordLsn: 15n,
+			},
+			targets: [{ kind: "staging", transactionId }],
+		});
+
+		const stats = await storage.stats();
+		expect(stats.strictBarrierCount).to.equal(5n);
+		expect(stats.strictDeleteCount).to.equal(2n);
+		expect(stats.stagingTransactions).to.equal(0);
+		expect(stats.checkpointGenerations).to.equal(3);
+		expect(stats.checkpointBytes).to.equal(
+			checkpointBytesTwo.byteLength + checkpointBytesThree.byteLength,
+		);
+
+		await closeStorage(storage);
+		const reopened = await openStorage(directory);
+		const latest = await reopened.readLatestCheckpoint();
+		expect(latest?.generation).to.equal(3n);
+		expect(latest?.bytes).to.deep.equal(checkpointBytesThree);
+		expect(await reopened.listStagingTransactionIds()).to.deep.equal([]);
+	});
+
+	it("abandons an unselected pending checkpoint without reusing its generation", async () => {
+		const directory = await temporaryDirectory();
+		let storage = await openStorage(directory);
+		const phases = [
+			NativeDurabilityPhase.DurablePrepared,
+			NativeDurabilityPhase.NativeApplied,
+			NativeDurabilityPhase.Published,
+			NativeDurabilityPhase.Committed,
+			NativeDurabilityPhase.Clean,
+		];
+		const transactionOne = await transactionFrames(
+			storage,
+			"pending-tx-1",
+			1n,
+			phases,
+		);
+		await storage.appendJournalAndSync(appendRequest(transactionOne));
+		const retainedOne = {
+			txSequence: 1n,
+			transactionId: "pending-tx-1",
+			phase: NativeDurabilityPhase.Clean,
+			operationKind: NativeDurabilityOperationKind.Append,
+			planDigest: transactionOne.planDigest,
+		};
+		const bytesOne = new Uint8Array([1]);
+		const requestOne: NativeDurabilityCheckpointRequest = {
+			scope: { transactionId: "pending-tx-1", txSequence: 1n, recordLsn: 5n },
+			checkpointLsn: 5n,
+			txSequenceHighwater: 1n,
+			bytes: bytesOne,
+			digest: digest(bytesOne),
+			stagingCoverage: [],
+			retainedTransactions: [retainedOne],
+		};
+		expect(
+			(await storage.writeCheckpointAndSync(requestOne)).generation,
+		).to.equal(1n);
+
+		const transactionTwo = await transactionFrames(
+			storage,
+			"pending-tx-2",
+			2n,
+			phases,
+			6n,
+		);
+		await storage.appendJournalAndSync(
+			appendRequest(transactionTwo, (await storage.readJournal()).byteLength),
+		);
+		const retainedTwo = {
+			txSequence: 2n,
+			transactionId: "pending-tx-2",
+			phase: NativeDurabilityPhase.Clean,
+			operationKind: NativeDurabilityOperationKind.Append,
+			planDigest: transactionTwo.planDigest,
+		};
+		const bytesTwo = new Uint8Array([2]);
+		const requestTwo: NativeDurabilityCheckpointRequest = {
+			scope: { transactionId: "pending-tx-2", txSequence: 2n, recordLsn: 10n },
+			checkpointLsn: 10n,
+			txSequenceHighwater: 2n,
+			bytes: bytesTwo,
+			digest: digest(bytesTwo),
+			stagingCoverage: [],
+			retainedTransactions: [retainedOne, retainedTwo],
+		};
+		await closeStorage(storage);
+
+		const checkpointDirectory = durabilityPath(directory, CHECKPOINTS);
+		await writeFileAndSync(
+			join(checkpointDirectory, "generation-highwater.json"),
+			encodeManifestEnvelope({
+				version: 1,
+				generation: "2",
+				pending: {
+					generation: "2",
+					requestDigest: Buffer.from(
+						digest(encodeNativeDurabilityCanonical(requestTwo)),
+					).toString("hex"),
+					transactionId: "pending-tx-2",
+					txSequence: "2",
+				},
+				completed: {
+					generation: "1",
+					requestDigest: Buffer.from(
+						digest(encodeNativeDurabilityCanonical(requestOne)),
+					).toString("hex"),
+					transactionId: "pending-tx-1",
+					txSequence: "1",
+				},
+			}),
+		);
+		const interruptedTemporary = join(
+			checkpointDirectory,
+			"checkpoint-2.bin.tmp-interrupted",
+		);
+		await writeFileAndSync(interruptedTemporary, new Uint8Array([2, 2]));
+
+		storage = await openStorage(directory);
+		expect(await pathExists(interruptedTemporary)).to.equal(false);
+		expect(
+			await pathExists(join(checkpointDirectory, "checkpoint-2.bin")),
+		).to.equal(false);
+		expect((await storage.readLatestCheckpoint())?.generation).to.equal(1n);
+		const recovered = await storage.writeCheckpointAndSync(requestTwo);
+		expect(recovered.generation).to.equal(4n);
+		expect(recovered.manifestSlot).to.equal("a");
+	});
+
+	it("fails closed when an A/B manifest is corrupt or the completed active slot is missing", async () => {
+		const directory = await temporaryDirectory();
+		const storage = await openStorage(directory);
+		const transaction = await transactionFrames(
+			storage,
+			"manifest-corruption",
+			1n,
+			[
+				NativeDurabilityPhase.DurablePrepared,
+				NativeDurabilityPhase.NativeApplied,
+				NativeDurabilityPhase.Published,
+				NativeDurabilityPhase.Committed,
+				NativeDurabilityPhase.Clean,
+			],
+		);
+		await storage.appendJournalAndSync(appendRequest(transaction));
+		const checkpointBytes = new Uint8Array([7]);
+		await storage.writeCheckpointAndSync({
+			scope: {
+				transactionId: "manifest-corruption",
+				txSequence: 1n,
+				recordLsn: 5n,
+			},
+			checkpointLsn: 5n,
+			txSequenceHighwater: 1n,
+			bytes: checkpointBytes,
+			digest: digest(checkpointBytes),
+			stagingCoverage: [],
+			retainedTransactions: [
+				{
+					txSequence: 1n,
+					transactionId: "manifest-corruption",
+					phase: NativeDurabilityPhase.Clean,
+					operationKind: NativeDurabilityOperationKind.Append,
+					planDigest: transaction.planDigest,
+				},
+			],
+		});
+		await closeStorage(storage);
+		const manifestA = durabilityPath(directory, CHECKPOINTS, "manifest-a.json");
+		const originalManifestA = new Uint8Array(await readFile(manifestA));
+		const corrupt = new Uint8Array(originalManifestA);
+		corrupt[corrupt.byteLength - 2] ^= 1;
+		await writeFileAndSync(manifestA, corrupt);
+
+		const error = await rejectedWith(openStorage(directory));
+		expect(error).to.be.instanceOf(NativeDurabilityStorageCorruptionError);
+
+		await writeFileAndSync(manifestA, originalManifestA);
+		await rm(durabilityPath(directory, CHECKPOINTS, "manifest-b.json"), {
+			force: true,
+		});
+		await syncDirectoryPath(durabilityPath(directory, CHECKPOINTS));
+		const missingActiveError = await rejectedWith(openStorage(directory));
+		expect(missingActiveError).to.be.instanceOf(
+			NativeDurabilityStorageCorruptionError,
+		);
+	});
+
+	it("drains admitted snapshots on close and rejects operations admitted afterward", async () => {
+		const directory = await temporaryDirectory();
+		const storage = await openStorage(directory);
+		const original = new Uint8Array(2 * 1024 * 1024).fill(0x5a);
+		const expected = new Uint8Array(original);
+		const request: NativeDurabilityStageRequest = {
+			scope: { transactionId: "closing-tx", txSequence: 1n, recordLsn: 1n },
+			blocks: [
+				{
+					ordinal: 0,
+					cid: "closing-cid",
+					bytes: original,
+					digest: digest(original),
+				},
+			],
+		};
+
+		const admitted = storage.stageAndSync(request);
+		request.blocks[0]!.bytes.fill(0);
+		request.blocks[0]!.digest.fill(0);
+		const closing = storage.close();
+		expect(storage.close()).to.equal(closing);
+		const lateError = await rejectedWith(storage.stats());
+		expect(lateError).to.be.instanceOf(NativeDurabilityStorageClosedError);
+		const receipt = await admitted;
+		await closing;
+		storages.delete(storage);
+		expect(receipt.transactionId).to.equal("closing-tx");
+		expect(
+			new Uint8Array(
+				await readFile(
+					join(
+						transactionDirectory(directory, "closing-tx"),
+						"000000000000.block",
+					),
+				),
+			),
+		).to.deep.equal(expected);
+
+		const reopened = await openStorage(directory);
+		const durable = await reopened.readStagedBlock("closing-tx", 0);
+		expect(durable).to.equal(undefined);
+		expect(await reopened.listStagingTransactionIds()).to.deep.equal([]);
+	});
+});

--- a/packages/utils/native-backbone/test/transaction-persistence.spec.ts
+++ b/packages/utils/native-backbone/test/transaction-persistence.spec.ts
@@ -1,0 +1,480 @@
+import { expect } from "chai";
+import {
+	type NativeDurabilityCheckpointTransactionState,
+	NativeDurabilityOperationKind,
+	NativeDurabilityPhase,
+} from "../src/durability/codec.js";
+import type { NativeDurabilityLease } from "../src/durability/lease.js";
+import { createMemoryNativeDurabilityStorage } from "../src/durability/memory-storage.js";
+import {
+	type NativeDurabilityCheckpointRequest,
+	NativeDurabilityIncompleteTailMismatchError,
+	type NativeDurabilityJournalClassification,
+	type NativeDurabilityJournalClassifier,
+	type NativeDurabilityOperationScope,
+	type NativeDurabilityStagingCoverage,
+	NativeDurabilityStorageClosedError,
+	copyNativeDurabilityBytes,
+	sha256NativeDurability,
+} from "../src/durability/storage.js";
+
+const bytes = (...values: number[]): Uint8Array => new Uint8Array(values);
+
+const concat = (...chunks: Uint8Array[]): Uint8Array => {
+	const result = new Uint8Array(
+		chunks.reduce((length, chunk) => length + chunk.byteLength, 0),
+	);
+	let offset = 0;
+	for (const chunk of chunks) {
+		result.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return result;
+};
+
+const rejected = async (promise: Promise<unknown>): Promise<unknown> => {
+	try {
+		await promise;
+		expect.fail("Expected promise to reject");
+	} catch (error) {
+		return error;
+	}
+};
+
+class TestLease implements NativeDurabilityLease {
+	readonly fence = Object.freeze({
+		epoch: 1n,
+		ownerId: "memory-writer",
+		domainId: "memory-domain",
+	});
+
+	private held = true;
+	private nextGate?: {
+		entered: () => void;
+		wait: Promise<void>;
+	};
+
+	blockNextOperation(): { entered: Promise<void>; release: () => void } {
+		let markEntered!: () => void;
+		let release!: () => void;
+		const entered = new Promise<void>((resolve) => {
+			markEntered = resolve;
+		});
+		const wait = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		this.nextGate = { entered: markEntered, wait };
+		return { entered, release };
+	}
+
+	async assertHeld(): Promise<void> {
+		if (!this.held) throw new Error("lease closed");
+	}
+
+	async runWhileHeld<T>(operation: () => Promise<T>): Promise<T> {
+		await this.assertHeld();
+		const gate = this.nextGate;
+		this.nextGate = undefined;
+		if (gate) {
+			gate.entered();
+			await gate.wait;
+		}
+		return operation();
+	}
+
+	async close(): Promise<void> {
+		this.held = false;
+	}
+}
+
+const completeClassifier: NativeDurabilityJournalClassifier = {
+	classify: (journal) => ({
+		kind: "complete",
+		validLength: journal.byteLength,
+		lastRecordLsn: 0n,
+	}),
+};
+
+const scope = (
+	transactionId: string,
+	txSequence: bigint,
+	recordLsn: bigint,
+): NativeDurabilityOperationScope => ({ transactionId, txSequence, recordLsn });
+
+const stage = async (
+	storage: ReturnType<typeof createMemoryNativeDurabilityStorage>,
+	transactionId: string,
+	txSequence: bigint,
+	recordLsn: bigint,
+	value: number,
+) => {
+	const block = bytes(value, value + 1);
+	return storage.stageAndSync({
+		scope: scope(transactionId, txSequence, recordLsn),
+		blocks: [
+			{
+				ordinal: 0,
+				cid: `cid-${transactionId}`,
+				bytes: block,
+				digest: await sha256NativeDurability(block),
+			},
+		],
+	});
+};
+
+const checkpointRequest = async (options: {
+	transactionId: string;
+	txSequence: bigint;
+	recordLsn: bigint;
+	checkpointLsn: bigint;
+	txSequenceHighwater: bigint;
+	value: number;
+	stagingCoverage?: NativeDurabilityStagingCoverage[];
+	retainedTransactions?: NativeDurabilityCheckpointTransactionState[];
+}): Promise<NativeDurabilityCheckpointRequest> => {
+	const checkpointBytes = bytes(options.value, options.value + 1);
+	return {
+		scope: scope(options.transactionId, options.txSequence, options.recordLsn),
+		checkpointLsn: options.checkpointLsn,
+		txSequenceHighwater: options.txSequenceHighwater,
+		bytes: checkpointBytes,
+		digest: await sha256NativeDurability(checkpointBytes),
+		stagingCoverage: options.stagingCoverage ?? [],
+		retainedTransactions: options.retainedTransactions ?? [],
+	};
+};
+
+const retainedClean = (
+	transactionId: string,
+	txSequence: bigint,
+	value: number,
+): NativeDurabilityCheckpointTransactionState => ({
+	txSequence,
+	transactionId,
+	phase: NativeDurabilityPhase.Clean,
+	operationKind: NativeDurabilityOperationKind.Append,
+	planDigest: new Uint8Array(32).fill(value),
+});
+
+describe("native durability memory transaction storage", () => {
+	it("snapshots and deeply clones checkpoint highwaters and retained transactions", async () => {
+		const storage = createMemoryNativeDurabilityStorage(
+			new TestLease(),
+			completeClassifier,
+		);
+		const staged = await stage(storage, "tx-1", 1n, 1n, 10);
+		const coverageDigest = copyNativeDurabilityBytes(staged.manifestDigest);
+		const retainedPlanDigest = new Uint8Array(32).fill(7);
+		const request = await checkpointRequest({
+			transactionId: "tx-1",
+			txSequence: 1n,
+			recordLsn: 1n,
+			checkpointLsn: 5n,
+			txSequenceHighwater: 3n,
+			value: 21,
+			stagingCoverage: [
+				{
+					transactionId: "tx-1",
+					txSequence: 1n,
+					coveredThroughLsn: 5n,
+					stagingManifestDigest: coverageDigest,
+				},
+			],
+			retainedTransactions: [
+				{
+					txSequence: 1n,
+					transactionId: "tx-1",
+					phase: NativeDurabilityPhase.Clean,
+					operationKind: NativeDurabilityOperationKind.Append,
+					planDigest: retainedPlanDigest,
+				},
+			],
+		});
+		const originalBytes = copyNativeDurabilityBytes(request.bytes);
+		const originalDigest = copyNativeDurabilityBytes(request.digest);
+		const originalCoverageDigest = copyNativeDurabilityBytes(coverageDigest);
+		const originalPlanDigest = copyNativeDurabilityBytes(retainedPlanDigest);
+
+		const writing = storage.writeCheckpointAndSync(request);
+		request.bytes.fill(99);
+		request.digest.fill(98);
+		coverageDigest.fill(97);
+		retainedPlanDigest.fill(96);
+		const receipt = await writing;
+
+		expect(receipt.checkpointDigest).to.deep.equal(originalDigest);
+		const first = await storage.readLatestCheckpoint();
+		expect(first?.txSequenceHighwater).to.equal(3n);
+		expect(first?.bytes).to.deep.equal(originalBytes);
+		expect(first?.digest).to.deep.equal(originalDigest);
+		expect(first?.stagingCoverage[0]?.stagingManifestDigest).to.deep.equal(
+			originalCoverageDigest,
+		);
+		expect(first?.retainedTransactions[0]?.planDigest).to.deep.equal(
+			originalPlanDigest,
+		);
+
+		first!.bytes.fill(1);
+		first!.digest.fill(2);
+		first!.stagingCoverage[0]!.stagingManifestDigest.fill(3);
+		first!.retainedTransactions[0]!.planDigest.fill(4);
+		receipt.checkpointDigest.fill(5);
+		const second = await storage.readLatestCheckpoint();
+		expect(second?.bytes).to.deep.equal(originalBytes);
+		expect(second?.digest).to.deep.equal(originalDigest);
+		expect(second?.stagingCoverage[0]?.stagingManifestDigest).to.deep.equal(
+			originalCoverageDigest,
+		);
+		expect(second?.retainedTransactions[0]?.planDigest).to.deep.equal(
+			originalPlanDigest,
+		);
+	});
+
+	it("requires exact active-checkpoint coverage and validates a delete batch before mutation", async () => {
+		const storage = createMemoryNativeDurabilityStorage(
+			new TestLease(),
+			completeClassifier,
+		);
+		const tx1 = await stage(storage, "tx-1", 1n, 1n, 1);
+		await stage(storage, "tx-2", 2n, 2n, 2);
+		const invalidCheckpoint = await rejected(
+			storage.writeCheckpointAndSync(
+				await checkpointRequest({
+					transactionId: "tx-2",
+					txSequence: 2n,
+					recordLsn: 2n,
+					checkpointLsn: 3n,
+					txSequenceHighwater: 2n,
+					value: 29,
+					stagingCoverage: [
+						{
+							transactionId: "tx-1",
+							txSequence: 1n,
+							coveredThroughLsn: 3n,
+							stagingManifestDigest: tx1.manifestDigest,
+						},
+					],
+				}),
+			),
+		);
+		expect(String(invalidCheckpoint)).to.contain("exact retained CLEAN");
+		expect((await storage.stats()).checkpointGenerations).to.equal(0);
+		const generation1 = await storage.writeCheckpointAndSync(
+			await checkpointRequest({
+				transactionId: "tx-2",
+				txSequence: 2n,
+				recordLsn: 2n,
+				checkpointLsn: 3n,
+				txSequenceHighwater: 2n,
+				value: 30,
+				stagingCoverage: [
+					{
+						transactionId: "tx-1",
+						txSequence: 1n,
+						coveredThroughLsn: 3n,
+						stagingManifestDigest: tx1.manifestDigest,
+					},
+				],
+				retainedTransactions: [retainedClean("tx-1", 1n, 1)],
+			}),
+		);
+
+		const uncovered = await rejected(
+			storage.deleteAndSync({
+				scope: scope("tx-2", 2n, 4n),
+				targets: [{ kind: "staging", transactionId: "tx-2" }],
+			}),
+		);
+		expect(String(uncovered)).to.contain("does not cover");
+		expect(await storage.readStagingManifest("tx-2")).to.not.equal(undefined);
+
+		await storage.deleteAndSync({
+			scope: scope("tx-1", 1n, 4n),
+			targets: [{ kind: "staging", transactionId: "tx-1" }],
+		});
+		expect(await storage.readStagingManifest("tx-1")).to.equal(undefined);
+
+		const generation2 = await storage.writeCheckpointAndSync(
+			await checkpointRequest({
+				transactionId: "tx-2",
+				txSequence: 2n,
+				recordLsn: 4n,
+				checkpointLsn: 4n,
+				txSequenceHighwater: 2n,
+				value: 31,
+			}),
+		);
+		const generation3 = await storage.writeCheckpointAndSync(
+			await checkpointRequest({
+				transactionId: "tx-2",
+				txSequence: 2n,
+				recordLsn: 5n,
+				checkpointLsn: 5n,
+				txSequenceHighwater: 2n,
+				value: 32,
+			}),
+		);
+		for (const protectedGeneration of [
+			generation2.generation,
+			generation3.generation,
+		]) {
+			const error = await rejected(
+				storage.deleteAndSync({
+					scope: scope("tx-2", 2n, 6n),
+					targets: [{ kind: "checkpoint", generation: protectedGeneration }],
+				}),
+			);
+			expect(String(error)).to.contain("active or previous");
+		}
+		await storage.deleteAndSync({
+			scope: scope("tx-2", 2n, 6n),
+			targets: [{ kind: "checkpoint", generation: generation1.generation }],
+		});
+
+		const tx3 = await stage(storage, "tx-3", 3n, 6n, 3);
+		const generation4 = await storage.writeCheckpointAndSync(
+			await checkpointRequest({
+				transactionId: "tx-3",
+				txSequence: 3n,
+				recordLsn: 6n,
+				checkpointLsn: 7n,
+				txSequenceHighwater: 3n,
+				value: 33,
+				stagingCoverage: [
+					{
+						transactionId: "tx-3",
+						txSequence: 3n,
+						coveredThroughLsn: 7n,
+						stagingManifestDigest: tx3.manifestDigest,
+					},
+				],
+				retainedTransactions: [retainedClean("tx-3", 3n, 3)],
+			}),
+		);
+		await rejected(
+			storage.deleteAndSync({
+				scope: scope("tx-3", 3n, 8n),
+				targets: [
+					{ kind: "staging", transactionId: "tx-3" },
+					{ kind: "checkpoint", generation: generation4.generation },
+				],
+			}),
+		);
+		expect(await storage.readStagingManifest("tx-3")).to.not.equal(undefined);
+	});
+
+	it("serializes admitted operations and drains them before closing", async () => {
+		const lease = new TestLease();
+		const storage = createMemoryNativeDurabilityStorage(
+			lease,
+			completeClassifier,
+		);
+		const firstBytes = bytes(1, 2);
+		const secondBytes = bytes(3, 4, 5);
+		const gate = lease.blockNextOperation();
+		const first = storage.appendJournalAndSync({
+			transactionId: "tx-1",
+			txSequence: 1n,
+			firstRecordLsn: 1n,
+			lastRecordLsn: 1n,
+			expectedOffset: 0,
+			frames: firstBytes,
+			framesDigest: await sha256NativeDurability(firstBytes),
+		});
+		const second = storage.appendJournalAndSync({
+			transactionId: "tx-2",
+			txSequence: 2n,
+			firstRecordLsn: 2n,
+			lastRecordLsn: 2n,
+			expectedOffset: firstBytes.byteLength,
+			frames: secondBytes,
+			framesDigest: await sha256NativeDurability(secondBytes),
+		});
+		const queuedRead = storage.readJournal();
+		let closeResolved = false;
+		const closing = storage.close().then(() => {
+			closeResolved = true;
+		});
+
+		await gate.entered;
+		expect(closeResolved).to.equal(false);
+		const lateError = await rejected(storage.readJournal());
+		expect(lateError).to.be.instanceOf(NativeDurabilityStorageClosedError);
+		gate.release();
+		const [, , journal] = await Promise.all([
+			first,
+			second,
+			queuedRead,
+			closing,
+		]);
+		expect(journal).to.deep.equal(concat(firstBytes, secondBytes));
+		expect(closeResolved).to.equal(true);
+	});
+
+	it("accepts truncation only from a defensively validated classifier result", async () => {
+		let classify = (
+			_journal: Uint8Array,
+		): NativeDurabilityJournalClassification => ({
+			kind: "incomplete-tail",
+			validLength: 1,
+			lastRecordLsn: "1" as unknown as bigint,
+			reason: "short-body",
+		});
+		const classifier: NativeDurabilityJournalClassifier = {
+			classify: (journal) => classify(journal),
+		};
+		const storage = createMemoryNativeDurabilityStorage(
+			new TestLease(),
+			classifier,
+		);
+		const original = bytes(1, 2, 3);
+		await storage.appendJournalAndSync({
+			transactionId: "tx-1",
+			txSequence: 1n,
+			firstRecordLsn: 1n,
+			lastRecordLsn: 1n,
+			expectedOffset: 0,
+			frames: original,
+			framesDigest: await sha256NativeDurability(original),
+		});
+
+		for (const invalid of [
+			() => classify,
+			() => (_journal: Uint8Array) =>
+				({
+					kind: "incomplete-tail",
+					validLength: 1,
+					lastRecordLsn: 1n,
+					reason: "checksum-corruption",
+				}) as unknown as NativeDurabilityJournalClassification,
+		]) {
+			classify = invalid() as typeof classify;
+			const error = await rejected(
+				storage.reconcileIncompleteJournalTailAndSync({
+					transactionId: "tx-1",
+					txSequence: 1n,
+				}),
+			);
+			expect(error).to.be.instanceOf(
+				NativeDurabilityIncompleteTailMismatchError,
+			);
+			expect(await storage.readJournal()).to.deep.equal(original);
+		}
+
+		classify = (journal) => {
+			journal[0] = 99;
+			return {
+				kind: "incomplete-tail",
+				validLength: 2,
+				lastRecordLsn: 1n,
+				reason: "short-body",
+			};
+		};
+		const receipt = await storage.reconcileIncompleteJournalTailAndSync({
+			transactionId: "tx-1",
+			txSequence: 1n,
+		});
+		expect(receipt.validLength).to.equal(2);
+		expect(await storage.readJournal()).to.deep.equal(bytes(1, 2));
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2844,6 +2844,9 @@ importers:
       '@peerbit/blocks-interface':
         specifier: workspace:*
         version: link:../../transport/blocks-interface
+      classic-level:
+        specifier: ^3.0.0
+        version: 3.0.0
 
   packages/utils/rateless-iblt: {}
 


### PR DESCRIPTION
## Summary

- add a versioned Rust/Wasm journal codec with strict frame and transaction validation
- add a factory-owned Node fsync backend with an OS-held directory lease, fencing epochs, staging, checkpoints, journal recovery, deletion, and stats
- add the non-crash-safe memory reference plus adversarial persistence, crash, retry, corruption, and authority tests

## Scope

This is phase one of the local on-disk recovery protocol described by #1037. It is not a peer-to-peer network protocol. The primitives remain intentionally unwired, so existing append and open behavior is unchanged. OPFS and journal compaction remain deferred to later conformance-gated phases.

This PR is stacked on #1037 and targets its design branch.

## Validation

- pnpm run build — full workspace passed
- pnpm --filter @peerbit/native-backbone test — 58 Rust and 88 Node tests passed
- pnpm --filter @peerbit/native-backbone lint — passed
- strict DOM-only declaration consumer without Node types — passed
- browser root import and tree-shaken bundle checks — passed
- pnpm run test — the changed package passed; the workspace run later failed in unchanged @peerbit/indexer-sqlite3 browser-test bundling because its statement test imports node:path and node:url