### PR TITLE
fix(vite): declare supported Node runtimes

### DIFF
--- a/.changeset/declare-vite-node-runtime.md
+++ b/.changeset/declare-vite-node-runtime.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/vite": patch
+---
+
+Declare Vite 7's supported Node.js runtime range so engine-strict installs reject unsupported Node.js versions before the plugin is loaded.

--- a/packages/clients/vite/package.json
+++ b/packages/clients/vite/package.json
@@ -61,7 +61,7 @@
 		"url": "https://github.com/dao-xyz/peerbit"
 	},
 	"engines": {
-		"node": ">=16.15.1"
+		"node": "^20.19.0 || >=22.12.0"
 	},
 	"author": "Peerbit contributors",
 	"license": "MIT",

--- a/scripts/test-published-security-smoke.mjs
+++ b/scripts/test-published-security-smoke.mjs
@@ -15,6 +15,7 @@ import {
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const npxCommand = process.platform === "win32" ? "npx.cmd" : "npx";
+const viteNodeEngine = "^20.19.0 || >=22.12.0";
 
 const run = (command, args, options = {}) => {
 	const result = spawnSync(command, args, {
@@ -142,6 +143,16 @@ try {
 			"secure-dependency-lines.md",
 		),
 	});
+	const packedPeerbitVite = packedPackages.get("@peerbit/vite");
+	assert(
+		packedPeerbitVite,
+		"@peerbit/vite must be included in the package smoke",
+	);
+	assert.equal(
+		packedPeerbitVite.manifest.engines?.node,
+		viteNodeEngine,
+		"packed @peerbit/vite must declare the Node.js floor imposed by Vite 7",
+	);
 	const packedDocument = packedPackages.get("@peerbit/document");
 	const workspaceTime = workspaceByName.get("@peerbit/time");
 	for (const packageName of ["peerbit", "@peerbit/stream"]) {
@@ -284,6 +295,19 @@ try {
 	);
 	assert.deepEqual(lockfile.packages[""].dependencies, dependencies);
 	const lockfilePackages = Object.entries(lockfile.packages);
+	const installedViteEntries = lockfilePackages.filter(([packagePath]) =>
+		packagePath.endsWith("node_modules/vite"),
+	);
+	assert.equal(
+		installedViteEntries.length,
+		1,
+		"the clean consumer must install exactly one Vite runtime",
+	);
+	assert.equal(
+		installedViteEntries[0][1].engines?.node,
+		viteNodeEngine,
+		"the clean consumer must retain Vite 7's Node.js engine contract",
+	);
 	for (const { manifest } of publishablePackages) {
 		const topLevelPath = `node_modules/${manifest.name}`;
 		const topLevelEntry = lockfile.packages[topLevelPath];

--- a/scripts/test-release-security-contracts.mjs
+++ b/scripts/test-release-security-contracts.mjs
@@ -19,6 +19,10 @@ const documentManifest = JSON.parse(
 		"packages/programs/data/document/document/package.json",
 	),
 );
+const viteManifest = JSON.parse(
+	await readRepositoryFile("packages/clients/vite/package.json"),
+);
+const viteNodeEngine = "^20.19.0 || >=22.12.0";
 
 assert.equal(
 	documentManifest.dependencies?.["@peerbit/time"],
@@ -29,6 +33,11 @@ assert.equal(
 	documentManifest.devDependencies?.["@peerbit/time"],
 	undefined,
 	"@peerbit/document must not hide @peerbit/time in devDependencies",
+);
+assert.equal(
+	viteManifest.engines?.node,
+	viteNodeEngine,
+	"@peerbit/vite must declare the Node.js floor imposed by Vite 7",
 );
 
 assert.equal(
@@ -166,6 +175,11 @@ assert.match(
 	postReleaseWorkflow,
 	/name: Use Node\.js[\s\S]*?node-version: 22/,
 	"post-release automation must use the supported Node floor",
+);
+assert.match(
+	publishedSecuritySmoke,
+	/packedPackages\.get\("@peerbit\/vite"\)/,
+	"the published-package gate must inspect the packed @peerbit/vite manifest",
 );
 const publishedCryptoPackageSmoke = await readRepositoryFile(
 	"scripts/test-published-crypto-package-smoke.mjs",


### PR DESCRIPTION
## Summary

- declare `@peerbit/vite` support for Node.js `^20.19.0 || >=22.12.0`, exactly matching its Vite 7 runtime dependency
- assert the packed plugin retains that range and a clean consumer installs exactly one Vite runtime with the same contract
- keep engine-strict fresh-package installation so unsupported Node versions fail before the plugin loads

The previous `>=16.15.1` declaration allowed installs on Node versions that Vite 7 explicitly does not support.

## Validation

- full workspace build
- `@peerbit/vite` tests: 5/5
- release security contract tests
- fresh packed install/import and Vite transform on Node 20.19.0, 22.12.0, and 24.14.1
- Node 20.18.3 is correctly rejected with `EBADENGINE`
- changeset resolves `@peerbit/vite` 2.0.8 → 2.0.9
- independent P0/P1/P2 review, Prettier, and `git diff --check`
