### PR TITLE
fix(pubsub): reset failed fanout kicks

### DIFF
--- a/.changeset/brisk-fanout-kicks.md
+++ b/.changeset/brisk-fanout-kicks.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/pubsub": patch
+---
+
+Reset peer connections when fanout KICK control delivery fails so removed children cannot retain a stale parent.

--- a/packages/transport/pubsub/src/fanout-tree.ts
+++ b/packages/transport/pubsub/src/fanout-tree.ts
@@ -4081,17 +4081,17 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 	}
 
 	private async _sendControlMany(to: string[], bytes: Uint8Array) {
-		if (to.length === 0) return;
+		if (to.length === 0) return true;
 		const streams = to
 			.map((t) => this.peers.get(t))
 			.filter((s): s is PeerStreams => Boolean(s));
-		if (streams.length === 0) return;
+		if (streams.length === 0) return false;
 		this.recordControlSend(bytes, streams.length);
 		const message = await this.createMessage(bytes, {
 			mode: new AnyWhere(),
 			priority: CONTROL_PRIORITY,
 		} as any);
-		await this.publishMessageMaybe(this.publicKey, message, streams);
+		return this.publishMessageMaybe(this.publicKey, message, streams);
 	}
 
 	private refillUploadTokens(ch: ChannelState, now = Date.now()) {
@@ -7603,7 +7603,11 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		const resetPeerConnections = options?.resetPeerConnections === true;
 		let kickFailed = false;
 		try {
-			await this._sendControlMany(unique, this.codec.encodeKick(ch.id.key));
+			const kickDelivered = await this._sendControlMany(
+				unique,
+				this.codec.encodeKick(ch.id.key),
+			);
+			kickFailed = !kickDelivered;
 		} catch (error) {
 			kickFailed = true;
 			throw error;

--- a/packages/transport/pubsub/test/fanout-tree.spec.ts
+++ b/packages/transport/pubsub/test/fanout-tree.spec.ts
@@ -284,6 +284,74 @@ describe("fanout-tree", () => {
 		}
 	});
 
+	it("resets a kicked child connection when control delivery returns false", async () => {
+		const session: TestSession<{ fanout: FanoutTree }> =
+			await createFanoutTestSession(2);
+
+		try {
+			await session.connect([[session.peers[0], session.peers[1]]]);
+
+			const root = session.peers[0].services.fanout;
+			const child = session.peers[1].services.fanout;
+			const rootInternals = root as any;
+			const childHash = child.publicKeyHash;
+			await waitForResolved(
+				() => expect(rootInternals.peers.get(childHash)).to.exist,
+			);
+
+			const id = root.openChannel("kick-delivery-failure", root.publicKeyHash, {
+				role: "root",
+				msgRate: 1,
+				msgSize: 8,
+				uploadLimitBps: 1_000_000,
+				maxChildren: 1,
+				repair: false,
+			});
+			const ch = rootInternals.channelsBySuffixKey.get(id.suffixKey);
+			expect(ch).to.exist;
+			ch.children.set(childHash, { bidPerByte: 0 });
+
+			const connectionManager = rootInternals.components
+				.connectionManager as any;
+			const originalPublishMessageMaybe = root.publishMessageMaybe;
+			const originalCloseConnections = connectionManager.closeConnections;
+			const closedPeerIds: string[] = [];
+
+			root.publishMessageMaybe = (async () =>
+				false) as typeof root.publishMessageMaybe;
+			connectionManager.closeConnections = async (peerId: any) => {
+				closedPeerIds.push(peerId.toString());
+			};
+
+			try {
+				await rootInternals.kickChildHashes(ch, [childHash], {
+					resetPeerConnections: true,
+				});
+				expect(closedPeerIds).to.deep.equal([
+					rootInternals.peers.get(childHash).peerId.toString(),
+				]);
+				expect(ch.children.has(childHash)).to.equal(false);
+
+				ch.children.set(childHash, { bidPerByte: 0 });
+				root.publishMessageMaybe = (async () => {
+					throw new Error("unexpected control publish failure");
+				}) as typeof root.publishMessageMaybe;
+
+				await expect(
+					rootInternals.kickChildHashes(ch, [childHash], {
+						resetPeerConnections: true,
+					}),
+				).to.be.rejectedWith("unexpected control publish failure");
+				expect(closedPeerIds).to.have.length(2);
+			} finally {
+				root.publishMessageMaybe = originalPublishMessageMaybe;
+				connectionManager.closeConnections = originalCloseConnections;
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
 	it("forms a small tree and delivers data", async () => {
 		const session: TestSession<{ fanout: FanoutTree }> =
 			await createFanoutTestSession(3);


### PR DESCRIPTION
## Summary

- propagate normal fanout control-delivery failures instead of silently treating them as success
- reset a kicked child connection when the KICK cannot be delivered, preventing stale parent attachment
- add deterministic coverage for false-without-throw and thrown control publish failures
- add an @peerbit/pubsub patch changeset

## Validation

- focused regression: 1 passing
- full @peerbit/pubsub suite: 147 passing
- TypeScript build: passing
- changed-file ESLint: passing
- git diff --check: passing

Follow-up to #1043.