### PR TITLE
fix(ci): use supported pnpm audit endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
 		"release": "pnpm run build && pnpm run release:security-gate && node ./scripts/publish-public-packages.mjs",
 		"release:publish": "pnpm run release && changeset tag && git push origin --tags",
 		"release:rc": "pnpm run build && pnpm run release:security-gate && AEGIR_PACKAGE_MANAGER=pnpm aegir release-rc",
-		"release:security-gate": "pnpm run test:release-security-contracts && pnpm run test:security-dependencies && pnpm run test:security-published-closure && pnpm run test:security-published && pnpm audit --prod && pnpm audit",
+		"release:security-gate": "pnpm run test:release-security-contracts && pnpm run test:security-dependencies && pnpm run test:security-published-closure && pnpm run test:security-published && pnpm dlx pnpm@11.13.0 with current audit --prod && pnpm dlx pnpm@11.13.0 with current audit",
 		"deploy": "pnpm run deploy:docs",
 		"deploy:docs": "pnpm run site:build && gh-pages --dist apps/peerbit-org/dist --dotfiles",
 		"fmt": "prettier --write '{*,**/*}.{js,ts,jsx,tsx,json,vue}'",

--- a/scripts/test-release-security-contracts.mjs
+++ b/scripts/test-release-security-contracts.mjs
@@ -17,7 +17,7 @@ const scripts = packageManifest.scripts;
 
 assert.equal(
 	scripts["release:security-gate"],
-	"pnpm run test:release-security-contracts && pnpm run test:security-dependencies && pnpm run test:security-published-closure && pnpm run test:security-published && pnpm audit --prod && pnpm audit",
+	"pnpm run test:release-security-contracts && pnpm run test:security-dependencies && pnpm run test:security-published-closure && pnpm run test:security-published && pnpm dlx pnpm@11.13.0 with current audit --prod && pnpm dlx pnpm@11.13.0 with current audit",
 	"the shared release gate must fail closed on its contract test, dependency probe, focused publication-closure proof, full published-package smoke, and both root audits",
 );
 assert.equal(


### PR DESCRIPTION
## Summary
- run the two root dependency audits through pinned pnpm 11.13 while keeping the repository on pnpm 10.24
- use pnpm 11 with current so audit reaches npm bulk advisories instead of the retired legacy endpoints
- update the exact fail-closed release security contract

## Why
npm now returns HTTP 410 for both legacy audit endpoints used by pnpm 10. This caused the Security Dependency Contracts job to fail after all repository security proofs had passed; it was not a vulnerability finding.

## Validation
- release security contract passed
- production audit passed with zero advisories
- full audit passed with zero advisories
- invalid-registry probe reached the bulk endpoint and exited nonzero
- formatting and diff checks passed
- exact-commit review: no P0, P1, or P2 findings

This does not ignore registry errors and does not migrate the repository package manager.