### PR TITLE
fix(shared-log): route strict live ranges

### DIFF
--- a/.changeset/strict-live-leaders.md
+++ b/.changeset/strict-live-leaders.md
@@ -1,0 +1,7 @@
+---
+"@peerbit/native-backbone": patch
+"@peerbit/shared-log": patch
+"@peerbit/shared-log-rust": patch
+---
+
+Route new entries to strict range replicators when they intersect the entry coordinates, even when strict ranges are excluded from the full-replica fallback. This restores live document-stream delivery without broadcasting each append to every peer.

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -280,6 +280,10 @@ impl PeerRangeStats {
             .first()
             .is_some_and(|range| range.is_matured(now, role_age_ms))
     }
+
+    fn has_strict_range(&self) -> bool {
+        self.all.len() > self.non_strict.len()
+    }
 }
 
 impl RangePlanner {
@@ -547,6 +551,16 @@ impl RangePlanner {
         options: &SampleOptions,
         include_strict: bool,
     ) -> Option<Vec<LeaderSample>> {
+        self.get_full_replica_leaders_inner(replicas, options, include_strict, false)
+    }
+
+    fn get_full_replica_leaders_inner(
+        &self,
+        replicas: usize,
+        options: &SampleOptions,
+        include_strict: bool,
+        require_coordinate_sampling_for_strict_only: bool,
+    ) -> Option<Vec<LeaderSample>> {
         let mut leaders: IndexSet<String> = IndexSet::new();
 
         for (hash, stats) in self.peer_ranges.iter() {
@@ -555,7 +569,23 @@ impl RangePlanner {
                     continue;
                 }
             }
-            if !stats.has_matured_range(options.now, options.role_age_ms, include_strict) {
+            let has_matured_range = if include_strict {
+                stats.has_matured_range(options.now, options.role_age_ms, true)
+            } else {
+                let has_matured_non_strict =
+                    stats.has_matured_range(options.now, options.role_age_ms, false);
+                // A strict-only peer is intentionally omitted from the global fallback,
+                // but it may still own one of this entry's coordinates. The fallback has
+                // no coordinates to check, so its partial result must not return early.
+                if require_coordinate_sampling_for_strict_only
+                    && stats.has_strict_range()
+                    && !has_matured_non_strict
+                {
+                    return None;
+                }
+                has_matured_non_strict
+            };
+            if !has_matured_range {
                 continue;
             }
 
@@ -866,9 +896,12 @@ fn find_leaders_with_prepared_options(
     include_strict_full_replica: bool,
 ) -> Vec<LeaderSample> {
     if full_replica_fallback {
-        if let Some(leaders) =
-            planner.get_full_replica_leaders(replicas, options, include_strict_full_replica)
-        {
+        if let Some(leaders) = get_routing_full_replica_leaders(
+            planner,
+            replicas,
+            options,
+            include_strict_full_replica,
+        ) {
             return leaders;
         }
     }
@@ -880,6 +913,15 @@ fn find_leaders_with_prepared_options(
         .map(|peers| IndexSet::from_iter(peers.iter().cloned()));
 
     planner.get_samples(cursors, &options)
+}
+
+fn get_routing_full_replica_leaders(
+    planner: &RangePlanner,
+    replicas: usize,
+    options: &SampleOptions,
+    include_strict_full_replica: bool,
+) -> Option<Vec<LeaderSample>> {
+    planner.get_full_replica_leaders_inner(replicas, options, include_strict_full_replica, true)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -934,7 +976,8 @@ fn find_leaders_with_batch_caches(
         if let Some(leaders) = full_replica_leaders_by_replicas
             .entry(replicas)
             .or_insert_with(|| {
-                planner.get_full_replica_leaders(
+                get_routing_full_replica_leaders(
+                    planner,
                     replicas,
                     prepared_options,
                     include_strict_full_replica,
@@ -977,9 +1020,13 @@ fn full_replica_self_leader_with_batch_caches(
     full_replica_self_leader_by_replicas
         .entry(replicas)
         .or_insert_with(|| {
-            planner
-                .get_full_replica_leaders(replicas, prepared_options, include_strict_full_replica)
-                .map(|leaders| leaders.iter().any(|leader| leader.hash == self_hash))
+            get_routing_full_replica_leaders(
+                planner,
+                replicas,
+                prepared_options,
+                include_strict_full_replica,
+            )
+            .map(|leaders| leaders.iter().any(|leader| leader.hash == self_hash))
         })
         .as_ref()
         .copied()
@@ -2866,7 +2913,8 @@ impl NativeSharedLogState {
                 full_replica_leaders_by_replicas
                     .entry(replicas)
                     .or_insert_with(|| {
-                        self.inner.range_planner.get_full_replica_leaders(
+                        get_routing_full_replica_leaders(
+                            &self.inner.range_planner,
                             replicas,
                             prepared_options,
                             include_strict_full_replica,
@@ -4167,7 +4215,7 @@ fn samples_to_rows(samples: Vec<LeaderSample>) -> Array {
 mod tests {
     use super::{
         find_leaders_with_prepared_options, LeaderSample, NativeSharedLogState, RangePlanner,
-        ReplicationRange, SampleOptions, SharedLogError,
+        ReplicationRange, SampleOptions, SharedLogError, MAX_U64,
     };
     use indexmap::IndexSet;
 
@@ -4612,6 +4660,61 @@ mod tests {
         assert_eq!(leaders[0].hash, "peer-a");
         assert_eq!(leaders[1].hash, "peer-b");
         assert!(leaders.iter().all(|leader| leader.intersecting));
+    }
+
+    #[test]
+    fn find_leaders_samples_strict_ranges_excluded_from_full_replica_fallback() {
+        let mut planner = RangePlanner::new("u64");
+        planner.put(ReplicationRange::new(
+            "writer",
+            "peer-writer",
+            0,
+            0,
+            MAX_U64,
+            0,
+            MAX_U64,
+            MAX_U64,
+            0,
+        ));
+        planner.put(ReplicationRange::new(
+            "viewer",
+            "peer-viewer",
+            0,
+            0,
+            86_400_000_000_000_000,
+            0,
+            86_400_000_000_000_000,
+            86_400_000_000_000_000,
+            1,
+        ));
+
+        let leaders = planner.find_leaders(
+            &[0, MAX_U64 / 2],
+            2,
+            &SampleOptions {
+                now: 1_000,
+                ..Default::default()
+            },
+            true,
+            "peer-writer",
+            true,
+            true,
+            false,
+        );
+
+        assert_eq!(
+            leaders,
+            vec![
+                LeaderSample {
+                    hash: "peer-writer".to_string(),
+                    intersecting: true,
+                },
+                LeaderSample {
+                    hash: "peer-viewer".to_string(),
+                    intersecting: true,
+                },
+            ],
+        );
     }
 
     #[test]

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -232,6 +232,35 @@ describe("native shared-log range planner", () => {
 		);
 	});
 
+	it("samples intersecting strict ranges excluded from full replica fallback", async () => {
+		const planner = await createRangePlanner("u32");
+		planner.put(
+			range({ id: "writer", hash: "peer-writer", start1: 0, end1: 100 }),
+		);
+		planner.put(
+			range({
+				id: "viewer",
+				hash: "peer-viewer",
+				start1: 0,
+				end1: 10,
+				mode: 1,
+			}),
+		);
+
+		expect(
+			planner.findLeaders([5, 75], 2, {
+				now: 1_000,
+				fullReplicaFallback: true,
+				includeStrictFullReplica: false,
+			}),
+		).to.deep.equal(
+			new Map([
+				["peer-writer", { intersecting: true }],
+				["peer-viewer", { intersecting: true }],
+			]),
+		);
+	});
+
 	it("finds hash gid leaders without returning coordinates to TypeScript", async () => {
 		const planner = await createRangePlanner("u32");
 		planner.put(range({ id: "a", hash: "peer-a", start1: 0, end1: 10 }));

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -17223,6 +17223,9 @@ export class SharedLog<
 	): Promise<Map<string, { intersecting: boolean }> | undefined> {
 		const now = Date.now();
 		const leaders = new Map<string, { intersecting: boolean }>();
+		// Strict-only peers are not global fallbacks, but may still own an entry's
+		// coordinates. Remember them so a partial fallback cannot bypass sampling.
+		const excludedStrictPeers = new Set<string>();
 		const includeStrict =
 			this._logProperties?.strictFullReplicaFallback !== false;
 		const iterator = this.replicationIndex.iterate(
@@ -17241,10 +17244,11 @@ export class SharedLog<
 					if (peerFilter && !peerFilter.has(range.hash)) {
 						continue;
 					}
-					if (!isMatured(range, now, roleAge)) {
+					if (range.mode === ReplicationIntent.Strict && !includeStrict) {
+						excludedStrictPeers.add(range.hash);
 						continue;
 					}
-					if (range.mode === ReplicationIntent.Strict && !includeStrict) {
+					if (!isMatured(range, now, roleAge)) {
 						continue;
 					}
 					leaders.set(range.hash, { intersecting: true });
@@ -17255,6 +17259,12 @@ export class SharedLog<
 			}
 		} finally {
 			await iterator.close();
+		}
+
+		for (const hash of excludedStrictPeers) {
+			if (!leaders.has(hash)) {
+				return undefined;
+			}
 		}
 
 		return leaders.size > 0 ? leaders : undefined;

--- a/packages/programs/data/shared-log/test/strict-live-routing.spec.ts
+++ b/packages/programs/data/shared-log/test/strict-live-routing.spec.ts
@@ -1,0 +1,91 @@
+import { Timestamp } from "@peerbit/log";
+import { TestSession } from "@peerbit/test-utils";
+import { waitForResolved } from "@peerbit/time";
+import { expect } from "chai";
+import { ReplicationIntent } from "../src/ranges.js";
+import {
+	type ReplicationDomainTime,
+	createReplicationDomainTime,
+} from "../src/replication-domain-time.js";
+import { AbsoluteReplicas } from "../src/replication.js";
+import { EventStore } from "./utils/stores/event-store.js";
+
+describe("strict live-range leader routing", () => {
+	let session: TestSession;
+
+	beforeEach(async () => {
+		session = await TestSession.connected(2);
+	});
+
+	afterEach(async () => {
+		await session.stop();
+	});
+
+	it("samples an intersecting strict viewer when strict full-replica fallback is disabled", async () => {
+		const domain = createReplicationDomainTime({
+			origin: new Date(0),
+			unit: "nanoseconds",
+		});
+		const replicas = {
+			min: new AbsoluteReplicas(2),
+			max: new AbsoluteReplicas(2),
+		};
+		const writer = await session.peers[0].open(
+			new EventStore<string, ReplicationDomainTime>(),
+			{
+				args: {
+					domain,
+					nativeRangePlanner: false,
+					replicas,
+					replicate: { factor: 1 },
+					strictFullReplicaFallback: false,
+					timeUntilRoleMaturity: 0,
+				},
+			},
+		);
+		const viewer = await session.peers[1].open(writer.clone(), {
+			args: {
+				domain,
+				nativeRangePlanner: false,
+				replicas,
+				replicate: {
+					factor: 10,
+					normalized: false,
+					offset: 0,
+					strict: true,
+				},
+				strictFullReplicaFallback: false,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+
+		await waitForResolved(async () =>
+			expect(await writer.log.replicationIndex.count()).to.equal(2),
+		);
+
+		const viewerHash = viewer.node.identity.publicKey.hashcode();
+		const viewerRanges = await writer.log.replicationIndex
+			.iterate({ query: { hash: viewerHash } })
+			.all();
+		expect(viewerRanges).to.have.length(1);
+		expect(viewerRanges[0].value.mode).to.equal(ReplicationIntent.Strict);
+		expect(viewerRanges[0].value.contains(5)).to.equal(true);
+
+		const { entry } = await writer.add("frame", {
+			meta: {
+				next: [],
+				timestamp: new Timestamp({ wallTime: 5n }),
+			},
+			replicas: new AbsoluteReplicas(2),
+			target: "none",
+		});
+		const leaders = await writer.log.findLeadersFromEntry(entry, 2, {
+			roleAge: 0,
+		});
+
+		expect([...leaders.keys()]).to.have.members([
+			writer.node.identity.publicKey.hashcode(),
+			viewerHash,
+		]);
+	});
+});

--- a/packages/programs/data/shared-log/test/utils/stores/event-store.ts
+++ b/packages/programs/data/shared-log/test/utils/stores/event-store.ts
@@ -81,6 +81,7 @@ export type Args<
 	nativeGraph?: boolean;
 	nativeBackbone?: SharedLogOptions<Operation<T>, D, R>["nativeBackbone"];
 	nativeRangePlanner?: SharedLogOptions<Operation<T>, D, R>["nativeRangePlanner"];
+	strictFullReplicaFallback?: boolean;
 };
 @variant("event_store")
 export class EventStore<
@@ -157,6 +158,7 @@ export class EventStore<
 			nativeGraph: properties?.nativeGraph,
 			nativeBackbone: properties?.nativeBackbone,
 			nativeRangePlanner: properties?.nativeRangePlanner,
+			strictFullReplicaFallback: properties?.strictFullReplicaFallback,
 
 			// staticArgs was unused; keep open args explicit in tests
 		});

--- a/packages/utils/native-backbone/test/index.spec.ts
+++ b/packages/utils/native-backbone/test/index.spec.ts
@@ -294,6 +294,54 @@ class FakeOPFSDirectoryHandle implements NativeBackboneOPFSDirectoryHandle {
 }
 
 describe("native peerbit backbone", () => {
+	it("samples intersecting strict ranges excluded from full replica fallback", async () => {
+		const maxU64 = (1n << 64n) - 1n;
+		const liveRangeEnd = 86_400_000_000_000_000n;
+		const backbone = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
+			resolution: "u64",
+		});
+		backbone.putRange({
+			id: "writer",
+			hash: "peer-writer",
+			timestamp: 0,
+			start1: 0n,
+			end1: maxU64,
+			start2: 0n,
+			end2: maxU64,
+			width: maxU64,
+			mode: 0,
+		});
+		backbone.putRange({
+			id: "viewer",
+			hash: "peer-viewer",
+			timestamp: 0,
+			start1: 0n,
+			end1: liveRangeEnd,
+			start2: 0n,
+			end2: liveRangeEnd,
+			width: liveRangeEnd,
+			mode: 1,
+		});
+
+		expect(
+			backbone.findLeaders([0n, maxU64 / 2n], 2, {
+				fullReplicaFallback: true,
+				includeStrictFullReplica: false,
+				now: 1_000,
+				selfHash: "peer-writer",
+				selfReplicating: true,
+			}),
+		).to.deep.equal(
+			new Map([
+				["peer-writer", { intersecting: true }],
+				["peer-viewer", { intersecting: true }],
+			]),
+		);
+	});
+
 	it("defaults buffered coordinate WAL to bounded pending bytes", () => {
 		const persistence = new NativeBackboneCoordinatePersistence(
 			new NativeBackboneMemoryCoordinatePersistenceStore(),


### PR DESCRIPTION
## What
- prevent full-replica fallback from bypassing coordinate sampling when strict-only peers are excluded from the global fallback
- apply the same routing rule to TypeScript, Rust/WASM, batch planning, and native-backbone paths
- add focused network and planner regressions

## Why
A strict live viewer could advertise the exact time range it wanted, yet miss new entries because a partial full-replica shortcut returned before coordinate sampling. This restores targeted live delivery without broadcasting every append to every strict peer.

## Validation
- full 69-workspace build
- shared-log focused network regression
- Rust core tests and focused planner regression
- native-backbone Rust and WASM regressions
- targeted lint and changeset validation