### PR TITLE
test(react): stabilize mutex coverage workers

### DIFF
--- a/packages/clients/peerbit-react/vitest.config.ts
+++ b/packages/clients/peerbit-react/vitest.config.ts
@@ -11,8 +11,9 @@ export default defineConfig({
 		exclude: ["dist", "node_modules"],
 		setupFiles: [path.join(ROOT, "vitest.setup.ts")],
 		// These suites intentionally replace process-global localStorage and timers.
-		// Running their coverage workers concurrently can leave a completed worker
-		// waiting forever during teardown.
+		// Keep them serial, and use a worker thread so a completed fork cannot get
+		// stuck waiting for its final IPC teardown message.
+		pool: "threads",
 		fileParallelism: false,
 		hookTimeout: 120_000,
 		testTimeout: 120_000,

--- a/packages/clients/peerbit-react/vitest/lockstorage.test.ts
+++ b/packages/clients/peerbit-react/vitest/lockstorage.test.ts
@@ -14,7 +14,6 @@ OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
 TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 */
-import { delay } from "@peerbit/time";
 import { expect } from "chai";
 import nodelocalstorage from "node-localstorage";
 import sinon from "sinon";
@@ -349,20 +348,27 @@ describe("FastMutex", () => {
 		fm.releaseIfOwnedBy("node-unref", () => true);
 	});
 
-	it("should reset the client stats after lock is released", async () => {
-		// without resetting the stats, the acquireStart will always be set, and
-		// after `timeout` ms, will be unable to acquire a lock anymore
+	it("can reacquire after the keep-alive callback releases the lock", async () => {
+		const clock = sandbox.useFakeTimers({ now: 30_000 });
 		const fm1 = new FastMutex({ localStorage: localStorage, timeout: 50 });
 		let keepLock = true;
 		let keepLockFn = () => keepLock;
 		await fm1.lock("resetStats", keepLockFn);
 		expect(fm1.isLocked("resetStats")).to.be.true;
 		keepLock = false;
-		await delay(100); // await timeout
-		expect(fm1.isLocked("resetStats")).to.be.false;
-		const p = fm1.lock("resetStats").then(() => fm1.release("resetStats"));
-
-		await p; // should not throw
+		clock.tick(50);
+		expect(fm1.getLockedOwners("resetStats")).to.deep.equal([]);
+		expect(fm1.intervals.size).to.eq(0);
+		try {
+			const stats = await fm1.lock("resetStats");
+			expect(stats).to.deep.equal({
+				restartCount: 0,
+				contentionCount: 0,
+				locksLost: 0,
+			});
+		} finally {
+			fm1.release("resetStats");
+		}
 	});
 
 	it("can keep lock with callback function", async () => {
@@ -373,17 +379,24 @@ describe("FastMutex", () => {
 		await fm1.lock("x").then(() => fm1.release("x"));
 	});
 
-	it("should reset the client stats if the lock has expired", async () => {
-		// in the event a lock cannot be acquired within `timeout`, acquireStart
-		// will never be reset, and a subsequent call (after the `timeout`) would
-		// immediately fail
+	it("can reacquire after the lock and its legacy grace period expire", async () => {
+		const clock = sandbox.useFakeTimers({ now: 40_000 });
 		const fm1 = new FastMutex({ localStorage: localStorage, timeout: 50 });
 
 		await fm1.lock("resetStats");
-
-		// try to acquire a lock after `timeout`:
-		await delay(75); // a small buffer over timeout to avoid flakiness
-
-		await fm1.lock("resetStats"); // should not throw
+		clock.tick(99);
+		expect(fm1.getLockedOwners("resetStats")).to.deep.equal([fm1.clientId]);
+		clock.tick(1);
+		expect(fm1.getLockedOwners("resetStats")).to.deep.equal([]);
+		try {
+			const stats = await fm1.lock("resetStats");
+			expect(stats).to.deep.equal({
+				restartCount: 0,
+				contentionCount: 0,
+				locksLost: 0,
+			});
+		} finally {
+			fm1.release("resetStats");
+		}
 	});
 });


### PR DESCRIPTION
## Summary
- replace wall-clock FastMutex expiry assertions with exact fake-time lease and legacy-grace boundaries
- assert owner, interval cleanup, and fresh acquisition counters directly
- keep React test files serial while pinning worker threads to avoid intermittent completed-fork IPC teardown hangs

## Validation
- `pnpm --filter @peerbit/react test:cov` on Node 22: 42/42
- `pnpm --filter @peerbit/react test:cov` on Node 24: 42/42
- 10/10 repeated focused Node 22 worker-thread runs
- Prettier, targeted ESLint, and `git diff --check`
- independent review: no P0/P1/P2 findings

No release changeset: this changes only tests and their runner configuration.