### PR TITLE
fix(react): let coverage workers exit cleanly

### DIFF
--- a/.changeset/quiet-react-lock-tests.md
+++ b/.changeset/quiet-react-lock-tests.md
@@ -1,0 +1,7 @@
+---
+"@peerbit/react": patch
+---
+
+Let Node exit while browser-style identity lock keep-alive timers are active,
+and serialize the package's process-global storage/timer tests so coverage jobs
+cannot hang after every assertion has passed.

--- a/packages/clients/peerbit-react/src/lockstorage.ts
+++ b/packages/clients/peerbit-react/src/lockstorage.ts
@@ -329,6 +329,10 @@ export class FastMutex {
 					);
 				}
 			}, this.timeout);
+			// A browser timer has no `unref`, while Node returns a Timeout object.
+			// Keeping the lease alive must not keep an otherwise finished Node
+			// process (or a Vitest coverage worker) alive indefinitely.
+			(interval as unknown as { unref?: () => void }).unref?.();
 			this.intervals.set(key, interval);
 			return ret;
 		}

--- a/packages/clients/peerbit-react/vitest.config.ts
+++ b/packages/clients/peerbit-react/vitest.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
 		include: ["vitest/**/*.test.ts?(x)"],
 		exclude: ["dist", "node_modules"],
 		setupFiles: [path.join(ROOT, "vitest.setup.ts")],
+		// These suites intentionally replace process-global localStorage and timers.
+		// Running their coverage workers concurrently can leave a completed worker
+		// waiting forever during teardown.
+		fileParallelism: false,
 		hookTimeout: 120_000,
 		testTimeout: 120_000,
 	},

--- a/packages/clients/peerbit-react/vitest/lockstorage.test.ts
+++ b/packages/clients/peerbit-react/vitest/lockstorage.test.ts
@@ -336,6 +336,19 @@ describe("FastMutex", () => {
 		holder.release(key);
 	});
 
+	it("does not keep a Node process alive for a keep-alive lock", () => {
+		const fm = new FastMutex({ localStorage, timeout: 1_000 });
+		fm.setItem("node-unref", "owner", () => true);
+
+		const interval = fm.intervals.get("node-unref") as
+			| { hasRef?: () => boolean }
+			| undefined;
+		expect(interval).to.not.equal(undefined);
+		expect(interval?.hasRef?.()).to.equal(false);
+
+		fm.releaseIfOwnedBy("node-unref", () => true);
+	});
+
 	it("should reset the client stats after lock is released", async () => {
 		// without resetting the stats, the acquireStart will always be set, and
 		// after `timeout` ms, will be unable to acquire a lock anymore


### PR DESCRIPTION
## Summary
- unref FastMutex keep-alive timers in Node so they cannot keep a finished process alive
- serialize the React package suites that replace process-global localStorage and timers
- add regression coverage for the Node timer behavior

## Why
The release PR test:ci:part-1 job reached 41/41 React assertions and then timed out because a concurrent coverage worker never completed teardown. The same command reproduced locally. With this patch, the exact coverage command runs 42/42 tests and exits normally.

## Validation
- pnpm --filter @peerbit/react test:cov
- pnpm --filter @peerbit/react build
- pnpm exec prettier --check packages/clients/peerbit-react/src/lockstorage.ts packages/clients/peerbit-react/vitest/lockstorage.test.ts packages/clients/peerbit-react/vitest.config.ts .changeset/quiet-react-lock-tests.md
- pnpm exec eslint packages/clients/peerbit-react/src/lockstorage.ts packages/clients/peerbit-react/vitest/lockstorage.test.ts packages/clients/peerbit-react/vitest.config.ts
- git diff --check