### PR TITLE
test(pubsub): restore leaf-only churn semantics

### DIFF
--- a/packages/transport/pubsub/test/pubsub-topic-sim.spec.ts
+++ b/packages/transport/pubsub/test/pubsub-topic-sim.spec.ts
@@ -91,7 +91,7 @@ describe("pubsub-topic-sim (ci)", () => {
 		expect(result.modeToLenMax).to.equal(0);
 	});
 
-	it("remains mostly connected under mild churn", async function () {
+	it("remains mostly connected under mild leaf churn", async function () {
 		this.timeout(90_000);
 
 		const result = await runPubsubTopicSimIsolated({
@@ -107,6 +107,10 @@ describe("pubsub-topic-sim (ci)", () => {
 			seed: 1,
 			topic: "concert",
 			subscribeModel: "preseed",
+			// This case measures ordinary subscriber churn. Keep relay capacity on the
+			// stable routers, which the churn selector excludes; relay-loss recovery is
+			// covered separately by deterministic fanout-tree tests.
+			relayFraction: 0,
 			warmupMessages: 2,
 			settleMs: 1_000,
 			timeoutMs: 60_000,
@@ -125,5 +129,6 @@ describe("pubsub-topic-sim (ci)", () => {
 		expect(result.deliveredOnlinePct).to.be.at.least(85);
 		expect(result.publishErrors).to.be.lessThan(10);
 		expect(result.churnEvents).to.be.greaterThan(0);
+		expect(result.params.relayFraction).to.equal(0);
 	});
 });


### PR DESCRIPTION
## Summary
- make the mild churn simulation explicitly leaf-only with `relayFraction: 0`
- assert the resolved simulator configuration so topology drift fails loudly
- retain the established >=85 delivery smoke threshold

## Why
The simulator default recently began promoting ordinary peers to relays. This historical test excludes stable routers from churn but did not override the new relay fraction, so it could terminate newly promoted relays. Relay recovery intentionally has a multi-second cooldown while the simulator quickly counts those peers online, making identical seeds vary across wall-clock scheduling. The test was introduced for mild leaf churn; relay-loss behavior remains covered by deterministic reparenting tests.

## Verification
- full pubsub suite: 147 passing
- focused leaf-churn runs under load: 6/6 passing, 94.44-100% delivery
- independent final review: no P0/P1/P2 findings
- direct zero-relay runs: 96.67%, 97.78%, 100%, with zero publish errors
- deterministic relay-loss tests: passing
- scoped dependency and pubsub build: passing
- `git diff --check`: passing