### PR TITLE
test(peerbit): restore browser target coverage

### DIFF
--- a/packages/clients/peerbit/test/bootstrap-recovery.spec.ts
+++ b/packages/clients/peerbit/test/bootstrap-recovery.spec.ts
@@ -7,6 +7,7 @@ import {
 	validateBootstrapRecoveryOptions,
 } from "../src/bootstrap-recovery.js";
 import { Peerbit } from "../src/peer.js";
+import { expectRejectedWith } from "./utils/rejection.js";
 
 const peerIdA = "12D3KooWKj1J1hHxrYyB37qDDGCi9aU2vcHzDZhtMk7te7dEmqqT";
 const peerIdB = "12D3KooWAYyiQBc1ti51riCkNX6Nvh33pWWvNfyrcPHrq373qCju";
@@ -352,9 +353,10 @@ describe("bootstrap recovery policy", () => {
 
 describe("Peerbit bootstrap recovery integration", () => {
 	it("keeps recovery opt-in and supports the create-time policy", async () => {
-		await expect(
+		await expectRejectedWith(
 			Peerbit.create({ bootstrapRecovery: { addresses: [] } }),
-		).to.be.rejectedWith("bootstrapRecovery.addresses must not be empty");
+			"bootstrapRecovery.addresses must not be empty",
+		);
 		const disabled = await Peerbit.create();
 		const enabled = await Peerbit.create({
 			bootstrapRecovery: {

--- a/packages/clients/peerbit/test/bootstrap.spec.ts
+++ b/packages/clients/peerbit/test/bootstrap.spec.ts
@@ -1,12 +1,13 @@
-import { expect } from "chai";
-import sinon from "sinon";
 import { noise } from "@chainsafe/libp2p-noise";
 import { yamux } from "@chainsafe/libp2p-yamux";
 import { identify } from "@libp2p/identify";
-import { webSockets } from "@libp2p/websockets";
 import type { Libp2p } from "@libp2p/interface";
+import { webSockets } from "@libp2p/websockets";
+import { expect } from "chai";
 import { createLibp2p } from "libp2p";
+import sinon from "sinon";
 import { Peerbit } from "../src/peer.js";
+import { expectRejectedWith } from "./utils/rejection.js";
 
 const isNode = typeof process !== "undefined" && !!process.versions?.node;
 
@@ -31,7 +32,9 @@ describe("bootstrap", () => {
 		await peer.bootstrap(bootstrapPeer.getMultiaddrs());
 		// Bootstrap readiness is transport-level; DirectStream neighbours may establish
 		// asynchronously after the dial succeeds.
-		expect(peer.libp2p.getConnections(bootstrapPeer.peerId).length).greaterThan(0);
+		expect(peer.libp2p.getConnections(bootstrapPeer.peerId).length).greaterThan(
+			0,
+		);
 	});
 
 	(isNode ? it : it.skip)("remote", async function () {
@@ -74,53 +77,61 @@ describe("bootstrap", () => {
 		},
 	);
 
-	it("reports partial failures when one bootstrap peer is reachable and another is not", async function () {
-		this.timeout(180_000);
-		const unreachable = `/ip4/127.0.0.1/tcp/1/ws/p2p/12D3KooWUnreachablePeer111111111111111111111111111111`;
-		const result = await peer.bootstrap([
-			...bootstrapPeer.getMultiaddrs().map((addr) => addr.toString()),
-			unreachable,
-		]);
+	(isNode ? it : it.skip)(
+		"reports partial failures when one bootstrap peer is reachable and another is not",
+		async function () {
+			this.timeout(180_000);
+			const unreachable = `/ip4/127.0.0.1/tcp/1/ws/p2p/12D3KooWUnreachablePeer111111111111111111111111111111`;
+			const result = await peer.bootstrap([
+				...bootstrapPeer.getMultiaddrs().map((addr) => addr.toString()),
+				unreachable,
+			]);
 
-		expect(result.connectedPeerIds).to.include(bootstrapPeer.peerId.toString());
-		expect(result.failures).to.have.length(1);
-		expect(result.failures[0]?.peerId).to.equal(
-			"12D3KooWUnreachablePeer111111111111111111111111111111",
-		);
-	});
+			expect(result.connectedPeerIds).to.include(
+				bootstrapPeer.peerId.toString(),
+			);
+			expect(result.failures).to.have.length(1);
+			expect(result.failures[0]?.peerId).to.equal(
+				"12D3KooWUnreachablePeer111111111111111111111111111111",
+			);
+		},
+	);
 
-	it("does not report a failure when a fallback address for the same bootstrap peer succeeds", async function () {
-		this.timeout(180_000);
-		const valid = bootstrapPeer.getMultiaddrs()[0]!.toString();
-		const invalidSamePeer = `/ip4/127.0.0.1/tcp/1/ws/p2p/${bootstrapPeer.peerId.toString()}`;
-		const result = await peer.bootstrap([invalidSamePeer, valid]);
+	(isNode ? it : it.skip)(
+		"does not report a failure when a fallback address for the same bootstrap peer succeeds",
+		async function () {
+			this.timeout(180_000);
+			const valid = bootstrapPeer.getMultiaddrs()[0]!.toString();
+			const invalidSamePeer = `/ip4/127.0.0.1/tcp/1/ws/p2p/${bootstrapPeer.peerId.toString()}`;
+			const result = await peer.bootstrap([invalidSamePeer, valid]);
 
-		expect(result.connectedPeerIds).to.include(bootstrapPeer.peerId.toString());
-		expect(result.failures).to.deep.equal([]);
-	});
+			expect(result.connectedPeerIds).to.include(
+				bootstrapPeer.peerId.toString(),
+			);
+			expect(result.failures).to.deep.equal([]);
+		},
+	);
 
 	it("reports unknown-address failures without a bootstrap peer id", async function () {
 		this.timeout(180_000);
 		const unknown = "/dns4/node-a.peerchecker.com/tcp/1/ws";
-		const originalDial = peer.dial.bind(peer);
-		const dialStub = sinon
-			.stub(peer, "dial")
-			.callsFake(async (address, ...args: any[]) => {
-				const value =
-					typeof address === "string" ? address : (address as any).toString();
-				if (value === unknown) {
-					throw "forced-string-reason";
-				}
-				return await (originalDial as any)(address, ...args);
-			});
+		const reachable = `/dns4/bootstrap.example/tcp/443/wss/p2p/${bootstrapPeer.peerId.toString()}`;
+		const dialStub = sinon.stub(peer, "dial").callsFake(async (address) => {
+			const value =
+				typeof address === "string" ? address : (address as any).toString();
+			if (value === unknown) {
+				throw "forced-string-reason";
+			}
+			expect(value).to.equal(reachable);
+			return true;
+		});
 
 		try {
-			const result = await peer.bootstrap([
-				...bootstrapPeer.getMultiaddrs().map((addr) => addr.toString()),
-				unknown,
-			]);
+			const result = await peer.bootstrap([reachable, unknown]);
 
-			expect(result.connectedPeerIds).to.include(bootstrapPeer.peerId.toString());
+			expect(result.connectedPeerIds).to.include(
+				bootstrapPeer.peerId.toString(),
+			);
 			expect(result.failures).to.deep.equal([
 				{
 					peerId: undefined,
@@ -133,22 +144,27 @@ describe("bootstrap", () => {
 	});
 
 	it("throws when bootstrapping with no addresses", async () => {
-		await expect(peer.bootstrap([])).to.be.rejectedWith(
+		await expectRejectedWith(
+			peer.bootstrap([]),
 			"Failed to find any addresses to dial",
 		);
 	});
 
-	it("throws when no bootstrap peer can be reached", async function () {
-		this.timeout(180_000);
-		const unreachable =
-			"/ip4/127.0.0.1/tcp/1/ws/p2p/12D3KooWUnreachablePeer111111111111111111111111111111";
-		await expect(peer.bootstrap([unreachable])).to.be.rejectedWith(
-			"Failed to succefully dial any bootstrap node",
-		);
-	});
+	(isNode ? it : it.skip)(
+		"throws when no bootstrap peer can be reached",
+		async function () {
+			this.timeout(180_000);
+			const unreachable =
+				"/ip4/127.0.0.1/tcp/1/ws/p2p/12D3KooWUnreachablePeer111111111111111111111111111111";
+			await expectRejectedWith(
+				peer.bootstrap([unreachable]),
+				"Failed to succefully dial any bootstrap node",
+			);
+		},
+	);
 
 	it("hosts shard roots when this peer is itself a bootstrap candidate", async () => {
-		const selfAddress = peer.getMultiaddrs()[0]!.toString();
+		const selfAddress = `/dns4/self.example/tcp/443/wss/p2p/${peer.peerId.toString()}`;
 		const dialStub = sinon.stub(peer, "dial").resolves(true);
 		const hostRootsSpy = sinon.stub(peer.services.pubsub, "hostShardRootsNow");
 

--- a/packages/clients/peerbit/test/connect.spec.ts
+++ b/packages/clients/peerbit/test/connect.spec.ts
@@ -1,6 +1,7 @@
 import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
 import { Peerbit } from "../src/index.js";
+import { expectRejectedWith } from "./utils/rejection.js";
 
 const isNode = typeof process !== "undefined" && !!process.versions?.node;
 
@@ -154,11 +155,12 @@ describe(`dial`, function () {
 			};
 
 			try {
-				await expect(
+				await expectRejectedWith(
 					clients[0].dial(clients[1].getMultiaddrs()[0], {
 						dialTimeoutMs: 5_000,
 					}),
-				).to.be.rejectedWith("Fanout");
+					"Fanout",
+				);
 			} finally {
 				(clients[0].services.fanout as any).waitFor = originalWaitFor;
 			}

--- a/packages/clients/peerbit/test/indexer.spec.ts
+++ b/packages/clients/peerbit/test/indexer.spec.ts
@@ -1,20 +1,17 @@
-import fs from "fs/promises";
-import os from "os";
-import path from "path";
 import { HashmapIndices, create } from "@peerbit/indexer-simple";
 import { SQLiteIndices } from "@peerbit/indexer-sqlite3";
 import { expect } from "chai";
 import { Peerbit } from "../src/index.js";
 
+const isNode = typeof process !== "undefined" && process.versions?.node != null;
+
 describe("indexer", () => {
 	let client: Peerbit;
-	let directory: string | undefined;
+	let cleanupDirectory: (() => Promise<void>) | undefined;
 	afterEach(async () => {
 		await client?.stop();
-		if (directory) {
-			await fs.rm(directory, { recursive: true, force: true });
-			directory = undefined;
-		}
+		await cleanupDirectory?.();
+		cleanupDirectory = undefined;
 	});
 
 	it("sqlite indexer by default", async () => {
@@ -23,12 +20,29 @@ describe("indexer", () => {
 		expect(await client.indexer.persisted()).to.be.false;
 	});
 
-	it("sqlite indexer is persistent when opened with a directory", async () => {
-		directory = await fs.mkdtemp(path.join(os.tmpdir(), "peerbit-indexer-"));
-		client = await Peerbit.create({ directory });
-		expect(client.indexer).to.be.instanceOf(SQLiteIndices);
-		expect(await client.indexer.persisted()).to.be.true;
-	});
+	(isNode ? it : it.skip)(
+		"sqlite indexer is persistent when opened with a directory",
+		async () => {
+			// Keep Node built-ins behind non-literal dynamic imports. Aegir bundles
+			// this spec for browsers too, where static Node imports cannot resolve.
+			const fsModule = "node:fs/promises";
+			const osModule = "node:os";
+			const pathModule = "node:path";
+			const [fs, os, path] = await Promise.all([
+				import(fsModule),
+				import(osModule),
+				import(pathModule),
+			]);
+			const directory = await fs.mkdtemp(
+				path.join(os.tmpdir(), "peerbit-indexer-"),
+			);
+			cleanupDirectory = () =>
+				fs.rm(directory, { recursive: true, force: true });
+			client = await Peerbit.create({ directory });
+			expect(client.indexer).to.be.instanceOf(SQLiteIndices);
+			expect(await client.indexer.persisted()).to.be.true;
+		},
+	);
 
 	it("can provide custom indexer", async () => {
 		client = await Peerbit.create({ indexer: create });

--- a/packages/clients/peerbit/test/shared-program.spec.ts
+++ b/packages/clients/peerbit/test/shared-program.spec.ts
@@ -1,9 +1,6 @@
 import { field, variant } from "@dao-xyz/borsh";
 import { Program } from "@peerbit/program";
 import { expect } from "chai";
-import fs from "fs/promises";
-import os from "os";
-import path from "path";
 import { Peerbit } from "../src/peer.js";
 
 @variant("test-shared_nested")
@@ -43,6 +40,7 @@ const rejectsWithMessage = async (promise: Promise<any>, message: string) => {
 		expect(error?.message).to.eq(message);
 	}
 };
+const isNode = typeof process !== "undefined" && process.versions?.node != null;
 
 describe(`shared`, () => {
 	let client: Peerbit;
@@ -159,43 +157,57 @@ describe(`shared`, () => {
 describe("remote program persistence", () => {
 	let writer: Peerbit | undefined;
 	let reader: Peerbit | undefined;
-	let directory: string | undefined;
+	let cleanupDirectory: (() => Promise<void>) | undefined;
 
 	afterEach(async () => {
 		await reader?.stop();
 		await writer?.stop();
-		if (directory) {
-			await fs.rm(directory, { recursive: true, force: true });
-		}
+		await cleanupDirectory?.();
+		cleanupDirectory = undefined;
 	});
 
-	it("reopens an address locally after its provider stops", async function () {
-		this.timeout(30_000);
-		directory = await fs.mkdtemp(
-			path.join(os.tmpdir(), "peerbit-program-restart-"),
-		);
-		writer = await Peerbit.create();
-		reader = await Peerbit.create({ directory });
-		await reader.dial(writer.getMultiaddrs()[0]!);
+	(isNode ? it : it.skip)(
+		"reopens an address locally after its provider stops",
+		async function () {
+			this.timeout(30_000);
+			// Keep Node built-ins behind non-literal dynamic imports so this file
+			// remains bundleable for the browser tests that exercise the shared core.
+			const fsModule = "node:fs/promises";
+			const osModule = "node:os";
+			const pathModule = "node:path";
+			const [fs, os, path] = await Promise.all([
+				import(fsModule),
+				import(osModule),
+				import(pathModule),
+			]);
+			const directory = await fs.mkdtemp(
+				path.join(os.tmpdir(), "peerbit-program-restart-"),
+			);
+			cleanupDirectory = () =>
+				fs.rm(directory, { recursive: true, force: true });
+			writer = await Peerbit.create();
+			reader = await Peerbit.create({ directory });
+			await reader.dial(writer.getMultiaddrs()[0]!);
 
-		const source = await writer.open(new TestProgram(7));
-		expect(await reader.services.blocks.has(source.address)).to.be.false;
+			const source = await writer.open(new TestProgram(7));
+			expect(await reader.services.blocks.has(source.address)).to.be.false;
 
-		const loaded = await reader.open<TestProgram>(source.address, {
-			timeout: 10_000,
-		});
-		expect(loaded.id).to.equal(7);
-		expect(await reader.services.blocks.has(source.address)).to.be.true;
+			const loaded = await reader.open<TestProgram>(source.address, {
+				timeout: 10_000,
+			});
+			expect(loaded.id).to.equal(7);
+			expect(await reader.services.blocks.has(source.address)).to.be.true;
 
-		await reader.stop();
-		reader = undefined;
-		await writer.stop();
-		writer = undefined;
+			await reader.stop();
+			reader = undefined;
+			await writer.stop();
+			writer = undefined;
 
-		reader = await Peerbit.create({ directory });
-		const reopened = await reader.open<TestProgram>(source.address, {
-			timeout: 100,
-		});
-		expect(reopened.id).to.equal(7);
-	});
+			reader = await Peerbit.create({ directory });
+			const reopened = await reader.open<TestProgram>(source.address, {
+				timeout: 100,
+			});
+			expect(reopened.id).to.equal(7);
+		},
+	);
 });

--- a/packages/clients/peerbit/test/utils/rejection.ts
+++ b/packages/clients/peerbit/test/utils/rejection.ts
@@ -1,0 +1,22 @@
+import { expect } from "chai";
+
+export const expectRejectedWith = async (
+	promise: Promise<unknown>,
+	expected: string | RegExp,
+) => {
+	try {
+		await promise;
+	} catch (error) {
+		const message =
+			typeof error === "object" && error !== null && "message" in error
+				? String((error as { message: unknown }).message)
+				: String(error);
+		if (typeof expected === "string") {
+			expect(message).to.contain(expected);
+		} else {
+			expect(message).to.match(expected);
+		}
+		return;
+	}
+	throw new Error("Expected promise to reject");
+};


### PR DESCRIPTION
## Summary

- keep Node-only filesystem integrations out of browser bundles without hiding portable bootstrap behavior
- replace Chai-as-promised-only assertions with a small cross-runtime rejection helper
- keep TCP/listener integrations explicitly Node-only while preserving browser and WebWorker coverage
- change tests only; no production runtime code is modified

## Reproduction

A pristine build of current master failed before executing the Peerbit browser suite because the browser bundle statically resolved Node built-ins (fs/promises and os) from two filesystem-only tests.

## Validation

- Node: 90 passing, 1 existing remote test pending
- Chromium: 50 passing, 10 intentional Node-only tests pending
- focused WebWorker bootstrap/indexer/shared/persistence suite: 27 passing, 9 intentional Node-only tests pending
- changed-file ESLint: passed
- Prettier: passed
- git diff --check: passed
