### PR TITLE
fix(program): persist remotely loaded manifests

### DIFF
--- a/.changeset/fresh-program-restarts.md
+++ b/.changeset/fresh-program-restarts.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/program": patch
+---
+
+Persist remotely loaded program manifests so their addresses can reopen from local storage after providers disconnect.

--- a/packages/clients/peerbit/test/shared-program.spec.ts
+++ b/packages/clients/peerbit/test/shared-program.spec.ts
@@ -1,6 +1,9 @@
 import { field, variant } from "@dao-xyz/borsh";
 import { Program } from "@peerbit/program";
 import { expect } from "chai";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
 import { Peerbit } from "../src/peer.js";
 
 @variant("test-shared_nested")
@@ -151,4 +154,48 @@ describe(`shared`, () => {
 	// TODO add tests and define behaviour for cross topic programs
 	// TODO add tests for shared subprogams
 	// TODO add tests for subprograms that is also open as root program
+});
+
+describe("remote program persistence", () => {
+	let writer: Peerbit | undefined;
+	let reader: Peerbit | undefined;
+	let directory: string | undefined;
+
+	afterEach(async () => {
+		await reader?.stop();
+		await writer?.stop();
+		if (directory) {
+			await fs.rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("reopens an address locally after its provider stops", async function () {
+		this.timeout(30_000);
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-program-restart-"),
+		);
+		writer = await Peerbit.create();
+		reader = await Peerbit.create({ directory });
+		await reader.dial(writer.getMultiaddrs()[0]!);
+
+		const source = await writer.open(new TestProgram(7));
+		expect(await reader.services.blocks.has(source.address)).to.be.false;
+
+		const loaded = await reader.open<TestProgram>(source.address, {
+			timeout: 10_000,
+		});
+		expect(loaded.id).to.equal(7);
+		expect(await reader.services.blocks.has(source.address)).to.be.true;
+
+		await reader.stop();
+		reader = undefined;
+		await writer.stop();
+		writer = undefined;
+
+		reader = await Peerbit.create({ directory });
+		const reopened = await reader.open<TestProgram>(source.address, {
+			timeout: 100,
+		});
+		expect(reopened.id).to.equal(7);
+	});
 });

--- a/packages/programs/program/program/src/program.ts
+++ b/packages/programs/program/program/src/program.ts
@@ -905,6 +905,7 @@ export abstract class Program<
 			remote: {
 				timeout: options?.timeout,
 				priority: 1,
+				replicate: true,
 			},
 		});
 		if (!bytes) {


### PR DESCRIPTION
## Summary
- retain CID-verified manifests fetched while opening remote programs
- prove a disk-backed peer can reopen the address after its provider stops
- add a patch changeset for `@peerbit/program`

## Validation
- focused remote persistence regression
- full `@peerbit/program` test suite (69 passing)
- full Peerbit client node suite (67 passing, 1 pending)
- workspace build
- ESLint on changed files
- `git diff --check`