### PR TITLE
fix(react): use OPFS without eviction grant

### DIFF
--- a/.changeset/fair-browser-opfs.md
+++ b/.changeset/fair-browser-opfs.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/react": patch
+---
+
+Use OPFS-backed browser storage even when persistent-storage permission is denied. The permission controls eviction protection, while the explicit `inMemory` option continues to select memory-only storage.

--- a/packages/clients/peerbit-react/e2e/browser/tests/identity.spec.ts
+++ b/packages/clients/peerbit-react/e2e/browser/tests/identity.spec.ts
@@ -11,6 +11,7 @@ import { Peerbit } from "peerbit";
 const launchPersistentBrowserContext = async (
 	testInfo: TestInfo,
 	baseURL: string,
+	protectedFromEviction = true,
 ) => {
 	const userDataDir = testInfo.outputPath("peerbit-react");
 	const context = await chromium.launchPersistentContext(userDataDir, {
@@ -19,16 +20,16 @@ const launchPersistentBrowserContext = async (
 		args: ["--enable-features=FileSystemAccessAPI"],
 	});
 
-	await context.addInitScript(() => {
-		Object.defineProperty(navigator, "storage", {
-			value: {
-				...navigator.storage,
-				persist: async () => true,
-				persisted: async () => true,
-			},
+	await context.addInitScript((persisted) => {
+		Object.defineProperty(navigator.storage, "persist", {
+			value: async () => persisted,
 			configurable: true,
 		});
-	});
+		Object.defineProperty(navigator.storage, "persisted", {
+			value: async () => persisted,
+			configurable: true,
+		});
+	}, protectedFromEviction);
 
 	const origin = new URL(baseURL).origin;
 	await context.grantPermissions(["storage-access"], { origin });
@@ -49,13 +50,29 @@ const waitForPeerHash = (page: Page) =>
 		{ timeout: 20_000 },
 	);
 
+const getStorageState = (page: Page) =>
+	page.evaluate(async () => {
+		const root = await navigator.storage.getDirectory();
+		let opfsEntryCount = 0;
+		for await (const _entry of root.entries()) {
+			opfsEntryCount += 1;
+		}
+		const estimate = await navigator.storage.estimate();
+		return {
+			evictionProtected: await navigator.storage.persisted(),
+			reactPersisted: (window as any).__peerInfo?.persisted ?? null,
+			opfsEntryCount,
+			usage: estimate.usage ?? 0,
+		};
+	});
+
 let bootstrap: Peerbit;
 let bootstrapAddr: string;
 let persistentContext: BrowserContext | undefined;
 let baseURL: string;
 
 test.describe("identity", () => {
-	test.beforeEach(async (_, testInfo) => {
+	test.beforeEach(async ({ browserName: _browserName }, testInfo) => {
 		baseURL =
 			testInfo.project.use.baseURL?.toString() ||
 			process.env.PLAYWRIGHT_BASE_URL ||
@@ -73,7 +90,7 @@ test.describe("identity", () => {
 		await bootstrap?.stop();
 	});
 
-	test("reuses identity across reload", async (_, testInfo) => {
+	test("reuses identity across reload", async ({ browserName: _browserName }, testInfo) => {
 		persistentContext = await launchPersistentBrowserContext(testInfo, baseURL);
 		const page = await persistentContext!.newPage();
 		const target = new URL(
@@ -96,20 +113,16 @@ test.describe("identity", () => {
 		expect(secondValue).toBe(firstValue);
 	});
 
-	test("reuses identity across reload without persistence", async ({
-		page,
-	}) => {
-		await page.addInitScript(() => {
-			Object.defineProperty(navigator, "storage", {
-				value: {
-					...navigator.storage,
-					persist: async () => false,
-					persisted: async () => false,
-				},
-				configurable: true,
-			});
-		});
-
+	test("uses OPFS and reuses identity without eviction protection", async (
+		{ browserName: _browserName },
+		testInfo,
+	) => {
+		persistentContext = await launchPersistentBrowserContext(
+			testInfo,
+			baseURL,
+			false,
+		);
+		const page = await persistentContext.newPage();
 		const target = new URL(
 			`/?bootstrap=${encodeURIComponent(bootstrapAddr)}`,
 			baseURL,
@@ -120,12 +133,22 @@ test.describe("identity", () => {
 		const first = await waitForPeerHash(page);
 		const firstValue = (await first.jsonValue()) as string | null;
 		expect(firstValue && firstValue !== "no-peer").toBeTruthy();
+		const firstStorage = await getStorageState(page);
+		expect(firstStorage.evictionProtected).toBe(false);
+		expect(firstStorage.reactPersisted).toBe(false);
+		expect(firstStorage.opfsEntryCount).toBeGreaterThan(0);
+		expect(firstStorage.usage).toBeGreaterThan(0);
 
 		await page.reload();
 
 		const second = await waitForPeerHash(page);
 		const secondValue = (await second.jsonValue()) as string | null;
 		expect(secondValue).toBe(firstValue);
+		const secondStorage = await getStorageState(page);
+		expect(secondStorage.evictionProtected).toBe(false);
+		expect(secondStorage.reactPersisted).toBe(false);
+		expect(secondStorage.opfsEntryCount).toBeGreaterThan(0);
+		expect(secondStorage.usage).toBeGreaterThan(0);
 	});
 
 	test("creates new identity when storage is cleared", async ({ page }) => {

--- a/packages/clients/peerbit-react/src/usePeer.tsx
+++ b/packages/clients/peerbit-react/src/usePeer.tsx
@@ -403,16 +403,42 @@ export const PeerProvider = ({ config, children }: PeerProviderProps) => {
 
 			let directory: string | undefined;
 			if (!nodeOptions.inMemory && !(await detectIncognito()).isPrivate) {
-				storageLog("requesting persist");
-				const persistedValue = await navigator.storage.persist();
+				const storage = navigator.storage as StorageManager & {
+					getDirectory?: () => Promise<FileSystemDirectoryHandle>;
+				};
+				let persistedValue = false;
+				if (typeof storage?.persist === "function") {
+					storageLog("requesting persist");
+					try {
+						persistedValue = await storage.persist();
+					} catch (error) {
+						console.warn(
+							"Failed to request protection from browser storage eviction.",
+							error,
+						);
+					}
+				}
 				setPersisted(persistedValue);
 				persistedResolved = persistedValue;
-				if (!persistedValue) {
-					console.error(
-						"Request persistence but permission was not granted by browser.",
-					);
+				if (typeof storage?.getDirectory === "function") {
+					try {
+						await storage.getDirectory();
+						directory = `./repo/${peerId.toString()}/`;
+						if (!persistedValue) {
+							console.warn(
+								"Browser storage is not protected from eviction; continuing with OPFS-backed storage.",
+							);
+						}
+					} catch (error) {
+						console.error(
+							"Origin-private file system storage could not be opened; falling back to in-memory storage.",
+							error,
+						);
+					}
 				} else {
-					directory = `./repo/${peerId.toString()}/`;
+					console.error(
+						"Origin-private file system storage is unavailable; falling back to in-memory storage.",
+					);
 				}
 			}
 

--- a/packages/clients/peerbit-react/vitest/usePeer.test.tsx
+++ b/packages/clients/peerbit-react/vitest/usePeer.test.tsx
@@ -8,6 +8,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => {
 	return {
 		create: vi.fn(),
+		detectIncognito: vi.fn(async () => ({ isPrivate: false })),
+		persist: vi.fn(async () => false),
+		getDirectory: vi.fn(async () => ({})),
 		getBootstrapPeerId: vi.fn((address: string) =>
 			address.includes("/p2p/12D3KooW-bootstrap")
 				? "12D3KooW-bootstrap"
@@ -26,7 +29,7 @@ const mocks = vi.hoisted(() => {
 });
 
 vi.mock("detectincognitojs", () => ({
-	detectIncognito: vi.fn(async () => ({ isPrivate: false })),
+	detectIncognito: mocks.detectIncognito,
 }));
 
 vi.mock("libsodium-wrappers", () => ({
@@ -131,6 +134,7 @@ describe("PeerProvider bootstrap handling", () => {
 	let root: ReactDOM.Root;
 	let consoleError: ReturnType<typeof vi.spyOn>;
 	let consoleWarn: ReturnType<typeof vi.spyOn>;
+	let originalStorage: PropertyDescriptor | undefined;
 
 	beforeEach(() => {
 		container = document.createElement("div");
@@ -139,6 +143,20 @@ describe("PeerProvider bootstrap handling", () => {
 		consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 		consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
 		mocks.create.mockReset();
+		mocks.detectIncognito.mockReset();
+		mocks.detectIncognito.mockResolvedValue({ isPrivate: false });
+		mocks.persist.mockReset();
+		mocks.persist.mockResolvedValue(false);
+		mocks.getDirectory.mockReset();
+		mocks.getDirectory.mockResolvedValue({});
+		originalStorage = Object.getOwnPropertyDescriptor(navigator, "storage");
+		Object.defineProperty(navigator, "storage", {
+			configurable: true,
+			value: {
+				persist: mocks.persist,
+				getDirectory: mocks.getDirectory,
+			},
+		});
 	});
 
 	afterEach(async () => {
@@ -148,7 +166,38 @@ describe("PeerProvider bootstrap handling", () => {
 		container.remove();
 		consoleError.mockRestore();
 		consoleWarn.mockRestore();
+		if (originalStorage) {
+			Object.defineProperty(navigator, "storage", originalStorage);
+		} else {
+			Reflect.deleteProperty(navigator, "storage");
+		}
 	});
+
+	const renderStorageProvider = async (inMemory?: boolean) => {
+		mocks.create.mockResolvedValue(createPeerInstance());
+
+		await act(async () => {
+			root.render(
+				<PeerProvider
+					config={{
+						runtime: "node",
+						network: { bootstrap: [] },
+						waitForConnected: true,
+						keypair: createFakeKeypair(),
+						...(inMemory === undefined ? {} : { inMemory }),
+					}}
+				>
+					<StatusView />
+				</PeerProvider>,
+			);
+		});
+
+		await waitFor(
+			() =>
+				container.querySelector("[data-testid='status']")?.textContent ===
+				"connected",
+		);
+	};
 
 	it("ignores bootstrap failures after unmount", async () => {
 		const stop = vi.fn(async () => undefined);
@@ -314,6 +363,128 @@ describe("PeerProvider bootstrap handling", () => {
 		expect(consoleWarn).toHaveBeenCalledWith(
 			expect.stringContaining("Connected to 1 bootstrap peer"),
 			expect.arrayContaining([expect.stringContaining("dial timeout")]),
+		);
+	});
+
+	it("uses OPFS when eviction protection is denied", async () => {
+		await renderStorageProvider();
+
+		expect(mocks.persist).toHaveBeenCalledTimes(1);
+		expect(mocks.getDirectory).toHaveBeenCalledTimes(1);
+		expect(mocks.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				directory: "./repo/12D3KooW-test/",
+			}),
+		);
+		expect(consoleWarn).toHaveBeenCalledWith(
+			"Browser storage is not protected from eviction; continuing with OPFS-backed storage.",
+		);
+		expect((window as any).__peerInfo.persisted).toBe(false);
+	});
+
+	it("reports granted eviction protection while using OPFS", async () => {
+		mocks.persist.mockResolvedValue(true);
+
+		await renderStorageProvider();
+
+		expect(mocks.getDirectory).toHaveBeenCalledTimes(1);
+		expect(mocks.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				directory: "./repo/12D3KooW-test/",
+			}),
+		);
+		expect(consoleWarn).not.toHaveBeenCalledWith(
+			"Browser storage is not protected from eviction; continuing with OPFS-backed storage.",
+		);
+		expect((window as any).__peerInfo.persisted).toBe(true);
+	});
+
+	it("uses OPFS when requesting eviction protection throws", async () => {
+		const error = new Error("storage permission failed");
+		mocks.persist.mockRejectedValue(error);
+
+		await renderStorageProvider();
+
+		expect(mocks.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				directory: "./repo/12D3KooW-test/",
+			}),
+		);
+		expect(consoleWarn).toHaveBeenCalledWith(
+			"Failed to request protection from browser storage eviction.",
+			error,
+		);
+		expect((window as any).__peerInfo.persisted).toBe(false);
+	});
+
+	it("uses OPFS when the persistence API is unavailable", async () => {
+		Object.defineProperty(navigator, "storage", {
+			configurable: true,
+			value: { getDirectory: mocks.getDirectory },
+		});
+
+		await renderStorageProvider();
+
+		expect(mocks.persist).not.toHaveBeenCalled();
+		expect(mocks.getDirectory).toHaveBeenCalledTimes(1);
+		expect(mocks.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				directory: "./repo/12D3KooW-test/",
+			}),
+		);
+		expect((window as any).__peerInfo.persisted).toBe(false);
+	});
+
+	it("falls back to memory when OPFS cannot be opened", async () => {
+		const error = new DOMException("OPFS denied", "SecurityError");
+		mocks.getDirectory.mockRejectedValue(error);
+
+		await renderStorageProvider();
+
+		expect(mocks.create).toHaveBeenCalledWith(
+			expect.objectContaining({ directory: undefined }),
+		);
+		expect(consoleError).toHaveBeenCalledWith(
+			"Origin-private file system storage could not be opened; falling back to in-memory storage.",
+			error,
+		);
+	});
+
+	it("falls back to memory when OPFS is unavailable", async () => {
+		Object.defineProperty(navigator, "storage", {
+			configurable: true,
+			value: { persist: mocks.persist },
+		});
+
+		await renderStorageProvider();
+
+		expect(mocks.create).toHaveBeenCalledWith(
+			expect.objectContaining({ directory: undefined }),
+		);
+		expect(consoleError).toHaveBeenCalledWith(
+			"Origin-private file system storage is unavailable; falling back to in-memory storage.",
+		);
+	});
+
+	it("keeps explicit in-memory mode in memory", async () => {
+		await renderStorageProvider(true);
+
+		expect(mocks.detectIncognito).not.toHaveBeenCalled();
+		expect(mocks.persist).not.toHaveBeenCalled();
+		expect(mocks.create).toHaveBeenCalledWith(
+			expect.objectContaining({ directory: undefined }),
+		);
+	});
+
+	it("keeps private browsing mode in memory", async () => {
+		mocks.detectIncognito.mockResolvedValue({ isPrivate: true });
+
+		await renderStorageProvider();
+
+		expect(mocks.persist).not.toHaveBeenCalled();
+		expect(mocks.getDirectory).not.toHaveBeenCalled();
+		expect(mocks.create).toHaveBeenCalledWith(
+			expect.objectContaining({ directory: undefined }),
 		);
 	});
 	});


### PR DESCRIPTION
## Summary

- use OPFS-backed browser storage when the browser declines eviction protection
- probe OPFS availability and fall back to memory if it is absent or cannot be opened
- preserve explicit `inMemory` and private-browsing behavior
- add unit coverage for storage capability/error combinations and a persistent-profile reload test

## Why

`navigator.storage.persist()` controls protection from browser eviction; a `false` result does not mean OPFS is unavailable. The previous branch selected `MemoryStore` whenever the browser declined that protection, so normal browser profiles could keep large Peerbit stores in RAM and lose the repository on restart even though OPFS worked.

The React `persisted` value continues to report eviction protection. When it is false and OPFS is available, the client now uses best-effort OPFS and warns that the browser may evict the data.

## Validation

- `@peerbit/react`: 29/29 unit tests
- `@peerbit/react` build
- browser E2E application build
- persistent identity/OPFS E2E: 3/3
- changed-file ESLint and `git diff --check`
- independent review: no remaining P0-P2 findings

In an interleaved 3x3 file-share test with fresh persistent Chromium profiles and a deterministic 256 MiB fixture, all six transfers passed topology, cohort, SHA-256, CRC-32, and final-hash validation. Stock selected memory backends; this branch selected OPFS for storage, indexer, and blocks while browser eviction protection remained false.

The separate physical-footprint attribution pair reduced the writer profile peak from 2.48 GiB to 1.32 GiB and the directional combined writer+reader peak from 3.39 GiB to 2.71 GiB. OPFS has a measured upload cost: uninstrumented median upload changed from 21.52 MiB/s to 10.53 MiB/s. The live reader became essentially fully local before download, so download rates are not a like-for-like comparison; median upload-through-download time changed from 61.1 s to 42.7 s. Writer-only OPFS throughput optimization remains a follow-up.
