### PR TITLE
fix(crypto): declare published runtime dependencies

### DIFF
--- a/.changeset/fix-crypto-runtime-dependencies.md
+++ b/.changeset/fix-crypto-runtime-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/crypto": patch
+---
+
+Declare `multiformats` and `uint8arrays` as runtime dependencies so clean and nested package installs can import the published crypto package without relying on dependency hoisting. Remove the unused runtime dependency on `@peerbit/cache`.

--- a/packages/utils/crypto/package.json
+++ b/packages/utils/crypto/package.json
@@ -64,9 +64,7 @@
 	"license": "MIT",
 	"devDependencies": {
 		"@types/libsodium-wrappers": "^0.7.14",
-		"ethers": "^6.17.0",
-		"multiformats": "^13.4.2",
-		"uint8arrays": "^5.1.0"
+		"ethers": "^6.17.0"
 	},
 	"dependencies": {
 		"@dao-xyz/borsh": "^6.0.0",
@@ -76,11 +74,12 @@
 		"@libp2p/interface": "^3.1.1",
 		"@libp2p/peer-id": "^6.0.5",
 		"@noble/curves": "1.9.7",
-		"@peerbit/cache": "workspace:*",
 		"@protobufjs/utf8": "^1.1.2",
 		"@stablelib/sha256": "^2.0.1",
 		"js-sha3": "^0.9.3",
-		"libsodium-wrappers": "0.7.15"
+		"libsodium-wrappers": "0.7.15",
+		"multiformats": "^13.4.2",
+		"uint8arrays": "^5.1.0"
 	},
 	"repository": {
 		"type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2679,9 +2679,6 @@ importers:
       '@noble/curves':
         specifier: 1.9.7
         version: 1.9.7
-      '@peerbit/cache':
-        specifier: workspace:*
-        version: link:../cache
       '@protobufjs/utf8':
         specifier: 1.1.2
         version: 1.1.2
@@ -2694,6 +2691,12 @@ importers:
       libsodium-wrappers:
         specifier: 0.7.15
         version: 0.7.15
+      multiformats:
+        specifier: ^13.4.2
+        version: 13.4.2
+      uint8arrays:
+        specifier: ^5.1.0
+        version: 5.1.0
     devDependencies:
       '@types/libsodium-wrappers':
         specifier: ^0.7.14
@@ -2701,12 +2704,6 @@ importers:
       ethers:
         specifier: ^6.17.0
         version: 6.17.0
-      multiformats:
-        specifier: ^13.4.2
-        version: 13.4.2
-      uint8arrays:
-        specifier: ^5.1.0
-        version: 5.1.0
 
   packages/utils/diagnostics: {}
 

--- a/scripts/test-published-crypto-package-smoke.mjs
+++ b/scripts/test-published-crypto-package-smoke.mjs
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const cryptoDirectory = join(repositoryRoot, "packages", "utils", "crypto");
+const npxCommand = process.platform === "win32" ? "npx.cmd" : "npx";
+
+const run = (command, args, options = {}) => {
+	const result = spawnSync(command, args, {
+		cwd: options.cwd ?? repositoryRoot,
+		encoding: "utf8",
+		env: {
+			...process.env,
+			FORCE_COLOR: "0",
+			NO_COLOR: "1",
+		},
+		timeout: options.timeout ?? 600_000,
+	});
+	assert.equal(
+		result.error,
+		undefined,
+		`${command} could not run: ${result.error?.message}`,
+	);
+	assert.equal(
+		result.status,
+		0,
+		[
+			`${command} ${args.join(" ")} exited with ${result.status}`,
+			result.stdout,
+			result.stderr,
+		].join("\n"),
+	);
+	return result;
+};
+
+const repositoryManifest = JSON.parse(
+	await readFile(join(repositoryRoot, "package.json"), "utf8"),
+);
+assert.equal(
+	repositoryManifest.engines?.node,
+	">=18",
+	"the isolated crypto smoke must track the repository's advertised Node floor",
+);
+const cryptoManifest = JSON.parse(
+	await readFile(join(cryptoDirectory, "package.json"), "utf8"),
+);
+const temporaryRoot = await mkdtemp(
+	join(tmpdir(), "peerbit-published-crypto-"),
+);
+const tarballDirectory = join(temporaryRoot, "tarball");
+const consumerDirectory = join(temporaryRoot, "consumer");
+
+try {
+	await mkdir(tarballDirectory);
+	await mkdir(consumerDirectory);
+	const packed = run("pnpm", [
+		"--dir",
+		cryptoDirectory,
+		"pack",
+		"--pack-destination",
+		tarballDirectory,
+		"--json",
+	]);
+	const packResult = JSON.parse(packed.stdout);
+	assert.equal(packResult.name, "@peerbit/crypto");
+	assert.equal(packResult.version, cryptoManifest.version);
+	const packedManifest = JSON.parse(
+		run("tar", ["-xOf", packResult.filename, "package/package.json"]).stdout,
+	);
+	for (const dependencyName of ["multiformats", "uint8arrays"]) {
+		const dependencyRange = cryptoManifest.dependencies?.[dependencyName];
+		assert.equal(
+			typeof dependencyRange,
+			"string",
+			`@peerbit/crypto must declare ${dependencyName} as a direct runtime dependency`,
+		);
+		assert.equal(
+			packedManifest.dependencies?.[dependencyName],
+			dependencyRange,
+			`the packed package must retain its direct ${dependencyName} runtime edge`,
+		);
+		assert.equal(
+			packedManifest.devDependencies?.[dependencyName],
+			undefined,
+			`the packed package must not duplicate ${dependencyName} in devDependencies`,
+		);
+	}
+	assert.equal(
+		packedManifest.dependencies?.["@peerbit/cache"],
+		undefined,
+		"the packed package must not retain the unused @peerbit/cache runtime edge",
+	);
+
+	const dependencies = {
+		"@peerbit/crypto": `file:${packResult.filename}`,
+	};
+	await writeFile(
+		join(consumerDirectory, "package.json"),
+		JSON.stringify(
+			{
+				name: "peerbit-published-crypto-isolated-consumer",
+				private: true,
+				type: "module",
+				dependencies,
+			},
+			null,
+			2,
+		) + "\n",
+	);
+	await writeFile(
+		join(consumerDirectory, "crypto-node18-smoke.mjs"),
+		await readFile(
+			join(
+				repositoryRoot,
+				"scripts",
+				"fixtures",
+				"published-crypto-node18-smoke.mjs",
+			),
+			"utf8",
+		),
+	);
+	run(
+		"npm",
+		[
+			"install",
+			"--install-strategy=nested",
+			"--no-audit",
+			"--no-fund",
+			"--loglevel=error",
+		],
+		{ cwd: consumerDirectory, timeout: 900_000 },
+	);
+	const lockfile = JSON.parse(
+		await readFile(join(consumerDirectory, "package-lock.json"), "utf8"),
+	);
+	assert.deepEqual(lockfile.packages[""].dependencies, dependencies);
+	for (const dependencyName of ["multiformats", "uint8arrays"]) {
+		assert(
+			lockfile.packages[
+				`node_modules/@peerbit/crypto/node_modules/${dependencyName}`
+			],
+			`nested install must place @peerbit/crypto's direct ${dependencyName} dependency below the package`,
+		);
+	}
+	const node18 = run(
+		npxCommand,
+		["--yes", "node@18", join(consumerDirectory, "crypto-node18-smoke.mjs")],
+		{ cwd: consumerDirectory, timeout: 300_000 },
+	);
+	assert.match(node18.stdout, /Node 18\./);
+	console.log(
+		"Packed @peerbit/crypto passed an isolated nested install and runtime import on Node 18.",
+	);
+} finally {
+	await rm(temporaryRoot, { recursive: true, force: true });
+}

--- a/scripts/test-published-security-smoke.mjs
+++ b/scripts/test-published-security-smoke.mjs
@@ -142,7 +142,27 @@ try {
 			"secure-dependency-lines.md",
 		),
 	});
-
+	const isolatedCryptoSmoke = run(
+		process.execPath,
+		[
+			join(
+				repositoryRoot,
+				"scripts",
+				"test-published-crypto-package-smoke.mjs",
+			),
+		],
+		{ status: 0, timeout: 1_200_000 },
+	);
+	assert.match(isolatedCryptoSmoke.stdout, /isolated nested install/);
+	const cryptoSmokeFixture = await readFile(
+		join(
+			repositoryRoot,
+			"scripts",
+			"fixtures",
+			"published-crypto-node18-smoke.mjs",
+		),
+		"utf8",
+	);
 	await writeFile(
 		join(consumerDirectory, "package.json"),
 		JSON.stringify(
@@ -197,15 +217,7 @@ try {
 	);
 	await writeFile(
 		join(consumerDirectory, "crypto-node18-smoke.mjs"),
-		await readFile(
-			join(
-				repositoryRoot,
-				"scripts",
-				"fixtures",
-				"published-crypto-node18-smoke.mjs",
-			),
-			"utf8",
-		),
+		cryptoSmokeFixture,
 	);
 
 	run("npm", ["install", "--no-audit", "--no-fund", "--loglevel=error"], {
@@ -306,7 +318,7 @@ try {
 	);
 	assert.match(node18.stdout, /Node 18\./);
 	console.log(
-		`Clean published-package consumer passed with ${packageDirectories.length} security roots and all ${publishablePackages.length} publishable workspace packages as exact local tarballs, zero production audit findings, esbuild ${esbuildVersions.join(", ")}, and the Node 18 crypto wire contract.`,
+		`Clean published-package consumer passed with ${packageDirectories.length} security roots and all ${publishablePackages.length} publishable workspace packages as exact local tarballs, zero production audit findings, esbuild ${esbuildVersions.join(", ")}, the isolated nested crypto install, and the Node 18 crypto wire contract.`,
 	);
 } finally {
 	await rm(temporaryRoot, { recursive: true, force: true });

--- a/scripts/test-release-security-contracts.mjs
+++ b/scripts/test-release-security-contracts.mjs
@@ -120,6 +120,17 @@ assert.doesNotMatch(
 	/expectedPublishedSecurityClosureNames|resolvePublishedSecurityClosure/,
 	"the consumer proof must not use a static forward closure",
 );
+assert.match(
+	publishedSecuritySmoke,
+	/test-published-crypto-package-smoke\.mjs/,
+	"the full published-package gate must include the isolated crypto package smoke",
+);
+const publishedCryptoPackageSmoke = await readRepositoryFile(
+	"scripts/test-published-crypto-package-smoke.mjs",
+);
+assert.match(publishedCryptoPackageSmoke, /--install-strategy=nested/);
+assert.match(publishedCryptoPackageSmoke, /node@18/);
+assert.match(publishedCryptoPackageSmoke, /"multiformats", "uint8arrays"/);
 const publicPackagePublisher = await readRepositoryFile(
 	"scripts/publish-public-packages.mjs",
 );


### PR DESCRIPTION
## Summary

- declare `multiformats` and `uint8arrays` as direct runtime dependencies of `@peerbit/crypto`
- remove the unused `@peerbit/cache` runtime edge
- add an isolated nested-install tarball import and Node 18 wire-contract smoke to the release security gate

## Why

A clean nested install of `@peerbit/media-streaming` exposed that published `@peerbit/crypto@3.1.3` imports `multiformats` and `uint8arrays` at runtime without owning either dependency. Workspace/npm hoisting masked the defect.

## Verification

- full workspace build
- complete release security gate
- crypto Node/browser/webworker tests (29/29 each)
- isolated packed nested install/import on Node 18
- runtime dependency audit and release-contract checks
- Prettier and `git diff --check`

Independently reviewed with no P0-P2 findings.