### PR TITLE
fix(peerbit): fall back when bootstrap discovery fails

### DIFF
--- a/.changeset/bright-relays-return.md
+++ b/.changeset/bright-relays-return.md
@@ -1,0 +1,5 @@
+---
+"peerbit": patch
+---
+
+Validate public bootstrap lists and fall back to the canonical repository source when the custom discovery endpoint is unavailable.

--- a/packages/clients/peerbit/package.json
+++ b/packages/clients/peerbit/package.json
@@ -80,6 +80,7 @@
 		"@libp2p/webrtc": "^6.0.15",
 		"@libp2p/websockets": "^10.1.7",
 		"@multiformats/multiaddr": "^13.0.1",
+		"@multiformats/multiaddr-matcher": "^3.0.1",
 		"@peerbit/any-store": "workspace:*",
 		"@peerbit/any-store-opfs": "workspace:*",
 		"@peerbit/blocks": "workspace:*",

--- a/packages/clients/peerbit/src/bootstrap.ts
+++ b/packages/clients/peerbit/src/bootstrap.ts
@@ -1,18 +1,263 @@
 import { type Multiaddr, multiaddr } from "@multiformats/multiaddr";
+import {
+	Circuit,
+	DNSADDR,
+	TCP,
+	WebRTC,
+	WebSockets,
+	WebSocketsSecure,
+} from "@multiformats/multiaddr-matcher";
+
+const BOOTSTRAP_LIST_FETCH_TIMEOUT_MS = 10_000;
+const MAX_BOOTSTRAP_LIST_BYTES = 64 * 1024;
+const MAX_BOOTSTRAP_LIST_LINES = 512;
+const MAX_BOOTSTRAP_ADDRESS_COUNT = 256;
+
+const hasRemoteEndpoint = (address: Multiaddr): boolean =>
+	!address
+		.getComponents()
+		.some(
+			(component) =>
+				(component.name === "tcp" && component.value === "0") ||
+				(component.name === "ip4" && component.value === "0.0.0.0") ||
+				(component.name === "ip6" && component.value === "::"),
+		);
+
+const hasDatagramTransport = (address: Multiaddr): boolean =>
+	address
+		.getComponents()
+		.some((component) =>
+			["udp", "quic", "quic-v1", "webtransport", "webrtc-direct"].includes(
+				component.name,
+			),
+		);
+
+const isWebSocketTarget = (address: Multiaddr): boolean =>
+	!hasDatagramTransport(address) && WebSockets.exactMatch(address);
+
+const isSecureWebSocketTarget = (address: Multiaddr): boolean =>
+	!hasDatagramTransport(address) && WebSocketsSecure.exactMatch(address);
+
+const hasDefaultDirectPrefix = (address: Multiaddr): boolean =>
+	!hasDatagramTransport(address) &&
+	(DNSADDR.matches(address) ||
+		TCP.matches(address) ||
+		WebSockets.matches(address) ||
+		WebSocketsSecure.matches(address));
+
+const hasBrowserSafeDirectPrefix = (address: Multiaddr): boolean =>
+	!hasDatagramTransport(address) &&
+	(DNSADDR.matches(address) || WebSocketsSecure.matches(address));
+
+const hasCircuitPeerIds = (address: Multiaddr): boolean => {
+	const components = address.getComponents();
+	const circuitIndex = components.findIndex(
+		(component) => component.name === "p2p-circuit",
+	);
+	return (
+		circuitIndex >= 0 &&
+		components
+			.slice(0, circuitIndex)
+			.some((component) => component.name === "p2p") &&
+		components
+			.slice(circuitIndex + 1)
+			.some((component) => component.name === "p2p")
+	);
+};
+
+const classifyBootstrapAddress = (
+	address: Multiaddr,
+): { supported: boolean; crossRuntime: boolean } => {
+	if (!hasRemoteEndpoint(address)) {
+		return { supported: false, crossRuntime: false };
+	}
+
+	const direct =
+		DNSADDR.exactMatch(address) ||
+		TCP.exactMatch(address) ||
+		isWebSocketTarget(address) ||
+		isSecureWebSocketTarget(address);
+	const circuit =
+		hasCircuitPeerIds(address) &&
+		Circuit.exactMatch(address) &&
+		hasDefaultDirectPrefix(address);
+	const webRTC =
+		hasCircuitPeerIds(address) &&
+		WebRTC.exactMatch(address) &&
+		hasBrowserSafeDirectPrefix(address);
+	const crossRuntime =
+		DNSADDR.exactMatch(address) ||
+		isSecureWebSocketTarget(address) ||
+		(circuit && hasBrowserSafeDirectPrefix(address));
+
+	return { supported: direct || circuit || webRTC, crossRuntime };
+};
+
+const getBootstrapListSources = (v: string): string[] => {
+	const file = `bootstrap${v ? "-" + encodeURIComponent(v) : ""}.env`;
+	return [
+		`https://bootstrap.peerbit.org/${file}`,
+		`https://raw.githubusercontent.com/dao-xyz/peerbit-bootstrap/master/${file}`,
+	];
+};
+
+const parseBootstrapAddresses = (value: string): string[] => {
+	const lines = value.split(/\r?\n/);
+	if (lines.length > MAX_BOOTSTRAP_LIST_LINES) {
+		throw new Error(
+			`Bootstrap list has too many lines (${lines.length} > ${MAX_BOOTSTRAP_LIST_LINES})`,
+		);
+	}
+
+	const addresses = lines
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0 && !line.startsWith("#"));
+
+	if (addresses.length === 0) {
+		throw new Error("Bootstrap list is empty");
+	}
+	if (addresses.length > MAX_BOOTSTRAP_ADDRESS_COUNT) {
+		throw new Error(
+			`Bootstrap list has too many addresses (${addresses.length} > ${MAX_BOOTSTRAP_ADDRESS_COUNT})`,
+		);
+	}
+
+	const canonicalAddresses: string[] = [];
+	let hasCrossRuntimeAddress = false;
+	for (const address of addresses) {
+		let parsed: Multiaddr;
+		try {
+			parsed = multiaddr(address);
+		} catch {
+			continue;
+		}
+		const classification = classifyBootstrapAddress(parsed);
+		if (!classification.supported) {
+			continue;
+		}
+		hasCrossRuntimeAddress ||= classification.crossRuntime;
+		canonicalAddresses.push(parsed.toString());
+	}
+	if (canonicalAddresses.length === 0) {
+		throw new Error("Bootstrap list has no supported dial targets");
+	}
+	if (!hasCrossRuntimeAddress) {
+		throw new Error(
+			"Bootstrap list has no browser-safe cross-runtime dial target",
+		);
+	}
+
+	return [...new Set(canonicalAddresses)];
+};
+
+const readBootstrapList = async (response: Response): Promise<string> => {
+	const declaredLength = response.headers.get("content-length");
+	if (declaredLength != null) {
+		if (!/^\d+$/.test(declaredLength)) {
+			throw new Error(
+				`Invalid bootstrap list Content-Length: ${declaredLength}`,
+			);
+		}
+		const length = Number(declaredLength);
+		if (!Number.isSafeInteger(length) || length > MAX_BOOTSTRAP_LIST_BYTES) {
+			throw new Error(
+				`Bootstrap list is too large (${declaredLength} > ${MAX_BOOTSTRAP_LIST_BYTES} bytes)`,
+			);
+		}
+	}
+
+	if (!response.body) {
+		return "";
+	}
+
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder("utf-8", { fatal: true });
+	let bytesRead = 0;
+	let value = "";
+	let completed = false;
+	try {
+		while (true) {
+			const chunk = await reader.read();
+			if (chunk.done) {
+				break;
+			}
+			bytesRead += chunk.value.byteLength;
+			if (bytesRead > MAX_BOOTSTRAP_LIST_BYTES) {
+				throw new Error(
+					`Bootstrap list is too large (${bytesRead} > ${MAX_BOOTSTRAP_LIST_BYTES} bytes)`,
+				);
+			}
+			value += decoder.decode(chunk.value, { stream: true });
+		}
+		value += decoder.decode();
+		completed = true;
+		return value;
+	} finally {
+		if (!completed) {
+			await reader
+				.cancel("Bootstrap list read did not complete")
+				.catch(() => {});
+		}
+		reader.releaseLock();
+	}
+};
+
+const fetchBootstrapAddresses = async (source: string): Promise<string[]> => {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => {
+		controller.abort(
+			new Error(
+				`Timed out fetching bootstrap list after ${BOOTSTRAP_LIST_FETCH_TIMEOUT_MS} ms`,
+			),
+		);
+	}, BOOTSTRAP_LIST_FETCH_TIMEOUT_MS);
+
+	let response: Response | undefined;
+	try {
+		response = await fetch(source, { signal: controller.signal });
+		if (!response.ok) {
+			throw new Error(
+				`Bootstrap list returned HTTP ${response.status}${
+					response.statusText ? ` ${response.statusText}` : ""
+				}`,
+			);
+		}
+		return parseBootstrapAddresses(await readBootstrapList(response));
+	} catch (error) {
+		if (response?.body && !response.body.locked) {
+			await response.body.cancel(error).catch(() => {});
+		}
+		if (!controller.signal.aborted) {
+			controller.abort(error);
+		}
+		throw error;
+	} finally {
+		clearTimeout(timeout);
+	}
+};
 
 export const resolveBootstrapAddresses = async (
 	v: string = "5",
 ): Promise<string[]> => {
-	// Bootstrap addresses for network
-	return (
-		await (
-			await fetch(
-				`https://bootstrap.peerbit.org/bootstrap${v ? "-" + v : ""}.env`,
-			)
-		).text()
-	)
-		.split(/\r?\n/)
-		.filter((x) => x.length > 0);
+	const failures: Error[] = [];
+	for (const source of getBootstrapListSources(v)) {
+		try {
+			return await fetchBootstrapAddresses(source);
+		} catch (error) {
+			failures.push(
+				new Error(
+					`Failed to load bootstrap addresses from ${source}: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				),
+			);
+		}
+	}
+
+	throw new AggregateError(
+		failures,
+		`Failed to resolve bootstrap addresses for network version ${v || "default"}`,
+	);
 };
 
 export const getBootstrapPeerId = (
@@ -20,8 +265,13 @@ export const getBootstrapPeerId = (
 ): string | undefined => {
 	try {
 		const parsed = typeof address === "string" ? multiaddr(address) : address;
-		return parsed.getComponents().find((component) => component.name === "p2p")
-			?.value;
+		const components = parsed.getComponents();
+		for (let index = components.length - 1; index >= 0; index--) {
+			if (components[index].name === "p2p") {
+				return components[index].value;
+			}
+		}
+		return undefined;
 	} catch {
 		return undefined;
 	}

--- a/packages/clients/peerbit/test/bootstrap-addresses.spec.ts
+++ b/packages/clients/peerbit/test/bootstrap-addresses.spec.ts
@@ -300,7 +300,7 @@ describe("resolveBootstrapAddresses", () => {
 				return new Response(`${addressA}\n`, { status: 200 });
 			}) as typeof fetch;
 			const fallbackResult = resolveBootstrapAddresses();
-			await clock.nextAsync();
+			clock.tick(10_000);
 			await secondRequestStarted;
 			expect(requestCount).to.equal(2);
 			expect(await fallbackResult).to.deep.equal([addressA]);
@@ -321,10 +321,10 @@ describe("resolveBootstrapAddresses", () => {
 			const failedResult = resolveBootstrapAddresses().catch((error) => {
 				failure = error;
 			});
-			await clock.nextAsync();
+			clock.tick(10_000);
 			await secondFailedRequestStarted;
 			expect(failedRequestCount).to.equal(2);
-			await clock.nextAsync();
+			clock.tick(10_000);
 			await failedResult;
 			expect(failure).to.be.instanceOf(AggregateError);
 			expect((failure as AggregateError).errors).to.have.length(2);

--- a/packages/clients/peerbit/test/bootstrap-addresses.spec.ts
+++ b/packages/clients/peerbit/test/bootstrap-addresses.spec.ts
@@ -266,7 +266,10 @@ describe("resolveBootstrapAddresses", () => {
 	});
 
 	it("aborts hanging sources before falling back or aggregating failures", async () => {
-		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+		const clock = sinon.useFakeTimers({
+			shouldClearNativeTimers: true,
+			toFake: ["setTimeout", "clearTimeout"],
+		});
 		const waitForAbort = (init?: RequestInit): Promise<Response> =>
 			new Promise((_resolve, reject) => {
 				const signal = init?.signal;
@@ -284,27 +287,45 @@ describe("resolveBootstrapAddresses", () => {
 
 		try {
 			let requestCount = 0;
+			let resolveSecondRequest!: () => void;
+			const secondRequestStarted = new Promise<void>((resolve) => {
+				resolveSecondRequest = resolve;
+			});
 			globalThis.fetch = (async (_input, init) => {
 				requestCount += 1;
-				return requestCount === 1
-					? waitForAbort(init)
-					: new Response(`${addressA}\n`, { status: 200 });
+				if (requestCount === 1) {
+					return waitForAbort(init);
+				}
+				resolveSecondRequest();
+				return new Response(`${addressA}\n`, { status: 200 });
 			}) as typeof fetch;
 			const fallbackResult = resolveBootstrapAddresses();
-			await clock.tickAsync(10_000);
-			expect(await fallbackResult).to.deep.equal([addressA]);
+			await clock.nextAsync();
+			await secondRequestStarted;
 			expect(requestCount).to.equal(2);
+			expect(await fallbackResult).to.deep.equal([addressA]);
 
-			globalThis.fetch = (async (_input, init) =>
-				waitForAbort(init)) as typeof fetch;
-			const failedResult = resolveBootstrapAddresses();
-			await clock.tickAsync(20_000);
+			let failedRequestCount = 0;
+			let resolveSecondFailedRequest!: () => void;
+			const secondFailedRequestStarted = new Promise<void>((resolve) => {
+				resolveSecondFailedRequest = resolve;
+			});
+			globalThis.fetch = (async (_input, init) => {
+				failedRequestCount += 1;
+				if (failedRequestCount === 2) {
+					resolveSecondFailedRequest();
+				}
+				return waitForAbort(init);
+			}) as typeof fetch;
 			let failure: unknown;
-			try {
-				await failedResult;
-			} catch (error) {
+			const failedResult = resolveBootstrapAddresses().catch((error) => {
 				failure = error;
-			}
+			});
+			await clock.nextAsync();
+			await secondFailedRequestStarted;
+			expect(failedRequestCount).to.equal(2);
+			await clock.nextAsync();
+			await failedResult;
 			expect(failure).to.be.instanceOf(AggregateError);
 			expect((failure as AggregateError).errors).to.have.length(2);
 			for (const error of (failure as AggregateError).errors) {

--- a/packages/clients/peerbit/test/bootstrap-addresses.spec.ts
+++ b/packages/clients/peerbit/test/bootstrap-addresses.spec.ts
@@ -1,9 +1,17 @@
-import { expect } from "chai";
 import { multiaddr } from "@multiformats/multiaddr";
+import { expect } from "chai";
+import sinon from "sinon";
 import {
 	getBootstrapPeerId,
 	resolveBootstrapAddresses,
 } from "../src/bootstrap.js";
+
+const peerIdA = "12D3KooWKj1J1hHxrYyB37qDDGCi9aU2vcHzDZhtMk7te7dEmqqT";
+const peerIdB = "12D3KooWAYyiQBc1ti51riCkNX6Nvh33pWWvNfyrcPHrq373qCju";
+const addressA = `/dns4/node-a.peerchecker.com/tcp/4003/wss/p2p/${peerIdA}`;
+const addressB = `/dns4/node-b.peerchecker.com/tcp/4003/wss/p2p/${peerIdB}`;
+const circuitAddress = `/dns4/relay.peerchecker.com/tcp/443/wss/p2p/${peerIdA}/p2p-circuit/p2p/${peerIdB}`;
+const webRTCAddress = `/dns4/relay.peerchecker.com/tcp/443/wss/p2p/${peerIdA}/p2p-circuit/webrtc/p2p/${peerIdB}`;
 
 describe("resolveBootstrapAddresses", () => {
 	const originalFetch = globalThis.fetch;
@@ -22,20 +30,14 @@ describe("resolveBootstrapAddresses", () => {
 						? input.toString()
 						: input.url,
 			);
-			return new Response(
-				"/dns4/node-a.peerchecker.com/tcp/4003/wss/p2p/12D3KooA\n\n/dns4/node-b.peerchecker.com/tcp/4003/wss/p2p/12D3KooB\n",
-				{ status: 200 },
-			);
+			return new Response(`${addressA}\n\n${addressB}\n`, { status: 200 });
 		}) as typeof fetch;
 
 		const result = await resolveBootstrapAddresses();
 		expect(requested).to.deep.equal([
 			"https://bootstrap.peerbit.org/bootstrap-5.env",
 		]);
-		expect(result).to.deep.equal([
-			"/dns4/node-a.peerchecker.com/tcp/4003/wss/p2p/12D3KooA",
-			"/dns4/node-b.peerchecker.com/tcp/4003/wss/p2p/12D3KooB",
-		]);
+		expect(result).to.deep.equal([addressA, addressB]);
 	});
 
 	it("uses an explicit version override", async () => {
@@ -48,7 +50,7 @@ describe("resolveBootstrapAddresses", () => {
 						? input.toString()
 						: input.url,
 			);
-			return new Response("", { status: 200 });
+			return new Response(`${addressA}\n`, { status: 200 });
 		}) as typeof fetch;
 
 		await resolveBootstrapAddresses("4");
@@ -56,28 +58,306 @@ describe("resolveBootstrapAddresses", () => {
 			"https://bootstrap.peerbit.org/bootstrap-4.env",
 		]);
 	});
+
+	it("falls back to the canonical repository when the public endpoint is unavailable", async () => {
+		const requested: string[] = [];
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			const url =
+				typeof input === "string"
+					? input
+					: input instanceof URL
+						? input.toString()
+						: input.url;
+			requested.push(url);
+			if (url.startsWith("https://bootstrap.peerbit.org/")) {
+				throw new TypeError("fetch failed");
+			}
+			return new Response(`${addressA}\n`, { status: 200 });
+		}) as typeof fetch;
+
+		const result = await resolveBootstrapAddresses();
+		expect(requested).to.deep.equal([
+			"https://bootstrap.peerbit.org/bootstrap-5.env",
+			"https://raw.githubusercontent.com/dao-xyz/peerbit-bootstrap/master/bootstrap-5.env",
+		]);
+		expect(result).to.deep.equal([addressA]);
+	});
+
+	it("rejects unusable content before accepting a fallback list", async () => {
+		let requestCount = 0;
+		globalThis.fetch = (async () => {
+			requestCount += 1;
+			return requestCount === 1
+				? new Response("<html>not a bootstrap list</html>", { status: 200 })
+				: new Response(`# current relays\n${addressA}\n${addressA}\n`, {
+						status: 200,
+					});
+		}) as typeof fetch;
+
+		expect(await resolveBootstrapAddresses()).to.deep.equal([addressA]);
+		expect(requestCount).to.equal(2);
+	});
+
+	it("rejects addresses the default transports cannot dial", async () => {
+		const unsupportedAddresses = [
+			`/p2p/${peerIdA}`,
+			"/dns4/bootstrap.example.com",
+			"/tcp/4003",
+			"/tcp/4003/dns4/bootstrap.example.com",
+			`/ws/p2p/${peerIdA}`,
+			`/dns4/bootstrap.example.com/p2p/${peerIdA}/tcp/4003`,
+			"/p2p-circuit",
+			"/webrtc",
+			`/p2p/${peerIdA}/p2p-circuit/p2p/${peerIdB}`,
+			`/dns4/relay.example.com/tcp/443/wss/p2p-circuit/p2p/${peerIdB}`,
+			`/dns4/relay.example.com/tcp/443/wss/p2p-circuit/webrtc/p2p/${peerIdB}`,
+			`/dns4/relay.example.com/tcp/443/wss/p2p/${peerIdA}/p2p-circuit`,
+			"/ip4/127.0.0.1/udp/4001",
+			"/ip4/127.0.0.1/udp/4001/quic-v1",
+			"/ip4/127.0.0.1/udp/443/webtransport",
+			"/ip4/1.2.3.4/udp/443/wss",
+			"/ip4/1.2.3.4/udp/443/quic-v1/wss",
+			"/dns4/bootstrap.example.com/udp/4001/tcp/4003/quic-v1",
+			"/dns4/bootstrap.example.com/tcp/0",
+			"/dns4/bootstrap.example.com/tcp/0/wss",
+			"/ip4/0.0.0.0/tcp/4003/wss",
+			"/ip6/::/tcp/4003/wss",
+		];
+		for (const unsupportedAddress of unsupportedAddresses) {
+			let requestCount = 0;
+			globalThis.fetch = (async () => {
+				requestCount += 1;
+				return new Response(
+					requestCount === 1
+						? `${unsupportedAddress}\n`
+						: "/dnsaddr/bootstrap.example.com\n",
+					{ status: 200 },
+				);
+			}) as typeof fetch;
+
+			expect(await resolveBootstrapAddresses()).to.deep.equal([
+				"/dnsaddr/bootstrap.example.com",
+			]);
+			expect(requestCount).to.equal(2);
+		}
+
+		for (const crossRuntimeAddress of [
+			"/dnsaddr/bootstrap.example.com",
+			"/dns4/bootstrap.example.com/tcp/4003/wss",
+			circuitAddress,
+		]) {
+			let requestCount = 0;
+			globalThis.fetch = (async () => {
+				requestCount += 1;
+				return new Response(`${crossRuntimeAddress}\n`, { status: 200 });
+			}) as typeof fetch;
+			expect(await resolveBootstrapAddresses()).to.deep.equal([
+				crossRuntimeAddress,
+			]);
+			expect(requestCount).to.equal(1);
+		}
+	});
+
+	it("keeps supported alternatives but requires a cross-runtime target", async () => {
+		const supplementalAddresses = [
+			"/dns4/bootstrap.example.com/tcp/4003",
+			"/dns4/bootstrap.example.com/tcp/4003/ws",
+			webRTCAddress,
+		];
+
+		for (const supplementalAddress of supplementalAddresses) {
+			let requestCount = 0;
+			globalThis.fetch = (async () => {
+				requestCount += 1;
+				return requestCount === 1
+					? new Response(`${supplementalAddress}\n${addressA}\n`, {
+							status: 200,
+						})
+					: new Response("/dnsaddr/fallback.example.com\n", {
+							status: 200,
+						});
+			}) as typeof fetch;
+
+			expect(await resolveBootstrapAddresses()).to.deep.equal([
+				supplementalAddress,
+				addressA,
+			]);
+			expect(requestCount).to.equal(1);
+
+			requestCount = 0;
+			globalThis.fetch = (async () => {
+				requestCount += 1;
+				return new Response(
+					requestCount === 1
+						? `${supplementalAddress}\n`
+						: "/dnsaddr/fallback.example.com\n",
+					{ status: 200 },
+				);
+			}) as typeof fetch;
+
+			expect(await resolveBootstrapAddresses()).to.deep.equal([
+				"/dnsaddr/fallback.example.com",
+			]);
+			expect(requestCount).to.equal(2);
+		}
+	});
+
+	it("ignores unsupported entries when a source still has a safe target", async () => {
+		let requestCount = 0;
+		globalThis.fetch = (async () => {
+			requestCount += 1;
+			return new Response(
+				`/tcp/4003/dns4/bootstrap.example.com\n${addressA}\n`,
+				{ status: 200 },
+			);
+		}) as typeof fetch;
+
+		expect(await resolveBootstrapAddresses()).to.deep.equal([addressA]);
+		expect(requestCount).to.equal(1);
+	});
+
+	it("bounds declared, streamed, and address-list sizes", async () => {
+		let declaredBodyCancelled = 0;
+		let streamedBodyCancelled = 0;
+		const declaredBody = new ReadableStream<Uint8Array>({
+			cancel() {
+				declaredBodyCancelled += 1;
+			},
+		});
+		const oversizedStream = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				controller.enqueue(new Uint8Array(40_000));
+			},
+			cancel() {
+				streamedBodyCancelled += 1;
+			},
+		});
+		const oversizedAddresses = `${Array.from(
+			{ length: 257 },
+			() => addressA,
+		).join("\n")}\n`;
+		const unusableResponses = [
+			new Response(declaredBody, {
+				status: 200,
+				headers: { "content-length": "65537" },
+			}),
+			new Response(oversizedStream, { status: 200 }),
+			new Response(oversizedAddresses, { status: 200 }),
+		];
+
+		for (const unusableResponse of unusableResponses) {
+			let requestCount = 0;
+			let firstSignal: AbortSignal | null | undefined;
+			globalThis.fetch = (async (_input, init) => {
+				requestCount += 1;
+				if (requestCount === 1) {
+					firstSignal = init?.signal;
+					return unusableResponse;
+				}
+				return new Response(`${addressA}\n`, { status: 200 });
+			}) as typeof fetch;
+
+			expect(await resolveBootstrapAddresses()).to.deep.equal([addressA]);
+			expect(requestCount).to.equal(2);
+			expect(firstSignal?.aborted).to.equal(true);
+		}
+		expect(declaredBodyCancelled).to.equal(1);
+		expect(streamedBodyCancelled).to.equal(1);
+	});
+
+	it("aborts hanging sources before falling back or aggregating failures", async () => {
+		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+		const waitForAbort = (init?: RequestInit): Promise<Response> =>
+			new Promise((_resolve, reject) => {
+				const signal = init?.signal;
+				if (!signal) {
+					reject(new Error("Missing bootstrap fetch signal"));
+					return;
+				}
+				const onAbort = () => reject(signal.reason);
+				if (signal.aborted) {
+					onAbort();
+				} else {
+					signal.addEventListener("abort", onAbort, { once: true });
+				}
+			});
+
+		try {
+			let requestCount = 0;
+			globalThis.fetch = (async (_input, init) => {
+				requestCount += 1;
+				return requestCount === 1
+					? waitForAbort(init)
+					: new Response(`${addressA}\n`, { status: 200 });
+			}) as typeof fetch;
+			const fallbackResult = resolveBootstrapAddresses();
+			await clock.tickAsync(10_000);
+			expect(await fallbackResult).to.deep.equal([addressA]);
+			expect(requestCount).to.equal(2);
+
+			globalThis.fetch = (async (_input, init) =>
+				waitForAbort(init)) as typeof fetch;
+			const failedResult = resolveBootstrapAddresses();
+			await clock.tickAsync(20_000);
+			let failure: unknown;
+			try {
+				await failedResult;
+			} catch (error) {
+				failure = error;
+			}
+			expect(failure).to.be.instanceOf(AggregateError);
+			expect((failure as AggregateError).errors).to.have.length(2);
+			for (const error of (failure as AggregateError).errors) {
+				expect((error as Error).message).to.contain("Timed out fetching");
+			}
+		} finally {
+			clock.restore();
+		}
+	});
+
+	it("reports every source failure instead of returning an empty list", async () => {
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			const url =
+				typeof input === "string"
+					? input
+					: input instanceof URL
+						? input.toString()
+						: input.url;
+			return url.startsWith("https://bootstrap.peerbit.org/")
+				? new Response("unavailable", { status: 503 })
+				: new Response("\n# no relays\n", { status: 200 });
+		}) as typeof fetch;
+
+		let failure: unknown;
+		try {
+			await resolveBootstrapAddresses();
+		} catch (error) {
+			failure = error;
+		}
+		expect(failure).to.be.instanceOf(AggregateError);
+		expect((failure as AggregateError).errors).to.have.length(2);
+		expect((failure as Error).message).to.contain(
+			"Failed to resolve bootstrap addresses",
+		);
+	});
 });
 
 describe("getBootstrapPeerId", () => {
 	it("extracts the p2p component using multiaddr parsing", () => {
-		expect(
-			getBootstrapPeerId(
-				"/dns4/node-a.peerchecker.com/tcp/4003/wss/p2p/12D3KooA",
-			),
-		).to.equal("12D3KooA");
+		expect(getBootstrapPeerId(addressA)).to.equal(peerIdA);
 	});
 
 	it("returns undefined for addresses without a p2p component", () => {
-		expect(getBootstrapPeerId("/dns4/node-a.peerchecker.com/tcp/4003/wss")).to.be
-			.undefined;
+		expect(getBootstrapPeerId("/dns4/node-a.peerchecker.com/tcp/4003/wss")).to
+			.be.undefined;
 	});
 
 	it("extracts the peer id from a Multiaddr instance", () => {
-		expect(
-			getBootstrapPeerId(
-				multiaddr("/dns4/node-a.peerchecker.com/tcp/4003/wss/p2p/12D3KooB"),
-			),
-		).to.equal("12D3KooB");
+		expect(getBootstrapPeerId(multiaddr(addressB))).to.equal(peerIdB);
+	});
+
+	it("extracts the terminal peer id from a routed address", () => {
+		expect(getBootstrapPeerId(circuitAddress)).to.equal(peerIdB);
 	});
 
 	it("returns undefined for malformed bootstrap addresses", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,6 +370,9 @@ importers:
       '@multiformats/multiaddr':
         specifier: ^13.0.1
         version: 13.0.1
+      '@multiformats/multiaddr-matcher':
+        specifier: ^3.0.1
+        version: 3.0.1
       '@peerbit/any-store':
         specifier: workspace:*
         version: link:../../utils/any-store/any-store


### PR DESCRIPTION
## Summary

- validate and bound public bootstrap list responses
- fall back to the canonical peerbit-bootstrap repository when the public endpoint fails or returns no safe cross-runtime target
- preserve supported TCP, WebSocket, circuit-relay, and relayed WebRTC alternatives while rejecting malformed or listener-only addresses
- use the terminal peer ID for routed bootstrap targets

## Validation

- `pnpm --filter peerbit test:node` (76 passing, 1 existing pending)
- repository ESLint on changed TypeScript files
- `pnpm install --offline --frozen-lockfile --ignore-scripts --filter peerbit...`
- real Chromium fallback probe on `https://files.dao.xyz`
- independent final and adversarial reviews: no P0-P2 findings

## Operational note

This hardens list discovery, but it does not make an unreachable relay healthy. The currently published v5 relay hostname still needs separate production DNS/node recovery and redundancy.