### PR TITLE
test(react): stabilize advisory lock marker timing

### DIFF
--- a/packages/clients/peerbit-react/vitest/utils.test.ts
+++ b/packages/clients/peerbit-react/vitest/utils.test.ts
@@ -364,10 +364,13 @@ describe("getKeypair", () => {
 	it("publishes a pinned advisory marker visible to legacy tabs", async () => {
 		const id = uuid();
 		const manager = new InMemoryLockManager();
+		// This test verifies cross-lock visibility, not the mutex timeout path.
+		// Keep enough headroom for loaded CI workers and instrumented coverage runs.
+		const lockTimeout = 1000;
 		const webMutex = new FastMutex({
 			localStorage,
 			clientId: createWebLockClientId(),
-			timeout: 50,
+			timeout: lockTimeout,
 		});
 		const current = await getFreeKeypairWithWebLock(
 			id,
@@ -382,7 +385,7 @@ describe("getKeypair", () => {
 		const legacyMutex = new FastMutex({
 			localStorage,
 			clientId: "later-legacy-owner",
-			timeout: 50,
+			timeout: lockTimeout,
 		});
 		const legacy = await getFreeKeypair(id, legacyMutex, () => true);
 		expect(legacy.index).to.eq(1);


### PR DESCRIPTION
## Summary
- give the cross-lock visibility test 1 second of mutex headroom instead of 50 ms
- keep production mutex behavior unchanged
- avoid false failures on loaded GitHub Actions coverage workers

## Validation
- focused advisory-marker test: 10/10 repeated passes
- full peerbit-react utils test file: 11/11
- peerbit-react dependency build
- git diff --check

All commits use the peerbit-org bot identity.