### PR TITLE
fix(program): make graph lifecycle retryable

### DIFF
--- a/.changeset/tidy-program-lifecycle.md
+++ b/.changeset/tidy-program-lifecycle.md
@@ -1,6 +1,7 @@
 ---
 "@peerbit/program": patch
 "@peerbit/shared-log": patch
+"@peerbit/native-backbone": patch
 "peerbit": patch
 ---
 
@@ -9,4 +10,5 @@ after partial failures; preserve parent/child ownership through rollback; fence
 concurrent initialization and teardown; and retain cleanup ownership until all
 terminal work completes. Direct lifecycle reentry into the owning handler stop
 now rejects instead of deadlocking; lifecycle code must schedule stop from its
-external owner rather than await its own teardown.
+external owner rather than await its own teardown. Interrupted native persistence
+drops can now resume their durable tombstone on the same adapter generation.

--- a/.changeset/tidy-program-lifecycle.md
+++ b/.changeset/tidy-program-lifecycle.md
@@ -1,0 +1,11 @@
+---
+"@peerbit/program": patch
+"peerbit": patch
+---
+
+Make program graph open, close, drop, and handler stop race-safe and retryable
+after partial failures; preserve parent/child ownership through rollback; fence
+concurrent initialization and teardown; and retain cleanup ownership until all
+terminal work completes. Direct lifecycle reentry into the owning handler stop
+now rejects instead of deadlocking; lifecycle code must schedule stop from its
+external owner rather than await its own teardown.

--- a/.changeset/tidy-program-lifecycle.md
+++ b/.changeset/tidy-program-lifecycle.md
@@ -1,5 +1,6 @@
 ---
 "@peerbit/program": patch
+"@peerbit/shared-log": patch
 "peerbit": patch
 ---
 

--- a/.changeset/tidy-program-lifecycle.md
+++ b/.changeset/tidy-program-lifecycle.md
@@ -2,13 +2,30 @@
 "@peerbit/program": patch
 "@peerbit/shared-log": patch
 "@peerbit/native-backbone": patch
+"@peerbit/rpc": patch
+"@peerbit/string": patch
 "peerbit": patch
 ---
 
 Make program graph open, close, drop, and handler stop race-safe and retryable
 after partial failures; preserve parent/child ownership through rollback; fence
 concurrent initialization and teardown; and retain cleanup ownership until all
-terminal work completes. Direct lifecycle reentry into the owning handler stop
-now rejects instead of deadlocking; lifecycle code must schedule stop from its
-external owner rather than await its own teardown. Interrupted native persistence
-drops can now resume their durable tombstone on the same adapter generation.
+terminal work completes. Lifecycle `onClose` and `onDrop` callbacks now run after
+base child teardown and the closed-state transition, are awaited, and retry when
+they reject; subclass cleanup performed after awaiting `super.close()` or
+`super.drop()` can still follow those callbacks. Immediate reentry into the
+owning handler stop or current terminal method now rejects, while synchronous
+delegation to a captured pre-replacement wrapper is unwrapped safely only for the
+same operation and owner. Cross-operation, changed-owner, and after-yield stale
+wrapper cycles reject before mutation. Parent teardown also restores missing
+inverse ownership edges and recognizes only validated stale-edge repair as
+progress. After lifecycle code has yielded, it must schedule stop or terminal
+work from its external owner rather than await its own teardown. SharedLog, RPC,
+and StringIndex now preserve their resources for non-terminal owner releases and
+invalid owners. RPC also becomes network-inert after a committed base close or
+drop error and checkpoints subscription and listener cleanup for exact retry.
+Interrupted native persistence drops can now resume their durable tombstone on
+the same adapter generation. A markerless failed drop keeps ordinary native
+persistence work fenced while still permitting destructive retry, and close
+retries resume the first incomplete flush/store-close stage without flushing a
+generation already admitted for drop.

--- a/packages/clients/peerbit/src/peer.ts
+++ b/packages/clients/peerbit/src/peer.ts
@@ -861,6 +861,7 @@ export class Peerbit implements ProgramClient {
 	}
 
 	async start() {
+		this._handler?.assertCanStart();
 		await this._storage.open();
 		await this.indexer.start();
 
@@ -870,6 +871,7 @@ export class Peerbit implements ProgramClient {
 		}
 		this._bootstrapRecoveryPaused = false;
 		await this._bootstrapRecoveryTransition;
+		this._handler?.start();
 		this.startBootstrapRecovery();
 	}
 	async stop() {

--- a/packages/programs/data/document/document/test/durable-native-commit-ack.spec.ts
+++ b/packages/programs/data/document/document/test/durable-native-commit-ack.spec.ts
@@ -674,6 +674,7 @@ describe("durable native commit acknowledgement", function () {
 			new Document({ id: "interrupted-drop", name: "erase-on-resume" }),
 			{ unique: true, replicate: false, target: "none" },
 		);
+		const acknowledgedHash = acknowledged.entry.hash;
 		const persistenceStore = first.sharedLog
 			._nativeBackboneCoordinatePersistenceStore as {
 			remove: (name: string) => Promise<void>;
@@ -708,10 +709,63 @@ describe("durable native commit acknowledgement", function () {
 		client = undefined;
 		const reopened = await createStore(directory!);
 		expect(await reopened.store.docs.get("interrupted-drop")).equal(undefined);
-		expect(
-			await reopened.sharedLog.log.entryIndex.has(acknowledged.entry.hash),
-		).equal(true);
+		expect(reopened.sharedLog.log.length).equal(0);
+		expect(await reopened.sharedLog.log.entryIndex.has(acknowledgedHash)).equal(
+			false,
+		);
+		expect(reopened.backbone.blocks.get(acknowledgedHash)).equal(undefined);
+		expect(await reopened.durable.has(acknowledgedHash)).equal(false);
 		expect(reopened.backbone.documentValueBytes("interrupted-drop")).equal(
+			undefined,
+		);
+		await expectNativePersistenceErased(directory!);
+	});
+
+	it("restarts native drop when failure precedes the durable tombstone", async () => {
+		const first = await openStore();
+		const acknowledged = await first.store.docs.put(
+			new Document({ id: "pre-tombstone-drop", name: "erase-on-retry" }),
+			{ unique: true, replicate: false, target: "none" },
+		);
+		const acknowledgedHash = acknowledged.entry.hash;
+		const persistenceStore = first.sharedLog
+			._nativeBackboneCoordinatePersistenceStore as {
+			write: (name: string, bytes: Uint8Array) => Promise<void>;
+		};
+		const originalWrite = persistenceStore.write.bind(persistenceStore);
+		const tombstoneFailure = new Error("injected drop tombstone write failure");
+		let injected = false;
+		persistenceStore.write = async (name, bytes) => {
+			if (name === "native-backbone-drop.tombstone" && !injected) {
+				injected = true;
+				throw tombstoneFailure;
+			}
+			await originalWrite(name, bytes);
+		};
+		const dropError = await first.store.drop().then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		persistenceStore.write = originalWrite;
+		expect(injected).equal(true);
+		expect(dropError).equal(tombstoneFailure);
+		await expectFileAbsent(
+			path.join(directory!, "coordinate-wal", "native-backbone-drop.tombstone"),
+		);
+
+		await client!.stop();
+		client = undefined;
+		const reopened = await createStore(directory!);
+		expect(await reopened.store.docs.get("pre-tombstone-drop")).equal(
+			undefined,
+		);
+		expect(reopened.sharedLog.log.length).equal(0);
+		expect(await reopened.sharedLog.log.entryIndex.has(acknowledgedHash)).equal(
+			false,
+		);
+		expect(reopened.backbone.blocks.get(acknowledgedHash)).equal(undefined);
+		expect(await reopened.durable.has(acknowledgedHash)).equal(false);
+		expect(reopened.backbone.documentValueBytes("pre-tombstone-drop")).equal(
 			undefined,
 		);
 		await expectNativePersistenceErased(directory!);

--- a/packages/programs/data/document/document/test/durable-native-commit-ack.spec.ts
+++ b/packages/programs/data/document/document/test/durable-native-commit-ack.spec.ts
@@ -771,6 +771,124 @@ describe("durable native commit acknowledgement", function () {
 		await expectNativePersistenceErased(directory!);
 	});
 
+	it("overwrites a partial native drop tombstone on exact retry", async () => {
+		const first = await openStore();
+		const acknowledged = await first.store.docs.put(
+			new Document({ id: "partial-tombstone-drop", name: "erase-on-retry" }),
+			{ unique: true, replicate: false, target: "none" },
+		);
+		const acknowledgedHash = acknowledged.entry.hash;
+		const persistenceStore = first.sharedLog
+			._nativeBackboneCoordinatePersistenceStore as {
+			write: (name: string, bytes: Uint8Array) => Promise<void>;
+		};
+		const originalWrite = persistenceStore.write.bind(persistenceStore);
+		const partialWriteFailure = new Error(
+			"injected partial drop tombstone write failure",
+		);
+		let injected = false;
+		persistenceStore.write = async (name, bytes) => {
+			if (name === "native-backbone-drop.tombstone" && !injected) {
+				injected = true;
+				await originalWrite(name, bytes.subarray(0, 1));
+				throw partialWriteFailure;
+			}
+			await originalWrite(name, bytes);
+		};
+		const dropError = await first.store.drop().then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		persistenceStore.write = originalWrite;
+		expect(injected).equal(true);
+		expect(dropError).equal(partialWriteFailure);
+		await fs.stat(
+			path.join(directory!, "coordinate-wal", "native-backbone-drop.tombstone"),
+		);
+
+		await client!.stop();
+		client = undefined;
+		const reopened = await createStore(directory!);
+		expect(await reopened.store.docs.get("partial-tombstone-drop")).equal(
+			undefined,
+		);
+		expect(reopened.sharedLog.log.length).equal(0);
+		expect(await reopened.sharedLog.log.entryIndex.has(acknowledgedHash)).equal(
+			false,
+		);
+		expect(reopened.backbone.blocks.get(acknowledgedHash)).equal(undefined);
+		expect(await reopened.durable.has(acknowledgedHash)).equal(false);
+		expect(
+			reopened.backbone.documentValueBytes("partial-tombstone-drop"),
+		).equal(undefined);
+		await expectNativePersistenceErased(directory!);
+	});
+
+	for (const target of [
+		"entry coordinates index",
+		"replication range index",
+		"log",
+		"post-drop close",
+	] as const) {
+		it(`retains failed ${target} cleanup for the exact terminal retry`, async () => {
+			const first = await openStore();
+			const id = `lower-cleanup-${target.replaceAll(" ", "-")}`;
+			const acknowledged = await first.store.docs.put(
+				new Document({ id, name: "erase-on-retry" }),
+				{ unique: true, replicate: false, target: "none" },
+			);
+			const acknowledgedHash = acknowledged.entry.hash;
+			const resource: {
+				drop?: () => Promise<void>;
+				stop?: () => Promise<void>;
+			} =
+				target === "entry coordinates index"
+					? first.sharedLog._entryCoordinatesIndex
+					: target === "replication range index"
+						? first.sharedLog._replicationRangeIndex
+						: target === "log"
+							? first.sharedLog.log
+							: first.sharedLog.remoteBlocks;
+			const method = target === "post-drop close" ? "stop" : "drop";
+			const original = resource[method]!.bind(resource);
+			const cleanupFailure = new Error(`injected ${target} cleanup failure`);
+			let attempts = 0;
+			resource[method] = async () => {
+				attempts++;
+				if (attempts === 1) {
+					throw cleanupFailure;
+				}
+				await original();
+			};
+
+			const dropError = await first.store.drop().then(
+				() => undefined,
+				(error: unknown) => error,
+			);
+			expect(dropError).equal(cleanupFailure);
+			if (target === "entry coordinates index") {
+				expect(first.sharedLog._entryCoordinatesIndex).equal(resource);
+			}
+			if (target === "replication range index") {
+				expect(first.sharedLog._replicationRangeIndex).equal(resource);
+			}
+
+			await client!.stop();
+			client = undefined;
+			expect(attempts).equal(2);
+
+			const reopened = await createStore(directory!);
+			expect(await reopened.store.docs.get(id)).equal(undefined);
+			expect(reopened.sharedLog.log.length).equal(0);
+			expect(
+				await reopened.sharedLog.log.entryIndex.has(acknowledgedHash),
+			).equal(false);
+			expect(reopened.backbone.blocks.get(acknowledgedHash)).equal(undefined);
+			expect(await reopened.durable.has(acknowledgedHash)).equal(false);
+			await expectNativePersistenceErased(directory!);
+		});
+	}
+
 	it("rejects a durable custom adapter without drop before lower mutation", async () => {
 		directory = await fs.mkdtemp(
 			path.join(os.tmpdir(), "peerbit-durable-native-no-drop-adapter-"),
@@ -3192,6 +3310,54 @@ describe("durable native commit acknowledgement", function () {
 		}
 	});
 
+	it("completes an exact poisoned close with conservative trim debt", async () => {
+		const { store, wrapper, durable } = await openStore(true);
+		await store.docs.put(
+			new Document({ id: "poison-debt-old", name: "poison-debt-old" }),
+			{ unique: true, target: "none", replicate: false },
+		);
+		const cleanupFailure = new Error("persistent trim cleanup failure");
+		const durableRmManyStub = sinon
+			.stub(durable, "rmMany")
+			.rejects(cleanupFailure);
+		try {
+			const replacement = await store.docs.put(
+				new Document({ id: "poison-debt-new", name: "poison-debt-new" }),
+				{ unique: true, target: "none", replicate: false },
+			);
+			expect(wrapper.pendingNativeDeleteCleanup.size).to.be.greaterThan(0);
+			const bytes = await durable.get(replacement.entry.hash);
+			if (!bytes) throw new Error("Expected durable replacement block");
+
+			const mirrorFailure = new Error("durable mirror poison with trim debt");
+			const durablePutStub = sinon
+				.stub(durable, "putKnown")
+				.rejects(mirrorFailure);
+			const poison = await wrapper.putKnown(replacement.entry.hash, bytes).then(
+				() => undefined,
+				(error: unknown) => error,
+			);
+			durablePutStub.restore();
+			expect(poison).to.be.instanceOf(NativeDurableCommitError);
+
+			const closeFailure = await store.close().then(
+				() => undefined,
+				(error: unknown) => error,
+			);
+			expect(closeFailure).equal(poison);
+			expect(wrapper.pendingNativeDeleteCleanup.size).to.be.greaterThan(0);
+			expect(wrapper.stopCompleted).equal(true);
+			expect(durable.status()).equal("closed");
+
+			await store.close();
+			expect(store.closed).equal(true);
+			expect(wrapper.pendingNativeDeleteCleanup.size).to.be.greaterThan(0);
+			expect(durable.status()).equal("closed");
+		} finally {
+			durableRmManyStub.restore();
+		}
+	});
+
 	it("keeps the new batch state through partial trim cleanup and reopen", async () => {
 		const { store, sharedLog, wrapper, durable } = await openStore(true);
 		const old = await store.docs.put(
@@ -3559,11 +3725,11 @@ describe("durable native commit acknowledgement", function () {
 			expect(oldRemote.status).equal("closed");
 			expect(durable.status()).equal("closed");
 			// Program parents retain their own open flag when a child close rejects.
-			// The child itself is fully torn down; one idempotent close at each parent
-			// level completes their bookkeeping before reopening the same objects.
-			await store.docs.close();
+			// Retry through the same parent operation so Handler can resume every
+			// committed child release with its original owner identity.
 			await store.close();
 			expect(store.closed).equal(true);
+			expect(durableStopSpy.calledOnce).equal(true);
 
 			const reopened = await client!.open(store, {
 				args: createOpenArgs(directory!),

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -14290,7 +14290,9 @@ export class SharedLog<
 		}
 	}
 
-	private async _close() {
+	private async _close(options?: { preserveDropRetryResources?: boolean }) {
+		const preserveDropRetryResources =
+			options?.preserveDropRetryResources === true;
 		let firstError: unknown;
 		const capture = async (operation: () => Promise<unknown> | unknown) => {
 			try {
@@ -14388,7 +14390,9 @@ export class SharedLog<
 		});
 		captureSync(() => this._checkedPrune.close());
 
-		await capture(() => this.remoteBlocks?.stop?.());
+		if (!preserveDropRetryResources) {
+			await capture(() => this.remoteBlocks?.stop?.());
+		}
 		captureSync(() => {
 			this._pendingIHave?.clear();
 			this.latestReplicationInfoMessage?.clear();
@@ -14406,10 +14410,12 @@ export class SharedLog<
 		captureSync(() => this.responseToPruneDebouncedFn?.close?.());
 		this.pruneDebouncedFn = undefined as any;
 		this.rebalanceParticipationDebounced = undefined;
-		await capture(() => this._replicationRangeIndex?.stop?.());
-		await capture(() => this._entryCoordinatesIndex?.stop?.());
-		this._replicationRangeIndex = undefined as any;
-		this._entryCoordinatesIndex = undefined as any;
+		if (!preserveDropRetryResources) {
+			await capture(() => this._replicationRangeIndex?.stop?.());
+			await capture(() => this._entryCoordinatesIndex?.stop?.());
+			this._replicationRangeIndex = undefined as any;
+			this._entryCoordinatesIndex = undefined as any;
+		}
 		this._nativeRangePlanner = undefined;
 		this._nativeSharedLogState = undefined;
 		this._residentEntryCoordinatesByHash = undefined;
@@ -14593,19 +14599,30 @@ export class SharedLog<
 			throw firstError;
 		}
 		if (nativePersistence) {
-			this._nativeBackboneDropStarted = true;
 			try {
-				await nativePersistence.drop!(
-					this._nativeBackboneCoordinatePersistenceStore
-						? NATIVE_STRICT_DURABLE_TRANSACTION_INTENT_FILES
-						: [],
-				);
+				if (this._nativeBackboneDropStarted) {
+					const resumed = await nativePersistence.resumeDrop!();
+					if (!resumed) {
+						await nativePersistence.drop!(
+							this._nativeBackboneCoordinatePersistenceStore
+								? NATIVE_STRICT_DURABLE_TRANSACTION_INTENT_FILES
+								: [],
+						);
+					}
+				} else {
+					this._nativeBackboneDropStarted = true;
+					await nativePersistence.drop!(
+						this._nativeBackboneCoordinatePersistenceStore
+							? NATIVE_STRICT_DURABLE_TRANSACTION_INTENT_FILES
+							: [],
+					);
+				}
 			} catch (error) {
 				firstError ??= error;
-				// The adapter remains in its drop lifecycle, so this closes handles
-				// without flushing live journals over a partial erase.
+				// Quiesce the failed generation without closing the lower block/index
+				// handles: exact drop retry still owns their destructive cleanup.
 				await capture(() => this.log.close());
-				await capture(() => this._close());
+				await capture(() => this._close({ preserveDropRetryResources: true }));
 				throw firstError;
 			}
 			// These in-memory states only stop being recovery-authoritative after all

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -70,7 +70,12 @@ import type {
 	NativePeerbitBackbone,
 	NativeBackboneCoordinatePersistenceConfig as RuntimeNativeBackboneCoordinatePersistenceConfig,
 } from "@peerbit/native-backbone";
-import { ClosedError, Program, type ProgramEvents } from "@peerbit/program";
+import {
+	ClosedError,
+	Program,
+	type ProgramEvents,
+	TerminalOperationNotStartedError,
+} from "@peerbit/program";
 import {
 	FanoutChannel,
 	type FanoutProviderHandle,
@@ -14517,7 +14522,7 @@ export class SharedLog<
 				nativePersistence.dropIsTerminal !== true)
 		) {
 			// Reject before `super.drop()` can drop child programs or any lower index.
-			throw new Error(
+			throw new TerminalOperationNotStartedError(
 				"NativeBackbone coordinate persistence adapters must expose a terminal underlying drop capability and resumeDrop before SharedLog.drop() can erase their namespace",
 			);
 		}

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -490,6 +490,7 @@ class NativeBackboneWriteThroughBlockStore {
 	// success. `.catch` also prevents unhandled-rejection noise.
 	private readonly pendingDurableWrites = new Set<Promise<unknown>>();
 	private nativeDurableCommitFailure?: NativeDurableCommitError;
+	private stopCompleted = false;
 	private readonly nativeDeleteTombstones = new Map<string, number>();
 	private nativeDeleteEpoch = 0;
 	private readonly nativeBlockWriteGenerations = new Map<string, number>();
@@ -897,14 +898,19 @@ class NativeBackboneWriteThroughBlockStore {
 	// persisted coordinate + signer facts without resolving the entry block.
 	async start(): Promise<void> {
 		await this.durable.start();
+		this.stopCompleted = false;
 	}
 
 	async stop(): Promise<void> {
+		if (this.stopCompleted) {
+			return;
+		}
 		// Surface any tracked (sync-path) durable write failure and ensure all
 		// mirror writes have settled before the durable store is torn down. Closing
 		// the durable store is unconditional: a prior columnar mirror failure must
 		// not leak the store lifecycle resource.
 		let firstError: unknown;
+		let shutdownError: unknown;
 		try {
 			await this.drainDurable();
 		} catch (error) {
@@ -918,11 +924,23 @@ class NativeBackboneWriteThroughBlockStore {
 			await this.retryNativeDeleteCleanup({ allowPoisoned: true });
 		} catch (error) {
 			firstError ??= error;
+			shutdownError ??= error;
 		}
 		try {
 			await this.durable.stop();
 		} catch (error) {
 			firstError ??= error;
+			shutdownError ??= error;
+		}
+		if (shutdownError === undefined) {
+			// A durable poison belongs to the generation being closed. Report it once
+			// so the owning terminal call observes the failed append, but remember that
+			// every mandatory shutdown stage completed. Conservative content-addressed
+			// trim debt may remain in this retired wrapper after best-effort cleanup; a
+			// fresh generation gets a new wrapper and must not be wedged by that debt.
+			// The exact terminal retry may therefore finish parent bookkeeping without
+			// rethrowing the same latched poison forever.
+			this.stopCompleted = true;
 		}
 		if (firstError !== undefined) {
 			throw firstError;
@@ -1884,6 +1902,11 @@ type NativeBackboneCoordinatePersistenceAdapter = {
 	flushJournalOnAppend?(backbone: unknown): number | Promise<number>;
 	compact?(backbone: unknown): Promise<void>;
 	drop?(additionalFiles?: readonly string[]): Promise<void>;
+	/**
+	 * Resume a failed tombstoned erase. `true` is terminal only when this adapter
+	 * initiated the drop; recovery of a prior generation returns active. `false`
+	 * restores explicit-drop admission, as must corrupt-marker rejection.
+	 */
 	resumeDrop?(): Promise<boolean>;
 	close?(): Promise<void>;
 };
@@ -14411,10 +14434,26 @@ export class SharedLog<
 		this.pruneDebouncedFn = undefined as any;
 		this.rebalanceParticipationDebounced = undefined;
 		if (!preserveDropRetryResources) {
-			await capture(() => this._replicationRangeIndex?.stop?.());
-			await capture(() => this._entryCoordinatesIndex?.stop?.());
-			this._replicationRangeIndex = undefined as any;
-			this._entryCoordinatesIndex = undefined as any;
+			const stopIndex = async (
+				index: Index<any> | undefined,
+				forget: () => void,
+			) => {
+				if (!index) {
+					return;
+				}
+				try {
+					await index.stop?.();
+					forget();
+				} catch (error) {
+					firstError ??= error;
+				}
+			};
+			await stopIndex(this._replicationRangeIndex, () => {
+				this._replicationRangeIndex = undefined as any;
+			});
+			await stopIndex(this._entryCoordinatesIndex, () => {
+				this._entryCoordinatesIndex = undefined as any;
+			});
 		}
 		this._nativeRangePlanner = undefined;
 		this._nativeSharedLogState = undefined;
@@ -14425,7 +14464,32 @@ export class SharedLog<
 			throw firstError;
 		}
 	}
+
+	private classifyTerminalOwnership(
+		from?: Program,
+	): "terminal" | "nonterminal" {
+		if (this.closed) {
+			return "terminal";
+		}
+		const parentIndex =
+			this.parents?.findIndex((parent) => parent === from) ?? -1;
+		if (from && parentIndex === -1) {
+			throw new TerminalOperationNotStartedError(
+				"Could not find from in parents",
+			);
+		}
+		return parentIndex !== -1 && (this.parents?.length ?? 0) > 1
+			? "nonterminal"
+			: "terminal";
+	}
+
 	async close(from?: Program): Promise<boolean> {
+		if (this.classifyTerminalOwnership(from) === "nonterminal") {
+			return super.close(from);
+		}
+		// Match Program.end()'s synchronous terminal admission fence before any
+		// SharedLog-specific await or observable teardown can admit a new owner.
+		this.preventParentAttachments();
 		this.ensureNativeDurabilityRuntimeState();
 		this.cancelCurrentReplicationStateAnnouncementRetry();
 		// Best-effort: announce that we are going offline before tearing down
@@ -14485,6 +14549,13 @@ export class SharedLog<
 		try {
 			superClosed = await super.close(from);
 		} catch (error) {
+			if (!this.closed || this.pendingTerminalOperation !== "close") {
+				// Child/base admission failed before Program committed this terminal
+				// transition (including a cleanly closed instance). Lower resources are
+				// still live data or belong to a completed generation, so do not mutate
+				// them while merely propagating the base error.
+				throw error;
+			}
 			firstError = error;
 		}
 		if (!superClosed && firstError === undefined) {
@@ -14518,6 +14589,9 @@ export class SharedLog<
 	}
 
 	async drop(from?: Program): Promise<boolean> {
+		if (this.classifyTerminalOwnership(from) === "nonterminal") {
+			return super.drop(from);
+		}
 		this.ensureNativeDurabilityRuntimeState();
 		const nativePersistence = this._nativeBackboneCoordinatePersistence;
 		if (
@@ -14532,6 +14606,9 @@ export class SharedLog<
 				"NativeBackbone coordinate persistence adapters must expose a terminal underlying drop capability and resumeDrop before SharedLog.drop() can erase their namespace",
 			);
 		}
+		// Adapter capability validation above is explicitly unstarted. Establish
+		// the terminal fence only after that precondition succeeds.
+		this.preventParentAttachments();
 		this.cancelCurrentReplicationStateAnnouncementRetry();
 		// Best-effort: announce that we are going offline before tearing down
 		// RPC/subscription state (same reasoning as in `close()`).
@@ -14575,6 +14652,12 @@ export class SharedLog<
 		try {
 			superDropped = await super.drop(from);
 		} catch (error) {
+			if (!this.closed || this.pendingTerminalOperation !== "drop") {
+				// A fresh drop on a cleanly closed Program is an API rejection, not
+				// permission to erase the already-closed lower log. Likewise, a child
+				// failure before the base drop commits must leave all lower data intact.
+				throw error;
+			}
 			firstError = error;
 		}
 		if (!superDropped && firstError === undefined) {
@@ -14600,22 +14683,34 @@ export class SharedLog<
 		}
 		if (nativePersistence) {
 			try {
+				const additionalFiles = this._nativeBackboneCoordinatePersistenceStore
+					? NATIVE_STRICT_DURABLE_TRANSACTION_INTENT_FILES
+					: [];
 				if (this._nativeBackboneDropStarted) {
-					const resumed = await nativePersistence.resumeDrop!();
+					let resumed: boolean;
+					try {
+						resumed = await nativePersistence.resumeDrop!();
+					} catch (resumeError) {
+						try {
+							// A corrupt or partial tombstone deliberately restores the
+							// adapter to active so explicit drop can overwrite it. For
+							// transient read/remove failures the adapter stays dropping,
+							// this fallback rejects, and the original recovery error wins.
+							await nativePersistence.drop!(additionalFiles);
+							resumed = true;
+						} catch (restartError) {
+							throw new AggregateError(
+								[resumeError, restartError],
+								"Failed to resume or restart native backbone drop",
+							);
+						}
+					}
 					if (!resumed) {
-						await nativePersistence.drop!(
-							this._nativeBackboneCoordinatePersistenceStore
-								? NATIVE_STRICT_DURABLE_TRANSACTION_INTENT_FILES
-								: [],
-						);
+						await nativePersistence.drop!(additionalFiles);
 					}
 				} else {
 					this._nativeBackboneDropStarted = true;
-					await nativePersistence.drop!(
-						this._nativeBackboneCoordinatePersistenceStore
-							? NATIVE_STRICT_DURABLE_TRANSACTION_INTENT_FILES
-							: [],
-					);
+					await nativePersistence.drop!(additionalFiles);
 				}
 			} catch (error) {
 				firstError ??= error;
@@ -14636,9 +14731,41 @@ export class SharedLog<
 			this._nativeDurableRecoveryReadyForReopen = false;
 			this._nativeDurableRecoveryCids.clear();
 		}
-		await capture(() => this._entryCoordinatesIndex?.drop());
-		await capture(() => this._replicationRangeIndex?.drop());
-		await capture(() => this.log.drop());
+		let destructiveCleanupFailed = false;
+		const dropIndex = async (
+			index: Index<any> | undefined,
+			forget: () => void,
+		) => {
+			if (!index) {
+				return;
+			}
+			try {
+				await index.drop();
+				forget();
+			} catch (error) {
+				firstError ??= error;
+				destructiveCleanupFailed = true;
+			}
+		};
+		await dropIndex(this._entryCoordinatesIndex, () => {
+			this._entryCoordinatesIndex = undefined as any;
+		});
+		await dropIndex(this._replicationRangeIndex, () => {
+			this._replicationRangeIndex = undefined as any;
+		});
+		try {
+			await this.log.drop();
+		} catch (error) {
+			firstError ??= error;
+			destructiveCleanupFailed = true;
+		}
+		if (destructiveCleanupFailed) {
+			// Exact drop retry still owns every failed destructive handle. Quiesce
+			// the rest of the generation without turning an erase failure into a
+			// successful close or forgetting the only object that can retry it.
+			await capture(() => this._close({ preserveDropRetryResources: true }));
+			throw firstError;
+		}
 		await capture(() => this._close());
 		if (firstError !== undefined) {
 			throw firstError;

--- a/packages/programs/data/shared-log/test/lifecycle.spec.ts
+++ b/packages/programs/data/shared-log/test/lifecycle.spec.ts
@@ -1,4 +1,5 @@
 // Include test utilities
+import { TerminalOperationNotStartedError } from "@peerbit/program";
 import { TestSession } from "@peerbit/test-utils";
 import { delay, waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
@@ -31,6 +32,39 @@ describe("lifecycle", () => {
 			expect(closeLog.called).to.be.true;
 		});
 
+		for (const target of [
+			"entry coordinates index",
+			"replication range index",
+		] as const) {
+			it(`retains a failed ${target} stop for the exact close retry`, async () => {
+				session = await TestSession.connected(1);
+				const db = await session.peers[0].open(new EventStore());
+				const sharedLog = db.log as any;
+				const index =
+					target === "entry coordinates index"
+						? sharedLog.entryCoordinatesIndex
+						: sharedLog.replicationIndex;
+				const originalStop = index.stop.bind(index);
+				const cleanupError = new Error(`injected ${target} close failure`);
+				let attempts = 0;
+				index.stop = async () => {
+					attempts += 1;
+					if (attempts === 1) throw cleanupError;
+					await originalStop();
+				};
+
+				await expect(db.close()).to.be.rejectedWith(cleanupError.message);
+				expect(
+					target === "entry coordinates index"
+						? sharedLog._entryCoordinatesIndex
+						: sharedLog._replicationRangeIndex,
+				).to.equal(index);
+
+				await db.close();
+				expect(attempts).to.equal(2);
+			});
+		}
+
 		it("closing does not affect other instances", async () => {
 			session = await TestSession.connected(1);
 			const db = await session.peers[0].open(new EventStore());
@@ -41,7 +75,154 @@ describe("lifecycle", () => {
 			expect((await db2.iterator({ limit: -1 })).collect()).to.have.length(1);
 		});
 	});
+
+	for (const operation of ["close", "drop"] as const) {
+		it(`${operation} rejects an invalid owner before SharedLog teardown`, async () => {
+			session = await TestSession.connected(1);
+			const db = await session.peers[0].open(new EventStore<string, any>());
+			const invalidOwner = new EventStore<string, any>();
+			const sharedLog = db.log;
+			const lowerLog = sharedLog.log;
+			const entryCoordinatesIndex = sharedLog.entryCoordinatesIndex;
+			const replicationIndex = sharedLog.replicationIndex;
+			const subscriptions = (sharedLog.node.services.pubsub as any)[
+				"subscriptions"
+			];
+			const subscriptionCounter = subscriptions.get(
+				sharedLog.rpc.topic,
+			)?.counter;
+			const replicationSegments = await sharedLog.getMyReplicationSegments();
+			const { entry: before } = await db.add("before");
+			const sandbox = sinon.createSandbox();
+			const lowerClose = sandbox.spy(lowerLog, "close");
+			const lowerDrop = sandbox.spy(lowerLog, "drop");
+			const entryStop = sandbox.spy(entryCoordinatesIndex, "stop");
+			const entryDrop = sandbox.spy(entryCoordinatesIndex, "drop");
+			const replicationStop = sandbox.spy(replicationIndex, "stop");
+			const replicationDrop = sandbox.spy(replicationIndex, "drop");
+
+			try {
+				await expect(sharedLog[operation](invalidOwner)).to.be.rejectedWith(
+					TerminalOperationNotStartedError,
+					"Could not find from in parents",
+				);
+				expect(sharedLog.closed).to.be.false;
+				expect(sharedLog.parents).to.deep.equal([db]);
+				expect(lowerClose.called).to.be.false;
+				expect(lowerDrop.called).to.be.false;
+				expect(entryStop.called).to.be.false;
+				expect(entryDrop.called).to.be.false;
+				expect(replicationStop.called).to.be.false;
+				expect(replicationDrop.called).to.be.false;
+				expect(sharedLog.entryCoordinatesIndex).to.equal(entryCoordinatesIndex);
+				expect(sharedLog.replicationIndex).to.equal(replicationIndex);
+				expect(await sharedLog.isReplicating()).to.be.true;
+				expect(await sharedLog.getMyReplicationSegments()).to.deep.equal(
+					replicationSegments,
+				);
+				expect(subscriptions.get(sharedLog.rpc.topic)?.counter).to.equal(
+					subscriptionCounter,
+				);
+
+				const { entry: after } = await db.add("after");
+				expect(await lowerLog.has(before.hash)).to.be.true;
+				expect(await lowerLog.has(after.hash)).to.be.true;
+				expect((await db.iterator({ limit: -1 })).collect()).to.have.length(2);
+				expect(await entryCoordinatesIndex.count()).to.equal(1);
+				expect(await replicationIndex.count()).to.equal(1);
+			} finally {
+				sandbox.restore();
+			}
+		});
+
+		it(`${operation} releases one owner reference without changing live SharedLog state`, async () => {
+			session = await TestSession.connected(1);
+			const db = await session.peers[0].open(new EventStore<string, any>());
+			const sharedLog = db.log;
+			await session.peers[0].open(sharedLog, {
+				parent: db as any,
+				existing: "reuse",
+			});
+			expect(sharedLog.parents).to.deep.equal([db, db]);
+			expect(db.children.filter((child) => child === sharedLog)).to.have.length(
+				2,
+			);
+
+			const lowerLog = sharedLog.log;
+			const entryCoordinatesIndex = sharedLog.entryCoordinatesIndex;
+			const replicationIndex = sharedLog.replicationIndex;
+			const subscriptions = (sharedLog.node.services.pubsub as any)[
+				"subscriptions"
+			];
+			const subscriptionCounter = subscriptions.get(
+				sharedLog.rpc.topic,
+			)?.counter;
+			const replicationSegments = await sharedLog.getMyReplicationSegments();
+			const { entry: before } = await db.add("before");
+			const sandbox = sinon.createSandbox();
+			const lowerClose = sandbox.spy(lowerLog, "close");
+			const lowerDrop = sandbox.spy(lowerLog, "drop");
+			const entryStop = sandbox.spy(entryCoordinatesIndex, "stop");
+			const entryDrop = sandbox.spy(entryCoordinatesIndex, "drop");
+			const replicationStop = sandbox.spy(replicationIndex, "stop");
+			const replicationDrop = sandbox.spy(replicationIndex, "drop");
+
+			try {
+				expect(await sharedLog[operation](db)).to.be.false;
+				expect(sharedLog.closed).to.be.false;
+				expect(sharedLog.parents).to.deep.equal([db]);
+				expect(
+					db.children.filter((child) => child === sharedLog),
+				).to.have.length(1);
+				expect(lowerClose.called).to.be.false;
+				expect(lowerDrop.called).to.be.false;
+				expect(entryStop.called).to.be.false;
+				expect(entryDrop.called).to.be.false;
+				expect(replicationStop.called).to.be.false;
+				expect(replicationDrop.called).to.be.false;
+				expect(sharedLog.entryCoordinatesIndex).to.equal(entryCoordinatesIndex);
+				expect(sharedLog.replicationIndex).to.equal(replicationIndex);
+				expect(await sharedLog.isReplicating()).to.be.true;
+				expect(await sharedLog.getMyReplicationSegments()).to.deep.equal(
+					replicationSegments,
+				);
+				expect(subscriptions.get(sharedLog.rpc.topic)?.counter).to.equal(
+					subscriptionCounter,
+				);
+
+				const { entry: after } = await db.add("after");
+				expect(await lowerLog.has(before.hash)).to.be.true;
+				expect(await lowerLog.has(after.hash)).to.be.true;
+				expect((await db.iterator({ limit: -1 })).collect()).to.have.length(2);
+				expect(await entryCoordinatesIndex.count()).to.equal(1);
+				expect(await replicationIndex.count()).to.equal(1);
+			} finally {
+				sandbox.restore();
+			}
+		});
+	}
+
 	describe("drop", () => {
+		it("rejects a fresh drop after clean close without erasing the lower log", async () => {
+			session = await TestSession.connected(1);
+			const db = await session.peers[0].open(new EventStore());
+			const { entry } = await db.add("keep-after-close");
+			const sharedLog = db.log;
+			const lowerDrop = sinon.spy(sharedLog.log, "drop");
+			try {
+				await sharedLog.close(db);
+				expect(await sharedLog.log.has(entry.hash)).to.be.true;
+
+				await expect(sharedLog.drop()).to.be.rejectedWith(
+					"Program is closed, can not drop",
+				);
+				expect(lowerDrop.called).to.be.false;
+				expect(await sharedLog.log.has(entry.hash)).to.be.true;
+			} finally {
+				lowerDrop.restore();
+			}
+		});
+
 		it("will drop all data", async () => {
 			session = await TestSession.connected(1);
 			const store = new EventStore();
@@ -144,9 +325,10 @@ describe("lifecycle", () => {
 			});
 
 			await waitForResolved(async () => {
-				const subscribers = await session.peers[0].services.pubsub.getSubscribers(
-					db1.log.rpc.topic,
-				);
+				const subscribers =
+					await session.peers[0].services.pubsub.getSubscribers(
+						db1.log.rpc.topic,
+					);
 				expect((subscribers || []).map((x) => x.hashcode())).to.include(
 					session.peers[1].identity.publicKey.hashcode(),
 				);
@@ -203,33 +385,33 @@ describe("lifecycle", () => {
 			await db2.close();
 			// Closing a remote log propagates through unsubscribe + replication updates.
 			// Under full-suite load this can take longer than the default wait timeout.
-				await waitForResolved(
-					async () => expect((await db3.log.getReplicators()).size).to.equal(1),
-					{ timeout: 30e3, delayInterval: 100 },
-				);
-				// Close/unsubscribe ordering can vary under full-suite load. Ensure we
-				// validate the cleanup behavior deterministically for the departed peers.
-				sync.onPeerDisconnected(db1Hash);
-				sync.onPeerDisconnected(db2Hash);
+			await waitForResolved(
+				async () => expect((await db3.log.getReplicators()).size).to.equal(1),
+				{ timeout: 30e3, delayInterval: 100 },
+			);
+			// Close/unsubscribe ordering can vary under full-suite load. Ensure we
+			// validate the cleanup behavior deterministically for the departed peers.
+			sync.onPeerDisconnected(db1Hash);
+			sync.onPeerDisconnected(db2Hash);
 
-				// Under suite-wide load there can be unrelated in-flight sync state from
-				// concurrent background exchanges. Assert that the departed peers are cleared.
-				await waitForResolved(
-					() =>
-						expect(
-							(db3.log.syncronizer as SimpleSyncronizer<any>).syncInFlight.has(
-								db1Hash,
-							),
-						).to.be.false,
-				);
-				await waitForResolved(
-					() =>
-						expect(
-							(db3.log.syncronizer as SimpleSyncronizer<any>).syncInFlight.has(
-								db2Hash,
-							),
-						).to.be.false,
-				);
+			// Under suite-wide load there can be unrelated in-flight sync state from
+			// concurrent background exchanges. Assert that the departed peers are cleared.
+			await waitForResolved(
+				() =>
+					expect(
+						(db3.log.syncronizer as SimpleSyncronizer<any>).syncInFlight.has(
+							db1Hash,
+						),
+					).to.be.false,
+			);
+			await waitForResolved(
+				() =>
+					expect(
+						(db3.log.syncronizer as SimpleSyncronizer<any>).syncInFlight.has(
+							db2Hash,
+						),
+					).to.be.false,
+			);
 			await waitForResolved(
 				() =>
 					expect(

--- a/packages/programs/data/string/src/string-index.ts
+++ b/packages/programs/data/string/src/string-index.ts
@@ -37,10 +37,13 @@ export class StringIndex extends Program {
 		this._log = store;
 	}
 
-	close(parent: any) {
-		this._string = "";
-		this._log = undefined!;
-		return super.close(parent);
+	async close(parent: any): Promise<boolean> {
+		const closed = await super.close(parent);
+		if (closed) {
+			this._string = "";
+			this._log = undefined!;
+		}
+		return closed;
 	}
 
 	async updateIndex(_change: Change<StringOperation>) {

--- a/packages/programs/data/string/test/index.spec.ts
+++ b/packages/programs/data/string/test/index.spec.ts
@@ -366,4 +366,49 @@ describe("load", () => {
 		await session.peers[0].open(store);
 		expect(await store.getValue()).to.deep.equal("hello world");
 	});
+
+	it("keeps the live index usable for a non-terminal owner release", async () => {
+		const hello = "hello";
+		await store.add(hello, new Range({ offset: 0, length: hello.length }));
+		const log = store._index._log;
+		await session.peers[0].open(store._index, {
+			parent: store as any,
+			existing: "reuse",
+		});
+		expect(store._index.parents).to.deep.equal([store, store]);
+
+		expect(await store._index.close(store)).to.be.false;
+		expect(store._index.closed).to.be.false;
+		expect(store._index.string).to.equal(hello);
+		expect(store._index._log).to.equal(log);
+
+		const world = " world";
+		await store.add(
+			world,
+			new Range({ offset: hello.length, length: world.length }),
+		);
+		expect(await store.getValue()).to.equal(hello + world);
+	});
+
+	it("keeps the live index unchanged for an invalid owner", async () => {
+		const hello = "hello";
+		await store.add(hello, new Range({ offset: 0, length: hello.length }));
+		const log = store._index._log;
+		const wrongOwner = new DString({});
+
+		await expect(store._index.close(wrongOwner)).to.be.rejectedWith(
+			"Could not find from in parents",
+		);
+		expect(store._index.closed).to.be.false;
+		expect(store._index.parents).to.deep.equal([store]);
+		expect(store._index.string).to.equal(hello);
+		expect(store._index._log).to.equal(log);
+
+		const world = " world";
+		await store.add(
+			world,
+			new Range({ offset: hello.length, length: world.length }),
+		);
+		expect(await store.getValue()).to.equal(hello + world);
+	});
 });

--- a/packages/programs/program/program/src/handler.ts
+++ b/packages/programs/program/program/src/handler.ts
@@ -1475,9 +1475,10 @@ export class Handler<T extends Manageable<any>> {
 			// A program explicitly opened with a parent is a weak/addressable
 			// reference. Structural beforeOpen() may already have made the exact
 			// instance live without persisting its standalone block.
-			await existing.save(this.properties.client.services.blocks, {
-				skipOnAddress: false,
-			});
+			const blocks = this.properties.client.services.blocks;
+			if (!(await blocks.has(address))) {
+				await existing.save(blocks, { skipOnAddress: false });
+			}
 		} catch (error) {
 			const parentIndex = existing.parents?.lastIndexOf(parent) ?? -1;
 			if (parentIndex !== -1) existing.parents.splice(parentIndex, 1);

--- a/packages/programs/program/program/src/handler.ts
+++ b/packages/programs/program/program/src/handler.ts
@@ -73,6 +73,7 @@ type OuterTerminalCall = {
 	from?: Manageable<any>;
 	terminal: boolean;
 	claimedOwnerReference: boolean;
+	invokedWrapper: (...args: any[]) => Promise<boolean>;
 	ownerReferencesBeforeInvoke?: number;
 	ownerReferencesAfterInvoke?: number;
 	promise: Promise<boolean>;
@@ -93,12 +94,18 @@ type TerminalOperationState<T extends Manageable<any>> = {
 	dropWrapper?: (...args: any[]) => Promise<boolean>;
 	closeOperation?: (...args: any[]) => Promise<boolean>;
 	dropOperation?: (...args: any[]) => Promise<boolean>;
+	synchronouslyInvokingWrapper?: {
+		type: TerminalOperation;
+		wrapper: (...args: any[]) => Promise<boolean>;
+		args: any[];
+	};
 	cleanupLease?: object;
 };
 
 type CleanupResidual = {
 	program: Manageable<any>;
 	failures: FailedTerminalCall[];
+	terminalState?: TerminalOperationState<any>;
 	cleanupLease?: object;
 	activeReservations: number;
 };
@@ -432,12 +439,19 @@ export class Handler<T extends Manageable<any>> {
 			state.terminalCompleted = false;
 		}
 		this._terminalOperationsByAddress.set(address, state);
+		this.refreshTerminalOperationWrappers(state);
+		return { state, newLifecycle };
+	}
 
+	private refreshTerminalOperationWrappers(
+		state: TerminalOperationState<T>,
+	): void {
+		const program = state.program;
 		if (program.close !== state.closeWrapper) {
 			const close = program.close;
 			state.closeOperation = close;
 			const closeWrapper = (...args: any[]) =>
-				this.runTerminalOperation(state!, "close", close, args);
+				this.runTerminalOperation(state, "close", close, args, closeWrapper);
 			state.closeWrapper = closeWrapper;
 			program.close = closeWrapper;
 		}
@@ -452,11 +466,10 @@ export class Handler<T extends Manageable<any>> {
 			const drop = droppable.drop;
 			state.dropOperation = drop;
 			const dropWrapper = (...args: any[]) =>
-				this.runTerminalOperation(state!, "drop", drop, args);
+				this.runTerminalOperation(state, "drop", drop, args, dropWrapper);
 			state.dropWrapper = dropWrapper;
 			droppable.drop = dropWrapper;
 		}
-		return { state, newLifecycle };
 	}
 
 	private runTerminalOperation(
@@ -464,8 +477,41 @@ export class Handler<T extends Manageable<any>> {
 		type: TerminalOperation,
 		operation: (...args: any[]) => Promise<boolean>,
 		args: any[],
+		invokedWrapper: (...args: any[]) => Promise<boolean>,
 	): Promise<boolean> {
 		const from = args[0] as Manageable<any> | undefined;
+		const synchronousInvocation = state.synchronouslyInvokingWrapper;
+		if (synchronousInvocation) {
+			if (type !== synchronousInvocation.type) {
+				return Promise.reject(
+					new TerminalOperationNotStartedError(
+						"Program terminal methods cannot synchronously invoke another terminal operation",
+					),
+				);
+			}
+			if (!this.sameTerminalArgs(args, synchronousInvocation.args)) {
+				return Promise.reject(
+					new TerminalOperationNotStartedError(
+						"A captured terminal wrapper cannot change the active operation owner",
+					),
+				);
+			}
+			if (invokedWrapper !== synchronousInvocation.wrapper) {
+				// A post-open replacement may delegate to the Handler wrapper it
+				// captured before being re-wrapped. Peel that stale wrapper back to its
+				// raw operation; the current outer wrapper still monitors the full promise.
+				try {
+					return Promise.resolve(operation.apply(state.program, args));
+				} catch (error) {
+					return Promise.reject(error);
+				}
+			}
+			return Promise.reject(
+				new TerminalOperationNotStartedError(
+					"Program terminal methods cannot wait for their own active operation",
+				),
+			);
+		}
 		if (
 			state.program.terminalLifecycleCallbackRunning ||
 			(this._terminalLifecycleCallbacks > 0 && state.activeCalls > 0)
@@ -482,6 +528,26 @@ export class Handler<T extends Manageable<any>> {
 			state.program.closed ||
 			parentIndex === -1 ||
 			(state.program.parents?.length ?? 0) === 1;
+		const currentWrapper =
+			type === "close" ? state.closeWrapper : state.dropWrapper;
+		if (
+			currentWrapper &&
+			invokedWrapper !== currentWrapper &&
+			[...state.outerCalls].some(
+				(call) => call.type === type && call.invokedWrapper === currentWrapper,
+			)
+		) {
+			// Once replacement code has yielded there is no portable async-call
+			// context that can distinguish its captured stale wrapper from an
+			// unrelated external stale call. Never return the active outer promise to
+			// code that may itself be awaiting this call: reject before base progress
+			// instead of forming a self-cycle that wedges Handler.stop().
+			return Promise.reject(
+				new TerminalOperationNotStartedError(
+					"A stale terminal wrapper cannot join its active replacement after yielding",
+				),
+			);
+		}
 		const matching = [...state.outerCalls].find(
 			(call) =>
 				call.terminal &&
@@ -544,6 +610,7 @@ export class Handler<T extends Manageable<any>> {
 			from,
 			terminal,
 			claimedOwnerReference: ownerReferences > 0,
+			invokedWrapper,
 			promise: tracked,
 		};
 		const hasPredecessor = state.outerCalls.size > 0;
@@ -587,11 +654,20 @@ export class Handler<T extends Manageable<any>> {
 						state.program.parents?.filter((parent) => parent === from).length ??
 						0;
 					let operationResult: Promise<boolean>;
+					const previousSynchronouslyInvokingWrapper =
+						state.synchronouslyInvokingWrapper;
+					state.synchronouslyInvokingWrapper = {
+						type,
+						wrapper: invokedWrapper,
+						args,
+					};
 					try {
 						operationResult = this.invokeLifecycleMethod(() =>
 							operation.apply(state.program, args),
 						);
 					} finally {
+						state.synchronouslyInvokingWrapper =
+							previousSynchronouslyInvokingWrapper;
 						outerCall.ownerReferencesAfterInvoke =
 							state.program.parents?.filter((parent) => parent === from)
 								.length ?? 0;
@@ -630,6 +706,7 @@ export class Handler<T extends Manageable<any>> {
 					state.failed = false;
 					state.failedOperation = undefined;
 					state.failedCall = undefined;
+					this.releaseRetainedTerminalIdentity(state);
 				} else {
 					const commit = this.terminalCommit(
 						state.program,
@@ -707,7 +784,16 @@ export class Handler<T extends Manageable<any>> {
 					releasedParentReferences,
 				};
 				state.terminalCompleted = false;
-				this.items.set(state.address, state.program);
+				const monitored = this.items.get(state.address);
+				if (!monitored || monitored === state.program) {
+					this.items.set(state.address, state.program);
+				} else {
+					// `items` is address-keyed, but embedded opening graphs may contain a
+					// distinct instance with the same address as a monitored root. Never
+					// orphan that root by replacing it with this failed cleanup identity.
+					const residual = this.reserveCleanupResidual(state.program);
+					residual.terminalState = state;
+				}
 				this._terminalOperationsByAddress.set(state.address, state);
 				throw error;
 			}
@@ -834,7 +920,11 @@ export class Handler<T extends Manageable<any>> {
 		if (residual.activeReservations < 0) {
 			throw new Error("Cleanup residual reservation underflow");
 		}
-		if (residual.activeReservations === 0 && residual.failures.length === 0) {
+		if (
+			residual.activeReservations === 0 &&
+			residual.failures.length === 0 &&
+			residual.terminalState == null
+		) {
 			this.releaseCleanupResidual(residual);
 		}
 	}
@@ -845,11 +935,29 @@ export class Handler<T extends Manageable<any>> {
 				"Cleanup residual cannot be released while rollback cleanup is active",
 			);
 		}
+		if (residual.terminalState != null) {
+			throw new Error(
+				"Cleanup residual cannot be released while terminal identity is retained",
+			);
+		}
 		if (residual.cleanupLease) {
 			residual.program[TERMINAL_OUTER_CLEANUP_RELEASE]?.(residual.cleanupLease);
 			residual.cleanupLease = undefined;
 		}
 		this._cleanupResiduals.delete(residual.program);
+	}
+
+	private releaseRetainedTerminalIdentity(
+		state: TerminalOperationState<T>,
+	): void {
+		const residual = this._cleanupResiduals.get(state.program);
+		if (residual?.terminalState !== state) {
+			return;
+		}
+		residual.terminalState = undefined;
+		if (residual.activeReservations === 0 && residual.failures.length === 0) {
+			this.releaseCleanupResidual(residual);
+		}
 	}
 
 	private async retryCleanupResidual(
@@ -1143,6 +1251,12 @@ export class Handler<T extends Manageable<any>> {
 		await this.waitForTerminalOperations(program);
 		let terminalState = this._terminalOperationsByProgram.get(program);
 		while (!program.closed || terminalState?.failed) {
+			if (terminalState) {
+				// Applications/tests may replace a failed wrapped method before stop.
+				// Re-wrap any replacement in the existing identity-specific state before
+				// invoking it, so both a fresh failure and exact recovery remain monitored.
+				this.refreshTerminalOperationWrappers(terminalState);
+			}
 			const wasRecovering = terminalState?.failed === true;
 			const failedCall = terminalState?.failedCall;
 			const ownersBefore = [...(program.parents ?? [])];
@@ -1174,18 +1288,22 @@ export class Handler<T extends Manageable<any>> {
 			await this.waitForTerminalOperations(program);
 			terminalState = this._terminalOperationsByProgram.get(program);
 			if (
-				closed &&
-				program.closed &&
 				terminalState?.failed &&
-				terminalState.failedOperation === operationType
+				terminalState.failedCall === failedCall &&
+				terminalState.failedOperation === operationType &&
+				((closed && program.closed) ||
+					(failedCall?.commit != null && closed === failedCall.commit.result))
 			) {
 				// This also supports a test/application replacing the wrapped method
 				// after open: closeCompletely awaited the full replacement call, so it
-				// is safe to mark the previously retained cleanup as recovered.
+				// is safe to mark the previously retained cleanup as recovered. A
+				// committed non-terminal release must reproduce its recorded `false`;
+				// the fresh loop below then drains the owners that remain.
 				terminalState.failed = false;
 				terminalState.failedOperation = undefined;
 				terminalState.failedCall = undefined;
-				terminalState.terminalCompleted = true;
+				terminalState.terminalCompleted = closed && program.closed;
+				this.releaseRetainedTerminalIdentity(terminalState);
 				if (terminalState.cleanupLease) {
 					program[TERMINAL_OUTER_CLEANUP_RELEASE]?.(terminalState.cleanupLease);
 					terminalState.cleanupLease = undefined;
@@ -1287,6 +1405,28 @@ export class Handler<T extends Manageable<any>> {
 		this._openingReservations.clear();
 		this._openingReservationsByAddress.clear();
 
+		// A failed child can have its wrapped terminal method replaced before stop.
+		// Refresh every retained failed identity before closing any parent root, so
+		// parent traversal consumes the recorded commit through the new wrapper
+		// instead of calling the replacement outside Handler monitoring.
+		const pendingTerminalGraphs: Manageable<any>[] = [
+			...this.items.values(),
+			...this._cleanupResiduals.keys(),
+		];
+		const visitedTerminalGraphs = new Set<Manageable<any>>();
+		while (pendingTerminalGraphs.length > 0) {
+			const candidate = pendingTerminalGraphs.pop()!;
+			if (visitedTerminalGraphs.has(candidate)) continue;
+			visitedTerminalGraphs.add(candidate);
+			const terminalState = this._terminalOperationsByProgram.get(candidate);
+			if (terminalState?.failed) {
+				this.refreshTerminalOperationWrappers(terminalState);
+			}
+			for (const child of candidate.children ?? []) {
+				pendingTerminalGraphs.push(child);
+			}
+		}
+
 		// A close can legitimately return false when it only releases one of several
 		// owners. Drain every ownership reference so stop cannot discard a still-live
 		// program from Handler state.
@@ -1329,6 +1469,7 @@ export class Handler<T extends Manageable<any>> {
 			if (
 				program.closed &&
 				residual.failures.length === 0 &&
+				residual.terminalState == null &&
 				!terminalState?.failed &&
 				(terminalState?.activeCalls ?? 0) === 0
 			) {

--- a/packages/programs/program/program/src/handler.ts
+++ b/packages/programs/program/program/src/handler.ts
@@ -7,7 +7,119 @@ import type { Address } from "./address.js";
 export const logger = loggerFn("peerbit:program:handler");
 
 type ProgramMergeStrategy = "replace" | "reject" | "reuse";
+type HandlerLifecycleState = "running" | "stopping" | "stopped" | "failed";
+export type TerminalOperation = "close" | "drop";
+export type TerminalBaseCommit = {
+	epoch: number;
+	version: number;
+	type: TerminalOperation;
+	from?: Manageable<any>;
+	result: boolean;
+	releasedParentReferences: number;
+};
+export const TERMINAL_BASE_CHECKPOINT = Symbol.for(
+	"@peerbit/program/terminal-base-checkpoint",
+);
+export const TERMINAL_BASE_COMMIT = Symbol.for(
+	"@peerbit/program/terminal-base-commit",
+);
+export const TERMINAL_BASE_RETRY = Symbol.for(
+	"@peerbit/program/terminal-base-retry",
+);
+export const TERMINAL_OUTER_CLEANUP_RETAIN = Symbol.for(
+	"@peerbit/program/terminal-outer-cleanup-retain",
+);
+export const TERMINAL_OUTER_CLEANUP_RELEASE = Symbol.for(
+	"@peerbit/program/terminal-outer-cleanup-release",
+);
+const TERMINAL_OPERATION_NOT_STARTED = Symbol.for(
+	"@peerbit/program/terminal-operation-not-started-error",
+);
+
+/**
+ * A terminal-operation precondition rejected the call before any lifecycle or
+ * resource mutation began. Handler leaves the program retryable instead of
+ * retaining this as partially completed cleanup.
+ */
+export class TerminalOperationNotStartedError extends Error {
+	readonly [TERMINAL_OPERATION_NOT_STARTED] = true;
+
+	constructor(message: string) {
+		super(message);
+		this.name = "TerminalOperationNotStartedError";
+	}
+
+	static [Symbol.hasInstance](instance: unknown): boolean {
+		return Boolean(
+			instance &&
+				typeof instance === "object" &&
+				(instance as Record<symbol, unknown>)[
+					TERMINAL_OPERATION_NOT_STARTED
+				] === true,
+		);
+	}
+}
 export type ExtractArgs<T> = T extends CanOpen<infer Args> ? Args : never;
+
+type FailedTerminalCall = {
+	type: TerminalOperation;
+	args: any[];
+	commit?: TerminalBaseCommit;
+	releasedParentReferences?: number;
+};
+
+type OuterTerminalCall = {
+	type: TerminalOperation;
+	from?: Manageable<any>;
+	terminal: boolean;
+	claimedOwnerReference: boolean;
+	ownerReferencesBeforeInvoke?: number;
+	ownerReferencesAfterInvoke?: number;
+	promise: Promise<boolean>;
+};
+
+type TerminalOperationState<T extends Manageable<any>> = {
+	program: T;
+	address: Address;
+	activeCalls: number;
+	pending: Set<Promise<boolean>>;
+	failed: boolean;
+	failedOperation?: TerminalOperation;
+	failedCall?: FailedTerminalCall;
+	terminalCompleted: boolean;
+	outerTail: Promise<void>;
+	outerCalls: Set<OuterTerminalCall>;
+	closeWrapper?: (...args: any[]) => Promise<boolean>;
+	dropWrapper?: (...args: any[]) => Promise<boolean>;
+	closeOperation?: (...args: any[]) => Promise<boolean>;
+	dropOperation?: (...args: any[]) => Promise<boolean>;
+	cleanupLease?: object;
+};
+
+type CleanupResidual = {
+	program: Manageable<any>;
+	failures: FailedTerminalCall[];
+	cleanupLease?: object;
+	activeReservations: number;
+};
+
+type OpeningReservationGroup = {
+	participantReferences: Map<Manageable<any>, number>;
+	reservations: Set<OpeningReservation<any>>;
+};
+
+type OpeningReservation<T extends Manageable<any>> = {
+	promise: Promise<T>;
+	phase: "opening" | "rollback";
+	observedReservations: Set<OpeningReservation<T>>;
+	adoptedParents: Set<Manageable<any>>;
+	contributedParticipants: Set<Manageable<any>>;
+	wakeWaiters: Set<() => void>;
+	group: OpeningReservationGroup;
+	programsByAddress: Map<string, Manageable<any>>;
+	programs: Set<Manageable<any>>;
+	provisionalTerminalStates: Set<TerminalOperationState<T>>;
+};
 
 export type EventOptions = {
 	onBeforeOpen?: (program: Manageable<any>) => Promise<void> | void;
@@ -36,7 +148,7 @@ export interface Saveable {
 			format?: string;
 			timeout?: number;
 			skipOnAddress?: boolean;
-			condition?: (address: string) => boolean | Promise<boolean>;
+			save?: (address: string) => boolean | Promise<boolean>;
 		},
 	): Promise<Address>;
 
@@ -57,6 +169,27 @@ export type Manageable<Args> = Closeable &
 	CanEmit & {
 		children: Manageable<any>[];
 		parents: (Manageable<any> | undefined)[];
+		/**
+		 * Programs with terminal work that must happen before `Program.end()` can
+		 * fence parent reuse while that work is in progress.
+		 */
+		readonly acceptsParentAttachments?: boolean;
+		/** Base terminal tail/deletion that must be resumed with this operation. */
+		readonly pendingTerminalOperation?: TerminalOperation;
+		/** A lifecycle callback must not recursively wait for Handler.stop(). */
+		readonly terminalLifecycleCallbackRunning?: boolean;
+		[TERMINAL_BASE_CHECKPOINT]?: () => number;
+		[TERMINAL_BASE_COMMIT]?: (
+			afterVersion: number,
+			type: TerminalOperation,
+			from?: Manageable<any>,
+		) => TerminalBaseCommit | undefined;
+		[TERMINAL_BASE_RETRY]?: (
+			commit: TerminalBaseCommit,
+			operation: () => Promise<boolean>,
+		) => Promise<boolean>;
+		[TERMINAL_OUTER_CLEANUP_RETAIN]?: () => object;
+		[TERMINAL_OUTER_CLEANUP_RELEASE]?: (lease: object) => void;
 	} & WithNode;
 
 export type ProgramInitializationOptions<Args, T extends Manageable<Args>> = {
@@ -66,7 +199,14 @@ export type ProgramInitializationOptions<Args, T extends Manageable<Args>> = {
 	WithParent<T> &
 	EventOptions;
 
+const assertCanAttachParent = (child: Manageable<any>) => {
+	if (child.acceptsParentAttachments === false) {
+		throw new Error("Program is terminating and cannot accept another parent");
+	}
+};
+
 export const addParent = (child: Manageable<any>, parent?: Manageable<any>) => {
+	assertCanAttachParent(child);
 	if (child.parents && child.parents.includes(parent) && parent == null) {
 		return; // prevent root parents to exist multiple times. This will allow use to close a program onces even if it is reused multiple times
 	}
@@ -77,10 +217,40 @@ export const addParent = (child: Manageable<any>, parent?: Manageable<any>) => {
 	}
 };
 
+/**
+ * Owns lifecycle state for one client. Handler instances do not share address
+ * reservations, so a client must use a single Handler for a program graph.
+ */
 export class Handler<T extends Manageable<any>> {
 	items: Map<string, T>;
 	private _openQueue: Map<string, PQueue>;
 	private _openingPromises: Map<string, Promise<T>>;
+	private _openingReservations: Set<OpeningReservation<T>>;
+	private _openingReservationsByPromise: WeakMap<
+		Promise<T>,
+		OpeningReservation<T>
+	>;
+	private _openingReservationsByAddress: Map<
+		string,
+		Set<OpeningReservation<T>>
+	>;
+	private _parentAttachmentReservations: Map<Manageable<any>, number>;
+	private _openAdmissions: Set<Promise<void>>;
+	private _openLifecycleCallbacks: number;
+	private _terminalLifecycleCallbacks: number;
+	private _lifecycleMethodInvocations: number;
+	private _acceptingOpens: boolean;
+	private _stopPromise?: Promise<void>;
+	private _lifecycleState: HandlerLifecycleState;
+	private _failedInitializations: Map<string, T>;
+	private _cleanupResiduals: Map<Manageable<any>, CleanupResidual>;
+	private _terminalOperationsByProgram: WeakMap<
+		Manageable<any>,
+		TerminalOperationState<T>
+	>;
+	private _terminalOperationsByAddress: Map<Address, TerminalOperationState<T>>;
+	private _initializationRollbacks: WeakSet<Manageable<any>>;
+	private _replacementClosures: WeakSet<Manageable<any>>;
 
 	constructor(
 		readonly properties: {
@@ -92,19 +262,1018 @@ export class Handler<T extends Manageable<any>> {
 			) => Promise<T | undefined>;
 			shouldMonitor: (thing: any) => boolean;
 			identity: Identity;
+			getDependencies?: (program: T) => Manageable<any>[];
 		},
 	) {
 		this._openQueue = new Map();
 		this._openingPromises = new Map();
+		this._openingReservations = new Set();
+		this._openingReservationsByPromise = new WeakMap();
+		this._openingReservationsByAddress = new Map();
+		this._parentAttachmentReservations = new Map();
+		this._openAdmissions = new Set();
+		this._openLifecycleCallbacks = 0;
+		this._terminalLifecycleCallbacks = 0;
+		this._lifecycleMethodInvocations = 0;
+		this._acceptingOpens = true;
+		this._lifecycleState = "running";
+		this._failedInitializations = new Map();
+		this._cleanupResiduals = new Map();
+		this._terminalOperationsByProgram = new WeakMap();
+		this._terminalOperationsByAddress = new Map();
+		this._initializationRollbacks = new WeakSet();
+		this._replacementClosures = new WeakSet();
 		this.items = new Map();
 	}
 
-	async stop() {
+	/**
+	 * Re-open admissions after the owning client has finished starting all of the
+	 * services programs depend on. This is an internal client lifecycle hook, not
+	 * a substitute for starting the client itself.
+	 *
+	 * This is called by the owning client after its services have started.
+	 */
+	start(): void {
+		if (this._lifecycleState === "running") {
+			return;
+		}
+		this.assertCanStart();
+		this._lifecycleState = "running";
+		this._acceptingOpens = true;
+	}
+
+	/** Validate restart eligibility without opening admissions. */
+	assertCanStart(): void {
+		if (this._lifecycleState === "running") {
+			return;
+		}
+		if (
+			this._lifecycleState !== "stopped" ||
+			this._stopPromise ||
+			this.items.size > 0 ||
+			this._openingPromises.size > 0 ||
+			this._openingReservations.size > 0 ||
+			this._openingReservationsByAddress.size > 0 ||
+			this._parentAttachmentReservations.size > 0 ||
+			this._openAdmissions.size > 0 ||
+			this._failedInitializations.size > 0 ||
+			this._cleanupResiduals.size > 0 ||
+			this._terminalOperationsByAddress.size > 0
+		) {
+			throw new Error(
+				"Program handler cannot start before a successful stop has fully drained",
+			);
+		}
+	}
+
+	/**
+	 * Stop the handler after admitted lifecycle work drains.
+	 *
+	 * Lifecycle overrides and callbacks must not await their own handler/client
+	 * stop. Immediate reentry is rejected. After user code has yielded, portable
+	 * JavaScript runtimes provide no reliable async-call provenance with which to
+	 * distinguish self-reentry from an unrelated external stop; schedule stop from
+	 * the lifecycle owner instead. A conservatively rejected external stop remains
+	 * retryable after the active callback finishes.
+	 */
+	stop(): Promise<void> {
+		if (
+			this._openLifecycleCallbacks > 0 ||
+			this._terminalLifecycleCallbacks > 0 ||
+			this._lifecycleMethodInvocations > 0 ||
+			[...this.items.values()].some(
+				(program) => program.terminalLifecycleCallbackRunning === true,
+			)
+		) {
+			return Promise.reject(
+				new TerminalOperationNotStartedError(
+					"Program lifecycle callbacks cannot wait for their own handler to stop",
+				),
+			);
+		}
+		if (this._stopPromise) {
+			return this._stopPromise;
+		}
+		if (this._lifecycleState === "stopped") {
+			return Promise.resolve();
+		}
+		// Close admissions synchronously. Every open that passed this fence has a
+		// completion promise in `_openAdmissions`, so stop has a stable set to drain.
+		this._acceptingOpens = false;
+		this._lifecycleState = "stopping";
+		this._stopPromise = this.stopOnce().then(
+			() => {
+				// The client still has storage, index, and transport teardown to perform.
+				// Only its completed start() transition may re-open admissions.
+				this._lifecycleState = "stopped";
+				this._stopPromise = undefined;
+			},
+			(error) => {
+				// Keep admissions closed after a partial stop. Clearing only the promise
+				// makes stop() retryable without exposing the live residual items to opens.
+				this._lifecycleState = "failed";
+				this._stopPromise = undefined;
+				throw error;
+			},
+		);
+		return this._stopPromise;
+	}
+
+	/**
+	 * Async methods execute synchronously until their first await. Fence that
+	 * invocation window so a lifecycle override cannot make stop wait on the very
+	 * operation that is awaiting stop. Awaited user callbacks have their own wider
+	 * callback fences below.
+	 */
+	private invokeLifecycleMethod<R>(
+		operation: () => R | PromiseLike<R>,
+	): Promise<R> {
+		this._lifecycleMethodInvocations += 1;
+		try {
+			return Promise.resolve(operation());
+		} finally {
+			this._lifecycleMethodInvocations -= 1;
+		}
+	}
+
+	/**
+	 * Program.end() can only observe the base implementation's lifetime. A
+	 * subclass is still free to do asynchronous cleanup after `super.close()` or
+	 * `super.drop()` has returned. Wrap the public, dynamically-dispatched method
+	 * on every managed instance so Handler state covers that full outer promise.
+	 */
+	private monitorTerminalOperations(
+		address: Address,
+		program: T,
+	): { state: TerminalOperationState<T>; newLifecycle: boolean } {
+		let state = this._terminalOperationsByProgram.get(program);
+		const newLifecycle =
+			!state || this._terminalOperationsByAddress.get(address) !== state;
+		if (!state) {
+			state = {
+				program,
+				address,
+				activeCalls: 0,
+				pending: new Set(),
+				failed: false,
+				terminalCompleted: false,
+				outerTail: Promise.resolve(),
+				outerCalls: new Set(),
+			};
+			this._terminalOperationsByProgram.set(program, state);
+		}
+
+		state.address = address;
+		if (newLifecycle) {
+			state.failed = false;
+			state.failedOperation = undefined;
+			state.failedCall = undefined;
+			state.terminalCompleted = false;
+		}
+		this._terminalOperationsByAddress.set(address, state);
+
+		if (program.close !== state.closeWrapper) {
+			const close = program.close;
+			state.closeOperation = close;
+			const closeWrapper = (...args: any[]) =>
+				this.runTerminalOperation(state!, "close", close, args);
+			state.closeWrapper = closeWrapper;
+			program.close = closeWrapper;
+		}
+
+		const droppable = program as T & {
+			drop?: (...args: any[]) => Promise<boolean>;
+		};
+		if (
+			typeof droppable.drop === "function" &&
+			droppable.drop !== state.dropWrapper
+		) {
+			const drop = droppable.drop;
+			state.dropOperation = drop;
+			const dropWrapper = (...args: any[]) =>
+				this.runTerminalOperation(state!, "drop", drop, args);
+			state.dropWrapper = dropWrapper;
+			droppable.drop = dropWrapper;
+		}
+		return { state, newLifecycle };
+	}
+
+	private runTerminalOperation(
+		state: TerminalOperationState<T>,
+		type: TerminalOperation,
+		operation: (...args: any[]) => Promise<boolean>,
+		args: any[],
+	): Promise<boolean> {
+		const from = args[0] as Manageable<any> | undefined;
+		if (
+			state.program.terminalLifecycleCallbackRunning ||
+			(this._terminalLifecycleCallbacks > 0 && state.activeCalls > 0)
+		) {
+			return Promise.reject(
+				new TerminalOperationNotStartedError(
+					"Program lifecycle callbacks cannot wait for their own terminal operation",
+				),
+			);
+		}
+		const parentIndex =
+			state.program.parents?.findIndex((parent) => parent === from) ?? -1;
+		const terminal =
+			state.program.closed ||
+			parentIndex === -1 ||
+			(state.program.parents?.length ?? 0) === 1;
+		const matching = [...state.outerCalls].find(
+			(call) =>
+				call.terminal &&
+				call.from === from &&
+				(call.type === type || (type === "close" && call.type === "drop")),
+		);
+		if (matching) {
+			return matching.promise;
+		}
+		try {
+			this.assertTerminalGraphCanStart(state.program);
+		} catch (error) {
+			return Promise.reject(error);
+		}
+
+		// The outer wrapper serializes subclass methods before Program sees them. A
+		// call admitted while another owner is still queued can therefore look
+		// non-terminal now even though it will be the final release when it runs.
+		// Count already-admitted compatible calls against the owner's current
+		// references so a duplicate of that future terminal call shares its exact
+		// promise. Keep one distinct call per real duplicate ownership reference.
+		const compatibleCalls = [...state.outerCalls].filter(
+			(call) =>
+				call.from === from &&
+				(call.type === type || (type === "close" && call.type === "drop")),
+		);
+		const ownerReferences =
+			state.program.parents?.filter((parent) => parent === from).length ?? 0;
+		const reservedOwnerReferences = compatibleCalls.filter(
+			(call) => call.claimedOwnerReference,
+		).length;
+		const synchronouslyReleasedOwnerReferences = compatibleCalls.reduce(
+			(released, call) => {
+				const before = call.ownerReferencesBeforeInvoke;
+				const after = call.ownerReferencesAfterInvoke;
+				return (
+					released +
+					(before == null || after == null
+						? 0
+						: Math.min(1, Math.max(0, before - after)))
+				);
+			},
+			0,
+		);
+		const unclaimedOwnerReferences =
+			ownerReferences -
+			(reservedOwnerReferences - synchronouslyReleasedOwnerReferences);
+		if (compatibleCalls.length > 0 && unclaimedOwnerReferences <= 0) {
+			return compatibleCalls.at(-1)!.promise;
+		}
+
+		let resolve!: (value: boolean) => void;
+		let reject!: (reason?: unknown) => void;
+		const tracked = new Promise<boolean>((promiseResolve, promiseReject) => {
+			resolve = promiseResolve;
+			reject = promiseReject;
+		});
+		const outerCall: OuterTerminalCall = {
+			type,
+			from,
+			terminal,
+			claimedOwnerReference: ownerReferences > 0,
+			promise: tracked,
+		};
+		const hasPredecessor = state.outerCalls.size > 0;
+		state.outerCalls.add(outerCall);
+		state.activeCalls += 1;
+		state.terminalCompleted = false;
+		this._terminalOperationsByAddress.set(state.address, state);
+		state.pending.add(tracked);
+
+		const predecessor = state.outerTail;
+		const execute = async (): Promise<boolean> => {
+			const recovering = state.failed;
+			const failedCall = state.failedCall;
+			if (
+				recovering &&
+				(failedCall?.type !== type ||
+					!this.sameTerminalArgs(failedCall.args, args))
+			) {
+				throw new Error(
+					`Program at ${state.address} has failed terminal cleanup that must be retried first`,
+				);
+			}
+
+			const startedClosed = state.program.closed;
+			const startedAcceptingParents = state.program.acceptsParentAttachments;
+			const startedParents = [...(state.program.parents ?? [])];
+			const checkpoint = this.terminalCheckpoint(state.program);
+			const existingCleanupLease = state.cleanupLease;
+			if (!state.cleanupLease) {
+				state.cleanupLease = state.program[TERMINAL_OUTER_CLEANUP_RETAIN]?.();
+			}
+			const releaseProvisionalCleanupLease = () => {
+				if (!existingCleanupLease && state.cleanupLease) {
+					state.program[TERMINAL_OUTER_CLEANUP_RELEASE]?.(state.cleanupLease);
+					state.cleanupLease = undefined;
+				}
+			};
+			try {
+				const invoke = () => {
+					outerCall.ownerReferencesBeforeInvoke =
+						state.program.parents?.filter((parent) => parent === from).length ??
+						0;
+					let operationResult: Promise<boolean>;
+					try {
+						operationResult = this.invokeLifecycleMethod(() =>
+							operation.apply(state.program, args),
+						);
+					} finally {
+						outerCall.ownerReferencesAfterInvoke =
+							state.program.parents?.filter((parent) => parent === from)
+								.length ?? 0;
+					}
+					return operationResult!;
+				};
+				const result =
+					recovering && failedCall?.commit
+						? await this.retryCommittedTerminalCall(
+								state.program,
+								failedCall.commit,
+								invoke,
+							)
+						: await invoke();
+				if (recovering) {
+					const recoveryOwner = failedCall?.args[0] as
+						| Manageable<any>
+						| undefined;
+					const releasedDuringRetry = Math.max(
+						0,
+						startedParents.filter((parent) => parent === recoveryOwner).length -
+							(state.program.parents?.filter(
+								(parent) => parent === recoveryOwner,
+							).length ?? 0),
+					);
+					this.removeReleasedParentChildReferences(
+						state.program,
+						recoveryOwner,
+						Math.max(
+							failedCall?.commit?.releasedParentReferences ??
+								failedCall?.releasedParentReferences ??
+								0,
+							releasedDuringRetry,
+						),
+					);
+					state.failed = false;
+					state.failedOperation = undefined;
+					state.failedCall = undefined;
+				} else {
+					const commit = this.terminalCommit(
+						state.program,
+						checkpoint,
+						type,
+						from,
+					);
+					this.removeReleasedParentChildReferences(
+						state.program,
+						from,
+						commit?.releasedParentReferences ?? 0,
+					);
+				}
+				if (result && state.program.closed && !state.failed) {
+					state.terminalCompleted = true;
+				}
+				if (state.cleanupLease) {
+					state.program[TERMINAL_OUTER_CLEANUP_RELEASE]?.(state.cleanupLease);
+					state.cleanupLease = undefined;
+				}
+				return result;
+			} catch (error) {
+				const observedCommit =
+					failedCall?.commit ||
+					this.terminalCommit(state.program, checkpoint, type, from);
+				if (
+					!recovering &&
+					error instanceof TerminalOperationNotStartedError &&
+					!observedCommit
+				) {
+					// Exclude this call's provisional lease while validating that the
+					// explicit precondition error made no lifecycle mutation.
+					releaseProvisionalCleanupLease();
+					if (
+						state.program.closed === startedClosed &&
+						state.program.acceptsParentAttachments ===
+							startedAcceptingParents &&
+						this.sameParents(state.program.parents ?? [], startedParents)
+					) {
+						state.terminalCompleted = startedClosed;
+						throw error;
+					}
+					state.cleanupLease = state.program[TERMINAL_OUTER_CLEANUP_RETAIN]?.();
+				}
+				if (startedClosed && !recovering) {
+					// A fresh drop of an already-cleanly-closed program, or a drop queued
+					// behind a winning close, is an API rejection rather than failed cleanup.
+					state.terminalCompleted = true;
+					releaseProvisionalCleanupLease();
+					throw error;
+				}
+				const commit = observedCommit;
+				const baseProgressed =
+					commit != null ||
+					state.program.closed !== startedClosed ||
+					!this.sameParents(state.program.parents ?? [], startedParents);
+				const recoveryType: TerminalOperation =
+					type === "drop" && !baseProgressed
+						? "drop"
+						: commit || state.program.closed
+							? type
+							: "close";
+				const releasedParentReferences = Math.max(
+					failedCall?.releasedParentReferences ?? 0,
+					startedParents.filter((parent) => parent === from).length -
+						(state.program.parents?.filter((parent) => parent === from)
+							.length ?? 0),
+				);
+				state.failed = true;
+				state.failedOperation = recoveryType;
+				state.failedCall = {
+					type: recoveryType,
+					args: [...args],
+					commit: recoveryType === type ? commit : undefined,
+					releasedParentReferences,
+				};
+				state.terminalCompleted = false;
+				this.items.set(state.address, state.program);
+				this._terminalOperationsByAddress.set(state.address, state);
+				throw error;
+			}
+		};
+
+		// Invoke the first outer method immediately. Program.end() and subclasses
+		// establish their mutation/attachment fences synchronously before their
+		// first await; deferring through Promise.then would admit same-turn writes
+		// after close/drop had already been requested. Only true followers use the
+		// serialized promise tail.
+		const execution = hasPredecessor
+			? predecessor.then(execute, execute)
+			: execute();
+		state.outerTail = tracked.then(
+			(): void => undefined,
+			(): void => undefined,
+		);
+		void execution.then(resolve, reject);
+		void tracked.then(
+			() => this.finishOuterTerminalCall(state, outerCall, tracked),
+			() => this.finishOuterTerminalCall(state, outerCall, tracked),
+		);
+		logger.trace(
+			`Tracking outer ${type} operation for program at ${state.address}`,
+		);
+		return tracked;
+	}
+
+	private finishOuterTerminalCall(
+		state: TerminalOperationState<T>,
+		call: OuterTerminalCall,
+		promise: Promise<boolean>,
+	): void {
+		state.activeCalls -= 1;
+		state.outerCalls.delete(call);
+		state.pending.delete(promise);
+		this.finishTerminalOperation(state);
+	}
+
+	private sameTerminalArgs(left: any[], right: any[]): boolean {
+		return (
+			left.length === right.length &&
+			left.every((value, index) => value === right[index])
+		);
+	}
+
+	private sameParents(
+		left: (Manageable<any> | undefined)[],
+		right: (Manageable<any> | undefined)[],
+	): boolean {
+		return (
+			left.length === right.length &&
+			left.every((parent, index) => parent === right[index])
+		);
+	}
+
+	private terminalCheckpoint(program: Manageable<any>): number {
+		return program[TERMINAL_BASE_CHECKPOINT]?.() ?? 0;
+	}
+
+	private terminalCommit(
+		program: Manageable<any>,
+		checkpoint: number,
+		type: TerminalOperation,
+		from?: Manageable<any>,
+	): TerminalBaseCommit | undefined {
+		return program[TERMINAL_BASE_COMMIT]?.(checkpoint, type, from);
+	}
+
+	private retryCommittedTerminalCall(
+		program: Manageable<any>,
+		commit: TerminalBaseCommit,
+		operation: () => Promise<boolean>,
+	): Promise<boolean> {
+		return program[TERMINAL_BASE_RETRY]
+			? program[TERMINAL_BASE_RETRY](commit, operation)
+			: operation();
+	}
+
+	private addCleanupResidual(
+		program: Manageable<any>,
+		failure: FailedTerminalCall,
+		cleanupLease?: object,
+	): void {
+		const residual = this.reserveCleanupResidual(program, cleanupLease);
+		if (
+			cleanupLease &&
+			residual.cleanupLease &&
+			cleanupLease !== residual.cleanupLease
+		) {
+			program[TERMINAL_OUTER_CLEANUP_RELEASE]?.(cleanupLease);
+		}
+		residual.failures.push(failure);
+	}
+
+	private reserveCleanupResidual(
+		program: Manageable<any>,
+		cleanupLease?: object,
+	): CleanupResidual {
+		const existing = this._cleanupResiduals.get(program);
+		if (existing) {
+			return existing;
+		}
+		const retainedLease =
+			cleanupLease ?? program[TERMINAL_OUTER_CLEANUP_RETAIN]?.();
+		const residual: CleanupResidual = {
+			program,
+			failures: [],
+			cleanupLease: retainedLease,
+			activeReservations: 0,
+		};
+		this._cleanupResiduals.set(program, residual);
+		return residual;
+	}
+
+	private acquireCleanupReservation(program: Manageable<any>): CleanupResidual {
+		const residual = this.reserveCleanupResidual(program);
+		residual.activeReservations += 1;
+		return residual;
+	}
+
+	private releaseCleanupReservation(residual: CleanupResidual): void {
+		residual.activeReservations -= 1;
+		if (residual.activeReservations < 0) {
+			throw new Error("Cleanup residual reservation underflow");
+		}
+		if (residual.activeReservations === 0 && residual.failures.length === 0) {
+			this.releaseCleanupResidual(residual);
+		}
+	}
+
+	private releaseCleanupResidual(residual: CleanupResidual): void {
+		if (residual.activeReservations > 0) {
+			throw new Error(
+				"Cleanup residual cannot be released while rollback cleanup is active",
+			);
+		}
+		if (residual.cleanupLease) {
+			residual.program[TERMINAL_OUTER_CLEANUP_RELEASE]?.(residual.cleanupLease);
+			residual.cleanupLease = undefined;
+		}
+		this._cleanupResiduals.delete(residual.program);
+	}
+
+	private async retryCleanupResidual(
+		residual: CleanupResidual,
+		failure: FailedTerminalCall,
+	): Promise<void> {
+		const operation = (
+			residual.program as Manageable<any> & {
+				drop?: (...args: any[]) => Promise<boolean>;
+			}
+		)[failure.type];
+		if (!operation) {
+			throw new Error(
+				`Program at ${residual.program.address} cannot retry its failed ${failure.type} cleanup`,
+			);
+		}
+		const checkpoint = this.terminalCheckpoint(residual.program);
+		const invoke = () =>
+			this.invokeLifecycleMethod(() =>
+				operation.apply(residual.program, failure.args),
+			);
+		try {
+			if (failure.commit) {
+				await this.retryCommittedTerminalCall(
+					residual.program,
+					failure.commit,
+					invoke,
+				);
+			} else {
+				await invoke();
+			}
+		} catch (error) {
+			failure.commit ??= this.terminalCommit(
+				residual.program,
+				checkpoint,
+				failure.type,
+				failure.args[0],
+			);
+			throw error;
+		}
+	}
+
+	private finishTerminalOperation(state: TerminalOperationState<T>): void {
+		if (
+			state.activeCalls > 0 ||
+			state.failed ||
+			!state.terminalCompleted ||
+			!state.program.closed
+		) {
+			return;
+		}
+		if (this.items.get(state.address) === state.program) {
+			this.items.delete(state.address);
+		}
+		this.restoreTerminalOperations(state);
+		if (this._failedInitializations.get(state.address) === state.program) {
+			this._failedInitializations.delete(state.address);
+		}
+		if (this._terminalOperationsByAddress.get(state.address) === state) {
+			this._terminalOperationsByAddress.delete(state.address);
+		}
+	}
+
+	private restoreTerminalOperations(state: TerminalOperationState<T>): void {
+		if (
+			state.closeWrapper &&
+			state.closeOperation &&
+			state.program.close === state.closeWrapper
+		) {
+			state.program.close = state.closeOperation;
+		}
+		const droppable = state.program as T & {
+			drop?: (...args: any[]) => Promise<boolean>;
+		};
+		if (
+			state.dropWrapper &&
+			state.dropOperation &&
+			droppable.drop === state.dropWrapper
+		) {
+			droppable.drop = state.dropOperation;
+		}
+	}
+
+	private findMonitoredPrograms(address: Address): T[] {
+		const targetAddress = address.toString();
+		const pending: Manageable<any>[] = [...this.items.values()];
+		const visited = new Set<Manageable<any>>();
+		const matches: T[] = [];
+		while (pending.length > 0) {
+			const candidate = pending.pop()!;
+			if (visited.has(candidate)) continue;
+			visited.add(candidate);
+			if (candidate.address.toString() === targetAddress) {
+				matches.push(candidate as T);
+			}
+			for (const child of candidate.children ?? []) {
+				pending.push(child);
+			}
+		}
+		return matches;
+	}
+
+	private findMonitoredProgram(
+		address: Address,
+		liveOnly = false,
+	): T | undefined {
+		const matches = this.findMonitoredPrograms(address);
+		return liveOnly
+			? matches.find((candidate) => !candidate.closed)
+			: (matches.find((candidate) => !candidate.closed) ?? matches[0]);
+	}
+
+	private attachExistingProgram<S extends T>(
+		address: Address,
+		program: S,
+		parent?: Manageable<any>,
+	): S {
+		if (parent) this.assertParentCanOwnOpen(parent);
+		addParent(program, parent);
+		if (parent == null && this.items.get(address) !== program) {
+			const direct = this.items.get(address);
+			if (direct && !direct.closed && direct !== program) {
+				throw new Error(
+					`Program at ${address} is already monitored as another live instance`,
+				);
+			}
+			this.monitorTerminalOperations(address, program);
+			this.items.set(address, program);
+		}
+		return program;
+	}
+
+	private assertNoTerminalOperation(
+		address: Address,
+		requestedProgram?: Manageable<any>,
+		allowSettledAncestorRepair = requestedProgram != null,
+	): void {
+		const residual = [...this._cleanupResiduals.values()].find(
+			(candidate) =>
+				candidate.program.address.toString() === address.toString(),
+		);
+		if (residual) {
+			throw new Error(
+				`Program at ${address} has pending cleanup residuals and cannot be reopened before cleanup is retried`,
+			);
+		}
+		const state = this._terminalOperationsByAddress.get(address);
+		if (state?.activeCalls) {
+			throw new Error(
+				`Program is terminating and cannot accept another parent while its close or drop operation is finishing (${address})`,
+			);
+		}
+		if (state?.failed) {
+			throw new Error(
+				`Program at ${address} failed terminal cleanup and cannot be reopened before cleanup is retried`,
+			);
+		}
+		const targetAddress = address.toString();
+		const pending: {
+			program: Manageable<any>;
+			ancestorActive: boolean;
+			ancestorSettled: boolean;
+			ancestorResidual: boolean;
+		}[] = [...this.items.values()].map((program) => ({
+			program,
+			ancestorActive: false,
+			ancestorSettled: false,
+			ancestorResidual: false,
+		}));
+		for (const cleanupResidual of this._cleanupResiduals.values()) {
+			pending.push({
+				program: cleanupResidual.program,
+				ancestorActive: false,
+				ancestorSettled: false,
+				ancestorResidual: true,
+			});
+		}
+		const visited = new Map<Manageable<any>, number>();
+		while (pending.length > 0) {
+			const {
+				program: candidate,
+				ancestorActive,
+				ancestorSettled,
+				ancestorResidual,
+			} = pending.pop()!;
+			const candidateState = this._terminalOperationsByProgram.get(
+				candidate as T,
+			);
+			const ownActive = (candidateState?.activeCalls ?? 0) > 0;
+			const ownFailed = candidateState?.failed === true;
+			const ownAttachmentFence =
+				candidate.acceptsParentAttachments === false &&
+				(!candidate.closed ||
+					candidate.pendingTerminalOperation != null ||
+					ownActive ||
+					ownFailed);
+			const stateMask =
+				(ancestorActive ? 1 : 0) |
+				(ancestorSettled ? 2 : 0) |
+				(ancestorResidual ? 4 : 0);
+			const previousMask = visited.get(candidate) ?? -1;
+			if (previousMask !== -1 && (previousMask | stateMask) === previousMask) {
+				continue;
+			}
+			visited.set(
+				candidate,
+				previousMask === -1 ? stateMask : previousMask | stateMask,
+			);
+			if (candidate.address.toString() === targetAddress) {
+				const exactRepair =
+					allowSettledAncestorRepair && requestedProgram === candidate;
+				if (
+					ownActive ||
+					ownFailed ||
+					ownAttachmentFence ||
+					ancestorActive ||
+					ancestorResidual ||
+					(ancestorSettled && !exactRepair)
+				) {
+					throw new Error(
+						`Program is terminating and cannot accept another parent while its cleanup is finishing (${address})`,
+					);
+				}
+			}
+			const descendantActive = ancestorActive || ownActive;
+			const descendantSettled =
+				ancestorSettled || (!ownActive && (ownFailed || ownAttachmentFence));
+			for (const child of candidate.children ?? []) {
+				pending.push({
+					program: child,
+					ancestorActive: descendantActive,
+					ancestorSettled: descendantSettled,
+					ancestorResidual,
+				});
+			}
+		}
+	}
+
+	private assertTerminalGraphCanStart(program: Manageable<any>): void {
+		if (this._initializationRollbacks.has(program)) {
+			return;
+		}
+		const replacing = this._replacementClosures.has(program);
+		const pending = [program];
+		const visited = new Set<Manageable<any>>();
+		while (pending.length > 0) {
+			const candidate = pending.pop()!;
+			if (visited.has(candidate)) continue;
+			visited.add(candidate);
+			if ((this._parentAttachmentReservations.get(candidate) ?? 0) > 0) {
+				throw new TerminalOperationNotStartedError(
+					`Program at ${candidate.address} has an opening child attachment that must finish first`,
+				);
+			}
+			const address = candidate.address.toString();
+			const rootReplacementOpen = replacing && candidate === program;
+			if (
+				(this._openingPromises.has(address) && !rootReplacementOpen) ||
+				(this._openingReservationsByAddress.get(address)?.size ?? 0) > 0
+			) {
+				throw new TerminalOperationNotStartedError(
+					`Program at ${address} cannot terminate while an open generation owns its address`,
+				);
+			}
+			const conflicting = this.findMonitoredPrograms(address).find(
+				(monitored) => monitored !== candidate && !monitored.closed,
+			);
+			if (conflicting) {
+				throw new TerminalOperationNotStartedError(
+					`Program at ${address} cannot terminate while another live instance owns its address`,
+				);
+			}
+			for (const child of candidate.children ?? []) {
+				pending.push(child);
+			}
+		}
+	}
+
+	private async waitForTerminalOperations(
+		program: Manageable<any>,
+	): Promise<void> {
+		const state = this._terminalOperationsByProgram.get(program);
+		while (state && state.pending.size > 0) {
+			// A rejected direct close is not itself the result of stop(). Once it has
+			// settled, closeCompletely() retries the retained instance below.
+			await Promise.allSettled([...state.pending]);
+		}
+	}
+
+	private async closeCompletely(program: Manageable<any>): Promise<void> {
+		await this.waitForTerminalOperations(program);
+		let terminalState = this._terminalOperationsByProgram.get(program);
+		while (!program.closed || terminalState?.failed) {
+			const wasRecovering = terminalState?.failed === true;
+			const failedCall = terminalState?.failedCall;
+			const ownersBefore = [...(program.parents ?? [])];
+			const owner = wasRecovering
+				? (failedCall?.args[0] as Manageable<any> | undefined)
+				: program.closed
+					? undefined
+					: ownersBefore[0];
+			const ownerReferencesBefore = ownersBefore.filter(
+				(candidate) => candidate === owner,
+			).length;
+			const operationType: TerminalOperation =
+				failedCall?.type ??
+				(terminalState?.failedOperation === "drop" ? "drop" : "close");
+			const operation = (
+				program as Manageable<any> & {
+					drop?: (from?: Manageable<any>) => Promise<boolean>;
+				}
+			)[operationType];
+			if (!operation) {
+				throw new Error(
+					`Program at ${program.address} cannot retry its failed ${operationType} cleanup`,
+				);
+			}
+			const operationArgs = wasRecovering ? (failedCall?.args ?? []) : [owner];
+			const closed = await (
+				operation as (...args: any[]) => Promise<boolean>
+			).apply(program, operationArgs);
+			await this.waitForTerminalOperations(program);
+			terminalState = this._terminalOperationsByProgram.get(program);
+			if (
+				closed &&
+				program.closed &&
+				terminalState?.failed &&
+				terminalState.failedOperation === operationType
+			) {
+				// This also supports a test/application replacing the wrapped method
+				// after open: closeCompletely awaited the full replacement call, so it
+				// is safe to mark the previously retained cleanup as recovered.
+				terminalState.failed = false;
+				terminalState.failedOperation = undefined;
+				terminalState.failedCall = undefined;
+				terminalState.terminalCompleted = true;
+				if (terminalState.cleanupLease) {
+					program[TERMINAL_OUTER_CLEANUP_RELEASE]?.(terminalState.cleanupLease);
+					terminalState.cleanupLease = undefined;
+				}
+				this.finishTerminalOperation(terminalState);
+			}
+
+			const ownersAfter = program.parents ?? [];
+			const ownerReferencesAfter = ownersAfter.filter(
+				(candidate) => candidate === owner,
+			).length;
+			if (owner) {
+				const inverseEdges =
+					owner.children?.filter((candidate) => candidate === program).length ??
+					0;
+				this.removeReleasedParentChildReferences(
+					program,
+					owner,
+					Math.max(0, inverseEdges - ownerReferencesAfter),
+				);
+			}
+			if (program.closed && !terminalState?.failed) {
+				return;
+			}
+			if (wasRecovering && !terminalState?.failed) {
+				// The failed outer call has now completed. Its base ownership transition
+				// may already have committed, so evaluate remaining owners on a fresh loop.
+				continue;
+			}
+			// A non-terminal Program.close(from) is valid only when it releases the
+			// requested owner and strictly reduces the total owner count. The latter is
+			// a monotonic measure that bounds this loop.
+			if (
+				closed ||
+				ownersAfter.length >= ownersBefore.length ||
+				ownerReferencesAfter >= ownerReferencesBefore
+			) {
+				throw new Error(
+					`Program at ${program.address} did not make ownership progress while stopping (${ownersBefore.length} -> ${ownersAfter.length})`,
+				);
+			}
+		}
+	}
+
+	private removeReleasedParentChildReferences(
+		program: Manageable<any>,
+		parent: Manageable<any> | undefined,
+		releasedReferences: number,
+	) {
+		if (!parent) {
+			return;
+		}
+		while (releasedReferences > 0) {
+			const childIndex = parent.children?.indexOf(program) ?? -1;
+			if (childIndex === -1) {
+				return;
+			}
+			parent.children.splice(childIndex, 1);
+			releasedReferences -= 1;
+		}
+	}
+
+	private assertNoFailedInitialization(address: Address) {
+		const failed = this._failedInitializations.get(address);
+		if (!failed) {
+			return;
+		}
+		if (failed.closed) {
+			if (this._terminalOperationsByAddress.get(address)?.failed) {
+				return;
+			}
+			this._failedInitializations.delete(address);
+			if (this.items.get(address) === failed) {
+				this.items.delete(address);
+			}
+			return;
+		}
+		throw new Error(
+			`Program at ${address} failed initialization cleanup and cannot be reopened before it is stopped`,
+		);
+	}
+
+	private async stopOnce(): Promise<void> {
+		// Do not PQueue.clear(): p-queue drops queued callbacks without settling the
+		// promises returned to callers. Admitted opens must run to completion (or
+		// rejection) before their programs can be closed below.
+		await Promise.all([...this._openAdmissions]);
 		await Promise.all(
-			[...this._openQueue.values()].map((x) => {
-				x.clear();
-				return x.onIdle();
-			}),
+			[...this._openQueue.values()].map((queue) => queue.onIdle()),
 		);
 		this._openQueue.clear();
 
@@ -114,60 +1283,884 @@ export class Handler<T extends Manageable<any>> {
 			await Promise.allSettled([...this._openingPromises.values()]);
 		}
 		this._openingPromises.clear();
+		this._openingReservations.clear();
+		this._openingReservationsByAddress.clear();
 
-		// Close all open databases
-		await Promise.all(
-			[...this.items.values()].map((program) => program.close()),
-		);
+		// A close can legitimately return false when it only releases one of several
+		// owners. Drain every ownership reference so stop cannot discard a still-live
+		// program from Handler state.
+		const closeErrors: unknown[] = [];
+		for (const [address, program] of [...this.items]) {
+			try {
+				await this.closeCompletely(program);
+			} catch (error) {
+				closeErrors.push(error);
+			}
+			const terminalState = this._terminalOperationsByProgram.get(program);
+			if (
+				program.closed &&
+				!terminalState?.failed &&
+				(terminalState?.activeCalls ?? 0) === 0 &&
+				this.items.get(address) === program
+			) {
+				this.items.delete(address);
+			}
+			if (
+				program.closed &&
+				!terminalState?.failed &&
+				this._failedInitializations.get(address) === program
+			) {
+				this._failedInitializations.delete(address);
+			}
+		}
+		for (const [program, residual] of [...this._cleanupResiduals]) {
+			try {
+				for (const failure of [...residual.failures]) {
+					await this.retryCleanupResidual(residual, failure);
+					const failureIndex = residual.failures.indexOf(failure);
+					if (failureIndex !== -1) residual.failures.splice(failureIndex, 1);
+				}
+				await this.closeCompletely(program);
+			} catch (error) {
+				closeErrors.push(error);
+			}
+			const terminalState = this._terminalOperationsByProgram.get(program);
+			if (
+				program.closed &&
+				residual.failures.length === 0 &&
+				!terminalState?.failed &&
+				(terminalState?.activeCalls ?? 0) === 0
+			) {
+				this.releaseCleanupResidual(residual);
+			}
+		}
+		if (closeErrors.length > 0) {
+			throw closeErrors[0];
+		}
 
-		// Remove all databases from the state
 		this.items = new Map();
+		this._failedInitializations.clear();
+		for (const residual of [...this._cleanupResiduals.values()]) {
+			this.releaseCleanupResidual(residual);
+		}
+		for (const state of new Set(this._terminalOperationsByAddress.values())) {
+			this.restoreTerminalOperations(state);
+		}
+		this._terminalOperationsByAddress.clear();
 	}
 
 	private _onProgamClose(program: Manageable<any>) {
-		this.items.delete(program.address!.toString());
-
+		const address = program.address!.toString();
+		const terminalState = this._terminalOperationsByProgram.get(program);
+		if (terminalState?.activeCalls || terminalState?.failed) {
+			// The base Program has ended, but the dynamically-dispatched subclass
+			// close/drop promise is still running. Its wrapper owns final eviction.
+			return;
+		}
+		if (this.items.get(address) === program) {
+			this.items.delete(address);
+		}
+		if (this._failedInitializations.get(address) === program) {
+			this._failedInitializations.delete(address);
+		}
 		// TODO remove item from this._openQueue?
+	}
+
+	private async closeForReplacement(
+		address: Address,
+		program: Manageable<any>,
+		parent?: Manageable<any>,
+	): Promise<void> {
+		const owners = program.parents ?? [];
+		if (owners.length > 1 || (owners.length === 1 && owners[0] !== parent)) {
+			throw new Error(
+				`Program at ${address} cannot be replaced while it has other owners`,
+			);
+		}
+		const parentReferencesBefore = owners.filter(
+			(candidate) => candidate === parent,
+		).length;
+		let closed: boolean;
+		this._replacementClosures.add(program);
+		try {
+			closed = await (
+				program.close as unknown as (from?: Manageable<any>) => Promise<boolean>
+			).call(program, parent);
+		} finally {
+			this._replacementClosures.delete(program);
+		}
+		const parentReferencesAfter = (program.parents ?? []).filter(
+			(candidate) => candidate === parent,
+		).length;
+		this.removeReleasedParentChildReferences(
+			program,
+			parent,
+			parentReferencesBefore - parentReferencesAfter,
+		);
+		if (!closed || !program.closed || parentReferencesAfter > 0) {
+			throw new Error(
+				`Program at ${address} cannot be replaced because close was not terminal`,
+			);
+		}
+		if (this.items.get(address) === program) {
+			this.items.delete(address);
+		}
 	}
 
 	private async checkProcessExisting<S extends T>(
 		address: Address,
 		toOpen: Manageable<any>,
 		mergeSrategy: ProgramMergeStrategy = "reject",
+		parent?: Manageable<any>,
 	): Promise<S | undefined> {
-		const prev = this.items.get(address);
+		this.assertNoFailedInitialization(address);
+		this.assertNoTerminalOperation(address, toOpen);
+		const prev = this.findMonitoredProgram(address);
+		if (prev?.closed) {
+			if (this.items.get(address) === prev) {
+				this.items.delete(address);
+			}
+			return undefined;
+		}
 		if (mergeSrategy === "reject") {
 			if (prev) {
 				throw new Error(`Program at ${address} is already open`);
 			}
 		} else if (mergeSrategy === "replace") {
 			if (prev && prev !== toOpen) {
-				await prev.close(); // clouse previous
+				await this.closeForReplacement(address, prev, parent);
 			}
 		} else if (mergeSrategy === "reuse") {
+			if (prev) {
+				this.attachExistingProgram(address, prev, parent);
+			}
 			return prev as S;
 		}
+	}
+
+	private async processParentExisting<S extends T>(
+		address: Address,
+		requestedProgram: Manageable<any> | undefined,
+		mergeStrategy: ProgramMergeStrategy,
+		parent: Manageable<any>,
+	): Promise<S | undefined> {
+		this.assertNoFailedInitialization(address);
+		this.assertNoTerminalOperation(address, requestedProgram);
+		const existing = this.findMonitoredProgram(address);
+		if (existing?.closed) {
+			if (this.items.get(address) === existing) {
+				this.items.delete(address);
+			}
+			return undefined;
+		}
+		if (!existing) {
+			return undefined;
+		}
+
+		if (mergeStrategy === "reject") {
+			throw new Error(`Program at ${address} is already open`);
+		}
+		if (mergeStrategy === "replace" && existing !== requestedProgram) {
+			await this.closeForReplacement(address, existing, parent);
+			return undefined;
+		}
+
+		this.attachExistingProgram(address, existing, parent);
+		try {
+			// A program explicitly opened with a parent is a weak/addressable
+			// reference. Structural beforeOpen() may already have made the exact
+			// instance live without persisting its standalone block.
+			await existing.save(this.properties.client.services.blocks, {
+				skipOnAddress: false,
+			});
+		} catch (error) {
+			const parentIndex = existing.parents?.lastIndexOf(parent) ?? -1;
+			if (parentIndex !== -1) existing.parents.splice(parentIndex, 1);
+			const childIndex = parent.children?.lastIndexOf(existing) ?? -1;
+			if (childIndex !== -1) parent.children.splice(childIndex, 1);
+			throw error;
+		}
+		return existing as S;
+	}
+
+	private async rollbackFailedInitialization(
+		address: Address,
+		program: Manageable<any>,
+		state: {
+			parents?: (Manageable<any> | undefined)[];
+			children?: Manageable<any>[];
+			parent?: Manageable<any>;
+			parentChildReferences: number;
+		},
+	): Promise<void> {
+		if (this.items.get(address) === program) {
+			this.items.delete(address);
+		}
+
+		const cleanupErrors: unknown[] = [];
+		const childrenAfterFailure = [...(program.children ?? [])];
+		try {
+			if (!program.closed) {
+				await program.close();
+			}
+		} catch (cleanupError) {
+			cleanupErrors.push(cleanupError);
+			logger.error(
+				`Failed to close partially opened program at ${address}: ${String(
+					cleanupError,
+				)}`,
+			);
+		}
+
+		// beforeOpen() can attach nested children before the parent itself becomes
+		// open. Remove only relationships added by this failed generation, then
+		// restore the exact caller-visible parent/child arrays captured at entry.
+		const baselineChildCounts = new Map<Manageable<any>, number>();
+		for (const child of state.children ?? []) {
+			baselineChildCounts.set(child, (baselineChildCounts.get(child) ?? 0) + 1);
+		}
+		const currentChildCounts = new Map<Manageable<any>, number>();
+		for (const child of childrenAfterFailure) {
+			currentChildCounts.set(child, (currentChildCounts.get(child) ?? 0) + 1);
+		}
+		for (const [child, currentCount] of currentChildCounts) {
+			const baselineCount = baselineChildCounts.get(child) ?? 0;
+			let extra = currentCount - baselineCount;
+			while (extra > 0) {
+				const referencesBefore =
+					child.parents?.filter((parent) => parent === program).length ?? 0;
+				let retainedFailure = false;
+				let cleanupReservation: CleanupResidual | undefined;
+				if (!child.closed && referencesBefore > 0) {
+					const checkpoint = this.terminalCheckpoint(child);
+					cleanupReservation = this.acquireCleanupReservation(child);
+					try {
+						await (
+							child.close as unknown as (
+								from?: Manageable<any>,
+							) => Promise<boolean>
+						).call(child, program);
+					} catch (cleanupError) {
+						retainedFailure = true;
+						const terminalState = this._terminalOperationsByProgram.get(
+							child as T,
+						);
+						const handlerOwnsFailure =
+							terminalState?.failed === true &&
+							terminalState.failedCall?.type === "close" &&
+							this.sameTerminalArgs(terminalState.failedCall.args, [program]);
+						if (handlerOwnsFailure) {
+						} else {
+							cleanupReservation.failures.push({
+								type: "close",
+								args: [program],
+								commit: this.terminalCommit(
+									child,
+									checkpoint,
+									"close",
+									program,
+								),
+							});
+						}
+						this.releaseCleanupReservation(cleanupReservation);
+						cleanupReservation = undefined;
+						cleanupErrors.push(cleanupError);
+						logger.error(
+							`Failed to close partially opened child of ${address}: ${String(
+								cleanupError,
+							)}`,
+						);
+					}
+				}
+				let referencesAfter =
+					child.parents?.filter((parent) => parent === program).length ?? 0;
+				if (
+					!retainedFailure &&
+					referencesAfter >= referencesBefore &&
+					referencesAfter > 0
+				) {
+					const parentIndex = child.parents.lastIndexOf(program);
+					child.parents.splice(parentIndex, 1);
+					referencesAfter -= 1;
+				}
+				if (cleanupReservation) {
+					this.releaseCleanupReservation(cleanupReservation);
+				}
+				extra -= 1;
+			}
+			const remainingProgramReferences =
+				child.parents?.filter((parent) => parent === program).length ?? 0;
+			if (
+				!child.closed &&
+				baselineCount === 0 &&
+				(remainingProgramReferences > 0 || (child.parents?.length ?? 0) === 0)
+			) {
+				// A failed nested cleanup must remain reachable by stop(); restoring the
+				// caller-visible arrays alone would otherwise orphan a live resource.
+				if (!this._cleanupResiduals.has(child)) {
+					this.addCleanupResidual(child, {
+						type: "close",
+						args: [remainingProgramReferences > 0 ? program : undefined],
+					});
+				}
+			}
+		}
+
+		(program as { parents?: (Manageable<any> | undefined)[] }).parents =
+			state.parents ? [...state.parents] : undefined;
+		(program as { children?: Manageable<any>[] }).children = state.children
+			? [...state.children]
+			: undefined;
+		if (state.parent) {
+			let currentReferences =
+				state.parent.children?.filter((child) => child === program).length ?? 0;
+			while (currentReferences > state.parentChildReferences) {
+				const childIndex = state.parent.children.lastIndexOf(program);
+				if (childIndex === -1) {
+					break;
+				}
+				state.parent.children.splice(childIndex, 1);
+				currentReferences -= 1;
+			}
+		}
+
+		if (!program.closed) {
+			// Never manufacture a terminal state after close() failed. Keep the
+			// partially initialized instance identity-tracked so later opens cannot
+			// reuse it and stop() can retry cleanup.
+			this.items.set(address, program as T);
+			this._failedInitializations.set(address, program as T);
+		} else {
+			this._failedInitializations.delete(address);
+		}
+
+		if (cleanupErrors.length > 0) {
+			logger.error(
+				`Program initialization rollback at ${address} encountered ${cleanupErrors.length} cleanup error(s)`,
+			);
+		}
+	}
+
+	private dependencyGraph(program: T): Manageable<any>[] {
+		const dependencies = this.properties.getDependencies?.(program) ?? [];
+		return [...new Set<Manageable<any>>([program, ...dependencies])];
+	}
+
+	private async resolveDependencyAddresses(
+		program: T,
+	): Promise<Map<Manageable<any>, string>> {
+		const addresses = new Map<Manageable<any>, string>();
+		for (const candidate of this.dependencyGraph(program)) {
+			const address = await candidate.save(
+				this.properties.client.services.blocks,
+				{
+					skipOnAddress: true,
+					save: () => false,
+				},
+			);
+			addresses.set(candidate, address.toString());
+		}
+		return addresses;
+	}
+
+	private cleanupFailedOpeningMonitoring(
+		reservation: OpeningReservation<T>,
+	): void {
+		for (const state of reservation.provisionalTerminalStates) {
+			if (
+				!state.program.closed ||
+				state.activeCalls > 0 ||
+				state.pending.size > 0 ||
+				state.failed ||
+				state.cleanupLease ||
+				state.program.pendingTerminalOperation != null ||
+				this._cleanupResiduals.has(state.program)
+			) {
+				continue;
+			}
+			this.restoreTerminalOperations(state);
+			if (this._terminalOperationsByAddress.get(state.address) === state) {
+				this._terminalOperationsByAddress.delete(state.address);
+			}
+			this._terminalOperationsByProgram.delete(state.program);
+		}
+		reservation.provisionalTerminalStates.clear();
+	}
+
+	private releaseOpeningReservation(
+		reservation: OpeningReservation<T>,
+		failed = false,
+	): void {
+		for (const address of reservation.programsByAddress.keys()) {
+			const reservations = this._openingReservationsByAddress.get(address);
+			reservations?.delete(reservation);
+			if (reservations?.size === 0) {
+				this._openingReservationsByAddress.delete(address);
+			}
+		}
+		if (failed) {
+			for (const participant of reservation.contributedParticipants) {
+				const references =
+					reservation.group.participantReferences.get(participant) ?? 0;
+				if (references <= 1) {
+					reservation.group.participantReferences.delete(participant);
+				} else {
+					reservation.group.participantReferences.set(
+						participant,
+						references - 1,
+					);
+				}
+			}
+		}
+		reservation.group.reservations.delete(reservation);
+		this._openingReservations.delete(reservation);
+		reservation.programsByAddress.clear();
+		reservation.programs.clear();
+		reservation.adoptedParents.clear();
+		reservation.contributedParticipants.clear();
+		reservation.wakeWaiters.clear();
+		if (failed) {
+			this.cleanupFailedOpeningMonitoring(reservation);
+		} else {
+			reservation.provisionalTerminalStates.clear();
+		}
+	}
+
+	private reservationContains(
+		reservation: OpeningReservation<T>,
+		program: Manageable<any>,
+	): boolean {
+		return reservation.group.participantReferences.has(program);
+	}
+
+	private contributeOpeningParticipant(
+		reservation: OpeningReservation<T>,
+		program: Manageable<any>,
+	): void {
+		if (reservation.contributedParticipants.has(program)) return;
+		reservation.contributedParticipants.add(program);
+		reservation.group.participantReferences.set(
+			program,
+			(reservation.group.participantReferences.get(program) ?? 0) + 1,
+		);
+	}
+
+	private mergeOpeningReservationGroups(
+		left: OpeningReservation<T>,
+		right: OpeningReservation<T>,
+	): void {
+		if (left.group === right.group) return;
+		const target = left.group;
+		const source = right.group;
+		for (const [participant, references] of source.participantReferences) {
+			target.participantReferences.set(
+				participant,
+				(target.participantReferences.get(participant) ?? 0) + references,
+			);
+		}
+		for (const reservation of source.reservations) {
+			reservation.group = target;
+			target.reservations.add(reservation);
+		}
+		source.reservations.clear();
+		source.participantReferences.clear();
+	}
+
+	private canShareOpeningReservation(
+		existing: OpeningReservation<T>,
+		reservation: OpeningReservation<T>,
+		address: string,
+		candidate: Manageable<any>,
+		parent?: Manageable<any>,
+	): boolean {
+		if (existing.programsByAddress.get(address) !== candidate) return false;
+		if (existing.group === reservation.group) return true;
+		if (parent && this.reservationContains(existing, parent)) return true;
+		return [...reservation.adoptedParents].some((adoptedParent) =>
+			this.reservationContains(existing, adoptedParent),
+		);
+	}
+
+	private adoptOpeningReservation(
+		promise: Promise<T>,
+		parent: Manageable<any>,
+	): void {
+		const reservation = this._openingReservationsByPromise.get(promise);
+		if (!reservation || reservation.phase !== "opening") return;
+		reservation.adoptedParents.add(parent);
+		this.contributeOpeningParticipant(reservation, parent);
+		for (const wake of [...reservation.wakeWaiters]) wake();
+	}
+
+	private async waitForOpeningConflictChange(
+		reservation: OpeningReservation<T>,
+		waits: Set<Promise<T>>,
+	): Promise<void> {
+		let wake!: () => void;
+		const adopted = new Promise<void>((resolve) => {
+			wake = resolve;
+		});
+		reservation.wakeWaiters.add(wake);
+		try {
+			await Promise.race([Promise.allSettled(waits), adopted]);
+		} finally {
+			reservation.wakeWaiters.delete(wake);
+		}
+	}
+
+	private assertParentCanOwnOpen(parent: Manageable<any>): void {
+		if (this._initializationRollbacks.has(parent)) {
+			throw new Error(
+				"Parent program is finishing initialization rollback cleanup",
+			);
+		}
+		if (
+			this._cleanupResiduals.has(parent) ||
+			[...this._failedInitializations.values()].some(
+				(failed) => (failed as Manageable<any>) === parent,
+			)
+		) {
+			throw new Error("Parent program has failed lifecycle cleanup");
+		}
+		const terminalState = this._terminalOperationsByProgram.get(parent);
+		if (
+			(terminalState?.activeCalls ?? 0) > 0 ||
+			terminalState?.failed ||
+			parent.acceptsParentAttachments === false
+		) {
+			throw new Error("Parent program is finishing terminal cleanup");
+		}
+		if (parent.closed) {
+			throw new Error("Parent program is closed");
+		}
+	}
+
+	private retainParentAttachment(parent: Manageable<any>): void {
+		this._parentAttachmentReservations.set(
+			parent,
+			(this._parentAttachmentReservations.get(parent) ?? 0) + 1,
+		);
+	}
+
+	private releaseParentAttachment(parent: Manageable<any>): void {
+		const reservations = this._parentAttachmentReservations.get(parent) ?? 0;
+		if (reservations <= 1) {
+			this._parentAttachmentReservations.delete(parent);
+		} else {
+			this._parentAttachmentReservations.set(parent, reservations - 1);
+		}
+	}
+
+	private isReservedNestedUse(
+		address: string,
+		program: Manageable<any> | undefined,
+		parent: Manageable<any>,
+	): boolean {
+		return [...(this._openingReservationsByAddress.get(address) ?? [])].some(
+			(reservation) =>
+				this.reservationContains(reservation, parent) &&
+				(program == null ||
+					reservation.programsByAddress.get(address) === program),
+		);
+	}
+
+	private async waitForOpeningReservations(
+		address: string,
+		program?: Manageable<any>,
+		parent?: Manageable<any>,
+		observedReservations: Set<OpeningReservation<T>> = new Set(),
+	): Promise<void> {
+		while (true) {
+			const waits = new Set<Promise<T>>();
+			for (const reservation of this._openingReservationsByAddress.get(
+				address,
+			) ?? []) {
+				if (
+					parent &&
+					this.reservationContains(reservation, parent) &&
+					(program == null ||
+						reservation.programsByAddress.get(address) === program)
+				) {
+					continue;
+				}
+				if (
+					reservation.phase === "rollback" &&
+					!observedReservations.has(reservation)
+				) {
+					throw new Error(
+						`Program at ${address} is finishing initialization rollback cleanup`,
+					);
+				}
+				waits.add(reservation.promise);
+			}
+			if (waits.size === 0) return;
+			await Promise.allSettled(waits);
+		}
+	}
+
+	private async prepareOpeningGraph(
+		program: T,
+		reservation: OpeningReservation<T>,
+		parent?: Manageable<any>,
+		resolvedAddresses?: Map<Manageable<any>, string>,
+	): Promise<Map<Manageable<any>, string>> {
+		const addresses =
+			resolvedAddresses ?? (await this.resolveDependencyAddresses(program));
+		const programs = [...addresses.keys()];
+		for (const candidate of programs) {
+			this.contributeOpeningParticipant(reservation, candidate);
+		}
+		const uniqueProgramsByAddress = new Map<string, Manageable<any>>();
+		for (const [candidate, address] of addresses) {
+			const duplicate = uniqueProgramsByAddress.get(address);
+			if (duplicate && duplicate !== candidate) {
+				throw new Error(
+					`Opening graph contains distinct program instances with the same address (${address})`,
+				);
+			}
+			uniqueProgramsByAddress.set(address, candidate);
+		}
+
+		while (true) {
+			const waits = new Set<Promise<T>>();
+			for (const [address, candidate] of uniqueProgramsByAddress) {
+				for (const existing of this._openingReservationsByAddress.get(
+					address,
+				) ?? []) {
+					if (existing === reservation) continue;
+					if (
+						this.canShareOpeningReservation(
+							existing,
+							reservation,
+							address,
+							candidate,
+							parent,
+						)
+					) {
+						this.mergeOpeningReservationGroups(reservation, existing);
+						continue;
+					}
+					if (
+						existing.phase === "rollback" &&
+						!reservation.observedReservations.has(existing)
+					) {
+						throw new Error(
+							`Program at ${address} is finishing initialization rollback cleanup`,
+						);
+					}
+					const existingProgram = existing.programsByAddress.get(address);
+					if (existingProgram && existingProgram !== candidate) {
+						throw new Error(
+							`Program at ${address} is already opening as another instance`,
+						);
+					}
+					waits.add(existing.promise);
+				}
+			}
+			if (waits.size === 0) break;
+			await this.waitForOpeningConflictChange(reservation, waits);
+		}
+
+		for (const [address, candidate] of uniqueProgramsByAddress) {
+			this.assertNoFailedInitialization(address);
+			this.assertNoTerminalOperation(address, candidate, candidate === program);
+			const conflicting = this.findMonitoredPrograms(address).find(
+				(monitored) => monitored !== candidate && !monitored.closed,
+			);
+			if (conflicting) {
+				throw new Error(
+					`Program at ${address} is already open as another live instance`,
+				);
+			}
+		}
+
+		// No await separates the final conflict check from claiming every address.
+		// Terminal admission reads the same map synchronously, so either the open
+		// generation owns the whole graph or cleanup wins and the checks above fail.
+		reservation.programs = new Set(programs);
+		for (const [address, candidate] of uniqueProgramsByAddress) {
+			for (const existing of this._openingReservationsByAddress.get(address) ??
+				[]) {
+				if (existing === reservation) continue;
+				if (
+					this.canShareOpeningReservation(
+						existing,
+						reservation,
+						address,
+						candidate,
+						parent,
+					)
+				) {
+					this.mergeOpeningReservationGroups(reservation, existing);
+				} else {
+					throw new TerminalOperationNotStartedError(
+						`Program at ${address} became reserved by another open generation`,
+					);
+				}
+			}
+			reservation.programsByAddress.set(address, candidate);
+			const reservations =
+				this._openingReservationsByAddress.get(address) ?? new Set();
+			reservations.add(reservation);
+			this._openingReservationsByAddress.set(address, reservations);
+		}
+		for (const [address, candidate] of uniqueProgramsByAddress) {
+			const monitoring = this.monitorTerminalOperations(
+				address,
+				candidate as T,
+			);
+			if (monitoring.newLifecycle) {
+				reservation.provisionalTerminalStates.add(monitoring.state);
+			}
+		}
+		return addresses;
+	}
+
+	private trackOpening<S extends T>(
+		address: string,
+		open: (reservation: OpeningReservation<T>) => Promise<S>,
+		observedReservations: Set<OpeningReservation<T>>,
+	): Promise<S> {
+		let resolve!: (program: S) => void;
+		let reject!: (error: unknown) => void;
+		const openPromise = new Promise<S>((promiseResolve, promiseReject) => {
+			resolve = promiseResolve;
+			reject = promiseReject;
+		});
+		const group: OpeningReservationGroup = {
+			participantReferences: new Map(),
+			reservations: new Set(),
+		};
+		const reservation: OpeningReservation<T> = {
+			promise: openPromise as Promise<T>,
+			phase: "opening",
+			observedReservations,
+			adoptedParents: new Set(),
+			contributedParticipants: new Set(),
+			wakeWaiters: new Set(),
+			group,
+			programsByAddress: new Map(),
+			programs: new Set(),
+			provisionalTerminalStates: new Set(),
+		};
+		group.reservations.add(reservation);
+		this._openingReservations.add(reservation);
+		this._openingReservationsByPromise.set(
+			openPromise as Promise<T>,
+			reservation,
+		);
+		this._openingPromises.set(address, openPromise as Promise<T>);
+		let execution: Promise<S>;
+		try {
+			execution = open(reservation);
+		} catch (error) {
+			execution = Promise.reject(error);
+		}
+		void execution.then(
+			(program) => {
+				this.releaseOpeningReservation(reservation);
+				if (this._openingPromises.get(address) === openPromise) {
+					this._openingPromises.delete(address);
+				}
+				resolve(program);
+			},
+			(error) => {
+				this.releaseOpeningReservation(reservation, true);
+				if (this._openingPromises.get(address) === openPromise) {
+					this._openingPromises.delete(address);
+				}
+				reject(error);
+			},
+		);
+		return openPromise;
 	}
 
 	async open<S extends T>(
 		storeOrAddress: S | Address | string,
 		options: OpenOptions<S> = {},
 	): Promise<S> {
-		const fn = async (): Promise<S> => {
+		if (!this._acceptingOpens) {
+			throw new Error("Program handler is stopping or stopped");
+		}
+		const attachmentParent =
+			options.parent && options.parent !== storeOrAddress
+				? options.parent
+				: undefined;
+		if (attachmentParent) {
+			this.assertParentCanOwnOpen(attachmentParent);
+			this.retainParentAttachment(attachmentParent);
+		}
+		const observedReservations = new Set(
+			[...this._openingReservations].filter(
+				(reservation) => reservation.phase === "opening",
+			),
+		);
+		let completeAdmission!: () => void;
+		const admission = new Promise<void>((resolve) => {
+			completeAdmission = resolve;
+		});
+		this._openAdmissions.add(admission);
+		try {
+			return await this.openAdmitted(
+				storeOrAddress,
+				options,
+				observedReservations,
+			);
+		} finally {
+			if (attachmentParent) {
+				this.releaseParentAttachment(attachmentParent);
+			}
+			this._openAdmissions.delete(admission);
+			completeAdmission();
+		}
+	}
+
+	private async openAdmitted<S extends T>(
+		storeOrAddress: S | Address | string,
+		options: OpenOptions<S> = {},
+		observedReservations: Set<OpeningReservation<T>> = new Set(),
+	): Promise<S> {
+		if (
+			typeof storeOrAddress !== "string" &&
+			this._cleanupResiduals.has(storeOrAddress)
+		) {
+			throw new Error(
+				`Program at ${storeOrAddress.address} has pending cleanup residuals and cannot be reopened before cleanup is retried`,
+			);
+		}
+		if (options.parent && options.parent !== storeOrAddress) {
+			this.assertParentCanOwnOpen(options.parent);
+		}
+		// Parent opens historically share subprograms by default. Explicit parent
+		// strategies still have to retain their reject/replace semantics.
+		const mergeStrategy: ProgramMergeStrategy | undefined = options.parent
+			? (options.existing ?? "reuse")
+			: options.existing;
+		const fn = async (
+			openingReservation?: OpeningReservation<T>,
+		): Promise<S> => {
 			// TODO add locks for store lifecycle, e.g. what happens if we try to open and close a store at the same time?
 			let program = storeOrAddress as S;
 			if (typeof storeOrAddress === "string") {
 				const address = storeOrAddress.toString();
 				try {
-					const existing = this.items.get(address);
+					this.assertNoFailedInitialization(address);
+					this.assertNoTerminalOperation(address);
+					const existing = this.findMonitoredProgram(address);
 					if (existing) {
 						// Be defensive: stale handles shouldn't be returned from the cache.
 						if (existing.closed) {
-							this.items.delete(address);
-						} else if (options?.existing === "reuse") {
-							return existing as S;
-						} else if (options?.existing === "replace") {
-							await existing.close();
+							if (this.items.get(address) === existing) {
+								this.items.delete(address);
+							}
+						} else if (mergeStrategy === "reuse") {
+							return this.attachExistingProgram(
+								address,
+								existing,
+								options.parent,
+							) as S;
+						} else if (mergeStrategy === "replace") {
+							await this.closeForReplacement(address, existing, options.parent);
 						} else {
 							throw new Error(`Program at ${address} is already open`);
 						}
@@ -201,16 +2194,22 @@ export class Handler<T extends Manageable<any>> {
 				}
 
 				if (!program.closed) {
-					const existing = this.items.get(program.address);
+					this.assertNoFailedInitialization(program.address);
+					this.assertNoTerminalOperation(program.address, program);
+					const existing = this.findMonitoredProgram(program.address);
 					if (existing === program) {
-						addParent(existing, options.parent);
-						return program;
+						return this.attachExistingProgram(
+							program.address,
+							existing,
+							options.parent,
+						) as S;
 					} else if (existing) {
 						// we got existing, but it is not the same instance
 						const existing = await this.checkProcessExisting(
 							program.address,
 							program,
-							options?.existing,
+							mergeStrategy,
+							options.parent,
 						);
 
 						if (existing) {
@@ -226,16 +2225,31 @@ export class Handler<T extends Manageable<any>> {
 								`Program at ${program.address} is already opened with a different client`,
 							);
 						}
+						assertCanAttachParent(program);
+						if (!openingReservation) {
+							throw new Error("Missing opening graph reservation");
+						}
+						resolvedDependencyAddresses = await this.prepareOpeningGraph(
+							program,
+							openingReservation,
+							options.parent,
+							resolvedDependencyAddresses,
+						);
 
 						// assume new instance was not added to monitored items, just add it
 						// and return it as we would opened it normally
 
 						await program.save(this.properties.client.services.blocks, {
 							skipOnAddress: false,
-							condition: (address) => {
-								return !this.items.has(address.toString());
+							save: (address) => {
+								return !this.findMonitoredProgram(address, true);
 							},
 						});
+						assertCanAttachParent(program);
+						if (options.parent) {
+							this.assertParentCanOwnOpen(options.parent);
+						}
+						this.monitorTerminalOperations(program.address, program);
 						this.items.set(program.address, program);
 						addParent(program, options.parent);
 						return program;
@@ -243,93 +2257,241 @@ export class Handler<T extends Manageable<any>> {
 				}
 			}
 
+			const existingBeforeSave = await this.checkProcessExisting(
+				program.address,
+				program,
+				mergeStrategy,
+				options.parent,
+			);
+			if (existingBeforeSave) {
+				return existingBeforeSave as S;
+			}
+			if (!openingReservation) {
+				throw new Error("Missing opening graph reservation");
+			}
+			resolvedDependencyAddresses = await this.prepareOpeningGraph(
+				program,
+				openingReservation,
+				options.parent,
+				resolvedDependencyAddresses,
+			);
+
 			logger.trace(`Open database '${program.constructor.name}`);
 
 			// todo make this nicer
 			let address = await program.save(this.properties.client.services.blocks, {
-				skipOnAddress: true,
-				condition: (address) => {
-					return !this.items.has(address.toString());
+				skipOnAddress: !resolvedWithoutSaving,
+				save: (address) => {
+					return !this.findMonitoredProgram(address, true);
 				},
 			});
 
 			const existing = await this.checkProcessExisting(
 				address,
 				program,
-				options?.existing,
+				mergeStrategy,
+				options.parent,
 			);
 			if (existing) {
 				return existing as S;
 			}
 
-			await program.beforeOpen(this.properties.client, {
-				onBeforeOpen: (p) => {
-					if (this.properties.shouldMonitor(program)) {
-						this.items.set(address, program);
+			const rollbackState = {
+				parents: program.parents ? [...program.parents] : undefined,
+				children: program.children ? [...program.children] : undefined,
+				parent: options.parent,
+				parentChildReferences:
+					options.parent?.children?.filter((child) => child === program)
+						.length ?? 0,
+			};
+			this.monitorTerminalOperations(address, program);
+			try {
+				const {
+					onBeforeOpen: userOnBeforeOpen,
+					onOpen: userOnOpen,
+					onClose: userOnClose,
+					onDrop: userOnDrop,
+					...programOptions
+				} = options;
+				if (options.parent) {
+					this.assertParentCanOwnOpen(options.parent);
+				}
+				await this.invokeLifecycleMethod(() =>
+					program.beforeOpen(this.properties.client, {
+						...programOptions,
+						onBeforeOpen: async (p) => {
+							if (this.properties.shouldMonitor(program)) {
+								this.items.set(address, program);
+							}
+							if (userOnBeforeOpen) {
+								this._openLifecycleCallbacks += 1;
+								try {
+									await userOnBeforeOpen(p);
+								} finally {
+									this._openLifecycleCallbacks -= 1;
+								}
+							}
+						},
+						onOpen: async (p) => {
+							if (!userOnOpen) return;
+							this._openLifecycleCallbacks += 1;
+							try {
+								await userOnOpen(p);
+							} finally {
+								this._openLifecycleCallbacks -= 1;
+							}
+						},
+						onClose: async (p) => {
+							if (this.properties.shouldMonitor(p)) {
+								this._onProgamClose(p as T); // TODO types
+							}
+							if (userOnClose) {
+								this._terminalLifecycleCallbacks += 1;
+								try {
+									await userOnClose(p);
+								} finally {
+									this._terminalLifecycleCallbacks -= 1;
+								}
+							}
+						},
+						onDrop: async (p) => {
+							if (this.properties.shouldMonitor(p)) {
+								this._onProgamClose(p);
+							}
+							if (userOnDrop) {
+								this._terminalLifecycleCallbacks += 1;
+								try {
+									await userOnDrop(p);
+								} finally {
+									this._terminalLifecycleCallbacks -= 1;
+								}
+							}
+						},
+						// If the program opens more programs
+						// reset: options.reset,
+					}),
+				);
+				await this.invokeLifecycleMethod(() => program.open(options.args));
+				await this.invokeLifecycleMethod(() => program.afterOpen());
+				return program as S;
+			} catch (error) {
+				try {
+					if (openingReservation) {
+						openingReservation.phase = "rollback";
 					}
-				},
-				onClose: (p) => {
-					if (this.properties.shouldMonitor(p)) {
-						return this._onProgamClose(p as T); // TODO types
+					const rollbackPrograms = new Set<Manageable<any>>([
+						program,
+						...(resolvedDependencyAddresses?.keys() ?? []),
+					]);
+					for (const rollbackProgram of rollbackPrograms) {
+						this._initializationRollbacks.add(rollbackProgram);
 					}
-				},
-				onDrop: (p) => {
-					if (this.properties.shouldMonitor(p)) {
-						return this._onProgamClose(p);
+					try {
+						await this.rollbackFailedInitialization(
+							address,
+							program,
+							rollbackState,
+						);
+					} finally {
+						for (const rollbackProgram of rollbackPrograms) {
+							this._initializationRollbacks.delete(rollbackProgram);
+						}
 					}
-				},
-				...options,
-				// If the program opens more programs
-				// reset: options.reset,
-			});
-			await program.open(options.args);
-			await program.afterOpen();
-			return program as S;
+				} catch (cleanupError) {
+					logger.error(
+						`Failed to roll back program at ${address}: ${String(cleanupError)}`,
+					);
+				}
+				throw error;
+			}
 		};
 
 		// Helper to resolve address from storeOrAddress
+		let resolvedWithoutSaving = false;
+		let resolvedDependencyAddresses: Map<Manageable<any>, string> | undefined;
 		const resolveAddress = async (): Promise<string> => {
 			if (typeof storeOrAddress === "string") {
 				return storeOrAddress;
 			}
-			if (!storeOrAddress.closed) {
-				return storeOrAddress.address;
+			resolvedWithoutSaving = storeOrAddress.closed;
+			resolvedDependencyAddresses =
+				await this.resolveDependencyAddresses(storeOrAddress);
+			const address = resolvedDependencyAddresses.get(storeOrAddress);
+			if (!address) {
+				throw new Error("Failed to resolve the root program address");
 			}
-			return storeOrAddress.save(this.properties.client.services.blocks, {
-				skipOnAddress: true,
-				condition: (addr) => !this.items.has(addr.toString()),
-			});
+			return address;
 		};
 
 		const address = await resolveAddress();
+		await this.waitForOpeningReservations(
+			address,
+			typeof storeOrAddress === "string" ? undefined : storeOrAddress,
+			options.parent,
+			observedReservations,
+		);
+		if (!this._openingPromises.has(address)) {
+			this.assertNoFailedInitialization(address);
+			this.assertNoTerminalOperation(
+				address,
+				typeof storeOrAddress === "string" ? undefined : storeOrAddress,
+			);
+		}
 
 		// For parent opens, check if already opened or in-progress and return early
 		// This prevents race conditions while avoiding deadlocks
 		if (options?.parent) {
-			// Check if there's an open in progress FIRST - wait for it
-			// This must be checked before items because beforeOpen() adds to items
-			// before open() completes
-			const existingPromise = this._openingPromises.get(address);
-			if (existingPromise) {
-				const result = await existingPromise;
-				addParent(result, options.parent);
-				return result as S;
-			}
+			while (true) {
+				// Check if there's an open in progress FIRST - wait for it. This
+				// must precede items because beforeOpen() adds to items before open()
+				// completes.
+				const existingPromise = this._openingPromises.get(address);
+				if (existingPromise) {
+					const requestedProgram =
+						typeof storeOrAddress === "string" ? undefined : storeOrAddress;
+					this.adoptOpeningReservation(existingPromise, options.parent);
+					if (
+						this.isReservedNestedUse(address, requestedProgram, options.parent)
+					) {
+						const existing = await this.processParentExisting<S>(
+							address,
+							requestedProgram,
+							mergeStrategy ?? "reuse",
+							options.parent,
+						);
+						if (existing) return existing;
+					}
+					try {
+						await existingPromise;
+					} catch {
+						// The failed generation has completed its identity-safe rollback.
+						// This admitted request still owns its independent open semantics.
+					}
+					continue;
+				}
 
-			// Check if already fully opened
-			const existing = this.items.get(address);
-			if (existing) {
-				addParent(existing, options.parent);
-				return existing as S;
-			}
+				const existing = await this.processParentExisting<S>(
+					address,
+					typeof storeOrAddress === "string" ? undefined : storeOrAddress,
+					mergeStrategy ?? "reuse",
+					options.parent,
+				);
+				if (existing) {
+					return existing;
+				}
 
-			// Track this open and bypass queue (parent already holds queue)
-			const openPromise = fn();
-			this._openingPromises.set(address, openPromise as Promise<T>);
-			try {
-				return await openPromise;
-			} finally {
-				this._openingPromises.delete(address);
+				// processParentExisting() can await replacement and even its empty
+				// async path yields once. Re-read both gates after that yield. With no
+				// await between this final check and trackOpening(), registering a new
+				// parent generation is an atomic singleflight claim on this JS turn.
+				if (this._openingPromises.has(address) || this.items.has(address)) {
+					continue;
+				}
+				return this.trackOpening(
+					address,
+					(reservation) => fn(reservation),
+					observedReservations,
+				);
 			}
 		}
 
@@ -339,6 +2501,49 @@ export class Handler<T extends Manageable<any>> {
 			queue = new PQueue({ concurrency: 1 });
 			this._openQueue.set(address, queue);
 		}
-		return queue.add(fn) as any as S;
+		return queue.add(async () => {
+			while (true) {
+				// Parent opens bypass the queue to avoid nested-open deadlocks. Wait for
+				// such a generation here before applying this root open's own
+				// reject/reuse/replace semantics. Loop so a newer parent generation that
+				// claimed the address while this waiter resumed is also observed.
+				const existingPromise = this._openingPromises.get(address);
+				if (existingPromise) {
+					try {
+						await existingPromise;
+					} catch {
+						// Re-read Handler state and apply this root request's own strategy
+						// after the failed generation has rolled back.
+					}
+					continue;
+				}
+
+				// Existing live non-replacement operations finish from Handler state
+				// and do not represent a new initialization generation. In particular,
+				// don't make a concurrent parent inherit a duplicate-open rejection. A
+				// stale closed cache entry, however, is evicted before fn() starts the
+				// new generation visible to parent opens.
+				const existing = this.findMonitoredProgram(address);
+				if (existing?.closed) {
+					this.assertNoTerminalOperation(
+						address,
+						typeof storeOrAddress === "string" ? undefined : storeOrAddress,
+					);
+					if (this.items.get(address) === existing) {
+						this.items.delete(address);
+					}
+				} else if (existing && mergeStrategy !== "replace") {
+					return fn();
+				}
+
+				// No await separates the empty gate from registration, so a parent
+				// open cannot claim this address in between.
+				return this.trackOpening(
+					address,
+					(reservation) => fn(reservation),
+					observedReservations,
+				);
+			}
+		}) as any as S;
 	}
 }

--- a/packages/programs/program/program/src/handler.ts
+++ b/packages/programs/program/program/src/handler.ts
@@ -116,7 +116,8 @@ type OpeningReservation<T extends Manageable<any>> = {
 	contributedParticipants: Set<Manageable<any>>;
 	wakeWaiters: Set<() => void>;
 	group: OpeningReservationGroup;
-	programsByAddress: Map<string, Manageable<any>>;
+	rootProgram?: Manageable<any>;
+	programsByAddress: Map<string, Set<Manageable<any>>>;
 	programs: Set<Manageable<any>>;
 	provisionalTerminalStates: Set<TerminalOperationState<T>>;
 };
@@ -954,8 +955,16 @@ export class Handler<T extends Manageable<any>> {
 	private findMonitoredProgram(
 		address: Address,
 		liveOnly = false,
+		preferred?: Manageable<any>,
 	): T | undefined {
 		const matches = this.findMonitoredPrograms(address);
+		if (
+			preferred &&
+			matches.includes(preferred as T) &&
+			(!liveOnly || !preferred.closed)
+		) {
+			return preferred as T;
+		}
 		return liveOnly
 			? matches.find((candidate) => !candidate.closed)
 			: (matches.find((candidate) => !candidate.closed) ?? matches[0]);
@@ -1111,14 +1120,6 @@ export class Handler<T extends Manageable<any>> {
 			) {
 				throw new TerminalOperationNotStartedError(
 					`Program at ${address} cannot terminate while an open generation owns its address`,
-				);
-			}
-			const conflicting = this.findMonitoredPrograms(address).find(
-				(monitored) => monitored !== candidate && !monitored.closed,
-			);
-			if (conflicting) {
-				throw new TerminalOperationNotStartedError(
-					`Program at ${address} cannot terminate while another live instance owns its address`,
 				);
 			}
 			for (const child of candidate.children ?? []) {
@@ -1415,7 +1416,7 @@ export class Handler<T extends Manageable<any>> {
 	): Promise<S | undefined> {
 		this.assertNoFailedInitialization(address);
 		this.assertNoTerminalOperation(address, toOpen);
-		const prev = this.findMonitoredProgram(address);
+		const prev = this.findMonitoredProgram(address, false, toOpen);
 		if (prev?.closed) {
 			if (this.items.get(address) === prev) {
 				this.items.delete(address);
@@ -1446,7 +1447,11 @@ export class Handler<T extends Manageable<any>> {
 	): Promise<S | undefined> {
 		this.assertNoFailedInitialization(address);
 		this.assertNoTerminalOperation(address, requestedProgram);
-		const existing = this.findMonitoredProgram(address);
+		const existing = this.findMonitoredProgram(
+			address,
+			false,
+			requestedProgram,
+		);
 		if (existing?.closed) {
 			if (this.items.get(address) === existing) {
 				this.items.delete(address);
@@ -1770,14 +1775,40 @@ export class Handler<T extends Manageable<any>> {
 		existing: OpeningReservation<T>,
 		reservation: OpeningReservation<T>,
 		address: string,
-		candidate: Manageable<any>,
+		candidates: Set<Manageable<any>>,
 		parent?: Manageable<any>,
 	): boolean {
-		if (existing.programsByAddress.get(address) !== candidate) return false;
+		const existingCandidates = existing.programsByAddress.get(address);
+		if (
+			!existingCandidates ||
+			[...candidates].some((candidate) => !existingCandidates.has(candidate))
+		) {
+			return false;
+		}
 		if (existing.group === reservation.group) return true;
 		if (parent && this.reservationContains(existing, parent)) return true;
 		return [...reservation.adoptedParents].some((adoptedParent) =>
 			this.reservationContains(existing, adoptedParent),
+		);
+	}
+
+	private canOpenAlongsideReservation(
+		existing: OpeningReservation<T>,
+		address: string,
+		candidates: Set<Manageable<any>>,
+		rootProgram: Manageable<any>,
+	): boolean {
+		const existingCandidates = existing.programsByAddress.get(address);
+		if (!existingCandidates) return false;
+		if (
+			[...candidates].some((candidate) => existingCandidates.has(candidate))
+		) {
+			return false;
+		}
+		return (
+			!candidates.has(rootProgram) &&
+			(existing.rootProgram == null ||
+				!existingCandidates.has(existing.rootProgram))
 		);
 	}
 
@@ -1860,7 +1891,7 @@ export class Handler<T extends Manageable<any>> {
 			(reservation) =>
 				this.reservationContains(reservation, parent) &&
 				(program == null ||
-					reservation.programsByAddress.get(address) === program),
+					reservation.programsByAddress.get(address)?.has(program) === true),
 		);
 	}
 
@@ -1879,7 +1910,7 @@ export class Handler<T extends Manageable<any>> {
 					parent &&
 					this.reservationContains(reservation, parent) &&
 					(program == null ||
-						reservation.programsByAddress.get(address) === program)
+						reservation.programsByAddress.get(address)?.has(program) === true)
 				) {
 					continue;
 				}
@@ -1906,24 +1937,21 @@ export class Handler<T extends Manageable<any>> {
 	): Promise<Map<Manageable<any>, string>> {
 		const addresses =
 			resolvedAddresses ?? (await this.resolveDependencyAddresses(program));
+		reservation.rootProgram = program;
 		const programs = [...addresses.keys()];
 		for (const candidate of programs) {
 			this.contributeOpeningParticipant(reservation, candidate);
 		}
-		const uniqueProgramsByAddress = new Map<string, Manageable<any>>();
+		const programsByAddress = new Map<string, Set<Manageable<any>>>();
 		for (const [candidate, address] of addresses) {
-			const duplicate = uniqueProgramsByAddress.get(address);
-			if (duplicate && duplicate !== candidate) {
-				throw new Error(
-					`Opening graph contains distinct program instances with the same address (${address})`,
-				);
-			}
-			uniqueProgramsByAddress.set(address, candidate);
+			const candidates = programsByAddress.get(address) ?? new Set();
+			candidates.add(candidate);
+			programsByAddress.set(address, candidates);
 		}
 
 		while (true) {
 			const waits = new Set<Promise<T>>();
-			for (const [address, candidate] of uniqueProgramsByAddress) {
+			for (const [address, candidates] of programsByAddress) {
 				for (const existing of this._openingReservationsByAddress.get(
 					address,
 				) ?? []) {
@@ -1933,7 +1961,7 @@ export class Handler<T extends Manageable<any>> {
 							existing,
 							reservation,
 							address,
-							candidate,
+							candidates,
 							parent,
 						)
 					) {
@@ -1948,8 +1976,23 @@ export class Handler<T extends Manageable<any>> {
 							`Program at ${address} is finishing initialization rollback cleanup`,
 						);
 					}
-					const existingProgram = existing.programsByAddress.get(address);
-					if (existingProgram && existingProgram !== candidate) {
+					if (
+						this.canOpenAlongsideReservation(
+							existing,
+							address,
+							candidates,
+							program,
+						)
+					) {
+						continue;
+					}
+					const existingPrograms = existing.programsByAddress.get(address);
+					if (
+						existingPrograms &&
+						![...candidates].some((candidate) =>
+							existingPrograms.has(candidate),
+						)
+					) {
 						throw new Error(
 							`Program at ${address} is already opening as another instance`,
 						);
@@ -1961,15 +2004,13 @@ export class Handler<T extends Manageable<any>> {
 			await this.waitForOpeningConflictChange(reservation, waits);
 		}
 
-		for (const [address, candidate] of uniqueProgramsByAddress) {
+		for (const [address, candidates] of programsByAddress) {
 			this.assertNoFailedInitialization(address);
-			this.assertNoTerminalOperation(address, candidate, candidate === program);
-			const conflicting = this.findMonitoredPrograms(address).find(
-				(monitored) => monitored !== candidate && !monitored.closed,
-			);
-			if (conflicting) {
-				throw new Error(
-					`Program at ${address} is already open as another live instance`,
+			for (const candidate of candidates) {
+				this.assertNoTerminalOperation(
+					address,
+					candidate,
+					candidate === program,
 				);
 			}
 		}
@@ -1978,7 +2019,7 @@ export class Handler<T extends Manageable<any>> {
 		// Terminal admission reads the same map synchronously, so either the open
 		// generation owns the whole graph or cleanup wins and the checks above fail.
 		reservation.programs = new Set(programs);
-		for (const [address, candidate] of uniqueProgramsByAddress) {
+		for (const [address, candidates] of programsByAddress) {
 			for (const existing of this._openingReservationsByAddress.get(address) ??
 				[]) {
 				if (existing === reservation) continue;
@@ -1987,30 +2028,41 @@ export class Handler<T extends Manageable<any>> {
 						existing,
 						reservation,
 						address,
-						candidate,
+						candidates,
 						parent,
 					)
 				) {
 					this.mergeOpeningReservationGroups(reservation, existing);
+				} else if (
+					this.canOpenAlongsideReservation(
+						existing,
+						address,
+						candidates,
+						program,
+					)
+				) {
+					continue;
 				} else {
 					throw new TerminalOperationNotStartedError(
 						`Program at ${address} became reserved by another open generation`,
 					);
 				}
 			}
-			reservation.programsByAddress.set(address, candidate);
+			reservation.programsByAddress.set(address, new Set(candidates));
 			const reservations =
 				this._openingReservationsByAddress.get(address) ?? new Set();
 			reservations.add(reservation);
 			this._openingReservationsByAddress.set(address, reservations);
 		}
-		for (const [address, candidate] of uniqueProgramsByAddress) {
-			const monitoring = this.monitorTerminalOperations(
-				address,
-				candidate as T,
-			);
-			if (monitoring.newLifecycle) {
-				reservation.provisionalTerminalStates.add(monitoring.state);
+		for (const [address, candidates] of programsByAddress) {
+			for (const candidate of candidates) {
+				const monitoring = this.monitorTerminalOperations(
+					address,
+					candidate as T,
+				);
+				if (monitoring.newLifecycle) {
+					reservation.provisionalTerminalStates.add(monitoring.state);
+				}
 			}
 		}
 		return addresses;

--- a/packages/programs/program/program/src/index.ts
+++ b/packages/programs/program/program/src/index.ts
@@ -1,6 +1,7 @@
 export {
 	type ProgramInitializationOptions,
 	type OpenOptions,
+	TerminalOperationNotStartedError,
 } from "./handler.js";
 export * from "./client.js";
 export * from "./program.js";

--- a/packages/programs/program/program/src/program.ts
+++ b/packages/programs/program/program/src/program.ts
@@ -690,6 +690,7 @@ export abstract class Program<
 			checkpoint: number;
 			startedClosed: boolean;
 			ownerReferencesBefore: number;
+			inverseOwnerReferencesBefore: number;
 			skipped: boolean;
 			cleanupLease?: object;
 		}[] = [];
@@ -707,6 +708,7 @@ export abstract class Program<
 				checkpoint: 0,
 				startedClosed: false,
 				ownerReferencesBefore: 0,
+				inverseOwnerReferencesBefore: 0,
 				skipped: false,
 				cleanupLease: previous?.cleanupLease,
 			};
@@ -715,6 +717,8 @@ export abstract class Program<
 				attempt.startedClosed = child.closed;
 				attempt.ownerReferencesBefore =
 					child.parents?.filter((parent) => parent === this).length ?? 0;
+				attempt.inverseOwnerReferencesBefore =
+					this.children?.filter((candidate) => candidate === child).length ?? 0;
 				if (
 					child.closed &&
 					(attempt.operation === "close" || retryingTerminalAttempt) &&
@@ -731,13 +735,41 @@ export abstract class Program<
 					: invoke());
 				const ownerReferencesAfter =
 					child.parents?.filter((parent) => parent === this).length ?? 0;
+				let inverseOwnerReferencesAfter =
+					this.children?.filter((candidate) => candidate === child).length ?? 0;
+				// A child override must not be able to hide a retained owner by deleting
+				// only the parent's inverse edge. Restore the minimum graph reachability
+				// required by the child's live owner references before validating progress.
+				while (inverseOwnerReferencesAfter < ownerReferencesAfter) {
+					this.children.push(child);
+					inverseOwnerReferencesAfter += 1;
+				}
+				// A successful retry may consume a previously committed parent release
+				// without changing the child's owner list again. Reconcile at most the one
+				// stale inverse edge represented by this occurrence before deciding whether
+				// the call made progress.
+				if (inverseOwnerReferencesAfter > ownerReferencesAfter) {
+					const childIndex = this.children.indexOf(child);
+					if (childIndex !== -1) {
+						this.children.splice(childIndex, 1);
+						inverseOwnerReferencesAfter -= 1;
+					}
+				}
 				const committedRelease =
 					(previous?.commit?.releasedParentReferences ?? 0) > 0;
+				const releasedOwnerReference =
+					ownerReferencesAfter < attempt.ownerReferencesBefore;
+				const repairedStaleInverseReference =
+					attempt.inverseOwnerReferencesBefore >
+						attempt.ownerReferencesBefore &&
+					ownerReferencesAfter === attempt.ownerReferencesBefore &&
+					inverseOwnerReferencesAfter < attempt.inverseOwnerReferencesBefore;
 				if (
 					!attempt.startedClosed &&
 					!child.closed &&
 					!committedRelease &&
-					ownerReferencesAfter >= attempt.ownerReferencesBefore
+					!releasedOwnerReference &&
+					!repairedStaleInverseReference
 				) {
 					throw new Error(
 						`Child program at ${child.address} did not release parent ownership during ${attempt.operation}`,

--- a/packages/programs/program/program/src/program.ts
+++ b/packages/programs/program/program/src/program.ts
@@ -17,6 +17,13 @@ import {
 	Handler,
 	type Manageable,
 	type ProgramInitializationOptions,
+	TERMINAL_BASE_CHECKPOINT,
+	TERMINAL_BASE_COMMIT,
+	TERMINAL_BASE_RETRY,
+	TERMINAL_OUTER_CLEANUP_RELEASE,
+	TERMINAL_OUTER_CLEANUP_RETAIN,
+	type TerminalBaseCommit,
+	TerminalOperationNotStartedError,
 	addParent,
 } from "./handler.js";
 import { getValuesWithType } from "./utils.js";
@@ -77,6 +84,7 @@ class ProgramHandler extends Handler<Program> {
 			identity: properties.client.identity,
 			client: properties.client,
 			shouldMonitor: (p) => p instanceof Program,
+			getDependencies: (program) => program.allPrograms,
 			load: Program.load,
 		});
 	}
@@ -86,6 +94,32 @@ export { ProgramHandler };
 type ExtractArgs<T> = T extends Program<infer Args> ? Args : never;
 
 const PROGRAM_INSTANCE_SYMBOL = Symbol.for("@peerbit/program/Program");
+
+type TerminalOperation = "close" | "drop";
+type TerminalCall = {
+	type: TerminalOperation;
+	from?: Program;
+	terminal: boolean;
+	promise: Promise<boolean>;
+};
+type FailedTerminalChild = {
+	program: Program;
+	operation: TerminalOperation;
+	commit?: TerminalBaseCommit;
+	cleanupLease?: object;
+};
+type TerminalRetryContext = {
+	commit: TerminalBaseCommit;
+	consumed: boolean;
+	promise: Promise<boolean>;
+};
+type PendingTerminalTail = {
+	type: TerminalOperation;
+	from?: Program;
+	hadParentReference: boolean;
+	eventEmitted: boolean;
+	callbackCompleted: boolean;
+};
 
 @variant(0)
 export abstract class Program<
@@ -132,9 +166,30 @@ export abstract class Program<
 
 	private _node: ProgramClient;
 	private _allPrograms: Program[] | undefined;
+	private _acceptsParentAttachments = true;
 
 	private _events: TypedEventTarget<ProgramEvents>;
 	private _closed: boolean;
+	private _terminalCalls: TerminalCall[] | undefined;
+	private _dropDeletePending: boolean | undefined;
+	private _failedTerminalChildren: FailedTerminalChild[] | undefined;
+	private _emittedTerminalEvents: Set<TerminalOperation> | undefined;
+	private _terminalBaseCommitVersion: number | undefined;
+	private _terminalBaseCommitEpoch: number | undefined;
+	private _terminalBaseCommitsByParent:
+		| WeakMap<
+				Manageable<any>,
+				Partial<Record<TerminalOperation, TerminalBaseCommit>>
+		  >
+		| undefined;
+	private _rootTerminalBaseCommits:
+		| Partial<Record<TerminalOperation, TerminalBaseCommit>>
+		| undefined;
+	private _terminalRetryContexts: TerminalRetryContext[] | undefined;
+	private _pendingTerminalTail: PendingTerminalTail | undefined;
+	private _terminalLifecycleCallbackRunning = false;
+	private _terminalOuterCleanupLeases: Set<object> | undefined;
+	private _pendingInverseParentReleases: Map<Program, number> | undefined;
 
 	parents: (Program<any> | undefined)[];
 	children: Program<Args>[];
@@ -198,6 +253,34 @@ export abstract class Program<
 		this._closed = closed;
 	}
 
+	get acceptsParentAttachments(): boolean {
+		// Program clones are borsh-created without running class field initializers.
+		return (
+			this._acceptsParentAttachments !== false &&
+			(this._terminalOuterCleanupLeases?.size ?? 0) === 0
+		);
+	}
+
+	get pendingTerminalOperation(): TerminalOperation | undefined {
+		return (
+			this._pendingTerminalTail?.type ||
+			(this._dropDeletePending ? "drop" : undefined)
+		);
+	}
+
+	get terminalLifecycleCallbackRunning(): boolean {
+		return this._terminalLifecycleCallbackRunning;
+	}
+
+	/**
+	 * Fence Handler reuse while a subclass performs irreversible terminal work
+	 * before delegating to Program.end(). A subsequent successful reopen clears
+	 * the fence in beforeOpen().
+	 */
+	protected preventParentAttachments(): void {
+		this._acceptsParentAttachments = false;
+	}
+
 	get node(): ProgramClient {
 		return this._node;
 	}
@@ -212,6 +295,25 @@ export abstract class Program<
 		node: ProgramClient,
 		options?: ProgramInitializationOptions<Args, this>,
 	) {
+		if ((this._terminalOuterCleanupLeases?.size ?? 0) > 0) {
+			throw new Error(
+				"Program terminal cleanup must finish before the program can reopen",
+			);
+		}
+		if (this.closed) {
+			if (this._pendingTerminalTail || this._dropDeletePending) {
+				throw new Error(
+					"Program terminal cleanup must finish before the program can reopen",
+				);
+			}
+			this._terminalBaseCommitEpoch = (this._terminalBaseCommitEpoch ?? 0) + 1;
+			this._acceptsParentAttachments = true;
+			this._failedTerminalChildren = undefined;
+			this._emittedTerminalEvents?.clear();
+			this._emittedTerminalEvents = undefined;
+			this._terminalBaseCommitsByParent = undefined;
+			this._rootTerminalBaseCommits = undefined;
+		}
 		// check that a  discriminator exist
 		const schema = getSchema(this.constructor);
 		if (!schema || typeof schema.variant !== "string") {
@@ -413,43 +515,416 @@ export abstract class Program<
 		e: CustomEvent<UnsubcriptionEvent>,
 	) => void;
 
-	private async processEnd(type: "drop" | "close") {
-		if (!this.closed) {
-			this.emitEvent(new CustomEvent(type, { detail: this }), true);
-			if (type === "close") {
-				this._eventOptions?.onClose?.(this);
-			} else if (type === "drop") {
-				this._eventOptions?.onDrop?.(this);
-			} else {
-				throw new Error("Unsupported event type: " + type);
-			}
+	[TERMINAL_BASE_CHECKPOINT](): number {
+		return this._terminalBaseCommitVersion ?? 0;
+	}
 
-			const promises: Promise<void | boolean>[] = [];
+	[TERMINAL_OUTER_CLEANUP_RETAIN](): object {
+		const lease = {};
+		const leases =
+			this._terminalOuterCleanupLeases ||
+			(this._terminalOuterCleanupLeases = new Set());
+		leases.add(lease);
+		return lease;
+	}
 
-			if (this.children) {
-				for (const program of this.children) {
-					if (program.closed) {
-						if (type === "close") {
-							continue;
-						}
-					}
-					promises.push(program[type](this as Program)); // TODO types
-				}
-				this.children = [];
-			}
-			await Promise.all(promises);
-
-			this._clear();
-			this.closed = true;
-			return true;
-		} else {
-			this._clear();
-			return true;
+	[TERMINAL_OUTER_CLEANUP_RELEASE](lease: object): void {
+		this._terminalOuterCleanupLeases?.delete(lease);
+		if (this._terminalOuterCleanupLeases?.size === 0) {
+			this._terminalOuterCleanupLeases = undefined;
+			this.reconcilePendingInverseParentReleases();
 		}
 	}
 
-	private async end(type: "drop" | "close", from?: Program): Promise<boolean> {
+	[TERMINAL_BASE_COMMIT](
+		afterVersion: number,
+		type: TerminalOperation,
+		from?: Manageable<any>,
+	): TerminalBaseCommit | undefined {
+		const commit = from
+			? this._terminalBaseCommitsByParent?.get(from)?.[type]
+			: this._rootTerminalBaseCommits?.[type];
+		return commit && commit.version > afterVersion ? commit : undefined;
+	}
+
+	async [TERMINAL_BASE_RETRY](
+		commit: TerminalBaseCommit,
+		operation: () => Promise<boolean>,
+	): Promise<boolean> {
+		if (commit.epoch !== (this._terminalBaseCommitEpoch ?? 0)) {
+			throw new Error(
+				"Program terminal cleanup belongs to a stale open lifecycle",
+			);
+		}
+		const context: TerminalRetryContext = {
+			commit,
+			consumed: false,
+			promise: Promise.resolve(commit.result),
+		};
+		const contexts =
+			this._terminalRetryContexts || (this._terminalRetryContexts = []);
+		contexts.push(context);
+		try {
+			return await operation();
+		} finally {
+			const index = contexts.indexOf(context);
+			if (index !== -1) contexts.splice(index, 1);
+			if (contexts.length === 0) this._terminalRetryContexts = undefined;
+		}
+	}
+
+	private consumeTerminalRetry(
+		type: TerminalOperation,
+		from?: Program,
+	): Promise<boolean> | undefined {
+		const context = this._terminalRetryContexts?.find(
+			(candidate) =>
+				!candidate.consumed &&
+				candidate.commit.type === type &&
+				candidate.commit.from === from,
+		);
+		if (!context) return undefined;
+		context.consumed = true;
+		return context.promise;
+	}
+
+	private recordTerminalBaseCommit(
+		type: TerminalOperation,
+		from: Program | undefined,
+		result: boolean,
+		releasedParentReferences: number,
+	): void {
+		const version = (this._terminalBaseCommitVersion ?? 0) + 1;
+		this._terminalBaseCommitVersion = version;
+		const commit = {
+			epoch: this._terminalBaseCommitEpoch ?? 0,
+			version,
+			type,
+			from,
+			result,
+			releasedParentReferences,
+		};
+		if (from) {
+			const commits =
+				this._terminalBaseCommitsByParent?.get(from) ??
+				({} as Partial<Record<TerminalOperation, TerminalBaseCommit>>);
+			commits[type] = commit;
+			const commitsByParent =
+				this._terminalBaseCommitsByParent ||
+				(this._terminalBaseCommitsByParent = new WeakMap());
+			commitsByParent.set(from, commits);
+		} else {
+			const commits =
+				this._rootTerminalBaseCommits || (this._rootTerminalBaseCommits = {});
+			commits[type] = commit;
+		}
+	}
+
+	private retainInverseParentRelease(from: Program | undefined): void {
+		if (!from) return;
+		const pending =
+			this._pendingInverseParentReleases ||
+			(this._pendingInverseParentReleases = new Map());
+		pending.set(from, (pending.get(from) ?? 0) + 1);
+	}
+
+	private reconcilePendingInverseParentReleases(from?: Program): void {
+		const pending = this._pendingInverseParentReleases;
+		if (!pending) return;
+		const parents = from ? [from] : [...pending.keys()];
+		for (const parent of parents) {
+			let releasedReferences = pending.get(parent) ?? 0;
+			const retainedReferences =
+				this.parents?.filter((candidate) => candidate === parent).length ?? 0;
+			while (releasedReferences > 0) {
+				const inverseReferences =
+					parent.children?.filter((candidate) => candidate === this).length ??
+					0;
+				if (inverseReferences > retainedReferences) {
+					const childIndex = parent.children.indexOf(this);
+					if (childIndex !== -1) parent.children.splice(childIndex, 1);
+				}
+				releasedReferences -= 1;
+			}
+			pending.delete(parent);
+		}
+		if (pending.size === 0) this._pendingInverseParentReleases = undefined;
+	}
+
+	private isOutermostBaseTerminalOperation(type: TerminalOperation): boolean {
+		const current = type === "close" ? this.close : this.drop;
+		const base =
+			type === "close" ? Program.prototype.close : Program.prototype.drop;
+		return current === base;
+	}
+
+	private async processEnd(
+		type: TerminalOperation,
+		from: Program | undefined,
+		hadParentReference: boolean,
+	) {
 		if (this.closed) {
+			this._clear();
+			return true;
+		}
+		// Lifecycle events retain their historical attempt semantics and parent-first
+		// ordering. A failed attempt emits once; retries in the same open epoch do not
+		// emit a duplicate event. The awaited onClose/onDrop callback below remains a
+		// committed-tail callback and only runs after children have drained.
+		const emittedTerminalEvents =
+			this._emittedTerminalEvents ||
+			(this._emittedTerminalEvents = new Set<TerminalOperation>());
+		const retryingTerminalAttempt = emittedTerminalEvents.has(type);
+		if (!emittedTerminalEvents.has(type)) {
+			emittedTerminalEvents.add(type);
+			this.emitEvent(new CustomEvent(type, { detail: this }), true);
+		}
+
+		const children = [...(this.children ?? [])];
+		const previousFailures = [...(this._failedTerminalChildren ?? [])];
+		const claimedFailures = new Set<FailedTerminalChild>();
+		const attempts: {
+			child: Program;
+			operation: TerminalOperation;
+			previous?: FailedTerminalChild;
+			checkpoint: number;
+			startedClosed: boolean;
+			ownerReferencesBefore: number;
+			skipped: boolean;
+			cleanupLease?: object;
+		}[] = [];
+		const tailsByChild = new Map<Program, Promise<boolean>>();
+		const childPromises = children.map((child) => {
+			const previous = previousFailures.find(
+				(failure) => failure.program === child && !claimedFailures.has(failure),
+			);
+			if (previous) claimedFailures.add(previous);
+			const attempt = {
+				child,
+				operation:
+					previous?.operation ?? child.pendingTerminalOperation ?? type,
+				previous,
+				checkpoint: 0,
+				startedClosed: false,
+				ownerReferencesBefore: 0,
+				skipped: false,
+				cleanupLease: previous?.cleanupLease,
+			};
+			attempts.push(attempt);
+			const run = async () => {
+				attempt.startedClosed = child.closed;
+				attempt.ownerReferencesBefore =
+					child.parents?.filter((parent) => parent === this).length ?? 0;
+				if (
+					child.closed &&
+					(attempt.operation === "close" || retryingTerminalAttempt) &&
+					!previous &&
+					!child.pendingTerminalOperation
+				) {
+					return true;
+				}
+				attempt.cleanupLease ??= child[TERMINAL_OUTER_CLEANUP_RETAIN]();
+				attempt.checkpoint = child[TERMINAL_BASE_CHECKPOINT]();
+				const invoke = () => child[attempt.operation](this as Program);
+				const result = await (previous?.commit
+					? child[TERMINAL_BASE_RETRY](previous.commit, invoke)
+					: invoke());
+				const ownerReferencesAfter =
+					child.parents?.filter((parent) => parent === this).length ?? 0;
+				const committedRelease =
+					(previous?.commit?.releasedParentReferences ?? 0) > 0;
+				if (
+					!attempt.startedClosed &&
+					!child.closed &&
+					!committedRelease &&
+					ownerReferencesAfter >= attempt.ownerReferencesBefore
+				) {
+					throw new Error(
+						`Child program at ${child.address} did not release parent ownership during ${attempt.operation}`,
+					);
+				}
+				return result;
+			};
+			const predecessor = tailsByChild.get(child);
+			const promise = predecessor
+				? predecessor.then(run, (error) => {
+						// Duplicate appearances represent distinct ownership references.
+						// Do not spend the next reference while cleanup for the preceding
+						// release is unresolved; retain it for the recovery attempt.
+						attempt.skipped = true;
+						throw error;
+					})
+				: run();
+			tailsByChild.set(child, promise);
+			return promise;
+		});
+		const results = await Promise.allSettled(childPromises);
+		const failedChildren: FailedTerminalChild[] = [];
+		let firstChildError: unknown;
+		for (let index = 0; index < results.length; index++) {
+			const result = results[index]!;
+			const attempt = attempts[index]!;
+			const child = attempt.child;
+			if (result.status === "rejected") {
+				if (attempt.skipped) {
+					if (attempt.previous) failedChildren.push(attempt.previous);
+					firstChildError ??= result.reason;
+					continue;
+				}
+				if (!attempt.startedClosed || attempt.previous) {
+					const ownerReferencesAfter =
+						child.parents?.filter((parent) => parent === this).length ?? 0;
+					const commit =
+						attempt.previous?.commit ||
+						child[TERMINAL_BASE_COMMIT](
+							attempt.checkpoint,
+							attempt.operation,
+							this,
+						);
+					const baseProgressed =
+						commit != null ||
+						child.closed !== attempt.startedClosed ||
+						ownerReferencesAfter !== attempt.ownerReferencesBefore;
+					const retainCleanupLease =
+						baseProgressed ||
+						attempt.previous != null ||
+						!(result.reason instanceof TerminalOperationNotStartedError);
+					const cleanupLease = retainCleanupLease
+						? attempt.cleanupLease
+						: undefined;
+					if (!retainCleanupLease && attempt.cleanupLease) {
+						child[TERMINAL_OUTER_CLEANUP_RELEASE](attempt.cleanupLease);
+						attempt.cleanupLease = undefined;
+					}
+					failedChildren.push({
+						program: child,
+						operation:
+							attempt.operation === "drop" && !baseProgressed
+								? "drop"
+								: commit || child.closed
+									? attempt.operation
+									: "close",
+						commit,
+						cleanupLease,
+					});
+				} else if (attempt.cleanupLease) {
+					child[TERMINAL_OUTER_CLEANUP_RELEASE](attempt.cleanupLease);
+					attempt.cleanupLease = undefined;
+				}
+				firstChildError ??= result.reason;
+				continue;
+			}
+			if (attempt.cleanupLease) {
+				child[TERMINAL_OUTER_CLEANUP_RELEASE](attempt.cleanupLease);
+				attempt.cleanupLease = undefined;
+			}
+			// A managed child's Handler may already have reconciled the inverse edge
+			// from its committed base release. Nested unmanaged children rely on this
+			// parent instead. Remove at most the one excess edge represented by this
+			// successful occurrence so both paths remain count-correct.
+			const childReferences =
+				child.parents?.filter((parent) => parent === this).length ?? 0;
+			const childEdges =
+				this.children?.filter((candidate) => candidate === child).length ?? 0;
+			if (childEdges > childReferences) {
+				const childIndex = this.children.indexOf(child);
+				if (childIndex !== -1) this.children.splice(childIndex, 1);
+			}
+		}
+		for (const previous of previousFailures) {
+			if (!claimedFailures.has(previous) && previous.cleanupLease) {
+				previous.program[TERMINAL_OUTER_CLEANUP_RELEASE](previous.cleanupLease);
+				previous.cleanupLease = undefined;
+			}
+		}
+		this._failedTerminalChildren =
+			failedChildren.length > 0 ? failedChildren : undefined;
+		if (firstChildError !== undefined) throw firstChildError;
+
+		this._clear();
+		this.closed = true;
+		this._pendingTerminalTail = {
+			type,
+			from,
+			hadParentReference,
+			eventEmitted: true,
+			callbackCompleted: false,
+		};
+		await this.finishTerminalTail();
+		return true;
+	}
+
+	private async finishTerminalTail(): Promise<void> {
+		const tail = this._pendingTerminalTail;
+		if (!tail) return;
+		if (!tail.eventEmitted) {
+			tail.eventEmitted = true;
+			const emittedTerminalEvents =
+				this._emittedTerminalEvents ||
+				(this._emittedTerminalEvents = new Set<TerminalOperation>());
+			if (!emittedTerminalEvents.has(tail.type)) {
+				emittedTerminalEvents.add(tail.type);
+				this.emitEvent(new CustomEvent(tail.type, { detail: this }), true);
+			}
+		}
+		if (!tail.callbackCompleted) {
+			const callback =
+				tail.type === "close"
+					? this._eventOptions?.onClose
+					: this._eventOptions?.onDrop;
+			this._terminalLifecycleCallbackRunning = true;
+			try {
+				await callback?.(this);
+			} finally {
+				this._terminalLifecycleCallbackRunning = false;
+			}
+			tail.callbackCompleted = true;
+		}
+
+		this.node?.services.pubsub.removeEventListener(
+			"subscribe",
+			this._subscriptionEventListener,
+		);
+		this.node?.services.pubsub.removeEventListener(
+			"unsubscribe",
+			this._unsubscriptionEventListener,
+		);
+		this._emittedEventsFor?.clear();
+		this._emittedEventsFor = undefined;
+		this._peerTopicsByHash?.clear();
+		this._peerTopicsByHash = undefined;
+		this._seedPeerTopicsFromSubscribers = undefined;
+		this._eventOptions = undefined;
+		if (tail.hadParentReference) {
+			const parentIndex =
+				this.parents?.findIndex((parent) => parent === tail.from) ?? -1;
+			if (parentIndex !== -1) {
+				this.parents.splice(parentIndex, 1);
+				this.retainInverseParentRelease(tail.from);
+			}
+		}
+		this._pendingTerminalTail = undefined;
+	}
+
+	private async end(type: TerminalOperation, from?: Program): Promise<boolean> {
+		if (this.closed) {
+			if (
+				this._pendingTerminalTail &&
+				this._pendingTerminalTail.type !== type
+			) {
+				throw new Error(
+					`Program has pending ${this._pendingTerminalTail.type} cleanup; retry it before ${type}`,
+				);
+			}
+			if (this._pendingTerminalTail) {
+				await this.finishTerminalTail();
+				return true;
+			}
+			if (this._dropDeletePending && type === "close") {
+				throw new Error(
+					"Program has pending drop deletion; retry drop before close",
+				);
+			}
 			if (type === "drop") {
 				throw new ClosedError("Program is closed, can not drop");
 			}
@@ -465,48 +940,166 @@ export abstract class Program<
 					close = true;
 				} else {
 					this.parents.splice(parentIdx, 1);
+					this.retainInverseParentRelease(from);
 					close = false;
 				}
 			} else if (from) {
-				throw new Error("Could not find from in parents");
+				throw new TerminalOperationNotStartedError(
+					"Could not find from in parents",
+				);
 			}
 		}
 
-		const end = close && (await this.processEnd(type));
-		if (end) {
-			this.node?.services.pubsub.removeEventListener(
-				"subscribe",
-				this._subscriptionEventListener,
-			);
-			this.node?.services.pubsub.removeEventListener(
-				"unsubscribe",
-				this._unsubscriptionEventListener,
-			);
-			this._emittedEventsFor?.clear();
+		if (close) {
+			// Establish the reuse fence synchronously once this call owns terminal
+			// shutdown. Non-terminal parent releases remain attachable.
+			this.preventParentAttachments();
+		}
+		return close && (await this.processEnd(type, from, parentIdx !== -1));
+	}
+	private performTerminalOperation(
+		type: TerminalOperation,
+		from?: Program,
+	): Promise<boolean> {
+		if (type === "close") {
 			this._emittedEventsFor = undefined;
-			this._peerTopicsByHash?.clear();
-			this._peerTopicsByHash = undefined;
-			this._seedPeerTopicsFromSubscribers = undefined;
-
-			this._eventOptions = undefined;
-
-			if (parentIdx !== -1) {
-				this.parents.splice(parentIdx, 1); // We splice this here because this._end depends on this parent to exist
-			}
+			return this.end("close", from);
 		}
-		return end;
-	}
-	async close(from?: Program): Promise<boolean> {
-		this._emittedEventsFor = undefined;
-		return this.end("close", from);
+		return this.performDrop(from);
 	}
 
-	async drop(from?: Program): Promise<boolean> {
+	private async performDrop(from?: Program): Promise<boolean> {
+		if (this.closed && this._dropDeletePending) {
+			await this.delete();
+			this._dropDeletePending = false;
+			return true;
+		}
+
 		const dropped = await this.end("drop", from);
 		if (dropped) {
+			// Remember the committed terminal transition before deletion. If rm()
+			// fails, a later drop retry must resume here instead of rejecting merely
+			// because Program.end() already made `closed` observable.
+			this._dropDeletePending = true;
 			await this.delete();
+			this._dropDeletePending = false;
 		}
 		return dropped;
+	}
+
+	private terminalOperation(
+		type: TerminalOperation,
+		from?: Program,
+	): Promise<boolean> {
+		if (this._terminalLifecycleCallbackRunning) {
+			return Promise.reject(
+				new TerminalOperationNotStartedError(
+					"Program lifecycle callbacks cannot wait for their own terminal operation",
+				),
+			);
+		}
+		const retry = this.consumeTerminalRetry(type, from);
+		if (retry) return retry;
+		const calls = this._terminalCalls || (this._terminalCalls = []);
+		const matching = calls.find(
+			(call) => call.type === type && call.from === from && call.terminal,
+		);
+		if (matching) {
+			return matching.promise;
+		}
+
+		if (type === "close") {
+			// Drop is the stronger terminal operation. A close admitted for the same
+			// owner while drop is pending observes that exact operation and promise.
+			const dropping = calls.find(
+				(call) => call.type === "drop" && call.from === from && call.terminal,
+			);
+			if (dropping) {
+				return dropping.promise;
+			}
+		}
+
+		const predecessor = calls.at(-1);
+		let resolve!: (value: boolean) => void;
+		let reject!: (reason?: unknown) => void;
+		const promise = new Promise<boolean>((promiseResolve, promiseReject) => {
+			resolve = promiseResolve;
+			reject = promiseReject;
+		});
+		const parentIndex =
+			this.parents?.findIndex((parent) => parent === from) ?? -1;
+		const terminal =
+			this.closed || parentIndex === -1 || (this.parents?.length ?? 0) === 1;
+		const call: TerminalCall = { type, from, terminal, promise };
+		calls.push(call);
+
+		const execute = () => {
+			let operation: Promise<boolean>;
+			const ownerReferencesBefore =
+				this.parents?.filter((parent) => parent === from).length ?? 0;
+			try {
+				operation = this.performTerminalOperation(type, from);
+			} catch (error) {
+				reject(error);
+				return;
+			}
+			void operation.then((result) => {
+				const ownerReferencesAfter =
+					this.parents?.filter((parent) => parent === from).length ?? 0;
+				this.recordTerminalBaseCommit(
+					type,
+					from,
+					result,
+					Math.max(0, ownerReferencesBefore - ownerReferencesAfter),
+				);
+				// Program only owns the base promise. A subclass may still be doing
+				// post-super terminal cleanup, so managed/embedded calls defer inverse-
+				// edge removal to the caller's outer cleanup lease. A non-terminal owner
+				// release leaves the child live and can reconcile immediately; an
+				// inherited base method is itself the full public operation.
+				if (
+					(this._terminalOuterCleanupLeases?.size ?? 0) === 0 &&
+					(!result || this.isOutermostBaseTerminalOperation(type))
+				) {
+					this.reconcilePendingInverseParentReleases(result ? undefined : from);
+				}
+				resolve(result);
+			}, reject);
+		};
+		if (predecessor) {
+			// Different owners and close-vs-drop calls are serialized. In particular,
+			// a drop admitted after close does not pretend destructive cleanup happened:
+			// it runs after close and receives ClosedError from the now-closed program.
+			void predecessor.promise.then(execute, execute);
+		} else {
+			execute();
+		}
+
+		void promise.then(
+			() => this.finishTerminalCall(call),
+			() => this.finishTerminalCall(call),
+		);
+		return promise;
+	}
+
+	private finishTerminalCall(call: TerminalCall): void {
+		const calls = this._terminalCalls;
+		const index = calls?.indexOf(call) ?? -1;
+		if (index !== -1) {
+			calls!.splice(index, 1);
+		}
+		if (calls?.length === 0) {
+			this._terminalCalls = undefined;
+		}
+	}
+
+	close(from?: Program): Promise<boolean> {
+		this._emittedEventsFor = undefined;
+		return this.terminalOperation("close", from);
+	}
+
+	drop(from?: Program): Promise<boolean> {
+		return this.terminalOperation("drop", from);
 	}
 
 	emitEvent(event: CustomEvent, parents = false) {
@@ -545,7 +1138,9 @@ export abstract class Program<
 			throw new Error("Program has no topics, cannot get ready");
 		}
 		const pubsub = this.node.services.pubsub;
-		const collectProvidedPublicKeys = (refs: PeerRefs): Map<string, PublicSignKey> => {
+		const collectProvidedPublicKeys = (
+			refs: PeerRefs,
+		): Map<string, PublicSignKey> => {
 			const providedPublicKeysByHash = new Map<string, PublicSignKey>();
 			const rememberPublicKey = (ref: unknown) => {
 				if (ref instanceof PublicSignKey) {
@@ -563,7 +1158,9 @@ export abstract class Program<
 				}
 				return providedPublicKeysByHash;
 			}
-			if (typeof (refs as Iterable<unknown>)?.[Symbol.iterator] === "function") {
+			if (
+				typeof (refs as Iterable<unknown>)?.[Symbol.iterator] === "function"
+			) {
 				for (const ref of refs as Iterable<unknown>) {
 					rememberPublicKey(ref);
 				}
@@ -816,10 +1413,18 @@ export abstract class Program<
 		if (this._allPrograms) {
 			return this._allPrograms;
 		}
-		const arr: Program[] = this.programs;
-		const nexts = this.programs;
-		for (const next of nexts) {
-			arr.push(...next.allPrograms);
+		const arr: Program[] = [];
+		const pending = [...this.programs];
+		const visited = new Set<Program>([this]);
+		while (pending.length > 0) {
+			const next = pending.pop()!;
+			if (visited.has(next)) continue;
+			visited.add(next);
+			arr.push(next);
+			const nested = (next as Program & { programs?: Program[] }).programs;
+			pending.push(
+				...(Array.isArray(nested) ? nested : getValuesWithType(next, Program)),
+			);
 		}
 		this._allPrograms = arr;
 		return this._allPrograms;

--- a/packages/programs/program/program/test/handler.spec.ts
+++ b/packages/programs/program/program/test/handler.spec.ts
@@ -782,6 +782,190 @@ describe(`shared`, () => {
 		await handler.stop();
 	});
 
+	it("retains a promoted root when a distinct same-address child cleanup fails", async () => {
+		const handler = new ProgramHandler({ client });
+		const seed = new TestNestedProgram(470);
+		const first = new TestProgram(471, seed.clone());
+		const second = new TestProgram(472, seed.clone());
+		let markSaveStarted!: () => void;
+		const saveStarted = new Promise<void>((resolve) => {
+			markSaveStarted = resolve;
+		});
+		let releaseSave!: () => void;
+		const saveGate = new Promise<void>((resolve) => {
+			releaseSave = resolve;
+		});
+		const originalSave = first.save.bind(first);
+		first.save = async (...args: Parameters<TestProgram["save"]>) => {
+			if (args[1]?.skipOnAddress === false) {
+				markSaveStarted();
+				await saveGate;
+			}
+			return originalSave(...args);
+		};
+		const childClose = second.nested.close.bind(second.nested);
+		const cleanupError = new Error("synthetic colliding child cleanup failure");
+		let childCloseAttempts = 0;
+		second.nested.close = async (from) => {
+			const closed = await childClose(from);
+			childCloseAttempts += 1;
+			if (childCloseAttempts === 1) throw cleanupError;
+			return closed;
+		};
+
+		const firstOpening = handler.open(first);
+		await saveStarted;
+		const secondOpening = handler.open(second);
+		try {
+			await secondOpening;
+		} finally {
+			releaseSave();
+		}
+		await firstOpening;
+		expect(first.nested).not.to.equal(second.nested);
+		expect(first.nested.address.toString()).to.equal(
+			second.nested.address.toString(),
+		);
+
+		// Promote the first identity to a root owner while the distinct clone
+		// remains embedded under the second root.
+		expect(await handler.open(first.nested)).to.equal(first.nested);
+		expect(handler.items.get(first.nested.address)).to.equal(first.nested);
+		await expect(second.close()).to.be.rejectedWith(cleanupError.message);
+		expect(handler.items.get(first.nested.address)).to.equal(first.nested);
+
+		await handler.stop();
+		expect(childCloseAttempts).to.equal(2);
+		expect(first.nested.closed).to.be.true;
+		expect(second.nested.closed).to.be.true;
+		expect(handler.items.size).to.equal(0);
+	});
+
+	it("releases a colliding retained identity after replacement cleanup", async () => {
+		const handler = new ProgramHandler({ client });
+		const seed = new TestNestedProgram(476);
+		const first = new TestProgram(477, seed.clone());
+		const second = new TestProgram(478, seed.clone());
+		let markSaveStarted!: () => void;
+		const saveStarted = new Promise<void>((resolve) => {
+			markSaveStarted = resolve;
+		});
+		let releaseSave!: () => void;
+		const saveGate = new Promise<void>((resolve) => {
+			releaseSave = resolve;
+		});
+		const originalSave = first.save.bind(first);
+		first.save = async (...args: Parameters<TestProgram["save"]>) => {
+			if (args[1]?.skipOnAddress === false) {
+				markSaveStarted();
+				await saveGate;
+			}
+			return originalSave(...args);
+		};
+		const childClose = second.nested.close.bind(second.nested);
+		const cleanupError = new Error(
+			"synthetic replaced colliding child cleanup failure",
+		);
+		second.nested.close = async (from) => {
+			await childClose(from);
+			throw cleanupError;
+		};
+
+		const firstOpening = handler.open(first);
+		await saveStarted;
+		const secondOpening = handler.open(second);
+		try {
+			await secondOpening;
+		} finally {
+			releaseSave();
+		}
+		await firstOpening;
+		expect(await handler.open(first.nested)).to.equal(first.nested);
+		expect(handler.items.get(first.nested.address)).to.equal(first.nested);
+
+		await expect(second.nested.close(second)).to.be.rejectedWith(
+			cleanupError.message,
+		);
+		expect(second.nested.closed).to.be.true;
+		expect(handler.items.get(first.nested.address)).to.equal(first.nested);
+
+		let replacementCalls = 0;
+		second.nested.close = async (from) => {
+			replacementCalls += 1;
+			expect(from).to.equal(second);
+			return true;
+		};
+		await handler.stop();
+		expect(replacementCalls).to.equal(1);
+		expect(handler.items.size).to.equal(0);
+		handler.start();
+		await handler.stop();
+	});
+
+	it("retains a promoted root across a colliding child rollback failure", async () => {
+		const handler = new ProgramHandler({ client });
+		const seed = new TestNestedProgram(473);
+		const first = new TestProgram(474, seed.clone());
+		const second = new TestProgram(475, seed.clone());
+		let markSecondBeforeOpen!: () => void;
+		const secondBeforeOpen = new Promise<void>((resolve) => {
+			markSecondBeforeOpen = resolve;
+		});
+		let releaseSecondBeforeOpen!: () => void;
+		const secondBeforeOpenGate = new Promise<void>((resolve) => {
+			releaseSecondBeforeOpen = resolve;
+		});
+		const openError = new Error("synthetic colliding root open failure");
+		const cleanupError = new Error(
+			"synthetic colliding rollback cleanup failure",
+		);
+		const childClose = second.nested.close.bind(second.nested);
+		let childCloseAttempts = 0;
+		second.nested.close = async (from) => {
+			const closed = await childClose(from);
+			childCloseAttempts += 1;
+			if (childCloseAttempts === 1) throw cleanupError;
+			return closed;
+		};
+
+		expect(await handler.open(first)).to.equal(first);
+		expect(first.nested).not.to.equal(second.nested);
+		// Promote the first child identity to an independently owned live root.
+		expect(await handler.open(first.nested)).to.equal(first.nested);
+		expect(handler.items.get(first.nested.address)).to.equal(first.nested);
+
+		const secondOpening = handler.open(second, {
+			onBeforeOpen: async (opened) => {
+				if (opened !== second) return;
+				markSecondBeforeOpen();
+				await secondBeforeOpenGate;
+				throw openError;
+			},
+		});
+		await secondBeforeOpen;
+		try {
+			expect(first.nested.address.toString()).to.equal(
+				second.nested.address.toString(),
+			);
+			// The distinct clone has been admitted and opened under the in-flight root,
+			// without displacing the promoted identity at the shared address.
+			expect(second.nested.closed).to.be.false;
+			expect(handler.items.get(first.nested.address)).to.equal(first.nested);
+		} finally {
+			releaseSecondBeforeOpen();
+		}
+		await expect(secondOpening).to.be.rejectedWith(openError.message);
+		expect(childCloseAttempts).to.equal(1);
+		expect(second.nested.closed).to.be.true;
+		expect(handler.items.get(first.nested.address)).to.equal(first.nested);
+
+		await handler.stop();
+		expect(childCloseAttempts).to.equal(2);
+		expect(first.nested.closed).to.be.true;
+		expect(second.nested.closed).to.be.true;
+		expect(handler.items.size).to.equal(0);
+	});
+
 	it("supports same-address siblings in one opening graph", async () => {
 		const handler = new ProgramHandler({ client });
 		const root = new TestSameAddressSiblingsProgram(468, 469);
@@ -1014,6 +1198,157 @@ describe(`shared`, () => {
 		await handler.stop();
 		expect(cleanupAttempts).to.equal(2);
 		expect(handler.items.size).to.equal(0);
+	});
+
+	it("monitors a terminal method replaced after open during stop", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestProgram(485);
+		const baseClose = program.close.bind(program);
+		await handler.open(program);
+		const cleanupError = new Error(
+			"synthetic post-open replacement cleanup failure",
+		);
+		let cleanupAttempts = 0;
+		program.close = async (from) => {
+			const closed = await baseClose(from);
+			cleanupAttempts += 1;
+			if (cleanupAttempts === 1) throw cleanupError;
+			return closed;
+		};
+
+		await expect(handler.stop()).to.be.rejectedWith(cleanupError.message);
+		expect(handler.items.get(program.address)).to.equal(program);
+		expect(program.closed).to.be.true;
+
+		await handler.stop();
+		expect(cleanupAttempts).to.equal(2);
+		expect(handler.items.size).to.equal(0);
+		handler.start();
+		await handler.stop();
+	});
+
+	it("unwraps a post-open replacement that delegates to its captured wrapper", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = await handler.open(new TestProgram(486));
+		const capturedWrapper = program.close;
+		program.close = capturedWrapper.bind(program);
+
+		let timeout: ReturnType<typeof setTimeout> | undefined;
+		try {
+			await Promise.race([
+				handler.stop(),
+				new Promise<never>((_, reject) => {
+					timeout = setTimeout(
+						() => reject(new Error("delegating replacement cleanup timed out")),
+						1_000,
+					);
+				}),
+			]);
+		} finally {
+			if (timeout) clearTimeout(timeout);
+		}
+		expect(program.closed).to.be.true;
+		expect(handler.items.size).to.equal(0);
+		handler.start();
+		await handler.stop();
+	});
+
+	it("rejects an after-yield captured wrapper cycle without deadlocking stop", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestProgram(487);
+		const baseClose = program.close.bind(program);
+		await handler.open(program);
+		const capturedWrapper = program.close;
+		program.close = async (...args) => {
+			await Promise.resolve();
+			return capturedWrapper(...args);
+		};
+
+		const outcome = await Promise.race([
+			handler.stop().then(
+				() => "stopped" as const,
+				(error: unknown) => error,
+			),
+			delay(1_000).then(() => "timeout" as const),
+		]);
+		expect(outcome).to.be.instanceOf(TerminalOperationNotStartedError);
+		expect(program.closed).to.be.false;
+		expect(handler.items.get(program.address)).to.equal(program);
+
+		program.close = baseClose;
+		await handler.stop();
+		expect(program.closed).to.be.true;
+		expect(handler.items.size).to.equal(0);
+		handler.start();
+		await handler.stop();
+	});
+
+	it("rejects synchronous cross-operation terminal delegation before mutation", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestProgram(488);
+		const baseClose = program.close.bind(program);
+		await handler.open(program);
+		let attempts = 0;
+		program.close = async (from) => {
+			attempts += 1;
+			await program.drop(from);
+			throw new Error("unreachable cleanup failure");
+		};
+
+		const failure = await handler.stop().then(
+			(): undefined => undefined,
+			(error: unknown) => error,
+		);
+		expect(failure).to.be.instanceOf(TerminalOperationNotStartedError);
+		expect(attempts).to.equal(1);
+		expect(program.closed).to.be.false;
+		expect(handler.items.get(program.address)).to.equal(program);
+
+		program.close = baseClose;
+		await handler.stop();
+		expect(program.closed).to.be.true;
+		expect(handler.items.size).to.equal(0);
+		handler.start();
+		await handler.stop();
+	});
+
+	it("rejects captured-wrapper delegation with a different owner before mutation", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestProgram(489);
+		const baseClose = program.close.bind(program);
+		await handler.open(program);
+		const parentA = await handler.open(new TestProgram(490));
+		const parentB = await handler.open(new TestProgram(491));
+		await handler.open(program, { parent: parentA, existing: "reuse" });
+		await handler.open(program, { parent: parentB, existing: "reuse" });
+		const capturedWrapper = program.close;
+		let attempts = 0;
+		program.close = async (from) => {
+			if (from === undefined) {
+				attempts += 1;
+				await capturedWrapper(parentB);
+				throw new Error("unreachable wrong-owner cleanup failure");
+			}
+			return baseClose(from);
+		};
+
+		const failure = await handler.stop().then(
+			(): undefined => undefined,
+			(error: unknown) => error,
+		);
+		expect(failure).to.be.instanceOf(TerminalOperationNotStartedError);
+		expect(attempts).to.equal(1);
+		expect(program.closed).to.be.false;
+		expect(program.parents).to.deep.equal([undefined]);
+		expect(parentA.children).not.to.include(program);
+		expect(parentB.children).not.to.include(program);
+
+		program.close = baseClose;
+		await handler.stop();
+		expect(program.closed).to.be.true;
+		expect(handler.items.size).to.equal(0);
+		handler.start();
+		await handler.stop();
 	});
 
 	it("retries base Program deletion after drop committed closed", async () => {
@@ -1302,6 +1637,129 @@ describe(`shared`, () => {
 		await handler.stop();
 	});
 
+	it("accepts replacement cleanup for a committed non-terminal release", async () => {
+		const handler = new ProgramHandler({ client });
+		const parentA = await handler.open(new TestProgram(479));
+		const parentB = await handler.open(new TestProgram(480));
+		const child = new TestProgram(481);
+		const childClose = child.close.bind(child);
+		const cleanupError = new Error(
+			"synthetic replaced non-terminal owner cleanup failure",
+		);
+		let cleanupAttempts = 0;
+		child.close = async (from) => {
+			const closed = await childClose(from);
+			cleanupAttempts += 1;
+			if (cleanupAttempts === 1) throw cleanupError;
+			return closed;
+		};
+
+		await handler.open(child, { parent: parentA });
+		await handler.open(child, { parent: parentB });
+		await expect(child.close(parentA)).to.be.rejectedWith(cleanupError.message);
+		expect(child.closed).to.be.false;
+		expect(child.parents).to.deep.equal([parentB]);
+
+		let replacementCalls = 0;
+		let remainingOwnerCalls = 0;
+		const remainingOwnerError = new Error(
+			"synthetic replacement remaining-owner cleanup failure",
+		);
+		child.close = async (from) => {
+			if (from === parentA) {
+				replacementCalls += 1;
+				return false;
+			}
+			const closed = await childClose(from);
+			remainingOwnerCalls += 1;
+			if (remainingOwnerCalls === 1) throw remainingOwnerError;
+			return closed;
+		};
+		const firstStopError = await handler.stop().then(
+			(): undefined => undefined,
+			(error: unknown) => error,
+		);
+		expect(String(firstStopError)).to.contain(remainingOwnerError.message);
+		expect(remainingOwnerCalls).to.equal(2);
+		expect(child.closed).to.be.true;
+		// The first stop keeps draining independent retained items after preserving
+		// the original error, so the child's exact cleanup retry can succeed in the
+		// same pass. The next stop only finishes the parent that surfaced that error.
+		await handler.stop();
+		expect(replacementCalls).to.equal(1);
+		expect(remainingOwnerCalls).to.equal(2);
+		expect(child.closed).to.be.true;
+		expect(parentA.children).not.to.include(child);
+		expect(parentB.children).not.to.include(child);
+		expect(handler.items.size).to.equal(0);
+		handler.start();
+		await handler.stop();
+		await parentA.close();
+		await parentB.close();
+	});
+
+	it("does not clear a newer queued owner failure with an older retry", async () => {
+		const handler = new ProgramHandler({ client });
+		const parentA = await handler.open(new TestProgram(482));
+		const parentB = await handler.open(new TestProgram(483));
+		const child = new TestProgram(484);
+		const childClose = child.close.bind(child);
+		const oldAError = new Error("synthetic old owner A cleanup failure");
+		const newBError = new Error("synthetic new owner B cleanup failure");
+		let ownerAAttempts = 0;
+		let ownerBAttempts = 0;
+		let markOwnerARetryStarted!: () => void;
+		const ownerARetryStarted = new Promise<void>((resolve) => {
+			markOwnerARetryStarted = resolve;
+		});
+		let releaseOwnerARetry!: () => void;
+		const ownerARetryGate = new Promise<void>((resolve) => {
+			releaseOwnerARetry = resolve;
+		});
+		child.close = async (from) => {
+			const closed = await childClose(from);
+			if (from === parentA) {
+				ownerAAttempts += 1;
+				if (ownerAAttempts === 1) throw oldAError;
+				if (ownerAAttempts === 2) {
+					markOwnerARetryStarted();
+					await ownerARetryGate;
+				}
+			} else if (from === parentB) {
+				ownerBAttempts += 1;
+				if (ownerBAttempts === 1) throw newBError;
+			}
+			return closed;
+		};
+
+		await handler.open(child, { parent: parentA });
+		await handler.open(child, { parent: parentB });
+		await expect(child.close(parentA)).to.be.rejectedWith(oldAError.message);
+		expect(child.parents).to.deep.equal([parentB]);
+		handler.items.delete(parentA.address);
+		handler.items.delete(parentB.address);
+
+		const stopping = handler.stop();
+		await ownerARetryStarted;
+		const closingB = child.close(parentB);
+		releaseOwnerARetry();
+		await expect(closingB).to.be.rejectedWith(newBError.message);
+		await expect(stopping).to.be.rejectedWith(
+			"did not make ownership progress",
+		);
+
+		await handler.stop();
+		expect(ownerAAttempts).to.equal(2);
+		expect(ownerBAttempts).to.equal(2);
+		expect(child.closed).to.be.true;
+		expect(parentA.children).not.to.include(child);
+		expect(parentB.children).not.to.include(child);
+		handler.start();
+		await handler.stop();
+		await parentA.close();
+		await parentB.close();
+	});
+
 	it("retries a committed terminal child cleanup with the original owner", async () => {
 		const handler = new ProgramHandler({ client });
 		const parent = await handler.open(new TestProgram(156));
@@ -1496,6 +1954,30 @@ describe(`shared`, () => {
 		expect(childCloseCalls).to.equal(3);
 		expect(child.closed).to.be.true;
 		expect(parent.children).not.to.include(child);
+		await handler.stop();
+	});
+
+	it("rejects inverse-only child cleanup that retains parent ownership", async () => {
+		const handler = new ProgramHandler({ client });
+		const parent = await handler.open(new TestProgram(485));
+		const child = new TestProgram(486);
+		const childClose = child.close.bind(child);
+		child.close = async (from) => {
+			const childIndex = from?.children.indexOf(child) ?? -1;
+			if (childIndex !== -1) from!.children.splice(childIndex, 1);
+			return false;
+		};
+
+		await handler.open(child, { parent });
+		await expect(parent.close()).to.be.rejectedWith(
+			"did not release parent ownership",
+		);
+		expect(parent.closed).to.be.false;
+		expect(child.closed).to.be.false;
+		expect(child.parents).to.deep.equal([parent]);
+		expect(parent.children).to.include(child);
+
+		child.close = childClose;
 		await handler.stop();
 	});
 

--- a/packages/programs/program/program/test/handler.spec.ts
+++ b/packages/programs/program/program/test/handler.spec.ts
@@ -2639,10 +2639,28 @@ describe(`shared`, () => {
 
 		expect(p1.nested.closed).to.be.false;
 		expect(p1.nested.address).to.exist;
+		expect(await client.services.blocks.has(p1.nested.address)).to.be.true;
 
 		await p1.close();
 		expect(p1.nested.closed).to.be.true;
 		expect(p1.closed).to.be.true;
+	});
+
+	it("reuses a persisted live child after its serialized value changes", async () => {
+		const handler = new ProgramHandler({ client });
+		const parent = await handler.open(new TestNestedProgram(470));
+		const child = await handler.open(new TestNestedProgram(471));
+		const address = child.address;
+		expect(await client.services.blocks.has(address)).to.be.true;
+
+		child.seed = 472;
+		expect(await handler.open(child, { parent, existing: "reuse" })).to.equal(
+			child,
+		);
+		expect(child.address).to.equal(address);
+		expect(child.parents).to.include(parent);
+
+		await handler.stop();
 	});
 
 	it("does not deadlock a reserved nested open behind an external waiter", async () => {

--- a/packages/programs/program/program/test/handler.spec.ts
+++ b/packages/programs/program/program/test/handler.spec.ts
@@ -11,6 +11,7 @@ import {
 	TestNestedProgram,
 	TestParenteRefernceProgram,
 	TestProgram,
+	TestSameAddressSiblingsProgram,
 } from "./samples.js";
 import { creatMockPeer } from "./utils.js";
 
@@ -745,7 +746,7 @@ describe(`shared`, () => {
 		await handler.stop();
 	});
 
-	it("rejects concurrent roots with distinct same-address children", async () => {
+	it("allows concurrent roots with distinct same-address children", async () => {
 		const handler = new ProgramHandler({ client });
 		const seed = new TestNestedProgram(441);
 		const first = new TestProgram(442, seed.clone());
@@ -769,16 +770,37 @@ describe(`shared`, () => {
 
 		const firstOpening = handler.open(first);
 		await saveStarted;
+		const secondOpening = handler.open(second);
 		try {
-			await expect(handler.open(second)).to.be.rejectedWith(
-				"already opening as another instance",
-			);
-			expect(second.closed).to.be.true;
-			expect(second.nested.closed).to.be.true;
+			expect(await secondOpening).to.equal(second);
+			expect(second.closed).to.be.false;
+			expect(second.nested.closed).to.be.false;
 		} finally {
 			releaseSave();
 		}
 		expect(await firstOpening).to.equal(first);
+		await handler.stop();
+	});
+
+	it("supports same-address siblings in one opening graph", async () => {
+		const handler = new ProgramHandler({ client });
+		const root = new TestSameAddressSiblingsProgram(468, 469);
+		await Promise.all([
+			root.first.calculateAddress(),
+			root.second.calculateAddress(),
+		]);
+		expect(root.first).not.to.equal(root.second);
+		expect(root.first.address.toString()).to.equal(
+			root.second.address.toString(),
+		);
+
+		expect(await handler.open(root)).to.equal(root);
+		expect(root.nestedOpenResult).to.equal(root.first);
+		expect(root.first.closed).to.be.false;
+		expect(root.second.closed).to.be.false;
+		expect(await root.close()).to.be.true;
+		expect(root.first.closed).to.be.true;
+		expect(root.second.closed).to.be.true;
 		await handler.stop();
 	});
 

--- a/packages/programs/program/program/test/handler.spec.ts
+++ b/packages/programs/program/program/test/handler.spec.ts
@@ -1,14 +1,56 @@
 import { delay } from "@peerbit/time";
 import { expect, use } from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { type ProgramClient } from "../src/index.js";
-import { TestParenteRefernceProgram, TestProgram } from "./samples.js";
+import {
+	ClosedError,
+	type ProgramClient,
+	ProgramHandler,
+	TerminalOperationNotStartedError,
+} from "../src/index.js";
+import {
+	TestNestedProgram,
+	TestParenteRefernceProgram,
+	TestProgram,
+} from "./samples.js";
 import { creatMockPeer } from "./utils.js";
 
 use(chaiAsPromised);
 
 describe(`shared`, () => {
 	let client: ProgramClient;
+	const reuseRoutes: {
+		name: string;
+		open: (program: TestProgram) => Promise<TestProgram>;
+	}[] = [
+		{
+			name: "same-instance",
+			open: (program) =>
+				client.open(program, { existing: "reuse" }) as Promise<TestProgram>,
+		},
+		{
+			name: "address",
+			open: (program) =>
+				client.open(program.address, {
+					existing: "reuse",
+				}) as Promise<TestProgram>,
+		},
+		{
+			name: "closed clone",
+			open: (program) =>
+				client.open(program.clone(), {
+					existing: "reuse",
+				}) as Promise<TestProgram>,
+		},
+		{
+			name: "already-open clone",
+			open: async (program) => {
+				const clone = program.clone();
+				await clone.calculateAddress();
+				clone.closed = false;
+				return client.open(clone, { existing: "reuse" });
+			},
+		},
+	];
 
 	beforeEach(async () => {
 		client = await creatMockPeer();
@@ -21,6 +63,1640 @@ describe(`shared`, () => {
 	it("open same store twice will share instance", async () => {
 		const db1 = await client.open(new TestProgram());
 		expect(await client.open(db1)).equal(db1);
+	});
+
+	it("singleflights concurrent base close calls with exact promise identity", async () => {
+		const program = await client.open(new TestProgram(142));
+		const childClose = program.nested.close.bind(program.nested);
+		let childCloseCalls = 0;
+		let parentCloseEvents = 0;
+		let childCloseEvents = 0;
+		program.nested.close = (from) => {
+			childCloseCalls += 1;
+			return childClose(from);
+		};
+		program.events.addEventListener("close", (event) => {
+			if (event.detail === program) parentCloseEvents += 1;
+		});
+		program.nested.events.addEventListener("close", () => {
+			childCloseEvents += 1;
+		});
+
+		const first = program.close();
+		const second = program.close();
+		expect(second).to.equal(first);
+		expect(await first).to.be.true;
+		expect(childCloseCalls).to.equal(1);
+		expect(parentCloseEvents).to.equal(1);
+		expect(childCloseEvents).to.equal(1);
+	});
+
+	it("singleflights the full async subclass close before invoking it", async () => {
+		const program = await client.open(new TestNestedProgram(146));
+		const pubsub = client.services.pubsub;
+		const unsubscribe = pubsub.unsubscribe.bind(pubsub);
+		let unsubscribeCalls = 0;
+		pubsub.unsubscribe = (...args) => {
+			unsubscribeCalls += 1;
+			return unsubscribe(...args);
+		};
+
+		const first = program.close();
+		const second = program.close();
+		expect(second).to.equal(first);
+		expect(await first).to.be.true;
+		expect(unsubscribeCalls).to.equal(1);
+		pubsub.unsubscribe = unsubscribe;
+	});
+
+	it("invokes the first outer close synchronously so its fence is immediate", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestProgram(166);
+		const baseClose = program.close.bind(program);
+		let invoked = false;
+		let releaseCleanup!: () => void;
+		const cleanupGate = new Promise<void>((resolve) => {
+			releaseCleanup = resolve;
+		});
+		program.close = async (from) => {
+			invoked = true;
+			const closed = await baseClose(from);
+			await cleanupGate;
+			return closed;
+		};
+
+		await handler.open(program);
+		const closing = program.close();
+		expect(invoked).to.be.true;
+		expect(program.acceptsParentAttachments).to.be.false;
+		releaseCleanup();
+		expect(await closing).to.be.true;
+		await handler.stop();
+	});
+
+	it("leaves an explicitly unstarted terminal rejection retryable", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestProgram(167);
+		const baseDrop = program.drop.bind(program);
+		let attempts = 0;
+		program.drop = async (from) => {
+			attempts += 1;
+			if (attempts === 1) {
+				throw new TerminalOperationNotStartedError(
+					"synthetic terminal precondition rejection",
+				);
+			}
+			return baseDrop(from);
+		};
+
+		await handler.open(program);
+		await expect(program.drop()).to.be.rejectedWith(
+			"synthetic terminal precondition rejection",
+		);
+		expect(program.closed).to.be.false;
+		expect(await program.drop()).to.be.true;
+		expect(attempts).to.equal(2);
+		await handler.stop();
+	});
+
+	it("leaves an invalid parent release retryable with the correct owner", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = await handler.open(new TestProgram(170));
+		const wrongParent = new TestProgram(171);
+
+		await expect(program.close(wrongParent)).to.be.rejectedWith(
+			"Could not find from in parents",
+		);
+		expect(program.closed).to.be.false;
+		expect(await program.close()).to.be.true;
+		await handler.stop();
+	});
+
+	it("rejects callback-reentrant stop without deadlocking cleanup", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestNestedProgram(172);
+		let callbackAttempts = 0;
+		await handler.open(program, {
+			onClose: async () => {
+				callbackAttempts += 1;
+				if (callbackAttempts === 1) await handler.stop();
+			},
+		});
+
+		await expect(program.close()).to.be.rejectedWith(
+			"Program lifecycle callbacks cannot wait for their own handler to stop",
+		);
+		expect(await program.close()).to.be.true;
+		expect(callbackAttempts).to.equal(2);
+		await handler.stop();
+	});
+
+	it("rejects callback-reentrant close without sharing its own promise", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestNestedProgram(173);
+		let callbackAttempts = 0;
+		await handler.open(program, {
+			onClose: async () => {
+				callbackAttempts += 1;
+				if (callbackAttempts === 1) await program.close();
+			},
+		});
+
+		await expect(program.close()).to.be.rejectedWith(
+			"Program lifecycle callbacks cannot wait for their own terminal operation",
+		);
+		expect(await program.close()).to.be.true;
+		expect(callbackAttempts).to.equal(2);
+		await handler.stop();
+	});
+
+	it("allows a terminal callback to close an unrelated program", async () => {
+		const handler = new ProgramHandler({ client });
+		const other = await handler.open(new TestNestedProgram(423));
+		const program = new TestNestedProgram(424);
+		await handler.open(program, {
+			onClose: async (closed) => {
+				if (closed === program) await other.close();
+			},
+		});
+
+		expect(await program.close()).to.be.true;
+		expect(program.closed).to.be.true;
+		expect(other.closed).to.be.true;
+		await handler.stop();
+	});
+
+	it("rejects a child callback waiting for its active parent close", async () => {
+		const handler = new ProgramHandler({ client });
+		const parent = new TestProgram(431);
+		let callbackAttempts = 0;
+		await handler.open(parent, {
+			onClose: async (closed) => {
+				if (closed !== parent.nested) return;
+				callbackAttempts += 1;
+				if (callbackAttempts === 1) await parent.close();
+			},
+		});
+
+		await expect(parent.close()).to.be.rejectedWith(
+			"Program lifecycle callbacks cannot wait for their own terminal operation",
+		);
+		expect(await parent.close()).to.be.true;
+		expect(callbackAttempts).to.equal(2);
+		await handler.stop();
+	});
+
+	it("rejects callback-reentrant stop during open without deadlocking admission", async () => {
+		const handler = new ProgramHandler({ client });
+		await expect(
+			handler.open(new TestProgram(174), {
+				onBeforeOpen: async () => handler.stop(),
+			}),
+		).to.be.rejectedWith(
+			"Program lifecycle callbacks cannot wait for their own handler to stop",
+		);
+		await handler.stop();
+	});
+
+	it("rejects stop invoked synchronously by a program open override", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestNestedProgram(458);
+		program.open = async () => {
+			await handler.stop();
+		};
+
+		await expect(handler.open(program)).to.be.rejectedWith(
+			"Program lifecycle callbacks cannot wait for their own handler to stop",
+		);
+		await handler.stop();
+	});
+
+	it("rejects stop invoked synchronously by a terminal override", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestNestedProgram(459);
+		const baseClose = program.close.bind(program);
+		let stopFromClose = false;
+		program.close = async (from) => {
+			if (stopFromClose) await handler.stop();
+			return baseClose(from);
+		};
+		await handler.open(program);
+		stopFromClose = true;
+
+		await expect(program.close()).to.be.rejectedWith(
+			"Program lifecycle callbacks cannot wait for their own handler to stop",
+		);
+		stopFromClose = false;
+		expect(await program.close()).to.be.true;
+		await handler.stop();
+	});
+
+	it("lets an in-flight drop subsume close with one terminal operation", async () => {
+		const program = await client.open(new TestProgram(143));
+		const childDrop = program.nested.drop.bind(program.nested);
+		let markChildDropStarted!: () => void;
+		const childDropStarted = new Promise<void>((resolve) => {
+			markChildDropStarted = resolve;
+		});
+		let releaseChildDrop!: () => void;
+		const childDropGate = new Promise<void>((resolve) => {
+			releaseChildDrop = resolve;
+		});
+		let childDropCalls = 0;
+		program.nested.drop = async (from) => {
+			childDropCalls += 1;
+			markChildDropStarted();
+			await childDropGate;
+			return childDrop(from);
+		};
+		const rootAddress = program.address;
+		const blocksRm = client.services.blocks.rm.bind(client.services.blocks);
+		let rootDeleteCalls = 0;
+		client.services.blocks.rm = (address) => {
+			if (address === rootAddress) rootDeleteCalls += 1;
+			return blocksRm(address);
+		};
+
+		const dropping = program.drop();
+		await childDropStarted;
+		const duplicateDrop = program.drop();
+		const closing = program.close();
+		expect(duplicateDrop).to.equal(dropping);
+		expect(closing).to.equal(dropping);
+		releaseChildDrop();
+		expect(await dropping).to.be.true;
+		expect(childDropCalls).to.equal(1);
+		expect(rootDeleteCalls).to.equal(1);
+	});
+
+	it("serializes drop behind close and reports that close won", async () => {
+		const program = await client.open(new TestProgram(144));
+		const childClose = program.nested.close.bind(program.nested);
+		let markChildCloseStarted!: () => void;
+		const childCloseStarted = new Promise<void>((resolve) => {
+			markChildCloseStarted = resolve;
+		});
+		let releaseChildClose!: () => void;
+		const childCloseGate = new Promise<void>((resolve) => {
+			releaseChildClose = resolve;
+		});
+		let childCloseCalls = 0;
+		program.nested.close = async (from) => {
+			childCloseCalls += 1;
+			markChildCloseStarted();
+			await childCloseGate;
+			return childClose(from);
+		};
+		const rootAddress = program.address;
+		const blocksRm = client.services.blocks.rm.bind(client.services.blocks);
+		let rootDeleteCalls = 0;
+		client.services.blocks.rm = (address) => {
+			if (address === rootAddress) rootDeleteCalls += 1;
+			return blocksRm(address);
+		};
+
+		const closing = program.close();
+		await childCloseStarted;
+		const dropping = program.drop();
+		expect(dropping).not.to.equal(closing);
+		releaseChildClose();
+		expect(await closing).to.be.true;
+		await expect(dropping).to.be.rejectedWith(ClosedError);
+		expect(childCloseCalls).to.equal(1);
+		expect(rootDeleteCalls).to.equal(0);
+	});
+
+	it("rejects parent reuse while attachment is fenced and permits a reopen", async () => {
+		const program = await client.open(new TestProgram());
+		const parent = await client.open(new TestProgram(1));
+		program.preventNewParents();
+
+		await expect(client.open(program, { parent })).to.be.rejectedWith(
+			"Program is terminating and cannot accept another parent",
+		);
+		expect(program.parents).to.deep.equal([undefined]);
+		expect(parent.children).not.to.include(program);
+
+		await program.close();
+		const reopened = await client.open(program, { parent });
+		expect(reopened).to.equal(program);
+		expect(reopened.parents).to.deep.equal([parent]);
+	});
+
+	for (const route of reuseRoutes) {
+		it(`automatically fences ${route.name} reuse while child close drains`, async () => {
+			const program = await client.open(new TestProgram());
+			const originalClose = program.nested.close.bind(program.nested);
+			let markChildCloseStarted!: () => void;
+			const childCloseStarted = new Promise<void>((resolve) => {
+				markChildCloseStarted = resolve;
+			});
+			let releaseChildClose!: () => void;
+			const childCloseGate = new Promise<void>((resolve) => {
+				releaseChildClose = resolve;
+			});
+			program.nested.close = async (from) => {
+				markChildCloseStarted();
+				await childCloseGate;
+				return originalClose(from);
+			};
+
+			const closing = program.close();
+			await childCloseStarted;
+			try {
+				await expect(route.open(program)).to.be.rejectedWith(
+					"Program is terminating and cannot accept another parent",
+				);
+				expect(program.closed).to.be.false;
+			} finally {
+				releaseChildClose();
+			}
+			await closing;
+			expect(program.closed).to.be.true;
+		});
+
+		it(`registers an undefined root attachment for ${route.name} reuse`, async () => {
+			const parent = await client.open(new TestProgram(100));
+			const program = await client.open(new TestProgram(101), { parent });
+			expect(program.parents).to.deep.equal([parent]);
+
+			const reused = await route.open(program);
+			expect(reused).to.equal(program);
+			expect(program.parents).to.deep.equal([parent, undefined]);
+
+			await parent.close();
+			expect(program.closed).to.be.false;
+			expect(program.parents).to.deep.equal([undefined]);
+			await program.close();
+		});
+
+		it(`rejects ${route.name} reuse while attachment is fenced`, async () => {
+			const program = await client.open(new TestProgram());
+			program.preventNewParents();
+
+			await expect(route.open(program)).to.be.rejectedWith(
+				"Program is terminating and cannot accept another parent",
+			);
+			expect(program.parents).to.deep.equal([undefined]);
+		});
+
+		it(`retains ${route.name} identity through post-super close cleanup`, async () => {
+			const program = new TestProgram(137);
+			const baseClose = program.close.bind(program);
+			let markPostSuperCleanupStarted!: () => void;
+			const postSuperCleanupStarted = new Promise<void>((resolve) => {
+				markPostSuperCleanupStarted = resolve;
+			});
+			let releasePostSuperCleanup!: () => void;
+			const postSuperCleanupGate = new Promise<void>((resolve) => {
+				releasePostSuperCleanup = resolve;
+			});
+			program.close = async (from) => {
+				const closed = await baseClose(from);
+				markPostSuperCleanupStarted();
+				await postSuperCleanupGate;
+				return closed;
+			};
+
+			await client.open(program);
+			const closing = program.close();
+			await postSuperCleanupStarted;
+			try {
+				expect(program.closed).to.be.true;
+				await expect(route.open(program)).to.be.rejectedWith(
+					"Program is terminating and cannot accept another parent",
+				);
+			} finally {
+				releasePostSuperCleanup();
+			}
+			await closing;
+		});
+	}
+
+	it("retains address identity through post-super drop cleanup", async () => {
+		const program = new TestProgram(138);
+		const baseDrop = program.drop.bind(program);
+		let markPostSuperCleanupStarted!: () => void;
+		const postSuperCleanupStarted = new Promise<void>((resolve) => {
+			markPostSuperCleanupStarted = resolve;
+		});
+		let releasePostSuperCleanup!: () => void;
+		const postSuperCleanupGate = new Promise<void>((resolve) => {
+			releasePostSuperCleanup = resolve;
+		});
+		program.drop = async (from) => {
+			const dropped = await baseDrop(from);
+			markPostSuperCleanupStarted();
+			await postSuperCleanupGate;
+			return dropped;
+		};
+
+		await client.open(program);
+		const dropping = program.drop();
+		await postSuperCleanupStarted;
+		try {
+			expect(program.closed).to.be.true;
+			await expect(
+				client.open(program.address, { existing: "reuse" }),
+			).to.be.rejectedWith(
+				"Program is terminating and cannot accept another parent",
+			);
+		} finally {
+			releasePostSuperCleanup();
+		}
+		await dropping;
+	});
+
+	it("fences embedded child reuse during post-super cleanup", async () => {
+		const handler = new ProgramHandler({ client });
+		const nested = new TestNestedProgram(401);
+		const baseClose = nested.close.bind(nested);
+		let markPostSuperCleanupStarted!: () => void;
+		const postSuperCleanupStarted = new Promise<void>((resolve) => {
+			markPostSuperCleanupStarted = resolve;
+		});
+		let releasePostSuperCleanup!: () => void;
+		const postSuperCleanupGate = new Promise<void>((resolve) => {
+			releasePostSuperCleanup = resolve;
+		});
+		nested.close = async (from) => {
+			const closed = await baseClose(from);
+			markPostSuperCleanupStarted();
+			await postSuperCleanupGate;
+			return closed;
+		};
+
+		const firstParent = await handler.open(new TestProgram(402, nested));
+		const closing = firstParent.close();
+		await postSuperCleanupStarted;
+		try {
+			await expect(
+				handler.open(new TestProgram(403, nested)),
+			).to.be.rejectedWith("finishing");
+			await expect(
+				handler.open(nested.clone(), { existing: "reuse" }),
+			).to.be.rejectedWith("finishing");
+			await expect(
+				handler.open(nested.address, { existing: "reuse" }),
+			).to.be.rejectedWith("finishing");
+			await expect(
+				handler.open(new TestProgram(435, nested.clone())),
+			).to.be.rejectedWith("finishing");
+		} finally {
+			releasePostSuperCleanup();
+		}
+		await closing;
+
+		const secondParent = await handler.open(new TestProgram(404, nested));
+		expect(secondParent.closed).to.be.false;
+		expect(nested.closed).to.be.false;
+		expect(nested.parents).to.deep.equal([secondParent]);
+		await handler.stop();
+	});
+
+	it("promotes an embedded reuse to a monitored root owner", async () => {
+		const handler = new ProgramHandler({ client });
+		const parent = await handler.open(new TestProgram(436));
+		const child = parent.nested;
+
+		const reused = await handler.open(child.clone(), { existing: "reuse" });
+		expect(reused).to.equal(child);
+		expect(handler.items.get(child.address)).to.equal(child);
+		expect(child.parents).to.include(undefined);
+
+		expect(await parent.close()).to.be.true;
+		expect(child.closed).to.be.false;
+		await handler.stop();
+		expect(child.closed).to.be.true;
+	});
+
+	it("does not resurrect a dropped child block from a rejected clone open", async () => {
+		const handler = new ProgramHandler({ client });
+		const parent = new TestProgram(428);
+		const child = parent.nested;
+		const baseChildDrop = child.drop.bind(child);
+		let markPostSuperCleanupStarted!: () => void;
+		const postSuperCleanupStarted = new Promise<void>((resolve) => {
+			markPostSuperCleanupStarted = resolve;
+		});
+		let releasePostSuperCleanup!: () => void;
+		const postSuperCleanupGate = new Promise<void>((resolve) => {
+			releasePostSuperCleanup = resolve;
+		});
+		child.drop = async (from) => {
+			const dropped = await baseChildDrop(from);
+			markPostSuperCleanupStarted();
+			await postSuperCleanupGate;
+			return dropped;
+		};
+
+		await handler.open(parent);
+		const childAddress = child.address;
+		await child.save(client.services.blocks, { skipOnAddress: false });
+		expect(await client.services.blocks.has(childAddress)).to.be.true;
+		const dropping = parent.drop();
+		await postSuperCleanupStarted;
+		try {
+			expect(await client.services.blocks.has(childAddress)).to.be.false;
+			await expect(
+				handler.open(child.clone(), { existing: "reuse" }),
+			).to.be.rejectedWith("finishing");
+			expect(await client.services.blocks.has(childAddress)).to.be.false;
+		} finally {
+			releasePostSuperCleanup();
+		}
+		expect(await dropping).to.be.true;
+		expect(await client.services.blocks.has(childAddress)).to.be.false;
+		await handler.stop();
+	});
+
+	it("fences embedded child reuse before base cleanup starts", async () => {
+		const handler = new ProgramHandler({ client });
+		const nested = new TestNestedProgram(408);
+		const baseClose = nested.close.bind(nested);
+		let markCleanupStarted!: () => void;
+		const cleanupStarted = new Promise<void>((resolve) => {
+			markCleanupStarted = resolve;
+		});
+		let releaseCleanup!: () => void;
+		const cleanupGate = new Promise<void>((resolve) => {
+			releaseCleanup = resolve;
+		});
+		nested.close = async (from) => {
+			markCleanupStarted();
+			await cleanupGate;
+			return baseClose(from);
+		};
+
+		const firstParent = await handler.open(new TestProgram(409, nested));
+		const closing = firstParent.close();
+		await cleanupStarted;
+		try {
+			await expect(
+				handler.open(new TestProgram(410, nested)),
+			).to.be.rejectedWith("finishing");
+			await expect(
+				handler.open(new TestProgram(437, nested.clone())),
+			).to.be.rejectedWith("finishing");
+		} finally {
+			releaseCleanup();
+		}
+		await closing;
+
+		const secondParent = await handler.open(new TestProgram(411, nested));
+		expect(nested.parents).to.deep.equal([secondParent]);
+		await handler.stop();
+	});
+
+	for (const gateAt of ["save", "beforeOpen"] as const) {
+		it(`reserves an embedded address through ${gateAt}`, async () => {
+			const handler = new ProgramHandler({ client });
+			const first = await handler.open(new TestProgram(438));
+			const child = first.nested;
+			const second = new TestProgram(gateAt === "save" ? 439 : 440, child);
+			let markGateStarted!: () => void;
+			const gateStarted = new Promise<void>((resolve) => {
+				markGateStarted = resolve;
+			});
+			let releaseGate!: () => void;
+			const gate = new Promise<void>((resolve) => {
+				releaseGate = resolve;
+			});
+
+			const originalSave = second.save.bind(second);
+			if (gateAt === "save") {
+				second.save = async (...args: Parameters<TestProgram["save"]>) => {
+					if (args[1]?.skipOnAddress === false) {
+						markGateStarted();
+						await gate;
+					}
+					return originalSave(...args);
+				};
+			}
+
+			const opening = handler.open(second, {
+				onBeforeOpen:
+					gateAt === "beforeOpen"
+						? async (opened) => {
+								if (opened !== second) return;
+								markGateStarted();
+								await gate;
+							}
+						: undefined,
+			});
+			await gateStarted;
+			try {
+				await expect(first.drop()).to.be.rejectedWith(
+					"open generation owns its address",
+				);
+				expect(first.closed).to.be.false;
+				expect(child.closed).to.be.false;
+			} finally {
+				releaseGate();
+			}
+			expect(await opening).to.equal(second);
+			expect(await first.drop()).to.be.true;
+			expect(child.closed).to.be.false;
+			expect(child.parents).to.deep.equal([second]);
+			await handler.stop();
+		});
+	}
+
+	it("does not expose a reserved child before its owning open completes", async () => {
+		const handler = new ProgramHandler({ client });
+		const root = new TestProgram(454);
+		const child = root.nested;
+		const baseOpen = root.open.bind(root);
+		let markRootOpenStarted!: () => void;
+		const rootOpenStarted = new Promise<void>((resolve) => {
+			markRootOpenStarted = resolve;
+		});
+		let releaseRootOpen!: () => void;
+		const rootOpenGate = new Promise<void>((resolve) => {
+			releaseRootOpen = resolve;
+		});
+		root.open = async (args) => {
+			markRootOpenStarted();
+			await rootOpenGate;
+			return baseOpen(args);
+		};
+
+		const rootOpening = handler.open(root);
+		await rootOpenStarted;
+		const waiters = [
+			handler.open(child),
+			handler.open(child.clone(), { existing: "reuse" }),
+			handler.open(child.address, { existing: "reuse" }),
+		];
+		let waitersSettled = false;
+		void Promise.all(waiters).then(() => {
+			waitersSettled = true;
+		});
+		await delay(25);
+		expect(waitersSettled).to.be.false;
+		expect(child.openInvoked).to.be.false;
+
+		releaseRootOpen();
+		expect(await rootOpening).to.equal(root);
+		for (const opened of await Promise.all(waiters)) {
+			expect(opened).to.equal(child);
+		}
+		expect(child.openInvoked).to.be.true;
+		await handler.stop();
+	});
+
+	it("rejects concurrent roots with distinct same-address children", async () => {
+		const handler = new ProgramHandler({ client });
+		const seed = new TestNestedProgram(441);
+		const first = new TestProgram(442, seed.clone());
+		const second = new TestProgram(443, seed.clone());
+		let markSaveStarted!: () => void;
+		const saveStarted = new Promise<void>((resolve) => {
+			markSaveStarted = resolve;
+		});
+		let releaseSave!: () => void;
+		const saveGate = new Promise<void>((resolve) => {
+			releaseSave = resolve;
+		});
+		const originalSave = first.save.bind(first);
+		first.save = async (...args: Parameters<TestProgram["save"]>) => {
+			if (args[1]?.skipOnAddress === false) {
+				markSaveStarted();
+				await saveGate;
+			}
+			return originalSave(...args);
+		};
+
+		const firstOpening = handler.open(first);
+		await saveStarted;
+		try {
+			await expect(handler.open(second)).to.be.rejectedWith(
+				"already opening as another instance",
+			);
+			expect(second.closed).to.be.true;
+			expect(second.nested.closed).to.be.true;
+		} finally {
+			releaseSave();
+		}
+		expect(await firstOpening).to.equal(first);
+		await handler.stop();
+	});
+
+	it("reconciles a shared child's released inverse owner edge", async () => {
+		const handler = new ProgramHandler({ client });
+		const child = new TestNestedProgram(444);
+		const first = await handler.open(new TestProgram(445, child));
+		const second = await handler.open(new TestProgram(446, child));
+
+		expect(await child.close(first)).to.be.false;
+		expect(child.parents).to.deep.equal([second]);
+		expect(first.children).not.to.include(child);
+		expect(await second.close()).to.be.true;
+		expect(child.closed).to.be.true;
+
+		const reopened = await handler.open(child.clone(), { existing: "reuse" });
+		expect(reopened.closed).to.be.false;
+		await handler.stop();
+	});
+
+	it("blocks a direct child drop while another root reserves it", async () => {
+		const handler = new ProgramHandler({ client });
+		const first = await handler.open(new TestProgram(447));
+		const child = first.nested;
+		await child.save(client.services.blocks, { skipOnAddress: false });
+		const second = new TestProgram(448, child);
+		let markSaveStarted!: () => void;
+		const saveStarted = new Promise<void>((resolve) => {
+			markSaveStarted = resolve;
+		});
+		let releaseSave!: () => void;
+		const saveGate = new Promise<void>((resolve) => {
+			releaseSave = resolve;
+		});
+		const originalSave = second.save.bind(second);
+		second.save = async (...args: Parameters<TestProgram["save"]>) => {
+			if (args[1]?.skipOnAddress === false) {
+				markSaveStarted();
+				await saveGate;
+			}
+			return originalSave(...args);
+		};
+
+		const opening = handler.open(second);
+		await saveStarted;
+		try {
+			await expect(child.drop(first)).to.be.rejectedWith(
+				"open generation owns its address",
+			);
+			expect(child.closed).to.be.false;
+			expect(await client.services.blocks.has(child.address)).to.be.true;
+		} finally {
+			releaseSave();
+		}
+		expect(await opening).to.equal(second);
+		expect(await child.drop(first)).to.be.false;
+		expect(await client.services.blocks.has(child.address)).to.be.true;
+		await handler.stop();
+	});
+
+	it("blocks cloned descendants during a direct post-super child drop", async () => {
+		const handler = new ProgramHandler({ client });
+		const child = new TestNestedProgram(449);
+		const baseDrop = child.drop.bind(child);
+		let markPostSuperStarted!: () => void;
+		const postSuperStarted = new Promise<void>((resolve) => {
+			markPostSuperStarted = resolve;
+		});
+		let releasePostSuper!: () => void;
+		const postSuperGate = new Promise<void>((resolve) => {
+			releasePostSuper = resolve;
+		});
+		child.drop = async (from) => {
+			const dropped = await baseDrop(from);
+			markPostSuperStarted();
+			await postSuperGate;
+			return dropped;
+		};
+		const first = await handler.open(new TestProgram(450, child));
+
+		const dropping = child.drop(first);
+		await postSuperStarted;
+		try {
+			await expect(
+				handler.open(new TestProgram(451, child.clone())),
+			).to.be.rejectedWith("operation is finishing");
+		} finally {
+			releasePostSuper();
+		}
+		expect(await dropping).to.be.true;
+		expect(first.children).not.to.include(child);
+
+		const reopened = await handler.open(new TestProgram(452, child.clone()));
+		expect(reopened.nested.closed).to.be.false;
+		await handler.stop();
+	});
+
+	it("reconciles a direct terminal child's inverse owner edge", async () => {
+		const handler = new ProgramHandler({ client });
+		const first = await handler.open(new TestProgram(453));
+		const child = first.nested;
+
+		expect(await child.close(first)).to.be.true;
+		expect(child.parents).to.be.empty;
+		expect(first.children).not.to.include(child);
+
+		const reopened = await handler.open(child.clone(), { existing: "reuse" });
+		expect(reopened.closed).to.be.false;
+		await handler.stop();
+	});
+
+	it("reserves descendant addresses while a final close is queued", async () => {
+		const handler = new ProgramHandler({ client });
+		const owner = await handler.open(new TestProgram(429));
+		const parent = new TestProgram(430);
+		const child = parent.nested;
+		const baseParentClose = parent.close.bind(parent);
+		let markOwnerReleaseStarted!: () => void;
+		const ownerReleaseStarted = new Promise<void>((resolve) => {
+			markOwnerReleaseStarted = resolve;
+		});
+		let releaseOwnerClose!: () => void;
+		const ownerCloseGate = new Promise<void>((resolve) => {
+			releaseOwnerClose = resolve;
+		});
+		let gated = false;
+		parent.close = async (from) => {
+			if (from === owner && !gated) {
+				gated = true;
+				markOwnerReleaseStarted();
+				await ownerCloseGate;
+			}
+			return baseParentClose(from);
+		};
+
+		await handler.open(parent);
+		await handler.open(parent, { parent: owner });
+		const ownerRelease = parent.close(owner);
+		await ownerReleaseStarted;
+		const finalClose = parent.close();
+		try {
+			expect(child.acceptsParentAttachments).to.be.true;
+			await expect(
+				handler.open(child.clone(), { existing: "reuse" }),
+			).to.be.rejectedWith("finishing");
+			await expect(
+				handler.open(child.address, { existing: "reuse" }),
+			).to.be.rejectedWith("finishing");
+		} finally {
+			releaseOwnerClose();
+		}
+		expect(await ownerRelease).to.be.false;
+		expect(await finalClose).to.be.true;
+		await handler.stop();
+	});
+
+	it("fences embedded child reuse after pre-super cleanup rejects", async () => {
+		const handler = new ProgramHandler({ client });
+		const nested = new TestNestedProgram(417);
+		const baseClose = nested.close.bind(nested);
+		const cleanupError = new Error("synthetic embedded pre-super failure");
+		let attempts = 0;
+		nested.close = async (from) => {
+			attempts += 1;
+			if (attempts === 1) throw cleanupError;
+			return baseClose(from);
+		};
+
+		const firstParent = await handler.open(new TestProgram(418, nested));
+		await expect(firstParent.close()).to.be.rejectedWith(cleanupError.message);
+		expect(nested.acceptsParentAttachments).to.be.false;
+		await expect(handler.open(new TestProgram(419, nested))).to.be.rejectedWith(
+			"cleanup",
+		);
+
+		expect(await firstParent.close()).to.be.true;
+		const secondParent = await handler.open(new TestProgram(420, nested));
+		expect(nested.parents).to.deep.equal([secondParent]);
+		await handler.stop();
+	});
+
+	it("retains rejected post-super cleanup until stop retries it", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestProgram(139);
+		const baseClose = program.close.bind(program);
+		const cleanupError = new Error("synthetic post-super cleanup failure");
+		let cleanupAttempts = 0;
+		program.close = async (from) => {
+			const closed = await baseClose(from);
+			cleanupAttempts += 1;
+			if (cleanupAttempts === 1) {
+				throw cleanupError;
+			}
+			return closed;
+		};
+
+		await handler.open(program);
+		let failure: unknown;
+		try {
+			await program.close();
+		} catch (error) {
+			failure = error;
+		}
+		expect(failure).to.equal(cleanupError);
+		expect(program.closed).to.be.true;
+		expect(handler.items.get(program.address)).to.equal(program);
+		await expect(
+			handler.open(program.address, { existing: "reuse" }),
+		).to.be.rejectedWith("failed terminal cleanup");
+
+		await handler.stop();
+		expect(cleanupAttempts).to.equal(2);
+		expect(handler.items.size).to.equal(0);
+	});
+
+	it("retries base Program deletion after drop committed closed", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestProgram(141);
+		await handler.open(program);
+		const rootAddress = program.address;
+		const childAddress = program.nested.address;
+		const blocksRm = client.services.blocks.rm.bind(client.services.blocks);
+		const cleanupError = new Error("synthetic block deletion failure");
+		let rootDeleteAttempts = 0;
+		let childDeleteAttempts = 0;
+		client.services.blocks.rm = (address) => {
+			if (address === childAddress) childDeleteAttempts += 1;
+			if (address === rootAddress) {
+				rootDeleteAttempts += 1;
+				if (rootDeleteAttempts === 1) throw cleanupError;
+			}
+			return blocksRm(address);
+		};
+
+		await expect(program.drop()).to.be.rejectedWith(cleanupError.message);
+		expect(program.closed).to.be.true;
+		expect(handler.items.get(program.address)).to.equal(program);
+
+		await handler.stop();
+		expect(rootDeleteAttempts).to.equal(2);
+		expect(childDeleteAttempts).to.equal(1);
+		expect(handler.items.size).to.equal(0);
+	});
+
+	it("retries the exact drop after cleanup fails before base drop starts", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestProgram(179);
+		const baseDrop = program.drop.bind(program);
+		const cleanupError = new Error("synthetic pre-super drop failure");
+		let attempts = 0;
+		program.drop = async (from) => {
+			attempts += 1;
+			if (attempts === 1) throw cleanupError;
+			return baseDrop(from);
+		};
+
+		await handler.open(program);
+		const address = program.address;
+		await expect(program.drop()).to.be.rejectedWith(cleanupError.message);
+		expect(program.closed).to.be.false;
+		expect(await program.drop()).to.be.true;
+		expect(attempts).to.equal(2);
+		expect(await client.services.blocks.has(address)).to.be.false;
+		await handler.stop();
+	});
+
+	it("fences same-instance admission across handlers until drop retry", async () => {
+		const firstHandler = new ProgramHandler({ client });
+		const secondHandler = new ProgramHandler({ client });
+		const program = new TestProgram(416);
+		const baseDrop = program.drop.bind(program);
+		const cleanupError = new Error("synthetic cross-handler drop failure");
+		let attempts = 0;
+		program.drop = async (from) => {
+			attempts += 1;
+			if (attempts === 1) throw cleanupError;
+			return baseDrop(from);
+		};
+
+		await firstHandler.open(program);
+		await expect(program.drop()).to.be.rejectedWith(cleanupError.message);
+		expect(program.closed).to.be.false;
+		expect(program.acceptsParentAttachments).to.be.false;
+		await expect(secondHandler.open(program)).to.be.rejectedWith(
+			"Program is terminating and cannot accept another parent",
+		);
+
+		expect(await program.drop()).to.be.true;
+		expect(attempts).to.equal(2);
+		await firstHandler.stop();
+
+		const reopened = await secondHandler.open(program);
+		expect(reopened).to.equal(program);
+		expect(reopened.closed).to.be.false;
+		await secondHandler.stop();
+	});
+
+	it("retries a fenced pre-super drop without downgrading deletion", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestProgram(182);
+		const baseDrop = program.drop.bind(program);
+		const cleanupError = new Error("synthetic fenced pre-super drop failure");
+		let attempts = 0;
+		program.drop = async (from) => {
+			attempts += 1;
+			if (attempts === 1) {
+				program.preventNewParents();
+				throw cleanupError;
+			}
+			return baseDrop(from);
+		};
+
+		await handler.open(program);
+		const address = program.address;
+		await expect(program.drop()).to.be.rejectedWith(cleanupError.message);
+		expect(program.acceptsParentAttachments).to.be.false;
+		expect(await program.drop()).to.be.true;
+		expect(attempts).to.equal(2);
+		expect(await client.services.blocks.has(address)).to.be.false;
+		await handler.stop();
+	});
+
+	it("releases a provisional child lease when drop rejects before starting", async () => {
+		const program = await client.open(new TestProgram(407), {
+			args: { dontOpenNested: true },
+		});
+
+		await expect(program.drop()).to.be.rejectedWith(ClosedError);
+		const nested = await client.open(program.nested);
+		expect(nested.closed).to.be.false;
+
+		expect(await program.drop()).to.be.true;
+		expect(await nested.close()).to.be.true;
+	});
+
+	it("reconciles the parent edge after retrying base drop deletion", async () => {
+		const handler = new ProgramHandler({ client });
+		const parent = await handler.open(new TestProgram(180));
+		const child = await handler.open(new TestProgram(181), { parent });
+		const address = child.address;
+		const blocksRm = client.services.blocks.rm.bind(client.services.blocks);
+		const cleanupError = new Error("synthetic child block deletion failure");
+		let attempts = 0;
+		client.services.blocks.rm = (candidate) => {
+			if (candidate === address) {
+				attempts += 1;
+				if (attempts === 1) throw cleanupError;
+			}
+			return blocksRm(candidate);
+		};
+
+		await expect(child.drop(parent)).to.be.rejectedWith(cleanupError.message);
+		expect(child.parents).to.be.empty;
+		expect(parent.children).to.include(child);
+		expect(await child.drop(parent)).to.be.true;
+		expect(attempts).to.equal(2);
+		expect(parent.children).not.to.include(child);
+		expect(await client.services.blocks.has(address)).to.be.false;
+
+		handler.items.delete(parent.address);
+		await handler.stop();
+		await parent.close();
+	});
+
+	it("retries rejected post-super drop cleanup without dropping twice", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestProgram(147);
+		const baseDrop = program.drop.bind(program);
+		const cleanupError = new Error("synthetic post-super drop failure");
+		let cleanupAttempts = 0;
+		program.drop = async (from) => {
+			const dropped = await baseDrop(from);
+			cleanupAttempts += 1;
+			if (cleanupAttempts === 1) throw cleanupError;
+			return dropped;
+		};
+
+		await handler.open(program);
+		await expect(program.drop()).to.be.rejectedWith(cleanupError.message);
+		expect(program.closed).to.be.true;
+		await handler.stop();
+		expect(cleanupAttempts).to.equal(2);
+		expect(handler.items.size).to.equal(0);
+	});
+
+	it("retries a nested post-super drop through a parent close", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestProgram(148);
+		const childDrop = program.nested.drop.bind(program.nested);
+		const cleanupError = new Error("synthetic nested post-super drop failure");
+		let cleanupAttempts = 0;
+		program.nested.drop = async (from) => {
+			const dropped = await childDrop(from);
+			cleanupAttempts += 1;
+			if (cleanupAttempts === 1) throw cleanupError;
+			return dropped;
+		};
+
+		await handler.open(program);
+		await expect(program.drop()).to.be.rejectedWith(cleanupError.message);
+		expect(program.closed).to.be.false;
+		expect(program.nested.closed).to.be.true;
+		await handler.stop();
+		expect(cleanupAttempts).to.equal(2);
+		expect(program.closed).to.be.true;
+		expect(handler.items.size).to.equal(0);
+	});
+
+	it("retries a retained child whose outer close failed after super", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestProgram(145);
+		const childClose = program.nested.close.bind(program.nested);
+		const cleanupError = new Error("synthetic nested post-super failure");
+		let childCloseAttempts = 0;
+		let childCloseEvents = 0;
+		let parentCloseEvents = 0;
+		program.nested.close = async (from) => {
+			const closed = await childClose(from);
+			childCloseAttempts += 1;
+			if (childCloseAttempts === 1) throw cleanupError;
+			return closed;
+		};
+		program.nested.events.addEventListener("close", () => {
+			childCloseEvents += 1;
+		});
+		program.events.addEventListener("close", (event) => {
+			if (event.detail === program) parentCloseEvents += 1;
+		});
+
+		await handler.open(program);
+		await expect(program.close()).to.be.rejectedWith(cleanupError.message);
+		expect(program.closed).to.be.false;
+		expect(program.nested.closed).to.be.true;
+		expect(program.children).to.include(program.nested);
+		expect(childCloseEvents).to.equal(1);
+		expect(parentCloseEvents).to.equal(1);
+
+		await handler.stop();
+		expect(childCloseAttempts).to.equal(2);
+		expect(childCloseEvents).to.equal(1);
+		expect(parentCloseEvents).to.equal(1);
+		expect(program.children).not.to.include(program.nested);
+		expect(program.closed).to.be.true;
+	});
+
+	it("releases a parent lease after direct child recovery removes its edge", async () => {
+		const handler = new ProgramHandler({ client });
+		const parent = await handler.open(new TestProgram(412));
+		const child = new TestProgram(413);
+		const baseClose = child.close.bind(child);
+		const cleanupError = new Error("synthetic direct child recovery failure");
+		let cleanupAttempts = 0;
+		child.close = async (from) => {
+			const closed = await baseClose(from);
+			cleanupAttempts += 1;
+			if (cleanupAttempts === 1) throw cleanupError;
+			return closed;
+		};
+
+		await handler.open(child, { parent });
+		await expect(parent.close()).to.be.rejectedWith(cleanupError.message);
+		expect(await child.close(parent)).to.be.true;
+		expect(parent.children).not.to.include(child);
+		expect(await parent.close()).to.be.true;
+
+		const reopened = await handler.open(child);
+		expect(reopened).to.equal(child);
+		expect(reopened.closed).to.be.false;
+		await handler.stop();
+	});
+
+	it("retries a committed non-terminal child release without releasing the next owner", async () => {
+		const handler = new ProgramHandler({ client });
+		const parentA = await handler.open(new TestProgram(149));
+		const parentB = await handler.open(new TestProgram(150));
+		const child = new TestProgram(151);
+		const childClose = child.close.bind(child);
+		const cleanupError = new Error("synthetic owner A post-super failure");
+		let cleanupAttempts = 0;
+		child.close = async (from) => {
+			const closed = await childClose(from);
+			cleanupAttempts += 1;
+			if (cleanupAttempts === 1) throw cleanupError;
+			return closed;
+		};
+
+		await handler.open(child, { parent: parentA });
+		await handler.open(child, { parent: parentB });
+		await expect(parentA.close()).to.be.rejectedWith(cleanupError.message);
+		expect(child.parents).to.deep.equal([parentB]);
+		expect(parentA.children).to.include(child);
+
+		expect(await parentA.close()).to.be.true;
+		expect(cleanupAttempts).to.equal(2);
+		expect(parentA.closed).to.be.true;
+		expect(child.closed).to.be.false;
+		expect(child.parents).to.deep.equal([parentB]);
+		expect(parentA.children).not.to.include(child);
+		await handler.stop();
+	});
+
+	it("retries a committed terminal child cleanup with the original owner", async () => {
+		const handler = new ProgramHandler({ client });
+		const parent = await handler.open(new TestProgram(156));
+		const child = new TestProgram(157);
+		const childClose = child.close.bind(child);
+		const cleanupError = new Error("synthetic terminal owner cleanup failure");
+		const cleanupOwners: (TestProgram | undefined)[] = [];
+		child.close = async (from) => {
+			const closed = await childClose(from);
+			cleanupOwners.push(from as TestProgram | undefined);
+			if (cleanupOwners.length === 1) throw cleanupError;
+			return closed;
+		};
+
+		await handler.open(child, { parent });
+		await expect(child.close(parent)).to.be.rejectedWith(cleanupError.message);
+		expect(child.closed).to.be.true;
+		expect(child.parents).to.be.empty;
+		expect(parent.children).to.include(child);
+
+		handler.items.delete(parent.address);
+		await handler.stop();
+		expect(cleanupOwners).to.deep.equal([parent, parent]);
+		expect(parent.children).not.to.include(child);
+		await parent.close();
+	});
+
+	it("serializes duplicate owner releases instead of coalescing them", async () => {
+		const handler = new ProgramHandler({ client });
+		const parent = await handler.open(new TestProgram(158));
+		const child = new TestProgram(159);
+		const childClose = child.close.bind(child);
+		let cleanupCalls = 0;
+		child.close = async (from) => {
+			cleanupCalls += 1;
+			await delay(1);
+			return childClose(from);
+		};
+
+		await handler.open(child, { parent });
+		await handler.open(child, { parent });
+		expect(child.parents).to.deep.equal([parent, parent]);
+		expect(
+			parent.children.filter((candidate) => candidate === child),
+		).to.have.length(2);
+
+		const first = child.close(parent);
+		const second = child.close(parent);
+		expect(second).not.to.equal(first);
+		expect(await first).to.be.false;
+		expect(await second).to.be.true;
+		expect(cleanupCalls).to.equal(2);
+		expect(child.parents).to.be.empty;
+		expect(parent.children).not.to.include(child);
+
+		handler.items.delete(parent.address);
+		await handler.stop();
+		await parent.close();
+	});
+
+	it("serializes immediate duplicate owner releases after synchronous base progress", async () => {
+		const handler = new ProgramHandler({ client });
+		const parent = await handler.open(new TestProgram(175));
+		const child = new TestProgram(176);
+
+		await handler.open(child, { parent });
+		await handler.open(child, { parent });
+		const first = child.close(parent);
+		const second = child.close(parent);
+
+		expect(second).not.to.equal(first);
+		expect(await first).to.be.false;
+		expect(await second).to.be.true;
+		expect(child.parents).to.be.empty;
+		expect(parent.children).not.to.include(child);
+		handler.items.delete(parent.address);
+		await handler.stop();
+		await parent.close();
+	});
+
+	it("keeps duplicate ownership edges aligned after a later close fails", async () => {
+		const handler = new ProgramHandler({ client });
+		const parent = await handler.open(new TestProgram(405));
+		const child = new TestProgram(406);
+		const baseClose = child.close.bind(child);
+		const cleanupError = new Error("synthetic second owner close failure");
+		let closeAttempts = 0;
+		child.close = async (from) => {
+			closeAttempts += 1;
+			if (closeAttempts === 2) throw cleanupError;
+			return baseClose(from);
+		};
+
+		await handler.open(child, { parent });
+		await handler.open(child, { parent });
+		handler.items.delete(parent.address);
+		await expect(handler.stop()).to.be.rejectedWith(cleanupError.message);
+		expect(child.closed).to.be.false;
+		expect(child.parents).to.deep.equal([parent]);
+		expect(
+			parent.children.filter((candidate) => candidate === child),
+		).to.have.length(1);
+
+		await handler.stop();
+		expect(child.closed).to.be.true;
+		expect(parent.children).not.to.include(child);
+		await parent.close();
+	});
+
+	it("restores wrapped terminal methods before another handler reopens an instance", async () => {
+		const firstHandler = new ProgramHandler({ client });
+		const secondHandler = new ProgramHandler({ client });
+		const program = new TestProgram(177);
+		const originalClose = program.close;
+		const originalDrop = program.drop;
+
+		await firstHandler.open(program);
+		expect(program.close).not.to.equal(originalClose);
+		expect(await program.close()).to.be.true;
+		expect(program.close).to.equal(originalClose);
+		expect(program.drop).to.equal(originalDrop);
+
+		await secondHandler.open(program);
+		expect(program.close).not.to.equal(originalClose);
+		expect(await program.close()).to.be.true;
+		expect(program.close).to.equal(originalClose);
+		expect(program.drop).to.equal(originalDrop);
+		await firstHandler.stop();
+		await secondHandler.stop();
+	});
+
+	it("does not spend a duplicate owner reference past failed cleanup", async () => {
+		const handler = new ProgramHandler({ client });
+		const parent = await handler.open(new TestProgram(163));
+		const child = new TestProgram(164);
+		const childClose = child.close.bind(child);
+		const cleanupError = new Error("synthetic duplicate owner cleanup failure");
+		let cleanupAttempts = 0;
+		child.close = async (from) => {
+			const closed = await childClose(from);
+			cleanupAttempts += 1;
+			if (cleanupAttempts === 1) throw cleanupError;
+			return closed;
+		};
+
+		await handler.open(child, { parent });
+		await handler.open(child, { parent });
+		await expect(parent.close()).to.be.rejectedWith(cleanupError.message);
+		expect(cleanupAttempts).to.equal(1);
+		expect(child.closed).to.be.false;
+		expect(child.parents).to.deep.equal([parent]);
+		expect(
+			parent.children.filter((candidate) => candidate === child),
+		).to.have.length(2);
+
+		expect(await parent.close()).to.be.true;
+		expect(cleanupAttempts).to.equal(3);
+		expect(child.closed).to.be.true;
+		expect(child.parents).to.be.empty;
+		expect(parent.children).not.to.include(child);
+
+		await handler.stop();
+	});
+
+	it("rejects a parent close when a child reports no ownership progress", async () => {
+		const handler = new ProgramHandler({ client });
+		const parent = await handler.open(new TestProgram(168));
+		const child = new TestProgram(169);
+		const childClose = child.close.bind(child);
+		let allowProgress = false;
+		let childCloseCalls = 0;
+		child.close = (from) => {
+			childCloseCalls += 1;
+			return allowProgress ? childClose(from) : Promise.resolve(false);
+		};
+
+		await handler.open(child, { parent });
+		await handler.open(child, { parent });
+		await expect(parent.close()).to.be.rejectedWith(
+			"did not release parent ownership",
+		);
+		expect(childCloseCalls).to.equal(1);
+		expect(parent.closed).to.be.false;
+		expect(child.closed).to.be.false;
+		expect(child.parents).to.deep.equal([parent, parent]);
+		expect(
+			parent.children.filter((candidate) => candidate === child),
+		).to.have.length(2);
+
+		allowProgress = true;
+		expect(await parent.close()).to.be.true;
+		expect(childCloseCalls).to.equal(3);
+		expect(child.closed).to.be.true;
+		expect(parent.children).not.to.include(child);
+		await handler.stop();
+	});
+
+	it("singleflights a queued release that will become terminal", async () => {
+		const handler = new ProgramHandler({ client });
+		const parentA = await handler.open(new TestProgram(160));
+		const parentB = await handler.open(new TestProgram(161));
+		const child = new TestProgram(162);
+		const childClose = child.close.bind(child);
+		let cleanupCalls = 0;
+		child.close = async (from) => {
+			cleanupCalls += 1;
+			await delay(1);
+			return childClose(from);
+		};
+
+		await handler.open(child, { parent: parentA });
+		await handler.open(child, { parent: parentB });
+		const releaseA = child.close(parentA);
+		const releaseB = child.close(parentB);
+		const duplicateB = child.close(parentB);
+
+		expect(releaseB).not.to.equal(releaseA);
+		expect(duplicateB).to.equal(releaseB);
+		expect(await releaseA).to.be.false;
+		expect(await releaseB).to.be.true;
+		expect(cleanupCalls).to.equal(2);
+		expect(child.parents).to.be.empty;
+		expect(parentA.children).not.to.include(child);
+		expect(parentB.children).not.to.include(child);
+
+		await handler.stop();
+	});
+
+	it("waits for and retries a failing outer close during stop", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestProgram(140);
+		const baseClose = program.close.bind(program);
+		const cleanupError = new Error("synthetic in-flight cleanup failure");
+		let cleanupAttempts = 0;
+		let markFirstCleanupStarted!: () => void;
+		const firstCleanupStarted = new Promise<void>((resolve) => {
+			markFirstCleanupStarted = resolve;
+		});
+		let releaseFirstCleanup!: () => void;
+		const firstCleanupGate = new Promise<void>((resolve) => {
+			releaseFirstCleanup = resolve;
+		});
+		program.close = async (from) => {
+			const closed = await baseClose(from);
+			cleanupAttempts += 1;
+			if (cleanupAttempts === 1) {
+				markFirstCleanupStarted();
+				await firstCleanupGate;
+				throw cleanupError;
+			}
+			return closed;
+		};
+
+		await handler.open(program);
+		const closing = program.close();
+		await firstCleanupStarted;
+		let stopSettled = false;
+		const stopping = handler.stop().then(() => {
+			stopSettled = true;
+		});
+		await delay(25);
+		expect(stopSettled).to.be.false;
+		releaseFirstCleanup();
+
+		let closeFailure: unknown;
+		try {
+			await closing;
+		} catch (error) {
+			closeFailure = error;
+		}
+		expect(closeFailure).to.equal(cleanupError);
+		await stopping;
+		expect(cleanupAttempts).to.equal(2);
+		expect(handler.items.size).to.equal(0);
+	});
+
+	it("serializes an address reload after evicting a stale closed cache entry", async () => {
+		const handler = new ProgramHandler({ client });
+		const stale = await handler.open(new TestProgram(102));
+		const address = stale.address;
+		await stale.close();
+		handler.items.set(address, stale);
+		const parent = await handler.open(new TestProgram(103));
+
+		const originalGet = client.services.blocks.get.bind(client.services.blocks);
+		let markLoadStarted!: () => void;
+		const loadStarted = new Promise<void>((resolve) => {
+			markLoadStarted = resolve;
+		});
+		let releaseLoad!: () => void;
+		const loadGate = new Promise<void>((resolve) => {
+			releaseLoad = resolve;
+		});
+		let matchingLoads = 0;
+		client.services.blocks.get = async (cid, options) => {
+			if (cid === address) {
+				matchingLoads += 1;
+				markLoadStarted();
+				await loadGate;
+			}
+			return originalGet(cid, options);
+		};
+
+		let rootOpen: Promise<TestProgram> | undefined;
+		let parentOpen: Promise<TestProgram> | undefined;
+		try {
+			rootOpen = handler.open(address, {
+				existing: "reuse",
+			}) as Promise<TestProgram>;
+			await loadStarted;
+			let parentResolved = false;
+			parentOpen = (
+				handler.open(address, { parent }) as Promise<TestProgram>
+			).then((program) => {
+				parentResolved = true;
+				return program;
+			});
+
+			await delay(25);
+			expect(parentResolved).to.be.false;
+			releaseLoad();
+
+			const [rootResult, parentResult] = await Promise.all([
+				rootOpen,
+				parentOpen,
+			]);
+			expect(rootResult).to.equal(parentResult);
+			expect(rootResult.closed).to.be.false;
+			expect(handler.items.get(address)).to.equal(rootResult);
+			expect(rootResult.parents).to.have.length(2);
+			expect(rootResult.parents).to.have.members([undefined, parent]);
+			expect(
+				parent.children.filter((child) => child === rootResult),
+			).to.have.length(1);
+			expect(matchingLoads).to.equal(1);
+		} finally {
+			releaseLoad();
+			await Promise.allSettled(
+				[rootOpen, parentOpen].filter(
+					(open): open is Promise<TestProgram> => open !== undefined,
+				),
+			);
+			client.services.blocks.get = originalGet;
+			await handler.stop();
+		}
+	});
+
+	it("serializes a closed-clone reopen after evicting a stale closed cache entry", async () => {
+		const handler = new ProgramHandler({ client });
+		const stale = await handler.open(new TestProgram(104));
+		const address = stale.address;
+		await stale.close();
+		handler.items.set(address, stale);
+		const parent = await handler.open(new TestProgram(105));
+		const candidate = stale.clone();
+
+		let markOpenStarted!: () => void;
+		const openStarted = new Promise<void>((resolve) => {
+			markOpenStarted = resolve;
+		});
+		let releaseOpen!: () => void;
+		const openGate = new Promise<void>((resolve) => {
+			releaseOpen = resolve;
+		});
+		let openCalls = 0;
+		const originalOpen = candidate.open.bind(candidate);
+		candidate.open = async (args) => {
+			openCalls += 1;
+			markOpenStarted();
+			await openGate;
+			return originalOpen(args);
+		};
+
+		let rootOpen: Promise<TestProgram> | undefined;
+		let parentOpen: Promise<TestProgram> | undefined;
+		try {
+			rootOpen = handler.open(candidate, { existing: "reuse" });
+			const firstOutcome = await Promise.race([
+				openStarted.then(() => "started" as const),
+				rootOpen.then(() => "resolved" as const),
+			]);
+			expect(firstOutcome).to.equal("started");
+
+			let parentResolved = false;
+			parentOpen = (
+				handler.open(address, { parent }) as Promise<TestProgram>
+			).then((program) => {
+				parentResolved = true;
+				return program;
+			});
+			await delay(25);
+			expect(parentResolved).to.be.false;
+			releaseOpen();
+
+			const [rootResult, parentResult] = await Promise.all([
+				rootOpen,
+				parentOpen,
+			]);
+			expect(rootResult).to.equal(candidate);
+			expect(rootResult).to.equal(parentResult);
+			expect(rootResult.closed).to.be.false;
+			expect(handler.items.get(address)).to.equal(rootResult);
+			expect(rootResult.parents).to.have.length(2);
+			expect(rootResult.parents).to.have.members([undefined, parent]);
+			expect(
+				parent.children.filter((child) => child === rootResult),
+			).to.have.length(1);
+			expect(openCalls).to.equal(1);
+		} finally {
+			releaseOpen();
+			await Promise.allSettled(
+				[rootOpen, parentOpen].filter(
+					(open): open is Promise<TestProgram> => open !== undefined,
+				),
+			);
+			await handler.stop();
+		}
 	});
 
 	it("can open different dbs concurrently", async () => {
@@ -62,6 +1738,702 @@ describe(`shared`, () => {
 		expect(db2.closed).to.be.false;
 		expect(db2.address).to.equal(address);
 		expect(db2).to.not.equal(db1);
+	});
+
+	it("honors reject for an already-open parent-owned program", async () => {
+		const parent = await client.open(new TestProgram(123));
+		const original = await client.open(new TestProgram(124), { parent });
+		const candidate = original.clone();
+		const parentChildrenBefore = [...parent.children];
+
+		await expect(
+			client.open(candidate, { parent, existing: "reject" }),
+		).to.be.rejectedWith(`Program at ${original.address} is already open`);
+		expect(original.closed).to.be.false;
+		expect(parent.children).to.deep.equal(parentChildrenBefore);
+		expect(parent.children).not.to.include(candidate);
+		expect(candidate.closed).to.be.true;
+	});
+
+	it("replaces a sole parent-owned program without leaving a stale child edge", async () => {
+		const parent = await client.open(new TestProgram(125));
+		const original = await client.open(new TestProgram(126), { parent });
+		const candidate = original.clone();
+		const unrelatedChildren = parent.children.filter(
+			(child) => child !== original,
+		);
+
+		const replacement = await client.open(candidate, {
+			parent,
+			existing: "replace",
+		});
+
+		expect(replacement).to.equal(candidate);
+		expect(original.closed).to.be.true;
+		expect(original.parents).to.deep.equal([]);
+		expect(
+			parent.children.filter((child) => child !== candidate),
+		).to.deep.equal(unrelatedChildren);
+		expect(parent.children).not.to.include(original);
+		expect(
+			parent.children.filter((child) => child === candidate),
+		).to.have.length(1);
+		expect(candidate.parents).to.deep.equal([parent]);
+
+		await parent.drop();
+		expect(candidate.closed).to.be.true;
+	});
+
+	it("rejects parent replacement while another parent still owns the program", async () => {
+		const firstParent = await client.open(new TestProgram(127));
+		const secondParent = await client.open(new TestProgram(128));
+		const original = await client.open(new TestProgram(129), {
+			parent: firstParent,
+		});
+		await client.open(original, { parent: secondParent });
+		const candidate = original.clone();
+		const firstParentChildrenBefore = [...firstParent.children];
+		const secondParentChildrenBefore = [...secondParent.children];
+
+		await expect(
+			client.open(candidate, {
+				parent: firstParent,
+				existing: "replace",
+			}),
+		).to.be.rejectedWith("cannot be replaced while it has other owners");
+		expect(original.closed).to.be.false;
+		expect(original.parents).to.have.members([firstParent, secondParent]);
+		expect(firstParent.children).to.deep.equal(firstParentChildrenBefore);
+		expect(secondParent.children).to.deep.equal(secondParentChildrenBefore);
+		expect(firstParent.children).not.to.include(candidate);
+		expect(secondParent.children).not.to.include(candidate);
+	});
+
+	for (const route of ["address", "closed clone"] as const) {
+		it(`does not replace through ${route} while another owner remains`, async () => {
+			const parent = await client.open(new TestProgram(106));
+			const original = await client.open(new TestProgram(107), { parent });
+			await client.open(original);
+			const parentsBefore = [...original.parents];
+			const parentChildrenBefore = [...parent.children];
+			const candidate = original.clone();
+
+			const replacement =
+				route === "address"
+					? client.open(original.address, { existing: "replace" })
+					: client.open(candidate, { existing: "replace" });
+			await expect(replacement).to.be.rejectedWith(
+				"cannot be replaced while it has other owners",
+			);
+
+			expect(original.closed).to.be.false;
+			expect(original.parents).to.deep.equal(parentsBefore);
+			expect(parent.children).to.deep.equal(parentChildrenBefore);
+			expect(
+				parent.children.filter((child) => child === original),
+			).to.have.length(1);
+			expect(
+				await client.open(original.address, { existing: "reuse" }),
+			).to.equal(original);
+			if (route === "closed clone") {
+				expect(candidate.closed).to.be.true;
+			}
+		});
+	}
+
+	it("does not replace when close reports a non-terminal result", async () => {
+		const original = await client.open(new TestProgram(108));
+		const candidate = original.clone();
+		const originalClose = original.close.bind(original);
+		original.close = async () => false;
+		try {
+			await expect(
+				client.open(candidate, { existing: "replace" }),
+			).to.be.rejectedWith("close was not terminal");
+
+			expect(original.closed).to.be.false;
+			expect(original.parents).to.deep.equal([undefined]);
+			expect(candidate.closed).to.be.true;
+			expect(
+				await client.open(original.address, { existing: "reuse" }),
+			).to.equal(original);
+		} finally {
+			original.close = originalClose;
+		}
+	});
+
+	it("rolls back a failed initialization and permits a clean retry", async () => {
+		const handler = new ProgramHandler({ client });
+		const parent = await handler.open(new TestProgram(109));
+		const candidate = new TestProgram(110);
+		const originalError = new Error("synthetic open failure");
+		const parentsBefore = candidate.parents;
+		const childrenBefore = candidate.children;
+		const parentChildrenBefore = [...parent.children];
+		const originalOpen = candidate.open.bind(candidate);
+		let attempts = 0;
+		candidate.open = async (args) => {
+			attempts += 1;
+			if (attempts === 1) {
+				throw originalError;
+			}
+			await originalOpen(args);
+		};
+
+		try {
+			let failure: unknown;
+			try {
+				await handler.open(candidate, { parent });
+			} catch (error) {
+				failure = error;
+			}
+			expect(failure).to.equal(originalError);
+			expect(handler.items.has(candidate.address)).to.be.false;
+			expect(candidate.closed).to.be.true;
+			expect(candidate.parents).to.deep.equal(parentsBefore);
+			expect(candidate.children).to.deep.equal(childrenBefore);
+			expect(candidate.nested.closed).to.be.true;
+			expect(parent.children).to.deep.equal(parentChildrenBefore);
+
+			const retried = await handler.open(candidate, { parent });
+			expect(retried).to.equal(candidate);
+			expect(retried.closed).to.be.false;
+			expect(attempts).to.equal(2);
+			expect(handler.items.get(candidate.address)).to.equal(candidate);
+			expect(candidate.parents).to.deep.equal([parent]);
+			expect(
+				parent.children.filter((child) => child === candidate),
+			).to.have.length(1);
+		} finally {
+			await handler.stop();
+		}
+	});
+
+	it("root-closes an unowned rollback child after a no-progress cleanup", async () => {
+		const handler = new ProgramHandler({ client });
+		const candidate = new TestProgram(170);
+		const childClose = candidate.nested.close.bind(candidate.nested);
+		let allowProgress = false;
+		let childCloseCalls = 0;
+		candidate.nested.close = (from) => {
+			childCloseCalls += 1;
+			return allowProgress ? childClose(from) : Promise.resolve(false);
+		};
+		candidate.open = async () => {
+			throw new Error("synthetic rollback no-progress failure");
+		};
+
+		await expect(handler.open(candidate)).to.be.rejectedWith(
+			"synthetic rollback no-progress failure",
+		);
+		expect(candidate.closed).to.be.false;
+		expect(candidate.nested.closed).to.be.false;
+		expect(candidate.nested.parents).to.be.empty;
+
+		allowProgress = true;
+		await handler.stop();
+		expect(candidate.closed).to.be.true;
+		expect(candidate.nested.closed).to.be.true;
+		expect(childCloseCalls).to.equal(3);
+		expect(handler.items.size).to.equal(0);
+	});
+
+	it("retains a rollback residual until repeated callback cleanup succeeds", async () => {
+		const handler = new ProgramHandler({ client });
+		const root = new TestProgram(421);
+		const cleanupError = new Error("synthetic residual callback failure");
+		let callbackAttempts = 0;
+
+		await expect(
+			handler.open(root, {
+				onBeforeOpen: async (opened) => {
+					if (opened === root) {
+						throw new Error("synthetic residual open failure");
+					}
+				},
+				onClose: async (closed) => {
+					if (closed !== root.nested) return;
+					callbackAttempts += 1;
+					if (callbackAttempts <= 2) throw cleanupError;
+				},
+			}),
+		).to.be.rejectedWith("synthetic residual open failure");
+		expect(callbackAttempts).to.equal(1);
+		expect(root.nested.closed).to.be.true;
+		expect(root.nested.pendingTerminalOperation).to.equal("close");
+		expect(handler.items.get(root.nested.address)).to.equal(root.nested);
+
+		await expect(handler.stop()).to.be.rejectedWith(cleanupError.message);
+		expect(callbackAttempts).to.equal(2);
+		expect(root.nested.pendingTerminalOperation).to.equal("close");
+
+		await handler.stop();
+		expect(callbackAttempts).to.equal(3);
+		expect(root.nested.pendingTerminalOperation).to.be.undefined;
+		handler.start();
+		await handler.stop();
+	});
+
+	it("blocks rollback residual reopen until post-super cleanup is retried", async () => {
+		const handler = new ProgramHandler({ client });
+		const root = new TestProgram(422);
+		const child = root.nested;
+		const baseChildClose = child.close.bind(child);
+		const cleanupError = new Error("synthetic residual post-super failure");
+		let childCloseCalls = 0;
+		child.close = async (from) => {
+			const closed = await baseChildClose(from);
+			childCloseCalls += 1;
+			if (childCloseCalls === 1) throw cleanupError;
+			return closed;
+		};
+
+		await expect(
+			handler.open(root, {
+				onBeforeOpen: async (opened) => {
+					if (opened === root) {
+						throw new Error("synthetic residual reopen failure");
+					}
+				},
+			}),
+		).to.be.rejectedWith("synthetic residual reopen failure");
+		expect(childCloseCalls).to.equal(1);
+		expect(child.closed).to.be.true;
+		await expect(handler.open(child)).to.be.rejectedWith("cleanup");
+
+		await handler.stop();
+		expect(childCloseCalls).to.equal(2);
+		expect(child.pendingTerminalOperation).to.be.undefined;
+
+		handler.start();
+		const reopened = await handler.open(child);
+		expect(reopened).to.equal(child);
+		expect(reopened.closed).to.be.false;
+		await handler.stop();
+	});
+
+	it("does not replay a managed child failure as a rollback residual", async () => {
+		const handler = new ProgramHandler({ client });
+		const child = new TestNestedProgram(425);
+		const baseChildClose = child.close.bind(child);
+		const cleanupError = new Error("synthetic managed rollback overlap");
+		const closeFrom: (TestProgram | undefined)[] = [];
+		child.close = async (from) => {
+			const closed = await baseChildClose(from);
+			closeFrom.push(from as TestProgram | undefined);
+			if (closeFrom.length === 1) throw cleanupError;
+			return closed;
+		};
+		await handler.open(child);
+		const root = new TestProgram(426, child);
+
+		await expect(
+			handler.open(root, {
+				onBeforeOpen: async (opened) => {
+					if (opened === root) {
+						throw new Error("synthetic managed root open failure");
+					}
+				},
+			}),
+		).to.be.rejectedWith("synthetic managed root open failure");
+
+		await handler.stop();
+		expect(closeFrom).to.deep.equal([root, root, undefined]);
+	});
+
+	it("reserves a rollback child address while post-super cleanup drains", async () => {
+		const handler = new ProgramHandler({ client });
+		const root = new TestProgram(427);
+		const child = root.nested;
+		const baseChildClose = child.close.bind(child);
+		const cleanupError = new Error("synthetic gated rollback cleanup");
+		let closeAttempts = 0;
+		let markPostSuperStarted!: () => void;
+		const postSuperStarted = new Promise<void>((resolve) => {
+			markPostSuperStarted = resolve;
+		});
+		let releasePostSuper!: () => void;
+		const postSuperGate = new Promise<void>((resolve) => {
+			releasePostSuper = resolve;
+		});
+		child.close = async (from) => {
+			const closed = await baseChildClose(from);
+			closeAttempts += 1;
+			if (closeAttempts === 1) {
+				markPostSuperStarted();
+				await postSuperGate;
+				throw cleanupError;
+			}
+			return closed;
+		};
+
+		const opening = handler.open(root, {
+			onBeforeOpen: async (opened) => {
+				if (opened === root) {
+					throw new Error("synthetic gated root open failure");
+				}
+			},
+		});
+		await postSuperStarted;
+		try {
+			await expect(handler.open(child)).to.be.rejectedWith("cleanup");
+			await expect(
+				handler.open(child.clone(), { existing: "reuse" }),
+			).to.be.rejectedWith("cleanup");
+			await expect(
+				handler.open(child.address, { existing: "reuse" }),
+			).to.be.rejectedWith("cleanup");
+		} finally {
+			releasePostSuper();
+		}
+		await expect(opening).to.be.rejectedWith(
+			"synthetic gated root open failure",
+		);
+		await expect(
+			handler.open(child.clone(), { existing: "reuse" }),
+		).to.be.rejectedWith("cleanup");
+
+		await handler.stop();
+		expect(closeAttempts).to.equal(2);
+		handler.start();
+		const reopened = await handler.open(child);
+		expect(reopened).to.equal(child);
+		await handler.stop();
+	});
+
+	it("rejects shared-child roots during rollback and permits a clean retry", async () => {
+		const handler = new ProgramHandler({ client });
+		const child = new TestNestedProgram(432);
+		const firstRoot = new TestProgram(433, child);
+		const secondRoot = new TestProgram(434, child);
+		const baseChildClose = child.close.bind(child);
+		let markFirstCleanupStarted!: () => void;
+		const firstCleanupStarted = new Promise<void>((resolve) => {
+			markFirstCleanupStarted = resolve;
+		});
+		let markSecondCleanupStarted!: () => void;
+		const secondCleanupStarted = new Promise<void>((resolve) => {
+			markSecondCleanupStarted = resolve;
+		});
+		let releaseFirstCleanup!: () => void;
+		const firstCleanupGate = new Promise<void>((resolve) => {
+			releaseFirstCleanup = resolve;
+		});
+		let releaseSecondCleanup!: () => void;
+		const secondCleanupGate = new Promise<void>((resolve) => {
+			releaseSecondCleanup = resolve;
+		});
+		child.close = async (from) => {
+			const closed = await baseChildClose(from);
+			if (from === firstRoot) {
+				markFirstCleanupStarted();
+				await firstCleanupGate;
+			} else if (from === secondRoot) {
+				markSecondCleanupStarted();
+				await secondCleanupGate;
+			}
+			return closed;
+		};
+		const openWithRootFailure = async (root: TestProgram): Promise<unknown> => {
+			try {
+				await handler.open(root, {
+					onBeforeOpen: async (opened) => {
+						if (opened === root) {
+							throw new Error(`synthetic shared rollback ${root.id}`);
+						}
+					},
+				});
+				return undefined;
+			} catch (error) {
+				return error;
+			}
+		};
+
+		const firstOpenResult = openWithRootFailure(firstRoot);
+		await firstCleanupStarted;
+		try {
+			await expect(
+				handler.open(child.clone(), { existing: "reuse" }),
+			).to.be.rejectedWith("cleanup");
+			const blockedSecondResult = await openWithRootFailure(secondRoot);
+			expect(blockedSecondResult).to.be.instanceOf(Error);
+			expect(String(blockedSecondResult)).to.contain("cleanup");
+			releaseFirstCleanup();
+			expect(await firstOpenResult).to.be.instanceOf(Error);
+
+			const secondOpenResult = openWithRootFailure(secondRoot);
+			await secondCleanupStarted;
+			await expect(
+				handler.open(child.address, { existing: "reuse" }),
+			).to.be.rejectedWith("cleanup");
+			releaseSecondCleanup();
+			expect(await secondOpenResult).to.be.instanceOf(Error);
+		} finally {
+			releaseFirstCleanup();
+			releaseSecondCleanup();
+		}
+
+		const reopened = await handler.open(child);
+		expect(reopened).to.equal(child);
+		await handler.stop();
+	});
+
+	it("preserves concurrent sibling attachments when rollback removes its edge", async () => {
+		const handler = new ProgramHandler({ client });
+		const parent = await handler.open(new TestProgram(118));
+		const failing = new TestProgram(119);
+		const sibling = new TestProgram(120);
+		let markOpenStarted!: () => void;
+		const openStarted = new Promise<void>((resolve) => {
+			markOpenStarted = resolve;
+		});
+		let releaseOpen!: () => void;
+		const openGate = new Promise<void>((resolve) => {
+			releaseOpen = resolve;
+		});
+		failing.open = async () => {
+			markOpenStarted();
+			await openGate;
+			throw new Error("synthetic concurrent failure");
+		};
+
+		const failedOpen = handler.open(failing, { parent });
+		try {
+			await openStarted;
+			const openedSibling = await handler.open(sibling, { parent });
+			expect(parent.children).to.include(failing);
+			expect(parent.children).to.include(openedSibling);
+
+			releaseOpen();
+			await expect(failedOpen).to.be.rejectedWith(
+				"synthetic concurrent failure",
+			);
+
+			expect(parent.children).not.to.include(failing);
+			expect(
+				parent.children.filter((child) => child === openedSibling),
+			).to.have.length(1);
+			expect(openedSibling.parents).to.deep.equal([parent]);
+
+			await parent.close();
+			expect(openedSibling.closed).to.be.true;
+		} finally {
+			releaseOpen();
+			await Promise.allSettled([failedOpen]);
+			await handler.stop();
+		}
+	});
+
+	it("retains a live failed cleanup until stop can retry it", async () => {
+		const handler = new ProgramHandler({ client });
+		const parent = await handler.open(new TestProgram(121));
+		const candidate = new TestProgram(122);
+		const originalOpen = candidate.open.bind(candidate);
+		const originalClose = candidate.close.bind(candidate);
+		const originalError = new Error("synthetic open failure");
+		const cleanupError = new Error("synthetic cleanup failure");
+		let attempts = 0;
+		candidate.open = async (args) => {
+			attempts += 1;
+			if (attempts === 1) {
+				throw originalError;
+			}
+			await originalOpen(args);
+		};
+		candidate.close = async () => {
+			throw cleanupError;
+		};
+
+		try {
+			let failure: unknown;
+			try {
+				await handler.open(candidate, { parent });
+			} catch (error) {
+				failure = error;
+			}
+			expect(failure).to.equal(originalError);
+			expect(candidate.closed).to.be.false;
+			expect(handler.items.get(candidate.address)).to.equal(candidate);
+			expect(parent.children).not.to.include(candidate);
+			await expect(handler.open(candidate, { parent })).to.be.rejectedWith(
+				"failed initialization cleanup",
+			);
+
+			candidate.close = originalClose;
+			await handler.stop();
+			expect(candidate.closed).to.be.true;
+			expect(handler.items.size).to.equal(0);
+
+			handler.start();
+			const reopenedParent = await handler.open(parent);
+			const retried = await handler.open(candidate, {
+				parent: reopenedParent,
+			});
+			expect(retried).to.equal(candidate);
+			expect(retried.closed).to.be.false;
+			expect(attempts).to.equal(2);
+		} finally {
+			candidate.close = originalClose;
+			await handler.stop();
+		}
+	});
+
+	it("composes user lifecycle callbacks without disabling Handler ownership", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestProgram(152);
+		let beforeOpenCalls = 0;
+		let closeCalls = 0;
+		await handler.open(program, {
+			onBeforeOpen: () => {
+				beforeOpenCalls += 1;
+			},
+			onClose: async () => {
+				closeCalls += 1;
+			},
+		});
+		expect(beforeOpenCalls).to.equal(2); // nested and root
+		expect(handler.items.get(program.address)).to.equal(program);
+
+		await handler.stop();
+		expect(closeCalls).to.equal(2); // nested and root
+		expect(program.closed).to.be.true;
+		expect(handler.items.size).to.equal(0);
+	});
+
+	it("retries an awaited terminal callback before releasing ownership", async () => {
+		const handler = new ProgramHandler({ client });
+		const parent = await handler.open(new TestProgram(153));
+		const child = new TestProgram(154);
+		const callbackError = new Error("synthetic terminal callback failure");
+		let callbackAttempts = 0;
+		await handler.open(child, {
+			parent,
+			onClose: async (closed) => {
+				if (closed !== child) return;
+				callbackAttempts += 1;
+				if (callbackAttempts === 1) throw callbackError;
+			},
+		});
+
+		await expect(child.close(parent)).to.be.rejectedWith(callbackError.message);
+		expect(child.closed).to.be.true;
+		expect(child.parents).to.deep.equal([parent]);
+		expect(parent.children).to.include(child);
+
+		handler.items.delete(parent.address);
+		await handler.stop();
+		expect(callbackAttempts).to.equal(2);
+		expect(child.parents).to.be.empty;
+		expect(parent.children).not.to.include(child);
+		await parent.close();
+	});
+
+	it("reconciles an owner edge released during a direct callback retry", async () => {
+		const handler = new ProgramHandler({ client });
+		const parent = await handler.open(new TestProgram(414));
+		const child = new TestProgram(415);
+		const callbackError = new Error("synthetic direct callback retry failure");
+		let callbackAttempts = 0;
+		await handler.open(child, {
+			parent,
+			onClose: async (closed) => {
+				if (closed !== child) return;
+				callbackAttempts += 1;
+				if (callbackAttempts === 1) throw callbackError;
+			},
+		});
+
+		await expect(child.close(parent)).to.be.rejectedWith(callbackError.message);
+		expect(child.parents).to.deep.equal([parent]);
+		expect(
+			parent.children.filter((candidate) => candidate === child),
+		).to.have.length(1);
+
+		expect(await child.close(parent)).to.be.true;
+		expect(callbackAttempts).to.equal(2);
+		expect(child.parents).to.be.empty;
+		expect(parent.children).not.to.include(child);
+
+		handler.items.delete(parent.address);
+		await handler.stop();
+		await parent.close();
+	});
+
+	it("lets a parent resume a nested child's pending close tail", async () => {
+		const handler = new ProgramHandler({ client });
+		const parent = new TestProgram(171);
+		const callbackError = new Error("synthetic nested close tail failure");
+		let callbackAttempts = 0;
+		await handler.open(parent, {
+			onClose: async (closed) => {
+				if (closed !== parent.nested) return;
+				callbackAttempts += 1;
+				if (callbackAttempts === 1) throw callbackError;
+			},
+		});
+
+		await expect(parent.nested.close(parent)).to.be.rejectedWith(
+			callbackError.message,
+		);
+		expect(parent.nested.closed).to.be.true;
+		expect(parent.nested.pendingTerminalOperation).to.equal("close");
+		expect(parent.children).to.include(parent.nested);
+
+		expect(await parent.close()).to.be.true;
+		expect(callbackAttempts).to.equal(2);
+		expect(parent.nested.pendingTerminalOperation).to.be.undefined;
+		expect(parent.children).not.to.include(parent.nested);
+		await handler.stop();
+	});
+
+	it("does not let close bypass pending drop callback cleanup", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestProgram(165);
+		const unwrappedClose = program.close.bind(program);
+		const callbackError = new Error("synthetic pending drop callback failure");
+		let callbackAttempts = 0;
+		await handler.open(program, {
+			onDrop: async (dropped) => {
+				if (dropped !== program) return;
+				callbackAttempts += 1;
+				if (callbackAttempts === 1) throw callbackError;
+			},
+		});
+
+		await expect(program.drop()).to.be.rejectedWith(callbackError.message);
+		expect(program.closed).to.be.true;
+		await expect(unwrappedClose()).to.be.rejectedWith("pending drop cleanup");
+
+		await handler.stop();
+		expect(callbackAttempts).to.equal(2);
+	});
+
+	it("retains closed nested cleanup failures from early initialization rollback", async () => {
+		const handler = new ProgramHandler({ client });
+		const program = new TestProgram(155);
+		const childClose = program.nested.close.bind(program.nested);
+		const cleanupError = new Error("synthetic closed rollback residual");
+		let cleanupAttempts = 0;
+		program.nested.close = async (from) => {
+			const closed = await childClose(from);
+			cleanupAttempts += 1;
+			if (cleanupAttempts === 1) throw cleanupError;
+			return closed;
+		};
+
+		await expect(
+			handler.open(program, {
+				onBeforeOpen: (opened) => {
+					if (opened === program)
+						throw new Error("synthetic root open failure");
+				},
+			}),
+		).to.be.rejectedWith("synthetic root open failure");
+		expect(program.closed).to.be.true;
+		expect(program.nested.closed).to.be.true;
+
+		await handler.stop();
+		expect(cleanupAttempts).to.equal(2);
 	});
 
 	it("is open on open", async () => {
@@ -251,6 +2623,261 @@ describe(`shared`, () => {
 		expect(p1.closed).to.be.true;
 	});
 
+	it("does not deadlock a reserved nested open behind an external waiter", async () => {
+		const handler = new ProgramHandler({ client });
+		const originalOpen = client.open.bind(client);
+		client.open = handler.open.bind(handler) as typeof client.open;
+		const root = new TestParenteRefernceProgram();
+		let markChildBeforeOpen!: () => void;
+		const childBeforeOpen = new Promise<void>((resolve) => {
+			markChildBeforeOpen = resolve;
+		});
+		let releaseChildBeforeOpen!: () => void;
+		const childBeforeOpenGate = new Promise<void>((resolve) => {
+			releaseChildBeforeOpen = resolve;
+		});
+
+		try {
+			const rootOpening = handler.open(root, {
+				onBeforeOpen: async (opened) => {
+					if (opened !== root.nested) return;
+					markChildBeforeOpen();
+					await childBeforeOpenGate;
+				},
+			});
+			await childBeforeOpen;
+			const externalChildOpening = handler.open(root.nested, {
+				existing: "reuse",
+			});
+			await delay(25);
+			releaseChildBeforeOpen();
+
+			const [openedRoot, openedChild] = await Promise.all([
+				rootOpening,
+				externalChildOpening,
+			]);
+			expect(openedRoot).to.equal(root);
+			expect(openedChild).to.equal(root.nested);
+			await handler.stop();
+		} finally {
+			releaseChildBeforeOpen();
+			client.open = originalOpen;
+		}
+	});
+
+	for (const route of ["exact", "clone", "address"] as const) {
+		it(`adopts a dynamic nested ${route} reuse into an external opening generation`, async () => {
+			const handler = new ProgramHandler({ client });
+			const originalOpen = client.open.bind(client);
+			client.open = handler.open.bind(handler) as typeof client.open;
+			const child = new TestNestedProgram(455);
+			const first = new TestProgram(456, child);
+			const second = new TestProgram(457, child);
+			await second.calculateAddress();
+			let markFirstOpenStarted!: () => void;
+			const firstOpenStarted = new Promise<void>((resolve) => {
+				markFirstOpenStarted = resolve;
+			});
+			let releaseNestedOpen!: () => void;
+			const nestedOpenGate = new Promise<void>((resolve) => {
+				releaseNestedOpen = resolve;
+			});
+			let nestedSecond: TestProgram | undefined;
+			let secondOpenCalls = 0;
+			const originalSecondOpen = second.open.bind(second);
+			second.open = async (args) => {
+				secondOpenCalls += 1;
+				await originalSecondOpen(args);
+			};
+			first.open = async () => {
+				markFirstOpenStarted();
+				await nestedOpenGate;
+				const requested =
+					route === "exact"
+						? second
+						: route === "clone"
+							? second.clone()
+							: second.address;
+				nestedSecond = (await first.node.open(requested, {
+					parent: first,
+					existing: "reuse",
+				})) as TestProgram;
+			};
+
+			try {
+				const firstOpening = handler.open(first);
+				await firstOpenStarted;
+				const secondOpening = handler.open(second);
+				await delay(25);
+				releaseNestedOpen();
+
+				const [openedFirst, openedSecond] = await Promise.all([
+					firstOpening,
+					secondOpening,
+				]);
+				expect(openedFirst).to.equal(first);
+				expect(openedSecond).to.equal(second);
+				expect(nestedSecond).to.equal(second);
+				expect(secondOpenCalls).to.equal(1);
+				expect(
+					second.parents.filter((parent) => parent == null),
+				).to.have.length(1);
+				expect(
+					second.parents.filter((parent) => parent === first),
+				).to.have.length(1);
+				expect(
+					child.parents.filter((parent) => parent === first),
+				).to.have.length(1);
+				expect(
+					child.parents.filter((parent) => parent === second),
+				).to.have.length(1);
+				await handler.stop();
+				const state = handler as unknown as {
+					_openingPromises: Map<string, Promise<TestProgram>>;
+					_openingReservations: Set<unknown>;
+					_openingReservationsByAddress: Map<string, Set<unknown>>;
+				};
+				expect(state._openingPromises.size).to.equal(0);
+				expect(state._openingReservations.size).to.equal(0);
+				expect(state._openingReservationsByAddress.size).to.equal(0);
+			} finally {
+				releaseNestedOpen();
+				client.open = originalOpen;
+			}
+		});
+	}
+
+	it("retracts a failed adopted participant before authorizing nested reuse", async () => {
+		const handler = new ProgramHandler({ client });
+		const originalOpen = client.open.bind(client);
+		client.open = handler.open.bind(handler) as typeof client.open;
+		const child = new TestNestedProgram(460);
+		const first = new TestProgram(461, child);
+		const second = new TestProgram(462, child);
+		await second.calculateAddress();
+		second.open = async () => {
+			throw new Error("synthetic adopted generation failure");
+		};
+		let markFirstOpenStarted!: () => void;
+		const firstOpenStarted = new Promise<void>((resolve) => {
+			markFirstOpenStarted = resolve;
+		});
+		let releaseNestedOpen!: () => void;
+		const nestedOpenGate = new Promise<void>((resolve) => {
+			releaseNestedOpen = resolve;
+		});
+		let markNestedFailed!: () => void;
+		const nestedFailed = new Promise<void>((resolve) => {
+			markNestedFailed = resolve;
+		});
+		let releaseFirstOpen!: () => void;
+		const firstOpenGate = new Promise<void>((resolve) => {
+			releaseFirstOpen = resolve;
+		});
+		first.open = async () => {
+			markFirstOpenStarted();
+			await nestedOpenGate;
+			try {
+				await first.node.open(second, { parent: first, existing: "reuse" });
+			} catch {
+				markNestedFailed();
+				await firstOpenGate;
+			}
+		};
+
+		try {
+			const firstOpening = handler.open(first);
+			await firstOpenStarted;
+			const secondOpening = handler.open(second);
+			await delay(25);
+			releaseNestedOpen();
+			await nestedFailed;
+			await expect(secondOpening).to.be.rejectedWith(
+				"synthetic adopted generation failure",
+			);
+			expect(second.closed).to.be.true;
+			const state = handler as unknown as {
+				_openingReservations: Set<{
+					programs: Set<unknown>;
+					group: { participantReferences: Map<unknown, number> };
+				}>;
+			};
+			const firstReservation = [...state._openingReservations].find(
+				(reservation) => reservation.programs.has(first),
+			);
+			expect(firstReservation).to.exist;
+			expect(firstReservation!.group.participantReferences.has(second)).to.be
+				.false;
+			await expect(
+				handler.open(child as any, {
+					parent: second as any,
+					existing: "reuse",
+				}),
+			).to.be.rejectedWith("Parent program");
+			expect(
+				child.parents.filter((parent) => parent === second),
+			).to.have.length(0);
+
+			releaseFirstOpen();
+			expect(await firstOpening).to.equal(first);
+			await handler.stop();
+			expect(child.closed).to.be.true;
+		} finally {
+			releaseNestedOpen();
+			releaseFirstOpen();
+			client.open = originalOpen;
+		}
+	});
+
+	it("rejects a reserved dependency as parent before it is open", async () => {
+		const handler = new ProgramHandler({ client });
+		const prospectiveParent = new TestNestedProgram(465);
+		const root = new TestProgram(466, prospectiveParent);
+		const outsider = new TestNestedProgram(467);
+		let markBeforeOpenStarted!: () => void;
+		const beforeOpenStarted = new Promise<void>((resolve) => {
+			markBeforeOpenStarted = resolve;
+		});
+		let releaseBeforeOpen!: () => void;
+		const beforeOpenGate = new Promise<void>((resolve) => {
+			releaseBeforeOpen = resolve;
+		});
+		root.beforeOpen = async () => {
+			markBeforeOpenStarted();
+			await beforeOpenGate;
+			throw new Error("synthetic root pre-open failure");
+		};
+
+		const rootOpening = handler.open(root);
+		try {
+			await beforeOpenStarted;
+			expect(prospectiveParent.closed).to.be.true;
+			await expect(
+				handler.open(outsider as any, {
+					parent: prospectiveParent as any,
+					existing: "reuse",
+				}),
+			).to.be.rejectedWith("Parent program is closed");
+			expect(outsider.closed).to.be.true;
+			expect(outsider.parents ?? []).to.have.length(0);
+			expect(
+				(prospectiveParent.children ?? []).filter(
+					(child) => child === outsider,
+				),
+			).to.have.length(0);
+
+			releaseBeforeOpen();
+			await expect(rootOpening).to.be.rejectedWith(
+				"synthetic root pre-open failure",
+			);
+			await handler.stop();
+			expect(outsider.closed).to.be.true;
+		} finally {
+			releaseBeforeOpen();
+			await Promise.allSettled([rootOpening]);
+		}
+	});
+
 	it("rejects", async () => {
 		const someParent = new TestProgram();
 		await expect(client.open(someParent, { parent: someParent })).rejectedWith(
@@ -355,6 +2982,289 @@ describe(`shared`, () => {
 	// TODO add tests for subprograms that is also open as root program
 
 	describe("parent option", () => {
+		it("fences parent close while a child attachment is waiting", async () => {
+			const handler = new ProgramHandler({ client });
+			const parent = await handler.open(new TestProgram(463));
+			const child = new TestNestedProgram(464);
+			const baseChildOpen = child.open.bind(child);
+			let markChildOpenStarted!: () => void;
+			const childOpenStarted = new Promise<void>((resolve) => {
+				markChildOpenStarted = resolve;
+			});
+			let releaseChildOpen!: () => void;
+			const childOpenGate = new Promise<void>((resolve) => {
+				releaseChildOpen = resolve;
+			});
+			child.open = async () => {
+				markChildOpenStarted();
+				await childOpenGate;
+				await baseChildOpen();
+			};
+
+			const rootOpening = handler.open(child);
+			await childOpenStarted;
+			const nestedOpening = handler.open(child as any, {
+				parent: parent as any,
+				existing: "reuse",
+			});
+			try {
+				await delay(25);
+				await expect(parent.close()).to.be.rejectedWith(
+					"opening child attachment",
+				);
+				expect(parent.closed).to.be.false;
+				releaseChildOpen();
+				const [root, nested] = await Promise.all([rootOpening, nestedOpening]);
+				expect(root).to.equal(child);
+				expect(nested).to.equal(child);
+				expect(
+					child.parents.filter((owner) => owner === parent),
+				).to.have.length(1);
+				expect(
+					parent.children.filter((owned) => owned === child),
+				).to.have.length(1);
+			} finally {
+				releaseChildOpen();
+				await Promise.allSettled([rootOpening, nestedOpening]);
+				await handler.stop();
+			}
+		});
+
+		for (const first of ["root", "parent"] as const) {
+			it(`waits for a ${first}-initiated open before resolving the concurrent ${
+				first === "root" ? "parent" : "root"
+			} open`, async () => {
+				const parent = await client.open(new TestProgram(999));
+				const child = new TestProgram(1);
+				let markOpenStarted!: () => void;
+				const openStarted = new Promise<void>((resolve) => {
+					markOpenStarted = resolve;
+				});
+				let releaseOpen!: () => void;
+				const openGate = new Promise<void>((resolve) => {
+					releaseOpen = resolve;
+				});
+				let openCompleted = false;
+				const originalOpen = child.open.bind(child);
+				child.open = async (args) => {
+					markOpenStarted();
+					await openGate;
+					await originalOpen(args);
+					openCompleted = true;
+				};
+
+				const rootOpen = () => client.open(child);
+				const parentOpen = () => client.open(child, { parent });
+				const firstOpen = first === "root" ? rootOpen() : parentOpen();
+				await openStarted;
+				let secondResolved = false;
+				const secondOpen = (first === "root" ? parentOpen() : rootOpen()).then(
+					(result) => {
+						secondResolved = true;
+						return result;
+					},
+				);
+
+				try {
+					await delay(25);
+					expect(secondResolved).to.be.false;
+					expect(openCompleted).to.be.false;
+				} finally {
+					releaseOpen();
+				}
+
+				const [firstResult, secondResult] = await Promise.all([
+					firstOpen,
+					secondOpen,
+				]);
+				expect(firstResult).to.equal(child);
+				expect(secondResult).to.equal(child);
+				expect(openCompleted).to.be.true;
+				expect(child.parents).to.have.length(2);
+				expect(child.parents).to.have.members([parent, undefined]);
+			});
+		}
+
+		it("singleflights simultaneous opens from two parents", async () => {
+			const handler = new ProgramHandler({ client });
+			const firstParent = await handler.open(new TestProgram(134));
+			const secondParent = await handler.open(new TestProgram(135));
+			const firstCandidate = new TestProgram(136);
+			const secondCandidate = firstCandidate.clone();
+
+			let saveArrivals = 0;
+			let releaseInitialSaves!: () => void;
+			const initialSaveGate = new Promise<void>((resolve) => {
+				releaseInitialSaves = resolve;
+			});
+			const gateInitialSave = (program: TestProgram) => {
+				const originalSave = program.save.bind(program);
+				let calls = 0;
+				program.save = async (store, options) => {
+					const address = await originalSave(store, options);
+					calls += 1;
+					if (calls === 1) {
+						saveArrivals += 1;
+						if (saveArrivals === 2) {
+							releaseInitialSaves();
+						}
+						await initialSaveGate;
+					}
+					return address;
+				};
+			};
+			gateInitialSave(firstCandidate);
+			gateInitialSave(secondCandidate);
+
+			let initializationStarts = 0;
+			let markInitializationStarted!: () => void;
+			const initializationStarted = new Promise<void>((resolve) => {
+				markInitializationStarted = resolve;
+			});
+			let releaseInitialization!: () => void;
+			const initializationGate = new Promise<void>((resolve) => {
+				releaseInitialization = resolve;
+			});
+			for (const candidate of [firstCandidate, secondCandidate]) {
+				const originalOpen = candidate.open.bind(candidate);
+				candidate.open = async (args) => {
+					initializationStarts += 1;
+					markInitializationStarted();
+					await initializationGate;
+					await originalOpen(args);
+				};
+			}
+
+			let firstOpen: Promise<TestProgram> | undefined;
+			let secondOpen: Promise<TestProgram> | undefined;
+			try {
+				firstOpen = handler.open(firstCandidate, { parent: firstParent });
+				secondOpen = handler.open(secondCandidate, { parent: secondParent });
+				await initializationStarted;
+				await delay(25);
+				expect(initializationStarts).to.equal(1);
+
+				releaseInitialization();
+				const [firstResult, secondResult] = await Promise.all([
+					firstOpen,
+					secondOpen,
+				]);
+				expect(firstResult).to.equal(secondResult);
+				expect([firstCandidate, secondCandidate]).to.include(firstResult);
+				expect(firstResult.parents).to.have.length(2);
+				expect(firstResult.parents).to.have.members([
+					firstParent,
+					secondParent,
+				]);
+				expect(
+					firstParent.children.filter((child) => child === firstResult),
+				).to.have.length(1);
+				expect(
+					secondParent.children.filter((child) => child === firstResult),
+				).to.have.length(1);
+			} finally {
+				releaseInitialSaves();
+				releaseInitialization();
+				await Promise.allSettled(
+					[firstOpen, secondOpen].filter(
+						(promise): promise is Promise<TestProgram> => promise !== undefined,
+					),
+				);
+				await handler.stop();
+			}
+		});
+
+		for (const first of ["root", "parent"] as const) {
+			it(`lets a concurrent ${first === "root" ? "parent" : "root"} open run after a ${first} generation fails`, async () => {
+				const handler = new ProgramHandler({ client });
+				const parent = await handler.open(new TestProgram(130));
+				const failing = new TestProgram(131);
+				const retry = failing.clone();
+				let markOpenStarted!: () => void;
+				const openStarted = new Promise<void>((resolve) => {
+					markOpenStarted = resolve;
+				});
+				let releaseOpen!: () => void;
+				const openGate = new Promise<void>((resolve) => {
+					releaseOpen = resolve;
+				});
+				failing.open = async () => {
+					markOpenStarted();
+					await openGate;
+					throw new Error("synthetic first-generation failure");
+				};
+
+				const firstOpen =
+					first === "root"
+						? handler.open(failing)
+						: handler.open(failing, { parent });
+				await openStarted;
+				const secondOpen =
+					first === "root"
+						? handler.open(retry, { parent })
+						: handler.open(retry);
+
+				try {
+					releaseOpen();
+					await expect(firstOpen).to.be.rejectedWith(
+						"synthetic first-generation failure",
+					);
+					const result = await secondOpen;
+					expect(result).to.equal(retry);
+					expect(result.closed).to.be.false;
+					expect(result.parents).to.deep.equal(
+						first === "root" ? [parent] : [undefined],
+					);
+					expect(parent.children).not.to.include(failing);
+				} finally {
+					releaseOpen();
+					await Promise.allSettled([firstOpen, secondOpen]);
+					await handler.stop();
+				}
+			});
+		}
+
+		it("applies parent reject after waiting for a successful root generation", async () => {
+			const handler = new ProgramHandler({ client });
+			const parent = await handler.open(new TestProgram(132));
+			const child = new TestProgram(133);
+			const candidate = child.clone();
+			let markOpenStarted!: () => void;
+			const openStarted = new Promise<void>((resolve) => {
+				markOpenStarted = resolve;
+			});
+			let releaseOpen!: () => void;
+			const openGate = new Promise<void>((resolve) => {
+				releaseOpen = resolve;
+			});
+			const originalOpen = child.open.bind(child);
+			child.open = async (args) => {
+				markOpenStarted();
+				await openGate;
+				await originalOpen(args);
+			};
+
+			const rootOpen = handler.open(child);
+			await openStarted;
+			const parentOpen = handler.open(candidate, {
+				parent,
+				existing: "reject",
+			});
+			try {
+				releaseOpen();
+				expect(await rootOpen).to.equal(child);
+				await expect(parentOpen).to.be.rejectedWith(
+					`Program at ${child.address} is already open`,
+				);
+				expect(child.parents).to.deep.equal([undefined]);
+				expect(parent.children).not.to.include(child);
+			} finally {
+				releaseOpen();
+				await Promise.allSettled([rootOpen, parentOpen]);
+				await handler.stop();
+			}
+		});
+
 		it("second open should wait for first open to complete", async () => {
 			const parent = new TestProgram(999);
 			await client.open(parent);
@@ -397,6 +3307,142 @@ describe(`shared`, () => {
 	});
 
 	describe("stop", () => {
+		it("drains admitted queued opens and requires an explicit restart", async () => {
+			const handler = new ProgramHandler({ client });
+			const first = new TestProgram(111);
+			const second = first.clone();
+			let markOpenStarted!: () => void;
+			const openStarted = new Promise<void>((resolve) => {
+				markOpenStarted = resolve;
+			});
+			let releaseOpen!: () => void;
+			const openGate = new Promise<void>((resolve) => {
+				releaseOpen = resolve;
+			});
+			const originalOpen = first.open.bind(first);
+			first.open = async (args) => {
+				markOpenStarted();
+				await openGate;
+				await originalOpen(args);
+			};
+
+			let firstOpen: Promise<TestProgram> | undefined;
+			let queuedOpen: Promise<TestProgram> | undefined;
+			let stopping: Promise<void> | undefined;
+			try {
+				firstOpen = handler.open(first);
+				await openStarted;
+				queuedOpen = handler.open(second, { existing: "reuse" });
+				stopping = handler.stop();
+
+				expect(handler.stop()).to.equal(stopping);
+				await expect(handler.open(new TestProgram(112))).to.be.rejectedWith(
+					"Program handler is stopping or stopped",
+				);
+
+				releaseOpen();
+				const [firstResult, queuedResult] = await Promise.all([
+					firstOpen,
+					queuedOpen,
+				]);
+				expect(firstResult).to.equal(first);
+				expect(queuedResult).to.equal(first);
+				await stopping;
+				expect(first.closed).to.be.true;
+
+				await expect(handler.open(new TestProgram(113))).to.be.rejectedWith(
+					"Program handler is stopping or stopped",
+				);
+				handler.start();
+				const reopened = await handler.open(new TestProgram(113));
+				expect(reopened.closed).to.be.false;
+				await handler.stop();
+				expect(reopened.closed).to.be.true;
+			} finally {
+				releaseOpen();
+				await Promise.allSettled(
+					[firstOpen, queuedOpen, stopping].filter(
+						(promise): promise is Promise<TestProgram> | Promise<void> =>
+							promise !== undefined,
+					),
+				);
+				await handler.stop();
+			}
+		});
+
+		it("fully closes a multi-owned program even when one close returns false", async () => {
+			const handler = new ProgramHandler({ client });
+			const parent = await handler.open(new TestProgram(114));
+			const child = await handler.open(new TestProgram(115), { parent });
+			await handler.open(child);
+			expect(child.parents).to.deep.equal([parent, undefined]);
+			const closeSteps: {
+				ownersBefore: number;
+				ownersAfter: number;
+				closed: boolean;
+			}[] = [];
+			const originalClose = child.close.bind(child);
+			child.close = async (from) => {
+				const ownersBefore = child.parents.length;
+				const closed = await originalClose(from);
+				closeSteps.push({
+					ownersBefore,
+					ownersAfter: child.parents.length,
+					closed,
+				});
+				return closed;
+			};
+
+			// Leave only the child under Handler ownership. This makes stop responsible
+			// for draining both of its references instead of relying on parent.close().
+			handler.items.delete(parent.address);
+			try {
+				await handler.stop();
+				expect(child.closed).to.be.true;
+				expect(handler.items.size).to.equal(0);
+				expect(parent.children).not.to.include(child);
+				expect(closeSteps).to.deep.equal([
+					{ ownersBefore: 2, ownersAfter: 1, closed: false },
+					{ ownersBefore: 1, ownersAfter: 0, closed: true },
+				]);
+			} finally {
+				child.close = originalClose;
+				await parent.close();
+				await handler.stop();
+			}
+		});
+
+		it("keeps admissions closed when stopping makes no ownership progress", async () => {
+			const handler = new ProgramHandler({ client });
+			const program = await handler.open(new TestProgram(116));
+			const originalClose = program.close.bind(program);
+			let closeCalls = 0;
+			program.close = async () => {
+				closeCalls += 1;
+				return false;
+			};
+
+			try {
+				await expect(handler.stop()).to.be.rejectedWith(
+					"did not make ownership progress while stopping (1 -> 1)",
+				);
+				expect(closeCalls).to.equal(1);
+				expect(program.closed).to.be.false;
+				expect(handler.items.get(program.address)).to.equal(program);
+				await expect(handler.open(new TestProgram(117))).to.be.rejectedWith(
+					"Program handler is stopping or stopped",
+				);
+
+				program.close = originalClose;
+				await handler.stop();
+				expect(program.closed).to.be.true;
+				expect(handler.items.size).to.equal(0);
+			} finally {
+				program.close = originalClose;
+				await handler.stop();
+			}
+		});
+
 		it("waits for in-progress parent opens to complete", async () => {
 			const parent = new TestProgram(999);
 			await client.open(parent);

--- a/packages/programs/program/program/test/samples.ts
+++ b/packages/programs/program/program/test/samples.ts
@@ -156,6 +156,34 @@ export class TestProgram extends Program<{ dontOpenNested?: boolean }> {
 	}
 }
 
+@variant("test-same-address-siblings")
+export class TestSameAddressSiblingsProgram extends Program {
+	nestedOpenResult?: TestNestedProgram;
+
+	@field({ type: "u32" })
+	id: number;
+
+	@field({ type: TestNestedProgram })
+	first: TestNestedProgram;
+
+	@field({ type: TestNestedProgram })
+	second: TestNestedProgram;
+
+	constructor(id: number = 0, seed: number = 0) {
+		super();
+		this.id = id;
+		this.first = new TestNestedProgram(seed);
+		this.second = new TestNestedProgram(seed);
+	}
+
+	async open(): Promise<void> {
+		this.nestedOpenResult = await this.node.open(this.first as any, {
+			parent: this as any,
+		});
+		await Promise.all([this.first.open(), this.second.open()]);
+	}
+}
+
 @variant("test-shared-loose-parent-ref")
 export class TestParenteRefernceProgram extends Program {
 	@field({ type: "u32" })

--- a/packages/programs/program/program/test/samples.ts
+++ b/packages/programs/program/program/test/samples.ts
@@ -143,6 +143,10 @@ export class TestProgram extends Program<{ dontOpenNested?: boolean }> {
 		this.nested = nested;
 	}
 
+	preventNewParents(): void {
+		this.preventParentAttachments();
+	}
+
 	async open(args?: { dontOpenNested?: boolean }): Promise<void> {
 		if (args?.dontOpenNested) {
 			this.nested.closed = true;

--- a/packages/programs/rpc/src/controller.ts
+++ b/packages/programs/rpc/src/controller.ts
@@ -129,6 +129,7 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 	private _responseType!: AbstractType<R>;
 	private _rpcTopic!: string;
 	private _onMessageBinded: ((arg: any) => any) | undefined = undefined;
+	private _listenerAttached = false;
 	private _keypair!: X25519Keypair;
 	private _getResponseValueFn!: (decrypted: DecryptedThing<R>) => R;
 	private _getRequestValueFn!: (decrypted: DecryptedThing<Q>) => Q;
@@ -148,24 +149,67 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 		await this.subscribe();
 	}
 
-	private async _close(from?: Program): Promise<void> {
+	private async _close(): Promise<void> {
 		if (this._subscribed) {
 			await this.node.services.pubsub.unsubscribe(this.topic);
+			this._subscribed = false;
+		}
+		if (this._listenerAttached) {
 			await this.node.services.pubsub.removeEventListener(
 				"data",
 				this._onMessageBinded,
 			);
+			this._listenerAttached = false;
 		}
-		this._subscribed = false;
 	}
 	public async close(from?: Program): Promise<boolean> {
-		await this._close(from);
-		return super.close(from);
+		let firstError: unknown;
+		let closed = false;
+		try {
+			closed = await super.close(from);
+		} catch (error) {
+			if (!this.closed || this.pendingTerminalOperation !== "close") {
+				throw error;
+			}
+			firstError = error;
+		}
+		if (!closed && firstError === undefined) {
+			return false;
+		}
+		try {
+			await this._close();
+		} catch (error) {
+			firstError ??= error;
+		}
+		if (firstError !== undefined) {
+			throw firstError;
+		}
+		return true;
 	}
 
 	public async drop(from?: Program): Promise<boolean> {
-		await this._close(from);
-		return super.drop(from);
+		let firstError: unknown;
+		let dropped = false;
+		try {
+			dropped = await super.drop(from);
+		} catch (error) {
+			if (!this.closed || this.pendingTerminalOperation !== "drop") {
+				throw error;
+			}
+			firstError = error;
+		}
+		if (!dropped && firstError === undefined) {
+			return false;
+		}
+		try {
+			await this._close();
+		} catch (error) {
+			firstError ??= error;
+		}
+		if (firstError !== undefined) {
+			throw firstError;
+		}
+		return true;
 	}
 
 	private _subscribing: Promise<void> | void | undefined;
@@ -180,6 +224,7 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 		this._onMessageBinded = this._onMessageBinded || this._onMessage.bind(this);
 
 		this.node.services.pubsub.addEventListener("data", this._onMessageBinded!);
+		this._listenerAttached = true;
 
 		this._subscribing = this.node.services.pubsub.subscribe(this.topic);
 
@@ -188,6 +233,9 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 	}
 
 	private async _onMessage(evt: CustomEvent<DataEvent>): Promise<void> {
+		if (this.closed) {
+			return;
+		}
 		const { data, message } = evt.detail;
 
 		if (data?.topics.find((x) => x === this.topic) != null) {
@@ -232,6 +280,9 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 							);
 							request = this._getRequestValueFn(decrypted);
 						}
+						if (this.closed) {
+							return;
+						}
 						stage = "handle-request";
 						let from = message.header.signatures!.publicKeys[0];
 
@@ -253,7 +304,7 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 							transport,
 						});
 
-						if (response && rpcMessage.respondTo) {
+						if (!this.closed && response && rpcMessage.respondTo) {
 							// send query and wait for replies in a generator like behaviour
 							stage = "encode-response";
 							const serializedResponse = serialize(response);
@@ -274,6 +325,9 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 								this._keypair,
 								[rpcMessage.respondTo],
 							);
+							if (this.closed) {
+								return;
+							}
 
 							await this.node.services.pubsub.publish(
 								serialize(

--- a/packages/programs/rpc/test/index.spec.ts
+++ b/packages/programs/rpc/test/index.spec.ts
@@ -626,6 +626,150 @@ describe("rpc", () => {
 			expect(listenerCount).equal(0);
 		});
 
+		for (const operation of ["close", "drop"] as const) {
+			it(`${operation} keeps the subscription for a non-terminal owner release`, async () => {
+				await session.peers[1].open(reader.query, {
+					parent: reader as any,
+					existing: "reuse",
+				});
+				expect(reader.query.parents).to.deep.equal([reader, reader]);
+
+				expect(await reader.query[operation](reader)).to.be.false;
+				expect(reader.query.closed).to.be.false;
+				expect(
+					(reader.node.services.pubsub as any)["listenerCount"]("data"),
+				).equal(1);
+				expect(
+					await reader.query.request(
+						new Body({ arr: new Uint8Array([8, 9]) }),
+						{ amount: 1 },
+					),
+				).to.have.length(1);
+			});
+
+			it(`${operation} does not unsubscribe for an invalid owner`, async () => {
+				const wrongOwner = new RPCTest([]);
+				wrongOwner.query = new RPC();
+				await expect(reader.query[operation](wrongOwner)).to.be.rejectedWith(
+					"Could not find from in parents",
+				);
+				expect(reader.query.closed).to.be.false;
+				expect(
+					(reader.node.services.pubsub as any)["listenerCount"]("data"),
+				).equal(1);
+				expect(
+					await reader.query.request(
+						new Body({ arr: new Uint8Array([10, 11]) }),
+						{ amount: 1 },
+					),
+				).to.have.length(1);
+			});
+		}
+
+		for (const operation of ["close", "drop"] as const) {
+			it(`${operation} makes a committed base failure network-inert before exact retry`, async () => {
+				const cleanupError = new Error(
+					`synthetic committed ${operation} failure`,
+				);
+				let handled = 0;
+				(responder.query as any)._responseHandler = async (query: Body) => {
+					handled += 1;
+					return query;
+				};
+
+				if (operation === "close") {
+					const eventOptions = (responder.query as any)._eventOptions;
+					const originalOnClose = eventOptions.onClose;
+					let callbackAttempts = 0;
+					eventOptions.onClose = async (program: Program) => {
+						callbackAttempts += 1;
+						if (callbackAttempts === 1) {
+							throw cleanupError;
+						}
+						await originalOnClose?.(program);
+					};
+				} else {
+					const blocks = responder.node.services.blocks;
+					const originalRm = blocks.rm.bind(blocks);
+					let deleteAttempts = 0;
+					blocks.rm = async (address) => {
+						if (address === responder.query.address) {
+							deleteAttempts += 1;
+							if (deleteAttempts === 1) {
+								throw cleanupError;
+							}
+						}
+						return originalRm(address);
+					};
+				}
+
+				await expect(responder.query[operation](responder)).to.be.rejectedWith(
+					cleanupError.message,
+				);
+				expect(responder.query.closed).to.be.true;
+				expect((responder.query as any)._subscribed).to.be.false;
+				expect(
+					(responder.node.services.pubsub as any)["listenerCount"]("data"),
+				).equal(0);
+
+				const responses = await reader.query.request(
+					new Body({ arr: new Uint8Array([12, 13]) }),
+					{ timeout: 50 },
+				);
+				expect(responses).to.have.length(0);
+				expect(handled).to.equal(0);
+
+				expect(await responder.query[operation](responder)).to.be.true;
+				expect((responder.query as any)._subscribed).to.be.false;
+			});
+		}
+
+		it("retries listener removal without spending another topic subscription", async () => {
+			const pubsub = responder.node.services.pubsub as any;
+			await pubsub.subscribe(responder.query.topic);
+			expect(pubsub["subscriptions"].get("topic").counter).equal(2);
+			let handled = 0;
+			(responder.query as any)._responseHandler = async (query: Body) => {
+				handled += 1;
+				return query;
+			};
+
+			const originalRemoveEventListener =
+				pubsub.removeEventListener.bind(pubsub);
+			let dataRemovalAttempts = 0;
+			pubsub.removeEventListener = (type: string, listener: unknown) => {
+				if (type === "data") {
+					dataRemovalAttempts += 1;
+					if (dataRemovalAttempts === 1) {
+						throw new Error("synthetic listener removal failure");
+					}
+				}
+				return originalRemoveEventListener(type, listener);
+			};
+
+			await expect(responder.query.close(responder)).to.be.rejectedWith(
+				"synthetic listener removal failure",
+			);
+			expect(responder.query.closed).to.be.true;
+			expect((responder.query as any)._subscribed).to.be.false;
+			expect((responder.query as any)._listenerAttached).to.be.true;
+			expect(pubsub["subscriptions"].get("topic").counter).equal(1);
+
+			const responses = await reader.query.request(
+				new Body({ arr: new Uint8Array([14, 15]) }),
+				{ timeout: 50 },
+			);
+			expect(responses).to.have.length(0);
+			expect(handled).to.equal(0);
+
+			pubsub.removeEventListener = originalRemoveEventListener;
+			expect(await responder.query.close(responder)).to.be.true;
+			expect((responder.query as any)._listenerAttached).to.be.false;
+			expect(pubsub["subscriptions"].get("topic").counter).equal(1);
+			await pubsub.unsubscribe(responder.query.topic);
+			expect(pubsub["subscriptions"].has("topic")).to.be.false;
+		});
+
 		it("drop", async () => {
 			let listenerCount = (reader.node.services.pubsub as any)["listenerCount"](
 				"data",

--- a/packages/utils/native-backbone/src/index.ts
+++ b/packages/utils/native-backbone/src/index.ts
@@ -9267,9 +9267,21 @@ export class NativeBackboneCoordinatePersistence {
 	}
 
 	async resumeDrop(): Promise<boolean> {
-		this.assertActive("resume drop");
+		if (this.persistenceLifecycle === "dropped") {
+			return true;
+		}
+		if (this.persistenceLifecycle !== "dropping") {
+			this.assertActive("resume drop");
+		}
 		this.persistenceLifecycle = "dropping";
-		return this.enqueuePersistence(() => this.resumeDropInternal("active"));
+		return this.enqueuePersistence(async () => {
+			// A concurrent drop may have completed before this queued recovery runs.
+			// Preserve its terminal lifecycle instead of reactivating the generation.
+			if (this.persistenceLifecycle === "dropped") {
+				return true;
+			}
+			return this.resumeDropInternal("active");
+		});
 	}
 
 	async hydrate(backbone: NativePeerbitBackbone): Promise<number> {

--- a/packages/utils/native-backbone/src/index.ts
+++ b/packages/utils/native-backbone/src/index.ts
@@ -3002,8 +3002,21 @@ export type NativeBackboneCoordinatePersistenceAdapter = {
 	 * sharing the same namespace. A tombstone makes interrupted erases resumable.
 	 */
 	drop?(additionalFiles?: readonly string[]): Promise<void>;
-	/** Complete an interrupted drop before any native state is hydrated. */
+	/**
+	 * Complete an interrupted drop before hydration or on the same adapter
+	 * generation after `drop()` rejected. Returning `true` means the tombstoned
+	 * erase completed: this generation remains terminal only if it initiated that
+	 * drop, while recovery of a prior generation's marker returns to active.
+	 * Returning `false` means no durable marker exists and an explicit `drop()`
+	 * may start again; a generation that already initiated drop remains fenced
+	 * from ordinary hydrate/flush work until that destructive retry completes.
+	 * A corrupt/invalid marker rejection must likewise restore the adapter to an
+	 * explicit-drop-admitting state so drop can overwrite it; transient I/O
+	 * failures may keep the generation in its resumable dropping state. Once
+	 * close is admitted, no new resume may queue behind terminal store teardown.
+	 */
 	resumeDrop?(): Promise<boolean>;
+	/** A rejected close may be retried to resume its first incomplete store stage. */
 	close?(): Promise<void>;
 };
 
@@ -9110,7 +9123,11 @@ export class NativeBackboneCoordinatePersistence {
 		| "dropped"
 		| "closing"
 		| "closed" = "active";
+	private dropInitiatedOnGeneration = false;
 	private persistenceFailure: unknown;
+	private closeMode: "flush" | "withoutFlush" | undefined;
+	private closeFlushCompleted = false;
+	private closeStoreCompleted = false;
 	private closePromise: Promise<void> | undefined;
 
 	constructor(
@@ -9192,6 +9209,11 @@ export class NativeBackboneCoordinatePersistence {
 			throw this.persistenceFailure;
 		}
 		this.assertLifecycleActive(operation);
+		if (this.dropInitiatedOnGeneration) {
+			throw new Error(
+				`Native backbone coordinate persistence can not ${operation} after drop was initiated; retry drop or resume drop first`,
+			);
+		}
 	}
 
 	private resetJournalTracking(): void {
@@ -9247,6 +9269,7 @@ export class NativeBackboneCoordinatePersistence {
 		}
 		// Flip synchronously so no later append/compact can enqueue behind this
 		// erase and recreate a file after its removal.
+		this.dropInitiatedOnGeneration = true;
 		this.persistenceLifecycle = "dropping";
 		await this.enqueuePersistence(async () => {
 			await this.store.write(
@@ -9270,8 +9293,19 @@ export class NativeBackboneCoordinatePersistence {
 		if (this.persistenceLifecycle === "dropped") {
 			return true;
 		}
-		if (this.persistenceLifecycle !== "dropping") {
-			this.assertActive("resume drop");
+		if (this.closeMode !== undefined) {
+			throw new Error(
+				"Native backbone coordinate persistence can not resume drop after close was initiated",
+			);
+		}
+		const resumesInProgress = this.persistenceLifecycle === "dropping";
+		const completesInitiatedDrop = this.dropInitiatedOnGeneration;
+		if (!resumesInProgress) {
+			if (completesInitiatedDrop) {
+				this.assertLifecycleActive("resume drop");
+			} else {
+				this.assertActive("resume drop");
+			}
 		}
 		this.persistenceLifecycle = "dropping";
 		return this.enqueuePersistence(async () => {
@@ -9280,7 +9314,9 @@ export class NativeBackboneCoordinatePersistence {
 			if (this.persistenceLifecycle === "dropped") {
 				return true;
 			}
-			return this.resumeDropInternal("active");
+			return this.resumeDropInternal(
+				completesInitiatedDrop ? "dropped" : "active",
+			);
 		});
 	}
 
@@ -9382,12 +9418,15 @@ export class NativeBackboneCoordinatePersistence {
 	}
 
 	private async resumeDropInternal(
-		finalLifecycle: "active" | "hydrating",
+		finalLifecycle: "active" | "hydrating" | "dropped",
 	): Promise<boolean> {
 		const bytes = await this.store.read(
 			nativeBackboneCoordinateDropTombstoneFile,
 		);
 		if (!bytes) {
+			// A failed drop can stop before its tombstone is durable. Restore the
+			// generation to active so the caller can start a complete drop; only a
+			// tombstone-backed erase may finish it as dropped.
 			this.persistenceLifecycle =
 				finalLifecycle === "hydrating"
 					? "hydrating"
@@ -9416,11 +9455,13 @@ export class NativeBackboneCoordinatePersistence {
 		await this.eraseDropFiles(tombstone.files);
 		this.resetJournalTracking();
 		this.persistenceLifecycle =
-			finalLifecycle === "hydrating"
-				? "hydrating"
-				: this.closePromise
-					? "closing"
-					: "active";
+			finalLifecycle === "dropped"
+				? "dropped"
+				: finalLifecycle === "hydrating"
+					? "hydrating"
+					: this.closePromise
+						? "closing"
+						: "active";
 		return true;
 	}
 
@@ -9612,31 +9653,52 @@ export class NativeBackboneCoordinatePersistence {
 		if (this.closePromise) {
 			return this.closePromise;
 		}
+		const closeMode: "flush" | "withoutFlush" =
+			this.closeMode ??
+			(this.persistenceLifecycle === "active" && !this.dropInitiatedOnGeneration
+				? "flush"
+				: "withoutFlush");
+		this.closeMode = closeMode;
 		// Close wins once invoked from an active generation. The synchronous
 		// transition rejects any later drop/hydrate/flush before the terminal
 		// store close starts, including for stores that forbid all post-close I/O.
-		const closesActiveGeneration = this.persistenceLifecycle === "active";
-		if (closesActiveGeneration) {
+		if (this.persistenceLifecycle === "active") {
 			this.persistenceLifecycle = "closing";
 		}
-		this.closePromise = this.enqueuePersistence(async () => {
-			if (closesActiveGeneration || this.persistenceLifecycle === "active") {
+		const closeAttempt = this.enqueuePersistence(async () => {
+			if (closeMode === "flush") {
 				this.persistenceLifecycle = "closing";
-				await this.store.flush?.();
-				await this.store.close?.();
-				this.persistenceLifecycle = "closed";
-				return;
-			}
-			if (this.persistenceLifecycle === "closing") {
-				await this.store.close?.({ flush: false });
+				if (!this.closeFlushCompleted) {
+					await this.store.flush?.();
+					this.closeFlushCompleted = true;
+				}
+				if (!this.closeStoreCompleted) {
+					await this.store.close?.();
+					this.closeStoreCompleted = true;
+				}
 				this.persistenceLifecycle = "closed";
 				return;
 			}
 			// A drop already in flight wins. Drain no buffered bytes after its
 			// tombstone erase and preserve the dropped terminal lifecycle.
-			await this.store.close?.({ flush: false });
+			if (!this.closeStoreCompleted) {
+				await this.store.close?.({ flush: false });
+				this.closeStoreCompleted = true;
+			}
+			if (this.persistenceLifecycle !== "dropped") {
+				this.persistenceLifecycle = "closed";
+			}
 		});
-		return this.closePromise;
+		this.closePromise = closeAttempt;
+		void closeAttempt.catch(() => {
+			// A rejected close is only the failed attempt, not terminal progress.
+			// Retain completed stages above, but let the exact owner retry the first
+			// incomplete store operation.
+			if (this.closePromise === closeAttempt) {
+				this.closePromise = undefined;
+			}
+		});
+		return closeAttempt;
 	}
 }
 

--- a/packages/utils/native-backbone/test/index.spec.ts
+++ b/packages/utils/native-backbone/test/index.spec.ts
@@ -3217,13 +3217,7 @@ describe("native peerbit backbone", () => {
 		const resuming = persistence.resumeDrop();
 		releaseRemove();
 		await dropping;
-		let resumeError: unknown;
-		try {
-			await resuming;
-		} catch (error) {
-			resumeError = error;
-		}
-		expect(String(resumeError)).to.contain("while dropping");
+		expect(await resuming).equal(true);
 
 		let secondDropError: unknown;
 		try {
@@ -3232,6 +3226,36 @@ describe("native peerbit backbone", () => {
 			secondDropError = error;
 		}
 		expect(String(secondDropError)).to.contain("while dropped");
+		expect(memory.files.size).equal(0);
+	});
+
+	it("resumes a failed drop on the same persistence generation", async () => {
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		let failRemoval = true;
+		const store: NativeBackboneCoordinatePersistenceStore = {
+			read: (name) => memory.read(name),
+			write: (name, bytes) => memory.write(name, bytes),
+			append: (name, bytes) => memory.append(name, bytes),
+			remove: async (name) => {
+				if (name === "coordinates.bin" && failRemoval) {
+					failRemoval = false;
+					throw new Error("injected removal failure");
+				}
+				await memory.remove(name);
+			},
+		};
+		const persistence = new NativeBackboneCoordinatePersistence(store);
+		await memory.append("coordinates.bin", new Uint8Array([1]));
+
+		const dropError = await persistence.drop().then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(dropError).to.be.instanceOf(AggregateError);
+		expect(memory.files.has("native-backbone-drop.tombstone")).equal(true);
+		expect(memory.files.has("coordinates.bin")).equal(true);
+
+		expect(await persistence.resumeDrop()).equal(true);
 		expect(memory.files.size).equal(0);
 	});
 

--- a/packages/utils/native-backbone/test/index.spec.ts
+++ b/packages/utils/native-backbone/test/index.spec.ts
@@ -3034,6 +3034,372 @@ describe("native peerbit backbone", () => {
 		expect(postCloseOperations).equal(0);
 	});
 
+	it("retries a transient active-close flush before closing the store", async () => {
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		let flushCalls = 0;
+		let closeCalls = 0;
+		const closeOptions: Array<{ flush?: boolean } | undefined> = [];
+		const store: NativeBackboneCoordinatePersistenceStore = {
+			read: (name) => memory.read(name),
+			write: (name, bytes) => memory.write(name, bytes),
+			append: (name, bytes) => memory.append(name, bytes),
+			remove: (name) => memory.remove(name),
+			flush: async () => {
+				flushCalls++;
+				if (flushCalls === 1) {
+					throw new Error("transient close flush failure");
+				}
+			},
+			close: async (options) => {
+				closeCalls++;
+				closeOptions.push(options);
+			},
+		};
+		const persistence = new NativeBackboneCoordinatePersistence(store);
+
+		const firstClose = persistence.close();
+		expect(persistence.close()).equal(firstClose);
+		const firstError = await firstClose.then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(String(firstError)).to.contain("transient close flush failure");
+		expect(flushCalls).equal(1);
+		expect(closeCalls).equal(0);
+
+		const retry = persistence.close();
+		expect(retry).not.equal(firstClose);
+		await retry;
+		expect(persistence.close()).equal(retry);
+		expect(flushCalls).equal(2);
+		expect(closeCalls).equal(1);
+		expect(closeOptions).to.deep.equal([undefined]);
+	});
+
+	it("retries only the incomplete store-close stage", async () => {
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		let flushCalls = 0;
+		let closeCalls = 0;
+		const closeOptions: Array<{ flush?: boolean } | undefined> = [];
+		const store: NativeBackboneCoordinatePersistenceStore = {
+			read: (name) => memory.read(name),
+			write: (name, bytes) => memory.write(name, bytes),
+			append: (name, bytes) => memory.append(name, bytes),
+			remove: (name) => memory.remove(name),
+			flush: async () => {
+				flushCalls++;
+			},
+			close: async (options) => {
+				closeCalls++;
+				closeOptions.push(options);
+				if (closeCalls === 1) {
+					throw new Error("transient store close failure");
+				}
+			},
+		};
+		const persistence = new NativeBackboneCoordinatePersistence(store);
+
+		const firstClose = persistence.close();
+		const firstError = await firstClose.then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(String(firstError)).to.contain("transient store close failure");
+		expect(flushCalls).equal(1);
+		expect(closeCalls).equal(1);
+
+		const retry = persistence.close();
+		expect(retry).not.equal(firstClose);
+		await retry;
+		expect(flushCalls).equal(1);
+		expect(closeCalls).equal(2);
+		expect(closeOptions).to.deep.equal([undefined, undefined]);
+	});
+
+	it("fences ordinary operations after a markerless explicit drop failure", async () => {
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		let failTombstoneWrite = true;
+		const store: NativeBackboneCoordinatePersistenceStore = {
+			read: (name) => memory.read(name),
+			write: async (name, bytes) => {
+				if (name === "native-backbone-drop.tombstone" && failTombstoneWrite) {
+					failTombstoneWrite = false;
+					throw new Error("transient tombstone write failure");
+				}
+				await memory.write(name, bytes);
+			},
+			append: (name, bytes) => memory.append(name, bytes),
+			remove: (name) => memory.remove(name),
+			flush: (name) => memory.flush(name),
+		};
+		const persistence = new NativeBackboneCoordinatePersistence(store);
+		const target = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
+		});
+		await memory.write("coordinates.wal", new Uint8Array([1, 2, 3]));
+
+		const dropError = await persistence.drop().then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(String(dropError)).to.contain("transient tombstone write failure");
+		expect(await persistence.resumeDrop()).equal(false);
+
+		const hydrateError = await persistence.hydrate(target).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(String(hydrateError)).to.contain(
+			"after drop was initiated; retry drop or resume drop first",
+		);
+		let flushError: unknown;
+		try {
+			await persistence.flushJournal(target);
+		} catch (error) {
+			flushError = error;
+		}
+		expect(String(flushError)).to.contain(
+			"after drop was initiated; retry drop or resume drop first",
+		);
+
+		// Only terminal recovery remains admitted on this generation.
+		await persistence.drop();
+		expect(memory.files.size).equal(0);
+	});
+
+	it("closes markerless explicit-drop debt without flushing", async () => {
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		let failTombstoneWrite = true;
+		let flushCalls = 0;
+		const closeOptions: Array<{ flush?: boolean } | undefined> = [];
+		const store: NativeBackboneCoordinatePersistenceStore = {
+			read: (name) => memory.read(name),
+			write: async (name, bytes) => {
+				if (name === "native-backbone-drop.tombstone" && failTombstoneWrite) {
+					failTombstoneWrite = false;
+					throw new Error("transient tombstone write failure");
+				}
+				await memory.write(name, bytes);
+			},
+			append: (name, bytes) => memory.append(name, bytes),
+			remove: (name) => memory.remove(name),
+			flush: async (name) => {
+				flushCalls++;
+				await memory.flush(name);
+			},
+			close: async (options) => {
+				closeOptions.push(options);
+			},
+		};
+		const persistence = new NativeBackboneCoordinatePersistence(store);
+		const target = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
+		});
+
+		await persistence.drop().then(
+			() => undefined,
+			() => undefined,
+		);
+		expect(await persistence.resumeDrop()).equal(false);
+		await persistence.close();
+
+		expect(flushCalls).equal(0);
+		expect(closeOptions).to.deep.equal([{ flush: false }]);
+		const hydrateError = await persistence.hydrate(target).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(String(hydrateError)).to.contain("while closed");
+	});
+
+	it("closes after a queued explicit drop rejection before admitting resume", async () => {
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		let writeEntered!: () => void;
+		const entered = new Promise<void>((resolve) => {
+			writeEntered = resolve;
+		});
+		let releaseWrite!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			releaseWrite = resolve;
+		});
+		let closed = false;
+		let postCloseReads = 0;
+		const closeOptions: Array<{ flush?: boolean } | undefined> = [];
+		const store: NativeBackboneCoordinatePersistenceStore = {
+			read: (name) => {
+				if (closed) {
+					postCloseReads++;
+					throw new Error("terminal store is closed");
+				}
+				return memory.read(name);
+			},
+			write: async (name, bytes) => {
+				if (name === "native-backbone-drop.tombstone") {
+					writeEntered();
+					await gate;
+					throw new Error("queued tombstone write failure");
+				}
+				await memory.write(name, bytes);
+			},
+			append: (name, bytes) => memory.append(name, bytes),
+			remove: (name) => memory.remove(name),
+			flush: (name) => memory.flush(name),
+			close: async (options) => {
+				closeOptions.push(options);
+				closed = true;
+			},
+		};
+		const persistence = new NativeBackboneCoordinatePersistence(store);
+
+		const dropping = persistence.drop();
+		await entered;
+		const closing = persistence.close();
+		const lateResume = persistence.resumeDrop().then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		releaseWrite();
+		const dropError = await dropping.then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(String(dropError)).to.contain("queued tombstone write failure");
+		await closing;
+
+		const resumeError = await lateResume;
+		expect(String(resumeError)).to.contain("after close was initiated");
+		const retryDropError = await persistence.drop().then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(String(retryDropError)).to.contain("while closed");
+		expect(closeOptions).to.deep.equal([{ flush: false }]);
+		expect(postCloseReads).equal(0);
+	});
+
+	it("closes behind recovery-origin resume without leaving an active adapter", async () => {
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		let failRemoval = true;
+		const seedStore: NativeBackboneCoordinatePersistenceStore = {
+			read: (name) => memory.read(name),
+			write: (name, bytes) => memory.write(name, bytes),
+			append: (name, bytes) => memory.append(name, bytes),
+			remove: async (name) => {
+				if (name === "coordinates.bin" && failRemoval) {
+					failRemoval = false;
+					throw new Error("seed interrupted drop");
+				}
+				await memory.remove(name);
+			},
+			flush: (name) => memory.flush(name),
+		};
+		await memory.write("coordinates.bin", new Uint8Array([1]));
+		const seed = new NativeBackboneCoordinatePersistence(seedStore);
+		await seed.drop().then(
+			() => undefined,
+			() => undefined,
+		);
+		expect(memory.files.has("native-backbone-drop.tombstone")).equal(true);
+
+		let readEntered!: () => void;
+		const entered = new Promise<void>((resolve) => {
+			readEntered = resolve;
+		});
+		let releaseRead!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			releaseRead = resolve;
+		});
+		let gateArmed = true;
+		let closed = false;
+		let postCloseReads = 0;
+		const closeOptions: Array<{ flush?: boolean } | undefined> = [];
+		const recoveryStore: NativeBackboneCoordinatePersistenceStore = {
+			read: async (name) => {
+				if (closed) {
+					postCloseReads++;
+					throw new Error("terminal store is closed");
+				}
+				if (name === "native-backbone-drop.tombstone" && gateArmed) {
+					gateArmed = false;
+					readEntered();
+					await gate;
+				}
+				return memory.read(name);
+			},
+			write: (name, bytes) => memory.write(name, bytes),
+			append: (name, bytes) => memory.append(name, bytes),
+			remove: (name) => memory.remove(name),
+			flush: (name) => memory.flush(name),
+			close: async (options) => {
+				closeOptions.push(options);
+				closed = true;
+			},
+		};
+		const recovering = new NativeBackboneCoordinatePersistence(recoveryStore);
+		const target = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
+		});
+
+		const resuming = recovering.resumeDrop();
+		await entered;
+		const closing = recovering.close();
+		releaseRead();
+		expect(await resuming).equal(true);
+		await closing;
+
+		expect(closeOptions).to.deep.equal([{ flush: false }]);
+		const hydrateError = await recovering.hydrate(target).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(String(hydrateError)).to.contain("while closed");
+		expect(postCloseReads).equal(0);
+	});
+
+	it("retries a drop-wins store close without flushing", async () => {
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		let closeCalls = 0;
+		const closeOptions: Array<{ flush?: boolean } | undefined> = [];
+		const store: NativeBackboneCoordinatePersistenceStore = {
+			read: (name) => memory.read(name),
+			write: (name, bytes) => memory.write(name, bytes),
+			append: (name, bytes) => memory.append(name, bytes),
+			remove: (name) => memory.remove(name),
+			flush: (name) => memory.flush(name),
+			close: async (options) => {
+				closeCalls++;
+				closeOptions.push(options);
+				if (closeCalls === 1) {
+					throw new Error("transient drop-wins close failure");
+				}
+			},
+		};
+		const persistence = new NativeBackboneCoordinatePersistence(store);
+		await memory.write("coordinates.wal", new Uint8Array([1, 2, 3]));
+
+		const dropping = persistence.drop();
+		const firstClose = persistence.close();
+		await dropping;
+		const firstError = await firstClose.then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(String(firstError)).to.contain("transient drop-wins close failure");
+		expect(memory.files.size).equal(0);
+
+		const retry = persistence.close();
+		expect(retry).not.equal(firstClose);
+		await retry;
+		expect(closeCalls).equal(2);
+		expect(closeOptions).to.deep.equal([{ flush: false }, { flush: false }]);
+	});
+
 	it("lets an in-flight drop finish before terminal close", async () => {
 		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
 		let closed = false;
@@ -3229,6 +3595,55 @@ describe("native peerbit backbone", () => {
 		expect(memory.files.size).equal(0);
 	});
 
+	it("keeps a retried recovery-origin resume active", async () => {
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		let failRemoval = true;
+		let failTombstoneRead = false;
+		const store: NativeBackboneCoordinatePersistenceStore = {
+			read: async (name) => {
+				if (name === "native-backbone-drop.tombstone" && failTombstoneRead) {
+					failTombstoneRead = false;
+					throw new Error("transient tombstone read failure");
+				}
+				return memory.read(name);
+			},
+			write: (name, bytes) => memory.write(name, bytes),
+			append: (name, bytes) => memory.append(name, bytes),
+			remove: async (name) => {
+				if (name === "coordinates.bin" && failRemoval) {
+					failRemoval = false;
+					throw new Error("seed interrupted drop");
+				}
+				await memory.remove(name);
+			},
+		};
+		await memory.append("coordinates.bin", new Uint8Array([1]));
+		const seed = new NativeBackboneCoordinatePersistence(store);
+		const seedError = await seed.drop().then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(String(seedError)).to.contain(
+			"Failed to erase native backbone coordinate persistence namespace",
+		);
+		expect(memory.files.has("native-backbone-drop.tombstone")).equal(true);
+
+		const recovering = new NativeBackboneCoordinatePersistence(store);
+		failTombstoneRead = true;
+		const resumeError = await recovering.resumeDrop().then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(String(resumeError)).to.contain("transient tombstone read failure");
+		expect(await recovering.resumeDrop()).equal(true);
+		expect(memory.files.size).equal(0);
+
+		// Recovery did not originate the erased generation, so this adapter remains
+		// active and can start a later explicit drop of its own.
+		await recovering.drop();
+		expect(memory.files.size).equal(0);
+	});
+
 	it("resumes a failed drop on the same persistence generation", async () => {
 		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
 		let failRemoval = true;
@@ -3257,6 +3672,14 @@ describe("native peerbit backbone", () => {
 
 		expect(await persistence.resumeDrop()).equal(true);
 		expect(memory.files.size).equal(0);
+
+		let secondDropError: unknown;
+		try {
+			await persistence.drop();
+		} catch (error) {
+			secondDropError = error;
+		}
+		expect(String(secondDropError)).to.contain("while dropped");
 	});
 
 	it("keeps journal records appended during a flush write for the next flush", async () => {


### PR DESCRIPTION
Summary:
- make Program close/drop and Handler stop retryable after partial base, callback, subclass, and deletion failures
- reserve complete serialized program graphs across open, rollback, replacement, and terminal cleanup
- serialize dynamic nested opens without duplicate initialization or A-to-B-to-A wait cycles
- reconcile parent/child ownership edges and retain exact cleanup responsibility across retries
- fence parent attachment races, failed/stale parents, and descendant terminal work
- add explicit Handler restart validation and Peerbit restart hooks
- preserve Program-like compatibility across module copies

Validation:
- @peerbit/program: 175 tests passed
- peerbit TypeScript build passed
- Peerbit start/stop smoke tests: 2 passed
- exact, clone, address, rollback, stale-parent, pre-open-parent, and successful-retention adversarial probes passed
- ESLint, Prettier, and git diff checks passed
- two independent lifecycle/reservation reviews found no remaining P0/P1 correctness defects

Lifecycle contract:
- lifecycle overrides and callbacks must schedule owning-client stop from an external owner; direct synchronous self-reentry rejects rather than deadlocks
- async-yielded call provenance is not uniformly available across supported JavaScript runtimes, so lifecycle code must not await its own teardown

All commits and GitHub actions for this PR use the peerbit-org bot identity.