### PR TITLE
test(shared-log): assert semantic joining ownership

### DIFF
--- a/packages/programs/data/shared-log/test/sharding.spec.ts
+++ b/packages/programs/data/shared-log/test/sharding.spec.ts
@@ -2251,11 +2251,13 @@ testSetups.forEach((setup) => {
 				);
 
 				const entryCount = shardingSmallEntryCount;
-				await appendInBatches(entryCount, (i) =>
-					db1.add(toBase64(new Uint8Array([i])), {
+				const appendedEntries: Entry<any>[] = [];
+				await appendInBatches(entryCount, async (i) => {
+					const { entry } = await db1.add(toBase64(new Uint8Array([i])), {
 						meta: { next: [] },
-					}),
-				);
+					});
+					appendedEntries.push(entry);
+				});
 
 				db3 = await EventStore.open<EventStore<string, any>>(
 					db1.address!,
@@ -2269,18 +2271,25 @@ testSetups.forEach((setup) => {
 						},
 					},
 				);
-				// The runtime now schedules delayed repair for late joiners. The contract
-				// here is the settled bounded distribution with no idle under-replication,
-				// not that every internal repair/prune timer has gone fully idle.
+				// The runtime now schedules delayed repair for late joiners. Assert the
+				// planner-agreed owners instead of a probabilistic per-peer size band: random
+				// peer identities can legitimately put one peer just outside that band.
 				await waitForParticipationToSettle(db1, db2, db3);
-				await waitForResolved(
-					async () => {
-						await checkBounded(entryCount, 0.5, 0.9, db1, db2, db3);
-						expect(
-							await countIdleUnderReplicatedEntries(2, db1, db2, db3),
-						).equal(0);
+				const fixedPeers = [
+					session.peers[0].identity.publicKey.hashcode(),
+					session.peers[1].identity.publicKey.hashcode(),
+					session.peers[2].identity.publicKey.hashcode(),
+				];
+				await waitForSemanticOwnership(
+					"distributes-to-joining-peers",
+					appendedEntries,
+					[db1, db2, db3],
+					fixedPeers,
+					{
+						expectedCount: entryCount,
+						mode: "exact",
+						requiredPeer: fixedPeers[2],
 					},
-					{ timeout: 120_000, delayInterval: 500 },
 				);
 			});
 


### PR DESCRIPTION
## Summary
- record the exact entries appended before a late peer joins
- replace the probabilistic per-peer length band with planner-agreed exact semantic ownership
- require the late joiner to own work and verify exact copies, union, and local block presence

## Why
The previous 50-90% per-peer size band depends on random peer identities. With 30 entries and replication degree two, a legitimate consistent-hash assignment can place 14 entries on one peer even though the lower heuristic bound is 15 and every entry is correctly replicated. CI reproduced that exact 14/15 miss.

The existing semantic oracle is stronger: all peers must independently agree on each entry owner set, every entry must have at least two owners, physical ownership must exactly match the plan, the union and total copy count must be exact, blocks must be locally present, and the plan must remain stable for three samples.

## Verification
- full workspace build: passing
- Node 22 focused runs after the change: 14/14 mode runs passing across u32-simple and u64-iblt, including a post-rebase run
- targeted ESLint: zero errors
- git diff check: passing
- independent final review: no P0/P1/P2 findings