### PR TITLE
fix(react): own program hook lifecycle sessions

### DIFF
--- a/.changeset/steady-program-react-sessions.md
+++ b/.changeset/steady-program-react-sessions.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/program-react": patch
+---
+
+Keep `useProgram` opens, listeners, and cleanup owned by their React effect session. Address-bearing object targets remain equivalent by address, while inline targets without an address retain the legacy shared request identity and can opt into intentional replacement with `id`. Stale client or lifecycle-policy requests cannot publish a program, synchronous setup failures no longer strand opened programs, and transient close failures are retried before replacement opens.

--- a/packages/programs/program/react/src/useProgram.tsx
+++ b/packages/programs/program/react/src/useProgram.tsx
@@ -1,17 +1,7 @@
-import type { Identity } from "@peerbit/crypto";
-import { PublicSignKey } from "@peerbit/crypto";
+import type { Identity, PublicSignKey } from "@peerbit/crypto";
 import type { OpenOptions, Program, ProgramEvents } from "@peerbit/program";
 import { useEffect, useReducer, useRef, useState } from "react";
 
-const addressOrDefined = <A, B extends ProgramEvents, P extends Program<A, B>>(
-	p?: P,
-) => {
-	try {
-		return p?.address;
-	} catch (error) {
-		return !!p;
-	}
-};
 type ExtractArgs<T> = T extends Program<infer Args> ? Args : never;
 type ExtractEvents<T> = T extends Program<any, infer Events> ? Events : never;
 
@@ -25,6 +15,54 @@ export type ProgramClientLike = {
 
 export type UseProgramStatus = "idle" | "loading" | "ready" | "error";
 
+const UNSAVED_TARGET_KEY = Object.freeze({});
+
+type ProgramRequest<P> = {
+	peer: ProgramClientLike;
+	target: P | string;
+	targetKey: string | object;
+	id: string | undefined;
+	keepOpenOnUnmount: boolean;
+};
+
+const isSameRequest = <P,>(
+	left: ProgramRequest<P> | undefined,
+	right: ProgramRequest<P> | undefined,
+) =>
+	left === right ||
+	(!!left &&
+		!!right &&
+		left.peer === right.peer &&
+		left.targetKey === right.targetKey &&
+		left.id === right.id &&
+		left.keepOpenOnUnmount === right.keepOpenOnUnmount);
+
+type ProgramView<P> = {
+	request: ProgramRequest<P>;
+	program?: P;
+	loading: boolean;
+	error?: Error;
+	peers: PublicSignKey[];
+};
+
+type ProgramSession<P> = {
+	generation: number;
+	request: ProgramRequest<P>;
+	active: boolean;
+	keepOpenOnUnmount: boolean;
+	openPromise: Promise<P | undefined>;
+	program?: P;
+	unsubscribe?: () => void;
+	cleanupComplete: boolean;
+	cleanupPromise?: Promise<void>;
+};
+
+type ProgramLoading<P> = {
+	request: ProgramRequest<P>;
+	owner: ProgramSession<P>;
+	promise: Promise<P | undefined>;
+};
+
 export function useProgram<
 	P extends Program<ExtractArgs<P>, ExtractEvents<P>> &
 		Program<any, ProgramEvents>,
@@ -36,160 +74,372 @@ export function useProgram<
 		keepOpenOnUnmount?: boolean;
 	},
 ) {
-	const [program, setProgram] = useState<P | undefined>();
-	const [id, setId] = useState<string | undefined>(options?.id);
-	const [loading, setLoading] = useState(false);
-	const [error, setError] = useState<Error | undefined>(undefined);
-	const [session, forceUpdate] = useReducer((x) => x + 1, 0);
-	const programLoadingRef = useRef<Promise<P | undefined> | undefined>(
-		undefined,
+	const keepOpenOnUnmount = options?.keepOpenOnUnmount === true;
+	const objectTargetKeysRef = useRef<WeakMap<object, string | object>>(
+		new WeakMap(),
 	);
-	const [peers, setPeers] = useState<PublicSignKey[]>([]);
+	// Preserve address equivalence for already-addressed programs, but pin the
+	// shared legacy unsaved key so inline constructors remain stable. options.id
+	// is the explicit generation key when callers intentionally swap unsaved targets.
+	const targetKey = (() => {
+		if (typeof addressOrOpen === "string") return addressOrOpen;
+		if (!addressOrOpen) return undefined;
+		const cached = objectTargetKeysRef.current.get(addressOrOpen);
+		if (cached !== undefined) return cached;
 
-	const closingRef = useRef<Promise<any>>(Promise.resolve());
-	/*   if (options?.debug) {
-          console.log("useProgram", addressOrOpen, options);
-      } */
+		let key: string | object = UNSAVED_TARGET_KEY;
+		try {
+			const address = addressOrOpen.address;
+			if (address) {
+				key = address;
+			}
+		} catch {}
+		objectTargetKeysRef.current.set(addressOrOpen, key);
+		return key;
+	})();
+	const currentRequest: ProgramRequest<P> | undefined =
+		peer && addressOrOpen && targetKey
+			? {
+					peer,
+					target: addressOrOpen,
+					targetKey,
+					id: options?.id,
+					keepOpenOnUnmount,
+				}
+			: undefined;
+	const [view, setView] = useState<ProgramView<P> | undefined>();
+	const [resolvedId, setResolvedId] = useState<
+		{ request: ProgramRequest<P>; value: string | undefined } | undefined
+	>();
+	const [session, forceUpdate] = useReducer((x) => x + 1, 0);
+	const programLoadingRef = useRef<ProgramLoading<P> | undefined>(undefined);
+	const currentSessionRef = useRef<ProgramSession<P> | undefined>(undefined);
+	const generationRef = useRef(0);
+	const lifecycleTailRef = useRef<Promise<void>>(Promise.resolve());
+	const cleanupDebtRef = useRef<ProgramSession<P>[]>([]);
+
+	const isCurrentSession = (candidate: ProgramSession<P>) =>
+		candidate.active &&
+		currentSessionRef.current === candidate &&
+		generationRef.current === candidate.generation;
+
+	const detachListener = (candidate: ProgramSession<P>) => {
+		const unsubscribe = candidate.unsubscribe;
+		candidate.unsubscribe = undefined;
+		try {
+			unsubscribe?.();
+		} catch (error) {
+			console.error("failed to remove program listeners", error);
+		}
+	};
+
+	const removeCleanupDebt = (candidate: ProgramSession<P>) => {
+		const index = cleanupDebtRef.current.indexOf(candidate);
+		if (index >= 0) {
+			cleanupDebtRef.current.splice(index, 1);
+		}
+	};
+
+	const attemptCleanup = (candidate: ProgramSession<P>): Promise<void> => {
+		if (candidate.cleanupComplete) {
+			return Promise.resolve();
+		}
+		if (candidate.cleanupPromise) {
+			return candidate.cleanupPromise;
+		}
+
+		const attempt = (async () => {
+			await candidate.openPromise.catch(() => undefined);
+			detachListener(candidate);
+			if (candidate.program && !candidate.keepOpenOnUnmount) {
+				await candidate.program.close();
+			}
+			candidate.cleanupComplete = true;
+			removeCleanupDebt(candidate);
+		})();
+		const tracked = attempt.catch((error: unknown) => {
+			candidate.cleanupPromise = undefined;
+			throw error;
+		});
+		candidate.cleanupPromise = tracked;
+		return tracked;
+	};
+
+	const cleanupWithRetry = async (
+		candidate: ProgramSession<P>,
+		attempts = 2,
+	) => {
+		let lastError: unknown;
+		for (let attempt = 0; attempt < attempts; attempt += 1) {
+			try {
+				await attemptCleanup(candidate);
+				return;
+			} catch (error) {
+				lastError = error;
+			}
+		}
+		throw lastError;
+	};
+
+	const drainCleanupDebt = async (current: ProgramSession<P>) => {
+		for (const candidate of [...cleanupDebtRef.current]) {
+			if (candidate !== current) {
+				await cleanupWithRetry(candidate);
+			}
+		}
+	};
+
 	useEffect(() => {
-		if (!peer || !addressOrOpen) {
-			setLoading(false);
-			setError(undefined);
-			setPeers([]);
-			setProgram(undefined);
+		if (!peer || !addressOrOpen || !targetKey) {
+			setView(undefined);
+			setResolvedId(undefined);
 			programLoadingRef.current = undefined;
 			return;
 		}
-		setError(undefined);
-		setLoading(true);
-		let changeListener: (() => void) | undefined = undefined;
 
-		closingRef.current.then(() => {
-			programLoadingRef.current = peer
-				?.open(addressOrOpen as P | string, {
+		const request: ProgramRequest<P> = {
+			peer,
+			target: addressOrOpen,
+			targetKey,
+			id: options?.id,
+			keepOpenOnUnmount,
+		};
+		const generation = ++generationRef.current;
+		const candidate: ProgramSession<P> = {
+			generation,
+			request,
+			active: true,
+			keepOpenOnUnmount: request.keepOpenOnUnmount,
+			openPromise: undefined as unknown as Promise<P | undefined>,
+			cleanupComplete: false,
+		};
+		currentSessionRef.current = candidate;
+		setView({ request, loading: true, peers: [] });
+		setResolvedId(undefined);
+
+		const predecessor = lifecycleTailRef.current;
+		const openPromise = (async (): Promise<P | undefined> => {
+			await predecessor;
+			if (!candidate.active) {
+				return undefined;
+			}
+
+			try {
+				await drainCleanupDebt(candidate);
+			} catch (error) {
+				if (isCurrentSession(candidate)) {
+					const resolvedError =
+						error instanceof Error ? error : new Error(String(error));
+					console.error(
+						"failed to clean up the previous program",
+						resolvedError,
+					);
+					setView({
+						request,
+						loading: false,
+						error: resolvedError,
+						peers: [],
+					});
+					forceUpdate();
+				}
+				return undefined;
+			}
+			if (!candidate.active) {
+				return undefined;
+			}
+
+			let program: P;
+			try {
+				program = await peer.open(addressOrOpen as P | string, {
 					...options,
 					existing: "reuse",
-				})
-				.then((p: P) => {
-					const subPrograms = (() => {
-						try {
-							const candidate = (p as any)?.allPrograms;
-							if (Array.isArray(candidate)) return candidate;
-							if (
-								candidate &&
-								typeof candidate === "object" &&
-								typeof (candidate as any)[Symbol.iterator] === "function"
-							) {
-								return [...candidate];
-							}
-						} catch {}
-						return [];
-					})();
-
-					const hasTopics =
-						[p, ...subPrograms].filter(
-							(x: any) =>
-								x?.closed === false &&
-								typeof x?.getTopics === "function" &&
-								x.getTopics?.().length > 0,
-						).length > 0;
-
-					// If program has no topics (or isn't a full Program instance), we can
-					// still use it; just default to "self" as the only known peer.
-					if (!hasTopics || typeof (p as any)?.getReady !== "function") {
-						setPeers([peer.identity.publicKey]);
-					} else {
-						changeListener = () => {
-							p.getReady().then((ready: Map<string, PublicSignKey>) => {
-								setPeers([...ready.values()]);
-							});
-						};
-						p.events.addEventListener("join", changeListener);
-						p.events.addEventListener("leave", changeListener);
-						p.getReady()
-							.then((ready: Map<string, PublicSignKey>) => {
-								setPeers([...ready.values()]);
-							})
-							.catch((e: any) => {
-								console.log("Error getReady()", e);
-							});
-					}
-
-					setProgram(p);
-					forceUpdate();
-					if (options?.id) {
-						setId(p.address);
-					}
-					return p;
-				})
-				.catch((e: unknown) => {
-					const err = e instanceof Error ? e : new Error(String(e));
-					console.error("failed to open", err);
-					setProgram(undefined);
-					setPeers([]);
-					setError(err);
-					forceUpdate();
-					return undefined;
-				})
-				.finally(() => {
-					setLoading(false);
 				});
-		});
-
-		// TODO AbortController?
-		return () => {
-			let startRef = programLoadingRef.current;
-
-			// TODO don't close on reopen the same db?
-			if (programLoadingRef.current) {
-				closingRef.current =
-					programLoadingRef.current.then((p) => {
-						if (!p) return;
-						const unsubscribe = () => {
-							changeListener &&
-								p.events.removeEventListener("join", changeListener);
-							changeListener &&
-								p.events.removeEventListener("leave", changeListener);
-						};
-
-						if (programLoadingRef.current === startRef) {
-							setProgram(undefined);
-							programLoadingRef.current = undefined as any;
-						}
-
-						if (options?.keepOpenOnUnmount) {
-							unsubscribe();
-							return; // nothing to close
-						}
-
-						return p.close().then(unsubscribe);
-					}) || Promise.resolve();
+				candidate.program = program;
+			} catch (error) {
+				if (isCurrentSession(candidate)) {
+					const resolvedError =
+						error instanceof Error ? error : new Error(String(error));
+					console.error("failed to open", resolvedError);
+					setView({
+						request,
+						loading: false,
+						error: resolvedError,
+						peers: [],
+					});
+					forceUpdate();
+				}
+				return undefined;
 			}
+
+			if (!isCurrentSession(candidate)) {
+				return program;
+			}
+
+			const subPrograms = (() => {
+				try {
+					const nested = (program as any)?.allPrograms;
+					if (Array.isArray(nested)) return nested;
+					if (
+						nested &&
+						typeof nested === "object" &&
+						typeof (nested as any)[Symbol.iterator] === "function"
+					) {
+						return [...nested];
+					}
+				} catch {}
+				return [];
+			})();
+
+			const hasTopics = [program, ...subPrograms].some((nested: any) => {
+				try {
+					return (
+						nested?.closed === false &&
+						typeof nested?.getTopics === "function" &&
+						nested.getTopics().length > 0
+					);
+				} catch {
+					return false;
+				}
+			});
+
+			let peers: PublicSignKey[] = [];
+			if (!hasTopics || typeof (program as any)?.getReady !== "function") {
+				peers = [peer.identity.publicKey];
+			} else {
+				const updatePeers = () => {
+					Promise.resolve()
+						.then(() => program.getReady())
+						.then((ready: Map<string, PublicSignKey>) => {
+							if (!isCurrentSession(candidate)) return;
+							setView((current) =>
+								isSameRequest(current?.request, request)
+									? { ...current!, peers: [...ready.values()] }
+									: current,
+							);
+						})
+						.catch((error: unknown) => {
+							if (isCurrentSession(candidate)) {
+								console.log("Error getReady()", error);
+							}
+						});
+				};
+				const changeListener = () => updatePeers();
+				const events = program.events;
+				let joinAttached = false;
+				let leaveAttached = false;
+				candidate.unsubscribe = () => {
+					if (joinAttached) {
+						events.removeEventListener("join", changeListener);
+						joinAttached = false;
+					}
+					if (leaveAttached) {
+						events.removeEventListener("leave", changeListener);
+						leaveAttached = false;
+					}
+				};
+				events.addEventListener("join", changeListener);
+				joinAttached = true;
+				events.addEventListener("leave", changeListener);
+				leaveAttached = true;
+				updatePeers();
+			}
+
+			if (!isCurrentSession(candidate)) {
+				detachListener(candidate);
+				return program;
+			}
+
+			setView({ request, program, loading: false, peers });
+			forceUpdate();
+			if (request.id) {
+				let value: string | undefined = request.id;
+				try {
+					value = program.address;
+				} catch {}
+				setResolvedId({ request, value });
+			}
+			return program;
+		})().catch((error: unknown) => {
+			detachListener(candidate);
+			if (isCurrentSession(candidate)) {
+				const resolvedError =
+					error instanceof Error ? error : new Error(String(error));
+				console.error("failed to initialize the opened program", resolvedError);
+				setView({
+					request,
+					loading: false,
+					error: resolvedError,
+					peers: [],
+				});
+				forceUpdate();
+			}
+			return undefined;
+		});
+		candidate.openPromise = openPromise;
+		programLoadingRef.current = {
+			request,
+			owner: candidate,
+			promise: openPromise,
 		};
-	}, [
-		peer?.identity.publicKey.hashcode(),
-		options?.id,
-		typeof addressOrOpen === "string"
-			? addressOrOpen
-			: addressOrDefined(addressOrOpen as P),
-	]);
-	const status: UseProgramStatus =
-		!peer || !addressOrOpen
-			? "idle"
-			: loading
-				? "loading"
-				: error
-					? "error"
-					: program
-						? "ready"
-						: "idle";
+
+		return () => {
+			candidate.active = false;
+			detachListener(candidate);
+			if (currentSessionRef.current === candidate) {
+				currentSessionRef.current = undefined;
+			}
+			if (programLoadingRef.current?.owner === candidate) {
+				programLoadingRef.current = undefined;
+			}
+			if (
+				!candidate.keepOpenOnUnmount &&
+				!cleanupDebtRef.current.includes(candidate)
+			) {
+				cleanupDebtRef.current.push(candidate);
+			}
+
+			const cleanup = lifecycleTailRef.current
+				.catch(() => undefined)
+				.then(() => cleanupWithRetry(candidate));
+			lifecycleTailRef.current = cleanup.catch((error: unknown) => {
+				console.error("failed to close program", error);
+			});
+		};
+	}, [peer, targetKey, options?.id, keepOpenOnUnmount]);
+
+	const currentView = isSameRequest(view?.request, currentRequest)
+		? view
+		: undefined;
+	const currentLoading = isSameRequest(
+		programLoadingRef.current?.request,
+		currentRequest,
+	)
+		? programLoadingRef.current
+		: undefined;
+	const currentId = isSameRequest(resolvedId?.request, currentRequest)
+		? resolvedId?.value
+		: options?.id;
+	const program = currentView?.program;
+	const loading = currentView?.loading ?? false;
+	const error = currentView?.error;
+	const status: UseProgramStatus = !currentRequest
+		? "idle"
+		: loading
+			? "loading"
+			: error
+				? "error"
+				: program
+					? "ready"
+					: "idle";
+
 	return {
 		program,
 		session,
 		loading,
 		status,
 		error,
-		promise: programLoadingRef.current,
-		peers,
-		id,
+		promise: currentLoading?.promise,
+		peers: currentView?.peers ?? [],
+		id: currentId,
 	};
 }

--- a/packages/programs/program/react/vitest/useProgram.dom.test.tsx
+++ b/packages/programs/program/react/vitest/useProgram.dom.test.tsx
@@ -1,26 +1,107 @@
-import { render, waitFor } from "@testing-library/react";
-import React from "react";
-import { describe, expect, it } from "vitest";
+import { act, render, waitFor } from "@testing-library/react";
+import React, { StrictMode } from "react";
+import { describe, expect, it, vi } from "vitest";
 import { useProgram } from "../src/useProgram.js";
 
+class CountingEventTarget extends EventTarget {
+	readonly added = new Map<string, number>();
+	readonly removed = new Map<string, number>();
+	readonly listeners = new Map<
+		string,
+		Set<EventListenerOrEventListenerObject>
+	>();
+
+	addEventListener(
+		type: string,
+		callback: EventListenerOrEventListenerObject | null,
+		options?: AddEventListenerOptions | boolean,
+	) {
+		if (callback) {
+			this.added.set(type, (this.added.get(type) ?? 0) + 1);
+			const listeners = this.listeners.get(type) ?? new Set();
+			listeners.add(callback);
+			this.listeners.set(type, listeners);
+		}
+		super.addEventListener(type, callback, options);
+	}
+
+	removeEventListener(
+		type: string,
+		callback: EventListenerOrEventListenerObject | null,
+		options?: EventListenerOptions | boolean,
+	) {
+		if (callback) {
+			this.removed.set(type, (this.removed.get(type) ?? 0) + 1);
+			this.listeners.get(type)?.delete(callback);
+		}
+		super.removeEventListener(type, callback, options);
+	}
+
+	listenerCount(type: string) {
+		return this.listeners.get(type)?.size ?? 0;
+	}
+}
+
+class ThrowingEventTarget extends CountingEventTarget {
+	addEventListener(
+		type: string,
+		callback: EventListenerOrEventListenerObject | null,
+		options?: AddEventListenerOptions | boolean,
+	) {
+		if (type === "leave") {
+			throw new Error("listener setup failed");
+		}
+		super.addEventListener(type, callback, options);
+	}
+}
+
 class FakeProgram {
-	address: string;
+	private _address?: string;
 	closed = false;
 	allPrograms: any[] = [];
-	events = new EventTarget();
-	constructor(address: string) {
-		this.address = address;
+	events = new CountingEventTarget();
+	closeCalls = 0;
+	closeFailures = 0;
+	readonly topics: string[];
+
+	constructor(address?: string, topics: string[] = []) {
+		this._address = address;
+		this.topics = topics;
+	}
+	get address() {
+		if (!this._address) {
+			throw new Error("address is not available until open");
+		}
+		return this._address;
+	}
+	set address(address: string) {
+		this._address = address;
 	}
 	getTopics() {
-		return [];
+		return this.topics;
 	}
 	async getReady() {
 		return new Map();
 	}
 	async close() {
+		this.closeCalls += 1;
+		if (this.closeFailures > 0) {
+			this.closeFailures -= 1;
+			throw new Error("close failed");
+		}
 		this.closed = true;
 	}
 }
+
+const deferred = <T,>() => {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+};
 
 describe("useProgram hook", () => {
 	it("opens program via peer context and exposes peers list", async () => {
@@ -44,6 +125,94 @@ describe("useProgram hook", () => {
 		expect(latest?.loading).toBe(false);
 		expect(latest?.status).toBe("ready");
 		expect(latest?.error).toBeUndefined();
+	});
+
+	it("keeps fresh address-equivalent object targets on the same request", async () => {
+		const renderedTargets: FakeProgram[] = [];
+		const fakePeer = {
+			identity: { publicKey: { hashcode: () => "peer-1" } },
+			open: vi.fn(async (target: FakeProgram) => target),
+		};
+
+		let latest: ReturnType<typeof useProgram<any>> | undefined;
+		const Wrapper = () => {
+			const target = new FakeProgram("shared-address");
+			renderedTargets.push(target);
+			latest = useProgram(fakePeer as any, target as any);
+			return null;
+		};
+		const view = render(<Wrapper />);
+		await waitFor(() => expect(latest?.program).toBeDefined());
+		const opened = latest!.program as FakeProgram;
+
+		view.rerender(<Wrapper />);
+		await act(async () => {
+			for (let i = 0; i < 5; i += 1) await Promise.resolve();
+		});
+
+		expect(renderedTargets.length).toBeGreaterThan(1);
+		expect(fakePeer.open).toHaveBeenCalledTimes(1);
+		expect(latest?.program).toBe(opened);
+		expect(opened.closeCalls).toBe(0);
+	});
+
+	it("keeps fresh inline unsaved targets on the legacy shared request", async () => {
+		const renderedTargets: FakeProgram[] = [];
+		const fakePeer = {
+			identity: { publicKey: { hashcode: () => "peer-1" } },
+			open: vi.fn(async (target: FakeProgram) => {
+				target.address = "assigned-during-open";
+				return target;
+			}),
+		};
+
+		let latest: ReturnType<typeof useProgram<any>> | undefined;
+		const Wrapper = () => {
+			const target = new FakeProgram();
+			renderedTargets.push(target);
+			latest = useProgram(fakePeer as any, target as any);
+			return null;
+		};
+		const view = render(<Wrapper />);
+		await waitFor(() => expect(latest?.program).toBeDefined());
+		const opened = latest!.program as FakeProgram;
+
+		view.rerender(<Wrapper />);
+		await act(async () => {
+			for (let i = 0; i < 5; i += 1) await Promise.resolve();
+		});
+
+		expect(renderedTargets.length).toBeGreaterThan(1);
+		expect(fakePeer.open).toHaveBeenCalledTimes(1);
+		expect(latest?.program).toBe(opened);
+		expect(opened.closeCalls).toBe(0);
+	});
+
+	it("keeps an unsaved object target on its identity after open assigns its address", async () => {
+		const target = new FakeProgram();
+		const fakePeer = {
+			identity: { publicKey: { hashcode: () => "peer-1" } },
+			open: vi.fn(async (program: FakeProgram) => {
+				program.address = "assigned-during-open";
+				return program;
+			}),
+		};
+
+		let latest: ReturnType<typeof useProgram<any>> | undefined;
+		const Wrapper = () => {
+			latest = useProgram(fakePeer as any, target as any);
+			return null;
+		};
+		const view = render(<Wrapper />);
+		await waitFor(() => expect(latest?.program).toBe(target));
+
+		view.rerender(<Wrapper />);
+		await act(async () => {
+			for (let i = 0; i < 5; i += 1) await Promise.resolve();
+		});
+
+		expect(fakePeer.open).toHaveBeenCalledTimes(1);
+		expect(target.closeCalls).toBe(0);
 	});
 
 	it("is idle (not loading) when peer is missing", async () => {
@@ -80,5 +249,358 @@ describe("useProgram hook", () => {
 		expect(latest?.loading).toBe(false);
 		expect(latest?.program).toBeUndefined();
 		expect(latest?.error?.message).toBe("open failed");
+	});
+
+	it("contains a synchronous getReady failure and still cleans up before replacement", async () => {
+		const first = new FakeProgram("first", ["topic"]);
+		first.getReady = () => {
+			throw new Error("getReady failed synchronously");
+		};
+		const second = new FakeProgram("second");
+		const fakePeer = {
+			identity: { publicKey: { hashcode: () => "peer-1" } },
+			open: vi.fn(async (target: FakeProgram) => target),
+		};
+		const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		try {
+			let target = first;
+			let latest: ReturnType<typeof useProgram<any>> | undefined;
+			const Wrapper = () => {
+				latest = useProgram(fakePeer as any, target as any);
+				return null;
+			};
+			const view = render(<Wrapper />);
+			await waitFor(() => expect(latest?.program).toBe(first));
+			await waitFor(() => expect(consoleLog).toHaveBeenCalledTimes(1));
+
+			target = second;
+			view.rerender(<Wrapper />);
+			await waitFor(() => expect(first.closeCalls).toBe(1));
+			await waitFor(() => expect(latest?.program).toBe(second));
+
+			expect(first.events.listenerCount("join")).toBe(0);
+			expect(first.events.listenerCount("leave")).toBe(0);
+			expect(fakePeer.open).toHaveBeenCalledTimes(2);
+		} finally {
+			consoleLog.mockRestore();
+		}
+	});
+
+	it("settles an unexpected post-open setup exception so cleanup cannot block replacements", async () => {
+		const first = new FakeProgram("first", ["topic"]);
+		first.events = new ThrowingEventTarget();
+		const second = new FakeProgram("second");
+		const fakePeer = {
+			identity: { publicKey: { hashcode: () => "peer-1" } },
+			open: vi.fn(async (target: FakeProgram) => target),
+		};
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+
+		try {
+			let target = first;
+			let latest: ReturnType<typeof useProgram<any>> | undefined;
+			const Wrapper = () => {
+				latest = useProgram(fakePeer as any, target as any);
+				return null;
+			};
+			const view = render(<Wrapper />);
+			await waitFor(() => expect(latest?.status).toBe("error"));
+			expect(latest?.error?.message).toBe("listener setup failed");
+			const publicPromise = latest?.promise;
+			expect(publicPromise).toBeDefined();
+			await expect(publicPromise).resolves.toBeUndefined();
+
+			target = second;
+			view.rerender(<Wrapper />);
+			await waitFor(() => expect(first.closeCalls).toBe(1));
+			await waitFor(() => expect(latest?.program).toBe(second));
+
+			expect(first.events.listenerCount("join")).toBe(0);
+			expect(fakePeer.open).toHaveBeenCalledTimes(2);
+		} finally {
+			consoleError.mockRestore();
+		}
+	});
+
+	it("keeps StrictMode opens owned across target changes and pending unmount cleanup", async () => {
+		const first = new FakeProgram(undefined, ["topic"]);
+		const second = new FakeProgram(undefined, ["topic"]);
+		const third = new FakeProgram(undefined, ["topic"]);
+		const gates = new Map([
+			[first, deferred<FakeProgram>()],
+			[second, deferred<FakeProgram>()],
+			[third, deferred<FakeProgram>()],
+		]);
+		const fakePeer = {
+			identity: { publicKey: { hashcode: () => "peer-1" } },
+			open: vi.fn(async (target: FakeProgram) => {
+				const opened = await gates.get(target)!.promise;
+				target.address =
+					target === first ? "first" : target === second ? "second" : "third";
+				return opened;
+			}),
+		};
+
+		let latest: ReturnType<typeof useProgram<any>> | undefined;
+		let target = first;
+		let requestId = "first";
+		const Wrapper = () => {
+			latest = useProgram(fakePeer as any, target as any, { id: requestId });
+			return null;
+		};
+		const view = render(
+			<StrictMode>
+				<Wrapper />
+			</StrictMode>,
+		);
+
+		await waitFor(() => expect(fakePeer.open).toHaveBeenCalledTimes(1));
+		expect(latest?.session).toBe(0);
+
+		target = second;
+		requestId = "second";
+		view.rerender(
+			<StrictMode>
+				<Wrapper />
+			</StrictMode>,
+		);
+		expect(latest?.program).toBeUndefined();
+
+		await act(async () => gates.get(first)!.resolve(first));
+		await waitFor(() => expect(first.closeCalls).toBe(1));
+		await waitFor(() => expect(fakePeer.open).toHaveBeenCalledTimes(2));
+		expect(first.events.added.size).toBe(0);
+		expect(latest?.session).toBe(0);
+
+		await act(async () => gates.get(second)!.resolve(second));
+		await waitFor(() => expect(latest?.program).toBe(second));
+		expect(latest?.session).toBe(1);
+		expect(second.events.listenerCount("join")).toBe(1);
+		expect(second.events.listenerCount("leave")).toBe(1);
+
+		// Assigning the address during open must not turn the same object target into
+		// a new request and cause a redundant close/reopen cycle.
+		view.rerender(
+			<StrictMode>
+				<Wrapper />
+			</StrictMode>,
+		);
+		await Promise.resolve();
+		expect(fakePeer.open).toHaveBeenCalledTimes(2);
+		expect(second.closeCalls).toBe(0);
+
+		target = third;
+		requestId = "third";
+		view.rerender(
+			<StrictMode>
+				<Wrapper />
+			</StrictMode>,
+		);
+		expect(latest?.program).toBeUndefined();
+		await waitFor(() => expect(second.closeCalls).toBe(1));
+		await waitFor(() => expect(fakePeer.open).toHaveBeenCalledTimes(3));
+		expect(second.events.listenerCount("join")).toBe(0);
+		expect(second.events.listenerCount("leave")).toBe(0);
+
+		view.unmount();
+		await act(async () => gates.get(third)!.resolve(third));
+		await waitFor(() => expect(third.closeCalls).toBe(1));
+		expect(fakePeer.open).toHaveBeenCalledTimes(3);
+		expect(third.events.added.size).toBe(0);
+		expect(second.events.added.get("join")).toBe(1);
+		expect(second.events.added.get("leave")).toBe(1);
+		expect(second.events.removed.get("join")).toBe(1);
+		expect(second.events.removed.get("leave")).toBe(1);
+		expect(latest?.session).toBe(1);
+	});
+
+	it("ignores a stale open rejection after the committed request changes", async () => {
+		const first = new FakeProgram("first");
+		const second = new FakeProgram("second");
+		const firstGate = deferred<FakeProgram>();
+		const fakePeer = {
+			identity: { publicKey: { hashcode: () => "peer-1" } },
+			open: vi.fn((target: FakeProgram) =>
+				target === first ? firstGate.promise : Promise.resolve(second),
+			),
+		};
+
+		let target = first;
+		let latest: ReturnType<typeof useProgram<any>> | undefined;
+		const Wrapper = () => {
+			latest = useProgram(fakePeer as any, target as any);
+			return null;
+		};
+		const view = render(<Wrapper />);
+		await waitFor(() => expect(fakePeer.open).toHaveBeenCalledTimes(1));
+
+		target = second;
+		view.rerender(<Wrapper />);
+		await act(async () => firstGate.reject(new Error("stale open failed")));
+		await waitFor(() => expect(latest?.program).toBe(second));
+
+		expect(fakePeer.open).toHaveBeenCalledTimes(2);
+		expect(latest?.error).toBeUndefined();
+		expect(latest?.status).toBe("ready");
+		expect(latest?.session).toBe(1);
+	});
+
+	it("does not expose a stale program while an equal-identity peer reopens the same target", async () => {
+		const target = new FakeProgram("target");
+		const firstProgram = new FakeProgram("target");
+		const secondProgram = new FakeProgram("target");
+		const secondGate = deferred<FakeProgram>();
+		const publicKey = { hashcode: () => "same-peer-identity" };
+		const firstPeer = {
+			identity: { publicKey },
+			open: vi.fn(async () => firstProgram),
+		};
+		const secondPeer = {
+			identity: { publicKey },
+			open: vi.fn(async () => secondGate.promise),
+		};
+
+		let peer = firstPeer;
+		let latest: ReturnType<typeof useProgram<any>> | undefined;
+		const Wrapper = () => {
+			latest = useProgram(peer as any, target as any);
+			return null;
+		};
+		const view = render(<Wrapper />);
+
+		await waitFor(() => expect(latest?.program).toBe(firstProgram));
+		expect(latest?.session).toBe(1);
+
+		peer = secondPeer;
+		view.rerender(<Wrapper />);
+		expect(latest?.program).toBeUndefined();
+		await waitFor(() => expect(firstProgram.closeCalls).toBe(1));
+		await waitFor(() => expect(secondPeer.open).toHaveBeenCalledTimes(1));
+		expect(latest?.session).toBe(1);
+
+		await act(async () => secondGate.resolve(secondProgram));
+		await waitFor(() => expect(latest?.program).toBe(secondProgram));
+		expect(latest?.session).toBe(2);
+	});
+
+	it("preserves explicit same-target reopen requests", async () => {
+		const target = new FakeProgram("target");
+		const firstProgram = new FakeProgram("target");
+		const secondProgram = new FakeProgram("target");
+		const fakePeer = {
+			identity: { publicKey: { hashcode: () => "peer-1" } },
+			open: vi
+				.fn()
+				.mockResolvedValueOnce(firstProgram)
+				.mockResolvedValueOnce(secondProgram),
+		};
+
+		let id = "first-request";
+		let latest: ReturnType<typeof useProgram<any>> | undefined;
+		const Wrapper = () => {
+			latest = useProgram(fakePeer as any, target as any, { id });
+			return null;
+		};
+		const view = render(<Wrapper />);
+		await waitFor(() => expect(latest?.program).toBe(firstProgram));
+
+		id = "second-request";
+		view.rerender(<Wrapper />);
+		expect(latest?.program).toBeUndefined();
+		await waitFor(() => expect(firstProgram.closeCalls).toBe(1));
+		await waitFor(() => expect(latest?.program).toBe(secondProgram));
+
+		expect(fakePeer.open).toHaveBeenCalledTimes(2);
+		expect(latest?.session).toBe(2);
+	});
+
+	it("retries transient close cleanup before opening the replacement", async () => {
+		const first = new FakeProgram("first");
+		first.closeFailures = 1;
+		const second = new FakeProgram("second");
+		const fakePeer = {
+			identity: { publicKey: { hashcode: () => "peer-1" } },
+			open: vi.fn(async (target: FakeProgram) => target),
+		};
+
+		let target = first;
+		let latest: ReturnType<typeof useProgram<any>> | undefined;
+		const Wrapper = () => {
+			latest = useProgram(fakePeer as any, target as any);
+			return null;
+		};
+		const view = render(<Wrapper />);
+		await waitFor(() => expect(latest?.program).toBe(first));
+
+		target = second;
+		view.rerender(<Wrapper />);
+		await waitFor(() => expect(first.closeCalls).toBe(2));
+		await waitFor(() => expect(latest?.program).toBe(second));
+		expect(fakePeer.open).toHaveBeenCalledTimes(2);
+	});
+
+	it("hides the prior session immediately when keepOpenOnUnmount changes", async () => {
+		const target = new FakeProgram("target");
+		const firstProgram = new FakeProgram("target");
+		const secondProgram = new FakeProgram("target");
+		const fakePeer = {
+			identity: { publicKey: { hashcode: () => "peer-1" } },
+			open: vi
+				.fn()
+				.mockResolvedValueOnce(firstProgram)
+				.mockResolvedValueOnce(secondProgram),
+		};
+
+		let keepOpenOnUnmount = false;
+		let latest: ReturnType<typeof useProgram<any>> | undefined;
+		const Wrapper = () => {
+			latest = useProgram(fakePeer as any, target as any, {
+				keepOpenOnUnmount,
+			});
+			return null;
+		};
+		const view = render(<Wrapper />);
+		await waitFor(() => expect(latest?.program).toBe(firstProgram));
+
+		keepOpenOnUnmount = true;
+		view.rerender(<Wrapper />);
+		expect(latest?.program).toBeUndefined();
+		await waitFor(() => expect(firstProgram.closeCalls).toBe(1));
+		await waitFor(() => expect(latest?.program).toBe(secondProgram));
+
+		view.unmount();
+		await act(async () => {
+			for (let i = 0; i < 5; i += 1) await Promise.resolve();
+		});
+		expect(fakePeer.open).toHaveBeenCalledTimes(2);
+		expect(secondProgram.closeCalls).toBe(0);
+	});
+
+	it("detaches listeners without closing when keepOpenOnUnmount is set", async () => {
+		const program = new FakeProgram("target", ["topic"]);
+		const fakePeer = {
+			identity: { publicKey: { hashcode: () => "peer-1" } },
+			open: vi.fn(async () => program),
+		};
+
+		let latest: ReturnType<typeof useProgram<any>> | undefined;
+		const Wrapper = () => {
+			latest = useProgram(fakePeer as any, program as any, {
+				keepOpenOnUnmount: true,
+			});
+			return null;
+		};
+		const view = render(<Wrapper />);
+		await waitFor(() => expect(latest?.program).toBe(program));
+		expect(program.events.listenerCount("join")).toBe(1);
+		expect(program.events.listenerCount("leave")).toBe(1);
+
+		view.unmount();
+		await waitFor(() => expect(program.events.listenerCount("join")).toBe(0));
+		expect(program.events.listenerCount("leave")).toBe(0);
+		expect(program.closeCalls).toBe(0);
 	});
 });


### PR DESCRIPTION
## Summary

- make each useProgram effect generation own its open, listeners, publication, and cleanup
- preserve address equivalence and legacy identity for inline unsaved targets, with id as an explicit replacement boundary
- fence stale peer and lifecycle-policy requests, clean up partial setup failures, and retry transient close debt before replacement opens
- cover StrictMode, target/client swaps, synchronous failures, listener cleanup, and keepOpenOnUnmount changes

## Validation

- pnpm --filter @peerbit/program-react test (15/15)
- pnpm --filter @peerbit/program-react build
- pnpm exec prettier --check on all changed files
- git diff --check origin/master...HEAD