### PR TITLE
fix(pubsub): recover initial fanout joins

### DIFF
--- a/.changeset/calm-fanout-joins.md
+++ b/.changeset/calm-fanout-joins.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/pubsub": patch
+---
+
+Recover initial fanout joins when a direct root has not opened its shard yet or an apparently connected stream stops delivering control responses.

--- a/packages/transport/pubsub/src/fanout-tree.ts
+++ b/packages/transport/pubsub/src/fanout-tree.ts
@@ -727,6 +727,7 @@ export type FanoutTreeChannelMetrics = {
 	joinAcceptReceived: number;
 	joinRejectSent: number;
 	joinRejectReceived: number;
+	joinPeerResets: number;
 	kickSent: number;
 	kickReceived: number;
 	reparentDisconnect: number;
@@ -861,6 +862,11 @@ const PARENT_REPAIR_DEAD_STREAK_THRESHOLD = 16;
 const PARENT_REPAIR_DEAD_MIN_LIVENESS_MS = 15_000;
 const REPAIR_RETRY_MIN_MS = 1_000;
 const REPAIR_RETRY_INTERVAL_FACTOR = 5;
+// A stream can remain locally readable/writable while silently dropping every
+// control frame. Repeated unanswered JOIN requests are end-to-end evidence that
+// the peer path needs to be rebuilt.
+const JOIN_TIMEOUT_RESET_STREAK_THRESHOLD = 3;
+const JOIN_TIMEOUT_RESET_COOLDOWN_MS = 10_000;
 
 const JOIN_REJECT_REDIRECT_QUEUE_MAX = 64;
 // When a relay loses its parent, pause before trying to rejoin so its children can
@@ -1226,6 +1232,7 @@ const createEmptyMetrics = (): FanoutTreeChannelMetrics => ({
 	joinAcceptReceived: 0,
 	joinRejectSent: 0,
 	joinRejectReceived: 0,
+	joinPeerResets: 0,
 	kickSent: 0,
 	kickReceived: 0,
 	reparentDisconnect: 0,
@@ -1314,6 +1321,8 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		string,
 		FanoutTreeChannelMetrics
 	>();
+	private readonly joinTimeoutStreakByPeer = new Map<string, number>();
+	private readonly joinResetCooldownUntilByPeer = new Map<string, number>();
 	private bootstraps: Multiaddr[] = [];
 	private trackerBySuffixKey = new Map<string, Map<string, TrackerEntry>>();
 	private trackerNamespaceLru = new Map<string, number>();
@@ -1398,6 +1407,8 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			);
 			this.underlayPeerDisconnectHandler = undefined;
 		}
+		this.joinTimeoutStreakByPeer.clear();
+		this.joinResetCooldownUntilByPeer.clear();
 		return super.stop();
 	}
 
@@ -2563,6 +2574,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 
 	private onPeerDisconnectedFromUnderlay(peerHash: string) {
 		if (!peerHash) return;
+		this.joinTimeoutStreakByPeer.delete(peerHash);
 
 		// Detach from a disconnected parent immediately, so children can rejoin.
 		// This is more reliable than polling `getConnections()` because the underlay
@@ -2796,11 +2808,21 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 
 		if (!ch.joinedOnce) ch.joinedOnce = createDeferred();
 		if (!ch.joinLoop) {
-			ch.joinLoop = this._joinLoop(ch, joinOpts).catch((err) => {
-				// Surface join errors to the caller without crashing the process
-				// via an unhandled rejection (joinLoop is not generally awaited).
-				ch.joinedOnce?.reject(err);
-			});
+			const joinedOnce = ch.joinedOnce;
+			const joinLoop = this._joinLoop(ch, joinOpts)
+				.catch((err) => {
+					// Surface join errors to the caller without crashing the process
+					// via an unhandled rejection (joinLoop is not generally awaited).
+					if (ch.joinLoop === joinLoop) ch.joinLoop = undefined;
+					if (ch.joinedOnce === joinedOnce && !ch.joinedAtLeastOnce) {
+						ch.joinedOnce = undefined;
+					}
+					joinedOnce.reject(err);
+				})
+				.finally(() => {
+					if (ch.joinLoop === joinLoop) ch.joinLoop = undefined;
+				});
+			ch.joinLoop = joinLoop;
 		}
 		return ch.joinedOnce.promise;
 	}
@@ -4009,6 +4031,42 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		const idx = seq % ch.cacheSeqs.length;
 		if (ch.cacheSeqs[idx] !== (seq | 0)) return;
 		return ch.cachePayloads[idx];
+	}
+
+	private noteJoinResponse(peerHash: string) {
+		this.joinTimeoutStreakByPeer.delete(peerHash);
+	}
+
+	private noteJoinTimeout(ch: ChannelState, peerHash: string) {
+		const streak = (this.joinTimeoutStreakByPeer.get(peerHash) ?? 0) + 1;
+		if (streak < JOIN_TIMEOUT_RESET_STREAK_THRESHOLD) {
+			this.joinTimeoutStreakByPeer.set(peerHash, streak);
+			return;
+		}
+
+		this.joinTimeoutStreakByPeer.delete(peerHash);
+		const now = Date.now();
+		for (const [hash, until] of this.joinResetCooldownUntilByPeer) {
+			if (until <= now) this.joinResetCooldownUntilByPeer.delete(hash);
+		}
+		const resetCooldownUntil =
+			this.joinResetCooldownUntilByPeer.get(peerHash) ?? 0;
+		if (resetCooldownUntil > now) return;
+
+		const stream = this.peers.get(peerHash);
+		if (!stream) return;
+		this.joinResetCooldownUntilByPeer.set(
+			peerHash,
+			now + JOIN_TIMEOUT_RESET_COOLDOWN_MS,
+		);
+		ch.metrics.joinPeerResets += 1;
+		try {
+			void this.components.connectionManager
+				.closeConnections(stream.peerId)
+				.catch(() => {});
+		} catch {
+			// Best-effort reset. The join loop keeps retrying other candidates.
+		}
 	}
 
 	private async _sendControl(to: string, bytes: Uint8Array) {
@@ -5904,7 +5962,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 							? " No fanout bootstraps are configured for this channel, and the root is not a direct neighbor. If this peer reached the network via a bootstrap or relay node, initialize it with Peerbit.bootstrap(...) instead of Peerbit.dial(...), or configure FanoutTree.setBootstraps(...) before joining sharded topics."
 							: "";
 					throw new Error(
-						`fanout join timed out after ${timeoutMs}ms (topic=${ch.id.topic} root=${ch.id.root} self=${this.publicKeyHash} rootNeighbor=${rootNeighbor} peers=${this.peers.size} bootstraps=${bootstrapsCount}).${bootstrapHint}`,
+						`fanout join timed out after ${timeoutMs}ms (topic=${ch.id.topic} root=${ch.id.root} self=${this.publicKeyHash} rootNeighbor=${rootNeighbor} peers=${this.peers.size} bootstraps=${bootstrapsCount} joinReqSent=${ch.metrics.joinReqSent} joinAcceptReceived=${ch.metrics.joinAcceptReceived} joinRejectReceived=${ch.metrics.joinRejectReceived} peerResets=${ch.metrics.joinPeerResets}).${bootstrapHint}`,
 					);
 				}
 
@@ -6290,6 +6348,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 					}
 
 					if (res.timedOut) {
+						this.noteJoinTimeout(ch, c.hash);
 						try {
 							await this.sendTrackerFeedback(
 								ch,
@@ -8379,6 +8438,8 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			if (kind === MSG_JOIN_ACCEPT || kind === MSG_JOIN_REJECT) {
 				const reqId = this.codec.decodeJoinResponseReqId(data);
 				if (reqId == null) return false;
+				// Any explicit join response proves this path is alive end to end.
+				this.noteJoinResponse(fromHash);
 				const pending = ch.pendingJoin.get(reqId);
 				if (!pending) return true;
 				ch.pendingJoin.delete(reqId);

--- a/packages/transport/pubsub/src/index.ts
+++ b/packages/transport/pubsub/src/index.ts
@@ -138,6 +138,7 @@ const AUTO_TOPIC_ROOT_CANDIDATES_MAX = 64;
 // Topic-root queries may need to wait for the responder to finish opening an
 // outbound stream back to the requester after an inbound-only dial.
 const DEFAULT_TOPIC_ROOT_QUERY_TIMEOUT_MS = 12_000;
+const DIRECT_SHARD_ROOT_CONFIRM_TIMEOUT_MS = 2_000;
 
 const DEFAULT_PUBSUB_FANOUT_CHANNEL_OPTIONS: Omit<
 	FanoutTreeChannelOptions,
@@ -1217,6 +1218,7 @@ export class TopicControlPlane
 	private async queryTopicRootFromPeer(
 		peer: PeerStreams,
 		topic: string,
+		timeoutMs = DEFAULT_TOPIC_ROOT_QUERY_TIMEOUT_MS,
 	): Promise<string | undefined> {
 		if (!this.started || this.stopping) return undefined;
 
@@ -1225,7 +1227,7 @@ export class TopicControlPlane
 			const timer = setTimeout(() => {
 				this.pendingTopicRootQueries.delete(requestId);
 				resolve(undefined);
-			}, DEFAULT_TOPIC_ROOT_QUERY_TIMEOUT_MS);
+			}, Math.max(1, Math.floor(timeoutMs)));
 			timer.unref?.();
 			this.pendingTopicRootQueries.set(requestId, { topic, resolve, timer });
 		});
@@ -1245,6 +1247,33 @@ export class TopicControlPlane
 		}
 
 		return responsePromise;
+	}
+
+	private async confirmDirectShardRoot(
+		shardTopic: string,
+		root: string,
+		signal?: AbortSignal,
+	): Promise<string> {
+		if (root === this.publicKeyHash) return root;
+		const rootPeer = this.peers.get(root);
+		if (!rootPeer) return root;
+
+		const confirmation = await withAbort(
+			this.queryTopicRootFromPeer(
+				rootPeer,
+				shardTopic,
+				DIRECT_SHARD_ROOT_CONFIRM_TIMEOUT_MS,
+			),
+			signal,
+		);
+		if (!confirmation) return root;
+		if (confirmation !== root) {
+			this.shardRootCache.set(shardTopic, {
+				root: confirmation,
+				authoritative: true,
+			});
+		}
+		return confirmation;
 	}
 
 	private async resolveQueryableTopicRoot(
@@ -1333,6 +1362,7 @@ export class TopicControlPlane
 		}
 
 		root = root ?? (await this.resolveShardRoot(t));
+		root = await this.confirmDirectShardRoot(t, root, options?.signal);
 		const channel = new FanoutChannel(this.fanout, { topic: t, root });
 
 		const onPayload = (payload: Uint8Array) => {
@@ -1465,9 +1495,9 @@ export class TopicControlPlane
 					// ignore
 				}
 				try {
-					channel.close();
+					await channel.leave({ notifyParent: false, kickChildren: false });
 				} catch {
-					// ignore
+					channel.close();
 				}
 				throw error;
 			}

--- a/packages/transport/pubsub/test/fanout-tree.spec.ts
+++ b/packages/transport/pubsub/test/fanout-tree.spec.ts
@@ -1592,6 +1592,140 @@ describe("fanout-tree", () => {
 		}
 	});
 
+	it("resets an already-connected root after unanswered initial joins", async function () {
+		this.timeout(30_000);
+		const session: TestSession<{ fanout: FanoutTree }> =
+			await createFanoutTestSession(2);
+
+		try {
+			await session.connect([[session.peers[0], session.peers[1]]]);
+
+			const rootNode = session.peers[0];
+			const root = rootNode.services.fanout;
+			const leaf = session.peers[1].services.fanout;
+			const topic = "initial-join-zombie-reset";
+			const rootId = root.publicKeyHash;
+			const bootstrapAddrs = rootNode
+				.getMultiaddrs()
+				.filter((address) => !address.getComponents().some((c) => c.code === 290));
+			root.openChannel(topic, rootId, {
+				role: "root",
+				msgRate: 10,
+				msgSize: 64,
+				uploadLimitBps: 1_000_000,
+				maxChildren: 1,
+				repair: false,
+			});
+
+			const leafInternals = leaf as any;
+			await waitForResolved(() =>
+				expect(leafInternals.peers.get(rootId)).to.exist,
+			);
+			const rootPeer = leafInternals.peers.get(rootId);
+			expect(rootPeer).to.exist;
+			const connectionManager = leafInternals.components.connectionManager as any;
+			const originalSendControl = leafInternals._sendControl;
+			const originalCloseConnections =
+				connectionManager.closeConnections.bind(connectionManager);
+			let dropJoinControls = true;
+			let resetCount = 0;
+
+			leafInternals._sendControl = async (to: string, bytes: Uint8Array) => {
+				if (dropJoinControls && to === rootId) return;
+				return originalSendControl.call(leaf, to, bytes);
+			};
+			connectionManager.closeConnections = async (...args: any[]) => {
+				if (args[0]?.toString?.() === rootPeer.peerId.toString()) {
+					resetCount += 1;
+					await originalCloseConnections(...args);
+					dropJoinControls = false;
+					return;
+				}
+				return originalCloseConnections(...args);
+			};
+
+			try {
+				await leaf.joinChannel(
+					topic,
+					rootId,
+					{
+						msgRate: 10,
+						msgSize: 64,
+						uploadLimitBps: 0,
+						maxChildren: 0,
+						repair: false,
+					},
+					{
+						timeoutMs: 5_000,
+						bootstrap: bootstrapAddrs,
+						retryMs: 5,
+						joinReqTimeoutMs: 25,
+						candidateCooldownMs: 0,
+						candidateScoringMode: "ranked-strict",
+					},
+				);
+				expect(resetCount).to.equal(1);
+				expect(leaf.getChannelMetrics(topic, rootId).joinPeerResets).to.equal(1);
+				expect(leaf.getChannelStats(topic, rootId)?.parent).to.equal(rootId);
+				expect(connectionManager.getConnections(rootPeer.peerId).length).to.be.greaterThan(
+					0,
+				);
+			} finally {
+				leafInternals._sendControl = originalSendControl;
+				connectionManager.closeConnections = originalCloseConnections;
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("starts a fresh join after an initial join timeout", async function () {
+		this.timeout(30_000);
+		const session: TestSession<{ fanout: FanoutTree }> =
+			await createFanoutTestSession(2);
+
+		try {
+			await session.connect([[session.peers[0], session.peers[1]]]);
+
+			const root = session.peers[0].services.fanout;
+			const leaf = session.peers[1].services.fanout;
+			const topic = "initial-join-timeout-retry";
+			const rootId = root.publicKeyHash;
+			const channelOptions = {
+				msgRate: 10,
+				msgSize: 64,
+				uploadLimitBps: 0,
+				maxChildren: 0,
+				repair: false,
+			};
+			const joinOptions = {
+				timeoutMs: 200,
+				retryMs: 5,
+				joinReqTimeoutMs: 25,
+				candidateCooldownMs: 0,
+				candidateScoringMode: "ranked-strict" as const,
+			};
+
+			await expect(
+				leaf.joinChannel(topic, rootId, channelOptions, joinOptions),
+			).to.be.rejectedWith("fanout join timed out after 200ms");
+
+			root.openChannel(topic, rootId, {
+				...channelOptions,
+				role: "root",
+				maxChildren: 1,
+				uploadLimitBps: 1_000_000,
+			});
+			await leaf.joinChannel(topic, rootId, channelOptions, {
+				...joinOptions,
+				timeoutMs: 5_000,
+			});
+			expect(leaf.getChannelStats(topic, rootId)?.parent).to.equal(rootId);
+		} finally {
+			await session.stop();
+		}
+	});
+
 	it("keeps rejoining after the initial join timeout has elapsed", async function () {
 		this.timeout(30_000);
 		const session: TestSession<{ fanout: FanoutTree }> =

--- a/packages/transport/pubsub/test/subscribe-races.spec.ts
+++ b/packages/transport/pubsub/test/subscribe-races.spec.ts
@@ -288,6 +288,84 @@ describe("pubsub (subscribe race regressions)", function () {
 		expect(resolvedRoot).to.equal(root.publicKeyHash);
 	});
 
+	it("confirms a gateway-resolved shard with the direct root before joining", async function () {
+		this.timeout(120_000);
+
+		const TOPIC = "gateway-root-host-confirmation";
+		session = await createDisconnectedSessionWithPerPeerRoots(3);
+
+		const peers = session.peers
+			.map((node) => ({ node, pubsub: node.services.pubsub }))
+			.sort((a, b) =>
+				a.pubsub.publicKeyHash < b.pubsub.publicKeyHash
+					? -1
+					: a.pubsub.publicKeyHash > b.pubsub.publicKeyHash
+						? 1
+						: 0,
+			);
+		const gateway = peers[0]!;
+		const root = peers[1]!;
+		const leaf = peers[2]!;
+
+		await leaf.node.dial(gateway.node.getMultiaddrs()[0]!);
+		await leaf.node.dial(root.node.getMultiaddrs()[0]!);
+		await waitForNeighbour(leaf.pubsub, gateway.pubsub);
+		await waitForNeighbour(leaf.pubsub, root.pubsub);
+		await Promise.all(
+			peers.map(
+				({ pubsub }) =>
+					(pubsub as any).hostOwnedShardRootsInFlight ?? Promise.resolve(),
+			),
+		);
+
+		const shardTopic = `/peerbit/pubsub-shard/1/${topicHash32(TOPIC) % 16}`;
+		leaf.pubsub.setTopicRootCandidates([]);
+		gateway.pubsub.setTopicRootCandidates([root.pubsub.publicKeyHash]);
+		root.pubsub.setTopicRootCandidates([root.pubsub.publicKeyHash]);
+		await root.pubsub.hostShardRootsNow();
+		await ((root.pubsub as any).hostOwnedShardRootsInFlight ?? Promise.resolve());
+		await (root.pubsub as any).closeFanoutChannel(shardTopic, { force: true });
+		await delay(100);
+		expect((root.pubsub as any).fanoutChannels.get(shardTopic)).to.equal(undefined);
+		expect(
+			root.node.services.fanout.getChannelStats(
+				shardTopic,
+				root.pubsub.publicKeyHash,
+			),
+		).to.equal(undefined);
+
+		const leafInternals = leaf.pubsub as any;
+		leafInternals.shardRootCache.clear();
+		expect([...leafInternals.peers.keys()]).to.include(gateway.pubsub.publicKeyHash);
+		expect([...leafInternals.peers.keys()]).to.include(root.pubsub.publicKeyHash);
+		const originalQueryTopicRootFromPeer = leafInternals.queryTopicRootFromPeer;
+		const queriedPeers: string[] = [];
+		leafInternals.queryTopicRootFromPeer = async (...args: any[]) => {
+			queriedPeers.push(args[0].publicKey.hashcode());
+			return originalQueryTopicRootFromPeer.apply(leaf.pubsub, args);
+		};
+
+		try {
+			await leaf.pubsub.subscribe(TOPIC);
+		} finally {
+			leafInternals.queryTopicRootFromPeer = originalQueryTopicRootFromPeer;
+		}
+
+		expect(queriedPeers.slice(0, 2)).to.deep.equal([
+			gateway.pubsub.publicKeyHash,
+			root.pubsub.publicKeyHash,
+		]);
+		expect((root.pubsub as any).fanoutChannels.get(shardTopic)?.root).to.equal(
+			root.pubsub.publicKeyHash,
+		);
+		expect(
+			leaf.node.services.fanout.getChannelStats(
+				shardTopic,
+				root.pubsub.publicKeyHash,
+			)?.parent,
+		).to.equal(root.pubsub.publicKeyHash);
+	});
+
 	it("hosts a shard before answering a direct root query for itself", async function () {
 		this.timeout(120_000);
 


### PR DESCRIPTION
## Summary

- confirm a directly connected shard root before joining so gateway-resolved roots host the shard first
- reset an apparently connected peer after three unanswered JOIN requests, with peer-wide cooldown deduplication and bootstrap redial
- clear failed initial-join state and remove failed channels so explicit retries start cleanly
- include JOIN response and peer-reset counters in timeout diagnostics

This uses the existing control messages and does not change the fanout wire format.

## Validation

- dependency-inclusive `@peerbit/pubsub` build
- full `@peerbit/pubsub` Node suite: 146 passing
- deterministic gateway/root-hosting, real close/bootstrap-redial, and retry-after-timeout regressions
- changed-file ESLint: 0 errors (one pre-existing unused-import warning)
- 10/10 dual circuit/WebRTC file-share browser transfers passed with persistent OPFS, live replication, topology/cohort validation, and SHA integrity
- independent review: no P0-P2 findings