### PR TITLE
test(indexer-sqlite3): isolate Node-only assertion

### DIFF
--- a/packages/utils/indexer/sqlite3/test/statement.spec.ts
+++ b/packages/utils/indexer/sqlite3/test/statement.spec.ts
@@ -6,11 +6,11 @@ import {
 	toId,
 } from "@peerbit/indexer-interface";
 import { expect } from "chai";
-import path from "node:path";
-import { pathToFileURL } from "node:url";
 import { SQLiteIndex } from "../src/engine.js";
 import { create } from "../src/index.js";
 import { setup } from "./utils.js";
+
+const isNode = typeof process !== "undefined" && process.versions?.node != null;
 
 describe("statement", () => {
 	let index: Awaited<ReturnType<typeof setup<any>>>;
@@ -76,12 +76,20 @@ describe("statement", () => {
 			); // + count stmt
 		});
 
-		it("count with a foreign query instance", async () => {
+		(isNode ? it : it.skip)("count with a foreign query instance", async () => {
 			await store.put(new DocumentWithFromProperty("1", "from1"));
+			// Keep Node built-ins behind non-literal dynamic imports. Aegir bundles this
+			// test file for browsers too, where static `node:` imports cannot resolve.
+			const pathModule = "node:path";
+			const urlModule = "node:url";
+			const [path, { pathToFileURL }] = await Promise.all([
+				import(pathModule) as Promise<typeof import("node:path")>,
+				import(urlModule) as Promise<typeof import("node:url")>,
+			]);
 			const { StringMatch: ForeignStringMatch } = await import(
 				pathToFileURL(
 					path.resolve(process.cwd(), "../interface/dist/src/query.js"),
-				).href,
+				).href
 			);
 
 			expect(


### PR DESCRIPTION
## Summary

- keep the filesystem-based foreign-query assertion active in Node
- skip that Node-only assertion in browser and worker runners
- hide `node:path` and `node:url` behind non-literal dynamic imports so Aegir can bundle the shared test file for Chromium

## Why

The unchanged `master` baseline fails before browser execution because esbuild tries to resolve the test's static `node:` imports for a browser target. This prevents the full workspace test command from completing and also masked dependency-rollup verification.

## Verification

- unchanged baseline reproduced the `Could not resolve "node:path"` / `node:url` failure
- `pnpm --filter @peerbit/indexer-sqlite3 test:browser`: 306 passing, 1 intentional Node-only pending
- `pnpm --filter @peerbit/indexer-sqlite3 test:node`: 307 passing, including `count with a foreign query instance`
- focused Prettier, ESLint, and `git diff --check`
