### PR TITLE
fix(benchmark): validate file-share transfers

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
 		"bench:file-share:prepare": "node ./scripts/file-share/prepare-peerbit-examples.mjs",
 		"bench:file-share:local": "node ./scripts/file-share/run-file-share-benchmark.mjs",
 		"bench:file-share:matrix": "node ./scripts/file-share/run-file-share-benchmark-matrix.mjs",
+		"bench:file-share:test": "node --test ./scripts/file-share/*.test.mjs",
 		"site:sync-updates": "node apps/peerbit-org/scripts/syncUpdatesEmail.mjs",
 		"dep-check": "aegir run dep-check",
 		"doc-check": "aegir run doc-check",

--- a/scripts/file-share/benchmark-invocation.mjs
+++ b/scripts/file-share/benchmark-invocation.mjs
@@ -1,0 +1,312 @@
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+
+export const BENCHMARK_INVOCATION_SCHEMA = {
+	id: "peerbit-file-share-benchmark-invocation",
+	version: 1,
+};
+
+export const TINY_FILE_CUTOFF_BYTES = 5_000_000;
+export const BENCHMARK_SERVER_MODE = "production-preview";
+export const BENCHMARK_SERVER_HOST = "127.0.0.1";
+
+const DEPLOYED_APP_HARNESS_MESSAGE =
+	"The locally instrumented core benchmark harness cannot use --base-url because it cannot attribute an external deployment to the selected Peerbit checkout; use a dedicated deployed-app benchmark harness that records deployment provenance";
+
+const DEFAULTS = {
+	uploadTimeoutMs: 600_000,
+	postUploadMonitorMs: 5_000,
+	pollMs: 1_000,
+	readyTimeoutMs: 180_000,
+	sampleMs: 15_000,
+	sampleCount: 4,
+	targetSeeders: 2,
+};
+
+const asNullableString = (value) => {
+	if (value == null || value === "") {
+		return null;
+	}
+	return String(value);
+};
+
+export const resolveBenchmarkPreviewProtocol = (requestedProtocol) => {
+	const protocol = asNullableString(requestedProtocol) ?? "http";
+	if (protocol !== "http") {
+		throw new Error(
+			`The local production preview only serves HTTP; unsupported benchmark preview protocol ${JSON.stringify(protocol)}`,
+		);
+	}
+	return protocol;
+};
+
+export const resolveBenchmarkPreviewOptions = ({
+	protocol,
+	viteMode,
+	viteConfig,
+} = {}) => {
+	const normalizedViteMode = asNullableString(viteMode);
+	if (normalizedViteMode !== null) {
+		throw new Error(
+			"--vite-mode is not supported by PW_BENCH=1 because the production preview command does not consume it",
+		);
+	}
+	const normalizedViteConfig = asNullableString(viteConfig);
+	if (normalizedViteConfig !== null) {
+		throw new Error(
+			"--vite-config is not supported by PW_BENCH=1 because the production build does not consume it and the preview command cannot safely attribute a partial custom configuration",
+		);
+	}
+	return {
+		protocol: resolveBenchmarkPreviewProtocol(protocol),
+		viteMode: null,
+		viteConfig: null,
+	};
+};
+
+export const assertCoreBenchmarkUsesLocalApp = (baseUrl) => {
+	if (asNullableString(baseUrl) !== null) {
+		throw new Error(DEPLOYED_APP_HARNESS_MESSAGE);
+	}
+	return null;
+};
+
+const requireNonNegativeSafeInteger = (value, label) => {
+	if (!Number.isSafeInteger(value) || value < 0) {
+		throw new Error(`${label} must be a non-negative safe integer`);
+	}
+	return value;
+};
+
+const requirePositiveSafeInteger = (value, label) => {
+	if (!Number.isSafeInteger(value) || value <= 0) {
+		throw new Error(`${label} must be a positive safe integer`);
+	}
+	return value;
+};
+
+export const assertBenchmarkFileSize = ({ scenario, fileMb }) => {
+	const sizeBytes = fileMb * 1024 * 1024;
+	if (
+		typeof fileMb !== "number" ||
+		!Number.isFinite(fileMb) ||
+		fileMb <= 0 ||
+		!Number.isSafeInteger(sizeBytes)
+	) {
+		throw new Error(
+			"--file-mb must resolve to a positive safe integer byte count",
+		);
+	}
+	if (scenario === "upload" && sizeBytes <= TINY_FILE_CUTOFF_BYTES) {
+		throw new Error(
+			`Upload benchmarks must exceed the ${TINY_FILE_CUTOFF_BYTES.toLocaleString("en-US")} byte TinyFile cutoff; choose a larger --file-mb value`,
+		);
+	}
+	return sizeBytes;
+};
+
+const normalizeLocalPackages = (localPackages) => {
+	if (!Array.isArray(localPackages)) {
+		throw new Error("localPackages must be an array");
+	}
+	const normalized = localPackages.map((name) => {
+		if (typeof name !== "string" || name.trim().length === 0) {
+			throw new Error("localPackages must contain non-empty package names");
+		}
+		return name.trim();
+	});
+	if (new Set(normalized).size !== normalized.length) {
+		throw new Error("localPackages must not contain duplicates");
+	}
+	return normalized.toSorted((left, right) => left.localeCompare(right));
+};
+
+/**
+ * Resolve every benchmark input before Playwright starts. Templates receive this
+ * exact object and results must echo it, so defaults and optional CLI knobs are
+ * part of the validity contract rather than ambient process state.
+ */
+export const createBenchmarkInvocation = ({
+	scenario,
+	mode,
+	network,
+	integrationMode,
+	fileMb,
+	fixtureSeed,
+	uploadTimeoutMs,
+	downloadTimeoutMs,
+	postUploadMonitorMs,
+	pollMs,
+	minReadySeeders,
+	readyTimeoutMs,
+	sampleMs,
+	sampleCount,
+	targetSeeders,
+	baseUrl,
+	protocol,
+	viteMode,
+	viteConfig,
+	localPackages = [],
+	enableVisibilityProbe = false,
+	verbose = false,
+}) => {
+	if (!["upload", "seeder-probe"].includes(scenario)) {
+		throw new Error(`Unsupported benchmark scenario ${String(scenario)}`);
+	}
+	if (!["adaptive", "fixed1", "observer"].includes(mode)) {
+		throw new Error(`Unsupported benchmark mode ${String(mode)}`);
+	}
+	if (!["local", "remote"].includes(network)) {
+		throw new Error(`Unsupported benchmark network ${String(network)}`);
+	}
+	if (!["none", "link"].includes(integrationMode)) {
+		throw new Error(
+			`Unsupported benchmark integration mode ${String(integrationMode)}`,
+		);
+	}
+	const resolvedBaseUrl = assertCoreBenchmarkUsesLocalApp(baseUrl);
+	const previewOptions = resolveBenchmarkPreviewOptions({
+		protocol,
+		viteMode,
+		viteConfig,
+	});
+	const sizeBytes = assertBenchmarkFileSize({ scenario, fileMb });
+	if (typeof fixtureSeed !== "string" || fixtureSeed.length === 0) {
+		throw new Error("fixtureSeed must be a non-empty string");
+	}
+
+	const resolvedUploadTimeoutMs = requirePositiveSafeInteger(
+		uploadTimeoutMs ?? DEFAULTS.uploadTimeoutMs,
+		"uploadTimeoutMs",
+	);
+	const resolvedDownloadTimeoutMs = requirePositiveSafeInteger(
+		downloadTimeoutMs ?? resolvedUploadTimeoutMs,
+		"downloadTimeoutMs",
+	);
+	const resolvedPostUploadMonitorMs = requireNonNegativeSafeInteger(
+		postUploadMonitorMs ?? DEFAULTS.postUploadMonitorMs,
+		"postUploadMonitorMs",
+	);
+	const resolvedPollMs = requirePositiveSafeInteger(
+		pollMs ?? DEFAULTS.pollMs,
+		"pollMs",
+	);
+	const resolvedMinReadySeeders = requireNonNegativeSafeInteger(
+		minReadySeeders ?? (mode === "adaptive" ? 2 : 0),
+		"minReadySeeders",
+	);
+	const resolvedReadyTimeoutMs = requirePositiveSafeInteger(
+		readyTimeoutMs ?? DEFAULTS.readyTimeoutMs,
+		"readyTimeoutMs",
+	);
+	const resolvedSampleMs = requirePositiveSafeInteger(
+		sampleMs ?? DEFAULTS.sampleMs,
+		"sampleMs",
+	);
+	const resolvedSampleCount = requirePositiveSafeInteger(
+		sampleCount ?? DEFAULTS.sampleCount,
+		"sampleCount",
+	);
+	const resolvedTargetSeeders = requireNonNegativeSafeInteger(
+		targetSeeders ?? DEFAULTS.targetSeeders,
+		"targetSeeders",
+	);
+
+	return {
+		schema: BENCHMARK_INVOCATION_SCHEMA,
+		scenario,
+		mode,
+		networkMode: network,
+		integrationMode,
+		fileSizeMb: fileMb,
+		fileSizeBytes: sizeBytes,
+		fixtureSeed,
+		uploadTimeoutMs: resolvedUploadTimeoutMs,
+		downloadTimeoutMs: resolvedDownloadTimeoutMs,
+		postUploadMonitorMs: resolvedPostUploadMonitorMs,
+		pollMs: resolvedPollMs,
+		minReadySeeders: resolvedMinReadySeeders,
+		readyTimeoutMs: resolvedReadyTimeoutMs,
+		sampleMs: resolvedSampleMs,
+		sampleCount: resolvedSampleCount,
+		targetSeeders: resolvedTargetSeeders,
+		baseUrl: resolvedBaseUrl,
+		protocol: previewOptions.protocol,
+		viteMode: previewOptions.viteMode,
+		viteConfig: previewOptions.viteConfig,
+		localPackages: normalizeLocalPackages(localPackages),
+		serverMode: BENCHMARK_SERVER_MODE,
+		serverHost: BENCHMARK_SERVER_HOST,
+		enableVisibilityProbe: Boolean(enableVisibilityProbe),
+		verbose: Boolean(verbose),
+	};
+};
+
+const stringValue = (value) => (value == null ? "" : String(value));
+
+/**
+ * Strip every PW_* variable, including future ones unknown to this harness, then
+ * install the complete effective benchmark contract. This prevents a caller's
+ * shell from changing the app URL, Vite mode, timeouts, or validation knobs.
+ */
+export const createPlaywrightBenchmarkEnvironment = ({
+	baseEnvironment = process.env,
+	invocation,
+	resultFile,
+	runNonce,
+	provenance,
+}) => {
+	const environment = {};
+	for (const [key, value] of Object.entries(baseEnvironment)) {
+		if (!key.startsWith("PW_") && key !== "E2E_PORT" && key !== "PORT") {
+			environment[key] = value;
+		}
+	}
+	Object.assign(environment, {
+		HOST: BENCHMARK_SERVER_HOST,
+		PW_BASE_URL: stringValue(invocation.baseUrl),
+		PW_BENCH: "1",
+		PW_BENCHMARK_INVOCATION: JSON.stringify(invocation),
+		PW_BENCHMARK_PROVENANCE: JSON.stringify(provenance),
+		PW_BENCHMARK_RUN_NONCE: runNonce,
+		PW_BENCHMARK_SCENARIO: invocation.scenario,
+		PW_DOWNLOAD_TIMEOUT_MS: String(invocation.downloadTimeoutMs),
+		PW_ENABLE_VISIBILITY_PROBE: invocation.enableVisibilityProbe ? "1" : "0",
+		PW_FILE_MB: String(invocation.fileSizeMb),
+		PW_FIXTURE_SEED: invocation.fixtureSeed,
+		PW_IGNORE_HTTPS_ERRORS: "0",
+		PW_MIN_READY_SEEDERS: String(invocation.minReadySeeders),
+		PW_NETWORK_MODE: invocation.networkMode,
+		PW_POLL_MS: String(invocation.pollMs),
+		PW_POST_UPLOAD_MONITOR_MS: String(invocation.postUploadMonitorMs),
+		PW_PROTOCOL: stringValue(invocation.protocol),
+		PW_READY_TIMEOUT_MS: String(invocation.readyTimeoutMs),
+		PW_REPLICATION_MODE: invocation.mode,
+		PW_RESULT_FILE: resultFile,
+		PW_SAMPLE_COUNT: String(invocation.sampleCount),
+		PW_SAMPLE_MS: String(invocation.sampleMs),
+		PW_TARGET_SEEDERS: String(invocation.targetSeeders),
+		PW_UPLOAD_TIMEOUT_MS: String(invocation.uploadTimeoutMs),
+		PW_VERBOSE: invocation.verbose ? "1" : "0",
+		PW_VITE_CONFIG: stringValue(invocation.viteConfig),
+		PW_VITE_MODE: stringValue(invocation.viteMode),
+	});
+	return environment;
+};
+
+export const assertMatrixInvocationUsesLocalApp = (invocation) => {
+	assertCoreBenchmarkUsesLocalApp(invocation.baseUrl);
+};
+
+export const createNonceIsolatedResultPath = ({ resultsDir, runNonce }) => {
+	if (typeof runNonce !== "string" || runNonce.length === 0) {
+		throw new Error("A run nonce is required for an isolated result path");
+	}
+	return path.join(resultsDir, "invocations", runNonce, "result.json");
+};
+
+export const assertInvocationUnchanged = (actual, expected, label) => {
+	if (!isDeepStrictEqual(actual, expected)) {
+		throw new Error(`${label} changed while the benchmark was running`);
+	}
+};

--- a/scripts/file-share/benchmark-invocation.test.mjs
+++ b/scripts/file-share/benchmark-invocation.test.mjs
@@ -1,0 +1,312 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+	TINY_FILE_CUTOFF_BYTES,
+	assertBenchmarkFileSize,
+	assertMatrixInvocationUsesLocalApp,
+	createBenchmarkInvocation,
+	createNonceIsolatedResultPath,
+	createPlaywrightBenchmarkEnvironment,
+	resolveBenchmarkPreviewOptions,
+	resolveBenchmarkPreviewProtocol,
+} from "./benchmark-invocation.mjs";
+
+const invocation = (overrides = {}) =>
+	createBenchmarkInvocation({
+		scenario: "upload",
+		mode: "adaptive",
+		network: "local",
+		integrationMode: "link",
+		fileMb: 5,
+		fixtureSeed: "deterministic-seed",
+		...overrides,
+	});
+
+test("resolves every default and requested optional knob", () => {
+	const resolved = invocation({
+		uploadTimeoutMs: 101,
+		downloadTimeoutMs: 202,
+		postUploadMonitorMs: 303,
+		pollMs: 4,
+		minReadySeeders: 5,
+		readyTimeoutMs: 606,
+		sampleMs: 7,
+		sampleCount: 8,
+		targetSeeders: 9,
+		protocol: "http",
+		enableVisibilityProbe: true,
+		verbose: true,
+		localPackages: ["peerbit", "@peerbit/document"],
+	});
+	assert.deepEqual(
+		{
+			uploadTimeoutMs: resolved.uploadTimeoutMs,
+			downloadTimeoutMs: resolved.downloadTimeoutMs,
+			postUploadMonitorMs: resolved.postUploadMonitorMs,
+			pollMs: resolved.pollMs,
+			minReadySeeders: resolved.minReadySeeders,
+			readyTimeoutMs: resolved.readyTimeoutMs,
+			sampleMs: resolved.sampleMs,
+			sampleCount: resolved.sampleCount,
+			targetSeeders: resolved.targetSeeders,
+			protocol: resolved.protocol,
+			viteMode: resolved.viteMode,
+			viteConfig: resolved.viteConfig,
+			enableVisibilityProbe: resolved.enableVisibilityProbe,
+			verbose: resolved.verbose,
+			localPackages: resolved.localPackages,
+			serverMode: resolved.serverMode,
+			serverHost: resolved.serverHost,
+		},
+		{
+			uploadTimeoutMs: 101,
+			downloadTimeoutMs: 202,
+			postUploadMonitorMs: 303,
+			pollMs: 4,
+			minReadySeeders: 5,
+			readyTimeoutMs: 606,
+			sampleMs: 7,
+			sampleCount: 8,
+			targetSeeders: 9,
+			protocol: "http",
+			viteMode: null,
+			viteConfig: null,
+			enableVisibilityProbe: true,
+			verbose: true,
+			localPackages: ["@peerbit/document", "peerbit"],
+			serverMode: "production-preview",
+			serverHost: "127.0.0.1",
+		},
+	);
+});
+
+test("removes all ambient PW variables and installs the exact invocation", () => {
+	const resolved = invocation();
+	const environment = createPlaywrightBenchmarkEnvironment({
+		baseEnvironment: {
+			PATH: "/bin",
+			HOST: "0.0.0.0",
+			PORT: "9999",
+			E2E_PORT: "9998",
+			PW_BASE_URL: "https://attacker.invalid",
+			PW_FILE_MB: "999",
+			PW_POST_UPLOAD_MONITOR_MS: "0",
+			PW_PORT: "4444",
+			PW_PROTOCOL: "https",
+			PW_VITE_CONFIG: "injected.config.ts",
+			PW_VITE_MODE: "staging",
+			PW_FUTURE_BYPASS: "yes",
+			PW_BENCH: "1",
+		},
+		invocation: resolved,
+		resultFile: "/tmp/result.json",
+		runNonce: "123e4567-e89b-42d3-a456-426614174000",
+		provenance: { bound: true },
+	});
+	assert.equal(environment.PATH, "/bin");
+	assert.equal(environment.PORT, undefined);
+	assert.equal(environment.E2E_PORT, undefined);
+	assert.equal(environment.PW_BASE_URL, "");
+	assert.equal(environment.HOST, "127.0.0.1");
+	assert.equal(environment.PW_FILE_MB, "5");
+	assert.equal(environment.PW_POST_UPLOAD_MONITOR_MS, "5000");
+	assert.equal(environment.PW_FUTURE_BYPASS, undefined);
+	assert.equal(environment.PW_PORT, undefined);
+	assert.equal(environment.PW_BENCH, "1");
+	assert.equal(environment.PW_PROTOCOL, "http");
+	assert.equal(environment.PW_VITE_CONFIG, "");
+	assert.equal(environment.PW_VITE_MODE, "");
+	assert.deepEqual(JSON.parse(environment.PW_BENCHMARK_INVOCATION), resolved);
+});
+
+test("upload benchmarks cannot exercise the TinyFile path", () => {
+	const cutoffMb = TINY_FILE_CUTOFF_BYTES / (1024 * 1024);
+	assert.throws(
+		() => assertBenchmarkFileSize({ scenario: "upload", fileMb: cutoffMb }),
+		/5,000,000 byte TinyFile cutoff/,
+	);
+	assert.throws(
+		() => invocation({ fileMb: cutoffMb }),
+		/5,000,000 byte TinyFile cutoff/,
+	);
+	assert.doesNotThrow(() =>
+		assertBenchmarkFileSize({ scenario: "upload", fileMb: 5 }),
+	);
+	assert.doesNotThrow(() =>
+		assertBenchmarkFileSize({ scenario: "seeder-probe", fileMb: 1 }),
+	);
+});
+
+test("production preview has one attributable HTTP configuration", () => {
+	assert.equal(resolveBenchmarkPreviewProtocol(undefined), "http");
+	assert.equal(resolveBenchmarkPreviewProtocol("http"), "http");
+	for (const protocol of ["https", "ws"]) {
+		assert.throws(
+			() => resolveBenchmarkPreviewProtocol(protocol),
+			/local production preview only serves HTTP/,
+		);
+	}
+	assert.deepEqual(resolveBenchmarkPreviewOptions(), {
+		protocol: "http",
+		viteMode: null,
+		viteConfig: null,
+	});
+	assert.throws(
+		() => resolveBenchmarkPreviewOptions({ viteMode: "staging" }),
+		/--vite-mode.*production preview command does not consume it/,
+	);
+	assert.throws(
+		() =>
+			resolveBenchmarkPreviewOptions({ viteConfig: "vite.config.remote.ts" }),
+		/--vite-config.*production build does not consume it/,
+	);
+	assert.throws(
+		() => invocation({ protocol: "https" }),
+		/local production preview only serves HTTP/,
+	);
+	assert.throws(
+		() => invocation({ viteMode: "staging" }),
+		/--vite-mode.*production preview command does not consume it/,
+	);
+	assert.throws(
+		() => invocation({ viteConfig: "vite.config.remote.ts" }),
+		/--vite-config.*production build does not consume it/,
+	);
+});
+
+test("rejects non-comparable timeout and seeder knobs before Playwright", () => {
+	assert.throws(
+		() => invocation({ integrationMode: "overlay" }),
+		/Unsupported benchmark integration mode overlay/,
+	);
+	for (const [overrides, pattern] of [
+		[{ uploadTimeoutMs: 0 }, /uploadTimeoutMs must be a positive safe integer/],
+		[
+			{ downloadTimeoutMs: 1.5 },
+			/downloadTimeoutMs must be a positive safe integer/,
+		],
+		[{ pollMs: 0 }, /pollMs must be a positive safe integer/],
+		[
+			{ postUploadMonitorMs: 0.5 },
+			/postUploadMonitorMs must be a non-negative safe integer/,
+		],
+		[
+			{ minReadySeeders: 0.5 },
+			/minReadySeeders must be a non-negative safe integer/,
+		],
+		[{ readyTimeoutMs: 0 }, /readyTimeoutMs must be a positive safe integer/],
+		[{ sampleMs: 0 }, /sampleMs must be a positive safe integer/],
+		[
+			{ targetSeeders: 0.5 },
+			/targetSeeders must be a non-negative safe integer/,
+		],
+	]) {
+		assert.throws(() => invocation(overrides), pattern);
+	}
+	assert.throws(
+		() => invocation({ localPackages: ["peerbit", "peerbit"] }),
+		/localPackages must not contain duplicates/,
+	);
+});
+
+test("core harness rejects external app origins without deployment provenance", () => {
+	assert.doesNotThrow(() => assertMatrixInvocationUsesLocalApp(invocation()));
+	assert.throws(
+		() => invocation({ baseUrl: "https://files.example" }),
+		/dedicated deployed-app benchmark harness.*deployment provenance/,
+	);
+	assert.throws(
+		() =>
+			assertMatrixInvocationUsesLocalApp({
+				baseUrl: "https://files.example",
+			}),
+		/dedicated deployed-app benchmark harness.*deployment provenance/,
+	);
+});
+
+test("standalone runner rejects external origins before mutating outputs", async () => {
+	const temporaryRoot = await mkdtemp(
+		path.join(os.tmpdir(), "peerbit-origin-preflight-"),
+	);
+	const summaryFile = path.join(temporaryRoot, "summary.json");
+	await writeFile(summaryFile, "sentinel\n");
+	try {
+		const child = spawnSync(
+			process.execPath,
+			[
+				path.resolve("scripts/file-share/run-file-share-benchmark.mjs"),
+				"--base-url",
+				"https://files.example",
+				"--summary-file",
+				summaryFile,
+			],
+			{ encoding: "utf8" },
+		);
+		assert.equal(child.status, 1);
+		assert.match(
+			child.stderr,
+			/dedicated deployed-app benchmark harness.*deployment provenance/,
+		);
+		assert.equal(await readFile(summaryFile, "utf8"), "sentinel\n");
+	} finally {
+		await rm(temporaryRoot, { recursive: true, force: true });
+	}
+});
+
+test("standalone runner rejects invalid integration modes before mutating outputs", async () => {
+	const temporaryRoot = await mkdtemp(
+		path.join(os.tmpdir(), "peerbit-integration-preflight-"),
+	);
+	const summaryFile = path.join(temporaryRoot, "summary.json");
+	await writeFile(summaryFile, "sentinel\n");
+	try {
+		for (const [args, error] of [
+			[["--integration-mode", "overlay"], /Unsupported --integration-mode/],
+			[
+				["--integration-mode", "link", "--local-packages", ","],
+				/link integration requires at least one local Peerbit package/,
+			],
+		]) {
+			const child = spawnSync(
+				process.execPath,
+				[
+					path.resolve("scripts/file-share/run-file-share-benchmark.mjs"),
+					...args,
+					"--summary-file",
+					summaryFile,
+				],
+				{ encoding: "utf8" },
+			);
+			assert.equal(child.status, 1);
+			assert.match(child.stderr, error);
+			assert.equal(await readFile(summaryFile, "utf8"), "sentinel\n");
+		}
+	} finally {
+		await rm(temporaryRoot, { recursive: true, force: true });
+	}
+});
+
+test("result files are isolated by invocation nonce", () => {
+	const first = createNonceIsolatedResultPath({
+		resultsDir: "/tmp/results/session-a",
+		runNonce: "nonce-a",
+	});
+	const second = createNonceIsolatedResultPath({
+		resultsDir: "/tmp/results/session-a",
+		runNonce: "nonce-b",
+	});
+	assert.notEqual(first, second);
+	assert.equal(
+		first,
+		path.join(
+			"/tmp/results/session-a",
+			"invocations",
+			"nonce-a",
+			"result.json",
+		),
+	);
+});

--- a/scripts/file-share/benchmark-provenance.mjs
+++ b/scripts/file-share/benchmark-provenance.mjs
@@ -1,0 +1,229 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+
+const git = (root, args, { binary = false } = {}) => {
+	const result = spawnSync("git", args, {
+		cwd: root,
+		env: process.env,
+		encoding: binary ? undefined : "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	if (result.error) {
+		throw new Error(`Could not start git in ${root}: ${result.error.message}`, {
+			cause: result.error,
+		});
+	}
+	if (result.status !== 0) {
+		const stderr = binary
+			? Buffer.from(result.stderr ?? []).toString("utf8")
+			: result.stderr;
+		throw new Error(
+			`git ${args.join(" ")} failed in ${root}: ${String(stderr).trim()}`,
+		);
+	}
+	return binary ? Buffer.from(result.stdout ?? []) : result.stdout.trim();
+};
+
+export const resolveGitCommitAt = (root, ref = "HEAD") =>
+	git(root, ["rev-parse", "--verify", `${ref}^{commit}`]);
+
+export const gitStatus = (root) =>
+	git(root, ["status", "--porcelain=v1", "--untracked-files=all"]);
+
+export const digestDirtyWorktree = async (root, status) => {
+	const hash = createHash("sha256");
+	hash.update("peerbit-worktree-v1\0");
+	hash.update(status);
+	hash.update("\0tracked-diff\0");
+	hash.update(git(root, ["diff", "--binary", "HEAD"], { binary: true }));
+	const untracked = git(
+		root,
+		["ls-files", "--others", "--exclude-standard", "-z"],
+		{ binary: true },
+	)
+		.toString("utf8")
+		.split("\0")
+		.filter(Boolean)
+		.sort();
+	for (const relativePath of untracked) {
+		const filePath = path.join(root, relativePath);
+		const details = await fsp.lstat(filePath);
+		hash.update("\0untracked\0");
+		hash.update(relativePath);
+		hash.update("\0");
+		if (details.isSymbolicLink()) {
+			hash.update(`symlink:${await fsp.readlink(filePath)}`);
+		} else if (details.isFile()) {
+			for await (const chunk of fs.createReadStream(filePath)) {
+				hash.update(chunk);
+			}
+		} else {
+			hash.update(`mode:${details.mode}:size:${details.size}`);
+		}
+	}
+	return hash.digest("hex");
+};
+
+export const getPeerbitProvenance = async ({
+	root,
+	requestedRef = "worktree",
+	requireClean = false,
+	expectedResolvedCommit,
+}) => {
+	const resolvedCommit = resolveGitCommitAt(root, "HEAD");
+	if (
+		expectedResolvedCommit != null &&
+		resolvedCommit !== expectedResolvedCommit
+	) {
+		throw new Error(
+			`Peerbit HEAD ${resolvedCommit} does not match the requested ref commit ${expectedResolvedCommit}`,
+		);
+	}
+	const status = gitStatus(root);
+	const dirty = status.length > 0;
+	if (requireClean && dirty) {
+		throw new Error(
+			`Matrix worktree variant is dirty and cannot be reproduced:\n${status}`,
+		);
+	}
+	return {
+		requestedRef,
+		resolvedCommit,
+		dirty,
+		worktreeDigest: dirty ? await digestDirtyWorktree(root, status) : null,
+	};
+};
+
+export const sha256FileHex = async (filePath) => {
+	const hash = createHash("sha256");
+	for await (const chunk of fs.createReadStream(filePath)) {
+		hash.update(chunk);
+	}
+	return hash.digest("hex");
+};
+
+export const assertExamplesBenchmarkContract = async (examplesRoot) => {
+	const requiredFiles = [
+		"package.json",
+		"pnpm-lock.yaml",
+		path.join("packages", "file-share", "frontend", "tests", "helpers.ts"),
+		path.join("packages", "file-share", "frontend", "src", "Drop.tsx"),
+	];
+	for (const relativePath of requiredFiles) {
+		if (!fs.existsSync(path.join(examplesRoot, relativePath))) {
+			throw new Error(
+				`Examples source is missing benchmark contract file ${relativePath}`,
+			);
+		}
+	}
+	const helpers = await fsp.readFile(
+		path.join(
+			examplesRoot,
+			"packages",
+			"file-share",
+			"frontend",
+			"tests",
+			"helpers.ts",
+		),
+		"utf8",
+	);
+	for (const helper of [
+		"createSyntheticFileOnDisk",
+		"sha256AndCrc32File",
+		"armSavedViaPicker",
+		"installNodeBackedMockSaveFilePicker",
+		"waitForUploadComplete",
+	]) {
+		if (
+			!new RegExp(
+				`export\\s+(?:async\\s+)?(?:function|const)\\s+${helper}\\b`,
+			).test(helpers)
+		) {
+			throw new Error(`Examples source is missing benchmark helper ${helper}`);
+		}
+	}
+	const drop = await fsp.readFile(
+		path.join(
+			examplesRoot,
+			"packages",
+			"file-share",
+			"frontend",
+			"src",
+			"Drop.tsx",
+		),
+		"utf8",
+	);
+	if (!drop.includes("getLightweightSnapshot")) {
+		throw new Error(
+			"Examples source lacks the ready-manifest benchmark snapshot contract",
+		);
+	}
+};
+
+export const getExamplesProvenance = async ({
+	root,
+	requestedRef,
+	fallbackResolvedCommit,
+	fallbackProvenance,
+	requireClean = false,
+	expectedResolvedCommit,
+	expectedLockfileSha256,
+}) => {
+	await assertExamplesBenchmarkContract(root);
+	let resolvedCommit =
+		fallbackProvenance?.resolvedCommit ?? fallbackResolvedCommit;
+	let dirty = fallbackProvenance?.dirty ?? false;
+	let worktreeDigest = fallbackProvenance?.worktreeDigest ?? null;
+	if (fs.existsSync(path.join(root, ".git"))) {
+		resolvedCommit = resolveGitCommitAt(root, "HEAD");
+		const status = gitStatus(root);
+		dirty = status.length > 0;
+		worktreeDigest = dirty ? await digestDirtyWorktree(root, status) : null;
+	} else {
+		// A copied template intentionally has no .git directory. Its source commit
+		// must be supplied by the caller and remains part of the result envelope.
+	}
+	if (!/^[0-9a-f]{40}$/.test(resolvedCommit ?? "")) {
+		throw new Error("Could not establish a pinned examples commit");
+	}
+	if (requireClean && dirty) {
+		throw new Error(
+			"Examples source is dirty before benchmark instrumentation; use a clean pinned checkout or record it without requireClean",
+		);
+	}
+	if (dirty && !/^[0-9a-f]{64}$/.test(worktreeDigest ?? "")) {
+		throw new Error("Dirty examples provenance is missing its worktree digest");
+	}
+	if (!dirty && worktreeDigest !== null) {
+		throw new Error(
+			"Clean examples provenance unexpectedly has a worktree digest",
+		);
+	}
+	const lockfileSha256 = await sha256FileHex(path.join(root, "pnpm-lock.yaml"));
+	if (
+		expectedResolvedCommit != null &&
+		resolvedCommit !== expectedResolvedCommit
+	) {
+		throw new Error(
+			`Examples commit ${resolvedCommit} does not match pinned commit ${expectedResolvedCommit}`,
+		);
+	}
+	if (
+		expectedLockfileSha256 != null &&
+		lockfileSha256 !== expectedLockfileSha256
+	) {
+		throw new Error(
+			`Examples lockfile SHA-256 ${lockfileSha256} does not match pinned digest ${expectedLockfileSha256}`,
+		);
+	}
+	return {
+		requestedRef,
+		resolvedCommit,
+		lockfileSha256,
+		dirty,
+		worktreeDigest,
+	};
+};

--- a/scripts/file-share/benchmark-provenance.test.mjs
+++ b/scripts/file-share/benchmark-provenance.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+	getExamplesProvenance,
+	getPeerbitProvenance,
+	sha256FileHex,
+} from "./benchmark-provenance.mjs";
+
+const git = (root, ...args) =>
+	execFileSync("git", args, {
+		cwd: root,
+		stdio: ["ignore", "pipe", "pipe"],
+		encoding: "utf8",
+	}).trim();
+
+const createExamplesRepository = async () => {
+	const root = await mkdtemp(path.join(os.tmpdir(), "peerbit-provenance-"));
+	const frontend = path.join(root, "packages", "file-share", "frontend");
+	await mkdir(path.join(frontend, "tests"), { recursive: true });
+	await mkdir(path.join(frontend, "src"), { recursive: true });
+	await writeFile(path.join(root, "package.json"), '{"name":"fixture"}\n');
+	await writeFile(
+		path.join(root, "pnpm-lock.yaml"),
+		"lockfileVersion: '9.0'\n",
+	);
+	await writeFile(
+		path.join(frontend, "tests", "helpers.ts"),
+		[
+			"export const createSyntheticFileOnDisk = () => {};",
+			"export const sha256AndCrc32File = () => {};",
+			"export const armSavedViaPicker = () => {};",
+			"export const installNodeBackedMockSaveFilePicker = () => {};",
+			"export const waitForUploadComplete = () => {};",
+			"",
+		].join("\n"),
+	);
+	await writeFile(
+		path.join(frontend, "src", "Drop.tsx"),
+		"export const getLightweightSnapshot = () => ({});\n",
+	);
+	git(root, "init", "--quiet");
+	git(root, "config", "user.name", "Benchmark Test");
+	git(root, "config", "user.email", "benchmark@example.invalid");
+	git(root, "add", ".");
+	git(root, "commit", "--quiet", "-m", "fixture");
+	return root;
+};
+
+test("binds exact Peerbit HEAD and digests dirty harness contents", async () => {
+	const root = await createExamplesRepository();
+	try {
+		const head = git(root, "rev-parse", "HEAD");
+		const clean = await getPeerbitProvenance({
+			root,
+			requestedRef: "requested-ref",
+			expectedResolvedCommit: head,
+		});
+		assert.deepEqual(clean, {
+			requestedRef: "requested-ref",
+			resolvedCommit: head,
+			dirty: false,
+			worktreeDigest: null,
+		});
+		await assert.rejects(
+			getPeerbitProvenance({
+				root,
+				expectedResolvedCommit: "f".repeat(40),
+			}),
+			/does not match the requested ref commit/,
+		);
+		await writeFile(path.join(root, "untracked.txt"), "first\n");
+		const dirty = await getPeerbitProvenance({ root });
+		assert.equal(dirty.dirty, true);
+		assert.match(dirty.worktreeDigest, /^[0-9a-f]{64}$/);
+		await writeFile(path.join(root, "untracked.txt"), "second\n");
+		const changed = await getPeerbitProvenance({ root });
+		assert.notEqual(changed.worktreeDigest, dirty.worktreeDigest);
+		await assert.rejects(
+			getPeerbitProvenance({ root, requireClean: true }),
+			/cannot be reproduced/,
+		);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("binds pinned examples commit, lockfile, and pre-instrumentation dirt", async () => {
+	const root = await createExamplesRepository();
+	try {
+		const head = git(root, "rev-parse", "HEAD");
+		const lockfileSha256 = await sha256FileHex(
+			path.join(root, "pnpm-lock.yaml"),
+		);
+		const clean = await getExamplesProvenance({
+			root,
+			requestedRef: "origin/master",
+			expectedResolvedCommit: head,
+			expectedLockfileSha256: lockfileSha256,
+		});
+		assert.equal(clean.dirty, false);
+		await writeFile(path.join(root, "pre-instrumentation.txt"), "dirty\n");
+		const dirty = await getExamplesProvenance({
+			root,
+			requestedRef: "origin/master",
+			expectedResolvedCommit: head,
+			expectedLockfileSha256: lockfileSha256,
+		});
+		assert.equal(dirty.dirty, true);
+		assert.match(dirty.worktreeDigest, /^[0-9a-f]{64}$/);
+		await assert.rejects(
+			getExamplesProvenance({
+				root,
+				requestedRef: "origin/master",
+				requireClean: true,
+			}),
+			/dirty before benchmark instrumentation/,
+		);
+		await assert.rejects(
+			getExamplesProvenance({
+				root,
+				requestedRef: "origin/master",
+				expectedLockfileSha256: "0".repeat(64),
+			}),
+			/does not match pinned digest/,
+		);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});

--- a/scripts/file-share/benchmark-validity.mjs
+++ b/scripts/file-share/benchmark-validity.mjs
@@ -1,0 +1,778 @@
+import fsp from "node:fs/promises";
+import { isDeepStrictEqual } from "node:util";
+
+const SHA256_BASE64_PATTERN = /^[A-Za-z0-9+/]{43}=$/;
+const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/;
+const GIT_COMMIT_PATTERN = /^[0-9a-f]{40}$/;
+const CRC32_HEX_PATTERN = /^[0-9a-f]{8}$/;
+const UUID_PATTERN =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SAMPLE_COUNT_DEFINITION =
+	"observation-density divisor: planned interval is min(sampleMs, floor(readyTimeoutMs/sampleCount)) clamped to 1ms; convergence may finish early";
+const POST_MONITOR_SCHEDULING_TOLERANCE_DEFINITION =
+	"max(250ms, pollMs + 250ms) for the final poll and event-loop scheduling";
+const TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION =
+	"max(5000ms, pollMs + 1000ms) for browser actions and event-loop scheduling";
+
+const isRecord = (value) =>
+	value != null && typeof value === "object" && !Array.isArray(value);
+
+const requireRecord = (value, label) => {
+	if (!isRecord(value)) {
+		throw new Error(`Benchmark result is missing ${label}`);
+	}
+	return value;
+};
+
+const requireString = (value, label) => {
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(`Benchmark result has invalid ${label}`);
+	}
+	return value;
+};
+
+const requireNonNegativeNumber = (value, label) => {
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+		throw new Error(`Benchmark result has invalid ${label}`);
+	}
+	return value;
+};
+
+const requirePositiveNumber = (value, label) => {
+	const parsed = requireNonNegativeNumber(value, label);
+	if (parsed <= 0) {
+		throw new Error(`Benchmark result has non-positive ${label}`);
+	}
+	return parsed;
+};
+
+const requireFiniteNumber = (value, label) => {
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		throw new Error(`Benchmark result has invalid ${label}`);
+	}
+	return value;
+};
+
+const requireNonNegativeSafeInteger = (value, label) => {
+	if (!Number.isSafeInteger(value) || value < 0) {
+		throw new Error(`Benchmark result has invalid ${label}`);
+	}
+	return value;
+};
+
+const requirePattern = (value, pattern, label) => {
+	const string = requireString(value, label);
+	if (!pattern.test(string)) {
+		throw new Error(`Benchmark result has malformed ${label}`);
+	}
+	return string;
+};
+
+export const assertPlaywrightSucceeded = (exitCode) => {
+	if (!Number.isInteger(exitCode) || exitCode !== 0) {
+		throw new Error(
+			`Playwright benchmark exited unsuccessfully (exitCode=${String(exitCode)})`,
+		);
+	}
+};
+
+export const parseBenchmarkResult = (
+	contents,
+	resultFile = "benchmark result",
+) => {
+	let result;
+	try {
+		result = JSON.parse(contents);
+	} catch (error) {
+		throw new Error(`Malformed JSON in ${resultFile}`, { cause: error });
+	}
+	if (!isRecord(result)) {
+		throw new Error(`${resultFile} must contain a JSON object`);
+	}
+	return result;
+};
+
+const validateUploadIntegrity = (
+	result,
+	expectedFileMb,
+	expectedFixtureSeed,
+) => {
+	const integrity = requireRecord(result.integrity, "integrity");
+	if (integrity.fixtureMode !== "deterministic") {
+		throw new Error("Benchmark result did not use deterministic fixture bytes");
+	}
+	if (integrity.fixtureFormat !== "aes-256-ctr-v1") {
+		throw new Error("Benchmark result has an unsupported fixture format");
+	}
+	if (integrity.fixtureSeed !== expectedFixtureSeed) {
+		throw new Error("Benchmark result fixture seed does not match the request");
+	}
+	const expectedSizeBytes = expectedFileMb * 1024 * 1024;
+	if (!Number.isSafeInteger(expectedSizeBytes) || expectedSizeBytes < 0) {
+		throw new Error(`Invalid expected benchmark size ${expectedFileMb} MiB`);
+	}
+	if (
+		integrity.expectedSizeBytes !== expectedSizeBytes ||
+		integrity.sourceSizeBytes !== expectedSizeBytes ||
+		integrity.manifestSizeBytes !== expectedSizeBytes ||
+		integrity.downloadedSizeBytes !== expectedSizeBytes ||
+		integrity.sizeVerified !== true ||
+		integrity.manifestVerified !== true
+	) {
+		throw new Error("Benchmark result failed its exact-size integrity gate");
+	}
+
+	const sourceSha256 = requirePattern(
+		integrity.sourceSha256Base64,
+		SHA256_BASE64_PATTERN,
+		"integrity.sourceSha256Base64",
+	);
+	const manifestSha256 = requirePattern(
+		integrity.manifestSha256Base64,
+		SHA256_BASE64_PATTERN,
+		"integrity.manifestSha256Base64",
+	);
+	const downloadedSha256 = requirePattern(
+		integrity.downloadedSha256Base64,
+		SHA256_BASE64_PATTERN,
+		"integrity.downloadedSha256Base64",
+	);
+	if (
+		integrity.sha256Verified !== true ||
+		sourceSha256 !== manifestSha256 ||
+		sourceSha256 !== downloadedSha256
+	) {
+		throw new Error("Benchmark result failed its SHA-256 integrity gate");
+	}
+
+	const sourceCrc32 = requirePattern(
+		integrity.sourceCrc32Hex,
+		CRC32_HEX_PATTERN,
+		"integrity.sourceCrc32Hex",
+	);
+	const downloadedCrc32 = requirePattern(
+		integrity.downloadedCrc32Hex,
+		CRC32_HEX_PATTERN,
+		"integrity.downloadedCrc32Hex",
+	);
+	if (integrity.crc32Verified !== true || sourceCrc32 !== downloadedCrc32) {
+		throw new Error("Benchmark result failed its CRC-32 integrity gate");
+	}
+	if (integrity.verified !== true || result.integrityVerified !== true) {
+		throw new Error("Benchmark result is missing the aggregate integrity gate");
+	}
+};
+
+const validateUploadTimings = (result, invocation) => {
+	if (result.downloadSink !== "node-file") {
+		throw new Error(
+			"Benchmark result did not use the persisted Node file sink",
+		);
+	}
+	const phases = requireRecord(result.phaseDurationsMs, "phaseDurationsMs");
+	const uploadSettledMs = requireNonNegativeNumber(
+		phases.timeToUploadSettled,
+		"phaseDurationsMs.timeToUploadSettled",
+	);
+	requireNonNegativeNumber(
+		phases.writerListingLag,
+		"phaseDurationsMs.writerListingLag",
+	);
+	requireNonNegativeNumber(
+		phases.readerListingLag,
+		"phaseDurationsMs.readerListingLag",
+	);
+	requireNonNegativeNumber(result.listingDurationMs, "listingDurationMs");
+	requireNonNegativeNumber(
+		result.postUploadMonitorDurationMs,
+		"postUploadMonitorDurationMs",
+	);
+	requireNonNegativeNumber(result.downloadDurationMs, "downloadDurationMs");
+	const uploadDurationMs = requirePositiveNumber(
+		result.uploadDurationMs,
+		"uploadDurationMs",
+	);
+	if (uploadDurationMs !== uploadSettledMs) {
+		throw new Error(
+			"uploadDurationMs must end at upload settlement and exclude listing/post-monitor/download",
+		);
+	}
+	const timestamps = requireRecord(result.timestamps, "timestamps");
+	const uploadStartedAt = requirePositiveNumber(
+		timestamps.uploadStartedAt,
+		"timestamps.uploadStartedAt",
+	);
+	const uploadSettledAt = requirePositiveNumber(
+		timestamps.uploadSettledAt,
+		"timestamps.uploadSettledAt",
+	);
+	const progressSettledAt = requirePositiveNumber(
+		timestamps.progressSettledAt,
+		"timestamps.progressSettledAt",
+	);
+	const writerListedAt = requirePositiveNumber(
+		timestamps.writerListedAt,
+		"timestamps.writerListedAt",
+	);
+	const readerListedAt = requirePositiveNumber(
+		timestamps.readerListedAt,
+		"timestamps.readerListedAt",
+	);
+	const postMonitorStartedAt = requirePositiveNumber(
+		timestamps.postMonitorStartedAt,
+		"timestamps.postMonitorStartedAt",
+	);
+	const postMonitorFinishedAt = requirePositiveNumber(
+		timestamps.postMonitorFinishedAt,
+		"timestamps.postMonitorFinishedAt",
+	);
+	const downloadStartedAt = requirePositiveNumber(
+		timestamps.downloadStartedAt,
+		"timestamps.downloadStartedAt",
+	);
+	const downloadFinishedAt = requirePositiveNumber(
+		timestamps.downloadFinishedAt,
+		"timestamps.downloadFinishedAt",
+	);
+	if (
+		uploadSettledAt <= uploadStartedAt ||
+		progressSettledAt < uploadStartedAt ||
+		progressSettledAt > uploadSettledAt ||
+		writerListedAt < uploadStartedAt ||
+		readerListedAt < uploadStartedAt ||
+		writerListedAt > uploadSettledAt ||
+		postMonitorStartedAt <
+			Math.max(uploadSettledAt, writerListedAt, readerListedAt) ||
+		postMonitorFinishedAt < postMonitorStartedAt ||
+		downloadStartedAt < postMonitorFinishedAt ||
+		downloadFinishedAt <= downloadStartedAt
+	) {
+		throw new Error("Benchmark phase timestamps are not monotonic");
+	}
+	const progressVisibleAt =
+		timestamps.progressVisibleAt == null
+			? undefined
+			: requirePositiveNumber(
+					timestamps.progressVisibleAt,
+					"timestamps.progressVisibleAt",
+				);
+	if (
+		progressVisibleAt != null &&
+		(progressVisibleAt < uploadStartedAt || progressVisibleAt > uploadSettledAt)
+	) {
+		throw new Error("Benchmark phase timestamps are not monotonic");
+	}
+	const expectedListingDuration = Math.max(
+		0,
+		Math.max(writerListedAt, readerListedAt) - uploadSettledAt,
+	);
+	if (
+		uploadDurationMs !== uploadSettledAt - uploadStartedAt ||
+		result.listingDurationMs !== expectedListingDuration ||
+		result.postUploadMonitorDurationMs !==
+			postMonitorFinishedAt - postMonitorStartedAt ||
+		result.downloadDurationMs !== downloadFinishedAt - downloadStartedAt ||
+		phases.writerListingLag !== Math.max(0, writerListedAt - uploadSettledAt) ||
+		phases.readerListingLag !== Math.max(0, readerListedAt - uploadSettledAt) ||
+		phases.readerAfterWriter !== readerListedAt - writerListedAt ||
+		phases.postUploadMonitor !== result.postUploadMonitorDurationMs ||
+		phases.download !== result.downloadDurationMs
+	) {
+		throw new Error("Benchmark phase duration arithmetic is inconsistent");
+	}
+	requireFiniteNumber(
+		phases.readerAfterWriter,
+		"phaseDurationsMs.readerAfterWriter",
+	);
+	if (progressVisibleAt == null) {
+		if (phases.timeToProgressVisible != null || phases.activeUpload != null) {
+			throw new Error("Benchmark progress duration arithmetic is inconsistent");
+		}
+	} else if (
+		phases.timeToProgressVisible !== progressVisibleAt - uploadStartedAt ||
+		phases.activeUpload !== uploadSettledAt - progressVisibleAt
+	) {
+		throw new Error("Benchmark progress duration arithmetic is inconsistent");
+	}
+
+	const expectedPostMonitorTolerance = Math.max(250, invocation.pollMs + 250);
+	if (
+		result.postUploadMonitorSchedulingToleranceMs !==
+			expectedPostMonitorTolerance ||
+		result.postUploadMonitorSchedulingToleranceDefinition !==
+			POST_MONITOR_SCHEDULING_TOLERANCE_DEFINITION
+	) {
+		throw new Error(
+			"Benchmark post-upload monitor scheduling tolerance is invalid",
+		);
+	}
+	if (
+		result.postUploadMonitorDurationMs < invocation.postUploadMonitorMs ||
+		result.postUploadMonitorDurationMs >
+			invocation.postUploadMonitorMs + expectedPostMonitorTolerance
+	) {
+		throw new Error(
+			"Measured post-upload monitor duration is outside the requested duration and scheduling tolerance",
+		);
+	}
+
+	const expectedTransferTolerance = Math.max(5_000, invocation.pollMs + 1_000);
+	if (
+		result.transferTimeoutSchedulingToleranceMs !== expectedTransferTolerance ||
+		result.transferTimeoutSchedulingToleranceDefinition !==
+			TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION
+	) {
+		throw new Error("Benchmark transfer scheduling tolerance is invalid");
+	}
+	if (
+		uploadDurationMs > invocation.uploadTimeoutMs + expectedTransferTolerance ||
+		result.downloadDurationMs >
+			invocation.downloadTimeoutMs + expectedTransferTolerance
+	) {
+		throw new Error(
+			"Measured transfer duration exceeded its requested timeout and scheduling tolerance",
+		);
+	}
+};
+
+const validateGitProvenance = (value, label) => {
+	const provenance = requireRecord(value, label);
+	requireString(provenance.requestedRef, `${label}.requestedRef`);
+	requirePattern(
+		provenance.resolvedCommit,
+		GIT_COMMIT_PATTERN,
+		`${label}.resolvedCommit`,
+	);
+	if (typeof provenance.dirty !== "boolean") {
+		throw new Error(`Benchmark result has invalid ${label}.dirty`);
+	}
+	if (provenance.dirty) {
+		requirePattern(
+			provenance.worktreeDigest,
+			SHA256_HEX_PATTERN,
+			`${label}.worktreeDigest`,
+		);
+	} else if (provenance.worktreeDigest !== null) {
+		throw new Error(`Clean ${label} has a worktree digest`);
+	}
+	return provenance;
+};
+
+const validateEnvelope = (
+	result,
+	{ expectedRunNonce, expectedProvenance, expectedNetwork, expectedInvocation },
+) => {
+	const schema = requireRecord(result.schema, "schema");
+	if (schema.id !== "peerbit-file-share-benchmark" || schema.version !== 2) {
+		throw new Error("Benchmark result has an unsupported schema");
+	}
+	if (
+		result.runNonce !== expectedRunNonce ||
+		!UUID_PATTERN.test(String(result.runNonce))
+	) {
+		throw new Error("Benchmark result run nonce does not match the invocation");
+	}
+	if (result.networkMode !== expectedNetwork) {
+		throw new Error("Benchmark result network does not match the invocation");
+	}
+	if (!isDeepStrictEqual(result.invocation, expectedInvocation)) {
+		throw new Error("Benchmark result invocation does not match the request");
+	}
+	const invocation = requireRecord(result.invocation, "invocation");
+	const invocationSchema = requireRecord(
+		invocation.schema,
+		"invocation.schema",
+	);
+	if (
+		invocationSchema.id !== "peerbit-file-share-benchmark-invocation" ||
+		invocationSchema.version !== 1
+	) {
+		throw new Error("Benchmark result has an unsupported invocation schema");
+	}
+	if (!isDeepStrictEqual(result.provenance, expectedProvenance)) {
+		throw new Error(
+			"Benchmark result provenance does not match the invocation",
+		);
+	}
+	const provenance = requireRecord(result.provenance, "provenance");
+	validateGitProvenance(provenance.harness, "provenance.harness");
+	validateGitProvenance(provenance.peerbit, "provenance.peerbit");
+	const examples = validateGitProvenance(
+		provenance.examples,
+		"provenance.examples",
+	);
+	requirePattern(
+		examples.lockfileSha256,
+		SHA256_HEX_PATTERN,
+		"provenance.examples.lockfileSha256",
+	);
+};
+
+const validateRequestedUploadKnobs = (result, invocation) => {
+	for (const [resultKey, invocationKey] of [
+		["postUploadMonitorMs", "postUploadMonitorMs"],
+		["pollMs", "pollMs"],
+		["uploadTimeoutMs", "uploadTimeoutMs"],
+		["downloadTimeoutMs", "downloadTimeoutMs"],
+		["minReadySeeders", "minReadySeeders"],
+	]) {
+		if (result[resultKey] !== invocation[invocationKey]) {
+			throw new Error(
+				`Benchmark result ${resultKey} does not match the requested invocation`,
+			);
+		}
+	}
+};
+
+const validateZeroErrors = (result, label) => {
+	if (
+		result.errorCount !== 0 ||
+		!Array.isArray(result.errors) ||
+		result.errors.length !== 0
+	) {
+		throw new Error(`Passed ${label} contains recorded errors`);
+	}
+};
+
+const validateUploadSnapshots = (result, invocation) => {
+	if (!Array.isArray(result.snapshots) || result.snapshots.length === 0) {
+		throw new Error("Passed upload result is missing seeder snapshots");
+	}
+	const timestamps = requireRecord(result.timestamps, "timestamps");
+	const postMonitorStartedAt = requirePositiveNumber(
+		timestamps.postMonitorStartedAt,
+		"timestamps.postMonitorStartedAt",
+	);
+	const postMonitorFinishedAt = requirePositiveNumber(
+		timestamps.postMonitorFinishedAt,
+		"timestamps.postMonitorFinishedAt",
+	);
+	let previousAt = -1;
+	let hasPostMonitorSample = false;
+	const labels = new Set();
+	const parsedSnapshots = [];
+	for (const [index, value] of result.snapshots.entries()) {
+		const snapshot = requireRecord(value, `snapshots[${index}]`);
+		const label = requireString(snapshot.label, `snapshots[${index}].label`);
+		if (
+			labels.has(label) ||
+			!/^(?:seeders-ready|during-\d+|after-\d+)$/.test(label)
+		) {
+			throw new Error(
+				"Upload seeder snapshot labels are invalid or duplicated",
+			);
+		}
+		labels.add(label);
+		const writerSeeders = requireNonNegativeSafeInteger(
+			snapshot.writerSeeders,
+			`snapshots[${index}].writerSeeders`,
+		);
+		const readerSeeders = requireNonNegativeSafeInteger(
+			snapshot.readerSeeders,
+			`snapshots[${index}].readerSeeders`,
+		);
+		const capturedAt = requirePositiveNumber(
+			snapshot.at,
+			`snapshots[${index}].at`,
+		);
+		if (capturedAt < previousAt) {
+			throw new Error("Upload seeder snapshots are not monotonic");
+		}
+		if (label.startsWith("after-")) {
+			if (
+				capturedAt < postMonitorStartedAt ||
+				capturedAt > postMonitorFinishedAt
+			) {
+				throw new Error(
+					"Upload post-monitor snapshot is outside the monitor window",
+				);
+			}
+			hasPostMonitorSample = true;
+		}
+		parsedSnapshots.push({ label, writerSeeders, readerSeeders });
+		previousAt = capturedAt;
+	}
+	if (invocation.postUploadMonitorMs > 0 && !hasPostMonitorSample) {
+		throw new Error(
+			"Passed upload result is missing a numeric post-monitor snapshot",
+		);
+	}
+	const readySnapshots = parsedSnapshots.filter(
+		(snapshot) => snapshot.label === "seeders-ready",
+	);
+	if (
+		readySnapshots.length !== 1 ||
+		parsedSnapshots[0]?.label !== "seeders-ready"
+	) {
+		throw new Error(
+			"Passed upload result must begin with exactly one ready-seeder baseline snapshot",
+		);
+	}
+	const baselineWriterSeeders = requireNonNegativeSafeInteger(
+		result.baselineWriterSeeders,
+		"baselineWriterSeeders",
+	);
+	const baselineReaderSeeders = requireNonNegativeSafeInteger(
+		result.baselineReaderSeeders,
+		"baselineReaderSeeders",
+	);
+	const readySnapshot = readySnapshots[0];
+	if (
+		baselineWriterSeeders !== readySnapshot.writerSeeders ||
+		baselineReaderSeeders !== readySnapshot.readerSeeders
+	) {
+		throw new Error(
+			"Upload seeder baseline fields contradict the ready-seeder snapshot",
+		);
+	}
+	if (
+		baselineWriterSeeders < invocation.minReadySeeders ||
+		baselineReaderSeeders < invocation.minReadySeeders
+	) {
+		throw new Error(
+			"Upload ready-seeder baseline is below the requested minimum",
+		);
+	}
+	const recomputedDroppedSeeders = parsedSnapshots
+		.slice(1)
+		.some(
+			(snapshot) =>
+				snapshot.writerSeeders < baselineWriterSeeders ||
+				snapshot.readerSeeders < baselineReaderSeeders,
+		);
+	if (result.droppedSeeders !== recomputedDroppedSeeders) {
+		throw new Error(
+			"Upload droppedSeeders claim contradicts its numeric snapshot evidence",
+		);
+	}
+};
+
+const validateSeederProbe = (result, invocation) => {
+	if (result.reachedTarget !== true) {
+		throw new Error("Passed seeder probe did not reach a clean target state");
+	}
+	validateZeroErrors(result, "seeder probe");
+	for (const key of [
+		"readyTimeoutMs",
+		"sampleMs",
+		"sampleCount",
+		"targetSeeders",
+	]) {
+		if (result[key] !== invocation[key]) {
+			throw new Error(
+				`Seeder probe ${key} does not match the requested invocation`,
+			);
+		}
+	}
+	if (!Array.isArray(result.samples) || result.samples.length === 0) {
+		throw new Error("Passed seeder probe is missing convergence samples");
+	}
+	if (result.sampleCountDefinition !== SAMPLE_COUNT_DEFINITION) {
+		throw new Error("Seeder probe has an invalid sampleCount definition");
+	}
+	const effectiveSampleIntervalMs = Math.max(
+		1,
+		Math.min(
+			invocation.sampleMs,
+			Math.max(
+				1,
+				Math.floor(invocation.readyTimeoutMs / invocation.sampleCount),
+			),
+		),
+	);
+	if (result.effectiveSampleIntervalMs !== effectiveSampleIntervalMs) {
+		throw new Error("Seeder probe has an invalid effective sample interval");
+	}
+	const maxSamples =
+		Math.floor(invocation.readyTimeoutMs / effectiveSampleIntervalMs) + 1;
+	if (result.samples.length > maxSamples) {
+		throw new Error(
+			"Seeder probe contains more samples than its deadline allows",
+		);
+	}
+	const probeStartedAt = requirePositiveNumber(
+		result.probeStartedAt,
+		"probeStartedAt",
+	);
+	const readyDeadlineAt = requirePositiveNumber(
+		result.readyDeadlineAt,
+		"readyDeadlineAt",
+	);
+	const probeFinishedAt = requirePositiveNumber(
+		result.probeFinishedAt,
+		"probeFinishedAt",
+	);
+	const probeDurationMs = requireNonNegativeNumber(
+		result.probeDurationMs,
+		"probeDurationMs",
+	);
+	const timeToTargetMs = requireNonNegativeNumber(
+		result.timeToTargetMs,
+		"timeToTargetMs",
+	);
+	if (
+		readyDeadlineAt !== probeStartedAt + invocation.readyTimeoutMs ||
+		probeFinishedAt !== probeStartedAt + probeDurationMs ||
+		probeDurationMs !== timeToTargetMs ||
+		probeFinishedAt > readyDeadlineAt ||
+		timeToTargetMs > invocation.readyTimeoutMs
+	) {
+		throw new Error(
+			"Seeder probe deadline/duration arithmetic is inconsistent",
+		);
+	}
+
+	let previousCapturedAt = -1;
+	let targetSample;
+	let firstTargetSampleLabel;
+	for (const [offset, value] of result.samples.entries()) {
+		const index = offset + 1;
+		const sample = requireRecord(value, `samples[${offset}]`);
+		if (sample.index !== index || sample.label !== `sample-${index}`) {
+			throw new Error("Seeder probe sample labels or indices are invalid");
+		}
+		const capturedAt = requirePositiveNumber(
+			sample.capturedAt,
+			`samples[${offset}].capturedAt`,
+		);
+		const elapsedMs = requireNonNegativeNumber(
+			sample.elapsedMs,
+			`samples[${offset}].elapsedMs`,
+		);
+		const writerSeeders = requireNonNegativeSafeInteger(
+			sample.writerSeeders,
+			`samples[${offset}].writerSeeders`,
+		);
+		const readerSeeders = requireNonNegativeSafeInteger(
+			sample.readerSeeders,
+			`samples[${offset}].readerSeeders`,
+		);
+		if (
+			capturedAt < previousCapturedAt ||
+			capturedAt !== probeStartedAt + elapsedMs ||
+			capturedAt > readyDeadlineAt
+		) {
+			throw new Error("Seeder probe samples are not monotonic and bounded");
+		}
+		previousCapturedAt = capturedAt;
+		if (
+			firstTargetSampleLabel == null &&
+			writerSeeders >= invocation.targetSeeders &&
+			readerSeeders >= invocation.targetSeeders
+		) {
+			firstTargetSampleLabel = sample.label;
+		}
+		if (sample.label === result.targetSampleLabel) {
+			targetSample = {
+				sample,
+				capturedAt,
+				elapsedMs,
+				writerSeeders,
+				readerSeeders,
+			};
+		}
+	}
+	if (
+		!targetSample ||
+		firstTargetSampleLabel !== result.targetSampleLabel ||
+		targetSample.sample !== result.samples.at(-1) ||
+		targetSample.writerSeeders < invocation.targetSeeders ||
+		targetSample.readerSeeders < invocation.targetSeeders ||
+		targetSample.elapsedMs !== timeToTargetMs ||
+		targetSample.capturedAt !== probeFinishedAt
+	) {
+		throw new Error(
+			"Seeder probe target evidence is invalid or is not the first observed target",
+		);
+	}
+};
+
+export const validateBenchmarkResult = (
+	result,
+	{
+		scenario,
+		expectedMode,
+		expectedFileMb,
+		expectedNetwork,
+		expectedFixtureSeed,
+		expectedRunNonce,
+		expectedProvenance,
+		expectedInvocation,
+	},
+) => {
+	if (!isRecord(result)) {
+		throw new Error("Benchmark result must be an object");
+	}
+	validateEnvelope(result, {
+		expectedRunNonce,
+		expectedProvenance,
+		expectedNetwork,
+		expectedInvocation,
+	});
+	if (result.status !== "passed") {
+		const detail =
+			typeof result.failure?.message === "string"
+				? `: ${result.failure.message}`
+				: "";
+		throw new Error(`Benchmark result status is not passed${detail}`);
+	}
+	if (result.mode !== expectedMode) {
+		throw new Error(
+			`Benchmark result mode mismatch (expected ${expectedMode}, got ${String(result.mode)})`,
+		);
+	}
+	if (scenario === "upload") {
+		if (result.fileSizeMb !== expectedFileMb) {
+			throw new Error(
+				`Benchmark result size mismatch (expected ${expectedFileMb} MiB, got ${String(result.fileSizeMb)})`,
+			);
+		}
+		validateUploadIntegrity(result, expectedFileMb, expectedFixtureSeed);
+		validateUploadTimings(result, expectedInvocation);
+		validateRequestedUploadKnobs(result, expectedInvocation);
+		validateZeroErrors(result, "upload result");
+		validateUploadSnapshots(result, expectedInvocation);
+		if (result.droppedSeeders !== false) {
+			throw new Error("Passed upload result contains seeder drops");
+		}
+	} else if (scenario === "seeder-probe") {
+		validateSeederProbe(result, expectedInvocation);
+	} else {
+		throw new Error(`Unsupported benchmark scenario ${String(scenario)}`);
+	}
+	return result;
+};
+
+export const loadAndValidateBenchmarkResult = async ({
+	resultFile,
+	exitCode,
+	scenario,
+	expectedMode,
+	expectedFileMb,
+	expectedNetwork,
+	expectedFixtureSeed,
+	expectedRunNonce,
+	expectedProvenance,
+	expectedInvocation,
+}) => {
+	assertPlaywrightSucceeded(exitCode);
+	let contents;
+	try {
+		contents = await fsp.readFile(resultFile, "utf8");
+	} catch (error) {
+		throw new Error(`Benchmark run did not produce ${resultFile}`, {
+			cause: error,
+		});
+	}
+	const result = parseBenchmarkResult(contents, resultFile);
+	return validateBenchmarkResult(result, {
+		scenario,
+		expectedMode,
+		expectedFileMb,
+		expectedNetwork,
+		expectedFixtureSeed,
+		expectedRunNonce,
+		expectedProvenance,
+		expectedInvocation,
+	});
+};

--- a/scripts/file-share/benchmark-validity.test.mjs
+++ b/scripts/file-share/benchmark-validity.test.mjs
@@ -1,0 +1,648 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createBenchmarkInvocation } from "./benchmark-invocation.mjs";
+import {
+	assertPlaywrightSucceeded,
+	loadAndValidateBenchmarkResult,
+	parseBenchmarkResult,
+	validateBenchmarkResult,
+} from "./benchmark-validity.mjs";
+
+const RUN_NONCE = "123e4567-e89b-42d3-a456-426614174000";
+const SHA256 = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+const FILE_MB = 5;
+const FILE_SIZE_BYTES = FILE_MB * 1024 * 1024;
+const SAMPLE_COUNT_DEFINITION =
+	"observation-density divisor: planned interval is min(sampleMs, floor(readyTimeoutMs/sampleCount)) clamped to 1ms; convergence may finish early";
+const POST_MONITOR_SCHEDULING_TOLERANCE_DEFINITION =
+	"max(250ms, pollMs + 250ms) for the final poll and event-loop scheduling";
+const TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION =
+	"max(5000ms, pollMs + 1000ms) for browser actions and event-loop scheduling";
+const PROVENANCE = {
+	harness: {
+		requestedRef: "harness-worktree",
+		resolvedCommit: "d".repeat(40),
+		dirty: true,
+		worktreeDigest: "e".repeat(64),
+	},
+	peerbit: {
+		requestedRef: "candidate",
+		resolvedCommit: "a".repeat(40),
+		dirty: false,
+		worktreeDigest: null,
+	},
+	examples: {
+		requestedRef: "66e250f1",
+		resolvedCommit: "b".repeat(40),
+		lockfileSha256: "c".repeat(64),
+		dirty: false,
+		worktreeDigest: null,
+	},
+};
+
+const INVOCATION = createBenchmarkInvocation({
+	scenario: "upload",
+	mode: "adaptive",
+	network: "local",
+	integrationMode: "link",
+	fileMb: FILE_MB,
+	fixtureSeed: "fixture-seed",
+	uploadTimeoutMs: 600_000,
+	downloadTimeoutMs: 600_000,
+	postUploadMonitorMs: 50,
+	pollMs: 1_000,
+	minReadySeeders: 2,
+});
+
+const options = {
+	scenario: "upload",
+	expectedMode: "adaptive",
+	expectedFileMb: FILE_MB,
+	expectedNetwork: "local",
+	expectedFixtureSeed: "fixture-seed",
+	expectedRunNonce: RUN_NONCE,
+	expectedProvenance: PROVENANCE,
+	expectedInvocation: INVOCATION,
+};
+
+const validResult = () => ({
+	schema: { id: "peerbit-file-share-benchmark", version: 2 },
+	runNonce: RUN_NONCE,
+	invocation: structuredClone(INVOCATION),
+	provenance: structuredClone(PROVENANCE),
+	status: "passed",
+	mode: "adaptive",
+	networkMode: "local",
+	fileSizeMb: FILE_MB,
+	integrityVerified: true,
+	integrity: {
+		fixtureMode: "deterministic",
+		fixtureFormat: "aes-256-ctr-v1",
+		fixtureSeed: "fixture-seed",
+		expectedSizeBytes: FILE_SIZE_BYTES,
+		sourceSizeBytes: FILE_SIZE_BYTES,
+		manifestSizeBytes: FILE_SIZE_BYTES,
+		downloadedSizeBytes: FILE_SIZE_BYTES,
+		sourceSha256Base64: SHA256,
+		manifestSha256Base64: SHA256,
+		downloadedSha256Base64: SHA256,
+		sourceCrc32Hex: "00000000",
+		downloadedCrc32Hex: "00000000",
+		sizeVerified: true,
+		manifestVerified: true,
+		sha256Verified: true,
+		crc32Verified: true,
+		verified: true,
+	},
+	uploadDurationMs: 101,
+	listingDurationMs: 19,
+	postUploadMonitorDurationMs: 50,
+	postUploadMonitorSchedulingToleranceMs: 1_250,
+	postUploadMonitorSchedulingToleranceDefinition:
+		POST_MONITOR_SCHEDULING_TOLERANCE_DEFINITION,
+	postUploadMonitorMs: 50,
+	pollMs: 1_000,
+	uploadTimeoutMs: 600_000,
+	downloadTimeoutMs: 600_000,
+	minReadySeeders: 2,
+	downloadDurationMs: 30,
+	transferTimeoutSchedulingToleranceMs: 5_000,
+	transferTimeoutSchedulingToleranceDefinition:
+		TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION,
+	downloadSink: "node-file",
+	phaseDurationsMs: {
+		timeToUploadSettled: 101,
+		writerListingLag: 0,
+		readerListingLag: 19,
+		readerAfterWriter: 20,
+		postUploadMonitor: 50,
+		download: 30,
+	},
+	timestamps: {
+		uploadStartedAt: 1000,
+		progressSettledAt: 1090,
+		writerListedAt: 1100,
+		uploadSettledAt: 1101,
+		readerListedAt: 1120,
+		postMonitorStartedAt: 1120,
+		postMonitorFinishedAt: 1170,
+		downloadStartedAt: 1170,
+		downloadFinishedAt: 1200,
+	},
+	baselineWriterSeeders: 2,
+	baselineReaderSeeders: 2,
+	droppedSeeders: false,
+	errorCount: 0,
+	errors: [],
+	snapshots: [
+		{
+			label: "seeders-ready",
+			writerSeeders: 2,
+			readerSeeders: 2,
+			at: 900,
+		},
+		{
+			label: "after-1",
+			writerSeeders: 2,
+			readerSeeders: 2,
+			at: 1130,
+		},
+	],
+});
+
+test("accepts a complete deterministic transfer result", () => {
+	assert.equal(
+		validateBenchmarkResult(validResult(), options).status,
+		"passed",
+	);
+});
+
+test("rejects failed, malformed, and stale Playwright outcomes", async () => {
+	assert.throws(() => assertPlaywrightSucceeded(1), /unsuccessfully/);
+	assert.throws(() => assertPlaywrightSucceeded(null), /unsuccessfully/);
+	assert.throws(() => parseBenchmarkResult("{"), /Malformed JSON/);
+	assert.throws(
+		() =>
+			validateBenchmarkResult({ ...validResult(), status: "failed" }, options),
+		/status is not passed/,
+	);
+
+	const directory = await mkdtemp(
+		path.join(os.tmpdir(), "peerbit-bench-test-"),
+	);
+	try {
+		const resultFile = path.join(directory, "result.json");
+		await writeFile(resultFile, JSON.stringify(validResult()));
+		await assert.rejects(
+			loadAndValidateBenchmarkResult({
+				resultFile,
+				exitCode: 2,
+				...options,
+			}),
+			/unsuccessfully/,
+		);
+		await assert.rejects(
+			loadAndValidateBenchmarkResult({
+				resultFile: path.join(directory, "missing.json"),
+				exitCode: 0,
+				...options,
+			}),
+			/did not produce/,
+		);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+for (const [name, mutate, pattern] of [
+	[
+		"schema",
+		(result) => {
+			result.schema.version = 1;
+		},
+		/unsupported schema/,
+	],
+	[
+		"integrity envelope",
+		(result) => {
+			delete result.integrity;
+		},
+		/missing integrity/,
+	],
+	[
+		"fixture mode",
+		(result) => {
+			result.integrity.fixtureMode = "sparse";
+		},
+		/deterministic fixture/,
+	],
+	[
+		"SHA-256 format",
+		(result) => {
+			result.integrity.sourceSha256Base64 = "x";
+			result.integrity.manifestSha256Base64 = "x";
+			result.integrity.downloadedSha256Base64 = "x";
+		},
+		/malformed integrity.sourceSha256Base64/,
+	],
+	[
+		"CRC-32 match",
+		(result) => {
+			result.integrity.downloadedCrc32Hex = "ffffffff";
+		},
+		/CRC-32/,
+	],
+	[
+		"manifest size",
+		(result) => {
+			delete result.integrity.manifestSizeBytes;
+		},
+		/exact-size/,
+	],
+	[
+		"aggregate integrity",
+		(result) => {
+			result.integrity.verified = false;
+		},
+		/aggregate integrity/,
+	],
+	[
+		"upload arithmetic",
+		(result) => {
+			result.uploadDurationMs += result.postUploadMonitorDurationMs;
+		},
+		/uploadDurationMs must end/,
+	],
+	[
+		"phase ordering",
+		(result) => {
+			result.timestamps.downloadStartedAt = 1100;
+		},
+		/not monotonic/,
+	],
+	[
+		"provenance",
+		(result) => {
+			result.provenance.peerbit.resolvedCommit = "d".repeat(40);
+		},
+		/provenance does not match/,
+	],
+	[
+		"invocation",
+		(result) => {
+			result.invocation.postUploadMonitorMs = 1;
+		},
+		/invocation does not match/,
+	],
+	[
+		"short monitor",
+		(result) => {
+			result.postUploadMonitorDurationMs = 49;
+			result.phaseDurationsMs.postUploadMonitor = 49;
+			result.timestamps.postMonitorFinishedAt = 1169;
+			result.timestamps.downloadStartedAt = 1169;
+			result.timestamps.downloadFinishedAt = 1199;
+		},
+		/outside the requested duration/,
+	],
+	[
+		"long monitor",
+		(result) => {
+			result.postUploadMonitorDurationMs = 1_301;
+			result.phaseDurationsMs.postUploadMonitor = 1_301;
+			result.timestamps.postMonitorFinishedAt = 2_421;
+			result.timestamps.downloadStartedAt = 2_421;
+			result.timestamps.downloadFinishedAt = 2_451;
+		},
+		/outside the requested duration/,
+	],
+	[
+		"post-monitor tolerance",
+		(result) => {
+			result.postUploadMonitorSchedulingToleranceMs += 1;
+		},
+		/monitor scheduling tolerance/,
+	],
+	[
+		"upload timeout",
+		(result) => {
+			result.uploadDurationMs = 605_001;
+			result.phaseDurationsMs.timeToUploadSettled = 605_001;
+			result.phaseDurationsMs.writerListingLag = 0;
+			result.phaseDurationsMs.readerListingLag = 0;
+			result.listingDurationMs = 0;
+			result.timestamps.uploadSettledAt = 606_001;
+			result.timestamps.postMonitorStartedAt = 606_001;
+			result.timestamps.postMonitorFinishedAt = 606_051;
+			result.timestamps.downloadStartedAt = 606_051;
+			result.timestamps.downloadFinishedAt = 606_081;
+		},
+		/requested timeout/,
+	],
+	[
+		"download timeout",
+		(result) => {
+			result.downloadDurationMs = 605_001;
+			result.phaseDurationsMs.download = 605_001;
+			result.timestamps.downloadFinishedAt =
+				result.timestamps.downloadStartedAt + 605_001;
+		},
+		/requested timeout/,
+	],
+	[
+		"transfer tolerance",
+		(result) => {
+			result.transferTimeoutSchedulingToleranceMs += 1;
+		},
+		/transfer scheduling tolerance/,
+	],
+	[
+		"recorded errors",
+		(result) => {
+			result.errors.push("writer:seeder-count:failed");
+		},
+		/recorded errors/,
+	],
+	[
+		"non-numeric seeder sample",
+		(result) => {
+			result.snapshots[0].writerSeeders = "error:failed";
+		},
+		/invalid snapshots\[0\]\.writerSeeders/,
+	],
+	[
+		"missing monitor sample",
+		(result) => {
+			result.snapshots = result.snapshots.filter(
+				(snapshot) => !snapshot.label.startsWith("after-"),
+			);
+		},
+		/missing a numeric post-monitor snapshot/,
+	],
+	[
+		"monitor sample bound",
+		(result) => {
+			result.snapshots[1].at = result.timestamps.postMonitorFinishedAt + 1;
+		},
+		/outside the monitor window/,
+	],
+	[
+		"duplicate sample label",
+		(result) => {
+			result.snapshots[1].label = "seeders-ready";
+		},
+		/labels are invalid or duplicated/,
+	],
+	[
+		"missing ready baseline snapshot",
+		(result) => {
+			result.snapshots = result.snapshots.filter(
+				(snapshot) => snapshot.label !== "seeders-ready",
+			);
+		},
+		/exactly one ready-seeder baseline snapshot/,
+	],
+	[
+		"ready baseline not first",
+		(result) => {
+			result.snapshots.reverse();
+			result.snapshots[0].at = 1130;
+			result.snapshots[1].at = 1140;
+		},
+		/exactly one ready-seeder baseline snapshot/,
+	],
+	[
+		"missing baseline field",
+		(result) => {
+			delete result.baselineWriterSeeders;
+		},
+		/invalid baselineWriterSeeders/,
+	],
+	[
+		"contradictory baseline field",
+		(result) => {
+			result.baselineReaderSeeders = 1;
+		},
+		/baseline fields contradict/,
+	],
+	[
+		"ready baseline below requested minimum",
+		(result) => {
+			result.baselineWriterSeeders = 1;
+			result.snapshots[0].writerSeeders = 1;
+		},
+		/below the requested minimum/,
+	],
+	[
+		"unreported seeder drop",
+		(result) => {
+			result.snapshots[1].writerSeeders = 1;
+		},
+		/droppedSeeders claim contradicts/,
+	],
+	[
+		"unsupported seeder drop claim",
+		(result) => {
+			result.droppedSeeders = true;
+		},
+		/droppedSeeders claim contradicts/,
+	],
+	[
+		"observed seeder drop in passed result",
+		(result) => {
+			result.snapshots[1].readerSeeders = 1;
+			result.droppedSeeders = true;
+		},
+		/contains seeder drops/,
+	],
+]) {
+	test(`rejects invalid ${name}`, () => {
+		const result = validResult();
+		mutate(result);
+		assert.throws(() => validateBenchmarkResult(result, options), pattern);
+	});
+}
+
+const createSeederProbeFixture = () => {
+	const invocation = createBenchmarkInvocation({
+		scenario: "seeder-probe",
+		mode: "adaptive",
+		network: "local",
+		integrationMode: "link",
+		fileMb: FILE_MB,
+		fixtureSeed: "fixture-seed",
+		readyTimeoutMs: 10,
+		sampleMs: 2,
+		sampleCount: 3,
+		targetSeeders: 2,
+	});
+	const seederResult = {
+		schema: { id: "peerbit-file-share-benchmark", version: 2 },
+		runNonce: RUN_NONCE,
+		invocation,
+		provenance: structuredClone(PROVENANCE),
+		status: "passed",
+		mode: "adaptive",
+		networkMode: "local",
+		readyTimeoutMs: 10,
+		sampleMs: 2,
+		sampleCount: 3,
+		targetSeeders: 2,
+		effectiveSampleIntervalMs: 2,
+		sampleCountDefinition: SAMPLE_COUNT_DEFINITION,
+		probeStartedAt: 1000,
+		readyDeadlineAt: 1010,
+		probeFinishedAt: 1002,
+		probeDurationMs: 2,
+		reachedTarget: true,
+		timeToTargetMs: 2,
+		targetSampleLabel: "sample-1",
+		errorCount: 0,
+		errors: [],
+		samples: [
+			{
+				index: 1,
+				label: "sample-1",
+				capturedAt: 1002,
+				elapsedMs: 2,
+				writerSeeders: 3,
+				readerSeeders: 2,
+			},
+		],
+	};
+	const seederOptions = {
+		scenario: "seeder-probe",
+		expectedMode: "adaptive",
+		expectedFileMb: FILE_MB,
+		expectedNetwork: "local",
+		expectedFixtureSeed: "fixture-seed",
+		expectedRunNonce: RUN_NONCE,
+		expectedProvenance: PROVENANCE,
+		expectedInvocation: invocation,
+	};
+	return { seederResult, seederOptions };
+};
+
+test("accepts bounded numeric seeder convergence evidence", () => {
+	const { seederResult, seederOptions } = createSeederProbeFixture();
+	assert.doesNotThrow(() =>
+		validateBenchmarkResult(seederResult, seederOptions),
+	);
+});
+
+test("keeps the non-transfer seeder probe fail closed", () => {
+	const { seederResult, seederOptions } = createSeederProbeFixture();
+	assert.throws(
+		() =>
+			validateBenchmarkResult(
+				{
+					...seederResult,
+					reachedTarget: false,
+				},
+				seederOptions,
+			),
+		/did not reach/,
+	);
+	assert.throws(
+		() =>
+			validateBenchmarkResult(
+				{
+					...seederResult,
+					runNonce: "223e4567-e89b-42d3-a456-426614174000",
+				},
+				seederOptions,
+			),
+		/run nonce/,
+	);
+});
+
+for (const [name, mutate, pattern] of [
+	[
+		"target counts",
+		(result) => {
+			result.samples[0].writerSeeders = 1;
+		},
+		/target evidence/,
+	],
+	[
+		"inflated time to target",
+		(result) => {
+			result.samples.push({
+				index: 2,
+				label: "sample-2",
+				capturedAt: 1004,
+				elapsedMs: 4,
+				writerSeeders: 3,
+				readerSeeders: 2,
+			});
+			result.targetSampleLabel = "sample-2";
+			result.probeFinishedAt = 1004;
+			result.probeDurationMs = 4;
+			result.timeToTargetMs = 4;
+		},
+		/first observed target/,
+	],
+	[
+		"target arithmetic",
+		(result) => {
+			result.timeToTargetMs = 1;
+		},
+		/deadline\/duration arithmetic/,
+	],
+	[
+		"deadline arithmetic",
+		(result) => {
+			result.readyDeadlineAt += 1;
+		},
+		/deadline\/duration arithmetic/,
+	],
+	[
+		"deadline bound",
+		(result) => {
+			result.probeFinishedAt = 1011;
+			result.probeDurationMs = 11;
+			result.timeToTargetMs = 11;
+			result.samples[0].capturedAt = 1011;
+			result.samples[0].elapsedMs = 11;
+		},
+		/deadline\/duration arithmetic/,
+	],
+	[
+		"numeric sample count",
+		(result) => {
+			result.samples[0].readerSeeders = "2";
+		},
+		/invalid samples\[0\]\.readerSeeders/,
+	],
+	[
+		"monotonic sample time",
+		(result) => {
+			result.samples.unshift({
+				index: 1,
+				label: "sample-1",
+				capturedAt: 1003,
+				elapsedMs: 3,
+				writerSeeders: 1,
+				readerSeeders: 1,
+			});
+			result.samples[1].index = 2;
+			result.samples[1].label = "sample-2";
+			result.targetSampleLabel = "sample-2";
+		},
+		/not monotonic and bounded/,
+	],
+	[
+		"sample labels",
+		(result) => {
+			result.samples[0].label = "target";
+			result.targetSampleLabel = "target";
+		},
+		/labels or indices/,
+	],
+	[
+		"sample-count semantics",
+		(result) => {
+			result.effectiveSampleIntervalMs = 3;
+		},
+		/effective sample interval/,
+	],
+	[
+		"seeder errors",
+		(result) => {
+			result.errors.push("reader:seeder-count:failed");
+		},
+		/recorded errors/,
+	],
+]) {
+	test(`rejects invalid seeder ${name}`, () => {
+		const { seederResult, seederOptions } = createSeederProbeFixture();
+		mutate(seederResult);
+		assert.throws(
+			() => validateBenchmarkResult(seederResult, seederOptions),
+			pattern,
+		);
+	});
+}

--- a/scripts/file-share/common.mjs
+++ b/scripts/file-share/common.mjs
@@ -12,7 +12,13 @@ export const repoRoot = path.resolve(__dirname, "..", "..");
 
 export const defaultExamplesSource = () => {
 	const sibling = path.resolve(repoRoot, "..", "peerbit-examples");
-	if (fs.existsSync(sibling)) {
+	if (
+		fs.existsSync(path.join(sibling, "package.json")) &&
+		fs.existsSync(path.join(sibling, "pnpm-lock.yaml")) &&
+		fs.existsSync(
+			path.join(sibling, "packages", "file-share", "frontend", "package.json"),
+		)
+	) {
 		return sibling;
 	}
 	return "https://github.com/dao-xyz/peerbit-examples.git";
@@ -30,10 +36,8 @@ export const defaultFileShareLocalPackages = [
 	"@peerbit/shared-log",
 	"@peerbit/stream",
 	"@peerbit/react",
-	"@peerbit/crypto",
 	"@peerbit/trusted-network",
 	"@peerbit/vite",
-	"@peerbit/test-utils",
 ];
 
 const BOOLEAN_ARGS = new Set([
@@ -42,6 +46,9 @@ const BOOLEAN_ARGS = new Set([
 	"build-peerbit",
 	"fresh-each-run",
 	"isolated-examples",
+	"enable-visibility-probe",
+	"verbose",
+	"require-clean-peerbit",
 ]);
 
 export const parseArgs = (argv) => {
@@ -81,6 +88,56 @@ export const run = (command, args, options = {}) => {
 		},
 	});
 };
+
+const removeNodeModulesTrees = async (root) => {
+	const entries = await fsp.readdir(root, { withFileTypes: true });
+	await Promise.all(
+		entries.map(async (entry) => {
+			const entryPath = path.join(root, entry.name);
+			if (entry.name === "node_modules") {
+				await fsp.rm(entryPath, { recursive: true, force: true });
+				return;
+			}
+			if (entry.name === ".git" || !entry.isDirectory()) {
+				return;
+			}
+			await removeNodeModulesTrees(entryPath);
+		}),
+	);
+};
+
+export const installPinnedExamplesDependencies = async (examplesRoot) => {
+	for (const required of ["package.json", "pnpm-lock.yaml"]) {
+		if (!fs.existsSync(path.join(examplesRoot, required))) {
+			throw new Error(
+				`Cannot install pinned examples dependencies: missing ${required} in ${examplesRoot}`,
+			);
+		}
+	}
+	await removeNodeModulesTrees(examplesRoot);
+	run("pnpm", ["install", "--frozen-lockfile"], { cwd: examplesRoot });
+	if (!fs.existsSync(path.join(examplesRoot, "node_modules"))) {
+		throw new Error(
+			`Pinned examples install did not produce ${path.join(examplesRoot, "node_modules")}`,
+		);
+	}
+};
+
+export const buildPeerbitPackages = (peerbitRoot, packageNames) => {
+	if (!Array.isArray(packageNames) || packageNames.length === 0) {
+		throw new Error("A clean Peerbit build requires at least one package");
+	}
+	run(
+		"pnpm",
+		[...packageNames.flatMap((name) => ["--filter", `${name}...`]), "build"],
+		{ cwd: peerbitRoot },
+	);
+};
+
+export const getFileShareConsumerRoots = (examplesRoot) => [
+	path.join(examplesRoot, "packages", "file-share", "frontend"),
+	path.join(examplesRoot, "packages", "file-share", "library"),
+];
 
 const walkPackageJsonFiles = async (root) => {
 	const pending = [path.join(root, "packages")];
@@ -138,8 +195,11 @@ const expandWorkspacePackageSelection = ({
 	selectedNames,
 	includeTransitive = true,
 }) => {
-	if (!selectedNames || selectedNames.size === 0) {
+	if (selectedNames == null) {
 		return new Set(workspacePackages.keys());
+	}
+	if (selectedNames.size === 0) {
+		return new Set();
 	}
 	if (!includeTransitive) {
 		return new Set(
@@ -179,9 +239,31 @@ export const collectLocalPeerbitPackages = async (
 ) => {
 	const workspacePackages = await loadWorkspacePeerbitPackages(peerbitRoot);
 	const mappings = new Map();
-	const selectedNames = Array.isArray(options.names)
-		? new Set(options.names)
+	const normalizedNames = Array.isArray(options.names)
+		? options.names.map((name) => {
+				if (typeof name !== "string" || name.trim().length === 0) {
+					throw new Error("Local package names must be non-empty strings");
+				}
+				return name.trim();
+			})
 		: undefined;
+	if (
+		normalizedNames &&
+		new Set(normalizedNames).size !== normalizedNames.length
+	) {
+		throw new Error("Duplicate local Peerbit package names are not allowed");
+	}
+	const selectedNames = normalizedNames ? new Set(normalizedNames) : undefined;
+	if (selectedNames) {
+		const unknownNames = [...selectedNames]
+			.filter((name) => !workspacePackages.has(name))
+			.sort((left, right) => left.localeCompare(right));
+		if (unknownNames.length > 0) {
+			throw new Error(
+				`Unknown local Peerbit package${unknownNames.length === 1 ? "" : "s"}: ${unknownNames.join(", ")}`,
+			);
+		}
+	}
 	const expandedSelection = expandWorkspacePackageSelection({
 		workspacePackages,
 		selectedNames,
@@ -193,46 +275,91 @@ export const collectLocalPeerbitPackages = async (
 		}
 		mappings.set(name, info.dir);
 	}
-	return new Map([...mappings.entries()].sort(([a], [b]) => a.localeCompare(b)));
+	return new Map(
+		[...mappings.entries()].sort(([a], [b]) => a.localeCompare(b)),
+	);
 };
 
-const getInstalledPackagePath = ({ root, packageName }) => {
-	if (packageName === "peerbit") {
-		return path.join(root, "node_modules", "peerbit");
-	}
-	const [scope, name] = packageName.split("/");
-	if (!scope || !name) {
-		throw new Error(`Unsupported package name "${packageName}"`);
-	}
-	return path.join(root, "node_modules", scope, name);
-};
-
-export const ensureExamplesAssetPackageLinks = async ({
-	examplesRoot,
+export const cleanPeerbitBuildArtifacts = async ({
 	peerbitRoot = repoRoot,
 	packageNames,
 }) => {
 	const localPackages = await collectLocalPeerbitPackages(peerbitRoot, {
 		names: packageNames,
 	});
-	const nodeModulesDir = path.join(examplesRoot, "node_modules");
-	const scopedDir = path.join(nodeModulesDir, "@peerbit");
-	await fsp.mkdir(scopedDir, { recursive: true });
-
-	for (const [packageName, packageDir] of localPackages) {
-		const linkPath =
-			packageName === "peerbit"
-				? path.join(nodeModulesDir, "peerbit")
-				: path.join(scopedDir, packageName.split("/")[1]);
-		const existing = await fsp.lstat(linkPath).catch(() => undefined);
-		if (existing) {
-			await fsp.rm(linkPath, {
+	await Promise.all(
+		[...localPackages.values()].map((packageDir) =>
+			fsp.rm(path.join(packageDir, "dist"), {
 				recursive: true,
 				force: true,
-			});
+			}),
+		),
+	);
+	return localPackages;
+};
+
+export const ensureExamplesAssetPackageLinks = async ({
+	examplesRoot,
+	peerbitRoot = repoRoot,
+	packageNames,
+	consumerRoots = [],
+}) => {
+	const localPackages = await collectLocalPeerbitPackages(peerbitRoot, {
+		names: packageNames,
+	});
+	for (const [packageName, packageDir] of localPackages) {
+		const builtDistPath = path.join(packageDir, "dist");
+		const builtDist = await fsp.stat(builtDistPath).catch(() => undefined);
+		if (!builtDist?.isDirectory()) {
+			throw new Error(
+				`Cannot link ${packageName}: the mandatory clean build did not produce ${builtDistPath}`,
+			);
 		}
-		await fsp.symlink(packageDir, linkPath, "dir");
 	}
+
+	const examplesRealPath = await fsp.realpath(examplesRoot);
+	const linkRoots = [examplesRoot, ...consumerRoots].map((root) =>
+		path.resolve(root),
+	);
+	for (const consumerRoot of linkRoots.slice(1)) {
+		const consumerRealPath = await fsp.realpath(consumerRoot);
+		const relative = path.relative(examplesRealPath, consumerRealPath);
+		if (relative === ".." || relative.startsWith(`..${path.sep}`)) {
+			throw new Error(
+				`Refusing to install benchmark package links outside ${examplesRealPath}: ${consumerRealPath}`,
+			);
+		}
+	}
+
+	for (const linkRoot of [...new Set(linkRoots)]) {
+		const nodeModulesDir = path.join(linkRoot, "node_modules");
+		const scopedDir = path.join(nodeModulesDir, "@peerbit");
+		await fsp.mkdir(scopedDir, { recursive: true });
+		for (const [packageName, packageDir] of localPackages) {
+			const linkPath =
+				packageName === "peerbit"
+					? path.join(nodeModulesDir, "peerbit")
+					: path.join(scopedDir, packageName.split("/")[1]);
+			const existing = await fsp.lstat(linkPath).catch(() => undefined);
+			if (existing) {
+				await fsp.rm(linkPath, {
+					recursive: true,
+					force: true,
+				});
+			}
+			await fsp.symlink(packageDir, linkPath, "dir");
+			const [linkedRealPath, packageRealPath] = await Promise.all([
+				fsp.realpath(linkPath),
+				fsp.realpath(packageDir),
+			]);
+			if (linkedRealPath !== packageRealPath) {
+				throw new Error(
+					`Linked package ${packageName} resolved to ${linkedRealPath}, not ${packageRealPath}`,
+				);
+			}
+		}
+	}
+	return localPackages;
 };
 
 const copyExamplesTemplate = async ({ template, dest }) => {
@@ -248,6 +375,9 @@ const copyExamplesTemplate = async ({ template, dest }) => {
 				"(",
 				"-name",
 				".git",
+				"-o",
+				"-name",
+				"node_modules",
 				"-o",
 				"-name",
 				"test-results",
@@ -270,6 +400,7 @@ const copyExamplesTemplate = async ({ template, dest }) => {
 		return;
 	} catch {
 		// Fall back to a filtered recursive copy on platforms without clonefile support.
+		await fsp.rm(dest, { recursive: true, force: true });
 	}
 	await fsp.cp(template, dest, {
 		recursive: true,
@@ -282,6 +413,7 @@ const copyExamplesTemplate = async ({ template, dest }) => {
 			return !segments.some((segment) =>
 				[
 					".git",
+					"node_modules",
 					"test-results",
 					"playwright-report",
 					".playwright-artifacts-0",
@@ -291,15 +423,33 @@ const copyExamplesTemplate = async ({ template, dest }) => {
 	});
 };
 
-const cloneExamplesRepo = async ({ source, dest, fresh }) => {
+const resolveCommit = (root, ref) =>
+	execFileSync("git", ["rev-parse", "--verify", `${ref}^{commit}`], {
+		cwd: root,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	}).trim();
+
+const cloneExamplesRepo = async ({ source, dest, fresh, ref = "HEAD" }) => {
 	if (fresh && fs.existsSync(dest)) {
 		await fsp.rm(dest, { recursive: true, force: true });
 	}
 	if (fs.existsSync(dest)) {
+		if (fs.existsSync(path.join(dest, ".git"))) {
+			const currentCommit = resolveCommit(dest, "HEAD");
+			const requestedCommit = resolveCommit(dest, ref);
+			if (currentCommit !== requestedCommit) {
+				throw new Error(
+					`Existing examples checkout is ${currentCommit}, not requested ${ref} (${requestedCommit}); rerun with --fresh`,
+				);
+			}
+		}
 		return;
 	}
 	await fsp.mkdir(path.dirname(dest), { recursive: true });
-	run("git", ["clone", "--depth", "1", source, dest]);
+	run("git", ["clone", "--no-checkout", source, dest]);
+	const commit = resolveCommit(dest, ref);
+	run("git", ["checkout", "--detach", commit], { cwd: dest });
 };
 
 export const prepareExamplesRepo = async ({
@@ -311,6 +461,7 @@ export const prepareExamplesRepo = async ({
 	install = false,
 	localPackageNames,
 	applyOverrides = true,
+	ref = "HEAD",
 } = {}) => {
 	if (fresh && fs.existsSync(dest)) {
 		await fsp.rm(dest, { recursive: true, force: true });
@@ -319,8 +470,14 @@ export const prepareExamplesRepo = async ({
 		if (template) {
 			await copyExamplesTemplate({ template, dest });
 		} else {
-			await cloneExamplesRepo({ source, dest, fresh: false });
+			await cloneExamplesRepo({ source, dest, fresh: false, ref });
 		}
+	} else if (template) {
+		throw new Error(
+			"A template-backed examples checkout must be recreated with --fresh so its pinned source cannot be confused with stale files",
+		);
+	} else {
+		await cloneExamplesRepo({ source, dest, fresh: false, ref });
 	}
 
 	const allLocalPackages = await collectLocalPeerbitPackages(peerbitRoot);
@@ -329,28 +486,31 @@ export const prepareExamplesRepo = async ({
 				names: localPackageNames,
 			})
 		: allLocalPackages;
-	const packageJsonPath = path.join(dest, "package.json");
-	const packageJson = JSON.parse(await fsp.readFile(packageJsonPath, "utf8"));
-	const currentOverrides = packageJson?.pnpm?.overrides ?? {};
-	const nextOverrides = { ...currentOverrides };
-	for (const name of allLocalPackages.keys()) {
-		delete nextOverrides[name];
-	}
 	if (applyOverrides) {
+		const packageJsonPath = path.join(dest, "package.json");
+		const packageJson = JSON.parse(await fsp.readFile(packageJsonPath, "utf8"));
+		const currentOverrides = packageJson?.pnpm?.overrides ?? {};
+		const nextOverrides = { ...currentOverrides };
+		for (const name of allLocalPackages.keys()) {
+			delete nextOverrides[name];
+		}
 		for (const [name, packageDir] of localPackages) {
 			nextOverrides[name] = `link:${packageDir}`;
 		}
-	}
-	packageJson.pnpm = packageJson.pnpm ?? {};
-	packageJson.pnpm.overrides = Object.fromEntries(
-		Object.entries(nextOverrides).sort(([a], [b]) => a.localeCompare(b)),
-	);
-	await fsp.writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 4)}\n`);
-	const patchesDir = path.join(dest, "patches");
-	if (fs.existsSync(patchesDir)) {
-		for (const entry of await fsp.readdir(patchesDir)) {
-			if (/^@peerbit\+shared-log\+.*\.patch$/.test(entry)) {
-				await fsp.rm(path.join(patchesDir, entry), { force: true });
+		packageJson.pnpm = packageJson.pnpm ?? {};
+		packageJson.pnpm.overrides = Object.fromEntries(
+			Object.entries(nextOverrides).sort(([a], [b]) => a.localeCompare(b)),
+		);
+		await fsp.writeFile(
+			packageJsonPath,
+			`${JSON.stringify(packageJson, null, 4)}\n`,
+		);
+		const patchesDir = path.join(dest, "patches");
+		if (fs.existsSync(patchesDir)) {
+			for (const entry of await fsp.readdir(patchesDir)) {
+				if (/^@peerbit\+shared-log\+.*\.patch$/.test(entry)) {
+					await fsp.rm(path.join(patchesDir, entry), { force: true });
+				}
 			}
 		}
 	}
@@ -363,6 +523,7 @@ export const prepareExamplesRepo = async ({
 				peerbitRoot,
 				source,
 				template,
+				ref,
 				packages: Object.fromEntries(localPackages),
 			},
 			null,
@@ -371,7 +532,11 @@ export const prepareExamplesRepo = async ({
 	);
 
 	if (install) {
-		run("pnpm", ["install"], { cwd: dest });
+		if (applyOverrides) {
+			run("pnpm", ["install"], { cwd: dest });
+		} else {
+			await installPinnedExamplesDependencies(dest);
+		}
 	}
 
 	return {
@@ -382,46 +547,11 @@ export const prepareExamplesRepo = async ({
 	};
 };
 
-export const overlayInstalledPackages = async ({
-	examplesRoot,
-	peerbitRoot = repoRoot,
-	packageNames,
+export const copyTemplate = async ({
+	templatePath,
+	outputPath,
+	replacements = {},
 }) => {
-	const skipMissing = !Array.isArray(packageNames);
-	const localPackages = await collectLocalPeerbitPackages(peerbitRoot, {
-		names: packageNames,
-	});
-	for (const [packageName, packageDir] of localPackages) {
-		const installedPackagePath = getInstalledPackagePath({
-			root: examplesRoot,
-			packageName,
-		});
-		if (!fs.existsSync(installedPackagePath)) {
-			if (skipMissing) {
-				continue;
-			}
-			throw new Error(
-				`Cannot overlay ${packageName}: missing installed package at ${installedPackagePath}`,
-			);
-		}
-		const installedRealPath = await fsp.realpath(installedPackagePath);
-		const packageRealPath = await fsp.realpath(packageDir);
-		if (installedRealPath === packageRealPath) {
-			continue;
-		}
-		for (const entry of ["dist", "src"]) {
-			const sourcePath = path.join(packageDir, entry);
-			if (!fs.existsSync(sourcePath)) {
-				continue;
-			}
-			const destPath = path.join(installedPackagePath, entry);
-			await fsp.rm(destPath, { recursive: true, force: true });
-			await fsp.cp(sourcePath, destPath, { recursive: true });
-		}
-	}
-};
-
-export const copyTemplate = async ({ templatePath, outputPath, replacements = {} }) => {
 	let contents = await fsp.readFile(templatePath, "utf8");
 	for (const [pattern, replacement] of Object.entries(replacements)) {
 		contents = contents.replaceAll(pattern, replacement);

--- a/scripts/file-share/common.test.mjs
+++ b/scripts/file-share/common.test.mjs
@@ -1,0 +1,258 @@
+import assert from "node:assert/strict";
+import {
+	lstat,
+	mkdir,
+	mkdtemp,
+	readFile,
+	realpath,
+	rm,
+	writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+	cleanPeerbitBuildArtifacts,
+	collectLocalPeerbitPackages,
+	ensureExamplesAssetPackageLinks,
+	prepareExamplesRepo,
+} from "./common.mjs";
+
+const createFixture = async () => {
+	const root = await mkdtemp(path.join(os.tmpdir(), "peerbit-link-test-"));
+	const packageDir = path.join(root, "packages", "peerbit");
+	const installedDir = path.join(root, "examples", "node_modules", "peerbit");
+	const consumerRoot = path.join(
+		root,
+		"examples",
+		"packages",
+		"file-share",
+		"frontend",
+	);
+	const consumerInstalledDir = path.join(
+		consumerRoot,
+		"node_modules",
+		"peerbit",
+	);
+	await mkdir(path.join(packageDir, "dist"), { recursive: true });
+	await mkdir(path.join(packageDir, "src"), { recursive: true });
+	await mkdir(path.join(installedDir, "dist"), { recursive: true });
+	await mkdir(path.join(consumerInstalledDir, "dist"), { recursive: true });
+	await writeFile(
+		path.join(packageDir, "package.json"),
+		'{"name":"peerbit","dependencies":{}}\n',
+	);
+	await writeFile(path.join(packageDir, "dist", "index.js"), "current\n");
+	await writeFile(path.join(packageDir, "src", "index.ts"), "current source\n");
+	await writeFile(path.join(installedDir, "dist", "index.js"), "stale\n");
+	await writeFile(
+		path.join(consumerInstalledDir, "dist", "index.js"),
+		"nested stale\n",
+	);
+	return {
+		root,
+		packageDir,
+		installedDir,
+		consumerRoot,
+		consumerInstalledDir,
+	};
+};
+
+test("links refuse stale artifacts and resolve to the clean-built package", async () => {
+	const fixture = await createFixture();
+	try {
+		await cleanPeerbitBuildArtifacts({
+			peerbitRoot: fixture.root,
+			packageNames: ["peerbit"],
+		});
+		await assert.rejects(
+			ensureExamplesAssetPackageLinks({
+				examplesRoot: path.join(fixture.root, "examples"),
+				peerbitRoot: fixture.root,
+				packageNames: ["peerbit"],
+				consumerRoots: [fixture.consumerRoot],
+			}),
+			/mandatory clean build did not produce/,
+		);
+		await mkdir(path.join(fixture.packageDir, "dist"), { recursive: true });
+		await writeFile(
+			path.join(fixture.packageDir, "dist", "index.js"),
+			"clean build\n",
+		);
+		await ensureExamplesAssetPackageLinks({
+			examplesRoot: path.join(fixture.root, "examples"),
+			peerbitRoot: fixture.root,
+			packageNames: ["peerbit"],
+			consumerRoots: [fixture.consumerRoot],
+		});
+		assert.equal((await lstat(fixture.installedDir)).isSymbolicLink(), true);
+		assert.equal(
+			await realpath(fixture.installedDir),
+			await realpath(fixture.packageDir),
+		);
+		assert.equal(
+			await readFile(
+				path.join(fixture.installedDir, "dist", "index.js"),
+				"utf8",
+			),
+			"clean build\n",
+		);
+		assert.equal(
+			await realpath(fixture.consumerInstalledDir),
+			await realpath(fixture.packageDir),
+		);
+	} finally {
+		await rm(fixture.root, { recursive: true, force: true });
+	}
+});
+
+test("local package selection is exact and rejects unknown names", async () => {
+	const fixture = await createFixture();
+	try {
+		assert.deepEqual(
+			[
+				...(
+					await collectLocalPeerbitPackages(fixture.root, { names: [] })
+				).keys(),
+			],
+			[],
+		);
+		assert.deepEqual(
+			[
+				...(
+					await collectLocalPeerbitPackages(fixture.root, {
+						names: ["peerbit"],
+					})
+				).keys(),
+			],
+			["peerbit"],
+		);
+		await assert.rejects(
+			collectLocalPeerbitPackages(fixture.root, {
+				names: ["@peerbit/not-a-real-package"],
+			}),
+			/Unknown local Peerbit package: @peerbit\/not-a-real-package/,
+		);
+		await assert.rejects(
+			collectLocalPeerbitPackages(fixture.root, {
+				names: ["peerbit", "peerbit"],
+			}),
+			/Duplicate local Peerbit package names/,
+		);
+	} finally {
+		await rm(fixture.root, { recursive: true, force: true });
+	}
+});
+
+test("link preflight leaves every installed package untouched when a later build artifact is missing", async () => {
+	const fixture = await createFixture();
+	const documentPackageDir = path.join(fixture.root, "packages", "document");
+	const installedDocumentDir = path.join(
+		fixture.root,
+		"examples",
+		"node_modules",
+		"@peerbit",
+		"document",
+	);
+	try {
+		await mkdir(path.join(documentPackageDir, "dist"), { recursive: true });
+		await mkdir(path.join(installedDocumentDir, "dist"), { recursive: true });
+		await writeFile(
+			path.join(documentPackageDir, "package.json"),
+			'{"name":"@peerbit/document","dependencies":{}}\n',
+		);
+		await writeFile(
+			path.join(documentPackageDir, "dist", "index.js"),
+			"current document\n",
+		);
+		await writeFile(
+			path.join(installedDocumentDir, "dist", "index.js"),
+			"stale document\n",
+		);
+		await writeFile(
+			path.join(fixture.packageDir, "package.json"),
+			'{"name":"peerbit","dependencies":{"@peerbit/document":"workspace:*"}}\n',
+		);
+		await rm(path.join(fixture.packageDir, "dist"), {
+			recursive: true,
+			force: true,
+		});
+		await assert.rejects(
+			ensureExamplesAssetPackageLinks({
+				examplesRoot: path.join(fixture.root, "examples"),
+				peerbitRoot: fixture.root,
+				packageNames: ["peerbit"],
+			}),
+			/mandatory clean build did not produce/,
+		);
+		assert.equal((await lstat(installedDocumentDir)).isDirectory(), true);
+		assert.equal(
+			await readFile(
+				path.join(installedDocumentDir, "dist", "index.js"),
+				"utf8",
+			),
+			"stale document\n",
+		);
+	} finally {
+		await rm(fixture.root, { recursive: true, force: true });
+	}
+});
+
+test("no-override preparation preserves the pinned dependency graph byte-for-byte", async () => {
+	const root = await mkdtemp(path.join(os.tmpdir(), "peerbit-prepare-test-"));
+	const peerbitRoot = path.join(root, "core");
+	const template = path.join(root, "template");
+	const dest = path.join(root, "prepared");
+	const packageJson =
+		'{"name":"examples","pnpm":{"overrides":{"peerbit":"5.3.3"}}}\n';
+	const lockfile = "lockfileVersion: '9.0'\n\nimporters: {}\n";
+	const patch = "pinned patch bytes\n";
+	try {
+		await mkdir(path.join(peerbitRoot, "packages", "peerbit"), {
+			recursive: true,
+		});
+		await writeFile(
+			path.join(peerbitRoot, "packages", "peerbit", "package.json"),
+			'{"name":"peerbit","dependencies":{}}\n',
+		);
+		await mkdir(path.join(template, "patches"), { recursive: true });
+		await mkdir(path.join(template, "node_modules", "stale"), {
+			recursive: true,
+		});
+		await writeFile(path.join(template, "package.json"), packageJson);
+		await writeFile(path.join(template, "pnpm-lock.yaml"), lockfile);
+		await writeFile(
+			path.join(template, "patches", "@peerbit+shared-log+1.0.0.patch"),
+			patch,
+		);
+		await writeFile(
+			path.join(template, "node_modules", "stale", "index.js"),
+			"stale install\n",
+		);
+		await prepareExamplesRepo({
+			template,
+			dest,
+			peerbitRoot,
+			localPackageNames: ["peerbit"],
+			applyOverrides: false,
+		});
+		assert.equal(
+			await readFile(path.join(dest, "package.json"), "utf8"),
+			packageJson,
+		);
+		assert.equal(
+			await readFile(path.join(dest, "pnpm-lock.yaml"), "utf8"),
+			lockfile,
+		);
+		assert.equal(
+			await readFile(
+				path.join(dest, "patches", "@peerbit+shared-log+1.0.0.patch"),
+				"utf8",
+			),
+			patch,
+		);
+		await assert.rejects(lstat(path.join(dest, "node_modules")), /ENOENT/);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});

--- a/scripts/file-share/matrix-variants.mjs
+++ b/scripts/file-share/matrix-variants.mjs
@@ -1,0 +1,251 @@
+import { randomUUID } from "node:crypto";
+import fsp from "node:fs/promises";
+import path from "node:path";
+
+const LABEL_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+const UUID_PATTERN =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const MATRIX_SESSION_MARKER = ".peerbit-file-share-matrix-session.json";
+
+const isInside = (parent, candidate) => {
+	const relative = path.relative(parent, candidate);
+	return (
+		relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative)
+	);
+};
+
+export const createExclusiveMatrixSession = async ({
+	baseDir,
+	repoRoot,
+	nonce = randomUUID(),
+	now = new Date(),
+}) => {
+	if (!UUID_PATTERN.test(nonce)) {
+		throw new Error("Matrix session nonce must be a UUID");
+	}
+	const requestedBase = path.resolve(baseDir);
+	if (requestedBase === path.parse(requestedBase).root) {
+		throw new Error("Refusing to use a filesystem root as the matrix base");
+	}
+	const requestedRepository = path.resolve(repoRoot);
+	if (
+		requestedBase === requestedRepository ||
+		isInside(requestedRepository, requestedBase)
+	) {
+		throw new Error(
+			"Refusing to create matrix output inside the Peerbit worktree",
+		);
+	}
+	await fsp.mkdir(requestedBase, { recursive: true });
+	const [matrixBase, repository] = await Promise.all([
+		fsp.realpath(requestedBase),
+		fsp.realpath(repoRoot),
+	]);
+	if (matrixBase === repository || isInside(repository, matrixBase)) {
+		throw new Error(
+			"Refusing to create matrix output inside the Peerbit worktree",
+		);
+	}
+	const timestamp = now.toISOString().replaceAll(":", "-").replaceAll(".", "-");
+	const matrixRoot = path.join(
+		matrixBase,
+		`peerbit-file-share-matrix-${timestamp}-${nonce}`,
+	);
+	await fsp.mkdir(matrixRoot, { recursive: false });
+	const markerFile = path.join(matrixRoot, MATRIX_SESSION_MARKER);
+	await fsp.writeFile(
+		markerFile,
+		`${JSON.stringify(
+			{
+				schema: {
+					id: "peerbit-file-share-matrix-session",
+					version: 1,
+				},
+				nonce,
+				createdAt: now.toISOString(),
+				matrixRoot,
+			},
+			null,
+			2,
+		)}\n`,
+		{ flag: "wx" },
+	);
+	return { matrixBase, matrixRoot, nonce, markerFile };
+};
+
+const parseToken = (token) => {
+	if (token === "current") {
+		return { name: "current", kind: "worktree" };
+	}
+	if (token === "head") {
+		return { name: "head", kind: "ref", ref: "HEAD" };
+	}
+	const separator = token.indexOf("=");
+	if (separator < 1 || separator === token.length - 1) {
+		const downstreamHint =
+			token === "downstream"
+				? ' Use an explicit real ref such as "downstream=origin/my-branch".'
+				: "";
+		throw new Error(
+			`Invalid matrix variant "${token}". Expected current, head, or name=git-ref.${downstreamHint}`,
+		);
+	}
+	const name = token.slice(0, separator).trim();
+	const ref = token.slice(separator + 1).trim();
+	if (!LABEL_PATTERN.test(name)) {
+		throw new Error(`Invalid matrix variant label "${name}"`);
+	}
+	if (ref.length === 0 || ref.startsWith("-") || /\s/.test(ref)) {
+		throw new Error(`Invalid git ref for matrix variant "${name}"`);
+	}
+	return { name, kind: "ref", ref };
+};
+
+export const assertMatrixIntegrationMode = (integrationMode) => {
+	if (integrationMode !== "link") {
+		throw new Error(
+			`A core ref matrix requires --integration-mode link; "${String(integrationMode)}" cannot preserve the selected Peerbit dependency graph`,
+		);
+	}
+	return integrationMode;
+};
+
+export const assertMatrixPackageRequest = ({
+	requestedNames,
+	requiredNames,
+}) => {
+	if (requestedNames == null) {
+		return;
+	}
+	if (
+		!Array.isArray(requestedNames) ||
+		requestedNames.some(
+			(name) => typeof name !== "string" || name.length === 0,
+		) ||
+		new Set(requestedNames).size !== requestedNames.length
+	) {
+		throw new Error(
+			"--local-packages must contain unique, non-empty package names",
+		);
+	}
+	const missingRequiredPackages = requiredNames.filter(
+		(name) => !requestedNames.includes(name),
+	);
+	if (missingRequiredPackages.length > 0) {
+		throw new Error(
+			`Matrix package selection is missing required file-share packages: ${missingRequiredPackages.join(", ")}`,
+		);
+	}
+};
+
+export const normalizeVariantSpecs = (value) => {
+	const tokens = (value ?? "baseline=origin/master")
+		.split(",")
+		.map((item) => item.trim())
+		.filter(Boolean);
+	if (tokens.length === 0) {
+		throw new Error("At least one matrix variant is required");
+	}
+	const specs = tokens.map(parseToken);
+	const names = new Set();
+	for (const spec of specs) {
+		if (names.has(spec.name)) {
+			throw new Error(`Duplicate matrix variant label "${spec.name}"`);
+		}
+		names.add(spec.name);
+	}
+	return specs;
+};
+
+export const assertUniqueResolvedVariantCommits = (specs) => {
+	const commits = new Map();
+	for (const spec of specs) {
+		if (!/^[0-9a-f]{40}$/.test(spec.resolvedCommit ?? "")) {
+			throw new Error(`Variant "${spec.name}" has no resolved git commit`);
+		}
+		const existing = commits.get(spec.resolvedCommit);
+		if (existing) {
+			throw new Error(
+				`Matrix variants "${existing}" and "${spec.name}" both resolve to ${spec.resolvedCommit}`,
+			);
+		}
+		commits.set(spec.resolvedCommit, spec.name);
+	}
+	return specs;
+};
+
+export const createVariantMaterializationPlan = ({
+	variantSpec,
+	variantRoot,
+}) => {
+	if (!variantSpec || !["worktree", "ref"].includes(variantSpec.kind)) {
+		throw new Error(
+			"Variant materialization requires a worktree or ref variant",
+		);
+	}
+	if (!/^[0-9a-f]{40}$/.test(variantSpec.resolvedCommit ?? "")) {
+		throw new Error("Variant materialization requires a resolved git commit");
+	}
+	if (typeof variantRoot !== "string" || variantRoot.length === 0) {
+		throw new Error("Variant materialization requires an isolated destination");
+	}
+	if (variantSpec.kind === "ref" && !variantSpec.ref) {
+		throw new Error("Ref variant materialization requires its requested ref");
+	}
+	return {
+		cloneCommit: variantSpec.resolvedCommit,
+		peerbitRoot: path.resolve(variantRoot),
+		requestedRef:
+			variantSpec.kind === "worktree" ? "worktree" : variantSpec.ref,
+		sourceWorktreeMustBeClean: variantSpec.kind === "worktree",
+	};
+};
+
+export const createCounterbalancedInvocationPlan = ({
+	variants,
+	modes,
+	runs,
+}) => {
+	if (!Array.isArray(variants) || variants.length === 0) {
+		throw new Error("Counterbalanced plan requires at least one variant");
+	}
+	if (!Array.isArray(modes) || modes.length === 0) {
+		throw new Error("Counterbalanced plan requires at least one mode");
+	}
+	if (!Number.isSafeInteger(runs) || runs <= 0) {
+		throw new Error("Counterbalanced plan requires a positive run count");
+	}
+	const plan = [];
+	let sequence = 0;
+	for (let run = 1; run <= runs; run++) {
+		const round = run - 1;
+		const offset = round % variants.length;
+		let variantOrder = [
+			...variants.slice(offset),
+			...variants.slice(0, offset),
+		];
+		if (Math.floor(round / variants.length) % 2 === 1) {
+			variantOrder = variantOrder.toReversed();
+		}
+		for (let lap = 0; lap < modes.length; lap++) {
+			for (let position = 0; position < variantOrder.length; position++) {
+				const modeIndex = (lap + position + round) % modes.length;
+				plan.push({
+					sequence: ++sequence,
+					run,
+					variant: variantOrder[position],
+					mode: modes[modeIndex],
+				});
+			}
+		}
+	}
+	return plan;
+};
+
+export const createCounterbalancedModePlan = ({ modes, runs }) =>
+	createCounterbalancedInvocationPlan({
+		variants: ["standalone"],
+		modes,
+		runs,
+	}).map(({ sequence, run, mode }) => ({ sequence, run, mode }));

--- a/scripts/file-share/matrix-variants.test.mjs
+++ b/scripts/file-share/matrix-variants.test.mjs
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, realpath, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+	MATRIX_SESSION_MARKER,
+	assertMatrixIntegrationMode,
+	assertMatrixPackageRequest,
+	assertUniqueResolvedVariantCommits,
+	createCounterbalancedInvocationPlan,
+	createCounterbalancedModePlan,
+	createExclusiveMatrixSession,
+	createVariantMaterializationPlan,
+	normalizeVariantSpecs,
+} from "./matrix-variants.mjs";
+
+test("defaults to one explicit real baseline ref", () => {
+	assert.deepEqual(normalizeVariantSpecs(), [
+		{ name: "baseline", kind: "ref", ref: "origin/master" },
+	]);
+});
+
+test("parses worktree, HEAD compatibility, and named real refs", () => {
+	assert.deepEqual(
+		normalizeVariantSpecs("current,head,candidate=refs/heads/feature"),
+		[
+			{ name: "current", kind: "worktree" },
+			{ name: "head", kind: "ref", ref: "HEAD" },
+			{ name: "candidate", kind: "ref", ref: "refs/heads/feature" },
+		],
+	);
+});
+
+test("rejects the obsolete invented downstream variant and unsafe labels", () => {
+	assert.throws(() => normalizeVariantSpecs("downstream"), /explicit real ref/);
+	assert.throws(() => normalizeVariantSpecs("../candidate=HEAD"), /label/);
+	assert.throws(() => normalizeVariantSpecs("candidate=--help"), /git ref/);
+	assert.throws(
+		() => normalizeVariantSpecs("candidate=HEAD,candidate=origin/master"),
+		/Duplicate/,
+	);
+});
+
+test("rejects two labels that resolve to the same commit", () => {
+	assert.throws(
+		() =>
+			assertUniqueResolvedVariantCommits([
+				{ name: "baseline", resolvedCommit: "a".repeat(40) },
+				{ name: "candidate", resolvedCommit: "a".repeat(40) },
+			]),
+		/both resolve/,
+	);
+	assert.doesNotThrow(() =>
+		assertUniqueResolvedVariantCommits([
+			{ name: "baseline", resolvedCommit: "a".repeat(40) },
+			{ name: "candidate", resolvedCommit: "b".repeat(40) },
+		]),
+	);
+});
+
+test("materializes current and ref variants into isolated clone roots", () => {
+	const variantRoot = path.join(
+		os.tmpdir(),
+		"matrix-session",
+		"variants",
+		"current",
+	);
+	const commit = "a".repeat(40);
+	assert.deepEqual(
+		createVariantMaterializationPlan({
+			variantSpec: {
+				kind: "worktree",
+				resolvedCommit: commit,
+			},
+			variantRoot,
+		}),
+		{
+			cloneCommit: commit,
+			peerbitRoot: path.resolve(variantRoot),
+			requestedRef: "worktree",
+			sourceWorktreeMustBeClean: true,
+		},
+	);
+	const refRoot = path.join(
+		os.tmpdir(),
+		"matrix-session",
+		"variants",
+		"baseline",
+	);
+	assert.deepEqual(
+		createVariantMaterializationPlan({
+			variantSpec: {
+				kind: "ref",
+				ref: "origin/master",
+				resolvedCommit: commit,
+			},
+			variantRoot: refRoot,
+		}),
+		{
+			cloneCommit: commit,
+			peerbitRoot: path.resolve(refRoot),
+			requestedRef: "origin/master",
+			sourceWorktreeMustBeClean: false,
+		},
+	);
+});
+
+test("matrix modes and direct package requests cannot become no-ops", () => {
+	assert.equal(assertMatrixIntegrationMode("link"), "link");
+	assert.throws(
+		() => assertMatrixIntegrationMode("overlay"),
+		/requires.*link.*dependency graph/,
+	);
+	assert.throws(
+		() => assertMatrixIntegrationMode("none"),
+		/requires.*link.*dependency graph/,
+	);
+	const requiredNames = ["peerbit", "@peerbit/document"];
+	assert.doesNotThrow(() =>
+		assertMatrixPackageRequest({
+			requestedNames: ["peerbit", "@peerbit/document", "@peerbit/react"],
+			requiredNames,
+		}),
+	);
+	assert.doesNotThrow(() =>
+		assertMatrixPackageRequest({
+			requestedNames: undefined,
+			requiredNames,
+		}),
+	);
+	assert.throws(
+		() =>
+			assertMatrixPackageRequest({
+				requestedNames: ["peerbit"],
+				requiredNames,
+			}),
+		/missing required.*@peerbit\/document/,
+	);
+	assert.throws(
+		() =>
+			assertMatrixPackageRequest({
+				requestedNames: ["peerbit", "peerbit"],
+				requiredNames,
+			}),
+		/unique, non-empty/,
+	);
+});
+
+test("interleaves and counterbalances variant/mode order deterministically", () => {
+	const options = {
+		variants: ["baseline", "candidate"],
+		modes: ["adaptive", "fixed1"],
+		runs: 2,
+	};
+	const plan = createCounterbalancedInvocationPlan(options);
+	assert.deepEqual(
+		plan.map(({ run, variant, mode }) => [run, variant, mode]),
+		[
+			[1, "baseline", "adaptive"],
+			[1, "candidate", "fixed1"],
+			[1, "baseline", "fixed1"],
+			[1, "candidate", "adaptive"],
+			[2, "candidate", "fixed1"],
+			[2, "baseline", "adaptive"],
+			[2, "candidate", "adaptive"],
+			[2, "baseline", "fixed1"],
+		],
+	);
+	assert.deepEqual(createCounterbalancedInvocationPlan(options), plan);
+	for (const run of [1, 2]) {
+		for (const variant of options.variants) {
+			for (const mode of options.modes) {
+				assert.equal(
+					plan.filter(
+						(item) =>
+							item.run === run &&
+							item.variant === variant &&
+							item.mode === mode,
+					).length,
+					1,
+				);
+			}
+		}
+	}
+});
+
+test("alternates standalone mode order between repetitions", () => {
+	assert.deepEqual(
+		createCounterbalancedModePlan({
+			modes: ["adaptive", "fixed1"],
+			runs: 2,
+		}).map(({ run, mode }) => [run, mode]),
+		[
+			[1, "adaptive"],
+			[1, "fixed1"],
+			[2, "fixed1"],
+			[2, "adaptive"],
+		],
+	);
+});
+
+test("creates UUID-owned exclusive matrix sessions without reusing the base", async () => {
+	const fixtureRoot = await mkdtemp(
+		path.join(os.tmpdir(), "peerbit-matrix-root-"),
+	);
+	const repository = path.join(fixtureRoot, "repository");
+	const baseDir = path.join(fixtureRoot, "output");
+	const nonce = "123e4567-e89b-42d3-a456-426614174000";
+	const now = new Date("2026-07-17T12:34:56.789Z");
+	await mkdir(repository);
+	try {
+		const session = await createExclusiveMatrixSession({
+			baseDir,
+			repoRoot: repository,
+			nonce,
+			now,
+		});
+		assert.equal(path.dirname(session.matrixRoot), await realpath(baseDir));
+		assert.equal(path.basename(session.markerFile), MATRIX_SESSION_MARKER);
+		const marker = JSON.parse(await readFile(session.markerFile, "utf8"));
+		assert.equal(marker.nonce, nonce);
+		assert.equal(marker.matrixRoot, session.matrixRoot);
+		await assert.rejects(
+			createExclusiveMatrixSession({
+				baseDir,
+				repoRoot: repository,
+				nonce,
+				now,
+			}),
+			/already exists|EEXIST/,
+		);
+		await assert.rejects(
+			createExclusiveMatrixSession({
+				baseDir: path.join(repository, "unsafe-output"),
+				repoRoot: repository,
+			}),
+			/inside the Peerbit worktree/,
+		);
+		await assert.rejects(
+			createExclusiveMatrixSession({
+				baseDir: path.parse(baseDir).root,
+				repoRoot: repository,
+			}),
+			/filesystem root/,
+		);
+	} finally {
+		await rm(fixtureRoot, { recursive: true, force: true });
+	}
+});

--- a/scripts/file-share/prepare-peerbit-examples.mjs
+++ b/scripts/file-share/prepare-peerbit-examples.mjs
@@ -1,11 +1,19 @@
+import path from "node:path";
 import {
+	buildPeerbitPackages,
+	cleanPeerbitBuildArtifacts,
 	defaultExamplesDest,
 	defaultExamplesSource,
 	defaultFileShareLocalPackages,
+	ensureExamplesAssetPackageLinks,
+	getFileShareConsumerRoots,
+	installPinnedExamplesDependencies,
 	parseArgs,
 	prepareExamplesRepo,
 	repoRoot,
+	run,
 } from "./common.mjs";
+import { instrumentFileShareViteConfigs } from "./vite-instrumentation.mjs";
 
 const usage = () => {
 	console.log(`Prepare a disposable peerbit-examples checkout pinned to the local peerbit workspace.
@@ -17,10 +25,9 @@ Options:
   --source <path-or-url>     examples repo source (default: ${defaultExamplesSource()})
   --dest <path>              output directory (default: ${defaultExamplesDest()})
   --peerbit-root <path>      peerbit workspace root (default: ${repoRoot})
-  --integration-mode <mode>  one of none, link, overlay (default: overlay)
-  --local-packages <csv>     package names to link/overlay (default: ${defaultFileShareLocalPackages.join(",")}; use "all" for every installed local package)
+  --integration-mode <mode>  one of none, link (default: link)
+  --local-packages <csv>     package names to link (default: ${defaultFileShareLocalPackages.join(",")}; use "all" for every installed local package)
   --fresh                    delete the destination before cloning
-  --install                  run pnpm install in the prepared checkout
 `);
 };
 
@@ -30,7 +37,12 @@ const main = async () => {
 		usage();
 		return;
 	}
-	const integrationMode = args["integration-mode"] ?? "overlay";
+	const integrationMode = args["integration-mode"] ?? "link";
+	if (!["none", "link"].includes(integrationMode)) {
+		throw new Error(
+			`Unsupported --integration-mode "${integrationMode}". Expected "none" or "link".`,
+		);
+	}
 	const localPackages =
 		integrationMode === "none"
 			? []
@@ -44,20 +56,44 @@ const main = async () => {
 	const prepared = await prepareExamplesRepo({
 		source: args.source,
 		dest: args.dest,
-		peerbitRoot: args["peerbit-root"] ?? repoRoot,
+		peerbitRoot: path.resolve(args["peerbit-root"] ?? repoRoot),
 		fresh: Boolean(args.fresh),
-		install: Boolean(args.install),
+		install: false,
 		localPackageNames: localPackages,
-		applyOverrides: integrationMode === "link",
+		applyOverrides: false,
 	});
+	const effectiveLocalPackageNames = [...prepared.localPackages.keys()];
+	if (integrationMode === "link") {
+		run("pnpm", ["install", "--frozen-lockfile"], {
+			cwd: prepared.peerbitRoot,
+		});
+		await cleanPeerbitBuildArtifacts({
+			peerbitRoot: prepared.peerbitRoot,
+			packageNames: effectiveLocalPackageNames,
+		});
+		buildPeerbitPackages(prepared.peerbitRoot, effectiveLocalPackageNames);
+	}
+	await installPinnedExamplesDependencies(prepared.dest);
+	if (integrationMode === "link") {
+		await ensureExamplesAssetPackageLinks({
+			examplesRoot: prepared.dest,
+			peerbitRoot: prepared.peerbitRoot,
+			packageNames: effectiveLocalPackageNames,
+			consumerRoots: getFileShareConsumerRoots(prepared.dest),
+		});
+		await instrumentFileShareViteConfigs(
+			getFileShareConsumerRoots(prepared.dest)[0],
+		);
+	}
 
 	console.log(`Prepared examples checkout: ${prepared.dest}`);
 	console.log(`Local peerbit workspace: ${prepared.peerbitRoot}`);
 	console.log(`Integration mode: ${integrationMode}`);
-	console.log(`Configured local packages: ${prepared.localPackages.size}`);
+	console.log(
+		`Configured local packages: ${effectiveLocalPackageNames.length}`,
+	);
 	console.log("");
 	console.log("Next steps:");
-	console.log(`  pnpm --dir ${prepared.dest} install`);
 	console.log(
 		`  pnpm --dir ${prepared.dest}/packages/file-share/frontend exec playwright test tests/uploadChurn.local.manual.e2e.spec.ts -c playwright.config.ts`,
 	);

--- a/scripts/file-share/run-file-share-benchmark-matrix.mjs
+++ b/scripts/file-share/run-file-share-benchmark-matrix.mjs
@@ -1,16 +1,36 @@
 import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
-	defaultExamplesDest,
+	assertBenchmarkFileSize,
+	assertCoreBenchmarkUsesLocalApp,
+	resolveBenchmarkPreviewOptions,
+} from "./benchmark-invocation.mjs";
+import {
+	getExamplesProvenance,
+	getPeerbitProvenance,
+	resolveGitCommitAt,
+} from "./benchmark-provenance.mjs";
+import {
+	collectLocalPeerbitPackages,
 	defaultExamplesSource,
 	defaultFileShareLocalPackages,
 	parseArgs,
 	repoRoot,
 	run,
 } from "./common.mjs";
+import {
+	assertMatrixIntegrationMode,
+	assertMatrixPackageRequest,
+	assertUniqueResolvedVariantCommits,
+	createCounterbalancedInvocationPlan,
+	createExclusiveMatrixSession,
+	createVariantMaterializationPlan,
+	normalizeVariantSpecs,
+} from "./matrix-variants.mjs";
 
 const RUNNER_PATH = path.join(
 	repoRoot,
@@ -19,308 +39,92 @@ const RUNNER_PATH = path.join(
 	"run-file-share-benchmark.mjs",
 );
 
-const VARIANT_ORDER = ["current", "head", "downstream"];
-
-const shellQuote = (value) => `'${String(value).replace(/'/g, `'\\''`)}'`;
-
-const runShell = (command, { cwd = repoRoot } = {}) => {
-	console.log(`$ ${command}`);
-	const result = spawnSync("bash", ["-lc", command], {
+const runGit = (args, { cwd = repoRoot, capture = false } = {}) => {
+	console.log(`$ git ${args.join(" ")}`);
+	const result = spawnSync("git", args, {
 		cwd,
-		stdio: "inherit",
 		env: process.env,
+		encoding: "utf8",
+		stdio: capture ? ["ignore", "pipe", "pipe"] : "inherit",
 	});
-	if (result.status !== 0) {
-		throw new Error(`Command failed with exit code ${result.status}: ${command}`);
-	}
-};
-
-const createHeadClone = async (dest) => {
-	await fsp.rm(dest, { recursive: true, force: true });
-	runShell(`git clone --quiet ${shellQuote(repoRoot)} ${shellQuote(dest)}`);
-	runShell(`git -C ${shellQuote(dest)} checkout --quiet --detach HEAD`);
-};
-
-const replaceOnce = (contents, search, replacement, label) => {
-	if (!contents.includes(search)) {
-		throw new Error(`Could not find expected snippet for ${label}`);
-	}
-	return contents.replace(search, replacement);
-};
-
-const applyDownstreamAdaptivePatch = async (variantRoot) => {
-	const filePath = path.join(
-		variantRoot,
-		"packages",
-		"programs",
-		"data",
-		"shared-log",
-		"src",
-		"index.ts",
-	);
-	let contents = await fsp.readFile(filePath, "utf8");
-
-	contents = replaceOnce(
-		contents,
-		`const RECALCULATE_PARTICIPATION_MIN_RELATIVE_CHANGE_WITH_MEMORY_LIMIT = 0.001;
-const RECALCULATE_PARTICIPATION_RELATIVE_DENOMINATOR_FLOOR = 1e-3;
-
-const DEFAULT_DISTRIBUTION_DEBOUNCE_TIME = 500;`,
-		`const RECALCULATE_PARTICIPATION_MIN_RELATIVE_CHANGE_WITH_MEMORY_LIMIT = 0.001;
-const RECALCULATE_PARTICIPATION_RELATIVE_DENOMINATOR_FLOOR = 1e-3;
-const ADAPTIVE_REBALANCE_IDLE_INTERVAL_MULTIPLIER = 5;
-const ADAPTIVE_REBALANCE_MIN_IDLE_AFTER_LOCAL_APPEND_MS = 10_000;
-
-const DEFAULT_DISTRIBUTION_DEBOUNCE_TIME = 500;`,
-		"constants",
-	);
-
-	contents = replaceOnce(
-		contents,
-		`	private cpuUsage?: CPUUsage;
-
-	timeUntilRoleMaturity!: number;`,
-		`	private cpuUsage?: CPUUsage;
-	private _lastLocalAppendAt!: number;
-	private adaptiveRebalanceIdleMs!: number;
-
-	timeUntilRoleMaturity!: number;`,
-		"fields",
-	);
-
-	contents = replaceOnce(
-		contents,
-		`	private setupRebalanceDebounceFunction(
-		interval = RECALCULATE_PARTICIPATION_DEBOUNCE_INTERVAL,
-	) {
-		this.rebalanceParticipationDebounced = undefined;
-
-		this.rebalanceParticipationDebounced = debounceFixedInterval(
-			() => this.rebalanceParticipation(),
-			/* Math.max(
-				REBALANCE_DEBOUNCE_INTERVAL,
-				Math.log(
-					(this.getReplicatorsSorted()?.getSize() || 0) *
-					REBALANCE_DEBOUNCE_INTERVAL
-				)
-			) */
-			interval, // TODO make this dynamic on the number of replicators
-		);
-	}
-
-	private async _replicate(`,
-		`	private setupRebalanceDebounceFunction(
-		interval = RECALCULATE_PARTICIPATION_DEBOUNCE_INTERVAL,
-	) {
-		this.rebalanceParticipationDebounced = undefined;
-
-		this.rebalanceParticipationDebounced = debounceFixedInterval(
-			() => this.rebalanceParticipation(),
-			/* Math.max(
-				REBALANCE_DEBOUNCE_INTERVAL,
-				Math.log(
-					(this.getReplicatorsSorted()?.getSize() || 0) *
-					REBALANCE_DEBOUNCE_INTERVAL
-				)
-			) */
-			interval, // TODO make this dynamic on the number of replicators
-		);
-	}
-
-	private markLocalAppendActivity(timestamp = Date.now()) {
-		this._lastLocalAppendAt = Math.max(this._lastLocalAppendAt ?? 0, timestamp);
-	}
-
-	private shouldDelayAdaptiveRebalance(now = Date.now()) {
-		return (
-			this._isAdaptiveReplicating &&
-			this._lastLocalAppendAt > 0 &&
-			now - this._lastLocalAppendAt < this.adaptiveRebalanceIdleMs
-		);
-	}
-
-	private async _replicate(`,
-		"methods",
-	);
-
-	contents = replaceOnce(
-		contents,
-		`	): Promise<{
-		entry: Entry<T>;
-		removed: ShallowOrFullEntry<T>[];
-	}> {
-		const appendOptions: AppendOptions<T> = { ...options };`,
-		`	): Promise<{
-		entry: Entry<T>;
-		removed: ShallowOrFullEntry<T>[];
-	}> {
-		if (this._isAdaptiveReplicating) {
-			this.markLocalAppendActivity();
-		}
-
-		const appendOptions: AppendOptions<T> = { ...options };`,
-		"append-activity",
-	);
-
-	contents = replaceOnce(
-		contents,
-		`		if (!isLeader) {
-			this.pruneDebouncedFnAddIfNotKeeping({
-				key: result.entry.hash,
-				value: { entry: result.entry, leaders },
-			});
-		}
-		this.rebalanceParticipationDebounced?.call();`,
-		`		if (!isLeader && !this.shouldDelayAdaptiveRebalance()) {
-			this.pruneDebouncedFnAddIfNotKeeping({
-				key: result.entry.hash,
-				value: { entry: result.entry, leaders },
-			});
-		}
-		if (!this._isAdaptiveReplicating) {
-			this.rebalanceParticipationDebounced?.call();
-		}`,
-		"append-prune-rebalance",
-	);
-
-	contents = replaceOnce(
-		contents,
-		`		this._replicatorLivenessCursor = 0;
-		this._replicatorLivenessFailures = new Map();
-		this._replicatorLastActivityAt = new Map();
-
-		this.openTime = +new Date();`,
-		`		this._replicatorLivenessCursor = 0;
-		this._replicatorLivenessFailures = new Map();
-		this._replicatorLastActivityAt = new Map();
-		this._lastLocalAppendAt = 0;
-		const adaptiveReplicateOptions =
-			options?.replicate && isAdaptiveReplicatorOption(options.replicate)
-				? options.replicate
-				: undefined;
-		this.adaptiveRebalanceIdleMs = Math.max(
-			ADAPTIVE_REBALANCE_MIN_IDLE_AFTER_LOCAL_APPEND_MS,
-			(adaptiveReplicateOptions?.limits?.interval ??
-				RECALCULATE_PARTICIPATION_DEBOUNCE_INTERVAL) *
-				ADAPTIVE_REBALANCE_IDLE_INTERVAL_MULTIPLIER,
-		);
-
-		this.openTime = +new Date();`,
-		"open-init",
-	);
-
-	contents = replaceOnce(
-		contents,
-		`	async rebalanceParticipation() {
-		// update more participation rate to converge to the average expected rate or bounded by
-		// resources such as memory and or cpu
-
-		const fn = async () => {`,
-		`	async rebalanceParticipation() {
-		// update more participation rate to converge to the average expected rate or bounded by
-		// resources such as memory and or cpu
-
-		const isClosedStoreRace = (error: any) => {
-			const message =
-				typeof error?.message === "string" ? error.message : String(error);
-			return (
-				this.closed ||
-				message.includes("Iterator is not open") ||
-				message.includes("cannot read after close()") ||
-				message.includes("Database is not open")
-			);
-		};
-
-		const fn = async () => {`,
-		"rebalance-helper",
-	);
-
-	contents = replaceOnce(
-		contents,
-		`			if (this._isAdaptiveReplicating) {
-				const peers = this.replicationIndex;
-				const usedMemory = await this.getMemoryUsage();`,
-		`			if (this._isAdaptiveReplicating) {
-				if (this.shouldDelayAdaptiveRebalance()) {
-					this.rebalanceParticipationDebounced?.call();
-					return false;
-				}
-
-				const peers = this.replicationIndex;
-				const usedMemory = await this.getMemoryUsage();`,
-		"rebalance-delay",
-	);
-
-	contents = replaceOnce(
-		contents,
-		`		const resp = await fn();
-`,
-		`		const resp = await fn().catch((error: any) => {
-			if (isNotStartedError(error) || isClosedStoreRace(error)) {
-				return false;
-			}
-			throw error;
+	if (result.error) {
+		throw new Error(`Could not start git: ${result.error.message}`, {
+			cause: result.error,
 		});
-`,
-		"rebalance-catch",
-	);
+	}
+	if (result.status !== 0) {
+		const detail = capture ? `: ${result.stderr.trim()}` : "";
+		throw new Error(
+			`git ${args.join(" ")} failed with exit code ${String(result.status)}${detail}`,
+		);
+	}
+	return capture ? result.stdout.trim() : undefined;
+};
 
-	await fsp.writeFile(filePath, contents);
+const createRefClone = async ({ dest, commit }) => {
+	await fsp.rm(dest, { recursive: true, force: true });
+	runGit(["clone", "--quiet", "--no-checkout", repoRoot, dest]);
+	runGit(["checkout", "--quiet", "--detach", commit], { cwd: dest });
+};
+
+const preparePinnedExamplesTemplate = async ({ source, ref, dest }) => {
+	await fsp.rm(dest, { recursive: true, force: true });
+	runGit(["clone", "--quiet", "--no-checkout", source, dest]);
+	const resolvedCommit = resolveGitCommitAt(dest, ref);
+	runGit(["checkout", "--quiet", "--detach", resolvedCommit], { cwd: dest });
+	const provenance = await getExamplesProvenance({
+		root: dest,
+		requestedRef: ref,
+	});
+	if (provenance.dirty) {
+		throw new Error("Pinned examples template must be clean");
+	}
+	run("pnpm", ["install", "--frozen-lockfile"], { cwd: dest });
+	const postInstallStatus = runGit(["status", "--porcelain=v1"], {
+		cwd: dest,
+		capture: true,
+	});
+	if (postInstallStatus) {
+		throw new Error(
+			`Installing the pinned examples template changed tracked files:\n${postInstallStatus}`,
+		);
+	}
+	return { root: dest, provenance };
+};
+
+const writeJsonAtomic = async (filePath, value) => {
+	await fsp.mkdir(path.dirname(filePath), { recursive: true });
+	const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+	await fsp.writeFile(temporaryPath, `${JSON.stringify(value, null, 2)}\n`);
+	await fsp.rename(temporaryPath, filePath);
 };
 
 const ensureDependenciesInstalled = async (variantRoot) => {
-	if (fs.existsSync(path.join(variantRoot, "node_modules"))) {
-		return;
-	}
-	run("pnpm", ["install"], { cwd: variantRoot });
+	run("pnpm", ["install", "--frozen-lockfile"], { cwd: variantRoot });
 };
 
-const buildVariant = async (variantRoot) => {
-	run(
-		"pnpm",
-		[
-			"--filter", "@peerbit/build-assets...",
-			"--filter", "@peerbit/any-store-opfs...",
-			"--filter", "peerbit...",
-			"--filter", "@peerbit/react...",
-			"--filter", "@peerbit/document...",
-			"--filter", "@peerbit/shared-log...",
-			"--filter", "@peerbit/stream...",
-			"--filter", "@peerbit/crypto...",
-			"--filter", "@peerbit/trusted-network...",
-			"--filter", "@peerbit/vite...",
-			"--filter", "@peerbit/test-utils...",
-			"build",
-		],
-		{ cwd: variantRoot },
-	);
-};
-
-const defaultMatrixRoot = () => {
+const defaultMatrixBase = () => {
 	const preferredParent = path.resolve(repoRoot, "..", "tmp");
 	const parent = fs.existsSync(preferredParent) ? preferredParent : os.tmpdir();
-	return path.join(
-		parent,
-		`peerbit-file-share-matrix-${new Date()
-			.toISOString()
-			.replaceAll(":", "-")
-			.replace(/\..+$/, "")}`,
-	);
+	return parent;
 };
 
-const normalizeVariants = (value) => {
-	const variants = (value ?? VARIANT_ORDER.join(","))
-		.split(",")
-		.map((item) => item.trim())
-		.filter(Boolean);
-	for (const variant of variants) {
-		if (!VARIANT_ORDER.includes(variant)) {
-			throw new Error(
-				`Unsupported variant "${variant}". Expected one of ${VARIANT_ORDER.join(", ")}`,
-			);
-		}
+const resolveVariantSpecs = async (variantSpecs) => {
+	const resolved = [];
+	for (const variantSpec of variantSpecs) {
+		const resolvedCommit =
+			variantSpec.kind === "worktree"
+				? (
+						await getPeerbitProvenance({
+							root: repoRoot,
+							requestedRef: "worktree",
+							requireClean: true,
+						})
+					).resolvedCommit
+				: resolveGitCommitAt(repoRoot, variantSpec.ref);
+		resolved.push({ ...variantSpec, resolvedCommit });
 	}
-	return variants;
+	return assertUniqueResolvedVariantCommits(resolved);
 };
 
 const summarizeUploadMatrix = (variantSummaries) => {
@@ -364,7 +168,9 @@ const summarizeMatrix = (variantSummaries, scenario) =>
 const compareAdaptiveAcrossVariants = (variantSummaries, scenario) => {
 	return variantSummaries
 		.map((summary) => {
-			const adaptive = summary.summary.find((entry) => entry.mode === "adaptive");
+			const adaptive = summary.summary.find(
+				(entry) => entry.mode === "adaptive",
+			);
 			if (!adaptive) {
 				return null;
 			}
@@ -375,33 +181,142 @@ const compareAdaptiveAcrossVariants = (variantSummaries, scenario) => {
 						writerSeedersLastAvg: adaptive.writerSeedersLastAvg ?? null,
 						readerSeedersLastAvg: adaptive.readerSeedersLastAvg ?? null,
 						errorCount: adaptive.errorCount ?? null,
-				  }
+					}
 				: adaptive.uploadDurationMsAvg != null
 					? {
 							variant: summary.variant,
 							adaptiveAvgMs: adaptive.uploadDurationMsAvg,
-					  }
+						}
 					: null;
 		})
 		.filter(Boolean);
 };
 
-const prepareVariant = async ({ variant, variantRoot }) => {
-	if (variant === "current") {
-		return { peerbitRoot: repoRoot, materialized: false };
+const average = (values) =>
+	values.length === 0
+		? null
+		: Number(
+				(
+					values.reduce((total, value) => total + value, 0) / values.length
+				).toFixed(1),
+			);
+
+const summarizeInvocationResults = (results, scenario) => {
+	const grouped = new Map();
+	for (const result of results) {
+		const items = grouped.get(result.mode) ?? [];
+		items.push(result);
+		grouped.set(result.mode, items);
 	}
-	if (variant === "head") {
-		await createHeadClone(variantRoot);
-		await ensureDependenciesInstalled(variantRoot);
-		return { peerbitRoot: variantRoot, materialized: true };
+	return [...grouped.entries()].map(([mode, items]) => {
+		const base = {
+			mode,
+			runs: items.length,
+			passed: items.filter((item) => item.status === "passed").length,
+			failed: items.filter((item) => item.status !== "passed").length,
+			errorCount: items.reduce(
+				(total, item) => total + (Number(item.errorCount) || 0),
+				0,
+			),
+		};
+		if (scenario === "seeder-probe") {
+			const lastNumbers = (key) =>
+				items
+					.map((item) => item.samples?.at(-1)?.[key])
+					.filter((value) => typeof value === "number");
+			const maxima = (key) =>
+				items
+					.map((item) => {
+						const values = (item.samples ?? [])
+							.map((sample) => sample[key])
+							.filter((value) => typeof value === "number");
+						return values.length > 0 ? Math.max(...values) : null;
+					})
+					.filter((value) => typeof value === "number");
+			return {
+				...base,
+				reachedTargetRuns: items.filter((item) => item.reachedTarget).length,
+				writerSeedersLastAvg: average(lastNumbers("writerSeeders")),
+				readerSeedersLastAvg: average(lastNumbers("readerSeeders")),
+				writerSeedersMaxAvg: average(maxima("writerSeeders")),
+				readerSeedersMaxAvg: average(maxima("readerSeeders")),
+			};
+		}
+		const numbers = (getter) =>
+			items
+				.filter((item) => item.status === "passed")
+				.map(getter)
+				.filter((value) => typeof value === "number");
+		return {
+			...base,
+			uploadDurationMsAvg: average(numbers((item) => item.uploadDurationMs)),
+			uploadSettledMsAvg: average(
+				numbers((item) => item.phaseDurationsMs?.timeToUploadSettled),
+			),
+			listingDurationMsAvg: average(numbers((item) => item.listingDurationMs)),
+			writerListingLagMsAvg: average(
+				numbers((item) => item.phaseDurationsMs?.writerListingLag),
+			),
+			readerListingLagMsAvg: average(
+				numbers((item) => item.phaseDurationsMs?.readerListingLag),
+			),
+			postUploadMonitorDurationMsAvg: average(
+				numbers((item) => item.postUploadMonitorDurationMs),
+			),
+			downloadDurationMsAvg: average(
+				numbers((item) => item.downloadDurationMs),
+			),
+			seederDrops: items.filter((item) => item.droppedSeeders).length,
+		};
+	});
+};
+
+const compareCombinedUploadModes = (results) => {
+	const passed = results.filter((result) => result.status === "passed");
+	const adaptive = passed.filter((result) => result.mode === "adaptive");
+	const fixed = passed.filter((result) => result.mode === "fixed1");
+	if (adaptive.length === 0 || fixed.length === 0) {
+		return null;
 	}
-	if (variant === "downstream") {
-		await createHeadClone(variantRoot);
-		await applyDownstreamAdaptivePatch(variantRoot);
-		await ensureDependenciesInstalled(variantRoot);
-		return { peerbitRoot: variantRoot, materialized: true };
+	const adaptiveAvg = average(adaptive.map((item) => item.uploadDurationMs));
+	const fixedAvg = average(fixed.map((item) => item.uploadDurationMs));
+	const delta = adaptiveAvg - fixedAvg;
+	return {
+		adaptiveAvgMs: adaptiveAvg,
+		fixed1AvgMs: fixedAvg,
+		deltaMs: Number(delta.toFixed(1)),
+		adaptiveVsFixed1Pct: Number(((delta / fixedAvg) * 100).toFixed(1)),
+	};
+};
+
+const prepareVariant = async ({ variantSpec, variantRoot }) => {
+	const materialization = createVariantMaterializationPlan({
+		variantSpec,
+		variantRoot,
+	});
+	if (materialization.sourceWorktreeMustBeClean) {
+		await getPeerbitProvenance({
+			root: repoRoot,
+			requestedRef: "worktree",
+			requireClean: true,
+			expectedResolvedCommit: variantSpec.resolvedCommit,
+		});
 	}
-	throw new Error(`Unhandled variant ${variant}`);
+	await createRefClone({
+		dest: materialization.peerbitRoot,
+		commit: materialization.cloneCommit,
+	});
+	await ensureDependenciesInstalled(materialization.peerbitRoot);
+	await getPeerbitProvenance({
+		root: materialization.peerbitRoot,
+		requestedRef: materialization.requestedRef,
+		requireClean: true,
+		expectedResolvedCommit: materialization.cloneCommit,
+	});
+	return {
+		peerbitRoot: materialization.peerbitRoot,
+		resolvedCommit: materialization.cloneCommit,
+	};
 };
 
 const runVariantBenchmark = async ({
@@ -409,6 +324,7 @@ const runVariantBenchmark = async ({
 	peerbitRoot,
 	examplesSource,
 	examplesTemplate,
+	pinnedExamplesProvenance,
 	examplesRoot,
 	resultsDir,
 	summaryFile,
@@ -420,8 +336,10 @@ const runVariantBenchmark = async ({
 	freshExamplesEachRun,
 	installExamples,
 	uploadTimeoutMs,
+	downloadTimeoutMs,
 	postUploadMonitorMs,
 	pollMs,
+	minReadySeeders,
 	scenario,
 	integrationMode,
 	localPackages,
@@ -429,186 +347,415 @@ const runVariantBenchmark = async ({
 	sampleMs,
 	sampleCount,
 	targetSeeders,
-	baseUrl,
 	protocol,
-	viteMode,
-	viteConfig,
+	fixtureSeed,
+	enableVisibilityProbe,
+	verbose,
+	variantRef,
+	resolvedCommit,
+	examplesRef,
 }) => {
-	buildVariant(peerbitRoot);
-	run("node", [
-		RUNNER_PATH,
-		"--scenario",
-		scenario,
-		"--integration-mode",
-		integrationMode,
-		"--peerbit-root",
-		peerbitRoot,
-		"--examples-root",
-		examplesRoot,
-		"--source",
-		examplesSource,
-		...(localPackages ? ["--local-packages", localPackages] : []),
-		...(examplesTemplate ? ["--template", examplesTemplate] : []),
-		"--results-dir",
-		resultsDir,
-		"--summary-file",
-		summaryFile,
-		"--file-mb",
-		String(fileMb),
-		"--runs",
-		String(runs),
-		"--mode",
-		mode,
-		"--network",
-		network,
-		...(freshExamples ? ["--fresh"] : []),
-		...(freshExamplesEachRun ? ["--fresh-each-run"] : []),
-		...(installExamples ? ["--install"] : []),
-		...(uploadTimeoutMs
-			? ["--upload-timeout-ms", String(uploadTimeoutMs)]
-			: []),
-		...(postUploadMonitorMs
-			? ["--post-upload-monitor-ms", String(postUploadMonitorMs)]
-			: []),
-		...(pollMs ? ["--poll-ms", String(pollMs)] : []),
-		...(readyTimeoutMs
-			? ["--ready-timeout-ms", String(readyTimeoutMs)]
-			: []),
-		...(sampleMs ? ["--sample-ms", String(sampleMs)] : []),
-		...(sampleCount ? ["--sample-count", String(sampleCount)] : []),
-		...(targetSeeders ? ["--target-seeders", String(targetSeeders)] : []),
-		...(baseUrl ? ["--base-url", baseUrl] : []),
-		...(protocol ? ["--protocol", protocol] : []),
-		...(viteMode ? ["--vite-mode", viteMode] : []),
-		...(viteConfig ? ["--vite-config", viteConfig] : []),
-	], {
-		cwd: repoRoot,
-		env: process.env,
-	});
+	await fsp.rm(summaryFile, { force: true });
+	run(
+		"node",
+		[
+			RUNNER_PATH,
+			"--scenario",
+			scenario,
+			"--integration-mode",
+			integrationMode,
+			"--peerbit-root",
+			peerbitRoot,
+			"--examples-root",
+			examplesRoot,
+			"--source",
+			examplesSource,
+			"--examples-ref",
+			examplesRef,
+			"--peerbit-ref-label",
+			variantRef,
+			"--expected-peerbit-commit",
+			resolvedCommit,
+			"--require-clean-peerbit",
+			"--expected-examples-commit",
+			pinnedExamplesProvenance.resolvedCommit,
+			"--expected-examples-lockfile-sha256",
+			pinnedExamplesProvenance.lockfileSha256,
+			...(localPackages ? ["--local-packages", localPackages] : []),
+			...(examplesTemplate ? ["--template", examplesTemplate] : []),
+			"--results-dir",
+			resultsDir,
+			"--summary-file",
+			summaryFile,
+			"--file-mb",
+			String(fileMb),
+			"--runs",
+			String(runs),
+			"--mode",
+			mode,
+			"--network",
+			network,
+			...(freshExamples ? ["--fresh"] : []),
+			...(freshExamplesEachRun ? ["--fresh-each-run"] : []),
+			...(installExamples ? ["--install"] : []),
+			...(uploadTimeoutMs != null
+				? ["--upload-timeout-ms", String(uploadTimeoutMs)]
+				: []),
+			...(downloadTimeoutMs != null
+				? ["--download-timeout-ms", String(downloadTimeoutMs)]
+				: []),
+			...(postUploadMonitorMs != null
+				? ["--post-upload-monitor-ms", String(postUploadMonitorMs)]
+				: []),
+			...(pollMs != null ? ["--poll-ms", String(pollMs)] : []),
+			...(minReadySeeders != null
+				? ["--min-ready-seeders", String(minReadySeeders)]
+				: []),
+			...(readyTimeoutMs != null
+				? ["--ready-timeout-ms", String(readyTimeoutMs)]
+				: []),
+			...(sampleMs != null ? ["--sample-ms", String(sampleMs)] : []),
+			...(sampleCount != null ? ["--sample-count", String(sampleCount)] : []),
+			...(targetSeeders != null
+				? ["--target-seeders", String(targetSeeders)]
+				: []),
+			...(protocol ? ["--protocol", protocol] : []),
+			...(fixtureSeed ? ["--fixture-seed", fixtureSeed] : []),
+			...(enableVisibilityProbe ? ["--enable-visibility-probe"] : []),
+			...(verbose ? ["--verbose"] : []),
+		],
+		{
+			cwd: repoRoot,
+			env: process.env,
+		},
+	);
 	const summary = JSON.parse(await fsp.readFile(summaryFile, "utf8"));
 	return {
 		variant,
+		variantRef,
+		resolvedCommit,
 		...summary,
 	};
 };
 
 const main = async () => {
 	const args = parseArgs(process.argv.slice(2));
-	const matrixRoot = path.resolve(args["matrix-root"] ?? defaultMatrixRoot());
-	const variants = normalizeVariants(args.variants);
+	assertCoreBenchmarkUsesLocalApp(args["base-url"]);
+	const previewOptions = resolveBenchmarkPreviewOptions({
+		protocol: args.protocol,
+		viteMode: args["vite-mode"],
+		viteConfig: args["vite-config"],
+	});
+	const requestedMatrixBase = path.resolve(
+		args["matrix-root"] ?? defaultMatrixBase(),
+	);
+	const requestedVariantSpecs = normalizeVariantSpecs(args.variants);
 	const fileMb = Number(args["file-mb"] ?? "5");
 	const runs = Number(args.runs ?? "1");
 	const mode = args.mode ?? "both";
+	const modes = mode === "both" ? ["adaptive", "fixed1"] : [mode];
 	const scenario = args.scenario ?? "upload";
-	const integrationMode = args["integration-mode"] ?? "overlay";
+	const integrationMode = args["integration-mode"] ?? "link";
 	const localPackages =
 		args["local-packages"] ?? defaultFileShareLocalPackages.join(",");
+	const requestedLocalPackageNames =
+		localPackages === "all"
+			? undefined
+			: localPackages.split(",").map((value) => value.trim());
 	const network = args.network ?? "local";
 	const uploadTimeoutMs = args["upload-timeout-ms"];
+	const downloadTimeoutMs = args["download-timeout-ms"];
 	const postUploadMonitorMs = args["post-upload-monitor-ms"];
 	const pollMs = args["poll-ms"];
+	const minReadySeeders = args["min-ready-seeders"];
 	const readyTimeoutMs = args["ready-timeout-ms"];
 	const sampleMs = args["sample-ms"];
 	const sampleCount = args["sample-count"];
 	const targetSeeders = args["target-seeders"];
-	const baseUrl = args["base-url"];
-	const protocol = args.protocol;
-	const viteMode = args["vite-mode"];
-	const viteConfig = args["vite-config"];
-	const examplesSource = args.source ?? defaultExamplesSource();
-	const isolatedExamples = Boolean(args["isolated-examples"]);
+	const { protocol } = previewOptions;
+	const fixtureSeed = args["fixture-seed"];
+	const enableVisibilityProbe = Boolean(args["enable-visibility-probe"]);
+	const verbose = Boolean(args.verbose);
+	const examplesSource =
+		args.source ??
+		args.template ??
+		args["examples-root"] ??
+		defaultExamplesSource();
+	const examplesRef = args["examples-ref"] ?? "HEAD";
 
 	if (!["local", "remote"].includes(network)) {
-		throw new Error(`Unsupported --network "${network}". Expected "local" or "remote".`);
-	}
-
-	const preparedExamplesRoot = fs.existsSync(path.join(defaultExamplesDest(), "node_modules"))
-		? defaultExamplesDest()
-		: undefined;
-	const sharedExamplesRoot = isolatedExamples
-		? undefined
-		: args["examples-root"] ?? preparedExamplesRoot;
-	const examplesTemplate = isolatedExamples
-		? args.template ?? args["examples-root"] ?? preparedExamplesRoot
-		: sharedExamplesRoot
-			? undefined
-			: args.template ?? preparedExamplesRoot;
-
-	if (isolatedExamples && !examplesTemplate) {
 		throw new Error(
-			"Isolated examples mode requires a prepared template checkout. Pass --template or --examples-root.",
+			`Unsupported --network "${network}". Expected "local" or "remote".`,
 		);
 	}
-
-	await fsp.mkdir(matrixRoot, { recursive: true });
-	const variantSummaries = [];
-
-	for (const variant of variants) {
-		console.log(`\n=== Variant: ${variant} ===`);
+	if (!Number.isSafeInteger(runs) || runs <= 0) {
+		throw new Error("--runs must be a positive safe integer");
+	}
+	if (
+		modes.some((entry) => !["adaptive", "fixed1", "observer"].includes(entry))
+	) {
+		throw new Error(
+			`Unsupported --mode "${mode}". Expected adaptive, fixed1, observer, or both.`,
+		);
+	}
+	if (!["upload", "seeder-probe"].includes(scenario)) {
+		throw new Error(`Unsupported --scenario "${scenario}"`);
+	}
+	assertMatrixIntegrationMode(integrationMode);
+	assertBenchmarkFileSize({ scenario, fileMb });
+	assertMatrixPackageRequest({
+		requestedNames: requestedLocalPackageNames,
+		requiredNames: defaultFileShareLocalPackages,
+	});
+	const variantSpecs = await resolveVariantSpecs(requestedVariantSpecs);
+	const matrixSession = await createExclusiveMatrixSession({
+		baseDir: requestedMatrixBase,
+		repoRoot,
+	});
+	const { matrixRoot } = matrixSession;
+	const pinnedExamples = await preparePinnedExamplesTemplate({
+		source: examplesSource,
+		ref: examplesRef,
+		dest: path.join(matrixRoot, "examples-template"),
+	});
+	const examplesTemplate = pinnedExamples.root;
+	const preparedVariants = new Map();
+	for (const variantSpec of variantSpecs) {
+		const variant = variantSpec.name;
+		console.log(
+			`\n=== Variant: ${variant}${variantSpec.ref ? ` (${variantSpec.ref})` : " (worktree)"} ===`,
+		);
 		const variantRoot = path.join(matrixRoot, "variants", variant);
-		const { peerbitRoot } = await prepareVariant({ variant, variantRoot });
-		const examplesRoot = sharedExamplesRoot
-			? path.resolve(sharedExamplesRoot)
-			: path.join(matrixRoot, "examples", variant);
-		const resultsDir = path.join(matrixRoot, "results", variant, "runs");
-		const summaryFile = path.join(matrixRoot, "results", variant, "summary.json");
-			const summary = await runVariantBenchmark({
-				variant,
-				peerbitRoot,
-				examplesSource,
-				examplesTemplate,
-				examplesRoot,
-				resultsDir,
-				summaryFile,
-				fileMb,
-				runs,
-				mode,
-				network,
-				scenario,
-				integrationMode,
-				localPackages,
-				freshExamples: !sharedExamplesRoot,
-				freshExamplesEachRun: isolatedExamples,
-				installExamples: isolatedExamples,
-				uploadTimeoutMs,
-				postUploadMonitorMs,
-				pollMs,
-				readyTimeoutMs,
-				sampleMs,
-				sampleCount,
-				targetSeeders,
-				baseUrl,
-				protocol,
-				viteMode,
-				viteConfig,
-			});
-		variantSummaries.push(summary);
+		const { peerbitRoot, resolvedCommit } = await prepareVariant({
+			variantSpec,
+			variantRoot,
+		});
+		const effectiveLocalPackageNames = [
+			...(
+				await collectLocalPeerbitPackages(peerbitRoot, {
+					names: requestedLocalPackageNames,
+				})
+			).keys(),
+		];
+		const missingRequiredPackages = defaultFileShareLocalPackages.filter(
+			(name) => !effectiveLocalPackageNames.includes(name),
+		);
+		if (
+			effectiveLocalPackageNames.length === 0 ||
+			missingRequiredPackages.length > 0
+		) {
+			throw new Error(
+				`Variant ${variant} cannot run the file-share matrix; missing effective packages: ${missingRequiredPackages.join(", ") || "all packages"}`,
+			);
+		}
+		preparedVariants.set(variant, {
+			variant,
+			variantRef:
+				variantSpec.kind === "worktree" ? "worktree" : variantSpec.ref,
+			resolvedCommit,
+			peerbitRoot,
+			effectiveLocalPackageNames,
+		});
 	}
 
-		const matrixSummary = {
+	const executionOrder = createCounterbalancedInvocationPlan({
+		variants: variantSpecs.map((spec) => spec.name),
+		modes,
+		runs,
+	});
+	const resultsByVariant = new Map(variantSpecs.map((spec) => [spec.name, []]));
+	const invocationRecords = [];
+	let benchmarkExamplesProvenance;
+	let benchmarkHarnessProvenance;
+
+	for (const plan of executionOrder) {
+		const prepared = preparedVariants.get(plan.variant);
+		if (!prepared) {
+			throw new Error(`Missing prepared variant ${plan.variant}`);
+		}
+		console.log(
+			`\n=== Invocation ${plan.sequence}/${executionOrder.length}: ${plan.variant} ${plan.mode}, repetition ${plan.run}/${runs} ===`,
+		);
+		const invocationSlug = `${String(plan.sequence).padStart(4, "0")}-${plan.variant}-${plan.mode}`;
+		const examplesRoot = path.join(
 			matrixRoot,
-			variants,
-			network,
+			"examples",
+			"invocations",
+			invocationSlug,
+		);
+		const resultsDir = path.join(
+			matrixRoot,
+			"results",
+			"invocations",
+			invocationSlug,
+		);
+		const summaryFile = path.join(resultsDir, "summary.json");
+		const invocationSummary = await runVariantBenchmark({
+			...prepared,
+			examplesSource,
+			examplesRef,
+			examplesTemplate,
+			pinnedExamplesProvenance: pinnedExamples.provenance,
+			examplesRoot,
+			resultsDir,
+			summaryFile,
 			fileMb,
-			runs,
-			mode,
+			runs: 1,
+			mode: plan.mode,
+			network,
 			scenario,
 			integrationMode,
 			localPackages,
-			examplesSource,
-			isolatedExamples,
-			sharedExamplesRoot,
-			examplesTemplate,
-			variantSummaries,
-			summary: summarizeMatrix(variantSummaries, scenario),
-			adaptiveComparison: compareAdaptiveAcrossVariants(variantSummaries, scenario),
+			freshExamples: true,
+			freshExamplesEachRun: false,
+			installExamples: false,
+			uploadTimeoutMs,
+			downloadTimeoutMs,
+			postUploadMonitorMs,
+			pollMs,
+			minReadySeeders,
+			readyTimeoutMs,
+			sampleMs,
+			sampleCount,
+			targetSeeders,
+			protocol,
+			fixtureSeed,
+			enableVisibilityProbe,
+			verbose,
+		});
+		if (
+			invocationSummary.peerbitProvenance?.resolvedCommit !==
+				prepared.resolvedCommit ||
+			invocationSummary.peerbitProvenance?.dirty !== false
+		) {
+			throw new Error(
+				`Variant ${plan.variant} did not report its exact clean resolved HEAD`,
+			);
+		}
+		if (
+			invocationSummary.examplesProvenance?.resolvedCommit !==
+				pinnedExamples.provenance.resolvedCommit ||
+			invocationSummary.examplesProvenance?.lockfileSha256 !==
+				pinnedExamples.provenance.lockfileSha256
+		) {
+			throw new Error(
+				`Variant ${plan.variant} did not use the pinned examples commit and lockfile`,
+			);
+		}
+		const [rawResult] = invocationSummary.results ?? [];
+		if (!rawResult || invocationSummary.results.length !== 1) {
+			throw new Error("Matrix invocation did not produce exactly one result");
+		}
+		if (rawResult.invocation?.baseUrl !== null) {
+			throw new Error(
+				"Matrix invocation used an effective remote PW_BASE_URL instead of its local app",
+			);
+		}
+		if (
+			JSON.stringify(rawResult.invocation?.localPackages) !==
+			JSON.stringify(prepared.effectiveLocalPackageNames)
+		) {
+			throw new Error(
+				`Variant ${plan.variant} did not bind its exact effective local package set`,
+			);
+		}
+		if (
+			rawResult.invocation?.serverMode !== "production-preview" ||
+			rawResult.invocation?.serverHost !== "127.0.0.1"
+		) {
+			throw new Error(
+				"Matrix invocation did not use the required local production preview server",
+			);
+		}
+		benchmarkExamplesProvenance ??= invocationSummary.examplesProvenance;
+		benchmarkHarnessProvenance ??= invocationSummary.harnessProvenance;
+		if (
+			JSON.stringify(benchmarkExamplesProvenance) !==
+				JSON.stringify(invocationSummary.examplesProvenance) ||
+			JSON.stringify(benchmarkHarnessProvenance) !==
+				JSON.stringify(invocationSummary.harnessProvenance)
+		) {
+			throw new Error(
+				"Matrix invocations changed harness or examples provenance",
+			);
+		}
+		const result = {
+			...rawResult,
+			variant: plan.variant,
+			run: plan.run,
+			matrixSequence: plan.sequence,
 		};
-	const matrixSummaryFile = path.join(matrixRoot, "results", "matrix-summary.json");
-	await fsp.mkdir(path.dirname(matrixSummaryFile), { recursive: true });
-	await fsp.writeFile(
-		matrixSummaryFile,
-		`${JSON.stringify(matrixSummary, null, 2)}\n`,
+		resultsByVariant.get(plan.variant).push(result);
+		invocationRecords.push({
+			...plan,
+			runNonce: result.runNonce,
+			resultFile: result.resultFile,
+			peerbitResolvedCommit: prepared.resolvedCommit,
+			effectiveLocalPackageNames: prepared.effectiveLocalPackageNames,
+		});
+	}
+
+	const variantSummaries = variantSpecs.map((variantSpec) => {
+		const prepared = preparedVariants.get(variantSpec.name);
+		const results = resultsByVariant
+			.get(variantSpec.name)
+			.toSorted((left, right) => left.matrixSequence - right.matrixSequence);
+		return {
+			variant: variantSpec.name,
+			variantRef: prepared.variantRef,
+			resolvedCommit: prepared.resolvedCommit,
+			effectiveLocalPackageNames: prepared.effectiveLocalPackageNames,
+			harnessProvenance: benchmarkHarnessProvenance,
+			peerbitProvenance: results[0]?.provenance?.peerbit,
+			examplesProvenance: benchmarkExamplesProvenance,
+			results,
+			summary: summarizeInvocationResults(results, scenario),
+			comparison:
+				scenario === "upload" ? compareCombinedUploadModes(results) : null,
+		};
+	});
+
+	const matrixSummary = {
+		schema: {
+			id: "peerbit-file-share-matrix-summary",
+			version: 2,
+		},
+		matrixBase: matrixSession.matrixBase,
+		matrixRoot,
+		matrixSessionNonce: matrixSession.nonce,
+		matrixSessionMarker: matrixSession.markerFile,
+		variants: variantSpecs,
+		network,
+		fileMb,
+		runs,
+		mode,
+		modes,
+		scenario,
+		integrationMode,
+		localPackages,
+		requestedLocalPackageNames:
+			requestedLocalPackageNames ?? "all-workspace-peerbit-packages",
+		examplesSource,
+		examplesRef,
+		examplesTemplate,
+		pinnedExamplesProvenance: pinnedExamples.provenance,
+		benchmarkExamplesProvenance,
+		benchmarkHarnessProvenance,
+		isolatedExamples: true,
+		executionOrder: invocationRecords,
+		variantSummaries,
+		summary: summarizeMatrix(variantSummaries, scenario),
+		adaptiveComparison: compareAdaptiveAcrossVariants(
+			variantSummaries,
+			scenario,
+		),
+	};
+	const matrixSummaryFile = path.join(
+		matrixRoot,
+		"results",
+		"matrix-summary.json",
 	);
+	await writeJsonAtomic(matrixSummaryFile, matrixSummary);
 
 	console.log("\nVariant summary");
 	console.table(matrixSummary.summary);

--- a/scripts/file-share/run-file-share-benchmark.mjs
+++ b/scripts/file-share/run-file-share-benchmark.mjs
@@ -1,20 +1,42 @@
 import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
+	assertBenchmarkFileSize,
+	assertCoreBenchmarkUsesLocalApp,
+	assertInvocationUnchanged,
+	createBenchmarkInvocation,
+	createNonceIsolatedResultPath,
+	createPlaywrightBenchmarkEnvironment,
+	resolveBenchmarkPreviewOptions,
+} from "./benchmark-invocation.mjs";
+import {
+	getExamplesProvenance,
+	getPeerbitProvenance,
+	resolveGitCommitAt,
+} from "./benchmark-provenance.mjs";
+import { loadAndValidateBenchmarkResult } from "./benchmark-validity.mjs";
+import {
+	buildPeerbitPackages,
+	cleanPeerbitBuildArtifacts,
+	collectLocalPeerbitPackages,
 	copyTemplate,
 	defaultExamplesDest,
 	defaultExamplesSource,
 	defaultFileShareLocalPackages,
 	ensureExamplesAssetPackageLinks,
-	overlayInstalledPackages,
+	getFileShareConsumerRoots,
+	installPinnedExamplesDependencies,
 	parseArgs,
 	prepareExamplesRepo,
 	repoRoot,
 	run,
 } from "./common.mjs";
+import { createCounterbalancedModePlan } from "./matrix-variants.mjs";
+import { instrumentFileShareViteConfigs } from "./vite-instrumentation.mjs";
 
 const SCENARIOS = {
 	upload: {
@@ -38,20 +60,11 @@ const SCENARIOS = {
 			"templates",
 			"seeder-probe.e2e.spec.ts",
 		),
-		generatedSpecPath: path.join(
-			"tests",
-			"generated.seeder-probe.e2e.spec.ts",
-		),
+		generatedSpecPath: path.join("tests", "generated.seeder-probe.e2e.spec.ts"),
 	},
 };
 const DROP_HOOK_MARKER = "/* peerbit-benchmark-hook */";
 const DROP_UPDATE_LIST_MARKER = "/* peerbit-benchmark-update-list */";
-const VITE_BENCHMARK_MARKER = "/* peerbit-benchmark-vite */";
-const REMOTE_NETWORK_DEFAULTS = {
-	viteMode: "staging",
-	viteConfig: "vite.config.remote.ts",
-};
-
 const getScenarioConfig = (scenario) => {
 	const config = SCENARIOS[scenario];
 	if (!config) {
@@ -60,70 +73,6 @@ const getScenarioConfig = (scenario) => {
 		);
 	}
 	return config;
-};
-
-const injectViteBenchmarkResolveGuards = (contents, filePath, frontendRoot) => {
-	let next = contents;
-	if (!next.includes("resolve: {")) {
-		throw new Error(`Could not find resolve block in ${filePath}`);
-	}
-	const examplesNodeModules = path.resolve(frontendRoot, "..", "..", "..", "node_modules");
-	const reactAliasBlock = `        ${VITE_BENCHMARK_MARKER}
-        alias: {
-            react: ${JSON.stringify(path.join(examplesNodeModules, "react"))},
-            "react-dom": ${JSON.stringify(path.join(examplesNodeModules, "react-dom"))},
-            "@dao-xyz/borsh": ${JSON.stringify(
-				path.join(examplesNodeModules, "@dao-xyz", "borsh"),
-			)},
-        },\n`;
-		next = next.replace(
-			/ {8}\/\* peerbit-benchmark-vite \*\/\n {8}alias: \{\n[\s\S]*? {8}\},\n/,
-			reactAliasBlock,
-		);
-	if (next.includes(`${VITE_BENCHMARK_MARKER}\n        preserveSymlinks: true,\n`)) {
-		next = next.replace(
-			`${VITE_BENCHMARK_MARKER}\n        preserveSymlinks: true,\n`,
-			reactAliasBlock,
-		);
-	}
-	if (!next.includes(VITE_BENCHMARK_MARKER)) {
-		next = next.replace("    resolve: {\n", `    resolve: {\n${reactAliasBlock}`);
-	}
-	if (!next.includes('"react",')) {
-		next = next.replace(
-			"        dedupe: [\n",
-			`        dedupe: [\n            "react",\n            "react-dom",\n`,
-		);
-	}
-	if (!next.includes('"@dao-xyz/borsh",')) {
-		next = next.replace(
-			'            "react-dom",\n',
-			'            "react-dom",\n            "@dao-xyz/borsh",\n',
-		);
-	}
-	next = next.replace(
-		'        include: [\n            "react",\n            "react-dom",\n',
-		"        include: [\n",
-	);
-	return next;
-};
-
-const instrumentFileShareViteConfigs = async (frontendRoot) => {
-	for (const configName of ["vite.config.ts", "vite.config.remote.ts"]) {
-		const configPath = path.join(frontendRoot, configName);
-		if (!fs.existsSync(configPath)) {
-			continue;
-		}
-		const contents = await fsp.readFile(configPath, "utf8");
-		const next = injectViteBenchmarkResolveGuards(
-			contents,
-			configPath,
-			frontendRoot,
-		);
-		if (next !== contents) {
-			await fsp.writeFile(configPath, next);
-		}
-	}
 };
 
 const maybeCopyFrontendCerts = async ({
@@ -337,10 +286,10 @@ const cleanupFrontendBenchmarkArtifacts = async (frontendRoot) => {
 const average = (values) =>
 	values.length > 0
 		? Number(
-				(
-					values.reduce((sum, value) => sum + value, 0) / values.length
-				).toFixed(1),
-		  )
+				(values.reduce((sum, value) => sum + value, 0) / values.length).toFixed(
+					1,
+				),
+			)
 		: null;
 
 const summarizeUploadResults = (results) => {
@@ -367,6 +316,11 @@ const summarizeUploadResults = (results) => {
 				.map((item) => item.phaseDurationsMs?.timeToUploadSettled)
 				.filter((value) => typeof value === "number"),
 		),
+		listingDurationMsAvg: average(
+			items
+				.map((item) => item.listingDurationMs)
+				.filter((value) => typeof value === "number"),
+		),
 		writerListingLagMsAvg: average(
 			items
 				.filter((item) => item.status === "passed")
@@ -377,6 +331,16 @@ const summarizeUploadResults = (results) => {
 			items
 				.filter((item) => item.status === "passed")
 				.map((item) => item.phaseDurationsMs?.readerListingLag)
+				.filter((value) => typeof value === "number"),
+		),
+		postUploadMonitorDurationMsAvg: average(
+			items
+				.map((item) => item.postUploadMonitorDurationMs)
+				.filter((value) => typeof value === "number"),
+		),
+		downloadDurationMsAvg: average(
+			items
+				.map((item) => item.downloadDurationMs)
 				.filter((value) => typeof value === "number"),
 		),
 		errorCount: items.reduce((sum, item) => sum + item.errorCount, 0),
@@ -392,9 +356,7 @@ const summarizeSeederProbeResults = (results) => {
 		grouped.set(result.mode, arr);
 	}
 	const sampleMetric = (result, fn) =>
-		(result.samples ?? [])
-			.map(fn)
-			.filter((value) => typeof value === "number");
+		(result.samples ?? []).map(fn).filter((value) => typeof value === "number");
 	return [...grouped.entries()].map(([mode, items]) => ({
 		mode,
 		runs: items.length,
@@ -475,47 +437,13 @@ const compareUploadModes = (results) => {
 	};
 };
 
-const buildPeerbitForFileShare = (peerbitRoot) => {
-	run(
-		"pnpm",
-		[
-			"--filter", "@peerbit/build-assets...",
-			"--filter", "@peerbit/any-store-opfs...",
-			"--filter", "peerbit...",
-			"--filter", "@peerbit/react...",
-			"--filter", "@peerbit/document...",
-			"--filter", "@peerbit/shared-log...",
-			"--filter", "@peerbit/stream...",
-			"--filter", "@peerbit/crypto...",
-			"--filter", "@peerbit/trusted-network...",
-			"--filter", "@peerbit/vite...",
-			"--filter", "@peerbit/test-utils...",
-			"build",
-		],
-		{ cwd: peerbitRoot },
-	);
-};
-
 const runPlaywright = ({
 	frontendRoot,
-	scenario,
 	generatedSpecPath,
-	mode,
-	fileMb,
 	resultFile,
-	network,
-	uploadTimeoutMs,
-	postUploadMonitorMs,
-	pollMs,
-	minReadySeeders,
-	readyTimeoutMs,
-	sampleMs,
-	sampleCount,
-	targetSeeders,
-	baseUrl,
-	protocol,
-	viteMode,
-	viteConfig,
+	runNonce,
+	provenance,
+	invocation,
 }) => {
 	const startedAt = Date.now();
 	const child = spawnSync(
@@ -534,68 +462,142 @@ const runPlaywright = ({
 		{
 			cwd: frontendRoot,
 			stdio: "inherit",
-			env: {
-				...process.env,
-				PW_FILE_MB: String(fileMb),
-				PW_REPLICATION_MODE: mode,
-				PW_RESULT_FILE: resultFile,
-				PW_BENCHMARK_SCENARIO: scenario,
-				PW_NETWORK_MODE: network,
-				...(minReadySeeders != null
-					? { PW_MIN_READY_SEEDERS: String(minReadySeeders) }
-					: {}),
-				...(uploadTimeoutMs
-					? { PW_UPLOAD_TIMEOUT_MS: String(uploadTimeoutMs) }
-					: {}),
-				...(postUploadMonitorMs
-					? { PW_POST_UPLOAD_MONITOR_MS: String(postUploadMonitorMs) }
-					: {}),
-				...(pollMs ? { PW_POLL_MS: String(pollMs) } : {}),
-				...(readyTimeoutMs
-					? { PW_READY_TIMEOUT_MS: String(readyTimeoutMs) }
-					: {}),
-				...(sampleMs ? { PW_SAMPLE_MS: String(sampleMs) } : {}),
-				...(sampleCount ? { PW_SAMPLE_COUNT: String(sampleCount) } : {}),
-				...(targetSeeders
-					? { PW_TARGET_SEEDERS: String(targetSeeders) }
-					: {}),
-				...(baseUrl ? { PW_BASE_URL: baseUrl } : {}),
-				...(protocol ? { PW_PROTOCOL: protocol } : {}),
-				...(viteMode ? { PW_VITE_MODE: viteMode } : {}),
-				...(viteConfig ? { PW_VITE_CONFIG: viteConfig } : {}),
-			},
+			env: createPlaywrightBenchmarkEnvironment({
+				baseEnvironment: process.env,
+				invocation,
+				resultFile,
+				runNonce,
+				provenance,
+			}),
 		},
 	);
 	return {
 		wallTimeMs: Date.now() - startedAt,
-		exitCode: child.status ?? (child.error ? 1 : 0),
+		exitCode: child.status,
+		signal: child.signal,
+		spawnError: child.error,
 	};
+};
+
+const parsePositiveInteger = (value, label) => {
+	const parsed = Number(value);
+	if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+		throw new Error(`${label} must be a positive safe integer`);
+	}
+	return parsed;
+};
+
+const parseNonNegativeNumber = (value, label) => {
+	if (value == null) {
+		return undefined;
+	}
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed) || parsed < 0) {
+		throw new Error(`${label} must be a finite non-negative number`);
+	}
+	return parsed;
+};
+
+const parseNonNegativeInteger = (value, label) => {
+	if (value == null) {
+		return undefined;
+	}
+	const parsed = Number(value);
+	if (!Number.isSafeInteger(parsed) || parsed < 0) {
+		throw new Error(`${label} must be a non-negative safe integer`);
+	}
+	return parsed;
+};
+
+const parseOptionalPositiveInteger = (value, label) =>
+	value == null ? undefined : parsePositiveInteger(value, label);
+
+const writeJsonAtomic = async (filePath, value) => {
+	await fsp.mkdir(path.dirname(filePath), { recursive: true });
+	const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+	await fsp.writeFile(temporaryPath, `${JSON.stringify(value, null, 2)}\n`);
+	await fsp.rename(temporaryPath, filePath);
 };
 
 const main = async () => {
 	const args = parseArgs(process.argv.slice(2));
-	const peerbitRoot = args["peerbit-root"] ?? repoRoot;
-	const examplesRoot = args["examples-root"] ?? defaultExamplesDest();
-	const freshEachRun = Boolean(args["fresh-each-run"]);
-	const fileMb = Number(args["file-mb"] ?? "25");
-	const runs = Number(args.runs ?? "1");
-	const requestedMode = args.mode ?? "both";
-	const modes = requestedMode === "both" ? ["adaptive", "fixed1"] : [requestedMode];
-	const scenario = args.scenario ?? "upload";
-	const network = args.network ?? "local";
-	const uploadTimeoutMs = args["upload-timeout-ms"];
-	const postUploadMonitorMs = args["post-upload-monitor-ms"];
-	const pollMs = args["poll-ms"];
-	const minReadySeeders = args["min-ready-seeders"];
-	const readyTimeoutMs = args["ready-timeout-ms"];
-	const sampleMs = args["sample-ms"];
-	const sampleCount = args["sample-count"];
-	const targetSeeders = args["target-seeders"];
 	const baseUrl = args["base-url"];
+	assertCoreBenchmarkUsesLocalApp(baseUrl);
+	const previewOptions = resolveBenchmarkPreviewOptions({
+		protocol: args.protocol,
+		viteMode: args["vite-mode"],
+		viteConfig: args["vite-config"],
+	});
+	const requestedSummaryFile = args["summary-file"]
+		? path.resolve(args["summary-file"])
+		: undefined;
+	const peerbitRoot = path.resolve(args["peerbit-root"] ?? repoRoot);
+	const examplesRoot = path.resolve(
+		args["examples-root"] ?? defaultExamplesDest(),
+	);
+	const freshEachRun = Boolean(args["fresh-each-run"]);
+	const fileMb = parseNonNegativeNumber(args["file-mb"] ?? "25", "--file-mb");
+	if (!Number.isSafeInteger(fileMb * 1024 * 1024)) {
+		throw new Error("--file-mb must resolve to a safe integer byte count");
+	}
+	if (fileMb <= 0) {
+		throw new Error("--file-mb must be greater than zero");
+	}
+	const runs = parsePositiveInteger(args.runs ?? "1", "--runs");
+	const requestedMode = args.mode ?? "both";
+	const modes =
+		requestedMode === "both" ? ["adaptive", "fixed1"] : [requestedMode];
+	const scenario = args.scenario ?? "upload";
+	assertBenchmarkFileSize({ scenario, fileMb });
+	const network = args.network ?? "local";
+	const uploadTimeoutMs = parseOptionalPositiveInteger(
+		args["upload-timeout-ms"],
+		"--upload-timeout-ms",
+	);
+	const downloadTimeoutMs = parseOptionalPositiveInteger(
+		args["download-timeout-ms"],
+		"--download-timeout-ms",
+	);
+	const postUploadMonitorMs = parseNonNegativeInteger(
+		args["post-upload-monitor-ms"],
+		"--post-upload-monitor-ms",
+	);
+	const pollMs = parseOptionalPositiveInteger(args["poll-ms"], "--poll-ms");
+	const minReadySeeders = parseNonNegativeInteger(
+		args["min-ready-seeders"],
+		"--min-ready-seeders",
+	);
+	const readyTimeoutMs = parseOptionalPositiveInteger(
+		args["ready-timeout-ms"],
+		"--ready-timeout-ms",
+	);
+	const sampleMs = parseOptionalPositiveInteger(
+		args["sample-ms"],
+		"--sample-ms",
+	);
+	const sampleCount = args["sample-count"]
+		? parsePositiveInteger(args["sample-count"], "--sample-count")
+		: undefined;
+	const targetSeeders = parseNonNegativeInteger(
+		args["target-seeders"],
+		"--target-seeders",
+	);
 	const examplesSource = args.source ?? defaultExamplesSource();
-	const requestedProtocol = args.protocol;
+	const fixtureSeed = args["fixture-seed"];
+	const resolvedFixtureSeed = fixtureSeed ?? "peerbit-file-share-benchmark-v1";
+	const peerbitRefLabel = args["peerbit-ref-label"] ?? "worktree";
+	const expectedPeerbitCommit =
+		args["expected-peerbit-commit"] ??
+		resolveGitCommitAt(
+			peerbitRoot,
+			peerbitRefLabel === "worktree" ? "HEAD" : peerbitRefLabel,
+		);
+	const examplesRequestedRef = args["examples-ref"] ?? "HEAD";
+	const expectedExamplesCommit = args["expected-examples-commit"];
+	const expectedExamplesLockfileSha256 =
+		args["expected-examples-lockfile-sha256"];
 	const scenarioConfig = getScenarioConfig(scenario);
-	const integrationMode = args["integration-mode"] ?? "overlay";
+	const integrationMode = args["integration-mode"] ?? "link";
 	const localPackagesArg = args["local-packages"];
 	const localPackageNames =
 		integrationMode === "none"
@@ -606,26 +608,70 @@ const main = async () => {
 						.split(",")
 						.map((value) => value.trim())
 						.filter(Boolean);
+	const effectiveLocalPackageNames = [
+		...(
+			await collectLocalPeerbitPackages(peerbitRoot, {
+				names: localPackageNames,
+			})
+		).keys(),
+	];
 
 	if (!["local", "remote"].includes(network)) {
-		throw new Error(`Unsupported --network "${network}". Expected "local" or "remote".`);
-	}
-	if (!["none", "link", "overlay"].includes(integrationMode)) {
 		throw new Error(
-			`Unsupported --integration-mode "${integrationMode}". Expected "none", "link", or "overlay".`,
+			`Unsupported --network "${network}". Expected "local" or "remote".`,
 		);
 	}
-
-	const viteMode =
-		args["vite-mode"] ??
-		(network === "remote" ? REMOTE_NETWORK_DEFAULTS.viteMode : undefined);
-	const viteConfig =
-		args["vite-config"] ??
-		(network === "remote" ? REMOTE_NETWORK_DEFAULTS.viteConfig : undefined);
-
-	if (args["build-peerbit"]) {
-		buildPeerbitForFileShare(peerbitRoot);
+	if (
+		modes.some((mode) => !["adaptive", "fixed1", "observer"].includes(mode))
+	) {
+		throw new Error(
+			`Unsupported --mode "${requestedMode}". Expected adaptive, fixed1, observer, or both.`,
+		);
 	}
+	if (!["none", "link"].includes(integrationMode)) {
+		throw new Error(
+			`Unsupported --integration-mode "${integrationMode}". Evidence-producing benchmarks require "link" so package metadata and dependencies match the selected Peerbit checkout; "none" benchmarks only the pinned published dependencies.`,
+		);
+	}
+	if (integrationMode === "link" && effectiveLocalPackageNames.length === 0) {
+		throw new Error(
+			"link integration requires at least one local Peerbit package",
+		);
+	}
+	if (requestedSummaryFile) {
+		await fsp.rm(requestedSummaryFile, { force: true });
+	}
+
+	const { protocol, viteMode, viteConfig } = previewOptions;
+	if (integrationMode === "link") {
+		run("pnpm", ["install", "--frozen-lockfile"], { cwd: peerbitRoot });
+		await cleanPeerbitBuildArtifacts({
+			peerbitRoot,
+			packageNames: effectiveLocalPackageNames,
+		});
+		buildPeerbitPackages(peerbitRoot, effectiveLocalPackageNames);
+	} else if (args["build-peerbit"]) {
+		buildPeerbitPackages(peerbitRoot, defaultFileShareLocalPackages);
+	}
+	const harnessProvenance = await getPeerbitProvenance({
+		root: repoRoot,
+		requestedRef: "harness-worktree",
+	});
+	const peerbitProvenance = await getPeerbitProvenance({
+		root: peerbitRoot,
+		requestedRef: peerbitRefLabel,
+		requireClean: Boolean(args["require-clean-peerbit"]),
+		expectedResolvedCommit: expectedPeerbitCommit,
+	});
+	const templateProvenance = args.template
+		? await getExamplesProvenance({
+				root: path.resolve(args.template),
+				requestedRef: examplesRequestedRef,
+				fallbackResolvedCommit: expectedExamplesCommit,
+				expectedResolvedCommit: expectedExamplesCommit,
+				expectedLockfileSha256: expectedExamplesLockfileSha256,
+			})
+		: undefined;
 
 	const prepareBenchmarkCheckout = async ({ fresh }) => {
 		await prepareExamplesRepo({
@@ -634,9 +680,10 @@ const main = async () => {
 			dest: examplesRoot,
 			peerbitRoot,
 			fresh,
-			install: Boolean(args.install),
+			install: false,
 			localPackageNames,
-			applyOverrides: integrationMode === "link",
+			applyOverrides: false,
+			ref: examplesRequestedRef,
 		});
 
 		const frontendRoot = path.join(
@@ -645,6 +692,17 @@ const main = async () => {
 			"file-share",
 			"frontend",
 		);
+		const examplesProvenance = await getExamplesProvenance({
+			root: examplesRoot,
+			requestedRef: examplesRequestedRef,
+			fallbackProvenance: templateProvenance,
+			fallbackResolvedCommit: expectedExamplesCommit,
+			expectedResolvedCommit:
+				expectedExamplesCommit ?? templateProvenance?.resolvedCommit,
+			expectedLockfileSha256:
+				expectedExamplesLockfileSha256 ?? templateProvenance?.lockfileSha256,
+		});
+		await installPinnedExamplesDependencies(examplesRoot);
 		await maybeCopyFrontendCerts({
 			frontendRoot,
 			sourceRoot: examplesSource,
@@ -661,98 +719,146 @@ const main = async () => {
 			outputPath: generatedSpec,
 		});
 
-		if (!fs.existsSync(path.join(examplesRoot, "node_modules"))) {
-			run("pnpm", ["install"], { cwd: examplesRoot });
-		}
 		if (integrationMode === "link") {
 			await ensureExamplesAssetPackageLinks({
 				examplesRoot,
 				peerbitRoot,
-				packageNames: localPackageNames,
-			});
-		} else if (integrationMode === "overlay") {
-			await overlayInstalledPackages({
-				examplesRoot,
-				peerbitRoot,
-				packageNames: localPackageNames,
+				packageNames: effectiveLocalPackageNames,
+				consumerRoots: getFileShareConsumerRoots(examplesRoot),
 			});
 		}
-		return { frontendRoot };
+		return { frontendRoot, examplesProvenance };
 	};
 
-	let { frontendRoot } = await prepareBenchmarkCheckout({
+	let { frontendRoot, examplesProvenance } = await prepareBenchmarkCheckout({
 		fresh: Boolean(args.fresh),
 	});
-	let protocol =
-		requestedProtocol ??
-		(network === "remote" && !baseUrl
-			? fs.existsSync(path.join(frontendRoot, ".cert", "key.pem"))
-				? "https"
-				: "http"
-			: undefined);
+	const expectedExamplesProvenance = { ...examplesProvenance };
 
 	const requestedResultsDir = args["results-dir"];
-	const resultsDir = requestedResultsDir
+	const resultsRoot = requestedResultsDir
 		? path.resolve(requestedResultsDir)
-		: await fsp.mkdtemp(path.join(os.tmpdir(), "peerbit-file-share-benchmark-"));
+		: await fsp.mkdtemp(
+				path.join(os.tmpdir(), "peerbit-file-share-benchmark-"),
+			);
 	if (requestedResultsDir) {
-		await fsp.mkdir(resultsDir, { recursive: true });
+		await fsp.mkdir(resultsRoot, { recursive: true });
 	}
+	const sessionNonce = randomUUID();
+	const resultsDir = path.join(resultsRoot, `session-${sessionNonce}`);
+	await fsp.mkdir(resultsDir, { recursive: false });
 	const results = [];
 	let benchmarkInvocationCount = 0;
+	const executionOrder = createCounterbalancedModePlan({ modes, runs });
 
-	for (const mode of modes) {
-		for (let runIndex = 1; runIndex <= runs; runIndex++) {
-			if (freshEachRun && benchmarkInvocationCount > 0) {
-				({ frontendRoot } = await prepareBenchmarkCheckout({ fresh: true }));
-				protocol =
-					requestedProtocol ??
-					(network === "remote" && !baseUrl
-						? fs.existsSync(path.join(frontendRoot, ".cert", "key.pem"))
-							? "https"
-							: "http"
-						: undefined);
-			}
-			const resultFile = path.join(resultsDir, `${mode}-${runIndex}.json`);
-			console.log(
-				`Running file-share benchmark scenario=${scenario} network=${network} mode=${mode} run=${runIndex}/${runs} fileMb=${fileMb}`,
+	for (const { sequence, mode, run: runIndex } of executionOrder) {
+		if (freshEachRun && benchmarkInvocationCount > 0) {
+			({ frontendRoot, examplesProvenance } = await prepareBenchmarkCheckout({
+				fresh: true,
+			}));
+			assertInvocationUnchanged(
+				examplesProvenance,
+				expectedExamplesProvenance,
+				"Pre-instrumentation examples provenance",
 			);
-			await cleanupFrontendBenchmarkArtifacts(frontendRoot);
-			const { wallTimeMs, exitCode } = runPlaywright({
-				frontendRoot,
-				scenario,
-				generatedSpecPath: scenarioConfig.generatedSpecPath,
-				mode,
-				fileMb,
-				resultFile,
-				network,
-				uploadTimeoutMs,
-				postUploadMonitorMs,
-				pollMs,
-				minReadySeeders,
-				readyTimeoutMs,
-				sampleMs,
-				sampleCount,
-				targetSeeders,
-				baseUrl,
-				protocol,
-				viteMode,
-				viteConfig,
-			});
-			if (!fs.existsSync(resultFile)) {
-				throw new Error(
-					`Benchmark run did not produce ${resultFile} (mode=${mode}, exitCode=${exitCode})`,
-				);
-			}
-			const result = JSON.parse(await fsp.readFile(resultFile, "utf8"));
-			results.push({
-				...result,
-				run: runIndex,
-				playwrightWallTimeMs: wallTimeMs,
-				playwrightExitCode: exitCode,
-			});
-			benchmarkInvocationCount++;
 		}
+		const runNonce = randomUUID();
+		const invocation = createBenchmarkInvocation({
+			scenario,
+			mode,
+			network,
+			integrationMode,
+			fileMb,
+			fixtureSeed: resolvedFixtureSeed,
+			uploadTimeoutMs,
+			downloadTimeoutMs,
+			postUploadMonitorMs,
+			pollMs,
+			minReadySeeders,
+			readyTimeoutMs,
+			sampleMs,
+			sampleCount,
+			targetSeeders,
+			baseUrl,
+			protocol,
+			viteMode,
+			viteConfig,
+			localPackages: effectiveLocalPackageNames,
+			enableVisibilityProbe: Boolean(args["enable-visibility-probe"]),
+			verbose: Boolean(args.verbose),
+		});
+		const resultFile = createNonceIsolatedResultPath({
+			resultsDir,
+			runNonce,
+		});
+		console.log(
+			`Running file-share benchmark sequence=${sequence}/${executionOrder.length} scenario=${scenario} network=${network} mode=${mode} run=${runIndex}/${runs} fileMb=${fileMb}`,
+		);
+		await cleanupFrontendBenchmarkArtifacts(frontendRoot);
+		await fsp.rm(resultFile, { force: true });
+		const provenance = {
+			harness: harnessProvenance,
+			peerbit: peerbitProvenance,
+			examples: examplesProvenance,
+		};
+		const { wallTimeMs, exitCode, signal, spawnError } = runPlaywright({
+			frontendRoot,
+			generatedSpecPath: scenarioConfig.generatedSpecPath,
+			resultFile,
+			runNonce,
+			provenance,
+			invocation,
+		});
+		if (spawnError) {
+			throw new Error(
+				`Could not start Playwright benchmark: ${spawnError.message}`,
+				{
+					cause: spawnError,
+				},
+			);
+		}
+		if (signal) {
+			throw new Error(`Playwright benchmark terminated by signal ${signal}`);
+		}
+		const result = await loadAndValidateBenchmarkResult({
+			resultFile,
+			exitCode,
+			scenario,
+			expectedMode: mode,
+			expectedFileMb: fileMb,
+			expectedNetwork: network,
+			expectedFixtureSeed: resolvedFixtureSeed,
+			expectedRunNonce: runNonce,
+			expectedProvenance: provenance,
+			expectedInvocation: invocation,
+		});
+		assertInvocationUnchanged(
+			await getPeerbitProvenance({
+				root: repoRoot,
+				requestedRef: "harness-worktree",
+			}),
+			harnessProvenance,
+			"Harness provenance",
+		);
+		assertInvocationUnchanged(
+			await getPeerbitProvenance({
+				root: peerbitRoot,
+				requestedRef: peerbitRefLabel,
+				requireClean: Boolean(args["require-clean-peerbit"]),
+				expectedResolvedCommit: expectedPeerbitCommit,
+			}),
+			peerbitProvenance,
+			"Peerbit provenance",
+		);
+		results.push({
+			...result,
+			run: runIndex,
+			invocationSequence: sequence,
+			resultFile,
+			playwrightWallTimeMs: wallTimeMs,
+			playwrightExitCode: exitCode,
+		});
+		benchmarkInvocationCount++;
 	}
 
 	console.log("\nPer-run results");
@@ -775,8 +881,12 @@ const main = async () => {
 					: null,
 			uploadDurationMs: result.uploadDurationMs,
 			uploadSettledMs: result.phaseDurationsMs?.timeToUploadSettled ?? null,
+			listingDurationMs: result.listingDurationMs ?? null,
 			writerListingLagMs: result.phaseDurationsMs?.writerListingLag ?? null,
 			readerListingLagMs: result.phaseDurationsMs?.readerListingLag ?? null,
+			postUploadMonitorDurationMs: result.postUploadMonitorDurationMs ?? null,
+			downloadDurationMs: result.downloadDurationMs ?? null,
+			integrityVerified: result.integrityVerified ?? null,
 			playwrightWallTimeMs: result.playwrightWallTimeMs,
 			playwrightExitCode: result.playwrightExitCode,
 			droppedSeeders: result.droppedSeeders,
@@ -792,25 +902,33 @@ const main = async () => {
 		console.table([comparison]);
 	}
 	const summary = {
+		schema: {
+			id: "peerbit-file-share-benchmark-summary",
+			version: 2,
+		},
+		sessionNonce,
+		harnessProvenance,
 		peerbitRoot,
+		peerbitProvenance,
 		examplesRoot,
+		examplesProvenance: expectedExamplesProvenance,
 		frontendRoot,
 		scenario,
 		integrationMode,
-		localPackageNames: localPackageNames ?? "all",
+		localPackageNames: effectiveLocalPackageNames,
 		network,
 		fileMb,
-			runs,
-			modes,
-			resultsDir,
-			results,
-			summary: summarizeResults(results, scenario),
-			comparison,
+		runs,
+		modes,
+		executionOrder,
+		resultsRoot,
+		resultsDir,
+		results,
+		summary: summarizeResults(results, scenario),
+		comparison,
 	};
-	if (args["summary-file"]) {
-		const summaryFile = path.resolve(args["summary-file"]);
-		await fsp.mkdir(path.dirname(summaryFile), { recursive: true });
-		await fsp.writeFile(summaryFile, `${JSON.stringify(summary, null, 2)}\n`);
+	if (requestedSummaryFile) {
+		await writeJsonAtomic(requestedSummaryFile, summary);
 	}
 	console.log(`\nRaw results: ${resultsDir}`);
 };

--- a/scripts/file-share/template-contract.test.mjs
+++ b/scripts/file-share/template-contract.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { repoRoot } from "./common.mjs";
+
+const templates = [
+	"upload-benchmark.local.e2e.spec.ts",
+	"seeder-probe.e2e.spec.ts",
+];
+
+for (const name of templates) {
+	test(`${name} emits the atomic v2 invocation envelope`, async () => {
+		const contents = await readFile(
+			path.join(repoRoot, "scripts", "file-share", "templates", name),
+			"utf8",
+		);
+		for (const required of [
+			'id: "peerbit-file-share-benchmark"',
+			"version: 2",
+			"PW_BENCHMARK_RUN_NONCE",
+			"PW_BENCHMARK_INVOCATION",
+			"PW_BENCHMARK_PROVENANCE",
+			'process.env.PW_BENCH !== "1"',
+			'serverMode: "production-preview"',
+			"schema: RESULT_SCHEMA",
+			"runNonce: RUN_NONCE",
+			"invocation: INVOCATION",
+			"provenance: PROVENANCE",
+			"await rename(temporaryPath, RESULT_FILE)",
+			"await rm(temporaryPath, { force: true })",
+		]) {
+			assert.ok(contents.includes(required), `missing ${required}`);
+		}
+		assert.ok(
+			contents.indexOf("await writeFile(temporaryPath") <
+				contents.indexOf("await rename(temporaryPath, RESULT_FILE)"),
+			"result must be fully written before its atomic rename",
+		);
+		assert.ok(
+			contents.indexOf("await rename(temporaryPath, RESULT_FILE)") <
+				contents.indexOf("await rm(temporaryPath, { force: true })"),
+			"a failed atomic rename must clean its temporary result",
+		);
+		assert.ok(
+			!contents.includes("`error:${error.message}`"),
+			"seeder-count failures must reject instead of becoming sample strings",
+		);
+	});
+}
+
+test("seeder probe records enforceable convergence timing evidence", async () => {
+	const contents = await readFile(
+		path.join(
+			repoRoot,
+			"scripts",
+			"file-share",
+			"templates",
+			"seeder-probe.e2e.spec.ts",
+		),
+		"utf8",
+	);
+	for (const required of [
+		"readyDeadlineAt = probeStartedAt + READY_TIMEOUT_MS",
+		"current.writerSeeders >= TARGET_SEEDERS",
+		"current.readerSeeders >= TARGET_SEEDERS",
+		"probeDurationMs",
+		"timeToTargetMs",
+		"targetSampleLabel",
+		"effectiveSampleIntervalMs",
+	]) {
+		assert.ok(contents.includes(required), `missing ${required}`);
+	}
+});
+
+test("upload probe fails closed and records bounded scheduling tolerances", async () => {
+	const contents = await readFile(
+		path.join(
+			repoRoot,
+			"scripts",
+			"file-share",
+			"templates",
+			"upload-benchmark.local.e2e.spec.ts",
+		),
+		"utf8",
+	);
+	for (const required of [
+		"readSeederCount(writer",
+		"readSeederCount(reader",
+		"POST_MONITOR_SCHEDULING_TOLERANCE_MS",
+		"TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS",
+		"Measured transfer duration exceeded",
+	]) {
+		assert.ok(contents.includes(required), `missing ${required}`);
+	}
+});

--- a/scripts/file-share/templates/seeder-probe.e2e.spec.ts
+++ b/scripts/file-share/templates/seeder-probe.e2e.spec.ts
@@ -1,13 +1,9 @@
-import { test, type Page } from "@playwright/test";
-import { mkdir, writeFile } from "node:fs/promises";
+import { type Page, test } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { startBootstrapPeer } from "./bootstrapPeer";
-import {
-	createSpace,
-	getSeederCount,
-	rootUrl,
-	withBootstrap,
-} from "./helpers";
+import { createSpace, getSeederCount, rootUrl, withBootstrap } from "./helpers";
 
 const MODE = process.env.PW_REPLICATION_MODE || "adaptive";
 const NETWORK_MODE = process.env.PW_NETWORK_MODE || "local";
@@ -16,9 +12,84 @@ const READY_TIMEOUT_MS = Number(process.env.PW_READY_TIMEOUT_MS || "180000");
 const SAMPLE_MS = Number(process.env.PW_SAMPLE_MS || "15000");
 const SAMPLE_COUNT = Number(process.env.PW_SAMPLE_COUNT || "4");
 const TARGET_SEEDERS = Number(process.env.PW_TARGET_SEEDERS || "2");
+const SAMPLE_COUNT_DEFINITION =
+	"observation-density divisor: planned interval is min(sampleMs, floor(readyTimeoutMs/sampleCount)) clamped to 1ms; convergence may finish early";
+const EFFECTIVE_SAMPLE_INTERVAL_MS = Math.max(
+	1,
+	Math.min(SAMPLE_MS, Math.max(1, Math.floor(READY_TIMEOUT_MS / SAMPLE_COUNT))),
+);
+const RESULT_SCHEMA = {
+	id: "peerbit-file-share-benchmark",
+	version: 2,
+} as const;
+const RUN_NONCE = process.env.PW_BENCHMARK_RUN_NONCE;
+const parseJsonEnvironment = (name: string) => {
+	const encoded = process.env[name];
+	if (!encoded) {
+		throw new Error(`Missing ${name}`);
+	}
+	try {
+		return JSON.parse(encoded) as Record<string, unknown>;
+	} catch (error) {
+		throw new Error(`Malformed ${name}`, { cause: error });
+	}
+};
+const PROVENANCE = parseJsonEnvironment("PW_BENCHMARK_PROVENANCE");
+const INVOCATION = parseJsonEnvironment("PW_BENCHMARK_INVOCATION");
 
 if (!["local", "remote"].includes(NETWORK_MODE)) {
 	throw new Error(`Unsupported PW_NETWORK_MODE='${NETWORK_MODE}'`);
+}
+if (!RUN_NONCE) {
+	throw new Error("Missing PW_BENCHMARK_RUN_NONCE");
+}
+if (process.env.PW_BENCH !== "1") {
+	throw new Error("Seeder benchmark must run against the production preview");
+}
+if (!Number.isSafeInteger(READY_TIMEOUT_MS) || READY_TIMEOUT_MS <= 0) {
+	throw new Error(
+		`Invalid PW_READY_TIMEOUT_MS='${process.env.PW_READY_TIMEOUT_MS}'`,
+	);
+}
+if (!Number.isSafeInteger(SAMPLE_MS) || SAMPLE_MS <= 0) {
+	throw new Error(`Invalid PW_SAMPLE_MS='${process.env.PW_SAMPLE_MS}'`);
+}
+if (!Number.isSafeInteger(SAMPLE_COUNT) || SAMPLE_COUNT <= 0) {
+	throw new Error(`Invalid PW_SAMPLE_COUNT='${process.env.PW_SAMPLE_COUNT}'`);
+}
+if (!Number.isSafeInteger(TARGET_SEEDERS) || TARGET_SEEDERS < 0) {
+	throw new Error(
+		`Invalid PW_TARGET_SEEDERS='${process.env.PW_TARGET_SEEDERS}'`,
+	);
+}
+if (
+	(INVOCATION.schema as Record<string, unknown> | undefined)?.id !==
+		"peerbit-file-share-benchmark-invocation" ||
+	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 1
+) {
+	throw new Error("Unsupported PW_BENCHMARK_INVOCATION schema");
+}
+const expectedInvocationValues: Record<string, unknown> = {
+	scenario: "seeder-probe",
+	mode: MODE,
+	networkMode: NETWORK_MODE,
+	readyTimeoutMs: READY_TIMEOUT_MS,
+	sampleMs: SAMPLE_MS,
+	sampleCount: SAMPLE_COUNT,
+	targetSeeders: TARGET_SEEDERS,
+	baseUrl: process.env.PW_BASE_URL || null,
+	protocol: process.env.PW_PROTOCOL || null,
+	viteMode: process.env.PW_VITE_MODE || null,
+	viteConfig: process.env.PW_VITE_CONFIG || null,
+	serverMode: "production-preview",
+	serverHost: process.env.HOST || null,
+};
+for (const [key, expected] of Object.entries(expectedInvocationValues)) {
+	if (INVOCATION[key] !== expected) {
+		throw new Error(
+			`PW_BENCHMARK_INVOCATION.${key} does not match the effective environment`,
+		);
+	}
 }
 
 const ROLE_BY_MODE: Record<string, any> = {
@@ -116,12 +187,49 @@ const getBodyText = async (page: Page) =>
 		.then((text) => text.slice(0, 500))
 		.catch(() => null);
 
+const withDeadline = async <T>(
+	promise: Promise<T>,
+	deadlineAt: number,
+	label: string,
+): Promise<T> => {
+	const remainingMs = deadlineAt - Date.now();
+	if (remainingMs <= 0) {
+		throw new Error(`${label} exceeded the seeder convergence deadline`);
+	}
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_resolve, reject) => {
+				timeout = setTimeout(
+					() =>
+						reject(
+							new Error(`${label} exceeded the seeder convergence deadline`),
+						),
+					remainingMs,
+				);
+			}),
+		]);
+	} finally {
+		if (timeout) {
+			clearTimeout(timeout);
+		}
+	}
+};
+
 const persistResult = async (result: Record<string, unknown>) => {
 	if (!RESULT_FILE) {
 		return;
 	}
 	await mkdir(path.dirname(RESULT_FILE), { recursive: true });
-	await writeFile(RESULT_FILE, `${JSON.stringify(result, null, 2)}\n`);
+	const temporaryPath = `${RESULT_FILE}.${process.pid}.${randomUUID()}.tmp`;
+	try {
+		await writeFile(temporaryPath, `${JSON.stringify(result, null, 2)}\n`);
+		await rename(temporaryPath, RESULT_FILE);
+	} catch (error) {
+		await rm(temporaryPath, { force: true }).catch(() => {});
+		throw error;
+	}
 };
 
 const logStage = (stage: string, details: Record<string, unknown> = {}) => {
@@ -135,7 +243,10 @@ const logStage = (stage: string, details: Record<string, unknown> = {}) => {
 };
 
 test.describe("generated seeder probe", () => {
-	test("tracks seeder convergence before upload", async ({ browser, baseURL }) => {
+	test("tracks seeder convergence before upload", async ({
+		browser,
+		baseURL,
+	}) => {
 		test.setTimeout(
 			Math.max(
 				15 * 60 * 1000,
@@ -147,8 +258,9 @@ test.describe("generated seeder probe", () => {
 		}
 
 		const usesLocalBootstrap = NETWORK_MODE === "local";
-		const bootstrap: Awaited<ReturnType<typeof startBootstrapPeer>> | undefined =
-			usesLocalBootstrap ? await startBootstrapPeer() : undefined;
+		const bootstrap:
+			| Awaited<ReturnType<typeof startBootstrapPeer>>
+			| undefined = usesLocalBootstrap ? await startBootstrapPeer() : undefined;
 		const writerContext = await browser.newContext({ acceptDownloads: true });
 		const readerContext = await browser.newContext({ acceptDownloads: true });
 		const writer = await writerContext.newPage();
@@ -159,10 +271,35 @@ test.describe("generated seeder probe", () => {
 		let shareUrl: string | undefined;
 		let reachedTarget = false;
 		let timeToTargetMs: number | undefined;
+		let targetSampleLabel: string | undefined;
+		let probeStartedAt: number | undefined;
+		let readyDeadlineAt: number | undefined;
+		let probeFinishedAt: number | undefined;
 		attachErrorCollector(writer, "writer", errors);
 		attachErrorCollector(reader, "reader", errors);
 
-		const sample = async (label: string, startedAt: number) => {
+		const readSeederCount = async (page: Page, label: string) => {
+			try {
+				const count = await getSeederCount(page);
+				if (!Number.isSafeInteger(count) || count < 0) {
+					throw new Error(`returned invalid count ${String(count)}`);
+				}
+				return count;
+			} catch (error: any) {
+				const message = `${label}:seeder-count:${
+					typeof error?.message === "string" ? error.message : String(error)
+				}`;
+				errors.push(message);
+				throw new Error(message, { cause: error });
+			}
+		};
+
+		const sample = async (
+			label: string,
+			index: number,
+			startedAt: number,
+			deadlineAt: number,
+		) => {
 			const [
 				writerSeeders,
 				readerSeeders,
@@ -170,17 +307,29 @@ test.describe("generated seeder probe", () => {
 				readerDiagnostics,
 				writerBodyText,
 				readerBodyText,
-			] = await Promise.all([
-				getSeederCount(writer).catch((error) => `error:${error.message}`),
-				getSeederCount(reader).catch((error) => `error:${error.message}`),
-				getDiagnostics(writer),
-				getDiagnostics(reader),
-				getBodyText(writer),
-				getBodyText(reader),
-			]);
-			const current = {
+			] = await withDeadline(
+				Promise.all([
+					readSeederCount(writer, "writer"),
+					readSeederCount(reader, "reader"),
+					getDiagnostics(writer),
+					getDiagnostics(reader),
+					getBodyText(writer),
+					getBodyText(reader),
+				]),
+				deadlineAt,
 				label,
-				atMs: Date.now() - startedAt,
+			);
+			const capturedAt = Date.now();
+			if (capturedAt > deadlineAt) {
+				throw new Error(
+					`${label} completed after the seeder convergence deadline`,
+				);
+			}
+			const current = {
+				index,
+				label,
+				capturedAt,
+				elapsedMs: capturedAt - startedAt,
 				writerSeeders,
 				readerSeeders,
 				writerDiagnostics,
@@ -217,23 +366,51 @@ test.describe("generated seeder probe", () => {
 				targetSeeders: TARGET_SEEDERS,
 				sampleMs: SAMPLE_MS,
 				sampleCount: SAMPLE_COUNT,
+				effectiveSampleIntervalMs: EFFECTIVE_SAMPLE_INTERVAL_MS,
+				readyTimeoutMs: READY_TIMEOUT_MS,
 			});
-			const startedAt = Date.now();
-			for (let sampleIndex = 1; sampleIndex <= SAMPLE_COUNT; sampleIndex++) {
-				await writer.waitForTimeout(SAMPLE_MS);
-				const current = await sample(`sample-${sampleIndex}`, startedAt);
+			probeStartedAt = Date.now();
+			readyDeadlineAt = probeStartedAt + READY_TIMEOUT_MS;
+			let sampleIndex = 0;
+			while (Date.now() <= readyDeadlineAt) {
+				sampleIndex += 1;
+				const current = await sample(
+					`sample-${sampleIndex}`,
+					sampleIndex,
+					probeStartedAt,
+					readyDeadlineAt,
+				);
 				if (
 					!reachedTarget &&
-					current.writerSeeders === TARGET_SEEDERS &&
-					current.readerSeeders === TARGET_SEEDERS
+					current.writerSeeders >= TARGET_SEEDERS &&
+					current.readerSeeders >= TARGET_SEEDERS
 				) {
 					reachedTarget = true;
-					timeToTargetMs = current.atMs as number;
+					timeToTargetMs = current.elapsedMs;
+					targetSampleLabel = current.label;
+					probeFinishedAt = current.capturedAt;
 					break;
 				}
+				const remainingMs = readyDeadlineAt - Date.now();
+				if (remainingMs <= 0) {
+					break;
+				}
+				await writer.waitForTimeout(
+					Math.min(EFFECTIVE_SAMPLE_INTERVAL_MS, remainingMs),
+				);
+			}
+			probeFinishedAt ??= Date.now();
+			if (errors.length > 0) {
+				throw new Error(
+					`Observed seeder probe errors: ${JSON.stringify(errors)}`,
+				);
 			}
 
 			const result = {
+				schema: RESULT_SCHEMA,
+				runNonce: RUN_NONCE,
+				invocation: INVOCATION,
+				provenance: PROVENANCE,
 				status: reachedTarget ? "passed" : "failed",
 				mode: MODE,
 				networkMode: NETWORK_MODE,
@@ -243,8 +420,15 @@ test.describe("generated seeder probe", () => {
 				sampleMs: SAMPLE_MS,
 				sampleCount: SAMPLE_COUNT,
 				readyTimeoutMs: READY_TIMEOUT_MS,
+				effectiveSampleIntervalMs: EFFECTIVE_SAMPLE_INTERVAL_MS,
+				sampleCountDefinition: SAMPLE_COUNT_DEFINITION,
+				probeStartedAt,
+				readyDeadlineAt,
+				probeFinishedAt,
+				probeDurationMs: probeFinishedAt - probeStartedAt,
 				reachedTarget,
 				timeToTargetMs,
+				targetSampleLabel,
 				errorCount: errors.length,
 				errors,
 				samples,
@@ -259,7 +443,12 @@ test.describe("generated seeder probe", () => {
 				);
 			}
 		} catch (error: any) {
+			probeFinishedAt ??= Date.now();
 			const result = {
+				schema: RESULT_SCHEMA,
+				runNonce: RUN_NONCE,
+				invocation: INVOCATION,
+				provenance: PROVENANCE,
 				status: "failed",
 				mode: MODE,
 				networkMode: NETWORK_MODE,
@@ -269,18 +458,23 @@ test.describe("generated seeder probe", () => {
 				sampleMs: SAMPLE_MS,
 				sampleCount: SAMPLE_COUNT,
 				readyTimeoutMs: READY_TIMEOUT_MS,
+				effectiveSampleIntervalMs: EFFECTIVE_SAMPLE_INTERVAL_MS,
+				sampleCountDefinition: SAMPLE_COUNT_DEFINITION,
+				probeStartedAt,
+				readyDeadlineAt,
+				probeFinishedAt,
+				probeDurationMs:
+					probeStartedAt == null ? undefined : probeFinishedAt - probeStartedAt,
 				reachedTarget,
 				timeToTargetMs,
+				targetSampleLabel,
 				errorCount: errors.length,
 				errors,
 				samples,
 				failure: {
 					message:
-						typeof error?.message === "string"
-							? error.message
-							: String(error),
-					stack:
-						typeof error?.stack === "string" ? error.stack : undefined,
+						typeof error?.message === "string" ? error.message : String(error),
+					stack: typeof error?.stack === "string" ? error.stack : undefined,
 				},
 			};
 			await persistResult(result);

--- a/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
+++ b/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
@@ -1,23 +1,62 @@
-import { test, type Page } from "@playwright/test";
-import { mkdir, writeFile } from "node:fs/promises";
+import { type Page, expect, test } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import { mkdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { startBootstrapPeer } from "./bootstrapPeer";
 import {
+	armSavedViaPicker,
 	createSpace,
+	createSyntheticFileOnDisk,
 	expectSeedersAtLeast,
 	getSeederCount,
+	installNodeBackedMockSaveFilePicker,
 	rootUrl,
-	uploadSyntheticFile,
-	waitForFileListed,
+	sha256AndCrc32File,
+	waitForUploadComplete,
 	withBootstrap,
 } from "./helpers";
 
 const FILE_SIZE_MB = Number(process.env.PW_FILE_MB || "100");
+const FILE_SIZE_BYTES = FILE_SIZE_MB * 1024 * 1024;
 const POLL_MS = Number(process.env.PW_POLL_MS || "1000");
 const POST_UPLOAD_MONITOR_MS = Number(
 	process.env.PW_POST_UPLOAD_MONITOR_MS || "5000",
 );
 const UPLOAD_TIMEOUT_MS = Number(process.env.PW_UPLOAD_TIMEOUT_MS || "600000");
+const DOWNLOAD_TIMEOUT_MS = Number(
+	process.env.PW_DOWNLOAD_TIMEOUT_MS ||
+		process.env.PW_UPLOAD_TIMEOUT_MS ||
+		"600000",
+);
+const POST_MONITOR_SCHEDULING_TOLERANCE_MS = Math.max(250, POLL_MS + 250);
+const POST_MONITOR_SCHEDULING_TOLERANCE_DEFINITION =
+	"max(250ms, pollMs + 250ms) for the final poll and event-loop scheduling";
+const TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS = Math.max(
+	5_000,
+	POLL_MS + 1_000,
+);
+const TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION =
+	"max(5000ms, pollMs + 1000ms) for browser actions and event-loop scheduling";
+const FIXTURE_SEED =
+	process.env.PW_FIXTURE_SEED || "peerbit-file-share-benchmark-v1";
+const RESULT_SCHEMA = {
+	id: "peerbit-file-share-benchmark",
+	version: 2,
+} as const;
+const RUN_NONCE = process.env.PW_BENCHMARK_RUN_NONCE;
+const parseJsonEnvironment = (name: string) => {
+	const encoded = process.env[name];
+	if (!encoded) {
+		throw new Error(`Missing ${name}`);
+	}
+	try {
+		return JSON.parse(encoded) as Record<string, unknown>;
+	} catch (error) {
+		throw new Error(`Malformed ${name}`, { cause: error });
+	}
+};
+const PROVENANCE = parseJsonEnvironment("PW_BENCHMARK_PROVENANCE");
+const INVOCATION = parseJsonEnvironment("PW_BENCHMARK_INVOCATION");
 const MODE = process.env.PW_REPLICATION_MODE || "adaptive";
 const NETWORK_MODE = process.env.PW_NETWORK_MODE || "local";
 const RESULT_FILE = process.env.PW_RESULT_FILE;
@@ -27,8 +66,53 @@ const MIN_READY_SEEDERS = Number(
 );
 const VERBOSE = process.env.PW_VERBOSE === "1";
 
+if (!Number.isSafeInteger(FILE_SIZE_BYTES) || FILE_SIZE_BYTES < 0) {
+	throw new Error(`Invalid PW_FILE_MB='${process.env.PW_FILE_MB}'`);
+}
+if (!RUN_NONCE) {
+	throw new Error("Missing PW_BENCHMARK_RUN_NONCE");
+}
+if (process.env.PW_BENCH !== "1") {
+	throw new Error("Upload benchmark must run against the production preview");
+}
 if (!["local", "remote"].includes(NETWORK_MODE)) {
 	throw new Error(`Unsupported PW_NETWORK_MODE='${NETWORK_MODE}'`);
+}
+
+const expectedInvocationValues: Record<string, unknown> = {
+	scenario: "upload",
+	mode: MODE,
+	networkMode: NETWORK_MODE,
+	fileSizeMb: FILE_SIZE_MB,
+	fileSizeBytes: FILE_SIZE_BYTES,
+	fixtureSeed: FIXTURE_SEED,
+	uploadTimeoutMs: UPLOAD_TIMEOUT_MS,
+	downloadTimeoutMs: DOWNLOAD_TIMEOUT_MS,
+	postUploadMonitorMs: POST_UPLOAD_MONITOR_MS,
+	pollMs: POLL_MS,
+	minReadySeeders: MIN_READY_SEEDERS,
+	baseUrl: process.env.PW_BASE_URL || null,
+	protocol: process.env.PW_PROTOCOL || null,
+	viteMode: process.env.PW_VITE_MODE || null,
+	viteConfig: process.env.PW_VITE_CONFIG || null,
+	serverMode: "production-preview",
+	serverHost: process.env.HOST || null,
+	enableVisibilityProbe: ENABLE_VISIBILITY_PROBE,
+	verbose: VERBOSE,
+};
+if (
+	(INVOCATION.schema as Record<string, unknown> | undefined)?.id !==
+		"peerbit-file-share-benchmark-invocation" ||
+	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 1
+) {
+	throw new Error("Unsupported PW_BENCHMARK_INVOCATION schema");
+}
+for (const [key, expected] of Object.entries(expectedInvocationValues)) {
+	if (INVOCATION[key] !== expected) {
+		throw new Error(
+			`PW_BENCHMARK_INVOCATION.${key} does not match the effective environment`,
+		);
+	}
 }
 
 const ROLE_BY_MODE: Record<string, any> = {
@@ -130,13 +214,80 @@ const probeVisibilityPath = async (page: Page) => {
 	try {
 		return await page.evaluate(async () => {
 			const hooks = (window as any).__peerbitFileShareTestHooks;
-			if (!hooks?.probeVisibilityPath) {
-				return null;
-			}
-			return await hooks.probeVisibilityPath();
+			return hooks?.probeVisibilityPath
+				? await hooks.probeVisibilityPath()
+				: null;
 		});
 	} catch {
 		return null;
+	}
+};
+
+type ReadyManifestEvidence = {
+	capturedAt: number;
+	sizeBytes: number;
+	finalHash: string;
+};
+
+const waitForReadyManifest = async (
+	page: Page,
+	fileName: string,
+	expectedSizeBytes: number,
+	expectedFinalHash: string,
+	timeout: number,
+) => {
+	const handle = await page.waitForFunction(
+		({ expectedName, expectedSize, expectedHash }) => {
+			const hooks = (window as any).__peerbitFileShareTestHooks;
+			if (!hooks?.getLightweightSnapshot) {
+				return null;
+			}
+			const snapshot = hooks.getLightweightSnapshot();
+			const file = snapshot?.listedFiles?.find(
+				(candidate: Record<string, unknown>) => candidate.name === expectedName,
+			);
+			if (!file || file.ready !== true) {
+				return null;
+			}
+			if (file.size !== String(expectedSize)) {
+				throw new Error(
+					`Ready manifest size ${String(file.size)} does not match ${expectedSize}`,
+				);
+			}
+			if (file.finalHash !== expectedHash) {
+				throw new Error("Ready manifest hash does not match fixture SHA-256");
+			}
+			const row = Array.from(document.querySelectorAll("li")).find(
+				(candidate) =>
+					Array.from(candidate.querySelectorAll("span")).some(
+						(label) => label.textContent === expectedName,
+					),
+			);
+			const button = row?.querySelector('[data-testid="download-file"]');
+			if (
+				!(button instanceof HTMLButtonElement) ||
+				button.disabled ||
+				button.textContent?.includes("pending")
+			) {
+				return null;
+			}
+			return {
+				capturedAt: Date.now(),
+				sizeBytes: expectedSize,
+				finalHash: file.finalHash,
+			};
+		},
+		{
+			expectedName: fileName,
+			expectedSize: expectedSizeBytes,
+			expectedHash: expectedFinalHash,
+		},
+		{ polling: 50, timeout },
+	);
+	try {
+		return (await handle.jsonValue()) as ReadyManifestEvidence;
+	} finally {
+		await handle.dispose();
 	}
 };
 
@@ -145,7 +296,14 @@ const persistResult = async (result: Record<string, unknown>) => {
 		return;
 	}
 	await mkdir(path.dirname(RESULT_FILE), { recursive: true });
-	await writeFile(RESULT_FILE, `${JSON.stringify(result, null, 2)}\n`);
+	const temporaryPath = `${RESULT_FILE}.${process.pid}.${randomUUID()}.tmp`;
+	try {
+		await writeFile(temporaryPath, `${JSON.stringify(result, null, 2)}\n`);
+		await rename(temporaryPath, RESULT_FILE);
+	} catch (error) {
+		await rm(temporaryPath, { force: true }).catch(() => {});
+		throw error;
+	}
 };
 
 const logStage = (stage: string, details: Record<string, unknown> = {}) => {
@@ -159,23 +317,28 @@ const logStage = (stage: string, details: Record<string, unknown> = {}) => {
 };
 
 const logSnapshot = (snapshot: Record<string, unknown>) => {
-	if (!VERBOSE) {
-		return;
+	if (VERBOSE) {
+		console.log(
+			`FILE_SHARE_BENCHMARK_SNAPSHOT ${JSON.stringify({
+				mode: MODE,
+				...snapshot,
+			})}`,
+		);
 	}
-	console.log(
-		`FILE_SHARE_BENCHMARK_SNAPSHOT ${JSON.stringify({
-			mode: MODE,
-			...snapshot,
-		})}`,
-	);
 };
 
-test.describe("generated upload benchmark", () => {
-	test("measures file-share upload duration", async ({ browser, baseURL }) => {
+test.describe("generated transfer-validity benchmark", () => {
+	test("measures upload, discovery, monitoring, and persisted download", async ({
+		browser,
+		baseURL,
+	}) => {
 		test.setTimeout(
 			Math.max(
 				20 * 60 * 1000,
-				UPLOAD_TIMEOUT_MS + POST_UPLOAD_MONITOR_MS + 5 * 60 * 1000,
+				UPLOAD_TIMEOUT_MS +
+					DOWNLOAD_TIMEOUT_MS +
+					POST_UPLOAD_MONITOR_MS +
+					5 * 60 * 1000,
 			),
 		);
 		if (!baseURL) {
@@ -183,8 +346,9 @@ test.describe("generated upload benchmark", () => {
 		}
 
 		const usesLocalBootstrap = NETWORK_MODE === "local";
-		const bootstrap: Awaited<ReturnType<typeof startBootstrapPeer>> | undefined =
-			usesLocalBootstrap ? await startBootstrapPeer() : undefined;
+		const bootstrap:
+			| Awaited<ReturnType<typeof startBootstrapPeer>>
+			| undefined = usesLocalBootstrap ? await startBootstrapPeer() : undefined;
 		const fileName = `file-share-benchmark-${MODE}-${Date.now()}.bin`;
 		const writerContext = await browser.newContext({ acceptDownloads: true });
 		const readerContext = await browser.newContext({ acceptDownloads: true });
@@ -192,44 +356,78 @@ test.describe("generated upload benchmark", () => {
 		const reader = await readerContext.newPage();
 		const errors: string[] = [];
 		const snapshots: Array<Record<string, unknown>> = [];
+		let preparedFile:
+			| Awaited<ReturnType<typeof createSyntheticFileOnDisk>>
+			| undefined;
+		let cleanupDownload: (() => Promise<void>) | undefined;
+		let nodeSinkController:
+			| Awaited<ReturnType<typeof installNodeBackedMockSaveFilePicker>>
+			| undefined;
 		let stage = "setup";
-		let startedAt: number | undefined;
-		let finishedAt: number | undefined;
-		let shareUrl: string | undefined;
-		let progressVisibleAt: number | undefined;
+		let uploadStartedAt: number | undefined;
 		let uploadSettledAt: number | undefined;
+		let progressSettledAt: number | undefined;
+		let progressVisibleAt: number | undefined;
 		let writerListedAt: number | undefined;
 		let readerListedAt: number | undefined;
+		let postMonitorStartedAt: number | undefined;
+		let postMonitorFinishedAt: number | undefined;
+		let downloadStartedAt: number | undefined;
+		let downloadFinishedAt: number | undefined;
+		let shareUrl: string | undefined;
 		let writerVisibilityProbe: Record<string, unknown> | null = null;
 		let readerVisibilityProbe: Record<string, unknown> | null = null;
+		let writerManifestEvidence: ReadyManifestEvidence | undefined;
+		let readerManifestEvidence: ReadyManifestEvidence | undefined;
 		let dropped = false;
 		let baselineWriterSeeders = MIN_READY_SEEDERS;
 		let baselineReaderSeeders = MIN_READY_SEEDERS;
 		attachTransferErrorCollector(writer, "writer", errors);
 		attachTransferErrorCollector(reader, "reader", errors);
 
+		const readSeederCount = async (page: Page, label: string) => {
+			try {
+				const count = await getSeederCount(page);
+				if (!Number.isSafeInteger(count) || count < 0) {
+					throw new Error(`returned invalid count ${String(count)}`);
+				}
+				return count;
+			} catch (error: any) {
+				const message = `${label}:seeder-count:${
+					typeof error?.message === "string" ? error.message : String(error)
+				}`;
+				errors.push(message);
+				throw new Error(message, { cause: error });
+			}
+		};
+
 		const snapshot = async (label: string) => {
-			const [writerSeeders, readerSeeders, uploadVisible, writerRow, readerRow] =
-				await Promise.all([
-					getSeederCount(writer).catch((e) => `error:${e.message}`),
-					getSeederCount(reader).catch((e) => `error:${e.message}`),
+			let values: [number, number, boolean, boolean, boolean];
+			try {
+				values = await Promise.all([
+					readSeederCount(writer, "writer"),
+					readSeederCount(reader, "reader"),
 					writer
 						.locator('[data-testid="upload-progress"], .progress-root')
 						.first()
-						.isVisible()
-						.catch(() => false),
-					writer
-						.locator("li", { hasText: fileName })
-						.first()
-						.isVisible()
-						.catch(() => false),
-					reader
-						.locator("li", { hasText: fileName })
-						.first()
-						.isVisible()
-						.catch(() => false),
+						.isVisible(),
+					writer.locator("li", { hasText: fileName }).first().isVisible(),
+					reader.locator("li", { hasText: fileName }).first().isVisible(),
 				]);
-
+			} catch (error: any) {
+				const message = `${label}:sample:${
+					typeof error?.message === "string" ? error.message : String(error)
+				}`;
+				errors.push(message);
+				throw new Error(message, { cause: error });
+			}
+			const [
+				writerSeeders,
+				readerSeeders,
+				uploadVisible,
+				writerRow,
+				readerRow,
+			] = values;
 			const state = {
 				label,
 				writerSeeders,
@@ -244,39 +442,61 @@ test.describe("generated upload benchmark", () => {
 			return state;
 		};
 
+		const noteSeederDrop = (current: Record<string, unknown>) => {
+			if (
+				(typeof current.writerSeeders === "number" &&
+					current.writerSeeders < baselineWriterSeeders) ||
+				(typeof current.readerSeeders === "number" &&
+					current.readerSeeders < baselineReaderSeeders)
+			) {
+				dropped = true;
+			}
+		};
+
 		const getPhaseDurations = () =>
-			startedAt == null
+			uploadStartedAt == null
 				? undefined
 				: {
 						timeToProgressVisible:
-							progressVisibleAt != null ? progressVisibleAt - startedAt : undefined,
+							progressVisibleAt != null
+								? progressVisibleAt - uploadStartedAt
+								: undefined,
 						activeUpload:
 							progressVisibleAt != null && uploadSettledAt != null
 								? uploadSettledAt - progressVisibleAt
-								: uploadSettledAt != null
-									? uploadSettledAt - startedAt
-									: undefined,
+								: undefined,
 						timeToUploadSettled:
-							uploadSettledAt != null ? uploadSettledAt - startedAt : undefined,
+							uploadSettledAt != null
+								? uploadSettledAt - uploadStartedAt
+								: undefined,
 						writerListingLag:
 							uploadSettledAt != null && writerListedAt != null
-								? writerListedAt - uploadSettledAt
+								? Math.max(0, writerListedAt - uploadSettledAt)
 								: undefined,
 						readerListingLag:
 							uploadSettledAt != null && readerListedAt != null
-								? readerListedAt - uploadSettledAt
+								? Math.max(0, readerListedAt - uploadSettledAt)
 								: undefined,
 						readerAfterWriter:
 							writerListedAt != null && readerListedAt != null
 								? readerListedAt - writerListedAt
 								: undefined,
-						timeToWriterListed:
-							writerListedAt != null ? writerListedAt - startedAt : undefined,
-						timeToReaderListed:
-							readerListedAt != null ? readerListedAt - startedAt : undefined,
+						postUploadMonitor:
+							postMonitorStartedAt != null && postMonitorFinishedAt != null
+								? postMonitorFinishedAt - postMonitorStartedAt
+								: undefined,
+						download:
+							downloadStartedAt != null && downloadFinishedAt != null
+								? downloadFinishedAt - downloadStartedAt
+								: undefined,
 					};
 
 		try {
+			stage = "install-node-download-sink";
+			nodeSinkController = await installNodeBackedMockSaveFilePicker(reader, {
+				expectedName: fileName,
+				expectedSizeBytes: FILE_SIZE_BYTES,
+			});
 			stage = "create-space";
 			logStage(stage, { networkMode: NETWORK_MODE });
 			const entryUrl =
@@ -302,8 +522,10 @@ test.describe("generated upload benchmark", () => {
 				await expectSeedersAtLeast(writer, MIN_READY_SEEDERS, 180_000);
 				await expectSeedersAtLeast(reader, MIN_READY_SEEDERS, 180_000);
 			} else {
-				await getSeederCount(writer);
-				await getSeederCount(reader);
+				await Promise.all([
+					readSeederCount(writer, "writer"),
+					readSeederCount(reader, "reader"),
+				]);
 			}
 			const ready = await snapshot("seeders-ready");
 			baselineWriterSeeders =
@@ -314,122 +536,293 @@ test.describe("generated upload benchmark", () => {
 				typeof ready.readerSeeders === "number"
 					? ready.readerSeeders
 					: MIN_READY_SEEDERS;
-			logStage(stage, {
-				baselineWriterSeeders,
-				baselineReaderSeeders,
-			});
 
-			stage = "upload";
-			logStage(stage);
-			startedAt = Date.now();
+			stage = "prepare-deterministic-fixture";
+			logStage(stage, { fixtureSeed: FIXTURE_SEED });
+			preparedFile = await createSyntheticFileOnDisk(fileName, FILE_SIZE_MB, {
+				mode: "deterministic",
+				seed: FIXTURE_SEED,
+			});
+			if (
+				!preparedFile.fixture.sha256Base64 ||
+				!preparedFile.fixture.crc32Hex
+			) {
+				throw new Error("Deterministic fixture did not provide both digests");
+			}
+			const expectedSizeBytes = FILE_SIZE_BYTES;
+			const sourceDetails = await stat(preparedFile.filePath);
+			if (sourceDetails.size !== expectedSizeBytes) {
+				throw new Error(
+					`Fixture size ${sourceDetails.size} does not match ${expectedSizeBytes}`,
+				);
+			}
+
 			stage = "wait-for-upload-input";
-			logStage(stage);
 			await writer.locator("#imgupload").waitFor({
 				state: "attached",
 				timeout: 60_000,
 			});
-			stage = "set-input-files";
+			stage = "upload";
 			logStage(stage);
-			await uploadSyntheticFile(writer, fileName, FILE_SIZE_MB);
-			stage = "wait-for-progress";
-			logStage(stage);
-			await writer
+			uploadStartedAt = Date.now();
+			await writer.locator("#imgupload").setInputFiles(preparedFile.filePath);
+			await expect(writer.locator("#imgupload")).toHaveValue("");
+			const writerListedPromise = waitForReadyManifest(
+				writer,
+				fileName,
+				expectedSizeBytes,
+				preparedFile.fixture.sha256Base64,
+				UPLOAD_TIMEOUT_MS,
+			).then((evidence) => ({ evidence, listedAt: evidence.capturedAt }));
+			const readerListedPromise = waitForReadyManifest(
+				reader,
+				fileName,
+				expectedSizeBytes,
+				preparedFile.fixture.sha256Base64,
+				UPLOAD_TIMEOUT_MS,
+			).then((evidence) => ({ evidence, listedAt: evidence.capturedAt }));
+			void readerListedPromise.catch(() => {});
+			const writerReadyPromise = Promise.all([
+				writerListedPromise,
+				waitForUploadComplete(writer, UPLOAD_TIMEOUT_MS).then(() => Date.now()),
+			]).then(([manifest, progressDoneAt]) => ({
+				manifest,
+				progressDoneAt,
+				readyAt: Date.now(),
+			}));
+			const progressWasVisible = await writer
 				.locator('[data-testid="upload-progress"], .progress-root')
 				.first()
 				.waitFor({ state: "visible", timeout: 5000 })
-				.catch(() => {});
-			progressVisibleAt = Date.now();
-			stage = "monitor-upload";
-			logStage(stage);
+				.then(
+					() => true,
+					() => false,
+				);
+			if (progressWasVisible) {
+				progressVisibleAt = Date.now();
+			}
 
-			let uploadCompleted = false;
-			while (!uploadCompleted) {
-				const current = await snapshot(`during-${snapshots.length}`);
-				if (
-					typeof current.writerSeeders === "number" &&
-					current.writerSeeders < baselineWriterSeeders
-				) {
-					dropped = true;
-				}
-				if (
-					typeof current.readerSeeders === "number" &&
-					current.readerSeeders < baselineReaderSeeders
-				) {
-					dropped = true;
-				}
-				uploadCompleted = !(current.uploadVisible as boolean);
-				if (uploadCompleted) {
-					uploadSettledAt = current.at as number;
+			stage = "wait-for-writer-ready";
+			let writerReady: Awaited<typeof writerReadyPromise> | undefined;
+			while (!writerReady) {
+				const outcome = await Promise.race([
+					writerReadyPromise.then((value) => ({ ready: value })),
+					writer.waitForTimeout(POLL_MS).then(() => ({ ready: undefined })),
+				]);
+				if (outcome.ready) {
+					writerReady = outcome.ready;
 					break;
 				}
-				if (Date.now() - startedAt > UPLOAD_TIMEOUT_MS) {
-					throw new Error(
-						`Upload did not finish within ${UPLOAD_TIMEOUT_MS}ms: ${JSON.stringify(snapshots)}`,
-					);
-				}
-				await writer.waitForTimeout(POLL_MS);
+				const current = await snapshot(`during-${snapshots.length}`);
+				noteSeederDrop(current);
 			}
+			writerManifestEvidence = writerReady.manifest.evidence;
+			writerListedAt = writerReady.manifest.listedAt;
+			progressSettledAt = writerReady.progressDoneAt;
+			// Writer readiness is the primary endpoint. A hidden progress element is
+			// only diagnostic because it can disappear before a ready manifest exists.
+			uploadSettledAt = writerReady.readyAt;
 
 			if (ENABLE_VISIBILITY_PROBE) {
 				stage = "probe-visibility-path";
-				logStage(stage);
 				[writerVisibilityProbe, readerVisibilityProbe] = await Promise.all([
 					probeVisibilityPath(writer),
 					probeVisibilityPath(reader),
 				]);
 			}
 
-			stage = "wait-for-listing";
+			stage = "wait-for-reader-listing";
 			logStage(stage);
-			[writerListedAt, readerListedAt] = await Promise.all([
-				(async () => {
-					await waitForFileListed(writer, fileName, 180_000);
-					return Date.now();
-				})(),
-				(async () => {
-					await waitForFileListed(reader, fileName, 180_000);
-					return Date.now();
-				})(),
-			]);
+			const readerManifest = await readerListedPromise;
+			readerManifestEvidence = readerManifest.evidence;
+			readerListedAt = readerManifest.listedAt;
 
 			stage = "post-upload-monitor";
 			logStage(stage);
-			const deadline = Date.now() + POST_UPLOAD_MONITOR_MS;
+			postMonitorStartedAt = Date.now();
+			const deadline = postMonitorStartedAt + POST_UPLOAD_MONITOR_MS;
 			while (Date.now() < deadline) {
 				const current = await snapshot(`after-${snapshots.length}`);
-				if (
-					typeof current.writerSeeders === "number" &&
-					current.writerSeeders < baselineWriterSeeders
-				) {
-					dropped = true;
-				}
-				if (
-					typeof current.readerSeeders === "number" &&
-					current.readerSeeders < baselineReaderSeeders
-				) {
-					dropped = true;
-				}
-				await writer.waitForTimeout(POLL_MS);
+				noteSeederDrop(current);
+				await writer.waitForTimeout(
+					Math.min(POLL_MS, Math.max(0, deadline - Date.now())),
+				);
+			}
+			postMonitorFinishedAt = Date.now();
+			const measuredPostMonitorMs =
+				postMonitorFinishedAt - postMonitorStartedAt;
+			if (
+				measuredPostMonitorMs < POST_UPLOAD_MONITOR_MS ||
+				measuredPostMonitorMs >
+					POST_UPLOAD_MONITOR_MS + POST_MONITOR_SCHEDULING_TOLERANCE_MS
+			) {
+				throw new Error(
+					`Post-upload monitor duration ${measuredPostMonitorMs}ms is outside ${POST_UPLOAD_MONITOR_MS}ms + ${POST_MONITOR_SCHEDULING_TOLERANCE_MS}ms scheduling tolerance`,
+				);
+			}
+
+			stage = "persisted-download";
+			logStage(stage);
+			const row = reader.locator("li", { hasText: fileName }).first();
+			await expect(row).toBeVisible({ timeout: DOWNLOAD_TIMEOUT_MS });
+			const byTestId = row.getByTestId("download-file");
+			const downloadButton =
+				(await byTestId.count()) > 0 ? byTestId : row.locator("button").first();
+			await expect(downloadButton).toBeEnabled({
+				timeout: DOWNLOAD_TIMEOUT_MS,
+			});
+			const downloadCompletion = armSavedViaPicker(
+				reader,
+				fileName,
+				FILE_SIZE_MB,
+				DOWNLOAD_TIMEOUT_MS,
+			);
+			downloadStartedAt = Date.now();
+			await downloadButton.click();
+			const download = await downloadCompletion;
+			downloadFinishedAt = Date.now();
+			cleanupDownload = download.cleanup;
+			if (download.sink !== "node-file" || !download.downloadPath) {
+				throw new Error(
+					"Download did not complete through the persisted Node file sink",
+				);
+			}
+
+			stage = "verify-integrity";
+			const downloadedDigests = await sha256AndCrc32File(download.downloadPath);
+			const sizeVerified = download.size === expectedSizeBytes;
+			const sha256Verified =
+				downloadedDigests.sha256Base64 === preparedFile.fixture.sha256Base64;
+			const crc32Verified =
+				downloadedDigests.crc32Hex === preparedFile.fixture.crc32Hex;
+			const manifestVerified =
+				writerManifestEvidence?.sizeBytes === expectedSizeBytes &&
+				readerManifestEvidence?.sizeBytes === expectedSizeBytes &&
+				writerManifestEvidence?.finalHash ===
+					preparedFile.fixture.sha256Base64 &&
+				readerManifestEvidence?.finalHash === preparedFile.fixture.sha256Base64;
+			const integrityVerified =
+				sizeVerified && sha256Verified && crc32Verified && manifestVerified;
+			const integrity = {
+				fixtureMode: "deterministic",
+				fixtureFormat: preparedFile.fixture.mode,
+				fixtureSeed: FIXTURE_SEED,
+				expectedSizeBytes,
+				sourceSizeBytes: sourceDetails.size,
+				manifestSizeBytes: readerManifestEvidence?.sizeBytes,
+				downloadedSizeBytes: download.size,
+				sourceSha256Base64: preparedFile.fixture.sha256Base64,
+				downloadedSha256Base64: downloadedDigests.sha256Base64,
+				manifestSha256Base64: readerManifestEvidence?.finalHash,
+				sourceCrc32Hex: preparedFile.fixture.crc32Hex,
+				downloadedCrc32Hex: downloadedDigests.crc32Hex,
+				sizeVerified,
+				sha256Verified,
+				crc32Verified,
+				manifestVerified,
+				verified: integrityVerified,
+			};
+			if (!integrityVerified) {
+				throw new Error(
+					`Downloaded file failed integrity validation: ${JSON.stringify(integrity)}`,
+				);
+			}
+			if (dropped) {
+				throw new Error("Seeder counts dropped during benchmark");
+			}
+			if (errors.length > 0) {
+				throw new Error(
+					`Observed transfer/delivery errors: ${JSON.stringify(errors)}`,
+				);
 			}
 
 			stage = "complete";
 			logStage(stage);
-			finishedAt = Date.now();
+			const phaseDurationsMs = getPhaseDurations();
+			if (
+				!phaseDurationsMs ||
+				uploadSettledAt == null ||
+				writerListedAt == null ||
+				readerListedAt == null ||
+				postMonitorStartedAt == null ||
+				postMonitorFinishedAt == null ||
+				downloadStartedAt == null ||
+				downloadFinishedAt == null
+			) {
+				throw new Error("Benchmark completed without all phase timestamps");
+			}
+			if (
+				phaseDurationsMs.timeToUploadSettled == null ||
+				phaseDurationsMs.download == null ||
+				phaseDurationsMs.timeToUploadSettled >
+					UPLOAD_TIMEOUT_MS + TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS ||
+				phaseDurationsMs.download >
+					DOWNLOAD_TIMEOUT_MS + TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS
+			) {
+				throw new Error(
+					"Measured transfer duration exceeded its requested timeout and scheduling tolerance",
+				);
+			}
 			const result = {
+				schema: RESULT_SCHEMA,
+				runNonce: RUN_NONCE,
+				invocation: INVOCATION,
+				provenance: PROVENANCE,
 				status: "passed",
 				mode: MODE,
 				networkMode: NETWORK_MODE,
 				fileSizeMb: FILE_SIZE_MB,
-				uploadDurationMs: finishedAt - startedAt,
+				integrity,
+				integrityVerified,
+				uploadDurationMs: phaseDurationsMs.timeToUploadSettled,
+				uploadDurationDefinition:
+					"input-set-to-writer-ready-manifest-and-upload-progress-settled; excludes reader discovery, post-monitor, and download",
+				listingDurationMs: Math.max(
+					0,
+					Math.max(writerListedAt, readerListedAt) - uploadSettledAt,
+				),
+				listingDurationDefinition:
+					"upload-settled-to-both-writer-and-reader-listed",
+				postUploadMonitorDurationMs:
+					postMonitorFinishedAt - postMonitorStartedAt,
+				postUploadMonitorDurationDefinition:
+					"post-listing seeder/error observation only",
+				postUploadMonitorSchedulingToleranceMs:
+					POST_MONITOR_SCHEDULING_TOLERANCE_MS,
+				postUploadMonitorSchedulingToleranceDefinition:
+					POST_MONITOR_SCHEDULING_TOLERANCE_DEFINITION,
+				downloadDurationMs: downloadFinishedAt - downloadStartedAt,
+				downloadDurationDefinition:
+					"reader-download-click-to-backpressured-node-file-sink-complete",
+				transferTimeoutSchedulingToleranceMs:
+					TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS,
+				transferTimeoutSchedulingToleranceDefinition:
+					TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION,
+				downloadSink: download.sink,
+				phaseDurationsMs,
+				timestamps: {
+					uploadStartedAt,
+					uploadSettledAt,
+					progressVisibleAt,
+					progressSettledAt,
+					writerListedAt,
+					readerListedAt,
+					postMonitorStartedAt,
+					postMonitorFinishedAt,
+					downloadStartedAt,
+					downloadFinishedAt,
+				},
+				writerManifestEvidence,
+				readerManifestEvidence,
 				postUploadMonitorMs: POST_UPLOAD_MONITOR_MS,
 				pollMs: POLL_MS,
 				uploadTimeoutMs: UPLOAD_TIMEOUT_MS,
+				downloadTimeoutMs: DOWNLOAD_TIMEOUT_MS,
 				minReadySeeders: MIN_READY_SEEDERS,
 				baselineWriterSeeders,
 				baselineReaderSeeders,
 				shareUrl,
 				droppedSeeders: dropped,
-				phaseDurationsMs: getPhaseDurations(),
 				writerVisibilityProbe,
 				readerVisibilityProbe,
 				errorCount: errors.length,
@@ -438,39 +831,39 @@ test.describe("generated upload benchmark", () => {
 				writerDiagnostics: await getDiagnostics(writer),
 				readerDiagnostics: await getDiagnostics(reader),
 			};
-
 			await persistResult(result);
 			console.log(`FILE_SHARE_BENCHMARK_RESULT ${JSON.stringify(result)}`);
-
-			if (dropped) {
-				throw new Error(
-					`Seeder counts dropped during benchmark: ${JSON.stringify(snapshots)}`,
-				);
-			}
-			if (errors.length > 0) {
-				throw new Error(
-					`Observed transfer/delivery errors: ${JSON.stringify(errors)}`,
-				);
-			}
 		} catch (error: any) {
 			await snapshot(`failure-${stage}`).catch(() => {});
 			const result = {
+				schema: RESULT_SCHEMA,
+				runNonce: RUN_NONCE,
+				invocation: INVOCATION,
+				provenance: PROVENANCE,
 				status: "failed",
 				mode: MODE,
 				networkMode: NETWORK_MODE,
 				fileSizeMb: FILE_SIZE_MB,
 				stage,
-				uploadDurationMs:
-					startedAt != null ? Date.now() - startedAt : undefined,
+				integrityVerified: false,
+				phaseDurationsMs: getPhaseDurations(),
+				postUploadMonitorSchedulingToleranceMs:
+					POST_MONITOR_SCHEDULING_TOLERANCE_MS,
+				postUploadMonitorSchedulingToleranceDefinition:
+					POST_MONITOR_SCHEDULING_TOLERANCE_DEFINITION,
+				transferTimeoutSchedulingToleranceMs:
+					TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS,
+				transferTimeoutSchedulingToleranceDefinition:
+					TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION,
 				postUploadMonitorMs: POST_UPLOAD_MONITOR_MS,
 				pollMs: POLL_MS,
 				uploadTimeoutMs: UPLOAD_TIMEOUT_MS,
+				downloadTimeoutMs: DOWNLOAD_TIMEOUT_MS,
 				minReadySeeders: MIN_READY_SEEDERS,
 				baselineWriterSeeders,
 				baselineReaderSeeders,
 				shareUrl,
 				droppedSeeders: dropped,
-				phaseDurationsMs: getPhaseDurations(),
 				writerVisibilityProbe,
 				readerVisibilityProbe,
 				errorCount: errors.length,
@@ -480,17 +873,21 @@ test.describe("generated upload benchmark", () => {
 				readerDiagnostics: await getDiagnostics(reader),
 				failure: {
 					message:
-						typeof error?.message === "string"
-							? error.message
-							: String(error),
-					stack:
-						typeof error?.stack === "string" ? error.stack : undefined,
+						typeof error?.message === "string" ? error.message : String(error),
+					stack: typeof error?.stack === "string" ? error.stack : undefined,
 				},
 			};
 			await persistResult(result);
 			console.error(`FILE_SHARE_BENCHMARK_RESULT ${JSON.stringify(result)}`);
 			throw error;
 		} finally {
+			await cleanupDownload?.().catch(() => {});
+			await nodeSinkController?.cleanup().catch(() => {});
+			if (preparedFile) {
+				await rm(preparedFile.dir, { recursive: true, force: true }).catch(
+					() => {},
+				);
+			}
 			await writerContext.close().catch(() => {});
 			await readerContext.close().catch(() => {});
 			await bootstrap?.stop().catch(() => {});

--- a/scripts/file-share/vite-instrumentation.mjs
+++ b/scripts/file-share/vite-instrumentation.mjs
@@ -1,0 +1,118 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+
+export const VITE_BENCHMARK_MARKER = "/* peerbit-benchmark-vite */";
+
+const markedResolveGuardPattern = () =>
+	new RegExp(
+		` {8}\\/\\* peerbit-benchmark-vite \\*\\/\\n(?: {8}["']?preserveSymlinks["']?\\s*:\\s*(?:true|false),\\n)? {8}alias: \\{\\n[\\s\\S]*? {8}\\},\\n`,
+	);
+
+const countMatches = (contents, pattern) =>
+	contents.match(pattern)?.length ?? 0;
+
+const ensureRequiredDedupeEntries = (contents, filePath) => {
+	const dedupePattern = /( {8}dedupe: \[\n)([\s\S]*?)( {8}\],)/;
+	const match = contents.match(dedupePattern);
+	if (!match) {
+		throw new Error(`Could not find dedupe block in ${filePath}`);
+	}
+	const required = ["react", "react-dom", "@dao-xyz/borsh"];
+	const requiredLines = new Set(required.map((name) => `"${name}",`));
+	const retainedBody = match[2]
+		.split("\n")
+		.filter((line) => !requiredLines.has(line.trim()))
+		.join("\n");
+	const normalizedBody = `${required
+		.map((name) => `            "${name}",\n`)
+		.join("")}${retainedBody}`;
+	return contents.replace(
+		dedupePattern,
+		`${match[1]}${normalizedBody}${match[3]}`,
+	);
+};
+
+export const injectViteBenchmarkResolveGuards = (
+	contents,
+	filePath,
+	frontendRoot,
+) => {
+	let next = contents;
+	if (!next.includes("resolve: {")) {
+		throw new Error(`Could not find resolve block in ${filePath}`);
+	}
+	const examplesNodeModules = path.resolve(
+		frontendRoot,
+		"..",
+		"..",
+		"..",
+		"node_modules",
+	);
+	const resolveGuardBlock = `        ${VITE_BENCHMARK_MARKER}
+        preserveSymlinks: false,
+        alias: {
+            react: ${JSON.stringify(path.join(examplesNodeModules, "react"))},
+            "react-dom": ${JSON.stringify(path.join(examplesNodeModules, "react-dom"))},
+            "@dao-xyz/borsh": ${JSON.stringify(
+							path.join(examplesNodeModules, "@dao-xyz", "borsh"),
+						)},
+        },\n`;
+	const markerCount = countMatches(next, /\/\* peerbit-benchmark-vite \*\//g);
+	if (markerCount > 1) {
+		throw new Error(`${filePath} contains multiple benchmark resolve guards`);
+	}
+	if (markerCount === 1) {
+		const markedBlock = markedResolveGuardPattern();
+		if (!markedBlock.test(next)) {
+			throw new Error(
+				`${filePath} contains a malformed benchmark resolve guard`,
+			);
+		}
+		next = next.replace(markedResolveGuardPattern(), resolveGuardBlock);
+	} else {
+		next = next.replace(
+			"    resolve: {\n",
+			`    resolve: {\n${resolveGuardBlock}`,
+		);
+	}
+	if (/["']?preserveSymlinks["']?\s*:\s*true/.test(next)) {
+		throw new Error(
+			`${filePath} enables preserveSymlinks, which would detach linked Peerbit packages from their pinned dependency graph`,
+		);
+	}
+	if (
+		countMatches(next, /\/\* peerbit-benchmark-vite \*\//g) !== 1 ||
+		countMatches(next, /["']?preserveSymlinks["']?\s*:/g) !== 1 ||
+		countMatches(next, /["']?alias["']?\s*:/g) !== 1 ||
+		!markedResolveGuardPattern().test(next)
+	) {
+		throw new Error(
+			`${filePath} does not contain exactly one attributable benchmark resolve guard`,
+		);
+	}
+	next = ensureRequiredDedupeEntries(next, filePath);
+	next = next.replace(
+		'        include: [\n            "react",\n            "react-dom",\n',
+		"        include: [\n",
+	);
+	return next;
+};
+
+export const instrumentFileShareViteConfigs = async (frontendRoot) => {
+	for (const configName of ["vite.config.ts", "vite.config.remote.ts"]) {
+		const configPath = path.join(frontendRoot, configName);
+		if (!fs.existsSync(configPath)) {
+			continue;
+		}
+		const contents = await fsp.readFile(configPath, "utf8");
+		const next = injectViteBenchmarkResolveGuards(
+			contents,
+			configPath,
+			frontendRoot,
+		);
+		if (next !== contents) {
+			await fsp.writeFile(configPath, next);
+		}
+	}
+};

--- a/scripts/file-share/vite-instrumentation.test.mjs
+++ b/scripts/file-share/vite-instrumentation.test.mjs
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { injectViteBenchmarkResolveGuards } from "./vite-instrumentation.mjs";
+
+const config = (resolvePrefix = "") => `export default {
+    resolve: {
+${resolvePrefix}        dedupe: [
+        ],
+    },
+    optimizeDeps: {
+        include: [
+            "react",
+            "react-dom",
+        ],
+    },
+};
+`;
+
+const aliases = (root) => `        /* peerbit-benchmark-vite */
+        preserveSymlinks: false,
+        alias: {
+            react: ${JSON.stringify(path.join(root, "react"))},
+            "react-dom": ${JSON.stringify(path.join(root, "react-dom"))},
+            "@dao-xyz/borsh": ${JSON.stringify(path.join(root, "@dao-xyz", "borsh"))},
+        },
+`;
+
+const assertOneCurrentGuard = (contents, examplesNodeModules) => {
+	assert.equal(contents.match(/\/\* peerbit-benchmark-vite \*\//g)?.length, 1);
+	assert.equal(contents.match(/preserveSymlinks\s*:/g)?.length, 1);
+	assert.equal(contents.match(/alias: \{/g)?.length, 1);
+	assert.ok(contents.includes(aliases(examplesNodeModules)));
+	assert.ok(!contents.includes("preserveSymlinks: true"));
+};
+
+test("Vite guard injection is complete and idempotent", () => {
+	const frontendRoot = path.join("/tmp", "benchmark", "packages", "frontend");
+	const examplesNodeModules = path.resolve(
+		frontendRoot,
+		"..",
+		"..",
+		"..",
+		"node_modules",
+	);
+	const injected = injectViteBenchmarkResolveGuards(
+		config(),
+		"vite.config.ts",
+		frontendRoot,
+	);
+	assertOneCurrentGuard(injected, examplesNodeModules);
+	assert.equal(
+		injectViteBenchmarkResolveGuards(injected, "vite.config.ts", frontendRoot),
+		injected,
+	);
+});
+
+test("Vite guard migration replaces legacy alias blocks atomically", () => {
+	const frontendRoot = path.join("/tmp", "new", "packages", "frontend");
+	const examplesNodeModules = path.resolve(
+		frontendRoot,
+		"..",
+		"..",
+		"..",
+		"node_modules",
+	);
+	for (const preserveLine of ["", "        preserveSymlinks: true,\n"]) {
+		const legacy = `        /* peerbit-benchmark-vite */
+${preserveLine}        alias: {
+            react: "/tmp/old/node_modules/react",
+            "react-dom": "/tmp/old/node_modules/react-dom",
+            "@dao-xyz/borsh": "/tmp/old/node_modules/@dao-xyz/borsh",
+        },
+`;
+		const migrated = injectViteBenchmarkResolveGuards(
+			config(legacy),
+			"vite.config.ts",
+			frontendRoot,
+		);
+		assertOneCurrentGuard(migrated, examplesNodeModules);
+		assert.ok(!migrated.includes("/tmp/old"));
+	}
+});
+
+test("Vite guard refreshes aliases when an instrumented template moves", () => {
+	const oldFrontendRoot = path.join(
+		"/tmp",
+		"old",
+		"examples",
+		"packages",
+		"file-share",
+		"frontend",
+	);
+	const oldNodeModules = path.resolve(
+		oldFrontendRoot,
+		"..",
+		"..",
+		"..",
+		"node_modules",
+	);
+	const newFrontendRoot = path.join(
+		"/tmp",
+		"new",
+		"examples",
+		"packages",
+		"file-share",
+		"frontend",
+	);
+	const newNodeModules = path.resolve(
+		newFrontendRoot,
+		"..",
+		"..",
+		"..",
+		"node_modules",
+	);
+	const refreshed = injectViteBenchmarkResolveGuards(
+		config(aliases(oldNodeModules)),
+		"vite.config.ts",
+		newFrontendRoot,
+	);
+	assertOneCurrentGuard(refreshed, newNodeModules);
+	assert.ok(!refreshed.includes(oldNodeModules));
+});
+
+test("Vite guard rejects unattributed preserveSymlinks settings", () => {
+	for (const property of [
+		"preserveSymlinks",
+		'"preserveSymlinks"',
+		"'preserveSymlinks'",
+	]) {
+		assert.throws(
+			() =>
+				injectViteBenchmarkResolveGuards(
+					config(`        ${property}: true,\n`),
+					"vite.config.ts",
+					path.join("/tmp", "benchmark", "packages", "frontend"),
+				),
+			/enables preserveSymlinks/,
+		);
+	}
+});
+
+test("Vite guard rejects unattributed alias blocks", () => {
+	for (const property of ["alias", '"alias"', "'alias'"]) {
+		assert.throws(
+			() =>
+				injectViteBenchmarkResolveGuards(
+					config(`        ${property}: { react: "/tmp/wrong" },\n`),
+					"vite.config.ts",
+					path.join("/tmp", "benchmark", "packages", "frontend"),
+				),
+			/does not contain exactly one attributable benchmark resolve guard/,
+		);
+	}
+});


### PR DESCRIPTION
## Summary

- bind each benchmark result to an exact invocation, nonce, Peerbit checkout, examples checkout, and lockfile digest
- replace sparse zero-filled upload fixtures with deterministic bytes and require exact size, manifest SHA-256, persisted-download SHA-256, and CRC-32 integrity gates
- measure upload settlement, reader discovery, post-upload monitoring, and backpressured persisted download as separate phases
- isolate and counterbalance matrix variants, require exact local package links, and reject stale or ambiguous inputs
- add fail-closed result validation and focused contract tests

Prerequisite dao-xyz/peerbit-examples#190 is merged.

## Validation

- pnpm run bench:file-share:test: 77 passed
- git diff --check: passed
- Prettier check for package.json and scripts/file-share: passed
- clean production-preview link smoke: 5 MiB deterministic upload and persisted download passed with exact SHA-256 and CRC-32 equality, zero transfer errors, zero seeder drops, and Playwright exit code 0
- smoke provenance: Peerbit d8ad699806020f60fd197c1a6ca4d85a0faa0ade; peerbit-examples 76c026b48abbaf667569596450b11dd82d479efd