### PR TITLE
fix(shared-log): retry timed-out replication announcements

### DIFF
--- a/.changeset/steady-replication-announcements.md
+++ b/.changeset/steady-replication-announcements.md
@@ -1,0 +1,6 @@
+---
+"@peerbit/shared-log": patch
+"@peerbit/time": patch
+---
+
+Retry timed-out replication announcements from an authoritative current-state snapshot while preserving explicit caller errors, adaptive scheduling, and shutdown ordering. Make fixed-interval debouncer shutdown terminal so queued work cannot restart after close.

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -1285,6 +1285,57 @@ const isNotStartedError = (e: Error) => {
 	return false;
 };
 
+/**
+ * Replication announcements are best-effort convergence messages. A detached
+ * fanout shard can time out even though the shared log itself remains open.
+ * Keep retries deliberately limited to concrete TimeoutErrors: abort/close and
+ * unexpected programming/data errors must retain their existing semantics.
+ *
+ * Exact constructor/name checks complement `instanceof` for errors crossing
+ * worker or duplicate-package boundaries in browsers.
+ */
+const isTransientReplicationAnnouncementError = (
+	error: unknown,
+	seen = new Set<unknown>(),
+): boolean => {
+	if (
+		error != null &&
+		(typeof error === "object" || typeof error === "function")
+	) {
+		if (seen.has(error)) {
+			return false;
+		}
+		seen.add(error);
+	}
+
+	if (error instanceof TimeoutError) {
+		return true;
+	}
+
+	const nested = (error as { errors?: unknown })?.errors;
+	if (Array.isArray(nested) && nested.length > 0) {
+		return nested.every((item) =>
+			isTransientReplicationAnnouncementError(item, new Set(seen)),
+		);
+	}
+
+	const cause = (error as { cause?: unknown })?.cause;
+	if (cause != null && isTransientReplicationAnnouncementError(cause, seen)) {
+		return true;
+	}
+
+	const constructorName =
+		typeof (error as { constructor?: { name?: unknown } })?.constructor?.name ===
+		"string"
+			? (error as { constructor: { name: string } }).constructor.name
+			: "";
+	const name =
+		typeof (error as { name?: unknown })?.name === "string"
+			? (error as { name: string }).name
+			: "";
+	return constructorName === "TimeoutError" || name === "TimeoutError";
+};
+
 interface IndexableDomain<R extends "u32" | "u64"> {
 	numbers: Numbers<R>;
 	constructorEntry: new (properties: {
@@ -1559,6 +1610,7 @@ const CHECKED_PRUNE_RETRY_MAX_DELAY_MS = 30_000;
 
 // DONT SET THIS ANY LOWER, because it will make the pid controller unstable as the system responses are not fast enough to updates from the pid controller
 const RECALCULATE_PARTICIPATION_DEBOUNCE_INTERVAL = 1000;
+const REPLICATION_ANNOUNCEMENT_RETRY_INTERVAL = 1000;
 const RECALCULATE_PARTICIPATION_MIN_RELATIVE_CHANGE = 0.01;
 const RECALCULATE_PARTICIPATION_MIN_RELATIVE_CHANGE_WITH_CPU_LIMIT = 0.005;
 const RECALCULATE_PARTICIPATION_MIN_RELATIVE_CHANGE_WITH_MEMORY_LIMIT = 0.001;
@@ -2170,6 +2222,12 @@ export class SharedLog<
 	private rebalanceParticipationDebounced:
 		| ReturnType<typeof debounceFixedInterval>
 		| undefined;
+	private replicationAnnouncementRetryDebounced:
+		| ReturnType<typeof debounceFixedInterval>
+		| undefined;
+	private _replicationAnnouncementRetryPending!: boolean;
+	private _replicationAnnouncementRetryGeneration!: number;
+	private _replicationAnnouncementRetryController!: AbortController;
 
 	// A fn for debouncing the calls for pruning
 	pruneDebouncedFn!: DebouncedAccumulatorMap<{
@@ -2312,6 +2370,9 @@ export class SharedLog<
 		this._replicatorLivenessCursor = 0;
 		this._replicatorLivenessFailures = new Map();
 		this._replicatorLastActivityAt = new Map();
+		this._replicationAnnouncementRetryPending = false;
+		this._replicationAnnouncementRetryGeneration = 0;
+		this._replicationAnnouncementRetryController = new AbortController();
 		this.pendingMaturity = new Map();
 		this._closeController = new AbortController();
 	}
@@ -3573,6 +3634,7 @@ export class SharedLog<
 	private setupRebalanceDebounceFunction(
 		interval = RECALCULATE_PARTICIPATION_DEBOUNCE_INTERVAL,
 	) {
+		this.rebalanceParticipationDebounced?.close();
 		this.rebalanceParticipationDebounced = undefined;
 
 		this.rebalanceParticipationDebounced = debounceFixedInterval(
@@ -3585,7 +3647,168 @@ export class SharedLog<
 				)
 			) */
 			interval, // TODO make this dynamic on the number of replicators
+			{
+				onError: (error) => this.onRebalanceParticipationError(error),
+			},
 		);
+	}
+
+	private queueCurrentReplicationStateAnnouncementRetry(
+		error: unknown,
+	): boolean {
+		if (
+			this.closed ||
+			this._closeController.signal.aborted ||
+			this._replicationAnnouncementRetryController.signal.aborted ||
+			!isTransientReplicationAnnouncementError(error)
+		) {
+			return false;
+		}
+
+		this._replicationAnnouncementRetryPending = true;
+		void this.replicationAnnouncementRetryDebounced?.call();
+		return true;
+	}
+
+	private onRebalanceParticipationError(error: Error): void {
+		if (
+			this.closed ||
+			isNotStartedError(error) ||
+			(isTransientReplicationAnnouncementError(error) &&
+				this._replicationAnnouncementRetryPending)
+		) {
+			return;
+		}
+
+		// Debounced invocations run from an un-awaited timer. Throwing here would
+		// create an unhandled rejection (and a browser pageerror), so surface
+		// unexpected failures through the logger instead.
+		logger.error(error);
+	}
+
+	private setupReplicationAnnouncementRetryFunction(
+		interval = REPLICATION_ANNOUNCEMENT_RETRY_INTERVAL,
+	): void {
+		this.replicationAnnouncementRetryDebounced?.close();
+		this._replicationAnnouncementRetryController?.abort();
+		this._replicationAnnouncementRetryController = new AbortController();
+		this.replicationAnnouncementRetryDebounced = debounceFixedInterval(
+			() => this.retryCurrentReplicationStateAnnouncement(),
+			interval,
+			{
+				leading: false,
+				onError: (error) => {
+					if (
+						this.closed ||
+						this._closeController.signal.aborted ||
+						isNotStartedError(error)
+					) {
+						return;
+					}
+					logger.error(error);
+				},
+			},
+		);
+	}
+
+	private cancelCurrentReplicationStateAnnouncementRetry(): void {
+		this._replicationAnnouncementRetryGeneration += 1;
+		this._replicationAnnouncementRetryPending = false;
+		this._replicationAnnouncementRetryController?.abort();
+		this.replicationAnnouncementRetryDebounced?.close();
+	}
+
+	private async sendReplicationAnnouncement(
+		message:
+			| AllReplicatingSegmentsMessage
+			| AddedReplicationSegmentMessage
+			| StoppedReplicating,
+	): Promise<void> {
+		// Advance before every post-mutation send, including successful ones. An
+		// authoritative retry already in flight may have captured the previous
+		// local state; the generation mismatch forces one more current snapshot
+		// after that stale send settles.
+		this._replicationAnnouncementRetryGeneration += 1;
+		try {
+			await this.rpc.send(message, {
+				priority: CONVERGENCE_MESSAGE_PRIORITY,
+			});
+		} catch (error) {
+			// The local replication-index mutation precedes all calls to this
+			// wrapper. Preserve the explicit caller's rejection, but independently
+			// schedule an authoritative snapshot so peers eventually observe the
+			// already-committed local state.
+			this.queueCurrentReplicationStateAnnouncementRetry(error);
+			throw error;
+		}
+	}
+
+	private async retryCurrentReplicationStateAnnouncement(): Promise<void> {
+		const generation = this._replicationAnnouncementRetryGeneration;
+		const controller = this._replicationAnnouncementRetryController;
+		try {
+			const segments = (await this.getMyReplicationSegments()).map((range) =>
+				range.toReplicationRange(),
+			);
+			if (
+				this.closed ||
+				this._closeController.signal.aborted ||
+				controller.signal.aborted
+			) {
+				return;
+			}
+			if (generation !== this._replicationAnnouncementRetryGeneration) {
+				void this.replicationAnnouncementRetryDebounced?.call();
+				return;
+			}
+
+			await this.rpc.send(new AllReplicatingSegmentsMessage({ segments }), {
+				priority: CONVERGENCE_MESSAGE_PRIORITY,
+				signal: controller.signal,
+			});
+		} catch (error) {
+			if (
+				this.closed ||
+				this._closeController.signal.aborted ||
+				controller.signal.aborted
+			) {
+				return;
+			}
+			if (this.queueCurrentReplicationStateAnnouncementRetry(error)) {
+				return;
+			}
+			if (generation === this._replicationAnnouncementRetryGeneration) {
+				this._replicationAnnouncementRetryPending = false;
+			} else {
+				void this.replicationAnnouncementRetryDebounced?.call();
+			}
+			throw error;
+		}
+		if (
+			this.closed ||
+			this._closeController.signal.aborted ||
+			controller.signal.aborted
+		) {
+			return;
+		}
+
+		// A newer mutation announcement may have started while this snapshot was
+		// in flight. In that case keep the repair pending so the newer current
+		// state is also announced in full, regardless of whether its incremental
+		// send succeeded or failed.
+		if (generation === this._replicationAnnouncementRetryGeneration) {
+			this._replicationAnnouncementRetryPending = false;
+			if (
+				!this.closed &&
+				!this._closeController.signal.aborted &&
+				!controller.signal.aborted &&
+				this._isAdaptiveReplicating
+			) {
+				void this.rebalanceParticipationDebounced?.call();
+			}
+		} else {
+			void this.replicationAnnouncementRetryDebounced?.call();
+		}
 	}
 
 	private markLocalAppendActivity(timestamp = Date.now()) {
@@ -3917,13 +4140,10 @@ export class SharedLog<
 		});
 
 		if (rangesToUnreplicate.length > 0) {
-			await this.rpc.send(
+			await this.sendReplicationAnnouncement(
 				new StoppedReplicating({
 					segmentIds: rangesToUnreplicate.map((x) => x.id),
 				}),
-				{
-					priority: CONVERGENCE_MESSAGE_PRIORITY,
-				},
 			);
 		}
 
@@ -4082,9 +4302,9 @@ export class SharedLog<
 			rangesToRemove,
 			this.node.identity.publicKey,
 		);
-		await this.rpc.send(new StoppedReplicating({ segmentIds }), {
-			priority: CONVERGENCE_MESSAGE_PRIORITY,
-		});
+		await this.sendReplicationAnnouncement(
+			new StoppedReplicating({ segmentIds }),
+		);
 	}
 
 	private async removeReplicator(
@@ -4111,9 +4331,9 @@ export class SharedLog<
 		if (isMe) {
 			// announce that we are no longer replicating
 
-			await this.rpc.send(new AllReplicatingSegmentsMessage({ segments: [] }), {
-				priority: CONVERGENCE_MESSAGE_PRIORITY,
-			});
+			await this.sendReplicationAnnouncement(
+				new AllReplicatingSegmentsMessage({ segments: [] }),
+			);
 		}
 
 		if (options?.noEvent !== true) {
@@ -4610,9 +4830,7 @@ export class SharedLog<
 				if (options.announce) {
 					return options.announce(message);
 				} else {
-					await this.rpc.send(message, {
-						priority: CONVERGENCE_MESSAGE_PRIORITY,
-					});
+					await this.sendReplicationAnnouncement(message);
 				}
 			}
 		}
@@ -8981,6 +9199,8 @@ export class SharedLog<
 		this._replicatorLivenessFailures = new Map();
 		this._replicatorLastActivityAt = new Map();
 		this._lastLocalAppendAt = 0;
+		this._replicationAnnouncementRetryPending = false;
+		this._replicationAnnouncementRetryGeneration = 0;
 		const adaptiveReplicateOptions =
 			options?.replicate && isAdaptiveReplicatorOption(options.replicate)
 				? options.replicate
@@ -9039,6 +9259,7 @@ export class SharedLog<
 		}
 
 		this._closeController = new AbortController();
+		this.setupReplicationAnnouncementRetryFunction();
 		this._closeController.signal.addEventListener("abort", () => {
 			for (const [_peer, state] of this._replicationInfoRequestByPeer) {
 				if (state.timer) clearTimeout(state.timer);
@@ -11099,6 +11320,8 @@ export class SharedLog<
 	}
 
 	private async _close() {
+		this.cancelCurrentReplicationStateAnnouncementRetry();
+		this.replicationAnnouncementRetryDebounced = undefined;
 		if (!this._entryCoordinatesIndex && !this._replicationRangeIndex) {
 			return;
 		}
@@ -11221,6 +11444,7 @@ export class SharedLog<
 		/* this._totalParticipation = 0; */
 	}
 	async close(from?: Program): Promise<boolean> {
+		this.cancelCurrentReplicationStateAnnouncementRetry();
 		// Best-effort: announce that we are going offline before tearing down
 		// RPC/subscription state.
 		//
@@ -11283,6 +11507,7 @@ export class SharedLog<
 	}
 
 	async drop(from?: Program): Promise<boolean> {
+		this.cancelCurrentReplicationStateAnnouncementRetry();
 		// Best-effort: announce that we are going offline before tearing down
 		// RPC/subscription state (same reasoning as in `close()`).
 		try {
@@ -14093,9 +14318,7 @@ export class SharedLog<
 			}
 
 			if (messageToSend) {
-				await this.rpc.send(messageToSend, {
-					priority: CONVERGENCE_MESSAGE_PRIORITY,
-				});
+				await this.sendReplicationAnnouncement(messageToSend);
 			}
 		}
 	}
@@ -18520,10 +18743,20 @@ export class SharedLog<
 						return false;
 					}
 
-					await this.startAnnounceReplicating([dynamicRange], {
-						checkDuplicates: false,
-						reset: false,
-					});
+					try {
+						await this.startAnnounceReplicating([dynamicRange], {
+							checkDuplicates: false,
+							reset: false,
+						});
+					} catch (error) {
+						if (
+							isTransientReplicationAnnouncementError(error) &&
+							this._replicationAnnouncementRetryPending
+						) {
+							return false;
+						}
+						throw error;
+					}
 
 					/* await this._updateRole(newRole, onRoleChange); */
 					this.rebalanceParticipationDebounced?.call();

--- a/packages/programs/data/shared-log/test/replication-announcement-retry.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-announcement-retry.spec.ts
@@ -1,0 +1,523 @@
+import { TestSession } from "@peerbit/test-utils";
+import {
+	AbortError,
+	TimeoutError,
+	delay,
+	waitForResolved,
+} from "@peerbit/time";
+import { expect } from "chai";
+import sinon from "sinon";
+import {
+	AddedReplicationSegmentMessage,
+	AllReplicatingSegmentsMessage,
+	StoppedReplicating,
+} from "../src/replication.js";
+import { EventStore } from "./utils/stores/index.js";
+
+describe("replication announcement retries", () => {
+	let session: TestSession | undefined;
+
+	const openStore = async (replicate: any) => {
+		session = await TestSession.disconnected(1);
+		return session.peers[0].open(new EventStore<string, any>(), {
+			args: {
+				replicate,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+	};
+
+	const useFastAnnouncementRetry = (log: any) => {
+		log.setupReplicationAnnouncementRetryFunction(10);
+	};
+
+	afterEach(async () => {
+		sinon.restore();
+		if (session) {
+			await session.stop();
+			session = undefined;
+		}
+	});
+
+	it("contains an adaptive timeout and retries the locally committed range as a full snapshot", async () => {
+		const store = await openStore({ limits: { interval: 60_000 } });
+		const log = store.log as any;
+		log.adaptiveRebalanceIdleMs = 0;
+		log.setupRebalanceDebounceFunction(10);
+		useFastAnnouncementRetry(log);
+
+		let targetFactor: number | undefined;
+		let stepCalls = 0;
+		sinon
+			.stub(log.replicationController, "step")
+			.callsFake((properties: any) => {
+				stepCalls++;
+				const currentFactor = properties.currentFactor as number;
+				targetFactor ??= currentFactor > 0.2 ? currentFactor / 2 : 0.5;
+				return targetFactor;
+			});
+
+		const timeout = new TimeoutError("detached fanout shard timed out");
+		let incrementalFailed = false;
+		const snapshots: AllReplicatingSegmentsMessage[] = [];
+		sinon.stub(store.log.rpc, "send").callsFake(async (message: any) => {
+			if (
+				message instanceof AddedReplicationSegmentMessage &&
+				!incrementalFailed
+			) {
+				incrementalFailed = true;
+				throw timeout;
+			}
+			if (message instanceof AllReplicatingSegmentsMessage) {
+				snapshots.push(message);
+			}
+			return [] as any;
+		});
+
+		const unhandled: unknown[] = [];
+		const onUnhandledRejection = (reason: unknown) => unhandled.push(reason);
+		process.on("unhandledRejection", onUnhandledRejection);
+
+		try {
+			void log.rebalanceParticipationDebounced.call();
+			await waitForResolved(() => expect(incrementalFailed).to.equal(true), {
+				timeout: 2_000,
+				delayInterval: 5,
+			});
+
+			const locallyCommitted = await store.log.getMyReplicationSegments();
+			expect(locallyCommitted).to.have.length(1);
+			expect(locallyCommitted[0].widthNormalized).to.be.closeTo(
+				targetFactor!,
+				1e-6,
+			);
+
+			await waitForResolved(() => expect(snapshots).to.have.length(1), {
+				timeout: 2_000,
+				delayInterval: 5,
+			});
+			expect(snapshots[0].segments).to.have.length(1);
+			expect(snapshots[0].segments[0].id).to.deep.equal(locallyCommitted[0].id);
+			expect(snapshots[0].segments[0].factor).to.deep.equal(
+				locallyCommitted[0].width,
+			);
+			expect(log._replicationAnnouncementRetryPending).to.equal(false);
+			await waitForResolved(() => expect(stepCalls).to.be.greaterThan(1), {
+				timeout: 500,
+				delayInterval: 5,
+			});
+
+			await delay(0);
+			expect(unhandled).to.deep.equal([]);
+		} finally {
+			process.off("unhandledRejection", onUnhandledRejection);
+		}
+	});
+
+	it("keeps explicit replicate rejection semantics without retrying an abort", async () => {
+		const store = await openStore(false);
+		const log = store.log as any;
+		useFastAnnouncementRetry(log);
+
+		const abort = new AbortError("fanout channel detached");
+		let announcementCalls = 0;
+		const snapshots: AllReplicatingSegmentsMessage[] = [];
+		sinon.stub(store.log.rpc, "send").callsFake(async (message: any) => {
+			if (
+				(message instanceof AddedReplicationSegmentMessage ||
+					message instanceof AllReplicatingSegmentsMessage) &&
+				announcementCalls++ === 0
+			) {
+				throw abort;
+			}
+			if (message instanceof AllReplicatingSegmentsMessage) {
+				snapshots.push(message);
+			}
+			return [] as any;
+		});
+
+		let rejected: unknown;
+		try {
+			await store.log.replicate({ factor: 0.25, offset: 0.1 });
+		} catch (error) {
+			rejected = error;
+		}
+		expect(rejected).to.equal(abort);
+
+		const locallyCommitted = await store.log.getMyReplicationSegments();
+		expect(locallyCommitted).to.have.length(1);
+		await delay(40);
+		expect(snapshots).to.deep.equal([]);
+		expect(log._replicationAnnouncementRetryPending).to.equal(false);
+	});
+
+	it("uses exact timeout branding without retrying generic closed or mixed aggregate failures", async () => {
+		const store = await openStore(false);
+		const log = store.log as any;
+		useFastAnnouncementRetry(log);
+
+		const mixed = new Error("mixed replication delivery failure") as Error & {
+			errors: unknown[];
+		};
+		mixed.errors = [
+			new TimeoutError("one shard timed out"),
+			new Error("invalid replication payload"),
+		];
+
+		expect(
+			log.queueCurrentReplicationStateAnnouncementRetry(
+				new Error("fanout channel closed while detached"),
+			),
+		).to.equal(false);
+		expect(log.queueCurrentReplicationStateAnnouncementRetry(mixed)).to.equal(
+			false,
+		);
+		expect(log._replicationAnnouncementRetryPending).to.equal(false);
+
+		const crossPackageTimeout = {
+			constructor: { name: "TimeoutError" },
+			name: "Error",
+		};
+		expect(
+			log.queueCurrentReplicationStateAnnouncementRetry(crossPackageTimeout),
+		).to.equal(true);
+		await waitForResolved(
+			() => expect(log._replicationAnnouncementRetryPending).to.equal(false),
+			{ timeout: 2_000, delayInterval: 5 },
+		);
+	});
+
+	it("follows an in-flight stale snapshot with the state from a newer successful announcement", async () => {
+		const store = await openStore(false);
+		const log = store.log as any;
+		useFastAnnouncementRetry(log);
+
+		const firstRangeId = new Uint8Array(32).fill(7);
+		const secondRangeId = new Uint8Array(32).fill(8);
+		const timeout = new TimeoutError("detached shard timed out");
+		let incrementalFailed = false;
+		let releaseStaleSnapshot!: () => void;
+		const staleSnapshotGate = new Promise<void>((resolve) => {
+			releaseStaleSnapshot = resolve;
+		});
+		const snapshots: AllReplicatingSegmentsMessage[] = [];
+		const successfulIncrementals: AddedReplicationSegmentMessage[] = [];
+		sinon.stub(store.log.rpc, "send").callsFake(async (message: any) => {
+			if (
+				message instanceof AddedReplicationSegmentMessage &&
+				!incrementalFailed
+			) {
+				incrementalFailed = true;
+				throw timeout;
+			}
+			if (message instanceof AllReplicatingSegmentsMessage) {
+				snapshots.push(message);
+				if (snapshots.length === 1) {
+					await staleSnapshotGate;
+				}
+			}
+			if (message instanceof AddedReplicationSegmentMessage) {
+				successfulIncrementals.push(message);
+			}
+			return [] as any;
+		});
+
+		try {
+			let rejected: unknown;
+			try {
+				await store.log.replicate({
+					id: firstRangeId,
+					factor: 0.25,
+					offset: 0.1,
+				});
+			} catch (error) {
+				rejected = error;
+			}
+			expect(rejected).to.equal(timeout);
+
+			await waitForResolved(() => expect(snapshots).to.have.length(1), {
+				timeout: 2_000,
+				delayInterval: 5,
+			});
+
+			// This successful incremental send contains only the second range. If the
+			// stale reset arrives after it, a final current reset is required to
+			// restore both ranges remotely.
+			await store.log.replicate({
+				id: secondRangeId,
+				factor: 0.2,
+				offset: 0.6,
+			});
+			const current = await store.log.getMyReplicationSegments();
+			expect(current).to.have.length(2);
+			expect(successfulIncrementals).to.have.length(1);
+			expect(successfulIncrementals[0].segments).to.have.length(1);
+			expect(successfulIncrementals[0].segments[0].id).to.deep.equal(
+				secondRangeId,
+			);
+			expect(snapshots[0].segments).to.have.length(1);
+			expect(snapshots[0].segments[0].id).to.deep.equal(firstRangeId);
+
+			releaseStaleSnapshot();
+			await waitForResolved(
+				() => {
+					expect(snapshots).to.have.length(2);
+					expect(log._replicationAnnouncementRetryPending).to.equal(false);
+				},
+				{ timeout: 2_000, delayInterval: 5 },
+			);
+			expect(snapshots[1].segments).to.have.length(2);
+			const finalIds = snapshots[1].segments.map((segment) =>
+				Array.from(segment.id).join(","),
+			);
+			expect(finalIds).to.have.members([
+				Array.from(firstRangeId).join(","),
+				Array.from(secondRangeId).join(","),
+			]);
+		} finally {
+			releaseStaleSnapshot();
+		}
+	});
+
+	it("recollects current state when a newer announcement starts during snapshot collection", async () => {
+		const store = await openStore(false);
+		const log = store.log as any;
+		useFastAnnouncementRetry(log);
+
+		const firstRangeId = new Uint8Array(32).fill(11);
+		const secondRangeId = new Uint8Array(32).fill(12);
+		const timeout = new TimeoutError("detached shard timed out");
+		let incrementalFailed = false;
+		let collectionStarted = false;
+		let releaseCollection!: () => void;
+		const collectionGate = new Promise<void>((resolve) => {
+			releaseCollection = resolve;
+		});
+		const originalGetSegments = store.log.getMyReplicationSegments.bind(
+			store.log,
+		);
+		let heldCollection = false;
+		sinon.stub(store.log, "getMyReplicationSegments").callsFake(async () => {
+			const captured = await originalGetSegments();
+			if (incrementalFailed && !heldCollection) {
+				heldCollection = true;
+				collectionStarted = true;
+				await collectionGate;
+			}
+			return captured;
+		});
+
+		const snapshots: AllReplicatingSegmentsMessage[] = [];
+		sinon.stub(store.log.rpc, "send").callsFake(async (message: any) => {
+			if (
+				message instanceof AddedReplicationSegmentMessage &&
+				!incrementalFailed
+			) {
+				incrementalFailed = true;
+				throw timeout;
+			}
+			if (message instanceof AllReplicatingSegmentsMessage) {
+				snapshots.push(message);
+			}
+			return [] as any;
+		});
+
+		try {
+			try {
+				await store.log.replicate({
+					id: firstRangeId,
+					factor: 0.25,
+					offset: 0.1,
+				});
+			} catch (error) {
+				expect(error).to.equal(timeout);
+			}
+
+			await waitForResolved(() => expect(collectionStarted).to.equal(true), {
+				timeout: 2_000,
+				delayInterval: 5,
+			});
+			await store.log.replicate({
+				id: secondRangeId,
+				factor: 0.2,
+				offset: 0.6,
+			});
+			releaseCollection();
+
+			await waitForResolved(
+				() => {
+					expect(snapshots).to.have.length(1);
+					expect(log._replicationAnnouncementRetryPending).to.equal(false);
+				},
+				{ timeout: 2_000, delayInterval: 5 },
+			);
+			const snapshotIds = snapshots[0].segments.map((segment) =>
+				Array.from(segment.id).join(","),
+			);
+			expect(snapshotIds).to.have.members([
+				Array.from(firstRangeId).join(","),
+				Array.from(secondRangeId).join(","),
+			]);
+		} finally {
+			releaseCollection();
+		}
+	});
+
+	it("clears pending after a non-timeout retry-worker failure", async () => {
+		const store = await openStore(false);
+		const log = store.log as any;
+		useFastAnnouncementRetry(log);
+
+		const timeout = new TimeoutError("detached shard timed out");
+		const workerError = new Error("synthetic snapshot encoding failure");
+		let incrementalFailed = false;
+		let snapshotAttempts = 0;
+		sinon.stub(store.log.rpc, "send").callsFake(async (message: any) => {
+			if (
+				message instanceof AddedReplicationSegmentMessage &&
+				!incrementalFailed
+			) {
+				incrementalFailed = true;
+				throw timeout;
+			}
+			if (message instanceof AllReplicatingSegmentsMessage) {
+				snapshotAttempts++;
+				throw workerError;
+			}
+			return [] as any;
+		});
+
+		try {
+			await store.log.replicate({ factor: 0.25, offset: 0.1 });
+		} catch (error) {
+			expect(error).to.equal(timeout);
+		}
+		await waitForResolved(
+			() => {
+				expect(snapshotAttempts).to.equal(1);
+				expect(log._replicationAnnouncementRetryPending).to.equal(false);
+			},
+			{ timeout: 2_000, delayInterval: 5 },
+		);
+		await delay(40);
+		expect(snapshotAttempts).to.equal(1);
+	});
+
+	it("retries an authoritative empty snapshot after unreplicate removes local state", async () => {
+		const store = await openStore({ factor: 0.5, offset: 0.1 });
+		const log = store.log as any;
+		useFastAnnouncementRetry(log);
+
+		const detached = new TimeoutError("detached shard timed out");
+		let emptyAnnouncementCalls = 0;
+		const successfulEmptySnapshots: AllReplicatingSegmentsMessage[] = [];
+		sinon.stub(store.log.rpc, "send").callsFake(async (message: any) => {
+			if (
+				message instanceof AllReplicatingSegmentsMessage &&
+				message.segments.length === 0
+			) {
+				if (emptyAnnouncementCalls++ === 0) {
+					throw detached;
+				}
+				successfulEmptySnapshots.push(message);
+			}
+			return [] as any;
+		});
+
+		let rejected: unknown;
+		try {
+			await store.log.unreplicate();
+		} catch (error) {
+			rejected = error;
+		}
+		expect(rejected).to.equal(detached);
+		expect(await store.log.getMyReplicationSegments()).to.deep.equal([]);
+
+		await waitForResolved(
+			() => expect(successfulEmptySnapshots).to.have.length(1),
+			{ timeout: 2_000, delayInterval: 5 },
+		);
+		expect(log._isReplicating).to.equal(false);
+		expect(log._replicationAnnouncementRetryPending).to.equal(false);
+	});
+
+	it("repairs a partial removal after an aggregate delivery timeout", async () => {
+		const store = await openStore({ factor: 0.5, offset: 0.1 });
+		const log = store.log as any;
+		useFastAnnouncementRetry(log);
+		const [segment] = await store.log.getMyReplicationSegments();
+		expect(segment).to.exist;
+
+		const aggregate = new Error("replication delivery failed") as Error & {
+			errors: unknown[];
+		};
+		aggregate.errors = [new TimeoutError("detached shard timed out")];
+		let stoppedFailed = false;
+		const snapshots: AllReplicatingSegmentsMessage[] = [];
+		sinon.stub(store.log.rpc, "send").callsFake(async (message: any) => {
+			if (message instanceof StoppedReplicating && !stoppedFailed) {
+				stoppedFailed = true;
+				throw aggregate;
+			}
+			if (message instanceof AllReplicatingSegmentsMessage) {
+				snapshots.push(message);
+			}
+			return [] as any;
+		});
+
+		let rejected: unknown;
+		try {
+			await store.log.unreplicate([{ id: segment.id }]);
+		} catch (error) {
+			rejected = error;
+		}
+		expect(rejected).to.equal(aggregate);
+		expect(await store.log.getMyReplicationSegments()).to.deep.equal([]);
+
+		await waitForResolved(() => expect(snapshots).to.have.length(1), {
+			timeout: 2_000,
+			delayInterval: 5,
+		});
+		expect(snapshots[0].segments).to.deep.equal([]);
+		expect(log._replicationAnnouncementRetryPending).to.equal(false);
+	});
+
+	it("cancels a pending authoritative retry before the close announcement", async () => {
+		const store = await openStore(false);
+		const log = store.log as any;
+		log.setupReplicationAnnouncementRetryFunction(100);
+
+		const timeout = new TimeoutError("detached shard timed out");
+		let incrementalFailed = false;
+		const nonEmptySnapshots: AllReplicatingSegmentsMessage[] = [];
+		sinon.stub(store.log.rpc, "send").callsFake(async (message: any) => {
+			if (
+				message instanceof AddedReplicationSegmentMessage &&
+				!incrementalFailed
+			) {
+				incrementalFailed = true;
+				throw timeout;
+			}
+			if (
+				message instanceof AllReplicatingSegmentsMessage &&
+				message.segments.length > 0
+			) {
+				nonEmptySnapshots.push(message);
+			}
+			return [] as any;
+		});
+
+		try {
+			await store.log.replicate({ factor: 0.25, offset: 0.1 });
+		} catch (error) {
+			expect(error).to.equal(timeout);
+		}
+		expect(incrementalFailed).to.equal(true);
+		expect(log._replicationAnnouncementRetryPending).to.equal(true);
+
+		await store.close();
+		await delay(150);
+		expect(nonEmptySnapshots).to.deep.equal([]);
+		expect(log._replicationAnnouncementRetryPending).to.equal(false);
+	});
+});

--- a/packages/utils/time/src/aggregators.ts
+++ b/packages/utils/time/src/aggregators.ts
@@ -22,6 +22,7 @@ export const debounceFixedInterval = <
 	let lastThis: any;
 	let pendingCall = false;
 	let isRunning = false;
+	let closed = false;
 	let waitingResolvers: Array<() => void> = [];
 	let lastInvokeTime: number | null = null;
 	let forceNextImmediate = false;
@@ -56,7 +57,7 @@ export const debounceFixedInterval = <
 
 	const invoke = async (): Promise<void> => {
 		timeout = null;
-		if (!lastArgs) {
+		if (closed || !lastArgs) {
 			return;
 		}
 
@@ -83,7 +84,7 @@ export const debounceFixedInterval = <
 			completedRuns++;
 			resolveRunWaiters();
 
-			if (pendingCall) {
+			if (!closed && pendingCall) {
 				if (forceNextImmediate) {
 					forceNextImmediate = false;
 					timeout = setTimeout(invoke, 0);
@@ -97,6 +98,9 @@ export const debounceFixedInterval = <
 	};
 
 	function debounced(this: any, ...args: Parameters<T>): Promise<void> {
+		if (closed) {
+			return Promise.resolve();
+		}
 		lastArgs = args;
 		lastThis = this;
 		pendingCall = true;
@@ -122,6 +126,9 @@ export const debounceFixedInterval = <
 	}
 
 	const flush = (): Promise<void> => {
+		if (closed) {
+			return Promise.resolve();
+		}
 		if (isRunning) {
 			const hadPendingArgs = Boolean(lastArgs);
 			if (hadPendingArgs) {
@@ -147,12 +154,30 @@ export const debounceFixedInterval = <
 	};
 
 	const close = (): void => {
+		if (closed) {
+			return;
+		}
+		closed = true;
 		if (timeout !== null) {
 			clearTimeout(timeout);
 			timeout = null;
 		}
-		isRunning = false;
+		lastArgs = null;
+		lastThis = undefined;
+		pendingCall = false;
 		forceNextImmediate = false;
+
+		const resolvers = waitingResolvers;
+		waitingResolvers = [];
+		for (const resolve of resolvers) {
+			resolve();
+		}
+
+		const flushWaiters = runWaiters;
+		runWaiters = [];
+		for (const waiter of flushWaiters) {
+			waiter.resolve();
+		}
 	};
 
 	return { call: debounced, close, flush };
@@ -186,7 +211,9 @@ export const debounceAccumulator = <K, T, V>(
 		await fn(toSend);
 	};
 
-	const deb = debounceFixedInterval(innerInvoke, delay, options);
+	const createDebouncer = () =>
+		debounceFixedInterval(innerInvoke, delay, options);
+	let deb = createDebouncer();
 
 	return {
 		add: (value: T): Promise<void> => {
@@ -200,6 +227,7 @@ export const debounceAccumulator = <K, T, V>(
 		has: (key: K): boolean => accumulator.has(key),
 		invoke: async (): Promise<void> => {
 			deb.close();
+			deb = createDebouncer();
 			await innerInvoke();
 		},
 		close: (): void => {

--- a/packages/utils/time/test/aggregators.spec.ts
+++ b/packages/utils/time/test/aggregators.spec.ts
@@ -138,6 +138,37 @@ describe("debounceFixedInterval", () => {
 		expect(invoked).to.eq(0);
 	});
 
+	it("close() is terminal while an invocation is running with queued work", async () => {
+		let invoked = 0;
+		let release!: () => void;
+		const running = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const d = debounceFixedInterval(
+			async () => {
+				invoked++;
+				await running;
+			},
+			20,
+			{ leading: true },
+		);
+
+		const first = d.call();
+		await waitForResolved(() => expect(invoked).to.eq(1));
+		const queued = d.call();
+		const flushed = d.flush();
+		d.close();
+		release();
+
+		await Promise.all([first, queued, flushed]);
+		await delay(60);
+		expect(invoked).to.eq(1);
+
+		await d.call();
+		await d.flush();
+		expect(invoked).to.eq(1);
+	});
+
 	it("preserves latest args and call-site `this`", async () => {
 		const seen: Array<{ selfHasValue: number | undefined; arg: string }> = [];
 


### PR DESCRIPTION
## Summary

- retry only TimeoutError-derived post-mutation replication announcement failures
- repair from a generation-safe authoritative full snapshot, including empty unreplicate state
- preserve explicit caller rejections and cancel retry work during close/drop
- keep adaptive rebalancing alive after a repaired background timeout
- make fixed-interval debouncer shutdown terminal so queued work cannot restart it

## Why

Replication-role mutations are network-visible protocol announcements. A detached fanout shard can time out even after local state changed; the previous fire-and-forget debouncer then surfaced the timeout as an unhandled page error and stopped adaptive scheduling. This keeps local intent and the advertised network state convergent without retrying unrelated errors.

## Validation

- 12/12 shared-log retry and adaptive tests
- 15/15 time/debouncer tests
- shared-log and time package builds
- targeted ESLint and diff checks
- independent correctness review