### PR TITLE
fix(release): require supported Node runtime

### DIFF
--- a/.changeset/require-node-twenty-two.md
+++ b/.changeset/require-node-twenty-two.md
@@ -1,0 +1,6 @@
+---
+"peerbit": patch
+"@peerbit/stream": patch
+---
+
+Require Node.js 22 or newer to match the supported runtime dependency graph.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,10 +115,14 @@ jobs:
           retention-days: 1
 
   security_dependency_contracts:
-    name: Security Dependency Contracts
+    name: Security Dependency Contracts (Node v${{ matrix.node-version }})
     needs: build_workspace
     runs-on: ubuntu-22.04
     timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22.x, 24.x]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -126,7 +130,7 @@ jobs:
           run_install: false
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: ${{ matrix.node-version }}
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - name: Install exact dependency graph

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Restore workspace dependency protocol
         run: node tools/restore-workspace-deps.mjs

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"packages/utils/rateless-iblt"
 	],
 	"engines": {
-		"node": ">=18"
+		"node": ">=22"
 	},
 	"scripts": {
 		"reset": "aegir run clean && aegir clean interop/node_modules packages/**/node_modules node_modules package-lock.json packages/*/package-lock.json interop/*/package-lock.json",

--- a/packages/clients/peerbit/package.json
+++ b/packages/clients/peerbit/package.json
@@ -61,7 +61,7 @@
 		"directory": "packages/clients/peerbit"
 	},
 	"engines": {
-		"node": ">=18"
+		"node": ">=22"
 	},
 	"browser": {
 		"./dist/src/transports.js": "./dist/src/transports.browser.js"

--- a/packages/transport/stream/package.json
+++ b/packages/transport/stream/package.json
@@ -60,7 +60,7 @@
 		"test:cov": "aegir test -t node --cov"
 	},
 	"engines": {
-		"node": ">=16.15.1"
+		"node": ">=22"
 	},
 	"repository": {
 		"type": "git",

--- a/scripts/test-published-crypto-package-smoke.mjs
+++ b/scripts/test-published-crypto-package-smoke.mjs
@@ -42,7 +42,7 @@ const repositoryManifest = JSON.parse(
 );
 assert.equal(
 	repositoryManifest.engines?.node,
-	">=18",
+	">=22",
 	"the isolated crypto smoke must track the repository's advertised Node floor",
 );
 const cryptoManifest = JSON.parse(

--- a/scripts/test-published-security-smoke.mjs
+++ b/scripts/test-published-security-smoke.mjs
@@ -144,6 +144,18 @@ try {
 	});
 	const packedDocument = packedPackages.get("@peerbit/document");
 	const workspaceTime = workspaceByName.get("@peerbit/time");
+	for (const packageName of ["peerbit", "@peerbit/stream"]) {
+		const packedPackage = packedPackages.get(packageName);
+		assert(
+			packedPackage,
+			`${packageName} must be included in the package smoke`,
+		);
+		assert.equal(
+			packedPackage.manifest.engines?.node,
+			">=22",
+			`${packageName}: packed Node engine must match its runtime dependency floor`,
+		);
+	}
 	assert(
 		packedDocument,
 		"@peerbit/document must be included in the package smoke",
@@ -242,6 +254,7 @@ try {
 
 	run("npm", ["install", "--no-audit", "--no-fund", "--loglevel=error"], {
 		cwd: consumerDirectory,
+		env: { NPM_CONFIG_ENGINE_STRICT: "true" },
 		status: 0,
 		timeout: 900_000,
 	});

--- a/scripts/test-release-security-contracts.mjs
+++ b/scripts/test-release-security-contracts.mjs
@@ -95,6 +95,8 @@ const securityJobEnd = ciWorkflow.indexOf("\n  test_push:", securityJobStart);
 assert(securityJobStart >= 0 && securityJobEnd > securityJobStart);
 const securityJob = ciWorkflow.slice(securityJobStart, securityJobEnd);
 assert.match(securityJob, /needs: build_workspace/);
+assert.match(securityJob, /node-version: \[22\.x, 24\.x\]/);
+assert.match(securityJob, /node-version: \$\{\{ matrix\.node-version \}\}/);
 assert.match(securityJob, /pnpm install --frozen-lockfile/);
 const restoreIndex = securityJob.indexOf("Restore workspace build outputs");
 const gateIndex = securityJob.indexOf("pnpm run release:security-gate");
@@ -140,6 +142,30 @@ assert.match(
 	publishedSecuritySmoke,
 	/test-published-crypto-package-smoke\.mjs/,
 	"the full published-package gate must include the isolated crypto package smoke",
+);
+assert.match(
+	publishedSecuritySmoke,
+	/NPM_CONFIG_ENGINE_STRICT: "true"/,
+	"the clean published-package install must reject unsupported Node engines",
+);
+for (const packagePath of [
+	"packages/clients/peerbit/package.json",
+	"packages/transport/stream/package.json",
+]) {
+	const manifest = JSON.parse(await readRepositoryFile(packagePath));
+	assert.equal(
+		manifest.engines?.node,
+		">=22",
+		`${manifest.name}: declared Node engine must match its runtime dependency floor`,
+	);
+}
+const postReleaseWorkflow = await readRepositoryFile(
+	".github/workflows/post-release.yml",
+);
+assert.match(
+	postReleaseWorkflow,
+	/name: Use Node\.js[\s\S]*?node-version: 22/,
+	"post-release automation must use the supported Node floor",
 );
 const publishedCryptoPackageSmoke = await readRepositoryFile(
 	"scripts/test-published-crypto-package-smoke.mjs",


### PR DESCRIPTION
## Summary

- require Node.js 22 or newer for the root workspace, `peerbit`, and `@peerbit/stream`, matching their fresh production dependency closure
- run the published-package security gate on current Node 22 and 24 with engine-strict npm installs
- assert the packed `peerbit` and `@peerbit/stream` manifests preserve the supported floor
- move post-release automation to Node 22 while retaining the isolated Node 18 compatibility smoke for `@peerbit/crypto`

Fresh registry resolution of `peerbit@5.3.8` and `@peerbit/stream@5.1.2` selects `libp2p` → `p-retry@8`, which requires Node 22. The old Node 18/16 declarations therefore allowed installs that npm could not run safely.

## Validation

- full workspace build
- release security contract tests
- publication-closure contracts for all 54 publishable packages
- engine-strict exact-tarball consumer smoke on Node 22.22.2: 54/54 packages, zero audit findings
- engine-strict exact-tarball consumer smoke on Node 24.14.1: 54/54 packages, zero audit findings
- isolated Node 18 crypto wire contract remains green
- changeset status, focused ESLint, Prettier, YAML parse, and `git diff --check`
