### PR TITLE
fix(shared-log-rust): emit browser wasm glue chunk

### DIFF
--- a/.changeset/lazy-wasm-chunks-load.md
+++ b/.changeset/lazy-wasm-chunks-load.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log-rust": patch
+---
+
+Let browser bundlers emit the lazy wasm-bindgen glue chunk so the native shared-log planner loads in Vite applications instead of requesting a missing `/wasm/shared_log_rust.js` path.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,6 +560,7 @@ jobs:
           cargo test
           pnpm run build
           pnpm exec aegir test -t node
+          pnpm run test:e2e
       - name: Test @peerbit/document-rust
         run: pnpm --filter @peerbit/document-rust run test
       - name: Test @peerbit/network-rust

--- a/packages/programs/data/shared-log/rust/.gitignore
+++ b/packages/programs/data/shared-log/rust/.gitignore
@@ -1,3 +1,5 @@
 /target
 /dist
 /wasm
+/test-results
+/playwright-report

--- a/packages/programs/data/shared-log/rust/e2e/index.html
+++ b/packages/programs/data/shared-log/rust/e2e/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Shared Log Rust Vite E2E</title>
+	</head>
+	<body>
+		<main style="font-family: sans-serif; padding: 16px">
+			<h1>Shared Log Rust Vite E2E</h1>
+			<p data-testid="status">loading</p>
+		</main>
+		<script type="module" src="/src/main.ts"></script>
+	</body>
+</html>

--- a/packages/programs/data/shared-log/rust/e2e/playwright.config.ts
+++ b/packages/programs/data/shared-log/rust/e2e/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test";
+import { fileURLToPath } from "node:url";
+
+const PORT = Number(process.env.PEERBIT_SHARED_LOG_RUST_E2E_PORT ?? 5275);
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+export default defineConfig({
+	testDir: "./tests",
+	fullyParallel: false,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 1 : 0,
+	workers: 1,
+	reporter: [["list"]],
+	use: {
+		baseURL: BASE_URL,
+		trace: "on-first-retry",
+	},
+	projects: [
+		{
+			name: "chromium",
+			use: { ...devices["Desktop Chrome"] },
+		},
+	],
+	webServer: [
+		{
+			command: `pnpm --dir ${PACKAGE_ROOT} e2e:preview --host 127.0.0.1 --port ${PORT}`,
+			url: BASE_URL,
+			reuseExistingServer: false,
+		},
+	],
+});

--- a/packages/programs/data/shared-log/rust/e2e/src/main.ts
+++ b/packages/programs/data/shared-log/rust/e2e/src/main.ts
@@ -1,0 +1,47 @@
+import { createRangePlanner } from "@peerbit/shared-log-rust";
+
+type BrowserResult = {
+	nativePlannerActive: boolean;
+	length: number;
+	samples: Array<[string, { intersecting: boolean }]>;
+};
+
+declare global {
+	interface Window {
+		__sharedLogRustResult?: BrowserResult;
+	}
+}
+
+const status = document.querySelector('[data-testid="status"]') as HTMLElement;
+
+try {
+	const planner = await createRangePlanner("u32");
+	planner.put({
+		id: "range-a",
+		hash: "peer-a",
+		timestamp: 0n,
+		start1: 10,
+		end1: 20,
+		start2: 10,
+		end2: 20,
+		width: 10,
+		mode: 0,
+	});
+
+	const native = (
+		planner as unknown as {
+			native?: { find_leaders?: unknown };
+		}
+	).native;
+	window.__sharedLogRustResult = {
+		nativePlannerActive: typeof native?.find_leaders === "function",
+		length: planner.length,
+		samples: [...planner.getSamples([15], { now: 1_000 })],
+	};
+	status.textContent = "native-ready";
+} catch (error) {
+	status.textContent = `error: ${
+		error instanceof Error ? error.message : String(error)
+	}`;
+	throw error;
+}

--- a/packages/programs/data/shared-log/rust/e2e/tests/vite-browser.spec.ts
+++ b/packages/programs/data/shared-log/rust/e2e/tests/vite-browser.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/test";
+
+const isSharedLogRustAsset = (url: string): boolean =>
+	/shared_log_rust[^/]*\.(?:js|wasm)(?:\?|$)/.test(url);
+
+test("loads Vite-emitted glue and WASM with the native planner active", async ({
+	page,
+}) => {
+	const responses: Array<{ status: number; url: string }> = [];
+	const failedRequests: string[] = [];
+	const pageErrors: string[] = [];
+
+	page.on("response", (response) => {
+		if (isSharedLogRustAsset(response.url())) {
+			responses.push({ status: response.status(), url: response.url() });
+		}
+	});
+	page.on("requestfailed", (request) => {
+		if (isSharedLogRustAsset(request.url())) {
+			failedRequests.push(request.url());
+		}
+	});
+	page.on("pageerror", (error) => pageErrors.push(error.message));
+
+	await page.goto("/");
+	await expect(page.getByTestId("status")).toHaveText("native-ready");
+
+	await expect
+		.poll(() =>
+			responses.some(({ url }) => new URL(url).pathname.endsWith(".wasm")),
+		)
+		.toBe(true);
+
+	const result = await page.evaluate(() => window.__sharedLogRustResult);
+	expect(result).toEqual({
+		nativePlannerActive: true,
+		length: 1,
+		samples: [["peer-a", { intersecting: true }]],
+	});
+	expect(failedRequests).toEqual([]);
+	expect(pageErrors).toEqual([]);
+	expect(
+		responses.some(({ url }) => new URL(url).pathname.endsWith(".js")),
+	).toBe(true);
+	expect(responses.every(({ status }) => status === 200)).toBe(true);
+	expect(
+		responses.some(
+			({ url }) => new URL(url).pathname === "/wasm/shared_log_rust.js",
+		),
+	).toBe(false);
+});

--- a/packages/programs/data/shared-log/rust/e2e/vite.config.ts
+++ b/packages/programs/data/shared-log/rust/e2e/vite.config.ts
@@ -1,0 +1,13 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
+
+const E2E_ROOT = fileURLToPath(new URL(".", import.meta.url));
+
+export default defineConfig({
+	root: E2E_ROOT,
+	build: {
+		emptyOutDir: true,
+		outDir: "dist",
+		target: "es2022",
+	},
+});

--- a/packages/programs/data/shared-log/rust/package.json
+++ b/packages/programs/data/shared-log/rust/package.json
@@ -54,12 +54,17 @@
 		"benchmark:get-samples": "npm run build && pnpm --filter @peerbit/shared-log run build && node ./dist/benchmark/get-samples.js",
 		"clean": "aegir clean && shx rm -rf ./wasm && cargo clean",
 		"build": "wasm-pack build --target web --out-dir wasm --out-name shared_log_rust && shx rm -rf ./wasm/.gitignore ./wasm/package.json && aegir build --no-bundle && shx rm -rf ./dist/wasm && shx cp -r ./wasm ./dist/wasm",
+		"e2e:build": "vite build --config e2e/vite.config.ts",
+		"e2e:preview": "vite preview --config e2e/vite.config.ts",
+		"test:e2e": "npm run build && npm run e2e:build && playwright test --config e2e/playwright.config.ts",
 		"test": "cargo test && npm run build && pnpm --filter @peerbit/shared-log run build && aegir test",
-		"lint": "cargo fmt --check && pnpm exec eslint --config ../../../../../eslint.config.js \"src/**/*.ts\" \"test/**/*.ts\" \"benchmark/**/*.ts\""
+		"lint": "cargo fmt --check && pnpm exec eslint --config ../../../../../eslint.config.js \"src/**/*.ts\" \"test/**/*.ts\" \"benchmark/**/*.ts\" \"e2e/**/*.ts\""
 	},
 	"author": "Peerbit contributors",
 	"license": "MIT",
 	"devDependencies": {
-		"@peerbit/indexer-sqlite3": "workspace:*"
+		"@peerbit/indexer-sqlite3": "workspace:*",
+		"@playwright/test": "^1.47.0",
+		"vite": "^7.1.7"
 	}
 }

--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -576,10 +576,12 @@ let wasmInitPromise: Promise<void> | undefined;
 
 const loadWasm = async (): Promise<WasmModule> => {
 	if (!wasmModulePromise) {
-		const wasmModulePath = "../wasm/shared_log_rust.js";
+		// Keep this import lazy, but leave the relative specifier visible to
+		// bundlers so they emit the wasm-bindgen glue as a real browser chunk.
+		// Node resolves the same path against dist/src/index.js.
 		wasmModulePromise = import(
-			/* @vite-ignore */ wasmModulePath
-		) as Promise<WasmModule>;
+			"../wasm/shared_log_rust.js"
+		) as unknown as Promise<WasmModule>;
 	}
 
 	const wasm = await wasmModulePromise;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1847,6 +1847,12 @@ importers:
       '@peerbit/indexer-sqlite3':
         specifier: workspace:*
         version: link:../../../../utils/indexer/sqlite3
+      '@playwright/test':
+        specifier: ^1.47.0
+        version: 1.56.1
+      vite:
+        specifier: ^7.1.7
+        version: 7.2.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1)(yaml@2.8.3)
 
   packages/programs/data/string:
     dependencies:

--- a/scripts/native-pack-smoke.mjs
+++ b/scripts/native-pack-smoke.mjs
@@ -32,6 +32,28 @@ assert((await store.size()) > 0);
 await store.close();
 console.log("@peerbit/any-store-rust tarball smoke OK");
 `,
+	"@peerbit/shared-log-rust": `
+import { strict as assert } from "node:assert";
+import { createRangePlanner } from "@peerbit/shared-log-rust";
+
+const planner = await createRangePlanner("u32");
+planner.put({
+	id: "range-a",
+	hash: "peer-a",
+	timestamp: 0n,
+	start1: 10,
+	end1: 20,
+	start2: 10,
+	end2: 20,
+	width: 10,
+	mode: 0,
+});
+assert.equal(planner.length, 1);
+assert.deepEqual([...planner.getSamples([15], { now: 1_000 })], [
+	["peer-a", { intersecting: true }],
+]);
+console.log("@peerbit/shared-log-rust tarball smoke OK");
+`,
 	"@peerbit/native-backbone": `
 import { strict as assert } from "node:assert";
 import { createNativePeerbitBackbone } from "@peerbit/native-backbone";


### PR DESCRIPTION
## Summary
- replace the runtime-hidden wasm-bindgen path with a statically analyzable lazy import
- add a production Vite + Chromium regression proving the emitted glue and WASM return 200 and the native planner is actually active
- add a packed-tarball Node smoke and run the browser regression in the native CI job

## Root cause
The variable `@vite-ignore` import survived the production build as `import("../wasm/shared_log_rust.js")`. From the hashed `/assets/index-*.js` chunk, browsers resolved that to the nonexistent `/wasm/shared_log_rust.js`. A literal lazy relative import lets Vite emit hashed glue and WASM chunks while Node still resolves the package-local `dist/wasm` artifact.

## Validation
- cargo test (22/22)
- Node wrapper tests (39/39)
- packed-tarball Node native-load smoke
- production Vite build + Chromium regression (native planner active; glue/WASM 200; no `/wasm/...` request)
- package lint
- frozen offline install, diff check, changeset status