### PR TITLE
fix(document): declare time runtime dependency

### DIFF
--- a/.changeset/fix-document-time-dependency.md
+++ b/.changeset/fix-document-time-dependency.md
@@ -1,0 +1,6 @@
+---
+"@peerbit/document": patch
+---
+
+Declare `@peerbit/time` as a runtime dependency so clean package consumers can
+import document search without relying on a hoisted development dependency.

--- a/packages/programs/data/document/document/package.json
+++ b/packages/programs/data/document/document/package.json
@@ -79,6 +79,7 @@
 		"@peerbit/rpc": "workspace:*",
 		"@peerbit/shared-log": "workspace:*",
 		"@peerbit/stream-interface": "workspace:*",
+		"@peerbit/time": "workspace:*",
 		"p-defer": "^4.0.0",
 		"uint8arrays": "^5.1.0"
 	},
@@ -91,7 +92,6 @@
 		"@peerbit/log-rust": "workspace:*",
 		"@peerbit/native-backbone": "workspace:*",
 		"@peerbit/test-utils": "workspace:*",
-		"@peerbit/time": "workspace:*",
 		"@types/pidusage": "^2.0.5",
 		"peerbit": "workspace:*",
 		"pidusage": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1268,6 +1268,9 @@ importers:
       '@peerbit/stream-interface':
         specifier: workspace:*
         version: link:../../../../transport/stream-interface
+      '@peerbit/time':
+        specifier: workspace:*
+        version: link:../../../../utils/time
       p-defer:
         specifier: ^4.0.0
         version: 4.0.1
@@ -1290,9 +1293,6 @@ importers:
       '@peerbit/test-utils':
         specifier: workspace:*
         version: link:../../../../clients/test-utils
-      '@peerbit/time':
-        specifier: workspace:*
-        version: link:../../../../utils/time
       '@types/pidusage':
         specifier: ^2.0.5
         version: 2.0.5

--- a/scripts/test-published-security-smoke.mjs
+++ b/scripts/test-published-security-smoke.mjs
@@ -142,6 +142,23 @@ try {
 			"secure-dependency-lines.md",
 		),
 	});
+	const packedDocument = packedPackages.get("@peerbit/document");
+	const workspaceTime = workspaceByName.get("@peerbit/time");
+	assert(
+		packedDocument,
+		"@peerbit/document must be included in the package smoke",
+	);
+	assert(workspaceTime, "@peerbit/time must be included in the package smoke");
+	assert.equal(
+		packedDocument.manifest.dependencies?.["@peerbit/time"],
+		workspaceTime.manifest.version,
+		"packed @peerbit/document must retain its exact runtime @peerbit/time edge",
+	);
+	assert.equal(
+		packedDocument.manifest.devDependencies?.["@peerbit/time"],
+		undefined,
+		"packed @peerbit/document must not hide @peerbit/time in devDependencies",
+	);
 	const isolatedCryptoSmoke = run(
 		process.execPath,
 		[
@@ -197,6 +214,9 @@ try {
 			"await store.put('key', new Uint8Array([1, 2, 3]));",
 			"assert.deepEqual(await store.get('key'), new Uint8Array([1, 2, 3]));",
 			"await store.close();",
+			"",
+			"const { Documents } = await import('@peerbit/document');",
+			"assert.equal(typeof Documents, 'function');",
 			"",
 			"const { getPort } = await import('@peerbit/server');",
 			"assert.equal(getPort('http:'), 8082);",

--- a/scripts/test-release-security-contracts.mjs
+++ b/scripts/test-release-security-contracts.mjs
@@ -14,6 +14,22 @@ const readRepositoryFile = (path) =>
 
 const packageManifest = JSON.parse(await readRepositoryFile("package.json"));
 const scripts = packageManifest.scripts;
+const documentManifest = JSON.parse(
+	await readRepositoryFile(
+		"packages/programs/data/document/document/package.json",
+	),
+);
+
+assert.equal(
+	documentManifest.dependencies?.["@peerbit/time"],
+	"workspace:*",
+	"@peerbit/document must own its runtime @peerbit/time import",
+);
+assert.equal(
+	documentManifest.devDependencies?.["@peerbit/time"],
+	undefined,
+	"@peerbit/document must not hide @peerbit/time in devDependencies",
+);
 
 assert.equal(
 	scripts["release:security-gate"],


### PR DESCRIPTION
## Summary

- move `@peerbit/time` from development-only metadata into `@peerbit/document` runtime dependencies
- add release-contract and packed-manifest assertions so hoisting cannot hide the edge again
- import the packed document entrypoint in the clean published-package consumer

## Why

`@peerbit/document@13.1.9` runtime-imports `@peerbit/time` from `search.ts`, but a clean nested install cannot resolve it because the package only declared it as a dev dependency. Workspace hoisting masked the defect.

## Validation

- full workspace build
- release security contract
- clean consumer with all 54 publishable tarballs and zero production audit findings
- isolated nested document tarball import on Node 18.20.8 and Node 24
- frozen lockfile, Prettier, and `git diff --check`

Independently reviewed with no remaining P0-P2 findings.