### PR TITLE
fix(stream): reject writes to closed peers

### DIFF
--- a/.changeset/closed-stream-writes.md
+++ b/.changeset/closed-stream-writes.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/stream": patch
+---
+
+Reject direct and queued writes to closed peer streams, including writes that were waiting for outbound queue capacity when the stream closed.

--- a/packages/transport/stream/src/index.ts
+++ b/packages/transport/stream/src/index.ts
@@ -624,6 +624,11 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 	 * Throws if there is no `stream` to write to available.
 	 */
 	write(data: Uint8Array | Uint8ArrayList, priority: number) {
+		if (this.closed) {
+			logger.error(`Failed to send to stream ${this.peerId}: closed`);
+			throw new AbortError("Closed");
+		}
+
 		if (data.length > MAX_DATA_LENGTH_OUT) {
 			throw new Error(
 				`Message too large (${data.length * 1e-6}) mb). Needs to be less than ${
@@ -709,12 +714,12 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 		priority = 0,
 		signal?: AbortSignal,
 	) {
-		if (this.closed) {
-			logger.error(`Failed to send to stream ${this.peerId}: closed`);
-			return;
-		}
-
 		while (true) {
+			if (this.closed) {
+				logger.error(`Failed to send to stream ${this.peerId}: closed`);
+				throw new AbortError("Closed");
+			}
+
 			if (!this.isWritable) {
 				// Outbound stream negotiation can legitimately take several seconds in CI
 				// (identify/protocol discovery, resource contention, etc). Keep this fairly
@@ -759,6 +764,9 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 					// Catch a race where writability flips after the first check.
 					if (this.isWritable) onOutbound();
 				});
+
+				// Re-enter through the lifecycle check before attempting the write.
+				continue;
 			}
 
 			try {

--- a/packages/transport/stream/test/priority-lanes.spec.ts
+++ b/packages/transport/stream/test/priority-lanes.spec.ts
@@ -1,6 +1,6 @@
 import { type PeerId } from "@libp2p/interface";
 import { Ed25519Keypair } from "@peerbit/crypto";
-import { delay, waitForResolved } from "@peerbit/time";
+import { AbortError, delay, waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
 import { PeerStreams } from "../src/index.js";
 
@@ -166,5 +166,106 @@ describe("priority lanes", () => {
 
 		await blockedLow;
 		await streams.close();
+	});
+
+	it("rejects a capacity-blocked write when the peer stream closes", async () => {
+		const keypair = await Ed25519Keypair.create();
+		const streams = new PeerStreams({
+			peerId: { toString: () => "test-peer" } as unknown as PeerId,
+			publicKey: keypair.publicKey,
+			protocol: "/test",
+			connId: "test-conn",
+			outboundQueue: {
+				maxBufferedBytes: 1,
+				reservedPriorityBytes: 0,
+			},
+		});
+
+		const outbound = new TestOutboundStream();
+		await streams.attachOutboundStream(outbound as any);
+
+		// Keep the raw stream blocked after its first frame, then fill the one-byte
+		// outbound queue behind it.
+		await streams.waitForWrite(new Uint8Array([1]), 0);
+		await waitForResolved(() =>
+			expect(outbound.sentPayloads).to.deep.equal([1]),
+		);
+		await streams.waitForWrite(new Uint8Array([2]), 0);
+		expect(streams.getOutboundQueuedBytes()).to.equal(1);
+
+		// Observe entry into the real capacity waiter so closing cannot race with
+		// the setup of this regression.
+		const queue = streams._getActiveOutboundPushable()!;
+		const originalOnBufferedBelow = queue.onBufferedBelow.bind(queue);
+		let capacityWaitStartedResolve!: () => void;
+		const capacityWaitStarted = new Promise<void>((resolve) => {
+			capacityWaitStartedResolve = resolve;
+		});
+		queue.onBufferedBelow = (limitBytes, options) => {
+			capacityWaitStartedResolve();
+			return originalOnBufferedBelow(limitBytes, options);
+		};
+
+		const blockedResult: Promise<unknown | undefined> = streams
+			.waitForWrite(new Uint8Array([3]), 0)
+			.then(
+				(): undefined => undefined,
+				(error: unknown): unknown => error,
+			);
+		await capacityWaitStarted;
+
+		await streams.close();
+		expect(await blockedResult).to.be.instanceOf(AbortError);
+	});
+
+	it("rechecks closure after outbound readiness wakes a write", async () => {
+		const keypair = await Ed25519Keypair.create();
+		const streams = new PeerStreams({
+			peerId: { toString: () => "test-peer" } as unknown as PeerId,
+			publicKey: keypair.publicKey,
+			protocol: "/test",
+			connId: "test-conn",
+		});
+
+		const writeResult: Promise<unknown | undefined> = streams
+			.waitForWrite(new Uint8Array([1]), 0)
+			.then(
+				(): undefined => undefined,
+				(error: unknown): unknown => error,
+			);
+
+		// waitForWrite registers its outbound listener synchronously. Wake that
+		// listener, then close before its promise continuation can run. The ended
+		// pushable must not make the pending write look successful.
+		const outbound = new TestOutboundStream();
+		const attaching = streams.attachOutboundStream(outbound as any);
+		const closing = streams.close();
+
+		await attaching;
+		await closing;
+		expect(await writeResult).to.be.instanceOf(AbortError);
+		expect(outbound.sentPayloads).to.deep.equal([]);
+	});
+
+	it("rejects a direct write while the peer stream is closing", async () => {
+		const keypair = await Ed25519Keypair.create();
+		const streams = new PeerStreams({
+			peerId: { toString: () => "test-peer" } as unknown as PeerId,
+			publicKey: keypair.publicKey,
+			protocol: "/test",
+			connId: "test-conn",
+		});
+
+		const outbound = new TestOutboundStream();
+		await streams.attachOutboundStream(outbound as any);
+
+		// close() marks the PeerStreams closed and ends its pushable before its
+		// first await. A direct write in that interval must not count the ended
+		// queue's no-op push as a successful delivery.
+		const closing = streams.close();
+		expect(() => streams.write(new Uint8Array([1]), 0)).to.throw(AbortError);
+
+		await closing;
+		expect(outbound.sentPayloads).to.deep.equal([]);
 	});
 });

--- a/packages/transport/stream/test/stream.spec.ts
+++ b/packages/transport/stream/test/stream.spec.ts
@@ -2968,6 +2968,37 @@ describe("streams", function () {
 					}
 				}
 			});
+
+			it("publishMessageMaybe returns false for an explicitly targeted closed stream", async () => {
+				const isolated = await disconnected(1, {
+					services: {
+						directstream: (c) =>
+							new TestDirectStream(c, { connectionManager: false }),
+					},
+				});
+
+				try {
+					const writer = stream(isolated, 0) as TestDirectStream;
+					const remoteKey = await Ed25519Keypair.create();
+					const peer = writer.addPeer(
+						{ toString: () => "closed-peer" } as PeerId,
+						remoteKey.publicKey,
+						"/test/0.0.0",
+						"conn-closed",
+					);
+					const message = await writer.createMessage(crypto.randomBytes(32), {
+						mode: new AnyWhere(),
+					});
+
+					await peer.close();
+
+					await expect(
+						writer.publishMessageMaybe(writer.publicKey, message, [peer]),
+					).to.eventually.equal(false);
+				} finally {
+					await isolated.stop();
+				}
+			});
 		});
 
 		describe("limits", () => {


### PR DESCRIPTION
## Summary

- reject direct and queued writes once a peer stream is closed instead of silently treating ended-queue pushes as success
- recheck stream lifecycle after outbound readiness and queue-capacity waits before writing
- make explicit AnyWhere publishMessageMaybe return false for a closed target
- cover pre-closed, close-while-capacity-blocked, readiness-wake/close, and direct close-in-flight races
- add an @peerbit/stream patch changeset

This changes local stream lifecycle/error handling only; it does not change the wire format or network protocol.

## Validation

- four exact close-race regressions: passing
- relevant stream test group: 8 passing
- direct @peerbit/stream suite: 169 passing; one unrelated temporary crypto-import fixture requires unavailable libsodium-wrappers
- dependency-inclusive seven-project build: passing
- changed-file ESLint: passing
- git diff --check: passing

Follow-up to #1044.