### PR TITLE
test(stream): make inflight wait assertion event-driven

### DIFF
--- a/packages/transport/stream/test/stream.spec.ts
+++ b/packages/transport/stream/test/stream.spec.ts
@@ -5040,20 +5040,25 @@ describe("start/stop", () => {
 					slowDownSetup(stream(session, 1), deferred.promise);
 
 					await session.connect();
-					let t0 = Date.now();
-					let t1 = Number.MAX_SAFE_INTEGER;
 					const waitForPromise = stream(session, 0).waitFor(
 						stream(session, 1).publicKey,
 						{ seek: "present" },
 					);
-					waitForPromise.finally(() => {
-						t1 = Date.now();
-					});
-					await delay(3e3);
-					deferred.resolve();
-					await waitForPromise;
-					clearTimeout(timeout);
-					expect(t1 - t0).to.be.greaterThan(3e3); // it should have waited for the slow down
+					try {
+						const settlementBeforeRelease = await Promise.race([
+							waitForPromise.then(
+								() => "settled",
+								() => "settled",
+							),
+							delay(100).then(() => "pending"),
+						]);
+						expect(settlementBeforeRelease).to.equal("pending");
+						deferred.resolve();
+						await waitForPromise;
+					} finally {
+						deferred.resolve();
+						clearTimeout(timeout);
+					}
 				});
 			});
 		});


### PR DESCRIPTION
## Summary

- replace the wall-clock greater-than-3000ms boundary with a direct pending-state assertion
- prove waitFor stays pending while the in-flight stream negotiation is deferred
- release the deferred and await the original promise to prove completion
- always settle the deferred and clear the watchdog in cleanup

## Why

The old test slept exactly 3000ms and required elapsed time to be strictly greater than 3000ms. CI occasionally measured exactly 3000ms even though the behavior was correct.

## Validation

- target and dependency build
- focused Aegir test
- full stream Node suite
- 20/20 direct repeats under two CPU-saturation workers
- independent P0/P1/P2 review: clean
- no residual test or CPU-saturation processes