### PR TITLE
fix(document): make remote pagination cleanup reliable

### DIFF
--- a/.changeset/calm-rpcs-abort.md
+++ b/.changeset/calm-rpcs-abort.md
@@ -1,0 +1,9 @@
+---
+"@peerbit/rpc": patch
+---
+
+Reject RPC requests with their original abort reason when the signal is already
+aborted, aborts while key/envelope setup is still pending, or carries a
+`TimeoutError`. Canceled setup no longer registers an interceptor/resolver or
+invokes the transport, while synchronous and asynchronous transport timeout
+failures retain their existing best-effort behavior.

--- a/.changeset/quiet-mails-iterate.md
+++ b/.changeset/quiet-mails-iterate.md
@@ -1,0 +1,11 @@
+---
+"@peerbit/document": patch
+---
+
+Honor `throwOnMissing` and bounded missing-response retries when a remote
+document iterator responder disappears between pages. Track default-cover and
+prefetched remote iterator identities before responses settle, close them from
+implicit consumers and aborted requests, detach completed lifecycle listeners,
+retain every superseded prefetch ID across bounded retries, avoid redundant
+closes for drained peers, and forward nested remote RPC options to follow-up page
+requests.

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -47,7 +47,7 @@ import {
 } from "@peerbit/stream-interface";
 import { AbortError, TimeoutError, waitFor } from "@peerbit/time";
 import pDefer, { type DeferredPromise } from "p-defer";
-import { concat, fromString } from "uint8arrays";
+import { concat, equals, fromString } from "uint8arrays";
 import { copySerialization } from "./borsh.js";
 import { MAX_BATCH_SIZE } from "./constants.js";
 import type { DocumentEvents, DocumentsChange } from "./events.js";
@@ -511,6 +511,7 @@ type QueryDetailedOptions<
 		from: PublicSignKey,
 	) => void | Promise<void>;
 	onMissingResponses?: (error: MissingResponsesError) => void | Promise<void>;
+	onRemoteTargets?: (targets: string[]) => void;
 	remote?: {
 		from?: string[]; // if specified, only query these peers
 	};
@@ -742,6 +743,7 @@ function isSubclassOf(
 const DEFAULT_TIMEOUT = 1e4;
 const DEFAULT_KEEP_REMOTE_ITERATOR_TIMEOUT = 3e5;
 const DISCOVER_TIMEOUT_FALLBACK = 500;
+const CLOSE_ITERATOR_REQUEST_TIMEOUT = 5e3;
 
 const DEFAULT_INDEX_BY = "id";
 
@@ -4283,6 +4285,7 @@ export class DocumentIndex<
 				let extraPromises: Promise<void>[] | undefined = undefined;
 
 				const seenRemoteHashes = new Set<string>();
+				const selectedRemoteHashes: string[] = [];
 				const groupHashes: string[][] = replicatorGroups
 					.filter((hash) => {
 						if (hash === this.node.identity.publicKey.hashcode()) {
@@ -4299,6 +4302,7 @@ export class DocumentIndex<
 							return false;
 						}
 						fetchFirstForRemote?.add(hash);
+						selectedRemoteHashes.push(hash);
 
 						const resultAlready = this._prefetch?.accumulator.consume(
 							queryRequest,
@@ -4324,6 +4328,7 @@ export class DocumentIndex<
 					})
 					.map((x) => [x]);
 
+				options?.onRemoteTargets?.(selectedRemoteHashes);
 				extraPromises && (await Promise.all(extraPromises));
 				let tearDown: (() => void) | undefined = undefined;
 				const search = this;
@@ -4482,23 +4487,25 @@ export class DocumentIndex<
 
 		const allResults: ValueTypeFromRequest<Resolve, T, I>[] = [];
 
-		while (
-			iterator.done() !== true &&
-			coercedRequest.fetch > allResults.length
-		) {
-			// We might need to pull .next multiple time due to data message size limitations
+		try {
+			while (
+				iterator.done() !== true &&
+				coercedRequest.fetch > allResults.length
+			) {
+				// We might need to pull .next multiple time due to data message size limitations
 
-			for (const result of await iterator.next(
-				coercedRequest.fetch - allResults.length,
-			)) {
-				allResults.push(result as ValueTypeFromRequest<Resolve, T, I>);
+				for (const result of await iterator.next(
+					coercedRequest.fetch - allResults.length,
+				)) {
+					allResults.push(result as ValueTypeFromRequest<Resolve, T, I>);
+				}
 			}
+
+			// Deduplicate and return values directly
+			return dedup(allResults, this.indexByResolver);
+		} finally {
+			await iterator.close();
 		}
-
-		await iterator.close();
-
-		// Deduplicate and return values directly
-		return dedup(allResults, this.indexByResolver);
 	}
 
 	private resolveIndexed<R>(
@@ -4790,6 +4797,50 @@ export class DocumentIndex<
 				buffer: BufferedResult<types.ResultTypeFromRequest<R, T, I> | I, I>[];
 			}
 		> = new Map();
+		const remoteIteratorPeersToClose = new Set<string>();
+		const staleRemoteIteratorIdsToClose = new Map<string, Uint8Array[]>();
+		const retiredRemoteIteratorPeers = new Set<string>();
+		const pendingMissingResponseRetryPeers = new Set<string>();
+		const missingResponseRetryAttempts = new Map<string, number>();
+		const maxMissingResponseRetryAttempts = 2;
+		const retireRemoteIteratorPeer = (peer: string) => {
+			remoteIteratorPeersToClose.add(peer);
+			retiredRemoteIteratorPeers.add(peer);
+			const peerBuffer = peerBufferMap.get(peer);
+			if (!peerBuffer || peerBuffer.buffer.length === 0) {
+				peerBufferMap.delete(peer);
+			} else {
+				// Keep already-received values available to the caller, but do not
+				// issue another CollectNextRequest until a fresh iteration succeeds.
+				peerBuffer.kept = 0;
+			}
+		};
+		const recordMissingResponseGroups = (missingGroups: string[][]) => {
+			const selfHash = this.node.identity.publicKey.hashcode();
+			for (const group of missingGroups) {
+				for (const hash of group) {
+					if (hash && hash !== selfHash) {
+						retireRemoteIteratorPeer(hash);
+					}
+				}
+
+				if (!retryMissingResponseGroups) {
+					continue;
+				}
+
+				const target = group.find((hash) => {
+					if (!hash || hash === selfHash) return false;
+					const attempts = missingResponseRetryAttempts.get(hash) ?? 0;
+					return attempts < maxMissingResponseRetryAttempts;
+				});
+				if (!target) continue;
+				pendingMissingResponseRetryPeers.add(target);
+				missingResponseRetryAttempts.set(
+					target,
+					(missingResponseRetryAttempts.get(target) ?? 0) + 1,
+				);
+			}
+		};
 		const visited = new Set<indexerTypes.IdPrimitive>();
 		let indexedPlaceholders:
 			| Map<
@@ -5021,6 +5072,17 @@ export class DocumentIndex<
 			n: number,
 			fetchOptions?: { from?: string[]; fetchedFirstForRemote?: Set<string> },
 		): Promise<boolean> => {
+			const remoteRequestOptions =
+				typeof options?.remote === "object" ? options.remote : undefined;
+			const fetchSignals = [
+				options?.signal,
+				remoteRequestOptions?.signal,
+				ensureController().signal,
+			].filter((signal): signal is AbortSignal => signal != null);
+			const fetchSignal =
+				fetchSignals.length === 1
+					? fetchSignals[0]
+					: AbortSignal.any(fetchSignals);
 			await warmupPromise;
 			let hasMore = false;
 			let missingResponses = false;
@@ -5036,33 +5098,43 @@ export class DocumentIndex<
 				typeof options?.remote === "object" &&
 				options.remote.reach?.discover &&
 				discoveredTargetHashes?.length === 0;
+			const queryRemote =
+				options?.remote !== false && !skipRemoteDueToDiscovery;
+			const remoteFrom =
+				fetchOptions?.from ??
+				initialRemoteTargets ??
+				remoteRequestOptions?.from;
+			if (queryRemote) {
+				const selfHash = this.node.identity.publicKey.hashcode();
+				for (const peer of remoteFrom ?? []) {
+					if (peer !== selfHash) {
+						remoteIteratorPeersToClose.add(peer);
+					}
+				}
+			}
 
 			queryRequestCoerced.fetch = n;
 			await this.queryCommence(
 				queryRequestCoerced,
 				{
 					local: fetchOptions?.from != null ? false : options?.local,
-					remote:
-						options?.remote !== false && !skipRemoteDueToDiscovery
-							? {
-									...(typeof options?.remote === "object"
-										? options.remote
-										: {}),
-									from:
-										fetchOptions?.from ??
-										initialRemoteTargets ??
-										(typeof options?.remote === "object"
-											? options.remote.from
-											: undefined),
-								}
-							: false,
+					remote: queryRemote
+						? {
+								...remoteRequestOptions,
+								from: remoteFrom,
+								signal: fetchSignal,
+							}
+						: false,
 					resolve,
-					signal: options?.signal,
+					signal: fetchSignal,
 					onResponse: async (response, from) => {
 						if (!from) {
 							logger.error("Missing response from");
 							return;
 						}
+						const fromHash = from.hashcode();
+						remoteIteratorPeersToClose.add(fromHash);
+						retiredRemoteIteratorPeers.delete(fromHash);
 						if (response instanceof types.NoAccess) {
 							logger.error("Dont have access");
 							return;
@@ -5071,7 +5143,7 @@ export class DocumentIndex<
 								types.ResultTypeFromRequest<R, T, I>
 							>;
 
-							const existingBuffer = peerBufferMap.get(from.hashcode());
+							const existingBuffer = peerBufferMap.get(fromHash);
 							const buffer: BufferedResult<
 								types.ResultTypeFromRequest<R, T, I> | I,
 								I
@@ -5079,10 +5151,12 @@ export class DocumentIndex<
 
 							if (results.kept === 0n && results.results.length === 0) {
 								if (keepRemoteAlive) {
-									peerBufferMap.set(from.hashcode(), {
+									peerBufferMap.set(fromHash, {
 										buffer,
 										kept: 0,
 									});
+								} else {
+									remoteIteratorPeersToClose.delete(fromHash);
 								}
 								return;
 							}
@@ -5097,6 +5171,8 @@ export class DocumentIndex<
 
 							if (effectiveKept > 0) {
 								hasMore = true;
+							} else if (!keepRemoteAlive) {
+								remoteIteratorPeersToClose.delete(fromHash);
 							}
 
 							for (const result of results.results) {
@@ -5160,7 +5236,7 @@ export class DocumentIndex<
 								}
 							}
 
-							peerBufferMap.set(from.hashcode(), {
+							peerBufferMap.set(fromHash, {
 								buffer,
 								kept: effectiveKept,
 							});
@@ -5172,9 +5248,6 @@ export class DocumentIndex<
 					},
 					onMissingResponses: (error) => {
 						missingResponses = true;
-						if (!retryMissingResponseGroups) {
-							return;
-						}
 						const missingGroups = (
 							error as MissingResponsesError & {
 								missingGroups?: string[][];
@@ -5183,27 +5256,22 @@ export class DocumentIndex<
 						if (!missingGroups?.length) {
 							return;
 						}
-
-						const selfHash = this.node.identity.publicKey.hashcode();
-						for (const group of missingGroups) {
-							const target = group.find((hash) => {
-								if (!hash || hash === selfHash) return false;
-								const attempts = missingResponseRetryAttempts.get(hash) ?? 0;
-								return attempts < maxMissingResponseRetryAttempts;
-							});
-							if (!target) continue;
-							pendingMissingResponseRetryPeers.add(target);
-							missingResponseRetryAttempts.set(
-								target,
-								(missingResponseRetryAttempts.get(target) ?? 0) + 1,
-							);
+						recordMissingResponseGroups(missingGroups);
+					},
+					onRemoteTargets: (targets) => {
+						for (const peer of targets) {
+							remoteIteratorPeersToClose.add(peer);
 						}
 					},
 				},
 				fetchOptions?.fetchedFirstForRemote,
 			);
 
-			if (missingResponses && retryMissingResponseGroups) {
+			if (
+				missingResponses &&
+				retryMissingResponseGroups &&
+				pendingMissingResponseRetryPeers.size > 0
+			) {
 				hasMore = true;
 				unsetDone();
 			}
@@ -5235,6 +5303,19 @@ export class DocumentIndex<
 			if (pendingMissingResponseRetryPeers.size > 0) {
 				const retryTargets = [...pendingMissingResponseRetryPeers];
 				pendingMissingResponseRetryPeers.clear();
+				const idTranslation =
+					this._prefetch?.accumulator.getTranslationMap(queryRequestCoerced);
+				for (const peer of retryTargets) {
+					const staleRemoteIteratorId = idTranslation?.get(peer);
+					if (staleRemoteIteratorId) {
+						const staleIds = staleRemoteIteratorIdsToClose.get(peer) ?? [];
+						if (!staleIds.some((id) => equals(id, staleRemoteIteratorId))) {
+							staleIds.push(staleRemoteIteratorId);
+							staleRemoteIteratorIdsToClose.set(peer, staleIds);
+						}
+						idTranslation!.delete(peer);
+					}
+				}
 				return setFetchPromise(
 					fetchFirst(n, {
 						from: retryTargets,
@@ -5248,6 +5329,12 @@ export class DocumentIndex<
 			let resultsLeft = 0;
 
 			for (const [peer, buffer] of peerBufferMap) {
+				if (retiredRemoteIteratorPeers.has(peer)) {
+					if (buffer.buffer.length === 0) {
+						peerBufferMap.delete(peer);
+					}
+					continue;
+				}
 				if (buffer.buffer.length < n) {
 					const hasExistingRemoteResults = buffer.kept > 0;
 					if (!hasExistingRemoteResults && !keepRemoteAlive) {
@@ -5390,10 +5477,11 @@ export class DocumentIndex<
 										"Failed to collect sorted results from self. " + e?.message,
 									);
 									peerBufferMap.delete(peer);
-								}),
+										}),
 						);
 					} else {
 						// Fetch remotely
+						remoteIteratorPeersToClose.add(peer);
 						const idTranslation =
 							this._prefetch?.accumulator.getTranslationMap(
 								queryRequestCoerced,
@@ -5405,22 +5493,45 @@ export class DocumentIndex<
 								amount: collectRequest.amount,
 							});
 						}
+						const remoteRequestOptions =
+							typeof options?.remote === "object" ? options.remote : undefined;
+						const collectSignals = [
+							options?.signal,
+							remoteRequestOptions?.signal,
+							ensureController().signal,
+						].filter((signal): signal is AbortSignal => signal != null);
+						const collectSignal =
+							collectSignals.length === 1
+								? collectSignals[0]
+								: AbortSignal.any(collectSignals);
 
 						promises.push(
 							this._query
 								.request(remoteCollectRequest, {
 									...options,
-									signal: options?.signal
-										? AbortSignal.any([
-												options.signal,
-												ensureController().signal,
-											])
-										: ensureController().signal,
+									...remoteRequestOptions,
+									signal: collectSignal,
 									priority: getRemoteQueryPriority(options?.remote),
 									mode: new SilentDelivery({ to: [peer], redundancy: 1 }),
 								})
-								.then((response) =>
-									introduceEntries(
+								.then((response) => {
+									if (
+										!response.some((result) => result.from?.hashcode() === peer)
+									) {
+										const missingGroups = [[peer]];
+										if (remoteRequestOptions?.throwOnMissing) {
+											retireRemoteIteratorPeer(peer);
+											throw new MissingResponsesError(
+												"Did not receive responses from all shards: " +
+													JSON.stringify(missingGroups),
+												missingGroups,
+											);
+										}
+										recordMissingResponseGroups(missingGroups);
+										return;
+									}
+
+									return introduceEntries(
 										queryRequestCoerced,
 										response,
 										this.documentType,
@@ -5436,6 +5547,12 @@ export class DocumentIndex<
 													if (!from) {
 														logger.error("Missing from for sorted query");
 														return;
+													}
+													if (
+														!keepRemoteAlive &&
+														response.response.kept === 0n
+													) {
+														remoteIteratorPeersToClose.delete(peer);
 													}
 
 													if (response.response.results.length === 0) {
@@ -5557,8 +5674,8 @@ export class DocumentIndex<
 													e?.message,
 											);
 											peerBufferMap.delete(peer);
-										}),
-								),
+										});
+								}),
 						);
 					}
 				} else {
@@ -5584,7 +5701,9 @@ export class DocumentIndex<
 							}
 						}
 					}
-					return resultsLeft === 0; // 0 results left to fetch and 0 pending results
+					return (
+						resultsLeft === 0 && pendingMissingResponseRetryPeers.size === 0
+					); // 0 results left to fetch and 0 pending results
 				}),
 			);
 		};
@@ -5705,32 +5824,89 @@ export class DocumentIndex<
 			done = true;
 		};
 
-		let close = async () => {
+		const outerSignal = options?.signal;
+		let outerAbortListener: (() => void) | undefined;
+		let closeStarted = false;
+		let closePromise: Promise<void> | undefined;
+		const performClose = async () => {
+			const idTranslation =
+				this._prefetch?.accumulator.getTranslationMap(queryRequestCoerced);
+			const remoteIteratorIds = idTranslation
+				? new Map(idTranslation)
+				: undefined;
 			cleanupAndDone();
 
 			// Keep-open iterators can still have active remote state even when
 			// their pending count has already drained to zero.
-			const closeRequest = new types.CloseIteratorRequest({
-				id: queryRequestCoerced.id,
-			});
 			const selfHash = this.node.identity.publicKey.hashcode();
-			const remotePeers = keepRemoteAlive
-				? [...peerBufferMap.keys()].filter((peer) => peer !== selfHash)
-				: [...peerBufferMap.entries()]
-						.filter(([peer, buffer]) => peer !== selfHash && buffer.kept > 0)
-						.map(([peer]) => peer);
+			const activeRemotePeers = new Set(
+				keepRemoteAlive
+					? [...peerBufferMap.keys()].filter((peer) => peer !== selfHash)
+					: [...peerBufferMap.entries()]
+							.filter(
+								([peer, buffer]) => peer !== selfHash && buffer.kept > 0,
+							)
+							.map(([peer]) => peer),
+			);
+			for (const peer of remoteIteratorPeersToClose) {
+				if (peer !== selfHash) {
+					activeRemotePeers.add(peer);
+				}
+			}
+			const staleRemoteIteratorIds = new Map(
+				[...staleRemoteIteratorIdsToClose].map(([peer, ids]) => [
+					peer,
+					[...ids],
+				]),
+			);
+			const remotePeers = new Set([
+				...activeRemotePeers,
+				...staleRemoteIteratorIds.keys(),
+			]);
 			peerBufferMap.clear();
+			retiredRemoteIteratorPeers.clear();
+			remoteIteratorPeersToClose.clear();
+			staleRemoteIteratorIdsToClose.clear();
+			if (remotePeers.size === 0) {
+				return;
+			}
+			const remoteCloseOptions =
+				typeof options?.remote === "object" ? options.remote : undefined;
+			const closeSignal = AbortSignal.timeout(CLOSE_ITERATOR_REQUEST_TIMEOUT);
 			await Promise.allSettled(
-				remotePeers.map((peer) =>
-					this._query.send(closeRequest, {
-						...options,
-						priority: getRemoteQueryPriority(options?.remote),
-						mode: new SilentDelivery({ to: [peer], redundancy: 1 }),
-					}),
-				),
+				[...remotePeers].flatMap((peer) => {
+					const ids: Uint8Array[] = [];
+					if (activeRemotePeers.has(peer)) {
+						ids.push(remoteIteratorIds?.get(peer) ?? queryRequestCoerced.id);
+					}
+					for (const staleRemoteIteratorId of
+						staleRemoteIteratorIds.get(peer) ?? []) {
+						if (!ids.some((id) => equals(id, staleRemoteIteratorId))) {
+							ids.push(staleRemoteIteratorId);
+						}
+					}
+					return ids.map((id) => {
+						const closeRequest = new types.CloseIteratorRequest({ id });
+						return this._query.send(closeRequest, {
+							...remoteCloseOptions,
+							signal: closeSignal,
+							priority: getRemoteQueryPriority(options?.remote),
+							mode: new SilentDelivery({ to: [peer], redundancy: 1 }),
+						});
+					});
+				}),
 			);
 		};
-		options?.signal && options.signal.addEventListener("abort", close);
+		const close = () => {
+			if (closeStarted) return closePromise!;
+			closeStarted = true;
+			if (outerAbortListener) {
+				outerSignal?.removeEventListener("abort", outerAbortListener);
+				outerAbortListener = undefined;
+			}
+			closePromise = performClose();
+			return closePromise;
+		};
 
 		let doneFn = () => {
 			return done;
@@ -5739,9 +5915,6 @@ export class DocumentIndex<
 		let joinListener: (() => void) | undefined;
 
 		let fetchedFirstForRemote: Set<string> | undefined = undefined;
-		const pendingMissingResponseRetryPeers = new Set<string>();
-		const missingResponseRetryAttempts = new Map<string, number>();
-		const maxMissingResponseRetryAttempts = 2;
 		let joinFetchesInFlight = 0;
 
 		let updateDeferred: ReturnType<typeof pDefer> | undefined;
@@ -6581,6 +6754,16 @@ export class DocumentIndex<
 			}
 		};
 
+		if (outerSignal) {
+			outerAbortListener = () => {
+				void close();
+			};
+			outerSignal.addEventListener("abort", outerAbortListener, { once: true });
+			if (outerSignal.aborted) {
+				void close();
+			}
+		}
+
 		return {
 			close,
 			next,
@@ -6654,53 +6837,62 @@ export class DocumentIndex<
 				const drainBatchSize = replicate ? 1000 : 100;
 				let result: ValueTypeFromRequest<Resolve, T, I>[] = [];
 				let c = 0;
-				while (doneFn() !== true) {
-					let batch = await next(drainBatchSize);
-					c += batch.length;
-					if (c > WARNING_WHEN_ITERATING_FOR_MORE_THAN) {
-						warn(
-							"Iterating for more than " +
-								WARNING_WHEN_ITERATING_FOR_MORE_THAN +
-								" results",
-						);
+				try {
+					while (doneFn() !== true) {
+						let batch = await next(drainBatchSize);
+						c += batch.length;
+						if (c > WARNING_WHEN_ITERATING_FOR_MORE_THAN) {
+							warn(
+								"Iterating for more than " +
+									WARNING_WHEN_ITERATING_FOR_MORE_THAN +
+									" results",
+							);
+						}
+						if (batch.length > 0) {
+							result.push(...batch);
+							continue;
+						}
+						await waitForUpdateAndResetDeferred();
 					}
-					if (batch.length > 0) {
-						result.push(...batch);
-						continue;
-					}
-					await waitForUpdateAndResetDeferred();
+					return result;
+				} finally {
+					await close();
 				}
-				cleanupAndDone();
-				return result;
 			},
 			first: async () => {
-				if (doneFn()) {
-					return undefined;
+				try {
+					if (doneFn()) {
+						return undefined;
+					}
+					let batch = await next(1);
+					return batch[0];
+				} finally {
+					await close();
 				}
-				let batch = await next(1);
-				cleanupAndDone();
-				return batch[0];
 			},
 			[Symbol.asyncIterator]: async function* () {
 				drain = true;
 				const drainBatchSize = replicate ? 1000 : 100;
 				let c = 0;
-				while (doneFn() !== true) {
-					const batch = await next(drainBatchSize);
-					c += batch.length;
-					if (c > WARNING_WHEN_ITERATING_FOR_MORE_THAN) {
-						warn(
-							"Iterating for more than " +
-								WARNING_WHEN_ITERATING_FOR_MORE_THAN +
-								" results",
-						);
+				try {
+					while (doneFn() !== true) {
+						const batch = await next(drainBatchSize);
+						c += batch.length;
+						if (c > WARNING_WHEN_ITERATING_FOR_MORE_THAN) {
+							warn(
+								"Iterating for more than " +
+									WARNING_WHEN_ITERATING_FOR_MORE_THAN +
+									" results",
+							);
+						}
+						for (const entry of batch) {
+							yield entry;
+						}
+						await waitForUpdateAndResetDeferred();
 					}
-					for (const entry of batch) {
-						yield entry;
-					}
-					await waitForUpdateAndResetDeferred();
+				} finally {
+					await close();
 				}
-				cleanupAndDone();
 			},
 		};
 	}

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -11193,6 +11193,505 @@ describe("index", () => {
 				});
 
 				describe("v8+", () => {
+					const missingResponderTimeout = 1_000;
+					const setupMissingLaterPageResponder = async ({
+						throwOnMissing,
+						retryMissingResponses,
+					}: {
+						throwOnMissing: boolean;
+						retryMissingResponses: boolean;
+					}) => {
+						stores[0] = await session.peers[0].open<TestStore>(
+							new TestStore({ docs: new Documents() }),
+							{
+								args: {
+									replicate: true,
+								},
+							},
+						);
+
+						for (let i = 0; i < 3; i++) {
+							await stores[0].docs.put(
+								new Document({ id: `missing-later-page-${i}` }),
+							);
+						}
+
+						stores[1] = await session.peers[1].open<TestStore>(
+							stores[0].clone(),
+							{
+								args: {
+									replicate: false,
+								},
+							},
+						);
+
+						await stores[1].docs.index.waitFor(
+							stores[0].node.identity.publicKey,
+						);
+
+						const writerHash = stores[0].node.identity.publicKey.hashcode();
+						const requestSpy = sinon.spy(
+							stores[1].docs.index._query,
+							"request",
+						);
+						const sendSpy = sinon.spy(stores[1].docs.index._query, "send");
+						const iterator = stores[1].docs.index.iterate(
+							{},
+							{
+								remote: {
+									from: [writerHash],
+									throwOnMissing,
+									retryMissingResponses,
+									timeout: missingResponderTimeout,
+								},
+							},
+						);
+
+						expect(await iterator.next(1)).to.have.length(1);
+						await stores[0].docs.index._query.close(stores[0].docs.index);
+
+						return { iterator, requestSpy, sendSpy, writerHash };
+					};
+
+					it("closes a directed remote iterator before its first response", async function () {
+						this.timeout(30_000);
+						stores[0] = await session.peers[0].open<TestStore>(
+							new TestStore({ docs: new Documents() }),
+							{ args: { replicate: true } },
+						);
+						stores[1] = await session.peers[1].open<TestStore>(
+							stores[0].clone(),
+							{ args: { replicate: false } },
+						);
+						await stores[1].docs.index.waitFor(
+							stores[0].node.identity.publicKey,
+						);
+
+						const writerHash = stores[0].node.identity.publicKey.hashcode();
+						await stores[0].docs.index._query.close(stores[0].docs.index);
+						const requestSpy = sinon.spy(
+							stores[1].docs.index._query,
+							"request",
+						);
+						const sendSpy = sinon.spy(stores[1].docs.index._query, "send");
+						const iterator = stores[1].docs.index.iterate(
+							{},
+							{
+								local: false,
+								remote: {
+									from: [writerHash],
+									timeout: 5_000,
+								},
+							},
+						);
+						const nextResult = iterator.next(1).then(
+							() => undefined,
+							(error: unknown) => error,
+						);
+
+						let closed = false;
+						try {
+							await waitForResolved(
+								() =>
+									expect(
+										requestSpy
+											.getCalls()
+											.filter(
+												(call) => call.args[0] instanceof IterationRequest,
+											),
+									).to.have.length(1),
+								{ timeout: 5_000 },
+							);
+							const started = Date.now();
+							await iterator.close();
+							closed = true;
+							const failure = await nextResult;
+							expect(failure).to.be.instanceOf(Error);
+							expect(Date.now() - started).to.be.lessThan(2_000);
+							expect(
+								sendSpy
+									.getCalls()
+									.filter(
+										(call) => call.args[0] instanceof CloseIteratorRequest,
+									),
+							).to.have.length(1);
+						} finally {
+							if (!closed) {
+								await iterator.close();
+							}
+							requestSpy.restore();
+							sendSpy.restore();
+						}
+					});
+
+					it("closes a default-cover remote iterator before its response is introduced", async function () {
+						this.timeout(30_000);
+						stores[0] = await session.peers[0].open<TestStore>(
+							new TestStore({ docs: new Documents() }),
+							{ args: { replicate: true } },
+						);
+						for (let i = 0; i < 3; i++) {
+							await stores[0].docs.put(
+								new Document({ id: `default-cover-close-race-${i}` }),
+							);
+						}
+						stores[1] = await session.peers[1].open<TestStore>(
+							stores[0].clone(),
+							{ args: { replicate: false } },
+						);
+						await stores[1].docs.index.waitFor(
+							stores[0].node.identity.publicKey,
+						);
+
+						const responseReady = pDefer<void>();
+						const releaseResponse = pDefer<void>();
+						const requestFn = stores[1].docs.index._query.request.bind(
+							stores[1].docs.index._query,
+						);
+						let holdInitialResponse = true;
+						stores[1].docs.index._query.request = async (request, options) => {
+							const response = await requestFn(request, options);
+							if (holdInitialResponse && request instanceof IterationRequest) {
+								holdInitialResponse = false;
+								responseReady.resolve();
+								await releaseResponse.promise;
+							}
+							return response;
+						};
+						const sendSpy = sinon.spy(stores[1].docs.index._query, "send");
+						const iterator = stores[1].docs.index.iterate(
+							{},
+							{
+								local: false,
+								remote: { timeout: 5_000 },
+							},
+						);
+						const nextResult = iterator.next(1).then(
+							() => undefined,
+							(error: unknown) => error,
+						);
+
+						try {
+							await responseReady.promise;
+							expect(stores[0].docs.index.countIteratorsInProgress).to.equal(1);
+
+							await iterator.close();
+							expect(
+								sendSpy
+									.getCalls()
+									.filter(
+										(call) => call.args[0] instanceof CloseIteratorRequest,
+									),
+							).to.have.length(1);
+							await waitForResolved(
+								() =>
+									expect(
+										stores[0].docs.index.countIteratorsInProgress,
+									).to.equal(0),
+								{ timeout: 5_000 },
+							);
+						} finally {
+							releaseResponse.resolve();
+							await nextResult;
+							await iterator.close();
+							stores[1].docs.index._query.request = requestFn;
+							sendSpy.restore();
+						}
+					});
+
+					it("does not close a remote iterator that drained successfully", async function () {
+						this.timeout(30_000);
+						stores[0] = await session.peers[0].open<TestStore>(
+							new TestStore({ docs: new Documents() }),
+							{ args: { replicate: true } },
+						);
+						await stores[0].docs.put(new Document({ id: "drained-remote" }));
+						stores[1] = await session.peers[1].open<TestStore>(
+							stores[0].clone(),
+							{ args: { replicate: false } },
+						);
+						await stores[1].docs.index.waitFor(
+							stores[0].node.identity.publicKey,
+						);
+
+						const writerHash = stores[0].node.identity.publicKey.hashcode();
+						const sendSpy = sinon.spy(stores[1].docs.index._query, "send");
+						const iterator = stores[1].docs.index.iterate(
+							{},
+							{ local: false, remote: { from: [writerHash] } },
+						);
+						let closed = false;
+
+						try {
+							expect(await iterator.next(1)).to.have.length(1);
+							expect(stores[0].docs.index.countIteratorsInProgress).to.equal(0);
+							await iterator.close();
+							closed = true;
+							expect(
+								sendSpy
+									.getCalls()
+									.filter(
+										(call) => call.args[0] instanceof CloseIteratorRequest,
+									),
+							).to.have.length(0);
+						} finally {
+							if (!closed) {
+								await iterator.close();
+							}
+							sendSpy.restore();
+						}
+					});
+
+					it("closes remote state from implicit iterator consumers", async function () {
+						this.timeout(30_000);
+						stores[0] = await session.peers[0].open<TestStore>(
+							new TestStore({ docs: new Documents() }),
+							{ args: { replicate: true } },
+						);
+						for (let i = 0; i < 3; i++) {
+							await stores[0].docs.put(
+								new Document({ id: `implicit-close-${i}` }),
+							);
+						}
+						stores[1] = await session.peers[1].open<TestStore>(
+							stores[0].clone(),
+							{ args: { replicate: false } },
+						);
+						await stores[1].docs.index.waitFor(
+							stores[0].node.identity.publicKey,
+						);
+
+						const writerHash = stores[0].node.identity.publicKey.hashcode();
+						const remote = { from: [writerHash], timeout: 5_000 };
+						const expectRemoteClosed = () =>
+							waitForResolved(
+								() =>
+									expect(
+										stores[0].docs.index.countIteratorsInProgress,
+									).to.equal(0),
+								{ timeout: 5_000 },
+							);
+
+						const batchFailure = new Error("FAIL_IMPLICIT_SEARCH_BATCH");
+						let searchFailure: unknown;
+						try {
+							await stores[1].docs.index.search(
+								new IterationRequest({ fetch: 1 }),
+								{
+									local: false,
+									remote,
+									updates: {
+										merge: false,
+										onBatch: () => {
+											throw batchFailure;
+										},
+									},
+								},
+							);
+						} catch (error) {
+							searchFailure = error;
+						}
+						expect(searchFailure).to.equal(batchFailure);
+						await expectRemoteClosed();
+
+						const first = await stores[1].docs.index
+							.iterate({}, { local: false, remote })
+							.first();
+						expect(first).to.not.equal(undefined);
+						await expectRemoteClosed();
+
+						const all = await stores[1].docs.index
+							.iterate({}, { local: false, remote, closePolicy: "manual" })
+							.all();
+						expect(all).to.have.length(3);
+						await expectRemoteClosed();
+
+						let yielded = 0;
+						for await (const _entry of stores[1].docs.index.iterate(
+							{},
+							{ local: false, remote, closePolicy: "manual" },
+						)) {
+							yielded++;
+							break;
+						}
+						expect(yielded).to.equal(1);
+						await expectRemoteClosed();
+					});
+
+					it("sends remote iterator cleanup after the outer signal aborts", async function () {
+						this.timeout(30_000);
+						stores[0] = await session.peers[0].open<TestStore>(
+							new TestStore({ docs: new Documents() }),
+							{ args: { replicate: true } },
+						);
+						for (let i = 0; i < 3; i++) {
+							await stores[0].docs.put(
+								new Document({ id: `outer-abort-close-${i}` }),
+							);
+						}
+						stores[1] = await session.peers[1].open<TestStore>(
+							stores[0].clone(),
+							{ args: { replicate: false } },
+						);
+						await stores[1].docs.index.waitFor(
+							stores[0].node.identity.publicKey,
+						);
+
+						const writerHash = stores[0].node.identity.publicKey.hashcode();
+						const outerController = new AbortController();
+						const remoteController = new AbortController();
+						const sendSpy = sinon.spy(stores[1].docs.index._query, "send");
+						const iterator = stores[1].docs.index.iterate(
+							{},
+							{
+								signal: outerController.signal,
+								remote: {
+									from: [writerHash],
+									signal: remoteController.signal,
+									timeout: 5_000,
+								},
+							},
+						);
+
+						try {
+							expect(await iterator.next(1)).to.have.length(1);
+							expect(stores[0].docs.index.countIteratorsInProgress).to.equal(1);
+
+							remoteController.abort(new Error("REMOTE_REQUEST_ABORT"));
+							outerController.abort(new Error("OUTER_ITERATOR_ABORT"));
+							let closeCall: ReturnType<typeof sendSpy.getCall> | undefined;
+							await waitForResolved(
+								() => {
+									closeCall = sendSpy
+										.getCalls()
+										.find(
+											(call) => call.args[0] instanceof CloseIteratorRequest,
+										);
+									expect(closeCall).to.not.equal(undefined);
+								},
+								{ timeout: 5_000 },
+							);
+							const closeSignal = closeCall!.args[1]?.signal as
+								| AbortSignal
+								| undefined;
+							expect(closeSignal).to.not.equal(outerController.signal);
+							expect(closeSignal).to.not.equal(remoteController.signal);
+							expect(closeSignal?.aborted).to.equal(false);
+							await waitForResolved(
+								() =>
+									expect(
+										stores[0].docs.index.countIteratorsInProgress,
+									).to.equal(0),
+								{ timeout: 5_000 },
+							);
+						} finally {
+							await iterator.close();
+							sendSpy.restore();
+						}
+					});
+
+					it("detaches the outer abort listener after iterator cleanup", async function () {
+						this.timeout(30_000);
+						stores[0] = await session.peers[0].open<TestStore>(
+							new TestStore({ docs: new Documents() }),
+							{ args: { replicate: true } },
+						);
+						for (let i = 0; i < 3; i++) {
+							await stores[0].docs.put(
+								new Document({ id: `outer-listener-cleanup-${i}` }),
+							);
+						}
+						stores[1] = await session.peers[1].open<TestStore>(
+							stores[0].clone(),
+							{ args: { replicate: false } },
+						);
+						await stores[1].docs.index.waitFor(
+							stores[0].node.identity.publicKey,
+						);
+
+						const writerHash = stores[0].node.identity.publicKey.hashcode();
+						const outerController = new AbortController();
+						const addListenerSpy = sinon.spy(
+							outerController.signal,
+							"addEventListener",
+						);
+						const removeListenerSpy = sinon.spy(
+							outerController.signal,
+							"removeEventListener",
+						);
+						const sendSpy = sinon.spy(stores[1].docs.index._query, "send");
+						const iterator = stores[1].docs.index.iterate(
+							{},
+							{
+								signal: outerController.signal,
+								local: false,
+								remote: { from: [writerHash], timeout: 5_000 },
+							},
+						);
+
+						try {
+							expect(await iterator.next(1)).to.have.length(1);
+							const abortRegistration = addListenerSpy
+								.getCalls()
+								.find((call) => call.args[0] === "abort");
+							expect(abortRegistration).to.not.equal(undefined);
+
+							await iterator.close();
+							await iterator.close();
+							expect(
+								removeListenerSpy.calledWith(
+									"abort",
+									abortRegistration!.args[1],
+								),
+							).to.equal(true);
+							const closeCalls = sendSpy
+								.getCalls()
+								.filter(
+									(call) => call.args[0] instanceof CloseIteratorRequest,
+								).length;
+							expect(closeCalls).to.equal(1);
+
+							outerController.abort(new Error("ABORT_AFTER_ITERATOR_CLOSE"));
+							await delay(10);
+							expect(
+								sendSpy
+									.getCalls()
+									.filter(
+										(call) => call.args[0] instanceof CloseIteratorRequest,
+									),
+							).to.have.length(closeCalls);
+
+							const alreadyAborted = new AbortController();
+							alreadyAborted.abort(new Error("ALREADY_ABORTED_ITERATOR"));
+							const abortedRemoveSpy = sinon.spy(
+								alreadyAborted.signal,
+								"removeEventListener",
+							);
+							try {
+								const abortedIterator = stores[1].docs.index.iterate(
+									{},
+									{
+										signal: alreadyAborted.signal,
+										local: false,
+										remote: { from: [writerHash], timeout: 5_000 },
+									},
+								);
+								expect(abortedIterator.done()).to.equal(true);
+								await abortedIterator.close();
+								expect(
+									abortedRemoveSpy.calledWith("abort", sinon.match.func),
+								).to.equal(true);
+							} finally {
+								abortedRemoveSpy.restore();
+							}
+						} finally {
+							await iterator.close();
+							sendSpy.restore();
+							removeListenerSpy.restore();
+							addListenerSpy.restore();
+						}
+					});
+
 					it("uses iteration request by default when compatibility is undefined", async () => {
 						stores[0] = await session.peers[0].open<TestStore>(
 							new TestStore({ docs: new Documents() }),
@@ -11332,6 +11831,119 @@ describe("index", () => {
 							);
 						} finally {
 							await iterator?.close();
+							requestSpy.restore();
+							sendSpy.restore();
+						}
+					});
+
+					it("rejects a missing later-page responder when throwOnMissing is true", async function () {
+						this.timeout(30_000);
+						const { iterator, requestSpy, sendSpy, writerHash } =
+							await setupMissingLaterPageResponder({
+								throwOnMissing: true,
+								retryMissingResponses: true,
+							});
+
+						try {
+							const started = Date.now();
+							let failure: unknown;
+							try {
+								await iterator.next(1);
+							} catch (error) {
+								failure = error;
+							}
+
+							expect(failure).to.be.instanceOf(MissingResponsesError);
+							expect(
+								(failure as MissingResponsesError).missingGroups,
+							).to.deep.equal([[writerHash]]);
+							const collectRequests = requestSpy
+								.getCalls()
+								.filter((call) => call.args[0] instanceof CollectNextRequest);
+							expect(collectRequests).to.have.length(1);
+							expect(collectRequests[0].args[1]?.timeout).to.equal(
+								missingResponderTimeout,
+							);
+							expect(Date.now() - started).to.be.lessThan(
+								missingResponderTimeout + 2_000,
+							);
+						} finally {
+							await iterator.close();
+							requestSpy.restore();
+							sendSpy.restore();
+						}
+					});
+
+					it("retires a missing later-page responder when retries are disabled", async function () {
+						this.timeout(30_000);
+						const { iterator, requestSpy, sendSpy } =
+							await setupMissingLaterPageResponder({
+								throwOnMissing: false,
+								retryMissingResponses: false,
+							});
+
+						const collectRequestCount = () =>
+							requestSpy
+								.getCalls()
+								.filter((call) => call.args[0] instanceof CollectNextRequest)
+								.length;
+
+						let closed = false;
+						try {
+							expect(await iterator.next(1)).to.deep.equal([]);
+							expect(collectRequestCount()).to.equal(1);
+							expect(await iterator.next(1)).to.deep.equal([]);
+							expect(collectRequestCount()).to.equal(1);
+							await iterator.close();
+							closed = true;
+							expect(
+								sendSpy
+									.getCalls()
+									.filter(
+										(call) => call.args[0] instanceof CloseIteratorRequest,
+									),
+							).to.have.length(1);
+						} finally {
+							if (!closed) {
+								await iterator.close();
+							}
+							requestSpy.restore();
+							sendSpy.restore();
+						}
+					});
+
+					it("retries a missing later page with a fresh iteration request", async function () {
+						this.timeout(30_000);
+						const { iterator, requestSpy, sendSpy } =
+							await setupMissingLaterPageResponder({
+								throwOnMissing: false,
+								retryMissingResponses: true,
+							});
+
+						const requestCount = (
+							requestType: typeof CollectNextRequest | typeof IterationRequest,
+						) =>
+							requestSpy
+								.getCalls()
+								.filter((call) => call.args[0] instanceof requestType).length;
+
+						try {
+							expect(await iterator.next(1)).to.deep.equal([]);
+							expect(iterator.done()).to.equal(false);
+							expect(requestCount(CollectNextRequest)).to.equal(1);
+							expect(requestCount(IterationRequest)).to.equal(1);
+
+							expect(await iterator.next(1)).to.deep.equal([]);
+							expect(iterator.done()).to.equal(false);
+							expect(requestCount(CollectNextRequest)).to.equal(1);
+							expect(requestCount(IterationRequest)).to.equal(2);
+
+							expect(await iterator.next(1)).to.deep.equal([]);
+							expect(iterator.done()).to.equal(true);
+							expect(requestCount(CollectNextRequest)).to.equal(1);
+							expect(requestCount(IterationRequest)).to.equal(3);
+						} finally {
+							await iterator.close();
 							requestSpy.restore();
 							sendSpy.restore();
 						}
@@ -15152,16 +15764,13 @@ describe("index", () => {
 								{},
 								{
 									local: false,
-									remote: {
-										wait: { timeout: 5_000, behavior: "keep-open" },
-									},
+									remote: { timeout: 5_000 },
 								},
 							);
 
 							await iterator.next(1); // initial
 							await iterator.next(1); // retry 1
 							await iterator.next(1); // retry 2 (max)
-							await iterator.next(1); // no additional retry beyond cap
 
 							expect(observedRemoteFrom).to.deep.equal([
 								undefined,
@@ -15169,7 +15778,7 @@ describe("index", () => {
 								[missingPeer],
 							]);
 							expect(missingCallbacks).to.equal(3);
-							expect(iterator.done()).to.equal(false);
+							expect(iterator.done()).to.equal(true);
 
 							await iterator.close();
 						});
@@ -19939,6 +20548,189 @@ describe("index", () => {
 			expect(sendSpy.callCount).to.eq(0); // even if we do a ".close()" on the iterator, we should not send a new request, because we only have 3 docs in total and we fetched all
 			expect(store.docs.index.countIteratorsInProgress).to.eq(0); // no iterators in progress
 			expect(store2.docs.index.countIteratorsInProgress).to.eq(0); // no iterators in progress
+		});
+
+		it("closes a partially consumed prefetched iterator by its remote id", async function () {
+			this.timeout(30_000);
+			const { store, store2 } = await setupInitialStoresAndPrefetch();
+			await waitForResolved(
+				() => expect(store2.docs.index.prefetch?.accumulator.size).to.equal(1),
+				{ timeout: 10_000 },
+			);
+
+			const iterator = store2.docs.index.iterate({}, { resolve: false });
+			let closed = false;
+			try {
+				expect(await iterator.next(1)).to.have.length(1);
+				expect(store.docs.index.countIteratorsInProgress).to.equal(1);
+
+				await iterator.close();
+				closed = true;
+				await waitForResolved(
+					() => expect(store.docs.index.countIteratorsInProgress).to.equal(0),
+					{ timeout: 5_000 },
+				);
+			} finally {
+				if (!closed) {
+					await iterator.close();
+				}
+			}
+		});
+
+		it("switches from a stale prefetched id when retrying a missing page", async function () {
+			this.timeout(30_000);
+			const { store, store2 } = await setupInitialStoresAndPrefetch();
+			await waitForResolved(
+				() => expect(store2.docs.index.prefetch?.accumulator.size).to.equal(1),
+				{ timeout: 10_000 },
+			);
+
+			const requestFn = store2.docs.index._query.request.bind(
+				store2.docs.index._query,
+			);
+			const observedRequests: AbstractSearchRequest[] = [];
+			let missFirstCollect = true;
+			store2.docs.index._query.request = async (request, options) => {
+				observedRequests.push(request);
+				if (missFirstCollect && request instanceof CollectNextRequest) {
+					missFirstCollect = false;
+					return [];
+				}
+				return requestFn(request, options);
+			};
+			const sendSpy = sinon.spy(store2.docs.index._query, "send");
+			const iterator = store2.docs.index.iterate({}, { resolve: false });
+
+			try {
+				expect((await iterator.next(1)).map((doc) => doc.id)).to.deep.equal([
+					"1",
+				]);
+				expect(await iterator.next(2)).to.deep.equal([]);
+				expect(iterator.done()).to.equal(false);
+
+				expect((await iterator.next(2)).map((doc) => doc.id)).to.deep.equal([
+					"2",
+				]);
+				expect((await iterator.next(1)).map((doc) => doc.id)).to.deep.equal([
+					"3",
+				]);
+
+				const iterationRequests = observedRequests.filter(
+					(request): request is IterationRequest =>
+						request instanceof IterationRequest,
+				);
+				const collectRequests = observedRequests.filter(
+					(request): request is CollectNextRequest =>
+						request instanceof CollectNextRequest,
+				);
+				expect(iterationRequests).to.have.length(1);
+				expect(collectRequests).to.have.length(2);
+				expect(equals(collectRequests[0].id, iterationRequests[0].id)).to.equal(
+					false,
+				);
+				expect(equals(collectRequests[1].id, iterationRequests[0].id)).to.equal(
+					true,
+				);
+
+				expect(store.docs.index.countIteratorsInProgress).to.equal(1);
+				await iterator.close();
+				await waitForResolved(
+					() => expect(store.docs.index.countIteratorsInProgress).to.equal(0),
+					{ timeout: 5_000 },
+				);
+				const closeRequests = sendSpy
+					.getCalls()
+					.map((call) => call.args[0])
+					.filter(
+						(request): request is CloseIteratorRequest =>
+							request instanceof CloseIteratorRequest,
+					);
+				expect(
+					closeRequests.some((request) =>
+						equals(request.id, collectRequests[0].id),
+					),
+				).to.equal(true);
+			} finally {
+				await iterator.close();
+				store2.docs.index._query.request = requestFn;
+				sendSpy.restore();
+			}
+		});
+
+		it("closes every stale prefetched id across repeated retries", async function () {
+			this.timeout(30_000);
+			const { store, store2 } = await setupInitialStoresAndPrefetch();
+			await waitForResolved(
+				() => expect(store2.docs.index.prefetch?.accumulator.size).to.equal(1),
+				{ timeout: 10_000 },
+			);
+
+			const writerHash = store.node.identity.publicKey.hashcode();
+			const requestFn = store2.docs.index._query.request.bind(
+				store2.docs.index._query,
+			);
+			const observedRequests: AbstractSearchRequest[] = [];
+			let missingCollectsRemaining = 2;
+			store2.docs.index._query.request = async (request, options) => {
+				observedRequests.push(request);
+				if (
+					missingCollectsRemaining > 0 &&
+					request instanceof CollectNextRequest
+				) {
+					missingCollectsRemaining--;
+					return [];
+				}
+				return requestFn(request, options);
+			};
+			const sendSpy = sinon.spy(store2.docs.index._query, "send");
+			const iterator = store2.docs.index.iterate({}, { resolve: false });
+
+			try {
+				expect(await iterator.next(1)).to.have.length(1);
+				expect(await iterator.next(2)).to.deep.equal([]);
+				expect(await iterator.next(2)).to.have.length(1);
+
+				const translationsByQuery = (
+					store2.docs.index.prefetch?.accumulator as any
+				).searchIdTranslationMap as Map<string, Map<string, Uint8Array>>;
+				const peerTranslations = [...translationsByQuery.values()][0];
+				expect(peerTranslations).to.not.equal(undefined);
+				const secondStaleId = randomBytes(32);
+				peerTranslations.set(writerHash, secondStaleId);
+
+				expect(await iterator.next(1)).to.deep.equal([]);
+				expect(iterator.done()).to.equal(false);
+				await iterator.next(1);
+
+				const collectRequests = observedRequests.filter(
+					(request): request is CollectNextRequest =>
+						request instanceof CollectNextRequest,
+				);
+				expect(collectRequests).to.have.length(2);
+				expect(equals(collectRequests[1].id, secondStaleId)).to.equal(true);
+
+				await iterator.close();
+				await waitForResolved(
+					() => expect(store.docs.index.countIteratorsInProgress).to.equal(0),
+					{ timeout: 5_000 },
+				);
+				const closeRequests = sendSpy
+					.getCalls()
+					.map((call) => call.args[0])
+					.filter(
+						(request): request is CloseIteratorRequest =>
+							request instanceof CloseIteratorRequest,
+					);
+				for (const staleId of [collectRequests[0].id, secondStaleId]) {
+					expect(
+						closeRequests.some((request) => equals(request.id, staleId)),
+					).to.equal(true);
+				}
+			} finally {
+				await iterator.close();
+				store2.docs.index._query.request = requestFn;
+				sendSpy.restore();
+			}
 		});
 
 		it("delivers prefetched batch to push-enabled iterator", async () => {

--- a/packages/programs/rpc/src/controller.ts
+++ b/packages/programs/rpc/src/controller.ts
@@ -608,12 +608,45 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 		request: Q,
 		options?: RPCRequestOptions<R>,
 	): Promise<RPCResponse<R>[]> {
-		// We are generatinga new encryption keypair for each send, so we now that when we get the responses, they are encrypted specifcally for me, and for this request
-		// this allows us to easily disregard a bunch of message just beacuse they are for a different receiver!
-		const keypair = await X25519Keypair.create();
+		const requestSignal = options?.signal;
+		const getAbortReason = (signal?: AbortSignal): unknown =>
+			signal?.reason === undefined ? new AbortError() : signal.reason;
+		if (requestSignal?.aborted) {
+			throw getAbortReason(requestSignal);
+		}
 
-		const requestMessage = await this.seal(request, keypair.publicKey, options);
-		const requestBytes = serialize(requestMessage);
+		let rejectSetupForAbort!: (reason?: unknown) => void;
+		const setupAbortPromise = new Promise<never>((_resolve, reject) => {
+			rejectSetupForAbort = reject;
+		});
+		const setupAbortListener = () => {
+			rejectSetupForAbort(getAbortReason(requestSignal));
+		};
+		requestSignal?.addEventListener("abort", setupAbortListener, { once: true });
+		const setupPromise = (async () => {
+			// We are generatinga new encryption keypair for each send, so we now that when we get the responses, they are encrypted specifcally for me, and for this request
+			// this allows us to easily disregard a bunch of message just beacuse they are for a different receiver!
+			const keypair = await X25519Keypair.create();
+			if (requestSignal?.aborted) {
+				throw getAbortReason(requestSignal);
+			}
+			const requestMessage = await this.seal(
+				request,
+				keypair.publicKey,
+				options,
+			);
+			return { keypair, requestBytes: serialize(requestMessage) };
+		})();
+		let setup: Awaited<typeof setupPromise>;
+		try {
+			setup = await Promise.race([setupPromise, setupAbortPromise]);
+		} finally {
+			requestSignal?.removeEventListener("abort", setupAbortListener);
+		}
+		const { keypair, requestBytes } = setup;
+		if (requestSignal?.aborted) {
+			throw getAbortReason(requestSignal);
+		}
 
 		const allResults: RPCResponse<R>[] = [];
 
@@ -636,12 +669,24 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 			options?.timeout || 10 * 1000,
 		);
 
-		const abortListener = (err: Event) => {
-			const reason = (err.target as any)?.["reason"] || new AbortError();
+		const rejectForAbort = (signal?: AbortSignal) => {
+			const reason = getAbortReason(signal);
 			abortPublish(reason);
 			deferredPromise.reject(reason);
 		};
-		options?.signal?.addEventListener("abort", abortListener);
+		const abortListener = (event: Event) => {
+			rejectForAbort(event.target as AbortSignal | undefined);
+		};
+		requestSignal?.addEventListener("abort", abortListener);
+		// Cover the narrow handoff between the setup listener and the active request
+		// listener before registering any resolver or transport side effects.
+		if (requestSignal?.aborted) {
+			const reason = getAbortReason(requestSignal);
+			abortPublish(reason);
+			clearTimeout(timeoutFn);
+			requestSignal.removeEventListener("abort", abortListener);
+			throw reason;
+		}
 
 		const closeListener = () => {
 			const reason = new AbortError("Closed");
@@ -679,30 +724,36 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 			})
 			.catch(() => {});
 
-		if (options?.responseInterceptor) {
-			options.responseInterceptor((response: RPCResponse<R>) => {
-				return this.handleDecodedResponse(
-					response,
-					deferredPromise,
-					allResults,
-					responders,
-					expectedResponders,
-					options,
-				);
-			});
-		}
-
 		try {
-			const publishPromise = Promise.resolve(
-				this.node.services.pubsub.publish(
-					requestBytes,
-					this.getPublishOptions(
-						messageId,
+			if (requestSignal?.aborted) {
+				throw getAbortReason(requestSignal);
+			}
+			if (options?.responseInterceptor) {
+				options.responseInterceptor((response: RPCResponse<R>) => {
+					return this.handleDecodedResponse(
+						response,
+						deferredPromise,
+						allResults,
+						responders,
+						expectedResponders,
 						options,
-						publishAbortController.signal,
+					);
+				});
+			}
+			if (requestSignal?.aborted) {
+				throw getAbortReason(requestSignal);
+			}
+			const publishPromise = Promise.resolve()
+				.then(() =>
+					this.node.services.pubsub.publish(
+						requestBytes,
+						this.getPublishOptions(
+							messageId,
+							options,
+							publishAbortController.signal,
+						),
 					),
-				),
-			)
+				)
 				.catch((error: any) => {
 					if (
 						publishAbortController.signal.aborted &&
@@ -719,16 +770,12 @@ export class RPC<Q, R> extends Program<RPCSetupOptions<Q, R>, RPCEvents<Q, R>> {
 				});
 			await Promise.race([publishPromise, deferredPromise.promise]);
 			await deferredPromise.promise;
-		} catch (error: any) {
-			if (!(error instanceof TimeoutError)) {
-				throw error;
-			}
 		} finally {
 			abortPublish(new AbortError("RPC request finished"));
 			clearTimeout(timeoutFn);
 			this.events.removeEventListener("close", closeListener);
 			this.events.removeEventListener("drop", dropListener);
-			options?.signal?.removeEventListener("abort", abortListener);
+			requestSignal?.removeEventListener("abort", abortListener);
 			this._responseResolver.delete(id);
 		}
 

--- a/packages/programs/rpc/test/index.spec.ts
+++ b/packages/programs/rpc/test/index.spec.ts
@@ -19,7 +19,13 @@ import {
 	SilentDelivery,
 } from "@peerbit/stream-interface";
 import { TestSession } from "@peerbit/test-utils";
-import { AbortError, delay, waitFor, waitForResolved } from "@peerbit/time";
+import {
+	AbortError,
+	TimeoutError,
+	delay,
+	waitFor,
+	waitForResolved,
+} from "@peerbit/time";
 import { expect } from "chai";
 import sinon from "sinon";
 import {
@@ -355,6 +361,163 @@ describe("rpc", () => {
 				expect(Date.now() - started).to.be.lessThan(1_000);
 			} finally {
 				publishStub.restore();
+			}
+		});
+
+		it("ignores a synchronous transport TimeoutError", async () => {
+			const publishTimeout = new TimeoutError("SYNCHRONOUS_PUBLISH_TIMEOUT");
+			const publishStub = sinon
+				.stub(reader.node.services.pubsub, "publish")
+				.throws(publishTimeout);
+
+			try {
+				const result = await reader.query.request(
+					new Body({ arr: new Uint8Array([1, 2, 3]) }),
+					{ timeout: 25 },
+				);
+
+				expect(result).to.deep.equal([]);
+				expect(publishStub.calledOnce).to.be.true;
+			} finally {
+				publishStub.restore();
+			}
+		});
+
+		it("preserves an already-aborted request signal", async () => {
+			const controller = new AbortController();
+			const reason = new AbortError("ALREADY_ABORTED");
+			controller.abort(reason);
+			const publishSpy = sinon.spy(reader.node.services.pubsub, "publish");
+
+			try {
+				let failure: unknown;
+				try {
+					await reader.query.request(
+						new Body({ arr: new Uint8Array([1, 2, 3]) }),
+						{ signal: controller.signal, timeout: 5_000 },
+					);
+				} catch (error) {
+					failure = error;
+				}
+
+				expect(failure).to.equal(reason);
+				expect(publishSpy.notCalled).to.be.true;
+			} finally {
+				publishSpy.restore();
+			}
+		});
+
+		it("observes a request signal aborted during envelope setup", async () => {
+			const controller = new AbortController();
+			const reason = new AbortError("ABORTED_DURING_SETUP");
+			const query = reader.query as any;
+			const originalSeal = query.seal.bind(query);
+			const sealStub = sinon
+				.stub(query, "seal")
+				.callsFake(async (...args: any[]) => {
+					const sealed = await originalSeal(...args);
+					controller.abort(reason);
+					return sealed;
+				});
+			const publishSpy = sinon.spy(reader.node.services.pubsub, "publish");
+			const removeListenerSpy = sinon.spy(
+				controller.signal,
+				"removeEventListener",
+			);
+			const resolverCountBefore = query._responseResolver.size;
+
+			try {
+				let failure: unknown;
+				try {
+					await reader.query.request(
+						new Body({ arr: new Uint8Array([1, 2, 3]) }),
+						{ signal: controller.signal, timeout: 5_000 },
+					);
+				} catch (error) {
+					failure = error;
+				}
+
+				expect(failure).to.equal(reason);
+				expect(publishSpy.notCalled).to.be.true;
+				expect(query._responseResolver.size).to.equal(resolverCountBefore);
+				expect(removeListenerSpy.calledWith("abort")).to.be.true;
+			} finally {
+				removeListenerSpy.restore();
+				publishSpy.restore();
+				sealStub.restore();
+			}
+		});
+
+		it("settles an abort while request envelope setup remains pending", async () => {
+			const controller = new AbortController();
+			const reason = new AbortError("ABORTED_WHILE_SETUP_PENDING");
+			const query = reader.query as any;
+			const originalSeal = query.seal.bind(query);
+			let resolveSetupStarted!: () => void;
+			const setupStarted = new Promise<void>((resolve) => {
+				resolveSetupStarted = resolve;
+			});
+			let releaseSetup!: () => void;
+			const setupRelease = new Promise<void>((resolve) => {
+				releaseSetup = resolve;
+			});
+			const sealStub = sinon
+				.stub(query, "seal")
+				.callsFake(async (...args: any[]) => {
+					resolveSetupStarted();
+					await setupRelease;
+					return originalSeal(...args);
+				});
+			const publishSpy = sinon.spy(reader.node.services.pubsub, "publish");
+
+			const request = reader.query.request(
+				new Body({ arr: new Uint8Array([1, 2, 3]) }),
+				{ signal: controller.signal, timeout: 5_000 },
+			);
+			try {
+				await setupStarted;
+				controller.abort(reason);
+				const failure = await Promise.race([
+					request.then(
+						(): undefined => undefined,
+						(error: unknown) => error,
+					),
+					delay(500).then(() => new Error("SETUP_ABORT_DID_NOT_SETTLE")),
+				]);
+				expect(failure).to.equal(reason);
+				expect(publishSpy.notCalled).to.be.true;
+			} finally {
+				releaseSetup();
+				await request.catch((): undefined => undefined);
+				publishSpy.restore();
+				sealStub.restore();
+			}
+		});
+
+		it("preserves a TimeoutError used as the request abort reason", async () => {
+			const controller = new AbortController();
+			const reason = new TimeoutError("ABORT_TIMEOUT_REASON");
+			const publishSpy = sinon.spy(reader.node.services.pubsub, "publish");
+
+			try {
+				let failure: unknown;
+				try {
+					await reader.query.request(
+						new Body({ arr: new Uint8Array([1, 2, 3]) }),
+						{
+							signal: controller.signal,
+							timeout: 5_000,
+							responseInterceptor: () => controller.abort(reason),
+						},
+					);
+				} catch (error) {
+					failure = error;
+				}
+
+				expect(failure).to.equal(reason);
+				expect(publishSpy.notCalled).to.be.true;
+			} finally {
+				publishSpy.restore();
 			}
 		});
 


### PR DESCRIPTION
## Summary

- close remote iterator state across default-cover races, implicit consumers, aborts, and prefetched ID translation
- retry missing later-page responders with fresh IDs while retaining every stale ID for cleanup
- make RPC aborts cancel pending setup, preserve abort reasons, and avoid canceled transport side effects

## Validation

- @peerbit/document: 439 passing full suite before the final narrow review fixes
- post-review Document pagination/prefetch regressions: 10 passing
- @peerbit/rpc: 39 passing
- targeted ESLint: 0 errors; 2 pre-existing RPC unused-import warnings
- git diff --check and changeset status: clean