### PR TITLE
perf(native-backbone): defer small durable block snapshots

### DIFF
--- a/.changeset/quiet-wals-close.md
+++ b/.changeset/quiet-wals-close.md
@@ -1,0 +1,6 @@
+---
+"@peerbit/any-store-rust": patch
+"@peerbit/shared-log": patch
+---
+
+Avoid rewriting the complete native durable block snapshot on every program close. Rust-backed sublevels can now defer close-time compaction below an explicit journal threshold while preserving crash-safe WAL recovery, generic store defaults, and immutable cached-sublevel policies.

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -5,6 +5,7 @@ import {
 	serialize,
 	variant,
 } from "@dao-xyz/borsh";
+import type { AnyStore } from "@peerbit/any-store";
 import { AnyBlockStore, RemoteBlocks } from "@peerbit/blocks";
 import { cidifyString } from "@peerbit/blocks-interface";
 import { Cache } from "@peerbit/cache";
@@ -381,6 +382,48 @@ const joinNativeCoordinateDirectory = (
 	nodeDirectory: string,
 	fsSafeLogId: string,
 ): string => `${nodeDirectory.replace(/[/\\]+$/, "")}/coordinates/${fsSafeLogId}`;
+
+// Native durable block mirrors are content-addressed and therefore primarily
+// append-only. Rewriting the complete live block set into a RustAnyStore
+// snapshot on every program close is redundant and makes close O(total block
+// bytes). Keep the WAL crash-safe and defer that rewrite on close until the
+// journal reaches this explicit threshold. This does not cap WAL growth during
+// an open session. Stores that do not support per-sublevel options ignore the
+// second argument and retain their existing behavior.
+const NATIVE_DURABLE_BLOCK_COMPACT_ON_CLOSE_MIN_JOURNAL_BYTES =
+	512 * 1024 * 1024;
+
+type DurableBlockSublevelStore = {
+	sublevel(
+		name: string,
+		options?: {
+			compactOnClose?: boolean;
+			compactOnCloseMinJournalBytes?: number;
+		},
+	): MaybePromise<AnyStore>;
+};
+
+const createNativeDurableBlockStore = async (
+	storage: DurableBlockSublevelStore,
+): Promise<AnyBlockStore> =>
+	new AnyBlockStore(
+		await storage.sublevel("blocks", {
+			compactOnClose: false,
+			compactOnCloseMinJournalBytes:
+				NATIVE_DURABLE_BLOCK_COMPACT_ON_CLOSE_MIN_JOURNAL_BYTES,
+		}),
+	);
+
+const createDefaultDurableBlockStore = async (
+	storage: DurableBlockSublevelStore,
+): Promise<AnyBlockStore> =>
+	new AnyBlockStore(
+		await storage.sublevel("blocks", {
+			// State this default explicitly so a cached child created by the native
+			// path cannot silently carry its deferred-close policy into this path.
+			compactOnClose: true,
+		}),
+	);
 
 /** The native backbone's in-wasm-memory block store. */
 type NativeBackboneBlocks = NativePeerbitBackbone["blocks"];
@@ -9081,7 +9124,9 @@ export class SharedLog<
 		let localBlocks: NonNullable<RemoteBlocks["localStore"]>;
 		if (this._nativeBackbone) {
 			if (this.node.directory != null) {
-				const durable = new AnyBlockStore(await storage.sublevel("blocks"));
+				const durable = await createNativeDurableBlockStore(
+					storage as unknown as DurableBlockSublevelStore,
+				);
 				localBlocks = new NativeBackboneWriteThroughBlockStore(
 					this._nativeBackbone.blocks,
 					durable,
@@ -9090,7 +9135,9 @@ export class SharedLog<
 				localBlocks = this._nativeBackbone.blocks;
 			}
 		} else {
-			localBlocks = new AnyBlockStore(await storage.sublevel("blocks"));
+			localBlocks = await createDefaultDurableBlockStore(
+				storage as unknown as DurableBlockSublevelStore,
+			);
 		}
 		this.remoteBlocks = new RemoteBlocks({
 			local: localBlocks,

--- a/packages/programs/data/shared-log/test/durable-native-restart.spec.ts
+++ b/packages/programs/data/shared-log/test/durable-native-restart.spec.ts
@@ -77,6 +77,21 @@ describe("durable native block store restart", function () {
 			log1._nativeBackboneCoordinatePersistence,
 			"session 1 auto-derived coordinate persistence",
 		).to.exist;
+		const durableBlockOptions = log1.remoteBlocks.localStore?.durable?._store
+			?.options as
+			| {
+					compactOnClose?: boolean;
+					compactOnCloseMinJournalBytes?: number;
+			  }
+			| undefined;
+		expect(
+			durableBlockOptions?.compactOnClose,
+			"native durable block sublevel skips redundant close snapshots",
+		).to.equal(false);
+		expect(
+			durableBlockOptions?.compactOnCloseMinJournalBytes,
+			"native durable block WAL retains an explicit close-time compaction threshold",
+		).to.equal(512 * 1024 * 1024);
 
 		for (let index = 0; index < entryCount; index++) {
 			await store1.add(`entry-${index}`, { meta: { next: [] } });

--- a/packages/utils/any-store/rust/src/index.ts
+++ b/packages/utils/any-store/rust/src/index.ts
@@ -37,6 +37,13 @@ type WasmModule = {
 
 export type RustAnyStoreOptions = {
 	compactOnClose?: boolean;
+	/**
+	 * When `compactOnClose` is false, compact during close only if the journal
+	 * has reached at least this many bytes. Append-heavy stores can defer a
+	 * complete live-value rewrite on smaller closes while retaining an explicit
+	 * checkpoint trigger for larger journals.
+	 */
+	compactOnCloseMinJournalBytes?: number;
 	durability?: "normal" | "strict";
 };
 
@@ -92,6 +99,7 @@ export class RustAnyStore implements AnyStore {
 	private queuedMutations = 0;
 	private journalQueue: Promise<unknown> = Promise.resolve();
 	private journalError?: unknown;
+	private journalByteLength = 0;
 	private children = new Map<string, RustAnyStore>();
 	private _status: StoreStatus = "closed";
 
@@ -182,7 +190,7 @@ export class RustAnyStore implements AnyStore {
 				closeError ??= error;
 			}
 		}
-		if (this.native && this.directory && this.options.compactOnClose !== false) {
+		if (this.native && this.directory && this.shouldCompactOnClose()) {
 			try {
 				await this.compact();
 			} catch (error) {
@@ -386,16 +394,88 @@ export class RustAnyStore implements AnyStore {
 		return native.has_many(keys);
 	}
 
-	async sublevel(name: string): Promise<AnyStore> {
+	async sublevel(
+		name: string,
+		options?: RustAnyStoreOptions,
+	): Promise<AnyStore> {
 		let child = this.children.get(name);
 		if (!child) {
-			child = new RustAnyStore(this.directory, [...this.level, name], this.options);
+			child = new RustAnyStore(
+				this.directory,
+				[...this.level, name],
+				this.mergeSublevelOptions(options),
+			);
 			this.children.set(name, child);
+		} else {
+			child.assertCompatibleSublevelOptions(options);
 		}
 		if (this._status === "open") {
 			await child.open();
 		}
 		return child;
+	}
+
+	private mergeSublevelOptions(
+		requested?: RustAnyStoreOptions,
+	): RustAnyStoreOptions {
+		return {
+			compactOnClose:
+				requested?.compactOnClose !== undefined
+					? requested.compactOnClose
+					: this.options.compactOnClose,
+			compactOnCloseMinJournalBytes:
+				requested?.compactOnCloseMinJournalBytes !== undefined
+					? requested.compactOnCloseMinJournalBytes
+					: this.options.compactOnCloseMinJournalBytes,
+			durability:
+				requested?.durability !== undefined
+					? requested.durability
+					: this.options.durability,
+		};
+	}
+
+	private assertCompatibleSublevelOptions(
+		requested?: RustAnyStoreOptions,
+	): void {
+		if (!requested) {
+			return;
+		}
+		this.assertCompatibleSublevelOption(
+			"compactOnClose",
+			requested.compactOnClose,
+			this.options.compactOnClose ?? true,
+		);
+		this.assertCompatibleSublevelOption(
+			"compactOnCloseMinJournalBytes",
+			requested.compactOnCloseMinJournalBytes == null
+				? undefined
+				: Math.max(0, requested.compactOnCloseMinJournalBytes),
+			this.options.compactOnCloseMinJournalBytes == null
+				? undefined
+				: Math.max(0, this.options.compactOnCloseMinJournalBytes),
+		);
+		this.assertCompatibleSublevelOption(
+			"durability",
+			requested.durability,
+			this.options.durability ?? "normal",
+		);
+	}
+
+	private assertCompatibleSublevelOption(
+		name: keyof RustAnyStoreOptions,
+		requested: RustAnyStoreOptions[keyof RustAnyStoreOptions],
+		configured: RustAnyStoreOptions[keyof RustAnyStoreOptions],
+	): void {
+		// An omitted field adds no constraint to an already-cached child.
+		if (requested === undefined || Object.is(requested, configured)) {
+			return;
+		}
+		const path = this.level.join("/");
+		throw new Error(
+			`RustAnyStore sublevel "${path}" already exists with ${name}=${String(
+				configured,
+			)}; requested ${String(requested)}`,
+		);
 	}
 
 	iterator(): {
@@ -463,6 +543,7 @@ export class RustAnyStore implements AnyStore {
 			native.load_snapshot(snapshot);
 		}
 		const journal = await this.persistence.readJournal();
+		this.journalByteLength = journal?.byteLength ?? 0;
 		if (journal && journal.byteLength > 0) {
 			const applied = native.apply_journal(journal);
 			if (applied < journal.byteLength) {
@@ -470,8 +551,21 @@ export class RustAnyStore implements AnyStore {
 				// records are not appended after the unreadable bytes and lost on
 				// the next replay.
 				await this.persistence.writeSnapshot(native.snapshot());
+				this.journalByteLength = 0;
 			}
 		}
+	}
+
+	private shouldCompactOnClose(): boolean {
+		if (this.options.compactOnClose !== false) {
+			return true;
+		}
+		const minJournalBytes = this.options.compactOnCloseMinJournalBytes;
+		return (
+			minJournalBytes != null &&
+			this.journalByteLength > 0 &&
+			this.journalByteLength >= Math.max(0, minJournalBytes)
+		);
 	}
 
 	private async ensureOpen(allowDraining = false): Promise<NativeAnyStore> {
@@ -569,18 +663,21 @@ export class RustAnyStore implements AnyStore {
 			throw new Error("RustAnyStore persistence backend is not open");
 		}
 		await this.persistence.writeSnapshot(journaled.snapshot());
+		this.journalByteLength = 0;
 	}
 
 	private recordJournal(record: Uint8Array): Promise<void> {
+		const recordByteLength = record.byteLength;
 		const write = this.journalQueue
-			.then(() => {
+			.then(async () => {
 				if (!this.persistence) {
 					throw new Error("RustAnyStore persistence backend is not open");
 				}
-				return this.persistence.appendJournal(
+				await this.persistence.appendJournal(
 					record,
 					this.options.durability ?? "normal",
 				);
+				this.journalByteLength += recordByteLength;
 			})
 			.catch((error) => {
 				this.journalError = error;

--- a/packages/utils/any-store/rust/test/index.spec.ts
+++ b/packages/utils/any-store/rust/test/index.spec.ts
@@ -1,6 +1,6 @@
 import { type AnyStore } from "@peerbit/any-store-interface";
 import { expect } from "chai";
-import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import { mkdtemp, readFile, rm, stat, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { createStore } from "../src/index.js";
@@ -170,6 +170,143 @@ describe("@peerbit/any-store-rust", () => {
 		expect(await store.get("a")).to.equal(undefined);
 		expect(await store.get("b")).to.deep.equal(new Uint8Array([2]));
 		await store.close();
+	});
+
+	it("validates immutable options when returning a cached sublevel", async () => {
+		const store = createStore();
+		await store.open();
+		const configured = await store.sublevel("blocks", {
+			compactOnClose: false,
+			compactOnCloseMinJournalBytes: 1024,
+		});
+		expect(await store.sublevel("blocks")).to.equal(configured);
+		expect(
+			await store.sublevel("blocks", {
+				compactOnClose: false,
+				compactOnCloseMinJournalBytes: 1024,
+			}),
+		).to.equal(configured);
+		expect(
+			await store.sublevel("blocks", {
+				compactOnClose: undefined,
+				compactOnCloseMinJournalBytes: undefined,
+			}),
+		).to.equal(configured);
+
+		let conflict: unknown;
+		try {
+			await store.sublevel("blocks", { compactOnClose: true });
+		} catch (error) {
+			conflict = error;
+		}
+		expect(conflict).to.be.instanceOf(Error);
+		expect((conflict as Error).message).to.contain(
+			'sublevel "blocks" already exists with compactOnClose=false; requested true',
+		);
+
+		conflict = undefined;
+		try {
+			await store.sublevel("blocks", {
+				compactOnCloseMinJournalBytes: 2048,
+			});
+		} catch (error) {
+			conflict = error;
+		}
+		expect(conflict).to.be.instanceOf(Error);
+		expect((conflict as Error).message).to.contain(
+			"compactOnCloseMinJournalBytes=1024; requested 2048",
+		);
+
+		const defaultConfigured = await store.sublevel("default-blocks");
+		expect(
+			await store.sublevel("default-blocks", {
+				compactOnClose: true,
+				durability: "normal",
+			}),
+		).to.equal(defaultConfigured);
+		conflict = undefined;
+		try {
+			await store.sublevel("default-blocks", { compactOnClose: false });
+		} catch (error) {
+			conflict = error;
+		}
+		expect(conflict).to.be.instanceOf(Error);
+		expect((conflict as Error).message).to.contain(
+			'sublevel "default-blocks" already exists with compactOnClose=true; requested false',
+		);
+		await store.close();
+	});
+
+	it("defers sublevel close compaction below its journal threshold and recovers a torn tail", async () => {
+		const directory = await tempDirectory();
+		cleanup.push(directory);
+		const sublevelDirectory = join(directory, "sublevels", "blocks");
+		const snapshotPath = join(sublevelDirectory, "store.bin");
+		const journalPath = join(sublevelDirectory, "store.wal");
+		const sublevelOptions = {
+			compactOnClose: false,
+			compactOnCloseMinJournalBytes: 1024,
+		};
+
+		let root = createStore(directory);
+		await root.open();
+		let blocks = await root.sublevel("blocks", sublevelOptions);
+		await blocks.put("a", new Uint8Array([1]));
+		await blocks.put("b", new Uint8Array([2, 3]));
+		await root.close();
+
+		// The generic root still uses its unchanged compact-on-close default, while
+		// the explicitly configured append-heavy child remains journal-backed below
+		// its close-time compaction threshold.
+		expect(await stat(join(directory, "store.bin"))).to.exist;
+		const snapshotExists = await stat(snapshotPath)
+			.then(() => true)
+			.catch(() => false);
+		expect(snapshotExists).to.equal(false);
+		const journal = await readFile(journalPath);
+		expect(journal.byteLength).to.be.greaterThan(0);
+		expect(journal.byteLength).to.be.lessThan(
+			sublevelOptions.compactOnCloseMinJournalBytes,
+		);
+
+		// Tear the second record. Reopen must retain the complete first record,
+		// discard the incomplete tail, and checkpoint before accepting new writes.
+		await writeFile(journalPath, journal.subarray(0, journal.byteLength - 3));
+		root = createStore(directory);
+		await root.open();
+		blocks = await root.sublevel("blocks", sublevelOptions);
+		expect(await blocks.get("a")).to.deep.equal(new Uint8Array([1]));
+		expect(await blocks.get("b")).to.equal(undefined);
+		await blocks.put("c", new Uint8Array([4]));
+		await root.close();
+
+		root = createStore(directory);
+		await root.open();
+		blocks = await root.sublevel("blocks", sublevelOptions);
+		expect(await blocks.get("a")).to.deep.equal(new Uint8Array([1]));
+		expect(await blocks.get("b")).to.equal(undefined);
+		expect(await blocks.get("c")).to.deep.equal(new Uint8Array([4]));
+		await root.close();
+	});
+
+	it("compacts an opted-out sublevel when its close-time journal threshold is reached", async () => {
+		const directory = await tempDirectory();
+		cleanup.push(directory);
+
+		const root = createStore(directory);
+		await root.open();
+		const blocks = await root.sublevel("blocks", {
+			compactOnClose: false,
+			compactOnCloseMinJournalBytes: 1,
+		});
+		await blocks.put("a", new Uint8Array([1]));
+		await root.close();
+
+		const sublevelDirectory = join(directory, "sublevels", "blocks");
+		expect(await stat(join(sublevelDirectory, "store.bin"))).to.exist;
+		expect(
+			(await readFile(join(sublevelDirectory, "store.wal"))).byteLength,
+		).to.equal(0);
 	});
 
 	it("recovers from a torn journal tail and keeps later writes", async () => {


### PR DESCRIPTION
## Summary

- add immutable per-sublevel close-compaction policies to RustAnyStore
- defer full close-time snapshots for native durable block mirrors while their WAL is below the explicit 512 MiB threshold
- preserve generic store defaults, torn-WAL recovery, and default/native policy isolation

## Performance

- isolated 256 MiB writer close: 1286.7 ms -> 128.4 ms (~90% reduction)
- upload/download throughput remained effectively unchanged and restart integrity passed
- isolated reopen was 1.09-1.24 s; this PR does not claim to fix the previously observed 15.1 s long-session tail, which was not reproducible in isolation

## Validation

- any-store Rust tests: 4 passing
- any-store Node tests: 17 passing
- shared-log durable native restart test: passing
- package builds, typechecks, ESLint, and diff checks: passing