### PR TITLE
fix(benchmark): make file-share comparisons honest

### DIFF
--- a/scripts/file-share/benchmark-invocation.mjs
+++ b/scripts/file-share/benchmark-invocation.mjs
@@ -192,7 +192,7 @@ export const createBenchmarkInvocation = ({
 		"pollMs",
 	);
 	const resolvedMinReadySeeders = requireNonNegativeSafeInteger(
-		minReadySeeders ?? (mode === "adaptive" ? 2 : 0),
+		minReadySeeders ?? (mode === "observer" ? 0 : 2),
 		"minReadySeeders",
 	);
 	const resolvedReadyTimeoutMs = requirePositiveSafeInteger(

--- a/scripts/file-share/benchmark-invocation.test.mjs
+++ b/scripts/file-share/benchmark-invocation.test.mjs
@@ -84,6 +84,16 @@ test("resolves every default and requested optional knob", () => {
 	);
 });
 
+test("uses the same ready-seeder baseline for comparable replication modes", () => {
+	assert.equal(invocation({ mode: "adaptive" }).minReadySeeders, 2);
+	assert.equal(invocation({ mode: "fixed1" }).minReadySeeders, 2);
+	assert.equal(invocation({ mode: "observer" }).minReadySeeders, 0);
+	assert.equal(
+		invocation({ mode: "fixed1", minReadySeeders: 4 }).minReadySeeders,
+		4,
+	);
+});
+
 test("removes all ambient PW variables and installs the exact invocation", () => {
 	const resolved = invocation();
 	const environment = createPlaywrightBenchmarkEnvironment({

--- a/scripts/file-share/benchmark-summary.mjs
+++ b/scripts/file-share/benchmark-summary.mjs
@@ -1,0 +1,149 @@
+const round = (value) => Number(value.toFixed(1));
+
+const average = (values) =>
+	values.length > 0
+		? Number(
+				(values.reduce((sum, value) => sum + value, 0) / values.length).toFixed(
+					1,
+				),
+			)
+		: null;
+
+const percentile = (sortedValues, fraction) => {
+	if (sortedValues.length === 0) {
+		return null;
+	}
+	const index = (sortedValues.length - 1) * fraction;
+	const lowerIndex = Math.floor(index);
+	const upperIndex = Math.ceil(index);
+	if (lowerIndex === upperIndex) {
+		return round(sortedValues[lowerIndex]);
+	}
+	const weight = index - lowerIndex;
+	return round(
+		sortedValues[lowerIndex] * (1 - weight) + sortedValues[upperIndex] * weight,
+	);
+};
+
+const passedNumbers = (results, getter) =>
+	results
+		.filter((result) => result.status === "passed")
+		.map(getter)
+		.filter((value) => typeof value === "number" && Number.isFinite(value));
+
+export const summarizeDistribution = (values) => {
+	const sortedValues = values
+		.filter((value) => typeof value === "number" && Number.isFinite(value))
+		.toSorted((left, right) => left - right);
+	return {
+		avg: average(sortedValues),
+		p25: percentile(sortedValues, 0.25),
+		median: percentile(sortedValues, 0.5),
+		p75: percentile(sortedValues, 0.75),
+		min: sortedValues.length > 0 ? sortedValues[0] : null,
+		max: sortedValues.length > 0 ? sortedValues.at(-1) : null,
+	};
+};
+
+const flattenDistribution = (prefix, distribution) => ({
+	[`${prefix}Avg`]: distribution.avg,
+	[`${prefix}P25`]: distribution.p25,
+	[`${prefix}Median`]: distribution.median,
+	[`${prefix}P75`]: distribution.p75,
+	[`${prefix}Min`]: distribution.min,
+	[`${prefix}Max`]: distribution.max,
+});
+
+/**
+ * Keep the end-to-end readiness timings next to the legacy post-settlement
+ * listing metric in every aggregate. The explicit alias documents that
+ * listingDurationMs does not start when the user selects the file.
+ */
+export const summarizeUploadPerformance = (results) => {
+	const uploadDuration = summarizeDistribution(
+		passedNumbers(results, (result) => result.uploadDurationMs),
+	);
+	const timeToWriterReady = summarizeDistribution(
+		passedNumbers(results, (result) => result.timeToWriterReadyMs),
+	);
+	const timeToReaderReady = summarizeDistribution(
+		passedNumbers(results, (result) => result.timeToReaderReadyMs),
+	);
+	const postSettlementListingDuration = summarizeDistribution(
+		passedNumbers(results, (result) => result.listingDurationMs),
+	);
+	const downloadDuration = summarizeDistribution(
+		passedNumbers(results, (result) => result.downloadDurationMs),
+	);
+	return {
+		...flattenDistribution("uploadDurationMs", uploadDuration),
+		...flattenDistribution("timeToWriterReadyMs", timeToWriterReady),
+		...flattenDistribution("timeToReaderReadyMs", timeToReaderReady),
+		// Kept for summary-schema compatibility.
+		listingDurationMsAvg: postSettlementListingDuration.avg,
+		...flattenDistribution(
+			"postSettlementListingDurationMs",
+			postSettlementListingDuration,
+		),
+		...flattenDistribution("downloadDurationMs", downloadDuration),
+	};
+};
+
+const compareModeMetric = (adaptiveResults, fixedResults, getter) => {
+	const adaptiveAvgMs = average(passedNumbers(adaptiveResults, getter));
+	const fixed1AvgMs = average(passedNumbers(fixedResults, getter));
+	if (adaptiveAvgMs == null || fixed1AvgMs == null) {
+		return null;
+	}
+	const deltaMs = round(adaptiveAvgMs - fixed1AvgMs);
+	return {
+		adaptiveAvgMs,
+		fixed1AvgMs,
+		deltaMs,
+		adaptiveVsFixed1Pct:
+			fixed1AvgMs === 0 ? null : round((deltaMs / fixed1AvgMs) * 100),
+	};
+};
+
+export const compareUploadPerformanceModes = (results) => {
+	const adaptive = results.filter((result) => result.mode === "adaptive");
+	const fixed1 = results.filter((result) => result.mode === "fixed1");
+	const upload = compareModeMetric(
+		adaptive,
+		fixed1,
+		(result) => result.uploadDurationMs,
+	);
+	const writerReady = compareModeMetric(
+		adaptive,
+		fixed1,
+		(result) => result.timeToWriterReadyMs,
+	);
+	const readerReady = compareModeMetric(
+		adaptive,
+		fixed1,
+		(result) => result.timeToReaderReadyMs,
+	);
+	if (!upload || !writerReady || !readerReady) {
+		return null;
+	}
+	return {
+		adaptiveAvgMs: upload.adaptiveAvgMs,
+		fixed1AvgMs: upload.fixed1AvgMs,
+		deltaMs: upload.deltaMs,
+		adaptiveVsFixed1Pct: upload.adaptiveVsFixed1Pct,
+		adaptiveWriterReadyAvgMs: writerReady.adaptiveAvgMs,
+		fixed1WriterReadyAvgMs: writerReady.fixed1AvgMs,
+		writerReadyDeltaMs: writerReady.deltaMs,
+		adaptiveVsFixed1WriterReadyPct: writerReady.adaptiveVsFixed1Pct,
+		adaptiveReaderReadyAvgMs: readerReady.adaptiveAvgMs,
+		fixed1ReaderReadyAvgMs: readerReady.fixed1AvgMs,
+		readerReadyDeltaMs: readerReady.deltaMs,
+		adaptiveVsFixed1ReaderReadyPct: readerReady.adaptiveVsFixed1Pct,
+	};
+};
+
+export const uploadTimingTableColumns = (result) => ({
+	timeToWriterReadyMs: result.timeToWriterReadyMs ?? null,
+	timeToReaderReadyMs: result.timeToReaderReadyMs ?? null,
+	postSettlementListingMs: result.listingDurationMs ?? null,
+});

--- a/scripts/file-share/benchmark-summary.mjs
+++ b/scripts/file-share/benchmark-summary.mjs
@@ -1,4 +1,6 @@
 const round = (value) => Number(value.toFixed(1));
+const TIMING_DISTRIBUTION_DEFINITION =
+	"avg/min/max and linearly interpolated p25/median/p75 over passed runs only";
 
 const average = (values) =>
 	values.length > 0
@@ -76,6 +78,7 @@ export const summarizeUploadPerformance = (results) => {
 		passedNumbers(results, (result) => result.downloadDurationMs),
 	);
 	return {
+		timingDistributionDefinition: TIMING_DISTRIBUTION_DEFINITION,
 		...flattenDistribution("uploadDurationMs", uploadDuration),
 		...flattenDistribution("timeToWriterReadyMs", timeToWriterReady),
 		...flattenDistribution("timeToReaderReadyMs", timeToReaderReady),

--- a/scripts/file-share/benchmark-summary.test.mjs
+++ b/scripts/file-share/benchmark-summary.test.mjs
@@ -33,6 +33,8 @@ test("propagates end-to-end readiness and labels post-settlement listing", () =>
 	];
 
 	assert.deepEqual(summarizeUploadPerformance(results), {
+		timingDistributionDefinition:
+			"avg/min/max and linearly interpolated p25/median/p75 over passed runs only",
 		uploadDurationMsAvg: 100,
 		uploadDurationMsP25: 90,
 		uploadDurationMsMedian: 100,

--- a/scripts/file-share/benchmark-summary.test.mjs
+++ b/scripts/file-share/benchmark-summary.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	compareUploadPerformanceModes,
+	summarizeUploadPerformance,
+	uploadTimingTableColumns,
+} from "./benchmark-summary.mjs";
+
+test("propagates end-to-end readiness and labels post-settlement listing", () => {
+	const results = [
+		{
+			status: "passed",
+			uploadDurationMs: 80,
+			timeToWriterReadyMs: 100,
+			timeToReaderReadyMs: 140,
+			listingDurationMs: 20,
+			downloadDurationMs: 50,
+		},
+		{
+			status: "passed",
+			uploadDurationMs: 120,
+			timeToWriterReadyMs: 200,
+			timeToReaderReadyMs: 260,
+			listingDurationMs: 40,
+			downloadDurationMs: 70,
+		},
+		{
+			status: "failed",
+			timeToWriterReadyMs: 9_999,
+			timeToReaderReadyMs: 9_999,
+			listingDurationMs: 9_999,
+		},
+	];
+
+	assert.deepEqual(summarizeUploadPerformance(results), {
+		uploadDurationMsAvg: 100,
+		uploadDurationMsP25: 90,
+		uploadDurationMsMedian: 100,
+		uploadDurationMsP75: 110,
+		uploadDurationMsMin: 80,
+		uploadDurationMsMax: 120,
+		timeToWriterReadyMsAvg: 150,
+		timeToWriterReadyMsP25: 125,
+		timeToWriterReadyMsMedian: 150,
+		timeToWriterReadyMsP75: 175,
+		timeToWriterReadyMsMin: 100,
+		timeToWriterReadyMsMax: 200,
+		timeToReaderReadyMsAvg: 200,
+		timeToReaderReadyMsP25: 170,
+		timeToReaderReadyMsMedian: 200,
+		timeToReaderReadyMsP75: 230,
+		timeToReaderReadyMsMin: 140,
+		timeToReaderReadyMsMax: 260,
+		listingDurationMsAvg: 30,
+		postSettlementListingDurationMsAvg: 30,
+		postSettlementListingDurationMsP25: 25,
+		postSettlementListingDurationMsMedian: 30,
+		postSettlementListingDurationMsP75: 35,
+		postSettlementListingDurationMsMin: 20,
+		postSettlementListingDurationMsMax: 40,
+		downloadDurationMsAvg: 60,
+		downloadDurationMsP25: 55,
+		downloadDurationMsMedian: 60,
+		downloadDurationMsP75: 65,
+		downloadDurationMsMin: 50,
+		downloadDurationMsMax: 70,
+	});
+	assert.deepEqual(uploadTimingTableColumns(results[0]), {
+		timeToWriterReadyMs: 100,
+		timeToReaderReadyMs: 140,
+		postSettlementListingMs: 20,
+	});
+});
+
+test("compares modes using upload and end-to-end readiness", () => {
+	assert.deepEqual(
+		compareUploadPerformanceModes([
+			{
+				status: "passed",
+				mode: "adaptive",
+				uploadDurationMs: 80,
+				timeToWriterReadyMs: 70,
+				timeToReaderReadyMs: 120,
+			},
+			{
+				status: "passed",
+				mode: "fixed1",
+				uploadDurationMs: 100,
+				timeToWriterReadyMs: 80,
+				timeToReaderReadyMs: 150,
+			},
+		]),
+		{
+			adaptiveAvgMs: 80,
+			fixed1AvgMs: 100,
+			deltaMs: -20,
+			adaptiveVsFixed1Pct: -20,
+			adaptiveWriterReadyAvgMs: 70,
+			fixed1WriterReadyAvgMs: 80,
+			writerReadyDeltaMs: -10,
+			adaptiveVsFixed1WriterReadyPct: -12.5,
+			adaptiveReaderReadyAvgMs: 120,
+			fixed1ReaderReadyAvgMs: 150,
+			readerReadyDeltaMs: -30,
+			adaptiveVsFixed1ReaderReadyPct: -20,
+		},
+	);
+});

--- a/scripts/file-share/benchmark-validity.mjs
+++ b/scripts/file-share/benchmark-validity.mjs
@@ -13,6 +13,12 @@ const POST_MONITOR_SCHEDULING_TOLERANCE_DEFINITION =
 	"max(250ms, pollMs + 250ms) for the final poll and event-loop scheduling";
 const TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION =
 	"max(5000ms, pollMs + 1000ms) for browser actions and event-loop scheduling";
+const TIME_TO_WRITER_READY_DEFINITION =
+	"upload-input-set-to-writer-ready-manifest-listed";
+const TIME_TO_READER_READY_DEFINITION =
+	"upload-input-set-to-reader-ready-manifest-listed";
+const LISTING_DURATION_DEFINITION =
+	"post-upload-settlement-to-both-writer-and-reader-ready-manifests-listed; excludes upload time";
 
 const isRecord = (value) =>
 	value != null && typeof value === "object" && !Array.isArray(value);
@@ -174,6 +180,22 @@ const validateUploadTimings = (result, invocation) => {
 		phases.timeToUploadSettled,
 		"phaseDurationsMs.timeToUploadSettled",
 	);
+	const phaseTimeToWriterReadyMs = requireNonNegativeNumber(
+		phases.timeToWriterReady,
+		"phaseDurationsMs.timeToWriterReady",
+	);
+	const phaseTimeToReaderReadyMs = requireNonNegativeNumber(
+		phases.timeToReaderReady,
+		"phaseDurationsMs.timeToReaderReady",
+	);
+	const timeToWriterReadyMs = requireNonNegativeNumber(
+		result.timeToWriterReadyMs,
+		"timeToWriterReadyMs",
+	);
+	const timeToReaderReadyMs = requireNonNegativeNumber(
+		result.timeToReaderReadyMs,
+		"timeToReaderReadyMs",
+	);
 	requireNonNegativeNumber(
 		phases.writerListingLag,
 		"phaseDurationsMs.writerListingLag",
@@ -196,6 +218,13 @@ const validateUploadTimings = (result, invocation) => {
 		throw new Error(
 			"uploadDurationMs must end at upload settlement and exclude listing/post-monitor/download",
 		);
+	}
+	if (
+		result.timeToWriterReadyDefinition !== TIME_TO_WRITER_READY_DEFINITION ||
+		result.timeToReaderReadyDefinition !== TIME_TO_READER_READY_DEFINITION ||
+		result.listingDurationDefinition !== LISTING_DURATION_DEFINITION
+	) {
+		throw new Error("Benchmark readiness duration definitions are invalid");
 	}
 	const timestamps = requireRecord(result.timestamps, "timestamps");
 	const uploadStartedAt = requirePositiveNumber(
@@ -268,6 +297,10 @@ const validateUploadTimings = (result, invocation) => {
 	);
 	if (
 		uploadDurationMs !== uploadSettledAt - uploadStartedAt ||
+		timeToWriterReadyMs !== writerListedAt - uploadStartedAt ||
+		timeToReaderReadyMs !== readerListedAt - uploadStartedAt ||
+		phaseTimeToWriterReadyMs !== timeToWriterReadyMs ||
+		phaseTimeToReaderReadyMs !== timeToReaderReadyMs ||
 		result.listingDurationMs !== expectedListingDuration ||
 		result.postUploadMonitorDurationMs !==
 			postMonitorFinishedAt - postMonitorStartedAt ||
@@ -415,6 +448,7 @@ const validateRequestedUploadKnobs = (result, invocation) => {
 		["uploadTimeoutMs", "uploadTimeoutMs"],
 		["downloadTimeoutMs", "downloadTimeoutMs"],
 		["minReadySeeders", "minReadySeeders"],
+		["readyTimeoutMs", "readyTimeoutMs"],
 	]) {
 		if (result[resultKey] !== invocation[invocationKey]) {
 			throw new Error(

--- a/scripts/file-share/benchmark-validity.test.mjs
+++ b/scripts/file-share/benchmark-validity.test.mjs
@@ -21,6 +21,12 @@ const POST_MONITOR_SCHEDULING_TOLERANCE_DEFINITION =
 	"max(250ms, pollMs + 250ms) for the final poll and event-loop scheduling";
 const TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION =
 	"max(5000ms, pollMs + 1000ms) for browser actions and event-loop scheduling";
+const TIME_TO_WRITER_READY_DEFINITION =
+	"upload-input-set-to-writer-ready-manifest-listed";
+const TIME_TO_READER_READY_DEFINITION =
+	"upload-input-set-to-reader-ready-manifest-listed";
+const LISTING_DURATION_DEFINITION =
+	"post-upload-settlement-to-both-writer-and-reader-ready-manifests-listed; excludes upload time";
 const PROVENANCE = {
 	harness: {
 		requestedRef: "harness-worktree",
@@ -55,6 +61,7 @@ const INVOCATION = createBenchmarkInvocation({
 	postUploadMonitorMs: 50,
 	pollMs: 1_000,
 	minReadySeeders: 2,
+	readyTimeoutMs: 180_000,
 });
 
 const options = {
@@ -98,7 +105,12 @@ const validResult = () => ({
 		verified: true,
 	},
 	uploadDurationMs: 101,
+	timeToWriterReadyMs: 100,
+	timeToWriterReadyDefinition: TIME_TO_WRITER_READY_DEFINITION,
+	timeToReaderReadyMs: 120,
+	timeToReaderReadyDefinition: TIME_TO_READER_READY_DEFINITION,
 	listingDurationMs: 19,
+	listingDurationDefinition: LISTING_DURATION_DEFINITION,
 	postUploadMonitorDurationMs: 50,
 	postUploadMonitorSchedulingToleranceMs: 1_250,
 	postUploadMonitorSchedulingToleranceDefinition:
@@ -108,6 +120,7 @@ const validResult = () => ({
 	uploadTimeoutMs: 600_000,
 	downloadTimeoutMs: 600_000,
 	minReadySeeders: 2,
+	readyTimeoutMs: 180_000,
 	downloadDurationMs: 30,
 	transferTimeoutSchedulingToleranceMs: 5_000,
 	transferTimeoutSchedulingToleranceDefinition:
@@ -115,6 +128,8 @@ const validResult = () => ({
 	downloadSink: "node-file",
 	phaseDurationsMs: {
 		timeToUploadSettled: 101,
+		timeToWriterReady: 100,
+		timeToReaderReady: 120,
 		writerListingLag: 0,
 		readerListingLag: 19,
 		readerAfterWriter: 20,
@@ -264,6 +279,27 @@ for (const [name, mutate, pattern] of [
 		/not monotonic/,
 	],
 	[
+		"writer readiness arithmetic",
+		(result) => {
+			result.timeToWriterReadyMs += 1;
+		},
+		/phase duration arithmetic is inconsistent/,
+	],
+	[
+		"reader readiness phase propagation",
+		(result) => {
+			result.phaseDurationsMs.timeToReaderReady += 1;
+		},
+		/phase duration arithmetic is inconsistent/,
+	],
+	[
+		"readiness definition",
+		(result) => {
+			result.timeToReaderReadyDefinition = "post-settlement-only";
+		},
+		/readiness duration definitions are invalid/,
+	],
+	[
 		"provenance",
 		(result) => {
 			result.provenance.peerbit.resolvedCommit = "d".repeat(40);
@@ -276,6 +312,13 @@ for (const [name, mutate, pattern] of [
 			result.invocation.postUploadMonitorMs = 1;
 		},
 		/invocation does not match/,
+	],
+	[
+		"ready timeout propagation",
+		(result) => {
+			result.readyTimeoutMs -= 1;
+		},
+		/readyTimeoutMs does not match the requested invocation/,
 	],
 	[
 		"short monitor",

--- a/scripts/file-share/run-file-share-benchmark-matrix.mjs
+++ b/scripts/file-share/run-file-share-benchmark-matrix.mjs
@@ -15,6 +15,10 @@ import {
 	resolveGitCommitAt,
 } from "./benchmark-provenance.mjs";
 import {
+	compareUploadPerformanceModes,
+	summarizeUploadPerformance,
+} from "./benchmark-summary.mjs";
+import {
 	collectLocalPeerbitPackages,
 	defaultExamplesSource,
 	defaultFileShareLocalPackages,
@@ -128,20 +132,26 @@ const resolveVariantSpecs = async (variantSpecs) => {
 };
 
 const summarizeUploadMatrix = (variantSummaries) => {
-	return variantSummaries.map((summary) => ({
-		variant: summary.variant,
-		adaptiveAvgMs: summary.comparison?.adaptiveAvgMs ?? null,
-		fixed1AvgMs: summary.comparison?.fixed1AvgMs ?? null,
-		adaptiveVsFixed1Pct: summary.comparison?.adaptiveVsFixed1Pct ?? null,
-		adaptiveStatus:
-			summary.summary.find((entry) => entry.mode === "adaptive")?.failed === 0
-				? "passed"
-				: "failed",
-		fixed1Status:
-			summary.summary.find((entry) => entry.mode === "fixed1")?.failed === 0
-				? "passed"
-				: "failed",
-	}));
+	return variantSummaries.map((summary) => {
+		const adaptive = summary.summary.find((entry) => entry.mode === "adaptive");
+		const fixed1 = summary.summary.find((entry) => entry.mode === "fixed1");
+		return {
+			variant: summary.variant,
+			adaptiveAvgMs: summary.comparison?.adaptiveAvgMs ?? null,
+			fixed1AvgMs: summary.comparison?.fixed1AvgMs ?? null,
+			adaptiveVsFixed1Pct: summary.comparison?.adaptiveVsFixed1Pct ?? null,
+			adaptiveWriterReadyMsAvg: adaptive?.timeToWriterReadyMsAvg ?? null,
+			fixed1WriterReadyMsAvg: fixed1?.timeToWriterReadyMsAvg ?? null,
+			adaptiveWriterReadyMsMedian: adaptive?.timeToWriterReadyMsMedian ?? null,
+			fixed1WriterReadyMsMedian: fixed1?.timeToWriterReadyMsMedian ?? null,
+			adaptiveReaderReadyMsAvg: adaptive?.timeToReaderReadyMsAvg ?? null,
+			fixed1ReaderReadyMsAvg: fixed1?.timeToReaderReadyMsAvg ?? null,
+			adaptiveReaderReadyMsMedian: adaptive?.timeToReaderReadyMsMedian ?? null,
+			fixed1ReaderReadyMsMedian: fixed1?.timeToReaderReadyMsMedian ?? null,
+			adaptiveStatus: adaptive?.failed === 0 ? "passed" : "failed",
+			fixed1Status: fixed1?.failed === 0 ? "passed" : "failed",
+		};
+	});
 };
 
 const summarizeSeederProbeMatrix = (variantSummaries) => {
@@ -186,6 +196,10 @@ const compareAdaptiveAcrossVariants = (variantSummaries, scenario) => {
 					? {
 							variant: summary.variant,
 							adaptiveAvgMs: adaptive.uploadDurationMsAvg,
+							adaptiveWriterReadyMsAvg: adaptive.timeToWriterReadyMsAvg,
+							adaptiveWriterReadyMsMedian: adaptive.timeToWriterReadyMsMedian,
+							adaptiveReaderReadyMsAvg: adaptive.timeToReaderReadyMsAvg,
+							adaptiveReaderReadyMsMedian: adaptive.timeToReaderReadyMsMedian,
 						}
 					: null;
 		})
@@ -249,11 +263,10 @@ const summarizeInvocationResults = (results, scenario) => {
 				.filter((value) => typeof value === "number");
 		return {
 			...base,
-			uploadDurationMsAvg: average(numbers((item) => item.uploadDurationMs)),
+			...summarizeUploadPerformance(items),
 			uploadSettledMsAvg: average(
 				numbers((item) => item.phaseDurationsMs?.timeToUploadSettled),
 			),
-			listingDurationMsAvg: average(numbers((item) => item.listingDurationMs)),
 			writerListingLagMsAvg: average(
 				numbers((item) => item.phaseDurationsMs?.writerListingLag),
 			),
@@ -263,30 +276,9 @@ const summarizeInvocationResults = (results, scenario) => {
 			postUploadMonitorDurationMsAvg: average(
 				numbers((item) => item.postUploadMonitorDurationMs),
 			),
-			downloadDurationMsAvg: average(
-				numbers((item) => item.downloadDurationMs),
-			),
 			seederDrops: items.filter((item) => item.droppedSeeders).length,
 		};
 	});
-};
-
-const compareCombinedUploadModes = (results) => {
-	const passed = results.filter((result) => result.status === "passed");
-	const adaptive = passed.filter((result) => result.mode === "adaptive");
-	const fixed = passed.filter((result) => result.mode === "fixed1");
-	if (adaptive.length === 0 || fixed.length === 0) {
-		return null;
-	}
-	const adaptiveAvg = average(adaptive.map((item) => item.uploadDurationMs));
-	const fixedAvg = average(fixed.map((item) => item.uploadDurationMs));
-	const delta = adaptiveAvg - fixedAvg;
-	return {
-		adaptiveAvgMs: adaptiveAvg,
-		fixed1AvgMs: fixedAvg,
-		deltaMs: Number(delta.toFixed(1)),
-		adaptiveVsFixed1Pct: Number(((delta / fixedAvg) * 100).toFixed(1)),
-	};
 };
 
 const prepareVariant = async ({ variantSpec, variantRoot }) => {
@@ -711,7 +703,7 @@ const main = async () => {
 			results,
 			summary: summarizeInvocationResults(results, scenario),
 			comparison:
-				scenario === "upload" ? compareCombinedUploadModes(results) : null,
+				scenario === "upload" ? compareUploadPerformanceModes(results) : null,
 		};
 	});
 

--- a/scripts/file-share/run-file-share-benchmark.mjs
+++ b/scripts/file-share/run-file-share-benchmark.mjs
@@ -18,6 +18,11 @@ import {
 	getPeerbitProvenance,
 	resolveGitCommitAt,
 } from "./benchmark-provenance.mjs";
+import {
+	compareUploadPerformanceModes,
+	summarizeUploadPerformance,
+	uploadTimingTableColumns,
+} from "./benchmark-summary.mjs";
 import { loadAndValidateBenchmarkResult } from "./benchmark-validity.mjs";
 import {
 	buildPeerbitPackages,
@@ -304,21 +309,11 @@ const summarizeUploadResults = (results) => {
 		runs: items.length,
 		passed: items.filter((item) => item.status === "passed").length,
 		failed: items.filter((item) => item.status !== "passed").length,
-		uploadDurationMsAvg: average(
-			items
-				.filter((item) => item.status === "passed")
-				.map((item) => item.uploadDurationMs)
-				.filter((value) => typeof value === "number"),
-		),
+		...summarizeUploadPerformance(items),
 		uploadSettledMsAvg: average(
 			items
 				.filter((item) => item.status === "passed")
 				.map((item) => item.phaseDurationsMs?.timeToUploadSettled)
-				.filter((value) => typeof value === "number"),
-		),
-		listingDurationMsAvg: average(
-			items
-				.map((item) => item.listingDurationMs)
 				.filter((value) => typeof value === "number"),
 		),
 		writerListingLagMsAvg: average(
@@ -336,11 +331,6 @@ const summarizeUploadResults = (results) => {
 		postUploadMonitorDurationMsAvg: average(
 			items
 				.map((item) => item.postUploadMonitorDurationMs)
-				.filter((value) => typeof value === "number"),
-		),
-		downloadDurationMsAvg: average(
-			items
-				.map((item) => item.downloadDurationMs)
 				.filter((value) => typeof value === "number"),
 		),
 		errorCount: items.reduce((sum, item) => sum + item.errorCount, 0),
@@ -407,35 +397,6 @@ const summarizeResults = (results, scenario) =>
 	scenario === "seeder-probe"
 		? summarizeSeederProbeResults(results)
 		: summarizeUploadResults(results);
-
-const compareUploadModes = (results) => {
-	const byMode = new Map();
-	for (const result of results) {
-		if (result.status !== "passed") {
-			continue;
-		}
-		const arr = byMode.get(result.mode) ?? [];
-		arr.push(result);
-		byMode.set(result.mode, arr);
-	}
-	const adaptive = byMode.get("adaptive");
-	const fixed = byMode.get("fixed1");
-	if (!adaptive?.length || !fixed?.length) {
-		return null;
-	}
-	const adaptiveAvg =
-		adaptive.reduce((sum, item) => sum + item.uploadDurationMs, 0) /
-		adaptive.length;
-	const fixedAvg =
-		fixed.reduce((sum, item) => sum + item.uploadDurationMs, 0) / fixed.length;
-	const deltaMs = adaptiveAvg - fixedAvg;
-	return {
-		adaptiveAvgMs: Number(adaptiveAvg.toFixed(1)),
-		fixed1AvgMs: Number(fixedAvg.toFixed(1)),
-		deltaMs: Number(deltaMs.toFixed(1)),
-		adaptiveVsFixed1Pct: Number(((deltaMs / fixedAvg) * 100).toFixed(1)),
-	};
-};
 
 const runPlaywright = ({
 	frontendRoot,
@@ -881,7 +842,7 @@ const main = async () => {
 					: null,
 			uploadDurationMs: result.uploadDurationMs,
 			uploadSettledMs: result.phaseDurationsMs?.timeToUploadSettled ?? null,
-			listingDurationMs: result.listingDurationMs ?? null,
+			...uploadTimingTableColumns(result),
 			writerListingLagMs: result.phaseDurationsMs?.writerListingLag ?? null,
 			readerListingLagMs: result.phaseDurationsMs?.readerListingLag ?? null,
 			postUploadMonitorDurationMs: result.postUploadMonitorDurationMs ?? null,
@@ -896,7 +857,8 @@ const main = async () => {
 	);
 	console.log("\nSummary");
 	console.table(summarizeResults(results, scenario));
-	const comparison = scenario === "upload" ? compareUploadModes(results) : null;
+	const comparison =
+		scenario === "upload" ? compareUploadPerformanceModes(results) : null;
 	if (comparison) {
 		console.log("\nAdaptive vs fixed1");
 		console.table([comparison]);

--- a/scripts/file-share/template-contract.test.mjs
+++ b/scripts/file-share/template-contract.test.mjs
@@ -38,6 +38,7 @@ for (const name of templates) {
 			"diagnostics.programClosed === false",
 			"await hooks.setReplicationRole(role)",
 			"timeout: READY_TIMEOUT_MS",
+			"2 * READY_TIMEOUT_MS",
 		]) {
 			assert.ok(
 				contents.includes(required),
@@ -104,7 +105,7 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"writerListedAt - uploadStartedAt",
 		"readerListedAt - uploadStartedAt",
 		"readyTimeoutMs: READY_TIMEOUT_MS",
-		"READY_TIMEOUT_MS +",
+		"2 * READY_TIMEOUT_MS +",
 		"POST_MONITOR_SCHEDULING_TOLERANCE_MS",
 		"TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS",
 		"Measured transfer duration exceeded",

--- a/scripts/file-share/template-contract.test.mjs
+++ b/scripts/file-share/template-contract.test.mjs
@@ -32,6 +32,17 @@ for (const name of templates) {
 		]) {
 			assert.ok(contents.includes(required), `missing ${required}`);
 		}
+		for (const required of [
+			"getLightweightSnapshot",
+			"diagnostics?.programAddress",
+			"diagnostics.programClosed === false",
+			"await hooks.setReplicationRole(role)",
+		]) {
+			assert.ok(
+				contents.includes(required),
+				`${name} must wait for a live program before applying a role`,
+			);
+		}
 		assert.ok(
 			contents.indexOf("await writeFile(temporaryPath") <
 				contents.indexOf("await rename(temporaryPath, RESULT_FILE)"),
@@ -87,10 +98,39 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 	for (const required of [
 		"readSeederCount(writer",
 		"readSeederCount(reader",
+		"timeToWriterReadyMs",
+		"timeToReaderReadyMs",
+		"writerListedAt - uploadStartedAt",
+		"readerListedAt - uploadStartedAt",
+		"readyTimeoutMs: READY_TIMEOUT_MS",
+		"READY_TIMEOUT_MS +",
 		"POST_MONITOR_SCHEDULING_TOLERANCE_MS",
 		"TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS",
 		"Measured transfer duration exceeded",
 	]) {
 		assert.ok(contents.includes(required), `missing ${required}`);
+	}
+	assert.ok(
+		contents.includes(
+			"const MIN_READY_SEEDERS = Number(process.env.PW_MIN_READY_SEEDERS)",
+		),
+		"the template must consume the resolved invocation value",
+	);
+	assert.ok(
+		!contents.includes('MODE === "adaptive" ? "2" : "0"'),
+		"the template must not redefine mode-specific ready-seeder defaults",
+	);
+	assert.ok(
+		!contents.includes("MIN_READY_SEEDERS, 180_000"),
+		"the upload probe must honor the invocation readiness timeout",
+	);
+	for (const peer of ["writer", "reader"]) {
+		assert.match(
+			contents,
+			new RegExp(
+				`expectSeedersAtLeast\\(\\s*${peer},\\s*MIN_READY_SEEDERS,\\s*READY_TIMEOUT_MS,?\\s*\\)`,
+			),
+			`${peer} readiness must use the invocation timeout`,
+		);
 	}
 });

--- a/scripts/file-share/template-contract.test.mjs
+++ b/scripts/file-share/template-contract.test.mjs
@@ -37,6 +37,7 @@ for (const name of templates) {
 			"diagnostics?.programAddress",
 			"diagnostics.programClosed === false",
 			"await hooks.setReplicationRole(role)",
+			"timeout: READY_TIMEOUT_MS",
 		]) {
 			assert.ok(
 				contents.includes(required),

--- a/scripts/file-share/templates/seeder-probe.e2e.spec.ts
+++ b/scripts/file-share/templates/seeder-probe.e2e.spec.ts
@@ -278,7 +278,7 @@ test.describe("generated seeder probe", () => {
 		test.setTimeout(
 			Math.max(
 				15 * 60 * 1000,
-				READY_TIMEOUT_MS + SAMPLE_MS * (SAMPLE_COUNT + 2) + 60_000,
+				2 * READY_TIMEOUT_MS + SAMPLE_MS * (SAMPLE_COUNT + 2) + 60_000,
 			),
 		);
 		if (!baseURL) {

--- a/scripts/file-share/templates/seeder-probe.e2e.spec.ts
+++ b/scripts/file-share/templates/seeder-probe.e2e.spec.ts
@@ -181,7 +181,7 @@ const waitForTestHooks = async (
 			requireRoleSetter: Boolean(options.requireRoleSetter),
 			role: options.role,
 		},
-		{ timeout: 60_000, polling: 100 },
+		{ timeout: READY_TIMEOUT_MS, polling: 100 },
 	);
 };
 

--- a/scripts/file-share/templates/seeder-probe.e2e.spec.ts
+++ b/scripts/file-share/templates/seeder-probe.e2e.spec.ts
@@ -140,33 +140,61 @@ const attachErrorCollector = (page: Page, label: string, output: string[]) => {
 
 const waitForTestHooks = async (
 	page: Page,
-	options: { requireRoleSetter?: boolean } = {},
+	options: {
+		requireRoleSetter?: boolean;
+		role?: ReturnType<typeof getRole>;
+	} = {},
 ) => {
 	await page.waitForFunction(
-		(requireRoleSetter) => {
+		async ({ requireRoleSetter, role }) => {
 			const hooks = (window as any).__peerbitFileShareTestHooks;
-			return requireRoleSetter
-				? Boolean(hooks?.setReplicationRole && hooks?.getDiagnostics)
-				: Boolean(hooks?.getDiagnostics);
+			if (!hooks?.getDiagnostics) {
+				return false;
+			}
+			if (!requireRoleSetter) {
+				return true;
+			}
+			if (!hooks.setReplicationRole) {
+				return false;
+			}
+			try {
+				const diagnostics = hooks.getLightweightSnapshot
+					? hooks.getLightweightSnapshot()
+					: await hooks.getDiagnostics();
+				const programReady =
+					typeof diagnostics?.programAddress === "string" &&
+					diagnostics.programClosed === false;
+				if (!programReady) {
+					return false;
+				}
+				await hooks.setReplicationRole(role);
+				return true;
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				if (message.includes("Program is not ready")) {
+					return false;
+				}
+				throw error;
+			}
 		},
-		Boolean(options.requireRoleSetter),
-		{ timeout: 60_000 },
+		{
+			requireRoleSetter: Boolean(options.requireRoleSetter),
+			role: options.role,
+		},
+		{ timeout: 60_000, polling: 100 },
 	);
 };
 
 const applyRole = async (page: Page, shareUrl: string) => {
 	await page.goto(shareUrl, { waitUntil: "domcontentloaded" });
-	await waitForTestHooks(page, { requireRoleSetter: MODE !== "adaptive" });
 	if (MODE === "adaptive") {
+		await waitForTestHooks(page);
 		return;
 	}
-	await page.evaluate(async (role) => {
-		const hooks = (window as any).__peerbitFileShareTestHooks;
-		if (!hooks?.setReplicationRole) {
-			throw new Error("Missing __peerbitFileShareTestHooks.setReplicationRole");
-		}
-		await hooks.setReplicationRole(role);
-	}, getRole());
+	await waitForTestHooks(page, {
+		requireRoleSetter: true,
+		role: getRole(),
+	});
 };
 
 const getDiagnostics = async (page: Page) =>

--- a/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
+++ b/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
@@ -228,7 +228,7 @@ const waitForTestHooks = async (
 			requireRoleSetter: Boolean(options.requireRoleSetter),
 			role: options.role,
 		},
-		{ timeout: 60_000, polling: 100 },
+		{ timeout: READY_TIMEOUT_MS, polling: 100 },
 	);
 };
 

--- a/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
+++ b/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
@@ -28,6 +28,7 @@ const DOWNLOAD_TIMEOUT_MS = Number(
 		process.env.PW_UPLOAD_TIMEOUT_MS ||
 		"600000",
 );
+const READY_TIMEOUT_MS = Number(process.env.PW_READY_TIMEOUT_MS);
 const POST_MONITOR_SCHEDULING_TOLERANCE_MS = Math.max(250, POLL_MS + 250);
 const POST_MONITOR_SCHEDULING_TOLERANCE_DEFINITION =
 	"max(250ms, pollMs + 250ms) for the final poll and event-loop scheduling";
@@ -37,6 +38,12 @@ const TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS = Math.max(
 );
 const TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION =
 	"max(5000ms, pollMs + 1000ms) for browser actions and event-loop scheduling";
+const TIME_TO_WRITER_READY_DEFINITION =
+	"upload-input-set-to-writer-ready-manifest-listed";
+const TIME_TO_READER_READY_DEFINITION =
+	"upload-input-set-to-reader-ready-manifest-listed";
+const LISTING_DURATION_DEFINITION =
+	"post-upload-settlement-to-both-writer-and-reader-ready-manifests-listed; excludes upload time";
 const FIXTURE_SEED =
 	process.env.PW_FIXTURE_SEED || "peerbit-file-share-benchmark-v1";
 const RESULT_SCHEMA = {
@@ -61,9 +68,7 @@ const MODE = process.env.PW_REPLICATION_MODE || "adaptive";
 const NETWORK_MODE = process.env.PW_NETWORK_MODE || "local";
 const RESULT_FILE = process.env.PW_RESULT_FILE;
 const ENABLE_VISIBILITY_PROBE = process.env.PW_ENABLE_VISIBILITY_PROBE === "1";
-const MIN_READY_SEEDERS = Number(
-	process.env.PW_MIN_READY_SEEDERS || (MODE === "adaptive" ? "2" : "0"),
-);
+const MIN_READY_SEEDERS = Number(process.env.PW_MIN_READY_SEEDERS);
 const VERBOSE = process.env.PW_VERBOSE === "1";
 
 if (!Number.isSafeInteger(FILE_SIZE_BYTES) || FILE_SIZE_BYTES < 0) {
@@ -71,6 +76,24 @@ if (!Number.isSafeInteger(FILE_SIZE_BYTES) || FILE_SIZE_BYTES < 0) {
 }
 if (!RUN_NONCE) {
 	throw new Error("Missing PW_BENCHMARK_RUN_NONCE");
+}
+if (
+	process.env.PW_MIN_READY_SEEDERS == null ||
+	!Number.isSafeInteger(MIN_READY_SEEDERS) ||
+	MIN_READY_SEEDERS < 0
+) {
+	throw new Error(
+		`Invalid PW_MIN_READY_SEEDERS='${process.env.PW_MIN_READY_SEEDERS}'`,
+	);
+}
+if (
+	process.env.PW_READY_TIMEOUT_MS == null ||
+	!Number.isSafeInteger(READY_TIMEOUT_MS) ||
+	READY_TIMEOUT_MS <= 0
+) {
+	throw new Error(
+		`Invalid PW_READY_TIMEOUT_MS='${process.env.PW_READY_TIMEOUT_MS}'`,
+	);
 }
 if (process.env.PW_BENCH !== "1") {
 	throw new Error("Upload benchmark must run against the production preview");
@@ -91,6 +114,7 @@ const expectedInvocationValues: Record<string, unknown> = {
 	postUploadMonitorMs: POST_UPLOAD_MONITOR_MS,
 	pollMs: POLL_MS,
 	minReadySeeders: MIN_READY_SEEDERS,
+	readyTimeoutMs: READY_TIMEOUT_MS,
 	baseUrl: process.env.PW_BASE_URL || null,
 	protocol: process.env.PW_PROTOCOL || null,
 	viteMode: process.env.PW_VITE_MODE || null,
@@ -163,33 +187,61 @@ const attachTransferErrorCollector = (
 
 const waitForTestHooks = async (
 	page: Page,
-	options: { requireRoleSetter?: boolean } = {},
+	options: {
+		requireRoleSetter?: boolean;
+		role?: ReturnType<typeof getRole>;
+	} = {},
 ) => {
 	await page.waitForFunction(
-		(requireRoleSetter) => {
+		async ({ requireRoleSetter, role }) => {
 			const hooks = (window as any).__peerbitFileShareTestHooks;
-			return requireRoleSetter
-				? Boolean(hooks?.setReplicationRole && hooks?.getDiagnostics)
-				: Boolean(hooks?.getDiagnostics);
+			if (!hooks?.getDiagnostics) {
+				return false;
+			}
+			if (!requireRoleSetter) {
+				return true;
+			}
+			if (!hooks.setReplicationRole) {
+				return false;
+			}
+			try {
+				const diagnostics = hooks.getLightweightSnapshot
+					? hooks.getLightweightSnapshot()
+					: await hooks.getDiagnostics();
+				const programReady =
+					typeof diagnostics?.programAddress === "string" &&
+					diagnostics.programClosed === false;
+				if (!programReady) {
+					return false;
+				}
+				await hooks.setReplicationRole(role);
+				return true;
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				if (message.includes("Program is not ready")) {
+					return false;
+				}
+				throw error;
+			}
 		},
-		Boolean(options.requireRoleSetter),
-		{ timeout: 60_000 },
+		{
+			requireRoleSetter: Boolean(options.requireRoleSetter),
+			role: options.role,
+		},
+		{ timeout: 60_000, polling: 100 },
 	);
 };
 
 const applyRole = async (page: Page, shareUrl: string) => {
 	await page.goto(shareUrl, { waitUntil: "domcontentloaded" });
-	await waitForTestHooks(page, { requireRoleSetter: MODE !== "adaptive" });
 	if (MODE === "adaptive") {
+		await waitForTestHooks(page);
 		return;
 	}
-	await page.evaluate(async (role) => {
-		const hooks = (window as any).__peerbitFileShareTestHooks;
-		if (!hooks?.setReplicationRole) {
-			throw new Error("Missing __peerbitFileShareTestHooks.setReplicationRole");
-		}
-		await hooks.setReplicationRole(role);
-	}, getRole());
+	await waitForTestHooks(page, {
+		requireRoleSetter: true,
+		role: getRole(),
+	});
 };
 
 const getDiagnostics = async (page: Page) => {
@@ -335,7 +387,8 @@ test.describe("generated transfer-validity benchmark", () => {
 		test.setTimeout(
 			Math.max(
 				20 * 60 * 1000,
-				UPLOAD_TIMEOUT_MS +
+				READY_TIMEOUT_MS +
+					UPLOAD_TIMEOUT_MS +
 					DOWNLOAD_TIMEOUT_MS +
 					POST_UPLOAD_MONITOR_MS +
 					5 * 60 * 1000,
@@ -469,6 +522,14 @@ test.describe("generated transfer-validity benchmark", () => {
 							uploadSettledAt != null
 								? uploadSettledAt - uploadStartedAt
 								: undefined,
+						timeToWriterReady:
+							writerListedAt != null
+								? writerListedAt - uploadStartedAt
+								: undefined,
+						timeToReaderReady:
+							readerListedAt != null
+								? readerListedAt - uploadStartedAt
+								: undefined,
 						writerListingLag:
 							uploadSettledAt != null && writerListedAt != null
 								? Math.max(0, writerListedAt - uploadSettledAt)
@@ -517,10 +578,15 @@ test.describe("generated transfer-validity benchmark", () => {
 			]);
 
 			stage = "wait-for-seeders";
-			logStage(stage, { minReadySeeders: MIN_READY_SEEDERS });
+			logStage(stage, {
+				minReadySeeders: MIN_READY_SEEDERS,
+				readyTimeoutMs: READY_TIMEOUT_MS,
+			});
 			if (MIN_READY_SEEDERS > 0) {
-				await expectSeedersAtLeast(writer, MIN_READY_SEEDERS, 180_000);
-				await expectSeedersAtLeast(reader, MIN_READY_SEEDERS, 180_000);
+				await Promise.all([
+					expectSeedersAtLeast(writer, MIN_READY_SEEDERS, READY_TIMEOUT_MS),
+					expectSeedersAtLeast(reader, MIN_READY_SEEDERS, READY_TIMEOUT_MS),
+				]);
 			} else {
 				await Promise.all([
 					readSeederCount(writer, "writer"),
@@ -753,6 +819,8 @@ test.describe("generated transfer-validity benchmark", () => {
 			}
 			if (
 				phaseDurationsMs.timeToUploadSettled == null ||
+				phaseDurationsMs.timeToWriterReady == null ||
+				phaseDurationsMs.timeToReaderReady == null ||
 				phaseDurationsMs.download == null ||
 				phaseDurationsMs.timeToUploadSettled >
 					UPLOAD_TIMEOUT_MS + TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS ||
@@ -777,12 +845,15 @@ test.describe("generated transfer-validity benchmark", () => {
 				uploadDurationMs: phaseDurationsMs.timeToUploadSettled,
 				uploadDurationDefinition:
 					"input-set-to-writer-ready-manifest-and-upload-progress-settled; excludes reader discovery, post-monitor, and download",
+				timeToWriterReadyMs: phaseDurationsMs.timeToWriterReady,
+				timeToWriterReadyDefinition: TIME_TO_WRITER_READY_DEFINITION,
+				timeToReaderReadyMs: phaseDurationsMs.timeToReaderReady,
+				timeToReaderReadyDefinition: TIME_TO_READER_READY_DEFINITION,
 				listingDurationMs: Math.max(
 					0,
 					Math.max(writerListedAt, readerListedAt) - uploadSettledAt,
 				),
-				listingDurationDefinition:
-					"upload-settled-to-both-writer-and-reader-listed",
+				listingDurationDefinition: LISTING_DURATION_DEFINITION,
 				postUploadMonitorDurationMs:
 					postMonitorFinishedAt - postMonitorStartedAt,
 				postUploadMonitorDurationDefinition:
@@ -819,6 +890,7 @@ test.describe("generated transfer-validity benchmark", () => {
 				uploadTimeoutMs: UPLOAD_TIMEOUT_MS,
 				downloadTimeoutMs: DOWNLOAD_TIMEOUT_MS,
 				minReadySeeders: MIN_READY_SEEDERS,
+				readyTimeoutMs: READY_TIMEOUT_MS,
 				baselineWriterSeeders,
 				baselineReaderSeeders,
 				shareUrl,
@@ -860,6 +932,7 @@ test.describe("generated transfer-validity benchmark", () => {
 				uploadTimeoutMs: UPLOAD_TIMEOUT_MS,
 				downloadTimeoutMs: DOWNLOAD_TIMEOUT_MS,
 				minReadySeeders: MIN_READY_SEEDERS,
+				readyTimeoutMs: READY_TIMEOUT_MS,
 				baselineWriterSeeders,
 				baselineReaderSeeders,
 				shareUrl,

--- a/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
+++ b/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
@@ -387,7 +387,7 @@ test.describe("generated transfer-validity benchmark", () => {
 		test.setTimeout(
 			Math.max(
 				20 * 60 * 1000,
-				READY_TIMEOUT_MS +
+				2 * READY_TIMEOUT_MS +
 					UPLOAD_TIMEOUT_MS +
 					DOWNLOAD_TIMEOUT_MS +
 					POST_UPLOAD_MONITOR_MS +


### PR DESCRIPTION
## Summary

- give adaptive and fixed1 the same default two-seeder readiness baseline; observer remains zero
- record upload-start-to-writer-ready and upload-start-to-reader-ready timings while preserving post-settlement listing metrics
- propagate averages, p25, median, p75, min, and max for readiness plus upload/download timings into standalone and matrix summaries
- honor readyTimeoutMs throughout upload readiness and apply fixed/observer roles atomically once the live program hook is ready
- strengthen timestamp arithmetic, definition, invocation, template, and summary contracts

## Validation

- pnpm run bench:file-share:test (84/84)
- Prettier check and git diff --check
- linked production-preview deterministic 5 MiB adaptive smoke passed with SHA-256/CRC-32 integrity
- linked production-preview deterministic 5 MiB fixed1 smoke passed with two ready seeders, SHA-256/CRC-32 integrity, and the new summary fields

No changeset: these are internal benchmark scripts and templates.