### PR TITLE
fix(peerbit): recover bootstrap connectivity

### DIFF
--- a/.changeset/calm-peers-recover.md
+++ b/.changeset/calm-peers-recover.md
@@ -1,0 +1,8 @@
+---
+"peerbit": patch
+---
+
+Add opt-in automatic bootstrap recovery with single-flight attempts, bounded
+exponential backoff and jitter, browser online wakeups, refreshed default
+bootstrap discovery, and lifecycle-safe teardown. Recovery remains disabled by
+default so creating a client does not introduce unexpected network activity.

--- a/packages/clients/peerbit/src/bootstrap-recovery.ts
+++ b/packages/clients/peerbit/src/bootstrap-recovery.ts
@@ -1,0 +1,343 @@
+import type { Multiaddr } from "@multiformats/multiaddr";
+
+/**
+ * Automatic bootstrap recovery is opt-in so creating a Peerbit client keeps
+ * its existing no-network-side-effect behavior unless an application asks for
+ * recovery explicitly.
+ */
+export type BootstrapRecoveryOptions = {
+	/** Set to false to leave recovery disabled. Defaults to true for an options object. */
+	enabled?: boolean;
+	/**
+	 * Fixed bootstrap targets. When omitted, every recovery attempt resolves the
+	 * current public bootstrap list, including its canonical fallback source.
+	 */
+	addresses?: Array<string | Multiaddr>;
+	/**
+	 * Delay after the first failed attempt. Defaults to 1 second; maximum is
+	 * 2,147,483,647 ms.
+	 */
+	initialDelayMs?: number;
+	/**
+	 * Maximum retry delay, including jitter. Defaults to 60 seconds; maximum is
+	 * 2,147,483,647 ms.
+	 */
+	maxDelayMs?: number;
+	/** Exponential multiplier applied after each failed attempt. Defaults to 2. */
+	backoffFactor?: number;
+	/** Symmetric jitter ratio in the inclusive range 0..1. Defaults to 0.2. */
+	jitter?: number;
+	/**
+	 * Minimum time between attempts and reconnects. Defaults to 1 second;
+	 * maximum is 2,147,483,647 ms.
+	 */
+	cooldownMs?: number;
+};
+
+type NormalizedBootstrapRecoveryOptions = {
+	initialDelayMs: number;
+	maxDelayMs: number;
+	backoffFactor: number;
+	jitter: number;
+	cooldownMs: number;
+};
+
+export type BootstrapRecoveryEventTarget = {
+	addEventListener(type: string, listener: EventListener): void;
+	removeEventListener(type: string, listener: EventListener): void;
+};
+
+export type BootstrapRecoveryRuntime = {
+	bootstrap(signal: AbortSignal): Promise<unknown>;
+	connectionEvents: BootstrapRecoveryEventTarget;
+	onlineEvents?: BootstrapRecoveryEventTarget;
+	isConnected(): boolean;
+	isOnline?: () => boolean;
+	now?: () => number;
+	random?: () => number;
+	onError?: (error: unknown) => void;
+};
+
+const DEFAULT_OPTIONS: NormalizedBootstrapRecoveryOptions = {
+	initialDelayMs: 1_000,
+	maxDelayMs: 60_000,
+	backoffFactor: 2,
+	jitter: 0.2,
+	cooldownMs: 1_000,
+};
+
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+const finiteNumber = (name: string, value: number, minimum: number): number => {
+	if (!Number.isFinite(value) || value < minimum) {
+		throw new Error(`${name} must be a finite number >= ${minimum}`);
+	}
+	return value;
+};
+
+const timerDelay = (name: string, value: number, minimum: number): number => {
+	const delay = finiteNumber(name, value, minimum);
+	if (delay > MAX_TIMER_DELAY_MS) {
+		throw new Error(`${name} must be <= ${MAX_TIMER_DELAY_MS}`);
+	}
+	return delay;
+};
+
+const normalizeOptions = (
+	options: BootstrapRecoveryOptions,
+): NormalizedBootstrapRecoveryOptions => {
+	const initialDelayMs = timerDelay(
+		"bootstrapRecovery.initialDelayMs",
+		options.initialDelayMs ?? DEFAULT_OPTIONS.initialDelayMs,
+		1,
+	);
+	const maxDelayMs = timerDelay(
+		"bootstrapRecovery.maxDelayMs",
+		options.maxDelayMs ?? DEFAULT_OPTIONS.maxDelayMs,
+		initialDelayMs,
+	);
+	const backoffFactor = finiteNumber(
+		"bootstrapRecovery.backoffFactor",
+		options.backoffFactor ?? DEFAULT_OPTIONS.backoffFactor,
+		1,
+	);
+	const jitter = finiteNumber(
+		"bootstrapRecovery.jitter",
+		options.jitter ?? DEFAULT_OPTIONS.jitter,
+		0,
+	);
+	if (jitter > 1) {
+		throw new Error("bootstrapRecovery.jitter must be <= 1");
+	}
+	const cooldownMs = timerDelay(
+		"bootstrapRecovery.cooldownMs",
+		options.cooldownMs ?? DEFAULT_OPTIONS.cooldownMs,
+		0,
+	);
+	return {
+		initialDelayMs,
+		maxDelayMs,
+		backoffFactor,
+		jitter,
+		cooldownMs,
+	};
+};
+
+/** Validate policy configuration before an owning client acquires resources. */
+export const validateBootstrapRecoveryOptions = (
+	options: BootstrapRecoveryOptions,
+): void => {
+	if (options.addresses?.length === 0) {
+		throw new Error("bootstrapRecovery.addresses must not be empty");
+	}
+	normalizeOptions(options);
+};
+
+/** Internal lifecycle controller, exported from its source module for tests. */
+export class BootstrapRecoveryController {
+	private readonly options: NormalizedBootstrapRecoveryOptions;
+	private readonly now: () => number;
+	private readonly random: () => number;
+	private running = false;
+	private timer?: ReturnType<typeof setTimeout>;
+	private timerDueAt?: number;
+	private inFlight?: Promise<void>;
+	private attemptAbort?: AbortController;
+	private consecutiveFailures = 0;
+	private lastAttemptAt = Number.NEGATIVE_INFINITY;
+	private retryNotBefore = Number.NEGATIVE_INFINITY;
+
+	private readonly onConnectionOpen: EventListener = () => {
+		// A bootstrap attempt emits this event from inside its own successful dial.
+		// Let that attempt finish all Peerbit bootstrap side effects before treating
+		// the recovery as complete.
+		if (this.inFlight) return;
+		this.markConnected();
+	};
+
+	private readonly onConnectionClose: EventListener = () => {
+		this.requestRecovery(false);
+	};
+
+	private readonly onOnline: EventListener = () => {
+		this.requestRecovery(true);
+	};
+
+	constructor(
+		private readonly runtime: BootstrapRecoveryRuntime,
+		options: BootstrapRecoveryOptions = {},
+	) {
+		this.options = normalizeOptions(options);
+		this.now = runtime.now ?? Date.now;
+		this.random = runtime.random ?? Math.random;
+	}
+
+	get started(): boolean {
+		return this.running;
+	}
+
+	start(): void {
+		if (this.running) return;
+		this.running = true;
+		this.runtime.connectionEvents.addEventListener(
+			"connection:open",
+			this.onConnectionOpen,
+		);
+		this.runtime.connectionEvents.addEventListener(
+			"connection:close",
+			this.onConnectionClose,
+		);
+		this.runtime.onlineEvents?.addEventListener("online", this.onOnline);
+
+		if (this.runtime.isConnected()) {
+			this.markConnected();
+		} else {
+			this.schedule(0, false);
+		}
+	}
+
+	stop(): Promise<void> {
+		if (this.running) {
+			this.running = false;
+			this.runtime.connectionEvents.removeEventListener(
+				"connection:open",
+				this.onConnectionOpen,
+			);
+			this.runtime.connectionEvents.removeEventListener(
+				"connection:close",
+				this.onConnectionClose,
+			);
+			this.runtime.onlineEvents?.removeEventListener("online", this.onOnline);
+			this.clearTimer();
+			this.attemptAbort?.abort(new Error("Bootstrap recovery stopped"));
+			this.attemptAbort = undefined;
+		}
+		return this.inFlight ?? Promise.resolve();
+	}
+
+	private markConnected(): void {
+		if (!this.running) return;
+		this.consecutiveFailures = 0;
+		this.retryNotBefore = Number.NEGATIVE_INFINITY;
+		this.lastAttemptAt = this.now();
+		this.clearTimer();
+	}
+
+	private requestRecovery(urgent: boolean): void {
+		if (!this.running || this.runtime.isConnected() || this.inFlight) return;
+		const now = this.now();
+		const cooldownRemaining = Math.max(
+			0,
+			this.lastAttemptAt + this.options.cooldownMs - now,
+		);
+		const retryRemaining = Math.max(0, this.retryNotBefore - now);
+		this.schedule(Math.max(cooldownRemaining, retryRemaining), urgent);
+	}
+
+	private clearTimer(): void {
+		if (this.timer) {
+			clearTimeout(this.timer);
+		}
+		this.timer = undefined;
+		this.timerDueAt = undefined;
+	}
+
+	private schedule(delayMs: number, replaceIfEarlier: boolean): void {
+		if (!this.running) return;
+		const delay = Math.max(0, delayMs);
+		const dueAt = this.now() + delay;
+		if (this.timer) {
+			if (!replaceIfEarlier || (this.timerDueAt ?? dueAt) <= dueAt) {
+				return;
+			}
+			this.clearTimer();
+		}
+		this.timerDueAt = dueAt;
+		this.timer = setTimeout(() => {
+			this.timer = undefined;
+			this.timerDueAt = undefined;
+			this.runAttempt();
+		}, delay);
+		(
+			this.timer as ReturnType<typeof setTimeout> & { unref?: () => void }
+		).unref?.();
+	}
+
+	private runAttempt(): void {
+		if (!this.running || this.runtime.isConnected()) {
+			if (this.runtime.isConnected()) this.markConnected();
+			return;
+		}
+		if (this.runtime.isOnline?.() === false) {
+			// Browser online events bring this forward immediately; the bounded timer
+			// remains as a safety net for missed or unreliable environment signals.
+			this.schedule(this.options.maxDelayMs, false);
+			return;
+		}
+		const cooldownRemaining = Math.max(
+			0,
+			this.lastAttemptAt + this.options.cooldownMs - this.now(),
+		);
+		if (cooldownRemaining > 0) {
+			this.schedule(cooldownRemaining, false);
+			return;
+		}
+		if (this.inFlight) return;
+
+		this.lastAttemptAt = this.now();
+		const controller = new AbortController();
+		this.attemptAbort = controller;
+		const attempt = Promise.resolve().then(async () => {
+			await this.runtime.bootstrap(controller.signal);
+		});
+		const flight = attempt
+			.catch((error) => {
+				if (this.running && !controller.signal.aborted) {
+					this.runtime.onError?.(error);
+				}
+			})
+			.finally(() => {
+				if (this.inFlight !== flight) return;
+				this.inFlight = undefined;
+				if (this.attemptAbort === controller) {
+					this.attemptAbort = undefined;
+				}
+				if (!this.running) return;
+				if (this.runtime.isConnected()) {
+					this.markConnected();
+					return;
+				}
+				// A bootstrap call that returns after its connection has already closed is
+				// still a recovery failure and must remain on the bounded retry path.
+				this.scheduleRetry();
+			});
+		this.inFlight = flight;
+	}
+
+	private scheduleRetry(): void {
+		const exponent = Math.min(this.consecutiveFailures, 52);
+		const baseDelay = Math.min(
+			this.options.maxDelayMs,
+			this.options.initialDelayMs *
+				Math.pow(this.options.backoffFactor, exponent),
+		);
+		this.consecutiveFailures += 1;
+		const random = Math.max(0, Math.min(1, this.random()));
+		const jitterMultiplier = 1 + (random * 2 - 1) * this.options.jitter;
+		const retryDelay = Math.max(
+			1,
+			Math.min(
+				this.options.maxDelayMs,
+				Math.round(baseDelay * jitterMultiplier),
+			),
+		);
+		const now = this.now();
+		const cooldownRemaining = Math.max(
+			0,
+			this.lastAttemptAt + this.options.cooldownMs - now,
+		);
+		const delay = Math.max(retryDelay, cooldownRemaining);
+		this.retryNotBefore = now + delay;
+		this.schedule(delay, false);
+	}
+}

--- a/packages/clients/peerbit/src/bootstrap.ts
+++ b/packages/clients/peerbit/src/bootstrap.ts
@@ -202,8 +202,20 @@ const readBootstrapList = async (response: Response): Promise<string> => {
 	}
 };
 
-const fetchBootstrapAddresses = async (source: string): Promise<string[]> => {
+const abortReason = (signal: AbortSignal): unknown =>
+	signal.reason ?? new Error("Bootstrap address resolution aborted");
+
+const fetchBootstrapAddresses = async (
+	source: string,
+	externalSignal?: AbortSignal,
+): Promise<string[]> => {
 	const controller = new AbortController();
+	const onExternalAbort = () => controller.abort(abortReason(externalSignal!));
+	if (externalSignal?.aborted) {
+		onExternalAbort();
+	} else {
+		externalSignal?.addEventListener("abort", onExternalAbort, { once: true });
+	}
 	const timeout = setTimeout(() => {
 		controller.abort(
 			new Error(
@@ -233,17 +245,29 @@ const fetchBootstrapAddresses = async (source: string): Promise<string[]> => {
 		throw error;
 	} finally {
 		clearTimeout(timeout);
+		externalSignal?.removeEventListener("abort", onExternalAbort);
 	}
+};
+
+export type ResolveBootstrapAddressesOptions = {
+	signal?: AbortSignal;
 };
 
 export const resolveBootstrapAddresses = async (
 	v: string = "5",
+	options: ResolveBootstrapAddressesOptions = {},
 ): Promise<string[]> => {
 	const failures: Error[] = [];
 	for (const source of getBootstrapListSources(v)) {
+		if (options.signal?.aborted) {
+			throw abortReason(options.signal);
+		}
 		try {
-			return await fetchBootstrapAddresses(source);
+			return await fetchBootstrapAddresses(source, options.signal);
 		} catch (error) {
+			if (options.signal?.aborted) {
+				throw abortReason(options.signal);
+			}
 			failures.push(
 				new Error(
 					`Failed to load bootstrap addresses from ${source}: ${

--- a/packages/clients/peerbit/src/index.ts
+++ b/packages/clients/peerbit/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./peer.js";
 export * from "./bootstrap.js";
+export type { BootstrapRecoveryOptions } from "./bootstrap-recovery.js";
 export {
 	createLibp2pExtended,
 	type Libp2pExtendServices,

--- a/packages/clients/peerbit/src/peer.ts
+++ b/packages/clients/peerbit/src/peer.ts
@@ -43,6 +43,12 @@ import path from "path-browserify";
 import { concat } from "uint8arrays";
 import { getBootstrapPeerId, resolveBootstrapAddresses } from "./bootstrap.js";
 import {
+	BootstrapRecoveryController,
+	type BootstrapRecoveryEventTarget,
+	type BootstrapRecoveryOptions,
+	validateBootstrapRecoveryOptions,
+} from "./bootstrap-recovery.js";
+import {
 	type Libp2pCreateOptions as ClientCreateOptions,
 	type Libp2pExtended,
 	type PartialLibp2pCreateOptions,
@@ -169,6 +175,12 @@ export type CreateInstanceOptions = (SimpleLibp2pOptions | Libp2pOptions) & {
 	indexer?: (directory?: string) => Promise<Indices> | Indices;
 	storage?: StorageCreateOptions;
 	network?: NativeNetworkCreateOptions;
+	/**
+	 * Opt-in automatic bootstrap recovery. `true` uses bounded defaults; an
+	 * options object customizes retry policy or fixed targets. It is disabled by
+	 * default to avoid unexpected network access from `Peerbit.create()`.
+	 */
+	bootstrapRecovery?: boolean | BootstrapRecoveryOptions;
 } & OptionalCreateOptions;
 
 export type DialReadiness =
@@ -193,6 +205,11 @@ export type BootstrapResult = {
 	failures: BootstrapFailure[];
 };
 
+export type BootstrapDialOptions = {
+	dialTimeoutMs?: number;
+	signal?: AbortSignal;
+};
+
 const isLibp2pInstance = (libp2p: Libp2pExtended | ClientCreateOptions) =>
 	!!(libp2p as Libp2p).getMultiaddrs;
 
@@ -210,6 +227,17 @@ const createCache = async (
 	return cache;
 };
 
+const getOnlineEventTarget = (): BootstrapRecoveryEventTarget | undefined => {
+	const target = globalThis as unknown as Partial<BootstrapRecoveryEventTarget>;
+	return typeof target.addEventListener === "function" &&
+		typeof target.removeEventListener === "function"
+		? (target as BootstrapRecoveryEventTarget)
+		: undefined;
+};
+
+const isEnvironmentOnline = (): boolean =>
+	typeof navigator === "undefined" || navigator.onLine !== false;
+
 const SELF_IDENTITY_KEY_ID = new Uint8Array([
 	95, 95, 115, 101, 108, 102, 95, 95,
 ]); // new TextEncoder().encode("__self__");
@@ -223,6 +251,11 @@ export class Peerbit implements ProgramClient {
 	private _indexer: Indices;
 	private _libp2pExternal?: boolean = false;
 	private _nativeNetwork?: NativeNetworkRuntime;
+	private _bootstrapRecoveryOptions?: BootstrapRecoveryOptions;
+	private _bootstrapRecovery?: BootstrapRecoveryController;
+	private _bootstrapRecoveryGeneration = 0;
+	private _bootstrapRecoveryTransition: Promise<void> = Promise.resolve();
+	private _bootstrapRecoveryPaused = false;
 
 	/**
 	 * Native shared-log defaults advertised to programs opened on this
@@ -266,6 +299,14 @@ export class Peerbit implements ProgramClient {
 	}
 
 	static async create(options: CreateInstanceOptions = {}): Promise<Peerbit> {
+		const bootstrapRecoveryOptions = options.bootstrapRecovery;
+		if (
+			bootstrapRecoveryOptions &&
+			bootstrapRecoveryOptions !== true &&
+			bootstrapRecoveryOptions.enabled !== false
+		) {
+			validateBootstrapRecoveryOptions(bootstrapRecoveryOptions);
+		}
 		await sodium.ready; // Some of the modules depends on sodium to be readyy
 
 		let libp2pExtended: Libp2pExtended | undefined = (options as Libp2pOptions)
@@ -594,6 +635,14 @@ export class Peerbit implements ProgramClient {
 			nativeNetwork,
 			sharedLogNativeDefaults,
 		});
+		if (options.bootstrapRecovery === true) {
+			peer.enableBootstrapRecovery();
+		} else if (
+			options.bootstrapRecovery &&
+			options.bootstrapRecovery.enabled !== false
+		) {
+			peer.enableBootstrapRecovery(options.bootstrapRecovery);
+		}
 		return peer;
 	}
 	get libp2p(): Libp2pExtended {
@@ -734,16 +783,98 @@ export class Peerbit implements ProgramClient {
 		// TODO wait for pubsub and blocks to disconnect?
 	}
 
+	get bootstrapRecoveryEnabled(): boolean {
+		return this._bootstrapRecoveryOptions != null;
+	}
+
+	/** Enable automatic recovery and schedule an immediate attempt if disconnected. */
+	enableBootstrapRecovery(options: BootstrapRecoveryOptions = {}): void {
+		if (options.enabled === false) {
+			this.disableBootstrapRecovery();
+			return;
+		}
+		validateBootstrapRecoveryOptions(options);
+		this._bootstrapRecoveryOptions = {
+			...options,
+			enabled: true,
+			addresses: options.addresses ? [...options.addresses] : undefined,
+		};
+		this.transitionBootstrapRecovery(true);
+	}
+
+	/** Disable recovery, remove environment listeners, and abort its active dial. */
+	disableBootstrapRecovery(): void {
+		this._bootstrapRecoveryOptions = undefined;
+		this.transitionBootstrapRecovery(false);
+	}
+
+	private transitionBootstrapRecovery(startAfterDrain: boolean): Promise<void> {
+		const generation = ++this._bootstrapRecoveryGeneration;
+		const previous = this._bootstrapRecovery;
+		this._bootstrapRecovery = undefined;
+		const drain = previous?.stop() ?? Promise.resolve();
+		const transition = Promise.all([
+			this._bootstrapRecoveryTransition,
+			drain,
+		]).then(() => {
+			if (
+				startAfterDrain &&
+				generation === this._bootstrapRecoveryGeneration
+			) {
+				this.startBootstrapRecovery();
+			}
+		});
+		this._bootstrapRecoveryTransition = transition.catch((error) => {
+			logger.error(`Bootstrap recovery lifecycle transition failed: ${error}`);
+		});
+		return this._bootstrapRecoveryTransition;
+	}
+
+	private startBootstrapRecovery(): void {
+		const options = this._bootstrapRecoveryOptions;
+		if (
+			!options ||
+			this._bootstrapRecovery ||
+			this._bootstrapRecoveryPaused ||
+			this.libp2p.status !== "started"
+		) {
+			return;
+		}
+		const controller = new BootstrapRecoveryController(
+			{
+				bootstrap: (signal) => {
+					const addresses = this._bootstrapRecoveryOptions?.addresses;
+					return this.bootstrap(addresses ? [...addresses] : undefined, {
+						signal,
+					});
+				},
+				connectionEvents: this
+					.libp2p as unknown as BootstrapRecoveryEventTarget,
+				onlineEvents: getOnlineEventTarget(),
+				isConnected: () => this.libp2p.getConnections().length > 0,
+				isOnline: isEnvironmentOnline,
+			},
+			options,
+		);
+		this._bootstrapRecovery = controller;
+		controller.start();
+	}
+
 	async start() {
 		await this._storage.open();
 		await this.indexer.start();
 
 		if (this.libp2p.status === "stopped" || this.libp2p.status === "stopping") {
 			this._libp2pExternal = false; // this means we will also close libp2p client on close
-			return this.libp2p.start();
+			await this.libp2p.start();
 		}
+		this._bootstrapRecoveryPaused = false;
+		await this._bootstrapRecoveryTransition;
+		this.startBootstrapRecovery();
 	}
 	async stop() {
+		this._bootstrapRecoveryPaused = true;
+		await this.transitionBootstrapRecovery(false);
 		await this._handler?.stop();
 		await this._storage.close();
 		await this.indexer.stop();
@@ -755,8 +886,16 @@ export class Peerbit implements ProgramClient {
 		}
 	}
 
-	async bootstrap(addresses?: string[] | Multiaddr[]) {
-		const _addresses = addresses ?? (await resolveBootstrapAddresses());
+	async bootstrap(
+		addresses?: Array<string | Multiaddr>,
+		options: BootstrapDialOptions = {},
+	) {
+		if (options.signal?.aborted) {
+			throw options.signal.reason ?? new Error("Bootstrap aborted");
+		}
+		const _addresses =
+			addresses ??
+			(await resolveBootstrapAddresses("5", { signal: options.signal }));
 		if (_addresses.length === 0) {
 			throw new Error("Failed to find any addresses to dial");
 		}
@@ -785,7 +924,7 @@ export class Peerbit implements ProgramClient {
 			byPeerId.set(pid, list);
 		}
 
-		const dialTimeoutMs = 30_000;
+		const dialTimeoutMs = options.dialTimeoutMs ?? 30_000;
 		const scoreBootstrapAddr = (a: Multiaddr) => {
 			const s = a.toString();
 			const isCircuit = s.includes("p2p-circuit");
@@ -803,7 +942,11 @@ export class Peerbit implements ProgramClient {
 					// Bootstrap nodes are rendezvous points; they may not immediately satisfy
 					// "services" readiness (pubsub/blocks/fanout neighbor checks), especially in
 					// browser runtimes. A successful transport-level dial is enough here.
-					await this.dial(ma, { dialTimeoutMs, readiness: "connection" });
+					await this.dial(ma, {
+						dialTimeoutMs,
+						readiness: "connection",
+						signal: options.signal,
+					});
 					return true;
 				} catch (e) {
 					lastError = e;
@@ -832,11 +975,15 @@ export class Peerbit implements ProgramClient {
 				promise: this.dial(typeof a === "string" ? multiaddr(a) : a, {
 					dialTimeoutMs,
 					readiness: "connection",
+					signal: options.signal,
 				}),
 			});
 		}
 
 		const settled = await Promise.allSettled(dialTasks.map((t) => t.promise));
+		if (options.signal?.aborted) {
+			throw options.signal.reason ?? new Error("Bootstrap aborted");
+		}
 		let once = false;
 		const connectedPeerIds = new Set<string>();
 		const failures: BootstrapFailure[] = [];

--- a/packages/clients/peerbit/test/bootstrap-addresses.spec.ts
+++ b/packages/clients/peerbit/test/bootstrap-addresses.spec.ts
@@ -336,6 +336,38 @@ describe("resolveBootstrapAddresses", () => {
 		}
 	});
 
+	it("aborts recovery discovery without trying the fallback source", async () => {
+		let requestCount = 0;
+		let fetchSignal: AbortSignal | null | undefined;
+		globalThis.fetch = ((_input, init) => {
+			requestCount += 1;
+			fetchSignal = init?.signal;
+			return new Promise<Response>((_resolve, reject) => {
+				const signal = init?.signal;
+				if (!signal) {
+					reject(new Error("Missing bootstrap fetch signal"));
+					return;
+				}
+				const onAbort = () => reject(signal.reason);
+				if (signal.aborted) {
+					onAbort();
+				} else {
+					signal.addEventListener("abort", onAbort, { once: true });
+				}
+			});
+		}) as typeof fetch;
+		const controller = new AbortController();
+		const failure = resolveBootstrapAddresses("5", {
+			signal: controller.signal,
+		}).catch((error) => error);
+		await Promise.resolve();
+		controller.abort(new Error("recovery stopped"));
+
+		expect((await failure).message).to.equal("recovery stopped");
+		expect(requestCount).to.equal(1);
+		expect(fetchSignal?.aborted).to.equal(true);
+	});
+
 	it("reports every source failure instead of returning an empty list", async () => {
 		globalThis.fetch = (async (input: string | URL | Request) => {
 			const url =

--- a/packages/clients/peerbit/test/bootstrap-recovery.spec.ts
+++ b/packages/clients/peerbit/test/bootstrap-recovery.spec.ts
@@ -1,0 +1,545 @@
+import { waitForResolved } from "@peerbit/time";
+import { expect } from "chai";
+import sinon from "sinon";
+import {
+	BootstrapRecoveryController,
+	type BootstrapRecoveryRuntime,
+	validateBootstrapRecoveryOptions,
+} from "../src/bootstrap-recovery.js";
+import { Peerbit } from "../src/peer.js";
+
+const peerIdA = "12D3KooWKj1J1hHxrYyB37qDDGCi9aU2vcHzDZhtMk7te7dEmqqT";
+const peerIdB = "12D3KooWAYyiQBc1ti51riCkNX6Nvh33pWWvNfyrcPHrq373qCju";
+const addressA = `/dns4/node-a.peerchecker.com/tcp/4003/wss/p2p/${peerIdA}`;
+const addressB = `/dns4/node-b.peerchecker.com/tcp/4003/wss/p2p/${peerIdB}`;
+const isNode = typeof process !== "undefined" && !!process.versions?.node;
+
+const makeRuntime = (properties: {
+	bootstrap: BootstrapRecoveryRuntime["bootstrap"];
+	connected: () => boolean;
+	online?: () => boolean;
+	connectionEvents?: EventTarget;
+	onlineEvents?: EventTarget;
+	random?: () => number;
+}): BootstrapRecoveryRuntime => ({
+	bootstrap: properties.bootstrap,
+	isConnected: properties.connected,
+	isOnline: properties.online,
+	connectionEvents: properties.connectionEvents ?? new EventTarget(),
+	onlineEvents: properties.onlineEvents,
+	random: properties.random,
+});
+
+describe("bootstrap recovery policy", () => {
+	let clock: sinon.SinonFakeTimers;
+	let controller: BootstrapRecoveryController | undefined;
+
+	beforeEach(() => {
+		clock = sinon.useFakeTimers({
+			now: 0,
+			shouldClearNativeTimers: true,
+			toFake: ["Date", "setTimeout", "clearTimeout"],
+		});
+	});
+
+	afterEach(async () => {
+		await controller?.stop();
+		controller = undefined;
+		clock.restore();
+	});
+
+	it("enforces the portable JavaScript timer boundary", () => {
+		const maximumTimerDelayMs = 2_147_483_647;
+		expect(() =>
+			validateBootstrapRecoveryOptions({
+				initialDelayMs: maximumTimerDelayMs,
+				maxDelayMs: maximumTimerDelayMs,
+				cooldownMs: maximumTimerDelayMs,
+			}),
+		).not.to.throw();
+
+		for (const field of [
+			"initialDelayMs",
+			"maxDelayMs",
+			"cooldownMs",
+		] as const) {
+			expect(() =>
+				validateBootstrapRecoveryOptions({
+					[field]: maximumTimerDelayMs + 1,
+				}),
+			).to.throw(
+				`bootstrapRecovery.${field} must be <= ${maximumTimerDelayMs}`,
+			);
+		}
+	});
+
+	it("recovers an offline-at-start browser on its online signal", async () => {
+		const connectionEvents = new EventTarget();
+		const onlineEvents = new EventTarget();
+		let connected = false;
+		let online = false;
+		let attempts = 0;
+		controller = new BootstrapRecoveryController(
+			makeRuntime({
+				connectionEvents,
+				onlineEvents,
+				connected: () => connected,
+				online: () => online,
+				bootstrap: async () => {
+					attempts += 1;
+					connected = true;
+				},
+			}),
+			{
+				initialDelayMs: 100,
+				maxDelayMs: 800,
+				cooldownMs: 50,
+				jitter: 0,
+			},
+		);
+
+		controller.start();
+		await clock.tickAsync(0);
+		expect(attempts).to.equal(0);
+		expect(clock.countTimers()).to.equal(1);
+
+		online = true;
+		onlineEvents.dispatchEvent(new Event("online"));
+		await clock.tickAsync(0);
+		expect(attempts).to.equal(1);
+		expect(clock.countTimers()).to.equal(0);
+	});
+
+	it("recovers after the last connection closes while respecting cooldown", async () => {
+		const connectionEvents = new EventTarget();
+		let connected = true;
+		let attempts = 0;
+		controller = new BootstrapRecoveryController(
+			makeRuntime({
+				connectionEvents,
+				connected: () => connected,
+				bootstrap: async () => {
+					attempts += 1;
+					connected = true;
+				},
+			}),
+			{
+				initialDelayMs: 100,
+				maxDelayMs: 100,
+				cooldownMs: 50,
+				jitter: 0,
+			},
+		);
+
+		controller.start();
+		connected = false;
+		connectionEvents.dispatchEvent(new Event("connection:close"));
+		await clock.tickAsync(49);
+		expect(attempts).to.equal(0);
+		await clock.tickAsync(1);
+		expect(attempts).to.equal(1);
+	});
+
+	it("bounds exponential backoff and deterministic jitter", async () => {
+		const attemptTimes: number[] = [];
+		controller = new BootstrapRecoveryController(
+			makeRuntime({
+				connected: () => false,
+				random: () => 1,
+				bootstrap: async () => {
+					attemptTimes.push(Date.now());
+					throw new Error("offline");
+				},
+			}),
+			{
+				initialDelayMs: 100,
+				maxDelayMs: 250,
+				backoffFactor: 2,
+				cooldownMs: 0,
+				jitter: 0.5,
+			},
+		);
+
+		controller.start();
+		await clock.tickAsync(0);
+		await clock.tickAsync(150);
+		await clock.tickAsync(250);
+		await clock.tickAsync(250);
+		expect(attemptTimes).to.deep.equal([0, 150, 400, 650]);
+	});
+
+	it("keeps a non-zero retry floor under maximum negative jitter", async () => {
+		let attempts = 0;
+		controller = new BootstrapRecoveryController(
+			makeRuntime({
+				connected: () => false,
+				random: () => 0,
+				bootstrap: async () => {
+					attempts += 1;
+					throw new Error("offline");
+				},
+			}),
+			{
+				initialDelayMs: 1,
+				maxDelayMs: 1,
+				cooldownMs: 0,
+				jitter: 1,
+			},
+		);
+
+		controller.start();
+		await clock.tickAsync(0);
+		expect(attempts).to.equal(1);
+		await clock.tickAsync(0);
+		expect(attempts).to.equal(1);
+		await clock.tickAsync(1);
+		expect(attempts).to.equal(2);
+	});
+
+	it("keeps retries single-flight with one timer under event storms", async () => {
+		const connectionEvents = new EventTarget();
+		const onlineEvents = new EventTarget();
+		let attempts = 0;
+		let rejectAttempt!: (error: Error) => void;
+		controller = new BootstrapRecoveryController(
+			makeRuntime({
+				connectionEvents,
+				onlineEvents,
+				connected: () => false,
+				bootstrap: () => {
+					attempts += 1;
+					return new Promise<void>((_resolve, reject) => {
+						rejectAttempt = reject;
+					});
+				},
+			}),
+			{
+				initialDelayMs: 100,
+				maxDelayMs: 400,
+				cooldownMs: 0,
+				jitter: 0,
+			},
+		);
+
+		controller.start();
+		await clock.tickAsync(0);
+		for (let index = 0; index < 20; index++) {
+			connectionEvents.dispatchEvent(new Event("connection:close"));
+			onlineEvents.dispatchEvent(new Event("online"));
+		}
+		await clock.tickAsync(1_000);
+		expect(attempts).to.equal(1);
+		expect(clock.countTimers()).to.equal(0);
+
+		rejectAttempt(new Error("offline"));
+		await clock.tickAsync(0);
+		expect(clock.countTimers()).to.equal(1);
+		for (let index = 0; index < 20; index++) {
+			connectionEvents.dispatchEvent(new Event("connection:close"));
+		}
+		expect(clock.countTimers()).to.equal(1);
+	});
+
+	it("preserves exponential backoff across online event storms", async () => {
+		const onlineEvents = new EventTarget();
+		const attemptTimes: number[] = [];
+		controller = new BootstrapRecoveryController(
+			makeRuntime({
+				onlineEvents,
+				connected: () => false,
+				bootstrap: async () => {
+					attemptTimes.push(Date.now());
+					throw new Error("offline");
+				},
+			}),
+			{
+				initialDelayMs: 100,
+				maxDelayMs: 800,
+				backoffFactor: 2,
+				cooldownMs: 0,
+				jitter: 0,
+			},
+		);
+
+		controller.start();
+		await clock.tickAsync(0);
+		await clock.tickAsync(10);
+		for (let index = 0; index < 20; index++) {
+			onlineEvents.dispatchEvent(new Event("online"));
+		}
+		await clock.tickAsync(89);
+		expect(attemptTimes).to.deep.equal([0]);
+		await clock.tickAsync(1);
+		expect(attemptTimes).to.deep.equal([0, 100]);
+
+		await clock.tickAsync(10);
+		for (let index = 0; index < 20; index++) {
+			onlineEvents.dispatchEvent(new Event("online"));
+		}
+		await clock.tickAsync(189);
+		expect(attemptTimes).to.deep.equal([0, 100]);
+		await clock.tickAsync(1);
+		expect(attemptTimes).to.deep.equal([0, 100, 300]);
+	});
+
+	it("lets an event-emitting successful bootstrap finish", async () => {
+		const connectionEvents = new EventTarget();
+		let connected = false;
+		let completed = false;
+		let attemptSignal: AbortSignal | undefined;
+		controller = new BootstrapRecoveryController(
+			makeRuntime({
+				connectionEvents,
+				connected: () => connected,
+				bootstrap: async (signal) => {
+					attemptSignal = signal;
+					connected = true;
+					connectionEvents.dispatchEvent(new Event("connection:open"));
+					await Promise.resolve();
+					completed = true;
+				},
+			}),
+			{ cooldownMs: 0 },
+		);
+
+		controller.start();
+		await clock.tickAsync(0);
+		expect(attemptSignal?.aborted).to.equal(false);
+		expect(completed).to.equal(true);
+	});
+
+	it("aborts active work and removes listeners and timers on stop", async () => {
+		const connectionEvents = new EventTarget();
+		const onlineEvents = new EventTarget();
+		let attempts = 0;
+		let attemptSignal: AbortSignal | undefined;
+		controller = new BootstrapRecoveryController(
+			makeRuntime({
+				connectionEvents,
+				onlineEvents,
+				connected: () => false,
+				bootstrap: (signal) => {
+					attempts += 1;
+					attemptSignal = signal;
+					return new Promise<void>((_resolve, reject) => {
+						signal.addEventListener("abort", () => reject(signal.reason), {
+							once: true,
+						});
+					});
+				},
+			}),
+			{
+				initialDelayMs: 100,
+				maxDelayMs: 400,
+				cooldownMs: 0,
+				jitter: 0,
+			},
+		);
+
+		controller.start();
+		await clock.tickAsync(0);
+		controller.stop();
+		await clock.tickAsync(0);
+		expect(attemptSignal?.aborted).to.equal(true);
+		expect(clock.countTimers()).to.equal(0);
+
+		connectionEvents.dispatchEvent(new Event("connection:close"));
+		onlineEvents.dispatchEvent(new Event("online"));
+		await clock.tickAsync(1_000);
+		expect(attempts).to.equal(1);
+	});
+});
+
+describe("Peerbit bootstrap recovery integration", () => {
+	it("keeps recovery opt-in and supports the create-time policy", async () => {
+		await expect(
+			Peerbit.create({ bootstrapRecovery: { addresses: [] } }),
+		).to.be.rejectedWith("bootstrapRecovery.addresses must not be empty");
+		const disabled = await Peerbit.create();
+		const enabled = await Peerbit.create({
+			bootstrapRecovery: {
+				addresses: [addressA],
+				initialDelayMs: 100,
+				maxDelayMs: 100,
+			},
+		});
+		try {
+			expect(disabled.bootstrapRecoveryEnabled).to.equal(false);
+			expect(enabled.bootstrapRecoveryEnabled).to.equal(true);
+			expect(() =>
+				enabled.enableBootstrapRecovery({ initialDelayMs: 0 }),
+			).to.throw(
+				"bootstrapRecovery.initialDelayMs must be a finite number >= 1",
+			);
+			expect(enabled.bootstrapRecoveryEnabled).to.equal(true);
+			enabled.disableBootstrapRecovery();
+			expect(enabled.bootstrapRecoveryEnabled).to.equal(false);
+		} finally {
+			disabled.disableBootstrapRecovery();
+			enabled.disableBootstrapRecovery();
+			await disabled.stop();
+			await enabled.stop();
+		}
+	});
+
+	it("refreshes the default bootstrap list and rotates endpoints", async () => {
+		const peer = await Peerbit.create();
+		const originalFetch = globalThis.fetch;
+		const requested: string[] = [];
+		const dialed: string[] = [];
+		let responseIndex = 0;
+		const dialStub = sinon.stub(peer, "dial").callsFake(async (address) => {
+			dialed.push(address.toString());
+			throw new Error("offline");
+		});
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			requested.push(
+				typeof input === "string"
+					? input
+					: input instanceof URL
+						? input.toString()
+						: input.url,
+			);
+			const address = responseIndex++ === 0 ? addressA : addressB;
+			return new Response(`${address}\n`, { status: 200 });
+		}) as typeof fetch;
+		const clock = sinon.useFakeTimers({
+			now: 0,
+			shouldClearNativeTimers: true,
+			toFake: ["Date", "setTimeout", "clearTimeout"],
+		});
+
+		try {
+			peer.enableBootstrapRecovery({
+				initialDelayMs: 100,
+				maxDelayMs: 100,
+				cooldownMs: 0,
+				jitter: 0,
+			});
+			await clock.tickAsync(0);
+			await clock.tickAsync(100);
+
+			expect(requested).to.deep.equal([
+				"https://bootstrap.peerbit.org/bootstrap-5.env",
+				"https://bootstrap.peerbit.org/bootstrap-5.env",
+			]);
+			expect(dialed).to.deep.equal([addressA, addressB]);
+		} finally {
+			peer.disableBootstrapRecovery();
+			clock.restore();
+			globalThis.fetch = originalFetch;
+			dialStub.restore();
+			await peer.stop();
+		}
+	});
+
+	it("serializes delayed cancellation before re-enabling", async () => {
+		const peer = await Peerbit.create();
+		const clock = sinon.useFakeTimers({
+			now: 0,
+			shouldClearNativeTimers: true,
+			toFake: ["Date", "setTimeout", "clearTimeout"],
+		});
+		const attempts: Array<{
+			addresses: Array<string>;
+			signal: AbortSignal;
+			release: () => void;
+		}> = [];
+		let active = 0;
+		let maxActive = 0;
+		const bootstrapStub = sinon.stub(peer, "bootstrap").callsFake(
+			(addresses, options = {}) =>
+				new Promise((resolve) => {
+					active += 1;
+					maxActive = Math.max(maxActive, active);
+					let released = false;
+					attempts.push({
+						addresses: (addresses ?? []).map((address) => address.toString()),
+						signal: options.signal!,
+						release: () => {
+							if (released) return;
+							released = true;
+							active -= 1;
+							resolve({ connectedPeerIds: [], failures: [] });
+						},
+					});
+				}),
+		);
+
+		try {
+			peer.enableBootstrapRecovery({
+				addresses: [addressA],
+				initialDelayMs: 100,
+				maxDelayMs: 100,
+				cooldownMs: 0,
+				jitter: 0,
+			});
+			await clock.tickAsync(0);
+			expect(attempts).to.have.length(1);
+
+			peer.disableBootstrapRecovery();
+			peer.enableBootstrapRecovery({
+				addresses: [addressB],
+				initialDelayMs: 100,
+				maxDelayMs: 100,
+				cooldownMs: 0,
+				jitter: 0,
+			});
+			expect(attempts[0]!.signal.aborted).to.equal(true);
+			await clock.tickAsync(1_000);
+			expect(attempts).to.have.length(1);
+
+			attempts[0]!.release();
+			await clock.tickAsync(0);
+			expect(attempts).to.have.length(2);
+			expect(attempts[1]!.addresses).to.deep.equal([addressB]);
+			expect(maxActive).to.equal(1);
+		} finally {
+			peer.disableBootstrapRecovery();
+			for (const attempt of attempts) attempt.release();
+			await clock.tickAsync(0);
+			clock.restore();
+			bootstrapStub.restore();
+			await peer.stop();
+		}
+	});
+
+	(isNode ? it : it.skip)(
+		"completes Peerbit bootstrap side effects after a real connection event",
+		async function () {
+			this.timeout(180_000);
+			const bootstrapPeer = await Peerbit.create();
+			const peer = await Peerbit.create();
+			const setCandidatesSpy = sinon.spy(
+				peer.services.pubsub,
+				"setTopicRootCandidates",
+			);
+
+			try {
+				peer.enableBootstrapRecovery({
+					addresses: bootstrapPeer.getMultiaddrs(),
+					initialDelayMs: 100,
+					maxDelayMs: 100,
+					cooldownMs: 0,
+					jitter: 0,
+				});
+				await waitForResolved(
+					() => {
+						expect(peer.libp2p.getConnections(bootstrapPeer.peerId)).not.to.be
+							.empty;
+						expect(setCandidatesSpy.called).to.equal(true);
+					},
+					{ timeout: 30_000, delayInterval: 20 },
+				);
+				expect(setCandidatesSpy.lastCall.args[0]).to.deep.equal([
+					bootstrapPeer.services.pubsub.publicKeyHash,
+				]);
+			} finally {
+				peer.disableBootstrapRecovery();
+				setCandidatesSpy.restore();
+				await peer.stop();
+				await bootstrapPeer.stop();
+			}
+		},
+	);
+});


### PR DESCRIPTION
Fixes #622

Adds opt-in automatic bootstrap recovery with:
- single-flight recovery attempts and lifecycle-safe cancellation/draining
- bounded exponential backoff, jitter, cooldown, and portable timer limits
- browser online wakeups without bypassing failure backoff
- refreshed default bootstrap discovery on every attempt
- fixed-target endpoint rotation support
- completion of Peerbit topic-root bootstrap side effects after transport connection events

Recovery remains disabled by default.

Validation:
- peerbit Node suite: 89 passing, 1 existing pending
- focused recovery/address suite after final audit: 24 passing
- peerbit build and repository CI lint
- Prettier and git diff checks