### PR TITLE
fix: make native commit acknowledgements crash durable

### DIFF
--- a/.changeset/native-block-durability-ack.md
+++ b/.changeset/native-block-durability-ack.md
@@ -1,0 +1,29 @@
+---
+"@peerbit/log": patch
+"@peerbit/shared-log": patch
+"@peerbit/blocks": patch
+"@peerbit/document": patch
+"@peerbit/native-backbone": patch
+"@peerbit/indexer-interface": patch
+"@peerbit/indexer-simple": patch
+"@peerbit/indexer-rust": patch
+"@peerbit/indexer-sqlite3": patch
+---
+
+Require native local-append acknowledgements to wait for their durable block mirror. Durable mirror failures now raise a typed, unsafe-to-retry error and poison further mutations on that program instance.
+
+Propagate native trim deletions to the durable mirror with staged tombstones and same-CID generation guards. Failed old-block deletion remains retryable cleanup debt so a fully durable replacement can publish one coherent new index/head state, while ownership-aware compensation preserves acknowledged, restored, shared, and otherwise uncertain content-addressed bytes. Retained orphans remain part of physical store size and therefore continue to count toward hard storage budgets until cleanup succeeds.
+
+Publish strict native lower-index facts through an operation-scoped generation token before consuming trim results. An index write failure now retracts only that append, cancels its deferred publication, and restores the authoritative graph, document, and coordinate state without erasing concurrent same-CID facts.
+
+Serialize lower-log close and drop with native append finalizers, retry incomplete rollback/index teardown stages, and erase blocks only after acknowledgements or compensation settle. Uncontended native hash mutation leases retain the synchronous commit-only fast path without recursive public bookkeeping.
+
+Close and drop now fail before changing lifecycle state while an internal or user mutation callback is still running; callers must retry after that callback completes.
+
+Advertise whether an indexer preserves rows across stop/start so ordinary close avoids duplicating every block hash for persistent or data-preserving backends, while destructive and unknown backends retain the exact drop set before stopping.
+
+Persist strict native recovery intent in alternating checksummed generations so an interrupted journal write cannot erase the last recoverable state. A committed lower marker remains authoritative, later mutations are blocked until failed intent retirement is recovered, and committed trim block cleanup resumes from the durable intent after restart.
+
+Make native coordinate, document, and signer acknowledgements wait for an explicit physical durability barrier, retain pending records after failures, reject torn or corrupt recovered WAL tails, and fail closed after ambiguous or short appends. Node barriers require `FileHandle.sync`; OPFS barriers require sync-access `flush`; buffered/custom adapters without the capability fail before a durable acknowledgement.
+
+Native persistence drop is now tombstone-backed and resumable, with explicit underlying-removal and terminal-drop capabilities checked before lower state is mutated. Hydration, recovery, validation, and native loads share one lifecycle queue so close waits and drop rejects before erasure. Ordinary custom close is never invoked after terminal drop, and unsafe custom compaction thresholds are rejected even on memory-only nodes. Built-in snapshot compaction remains disabled until it can use a crash-atomic generation protocol.

--- a/.changeset/strict-rust-wals-rollback.md
+++ b/.changeset/strict-rust-wals-rollback.md
@@ -1,0 +1,9 @@
+---
+"@peerbit/any-store-rust": patch
+---
+
+Make Node and OPFS journal appends crash-safe across short writes by rolling rejected records back to their original offset and poisoning the open store after journal failure until a verified reopen. Strict mutations already queued behind the failed append now reject with the same sticky first error before changing memory or the WAL.
+
+Repair torn journals by durably truncating only their verified prefix instead of implicitly rewriting a checkpoint. Strict stores now remain WAL-backed even when close compaction or a threshold is forced, and OPFS checkpoint writes loop until every byte is written before publishing their manifest.
+
+Only a structurally incomplete final frame is treated as a recoverable crash tail. A complete frame with invalid magic, checksum, or payload now fails closed without applying a partial replay or rewriting the WAL, and failed-open persistence handles are closed before a retry.

--- a/packages/log/src/entry-index.ts
+++ b/packages/log/src/entry-index.ts
@@ -75,6 +75,26 @@ type EntryIndexProfileSink = (event: EntryIndexProfileEvent) => void;
 
 const entryIndexProfileNow = () =>
 	globalThis.performance?.now?.() ?? Date.now();
+
+const shallowEntryEquals = (
+	left: ShallowEntry | undefined,
+	right: ShallowEntry | undefined,
+) => {
+	if (!left || !right) {
+		return left === right;
+	}
+	const leftBytes = serialize(left);
+	const rightBytes = serialize(right);
+	if (leftBytes.byteLength !== rightBytes.byteLength) {
+		return false;
+	}
+	for (let index = 0; index < leftBytes.byteLength; index++) {
+		if (leftBytes[index] !== rightBytes[index]) {
+			return false;
+		}
+	}
+	return true;
+};
 const entryIndexProfileStart = (sink: EntryIndexProfileSink | undefined) =>
 	sink ? entryIndexProfileNow() : 0;
 const emitEntryIndexProfileDuration = (
@@ -102,12 +122,52 @@ type BlocksWithRmMany = Blocks & {
 	rmMany?: (cids: string[]) => Promise<number | void> | number | void;
 };
 
+type BlocksWithNativeDeleteMirror = Blocks & {
+	rmManyAfterNativeDelete: (
+		cids: string[],
+		cleanupToken?: unknown,
+	) => Promise<number | void> | number | void;
+};
+
+type NativeTrimConsumeOptions = {
+	skipNextHeadUpdates?: boolean;
+	deleteBlocks?: boolean;
+	/** The native transaction positively reported that it deleted hot blocks. */
+	nativeBlocksDeleted?: boolean;
+	/** Opaque token for a delete announced before the native prepare awaited. */
+	nativeDeleteCleanupToken?: unknown;
+	/** Operation-scoped rollback ownership for strict native publication. */
+	nativeCommittedAppendFactsTransaction?: NativeCommittedAppendFactsTransaction;
+	/** Reentrant ownership for ordinary native graph/index mutations. */
+	hashMutationLockOwner?: EntryIndexHashMutationLockOwner;
+};
+
+type EntryIndexDeleteOptions = {
+	skipNextHeadUpdates?: boolean;
+	hashMutationLockOwner?: EntryIndexHashMutationLockOwner;
+};
+
 type BlocksWithPutKnown = Blocks & {
 	putKnown?: (cid: string, bytes: Uint8Array) => Promise<string> | string;
 };
 
 const hasRmMany = (store: Blocks): store is BlocksWithRmMany =>
 	typeof (store as BlocksWithRmMany).rmMany === "function";
+
+const hasNativeDeleteMirror = (
+	store: Blocks,
+): store is BlocksWithNativeDeleteMirror =>
+	typeof (store as BlocksWithNativeDeleteMirror).rmManyAfterNativeDelete ===
+	"function";
+
+const mirrorNativeDelete = (
+	store: BlocksWithNativeDeleteMirror,
+	cids: string[],
+	cleanupToken?: unknown,
+) =>
+	cleanupToken === undefined
+		? store.rmManyAfterNativeDelete(cids)
+		: store.rmManyAfterNativeDelete(cids, cleanupToken);
 
 type IndexWithExactDelete = Index<any> & {
 	delIds: (
@@ -170,6 +230,89 @@ type NativeJoinPlanInput = {
 type MaybePromise<T> = T | Promise<T>;
 type PendingIndexWrite = ShallowEntry | (() => ShallowEntry);
 
+type NativeCommittedAppendFactsTransactionRow = {
+	hash: string;
+	pending: PendingIndexWrite;
+	generation: number;
+	previousPending?: PendingIndexWrite;
+	previousGeneration?: number;
+	lengthIncremented: boolean;
+	shared: boolean;
+	hasNewerPendingWrite: boolean;
+	pendingRemovedByFlush: boolean;
+	indexValueBefore?: ShallowEntry;
+	indexSnapshotTaken: boolean;
+	indexWriteAttempted: boolean;
+};
+
+type NativeCommittedAppendFactsTrimTransactionRow = {
+	hash: string;
+	previousPending?: PendingIndexWrite;
+	previousGeneration?: number;
+	previousIndex?: ShallowEntry;
+	pendingRemoved: boolean;
+	indexDeleteAttempted: boolean;
+	lengthDecremented: boolean;
+};
+
+type NativeCommittedAppendFactsTrimTransactionBatch = {
+	rows: NativeCommittedAppendFactsTrimTransactionRow[];
+	nativeBlocksDeleted: boolean;
+	nativeDeleteCleanupToken?: unknown;
+};
+
+type NativeCommittedAppendFactsHeadTransactionRow = {
+	hash: string;
+	previousPending?: PendingIndexWrite;
+	previousGeneration?: number;
+	previousIndex?: ShallowEntry;
+	pendingRemoved: boolean;
+	pendingAfterCommit?: ShallowEntry;
+	coveredByAppend: boolean;
+	indexWriteAttempted: boolean;
+};
+
+type NativeCommittedAppendFactsHashLock = {
+	hash: string;
+	tail: Promise<void>;
+	ready: Promise<void>;
+	waitsForPrevious: boolean;
+	release: () => void;
+};
+
+/**
+ * @internal Opaque, operation-scoped ownership of entry-index hash mutations.
+ * Callers may pass this back to trusted lower-log APIs, but cannot construct it.
+ */
+export type EntryIndexHashMutationLockOwner = {
+	readonly __peerbitEntryIndexHashMutationLockOwner: never;
+};
+
+type EntryIndexHashMutationLockOwnerState = {
+	locks: Map<string, NativeCommittedAppendFactsHashLock>;
+	released: boolean;
+};
+
+/** @internal Opaque ownership for one native no-next index publication. */
+export type NativeCommittedAppendFactsTransaction = {
+	id: number;
+	state:
+		| "open"
+		| "rolling-back"
+		| "rollback-failed"
+		| "acknowledged"
+		| "rolled-back";
+	rows: NativeCommittedAppendFactsTransactionRow[];
+	externalNextHashes: Set<string>;
+	headRows: NativeCommittedAppendFactsHeadTransactionRow[];
+	trimRows: NativeCommittedAppendFactsTrimTransactionRow[];
+	trimBatches: NativeCommittedAppendFactsTrimTransactionBatch[];
+	hashLocks: Map<string, NativeCommittedAppendFactsHashLock>;
+	hashLocksReady: Promise<void>;
+	hashMutationLockOwner?: EntryIndexHashMutationLockOwner;
+	rollbackPromise?: Promise<void>;
+};
+
 const isPromiseLike = <T>(value: MaybePromise<T>): value is Promise<T> =>
 	!!value && typeof (value as { then?: unknown }).then === "function";
 
@@ -182,8 +325,7 @@ const materializePreparedAppendShallowEntry = (
 	entry: PreparedAppendIndexFacts,
 	isHead: boolean,
 ): ShallowEntry => {
-	const shallowEntry =
-		entry.shallowEntry ?? entry.getShallowEntry?.(isHead);
+	const shallowEntry = entry.shallowEntry ?? entry.getShallowEntry?.(isHead);
 	if (!shallowEntry) {
 		throw new Error("Missing prepared append shallow entry");
 	}
@@ -523,8 +665,26 @@ export class EntryIndex<T> {
 	private _length: number;
 	private insertionPromises: Map<string, Promise<void>>;
 	private pendingIndexWrites: Map<string, PendingIndexWrite>;
+	private pendingIndexWriteGenerations: Map<string, number>;
+	private retainedBlockHashesForDrop: Set<string>;
+	private nextPendingIndexWriteGeneration = 0;
+	private nextNativeCommittedAppendFactsTransactionId = 0;
+	private nativeCommittedAppendFactsOwners: Map<
+		string,
+		Set<NativeCommittedAppendFactsTransaction>
+	>;
+	private hashMutationLockTails: Map<string, Promise<void>>;
+	private hashMutationLockOwners: WeakMap<
+		EntryIndexHashMutationLockOwner,
+		EntryIndexHashMutationLockOwnerState
+	>;
+	private failedNativeCommittedAppendFactsRollbacks: Set<NativeCommittedAppendFactsTransaction>;
+	private nativeCommittedAppendFactsRollbackFailure?: unknown;
+	private nativeDurableTransactionMutationFailure?: unknown;
 	private pendingIndexFlushTimer?: ReturnType<typeof setTimeout>;
 	private pendingIndexFlushLastWriteMs = 0;
+	private clearIndexRestartPending = false;
+	private clearIndexAmbiguousDropRestartPending = false;
 	constructor(
 		readonly properties: {
 			store: Blocks;
@@ -560,6 +720,12 @@ export class EntryIndex<T> {
 		this._length = 0;
 		this.insertionPromises = new Map();
 		this.pendingIndexWrites = new Map();
+		this.pendingIndexWriteGenerations = new Map();
+		this.retainedBlockHashesForDrop = new Set();
+		this.nativeCommittedAppendFactsOwners = new Map();
+		this.hashMutationLockTails = new Map();
+		this.hashMutationLockOwners = new WeakMap();
+		this.failedNativeCommittedAppendFactsRollbacks = new Set();
 	}
 
 	/**
@@ -643,6 +809,402 @@ export class EntryIndex<T> {
 		return result;
 	}
 
+	private markNativeCommittedAppendFactsShared(
+		hash: string,
+		except?: NativeCommittedAppendFactsTransaction,
+	) {
+		for (const transaction of this.nativeCommittedAppendFactsOwners.get(hash) ??
+			[]) {
+			if (transaction === except) {
+				continue;
+			}
+			for (const row of transaction.rows) {
+				if (row.hash === hash) {
+					row.shared = true;
+					row.hasNewerPendingWrite = true;
+				}
+			}
+		}
+	}
+
+	/** Reject mutations while exact compensation remains incomplete. */
+	throwIfNativeCommittedAppendFactsRollbackFailed() {
+		if (this.nativeCommittedAppendFactsRollbackFailure !== undefined) {
+			throw new Error(
+				"Entry index is poisoned by an incomplete native transaction rollback",
+				{ cause: this.nativeCommittedAppendFactsRollbackFailure },
+			);
+		}
+	}
+
+	/** Reject new lower mutations while a durable intent needs recovery. */
+	poisonNativeDurableTransactionMutations(cause: unknown) {
+		this.nativeDurableTransactionMutationFailure ??= cause;
+	}
+
+	/** Recovery has retired the durable intent. */
+	clearNativeDurableTransactionMutationFailure() {
+		this.nativeDurableTransactionMutationFailure = undefined;
+	}
+
+	/** Reject new mutations while any native recovery is incomplete. */
+	throwIfNativeDurableTransactionMutationsFailed() {
+		this.throwIfNativeCommittedAppendFactsRollbackFailed();
+		if (this.nativeDurableTransactionMutationFailure !== undefined) {
+			throw new Error(
+				"Entry index is poisoned by a retained native durable transaction intent",
+				{ cause: this.nativeDurableTransactionMutationFailure },
+			);
+		}
+	}
+
+	private claimHashMutationLocks(hashes: Iterable<string>): {
+		locks: Map<string, NativeCommittedAppendFactsHashLock>;
+		ready?: Promise<void>;
+	} {
+		const locks = new Map<string, NativeCommittedAppendFactsHashLock>();
+		const waits: Promise<void>[] = [];
+		for (const hash of [...new Set(hashes)].filter(Boolean).sort()) {
+			const previousTail = this.hashMutationLockTails.get(hash);
+			let release!: () => void;
+			const held = new Promise<void>((resolve) => {
+				release = resolve;
+			});
+			const tail = previousTail ? previousTail.then(() => held) : held;
+			this.hashMutationLockTails.set(hash, tail);
+			void tail.then(() => {
+				if (this.hashMutationLockTails.get(hash) === tail) {
+					this.hashMutationLockTails.delete(hash);
+				}
+			});
+			locks.set(hash, {
+				hash,
+				tail,
+				ready: previousTail ?? Promise.resolve(),
+				waitsForPrevious: previousTail !== undefined,
+				release,
+			});
+			if (previousTail) {
+				waits.push(previousTail);
+			}
+		}
+		return {
+			locks,
+			ready:
+				waits.length > 0 ? Promise.all(waits).then(() => undefined) : undefined,
+		};
+	}
+
+	private getHashMutationLockOwnerState(
+		owner: EntryIndexHashMutationLockOwner,
+	): EntryIndexHashMutationLockOwnerState {
+		const state = this.hashMutationLockOwners.get(owner);
+		if (!state || state.released) {
+			throw new Error(
+				"Invalid or released entry-index hash mutation lock owner",
+			);
+		}
+		return state;
+	}
+
+	private acquireHashMutationLocksMaybe(
+		hashes: Iterable<string>,
+	): MaybePromise<EntryIndexHashMutationLockOwner> {
+		this.throwIfNativeDurableTransactionMutationsFailed();
+		const claimed = this.claimHashMutationLocks(hashes);
+		const owner = {} as EntryIndexHashMutationLockOwner;
+		const state: EntryIndexHashMutationLockOwnerState = {
+			locks: claimed.locks,
+			released: false,
+		};
+		this.hashMutationLockOwners.set(owner, state);
+		const afterReady = (): EntryIndexHashMutationLockOwner => {
+			try {
+				// A mutation may have queued before marker retirement failed. Recheck only
+				// after its predecessor releases the lease so it cannot slip into recovery.
+				this.throwIfNativeDurableTransactionMutationsFailed();
+				return owner;
+			} catch (error) {
+				this.releaseHashMutationLocks(owner);
+				throw error;
+			}
+		};
+		return claimed.ready ? claimed.ready.then(afterReady) : afterReady();
+	}
+
+	/** Acquire one sorted, deadlock-free lease before taking operation snapshots. */
+	async acquireHashMutationLocks(
+		hashes: Iterable<string>,
+	): Promise<EntryIndexHashMutationLockOwner> {
+		return this.acquireHashMutationLocksMaybe(hashes);
+	}
+
+	/** Verify that a trusted operation's lease covers every mutation. */
+	assertHashMutationLocks(
+		owner: EntryIndexHashMutationLockOwner,
+		hashes: Iterable<string>,
+	) {
+		const state = this.getHashMutationLockOwnerState(owner);
+		for (const hash of new Set([...hashes].filter(Boolean))) {
+			if (!state.locks.has(hash)) {
+				throw new Error(
+					`Entry-index hash mutation lock does not cover ${hash}`,
+				);
+			}
+		}
+	}
+
+	/** Release an operation lease after its lower finalizer settles. */
+	releaseHashMutationLocks(owner: EntryIndexHashMutationLockOwner) {
+		const state = this.getHashMutationLockOwnerState(owner);
+		state.released = true;
+		for (const lock of state.locks.values()) {
+			this.releaseHashMutationLock(lock);
+		}
+		state.locks.clear();
+	}
+
+	private releaseHashMutationLock(lock: NativeCommittedAppendFactsHashLock) {
+		lock.release();
+		if (this.hashMutationLockTails.get(lock.hash) === lock.tail) {
+			this.hashMutationLockTails.delete(lock.hash);
+		}
+	}
+
+	private reserveNativeCommittedAppendFactsHashLocks(
+		transaction: NativeCommittedAppendFactsTransaction,
+		hashes: Iterable<string>,
+	) {
+		if (transaction.state !== "open") {
+			throw new Error("Native append-facts transaction is not open");
+		}
+		const missing = [...new Set(hashes)].filter(
+			(hash) => !!hash && !transaction.hashLocks.has(hash),
+		);
+		if (missing.length === 0) {
+			return;
+		}
+		if (transaction.hashMutationLockOwner) {
+			const state = this.getHashMutationLockOwnerState(
+				transaction.hashMutationLockOwner,
+			);
+			for (const hash of missing) {
+				const lock = state.locks.get(hash);
+				if (!lock) {
+					throw new Error(
+						`Native transaction attempted an unlocked hash mutation: ${hash}; locked=${[
+							...state.locks.keys(),
+						].join(",")}`,
+					);
+				}
+				transaction.hashLocks.set(hash, lock);
+			}
+			return;
+		}
+		const claimed = this.claimHashMutationLocks(missing);
+		for (const [hash, lock] of claimed.locks) {
+			transaction.hashLocks.set(hash, lock);
+		}
+		if (claimed.ready) {
+			transaction.hashLocksReady = Promise.all([
+				transaction.hashLocksReady,
+				claimed.ready,
+			]).then(() => undefined);
+		}
+	}
+
+	private releaseNativeCommittedAppendFactsHashLocks(
+		transaction: NativeCommittedAppendFactsTransaction,
+	) {
+		if (!transaction.hashMutationLockOwner) {
+			for (const lock of transaction.hashLocks.values()) {
+				this.releaseHashMutationLock(lock);
+			}
+		}
+		transaction.hashLocks.clear();
+	}
+
+	private withHashMutationLocks<TValue>(
+		hashes: Iterable<string>,
+		operation: (owner: EntryIndexHashMutationLockOwner) => MaybePromise<TValue>,
+		owner?: EntryIndexHashMutationLockOwner,
+	): MaybePromise<TValue> {
+		if (owner) {
+			this.assertHashMutationLocks(owner, hashes);
+			return operation(owner);
+		}
+		const execute = (
+			acquired: EntryIndexHashMutationLockOwner,
+		): MaybePromise<TValue> => {
+			let result: MaybePromise<TValue>;
+			try {
+				result = operation(acquired);
+			} catch (error) {
+				this.releaseHashMutationLocks(acquired);
+				throw error;
+			}
+			if (isPromiseLike(result)) {
+				return result.finally(() => this.releaseHashMutationLocks(acquired));
+			}
+			this.releaseHashMutationLocks(acquired);
+			return result;
+		};
+		return mapMaybePromise(this.acquireHashMutationLocksMaybe(hashes), execute);
+	}
+
+	private setPendingIndexWrite(
+		hash: string,
+		pending: PendingIndexWrite,
+		owner?: NativeCommittedAppendFactsTransaction,
+	): number {
+		this.markNativeCommittedAppendFactsShared(hash, owner);
+		const generation = ++this.nextPendingIndexWriteGeneration;
+		this.pendingIndexWrites.set(hash, pending);
+		this.pendingIndexWriteGenerations.set(hash, generation);
+		return generation;
+	}
+
+	private deletePendingIndexWrite(hash: string, generation?: number): boolean {
+		if (
+			generation !== undefined &&
+			this.pendingIndexWriteGenerations.get(hash) !== generation
+		) {
+			return false;
+		}
+		const deleted = this.pendingIndexWrites.delete(hash);
+		if (deleted) {
+			this.pendingIndexWriteGenerations.delete(hash);
+		}
+		return deleted;
+	}
+
+	private restorePendingIndexWrite(
+		hash: string,
+		pending: PendingIndexWrite,
+		generation: number,
+	) {
+		this.pendingIndexWrites.set(hash, pending);
+		this.pendingIndexWriteGenerations.set(hash, generation);
+	}
+
+	/** @internal */
+	beginNativeCommittedAppendFactsTransaction(
+		hashes: Iterable<string> = [],
+		hashMutationLockOwner?: EntryIndexHashMutationLockOwner,
+	): NativeCommittedAppendFactsTransaction {
+		this.throwIfNativeDurableTransactionMutationsFailed();
+		const transaction: NativeCommittedAppendFactsTransaction = {
+			id: ++this.nextNativeCommittedAppendFactsTransactionId,
+			state: "open",
+			rows: [],
+			externalNextHashes: new Set(),
+			headRows: [],
+			trimRows: [],
+			trimBatches: [],
+			hashLocks: new Map(),
+			hashLocksReady: Promise.resolve(),
+			hashMutationLockOwner,
+		};
+		this.reserveNativeCommittedAppendFactsHashLocks(transaction, hashes);
+		return transaction;
+	}
+
+	private stageNativeCommittedAppendExternalNextHashes(
+		transaction: NativeCommittedAppendFactsTransaction,
+		hashes: Iterable<string>,
+	) {
+		const normalized = [...new Set(hashes)].filter(Boolean);
+		if (normalized.length === 0) {
+			return;
+		}
+		this.reserveNativeCommittedAppendFactsHashLocks(transaction, normalized);
+		for (const hash of normalized) {
+			transaction.externalNextHashes.add(hash);
+		}
+	}
+
+	private stageNativeCommittedAppendFact(
+		transaction: NativeCommittedAppendFactsTransaction,
+		hash: string,
+		pending: PendingIndexWrite,
+		lengthIncremented: boolean,
+	): Promise<void> | void {
+		if (transaction.state !== "open") {
+			throw new Error("Native append-facts transaction is not open");
+		}
+		this.reserveNativeCommittedAppendFactsHashLocks(transaction, [hash]);
+		const lock = transaction.hashLocks.get(hash)!;
+		if (lock.waitsForPrevious) {
+			return lock.ready.then(() => {
+				this.stageNativeCommittedAppendFactAfterHashLock(
+					transaction,
+					hash,
+					pending,
+					lengthIncremented,
+				);
+			});
+		}
+		this.stageNativeCommittedAppendFactAfterHashLock(
+			transaction,
+			hash,
+			pending,
+			lengthIncremented,
+		);
+	}
+
+	private stageNativeCommittedAppendFactAfterHashLock(
+		transaction: NativeCommittedAppendFactsTransaction,
+		hash: string,
+		pending: PendingIndexWrite,
+		lengthIncremented: boolean,
+	) {
+		if (transaction.state !== "open") {
+			throw new Error("Native append-facts transaction is not open");
+		}
+		if (transaction.rows.length === 0) {
+			this.clearPendingIndexFlushTimer();
+		}
+		let owners = this.nativeCommittedAppendFactsOwners.get(hash);
+		if (!owners) {
+			owners = new Set();
+			this.nativeCommittedAppendFactsOwners.set(hash, owners);
+		}
+		const ownedByThisTransaction = owners.has(transaction);
+		const shared =
+			[...owners].some((owner) => owner !== transaction) ||
+			(this.pendingIndexWrites.has(hash) && !ownedByThisTransaction);
+		this.markNativeCommittedAppendFactsShared(hash, transaction);
+		const previousPending = this.pendingIndexWrites.get(hash);
+		const previousGeneration = this.pendingIndexWriteGenerations.get(hash);
+		owners.add(transaction);
+		const generation = this.setPendingIndexWrite(hash, pending, transaction);
+		transaction.rows.push({
+			hash,
+			pending,
+			generation,
+			previousPending,
+			previousGeneration,
+			lengthIncremented,
+			shared,
+			hasNewerPendingWrite: false,
+			pendingRemovedByFlush: false,
+			indexSnapshotTaken: false,
+			indexWriteAttempted: false,
+		});
+	}
+
+	private releaseNativeCommittedAppendFactsTransaction(
+		transaction: NativeCommittedAppendFactsTransaction,
+	) {
+		for (const hash of new Set(transaction.rows.map((row) => row.hash))) {
+			const owners = this.nativeCommittedAppendFactsOwners.get(hash);
+			owners?.delete(transaction);
+			if (owners?.size === 0) {
+				this.nativeCommittedAppendFactsOwners.delete(hash);
+			}
+		}
+	}
+
 	private materializePendingIndexWrite(
 		hash: string,
 		pending: PendingIndexWrite,
@@ -652,6 +1214,18 @@ export class EntryIndex<T> {
 		}
 		const shallowEntry = pending();
 		this.pendingIndexWrites.set(hash, shallowEntry);
+		const generation = this.pendingIndexWriteGenerations.get(hash);
+		if (generation !== undefined) {
+			for (const transaction of this.nativeCommittedAppendFactsOwners.get(
+				hash,
+			) ?? []) {
+				for (const row of transaction.rows) {
+					if (row.hash === hash && row.generation === generation) {
+						row.pending = shallowEntry;
+					}
+				}
+			}
+		}
 		return shallowEntry;
 	}
 
@@ -696,37 +1270,539 @@ export class EntryIndex<T> {
 		this.pendingIndexFlushTimer = undefined;
 	}
 
-	async flushPendingWrites(hashes?: Iterable<string>) {
+	async flushPendingWrites(
+		hashes?: Iterable<string>,
+		hashMutationLockOwner?: EntryIndexHashMutationLockOwner,
+	) {
 		const keys = hashes
 			? [...new Set([...hashes].filter((hash): hash is string => !!hash))]
 			: [...this.pendingIndexWrites.keys()];
 		if (keys.length === 0) {
 			return;
 		}
-		this.clearPendingIndexFlushTimer();
-		const writes: ShallowEntry[] = [];
-		for (const hash of keys) {
-			const pending = this.pendingIndexWrites.get(hash);
-			if (!pending) {
-				continue;
-			}
-			writes.push(this.materializePendingIndexWrite(hash, pending));
-		}
-		if (writes.length === 0) {
-			return;
-		}
-		if (writes.length > 1 && this.properties.index.putBatch) {
-			await this.properties.index.putBatch(writes);
-		} else {
-			for (const write of writes) {
-				await this.properties.index.put(write);
-			}
-		}
-		for (const write of writes) {
-			this.pendingIndexWrites.delete(write.hash);
-		}
+		this.throwIfNativeCommittedAppendFactsRollbackFailed();
+		await this.withHashMutationLocks(
+			keys,
+			async () => {
+				this.throwIfNativeCommittedAppendFactsRollbackFailed();
+				this.clearPendingIndexFlushTimer();
+				const writes: Array<{
+					hash: string;
+					generation: number | undefined;
+					value: ShallowEntry;
+				}> = [];
+				for (const hash of keys) {
+					const pending = this.pendingIndexWrites.get(hash);
+					if (!pending) {
+						continue;
+					}
+					writes.push({
+						hash,
+						generation: this.pendingIndexWriteGenerations.get(hash),
+						value: this.materializePendingIndexWrite(hash, pending),
+					});
+				}
+				if (writes.length === 0) {
+					return;
+				}
+				if (writes.length > 1 && this.properties.index.putBatch) {
+					await this.properties.index.putBatch(
+						writes.map((write) => write.value),
+					);
+				} else {
+					for (const write of writes) {
+						await this.properties.index.put(write.value);
+					}
+				}
+				for (const write of writes) {
+					this.deletePendingIndexWrite(write.hash, write.generation);
+				}
+			},
+			hashMutationLockOwner,
+		);
 		if (this.pendingIndexWrites.size > 0) {
 			this.schedulePendingIndexWriteFlush();
+		}
+	}
+
+	private materializeNativeCommittedAppendFact(
+		row: NativeCommittedAppendFactsTransactionRow,
+	): ShallowEntry {
+		if (typeof row.pending !== "function") {
+			return row.pending;
+		}
+		const shallowEntry = row.pending();
+		row.pending = shallowEntry;
+		if (this.pendingIndexWriteGenerations.get(row.hash) === row.generation) {
+			this.pendingIndexWrites.set(row.hash, shallowEntry);
+		}
+		return shallowEntry;
+	}
+
+	private cloneShallowEntry(entry: ShallowEntry): ShallowEntry {
+		return deserialize(serialize(entry), ShallowEntry);
+	}
+
+	/** Publish existing-next head changes before the new append marker. */
+	async flushNativeCommittedExternalNextFacts(
+		transaction: NativeCommittedAppendFactsTransaction,
+	) {
+		if (transaction.state !== "open") {
+			throw new Error("Native append-facts transaction is not open");
+		}
+		await transaction.hashLocksReady;
+		this.throwIfNativeCommittedAppendFactsRollbackFailed();
+		for (const hash of transaction.externalNextHashes) {
+			if (transaction.headRows.some((row) => row.hash === hash)) {
+				continue;
+			}
+			const pending = this.pendingIndexWrites.get(hash);
+			const previousGeneration = this.pendingIndexWriteGenerations.get(hash);
+			const previousPending = pending
+				? this.cloneShallowEntry(
+						this.materializePendingIndexWrite(hash, pending),
+					)
+				: undefined;
+			const previousIndex = (await this.properties.index.get(toId(hash)))
+				?.value;
+			const source = previousPending ?? previousIndex;
+			if (!source) {
+				continue;
+			}
+			const value = this.cloneShallowEntry(source);
+			value.head = false;
+			const coveredByAppend = transaction.rows.some(
+				(row) =>
+					row.hash === hash &&
+					previousGeneration !== undefined &&
+					row.generation === previousGeneration,
+			);
+			const row: NativeCommittedAppendFactsHeadTransactionRow = {
+				hash,
+				previousPending,
+				previousGeneration,
+				previousIndex,
+				pendingRemoved: false,
+				pendingAfterCommit: value,
+				coveredByAppend,
+				indexWriteAttempted: false,
+			};
+			transaction.headRows.push(row);
+			if (coveredByAppend) {
+				const appendRow = transaction.rows.find(
+					(candidate) =>
+						candidate.hash === hash &&
+						candidate.generation === previousGeneration,
+				)!;
+				appendRow.pending = value;
+				if (
+					this.pendingIndexWriteGenerations.get(hash) === previousGeneration
+				) {
+					this.pendingIndexWrites.set(hash, value);
+				}
+				continue;
+			}
+			row.indexWriteAttempted = true;
+			await this.properties.index.put(value);
+			row.pendingRemoved = this.deletePendingIndexWrite(
+				hash,
+				previousGeneration,
+			);
+		}
+	}
+
+	/**
+	 * Flushes exactly the rows staged by a native no-next append. A later write
+	 * of the same CID owns a different generation and is never removed here.
+	 * @internal
+	 */
+	async flushNativeCommittedAppendFacts(
+		transaction: NativeCommittedAppendFactsTransaction,
+	) {
+		if (transaction.state !== "open") {
+			throw new Error("Native append-facts transaction is not open");
+		}
+		if (transaction.rows.length === 0) {
+			return;
+		}
+		this.throwIfNativeCommittedAppendFactsRollbackFailed();
+		this.reserveNativeCommittedAppendFactsHashLocks(
+			transaction,
+			transaction.rows.map((row) => row.hash),
+		);
+		await transaction.hashLocksReady;
+		this.throwIfNativeCommittedAppendFactsRollbackFailed();
+		this.clearPendingIndexFlushTimer();
+		const transactionRowsByHash = new Map<
+			string,
+			NativeCommittedAppendFactsTransactionRow[]
+		>();
+		for (const row of transaction.rows) {
+			const matching = transactionRowsByHash.get(row.hash);
+			if (matching) {
+				matching.push(row);
+			} else {
+				transactionRowsByHash.set(row.hash, [row]);
+			}
+		}
+		const rows = [...transactionRowsByHash.values()].map(
+			(matching) => matching[matching.length - 1]!,
+		);
+		try {
+			for (const row of rows) {
+				const existing = await this.properties.index.get(toId(row.hash));
+				for (const matching of transactionRowsByHash.get(row.hash)!) {
+					matching.indexValueBefore = existing?.value;
+					matching.indexSnapshotTaken = true;
+				}
+			}
+			const writes = rows.map((row) =>
+				this.materializeNativeCommittedAppendFact(row),
+			);
+			if (writes.length > 1 && this.properties.index.putBatch) {
+				for (const row of transaction.rows) {
+					row.indexWriteAttempted = true;
+				}
+				await this.properties.index.putBatch(writes);
+			} else {
+				for (let index = 0; index < writes.length; index++) {
+					const row = rows[index]!;
+					for (const matching of transactionRowsByHash.get(row.hash)!) {
+						matching.indexWriteAttempted = true;
+					}
+					await this.properties.index.put(writes[index]!);
+				}
+			}
+			for (const row of transaction.rows) {
+				row.pendingRemovedByFlush = this.deletePendingIndexWrite(
+					row.hash,
+					row.generation,
+				);
+			}
+		} finally {
+			if (this.pendingIndexWrites.size > 0) {
+				this.schedulePendingIndexWriteFlush();
+			}
+		}
+	}
+
+	/** Apply transaction-owned trims after the new append facts are durable. */
+	async flushNativeCommittedTrimFacts(
+		transaction: NativeCommittedAppendFactsTransaction,
+	) {
+		if (transaction.state !== "open") {
+			throw new Error("Native append-facts transaction is not open");
+		}
+		await transaction.hashLocksReady;
+		this.throwIfNativeCommittedAppendFactsRollbackFailed();
+		for (const batch of transaction.trimBatches) {
+			const rows = batch.rows.filter((row) => !row.indexDeleteAttempted);
+			if (rows.length === 0) {
+				continue;
+			}
+			for (const row of rows) {
+				row.pendingRemoved = this.deletePendingIndexWrite(
+					row.hash,
+					row.previousGeneration,
+				);
+				row.indexDeleteAttempted = true;
+			}
+			await this.deleteNativeCommittedAppendFactsIndexHashes(
+				rows.map((row) => row.hash),
+			);
+			const store = this.properties.store;
+			if (batch.nativeBlocksDeleted && hasNativeDeleteMirror(store)) {
+				await mirrorNativeDelete(
+					store,
+					rows.map((row) => row.hash),
+					batch.nativeDeleteCleanupToken,
+				);
+			}
+			for (const row of rows) {
+				if (
+					row.previousPending !== undefined ||
+					row.previousIndex !== undefined
+				) {
+					row.lengthDecremented = true;
+				}
+			}
+		}
+	}
+
+	/** Persist the append marker first and perform trim deletion as post-marker GC. */
+	async commitNativeCommittedAppendFacts(
+		transaction: NativeCommittedAppendFactsTransaction,
+	) {
+		await this.flushNativeCommittedExternalNextFacts(transaction);
+		await this.flushNativeCommittedAppendFacts(transaction);
+		await this.flushNativeCommittedTrimFacts(transaction);
+	}
+
+	/** @internal */
+	acknowledgeNativeCommittedAppendFacts(
+		transaction: NativeCommittedAppendFactsTransaction,
+	) {
+		if (transaction.state !== "open") {
+			return;
+		}
+		const appendedHashes = new Set<string>();
+		for (const row of transaction.rows) {
+			if (
+				row.lengthIncremented &&
+				row.indexSnapshotTaken &&
+				row.indexValueBefore === undefined &&
+				!appendedHashes.has(row.hash)
+			) {
+				appendedHashes.add(row.hash);
+				this._length++;
+			}
+		}
+		const trimmedHashes = new Set<string>();
+		for (const row of transaction.trimRows) {
+			if (row.lengthDecremented && !trimmedHashes.has(row.hash)) {
+				trimmedHashes.add(row.hash);
+				this._length--;
+			}
+		}
+		for (const row of transaction.headRows) {
+			if (
+				row.pendingRemoved &&
+				!this.pendingIndexWrites.has(row.hash) &&
+				row.pendingAfterCommit &&
+				row.previousGeneration !== undefined
+			) {
+				this.restorePendingIndexWrite(
+					row.hash,
+					row.pendingAfterCommit,
+					row.previousGeneration,
+				);
+			}
+		}
+		transaction.state = "acknowledged";
+		this.releaseNativeCommittedAppendFactsTransaction(transaction);
+		this.releaseNativeCommittedAppendFactsHashLocks(transaction);
+		if (this.pendingIndexWrites.size > 0) {
+			this.schedulePendingIndexWriteFlush();
+		}
+	}
+
+	private async deleteNativeCommittedAppendFactsIndexHashes(hashes: string[]) {
+		if (hashes.length === 0) {
+			return;
+		}
+		if (hasExactDelete(this.properties.index)) {
+			await this.properties.index.delIds(hashes);
+			return;
+		}
+		await this.properties.index.del({
+			query: createHashMatchQuery(hashes),
+		});
+	}
+
+	private async restoreNativeCommittedAppendFactsIndexValue(
+		hash: string,
+		value: ShallowEntry | undefined,
+	) {
+		const readCurrent = async () =>
+			(await this.properties.index.get(toId(hash)))?.value;
+		if (shallowEntryEquals(await readCurrent(), value)) {
+			return;
+		}
+		try {
+			if (value) {
+				await this.properties.index.put(value);
+			} else {
+				await this.deleteNativeCommittedAppendFactsIndexHashes([hash]);
+			}
+		} catch (error) {
+			// Index adapters can reject after applying a write. Verify the exact row
+			// before recording rollback debt; a matching row is already compensated.
+			if (!shallowEntryEquals(await readCurrent(), value)) {
+				throw error;
+			}
+		}
+	}
+
+	private rebaseNativeCommittedAppendFactsDependents(
+		transaction: NativeCommittedAppendFactsTransaction,
+	) {
+		for (const row of transaction.rows) {
+			for (const owner of this.nativeCommittedAppendFactsOwners.get(row.hash) ??
+				[]) {
+				if (owner === transaction) {
+					continue;
+				}
+				for (const dependent of owner.rows) {
+					if (
+						dependent.hash === row.hash &&
+						dependent.previousGeneration === row.generation
+					) {
+						dependent.previousPending = row.previousPending;
+						dependent.previousGeneration = row.previousGeneration;
+					}
+				}
+			}
+		}
+	}
+
+	private async performNativeCommittedAppendFactsRollback(
+		transaction: NativeCommittedAppendFactsTransaction,
+	) {
+		transaction.state = "rolling-back";
+		this.clearPendingIndexFlushTimer();
+		try {
+			for (let index = transaction.trimRows.length - 1; index >= 0; index--) {
+				const row = transaction.trimRows[index]!;
+				if (!row.indexDeleteAttempted) {
+					continue;
+				}
+				await this.restoreNativeCommittedAppendFactsIndexValue(
+					row.hash,
+					row.previousIndex,
+				);
+			}
+
+			const restoredAppendHashes = new Set<string>();
+			for (let index = transaction.rows.length - 1; index >= 0; index--) {
+				const row = transaction.rows[index]!;
+				if (
+					!row.indexWriteAttempted ||
+					!row.indexSnapshotTaken ||
+					restoredAppendHashes.has(row.hash)
+				) {
+					continue;
+				}
+				restoredAppendHashes.add(row.hash);
+				await this.restoreNativeCommittedAppendFactsIndexValue(
+					row.hash,
+					row.indexValueBefore,
+				);
+			}
+			for (let index = transaction.headRows.length - 1; index >= 0; index--) {
+				const row = transaction.headRows[index]!;
+				if (!row.indexWriteAttempted || row.coveredByAppend) {
+					continue;
+				}
+				await this.restoreNativeCommittedAppendFactsIndexValue(
+					row.hash,
+					row.previousIndex,
+				);
+			}
+		} catch (error) {
+			transaction.state = "rollback-failed";
+			this.failedNativeCommittedAppendFactsRollbacks.add(transaction);
+			this.nativeCommittedAppendFactsRollbackFailure = error;
+			throw new Error(
+				"Failed to restore the entry index after a native transaction",
+				{ cause: error },
+			);
+		}
+
+		for (let index = transaction.trimRows.length - 1; index >= 0; index--) {
+			const row = transaction.trimRows[index]!;
+			const ownsCurrentPending =
+				row.previousGeneration !== undefined &&
+				this.pendingIndexWriteGenerations.get(row.hash) ===
+					row.previousGeneration;
+			if (
+				row.pendingRemoved &&
+				!ownsCurrentPending &&
+				!this.pendingIndexWrites.has(row.hash) &&
+				row.previousPending !== undefined &&
+				row.previousGeneration !== undefined
+			) {
+				this.restorePendingIndexWrite(
+					row.hash,
+					row.previousPending,
+					row.previousGeneration,
+				);
+			}
+		}
+		for (let index = transaction.headRows.length - 1; index >= 0; index--) {
+			const row = transaction.headRows[index]!;
+			if (
+				!row.coveredByAppend &&
+				row.pendingRemoved &&
+				!this.pendingIndexWrites.has(row.hash) &&
+				row.previousPending !== undefined &&
+				row.previousGeneration !== undefined
+			) {
+				this.restorePendingIndexWrite(
+					row.hash,
+					row.previousPending,
+					row.previousGeneration,
+				);
+			}
+		}
+
+		this.rebaseNativeCommittedAppendFactsDependents(transaction);
+		for (let index = transaction.rows.length - 1; index >= 0; index--) {
+			const row = transaction.rows[index]!;
+			const ownsCurrentPending =
+				this.pendingIndexWriteGenerations.get(row.hash) === row.generation;
+			const removedOwnPendingWithoutReplacement =
+				!this.pendingIndexWrites.has(row.hash) &&
+				row.pendingRemovedByFlush &&
+				!row.hasNewerPendingWrite;
+			if (ownsCurrentPending || removedOwnPendingWithoutReplacement) {
+				if (
+					row.previousPending !== undefined &&
+					row.previousGeneration !== undefined
+				) {
+					this.restorePendingIndexWrite(
+						row.hash,
+						row.previousPending,
+						row.previousGeneration,
+					);
+				} else {
+					this.deletePendingIndexWrite(row.hash, row.generation);
+				}
+			}
+		}
+
+		transaction.state = "rolled-back";
+		this.failedNativeCommittedAppendFactsRollbacks.delete(transaction);
+		if (this.failedNativeCommittedAppendFactsRollbacks.size === 0) {
+			this.nativeCommittedAppendFactsRollbackFailure = undefined;
+		}
+		this.releaseNativeCommittedAppendFactsTransaction(transaction);
+		this.releaseNativeCommittedAppendFactsHashLocks(transaction);
+		if (this.pendingIndexWrites.size > 0) {
+			this.schedulePendingIndexWriteFlush();
+		}
+	}
+
+	/** @internal */
+	async rollbackNativeCommittedAppendFacts(
+		transaction: NativeCommittedAppendFactsTransaction,
+	) {
+		if (
+			transaction.state === "acknowledged" ||
+			transaction.state === "rolled-back"
+		) {
+			return;
+		}
+		if (transaction.rollbackPromise) {
+			return transaction.rollbackPromise;
+		}
+		const rollbackPromise =
+			this.performNativeCommittedAppendFactsRollback(transaction);
+		transaction.rollbackPromise = rollbackPromise;
+		try {
+			await rollbackPromise;
+		} finally {
+			if (transaction.rollbackPromise === rollbackPromise) {
+				transaction.rollbackPromise = undefined;
+			}
+		}
+	}
+
+	/** Retry an incomplete idempotent compensation before accepting more work. */
+	async retryFailedNativeCommittedAppendFactsRollbacks() {
+		for (const transaction of [
+			...this.failedNativeCommittedAppendFactsRollbacks,
+		]) {
+			await this.rollbackNativeCommittedAppendFacts(transaction);
 		}
 	}
 
@@ -1568,50 +2644,66 @@ export class EntryIndex<T> {
 				throw new Error("Missing hash");
 			}
 		}
+		const hashMutationLockOwner = this.properties.nativeGraph
+			? await this.acquireHashMutationLocks([entry.hash, ...entry.meta.next])
+			: undefined;
 
-		const existingPromise = this.insertionPromises.get(entry.hash);
-		if (existingPromise) {
-			return existingPromise;
-		} else {
-			const fn = async () => {
-				if (properties.unique === true || !(await this.has(entry.hash))) {
-					this._length++;
-				}
+		try {
+			const existingPromise = this.insertionPromises.get(entry.hash);
+			if (existingPromise) {
+				return await existingPromise;
+			} else {
+				const fn = async () => {
+					if (properties.unique === true || !(await this.has(entry.hash))) {
+						this._length++;
+					}
 
-				// add cache after .has check before .has uses the cache
-				this.cache.add(entry.hash, entry);
-				const shallowEntry =
-					Entry.takePreparedShallowEntry(entry, properties.isHead) ??
-					entry.toShallow(properties.isHead);
-				const nativeEntry =
-					Entry.takePreparedNativeLogEntry(entry, properties.isHead) ??
-					toNativeLogEntry(shallowEntry);
-				const shouldDeferIndexWrite =
-					properties.deferIndexWrite === true &&
-					properties.isHead &&
-					entry.meta.type !== EntryType.CUT &&
-					entry.meta.next.length === 0;
+					// add cache after .has check before .has uses the cache
+					this.cache.add(entry.hash, entry);
+					const shallowEntry =
+						Entry.takePreparedShallowEntry(entry, properties.isHead) ??
+						entry.toShallow(properties.isHead);
+					const nativeEntry =
+						Entry.takePreparedNativeLogEntry(entry, properties.isHead) ??
+						toNativeLogEntry(shallowEntry);
+					const shouldDeferIndexWrite =
+						properties.deferIndexWrite === true &&
+						properties.isHead &&
+						entry.meta.type !== EntryType.CUT &&
+						entry.meta.next.length === 0;
 
-				if (shouldDeferIndexWrite) {
-					this.pendingIndexWrites.set(entry.hash, shallowEntry);
-					this.schedulePendingIndexWriteFlush();
-				} else {
-					await this.flushPendingWrites(entry.meta.next);
-					await this.properties.index.put(shallowEntry);
-				}
-				this.properties.nativeGraph?.graph.put(nativeEntry);
+					if (shouldDeferIndexWrite) {
+						this.setPendingIndexWrite(entry.hash, shallowEntry);
+						this.schedulePendingIndexWriteFlush();
+					} else {
+						await this.flushPendingWrites(
+							entry.meta.next,
+							hashMutationLockOwner,
+						);
+						await this.properties.index.put(shallowEntry);
+					}
+					this.properties.nativeGraph?.graph.put(nativeEntry);
 
-				// check if gids has been shadowed, by query all nexts that have a different gid
-				await this.notifyShadowedGids(entry);
+					// check if gids has been shadowed, by query all nexts that have a different gid
+					await this.notifyShadowedGids(entry);
 
-				// mark all next entries as not heads
-				await this.privateUpdateNextHeadProperty(entry, false);
+					// mark all next entries as not heads
+					await this.privateUpdateNextHeadProperty(
+						entry,
+						false,
+						hashMutationLockOwner,
+					);
 
-				this.insertionPromises.delete(entry.hash);
-			};
-			const promise = fn();
-			this.insertionPromises.set(entry.hash, promise);
-			return promise;
+					this.insertionPromises.delete(entry.hash);
+				};
+				const promise = fn();
+				this.insertionPromises.set(entry.hash, promise);
+				return await promise;
+			}
+		} finally {
+			if (hashMutationLockOwner) {
+				this.releaseHashMutationLocks(hashMutationLockOwner);
+			}
 		}
 	}
 
@@ -1655,68 +2747,109 @@ export class EntryIndex<T> {
 				await existingPromise;
 			}
 		}
+		const hashMutationLockOwner = this.properties.nativeGraph
+			? await this.acquireHashMutationLocks([
+					...entries.flatMap((entry) => [entry.hash, ...entry.meta.next]),
+					...(properties.externalNextHashes ?? []),
+				])
+			: undefined;
 
-		const promise = (async () => {
-			const profile = properties.profile;
-			const prepareStartedAt = entryIndexProfileStart(profile);
-			const externalNexts = new Set<string>(
-				properties.externalNextHashes ?? [],
-			);
-			const shouldDiscoverExternalNexts = !properties.externalNextHashes;
-			const batchHashes = shouldDiscoverExternalNexts
-				? new Set(entries.map((entry) => entry.hash))
-				: undefined;
-			const putBatch =
-				!this.properties.onGidRemoved && this.properties.index.putBatch;
-			const shallowEntries: ShallowEntry[] = [];
-			const nativeGraphUpdated =
-				properties.prepared?.nativeGraphUpdated === true;
-			const nativeCommitOwnsHotIndex =
-				nativeGraphUpdated &&
-				properties.prepared?.nativeBlocksCommitted === true &&
-				!this.properties.onGidRemoved;
-			const nativeGraphPutAppendChain =
-				!nativeGraphUpdated &&
-				!this.properties.onGidRemoved &&
-				properties.externalNextHashes &&
-				this.properties.nativeGraph?.graph.putAppendChain
-					? this.properties.nativeGraph.graph.putAppendChain.bind(
-							this.properties.nativeGraph.graph,
-						)
+		try {
+			const promise = (async () => {
+				const profile = properties.profile;
+				const prepareStartedAt = entryIndexProfileStart(profile);
+				const externalNexts = new Set<string>(
+					properties.externalNextHashes ?? [],
+				);
+				const shouldDiscoverExternalNexts = !properties.externalNextHashes;
+				const batchHashes = shouldDiscoverExternalNexts
+					? new Set(entries.map((entry) => entry.hash))
 					: undefined;
-			const nativeGraphPutBatch =
-				!nativeGraphUpdated &&
-				!this.properties.onGidRemoved &&
-				this.properties.nativeGraph?.graph.putBatch
-					? this.properties.nativeGraph.graph.putBatch.bind(
-							this.properties.nativeGraph.graph,
-						)
-					: undefined;
-			const deferBatchIndexWrite =
-				properties.deferIndexWrite === true &&
-				!!putBatch &&
-				!!this.properties.nativeGraph &&
-				!this.properties.onGidRemoved &&
-				entries.every((entry) => entry.meta.type !== EntryType.CUT);
-			const nativeEntries: NativeLogEntry[] = [];
-			for (let i = 0; i < entries.length; i++) {
-				const entry = entries[i];
-				const isHead = properties.heads?.[i] ?? i === entries.length - 1;
-				if (properties.unique === true || !(await this.has(entry.hash))) {
-					this._length++;
-				}
+				const putBatch =
+					!this.properties.onGidRemoved && this.properties.index.putBatch;
+				const shallowEntries: ShallowEntry[] = [];
+				const nativeGraphUpdated =
+					properties.prepared?.nativeGraphUpdated === true;
+				const nativeCommitOwnsHotIndex =
+					nativeGraphUpdated &&
+					properties.prepared?.nativeBlocksCommitted === true &&
+					!this.properties.onGidRemoved;
+				const nativeGraphPutAppendChain =
+					!nativeGraphUpdated &&
+					!this.properties.onGidRemoved &&
+					properties.externalNextHashes &&
+					this.properties.nativeGraph?.graph.putAppendChain
+						? this.properties.nativeGraph.graph.putAppendChain.bind(
+								this.properties.nativeGraph.graph,
+							)
+						: undefined;
+				const nativeGraphPutBatch =
+					!nativeGraphUpdated &&
+					!this.properties.onGidRemoved &&
+					this.properties.nativeGraph?.graph.putBatch
+						? this.properties.nativeGraph.graph.putBatch.bind(
+								this.properties.nativeGraph.graph,
+							)
+						: undefined;
+				const deferBatchIndexWrite =
+					properties.deferIndexWrite === true &&
+					!!putBatch &&
+					!!this.properties.nativeGraph &&
+					!this.properties.onGidRemoved &&
+					entries.every((entry) => entry.meta.type !== EntryType.CUT);
+				const nativeEntries: NativeLogEntry[] = [];
+				for (let i = 0; i < entries.length; i++) {
+					const entry = entries[i];
+					const isHead = properties.heads?.[i] ?? i === entries.length - 1;
+					if (properties.unique === true || !(await this.has(entry.hash))) {
+						this._length++;
+					}
 
-				this.cache.add(entry.hash, entry);
-				const preparedShallowEntry = properties.prepared?.shallowEntries[i];
-				if (preparedShallowEntry) {
-					preparedShallowEntry.head = isHead;
-				}
-				const shallowEntry =
-					preparedShallowEntry ??
-					Entry.takePreparedShallowEntry(entry, isHead) ??
-					entry.toShallow(isHead);
-				if (nativeCommitOwnsHotIndex) {
-					this.pendingIndexWrites.set(entry.hash, shallowEntry);
+					this.cache.add(entry.hash, entry);
+					const preparedShallowEntry = properties.prepared?.shallowEntries[i];
+					if (preparedShallowEntry) {
+						preparedShallowEntry.head = isHead;
+					}
+					const shallowEntry =
+						preparedShallowEntry ??
+						Entry.takePreparedShallowEntry(entry, isHead) ??
+						entry.toShallow(isHead);
+					if (nativeCommitOwnsHotIndex) {
+						this.setPendingIndexWrite(entry.hash, shallowEntry);
+						if (batchHashes) {
+							for (const next of entry.meta.next) {
+								if (!batchHashes.has(next)) {
+									externalNexts.add(next);
+								}
+							}
+						}
+						continue;
+					}
+					const preparedNativeEntry = properties.prepared?.nativeEntries?.[i];
+					if (preparedNativeEntry) {
+						preparedNativeEntry.head = isHead;
+					}
+					const nativeEntry =
+						!nativeGraphUpdated &&
+						this.properties.nativeGraph &&
+						(preparedNativeEntry ??
+							Entry.takePreparedNativeLogEntry(entry, isHead) ??
+							toNativeLogEntry(shallowEntry));
+					if (putBatch) {
+						shallowEntries.push(shallowEntry);
+						nativeEntry && nativeEntries.push(nativeEntry);
+					} else {
+						await this.properties.index.put(shallowEntry);
+						if (nativeGraphPutAppendChain || nativeGraphPutBatch) {
+							nativeEntry && nativeEntries.push(nativeEntry);
+						} else {
+							if (nativeEntry) {
+								this.properties.nativeGraph?.graph.put(nativeEntry);
+								await this.notifyShadowedGids(entry);
+							}
+						}
+					}
+
 					if (batchHashes) {
 						for (const next of entry.meta.next) {
 							if (!batchHashes.has(next)) {
@@ -1724,147 +2857,122 @@ export class EntryIndex<T> {
 							}
 						}
 					}
-					continue;
 				}
-				const preparedNativeEntry = properties.prepared?.nativeEntries?.[i];
-				if (preparedNativeEntry) {
-					preparedNativeEntry.head = isHead;
-				}
-				const nativeEntry =
-					!nativeGraphUpdated &&
-					this.properties.nativeGraph &&
-					(preparedNativeEntry ??
-						Entry.takePreparedNativeLogEntry(entry, isHead) ??
-						toNativeLogEntry(shallowEntry));
-				if (putBatch) {
-					shallowEntries.push(shallowEntry);
-					nativeEntry && nativeEntries.push(nativeEntry);
-				} else {
-					await this.properties.index.put(shallowEntry);
-					if (nativeGraphPutAppendChain || nativeGraphPutBatch) {
-						nativeEntry && nativeEntries.push(nativeEntry);
-					} else {
-						if (nativeEntry) {
-							this.properties.nativeGraph?.graph.put(nativeEntry);
-							await this.notifyShadowedGids(entry);
-						}
+				emitEntryIndexProfileDuration(profile, prepareStartedAt, {
+					name: "log.entryIndex.putAppendBatch.prepare",
+					component: "log",
+					entries: entries.length,
+					messages: 1,
+					details: {
+						unique: properties.unique,
+						usedPreparedShallowEntries:
+							properties.prepared?.shallowEntries.length ?? 0,
+						usedPreparedNativeEntries:
+							properties.prepared?.nativeEntries?.length ?? 0,
+						nativeEntries: nativeEntries.length,
+						discoverExternalNexts: shouldDiscoverExternalNexts,
+					},
+				});
+
+				const putNativeEntries = (allowLoopFallback: boolean) => {
+					if (nativeEntries.length === 0) {
+						return;
 					}
+					if (nativeGraphPutAppendChain) {
+						const nativePutStartedAt = entryIndexProfileStart(profile);
+						nativeGraphPutAppendChain(nativeEntries);
+						emitEntryIndexProfileDuration(profile, nativePutStartedAt, {
+							name: "log.entryIndex.putAppendBatch.nativeGraphPut",
+							component: "log",
+							entries: nativeEntries.length,
+							messages: 1,
+							details: { method: "putAppendChain" },
+						});
+					} else if (nativeGraphPutBatch) {
+						const nativePutStartedAt = entryIndexProfileStart(profile);
+						nativeGraphPutBatch(nativeEntries);
+						emitEntryIndexProfileDuration(profile, nativePutStartedAt, {
+							name: "log.entryIndex.putAppendBatch.nativeGraphPut",
+							component: "log",
+							entries: nativeEntries.length,
+							messages: 1,
+							details: { method: "putBatch" },
+						});
+					} else if (allowLoopFallback) {
+						const nativePutStartedAt = entryIndexProfileStart(profile);
+						for (const nativeEntry of nativeEntries) {
+							this.properties.nativeGraph?.graph.put(nativeEntry);
+						}
+						emitEntryIndexProfileDuration(profile, nativePutStartedAt, {
+							name: "log.entryIndex.putAppendBatch.nativeGraphPut",
+							component: "log",
+							entries: nativeEntries.length,
+							messages: 1,
+							details: { method: "putLoop" },
+						});
+					}
+				};
+
+				if (nativeCommitOwnsHotIndex) {
+					this.schedulePendingIndexWriteFlush();
+				} else if (deferBatchIndexWrite) {
+					const indexPutStartedAt = entryIndexProfileStart(profile);
+					for (const shallowEntry of shallowEntries) {
+						this.setPendingIndexWrite(shallowEntry.hash, shallowEntry);
+					}
+					this.schedulePendingIndexWriteFlush();
+					emitEntryIndexProfileDuration(profile, indexPutStartedAt, {
+						name: "log.entryIndex.putAppendBatch.indexPut",
+						component: "log",
+						entries: shallowEntries.length,
+						messages: 1,
+						details: { deferred: true },
+					});
+					putNativeEntries(true);
+				} else if (putBatch) {
+					const indexPutStartedAt = entryIndexProfileStart(profile);
+					await putBatch.call(this.properties.index, shallowEntries);
+					emitEntryIndexProfileDuration(profile, indexPutStartedAt, {
+						name: "log.entryIndex.putAppendBatch.indexPut",
+						component: "log",
+						entries: shallowEntries.length,
+						messages: 1,
+					});
+					putNativeEntries(true);
+				} else if (nativeEntries.length > 0) {
+					putNativeEntries(false);
 				}
 
-				if (batchHashes) {
-					for (const next of entry.meta.next) {
-						if (!batchHashes.has(next)) {
-							externalNexts.add(next);
-						}
-					}
+				if (externalNexts.size > 0) {
+					const externalNextStartedAt = entryIndexProfileStart(profile);
+					await this.privateUpdateNextHeadHashes(
+						[...externalNexts],
+						false,
+						hashMutationLockOwner,
+					);
+					emitEntryIndexProfileDuration(profile, externalNextStartedAt, {
+						name: "log.entryIndex.putAppendBatch.externalNexts",
+						component: "log",
+						entries: externalNexts.size,
+						messages: 1,
+					});
 				}
-			}
-			emitEntryIndexProfileDuration(profile, prepareStartedAt, {
-				name: "log.entryIndex.putAppendBatch.prepare",
-				component: "log",
-				entries: entries.length,
-				messages: 1,
-				details: {
-					unique: properties.unique,
-					usedPreparedShallowEntries:
-						properties.prepared?.shallowEntries.length ?? 0,
-					usedPreparedNativeEntries:
-						properties.prepared?.nativeEntries?.length ?? 0,
-					nativeEntries: nativeEntries.length,
-					discoverExternalNexts: shouldDiscoverExternalNexts,
-				},
+			})().finally(() => {
+				for (const entry of entries) {
+					this.insertionPromises.delete(entry.hash);
+				}
 			});
 
-			const putNativeEntries = (allowLoopFallback: boolean) => {
-				if (nativeEntries.length === 0) {
-					return;
-				}
-				if (nativeGraphPutAppendChain) {
-					const nativePutStartedAt = entryIndexProfileStart(profile);
-					nativeGraphPutAppendChain(nativeEntries);
-					emitEntryIndexProfileDuration(profile, nativePutStartedAt, {
-						name: "log.entryIndex.putAppendBatch.nativeGraphPut",
-						component: "log",
-						entries: nativeEntries.length,
-						messages: 1,
-						details: { method: "putAppendChain" },
-					});
-				} else if (nativeGraphPutBatch) {
-					const nativePutStartedAt = entryIndexProfileStart(profile);
-					nativeGraphPutBatch(nativeEntries);
-					emitEntryIndexProfileDuration(profile, nativePutStartedAt, {
-						name: "log.entryIndex.putAppendBatch.nativeGraphPut",
-						component: "log",
-						entries: nativeEntries.length,
-						messages: 1,
-						details: { method: "putBatch" },
-					});
-				} else if (allowLoopFallback) {
-					const nativePutStartedAt = entryIndexProfileStart(profile);
-					for (const nativeEntry of nativeEntries) {
-						this.properties.nativeGraph?.graph.put(nativeEntry);
-					}
-					emitEntryIndexProfileDuration(profile, nativePutStartedAt, {
-						name: "log.entryIndex.putAppendBatch.nativeGraphPut",
-						component: "log",
-						entries: nativeEntries.length,
-						messages: 1,
-						details: { method: "putLoop" },
-					});
-				}
-			};
-
-			if (nativeCommitOwnsHotIndex) {
-				this.schedulePendingIndexWriteFlush();
-			} else if (deferBatchIndexWrite) {
-				const indexPutStartedAt = entryIndexProfileStart(profile);
-				for (const shallowEntry of shallowEntries) {
-					this.pendingIndexWrites.set(shallowEntry.hash, shallowEntry);
-				}
-				this.schedulePendingIndexWriteFlush();
-				emitEntryIndexProfileDuration(profile, indexPutStartedAt, {
-					name: "log.entryIndex.putAppendBatch.indexPut",
-					component: "log",
-					entries: shallowEntries.length,
-					messages: 1,
-					details: { deferred: true },
-				});
-				putNativeEntries(true);
-			} else if (putBatch) {
-				const indexPutStartedAt = entryIndexProfileStart(profile);
-				await putBatch.call(this.properties.index, shallowEntries);
-				emitEntryIndexProfileDuration(profile, indexPutStartedAt, {
-					name: "log.entryIndex.putAppendBatch.indexPut",
-					component: "log",
-					entries: shallowEntries.length,
-					messages: 1,
-				});
-				putNativeEntries(true);
-			} else if (nativeEntries.length > 0) {
-				putNativeEntries(false);
-			}
-
-			if (externalNexts.size > 0) {
-				const externalNextStartedAt = entryIndexProfileStart(profile);
-				await this.privateUpdateNextHeadHashes([...externalNexts], false);
-				emitEntryIndexProfileDuration(profile, externalNextStartedAt, {
-					name: "log.entryIndex.putAppendBatch.externalNexts",
-					component: "log",
-					entries: externalNexts.size,
-					messages: 1,
-				});
-			}
-		})().finally(() => {
 			for (const entry of entries) {
-				this.insertionPromises.delete(entry.hash);
+				this.insertionPromises.set(entry.hash, promise);
 			}
-		});
 
-		for (const entry of entries) {
-			this.insertionPromises.set(entry.hash, promise);
+			return await promise;
+		} finally {
+			if (hashMutationLockOwner) {
+				this.releaseHashMutationLocks(hashMutationLockOwner);
+			}
 		}
-
-		return promise;
 	}
 
 	// Internal trusted receive path for callers that can supply prepared append facts.
@@ -1897,195 +3005,211 @@ export class EntryIndex<T> {
 				await existingPromise;
 			}
 		}
+		const hashMutationLockOwner = this.properties.nativeGraph
+			? await this.acquireHashMutationLocks([
+					...entries.flatMap((entry) => [entry.hash, ...entry.meta.next]),
+					...(properties.externalNextHashes ?? []),
+				])
+			: undefined;
 
-		const promise = (async () => {
-			const profile = properties.profile;
-			const prepareStartedAt = entryIndexProfileStart(profile);
-			const externalNexts = new Set<string>(
-				properties.externalNextHashes ?? [],
-			);
-			const shouldDiscoverExternalNexts = !properties.externalNextHashes;
-			const batchHashes = shouldDiscoverExternalNexts
-				? new Set(entries.map((entry) => entry.hash))
-				: undefined;
-			const putBatch = this.properties.index.putBatch;
-			const shallowEntries: ShallowEntry[] = [];
-			const nativeEntries: NativeLogEntry[] = [];
-			const nativeGraphUpdated = properties.nativeGraphUpdated === true;
-			const nativeGraphPutAppendChain =
-				!nativeGraphUpdated &&
-				properties.externalNextHashes &&
-				this.properties.nativeGraph?.graph.putAppendChain
-					? this.properties.nativeGraph.graph.putAppendChain.bind(
-							this.properties.nativeGraph.graph,
-						)
+		try {
+			const promise = (async () => {
+				const profile = properties.profile;
+				const prepareStartedAt = entryIndexProfileStart(profile);
+				const externalNexts = new Set<string>(
+					properties.externalNextHashes ?? [],
+				);
+				const shouldDiscoverExternalNexts = !properties.externalNextHashes;
+				const batchHashes = shouldDiscoverExternalNexts
+					? new Set(entries.map((entry) => entry.hash))
 					: undefined;
-			const nativeGraphPutBatch =
-				!nativeGraphUpdated && this.properties.nativeGraph?.graph.putBatch
-					? this.properties.nativeGraph.graph.putBatch.bind(
-							this.properties.nativeGraph.graph,
-						)
-					: undefined;
-			const deferBatchIndexWrite =
-				properties.deferIndexWrite === true &&
-				!!this.properties.nativeGraph &&
-				entries.every((entry) => entry.meta.type !== EntryType.CUT);
-			const lazyNativeGraphUpdatedDeferredIndexWrite =
-				nativeGraphUpdated && deferBatchIndexWrite;
-
-			for (let i = 0; i < entries.length; i++) {
-				const entry = entries[i]!;
-				const isHead = properties.heads?.[i] ?? i === entries.length - 1;
-				if (properties.unique === true || !(await this.has(entry.hash))) {
-					this._length++;
-				}
-
-				let shallowEntry: ShallowEntry | undefined;
-				if (lazyNativeGraphUpdatedDeferredIndexWrite) {
-					this.pendingIndexWrites.set(entry.hash, () =>
-						materializePreparedAppendShallowEntry(entry, isHead),
-					);
-				} else {
-					shallowEntry = materializePreparedAppendShallowEntry(entry, isHead);
-				}
-				const nativeEntry =
+				const putBatch = this.properties.index.putBatch;
+				const shallowEntries: ShallowEntry[] = [];
+				const nativeEntries: NativeLogEntry[] = [];
+				const nativeGraphUpdated = properties.nativeGraphUpdated === true;
+				const nativeGraphPutAppendChain =
 					!nativeGraphUpdated &&
-					this.properties.nativeGraph &&
-					(entry.nativeEntry ??
-						toNativeLogEntry(
-							shallowEntry ??
-								materializePreparedAppendShallowEntry(entry, isHead),
-						));
-				if (nativeEntry) {
-					nativeEntry.head = isHead;
-				}
-				if (lazyNativeGraphUpdatedDeferredIndexWrite) {
-					// The native commit already updated blocks/graph; keep the JS
-					// compatibility index write lazy for later flushes.
-				} else if (deferBatchIndexWrite || putBatch) {
-					shallowEntries.push(shallowEntry!);
-					nativeEntry && nativeEntries.push(nativeEntry);
-				} else {
-					await this.properties.index.put(shallowEntry!);
-					nativeEntry && nativeEntries.push(nativeEntry);
-				}
+					properties.externalNextHashes &&
+					this.properties.nativeGraph?.graph.putAppendChain
+						? this.properties.nativeGraph.graph.putAppendChain.bind(
+								this.properties.nativeGraph.graph,
+							)
+						: undefined;
+				const nativeGraphPutBatch =
+					!nativeGraphUpdated && this.properties.nativeGraph?.graph.putBatch
+						? this.properties.nativeGraph.graph.putBatch.bind(
+								this.properties.nativeGraph.graph,
+							)
+						: undefined;
+				const deferBatchIndexWrite =
+					properties.deferIndexWrite === true &&
+					!!this.properties.nativeGraph &&
+					entries.every((entry) => entry.meta.type !== EntryType.CUT);
+				const lazyNativeGraphUpdatedDeferredIndexWrite =
+					nativeGraphUpdated && deferBatchIndexWrite;
 
-				if (batchHashes) {
-					for (const next of entry.meta.next) {
-						if (!batchHashes.has(next)) {
-							externalNexts.add(next);
+				for (let i = 0; i < entries.length; i++) {
+					const entry = entries[i]!;
+					const isHead = properties.heads?.[i] ?? i === entries.length - 1;
+					if (properties.unique === true || !(await this.has(entry.hash))) {
+						this._length++;
+					}
+
+					let shallowEntry: ShallowEntry | undefined;
+					if (lazyNativeGraphUpdatedDeferredIndexWrite) {
+						this.setPendingIndexWrite(entry.hash, () =>
+							materializePreparedAppendShallowEntry(entry, isHead),
+						);
+					} else {
+						shallowEntry = materializePreparedAppendShallowEntry(entry, isHead);
+					}
+					const nativeEntry =
+						!nativeGraphUpdated &&
+						this.properties.nativeGraph &&
+						(entry.nativeEntry ??
+							toNativeLogEntry(
+								shallowEntry ??
+									materializePreparedAppendShallowEntry(entry, isHead),
+							));
+					if (nativeEntry) {
+						nativeEntry.head = isHead;
+					}
+					if (lazyNativeGraphUpdatedDeferredIndexWrite) {
+						// The native commit already updated blocks/graph; keep the JS
+						// compatibility index write lazy for later flushes.
+					} else if (deferBatchIndexWrite || putBatch) {
+						shallowEntries.push(shallowEntry!);
+						nativeEntry && nativeEntries.push(nativeEntry);
+					} else {
+						await this.properties.index.put(shallowEntry!);
+						nativeEntry && nativeEntries.push(nativeEntry);
+					}
+
+					if (batchHashes) {
+						for (const next of entry.meta.next) {
+							if (!batchHashes.has(next)) {
+								externalNexts.add(next);
+							}
 						}
 					}
 				}
-			}
-			emitEntryIndexProfileDuration(profile, prepareStartedAt, {
-				name: "log.entryIndex.putAppendFactsBatch.prepare",
-				component: "log",
-				entries: entries.length,
-				messages: 1,
-				details: {
-					unique: properties.unique,
-					nativeEntries: nativeEntries.length,
-					discoverExternalNexts: shouldDiscoverExternalNexts,
-					nativeGraphUpdated,
-				},
-			});
-
-			const putNativeEntries = (allowLoopFallback: boolean) => {
-				if (nativeEntries.length === 0) {
-					return;
-				}
-				if (nativeGraphPutAppendChain) {
-					const nativePutStartedAt = entryIndexProfileStart(profile);
-					nativeGraphPutAppendChain(nativeEntries);
-					emitEntryIndexProfileDuration(profile, nativePutStartedAt, {
-						name: "log.entryIndex.putAppendFactsBatch.nativeGraphPut",
-						component: "log",
-						entries: nativeEntries.length,
-						messages: 1,
-						details: { method: "putAppendChain" },
-					});
-				} else if (nativeGraphPutBatch) {
-					const nativePutStartedAt = entryIndexProfileStart(profile);
-					nativeGraphPutBatch(nativeEntries);
-					emitEntryIndexProfileDuration(profile, nativePutStartedAt, {
-						name: "log.entryIndex.putAppendFactsBatch.nativeGraphPut",
-						component: "log",
-						entries: nativeEntries.length,
-						messages: 1,
-						details: { method: "putBatch" },
-					});
-				} else if (allowLoopFallback) {
-					const nativePutStartedAt = entryIndexProfileStart(profile);
-					for (const nativeEntry of nativeEntries) {
-						this.properties.nativeGraph?.graph.put(nativeEntry);
-					}
-					emitEntryIndexProfileDuration(profile, nativePutStartedAt, {
-						name: "log.entryIndex.putAppendFactsBatch.nativeGraphPut",
-						component: "log",
-						entries: nativeEntries.length,
-						messages: 1,
-						details: { method: "putLoop" },
-					});
-				}
-			};
-
-			if (deferBatchIndexWrite) {
-				const indexPutStartedAt = entryIndexProfileStart(profile);
-				if (!lazyNativeGraphUpdatedDeferredIndexWrite) {
-					for (const shallowEntry of shallowEntries) {
-						this.pendingIndexWrites.set(shallowEntry.hash, shallowEntry);
-					}
-				}
-				this.schedulePendingIndexWriteFlush();
-				emitEntryIndexProfileDuration(profile, indexPutStartedAt, {
-					name: "log.entryIndex.putAppendFactsBatch.indexPut",
+				emitEntryIndexProfileDuration(profile, prepareStartedAt, {
+					name: "log.entryIndex.putAppendFactsBatch.prepare",
 					component: "log",
-					entries: lazyNativeGraphUpdatedDeferredIndexWrite
-						? entries.length
-						: shallowEntries.length,
+					entries: entries.length,
 					messages: 1,
 					details: {
-						deferred: true,
-						lazy: lazyNativeGraphUpdatedDeferredIndexWrite,
+						unique: properties.unique,
+						nativeEntries: nativeEntries.length,
+						discoverExternalNexts: shouldDiscoverExternalNexts,
+						nativeGraphUpdated,
 					},
 				});
-				putNativeEntries(true);
-			} else if (putBatch) {
-				const indexPutStartedAt = entryIndexProfileStart(profile);
-				await putBatch.call(this.properties.index, shallowEntries);
-				emitEntryIndexProfileDuration(profile, indexPutStartedAt, {
-					name: "log.entryIndex.putAppendFactsBatch.indexPut",
-					component: "log",
-					entries: shallowEntries.length,
-					messages: 1,
-				});
-				putNativeEntries(true);
-			} else if (nativeEntries.length > 0) {
-				putNativeEntries(true);
-			}
 
-			if (externalNexts.size > 0) {
-				const externalNextStartedAt = entryIndexProfileStart(profile);
-				await this.privateUpdateNextHeadHashes([...externalNexts], false);
-				emitEntryIndexProfileDuration(profile, externalNextStartedAt, {
-					name: "log.entryIndex.putAppendFactsBatch.externalNexts",
-					component: "log",
-					entries: externalNexts.size,
-					messages: 1,
-				});
-			}
-		})().finally(() => {
+				const putNativeEntries = (allowLoopFallback: boolean) => {
+					if (nativeEntries.length === 0) {
+						return;
+					}
+					if (nativeGraphPutAppendChain) {
+						const nativePutStartedAt = entryIndexProfileStart(profile);
+						nativeGraphPutAppendChain(nativeEntries);
+						emitEntryIndexProfileDuration(profile, nativePutStartedAt, {
+							name: "log.entryIndex.putAppendFactsBatch.nativeGraphPut",
+							component: "log",
+							entries: nativeEntries.length,
+							messages: 1,
+							details: { method: "putAppendChain" },
+						});
+					} else if (nativeGraphPutBatch) {
+						const nativePutStartedAt = entryIndexProfileStart(profile);
+						nativeGraphPutBatch(nativeEntries);
+						emitEntryIndexProfileDuration(profile, nativePutStartedAt, {
+							name: "log.entryIndex.putAppendFactsBatch.nativeGraphPut",
+							component: "log",
+							entries: nativeEntries.length,
+							messages: 1,
+							details: { method: "putBatch" },
+						});
+					} else if (allowLoopFallback) {
+						const nativePutStartedAt = entryIndexProfileStart(profile);
+						for (const nativeEntry of nativeEntries) {
+							this.properties.nativeGraph?.graph.put(nativeEntry);
+						}
+						emitEntryIndexProfileDuration(profile, nativePutStartedAt, {
+							name: "log.entryIndex.putAppendFactsBatch.nativeGraphPut",
+							component: "log",
+							entries: nativeEntries.length,
+							messages: 1,
+							details: { method: "putLoop" },
+						});
+					}
+				};
+
+				if (deferBatchIndexWrite) {
+					const indexPutStartedAt = entryIndexProfileStart(profile);
+					if (!lazyNativeGraphUpdatedDeferredIndexWrite) {
+						for (const shallowEntry of shallowEntries) {
+							this.setPendingIndexWrite(shallowEntry.hash, shallowEntry);
+						}
+					}
+					this.schedulePendingIndexWriteFlush();
+					emitEntryIndexProfileDuration(profile, indexPutStartedAt, {
+						name: "log.entryIndex.putAppendFactsBatch.indexPut",
+						component: "log",
+						entries: lazyNativeGraphUpdatedDeferredIndexWrite
+							? entries.length
+							: shallowEntries.length,
+						messages: 1,
+						details: {
+							deferred: true,
+							lazy: lazyNativeGraphUpdatedDeferredIndexWrite,
+						},
+					});
+					putNativeEntries(true);
+				} else if (putBatch) {
+					const indexPutStartedAt = entryIndexProfileStart(profile);
+					await putBatch.call(this.properties.index, shallowEntries);
+					emitEntryIndexProfileDuration(profile, indexPutStartedAt, {
+						name: "log.entryIndex.putAppendFactsBatch.indexPut",
+						component: "log",
+						entries: shallowEntries.length,
+						messages: 1,
+					});
+					putNativeEntries(true);
+				} else if (nativeEntries.length > 0) {
+					putNativeEntries(true);
+				}
+
+				if (externalNexts.size > 0) {
+					const externalNextStartedAt = entryIndexProfileStart(profile);
+					await this.privateUpdateNextHeadHashes(
+						[...externalNexts],
+						false,
+						hashMutationLockOwner,
+					);
+					emitEntryIndexProfileDuration(profile, externalNextStartedAt, {
+						name: "log.entryIndex.putAppendFactsBatch.externalNexts",
+						component: "log",
+						entries: externalNexts.size,
+						messages: 1,
+					});
+				}
+			})().finally(() => {
+				for (const entry of entries) {
+					this.insertionPromises.delete(entry.hash);
+				}
+			});
+
 			for (const entry of entries) {
-				this.insertionPromises.delete(entry.hash);
+				this.insertionPromises.set(entry.hash, promise);
 			}
-		});
 
-		for (const entry of entries) {
-			this.insertionPromises.set(entry.hash, promise);
+			return await promise;
+		} finally {
+			if (hashMutationLockOwner) {
+				this.releaseHashMutationLocks(hashMutationLockOwner);
+			}
 		}
-
-		return promise;
 	}
 
 	/** @internal */
@@ -2101,62 +3225,123 @@ export class EntryIndex<T> {
 		if (!entry.hash) {
 			throw new Error("Missing hash");
 		}
-		const existingPromise = this.insertionPromises.get(entry.hash);
-		if (existingPromise) {
-			await existingPromise;
+		const hashMutationLockOwner = this.properties.nativeGraph
+			? await this.acquireHashMutationLocks([
+					entry.hash,
+					...properties.externalNextHashes,
+				])
+			: undefined;
+		try {
+			const existingPromise = this.insertionPromises.get(entry.hash);
+			if (existingPromise) {
+				await existingPromise;
+			}
+
+			const promise = (async () => {
+				const isHead = properties.isHead ?? true;
+				if (properties.unique === true || !(await this.has(entry.hash))) {
+					this._length++;
+				}
+
+				this.cache.add(entry.hash, entry);
+				const shallowEntry =
+					properties.shallowEntry ??
+					Entry.takePreparedShallowEntry(entry, isHead) ??
+					entry.toShallow(isHead);
+				shallowEntry.head = isHead;
+				this.setPendingIndexWrite(entry.hash, shallowEntry);
+				this.schedulePendingIndexWriteFlush();
+
+				if (properties.externalNextHashes.length > 0) {
+					await this.privateUpdateNextHeadHashes(
+						properties.externalNextHashes,
+						false,
+						hashMutationLockOwner,
+					);
+				}
+			})().finally(() => {
+				this.insertionPromises.delete(entry.hash);
+			});
+
+			this.insertionPromises.set(entry.hash, promise);
+			return await promise;
+		} finally {
+			if (hashMutationLockOwner) {
+				this.releaseHashMutationLocks(hashMutationLockOwner);
+			}
 		}
-
-		const promise = (async () => {
-			const isHead = properties.isHead ?? true;
-			if (properties.unique === true || !(await this.has(entry.hash))) {
-				this._length++;
-			}
-
-			this.cache.add(entry.hash, entry);
-			const shallowEntry =
-				properties.shallowEntry ??
-				Entry.takePreparedShallowEntry(entry, isHead) ??
-				entry.toShallow(isHead);
-			shallowEntry.head = isHead;
-			this.pendingIndexWrites.set(entry.hash, shallowEntry);
-			this.schedulePendingIndexWriteFlush();
-
-			if (properties.externalNextHashes.length > 0) {
-				await this.privateUpdateNextHeadHashes(
-					properties.externalNextHashes,
-					false,
-				);
-			}
-		})().finally(() => {
-			this.insertionPromises.delete(entry.hash);
-		});
-
-		this.insertionPromises.set(entry.hash, promise);
-		return promise;
 	}
 
 	/** @internal */
-	putNativeCommittedAppendFacts(properties: {
-		hash: string;
-		unique: boolean;
-		externalNextHashes: string[];
-		shallowEntry?: ShallowEntry;
-		getShallowEntry?: () => ShallowEntry;
-		isHead?: boolean;
-	}): Promise<void> | void {
+	putNativeCommittedAppendFacts(
+		properties: {
+			hash: string;
+			unique: boolean;
+			externalNextHashes: string[];
+			shallowEntry?: ShallowEntry;
+			getShallowEntry?: () => ShallowEntry;
+			isHead?: boolean;
+		},
+		transaction?: NativeCommittedAppendFactsTransaction,
+		hashMutationLockOwner?: EntryIndexHashMutationLockOwner,
+	): Promise<void> | void {
 		if (!properties.hash) {
 			throw new Error("Missing hash");
+		}
+		if (!properties.shallowEntry && !properties.getShallowEntry) {
+			throw new Error("Missing shallow entry");
+		}
+		if (!transaction && hashMutationLockOwner) {
+			this.assertHashMutationLocks(hashMutationLockOwner, [
+				properties.hash,
+				...properties.externalNextHashes,
+			]);
+		}
+		if (!transaction && this.properties.nativeGraph && !hashMutationLockOwner) {
+			return this.withHashMutationLocks(
+				[properties.hash, ...properties.externalNextHashes],
+				(owner) =>
+					this.putNativeCommittedAppendFactsLocked(
+						properties,
+						undefined,
+						owner,
+					),
+			);
+		}
+		return this.putNativeCommittedAppendFactsLocked(
+			properties,
+			transaction,
+			hashMutationLockOwner,
+		);
+	}
+
+	private putNativeCommittedAppendFactsLocked(
+		properties: {
+			hash: string;
+			unique: boolean;
+			externalNextHashes: string[];
+			shallowEntry?: ShallowEntry;
+			getShallowEntry?: () => ShallowEntry;
+			isHead?: boolean;
+		},
+		transaction?: NativeCommittedAppendFactsTransaction,
+		hashMutationLockOwner?: EntryIndexHashMutationLockOwner,
+	): Promise<void> | void {
+		if (transaction) {
+			this.stageNativeCommittedAppendExternalNextHashes(
+				transaction,
+				properties.externalNextHashes,
+			);
 		}
 		const existingPromise = this.insertionPromises.get(properties.hash);
 		if (
 			!existingPromise &&
 			properties.unique === true &&
-			properties.externalNextHashes.length === 0
+			(properties.externalNextHashes.length === 0 || transaction !== undefined)
 		) {
 			const isHead = properties.isHead ?? true;
-			this._length++;
-			if (!properties.shallowEntry && !properties.getShallowEntry) {
-				throw new Error("Missing shallow entry");
+			if (!transaction) {
+				this._length++;
 			}
 			const pending =
 				properties.shallowEntry ??
@@ -2168,12 +3353,26 @@ export class EntryIndex<T> {
 			if (properties.shallowEntry) {
 				properties.shallowEntry.head = isHead;
 			}
-			this.pendingIndexWrites.set(properties.hash, pending);
-			this.schedulePendingIndexWriteFlush();
+			if (transaction) {
+				return this.stageNativeCommittedAppendFact(
+					transaction,
+					properties.hash,
+					pending,
+					true,
+				);
+			} else {
+				this.setPendingIndexWrite(properties.hash, pending);
+				this.schedulePendingIndexWriteFlush();
+			}
 			return;
 		}
 
-		return this.putNativeCommittedAppendFactsAsync(properties, existingPromise);
+		return this.putNativeCommittedAppendFactsAsync(
+			properties,
+			existingPromise,
+			transaction,
+			hashMutationLockOwner,
+		);
 	}
 
 	/** @internal */
@@ -2186,23 +3385,66 @@ export class EntryIndex<T> {
 			getShallowEntry?: () => ShallowEntry;
 			isHead?: boolean;
 		}>,
+		transaction?: NativeCommittedAppendFactsTransaction,
+		hashMutationLockOwner?: EntryIndexHashMutationLockOwner,
 	): Promise<void> | void {
 		if (rows.length === 0) {
 			return;
 		}
+		if (!transaction && hashMutationLockOwner) {
+			this.assertHashMutationLocks(
+				hashMutationLockOwner,
+				rows.flatMap((row) => [row.hash, ...row.externalNextHashes]),
+			);
+		}
+		if (!transaction && this.properties.nativeGraph && !hashMutationLockOwner) {
+			return this.withHashMutationLocks(
+				rows.flatMap((row) => [row.hash, ...row.externalNextHashes]),
+				(owner) =>
+					this.putNativeCommittedAppendFactsBatchLocked(rows, undefined, owner),
+			);
+		}
+		return this.putNativeCommittedAppendFactsBatchLocked(
+			rows,
+			transaction,
+			hashMutationLockOwner,
+		);
+	}
+
+	private putNativeCommittedAppendFactsBatchLocked(
+		rows: Array<{
+			hash: string;
+			unique: boolean;
+			externalNextHashes: string[];
+			shallowEntry?: ShallowEntry;
+			getShallowEntry?: () => ShallowEntry;
+			isHead?: boolean;
+		}>,
+		transaction?: NativeCommittedAppendFactsTransaction,
+		hashMutationLockOwner?: EntryIndexHashMutationLockOwner,
+	): Promise<void> | void {
 		const asyncRows: typeof rows = [];
 		const externalNextHashes: string[] = [];
+		const stagedRows: Promise<void>[] = [];
 		let scheduledPendingFlush = false;
 		for (const row of rows) {
 			if (!row.hash) {
 				throw new Error("Missing hash");
 			}
+			if (transaction) {
+				this.stageNativeCommittedAppendExternalNextHashes(
+					transaction,
+					row.externalNextHashes,
+				);
+			}
 			const existingPromise = this.insertionPromises.get(row.hash);
 			if (!existingPromise && row.unique === true) {
 				const isHead = row.isHead ?? true;
-				this._length++;
 				if (!row.shallowEntry && !row.getShallowEntry) {
 					throw new Error("Missing shallow entry");
+				}
+				if (!transaction) {
+					this._length++;
 				}
 				const pending =
 					row.shallowEntry ??
@@ -2214,11 +3456,23 @@ export class EntryIndex<T> {
 				if (row.shallowEntry) {
 					row.shallowEntry.head = isHead;
 				}
-				this.pendingIndexWrites.set(row.hash, pending);
-				if (row.externalNextHashes.length > 0) {
+				if (transaction) {
+					const staged = this.stageNativeCommittedAppendFact(
+						transaction,
+						row.hash,
+						pending,
+						true,
+					);
+					if (staged) {
+						stagedRows.push(staged);
+					}
+				} else {
+					this.setPendingIndexWrite(row.hash, pending);
+				}
+				if (!transaction && row.externalNextHashes.length > 0) {
 					externalNextHashes.push(...row.externalNextHashes);
 				}
-				scheduledPendingFlush = true;
+				scheduledPendingFlush ||= transaction === undefined;
 			} else {
 				asyncRows.push(row);
 			}
@@ -2228,12 +3482,23 @@ export class EntryIndex<T> {
 		}
 		const batchedNextUpdate =
 			externalNextHashes.length > 0
-				? this.privateUpdateNextHeadHashes(externalNextHashes, false)
+				? this.privateUpdateNextHeadHashes(
+						externalNextHashes,
+						false,
+						hashMutationLockOwner,
+					)
 				: undefined;
-		if (asyncRows.length > 0 || batchedNextUpdate) {
+		if (asyncRows.length > 0 || batchedNextUpdate || stagedRows.length > 0) {
 			return Promise.all([
 				batchedNextUpdate,
-				...asyncRows.map((row) => this.putNativeCommittedAppendFacts(row)),
+				...stagedRows,
+				...asyncRows.map((row) =>
+					this.putNativeCommittedAppendFactsLocked(
+						row,
+						transaction,
+						hashMutationLockOwner,
+					),
+				),
 			]).then(() => undefined);
 		}
 	}
@@ -2248,19 +3513,22 @@ export class EntryIndex<T> {
 			isHead?: boolean;
 		},
 		existingPromise?: Promise<void>,
+		transaction?: NativeCommittedAppendFactsTransaction,
+		hashMutationLockOwner?: EntryIndexHashMutationLockOwner,
 	) {
 		if (existingPromise) {
 			await existingPromise;
 		}
 		const promise = (async () => {
 			const isHead = properties.isHead ?? true;
+			let lengthIncremented = false;
 			if (properties.unique === true || !(await this.has(properties.hash))) {
-				this._length++;
+				if (!transaction) {
+					this._length++;
+				}
+				lengthIncremented = true;
 			}
 
-			if (!properties.shallowEntry && !properties.getShallowEntry) {
-				throw new Error("Missing shallow entry");
-			}
 			const pending =
 				properties.shallowEntry ??
 				(() => {
@@ -2271,13 +3539,23 @@ export class EntryIndex<T> {
 			if (properties.shallowEntry) {
 				properties.shallowEntry.head = isHead;
 			}
-			this.pendingIndexWrites.set(properties.hash, pending);
-			this.schedulePendingIndexWriteFlush();
+			if (transaction) {
+				await this.stageNativeCommittedAppendFact(
+					transaction,
+					properties.hash,
+					pending,
+					lengthIncremented,
+				);
+			} else {
+				this.setPendingIndexWrite(properties.hash, pending);
+				this.schedulePendingIndexWriteFlush();
+			}
 
-			if (properties.externalNextHashes.length > 0) {
+			if (!transaction && properties.externalNextHashes.length > 0) {
 				await this.privateUpdateNextHeadHashes(
 					properties.externalNextHashes,
 					false,
+					hashMutationLockOwner,
 				);
 			}
 		})().finally(() => {
@@ -2289,37 +3567,73 @@ export class EntryIndex<T> {
 	}
 
 	async delete(k: string, from?: Entry<any> | ShallowEntry) {
-		return this.withCacheInvalidation([k], async () => {
-			if (from && from.hash !== k) {
-				throw new Error("Shallow hash doesn't match the key");
+		if (from && from.hash !== k) {
+			throw new Error("Shallow hash doesn't match the key");
+		}
+		let hashMutationLockOwner: EntryIndexHashMutationLockOwner | undefined;
+		if (this.properties.nativeGraph) {
+			if (from) {
+				hashMutationLockOwner = await this.acquireHashMutationLocks([
+					k,
+					...from.meta.next,
+				]);
+			} else {
+				// First lock the content-addressed row before inspecting its immutable
+				// `next` set, then reacquire the complete sorted set in one lease.
+				hashMutationLockOwner = await this.acquireHashMutationLocks([k]);
+				const snapshot =
+					this.getPendingIndexWrite(k) ?? (await this.getShallow(k))?.value;
+				const nexts = snapshot?.meta.next ?? [];
+				if (nexts.length > 0) {
+					this.releaseHashMutationLocks(hashMutationLockOwner);
+					hashMutationLockOwner = await this.acquireHashMutationLocks([
+						k,
+						...nexts,
+					]);
+				}
 			}
+		}
+		try {
+			return await this.withCacheInvalidation([k], async () => {
+				const pending = this.getPendingIndexWrite(k);
+				from = from || pending || (await this.getShallow(k))?.value;
+				if (!from) {
+					return; // already deleted
+				}
+				if (pending) {
+					this.deletePendingIndexWrite(k);
+					await this.properties.store.rm(k);
+					this._length--;
+					this.properties.nativeGraph?.graph.delete(k);
+					await this.privateUpdateNextHeadProperty(
+						from,
+						true,
+						hashMutationLockOwner,
+					);
+					return from;
+				}
 
-			const pending = this.getPendingIndexWrite(k);
-			from = from || pending || (await this.getShallow(k))?.value;
-			if (!from) {
-				return; // already deleted
-			}
-			if (pending) {
-				this.pendingIndexWrites.delete(k);
+				let deleted = await this.properties.index.del({ query: { hash: k } });
 				await this.properties.store.rm(k);
-				this._length--;
-				this.properties.nativeGraph?.graph.delete(k);
-				await this.privateUpdateNextHeadProperty(from, true);
-				return from;
+
+				if (deleted.length > 0) {
+					this._length -= deleted.length;
+					this.properties.nativeGraph?.graph.delete(k);
+
+					// mark all next entries as new heads
+					await this.privateUpdateNextHeadProperty(
+						from,
+						true,
+						hashMutationLockOwner,
+					);
+					return from;
+				}
+			});
+		} finally {
+			if (hashMutationLockOwner) {
+				this.releaseHashMutationLocks(hashMutationLockOwner);
 			}
-
-			let deleted = await this.properties.index.del({ query: { hash: k } });
-			await this.properties.store.rm(k);
-
-			if (deleted.length > 0) {
-				this._length -= deleted.length;
-				this.properties.nativeGraph?.graph.delete(k);
-
-				// mark all next entries as new heads
-				await this.privateUpdateNextHeadProperty(from, true);
-				return from;
-			}
-		});
+		}
 	}
 
 	canDeleteMany(): boolean {
@@ -2331,27 +3645,40 @@ export class EntryIndex<T> {
 
 	async deleteMany(
 		from: ShallowEntry[],
-		options?: { skipNextHeadUpdates?: boolean },
+		options?: EntryIndexDeleteOptions,
 	): Promise<ShallowEntry[]> {
 		return this.deleteManyMaybe(from, options);
 	}
 
 	deleteManyMaybe(
 		from: ShallowEntry[],
-		options?: { skipNextHeadUpdates?: boolean },
+		options?: EntryIndexDeleteOptions,
 	): MaybePromise<ShallowEntry[]> {
 		if (from.length === 0) {
 			return [];
 		}
-		return this.withCacheInvalidation(
-			from.map((node) => node.hash),
-			() => this.deleteManyWithInvalidation(from, options),
-		);
+		const hashes = from.flatMap((node) => [node.hash, ...node.meta.next]);
+		const run = (hashMutationLockOwner?: EntryIndexHashMutationLockOwner) =>
+			this.withCacheInvalidation(
+				from.map((node) => node.hash),
+				() =>
+					this.deleteManyWithInvalidation(from, {
+						...options,
+						hashMutationLockOwner,
+					}),
+			);
+		return this.properties.nativeGraph
+			? this.withHashMutationLocks(
+					hashes,
+					(owner) => run(owner),
+					options?.hashMutationLockOwner,
+				)
+			: run();
 	}
 
 	private deleteManyWithInvalidation(
 		from: ShallowEntry[],
-		options?: { skipNextHeadUpdates?: boolean },
+		options?: EntryIndexDeleteOptions,
 	): MaybePromise<ShallowEntry[]> {
 		if (from.length === 1) {
 			return this.deleteSingleMaybe(from[0]!, options);
@@ -2374,7 +3701,7 @@ export class EntryIndex<T> {
 		for (const node of nodes) {
 			const pending = this.getPendingIndexWrite(node.hash);
 			if (pending) {
-				this.pendingIndexWrites.delete(node.hash);
+				this.deletePendingIndexWrite(node.hash);
 				deletedByHash.set(node.hash, pending);
 				storeHashes.push(node.hash);
 			} else {
@@ -2424,7 +3751,7 @@ export class EntryIndex<T> {
 
 	consumeNativeTrimmedEntriesMaybe(
 		from: ShallowEntry[],
-		options?: { skipNextHeadUpdates?: boolean; deleteBlocks?: boolean },
+		options?: NativeTrimConsumeOptions,
 	): MaybePromise<ShallowEntry[]> {
 		if (from.length === 0) {
 			return [];
@@ -2445,7 +3772,7 @@ export class EntryIndex<T> {
 
 	consumeNativeTrimmedEntryHashesMaybe(
 		hashes: string[],
-		options?: { skipNextHeadUpdates?: boolean; deleteBlocks?: boolean },
+		options?: NativeTrimConsumeOptions,
 	): MaybePromise<ShallowEntry[]> {
 		if (hashes.length === 0) {
 			return [];
@@ -2466,7 +3793,7 @@ export class EntryIndex<T> {
 
 	consumeNativeTrimmedEntryHashesNoReturnMaybe(
 		hashes: string[],
-		options?: { skipNextHeadUpdates?: boolean; deleteBlocks?: boolean },
+		options?: NativeTrimConsumeOptions,
 	): MaybePromise<boolean> | undefined {
 		if (
 			!options?.skipNextHeadUpdates ||
@@ -2475,14 +3802,38 @@ export class EntryIndex<T> {
 		) {
 			return undefined;
 		}
-		return this.withCacheInvalidation(hashes, () =>
-			this.consumeNativeTrimmedEntryHashesNoReturnWithInvalidation(hashes),
-		);
+		const run = (hashMutationLockOwner?: EntryIndexHashMutationLockOwner) =>
+			this.withCacheInvalidation(hashes, () =>
+				this.consumeNativeTrimmedEntryHashesNoReturnWithInvalidation(hashes, {
+					...options,
+					hashMutationLockOwner,
+				}),
+			);
+		if (options.nativeCommittedAppendFactsTransaction) {
+			return run(
+				options.nativeCommittedAppendFactsTransaction.hashMutationLockOwner,
+			);
+		}
+		return this.properties.nativeGraph
+			? this.withHashMutationLocks(
+					hashes,
+					(owner) => run(owner),
+					options.hashMutationLockOwner,
+				)
+			: run();
 	}
 
 	private consumeNativeTrimmedEntryHashesNoReturnWithInvalidation(
 		hashes: string[],
+		options: NativeTrimConsumeOptions,
 	): MaybePromise<boolean> {
+		if (options.nativeCommittedAppendFactsTransaction) {
+			return this.consumeNativeTrimmedEntriesInTransaction(
+				hashes,
+				undefined,
+				options,
+			).then(() => true);
+		}
 		const indexedHashes: string[] = [];
 		let pendingDeleted = 0;
 		const seen = new Set<string>();
@@ -2491,16 +3842,33 @@ export class EntryIndex<T> {
 				continue;
 			}
 			seen.add(hash);
-			if (this.pendingIndexWrites.delete(hash)) {
+			if (this.deletePendingIndexWrite(hash)) {
 				pendingDeleted++;
 			} else {
 				indexedHashes.push(hash);
 			}
 		}
 
-		const finish = (indexedDeleted: number) => {
-			this._length -= pendingDeleted + indexedDeleted;
-			return true;
+		const finish = (indexedDeleted: number): MaybePromise<boolean> => {
+			const afterNativeDeleteMirror = () => {
+				this._length -= pendingDeleted + indexedDeleted;
+				return true;
+			};
+			const store = this.properties.store;
+			if (
+				options.nativeBlocksDeleted === true &&
+				hasNativeDeleteMirror(store)
+			) {
+				return mapMaybePromise(
+					mirrorNativeDelete(
+						store,
+						[...seen],
+						options.nativeDeleteCleanupToken,
+					),
+					afterNativeDeleteMirror,
+				);
+			}
+			return afterNativeDeleteMirror();
 		};
 		if (indexedHashes.length === 0) {
 			return finish(0);
@@ -2531,7 +3899,7 @@ export class EntryIndex<T> {
 
 	private async consumeNativeTrimmedEntryHashesNoReturnByQuery(
 		indexedHashes: string[],
-		finish: (indexedDeleted: number) => boolean,
+		finish: (indexedDeleted: number) => MaybePromise<boolean>,
 	): Promise<boolean> {
 		const batchSize = 64;
 		let deletedCount = 0;
@@ -2547,25 +3915,50 @@ export class EntryIndex<T> {
 
 	private consumeNativeTrimmedEntryNodesMaybe(
 		nodes: ShallowEntry[],
-		options?: { skipNextHeadUpdates?: boolean; deleteBlocks?: boolean },
+		options?: NativeTrimConsumeOptions,
 	): MaybePromise<ShallowEntry[]> {
-		return this.withCacheInvalidation(
-			nodes.map((node) => node.hash),
-			() => this.consumeNativeTrimmedEntryNodesWithInvalidation(nodes, options),
-		);
+		const hashes = nodes.flatMap((node) => [node.hash, ...node.meta.next]);
+		const run = (hashMutationLockOwner?: EntryIndexHashMutationLockOwner) =>
+			this.withCacheInvalidation(
+				nodes.map((node) => node.hash),
+				() =>
+					this.consumeNativeTrimmedEntryNodesWithInvalidation(nodes, {
+						...options,
+						hashMutationLockOwner,
+					}),
+			);
+		if (options?.nativeCommittedAppendFactsTransaction) {
+			return run(
+				options.nativeCommittedAppendFactsTransaction.hashMutationLockOwner,
+			);
+		}
+		return this.properties.nativeGraph
+			? this.withHashMutationLocks(
+					hashes,
+					(owner) => run(owner),
+					options?.hashMutationLockOwner,
+				)
+			: run();
 	}
 
 	private consumeNativeTrimmedEntryNodesWithInvalidation(
 		nodes: ShallowEntry[],
-		options?: { skipNextHeadUpdates?: boolean; deleteBlocks?: boolean },
+		options?: NativeTrimConsumeOptions,
 	): MaybePromise<ShallowEntry[]> {
+		if (options?.nativeCommittedAppendFactsTransaction) {
+			return this.consumeNativeTrimmedEntriesInTransaction(
+				nodes.map((node) => node.hash),
+				new Map(nodes.map((node) => [node.hash, node])),
+				options,
+			);
+		}
 		const indexedByHash = new Map(nodes.map((node) => [node.hash, node]));
 		const deletedByHash = new Map<string, ShallowEntry>();
 		const indexedHashes: string[] = [];
 		for (const node of nodes) {
 			const pending = this.getPendingIndexWrite(node.hash);
 			if (pending) {
-				this.pendingIndexWrites.delete(node.hash);
+				this.deletePendingIndexWrite(node.hash);
 				deletedByHash.set(node.hash, pending);
 			} else {
 				indexedHashes.push(node.hash);
@@ -2608,13 +4001,68 @@ export class EntryIndex<T> {
 		return finish();
 	}
 
+	private async consumeNativeTrimmedEntriesInTransaction(
+		hashes: string[],
+		nodesByHash: Map<string, ShallowEntry> | undefined,
+		options: NativeTrimConsumeOptions,
+	): Promise<ShallowEntry[]> {
+		const transaction = options.nativeCommittedAppendFactsTransaction;
+		if (!transaction) {
+			throw new Error("Missing native append-facts transaction");
+		}
+		if (transaction.state !== "open") {
+			throw new Error("Native append-facts transaction is not open");
+		}
+		const uniqueHashes = [...new Set(hashes.filter(Boolean))];
+		this.reserveNativeCommittedAppendFactsHashLocks(transaction, uniqueHashes);
+		await transaction.hashLocksReady;
+		this.throwIfNativeCommittedAppendFactsRollbackFailed();
+
+		const operationRows: NativeCommittedAppendFactsTrimTransactionRow[] = [];
+		const removed: ShallowEntry[] = [];
+		for (const hash of uniqueHashes) {
+			const previousPending = this.pendingIndexWrites.get(hash);
+			const previousGeneration = this.pendingIndexWriteGenerations.get(hash);
+			const previousIndex = (await this.properties.index.get(toId(hash)))
+				?.value;
+			const row: NativeCommittedAppendFactsTrimTransactionRow = {
+				hash,
+				previousPending,
+				previousGeneration,
+				previousIndex,
+				pendingRemoved: false,
+				indexDeleteAttempted: false,
+				lengthDecremented: false,
+			};
+			transaction.trimRows.push(row);
+			operationRows.push(row);
+			if (previousPending) {
+				removed.push(this.materializePendingIndexWrite(hash, previousPending));
+			} else if (previousIndex) {
+				removed.push(previousIndex);
+			} else if (nodesByHash?.has(hash)) {
+				// A native graph may have removed the durable row before returning its
+				// trim set. The supplied node is useful to callers, but it must not
+				// affect length unless this transaction owned an index fact.
+				removed.push(nodesByHash.get(hash)!);
+			}
+		}
+
+		transaction.trimBatches.push({
+			rows: operationRows,
+			nativeBlocksDeleted: options.nativeBlocksDeleted === true,
+			nativeDeleteCleanupToken: options.nativeDeleteCleanupToken,
+		});
+		return removed;
+	}
+
 	private deleteSingleMaybe(
 		node: ShallowEntry,
-		options?: { skipNextHeadUpdates?: boolean },
+		options?: EntryIndexDeleteOptions,
 	): MaybePromise<ShallowEntry[]> {
 		const pending = this.getPendingIndexWrite(node.hash);
 		if (pending) {
-			this.pendingIndexWrites.delete(node.hash);
+			this.deletePendingIndexWrite(node.hash);
 			return this.finishDeleteSingle(pending, options);
 		}
 
@@ -2641,14 +4089,18 @@ export class EntryIndex<T> {
 
 	private finishDeleteSingle(
 		node: ShallowEntry,
-		options?: { skipNextHeadUpdates?: boolean },
+		options?: EntryIndexDeleteOptions,
 	): MaybePromise<ShallowEntry[]> {
 		const afterStoreDelete = (): MaybePromise<ShallowEntry[]> => {
 			this._length--;
 			this.properties.nativeGraph?.graph.delete(node.hash);
 			if (!options?.skipNextHeadUpdates && node.meta.type !== EntryType.CUT) {
 				return mapMaybePromise(
-					this.privateUpdateNextHeadHashes(node.meta.next, true),
+					this.privateUpdateNextHeadHashes(
+						node.meta.next,
+						true,
+						options?.hashMutationLockOwner,
+					),
 					() => [node],
 				);
 			}
@@ -2666,7 +4118,7 @@ export class EntryIndex<T> {
 		deletedByHash: Map<string, ShallowEntry>,
 		nodes: ShallowEntry[],
 		storeHashes: string[],
-		options?: { skipNextHeadUpdates?: boolean },
+		options?: EntryIndexDeleteOptions,
 	): Promise<ShallowEntry[]> {
 		const batchSize = 64;
 		for (let i = 0; i < indexedHashes.length; i += batchSize) {
@@ -2692,7 +4144,7 @@ export class EntryIndex<T> {
 		indexedByHash: Map<string, ShallowEntry>,
 		deletedByHash: Map<string, ShallowEntry>,
 		nodes: ShallowEntry[],
-		options?: { skipNextHeadUpdates?: boolean; deleteBlocks?: boolean },
+		options?: NativeTrimConsumeOptions,
 	): Promise<ShallowEntry[]> {
 		const batchSize = 64;
 		for (let i = 0; i < indexedHashes.length; i += batchSize) {
@@ -2719,16 +4171,16 @@ export class EntryIndex<T> {
 	private finishConsumeNativeTrimmedEntries(
 		deletedByHash: Map<string, ShallowEntry>,
 		nodes: ShallowEntry[],
-		options?: { skipNextHeadUpdates?: boolean; deleteBlocks?: boolean },
+		options?: NativeTrimConsumeOptions,
 	): MaybePromise<ShallowEntry[]> {
 		const deleted = nodes
 			.map((node) => deletedByHash.get(node.hash))
 			.filter((node): node is ShallowEntry => !!node);
-		if (deleted.length === 0) {
-			return [];
-		}
 
 		const afterStoreDelete = () => {
+			if (deleted.length === 0) {
+				return [];
+			}
 			this._length -= deleted.length;
 			if (!options?.skipNextHeadUpdates) {
 				const deletedNexts: string[] = [];
@@ -2738,21 +4190,35 @@ export class EntryIndex<T> {
 					}
 				}
 				return mapMaybePromise(
-					this.privateUpdateNextHeadHashes(deletedNexts, true),
+					this.privateUpdateNextHeadHashes(
+						deletedNexts,
+						true,
+						options?.hashMutationLockOwner,
+					),
 					() => deleted,
 				);
 			}
 			return deleted;
 		};
 
+		const store = this.properties.store;
 		if (options?.deleteBlocks) {
-			const store = this.properties.store;
 			const hashes = deleted.map((node) => node.hash);
 			const deleteResult =
 				hasRmMany(store) && store.rmMany
 					? store.rmMany(hashes)
 					: Promise.all(hashes.map((hash) => store.rm(hash))).then(() => {});
 			return mapMaybePromise(deleteResult, afterStoreDelete);
+		}
+		if (options?.nativeBlocksDeleted === true && hasNativeDeleteMirror(store)) {
+			return mapMaybePromise(
+				mirrorNativeDelete(
+					store,
+					nodes.map((node) => node.hash),
+					options.nativeDeleteCleanupToken,
+				),
+				afterStoreDelete,
+			);
 		}
 		return afterStoreDelete();
 	}
@@ -2761,7 +4227,7 @@ export class EntryIndex<T> {
 		deletedByHash: Map<string, ShallowEntry>,
 		nodes: ShallowEntry[],
 		storeHashes: string[],
-		options?: { skipNextHeadUpdates?: boolean },
+		options?: EntryIndexDeleteOptions,
 	): MaybePromise<ShallowEntry[]> {
 		const deleted = nodes
 			.map((node) => deletedByHash.get(node.hash))
@@ -2789,7 +4255,11 @@ export class EntryIndex<T> {
 					}
 				}
 				return mapMaybePromise(
-					this.privateUpdateNextHeadHashes(deletedNexts, true),
+					this.privateUpdateNextHeadHashes(
+						deletedNexts,
+						true,
+						options?.hashMutationLockOwner,
+					),
 					() => deleted,
 				);
 			}
@@ -2848,6 +4318,40 @@ export class EntryIndex<T> {
 		return entries.map((entry) => this.nativeLogEntryToShallowEntry(entry));
 	}
 
+	/** Republish authoritative lower index facts without clearing concurrent rows. */
+	async restoreNativeGraphFromIndex() {
+		const graph = this.properties.nativeGraph?.graph;
+		if (!graph) {
+			return;
+		}
+		const iterator = this.properties.index.iterate(
+			{ query: [] },
+			{
+				shape: {
+					hash: true,
+					meta: { clock: true, gid: true, next: true, type: true },
+					payloadSize: true,
+					head: true,
+				},
+			},
+		);
+		try {
+			while (!iterator.done()) {
+				const results = await iterator.next(NATIVE_GRAPH_REBUILD_BATCH_SIZE);
+				for (const result of results) {
+					graph.put(toNativeLogEntry(result.value));
+				}
+			}
+		} finally {
+			await iterator.close();
+		}
+		for (const [hash, pending] of this.pendingIndexWrites) {
+			graph.put(
+				toNativeLogEntry(this.materializePendingIndexWrite(hash, pending)),
+			);
+		}
+	}
+
 	async getMemoryUsage() {
 		if (this.properties.nativeGraph) {
 			return this.properties.nativeGraph.graph.payloadSizeSum();
@@ -2867,20 +4371,43 @@ export class EntryIndex<T> {
 	private async privateUpdateNextHeadProperty(
 		from: ShallowEntry | Entry<any>,
 		isHead: boolean,
+		hashMutationLockOwner?: EntryIndexHashMutationLockOwner,
 	) {
 		if (from.meta.type === EntryType.CUT) {
 			// if the next is a cut, we can't update it, since it's not in the index
 			return;
 		}
 
-		await this.privateUpdateNextHeadHashes(from.meta.next, isHead);
+		await this.privateUpdateNextHeadHashes(
+			from.meta.next,
+			isHead,
+			hashMutationLockOwner,
+		);
 	}
 
-	private async privateUpdateNextHeadHashes(nexts: string[], isHead: boolean) {
+	private async privateUpdateNextHeadHashes(
+		nexts: string[],
+		isHead: boolean,
+		hashMutationLockOwner?: EntryIndexHashMutationLockOwner,
+	) {
 		const hashes = [...new Set(nexts.filter(Boolean))];
 		if (hashes.length === 0) {
 			return;
 		}
+		if (this.properties.nativeGraph) {
+			return this.withHashMutationLocks(
+				hashes,
+				() => this.privateUpdateNextHeadHashesLocked(hashes, isHead),
+				hashMutationLockOwner,
+			);
+		}
+		return this.privateUpdateNextHeadHashesLocked(hashes, isHead);
+	}
+
+	private async privateUpdateNextHeadHashesLocked(
+		hashes: string[],
+		isHead: boolean,
+	) {
 		const existingNexts =
 			isHead && this.properties.nativeGraph
 				? this.properties.nativeGraph.graph.hasMany(hashes)
@@ -2938,22 +4465,83 @@ export class EntryIndex<T> {
 		}
 	}
 
+	/** Preserve block identities across indexer shutdown so close followed by drop
+	 * can still erase an ephemeral indexer's blocks after its database is gone. */
+	async retainBlockHashesForDrop() {
+		await this.flushPendingWrites();
+		const iterator = this.iterate([], undefined, false);
+		try {
+			while (!iterator.done()) {
+				const results = await iterator.next(100);
+				for (const result of results) {
+					this.retainedBlockHashesForDrop.add(result.hash);
+				}
+			}
+		} finally {
+			await iterator.close();
+		}
+	}
+
 	async clear() {
 		this.clearPendingIndexFlushTimer();
-		const hashes = new Set<string>(this.pendingIndexWrites.keys());
-		const iterator = this.iterate([], undefined, false);
-		while (!iterator.done()) {
-			const results = await iterator.next(100);
-			for (const result of results) {
-				hashes.add(result.hash);
-			}
+		if (this.clearIndexAmbiguousDropRestartPending) {
+			await this.properties.index.start();
+			this.clearIndexAmbiguousDropRestartPending = false;
+			// The prior drop rejected, so its effect is unknown. Re-run the full
+			// idempotent clear/drop sequence after reopening instead of assuming it
+			// applied.
 		}
-		this.pendingIndexWrites.clear();
+		if (this.clearIndexRestartPending) {
+			await this.properties.index.start();
+			this.clearIndexRestartPending = false;
+			this.properties.nativeGraph?.graph.clear();
+			this.cache.clear();
+			this._length = 0;
+			return;
+		}
+		const hashes = new Set<string>([
+			...this.retainedBlockHashesForDrop,
+			...this.pendingIndexWrites.keys(),
+		]);
+		const iterator = this.iterate([], undefined, false);
+		try {
+			while (!iterator.done()) {
+				const results = await iterator.next(100);
+				for (const result of results) {
+					hashes.add(result.hash);
+				}
+			}
+		} finally {
+			await iterator.close();
+		}
 		for (const hash of hashes) {
 			await this.properties.store.rm(hash);
 		}
-		await this.properties.index.drop();
+		this.retainedBlockHashesForDrop.clear();
+		// Keep pending-only rows discoverable until every block was erased. A
+		// failed rm can then retry the complete erase instead of leaking bytes.
+		this.pendingIndexWrites.clear();
+		this.pendingIndexWriteGenerations.clear();
+		this.nativeCommittedAppendFactsOwners.clear();
+		try {
+			await this.properties.index.drop();
+		} catch (error) {
+			// A backend can reject after applying drop. Re-open it before surfacing
+			// the failure so a retry can deterministically finish the clear stage.
+			try {
+				await this.properties.index.start();
+			} catch (restartError) {
+				this.clearIndexAmbiguousDropRestartPending = true;
+				throw new AggregateError(
+					[error, restartError],
+					"Entry index drop and restart both failed",
+				);
+			}
+			throw error;
+		}
+		this.clearIndexRestartPending = true;
 		await this.properties.index.start();
+		this.clearIndexRestartPending = false;
 		this.properties.nativeGraph?.graph.clear();
 		this.cache.clear();
 		this._length = 0;
@@ -2968,7 +4556,10 @@ export class EntryIndex<T> {
 
 	async init() {
 		this.clearPendingIndexFlushTimer();
+		this.clearIndexRestartPending = false;
 		this.pendingIndexWrites.clear();
+		this.pendingIndexWriteGenerations.clear();
+		this.nativeCommittedAppendFactsOwners.clear();
 		this._length = await this.properties.index.getSize();
 		await this.rebuildNativeGraph();
 		this.initialied = true;

--- a/packages/log/src/index.ts
+++ b/packages/log/src/index.ts
@@ -19,4 +19,5 @@ export * from "./trim.js";
 export * from "./change.js";
 export * from "./entry-v0.js";
 export * from "./entry-create.js";
+export type { EntryIndexHashMutationLockOwner } from "./entry-index.js";
 export type { TrimToByteLengthOption, TrimToLengthOption } from "./trim.js";

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -25,7 +25,9 @@ import {
 import { type Encoding, NO_ENCODING } from "./encoding.js";
 import {
 	EntryIndex,
+	type EntryIndexHashMutationLockOwner,
 	type MaybeResolveOptions,
+	type NativeCommittedAppendFactsTransaction,
 	type NativeLogGraph,
 	type PreparedAppendIndexFacts,
 	type ResultsIterator,
@@ -46,9 +48,9 @@ import {
 	type ShallowOrFullEntry,
 } from "./entry.js";
 import { findUniques } from "./find-uniques.js";
-import { logger as baseLogger } from "./logger.js";
 import * as LogError from "./log-errors.js";
 import * as Sorting from "./log-sorting.js";
+import { logger as baseLogger } from "./logger.js";
 import type { Payload } from "./payload.js";
 import { canUseOptionalNativeModuleImports } from "./runtime.js";
 import { Trim, type TrimOptions } from "./trim.js";
@@ -78,6 +80,26 @@ type BlocksWithPutKnown = Blocks & {
 	putKnown: (cid: string, bytes: Uint8Array) => Promise<string> | string;
 };
 
+type BlocksWithDurableWriteBarrier = Blocks & {
+	waitForDurableWrites: () => Promise<void> | void;
+};
+
+type BlocksWithDurableFailureGuard = Blocks & {
+	throwIfDurableWritesFailed: () => void;
+};
+
+type BlocksWithFailedNativeRollback = Blocks & {
+	rollbackFailedNativeCommits: (
+		cids: string[],
+		restoreNativeCids?: string[],
+		ownershipToken?: unknown,
+	) => Promise<void>;
+};
+
+type BlocksWithNativeCommitOwnershipAck = Blocks & {
+	acknowledgeNativeCommitOwnership: (ownershipToken: unknown) => void;
+};
+
 const hasPutMany = (storage: Blocks): storage is BlocksWithPutMany =>
 	typeof (storage as BlocksWithPutMany).putMany === "function";
 
@@ -92,6 +114,30 @@ const hasPutKnownManyColumns = (
 ): storage is BlocksWithPutKnownManyColumns =>
 	typeof (storage as BlocksWithPutKnownManyColumns).putKnownManyColumns ===
 	"function";
+
+const hasDurableWriteBarrier = (
+	storage: Blocks,
+): storage is BlocksWithDurableWriteBarrier =>
+	typeof (storage as BlocksWithDurableWriteBarrier).waitForDurableWrites ===
+	"function";
+
+const hasDurableFailureGuard = (
+	storage: Blocks,
+): storage is BlocksWithDurableFailureGuard =>
+	typeof (storage as BlocksWithDurableFailureGuard)
+		.throwIfDurableWritesFailed === "function";
+
+const hasFailedNativeRollback = (
+	storage: Blocks,
+): storage is BlocksWithFailedNativeRollback =>
+	typeof (storage as BlocksWithFailedNativeRollback)
+		.rollbackFailedNativeCommits === "function";
+
+const hasNativeCommitOwnershipAck = (
+	storage: Blocks,
+): storage is BlocksWithNativeCommitOwnershipAck =>
+	typeof (storage as BlocksWithNativeCommitOwnershipAck)
+		.acknowledgeNativeCommitOwnership === "function";
 
 type MaybePromise<T> = T | Promise<T>;
 
@@ -108,6 +154,62 @@ type InternalProfileEvent = {
 };
 type InternalProfileSink = (event: InternalProfileEvent) => void;
 type InternalAppendHashesSink = (hashes: string[]) => void | Promise<void>;
+
+type NativeCommittedAppendFinalizer = {
+	acknowledge(onLowerMarkerDurable?: () => Promise<void>): Promise<void>;
+	retainForRecovery(): void;
+	rollback(): Promise<void>;
+	settleForTerminal(): Promise<void>;
+};
+
+type NativeCommittedAppendAdmission = {
+	settled: Promise<void>;
+	release(): void;
+};
+
+type LogLifecycleState =
+	| "closed"
+	| "opening"
+	| "active"
+	| "closing"
+	| "close-failed"
+	| "dropping"
+	| "drop-failed"
+	| "dropped";
+
+type LogCloseProgress = {
+	admissionsSettled: boolean;
+	finalizersSettled: boolean;
+	rollbacksRetried: boolean;
+	pendingWritesFlushed: boolean;
+	blockHashesRetained: boolean;
+	indexerStopped: boolean;
+};
+
+type LogDropProgress = {
+	admissionsSettled: boolean;
+	finalizersSettled: boolean;
+	entryIndexCleared: boolean;
+	indexerDropped: boolean;
+	indexerStopped: boolean;
+};
+
+const createLogCloseProgress = (): LogCloseProgress => ({
+	admissionsSettled: false,
+	finalizersSettled: false,
+	rollbacksRetried: false,
+	pendingWritesFlushed: false,
+	blockHashesRetained: false,
+	indexerStopped: false,
+});
+
+const createLogDropProgress = (): LogDropProgress => ({
+	admissionsSettled: false,
+	finalizersSettled: false,
+	entryIndexCleared: false,
+	indexerDropped: false,
+	indexerStopped: false,
+});
 
 const internalProfileNow = () => globalThis.performance?.now?.() ?? Date.now();
 const internalProfileStart = (sink: InternalProfileSink | undefined) =>
@@ -145,6 +247,7 @@ type PreparedCommitOnlyAppendResult<T> = {
 		gid: string;
 		size: number;
 	};
+	nativeCommittedAppendFinalizer?: NativeCommittedAppendFinalizer;
 };
 
 type PreparedCommitOnlyAppendBatchResult<T> = {
@@ -154,6 +257,7 @@ type PreparedCommitOnlyAppendBatchResult<T> = {
 	removedHashes?: string[];
 	appendFacts: PreparedAppendFacts[];
 	documentTrimmedHeadsProcessed?: boolean[];
+	nativeCommittedAppendFinalizer?: NativeCommittedAppendFinalizer;
 };
 
 type PreparedIndependentAppendBatch = {
@@ -198,6 +302,10 @@ type NativePreparedNoNextCommit = {
 	hashDigestBytes?: Uint8Array;
 	trimmedEntries?: PreparedNativeLogEntry[];
 	trimmedEntryHashes?: string[];
+	nativeBlocksDeleted?: boolean;
+	nativeDeleteCleanupToken?: unknown;
+	nativeCommitOwnershipToken?: unknown;
+	nativeIndexMutationLockOwner?: EntryIndexHashMutationLockOwner;
 	documentTrimmedHeadsProcessed?: boolean;
 	documentPreviousContext?: PreparedCommitOnlyAppendResult<unknown>["documentPreviousContext"];
 };
@@ -409,6 +517,8 @@ type EntryWithMetaBytes = {
 	getHashDigestBytes?: () => Uint8Array | undefined;
 };
 
+type MutationCallback = (...args: any[]) => any;
+
 @variant(0)
 export class Log<T> {
 	@field({ type: fixedArray("u8", 32) })
@@ -434,20 +544,191 @@ export class Log<T> {
 	private _canAppend?: CanAppend<T>;
 	private _onChange?: OnChange<T>;
 	private _closed = true;
+	private _dropCompleted = false;
+	private _closeCompleted = false;
+	private _terminalAdmissionClosed = true;
+	private _lifecycleState: LogLifecycleState = "closed";
+	private _lifecycleEpoch = 0;
+	private _openPromise?: Promise<void>;
+	private _closePromise?: Promise<void>;
+	private _dropPromise?: Promise<void>;
+	private _terminalLifecycleQueue: Promise<void> = Promise.resolve();
+	private _closeProgress = createLogCloseProgress();
+	private _dropProgress = createLogDropProgress();
 	private _closeController!: AbortController;
 	private _loadedOnce = false;
 	private _indexer!: Indices;
+	private _openingIndexer?: Indices;
 	private _appendDurability!: AppendDurability;
 	private _joining!: Map<string, Promise<any>>; // entry hashes that are currently joining into this log
 	private _sortFn!: Sorting.SortFn;
 	private _hasCustomCanAppend = false;
+	private _nativeCommittedAppendFinalizers?: Set<NativeCommittedAppendFinalizer>;
+	private _nativeCommittedAppendAdmissions?: Set<Promise<void>>;
+	private _mutationCallbacksInFlight = 0;
+	private _mutationCallbackWrappers = new WeakMap<
+		MutationCallback,
+		MutationCallback
+	>();
 
 	constructor(properties?: { id?: Uint8Array }) {
 		this._id = properties?.id || randomBytes(32);
-		this._closeController = new AbortController();
+		this.ensureRuntimeState();
+	}
+
+	private ensureRuntimeState(): void {
+		// Borsh creates instances with Object.create by default, so undecorated
+		// runtime fields and their class initializers are absent after a round trip.
+		// Initialize each field independently to preserve failed close/drop progress
+		// and in-flight lifecycle ownership on ordinary, already-live instances.
+		this._closed ??= true;
+		this._dropCompleted ??= false;
+		this._closeCompleted ??= false;
+		this._terminalAdmissionClosed ??= true;
+		this._lifecycleState ??= "closed";
+		this._lifecycleEpoch ??= 0;
+		this._terminalLifecycleQueue ??= Promise.resolve();
+		this._closeProgress ??= createLogCloseProgress();
+		this._dropProgress ??= createLogDropProgress();
+		this._closeController ??= new AbortController();
+		this._loadedOnce ??= false;
+		this._hasCustomCanAppend ??= false;
+		this._mutationCallbacksInFlight ??= 0;
+		this._mutationCallbackWrappers ??= new WeakMap();
+	}
+
+	private throwIfDurableWritesFailed(): void {
+		this.ensureRuntimeState();
+		if (this._terminalAdmissionClosed) {
+			throw new Error("Log is closed");
+		}
+		if (hasDurableFailureGuard(this._storage)) {
+			this._storage.throwIfDurableWritesFailed();
+		}
+		this._entryIndex?.throwIfNativeDurableTransactionMutationsFailed();
+	}
+
+	private waitForDurableWrites(): MaybePromise<void> {
+		return hasDurableWriteBarrier(this._storage)
+			? this._storage.waitForDurableWrites()
+			: undefined;
 	}
 
 	async open(store: Blocks, identity: Identity, options: LogOptions<T> = {}) {
+		this.ensureRuntimeState();
+		// Reject before touching lifecycle ownership. A rejected reopen must never
+		// change the state of the live generation, and one in-flight initializer
+		// must remain the sole owner of fields/resources.
+		if (
+			this._openPromise ||
+			!this._closed ||
+			this._lifecycleState === "active" ||
+			this._lifecycleState === "opening"
+		) {
+			throw new Error("Already open");
+		}
+		if (this._dropPromise || this._lifecycleState === "dropping") {
+			throw new Error("Log drop must complete before reopening");
+		}
+		if (this._closePromise || this._lifecycleState === "closing") {
+			throw new Error("Log close must complete before reopening");
+		}
+		if (this._lifecycleState === "drop-failed") {
+			throw new Error("Failed log drop must be retried before reopening");
+		}
+		if (this._lifecycleState === "close-failed") {
+			throw new Error("Failed log close must be retried before reopening");
+		}
+		// Admission of a new generation resets terminal progress synchronously.
+		// A close admitted in the next microtask must not inherit completed stages
+		// from the previous generation and skip teardown of this initializer.
+		this._dropCompleted = false;
+		this._closeCompleted = false;
+		this._terminalAdmissionClosed = true;
+		this._closeProgress = createLogCloseProgress();
+		this._dropProgress = createLogDropProgress();
+		const epoch = ++this._lifecycleEpoch;
+		const terminalTail = this._terminalLifecycleQueue;
+		const operation = (async () => {
+			await terminalTail;
+			if (epoch === this._lifecycleEpoch) {
+				this._lifecycleState = "opening";
+			}
+			try {
+				await this.openInternal(store, identity, options);
+			} catch (error) {
+				const openingIndexer = this._openingIndexer;
+				this._openingIndexer = undefined;
+				let cleanupError: unknown;
+				if (openingIndexer) {
+					try {
+						await openingIndexer.stop?.();
+					} catch (stopError) {
+						cleanupError = stopError;
+					}
+				}
+				this._closed = true;
+				if (cleanupError !== undefined) {
+					this._closeProgress = {
+						admissionsSettled: true,
+						finalizersSettled: true,
+						rollbacksRetried: true,
+						pendingWritesFlushed: true,
+						blockHashesRetained: true,
+						indexerStopped: false,
+					};
+					if (epoch === this._lifecycleEpoch) {
+						this._lifecycleState = "close-failed";
+					}
+					throw new AggregateError(
+						[error, cleanupError],
+						"Log open and indexer cleanup both failed",
+					);
+				}
+				// The failed initializer successfully stopped every resource it opened.
+				// Treat close as complete so a later/concurrent close never scans the
+				// stopped partial EntryIndex. Keep the stopped indexer reference only so
+				// an explicitly queued drop can restart it and erase existing rows.
+				this._closeProgress = {
+					admissionsSettled: true,
+					finalizersSettled: true,
+					rollbacksRetried: true,
+					pendingWritesFlushed: true,
+					blockHashesRetained: false,
+					indexerStopped: true,
+				};
+				this._closeCompleted = true;
+				this._loadedOnce = false;
+				if (epoch === this._lifecycleEpoch) {
+					this._lifecycleState = "closed";
+				}
+				throw error;
+			}
+			this._openingIndexer = undefined;
+			if (epoch !== this._lifecycleEpoch) {
+				// A close/drop admitted while startup was in flight owns teardown.
+				this._closed = true;
+				return;
+			}
+			this._closed = false;
+			this._terminalAdmissionClosed = false;
+			this._lifecycleState = "active";
+			this._closeController = new AbortController();
+		})();
+		const wrapped: Promise<void> = operation.finally(() => {
+			if (this._openPromise === wrapped) {
+				this._openPromise = undefined;
+			}
+		});
+		this._openPromise = wrapped;
+		return wrapped;
+	}
+
+	private async openInternal(
+		store: Blocks,
+		identity: Identity,
+		options: LogOptions<T> = {},
+	) {
 		if (store == null) {
 			throw LogError.BlockStoreNotDefinedError();
 		}
@@ -477,6 +758,7 @@ export class Log<T> {
 
 		this._storage = store;
 		this._indexer = indexer || (await createDefaultIndexer());
+		this._openingIndexer = this._indexer;
 		await this._indexer.start?.();
 
 		this._encoding = encoding || NO_ENCODING;
@@ -617,12 +899,14 @@ export class Log<T> {
 				sortFn: this._sortFn,
 				getLength: () => this.length,
 			},
-			trim,
+			this.wrapTrimCallbacks(trim),
 		);
 
 		this._canAppend = async (entry) => {
 			if (options?.canAppend) {
-				if (!(await options.canAppend(entry))) {
+				if (
+					!(await this.runWithMutationCallback(() => options.canAppend!(entry)))
+				) {
 					return false;
 				}
 			}
@@ -630,9 +914,9 @@ export class Log<T> {
 		};
 		this._hasCustomCanAppend = !!options?.canAppend;
 
-		this._onChange = options?.onChange;
-		this._closed = false;
-		this._closeController = new AbortController();
+		this._onChange = options?.onChange
+			? this.wrapMutationCallback(options.onChange)
+			: undefined;
 	}
 
 	private _idString: string | undefined;
@@ -663,7 +947,7 @@ export class Log<T> {
 	 * Returns the length of the log.
 	 */
 	get length() {
-		if (this._closed) {
+		if (this.closed) {
 			throw new Error("Closed");
 		}
 		return this._entryIndex.length;
@@ -755,7 +1039,7 @@ export class Log<T> {
 	}
 
 	get closed() {
-		return this._closed;
+		return this._closed !== false;
 	}
 
 	/**
@@ -887,68 +1171,96 @@ export class Log<T> {
 		data: T,
 		options: AppendOptions<T> = {},
 	): Promise<{ entry: Entry<T>; removed: ShallowOrFullEntry<T>[] }> {
+		this.throwIfDurableWritesFailed();
+		return this.withNativeCommittedAppendAdmission(() =>
+			this.appendAdmitted(data, options),
+		);
+	}
+
+	private async appendAdmitted(
+		data: T,
+		options: AppendOptions<T>,
+	): Promise<{ entry: Entry<T>; removed: ShallowOrFullEntry<T>[] }> {
 		const nexts = await this.getNextsForAppend(options);
 		const deferBlockStore = hasPutMany(this._storage);
-		const nativeAppendChain = this.entryIndex.properties.nativeGraph
-			? await this.createNativePlainAppendChain(
-					[data],
-					options,
-					nexts,
-					deferBlockStore,
-				)
-			: undefined;
-		let entry: Entry<T>;
-		if (nativeAppendChain) {
-			entry = nativeAppendChain.entries[0]!;
-			try {
-				await this.joinMissingNexts(entry, nexts);
-				if (deferBlockStore && !nativeAppendChain.nativeBlocksCommitted) {
-					await this.putAppendEntryBlocks([entry], nativeAppendChain.blocks);
+		type MutationResult = {
+			entry: Entry<T>;
+			pendingDeletes: (
+				| PendingDelete<T>
+				| { entry: ShallowOrFullEntry<T>; fn: undefined }
+			)[];
+			removed: ShallowOrFullEntry<T>[];
+			changes: Change<T>;
+		};
+		const finishMutation = async (entry: Entry<T>): Promise<MutationResult> => {
+			const pendingDeletes: MutationResult["pendingDeletes"] =
+				await this.processEntry(entry);
+			entry.init({ encoding: this._encoding, keychain: this._keychain });
+			const trimmed = await this.trimIfConfigured(options.trim);
+			if (trimmed) {
+				for (const trimmedEntry of trimmed) {
+					pendingDeletes.push({ entry: trimmedEntry, fn: undefined });
 				}
-				await this.putAppendEntries(
-					[entry],
-					options,
-					nexts.map((next) => next.hash),
-					nativeAppendChain,
-				);
-			} catch (error) {
-				if (nativeAppendChain.nativeGraphUpdated) {
-					this.rollbackNativeAppendGraph([entry]);
-				}
-				if (nativeAppendChain.nativeBlocksCommitted) {
-					await this.rollbackNativeAppendBlocks([entry]);
-				}
-				throw error;
 			}
-		} else {
-			entry = await this.createAppendEntry(data, options, nexts);
-			await this.joinMissingNexts(entry, nexts);
-			await this.putAppendEntry(entry, options);
-		}
-
-		const pendingDeletes: (
-			| PendingDelete<T>
-			| { entry: ShallowOrFullEntry<T>; fn: undefined }
-		)[] = await this.processEntry(entry);
-
-		entry.init({ encoding: this._encoding, keychain: this._keychain });
-
-		const trimmed = await this.trimIfConfigured(options?.trim);
-
-		if (trimmed) {
-			for (const entry of trimmed) {
-				pendingDeletes.push({ entry, fn: undefined });
-			}
-		}
-		const removed = pendingDeletes.map((x) => x.entry);
-		const changes: Change<T> = {
-			added: [{ head: true, entry }],
-			removed,
+			const removed = pendingDeletes.map((pending) => pending.entry);
+			return {
+				entry,
+				pendingDeletes,
+				removed,
+				changes: { added: [{ head: true, entry }], removed },
+			};
 		};
 
-		await (options?.onChange || this._onChange)?.(changes);
-		await Promise.all(pendingDeletes.map((x) => x.fn?.()));
-		return { entry, removed };
+		let mutation: MutationResult | undefined;
+		if (this.entryIndex.properties.nativeGraph) {
+			const nativeAppendChain = await this.createNativePlainAppendChain(
+				[data],
+				options,
+				nexts,
+				deferBlockStore,
+			);
+			if (nativeAppendChain) {
+				const entry = nativeAppendChain.entries[0]!;
+				try {
+					await this.joinMissingNexts(entry, nexts);
+					if (deferBlockStore && !nativeAppendChain.nativeBlocksCommitted) {
+						await this.putAppendEntryBlocks([entry], nativeAppendChain.blocks);
+					}
+					await this.putAppendEntries(
+						[entry],
+						options,
+						nexts.map((next) => next.hash),
+						nativeAppendChain,
+					);
+				} catch (error) {
+					if (nativeAppendChain.nativeGraphUpdated) {
+						this.rollbackNativeAppendGraph([entry]);
+					}
+					if (nativeAppendChain.nativeBlocksCommitted) {
+						await this.rollbackNativeAppendBlocks([entry]);
+					}
+					throw error;
+				}
+				mutation = await finishMutation(entry);
+			}
+		}
+
+		if (!mutation) {
+			const entry = await this.createAppendEntry(data, options, nexts);
+			await this.joinMissingNexts(entry, nexts);
+			await this.putAppendEntry(entry, options);
+			mutation = await finishMutation(entry);
+		}
+
+		if (options.onChange) {
+			await this.runWithMutationCallback(() =>
+				options.onChange!(mutation.changes),
+			);
+		} else {
+			await this._onChange?.(mutation.changes);
+		}
+		await Promise.all(mutation.pendingDeletes.map((pending) => pending.fn?.()));
+		return { entry: mutation.entry, removed: mutation.removed };
 	}
 
 	// Internal trusted local append path for callers that already handled validation
@@ -956,6 +1268,28 @@ export class Log<T> {
 	private async appendLocallyPrepared(
 		data: T,
 		options: AppendOptions<T> = {},
+		properties?: {
+			skipMissingNextJoin?: boolean;
+			resolveTrimmedEntries?: boolean;
+			payloadData?: Uint8Array;
+			includeMaterializationBytes?: boolean;
+			includeAppendFactsBytes?: boolean;
+		},
+	): Promise<{
+		entry: Entry<T>;
+		removed: ShallowOrFullEntry<T>[];
+		change: Change<T>;
+		appendFacts: PreparedAppendFacts;
+	}> {
+		this.throwIfDurableWritesFailed();
+		return this.withNativeCommittedAppendAdmission(() =>
+			this.appendLocallyPreparedAdmitted(data, options, properties),
+		);
+	}
+
+	private async appendLocallyPreparedAdmitted(
+		data: T,
+		options: AppendOptions<T>,
 		properties?: {
 			skipMissingNextJoin?: boolean;
 			resolveTrimmedEntries?: boolean;
@@ -1061,6 +1395,7 @@ export class Log<T> {
 			includeAppendFactsBytes?: boolean;
 		},
 	): MaybePromise<PreparedCommitOnlyAppendResult<T> | undefined> {
+		this.throwIfDurableWritesFailed();
 		if (
 			options.canAppend ||
 			options.onChange ||
@@ -1095,11 +1430,13 @@ export class Log<T> {
 			resolveTrimmedEntries?: boolean;
 			skipMissingNextJoin?: boolean;
 			retainMaterializationBytes?: boolean;
+			deferNativeTransactionAcknowledgement?: boolean;
 		},
 		prepare: (
 			input: NativeNoNextCommitInput,
 		) => MaybePromise<NativePreparedNoNextCommit | undefined>,
 	): MaybePromise<PreparedCommitOnlyAppendResult<T> | undefined> {
+		this.throwIfDurableWritesFailed();
 		const directResult = this.appendLocallyPreparedNativeKnownNoNextCommitOnly(
 			data,
 			options,
@@ -1125,11 +1462,13 @@ export class Log<T> {
 			resolveTrimmedEntries?: boolean;
 			skipMissingNextJoin?: boolean;
 			retainMaterializationBytes?: boolean;
+			deferNativeTransactionAcknowledgement?: boolean;
 		},
 		prepare: (
 			input: NativeNoNextCommitInput,
 		) => MaybePromise<NativePreparedNoNextCommit | undefined>,
 	): MaybePromise<PreparedCommitOnlyAppendResult<T> | undefined> {
+		this.throwIfDurableWritesFailed();
 		if (options.meta?.next == null || options.meta.next.length !== 0) {
 			return undefined;
 		}
@@ -1175,6 +1514,7 @@ export class Log<T> {
 			payloadData?: Uint8Array;
 			resolveTrimmedEntries?: boolean;
 			retainMaterializationBytes?: boolean;
+			deferNativeTransactionAcknowledgement?: boolean;
 		},
 		prepare: (
 			input: NativeNoNextCommitInput,
@@ -1210,20 +1550,24 @@ export class Log<T> {
 		const resolvedGid = EntryV0.createGid() as string;
 		const timestamp = this._hlc.now();
 		const entryType = options.meta?.type ?? EntryType.APPEND;
-		const preparedValue = prepare({
-			clockId: identity.publicKey.bytes,
-			privateKey: identity.privateKey.privateKey,
-			publicKey: identity.publicKey.publicKey,
-			wallTime: timestamp.wallTime,
-			logical: timestamp.logical,
-			gid: resolvedGid,
-			type: entryType,
-			metaData: options.meta?.data,
-			payloadData,
-			resolveTrimmedEntries: properties.resolveTrimmedEntries,
-			trimLengthTo: nativeTrimLengthTo,
-		});
-		return mapMaybePromise(preparedValue, (prepared) => {
+		const nativePreparation = this.prepareNativeCommittedAppend(() =>
+			prepare({
+				clockId: identity.publicKey.bytes,
+				privateKey: identity.privateKey.privateKey,
+				publicKey: identity.publicKey.publicKey,
+				wallTime: timestamp.wallTime,
+				logical: timestamp.logical,
+				gid: resolvedGid,
+				type: entryType,
+				metaData: options.meta?.data,
+				payloadData,
+				resolveTrimmedEntries: properties.resolveTrimmedEntries,
+				trimLengthTo: nativeTrimLengthTo,
+			}),
+		);
+		const consumePrepared = (
+			prepared: NativePreparedNoNextCommit | undefined,
+		): MaybePromise<PreparedCommitOnlyAppendResult<T> | undefined> => {
 			if (!prepared) {
 				return undefined;
 			}
@@ -1246,10 +1590,7 @@ export class Log<T> {
 				const bytes =
 					prepared.getBytes?.(hash) ??
 					(this._storage.get(hash) as Uint8Array | undefined);
-				if (
-					bytes &&
-					typeof (bytes as { then?: unknown }).then !== "function"
-				) {
+				if (bytes && typeof (bytes as { then?: unknown }).then !== "function") {
 					retainedMaterializationBytes = bytes;
 				}
 			};
@@ -1313,6 +1654,7 @@ export class Log<T> {
 				materializedEntry = entry;
 				return entry;
 			};
+			let indexTransaction: NativeCommittedAppendFactsTransaction | undefined;
 			const finish = (): PreparedCommitOnlyAppendResult<T> => {
 				retainMaterializationBytes();
 				return {
@@ -1351,6 +1693,9 @@ export class Log<T> {
 								{
 									skipNextHeadUpdates: true,
 									deleteBlocks: false,
+									nativeBlocksDeleted: prepared.nativeBlocksDeleted === true,
+									nativeDeleteCleanupToken: prepared.nativeDeleteCleanupToken,
+									nativeCommittedAppendFactsTransaction: indexTransaction,
 								},
 							);
 						if (consumedNoReturn !== undefined) {
@@ -1377,6 +1722,9 @@ export class Log<T> {
 							{
 								skipNextHeadUpdates: true,
 								deleteBlocks: false,
+								nativeBlocksDeleted: prepared.nativeBlocksDeleted === true,
+								nativeDeleteCleanupToken: prepared.nativeDeleteCleanupToken,
+								nativeCommittedAppendFactsTransaction: indexTransaction,
 							},
 						);
 					return mapMaybePromise(consumedResult, (removed) => ({
@@ -1406,6 +1754,9 @@ export class Log<T> {
 					{
 						skipNextHeadUpdates: true,
 						deleteBlocks: false,
+						nativeBlocksDeleted: prepared.nativeBlocksDeleted === true,
+						nativeDeleteCleanupToken: prepared.nativeDeleteCleanupToken,
+						nativeCommittedAppendFactsTransaction: indexTransaction,
 					},
 				);
 				return mapMaybePromise(consumedResult, (removed) => ({
@@ -1435,26 +1786,85 @@ export class Log<T> {
 					finishTrim,
 				);
 			};
-			const rollback = (error: unknown): never | Promise<never> => {
-				this.rollbackNativeAppendGraphHashes([hash]);
-				return this.rollbackNativeAppendBlocksHashes([hash]).then(() => {
+			const trimmedHashes =
+				prepared.trimmedEntryHashes ??
+				prepared.trimmedEntries?.map((entry) => entry.hash) ??
+				[];
+			let finalizer: NativeCommittedAppendFinalizer | undefined;
+			const rollback = async (error: unknown): Promise<never> => {
+				if (finalizer) {
+					try {
+						await finalizer.rollback();
+					} catch (rollbackError) {
+						throw new AggregateError(
+							[error, rollbackError],
+							"Native append and its compensation both failed",
+						);
+					}
 					throw error;
-				});
+				}
+				this.rollbackNativeAppendGraphHashes([hash]);
+				return this.rollbackNativeAppendFactsAndBlocksHashesPreservingError(
+					indexTransaction,
+					[hash],
+					error,
+					trimmedHashes,
+					prepared.nativeCommitOwnershipToken,
+				);
 			};
 			try {
-				const putResult = this.entryIndex.putNativeCommittedAppendFacts({
-					hash,
-					unique: true,
-					externalNextHashes: effectiveNextHashes,
-					getShallowEntry,
-					isHead: true,
-				});
+				indexTransaction =
+					prepared.nativeCommitOwnershipToken !== undefined ||
+					properties.deferNativeTransactionAcknowledgement === true
+						? this.entryIndex.beginNativeCommittedAppendFactsTransaction(
+								[hash, ...effectiveNextHashes, ...trimmedHashes],
+								prepared.nativeIndexMutationLockOwner,
+							)
+						: undefined;
+				finalizer = indexTransaction
+					? this.createNativeCommittedAppendFinalizer({
+							transaction: indexTransaction,
+							hashes: [hash],
+							restoreNativeCids: trimmedHashes,
+							ownershipToken: prepared.nativeCommitOwnershipToken,
+						})
+					: undefined;
+				const putResult = this.entryIndex.putNativeCommittedAppendFacts(
+					{
+						hash,
+						unique: true,
+						externalNextHashes: effectiveNextHashes,
+						getShallowEntry,
+						isHead: true,
+					},
+					indexTransaction,
+				);
 				const result = mapMaybePromise(putResult, finishBlocks);
-				return isPromiseLike(result) ? result.catch(rollback) : result;
+				const acknowledged = mapMaybePromise(result, async (value) => {
+					if (
+						finalizer &&
+						properties.deferNativeTransactionAcknowledgement === true
+					) {
+						value.nativeCommittedAppendFinalizer = finalizer;
+						return value;
+					}
+					if (finalizer) {
+						await finalizer.acknowledge();
+					} else if (hasNativeCommitOwnershipAck(this._storage)) {
+						this._storage.acknowledgeNativeCommitOwnership(
+							prepared.nativeCommitOwnershipToken,
+						);
+					}
+					return value;
+				});
+				return isPromiseLike(acknowledged)
+					? acknowledged.catch(rollback)
+					: acknowledged;
 			} catch (error) {
 				return rollback(error);
 			}
-		});
+		};
+		return this.finishNativeCommittedAppend(nativePreparation, consumePrepared);
 	}
 
 	private appendLocallyPreparedNativeCommitOnly(
@@ -1466,12 +1876,14 @@ export class Log<T> {
 			skipMissingNextJoin?: boolean;
 			knownNoNext?: boolean;
 			retainMaterializationBytes?: boolean;
+			deferNativeTransactionAcknowledgement?: boolean;
 		},
 		prepare: (
 			input: NativeCommitInput,
 		) => MaybePromise<NativePreparedNoNextCommit | undefined>,
 		knownNoNext = false,
 	): MaybePromise<PreparedCommitOnlyAppendResult<T> | undefined> {
+		this.throwIfDurableWritesFailed();
 		const resolvedTrim = options.trim ?? this._trim.options;
 		const supportsNativeTrim =
 			!resolvedTrim ||
@@ -1540,21 +1952,25 @@ export class Log<T> {
 					timestamp: this._hlc.now(),
 				});
 				const entryType = appendOptions.meta?.type ?? EntryType.APPEND;
-				const preparedValue = prepare({
-					clockId: identity.publicKey.bytes,
-					privateKey: identity.privateKey.privateKey,
-					publicKey: identity.publicKey.publicKey,
-					wallTime: clock.timestamp.wallTime,
-					logical: clock.timestamp.logical,
-					gid: resolvedGid,
-					next: nextHashes,
-					type: entryType,
-					metaData: appendOptions.meta?.data,
-					payloadData,
-					resolveTrimmedEntries: properties.resolveTrimmedEntries,
-					trimLengthTo: nativeTrimLengthTo,
-				});
-				return mapMaybePromise(preparedValue, (prepared) => {
+				const nativePreparation = this.prepareNativeCommittedAppend(() =>
+					prepare({
+						clockId: identity.publicKey.bytes,
+						privateKey: identity.privateKey.privateKey,
+						publicKey: identity.publicKey.publicKey,
+						wallTime: clock.timestamp.wallTime,
+						logical: clock.timestamp.logical,
+						gid: resolvedGid,
+						next: nextHashes,
+						type: entryType,
+						metaData: appendOptions.meta?.data,
+						payloadData,
+						resolveTrimmedEntries: properties.resolveTrimmedEntries,
+						trimLengthTo: nativeTrimLengthTo,
+					}),
+				);
+				const consumePrepared = (
+					prepared: NativePreparedNoNextCommit | undefined,
+				): MaybePromise<PreparedCommitOnlyAppendResult<T> | undefined> => {
 					if (!prepared) {
 						return undefined;
 					}
@@ -1631,10 +2047,16 @@ export class Log<T> {
 						entry.size = prepared.byteLength;
 						entry.createdLocally = true;
 						Entry.prepareShallowEntry(entry, shallowEntry);
-						entry.init({ encoding: this._encoding, keychain: this._keychain });
+						entry.init({
+							encoding: this._encoding,
+							keychain: this._keychain,
+						});
 						materializedEntry = entry;
 						return entry;
 					};
+					let indexTransaction:
+						| NativeCommittedAppendFactsTransaction
+						| undefined;
 					const finish = (): PreparedCommitOnlyAppendResult<T> => {
 						retainMaterializationBytes();
 						return {
@@ -1685,6 +2107,11 @@ export class Log<T> {
 										{
 											skipNextHeadUpdates: true,
 											deleteBlocks: false,
+											nativeBlocksDeleted:
+												prepared.nativeBlocksDeleted === true,
+											nativeDeleteCleanupToken:
+												prepared.nativeDeleteCleanupToken,
+											nativeCommittedAppendFactsTransaction: indexTransaction,
 										},
 									);
 								if (consumedNoReturn !== undefined) {
@@ -1709,6 +2136,9 @@ export class Log<T> {
 									{
 										skipNextHeadUpdates: true,
 										deleteBlocks: false,
+										nativeBlocksDeleted: prepared.nativeBlocksDeleted === true,
+										nativeDeleteCleanupToken: prepared.nativeDeleteCleanupToken,
+										nativeCommittedAppendFactsTransaction: indexTransaction,
 									},
 								);
 							return mapMaybePromise(consumedResult, (removed) => ({
@@ -1735,6 +2165,9 @@ export class Log<T> {
 							this.entryIndex.consumeNativeTrimmedEntriesMaybe(trimmedEntries, {
 								skipNextHeadUpdates: true,
 								deleteBlocks: false,
+								nativeBlocksDeleted: prepared.nativeBlocksDeleted === true,
+								nativeDeleteCleanupToken: prepared.nativeDeleteCleanupToken,
+								nativeCommittedAppendFactsTransaction: indexTransaction,
 							});
 						return mapMaybePromise(consumedResult, (removed) => ({
 							get entry() {
@@ -1749,31 +2182,117 @@ export class Log<T> {
 							documentPreviousContext: prepared.documentPreviousContext,
 						}));
 					};
-					const rollback = (error: unknown): never | Promise<never> => {
-						this.rollbackNativeAppendGraphHashes([hash]);
-						return this.rollbackNativeAppendBlocksHashes([hash]).then(() => {
+					const trimmedHashes =
+						prepared.trimmedEntryHashes ??
+						prepared.trimmedEntries?.map((entry) => entry.hash) ??
+						[];
+					let finalizer: NativeCommittedAppendFinalizer | undefined;
+					const rollback = async (error: unknown): Promise<never> => {
+						if (finalizer) {
+							try {
+								await finalizer.rollback();
+							} catch (rollbackError) {
+								throw new AggregateError(
+									[error, rollbackError],
+									"Native append and its compensation both failed",
+								);
+							}
 							throw error;
-						});
+						}
+						this.rollbackNativeAppendGraphHashes([hash]);
+						return this.rollbackNativeAppendFactsAndBlocksHashesPreservingError(
+							indexTransaction,
+							[hash],
+							error,
+							trimmedHashes,
+							prepared.nativeCommitOwnershipToken,
+						);
 					};
 					try {
-						const putResult = this.entryIndex.putNativeCommittedAppendFacts({
-							hash,
-							unique: true,
-							externalNextHashes: nextHashes,
-							shallowEntry,
-							isHead: true,
-						});
+						indexTransaction =
+							prepared.nativeCommitOwnershipToken !== undefined ||
+							properties.deferNativeTransactionAcknowledgement === true
+								? this.entryIndex.beginNativeCommittedAppendFactsTransaction(
+										[hash, ...nextHashes, ...trimmedHashes],
+										prepared.nativeIndexMutationLockOwner,
+									)
+								: undefined;
+						finalizer = indexTransaction
+							? this.createNativeCommittedAppendFinalizer({
+									transaction: indexTransaction,
+									hashes: [hash],
+									restoreNativeCids: trimmedHashes,
+									ownershipToken: prepared.nativeCommitOwnershipToken,
+								})
+							: undefined;
+						const putResult = this.entryIndex.putNativeCommittedAppendFacts(
+							{
+								hash,
+								unique: true,
+								externalNextHashes: nextHashes,
+								shallowEntry,
+								isHead: true,
+							},
+							indexTransaction,
+						);
 						const result = mapMaybePromise(putResult, finishBlocks);
-						return isPromiseLike(result) ? result.catch(rollback) : result;
+						const acknowledged = mapMaybePromise(result, async (value) => {
+							if (
+								finalizer &&
+								properties.deferNativeTransactionAcknowledgement === true
+							) {
+								value.nativeCommittedAppendFinalizer = finalizer;
+								return value;
+							}
+							if (finalizer) {
+								await finalizer.acknowledge();
+							} else if (hasNativeCommitOwnershipAck(this._storage)) {
+								this._storage.acknowledgeNativeCommitOwnership(
+									prepared.nativeCommitOwnershipToken,
+								);
+							}
+							return value;
+						});
+						return isPromiseLike(acknowledged)
+							? acknowledged.catch(rollback)
+							: acknowledged;
 					} catch (error) {
 						return rollback(error);
 					}
-				});
+				};
+				return this.finishNativeCommittedAppend(
+					nativePreparation,
+					consumePrepared,
+				);
 			});
 		});
 	}
 
 	private appendLocallyPreparedCommitOnlyWithNexts(
+		data: T,
+		appendOptions: AppendOptions<T>,
+		nexts: Sorting.SortableEntry[],
+		properties?: {
+			skipMissingNextJoin?: boolean;
+			resolveTrimmedEntries?: boolean;
+			payloadData?: Uint8Array;
+			includeMaterializationBytes?: boolean;
+			includeAppendFactsBytes?: boolean;
+		},
+		nativeTrimLengthTo?: number,
+	): MaybePromise<PreparedCommitOnlyAppendResult<T> | undefined> {
+		return this.withNativeCommittedAppendAdmission(() =>
+			this.appendLocallyPreparedCommitOnlyWithNextsAdmitted(
+				data,
+				appendOptions,
+				nexts,
+				properties,
+				nativeTrimLengthTo,
+			),
+		);
+	}
+
+	private appendLocallyPreparedCommitOnlyWithNextsAdmitted(
 		data: T,
 		appendOptions: AppendOptions<T>,
 		nexts: Sorting.SortableEntry[],
@@ -1846,6 +2365,7 @@ export class Log<T> {
 							{
 								skipNextHeadUpdates: true,
 								deleteBlocks: false,
+								nativeBlocksDeleted: true,
 							},
 						);
 					if (consumedNoReturn !== undefined) {
@@ -1868,6 +2388,8 @@ export class Log<T> {
 							skipNextHeadUpdates: true,
 							deleteBlocks:
 								nativeAppendChain.trimmedNativeBlocksDeleted !== true,
+							nativeBlocksDeleted:
+								nativeAppendChain.trimmedNativeBlocksDeleted === true,
 						},
 					);
 				return mapMaybePromise(consumedResult, (removed) => ({
@@ -1890,6 +2412,8 @@ export class Log<T> {
 					{
 						skipNextHeadUpdates: true,
 						deleteBlocks: nativeAppendChain.trimmedNativeBlocksDeleted !== true,
+						nativeBlocksDeleted:
+							nativeAppendChain.trimmedNativeBlocksDeleted === true,
 					},
 				);
 				return mapMaybePromise(consumedResult, (removed) => ({
@@ -1937,6 +2461,15 @@ export class Log<T> {
 					finishFacts,
 				);
 			}
+			if (
+				nativeAppendChain.nativeBlocksCommitted &&
+				hasDurableWriteBarrier(this._storage)
+			) {
+				return mapMaybePromise(
+					this._storage.waitForDurableWrites(),
+					finishFacts,
+				);
+			}
 			return finishFacts();
 		};
 		const rollback = (error: unknown): never | Promise<never> => {
@@ -1944,10 +2477,11 @@ export class Log<T> {
 				this.rollbackNativeAppendGraphHashes([appendFacts.hash]);
 			}
 			if (nativeAppendChain.nativeBlocksCommitted) {
-				return this.rollbackNativeAppendBlocksHashes([appendFacts.hash]).then(
-					() => {
-						throw error;
-					},
+				return this.rollbackNativeAppendBlocksHashesPreservingError(
+					[appendFacts.hash],
+					error,
+					nativeAppendChain.trimmedNativeEntryHashes ??
+						nativeAppendChain.trimmedNativeEntries?.map((entry) => entry.hash),
 				);
 			}
 			throw error;
@@ -1971,6 +2505,33 @@ export class Log<T> {
 	private async appendLocallyPreparedManyIndependent(
 		data: T[],
 		options: AppendOptions<T> = {},
+		properties?: {
+			resolveTrimmedEntries?: boolean;
+			payloadDatas?: Uint8Array[];
+			nexts?: Sorting.SortableEntry[][];
+		},
+	): Promise<
+		| {
+				entries: Entry<T>[];
+				removed: ShallowOrFullEntry<T>[];
+				change: Change<T>;
+				appendFacts: PreparedAppendFacts[];
+		  }
+		| undefined
+	> {
+		this.throwIfDurableWritesFailed();
+		return this.withNativeCommittedAppendAdmission(() =>
+			this.appendLocallyPreparedManyIndependentAdmitted(
+				data,
+				options,
+				properties,
+			),
+		);
+	}
+
+	private async appendLocallyPreparedManyIndependentAdmitted(
+		data: T[],
+		options: AppendOptions<T>,
 		properties?: {
 			resolveTrimmedEntries?: boolean;
 			payloadDatas?: Uint8Array[];
@@ -2069,11 +2630,15 @@ export class Log<T> {
 			resolveTrimmedEntries?: boolean;
 			allowPreparedNexts?: boolean;
 			retainMaterializationBytes?: boolean;
+			deferNativeTransactionAcknowledgement?: boolean;
 		},
 		prepare: (
 			inputs: NativeNoNextCommitInput[],
-		) => MaybePromise<Array<NativePreparedNoNextCommit | undefined> | undefined>,
+		) => MaybePromise<
+			Array<NativePreparedNoNextCommit | undefined> | undefined
+		>,
 	): MaybePromise<PreparedCommitOnlyAppendBatchResult<T> | undefined> {
+		this.throwIfDurableWritesFailed();
 		if (data.length === 0) {
 			return {
 				entries: [],
@@ -2137,8 +2702,12 @@ export class Log<T> {
 				} satisfies NativeNoNextCommitInput,
 			};
 		});
-		const preparedValue = prepare(rows.map((row) => row.input));
-		return mapMaybePromise(preparedValue, (preparedRows) => {
+		const nativePreparation = this.prepareNativeCommittedAppend(() =>
+			prepare(rows.map((row) => row.input)),
+		);
+		const consumePrepared = (
+			preparedRows: Array<NativePreparedNoNextCommit | undefined> | undefined,
+		): MaybePromise<PreparedCommitOnlyAppendBatchResult<T> | undefined> => {
 			if (!preparedRows || preparedRows.length !== rows.length) {
 				return undefined;
 			}
@@ -2149,6 +2718,12 @@ export class Log<T> {
 				EntryIndex<T>["putNativeCommittedAppendFactsBatch"]
 			>[0] = [];
 			const trimmedEntryHashes: string[] = [];
+			let trimmedNativeBlocksDeleted = true;
+			let nativeDeleteCleanupToken: unknown;
+			let nativeCommitOwnershipToken: unknown;
+			let nativeIndexMutationLockOwner:
+				| EntryIndexHashMutationLockOwner
+				| undefined;
 			const documentTrimmedHeadsProcessed: boolean[] = [];
 			for (let index = 0; index < rows.length; index++) {
 				const row = rows[index]!;
@@ -2257,22 +2832,40 @@ export class Log<T> {
 					getShallowEntry,
 					isHead: true,
 				});
+				nativeCommitOwnershipToken ??= prepared.nativeCommitOwnershipToken;
+				nativeIndexMutationLockOwner ??= prepared.nativeIndexMutationLockOwner;
 				if (prepared.trimmedEntryHashes?.length) {
 					trimmedEntryHashes.push(...prepared.trimmedEntryHashes);
+					trimmedNativeBlocksDeleted &&= prepared.nativeBlocksDeleted === true;
+					nativeDeleteCleanupToken ??= prepared.nativeDeleteCleanupToken;
 				}
 				documentTrimmedHeadsProcessed.push(
 					prepared.documentTrimmedHeadsProcessed === true,
 				);
 			}
-			const rollback = (error: unknown): never | Promise<never> => {
-				this.rollbackNativeAppendGraphHashes(
-					appendFacts.map((facts) => facts.hash),
-				);
-				return this.rollbackNativeAppendBlocksHashes(
-					appendFacts.map((facts) => facts.hash),
-				).then(() => {
+			const appendHashes = appendFacts.map((facts) => facts.hash);
+			let indexTransaction: NativeCommittedAppendFactsTransaction | undefined;
+			let finalizer: NativeCommittedAppendFinalizer | undefined;
+			const rollback = async (error: unknown): Promise<never> => {
+				if (finalizer) {
+					try {
+						await finalizer.rollback();
+					} catch (rollbackError) {
+						throw new AggregateError(
+							[error, rollbackError],
+							"Native append batch and its compensation both failed",
+						);
+					}
 					throw error;
-				});
+				}
+				this.rollbackNativeAppendGraphHashes(appendHashes);
+				return this.rollbackNativeAppendFactsAndBlocksHashesPreservingError(
+					indexTransaction,
+					appendHashes,
+					error,
+					trimmedEntryHashes,
+					nativeCommitOwnershipToken,
+				);
 			};
 			const finish = (): PreparedCommitOnlyAppendBatchResult<T> => {
 				for (const retainMaterializationBytes of retainMaterializationBytesFns) {
@@ -2315,6 +2908,9 @@ export class Log<T> {
 						{
 							skipNextHeadUpdates: true,
 							deleteBlocks: false,
+							nativeBlocksDeleted: trimmedNativeBlocksDeleted,
+							nativeDeleteCleanupToken,
+							nativeCommittedAppendFactsTransaction: indexTransaction,
 						},
 					);
 				if (consumedNoReturn === undefined) {
@@ -2323,14 +2919,60 @@ export class Log<T> {
 				return mapMaybePromise(consumedNoReturn, finish);
 			};
 			try {
-				const putResult =
-					this.entryIndex.putNativeCommittedAppendFactsBatch(indexRows);
+				indexTransaction =
+					nativeCommitOwnershipToken !== undefined ||
+					properties.deferNativeTransactionAcknowledgement === true
+						? this.entryIndex.beginNativeCommittedAppendFactsTransaction(
+								[
+									...appendHashes,
+									...indexRows.flatMap((row) => row.externalNextHashes),
+									...trimmedEntryHashes,
+								],
+								nativeIndexMutationLockOwner,
+							)
+						: undefined;
+				finalizer = indexTransaction
+					? this.createNativeCommittedAppendFinalizer({
+							transaction: indexTransaction,
+							hashes: appendHashes,
+							restoreNativeCids: trimmedEntryHashes,
+							ownershipToken: nativeCommitOwnershipToken,
+						})
+					: undefined;
+				const putResult = this.entryIndex.putNativeCommittedAppendFactsBatch(
+					indexRows,
+					indexTransaction,
+				);
 				const result = mapMaybePromise(putResult, finishTrim);
-				return isPromiseLike(result) ? result.catch(rollback) : result;
+				const acknowledged = mapMaybePromise(result, async (value) => {
+					if (!value) {
+						await finalizer?.rollback();
+						return value;
+					}
+					if (
+						finalizer &&
+						properties.deferNativeTransactionAcknowledgement === true
+					) {
+						value.nativeCommittedAppendFinalizer = finalizer;
+						return value;
+					}
+					if (finalizer) {
+						await finalizer.acknowledge();
+					} else if (hasNativeCommitOwnershipAck(this._storage)) {
+						this._storage.acknowledgeNativeCommitOwnership(
+							nativeCommitOwnershipToken,
+						);
+					}
+					return value;
+				});
+				return isPromiseLike(acknowledged)
+					? acknowledged.catch(rollback)
+					: acknowledged;
 			} catch (error) {
 				return rollback(error);
 			}
-		});
+		};
+		return this.finishNativeCommittedAppend(nativePreparation, consumePrepared);
 	}
 
 	private createPreparedAppendFacts(
@@ -2377,6 +3019,16 @@ export class Log<T> {
 		data: T[],
 		options: AppendOptions<T> = {},
 	): Promise<{ entries: Entry<T>[]; removed: ShallowOrFullEntry<T>[] }> {
+		this.throwIfDurableWritesFailed();
+		return this.withNativeCommittedAppendAdmission(() =>
+			this.appendManyAdmitted(data, options),
+		);
+	}
+
+	private async appendManyAdmitted(
+		data: T[],
+		options: AppendOptions<T>,
+	): Promise<{ entries: Entry<T>[]; removed: ShallowOrFullEntry<T>[] }> {
 		if (data.length === 0) {
 			return { entries: [], removed: [] };
 		}
@@ -2384,25 +3036,70 @@ export class Log<T> {
 			throw new Error("appendMany does not support CUT entries");
 		}
 
-		let nexts = await this.getNextsForAppend(options);
-		const initialNexts = nexts;
-		const entries: Entry<T>[] = [];
-		const pendingDeletes: (
-			| PendingDelete<T>
-			| { entry: ShallowOrFullEntry<T>; fn: undefined }
-		)[] = [];
+		const initialNexts = await this.getNextsForAppend(options);
 		const deferBlockStore = hasPutMany(this._storage);
+		type MutationResult = {
+			entries: Entry<T>[];
+			removed: ShallowOrFullEntry<T>[];
+			changes: Change<T>;
+		};
+		const finishMutation = async (
+			entries: Entry<T>[],
+		): Promise<MutationResult> => {
+			for (const entry of entries) {
+				entry.init({ encoding: this._encoding, keychain: this._keychain });
+			}
+			const removed =
+				(await this.trimIfConfigured(options.trim))?.map((entry) => entry) ??
+				[];
+			return {
+				entries,
+				removed,
+				changes: {
+					added: entries.map((entry, index) => ({
+						head: index === entries.length - 1,
+						entry,
+					})),
+					removed,
+				},
+			};
+		};
+
+		let mutation: MutationResult | undefined;
 		const nativeAppendChain = await this.createNativePlainAppendChain(
 			data,
 			options,
-			nexts,
+			initialNexts,
 			deferBlockStore,
 		);
-
 		if (nativeAppendChain) {
-			entries.push(...nativeAppendChain.entries);
-			nexts = [entries[entries.length - 1]!];
-		} else {
+			const entries = nativeAppendChain.entries;
+			try {
+				await this.joinMissingNexts(entries[0]!, initialNexts);
+				if (deferBlockStore && !nativeAppendChain.nativeBlocksCommitted) {
+					await this.putAppendEntryBlocks(entries, nativeAppendChain.blocks);
+				}
+				await this.putAppendEntries(
+					entries,
+					options,
+					initialNexts.map((entry) => entry.hash),
+					nativeAppendChain,
+				);
+			} catch (error) {
+				if (nativeAppendChain.nativeGraphUpdated) {
+					this.rollbackNativeAppendGraph(entries);
+				}
+				if (nativeAppendChain.nativeBlocksCommitted) {
+					await this.rollbackNativeAppendBlocks(entries);
+				}
+				throw error;
+			}
+			mutation = await finishMutation(entries);
+		}
+
+		if (!mutation) {
+			const entries: Entry<T>[] = [];
+			let nexts = initialNexts;
 			for (const item of data) {
 				const entry = await this.createAppendEntry(item, options, nexts, {
 					deferStore: deferBlockStore,
@@ -2410,52 +3107,26 @@ export class Log<T> {
 				entries.push(entry);
 				nexts = [entry];
 			}
-		}
-
-		try {
 			await this.joinMissingNexts(entries[0]!, initialNexts);
-			if (deferBlockStore && !nativeAppendChain?.nativeBlocksCommitted) {
-				await this.putAppendEntryBlocks(entries, nativeAppendChain?.blocks);
+			if (deferBlockStore) {
+				await this.putAppendEntryBlocks(entries);
 			}
 			await this.putAppendEntries(
 				entries,
 				options,
 				initialNexts.map((entry) => entry.hash),
-				nativeAppendChain,
 			);
-		} catch (error) {
-			if (nativeAppendChain?.nativeGraphUpdated) {
-				this.rollbackNativeAppendGraph(entries);
-			}
-			if (nativeAppendChain?.nativeBlocksCommitted) {
-				await this.rollbackNativeAppendBlocks(entries);
-			}
-			throw error;
+			mutation = await finishMutation(entries);
 		}
 
-		for (const entry of entries) {
-			entry.init({ encoding: this._encoding, keychain: this._keychain });
+		if (options.onChange) {
+			await this.runWithMutationCallback(() =>
+				options.onChange!(mutation.changes),
+			);
+		} else {
+			await this._onChange?.(mutation.changes);
 		}
-
-		const trimmed = await this.trimIfConfigured(options?.trim);
-		if (trimmed) {
-			for (const entry of trimmed) {
-				pendingDeletes.push({ entry, fn: undefined });
-			}
-		}
-
-		const removed = pendingDeletes.map((x) => x.entry);
-		const changes: Change<T> = {
-			added: entries.map((entry, index) => ({
-				head: index === entries.length - 1,
-				entry,
-			})),
-			removed,
-		};
-
-		await (options?.onChange || this._onChange)?.(changes);
-		await Promise.all(pendingDeletes.map((x) => x.fn?.()));
-		return { entries, removed };
+		return { entries: mutation.entries, removed: mutation.removed };
 	}
 
 	private createNativePlainAppendChain(
@@ -2732,13 +3403,338 @@ export class Log<T> {
 		);
 	}
 
-	private async rollbackNativeAppendBlocksHashes(hashes: string[]) {
+	private async rollbackNativeAppendBlocksHashes(
+		hashes: string[],
+		restoreNativeCids: string[] = [],
+		ownershipToken?: unknown,
+	) {
+		if (hasFailedNativeRollback(this._storage)) {
+			await this._storage.rollbackFailedNativeCommits(
+				hashes,
+				restoreNativeCids,
+				ownershipToken,
+			);
+			return;
+		}
 		const storage = this._storage as BlocksWithPutMany;
 		if (typeof storage.rmMany === "function") {
 			await storage.rmMany(hashes);
 			return;
 		}
 		await Promise.all(hashes.map((hash) => this._storage.rm(hash)));
+	}
+
+	/** Reserve an in-flight native mutation before its prepare callback can commit
+	 * blocks. Terminal teardown closes admission synchronously and waits for every
+	 * earlier reservation to either finish or compensate. */
+	private beginNativeCommittedAppendAdmission(): NativeCommittedAppendAdmission {
+		if (this._terminalAdmissionClosed || this._lifecycleState !== "active") {
+			throw new Error(
+				"Native append transaction cannot start while the log is closing or dropped",
+			);
+		}
+		let resolveSettled!: () => void;
+		const settled = new Promise<void>((resolve) => {
+			resolveSettled = resolve;
+		});
+		(this._nativeCommittedAppendAdmissions ??= new Set()).add(settled);
+		let released = false;
+		return {
+			settled,
+			release: () => {
+				if (released) {
+					return;
+				}
+				released = true;
+				this._nativeCommittedAppendAdmissions?.delete(settled);
+				resolveSettled();
+			},
+		};
+	}
+
+	private prepareNativeCommittedAppend<TValue>(
+		prepare: () => MaybePromise<TValue>,
+	): {
+		admission: NativeCommittedAppendAdmission;
+		prepared: MaybePromise<TValue>;
+	} {
+		const admission = this.beginNativeCommittedAppendAdmission();
+		let prepared: MaybePromise<TValue>;
+		try {
+			prepared = prepare();
+		} catch (error) {
+			admission.release();
+			throw error;
+		}
+		return { admission, prepared };
+	}
+
+	private finishNativeCommittedAppend<TValue, TResult>(
+		preparation: {
+			admission: NativeCommittedAppendAdmission;
+			prepared: MaybePromise<TValue>;
+		},
+		operation: (value: TValue) => MaybePromise<TResult>,
+	): MaybePromise<TResult> {
+		let result: MaybePromise<TResult>;
+		try {
+			result = mapMaybePromise(preparation.prepared, operation);
+		} catch (error) {
+			preparation.admission.release();
+			throw error;
+		}
+		if (isPromiseLike(result)) {
+			return result.finally(preparation.admission.release);
+		}
+		preparation.admission.release();
+		return result;
+	}
+
+	private withNativeCommittedAppendAdmission<TResult>(
+		operation: () => Promise<TResult>,
+	): Promise<TResult>;
+	private withNativeCommittedAppendAdmission<TResult>(
+		operation: () => MaybePromise<TResult>,
+	): MaybePromise<TResult>;
+	private withNativeCommittedAppendAdmission<TResult>(
+		operation: () => MaybePromise<TResult>,
+	): MaybePromise<TResult> {
+		const preparation = this.prepareNativeCommittedAppend(operation);
+		return this.finishNativeCommittedAppend(preparation, (result) => result);
+	}
+
+	private runWithMutationCallback<TResult>(
+		callback: () => MaybePromise<TResult>,
+	): MaybePromise<TResult> {
+		this._mutationCallbacksInFlight++;
+		let result: MaybePromise<TResult>;
+		try {
+			result = callback();
+		} catch (error) {
+			this._mutationCallbacksInFlight--;
+			throw error;
+		}
+		if (isPromiseLike(result)) {
+			return result.finally(() => {
+				this._mutationCallbacksInFlight--;
+			});
+		}
+		this._mutationCallbacksInFlight--;
+		return result;
+	}
+
+	private wrapMutationCallback<TCallback extends (...args: any[]) => any>(
+		callback: TCallback,
+	): TCallback {
+		const existing = this._mutationCallbackWrappers.get(callback);
+		if (existing) {
+			return existing as TCallback;
+		}
+		const wrapped = ((...args: Parameters<TCallback>) =>
+			this.runWithMutationCallback(() => callback(...args))) as TCallback;
+		this._mutationCallbackWrappers.set(callback, wrapped);
+		return wrapped;
+	}
+
+	private wrapTrimCallbacks(option?: TrimOptions): TrimOptions | undefined {
+		if (!option?.filter?.canTrim) {
+			return option;
+		}
+		return {
+			...option,
+			filter: {
+				...option.filter,
+				canTrim: this.wrapMutationCallback(option.filter.canTrim),
+			},
+		};
+	}
+
+	private async settleNativeCommittedAppendAdmissions(): Promise<void> {
+		while ((this._nativeCommittedAppendAdmissions?.size ?? 0) > 0) {
+			await Promise.all([...this._nativeCommittedAppendAdmissions!]);
+		}
+	}
+
+	private createNativeCommittedAppendFinalizer(properties: {
+		transaction: NativeCommittedAppendFactsTransaction;
+		hashes: string[];
+		restoreNativeCids?: string[];
+		ownershipToken?: unknown;
+	}): NativeCommittedAppendFinalizer {
+		if (this._terminalAdmissionClosed || this._lifecycleState !== "active") {
+			throw new Error(
+				"Native append transaction cannot start while the log is closing or dropped",
+			);
+		}
+		let state:
+			| "open"
+			| "acknowledging"
+			| "acknowledged"
+			| "rolling-back"
+			| "rollback-required"
+			| "rolled-back" = "open";
+		let terminalSettlementRequested = false;
+		let acknowledgePromise: Promise<void> | undefined;
+		let rollbackPromise: Promise<void> | undefined;
+		const finalizer: NativeCommittedAppendFinalizer = {
+			acknowledge: async (onLowerMarkerDurable) => {
+				if (state === "acknowledged") {
+					return;
+				}
+				if (
+					state === "rolled-back" ||
+					state === "rolling-back" ||
+					state === "rollback-required"
+				) {
+					throw new Error("Native append transaction was already rolled back");
+				}
+				if (acknowledgePromise) {
+					return acknowledgePromise;
+				}
+				state = "acknowledging";
+				acknowledgePromise = (async () => {
+					await this.entryIndex.flushNativeCommittedExternalNextFacts(
+						properties.transaction,
+					);
+					await this.entryIndex.flushNativeCommittedAppendFacts(
+						properties.transaction,
+					);
+					await onLowerMarkerDurable?.();
+					await this.entryIndex.flushNativeCommittedTrimFacts(
+						properties.transaction,
+					);
+					if (hasNativeCommitOwnershipAck(this._storage)) {
+						this._storage.acknowledgeNativeCommitOwnership(
+							properties.ownershipToken,
+						);
+					}
+					this.entryIndex.acknowledgeNativeCommittedAppendFacts(
+						properties.transaction,
+					);
+					state = "acknowledged";
+					this._nativeCommittedAppendFinalizers?.delete(finalizer);
+				})();
+				try {
+					await acknowledgePromise;
+				} catch (error) {
+					state = terminalSettlementRequested ? "rollback-required" : "open";
+					acknowledgePromise = undefined;
+					throw error;
+				}
+			},
+			retainForRecovery: () => {
+				if (state === "acknowledged") {
+					return;
+				}
+				if (state !== "open" || terminalSettlementRequested) {
+					throw new Error(
+						"Native append transaction cannot be retained for recovery",
+					);
+				}
+				const failures: unknown[] = [];
+				try {
+					if (hasNativeCommitOwnershipAck(this._storage)) {
+						this._storage.acknowledgeNativeCommitOwnership(
+							properties.ownershipToken,
+						);
+					}
+				} catch (error) {
+					failures.push(error);
+				}
+				try {
+					// The durable strict intent is now the recovery authority. Finalize
+					// in-memory ownership and locks so close cannot roll back a lower
+					// marker that may still be durably true; reopen finishes any trim debt.
+					this.entryIndex.acknowledgeNativeCommittedAppendFacts(
+						properties.transaction,
+					);
+				} catch (error) {
+					failures.push(error);
+				}
+				state = "acknowledged";
+				this._nativeCommittedAppendFinalizers?.delete(finalizer);
+				if (failures.length > 0) {
+					throw new AggregateError(
+						failures,
+						"Failed to retain a native append transaction for recovery",
+					);
+				}
+			},
+			rollback: async () => {
+				if (state === "rolled-back") {
+					return;
+				}
+				if (state === "acknowledged" || state === "acknowledging") {
+					throw new Error("Native append transaction was already acknowledged");
+				}
+				if (rollbackPromise) {
+					return rollbackPromise;
+				}
+				// Compensation direction is irrevocable once any rollback begins. A
+				// partial failure may retry rollback, but can never switch to publish.
+				terminalSettlementRequested = true;
+				state = "rolling-back";
+				rollbackPromise = (async () => {
+					const failures: unknown[] = [];
+					try {
+						this.rollbackNativeAppendGraphHashes(properties.hashes);
+					} catch (error) {
+						failures.push(error);
+					}
+					try {
+						await this.entryIndex.rollbackNativeCommittedAppendFacts(
+							properties.transaction,
+						);
+					} catch (error) {
+						failures.push(error);
+					}
+					try {
+						await this.rollbackNativeAppendBlocksHashes(
+							properties.hashes,
+							properties.restoreNativeCids,
+							properties.ownershipToken,
+						);
+					} catch (error) {
+						failures.push(error);
+					}
+					try {
+						await this.entryIndex.restoreNativeGraphFromIndex();
+					} catch (error) {
+						failures.push(error);
+					}
+					if (failures.length > 0) {
+						throw new AggregateError(
+							failures,
+							"Failed to compensate a native append transaction",
+						);
+					}
+					state = "rolled-back";
+					this._nativeCommittedAppendFinalizers?.delete(finalizer);
+				})();
+				try {
+					await rollbackPromise;
+				} catch (error) {
+					state = "rollback-required";
+					rollbackPromise = undefined;
+					throw error;
+				}
+			},
+			settleForTerminal: () => {
+				terminalSettlementRequested = true;
+				if (state === "acknowledged" || state === "rolled-back") {
+					return Promise.resolve();
+				}
+				if (state === "acknowledging" && acknowledgePromise) {
+					return acknowledgePromise;
+				}
+				if (state === "rolling-back" && rollbackPromise) {
+					return rollbackPromise;
+				}
+				return finalizer.rollback();
+			},
+		};
+		(this._nativeCommittedAppendFinalizers ??= new Set()).add(finalizer);
+		return finalizer;
 	}
 
 	private validateExplicitNexts(options: AppendOptions<T>) {
@@ -2752,6 +3748,60 @@ export class Log<T> {
 				);
 			}
 		}
+	}
+
+	private async rollbackNativeAppendBlocksHashesPreservingError(
+		hashes: string[],
+		error: unknown,
+		restoreNativeCids: string[] = [],
+		ownershipToken?: unknown,
+	): Promise<never> {
+		try {
+			await this.rollbackNativeAppendBlocksHashes(
+				hashes,
+				restoreNativeCids,
+				ownershipToken,
+			);
+		} catch (rollbackError) {
+			throw new AggregateError(
+				[error, rollbackError],
+				"Native append and block compensation both failed",
+			);
+		}
+		throw error;
+	}
+
+	private async rollbackNativeAppendFactsAndBlocksHashesPreservingError(
+		transaction: NativeCommittedAppendFactsTransaction | undefined,
+		hashes: string[],
+		error: unknown,
+		restoreNativeCids: string[] = [],
+		ownershipToken?: unknown,
+	): Promise<never> {
+		const rollbackFailures: unknown[] = [];
+		if (transaction) {
+			try {
+				await this.entryIndex.rollbackNativeCommittedAppendFacts(transaction);
+			} catch (rollbackError) {
+				rollbackFailures.push(rollbackError);
+			}
+		}
+		try {
+			await this.rollbackNativeAppendBlocksHashes(
+				hashes,
+				restoreNativeCids,
+				ownershipToken,
+			);
+		} catch (rollbackError) {
+			rollbackFailures.push(rollbackError);
+		}
+		if (rollbackFailures.length > 0) {
+			throw new AggregateError(
+				[error, ...rollbackFailures],
+				"Native append and compensation both failed",
+			);
+		}
+		throw error;
 	}
 
 	private getNextsForAppend(
@@ -2783,7 +3833,9 @@ export class Log<T> {
 		const entry = await EntryV0.create<T>({
 			store: this._storage,
 			identity: options.identity || this._identity,
-			signers: options.signers,
+			signers: options.signers?.map((signer) =>
+				this.wrapMutationCallback(signer),
+			),
 			data,
 			meta: {
 				clock,
@@ -2801,11 +3853,14 @@ export class Log<T> {
 						},
 					}
 				: undefined,
-			canAppend:
-				canAppendAlreadyValidated(options)
-					? undefined
-					: options.canAppend ||
-						(this._hasCustomCanAppend ? this._canAppend : undefined),
+			canAppend: canAppendAlreadyValidated(options)
+				? undefined
+				: options.canAppend
+					? (entry) =>
+							this.runWithMutationCallback(() => options.canAppend!(entry))
+					: this._hasCustomCanAppend
+						? this._canAppend
+						: undefined,
 			deferStore: storeOptions?.deferStore,
 		});
 
@@ -2872,6 +3927,12 @@ export class Log<T> {
 					}
 				: undefined;
 		if (
+			prepared?.nativeBlocksCommitted === true &&
+			hasDurableWriteBarrier(this._storage)
+		) {
+			await this._storage.waitForDurableWrites();
+		}
+		if (
 			entries.length === 1 &&
 			prepared?.nativeGraphUpdated === true &&
 			!this.entryIndex.properties.onGidRemoved
@@ -2920,6 +3981,7 @@ export class Log<T> {
 			if (cid !== block.cid) {
 				throw new Error("Unexpected block cid");
 			}
+			await this.waitForDurableWrites();
 			return;
 		}
 		if (hasPutKnownManyColumns(this._storage)) {
@@ -2940,6 +4002,7 @@ export class Log<T> {
 					throw new Error("Unexpected block batch cid");
 				}
 			}
+			await this.waitForDurableWrites();
 			return;
 		}
 		if (hasPutKnownMany(this._storage)) {
@@ -2955,6 +4018,7 @@ export class Log<T> {
 					throw new Error("Unexpected block batch cid");
 				}
 			}
+			await this.waitForDurableWrites();
 			return;
 		}
 		const cids = await (this._storage as BlocksWithPutMany).putMany!(blocks);
@@ -2966,6 +4030,7 @@ export class Log<T> {
 				throw new Error("Unexpected block batch cid");
 			}
 		}
+		await this.waitForDurableWrites();
 	}
 
 	private async putKnownEntryBytesBatch(
@@ -2981,6 +4046,7 @@ export class Log<T> {
 			if (cid !== block.cid) {
 				throw new Error("Unexpected block cid");
 			}
+			await this.waitForDurableWrites();
 			return;
 		}
 		if (hasPutKnownManyColumns(this._storage)) {
@@ -3001,6 +4067,7 @@ export class Log<T> {
 					throw new Error("Unexpected block batch cid");
 				}
 			}
+			await this.waitForDurableWrites();
 			return;
 		}
 		if (hasPutKnownMany(this._storage)) {
@@ -3016,6 +4083,7 @@ export class Log<T> {
 					throw new Error("Unexpected block batch cid");
 				}
 			}
+			await this.waitForDurableWrites();
 			return;
 		}
 		const preparedBlocks = blocks.map((block) =>
@@ -3032,6 +4100,7 @@ export class Log<T> {
 				throw new Error("Unexpected block batch cid");
 			}
 		}
+		await this.waitForDurableWrites();
 	}
 
 	private putPreparedAppendBlocks(
@@ -3048,11 +4117,10 @@ export class Log<T> {
 					throw new Error("Unexpected block cid");
 				}
 			};
-			if (isPromiseLike(cidResult)) {
-				return cidResult.then(checkCid);
-			}
-			checkCid(cidResult);
-			return;
+			return mapMaybePromise(cidResult, (cid) => {
+				checkCid(cid);
+				return this.waitForDurableWrites();
+			});
 		}
 		const checkCids = (cids: string[]) => {
 			if (cids.length !== preparedBlocks.length) {
@@ -3073,29 +4141,27 @@ export class Log<T> {
 				bytes[i] = block.block.bytes;
 			}
 			const cidsResult = this._storage.putKnownManyColumns(cids, bytes);
-			if (isPromiseLike(cidsResult)) {
-				return cidsResult.then(checkCids);
-			}
-			checkCids(cidsResult);
-			return;
+			return mapMaybePromise(cidsResult, (result) => {
+				checkCids(result);
+				return this.waitForDurableWrites();
+			});
 		}
 		if (hasPutKnownMany(this._storage)) {
 			const cidsResult = this._storage.putKnownMany(
 				preparedBlocks.map((block) => [block.cid, block.block.bytes] as const),
 			);
-			if (isPromiseLike(cidsResult)) {
-				return cidsResult.then(checkCids);
-			}
-			checkCids(cidsResult);
-			return;
+			return mapMaybePromise(cidsResult, (result) => {
+				checkCids(result);
+				return this.waitForDurableWrites();
+			});
 		}
 		const cidsResult = (this._storage as BlocksWithPutMany).putMany!(
 			preparedBlocks,
 		);
-		if (isPromiseLike(cidsResult)) {
-			return cidsResult.then(checkCids);
-		}
-		checkCids(cidsResult);
+		return mapMaybePromise(cidsResult, (result) => {
+			checkCids(result);
+			return this.waitForDurableWrites();
+		});
 	}
 
 	async remove(
@@ -3104,6 +4170,7 @@ export class Log<T> {
 			| { hash: string; meta: { next: string[] } }[],
 		options?: { recursively?: boolean },
 	): Promise<Change<T>> {
+		this.throwIfDurableWritesFailed();
 		/* await this.load({ reload: false }); */
 		const entries = Array.isArray(entry) ? entry : [entry];
 
@@ -3147,6 +4214,7 @@ export class Log<T> {
 		option: TrimOptions | undefined = this._trim.options,
 		properties?: { resolveDeletedEntries?: boolean },
 	) {
+		this.throwIfDurableWritesFailed();
 		return this._trim.trim(option, properties);
 	}
 
@@ -3154,7 +4222,9 @@ export class Log<T> {
 		option?: TrimOptions,
 		properties?: { resolveDeletedEntries?: boolean },
 	): MaybePromise<ShallowOrFullEntry<T>[] | undefined> {
-		const resolved = option ?? this._trim.options;
+		const resolved = option
+			? this.wrapTrimCallbacks(option)
+			: this._trim.options;
 		return resolved ? this.trim(resolved, properties) : undefined;
 	}
 
@@ -3193,6 +4263,7 @@ export class Log<T> {
 			| ResultsIterator<Entry<any>>,
 		options?: TrustedJoinOptions<T>,
 	): Promise<void> {
+		this.throwIfDurableWritesFailed();
 		let entries: Entry<T>[];
 		const references: Map<string, Entry<T>> = new Map();
 
@@ -3382,6 +4453,16 @@ export class Log<T> {
 		entries: PreparedAppendJoinFacts[],
 		options?: TrustedPreparedAppendFactsBatchJoinOptions,
 	): Promise<boolean> {
+		this.throwIfDurableWritesFailed();
+		return this.withNativeCommittedAppendAdmission(() =>
+			this.joinPreparedAppendFactsBatchAdmitted(entries, options),
+		);
+	}
+
+	private async joinPreparedAppendFactsBatchAdmitted(
+		entries: PreparedAppendJoinFacts[],
+		options?: TrustedPreparedAppendFactsBatchJoinOptions,
+	): Promise<boolean> {
 		if (
 			entries.length === 0 ||
 			!canAppendAlreadyValidated(options) ||
@@ -3517,14 +4598,16 @@ export class Log<T> {
 			if (resolvedOptions.__peerbitNativePreparedJoinCommit) {
 				const nativeCommitStartedAt = internalProfileStart(profile);
 				nativePreparedCommitted =
-					(await resolvedOptions.__peerbitNativePreparedJoinCommit({
-						entries,
-						hashes: entryHashes,
-						headFlags,
-						headFlagsBytes,
-						trustedMissing,
-						validatePlan: nativeCommitValidatesPlan,
-					})) === true;
+					(await this.runWithMutationCallback(() =>
+						resolvedOptions.__peerbitNativePreparedJoinCommit!({
+							entries,
+							hashes: entryHashes,
+							headFlags,
+							headFlagsBytes,
+							trustedMissing,
+							validatePlan: nativeCommitValidatesPlan,
+						}),
+					)) === true;
 				emitInternalProfileDuration(profile, nativeCommitStartedAt, {
 					name: "log.joinPreparedFacts.nativePreparedCommit",
 					component: "log",
@@ -3545,6 +4628,11 @@ export class Log<T> {
 						bytes: entry.bytes,
 					})),
 				);
+			} else {
+				// A native prepared receive may have used the synchronous columnar block
+				// callback. Hold index/head/change publication behind the one batch-level
+				// durability barrier just like the generic block-store fallback.
+				await this.waitForDurableWrites();
 			}
 			emitInternalProfileDuration(profile, blocksStartedAt, {
 				name: "log.joinPreparedFacts.blocks",
@@ -3608,12 +4696,14 @@ export class Log<T> {
 
 			if (resolvedOptions.__peerbitOnPreparedJoinCommitted) {
 				const committedStartedAt = internalProfileStart(profile);
-				await resolvedOptions.__peerbitOnPreparedJoinCommitted({
-					entries,
-					hashes: entryHashes,
-					headFlags,
-					nativePreparedCommitted,
-				});
+				await this.runWithMutationCallback(() =>
+					resolvedOptions.__peerbitOnPreparedJoinCommitted!({
+						entries,
+						hashes: entryHashes,
+						headFlags,
+						nativePreparedCommitted,
+					}),
+				);
 				emitInternalProfileDuration(profile, committedStartedAt, {
 					name: "log.joinPreparedFacts.committed",
 					component: "log",
@@ -3625,8 +4715,10 @@ export class Log<T> {
 
 			const changeStartedAt = internalProfileStart(profile);
 			if (resolvedOptions.__peerbitOnAppendHashes) {
-				await resolvedOptions.__peerbitOnAppendHashes(
-					entries.map((entry) => entry.hash),
+				await this.runWithMutationCallback(() =>
+					resolvedOptions.__peerbitOnAppendHashes!(
+						entries.map((entry) => entry.hash),
+					),
 				);
 			} else {
 				const change: Change<T> = {
@@ -3811,7 +4903,9 @@ export class Log<T> {
 					})),
 					removed: [],
 				};
-				await options.onChange?.(change);
+				if (options.onChange) {
+					await this.runWithMutationCallback(() => options.onChange!(change));
+				}
 				await this._onChange?.(change);
 			}
 			emitInternalProfileDuration(profile, changeStartedAt, {
@@ -4061,10 +5155,14 @@ export class Log<T> {
 
 		const removed = pendingDeletes.map((x) => x.entry);
 
-		await options.onChange?.({
-			added: [{ head: options.isHead, entry }],
-			removed,
-		});
+		if (options.onChange) {
+			await this.runWithMutationCallback(() =>
+				options.onChange!({
+					added: [{ head: options.isHead, entry }],
+					removed,
+				}),
+			);
+		}
 		await this._onChange?.({
 			added: [{ head: options.isHead, entry }],
 			removed,
@@ -4163,6 +5261,7 @@ export class Log<T> {
 	async prepareDelete(
 		hash: string,
 	): Promise<PendingDelete<T> | { entry: undefined }> {
+		this.throwIfDurableWritesFailed();
 		let entry = await this._entryIndex.getShallow(hash);
 		if (!entry) {
 			return { entry: undefined };
@@ -4170,6 +5269,7 @@ export class Log<T> {
 		return {
 			entry: entry.value,
 			fn: async () => {
+				this.throwIfDurableWritesFailed();
 				await this._trim.deleteFromCache(hash);
 				const removedEntry = (await this._entryIndex.delete(
 					hash,
@@ -4181,6 +5281,7 @@ export class Log<T> {
 	}
 
 	async delete(hash: string): Promise<ShallowEntry | undefined> {
+		this.throwIfDurableWritesFailed();
 		const deleteFn = await this.prepareDelete(hash);
 		return deleteFn.entry && deleteFn.fn();
 	}
@@ -4220,23 +5321,204 @@ export class Log<T> {
 		).join("\n");
 	}
 
-	async close() {
-		// Don't return early here if closed = true, because "load" might create processes that needs to be closed
-		this._closed = true; // closed = true before doing below, else we might try to open the headsIndex cache because it is closed as we assume log is still open
-		this._closeController?.abort();
-		await this._entryIndex?.flushPendingWrites();
-		await this._indexer?.stop?.();
-		this._indexer = undefined as any;
-		this._loadedOnce = false;
+	private enqueueTerminalLifecycle<T>(operation: () => Promise<T>): Promise<T> {
+		const next = this._terminalLifecycleQueue.then(operation);
+		this._terminalLifecycleQueue = next.then(
+			() => undefined,
+			() => undefined,
+		);
+		return next;
 	}
 
-	async drop() {
-		// Don't return early here if closed = true, because "load" might create processes that needs to be closed
-		this._closed = true; // closed = true before doing below, else we might try to open the headsIndex cache because it is closed as we assume log is still open
-		this._closeController.abort();
-		await this._entryIndex?.clear();
-		await this._indexer?.drop();
-		await this._indexer?.stop?.();
+	private async settleNativeCommittedAppendFinalizers(): Promise<void> {
+		while ((this._nativeCommittedAppendFinalizers?.size ?? 0) > 0) {
+			const finalizers = [...this._nativeCommittedAppendFinalizers!];
+			for (const finalizer of finalizers) {
+				await finalizer.settleForTerminal();
+			}
+		}
+	}
+
+	close(): Promise<void> {
+		this.ensureRuntimeState();
+		// Mutation callbacks run inside terminal admission. Waiting for teardown
+		// from one would create a self-deadlock, so reject before changing any
+		// lifecycle state and let the caller retry after the mutation settles.
+		if (this._mutationCallbacksInFlight > 0) {
+			return Promise.reject(
+				new Error(
+					"Cannot close a log while a mutation callback is running; retry after the callback completes",
+				),
+			);
+		}
+		if (this._dropCompleted) {
+			return Promise.resolve();
+		}
+		if (this._dropPromise) {
+			return this._dropPromise;
+		}
+		if (this._lifecycleState === "drop-failed") {
+			// Drop is the stronger terminal operation. Never let close downgrade a
+			// failed erase into a clean closed state that can be reopened.
+			return this.drop();
+		}
+		if (this._closePromise) {
+			return this._closePromise;
+		}
+		if (this._closeCompleted) {
+			return Promise.resolve();
+		}
+
+		const opening = this._openPromise;
+		this._lifecycleEpoch++;
+		this._closed = true;
+		this._terminalAdmissionClosed = true;
+		this._lifecycleState = "closing";
+		this._closeController?.abort();
+		const operation = this.enqueueTerminalLifecycle(async () => {
+			// If startup was admitted first, it owns initialization and this close
+			// owns every teardown stage that follows. Its failure does not skip cleanup.
+			await opening?.catch(() => undefined);
+			this._closed = true;
+			this._lifecycleState = "closing";
+			if (!this._closeProgress.admissionsSettled) {
+				await this.settleNativeCommittedAppendAdmissions();
+				this._closeProgress.admissionsSettled = true;
+			}
+			if (!this._closeProgress.finalizersSettled) {
+				await this.settleNativeCommittedAppendFinalizers();
+				this._closeProgress.finalizersSettled = true;
+			}
+			if (!this._closeProgress.rollbacksRetried) {
+				await this._entryIndex?.retryFailedNativeCommittedAppendFactsRollbacks();
+				this._closeProgress.rollbacksRetried = true;
+			}
+			if (!this._closeProgress.pendingWritesFlushed) {
+				await this._entryIndex?.flushPendingWrites();
+				this._closeProgress.pendingWritesFlushed = true;
+			}
+			if (!this._closeProgress.blockHashesRetained && this._entryIndex) {
+				const explicitlyPreservesData =
+					await this._indexer?.preservesDataOnStop?.();
+				const preservesDataOnStop =
+					explicitlyPreservesData ??
+					(await this._indexer?.persisted?.()) ??
+					false;
+				// A destructive/unknown stop must snapshot before stopping regardless of
+				// when drop is requested. Data-preserving backends avoid this O(n) work
+				// on ordinary close and can be restarted for a later drop.
+				if (this._dropPromise || !preservesDataOnStop) {
+					await this._entryIndex.retainBlockHashesForDrop();
+					this._closeProgress.blockHashesRetained = true;
+				}
+			}
+			if (!this._closeProgress.indexerStopped) {
+				await this._indexer?.stop?.();
+				this._closeProgress.indexerStopped = true;
+			}
+			this._loadedOnce = false;
+			this._closeCompleted = true;
+			this._lifecycleState = "closed";
+		});
+		const wrapped: Promise<void> = operation
+			.catch((error) => {
+				this._lifecycleState = "close-failed";
+				throw error;
+			})
+			.finally(() => {
+				if (this._closePromise === wrapped) {
+					this._closePromise = undefined;
+				}
+			});
+		this._closePromise = wrapped;
+		return wrapped;
+	}
+
+	drop(): Promise<void> {
+		this.ensureRuntimeState();
+		// See close(): terminal reentrancy from a mutation callback must fail before
+		// this stronger terminal operation mutates lifecycle ownership.
+		if (this._mutationCallbacksInFlight > 0) {
+			return Promise.reject(
+				new Error(
+					"Cannot drop a log while a mutation callback is running; retry after the callback completes",
+				),
+			);
+		}
+		if (this._dropCompleted) {
+			return Promise.resolve();
+		}
+		if (this._dropPromise) {
+			return this._dropPromise;
+		}
+
+		const opening = this._openPromise;
+		this._lifecycleEpoch++;
+		this._closed = true;
+		this._terminalAdmissionClosed = true;
+		this._lifecycleState = "dropping";
+		this._closeController?.abort();
+		const operation = this.enqueueTerminalLifecycle(async () => {
+			await opening?.catch(() => undefined);
+			this._closed = true;
+			this._lifecycleState = "dropping";
+			if (!this._dropProgress.admissionsSettled) {
+				await this.settleNativeCommittedAppendAdmissions();
+				this._dropProgress.admissionsSettled = true;
+			}
+			if (!this._dropProgress.entryIndexCleared) {
+				// start() is required even when a prior stop rejected: backends may
+				// reject after applying stop, and start is intentionally idempotent.
+				await this._indexer?.start?.();
+				if (
+					!this._closeProgress.blockHashesRetained &&
+					(this._closeCompleted || this._closeProgress.pendingWritesFlushed) &&
+					this._entryIndex
+				) {
+					const reopenedSize =
+						await this._entryIndex.properties.index.getSize();
+					if (reopenedSize !== this._entryIndex.length) {
+						throw new Error(
+							"Cannot drop after close discarded an ephemeral entry index; request drop before close completes",
+						);
+					}
+				}
+			}
+			if (!this._dropProgress.finalizersSettled) {
+				await this.settleNativeCommittedAppendFinalizers();
+				await this._entryIndex?.retryFailedNativeCommittedAppendFactsRollbacks();
+				this._dropProgress.finalizersSettled = true;
+			}
+			if (!this._dropProgress.entryIndexCleared) {
+				await this._entryIndex?.clear();
+				this._dropProgress.entryIndexCleared = true;
+			}
+			if (!this._dropProgress.indexerDropped) {
+				await this._indexer?.drop();
+				this._dropProgress.indexerDropped = true;
+			}
+			if (!this._dropProgress.indexerStopped) {
+				await this._indexer?.stop?.();
+				this._dropProgress.indexerStopped = true;
+			}
+			this._indexer = undefined as any;
+			this._loadedOnce = false;
+			this._dropCompleted = true;
+			this._closeCompleted = true;
+			this._lifecycleState = "dropped";
+		});
+		const wrapped: Promise<void> = operation
+			.catch((error) => {
+				this._lifecycleState = "drop-failed";
+				throw error;
+			})
+			.finally(() => {
+				if (this._dropPromise === wrapped) {
+					this._dropPromise = undefined;
+				}
+			});
+		this._dropPromise = wrapped;
+		return wrapped;
 	}
 
 	async recover() {

--- a/packages/log/test/append.spec.ts
+++ b/packages/log/test/append.spec.ts
@@ -145,6 +145,150 @@ describe("append", function () {
 		putSpy.restore();
 	});
 
+	it("rolls back only its native index generation and preserves same-CID pending facts", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			indexer: new HashmapIndices(),
+			appendDurability: "strict",
+		});
+		const { entry } = await log.append(new Uint8Array([1]), {
+			meta: { next: [] },
+		});
+		const index = log.entryIndex.properties.index;
+		const concurrentShallow = entry.toShallow(false);
+		const rejectedShallow = entry.toShallow(true);
+
+		await log.entryIndex.putNativeCommittedAppendFacts({
+			hash: entry.hash,
+			unique: false,
+			externalNextHashes: [],
+			shallowEntry: concurrentShallow,
+			isHead: false,
+		});
+		const transaction =
+			log.entryIndex.beginNativeCommittedAppendFactsTransaction();
+		log.entryIndex.putNativeCommittedAppendFacts(
+			{
+				hash: entry.hash,
+				unique: true,
+				externalNextHashes: [],
+				shallowEntry: rejectedShallow,
+				isHead: true,
+			},
+			transaction,
+		);
+		// A later same-CID publication gets its own generation and must survive
+		// compensation of the rejected transaction.
+		await log.entryIndex.putNativeCommittedAppendFacts({
+			hash: entry.hash,
+			unique: false,
+			externalNextHashes: [],
+			shallowEntry: concurrentShallow,
+			isHead: false,
+		});
+
+		const failure = new Error("native index generation failed");
+		const putStub = sinon.stub(index, "put").rejects(failure);
+		try {
+			const rejected = await log.entryIndex
+				.flushNativeCommittedAppendFacts(transaction)
+				.then(
+					() => undefined,
+					(error: unknown) => error,
+				);
+			expect(rejected).equal(failure);
+			await log.entryIndex.rollbackNativeCommittedAppendFacts(transaction);
+			expect(log.length).equal(1);
+		} finally {
+			putStub.restore();
+		}
+
+		const laterPutSpy = sinon.spy(index, "put");
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 400));
+			expect(laterPutSpy.callCount).equal(1);
+			expect((await log.entryIndex.getShallow(entry.hash))?.value.head).equal(
+				false,
+			);
+			await log.entryIndex.flushPendingWrites();
+			expect(laterPutSpy.callCount).equal(1);
+			expect(log.length).equal(1);
+		} finally {
+			laterPutSpy.restore();
+			await log.close();
+		}
+	});
+
+	it("restores an earlier same-CID pending fact after an applied native index write rejects", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			indexer: new HashmapIndices(),
+			appendDurability: "strict",
+		});
+		const { entry } = await log.append(new Uint8Array([1]), {
+			meta: { next: [] },
+		});
+		const index = log.entryIndex.properties.index;
+		const previousShallow = entry.toShallow(false);
+		const rejectedShallow = entry.toShallow(true);
+
+		await log.entryIndex.putNativeCommittedAppendFacts({
+			hash: entry.hash,
+			unique: false,
+			externalNextHashes: [],
+			shallowEntry: previousShallow,
+			isHead: false,
+		});
+		const transaction =
+			log.entryIndex.beginNativeCommittedAppendFactsTransaction();
+		log.entryIndex.putNativeCommittedAppendFacts(
+			{
+				hash: entry.hash,
+				unique: true,
+				externalNextHashes: [],
+				shallowEntry: rejectedShallow,
+				isHead: true,
+			},
+			transaction,
+		);
+
+		const failure = new Error("applied native index generation failed");
+		const originalPut = index.put.bind(index);
+		const putStub = sinon.stub(index, "put").callsFake(async (value) => {
+			await originalPut(value);
+			throw failure;
+		});
+		try {
+			const rejected = await log.entryIndex
+				.flushNativeCommittedAppendFacts(transaction)
+				.then(
+					() => undefined,
+					(error: unknown) => error,
+				);
+			expect(rejected).equal(failure);
+			await log.entryIndex.rollbackNativeCommittedAppendFacts(transaction);
+			expect(log.length).equal(1);
+			expect((await log.entryIndex.getShallow(entry.hash))?.value.head).equal(
+				false,
+			);
+		} finally {
+			putStub.restore();
+		}
+
+		const restoredPutSpy = sinon.spy(index, "put");
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 400));
+			expect(restoredPutSpy.callCount).equal(1);
+			expect((await log.entryIndex.getShallow(entry.hash))?.value.head).equal(
+				false,
+			);
+			expect(log.length).equal(1);
+		} finally {
+			restoredPutSpy.restore();
+			await log.close();
+		}
+	});
+
 	it("appendMany appends a local chain with one coalesced change", async () => {
 		const log = new Log<Uint8Array>();
 		const changes: any[] = [];
@@ -181,10 +325,7 @@ describe("append", function () {
 				.putKnownManyColumns === "function"
 				? sinon.spy(
 						store as unknown as {
-							putKnownManyColumns: (
-								cids: string[],
-								bytes: Uint8Array[],
-							) => any;
+							putKnownManyColumns: (cids: string[], bytes: Uint8Array[]) => any;
 						},
 						"putKnownManyColumns",
 					)
@@ -429,6 +570,78 @@ describe("append", function () {
 		}
 	});
 
+	it("holds native commit-only publication behind its durable barrier", async () => {
+		const { createNativeLogBlockStore } = await import("@peerbit/log-rust");
+		const nativeStore = await createNativeLogBlockStore();
+		await nativeStore.start();
+		let releaseBarrier!: () => void;
+		const barrierGate = new Promise<void>((resolve) => {
+			releaseBarrier = resolve;
+		});
+		let markBarrierStarted!: () => void;
+		const barrierStarted = new Promise<void>((resolve) => {
+			markBarrierStarted = resolve;
+		});
+		const barrierSpy = sinon.spy(async () => {
+			markBarrierStarted();
+			await barrierGate;
+		});
+		(
+			nativeStore as typeof nativeStore & {
+				waitForDurableWrites?: () => Promise<void>;
+			}
+		).waitForDurableWrites = barrierSpy;
+		const log = new Log<Uint8Array>();
+		await log.open(nativeStore, signKey, {
+			appendDurability: "strict",
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+		});
+
+		try {
+			let settled = false;
+			const pending = Promise.resolve(
+				(log as any).appendLocallyPreparedCommitOnly(
+					new Uint8Array([1]),
+					{ meta: { next: [] } },
+					{
+						skipMissingNextJoin: true,
+						resolveTrimmedEntries: false,
+						includeMaterializationBytes: false,
+						includeAppendFactsBytes: true,
+					},
+				),
+			);
+			void pending.then(
+				() => {
+					settled = true;
+				},
+				() => {
+					settled = true;
+				},
+			);
+			await barrierStarted;
+			await Promise.resolve();
+			expect(settled).equal(false);
+			expect(log.length).equal(0);
+
+			releaseBarrier();
+			const result = await pending;
+			expect(result).to.not.equal(undefined);
+			expect(log.length).equal(1);
+			expect(barrierSpy.callCount).equal(1);
+		} finally {
+			releaseBarrier();
+			delete (
+				nativeStore as typeof nativeStore & {
+					waitForDurableWrites?: () => Promise<void>;
+				}
+			).waitForDurableWrites;
+			await log.close();
+			await nativeStore.stop();
+		}
+	});
+
 	it("uses single native committed append bookkeeping for prepared append", async () => {
 		const { createNativeLogBlockStore } = await import("@peerbit/log-rust");
 		const nativeStore = await createNativeLogBlockStore();
@@ -582,6 +795,270 @@ describe("append", function () {
 		}
 	});
 
+	it("keeps uncontended native append-facts bookkeeping synchronous and single-pass", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+		});
+		const { entry: template } = await log.append(new Uint8Array([41]), {
+			meta: { next: [] },
+		});
+		const entryIndex = log.entryIndex as any;
+		const makeShallow = (hash: string) => {
+			const shallow = template.toShallow(true);
+			shallow.hash = hash;
+			shallow.meta.next = [];
+			return shallow;
+		};
+		const singleSpy = sinon.spy(
+			log.entryIndex,
+			"putNativeCommittedAppendFacts",
+		);
+		const batchSpy = sinon.spy(
+			log.entryIndex,
+			"putNativeCommittedAppendFactsBatch",
+		);
+		try {
+			const generationBefore = entryIndex.nextPendingIndexWriteGeneration;
+			const lengthBefore = log.length;
+			const single = log.entryIndex.putNativeCommittedAppendFacts({
+				hash: "uncontended-single",
+				unique: true,
+				externalNextHashes: [],
+				shallowEntry: makeShallow("uncontended-single"),
+			});
+			expect((single as { then?: unknown } | undefined)?.then).to.equal(
+				undefined,
+			);
+			expect(singleSpy.callCount).to.equal(1);
+			expect(log.length).to.equal(lengthBefore + 1);
+			expect(entryIndex.nextPendingIndexWriteGeneration).to.equal(
+				generationBefore + 1,
+			);
+
+			const batchGenerationBefore = entryIndex.nextPendingIndexWriteGeneration;
+			const batchLengthBefore = log.length;
+			const batch = log.entryIndex.putNativeCommittedAppendFactsBatch([
+				{
+					hash: "uncontended-batch-a",
+					unique: true,
+					externalNextHashes: [],
+					shallowEntry: makeShallow("uncontended-batch-a"),
+				},
+				{
+					hash: "uncontended-batch-b",
+					unique: true,
+					externalNextHashes: [],
+					shallowEntry: makeShallow("uncontended-batch-b"),
+				},
+			]);
+			expect((batch as { then?: unknown } | undefined)?.then).to.equal(
+				undefined,
+			);
+			expect(batchSpy.callCount).to.equal(1);
+			expect(log.length).to.equal(batchLengthBefore + 2);
+			expect(entryIndex.nextPendingIndexWriteGeneration).to.equal(
+				batchGenerationBefore + 2,
+			);
+		} finally {
+			batchSpy.restore();
+			singleSpy.restore();
+			await log.close();
+		}
+	});
+
+	it("defers same-hash native append-facts bookkeeping until the held lease releases", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+		});
+		const { entry: template } = await log.append(new Uint8Array([42]), {
+			meta: { next: [] },
+		});
+		const hash = "contended-native-facts";
+		const shallowEntry = template.toShallow(true);
+		shallowEntry.hash = hash;
+		shallowEntry.meta.next = [];
+		const entryIndex = log.entryIndex as any;
+		const owner = await log.entryIndex.acquireHashMutationLocks([hash]);
+		const lengthBefore = log.length;
+		const generationBefore = entryIndex.nextPendingIndexWriteGeneration;
+		try {
+			const pending = log.entryIndex.putNativeCommittedAppendFacts({
+				hash,
+				unique: true,
+				externalNextHashes: [],
+				shallowEntry,
+			});
+			expect(pending).to.be.instanceOf(Promise);
+			expect(log.length).to.equal(lengthBefore);
+			expect(entryIndex.nextPendingIndexWriteGeneration).to.equal(
+				generationBefore,
+			);
+			log.entryIndex.releaseHashMutationLocks(owner);
+			await pending;
+			expect(log.length).to.equal(lengthBefore + 1);
+			expect(entryIndex.nextPendingIndexWriteGeneration).to.equal(
+				generationBefore + 1,
+			);
+		} finally {
+			try {
+				log.entryIndex.releaseHashMutationLocks(owner);
+			} catch {
+				// The successful path already released the caller-owned test lease.
+			}
+			await log.close();
+		}
+	});
+
+	it("releases native hash leases after synchronous throws and async rejection", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+		});
+		const { entry: template } = await log.append(new Uint8Array([43]), {
+			meta: { next: [] },
+		});
+		const makeShallow = (hash: string) => {
+			const shallow = template.toShallow(true);
+			shallow.hash = hash;
+			shallow.meta.next = [];
+			return shallow;
+		};
+		try {
+			const syncHash = "sync-throw-native-facts";
+			expect(() =>
+				log.entryIndex.putNativeCommittedAppendFactsBatch([
+					{
+						hash: syncHash,
+						unique: true,
+						externalNextHashes: [],
+					},
+				]),
+			).to.throw("Missing shallow entry");
+			const afterSyncThrow = log.entryIndex.putNativeCommittedAppendFacts({
+				hash: syncHash,
+				unique: true,
+				externalNextHashes: [],
+				shallowEntry: makeShallow(syncHash),
+			});
+			expect((afterSyncThrow as { then?: unknown } | undefined)?.then).to.equal(
+				undefined,
+			);
+
+			const asyncHash = "async-reject-native-facts";
+			const failure = new Error("injected native facts lookup failure");
+			const has = sinon.stub(log.entryIndex, "has").rejects(failure);
+			const rejected = log.entryIndex.putNativeCommittedAppendFacts({
+				hash: asyncHash,
+				unique: false,
+				externalNextHashes: [],
+				shallowEntry: makeShallow(asyncHash),
+			});
+			expect(rejected).to.be.instanceOf(Promise);
+			expect(
+				await Promise.resolve(rejected).then(
+					() => undefined,
+					(error: unknown) => error,
+				),
+			).to.equal(failure);
+			has.restore();
+			const afterAsyncReject = log.entryIndex.putNativeCommittedAppendFacts({
+				hash: asyncHash,
+				unique: true,
+				externalNextHashes: [],
+				shallowEntry: makeShallow(asyncHash),
+			});
+			expect(
+				(afterAsyncReject as { then?: unknown } | undefined)?.then,
+			).to.equal(undefined);
+		} finally {
+			sinon.restore();
+			await log.close();
+		}
+	});
+
+	it("does not release a caller-supplied native hash-lock owner", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+		});
+		const { entry: template } = await log.append(new Uint8Array([44]), {
+			meta: { next: [] },
+		});
+		const hash = "caller-owned-native-facts";
+		const makeShallow = (value = hash) => {
+			const shallow = template.toShallow(true);
+			shallow.hash = value;
+			shallow.meta.next = [];
+			return shallow;
+		};
+		const owner = await log.entryIndex.acquireHashMutationLocks([hash]);
+		try {
+			const lengthBeforeRejectedOwners = log.length;
+			expect(() =>
+				log.entryIndex.putNativeCommittedAppendFacts(
+					{
+						hash: "uncovered-single",
+						unique: true,
+						externalNextHashes: [],
+						shallowEntry: makeShallow("uncovered-single"),
+					},
+					undefined,
+					owner,
+				),
+			).to.throw("does not cover uncovered-single");
+			expect(() =>
+				log.entryIndex.putNativeCommittedAppendFactsBatch(
+					[
+						{
+							hash: "uncovered-batch",
+							unique: true,
+							externalNextHashes: [],
+							shallowEntry: makeShallow("uncovered-batch"),
+						},
+					],
+					undefined,
+					owner,
+				),
+			).to.throw("does not cover uncovered-batch");
+			expect(log.length).to.equal(lengthBeforeRejectedOwners);
+			const owned = log.entryIndex.putNativeCommittedAppendFacts(
+				{
+					hash,
+					unique: true,
+					externalNextHashes: [],
+					shallowEntry: makeShallow(),
+				},
+				undefined,
+				owner,
+			);
+			expect((owned as { then?: unknown } | undefined)?.then).to.equal(
+				undefined,
+			);
+			const waiting = log.entryIndex.putNativeCommittedAppendFacts({
+				hash,
+				unique: false,
+				externalNextHashes: [],
+				shallowEntry: makeShallow(),
+			});
+			expect(waiting).to.be.instanceOf(Promise);
+			log.entryIndex.releaseHashMutationLocks(owner);
+			await waiting;
+		} finally {
+			try {
+				log.entryIndex.releaseHashMutationLocks(owner);
+			} catch {
+				// The test releases its owner before awaiting the contended mutation.
+			}
+			await log.close();
+		}
+	});
+
 	it("uses native graph trim facts for commit-only prepared append without native block store", async () => {
 		const log = new Log<Uint8Array>();
 		await log.open(store, signKey, {
@@ -639,6 +1116,56 @@ describe("append", function () {
 		}
 	});
 
+	it("mirrors trim deletion only after native confirms hot deletion", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			appendDurability: "strict",
+			indexer: new HashmapIndices(),
+		});
+		const nativeDeleteMirror = sinon.stub().resolves();
+		(
+			store as BlockStore & {
+				rmManyAfterNativeDelete?: (hashes: string[]) => Promise<void>;
+			}
+		).rmManyAfterNativeDelete = nativeDeleteMirror;
+
+		try {
+			const first = await log.append(new Uint8Array([1]), {
+				meta: { next: [] },
+			});
+			await log.entryIndex.consumeNativeTrimmedEntryHashesNoReturnMaybe(
+				[first.entry.hash],
+				{
+					skipNextHeadUpdates: true,
+					deleteBlocks: false,
+				},
+			);
+			expect(nativeDeleteMirror.callCount).equal(0);
+
+			const second = await log.append(new Uint8Array([2]), {
+				meta: { next: [] },
+			});
+			await log.entryIndex.consumeNativeTrimmedEntryHashesNoReturnMaybe(
+				[second.entry.hash],
+				{
+					skipNextHeadUpdates: true,
+					deleteBlocks: false,
+					nativeBlocksDeleted: true,
+				},
+			);
+			expect(
+				nativeDeleteMirror.calledOnceWithExactly([second.entry.hash]),
+			).equal(true);
+		} finally {
+			delete (
+				store as BlockStore & {
+					rmManyAfterNativeDelete?: (hashes: string[]) => Promise<void>;
+				}
+			).rmManyAfterNativeDelete;
+			await log.close();
+		}
+	});
+
 	it("keeps known no-next native append on the direct path with length trim", async () => {
 		const log = new Log<Uint8Array>();
 		await log.open(store, signKey, {
@@ -663,7 +1190,9 @@ describe("append", function () {
 			});
 
 		try {
-			const first = await (log as any).appendLocallyPreparedNativeNoNextCommitOnly(
+			const first = await (
+				log as any
+			).appendLocallyPreparedNativeNoNextCommitOnly(
 				new Uint8Array([1]),
 				{ meta: { next: [] } },
 				{ resolveTrimmedEntries: false },
@@ -694,6 +1223,301 @@ describe("append", function () {
 			trimSpy.restore();
 			getNextsForAppendSpy.restore();
 			await log.close();
+		}
+	});
+
+	it("waits for an admitted native prepare and compensates terminal admission", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			appendDurability: "strict",
+			indexer: new HashmapIndices(),
+		});
+		const cid = await store.put(Uint8Array.of(99));
+		let markPrepared!: () => void;
+		const prepared = new Promise<void>((resolve) => {
+			markPrepared = resolve;
+		});
+		let releasePrepare!: () => void;
+		const prepareGate = new Promise<void>((resolve) => {
+			releasePrepare = resolve;
+		});
+		const pending = Promise.resolve(
+			(log as any).appendLocallyPreparedNativeNoNextCommitOnly(
+				Uint8Array.of(1),
+				{ meta: { next: [] } },
+				{
+					resolveTrimmedEntries: false,
+					skipMissingNextJoin: true,
+					retainMaterializationBytes: false,
+					deferNativeTransactionAcknowledgement: true,
+				},
+				async () => {
+					markPrepared();
+					await prepareGate;
+					return {
+						cid,
+						byteLength: 1,
+						nativeCommitOwnershipToken: {},
+					};
+				},
+			),
+		);
+		try {
+			await prepared;
+			let closeSettled = false;
+			const closing = log.close().finally(() => {
+				closeSettled = true;
+			});
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(closeSettled).to.equal(false);
+			releasePrepare();
+			const [appendResult, closeResult] = await Promise.allSettled([
+				pending,
+				closing,
+			]);
+			expect(appendResult.status).to.equal("rejected");
+			expect(closeResult.status).to.equal("fulfilled");
+			expect(await store.get(cid)).to.equal(undefined);
+			expect((log as any)._nativeCommittedAppendFinalizers?.size ?? 0).to.equal(
+				0,
+			);
+		} finally {
+			releasePrepare();
+			await pending.catch(() => undefined);
+			await log.close().catch(() => undefined);
+		}
+	});
+
+	for (const method of ["append", "appendMany"] as const) {
+		it(`waits for an admitted public ${method} before closing`, async () => {
+			const log = new Log<Uint8Array>();
+			await log.open(store, signKey, {
+				indexer: new HashmapIndices(),
+				nativeGraph: true,
+			});
+			const originalCreateNativePlainAppendChain = (
+				log as any
+			).createNativePlainAppendChain.bind(log);
+			let markPrepared!: () => void;
+			const prepared = new Promise<void>((resolve) => {
+				markPrepared = resolve;
+			});
+			let releasePrepared!: () => void;
+			const preparedGate = new Promise<void>((resolve) => {
+				releasePrepared = resolve;
+			});
+			const createNativePlainAppendChain = sinon
+				.stub(log as any, "createNativePlainAppendChain")
+				.callsFake(async (...args: any[]) => {
+					const chain = await originalCreateNativePlainAppendChain(...args);
+					expect(chain).to.not.equal(undefined);
+					expect(chain.nativeBlocksCommitted).to.equal(false);
+					markPrepared();
+					await preparedGate;
+					return chain;
+				});
+			const pending =
+				method === "append"
+					? log.append(Uint8Array.of(7))
+					: log.appendMany([Uint8Array.of(7), Uint8Array.of(8)]);
+			try {
+				await prepared;
+				let closeSettled = false;
+				const closing = log.close().finally(() => {
+					closeSettled = true;
+				});
+				await Promise.resolve();
+				await Promise.resolve();
+				expect(closeSettled).to.equal(false);
+
+				releasePrepared();
+				const [appendResult, closeResult] = await Promise.allSettled([
+					pending,
+					closing,
+				]);
+				expect(appendResult.status).to.equal("fulfilled");
+				expect(closeResult.status).to.equal("fulfilled");
+				if (appendResult.status === "fulfilled") {
+					const hashes =
+						"entry" in appendResult.value
+							? [appendResult.value.entry.hash]
+							: appendResult.value.entries.map((entry) => entry.hash);
+					for (const hash of hashes) {
+						expect(await blockExists(hash)).to.equal(true);
+					}
+				}
+				expect((log.entryIndex as any).pendingIndexWrites.size).to.equal(0);
+			} finally {
+				releasePrepared();
+				await pending.catch(() => undefined);
+				await log.close().catch(() => undefined);
+				createNativePlainAppendChain.restore();
+			}
+		});
+	}
+
+	it("lets an onChange observer catch terminal reentrancy and retry later", async () => {
+		const log = new Log<Uint8Array>();
+		let closeError: unknown;
+		let dropError: unknown;
+		await log.open(store, signKey, {
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+			onChange: async () => {
+				closeError = await log.close().then(
+					() => undefined,
+					(error: unknown) => error,
+				);
+				dropError = await log.drop().then(
+					() => undefined,
+					(error: unknown) => error,
+				);
+			},
+		});
+
+		const result = await Promise.race([
+			log.append(Uint8Array.of(10)),
+			new Promise<never>((_, reject) =>
+				setTimeout(() => reject(new Error("onChange close deadlocked")), 1000),
+			),
+		]);
+		expect(result.entry.hash).to.be.a("string");
+		expect(String(closeError)).to.contain("mutation callback");
+		expect(String(dropError)).to.contain("mutation callback");
+		expect(log.closed).to.equal(false);
+		await log.drop();
+		expect(log.closed).to.equal(true);
+		expect(await blockExists(result.entry.hash)).to.equal(false);
+	});
+
+	it("rejects post-commit on uncaught onChange terminal reentrancy", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			indexer: new HashmapIndices(),
+			nativeGraph: true,
+			onChange: async () => log.close(),
+		});
+
+		const result = await Promise.race([
+			log.append(Uint8Array.of(12)).then(
+				() => ({ status: "fulfilled" as const }),
+				(error: unknown) => ({ status: "rejected" as const, error }),
+			),
+			new Promise<never>((_, reject) =>
+				setTimeout(() => reject(new Error("onChange close deadlocked")), 1000),
+			),
+		]);
+		expect(result.status).to.equal("rejected");
+		if (result.status === "rejected") {
+			expect(String(result.error)).to.contain("mutation callback");
+		}
+		expect(log.length).to.equal(1);
+		expect(log.closed).to.equal(false);
+		await log.close();
+		expect(log.closed).to.equal(true);
+	});
+
+	it("rejects without deadlocking when canAppend closes the log", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			indexer: new HashmapIndices(),
+			canAppend: async () => {
+				await log.close();
+				return true;
+			},
+		});
+
+		const result = await Promise.race([
+			log.append(Uint8Array.of(11)).then(
+				() => ({ status: "fulfilled" as const }),
+				(error: unknown) => ({ status: "rejected" as const, error }),
+			),
+			new Promise<never>((_, reject) =>
+				setTimeout(() => reject(new Error("canAppend close deadlocked")), 1000),
+			),
+		]);
+		expect(result.status).to.equal("rejected");
+		if (result.status === "rejected") {
+			expect(String(result.error)).to.contain("mutation callback");
+		}
+		expect(log.length).to.equal(0);
+		expect(log.closed).to.equal(false);
+		await log.close();
+		expect(log.closed).to.equal(true);
+	});
+
+	it("rejects terminal reentrancy from canTrim without deadlocking", async () => {
+		const log = new Log<Uint8Array>();
+		let closeError: unknown;
+		await log.open(store, signKey, {
+			indexer: new HashmapIndices(),
+			trim: {
+				type: "length",
+				to: 1,
+				filter: {
+					canTrim: async () => {
+						closeError = await log.close().then(
+							() => undefined,
+							(error: unknown) => error,
+						);
+						return true;
+					},
+				},
+			},
+		});
+		await log.append(Uint8Array.of(15));
+
+		await Promise.race([
+			log.append(Uint8Array.of(16)),
+			new Promise<never>((_, reject) =>
+				setTimeout(() => reject(new Error("canTrim close deadlocked")), 1000),
+			),
+		]);
+		expect(String(closeError)).to.contain("mutation callback");
+		expect(log.length).to.equal(1);
+		expect(log.closed).to.equal(false);
+		await log.close();
+		expect(log.closed).to.equal(true);
+	});
+
+	it("finishes CUT deletion before terminal admission is released", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, { indexer: new HashmapIndices() });
+		const { entry: first } = await log.append(Uint8Array.of(13));
+		let markChange!: () => void;
+		const changeStarted = new Promise<void>((resolve) => {
+			markChange = resolve;
+		});
+		let releaseChange!: () => void;
+		const changeGate = new Promise<void>((resolve) => {
+			releaseChange = resolve;
+		});
+		const cutting = log.append(Uint8Array.of(14), {
+			meta: { type: EntryType.CUT },
+			onChange: async () => {
+				markChange();
+				await changeGate;
+			},
+		});
+		try {
+			await changeStarted;
+			const closeError = await log.close().then(
+				() => undefined,
+				(error: unknown) => error,
+			);
+			expect(String(closeError)).to.contain("mutation callback");
+			expect(await blockExists(first.hash)).to.equal(true);
+
+			releaseChange();
+			await cutting;
+			expect(await blockExists(first.hash)).to.equal(false);
+			await log.close();
+			expect(log.closed).to.equal(true);
+		} finally {
+			releaseChange();
+			await cutting.catch(() => undefined);
+			await log.close().catch(() => undefined);
 		}
 	});
 

--- a/packages/log/test/drop.spec.ts
+++ b/packages/log/test/drop.spec.ts
@@ -1,11 +1,41 @@
 import { AnyBlockStore } from "@peerbit/blocks";
 import { Ed25519Keypair } from "@peerbit/crypto";
+import { HashmapIndices } from "@peerbit/indexer-simple";
 import { expect } from "chai";
+import sinon from "sinon";
 import { Log } from "../src/log.js";
 
 describe("drop", () => {
 	let log: Log<Uint8Array>;
 	let store: AnyBlockStore;
+	let uniqueByte = 100;
+
+	const stageNativeFinalizer = async () => {
+		const { entry: template } = await log.append(
+			new Uint8Array([uniqueByte++]),
+		);
+		const hash = await store.put(new Uint8Array([uniqueByte++]));
+		const shallowEntry = template.toShallow(true);
+		shallowEntry.hash = hash;
+		shallowEntry.meta.next = [];
+		const transaction =
+			log.entryIndex.beginNativeCommittedAppendFactsTransaction([hash]);
+		await log.entryIndex.putNativeCommittedAppendFacts(
+			{
+				hash,
+				unique: true,
+				externalNextHashes: [],
+				shallowEntry,
+				isHead: true,
+			},
+			transaction,
+		);
+		const finalizer = (log as any).createNativeCommittedAppendFinalizer({
+			transaction,
+			hashes: [hash],
+		});
+		return { finalizer, hash, transaction };
+	};
 	beforeEach(async () => {
 		log = new Log();
 		store = new AnyBlockStore();
@@ -25,5 +55,463 @@ describe("drop", () => {
 		await log.drop();
 		loadedEntry = await store.get(e0.entry.hash);
 		expect(loadedEntry).equal(undefined);
+	});
+
+	it("completes a drop queued behind close and erases the retained block", async () => {
+		const { entry } = await log.append(new Uint8Array([9]));
+		const clear = sinon.spy(log.entryIndex, "clear");
+		const retain = sinon.spy(log.entryIndex, "retainBlockHashesForDrop");
+		const remove = sinon.spy(store, "rm");
+		const closing = log.close();
+		const dropping = log.drop();
+		await Promise.all([closing, dropping]);
+		expect(clear.calledOnce).to.equal(true);
+		expect(retain.calledOnce).to.equal(true);
+		expect(remove.calledWith(entry.hash)).to.equal(true);
+		expect(await store.get(entry.hash)).to.equal(undefined);
+		expect(log.closed).to.equal(true);
+		await log.drop();
+	});
+
+	it("does not scan or retain every hash for an ordinary close", async () => {
+		const preservingLog = new Log<Uint8Array>();
+		await preservingLog.open(store, await Ed25519Keypair.create(), {
+			indexer: new HashmapIndices(),
+		});
+		try {
+			await preservingLog.append(new Uint8Array([12]));
+			const retain = sinon.spy(
+				preservingLog.entryIndex,
+				"retainBlockHashesForDrop",
+			);
+			await preservingLog.close();
+			expect(retain.callCount).to.equal(0);
+		} finally {
+			await preservingLog.close();
+		}
+	});
+
+	it("drops indexed blocks after an earlier close", async () => {
+		const { entry } = await log.append(new Uint8Array([12]));
+		await log.close();
+		expect(await (log as any)._indexer.properties.db.status()).to.equal(
+			"closed",
+		);
+		expect(await store.get(entry.hash)).to.not.equal(undefined);
+		await log.drop();
+		expect(await store.get(entry.hash)).to.equal(undefined);
+	});
+
+	it("drops blocks requested while a destructive stop is in flight", async () => {
+		const { entry } = await log.append(new Uint8Array([15]));
+		const indexer = (log as any)._indexer;
+		const originalStop = indexer.stop.bind(indexer);
+		let markStopping!: () => void;
+		const stopping = new Promise<void>((resolve) => {
+			markStopping = resolve;
+		});
+		let releaseStop!: () => void;
+		const stopGate = new Promise<void>((resolve) => {
+			releaseStop = resolve;
+		});
+		const stop = sinon.stub(indexer, "stop").callsFake(async () => {
+			markStopping();
+			await stopGate;
+			await originalStop();
+		});
+		const retain = sinon.spy(log.entryIndex, "retainBlockHashesForDrop");
+		const closing = log.close();
+		try {
+			await stopping;
+			const dropping = log.drop();
+			releaseStop();
+			await Promise.all([closing, dropping]);
+			expect(retain.calledOnce).to.equal(true);
+			expect(await store.get(entry.hash)).to.equal(undefined);
+			expect(log.closed).to.equal(true);
+		} finally {
+			releaseStop();
+			await closing.catch(() => undefined);
+			await log.drop().catch(() => undefined);
+			stop.restore();
+		}
+	});
+
+	it("rejects reopen during close and keeps repeated close on one owner", async () => {
+		await log.append(new Uint8Array([10]));
+		const internals = log as any;
+		const indexer = internals._indexer;
+		const originalStop = indexer.stop.bind(indexer);
+		let markStopping!: () => void;
+		const stopping = new Promise<void>((resolve) => {
+			markStopping = resolve;
+		});
+		let releaseStop!: () => void;
+		const stopGate = new Promise<void>((resolve) => {
+			releaseStop = resolve;
+		});
+		const stop = sinon.stub(indexer, "stop").callsFake(async () => {
+			markStopping();
+			await stopGate;
+			await originalStop();
+		});
+
+		const firstClose = log.close();
+		try {
+			await stopping;
+			const secondClose = log.close();
+			expect(secondClose).to.equal(firstClose);
+			await expect(log.open(store, internals._identity)).rejectedWith(
+				"Log close must complete before reopening",
+			);
+			releaseStop();
+			await Promise.all([firstClose, secondClose]);
+			expect(log.closed).to.equal(true);
+			expect(stop.calledOnce).to.equal(true);
+		} finally {
+			releaseStop();
+			await firstClose.catch(() => undefined);
+		}
+	});
+
+	it("rejects reopen during drop and keeps repeated drop on one owner", async () => {
+		const { entry } = await log.append(new Uint8Array([11]));
+		const internals = log as any;
+		const originalClear = internals._entryIndex.clear.bind(
+			internals._entryIndex,
+		);
+		let markClearing!: () => void;
+		const clearing = new Promise<void>((resolve) => {
+			markClearing = resolve;
+		});
+		let releaseClear!: () => void;
+		const clearGate = new Promise<void>((resolve) => {
+			releaseClear = resolve;
+		});
+		const clear = sinon
+			.stub(internals._entryIndex, "clear")
+			.callsFake(async () => {
+				markClearing();
+				await clearGate;
+				await originalClear();
+			});
+
+		const firstDrop = log.drop();
+		try {
+			await clearing;
+			const secondDrop = log.drop();
+			expect(secondDrop).to.equal(firstDrop);
+			await expect(log.open(store, internals._identity)).rejectedWith(
+				"Log drop must complete before reopening",
+			);
+			releaseClear();
+			await Promise.all([firstDrop, secondDrop]);
+			expect(await store.get(entry.hash)).to.equal(undefined);
+			expect(clear.calledOnce).to.equal(true);
+		} finally {
+			releaseClear();
+			await firstDrop.catch(() => undefined);
+		}
+	});
+
+	it("rolls back an open finalizer before clear without deadlocking", async () => {
+		const { hash } = await stageNativeFinalizer();
+		await log.drop();
+		expect(await store.get(hash)).to.equal(undefined);
+	});
+
+	it("waits for an acknowledging finalizer, then erases its publication", async () => {
+		const { finalizer, hash } = await stageNativeFinalizer();
+		let markAcknowledging!: () => void;
+		const acknowledging = new Promise<void>((resolve) => {
+			markAcknowledging = resolve;
+		});
+		let releaseAcknowledgement!: () => void;
+		const acknowledgementGate = new Promise<void>((resolve) => {
+			releaseAcknowledgement = resolve;
+		});
+		const acknowledge = finalizer.acknowledge(async () => {
+			markAcknowledging();
+			await acknowledgementGate;
+		});
+		await acknowledging;
+
+		let settled = false;
+		const dropping = log.drop().finally(() => {
+			settled = true;
+		});
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(settled).to.equal(false);
+		releaseAcknowledgement();
+		await Promise.all([acknowledge, dropping]);
+		expect(await store.get(hash)).to.equal(undefined);
+		await Promise.resolve();
+		expect(await store.get(hash)).to.equal(undefined);
+	});
+
+	it("rejects finalizer admission after terminal drop", async () => {
+		await log.drop();
+		expect(() =>
+			(log as any).createNativeCommittedAppendFinalizer({
+				transaction: {},
+				hashes: ["late"],
+			}),
+		).to.throw("log is closing or dropped");
+	});
+
+	it("waits for an in-flight acknowledgement before close settles", async () => {
+		const { finalizer, hash } = await stageNativeFinalizer();
+		let markAcknowledging!: () => void;
+		const acknowledging = new Promise<void>((resolve) => {
+			markAcknowledging = resolve;
+		});
+		let releaseAcknowledgement!: () => void;
+		const acknowledgementGate = new Promise<void>((resolve) => {
+			releaseAcknowledgement = resolve;
+		});
+		const acknowledge = finalizer.acknowledge(async () => {
+			markAcknowledging();
+			await acknowledgementGate;
+		});
+		await acknowledging;
+
+		let settled = false;
+		const closing = log.close().finally(() => {
+			settled = true;
+		});
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(settled).to.equal(false);
+		releaseAcknowledgement();
+		await Promise.all([acknowledge, closing]);
+		expect(await store.get(hash)).to.not.equal(undefined);
+		const lengthAfterClose = log.entryIndex.length;
+		await Promise.resolve();
+		expect(log.entryIndex.length).to.equal(lengthAfterClose);
+	});
+
+	it("keeps a failed terminal rollback rollback-only for close retry", async () => {
+		const { finalizer, hash } = await stageNativeFinalizer();
+		const entryIndex = log.entryIndex;
+		const originalRollback =
+			entryIndex.rollbackNativeCommittedAppendFacts.bind(entryIndex);
+		const failure = new Error("transient native rollback failure");
+		const rollback = sinon.stub(
+			entryIndex,
+			"rollbackNativeCommittedAppendFacts",
+		);
+		rollback.onFirstCall().rejects(failure);
+		rollback.onSecondCall().callsFake(originalRollback);
+
+		const closeFailure = await log.close().then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(closeFailure).to.be.instanceOf(AggregateError);
+		expect(rollback.calledOnce).to.equal(true);
+		expect((log as any)._nativeCommittedAppendFinalizers.size).to.equal(1);
+		await expect(finalizer.acknowledge()).rejectedWith("already rolled back");
+		expect(() => finalizer.retainForRecovery()).to.throw(
+			"cannot be retained for recovery",
+		);
+		expect(await store.get(hash)).to.equal(undefined);
+
+		await log.close();
+		expect(rollback.callCount).to.equal(2);
+		expect((log as any)._nativeCommittedAppendFinalizers.size).to.equal(0);
+		expect(await store.get(hash)).to.equal(undefined);
+	});
+
+	it("retains the indexer when close stop fails and retries the stage", async () => {
+		await log.append(new Uint8Array([5]));
+		const internals = log as any;
+		const indexer = internals._indexer;
+		const originalStop = indexer.stop.bind(indexer);
+		const failure = new Error("transient close stop failure");
+		const stop = sinon.stub(indexer, "stop");
+		stop.onFirstCall().callsFake(async () => {
+			await originalStop();
+			throw failure;
+		});
+		stop.onSecondCall().callsFake(originalStop);
+
+		expect(
+			await log.close().then(
+				() => undefined,
+				(error: unknown) => error,
+			),
+		).to.equal(failure);
+		expect(stop.calledOnce).to.equal(true);
+		expect(internals._indexer).to.equal(indexer);
+		await expect(log.open(store, internals._identity)).rejectedWith(
+			"Failed log close must be retried before reopening",
+		);
+		expect(stop.calledOnce).to.equal(true);
+		expect(internals._indexer).to.equal(indexer);
+
+		await log.close();
+		expect(stop.callCount).to.equal(2);
+		expect(internals._indexer).to.equal(indexer);
+	});
+
+	it("retries a failed clear and erases the actual block before completing", async () => {
+		const { entry } = await log.append(new Uint8Array([2]));
+		const internals = log as unknown as {
+			_closed: boolean;
+			_loadedOnce: boolean;
+			_entryIndex: { clear: () => Promise<void> };
+			_indexer?: { drop: () => Promise<void>; stop: () => Promise<void> };
+		};
+		const first = new Error("entry clear failed");
+		const originalClear = internals._entryIndex.clear.bind(
+			internals._entryIndex,
+		);
+		const clear = sinon.stub(internals._entryIndex, "clear");
+		clear.onFirstCall().rejects(first);
+		clear.onSecondCall().callsFake(originalClear);
+		const drop = sinon.spy(internals._indexer!, "drop");
+		const stop = sinon.spy(internals._indexer!, "stop");
+
+		const failure = await log.drop().then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(failure).to.equal(first);
+		expect(clear.calledOnce).to.equal(true);
+		expect(drop.callCount).to.equal(0);
+		expect(stop.callCount).to.equal(0);
+		expect(internals._closed).to.equal(true);
+		expect(internals._indexer).to.not.equal(undefined);
+		expect(await store.get(entry.hash)).to.not.equal(undefined);
+		await expect(log.open(store, (log as any)._identity)).rejectedWith(
+			"Failed log drop must be retried before reopening",
+		);
+		expect(clear.calledOnce).to.equal(true);
+		expect(await store.get(entry.hash)).to.not.equal(undefined);
+
+		await log.drop();
+		expect(clear.callCount).to.equal(2);
+		expect(drop.calledOnce).to.equal(true);
+		expect(stop.calledOnce).to.equal(true);
+		expect(internals._loadedOnce).to.equal(false);
+		expect(internals._indexer).to.equal(undefined);
+		expect(await store.get(entry.hash)).to.equal(undefined);
+
+		await log.drop();
+		expect(clear.callCount).to.equal(2);
+		expect(drop.calledOnce).to.equal(true);
+		expect(stop.calledOnce).to.equal(true);
+	});
+
+	it("keeps failed drop dominant when close is requested next", async () => {
+		const { entry } = await log.append(new Uint8Array([13]));
+		const originalClear = log.entryIndex.clear.bind(log.entryIndex);
+		const failure = new Error("first erase attempt failed");
+		const clear = sinon.stub(log.entryIndex, "clear");
+		clear.onFirstCall().rejects(failure);
+		clear.onSecondCall().callsFake(originalClear);
+
+		expect(
+			await log.drop().then(
+				() => undefined,
+				(error: unknown) => error,
+			),
+		).to.equal(failure);
+		await log.close();
+		expect(clear.callCount).to.equal(2);
+		expect(await store.get(entry.hash)).to.equal(undefined);
+		expect((log as any)._lifecycleState).to.equal("dropped");
+	});
+
+	it("retries clear after an inner index drop rejects post-apply", async () => {
+		const { entry } = await log.append(new Uint8Array([14]));
+		const index = log.entryIndex.properties.index;
+		const originalDrop = index.drop.bind(index);
+		const failure = new Error("post-apply entry-index drop failure");
+		const innerDrop = sinon.stub(index, "drop");
+		innerDrop.onFirstCall().callsFake(async () => {
+			await originalDrop();
+			throw failure;
+		});
+		innerDrop.onSecondCall().callsFake(originalDrop);
+
+		expect(
+			await log.drop().then(
+				() => undefined,
+				(error: unknown) => error,
+			),
+		).to.equal(failure);
+		expect(await store.get(entry.hash)).to.equal(undefined);
+		await log.drop();
+		expect(innerDrop.callCount).to.be.greaterThanOrEqual(2);
+		expect((log as any)._lifecycleState).to.equal("dropped");
+	});
+
+	it("retries index drop without repeating a completed entry clear", async () => {
+		const { entry } = await log.append(new Uint8Array([3]));
+		const internals = log as unknown as {
+			_entryIndex: { clear: () => Promise<void> };
+			_indexer?: { drop: () => Promise<void>; stop: () => Promise<void> };
+		};
+		const clear = sinon.spy(internals._entryIndex, "clear");
+		const indexer = internals._indexer!;
+		const originalDrop = indexer.drop.bind(indexer);
+		const failure = new Error("index drop failed");
+		const drop = sinon.stub(indexer, "drop");
+		drop.onFirstCall().rejects(failure);
+		drop.onSecondCall().callsFake(originalDrop);
+		const stop = sinon.spy(indexer, "stop");
+
+		expect(
+			await log.drop().then(
+				() => undefined,
+				(error: unknown) => error,
+			),
+		).to.equal(failure);
+		expect(clear.calledOnce).to.equal(true);
+		expect(drop.calledOnce).to.equal(true);
+		expect(stop.callCount).to.equal(0);
+		expect(await store.get(entry.hash)).to.equal(undefined);
+		expect(internals._indexer).to.equal(indexer);
+
+		await log.drop();
+		expect(clear.calledOnce).to.equal(true);
+		expect(drop.callCount).to.equal(2);
+		expect(stop.calledOnce).to.equal(true);
+		expect(internals._indexer).to.equal(undefined);
+	});
+
+	it("retains the dropped indexer until a transient stop failure is retried", async () => {
+		await log.append(new Uint8Array([4]));
+		const internals = log as unknown as {
+			_entryIndex: { clear: () => Promise<void> };
+			_indexer?: { drop: () => Promise<void>; stop: () => Promise<void> };
+		};
+		const clear = sinon.spy(internals._entryIndex, "clear");
+		const indexer = internals._indexer!;
+		const drop = sinon.spy(indexer, "drop");
+		const originalStop = indexer.stop.bind(indexer);
+		const failure = new Error("index stop failed");
+		const stop = sinon.stub(indexer, "stop");
+		stop.onFirstCall().rejects(failure);
+		stop.onSecondCall().callsFake(originalStop);
+
+		expect(
+			await log.drop().then(
+				() => undefined,
+				(error: unknown) => error,
+			),
+		).to.equal(failure);
+		expect(clear.calledOnce).to.equal(true);
+		expect(drop.calledOnce).to.equal(true);
+		expect(stop.calledOnce).to.equal(true);
+		expect(internals._indexer).to.equal(indexer);
+
+		await log.drop();
+		expect(clear.calledOnce).to.equal(true);
+		expect(drop.calledOnce).to.equal(true);
+		expect(stop.callCount).to.equal(2);
+		expect(internals._indexer).to.equal(undefined);
 	});
 });

--- a/packages/log/test/log.spec.ts
+++ b/packages/log/test/log.spec.ts
@@ -1,3 +1,4 @@
+import { deserialize, serialize } from "@dao-xyz/borsh";
 import { AnyBlockStore, type BlockStore } from "@peerbit/blocks";
 import { HashmapIndices } from "@peerbit/indexer-simple";
 import {
@@ -36,10 +37,205 @@ describe("properties", function () {
 			assert.deepStrictEqual(await log.getTailHashes(), []);
 		});
 
-		it("can not open twice", async () => {
-			const log = new Log();
+		it("initializes runtime lifecycle state after a borsh round trip", async () => {
+			const log = deserialize(
+				serialize(new Log<Uint8Array>()),
+				Log,
+			) as Log<Uint8Array>;
+			let changes = 0;
+			const onChange = async () => {
+				changes++;
+			};
+
+			expect(log.closed).to.equal(true);
+			await log.open(store, signKey, { onChange });
+			expect(log.closed).to.equal(false);
+			await log.append(new Uint8Array([1]));
+			expect(changes).to.equal(1);
+			await log.close();
+			expect(log.closed).to.equal(true);
+
+			await log.open(store, signKey, { onChange });
+			await log.append(new Uint8Array([2]));
+			expect(changes).to.equal(2);
+			await log.drop();
+			expect(log.closed).to.equal(true);
+		});
+
+		it("closes and drops unopened borsh round trips", async () => {
+			const roundTrip = () =>
+				deserialize(serialize(new Log<Uint8Array>()), Log) as Log<Uint8Array>;
+			const closing = roundTrip();
+			const dropping = roundTrip();
+
+			expect(closing.closed).to.equal(true);
+			await closing.close();
+			expect(closing.closed).to.equal(true);
+			expect(dropping.closed).to.equal(true);
+			await dropping.drop();
+			expect(dropping.closed).to.equal(true);
+		});
+
+		it("rejects reopen without corrupting the live generation", async () => {
+			const log = new Log<Uint8Array>();
 			await log.open(store, signKey, undefined);
-			await expect(log.open(store, signKey, undefined)).rejectedWith();
+			const first = await log.append(new Uint8Array([1]));
+			await expect(log.open(store, signKey, undefined)).rejectedWith(
+				"Already open",
+			);
+			expect(log.closed).to.equal(false);
+			expect(log.length).to.equal(1);
+			expect((await log.get(first.entry.hash))?.hash).to.equal(
+				first.entry.hash,
+			);
+			await log.append(new Uint8Array([2]));
+			expect(log.length).to.equal(2);
+			await log.close();
+			expect(log.closed).to.equal(true);
+		});
+
+		it("lets only the first concurrent open initialize the log", async () => {
+			const log = new Log<Uint8Array>();
+			const indexer = new HashmapIndices();
+			const originalStart = indexer.start.bind(indexer);
+			let markStarted!: () => void;
+			const started = new Promise<void>((resolve) => {
+				markStarted = resolve;
+			});
+			let releaseStart!: () => void;
+			const startGate = new Promise<void>((resolve) => {
+				releaseStart = resolve;
+			});
+			const start = sinon.stub(indexer, "start").callsFake(async () => {
+				markStarted();
+				await startGate;
+				await originalStart();
+			});
+
+			const first = log.open(store, signKey, { indexer });
+			const second = log.open(store, signKey, { indexer });
+			try {
+				await expect(second).rejectedWith("Already open");
+				await started;
+				expect(start.calledOnce).to.equal(true);
+				releaseStart();
+				await first;
+				expect(log.closed).to.equal(false);
+				await log.append(new Uint8Array([3]));
+				expect(log.length).to.equal(1);
+				await log.close();
+				expect(log.closed).to.equal(true);
+			} finally {
+				releaseStart();
+				await first.catch(() => undefined);
+				await log.close().catch(() => undefined);
+				start.restore();
+			}
+		});
+
+		it("stops a started indexer when later open initialization fails", async () => {
+			const log = new Log<Uint8Array>();
+			const failedIndexer = new HashmapIndices();
+			const start = sinon.spy(failedIndexer, "start");
+			const stop = sinon.spy(failedIndexer, "stop");
+			const failure = new Error("scope initialization failed");
+			const scope = sinon.stub(failedIndexer, "scope").rejects(failure);
+
+			expect(
+				await log.open(store, signKey, { indexer: failedIndexer }).then(
+					() => undefined,
+					(error: unknown) => error,
+				),
+			).to.equal(failure);
+			expect(start.calledOnce).to.equal(true);
+			expect(stop.calledOnce).to.equal(true);
+			expect(log.closed).to.equal(true);
+
+			await log.open(store, signKey, { indexer: new HashmapIndices() });
+			await log.append(Uint8Array.of(4));
+			expect(log.length).to.equal(1);
+			await log.close();
+			scope.restore();
+		});
+
+		it("treats a post-init open failure as already closed", async () => {
+			const log = new Log<Uint8Array>();
+			const failedIndexer = new HashmapIndices();
+			const heads = await failedIndexer.scope("heads");
+			const originalInit = heads.init.bind(heads);
+			const failure = new Error("persisted failed after init");
+			const init = sinon.stub(heads, "init").callsFake(async (properties) => {
+				const index = await originalInit(properties as any);
+				sinon.stub(index, "persisted").rejects(failure);
+				return index;
+			});
+			const stop = sinon.spy(failedIndexer, "stop");
+
+			expect(
+				await log.open(store, signKey, { indexer: failedIndexer }).then(
+					() => undefined,
+					(error: unknown) => error,
+				),
+			).to.equal(failure);
+			expect(stop.calledOnce).to.equal(true);
+			await log.close();
+			expect(stop.calledOnce).to.equal(true);
+			expect((log as any)._lifecycleState).to.equal("closed");
+
+			await log.open(store, signKey, { indexer: new HashmapIndices() });
+			await log.close();
+			init.restore();
+		});
+
+		it("lets concurrent close own a post-init open failure", async () => {
+			const log = new Log<Uint8Array>();
+			const failedIndexer = new HashmapIndices();
+			const heads = await failedIndexer.scope("heads");
+			const originalInit = heads.init.bind(heads);
+			const failure = new Error("persisted failed after init");
+			let markPersisted!: () => void;
+			const persisted = new Promise<void>((resolve) => {
+				markPersisted = resolve;
+			});
+			let releasePersisted!: () => void;
+			const persistedGate = new Promise<void>((resolve) => {
+				releasePersisted = resolve;
+			});
+			const init = sinon.stub(heads, "init").callsFake(async (properties) => {
+				const index = await originalInit(properties as any);
+				sinon.stub(index, "persisted").callsFake(async () => {
+					markPersisted();
+					await persistedGate;
+					throw failure;
+				});
+				return index;
+			});
+			const stop = sinon.spy(failedIndexer, "stop");
+			const opening = log.open(store, signKey, { indexer: failedIndexer });
+			try {
+				await persisted;
+				const closing = log.close();
+				releasePersisted();
+				const [openResult, closeResult] = await Promise.allSettled([
+					opening,
+					closing,
+				]);
+				expect(openResult.status).to.equal("rejected");
+				if (openResult.status === "rejected") {
+					expect(openResult.reason).to.equal(failure);
+				}
+				expect(closeResult.status).to.equal("fulfilled");
+				expect(stop.calledOnce).to.equal(true);
+				expect((log as any)._lifecycleState).to.equal("closed");
+
+				await log.open(store, signKey, { indexer: new HashmapIndices() });
+				await log.close();
+			} finally {
+				releasePersisted();
+				await opening.catch(() => undefined);
+				await log.close().catch(() => undefined);
+				init.restore();
+			}
 		});
 		it("sets an id", async () => {
 			const log = new Log({ id: new Uint8Array(1) });

--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -735,6 +735,7 @@ type TrustedDocumentSharedLogAppendManyResult = {
 };
 
 type TrustedDocumentSharedLog = {
+	finishNativeStrictDurableDocumentRecovery(): Promise<void>;
 	appendLocallyPrepared(
 		data: Operation,
 		options?: SharedAppendOptions<Operation>,
@@ -2418,6 +2419,9 @@ export class Documents<
 				await initializeDocumentRust();
 			}
 		}
+		await asTrustedDocumentSharedLog(
+			this.log,
+		).finishNativeStrictDurableDocumentRecovery();
 
 		this._optionCanPerformNativeFastPath = this._optionCanPerformNativePolicy
 			? createCanPerformPolicyEvaluator(

--- a/packages/programs/data/document/document/test/durable-native-commit-ack.spec.ts
+++ b/packages/programs/data/document/document/test/durable-native-commit-ack.spec.ts
@@ -1,0 +1,3585 @@
+import { deserialize, serialize } from "@dao-xyz/borsh";
+import { ShallowEntry } from "@peerbit/log";
+import {
+	NativeBackboneNodeCoordinatePersistence,
+	NativeBackboneNodeCoordinatePersistenceStore,
+} from "@peerbit/native-backbone";
+import {
+	NativeDurableCommitError,
+	StashBackedRawExchangeHeadsMessage,
+} from "@peerbit/shared-log";
+import { expect } from "chai";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Peerbit } from "peerbit";
+import { createRustPeerbitOptions } from "peerbit/rust";
+import sinon from "sinon";
+import { policy, transform } from "../src/index.js";
+import { Documents } from "../src/program.js";
+import { Document, TestStore } from "./data.js";
+
+describe("durable native commit acknowledgement", function () {
+	this.timeout(120_000);
+
+	let client: Peerbit | undefined;
+	let directory: string | undefined;
+
+	const within = async <T>(
+		promise: Promise<T>,
+		step: string,
+		timeoutMs = 5_000,
+	): Promise<T> => {
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		try {
+			return await Promise.race([
+				promise,
+				new Promise<never>((_, reject) => {
+					timer = setTimeout(
+						() => reject(new Error(`Timed out waiting for ${step}`)),
+						timeoutMs,
+					);
+				}),
+			]);
+		} finally {
+			if (timer) {
+				clearTimeout(timer);
+			}
+		}
+	};
+
+	const waitForWorkerMessage = <T>(
+		child: ReturnType<typeof spawn>,
+		step: string,
+	): Promise<T> => {
+		let stdout = "";
+		let stderr = "";
+		child.stderr?.on("data", (chunk) => {
+			stderr += chunk.toString();
+		});
+		return within(
+			new Promise<T>((resolve, reject) => {
+				child.stdout?.on("data", (chunk) => {
+					stdout += chunk.toString();
+					const lines = stdout.split("\n");
+					stdout = lines.pop() ?? "";
+					for (const line of lines) {
+						if (!line.startsWith("{")) {
+							continue;
+						}
+						try {
+							resolve(JSON.parse(line) as T);
+							return;
+						} catch {
+							// Ignore non-protocol output and keep reading.
+						}
+					}
+				});
+				child.once("exit", (code, signal) => {
+					reject(
+						new Error(
+							`Worker exited before ${step} (code=${String(code)}, signal=${String(signal)}): ${stderr}`,
+						),
+					);
+				});
+			}),
+			step,
+			30_000,
+		);
+	};
+
+	afterEach(async () => {
+		try {
+			await client?.stop();
+		} catch (error) {
+			if (!(error instanceof NativeDurableCommitError)) {
+				throw error;
+			}
+		}
+		client = undefined;
+		if (directory) {
+			await fs.rm(directory, { recursive: true, force: true });
+			directory = undefined;
+		}
+	});
+
+	const createOpenArgs = (
+		storeDirectory: string,
+		trim = false,
+		replicate: boolean = false,
+		coordinatePersistence: any = new NativeBackboneNodeCoordinatePersistence(
+			path.join(storeDirectory, "coordinate-wal"),
+			{ flushOnAppend: true },
+		),
+	) => ({
+		mode: "native" as const,
+		replicate,
+		nativeGraph: true,
+		nativeBackbone: {
+			optional: false,
+			documentIndex: true,
+			coordinatePersistence,
+		},
+		canPerform: policy.allowAll<Document>(),
+		index: {
+			type: Document,
+			transform: transform.identity<Document>(),
+		},
+		...(trim ? { log: { trim: { type: "length" as const, to: 1 } } } : {}),
+	});
+
+	const createStore = async (
+		storeDirectory: string,
+		trim = false,
+		replicate = false,
+		coordinatePersistence?: any,
+	) => {
+		client = await Peerbit.create({
+			directory: storeDirectory,
+			...createRustPeerbitOptions(),
+		});
+		const storeId = new Uint8Array(32);
+		for (let index = 0; index < storeId.length; index++) {
+			storeId[index] = (index * 13 + 7) & 0xff;
+		}
+		const store = new TestStore<Document>({
+			docs: new Documents<Document>({ id: storeId }),
+		});
+		store.id = storeId;
+		await client.open(store, {
+			args: createOpenArgs(
+				storeDirectory,
+				trim,
+				replicate,
+				coordinatePersistence,
+			),
+		});
+		const sharedLog = store.docs.log as any;
+		const wrapper = sharedLog.remoteBlocks.localStore as any;
+		expect(wrapper).to.not.equal(sharedLog._nativeBackbone.blocks);
+		return {
+			store,
+			sharedLog,
+			wrapper,
+			durable: wrapper.durable as any,
+			backbone: sharedLog._nativeBackbone as any,
+		};
+	};
+
+	const openStore = async (trim = false, replicate = false) => {
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-durable-native-commit-"),
+		);
+		return createStore(directory, trim, replicate);
+	};
+
+	const nativePersistenceFiles = [
+		"coordinates.bin",
+		"coordinates.wal",
+		"document-values.bin",
+		"document-values.wal",
+		"document-signers.bin",
+		"document-signers.wal",
+		"strict-durable-transaction-intent.json",
+		"strict-durable-transaction-intent.backup.json",
+	] as const;
+
+	const expectFileAbsent = async (file: string) => {
+		try {
+			await fs.stat(file);
+			expect.fail(`Expected ${file} to be absent`);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+				throw error;
+			}
+		}
+	};
+
+	const expectNativePersistenceErased = async (storeDirectory: string) => {
+		const coordinateDirectory = path.join(storeDirectory, "coordinate-wal");
+		for (const name of nativePersistenceFiles) {
+			let bytes: Uint8Array | undefined;
+			try {
+				bytes = await fs.readFile(path.join(coordinateDirectory, name));
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+					throw error;
+				}
+			}
+			expect(bytes?.byteLength ?? 0, `${name} was not erased`).equal(0);
+		}
+		await expectFileAbsent(
+			path.join(coordinateDirectory, "native-backbone-drop.tombstone"),
+		);
+	};
+
+	const wrapCoordinatePersistence = (
+		persistence: NativeBackboneNodeCoordinatePersistence,
+		withIntentStore: boolean,
+		withDropLifecycle = false,
+	) => ({
+		...(withIntentStore ? { intentStore: persistence.intentStore } : {}),
+		...(withDropLifecycle
+			? {
+					drop: persistence.drop.bind(persistence),
+					resumeDrop: persistence.resumeDrop.bind(persistence),
+					supportsDrop: persistence.supportsDrop,
+					dropIsTerminal: persistence.dropIsTerminal,
+				}
+			: {}),
+		durableBarrier: persistence.durableBarrier,
+		flushOnAppend: persistence.flushOnAppend,
+		flushMaxPendingBytes: persistence.flushMaxPendingBytes,
+		flushIntervalMs: persistence.flushIntervalMs,
+		compactMaxJournalBytes: persistence.compactMaxJournalBytes,
+		compactMaxJournalRecords: persistence.compactMaxJournalRecords,
+		crashSafeCompaction: persistence.crashSafeCompaction,
+		hydrate: persistence.hydrate.bind(persistence),
+		flushJournal: persistence.flushJournal.bind(persistence),
+		flushJournalOnAppend: persistence.flushJournalOnAppend.bind(persistence),
+		compact: persistence.compact.bind(persistence),
+		close: persistence.close.bind(persistence),
+	});
+
+	it("reopens an acknowledged native append after SIGKILL", async function () {
+		if (process.platform === "win32") {
+			this.skip();
+		}
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-durable-native-hard-kill-"),
+		);
+		const workerPath = path.join(
+			process.cwd(),
+			"test/durable-native-hard-kill-worker.mjs",
+		);
+		const writer = spawn(process.execPath, [workerPath, "write", directory], {
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		const writerExit = once(writer, "exit");
+		let acknowledged: { event: "ack"; hash: string } | undefined;
+		try {
+			acknowledged = await waitForWorkerMessage<{
+				event: "ack";
+				hash: string;
+			}>(writer, "hard-kill write acknowledgement");
+			expect(writer.kill("SIGKILL")).equal(true);
+			await within(
+				writerExit.then(() => undefined),
+				"hard-kill writer exit",
+			);
+		} finally {
+			if (writer.exitCode === null && writer.signalCode === null) {
+				writer.kill("SIGKILL");
+			}
+		}
+		if (!acknowledged) {
+			throw new Error("Writer exited without an acknowledgement");
+		}
+
+		const reader = spawn(
+			process.execPath,
+			[workerPath, "read", directory, acknowledged.hash],
+			{ stdio: ["ignore", "pipe", "pipe"] },
+		);
+		const readerExit = once(reader, "exit") as Promise<
+			[number | null, NodeJS.Signals | null]
+		>;
+		try {
+			const reopened = await waitForWorkerMessage<{
+				event: "read";
+				documentName?: string;
+				entryHash?: string;
+			}>(reader, "hard-kill reopen");
+			expect(reopened).deep.equal({
+				event: "read",
+				documentName: "hard-kill",
+				entryHash: acknowledged.hash,
+			});
+			const [exitCode] = await within(
+				readerExit,
+				"hard-kill reader exit",
+				30_000,
+			);
+			expect(exitCode).equal(0);
+		} finally {
+			if (reader.exitCode === null && reader.signalCode === null) {
+				reader.kill("SIGKILL");
+			}
+		}
+	});
+
+	it("fails closed when the only native intent slot is corrupt", async () => {
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-durable-native-corrupt-intent-"),
+		);
+		const journalDirectory = path.join(directory, "coordinate-wal");
+		await fs.mkdir(journalDirectory, { recursive: true });
+		await fs.writeFile(
+			path.join(journalDirectory, "strict-durable-transaction-intent.json"),
+			'{"version":1,"lowerMarkerCommitted":',
+		);
+
+		let openError: unknown;
+		try {
+			await createStore(directory);
+		} catch (error) {
+			openError = error;
+		}
+		expect(openError).to.be.instanceOf(Error);
+		expect(String(openError)).to.contain(
+			"No valid native durable transaction journal generation remains",
+		);
+	});
+
+	it("rejects an opaque coordinate adapter on durable strict-native open", async () => {
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-durable-native-opaque-adapter-"),
+		);
+		const persistence = new NativeBackboneNodeCoordinatePersistence(
+			path.join(directory, "coordinate-wal"),
+			{ flushOnAppend: true },
+		);
+		let openError: unknown;
+		try {
+			await createStore(
+				directory,
+				false,
+				false,
+				wrapCoordinatePersistence(persistence, false),
+			);
+		} catch (error) {
+			openError = error;
+		}
+		expect(openError).to.be.instanceOf(Error);
+		expect(String(openError)).to.contain("must expose intentStore");
+	});
+
+	it("rejects durable coordinate persistence without a physical barrier", async () => {
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-durable-native-no-barrier-"),
+		);
+		const persistence = new NativeBackboneNodeCoordinatePersistence(
+			path.join(directory, "coordinate-wal"),
+			{ flushOnAppend: true },
+		);
+		const adapter = wrapCoordinatePersistence(persistence, true);
+		adapter.durableBarrier = false;
+		let openError: unknown;
+		await createStore(directory, false, false, adapter).catch((error) => {
+			openError = error;
+		});
+		expect(String(openError)).to.contain("physical durability barrier");
+	});
+
+	it("rejects a buffered custom store without a durability capability", async () => {
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-durable-native-buffered-no-barrier-"),
+		);
+		const files = new Map<string, Uint8Array>();
+		const store = {
+			read: async (name: string) => files.get(name),
+			write: async (name: string, bytes: Uint8Array) => {
+				files.set(name, bytes.slice());
+			},
+			append: async (name: string, bytes: Uint8Array) => {
+				const previous = files.get(name) ?? new Uint8Array();
+				const next = new Uint8Array(previous.byteLength + bytes.byteLength);
+				next.set(previous);
+				next.set(bytes, previous.byteLength);
+				files.set(name, next);
+			},
+			remove: async (name: string) => {
+				files.delete(name);
+			},
+		};
+		let openError: unknown;
+		await createStore(directory, false, false, {
+			store,
+			buffered: true,
+			flushOnAppend: true,
+		}).catch((error) => {
+			openError = error;
+		});
+		expect(String(openError)).to.contain("physical durability barrier");
+	});
+
+	it("rejects durable custom compaction without a crash-safe capability", async () => {
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-durable-native-unsafe-compaction-"),
+		);
+		const persistence = new NativeBackboneNodeCoordinatePersistence(
+			path.join(directory, "coordinate-wal"),
+			{ flushOnAppend: true },
+		);
+		const adapter = {
+			...wrapCoordinatePersistence(persistence, true),
+			compactMaxJournalRecords: 1,
+			crashSafeCompaction: false,
+		};
+		let openError: unknown;
+		await createStore(directory, false, false, adapter).catch((error) => {
+			openError = error;
+		});
+		expect(String(openError)).to.contain(
+			"compaction thresholds require crashSafeCompaction",
+		);
+	});
+
+	it("accepts a capable custom adapter and reopens its acknowledged append", async () => {
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-durable-native-capable-adapter-"),
+		);
+		const coordinateDirectory = path.join(directory, "coordinate-wal");
+		const firstPersistence = new NativeBackboneNodeCoordinatePersistence(
+			coordinateDirectory,
+			{ flushOnAppend: true },
+		);
+		const first = await createStore(
+			directory,
+			false,
+			false,
+			wrapCoordinatePersistence(firstPersistence, true),
+		);
+		const acknowledged = await first.store.docs.put(
+			new Document({ id: "capable-adapter", name: "acknowledged" }),
+			{ unique: true, replicate: false, target: "none" },
+		);
+		await client!.stop();
+		client = undefined;
+
+		const reopenedPersistence = new NativeBackboneNodeCoordinatePersistence(
+			coordinateDirectory,
+			{ flushOnAppend: true },
+		);
+		const reopened = await createStore(
+			directory,
+			false,
+			false,
+			wrapCoordinatePersistence(reopenedPersistence, true),
+		);
+		expect((await reopened.store.docs.get("capable-adapter"))?.name).equal(
+			"acknowledged",
+		);
+		expect(
+			await reopened.sharedLog.log.entryIndex.has(acknowledged.entry.hash),
+		).equal(true);
+	});
+
+	it("keeps opaque coordinate adapters compatible for memory-only nodes", async () => {
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-memory-native-opaque-adapter-"),
+		);
+		client = await Peerbit.create(createRustPeerbitOptions());
+		const storeId = new Uint8Array(32).fill(41);
+		const store = new TestStore<Document>({
+			docs: new Documents<Document>({ id: storeId }),
+		});
+		store.id = storeId;
+		const persistence = new NativeBackboneNodeCoordinatePersistence(
+			path.join(directory, "coordinate-wal"),
+			{ flushOnAppend: true },
+		);
+		await client.open(store, {
+			args: createOpenArgs(
+				directory,
+				false,
+				false,
+				wrapCoordinatePersistence(persistence, false),
+			),
+		});
+		await store.docs.put(
+			new Document({ id: "memory-opaque", name: "compatible" }),
+			{ unique: true, replicate: false, target: "none" },
+		);
+		expect((await store.docs.get("memory-opaque"))?.name).equal("compatible");
+		let dropError: unknown;
+		try {
+			await store.docs.log.drop();
+		} catch (error) {
+			dropError = error;
+		}
+		expect(String(dropError)).to.contain("terminal underlying drop capability");
+		expect((await store.docs.get("memory-opaque"))?.name).equal("compatible");
+	});
+
+	it("rejects unsafe custom compaction thresholds on a memory-only node", async () => {
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-memory-native-unsafe-compaction-"),
+		);
+		client = await Peerbit.create(createRustPeerbitOptions());
+		const storeId = new Uint8Array(32).fill(43);
+		const store = new TestStore<Document>({
+			docs: new Documents<Document>({ id: storeId }),
+		});
+		store.id = storeId;
+		const persistence = new NativeBackboneNodeCoordinatePersistence(
+			path.join(directory, "coordinate-wal"),
+			{ flushOnAppend: true },
+		);
+		const adapter = {
+			...wrapCoordinatePersistence(persistence, false),
+			compactMaxJournalRecords: 1,
+			crashSafeCompaction: false,
+		};
+		let openError: unknown;
+		await client
+			.open(store, {
+				args: createOpenArgs(directory, false, false, adapter),
+			})
+			.catch((error) => {
+				openError = error;
+			});
+		expect(String(openError)).to.contain(
+			"compaction thresholds require crashSafeCompaction",
+		);
+	});
+
+	it("drops a persistent custom adapter on a memory-only node", async () => {
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-memory-native-drop-adapter-"),
+		);
+		const coordinateDirectory = path.join(directory, "coordinate-wal");
+		const storeId = new Uint8Array(32).fill(42);
+		client = await Peerbit.create(createRustPeerbitOptions());
+		const firstStore = new TestStore<Document>({
+			docs: new Documents<Document>({ id: storeId }),
+		});
+		firstStore.id = storeId;
+		const firstPersistence = new NativeBackboneNodeCoordinatePersistence(
+			coordinateDirectory,
+			{ flushOnAppend: true },
+		);
+		await client.open(firstStore, {
+			args: createOpenArgs(
+				directory,
+				false,
+				false,
+				wrapCoordinatePersistence(firstPersistence, false, true),
+			),
+		});
+		await firstStore.docs.put(
+			new Document({ id: "memory-drop", name: "erase-me" }),
+			{ unique: true, replicate: false, target: "none" },
+		);
+
+		await firstStore.drop();
+		await client.stop();
+		client = undefined;
+		await expectNativePersistenceErased(directory);
+
+		client = await Peerbit.create(createRustPeerbitOptions());
+		const reopenedStore = new TestStore<Document>({
+			docs: new Documents<Document>({ id: storeId }),
+		});
+		reopenedStore.id = storeId;
+		const reopenedPersistence = new NativeBackboneNodeCoordinatePersistence(
+			coordinateDirectory,
+			{ flushOnAppend: true },
+		);
+		await client.open(reopenedStore, {
+			args: createOpenArgs(
+				directory,
+				false,
+				false,
+				wrapCoordinatePersistence(reopenedPersistence, false, true),
+			),
+		});
+		expect(await reopenedStore.docs.get("memory-drop")).equal(undefined);
+		expect((reopenedStore.docs.log as any).log.length).equal(0);
+		await expectNativePersistenceErased(directory);
+	});
+
+	it("durably drops native rows, heads, documents, blocks, and all persistence files", async () => {
+		const first = await openStore();
+		const acknowledged = await first.store.docs.put(
+			new Document({ id: "durable-drop", name: "erase-me" }),
+			{ unique: true, replicate: false, target: "none" },
+		);
+		expect(await first.store.docs.get("durable-drop")).to.not.equal(undefined);
+		expect(await first.durable.has(acknowledged.entry.hash)).equal(true);
+
+		await first.store.drop();
+		await client!.stop();
+		client = undefined;
+		await expectNativePersistenceErased(directory!);
+
+		const reopened = await createStore(directory!);
+		expect(await reopened.store.docs.get("durable-drop")).equal(undefined);
+		expect(reopened.sharedLog.log.length).equal(0);
+		expect(
+			await reopened.sharedLog.log.entryIndex.has(acknowledged.entry.hash),
+		).equal(false);
+		expect(await reopened.sharedLog.log.getHeads().all()).deep.equal([]);
+		expect(reopened.backbone.blocks.get(acknowledged.entry.hash)).equal(
+			undefined,
+		);
+		expect(await reopened.durable.has(acknowledged.entry.hash)).equal(false);
+		await expectNativePersistenceErased(directory!);
+	});
+
+	for (const lowerMarkerCommitted of [true, false]) {
+		it(`drops and does not replay a retained ${
+			lowerMarkerCommitted ? "committed" : "uncommitted"
+		} native intent`, async () => {
+			const first = await openStore();
+			const id = lowerMarkerCommitted
+				? "retained-committed-drop"
+				: "retained-uncommitted-drop";
+			const acknowledged = await first.store.docs.put(
+				new Document({ id, name: "erase-retained-intent" }),
+				{ unique: true, replicate: false, target: "none" },
+			);
+			await first.sharedLog.writeNativeStrictDurableTransactionIntent({
+				version: 1,
+				lowerMarkerCommitted,
+				appendHashes: [acknowledged.entry.hash],
+				trimHashes: [],
+				coordinateDeleteHashes: [],
+				lowerIndexRows: [],
+				coordinates: [],
+				documents: [
+					{
+						key: id,
+						byteElementIndexLimit: 0,
+					},
+				],
+			});
+			expect(
+				first.sharedLog._nativeStrictDurableTransactionJournalState.intent
+					.lowerMarkerCommitted,
+			).equal(lowerMarkerCommitted);
+
+			await first.store.drop();
+			await client!.stop();
+			client = undefined;
+			await expectNativePersistenceErased(directory!);
+
+			const reopened = await createStore(directory!);
+			expect(await reopened.store.docs.get(id)).equal(undefined);
+			expect(reopened.sharedLog.log.length).equal(0);
+			expect(
+				await reopened.sharedLog.log.entryIndex.has(acknowledged.entry.hash),
+			).equal(false);
+			expect(
+				reopened.sharedLog._nativeStrictDurableTransactionJournalState.intent,
+			).equal(undefined);
+		});
+	}
+
+	it("resumes a tombstoned native drop after an injected removal failure", async () => {
+		const first = await openStore();
+		const acknowledged = await first.store.docs.put(
+			new Document({ id: "interrupted-drop", name: "erase-on-resume" }),
+			{ unique: true, replicate: false, target: "none" },
+		);
+		const persistenceStore = first.sharedLog
+			._nativeBackboneCoordinatePersistenceStore as {
+			remove: (name: string) => Promise<void>;
+		};
+		const originalRemove = persistenceStore.remove.bind(persistenceStore);
+		const removalFailure = new Error(
+			"injected native namespace removal failure",
+		);
+		let injected = false;
+		persistenceStore.remove = async (name) => {
+			if (name === "document-values.wal" && !injected) {
+				injected = true;
+				throw removalFailure;
+			}
+			await originalRemove(name);
+		};
+		let dropError: unknown;
+		try {
+			await first.store.drop();
+		} catch (error) {
+			dropError = error;
+		} finally {
+			persistenceStore.remove = originalRemove;
+		}
+		expect(injected).equal(true);
+		expect(dropError).to.be.instanceOf(AggregateError);
+		await fs.stat(
+			path.join(directory!, "coordinate-wal", "native-backbone-drop.tombstone"),
+		);
+
+		await client!.stop();
+		client = undefined;
+		const reopened = await createStore(directory!);
+		expect(await reopened.store.docs.get("interrupted-drop")).equal(undefined);
+		expect(
+			await reopened.sharedLog.log.entryIndex.has(acknowledged.entry.hash),
+		).equal(true);
+		expect(reopened.backbone.documentValueBytes("interrupted-drop")).equal(
+			undefined,
+		);
+		await expectNativePersistenceErased(directory!);
+	});
+
+	it("rejects a durable custom adapter without drop before lower mutation", async () => {
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-durable-native-no-drop-adapter-"),
+		);
+		const persistence = new NativeBackboneNodeCoordinatePersistence(
+			path.join(directory, "coordinate-wal"),
+			{ flushOnAppend: true },
+		);
+		const first = await createStore(
+			directory,
+			false,
+			false,
+			wrapCoordinatePersistence(persistence, true, false),
+		);
+		const acknowledged = await first.store.docs.put(
+			new Document({ id: "no-drop-capability", name: "must-remain" }),
+			{ unique: true, replicate: false, target: "none" },
+		);
+		let dropError: unknown;
+		try {
+			await first.sharedLog.drop();
+		} catch (error) {
+			dropError = error;
+		}
+		expect(String(dropError)).to.contain("terminal underlying drop capability");
+		expect(first.sharedLog.closed).equal(false);
+		expect(first.sharedLog.log.length).equal(1);
+		expect(
+			await first.sharedLog.log.entryIndex.has(acknowledged.entry.hash),
+		).equal(true);
+		expect((await first.store.docs.get("no-drop-capability"))?.name).equal(
+			"must-remain",
+		);
+	});
+
+	it("rejects a wrapper whose underlying store can not remove before lower mutation", async () => {
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-durable-native-store-no-remove-"),
+		);
+		const inner = new NativeBackboneNodeCoordinatePersistenceStore(
+			path.join(directory, "coordinate-wal"),
+		);
+		const storeWithoutRemove = {
+			read: inner.read.bind(inner),
+			write: inner.write.bind(inner),
+			append: inner.append.bind(inner),
+			durableBarrier: inner.durableBarrier!.bind(inner),
+			close: inner.close.bind(inner),
+		};
+		const first = await createStore(directory, false, false, {
+			store: storeWithoutRemove,
+			buffered: true,
+			flushOnAppend: true,
+		});
+		const acknowledged = await first.store.docs.put(
+			new Document({ id: "no-store-remove", name: "must-remain" }),
+			{ unique: true, replicate: false, target: "none" },
+		);
+		const dropError = await first.sharedLog.drop().then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(String(dropError)).to.contain("terminal underlying drop capability");
+		expect(first.sharedLog.closed).equal(false);
+		expect(first.sharedLog.log.length).equal(1);
+		expect(
+			await first.sharedLog.log.entryIndex.has(acknowledged.entry.hash),
+		).equal(true);
+		expect((await first.store.docs.get("no-store-remove"))?.name).equal(
+			"must-remain",
+		);
+	});
+
+	it("does not call an ordinary custom close after terminal drop", async () => {
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-durable-native-terminal-drop-"),
+		);
+		const coordinateDirectory = path.join(directory, "coordinate-wal");
+		const persistence = new NativeBackboneNodeCoordinatePersistence(
+			coordinateDirectory,
+			{ flushOnAppend: true },
+		);
+		let closeCalls = 0;
+		const adapter = {
+			...wrapCoordinatePersistence(persistence, true, true),
+			close: async () => {
+				closeCalls++;
+				await fs.mkdir(coordinateDirectory, { recursive: true });
+				await fs.writeFile(
+					path.join(coordinateDirectory, "coordinates.wal"),
+					new Uint8Array([1, 2, 3]),
+				);
+			},
+		};
+		const first = await createStore(directory, false, false, adapter);
+		await first.store.docs.put(
+			new Document({ id: "terminal-drop", name: "erase-me" }),
+			{ unique: true, replicate: false, target: "none" },
+		);
+
+		await first.store.drop();
+		expect(closeCalls).equal(0);
+		await expectNativePersistenceErased(directory);
+	});
+
+	it("fully compensates a direct native commit when the operation intent write fails", async () => {
+		const { store, sharedLog, durable, backbone } = await openStore(true);
+		const forceDirectFallback = sinon
+			.stub(sharedLog, "canUseNativeBackboneResidentCoordinateState")
+			.returns(false);
+		const intentStore = sharedLog._nativeBackboneCoordinatePersistenceStore as {
+			write: (name: string, bytes: Uint8Array) => Promise<void>;
+		};
+		const originalWrite = intentStore.write.bind(intentStore);
+		let intentWrites = 0;
+		const intentFailure = new Error("injected operation-intent write failure");
+		intentStore.write = async (name, bytes) => {
+			let record: any;
+			try {
+				record = JSON.parse(new TextDecoder().decode(bytes));
+			} catch {}
+			if (record?.state === "intent" && ++intentWrites === 2) {
+				throw intentFailure;
+			}
+			await originalWrite(name, bytes);
+		};
+
+		const originalPrepare = backbone.graph.prepareEntryV0PlainEntryCommit.bind(
+			backbone.graph,
+		);
+		let failedHash: string | undefined;
+		const prepareStub = sinon
+			.stub(backbone.graph, "prepareEntryV0PlainEntryCommit")
+			.callsFake((...args: any[]) => {
+				const prepared = originalPrepare(...args);
+				failedHash = prepared?.cid ?? prepared?.hash;
+				return prepared;
+			});
+		let appendError: unknown;
+		try {
+			await store.docs.put(
+				new Document({ id: "intent-failure", name: "must-rollback" }),
+				{ unique: true, replicate: false, target: "none" },
+			);
+		} catch (error) {
+			appendError = error;
+		} finally {
+			intentStore.write = originalWrite;
+			prepareStub.restore();
+			forceDirectFallback.restore();
+		}
+		expect(appendError).equal(intentFailure);
+		expect(intentWrites).equal(2);
+		expect(failedHash).to.be.a("string").and.not.empty;
+		expect(await store.docs.get("intent-failure")).equal(undefined);
+		expect(sharedLog.log.length).equal(0);
+		expect(await sharedLog.log.entryIndex.has(failedHash!)).equal(false);
+		expect(backbone.graph.hasMany([failedHash!]).has(failedHash!)).equal(false);
+		expect(backbone.blocks.get(failedHash!)).equal(undefined);
+		expect(await durable.has(failedHash!)).equal(false);
+		expect(
+			sharedLog._residentEntryCoordinatesByHash?.has(failedHash!) ?? false,
+		).equal(false);
+		expect(sharedLog._nativeStrictDurableTransactionJournalState.intent).equal(
+			undefined,
+		);
+
+		const later = await store.docs.put(
+			new Document({ id: "after-intent-failure", name: "survives" }),
+			{ unique: true, replicate: false, target: "none" },
+		);
+		await client!.stop();
+		client = undefined;
+		const reopened = await createStore(directory!, true);
+		expect(await reopened.store.docs.get("intent-failure")).equal(undefined);
+		expect((await reopened.store.docs.get("after-intent-failure"))?.name).equal(
+			"survives",
+		);
+		expect(await reopened.sharedLog.log.entryIndex.has(later.entry.hash)).equal(
+			true,
+		);
+	});
+
+	it("recovers the last valid intent generation after SIGKILL during a marker write", async function () {
+		if (process.platform === "win32") this.skip();
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-durable-native-intent-torn-kill-"),
+		);
+		const workerPath = path.join(
+			process.cwd(),
+			"test/durable-native-hard-kill-worker.mjs",
+		);
+		const writer = spawn(
+			process.execPath,
+			[workerPath, "intent-marker-write", directory],
+			{ stdio: ["ignore", "pipe", "pipe"] },
+		);
+		const writerExit = once(writer, "exit");
+		let interrupted:
+			| { event: "intent-marker-partial"; hash: string }
+			| undefined;
+		try {
+			interrupted = await waitForWorkerMessage(
+				writer,
+				"partial durable intent marker",
+			);
+			expect(writer.kill("SIGKILL")).equal(true);
+			await within(
+				writerExit.then(() => undefined),
+				"partial intent writer exit",
+			);
+		} finally {
+			if (writer.exitCode === null && writer.signalCode === null) {
+				writer.kill("SIGKILL");
+			}
+		}
+		if (!interrupted) throw new Error("Writer did not tear the marker intent");
+
+		const reader = spawn(
+			process.execPath,
+			[workerPath, "read", directory, interrupted.hash],
+			{ stdio: ["ignore", "pipe", "pipe"] },
+		);
+		const readerExit = once(reader, "exit") as Promise<
+			[number | null, NodeJS.Signals | null]
+		>;
+		try {
+			const reopened = await waitForWorkerMessage<{
+				event: "read";
+				documentName?: string;
+				entryHash?: string;
+			}>(reader, "partial intent recovery");
+			expect(reopened).deep.equal({
+				event: "read",
+				documentName: "hard-kill",
+				entryHash: interrupted.hash,
+			});
+			expect((await within(readerExit, "partial intent reader exit"))[0]).equal(
+				0,
+			);
+		} finally {
+			if (reader.exitCode === null && reader.signalCode === null) {
+				reader.kill("SIGKILL");
+			}
+		}
+	});
+
+	it("preserves a later generic receive when recovering a torn strict marker after SIGKILL", async function () {
+		if (process.platform === "win32") this.skip();
+		directory = await fs.mkdtemp(
+			path.join(
+				os.tmpdir(),
+				"peerbit-durable-native-strict-generic-torn-kill-",
+			),
+		);
+		const workerPath = path.join(
+			process.cwd(),
+			"test/durable-native-hard-kill-worker.mjs",
+		);
+		const writer = spawn(
+			process.execPath,
+			[workerPath, "strict-generic-torn-marker-write", directory],
+			{ stdio: ["ignore", "pipe", "pipe"] },
+		);
+		const writerExit = once(writer, "exit");
+		let raced:
+			| {
+					event: "strict-generic-torn-marker";
+					strictHash: string;
+					genericHash: string;
+					strictIndexed: boolean;
+					genericIndexed: boolean;
+					strictHead: boolean;
+					genericHead: boolean;
+					headHashes: string[];
+			  }
+			| undefined;
+		try {
+			const writerResult = await waitForWorkerMessage<
+				NonNullable<typeof raced>
+			>(writer, "strict/generic torn-marker race");
+			raced = writerResult;
+			expect(writerResult.strictIndexed).equal(true);
+			expect(writerResult.genericIndexed).equal(true);
+			expect(writerResult.strictHead).equal(false);
+			expect(writerResult.genericHead).equal(true);
+			expect(writerResult.headHashes).deep.equal([writerResult.genericHash]);
+			expect(writer.kill("SIGKILL")).equal(true);
+			await within(
+				writerExit.then(() => undefined),
+				"strict/generic torn-marker writer exit",
+			);
+		} finally {
+			if (writer.exitCode === null && writer.signalCode === null) {
+				writer.kill("SIGKILL");
+			}
+		}
+		if (!raced) throw new Error("Writer did not complete the receive race");
+
+		const reader = spawn(
+			process.execPath,
+			[
+				workerPath,
+				"strict-generic-torn-marker-read",
+				directory,
+				raced.strictHash,
+				raced.genericHash,
+			],
+			{ stdio: ["ignore", "pipe", "pipe"] },
+		);
+		const readerExit = once(reader, "exit") as Promise<
+			[number | null, NodeJS.Signals | null]
+		>;
+		try {
+			const reopened = await waitForWorkerMessage<{
+				event: "strict-generic-torn-marker-read";
+				lowerLogLength: number;
+				strictIndexed: boolean;
+				genericIndexed: boolean;
+				strictHead: boolean;
+				genericHead: boolean;
+				headHashes: string[];
+			}>(reader, "strict/generic torn-marker recovery");
+			expect(reopened).deep.equal({
+				event: "strict-generic-torn-marker-read",
+				lowerLogLength: 2,
+				strictIndexed: true,
+				genericIndexed: true,
+				strictHead: false,
+				genericHead: true,
+				headHashes: [raced.genericHash],
+			});
+			expect(
+				(await within(readerExit, "strict/generic torn-marker reader exit"))[0],
+			).equal(0);
+		} finally {
+			if (reader.exitCode === null && reader.signalCode === null) {
+				reader.kill("SIGKILL");
+			}
+		}
+	});
+
+	it("does not infer a torn marker from pre-existing append presence", async () => {
+		const first = await openStore();
+		const existing = await first.store.docs.put(
+			new Document({ id: "existing-marker-row", name: "existing" }),
+			{ replicate: false, target: "none" },
+		);
+		const indexed = await first.sharedLog.log.entryIndex.getShallow(
+			existing.entry.hash,
+		);
+		expect(indexed).to.not.equal(undefined);
+		const before = [...serialize(indexed!.value)];
+		const afterRow = deserialize(Uint8Array.from(before), ShallowEntry);
+		afterRow.head = !afterRow.head;
+		const journal = first.sharedLog
+			._nativeStrictDurableTransactionJournalState as {
+			intent?: unknown;
+		};
+		journal.intent = {
+			version: 1,
+			lowerMarkerCommitted: false,
+			appendHashes: [existing.entry.hash],
+			trimHashes: [],
+			coordinateDeleteHashes: [],
+			lowerIndexRows: [
+				{
+					hash: existing.entry.hash,
+					before,
+					after: [...serialize(afterRow)],
+				},
+			],
+			coordinates: [],
+			documents: [
+				{
+					key: "existing-marker-rollback-probe",
+					byteElementIndexLimit: 0,
+				},
+			],
+		};
+		const restoreDocument = sinon.spy(
+			first.sharedLog,
+			"restoreNativeBackboneDocument",
+		);
+		try {
+			await first.sharedLog.recoverNativeStrictDurableTransactionIntent();
+		} finally {
+			restoreDocument.restore();
+		}
+		expect(restoreDocument.calledOnce).equal(true);
+		expect(restoreDocument.firstCall.args[0].key).equal(
+			"existing-marker-rollback-probe",
+		);
+		expect(await first.sharedLog.log.entryIndex.has(existing.entry.hash)).equal(
+			true,
+		);
+		expect(
+			first.sharedLog._nativeStrictDurableTransactionJournalState.intent,
+		).equal(undefined);
+
+		const legacyJournal = first.sharedLog
+			._nativeStrictDurableTransactionJournalState as {
+			intent?: unknown;
+		};
+		legacyJournal.intent = {
+			version: 1,
+			lowerMarkerCommitted: false,
+			appendHashes: [existing.entry.hash],
+			trimHashes: [],
+			coordinateDeleteHashes: [],
+			lowerIndexRows: [],
+			coordinates: [],
+			documents: [
+				{
+					key: "legacy-existing-marker-rollback-probe",
+					byteElementIndexLimit: 0,
+				},
+			],
+		};
+		const restoreLegacyDocument = sinon.spy(
+			first.sharedLog,
+			"restoreNativeBackboneDocument",
+		);
+		try {
+			await first.sharedLog.recoverNativeStrictDurableTransactionIntent();
+		} finally {
+			restoreLegacyDocument.restore();
+		}
+		expect(restoreLegacyDocument.calledOnce).equal(true);
+		expect(restoreLegacyDocument.firstCall.args[0].key).equal(
+			"legacy-existing-marker-rollback-probe",
+		);
+		expect(await first.sharedLog.log.entryIndex.has(existing.entry.hash)).equal(
+			true,
+		);
+	});
+
+	it("serializes a generic receive batch behind an in-process strict rollback", async () => {
+		const first = await openStore();
+		const entryIndex = first.sharedLog.log.entryIndex;
+		const lowerIndex = entryIndex.properties.index;
+		const originalPut = lowerIndex.put.bind(lowerIndex);
+		const indexFailure = new Error("injected strict lower-index failure");
+		let sourceClient: Peerbit | undefined;
+		let genericMutation: Promise<unknown> | undefined;
+		let strictHash: string | undefined;
+		let genericHash: string | undefined;
+		let strictBytes: Uint8Array | undefined;
+		let genericBytes: Uint8Array | undefined;
+		let injected = false;
+		lowerIndex.put = async (value: ShallowEntry) => {
+			await originalPut(value);
+			if (injected) return;
+			injected = true;
+			lowerIndex.put = originalPut;
+			strictHash = value.hash;
+			const strictEntry = await first.sharedLog.log.get(strictHash);
+			strictBytes = await first.sharedLog.log.blocks.get(strictHash);
+			if (!strictEntry || !strictBytes) {
+				throw new Error("Expected strict entry facts before lower rollback");
+			}
+
+			sourceClient = await Peerbit.create(createRustPeerbitOptions());
+			const storeId = new Uint8Array(32);
+			for (let index = 0; index < storeId.length; index++) {
+				storeId[index] = (index * 13 + 7) & 0xff;
+			}
+			const sourceStore = new TestStore<Document>({
+				docs: new Documents<Document>({ id: storeId }),
+			});
+			sourceStore.id = storeId;
+			await sourceClient.open(sourceStore, {
+				args: {
+					replicate: false,
+					canPerform: policy.allowAll<Document>(),
+					index: {
+						type: Document,
+						transform: transform.identity<Document>(),
+					},
+				},
+			});
+			await sourceStore.docs.log.log.blocks.putKnown!(strictHash, strictBytes);
+			await sourceStore.docs.log.log.join([strictEntry]);
+			const generic = await sourceStore.docs.put(
+				new Document({ id: "rollback-generic-y", name: "generic" }),
+				{
+					replicate: false,
+					target: "none",
+					meta: { next: [strictEntry] },
+				},
+			);
+			genericHash = generic.entry.hash;
+			genericBytes = await sourceStore.docs.log.log.blocks.get(genericHash);
+			if (!genericBytes) throw new Error("Expected generic receive bytes");
+
+			const queuedGenericMutation = entryIndex
+				.putAppendBatch([strictEntry, generic.entry], {
+					unique: false,
+					heads: [false, true],
+				})
+				.then(
+					() => undefined,
+					(error: unknown) => error,
+				);
+			genericMutation = queuedGenericMutation;
+			let genericSettled = false;
+			void queuedGenericMutation.then(() => {
+				genericSettled = true;
+			});
+			await new Promise((resolve) => setTimeout(resolve, 25));
+			expect(genericSettled).equal(false);
+			throw indexFailure;
+		};
+
+		try {
+			const strictError = await first.store.docs
+				.put(new Document({ id: "rollback-strict-x", name: "must-rollback" }), {
+					replicate: false,
+					target: "none",
+				})
+				.then(
+					() => undefined,
+					(error: unknown) => error,
+				);
+			expect(strictError).to.be.instanceOf(Error);
+			expect(injected).equal(true);
+			expect(genericMutation).to.not.equal(undefined);
+			expect(await genericMutation!).equal(undefined);
+			if (!strictHash || !genericHash || !strictBytes || !genericBytes) {
+				throw new Error("Missing strict/generic rollback race facts");
+			}
+			await first.sharedLog.log.blocks.putKnown(strictHash, strictBytes);
+			await first.sharedLog.log.blocks.putKnown(genericHash, genericBytes);
+			const strictRow = await entryIndex.getShallow(strictHash);
+			const genericRow = await entryIndex.getShallow(genericHash);
+			const heads = await first.sharedLog.log.getHeads().all();
+			expect(await entryIndex.has(strictHash)).equal(true);
+			expect(await entryIndex.has(genericHash)).equal(true);
+			expect(strictRow?.value.head).equal(false);
+			expect(genericRow?.value.head).equal(true);
+			expect(heads.map((entry: { hash: string }) => entry.hash)).deep.equal([
+				genericHash,
+			]);
+			expect(first.sharedLog.log.length).equal(2);
+			expect(
+				first.sharedLog._nativeStrictDurableTransactionJournalState.intent,
+			).equal(undefined);
+		} finally {
+			lowerIndex.put = originalPut;
+			await sourceClient?.stop();
+		}
+	});
+
+	it("keeps an acknowledged marker authoritative and poisons mutations when intent retirement fails", async () => {
+		const first = await openStore();
+		const intentStore = first.sharedLog
+			._nativeBackboneCoordinatePersistenceStore as {
+			write: (name: string, bytes: Uint8Array) => Promise<void>;
+		};
+		const originalWrite = intentStore.write.bind(intentStore);
+		let clearRejected = false;
+		let sawTrueMarker = false;
+		let queuedDirectLowerMutation: Promise<unknown> | undefined;
+		intentStore.write = async (name, bytes) => {
+			let record: any;
+			try {
+				record = JSON.parse(new TextDecoder().decode(bytes));
+			} catch {}
+			if (record?.intent?.lowerMarkerCommitted === true) {
+				sawTrueMarker = true;
+				const hash = record.intent.appendHashes[0] as string;
+				queuedDirectLowerMutation ??= first.sharedLog.log.entryIndex
+					.delete(hash)
+					.then(
+						() => undefined,
+						(error: unknown) => error,
+					);
+			}
+			if (!clearRejected && sawTrueMarker && record?.state === "cleared") {
+				clearRejected = true;
+				throw new Error("injected intent retirement failure");
+			}
+			await originalWrite(name, bytes);
+		};
+
+		const acknowledged = await first.store.docs.put(
+			new Document({ id: "intent-retirement", name: "acknowledged" }),
+		);
+		expect(clearRejected).equal(true);
+		expect(queuedDirectLowerMutation).to.not.equal(undefined);
+		const directLowerMutationError = await queuedDirectLowerMutation!;
+		expect(directLowerMutationError).to.be.instanceOf(Error);
+		expect((directLowerMutationError as Error).message).to.contain(
+			"retained native durable transaction intent",
+		);
+		expect(
+			await first.sharedLog.log.entryIndex.has(acknowledged.entry.hash),
+		).equal(true);
+		const directLogMutationError = await first.sharedLog.log
+			.join([acknowledged.entry], { reset: true })
+			.then(
+				() => undefined,
+				(error: unknown) => error,
+			);
+		expect(directLogMutationError).to.be.instanceOf(Error);
+		expect((directLogMutationError as Error).message).to.contain(
+			"retained native durable transaction intent",
+		);
+		let laterMutationError: unknown;
+		try {
+			await first.store.docs.put(
+				new Document({ id: "must-not-run", name: "must-not-run" }),
+			);
+		} catch (error) {
+			laterMutationError = error;
+		}
+		expect(laterMutationError).to.be.instanceOf(Error);
+		expect((laterMutationError as Error).message).to.contain(
+			"recovery is required",
+		);
+
+		// Reproduce the exact adverse row evolution from the review. Even if an
+		// internal actor bypassed the poison and demoted the row, the persisted true
+		// marker is monotonic and recovery must never restore the pre-append absence.
+		const indexed = await first.sharedLog.log.entryIndex.getShallow(
+			acknowledged.entry.hash,
+		);
+		expect(indexed).to.not.equal(undefined);
+		indexed!.value.head = false;
+		await first.sharedLog.log.entryIndex.properties.index.put(indexed!.value);
+		intentStore.write = originalWrite;
+		await client!.stop();
+		client = undefined;
+
+		const reopened = await createStore(directory!);
+		expect(
+			await reopened.sharedLog.log.entryIndex.has(acknowledged.entry.hash),
+		).equal(true);
+		expect(reopened.sharedLog.log.length).equal(1);
+		expect((await reopened.store.docs.get("intent-retirement"))?.name).equal(
+			"acknowledged",
+		);
+	});
+
+	it("keeps a true marker authoritative when a legacy intent has no row snapshots", async () => {
+		const first = await openStore();
+		const intentStore = first.sharedLog
+			._nativeBackboneCoordinatePersistenceStore as {
+			write: (name: string, bytes: Uint8Array) => Promise<void>;
+		};
+		const originalWrite = intentStore.write.bind(intentStore);
+		let clearRejected = false;
+		let sawTrueMarker = false;
+		intentStore.write = async (name, bytes) => {
+			let record: any;
+			try {
+				record = JSON.parse(new TextDecoder().decode(bytes));
+			} catch {}
+			if (record?.intent?.lowerMarkerCommitted === true) {
+				sawTrueMarker = true;
+			}
+			if (!clearRejected && sawTrueMarker && record?.state === "cleared") {
+				clearRejected = true;
+				throw new Error("injected legacy intent retirement failure");
+			}
+			await originalWrite(name, bytes);
+		};
+
+		await first.store.docs.put(
+			new Document({ id: "empty-row-marker", name: "committed" }),
+		);
+		const journal = first.sharedLog
+			._nativeStrictDurableTransactionJournalState as {
+			intent?: { lowerMarkerCommitted: boolean; lowerIndexRows: unknown[] };
+		};
+		expect(journal.intent?.lowerMarkerCommitted).equal(true);
+		journal.intent!.lowerIndexRows = [];
+		const hasManyStub = sinon
+			.stub(first.sharedLog.log.entryIndex, "hasMany")
+			.resolves(new Set());
+		try {
+			await first.sharedLog.recoverNativeStrictDurableTransactionIntent();
+		} finally {
+			hasManyStub.restore();
+			intentStore.write = originalWrite;
+		}
+		expect((await first.store.docs.get("empty-row-marker"))?.name).equal(
+			"committed",
+		);
+	});
+
+	it("retains a true marker for recovery when rollback demotion cannot be persisted", async () => {
+		const first = await openStore(true);
+		const old = await first.store.docs.put(
+			new Document({ id: "rollback-marker-old", name: "old" }),
+			{ unique: true },
+		);
+		const intentStore = first.sharedLog
+			._nativeBackboneCoordinatePersistenceStore as {
+			write: (name: string, bytes: Uint8Array) => Promise<void>;
+		};
+		const originalWrite = intentStore.write.bind(intentStore);
+		let sawTrueMarker = false;
+		let rejectedRollbackMarker = false;
+		let replacementHash: string | undefined;
+		intentStore.write = async (name, bytes) => {
+			let record: any;
+			try {
+				record = JSON.parse(new TextDecoder().decode(bytes));
+			} catch {}
+			if (record?.intent?.lowerMarkerCommitted === true) {
+				sawTrueMarker = true;
+				replacementHash = record.intent.appendHashes[0];
+			} else if (
+				sawTrueMarker &&
+				record?.intent?.lowerMarkerCommitted === false
+			) {
+				rejectedRollbackMarker = true;
+				throw new Error("injected rollback-marker write failure");
+			}
+			await originalWrite(name, bytes);
+		};
+		const trimFailure = new Error("injected post-marker trim failure");
+		const trimStub = sinon
+			.stub(first.sharedLog.log.entryIndex, "flushNativeCommittedTrimFacts")
+			.rejects(trimFailure);
+
+		let appendError: unknown;
+		try {
+			await first.store.docs.put(
+				new Document({ id: "rollback-marker-new", name: "new" }),
+				{ unique: true },
+			);
+		} catch (error) {
+			appendError = error;
+		}
+		expect(appendError).to.be.instanceOf(AggregateError);
+		expect(sawTrueMarker).equal(true);
+		expect(rejectedRollbackMarker).equal(true);
+		expect(replacementHash).to.be.a("string");
+
+		let laterMutationError: unknown;
+		try {
+			await first.store.docs.put(
+				new Document({ id: "rollback-marker-must-not-run", name: "blocked" }),
+			);
+		} catch (error) {
+			laterMutationError = error;
+		}
+		expect(laterMutationError).to.be.instanceOf(Error);
+		expect((laterMutationError as Error).message).to.contain(
+			"recovery is required",
+		);
+
+		intentStore.write = originalWrite;
+		trimStub.restore();
+		await client!.stop();
+		client = undefined;
+		const reopened = await createStore(directory!, true);
+		expect(reopened.sharedLog.log.length).equal(1);
+		expect(await reopened.sharedLog.log.entryIndex.has(replacementHash!)).equal(
+			true,
+		);
+		expect(await reopened.sharedLog.log.entryIndex.has(old.entry.hash)).equal(
+			false,
+		);
+		expect((await reopened.store.docs.get("rollback-marker-new"))?.name).equal(
+			"new",
+		);
+		expect(await reopened.store.docs.get("rollback-marker-old")).equal(
+			undefined,
+		);
+	});
+
+	it("settles a post-marker trim failure before concurrent close tears down recovery state", async () => {
+		const first = await openStore(true);
+		const old = await first.store.docs.put(
+			new Document({ id: "close-race", name: "old" }),
+			{ unique: true },
+		);
+		let markTrimStarted!: () => void;
+		const trimStarted = new Promise<void>((resolve) => {
+			markTrimStarted = resolve;
+		});
+		let releaseTrim!: () => void;
+		const trimGate = new Promise<void>((resolve) => {
+			releaseTrim = resolve;
+		});
+		const trimFailure = new Error("injected close-race trim failure");
+		const trimStub = sinon
+			.stub(first.sharedLog.log.entryIndex, "flushNativeCommittedTrimFacts")
+			.callsFake(async () => {
+				markTrimStarted();
+				await trimGate;
+				throw trimFailure;
+			});
+
+		try {
+			const append = first.store.docs
+				.put(new Document({ id: "close-race", name: "replacement" }), {
+					unique: true,
+				})
+				.then(
+					() => undefined,
+					(error: unknown) => error,
+				);
+			await within(trimStarted, "post-marker trim flush");
+			expect(
+				first.sharedLog._nativeStrictDurableTransactionJournalState.intent
+					.lowerMarkerCommitted,
+			).equal(true);
+
+			let closeSettled = false;
+			const close = first.sharedLog.close().then(
+				(value: boolean) => value,
+				(error: unknown) => error,
+			);
+			void close.then(() => {
+				closeSettled = true;
+			});
+			await new Promise((resolve) => setTimeout(resolve, 25));
+			expect(closeSettled).equal(false);
+
+			releaseTrim();
+			expect(await append).equal(trimFailure);
+			expect(await within(close, "concurrent shared-log close")).equal(true);
+		} finally {
+			releaseTrim();
+			trimStub.restore();
+		}
+
+		await client!.stop();
+		client = undefined;
+		const reopened = await createStore(directory!, true);
+		expect(reopened.sharedLog.log.length).equal(1);
+		expect(await reopened.sharedLog.log.entryIndex.has(old.entry.hash)).equal(
+			true,
+		);
+		expect(
+			(await reopened.sharedLog.log.getHeads().all()).map(
+				(entry: { hash: string }) => entry.hash,
+			),
+		).deep.equal([old.entry.hash]);
+		expect((await reopened.store.docs.get("close-race"))?.name).equal("old");
+		expect(
+			reopened.sharedLog._nativeStrictDurableTransactionJournalState.intent,
+		).equal(undefined);
+		const afterRecovery = await reopened.store.docs.put(
+			new Document({ id: "close-race-after", name: "after" }),
+			{ unique: true },
+		);
+		expect(afterRecovery.entry.hash).to.be.a("string").and.not.empty;
+	});
+
+	it("retains the lower finalizer before concurrent close when rollback-marker persistence fails", async () => {
+		const first = await openStore(true);
+		const old = await first.store.docs.put(
+			new Document({ id: "close-marker-race", name: "old" }),
+			{ unique: true },
+		);
+		const intentStore = first.sharedLog
+			._nativeBackboneCoordinatePersistenceStore as {
+			write: (name: string, bytes: Uint8Array) => Promise<void>;
+		};
+		const originalWrite = intentStore.write.bind(intentStore);
+		let replacementHash: string | undefined;
+		let rejectedRollbackMarker = false;
+		intentStore.write = async (name, bytes) => {
+			let record: any;
+			try {
+				record = JSON.parse(new TextDecoder().decode(bytes));
+			} catch {}
+			if (record?.intent?.lowerMarkerCommitted === true) {
+				replacementHash = record.intent.appendHashes[0];
+			} else if (
+				replacementHash &&
+				record?.intent?.lowerMarkerCommitted === false
+			) {
+				rejectedRollbackMarker = true;
+				throw new Error("injected close-race rollback-marker failure");
+			}
+			await originalWrite(name, bytes);
+		};
+		let markTrimStarted!: () => void;
+		const trimStarted = new Promise<void>((resolve) => {
+			markTrimStarted = resolve;
+		});
+		let releaseTrim!: () => void;
+		const trimGate = new Promise<void>((resolve) => {
+			releaseTrim = resolve;
+		});
+		const trimStub = sinon
+			.stub(first.sharedLog.log.entryIndex, "flushNativeCommittedTrimFacts")
+			.callsFake(async () => {
+				markTrimStarted();
+				await trimGate;
+				throw new Error("injected close-race post-marker trim failure");
+			});
+
+		try {
+			const append = first.store.docs
+				.put(new Document({ id: "close-marker-race", name: "replacement" }), {
+					unique: true,
+				})
+				.then(
+					() => undefined,
+					(error: unknown) => error,
+				);
+			await within(trimStarted, "rollback-marker close race trim flush");
+			expect(replacementHash).to.be.a("string").and.not.empty;
+
+			let closeSettled = false;
+			const close = first.sharedLog.close().then(
+				(value: boolean) => value,
+				(error: unknown) => error,
+			);
+			void close.then(() => {
+				closeSettled = true;
+			});
+			await new Promise((resolve) => setTimeout(resolve, 25));
+			expect(closeSettled).equal(false);
+
+			releaseTrim();
+			expect(await append).to.be.instanceOf(AggregateError);
+			expect(rejectedRollbackMarker).equal(true);
+			expect(await within(close, "rollback-marker concurrent close")).equal(
+				true,
+			);
+		} finally {
+			releaseTrim();
+			trimStub.restore();
+			intentStore.write = originalWrite;
+		}
+
+		await client!.stop();
+		client = undefined;
+		const reopened = await createStore(directory!, true);
+		expect(reopened.sharedLog.log.length).equal(1);
+		expect(await reopened.sharedLog.log.entryIndex.has(replacementHash!)).equal(
+			true,
+		);
+		expect(await reopened.sharedLog.log.entryIndex.has(old.entry.hash)).equal(
+			false,
+		);
+		expect((await reopened.store.docs.get("close-marker-race"))?.name).equal(
+			"replacement",
+		);
+		expect(
+			reopened.sharedLog._nativeStrictDurableTransactionJournalState.intent,
+		).equal(undefined);
+	});
+
+	it("keeps acknowledged replacement state recoverable after cleanup rejection and SIGKILL", async function () {
+		if (process.platform === "win32") this.skip();
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-durable-native-trim-hard-kill-"),
+		);
+		const workerPath = path.join(
+			process.cwd(),
+			"test/durable-native-hard-kill-worker.mjs",
+		);
+		const writer = spawn(
+			process.execPath,
+			[workerPath, "trim-failure-write", directory],
+			{ stdio: ["ignore", "pipe", "pipe"] },
+		);
+		const writerExit = once(writer, "exit");
+		let acknowledged:
+			| {
+					event: "trim-ack";
+					firstHash: string;
+					replacementHash: string;
+					cleanupDebt: number;
+			  }
+			| undefined;
+		try {
+			acknowledged = await waitForWorkerMessage<{
+				event: "trim-ack";
+				firstHash: string;
+				replacementHash: string;
+				cleanupDebt: number;
+			}>(writer, "hard-kill trim acknowledgement");
+			expect(acknowledged.cleanupDebt).to.be.greaterThan(0);
+			expect(writer.kill("SIGKILL")).equal(true);
+			await within(
+				writerExit.then(() => undefined),
+				"hard-kill trim writer exit",
+			);
+		} finally {
+			if (writer.exitCode === null && writer.signalCode === null) {
+				writer.kill("SIGKILL");
+			}
+		}
+		if (!acknowledged) {
+			throw new Error("Writer exited without trim acknowledgement");
+		}
+
+		const reader = spawn(
+			process.execPath,
+			[
+				workerPath,
+				"trim-failure-read",
+				directory,
+				acknowledged.replacementHash,
+				acknowledged.firstHash,
+			],
+			{ stdio: ["ignore", "pipe", "pipe"] },
+		);
+		const readerExit = once(reader, "exit") as Promise<
+			[number | null, NodeJS.Signals | null]
+		>;
+		try {
+			const reopened = await waitForWorkerMessage<{
+				event: "trim-read";
+				replacementBlockPresent: boolean;
+				documentName?: string;
+				lowerLogLength: number;
+				headHashes: string[];
+				oldBlockPresent: boolean;
+			}>(reader, "hard-kill trim reopen");
+			expect(reopened.event).equal("trim-read");
+			expect(reopened.replacementBlockPresent).equal(true);
+			expect(reopened.documentName).equal("replacement");
+			expect(reopened.lowerLogLength).equal(1);
+			expect(reopened.headHashes).deep.equal([acknowledged.replacementHash]);
+			expect(reopened.oldBlockPresent).equal(false);
+			const [exitCode] = await within(
+				readerExit,
+				"hard-kill trim reader exit",
+				30_000,
+			);
+			expect(exitCode).equal(0);
+		} finally {
+			if (reader.exitCode === null && reader.signalCode === null) {
+				reader.kill("SIGKILL");
+			}
+		}
+	});
+
+	it("rolls back durable document and coordinate prepublication after SIGKILL before the lower marker", async function () {
+		if (process.platform === "win32") this.skip();
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-durable-native-premark-kill-"),
+		);
+		const workerPath = path.join(
+			process.cwd(),
+			"test/durable-native-hard-kill-worker.mjs",
+		);
+		const writer = spawn(
+			process.execPath,
+			[workerPath, "premarker-write", directory],
+			{ stdio: ["ignore", "pipe", "pipe"] },
+		);
+		const writerExit = once(writer, "exit");
+		let phase: { event: "premarker"; hash: string } | undefined;
+		try {
+			phase = await waitForWorkerMessage(writer, "pre-marker phase");
+			expect(writer.kill("SIGKILL")).equal(true);
+			await within(
+				writerExit.then(() => undefined),
+				"pre-marker writer exit",
+			);
+		} finally {
+			if (writer.exitCode === null && writer.signalCode === null) {
+				writer.kill("SIGKILL");
+			}
+		}
+		if (!phase) throw new Error("Writer did not reach the pre-marker phase");
+
+		const reader = spawn(
+			process.execPath,
+			[workerPath, "premarker-read", directory, phase.hash],
+			{ stdio: ["ignore", "pipe", "pipe"] },
+		);
+		const readerExit = once(reader, "exit") as Promise<
+			[number | null, NodeJS.Signals | null]
+		>;
+		try {
+			const reopened = await waitForWorkerMessage<{
+				event: "premarker-read";
+				documentVisible: boolean;
+				lowerLogLength: number;
+				coordinateVisible: boolean;
+			}>(reader, "pre-marker recovery");
+			expect(reopened).deep.equal({
+				event: "premarker-read",
+				documentVisible: false,
+				lowerLogLength: 0,
+				coordinateVisible: false,
+			});
+			expect((await within(readerExit, "pre-marker reader exit"))[0]).equal(0);
+		} finally {
+			if (reader.exitCode === null && reader.signalCode === null) {
+				reader.kill("SIGKILL");
+			}
+		}
+	});
+
+	it("restores a pending external-next head after SIGKILL before the lower marker", async function () {
+		if (process.platform === "win32") this.skip();
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-durable-native-pending-next-kill-"),
+		);
+		const workerPath = path.join(
+			process.cwd(),
+			"test/durable-native-hard-kill-worker.mjs",
+		);
+		const writer = spawn(
+			process.execPath,
+			[workerPath, "pending-next-premarker-write", directory],
+			{ stdio: ["ignore", "pipe", "pipe"] },
+		);
+		const writerExit = once(writer, "exit");
+		let phase:
+			| { event: "pending-next-premarker"; firstHash: string }
+			| undefined;
+		try {
+			phase = await waitForWorkerMessage(
+				writer,
+				"pending external-next pre-marker phase",
+			);
+			expect(writer.kill("SIGKILL")).equal(true);
+			await within(
+				writerExit.then(() => undefined),
+				"pending external-next writer exit",
+			);
+		} finally {
+			if (writer.exitCode === null && writer.signalCode === null) {
+				writer.kill("SIGKILL");
+			}
+		}
+		if (!phase) {
+			throw new Error("Writer did not demote the pending external-next row");
+		}
+
+		const reader = spawn(
+			process.execPath,
+			[workerPath, "pending-next-premarker-read", directory, phase.firstHash],
+			{ stdio: ["ignore", "pipe", "pipe"] },
+		);
+		const readerExit = once(reader, "exit") as Promise<
+			[number | null, NodeJS.Signals | null]
+		>;
+		try {
+			const reopened = await waitForWorkerMessage<{
+				event: "pending-next-premarker-read";
+				documentName?: string;
+				lowerLogLength: number;
+				oldIndexed: boolean;
+				oldHead?: boolean;
+			}>(reader, "pending external-next recovery");
+			expect(reopened).deep.equal({
+				event: "pending-next-premarker-read",
+				documentName: "old",
+				lowerLogLength: 1,
+				oldIndexed: true,
+				oldHead: true,
+			});
+			expect(
+				(await within(readerExit, "pending external-next reader exit"))[0],
+			).equal(0);
+		} finally {
+			if (reader.exitCode === null && reader.signalCode === null) {
+				reader.kill("SIGKILL");
+			}
+		}
+	});
+
+	it("finishes post-marker trim GC after SIGKILL between marker and delete", async function () {
+		if (process.platform === "win32") this.skip();
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-durable-native-marker-trim-kill-"),
+		);
+		const workerPath = path.join(
+			process.cwd(),
+			"test/durable-native-hard-kill-worker.mjs",
+		);
+		const writer = spawn(
+			process.execPath,
+			[workerPath, "trim-marker-write", directory],
+			{ stdio: ["ignore", "pipe", "pipe"] },
+		);
+		const writerExit = once(writer, "exit");
+		let phase:
+			| {
+					event: "trim-marker";
+					firstHash: string;
+					replacementHash: string;
+			  }
+			| undefined;
+		try {
+			phase = await waitForWorkerMessage(writer, "post-marker trim phase");
+			expect(phase!.replacementHash).to.be.a("string").and.not.empty;
+			expect(writer.kill("SIGKILL")).equal(true);
+			await within(
+				writerExit.then(() => undefined),
+				"post-marker writer exit",
+			);
+		} finally {
+			if (writer.exitCode === null && writer.signalCode === null) {
+				writer.kill("SIGKILL");
+			}
+		}
+		if (!phase) throw new Error("Writer did not reach post-marker trim");
+
+		const reader = spawn(
+			process.execPath,
+			[
+				workerPath,
+				"trim-marker-read",
+				directory,
+				phase.replacementHash,
+				phase.firstHash,
+			],
+			{ stdio: ["ignore", "pipe", "pipe"] },
+		);
+		const readerExit = once(reader, "exit") as Promise<
+			[number | null, NodeJS.Signals | null]
+		>;
+		try {
+			const reopened = await waitForWorkerMessage<{
+				event: "trim-marker-read";
+				documentName?: string;
+				lowerLogLength: number;
+				headHashes: string[];
+				replacementIndexed: boolean;
+				oldBlockPresent: boolean;
+			}>(reader, "post-marker trim recovery");
+			expect(reopened).deep.equal({
+				event: "trim-marker-read",
+				documentName: "replacement",
+				lowerLogLength: 1,
+				headHashes: [phase.replacementHash],
+				replacementIndexed: true,
+				oldBlockPresent: false,
+			});
+			expect((await within(readerExit, "post-marker reader exit"))[0]).equal(0);
+		} finally {
+			if (reader.exitCode === null && reader.signalCode === null) {
+				reader.kill("SIGKILL");
+			}
+		}
+	});
+
+	it("finishes post-marker next-coordinate cleanup after SIGKILL", async function () {
+		if (process.platform === "win32") this.skip();
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-durable-native-marker-next-kill-"),
+		);
+		const workerPath = path.join(
+			process.cwd(),
+			"test/durable-native-hard-kill-worker.mjs",
+		);
+		const writer = spawn(
+			process.execPath,
+			[workerPath, "next-marker-write", directory],
+			{ stdio: ["ignore", "pipe", "pipe"] },
+		);
+		const writerExit = once(writer, "exit");
+		let phase:
+			| {
+					event: "next-marker";
+					firstHash: string;
+					replacementHash: string;
+					deleteHashes: string[];
+			  }
+			| undefined;
+		try {
+			phase = await waitForWorkerMessage(writer, "post-marker next phase");
+			expect(phase!.replacementHash).to.be.a("string").and.not.empty;
+			expect(phase!.deleteHashes).to.include(phase!.firstHash);
+			expect(writer.kill("SIGKILL")).equal(true);
+			await within(
+				writerExit.then(() => undefined),
+				"post-marker next writer exit",
+			);
+		} finally {
+			if (writer.exitCode === null && writer.signalCode === null) {
+				writer.kill("SIGKILL");
+			}
+		}
+		if (!phase)
+			throw new Error("Writer did not reach post-marker next cleanup");
+
+		const reader = spawn(
+			process.execPath,
+			[
+				workerPath,
+				"next-marker-read",
+				directory,
+				phase.firstHash,
+				phase.replacementHash,
+			],
+			{ stdio: ["ignore", "pipe", "pipe"] },
+		);
+		const readerExit = once(reader, "exit") as Promise<
+			[number | null, NodeJS.Signals | null]
+		>;
+		try {
+			const reopened = await waitForWorkerMessage<{
+				event: "next-marker-read";
+				documentName?: string;
+				lowerLogLength: number;
+				headHashes: string[];
+				oldCoordinateVisible: boolean;
+				replacementCoordinateVisible: boolean;
+			}>(reader, "post-marker next recovery");
+			expect(reopened).deep.equal({
+				event: "next-marker-read",
+				documentName: "replacement",
+				lowerLogLength: 2,
+				headHashes: [phase.replacementHash],
+				oldCoordinateVisible: false,
+				replacementCoordinateVisible: true,
+			});
+			expect(
+				(await within(readerExit, "post-marker next reader exit"))[0],
+			).equal(0);
+		} finally {
+			if (reader.exitCode === null && reader.signalCode === null) {
+				reader.kill("SIGKILL");
+			}
+		}
+	});
+
+	for (const coordinateCleanupCase of [
+		{
+			label: "single commit-only trim",
+			trim: true,
+			forceCommitOnly: true,
+			batch: false,
+			externalNext: false,
+		},
+		{
+			label: "direct storage trim",
+			trim: true,
+			forceCommitOnly: false,
+			batch: false,
+			externalNext: false,
+		},
+		{
+			label: "native batch trim",
+			trim: true,
+			forceCommitOnly: false,
+			batch: true,
+			externalNext: false,
+		},
+		{
+			label: "external-next replacement",
+			trim: false,
+			forceCommitOnly: false,
+			batch: false,
+			externalNext: true,
+		},
+	] as const) {
+		it(`retains and recovers committed coordinate cleanup debt for ${coordinateCleanupCase.label}`, async () => {
+			const first = await openStore(coordinateCleanupCase.trim);
+			const documentId = coordinateCleanupCase.externalNext
+				? "coordinate-debt-external-next"
+				: `coordinate-debt-old-${coordinateCleanupCase.label}`;
+			const old = await first.store.docs.put(
+				new Document({ id: documentId, name: "old" }),
+				{ unique: true, replicate: false, target: "none" },
+			);
+			expect(
+				first.sharedLog._residentEntryCoordinatesByHash.has(old.entry.hash),
+			).equal(true);
+
+			const forceCommitOnly = coordinateCleanupCase.forceCommitOnly
+				? sinon
+						.stub(
+							first.sharedLog,
+							"canUseNativeBackboneResidentCoordinateState",
+						)
+						.returns(false)
+				: undefined;
+			const storageSpy = sinon.spy(
+				first.sharedLog,
+				"appendLocallyPreparedPayloadNativeBackboneStorageTransaction",
+			);
+			const batchSpy = sinon.spy(
+				first.sharedLog,
+				"appendLocallyPreparedPayloadsManyNativeBackboneDocumentIndexBatch",
+			);
+			const originalDelete = first.sharedLog.deleteCoordinatesForHashes.bind(
+				first.sharedLog,
+			);
+			let injected = false;
+			const cleanupFailure = new Error(
+				`injected ${coordinateCleanupCase.label} coordinate cleanup failure`,
+			);
+			const deleteStub = sinon
+				.stub(first.sharedLog, "deleteCoordinatesForHashes")
+				.callsFake((...args: unknown[]) => {
+					const hashes = args[0] as Iterable<string>;
+					const values = [...hashes];
+					if (!injected && values.includes(old.entry.hash)) {
+						injected = true;
+						throw cleanupFailure;
+					}
+					return originalDelete(values);
+				});
+
+			let acknowledgedHash: string | undefined;
+			try {
+				if (coordinateCleanupCase.batch) {
+					const acknowledged = await first.store.docs.putMany(
+						[
+							new Document({ id: "coordinate-debt-batch-1", name: "one" }),
+							new Document({ id: "coordinate-debt-batch-2", name: "two" }),
+							new Document({ id: "coordinate-debt-batch-3", name: "three" }),
+						],
+						{ unique: true, replicate: false, target: "none" },
+					);
+					acknowledgedHash = acknowledged.entries.at(-1)?.hash;
+				} else {
+					const acknowledged = await first.store.docs.put(
+						new Document({
+							id: coordinateCleanupCase.externalNext
+								? documentId
+								: `coordinate-debt-new-${coordinateCleanupCase.label}`,
+							name: "replacement",
+						}),
+						coordinateCleanupCase.externalNext
+							? { replicate: false, target: "none" }
+							: { unique: true, replicate: false, target: "none" },
+					);
+					acknowledgedHash = acknowledged.entry.hash;
+				}
+				expect(acknowledgedHash).to.be.a("string").and.not.empty;
+				expect(injected).equal(true);
+				if (coordinateCleanupCase.batch) {
+					expect(batchSpy.calledOnce).equal(true);
+				} else if (!coordinateCleanupCase.forceCommitOnly) {
+					expect(storageSpy.calledOnce).equal(true);
+				}
+				const retainedIntent =
+					first.sharedLog._nativeStrictDurableTransactionJournalState.intent;
+				expect(retainedIntent?.lowerMarkerCommitted).equal(true);
+				expect(retainedIntent?.coordinateDeleteHashes).to.include(
+					old.entry.hash,
+				);
+
+				const laterMutation = await first.store.docs
+					.put(
+						new Document({ id: "coordinate-debt-blocked", name: "blocked" }),
+						{ unique: true, replicate: false, target: "none" },
+					)
+					.then(
+						() => undefined,
+						(error: unknown) => error,
+					);
+				expect(laterMutation).to.be.instanceOf(Error);
+				expect((laterMutation as Error).message).to.contain(
+					"recovery is required",
+				);
+			} finally {
+				deleteStub.restore();
+				batchSpy.restore();
+				storageSpy.restore();
+				forceCommitOnly?.restore();
+			}
+
+			if (!acknowledgedHash) {
+				throw new Error(
+					"Committed coordinate cleanup test was not acknowledged",
+				);
+			}
+			await client!.stop();
+			client = undefined;
+			const reopened = await createStore(
+				directory!,
+				coordinateCleanupCase.trim,
+			);
+			expect(
+				reopened.sharedLog._residentEntryCoordinatesByHash.has(old.entry.hash),
+			).equal(false);
+			if (!coordinateCleanupCase.forceCommitOnly) {
+				expect(
+					reopened.sharedLog._residentEntryCoordinatesByHash.has(
+						acknowledgedHash,
+					),
+				).equal(true);
+			}
+			expect(
+				reopened.sharedLog._nativeStrictDurableTransactionJournalState.intent,
+			).equal(undefined);
+			const afterRecovery = await reopened.store.docs.put(
+				new Document({
+					id: `coordinate-debt-after-${coordinateCleanupCase.label}`,
+					name: "after",
+				}),
+				{ unique: true, replicate: false, target: "none" },
+			);
+			expect(afterRecovery.entry.hash).to.be.a("string").and.not.empty;
+		});
+	}
+
+	for (const recovery of [
+		{
+			label: "graceful close",
+			mode: "mirror-failure-graceful-write",
+			kill: false,
+		},
+		{ label: "SIGKILL", mode: "mirror-failure-write", kill: true },
+	] as const) {
+		it(`discards a failed native document transaction across ${recovery.label} and fresh-process reopen`, async function () {
+			if (recovery.kill && process.platform === "win32") this.skip();
+			directory = await fs.mkdtemp(
+				path.join(os.tmpdir(), "peerbit-durable-native-failed-recovery-"),
+			);
+			const workerPath = path.join(
+				process.cwd(),
+				"test/durable-native-hard-kill-worker.mjs",
+			);
+			const writer = spawn(
+				process.execPath,
+				[workerPath, recovery.mode, directory],
+				{ stdio: ["ignore", "pipe", "pipe"] },
+			);
+			const writerExit = once(writer, "exit") as Promise<
+				[number | null, NodeJS.Signals | null]
+			>;
+			let rejected:
+				| {
+						event: "mirror-rejected";
+						failedHash?: string;
+						errorName?: string;
+						documentVisible: boolean;
+						lowerLogLength: number;
+						coordinateVisible: boolean;
+				  }
+				| undefined;
+			try {
+				rejected = await waitForWorkerMessage(
+					writer,
+					"failed mirror rejection",
+				);
+				if (!rejected) throw new Error("Missing failed mirror rejection");
+				expect(rejected.errorName).equal("NativeDurableCommitError");
+				expect(rejected.failedHash).to.be.a("string");
+				expect(rejected.documentVisible).equal(false);
+				expect(rejected.lowerLogLength).equal(0);
+				expect(rejected.coordinateVisible).equal(false);
+				if (recovery.kill) {
+					expect(writer.kill("SIGKILL")).equal(true);
+				}
+				const [exitCode] = await within(
+					writerExit,
+					"failed mirror writer exit",
+					30_000,
+				);
+				if (!recovery.kill) expect(exitCode).equal(0);
+			} finally {
+				if (writer.exitCode === null && writer.signalCode === null) {
+					writer.kill("SIGKILL");
+				}
+			}
+			if (!rejected?.failedHash) throw new Error("Missing failed native CID");
+
+			const reader = spawn(
+				process.execPath,
+				[workerPath, "mirror-failure-read", directory, rejected.failedHash],
+				{ stdio: ["ignore", "pipe", "pipe"] },
+			);
+			const readerExit = once(reader, "exit") as Promise<
+				[number | null, NodeJS.Signals | null]
+			>;
+			try {
+				const reopened = await waitForWorkerMessage<{
+					event: "mirror-read";
+					documentVisible: boolean;
+					blockVisible: boolean;
+					lowerLogLength: number;
+					coordinateVisible: boolean;
+				}>(reader, "failed mirror fresh-process reopen");
+				expect(reopened).deep.equal({
+					event: "mirror-read",
+					documentVisible: false,
+					blockVisible: false,
+					lowerLogLength: 0,
+					coordinateVisible: false,
+				});
+				const [exitCode] = await within(
+					readerExit,
+					"failed mirror reader exit",
+				);
+				expect(exitCode).equal(0);
+			} finally {
+				if (reader.exitCode === null && reader.signalCode === null) {
+					reader.kill("SIGKILL");
+				}
+			}
+		});
+	}
+
+	it("reports durable bytes after a cold native reopen", async () => {
+		const { store, wrapper, durable } = await openStore();
+		const put = await store.docs.put(
+			new Document({ id: "durable-size", name: "durable-size" }),
+		);
+		const beforeClose = await wrapper.size();
+		expect(beforeClose).equal(await durable.size());
+		expect(beforeClose).greaterThan(0);
+
+		const storeDirectory = directory!;
+		await client!.stop();
+		client = undefined;
+		const reopened = await createStore(storeDirectory);
+		expect(reopened.backbone.blocks.has(put.entry.hash)).equal(false);
+		expect(reopened.backbone.blocks.size()).equal(0);
+		const reopenedSize = await reopened.wrapper.size();
+		expect(reopenedSize).equal(await reopened.durable.size());
+		expect(reopenedSize).equal(beforeClose);
+	});
+
+	it("does not acknowledge a native append before durable storage", async () => {
+		const { store, wrapper, durable } = await openStore();
+		const originalPutKnown = durable.putKnown.bind(durable);
+		let releaseWrite!: () => void;
+		const writeGate = new Promise<void>((resolve) => {
+			releaseWrite = resolve;
+		});
+		let markWriteStarted!: () => void;
+		const writeStarted = new Promise<void>((resolve) => {
+			markWriteStarted = resolve;
+		});
+		const durablePutStub = sinon
+			.stub(durable, "putKnown")
+			.callsFake(async (...args: unknown[]) => {
+				const [cid, bytes] = args as [string, Uint8Array];
+				markWriteStarted();
+				await writeGate;
+				return originalPutKnown(cid, bytes);
+			});
+		const mirrorSpy = sinon.spy(wrapper, "mirrorToDurable");
+
+		try {
+			let settled = false;
+			const pendingPut = store.docs.put(
+				new Document({ id: "ordered", name: "ordered" }),
+			);
+			void pendingPut.then(
+				() => {
+					settled = true;
+				},
+				() => {
+					settled = true;
+				},
+			);
+			await within(writeStarted, "durable block write");
+			await Promise.resolve();
+			expect(settled).equal(false);
+
+			releaseWrite();
+			const put = await pendingPut;
+			expect(mirrorSpy.callCount).equal(1);
+			expect(await durable.has(put.entry.hash)).equal(true);
+		} finally {
+			releaseWrite();
+			mirrorSpy.restore();
+			durablePutStub.restore();
+		}
+	});
+
+	it("does not acknowledge when batching defers the native WAL durability barrier", async () => {
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-native-wal-barrier-"),
+		);
+		const persistence = new NativeBackboneNodeCoordinatePersistence(
+			path.join(directory, "coordinate-wal"),
+			{
+				flushOnAppend: false,
+				flushMaxPendingBytes: Number.MAX_SAFE_INTEGER,
+				writeBufferMaxBytes: Number.MAX_SAFE_INTEGER,
+			},
+		);
+		const originalFlush = persistence.intentStore.flush!.bind(
+			persistence.intentStore,
+		);
+		let releaseWalFlush!: () => void;
+		const flushGate = new Promise<void>((resolve) => {
+			releaseWalFlush = resolve;
+		});
+		let markWalFlushStarted!: () => void;
+		const walFlushStarted = new Promise<void>((resolve) => {
+			markWalFlushStarted = resolve;
+		});
+		let gateArmed = false;
+		const flushStub = sinon
+			.stub(persistence.intentStore, "flush")
+			.callsFake(async (name?: string) => {
+				if (gateArmed && name?.endsWith(".wal")) {
+					gateArmed = false;
+					markWalFlushStarted();
+					await flushGate;
+				}
+				await originalFlush(name);
+			});
+
+		try {
+			const { store } = await createStore(directory, false, false, persistence);
+			gateArmed = true;
+			let settled = false;
+			const pendingPut = store.docs.put(
+				new Document({ id: "wal-barrier", name: "wal-barrier" }),
+			);
+			void pendingPut.then(
+				() => {
+					settled = true;
+				},
+				() => {
+					settled = true;
+				},
+			);
+			await within(walFlushStarted, "native WAL durability barrier");
+			await Promise.resolve();
+			expect(settled).equal(false);
+
+			releaseWalFlush();
+			await pendingPut;
+			expect(settled).equal(true);
+		} finally {
+			releaseWalFlush();
+			flushStub.restore();
+		}
+	});
+
+	it("returns a typed unsafe-retry error and poisons later mutations", async () => {
+		const { store, sharedLog, wrapper, durable, backbone } = await openStore();
+		// Force the graph commit-only variant; the normal test above covers the
+		// resident-coordinate storage transaction variant.
+		const residentStateStub = sinon
+			.stub(sharedLog, "canUseNativeBackboneResidentCoordinateState")
+			.returns(false);
+		const durablePutStub = sinon
+			.stub(durable, "putKnown")
+			.rejects(new Error("durable mirror failed"));
+		const mirrorSpy = sinon.spy(wrapper, "mirrorToDurable");
+
+		try {
+			const failure = await store.docs
+				.put(new Document({ id: "failure", name: "failure" }))
+				.then(
+					() => undefined,
+					(error: unknown) => error,
+				);
+			expect(failure).to.be.instanceOf(NativeDurableCommitError);
+			const typed = failure as NativeDurableCommitError;
+			expect(typed.nativeCommitApplied).equal(true);
+			expect(typed.retrySafe).equal(false);
+			expect(store.docs.log.log.length).equal(0);
+			expect(mirrorSpy.callCount).equal(1);
+			const committedHash = mirrorSpy.firstCall.args[0] as string;
+			expect(typed.committedCids).deep.equal([committedHash]);
+			expect(typed.failedCids).deep.equal([committedHash]);
+			// The prepare happened before exclusive hot-map ownership could be proven.
+			// Its unreachable native bytes are retained, while lower-log/durable liveness
+			// remains absent and poisoned reads cannot expose the orphan.
+			expect(backbone.blocks.has(committedHash)).equal(true);
+			expect(await durable.has(committedHash)).equal(false);
+			expect(await store.docs.log.log.entryIndex.has(committedHash)).equal(
+				false,
+			);
+			expect(await wrapper.get(committedHash)).equal(undefined);
+
+			const retryFailure = await store.docs
+				.put(new Document({ id: "retry", name: "retry" }))
+				.then(
+					() => undefined,
+					(error: unknown) => error,
+				);
+			expect(retryFailure).equal(failure);
+			expect(mirrorSpy.callCount).equal(1);
+		} finally {
+			mirrorSpy.restore();
+			durablePutStub.restore();
+			residentStateStub.restore();
+		}
+	});
+
+	it("rejects concurrent receive writes and onMessage with one poison", async () => {
+		const { store, sharedLog, wrapper, durable } = await openStore();
+		const baseline = await store.docs.put(
+			new Document({ id: "receive-poison", name: "receive-poison" }),
+		);
+		const cid = baseline.entry.hash;
+		const bytes = await durable.get(cid);
+		if (!bytes) {
+			throw new Error("Expected baseline durable bytes");
+		}
+		const originalPutKnown = durable.putKnown.bind(durable);
+		let releaseFirst!: () => void;
+		const firstGate = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		let releaseSecond!: () => void;
+		const secondGate = new Promise<void>((resolve) => {
+			releaseSecond = resolve;
+		});
+		let markFirstStarted!: () => void;
+		const firstStarted = new Promise<void>((resolve) => {
+			markFirstStarted = resolve;
+		});
+		let markSecondStarted!: () => void;
+		const secondStarted = new Promise<void>((resolve) => {
+			markSecondStarted = resolve;
+		});
+		let callIndex = 0;
+		const durablePutStub = sinon
+			.stub(durable, "putKnown")
+			.callsFake(async (...args: unknown[]) => {
+				const [putCid, putBytes] = args as [string, Uint8Array];
+				const current = callIndex++;
+				if (current === 0) {
+					markFirstStarted();
+					await firstGate;
+					throw new Error("receive durable mirror failed");
+				}
+				markSecondStarted();
+				await secondGate;
+				return originalPutKnown(putCid, putBytes);
+			});
+
+		try {
+			const firstWrite = wrapper.putKnown(cid, bytes).then(
+				() => undefined,
+				(error: unknown) => error,
+			);
+			const concurrentWrite = wrapper.putKnown(cid, bytes).then(
+				() => undefined,
+				(error: unknown) => error,
+			);
+			await within(firstStarted, "first receive durable write");
+			await within(secondStarted, "concurrent receive durable write");
+
+			releaseFirst();
+			const failure = await firstWrite;
+			expect(failure).to.be.instanceOf(NativeDurableCommitError);
+			releaseSecond();
+			expect(await concurrentWrite).equal(failure);
+
+			let synchronousFailure: unknown;
+			try {
+				wrapper.putKnownManyColumns([cid], [bytes]);
+			} catch (error) {
+				synchronousFailure = error;
+			}
+			expect(synchronousFailure).equal(failure);
+			const releaseStash = sinon.stub().returns(true);
+			const stashMessage = new StashBackedRawExchangeHeadsMessage({
+				messageId: new Uint8Array([1]),
+				hashes: [],
+				gidRefrences: [],
+				byteLengths: new Uint32Array(),
+				reserved: new Uint8Array(4),
+				stash: {
+					stashedBlocks: () => undefined,
+					release: releaseStash,
+				},
+			});
+			const messageFailure = await sharedLog
+				.onMessage(stashMessage, {} as any)
+				.then(
+					() => undefined,
+					(error: unknown) => error,
+				);
+			expect(messageFailure).equal(failure);
+			expect(releaseStash.calledOnce).equal(true);
+			expect(stashMessage.release()).equal(false);
+			expect(releaseStash.calledOnce).equal(true);
+		} finally {
+			releaseFirst();
+			releaseSecond();
+			durablePutStub.restore();
+		}
+	});
+
+	for (const forceGenericFallback of [false, true]) {
+		it(`holds a two-entry stash receive behind its durable barrier (${forceGenericFallback ? "generic fallback" : "prepared facts"})`, async () => {
+			const { store, sharedLog, durable } = await openStore(false, true);
+			const sourceDirectory = await fs.mkdtemp(
+				path.join(os.tmpdir(), "peerbit-durable-native-receive-source-"),
+			);
+			const sourceClient = await Peerbit.create({
+				directory: sourceDirectory,
+				...createRustPeerbitOptions(),
+			});
+			const storeId = store.id;
+			const source = new TestStore<Document>({
+				docs: new Documents<Document>({ id: storeId }),
+			});
+			source.id = storeId;
+			await sourceClient.open(source, {
+				args: createOpenArgs(sourceDirectory),
+			});
+			const writes = await Promise.all([
+				source.docs.put(new Document({ id: "receive-a", name: "receive-a" })),
+				source.docs.put(new Document({ id: "receive-b", name: "receive-b" })),
+			]);
+			const hashes = writes.map((write) => write.entry.hash);
+			expect(await sharedLog.log.hasMany(hashes)).deep.equal(new Set());
+			const blocks = await Promise.all(
+				hashes.map(async (hash) => {
+					const bytes = await source.docs.log.log.blocks.get(hash);
+					if (!bytes) throw new Error(`Missing source block ${hash}`);
+					return bytes;
+				}),
+			);
+
+			let releaseWrite!: () => void;
+			const writeGate = new Promise<void>((resolve) => {
+				releaseWrite = resolve;
+			});
+			let markWriteStarted!: () => void;
+			const writeStarted = new Promise<void>((resolve) => {
+				markWriteStarted = resolve;
+			});
+			const durableFailure = new Error("delayed stash durable rejection");
+			const durablePutStub = sinon
+				.stub(durable, "putKnownMany")
+				.callsFake(async () => {
+					markWriteStarted();
+					await writeGate;
+					throw durableFailure;
+				});
+			const canAppendValidationStub = sinon
+				.stub(sharedLog, "canSkipLowerLogCanAppendForNetworkJoin")
+				.resolves(true);
+			const preparedJoinProbe = forceGenericFallback
+				? sinon
+						.stub(sharedLog.log, "joinPreparedAppendFactsBatch")
+						.resolves(false)
+				: sinon.spy(sharedLog.log, "joinPreparedAppendFactsBatch");
+			const genericJoinSpy = sinon.spy(sharedLog.log, "join");
+			const releaseStash = sinon.stub().returns(true);
+			const stashMessage = new StashBackedRawExchangeHeadsMessage({
+				messageId: new Uint8Array([7, forceGenericFallback ? 1 : 0]),
+				hashes,
+				gidRefrences: hashes.map(() => []),
+				byteLengths: Uint32Array.from(blocks.map((bytes) => bytes.byteLength)),
+				reserved: new Uint8Array(4),
+				stash: {
+					stashedBlocks: (_id, indexes) =>
+						indexes ? Array.from(indexes, (index) => blocks[index]!) : blocks,
+					release: releaseStash,
+				},
+			});
+
+			try {
+				let settled = false;
+				const handler = sharedLog
+					.onMessage(stashMessage, {
+						from: source.node.identity.publicKey,
+					} as any)
+					.then(
+						() => undefined,
+						(error: unknown) => error,
+					);
+				void handler.then(() => {
+					settled = true;
+				});
+				const firstOutcome = await within(
+					Promise.race([
+						writeStarted.then(() => ({ kind: "write" as const })),
+						handler.then((result: unknown) => ({
+							kind: "handler" as const,
+							result,
+						})),
+					]),
+					"stash durable batch write",
+				);
+				if (firstOutcome.kind === "handler") {
+					throw (
+						firstOutcome.result ??
+						new Error("Stash handler returned before its durable batch write")
+					);
+				}
+				await Promise.resolve();
+				expect(settled).equal(false);
+				expect(sharedLog.log.length).equal(0);
+				expect(await store.docs.index.getSize()).equal(0);
+
+				releaseWrite();
+				const failure = await handler;
+				expect(failure).to.be.instanceOf(NativeDurableCommitError);
+				expect(failure).equal(sharedLog._nativeDurableCommitFailure);
+				expect(releaseStash.calledOnce).equal(true);
+				expect(stashMessage.release()).equal(false);
+				expect(releaseStash.calledOnce).equal(true);
+				expect(sharedLog.log.length).equal(0);
+				expect(await store.docs.index.getSize()).equal(0);
+				expect(preparedJoinProbe.calledOnce).equal(true);
+				expect(genericJoinSpy.callCount).equal(forceGenericFallback ? 1 : 0);
+				for (const hash of hashes) {
+					expect(
+						sharedLog._residentEntryCoordinatesByHash?.has(hash) ?? false,
+					).equal(false);
+				}
+			} finally {
+				releaseWrite();
+				genericJoinSpy.restore();
+				preparedJoinProbe.restore();
+				canAppendValidationStub.restore();
+				durablePutStub.restore();
+				await sourceClient.stop();
+				await fs.rm(sourceDirectory, { recursive: true, force: true });
+			}
+		});
+	}
+
+	it("uses one durable barrier for a native batch and reports its failure", async () => {
+		const { store, wrapper, durable, backbone } = await openStore();
+		const docs = [
+			new Document({ id: "batch-1", name: "batch-1" }),
+			new Document({ id: "batch-2", name: "batch-2" }),
+			new Document({ id: "batch-3", name: "batch-3" }),
+		];
+		let releaseWrite!: () => void;
+		const writeGate = new Promise<void>((resolve) => {
+			releaseWrite = resolve;
+		});
+		let markWriteStarted!: () => void;
+		const writeStarted = new Promise<void>((resolve) => {
+			markWriteStarted = resolve;
+		});
+		const durablePutStub = sinon
+			.stub(durable, "putKnownMany")
+			.callsFake(async () => {
+				markWriteStarted();
+				await writeGate;
+				throw new Error("batch durable mirror failed");
+			});
+		const singlePutSpy = sinon.spy(durable, "putKnown");
+		const mirrorSpy = sinon.spy(wrapper, "mirrorManyToDurable");
+		const nativeBatchSpy = sinon.spy(
+			backbone,
+			"preparePlainCommittedNoNextStorageAppendDocumentIndexCompactBatchTransaction",
+		);
+
+		try {
+			let settled = false;
+			const pending = store.docs.putMany(docs, {
+				unique: true,
+				target: "none",
+			});
+			void pending.then(
+				() => {
+					settled = true;
+				},
+				() => {
+					settled = true;
+				},
+			);
+			await within(writeStarted, "durable batch mirror");
+			expect(mirrorSpy.callCount).equal(1);
+			expect(durablePutStub.callCount).equal(1);
+			expect(singlePutSpy.callCount).equal(0);
+			expect(settled).equal(false);
+
+			releaseWrite();
+			const failure = await pending.then(
+				() => undefined,
+				(error: unknown) => error,
+			);
+			expect(failure).to.be.instanceOf(NativeDurableCommitError);
+			const prepared = nativeBatchSpy.firstCall.returnValue as Array<{
+				entry: { hash: string };
+			}>;
+			expect((failure as NativeDurableCommitError).committedCids).deep.equal(
+				prepared.map(({ entry }) => entry.hash),
+			);
+			expect((failure as NativeDurableCommitError).failedCids).deep.equal(
+				prepared.map(({ entry }) => entry.hash),
+			);
+			expect(store.docs.log.log.length).equal(0);
+		} finally {
+			releaseWrite();
+			nativeBatchSpy.restore();
+			mirrorSpy.restore();
+			singlePutSpy.restore();
+			durablePutStub.restore();
+		}
+	});
+
+	it("does not delete the published head when its replacement mirror fails", async () => {
+		const { store, wrapper, durable } = await openStore(true);
+		const first = await store.docs.put(
+			new Document({ id: "old-head", name: "old-head" }),
+			{ unique: true },
+		);
+		const firstHash = first.entry.hash;
+		const durablePutStub = sinon
+			.stub(durable, "putKnown")
+			.rejects(new Error("replacement mirror failed"));
+
+		try {
+			const failure = await store.docs
+				.put(new Document({ id: "replacement", name: "replacement" }), {
+					unique: true,
+				})
+				.then(
+					() => undefined,
+					(error: unknown) => error,
+				);
+			expect(failure).to.be.instanceOf(NativeDurableCommitError);
+			expect(wrapper.stagedNativeDeleteCleanups.size).equal(0);
+			expect(store.docs.log.log.length).equal(1);
+			expect(await durable.has(firstHash)).equal(true);
+			expect(await wrapper.get(firstHash)).to.be.instanceOf(Uint8Array);
+		} finally {
+			durablePutStub.restore();
+		}
+	});
+
+	it("preserves acknowledged and shared same-CID bytes during compensation", async () => {
+		const { store, wrapper, durable, backbone } = await openStore();
+		const appended = await store.docs.put(
+			new Document({ id: "same-cid", name: "same-cid" }),
+		);
+		const cid = appended.entry.hash;
+		const bytes = await durable.get(cid);
+		if (!bytes) throw new Error("Expected acknowledged durable bytes");
+
+		// No opaque ownership evidence means compensation must retain an orphan.
+		await wrapper.rollbackFailedNativeCommits([cid]);
+		expect(await durable.has(cid)).equal(true);
+		expect(backbone.blocks.has(cid)).equal(true);
+		expect(await wrapper.get(cid)).deep.equal(bytes);
+
+		// Two explicit mirrors of the same CID are shared generations. Rolling one
+		// back while restoring the CID must not remove either acknowledged copy.
+		const firstOwnership = await wrapper.mirrorToDurable(cid, bytes);
+		const secondOwnership = await wrapper.mirrorToDurable(cid, bytes);
+		await wrapper.rollbackFailedNativeCommits([cid], [cid], secondOwnership);
+		wrapper.acknowledgeNativeCommitOwnership(firstOwnership);
+		expect(await durable.has(cid)).equal(true);
+		expect(backbone.blocks.has(cid)).equal(true);
+		expect(await store.docs.log.log.entryIndex.has(cid)).equal(true);
+		expect((await store.docs.log.log.getHeads().all())[0]?.hash).equal(cid);
+	});
+
+	it("generation-fences unmirrored rollback from a same-CID generic write", async () => {
+		const { wrapper, durable, backbone } = await openStore();
+		const bytes = new Uint8Array([91, 17, 203, 4, 55, 8]);
+		// Simulate the strict native prepare: it writes the hot map directly and
+		// therefore does not advance the wrapper's generic-write generation.
+		const cid = await backbone.blocks.put(bytes);
+		expect(await durable.has(cid)).equal(false);
+
+		const originalHasMany = durable.hasMany.bind(durable);
+		let markPresenceReadStarted!: () => void;
+		const presenceReadStarted = new Promise<void>((resolve) => {
+			markPresenceReadStarted = resolve;
+		});
+		let releaseStalePresence!: () => void;
+		const stalePresenceGate = new Promise<void>((resolve) => {
+			releaseStalePresence = resolve;
+		});
+		const hasManyStub = sinon
+			.stub(durable, "hasMany")
+			.callsFake(async (...args: unknown[]) => {
+				const [cids] = args as [string[]];
+				markPresenceReadStarted();
+				await stalePresenceGate;
+				return cids.map(() => false);
+			});
+		try {
+			const rollback = wrapper.rollbackUnmirroredNativeCommits([cid]);
+			await within(presenceReadStarted, "unmirrored rollback presence read");
+			const genericWrite = wrapper.putKnown(cid, bytes);
+			await genericWrite;
+			releaseStalePresence();
+			await rollback;
+			expect(backbone.blocks.has(cid)).equal(true);
+			expect(await durable.has(cid)).equal(true);
+			expect(await wrapper.get(cid)).deep.equal(bytes);
+		} finally {
+			releaseStalePresence();
+			hasManyStub.restore();
+			// Verify the original adapter still answers after the gated stub is gone.
+			expect(await originalHasMany([cid])).deep.equal([true]);
+		}
+	});
+
+	it("rolls back a trimmed single append when its lower index flush fails", async () => {
+		const { store, sharedLog } = await openStore(true);
+		const old = await store.docs.put(
+			new Document({ id: "index-single-old", name: "index-single-old" }),
+			{ unique: true },
+		);
+		const oldHash = old.entry.hash;
+		const changes: unknown[] = [];
+		store.docs.events.addEventListener("change", (event) =>
+			changes.push(event.detail),
+		);
+		const indexFailure = new Error("single lower index flush failed");
+		const lowerIndex = sharedLog.log.entryIndex.properties.index;
+		const originalPut = lowerIndex.put.bind(lowerIndex);
+		const putStub = sinon
+			.stub(lowerIndex, "put")
+			.callsFake(async (...args: Parameters<typeof lowerIndex.put>) => {
+				await originalPut(...args);
+				throw indexFailure;
+			});
+
+		try {
+			const failure = await store.docs
+				.put(
+					new Document({
+						id: "index-single-new",
+						name: "index-single-new",
+					}),
+					{ unique: true },
+				)
+				.then(
+					() => undefined,
+					(error: unknown) => error,
+				);
+			expect(failure).equal(indexFailure);
+			const failedHash = (putStub.firstCall.args[0] as { hash: string }).hash;
+			expect(sharedLog.log.length).equal(1);
+			expect(
+				(await sharedLog.log.entryIndex.getShallow(oldHash))?.value.hash,
+				"old lower index row",
+			).equal(oldHash);
+			expect(await sharedLog.log.entryIndex.has(oldHash)).equal(true);
+			expect(await sharedLog.log.entryIndex.has(failedHash)).equal(false);
+			expect(await sharedLog.log.entryIndex.getShallow(failedHash)).equal(
+				undefined,
+			);
+			expect(
+				(await sharedLog.log.getHeads().all()).map(
+					(entry: { hash: string }) => entry.hash,
+				),
+			).deep.equal([oldHash]);
+			expect((await store.docs.get("index-single-old"))?.name).equal(
+				"index-single-old",
+			);
+			expect(await store.docs.get("index-single-new")).equal(undefined);
+			expect(changes).deep.equal([]);
+
+			await new Promise((resolve) => setTimeout(resolve, 400));
+			expect(sharedLog.log.length).equal(1);
+			expect(await sharedLog.log.entryIndex.has(oldHash)).equal(true);
+			expect(changes).deep.equal([]);
+			await store.close();
+			await client!.open(store, {
+				args: createOpenArgs(directory!, true),
+			});
+			expect(store.docs.log.log.length).equal(1);
+			expect(
+				(await store.docs.log.log.getHeads().all()).map((entry) => entry.hash),
+			).deep.equal([oldHash]);
+			expect(await store.docs.log.log.entryIndex.has(failedHash)).equal(false);
+			expect((await store.docs.get("index-single-old"))?.name).equal(
+				"index-single-old",
+			);
+			expect(await store.docs.get("index-single-new")).equal(undefined);
+		} finally {
+			putStub.restore();
+		}
+	});
+
+	it("rolls back a trimmed batch when its lower index flush fails", async () => {
+		const { store, sharedLog } = await openStore(true);
+		const old = await store.docs.put(
+			new Document({ id: "index-batch-old", name: "index-batch-old" }),
+			{ unique: true },
+		);
+		const oldHash = old.entry.hash;
+		const changes: unknown[] = [];
+		store.docs.events.addEventListener("change", (event) =>
+			changes.push(event.detail),
+		);
+		const indexFailure = new Error("batch lower index flush failed");
+		const lowerIndex = sharedLog.log.entryIndex.properties.index;
+		const originalPutBatch = lowerIndex.putBatch!.bind(lowerIndex);
+		const putBatchStub = sinon
+			.stub(lowerIndex, "putBatch")
+			.callsFake(async (...args: Parameters<typeof originalPutBatch>) => {
+				await originalPutBatch(...args);
+				throw indexFailure;
+			});
+
+		try {
+			const failure = await store.docs
+				.putMany(
+					[
+						new Document({ id: "index-batch-new-1", name: "new-1" }),
+						new Document({ id: "index-batch-new-2", name: "new-2" }),
+						new Document({ id: "index-batch-new-3", name: "new-3" }),
+					],
+					{ unique: true, target: "none" },
+				)
+				.then(
+					() => undefined,
+					(error: unknown) => error,
+				);
+			expect(failure).equal(indexFailure);
+			const failedHashes = (
+				putBatchStub.firstCall.args[0] as Array<{ hash: string }>
+			).map((entry) => entry.hash);
+			expect(sharedLog.log.length).equal(1);
+			expect(await sharedLog.log.entryIndex.has(oldHash)).equal(true);
+			for (const hash of failedHashes) {
+				expect(await sharedLog.log.entryIndex.has(hash)).equal(false);
+				expect(await sharedLog.log.entryIndex.getShallow(hash)).equal(
+					undefined,
+				);
+			}
+			expect(
+				(await sharedLog.log.getHeads().all()).map(
+					(entry: { hash: string }) => entry.hash,
+				),
+			).deep.equal([oldHash]);
+			expect((await store.docs.get("index-batch-old"))?.name).equal(
+				"index-batch-old",
+			);
+			for (const id of [
+				"index-batch-new-1",
+				"index-batch-new-2",
+				"index-batch-new-3",
+			]) {
+				expect(await store.docs.get(id)).equal(undefined);
+			}
+			expect(changes).deep.equal([]);
+
+			await new Promise((resolve) => setTimeout(resolve, 400));
+			expect(sharedLog.log.length).equal(1);
+			expect(await sharedLog.log.entryIndex.has(oldHash)).equal(true);
+			expect(changes).deep.equal([]);
+			await store.close();
+			await client!.open(store, {
+				args: createOpenArgs(directory!, true),
+			});
+			expect(store.docs.log.log.length).equal(1);
+			expect(
+				(await store.docs.log.log.getHeads().all()).map((entry) => entry.hash),
+			).deep.equal([oldHash]);
+			for (const hash of failedHashes) {
+				expect(await store.docs.log.log.entryIndex.has(hash)).equal(false);
+			}
+			expect((await store.docs.get("index-batch-old"))?.name).equal(
+				"index-batch-old",
+			);
+			for (const id of [
+				"index-batch-new-1",
+				"index-batch-new-2",
+				"index-batch-new-3",
+			]) {
+				expect(await store.docs.get(id)).equal(undefined);
+			}
+		} finally {
+			putBatchStub.restore();
+		}
+	});
+
+	it("commits replacement facts and retains retry debt when trim cleanup fails", async () => {
+		const { store, sharedLog, wrapper, durable } = await openStore(true);
+		const first = await store.docs.put(
+			new Document({ id: "trim-old", name: "trim-old" }),
+			{ unique: true },
+		);
+		const cleanupFailure = new Error("durable trim cleanup failed");
+		const changes: Array<{
+			added: Array<{ id: string }>;
+			removed: Array<{ id: string }>;
+		}> = [];
+		store.docs.events.addEventListener("change", (event) =>
+			changes.push(event.detail as (typeof changes)[number]),
+		);
+		const originalRmMany = durable.rmMany.bind(durable);
+		let cleanupFailuresRemaining = 2;
+		const durableRmManyStub = sinon
+			.stub(durable, "rmMany")
+			.callsFake(async (...args: unknown[]) => {
+				const [cids] = args as [string[]];
+				if (cleanupFailuresRemaining > 0) {
+					cleanupFailuresRemaining--;
+					throw cleanupFailure;
+				}
+				return originalRmMany(cids);
+			});
+
+		try {
+			const replacement = await store.docs.put(
+				new Document({ id: "trim-new", name: "trim-new" }),
+				{ unique: true },
+			);
+			expect(sharedLog.log.length).equal(1);
+			expect(
+				(await sharedLog.log.getHeads().all()).map(
+					(entry: { hash: string }) => entry.hash,
+				),
+			).deep.equal([replacement.entry.hash]);
+			expect(await sharedLog.log.entryIndex.has(first.entry.hash)).equal(false);
+			expect(await sharedLog.log.entryIndex.has(replacement.entry.hash)).equal(
+				true,
+			);
+			expect(await store.docs.get("trim-old")).equal(undefined);
+			expect((await store.docs.get("trim-new"))?.name).equal("trim-new");
+			expect(changes).to.have.length(1);
+			expect(changes[0]!.added.map((document) => document.id)).deep.equal([
+				"trim-new",
+			]);
+			expect(changes[0]!.removed.map((document) => document.id)).deep.equal([
+				"trim-old",
+			]);
+			expect(wrapper.pendingNativeDeleteCleanup.size).equal(1);
+			expect(await durable.has(first.entry.hash)).equal(true);
+
+			await store.close();
+			expect(durableRmManyStub.callCount).equal(3);
+			expect(wrapper.pendingNativeDeleteCleanup.size).equal(0);
+			expect(durable.status()).equal("closed");
+		} finally {
+			durableRmManyStub.restore();
+		}
+	});
+
+	it("keeps the new batch state through partial trim cleanup and reopen", async () => {
+		const { store, sharedLog, wrapper, durable } = await openStore(true);
+		const old = await store.docs.put(
+			new Document({ id: "partial-old", name: "partial-old" }),
+			{ unique: true },
+		);
+		const changes: Array<{
+			added: Array<{ id: string }>;
+			removed: Array<{ id: string }>;
+		}> = [];
+		store.docs.events.addEventListener("change", (event) =>
+			changes.push(event.detail as (typeof changes)[number]),
+		);
+		const originalRmMany = durable.rmMany.bind(durable);
+		const cleanupFailure = new Error("partial durable trim cleanup failed");
+		const durableRmManyStub = sinon
+			.stub(durable, "rmMany")
+			.callsFake(async (...args: unknown[]) => {
+				const [cids] = args as [string[]];
+				if (cids.length > 0) await originalRmMany([cids[0]!]);
+				throw cleanupFailure;
+			});
+
+		const replacements = await store.docs.putMany(
+			[
+				new Document({ id: "partial-new-1", name: "partial-new-1" }),
+				new Document({ id: "partial-new-2", name: "partial-new-2" }),
+				new Document({ id: "partial-new-3", name: "partial-new-3" }),
+			],
+			{ unique: true, target: "none" },
+		);
+		const kept = replacements.entries.at(-1)!;
+		expect(sharedLog.log.length).equal(1);
+		expect(
+			(await sharedLog.log.getHeads().all()).map(
+				(entry: { hash: string }) => entry.hash,
+			),
+		).deep.equal([kept.hash]);
+		expect(await sharedLog.log.entryIndex.has(old.entry.hash)).equal(false);
+		for (const removed of replacements.entries.slice(0, -1)) {
+			expect(await sharedLog.log.entryIndex.has(removed.hash)).equal(false);
+		}
+		expect(await sharedLog.log.entryIndex.has(kept.hash)).equal(true);
+		expect(changes).to.have.length(1);
+		expect(changes[0]!.added.map((document) => document.id)).deep.equal([
+			"partial-new-1",
+			"partial-new-2",
+			"partial-new-3",
+		]);
+		expect(changes[0]!.removed).deep.equal([]);
+		expect(wrapper.pendingNativeDeleteCleanup.size).to.be.greaterThan(0);
+		expect(wrapper.nativeCommitOwnerships.size).equal(0);
+
+		await store.close();
+		expect(durable.status()).equal("closed");
+		durableRmManyStub.restore();
+		await client!.open(store, {
+			args: createOpenArgs(directory!, true),
+		});
+		expect(store.docs.log.log.length).equal(1);
+		expect(
+			(await store.docs.log.log.getHeads().all()).map((entry) => entry.hash),
+		).deep.equal([kept.hash]);
+		expect((await store.docs.get("partial-new-3"))?.name).equal(
+			"partial-new-3",
+		);
+	});
+
+	it("rechecks poison after waiting for tracked writes before trim cleanup", async () => {
+		const { store, wrapper, durable } = await openStore();
+		const put = await store.docs.put(
+			new Document({ id: "cleanup-race", name: "cleanup-race" }),
+		);
+		const cid = put.entry.hash;
+		const bytes = await durable.get(cid);
+		if (!bytes) throw new Error("Expected durable test block");
+		let releaseWrite!: () => void;
+		const writeGate = new Promise<void>((resolve) => {
+			releaseWrite = resolve;
+		});
+		let markWriteStarted!: () => void;
+		const writeStarted = new Promise<void>((resolve) => {
+			markWriteStarted = resolve;
+		});
+		const durablePutStub = sinon
+			.stub(durable, "putKnownMany")
+			.callsFake(async () => {
+				markWriteStarted();
+				await writeGate;
+				throw new Error("tracked mirror failed");
+			});
+		const durableRmManySpy = sinon.spy(durable, "rmMany");
+
+		try {
+			expect(wrapper.putKnownManyColumns([cid], [bytes])).deep.equal([cid]);
+			await within(writeStarted, "tracked mirror start");
+			const cleanup = wrapper.rmManyAfterNativeDelete([cid]).then(
+				() => undefined,
+				(error: unknown) => error,
+			);
+			releaseWrite();
+			const failure = await cleanup;
+			expect(failure).to.be.instanceOf(NativeDurableCommitError);
+			expect(durableRmManySpy.callCount).equal(0);
+		} finally {
+			releaseWrite();
+			durableRmManySpy.restore();
+			durablePutStub.restore();
+		}
+	});
+
+	it("mirrors and then removes rows trimmed inside one native batch", async () => {
+		const { store, durable, backbone } = await openStore(true);
+		const docs = [
+			new Document({ id: "trim-batch-1", name: "trim-batch-1" }),
+			new Document({ id: "trim-batch-2", name: "trim-batch-2" }),
+			new Document({ id: "trim-batch-3", name: "trim-batch-3" }),
+		];
+		const appended = await store.docs.putMany(docs, {
+			unique: true,
+			target: "none",
+		});
+
+		expect(appended.entries).to.have.length(docs.length);
+		expect(store.docs.log.log.length).equal(1);
+		for (const entry of appended.entries.slice(0, -1)) {
+			expect(backbone.blocks.has(entry.hash)).equal(false);
+			expect(await durable.has(entry.hash)).equal(false);
+		}
+		const kept = appended.entries.at(-1)!;
+		expect(backbone.blocks.has(kept.hash)).equal(true);
+		expect(await durable.has(kept.hash)).equal(true);
+	});
+
+	it("does not repopulate native after a delayed durable get races poison", async () => {
+		const { store, wrapper, durable, backbone } = await openStore();
+		const readEntry = await store.docs.put(
+			new Document({ id: "delayed-get", name: "delayed-get" }),
+		);
+		const poisonEntry = await store.docs.put(
+			new Document({ id: "get-poison", name: "get-poison" }),
+		);
+		const readBytes = await durable.get(readEntry.entry.hash);
+		const poisonBytes = await durable.get(poisonEntry.entry.hash);
+		if (!readBytes || !poisonBytes)
+			throw new Error("Expected durable test blocks");
+		backbone.blocks.rm(readEntry.entry.hash);
+		let releaseRead!: () => void;
+		const readGate = new Promise<void>((resolve) => {
+			releaseRead = resolve;
+		});
+		let markReadStarted!: () => void;
+		const readStarted = new Promise<void>((resolve) => {
+			markReadStarted = resolve;
+		});
+		const originalGet = durable.get.bind(durable);
+		const durableGetStub = sinon
+			.stub(durable, "get")
+			.callsFake(async (...args: unknown[]) => {
+				const [cid] = args as [string];
+				if (cid === readEntry.entry.hash) {
+					markReadStarted();
+					await readGate;
+				}
+				return originalGet(cid);
+			});
+		const durablePutStub = sinon
+			.stub(durable, "putKnown")
+			.rejects(new Error("concurrent get poison"));
+		const repopulateSpy = sinon.spy(backbone.blocks, "putKnownManyColumns");
+
+		try {
+			const pendingRead = wrapper.get(readEntry.entry.hash);
+			await within(readStarted, "delayed durable get");
+			const failure = await wrapper
+				.putKnown(poisonEntry.entry.hash, poisonBytes)
+				.then(
+					() => undefined,
+					(error: unknown) => error,
+				);
+			expect(failure).to.be.instanceOf(NativeDurableCommitError);
+			releaseRead();
+			expect(await pendingRead).deep.equal(readBytes);
+			expect(repopulateSpy.callCount).equal(0);
+			expect(backbone.blocks.has(readEntry.entry.hash)).equal(false);
+		} finally {
+			releaseRead();
+			repopulateSpy.restore();
+			durablePutStub.restore();
+			durableGetStub.restore();
+		}
+	});
+
+	it("does not repopulate native after a delayed durable getMany races poison", async () => {
+		const { store, wrapper, durable, backbone } = await openStore();
+		const readEntry = await store.docs.put(
+			new Document({ id: "delayed-many", name: "delayed-many" }),
+		);
+		const poisonEntry = await store.docs.put(
+			new Document({ id: "many-poison", name: "many-poison" }),
+		);
+		const readBytes = await durable.get(readEntry.entry.hash);
+		const poisonBytes = await durable.get(poisonEntry.entry.hash);
+		if (!readBytes || !poisonBytes)
+			throw new Error("Expected durable test blocks");
+		backbone.blocks.rm(readEntry.entry.hash);
+		let releaseRead!: () => void;
+		const readGate = new Promise<void>((resolve) => {
+			releaseRead = resolve;
+		});
+		let markReadStarted!: () => void;
+		const readStarted = new Promise<void>((resolve) => {
+			markReadStarted = resolve;
+		});
+		const originalGetMany = durable.getMany.bind(durable);
+		let getManyCall = 0;
+		const durableGetManyStub = sinon
+			.stub(durable, "getMany")
+			.callsFake(async (...args: unknown[]) => {
+				const [cids] = args as [string[]];
+				if (getManyCall++ === 0) {
+					markReadStarted();
+					await readGate;
+				}
+				return originalGetMany(cids);
+			});
+		const durablePutStub = sinon
+			.stub(durable, "putKnown")
+			.rejects(new Error("concurrent getMany poison"));
+		const repopulateSpy = sinon.spy(backbone.blocks, "putKnownManyColumns");
+
+		try {
+			const pendingRead = wrapper.getMany([readEntry.entry.hash]);
+			await within(readStarted, "delayed durable getMany");
+			const failure = await wrapper
+				.putKnown(poisonEntry.entry.hash, poisonBytes)
+				.then(
+					() => undefined,
+					(error: unknown) => error,
+				);
+			expect(failure).to.be.instanceOf(NativeDurableCommitError);
+			releaseRead();
+			expect(await pendingRead).deep.equal([readBytes]);
+			expect(durableGetManyStub.callCount).equal(2);
+			expect(repopulateSpy.callCount).equal(0);
+			expect(backbone.blocks.has(readEntry.entry.hash)).equal(false);
+		} finally {
+			releaseRead();
+			repopulateSpy.restore();
+			durablePutStub.restore();
+			durableGetManyStub.restore();
+		}
+	});
+
+	it("keeps staged and pending same-CID cleanup when native re-add throws", async () => {
+		const { store, wrapper, durable, backbone } = await openStore();
+		const put = await store.docs.put(
+			new Document({ id: "failed-readd", name: "failed-readd" }),
+		);
+		const cid = put.entry.hash;
+		const bytes = await durable.get(cid);
+		if (!bytes) throw new Error("Expected durable test block");
+
+		const stagedToken = wrapper.beginNativeDeleteCleanup([cid]);
+		const stagedFailure = new Error("staged native re-add failed");
+		const nativePutStub = sinon
+			.stub(backbone.blocks, "putKnown")
+			.throws(stagedFailure);
+		try {
+			expect(
+				await wrapper.putKnown(cid, bytes).then(
+					() => undefined,
+					(error: unknown) => error,
+				),
+			).equal(stagedFailure);
+			expect(
+				wrapper.stagedNativeDeleteCleanups.get(stagedToken).has(cid),
+			).equal(true);
+			expect(wrapper.nativeDeleteTombstones.has(cid)).equal(true);
+		} finally {
+			nativePutStub.restore();
+			wrapper.cancelNativeDeleteCleanup(stagedToken);
+		}
+
+		const retryStub = sinon
+			.stub(wrapper, "retryNativeDeleteCleanup")
+			.resolves();
+		await wrapper.rmManyAfterNativeDelete([cid]);
+		retryStub.restore();
+		expect(wrapper.pendingNativeDeleteCleanup.has(cid)).equal(true);
+		const pendingFailure = new Error("pending native re-add failed");
+		const nativePutManyStub = sinon
+			.stub(backbone.blocks, "putKnownMany")
+			.throws(pendingFailure);
+		try {
+			expect(
+				await wrapper.putKnownMany([[cid, bytes]]).then(
+					() => undefined,
+					(error: unknown) => error,
+				),
+			).equal(pendingFailure);
+			expect(wrapper.pendingNativeDeleteCleanup.has(cid)).equal(true);
+			expect(wrapper.nativeDeleteTombstones.has(cid)).equal(true);
+		} finally {
+			nativePutManyStub.restore();
+			await wrapper.retryNativeDeleteCleanup();
+		}
+	});
+
+	it("guards join/index mutations and resets poison only after same-object reopen", async () => {
+		const { store, sharedLog, wrapper, durable } = await openStore();
+		const durablePutStub = sinon
+			.stub(durable, "putKnown")
+			.rejects(new Error("reopen poison"));
+		const failure = await store.docs
+			.put(new Document({ id: "poison-reopen", name: "poison-reopen" }))
+			.then(
+				() => undefined,
+				(error: unknown) => error,
+			);
+		expect(failure).to.be.instanceOf(NativeDurableCommitError);
+		const failedHash = (failure as NativeDurableCommitError).committedCids[0]!;
+		expect(await store.docs.get("poison-reopen")).equal(undefined);
+		expect(sharedLog.log.length).equal(0);
+		expect(
+			sharedLog._residentEntryCoordinatesByHash?.has(failedHash) ?? false,
+		).equal(false);
+		expect(await durable.has(failedHash)).equal(false);
+
+		const guardedMutations = [
+			["shared join", () => sharedLog.join([])],
+			["lower join", () => sharedLog.log.join([])],
+			["lower trim", () => sharedLog.log.trim()],
+			["lower delete", () => sharedLog.log.delete("missing")],
+		];
+		for (const [name, mutate] of guardedMutations) {
+			expect(
+				await (mutate as () => Promise<unknown>)().then(
+					() => undefined,
+					(error: unknown) => error,
+				),
+				name as string,
+			).equal(failure);
+		}
+
+		const oldRemote = sharedLog.remoteBlocks;
+		const durableStopSpy = sinon.spy(durable, "stop");
+		const rangeStopSpy = sinon.spy(sharedLog._replicationRangeIndex, "stop");
+		const coordinateStopSpy = sinon.spy(
+			sharedLog._entryCoordinatesIndex,
+			"stop",
+		);
+		const logCloseSpy = sinon.spy(sharedLog.log, "close");
+		durablePutStub.restore();
+		try {
+			const closeFailure = await store.close().then(
+				() => undefined,
+				(error: unknown) => error,
+			);
+			expect(closeFailure).equal(failure);
+			expect(durableStopSpy.calledOnce).equal(true);
+			expect(rangeStopSpy.calledOnce).equal(true);
+			expect(coordinateStopSpy.calledOnce).equal(true);
+			expect(logCloseSpy.calledOnce).equal(true);
+			expect(oldRemote.status).equal("closed");
+			expect(durable.status()).equal("closed");
+			// Program parents retain their own open flag when a child close rejects.
+			// The child itself is fully torn down; one idempotent close at each parent
+			// level completes their bookkeeping before reopening the same objects.
+			await store.docs.close();
+			await store.close();
+			expect(store.closed).equal(true);
+
+			const reopened = await client!.open(store, {
+				args: createOpenArgs(directory!),
+			});
+			expect(reopened).equal(store);
+			const freshWrapper = sharedLog.remoteBlocks.localStore;
+			expect(freshWrapper).not.equal(wrapper);
+			expect(sharedLog._nativeDurableCommitFailure).equal(undefined);
+			expect(await store.docs.get("poison-reopen")).equal(undefined);
+			expect(sharedLog.log.length).equal(0);
+			expect(await sharedLog.remoteBlocks.localStore.has(failedHash)).equal(
+				false,
+			);
+			await store.docs.put(
+				new Document({ id: "after-reopen", name: "after-reopen" }),
+			);
+		} finally {
+			logCloseSpy.restore();
+			coordinateStopSpy.restore();
+			rangeStopSpy.restore();
+			durableStopSpy.restore();
+		}
+	});
+
+	it("does not let a queued trim delete a same-CID re-add", async () => {
+		const { store, wrapper, durable, backbone } = await openStore();
+		const first = await store.docs.put(
+			new Document({ id: "re-add", name: "re-add" }),
+		);
+		const cid = first.entry.hash;
+		const bytes = await durable.get(cid);
+		if (!bytes) {
+			throw new Error("Expected the block in durable storage");
+		}
+		backbone.blocks.rm(cid);
+		const originalRmMany = durable.rmMany.bind(durable);
+		let releaseRemove!: () => void;
+		const removeGate = new Promise<void>((resolve) => {
+			releaseRemove = resolve;
+		});
+		let markRemoveStarted!: () => void;
+		const removeStarted = new Promise<void>((resolve) => {
+			markRemoveStarted = resolve;
+		});
+		const durableRmManyStub = sinon
+			.stub(durable, "rmMany")
+			.callsFake(async (...args: unknown[]) => {
+				const [cids] = args as [string[]];
+				markRemoveStarted();
+				await removeGate;
+				return originalRmMany(cids);
+			});
+
+		try {
+			const cleanup = wrapper.rmManyAfterNativeDelete([cid]);
+			await within(removeStarted, "same-CID durable trim");
+			expect(wrapper.putKnownManyColumns([cid], [bytes])).deep.equal([cid]);
+			expect(backbone.blocks.has(cid)).equal(true);
+
+			releaseRemove();
+			await cleanup;
+			await wrapper.waitForDurableWrites();
+			await wrapper.completeCommittedNativeDeleteCleanup([cid]);
+			expect(durableRmManyStub.callCount).equal(1);
+			expect(backbone.blocks.has(cid)).equal(true);
+			expect(await durable.has(cid)).equal(true);
+			expect(await wrapper.has(cid)).equal(true);
+		} finally {
+			releaseRemove();
+			durableRmManyStub.restore();
+		}
+	});
+});

--- a/packages/programs/data/document/document/test/durable-native-hard-kill-worker.mjs
+++ b/packages/programs/data/document/document/test/durable-native-hard-kill-worker.mjs
@@ -1,0 +1,531 @@
+import { NativeBackboneNodeCoordinatePersistence } from "@peerbit/native-backbone";
+import path from "node:path";
+import { Peerbit } from "peerbit";
+import { createRustPeerbitOptions } from "peerbit/rust";
+
+// Keep package build output out of TypeScript's input graph while retaining a
+// plain Node worker that executes the exact compiled artifacts under test.
+const distModule = (relativePath) =>
+	new URL(`../dist/${relativePath}`, import.meta.url).href;
+const { policy, transform } = await import(distModule("src/index.js"));
+const { Documents } = await import(distModule("src/program.js"));
+const { Document, TestStore } = await import(distModule("test/data.js"));
+
+const [mode, directory, expectedHash, expectedOtherHash] =
+	process.argv.slice(2);
+if (!mode || !directory) {
+	throw new Error("Expected mode and directory");
+}
+
+const storeId = new Uint8Array(32);
+for (let index = 0; index < storeId.length; index++) {
+	storeId[index] = (index * 13 + 7) & 0xff;
+}
+
+const client = await Peerbit.create({
+	directory,
+	...createRustPeerbitOptions(),
+});
+const store = new TestStore({ docs: new Documents({ id: storeId }) });
+store.id = storeId;
+await client.open(store, {
+	args: {
+		mode: "native",
+		replicate: false,
+		nativeGraph: true,
+		nativeBackbone: {
+			optional: false,
+			documentIndex: true,
+			coordinatePersistence: new NativeBackboneNodeCoordinatePersistence(
+				path.join(directory, "coordinate-wal"),
+				{ flushOnAppend: true },
+			),
+		},
+		canPerform: policy.allowAll(),
+		index: { type: Document, transform: transform.identity() },
+		...(mode.startsWith("trim-")
+			? { log: { trim: { type: "length", to: 1 } } }
+			: {}),
+	},
+});
+
+if (mode === "strict-generic-torn-marker-write") {
+	const sharedLog = store.docs.log;
+	const entryIndex = sharedLog.log.entryIndex;
+	const intentStore = sharedLog._nativeBackboneCoordinatePersistenceStore;
+	const originalIntentWrite = intentStore.write.bind(intentStore);
+	const originalIndexPut = entryIndex.put.bind(entryIndex);
+	let genericHash;
+	let genericJoin;
+	let genericJoinEnteredResolve;
+	const genericJoinEntered = new Promise((resolve) => {
+		genericJoinEnteredResolve = resolve;
+	});
+	entryIndex.put = async (...args) => {
+		if (args[0]?.hash === genericHash) genericJoinEnteredResolve();
+		return originalIndexPut(...args);
+	};
+
+	let sourceClient;
+	let tornMarker = false;
+	let strictHash;
+	intentStore.write = async (name, bytes) => {
+		let record;
+		try {
+			record = JSON.parse(new TextDecoder().decode(bytes));
+		} catch {}
+		if (
+			!tornMarker &&
+			record?.format === "peerbit-native-strict-durable-transaction" &&
+			record.intent?.lowerMarkerCommitted === true
+		) {
+			strictHash = record.intent.appendHashes[0];
+			const strictEntry = await sharedLog.log.get(strictHash);
+			const strictBytes = await sharedLog.log.blocks.get(strictHash);
+			if (!strictEntry || !strictBytes) {
+				throw new Error(
+					"Expected the strict append to be readable at its marker",
+				);
+			}
+
+			sourceClient = await Peerbit.create(createRustPeerbitOptions());
+			const sourceStore = new TestStore({
+				docs: new Documents({ id: storeId }),
+			});
+			sourceStore.id = storeId;
+			await sourceClient.open(sourceStore, {
+				args: {
+					replicate: false,
+					canPerform: policy.allowAll(),
+					index: { type: Document, transform: transform.identity() },
+				},
+			});
+			await sourceStore.docs.log.log.blocks.putKnown(strictHash, strictBytes);
+			await sourceStore.docs.log.log.join([strictEntry]);
+			const generic = await sourceStore.docs.put(
+				new Document({ id: "strict-generic-y", name: "generic" }),
+				{
+					replicate: false,
+					target: "none",
+					meta: { next: [strictEntry] },
+				},
+			);
+			genericHash = generic.entry.hash;
+			if (!generic.entry.meta.next.includes(strictHash)) {
+				throw new Error(
+					"Expected the generic append to extend the strict append",
+				);
+			}
+			const genericBytes =
+				await sourceStore.docs.log.log.blocks.get(genericHash);
+			if (!genericBytes) throw new Error("Expected generic append bytes");
+			await sharedLog.log.blocks.putKnown(genericHash, genericBytes);
+
+			genericJoin = sharedLog.log.join([generic.entry]);
+			await genericJoinEntered;
+			const joinedWhileStrictLeaseHeld = await Promise.race([
+				genericJoin.then(() => true),
+				new Promise((resolve) => setTimeout(() => resolve(false), 25)),
+			]);
+			if (joinedWhileStrictLeaseHeld) {
+				throw new Error(
+					"Generic receive bypassed the strict native hash mutation lease",
+				);
+			}
+
+			// Persist only a torn true marker. The following clear is deliberately
+			// acknowledged without touching disk, leaving the preceding complete false
+			// intent as the sole valid generation for fresh-process recovery.
+			await originalIntentWrite(
+				name,
+				bytes.subarray(0, Math.max(1, Math.floor(bytes.byteLength / 2))),
+			);
+			tornMarker = true;
+			return;
+		}
+		if (tornMarker && record?.state === "cleared") return;
+		return originalIntentWrite(name, bytes);
+	};
+
+	const strict = await store.docs.put(
+		new Document({ id: "strict-generic-x", name: "strict" }),
+		{ replicate: false, target: "none" },
+	);
+	if (strict.entry.hash !== strictHash || !genericHash || !genericJoin) {
+		throw new Error("Strict/generic torn-marker race did not reach its marker");
+	}
+	await genericJoin;
+	entryIndex.put = originalIndexPut;
+	await sourceClient?.stop();
+	const strictShallow = await entryIndex.getShallow(strictHash);
+	const genericShallow = await entryIndex.getShallow(genericHash);
+	const heads = await sharedLog.log.getHeads().all();
+	process.stdout.write(
+		`${JSON.stringify({
+			event: "strict-generic-torn-marker",
+			strictHash,
+			genericHash,
+			strictIndexed: await entryIndex.has(strictHash),
+			genericIndexed: await entryIndex.has(genericHash),
+			strictHead: strictShallow?.value.head,
+			genericHead: genericShallow?.value.head,
+			headHashes: heads.map((entry) => entry.hash),
+		})}\n`,
+	);
+	setInterval(() => {}, 60_000);
+} else if (mode === "strict-generic-torn-marker-read") {
+	const sharedLog = store.docs.log;
+	const strictShallow = expectedHash
+		? await sharedLog.log.entryIndex.getShallow(expectedHash)
+		: undefined;
+	const genericShallow = expectedOtherHash
+		? await sharedLog.log.entryIndex.getShallow(expectedOtherHash)
+		: undefined;
+	const heads = await sharedLog.log.getHeads().all();
+	process.stdout.write(
+		`${JSON.stringify({
+			event: "strict-generic-torn-marker-read",
+			lowerLogLength: sharedLog.log.length,
+			strictIndexed: expectedHash
+				? await sharedLog.log.entryIndex.has(expectedHash)
+				: false,
+			genericIndexed: expectedOtherHash
+				? await sharedLog.log.entryIndex.has(expectedOtherHash)
+				: false,
+			strictHead: strictShallow?.value.head,
+			genericHead: genericShallow?.value.head,
+			headHashes: heads.map((entry) => entry.hash),
+		})}\n`,
+	);
+	await client.stop();
+} else if (mode === "intent-marker-write") {
+	const sharedLog = store.docs.log;
+	const intentStore = sharedLog._nativeBackboneCoordinatePersistenceStore;
+	const originalWrite = intentStore.write.bind(intentStore);
+	intentStore.write = async (name, bytes) => {
+		let record;
+		try {
+			record = JSON.parse(new TextDecoder().decode(bytes));
+		} catch {}
+		if (
+			record?.format === "peerbit-native-strict-durable-transaction" &&
+			record.intent?.lowerMarkerCommitted === true
+		) {
+			// Simulate a process dying after truncate/partial write. The alternating
+			// journal must retain the preceding complete generation, whose exact lower
+			// row is sufficient to infer this committed marker.
+			await originalWrite(
+				name,
+				bytes.subarray(0, Math.max(1, Math.floor(bytes.byteLength / 2))),
+			);
+			process.stdout.write(
+				`${JSON.stringify({
+					event: "intent-marker-partial",
+					hash: record.intent.appendHashes[0],
+				})}\n`,
+			);
+			await new Promise(() => {});
+		}
+		return originalWrite(name, bytes);
+	};
+	await store.docs.put(new Document({ id: "hard-kill", name: "hard-kill" }));
+} else if (mode === "write") {
+	const result = await store.docs.put(
+		new Document({ id: "hard-kill", name: "hard-kill" }),
+	);
+	process.stdout.write(
+		`${JSON.stringify({ event: "ack", hash: result.entry.hash })}\n`,
+	);
+	// The parent deliberately SIGKILLs this process after observing the ack.
+	setInterval(() => {}, 60_000);
+} else if (mode === "premarker-write") {
+	const sharedLog = store.docs.log;
+	const lowerIndex = sharedLog.log.entryIndex.properties.index;
+	lowerIndex.put = async (value) => {
+		process.stdout.write(
+			`${JSON.stringify({ event: "premarker", hash: value.hash })}\n`,
+		);
+		await new Promise(() => {});
+	};
+	await store.docs.put(
+		new Document({ id: "premarker-hard-kill", name: "must-rollback" }),
+	);
+} else if (mode === "pending-next-premarker-write") {
+	const first = await store.docs.put(
+		new Document({ id: "pending-next-premarker", name: "old" }),
+		{ replicate: false, target: "none" },
+	);
+	const sharedLog = store.docs.log;
+	const entryIndex = sharedLog.log.entryIndex;
+	const lowerIndex = entryIndex.properties.index;
+	const oldShallow = (await entryIndex.getShallow(first.entry.hash))?.value;
+	if (!oldShallow) throw new Error("Expected acknowledged old shallow row");
+	if (!lowerIndex.delIds)
+		throw new Error("Expected exact lower-index deletion");
+	await lowerIndex.delIds([first.entry.hash]);
+	// Recreate the normal deferred-publication state: the acknowledged old head is
+	// logically visible to EntryIndex but absent from the durable index. The next
+	// append consumes and demotes this pending row before its own marker is written.
+	entryIndex.pendingIndexWrites.set(first.entry.hash, oldShallow);
+	entryIndex.pendingIndexWriteGenerations.set(first.entry.hash, 1_000_000);
+	const originalPut = lowerIndex.put.bind(lowerIndex);
+	lowerIndex.put = async (value) => {
+		await originalPut(value);
+		if (value.hash !== first.entry.hash || value.head !== false) return;
+		process.stdout.write(
+			`${JSON.stringify({
+				event: "pending-next-premarker",
+				firstHash: first.entry.hash,
+			})}\n`,
+		);
+		await new Promise(() => {});
+	};
+	await store.docs.put(
+		new Document({ id: "pending-next-premarker", name: "replacement" }),
+		{ replicate: false, target: "none" },
+	);
+} else if (mode === "pending-next-premarker-read") {
+	const sharedLog = store.docs.log;
+	const document = await store.docs.get("pending-next-premarker");
+	const oldShallow = expectedHash
+		? await sharedLog.log.entryIndex.getShallow(expectedHash)
+		: undefined;
+	process.stdout.write(
+		`${JSON.stringify({
+			event: "pending-next-premarker-read",
+			documentName: document?.name,
+			lowerLogLength: sharedLog.log.length,
+			oldIndexed: expectedHash
+				? await sharedLog.log.entryIndex.has(expectedHash)
+				: false,
+			oldHead: oldShallow?.value.head,
+		})}\n`,
+	);
+	await client.stop();
+} else if (mode === "premarker-read") {
+	const sharedLog = store.docs.log;
+	const document = await store.docs.get("premarker-hard-kill");
+	process.stdout.write(
+		`${JSON.stringify({
+			event: "premarker-read",
+			documentVisible: !!document,
+			lowerLogLength: sharedLog.log.length,
+			coordinateVisible: expectedHash
+				? sharedLog._residentEntryCoordinatesByHash?.has(expectedHash) === true
+				: false,
+		})}\n`,
+	);
+	await client.stop();
+} else if (mode === "read") {
+	const document = await store.docs.get("hard-kill");
+	const block = expectedHash
+		? await store.docs.log.log.blocks.get(expectedHash)
+		: undefined;
+	process.stdout.write(
+		`${JSON.stringify({
+			event: "read",
+			documentName: document?.name,
+			entryHash: block ? expectedHash : undefined,
+		})}\n`,
+	);
+	await client.stop();
+} else if (mode === "trim-failure-write") {
+	const first = await store.docs.put(
+		new Document({ id: "trim-hard-kill", name: "acknowledged" }),
+		{ unique: true },
+	);
+	const sharedLog = store.docs.log;
+	const durable = sharedLog.remoteBlocks.localStore.durable;
+	durable.rmMany = async () => {
+		throw new Error("injected durable trim cleanup failure");
+	};
+	const replacement = await store.docs.put(
+		new Document({ id: "trim-hard-kill", name: "replacement" }),
+		{ unique: true },
+	);
+	process.stdout.write(
+		`${JSON.stringify({
+			event: "trim-ack",
+			firstHash: first.entry.hash,
+			replacementHash: replacement.entry.hash,
+			cleanupDebt:
+				sharedLog.remoteBlocks.localStore.pendingNativeDeleteCleanup.size,
+		})}\n`,
+	);
+	setInterval(() => {}, 60_000);
+} else if (mode === "trim-marker-write") {
+	const first = await store.docs.put(
+		new Document({ id: "trim-marker-hard-kill", name: "old" }),
+		{ unique: true },
+	);
+	const sharedLog = store.docs.log;
+	const lowerIndex = sharedLog.log.entryIndex.properties.index;
+	const originalPut = lowerIndex.put.bind(lowerIndex);
+	let replacementHash;
+	lowerIndex.put = async (value) => {
+		await originalPut(value);
+		if (value.hash !== first.entry.hash) replacementHash = value.hash;
+	};
+	const originalDelIds = lowerIndex.delIds?.bind(lowerIndex);
+	if (!originalDelIds) throw new Error("Expected exact lower-index deletion");
+	lowerIndex.delIds = async (hashes) => {
+		process.stdout.write(
+			`${JSON.stringify({
+				event: "trim-marker",
+				firstHash: first.entry.hash,
+				replacementHash,
+				trimHashes: hashes,
+			})}\n`,
+		);
+		await new Promise(() => {});
+	};
+	await store.docs.put(
+		new Document({ id: "trim-marker-hard-kill", name: "replacement" }),
+		{ unique: true },
+	);
+} else if (mode === "trim-marker-read") {
+	const sharedLog = store.docs.log;
+	const document = await store.docs.get("trim-marker-hard-kill");
+	const heads = await sharedLog.log.getHeads().all();
+	const oldBlock = expectedOtherHash
+		? await sharedLog.log.blocks.get(expectedOtherHash)
+		: undefined;
+	process.stdout.write(
+		`${JSON.stringify({
+			event: "trim-marker-read",
+			documentName: document?.name,
+			lowerLogLength: sharedLog.log.length,
+			headHashes: heads.map((entry) => entry.hash),
+			replacementIndexed: expectedHash
+				? await sharedLog.log.entryIndex.has(expectedHash)
+				: false,
+			oldBlockPresent: !!oldBlock,
+		})}\n`,
+	);
+	await client.stop();
+} else if (mode === "next-marker-write") {
+	const first = await store.docs.put(
+		new Document({ id: "next-marker-hard-kill", name: "old" }),
+		{ replicate: false, target: "none" },
+	);
+	const sharedLog = store.docs.log;
+	const lowerIndex = sharedLog.log.entryIndex.properties.index;
+	const originalPut = lowerIndex.put.bind(lowerIndex);
+	lowerIndex.put = async (value) => {
+		await originalPut(value);
+		if (value.hash === first.entry.hash) return;
+		process.stdout.write(
+			`${JSON.stringify({
+				event: "next-marker",
+				firstHash: first.entry.hash,
+				replacementHash: value.hash,
+				deleteHashes: [first.entry.hash],
+			})}\n`,
+		);
+		await new Promise(() => {});
+	};
+	await store.docs.put(
+		new Document({ id: "next-marker-hard-kill", name: "replacement" }),
+		{ replicate: false, target: "none" },
+	);
+} else if (mode === "next-marker-read") {
+	const sharedLog = store.docs.log;
+	const document = await store.docs.get("next-marker-hard-kill");
+	const heads = await sharedLog.log.getHeads().all();
+	process.stdout.write(
+		`${JSON.stringify({
+			event: "next-marker-read",
+			documentName: document?.name,
+			lowerLogLength: sharedLog.log.length,
+			headHashes: heads.map((entry) => entry.hash),
+			oldCoordinateVisible: expectedHash
+				? sharedLog._residentEntryCoordinatesByHash?.has(expectedHash) === true
+				: false,
+			replacementCoordinateVisible: expectedOtherHash
+				? sharedLog._residentEntryCoordinatesByHash?.has(expectedOtherHash) ===
+					true
+				: false,
+		})}\n`,
+	);
+	await client.stop();
+} else if (mode === "trim-failure-read") {
+	const block = expectedHash
+		? await store.docs.log.log.blocks.get(expectedHash)
+		: undefined;
+	const document = await store.docs.get("trim-hard-kill");
+	const heads = await store.docs.log.log.getHeads().all();
+	const oldBlock = expectedOtherHash
+		? await store.docs.log.log.blocks.get(expectedOtherHash)
+		: undefined;
+	process.stdout.write(
+		`${JSON.stringify({
+			event: "trim-read",
+			replacementBlockPresent: !!block,
+			documentName: document?.name,
+			lowerLogLength: store.docs.log.log.length,
+			headHashes: heads.map((entry) => entry.hash),
+			oldBlockPresent: !!oldBlock,
+		})}\n`,
+	);
+	await client.stop();
+} else if (
+	mode === "mirror-failure-write" ||
+	mode === "mirror-failure-graceful-write"
+) {
+	const sharedLog = store.docs.log;
+	const durable = sharedLog.remoteBlocks.localStore.durable;
+	durable.putKnown = async () => {
+		throw new Error("injected durable mirror failure");
+	};
+	let rejection;
+	try {
+		await store.docs.put(
+			new Document({ id: "mirror-failed", name: "must-not-survive" }),
+		);
+	} catch (error) {
+		rejection = error;
+	}
+	const failedHash = rejection?.committedCids?.[0];
+	process.stdout.write(
+		`${JSON.stringify({
+			event: "mirror-rejected",
+			failedHash,
+			errorName: rejection?.name,
+			documentVisible: !!(await store.docs.get("mirror-failed")),
+			lowerLogLength: sharedLog.log.length,
+			coordinateVisible: failedHash
+				? sharedLog._residentEntryCoordinatesByHash?.has(failedHash) === true
+				: false,
+		})}\n`,
+	);
+	if (mode === "mirror-failure-graceful-write") {
+		try {
+			await client.stop();
+		} catch (error) {
+			if (error !== rejection) throw error;
+		}
+		process.exit(0);
+	} else {
+		setInterval(() => {}, 60_000);
+	}
+} else if (mode === "mirror-failure-read") {
+	const sharedLog = store.docs.log;
+	const document = await store.docs.get("mirror-failed");
+	const block = expectedHash
+		? await sharedLog.log.blocks.get(expectedHash)
+		: undefined;
+	process.stdout.write(
+		`${JSON.stringify({
+			event: "mirror-read",
+			documentVisible: !!document,
+			blockVisible: !!block,
+			lowerLogLength: sharedLog.log.length,
+			coordinateVisible: expectedHash
+				? sharedLog._residentEntryCoordinatesByHash?.has(expectedHash) === true
+				: false,
+		})}\n`,
+	);
+	await client.stop();
+} else {
+	throw new Error(`Unknown mode: ${mode}`);
+}

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -2199,7 +2199,7 @@ describe("index", () => {
 				}
 			});
 
-			it("removes trimmed prepared puts from the document index by head", async () => {
+			it("removes durably indexed native puts by exact head", async () => {
 				const rustSession = await TestSession.connected(
 					1,
 					createRustPeerbitOptions(),
@@ -2254,9 +2254,12 @@ describe("index", () => {
 					expect(entryIndexGetSpy.withArgs(first.entry.hash).callCount).equal(
 						0,
 					);
-					expect(
-						entryIndexDelIdsSpy.callCount + entryIndexDelSpy.callCount,
-					).equal(0);
+					// Strict native acknowledgement flushes append facts before returning,
+					// so trim must delete the now-durable row by exact id.
+					expect(entryIndexDelIdsSpy.callCount).equal(1);
+					expect(entryIndexDelIdsSpy.firstCall.args[0]).to.deep.equal([
+						first.entry.hash,
+					]);
 					expect(entryIndexDelSpy.callCount).equal(0);
 					expect(await store.docs.get(firstId)).to.be.undefined;
 					expect(changes).to.have.length(2);

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -2210,6 +2210,8 @@ describe("index", () => {
 				await rustSession.peers[0].open(store, {
 					args: {
 						replicate: false,
+						nativeGraph: true,
+						nativeBackbone: { optional: false },
 						log: {
 							trim: { type: "length", to: 1 },
 						},
@@ -2241,6 +2243,10 @@ describe("index", () => {
 				const entryIndexDelSpy = sinon.spy(entryIndexBackend, "del");
 
 				try {
+					expect(
+						await entryIndexBackend.get(toId(first.entry.hash)),
+						"strict native acknowledgement must durably index the append",
+					).to.not.be.undefined;
 					await store.docs.put(
 						new Document({ id: uuid(), name: "remaining" }),
 						{

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -55,6 +55,7 @@ import {
 	NativeBackboneBufferedCoordinatePersistenceStore,
 	NativeBackboneCoordinatePersistence,
 	NativeBackboneMemoryCoordinatePersistenceStore,
+	NativeBackboneNodeCoordinatePersistenceStore,
 	createNativePeerbitBackbone,
 } from "@peerbit/native-backbone";
 import { ClosedError, Program } from "@peerbit/program";
@@ -1948,7 +1949,7 @@ describe("index", () => {
 				}
 			});
 
-			it("flushes buffered native backbone coordinate WAL on close", async () => {
+			it("flushes buffered native backbone WAL before strict acknowledgement", async () => {
 				const rustSession = await TestSession.connected(
 					1,
 					createRustPeerbitOptions(),
@@ -2027,9 +2028,11 @@ describe("index", () => {
 					expect(documentStoredIdentityPutSpy.callCount).equal(0);
 					expect(backendStoredContextPutSpy.callCount).equal(0);
 					expect(backbone.documentValueLength).equal(1);
-					expect(flushSpy.callCount).equal(0);
-					expect(backbone.coordinatePendingJournalLength).to.be.greaterThan(0);
-					expect(coordinateStore.files.has("coordinates.wal")).equal(false);
+					expect(flushSpy.callCount).equal(1);
+					expect(backbone.coordinatePendingJournalLength).to.equal(0);
+					expect(backbone.documentPendingJournalLength).to.equal(0);
+					expect(backbone.documentSignerPendingJournalLength).to.equal(0);
+					expect(coordinateStore.files.has("coordinates.wal")).equal(true);
 					await store.close();
 					store = undefined;
 
@@ -3565,7 +3568,10 @@ describe("index", () => {
 				it("keeps strict native same-signer policies native after reopen with persisted signer facts", async () => {
 					const [{ rm }] = await Promise.all([import("node:fs/promises")]);
 					const directory = `./tmp/document-store/native-same-signer-reopen-${uuid()}`;
-					const coordinateStore = new MemoryCoordinatePersistenceStore();
+					const coordinateStore =
+						new NativeBackboneNodeCoordinatePersistenceStore(
+							`${directory}/native-backbone-coordinates`,
+						);
 					const openArgs = () => ({
 						mode: "native" as const,
 						replicate: false,
@@ -3615,10 +3621,8 @@ describe("index", () => {
 						store = undefined;
 						await peer.stop();
 						peer = undefined;
-						expect(coordinateStore.files.has("coordinates.wal")).equal(true);
-						expect(coordinateStore.files.has("document-signers.wal")).equal(
-							true,
-						);
+						expect(await coordinateStore.read("coordinates.wal")).to.exist;
+						expect(await coordinateStore.read("document-signers.wal")).to.exist;
 
 						peer = await Peerbit.create({
 							...createRustPeerbitOptions(),
@@ -3674,10 +3678,16 @@ describe("index", () => {
 					const [{ rm }] = await Promise.all([import("node:fs/promises")]);
 					const sourceDirectory = `./tmp/document-store/native-same-signer-receive-source-${uuid()}`;
 					const targetDirectory = `./tmp/document-store/native-same-signer-receive-target-${uuid()}`;
-					const sourceCoordinateStore = new MemoryCoordinatePersistenceStore();
-					const targetCoordinateStore = new MemoryCoordinatePersistenceStore();
+					const sourceCoordinateStore =
+						new NativeBackboneNodeCoordinatePersistenceStore(
+							`${sourceDirectory}/native-backbone-coordinates`,
+						);
+					const targetCoordinateStore =
+						new NativeBackboneNodeCoordinatePersistenceStore(
+							`${targetDirectory}/native-backbone-coordinates`,
+						);
 					const openArgs = (
-						coordinateStore: MemoryCoordinatePersistenceStore,
+						coordinateStore: NativeBackboneNodeCoordinatePersistenceStore,
 						replicate: false | { factor: number } = { factor: 1 },
 					) => ({
 						mode: "native" as const,
@@ -3753,9 +3763,9 @@ describe("index", () => {
 							reopenedTarget = await targetPeer.open(clone, {
 								args: openArgs(targetCoordinateStore, false),
 							});
-						expect(targetCoordinateStore.files.has("document-signers.wal")).equal(
-							true,
-						);
+						expect(
+							await targetCoordinateStore.read("document-signers.wal"),
+						).to.exist;
 						const reopenedBackbone = (reopenedTarget.docs.log as any)
 							._nativeBackbone;
 						const reopenedSignerFact =
@@ -3841,7 +3851,10 @@ describe("index", () => {
 
 					const [{ rm }] = await Promise.all([import("node:fs/promises")]);
 					const directory = `./tmp/document-store/native-same-signer-batch-reopen-${uuid()}`;
-					const coordinateStore = new MemoryCoordinatePersistenceStore();
+					const coordinateStore =
+						new NativeBackboneNodeCoordinatePersistenceStore(
+							`${directory}/native-backbone-coordinates`,
+						);
 					const openArgs = () => ({
 						mode: "native" as const,
 						replicate: false,
@@ -3911,11 +3924,9 @@ describe("index", () => {
 						store = undefined;
 						await peer.stop();
 						peer = undefined;
-						expect(coordinateStore.files.has("coordinates.wal")).equal(true);
-						expect(coordinateStore.files.has("document-values.wal")).equal(true);
-						expect(coordinateStore.files.has("document-signers.wal")).equal(
-							true,
-						);
+						expect(await coordinateStore.read("coordinates.wal")).to.exist;
+						expect(await coordinateStore.read("document-values.wal")).to.exist;
+						expect(await coordinateStore.read("document-signers.wal")).to.exist;
 
 						peer = await Peerbit.create({
 							...createRustPeerbitOptions(),
@@ -5797,10 +5808,16 @@ describe("index", () => {
 							const [{ rm }] = await Promise.all([import("node:fs/promises")]);
 							const sourceDirectory = `./tmp/document-store/native-project-receive-wal-source-${uuid()}`;
 							const targetDirectory = `./tmp/document-store/native-project-receive-wal-target-${uuid()}`;
-							const sourceCoordinateStore = new MemoryCoordinatePersistenceStore();
-							const targetCoordinateStore = new MemoryCoordinatePersistenceStore();
+							const sourceCoordinateStore =
+								new NativeBackboneNodeCoordinatePersistenceStore(
+									`${sourceDirectory}/native-backbone-coordinates`,
+								);
+							const targetCoordinateStore =
+								new NativeBackboneNodeCoordinatePersistenceStore(
+									`${targetDirectory}/native-backbone-coordinates`,
+								);
 							const openArgs = (
-								coordinateStore: MemoryCoordinatePersistenceStore,
+								coordinateStore: NativeBackboneNodeCoordinatePersistenceStore,
 								replicate: false | { factor: number } = { factor: 1 },
 							) => ({
 								mode: "native" as const,
@@ -5890,9 +5907,9 @@ describe("index", () => {
 								target = undefined;
 								await targetPeer.stop();
 								targetPeer = undefined;
-								expect(targetCoordinateStore.files.has("document-values.wal")).equal(
-									true,
-								);
+								expect(
+									await targetCoordinateStore.read("document-values.wal"),
+								).to.exist;
 
 								targetPeer = await Peerbit.create({
 									...createRustPeerbitOptions(),
@@ -6411,7 +6428,10 @@ describe("index", () => {
 				it("restores strict native document index from native document WAL without indexer mirror", async () => {
 					const [{ rm }] = await Promise.all([import("node:fs/promises")]);
 					const directory = `./tmp/document-store/native-document-index-wal-${uuid()}`;
-					const coordinateStore = new MemoryCoordinatePersistenceStore();
+					const coordinateStore =
+						new NativeBackboneNodeCoordinatePersistenceStore(
+							`${directory}/native-backbone-coordinates`,
+						);
 					const openArgs = () => ({
 						mode: "native" as const,
 						replicate: false,
@@ -6471,7 +6491,7 @@ describe("index", () => {
 						store = undefined;
 						await peer.stop();
 						peer = undefined;
-						expect(coordinateStore.files.has("document-values.wal")).equal(true);
+						expect(await coordinateStore.read("document-values.wal")).to.exist;
 
 						peer = await Peerbit.create({
 							...createRustPeerbitOptions(),
@@ -6529,7 +6549,10 @@ describe("index", () => {
 
 					const [{ rm }] = await Promise.all([import("node:fs/promises")]);
 					const directory = `./tmp/document-store/native-document-index-project-wal-${uuid()}`;
-					const coordinateStore = new MemoryCoordinatePersistenceStore();
+					const coordinateStore =
+						new NativeBackboneNodeCoordinatePersistenceStore(
+							`${directory}/native-backbone-coordinates`,
+						);
 					const openArgs = () => ({
 						mode: "native" as const,
 						replicate: false,
@@ -6613,7 +6636,7 @@ describe("index", () => {
 						store = undefined;
 						await peer.stop();
 						peer = undefined;
-						expect(coordinateStore.files.has("document-values.wal")).equal(true);
+						expect(await coordinateStore.read("document-values.wal")).to.exist;
 
 						peer = await Peerbit.create({
 							...createRustPeerbitOptions(),
@@ -9088,7 +9111,10 @@ describe("index", () => {
 					}
 
 					const directory = `./tmp/document-store/native-delete-owner-reopen-${uuid()}`;
-					const coordinateStore = new MemoryCoordinatePersistenceStore();
+					const coordinateStore =
+						new NativeBackboneNodeCoordinatePersistenceStore(
+							`${directory}/native-backbone-coordinates`,
+						);
 					const openArgs = () => ({
 						mode: "native" as const,
 						replicate: false,

--- a/packages/programs/data/shared-log/src/errors.ts
+++ b/packages/programs/data/shared-log/src/errors.ts
@@ -5,3 +5,65 @@ export class NoPeersError extends Error {
 		);
 	}
 }
+
+/**
+ * The native transaction committed hot/runtime facts before its entry block
+ * could be mirrored to durable storage. Lower-log publication is held behind
+ * the mirror barrier, but blindly retrying the user operation is unsafe because
+ * native state may already contain the attempted commit.
+ */
+export class NativeDurableCommitError extends Error {
+	readonly nativeCommitApplied = true;
+	readonly retrySafe = false;
+	readonly cause: unknown;
+	readonly committedCids: readonly string[];
+	readonly failedCids: readonly string[];
+	private readonly committedCidList: string[];
+	private readonly failedCidList: string[];
+
+	constructor(
+		cause: unknown,
+		options?: {
+			committedCids?: Iterable<string>;
+			failedCids?: Iterable<string>;
+		},
+	) {
+		const committedCids = [...(options?.committedCids ?? [])];
+		const failedCids = [...(options?.failedCids ?? committedCids)];
+		super(
+			`Native commit applied but a durable block mutation failed; automatic retry is unsafe: ${
+				cause instanceof Error ? cause.message : String(cause)
+			}${failedCids.length > 0 ? ` (failed CIDs: ${failedCids.join(", ")})` : ""}`,
+		);
+		this.name = "NativeDurableCommitError";
+		this.cause = cause;
+		this.committedCidList = committedCids;
+		this.failedCidList = failedCids;
+		this.committedCids = this.committedCidList;
+		this.failedCids = this.failedCidList;
+	}
+
+	/** @internal Merge facts from other mutations covered by the same poison. */
+	addCommitContext(
+		options?: {
+			committedCids?: Iterable<string>;
+			failedCids?: Iterable<string>;
+		},
+		properties?: { preferIncomingOrder?: boolean },
+	): void {
+		const merge = (
+			target: string[],
+			incoming: Iterable<string> | undefined,
+		): void => {
+			if (!incoming) {
+				return;
+			}
+			const values = properties?.preferIncomingOrder
+				? [...incoming, ...target]
+				: [...target, ...incoming];
+			target.splice(0, target.length, ...new Set(values));
+		};
+		merge(this.committedCidList, options?.committedCids);
+		merge(this.failedCidList, options?.failedCids);
+	}
+}

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -38,6 +38,7 @@ import {
 	type Change,
 	type Ed25519VerifyBatchInput,
 	Entry,
+	type EntryIndexHashMutationLockOwner,
 	EntryType,
 	LamportClock,
 	Log,
@@ -59,15 +60,15 @@ import type {
 	NativeBackboneAppendResult,
 	NativeBackboneCoordinateCommitColumns,
 	NativeBackboneCoordinateFields,
-	NativeBackboneCoordinatePersistenceConfig as RuntimeNativeBackboneCoordinatePersistenceConfig,
 	NativeBackboneLogCommitEntry,
-	NativeBackboneRequestPruneHintColumns,
 	NativeBackboneRawReceiveGroupAssignmentPlan,
 	NativeBackboneRawReceiveGroupIndexPlan,
 	NativeBackboneRawReceiveGroupLeaderPlan,
 	NativeBackboneRawReceiveGroupPlan,
 	NativeBackboneRawReceiveSelectionPlan,
+	NativeBackboneRequestPruneHintColumns,
 	NativePeerbitBackbone,
+	NativeBackboneCoordinatePersistenceConfig as RuntimeNativeBackboneCoordinatePersistenceConfig,
 } from "@peerbit/native-backbone";
 import { ClosedError, Program, type ProgramEvents } from "@peerbit/program";
 import {
@@ -127,15 +128,15 @@ import {
 	type DebouncedAccumulatorMap,
 	debouncedAccumulatorMap,
 } from "./debounce.js";
-import { NoPeersError } from "./errors.js";
+import { NativeDurableCommitError, NoPeersError } from "./errors.js";
 import {
 	EXCHANGE_HEADS_REPAIR_HINT,
 	EntryWithRefs,
 	ExchangeHeadsMessage,
 	MAX_RAW_EXCHANGE_MESSAGE_SIZE,
 	RawEntryWithRefs,
-	RawExchangeHeadsMessage,
 	type RawExchangeHeadSendPlan,
+	RawExchangeHeadsMessage,
 	type RawReceiveHashSelection,
 	RequestIPrune,
 	ResponseIPrune,
@@ -151,8 +152,8 @@ import {
 	getPreparedRawExchangeHeadAppendFacts,
 	getPreparedRawExchangeHeadGid,
 	getPreparedRawExchangeHeadRequestedReplicas,
-	getPreparedRawExchangeHeadSignatureVerified,
 	getPreparedRawExchangeHeadShallowEntry,
+	getPreparedRawExchangeHeadSignatureVerified,
 	getPreparedRawExchangeNext,
 	getPreparedRawExchangeRequestedReplicas,
 	getPreparedRawExchangeTimestamp,
@@ -339,6 +340,7 @@ export {
 	EntryReplicatedU32,
 	EntryReplicatedU64,
 	type CoverRange,
+	NativeDurableCommitError,
 	NoPeersError,
 };
 export { MAX_U32, MAX_U64, type NumberFromType };
@@ -348,7 +350,11 @@ export type {
 	SyncProfileEvent,
 	SyncProfileFn,
 } from "./sync/index.js";
-export { ExchangeHeadsMessage, RawExchangeHeadsMessage };
+export {
+	ExchangeHeadsMessage,
+	RawExchangeHeadsMessage,
+	StashBackedRawExchangeHeadsMessage,
+};
 export const logger = loggerFn("peerbit:shared-log");
 const warn = logger.newScope("warn");
 const traceLogger = logger.trace as typeof logger.trace & { enabled?: boolean };
@@ -381,17 +387,8 @@ const canUseOptionalNativeModuleImports = (): boolean => {
 const joinNativeCoordinateDirectory = (
 	nodeDirectory: string,
 	fsSafeLogId: string,
-): string => `${nodeDirectory.replace(/[/\\]+$/, "")}/coordinates/${fsSafeLogId}`;
-
-// Native durable block mirrors are content-addressed and therefore primarily
-// append-only. Rewriting the complete live block set into a RustAnyStore
-// snapshot on every program close is redundant and makes close O(total block
-// bytes). Keep the WAL crash-safe and defer that rewrite on close until the
-// journal reaches this explicit threshold. This does not cap WAL growth during
-// an open session. Stores that do not support per-sublevel options ignore the
-// second argument and retain their existing behavior.
-const NATIVE_DURABLE_BLOCK_COMPACT_ON_CLOSE_MIN_JOURNAL_BYTES =
-	512 * 1024 * 1024;
+): string =>
+	`${nodeDirectory.replace(/[/\\]+$/, "")}/coordinates/${fsSafeLogId}`;
 
 type DurableBlockSublevelStore = {
 	sublevel(
@@ -399,6 +396,7 @@ type DurableBlockSublevelStore = {
 		options?: {
 			compactOnClose?: boolean;
 			compactOnCloseMinJournalBytes?: number;
+			durability?: "normal" | "strict";
 		},
 	): MaybePromise<AnyStore>;
 };
@@ -408,9 +406,14 @@ const createNativeDurableBlockStore = async (
 ): Promise<AnyBlockStore> =>
 	new AnyBlockStore(
 		await storage.sublevel("blocks", {
+			// Strict mirrors remain WAL-backed across close. The available snapshot
+			// rewrite is not a crash-atomic generation protocol, so thresholds must
+			// not re-enable it behind this acknowledgement boundary.
 			compactOnClose: false,
-			compactOnCloseMinJournalBytes:
-				NATIVE_DURABLE_BLOCK_COMPACT_ON_CLOSE_MIN_JOURNAL_BYTES,
+			// A native append is acknowledged only after this mirror resolves. The
+			// Rust store's normal immutable fast path may resolve before its WAL write;
+			// strict mode waits for the journal write and sync, closing the SIGKILL gap.
+			durability: "strict",
 		}),
 	);
 
@@ -427,6 +430,18 @@ const createDefaultDurableBlockStore = async (
 
 /** The native backbone's in-wasm-memory block store. */
 type NativeBackboneBlocks = NativePeerbitBackbone["blocks"];
+
+type NativeCommitOwnershipToken = {
+	id: number;
+	rows: Map<
+		string,
+		{
+			generation: number;
+			durableExistedBefore?: boolean;
+			shared: boolean;
+		}
+	>;
+};
 
 /**
  * Write-through block store bridging the native backbone's in-wasm-memory block
@@ -447,11 +462,12 @@ type NativeBackboneBlocks = NativePeerbitBackbone["blocks"];
  * METHOD SURFACE (see #1006): `RemoteBlocks` and the log feature-detect the
  * optional batch methods (`putMany`/`putKnown`/`putKnownMany`/
  * `putKnownManyColumns`/`rmMany`). To keep the receive-fusion / columnar fast
- * paths engaged this wrapper exposes EXACTLY the methods the native store
- * exposes — including `putKnownManyColumns`, which `AnyBlockStore` does not have
- * — and delegates each. It deliberately does not add methods the native store
- * lacks (`getBlockResponsePayload`/`getNativeLogBlockStoreHandle` stay absent so
- * the optional-chained probes in `RemoteBlocks` behave exactly as today).
+ * paths engaged this wrapper preserves the native store's optional write
+ * methods — including `putKnownManyColumns`, which `AnyBlockStore` does not have
+ * — and delegates each. It adds only local durability/trim coordination hooks
+ * consumed by `RemoteBlocks` and the log; protocol/native-handle capabilities
+ * such as `getBlockResponsePayload`/`getNativeLogBlockStoreHandle` stay absent,
+ * so their optional-chained probes keep the existing fallback behavior.
  */
 class NativeBackboneWriteThroughBlockStore {
 	constructor(
@@ -468,9 +484,357 @@ class NativeBackboneWriteThroughBlockStore {
 	// vanishing and leaving the block out of durable while native/log report
 	// success. `.catch` also prevents unhandled-rejection noise.
 	private readonly pendingDurableWrites = new Set<Promise<unknown>>();
-	private durableWriteError: unknown;
+	private nativeDurableCommitFailure?: NativeDurableCommitError;
+	private readonly nativeDeleteTombstones = new Map<string, number>();
+	private nativeDeleteEpoch = 0;
+	private readonly nativeBlockWriteGenerations = new Map<string, number>();
+	private readonly pendingNativeDeleteCleanup = new Map<string, number>();
+	private readonly stagedNativeDeleteCleanups = new Map<
+		number,
+		Map<string, number>
+	>();
+	private nextNativeDeleteCleanupToken = 0;
+	private nativeDeleteCleanupRunning: Promise<void> | undefined;
+	private nextNativeCommitOwnershipToken = 0;
+	private readonly nativeCommitOwnerships = new Map<
+		number,
+		NativeCommitOwnershipToken
+	>();
+	private readonly nativeCommitOwnershipsByCid = new Map<string, Set<number>>();
 
-	private trackDurable(result: unknown): void {
+	getNativeDurableCommitFailure(): NativeDurableCommitError | undefined {
+		return this.nativeDurableCommitFailure;
+	}
+
+	private recordNativeDurableCommitFailure(
+		cause: unknown,
+		options?: {
+			committedCids?: Iterable<string>;
+			failedCids?: Iterable<string>;
+		},
+	): NativeDurableCommitError {
+		if (this.nativeDurableCommitFailure) {
+			this.nativeDurableCommitFailure.addCommitContext(options);
+			return this.nativeDurableCommitFailure;
+		}
+		this.nativeDurableCommitFailure =
+			cause instanceof NativeDurableCommitError
+				? cause
+				: new NativeDurableCommitError(cause, options);
+		if (cause instanceof NativeDurableCommitError) {
+			cause.addCommitContext(options);
+		}
+		return this.nativeDurableCommitFailure;
+	}
+
+	private throwIfNativeDurableCommitFailed(): void {
+		if (this.nativeDurableCommitFailure) {
+			throw this.nativeDurableCommitFailure;
+		}
+	}
+
+	throwIfDurableWritesFailed(): void {
+		this.throwIfNativeDurableCommitFailed();
+	}
+
+	private async commitDurableMutation<T>(
+		operation: () => MaybePromise<T>,
+		committedCids: Iterable<string>,
+		failedCids?: Iterable<string>,
+	): Promise<T> {
+		this.throwIfNativeDurableCommitFailed();
+		const committedCidList = [...committedCids];
+		const failedCidList = failedCids ? [...failedCids] : committedCidList;
+		let result: T;
+		const operationResult = Promise.resolve().then(operation);
+		this.trackAwaitedDurable(operationResult);
+		try {
+			result = await operationResult;
+		} catch (error) {
+			throw this.recordNativeDurableCommitFailure(error, {
+				committedCids: committedCidList,
+				failedCids: failedCidList,
+			});
+		}
+		// A different concurrent native mutation may have poisoned the wrapper
+		// while this durable call was in flight. Include this operation among the
+		// native-applied facts, but not among durable calls that actually failed.
+		if (this.nativeDurableCommitFailure) {
+			this.nativeDurableCommitFailure.addCommitContext({
+				committedCids: committedCidList,
+				failedCids: [],
+			});
+			throw this.nativeDurableCommitFailure;
+		}
+		return result;
+	}
+
+	private beginNativeDelete(cids: string[]): void {
+		this.nativeDeleteEpoch++;
+		for (const cid of cids) {
+			this.nativeDeleteTombstones.set(
+				cid,
+				(this.nativeDeleteTombstones.get(cid) ?? 0) + 1,
+			);
+		}
+	}
+
+	private endNativeDelete(cids: string[]): void {
+		for (const cid of cids) {
+			const remaining = (this.nativeDeleteTombstones.get(cid) ?? 1) - 1;
+			if (remaining <= 0) {
+				this.nativeDeleteTombstones.delete(cid);
+			} else {
+				this.nativeDeleteTombstones.set(cid, remaining);
+			}
+		}
+	}
+
+	private isNativeDeletePending(cid: string): boolean {
+		return this.nativeDeleteTombstones.has(cid);
+	}
+
+	// A CID can be legitimately re-added after a native trim (content addressing
+	// makes the bytes identical, but its liveness is new). Cancel any queued trim
+	// for that CID and advance its generation before the write is exposed. An
+	// already-running cleanup uses the generation/pending map to avoid deleting
+	// the new native value; synchronous columnar writes also chain their durable
+	// mirror behind that cleanup below.
+	private noteNativeBlockWrite(cids: string[]): Map<string, number> {
+		const generations = new Map<string, number>();
+		for (const cid of new Set(cids)) {
+			const generation = (this.nativeBlockWriteGenerations.get(cid) ?? 0) + 1;
+			this.nativeBlockWriteGenerations.set(cid, generation);
+			generations.set(cid, generation);
+			if (this.pendingNativeDeleteCleanup.delete(cid)) {
+				this.endNativeDelete([cid]);
+			}
+			for (const staged of this.stagedNativeDeleteCleanups.values()) {
+				if (staged.delete(cid)) {
+					this.endNativeDelete([cid]);
+				}
+			}
+		}
+		return generations;
+	}
+
+	private beginNativeCommitOwnership(
+		generations: Map<string, number>,
+	): NativeCommitOwnershipToken | undefined {
+		if (generations.size === 0) {
+			return undefined;
+		}
+		const token: NativeCommitOwnershipToken = {
+			id: ++this.nextNativeCommitOwnershipToken,
+			rows: new Map(),
+		};
+		for (const [cid, generation] of generations) {
+			const owners = this.nativeCommitOwnershipsByCid.get(cid) ?? new Set();
+			const shared = owners.size > 0;
+			for (const ownerId of owners) {
+				const owner = this.nativeCommitOwnerships.get(ownerId);
+				const row = owner?.rows.get(cid);
+				if (row) row.shared = true;
+			}
+			owners.add(token.id);
+			this.nativeCommitOwnershipsByCid.set(cid, owners);
+			token.rows.set(cid, { generation, shared });
+		}
+		this.nativeCommitOwnerships.set(token.id, token);
+		return token;
+	}
+
+	private releaseNativeCommitOwnership(token: unknown): void {
+		if (
+			!token ||
+			typeof token !== "object" ||
+			typeof (token as NativeCommitOwnershipToken).id !== "number"
+		) {
+			return;
+		}
+		const owned = this.nativeCommitOwnerships.get(
+			(token as NativeCommitOwnershipToken).id,
+		);
+		if (owned !== token) {
+			return;
+		}
+		this.nativeCommitOwnerships.delete(owned.id);
+		for (const cid of owned.rows.keys()) {
+			const owners = this.nativeCommitOwnershipsByCid.get(cid);
+			owners?.delete(owned.id);
+			if (owners?.size === 0) {
+				this.nativeCommitOwnershipsByCid.delete(cid);
+			}
+		}
+	}
+
+	acknowledgeNativeCommitOwnership(token: unknown): void {
+		this.releaseNativeCommitOwnership(token);
+	}
+
+	private enqueueNativeDeleteCleanup(cids: string[]): void {
+		for (const cid of new Set(cids)) {
+			if (!this.pendingNativeDeleteCleanup.has(cid)) {
+				this.pendingNativeDeleteCleanup.set(
+					cid,
+					this.nativeBlockWriteGenerations.get(cid) ?? 0,
+				);
+				this.beginNativeDelete([cid]);
+			}
+		}
+	}
+
+	private releaseStagedNativeDeleteCleanup(token: number): boolean {
+		const staged = this.stagedNativeDeleteCleanups.get(token);
+		if (!staged) {
+			return false;
+		}
+		this.stagedNativeDeleteCleanups.delete(token);
+		for (const [cid] of staged) {
+			this.endNativeDelete([cid]);
+		}
+		return true;
+	}
+
+	private discardStagedNativeDeleteCleanups(): void {
+		for (const token of [...this.stagedNativeDeleteCleanups.keys()]) {
+			this.releaseStagedNativeDeleteCleanup(token);
+		}
+	}
+
+	// Native commit callbacks call this immediately after the native transaction
+	// returns, before awaiting the new block's durable mirror. This stages read
+	// tombstones only. Durable deletion is promoted later by the exact EntryIndex
+	// consume token, so an unacknowledged/failed append cannot delete the old
+	// durable head that the lower log still publishes.
+	beginNativeDeleteCleanup(cids: string[]): number | undefined {
+		this.throwIfNativeDurableCommitFailed();
+		const uniqueCids = [...new Set(cids)];
+		if (uniqueCids.length === 0) {
+			return undefined;
+		}
+		const token = ++this.nextNativeDeleteCleanupToken;
+		const staged = new Map(
+			uniqueCids.map((cid) => [
+				cid,
+				this.nativeBlockWriteGenerations.get(cid) ?? 0,
+			]),
+		);
+		this.stagedNativeDeleteCleanups.set(token, staged);
+		this.beginNativeDelete(uniqueCids);
+		return token;
+	}
+
+	cancelNativeDeleteCleanup(cleanupToken: unknown): void {
+		if (typeof cleanupToken === "number") {
+			this.releaseStagedNativeDeleteCleanup(cleanupToken);
+		}
+	}
+
+	private async waitForNativeDeleteCleanup(): Promise<void> {
+		while (this.nativeDeleteCleanupRunning) {
+			await this.nativeDeleteCleanupRunning;
+		}
+	}
+
+	private async waitForTrackedDurableWrites(): Promise<void> {
+		while (this.pendingDurableWrites.size > 0) {
+			await Promise.allSettled([...this.pendingDurableWrites]);
+		}
+	}
+
+	private async retryNativeDeleteCleanup(options?: {
+		allowPoisoned?: boolean;
+		throwOnFailure?: boolean;
+	}): Promise<void> {
+		await this.waitForNativeDeleteCleanup();
+		if (this.nativeDurableCommitFailure && !options?.allowPoisoned) {
+			throw this.nativeDurableCommitFailure;
+		}
+		// A synchronous columnar write may already have scheduled its durable
+		// mirror. Let it settle before deleting queued CIDs, but leave any recorded
+		// error for drainDurable() to surface to its owning operation/stop.
+		await this.waitForTrackedDurableWrites();
+		await this.waitForNativeDeleteCleanup();
+		// A tracked mirror or the cleanup we just waited for may have poisoned the
+		// wrapper. Do not begin another durable mutation on the ordinary path after
+		// that asynchronous boundary. stop() alone opts into one cleanup retry so a
+		// transient delete failure can still release its tombstones and resources.
+		if (this.nativeDurableCommitFailure && !options?.allowPoisoned) {
+			throw this.nativeDurableCommitFailure;
+		}
+		if (this.pendingNativeDeleteCleanup.size === 0) {
+			return;
+		}
+		const cleanupEntries = [...this.pendingNativeDeleteCleanup].filter(
+			([cid, generation]) =>
+				(this.nativeBlockWriteGenerations.get(cid) ?? 0) === generation,
+		);
+		if (cleanupEntries.length === 0) {
+			return;
+		}
+		const cids = cleanupEntries.map(([cid]) => cid);
+		let cleanupFailure: unknown;
+		const running = (async () => {
+			let durableRemoved = false;
+			let nativeRemoved = false;
+			try {
+				await this.durable.rmMany(cids);
+				durableRemoved = true;
+			} catch (error) {
+				cleanupFailure = error;
+				// The new entry blocks are already durable at this point and the native
+				// transaction has selected the new graph/index state. Old content-addressed
+				// blocks are therefore harmless unreachable orphans. Keep this cleanup as
+				// retryable debt instead of poisoning/rolling back a fully durable append;
+				// a partial rmMany is safe for the same reason.
+				warn(
+					`Failed durable native-trim cleanup; retaining retry debt: ${String(error)}`,
+				);
+			} finally {
+				// A read that began in the native-transaction -> cleanup-hook gap may
+				// have repopulated native. Always repeat the native removal, even when
+				// durable rm failed. Exclude CIDs re-added while durable IO was pending;
+				// their generation change cancelled the queued delete.
+				const stillDeleted = cids.filter((cid) =>
+					this.pendingNativeDeleteCleanup.has(cid),
+				);
+				try {
+					if (stillDeleted.length > 0) {
+						await this.native.rmMany(stillDeleted);
+					}
+					nativeRemoved = true;
+				} catch (error) {
+					cleanupFailure ??= error;
+					warn(
+						`Failed to repeat native-trim hot block removal: ${String(error)}`,
+					);
+				}
+			}
+			if (durableRemoved && nativeRemoved) {
+				for (const [cid, generation] of cleanupEntries) {
+					if (this.pendingNativeDeleteCleanup.get(cid) === generation) {
+						this.pendingNativeDeleteCleanup.delete(cid);
+						this.nativeBlockWriteGenerations.delete(cid);
+						this.endNativeDelete([cid]);
+					}
+				}
+			}
+		})();
+		this.nativeDeleteCleanupRunning = running;
+		try {
+			await running;
+		} finally {
+			if (this.nativeDeleteCleanupRunning === running) {
+				this.nativeDeleteCleanupRunning = undefined;
+			}
+		}
+		if (options?.throwOnFailure && cleanupFailure !== undefined) {
+			throw cleanupFailure;
+		}
+	}
+
+	private trackDurable(result: unknown, cids: string[]): void {
 		// The durable store may answer synchronously (an in-memory or already
 		// resolved store); only a real pending promise needs tracking. A sync
 		// success is already durable; a sync throw would have propagated already.
@@ -483,9 +847,26 @@ class NativeBackboneWriteThroughBlockStore {
 			},
 			(error) => {
 				this.pendingDurableWrites.delete(tracked);
-				if (this.durableWriteError === undefined) {
-					this.durableWriteError = error;
-				}
+				this.recordNativeDurableCommitFailure(error, {
+					committedCids: cids,
+					failedCids: cids,
+				});
+			},
+		);
+		this.pendingDurableWrites.add(tracked);
+	}
+
+	// Awaited mirror writes surface their own rejection to the append that
+	// created them. Track a non-rejecting settlement companion as well so stop()
+	// and later wrapper operations cannot close/use durable storage while that
+	// append barrier is still in flight.
+	private trackAwaitedDurable(result: Promise<unknown>): void {
+		const tracked = result.then(
+			() => {
+				this.pendingDurableWrites.delete(tracked);
+			},
+			() => {
+				this.pendingDurableWrites.delete(tracked);
 			},
 		);
 		this.pendingDurableWrites.add(tracked);
@@ -495,14 +876,8 @@ class NativeBackboneWriteThroughBlockStore {
 	// the first failure. Awaited methods call this so a prior columnar durable
 	// failure propagates as back-pressure to the next caller.
 	private async drainDurable(): Promise<void> {
-		while (this.pendingDurableWrites.size > 0) {
-			await Promise.allSettled([...this.pendingDurableWrites]);
-		}
-		if (this.durableWriteError !== undefined) {
-			const error = this.durableWriteError;
-			this.durableWriteError = undefined;
-			throw error;
-		}
+		await this.waitForTrackedDurableWrites();
+		this.throwIfNativeDurableCommitFailed();
 	}
 
 	// --- lifecycle -------------------------------------------------------
@@ -521,9 +896,32 @@ class NativeBackboneWriteThroughBlockStore {
 
 	async stop(): Promise<void> {
 		// Surface any tracked (sync-path) durable write failure and ensure all
-		// mirror writes have settled before the durable store is torn down.
-		await this.drainDurable();
-		await this.durable.stop();
+		// mirror writes have settled before the durable store is torn down. Closing
+		// the durable store is unconditional: a prior columnar mirror failure must
+		// not leak the store lifecycle resource.
+		let firstError: unknown;
+		try {
+			await this.drainDurable();
+		} catch (error) {
+			firstError = error;
+		}
+		// Tokens not consumed by EntryIndex belong to native prepares that never
+		// published their lower-log trim. Release their read tombstones, but never
+		// promote them to durable deletion during shutdown.
+		this.discardStagedNativeDeleteCleanups();
+		try {
+			await this.retryNativeDeleteCleanup({ allowPoisoned: true });
+		} catch (error) {
+			firstError ??= error;
+		}
+		try {
+			await this.durable.stop();
+		} catch (error) {
+			firstError ??= error;
+		}
+		if (firstError !== undefined) {
+			throw firstError;
+		}
 	}
 
 	status() {
@@ -534,6 +932,13 @@ class NativeBackboneWriteThroughBlockStore {
 		return Promise.resolve([]);
 	}
 
+	// Native commit APIs must keep their block-store callback synchronous. The
+	// lower log calls this barrier after that callback reports committed blocks
+	// and before publishing index/head facts.
+	waitForDurableWrites(): Promise<void> {
+		return this.drainDurable();
+	}
+
 	// Mirror a single already-committed block (present in the wasm map) to the
 	// durable store ONLY. Used by the native commit-only append fast path: the
 	// native prepare commits the entry block into the wasm map and returns no raw
@@ -541,11 +946,191 @@ class NativeBackboneWriteThroughBlockStore {
 	// route the block through the log's finishBlocks/putKnown* (that would disturb
 	// the commit-only append path the RCS optimization depends on). Instead the
 	// caller reads the committed bytes back and calls this so the block lands in
-	// durable directly. Like putKnownManyColumns' durable mirror, the write is
-	// tracked (not fire-and-forget) so an IO/disk-full failure surfaces on the
-	// next awaited wrapper method / stop() rather than being swallowed.
-	mirrorToDurable(cid: string, bytes: Uint8Array): void {
-		this.trackDurable(this.durable.putKnown(cid, bytes));
+	// durable directly. The caller awaits this method before acknowledging its
+	// append, so a failed write rejects the append that produced the block.
+	async mirrorToDurable(
+		cid: string,
+		bytes: Uint8Array,
+		options?: { nativeTrimmed?: boolean },
+	): Promise<unknown> {
+		this.throwIfNativeDurableCommitFailed();
+		// The native commit happened before this call. Mark the CID live before
+		// awaiting anything so a concurrent retry of an older trim cannot remove
+		// the newly committed hot block.
+		let ownership: NativeCommitOwnershipToken | undefined;
+		if (options?.nativeTrimmed !== true) {
+			ownership = this.beginNativeCommitOwnership(
+				this.noteNativeBlockWrite([cid]),
+			);
+			await this.waitForNativeDeleteCleanup();
+		}
+		try {
+			await this.drainDurable();
+			if (ownership) {
+				const existed = await this.durable.hasMany([...ownership.rows.keys()]);
+				let index = 0;
+				for (const row of ownership.rows.values()) {
+					row.durableExistedBefore = existed[index++] === true;
+				}
+			}
+			const result = this.commitDurableMutation(
+				() => this.durable.putKnown(cid, bytes),
+				[cid],
+			);
+			await result;
+			await this.retryNativeDeleteCleanup();
+			this.throwIfNativeDurableCommitFailed();
+			return ownership;
+		} catch (error) {
+			// The caller never receives an ownership token for an indeterminate write.
+			// Release the in-memory claim and preserve any bytes the backend may have
+			// applied before rejecting.
+			this.releaseNativeCommitOwnership(ownership);
+			throw error;
+		}
+	}
+
+	async mirrorManyToDurable(
+		blocks: Array<readonly [cid: string, bytes: Uint8Array]>,
+		options?: { nativeTrimmedCids?: ReadonlySet<string> },
+	): Promise<unknown> {
+		this.throwIfNativeDurableCommitFailed();
+		const cids = blocks.map(([cid]) => cid);
+		// Rows trimmed later in the same native batch deliberately remain owned by
+		// that batch's staged cleanup; only mark surviving rows live.
+		const liveCids = cids.filter(
+			(cid) => !options?.nativeTrimmedCids?.has(cid),
+		);
+		const ownership = this.beginNativeCommitOwnership(
+			this.noteNativeBlockWrite(liveCids),
+		);
+		if (liveCids.length > 0) {
+			await this.waitForNativeDeleteCleanup();
+		}
+		try {
+			await this.drainDurable();
+			if (ownership) {
+				const existed = await this.durable.hasMany([...ownership.rows.keys()]);
+				let index = 0;
+				for (const row of ownership.rows.values()) {
+					row.durableExistedBefore = existed[index++] === true;
+				}
+			}
+			if (blocks.length > 0) {
+				await this.commitDurableMutation(
+					() => this.durable.putKnownMany(blocks),
+					cids,
+				);
+			}
+			await this.retryNativeDeleteCleanup();
+			this.throwIfNativeDurableCommitFailed();
+			return ownership;
+		} catch (error) {
+			this.releaseNativeCommitOwnership(ownership);
+			throw error;
+		}
+	}
+
+	async rollbackFailedNativeCommits(
+		cids: string[],
+		restoreNativeCids: string[] = [],
+		ownershipToken?: unknown,
+	): Promise<void> {
+		// This is the sole mutation allowed after poison: it removes a native
+		// transaction that the lower log never published. Do not route through the
+		// guarded rmMany path, and settle the failed mirror before compensating it.
+		await this.waitForTrackedDurableWrites();
+		// A failed replacement never published its trim. Reassert the restored CIDs
+		// as live before any compensation IO so staged/pending delete intents cannot
+		// remove the last acknowledged blocks during stop or reopen.
+		const ownership =
+			ownershipToken && typeof ownershipToken === "object"
+				? this.nativeCommitOwnerships.get(
+						(ownershipToken as NativeCommitOwnershipToken).id,
+					)
+				: undefined;
+		const verifiedOwnership =
+			ownership && ownership === ownershipToken ? ownership : undefined;
+		const restoreSet = new Set(restoreNativeCids);
+		const safeDurableDeletes = verifiedOwnership
+			? [...new Set(cids)].filter((cid) => {
+					const row = verifiedOwnership.rows.get(cid);
+					const owners = this.nativeCommitOwnershipsByCid.get(cid);
+					return (
+						!restoreSet.has(cid) &&
+						row?.durableExistedBefore === false &&
+						row.shared === false &&
+						(this.nativeBlockWriteGenerations.get(cid) ?? 0) ===
+							row.generation &&
+						owners?.size === 1 &&
+						owners.has(verifiedOwnership.id)
+					);
+				})
+			: [];
+		this.noteNativeBlockWrite(restoreNativeCids);
+		let firstError: unknown;
+		try {
+			if (safeDurableDeletes.length > 0) {
+				await this.durable.rmMany(safeDurableDeletes);
+			}
+		} catch (error) {
+			firstError = error;
+		}
+		// A native prepare runs before ownership can observe the hot map, so it cannot
+		// prove that a CID was absent there before this operation. Keep native bytes as
+		// unreachable orphans rather than deleting acknowledged/shared/restored data.
+		if (restoreNativeCids.length > 0) {
+			try {
+				const values = await this.durable.getMany(restoreNativeCids);
+				const restore: Array<readonly [string, Uint8Array]> = [];
+				for (let index = 0; index < restoreNativeCids.length; index++) {
+					const value = values[index];
+					if (value) restore.push([restoreNativeCids[index]!, value]);
+				}
+				if (restore.length > 0) {
+					this.native.putKnownMany(restore);
+				}
+			} catch (error) {
+				firstError ??= error;
+			}
+		}
+		this.releaseNativeCommitOwnership(ownershipToken);
+		if (firstError !== undefined) throw firstError;
+	}
+
+	/**
+	 * Compensate a native prepare that failed before its durable mirror began.
+	 * Durable presence proves a same-CID acknowledged owner; an active ownership
+	 * token proves a concurrent mirror. Only an unowned, non-durable hot block is
+	 * exclusively attributable to the failed prepare and safe to remove.
+	 */
+	async rollbackUnmirroredNativeCommits(
+		cids: string[],
+		restoreNativeCids: string[] = [],
+	): Promise<void> {
+		const unique = [...new Set(cids)];
+		// Native prepares bypass this wrapper. Any observed wrapper generation is
+		// therefore evidence of a generic/same-CID writer, not of the failed prepare.
+		// Snapshot before the first await and require both absence and stability so a
+		// write starting before or during durable.hasMany cannot lose its hot value to
+		// a stale `false` result.
+		const genericWriteGenerations = new Map(
+			unique.map((cid) => [cid, this.nativeBlockWriteGenerations.get(cid)]),
+		);
+		await this.rollbackFailedNativeCommits(cids, restoreNativeCids);
+		const durablePresence = await this.durable.hasMany(unique);
+		const restore = new Set(restoreNativeCids);
+		const safeNativeDeletes = unique.filter(
+			(cid, index) =>
+				!restore.has(cid) &&
+				durablePresence[index] !== true &&
+				genericWriteGenerations.get(cid) === undefined &&
+				this.nativeBlockWriteGenerations.get(cid) === undefined &&
+				(this.nativeCommitOwnershipsByCid.get(cid)?.size ?? 0) === 0,
+		);
+		if (safeNativeDeletes.length > 0) {
+			await this.native.rmMany(safeNativeDeletes);
+		}
 	}
 
 	// --- writes (apply to BOTH: native first for the hot path, then durable) ---
@@ -562,7 +1147,16 @@ class NativeBackboneWriteThroughBlockStore {
 			data instanceof Uint8Array
 				? data
 				: (data as { block: { bytes: Uint8Array } }).block.bytes;
-		await this.durable.putKnown(cid, value);
+		this.noteNativeBlockWrite([cid]);
+		await this.waitForNativeDeleteCleanup();
+		// put() may have yielded while calculating the CID. Restore the hot value
+		// after any older cleanup that was already in flight.
+		this.throwIfNativeDurableCommitFailed();
+		this.native.putKnown(cid, value);
+		await this.commitDurableMutation(
+			() => this.durable.putKnown(cid, value),
+			[cid],
+		);
 		return cid;
 	}
 
@@ -581,7 +1175,14 @@ class NativeBackboneWriteThroughBlockStore {
 				return [cid, value] as const;
 			},
 		);
-		await this.durable.putKnownMany(durableBlocks);
+		this.noteNativeBlockWrite(cids);
+		await this.waitForNativeDeleteCleanup();
+		this.throwIfNativeDurableCommitFailed();
+		this.native.putKnownMany(durableBlocks);
+		await this.commitDurableMutation(
+			() => this.durable.putKnownMany(durableBlocks),
+			cids,
+		);
 		return cids;
 	}
 
@@ -592,8 +1193,14 @@ class NativeBackboneWriteThroughBlockStore {
 	// both await this method, so returning a promise is compatible.
 	async putKnown(cid: string, bytes: Uint8Array): Promise<string> {
 		await this.drainDurable();
+		await this.waitForNativeDeleteCleanup();
+		this.throwIfNativeDurableCommitFailed();
 		const stored = this.native.putKnown(cid, bytes);
-		await this.durable.putKnown(cid, bytes);
+		this.noteNativeBlockWrite([cid]);
+		await this.commitDurableMutation(
+			() => this.durable.putKnown(cid, bytes),
+			[cid],
+		);
 		return stored;
 	}
 
@@ -601,13 +1208,25 @@ class NativeBackboneWriteThroughBlockStore {
 		blocks: Array<readonly [cid: string, bytes: Uint8Array]>,
 	): Promise<string[]> {
 		await this.drainDurable();
+		await this.waitForNativeDeleteCleanup();
+		this.throwIfNativeDurableCommitFailed();
 		const cids = this.native.putKnownMany(blocks);
-		await this.durable.putKnownMany(blocks);
+		this.noteNativeBlockWrite(cids);
+		await this.commitDurableMutation(
+			() => this.durable.putKnownMany(blocks),
+			cids,
+		);
 		return cids;
 	}
 
 	putKnownManyColumns(cids: string[], bytes: Uint8Array[]): string[] {
+		this.throwIfNativeDurableCommitFailed();
+		if (cids.length !== bytes.length) {
+			throw new Error("Expected equal block column lengths");
+		}
+		const cleanupBarrier = this.nativeDeleteCleanupRunning;
 		const stored = this.native.putKnownManyColumns(cids, bytes);
+		this.noteNativeBlockWrite(cids);
 		// AnyBlockStore has no columnar method; mirror via putKnownMany, which
 		// takes [cid, bytes] tuples and hits the same batched store path.
 		// This method must return a synchronous string[] (RemoteBlocks.putKnownManyColumns
@@ -617,7 +1236,18 @@ class NativeBackboneWriteThroughBlockStore {
 		const durableBlocks = cids.map(
 			(cid, index) => [cid, bytes[index]!] as const,
 		);
-		this.trackDurable(this.durable.putKnownMany(durableBlocks));
+		let durableResult: unknown;
+		try {
+			durableResult = cleanupBarrier
+				? cleanupBarrier.then(() => this.durable.putKnownMany(durableBlocks))
+				: this.durable.putKnownMany(durableBlocks);
+		} catch (error) {
+			throw this.recordNativeDurableCommitFailure(error, {
+				committedCids: cids,
+				failedCids: cids,
+			});
+		}
+		this.trackDurable(durableResult, cids);
 		return stored;
 	}
 
@@ -628,11 +1258,28 @@ class NativeBackboneWriteThroughBlockStore {
 	// avoids a spurious miss (which would otherwise fall through to a remote
 	// read) for a block that is present on disk.
 	async get(cid: string, _options?: unknown): Promise<Uint8Array | undefined> {
+		if (this.nativeDurableCommitFailure) {
+			// After poison, durable storage is the last acknowledged authority. Do not
+			// repopulate or otherwise mutate the native store until reopen.
+			return this.isNativeDeletePending(cid)
+				? undefined
+				: this.durable.get(cid);
+		}
+		const deleteEpoch = this.nativeDeleteEpoch;
+		if (this.isNativeDeletePending(cid)) {
+			return undefined;
+		}
 		const local = this.native.get(cid);
 		if (local != null) {
-			return local;
+			return deleteEpoch === this.nativeDeleteEpoch ? local : this.get(cid);
 		}
 		const durableValue = await this.durable.get(cid);
+		if (this.nativeDurableCommitFailure) {
+			return this.isNativeDeletePending(cid) ? undefined : durableValue;
+		}
+		if (deleteEpoch !== this.nativeDeleteEpoch) {
+			return this.get(cid);
+		}
 		if (durableValue != null) {
 			// Repopulate the native map so the native graph reads it next time.
 			this.native.putKnownManyColumns([cid], [durableValue]);
@@ -642,25 +1289,55 @@ class NativeBackboneWriteThroughBlockStore {
 	}
 
 	async getMany(cids: string[]): Promise<Array<Uint8Array | undefined>> {
+		if (this.nativeDurableCommitFailure) {
+			const values = await this.durable.getMany(cids);
+			for (let index = 0; index < cids.length; index++) {
+				if (this.isNativeDeletePending(cids[index]!)) {
+					values[index] = undefined;
+				}
+			}
+			return values;
+		}
+		const deleteEpoch = this.nativeDeleteEpoch;
 		const results = await this.native.getMany(cids);
+		if (deleteEpoch !== this.nativeDeleteEpoch) {
+			return this.getMany(cids);
+		}
 		const missing: string[] = [];
+		const missingIndexes: number[] = [];
 		for (let i = 0; i < results.length; i++) {
-			if (results[i] == null) {
+			if (this.isNativeDeletePending(cids[i]!)) {
+				results[i] = undefined;
+			} else if (results[i] == null) {
 				missing.push(cids[i]!);
+				missingIndexes.push(i);
 			}
 		}
 		if (missing.length === 0) {
 			return results;
 		}
 		const durableValues = await this.durable.getMany(missing);
+		if (this.nativeDurableCommitFailure) {
+			const values = await this.durable.getMany(cids);
+			for (let index = 0; index < cids.length; index++) {
+				if (this.isNativeDeletePending(cids[index]!)) {
+					values[index] = undefined;
+				}
+			}
+			return values;
+		}
+		if (deleteEpoch !== this.nativeDeleteEpoch) {
+			return this.getMany(cids);
+		}
 		const repopulateCids: string[] = [];
 		const repopulateBytes: Uint8Array[] = [];
-		let missingIndex = 0;
-		for (let i = 0; i < results.length; i++) {
-			if (results[i] != null) {
-				continue;
-			}
-			const value = durableValues[missingIndex++];
+		for (
+			let missingIndex = 0;
+			missingIndex < missingIndexes.length;
+			missingIndex++
+		) {
+			const i = missingIndexes[missingIndex]!;
+			const value = durableValues[missingIndex];
 			if (value != null) {
 				results[i] = value;
 				repopulateCids.push(cids[i]!);
@@ -675,8 +1352,15 @@ class NativeBackboneWriteThroughBlockStore {
 	}
 
 	async has(cid: string): Promise<boolean> {
+		if (this.nativeDurableCommitFailure) {
+			return this.isNativeDeletePending(cid) ? false : this.durable.has(cid);
+		}
+		const deleteEpoch = this.nativeDeleteEpoch;
+		if (this.isNativeDeletePending(cid)) {
+			return false;
+		}
 		if (this.native.has(cid)) {
-			return true;
+			return deleteEpoch === this.nativeDeleteEpoch ? true : this.has(cid);
 		}
 		// Mirror getMany/hasMany: a block absent from the native wasm map may still
 		// be present in the durable store (e.g. persisted on disk but not yet
@@ -684,26 +1368,48 @@ class NativeBackboneWriteThroughBlockStore {
 		// checks agree with the resolves that getMany/hasMany already durable-fall
 		// back on. `Blocks.has` is declared `MaybePromise<boolean>`, so returning a
 		// promise here is contract-compatible.
-		return this.durable.has(cid);
+		const durableHas = await this.durable.has(cid);
+		return deleteEpoch === this.nativeDeleteEpoch ? durableHas : this.has(cid);
 	}
 
 	async hasMany(cids: string[]): Promise<boolean[]> {
+		if (this.nativeDurableCommitFailure) {
+			const values = await this.durable.hasMany(cids);
+			for (let index = 0; index < cids.length; index++) {
+				if (this.isNativeDeletePending(cids[index]!)) {
+					values[index] = false;
+				}
+			}
+			return values;
+		}
+		const deleteEpoch = this.nativeDeleteEpoch;
 		const nativeHas = await this.native.hasMany(cids);
+		if (deleteEpoch !== this.nativeDeleteEpoch) {
+			return this.hasMany(cids);
+		}
 		const missing: string[] = [];
+		const missingIndexes: number[] = [];
 		for (let i = 0; i < nativeHas.length; i++) {
-			if (!nativeHas[i]) {
+			if (this.isNativeDeletePending(cids[i]!)) {
+				nativeHas[i] = false;
+			} else if (!nativeHas[i]) {
 				missing.push(cids[i]!);
+				missingIndexes.push(i);
 			}
 		}
 		if (missing.length === 0) {
 			return nativeHas;
 		}
 		const durableHas = await this.durable.hasMany(missing);
-		let missingIndex = 0;
-		for (let i = 0; i < nativeHas.length; i++) {
-			if (!nativeHas[i]) {
-				nativeHas[i] = durableHas[missingIndex++]!;
-			}
+		if (deleteEpoch !== this.nativeDeleteEpoch) {
+			return this.hasMany(cids);
+		}
+		for (
+			let missingIndex = 0;
+			missingIndex < missingIndexes.length;
+			missingIndex++
+		) {
+			nativeHas[missingIndexes[missingIndex]!] = durableHas[missingIndex]!;
 		}
 		return nativeHas;
 	}
@@ -713,29 +1419,147 @@ class NativeBackboneWriteThroughBlockStore {
 	// resolves only after both succeed and a durable failure rejects here rather
 	// than being swallowed. All rm callers (RemoteBlocks.rm, the log) await it.
 	async rm(cid: string): Promise<void> {
-		await this.drainDurable();
-		this.native.rm(cid);
-		await this.durable.rm(cid);
+		this.throwIfNativeDurableCommitFailed();
+		const writeGeneration = this.nativeBlockWriteGenerations.get(cid);
+		this.beginNativeDelete([cid]);
+		try {
+			await this.drainDurable();
+			this.native.rm(cid);
+			await this.commitDurableMutation(() => this.durable.rm(cid), [cid]);
+			// A durable read that began before the tombstone may have repopulated
+			// native while durable rm was pending. Remove it idempotently again.
+			this.native.rm(cid);
+			if (
+				this.nativeBlockWriteGenerations.get(cid) === writeGeneration &&
+				!this.pendingNativeDeleteCleanup.has(cid)
+			) {
+				this.nativeBlockWriteGenerations.delete(cid);
+			}
+		} finally {
+			this.endNativeDelete([cid]);
+		}
 	}
 
-	del(cid: string): void {
-		void this.rm(cid);
+	del(cid: string): Promise<void> {
+		return this.rm(cid);
 	}
 
 	async rmMany(cids: string[]): Promise<number> {
-		await this.drainDurable();
-		const removed = await this.native.rmMany(cids);
-		await this.durable.rmMany(cids);
-		return removed;
+		this.throwIfNativeDurableCommitFailed();
+		const writeGenerations = new Map(
+			cids.map((cid) => [cid, this.nativeBlockWriteGenerations.get(cid)]),
+		);
+		this.beginNativeDelete(cids);
+		try {
+			await this.drainDurable();
+			const removed = await this.native.rmMany(cids);
+			await this.commitDurableMutation(() => this.durable.rmMany(cids), cids);
+			await this.native.rmMany(cids);
+			for (const cid of cids) {
+				if (
+					this.nativeBlockWriteGenerations.get(cid) ===
+						writeGenerations.get(cid) &&
+					!this.pendingNativeDeleteCleanup.has(cid)
+				) {
+					this.nativeBlockWriteGenerations.delete(cid);
+				}
+			}
+			return removed;
+		} finally {
+			this.endNativeDelete(cids);
+		}
+	}
+
+	// Native trim may already have removed the hot wasm blocks. Queue the durable
+	// copy for cleanup, retaining read tombstones until removal succeeds; a
+	// cleanup failure is retried and never fed into ordinary append rollback.
+	// EntryIndex feature-detects this hook.
+	async rmManyAfterNativeDelete(
+		cids: string[],
+		cleanupToken?: unknown,
+	): Promise<void> {
+		if (this.nativeDurableCommitFailure) {
+			this.cancelNativeDeleteCleanup(cleanupToken);
+			throw this.nativeDurableCommitFailure;
+		}
+		let preannounced = false;
+		if (typeof cleanupToken === "number") {
+			const staged = this.stagedNativeDeleteCleanups.get(cleanupToken);
+			if (staged) {
+				preannounced = true;
+				this.stagedNativeDeleteCleanups.delete(cleanupToken);
+				for (const [cid, generation] of staged) {
+					if ((this.nativeBlockWriteGenerations.get(cid) ?? 0) !== generation) {
+						this.endNativeDelete([cid]);
+						continue;
+					}
+					if (this.pendingNativeDeleteCleanup.has(cid)) {
+						// Another delete already owns a tombstone for this CID.
+						this.endNativeDelete([cid]);
+					} else {
+						// Transfer the staged tombstone to the now-published cleanup.
+						this.pendingNativeDeleteCleanup.set(cid, generation);
+					}
+				}
+			}
+		}
+		if (!preannounced) {
+			this.enqueueNativeDeleteCleanup(cids);
+		}
+		await this.retryNativeDeleteCleanup();
+	}
+
+	/** Finish committed trim GC before its durable recovery intent is retired. */
+	async completeCommittedNativeDeleteCleanup(
+		cids: string[],
+		options?: { reconstructMissing?: boolean },
+	): Promise<void> {
+		this.throwIfNativeDurableCommitFailed();
+		const uniqueCids = [...new Set(cids.filter(Boolean))];
+		if (uniqueCids.length === 0) {
+			return;
+		}
+		// Only restart recovery reconstructs missing debt. On the live path, an
+		// absent row may mean the CID was legitimately re-added after its original
+		// generation-owned trim completed or was cancelled; re-enqueueing it here
+		// would capture the new generation and delete live content.
+		if (options?.reconstructMissing) {
+			this.enqueueNativeDeleteCleanup(uniqueCids);
+		}
+		if (!uniqueCids.some((cid) => this.pendingNativeDeleteCleanup.has(cid))) {
+			return;
+		}
+		await this.retryNativeDeleteCleanup({ throwOnFailure: true });
+		const remaining = uniqueCids.filter((cid) =>
+			this.pendingNativeDeleteCleanup.has(cid),
+		);
+		if (remaining.length > 0) {
+			throw new Error(
+				`Committed native trim cleanup remains incomplete: ${remaining.join(", ")}`,
+			);
+		}
 	}
 
 	// --- misc ------------------------------------------------------------
 	async *iterator(): AsyncGenerator<[string, Uint8Array], void, void> {
+		if (this.nativeDurableCommitFailure) {
+			for await (const block of this.durable.iterator()) {
+				if (!this.isNativeDeletePending(block[0])) {
+					yield block;
+				}
+			}
+			return;
+		}
 		yield* this.native.iterator();
 	}
 
-	size(): number {
-		return this.native.size();
+	async size(): Promise<number> {
+		// The hot wasm map is intentionally cold after reopen, so it cannot be the
+		// storage-budget authority. Settle synchronous columnar mirrors first, then
+		// report durable bytes; pending trim cleanup remains conservatively counted
+		// until its durable deletion succeeds.
+		await this.drainDurable();
+		return this.durable.size();
 	}
 
 	persisted(): boolean {
@@ -925,7 +1749,13 @@ type NativeBackboneReceiveCoordinateRow<R extends "u32" | "u64"> = {
 
 type NativeBackboneReceiveCoordinateBatch<R extends "u32" | "u64"> = {
 	rows: NativeBackboneReceiveCoordinateRow<R>[];
-	rollbackCoordinateEntries?: Map<string, ResidentCoordinateEntry<R>>;
+	rollbackCoordinateEntries?: NativeBackboneCoordinateRollback<R>;
+};
+
+type NativeBackboneCoordinateRollback<R extends "u32" | "u64"> = {
+	hashes: Set<string>;
+	entries: Map<string, ResidentCoordinateEntry<R>>;
+	generations: Map<string, number>;
 };
 
 type RepairDispatchEntry<R extends "u32" | "u64"> = ResidentCoordinateEntry<R>;
@@ -980,6 +1810,12 @@ type NativeBackboneDocumentIndexCommitInput = {
 	requiredPreviousSignerPublicKey?: Uint8Array;
 };
 
+type NativeBackboneDocumentRollback = {
+	key: string;
+	value?: Uint8Array;
+	byteElementIndexLimit: number;
+};
+
 type NativeBackboneDocumentIndexAppendFacts = {
 	wallTime: bigint | number | string;
 	gid: string;
@@ -1020,20 +1856,30 @@ type NativeBackboneCoordinatePersistenceStore = {
 	write(name: string, bytes: Uint8Array): Promise<void>;
 	append(name: string, bytes: Uint8Array): Promise<void>;
 	remove?(name: string): Promise<void>;
-	flush?(): Promise<void>;
-	close?(): Promise<void>;
+	durableBarrier?(name?: string): Promise<void>;
+	supportsRemoval?: boolean;
+	flush?(name?: string): Promise<void>;
+	close?(options?: { flush?: boolean }): Promise<void>;
 };
 
 type NativeBackboneCoordinatePersistenceAdapter = {
+	/** Explicit capability required by durable strict-native operation intents. */
+	intentStore?: NativeBackboneCoordinatePersistenceStore;
 	flushOnAppend?: boolean;
 	flushMaxPendingBytes?: number;
 	flushIntervalMs?: number;
 	compactMaxJournalBytes?: number;
 	compactMaxJournalRecords?: number;
+	crashSafeCompaction?: boolean;
+	durableBarrier?: boolean;
+	supportsDrop?: boolean;
+	dropIsTerminal?: boolean;
 	hydrate(backbone: unknown): Promise<number>;
 	flushJournal(backbone: unknown): Promise<number>;
 	flushJournalOnAppend?(backbone: unknown): number | Promise<number>;
 	compact?(backbone: unknown): Promise<void>;
+	drop?(additionalFiles?: readonly string[]): Promise<void>;
+	resumeDrop?(): Promise<boolean>;
 	close?(): Promise<void>;
 };
 
@@ -1043,6 +1889,103 @@ type NativeBackboneCoordinatePersistenceConfig =
 			store: NativeBackboneCoordinatePersistenceStore;
 			buffered?: boolean | { maxBufferedBytes?: number };
 	  });
+
+type NativeStrictDurableTransactionIntent = {
+	version: 1;
+	lowerMarkerCommitted?: boolean;
+	appendHashes: string[];
+	trimHashes: string[];
+	coordinateDeleteHashes?: string[];
+	lowerIndexRows: Array<{
+		hash: string;
+		before?: number[];
+		after?: number[];
+	}>;
+	coordinates: Array<{
+		hash: string;
+		value?: {
+			hashNumber: string;
+			gid: string;
+			coordinates: string[];
+			wallTime: string;
+			assignedToRangeBoundary: boolean;
+			metaBytes: number[];
+		};
+	}>;
+	documents: Array<{
+		key: string;
+		value?: number[];
+		byteElementIndexLimit: number;
+	}>;
+};
+
+type NativeStrictDurableTransactionJournalBody = {
+	format: "peerbit-native-strict-durable-transaction";
+	version: 1;
+	sequence: number;
+	state: "intent" | "cleared";
+	intent: NativeStrictDurableTransactionIntent | null;
+};
+
+type NativeStrictDurableTransactionJournalRecord =
+	NativeStrictDurableTransactionJournalBody & {
+		checksum: string;
+	};
+
+type NativeStrictDurableTransactionJournalState = {
+	sequence: number;
+	slot: 0 | 1;
+	intent?: NativeStrictDurableTransactionIntent;
+	/** No journal file exists yet; materialize a cleared frame before first use. */
+	implicit?: boolean;
+};
+
+type NativeStrictDurableTransactionHandle = {
+	intent: NativeStrictDurableTransactionIntent;
+	release: () => void;
+	released: boolean;
+	lowerHashMutationLockOwner?: EntryIndexHashMutationLockOwner;
+};
+
+const NATIVE_STRICT_DURABLE_TRANSACTION_INTENT_FILE =
+	"strict-durable-transaction-intent.json";
+const NATIVE_STRICT_DURABLE_TRANSACTION_INTENT_BACKUP_FILE =
+	"strict-durable-transaction-intent.backup.json";
+const NATIVE_STRICT_DURABLE_TRANSACTION_INTENT_FILES = [
+	NATIVE_STRICT_DURABLE_TRANSACTION_INTENT_FILE,
+	NATIVE_STRICT_DURABLE_TRANSACTION_INTENT_BACKUP_FILE,
+] as const;
+const NATIVE_STRICT_DURABLE_TRANSACTION_JOURNAL_FORMAT =
+	"peerbit-native-strict-durable-transaction" as const;
+
+const nativeStrictDurableTransactionJournalBody = (
+	sequence: number,
+	intent: NativeStrictDurableTransactionIntent | undefined,
+): NativeStrictDurableTransactionJournalBody => ({
+	format: NATIVE_STRICT_DURABLE_TRANSACTION_JOURNAL_FORMAT,
+	version: 1,
+	sequence,
+	state: intent ? "intent" : "cleared",
+	intent: intent ?? null,
+});
+
+const nativeStrictDurableTransactionJournalBodyBytes = (
+	body: NativeStrictDurableTransactionJournalBody,
+) => new TextEncoder().encode(JSON.stringify(body));
+
+const nativeStrictDurableTransactionJournalRecordBytes = (
+	sequence: number,
+	intent: NativeStrictDurableTransactionIntent | undefined,
+) => {
+	const body = nativeStrictDurableTransactionJournalBody(sequence, intent);
+	const record: NativeStrictDurableTransactionJournalRecord = {
+		...body,
+		checksum: toHexString(
+			sha256Sync(nativeStrictDurableTransactionJournalBodyBytes(body)),
+		),
+	};
+	return new TextEncoder().encode(JSON.stringify(record));
+};
 
 type PreparedPayloadCommitOnlyProperties =
 	NativeBackboneDocumentCommitOptions & {
@@ -1325,8 +2268,8 @@ const isTransientReplicationAnnouncementError = (
 	}
 
 	const constructorName =
-		typeof (error as { constructor?: { name?: unknown } })?.constructor?.name ===
-		"string"
+		typeof (error as { constructor?: { name?: unknown } })?.constructor
+			?.name === "string"
 			? (error as { constructor: { name: string } }).constructor.name
 			: "";
 	const name =
@@ -1947,6 +2890,10 @@ type TrustedLowerLogNativePreparedCommit = {
 	hashDigestBytes?: Uint8Array;
 	trimmedEntries?: unknown[];
 	trimmedEntryHashes?: string[];
+	nativeBlocksDeleted?: boolean;
+	nativeDeleteCleanupToken?: unknown;
+	nativeCommitOwnershipToken?: unknown;
+	nativeIndexMutationLockOwner?: EntryIndexHashMutationLockOwner;
 	documentTrimmedHeadsProcessed?: boolean;
 	documentPreviousContext?: PreparedLocalAppendCommit<"u32">["documentPreviousContext"];
 };
@@ -1961,11 +2908,13 @@ type TrustedLowerLogPreparedAppendResult<T> = {
 type TrustedLowerLogCommitOnlyAppendResult<T> = {
 	entry: Entry<T>;
 	materializeEntry: () => Entry<T>;
+	shallowEntry: ShallowEntry;
 	removed: ShallowOrFullEntry<T>[];
 	removedHashes?: string[];
 	appendFacts: PreparedAppendFacts;
 	documentTrimmedHeadsProcessed?: boolean;
 	documentPreviousContext?: PreparedLocalAppendCommit<"u32">["documentPreviousContext"];
+	nativeCommittedAppendFinalizer?: TrustedLowerLogNativeCommitFinalizer;
 };
 
 type TrustedLowerLogCommitOnlyAppendBatchResult<T> = {
@@ -1975,6 +2924,13 @@ type TrustedLowerLogCommitOnlyAppendBatchResult<T> = {
 	removedHashes?: string[];
 	appendFacts: PreparedAppendFacts[];
 	documentTrimmedHeadsProcessed?: boolean[];
+	nativeCommittedAppendFinalizer?: TrustedLowerLogNativeCommitFinalizer;
+};
+
+type TrustedLowerLogNativeCommitFinalizer = {
+	acknowledge(onLowerMarkerDurable?: () => Promise<void>): Promise<void>;
+	retainForRecovery(): void;
+	rollback(): Promise<void>;
 };
 
 type TrustedLowerLog<T> = {
@@ -2008,6 +2964,7 @@ type TrustedLowerLog<T> = {
 			resolveTrimmedEntries?: boolean;
 			skipMissingNextJoin?: boolean;
 			retainMaterializationBytes?: boolean;
+			deferNativeTransactionAcknowledgement?: boolean;
 		},
 		prepare: (
 			input: TrustedLowerLogNativeCommitInput,
@@ -2021,6 +2978,7 @@ type TrustedLowerLog<T> = {
 			resolveTrimmedEntries?: boolean;
 			skipMissingNextJoin?: boolean;
 			retainMaterializationBytes?: boolean;
+			deferNativeTransactionAcknowledgement?: boolean;
 		},
 		prepare: (
 			input: TrustedLowerLogNativeCommitInput,
@@ -2035,6 +2993,7 @@ type TrustedLowerLog<T> = {
 			skipMissingNextJoin?: boolean;
 			knownNoNext?: boolean;
 			retainMaterializationBytes?: boolean;
+			deferNativeTransactionAcknowledgement?: boolean;
 		},
 		prepare: (
 			input: TrustedLowerLogNativeCommitInput,
@@ -2066,6 +3025,7 @@ type TrustedLowerLog<T> = {
 			resolveTrimmedEntries?: boolean;
 			allowPreparedNexts?: boolean;
 			retainMaterializationBytes?: boolean;
+			deferNativeTransactionAcknowledgement?: boolean;
 		},
 		prepare: (
 			inputs: TrustedLowerLogNativeCommitInput[],
@@ -2129,9 +3089,20 @@ export class SharedLog<
 	private _nativeRangePlanner?: SharedLogRangePlanner;
 	private _nativeSharedLogState?: SharedLogNativeState;
 	private _nativeBackbone?: NativePeerbitBackbone;
+	private _nativeDurableCommitFailure?: NativeDurableCommitError;
+	private _nativeDurableRecoveryReadyForReopen = false;
+	private _nativeDurableRecoveryCids = new Set<string>();
 	private _wireSyncSession?: SharedLogNativeWireSync;
 	private _nativeBackboneCoordinatePersistence?: NativeBackboneCoordinatePersistenceAdapter;
+	private _nativeBackboneCoordinatePersistenceStore?: NativeBackboneCoordinatePersistenceStore;
+	private _nativeBackboneDropStarted = false;
 	private _nativeBackboneCoordinateJournalLastFlushMs = 0;
+	private _nativeStrictDurableTransactionTail?: Promise<void>;
+	private _nativeStrictDurableTransactions?: Set<NativeStrictDurableTransactionHandle>;
+	private _nativeStrictDurableTransactionJournalState?: NativeStrictDurableTransactionJournalState;
+	private _nativeStrictDurableDocumentRecoveryDeferred = false;
+	private _nativeStrictDurableTransactionsClosing = false;
+	private _nativeStrictDurableTransactionFailure?: unknown;
 	private _defaultAppendReplicaMetadataCache?: {
 		source: MinReplicas;
 		value: number;
@@ -2141,6 +3112,7 @@ export class SharedLog<
 		string,
 		ResidentCoordinateEntry<R>
 	>;
+	private _nativeCoordinateMutationGenerations?: Map<string, number>;
 	private coordinateToHash!: Cache<string>;
 	private recentlyRebalanced!: Cache<string>;
 
@@ -2211,6 +3183,950 @@ export class SharedLog<
 
 	private remoteBlocks!: RemoteBlocks;
 
+	private throwIfNativeDurableCommitFailed(): void {
+		if (this._nativeStrictDurableTransactionFailure !== undefined) {
+			throw new Error(
+				"Native durable transaction recovery is required before another mutation",
+				{ cause: this._nativeStrictDurableTransactionFailure },
+			);
+		}
+		const wrapperFailure = (
+			this.remoteBlocks?.localStore as unknown as {
+				getNativeDurableCommitFailure?: () =>
+					| NativeDurableCommitError
+					| undefined;
+			}
+		)?.getNativeDurableCommitFailure?.();
+		if (wrapperFailure) {
+			this._nativeDurableCommitFailure ??= wrapperFailure;
+		}
+		if (this._nativeDurableCommitFailure) {
+			throw this._nativeDurableCommitFailure;
+		}
+	}
+
+	private poisonNativeStrictDurableTransaction(cause: unknown): void {
+		this._nativeStrictDurableTransactionFailure ??= cause;
+		this.log?.entryIndex?.poisonNativeDurableTransactionMutations(
+			this._nativeStrictDurableTransactionFailure,
+		);
+	}
+
+	private clearNativeStrictDurableTransactionFailure(): void {
+		this._nativeStrictDurableTransactionFailure = undefined;
+		this.log?.entryIndex?.clearNativeDurableTransactionMutationFailure();
+	}
+
+	private failNativeDurableCommit(
+		cause: unknown,
+		options?: {
+			committedCids?: Iterable<string>;
+			failedCids?: Iterable<string>;
+		},
+	): never {
+		this.ensureNativeDurabilityRuntimeState();
+		for (const cid of options?.committedCids ?? []) {
+			this._nativeDurableRecoveryCids.add(cid);
+		}
+		if (cause instanceof NativeDurableCommitError) {
+			cause.addCommitContext(options, { preferIncomingOrder: true });
+		}
+		this._nativeDurableCommitFailure ??=
+			cause instanceof NativeDurableCommitError
+				? cause
+				: new NativeDurableCommitError(cause, options);
+		this._nativeDurableCommitFailure.addCommitContext(options, {
+			preferIncomingOrder: true,
+		});
+		throw this._nativeDurableCommitFailure;
+	}
+
+	private snapshotNativeBackboneDocument(
+		input: NativeBackboneDocumentIndexCommitInput | undefined,
+	): NativeBackboneDocumentRollback | undefined {
+		const backbone = this._nativeBackbone;
+		if (!backbone || !input) return undefined;
+		const value = backbone.documentValueBytes(input.key);
+		return {
+			key: input.key,
+			value: value ? new Uint8Array(value) : undefined,
+			byteElementIndexLimit: input.byteElementIndexLimit ?? 0,
+		};
+	}
+
+	private restoreNativeBackboneDocument(
+		rollback: NativeBackboneDocumentRollback,
+	): void {
+		const backbone = this._nativeBackbone;
+		if (!backbone) return;
+		backbone.deleteDocument(rollback.key);
+		if (rollback.value) {
+			// documentValueBytes returns the complete stored encoding, so it can be
+			// restored as one prefix with an empty suffix.
+			backbone.putDocumentEncodedPartsStored(
+				rollback.key,
+				rollback.value,
+				new Uint8Array(),
+				rollback.byteElementIndexLimit,
+			);
+		}
+	}
+
+	private parseNativeStrictDurableTransactionJournalRecord(
+		bytes: Uint8Array | undefined,
+		slot: 0 | 1,
+	): NativeStrictDurableTransactionJournalState | undefined {
+		if (bytes === undefined) {
+			return undefined;
+		}
+		// The pre-journal implementation represented a cleared intent as an empty
+		// primary file. Treat it as generation zero so the first framed update is
+		// written to the other slot and can never destroy the only valid state.
+		if (bytes.byteLength === 0) {
+			return { sequence: 0, slot };
+		}
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(new TextDecoder().decode(bytes));
+		} catch (error) {
+			throw new Error("Invalid native durable transaction journal JSON", {
+				cause: error,
+			});
+		}
+		if (!parsed || typeof parsed !== "object") {
+			throw new Error("Invalid native durable transaction journal record");
+		}
+		const candidate =
+			parsed as Partial<NativeStrictDurableTransactionJournalRecord>;
+		if (candidate.format === NATIVE_STRICT_DURABLE_TRANSACTION_JOURNAL_FORMAT) {
+			if (
+				candidate.version !== 1 ||
+				!Number.isSafeInteger(candidate.sequence) ||
+				(candidate.sequence ?? -1) < 1 ||
+				(candidate.state !== "intent" && candidate.state !== "cleared") ||
+				typeof candidate.checksum !== "string"
+			) {
+				throw new Error("Invalid native durable transaction journal frame");
+			}
+			const intent = candidate.intent ?? null;
+			if (
+				(candidate.state === "intent" && intent?.version !== 1) ||
+				(candidate.state === "cleared" && intent !== null)
+			) {
+				throw new Error("Invalid native durable transaction journal state");
+			}
+			const body = nativeStrictDurableTransactionJournalBody(
+				candidate.sequence!,
+				intent ?? undefined,
+			);
+			const checksum = toHexString(
+				sha256Sync(nativeStrictDurableTransactionJournalBodyBytes(body)),
+			);
+			if (checksum !== candidate.checksum) {
+				throw new Error("Native durable transaction journal checksum mismatch");
+			}
+			return {
+				sequence: candidate.sequence!,
+				slot,
+				intent: intent ?? undefined,
+			};
+		}
+		// Backward compatibility with the original single raw-JSON intent. A
+		// framed generation always sorts after this synthetic generation zero.
+		const legacy = parsed as Partial<NativeStrictDurableTransactionIntent>;
+		if (legacy.version !== 1) {
+			throw new Error("Unsupported native durable transaction recovery intent");
+		}
+		return {
+			sequence: 0,
+			slot,
+			intent: legacy as NativeStrictDurableTransactionIntent,
+		};
+	}
+
+	private async loadNativeStrictDurableTransactionJournalState(): Promise<NativeStrictDurableTransactionJournalState> {
+		if (this._nativeStrictDurableTransactionJournalState) {
+			return this._nativeStrictDurableTransactionJournalState;
+		}
+		const store = this._nativeBackboneCoordinatePersistenceStore;
+		if (!store) {
+			return (this._nativeStrictDurableTransactionJournalState = {
+				sequence: 0,
+				slot: 0,
+			});
+		}
+		const bytes = await Promise.all(
+			NATIVE_STRICT_DURABLE_TRANSACTION_INTENT_FILES.map((name) =>
+				store.read(name),
+			),
+		);
+		const valid: NativeStrictDurableTransactionJournalState[] = [];
+		const errors: unknown[] = [];
+		for (let index = 0; index < bytes.length; index++) {
+			try {
+				const state = this.parseNativeStrictDurableTransactionJournalRecord(
+					bytes[index],
+					index as 0 | 1,
+				);
+				if (state) valid.push(state);
+			} catch (error) {
+				errors.push(error);
+			}
+		}
+		if (valid.length === 0) {
+			if (errors.length > 0) {
+				throw new AggregateError(
+					errors,
+					"No valid native durable transaction journal generation remains",
+				);
+			}
+			// A completely new store has an implicit cleared generation. Before the
+			// first intent is written we materialize this baseline in one slot, so a
+			// corrupt sole slot can never be confused with a safe first-write tear (or
+			// with a torn legacy single-file intent).
+			return (this._nativeStrictDurableTransactionJournalState = {
+				sequence: 0,
+				slot: 0,
+				implicit: true,
+			});
+		}
+		valid.sort(
+			(left, right) => left.sequence - right.sequence || left.slot - right.slot,
+		);
+		return (this._nativeStrictDurableTransactionJournalState = valid.at(-1)!);
+	}
+
+	private async writeNativeStrictDurableTransactionIntent(
+		intent: NativeStrictDurableTransactionIntent | undefined,
+	) {
+		const store = this._nativeBackboneCoordinatePersistenceStore;
+		if (!store) {
+			return;
+		}
+		let previous = await this.loadNativeStrictDurableTransactionJournalState();
+		if (previous.implicit) {
+			const baselineSequence = previous.sequence + 1;
+			const baselineSlot = (previous.slot === 0 ? 1 : 0) as 0 | 1;
+			const baselineFile =
+				NATIVE_STRICT_DURABLE_TRANSACTION_INTENT_FILES[baselineSlot];
+			await store.write(
+				baselineFile,
+				nativeStrictDurableTransactionJournalRecordBytes(
+					baselineSequence,
+					undefined,
+				),
+			);
+			await this.barrierNativeStrictDurableStore(store, baselineFile);
+			previous = {
+				sequence: baselineSequence,
+				slot: baselineSlot,
+			};
+			this._nativeStrictDurableTransactionJournalState = previous;
+		}
+		const sequence = previous.sequence + 1;
+		const slot = (previous.slot === 0 ? 1 : 0) as 0 | 1;
+		const bytes = nativeStrictDurableTransactionJournalRecordBytes(
+			sequence,
+			intent,
+		);
+		const file = NATIVE_STRICT_DURABLE_TRANSACTION_INTENT_FILES[slot];
+		// Alternate slots. If this write is interrupted or torn, the previous
+		// checksummed generation remains untouched and recovery ignores the invalid
+		// newer slot. A durable shared-log generation requires an explicit physical
+		// barrier before this generation can become recovery-authoritative.
+		await store.write(file, bytes);
+		await this.barrierNativeStrictDurableStore(store, file);
+		this._nativeStrictDurableTransactionJournalState = {
+			sequence,
+			slot,
+			intent,
+		};
+	}
+
+	private async barrierNativeStrictDurableStore(
+		store: NativeBackboneCoordinatePersistenceStore,
+		file: string,
+	): Promise<void> {
+		if (this.node.directory != null) {
+			if (typeof store.durableBarrier !== "function") {
+				throw new Error(
+					"Durable native coordinate persistence does not expose a physical durability barrier",
+				);
+			}
+			await store.durableBarrier(file);
+			return;
+		}
+		// Memory-only operation has no durable lower marker. Preserve compatibility
+		// for transient adapters while still using a real barrier when they expose it.
+		if (store.durableBarrier) {
+			await store.durableBarrier(file);
+		} else {
+			await store.flush?.(file);
+		}
+	}
+
+	private async beginNativeStrictDurableTransaction(
+		documents: NativeBackboneDocumentRollback[],
+	): Promise<NativeStrictDurableTransactionHandle> {
+		this.throwIfNativeDurableCommitFailed();
+		if (this._nativeStrictDurableTransactionsClosing) {
+			throw new Error("Shared log is closing");
+		}
+		const previous =
+			this._nativeStrictDurableTransactionTail ?? Promise.resolve();
+		let release!: () => void;
+		const held = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		this._nativeStrictDurableTransactionTail = previous.then(() => held);
+		await previous;
+		try {
+			this.throwIfNativeDurableCommitFailed();
+			if (this._nativeStrictDurableTransactionsClosing) {
+				throw new Error("Shared log is closing");
+			}
+		} catch (error) {
+			release();
+			throw error;
+		}
+		const handle: NativeStrictDurableTransactionHandle = {
+			intent: {
+				version: 1,
+				lowerMarkerCommitted: false,
+				appendHashes: [],
+				trimHashes: [],
+				coordinateDeleteHashes: [],
+				lowerIndexRows: [],
+				coordinates: [],
+				documents: documents.map((document) => ({
+					key: document.key,
+					value: document.value ? [...document.value] : undefined,
+					byteElementIndexLimit: document.byteElementIndexLimit,
+				})),
+			},
+			release,
+			released: false,
+		};
+		(this._nativeStrictDurableTransactions ??= new Set()).add(handle);
+		try {
+			await this.writeNativeStrictDurableTransactionIntent(handle.intent);
+			return handle;
+		} catch (error) {
+			handle.released = true;
+			this._nativeStrictDurableTransactions.delete(handle);
+			handle.release();
+			throw error;
+		}
+	}
+
+	private async setNativeStrictDurableTransactionOperation(
+		handle: NativeStrictDurableTransactionHandle | undefined,
+		appendHashes: string[],
+		trimHashes: string[],
+		coordinateRollback?: NativeBackboneCoordinateRollback<R>,
+		coordinateDeleteHashes: string[] = [],
+	) {
+		if (!handle) {
+			return;
+		}
+		handle.intent.appendHashes = [...new Set(appendHashes.filter(Boolean))];
+		handle.intent.trimHashes = [...new Set(trimHashes.filter(Boolean))];
+		handle.intent.coordinateDeleteHashes = [
+			...new Set(coordinateDeleteHashes.filter(Boolean)),
+		];
+		const lowerHashes = [
+			...new Set([
+				...handle.intent.appendHashes,
+				...handle.intent.trimHashes,
+				...(coordinateRollback?.hashes ?? []),
+				...handle.intent.coordinateDeleteHashes,
+			]),
+		];
+		if (handle.lowerHashMutationLockOwner) {
+			throw new Error("Native durable transaction operation is already locked");
+		}
+		// This lease is shared with the lower native transaction and every ordinary
+		// EntryIndex mutation. Acquire it before reading any before-image, then hold
+		// it through marker acknowledgement or exact compensation.
+		handle.lowerHashMutationLockOwner =
+			await this.log.entryIndex.acquireHashMutationLocks(lowerHashes);
+		handle.intent.lowerIndexRows = await Promise.all(
+			lowerHashes.map(async (hash) => {
+				// EntryIndex publication may still live only in its pending generation.
+				// Snapshot the exact logical row that the marker phase will consume,
+				// rather than only the durable index, so a pre-marker crash can restore a
+				// pending external-next head instead of treating it as previously absent.
+				const previous = (await this.log.entryIndex.getShallow(hash))?.value;
+				return {
+					hash,
+					before: previous ? [...serialize(previous)] : undefined,
+				};
+			}),
+		);
+		handle.intent.coordinates = coordinateRollback
+			? [...coordinateRollback.hashes].map((hash) => {
+					const previous = coordinateRollback.entries.get(hash);
+					if (!previous) {
+						return { hash };
+					}
+					const materialized =
+						this.materializeResidentCoordinateEntry(previous);
+					return {
+						hash,
+						value: {
+							hashNumber: materialized.hashNumber.toString(),
+							gid: materialized.gid,
+							coordinates: materialized.coordinates.map((value) =>
+								value.toString(),
+							),
+							wallTime: materialized.wallTime.toString(),
+							assignedToRangeBoundary: materialized.assignedToRangeBoundary,
+							metaBytes: [...materialized.getMetaBytes()],
+						},
+					};
+				})
+			: [];
+		await this.writeNativeStrictDurableTransactionIntent(handle.intent);
+	}
+
+	private async setNativeStrictDurableTransactionExpectedRows(
+		handle: NativeStrictDurableTransactionHandle | undefined,
+		rows: ShallowEntry[],
+	) {
+		if (!handle) {
+			return;
+		}
+		if (!handle.lowerHashMutationLockOwner) {
+			throw new Error(
+				"Native durable transaction has no lower hash lock owner",
+			);
+		}
+		this.log.entryIndex.assertHashMutationLocks(
+			handle.lowerHashMutationLockOwner,
+			rows.flatMap((row) => [row.hash, ...row.meta.next]),
+		);
+		const rowsByHash = new Map(
+			handle.intent.lowerIndexRows.map((row) => [row.hash, row]),
+		);
+		for (const row of rows) {
+			const intentRow = rowsByHash.get(row.hash);
+			if (intentRow) {
+				intentRow.after = [...serialize(row)];
+			}
+		}
+		for (const nextHash of new Set(rows.flatMap((row) => row.meta.next))) {
+			const existingIntentRow = rowsByHash.get(nextHash);
+			if (existingIntentRow) {
+				if (!existingIntentRow.after && existingIntentRow.before) {
+					const after = deserialize(
+						Uint8Array.from(existingIntentRow.before),
+						ShallowEntry,
+					);
+					after.head = false;
+					existingIntentRow.after = [...serialize(after)];
+				}
+				continue;
+			}
+			const previous = (await this.log.entryIndex.getShallow(nextHash))?.value;
+			if (!previous) {
+				continue;
+			}
+			const after = deserialize(serialize(previous), ShallowEntry);
+			after.head = false;
+			const intentRow = {
+				hash: nextHash,
+				before: [...serialize(previous)],
+				after: [...serialize(after)],
+			};
+			handle.intent.lowerIndexRows.push(intentRow);
+			rowsByHash.set(nextHash, intentRow);
+		}
+		handle.intent.coordinateDeleteHashes = [
+			...new Set([
+				...(handle.intent.coordinateDeleteHashes ?? []),
+				...handle.intent.trimHashes,
+				...rows.flatMap((row) => row.meta.next),
+			]),
+		];
+		await this.writeNativeStrictDurableTransactionIntent(handle.intent);
+	}
+
+	private async markNativeStrictDurableTransactionLowerMarker(
+		handle: NativeStrictDurableTransactionHandle | undefined,
+	) {
+		if (!handle || handle.released) {
+			return;
+		}
+		handle.intent.lowerMarkerCommitted = true;
+		await this.writeNativeStrictDurableTransactionIntent(handle.intent);
+	}
+
+	private async markNativeStrictDurableTransactionRollback(
+		handle: NativeStrictDurableTransactionHandle | undefined,
+	) {
+		if (!handle || handle.released) {
+			return;
+		}
+		const previousMarker = handle.intent.lowerMarkerCommitted;
+		handle.intent.lowerMarkerCommitted = false;
+		try {
+			await this.writeNativeStrictDurableTransactionIntent(handle.intent);
+		} catch (error) {
+			// The last valid generation may still contain a true marker. Preserve
+			// that in-memory knowledge and keep the handle held until the caller has
+			// retained the lower finalizer. Releasing first would let concurrent close
+			// compensate lower facts while recovery still sees a committed marker.
+			handle.intent.lowerMarkerCommitted = previousMarker;
+			this.poisonNativeStrictDurableTransaction(error);
+			throw error;
+		}
+	}
+
+	private async completeNativeStrictDurableTrimCleanup(
+		intent: NativeStrictDurableTransactionIntent,
+		committed = intent.lowerMarkerCommitted === true,
+		reconstructMissing = false,
+	) {
+		if (!committed || intent.trimHashes.length === 0) {
+			return;
+		}
+		const localStore = this.remoteBlocks?.localStore as unknown as {
+			completeCommittedNativeDeleteCleanup?: (
+				cids: string[],
+				options?: { reconstructMissing?: boolean },
+			) => Promise<void>;
+		};
+		if (
+			typeof localStore?.completeCommittedNativeDeleteCleanup === "function"
+		) {
+			await localStore.completeCommittedNativeDeleteCleanup(intent.trimHashes, {
+				reconstructMissing,
+			});
+		}
+	}
+
+	private async completeNativeStrictDurableCoordinateCleanup(
+		intent: NativeStrictDurableTransactionIntent,
+		committed = intent.lowerMarkerCommitted === true,
+	) {
+		const hashes = intent.coordinateDeleteHashes ?? [];
+		if (!committed || hashes.length === 0) {
+			return;
+		}
+		await this.deleteCoordinatesForHashes(hashes);
+		const flushed = this.flushNativeBackboneCoordinateJournal();
+		if (isPromiseLike(flushed)) {
+			await flushed;
+		}
+	}
+
+	private async completeNativeStrictDurableTransaction(
+		handle: NativeStrictDurableTransactionHandle | undefined,
+	) {
+		if (!handle || handle.released) {
+			return;
+		}
+		try {
+			await this.completeNativeStrictDurableCoordinateCleanup(handle.intent);
+			await this.completeNativeStrictDurableTrimCleanup(handle.intent);
+			await this.writeNativeStrictDurableTransactionIntent(undefined);
+			this.clearNativeStrictDurableTransactionFailure();
+		} catch (error) {
+			// The lower marker may already be acknowledged. Retain the intent and
+			// reject every later mutation until reopen can finish recovery; allowing a
+			// new transaction to overwrite this generation would make rollback/GC debt
+			// ambiguous and can erase acknowledged data.
+			this.poisonNativeStrictDurableTransaction(error);
+			throw error;
+		} finally {
+			if (handle.lowerHashMutationLockOwner) {
+				this.log.entryIndex.releaseHashMutationLocks(
+					handle.lowerHashMutationLockOwner,
+				);
+				handle.lowerHashMutationLockOwner = undefined;
+			}
+			handle.released = true;
+			this._nativeStrictDurableTransactions?.delete(handle);
+			handle.release();
+		}
+	}
+
+	private releaseNativeStrictDurableTransaction(
+		handle: NativeStrictDurableTransactionHandle | undefined,
+		cause: unknown = new Error(
+			"Native durable transaction intent was retained for recovery",
+		),
+	) {
+		if (!handle || handle.released) {
+			return;
+		}
+		this.poisonNativeStrictDurableTransaction(cause);
+		if (handle.lowerHashMutationLockOwner) {
+			this.log.entryIndex.releaseHashMutationLocks(
+				handle.lowerHashMutationLockOwner,
+			);
+			handle.lowerHashMutationLockOwner = undefined;
+		}
+		handle.released = true;
+		this._nativeStrictDurableTransactions?.delete(handle);
+		handle.release();
+	}
+
+	private retainNativeStrictDurableTransactionAfterMarkerFailure(
+		handle: NativeStrictDurableTransactionHandle | undefined,
+		finalizer: TrustedLowerLogNativeCommitFinalizer | undefined,
+		cause: unknown,
+	): unknown[] {
+		const failures: unknown[] = [cause];
+		try {
+			finalizer?.retainForRecovery();
+		} catch (error) {
+			failures.push(error);
+		} finally {
+			// retainForRecovery finalizes its lower transaction even when one of its
+			// internal cleanup steps reports an error. Only release the strict handle
+			// after that synchronous state transition has been attempted.
+			this.releaseNativeStrictDurableTransaction(handle, cause);
+		}
+		return failures;
+	}
+
+	private async settleNativeStrictDurableTransactionsForClose(): Promise<void> {
+		while ((this._nativeStrictDurableTransactions?.size ?? 0) > 0) {
+			const tail = this._nativeStrictDurableTransactionTail;
+			if (!tail) {
+				throw new Error(
+					"Native strict durable transaction has no settlement tail",
+				);
+			}
+			// A close racing an acknowledged lower marker must not release the strict
+			// handle and let Log.close() compensate while the on-disk intent still says
+			// committed. Wait until the owner either retires the intent or deliberately
+			// retains it for recovery before closing the lower log or persistence stores.
+			await tail;
+		}
+	}
+
+	private async recoverNativeStrictDurableTransactionIntent(
+		documentIndexReady = false,
+	): Promise<boolean> {
+		const store = this._nativeBackboneCoordinatePersistenceStore;
+		if (!store || !this._nativeBackbone) {
+			this._nativeStrictDurableDocumentRecoveryDeferred = false;
+			return true;
+		}
+		const journalState =
+			await this.loadNativeStrictDurableTransactionJournalState();
+		const intent = journalState.intent;
+		if (!intent) {
+			this._nativeStrictDurableDocumentRecoveryDeferred = false;
+			this.clearNativeStrictDurableTransactionFailure();
+			return true;
+		}
+		if (intent.version !== 1) {
+			throw new Error("Unsupported native durable transaction recovery intent");
+		}
+		intent.trimHashes ??= [];
+		intent.coordinateDeleteHashes ??= [];
+		intent.lowerIndexRows ??= [];
+		intent.coordinates ??= [];
+		const bytesEqual = (
+			left: Uint8Array | undefined,
+			right: number[] | undefined,
+		) => {
+			if (!left || !right) {
+				return left === undefined && right === undefined;
+			}
+			if (left.byteLength !== right.length) {
+				return false;
+			}
+			for (let index = 0; index < left.byteLength; index++) {
+				if (left[index] !== right[index]) {
+					return false;
+				}
+			}
+			return true;
+		};
+		const immutableRowEquals = (
+			current: Uint8Array | undefined,
+			expected: number[] | undefined,
+		) => {
+			if (!current || !expected) {
+				return current === undefined && expected === undefined;
+			}
+			const currentRow = deserialize(current, ShallowEntry);
+			const expectedRow = deserialize(Uint8Array.from(expected), ShallowEntry);
+			// `head` is a mutable graph projection. Hash, payload size, and metadata
+			// are content-addressed append identity and are safe marker evidence even
+			// when a later acknowledged entry has demoted this row.
+			currentRow.head = false;
+			expectedRow.head = false;
+			return bytesEqual(serialize(currentRow), [...serialize(expectedRow)]);
+		};
+		const currentLowerRows = new Map<string, Uint8Array | undefined>();
+		for (const row of intent.lowerIndexRows) {
+			const current = (
+				await this.log.entryIndex.properties.index.get(toId(row.hash))
+			)?.value;
+			currentLowerRows.set(row.hash, current ? serialize(current) : undefined);
+		}
+		const trimHashes = new Set(intent.trimHashes);
+		const retainedMarkerRows = intent.lowerIndexRows.filter(
+			(row) =>
+				intent.appendHashes.includes(row.hash) &&
+				!trimHashes.has(row.hash) &&
+				row.after !== undefined,
+		);
+		// Only a row known absent in the before-image is an unambiguous lower commit
+		// marker. An existing content-addressed row can equal the after-image once
+		// mutable `head` is ignored even before this transaction mutated anything.
+		const expectedMarkerRows = retainedMarkerRows.filter(
+			(row) => row.before === undefined,
+		);
+		let lowerMarkerCommitted =
+			intent.lowerMarkerCommitted === true ||
+			(expectedMarkerRows.length > 0 &&
+				expectedMarkerRows.every((row) =>
+					immutableRowEquals(currentLowerRows.get(row.hash), row.after),
+				));
+		if (
+			!lowerMarkerCommitted &&
+			!documentIndexReady &&
+			intent.documents.some((document) => document.value !== undefined)
+		) {
+			// SharedLog opens before Documents can attach its schema-aware native
+			// index. Restoring an encoded before-image requires that schema. Keep the
+			// intent authoritative and mutations poisoned until Documents has attached
+			// the index and explicitly resumes recovery.
+			this._nativeStrictDurableDocumentRecoveryDeferred = true;
+			this.poisonNativeStrictDurableTransaction(
+				new Error(
+					"Native strict durable document recovery is waiting for its document index",
+				),
+			);
+			return false;
+		}
+
+		const lowerIndex = this.log.entryIndex.properties
+			.index as PutAndDeleteIndex<ShallowEntry>;
+		const deleteLowerIndexHash = async (hash: string) => {
+			if (lowerIndex.delIds) {
+				await lowerIndex.delIds([hash]);
+			} else if (lowerIndex.delIdsNoReturn) {
+				await lowerIndex.delIdsNoReturn([hash]);
+			} else {
+				await lowerIndex.del({ query: { hash } });
+			}
+		};
+		let lowerIndexChanged = false;
+		if (lowerMarkerCommitted) {
+			for (const row of intent.lowerIndexRows) {
+				if (trimHashes.has(row.hash) || !row.after) {
+					continue;
+				}
+				const current = currentLowerRows.get(row.hash);
+				if (immutableRowEquals(current, row.after)) {
+					// Preserve the current mutable head projection. It may include a later
+					// acknowledged Y -> X demotion that must survive recovery.
+					continue;
+				}
+				if (!intent.appendHashes.includes(row.hash) || current !== undefined) {
+					// External-next rows are not resurrected over a later delete, and a
+					// conflicting present content-addressed row is never overwritten.
+					continue;
+				}
+				await lowerIndex.put(
+					deserialize(Uint8Array.from(row.after), ShallowEntry),
+				);
+				lowerIndexChanged = true;
+			}
+			for (const hash of intent.trimHashes) {
+				const current = await lowerIndex.get(toId(hash));
+				const intentRow = intent.lowerIndexRows.find(
+					(row) => row.hash === hash,
+				);
+				if (
+					current &&
+					intentRow?.before &&
+					bytesEqual(serialize(current.value), intentRow.before)
+				) {
+					await deleteLowerIndexHash(hash);
+					lowerIndexChanged = true;
+				}
+			}
+		} else {
+			for (const row of intent.lowerIndexRows) {
+				const current = currentLowerRows.get(row.hash);
+				if (bytesEqual(current, row.before)) {
+					continue;
+				}
+				// Exact after-image CAS: a later mutation (including only a `head`
+				// change) owns the row and must not be erased or overwritten by recovery.
+				if (!bytesEqual(current, row.after)) {
+					continue;
+				}
+				if (row.before) {
+					await lowerIndex.put(
+						deserialize(Uint8Array.from(row.before), ShallowEntry),
+					);
+				} else {
+					await deleteLowerIndexHash(row.hash);
+				}
+				lowerIndexChanged = true;
+			}
+		}
+		if (lowerIndexChanged) {
+			await this.log.entryIndex.init();
+		}
+
+		if (!lowerMarkerCommitted) {
+			if (intent.coordinates.length > 0) {
+				const mutationGenerations =
+					(this._nativeCoordinateMutationGenerations ??= new Map());
+				const rollback: NativeBackboneCoordinateRollback<R> = {
+					hashes: new Set(),
+					entries: new Map(),
+					generations: new Map(),
+				};
+				for (const coordinate of intent.coordinates) {
+					rollback.hashes.add(coordinate.hash);
+					const generation =
+						(mutationGenerations.get(coordinate.hash) ?? 0) + 1;
+					mutationGenerations.set(coordinate.hash, generation);
+					rollback.generations.set(coordinate.hash, generation);
+					if (coordinate.value) {
+						const number = (value: string) =>
+							(this.domain.resolution === "u32"
+								? Number(value)
+								: BigInt(value)) as NumberFromType<R>;
+						rollback.entries.set(
+							coordinate.hash,
+							new this.indexableDomain.constructorEntry({
+								hash: coordinate.hash,
+								hashNumber: number(coordinate.value.hashNumber),
+								gid: coordinate.value.gid,
+								coordinates: coordinate.value.coordinates.map(number),
+								wallTime: BigInt(coordinate.value.wallTime),
+								assignedToRangeBoundary:
+									coordinate.value.assignedToRangeBoundary,
+								metaBytes: Uint8Array.from(coordinate.value.metaBytes),
+							}),
+						);
+					}
+				}
+				await this.rollbackNativeBackboneCoordinateAppendDurably("", rollback);
+			}
+			for (const document of intent.documents) {
+				this.restoreNativeBackboneDocument({
+					key: document.key,
+					value: document.value ? Uint8Array.from(document.value) : undefined,
+					byteElementIndexLimit: document.byteElementIndexLimit,
+				});
+			}
+			const flushed = this.flushNativeBackboneCoordinateJournal();
+			if (isPromiseLike(flushed)) {
+				await flushed;
+			}
+		}
+		if (lowerMarkerCommitted) {
+			await this.completeNativeStrictDurableCoordinateCleanup(intent, true);
+			await this.completeNativeStrictDurableTrimCleanup(intent, true, true);
+		}
+		await this.writeNativeStrictDurableTransactionIntent(undefined);
+		this._nativeStrictDurableDocumentRecoveryDeferred = false;
+		this.clearNativeStrictDurableTransactionFailure();
+		return true;
+	}
+
+	/** @internal Complete a deferred rollback after Documents attaches its schema. */
+	async finishNativeStrictDurableDocumentRecovery(): Promise<void> {
+		if (!this._nativeStrictDurableDocumentRecoveryDeferred) {
+			return;
+		}
+		const completed =
+			await this.recoverNativeStrictDurableTransactionIntent(true);
+		if (!completed) {
+			throw new Error(
+				"Native strict durable document recovery did not complete",
+			);
+		}
+		await this.reconcileNativeCoordinatesWithLowerCommitMarkers();
+	}
+
+	private async rollbackFailedNativeBackboneTransaction(properties: {
+		committedHashes: string[];
+		trimmedEntries?: Parameters<NativePeerbitBackbone["graph"]["putBatch"]>[0];
+		coordinateEntries?: NativeBackboneCoordinateRollback<R>;
+		documents?: NativeBackboneDocumentRollback[];
+		unmirroredBlockCompensation?: boolean;
+		skipBlockCompensation?: boolean;
+		restoreGraphFromIndex?: boolean;
+		durableWrapper?: {
+			rollbackUnmirroredNativeCommits?: (
+				cids: string[],
+				restoreNativeCids?: string[],
+			) => Promise<void>;
+			rollbackFailedNativeCommits?: (
+				cids: string[],
+				restoreNativeCids?: string[],
+			) => Promise<void>;
+		};
+	}): Promise<void> {
+		const backbone = this._nativeBackbone;
+		if (!backbone) return;
+		for (
+			let index = properties.committedHashes.length - 1;
+			index >= 0;
+			index--
+		) {
+			const hash = properties.committedHashes[index]!;
+			backbone.graph.delete(hash);
+			this.rollbackNativeBackboneCoordinateAppend(
+				hash,
+				properties.coordinateEntries,
+			);
+		}
+		if (properties.restoreGraphFromIndex) {
+			await this.log.entryIndex.restoreNativeGraphFromIndex();
+		} else {
+			if (properties.trimmedEntries?.length) {
+				backbone.graph.putBatch(properties.trimmedEntries);
+			}
+		}
+		for (const document of properties.documents ?? []) {
+			this.restoreNativeBackboneDocument(document);
+		}
+		const flushed = this.flushNativeBackboneCoordinateJournal();
+		if (isPromiseLike(flushed)) {
+			await flushed;
+		}
+		if (properties.skipBlockCompensation) {
+			return;
+		}
+		let compensated = false;
+		try {
+			if (
+				properties.unmirroredBlockCompensation &&
+				properties.durableWrapper?.rollbackUnmirroredNativeCommits
+			) {
+				await properties.durableWrapper.rollbackUnmirroredNativeCommits(
+					properties.committedHashes,
+					properties.trimmedEntries?.map((entry) => entry.hash),
+				);
+			} else if (properties.durableWrapper?.rollbackFailedNativeCommits) {
+				await properties.durableWrapper.rollbackFailedNativeCommits(
+					properties.committedHashes,
+					properties.trimmedEntries?.map((entry) => entry.hash),
+				);
+			} else {
+				await backbone.blocks.rmMany(properties.committedHashes);
+			}
+			compensated = true;
+		} finally {
+			this._nativeDurableRecoveryReadyForReopen = compensated;
+		}
+	}
+
 	private openTime!: number;
 	private oldestOpenTime!: number;
 
@@ -2267,12 +4183,18 @@ export class SharedLog<
 		RepairDispatchMode,
 		Map<string, Map<string, RepairDispatchEntry<R>>>
 	>;
-	private _repairFrontierActiveTargetsByMode!: Map<RepairDispatchMode, Set<string>>;
+	private _repairFrontierActiveTargetsByMode!: Map<
+		RepairDispatchMode,
+		Set<string>
+	>;
 	private _repairFrontierBypassKnownPeersByMode!: Map<
 		RepairDispatchMode,
 		Set<string>
 	>;
-	private _repairSweepOptimisticGidPeersPending!: Map<string, Map<string, number>>;
+	private _repairSweepOptimisticGidPeersPending!: Map<
+		string,
+		Map<string, number>
+	>;
 	private _entryKnownPeers!: Map<string, Set<string>>;
 	private _entryKnownPeerObservedAt!: Map<string, Map<string, number>>;
 	private _joinAuthoritativeRepairTimersByDelay!: Map<
@@ -2331,6 +4253,7 @@ export class SharedLog<
 
 	constructor(properties?: { id?: Uint8Array }) {
 		super();
+		this.ensureNativeDurabilityRuntimeState();
 		this.log = new Log(properties);
 		this.rpc = new RPC();
 		this._checkedPrune = new CheckedPruneCoordinator<T, R>();
@@ -2375,6 +4298,18 @@ export class SharedLog<
 		this._replicationAnnouncementRetryController = new AbortController();
 		this.pendingMaturity = new Map();
 		this._closeController = new AbortController();
+	}
+
+	private ensureNativeDurabilityRuntimeState(): void {
+		// Program clones are borsh-created without running class field initializers.
+		// Keep recovery state from an existing generation, while supplying fresh
+		// defaults only when the runtime-only fields are absent.
+		this._nativeDurableRecoveryReadyForReopen ??= false;
+		this._nativeDurableRecoveryCids ??= new Set();
+		this._nativeBackboneDropStarted ??= false;
+		this._nativeBackboneCoordinateJournalLastFlushMs ??= 0;
+		this._nativeStrictDurableDocumentRecoveryDeferred ??= false;
+		this._nativeStrictDurableTransactionsClosing ??= false;
 	}
 
 	get compatibility(): number | undefined {
@@ -2962,9 +4897,10 @@ export class SharedLog<
 		const encodeChunk = (from: number, until: number): boolean => {
 			const payload = backbone.encodeRawExchangeSyncPayload!({
 				topic,
-				hashes: from === 0 && until === plan.hashes.length
-					? plan.hashes
-					: plan.hashes.slice(from, until),
+				hashes:
+					from === 0 && until === plan.hashes.length
+						? plan.hashes
+						: plan.hashes.slice(from, until),
 				gidRefrences:
 					from === 0 && until === plan.gidRefrences.length
 						? plan.gidRefrences
@@ -5223,10 +7159,7 @@ export class SharedLog<
 			}
 			return;
 		}
-		for await (const message of createExchangeHeadsMessages(
-			this.log,
-			hashes,
-		)) {
+		for await (const message of createExchangeHeadsMessages(this.log, hashes)) {
 			message.reserved[0] |= EXCHANGE_HEADS_REPAIR_HINT;
 			await this.rpc.send(message, {
 				priority: SYNC_MESSAGE_PRIORITY,
@@ -6475,6 +8408,7 @@ export class SharedLog<
 		entry: Entry<T>;
 		removed: ShallowOrFullEntry<T>[];
 	}> {
+		this.throwIfNativeDurableCommitFailed();
 		if (this._isAdaptiveReplicating) {
 			this.markLocalAppendActivity();
 		}
@@ -6496,6 +8430,7 @@ export class SharedLog<
 		entry: Entry<T>;
 		removed: ShallowOrFullEntry<T>[];
 	}> {
+		this.throwIfNativeDurableCommitFailed();
 		if (options?.canAppend || options?.onChange) {
 			throw new Error(
 				"appendLocallyValidated does not accept canAppend or onChange hooks",
@@ -6530,6 +8465,7 @@ export class SharedLog<
 		removed: ShallowOrFullEntry<T>[];
 		appendCommit: PreparedLocalAppendCommit<R>;
 	}> {
+		this.throwIfNativeDurableCommitFailed();
 		if (options?.canAppend || options?.onChange) {
 			throw new Error(
 				"appendLocallyPrepared does not accept canAppend or onChange hooks",
@@ -6728,6 +8664,7 @@ export class SharedLog<
 		options?: SharedAppendOptions<T> | undefined,
 		properties?: PreparedPayloadCommitOnlyProperties,
 	): MaybePromise<PreparedPayloadCommitOnlyResult<T, R> | undefined> {
+		this.throwIfNativeDurableCommitFailed();
 		if (options?.canAppend || options?.onChange) {
 			throw new Error(
 				"appendLocallyPreparedPayloadCommitOnly does not accept canAppend or onChange hooks",
@@ -6791,6 +8728,7 @@ export class SharedLog<
 		options?: SharedAppendOptions<T> | undefined,
 		properties?: PreparedPayloadCommitOnlyProperties,
 	): MaybePromise<PreparedPayloadCommitOnlyResult<T, R> | undefined> {
+		this.throwIfNativeDurableCommitFailed();
 		if (options?.canAppend || options?.onChange) {
 			throw new Error(
 				"appendStrictNativeDocumentPayloadCommitOnly does not accept canAppend or onChange hooks",
@@ -6833,17 +8771,13 @@ export class SharedLog<
 	): MaybePromise<PreparedPayloadCommitOnlyResult<T, R> | undefined> {
 		const resultMaybe = asTrustedLowerLog(
 			this.log,
-		).appendLocallyPreparedCommitOnly(
-			undefined as T,
-			appendOptions,
-			{
-				skipMissingNextJoin: properties?.skipMissingNextJoin,
-				resolveTrimmedEntries: properties?.resolveTrimmedEntries,
-				payloadData,
-				includeMaterializationBytes: false,
-				includeAppendFactsBytes: !deferHeadCoordinatePersistence,
-			},
-		);
+		).appendLocallyPreparedCommitOnly(undefined as T, appendOptions, {
+			skipMissingNextJoin: properties?.skipMissingNextJoin,
+			resolveTrimmedEntries: properties?.resolveTrimmedEntries,
+			payloadData,
+			includeMaterializationBytes: false,
+			includeAppendFactsBytes: !deferHeadCoordinatePersistence,
+		});
 		return mapMaybePromise(resultMaybe, (result) =>
 			this.finishPreparedPayloadCommitOnlyAppend(
 				result,
@@ -6926,15 +8860,48 @@ export class SharedLog<
 		// commit-only block can be mirrored to durable WITHOUT routing it through
 		// the log's finishBlocks/putKnown* (which would disturb the strict-native
 		// resident-coordinate append path). `mirrorToDurable` writes to the durable
-		// side only and tracks the write for error-surfacing.
+		// side only; the lower-log result is held behind that durability barrier.
 		const durableWrapper = durableWrapperActive
 			? (this.remoteBlocks?.localStore as unknown as {
-					mirrorToDurable?: (cid: string, bytes: Uint8Array) => void;
+					beginNativeDeleteCleanup?: (cids: string[]) => number | undefined;
+					cancelNativeDeleteCleanup?: (cleanupToken: unknown) => void;
+					mirrorToDurable?: (
+						cid: string,
+						bytes: Uint8Array,
+						options?: { nativeTrimmed?: boolean },
+					) => Promise<unknown>;
+					rollbackFailedNativeCommits?: (
+						cids: string[],
+						restoreNativeCids?: string[],
+					) => Promise<void>;
 				})
 			: undefined;
 		let nativeBackboneDocumentIndexCommitted = false;
-		let committedNativeBackboneDocumentIndex:
-			| NativeBackboneDocumentIndexCommitInput
+		let nativeDeleteCleanupToken: unknown;
+		let nativeDocumentRollback: NativeBackboneDocumentRollback | undefined;
+		let nativeStrictTransaction:
+			| NativeStrictDurableTransactionHandle
+			| undefined;
+		let lowerPublicationRollback:
+			| {
+					committedHashes: string[];
+					trimmedEntries?: Parameters<
+						NativePeerbitBackbone["graph"]["putBatch"]
+					>[0];
+					coordinateEntries?: NativeBackboneCoordinateRollback<R>;
+					documents?: NativeBackboneDocumentRollback[];
+					durableWrapper?: {
+						rollbackUnmirroredNativeCommits?: (
+							cids: string[],
+							restoreNativeCids?: string[],
+						) => Promise<void>;
+						rollbackFailedNativeCommits?: (
+							cids: string[],
+							restoreNativeCids?: string[],
+						) => Promise<void>;
+					};
+					lowerPublicationStarted: boolean;
+			  }
 			| undefined;
 		const nativeCommitProperties = {
 			payloadData,
@@ -6944,128 +8911,386 @@ export class SharedLog<
 			resolveTrimmedEntries?: boolean;
 			skipMissingNextJoin?: boolean;
 			retainMaterializationBytes?: boolean;
+			deferNativeTransactionAcknowledgement?: boolean;
 		};
 		nativeCommitProperties.skipMissingNextJoin =
 			properties?.skipMissingNextJoin;
 		nativeCommitProperties.retainMaterializationBytes =
 			this._logProperties?.trim != null;
-		const result = asTrustedLowerLog(
-			this.log,
-		).appendLocallyPreparedNativeNoNextCommitOnly(
-			undefined as T,
-			appendOptions,
-			nativeCommitProperties,
-			(input) => {
-				const next =
-					"next" in input && Array.isArray(input.next) ? input.next : [];
-				const nativeBackboneDocumentIndex =
-					properties?.nativeBackboneDocumentIndex ??
-					properties?.prepareNativeBackboneDocumentIndex?.({
-						wallTime: input.wallTime,
-						gid: input.gid,
-						payloadSize: input.payloadData.byteLength,
+		nativeCommitProperties.deferNativeTransactionAcknowledgement = true;
+		const rollbackLowerPublication = async (error: unknown): Promise<never> => {
+			durableWrapper?.cancelNativeDeleteCleanup?.(nativeDeleteCleanupToken);
+			const rollbackFailures: unknown[] = [];
+			if (
+				lowerPublicationRollback &&
+				!(error instanceof NativeDurableCommitError)
+			) {
+				try {
+					const lowerPublicationStarted =
+						lowerPublicationRollback.lowerPublicationStarted;
+					await this.rollbackFailedNativeBackboneTransaction({
+						committedHashes: lowerPublicationRollback.committedHashes,
+						trimmedEntries: lowerPublicationRollback.trimmedEntries,
+						coordinateEntries: lowerPublicationRollback.coordinateEntries,
+						documents: lowerPublicationRollback.documents,
+						durableWrapper: lowerPublicationStarted
+							? undefined
+							: lowerPublicationRollback.durableWrapper,
+						skipBlockCompensation: lowerPublicationStarted,
+						unmirroredBlockCompensation: !lowerPublicationStarted,
+						restoreGraphFromIndex: true,
 					});
-				const nativeBackboneDocumentIndexForAppend =
-					nativeBackboneDocumentIndex &&
-					input.trimLengthTo == null &&
-					nativeBackboneDocumentIndex.deleteTrimmedHeads === true
-						? {
-								...nativeBackboneDocumentIndex,
-								deleteTrimmedHeads: false,
-							}
-						: nativeBackboneDocumentIndex;
-				if (nativeBackboneDocumentIndex) {
-					nativeBackboneDocumentIndexCommitted = true;
-					committedNativeBackboneDocumentIndex = nativeBackboneDocumentIndex;
+				} catch (rollbackError) {
+					rollbackFailures.push(rollbackError);
 				}
-				const useLatestDocumentContext =
-					properties?.useNativeExistingDocumentContext === true;
-				const prepared = backbone.graph.prepareEntryV0PlainEntryCommit(
-					{
-						...input,
-						next,
-						includeMaterializationBytes: false,
-						includeAppendFactsBytes: true,
-						trimLengthTo: input.trimLengthTo,
-						...(nativeBackboneDocumentIndexForAppend
-							? {
-									documentIndex: {
-										...nativeBackboneDocumentIndexForAppend,
-										...(useLatestDocumentContext
-											? { useLatestContext: true }
-											: {}),
-									},
-								}
-							: {}),
-					},
-					backbone.blocks,
-				);
-				if (prepared && !prepared.bytes) {
-					if (durableWrapper) {
-						// The durable write-through wrapper is active, so the block store
-						// the log writes through (this.remoteBlocks.localStore) is the
-						// wrapper, NOT the raw wasm block map. prepareEntryV0PlainEntryCommit
-						// committed the block into the wasm map ONLY and returned no raw
-						// bytes, so on its own the block would never reach durable (log's
-						// finishBlocks only calls putKnown* when prepared.bytes is set) and
-						// a non-replicating native node would lose it on restart.
-						//
-						// Mirror the just-committed block (read back from the wasm store)
-						// straight to the DURABLE side of the wrapper. Crucially we do NOT
-						// attach prepared.bytes: doing so would make the log's finishBlocks
-						// call putKnown*, which changes the commit-only append path and
-						// breaks the strict-native resident-coordinate optimization (the
-						// reopen tests assert the append stays native and resolves no entry
-						// block). Instead the prepared result is returned exactly as the
-						// memory-only branch below (getBytes only, no bytes), so the log's
-						// finishBlocks path is UNCHANGED, and the block is made durable
-						// out-of-band here. mirrorToDurable tracks the write so an IO/
-						// disk-full failure surfaces on a later awaited wrapper method.
-						const preparedHash = prepared.cid ?? prepared.hash;
-						const committedBytes = preparedHash
-							? backbone.blocks.get(preparedHash)
-							: undefined;
-						if (committedBytes && durableWrapper.mirrorToDurable) {
-							durableWrapper.mirrorToDurable(preparedHash!, committedBytes);
-						}
+			} else if (
+				nativeDocumentRollback &&
+				!(error instanceof NativeDurableCommitError)
+			) {
+				try {
+					this.restoreNativeBackboneDocument(nativeDocumentRollback);
+					const flushed = this.flushNativeBackboneCoordinateJournal();
+					if (isPromiseLike(flushed)) {
+						await flushed;
 					}
-					// The block lives in the wasm map; expose getBytes for materialization
-					// (identical to the memory-only native node path). When the durable
-					// wrapper is active the durable copy was mirrored just above.
-					return {
-						...prepared,
-						getBytes: (hash: string) => backbone.blocks.get(hash),
-					};
+				} catch (rollbackError) {
+					rollbackFailures.push(rollbackError);
 				}
-				return prepared;
-			},
-		);
-		if (!result) {
-			return undefined;
+			}
+			if (rollbackFailures.length > 0) {
+				this.releaseNativeStrictDurableTransaction(nativeStrictTransaction);
+				throw new AggregateError(
+					[error, ...rollbackFailures],
+					"Lower-log publication and native compensation both failed",
+				);
+			}
+			await this.completeNativeStrictDurableTransaction(
+				nativeStrictTransaction,
+			);
+			throw error;
+		};
+		let result: MaybePromise<
+			TrustedLowerLogCommitOnlyAppendResult<T> | undefined
+		>;
+		try {
+			result = asTrustedLowerLog(
+				this.log,
+			).appendLocallyPreparedNativeNoNextCommitOnly(
+				undefined as T,
+				appendOptions,
+				nativeCommitProperties,
+				async (input) => {
+					const next =
+						"next" in input && Array.isArray(input.next) ? input.next : [];
+					const nativeBackboneDocumentIndex =
+						properties?.nativeBackboneDocumentIndex ??
+						properties?.prepareNativeBackboneDocumentIndex?.({
+							wallTime: input.wallTime,
+							gid: input.gid,
+							payloadSize: input.payloadData.byteLength,
+						});
+					const nativeBackboneDocumentIndexForAppend =
+						nativeBackboneDocumentIndex &&
+						input.trimLengthTo == null &&
+						nativeBackboneDocumentIndex.deleteTrimmedHeads === true
+							? {
+									...nativeBackboneDocumentIndex,
+									deleteTrimmedHeads: false,
+								}
+							: nativeBackboneDocumentIndex;
+					if (nativeBackboneDocumentIndex) {
+						nativeBackboneDocumentIndexCommitted = true;
+					}
+					const useLatestDocumentContext =
+						properties?.useNativeExistingDocumentContext === true;
+					nativeDocumentRollback = this.snapshotNativeBackboneDocument(
+						nativeBackboneDocumentIndexForAppend,
+					);
+					nativeStrictTransaction =
+						await this.beginNativeStrictDurableTransaction(
+							nativeDocumentRollback ? [nativeDocumentRollback] : [],
+						);
+					const prepared = backbone.graph.prepareEntryV0PlainEntryCommit(
+						{
+							...input,
+							next,
+							includeMaterializationBytes: false,
+							includeAppendFactsBytes: true,
+							trimLengthTo: input.trimLengthTo,
+							...(nativeBackboneDocumentIndexForAppend
+								? {
+										documentIndex: {
+											...nativeBackboneDocumentIndexForAppend,
+											...(useLatestDocumentContext
+												? { useLatestContext: true }
+												: {}),
+										},
+									}
+								: {}),
+						},
+						backbone.blocks,
+					);
+					if (prepared) {
+						const preparedHash = prepared.cid ?? prepared.hash;
+						const preparedNext = prepared.next ?? next;
+						const nativeTrimmedHashes =
+							prepared.trimmedEntryHashes ??
+							(
+								prepared.trimmedEntries as Array<{ hash?: string }> | undefined
+							)?.flatMap((entry) => (entry.hash ? [entry.hash] : [])) ??
+							[];
+						const coordinateRollback = this.snapshotResidentCoordinateEntries([
+							...(preparedHash ? [preparedHash] : []),
+							...preparedNext,
+							...nativeTrimmedHashes,
+						]);
+						lowerPublicationRollback = {
+							committedHashes: preparedHash ? [preparedHash] : [],
+							trimmedEntries: prepared.trimmedEntries,
+							coordinateEntries: coordinateRollback,
+							documents: nativeDocumentRollback
+								? [nativeDocumentRollback]
+								: undefined,
+							durableWrapper,
+							lowerPublicationStarted: false,
+						};
+						await this.setNativeStrictDurableTransactionOperation(
+							nativeStrictTransaction,
+							preparedHash ? [preparedHash] : [],
+							nativeTrimmedHashes,
+							coordinateRollback,
+							combineCoordinateDeleteHashes(preparedNext, nativeTrimmedHashes),
+						);
+						if (prepared.bytes) {
+							lowerPublicationRollback.lowerPublicationStarted = true;
+							return {
+								...prepared,
+								nativeIndexMutationLockOwner:
+									nativeStrictTransaction?.lowerHashMutationLockOwner,
+							};
+						}
+						const rollbackCommitted = async (
+							cause: unknown,
+							committedCids: string[],
+						): Promise<never> => {
+							durableWrapper?.cancelNativeDeleteCleanup?.(
+								nativeDeleteCleanupToken,
+							);
+							let compensated = false;
+							try {
+								await this.rollbackFailedNativeBackboneTransaction({
+									committedHashes: committedCids,
+									trimmedEntries: prepared.trimmedEntries,
+									coordinateEntries: coordinateRollback,
+									documents: nativeDocumentRollback
+										? [nativeDocumentRollback]
+										: undefined,
+									durableWrapper,
+								});
+								compensated = true;
+							} catch {
+								// Keep recovery marked incomplete; close will discard pending native
+								// journals. Reopen preserves uncertain content-addressed bytes and
+								// recovers liveness from the authoritative lower-log facts.
+							}
+							if (compensated) {
+								await this.completeNativeStrictDurableTransaction(
+									nativeStrictTransaction,
+								);
+							} else {
+								this.releaseNativeStrictDurableTransaction(
+									nativeStrictTransaction,
+								);
+							}
+							return this.failNativeDurableCommit(cause, {
+								committedCids,
+								failedCids: committedCids,
+							});
+						};
+						if (
+							durableWrapper &&
+							nativeTrimmedHashes.length > 0 &&
+							!durableWrapper.beginNativeDeleteCleanup
+						) {
+							return rollbackCommitted(
+								new Error(
+									"Native durable block wrapper cannot preannounce trim cleanup",
+								),
+								preparedHash ? [preparedHash] : [],
+							);
+						}
+						nativeDeleteCleanupToken =
+							durableWrapper?.beginNativeDeleteCleanup?.(nativeTrimmedHashes);
+						const preparedResult = {
+							...prepared,
+							nativeIndexMutationLockOwner:
+								nativeStrictTransaction?.lowerHashMutationLockOwner,
+							getBytes: (hash: string) => backbone.blocks.get(hash),
+							nativeBlocksDeleted: true,
+							nativeDeleteCleanupToken,
+						};
+						if (durableWrapper) {
+							// The durable write-through wrapper is active, so the block store
+							// the log writes through (this.remoteBlocks.localStore) is the
+							// wrapper, NOT the raw wasm block map. prepareEntryV0PlainEntryCommit
+							// committed the block into the wasm map ONLY and returned no raw
+							// bytes, so on its own the block would never reach durable (log's
+							// finishBlocks only calls putKnown* when prepared.bytes is set) and
+							// a non-replicating native node would lose it on restart.
+							//
+							// Mirror the just-committed block (read back from the wasm store)
+							// straight to the DURABLE side of the wrapper. Crucially we do NOT
+							// attach prepared.bytes: doing so would make the log's finishBlocks
+							// call putKnown*, which changes the commit-only append path and
+							// breaks the strict-native resident-coordinate optimization (the
+							// reopen tests assert the append stays native and resolves no entry
+							// block). Instead the prepared result is returned exactly as the
+							// memory-only branch below (getBytes only, no bytes), so the log's
+							// finishBlocks path is UNCHANGED. Returning the mirror promise from
+							// this prepare callback holds lower-log index/head/trim publication
+							// until durable succeeds.
+							if (!preparedHash) {
+								durableWrapper.cancelNativeDeleteCleanup?.(
+									nativeDeleteCleanupToken,
+								);
+								return rollbackCommitted(
+									new Error("Native commit returned no entry CID to mirror"),
+									[],
+								);
+							}
+							if (!durableWrapper.mirrorToDurable) {
+								durableWrapper.cancelNativeDeleteCleanup?.(
+									nativeDeleteCleanupToken,
+								);
+								return rollbackCommitted(
+									new Error(
+										"Native durable block wrapper has no mirror method",
+									),
+									[preparedHash],
+								);
+							}
+							const committedBytes = backbone.blocks.get(preparedHash);
+							if (!committedBytes) {
+								durableWrapper.cancelNativeDeleteCleanup?.(
+									nativeDeleteCleanupToken,
+								);
+								return rollbackCommitted(
+									new Error(
+										`Native committed block ${preparedHash} is missing from the hot store`,
+									),
+									[preparedHash],
+								);
+							}
+							return durableWrapper
+								.mirrorToDurable(preparedHash, committedBytes, {
+									nativeTrimmed: nativeTrimmedHashes.includes(preparedHash),
+								})
+								.then(
+									(nativeCommitOwnershipToken) => {
+										lowerPublicationRollback!.lowerPublicationStarted = true;
+										return {
+											...preparedResult,
+											nativeCommitOwnershipToken,
+										};
+									},
+									(error) => {
+										durableWrapper.cancelNativeDeleteCleanup?.(
+											nativeDeleteCleanupToken,
+										);
+										return rollbackCommitted(error, [preparedHash]);
+									},
+								);
+						}
+						lowerPublicationRollback.lowerPublicationStarted = true;
+						return preparedResult;
+					}
+					await this.completeNativeStrictDurableTransaction(
+						nativeStrictTransaction,
+					);
+					return prepared;
+				},
+			);
+			if (isPromiseLike(result)) {
+				result = result.catch(rollbackLowerPublication);
+			}
+		} catch (error) {
+			return rollbackLowerPublication(error);
 		}
-		return mapMaybePromise(result, (prepared) => {
+		if (!result) {
+			return this.completeNativeStrictDurableTransaction(
+				nativeStrictTransaction,
+			).then(() => undefined);
+		}
+		return mapMaybePromise(result, async (prepared) => {
 			if (!prepared) {
+				await this.completeNativeStrictDurableTransaction(
+					nativeStrictTransaction,
+				);
 				return undefined;
 			}
-			const rollback = (error: unknown): never => {
-				if (committedNativeBackboneDocumentIndex) {
-					backbone.deleteDocument(committedNativeBackboneDocumentIndex.key);
+			const rollback = async (error: unknown): Promise<never> => {
+				const rollbackFailures: unknown[] = [];
+				try {
+					await this.markNativeStrictDurableTransactionRollback(
+						nativeStrictTransaction,
+					);
+				} catch (rollbackError) {
+					const retentionFailures =
+						this.retainNativeStrictDurableTransactionAfterMarkerFailure(
+							nativeStrictTransaction,
+							prepared.nativeCommittedAppendFinalizer,
+							rollbackError,
+						);
+					throw new AggregateError(
+						[error, ...retentionFailures],
+						"Native rollback marker could not be persisted; recovery is required",
+					);
+				}
+				try {
+					await prepared.nativeCommittedAppendFinalizer?.rollback();
+				} catch (rollbackError) {
+					rollbackFailures.push(rollbackError);
+				}
+				try {
+					await this.rollbackNativeBackboneCoordinateAppendDurably(
+						prepared.appendFacts.hash,
+						lowerPublicationRollback?.coordinateEntries,
+					);
+					for (const document of lowerPublicationRollback?.documents ?? []) {
+						this.restoreNativeBackboneDocument(document);
+					}
+					const flushed = this.flushNativeBackboneCoordinateJournal();
+					if (isPromiseLike(flushed)) {
+						await flushed;
+					}
+				} catch (rollbackError) {
+					rollbackFailures.push(rollbackError);
+				}
+				if (rollbackFailures.length === 0) {
+					try {
+						await this.completeNativeStrictDurableTransaction(
+							nativeStrictTransaction,
+						);
+					} catch (rollbackError) {
+						rollbackFailures.push(rollbackError);
+					}
+				} else {
+					this.releaseNativeStrictDurableTransaction(nativeStrictTransaction);
+				}
+				if (rollbackFailures.length > 0) {
+					throw new AggregateError(
+						[error, ...rollbackFailures],
+						"Shared-log append and compensation both failed",
+					);
 				}
 				throw error;
 			};
+			let finishResult: PreparedPayloadCommitOnlyResult<T, R> | undefined;
 			try {
-				const deferredCoordinateDeleteHashes =
-					this.applyPreparedAppendFactsWithDeferredCoordinateDeletes(
-						prepared.appendFacts,
-						prepared.removed,
-						prepared.materializeEntry,
-						{ removedHashes: prepared.removedHashes },
-					);
-				const deleteHashes =
-					deferredCoordinateDeleteHashes &&
-					deferredCoordinateDeleteHashes.length > 0
-						? deferredCoordinateDeleteHashes
-						: [];
+				await this.setNativeStrictDurableTransactionExpectedRows(
+					nativeStrictTransaction,
+					[prepared.shallowEntry],
+				);
 				const finish = (): PreparedPayloadCommitOnlyResult<T, R> => {
 					const appendCommit = this.createPreparedLocalAppendCommitFromFacts(
 						prepared.appendFacts,
@@ -7084,19 +9309,36 @@ export class SharedLog<
 						appendCommit,
 					};
 				};
-				const completed =
-					deleteHashes.length === 0
-						? finish()
-						: mapMaybePromise(
-								this.deleteCoordinatesForHashes(deleteHashes),
-								finish,
-							);
-				return isPromiseLike(completed)
-					? completed.catch((error) => rollback(error))
-					: completed;
+				if (!prepared.nativeCommittedAppendFinalizer) {
+					throw new Error("Missing deferred native append finalizer");
+				}
+				// Strict success cannot honor batching thresholds: native
+				// coordinate/document/signer facts must be physically durable before
+				// the lower commit marker is acknowledged and its intent is retired.
+				await this.flushNativeBackboneCoordinateJournal();
+				await prepared.nativeCommittedAppendFinalizer.acknowledge(() =>
+					this.markNativeStrictDurableTransactionLowerMarker(
+						nativeStrictTransaction,
+					),
+				);
+				finishResult = finish();
 			} catch (error) {
 				return rollback(error);
 			}
+			this.applyPreparedAppendFactsWithDeferredCoordinateDeletes(
+				prepared.appendFacts,
+				prepared.removed,
+				prepared.materializeEntry,
+				{ removedHashes: prepared.removedHashes },
+			);
+			try {
+				await this.completeNativeStrictDurableTransaction(
+					nativeStrictTransaction,
+				);
+			} catch (error) {
+				warn(`Failed to retire committed native intent: ${String(error)}`);
+			}
+			return finishResult;
 		});
 	}
 
@@ -7144,7 +9386,17 @@ export class SharedLog<
 				this.remoteBlocks?.localStore !== backbone.blocks;
 			const durableWrapper = durableWrapperActive
 				? (this.remoteBlocks?.localStore as unknown as {
-						mirrorToDurable?: (cid: string, bytes: Uint8Array) => void;
+						beginNativeDeleteCleanup?: (cids: string[]) => number | undefined;
+						cancelNativeDeleteCleanup?: (cleanupToken: unknown) => void;
+						mirrorToDurable?: (
+							cid: string,
+							bytes: Uint8Array,
+							options?: { nativeTrimmed?: boolean },
+						) => Promise<unknown>;
+						rollbackFailedNativeCommits?: (
+							cids: string[],
+							restoreNativeCids?: string[],
+						) => Promise<void>;
 					})
 				: undefined;
 			const commitBlocksInBackbone =
@@ -7152,10 +9404,15 @@ export class SharedLog<
 				durableWrapperActive;
 			let nativeBackboneDocumentIndexCommitted = false;
 			let nativeBackboneDocumentDeleteCommitted = false;
-			let committedNativeBackboneDocumentIndex:
-				| NativeBackboneDocumentIndexCommitInput
+			let nativeDocumentRollback: NativeBackboneDocumentRollback | undefined;
+			let nativeCoordinateRollback:
+				| NativeBackboneCoordinateRollback<R>
 				| undefined;
-			const prepareBackboneAppend = (input: {
+			let nativeDeleteCleanupToken: unknown;
+			let nativeStrictTransaction:
+				| NativeStrictDurableTransactionHandle
+				| undefined;
+			const prepareBackboneAppend = async (input: {
 				wallTime: bigint;
 				logical: number;
 				gid: string;
@@ -7208,21 +9465,32 @@ export class SharedLog<
 						"Native backbone append cannot both put and delete a document index row",
 					);
 				}
-				const appendInputWithDocumentIndex = nativeBackboneDocumentIndexForAppend
-					? {
-							...appendInput,
-							documentIndex: {
-								...nativeBackboneDocumentIndexForAppend,
-								useLatestContext:
-									properties?.useNativeExistingDocumentContext === true,
-							},
-						}
-					: nativeBackboneDocumentDeleteKey
+				const appendInputWithDocumentIndex =
+					nativeBackboneDocumentIndexForAppend
 						? {
 								...appendInput,
-								documentDeleteKey: nativeBackboneDocumentDeleteKey,
+								documentIndex: {
+									...nativeBackboneDocumentIndexForAppend,
+									useLatestContext:
+										properties?.useNativeExistingDocumentContext === true,
+								},
 							}
-						: appendInput;
+						: nativeBackboneDocumentDeleteKey
+							? {
+									...appendInput,
+									documentDeleteKey: nativeBackboneDocumentDeleteKey,
+								}
+							: appendInput;
+				nativeDocumentRollback = this.snapshotNativeBackboneDocument(
+					nativeBackboneDocumentIndexForAppend ??
+						(nativeBackboneDocumentDeleteKey
+							? { key: nativeBackboneDocumentDeleteKey }
+							: undefined),
+				);
+				nativeStrictTransaction =
+					await this.beginNativeStrictDurableTransaction(
+						nativeDocumentRollback ? [nativeDocumentRollback] : [],
+					);
 				if (next.length === 0) {
 					if (commitBlocksInBackbone) {
 						if (
@@ -7267,31 +9535,81 @@ export class SharedLog<
 				}
 				if (nativeBackboneDocumentIndex) {
 					nativeBackboneDocumentIndexCommitted = true;
-					committedNativeBackboneDocumentIndex = nativeBackboneDocumentIndex;
 				}
 				nativeBackboneDocumentDeleteCommitted =
 					!!nativeBackboneDocumentDeleteKey;
 				const useTrimmedHashesOnly =
 					properties?.resolveTrimmedEntries === false;
-				if (durableWrapper?.mirrorToDurable) {
-					// The block was committed into the wasm map (commitBlocksInBackbone is
-					// true) but not into durable, because the log's finishBlocks path is
-					// left UNCHANGED for strict-native mode (getBytes only, no bytes, so
-					// no putKnown* through the wrapper). Mirror the just-committed block
-					// straight to the durable side so a non-replicating native node keeps
-					// it across a restart. mirrorToDurable tracks the write for
-					// error-surfacing.
-					const committedHash =
-						backboneAppend.entry.cid ?? backboneAppend.entry.hash;
-					const committedBytes = committedHash
-						? backbone.blocks.get(committedHash)
-						: undefined;
-					if (committedBytes) {
-						durableWrapper.mirrorToDurable(committedHash!, committedBytes);
+				const nativeTrimmedHashes =
+					backboneAppend.trimmedHashes ??
+					backboneAppend.trimmed.map((entry) => entry.hash);
+				const committedHash =
+					backboneAppend.entry.cid ?? backboneAppend.entry.hash;
+				const committedNext = backboneAppend.entry.next ?? next;
+				nativeCoordinateRollback = this.snapshotResidentCoordinateEntries([
+					...(committedHash ? [committedHash] : []),
+					...committedNext,
+					...nativeTrimmedHashes,
+				]);
+				await this.setNativeStrictDurableTransactionOperation(
+					nativeStrictTransaction,
+					committedHash ? [committedHash] : [],
+					nativeTrimmedHashes,
+					nativeCoordinateRollback,
+					combineCoordinateDeleteHashes(committedNext, nativeTrimmedHashes),
+				);
+				const rollbackCommitted = async (
+					cause: unknown,
+					committedCids: string[],
+				): Promise<never> => {
+					durableWrapper?.cancelNativeDeleteCleanup?.(nativeDeleteCleanupToken);
+					let compensated = false;
+					try {
+						await this.rollbackFailedNativeBackboneTransaction({
+							committedHashes: committedCids,
+							trimmedEntries: backboneAppend?.trimmed,
+							coordinateEntries: nativeCoordinateRollback,
+							documents: nativeDocumentRollback
+								? [nativeDocumentRollback]
+								: undefined,
+							durableWrapper,
+						});
+						compensated = true;
+					} catch {
+						// close/reopen completes recovery if durable compensation failed
 					}
+					if (compensated) {
+						await this.completeNativeStrictDurableTransaction(
+							nativeStrictTransaction,
+						);
+					} else {
+						this.releaseNativeStrictDurableTransaction(nativeStrictTransaction);
+					}
+					return this.failNativeDurableCommit(cause, {
+						committedCids,
+						failedCids: committedCids,
+					});
+				};
+				if (
+					durableWrapper &&
+					commitBlocksInBackbone &&
+					nativeTrimmedHashes.length > 0 &&
+					!durableWrapper.beginNativeDeleteCleanup
+				) {
+					return rollbackCommitted(
+						new Error(
+							"Native durable block wrapper cannot preannounce trim cleanup",
+						),
+						committedHash ? [committedHash] : [],
+					);
 				}
-				return {
+				nativeDeleteCleanupToken = commitBlocksInBackbone
+					? durableWrapper?.beginNativeDeleteCleanup?.(nativeTrimmedHashes)
+					: undefined;
+				const preparedResult = {
 					...backboneAppend.entry,
+					nativeIndexMutationLockOwner:
+						nativeStrictTransaction?.lowerHashMutationLockOwner,
 					gid: backboneAppend.coordinate.gid,
 					getBytes: commitBlocksInBackbone
 						? (hash: string) => backbone.blocks.get(hash)
@@ -7302,8 +9620,63 @@ export class SharedLog<
 					trimmedEntryHashes: useTrimmedHashesOnly
 						? backboneAppend.trimmedHashes
 						: undefined,
+					nativeBlocksDeleted: commitBlocksInBackbone,
+					nativeDeleteCleanupToken,
 					documentPreviousContext: backboneAppend.documentPreviousContext,
 				};
+				if (durableWrapper?.mirrorToDurable) {
+					// The block was committed into the wasm map (commitBlocksInBackbone is
+					// true) but not into durable, because the log's finishBlocks path is
+					// left UNCHANGED for strict-native mode (getBytes only, no bytes, so
+					// no putKnown* through the wrapper). Returning the promise here prevents
+					// lower-log index/head/trim publication until the mirror settles.
+					if (!committedHash) {
+						durableWrapper.cancelNativeDeleteCleanup?.(
+							nativeDeleteCleanupToken,
+						);
+						return rollbackCommitted(
+							new Error("Native commit returned no entry CID to mirror"),
+							[],
+						);
+					}
+					const committedBytes =
+						backboneAppend.entry.bytes ?? backbone.blocks.get(committedHash);
+					if (!committedBytes) {
+						durableWrapper.cancelNativeDeleteCleanup?.(
+							nativeDeleteCleanupToken,
+						);
+						return rollbackCommitted(
+							new Error(
+								`Native committed block ${committedHash} is missing from the hot store`,
+							),
+							[committedHash],
+						);
+					}
+					return durableWrapper
+						.mirrorToDurable(committedHash, committedBytes, {
+							nativeTrimmed: nativeTrimmedHashes.includes(committedHash),
+						})
+						.then(
+							(nativeCommitOwnershipToken) => ({
+								...preparedResult,
+								nativeCommitOwnershipToken,
+							}),
+							(error) => {
+								durableWrapper.cancelNativeDeleteCleanup?.(
+									nativeDeleteCleanupToken,
+								);
+								return rollbackCommitted(error, [committedHash]);
+							},
+						);
+				}
+				if (durableWrapper) {
+					durableWrapper.cancelNativeDeleteCleanup?.(nativeDeleteCleanupToken);
+					return rollbackCommitted(
+						new Error("Native durable block wrapper has no mirror method"),
+						committedHash ? [committedHash] : [],
+					);
+				}
+				return preparedResult;
 			};
 			const hasKnownNoNext =
 				appendOptions.meta?.next != null &&
@@ -7316,32 +9689,78 @@ export class SharedLog<
 						payloadData,
 						resolveTrimmedEntries: properties?.resolveTrimmedEntries,
 						skipMissingNextJoin: properties?.skipMissingNextJoin,
-						retainMaterializationBytes:
-							this._logProperties?.trim != null,
+						retainMaterializationBytes: this._logProperties?.trim != null,
+						deferNativeTransactionAcknowledgement: true,
 					},
 					prepareBackboneAppend,
 				);
-			const directNoNextResult = hasKnownNoNext
-				? asTrustedLowerLog(
-						this.log,
-					).appendLocallyPreparedNativeKnownNoNextCommitOnly(
-						undefined as T,
-						appendOptions,
-						{
-							payloadData,
-							resolveTrimmedEntries: properties?.resolveTrimmedEntries,
-							retainMaterializationBytes:
-								this._logProperties?.trim != null,
-						},
-						prepareBackboneAppend,
-					)
-				: undefined;
-			const result =
-				directNoNextResult === undefined
-					? appendGenericNativeCommit()
-					: directNoNextResult;
-			return mapMaybePromise(result, (prepared) => {
+			const rollbackLowerPublication = async (
+				error: unknown,
+			): Promise<never> => {
+				durableWrapper?.cancelNativeDeleteCleanup?.(nativeDeleteCleanupToken);
+				let compensated = !backboneAppend;
+				if (backboneAppend && !(error instanceof NativeDurableCommitError)) {
+					const committedHash =
+						backboneAppend.entry.cid ?? backboneAppend.entry.hash;
+					try {
+						await this.rollbackFailedNativeBackboneTransaction({
+							committedHashes: committedHash ? [committedHash] : [],
+							coordinateEntries: nativeCoordinateRollback,
+							documents: nativeDocumentRollback
+								? [nativeDocumentRollback]
+								: undefined,
+							skipBlockCompensation: true,
+							restoreGraphFromIndex: true,
+						});
+						compensated = true;
+					} catch {
+						// Lower-log compensation already handled durable/native blocks.
+						// Preserve the index publication error for this caller.
+					}
+				}
+				if (compensated) {
+					await this.completeNativeStrictDurableTransaction(
+						nativeStrictTransaction,
+					);
+				} else {
+					this.releaseNativeStrictDurableTransaction(nativeStrictTransaction);
+				}
+				throw error;
+			};
+			let result: MaybePromise<
+				TrustedLowerLogCommitOnlyAppendResult<T> | undefined
+			>;
+			try {
+				const directNoNextResult = hasKnownNoNext
+					? asTrustedLowerLog(
+							this.log,
+						).appendLocallyPreparedNativeKnownNoNextCommitOnly(
+							undefined as T,
+							appendOptions,
+							{
+								payloadData,
+								resolveTrimmedEntries: properties?.resolveTrimmedEntries,
+								retainMaterializationBytes: this._logProperties?.trim != null,
+								deferNativeTransactionAcknowledgement: true,
+							},
+							prepareBackboneAppend,
+						)
+					: undefined;
+				result =
+					directNoNextResult === undefined
+						? appendGenericNativeCommit()
+						: directNoNextResult;
+				if (isPromiseLike(result)) {
+					result = result.catch(rollbackLowerPublication);
+				}
+			} catch (error) {
+				return rollbackLowerPublication(error);
+			}
+			return mapMaybePromise(result, async (prepared) => {
 				if (!prepared || !backboneAppend) {
+					await this.completeNativeStrictDurableTransaction(
+						nativeStrictTransaction,
+					);
 					return undefined;
 				}
 				const coordinateFields = this.createCoordinateFieldsFromNativePlanFacts(
@@ -7366,17 +9785,11 @@ export class SharedLog<
 					prepared.removedHashes ?? prepared.removed.map((entry) => entry.hash),
 				);
 				const rollbackCoordinateEntries =
-					this.snapshotResidentCoordinateEntries(plannedCoordinateDeleteHashes);
-				const deferredCoordinateDeleteHashes =
-					this.applyPreparedAppendFactsWithDeferredCoordinateDeletes(
-						prepared.appendFacts,
-						prepared.removed,
-						prepared.materializeEntry,
-						{
-							forgetNativeCoordinates: false,
-							removedHashes: prepared.removedHashes,
-						},
-					);
+					nativeCoordinateRollback ??
+					this.snapshotResidentCoordinateEntries([
+						prepared.appendFacts.hash,
+						...plannedCoordinateDeleteHashes,
+					]);
 				const finish = (): PreparedPayloadCommitOnlyResult<T, R> => {
 					const appendCommit = this.createPreparedLocalAppendCommitFromFacts(
 						prepared.appendFacts,
@@ -7409,17 +9822,65 @@ export class SharedLog<
 				const coordinateIndex = this.entryCoordinatesIndex as PutAndDeleteIndex<
 					EntryReplicated<R>
 				>;
-				const rollback = (error: unknown): never => {
-					this.rollbackNativeBackboneCoordinateAppend(
-						prepared.appendFacts.hash,
-						rollbackCoordinateEntries,
-					);
-					if (committedNativeBackboneDocumentIndex) {
-						backbone.deleteDocument(committedNativeBackboneDocumentIndex.key);
+				const rollback = async (error: unknown): Promise<never> => {
+					const rollbackFailures: unknown[] = [];
+					try {
+						await this.markNativeStrictDurableTransactionRollback(
+							nativeStrictTransaction,
+						);
+					} catch (rollbackError) {
+						const retentionFailures =
+							this.retainNativeStrictDurableTransactionAfterMarkerFailure(
+								nativeStrictTransaction,
+								prepared.nativeCommittedAppendFinalizer,
+								rollbackError,
+							);
+						throw new AggregateError(
+							[error, ...retentionFailures],
+							"Native rollback marker could not be persisted; recovery is required",
+						);
 					}
+					try {
+						await prepared.nativeCommittedAppendFinalizer?.rollback();
+					} catch (rollbackError) {
+						rollbackFailures.push(rollbackError);
+					}
+					try {
+						await this.rollbackNativeBackboneCoordinateAppendDurably(
+							prepared.appendFacts.hash,
+							rollbackCoordinateEntries,
+						);
+					} catch (rollbackError) {
+						rollbackFailures.push(rollbackError);
+					}
+					if (nativeDocumentRollback) {
+						try {
+							this.restoreNativeBackboneDocument(nativeDocumentRollback);
+							const flushed = this.flushNativeBackboneCoordinateJournal();
+							if (isPromiseLike(flushed)) {
+								await flushed;
+							}
+						} catch (rollbackError) {
+							rollbackFailures.push(rollbackError);
+						}
+					}
+					if (rollbackFailures.length > 0) {
+						this.releaseNativeStrictDurableTransaction(nativeStrictTransaction);
+						throw new AggregateError(
+							[error, ...rollbackFailures],
+							"Shared-log append and compensation both failed",
+						);
+					}
+					await this.completeNativeStrictDurableTransaction(
+						nativeStrictTransaction,
+					);
 					throw error;
 				};
 				try {
+					await this.setNativeStrictDurableTransactionExpectedRows(
+						nativeStrictTransaction,
+						[prepared.shallowEntry],
+					);
 					const hasNativeCoordinatePut =
 						this.canUseBackboneOnlyCoordinatePersistence() ||
 						coordinateIndex.putSharedLogCoordinateFieldsEncodedAndDeleteHashesNoReturn ||
@@ -7429,7 +9890,7 @@ export class SharedLog<
 								coordinateIndex,
 								fields: coordinateFields,
 								hash: prepared.appendFacts.hash,
-								deleteHashes: plannedCoordinateDeleteHashes,
+								deleteHashes: [],
 								coordinates: backboneAppend.coordinate
 									.coordinates as NumberFromType<R>[],
 								skipGenericTransientCoordinateIndex: runtimeOnlyCoordinates,
@@ -7437,46 +9898,69 @@ export class SharedLog<
 						: this.persistPreparedCoordinate({
 								prepared: getPreparedCoordinate(),
 								hash: prepared.appendFacts.hash,
-								nextHashes: prepared.appendFacts.next,
-								deleteHashes: deferredCoordinateDeleteHashes,
+								nextHashes: [],
+								deleteHashes: [],
 								coordinates: backboneAppend.coordinate
 									.coordinates as NumberFromType<R>[],
 								replicas: backboneAppend.coordinate.coordinates.length,
 								commitNative: true,
 								commitNativeBackbone: false,
 							});
-					const completed = mapMaybePromise(persisted, () => {
-						if (
-							commitBlocksInBackbone &&
-							!runtimeOnlyCoordinates &&
-							this.remoteBlocks.hasNotifyStoredHook()
-						) {
-							this.remoteBlocks.notifyStoredDeferred(prepared.appendFacts.hash);
-						}
-						const delayAdaptiveRebalance = this.shouldDelayAdaptiveRebalance();
-						if (!backboneAppend!.isLeader && !delayAdaptiveRebalance) {
-							const leaders = backboneAppend!.leaders;
-							if (leaders) {
-								const pruneEntry = this.materializePreparedCoordinateEntry(
-									getPreparedCoordinate(),
-								);
-								this.pruneDebouncedFnAddIfNotKeeping({
-									key: pruneEntry.hash,
-									value: { entry: pruneEntry, leaders },
-								});
-							}
-						}
-						if (!delayAdaptiveRebalance) {
-							this.rebalanceParticipationDebounced?.call();
-						}
-						return finish();
-					});
-					return isPromiseLike(completed)
-						? completed.catch((error) => rollback(error))
-						: completed;
+					if (isPromiseLike(persisted)) {
+						await persisted;
+					}
+					if (!prepared.nativeCommittedAppendFinalizer) {
+						throw new Error("Missing deferred native append finalizer");
+					}
+					await this.flushNativeBackboneCoordinateJournal();
+					await prepared.nativeCommittedAppendFinalizer.acknowledge(() =>
+						this.markNativeStrictDurableTransactionLowerMarker(
+							nativeStrictTransaction,
+						),
+					);
 				} catch (error) {
 					return rollback(error);
 				}
+				this.applyPreparedAppendFactsWithDeferredCoordinateDeletes(
+					prepared.appendFacts,
+					prepared.removed,
+					prepared.materializeEntry,
+					{
+						forgetNativeCoordinates: false,
+						removedHashes: prepared.removedHashes,
+					},
+				);
+				try {
+					await this.completeNativeStrictDurableTransaction(
+						nativeStrictTransaction,
+					);
+				} catch (error) {
+					warn(`Failed to retire committed native intent: ${String(error)}`);
+				}
+				if (
+					commitBlocksInBackbone &&
+					!runtimeOnlyCoordinates &&
+					this.remoteBlocks.hasNotifyStoredHook()
+				) {
+					this.remoteBlocks.notifyStoredDeferred(prepared.appendFacts.hash);
+				}
+				const delayAdaptiveRebalance = this.shouldDelayAdaptiveRebalance();
+				if (!backboneAppend.isLeader && !delayAdaptiveRebalance) {
+					const leaders = backboneAppend.leaders;
+					if (leaders) {
+						const pruneEntry = this.materializePreparedCoordinateEntry(
+							getPreparedCoordinate(),
+						);
+						this.pruneDebouncedFnAddIfNotKeeping({
+							key: pruneEntry.hash,
+							value: { entry: pruneEntry, leaders },
+						});
+					}
+				}
+				if (!delayAdaptiveRebalance) {
+					this.rebalanceParticipationDebounced?.call();
+				}
+				return finish();
 			});
 		});
 	}
@@ -7832,12 +10316,12 @@ export class SharedLog<
 		properties: PreparedPayloadsManyIndependentProperties<T> | undefined,
 		minReplicasValue: number,
 	): Promise<
-			| {
-					entries: Entry<T>[];
-					materializeEntries?: Array<() => Entry<T>>;
-					removed: ShallowOrFullEntry<T>[];
-					appendCommits: PreparedLocalAppendCommit<R>[];
-			  }
+		| {
+				entries: Entry<T>[];
+				materializeEntries?: Array<() => Entry<T>>;
+				removed: ShallowOrFullEntry<T>[];
+				appendCommits: PreparedLocalAppendCommit<R>[];
+		  }
 		| undefined
 	> {
 		const backbone = this._nativeBackbone;
@@ -7868,7 +10352,21 @@ export class SharedLog<
 			this.remoteBlocks?.localStore !== backbone.blocks;
 		const durableWrapper = durableWrapperActive
 			? (this.remoteBlocks?.localStore as unknown as {
-					mirrorToDurable?: (cid: string, bytes: Uint8Array) => void;
+					beginNativeDeleteCleanup?: (cids: string[]) => number | undefined;
+					cancelNativeDeleteCleanup?: (cleanupToken: unknown) => void;
+					mirrorToDurable?: (
+						cid: string,
+						bytes: Uint8Array,
+						options?: { nativeTrimmed?: boolean },
+					) => Promise<unknown>;
+					mirrorManyToDurable?: (
+						blocks: Array<readonly [cid: string, bytes: Uint8Array]>,
+						options?: { nativeTrimmedCids?: ReadonlySet<string> },
+					) => Promise<unknown>;
+					rollbackFailedNativeCommits?: (
+						cids: string[],
+						restoreNativeCids?: string[],
+					) => Promise<void>;
 				})
 			: undefined;
 		const usesLatestDocumentContext = documentIndexes.every(
@@ -7905,8 +10403,17 @@ export class SharedLog<
 		const context = await this.createLeaderSelectionContext();
 		const nativeLeaderOptions = this.createNativeLeaderOptions(context);
 		let backboneAppends: NativeBackboneAppendResult[] | undefined;
-		const appended =
-			await asTrustedLowerLog(
+		let batchDocumentRollbacks: NativeBackboneDocumentRollback[] = [];
+		let batchCoordinateRollback:
+			| NativeBackboneCoordinateRollback<R>
+			| undefined;
+		let nativeDeleteCleanupToken: unknown;
+		let nativeStrictTransaction:
+			| NativeStrictDurableTransactionHandle
+			| undefined;
+		let appended: TrustedLowerLogCommitOnlyAppendBatchResult<T> | undefined;
+		try {
+			appended = await asTrustedLowerLog(
 				this.log,
 			).appendLocallyPreparedNativeKnownNoNextCommitOnlyBatch(
 				data,
@@ -7918,61 +10425,152 @@ export class SharedLog<
 					retainMaterializationBytes:
 						properties?.retainMaterializationBytes === true ||
 						this._logProperties?.trim != null,
+					deferNativeTransactionAcknowledgement: true,
 				},
-				(inputs) => {
+				async (inputs) => {
+					batchDocumentRollbacks = documentIndexes
+						.map((index) => this.snapshotNativeBackboneDocument(index))
+						.filter(
+							(value): value is NativeBackboneDocumentRollback => !!value,
+						);
+					nativeStrictTransaction =
+						await this.beginNativeStrictDurableTransaction(
+							batchDocumentRollbacks,
+						);
 					const documentDeleteTrimmedHeadsForAppend =
 						deleteTrimmedHeads && inputs[0]?.trimLengthTo != null;
-					backboneAppends =
-						usesLatestDocumentContext
-							? backbone.preparePlainCommittedStorageAppendDocumentIndexLatestBatchTransaction(
-									{
-										entries: inputs.map((input, index) => ({
-											wallTime: input.wallTime,
-											logical: input.logical,
-											gid: input.gid,
-											type: input.type,
-											metaData: input.metaData,
-											payloadData: input.payloadData,
-											documentIndex: documentIndexes[index]!,
-										})),
-										replicas: minReplicasValue,
-										roleAgeMs: nativeLeaderOptions.roleAge,
-										now: nativeLeaderOptions.now,
-										selfHash: nativeLeaderOptions.selfHash,
-										selfReplicating: nativeLeaderOptions.selfReplicating,
-										resolveTrimmedEntries:
-											properties?.resolveTrimmedEntries,
-										documentByteElementIndexLimit:
-											byteElementIndexLimit,
-										documentDeleteTrimmedHeads:
-											documentDeleteTrimmedHeadsForAppend,
-										trimLengthTo: inputs[0]?.trimLengthTo,
-									},
-								)
-							: backbone.preparePlainCommittedNoNextStorageAppendDocumentIndexCompactBatchTransaction(
-									{
-										entries: inputs.map((input, index) => ({
-											wallTime: input.wallTime,
-											logical: input.logical,
-											gid: input.gid,
-											type: input.type,
-											metaData: input.metaData,
-											payloadData: input.payloadData,
-											documentIndex: documentIndexes[index]!,
-										})),
-										replicas: minReplicasValue,
-										roleAgeMs: nativeLeaderOptions.roleAge,
-										now: nativeLeaderOptions.now,
-										selfHash: nativeLeaderOptions.selfHash,
-										selfReplicating: nativeLeaderOptions.selfReplicating,
-										documentByteElementIndexLimit:
-											byteElementIndexLimit,
-										documentDeleteTrimmedHeads:
-											documentDeleteTrimmedHeadsForAppend,
-										trimLengthTo: inputs[0]?.trimLengthTo,
-									},
-								);
-					return backboneAppends?.map((append) => ({
+					backboneAppends = usesLatestDocumentContext
+						? backbone.preparePlainCommittedStorageAppendDocumentIndexLatestBatchTransaction(
+								{
+									entries: inputs.map((input, index) => ({
+										wallTime: input.wallTime,
+										logical: input.logical,
+										gid: input.gid,
+										type: input.type,
+										metaData: input.metaData,
+										payloadData: input.payloadData,
+										documentIndex: documentIndexes[index]!,
+									})),
+									replicas: minReplicasValue,
+									roleAgeMs: nativeLeaderOptions.roleAge,
+									now: nativeLeaderOptions.now,
+									selfHash: nativeLeaderOptions.selfHash,
+									selfReplicating: nativeLeaderOptions.selfReplicating,
+									resolveTrimmedEntries: properties?.resolveTrimmedEntries,
+									documentByteElementIndexLimit: byteElementIndexLimit,
+									documentDeleteTrimmedHeads:
+										documentDeleteTrimmedHeadsForAppend,
+									trimLengthTo: inputs[0]?.trimLengthTo,
+								},
+							)
+						: backbone.preparePlainCommittedNoNextStorageAppendDocumentIndexCompactBatchTransaction(
+								{
+									entries: inputs.map((input, index) => ({
+										wallTime: input.wallTime,
+										logical: input.logical,
+										gid: input.gid,
+										type: input.type,
+										metaData: input.metaData,
+										payloadData: input.payloadData,
+										documentIndex: documentIndexes[index]!,
+									})),
+									replicas: minReplicasValue,
+									roleAgeMs: nativeLeaderOptions.roleAge,
+									now: nativeLeaderOptions.now,
+									selfHash: nativeLeaderOptions.selfHash,
+									selfReplicating: nativeLeaderOptions.selfReplicating,
+									documentByteElementIndexLimit: byteElementIndexLimit,
+									documentDeleteTrimmedHeads:
+										documentDeleteTrimmedHeadsForAppend,
+									trimLengthTo: inputs[0]?.trimLengthTo,
+								},
+							);
+					if (!backboneAppends) {
+						await this.completeNativeStrictDurableTransaction(
+							nativeStrictTransaction,
+						);
+						return undefined;
+					}
+					const committedAppends = backboneAppends;
+					const committedCids = committedAppends
+						.map((append) => append.entry.cid ?? append.entry.hash)
+						.filter((cid): cid is string => !!cid);
+					const nativeTrimmedHashSet = new Set(
+						committedAppends.flatMap(
+							(append) =>
+								append.trimmedHashes ??
+								append.trimmed.map((entry) => entry.hash),
+						),
+					);
+					const nativeTrimmedHashes = [...nativeTrimmedHashSet];
+					batchCoordinateRollback = this.snapshotResidentCoordinateEntries(
+						committedAppends.flatMap((append) => [
+							...((append.entry.cid ?? append.entry.hash)
+								? [append.entry.cid ?? append.entry.hash!]
+								: []),
+							...append.entry.next,
+							...(append.trimmedHashes ??
+								append.trimmed.map((entry) => entry.hash)),
+						]),
+					);
+					await this.setNativeStrictDurableTransactionOperation(
+						nativeStrictTransaction,
+						committedCids,
+						nativeTrimmedHashes,
+						batchCoordinateRollback,
+						committedAppends.flatMap((append) => [
+							...append.entry.next,
+							...(append.trimmedHashes ??
+								append.trimmed.map((entry) => entry.hash)),
+						]),
+					);
+					const rollbackCommitted = async (cause: unknown): Promise<never> => {
+						durableWrapper?.cancelNativeDeleteCleanup?.(
+							nativeDeleteCleanupToken,
+						);
+						let compensated = false;
+						try {
+							await this.rollbackFailedNativeBackboneTransaction({
+								committedHashes: committedCids,
+								trimmedEntries: committedAppends.flatMap(
+									(append) => append.trimmed,
+								),
+								coordinateEntries: batchCoordinateRollback,
+								documents: batchDocumentRollbacks,
+								durableWrapper,
+							});
+							compensated = true;
+						} catch {
+							// close/reopen completes recovery if durable compensation failed
+						}
+						if (compensated) {
+							await this.completeNativeStrictDurableTransaction(
+								nativeStrictTransaction,
+							);
+						} else {
+							this.releaseNativeStrictDurableTransaction(
+								nativeStrictTransaction,
+							);
+						}
+						return this.failNativeDurableCommit(cause, {
+							committedCids,
+							failedCids: committedCids,
+						});
+					};
+					if (
+						durableWrapper &&
+						nativeTrimmedHashes.length > 0 &&
+						!durableWrapper.beginNativeDeleteCleanup
+					) {
+						return rollbackCommitted(
+							new Error(
+								"Native durable block wrapper cannot preannounce trim cleanup",
+							),
+						);
+					}
+					nativeDeleteCleanupToken =
+						durableWrapper?.beginNativeDeleteCleanup?.(nativeTrimmedHashes);
+					const preparedRows = committedAppends.map((append) => ({
 						cid: append.entry.hash,
 						hash: append.entry.hash,
 						gid: append.coordinate.gid,
@@ -7982,49 +10580,290 @@ export class SharedLog<
 						metaBytes: append.entry.metaBytes,
 						hashDigestBytes: append.entry.hashDigestBytes,
 						getBytes: (hash: string) => backbone.blocks.get(hash),
+						nativeIndexMutationLockOwner:
+							nativeStrictTransaction?.lowerHashMutationLockOwner,
 						trimmedEntryHashes: append.trimmedHashes,
-						documentTrimmedHeadsProcessed:
-							append.documentTrimmedHeadsProcessed,
+						nativeBlocksDeleted: true,
+						nativeDeleteCleanupToken,
+						documentTrimmedHeadsProcessed: append.documentTrimmedHeadsProcessed,
 						documentPreviousContext: append.documentPreviousContext,
 					}));
+					if (!durableWrapper) {
+						return preparedRows;
+					}
+					if (!durableWrapper.mirrorManyToDurable) {
+						durableWrapper.cancelNativeDeleteCleanup?.(
+							nativeDeleteCleanupToken,
+						);
+						return rollbackCommitted(
+							new Error(
+								"Native durable block wrapper has no batch mirror method",
+							),
+						);
+					}
+					const durableMirrorBlocks: Array<
+						readonly [cid: string, bytes: Uint8Array]
+					> = [];
+					const missingCommittedCids: string[] = [];
+					let missingCommittedHash = false;
+					for (const backboneAppend of committedAppends) {
+						const committedHash =
+							backboneAppend.entry.cid ?? backboneAppend.entry.hash;
+						if (!committedHash) {
+							missingCommittedHash = true;
+							continue;
+						}
+						// Earlier rows can be trimmed by later rows in this one native batch.
+						// The native result retains their bytes even though the final hot map
+						// no longer does; mirror those bytes, then let the explicit trim cleanup
+						// remove the durable copy.
+						const committedBytes =
+							backboneAppend.entry.bytes ?? backbone.blocks.get(committedHash);
+						if (!committedBytes) {
+							missingCommittedCids.push(committedHash);
+							continue;
+						}
+						durableMirrorBlocks.push([committedHash, committedBytes]);
+					}
+					// One strict putKnownMany WAL mutation gives the whole native batch one
+					// durability barrier instead of issuing and fsyncing one record per row.
+					const durableMirror =
+						durableMirrorBlocks.length > 0
+							? durableWrapper.mirrorManyToDurable(durableMirrorBlocks, {
+									nativeTrimmedCids: nativeTrimmedHashSet,
+								})
+							: Promise.resolve();
+					return Promise.allSettled([durableMirror]).then(async (settled) => {
+						const rejected =
+							settled[0]?.status === "rejected"
+								? (settled[0] as PromiseRejectedResult).reason
+								: undefined;
+						if (
+							missingCommittedHash ||
+							missingCommittedCids.length > 0 ||
+							rejected !== undefined
+						) {
+							durableWrapper.cancelNativeDeleteCleanup?.(
+								nativeDeleteCleanupToken,
+							);
+							const cause =
+								rejected === undefined
+									? new Error(
+											missingCommittedHash
+												? "Native batch commit returned an entry with no CID to mirror"
+												: `Native committed blocks are missing from the hot store: ${missingCommittedCids.join(", ")}`,
+										)
+									: rejected;
+							const rejectedCids =
+								cause instanceof NativeDurableCommitError
+									? cause.failedCids.filter((cid) =>
+											committedCids.includes(cid),
+										)
+									: durableMirrorBlocks.map(([cid]) => cid);
+							if (cause instanceof NativeDurableCommitError) {
+								cause.addCommitContext({
+									committedCids,
+									failedCids: [...missingCommittedCids, ...rejectedCids],
+								});
+							}
+							return rollbackCommitted(cause);
+						}
+						const nativeCommitOwnershipToken =
+							settled[0]?.status === "fulfilled" ? settled[0].value : undefined;
+						return preparedRows.map((row) => ({
+							...row,
+							nativeCommitOwnershipToken,
+						}));
+					});
 				},
 			);
-		if (!appended || !backboneAppends) {
-			return undefined;
-		}
-		const appendCommits: PreparedLocalAppendCommit<R>[] = [];
-		const runtimeOnlyCoordinates = options?.replicate === false;
-		for (let i = 0; i < appended.appendFacts.length; i++) {
-			const facts = appended.appendFacts[i]!;
-			const backboneAppend = backboneAppends[i]!;
-			if (durableWrapper?.mirrorToDurable) {
-				// The batch prepare committed each block into the wasm map; the log's
-				// finishBlocks path is left unchanged (getBytes only) to preserve
-				// strict-native mode, so mirror the committed block straight to durable
-				// so a non-replicating native node keeps it across a restart. Tracked
-				// for error-surfacing by mirrorToDurable.
-				const committedHash =
-					backboneAppend.entry.cid ?? backboneAppend.entry.hash;
-				const committedBytes = committedHash
-					? backbone.blocks.get(committedHash)
-					: undefined;
-				if (committedBytes) {
-					durableWrapper.mirrorToDurable(committedHash!, committedBytes);
+		} catch (error) {
+			durableWrapper?.cancelNativeDeleteCleanup?.(nativeDeleteCleanupToken);
+			let compensated = !backboneAppends;
+			if (backboneAppends && !(error instanceof NativeDurableCommitError)) {
+				try {
+					await this.rollbackFailedNativeBackboneTransaction({
+						committedHashes: backboneAppends
+							.map((append) => append.entry.cid ?? append.entry.hash)
+							.filter((hash): hash is string => !!hash),
+						coordinateEntries: batchCoordinateRollback,
+						documents: batchDocumentRollbacks,
+						skipBlockCompensation: true,
+						restoreGraphFromIndex: true,
+					});
+					compensated = true;
+				} catch {
+					// Preserve the lower index publication failure.
 				}
 			}
-			const coordinateFields = this.createCoordinateFieldsFromNativePlanFacts({
-				appendFacts: facts,
-				plan: backboneAppend.coordinate,
-			});
-			if (!coordinateFields) {
-				throw new Error(
-					"Native backbone batch append transaction returned mismatched coordinate facts",
+			if (!(error instanceof NativeDurableCommitError)) {
+				if (compensated) {
+					await this.completeNativeStrictDurableTransaction(
+						nativeStrictTransaction,
+					);
+				} else {
+					this.releaseNativeStrictDurableTransaction(nativeStrictTransaction);
+				}
+			}
+			throw error;
+		}
+		if (!appended || !backboneAppends) {
+			await this.completeNativeStrictDurableTransaction(
+				nativeStrictTransaction,
+			);
+			return undefined;
+		}
+		const runtimeOnlyCoordinates = options?.replicate === false;
+		const rollbackBatch = async (error: unknown): Promise<never> => {
+			const rollbackFailures: unknown[] = [];
+			try {
+				await this.markNativeStrictDurableTransactionRollback(
+					nativeStrictTransaction,
+				);
+			} catch (rollbackError) {
+				const retentionFailures =
+					this.retainNativeStrictDurableTransactionAfterMarkerFailure(
+						nativeStrictTransaction,
+						appended.nativeCommittedAppendFinalizer,
+						rollbackError,
+					);
+				throw new AggregateError(
+					[error, ...retentionFailures],
+					"Native rollback marker could not be persisted; recovery is required",
 				);
 			}
-			const plannedCoordinateDeleteHashes = combineCoordinateDeleteHashes(
-				facts.next,
-				backboneAppend.trimmedHashes ?? [],
+			try {
+				await appended.nativeCommittedAppendFinalizer?.rollback();
+			} catch (rollbackError) {
+				rollbackFailures.push(rollbackError);
+			}
+			try {
+				await this.rollbackNativeBackboneCoordinateAppendDurably(
+					appended.appendFacts[0]?.hash ?? "",
+					batchCoordinateRollback,
+				);
+			} catch (rollbackError) {
+				rollbackFailures.push(rollbackError);
+			}
+			try {
+				for (const document of batchDocumentRollbacks) {
+					this.restoreNativeBackboneDocument(document);
+				}
+				const flushed = this.flushNativeBackboneCoordinateJournal();
+				if (isPromiseLike(flushed)) {
+					await flushed;
+				}
+			} catch (rollbackError) {
+				rollbackFailures.push(rollbackError);
+			}
+			if (rollbackFailures.length > 0) {
+				this.releaseNativeStrictDurableTransaction(nativeStrictTransaction);
+				throw new AggregateError(
+					[error, ...rollbackFailures],
+					"Shared-log append batch and compensation both failed",
+				);
+			}
+			await this.completeNativeStrictDurableTransaction(
+				nativeStrictTransaction,
 			);
+			throw error;
+		};
+		const coordinateRows: Array<{
+			facts: PreparedAppendFacts;
+			backboneAppend: NativeBackboneAppendResult;
+			coordinateFields: SharedLogCoordinateNativeFields<R>;
+			plannedCoordinateDeleteHashes: string[];
+		}> = [];
+		try {
+			const batchExternalNextHashes = new Set(
+				appended.appendFacts.flatMap((facts) => facts.next),
+			);
+			await this.setNativeStrictDurableTransactionExpectedRows(
+				nativeStrictTransaction,
+				appended.appendFacts.map(
+					(facts) =>
+						new ShallowEntry({
+							hash: facts.hash,
+							payloadSize: facts.payloadSize,
+							head: !batchExternalNextHashes.has(facts.hash),
+							meta: new ShallowMeta({
+								gid: facts.gid,
+								clock: new LamportClock({
+									id: facts.clockId ?? this.node.identity.publicKey.bytes,
+									timestamp: new Timestamp({
+										wallTime: facts.wallTime,
+										logical: facts.logical,
+									}),
+								}),
+								data: facts.metaData,
+								next: facts.next,
+								type: facts.type ?? EntryType.APPEND,
+							}),
+						}),
+				),
+			);
+			for (let i = 0; i < appended.appendFacts.length; i++) {
+				const facts = appended.appendFacts[i]!;
+				const backboneAppend = backboneAppends[i]!;
+				const coordinateFields = this.createCoordinateFieldsFromNativePlanFacts(
+					{
+						appendFacts: facts,
+						plan: backboneAppend.coordinate,
+					},
+				);
+				if (!coordinateFields) {
+					throw new Error(
+						"Native backbone batch append transaction returned mismatched coordinate facts",
+					);
+				}
+				const plannedCoordinateDeleteHashes = combineCoordinateDeleteHashes(
+					facts.next,
+					backboneAppend.trimmedHashes ?? [],
+				);
+				coordinateRows.push({
+					facts,
+					backboneAppend,
+					coordinateFields,
+					plannedCoordinateDeleteHashes,
+				});
+				const persisted = this.persistBackboneCoordinateFieldsNativeTransaction(
+					{
+						coordinateIndex: this.entryCoordinatesIndex as PutAndDeleteIndex<
+							EntryReplicated<R>
+						>,
+						fields: coordinateFields,
+						hash: facts.hash,
+						deleteHashes: [],
+						coordinates: backboneAppend.coordinate
+							.coordinates as NumberFromType<R>[],
+						skipGenericTransientCoordinateIndex: runtimeOnlyCoordinates,
+					},
+				);
+				if (isPromiseLike(persisted)) {
+					await persisted;
+				}
+			}
+			if (!appended.nativeCommittedAppendFinalizer) {
+				throw new Error("Missing deferred native append batch finalizer");
+			}
+			await this.flushNativeBackboneCoordinateJournal();
+			await appended.nativeCommittedAppendFinalizer.acknowledge(() =>
+				this.markNativeStrictDurableTransactionLowerMarker(
+					nativeStrictTransaction,
+				),
+			);
+		} catch (error) {
+			return rollbackBatch(error);
+		}
+
+		const appendCommits: PreparedLocalAppendCommit<R>[] = [];
+		for (let i = 0; i < coordinateRows.length; i++) {
+			const {
+				facts,
+				backboneAppend,
+				coordinateFields,
+				plannedCoordinateDeleteHashes,
+			} = coordinateRows[i]!;
 			this.applyPreparedAppendFactsWithDeferredCoordinateDeletes(
 				facts,
 				[],
@@ -8034,27 +10873,13 @@ export class SharedLog<
 					removedHashes: plannedCoordinateDeleteHashes,
 				},
 			);
-			const persisted = this.persistBackboneCoordinateFieldsNativeTransaction({
-				coordinateIndex: this.entryCoordinatesIndex as PutAndDeleteIndex<
-					EntryReplicated<R>
-				>,
-				fields: coordinateFields,
-				hash: facts.hash,
-				deleteHashes: plannedCoordinateDeleteHashes,
-				coordinates: backboneAppend.coordinate.coordinates as NumberFromType<R>[],
-				skipGenericTransientCoordinateIndex: runtimeOnlyCoordinates,
-			});
-			if (isPromiseLike(persisted)) {
-				await persisted;
-			}
 			if (!runtimeOnlyCoordinates && this.remoteBlocks.hasNotifyStoredHook()) {
 				this.remoteBlocks.notifyStoredDeferred(facts.hash);
 			}
 			const appendCommit = this.createPreparedLocalAppendCommitFromFacts(
 				facts,
 				{
-					hashNumber: backboneAppend.coordinate
-						.hashNumber as NumberFromType<R>,
+					hashNumber: backboneAppend.coordinate.hashNumber as NumberFromType<R>,
 					coordinateFields,
 				},
 			);
@@ -8064,6 +10889,13 @@ export class SharedLog<
 			appendCommit.documentPreviousContext =
 				backboneAppend.documentPreviousContext;
 			appendCommits.push(appendCommit);
+		}
+		try {
+			await this.completeNativeStrictDurableTransaction(
+				nativeStrictTransaction,
+			);
+		} catch (error) {
+			warn(`Failed to retire committed native intent: ${String(error)}`);
 		}
 		const delayAdaptiveRebalance = this.shouldDelayAdaptiveRebalance();
 		if (!delayAdaptiveRebalance) {
@@ -8092,6 +10924,7 @@ export class SharedLog<
 		  }
 		| undefined
 	> {
+		this.throwIfNativeDurableCommitFailed();
 		if (data.length === 0) {
 			return { entries: [], removed: [], appendCommits: [] };
 		}
@@ -8120,15 +10953,11 @@ export class SharedLog<
 		}
 		const result = await asTrustedLowerLog(
 			this.log,
-		).appendLocallyPreparedManyIndependent(
-			data,
-			appendOptions,
-			{
-				resolveTrimmedEntries: properties?.resolveTrimmedEntries,
-				payloadDatas: properties?.payloadDatas,
-				nexts: properties?.nexts,
-			},
-		);
+		).appendLocallyPreparedManyIndependent(data, appendOptions, {
+			resolveTrimmedEntries: properties?.resolveTrimmedEntries,
+			payloadDatas: properties?.payloadDatas,
+			nexts: properties?.nexts,
+		});
 		if (!result) {
 			return undefined;
 		}
@@ -8216,7 +11045,10 @@ export class SharedLog<
 	private async appendLocallyPreparedPayloadsManyIndependent(
 		payloadDatas: Uint8Array[],
 		options?: SharedAppendOptions<T> | undefined,
-		properties?: Omit<PreparedPayloadsManyIndependentProperties<T>, "payloadDatas">,
+		properties?: Omit<
+			PreparedPayloadsManyIndependentProperties<T>,
+			"payloadDatas"
+		>,
 	) {
 		return this.appendLocallyPreparedManyIndependent(
 			new Array(payloadDatas.length) as T[],
@@ -8239,6 +11071,7 @@ export class SharedLog<
 		entries: Entry<T>[];
 		removed: ShallowOrFullEntry<T>[];
 	}> {
+		this.throwIfNativeDurableCommitFailed();
 		if (data.length === 0) {
 			return { entries: [], removed: [] };
 		}
@@ -9124,6 +11957,10 @@ export class SharedLog<
 	}
 
 	async open(options?: Args<T, D, R>): Promise<void> {
+		this.ensureNativeDurabilityRuntimeState();
+		this._nativeStrictDurableTransactionsClosing = false;
+		const recoveringNativeDurableFailure =
+			this._nativeDurableCommitFailure !== undefined;
 		options = applySharedLogNativeDefaults(
 			options,
 			(this.node as unknown as NodeWithSharedLogNativeDefaults)
@@ -9554,6 +12391,10 @@ export class SharedLog<
 		);
 
 		await remoteBlocksStartPromise;
+		// Failed native prepares can leave content-addressed bytes behind. Recovery
+		// deliberately preserves them: the reopened lower log is the liveness
+		// authority, while these unreachable bytes are safer than deleting a CID that
+		// may also belong to an acknowledged, restored, or concurrent operation.
 		const useNativeBackboneBlocks =
 			this._nativeBackbone && this._logProperties?.replicate === false;
 		const nativeBackboneGraph = this._nativeBackbone
@@ -9567,41 +12408,62 @@ export class SharedLog<
 		// joins rely on: a replicate:false observer syncing a head whose parents
 		// are not local would fail block resolution, and Log.join treats that as
 		// recoverable and skips the entry without persisting anything.
-		await this.log.open(
-			this.remoteBlocks,
-			this.node.identity,
-			{
-				keychain: this.node.services.keychain,
-				resolveRemotePeers: (hash, options) =>
-					this.resolveCandidatePeersForHash(hash, {
-						signal: options?.signal,
-						maxPeers: 8,
-					}),
-				...this._logProperties,
-				nativeGraph: nativeBackboneGraph
-					? {
-							graph: nativeBackboneGraph,
-							heads: this._logProperties?.nativeBackbone
-								? this._logProperties.nativeBackbone.heads
-								: undefined,
-						}
-					: (this._logProperties?.nativeGraph ?? { optional: true }),
-				onChange: async (change) => {
-					await this.onChange(change);
-					return this._logProperties?.onChange?.(change);
-				},
-				canAppend: async (entry) => {
-					if (!(await this.canAppend(entry))) {
-						return false;
+		await this.log.open(this.remoteBlocks, this.node.identity, {
+			keychain: this.node.services.keychain,
+			resolveRemotePeers: (hash, options) =>
+				this.resolveCandidatePeersForHash(hash, {
+					signal: options?.signal,
+					maxPeers: 8,
+				}),
+			...this._logProperties,
+			nativeGraph: nativeBackboneGraph
+				? {
+						graph: nativeBackboneGraph,
+						heads: this._logProperties?.nativeBackbone
+							? this._logProperties.nativeBackbone.heads
+							: undefined,
 					}
-					return this._logProperties?.canAppend?.(entry) ?? true;
-				},
-				trim: this._logProperties?.trim && {
-					...this._logProperties?.trim,
-				},
-				indexer: logIndex,
+				: (this._logProperties?.nativeGraph ?? { optional: true }),
+			onChange: async (change) => {
+				await this.onChange(change);
+				return this._logProperties?.onChange?.(change);
 			},
-		);
+			canAppend: async (entry) => {
+				if (!(await this.canAppend(entry))) {
+					return false;
+				}
+				return this._logProperties?.canAppend?.(entry) ?? true;
+			},
+			trim: this._logProperties?.trim && {
+				...this._logProperties?.trim,
+			},
+			indexer: logIndex,
+		});
+		try {
+			const recovered =
+				await this.recoverNativeStrictDurableTransactionIntent();
+			if (recovered) {
+				await this.reconcileNativeCoordinatesWithLowerCommitMarkers();
+			}
+		} catch (error) {
+			this.poisonNativeStrictDurableTransaction(error);
+			throw error;
+		}
+		// A fresh wrapper alone is not proof of recovery. Clear the cached poison
+		// only after the failed native transaction was compensated (or its pending
+		// native journals were deliberately discarded during close) and the lower log
+		// reopened successfully. Unreferenced content-addressed bytes are preserved;
+		// the reopened lower-log facts, not block presence, determine liveness.
+		if (
+			localBlocks instanceof NativeBackboneWriteThroughBlockStore &&
+			!localBlocks.getNativeDurableCommitFailure() &&
+			(!recoveringNativeDurableFailure ||
+				this._nativeDurableRecoveryReadyForReopen)
+		) {
+			this._nativeDurableCommitFailure = undefined;
+			this._nativeDurableRecoveryReadyForReopen = false;
+			this._nativeDurableRecoveryCids.clear();
+		}
 		const resolveHashesForSymbols = (
 			symbols: readonly bigint[] | BigUint64Array,
 		) => {
@@ -9882,6 +12744,10 @@ export class SharedLog<
 			await rangeIterator.close();
 		}
 		if (this._nativeBackboneCoordinatePersistence) {
+			// A previous explicit drop may have been interrupted after its durable
+			// tombstone was written. Complete that erase before the adapter can expose
+			// any stale coordinate or document state to this backbone.
+			await this._nativeBackboneCoordinatePersistence.resumeDrop?.();
 			await this._nativeBackboneCoordinatePersistence.hydrate(backbone);
 			this._nativeBackboneCoordinateJournalLastFlushMs = Date.now();
 			this.hydrateNativeCoordinateStateFromBackbone(backbone);
@@ -9916,6 +12782,63 @@ export class SharedLog<
 			}
 		} finally {
 			await iterator.close();
+		}
+	}
+
+	private async reconcileNativeCoordinatesWithLowerCommitMarkers() {
+		if (!this._nativeBackbone) {
+			return;
+		}
+		const hashes = new Set(this._residentEntryCoordinatesByHash?.keys() ?? []);
+		const iterator = this.entryCoordinatesIndex.iterate({});
+		try {
+			for (;;) {
+				const batch = await iterator.next(256);
+				if (batch.length === 0) {
+					break;
+				}
+				for (const result of batch) {
+					hashes.add(result.value.hash);
+				}
+			}
+		} finally {
+			await iterator.close();
+		}
+		if (hashes.size === 0) {
+			return;
+		}
+		const committed = await this.log.entryIndex.hasMany(hashes);
+		const orphaned = [...hashes].filter((hash) => !committed.has(hash));
+		if (orphaned.length === 0) {
+			return;
+		}
+		const coordinateIndex = this.entryCoordinatesIndex as PutAndDeleteIndex<
+			EntryReplicated<R>
+		>;
+		if (coordinateIndex.delIdsNoReturn) {
+			await coordinateIndex.delIdsNoReturn(orphaned);
+		} else if (coordinateIndex.delIds) {
+			await coordinateIndex.delIds(orphaned);
+		} else {
+			await coordinateIndex.del({
+				query:
+					orphaned.length === 1
+						? { hash: orphaned[0]! }
+						: new Or(
+								orphaned.map(
+									(hash) => new StringMatch({ key: "hash", value: hash }),
+								),
+							),
+			});
+		}
+		for (const hash of orphaned) {
+			this._nativeBackbone.deleteEntryCoordinates(hash);
+			this._nativeSharedLogState?.deleteEntryCoordinates(hash);
+			this._residentEntryCoordinatesByHash?.delete(hash);
+		}
+		const flushed = this.flushNativeBackboneCoordinateJournal();
+		if (isPromiseLike(flushed)) {
+			await flushed;
 		}
 	}
 
@@ -9991,7 +12914,7 @@ export class SharedLog<
 
 		try {
 			const { createRangePlanner, createSharedLogState } = await import(
-				/* @vite-ignore */ "@peerbit/shared-log-rust",
+				/* @vite-ignore */ "@peerbit/shared-log-rust"
 			);
 			const [planner, state] = await Promise.all([
 				createRangePlanner(this.domain.resolution),
@@ -10021,7 +12944,10 @@ export class SharedLog<
 		options: SharedLogOptions<T, D, R>["nativeBackbone"],
 	): Promise<NativePeerbitBackbone | undefined> {
 		this._nativeBackboneCoordinatePersistence = undefined;
+		this._nativeBackboneCoordinatePersistenceStore = undefined;
+		this._nativeBackboneDropStarted = false;
 		this._nativeBackboneCoordinateJournalLastFlushMs = 0;
+		this._nativeStrictDurableTransactionJournalState = undefined;
 		if (!options) {
 			return undefined;
 		}
@@ -10066,6 +12992,17 @@ export class SharedLog<
 			// peer to re-derive from. Memory-only nodes (no directory) keep the
 			// previous in-memory behavior.
 			if (options.coordinatePersistence) {
+				if ("store" in options.coordinatePersistence) {
+					this._nativeBackboneCoordinatePersistenceStore =
+						options.coordinatePersistence.store;
+				} else if (options.coordinatePersistence.intentStore) {
+					this._nativeBackboneCoordinatePersistenceStore =
+						options.coordinatePersistence.intentStore;
+				} else if (this.node.directory != null) {
+					throw new Error(
+						"Durable nativeBackbone.coordinatePersistence adapters must expose intentStore",
+					);
+				}
 				this._nativeBackboneCoordinatePersistence =
 					createNativeBackboneCoordinatePersistence(
 						options.coordinatePersistence as RuntimeNativeBackboneCoordinatePersistenceConfig,
@@ -10075,6 +13012,34 @@ export class SharedLog<
 					await this.createAutoDerivedCoordinatePersistence(
 						nativeBackboneModule,
 					);
+			}
+			if (
+				this.node.directory != null &&
+				this._nativeBackboneCoordinatePersistence
+			) {
+				if (
+					this._nativeBackboneCoordinatePersistence.durableBarrier !== true ||
+					typeof this._nativeBackboneCoordinatePersistenceStore
+						?.durableBarrier !== "function"
+				) {
+					throw new Error(
+						"Durable nativeBackbone coordinate persistence requires an explicit physical durability barrier",
+					);
+				}
+			}
+			if (
+				this._nativeBackboneCoordinatePersistence &&
+				(this._nativeBackboneCoordinatePersistence.compactMaxJournalBytes !=
+					null ||
+					this._nativeBackboneCoordinatePersistence.compactMaxJournalRecords !=
+						null) &&
+				this._nativeBackboneCoordinatePersistence.crashSafeCompaction !== true
+			) {
+				// Durable custom adapters must explicitly advertise an atomic generation
+				// protocol before SharedLog permits automatic WAL compaction.
+				throw new Error(
+					"Durable native coordinate persistence compaction thresholds require crashSafeCompaction",
+				);
 			}
 			return backbone;
 		} catch (error) {
@@ -10142,6 +13107,7 @@ export class SharedLog<
 				directory: ["coordinates", namespace],
 			});
 		}
+		this._nativeBackboneCoordinatePersistenceStore = store;
 		return createNativeBackboneCoordinatePersistence({
 			store,
 			buffered: true,
@@ -11320,130 +14286,136 @@ export class SharedLog<
 	}
 
 	private async _close() {
-		this.cancelCurrentReplicationStateAnnouncementRetry();
-		this.replicationAnnouncementRetryDebounced = undefined;
-		if (!this._entryCoordinatesIndex && !this._replicationRangeIndex) {
-			return;
-		}
-		if (this._wireSyncSession) {
-			this._wireSyncSession.unregisterTopic(this.topic);
-			this._wireSyncSession = undefined;
-		}
-		await this.closeNativeBackboneCoordinatePersistence();
-		await this.syncronizer?.close();
-
-		for (const [_key, peerMap] of this.pendingMaturity ?? []) {
-			for (const [_key2, info] of peerMap) {
-				clearTimeout(info.timeout);
+		let firstError: unknown;
+		const capture = async (operation: () => Promise<unknown> | unknown) => {
+			try {
+				await operation();
+			} catch (error) {
+				firstError ??= error;
 			}
-		}
+		};
+		const captureSync = (operation: () => unknown) => {
+			try {
+				operation();
+			} catch (error) {
+				firstError ??= error;
+			}
+		};
+		captureSync(() => this.cancelCurrentReplicationStateAnnouncementRetry());
+		this.replicationAnnouncementRetryDebounced = undefined;
+		captureSync(() => {
+			if (this._wireSyncSession) {
+				this._wireSyncSession.unregisterTopic(this.topic);
+				this._wireSyncSession = undefined;
+			}
+		});
+		await capture(() => this.closeNativeBackboneCoordinatePersistence());
+		await capture(() => this.syncronizer?.close());
 
-		this.pendingMaturity?.clear();
-
-		this.distributeQueue?.clear();
-		this._closeFanoutChannel();
-		try {
-			this._providerHandle?.close();
-		} catch {
-			// ignore
-		}
+		captureSync(() => {
+			for (const [_key, peerMap] of this.pendingMaturity ?? []) {
+				for (const [_key2, info] of peerMap) clearTimeout(info.timeout);
+			}
+			this.pendingMaturity?.clear();
+			this.distributeQueue?.clear();
+		});
+		captureSync(() => this._closeFanoutChannel());
+		captureSync(() => this._providerHandle?.close());
 		this._providerHandle = undefined;
-		this.coordinateToHash?.clear();
-		this.recentlyRebalanced?.clear();
-		this.uniqueReplicators?.clear();
-		this._topicSubscribersCache?.clear();
-		this._closeController.abort();
-
-		clearInterval(this.interval);
-		this.stopReplicatorLivenessSweep();
-
-		this.node.services.pubsub.removeEventListener(
-			"subscribe",
-			this._onSubscriptionFn,
+		captureSync(() => {
+			this.coordinateToHash?.clear();
+			this.recentlyRebalanced?.clear();
+			this.uniqueReplicators?.clear();
+			this._topicSubscribersCache?.clear();
+			this._closeController.abort();
+			clearInterval(this.interval);
+			this.stopReplicatorLivenessSweep();
+		});
+		captureSync(() =>
+			this.node.services.pubsub.removeEventListener(
+				"subscribe",
+				this._onSubscriptionFn,
+			),
 		);
-
-		this.node.services.pubsub.removeEventListener(
-			"unsubscribe",
-			this._onUnsubscriptionFn,
+		captureSync(() =>
+			this.node.services.pubsub.removeEventListener(
+				"unsubscribe",
+				this._onUnsubscriptionFn,
+			),
 		);
-		for (const timer of this._repairRetryTimers ?? []) {
-			clearTimeout(timer);
-		}
-		this._repairRetryTimers?.clear();
-		this._recentRepairDispatch?.clear();
-		this._repairSweepRunning = false;
-		this._repairSweepPendingModes?.clear();
-		for (const peers of this._repairSweepPendingPeersByMode?.values() ?? []) {
-			peers.clear();
-		}
-		this._repairSweepOptimisticGidPeersPending?.clear();
-		this._entryKnownPeers?.clear();
-		this._entryKnownPeerObservedAt?.clear();
-		this._nativeSharedLogState?.clearEntryKnownPeers();
-		this._nativeBackbone?.clearEntryKnownPeers();
-		for (const timer of this._joinAuthoritativeRepairTimersByDelay?.values() ??
-			[]) {
-			clearTimeout(timer);
-		}
-		this._joinAuthoritativeRepairTimersByDelay?.clear();
-		this._joinAuthoritativeRepairPeersByDelay?.clear();
-		for (const targets of this._repairFrontierByMode?.values() ?? []) {
-			targets.clear();
-		}
-		for (const targets of this._repairFrontierActiveTargetsByMode?.values() ??
-			[]) {
-			targets.clear();
-		}
-		for (const targets of this._repairFrontierBypassKnownPeersByMode?.values() ??
-			[]) {
-			targets.clear();
-		}
-		if (this._appendBackfillTimer) {
-			clearTimeout(this._appendBackfillTimer);
-			this._appendBackfillTimer = undefined;
-		}
-		this._appendBackfillPendingByTarget?.clear();
+		captureSync(() => {
+			for (const timer of this._repairRetryTimers ?? []) clearTimeout(timer);
+			this._repairRetryTimers?.clear();
+			this._recentRepairDispatch?.clear();
+			this._repairSweepRunning = false;
+			this._repairSweepPendingModes?.clear();
+			for (const peers of this._repairSweepPendingPeersByMode?.values() ?? [])
+				peers.clear();
+			this._repairSweepOptimisticGidPeersPending?.clear();
+			this._entryKnownPeers?.clear();
+			this._entryKnownPeerObservedAt?.clear();
+			this._nativeSharedLogState?.clearEntryKnownPeers();
+			this._nativeBackbone?.clearEntryKnownPeers();
+			for (const timer of this._joinAuthoritativeRepairTimersByDelay?.values() ??
+				[])
+				clearTimeout(timer);
+			this._joinAuthoritativeRepairTimersByDelay?.clear();
+			this._joinAuthoritativeRepairPeersByDelay?.clear();
+			for (const targets of this._repairFrontierByMode?.values() ?? [])
+				targets.clear();
+			for (const targets of this._repairFrontierActiveTargetsByMode?.values() ??
+				[])
+				targets.clear();
+			for (const targets of this._repairFrontierBypassKnownPeersByMode?.values() ??
+				[])
+				targets.clear();
+			if (this._appendBackfillTimer) {
+				clearTimeout(this._appendBackfillTimer);
+				this._appendBackfillTimer = undefined;
+			}
+			this._appendBackfillPendingByTarget?.clear();
+			for (const [_key, value] of this._pendingIHave ?? []) value.clear();
+			if (this._pendingIHaveExpiryTimer) {
+				clearTimeout(this._pendingIHaveExpiryTimer);
+				this._pendingIHaveExpiryTimer = undefined;
+				this._pendingIHaveExpiryDeadline = Number.POSITIVE_INFINITY;
+			}
+		});
+		captureSync(() => this._checkedPrune.close());
 
-		for (const [_k, v] of this._pendingIHave ?? []) {
-			v.clear();
-		}
-		if (this._pendingIHaveExpiryTimer) {
-			clearTimeout(this._pendingIHaveExpiryTimer);
-			this._pendingIHaveExpiryTimer = undefined;
-			this._pendingIHaveExpiryDeadline = Number.POSITIVE_INFINITY;
-		}
-		this._checkedPrune.close();
-
-		await this.remoteBlocks?.stop?.();
-		this._pendingIHave?.clear();
-		this.latestReplicationInfoMessage?.clear();
-		this._gidPeersHistory?.clear();
-		this._peerSyncCapabilities?.clear();
-		this._liveRawGossipBatches?.clear();
-		this._nativeSharedLogState?.clearGidPeers();
-		this._nativeBackbone?.clearGidPeers();
-		// Cancel any pending debounced timers so they can't fire after we've torn down
-		// indexes/RPC state.
-		this.rebalanceParticipationDebounced?.close();
-		this.replicationChangeDebounceFn?.close?.();
-		this.pruneDebouncedFn?.close?.();
-		this.responseToPruneDebouncedFn?.close?.();
+		await capture(() => this.remoteBlocks?.stop?.());
+		captureSync(() => {
+			this._pendingIHave?.clear();
+			this.latestReplicationInfoMessage?.clear();
+			this._gidPeersHistory?.clear();
+			this._peerSyncCapabilities?.clear();
+			this._liveRawGossipBatches?.clear();
+			this._nativeSharedLogState?.clearGidPeers();
+			this._nativeBackbone?.clearGidPeers();
+		});
+		// Cancel every debounce independently so one faulty close hook cannot keep
+		// the remaining timers or indexes alive.
+		captureSync(() => this.rebalanceParticipationDebounced?.close());
+		captureSync(() => this.replicationChangeDebounceFn?.close?.());
+		captureSync(() => this.pruneDebouncedFn?.close?.());
+		captureSync(() => this.responseToPruneDebouncedFn?.close?.());
 		this.pruneDebouncedFn = undefined as any;
 		this.rebalanceParticipationDebounced = undefined;
-		await Promise.all([
-			this._replicationRangeIndex?.stop?.(),
-			this._entryCoordinatesIndex?.stop?.(),
-		]);
+		await capture(() => this._replicationRangeIndex?.stop?.());
+		await capture(() => this._entryCoordinatesIndex?.stop?.());
 		this._replicationRangeIndex = undefined as any;
 		this._entryCoordinatesIndex = undefined as any;
 		this._nativeRangePlanner = undefined;
 		this._nativeSharedLogState = undefined;
 		this._residentEntryCoordinatesByHash = undefined;
+		captureSync(() => this.cpuUsage?.stop?.());
 
-		this.cpuUsage?.stop?.();
-		/* this._totalParticipation = 0; */
+		if (firstError !== undefined) {
+			throw firstError;
+		}
 	}
 	async close(from?: Program): Promise<boolean> {
+		this.ensureNativeDurabilityRuntimeState();
 		this.cancelCurrentReplicationStateAnnouncementRetry();
 		// Best-effort: announce that we are going offline before tearing down
 		// RPC/subscription state.
@@ -11497,16 +14469,58 @@ export class SharedLog<
 		} catch {
 			// ignore: close should be resilient even if we were never fully started
 		}
-		const superClosed = await super.close(from);
-		if (!superClosed) {
-			return superClosed;
+		let firstError: unknown;
+		let superClosed = false;
+		try {
+			superClosed = await super.close(from);
+		} catch (error) {
+			firstError = error;
 		}
-		await this._close();
-		await this.log.close();
+		if (!superClosed && firstError === undefined) {
+			return false;
+		}
+		this._nativeStrictDurableTransactionsClosing = true;
+		let strictTransactionsSettled = false;
+		try {
+			await this.settleNativeStrictDurableTransactionsForClose();
+			strictTransactionsSettled = true;
+		} catch (error) {
+			firstError ??= error;
+		}
+		if (!strictTransactionsSettled) {
+			throw firstError;
+		}
+		try {
+			await this.log.close();
+		} catch (error) {
+			firstError ??= error;
+		}
+		try {
+			await this._close();
+		} catch (error) {
+			firstError ??= error;
+		}
+		if (firstError !== undefined) {
+			throw firstError;
+		}
 		return true;
 	}
 
 	async drop(from?: Program): Promise<boolean> {
+		this.ensureNativeDurabilityRuntimeState();
+		const nativePersistence = this._nativeBackboneCoordinatePersistence;
+		if (
+			nativePersistence &&
+			(typeof nativePersistence.drop !== "function" ||
+				typeof nativePersistence.resumeDrop !== "function" ||
+				nativePersistence.supportsDrop !== true ||
+				nativePersistence.dropIsTerminal !== true)
+		) {
+			// Reject before `super.drop()` can drop child programs or any lower index.
+			throw new Error(
+				"NativeBackbone coordinate persistence adapters must expose a terminal underlying drop capability and resumeDrop before SharedLog.drop() can erase their namespace",
+			);
+		}
 		this.cancelCurrentReplicationStateAnnouncementRetry();
 		// Best-effort: announce that we are going offline before tearing down
 		// RPC/subscription state (same reasoning as in `close()`).
@@ -11545,14 +14559,68 @@ export class SharedLog<
 			// ignore: drop should be resilient even if we were never fully started
 		}
 
-		const superDropped = await super.drop(from);
-		if (!superDropped) {
-			return superDropped;
+		let firstError: unknown;
+		let superDropped = false;
+		try {
+			superDropped = await super.drop(from);
+		} catch (error) {
+			firstError = error;
 		}
-		await this._entryCoordinatesIndex.drop();
-		await this._replicationRangeIndex.drop();
-		await this.log.drop();
-		await this._close();
+		if (!superDropped && firstError === undefined) {
+			return false;
+		}
+		this._nativeStrictDurableTransactionsClosing = true;
+		const capture = async (operation: () => Promise<unknown> | unknown) => {
+			try {
+				await operation();
+			} catch (error) {
+				firstError ??= error;
+			}
+		};
+		let strictTransactionsSettled = false;
+		try {
+			await this.settleNativeStrictDurableTransactionsForClose();
+			strictTransactionsSettled = true;
+		} catch (error) {
+			firstError ??= error;
+		}
+		if (!strictTransactionsSettled) {
+			throw firstError;
+		}
+		if (nativePersistence) {
+			this._nativeBackboneDropStarted = true;
+			try {
+				await nativePersistence.drop!(
+					this._nativeBackboneCoordinatePersistenceStore
+						? NATIVE_STRICT_DURABLE_TRANSACTION_INTENT_FILES
+						: [],
+				);
+			} catch (error) {
+				firstError ??= error;
+				// The adapter remains in its drop lifecycle, so this closes handles
+				// without flushing live journals over a partial erase.
+				await capture(() => this.log.close());
+				await capture(() => this._close());
+				throw firstError;
+			}
+			// These in-memory states only stop being recovery-authoritative after all
+			// six persistence files and both alternating intent slots are durably gone.
+			this._nativeStrictDurableTransactionJournalState = undefined;
+			this._nativeStrictDurableDocumentRecoveryDeferred = false;
+			this._nativeStrictDurableTransactionTail = undefined;
+			this._nativeStrictDurableTransactions?.clear();
+			this.clearNativeStrictDurableTransactionFailure();
+			this._nativeDurableCommitFailure = undefined;
+			this._nativeDurableRecoveryReadyForReopen = false;
+			this._nativeDurableRecoveryCids.clear();
+		}
+		await capture(() => this._entryCoordinatesIndex?.drop());
+		await capture(() => this._replicationRangeIndex?.drop());
+		await capture(() => this.log.drop());
+		await capture(() => this._close());
+		if (firstError !== undefined) {
+			throw firstError;
+		}
 		return true;
 	}
 
@@ -11609,6 +14677,7 @@ export class SharedLog<
 			? msg
 			: undefined;
 		try {
+			this.throwIfNativeDurableCommitFailed();
 			if (!context.from) {
 				throw new Error("Missing from in update role message");
 			}
@@ -11665,10 +14734,7 @@ export class SharedLog<
 				}
 				if (rawConfirmedHashes.size > 0 && !fromIsSelf) {
 					const rawConfirmStartedAt = syncProfileStart(syncProfile);
-					this.markEntriesKnownByPeer(
-						rawConfirmedHashes,
-						rawFrom.hashcode(),
-					);
+					this.markEntriesKnownByPeer(rawConfirmedHashes, rawFrom.hashcode());
 					await this.sendRepairConfirmation(rawFrom, rawConfirmedHashes);
 					if (syncProfile) {
 						emitSyncProfileDuration(syncProfile, rawConfirmStartedAt, {
@@ -11736,8 +14802,7 @@ export class SharedLog<
 							hashes,
 							from: rawFrom,
 						});
-					rawPreparedReceiveSelectionValue =
-						await rawPreparedReceiveSelection;
+					rawPreparedReceiveSelectionValue = await rawPreparedReceiveSelection;
 					return rawPreparedReceiveSelectionValue;
 				};
 				// Receive fusion: when this message was resolved from the wire
@@ -11774,87 +14839,83 @@ export class SharedLog<
 								}
 							}
 						: undefined;
-				const prepareNativeBackboneExpectedColumnsAndSelection =
-					rawIsRepairHint
-						? undefined
-						: async ({
-								blocks,
-								hashes,
-								verifySignatures,
-							}: {
-								blocks: () => Uint8Array[];
-								hashes: string[];
-								verifySignatures: boolean;
-							}) => {
+				const prepareNativeBackboneExpectedColumnsAndSelection = rawIsRepairHint
+					? undefined
+					: async ({
+							blocks,
+							hashes,
+							verifySignatures,
+						}: {
+							blocks: () => Uint8Array[];
+							hashes: string[];
+							verifySignatures: boolean;
+						}) => {
+							if (
+								verifySignatures ||
+								!canDeferRawReceiveVerificationUntilNativeSelection
+							) {
+								return undefined;
+							}
+							try {
+								const replicaOptions = {
+									minReplicas: this.replicas.min?.getValue(this) || 1,
+									maxReplicas: this.replicas.max?.getValue(this),
+								};
+								const leaderSelectionContext =
+									await this.createLeaderSelectionContext();
+								const prepareOptions = {
+									verifySignatures: false as const,
+									...replicaOptions,
+									leaderOptions: this.createNativeLeaderOptions(
+										leaderSelectionContext,
+									),
+									fromHash: rawFrom.hashcode(),
+								};
+								let prepared:
+									| ReturnType<
+											NativePeerbitBackbone["prepareRawReceiveExpectedColumnsAndSelectionBatch"]
+									  >
+									| undefined;
+								const wireSession = this._wireSyncSession;
 								if (
-									verifySignatures ||
-									!canDeferRawReceiveVerificationUntilNativeSelection
+									stashBackedRawMessage &&
+									rawStashIndexes &&
+									wireSession &&
+									this._nativeBackbone
 								) {
+									prepared =
+										this._nativeBackbone.prepareStashedRawReceiveExpectedColumnsAndSelectionBatch(
+											wireSession,
+											stashBackedRawMessage.messageId,
+											rawStashIndexes,
+											hashes,
+											prepareOptions,
+										);
+								}
+								if (
+									!prepared &&
+									this._nativeBackbone
+										?.prepareRawReceiveExpectedColumnsAndSelectionBatch
+								) {
+									prepared =
+										this._nativeBackbone.prepareRawReceiveExpectedColumnsAndSelectionBatch(
+											blocks(),
+											hashes,
+											prepareOptions,
+										);
+								}
+								if (!prepared) {
 									return undefined;
 								}
-								try {
-									const replicaOptions = {
-										minReplicas:
-											this.replicas.min?.getValue(this) || 1,
-										maxReplicas: this.replicas.max?.getValue(this),
-									};
-									const leaderSelectionContext =
-										await this.createLeaderSelectionContext();
-									const prepareOptions = {
-										verifySignatures: false as const,
-										...replicaOptions,
-										leaderOptions:
-											this.createNativeLeaderOptions(
-												leaderSelectionContext,
-											),
-										fromHash: rawFrom.hashcode(),
-									};
-									let prepared:
-										| ReturnType<
-												NativePeerbitBackbone["prepareRawReceiveExpectedColumnsAndSelectionBatch"]
-										  >
-										| undefined;
-									const wireSession = this._wireSyncSession;
-									if (
-										stashBackedRawMessage &&
-										rawStashIndexes &&
-										wireSession &&
-										this._nativeBackbone
-									) {
-										prepared =
-											this._nativeBackbone.prepareStashedRawReceiveExpectedColumnsAndSelectionBatch(
-												wireSession,
-												stashBackedRawMessage.messageId,
-												rawStashIndexes,
-												hashes,
-												prepareOptions,
-											);
-									}
-									if (
-										!prepared &&
-										this._nativeBackbone
-											?.prepareRawReceiveExpectedColumnsAndSelectionBatch
-									) {
-										prepared =
-											this._nativeBackbone.prepareRawReceiveExpectedColumnsAndSelectionBatch(
-												blocks(),
-												hashes,
-												prepareOptions,
-											);
-									}
-									if (!prepared) {
-										return undefined;
-									}
-									rawPreparedReceiveSelectionValue =
-										prepared.selection;
-									rawPreparedReceiveSelection = Promise.resolve(
-										rawPreparedReceiveSelectionValue,
-									);
-									return { columns: prepared.columns };
-								} catch {
-									return undefined;
-								}
-							};
+								rawPreparedReceiveSelectionValue = prepared.selection;
+								rawPreparedReceiveSelection = Promise.resolve(
+									rawPreparedReceiveSelectionValue,
+								);
+								return { columns: prepared.columns };
+							} catch {
+								return undefined;
+							}
+						};
 				const rawMaterializeStartedAt = syncProfileStart(syncProfile);
 				const materializedRawMessage =
 					await materializeVerifiedRawExchangeHeadsMessage(
@@ -11885,8 +14946,10 @@ export class SharedLog<
 											from: rawFrom,
 											fromIsSelf,
 											syncProfile,
-											selection:
-												await getRawPreparedReceiveSelection(heads, hashes),
+											selection: await getRawPreparedReceiveSelection(
+												heads,
+												hashes,
+											),
 										}),
 							selectPreparedRawReceiveHashes: rawIsRepairHint
 								? undefined
@@ -11897,8 +14960,10 @@ export class SharedLog<
 											from: rawFrom,
 											fromIsSelf,
 											syncProfile,
-											selection:
-												await getRawPreparedReceiveSelection(heads, hashes),
+											selection: await getRawPreparedReceiveSelection(
+												heads,
+												hashes,
+											),
 										}),
 						},
 					);
@@ -11955,9 +15020,7 @@ export class SharedLog<
 
 				logger.trace(
 					`${this.node.identity.publicKey.hashcode()}: Recieved heads: ${
-						heads.length === 1
-							? headHashes[0]
-							: "#" + heads.length
+						heads.length === 1 ? headHashes[0] : "#" + heads.length
 					}, logId: ${this.log.idString}`,
 				);
 
@@ -12003,10 +15066,7 @@ export class SharedLog<
 					const fromIsSelf = context.from.equals(this.node.identity.publicKey);
 					const contextFromHash = context.from.hashcode();
 					if (!fromIsSelf) {
-						this.markEntriesKnownByPeer(
-							headHashes,
-							contextFromHash,
-						);
+						this.markEntriesKnownByPeer(headHashes, contextFromHash);
 					}
 
 					if (filteredHeads.length === 0) {
@@ -12112,8 +15172,7 @@ export class SharedLog<
 						};
 						if (
 							!isReplicating &&
-							rawPreparedReceiveSelectionValue
-								?.retainedGroupLeaderPlans &&
+							rawPreparedReceiveSelectionValue?.retainedGroupLeaderPlans &&
 							rawPreparedReceiveSelectionValue.retainedHashes.length ===
 								filteredHeadHashes.length &&
 							rawPreparedReceiveSelectionValue.retainedHashes.every(
@@ -12145,8 +15204,7 @@ export class SharedLog<
 										nativeRawGroupAssignmentPlans &&
 										!nativeRawGroupAssignmentPlans.every((plan) => {
 											const keepAsLeader =
-												plan.isLeader ||
-												(isRepairHint && plan.fromIsLeader);
+												plan.isLeader || (isRepairHint && plan.fromIsLeader);
 											const canKeepWithoutWait = isReplicating
 												? plan.isLeader
 												: keepAsLeader;
@@ -12233,13 +15291,11 @@ export class SharedLog<
 								maxReplicasFromNewEntries: plan.maxReplicasFromNewEntries,
 								maxMaxReplicas: plan.maxMaxReplicas,
 								leaderPlan: {
-									coordinates:
-										plan.coordinates as NumberFromType<R>[],
+									coordinates: plan.coordinates as NumberFromType<R>[],
 									coordinateStrings: plan.coordinateStrings,
 									leaders: new Map(),
 									isLeader: plan.isLeader,
-									assignedToRangeBoundary:
-										plan.assignedToRangeBoundary,
+									assignedToRangeBoundary: plan.assignedToRangeBoundary,
 								},
 								leaders: false,
 								isLeader: plan.isLeader,
@@ -12456,14 +15512,13 @@ export class SharedLog<
 					let usedNativeReceiveGroupLeaderPlans = false;
 					if (!isReplicating) {
 						let leaderPlans =
-							usedNativeRawGroupLeaderPlans ||
-							usedNativeRawGroupAssignmentPlans
+							usedNativeRawGroupLeaderPlans || usedNativeRawGroupAssignmentPlans
 								? receiveGroups.map((group) => group.leaderPlan!)
 								: usedNativeRawGroups && this._nativeBackbone
-								? await this.planNativeBackboneReceiveGroupLeaders(
-										receiveGroups,
-									)
-								: undefined;
+									? await this.planNativeBackboneReceiveGroupLeaders(
+											receiveGroups,
+										)
+									: undefined;
 						usedNativeReceiveGroupLeaderPlans = leaderPlans !== undefined;
 						leaderPlans ??= await this.planEntryLeaderBatch(
 							receiveGroups.map((group) => ({
@@ -12495,8 +15550,7 @@ export class SharedLog<
 								predecodedReplicaHits: receivePredecodedReplicaHits,
 								nativeRawGroups: usedNativeRawGroups,
 								nativeRawGroupIndexes: usedNativeRawGroupIndexes,
-								nativeRawGroupLeaderPlans:
-									usedNativeRawGroupLeaderPlans,
+								nativeRawGroupLeaderPlans: usedNativeRawGroupLeaderPlans,
 								nativeRawGroupAssignmentPlans:
 									usedNativeRawGroupAssignmentPlans,
 								nativeRawGroupLeaderPlansFromSelection:
@@ -12610,9 +15664,7 @@ export class SharedLog<
 							(group) =>
 								group.isLeader === false &&
 								group.fromIsLeader === false &&
-								group.entries.every(
-									(entry) => entry.gidRefrences.length === 0,
-								),
+								group.entries.every((entry) => entry.gidRefrences.length === 0),
 						);
 					if (canFastDropNativeRawReceive) {
 						const joinPlanStartedAt = syncProfileStart(syncProfile);
@@ -12661,21 +15713,15 @@ export class SharedLog<
 						receiveGroups.every(
 							(group) =>
 								group.leaders !== undefined &&
-								group.entries.every(
-									(entry) => entry.gidRefrences.length === 0,
-								),
+								group.entries.every((entry) => entry.gidRefrences.length === 0),
 						);
-					let canUseAllKeptNativeJoinPlan =
-						canUseNativeSynchronousJoinPlanBase;
+					let canUseAllKeptNativeJoinPlan = canUseNativeSynchronousJoinPlanBase;
 					if (canUseAllKeptNativeJoinPlan) {
 						for (const group of receiveGroups) {
 							const fromIsLeader = group.fromIsLeader ?? false;
 							const keepAsLeader =
 								group.isLeader === true || (isRepairHint && fromIsLeader);
-							if (
-								group.maxReplicasFromNewEntries <
-								group.maxReplicasFromHead
-							) {
+							if (group.maxReplicasFromNewEntries < group.maxReplicasFromHead) {
 								canUseAllKeptNativeJoinPlan = false;
 								break;
 							}
@@ -12714,10 +15760,7 @@ export class SharedLog<
 									immediateReplicatingLeaderPlanHits++;
 								}
 								if (group.fromIsLeader) {
-									this.addPeersToGidPeerHistory(
-										group.gid,
-										contextFromHashes,
-									);
+									this.addPeersToGidPeerHistory(group.gid, contextFromHashes);
 								}
 								for (const entry of group.entries) {
 									const hash = getExchangeHeadHash(entry);
@@ -12728,9 +15771,7 @@ export class SharedLog<
 								}
 							}
 							this.removePruneRequestsSent(cleanupHashes);
-							this._checkedPrune.clearConfirmedReplicatorsBatch(
-								cleanupHashes,
-							);
+							this._checkedPrune.clearConfirmedReplicatorsBatch(cleanupHashes);
 							nativeAllKeptJoinHashes = cleanupHashes;
 							joinPlans = [
 								{
@@ -12765,8 +15806,7 @@ export class SharedLog<
 										this.addPeersToGidPeerHistory(group.gid, [contextFromHash]);
 									}
 									if (
-										group.maxReplicasFromNewEntries <
-										group.maxReplicasFromHead
+										group.maxReplicasFromNewEntries < group.maxReplicasFromHead
 									) {
 										(maybeDelete || (maybeDelete = [])).push(group.entries);
 									}
@@ -12829,7 +15869,8 @@ export class SharedLog<
 													isLeader =
 														isLeader ||
 														this.node.identity.publicKey.hashcode() === key;
-													fromIsLeader = fromIsLeader || contextFromHash === key;
+													fromIsLeader =
+														fromIsLeader || contextFromHash === key;
 												},
 											},
 										);
@@ -12893,8 +15934,7 @@ export class SharedLog<
 									const entry = entries[i]!;
 									let shouldKeep = keepAsLeader;
 									if (!shouldKeep && this.keep) {
-										const keepResult =
-											getReceiveKeepDecision(entry);
+										const keepResult = getReceiveKeepDecision(entry);
 										shouldKeep = isPromiseLike(keepResult)
 											? await keepResult
 											: keepResult;
@@ -12952,8 +15992,7 @@ export class SharedLog<
 								immediateReplicatingLeaderPlanHits,
 								immediateReplicatingLeaderPlans:
 									immediateReplicatingLeaderPlans?.length ?? 0,
-								nativeSynchronousJoinPlan:
-									usedNativeSynchronousJoinPlan,
+								nativeSynchronousJoinPlan: usedNativeSynchronousJoinPlan,
 								nativeAllKeptJoinPlan: usedNativeAllKeptJoinPlan,
 							},
 						});
@@ -13039,15 +16078,10 @@ export class SharedLog<
 							!programOnChange &&
 							!!this.syncronizer.onEntryAddedHashes &&
 							this._pendingIHave.size === 0;
-						let mergeEntryByHash:
-							| Map<string, EntryWithRefs<any>>
-							| undefined;
+						let mergeEntryByHash: Map<string, EntryWithRefs<any>> | undefined;
 						const materializeMergedEntry = (hash: string) => {
 							mergeEntryByHash ??= new Map(
-								allToMerge.map((entry) => [
-									getExchangeHeadHash(entry),
-									entry,
-								]),
+								allToMerge.map((entry) => [getExchangeHeadHash(entry), entry]),
 							);
 							const entryRef = mergeEntryByHash.get(hash);
 							if (!entryRef) {
@@ -13129,9 +16163,7 @@ export class SharedLog<
 									nativeCommitVerifyAllHashes,
 									syncProfile,
 									(committedHashes) => {
-										nativePreparedCommittedHashes = new Set(
-											committedHashes,
-										);
+										nativePreparedCommittedHashes = new Set(committedHashes);
 									},
 								)
 							: undefined;
@@ -13197,10 +16229,9 @@ export class SharedLog<
 									__peerbitNativePreparedJoinCommit: nativePreparedJoinCommit,
 									__peerbitNativePreparedJoinCommitValidatesPlan:
 										nativePreparedJoinCommitValidatesPlan,
-									__peerbitOnPreparedJoinCommitted:
-										nativePreparedJoinCommit
-											? finishNativePreparedCoordinates
-											: undefined,
+									__peerbitOnPreparedJoinCommitted: nativePreparedJoinCommit
+										? finishNativePreparedCoordinates
+										: undefined,
 								},
 							));
 						if (!joinedPreparedFacts) {
@@ -13303,14 +16334,11 @@ export class SharedLog<
 							confirmedHashes.add(hash);
 						}
 						const checkedPruneStartedAt = syncProfileStart(syncProfile);
-						await this.pruneJoinedEntriesNoLongerLed(
-							allToMergeShallowEntries,
-							{
-								decodedReplicaCounts: receiveReplicaCounts,
-								reusableLeaderPlans: reusableCoordinatePlans,
-								profile: syncProfile,
-							},
-						);
+						await this.pruneJoinedEntriesNoLongerLed(allToMergeShallowEntries, {
+							decodedReplicaCounts: receiveReplicaCounts,
+							reusableLeaderPlans: reusableCoordinatePlans,
+							profile: syncProfile,
+						});
 						if (syncProfile) {
 							emitSyncProfileDuration(syncProfile, checkedPruneStartedAt, {
 								name: "sharedLog.receive.checkedPrune",
@@ -13369,9 +16397,7 @@ export class SharedLog<
 							)
 						: filteredHeadHashes;
 					if (hashesToClear.length > 0) {
-						this._nativeBackbone?.clearPreparedRawReceiveEntries(
-							hashesToClear,
-						);
+						this._nativeBackbone?.clearPreparedRawReceiveEntries(hashesToClear);
 					}
 					if (syncProfile) {
 						emitSyncProfileDuration(syncProfile, clearPreparedStartedAt, {
@@ -13380,8 +16406,7 @@ export class SharedLog<
 							entries: hashesToClear.length,
 							messages: 1,
 							details: {
-								nativeCommitted:
-									nativePreparedCommittedHashes?.size ?? 0,
+								nativeCommitted: nativePreparedCommittedHashes?.size ?? 0,
 							},
 						});
 					}
@@ -13456,30 +16481,25 @@ export class SharedLog<
 									nativeLeaderHints.presentBlockHashes?.size ??
 									countTruthyValues(nativeLeaderHints.presentBlocks) ??
 									0,
-								localLeaders:
-									nativeLeaderHints.nativeAllConfirmed
-										? msg.hashes.length
-										: nativeLeaderHints.localLeaderHashes.size ||
-											countTruthyValues(nativeLeaderHints.localLeaderFlags) ||
-											0,
-								plannedEntries:
-									nativeLeaderHints.nativeAllConfirmed
-										? msg.hashes.length
-										: nativeLeaderHints.replicaCounts.size ||
-											countPositiveValues(
-												nativeLeaderHints.replicaCountsByIndex,
-											) ||
-											0,
-								peerHistoryGids:
-									nativeLeaderHints.peerHistoryGids.length,
+								localLeaders: nativeLeaderHints.nativeAllConfirmed
+									? msg.hashes.length
+									: nativeLeaderHints.localLeaderHashes.size ||
+										countTruthyValues(nativeLeaderHints.localLeaderFlags) ||
+										0,
+								plannedEntries: nativeLeaderHints.nativeAllConfirmed
+									? msg.hashes.length
+									: nativeLeaderHints.replicaCounts.size ||
+										countPositiveValues(
+											nativeLeaderHints.replicaCountsByIndex,
+										) ||
+										0,
+								peerHistoryGids: nativeLeaderHints.peerHistoryGids.length,
 							},
 						});
 					}
 				} else {
 					const metadataStartedAt = syncProfileStart(syncProfile);
-					nativeEntryMetadata = this.getNativeLogEntryMetadataBatch(
-						msg.hashes,
-					);
+					nativeEntryMetadata = this.getNativeLogEntryMetadataBatch(msg.hashes);
 					if (syncProfile) {
 						emitSyncProfileDuration(syncProfile, metadataStartedAt, {
 							name: "sharedLog.receive.requestPrune.nativeMetadata",
@@ -13529,8 +16549,7 @@ export class SharedLog<
 							details: {
 								localLeaders: nativeLeaderHints.localLeaderHashes.size,
 								plannedEntries: nativeLeaderHints.replicaCounts.size,
-								peerHistoryGids:
-									nativeLeaderHints.peerHistoryGids.length,
+								peerHistoryGids: nativeLeaderHints.peerHistoryGids.length,
 							},
 						});
 					}
@@ -13621,8 +16640,8 @@ export class SharedLog<
 						: nativeLeaderHints.presentBlocks
 							? !!nativeLeaderHints.presentBlocks[i]
 							: presentBlocks
-							? presentBlocks[i] === true
-							: await this.log.blocks.has(hash);
+								? presentBlocks[i] === true
+								: await this.log.blocks.has(hash);
 					if (
 						!presentBlocks &&
 						!nativeLeaderHints.presentBlockHashes &&
@@ -13657,13 +16676,15 @@ export class SharedLog<
 							}
 						} else {
 							const gid =
-								nativeEntryGid ?? nativeEntry?.gid ?? indexedEntry!.value.meta.gid;
+								nativeEntryGid ??
+								nativeEntry?.gid ??
+								indexedEntry!.value.meta.gid;
 							const replicaCountByIndex =
 								nativeLeaderHints.replicaCountsByIndex?.[i];
 							const replicas =
 								replicaCountByIndex != null && replicaCountByIndex > 0
 									? replicaCountByIndex
-									: nativeLeaderHints.replicaCounts.get(hash) ??
+									: (nativeLeaderHints.replicaCounts.get(hash) ??
 										decodeReplicas({
 											meta: {
 												data:
@@ -13671,7 +16692,7 @@ export class SharedLog<
 													nativeEntry?.data ??
 													indexedEntry!.value.meta.data,
 											},
-										}).getValue(this);
+										}).getValue(this));
 
 							if (
 								!nativeLeaderHints.peerHistoryRemovedFlags?.[i] &&
@@ -13732,8 +16753,7 @@ export class SharedLog<
 							let pendingIHave!: PendingIHave<T>;
 							pendingIHave = {
 								requesting,
-								resetTimeout: () =>
-									this.resetPendingIHaveTimeout(pendingIHave),
+								resetTimeout: () => this.resetPendingIHaveTimeout(pendingIHave),
 								clear: () => this.clearPendingIHaveTimeout(pendingIHave),
 								callback: async (entry: Entry<T>) => {
 									this.removePeerFromGidPeerHistory(from, entry.meta.gid);
@@ -13976,6 +16996,9 @@ export class SharedLog<
 				throw new Error("Unexpected message");
 			}
 		} catch (e: any) {
+			if (e instanceof NativeDurableCommitError) {
+				throw e;
+			}
 			if (
 				e instanceof AbortError ||
 				e instanceof NotStartedError ||
@@ -14003,20 +17026,26 @@ export class SharedLog<
 			}
 			logger.error(e);
 		} finally {
-			if (stashBackedRawMessage && stashBackedRawMessage.release()) {
-				const syncProfile = this._logProperties?.sync?.profile;
-				if (syncProfile) {
-					emitSyncProfileEvent(syncProfile, {
-						name: "sharedLog.rawReceive.wireStashRelease",
-						component: "shared-log",
-						entries: stashBackedRawMessage.heads.length,
-						messages: 1,
-						details: {
-							bytesMaterialized:
-								stashBackedRawMessage.bytesMaterializedCount,
-						},
-					});
+			try {
+				if (stashBackedRawMessage && stashBackedRawMessage.release()) {
+					const syncProfile = this._logProperties?.sync?.profile;
+					if (syncProfile) {
+						emitSyncProfileEvent(syncProfile, {
+							name: "sharedLog.rawReceive.wireStashRelease",
+							component: "shared-log",
+							entries: stashBackedRawMessage.heads.length,
+							messages: 1,
+							details: {
+								bytesMaterialized: stashBackedRawMessage.bytesMaterializedCount,
+							},
+						});
+					}
 				}
+			} finally {
+				// Every return and every locally swallowed receive error passes this
+				// boundary. Release a native wire stash exactly once first, then surface
+				// any durable mutation poison that arose while handling the message.
+				this.throwIfNativeDurableCommitFailed();
 			}
 		}
 	}
@@ -14173,6 +17202,7 @@ export class SharedLog<
 				  };
 		},
 	): Promise<void> {
+		this.throwIfNativeDurableCommitFailed();
 		let entriesToReplicate: Entry<T>[] = [];
 		const localHashes =
 			options?.replicate && this.log.length > 0
@@ -14909,7 +17939,8 @@ export class SharedLog<
 			this._checkedPrune.pendingDeletes.size > 0
 				? [...this._checkedPrune.pendingDeletes.keys()]
 				: [];
-		const nativeBackboneHintArrays = this._nativeBackbone as NativePeerbitBackbone & {
+		const nativeBackboneHintArrays = this
+			._nativeBackbone as NativePeerbitBackbone & {
 			planRequestPruneAllConfirmed?: (
 				hashes: Iterable<string>,
 				prunePeer: string,
@@ -14923,16 +17954,12 @@ export class SharedLog<
 		};
 		if (skipHashes.length === 0) {
 			const allConfirmed =
-				nativeBackboneHintArrays.planRequestPruneAllConfirmed?.(
-					hashes,
-					from,
-					{
-						...this.createNativeLeaderOptions(context),
-						omitPeerHistoryGids:
-							this._gidPeersHistory.size === 0 &&
-							this._nativeSharedLogState == null,
-					},
-				);
+				nativeBackboneHintArrays.planRequestPruneAllConfirmed?.(hashes, from, {
+					...this.createNativeLeaderOptions(context),
+					omitPeerHistoryGids:
+						this._gidPeersHistory.size === 0 &&
+						this._nativeSharedLogState == null,
+				});
 			if (allConfirmed?.allConfirmed) {
 				return {
 					localLeaderHashes: new Set(),
@@ -15612,34 +18639,53 @@ export class SharedLog<
 
 	private snapshotResidentCoordinateEntries(
 		hashes: Iterable<string>,
-	): Map<string, ResidentCoordinateEntry<R>> | undefined {
-		if (!this._residentEntryCoordinatesByHash) {
+	): NativeBackboneCoordinateRollback<R> | undefined {
+		const uniqueHashes = new Set([...hashes].filter(Boolean));
+		if (uniqueHashes.size === 0) {
 			return undefined;
 		}
-		const snapshot = new Map<string, ResidentCoordinateEntry<R>>();
-		for (const hash of new Set([...hashes].filter(Boolean))) {
-			const entry = this._residentEntryCoordinatesByHash.get(hash);
+		const entries = new Map<string, ResidentCoordinateEntry<R>>();
+		const generations = new Map<string, number>();
+		const mutationGenerations = (this._nativeCoordinateMutationGenerations ??=
+			new Map());
+		for (const hash of uniqueHashes) {
+			const generation = (mutationGenerations.get(hash) ?? 0) + 1;
+			mutationGenerations.set(hash, generation);
+			generations.set(hash, generation);
+			const entry = this._residentEntryCoordinatesByHash?.get(hash);
 			if (entry) {
-				snapshot.set(hash, entry);
+				entries.set(hash, entry);
 			}
 		}
-		return snapshot.size === 0 ? undefined : snapshot;
+		return { hashes: uniqueHashes, entries, generations };
 	}
 
 	private rollbackNativeBackboneCoordinateAppend(
 		appendHash: string,
-		previousEntries?: Map<string, ResidentCoordinateEntry<R>>,
+		rollback?: NativeBackboneCoordinateRollback<R>,
 	): void {
 		const backbone = this._nativeBackbone;
 		if (!backbone) {
 			return;
 		}
-		backbone.deleteEntryCoordinates(appendHash);
-		this._residentEntryCoordinatesByHash?.delete(appendHash);
-		if (!previousEntries) {
-			return;
-		}
-		for (const [hash, entry] of previousEntries) {
+		const hashes = rollback?.hashes ?? new Set([appendHash]);
+		const mutationGenerations = (this._nativeCoordinateMutationGenerations ??=
+			new Map());
+		for (const hash of hashes) {
+			const expectedGeneration = rollback?.generations.get(hash);
+			if (
+				expectedGeneration !== undefined &&
+				mutationGenerations.get(hash) !== expectedGeneration
+			) {
+				continue;
+			}
+			backbone.deleteEntryCoordinates(hash);
+			this._nativeSharedLogState?.deleteEntryCoordinates(hash);
+			this._residentEntryCoordinatesByHash?.delete(hash);
+			const entry = rollback?.entries.get(hash);
+			if (!entry) {
+				continue;
+			}
 			const fields = isEntryReplicated(entry)
 				? {
 						hash: entry.hash,
@@ -15660,7 +18706,53 @@ export class SharedLog<
 				requestedReplicas,
 				fields.hashNumber,
 			);
+			this._nativeSharedLogState?.putEntryCoordinates(
+				fields.hash,
+				fields.gid,
+				fields.coordinates,
+				fields.assignedToRangeBoundary,
+				requestedReplicas,
+				fields.hashNumber,
+			);
 			this._residentEntryCoordinatesByHash?.set(hash, entry);
+		}
+	}
+
+	private async rollbackNativeBackboneCoordinateAppendDurably(
+		appendHash: string,
+		rollback?: NativeBackboneCoordinateRollback<R>,
+	): Promise<void> {
+		this.rollbackNativeBackboneCoordinateAppend(appendHash, rollback);
+		const coordinateIndex = this.entryCoordinatesIndex as PutAndDeleteIndex<
+			EntryReplicated<R>
+		>;
+		const hashes = rollback?.hashes ?? new Set([appendHash]);
+		const mutationGenerations = (this._nativeCoordinateMutationGenerations ??=
+			new Map());
+		for (const hash of hashes) {
+			const expectedGeneration = rollback?.generations.get(hash);
+			if (
+				expectedGeneration !== undefined &&
+				mutationGenerations.get(hash) !== expectedGeneration
+			) {
+				continue;
+			}
+			const previous = rollback?.entries.get(hash);
+			if (previous) {
+				await coordinateIndex.put(
+					this.materializeResidentCoordinateEntry(previous),
+				);
+			} else if (coordinateIndex.delIds) {
+				await coordinateIndex.delIds([hash]);
+			} else if (coordinateIndex.delIdsNoReturn) {
+				await coordinateIndex.delIdsNoReturn([hash]);
+			} else {
+				await coordinateIndex.del({ query: { hash } });
+			}
+		}
+		const flushed = this.flushNativeBackboneCoordinateJournal();
+		if (isPromiseLike(flushed)) {
+			await flushed;
 		}
 	}
 
@@ -15935,7 +19027,14 @@ export class SharedLog<
 	private flushNativeBackboneCoordinateJournal(): MaybePromise<void> {
 		const backbone = this._nativeBackbone;
 		const persistence = this._nativeBackboneCoordinatePersistence;
-		if (!backbone || !persistence) {
+		if (!backbone || !persistence || this._nativeBackboneDropStarted) {
+			return undefined;
+		}
+		if (
+			backbone.coordinatePendingJournalLength === 0 &&
+			backbone.documentPendingJournalLength === 0 &&
+			backbone.documentSignerPendingJournalLength === 0
+		) {
 			return undefined;
 		}
 		return mapMaybePromise(persistence.flushJournal(backbone), () => {
@@ -15947,7 +19046,7 @@ export class SharedLog<
 	private flushNativeBackboneCoordinateJournalOnAppend(): MaybePromise<void> {
 		const backbone = this._nativeBackbone;
 		const persistence = this._nativeBackboneCoordinatePersistence;
-		if (!backbone || !persistence) {
+		if (!backbone || !persistence || this._nativeBackboneDropStarted) {
 			return undefined;
 		}
 		if (persistence.flushJournalOnAppend) {
@@ -15991,6 +19090,25 @@ export class SharedLog<
 	private async closeNativeBackboneCoordinatePersistence(): Promise<void> {
 		const persistence = this._nativeBackboneCoordinatePersistence;
 		if (!persistence) {
+			return;
+		}
+		if (this._nativeBackboneDropStarted) {
+			// `drop()` owns the durable namespace lifecycle. Never flush the live wasm
+			// journals or invoke an ordinary custom close after its tombstone/erase has
+			// started: a close implementation that rewrites cached state could resurrect
+			// files after a successful terminal drop.
+			return;
+		}
+		if (
+			this._nativeDurableCommitFailure &&
+			!this._nativeDurableRecoveryReadyForReopen
+		) {
+			// The failed native transaction was never published by the lower log.
+			// Its coordinate/document/signer records are still only in the wasm
+			// pending journals. Closing without flushing discards that generation;
+			// the next backbone hydrates the last acknowledged checkpoint.
+			await persistence.close?.();
+			this._nativeDurableRecoveryReadyForReopen = true;
 			return;
 		}
 		await this.flushNativeBackboneCoordinateJournal();
@@ -16818,12 +19936,8 @@ export class SharedLog<
 				for (let i = 0; i < nativeGroups.length; i++) {
 					const group = nativeGroups[i]!;
 					const leaders = leaderSamples[i]!;
-					const shouldRetain = leaders.has(
-						leaderSelectionContext!.selfHash,
-					);
-					(shouldRetain ? retainedHashes : droppedHashes).push(
-						...group.hashes,
-					);
+					const shouldRetain = leaders.has(leaderSelectionContext!.selfHash);
+					(shouldRetain ? retainedHashes : droppedHashes).push(...group.hashes);
 				}
 			} else {
 				for (let i = 0; i < nativeGroups.length; i++) {
@@ -16833,9 +19947,7 @@ export class SharedLog<
 						return undefined;
 					}
 					const shouldRetain = leaderPlan.isLeader;
-					(shouldRetain ? retainedHashes : droppedHashes).push(
-						...group.hashes,
-					);
+					(shouldRetain ? retainedHashes : droppedHashes).push(...group.hashes);
 				}
 			}
 			if (droppedHashes.length === 0) {
@@ -16886,8 +19998,7 @@ export class SharedLog<
 					predecodedReplicaHits: selection.plannedHashCount,
 					nativeRawGroups: true,
 					nativeReceiveGroupLeaderPlans: true,
-					nativeReceiveGroupLeaderSamples:
-						selection.usedLeaderSamplePlans,
+					nativeReceiveGroupLeaderSamples: selection.usedLeaderSamplePlans,
 					nativePreparedFastDropPlan: selection.usedNativeFastDropPlan,
 					nativeFastDropEarly: true,
 				},
@@ -16931,11 +20042,11 @@ export class SharedLog<
 					nativeFastDrop: true,
 					nativeFastDropEarly: true,
 				},
-				});
-			}
-			backbone.clearPreparedRawReceiveEntries?.(selection.droppedHashes);
-			return true;
+			});
 		}
+		backbone.clearPreparedRawReceiveEntries?.(selection.droppedHashes);
+		return true;
+	}
 
 	private async selectNativePreparedRawReceiveHashes(properties: {
 		heads: RawEntryWithRefs[];
@@ -17464,13 +20575,13 @@ export class SharedLog<
 				const optimisticPeers = properties.optimisticGidPeersByMode
 					.get(mode)
 					?.get(entry.gid);
-					const broadRepairCandidatePlanning =
-						this.usesBroadRepairCandidatePlanning(mode);
-					for (const peer of modePeers) {
-						if (
-							!broadRepairCandidatePlanning &&
-							this.isEntryKnownByPeer(entry.hash, peer)
-						) {
+				const broadRepairCandidatePlanning =
+					this.usesBroadRepairCandidatePlanning(mode);
+				for (const peer of modePeers) {
+					if (
+						!broadRepairCandidatePlanning &&
+						this.isEntryKnownByPeer(entry.hash, peer)
+					) {
 						continue;
 					}
 					const wasOptimisticallyAssigned = optimisticPeers?.has(peer) === true;
@@ -18569,7 +21680,9 @@ export class SharedLog<
 			const hasFixedSelfRangeRemovalToZero =
 				localSegmentsAfterChange != null &&
 				localSegmentsAfterChange.length > 0 &&
-				localSegmentsAfterChange.every((segment) => segment.widthNormalized === 0);
+				localSegmentsAfterChange.every(
+					(segment) => segment.widthNormalized === 0,
+				);
 			const shouldRunLocalPruneScan =
 				hasFixedSelfRangeRemovalToZero ||
 				(this._isAdaptiveReplicating &&

--- a/packages/programs/data/shared-log/test/durable-native-restart.spec.ts
+++ b/packages/programs/data/shared-log/test/durable-native-restart.spec.ts
@@ -90,8 +90,8 @@ describe("durable native block store restart", function () {
 		).to.equal(false);
 		expect(
 			durableBlockOptions?.compactOnCloseMinJournalBytes,
-			"native durable block WAL retains an explicit close-time compaction threshold",
-		).to.equal(512 * 1024 * 1024);
+			"strict native durable block WAL has no checkpoint threshold",
+		).to.equal(undefined);
 
 		for (let index = 0; index < entryCount; index++) {
 			await store1.add(`entry-${index}`, { meta: { next: [] } });
@@ -174,9 +174,10 @@ describe("durable native block store restart", function () {
 			.collect()
 			.map((entry: any) => entry.payload.getValue().value)
 			.sort();
-		expect(restoredValues, "restored documents match pre-restart").to.deep.equal(
-			preRestartValues,
-		);
+		expect(
+			restoredValues,
+			"restored documents match pre-restart",
+		).to.deep.equal(preRestartValues);
 
 		// (iv) coordinates restored (coordinate slice; kept green here).
 		const restoredCoordinateHashes = [

--- a/packages/transport/blocks/src/remote.ts
+++ b/packages/transport/blocks/src/remote.ts
@@ -18,8 +18,8 @@ import {
 	dontThrowIfDeliveryError,
 } from "@peerbit/stream";
 import {
-	type RequestTransportContext,
 	type PeerRefs,
+	type RequestTransportContext,
 	SilentDelivery,
 	type WaitForAnyOpts,
 	type WaitForPeersFn,
@@ -94,6 +94,24 @@ export class RemoteBlocks implements IBlocks {
 	// callers feature-detect this method (the log's columnar raw-receive
 	// fast path), so it must not exist without a delegation target.
 	putKnownManyColumns?: (cids: string[], bytes: Uint8Array[]) => string[];
+	// Native commit callbacks are synchronous, so a write-through local store
+	// exposes an explicit post-commit durability barrier for the lower log.
+	waitForDurableWrites?: () => Promise<void> | void;
+	// Durable native stores expose a synchronous poison guard so lower-log
+	// mutation entry points can reject before changing graph/index state.
+	throwIfDurableWritesFailed?: () => void;
+	rollbackFailedNativeCommits?: (
+		cids: string[],
+		restoreNativeCids?: string[],
+		ownershipToken?: unknown,
+	) => Promise<void>;
+	acknowledgeNativeCommitOwnership?: (ownershipToken: unknown) => void;
+	// Native trim uses the same feature-detection pattern to mirror a hot-store
+	// deletion into a write-through store without re-entering generic rmMany.
+	rmManyAfterNativeDelete?: (
+		cids: string[],
+		cleanupToken?: unknown,
+	) => Promise<number | void> | number | void;
 
 	private _responseHandler?: (
 		data: BlockMessage,
@@ -207,10 +225,7 @@ export class RemoteBlocks implements IBlocks {
 		this.localStore = options?.local;
 		const localPutKnownManyColumns = (
 			this.localStore as {
-				putKnownManyColumns?: (
-					cids: string[],
-					bytes: Uint8Array[],
-				) => string[];
+				putKnownManyColumns?: (cids: string[], bytes: Uint8Array[]) => string[];
 			}
 		)?.putKnownManyColumns;
 		if (typeof localPutKnownManyColumns === "function") {
@@ -220,9 +235,81 @@ export class RemoteBlocks implements IBlocks {
 					cids,
 					bytes,
 				);
-				void this.notifyPuts(stored);
+				const durableBarrier = this.waitForDurableWrites?.();
+				if (durableBarrier && typeof durableBarrier.then === "function") {
+					void Promise.resolve(durableBarrier).then(
+						() => this.notifyPuts(stored),
+						(): void => undefined,
+					);
+				} else {
+					void this.notifyPuts(stored);
+				}
 				return stored;
 			};
+		}
+		const localWaitForDurableWrites = (
+			this.localStore as {
+				waitForDurableWrites?: () => Promise<void> | void;
+			}
+		).waitForDurableWrites;
+		if (typeof localWaitForDurableWrites === "function") {
+			this.waitForDurableWrites = () =>
+				localWaitForDurableWrites.call(this.localStore);
+		}
+		const localThrowIfDurableWritesFailed = (
+			this.localStore as {
+				throwIfDurableWritesFailed?: () => void;
+			}
+		).throwIfDurableWritesFailed;
+		if (typeof localThrowIfDurableWritesFailed === "function") {
+			this.throwIfDurableWritesFailed = () =>
+				localThrowIfDurableWritesFailed.call(this.localStore);
+		}
+		const localRollbackFailedNativeCommits = (
+			this.localStore as {
+				rollbackFailedNativeCommits?: (
+					cids: string[],
+					restoreNativeCids?: string[],
+					ownershipToken?: unknown,
+				) => Promise<void>;
+			}
+		).rollbackFailedNativeCommits;
+		if (typeof localRollbackFailedNativeCommits === "function") {
+			this.rollbackFailedNativeCommits = (
+				cids,
+				restoreNativeCids,
+				ownershipToken,
+			) =>
+				localRollbackFailedNativeCommits.call(
+					this.localStore,
+					cids,
+					restoreNativeCids,
+					ownershipToken,
+				);
+		}
+		const localAcknowledgeNativeCommitOwnership = (
+			this.localStore as {
+				acknowledgeNativeCommitOwnership?: (ownershipToken: unknown) => void;
+			}
+		).acknowledgeNativeCommitOwnership;
+		if (typeof localAcknowledgeNativeCommitOwnership === "function") {
+			this.acknowledgeNativeCommitOwnership = (ownershipToken) =>
+				localAcknowledgeNativeCommitOwnership.call(
+					this.localStore,
+					ownershipToken,
+				);
+		}
+		const localRmManyAfterNativeDelete = (
+			this.localStore as {
+				rmManyAfterNativeDelete?: (
+					cids: string[],
+					cleanupToken?: unknown,
+				) => Promise<number | void> | number | void;
+			}
+		).rmManyAfterNativeDelete;
+		if (typeof localRmManyAfterNativeDelete === "function") {
+			this.rmManyAfterNativeDelete = (cids, cleanupToken) =>
+				localRmManyAfterNativeDelete.call(this.localStore, cids, cleanupToken);
 		}
 		this._resolvers = new Map();
 		this._readFromPeersPromises = new Map();
@@ -398,7 +485,10 @@ export class RemoteBlocks implements IBlocks {
 		if (cached.length > 0 && !options?.refresh) return cached;
 		try {
 			const resolved = await this.options.resolveProviders(cidString, options);
-			const normalized = this.normalizeProviderHints([...cached, ...(resolved ?? [])]);
+			const normalized = this.normalizeProviderHints([
+				...cached,
+				...(resolved ?? []),
+			]);
 			if (normalized.length > 0) {
 				this.rememberProviderHints(cidString, normalized);
 			}
@@ -420,7 +510,9 @@ export class RemoteBlocks implements IBlocks {
 	}
 
 	async putMany(
-		blocks: Array<Uint8Array | { block: Block<any, any, any, any>; cid: string }>,
+		blocks: Array<
+			Uint8Array | { block: Block<any, any, any, any>; cid: string }
+		>,
 	): Promise<string[]> {
 		if (!this.localStore) {
 			throw new Error("Local store not set");
@@ -767,7 +859,9 @@ export class RemoteBlocks implements IBlocks {
 		let providers =
 			explicitFrom.length > 0
 				? explicitFrom
-				: await this.resolveRemoteProviders(cidString, { signal: options.signal });
+				: await this.resolveRemoteProviders(cidString, {
+						signal: options.signal,
+					});
 		// A resolver may observe abort and still complete normally. Do not create a
 		// timeout-backed read from the candidates it returns after shutdown.
 		throwIfReadWasAborted();
@@ -788,9 +882,7 @@ export class RemoteBlocks implements IBlocks {
 			const promise = new Promise<Block<any, any, any, 1> | undefined>(
 				(resolve, reject) => {
 					let timeoutCallback: ReturnType<typeof setTimeout> | undefined;
-					let resolver:
-						| ((bytes: Uint8Array) => Promise<void>)
-						| undefined;
+					let resolver: ((bytes: Uint8Array) => Promise<void>) | undefined;
 					let settled = false;
 					const abortHandler = () => {
 						cleanup();
@@ -819,12 +911,15 @@ export class RemoteBlocks implements IBlocks {
 						return;
 					}
 
-					timeoutCallback = setTimeout(() => {
-						cleanup();
-						if (settled) return;
-						settled = true;
-						resolve(undefined);
-					}, options.timeout || 30 * 1000);
+					timeoutCallback = setTimeout(
+						() => {
+							cleanup();
+							if (settled) return;
+							settled = true;
+							resolve(undefined);
+						},
+						options.timeout || 30 * 1000,
+					);
 
 					resolver = async (bytes: Uint8Array) => {
 						const value = await tryDecode(bytes);
@@ -851,10 +946,7 @@ export class RemoteBlocks implements IBlocks {
 				Math.min(1_000, Math.floor(requestRetryIntervalMs / 2)),
 			);
 			let retryTimeout: ReturnType<typeof setTimeout> | undefined;
-			let stopWatchingProviders:
-				| void
-				| (() => void)
-				| { close: () => void };
+			let stopWatchingProviders: void | (() => void) | { close: () => void };
 			const refreshProviders = async (force = false) => {
 				if (!canResolveLater) return;
 				if (!force && explicitFrom.length > 0) return;
@@ -883,18 +975,15 @@ export class RemoteBlocks implements IBlocks {
 							? this.normalizeProviderHints(properties.providers)
 							: this.pickRequestBatch(providers, requeryCount);
 					if (requestProviders.length === 0) return;
-					await this.options.publish(
-						new BlockRequest(cidString),
-						{
-							priority: options.priority,
-							responsePriority: options.priority,
-							expiresAt,
-							mode: new SilentDelivery({
-								to: requestProviders,
-								redundancy: requestProviders.length,
-							}),
-						},
-					);
+					await this.options.publish(new BlockRequest(cidString), {
+						priority: options.priority,
+						responsePriority: options.priority,
+						expiresAt,
+						mode: new SilentDelivery({
+							to: requestProviders,
+							redundancy: requestProviders.length,
+						}),
+					});
 					requeryCount += 1;
 				} catch (e) {
 					dontThrowIfDeliveryError(e);
@@ -926,7 +1015,8 @@ export class RemoteBlocks implements IBlocks {
 			};
 			inFlight = {
 				promise,
-				addProviders: (nextProviders) => publishAdditionalProviders(nextProviders),
+				addProviders: (nextProviders) =>
+					publishAdditionalProviders(nextProviders),
 			};
 			this._readFromPeersPromises.set(cidString, inFlight);
 
@@ -964,7 +1054,11 @@ export class RemoteBlocks implements IBlocks {
 				);
 			};
 
-			if (canResolveLater && explicitFrom.length === 0 && this.options.watchProviders) {
+			if (
+				canResolveLater &&
+				explicitFrom.length === 0 &&
+				this.options.watchProviders
+			) {
 				stopWatchingProviders = this.options.watchProviders(cidString, {
 					signal: options.signal,
 					onProviders: (nextProviders) => {
@@ -972,7 +1066,10 @@ export class RemoteBlocks implements IBlocks {
 						const normalized = this.normalizeProviderHints(nextProviders);
 						if (normalized.length === 0) return;
 						this.rememberProviderHints(cidString, normalized);
-						providers = this.normalizeProviderHints([...providers, ...normalized]);
+						providers = this.normalizeProviderHints([
+							...providers,
+							...normalized,
+						]);
 						tryPublishRequest({ force: true, providers: normalized }).catch(
 							dontThrowIfDeliveryError,
 						);
@@ -993,7 +1090,10 @@ export class RemoteBlocks implements IBlocks {
 				}
 				this._readFromPeersPromises.delete(cidString);
 				this._events.removeEventListener("peer:reachable", publishOnNewPeers);
-				this._events.removeEventListener("providers:hints", publishOnProviderHints);
+				this._events.removeEventListener(
+					"providers:hints",
+					publishOnProviderHints,
+				);
 				if (typeof stopWatchingProviders === "function") {
 					stopWatchingProviders();
 				} else if (stopWatchingProviders) {
@@ -1040,9 +1140,12 @@ export class RemoteBlocks implements IBlocks {
 			}
 
 			if (options.timeout != null) {
-				timeout = setTimeout(() => {
-					finish(() => resolve(undefined));
-				}, Math.max(0, options.timeout));
+				timeout = setTimeout(
+					() => {
+						finish(() => resolve(undefined));
+					},
+					Math.max(0, options.timeout),
+				);
 			}
 			options.signal?.addEventListener("abort", abort, { once: true });
 
@@ -1054,18 +1157,26 @@ export class RemoteBlocks implements IBlocks {
 	}
 
 	async stop(): Promise<void> {
-		// Dont listen for more incoming messages
+		let firstError: unknown;
+		const capture = async (operation: () => Promise<unknown> | unknown) => {
+			try {
+				await operation();
+			} catch (error) {
+				firstError ??= error;
+			}
+		};
 
-		// Wait for processing request
-		this.closeController.abort();
+		// Stop accepting work first, then always release every independent
+		// queue/store/cache resource even when an earlier drain fails.
+		await capture(() => this.closeController.abort());
 		if (this._deferredStoredNotificationTimer) {
 			clearTimeout(this._deferredStoredNotificationTimer);
 			this._deferredStoredNotificationTimer = undefined;
 		}
-		await this.flushDeferredStoredNotifications();
-		this._loadFetchQueue.clear();
-		await this._loadFetchQueue.onIdle(); // wait for pending
-		await this.localStore?.stop();
+		await capture(() => this.flushDeferredStoredNotifications());
+		await capture(() => this._loadFetchQueue.clear());
+		await capture(() => this._loadFetchQueue.onIdle());
+		await capture(() => this.localStore?.stop());
 		this._readFromPeersPromises.clear();
 		this._resolvers.clear();
 		this._blockCache?.clear();
@@ -1073,6 +1184,9 @@ export class RemoteBlocks implements IBlocks {
 		this._rustProviderCache?.clear();
 		this._open = false;
 		// we dont cleanup subscription because we dont know if someone else is sbuscribing also
+		if (firstError !== undefined) {
+			throw firstError;
+		}
 	}
 
 	waitFor(

--- a/packages/transport/blocks/test/shutdown-race.spec.ts
+++ b/packages/transport/blocks/test/shutdown-race.spec.ts
@@ -5,28 +5,54 @@
  * the Level backend throws { code: "LEVEL_DATABASE_NOT_OPEN" }.
  * put() should catch this and return the CID as a silent no-op.
  */
-
-import { expect } from "chai";
-import os from "os";
-import path from "path";
-import fs from "fs";
 import { createStore } from "@peerbit/any-store";
 import type { AnyStore } from "@peerbit/any-store-interface";
+import { Ed25519Keypair } from "@peerbit/crypto";
+import { expect } from "chai";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import sinon from "sinon";
 import { AnyBlockStore } from "../src/any-blockstore.js";
+import { RemoteBlocks } from "../src/remote.js";
 
 describe("@peerbit/blocks — shutdown race", () => {
 	let tmpDir: string;
+	let stores: AnyBlockStore[];
+	let remotes: RemoteBlocks[];
+	const trackStore = <T extends AnyBlockStore>(store: T): T => {
+		stores.push(store);
+		return store;
+	};
+	const trackRemote = <T extends RemoteBlocks>(remote: T): T => {
+		remotes.push(remote);
+		return remote;
+	};
 
 	beforeEach(() => {
-		tmpDir = path.join(os.tmpdir(), "blocks-shutdown-test-" + Date.now());
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "blocks-shutdown-test-"));
+		stores = [];
+		remotes = [];
 	});
 
-	afterEach(() => {
-		fs.rmSync(tmpDir, { recursive: true, force: true });
+	afterEach(async () => {
+		// Always close live handles before deleting their directory. This keeps the
+		// race tests deterministic on Windows and after an assertion failure.
+		for (const remote of remotes.reverse()) {
+			if (remote.status !== "closed") {
+				await remote.stop().catch((): void => undefined);
+			}
+		}
+		for (const store of stores.reverse()) {
+			if (store.status() !== "closed") {
+				await store.stop().catch((): void => undefined);
+			}
+		}
+		await fs.promises.rm(tmpDir, { recursive: true, force: true });
 	});
 
 	it("put() after stop() should not throw LEVEL_DATABASE_NOT_OPEN", async () => {
-		const store = new AnyBlockStore(createStore(tmpDir));
+		const store = trackStore(new AnyBlockStore(createStore(tmpDir)));
 		await store.start();
 
 		const data = new Uint8Array([1, 2, 3, 4]);
@@ -41,7 +67,7 @@ describe("@peerbit/blocks — shutdown race", () => {
 	});
 
 	it("putMany() after stop() should not throw LEVEL_DATABASE_NOT_OPEN", async () => {
-		const store = new AnyBlockStore(createStore(tmpDir));
+		const store = trackStore(new AnyBlockStore(createStore(tmpDir)));
 		await store.start();
 
 		const data = [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])];
@@ -74,7 +100,7 @@ describe("@peerbit/blocks — shutdown race", () => {
 			size: async () => 0,
 			persisted: async () => true,
 		};
-		const store = new AnyBlockStore(unopenedStore);
+		const store = trackStore(new AnyBlockStore(unopenedStore));
 
 		try {
 			await store.put(new Uint8Array([5, 6, 7, 8]));
@@ -85,7 +111,7 @@ describe("@peerbit/blocks — shutdown race", () => {
 	});
 
 	it("get() after stop() should not throw (baseline check)", async () => {
-		const store = new AnyBlockStore(createStore(tmpDir));
+		const store = trackStore(new AnyBlockStore(createStore(tmpDir)));
 		await store.start();
 
 		const data = new Uint8Array([10, 20, 30]);
@@ -97,5 +123,81 @@ describe("@peerbit/blocks — shutdown race", () => {
 		} catch {
 			// acceptable — the point is no *unhandled* rejection
 		}
+	});
+
+	it("RemoteBlocks.stop releases later resources and rethrows the first drain error", async () => {
+		const local = trackStore(new AnyBlockStore(createStore(tmpDir)));
+		const key = await Ed25519Keypair.create();
+		const remote = trackRemote(
+			new RemoteBlocks({
+				local,
+				publicKey: key.publicKey,
+				publish: async () => undefined,
+				waitFor: async () => [],
+			}),
+		);
+		await remote.start();
+		const failure = new Error("deferred notification flush failed");
+		const flushStub = sinon
+			.stub(remote as any, "flushDeferredStoredNotifications")
+			.rejects(failure);
+		const localStopSpy = sinon.spy(local, "stop");
+		(remote as any)._resolvers.set("pending", async (): Promise<void> => {});
+		(remote as any)._readFromPeersPromises.set("pending", {
+			promise: Promise.resolve(undefined),
+			addProviders: (): void => {},
+		});
+
+		try {
+			const thrown = await remote.stop().then(
+				(): undefined => undefined,
+				(error: unknown) => error,
+			);
+			expect(thrown).equal(failure);
+			expect(localStopSpy.calledOnce).equal(true);
+			expect(local.status()).equal("closed");
+			expect(remote.status).equal("closed");
+			expect((remote as any)._resolvers.size).equal(0);
+			expect((remote as any)._readFromPeersPromises.size).equal(0);
+		} finally {
+			localStopSpy.restore();
+			flushStub.restore();
+		}
+	});
+
+	it("does not announce columnar puts when the durability barrier fails", async () => {
+		const local = trackStore(
+			new AnyBlockStore(createStore(tmpDir)),
+		) as AnyBlockStore & {
+			putKnownManyColumns: (cids: string[], bytes: Uint8Array[]) => string[];
+			waitForDurableWrites: () => Promise<void>;
+		};
+		local.putKnownManyColumns = (cids) => cids;
+		let rejectBarrier!: (error: unknown) => void;
+		const barrier = new Promise<void>((_resolve, reject) => {
+			rejectBarrier = reject;
+		});
+		local.waitForDurableWrites = () => barrier;
+		const key = await Ed25519Keypair.create();
+		const onPut = sinon.spy();
+		const remote = trackRemote(
+			new RemoteBlocks({
+				local,
+				publicKey: key.publicKey,
+				publish: async () => undefined,
+				waitFor: async () => [],
+				onPut,
+			}),
+		);
+		const cid = "columnar-cid";
+
+		expect(
+			remote.putKnownManyColumns?.([cid], [new Uint8Array([1])]),
+		).deep.equal([cid]);
+		expect(onPut.callCount).equal(0);
+		rejectBarrier(new Error("durability failed"));
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(onPut.callCount).equal(0);
 	});
 });

--- a/packages/utils/any-store/rust/src/index.ts
+++ b/packages/utils/any-store/rust/src/index.ts
@@ -1,7 +1,7 @@
 import { type AnyStore } from "@peerbit/any-store-interface";
 import {
-	createPersistenceBackend,
 	type RustAnyStorePersistenceBackend,
+	createPersistenceBackend,
 } from "./persistence.js";
 
 type NativeAnyStore = {
@@ -56,14 +56,17 @@ let wasmInitPromise: Promise<void> | undefined;
 const loadWasm = async (): Promise<WasmModule> => {
 	if (!wasmModulePromise) {
 		const wasmModulePath = "../wasm/any_store_rust.js";
-		wasmModulePromise = import(/* @vite-ignore */ wasmModulePath) as Promise<WasmModule>;
+		wasmModulePromise = import(
+			/* @vite-ignore */ wasmModulePath
+		) as Promise<WasmModule>;
 	}
 
 	const wasm = await wasmModulePromise;
 	if (!wasmInitialized) {
 		wasmInitPromise ??= (async () => {
-			const processLike = (globalThis as { process?: { versions?: { node?: string } } })
-				.process;
+			const processLike = (
+				globalThis as { process?: { versions?: { node?: string } } }
+			).process;
 			if (processLike?.versions?.node) {
 				const fsPromises = "fs/promises";
 				const { readFile } = (await import(
@@ -75,7 +78,10 @@ const loadWasm = async (): Promise<WasmModule> => {
 				wasm.initSync({ module: bytes });
 			} else {
 				await wasm.default({
-					module_or_path: new URL("../wasm/any_store_rust_bg.wasm", import.meta.url),
+					module_or_path: new URL(
+						"../wasm/any_store_rust_bg.wasm",
+						import.meta.url,
+					),
 				});
 			}
 			wasmInitialized = true;
@@ -133,8 +139,17 @@ export class RustAnyStore implements AnyStore {
 				this._status = "open";
 			} catch (error) {
 				this._status = "closed";
+				const persistence = this.persistence;
 				this.native = undefined;
 				this.persistence = undefined;
+				try {
+					await persistence?.close();
+				} catch (closeError) {
+					throw new AggregateError(
+						[error, closeError],
+						"RustAnyStore open failed and its persistence backend could not close",
+					);
+				}
 				throw error;
 			}
 		});
@@ -255,7 +270,7 @@ export class RustAnyStore implements AnyStore {
 		}
 		const normalNative = this.openNormalDurabilityNative();
 		if (normalNative && this.directory) {
-			const journalError = this.takePendingJournalError();
+			const journalError = this.pendingJournalError();
 			if (journalError) {
 				return Promise.reject(journalError);
 			}
@@ -276,7 +291,9 @@ export class RustAnyStore implements AnyStore {
 		});
 	}
 
-	putMany(entries: Iterable<readonly [string, Uint8Array]>): Promise<void> | void {
+	putMany(
+		entries: Iterable<readonly [string, Uint8Array]>,
+	): Promise<void> | void {
 		const inputPairs = Array.from(entries);
 		if (inputPairs.length === 0) {
 			return;
@@ -290,7 +307,9 @@ export class RustAnyStore implements AnyStore {
 			return;
 		}
 
-		const pairs = inputPairs.map(([key, value]) => [key, copyBytes(value)] as const);
+		const pairs = inputPairs.map(
+			([key, value]) => [key, copyBytes(value)] as const,
+		);
 		if (pairs.length === 0) {
 			return;
 		}
@@ -326,7 +345,7 @@ export class RustAnyStore implements AnyStore {
 		}
 		const normalNative = this.openNormalDurabilityNative();
 		if (normalNative && this.directory) {
-			const journalError = this.takePendingJournalError();
+			const journalError = this.pendingJournalError();
 			if (journalError) {
 				return Promise.reject(journalError);
 			}
@@ -384,7 +403,9 @@ export class RustAnyStore implements AnyStore {
 		});
 	}
 
-	async getMany(keys: Iterable<string>): Promise<Array<Uint8Array | undefined>> {
+	async getMany(
+		keys: Iterable<string>,
+	): Promise<Array<Uint8Array | undefined>> {
 		const native = await this.ensureOpen();
 		return native.get_many(Array.from(keys)).map((value) => value ?? undefined);
 	}
@@ -479,7 +500,11 @@ export class RustAnyStore implements AnyStore {
 	}
 
 	iterator(): {
-		[Symbol.asyncIterator]: () => AsyncIterator<[string, Uint8Array], void, void>;
+		[Symbol.asyncIterator]: () => AsyncIterator<
+			[string, Uint8Array],
+			void,
+			void
+		>;
 	} {
 		return {
 			[Symbol.asyncIterator]: () => {
@@ -487,7 +512,9 @@ export class RustAnyStore implements AnyStore {
 				let index = 0;
 				return {
 					next: async () => {
-						entriesPromise ??= this.ensureOpen().then((native) => native.entries());
+						entriesPromise ??= this.ensureOpen().then((native) =>
+							native.entries(),
+						);
 						const entries = await entriesPromise;
 						if (index >= entries.length) {
 							return { done: true, value: undefined };
@@ -506,7 +533,9 @@ export class RustAnyStore implements AnyStore {
 	async clear(): Promise<void> {
 		await this.enqueueMutation(async (native) => {
 			if (this.directory) {
-				await this.recordJournal(this.journaledNative(native).encode_clear_record());
+				await this.recordJournal(
+					this.journaledNative(native).encode_clear_record(),
+				);
 			}
 			native.clear();
 		});
@@ -537,7 +566,10 @@ export class RustAnyStore implements AnyStore {
 			return;
 		}
 		const native = this.journaledNative(this.native);
-		this.persistence = await createPersistenceBackend(this.directory, this.level);
+		this.persistence = await createPersistenceBackend(
+			this.directory,
+			this.level,
+		);
 		const snapshot = await this.persistence.readSnapshot();
 		if (snapshot && snapshot.byteLength > 0) {
 			native.load_snapshot(snapshot);
@@ -547,16 +579,26 @@ export class RustAnyStore implements AnyStore {
 		if (journal && journal.byteLength > 0) {
 			const applied = native.apply_journal(journal);
 			if (applied < journal.byteLength) {
-				// Torn tail from a mid-write crash: rewrite the checkpoint so new
-				// records are not appended after the unreadable bytes and lost on
-				// the next replay.
-				await this.persistence.writeSnapshot(native.snapshot());
-				this.journalByteLength = 0;
+				// Torn tail from a mid-write crash: retain the verified WAL prefix and
+				// durably remove only the unreadable suffix. A checkpoint rewrite is
+				// not crash-safe on every backend and must never be an implicit repair.
+				await this.persistence.truncateJournal(applied);
+				this.journalByteLength = applied;
 			}
 		}
+		// A journal failure poisons the current open generation. Only a complete
+		// close/reopen that replays a verified checkpoint may clear it.
+		this.journalError = undefined;
+		this.journalQueue = Promise.resolve();
 	}
 
 	private shouldCompactOnClose(): boolean {
+		// Strict mode backs acknowledgement-sensitive mirrors. Until every backend
+		// has a proven crash-atomic generation protocol, neither an explicit close
+		// request nor a forced threshold may replace its WAL with a checkpoint.
+		if (this.options.durability === "strict") {
+			return false;
+		}
 		if (this.options.compactOnClose !== false) {
 			return true;
 		}
@@ -615,14 +657,14 @@ export class RustAnyStore implements AnyStore {
 		}
 	}
 
-	private takePendingJournalError(): unknown {
-		const error = this.journalError;
-		this.journalError = undefined;
-		return error;
+	private pendingJournalError(): unknown {
+		return this.journalError;
 	}
 
-	private enqueueMutation<T>(fn: (native: NativeAnyStore) => Promise<T>): Promise<T> {
-		const journalError = this.takePendingJournalError();
+	private enqueueMutation<T>(
+		fn: (native: NativeAnyStore) => Promise<T>,
+	): Promise<T> {
+		const journalError = this.pendingJournalError();
 		if (journalError) {
 			return Promise.reject(journalError);
 		}
@@ -633,9 +675,18 @@ export class RustAnyStore implements AnyStore {
 		// A mutation enqueued behind a pending close belongs to the queued
 		// re-open and must not drain into the closing native.
 		const drainAllowed = this.pendingCloses === 0;
-		const next = this.mutationQueue.then(async () =>
-			fn(await this.ensureOpen(drainAllowed)),
-		);
+		const next = this.mutationQueue.then(async () => {
+			// A strict mutation can be queued while the mutation ahead of it is still
+			// waiting for fsync. Re-check poison after reaching the head of the queue;
+			// the enqueue-time check alone would let this follower mutate memory/WAL
+			// after its predecessor recorded the generation's sticky first error.
+			const queuedError = this.pendingJournalError();
+			if (queuedError) throw queuedError;
+			const native = await this.ensureOpen(drainAllowed);
+			const openError = this.pendingJournalError();
+			if (openError) throw openError;
+			return fn(native);
+		});
 		this.mutationQueue = next.then(
 			() => undefined,
 			() => undefined,
@@ -647,7 +698,9 @@ export class RustAnyStore implements AnyStore {
 
 	private journaledNative(native: NativeAnyStore): JournaledNativeAnyStore {
 		if (!("encode_put_record" in native)) {
-			throw new Error("RustAnyStore native store does not expose journal records");
+			throw new Error(
+				"RustAnyStore native store does not expose journal records",
+			);
 		}
 		return native as JournaledNativeAnyStore;
 	}
@@ -670,6 +723,8 @@ export class RustAnyStore implements AnyStore {
 		const recordByteLength = record.byteLength;
 		const write = this.journalQueue
 			.then(async () => {
+				const journalError = this.pendingJournalError();
+				if (journalError) throw journalError;
 				if (!this.persistence) {
 					throw new Error("RustAnyStore persistence backend is not open");
 				}
@@ -680,8 +735,8 @@ export class RustAnyStore implements AnyStore {
 				this.journalByteLength += recordByteLength;
 			})
 			.catch((error) => {
-				this.journalError = error;
-				throw error;
+				this.journalError ??= error;
+				throw this.journalError;
 			});
 		this.journalQueue = write.then(
 			() => undefined,
@@ -692,7 +747,7 @@ export class RustAnyStore implements AnyStore {
 
 	private async waitForJournal(): Promise<void> {
 		await this.journalQueue;
-		const journalError = this.takePendingJournalError();
+		const journalError = this.pendingJournalError();
 		if (journalError) {
 			throw journalError;
 		}

--- a/packages/utils/any-store/rust/src/lib.rs
+++ b/packages/utils/any-store/rust/src/lib.rs
@@ -303,17 +303,28 @@ fn encode_record(operation: JournalOperation, key: &[u8], value: &[u8]) -> Vec<u
     output
 }
 
-/// Replays journal records, stopping at the first record that does not frame
-/// cleanly (torn tail after a mid-write crash) instead of failing the whole
-/// replay, mirroring peerbit_indexer_core journal recovery. Returns the number
-/// of bytes applied so callers can detect the tear and rewrite the checkpoint.
-/// Records that pass the checksum but carry an invalid payload still error.
+/// Replays journal records. Only a structurally incomplete final frame is a
+/// recoverable crash tail; complete frames with bad magic, checksum, or payload
+/// fail closed. Replay is transactional on corruption so the caller never sees
+/// a partially applied corrupt generation. Returns the verified prefix length
+/// so callers can durably truncate an incomplete EOF tail.
 fn apply_journal(store: &mut NativeAnyStore, bytes: &[u8]) -> Result<usize, String> {
+    let mut replay = NativeAnyStore {
+        entries: store.entries.clone(),
+        total_size: store.total_size,
+    };
     let mut applied = 0;
     while applied < bytes.len() {
         let mut offset = applied;
-        if !bytes[offset..].starts_with(JOURNAL_MAGIC) {
-            break;
+        let remaining = &bytes[offset..];
+        if remaining.len() < JOURNAL_MAGIC.len() {
+            if JOURNAL_MAGIC.starts_with(remaining) {
+                break;
+            }
+            return Err("journal magic mismatch".to_string());
+        }
+        if !remaining.starts_with(JOURNAL_MAGIC) {
+            return Err("journal magic mismatch".to_string());
         }
         offset += JOURNAL_MAGIC.len();
         let Ok(payload_len) = read_u32(bytes, &mut offset) else {
@@ -326,11 +337,13 @@ fn apply_journal(store: &mut NativeAnyStore, bytes: &[u8]) -> Result<usize, Stri
             break;
         };
         if fnv1a(payload) != checksum {
-            break;
+            return Err("journal checksum mismatch".to_string());
         }
-        apply_record_payload(store, payload)?;
+        apply_record_payload(&mut replay, payload)?;
         applied = offset;
     }
+    store.entries = replay.entries;
+    store.total_size = replay.total_size;
     Ok(applied)
 }
 
@@ -408,20 +421,35 @@ mod tests {
     }
 
     #[test]
-    fn journal_stops_at_checksum_mismatch() {
+    fn journal_rejects_checksum_mismatch_without_partial_replay() {
         let encoder = NativeAnyStore::new();
         let mut journal = Vec::new();
         journal.extend_from_slice(&encoder.encode_put_record("a".to_string(), vec![1]));
-        let clean_len = journal.len();
         let mut corrupt = encoder.encode_put_record("b".to_string(), vec![2]);
         let last = corrupt.len() - 1;
         corrupt[last] ^= 0xff;
         journal.extend_from_slice(&corrupt);
 
         let mut store = NativeAnyStore::new();
-        let applied = apply_journal(&mut store, &journal).unwrap();
-        assert_eq!(applied, clean_len);
-        assert_eq!(store.get("a"), Some(vec![1]));
+        store.put("seed".to_string(), vec![9]);
+        let error = apply_journal(&mut store, &journal).unwrap_err();
+        assert_eq!(error, "journal checksum mismatch");
+        assert_eq!(store.get("seed"), Some(vec![9]));
+        assert_eq!(store.get("a"), None);
         assert_eq!(store.get("b"), None);
+    }
+
+    #[test]
+    fn journal_rejects_non_prefix_magic_without_partial_replay() {
+        let encoder = NativeAnyStore::new();
+        let mut journal = encoder.encode_put_record("a".to_string(), vec![1]);
+        journal.extend_from_slice(b"BAD");
+
+        let mut store = NativeAnyStore::new();
+        store.put("seed".to_string(), vec![9]);
+        let error = apply_journal(&mut store, &journal).unwrap_err();
+        assert_eq!(error, "journal magic mismatch");
+        assert_eq!(store.get("seed"), Some(vec![9]));
+        assert_eq!(store.get("a"), None);
     }
 }

--- a/packages/utils/any-store/rust/src/persistence.ts
+++ b/packages/utils/any-store/rust/src/persistence.ts
@@ -3,7 +3,15 @@ export type PersistenceDurability = "normal" | "strict";
 export interface RustAnyStorePersistenceBackend {
 	readSnapshot(): Promise<Uint8Array | undefined>;
 	readJournal(): Promise<Uint8Array | undefined>;
-	appendJournal(record: Uint8Array, durability: PersistenceDurability): Promise<void>;
+	appendJournal(
+		record: Uint8Array,
+		durability: PersistenceDurability,
+	): Promise<void>;
+	/**
+	 * Remove an unreadable journal tail and make the new length durable before
+	 * any later record can be appended.
+	 */
+	truncateJournal(byteLength: number): Promise<void>;
 	writeSnapshot(snapshot: Uint8Array): Promise<void>;
 	removeSublevels(): Promise<void>;
 	close(): Promise<void>;
@@ -27,13 +35,16 @@ type ActiveManifest = CheckpointManifest & {
 };
 
 const encodePathPart = (part: string): string =>
-	encodeURIComponent(part).replace(/[!'()*]/g, (char) =>
-		`%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+	encodeURIComponent(part).replace(
+		/[!'()*]/g,
+		(char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
 	);
 
 const isNodeRuntime = () =>
-	Boolean((globalThis as { process?: { versions?: { node?: string } } }).process
-		?.versions?.node);
+	Boolean(
+		(globalThis as { process?: { versions?: { node?: string } } }).process
+			?.versions?.node,
+	);
 
 const isNotFoundError = (error: unknown): boolean =>
 	Boolean(
@@ -64,7 +75,10 @@ const manifestPayload = (manifest: CheckpointManifest): string =>
 const encodeManifest = (manifest: CheckpointManifest): Uint8Array => {
 	const payload = manifestPayload(manifest);
 	return new TextEncoder().encode(
-		JSON.stringify({ payload: JSON.parse(payload), checksum: checksumString(payload) }),
+		JSON.stringify({
+			payload: JSON.parse(payload),
+			checksum: checksumString(payload),
+		}),
 	);
 };
 
@@ -104,7 +118,9 @@ let nodeFsModule: Promise<NodeFsModule> | undefined;
 const importNodeFs = (): Promise<NodeFsModule> => {
 	if (!nodeFsModule) {
 		const fsPromises = "fs/promises";
-		nodeFsModule = import(/* @vite-ignore */ fsPromises) as Promise<NodeFsModule>;
+		nodeFsModule = import(
+			/* @vite-ignore */ fsPromises
+		) as Promise<NodeFsModule>;
 	}
 	return nodeFsModule;
 };
@@ -120,7 +136,9 @@ const importNodePathJoin = (): Promise<(...parts: string[]) => string> => {
 	return nodePathJoin;
 };
 
-const readNodeFileIfExists = async (path: string): Promise<Uint8Array | undefined> => {
+const readNodeFileIfExists = async (
+	path: string,
+): Promise<Uint8Array | undefined> => {
 	const { readFile } = await importNodeFs();
 	try {
 		return new Uint8Array(await readFile(path));
@@ -132,9 +150,23 @@ const readNodeFileIfExists = async (path: string): Promise<Uint8Array | undefine
 	}
 };
 
-class NodePersistenceBackend implements RustAnyStorePersistenceBackend {
+const validateWriteProgress = (
+	written: number,
+	remaining: number,
+	target: string,
+): number => {
+	if (!Number.isSafeInteger(written) || written <= 0 || written > remaining) {
+		throw new Error(
+			`${target} write made invalid progress: wrote ${written} of ${remaining} remaining bytes`,
+		);
+	}
+	return written;
+};
+
+export class NodePersistenceBackend implements RustAnyStorePersistenceBackend {
 	private journalHandle?: import("fs/promises").FileHandle;
 	private journalOffset?: number;
+	private journalPoison?: unknown;
 	private levelDirectoryPath?: string;
 	private sublevelsDirectoryPath?: string;
 	private snapshotFilePath?: string;
@@ -142,7 +174,10 @@ class NodePersistenceBackend implements RustAnyStorePersistenceBackend {
 	private journalFilePath?: string;
 	private directoryEnsured = false;
 
-	constructor(private readonly rootDirectory: string, private readonly level: string[]) {}
+	constructor(
+		private readonly rootDirectory: string,
+		private readonly level: string[],
+	) {}
 
 	async readSnapshot(): Promise<Uint8Array | undefined> {
 		return readNodeFileIfExists(await this.snapshotPath());
@@ -160,24 +195,68 @@ class NodePersistenceBackend implements RustAnyStorePersistenceBackend {
 		record: Uint8Array,
 		durability: PersistenceDurability,
 	): Promise<void> {
-		await this.ensureLevelDirectory();
-		const { open, stat } = await importNodeFs();
-		if (!this.journalHandle) {
-			const path = await this.journalPath();
-			this.journalHandle = await open(path, "a+");
-			if (this.journalOffset == null) {
-				try {
-					this.journalOffset = (await stat(path)).size;
-				} catch {
-					this.journalOffset = 0;
-				}
-			}
+		if (this.journalPoison !== undefined) {
+			throw this.journalPoison;
 		}
+		await this.ensureLevelDirectory();
+		await this.ensureJournalHandle();
+		const handle = this.journalHandle!;
 		const offset = this.journalOffset ?? 0;
-		await this.journalHandle.write(record, 0, record.byteLength, offset);
-		this.journalOffset = offset + record.byteLength;
-		if (durability === "strict") {
-			await this.journalHandle.sync();
+		let written = 0;
+		try {
+			while (written < record.byteLength) {
+				const remaining = record.byteLength - written;
+				const result = await handle.write(
+					record,
+					written,
+					remaining,
+					offset + written,
+				);
+				written += validateWriteProgress(
+					result.bytesWritten,
+					remaining,
+					"Node persistence journal",
+				);
+			}
+			if (durability === "strict") {
+				await handle.sync();
+			}
+			this.journalOffset = offset + written;
+		} catch (error) {
+			try {
+				// A rejected record must be completely absent before another write is
+				// allowed. Persist the rollback even for normal durability: otherwise a
+				// later valid record could be stranded behind an unreadable torn tail.
+				await handle.truncate(offset);
+				await handle.sync();
+				this.journalOffset = offset;
+			} catch (rollbackError) {
+				this.journalPoison = new AggregateError(
+					[error, rollbackError],
+					"Node persistence journal rollback failed; reopen is required",
+				);
+				throw this.journalPoison;
+			}
+			throw error;
+		}
+	}
+
+	async truncateJournal(byteLength: number): Promise<void> {
+		if (!Number.isSafeInteger(byteLength) || byteLength < 0) {
+			throw new Error(`Invalid Node persistence journal length: ${byteLength}`);
+		}
+		if (this.journalPoison !== undefined) {
+			throw this.journalPoison;
+		}
+		await this.ensureLevelDirectory();
+		await this.ensureJournalHandle();
+		try {
+			await this.journalHandle!.truncate(byteLength);
+			await this.journalHandle!.sync();
+			this.journalOffset = byteLength;
+		} catch (error) {
+			this.journalPoison = error;
+			throw error;
 		}
 	}
 
@@ -199,6 +278,8 @@ class NodePersistenceBackend implements RustAnyStorePersistenceBackend {
 
 	async close(): Promise<void> {
 		this.directoryEnsured = false;
+		this.journalOffset = undefined;
+		this.journalPoison = undefined;
 		if (!this.journalHandle) {
 			return;
 		}
@@ -215,6 +296,31 @@ class NodePersistenceBackend implements RustAnyStorePersistenceBackend {
 		const { mkdir } = await importNodeFs();
 		await mkdir(await this.levelDirectory(), { recursive: true });
 		this.directoryEnsured = true;
+	}
+
+	private async ensureJournalHandle(): Promise<void> {
+		if (this.journalHandle) {
+			return;
+		}
+		const { open, stat } = await importNodeFs();
+		const path = await this.journalPath();
+		try {
+			// O_APPEND ignores positional offsets on Linux. Use a positional
+			// read/write handle so a retry can never append behind a torn tail.
+			this.journalHandle = await open(path, "r+");
+		} catch (error) {
+			if (!isNotFoundError(error)) {
+				throw error;
+			}
+			this.journalHandle = await open(path, "w+");
+		}
+		if (this.journalOffset == null) {
+			try {
+				this.journalOffset = (await stat(path)).size;
+			} catch {
+				this.journalOffset = 0;
+			}
+		}
 	}
 
 	private async levelDirectory(): Promise<string> {
@@ -262,9 +368,10 @@ class NodePersistenceBackend implements RustAnyStorePersistenceBackend {
 	}
 }
 
-class OpfsPersistenceBackend implements RustAnyStorePersistenceBackend {
+export class OpfsPersistenceBackend implements RustAnyStorePersistenceBackend {
 	private journalHandle?: FileSystemSyncAccessHandle;
 	private journalOffset?: number;
+	private journalPoison?: unknown;
 	private journalFileName?: string;
 	private activeManifest?: ActiveManifest;
 	private manifestLoaded = false;
@@ -300,6 +407,9 @@ class OpfsPersistenceBackend implements RustAnyStorePersistenceBackend {
 		record: Uint8Array,
 		durability: PersistenceDurability,
 	): Promise<void> {
+		if (this.journalPoison !== undefined) {
+			throw this.journalPoison;
+		}
 		await this.ensureManifestLoaded();
 		const journalFile = this.activeManifest?.journal ?? JOURNAL_FILE_NAME;
 		if (this.journalHandle && this.journalFileName !== journalFile) {
@@ -314,10 +424,64 @@ class OpfsPersistenceBackend implements RustAnyStorePersistenceBackend {
 			this.journalOffset ??= this.journalHandle.getSize();
 		}
 		const offset = this.journalOffset ?? 0;
-		this.journalHandle.write(record, { at: offset });
-		this.journalOffset = offset + record.byteLength;
-		if (durability === "strict") {
+		let written = 0;
+		try {
+			while (written < record.byteLength) {
+				const remaining = record.byteLength - written;
+				written += validateWriteProgress(
+					this.journalHandle.write(record.subarray(written), {
+						at: offset + written,
+					}),
+					remaining,
+					"OPFS",
+				);
+			}
+			if (durability === "strict") {
+				this.journalHandle.flush();
+			}
+			this.journalOffset = offset + written;
+		} catch (error) {
+			try {
+				this.journalHandle.truncate(offset);
+				this.journalHandle.flush();
+				this.journalOffset = offset;
+			} catch (rollbackError) {
+				this.journalPoison = new AggregateError(
+					[error, rollbackError],
+					"OPFS persistence journal rollback failed; reopen is required",
+				);
+				throw this.journalPoison;
+			}
+			throw error;
+		}
+	}
+
+	async truncateJournal(byteLength: number): Promise<void> {
+		if (!Number.isSafeInteger(byteLength) || byteLength < 0) {
+			throw new Error(`Invalid OPFS persistence journal length: ${byteLength}`);
+		}
+		if (this.journalPoison !== undefined) {
+			throw this.journalPoison;
+		}
+		await this.ensureManifestLoaded();
+		const journalFile = this.activeManifest?.journal ?? JOURNAL_FILE_NAME;
+		if (this.journalHandle && this.journalFileName !== journalFile) {
+			await this.close();
+		}
+		if (!this.journalHandle) {
+			const file = await this.directory.getFileHandle(journalFile, {
+				create: true,
+			});
+			this.journalHandle = await createSyncAccessHandle(file);
+			this.journalFileName = journalFile;
+		}
+		try {
+			this.journalHandle.truncate(byteLength);
 			this.journalHandle.flush();
+			this.journalOffset = byteLength;
+		} catch (error) {
+			this.journalPoison = error;
+			throw error;
 		}
 	}
 
@@ -351,6 +515,8 @@ class OpfsPersistenceBackend implements RustAnyStorePersistenceBackend {
 	}
 
 	async close(): Promise<void> {
+		this.journalOffset = undefined;
+		this.journalPoison = undefined;
 		if (!this.journalHandle) {
 			return;
 		}
@@ -360,7 +526,9 @@ class OpfsPersistenceBackend implements RustAnyStorePersistenceBackend {
 		handle.close();
 	}
 
-	private async readFileIfExists(name: string): Promise<Uint8Array | undefined> {
+	private async readFileIfExists(
+		name: string,
+	): Promise<Uint8Array | undefined> {
 		try {
 			const file = await this.directory.getFileHandle(name);
 			const handle = await createSyncAccessHandle(file);
@@ -385,17 +553,26 @@ class OpfsPersistenceBackend implements RustAnyStorePersistenceBackend {
 		flush: boolean,
 	): Promise<void> {
 		const file = await this.directory.getFileHandle(name, { create: true });
-		await this.writeHandle(file, bytes, flush);
+		await this.writeHandle(file, bytes, flush, name);
 	}
 
 	private async writeHandle(
 		file: FileSystemFileHandle,
 		bytes: Uint8Array,
 		flush: boolean,
+		target: string,
 	): Promise<void> {
 		const handle = await createSyncAccessHandle(file);
 		try {
-			handle.write(bytes, { at: 0 });
+			let written = 0;
+			while (written < bytes.byteLength) {
+				const remaining = bytes.byteLength - written;
+				written += validateWriteProgress(
+					handle.write(bytes.subarray(written), { at: written }),
+					remaining,
+					`OPFS persistence file ${target}`,
+				);
+			}
 			handle.truncate(bytes.byteLength);
 			if (flush) {
 				handle.flush();
@@ -464,7 +641,10 @@ class OpfsPersistenceBackend implements RustAnyStorePersistenceBackend {
 		]);
 	}
 
-	private async removeEntryIfExists(name: string, recursive = false): Promise<void> {
+	private async removeEntryIfExists(
+		name: string,
+		recursive = false,
+	): Promise<void> {
 		try {
 			await this.directory.removeEntry(name, { recursive });
 		} catch (error) {
@@ -527,5 +707,7 @@ export const createPersistenceBackend = async (
 	if (isNodeRuntime()) {
 		return new NodePersistenceBackend(directory, level);
 	}
-	return new OpfsPersistenceBackend(await getOpfsLevelDirectory(directory, level));
+	return new OpfsPersistenceBackend(
+		await getOpfsLevelDirectory(directory, level),
+	);
 };

--- a/packages/utils/any-store/rust/test/index.spec.ts
+++ b/packages/utils/any-store/rust/test/index.spec.ts
@@ -3,9 +3,15 @@ import { expect } from "chai";
 import { mkdtemp, readFile, rm, stat, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
+import sinon from "sinon";
 import { createStore } from "../src/index.js";
+import {
+	NodePersistenceBackend,
+	OpfsPersistenceBackend,
+} from "../src/persistence.js";
 
-const tempDirectory = async () => mkdtemp(join(tmpdir(), "peerbit-any-store-rust-"));
+const tempDirectory = async () =>
+	mkdtemp(join(tmpdir(), "peerbit-any-store-rust-"));
 
 type StoreInternals = {
 	persistence: {
@@ -19,6 +25,87 @@ type StoreInternals = {
 
 const internalsOf = (store: unknown): StoreInternals => store as StoreInternals;
 
+class ShortWriteOpfsDirectory {
+	readonly files = new Map<string, { bytes: Uint8Array }>();
+	maxWriteBytes = Number.POSITIVE_INFINITY;
+	stallWrites = false;
+	stallAfterWrites: number | undefined;
+	truncateFailure: Error | undefined;
+
+	async getFileHandle(
+		name: string,
+		options?: { create?: boolean },
+	): Promise<FileSystemFileHandle> {
+		let file = this.files.get(name);
+		if (!file && options?.create) {
+			file = { bytes: new Uint8Array() };
+			this.files.set(name, file);
+		}
+		if (!file) {
+			const error = new Error(`Missing OPFS test file: ${name}`);
+			error.name = "NotFoundError";
+			throw error;
+		}
+		const directory = this;
+		return {
+			async createSyncAccessHandle() {
+				let closed = false;
+				return {
+					getSize: () => file!.bytes.byteLength,
+					write(source: Uint8Array, { at = 0 }: { at?: number } = {}) {
+						if (closed) {
+							throw new Error("OPFS test handle is closed");
+						}
+						if (directory.stallWrites || directory.stallAfterWrites === 0) {
+							return 0;
+						}
+						if (directory.stallAfterWrites != null) {
+							directory.stallAfterWrites--;
+						}
+						const count = Math.min(source.byteLength, directory.maxWriteBytes);
+						const required = at + count;
+						if (required > file!.bytes.byteLength) {
+							const grown = new Uint8Array(required);
+							grown.set(file!.bytes);
+							file!.bytes = grown;
+						}
+						file!.bytes.set(source.subarray(0, count), at);
+						return count;
+					},
+					read(target: Uint8Array, { at = 0 }: { at?: number } = {}) {
+						const count = Math.min(
+							target.byteLength,
+							Math.max(0, file!.bytes.byteLength - at),
+						);
+						target.set(file!.bytes.subarray(at, at + count));
+						return count;
+					},
+					truncate(size: number) {
+						if (directory.truncateFailure) {
+							throw directory.truncateFailure;
+						}
+						const resized = new Uint8Array(size);
+						resized.set(file!.bytes.subarray(0, size));
+						file!.bytes = resized;
+					},
+					flush() {},
+					close() {
+						closed = true;
+					},
+				} as unknown as FileSystemSyncAccessHandle;
+			},
+		} as FileSystemFileHandle;
+	}
+
+	async removeEntry(name: string): Promise<void> {
+		if (!this.files.delete(name)) {
+			const error = new Error(`Missing OPFS test file: ${name}`);
+			error.name = "NotFoundError";
+			throw error;
+		}
+	}
+}
+
 const collectKeys = async (store: AnyStore): Promise<string[]> => {
 	const keys: string[] = [];
 	for await (const [key] of store.iterator()) {
@@ -31,7 +118,290 @@ describe("@peerbit/any-store-rust", () => {
 	const cleanup: string[] = [];
 
 	afterEach(async () => {
-		await Promise.all(cleanup.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+		await Promise.all(
+			cleanup.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+		);
+	});
+
+	it("completes short Node WAL writes before acknowledging and reopens exactly", async () => {
+		const directory = await tempDirectory();
+		cleanup.push(directory);
+		const first = new Uint8Array([1]);
+		const second = new Uint8Array([2, 3, 4, 5, 6]);
+		const backend = new NodePersistenceBackend(directory, []);
+		await backend.appendJournal(first, "strict");
+		const handle = (
+			backend as unknown as {
+				journalHandle: {
+					write: (...args: any[]) => Promise<{ bytesWritten: number }>;
+				};
+			}
+		).journalHandle;
+		const write = handle.write.bind(handle);
+		handle.write = (buffer, offset, length, position) =>
+			write(buffer, offset, Math.min(length, 2), position);
+
+		await backend.appendJournal(second, "strict");
+		await backend.close();
+
+		const reopened = new NodePersistenceBackend(directory, []);
+		expect(await reopened.readJournal()).to.deep.equal(
+			new Uint8Array([...first, ...second]),
+		);
+		await reopened.close();
+	});
+
+	it("rejects a Node WAL write that makes no progress", async () => {
+		const directory = await tempDirectory();
+		cleanup.push(directory);
+		const backend = new NodePersistenceBackend(directory, []);
+		await backend.appendJournal(new Uint8Array([1]), "strict");
+		const handle = (
+			backend as unknown as {
+				journalHandle: {
+					write: (...args: any[]) => Promise<{ bytesWritten: number }>;
+				};
+			}
+		).journalHandle;
+		handle.write = async () => ({ bytesWritten: 0 });
+
+		let thrown: unknown;
+		try {
+			await backend.appendJournal(new Uint8Array([2]), "strict");
+		} catch (error) {
+			thrown = error;
+		}
+		expect(thrown).to.be.instanceOf(Error);
+		expect((thrown as Error).message).to.contain("invalid progress");
+		await backend.close();
+	});
+
+	it("rolls back a partial Node WAL write before a later mutation and reopen", async () => {
+		const directory = await tempDirectory();
+		cleanup.push(directory);
+		const backend = new NodePersistenceBackend(directory, []);
+		const first = new Uint8Array([1, 2, 3]);
+		const rejected = new Uint8Array([4, 5, 6, 7]);
+		const later = new Uint8Array([8, 9]);
+		await backend.appendJournal(first, "strict");
+		const handle = (
+			backend as unknown as {
+				journalHandle: {
+					write: (...args: any[]) => Promise<{ bytesWritten: number }>;
+				};
+			}
+		).journalHandle;
+		const write = handle.write.bind(handle);
+		let call = 0;
+		handle.write = (buffer, offset, length, position) => {
+			call++;
+			return call === 1
+				? write(buffer, offset, Math.min(length, 2), position)
+				: Promise.resolve({ bytesWritten: 0 });
+		};
+
+		let failure: unknown;
+		try {
+			await backend.appendJournal(rejected, "strict");
+		} catch (error) {
+			failure = error;
+		}
+		expect(failure).to.be.instanceOf(Error);
+		handle.write = write;
+		await backend.appendJournal(later, "strict");
+		await backend.close();
+
+		const reopened = new NodePersistenceBackend(directory, []);
+		expect(await reopened.readJournal()).to.deep.equal(
+			new Uint8Array([...first, ...later]),
+		);
+		await reopened.close();
+	});
+
+	it("poisons the Node WAL backend when rollback cannot be made durable", async () => {
+		const directory = await tempDirectory();
+		cleanup.push(directory);
+		const backend = new NodePersistenceBackend(directory, []);
+		await backend.appendJournal(new Uint8Array([1, 2, 3]), "strict");
+		const handle = (
+			backend as unknown as {
+				journalHandle: {
+					write: (...args: any[]) => Promise<{ bytesWritten: number }>;
+					truncate: (length?: number) => Promise<void>;
+				};
+			}
+		).journalHandle;
+		const write = handle.write.bind(handle);
+		const truncate = handle.truncate.bind(handle);
+		let call = 0;
+		handle.write = (buffer, offset, length, position) => {
+			call++;
+			return call === 1
+				? write(buffer, offset, Math.min(length, 2), position)
+				: Promise.resolve({ bytesWritten: 0 });
+		};
+		const rollbackFailure = new Error("injected Node truncate failure");
+		handle.truncate = async () => {
+			throw rollbackFailure;
+		};
+
+		let poison: unknown;
+		try {
+			await backend.appendJournal(new Uint8Array([4, 5, 6]), "strict");
+		} catch (error) {
+			poison = error;
+		}
+		expect(poison).to.be.instanceOf(AggregateError);
+		expect((poison as Error).message).to.contain("reopen is required");
+
+		handle.write = write;
+		handle.truncate = truncate;
+		let repeated: unknown;
+		try {
+			await backend.appendJournal(new Uint8Array([7]), "strict");
+		} catch (error) {
+			repeated = error;
+		}
+		expect(repeated).to.equal(poison);
+		await backend.close();
+	});
+
+	it("completes short OPFS WAL writes before acknowledging and reopens exactly", async () => {
+		const directory = new ShortWriteOpfsDirectory();
+		directory.maxWriteBytes = 2;
+		const first = new Uint8Array([1, 2, 3]);
+		const second = new Uint8Array([4, 5, 6, 7, 8]);
+		const backend = new OpfsPersistenceBackend(
+			directory as unknown as FileSystemDirectoryHandle,
+		);
+		await backend.appendJournal(first, "strict");
+		await backend.appendJournal(second, "strict");
+		await backend.close();
+
+		const reopened = new OpfsPersistenceBackend(
+			directory as unknown as FileSystemDirectoryHandle,
+		);
+		expect(await reopened.readJournal()).to.deep.equal(
+			new Uint8Array([...first, ...second]),
+		);
+		await reopened.close();
+	});
+
+	it("rejects an OPFS WAL write that makes no progress", async () => {
+		const directory = new ShortWriteOpfsDirectory();
+		directory.stallWrites = true;
+		const backend = new OpfsPersistenceBackend(
+			directory as unknown as FileSystemDirectoryHandle,
+		);
+
+		let thrown: unknown;
+		try {
+			await backend.appendJournal(new Uint8Array([1]), "strict");
+		} catch (error) {
+			thrown = error;
+		}
+		expect(thrown).to.be.instanceOf(Error);
+		expect((thrown as Error).message).to.contain("invalid progress");
+		await backend.close();
+	});
+
+	it("rolls back a partial OPFS WAL write before a later mutation and reopen", async () => {
+		const directory = new ShortWriteOpfsDirectory();
+		const backend = new OpfsPersistenceBackend(
+			directory as unknown as FileSystemDirectoryHandle,
+		);
+		const first = new Uint8Array([1, 2, 3]);
+		const rejected = new Uint8Array([4, 5, 6, 7]);
+		const later = new Uint8Array([8, 9]);
+		await backend.appendJournal(first, "strict");
+		directory.maxWriteBytes = 2;
+		directory.stallAfterWrites = 1;
+
+		let failure: unknown;
+		try {
+			await backend.appendJournal(rejected, "strict");
+		} catch (error) {
+			failure = error;
+		}
+		expect(failure).to.be.instanceOf(Error);
+		directory.stallAfterWrites = undefined;
+		directory.maxWriteBytes = Number.POSITIVE_INFINITY;
+		await backend.appendJournal(later, "strict");
+		await backend.close();
+
+		const reopened = new OpfsPersistenceBackend(
+			directory as unknown as FileSystemDirectoryHandle,
+		);
+		expect(await reopened.readJournal()).to.deep.equal(
+			new Uint8Array([...first, ...later]),
+		);
+		await reopened.close();
+	});
+
+	it("poisons the OPFS WAL backend when rollback cannot be made durable", async () => {
+		const directory = new ShortWriteOpfsDirectory();
+		const backend = new OpfsPersistenceBackend(
+			directory as unknown as FileSystemDirectoryHandle,
+		);
+		await backend.appendJournal(new Uint8Array([1, 2, 3]), "strict");
+		directory.maxWriteBytes = 2;
+		directory.stallAfterWrites = 1;
+		directory.truncateFailure = new Error("injected OPFS truncate failure");
+
+		let poison: unknown;
+		try {
+			await backend.appendJournal(new Uint8Array([4, 5, 6]), "strict");
+		} catch (error) {
+			poison = error;
+		}
+		expect(poison).to.be.instanceOf(AggregateError);
+		expect((poison as Error).message).to.contain("reopen is required");
+
+		directory.stallAfterWrites = undefined;
+		directory.truncateFailure = undefined;
+		directory.maxWriteBytes = Number.POSITIVE_INFINITY;
+		let repeated: unknown;
+		try {
+			await backend.appendJournal(new Uint8Array([7]), "strict");
+		} catch (error) {
+			repeated = error;
+		}
+		expect(repeated).to.equal(poison);
+		await backend.close();
+	});
+
+	it("completes short OPFS checkpoint writes before publishing the manifest", async () => {
+		const directory = new ShortWriteOpfsDirectory();
+		directory.maxWriteBytes = 2;
+		const snapshot = new Uint8Array([1, 2, 3, 4, 5, 6, 7]);
+		const backend = new OpfsPersistenceBackend(
+			directory as unknown as FileSystemDirectoryHandle,
+		);
+		await backend.writeSnapshot(snapshot);
+		await backend.close();
+
+		const reopened = new OpfsPersistenceBackend(
+			directory as unknown as FileSystemDirectoryHandle,
+		);
+		expect(await reopened.readSnapshot()).to.deep.equal(snapshot);
+		expect(await reopened.readJournal()).to.deep.equal(new Uint8Array());
+		await reopened.close();
+	});
+
+	it("rejects an OPFS checkpoint write that makes no progress", async () => {
+		const directory = new ShortWriteOpfsDirectory();
+		directory.stallWrites = true;
+		const backend = new OpfsPersistenceBackend(
+			directory as unknown as FileSystemDirectoryHandle,
+		);
+
+		const failure = await backend.writeSnapshot(new Uint8Array([1])).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(failure).to.be.instanceOf(Error);
+		expect((failure as Error).message).to.contain("invalid progress");
+		await backend.close();
 	});
 
 	it("stores transient values", async () => {
@@ -53,10 +423,12 @@ describe("@peerbit/any-store-rust", () => {
 	it("applies batched mutations", async () => {
 		const store = createStore();
 		await store.open();
-		expect(store.putMany([
-			["a", new Uint8Array([1])],
-			["b", new Uint8Array([2, 3])],
-		])).to.equal(undefined);
+		expect(
+			store.putMany([
+				["a", new Uint8Array([1])],
+				["b", new Uint8Array([2, 3])],
+			]),
+		).to.equal(undefined);
 
 		expect(await store.getMany(["a", "b", "c"])).to.deep.equal([
 			new Uint8Array([1]),
@@ -148,9 +520,9 @@ describe("@peerbit/any-store-rust", () => {
 		expect(store.putImmutable("a", new Uint8Array([1]))).to.be.instanceOf(
 			Promise,
 		);
-		expect(store.putManyImmutable([["b", new Uint8Array([2])]])).to.be.instanceOf(
-			Promise,
-		);
+		expect(
+			store.putManyImmutable([["b", new Uint8Array([2])]]),
+		).to.be.instanceOf(Promise);
 		await store.close();
 	});
 
@@ -269,8 +641,8 @@ describe("@peerbit/any-store-rust", () => {
 			sublevelOptions.compactOnCloseMinJournalBytes,
 		);
 
-		// Tear the second record. Reopen must retain the complete first record,
-		// discard the incomplete tail, and checkpoint before accepting new writes.
+		// Tear the second record. Reopen must retain the complete first record and
+		// durably truncate the incomplete tail before accepting new writes.
 		await writeFile(journalPath, journal.subarray(0, journal.byteLength - 3));
 		root = createStore(directory);
 		await root.open();
@@ -307,6 +679,186 @@ describe("@peerbit/any-store-rust", () => {
 		expect(
 			(await readFile(join(sublevelDirectory, "store.wal"))).byteLength,
 		).to.equal(0);
+	});
+
+	it("never checkpoints a strict store even when close compaction is forced", async () => {
+		const directory = await tempDirectory();
+		cleanup.push(directory);
+
+		const store = createStore(directory, {
+			durability: "strict",
+			compactOnClose: true,
+			compactOnCloseMinJournalBytes: 1,
+		});
+		await store.open();
+		await store.put("a", new Uint8Array([1]));
+		await store.close();
+
+		const snapshotExists = await stat(join(directory, "store.bin"))
+			.then(() => true)
+			.catch(() => false);
+		expect(snapshotExists).to.equal(false);
+		expect(
+			(await readFile(join(directory, "store.wal"))).byteLength,
+		).to.be.greaterThan(0);
+	});
+
+	it("survives two torn-tail crashes without checkpointing a strict store", async () => {
+		const directory = await tempDirectory();
+		cleanup.push(directory);
+		const journalPath = join(directory, "store.wal");
+		const options = {
+			durability: "strict" as const,
+			compactOnClose: true,
+			compactOnCloseMinJournalBytes: 1,
+		};
+
+		let store = createStore(directory, options);
+		await store.open();
+		await store.put("a", new Uint8Array([1]));
+		await store.put("b", new Uint8Array([2]));
+		await store.close();
+
+		let journal = await readFile(journalPath);
+		await writeFile(journalPath, journal.subarray(0, journal.byteLength - 3));
+		store = createStore(directory, options);
+		await store.open();
+		expect(await store.get("a")).to.deep.equal(new Uint8Array([1]));
+		expect(await store.get("b")).to.equal(undefined);
+		await store.put("c", new Uint8Array([3]));
+		await store.close();
+
+		expect(
+			await stat(join(directory, "store.bin"))
+				.then(() => true)
+				.catch(() => false),
+		).to.equal(false);
+		journal = await readFile(journalPath);
+		const tornAgain = new Uint8Array(journal.byteLength + 3);
+		tornAgain.set(journal);
+		// A recoverable EOF tail must be a structural prefix of the next frame,
+		// not arbitrary corruption that happens to be shorter than the magic.
+		tornAgain.set(new TextEncoder().encode("PBA"), journal.byteLength);
+		await writeFile(journalPath, tornAgain);
+
+		store = createStore(directory, options);
+		await store.open();
+		expect(await store.get("a")).to.deep.equal(new Uint8Array([1]));
+		expect(await store.get("b")).to.equal(undefined);
+		expect(await store.get("c")).to.deep.equal(new Uint8Array([3]));
+		await store.close();
+		expect((await readFile(journalPath)).byteLength).to.equal(
+			journal.byteLength,
+		);
+	});
+
+	it("rejects a complete checksum-bad strict WAL without rewriting it", async () => {
+		const directory = await tempDirectory();
+		cleanup.push(directory);
+		const journalPath = join(directory, "store.wal");
+		const snapshotPath = join(directory, "store.bin");
+		const options = {
+			durability: "strict" as const,
+			compactOnClose: false,
+		};
+
+		const writer = createStore(directory, options);
+		await writer.open();
+		await writer.put("a", new Uint8Array([1]));
+		await writer.put("b", new Uint8Array([2, 3]));
+		await writer.close();
+
+		const validJournal = new Uint8Array(await readFile(journalPath));
+		const corruptJournal = new Uint8Array(validJournal);
+		corruptJournal[corruptJournal.byteLength - 1] ^= 0xff;
+		await writeFile(journalPath, corruptJournal);
+
+		const store = createStore(directory, options);
+		const failure = await store.open().then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(String(failure)).to.contain("journal checksum mismatch");
+		expect(store.status()).to.equal("closed");
+		expect(new Uint8Array(await readFile(journalPath))).to.deep.equal(
+			corruptJournal,
+		);
+		expect(
+			await stat(snapshotPath)
+				.then(() => true)
+				.catch(() => false),
+		).to.equal(false);
+
+		await writeFile(journalPath, validJournal);
+		await store.open();
+		expect(await store.get("a")).to.deep.equal(new Uint8Array([1]));
+		expect(await store.get("b")).to.deep.equal(new Uint8Array([2, 3]));
+		await store.close();
+	});
+
+	it("closes a failed replay backend, aggregates close failure, and retries", async () => {
+		const directory = await tempDirectory();
+		cleanup.push(directory);
+		const journalPath = join(directory, "store.wal");
+		const options = {
+			durability: "strict" as const,
+			compactOnClose: false,
+		};
+
+		const writer = createStore(directory, options);
+		await writer.open();
+		await writer.put("kept", new Uint8Array([1]));
+		await writer.put("torn", new Uint8Array([2]));
+		await writer.close();
+		const journal = await readFile(journalPath);
+		await writeFile(journalPath, journal.subarray(0, journal.byteLength - 3));
+
+		const truncateFailure = new Error("injected replay truncate failure");
+		const closeFailure = new Error("injected replay backend close failure");
+		const originalTruncate = NodePersistenceBackend.prototype.truncateJournal;
+		const originalClose = NodePersistenceBackend.prototype.close;
+		const truncate = sinon
+			.stub(NodePersistenceBackend.prototype, "truncateJournal")
+			.callsFake(async function (this: NodePersistenceBackend) {
+				// Open the WAL handle without changing its torn bytes so cleanup has a
+				// real resource to release and the retry must still repair the tail.
+				await this.appendJournal(new Uint8Array(), "strict");
+				throw truncateFailure;
+			});
+		const close = sinon
+			.stub(NodePersistenceBackend.prototype, "close")
+			.callsFake(async function (this: NodePersistenceBackend) {
+				await originalClose.call(this);
+				throw closeFailure;
+			});
+		const store = createStore(directory, options);
+		try {
+			const failure = await store.open().then(
+				() => undefined,
+				(error: unknown) => error,
+			);
+			expect(failure).to.be.instanceOf(AggregateError);
+			expect((failure as AggregateError).errors).to.deep.equal([
+				truncateFailure,
+				closeFailure,
+			]);
+			expect(truncate.calledOnce).to.equal(true);
+			expect(close.calledOnce).to.equal(true);
+			expect(store.status()).to.equal("closed");
+		} finally {
+			truncate.restore();
+			close.restore();
+		}
+
+		// Reopening the same object proves the failed generation did not retain
+		// the poisoned backend or its file handle.
+		expect(NodePersistenceBackend.prototype.truncateJournal).to.equal(
+			originalTruncate,
+		);
+		await store.open();
+		expect(await store.get("kept")).to.deep.equal(new Uint8Array([1]));
+		expect(await store.get("torn")).to.equal(undefined);
+		await store.close();
 	});
 
 	it("recovers from a torn journal tail and keeps later writes", async () => {
@@ -369,7 +921,7 @@ describe("@peerbit/any-store-rust", () => {
 		await store.close();
 	});
 
-	it("surfaces a failed journal append on the next mutation and clears it once reported", async () => {
+	it("keeps a failed journal append poisoned until close and reopen", async () => {
 		const directory = await tempDirectory();
 		cleanup.push(directory);
 
@@ -403,11 +955,95 @@ describe("@peerbit/any-store-rust", () => {
 		}
 		expect(reported).to.equal(failure);
 
-		// reported once: the store recovers and keeps serving writes
+		let repeated: unknown;
+		try {
+			await store.put("c", new Uint8Array([3]));
+		} catch (error) {
+			repeated = error;
+		}
+		expect(repeated).to.equal(failure);
+		let closeFailure: unknown;
+		try {
+			await store.close();
+		} catch (error) {
+			closeFailure = error;
+		}
+		expect(closeFailure).to.equal(failure);
+		expect(store.status()).to.equal("closed");
+
+		await store.open();
 		await store.put("c", new Uint8Array([3]));
 		expect(await store.get("c")).to.deep.equal(new Uint8Array([3]));
 		await store.close();
-		expect(store.status()).to.equal("closed");
+	});
+
+	it("rejects strict mutations queued behind the sticky first journal error", async () => {
+		const directory = await tempDirectory();
+		cleanup.push(directory);
+
+		const store = createStore(directory, {
+			durability: "strict",
+			compactOnClose: false,
+		});
+		await store.open();
+		await store.put("kept", new Uint8Array([1]));
+		const internals = internalsOf(store);
+		await internals.journalQueue;
+
+		const failure = new Error("strict first journal append failed");
+		let markStarted!: () => void;
+		const started = new Promise<void>((resolve) => {
+			markStarted = resolve;
+		});
+		let releaseFailure!: () => void;
+		const failureGate = new Promise<void>((resolve) => {
+			releaseFailure = resolve;
+		});
+		let appendCalls = 0;
+		internals.persistence.appendJournal = async () => {
+			appendCalls++;
+			markStarted();
+			await failureGate;
+			throw failure;
+		};
+
+		const first = Promise.resolve(store.put("failed", new Uint8Array([2])));
+		await started;
+		const queuedBatch = Promise.resolve(
+			store.putMany([
+				["queued-a", new Uint8Array([3])],
+				["queued-b", new Uint8Array([4])],
+			]),
+		);
+		const queuedDelete = Promise.resolve(store.del("kept"));
+		releaseFailure();
+
+		const results = await Promise.allSettled([
+			first,
+			queuedBatch,
+			queuedDelete,
+		]);
+		for (const result of results) {
+			expect(result.status).to.equal("rejected");
+			expect((result as PromiseRejectedResult).reason).to.equal(failure);
+		}
+		expect(appendCalls).to.equal(1);
+		expect(await store.get("failed")).to.equal(undefined);
+		expect(await store.get("queued-a")).to.equal(undefined);
+		expect(await store.get("queued-b")).to.equal(undefined);
+		expect(await store.get("kept")).to.deep.equal(new Uint8Array([1]));
+
+		const closeFailure = await store.close().then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(closeFailure).to.equal(failure);
+		await store.open();
+		expect(await store.get("failed")).to.equal(undefined);
+		expect(await store.get("queued-a")).to.equal(undefined);
+		expect(await store.get("queued-b")).to.equal(undefined);
+		expect(await store.get("kept")).to.deep.equal(new Uint8Array([1]));
+		await store.close();
 	});
 
 	it("reaches closed status when the journal flush fails during close", async () => {

--- a/packages/utils/indexer/interface/src/index-engine.ts
+++ b/packages/utils/indexer/interface/src/index-engine.ts
@@ -199,6 +199,10 @@ export interface Indices {
 	): MaybePromise<Index<T, NestedType>>;
 	scope(name: string): MaybePromise<Indices>;
 	persisted(): MaybePromise<boolean>;
+	/** Whether stop/start preserves every indexed row even for a non-persistent
+	 * backend. When absent, persistent backends are treated as preserving and
+	 * unknown non-persistent backends as destructive. */
+	preservesDataOnStop?(): MaybePromise<boolean>;
 	start(): MaybePromise<void>;
 	stop(): MaybePromise<void>;
 	drop(): MaybePromise<void>;

--- a/packages/utils/indexer/rust/src/index.ts
+++ b/packages/utils/indexer/rust/src/index.ts
@@ -5386,6 +5386,10 @@ export class RustIndices implements types.Indices {
 		return Boolean(this.directory);
 	}
 
+	preservesDataOnStop(): boolean {
+		return true;
+	}
+
 	async start(): Promise<void> {
 		this.closed = false;
 		for (const scope of this.scopes.values()) {

--- a/packages/utils/indexer/simple/src/index.ts
+++ b/packages/utils/indexer/simple/src/index.ts
@@ -663,6 +663,10 @@ export class HashmapIndices implements types.Indices {
 		return false;
 	}
 
+	preservesDataOnStop(): boolean {
+		return true;
+	}
+
 	async start(): Promise<void> {
 		this.closed = false;
 		for (const scope of this.scopes.values()) {

--- a/packages/utils/indexer/sqlite3/src/engine.ts
+++ b/packages/utils/indexer/sqlite3/src/engine.ts
@@ -1382,6 +1382,10 @@ export class SQLiteIndices implements types.Indices {
 		return this.properties.directory != null;
 	}
 
+	preservesDataOnStop(): boolean {
+		return this.properties.directory != null;
+	}
+
 	async start(): Promise<void> {
 		this.closed = false;
 

--- a/packages/utils/native-backbone/src/index.ts
+++ b/packages/utils/native-backbone/src/index.ts
@@ -1281,10 +1281,10 @@ type NativePeerbitBackboneHandle = {
 		documentProjectionEncodedDocument: Uint8Array,
 		documentProjectionSigner: Uint8Array | undefined,
 	) => unknown[];
-		prepare_plain_committed_no_next_storage_append_document_index_compact_transaction: (
-			wallTime: bigint,
-			logical: number,
-			gid: string,
+	prepare_plain_committed_no_next_storage_append_document_index_compact_transaction: (
+		wallTime: bigint,
+		logical: number,
+		gid: string,
 		type: number,
 		metaData: Uint8Array | undefined,
 		payloadData: Uint8Array,
@@ -1297,31 +1297,31 @@ type NativePeerbitBackboneHandle = {
 		documentValuePrefixBytes: Uint8Array,
 		documentExistingCreated: string,
 		documentByteElementIndexLimit: number,
-			documentDeleteTrimmedHeads: boolean,
-			trimLengthTo: number | undefined,
-		) => unknown[];
-		prepare_plain_committed_no_next_storage_append_document_index_compact_plain_put_payload_transaction?: (
-			wallTime: bigint,
-			logical: number,
-			gid: string,
-			type: number,
-			metaData: Uint8Array | undefined,
-			payloadData: Uint8Array,
-			replicas: number,
-			roleAgeMs: number,
-			now: string,
-			selfHash: string,
-			selfReplicating: boolean,
-			documentKey: string,
-			documentExistingCreated: string,
-			documentByteElementIndexLimit: number,
-			documentDeleteTrimmedHeads: boolean,
-			trimLengthTo: number | undefined,
-		) => unknown[];
-		prepare_plain_committed_no_next_storage_append_document_index_compact_batch_transaction?: (
-			wallTimes: BigUint64Array,
-			logicals: Uint32Array,
-			gids: string[],
+		documentDeleteTrimmedHeads: boolean,
+		trimLengthTo: number | undefined,
+	) => unknown[];
+	prepare_plain_committed_no_next_storage_append_document_index_compact_plain_put_payload_transaction?: (
+		wallTime: bigint,
+		logical: number,
+		gid: string,
+		type: number,
+		metaData: Uint8Array | undefined,
+		payloadData: Uint8Array,
+		replicas: number,
+		roleAgeMs: number,
+		now: string,
+		selfHash: string,
+		selfReplicating: boolean,
+		documentKey: string,
+		documentExistingCreated: string,
+		documentByteElementIndexLimit: number,
+		documentDeleteTrimmedHeads: boolean,
+		trimLengthTo: number | undefined,
+	) => unknown[];
+	prepare_plain_committed_no_next_storage_append_document_index_compact_batch_transaction?: (
+		wallTimes: BigUint64Array,
+		logicals: Uint32Array,
+		gids: string[],
 		type: number,
 		metaDatas: Array<Uint8Array | undefined>,
 		payloadDatas: Uint8Array[],
@@ -1334,27 +1334,27 @@ type NativePeerbitBackboneHandle = {
 		documentValuePrefixBytes: Uint8Array[],
 		documentExistingCreated: string[],
 		documentByteElementIndexLimit: number,
-			documentDeleteTrimmedHeads: boolean,
-			trimLengthTo: number | undefined,
-		) => unknown[][];
-		prepare_plain_committed_no_next_storage_append_document_index_compact_plain_put_payload_batch_transaction?: (
-			wallTimes: BigUint64Array,
-			logicals: Uint32Array,
-			gids: string[],
-			type: number,
-			metaDatas: Array<Uint8Array | undefined>,
-			payloadDatas: Uint8Array[],
-			replicas: number,
-			roleAgeMs: number,
-			now: string,
-			selfHash: string,
-			selfReplicating: boolean,
-			documentKeys: string[],
-			documentExistingCreated: string[],
-			documentByteElementIndexLimit: number,
-			documentDeleteTrimmedHeads: boolean,
-			trimLengthTo: number | undefined,
-		) => unknown[][];
+		documentDeleteTrimmedHeads: boolean,
+		trimLengthTo: number | undefined,
+	) => unknown[][];
+	prepare_plain_committed_no_next_storage_append_document_index_compact_plain_put_payload_batch_transaction?: (
+		wallTimes: BigUint64Array,
+		logicals: Uint32Array,
+		gids: string[],
+		type: number,
+		metaDatas: Array<Uint8Array | undefined>,
+		payloadDatas: Uint8Array[],
+		replicas: number,
+		roleAgeMs: number,
+		now: string,
+		selfHash: string,
+		selfReplicating: boolean,
+		documentKeys: string[],
+		documentExistingCreated: string[],
+		documentByteElementIndexLimit: number,
+		documentDeleteTrimmedHeads: boolean,
+		trimLengthTo: number | undefined,
+	) => unknown[][];
 	prepare_plain_committed_no_next_storage_append_document_index_cached_plan_compact_batch_transaction?: (
 		wallTimes: BigUint64Array,
 		logicals: Uint32Array,
@@ -1591,8 +1591,8 @@ type NativePeerbitBackboneHandle = {
 		documentProjectionSigner: Uint8Array | undefined,
 		trimLengthTo: number,
 	) => unknown[];
-		prepare_plain_committed_storage_append_transaction: (
-			wallTime: bigint,
+	prepare_plain_committed_storage_append_transaction: (
+		wallTime: bigint,
 		logical: number,
 		gid: string,
 		next: string[],
@@ -1603,25 +1603,25 @@ type NativePeerbitBackboneHandle = {
 		roleAgeMs: number,
 		now: string,
 		selfHash: string,
-			selfReplicating: boolean,
-			resolveTrimmedEntries: boolean,
-		) => unknown[];
-		prepare_plain_committed_storage_append_document_delete_transaction: (
-			wallTime: bigint,
-			logical: number,
-			gid: string,
-			next: string[],
-			type: number,
-			metaData: Uint8Array | undefined,
-			payloadData: Uint8Array,
-			replicas: number,
-			roleAgeMs: number,
-			now: string,
-			selfHash: string,
-			selfReplicating: boolean,
-			resolveTrimmedEntries: boolean,
-			documentKey: string,
-		) => unknown[];
+		selfReplicating: boolean,
+		resolveTrimmedEntries: boolean,
+	) => unknown[];
+	prepare_plain_committed_storage_append_document_delete_transaction: (
+		wallTime: bigint,
+		logical: number,
+		gid: string,
+		next: string[],
+		type: number,
+		metaData: Uint8Array | undefined,
+		payloadData: Uint8Array,
+		replicas: number,
+		roleAgeMs: number,
+		now: string,
+		selfHash: string,
+		selfReplicating: boolean,
+		resolveTrimmedEntries: boolean,
+		documentKey: string,
+	) => unknown[];
 	prepare_plain_committed_storage_append_document_index_transaction: (
 		wallTime: bigint,
 		logical: number,
@@ -1671,10 +1671,10 @@ type NativePeerbitBackboneHandle = {
 		documentProjectionSigner: Uint8Array | undefined,
 		trimLengthTo: number | undefined,
 	) => unknown[];
-		prepare_plain_committed_storage_append_document_index_latest_required_previous_signer_transaction?: (
-			wallTime: bigint,
-			logical: number,
-			gid: string,
+	prepare_plain_committed_storage_append_document_index_latest_required_previous_signer_transaction?: (
+		wallTime: bigint,
+		logical: number,
+		gid: string,
 		type: number,
 		metaData: Uint8Array | undefined,
 		payloadData: Uint8Array,
@@ -1693,116 +1693,116 @@ type NativePeerbitBackboneHandle = {
 			| undefined,
 		documentProjectionEncodedDocument: Uint8Array | undefined,
 		documentProjectionSigner: Uint8Array | undefined,
-			requiredPreviousSignerPublicKey: Uint8Array,
-			trimLengthTo: number | undefined,
-		) => unknown[];
-			prepare_plain_committed_storage_append_document_index_latest_compact_transaction?: (
-				wallTime: bigint,
-				logical: number,
-				gid: string,
-			type: number,
-			metaData: Uint8Array | undefined,
-			payloadData: Uint8Array,
-			replicas: number,
-			roleAgeMs: number,
-			now: string,
-			selfHash: string,
-			selfReplicating: boolean,
-			documentKey: string,
-			documentValuePrefixBytes: Uint8Array,
-			documentByteElementIndexLimit: number,
-			documentDeleteTrimmedHeads: boolean,
-			documentProjectionPlan:
-				| NativeBackboneSimpleDocumentProjectionPlan
-				| undefined,
-			documentProjectionEncodedDocument: Uint8Array | undefined,
-				documentProjectionSigner: Uint8Array | undefined,
-				trimLengthTo: number | undefined,
-			) => unknown[];
-			prepare_plain_committed_storage_append_document_index_latest_compact_plain_put_payload_transaction?: (
-				wallTime: bigint,
-				logical: number,
-				gid: string,
-				type: number,
-				metaData: Uint8Array | undefined,
-				payloadData: Uint8Array,
-				replicas: number,
-				roleAgeMs: number,
-				now: string,
-				selfHash: string,
-				selfReplicating: boolean,
-				documentKey: string,
-				documentByteElementIndexLimit: number,
-				documentDeleteTrimmedHeads: boolean,
-				trimLengthTo: number | undefined,
-			) => unknown[];
-			prepare_plain_committed_storage_append_document_index_latest_required_previous_signer_compact_transaction?: (
-				wallTime: bigint,
-				logical: number,
-				gid: string,
-			type: number,
-			metaData: Uint8Array | undefined,
-			payloadData: Uint8Array,
-			replicas: number,
-			roleAgeMs: number,
-			now: string,
-			selfHash: string,
-			selfReplicating: boolean,
-			documentKey: string,
-			documentValuePrefixBytes: Uint8Array,
-			documentByteElementIndexLimit: number,
-			documentDeleteTrimmedHeads: boolean,
-			documentProjectionPlan:
-				| NativeBackboneSimpleDocumentProjectionPlan
-				| undefined,
-			documentProjectionEncodedDocument: Uint8Array | undefined,
-			documentProjectionSigner: Uint8Array | undefined,
-			requiredPreviousSignerPublicKey: Uint8Array,
-			trimLengthTo: number | undefined,
-		) => unknown[];
-		prepare_plain_committed_storage_append_document_index_latest_cached_plan_compact_transaction?: (
-			wallTime: bigint,
-			logical: number,
-			gid: string,
-			type: number,
-			metaData: Uint8Array | undefined,
-			payloadData: Uint8Array,
-			replicas: number,
-			roleAgeMs: number,
-			now: string,
-			selfHash: string,
-			selfReplicating: boolean,
-			documentKey: string,
-			documentByteElementIndexLimit: number,
-			documentDeleteTrimmedHeads: boolean,
-			documentProjectionPlanId: number,
-			documentProjectionEncodedDocument: Uint8Array,
-			documentProjectionSigner: Uint8Array | undefined,
-			trimLengthTo: number | undefined,
-		) => unknown[];
-		prepare_plain_committed_storage_append_document_index_latest_cached_plan_compact_plain_put_payload_transaction?: (
-			wallTime: bigint,
-			logical: number,
-			gid: string,
-			type: number,
-			metaData: Uint8Array | undefined,
-			payloadData: Uint8Array,
-			replicas: number,
-			roleAgeMs: number,
-			now: string,
-			selfHash: string,
-			selfReplicating: boolean,
-			documentKey: string,
-			documentByteElementIndexLimit: number,
-			documentDeleteTrimmedHeads: boolean,
-			documentProjectionPlanId: number,
-			documentProjectionSigner: Uint8Array | undefined,
-			trimLengthTo: number | undefined,
-		) => unknown[];
-		prepare_plain_committed_storage_append_document_index_latest_cached_plan_transaction: (
-			wallTime: bigint,
-			logical: number,
-			gid: string,
+		requiredPreviousSignerPublicKey: Uint8Array,
+		trimLengthTo: number | undefined,
+	) => unknown[];
+	prepare_plain_committed_storage_append_document_index_latest_compact_transaction?: (
+		wallTime: bigint,
+		logical: number,
+		gid: string,
+		type: number,
+		metaData: Uint8Array | undefined,
+		payloadData: Uint8Array,
+		replicas: number,
+		roleAgeMs: number,
+		now: string,
+		selfHash: string,
+		selfReplicating: boolean,
+		documentKey: string,
+		documentValuePrefixBytes: Uint8Array,
+		documentByteElementIndexLimit: number,
+		documentDeleteTrimmedHeads: boolean,
+		documentProjectionPlan:
+			| NativeBackboneSimpleDocumentProjectionPlan
+			| undefined,
+		documentProjectionEncodedDocument: Uint8Array | undefined,
+		documentProjectionSigner: Uint8Array | undefined,
+		trimLengthTo: number | undefined,
+	) => unknown[];
+	prepare_plain_committed_storage_append_document_index_latest_compact_plain_put_payload_transaction?: (
+		wallTime: bigint,
+		logical: number,
+		gid: string,
+		type: number,
+		metaData: Uint8Array | undefined,
+		payloadData: Uint8Array,
+		replicas: number,
+		roleAgeMs: number,
+		now: string,
+		selfHash: string,
+		selfReplicating: boolean,
+		documentKey: string,
+		documentByteElementIndexLimit: number,
+		documentDeleteTrimmedHeads: boolean,
+		trimLengthTo: number | undefined,
+	) => unknown[];
+	prepare_plain_committed_storage_append_document_index_latest_required_previous_signer_compact_transaction?: (
+		wallTime: bigint,
+		logical: number,
+		gid: string,
+		type: number,
+		metaData: Uint8Array | undefined,
+		payloadData: Uint8Array,
+		replicas: number,
+		roleAgeMs: number,
+		now: string,
+		selfHash: string,
+		selfReplicating: boolean,
+		documentKey: string,
+		documentValuePrefixBytes: Uint8Array,
+		documentByteElementIndexLimit: number,
+		documentDeleteTrimmedHeads: boolean,
+		documentProjectionPlan:
+			| NativeBackboneSimpleDocumentProjectionPlan
+			| undefined,
+		documentProjectionEncodedDocument: Uint8Array | undefined,
+		documentProjectionSigner: Uint8Array | undefined,
+		requiredPreviousSignerPublicKey: Uint8Array,
+		trimLengthTo: number | undefined,
+	) => unknown[];
+	prepare_plain_committed_storage_append_document_index_latest_cached_plan_compact_transaction?: (
+		wallTime: bigint,
+		logical: number,
+		gid: string,
+		type: number,
+		metaData: Uint8Array | undefined,
+		payloadData: Uint8Array,
+		replicas: number,
+		roleAgeMs: number,
+		now: string,
+		selfHash: string,
+		selfReplicating: boolean,
+		documentKey: string,
+		documentByteElementIndexLimit: number,
+		documentDeleteTrimmedHeads: boolean,
+		documentProjectionPlanId: number,
+		documentProjectionEncodedDocument: Uint8Array,
+		documentProjectionSigner: Uint8Array | undefined,
+		trimLengthTo: number | undefined,
+	) => unknown[];
+	prepare_plain_committed_storage_append_document_index_latest_cached_plan_compact_plain_put_payload_transaction?: (
+		wallTime: bigint,
+		logical: number,
+		gid: string,
+		type: number,
+		metaData: Uint8Array | undefined,
+		payloadData: Uint8Array,
+		replicas: number,
+		roleAgeMs: number,
+		now: string,
+		selfHash: string,
+		selfReplicating: boolean,
+		documentKey: string,
+		documentByteElementIndexLimit: number,
+		documentDeleteTrimmedHeads: boolean,
+		documentProjectionPlanId: number,
+		documentProjectionSigner: Uint8Array | undefined,
+		trimLengthTo: number | undefined,
+	) => unknown[];
+	prepare_plain_committed_storage_append_document_index_latest_cached_plan_transaction: (
+		wallTime: bigint,
+		logical: number,
+		gid: string,
 		type: number,
 		metaData: Uint8Array | undefined,
 		payloadData: Uint8Array,
@@ -1859,10 +1859,10 @@ type NativePeerbitBackboneHandle = {
 		requiredPreviousSignerPublicKey: Uint8Array,
 		trimLengthTo: number | undefined,
 	) => unknown[][];
-			prepare_plain_committed_storage_append_document_index_latest_compact_batch_transaction?: (
-				wallTimes: BigUint64Array,
-				logicals: Uint32Array,
-				gids: string[],
+	prepare_plain_committed_storage_append_document_index_latest_compact_batch_transaction?: (
+		wallTimes: BigUint64Array,
+		logicals: Uint32Array,
+		gids: string[],
 		type: number,
 		metaDatas: Array<Uint8Array | undefined>,
 		payloadDatas: Uint8Array[],
@@ -1874,26 +1874,26 @@ type NativePeerbitBackboneHandle = {
 		documentKeys: string[],
 		documentValuePrefixBytes: Uint8Array[],
 		documentByteElementIndexLimit: number,
-				documentDeleteTrimmedHeads: boolean,
-				trimLengthTo: number | undefined,
-			) => unknown[][];
-			prepare_plain_committed_storage_append_document_index_latest_compact_plain_put_payload_batch_transaction?: (
-				wallTimes: BigUint64Array,
-				logicals: Uint32Array,
-				gids: string[],
-				type: number,
-				metaDatas: Array<Uint8Array | undefined>,
-				payloadDatas: Uint8Array[],
-				replicas: number,
-				roleAgeMs: number,
-				now: string,
-				selfHash: string,
-				selfReplicating: boolean,
-				documentKeys: string[],
-				documentByteElementIndexLimit: number,
-				documentDeleteTrimmedHeads: boolean,
-				trimLengthTo: number | undefined,
-			) => unknown[][];
+		documentDeleteTrimmedHeads: boolean,
+		trimLengthTo: number | undefined,
+	) => unknown[][];
+	prepare_plain_committed_storage_append_document_index_latest_compact_plain_put_payload_batch_transaction?: (
+		wallTimes: BigUint64Array,
+		logicals: Uint32Array,
+		gids: string[],
+		type: number,
+		metaDatas: Array<Uint8Array | undefined>,
+		payloadDatas: Uint8Array[],
+		replicas: number,
+		roleAgeMs: number,
+		now: string,
+		selfHash: string,
+		selfReplicating: boolean,
+		documentKeys: string[],
+		documentByteElementIndexLimit: number,
+		documentDeleteTrimmedHeads: boolean,
+		trimLengthTo: number | undefined,
+	) => unknown[][];
 	prepare_plain_committed_storage_append_document_index_latest_required_previous_signer_compact_batch_transaction?: (
 		wallTimes: BigUint64Array,
 		logicals: Uint32Array,
@@ -1913,9 +1913,9 @@ type NativePeerbitBackboneHandle = {
 		requiredPreviousSignerPublicKey: Uint8Array,
 		trimLengthTo: number | undefined,
 	) => unknown[][];
-		prepare_plain_committed_storage_append_document_index_latest_cached_plan_batch_transaction?: (
-			wallTimes: BigUint64Array,
-			logicals: Uint32Array,
+	prepare_plain_committed_storage_append_document_index_latest_cached_plan_batch_transaction?: (
+		wallTimes: BigUint64Array,
+		logicals: Uint32Array,
 		gids: string[],
 		type: number,
 		metaDatas: Array<Uint8Array | undefined>,
@@ -1931,34 +1931,34 @@ type NativePeerbitBackboneHandle = {
 		documentDeleteTrimmedHeads: boolean,
 		documentProjectionPlanIds: Uint32Array,
 		documentProjectionEncodedDocuments: Uint8Array[],
-			documentProjectionSigners: Array<Uint8Array | undefined>,
-			trimLengthTo: number | undefined,
-		) => unknown[][];
-		prepare_plain_committed_storage_append_document_index_latest_required_previous_signer_cached_plan_batch_transaction?: (
-			wallTimes: BigUint64Array,
-			logicals: Uint32Array,
-			gids: string[],
-			type: number,
-			metaDatas: Array<Uint8Array | undefined>,
-			payloadDatas: Uint8Array[],
-			replicas: number,
-			roleAgeMs: number,
-			now: string,
-			selfHash: string,
-			selfReplicating: boolean,
-			resolveTrimmedEntries: boolean,
-			documentKeys: string[],
-			documentByteElementIndexLimit: number,
-			documentDeleteTrimmedHeads: boolean,
-			documentProjectionPlanIds: Uint32Array,
-			documentProjectionEncodedDocuments: Uint8Array[],
-			documentProjectionSigners: Array<Uint8Array | undefined>,
-			requiredPreviousSignerPublicKey: Uint8Array,
-			trimLengthTo: number | undefined,
-		) => unknown[][];
-		prepare_plain_committed_storage_append_document_index_latest_cached_plan_compact_batch_transaction?: (
-			wallTimes: BigUint64Array,
-			logicals: Uint32Array,
+		documentProjectionSigners: Array<Uint8Array | undefined>,
+		trimLengthTo: number | undefined,
+	) => unknown[][];
+	prepare_plain_committed_storage_append_document_index_latest_required_previous_signer_cached_plan_batch_transaction?: (
+		wallTimes: BigUint64Array,
+		logicals: Uint32Array,
+		gids: string[],
+		type: number,
+		metaDatas: Array<Uint8Array | undefined>,
+		payloadDatas: Uint8Array[],
+		replicas: number,
+		roleAgeMs: number,
+		now: string,
+		selfHash: string,
+		selfReplicating: boolean,
+		resolveTrimmedEntries: boolean,
+		documentKeys: string[],
+		documentByteElementIndexLimit: number,
+		documentDeleteTrimmedHeads: boolean,
+		documentProjectionPlanIds: Uint32Array,
+		documentProjectionEncodedDocuments: Uint8Array[],
+		documentProjectionSigners: Array<Uint8Array | undefined>,
+		requiredPreviousSignerPublicKey: Uint8Array,
+		trimLengthTo: number | undefined,
+	) => unknown[][];
+	prepare_plain_committed_storage_append_document_index_latest_cached_plan_compact_batch_transaction?: (
+		wallTimes: BigUint64Array,
+		logicals: Uint32Array,
 		gids: string[],
 		type: number,
 		metaDatas: Array<Uint8Array | undefined>,
@@ -1973,33 +1973,33 @@ type NativePeerbitBackboneHandle = {
 		documentDeleteTrimmedHeads: boolean,
 		documentProjectionPlanIds: Uint32Array,
 		documentProjectionEncodedDocuments: Uint8Array[],
-			documentProjectionSigners: Array<Uint8Array | undefined>,
-			trimLengthTo: number | undefined,
-		) => unknown[][];
-		prepare_plain_committed_storage_append_document_index_latest_required_previous_signer_cached_plan_compact_batch_transaction?: (
-			wallTimes: BigUint64Array,
-			logicals: Uint32Array,
-			gids: string[],
-			type: number,
-			metaDatas: Array<Uint8Array | undefined>,
-			payloadDatas: Uint8Array[],
-			replicas: number,
-			roleAgeMs: number,
-			now: string,
-			selfHash: string,
-			selfReplicating: boolean,
-			documentKeys: string[],
-			documentByteElementIndexLimit: number,
-			documentDeleteTrimmedHeads: boolean,
-			documentProjectionPlanIds: Uint32Array,
-			documentProjectionEncodedDocuments: Uint8Array[],
-			documentProjectionSigners: Array<Uint8Array | undefined>,
-			requiredPreviousSignerPublicKey: Uint8Array,
-			trimLengthTo: number | undefined,
-		) => unknown[][];
-		prepare_plain_committed_storage_append_document_index_latest_cached_plan_compact_plain_put_payload_batch_transaction?: (
-			wallTimes: BigUint64Array,
-			logicals: Uint32Array,
+		documentProjectionSigners: Array<Uint8Array | undefined>,
+		trimLengthTo: number | undefined,
+	) => unknown[][];
+	prepare_plain_committed_storage_append_document_index_latest_required_previous_signer_cached_plan_compact_batch_transaction?: (
+		wallTimes: BigUint64Array,
+		logicals: Uint32Array,
+		gids: string[],
+		type: number,
+		metaDatas: Array<Uint8Array | undefined>,
+		payloadDatas: Uint8Array[],
+		replicas: number,
+		roleAgeMs: number,
+		now: string,
+		selfHash: string,
+		selfReplicating: boolean,
+		documentKeys: string[],
+		documentByteElementIndexLimit: number,
+		documentDeleteTrimmedHeads: boolean,
+		documentProjectionPlanIds: Uint32Array,
+		documentProjectionEncodedDocuments: Uint8Array[],
+		documentProjectionSigners: Array<Uint8Array | undefined>,
+		requiredPreviousSignerPublicKey: Uint8Array,
+		trimLengthTo: number | undefined,
+	) => unknown[][];
+	prepare_plain_committed_storage_append_document_index_latest_cached_plan_compact_plain_put_payload_batch_transaction?: (
+		wallTimes: BigUint64Array,
+		logicals: Uint32Array,
 		gids: string[],
 		type: number,
 		metaDatas: Array<Uint8Array | undefined>,
@@ -2016,8 +2016,8 @@ type NativePeerbitBackboneHandle = {
 		documentProjectionSigners: Array<Uint8Array | undefined>,
 		trimLengthTo: number | undefined,
 	) => unknown[][];
-		prepare_plain_committed_storage_append_transaction_trim: (
-			wallTime: bigint,
+	prepare_plain_committed_storage_append_transaction_trim: (
+		wallTime: bigint,
 		logical: number,
 		gid: string,
 		next: string[],
@@ -2029,26 +2029,26 @@ type NativePeerbitBackboneHandle = {
 		now: string,
 		selfHash: string,
 		selfReplicating: boolean,
-			resolveTrimmedEntries: boolean,
-			trimLengthTo: number,
-		) => unknown[];
-		prepare_plain_committed_storage_append_document_delete_transaction_trim: (
-			wallTime: bigint,
-			logical: number,
-			gid: string,
-			next: string[],
-			type: number,
-			metaData: Uint8Array | undefined,
-			payloadData: Uint8Array,
-			replicas: number,
-			roleAgeMs: number,
-			now: string,
-			selfHash: string,
-			selfReplicating: boolean,
-			resolveTrimmedEntries: boolean,
-			documentKey: string,
-			trimLengthTo: number,
-		) => unknown[];
+		resolveTrimmedEntries: boolean,
+		trimLengthTo: number,
+	) => unknown[];
+	prepare_plain_committed_storage_append_document_delete_transaction_trim: (
+		wallTime: bigint,
+		logical: number,
+		gid: string,
+		next: string[],
+		type: number,
+		metaData: Uint8Array | undefined,
+		payloadData: Uint8Array,
+		replicas: number,
+		roleAgeMs: number,
+		now: string,
+		selfHash: string,
+		selfReplicating: boolean,
+		resolveTrimmedEntries: boolean,
+		documentKey: string,
+		trimLengthTo: number,
+	) => unknown[];
 	prepare_plain_committed_storage_append_document_index_transaction_trim: (
 		wallTime: bigint,
 		logical: number,
@@ -2091,15 +2091,10 @@ type NativeWireSyncSessionHandle = {
 	register_topic: (topic: string) => void;
 	unregister_topic: (topic: string) => boolean;
 	topic_count: () => number;
-	decode_and_verify_batch: (
-		frames: Uint8Array[],
-		nowMs: number,
-	) => Uint32Array;
+	decode_and_verify_batch: (frames: Uint8Array[], nowMs: number) => Uint32Array;
 	stashed_meta: (
 		id: Uint8Array,
-	) =>
-		| [string[], string[][], Uint32Array, Uint8Array, number]
-		| undefined;
+	) => [string[], string[][], Uint32Array, Uint8Array, number] | undefined;
 	stashed_blocks: (
 		id: Uint8Array,
 		indexes?: Uint32Array,
@@ -2393,10 +2388,7 @@ type NativeBackboneResidentRepairDispatchInput = Omit<
 	"entries"
 >;
 
-type NativeBackboneRepairDispatchPlan = Map<
-	string,
-	Map<string, string[]>
->;
+type NativeBackboneRepairDispatchPlan = Map<string, Map<string, string[]>>;
 
 type NativeBackboneCommittedEntry = {
 	cid: string;
@@ -2966,26 +2958,52 @@ export type NativeBackboneCoordinatePersistenceStore = {
 	/**
 	 * Appends `bytes` to the named file. Callers hand over ownership of
 	 * `bytes` and must not mutate it afterwards: buffering stores keep the
-	 * array until their next flush instead of copying it.
+	 * array until their next flush instead of copying it. A rejected append
+	 * must either leave the file unchanged or make later appends fail closed.
 	 */
 	append(name: string, bytes: Uint8Array): Promise<void>;
 	remove?(name: string): Promise<void>;
-	flush?(): Promise<void>;
-	close?(): Promise<void>;
+	/** Explicit physical durability barrier; its presence is a capability. */
+	durableBarrier?(name?: string): Promise<void>;
+	/** Override removal inference for wrappers whose remove method is conditional. */
+	supportsRemoval?: boolean;
+	/** Flush one named file when supported, otherwise the complete store. */
+	flush?(name?: string): Promise<void>;
+	close?(options?: { flush?: boolean }): Promise<void>;
 };
 
 export type NativeBackboneCoordinatePersistenceAdapter = {
+	/**
+	 * Optional durable capability used by higher layers for atomic operation
+	 * intents that must share this persistence lifecycle.
+	 */
+	intentStore?: NativeBackboneCoordinatePersistenceStore;
 	flushOnAppend?: boolean;
 	flushMaxPendingBytes?: number;
 	flushIntervalMs?: number;
 	compactMaxJournalBytes?: number;
 	compactMaxJournalRecords?: number;
+	/** Explicit opt-in for a generation-based, crash-atomic compaction protocol. */
+	crashSafeCompaction?: boolean;
+	/** Every acknowledged WAL/intent write crosses a physical durability barrier. */
+	durableBarrier?: boolean;
+	/** Drop is implemented by the underlying namespace, not only by a wrapper. */
+	supportsDrop?: boolean;
+	/** A successful drop owns handle cleanup and must not need ordinary close(). */
+	dropIsTerminal?: boolean;
 	hydrate(backbone: NativePeerbitBackbone): Promise<number>;
 	flushJournal(backbone: NativePeerbitBackbone): Promise<number>;
 	flushJournalOnAppend?(
 		backbone: NativePeerbitBackbone,
 	): number | Promise<number>;
 	compact?(backbone: NativePeerbitBackbone): Promise<void>;
+	/**
+	 * Durably erase this adapter's configured files and any additional files
+	 * sharing the same namespace. A tombstone makes interrupted erases resumable.
+	 */
+	drop?(additionalFiles?: readonly string[]): Promise<void>;
+	/** Complete an interrupted drop before any native state is hydrated. */
+	resumeDrop?(): Promise<boolean>;
 	close?(): Promise<void>;
 };
 
@@ -3020,9 +3038,75 @@ const nativeBackboneCoordinatePersistenceFiles = {
 	documentSignerJournal: "document-signers.wal",
 } as const;
 
+export const nativeBackboneCoordinateDropTombstoneFile =
+	"native-backbone-drop.tombstone";
+
 export const defaultNativeBackboneCoordinateFlushMaxPendingBytes = 1024 * 1024;
+/** @deprecated Built-in coordinate persistence compaction is currently disabled. */
 export const defaultNativeBackboneCoordinateCompactMaxJournalBytes =
 	64 * 1024 * 1024;
+
+const nativeBackboneCoordinateCompactionDisabledMessage =
+	"Native backbone coordinate persistence compaction is disabled until snapshots use a crash-safe generation protocol";
+
+const nativeBackboneCoordinateJournalMagic = Uint8Array.from([
+	0x50, 0x42, 0x52, 0x49, 0x44, 0x58, 0x57, 0x31,
+]);
+
+const readCoordinateJournalU32 = (bytes: Uint8Array, offset: number): number =>
+	(bytes[offset]! |
+		(bytes[offset + 1]! << 8) |
+		(bytes[offset + 2]! << 16) |
+		(bytes[offset + 3]! << 24)) >>>
+	0;
+
+const coordinateJournalChecksum = (bytes: Uint8Array): number => {
+	let checksum = 0x811c9dc5;
+	for (const byte of bytes) {
+		checksum = Math.imul(checksum ^ byte, 0x01000193) >>> 0;
+	}
+	return checksum;
+};
+
+const hasCoordinateJournalMagic = (bytes: Uint8Array): boolean =>
+	bytes.byteLength >= nativeBackboneCoordinateJournalMagic.byteLength &&
+	nativeBackboneCoordinateJournalMagic.every(
+		(byte, index) => bytes[index] === byte,
+	);
+
+/**
+ * The Rust decoder intentionally stops at a torn/corrupt tail. Persistence
+ * must reject that tail before hydrate, otherwise a later append can land
+ * behind it and remain permanently invisible to replay.
+ */
+const validateCoordinateJournal = (
+	bytes: Uint8Array | undefined,
+	name: string,
+): void => {
+	if (!bytes || bytes.byteLength === 0) {
+		return;
+	}
+	let offset = hasCoordinateJournalMagic(bytes)
+		? nativeBackboneCoordinateJournalMagic.byteLength
+		: 0;
+	while (offset < bytes.byteLength) {
+		if (bytes.byteLength - offset < 8) {
+			throw new Error(`Native backbone ${name} has a torn record header`);
+		}
+		const length = readCoordinateJournalU32(bytes, offset);
+		const expectedChecksum = readCoordinateJournalU32(bytes, offset + 4);
+		const payloadOffset = offset + 8;
+		const end = payloadOffset + length;
+		if (!Number.isSafeInteger(end) || end > bytes.byteLength) {
+			throw new Error(`Native backbone ${name} has a torn record payload`);
+		}
+		const payload = bytes.subarray(payloadOffset, end);
+		if (coordinateJournalChecksum(payload) !== expectedChecksum) {
+			throw new Error(`Native backbone ${name} has a checksum mismatch`);
+		}
+		offset = end;
+	}
+};
 
 const resolveCoordinateFlushMaxPendingBytes = (
 	options: NativeBackboneCoordinatePersistenceOptions,
@@ -3046,7 +3130,8 @@ type NativeBackboneNodeFs = {
 };
 
 type NativeBackboneNodeAppendFileHandle = {
-	write(data: Uint8Array): Promise<unknown>;
+	write(data: Uint8Array): Promise<{ bytesWritten: number }>;
+	sync?(): Promise<unknown>;
 	close(): Promise<unknown>;
 };
 
@@ -3058,6 +3143,7 @@ type NativeBackboneOPFSFile = {
 type NativeBackboneOPFSSyncAccessHandle = {
 	getSize(): number;
 	write(buffer: Uint8Array, options?: { at?: number }): number;
+	truncate?(size: number): void;
 	flush?(): void;
 	close(): void;
 };
@@ -3091,6 +3177,29 @@ export type NativeBackboneOPFSDirectoryHandle = {
 const isNotFoundError = (error: unknown): boolean => {
 	const maybeError = error as { code?: string; name?: string } | undefined;
 	return maybeError?.code === "ENOENT" || maybeError?.name === "NotFoundError";
+};
+
+const isUnsupportedDirectorySyncError = (error: unknown): boolean => {
+	const code = (error as { code?: string } | undefined)?.code;
+	return (
+		code === "EISDIR" ||
+		code === "EINVAL" ||
+		code === "EPERM" ||
+		code === "ENOTSUP"
+	);
+};
+
+const validateCoordinatePersistenceWriteProgress = (
+	written: number,
+	remaining: number,
+	target: string,
+): number => {
+	if (!Number.isSafeInteger(written) || written <= 0 || written > remaining) {
+		throw new Error(
+			`Invalid ${target} write progress: ${String(written)} for ${remaining} remaining bytes`,
+		);
+	}
+	return written;
 };
 
 // Non-literal specifiers keep browser bundlers (esbuild statically resolves
@@ -3131,6 +3240,94 @@ const validateCoordinatePersistenceName = (name: string): string => {
 		);
 	}
 	return name;
+};
+
+type NativeBackboneCoordinateDropTombstoneBody = {
+	format: "peerbit-native-backbone-coordinate-drop";
+	version: 1;
+	files: string[];
+};
+
+type NativeBackboneCoordinateDropTombstone =
+	NativeBackboneCoordinateDropTombstoneBody & {
+		checksum: string;
+	};
+
+const nativeBackboneCoordinateDropTombstoneBodyBytes = (
+	body: NativeBackboneCoordinateDropTombstoneBody,
+): Uint8Array => new TextEncoder().encode(JSON.stringify(body));
+
+const nativeBackboneCoordinateDropChecksum = (bytes: Uint8Array): string => {
+	let checksum = 0xffffffff;
+	for (const byte of bytes) {
+		checksum ^= byte;
+		for (let bit = 0; bit < 8; bit++) {
+			checksum = (checksum >>> 1) ^ (checksum & 1 ? 0xedb88320 : 0);
+		}
+	}
+	return ((checksum ^ 0xffffffff) >>> 0).toString(16).padStart(8, "0");
+};
+
+const nativeBackboneCoordinateDropTombstoneBytes = (
+	files: readonly string[],
+): Uint8Array => {
+	const body: NativeBackboneCoordinateDropTombstoneBody = {
+		format: "peerbit-native-backbone-coordinate-drop",
+		version: 1,
+		files: [...files],
+	};
+	return new TextEncoder().encode(
+		JSON.stringify({
+			...body,
+			checksum: nativeBackboneCoordinateDropChecksum(
+				nativeBackboneCoordinateDropTombstoneBodyBytes(body),
+			),
+		} satisfies NativeBackboneCoordinateDropTombstone),
+	);
+};
+
+const parseNativeBackboneCoordinateDropTombstone = (
+	bytes: Uint8Array,
+): NativeBackboneCoordinateDropTombstoneBody => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(new TextDecoder().decode(bytes));
+	} catch (error) {
+		throw new Error("Invalid native backbone drop tombstone JSON", {
+			cause: error,
+		});
+	}
+	const candidate = parsed as Partial<NativeBackboneCoordinateDropTombstone>;
+	if (
+		!candidate ||
+		candidate.format !== "peerbit-native-backbone-coordinate-drop" ||
+		candidate.version !== 1 ||
+		!Array.isArray(candidate.files) ||
+		candidate.files.some((name) => typeof name !== "string") ||
+		typeof candidate.checksum !== "string"
+	) {
+		throw new Error("Invalid native backbone drop tombstone");
+	}
+	const files = candidate.files.map(validateCoordinatePersistenceName);
+	if (
+		new Set(files).size !== files.length ||
+		files.includes(nativeBackboneCoordinateDropTombstoneFile)
+	) {
+		throw new Error("Invalid native backbone drop tombstone file set");
+	}
+	const body: NativeBackboneCoordinateDropTombstoneBody = {
+		format: "peerbit-native-backbone-coordinate-drop",
+		version: 1,
+		files,
+	};
+	if (
+		nativeBackboneCoordinateDropChecksum(
+			nativeBackboneCoordinateDropTombstoneBodyBytes(body),
+		) !== candidate.checksum
+	) {
+		throw new Error("Native backbone drop tombstone checksum mismatch");
+	}
+	return body;
 };
 
 const concatBytes = (chunks: Uint8Array[]): Uint8Array => {
@@ -3598,8 +3795,12 @@ const metadataEntryFromRow = (row: unknown) => {
 		Uint8Array | undefined,
 		number | undefined,
 	];
-	const entry: { hash: string; gid: string; data?: Uint8Array; replicas?: number } =
-		{ hash, gid, data };
+	const entry: {
+		hash: string;
+		gid: string;
+		data?: Uint8Array;
+		replicas?: number;
+	} = { hash, gid, data };
 	if (replicas != null) {
 		entry.replicas = replicas;
 	}
@@ -3615,8 +3816,12 @@ const requestPruneEntryFromRow = (
 		number | undefined,
 		Uint8Array | undefined,
 	];
-	const entry: { hash: string; gid: string; data?: Uint8Array; replicas?: number } =
-		{ hash, gid };
+	const entry: {
+		hash: string;
+		gid: string;
+		data?: Uint8Array;
+		replicas?: number;
+	} = { hash, gid };
 	if (replicas != null) {
 		entry.replicas = replicas;
 	}
@@ -3997,7 +4202,11 @@ const validateNativeBackboneCoordinateCommitColumns = (
 	) {
 		throw new Error("Expected equal native coordinate commit column lengths");
 	}
-	if (columns.hashNumberValues || columns.coordinateCounts || columns.coordinateValues) {
+	if (
+		columns.hashNumberValues ||
+		columns.coordinateCounts ||
+		columns.coordinateValues
+	) {
 		if (
 			!columns.hashNumberValues ||
 			!columns.coordinateCounts ||
@@ -4005,7 +4214,9 @@ const validateNativeBackboneCoordinateCommitColumns = (
 			columns.hashNumberValues.length !== length ||
 			columns.coordinateCounts.length !== length
 		) {
-			throw new Error("Expected equal native coordinate numeric column lengths");
+			throw new Error(
+				"Expected equal native coordinate numeric column lengths",
+			);
 		}
 		let coordinateCount = 0;
 		for (const count of columns.coordinateCounts) {
@@ -4021,7 +4232,11 @@ const validateNativeBackboneCoordinateCommitColumns = (
 	) {
 		throw new Error("Expected equal native coordinate replica column lengths");
 	}
-	if (columns.hashNumbers || columns.coordinateBatches || columns.requestedReplicas) {
+	if (
+		columns.hashNumbers ||
+		columns.coordinateBatches ||
+		columns.requestedReplicas
+	) {
 		if (
 			!columns.hashNumbers ||
 			!columns.coordinateBatches ||
@@ -4072,7 +4287,11 @@ const nativeBackboneCoordinateCommitStringColumns = (
 		"hashNumbers" | "coordinateBatches" | "requestedReplicas"
 	>
 > => {
-	if (columns.hashNumbers && columns.coordinateBatches && columns.requestedReplicas) {
+	if (
+		columns.hashNumbers &&
+		columns.coordinateBatches &&
+		columns.requestedReplicas
+	) {
 		return {
 			hashNumbers: columns.hashNumbers,
 			coordinateBatches: columns.coordinateBatches,
@@ -4193,8 +4412,7 @@ const rawReceivePreparedFactsFromColumns = ([
 				requestedReplicas[i] && requestedReplicas[i] > 0
 					? requestedReplicas[i]
 					: undefined,
-			hashNumber:
-				hashNumbers[i] == null ? undefined : String(hashNumbers[i]),
+			hashNumber: hashNumbers[i] == null ? undefined : String(hashNumbers[i]),
 		};
 	}
 	return out;
@@ -4963,11 +5181,7 @@ class NativeBackboneLogGraph {
 				),
 			);
 		}
-		if (
-			documentIndexArgs &&
-			input.trimLengthTo == null &&
-			hasNoNext
-		) {
+		if (documentIndexArgs && input.trimLengthTo == null && hasNoNext) {
 			return preparedCommitFactsFromRow(
 				this.native.prepare_plain_entry_commit_no_next_facts_document_index_compact(
 					wallTime,
@@ -6317,9 +6531,7 @@ export class NativePeerbitBackbone {
 		return { exists, publicKey };
 	}
 
-	documentContextsAndPreviousSignaturePublicKeys(
-		keys: string[],
-	):
+	documentContextsAndPreviousSignaturePublicKeys(keys: string[]):
 		| Array<{
 				context?: NativeBackboneDocumentContextFacts;
 				publicKey?: Uint8Array;
@@ -6710,12 +6922,8 @@ export class NativePeerbitBackbone {
 	commitEntryCoordinatesColumnsBatch(
 		columns: NativeBackboneCoordinateCommitColumns,
 	): void {
-		const {
-			hashes,
-			gids,
-			nextHashBatches,
-			assignedToRangeBoundaries,
-		} = columns;
+		const { hashes, gids, nextHashBatches, assignedToRangeBoundaries } =
+			columns;
 		if (hashes.length === 0) {
 			return;
 		}
@@ -6979,7 +7187,9 @@ export class NativePeerbitBackbone {
 	planRequestPruneAllConfirmed(
 		hashes: Iterable<string>,
 		prunePeer: string,
-		options?: NativeBackboneFindLeaderOptions & { omitPeerHistoryGids?: boolean },
+		options?: NativeBackboneFindLeaderOptions & {
+			omitPeerHistoryGids?: boolean;
+		},
 	): NativeBackboneRequestPruneAllConfirmed | undefined {
 		const hashArray = iterableToArray(hashes);
 		if (
@@ -7459,10 +7669,12 @@ export class NativePeerbitBackbone {
 					}
 				}
 				const projection = documentIndex.projection;
-					if (projection) {
-						const projectionPlanId = this.documentProjectionPlanId(projection.plan);
-						const nativeCompactPlainPutPayload =
-							documentIndex.usePlainPutPayload === true
+				if (projection) {
+					const projectionPlanId = this.documentProjectionPlanId(
+						projection.plan,
+					);
+					const nativeCompactPlainPutPayload =
+						documentIndex.usePlainPutPayload === true
 							? this.native
 									.prepare_plain_committed_storage_append_document_index_latest_cached_plan_compact_plain_put_payload_transaction
 							: undefined;
@@ -7519,45 +7731,45 @@ export class NativePeerbitBackbone {
 						);
 						return compactCommittedLatestStorageAppendResultFromRow(
 							this.resolution,
-								row,
-							);
-						}
+							row,
+						);
 					}
-					if (
-						!requiredPreviousSignerPublicKey &&
-						documentIndex.usePlainPutPayload === true
-					) {
-						const nativeCompactPlainPutPayload =
-							this.native
-								.prepare_plain_committed_storage_append_document_index_latest_compact_plain_put_payload_transaction;
-						if (nativeCompactPlainPutPayload) {
-							const row = nativeCompactPlainPutPayload.call(
-								this.native,
-								BigInt(input.wallTime),
-								input.logical ?? 0,
-								input.gid,
-								input.type ?? 0,
-								input.metaData,
-								input.payloadData,
-								input.replicas,
-								input.roleAgeMs ?? 0,
-								integerString(input.now ?? Date.now()),
-								input.selfHash ?? "",
-								input.selfReplicating ?? true,
-								documentIndex.key,
-								documentIndex.byteElementIndexLimit ?? 0,
-								documentIndex.deleteTrimmedHeads === true,
-								input.trimLengthTo,
-							);
-							return compactCommittedLatestStorageAppendResultFromRow(
-								this.resolution,
-								row,
-							);
-						}
-					}
-					const nativeCompact =
+				}
+				if (
+					!requiredPreviousSignerPublicKey &&
+					documentIndex.usePlainPutPayload === true
+				) {
+					const nativeCompactPlainPutPayload =
 						this.native
-							.prepare_plain_committed_storage_append_document_index_latest_compact_transaction;
+							.prepare_plain_committed_storage_append_document_index_latest_compact_plain_put_payload_transaction;
+					if (nativeCompactPlainPutPayload) {
+						const row = nativeCompactPlainPutPayload.call(
+							this.native,
+							BigInt(input.wallTime),
+							input.logical ?? 0,
+							input.gid,
+							input.type ?? 0,
+							input.metaData,
+							input.payloadData,
+							input.replicas,
+							input.roleAgeMs ?? 0,
+							integerString(input.now ?? Date.now()),
+							input.selfHash ?? "",
+							input.selfReplicating ?? true,
+							documentIndex.key,
+							documentIndex.byteElementIndexLimit ?? 0,
+							documentIndex.deleteTrimmedHeads === true,
+							input.trimLengthTo,
+						);
+						return compactCommittedLatestStorageAppendResultFromRow(
+							this.resolution,
+							row,
+						);
+					}
+				}
+				const nativeCompact =
+					this.native
+						.prepare_plain_committed_storage_append_document_index_latest_compact_transaction;
 				if (nativeCompact) {
 					const row = nativeCompact.call(
 						this.native,
@@ -7710,8 +7922,7 @@ export class NativePeerbitBackbone {
 		const requiredPreviousSignerPublicKeys = input.entries
 			.map((entry) => entry.documentIndex.requiredPreviousSignerPublicKey)
 			.filter((key): key is Uint8Array => !!key);
-		const requiredPreviousSignerPublicKey =
-			requiredPreviousSignerPublicKeys[0];
+		const requiredPreviousSignerPublicKey = requiredPreviousSignerPublicKeys[0];
 		if (
 			requiredPreviousSignerPublicKeys.length > 0 &&
 			requiredPreviousSignerPublicKeys.length !== input.entries.length
@@ -7723,25 +7934,25 @@ export class NativePeerbitBackbone {
 			requiredPreviousSignerPublicKeys.some(
 				(key) =>
 					key.byteLength !== requiredPreviousSignerPublicKey.byteLength ||
-					key.some((byte, index) => byte !== requiredPreviousSignerPublicKey[index]),
+					key.some(
+						(byte, index) => byte !== requiredPreviousSignerPublicKey[index],
+					),
 			)
 		) {
 			return undefined;
 		}
-			const projected = input.entries.every(
-				(entry) => entry.documentIndex.projection,
+		const projected = input.entries.every(
+			(entry) => entry.documentIndex.projection,
+		);
+		if (projected) {
+			const usePlainPutPayload = input.entries.every(
+				(entry) => entry.documentIndex.usePlainPutPayload === true,
 			);
-			if (projected) {
-				const usePlainPutPayload = input.entries.every(
-					(entry) => entry.documentIndex.usePlainPutPayload === true,
-				);
 			const baseArgs = [
 				new BigUint64Array(
 					input.entries.map((entry) => BigInt(entry.wallTime)),
 				),
-				new Uint32Array(
-					input.entries.map((entry) => entry.logical ?? 0),
-				),
+				new Uint32Array(input.entries.map((entry) => entry.logical ?? 0)),
 				input.entries.map((entry) => entry.gid),
 				input.type ?? 0,
 				input.entries.map((entry) => entry.metaData),
@@ -7758,9 +7969,7 @@ export class NativePeerbitBackbone {
 				input.documentDeleteTrimmedHeads === true,
 				new Uint32Array(
 					input.entries.map((entry) =>
-						this.documentProjectionPlanId(
-							entry.documentIndex.projection!.plan,
-						),
+						this.documentProjectionPlanId(entry.documentIndex.projection!.plan),
 					),
 				),
 			] as const;
@@ -7773,43 +7982,20 @@ export class NativePeerbitBackbone {
 			const nativeCompactCachedBatch =
 				this.native
 					.prepare_plain_committed_storage_append_document_index_latest_cached_plan_compact_batch_transaction;
-				const nativeCompactCachedPlainPayloadBatch =
-					this.native
-						.prepare_plain_committed_storage_append_document_index_latest_cached_plan_compact_plain_put_payload_batch_transaction;
-				if (requiredPreviousSignerPublicKey) {
-					if (useCompact) {
-						const nativeRequiredCompactCachedBatch =
-							this.native
-								.prepare_plain_committed_storage_append_document_index_latest_required_previous_signer_cached_plan_compact_batch_transaction;
-						if (!nativeRequiredCompactCachedBatch) {
-							return undefined;
-						}
-						const rows = nativeRequiredCompactCachedBatch.call(
-							this.native,
-							...baseArgs,
-							...documentPlanArgs,
-							documentEncodedDocuments,
-							documentSigners,
-							requiredPreviousSignerPublicKey,
-							input.trimLengthTo,
-						);
-						return rows.map((row) =>
-							compactCommittedLatestStorageAppendResultFromRow(
-								this.resolution,
-								row,
-							),
-						);
-					}
-					const nativeRequiredCachedBatch =
+			const nativeCompactCachedPlainPayloadBatch =
+				this.native
+					.prepare_plain_committed_storage_append_document_index_latest_cached_plan_compact_plain_put_payload_batch_transaction;
+			if (requiredPreviousSignerPublicKey) {
+				if (useCompact) {
+					const nativeRequiredCompactCachedBatch =
 						this.native
-							.prepare_plain_committed_storage_append_document_index_latest_required_previous_signer_cached_plan_batch_transaction;
-					if (!nativeRequiredCachedBatch) {
+							.prepare_plain_committed_storage_append_document_index_latest_required_previous_signer_cached_plan_compact_batch_transaction;
+					if (!nativeRequiredCompactCachedBatch) {
 						return undefined;
 					}
-					const rows = nativeRequiredCachedBatch.call(
+					const rows = nativeRequiredCompactCachedBatch.call(
 						this.native,
 						...baseArgs,
-						input.resolveTrimmedEntries !== false,
 						...documentPlanArgs,
 						documentEncodedDocuments,
 						documentSigners,
@@ -7817,12 +8003,35 @@ export class NativePeerbitBackbone {
 						input.trimLengthTo,
 					);
 					return rows.map((row) =>
-						committedStorageAppendResultFromRow(this.resolution, row),
+						compactCommittedLatestStorageAppendResultFromRow(
+							this.resolution,
+							row,
+						),
 					);
 				}
-				if (
-					useCompact &&
-					usePlainPutPayload &&
+				const nativeRequiredCachedBatch =
+					this.native
+						.prepare_plain_committed_storage_append_document_index_latest_required_previous_signer_cached_plan_batch_transaction;
+				if (!nativeRequiredCachedBatch) {
+					return undefined;
+				}
+				const rows = nativeRequiredCachedBatch.call(
+					this.native,
+					...baseArgs,
+					input.resolveTrimmedEntries !== false,
+					...documentPlanArgs,
+					documentEncodedDocuments,
+					documentSigners,
+					requiredPreviousSignerPublicKey,
+					input.trimLengthTo,
+				);
+				return rows.map((row) =>
+					committedStorageAppendResultFromRow(this.resolution, row),
+				);
+			}
+			if (
+				useCompact &&
+				usePlainPutPayload &&
 				nativeCompactCachedPlainPayloadBatch
 			) {
 				const rows = nativeCompactCachedPlainPayloadBatch.call(
@@ -7876,16 +8085,12 @@ export class NativePeerbitBackbone {
 		}
 		if (
 			input.entries.some((entry) => entry.documentIndex.projection) ||
-			input.entries.some(
-				(entry) => !entry.documentIndex.valuePrefixBytes,
-			)
+			input.entries.some((entry) => !entry.documentIndex.valuePrefixBytes)
 		) {
 			return undefined;
 		}
 		const baseArgs = [
-			new BigUint64Array(
-				input.entries.map((entry) => BigInt(entry.wallTime)),
-			),
+			new BigUint64Array(input.entries.map((entry) => BigInt(entry.wallTime))),
 			new Uint32Array(input.entries.map((entry) => entry.logical ?? 0)),
 			input.entries.map((entry) => entry.gid),
 			input.type ?? 0,
@@ -7897,38 +8102,34 @@ export class NativePeerbitBackbone {
 			input.selfHash ?? "",
 			input.selfReplicating ?? true,
 		] as const;
-			const documentKeys = input.entries.map((entry) => entry.documentIndex.key);
-			const usePlainPutPayload = input.entries.every(
-				(entry) => entry.documentIndex.usePlainPutPayload === true,
-			);
-			if (
-				!requiredPreviousSignerPublicKey &&
-				useCompact &&
-				usePlainPutPayload
-			) {
-				const nativeCompactPlainPutPayloadBatch =
-					this.native
-						.prepare_plain_committed_storage_append_document_index_latest_compact_plain_put_payload_batch_transaction;
-				if (nativeCompactPlainPutPayloadBatch) {
-					const rows = nativeCompactPlainPutPayloadBatch.call(
-						this.native,
-						...baseArgs,
-						documentKeys,
-						input.documentByteElementIndexLimit ?? 0,
-						input.documentDeleteTrimmedHeads === true,
-						input.trimLengthTo,
-					);
-					return rows.map((row) =>
-						compactCommittedLatestStorageAppendResultFromRow(
-							this.resolution,
-							row,
-						),
-					);
-				}
+		const documentKeys = input.entries.map((entry) => entry.documentIndex.key);
+		const usePlainPutPayload = input.entries.every(
+			(entry) => entry.documentIndex.usePlainPutPayload === true,
+		);
+		if (!requiredPreviousSignerPublicKey && useCompact && usePlainPutPayload) {
+			const nativeCompactPlainPutPayloadBatch =
+				this.native
+					.prepare_plain_committed_storage_append_document_index_latest_compact_plain_put_payload_batch_transaction;
+			if (nativeCompactPlainPutPayloadBatch) {
+				const rows = nativeCompactPlainPutPayloadBatch.call(
+					this.native,
+					...baseArgs,
+					documentKeys,
+					input.documentByteElementIndexLimit ?? 0,
+					input.documentDeleteTrimmedHeads === true,
+					input.trimLengthTo,
+				);
+				return rows.map((row) =>
+					compactCommittedLatestStorageAppendResultFromRow(
+						this.resolution,
+						row,
+					),
+				);
 			}
-			const documentValuePrefixBytes = input.entries.map(
-				(entry) => entry.documentIndex.valuePrefixBytes!,
-			);
+		}
+		const documentValuePrefixBytes = input.entries.map(
+			(entry) => entry.documentIndex.valuePrefixBytes!,
+		);
 		const documentByteElementIndexLimit =
 			input.documentByteElementIndexLimit ?? 0;
 		const documentDeleteTrimmedHeads =
@@ -7996,10 +8197,7 @@ export class NativePeerbitBackbone {
 				...documentArgs,
 			);
 			return rows.map((row) =>
-				compactCommittedLatestStorageAppendResultFromRow(
-					this.resolution,
-					row,
-				),
+				compactCommittedLatestStorageAppendResultFromRow(this.resolution, row),
 			);
 		}
 		const nativeBatch =
@@ -8217,9 +8415,7 @@ export class NativePeerbitBackbone {
 				new BigUint64Array(
 					input.entries.map((entry) => BigInt(entry.wallTime)),
 				),
-				new Uint32Array(
-					input.entries.map((entry) => entry.logical ?? 0),
-				),
+				new Uint32Array(input.entries.map((entry) => entry.logical ?? 0)),
 				input.entries.map((entry) => entry.gid),
 				input.type ?? 0,
 				input.entries.map((entry) => entry.metaData),
@@ -8239,46 +8435,35 @@ export class NativePeerbitBackbone {
 				input.documentDeleteTrimmedHeads === true,
 				new Uint32Array(
 					input.entries.map((entry) =>
-						this.documentProjectionPlanId(
-							entry.documentIndex.projection!.plan,
-						),
+						this.documentProjectionPlanId(entry.documentIndex.projection!.plan),
 					),
 				),
 			] as const;
 			const rows = usePlainPutPayload
-				? this.native
-						.prepare_plain_committed_no_next_storage_append_document_index_cached_plan_compact_plain_put_payload_batch_transaction?.call(
-							this.native,
-							...baseArgs,
-							input.entries.map(
-								(entry) =>
-									entry.documentIndex.projection!.signer,
-							),
-							input.trimLengthTo,
-						)
-				: this.native
-						.prepare_plain_committed_no_next_storage_append_document_index_cached_plan_compact_batch_transaction?.call(
-							this.native,
-							...baseArgs,
-							input.entries.map(
-								(entry) =>
-									entry.documentIndex.projection!
-										.encodedDocument,
-							),
-							input.entries.map(
-								(entry) =>
-									entry.documentIndex.projection!.signer,
-							),
-							input.trimLengthTo,
-						);
+				? this.native.prepare_plain_committed_no_next_storage_append_document_index_cached_plan_compact_plain_put_payload_batch_transaction?.call(
+						this.native,
+						...baseArgs,
+						input.entries.map(
+							(entry) => entry.documentIndex.projection!.signer,
+						),
+						input.trimLengthTo,
+					)
+				: this.native.prepare_plain_committed_no_next_storage_append_document_index_cached_plan_compact_batch_transaction?.call(
+						this.native,
+						...baseArgs,
+						input.entries.map(
+							(entry) => entry.documentIndex.projection!.encodedDocument,
+						),
+						input.entries.map(
+							(entry) => entry.documentIndex.projection!.signer,
+						),
+						input.trimLengthTo,
+					);
 			if (!rows) {
 				return undefined;
 			}
 			return rows.map((row) =>
-				compactCommittedNoNextStorageAppendResultFromRow(
-					this.resolution,
-					row,
-				),
+				compactCommittedNoNextStorageAppendResultFromRow(this.resolution, row),
 			);
 		}
 		if (
@@ -8336,9 +8521,7 @@ export class NativePeerbitBackbone {
 		}
 		const rows = nativeBatch.call(
 			this.native,
-			new BigUint64Array(
-				input.entries.map((entry) => BigInt(entry.wallTime)),
-			),
+			new BigUint64Array(input.entries.map((entry) => BigInt(entry.wallTime))),
 			new Uint32Array(input.entries.map((entry) => entry.logical ?? 0)),
 			input.entries.map((entry) => entry.gid),
 			input.type ?? 0,
@@ -8351,8 +8534,7 @@ export class NativePeerbitBackbone {
 			input.selfReplicating ?? true,
 			input.entries.map((entry) => entry.documentIndex.key),
 			input.entries.map(
-				(entry) =>
-					entry.documentIndex.valuePrefixBytes ?? EMPTY_UINT8_ARRAY,
+				(entry) => entry.documentIndex.valuePrefixBytes ?? EMPTY_UINT8_ARRAY,
 			),
 			input.entries.map((entry) =>
 				entry.documentIndex.existingCreated == null
@@ -8364,13 +8546,9 @@ export class NativePeerbitBackbone {
 			input.trimLengthTo,
 		);
 		return rows.map((row) =>
-			compactCommittedNoNextStorageAppendResultFromRow(
-				this.resolution,
-				row,
-			),
+			compactCommittedNoNextStorageAppendResultFromRow(this.resolution, row),
 		);
 	}
-
 }
 
 export class NativeBackboneMemoryCoordinatePersistenceStore
@@ -8399,6 +8577,8 @@ export class NativeBackboneMemoryCoordinatePersistenceStore
 	async remove(name: string): Promise<void> {
 		this.files.delete(validateCoordinatePersistenceName(name));
 	}
+
+	async flush(_name?: string): Promise<void> {}
 }
 
 export class NativeBackboneNodeCoordinatePersistenceStore
@@ -8410,11 +8590,20 @@ export class NativeBackboneNodeCoordinatePersistenceStore
 	>();
 	private readonly filePaths = new Map<string, string>();
 	private directoryEnsured = false;
+	private appendFailure: unknown;
+	readonly durableBarrier?: (name?: string) => Promise<void>;
 
 	constructor(
 		private readonly directory: string,
 		private readonly fs?: NativeBackboneNodeFs,
-	) {}
+	) {
+		// The default Node backend has FileHandle.sync. Injected test/custom
+		// backends only advertise durability when they at least expose open(); the
+		// barrier itself verifies sync on every opened handle before ACK.
+		if (!fs || typeof fs.open === "function") {
+			this.durableBarrier = (name) => this.syncDurably(name);
+		}
+	}
 
 	private async nodeFs(): Promise<NativeBackboneNodeFs> {
 		return this.fs ?? (await importNodeFs());
@@ -8483,14 +8672,45 @@ export class NativeBackboneNodeCoordinatePersistenceStore
 	}
 
 	async append(name: string, bytes: Uint8Array): Promise<void> {
+		if (this.appendFailure !== undefined) {
+			throw this.appendFailure;
+		}
 		const fs = await this.ensureDirectory();
 		const path = await this.filePath(name);
 		const handle = await this.appendHandle(fs, path);
 		if (handle) {
-			await handle.write(bytes);
+			let offset = 0;
+			while (offset < bytes.byteLength) {
+				let result: { bytesWritten: number };
+				try {
+					result = await handle.write(bytes.subarray(offset));
+				} catch (error) {
+					// FileHandle.write does not expose progress on rejection, even for the
+					// first call, so a partial tail can not be ruled out.
+					this.appendFailure ??= error;
+					throw this.appendFailure;
+				}
+				try {
+					offset += validateCoordinatePersistenceWriteProgress(
+						result.bytesWritten,
+						bytes.byteLength - offset,
+						"Node coordinate WAL",
+					);
+				} catch (error) {
+					this.appendFailure ??= error;
+					throw this.appendFailure;
+				}
+			}
 			return;
 		}
-		await fs.appendFile(path, bytes);
+		try {
+			await fs.appendFile(path, bytes);
+		} catch (error) {
+			// appendFile does not report partial progress. Conservatively prevent a
+			// later append from landing behind a possibly torn tail.
+			this.appendFailure ??= error;
+			throw this.appendFailure;
+		}
 	}
 
 	async remove(name: string): Promise<void> {
@@ -8506,6 +8726,74 @@ export class NativeBackboneNodeCoordinatePersistenceStore
 		}
 	}
 
+	async flush(name?: string): Promise<void> {
+		if (!this.durableBarrier) {
+			return;
+		}
+		try {
+			await this.durableBarrier(name);
+		} catch (error) {
+			// Ordinary buffering reads flush a named queue before discovering whether
+			// the backing file exists. Missing files are expected there; strict ACK
+			// paths call durableBarrier directly and therefore remain fail-closed.
+			if (!name || !isNotFoundError(error)) {
+				throw error;
+			}
+		}
+	}
+
+	private async syncDurably(name?: string): Promise<void> {
+		const fs = await this.nodeFs();
+		if (!fs.open) {
+			throw new Error(
+				"Node coordinate persistence does not expose a durable FileHandle.sync barrier",
+			);
+		}
+		const syncHandle = async (
+			handle: NativeBackboneNodeAppendFileHandle,
+			target: string,
+		): Promise<void> => {
+			if (typeof handle.sync !== "function") {
+				throw new Error(
+					`Node coordinate persistence ${target} does not expose FileHandle.sync`,
+				);
+			}
+			await handle.sync();
+		};
+		if (name) {
+			const path = await this.filePath(name);
+			const appendHandle = this.appendHandles.get(path);
+			if (appendHandle) {
+				await syncHandle(await appendHandle, `file ${name}`);
+			} else {
+				let handle: NativeBackboneNodeAppendFileHandle | undefined;
+				try {
+					handle = await fs.open(path, "r");
+					await syncHandle(handle, `file ${name}`);
+				} finally {
+					await handle?.close();
+				}
+			}
+		} else {
+			await Promise.all(
+				[...this.appendHandles.entries()].map(async ([path, handle]) =>
+					syncHandle(await handle, `file ${path}`),
+				),
+			);
+		}
+		let directoryHandle: NativeBackboneNodeAppendFileHandle | undefined;
+		try {
+			directoryHandle = await fs.open(this.directory, "r");
+			await syncHandle(directoryHandle, "directory");
+		} catch (error) {
+			if (!isNotFoundError(error) && !isUnsupportedDirectorySyncError(error)) {
+				throw error;
+			}
+		} finally {
+			await directoryHandle?.close();
+		}
+	}
+
 	async close(): Promise<void> {
 		this.directoryEnsured = false;
 		const handles = [...this.appendHandles.values()];
@@ -8517,6 +8805,8 @@ export class NativeBackboneNodeCoordinatePersistenceStore
 export class NativeBackboneOPFSCoordinatePersistenceStore
 	implements NativeBackboneCoordinatePersistenceStore
 {
+	private appendFailure: unknown;
+
 	constructor(private readonly directory: NativeBackboneOPFSDirectoryHandle) {}
 
 	static async create(options?: {
@@ -8588,6 +8878,9 @@ export class NativeBackboneOPFSCoordinatePersistenceStore
 	}
 
 	async append(name: string, bytes: Uint8Array): Promise<void> {
+		if (this.appendFailure !== undefined) {
+			throw this.appendFailure;
+		}
 		const handle = await this.directory.getFileHandle(
 			validateCoordinatePersistenceName(name),
 			{ create: true },
@@ -8600,10 +8893,29 @@ export class NativeBackboneOPFSCoordinatePersistenceStore
 				// Main-thread OPFS and some browser contexts do not expose sync handles.
 			}
 			if (access) {
+				const originalSize = access.getSize();
+				let offset = 0;
 				try {
-					access.write(bytes, { at: access.getSize() });
+					while (offset < bytes.byteLength) {
+						offset += validateCoordinatePersistenceWriteProgress(
+							access.write(bytes.subarray(offset), {
+								at: originalSize + offset,
+							}),
+							bytes.byteLength - offset,
+							"OPFS coordinate WAL",
+						);
+					}
 					access.flush?.();
 					return;
+				} catch (error) {
+					try {
+						access.truncate?.(originalSize);
+						access.flush?.();
+					} catch {
+						// The sticky error below prevents appending behind a torn tail.
+					}
+					this.appendFailure ??= error;
+					throw this.appendFailure;
 				} finally {
 					access.close();
 				}
@@ -8614,8 +8926,16 @@ export class NativeBackboneOPFSCoordinatePersistenceStore
 		try {
 			await writable.seek(file.size);
 			await writable.write(bytes);
-		} finally {
 			await writable.close();
+		} catch (error) {
+			try {
+				await writable.close();
+			} catch {
+				// Preserve the first error; the adapter is terminal either way.
+			}
+			// Async OPFS reports no write progress, so failure may leave a torn tail.
+			this.appendFailure ??= error;
+			throw this.appendFailure;
 		}
 	}
 
@@ -8628,6 +8948,36 @@ export class NativeBackboneOPFSCoordinatePersistenceStore
 			}
 		}
 	}
+
+	async flush(_name?: string): Promise<void> {}
+
+	async durableBarrier(name?: string): Promise<void> {
+		if (!name) {
+			throw new Error(
+				"OPFS coordinate persistence requires a named durable barrier",
+			);
+		}
+		const handle = await this.directory.getFileHandle(
+			validateCoordinatePersistenceName(name),
+			{ create: false },
+		);
+		if (!handle.createSyncAccessHandle) {
+			throw new Error(
+				"OPFS coordinate persistence durable barriers require createSyncAccessHandle",
+			);
+		}
+		const access = await handle.createSyncAccessHandle();
+		try {
+			if (typeof access.flush !== "function") {
+				throw new Error(
+					"OPFS coordinate persistence sync handle does not expose flush",
+				);
+			}
+			access.flush();
+		} finally {
+			access.close();
+		}
+	}
 }
 
 export class NativeBackboneBufferedCoordinatePersistenceStore
@@ -8635,11 +8985,22 @@ export class NativeBackboneBufferedCoordinatePersistenceStore
 {
 	private readonly buffers = new Map<string, Uint8Array[]>();
 	private bufferedBytes = 0;
+	readonly supportsRemoval: boolean;
+	readonly durableBarrier?: (name?: string) => Promise<void>;
 
 	constructor(
 		private readonly inner: NativeBackboneCoordinatePersistenceStore,
 		private readonly options: { maxBufferedBytes?: number } = {},
-	) {}
+	) {
+		this.supportsRemoval =
+			inner.supportsRemoval ?? typeof inner.remove === "function";
+		if (typeof inner.durableBarrier === "function") {
+			this.durableBarrier = async (name) => {
+				await this.flush(name);
+				await inner.durableBarrier!(name);
+			};
+		}
+	}
 
 	private buffer(name: string): Uint8Array[] {
 		const validName = validateCoordinatePersistenceName(name);
@@ -8685,7 +9046,12 @@ export class NativeBackboneBufferedCoordinatePersistenceStore
 				this.bufferedBytes -= chunk.byteLength;
 			}
 		}
-		await this.inner.remove?.(name);
+		if (!this.inner.remove) {
+			throw new Error(
+				"Native backbone coordinate persistence store does not support removal",
+			);
+		}
+		await this.inner.remove(name);
 	}
 
 	async flush(name?: string): Promise<void> {
@@ -8702,12 +9068,17 @@ export class NativeBackboneBufferedCoordinatePersistenceStore
 			this.bufferedBytes -= bytes.byteLength;
 			await this.inner.append(fileName, bytes);
 		}
-		await this.inner.flush?.();
+		await this.inner.flush?.(name);
 	}
 
-	async close(): Promise<void> {
-		await this.flush();
-		await this.inner.close?.();
+	async close(options?: { flush?: boolean }): Promise<void> {
+		if (options?.flush === false) {
+			this.buffers.clear();
+			this.bufferedBytes = 0;
+		} else {
+			await this.flush();
+		}
+		await this.inner.close?.(options);
 	}
 }
 
@@ -8717,6 +9088,10 @@ export class NativeBackboneCoordinatePersistence {
 	readonly flushIntervalMs?: number;
 	readonly compactMaxJournalBytes?: number;
 	readonly compactMaxJournalRecords?: number;
+	readonly crashSafeCompaction = false;
+	readonly durableBarrier: boolean;
+	readonly supportsDrop: boolean;
+	readonly dropIsTerminal = true;
 	private readonly snapshotFile: string;
 	private readonly journalFile: string;
 	private readonly documentSnapshotFile: string;
@@ -8724,101 +9099,317 @@ export class NativeBackboneCoordinatePersistence {
 	private readonly documentSignerSnapshotFile: string;
 	private readonly documentSignerJournalFile: string;
 	private journalInitialized: boolean | undefined;
-	private journalByteLength = 0;
-	private journalRecordCount = 0;
 	private documentJournalInitialized: boolean | undefined;
-	private documentJournalByteLength = 0;
-	private documentJournalRecordCount = 0;
 	private documentSignerJournalInitialized: boolean | undefined;
-	private documentSignerJournalByteLength = 0;
-	private documentSignerJournalRecordCount = 0;
 	private lastFlushMs = Date.now();
 	private persistenceQueue: Promise<unknown> | undefined;
+	private persistenceLifecycle:
+		| "active"
+		| "hydrating"
+		| "dropping"
+		| "dropped"
+		| "closing"
+		| "closed" = "active";
+	private persistenceFailure: unknown;
+	private closePromise: Promise<void> | undefined;
 
 	constructor(
 		private readonly store: NativeBackboneCoordinatePersistenceStore,
 		options: NativeBackboneCoordinatePersistenceOptions = {},
 	) {
-		this.snapshotFile =
-			options.snapshot ?? nativeBackboneCoordinatePersistenceFiles.snapshot;
-		this.journalFile =
-			options.journal ?? nativeBackboneCoordinatePersistenceFiles.journal;
-		this.documentSnapshotFile =
+		this.durableBarrier = typeof store.durableBarrier === "function";
+		this.supportsDrop =
+			(store.supportsRemoval ?? typeof store.remove === "function") &&
+			typeof store.remove === "function";
+		this.snapshotFile = validateCoordinatePersistenceName(
+			options.snapshot ?? nativeBackboneCoordinatePersistenceFiles.snapshot,
+		);
+		this.journalFile = validateCoordinatePersistenceName(
+			options.journal ?? nativeBackboneCoordinatePersistenceFiles.journal,
+		);
+		this.documentSnapshotFile = validateCoordinatePersistenceName(
 			options.documentSnapshot ??
-			nativeBackboneCoordinatePersistenceFiles.documentSnapshot;
-		this.documentJournalFile =
+				nativeBackboneCoordinatePersistenceFiles.documentSnapshot,
+		);
+		this.documentJournalFile = validateCoordinatePersistenceName(
 			options.documentJournal ??
-			nativeBackboneCoordinatePersistenceFiles.documentJournal;
-		this.documentSignerSnapshotFile =
+				nativeBackboneCoordinatePersistenceFiles.documentJournal,
+		);
+		this.documentSignerSnapshotFile = validateCoordinatePersistenceName(
 			options.documentSignerSnapshot ??
-			nativeBackboneCoordinatePersistenceFiles.documentSignerSnapshot;
-		this.documentSignerJournalFile =
+				nativeBackboneCoordinatePersistenceFiles.documentSignerSnapshot,
+		);
+		this.documentSignerJournalFile = validateCoordinatePersistenceName(
 			options.documentSignerJournal ??
-			nativeBackboneCoordinatePersistenceFiles.documentSignerJournal;
+				nativeBackboneCoordinatePersistenceFiles.documentSignerJournal,
+		);
+		if (
+			this.configuredFiles().includes(nativeBackboneCoordinateDropTombstoneFile)
+		) {
+			throw new Error(
+				"Native backbone coordinate persistence file conflicts with its drop tombstone",
+			);
+		}
 		this.flushOnAppend = options.flushOnAppend ?? true;
 		this.flushMaxPendingBytes = resolveCoordinateFlushMaxPendingBytes(options);
 		if (options.flushIntervalMs != null) {
 			this.flushIntervalMs = Math.max(0, options.flushIntervalMs);
 		}
-		if (options.compactMaxJournalBytes != null) {
-			this.compactMaxJournalBytes = Math.max(
-				0,
-				options.compactMaxJournalBytes,
-			);
+		if (
+			options.compactMaxJournalBytes != null ||
+			options.compactMaxJournalRecords != null
+		) {
+			throw new Error(nativeBackboneCoordinateCompactionDisabledMessage);
 		}
-		if (options.compactMaxJournalRecords != null) {
-			this.compactMaxJournalRecords = Math.max(
-				0,
-				options.compactMaxJournalRecords,
+	}
+
+	/** Durable operation-intent capability for strict shared-log transactions. */
+	get intentStore(): NativeBackboneCoordinatePersistenceStore {
+		return this.store;
+	}
+
+	private configuredFiles(): string[] {
+		return [
+			this.snapshotFile,
+			this.journalFile,
+			this.documentSnapshotFile,
+			this.documentJournalFile,
+			this.documentSignerSnapshotFile,
+			this.documentSignerJournalFile,
+		];
+	}
+
+	private assertLifecycleActive(operation: string): void {
+		if (this.persistenceLifecycle !== "active") {
+			throw new Error(
+				`Native backbone coordinate persistence can not ${operation} while ${this.persistenceLifecycle}`,
 			);
 		}
 	}
 
-	async hydrate(backbone: NativePeerbitBackbone): Promise<number> {
-		const [
-			snapshot,
-			journal,
-			documentSnapshot,
-			documentJournal,
-			documentSignerSnapshot,
-			documentSignerJournal,
-		] = await Promise.all([
-			this.store.read(this.snapshotFile),
-			this.store.read(this.journalFile),
-			this.store.read(this.documentSnapshotFile),
-			this.store.read(this.documentJournalFile),
-			this.store.read(this.documentSignerSnapshotFile),
-			this.store.read(this.documentSignerJournalFile),
-		]);
-		const operations = backbone.loadCoordinateSnapshotAndJournal(
-			snapshot,
-			journal,
-		);
-		const documentOperations = backbone.loadDocumentSnapshotAndJournal(
-			documentSnapshot,
-			documentJournal,
-		);
-		const documentSignerOperations = backbone.loadDocumentSignerSnapshotAndJournal(
-			documentSignerSnapshot,
-			documentSignerJournal,
-		);
-		this.journalInitialized = !!journal && journal.byteLength > 0;
-		this.journalByteLength = journal?.byteLength ?? 0;
-		this.journalRecordCount = operations;
-		this.documentJournalInitialized =
-			!!documentJournal && documentJournal.byteLength > 0;
-		this.documentJournalByteLength = documentJournal?.byteLength ?? 0;
-		this.documentJournalRecordCount = documentOperations;
-		this.documentSignerJournalInitialized =
-			!!documentSignerJournal && documentSignerJournal.byteLength > 0;
-		this.documentSignerJournalByteLength =
-			documentSignerJournal?.byteLength ?? 0;
-		this.documentSignerJournalRecordCount = documentSignerOperations;
-		backbone.setCoordinateJournalEnabled(true);
-		backbone.setDocumentJournalEnabled(true);
-		backbone.setDocumentSignerJournalEnabled(true);
+	private assertActive(operation: string): void {
+		if (this.persistenceFailure !== undefined) {
+			throw this.persistenceFailure;
+		}
+		this.assertLifecycleActive(operation);
+	}
+
+	private resetJournalTracking(): void {
+		this.journalInitialized = undefined;
+		this.documentJournalInitialized = undefined;
+		this.documentSignerJournalInitialized = undefined;
 		this.lastFlushMs = Date.now();
-		return operations + documentOperations + documentSignerOperations;
+	}
+
+	private async eraseDropFiles(files: readonly string[]): Promise<void> {
+		if (!this.supportsDrop || !this.store.remove) {
+			throw new Error(
+				"Native backbone coordinate persistence store does not support removal",
+			);
+		}
+		const removals = await Promise.allSettled(
+			files.map((name) => this.store.remove!(name)),
+		);
+		const failures = removals.flatMap((result) =>
+			result.status === "rejected" ? [result.reason] : [],
+		);
+		if (failures.length > 0) {
+			throw new AggregateError(
+				failures,
+				"Failed to erase native backbone coordinate persistence namespace",
+			);
+		}
+		await this.store.flush?.();
+		await this.store.remove(nativeBackboneCoordinateDropTombstoneFile);
+		await this.store.flush?.();
+	}
+
+	async drop(additionalFiles: readonly string[] = []): Promise<void> {
+		// Drop is the recovery escape hatch for a persistence generation that has
+		// already failed closed, so only the lifecycle (not persistenceFailure)
+		// gates this destructive operation.
+		this.assertLifecycleActive("drop");
+		const files = [
+			...new Set([
+				...this.configuredFiles(),
+				...additionalFiles.map(validateCoordinatePersistenceName),
+			]),
+		];
+		if (files.includes(nativeBackboneCoordinateDropTombstoneFile)) {
+			throw new Error(
+				"Native backbone drop targets can not include the drop tombstone",
+			);
+		}
+		if (!this.supportsDrop || !this.store.remove) {
+			throw new Error(
+				"Native backbone coordinate persistence store does not support removal",
+			);
+		}
+		// Flip synchronously so no later append/compact can enqueue behind this
+		// erase and recreate a file after its removal.
+		this.persistenceLifecycle = "dropping";
+		await this.enqueuePersistence(async () => {
+			await this.store.write(
+				nativeBackboneCoordinateDropTombstoneFile,
+				nativeBackboneCoordinateDropTombstoneBytes(files),
+			);
+			if (this.store.durableBarrier) {
+				await this.store.durableBarrier(
+					nativeBackboneCoordinateDropTombstoneFile,
+				);
+			} else {
+				await this.store.flush?.(nativeBackboneCoordinateDropTombstoneFile);
+			}
+			await this.eraseDropFiles(files);
+			this.resetJournalTracking();
+			this.persistenceLifecycle = "dropped";
+		});
+	}
+
+	async resumeDrop(): Promise<boolean> {
+		this.assertActive("resume drop");
+		this.persistenceLifecycle = "dropping";
+		return this.enqueuePersistence(() => this.resumeDropInternal("active"));
+	}
+
+	async hydrate(backbone: NativePeerbitBackbone): Promise<number> {
+		this.assertActive("hydrate");
+		// Claim the lifecycle synchronously. close() queues after this complete
+		// read/validate/load operation; drop() rejects before erasing anything.
+		this.persistenceLifecycle = "hydrating";
+		return this.enqueuePersistence(async () => {
+			try {
+				this.assertHydrating();
+				await this.resumeDropInternal("hydrating");
+				this.assertHydrating();
+				const [
+					snapshot,
+					journal,
+					documentSnapshot,
+					documentJournal,
+					documentSignerSnapshot,
+					documentSignerJournal,
+				] = await Promise.all([
+					this.store.read(this.snapshotFile),
+					this.store.read(this.journalFile),
+					this.store.read(this.documentSnapshotFile),
+					this.store.read(this.documentJournalFile),
+					this.store.read(this.documentSignerSnapshotFile),
+					this.store.read(this.documentSignerJournalFile),
+				]);
+				this.assertHydrating();
+				try {
+					validateCoordinateJournal(journal, this.journalFile);
+					validateCoordinateJournal(documentJournal, this.documentJournalFile);
+					validateCoordinateJournal(
+						documentSignerJournal,
+						this.documentSignerJournalFile,
+					);
+				} catch (error) {
+					this.persistenceFailure ??= error;
+					throw this.persistenceFailure;
+				}
+				let operations: number;
+				let documentOperations: number;
+				let documentSignerOperations: number;
+				try {
+					this.assertHydrating();
+					operations = backbone.loadCoordinateSnapshotAndJournal(
+						snapshot,
+						journal,
+					);
+					this.assertHydrating();
+					documentOperations = backbone.loadDocumentSnapshotAndJournal(
+						documentSnapshot,
+						documentJournal,
+					);
+					this.assertHydrating();
+					documentSignerOperations =
+						backbone.loadDocumentSignerSnapshotAndJournal(
+							documentSignerSnapshot,
+							documentSignerJournal,
+						);
+				} catch (error) {
+					if (
+						journal?.byteLength ||
+						documentJournal?.byteLength ||
+						documentSignerJournal?.byteLength
+					) {
+						this.persistenceFailure ??= error;
+						throw this.persistenceFailure;
+					}
+					throw error;
+				}
+				this.assertHydrating();
+				this.journalInitialized = !!journal && journal.byteLength > 0;
+				this.documentJournalInitialized =
+					!!documentJournal && documentJournal.byteLength > 0;
+				this.documentSignerJournalInitialized =
+					!!documentSignerJournal && documentSignerJournal.byteLength > 0;
+				backbone.setCoordinateJournalEnabled(true);
+				backbone.setDocumentJournalEnabled(true);
+				backbone.setDocumentSignerJournalEnabled(true);
+				this.lastFlushMs = Date.now();
+				this.persistenceLifecycle = this.closePromise ? "closing" : "active";
+				return operations + documentOperations + documentSignerOperations;
+			} catch (error) {
+				if (this.persistenceLifecycle === "hydrating") {
+					this.persistenceLifecycle = this.closePromise ? "closing" : "active";
+				}
+				throw error;
+			}
+		});
+	}
+
+	private assertHydrating(): void {
+		if (this.persistenceLifecycle !== "hydrating") {
+			throw new Error(
+				`Native backbone coordinate persistence hydrate was interrupted while ${this.persistenceLifecycle}`,
+			);
+		}
+	}
+
+	private async resumeDropInternal(
+		finalLifecycle: "active" | "hydrating",
+	): Promise<boolean> {
+		const bytes = await this.store.read(
+			nativeBackboneCoordinateDropTombstoneFile,
+		);
+		if (!bytes) {
+			this.persistenceLifecycle =
+				finalLifecycle === "hydrating"
+					? "hydrating"
+					: this.closePromise
+						? "closing"
+						: "active";
+			return false;
+		}
+		let tombstone: NativeBackboneCoordinateDropTombstoneBody;
+		try {
+			tombstone = parseNativeBackboneCoordinateDropTombstone(bytes);
+			for (const file of this.configuredFiles()) {
+				if (!tombstone.files.includes(file)) {
+					throw new Error(
+						"Native backbone drop tombstone does not cover the configured namespace",
+					);
+				}
+			}
+		} catch (error) {
+			// Corruption must never hydrate stale files, but an explicit drop must
+			// remain available to overwrite the bad marker and erase the namespace.
+			this.persistenceFailure ??= error;
+			this.persistenceLifecycle = this.closePromise ? "closing" : "active";
+			throw this.persistenceFailure;
+		}
+		await this.eraseDropFiles(tombstone.files);
+		this.resetJournalTracking();
+		this.persistenceLifecycle =
+			finalLifecycle === "hydrating"
+				? "hydrating"
+				: this.closePromise
+					? "closing"
+					: "active";
+		return true;
 	}
 
 	shouldFlushJournalOnAppend(
@@ -8853,6 +9444,7 @@ export class NativeBackboneCoordinatePersistence {
 	flushJournalOnAppend(
 		backbone: NativePeerbitBackbone,
 	): number | Promise<number> {
+		this.assertActive("flush on append");
 		if (!this.shouldFlushJournalOnAppend(backbone)) {
 			return 0;
 		}
@@ -8860,6 +9452,7 @@ export class NativeBackboneCoordinatePersistence {
 	}
 
 	flushJournal(backbone: NativePeerbitBackbone): Promise<number> {
+		this.assertActive("flush");
 		// Serialized with compact() so a flush never clears records appended to
 		// the wasm journal while a previous flush was awaiting its disk write.
 		return this.enqueuePersistence(() => this.flushJournalInternal(backbone));
@@ -8869,9 +9462,7 @@ export class NativeBackboneCoordinatePersistence {
 		// Runs `fn` immediately when no other persistence operation is in
 		// flight so the common uncontended flush starts synchronously; queued
 		// operations still run strictly one at a time, in order.
-		const next = this.persistenceQueue
-			? this.persistenceQueue.then(fn)
-			: fn();
+		const next = this.persistenceQueue ? this.persistenceQueue.then(fn) : fn();
 		const tail: Promise<void> = next.then(
 			() => undefined,
 			() => undefined,
@@ -8889,153 +9480,151 @@ export class NativeBackboneCoordinatePersistence {
 		backbone: NativePeerbitBackbone,
 	): Promise<number> {
 		let written = 0;
+		let persistenceMutationStarted = false;
+		let coordinateBytes: Uint8Array | undefined;
+		let documentBytes: Uint8Array | undefined;
+		let signerBytes: Uint8Array | undefined;
 		const coordinateRecords = backbone.coordinateJournal();
 		const coordinateRecordCount = backbone.coordinatePendingJournalLength;
-		if (coordinateRecords.byteLength > 0) {
-			if (this.journalInitialized === undefined) {
-				const existing = await this.store.read(this.journalFile);
-				this.journalInitialized = !!existing && existing.byteLength > 0;
+		const documentRecords = backbone.documentJournal();
+		const documentRecordCount = backbone.documentPendingJournalLength;
+		const signerRecords = backbone.documentSignerJournal();
+		const signerRecordCount = backbone.documentSignerPendingJournalLength;
+		try {
+			if (coordinateRecords.byteLength > 0) {
+				if (this.journalInitialized === undefined) {
+					const existing = await this.store.read(this.journalFile);
+					this.journalInitialized = !!existing && existing.byteLength > 0;
+				}
+				coordinateBytes = this.journalInitialized
+					? coordinateRecords
+					: concatBytes([
+							backbone.coordinateJournalHeader(),
+							coordinateRecords,
+						]);
+				await this.store.append(this.journalFile, coordinateBytes);
+				persistenceMutationStarted = true;
+				written += coordinateRecords.byteLength;
 			}
-			const bytes = this.journalInitialized
-				? coordinateRecords
-				: concatBytes([backbone.coordinateJournalHeader(), coordinateRecords]);
-			await this.store.append(this.journalFile, bytes);
-			this.journalInitialized = true;
-			this.journalByteLength += bytes.byteLength;
-			this.journalRecordCount += coordinateRecordCount;
+			if (documentRecords.byteLength > 0) {
+				if (this.documentJournalInitialized === undefined) {
+					const existing = await this.store.read(this.documentJournalFile);
+					this.documentJournalInitialized =
+						!!existing && existing.byteLength > 0;
+				}
+				documentBytes = this.documentJournalInitialized
+					? documentRecords
+					: concatBytes([backbone.documentJournalHeader(), documentRecords]);
+				await this.store.append(this.documentJournalFile, documentBytes);
+				persistenceMutationStarted = true;
+				written += documentRecords.byteLength;
+			}
+			if (signerRecords.byteLength > 0) {
+				if (this.documentSignerJournalInitialized === undefined) {
+					const existing = await this.store.read(
+						this.documentSignerJournalFile,
+					);
+					this.documentSignerJournalInitialized =
+						!!existing && existing.byteLength > 0;
+				}
+				signerBytes = this.documentSignerJournalInitialized
+					? signerRecords
+					: concatBytes([
+							backbone.documentSignerJournalHeader(),
+							signerRecords,
+						]);
+				await this.store.append(this.documentSignerJournalFile, signerBytes);
+				persistenceMutationStarted = true;
+				written += signerRecords.byteLength;
+			}
+			if (written === 0) {
+				this.lastFlushMs = Date.now();
+				return 0;
+			}
+
+			// `append` may only enqueue bytes in a buffered store. Drain and fsync
+			// every affected WAL before clearing its wasm prefix or returning an ACK.
+			for (const file of [
+				coordinateBytes ? this.journalFile : undefined,
+				documentBytes ? this.documentJournalFile : undefined,
+				signerBytes ? this.documentSignerJournalFile : undefined,
+			]) {
+				if (file) {
+					if (this.store.durableBarrier) {
+						await this.store.durableBarrier(file);
+					} else {
+						await this.store.flush?.(file);
+					}
+				}
+			}
+
+			if (coordinateBytes) {
+				this.journalInitialized = true;
+			}
+			if (documentBytes) {
+				this.documentJournalInitialized = true;
+			}
+			if (signerBytes) {
+				this.documentSignerJournalInitialized = true;
+			}
+
 			backbone.clearCoordinateJournalPrefix(
 				coordinateRecords.byteLength,
 				coordinateRecordCount,
 			);
-			written += coordinateRecords.byteLength;
-		}
-		const documentRecords = backbone.documentJournal();
-		const documentRecordCount = backbone.documentPendingJournalLength;
-		if (documentRecords.byteLength > 0) {
-			if (this.documentJournalInitialized === undefined) {
-				const existing = await this.store.read(this.documentJournalFile);
-				this.documentJournalInitialized = !!existing && existing.byteLength > 0;
-			}
-			const bytes = this.documentJournalInitialized
-				? documentRecords
-				: concatBytes([backbone.documentJournalHeader(), documentRecords]);
-			await this.store.append(this.documentJournalFile, bytes);
-			this.documentJournalInitialized = true;
-			this.documentJournalByteLength += bytes.byteLength;
-			this.documentJournalRecordCount += documentRecordCount;
 			backbone.clearDocumentJournalPrefix(
 				documentRecords.byteLength,
 				documentRecordCount,
 			);
-			written += documentRecords.byteLength;
-		}
-		const signerRecords = backbone.documentSignerJournal();
-		const signerRecordCount = backbone.documentSignerPendingJournalLength;
-		if (signerRecords.byteLength > 0) {
-			if (this.documentSignerJournalInitialized === undefined) {
-				const existing = await this.store.read(this.documentSignerJournalFile);
-				this.documentSignerJournalInitialized =
-					!!existing && existing.byteLength > 0;
-			}
-			const bytes = this.documentSignerJournalInitialized
-				? signerRecords
-				: concatBytes([backbone.documentSignerJournalHeader(), signerRecords]);
-			await this.store.append(this.documentSignerJournalFile, bytes);
-			this.documentSignerJournalInitialized = true;
-			this.documentSignerJournalByteLength += bytes.byteLength;
-			this.documentSignerJournalRecordCount += signerRecordCount;
 			backbone.clearDocumentSignerJournalPrefix(
 				signerRecords.byteLength,
 				signerRecordCount,
 			);
-			written += signerRecords.byteLength;
-		}
-		if (written === 0) {
 			this.lastFlushMs = Date.now();
-			return 0;
+			return written;
+		} catch (error) {
+			if (persistenceMutationStarted) {
+				this.persistenceFailure ??= error;
+				throw this.persistenceFailure;
+			}
+			throw error;
 		}
-		this.lastFlushMs = Date.now();
-		if (this.shouldCompactJournal()) {
-			await this.compactInternal(backbone);
+	}
+
+	async compact(_backbone: NativePeerbitBackbone): Promise<void> {
+		this.assertActive("compact");
+		throw new Error(nativeBackboneCoordinateCompactionDisabledMessage);
+	}
+
+	close(): Promise<void> {
+		if (this.closePromise) {
+			return this.closePromise;
 		}
-		return written;
-	}
-
-	private shouldCompactJournal(): boolean {
-		return (
-			(this.compactMaxJournalBytes != null &&
-				this.journalByteLength +
-					this.documentJournalByteLength +
-					this.documentSignerJournalByteLength >=
-					this.compactMaxJournalBytes) ||
-			(this.compactMaxJournalRecords != null &&
-				this.journalRecordCount +
-					this.documentJournalRecordCount +
-					this.documentSignerJournalRecordCount >=
-					this.compactMaxJournalRecords)
-		);
-	}
-
-	compact(backbone: NativePeerbitBackbone): Promise<void> {
-		return this.enqueuePersistence(() => this.compactInternal(backbone));
-	}
-
-	private async compactInternal(backbone: NativePeerbitBackbone): Promise<void> {
-		// The snapshots below cover exactly the journal records pending right
-		// now; records appended during the awaited writes must survive the
-		// clears at the end, so only this prefix is dropped.
-		const coordinateJournalByteLength =
-			backbone.coordinatePendingJournalByteLength;
-		const coordinateJournalRecordCount =
-			backbone.coordinatePendingJournalLength;
-		const documentJournalByteLength = backbone.documentPendingJournalByteLength;
-		const documentJournalRecordCount = backbone.documentPendingJournalLength;
-		const documentSignerJournalByteLength =
-			backbone.documentSignerPendingJournalByteLength;
-		const documentSignerJournalRecordCount =
-			backbone.documentSignerPendingJournalLength;
-		await Promise.all([
-			this.store.write(this.snapshotFile, backbone.coordinateSnapshot()),
-			this.store.write(this.documentSnapshotFile, backbone.documentSnapshot()),
-			this.store.write(
-				this.documentSignerSnapshotFile,
-				backbone.documentSignerSnapshot(),
-			),
-		]);
-		await Promise.all([
-			this.store.remove?.(this.journalFile),
-			this.store.remove?.(this.documentJournalFile),
-			this.store.remove?.(this.documentSignerJournalFile),
-		]);
-		this.journalInitialized = false;
-		this.journalByteLength = 0;
-		this.journalRecordCount = 0;
-		this.documentJournalInitialized = false;
-		this.documentJournalByteLength = 0;
-		this.documentJournalRecordCount = 0;
-		this.documentSignerJournalInitialized = false;
-		this.documentSignerJournalByteLength = 0;
-		this.documentSignerJournalRecordCount = 0;
-		backbone.clearCoordinateJournalPrefix(
-			coordinateJournalByteLength,
-			coordinateJournalRecordCount,
-		);
-		backbone.clearDocumentJournalPrefix(
-			documentJournalByteLength,
-			documentJournalRecordCount,
-		);
-		backbone.clearDocumentSignerJournalPrefix(
-			documentSignerJournalByteLength,
-			documentSignerJournalRecordCount,
-		);
-		// Compact persists the full pending state, so it restarts the
-		// flushIntervalMs pacing window like a flush does.
-		this.lastFlushMs = Date.now();
-	}
-
-	async close(): Promise<void> {
-		await this.store.flush?.();
-		await this.store.close?.();
+		// Close wins once invoked from an active generation. The synchronous
+		// transition rejects any later drop/hydrate/flush before the terminal
+		// store close starts, including for stores that forbid all post-close I/O.
+		const closesActiveGeneration = this.persistenceLifecycle === "active";
+		if (closesActiveGeneration) {
+			this.persistenceLifecycle = "closing";
+		}
+		this.closePromise = this.enqueuePersistence(async () => {
+			if (closesActiveGeneration || this.persistenceLifecycle === "active") {
+				this.persistenceLifecycle = "closing";
+				await this.store.flush?.();
+				await this.store.close?.();
+				this.persistenceLifecycle = "closed";
+				return;
+			}
+			if (this.persistenceLifecycle === "closing") {
+				await this.store.close?.({ flush: false });
+				this.persistenceLifecycle = "closed";
+				return;
+			}
+			// A drop already in flight wins. Drain no buffered bytes after its
+			// tombstone erase and preserve the dropped terminal lifecycle.
+			await this.store.close?.({ flush: false });
+		});
+		return this.closePromise;
 	}
 }
 
@@ -9093,20 +9682,13 @@ export const createNativeBackboneCoordinatePersistence = (
 		return config;
 	}
 	const { store, buffered, ...options } = config;
-	const isBuffered = buffered === true || !!buffered;
 	const resolvedStore =
 		buffered === true
 			? new NativeBackboneBufferedCoordinatePersistenceStore(store)
 			: buffered
 				? new NativeBackboneBufferedCoordinatePersistenceStore(store, buffered)
 				: store;
-	return new NativeBackboneCoordinatePersistence(resolvedStore, {
-		...options,
-		compactMaxJournalBytes:
-			isBuffered && options.compactMaxJournalBytes == null
-				? defaultNativeBackboneCoordinateCompactMaxJournalBytes
-				: options.compactMaxJournalBytes,
-	});
+	return new NativeBackboneCoordinatePersistence(resolvedStore, options);
 };
 
 export const createBufferedNativeBackboneCoordinatePersistence = (
@@ -9117,8 +9699,7 @@ export const createBufferedNativeBackboneCoordinatePersistence = (
 		options.maxBufferedBytes ??
 		options.flushMaxPendingBytes ??
 		defaultNativeBackboneCoordinateFlushMaxPendingBytes;
-	const flushMaxPendingBytes =
-		options.flushMaxPendingBytes ?? maxBufferedBytes;
+	const flushMaxPendingBytes = options.flushMaxPendingBytes ?? maxBufferedBytes;
 	return new NativeBackboneCoordinatePersistence(
 		new NativeBackboneBufferedCoordinatePersistenceStore(store, {
 			maxBufferedBytes,
@@ -9133,9 +9714,7 @@ export const createBufferedNativeBackboneCoordinatePersistence = (
 			flushOnAppend: false,
 			flushMaxPendingBytes,
 			flushIntervalMs: options.flushIntervalMs,
-			compactMaxJournalBytes:
-				options.compactMaxJournalBytes ??
-				defaultNativeBackboneCoordinateCompactMaxJournalBytes,
+			compactMaxJournalBytes: options.compactMaxJournalBytes,
 			compactMaxJournalRecords: options.compactMaxJournalRecords,
 		},
 	);
@@ -9153,9 +9732,6 @@ export const createBufferedNativeBackboneNodeCoordinatePersistence = (
 		flushOnAppend: false,
 		flushMaxPendingBytes,
 		writeBufferMaxBytes: options.writeBufferMaxBytes ?? flushMaxPendingBytes,
-		compactMaxJournalBytes:
-			options.compactMaxJournalBytes ??
-			defaultNativeBackboneCoordinateCompactMaxJournalBytes,
 	});
 };
 

--- a/packages/utils/native-backbone/test/index.spec.ts
+++ b/packages/utils/native-backbone/test/index.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import { benchmarkPlainCommittedNoNextStorageAppendTransactionLoop } from "../src/benchmark.js";
 import {
 	NativeBackboneBufferedCoordinatePersistenceStore,
 	NativeBackboneCoordinatePersistence,
@@ -12,10 +13,8 @@ import {
 	createBufferedNativeBackboneNodeCoordinatePersistence,
 	createNativeBackboneCoordinatePersistence,
 	createNativePeerbitBackbone,
-	defaultNativeBackboneCoordinateCompactMaxJournalBytes,
 	defaultNativeBackboneCoordinateFlushMaxPendingBytes,
 } from "../src/index.js";
-import { benchmarkPlainCommittedNoNextStorageAppendTransactionLoop } from "../src/benchmark.js";
 
 const fromHex = (hex: string) =>
 	Uint8Array.from(
@@ -206,6 +205,7 @@ class FakeOPFSFileHandle {
 	async createSyncAccessHandle(): Promise<{
 		getSize(): number;
 		write(buffer: Uint8Array, options?: { at?: number }): number;
+		truncate(size: number): void;
 		flush(): void;
 		close(): void;
 	}> {
@@ -220,9 +220,15 @@ class FakeOPFSFileHandle {
 		return {
 			getSize: () => this.directory.fileBytes(this.name).byteLength,
 			write: (buffer, options) => {
-				this.writeAt(options?.at ?? 0, buffer);
+				const written = this.directory.nextSyncWriteCount(buffer.byteLength);
+				if (written > 0 && written <= buffer.byteLength) {
+					this.writeAt(options?.at ?? 0, buffer.subarray(0, written));
+				}
 				this.directory.syncWriteCount++;
-				return buffer.byteLength;
+				return written;
+			},
+			truncate: (size) => {
+				this.replace(this.directory.fileBytes(this.name).subarray(0, size));
 			},
 			flush: () => {
 				this.directory.syncFlushCount++;
@@ -259,7 +265,14 @@ class FakeOPFSDirectoryHandle implements NativeBackboneOPFSDirectoryHandle {
 	syncFlushCount = 0;
 	syncCloseCount = 0;
 
-	constructor(private readonly syncAccess = false) {}
+	constructor(
+		private readonly syncAccess = false,
+		private readonly syncWriteCounts: number[] = [],
+	) {}
+
+	nextSyncWriteCount(requested: number): number {
+		return this.syncWriteCounts.shift() ?? requested;
+	}
 
 	fileBytes(name: string): Uint8Array {
 		return this.files.get(name)?.slice() ?? new Uint8Array();
@@ -366,9 +379,7 @@ describe("native peerbit backbone", () => {
 			flushOnAppend: false,
 		});
 
-		expect(persistence.compactMaxJournalBytes).equal(
-			defaultNativeBackboneCoordinateCompactMaxJournalBytes,
-		);
+		expect(persistence.compactMaxJournalBytes).equal(undefined);
 		await persistence.hydrate(backbone);
 		backbone.putEntryCoordinates(
 			"hash-config",
@@ -381,52 +392,24 @@ describe("native peerbit backbone", () => {
 		expect(await persistence.flushJournalOnAppend?.(backbone)).equal(0);
 		expect(store.files.has("coordinates.wal")).equal(false);
 		expect(await persistence.flushJournal(backbone)).to.be.greaterThan(0);
-		expect(store.files.has("coordinates.wal")).equal(false);
+		expect(store.files.has("coordinates.wal")).equal(true);
 		await persistence.close?.();
 		expect(store.files.get("coordinates.wal")?.byteLength).to.be.greaterThan(
 			backbone.coordinateJournalHeader().byteLength,
 		);
 	});
 
-	it("honors buffered store config coordinate WAL checkpoint thresholds", async () => {
-		const backbone = await createNativePeerbitBackbone({
-			clockId: publicKey,
-			privateKey,
-			publicKey,
-		});
-		const restored = await createNativePeerbitBackbone({
-			clockId: publicKey,
-			privateKey,
-			publicKey,
-		});
+	it("rejects buffered store config coordinate WAL compaction thresholds", () => {
 		const store = new NativeBackboneMemoryCoordinatePersistenceStore();
-		const persistence = createNativeBackboneCoordinatePersistence({
-			store,
-			buffered: true,
-			flushOnAppend: false,
-			flushMaxPendingBytes: 1,
-			compactMaxJournalRecords: 1,
-		});
-
-		await persistence.hydrate(backbone);
-		backbone.putEntryCoordinates(
-			"hash-buffered-config-compact",
-			"gid-buffered-config-compact",
-			[1n],
-			false,
-			1,
-			1n,
-		);
-
-		expect(await persistence.flushJournalOnAppend?.(backbone)).to.be.greaterThan(
-			0,
-		);
-		expect(store.files.has("coordinates.bin")).equal(true);
-		expect(store.files.has("coordinates.wal")).equal(false);
-		await new NativeBackboneCoordinatePersistence(store).hydrate(restored);
-		expect(restored.getEntryCoordinateHashes()).to.deep.equal([
-			"hash-buffered-config-compact",
-		]);
+		expect(() =>
+			createNativeBackboneCoordinatePersistence({
+				store,
+				buffered: true,
+				flushOnAppend: false,
+				flushMaxPendingBytes: 1,
+				compactMaxJournalRecords: 1,
+			}),
+		).to.throw("compaction is disabled");
 	});
 
 	it("creates high-throughput buffered coordinate persistence with bounded flush policy", async () => {
@@ -443,9 +426,7 @@ describe("native peerbit backbone", () => {
 
 		expect(persistence.flushOnAppend).equal(false);
 		expect(persistence.flushMaxPendingBytes).equal(1024);
-		expect(persistence.compactMaxJournalBytes).equal(
-			defaultNativeBackboneCoordinateCompactMaxJournalBytes,
-		);
+		expect(persistence.compactMaxJournalBytes).equal(undefined);
 		await persistence.hydrate(backbone);
 		backbone.putEntryCoordinates(
 			"hash-buffered",
@@ -459,7 +440,7 @@ describe("native peerbit backbone", () => {
 		expect(await persistence.flushJournalOnAppend?.(backbone)).equal(0);
 		expect(store.files.has("coordinates.wal")).equal(false);
 		expect(await persistence.flushJournal(backbone)).to.be.greaterThan(0);
-		expect(store.files.has("coordinates.wal")).equal(false);
+		expect(store.files.has("coordinates.wal")).equal(true);
 		await persistence.close?.();
 		expect(store.files.get("coordinates.wal")?.byteLength).to.be.greaterThan(
 			backbone.coordinateJournalHeader().byteLength,
@@ -497,22 +478,24 @@ describe("native peerbit backbone", () => {
 		);
 
 		await persistence.hydrate(source);
-		source.preparePlainCommittedNoNextStorageAppendDocumentIndexCompactTransaction({
-			wallTime: 11n,
-			logical: 1,
-			gid: "gid-buffered-document-custom",
-			payloadData: new Uint8Array([1, 2, 3]),
-			replicas: 1,
-			selfHash: "peer",
-			documentIndex: {
-				key: "doc-buffered-custom",
-				valuePrefixBytes: new Uint8Array(0),
+		source.preparePlainCommittedNoNextStorageAppendDocumentIndexCompactTransaction(
+			{
+				wallTime: 11n,
+				logical: 1,
+				gid: "gid-buffered-document-custom",
+				payloadData: new Uint8Array([1, 2, 3]),
+				replicas: 1,
+				selfHash: "peer",
+				documentIndex: {
+					key: "doc-buffered-custom",
+					valuePrefixBytes: new Uint8Array(0),
+				},
 			},
-		});
+		);
 		expect(source.documentPendingJournalLength).equal(1);
 
 		expect(await persistence.flushJournal(source)).to.be.greaterThan(0);
-		expect(store.files.has("custom-document-values.wal")).equal(false);
+		expect(store.files.has("custom-document-values.wal")).equal(true);
 		expect(store.files.has("document-values.wal")).equal(false);
 		await persistence.close?.();
 		expect(store.files.has("custom-document-values.wal")).equal(true);
@@ -571,18 +554,20 @@ describe("native peerbit backbone", () => {
 		);
 
 		await persistence.hydrate(source);
-		source.preparePlainCommittedNoNextStorageAppendDocumentIndexCompactTransaction({
-			wallTime: 11n,
-			logical: 1,
-			gid: "gid-buffered-document-signer-custom",
-			payloadData: new Uint8Array([1, 2, 3]),
-			replicas: 1,
-			selfHash: "peer",
-			documentIndex: {
-				key: "doc-buffered-signer-custom",
-				valuePrefixBytes: new Uint8Array(0),
+		source.preparePlainCommittedNoNextStorageAppendDocumentIndexCompactTransaction(
+			{
+				wallTime: 11n,
+				logical: 1,
+				gid: "gid-buffered-document-signer-custom",
+				payloadData: new Uint8Array([1, 2, 3]),
+				replicas: 1,
+				selfHash: "peer",
+				documentIndex: {
+					key: "doc-buffered-signer-custom",
+					valuePrefixBytes: new Uint8Array(0),
+				},
 			},
-		});
+		);
 		const documentValue = source.documentValueBytes(
 			"doc-buffered-signer-custom",
 		);
@@ -595,7 +580,7 @@ describe("native peerbit backbone", () => {
 		expect(source.documentSignerPendingJournalLength).equal(1);
 
 		expect(await persistence.flushJournal(source)).to.be.greaterThan(0);
-		expect(store.files.has("custom-document-signers.wal")).equal(false);
+		expect(store.files.has("custom-document-signers.wal")).equal(true);
 		expect(store.files.has("document-signers.wal")).equal(false);
 		await persistence.close?.();
 		expect(store.files.has("custom-document-signers.wal")).equal(true);
@@ -620,77 +605,24 @@ describe("native peerbit backbone", () => {
 		).to.deep.equal(Array.from(publicKey));
 	});
 
-	it("checkpoints generic coordinate WAL after compact thresholds", async () => {
-		const backbone = await createNativePeerbitBackbone({
-			clockId: publicKey,
-			privateKey,
-			publicKey,
-		});
-		const restored = await createNativePeerbitBackbone({
-			clockId: publicKey,
-			privateKey,
-			publicKey,
-		});
+	it("rejects generic coordinate WAL compaction thresholds", () => {
 		const store = new NativeBackboneMemoryCoordinatePersistenceStore();
-		const persistence = new NativeBackboneCoordinatePersistence(store, {
-			compactMaxJournalRecords: 1,
-		});
-
-		await persistence.hydrate(backbone);
-		backbone.putEntryCoordinates(
-			"hash-compact",
-			"gid-compact",
-			[1n],
-			false,
-			1,
-			1n,
-		);
-
-		expect(await persistence.flushJournal(backbone)).to.be.greaterThan(0);
-		expect(store.files.has("coordinates.bin")).equal(true);
-		expect(store.files.has("coordinates.wal")).equal(false);
-		expect(backbone.coordinatePendingJournalLength).equal(0);
-		await new NativeBackboneCoordinatePersistence(store).hydrate(restored);
-		expect(restored.getEntryCoordinateHashes()).to.deep.equal(["hash-compact"]);
+		expect(
+			() =>
+				new NativeBackboneCoordinatePersistence(store, {
+					compactMaxJournalBytes: 1,
+				}),
+		).to.throw("compaction is disabled");
 	});
 
-	it("checkpoints buffered coordinate WAL after compact thresholds", async () => {
-		const backbone = await createNativePeerbitBackbone({
-			clockId: publicKey,
-			privateKey,
-			publicKey,
-		});
-		const restored = await createNativePeerbitBackbone({
-			clockId: publicKey,
-			privateKey,
-			publicKey,
-		});
+	it("rejects buffered coordinate WAL compaction thresholds", () => {
 		const store = new NativeBackboneMemoryCoordinatePersistenceStore();
-		const persistence = createBufferedNativeBackboneCoordinatePersistence(
-			store,
-			{ compactMaxJournalRecords: 1, flushMaxPendingBytes: 1 },
-		);
-
-		await persistence.hydrate(backbone);
-		backbone.putEntryCoordinates(
-			"hash-buffered-compact",
-			"gid-buffered-compact",
-			[1n],
-			false,
-			1,
-			1n,
-		);
-
-		expect(await persistence.flushJournalOnAppend?.(backbone)).to.be.greaterThan(
-			0,
-		);
-		expect(store.files.has("coordinates.bin")).equal(true);
-		expect(store.files.has("coordinates.wal")).equal(false);
-		expect(backbone.coordinatePendingJournalLength).equal(0);
-		await new NativeBackboneCoordinatePersistence(store).hydrate(restored);
-		expect(restored.getEntryCoordinateHashes()).to.deep.equal([
-			"hash-buffered-compact",
-		]);
+		expect(() =>
+			createBufferedNativeBackboneCoordinatePersistence(store, {
+				compactMaxJournalRecords: 1,
+				flushMaxPendingBytes: 1,
+			}),
+		).to.throw("compaction is disabled");
 	});
 
 	it("owns coordinate WAL append flush decisions", async () => {
@@ -1040,10 +972,7 @@ describe("native peerbit backbone", () => {
 			undefined,
 			undefined,
 		]);
-		expect(results?.map((result) => result.entry.next)).to.deep.equal([
-			[],
-			[],
-		]);
+		expect(results?.map((result) => result.entry.next)).to.deep.equal([[], []]);
 		expect(backbone.documentValueLength).to.equal(2);
 		expect(backbone.getEntryCoordinateHashes()).to.deep.equal(
 			results?.map((result) => result.entry.hash),
@@ -1084,8 +1013,7 @@ describe("native peerbit backbone", () => {
 							documentIndex: {
 								key: "doc-projected-batch-1",
 								projection: {
-									encodedDocument:
-										encodedDocumentWithIdScoreAndBytes("abc", 7),
+									encodedDocument: encodedDocumentWithIdScoreAndBytes("abc", 7),
 									plan: projection,
 								},
 							},
@@ -1098,8 +1026,7 @@ describe("native peerbit backbone", () => {
 							documentIndex: {
 								key: "doc-projected-batch-2",
 								projection: {
-									encodedDocument:
-										encodedDocumentWithIdScoreAndBytes("def", 8),
+									encodedDocument: encodedDocumentWithIdScoreAndBytes("def", 8),
 									plan: projection,
 								},
 							},
@@ -1124,11 +1051,11 @@ describe("native peerbit backbone", () => {
 		).to.equal("doc-projected-batch-2");
 	});
 
-		it("batches compact committed no-next cached-plan plain-put-payload document index transactions", async () => {
-			const backbone = await createNativePeerbitBackbone({
-				clockId: publicKey,
-				privateKey,
-				publicKey,
+	it("batches compact committed no-next cached-plan plain-put-payload document index transactions", async () => {
+		const backbone = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
 		});
 		backbone.configureDocumentSchemaIr(contextOnlySchema());
 		backbone.setDocumentContextHeadField(3);
@@ -1190,55 +1117,55 @@ describe("native peerbit backbone", () => {
 			backbone.documentExactStringFirstKey(3, results![0]!.entry.hash),
 		).to.equal("doc-projected-payload-batch-1");
 		expect(
-				backbone.documentExactStringFirstKey(3, results![1]!.entry.hash),
-			).to.equal("doc-projected-payload-batch-2");
+			backbone.documentExactStringFirstKey(3, results![1]!.entry.hash),
+		).to.equal("doc-projected-payload-batch-2");
+	});
+
+	it("commits compact no-next identity document indexes from plain put payloads", async () => {
+		const backbone = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
+		});
+		backbone.configureDocumentSchemaIr(contextOnlySchema());
+		backbone.setDocumentContextHeadField(3);
+		backbone.setDocumentContextFields({
+			created: 1,
+			modified: 2,
+			head: 3,
+			gid: 4,
+			size: 5,
 		});
 
-		it("commits compact no-next identity document indexes from plain put payloads", async () => {
-			const backbone = await createNativePeerbitBackbone({
-				clockId: publicKey,
-				privateKey,
-				publicKey,
-			});
-			backbone.configureDocumentSchemaIr(contextOnlySchema());
-			backbone.setDocumentContextHeadField(3);
-			backbone.setDocumentContextFields({
-				created: 1,
-				modified: 2,
-				head: 3,
-				gid: 4,
-				size: 5,
-			});
-
-			const result =
-				backbone.preparePlainCommittedNoNextStorageAppendDocumentIndexCompactTransaction(
-					{
-						wallTime: 34n,
-						logical: 1,
-						gid: "gid-doc-index-identity-payload",
-						payloadData: plainPutPayload(new Uint8Array(0)),
-						documentIndex: {
-							key: "doc-identity-payload",
-							valuePrefixBytes: new Uint8Array(0),
-							usePlainPutPayload: true,
-						},
-						replicas: 1,
-						selfHash: "peer",
+		const result =
+			backbone.preparePlainCommittedNoNextStorageAppendDocumentIndexCompactTransaction(
+				{
+					wallTime: 34n,
+					logical: 1,
+					gid: "gid-doc-index-identity-payload",
+					payloadData: plainPutPayload(new Uint8Array(0)),
+					documentIndex: {
+						key: "doc-identity-payload",
+						valuePrefixBytes: new Uint8Array(0),
+						usePlainPutPayload: true,
 					},
-				);
+					replicas: 1,
+					selfHash: "peer",
+				},
+			);
 
-			expect(result.entry.bytes).equal(undefined);
-			expect(backbone.documentValueLength).to.equal(1);
-			expect(
-				backbone.documentExactStringFirstKey(3, result.entry.hash),
-			).to.equal("doc-identity-payload");
-		});
+		expect(result.entry.bytes).equal(undefined);
+		expect(backbone.documentValueLength).to.equal(1);
+		expect(backbone.documentExactStringFirstKey(3, result.entry.hash)).to.equal(
+			"doc-identity-payload",
+		);
+	});
 
-		it("batches committed latest-context document index transactions", async () => {
-			const backbone = await createNativePeerbitBackbone({
-				clockId: publicKey,
-				privateKey,
-				publicKey,
+	it("batches committed latest-context document index transactions", async () => {
+		const backbone = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
 		});
 		backbone.configureDocumentSchemaIr(contextOnlySchema());
 		backbone.setDocumentContextHeadField(3);
@@ -1298,71 +1225,71 @@ describe("native peerbit backbone", () => {
 			first[0]!.entry.hash,
 		);
 		expect(backbone.documentValueLength).to.equal(1);
-			expect(
-				backbone.documentExactStringFirstKey(3, updated[0]!.entry.hash),
-			).to.equal("doc-latest-batch-1");
+		expect(
+			backbone.documentExactStringFirstKey(3, updated[0]!.entry.hash),
+		).to.equal("doc-latest-batch-1");
+	});
+
+	it("commits latest-context identity document indexes from plain put payloads", async () => {
+		const backbone = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
+		});
+		backbone.configureDocumentSchemaIr(contextOnlySchema());
+		backbone.setDocumentContextHeadField(3);
+		backbone.setDocumentContextFields({
+			created: 1,
+			modified: 2,
+			head: 3,
+			gid: 4,
+			size: 5,
 		});
 
-		it("commits latest-context identity document indexes from plain put payloads", async () => {
-			const backbone = await createNativePeerbitBackbone({
-				clockId: publicKey,
-				privateKey,
-				publicKey,
-			});
-			backbone.configureDocumentSchemaIr(contextOnlySchema());
-			backbone.setDocumentContextHeadField(3);
-			backbone.setDocumentContextFields({
-				created: 1,
-				modified: 2,
-				head: 3,
-				gid: 4,
-				size: 5,
-			});
-
-			const first =
-				backbone.preparePlainCommittedNoNextStorageAppendDocumentIndexCompactTransaction(
-					{
-						wallTime: 44n,
-						logical: 1,
-						gid: "gid-doc-latest-identity",
-						payloadData: plainPutPayload(new Uint8Array(0)),
-						documentIndex: {
-							key: "doc-latest-identity",
-							valuePrefixBytes: new Uint8Array(0),
-							usePlainPutPayload: true,
-						},
-						replicas: 1,
-						selfHash: "peer",
+		const first =
+			backbone.preparePlainCommittedNoNextStorageAppendDocumentIndexCompactTransaction(
+				{
+					wallTime: 44n,
+					logical: 1,
+					gid: "gid-doc-latest-identity",
+					payloadData: plainPutPayload(new Uint8Array(0)),
+					documentIndex: {
+						key: "doc-latest-identity",
+						valuePrefixBytes: new Uint8Array(0),
+						usePlainPutPayload: true,
 					},
-				);
-
-			const updated = backbone.preparePlainCommittedStorageAppendTransaction({
-				wallTime: 45n,
-				logical: 2,
-				gid: "fallback-doc-latest-identity",
-				payloadData: plainPutPayload(new Uint8Array(0)),
-				documentIndex: {
-					key: "doc-latest-identity",
-					valuePrefixBytes: new Uint8Array(0),
-					useLatestContext: true,
-					usePlainPutPayload: true,
+					replicas: 1,
+					selfHash: "peer",
 				},
-				replicas: 1,
-				selfHash: "peer",
-				resolveTrimmedEntries: false,
-			});
+			);
 
-			expect(updated.entry.next).to.deep.equal([first.entry.hash]);
-			expect(updated.coordinate.gid).to.equal("gid-doc-latest-identity");
-			expect(backbone.documentValueLength).to.equal(1);
-			expect(
-				backbone.documentExactStringFirstKey(3, updated.entry.hash),
-			).to.equal("doc-latest-identity");
+		const updated = backbone.preparePlainCommittedStorageAppendTransaction({
+			wallTime: 45n,
+			logical: 2,
+			gid: "fallback-doc-latest-identity",
+			payloadData: plainPutPayload(new Uint8Array(0)),
+			documentIndex: {
+				key: "doc-latest-identity",
+				valuePrefixBytes: new Uint8Array(0),
+				useLatestContext: true,
+				usePlainPutPayload: true,
+			},
+			replicas: 1,
+			selfHash: "peer",
+			resolveTrimmedEntries: false,
 		});
 
-		it("batches committed latest-context cached-plan plain-put-payload document index transactions", async () => {
-			const backbone = await createNativePeerbitBackbone({
-				clockId: publicKey,
+		expect(updated.entry.next).to.deep.equal([first.entry.hash]);
+		expect(updated.coordinate.gid).to.equal("gid-doc-latest-identity");
+		expect(backbone.documentValueLength).to.equal(1);
+		expect(
+			backbone.documentExactStringFirstKey(3, updated.entry.hash),
+		).to.equal("doc-latest-identity");
+	});
+
+	it("batches committed latest-context cached-plan plain-put-payload document index transactions", async () => {
+		const backbone = await createNativePeerbitBackbone({
+			clockId: publicKey,
 			privateKey,
 			publicKey,
 		});
@@ -1431,9 +1358,7 @@ describe("native peerbit backbone", () => {
 
 		expect(updated).to.have.length(1);
 		expect(updated[0]!.entry.next).to.deep.equal([first[0]!.entry.hash]);
-		expect(updated[0]!.coordinate.gid).to.equal(
-			"gid-doc-latest-payload-batch",
-		);
+		expect(updated[0]!.coordinate.gid).to.equal("gid-doc-latest-payload-batch");
 		expect(updated[0]!.documentPreviousContext?.head).to.equal(
 			first[0]!.entry.hash,
 		);
@@ -1643,16 +1568,13 @@ describe("native peerbit backbone", () => {
 		expect(Array.from(expectedColumns?.[14] ?? [], String)).to.deep.equal([
 			String(expectedHashNumber),
 		]);
-		const compactExpectedColumns =
-			target.prepareRawReceiveExpectedColumnsBatch(
-				[prepared.bytes],
-				[prepared.hash],
-			);
+		const compactExpectedColumns = target.prepareRawReceiveExpectedColumnsBatch(
+			[prepared.bytes],
+			[prepared.hash],
+		);
 		expect(compactExpectedColumns?.[0]).to.deep.equal([]);
 		expect(compactExpectedColumns?.[1][0]).to.equal(undefined);
-		expect(Array.from(compactExpectedColumns?.[12] ?? [])).to.deep.equal([
-			1,
-		]);
+		expect(Array.from(compactExpectedColumns?.[12] ?? [])).to.deep.equal([1]);
 		expect(
 			Array.from(compactExpectedColumns?.[14] ?? [], String),
 		).to.deep.equal([String(expectedHashNumber)]);
@@ -1675,32 +1597,26 @@ describe("native peerbit backbone", () => {
 			);
 		expect(compactUnverifiedColumns?.[0]).to.deep.equal([]);
 		expect(compactUnverifiedColumns?.[1][0]).to.equal(undefined);
-		expect(Array.from(compactUnverifiedColumns?.[12] ?? [])).to.deep.equal([
-			0,
-		]);
+		expect(Array.from(compactUnverifiedColumns?.[12] ?? [])).to.deep.equal([0]);
 		expect(
 			target.graph.verifyPreparedRawReceiveEntries([prepared.hash]),
 		).to.deep.equal([true]);
-		expect(
-			target.graph.verifyPreparedRawReceiveEntries(["missing"]),
-		).to.equal(undefined);
+		expect(target.graph.verifyPreparedRawReceiveEntries(["missing"])).to.equal(
+			undefined,
+		);
 		expect(() =>
 			target.prepareRawReceiveColumnsBatch([prepared.bytes], ["not-a-cid"]),
 		).to.throw("Expected base58btc CID");
 		expect(
-			target.graph.commitPreparedRawReceiveBatch(
-				[prepared.hash],
-				[true],
-				{
-					hashes: [prepared.hash],
-					gids: ["gid-raw-receive"],
-					hashNumbers: ["9"],
-					coordinateBatches: [["11"]],
-					nextHashBatches: [[]],
-					assignedToRangeBoundaries: new Uint8Array([0]),
-					requestedReplicas: [1],
-				},
-			),
+			target.graph.commitPreparedRawReceiveBatch([prepared.hash], [true], {
+				hashes: [prepared.hash],
+				gids: ["gid-raw-receive"],
+				hashNumbers: ["9"],
+				coordinateBatches: [["11"]],
+				nextHashBatches: [[]],
+				assignedToRangeBoundaries: new Uint8Array([0]),
+				requestedReplicas: [1],
+			}),
 		).to.equal(true);
 
 		expect(target.hasBlock(prepared.hash)).to.equal(true);
@@ -1831,35 +1747,32 @@ describe("native peerbit backbone", () => {
 			maxReplicasFromNewEntries: 3,
 			maxMaxReplicas: 3,
 		});
-		expect(Array.from(indexPlans?.[0].indexes ?? [])).to.deep.equal([
-			0,
-			1,
-		]);
+		expect(Array.from(indexPlans?.[0].indexes ?? [])).to.deep.equal([0, 1]);
 		expect(indexPlans?.[0].requestedReplicas).to.deep.equal([2, 4]);
-			expect(indexPlans?.[1]).to.deep.include({
-				gid: "gid-raw-group-b",
-				latestIndex: 2,
-				maxReplicasFromHead: 1,
-				maxReplicasFromNewEntries: 1,
-				maxMaxReplicas: 1,
-			});
-			const groupACoordinate = Number(
-				target.getGidCoordinates("gid-raw-group-a", 3)[0],
-			);
-			target.putRange({
-				id: "peer-keep-range",
-				hash: "peer-keep",
-				timestamp: 0,
-				start1: groupACoordinate,
-				end1: groupACoordinate + 1,
-				start2: groupACoordinate,
-				end2: groupACoordinate + 1,
-				width: 1,
-				mode: 0,
-			});
-			const leaderPlans = target.planPreparedRawReceiveGroupLeaders(
-				[first.hash, second.hash, third.hash],
-				{ minReplicas: 1, maxReplicas: 3 },
+		expect(indexPlans?.[1]).to.deep.include({
+			gid: "gid-raw-group-b",
+			latestIndex: 2,
+			maxReplicasFromHead: 1,
+			maxReplicasFromNewEntries: 1,
+			maxMaxReplicas: 1,
+		});
+		const groupACoordinate = Number(
+			target.getGidCoordinates("gid-raw-group-a", 3)[0],
+		);
+		target.putRange({
+			id: "peer-keep-range",
+			hash: "peer-keep",
+			timestamp: 0,
+			start1: groupACoordinate,
+			end1: groupACoordinate + 1,
+			start2: groupACoordinate,
+			end2: groupACoordinate + 1,
+			width: 1,
+			mode: 0,
+		});
+		const leaderPlans = target.planPreparedRawReceiveGroupLeaders(
+			[first.hash, second.hash, third.hash],
+			{ minReplicas: 1, maxReplicas: 3 },
 			{
 				selfHash: "peer-a",
 				selfReplicating: false,
@@ -1874,261 +1787,245 @@ describe("native peerbit backbone", () => {
 			maxReplicasFromNewEntries: 3,
 			maxMaxReplicas: 3,
 		});
-		expect(Array.from(leaderPlans?.[0].indexes ?? [])).to.deep.equal([
-			0,
-			1,
+		expect(Array.from(leaderPlans?.[0].indexes ?? [])).to.deep.equal([0, 1]);
+		expect(leaderPlans?.[0].coordinates).to.have.length(3);
+		expect(leaderPlans?.[0].coordinateStrings).to.have.length(3);
+		expect(leaderPlans?.[0].leaders).to.be.instanceOf(Map);
+		expect(leaderPlans?.[0].leaders.has("peer-keep")).to.equal(true);
+		const assignmentPlans = target.planPreparedRawReceiveGroupAssignments(
+			[first.hash, second.hash, third.hash],
+			{ minReplicas: 1, maxReplicas: 3 },
+			{
+				selfHash: "peer-keep",
+				selfReplicating: false,
+				fullReplicaFallback: false,
+			},
+			"peer-b",
+		);
+		expect(assignmentPlans).to.have.length(2);
+		expect(assignmentPlans?.[0]).to.deep.include({
+			gid: "gid-raw-group-a",
+			latestIndex: 1,
+			isLeader: true,
+			fromIsLeader: false,
+		});
+		expect(assignmentPlans?.[0].coordinates).to.have.length(3);
+		expect(assignmentPlans?.[0].coordinateStrings).to.have.length(3);
+		expect(assignmentPlans?.[0].assignedToRangeBoundary).to.be.a("boolean");
+		expect(assignmentPlans?.[1]).to.deep.include({
+			gid: "gid-raw-group-b",
+			latestIndex: 2,
+			fromIsLeader: false,
+		});
+		expect(assignmentPlans?.[1].isLeader).to.be.a("boolean");
+		expect(
+			target.planPreparedRawReceiveFastDrop(
+				[first.hash, second.hash, third.hash],
+				{ minReplicas: 1, maxReplicas: 3 },
+				{
+					selfHash: "peer-a",
+					selfReplicating: false,
+					fullReplicaFallback: true,
+				},
+				"peer-b",
+			),
+		).to.deep.include({
+			canDrop: true,
+			groupCount: 2,
+			plannedHashCount: 3,
+		});
+		expect(
+			target.selectPreparedRawReceiveHashes(
+				[first.hash, second.hash, third.hash],
+				{ minReplicas: 1, maxReplicas: 3 },
+				{
+					selfHash: "peer-a",
+					selfReplicating: false,
+					fullReplicaFallback: true,
+				},
+				"peer-b",
+			),
+		).to.deep.include({
+			retainedHashes: [],
+			droppedHashes: [first.hash, second.hash, third.hash],
+			groupCount: 2,
+			plannedHashCount: 3,
+			usedNativeFastDropPlan: true,
+			usedLeaderSamplePlans: false,
+		});
+		expect(
+			target.planPreparedRawReceiveFastDrop(
+				[first.hash, second.hash, third.hash],
+				{ minReplicas: 1, maxReplicas: 3 },
+				{
+					selfHash: "peer-a",
+					selfReplicating: false,
+					fullReplicaFallback: true,
+				},
+				"peer-keep",
+			),
+		).to.deep.include({
+			canDrop: true,
+			groupCount: 2,
+			plannedHashCount: 3,
+		});
+		expect(
+			target.selectPreparedRawReceiveHashes(
+				[first.hash, second.hash, third.hash],
+				{ minReplicas: 1, maxReplicas: 3 },
+				{
+					selfHash: "peer-a",
+					selfReplicating: false,
+					fullReplicaFallback: true,
+				},
+				"peer-keep",
+			),
+		).to.deep.include({
+			retainedHashes: [],
+			droppedHashes: [first.hash, second.hash, third.hash],
+			groupCount: 2,
+			plannedHashCount: 3,
+			usedNativeFastDropPlan: true,
+			usedLeaderSamplePlans: false,
+		});
+		expect(
+			target.planPreparedRawReceiveSelection(
+				[first.hash, second.hash, third.hash],
+				{ minReplicas: 1, maxReplicas: 3 },
+				{
+					selfHash: "peer-a",
+					selfReplicating: false,
+					fullReplicaFallback: true,
+				},
+				"peer-b",
+			),
+		).to.deep.include({
+			retainedHashes: [],
+			droppedHashes: [first.hash, second.hash, third.hash],
+			groupCount: 2,
+			plannedHashCount: 3,
+			usedNativeFastDropPlan: true,
+			usedLeaderSamplePlans: true,
+		});
+		const groupBCoordinate = Number(
+			target.getGidCoordinates("gid-raw-group-b", 1)[0],
+		);
+		target.putRange({
+			id: "peer-drop-range",
+			hash: "peer-drop",
+			timestamp: 0,
+			start1: groupBCoordinate,
+			end1: groupBCoordinate + 1,
+			start2: groupBCoordinate,
+			end2: groupBCoordinate + 1,
+			width: 1,
+			mode: 0,
+		});
+		const mixedSelection = target.selectPreparedRawReceiveHashes(
+			[first.hash, second.hash, third.hash],
+			{ minReplicas: 1, maxReplicas: 3 },
+			{
+				selfHash: "peer-keep",
+				selfReplicating: false,
+				fullReplicaFallback: false,
+			},
+			"peer-b",
+		);
+		expect(mixedSelection?.retainedHashes).to.deep.equal([
+			first.hash,
+			second.hash,
 		]);
-			expect(leaderPlans?.[0].coordinates).to.have.length(3);
-			expect(leaderPlans?.[0].coordinateStrings).to.have.length(3);
-			expect(leaderPlans?.[0].leaders).to.be.instanceOf(Map);
-			expect(leaderPlans?.[0].leaders.has("peer-keep")).to.equal(true);
-			const assignmentPlans =
-				target.planPreparedRawReceiveGroupAssignments(
-					[first.hash, second.hash, third.hash],
-					{ minReplicas: 1, maxReplicas: 3 },
-					{
+		expect(mixedSelection?.droppedHashes).to.deep.equal([third.hash]);
+		expect(Array.from(mixedSelection?.retainedIndexes ?? [])).to.deep.equal([
+			0, 1,
+		]);
+		expect(Array.from(mixedSelection?.droppedIndexes ?? [])).to.deep.equal([2]);
+		expect(mixedSelection).to.deep.include({
+			groupCount: 2,
+			plannedHashCount: 3,
+			usedNativeFastDropPlan: false,
+			usedLeaderSamplePlans: false,
+		});
+		expect(mixedSelection?.retainedGroupLeaderPlans).to.have.length(1);
+		expect(mixedSelection?.retainedGroupLeaderPlans?.[0]).to.deep.include({
+			gid: "gid-raw-group-a",
+			latestIndex: 1,
+			maxReplicasFromHead: 1,
+			maxReplicasFromNewEntries: 3,
+			maxMaxReplicas: 3,
+		});
+		expect(
+			Array.from(mixedSelection?.retainedGroupLeaderPlans?.[0]?.indexes ?? []),
+		).to.deep.equal([0, 1]);
+		expect(
+			mixedSelection?.retainedGroupLeaderPlans?.[0]?.leaders.has("peer-keep"),
+		).to.equal(true);
+		const mixedFusedSelection = target.planPreparedRawReceiveSelection(
+			[first.hash, second.hash, third.hash],
+			{ minReplicas: 1, maxReplicas: 3 },
+			{
+				selfHash: "peer-keep",
+				selfReplicating: false,
+				fullReplicaFallback: false,
+			},
+			"peer-b",
+		);
+		expect(mixedFusedSelection?.retainedHashes).to.deep.equal([
+			first.hash,
+			second.hash,
+		]);
+		expect(mixedFusedSelection?.droppedHashes).to.deep.equal([third.hash]);
+		expect(
+			Array.from(mixedFusedSelection?.retainedIndexes ?? []),
+		).to.deep.equal([0, 1]);
+		expect(Array.from(mixedFusedSelection?.droppedIndexes ?? [])).to.deep.equal(
+			[2],
+		);
+		expect(mixedFusedSelection).to.deep.include({
+			groupCount: 2,
+			plannedHashCount: 3,
+			usedNativeFastDropPlan: false,
+			usedLeaderSamplePlans: false,
+		});
+		expect(mixedFusedSelection?.retainedGroupLeaderPlans).to.have.length(1);
+		const mixedPreparedSelection =
+			target.prepareRawReceiveExpectedColumnsAndSelectionBatch(
+				[first.bytes, second.bytes, third.bytes],
+				[first.hash, second.hash, third.hash],
+				{
+					verifySignatures: false,
+					minReplicas: 1,
+					maxReplicas: 3,
+					leaderOptions: {
 						selfHash: "peer-keep",
 						selfReplicating: false,
 						fullReplicaFallback: false,
 					},
-					"peer-b",
-				);
-			expect(assignmentPlans).to.have.length(2);
-			expect(assignmentPlans?.[0]).to.deep.include({
-				gid: "gid-raw-group-a",
-				latestIndex: 1,
-				isLeader: true,
-				fromIsLeader: false,
-			});
-			expect(assignmentPlans?.[0].coordinates).to.have.length(3);
-			expect(assignmentPlans?.[0].coordinateStrings).to.have.length(3);
-			expect(assignmentPlans?.[0].assignedToRangeBoundary).to.be.a(
-				"boolean",
-			);
-			expect(assignmentPlans?.[1]).to.deep.include({
-				gid: "gid-raw-group-b",
-				latestIndex: 2,
-				fromIsLeader: false,
-			});
-			expect(assignmentPlans?.[1].isLeader).to.be.a("boolean");
-			expect(
-				target.planPreparedRawReceiveFastDrop(
-					[first.hash, second.hash, third.hash],
-					{ minReplicas: 1, maxReplicas: 3 },
-					{
-						selfHash: "peer-a",
-						selfReplicating: false,
-						fullReplicaFallback: true,
-					},
-					"peer-b",
-				),
-			).to.deep.include({
-				canDrop: true,
-				groupCount: 2,
-				plannedHashCount: 3,
-			});
-			expect(
-				target.selectPreparedRawReceiveHashes(
-					[first.hash, second.hash, third.hash],
-					{ minReplicas: 1, maxReplicas: 3 },
-					{
-						selfHash: "peer-a",
-						selfReplicating: false,
-						fullReplicaFallback: true,
-					},
-					"peer-b",
-				),
-			).to.deep.include({
-				retainedHashes: [],
-				droppedHashes: [first.hash, second.hash, third.hash],
-				groupCount: 2,
-				plannedHashCount: 3,
-				usedNativeFastDropPlan: true,
-				usedLeaderSamplePlans: false,
-			});
-			expect(
-				target.planPreparedRawReceiveFastDrop(
-					[first.hash, second.hash, third.hash],
-					{ minReplicas: 1, maxReplicas: 3 },
-					{
-						selfHash: "peer-a",
-						selfReplicating: false,
-						fullReplicaFallback: true,
-					},
-					"peer-keep",
-				),
-			).to.deep.include({
-				canDrop: true,
-				groupCount: 2,
-				plannedHashCount: 3,
-			});
-			expect(
-				target.selectPreparedRawReceiveHashes(
-					[first.hash, second.hash, third.hash],
-					{ minReplicas: 1, maxReplicas: 3 },
-					{
-						selfHash: "peer-a",
-						selfReplicating: false,
-						fullReplicaFallback: true,
-					},
-					"peer-keep",
-				),
-				).to.deep.include({
-				retainedHashes: [],
-				droppedHashes: [first.hash, second.hash, third.hash],
-				groupCount: 2,
-				plannedHashCount: 3,
-				usedNativeFastDropPlan: true,
-				usedLeaderSamplePlans: false,
-			});
-			expect(
-				target.planPreparedRawReceiveSelection(
-					[first.hash, second.hash, third.hash],
-					{ minReplicas: 1, maxReplicas: 3 },
-					{
-						selfHash: "peer-a",
-						selfReplicating: false,
-						fullReplicaFallback: true,
-					},
-					"peer-b",
-				),
-				).to.deep.include({
-				retainedHashes: [],
-				droppedHashes: [first.hash, second.hash, third.hash],
-				groupCount: 2,
-				plannedHashCount: 3,
-				usedNativeFastDropPlan: true,
-				usedLeaderSamplePlans: true,
-			});
-			const groupBCoordinate = Number(
-				target.getGidCoordinates("gid-raw-group-b", 1)[0],
-			);
-			target.putRange({
-				id: "peer-drop-range",
-				hash: "peer-drop",
-				timestamp: 0,
-				start1: groupBCoordinate,
-				end1: groupBCoordinate + 1,
-				start2: groupBCoordinate,
-				end2: groupBCoordinate + 1,
-				width: 1,
-				mode: 0,
-			});
-			const mixedSelection = target.selectPreparedRawReceiveHashes(
-				[first.hash, second.hash, third.hash],
-				{ minReplicas: 1, maxReplicas: 3 },
-				{
-					selfHash: "peer-keep",
-					selfReplicating: false,
-					fullReplicaFallback: false,
-				},
-				"peer-b",
-			);
-			expect(mixedSelection?.retainedHashes).to.deep.equal([
-				first.hash,
-				second.hash,
-			]);
-			expect(mixedSelection?.droppedHashes).to.deep.equal([third.hash]);
-			expect(Array.from(mixedSelection?.retainedIndexes ?? [])).to.deep.equal([
-				0, 1,
-			]);
-			expect(Array.from(mixedSelection?.droppedIndexes ?? [])).to.deep.equal([
-				2,
-			]);
-			expect(mixedSelection).to.deep.include({
-				groupCount: 2,
-				plannedHashCount: 3,
-				usedNativeFastDropPlan: false,
-				usedLeaderSamplePlans: false,
-			});
-			expect(mixedSelection?.retainedGroupLeaderPlans).to.have.length(1);
-			expect(mixedSelection?.retainedGroupLeaderPlans?.[0]).to.deep.include(
-				{
-					gid: "gid-raw-group-a",
-					latestIndex: 1,
-					maxReplicasFromHead: 1,
-					maxReplicasFromNewEntries: 3,
-					maxMaxReplicas: 3,
+					fromHash: "peer-b",
 				},
 			);
-			expect(
-				Array.from(
-					mixedSelection?.retainedGroupLeaderPlans?.[0]?.indexes ?? [],
-				),
-			).to.deep.equal([0, 1]);
-			expect(
-				mixedSelection?.retainedGroupLeaderPlans?.[0]?.leaders.has(
-					"peer-keep",
-				),
-			).to.equal(true);
-			const mixedFusedSelection = target.planPreparedRawReceiveSelection(
-				[first.hash, second.hash, third.hash],
-				{ minReplicas: 1, maxReplicas: 3 },
-				{
-					selfHash: "peer-keep",
-					selfReplicating: false,
-					fullReplicaFallback: false,
-				},
-				"peer-b",
-			);
-			expect(mixedFusedSelection?.retainedHashes).to.deep.equal([
-				first.hash,
-				second.hash,
-			]);
-			expect(mixedFusedSelection?.droppedHashes).to.deep.equal([third.hash]);
-			expect(
-				Array.from(mixedFusedSelection?.retainedIndexes ?? []),
-			).to.deep.equal([0, 1]);
-			expect(
-				Array.from(mixedFusedSelection?.droppedIndexes ?? []),
-			).to.deep.equal([2]);
-			expect(mixedFusedSelection).to.deep.include({
-				groupCount: 2,
-				plannedHashCount: 3,
-				usedNativeFastDropPlan: false,
-				usedLeaderSamplePlans: false,
-			});
-			expect(mixedFusedSelection?.retainedGroupLeaderPlans).to.have.length(
-				1,
-			);
-			const mixedPreparedSelection =
-				target.prepareRawReceiveExpectedColumnsAndSelectionBatch(
-					[first.bytes, second.bytes, third.bytes],
-					[first.hash, second.hash, third.hash],
-					{
-						verifySignatures: false,
-						minReplicas: 1,
-						maxReplicas: 3,
-						leaderOptions: {
-							selfHash: "peer-keep",
-							selfReplicating: false,
-							fullReplicaFallback: false,
-						},
-						fromHash: "peer-b",
-					},
-				);
-			expect(mixedPreparedSelection?.columns[0]).to.deep.equal([]);
-			expect(
-				Array.from(mixedPreparedSelection?.columns[12] ?? []),
-			).to.deep.equal([0, 0, 0]);
-			expect(mixedPreparedSelection?.selection?.retainedHashes).to.deep.equal([
-				first.hash,
-				second.hash,
-			]);
-			expect(mixedPreparedSelection?.selection?.droppedHashes).to.deep.equal([
-				third.hash,
-			]);
-			expect(
-				Array.from(mixedPreparedSelection?.selection?.retainedIndexes ?? []),
-			).to.deep.equal([0, 1]);
-			expect(
-				Array.from(mixedPreparedSelection?.selection?.droppedIndexes ?? []),
-			).to.deep.equal([2]);
+		expect(mixedPreparedSelection?.columns[0]).to.deep.equal([]);
+		expect(Array.from(mixedPreparedSelection?.columns[12] ?? [])).to.deep.equal(
+			[0, 0, 0],
+		);
+		expect(mixedPreparedSelection?.selection?.retainedHashes).to.deep.equal([
+			first.hash,
+			second.hash,
+		]);
+		expect(mixedPreparedSelection?.selection?.droppedHashes).to.deep.equal([
+			third.hash,
+		]);
+		expect(
+			Array.from(mixedPreparedSelection?.selection?.retainedIndexes ?? []),
+		).to.deep.equal([0, 1]);
+		expect(
+			Array.from(mixedPreparedSelection?.selection?.droppedIndexes ?? []),
+		).to.deep.equal([2]);
 
-			target.storageBackedGraph.prepareEntryV0PlainEntryAndPut({
-				clockId: publicKey,
-				privateKey,
-				publicKey,
+		target.storageBackedGraph.prepareEntryV0PlainEntryAndPut({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
 			wallTime: 1n,
 			gid: "gid-raw-existing-head",
 			metaData: replicaData(5),
@@ -2179,22 +2076,22 @@ describe("native peerbit backbone", () => {
 					selfReplicating: false,
 					fullReplicaFallback: true,
 				},
-					"peer-b",
-				),
-			).to.equal(undefined);
-			expect(
-				target.selectPreparedRawReceiveHashes(
-					["missing"],
-					{ minReplicas: 1, maxReplicas: 3 },
-					{
-						selfHash: "peer-a",
-						selfReplicating: false,
-						fullReplicaFallback: true,
-					},
-					"peer-b",
-				),
-			).to.equal(undefined);
-		});
+				"peer-b",
+			),
+		).to.equal(undefined);
+		expect(
+			target.selectPreparedRawReceiveHashes(
+				["missing"],
+				{ minReplicas: 1, maxReplicas: 3 },
+				{
+					selfHash: "peer-a",
+					selfReplicating: false,
+					fullReplicaFallback: true,
+				},
+				"peer-b",
+			),
+		).to.equal(undefined);
+	});
 
 	it("validates and commits prepared raw receive joins natively", async () => {
 		const source = await createNativePeerbitBackbone({
@@ -2332,12 +2229,12 @@ describe("native peerbit backbone", () => {
 			payloadData: new Uint8Array([3]),
 		});
 
-		expect(backbone.graph.uniqueReferenceGidRowsFlatBatch([head.hash])).to.deep.equal(
-			[
-				[0, root.hash, "root-gid"],
-				[0, side.hash, "side-gid"],
-			],
-		);
+		expect(
+			backbone.graph.uniqueReferenceGidRowsFlatBatch([head.hash]),
+		).to.deep.equal([
+			[0, root.hash, "root-gid"],
+			[0, side.hash, "side-gid"],
+		]);
 		expect(
 			backbone.graph.uniqueReferenceGidRowsFlatBatch([head.hash, root.hash]),
 		).to.deep.equal([
@@ -2658,35 +2555,33 @@ describe("native peerbit backbone", () => {
 			leaderPlan.leaders.has("peer-a"),
 		);
 		expect(requestPruneHints.entries.has("missing")).equal(false);
-		const requestPruneHintColumns =
-			backbone.planRequestPruneLeaderHintColumns(
-					[second.entry.hash, "missing"],
-					[],
-					{
-						selfHash: "peer-a",
-						selfReplicating: true,
-						fullReplicaFallback: true,
-					},
-				)!;
-			expect(requestPruneHintColumns.gids[0]).equal(
-				"gid-storage-committed-no-next",
-			);
-			expect(requestPruneHintColumns.gids[1]).equal(undefined);
-			expect([...requestPruneHintColumns.presentBlockFlags]).to.deep.equal([
-				1,
-				0,
-			]);
-			expect([...requestPruneHintColumns.replicaCounts]).to.deep.equal([1, 0]);
-			expect([...requestPruneHintColumns.localLeaderFlags]).to.deep.equal([
-				leaderPlan.leaders.has("peer-a") ? 1 : 0,
-				0,
-			]);
-			expect([...requestPruneHintColumns.peerHistoryRemovedFlags]).to.deep.equal(
-				[1, 0],
-			);
-			expect(
-				backbone.getGidCoordinates("gid-storage-committed-no-next", 1),
-			).to.deep.equal(leaderPlan.coordinates);
+		const requestPruneHintColumns = backbone.planRequestPruneLeaderHintColumns(
+			[second.entry.hash, "missing"],
+			[],
+			{
+				selfHash: "peer-a",
+				selfReplicating: true,
+				fullReplicaFallback: true,
+			},
+		)!;
+		expect(requestPruneHintColumns.gids[0]).equal(
+			"gid-storage-committed-no-next",
+		);
+		expect(requestPruneHintColumns.gids[1]).equal(undefined);
+		expect([...requestPruneHintColumns.presentBlockFlags]).to.deep.equal([
+			1, 0,
+		]);
+		expect([...requestPruneHintColumns.replicaCounts]).to.deep.equal([1, 0]);
+		expect([...requestPruneHintColumns.localLeaderFlags]).to.deep.equal([
+			leaderPlan.leaders.has("peer-a") ? 1 : 0,
+			0,
+		]);
+		expect([...requestPruneHintColumns.peerHistoryRemovedFlags]).to.deep.equal([
+			1, 0,
+		]);
+		expect(
+			backbone.getGidCoordinates("gid-storage-committed-no-next", 1),
+		).to.deep.equal(leaderPlan.coordinates);
 		expect(backbone.getGrid(leaderPlan.coordinates[0]!, 1)).to.deep.equal(
 			leaderPlan.coordinates,
 		);
@@ -2766,15 +2661,17 @@ describe("native peerbit backbone", () => {
 		backbone.setCoordinateJournalEnabled(true);
 		backbone.resetAppendProfile();
 		backbone.setAppendProfileEnabled(true);
-		const result =
-			benchmarkPlainCommittedNoNextStorageAppendTransactionLoop(backbone, {
+		const result = benchmarkPlainCommittedNoNextStorageAppendTransactionLoop(
+			backbone,
+			{
 				iterations: 3,
 				wallTimeStart: 100n,
 				payloadData: new Uint8Array([1, 2, 3]),
 				replicas: 1,
 				selfHash: "peer-a",
 				useDocumentIndex: true,
-			});
+			},
+		);
 		backbone.setAppendProfileEnabled(false);
 
 		const profile = backbone.appendProfile();
@@ -2974,7 +2871,7 @@ describe("native peerbit backbone", () => {
 		expect(target.coordinatePendingJournalLength).to.equal(0);
 	});
 
-	it("flushes and compacts native coordinate state through the persistence adapter", async () => {
+	it("flushes native coordinate state and rejects unsafe compaction", async () => {
 		const source = await createNativePeerbitBackbone({
 			clockId: publicKey,
 			privateKey,
@@ -2985,7 +2882,7 @@ describe("native peerbit backbone", () => {
 			privateKey,
 			publicKey,
 		});
-		const compacted = await createNativePeerbitBackbone({
+		const reflushed = await createNativePeerbitBackbone({
 			clockId: publicKey,
 			privateKey,
 			publicKey,
@@ -3004,14 +2901,338 @@ describe("native peerbit backbone", () => {
 		expect(restored.getEntryCoordinateHashes()).to.deep.equal(["hash-a"]);
 
 		source.putEntryCoordinates("hash-b", "gid-b", [2n], false, 1, 2n);
-		await persistence.compact(source);
-		expect(store.files.has("coordinates.wal")).equal(false);
-		expect(await persistence.hydrate(compacted)).to.equal(0);
-		expect(compacted.getEntryCoordinateHashes()).to.deep.equal([
+		let compactError: unknown;
+		await persistence.compact(source).catch((error) => {
+			compactError = error;
+		});
+		expect(String(compactError)).to.contain("compaction is disabled");
+		expect(source.coordinatePendingJournalLength).to.equal(1);
+		await persistence.flushJournal(source);
+		expect(store.files.has("coordinates.wal")).equal(true);
+		expect(await persistence.hydrate(reflushed)).to.equal(2);
+		expect(reflushed.getEntryCoordinateHashes()).to.deep.equal([
 			"hash-a",
 			"hash-b",
 		]);
-		expect(compacted.coordinateIndexLength).to.equal(2);
+		expect(reflushed.coordinateIndexLength).to.equal(2);
+	});
+
+	it("drops every configured native file through memory and buffered stores", async () => {
+		const files = {
+			snapshot: "custom-coordinates.bin",
+			journal: "custom-coordinates.wal",
+			documentSnapshot: "custom-document-values.bin",
+			documentJournal: "custom-document-values.wal",
+			documentSignerSnapshot: "custom-document-signers.bin",
+			documentSignerJournal: "custom-document-signers.wal",
+		};
+		for (const buffered of [false, true]) {
+			const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+			const store = buffered
+				? new NativeBackboneBufferedCoordinatePersistenceStore(memory)
+				: memory;
+			const persistence = new NativeBackboneCoordinatePersistence(store, files);
+			for (const name of Object.values(files)) {
+				await store.append(name, new Uint8Array([1, 2, 3]));
+			}
+			await store.write("strict-intent-a", new Uint8Array([4]));
+			await store.write("strict-intent-b", new Uint8Array([5]));
+
+			await persistence.drop(["strict-intent-a", "strict-intent-b"]);
+			await persistence.close();
+			expect(memory.files.size, `buffered=${String(buffered)}`).equal(0);
+		}
+	});
+
+	it("fails closed on a corrupt drop tombstone but still permits explicit erase", async () => {
+		const target = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
+		});
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		await memory.write("coordinates.wal", new Uint8Array([1, 2, 3]));
+		await memory.write(
+			"native-backbone-drop.tombstone",
+			new TextEncoder().encode(
+				'{"format":"peerbit-native-backbone-coordinate-drop"',
+			),
+		);
+		const persistence = new NativeBackboneCoordinatePersistence(memory);
+
+		let hydrateError: unknown;
+		await persistence.hydrate(target).catch((error) => {
+			hydrateError = error;
+		});
+		expect(String(hydrateError)).to.contain(
+			"Invalid native backbone drop tombstone JSON",
+		);
+		expect(memory.files.has("coordinates.wal")).equal(true);
+		expect(memory.files.has("native-backbone-drop.tombstone")).equal(true);
+
+		await persistence.drop();
+		expect(memory.files.size).equal(0);
+	});
+
+	it("makes close terminal before a later drop can touch the store", async () => {
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		let closed = false;
+		let closeCalls = 0;
+		let postCloseOperations = 0;
+		const assertOpen = () => {
+			if (closed) {
+				postCloseOperations++;
+				throw new Error("terminal store is closed");
+			}
+		};
+		const inner: NativeBackboneCoordinatePersistenceStore = {
+			read: (name) => {
+				assertOpen();
+				return memory.read(name);
+			},
+			write: (name, bytes) => {
+				assertOpen();
+				return memory.write(name, bytes);
+			},
+			append: (name, bytes) => {
+				assertOpen();
+				return memory.append(name, bytes);
+			},
+			remove: (name) => {
+				assertOpen();
+				return memory.remove(name);
+			},
+			flush: (name) => {
+				assertOpen();
+				return memory.flush(name);
+			},
+			close: async () => {
+				assertOpen();
+				closeCalls++;
+				closed = true;
+			},
+		};
+		const buffered = new NativeBackboneBufferedCoordinatePersistenceStore(
+			inner,
+		);
+		const persistence = new NativeBackboneCoordinatePersistence(buffered);
+		await buffered.append("coordinates.wal", new Uint8Array([7, 8, 9]));
+
+		const closing = persistence.close();
+		expect(persistence.close()).equal(closing);
+		let dropError: unknown;
+		await persistence.drop().catch((error) => {
+			dropError = error;
+		});
+		await closing;
+
+		expect(String(dropError)).to.contain("while closing");
+		expect(memory.files.get("coordinates.wal")).to.deep.equal(
+			new Uint8Array([7, 8, 9]),
+		);
+		expect(closeCalls).equal(1);
+		expect(postCloseOperations).equal(0);
+	});
+
+	it("lets an in-flight drop finish before terminal close", async () => {
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		let closed = false;
+		let closeCalls = 0;
+		const assertOpen = () => {
+			if (closed) {
+				throw new Error("terminal store is closed");
+			}
+		};
+		const store: NativeBackboneCoordinatePersistenceStore = {
+			read: (name) => {
+				assertOpen();
+				return memory.read(name);
+			},
+			write: (name, bytes) => {
+				assertOpen();
+				return memory.write(name, bytes);
+			},
+			append: (name, bytes) => {
+				assertOpen();
+				return memory.append(name, bytes);
+			},
+			remove: (name) => {
+				assertOpen();
+				return memory.remove(name);
+			},
+			flush: (name) => {
+				assertOpen();
+				return memory.flush(name);
+			},
+			close: async () => {
+				assertOpen();
+				closeCalls++;
+				closed = true;
+			},
+		};
+		const persistence = new NativeBackboneCoordinatePersistence(store);
+		await memory.write("coordinates.wal", new Uint8Array([1, 2, 3]));
+
+		const dropping = persistence.drop();
+		const closing = persistence.close();
+		expect(persistence.close()).equal(closing);
+		await Promise.all([dropping, closing]);
+
+		expect(memory.files.size).equal(0);
+		expect(closeCalls).equal(1);
+	});
+
+	it("serializes close behind all hydrate data reads and backbone loads", async () => {
+		const target = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
+		});
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		let readEntered!: () => void;
+		const entered = new Promise<void>((resolve) => {
+			readEntered = resolve;
+		});
+		let releaseRead!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			releaseRead = resolve;
+		});
+		let gateArmed = true;
+		let closed = false;
+		let postCloseReads = 0;
+		const store: NativeBackboneCoordinatePersistenceStore = {
+			read: async (name) => {
+				if (closed) {
+					postCloseReads++;
+					throw new Error("terminal store is closed");
+				}
+				if (gateArmed && name === "coordinates.wal") {
+					gateArmed = false;
+					readEntered();
+					await gate;
+				}
+				return memory.read(name);
+			},
+			write: (name, bytes) => memory.write(name, bytes),
+			append: (name, bytes) => memory.append(name, bytes),
+			remove: (name) => memory.remove(name),
+			flush: (name) => memory.flush(name),
+			close: async () => {
+				closed = true;
+			},
+		};
+		const persistence = new NativeBackboneCoordinatePersistence(store);
+		const hydrating = persistence.hydrate(target);
+		await entered;
+		let closeSettled = false;
+		const closing = persistence.close().finally(() => {
+			closeSettled = true;
+		});
+		await Promise.resolve();
+		expect(closeSettled).equal(false);
+		releaseRead();
+		expect(await hydrating).equal(0);
+		await closing;
+
+		expect(postCloseReads).equal(0);
+	});
+
+	it("rejects drop before erasure while a hydrate data read is in flight", async () => {
+		const target = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
+		});
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		await memory.write("coordinates.bin", target.coordinateSnapshot());
+		let readEntered!: () => void;
+		const entered = new Promise<void>((resolve) => {
+			readEntered = resolve;
+		});
+		let releaseRead!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			releaseRead = resolve;
+		});
+		let gateArmed = true;
+		let removes = 0;
+		const store: NativeBackboneCoordinatePersistenceStore = {
+			read: async (name) => {
+				if (gateArmed && name === "document-values.wal") {
+					gateArmed = false;
+					readEntered();
+					await gate;
+				}
+				return memory.read(name);
+			},
+			write: (name, bytes) => memory.write(name, bytes),
+			append: (name, bytes) => memory.append(name, bytes),
+			remove: async (name) => {
+				removes++;
+				await memory.remove(name);
+			},
+		};
+		const persistence = new NativeBackboneCoordinatePersistence(store);
+		const hydrating = persistence.hydrate(target);
+		await entered;
+		const dropError = await persistence.drop().then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(String(dropError)).to.contain("while hydrating");
+		expect(removes).equal(0);
+		releaseRead();
+		expect(await hydrating).equal(0);
+		expect(memory.files.has("coordinates.bin")).equal(true);
+	});
+
+	it("does not reactivate a dropped generation from a queued resume", async () => {
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		let removeEntered!: () => void;
+		const entered = new Promise<void>((resolve) => {
+			removeEntered = resolve;
+		});
+		let releaseRemove!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			releaseRemove = resolve;
+		});
+		let gateArmed = true;
+		const store: NativeBackboneCoordinatePersistenceStore = {
+			read: (name) => memory.read(name),
+			write: (name, bytes) => memory.write(name, bytes),
+			append: (name, bytes) => memory.append(name, bytes),
+			remove: async (name) => {
+				if (name === "coordinates.bin" && gateArmed) {
+					gateArmed = false;
+					removeEntered();
+					await gate;
+				}
+				await memory.remove(name);
+			},
+		};
+		const persistence = new NativeBackboneCoordinatePersistence(store);
+		await memory.append("coordinates.bin", new Uint8Array([1]));
+
+		const dropping = persistence.drop();
+		await entered;
+		const resuming = persistence.resumeDrop();
+		releaseRemove();
+		await dropping;
+		let resumeError: unknown;
+		try {
+			await resuming;
+		} catch (error) {
+			resumeError = error;
+		}
+		expect(String(resumeError)).to.contain("while dropping");
+
+		let secondDropError: unknown;
+		try {
+			await persistence.drop();
+		} catch (error) {
+			secondDropError = error;
+		}
+		expect(String(secondDropError)).to.contain("while dropped");
+		expect(memory.files.size).equal(0);
 	});
 
 	it("keeps journal records appended during a flush write for the next flush", async () => {
@@ -3071,7 +3292,111 @@ describe("native peerbit backbone", () => {
 		]);
 	});
 
-	it("replays only the clean WAL prefix when the journal tail is truncated mid-record", async () => {
+	it("keeps the wasm journal pending until the WAL durability barrier completes", async () => {
+		const source = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
+		});
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		let flushEntered!: () => void;
+		const entered = new Promise<void>((resolve) => {
+			flushEntered = resolve;
+		});
+		let releaseFlush!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			releaseFlush = resolve;
+		});
+		let gateArmed = false;
+		const store: NativeBackboneCoordinatePersistenceStore = {
+			read: (name) => memory.read(name),
+			write: (name, bytes) => memory.write(name, bytes),
+			append: (name, bytes) => memory.append(name, bytes),
+			remove: (name) => memory.remove(name),
+			durableBarrier: async (name) => {
+				if (gateArmed && name === "coordinates.wal") {
+					gateArmed = false;
+					flushEntered();
+					await gate;
+				}
+				await memory.flush(name);
+			},
+		};
+		const persistence = new NativeBackboneCoordinatePersistence(store);
+		await persistence.hydrate(source);
+		source.putEntryCoordinates(
+			"hash-barrier",
+			"gid-barrier",
+			[1n],
+			false,
+			1,
+			1n,
+		);
+
+		gateArmed = true;
+		let settled = false;
+		const flushing = persistence.flushJournal(source).finally(() => {
+			settled = true;
+		});
+		await entered;
+		await Promise.resolve();
+		expect(settled).equal(false);
+		expect(source.coordinatePendingJournalLength).equal(1);
+
+		releaseFlush();
+		expect(await flushing).to.be.greaterThan(0);
+		expect(source.coordinatePendingJournalLength).equal(0);
+	});
+
+	it("poisons the adapter when the WAL durability barrier fails", async () => {
+		const source = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
+		});
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		const barrierError = new Error("injected WAL fsync failure");
+		let appendCalls = 0;
+		const store: NativeBackboneCoordinatePersistenceStore = {
+			read: (name) => memory.read(name),
+			write: (name, bytes) => memory.write(name, bytes),
+			append: async (name, bytes) => {
+				appendCalls++;
+				await memory.append(name, bytes);
+			},
+			remove: (name) => memory.remove(name),
+			durableBarrier: async (name) => {
+				if (name === "coordinates.wal") {
+					throw barrierError;
+				}
+				await memory.flush(name);
+			},
+		};
+		const persistence = new NativeBackboneCoordinatePersistence(store);
+		await persistence.hydrate(source);
+		source.putEntryCoordinates("hash-fsync", "gid-fsync", [1n], false, 1, 1n);
+
+		let firstError: unknown;
+		await persistence.flushJournal(source).catch((error) => {
+			firstError = error;
+		});
+		expect(firstError).equal(barrierError);
+		expect(source.coordinatePendingJournalLength).equal(1);
+		expect(appendCalls).equal(1);
+
+		let secondError: unknown;
+		try {
+			await persistence.flushJournal(source);
+		} catch (error) {
+			secondError = error;
+		}
+		expect(secondError).equal(firstError);
+		expect(appendCalls).equal(1);
+		await persistence.drop();
+		expect(memory.files.size).equal(0);
+	});
+
+	it("fails closed when the journal tail is truncated mid-record", async () => {
 		const source = await createNativePeerbitBackbone({
 			clockId: publicKey,
 			privateKey,
@@ -3083,11 +3408,25 @@ describe("native peerbit backbone", () => {
 			publicKey,
 		});
 		source.setCoordinateJournalEnabled(true);
-		source.putEntryCoordinates("hash-snapshot", "gid-snapshot", [1n], false, 1, 1n);
+		source.putEntryCoordinates(
+			"hash-snapshot",
+			"gid-snapshot",
+			[1n],
+			false,
+			1,
+			1n,
+		);
 		const snapshot = source.coordinateSnapshot();
 		source.clearCoordinateJournal();
 		const recordBytes = (hash: string, coordinate: bigint) => {
-			source.putEntryCoordinates(hash, `gid-${hash}`, [coordinate], false, 1, coordinate);
+			source.putEntryCoordinates(
+				hash,
+				`gid-${hash}`,
+				[coordinate],
+				false,
+				1,
+				coordinate,
+			);
 			const record = source.coordinateJournal();
 			source.clearCoordinateJournal();
 			return record;
@@ -3109,18 +3448,22 @@ describe("native peerbit backbone", () => {
 			]),
 		);
 
-		// decode_journal is stop-at-tail tolerant: the torn record is dropped and
-		// only the clean prefix is replayed on top of the snapshot.
-		expect(await persistence.hydrate(target)).to.equal(1);
-		expect(target.getEntryCoordinateHashes()).to.deep.equal([
-			"hash-snapshot",
-			"hash-a",
-		]);
-		expect(target.hasCoordinateIndexHash("hash-b")).equal(false);
-		expect(target.coordinatePendingJournalLength).to.equal(0);
+		let hydrateError: unknown;
+		await persistence.hydrate(target).catch((error) => {
+			hydrateError = error;
+		});
+		expect(String(hydrateError)).to.contain("torn record payload");
+		expect(target.getEntryCoordinateHashes()).to.deep.equal([]);
+		let flushError: unknown;
+		try {
+			await persistence.flushJournal(target);
+		} catch (error) {
+			flushError = error;
+		}
+		expect(flushError).equal(hydrateError);
 	});
 
-	it("stops WAL replay at a checksum-corrupted journal record", async () => {
+	it("fails closed on a checksum-corrupted journal record", async () => {
 		const source = await createNativePeerbitBackbone({
 			clockId: publicKey,
 			privateKey,
@@ -3133,7 +3476,14 @@ describe("native peerbit backbone", () => {
 		});
 		source.setCoordinateJournalEnabled(true);
 		const recordBytes = (hash: string, coordinate: bigint) => {
-			source.putEntryCoordinates(hash, `gid-${hash}`, [coordinate], false, 1, coordinate);
+			source.putEntryCoordinates(
+				hash,
+				`gid-${hash}`,
+				[coordinate],
+				false,
+				1,
+				coordinate,
+			);
 			const record = source.coordinateJournal();
 			source.clearCoordinateJournal();
 			return record;
@@ -3158,12 +3508,12 @@ describe("native peerbit backbone", () => {
 			]),
 		);
 
-		// Stop-at-tail semantics: replay halts at the corrupted record, so the
-		// intact record behind it is ignored too.
-		expect(await persistence.hydrate(target)).to.equal(1);
-		expect(target.getEntryCoordinateHashes()).to.deep.equal(["hash-a"]);
-		expect(target.hasCoordinateIndexHash("hash-b")).equal(false);
-		expect(target.hasCoordinateIndexHash("hash-c")).equal(false);
+		let hydrateError: unknown;
+		await persistence.hydrate(target).catch((error) => {
+			hydrateError = error;
+		});
+		expect(String(hydrateError)).to.contain("checksum mismatch");
+		expect(target.getEntryCoordinateHashes()).to.deep.equal([]);
 	});
 
 	it("rejects hydrate on a checksum-corrupted snapshot and stays usable", async () => {
@@ -3177,7 +3527,14 @@ describe("native peerbit backbone", () => {
 			privateKey,
 			publicKey,
 		});
-		source.putEntryCoordinates("hash-snapshot", "gid-snapshot", [1n], false, 1, 1n);
+		source.putEntryCoordinates(
+			"hash-snapshot",
+			"gid-snapshot",
+			[1n],
+			false,
+			1,
+			1n,
+		);
 		const snapshot = source.coordinateSnapshot();
 		// Flip a payload byte behind the envelope header (magic + length +
 		// checksum = 16 bytes) so the envelope checksum no longer matches.
@@ -3249,11 +3606,6 @@ describe("native peerbit backbone", () => {
 			privateKey,
 			publicKey,
 		});
-		const restoredFromSnapshot = await createNativePeerbitBackbone({
-			clockId: publicKey,
-			privateKey,
-			publicKey,
-		});
 		source.configureDocumentSchemaIr(contextOnlySchema());
 		source.setDocumentContextHeadField(3);
 		source.setDocumentContextFields({
@@ -3267,24 +3619,26 @@ describe("native peerbit backbone", () => {
 		const persistence = new NativeBackboneCoordinatePersistence(store);
 
 		await persistence.hydrate(source);
-		source.preparePlainCommittedNoNextStorageAppendDocumentIndexCompactTransaction({
-			wallTime: 11n,
-			logical: 1,
-			gid: "gid-document-persist",
-			payloadData: new Uint8Array([1, 2, 3]),
-			replicas: 1,
-			selfHash: "peer",
-			documentIndex: {
-				key: "doc-value",
-				valuePrefixBytes: new Uint8Array(0),
+		source.preparePlainCommittedNoNextStorageAppendDocumentIndexCompactTransaction(
+			{
+				wallTime: 11n,
+				logical: 1,
+				gid: "gid-document-persist",
+				payloadData: new Uint8Array([1, 2, 3]),
+				replicas: 1,
+				selfHash: "peer",
+				documentIndex: {
+					key: "doc-value",
+					valuePrefixBytes: new Uint8Array(0),
+				},
 			},
-		});
+		);
 		expect(source.documentPendingJournalLength).to.equal(1);
 		await persistence.flushJournal(source);
 		expect(store.files.has("document-values.wal")).equal(true);
-		expect(store.files.get("document-values.wal")?.byteLength).to.be.greaterThan(
-			source.documentJournalHeader().byteLength,
-		);
+		expect(
+			store.files.get("document-values.wal")?.byteLength,
+		).to.be.greaterThan(source.documentJournalHeader().byteLength);
 
 		await persistence.hydrate(restoredFromWal);
 		expect(restoredFromWal.documentValueLength).to.equal(1);
@@ -3302,24 +3656,6 @@ describe("native peerbit backbone", () => {
 		expect(
 			Array.from(restoredFromWal.documentKeysExist(["doc-value"])),
 		).to.deep.equal([1]);
-
-		await persistence.compact(source);
-		expect(store.files.has("document-values.wal")).equal(false);
-		expect(store.files.has("document-values.bin")).equal(true);
-		await persistence.hydrate(restoredFromSnapshot);
-		restoredFromSnapshot.configureDocumentSchemaIr(contextOnlySchema());
-		restoredFromSnapshot.setDocumentContextHeadField(3);
-		restoredFromSnapshot.setDocumentContextFields({
-			created: 1,
-			modified: 2,
-			head: 3,
-			gid: 4,
-			size: 5,
-		});
-		expect(restoredFromSnapshot.documentIndexLength).to.equal(1);
-		expect(
-			Array.from(restoredFromSnapshot.documentKeysExist(["doc-value"])),
-		).to.deep.equal([1]);
 	});
 
 	it("persists document previous signer facts through the native persistence adapter", async () => {
@@ -3333,12 +3669,7 @@ describe("native peerbit backbone", () => {
 			privateKey,
 			publicKey,
 		});
-		const restoredFromSnapshot = await createNativePeerbitBackbone({
-			clockId: publicKey,
-			privateKey,
-			publicKey,
-		});
-		for (const backbone of [source, restoredFromWal, restoredFromSnapshot]) {
+		for (const backbone of [source, restoredFromWal]) {
 			backbone.configureDocumentSchemaIr(contextOnlySchema());
 			backbone.setDocumentContextHeadField(3);
 			backbone.setDocumentContextFields({
@@ -3378,9 +3709,9 @@ describe("native peerbit backbone", () => {
 		expect(source.documentSignerPendingJournalLength).to.equal(1);
 		await persistence.flushJournal(source);
 		expect(store.files.has("document-signers.wal")).equal(true);
-		expect(store.files.get("document-signers.wal")?.byteLength).to.be.greaterThan(
-			source.documentSignerJournalHeader().byteLength,
-		);
+		expect(
+			store.files.get("document-signers.wal")?.byteLength,
+		).to.be.greaterThan(source.documentSignerJournalHeader().byteLength);
 
 		await persistence.hydrate(restoredFromWal);
 		restoredFromWal.clearDocumentIndex();
@@ -3393,24 +3724,6 @@ describe("native peerbit backbone", () => {
 		expect(
 			Array.from(
 				restoredFromWal.documentPreviousSignaturePublicKey("doc-signer")
-					?.publicKey ?? [],
-			),
-		).to.deep.equal(Array.from(publicKey));
-
-		await persistence.compact(source);
-		expect(store.files.has("document-signers.wal")).equal(false);
-		expect(store.files.has("document-signers.bin")).equal(true);
-		await persistence.hydrate(restoredFromSnapshot);
-		restoredFromSnapshot.clearDocumentIndex();
-		restoredFromSnapshot.putDocumentEncodedPartsStored(
-			"doc-signer",
-			documentValue!,
-			new Uint8Array(0),
-		);
-		expect(restoredFromSnapshot.hasBlock(append.entry.hash)).equal(false);
-		expect(
-			Array.from(
-				restoredFromSnapshot.documentPreviousSignaturePublicKey("doc-signer")
 					?.publicKey ?? [],
 			),
 		).to.deep.equal(Array.from(publicKey));
@@ -3436,7 +3749,7 @@ describe("native peerbit backbone", () => {
 				privateKey,
 				publicKey,
 			});
-			const compacted = await createNativePeerbitBackbone({
+			const reflushed = await createNativePeerbitBackbone({
 				clockId: publicKey,
 				privateKey,
 				publicKey,
@@ -3452,16 +3765,155 @@ describe("native peerbit backbone", () => {
 			expect(restored.getEntryCoordinateHashes()).to.deep.equal(["hash-a"]);
 
 			source.putEntryCoordinates("hash-b", "gid-b", [2n], false, 1, 2n);
-			await persistence.compact(source);
-			expect(await persistence.hydrate(compacted)).to.equal(0);
-			expect(compacted.getEntryCoordinateHashes()).to.deep.equal([
+			await persistence.flushJournal(source);
+			expect(await persistence.hydrate(reflushed)).to.equal(2);
+			expect(reflushed.getEntryCoordinateHashes()).to.deep.equal([
 				"hash-a",
 				"hash-b",
 			]);
-			expect(compacted.coordinateIndexLength).to.equal(2);
+			expect(reflushed.coordinateIndexLength).to.equal(2);
 		} finally {
 			await rm(directory, { recursive: true, force: true });
 		}
+	});
+
+	it("completes short Node WAL writes and poisons zero-progress writes", async () => {
+		const createStore = (writeCounts: number[]) => {
+			const files = new Map<string, Uint8Array>();
+			let writeCalls = 0;
+			const store = new NativeBackboneNodeCoordinatePersistenceStore(
+				"coordinate-directory",
+				{
+					mkdir: async () => {},
+					readFile: async (path) => {
+						const bytes = files.get(path);
+						if (!bytes) {
+							throw Object.assign(new Error("not found"), { code: "ENOENT" });
+						}
+						return bytes.slice();
+					},
+					writeFile: async (path, data) => {
+						files.set(path, data.slice());
+					},
+					appendFile: async (path, data) => {
+						files.set(
+							path,
+							concatBytes([files.get(path) ?? new Uint8Array(), data]),
+						);
+					},
+					open: async (path) => ({
+						write: async (data) => {
+							writeCalls++;
+							const bytesWritten = writeCounts.shift() ?? data.byteLength;
+							if (bytesWritten > 0 && bytesWritten <= data.byteLength) {
+								files.set(
+									path,
+									concatBytes([
+										files.get(path) ?? new Uint8Array(),
+										data.subarray(0, bytesWritten),
+									]),
+								);
+							}
+							return { bytesWritten };
+						},
+						sync: async () => {},
+						close: async () => {},
+					}),
+					rm: async (path) => {
+						files.delete(path);
+					},
+				},
+			);
+			return { store, files, writeCalls: () => writeCalls };
+		};
+
+		const short = createStore([2]);
+		await short.store.append("coordinates.wal", new Uint8Array([1, 2, 3, 4]));
+		expect(short.writeCalls()).equal(2);
+		expect([...short.files.values()][0]).deep.equal(
+			new Uint8Array([1, 2, 3, 4]),
+		);
+
+		const zero = createStore([0]);
+		let firstError: unknown;
+		try {
+			await zero.store.append("coordinates.wal", new Uint8Array([5, 6]));
+		} catch (error) {
+			firstError = error;
+		}
+		expect(String(firstError)).to.contain(
+			"Invalid Node coordinate WAL write progress",
+		);
+		let secondError: unknown;
+		try {
+			await zero.store.append("coordinates.wal", new Uint8Array([7]));
+		} catch (error) {
+			secondError = error;
+		}
+		expect(secondError).equal(firstError);
+		expect(zero.writeCalls()).equal(1);
+		expect([...zero.files.values()][0]?.byteLength ?? 0).equal(0);
+	});
+
+	it("refuses a Node WAL acknowledgement without FileHandle.sync", async () => {
+		const files = new Map<string, Uint8Array>();
+		const store = new NativeBackboneNodeCoordinatePersistenceStore(
+			"coordinate-directory",
+			{
+				mkdir: async () => {},
+				readFile: async (path) => {
+					const bytes = files.get(path);
+					if (!bytes) {
+						throw Object.assign(new Error("not found"), { code: "ENOENT" });
+					}
+					return bytes.slice();
+				},
+				writeFile: async (path, data) => {
+					files.set(path, data.slice());
+				},
+				appendFile: async (path, data) => {
+					files.set(
+						path,
+						concatBytes([files.get(path) ?? new Uint8Array(), data]),
+					);
+				},
+				open: async (path) => ({
+					write: async (data) => {
+						files.set(
+							path,
+							concatBytes([files.get(path) ?? new Uint8Array(), data]),
+						);
+						return { bytesWritten: data.byteLength };
+					},
+					close: async () => {},
+				}),
+				rm: async (path) => {
+					files.delete(path);
+				},
+			},
+		);
+		const persistence = new NativeBackboneCoordinatePersistence(store);
+		const source = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
+		});
+		await persistence.hydrate(source);
+		source.putEntryCoordinates(
+			"hash-no-sync",
+			"gid-no-sync",
+			[1n],
+			false,
+			1,
+			1n,
+		);
+
+		const failure = await persistence.flushJournal(source).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(String(failure)).to.contain("does not expose FileHandle.sync");
+		expect(source.coordinatePendingJournalLength).equal(1);
 	});
 
 	it("persists native coordinate WAL through the direct node adapter", async () => {
@@ -3574,16 +4026,16 @@ describe("native peerbit backbone", () => {
 				privateKey,
 				publicKey,
 			});
-			const persistence =
-				createBufferedNativeBackboneNodeCoordinatePersistence(directory, {
+			const persistence = createBufferedNativeBackboneNodeCoordinatePersistence(
+				directory,
+				{
 					flushMaxPendingBytes: 1024,
-				});
+				},
+			);
 
 			expect(persistence.flushOnAppend).equal(false);
 			expect(persistence.flushMaxPendingBytes).equal(1024);
-			expect(persistence.compactMaxJournalBytes).equal(
-				defaultNativeBackboneCoordinateCompactMaxJournalBytes,
-			);
+			expect(persistence.compactMaxJournalBytes).equal(undefined);
 			await persistence.hydrate(source);
 			source.putEntryCoordinates(
 				"hash-node-buffered",
@@ -3611,7 +4063,7 @@ describe("native peerbit backbone", () => {
 		}
 	});
 
-	it("checkpoints node coordinate WAL after compact thresholds", async () => {
+	it("rejects node coordinate WAL compaction thresholds", async () => {
 		const [{ mkdtemp, rm }, { tmpdir }, { join }] = await Promise.all([
 			import("node:fs/promises"),
 			import("node:os"),
@@ -3621,47 +4073,18 @@ describe("native peerbit backbone", () => {
 			join(tmpdir(), "peerbit-native-backbone-node-coordinate-compact-"),
 		);
 		try {
-			const source = await createNativePeerbitBackbone({
-				clockId: publicKey,
-				privateKey,
-				publicKey,
-			});
-			const restored = await createNativePeerbitBackbone({
-				clockId: publicKey,
-				privateKey,
-				publicKey,
-			});
-			const persistence = new NativeBackboneNodeCoordinatePersistence(
-				directory,
-				{ compactMaxJournalRecords: 1 },
-			);
-
-			await persistence.hydrate(source);
-			source.putEntryCoordinates(
-				"hash-node-compact",
-				"gid-node-compact",
-				[1n],
-				false,
-				1,
-				1n,
-			);
-			expect(await persistence.flushJournal(source)).to.be.greaterThan(0);
-			await persistence.close();
-
-			const restoredPersistence = new NativeBackboneNodeCoordinatePersistence(
-				directory,
-			);
-			expect(await restoredPersistence.hydrate(restored)).equal(0);
-			expect(restored.getEntryCoordinateHashes()).to.deep.equal([
-				"hash-node-compact",
-			]);
-			await restoredPersistence.close();
+			expect(
+				() =>
+					new NativeBackboneNodeCoordinatePersistence(directory, {
+						compactMaxJournalRecords: 1,
+					}),
+			).to.throw("compaction is disabled");
 		} finally {
 			await rm(directory, { recursive: true, force: true });
 		}
 	});
 
-	it("keeps unflushed WAL records when a node append fails and flushes them on retry", async () => {
+	it("keeps WAL records pending and requires a new adapter after append failure", async () => {
 		const [fsPromises, { tmpdir }, { join }] = await Promise.all([
 			import("node:fs/promises"),
 			import("node:os"),
@@ -3724,9 +4147,22 @@ describe("native peerbit backbone", () => {
 			// unflushed records must still be pending in the wasm journal.
 			expect(source.coordinatePendingJournalLength).to.equal(2);
 
-			expect(await persistence.flushJournal(source)).to.be.greaterThan(0);
-			expect(source.coordinatePendingJournalLength).to.equal(0);
+			let repeatedError: unknown;
+			try {
+				await persistence.flushJournal(source);
+			} catch (error) {
+				repeatedError = error;
+			}
+			expect(repeatedError).equal(thrown);
+			expect(source.coordinatePendingJournalLength).to.equal(2);
 			await persistence.close();
+
+			const retryPersistence = new NativeBackboneNodeCoordinatePersistence(
+				directory,
+			);
+			expect(await retryPersistence.flushJournal(source)).to.be.greaterThan(0);
+			expect(source.coordinatePendingJournalLength).to.equal(0);
+			await retryPersistence.close();
 
 			const restoredPersistence = new NativeBackboneNodeCoordinatePersistence(
 				directory,
@@ -3790,14 +4226,7 @@ describe("native peerbit backbone", () => {
 			);
 
 			await persistence.hydrate(source);
-			source.putEntryCoordinates(
-				"hash-mkdir",
-				"gid-mkdir",
-				[1n],
-				false,
-				1,
-				1n,
-			);
+			source.putEntryCoordinates("hash-mkdir", "gid-mkdir", [1n], false, 1, 1n);
 
 			failNextMkdir = true;
 			let thrown: unknown;
@@ -3856,17 +4285,20 @@ describe("native peerbit backbone", () => {
 			const buffered = new NativeBackboneBufferedCoordinatePersistenceStore(
 				nodeStore,
 			);
-			const persistence = new NativeBackboneCoordinatePersistence(buffered);
+			const persistence = new NativeBackboneCoordinatePersistence(buffered, {
+				flushOnAppend: false,
+				flushMaxPendingBytes: 1024,
+			});
 
 			await persistence.hydrate(source);
 			source.putEntryCoordinates("hash-a", "gid-a", [1n], false, 1, 1n);
-			expect(await persistence.flushJournal(source)).to.be.greaterThan(0);
+			expect(await persistence.flushJournalOnAppend(source)).equal(0);
 
 			const writeThroughPersistence = new NativeBackboneCoordinatePersistence(
 				new NativeBackboneNodeCoordinatePersistenceStore(directory),
 			);
 			expect(await writeThroughPersistence.hydrate(beforeFlush)).to.equal(0);
-			await buffered.flush();
+			expect(await persistence.flushJournal(source)).to.be.greaterThan(0);
 			expect(await writeThroughPersistence.hydrate(afterFlush)).to.equal(1);
 			expect(afterFlush.getEntryCoordinateHashes()).to.deep.equal(["hash-a"]);
 			await persistence.close();
@@ -3891,6 +4323,41 @@ describe("native peerbit backbone", () => {
 		expect(directory.syncFlushCount).to.equal(2);
 		expect(directory.syncCloseCount).to.equal(2);
 		expect(directory.asyncWritableCount).to.equal(0);
+	});
+
+	it("completes short OPFS WAL writes and poisons zero-progress writes", async () => {
+		const shortDirectory = new FakeOPFSDirectoryHandle(true, [2]);
+		const shortStore = new NativeBackboneOPFSCoordinatePersistenceStore(
+			shortDirectory,
+		);
+		await shortStore.append("coordinates.wal", new Uint8Array([1, 2, 3, 4]));
+		expect(shortDirectory.syncWriteCount).equal(2);
+		expect(await shortStore.read("coordinates.wal")).deep.equal(
+			new Uint8Array([1, 2, 3, 4]),
+		);
+
+		const zeroDirectory = new FakeOPFSDirectoryHandle(true, [0]);
+		const zeroStore = new NativeBackboneOPFSCoordinatePersistenceStore(
+			zeroDirectory,
+		);
+		let firstError: unknown;
+		try {
+			await zeroStore.append("coordinates.wal", new Uint8Array([5, 6]));
+		} catch (error) {
+			firstError = error;
+		}
+		expect(String(firstError)).to.contain(
+			"Invalid OPFS coordinate WAL write progress",
+		);
+		let secondError: unknown;
+		try {
+			await zeroStore.append("coordinates.wal", new Uint8Array([7]));
+		} catch (error) {
+			secondError = error;
+		}
+		expect(secondError).equal(firstError);
+		expect(zeroDirectory.syncWriteCount).equal(1);
+		expect((await zeroStore.read("coordinates.wal"))?.byteLength).equal(0);
 	});
 
 	it("uses buffered coordinate persistence with OPFS stores", async () => {
@@ -3923,20 +4390,58 @@ describe("native peerbit backbone", () => {
 		expect(await persistence.flushJournalOnAppend?.(source)).equal(0);
 		expect(await opfsStore.read("coordinates.wal")).equal(undefined);
 		await persistence.flushJournal(source);
-		expect(await opfsStore.read("coordinates.wal")).equal(undefined);
+		expect(
+			(await opfsStore.read("coordinates.wal"))?.byteLength,
+		).to.be.greaterThan(source.coordinateJournalHeader().byteLength);
 		await new NativeBackboneCoordinatePersistence(opfsStore).hydrate(
 			beforeClose,
 		);
-		expect(beforeClose.getEntryCoordinateHashes()).to.deep.equal([]);
+		expect(beforeClose.getEntryCoordinateHashes()).to.deep.equal(["hash-opfs"]);
 
 		await persistence.close?.();
-		await new NativeBackboneCoordinatePersistence(opfsStore).hydrate(afterClose);
+		await new NativeBackboneCoordinatePersistence(opfsStore).hydrate(
+			afterClose,
+		);
 		expect(afterClose.getEntryCoordinateHashes()).to.deep.equal(["hash-opfs"]);
 		expect(directory.syncAccessCount).to.be.greaterThan(0);
 	});
 
-	it("persists buffered native document WAL and signer facts through OPFS sync and writable stores", async () => {
-		for (const syncAccess of [true, false]) {
+	it("drops buffered native persistence through OPFS without replaying buffers", async () => {
+		const directory = new FakeOPFSDirectoryHandle(true);
+		const opfsStore = new NativeBackboneOPFSCoordinatePersistenceStore(
+			directory,
+		);
+		const persistence = createBufferedNativeBackboneCoordinatePersistence(
+			opfsStore,
+			{ flushMaxPendingBytes: 1024 },
+		);
+		for (const name of [
+			"coordinates.bin",
+			"coordinates.wal",
+			"document-values.bin",
+			"document-values.wal",
+			"document-signers.bin",
+			"document-signers.wal",
+		]) {
+			await persistence.intentStore!.append(name, new Uint8Array([1, 2, 3]));
+		}
+		await persistence.intentStore!.write(
+			"strict-intent-a",
+			new Uint8Array([4]),
+		);
+		await persistence.intentStore!.write(
+			"strict-intent-b",
+			new Uint8Array([5]),
+		);
+
+		await persistence.drop!(["strict-intent-a", "strict-intent-b"]);
+		await persistence.close?.();
+		expect(directory.files.size).equal(0);
+	});
+
+	it("persists buffered native document WAL and signer facts through OPFS sync stores", async () => {
+		{
+			const syncAccess = true;
 			const directory = new FakeOPFSDirectoryHandle(syncAccess);
 			const opfsStore = new NativeBackboneOPFSCoordinatePersistenceStore(
 				directory,
@@ -3993,8 +4498,12 @@ describe("native peerbit backbone", () => {
 			expect(source.documentSignerPendingJournalLength).equal(1);
 
 			expect(await persistence.flushJournal(source)).to.be.greaterThan(0);
-			expect(await opfsStore.read("document-values.wal")).equal(undefined);
-			expect(await opfsStore.read("document-signers.wal")).equal(undefined);
+			expect(
+				(await opfsStore.read("document-values.wal"))?.byteLength,
+			).to.be.greaterThan(source.documentJournalHeader().byteLength);
+			expect(
+				(await opfsStore.read("document-signers.wal"))?.byteLength,
+			).to.be.greaterThan(source.documentSignerJournalHeader().byteLength);
 			await persistence.close?.();
 			expect(
 				(await opfsStore.read("document-values.wal"))?.byteLength,
@@ -4003,7 +4512,9 @@ describe("native peerbit backbone", () => {
 				(await opfsStore.read("document-signers.wal"))?.byteLength,
 			).to.be.greaterThan(source.documentSignerJournalHeader().byteLength);
 
-			await new NativeBackboneCoordinatePersistence(opfsStore).hydrate(restored);
+			await new NativeBackboneCoordinatePersistence(opfsStore).hydrate(
+				restored,
+			);
 			expect(restored.documentIndexLength).equal(1);
 			expect(
 				Array.from(restored.documentKeysExist(["doc-opfs"])),
@@ -4020,14 +4531,42 @@ describe("native peerbit backbone", () => {
 						[],
 				),
 			).to.deep.equal(Array.from(publicKey));
-			if (syncAccess) {
-				expect(directory.syncAccessCount).to.be.greaterThan(0);
-				expect(directory.asyncWritableCount).equal(0);
-			} else {
-				expect(directory.syncAccessCount).equal(0);
-				expect(directory.asyncWritableCount).to.be.greaterThan(0);
-			}
+			expect(directory.syncAccessCount).to.be.greaterThan(0);
+			expect(directory.asyncWritableCount).equal(0);
 		}
+	});
+
+	it("rejects a durable ACK when OPFS only exposes writable streams", async () => {
+		const directory = new FakeOPFSDirectoryHandle(false);
+		const opfsStore = new NativeBackboneOPFSCoordinatePersistenceStore(
+			directory,
+		);
+		const persistence = createBufferedNativeBackboneCoordinatePersistence(
+			opfsStore,
+			{ flushMaxPendingBytes: 1024 },
+		);
+		const source = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
+		});
+		await persistence.hydrate(source);
+		source.putEntryCoordinates(
+			"hash-no-opfs-barrier",
+			"gid-no-opfs-barrier",
+			[1n],
+			false,
+			1,
+			1n,
+		);
+
+		const failure = await persistence.flushJournal(source).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(String(failure)).to.contain("sync handles unavailable");
+		expect(source.coordinatePendingJournalLength).equal(1);
+		expect(directory.asyncWritableCount).to.be.greaterThan(0);
 	});
 
 	it("appends coordinate WAL bytes through OPFS writable fallback", async () => {


### PR DESCRIPTION
## Summary
- make native append, trim, document, coordinate, and signer acknowledgements wait for physical durability
- add crash-safe WAL recovery, resumable drop/cleanup, and lifecycle serialization across native stores
- preserve acknowledged content through rollback and hard-kill recovery while failing closed on ambiguous persistence

## Validation
- full @peerbit/log suite: 277/277
- focused adversarial suite: 13/13
- durable document/SIGKILL matrix: 60/60
- interface, simple, Rust, and SQLite indexer builds
- Rust/TypeScript/native backbone/block smoke suites
- independent exact-commit review: no P0, P1, or P2 findings

All commits use the peerbit-org bot identity.