### PR TITLE
fix(benchmark): retain failed invocation evidence

### DIFF
--- a/scripts/file-share/README.md
+++ b/scripts/file-share/README.md
@@ -1,0 +1,25 @@
+# File-share benchmark evidence
+
+Run a single checkout with `pnpm bench:file-share:local` or compare pinned
+Peerbit revisions with `pnpm bench:file-share:matrix`.
+
+Result schema v3 defines `errorCount` as every uncaught browser `pageerror`,
+every browser `console.error`, every console message at any level that contains
+a declared Peerbit failure signature, and scenario-recorded operation failures.
+Each result embeds the exact `errorCollectionDefinition` and signature list.
+Playwright `requestfailed` events are retained separately under
+`requestFailures`; they are diagnostics and are not automatically fatal because
+peer-to-peer discovery can legitimately exercise failed network candidates.
+
+The standalone runner continues counterbalanced repetitions after an individual
+Playwright or result-validation failure when setup remains usable. Once
+invocation execution begins, it writes a summary with planned, completed,
+passed, and failed counts, then exits nonzero if any repetition failed. A
+preflight, dependency-installation, or build failure can still stop before that
+summary exists. If browser evidence is missing or malformed, the synthetic
+failure uses `errorCount: null` and
+`errorCollectionComplete: false` instead of claiming that zero errors occurred.
+
+The matrix runner also reads nonzero sub-run summaries, keeps their failure
+evidence in the matrix summary, continues later invocations, and exits nonzero
+after writing the aggregate matrix summary when any invocation failed.

--- a/scripts/file-share/benchmark-orchestration.mjs
+++ b/scripts/file-share/benchmark-orchestration.mjs
@@ -1,0 +1,386 @@
+import fsp from "node:fs/promises";
+
+export const BENCHMARK_RESULT_SCHEMA = Object.freeze({
+	id: "peerbit-file-share-benchmark",
+	version: 3,
+});
+
+export const BENCHMARK_SUMMARY_SCHEMA = Object.freeze({
+	id: "peerbit-file-share-benchmark-summary",
+	version: 3,
+});
+
+export const MATRIX_SUMMARY_SCHEMA = Object.freeze({
+	id: "peerbit-file-share-matrix-summary",
+	version: 3,
+});
+
+export const KNOWN_PEERBIT_FAILURE_SIGNATURES = Object.freeze([
+	"Failed to resolve block",
+	"DeliveryError",
+	"Failed to get message",
+	"delivery acknowledges",
+	"Failed to bootstrap",
+	"failed to open",
+	"BorshError",
+	"Failed to create space",
+]);
+
+export const ERROR_COLLECTION_DEFINITION =
+	"from collector attachment through result snapshot: every uncaught pageerror; every console.error; every console message at any level containing a known Peerbit failure signature; plus scenario-recorded operation failures";
+
+export const REQUEST_FAILURE_COLLECTION_DEFINITION =
+	"from collector attachment through result snapshot: every Playwright requestfailed event, retained as non-fatal diagnostics and excluded from errorCount";
+
+const isRecord = (value) =>
+	value != null && typeof value === "object" && !Array.isArray(value);
+
+export const serializeError = (error) => {
+	if (error instanceof Error) {
+		return {
+			name: error.name,
+			message: error.message,
+			...(typeof error.stack === "string" ? { stack: error.stack } : {}),
+		};
+	}
+	return {
+		name: "Error",
+		message: String(error),
+	};
+};
+
+export const readJsonEvidence = async (
+	filePath,
+	{ readFile = fsp.readFile } = {},
+) => {
+	let contents;
+	try {
+		contents = await readFile(filePath, "utf8");
+	} catch (error) {
+		return {
+			kind: "missing",
+			filePath,
+			failure: serializeError(error),
+		};
+	}
+	try {
+		const value = JSON.parse(contents);
+		if (!isRecord(value)) {
+			throw new Error("JSON evidence must contain an object");
+		}
+		return { kind: "parsed", filePath, value };
+	} catch (error) {
+		return {
+			kind: "malformed",
+			filePath,
+			failure: serializeError(error),
+		};
+	}
+};
+
+export const processOutcomeFailure = (outcome) => {
+	if (outcome == null) {
+		return null;
+	}
+	const { exitCode, signal, spawnError } = outcome;
+	if (spawnError) {
+		return {
+			kind: "spawn-error",
+			message: `Could not start benchmark process: ${spawnError.message}`,
+		};
+	}
+	if (signal) {
+		return {
+			kind: "signal",
+			message: `Benchmark process terminated by signal ${signal}`,
+		};
+	}
+	if (!Number.isInteger(exitCode) || exitCode !== 0) {
+		return {
+			kind: "nonzero-exit",
+			message: `Benchmark process exited unsuccessfully (exitCode=${String(exitCode)})`,
+		};
+	}
+	return null;
+};
+
+const hasCompleteErrorCollection = (result) =>
+	isRecord(result) &&
+	result.errorCollectionComplete === true &&
+	result.errorCollectionDefinition === ERROR_COLLECTION_DEFINITION &&
+	Array.isArray(result.knownPeerbitFailureSignatures) &&
+	JSON.stringify(result.knownPeerbitFailureSignatures) ===
+		JSON.stringify(KNOWN_PEERBIT_FAILURE_SIGNATURES) &&
+	Number.isSafeInteger(result.errorCount) &&
+	result.errorCount >= 0 &&
+	Array.isArray(result.errors) &&
+	result.errorCount === result.errors.length &&
+	result.errors.every((entry) => typeof entry === "string" && entry.length > 0);
+
+const hasCompleteRequestFailureCollection = (result) =>
+	isRecord(result) &&
+	result.requestFailureCollectionComplete === true &&
+	result.requestFailureCollectionDefinition ===
+		REQUEST_FAILURE_COLLECTION_DEFINITION &&
+	Number.isSafeInteger(result.requestFailureCount) &&
+	result.requestFailureCount >= 0 &&
+	Array.isArray(result.requestFailures) &&
+	result.requestFailureCount === result.requestFailures.length &&
+	result.requestFailures.every(
+		(entry) => typeof entry === "string" && entry.length > 0,
+	);
+
+export const extractCollectedErrorEvidence = (result) => {
+	const errorCollectionComplete = hasCompleteErrorCollection(result);
+	const requestFailureCollectionComplete =
+		hasCompleteRequestFailureCollection(result);
+	return {
+		errorCollectionComplete,
+		errorCount: errorCollectionComplete ? result.errorCount : null,
+		errors: errorCollectionComplete ? result.errors : null,
+		requestFailureCollectionComplete,
+		requestFailureCount: requestFailureCollectionComplete
+			? result.requestFailureCount
+			: null,
+		requestFailures: requestFailureCollectionComplete
+			? result.requestFailures
+			: null,
+	};
+};
+
+export const createInvocationFailureEvidence = ({
+	scenario,
+	mode,
+	network,
+	fileMb,
+	runNonce,
+	invocation,
+	provenance,
+	resultFile,
+	processOutcome,
+	resultEvidence,
+	failure,
+}) => {
+	const browserResult =
+		resultEvidence?.kind === "parsed" ? resultEvidence.value : null;
+	const collectedErrorEvidence = extractCollectedErrorEvidence(browserResult);
+	const processFailure = processOutcomeFailure(processOutcome);
+	const evidenceFailure =
+		resultEvidence?.kind === "missing"
+			? {
+					kind: "missing-result",
+					message: `Benchmark run did not produce ${resultFile}`,
+				}
+			: resultEvidence?.kind === "malformed"
+				? {
+						kind: "malformed-result",
+						message: `Benchmark run produced malformed JSON in ${resultFile}`,
+					}
+				: null;
+	const primaryFailure =
+		processFailure ??
+		evidenceFailure ??
+		(failure == null
+			? {
+					kind: "invalid-result",
+					message: "Benchmark result did not satisfy the validity contract",
+				}
+			: {
+					kind: "result-validation",
+					...serializeError(failure),
+				});
+	return {
+		schema: BENCHMARK_RESULT_SCHEMA,
+		runNonce,
+		invocation,
+		provenance,
+		status: "failed",
+		scenario,
+		mode,
+		networkMode: network,
+		fileSizeMb: fileMb,
+		stage: "runner-evidence",
+		browserStatus: browserResult?.status ?? null,
+		browserStage: browserResult?.stage ?? null,
+		browserFailure: browserResult?.failure ?? null,
+		errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
+		knownPeerbitFailureSignatures: KNOWN_PEERBIT_FAILURE_SIGNATURES,
+		errorCollectionComplete: collectedErrorEvidence.errorCollectionComplete,
+		errorCount: collectedErrorEvidence.errorCount,
+		errors: collectedErrorEvidence.errors,
+		requestFailureCollectionDefinition: REQUEST_FAILURE_COLLECTION_DEFINITION,
+		requestFailureCollectionComplete:
+			collectedErrorEvidence.requestFailureCollectionComplete,
+		requestFailureCount: collectedErrorEvidence.requestFailureCount,
+		requestFailures: collectedErrorEvidence.requestFailures,
+		resultFile,
+		playwrightExitCode: processOutcome?.exitCode ?? null,
+		playwrightSignal: processOutcome?.signal ?? null,
+		playwrightSpawnError: processOutcome?.spawnError
+			? serializeError(processOutcome.spawnError)
+			: null,
+		failure: primaryFailure,
+		runnerFailure: failure == null ? null : serializeError(failure),
+		resultEvidence:
+			resultEvidence?.kind === "parsed" ? { kind: "parsed" } : resultEvidence,
+		browserResult,
+	};
+};
+
+export const executePlanContinuing = async ({
+	plan,
+	execute,
+	shouldStop = () => false,
+}) => {
+	const outcomes = [];
+	for (const entry of plan) {
+		try {
+			outcomes.push({
+				entry,
+				status: "fulfilled",
+				value: await execute(entry),
+			});
+		} catch (error) {
+			outcomes.push({
+				entry,
+				status: "rejected",
+				error,
+				failure: serializeError(error),
+			});
+			if (shouldStop(error, entry)) {
+				break;
+			}
+		}
+	}
+	return outcomes;
+};
+
+export const countBenchmarkOutcomes = (results, planned = results.length) => {
+	const passed = results.filter((result) => result.status === "passed").length;
+	const failed = results.length - passed;
+	return {
+		planned,
+		completed: results.length,
+		passed,
+		failed,
+	};
+};
+
+export const classifySubprocessSummary = ({
+	processOutcome,
+	summaryEvidence,
+	expectedSchema = BENCHMARK_SUMMARY_SCHEMA,
+}) => {
+	const failures = [];
+	const processFailure = processOutcomeFailure(processOutcome);
+	if (processFailure) {
+		failures.push(processFailure);
+	}
+	let summary = null;
+	if (summaryEvidence.kind !== "parsed") {
+		failures.push({
+			kind: `${summaryEvidence.kind}-summary`,
+			message:
+				summaryEvidence.kind === "missing"
+					? `Benchmark subprocess did not write ${summaryEvidence.filePath}`
+					: `Benchmark subprocess wrote malformed JSON in ${summaryEvidence.filePath}`,
+		});
+	} else {
+		summary = summaryEvidence.value;
+		if (
+			summary.schema?.id !== expectedSchema.id ||
+			summary.schema?.version !== expectedSchema.version
+		) {
+			failures.push({
+				kind: "unsupported-summary",
+				message: "Benchmark subprocess summary has an unsupported schema",
+			});
+		}
+		if (!Array.isArray(summary.results)) {
+			failures.push({
+				kind: "invalid-summary",
+				message: "Benchmark subprocess summary is missing its results array",
+			});
+		}
+		if (
+			summary.errorCollectionDefinition !== ERROR_COLLECTION_DEFINITION ||
+			JSON.stringify(summary.knownPeerbitFailureSignatures) !==
+				JSON.stringify(KNOWN_PEERBIT_FAILURE_SIGNATURES) ||
+			summary.requestFailureCollectionDefinition !==
+				REQUEST_FAILURE_COLLECTION_DEFINITION
+		) {
+			failures.push({
+				kind: "invalid-summary-error-contract",
+				message:
+					"Benchmark subprocess summary has an invalid error evidence contract",
+			});
+		}
+	}
+	return {
+		ok: failures.length === 0,
+		processSucceeded: processFailure == null,
+		summary,
+		failures,
+	};
+};
+
+export const inspectSingleInvocationSummary = (summary) => {
+	if (!isRecord(summary)) {
+		return {
+			result: null,
+			resultEvidence: null,
+			failures: [
+				{
+					kind: "invalid-summary",
+					message: "Benchmark subprocess summary is not an object",
+				},
+			],
+		};
+	}
+	const results = Array.isArray(summary.results) ? summary.results : [];
+	const [resultEvidence] = results;
+	if (results.length !== 1 || !isRecord(resultEvidence)) {
+		return {
+			result: null,
+			resultEvidence: resultEvidence ?? null,
+			failures: [
+				{
+					kind: "result-cardinality",
+					message:
+						"Benchmark subprocess summary did not contain exactly one object result",
+				},
+			],
+		};
+	}
+	const failures = [];
+	if (!["passed", "failed"].includes(resultEvidence.status)) {
+		failures.push({
+			kind: "invalid-result-status",
+			message: "Benchmark subprocess result has an unsupported status",
+		});
+	}
+	if (summary.status !== resultEvidence.status) {
+		failures.push({
+			kind: "summary-status",
+			message:
+				"Benchmark subprocess summary status contradicts its result status",
+		});
+	}
+	const expectedPassed = resultEvidence.status === "passed" ? 1 : 0;
+	const expectedFailed = resultEvidence.status === "passed" ? 0 : 1;
+	const counts = summary.outcomeCounts;
+	if (
+		!isRecord(counts) ||
+		counts.planned !== 1 ||
+		counts.completed !== 1 ||
+		counts.passed !== expectedPassed ||
+		counts.failed !== expectedFailed
+	) {
+		failures.push({
+			kind: "summary-outcome-counts",
+			message:
+				"Benchmark subprocess summary outcome counts contradict its result",
+		});
+	}
+	return { result: resultEvidence, resultEvidence, failures };
+};

--- a/scripts/file-share/benchmark-orchestration.test.mjs
+++ b/scripts/file-share/benchmark-orchestration.test.mjs
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+	BENCHMARK_RESULT_SCHEMA,
+	BENCHMARK_SUMMARY_SCHEMA,
+	classifySubprocessSummary,
+	countBenchmarkOutcomes,
+	createInvocationFailureEvidence,
+	ERROR_COLLECTION_DEFINITION,
+	executePlanContinuing,
+	extractCollectedErrorEvidence,
+	inspectSingleInvocationSummary,
+	KNOWN_PEERBIT_FAILURE_SIGNATURES,
+	readJsonEvidence,
+	REQUEST_FAILURE_COLLECTION_DEFINITION,
+} from "./benchmark-orchestration.mjs";
+
+test("reads parsed, missing, and malformed JSON evidence without throwing", async () => {
+	const root = await mkdtemp(path.join(os.tmpdir(), "peerbit-evidence-test-"));
+	try {
+		const parsedFile = path.join(root, "parsed.json");
+		const malformedFile = path.join(root, "malformed.json");
+		await writeFile(parsedFile, '{"status":"failed"}\n');
+		await writeFile(malformedFile, "{\n");
+		assert.deepEqual(await readJsonEvidence(parsedFile), {
+			kind: "parsed",
+			filePath: parsedFile,
+			value: { status: "failed" },
+		});
+		assert.equal((await readJsonEvidence(malformedFile)).kind, "malformed");
+		assert.equal(
+			(await readJsonEvidence(path.join(root, "missing.json"))).kind,
+			"missing",
+		);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("continues a counterbalanced plan after an invocation rejects", async () => {
+	const visited = [];
+	const outcomes = await executePlanContinuing({
+		plan: [1, 2, 3],
+		execute: async (entry) => {
+			visited.push(entry);
+			if (entry === 2) {
+				throw new Error("synthetic failure");
+			}
+			return { status: "passed", entry };
+		},
+	});
+	assert.deepEqual(visited, [1, 2, 3]);
+	assert.deepEqual(
+		outcomes.map((outcome) => outcome.status),
+		["fulfilled", "rejected", "fulfilled"],
+	);
+	assert.match(outcomes[1].failure.message, /synthetic failure/);
+});
+
+test("stops a plan after an explicitly unsafe failure", async () => {
+	const visited = [];
+	const outcomes = await executePlanContinuing({
+		plan: [1, 2, 3],
+		shouldStop: (error) => error.stop === true,
+		execute: async (entry) => {
+			visited.push(entry);
+			if (entry === 2) {
+				const error = new Error("provenance drift");
+				error.stop = true;
+				throw error;
+			}
+			return { status: "passed" };
+		},
+	});
+	assert.deepEqual(visited, [1, 2]);
+	assert.equal(outcomes.length, 2);
+	assert.equal(outcomes.at(-1).status, "rejected");
+});
+
+test("constructs honest failure evidence from a failed browser result", () => {
+	const browserResult = {
+		errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
+		knownPeerbitFailureSignatures: KNOWN_PEERBIT_FAILURE_SIGNATURES,
+		errorCollectionComplete: true,
+		errorCount: 1,
+		errors: ["writer:pageerror:boom"],
+		requestFailureCollectionDefinition: REQUEST_FAILURE_COLLECTION_DEFINITION,
+		requestFailureCollectionComplete: true,
+		requestFailureCount: 1,
+		requestFailures: ["writer:requestfailed:{}"],
+	};
+	const result = createInvocationFailureEvidence({
+		scenario: "upload",
+		mode: "adaptive",
+		network: "local",
+		fileMb: 5,
+		runNonce: "nonce",
+		invocation: { mode: "adaptive" },
+		provenance: { peerbit: { resolvedCommit: "a" } },
+		resultFile: "/tmp/result.json",
+		processOutcome: {
+			exitCode: 1,
+			signal: null,
+			spawnError: undefined,
+		},
+		resultEvidence: { kind: "parsed", value: browserResult },
+		failure: new Error("Playwright failed"),
+	});
+	assert.deepEqual(result.schema, BENCHMARK_RESULT_SCHEMA);
+	assert.equal(result.status, "failed");
+	assert.equal(result.errorCollectionComplete, true);
+	assert.equal(result.errorCount, 1);
+	assert.equal(result.requestFailureCount, 1);
+	assert.equal(result.browserResult, browserResult);
+	assert.equal(result.failure.kind, "nonzero-exit");
+});
+
+test("rejects malformed error entries instead of treating collection as complete", () => {
+	const evidence = extractCollectedErrorEvidence({
+		errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
+		knownPeerbitFailureSignatures: KNOWN_PEERBIT_FAILURE_SIGNATURES,
+		errorCollectionComplete: true,
+		errorCount: 1,
+		errors: [null],
+		requestFailureCollectionDefinition: REQUEST_FAILURE_COLLECTION_DEFINITION,
+		requestFailureCollectionComplete: true,
+		requestFailureCount: 1,
+		requestFailures: [null],
+	});
+	assert.equal(evidence.errorCollectionComplete, false);
+	assert.equal(evidence.errorCount, null);
+	assert.equal(evidence.requestFailureCollectionComplete, false);
+	assert.equal(evidence.requestFailureCount, null);
+});
+
+test("uses null rather than claiming zero errors when result evidence is absent", () => {
+	const result = createInvocationFailureEvidence({
+		scenario: "upload",
+		mode: "adaptive",
+		network: "local",
+		fileMb: 5,
+		runNonce: "nonce",
+		invocation: {},
+		provenance: {},
+		resultFile: "/tmp/missing.json",
+		processOutcome: null,
+		resultEvidence: {
+			kind: "missing",
+			filePath: "/tmp/missing.json",
+			failure: { message: "ENOENT" },
+		},
+		failure: new Error("missing"),
+	});
+	assert.equal(result.errorCollectionComplete, false);
+	assert.equal(result.errorCount, null);
+	assert.equal(result.errors, null);
+	assert.equal(result.failure.kind, "missing-result");
+});
+
+test("preserves a parsed sub-run summary while classifying nonzero exit", () => {
+	const summary = {
+		schema: BENCHMARK_SUMMARY_SCHEMA,
+		status: "failed",
+		errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
+		knownPeerbitFailureSignatures: KNOWN_PEERBIT_FAILURE_SIGNATURES,
+		requestFailureCollectionDefinition: REQUEST_FAILURE_COLLECTION_DEFINITION,
+		results: [{ status: "failed" }],
+	};
+	const classification = classifySubprocessSummary({
+		processOutcome: { exitCode: 1, signal: null, spawnError: undefined },
+		summaryEvidence: {
+			kind: "parsed",
+			filePath: "/tmp/summary.json",
+			value: summary,
+		},
+	});
+	assert.equal(classification.ok, false);
+	assert.equal(classification.processSucceeded, false);
+	assert.equal(classification.summary, summary);
+	assert.deepEqual(
+		classification.failures.map((failure) => failure.kind),
+		["nonzero-exit"],
+	);
+});
+
+test("inspects one sub-run result and rejects contradictory aggregate claims", () => {
+	const passed = { status: "passed" };
+	assert.deepEqual(
+		inspectSingleInvocationSummary({
+			status: "passed",
+			outcomeCounts: { planned: 1, completed: 1, passed: 1, failed: 0 },
+			results: [passed],
+		}),
+		{ result: passed, resultEvidence: passed, failures: [] },
+	);
+	assert.deepEqual(
+		inspectSingleInvocationSummary({
+			status: "passed",
+			outcomeCounts: { planned: 1, completed: 1, passed: 1, failed: 0 },
+			results: { status: "passed" },
+		}).failures.map((failure) => failure.kind),
+		["result-cardinality"],
+	);
+	assert.deepEqual(
+		inspectSingleInvocationSummary({
+			status: "failed",
+			outcomeCounts: { planned: 1, completed: 1, passed: 1, failed: 0 },
+			results: [passed],
+		}).failures.map((failure) => failure.kind),
+		["summary-status"],
+	);
+	assert.deepEqual(
+		inspectSingleInvocationSummary({
+			status: "unknown",
+			outcomeCounts: { planned: 1, completed: 1, passed: 0, failed: 1 },
+			results: [{ status: "unknown" }],
+		}).failures.map((failure) => failure.kind),
+		["invalid-result-status"],
+	);
+});
+
+test("counts failed and passed aggregate outcomes", () => {
+	assert.deepEqual(
+		countBenchmarkOutcomes([{ status: "passed" }, { status: "failed" }], 3),
+		{ planned: 3, completed: 2, passed: 1, failed: 1 },
+	);
+});

--- a/scripts/file-share/benchmark-validity.mjs
+++ b/scripts/file-share/benchmark-validity.mjs
@@ -1,5 +1,11 @@
 import fsp from "node:fs/promises";
 import { isDeepStrictEqual } from "node:util";
+import {
+	BENCHMARK_RESULT_SCHEMA,
+	ERROR_COLLECTION_DEFINITION,
+	KNOWN_PEERBIT_FAILURE_SIGNATURES,
+	REQUEST_FAILURE_COLLECTION_DEFINITION,
+} from "./benchmark-orchestration.mjs";
 
 const SHA256_BASE64_PATTERN = /^[A-Za-z0-9+/]{43}=$/;
 const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/;
@@ -396,7 +402,10 @@ const validateEnvelope = (
 	{ expectedRunNonce, expectedProvenance, expectedNetwork, expectedInvocation },
 ) => {
 	const schema = requireRecord(result.schema, "schema");
-	if (schema.id !== "peerbit-file-share-benchmark" || schema.version !== 2) {
+	if (
+		schema.id !== BENCHMARK_RESULT_SCHEMA.id ||
+		schema.version !== BENCHMARK_RESULT_SCHEMA.version
+	) {
 		throw new Error("Benchmark result has an unsupported schema");
 	}
 	if (
@@ -458,12 +467,85 @@ const validateRequestedUploadKnobs = (result, invocation) => {
 	}
 };
 
-const validateZeroErrors = (result, label) => {
+const validateCollectedStringEvidence = ({
+	result,
+	completeKey,
+	countKey,
+	itemsKey,
+	label,
+	inconsistentLabel = label,
+	allowIncomplete,
+}) => {
+	if (result[completeKey] === false && allowIncomplete) {
+		if (result[countKey] !== null || result[itemsKey] !== null) {
+			throw new Error(
+				`Incomplete ${label} must use null count and evidence fields`,
+			);
+		}
+		return;
+	}
+	if (result[completeKey] !== true) {
+		throw new Error(`Benchmark result has an incomplete ${label}`);
+	}
+	const count = requireNonNegativeSafeInteger(result[countKey], countKey);
 	if (
-		result.errorCount !== 0 ||
-		!Array.isArray(result.errors) ||
-		result.errors.length !== 0
+		!Array.isArray(result[itemsKey]) ||
+		result[itemsKey].length !== count ||
+		result[itemsKey].some(
+			(entry) => typeof entry !== "string" || entry.length === 0,
+		)
 	) {
+		throw new Error(`Benchmark result has inconsistent ${inconsistentLabel}`);
+	}
+};
+
+const validateErrorCollection = (result, { allowIncomplete = false } = {}) => {
+	if (result.errorCollectionDefinition !== ERROR_COLLECTION_DEFINITION) {
+		throw new Error(
+			"Benchmark result has an invalid error collection definition",
+		);
+	}
+	if (
+		!isDeepStrictEqual(
+			result.knownPeerbitFailureSignatures,
+			KNOWN_PEERBIT_FAILURE_SIGNATURES,
+		)
+	) {
+		throw new Error(
+			"Benchmark result has invalid known Peerbit failure signatures",
+		);
+	}
+	validateCollectedStringEvidence({
+		result,
+		completeKey: "errorCollectionComplete",
+		countKey: "errorCount",
+		itemsKey: "errors",
+		label: "error collection",
+		inconsistentLabel: "recorded errors",
+		allowIncomplete,
+	});
+	if (
+		result.requestFailureCollectionDefinition !==
+		REQUEST_FAILURE_COLLECTION_DEFINITION
+	) {
+		throw new Error(
+			"Benchmark result has an invalid request-failure collection definition",
+		);
+	}
+	validateCollectedStringEvidence({
+		result,
+		completeKey: "requestFailureCollectionComplete",
+		countKey: "requestFailureCount",
+		itemsKey: "requestFailures",
+		label: "request-failure collection",
+		inconsistentLabel: "request-failure diagnostics",
+		allowIncomplete,
+	});
+};
+
+const validateZeroErrors = (result, label) => {
+	validateErrorCollection(result);
+	if (result.errorCount !== 0 || result.errors.length !== 0) {
 		throw new Error(`Passed ${label} contains recorded errors`);
 	}
 };
@@ -721,14 +803,12 @@ const validateSeederProbe = (result, invocation) => {
 	}
 };
 
-export const validateBenchmarkResult = (
+export const validateBenchmarkResultEnvelope = (
 	result,
 	{
-		scenario,
 		expectedMode,
 		expectedFileMb,
 		expectedNetwork,
-		expectedFixtureSeed,
 		expectedRunNonce,
 		expectedProvenance,
 		expectedInvocation,
@@ -743,6 +823,49 @@ export const validateBenchmarkResult = (
 		expectedNetwork,
 		expectedInvocation,
 	});
+	if (!["passed", "failed"].includes(result.status)) {
+		throw new Error("Benchmark result has an unsupported status");
+	}
+	if (result.mode !== expectedMode) {
+		throw new Error(
+			`Benchmark result mode mismatch (expected ${expectedMode}, got ${String(result.mode)})`,
+		);
+	}
+	if (
+		expectedInvocation.scenario === "upload" &&
+		result.fileSizeMb !== expectedFileMb
+	) {
+		throw new Error(
+			`Benchmark result size mismatch (expected ${expectedFileMb} MiB, got ${String(result.fileSizeMb)})`,
+		);
+	}
+	validateErrorCollection(result, {
+		allowIncomplete: result.status === "failed",
+	});
+	return result;
+};
+
+export const validateBenchmarkResult = (
+	result,
+	{
+		scenario,
+		expectedMode,
+		expectedFileMb,
+		expectedNetwork,
+		expectedFixtureSeed,
+		expectedRunNonce,
+		expectedProvenance,
+		expectedInvocation,
+	},
+) => {
+	validateBenchmarkResultEnvelope(result, {
+		expectedMode,
+		expectedFileMb,
+		expectedNetwork,
+		expectedRunNonce,
+		expectedProvenance,
+		expectedInvocation,
+	});
 	if (result.status !== "passed") {
 		const detail =
 			typeof result.failure?.message === "string"
@@ -750,17 +873,7 @@ export const validateBenchmarkResult = (
 				: "";
 		throw new Error(`Benchmark result status is not passed${detail}`);
 	}
-	if (result.mode !== expectedMode) {
-		throw new Error(
-			`Benchmark result mode mismatch (expected ${expectedMode}, got ${String(result.mode)})`,
-		);
-	}
 	if (scenario === "upload") {
-		if (result.fileSizeMb !== expectedFileMb) {
-			throw new Error(
-				`Benchmark result size mismatch (expected ${expectedFileMb} MiB, got ${String(result.fileSizeMb)})`,
-			);
-		}
 		validateUploadIntegrity(result, expectedFileMb, expectedFixtureSeed);
 		validateUploadTimings(result, expectedInvocation);
 		validateRequestedUploadKnobs(result, expectedInvocation);

--- a/scripts/file-share/benchmark-validity.test.mjs
+++ b/scripts/file-share/benchmark-validity.test.mjs
@@ -5,10 +5,17 @@ import path from "node:path";
 import test from "node:test";
 import { createBenchmarkInvocation } from "./benchmark-invocation.mjs";
 import {
+	BENCHMARK_RESULT_SCHEMA,
+	ERROR_COLLECTION_DEFINITION,
+	KNOWN_PEERBIT_FAILURE_SIGNATURES,
+	REQUEST_FAILURE_COLLECTION_DEFINITION,
+} from "./benchmark-orchestration.mjs";
+import {
 	assertPlaywrightSucceeded,
 	loadAndValidateBenchmarkResult,
 	parseBenchmarkResult,
 	validateBenchmarkResult,
+	validateBenchmarkResultEnvelope,
 } from "./benchmark-validity.mjs";
 
 const RUN_NONCE = "123e4567-e89b-42d3-a456-426614174000";
@@ -76,7 +83,7 @@ const options = {
 };
 
 const validResult = () => ({
-	schema: { id: "peerbit-file-share-benchmark", version: 2 },
+	schema: { ...BENCHMARK_RESULT_SCHEMA },
 	runNonce: RUN_NONCE,
 	invocation: structuredClone(INVOCATION),
 	provenance: structuredClone(PROVENANCE),
@@ -150,8 +157,15 @@ const validResult = () => ({
 	baselineWriterSeeders: 2,
 	baselineReaderSeeders: 2,
 	droppedSeeders: false,
+	errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
+	knownPeerbitFailureSignatures: [...KNOWN_PEERBIT_FAILURE_SIGNATURES],
+	errorCollectionComplete: true,
 	errorCount: 0,
 	errors: [],
+	requestFailureCollectionDefinition: REQUEST_FAILURE_COLLECTION_DEFINITION,
+	requestFailureCollectionComplete: true,
+	requestFailureCount: 0,
+	requestFailures: [],
 	snapshots: [
 		{
 			label: "seeders-ready",
@@ -173,6 +187,48 @@ test("accepts a complete deterministic transfer result", () => {
 		validateBenchmarkResult(validResult(), options).status,
 		"passed",
 	);
+});
+
+test("rejects a status-only passed payload at the v3 evidence envelope", () => {
+	assert.throws(
+		() => validateBenchmarkResultEnvelope({ status: "passed" }, options),
+		/missing schema/,
+	);
+});
+
+test("requires explicit error evidence on failed v3 envelopes", () => {
+	const completeFailure = validResult();
+	completeFailure.status = "failed";
+	completeFailure.failure = { message: "synthetic browser failure" };
+	assert.equal(
+		validateBenchmarkResultEnvelope(completeFailure, options).status,
+		"failed",
+	);
+
+	const incompleteFailure = structuredClone(completeFailure);
+	incompleteFailure.errorCollectionComplete = false;
+	incompleteFailure.errorCount = null;
+	incompleteFailure.errors = null;
+	incompleteFailure.requestFailureCollectionComplete = false;
+	incompleteFailure.requestFailureCount = null;
+	incompleteFailure.requestFailures = null;
+	assert.equal(
+		validateBenchmarkResultEnvelope(incompleteFailure, options).status,
+		"failed",
+	);
+
+	delete incompleteFailure.errorCollectionComplete;
+	assert.throws(
+		() => validateBenchmarkResultEnvelope(incompleteFailure, options),
+		/incomplete error collection/,
+	);
+});
+
+test("retains request failures as non-fatal diagnostics", () => {
+	const result = validResult();
+	result.requestFailures.push("writer:requestfailed:{}");
+	result.requestFailureCount = result.requestFailures.length;
+	assert.equal(validateBenchmarkResult(result, options).status, "passed");
 });
 
 test("rejects failed, malformed, and stale Playwright outcomes", async () => {
@@ -390,6 +446,55 @@ for (const [name, mutate, pattern] of [
 		/recorded errors/,
 	],
 	[
+		"error collection definition",
+		(result) => {
+			result.errorCollectionDefinition = "selected errors only";
+		},
+		/invalid error collection definition/,
+	],
+	[
+		"error collection completeness",
+		(result) => {
+			result.errorCollectionComplete = false;
+		},
+		/incomplete error collection/,
+	],
+	[
+		"known Peerbit signatures",
+		(result) => {
+			result.knownPeerbitFailureSignatures.pop();
+		},
+		/invalid known Peerbit failure signatures/,
+	],
+	[
+		"error count arithmetic",
+		(result) => {
+			result.errorCount = 1;
+		},
+		/inconsistent recorded errors/,
+	],
+	[
+		"request-failure definition",
+		(result) => {
+			result.requestFailureCollectionDefinition = "fatal network failures";
+		},
+		/invalid request-failure collection definition/,
+	],
+	[
+		"request-failure completeness",
+		(result) => {
+			result.requestFailureCollectionComplete = false;
+		},
+		/incomplete request-failure collection/,
+	],
+	[
+		"request-failure count arithmetic",
+		(result) => {
+			result.requestFailureCount = 1;
+		},
+		/inconsistent request-failure diagnostics/,
+	],
+	[
 		"non-numeric seeder sample",
 		(result) => {
 			result.snapshots[0].writerSeeders = "error:failed";
@@ -503,7 +608,7 @@ const createSeederProbeFixture = () => {
 		targetSeeders: 2,
 	});
 	const seederResult = {
-		schema: { id: "peerbit-file-share-benchmark", version: 2 },
+		schema: { ...BENCHMARK_RESULT_SCHEMA },
 		runNonce: RUN_NONCE,
 		invocation,
 		provenance: structuredClone(PROVENANCE),
@@ -523,8 +628,15 @@ const createSeederProbeFixture = () => {
 		reachedTarget: true,
 		timeToTargetMs: 2,
 		targetSampleLabel: "sample-1",
+		errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
+		knownPeerbitFailureSignatures: [...KNOWN_PEERBIT_FAILURE_SIGNATURES],
+		errorCollectionComplete: true,
 		errorCount: 0,
 		errors: [],
+		requestFailureCollectionDefinition: REQUEST_FAILURE_COLLECTION_DEFINITION,
+		requestFailureCollectionComplete: true,
+		requestFailureCount: 0,
+		requestFailures: [],
 		samples: [
 			{
 				index: 1,

--- a/scripts/file-share/run-file-share-benchmark-matrix.mjs
+++ b/scripts/file-share/run-file-share-benchmark-matrix.mjs
@@ -4,11 +4,27 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import {
 	assertBenchmarkFileSize,
 	assertCoreBenchmarkUsesLocalApp,
+	createBenchmarkInvocation,
 	resolveBenchmarkPreviewOptions,
 } from "./benchmark-invocation.mjs";
+import {
+	BENCHMARK_RESULT_SCHEMA,
+	BENCHMARK_SUMMARY_SCHEMA,
+	classifySubprocessSummary,
+	countBenchmarkOutcomes,
+	ERROR_COLLECTION_DEFINITION,
+	extractCollectedErrorEvidence,
+	inspectSingleInvocationSummary,
+	KNOWN_PEERBIT_FAILURE_SIGNATURES,
+	MATRIX_SUMMARY_SCHEMA,
+	readJsonEvidence,
+	REQUEST_FAILURE_COLLECTION_DEFINITION,
+	serializeError,
+} from "./benchmark-orchestration.mjs";
 import {
 	getExamplesProvenance,
 	getPeerbitProvenance,
@@ -18,6 +34,10 @@ import {
 	compareUploadPerformanceModes,
 	summarizeUploadPerformance,
 } from "./benchmark-summary.mjs";
+import {
+	validateBenchmarkResult,
+	validateBenchmarkResultEnvelope,
+} from "./benchmark-validity.mjs";
 import {
 	collectLocalPeerbitPackages,
 	defaultExamplesSource,
@@ -42,6 +62,9 @@ const RUNNER_PATH = path.join(
 	"file-share",
 	"run-file-share-benchmark.mjs",
 );
+const DEFAULT_FIXTURE_SEED = "peerbit-file-share-benchmark-v1";
+
+const optionalNumber = (value) => (value == null ? undefined : Number(value));
 
 const runGit = (args, { cwd = repoRoot, capture = false } = {}) => {
 	console.log(`$ git ${args.join(" ")}`);
@@ -150,6 +173,14 @@ const summarizeUploadMatrix = (variantSummaries) => {
 			fixed1ReaderReadyMsMedian: fixed1?.timeToReaderReadyMsMedian ?? null,
 			adaptiveStatus: adaptive?.failed === 0 ? "passed" : "failed",
 			fixed1Status: fixed1?.failed === 0 ? "passed" : "failed",
+			adaptiveErrorCount: adaptive?.errorCount ?? null,
+			fixed1ErrorCount: fixed1?.errorCount ?? null,
+			adaptiveIncompleteErrorCollections:
+				adaptive?.incompleteErrorCollections ?? null,
+			fixed1IncompleteErrorCollections:
+				fixed1?.incompleteErrorCollections ?? null,
+			adaptiveRequestFailureCount: adaptive?.requestFailureCount ?? null,
+			fixed1RequestFailureCount: fixed1?.requestFailureCount ?? null,
 		};
 	});
 };
@@ -166,6 +197,8 @@ const summarizeSeederProbeMatrix = (variantSummaries) => {
 			writerSeedersMaxAvg: adaptive?.writerSeedersMaxAvg ?? null,
 			readerSeedersMaxAvg: adaptive?.readerSeedersMaxAvg ?? null,
 			errorCount: adaptive?.errorCount ?? null,
+			incompleteErrorCollections: adaptive?.incompleteErrorCollections ?? null,
+			requestFailureCount: adaptive?.requestFailureCount ?? null,
 		};
 	});
 };
@@ -230,6 +263,13 @@ const summarizeInvocationResults = (results, scenario) => {
 			failed: items.filter((item) => item.status !== "passed").length,
 			errorCount: items.reduce(
 				(total, item) => total + (Number(item.errorCount) || 0),
+				0,
+			),
+			incompleteErrorCollections: items.filter(
+				(item) => item.errorCollectionComplete !== true,
+			).length,
+			requestFailureCount: items.reduce(
+				(total, item) => total + (Number(item.requestFailureCount) || 0),
 				0,
 			),
 		};
@@ -299,7 +339,7 @@ const prepareVariant = async ({ variantSpec, variantRoot }) => {
 		commit: materialization.cloneCommit,
 	});
 	await ensureDependenciesInstalled(materialization.peerbitRoot);
-	await getPeerbitProvenance({
+	const peerbitProvenance = await getPeerbitProvenance({
 		root: materialization.peerbitRoot,
 		requestedRef: materialization.requestedRef,
 		requireClean: true,
@@ -308,6 +348,7 @@ const prepareVariant = async ({ variantSpec, variantRoot }) => {
 	return {
 		peerbitRoot: materialization.peerbitRoot,
 		resolvedCommit: materialization.cloneCommit,
+		peerbitProvenance,
 	};
 };
 
@@ -348,85 +389,149 @@ const runVariantBenchmark = async ({
 	examplesRef,
 }) => {
 	await fsp.rm(summaryFile, { force: true });
-	run(
-		"node",
-		[
-			RUNNER_PATH,
-			"--scenario",
-			scenario,
-			"--integration-mode",
-			integrationMode,
-			"--peerbit-root",
-			peerbitRoot,
-			"--examples-root",
-			examplesRoot,
-			"--source",
-			examplesSource,
-			"--examples-ref",
-			examplesRef,
-			"--peerbit-ref-label",
-			variantRef,
-			"--expected-peerbit-commit",
-			resolvedCommit,
-			"--require-clean-peerbit",
-			"--expected-examples-commit",
-			pinnedExamplesProvenance.resolvedCommit,
-			"--expected-examples-lockfile-sha256",
-			pinnedExamplesProvenance.lockfileSha256,
-			...(localPackages ? ["--local-packages", localPackages] : []),
-			...(examplesTemplate ? ["--template", examplesTemplate] : []),
-			"--results-dir",
-			resultsDir,
-			"--summary-file",
-			summaryFile,
-			"--file-mb",
-			String(fileMb),
-			"--runs",
-			String(runs),
-			"--mode",
-			mode,
-			"--network",
-			network,
-			...(freshExamples ? ["--fresh"] : []),
-			...(freshExamplesEachRun ? ["--fresh-each-run"] : []),
-			...(installExamples ? ["--install"] : []),
-			...(uploadTimeoutMs != null
-				? ["--upload-timeout-ms", String(uploadTimeoutMs)]
-				: []),
-			...(downloadTimeoutMs != null
-				? ["--download-timeout-ms", String(downloadTimeoutMs)]
-				: []),
-			...(postUploadMonitorMs != null
-				? ["--post-upload-monitor-ms", String(postUploadMonitorMs)]
-				: []),
-			...(pollMs != null ? ["--poll-ms", String(pollMs)] : []),
-			...(minReadySeeders != null
-				? ["--min-ready-seeders", String(minReadySeeders)]
-				: []),
-			...(readyTimeoutMs != null
-				? ["--ready-timeout-ms", String(readyTimeoutMs)]
-				: []),
-			...(sampleMs != null ? ["--sample-ms", String(sampleMs)] : []),
-			...(sampleCount != null ? ["--sample-count", String(sampleCount)] : []),
-			...(targetSeeders != null
-				? ["--target-seeders", String(targetSeeders)]
-				: []),
-			...(protocol ? ["--protocol", protocol] : []),
-			...(fixtureSeed ? ["--fixture-seed", fixtureSeed] : []),
-			...(enableVisibilityProbe ? ["--enable-visibility-probe"] : []),
-			...(verbose ? ["--verbose"] : []),
-		],
-		{
-			cwd: repoRoot,
-			env: process.env,
-		},
-	);
-	const summary = JSON.parse(await fsp.readFile(summaryFile, "utf8"));
+	const runnerArgs = [
+		RUNNER_PATH,
+		"--scenario",
+		scenario,
+		"--integration-mode",
+		integrationMode,
+		"--peerbit-root",
+		peerbitRoot,
+		"--examples-root",
+		examplesRoot,
+		"--source",
+		examplesSource,
+		"--examples-ref",
+		examplesRef,
+		"--peerbit-ref-label",
+		variantRef,
+		"--expected-peerbit-commit",
+		resolvedCommit,
+		"--require-clean-peerbit",
+		"--expected-examples-commit",
+		pinnedExamplesProvenance.resolvedCommit,
+		"--expected-examples-lockfile-sha256",
+		pinnedExamplesProvenance.lockfileSha256,
+		...(localPackages ? ["--local-packages", localPackages] : []),
+		...(examplesTemplate ? ["--template", examplesTemplate] : []),
+		"--results-dir",
+		resultsDir,
+		"--summary-file",
+		summaryFile,
+		"--file-mb",
+		String(fileMb),
+		"--runs",
+		String(runs),
+		"--mode",
+		mode,
+		"--network",
+		network,
+		...(freshExamples ? ["--fresh"] : []),
+		...(freshExamplesEachRun ? ["--fresh-each-run"] : []),
+		...(installExamples ? ["--install"] : []),
+		...(uploadTimeoutMs != null
+			? ["--upload-timeout-ms", String(uploadTimeoutMs)]
+			: []),
+		...(downloadTimeoutMs != null
+			? ["--download-timeout-ms", String(downloadTimeoutMs)]
+			: []),
+		...(postUploadMonitorMs != null
+			? ["--post-upload-monitor-ms", String(postUploadMonitorMs)]
+			: []),
+		...(pollMs != null ? ["--poll-ms", String(pollMs)] : []),
+		...(minReadySeeders != null
+			? ["--min-ready-seeders", String(minReadySeeders)]
+			: []),
+		...(readyTimeoutMs != null
+			? ["--ready-timeout-ms", String(readyTimeoutMs)]
+			: []),
+		...(sampleMs != null ? ["--sample-ms", String(sampleMs)] : []),
+		...(sampleCount != null ? ["--sample-count", String(sampleCount)] : []),
+		...(targetSeeders != null
+			? ["--target-seeders", String(targetSeeders)]
+			: []),
+		...(protocol ? ["--protocol", protocol] : []),
+		...(fixtureSeed ? ["--fixture-seed", fixtureSeed] : []),
+		...(enableVisibilityProbe ? ["--enable-visibility-probe"] : []),
+		...(verbose ? ["--verbose"] : []),
+	];
+	console.log(`$ node ${runnerArgs.join(" ")}`);
+	const startedAt = Date.now();
+	const child = spawnSync("node", runnerArgs, {
+		cwd: repoRoot,
+		env: process.env,
+		stdio: "inherit",
+	});
+	const processOutcome = {
+		wallTimeMs: Date.now() - startedAt,
+		exitCode: child.status,
+		signal: child.signal,
+		spawnError: child.error ? serializeError(child.error) : null,
+	};
+	const summaryEvidence = await readJsonEvidence(summaryFile);
+	const classification = classifySubprocessSummary({
+		processOutcome,
+		summaryEvidence,
+		expectedSchema: BENCHMARK_SUMMARY_SCHEMA,
+	});
 	return {
 		variant,
 		variantRef,
 		resolvedCommit,
-		...summary,
+		summaryFile,
+		processOutcome,
+		summaryEvidenceKind: summaryEvidence.kind,
+		subprocessFailures: classification.failures,
+		subprocessSucceeded: classification.processSucceeded,
+		summary: classification.summary,
+	};
+};
+
+const createMatrixInvocationFailure = ({
+	plan,
+	scenario,
+	network,
+	fileMb,
+	summaryFile,
+	processOutcome,
+	expectedInvocation,
+	expectedProvenance,
+	failures,
+	browserResult,
+}) => {
+	const collectedErrorEvidence = extractCollectedErrorEvidence(browserResult);
+	return {
+		schema: BENCHMARK_RESULT_SCHEMA,
+		runNonce: browserResult?.runNonce ?? null,
+		invocation: expectedInvocation ?? null,
+		provenance: expectedProvenance,
+		status: "failed",
+		scenario,
+		mode: plan.mode,
+		networkMode: network,
+		fileSizeMb: fileMb,
+		stage: "matrix-orchestration",
+		errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
+		knownPeerbitFailureSignatures: KNOWN_PEERBIT_FAILURE_SIGNATURES,
+		errorCollectionComplete: collectedErrorEvidence.errorCollectionComplete,
+		errorCount: collectedErrorEvidence.errorCount,
+		errors: collectedErrorEvidence.errors,
+		requestFailureCollectionDefinition: REQUEST_FAILURE_COLLECTION_DEFINITION,
+		requestFailureCollectionComplete:
+			collectedErrorEvidence.requestFailureCollectionComplete,
+		requestFailureCount: collectedErrorEvidence.requestFailureCount,
+		requestFailures: collectedErrorEvidence.requestFailures,
+		variant: plan.variant,
+		run: plan.run,
+		matrixSequence: plan.sequence,
+		subRunSummaryFile: summaryFile,
+		subprocess: processOutcome ?? null,
+		orchestrationFailures: failures,
+		failure: {
+			kind: "matrix-subrun",
+			message: failures.map((failure) => failure.message).join("; "),
+		},
+		browserResult: browserResult ?? null,
 	};
 };
 
@@ -499,6 +604,10 @@ const main = async () => {
 		requestedNames: requestedLocalPackageNames,
 		requiredNames: defaultFileShareLocalPackages,
 	});
+	const expectedHarnessProvenance = await getPeerbitProvenance({
+		root: repoRoot,
+		requestedRef: "harness-worktree",
+	});
 	const variantSpecs = await resolveVariantSpecs(requestedVariantSpecs);
 	const matrixSession = await createExclusiveMatrixSession({
 		baseDir: requestedMatrixBase,
@@ -518,10 +627,11 @@ const main = async () => {
 			`\n=== Variant: ${variant}${variantSpec.ref ? ` (${variantSpec.ref})` : " (worktree)"} ===`,
 		);
 		const variantRoot = path.join(matrixRoot, "variants", variant);
-		const { peerbitRoot, resolvedCommit } = await prepareVariant({
-			variantSpec,
-			variantRoot,
-		});
+		const { peerbitRoot, resolvedCommit, peerbitProvenance } =
+			await prepareVariant({
+				variantSpec,
+				variantRoot,
+			});
 		const effectiveLocalPackageNames = [
 			...(
 				await collectLocalPeerbitPackages(peerbitRoot, {
@@ -546,6 +656,7 @@ const main = async () => {
 				variantSpec.kind === "worktree" ? "worktree" : variantSpec.ref,
 			resolvedCommit,
 			peerbitRoot,
+			peerbitProvenance,
 			effectiveLocalPackageNames,
 		});
 	}
@@ -557,8 +668,8 @@ const main = async () => {
 	});
 	const resultsByVariant = new Map(variantSpecs.map((spec) => [spec.name, []]));
 	const invocationRecords = [];
-	let benchmarkExamplesProvenance;
-	let benchmarkHarnessProvenance;
+	const benchmarkExamplesProvenance = pinnedExamples.provenance;
+	const benchmarkHarnessProvenance = expectedHarnessProvenance;
 
 	for (const plan of executionOrder) {
 		const prepared = preparedVariants.get(plan.variant);
@@ -582,106 +693,260 @@ const main = async () => {
 			invocationSlug,
 		);
 		const summaryFile = path.join(resultsDir, "summary.json");
-		const invocationSummary = await runVariantBenchmark({
-			...prepared,
-			examplesSource,
-			examplesRef,
-			examplesTemplate,
-			pinnedExamplesProvenance: pinnedExamples.provenance,
-			examplesRoot,
-			resultsDir,
-			summaryFile,
-			fileMb,
-			runs: 1,
-			mode: plan.mode,
-			network,
-			scenario,
-			integrationMode,
-			localPackages,
-			freshExamples: true,
-			freshExamplesEachRun: false,
-			installExamples: false,
-			uploadTimeoutMs,
-			downloadTimeoutMs,
-			postUploadMonitorMs,
-			pollMs,
-			minReadySeeders,
-			readyTimeoutMs,
-			sampleMs,
-			sampleCount,
-			targetSeeders,
-			protocol,
-			fixtureSeed,
-			enableVisibilityProbe,
-			verbose,
-		});
-		if (
-			invocationSummary.peerbitProvenance?.resolvedCommit !==
-				prepared.resolvedCommit ||
-			invocationSummary.peerbitProvenance?.dirty !== false
-		) {
-			throw new Error(
-				`Variant ${plan.variant} did not report its exact clean resolved HEAD`,
-			);
+		let subRun;
+		const structuralFailures = [];
+		try {
+			subRun = await runVariantBenchmark({
+				...prepared,
+				examplesSource,
+				examplesRef,
+				examplesTemplate,
+				pinnedExamplesProvenance: pinnedExamples.provenance,
+				examplesRoot,
+				resultsDir,
+				summaryFile,
+				fileMb,
+				runs: 1,
+				mode: plan.mode,
+				network,
+				scenario,
+				integrationMode,
+				localPackages,
+				freshExamples: true,
+				freshExamplesEachRun: false,
+				installExamples: false,
+				uploadTimeoutMs,
+				downloadTimeoutMs,
+				postUploadMonitorMs,
+				pollMs,
+				minReadySeeders,
+				readyTimeoutMs,
+				sampleMs,
+				sampleCount,
+				targetSeeders,
+				protocol,
+				fixtureSeed,
+				enableVisibilityProbe,
+				verbose,
+			});
+		} catch (error) {
+			structuralFailures.push({
+				kind: "subrun-orchestration",
+				...serializeError(error),
+			});
 		}
-		if (
-			invocationSummary.examplesProvenance?.resolvedCommit !==
-				pinnedExamples.provenance.resolvedCommit ||
-			invocationSummary.examplesProvenance?.lockfileSha256 !==
-				pinnedExamples.provenance.lockfileSha256
-		) {
-			throw new Error(
-				`Variant ${plan.variant} did not use the pinned examples commit and lockfile`,
-			);
+		const invocationSummary = subRun?.summary;
+		const subprocessFailures = subRun?.subprocessFailures ?? [];
+		const processFailures = [];
+		for (const failure of subprocessFailures) {
+			if (["spawn-error", "signal", "nonzero-exit"].includes(failure.kind)) {
+				processFailures.push(failure);
+			} else {
+				structuralFailures.push(failure);
+			}
 		}
-		const [rawResult] = invocationSummary.results ?? [];
-		if (!rawResult || invocationSummary.results.length !== 1) {
-			throw new Error("Matrix invocation did not produce exactly one result");
-		}
-		if (rawResult.invocation?.baseUrl !== null) {
-			throw new Error(
-				"Matrix invocation used an effective remote PW_BASE_URL instead of its local app",
-			);
-		}
-		if (
-			JSON.stringify(rawResult.invocation?.localPackages) !==
-			JSON.stringify(prepared.effectiveLocalPackageNames)
-		) {
-			throw new Error(
-				`Variant ${plan.variant} did not bind its exact effective local package set`,
-			);
-		}
-		if (
-			rawResult.invocation?.serverMode !== "production-preview" ||
-			rawResult.invocation?.serverHost !== "127.0.0.1"
-		) {
-			throw new Error(
-				"Matrix invocation did not use the required local production preview server",
-			);
-		}
-		benchmarkExamplesProvenance ??= invocationSummary.examplesProvenance;
-		benchmarkHarnessProvenance ??= invocationSummary.harnessProvenance;
-		if (
-			JSON.stringify(benchmarkExamplesProvenance) !==
-				JSON.stringify(invocationSummary.examplesProvenance) ||
-			JSON.stringify(benchmarkHarnessProvenance) !==
-				JSON.stringify(invocationSummary.harnessProvenance)
-		) {
-			throw new Error(
-				"Matrix invocations changed harness or examples provenance",
-			);
-		}
-		const result = {
-			...rawResult,
-			variant: plan.variant,
-			run: plan.run,
-			matrixSequence: plan.sequence,
+		const expectedProvenance = {
+			harness: expectedHarnessProvenance,
+			peerbit: prepared.peerbitProvenance,
+			examples: pinnedExamples.provenance,
 		};
+		let expectedInvocation;
+		try {
+			expectedInvocation = createBenchmarkInvocation({
+				scenario,
+				mode: plan.mode,
+				network,
+				integrationMode,
+				fileMb,
+				fixtureSeed: fixtureSeed ?? DEFAULT_FIXTURE_SEED,
+				uploadTimeoutMs: optionalNumber(uploadTimeoutMs),
+				downloadTimeoutMs: optionalNumber(downloadTimeoutMs),
+				postUploadMonitorMs: optionalNumber(postUploadMonitorMs),
+				pollMs: optionalNumber(pollMs),
+				minReadySeeders: optionalNumber(minReadySeeders),
+				readyTimeoutMs: optionalNumber(readyTimeoutMs),
+				sampleMs: optionalNumber(sampleMs),
+				sampleCount: optionalNumber(sampleCount),
+				targetSeeders: optionalNumber(targetSeeders),
+				baseUrl: null,
+				protocol,
+				viteMode: null,
+				viteConfig: null,
+				localPackages: prepared.effectiveLocalPackageNames,
+				enableVisibilityProbe,
+				verbose,
+			});
+		} catch (error) {
+			structuralFailures.push({
+				kind: "expected-invocation",
+				...serializeError(error),
+			});
+		}
+		let rawResult;
+		let rawResultEvidence;
+		if (invocationSummary) {
+			const inspection = inspectSingleInvocationSummary(invocationSummary);
+			rawResult = inspection.result;
+			rawResultEvidence = inspection.resultEvidence;
+			structuralFailures.push(...inspection.failures);
+			if (
+				!isDeepStrictEqual(
+					invocationSummary.harnessProvenance,
+					expectedHarnessProvenance,
+				)
+			) {
+				structuralFailures.push({
+					kind: "harness-provenance",
+					message:
+						"Benchmark subprocess did not report the matrix harness's exact pinned provenance",
+				});
+			}
+			if (
+				!isDeepStrictEqual(
+					invocationSummary.peerbitProvenance,
+					prepared.peerbitProvenance,
+				)
+			) {
+				structuralFailures.push({
+					kind: "peerbit-provenance",
+					message: `Variant ${plan.variant} did not report its exact clean pinned provenance`,
+				});
+			}
+			if (
+				!isDeepStrictEqual(
+					invocationSummary.examplesProvenance,
+					pinnedExamples.provenance,
+				)
+			) {
+				structuralFailures.push({
+					kind: "examples-provenance",
+					message: `Variant ${plan.variant} did not report the exact clean pinned examples provenance`,
+				});
+			}
+			if (
+				rawResult &&
+				(!isDeepStrictEqual(
+					invocationSummary.harnessProvenance,
+					rawResult.provenance?.harness,
+				) ||
+					!isDeepStrictEqual(
+						invocationSummary.peerbitProvenance,
+						rawResult.provenance?.peerbit,
+					) ||
+					!isDeepStrictEqual(
+						invocationSummary.examplesProvenance,
+						rawResult.provenance?.examples,
+					))
+			) {
+				structuralFailures.push({
+					kind: "summary-result-provenance",
+					message:
+						"Benchmark subprocess summary provenance contradicts its result envelope",
+				});
+			}
+			if (rawResult && expectedInvocation) {
+				let envelopeValid = false;
+				try {
+					validateBenchmarkResultEnvelope(rawResult, {
+						expectedMode: plan.mode,
+						expectedFileMb: fileMb,
+						expectedNetwork: network,
+						expectedRunNonce: rawResult.runNonce,
+						expectedProvenance,
+						expectedInvocation,
+					});
+					envelopeValid = true;
+				} catch (error) {
+					structuralFailures.push({
+						kind: "invalid-result-envelope",
+						...serializeError(error),
+					});
+				}
+				if (envelopeValid && rawResult.status === "passed") {
+					try {
+						validateBenchmarkResult(rawResult, {
+							scenario,
+							expectedMode: plan.mode,
+							expectedFileMb: fileMb,
+							expectedNetwork: network,
+							expectedFixtureSeed: fixtureSeed ?? DEFAULT_FIXTURE_SEED,
+							expectedRunNonce: rawResult.runNonce,
+							expectedProvenance,
+							expectedInvocation,
+						});
+					} catch (error) {
+						structuralFailures.push({
+							kind: "invalid-passed-result",
+							...serializeError(error),
+						});
+					}
+				}
+			}
+		}
+		if (
+			rawResult?.status === "passed" &&
+			subRun?.subprocessSucceeded === false
+		) {
+			structuralFailures.push({
+				kind: "passed-result-nonzero-exit",
+				message:
+					"Benchmark subprocess returned a passed result with an unsuccessful process outcome",
+			});
+		}
+		if (
+			rawResult?.status !== "passed" &&
+			subRun?.subprocessSucceeded === true
+		) {
+			structuralFailures.push({
+				kind: "failed-result-zero-exit",
+				message:
+					"Benchmark subprocess returned a failed result with a successful process outcome",
+			});
+		}
+		const allFailures = [...processFailures, ...structuralFailures];
+		const result =
+			rawResult && structuralFailures.length === 0
+				? {
+						...rawResult,
+						variant: plan.variant,
+						run: plan.run,
+						matrixSequence: plan.sequence,
+						subRunSummaryFile: summaryFile,
+						subprocess: subRun.processOutcome,
+						subprocessFailures,
+					}
+				: createMatrixInvocationFailure({
+						plan,
+						scenario,
+						network,
+						fileMb,
+						summaryFile,
+						processOutcome: subRun?.processOutcome,
+						expectedInvocation,
+						expectedProvenance,
+						failures:
+							allFailures.length > 0
+								? allFailures
+								: [
+										{
+											kind: "missing-summary",
+											message:
+												"Matrix invocation did not return usable summary evidence",
+										},
+									],
+						browserResult: rawResultEvidence,
+					});
 		resultsByVariant.get(plan.variant).push(result);
 		invocationRecords.push({
 			...plan,
+			status: result.status,
 			runNonce: result.runNonce,
-			resultFile: result.resultFile,
+			resultFile: result.resultFile ?? null,
+			subRunSummaryFile: summaryFile,
+			subRunSummary: invocationSummary ?? null,
+			subprocess: subRun?.processOutcome ?? null,
+			subprocessFailures,
+			orchestrationFailures: structuralFailures,
 			peerbitResolvedCommit: prepared.resolvedCommit,
 			effectiveLocalPackageNames: prepared.effectiveLocalPackageNames,
 		});
@@ -698,7 +963,7 @@ const main = async () => {
 			resolvedCommit: prepared.resolvedCommit,
 			effectiveLocalPackageNames: prepared.effectiveLocalPackageNames,
 			harnessProvenance: benchmarkHarnessProvenance,
-			peerbitProvenance: results[0]?.provenance?.peerbit,
+			peerbitProvenance: prepared.peerbitProvenance,
 			examplesProvenance: benchmarkExamplesProvenance,
 			results,
 			summary: summarizeInvocationResults(results, scenario),
@@ -707,11 +972,18 @@ const main = async () => {
 		};
 	});
 
+	const allResults = [...resultsByVariant.values()].flat();
+	const outcomeCounts = countBenchmarkOutcomes(
+		allResults,
+		executionOrder.length,
+	);
 	const matrixSummary = {
-		schema: {
-			id: "peerbit-file-share-matrix-summary",
-			version: 2,
-		},
+		schema: MATRIX_SUMMARY_SCHEMA,
+		status: outcomeCounts.failed === 0 ? "passed" : "failed",
+		outcomeCounts,
+		errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
+		knownPeerbitFailureSignatures: KNOWN_PEERBIT_FAILURE_SIGNATURES,
+		requestFailureCollectionDefinition: REQUEST_FAILURE_COLLECTION_DEFINITION,
 		matrixBase: matrixSession.matrixBase,
 		matrixRoot,
 		matrixSessionNonce: matrixSession.nonce,
@@ -751,9 +1023,14 @@ const main = async () => {
 
 	console.log("\nVariant summary");
 	console.table(matrixSummary.summary);
+	console.log("\nOutcome counts");
+	console.table([outcomeCounts]);
 	console.log("\nAdaptive across variants");
 	console.table(matrixSummary.adaptiveComparison);
 	console.log(`\nMatrix summary: ${matrixSummaryFile}`);
+	if (outcomeCounts.failed > 0) {
+		process.exitCode = 1;
+	}
 };
 
 main().catch((error) => {

--- a/scripts/file-share/run-file-share-benchmark.mjs
+++ b/scripts/file-share/run-file-share-benchmark.mjs
@@ -14,6 +14,16 @@ import {
 	resolveBenchmarkPreviewOptions,
 } from "./benchmark-invocation.mjs";
 import {
+	BENCHMARK_SUMMARY_SCHEMA,
+	countBenchmarkOutcomes,
+	createInvocationFailureEvidence,
+	ERROR_COLLECTION_DEFINITION,
+	executePlanContinuing,
+	KNOWN_PEERBIT_FAILURE_SIGNATURES,
+	readJsonEvidence,
+	REQUEST_FAILURE_COLLECTION_DEFINITION,
+} from "./benchmark-orchestration.mjs";
+import {
 	getExamplesProvenance,
 	getPeerbitProvenance,
 	resolveGitCommitAt,
@@ -333,7 +343,17 @@ const summarizeUploadResults = (results) => {
 				.map((item) => item.postUploadMonitorDurationMs)
 				.filter((value) => typeof value === "number"),
 		),
-		errorCount: items.reduce((sum, item) => sum + item.errorCount, 0),
+		errorCount: items.reduce(
+			(sum, item) => sum + (Number(item.errorCount) || 0),
+			0,
+		),
+		incompleteErrorCollections: items.filter(
+			(item) => item.errorCollectionComplete !== true,
+		).length,
+		requestFailureCount: items.reduce(
+			(sum, item) => sum + (Number(item.requestFailureCount) || 0),
+			0,
+		),
 		seederDrops: items.filter((item) => item.droppedSeeders).length,
 	}));
 };
@@ -389,7 +409,17 @@ const summarizeSeederProbeResults = (results) => {
 				})
 				.filter((value) => typeof value === "number"),
 		),
-		errorCount: items.reduce((sum, item) => sum + item.errorCount, 0),
+		errorCount: items.reduce(
+			(sum, item) => sum + (Number(item.errorCount) || 0),
+			0,
+		),
+		incompleteErrorCollections: items.filter(
+			(item) => item.errorCollectionComplete !== true,
+		).length,
+		requestFailureCount: items.reduce(
+			(sum, item) => sum + (Number(item.requestFailureCount) || 0),
+			0,
+		),
 	}));
 };
 
@@ -478,6 +508,36 @@ const writeJsonAtomic = async (filePath, value) => {
 	const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
 	await fsp.writeFile(temporaryPath, `${JSON.stringify(value, null, 2)}\n`);
 	await fsp.rename(temporaryPath, filePath);
+};
+
+const assertSafeInvocationUnchanged = (actual, expected, label) => {
+	try {
+		assertInvocationUnchanged(actual, expected, label);
+	} catch (error) {
+		const unsafeError = new Error(
+			`${label} changed during the benchmark; remaining invocations are unsafe`,
+			{ cause: error },
+		);
+		unsafeError.stopBenchmarkPlan = true;
+		throw unsafeError;
+	}
+};
+
+const readAndAssertSafeInvocationUnchanged = async (
+	readActual,
+	expected,
+	label,
+) => {
+	try {
+		assertInvocationUnchanged(await readActual(), expected, label);
+	} catch (error) {
+		const unsafeError = new Error(
+			`${label} changed during the benchmark; remaining invocations are unsafe`,
+			{ cause: error },
+		);
+		unsafeError.stopBenchmarkPlan = true;
+		throw unsafeError;
+	}
 };
 
 const main = async () => {
@@ -708,118 +768,200 @@ const main = async () => {
 	const sessionNonce = randomUUID();
 	const resultsDir = path.join(resultsRoot, `session-${sessionNonce}`);
 	await fsp.mkdir(resultsDir, { recursive: false });
+	const aggregateSummaryFile =
+		requestedSummaryFile ?? path.join(resultsDir, "summary.json");
 	const results = [];
 	let benchmarkInvocationCount = 0;
 	const executionOrder = createCounterbalancedModePlan({ modes, runs });
-
-	for (const { sequence, mode, run: runIndex } of executionOrder) {
-		if (freshEachRun && benchmarkInvocationCount > 0) {
-			({ frontendRoot, examplesProvenance } = await prepareBenchmarkCheckout({
-				fresh: true,
-			}));
-			assertInvocationUnchanged(
-				examplesProvenance,
-				expectedExamplesProvenance,
-				"Pre-instrumentation examples provenance",
-			);
+	const invocationContexts = new Map();
+	const outcomes = await executePlanContinuing({
+		plan: executionOrder,
+		shouldStop: (error) => error?.stopBenchmarkPlan === true,
+		execute: async ({ sequence, mode, run: runIndex }) => {
+			const runNonce = randomUUID();
+			const invocation = createBenchmarkInvocation({
+				scenario,
+				mode,
+				network,
+				integrationMode,
+				fileMb,
+				fixtureSeed: resolvedFixtureSeed,
+				uploadTimeoutMs,
+				downloadTimeoutMs,
+				postUploadMonitorMs,
+				pollMs,
+				minReadySeeders,
+				readyTimeoutMs,
+				sampleMs,
+				sampleCount,
+				targetSeeders,
+				baseUrl,
+				protocol,
+				viteMode,
+				viteConfig,
+				localPackages: effectiveLocalPackageNames,
+				enableVisibilityProbe: Boolean(args["enable-visibility-probe"]),
+				verbose: Boolean(args.verbose),
+			});
+			const resultFile = createNonceIsolatedResultPath({
+				resultsDir,
+				runNonce,
+			});
+			const context = {
+				runNonce,
+				invocation,
+				resultFile,
+				processOutcome: null,
+				provenance: {
+					harness: harnessProvenance,
+					peerbit: peerbitProvenance,
+					examples: examplesProvenance,
+				},
+			};
+			invocationContexts.set(sequence, context);
+			try {
+				if (freshEachRun && benchmarkInvocationCount > 0) {
+					({ frontendRoot, examplesProvenance } =
+						await prepareBenchmarkCheckout({
+							fresh: true,
+						}));
+					assertSafeInvocationUnchanged(
+						examplesProvenance,
+						expectedExamplesProvenance,
+						"Pre-instrumentation examples provenance",
+					);
+					context.provenance = {
+						harness: harnessProvenance,
+						peerbit: peerbitProvenance,
+						examples: examplesProvenance,
+					};
+				}
+				console.log(
+					`Running file-share benchmark sequence=${sequence}/${executionOrder.length} scenario=${scenario} network=${network} mode=${mode} run=${runIndex}/${runs} fileMb=${fileMb}`,
+				);
+				await cleanupFrontendBenchmarkArtifacts(frontendRoot);
+				await fsp.rm(resultFile, { force: true });
+				const processOutcome = runPlaywright({
+					frontendRoot,
+					generatedSpecPath: scenarioConfig.generatedSpecPath,
+					resultFile,
+					runNonce,
+					provenance: context.provenance,
+					invocation,
+				});
+				context.processOutcome = processOutcome;
+				const { wallTimeMs, exitCode, signal, spawnError } = processOutcome;
+				let result;
+				let invocationFailure;
+				try {
+					if (spawnError) {
+						throw new Error(
+							`Could not start Playwright benchmark: ${spawnError.message}`,
+							{ cause: spawnError },
+						);
+					}
+					if (signal) {
+						throw new Error(
+							`Playwright benchmark terminated by signal ${signal}`,
+						);
+					}
+					result = await loadAndValidateBenchmarkResult({
+						resultFile,
+						exitCode,
+						scenario,
+						expectedMode: mode,
+						expectedFileMb: fileMb,
+						expectedNetwork: network,
+						expectedFixtureSeed: resolvedFixtureSeed,
+						expectedRunNonce: runNonce,
+						expectedProvenance: context.provenance,
+						expectedInvocation: invocation,
+					});
+				} catch (error) {
+					invocationFailure = error;
+				}
+				let unsafeProvenanceFailure;
+				for (const [readActual, expected, label] of [
+					[
+						() =>
+							getPeerbitProvenance({
+								root: repoRoot,
+								requestedRef: "harness-worktree",
+							}),
+						harnessProvenance,
+						"Harness provenance",
+					],
+					[
+						() =>
+							getPeerbitProvenance({
+								root: peerbitRoot,
+								requestedRef: peerbitRefLabel,
+								requireClean: Boolean(args["require-clean-peerbit"]),
+								expectedResolvedCommit: expectedPeerbitCommit,
+							}),
+						peerbitProvenance,
+						"Peerbit provenance",
+					],
+				]) {
+					try {
+						await readAndAssertSafeInvocationUnchanged(
+							readActual,
+							expected,
+							label,
+						);
+					} catch (error) {
+						unsafeProvenanceFailure ??= error;
+					}
+				}
+				if (unsafeProvenanceFailure) {
+					throw unsafeProvenanceFailure;
+				}
+				if (invocationFailure) {
+					throw invocationFailure;
+				}
+				return {
+					...result,
+					run: runIndex,
+					invocationSequence: sequence,
+					resultFile,
+					playwrightWallTimeMs: wallTimeMs,
+					playwrightExitCode: exitCode,
+				};
+			} finally {
+				benchmarkInvocationCount++;
+			}
+		},
+	});
+	for (const outcome of outcomes) {
+		if (outcome.status === "fulfilled") {
+			results.push(outcome.value);
+			continue;
 		}
-		const runNonce = randomUUID();
-		const invocation = createBenchmarkInvocation({
+		const { sequence, mode, run: runIndex } = outcome.entry;
+		const context = invocationContexts.get(sequence);
+		if (!context) {
+			throw new Error(`Missing invocation context for sequence ${sequence}`);
+		}
+		const resultEvidence = await readJsonEvidence(context.resultFile);
+		const failedResult = createInvocationFailureEvidence({
 			scenario,
 			mode,
 			network,
-			integrationMode,
 			fileMb,
-			fixtureSeed: resolvedFixtureSeed,
-			uploadTimeoutMs,
-			downloadTimeoutMs,
-			postUploadMonitorMs,
-			pollMs,
-			minReadySeeders,
-			readyTimeoutMs,
-			sampleMs,
-			sampleCount,
-			targetSeeders,
-			baseUrl,
-			protocol,
-			viteMode,
-			viteConfig,
-			localPackages: effectiveLocalPackageNames,
-			enableVisibilityProbe: Boolean(args["enable-visibility-probe"]),
-			verbose: Boolean(args.verbose),
+			runNonce: context.runNonce,
+			invocation: context.invocation,
+			provenance: context.provenance,
+			resultFile: context.resultFile,
+			processOutcome: context.processOutcome,
+			resultEvidence,
+			failure: outcome.error,
 		});
-		const resultFile = createNonceIsolatedResultPath({
-			resultsDir,
-			runNonce,
-		});
-		console.log(
-			`Running file-share benchmark sequence=${sequence}/${executionOrder.length} scenario=${scenario} network=${network} mode=${mode} run=${runIndex}/${runs} fileMb=${fileMb}`,
-		);
-		await cleanupFrontendBenchmarkArtifacts(frontendRoot);
-		await fsp.rm(resultFile, { force: true });
-		const provenance = {
-			harness: harnessProvenance,
-			peerbit: peerbitProvenance,
-			examples: examplesProvenance,
-		};
-		const { wallTimeMs, exitCode, signal, spawnError } = runPlaywright({
-			frontendRoot,
-			generatedSpecPath: scenarioConfig.generatedSpecPath,
-			resultFile,
-			runNonce,
-			provenance,
-			invocation,
-		});
-		if (spawnError) {
-			throw new Error(
-				`Could not start Playwright benchmark: ${spawnError.message}`,
-				{
-					cause: spawnError,
-				},
-			);
-		}
-		if (signal) {
-			throw new Error(`Playwright benchmark terminated by signal ${signal}`);
-		}
-		const result = await loadAndValidateBenchmarkResult({
-			resultFile,
-			exitCode,
-			scenario,
-			expectedMode: mode,
-			expectedFileMb: fileMb,
-			expectedNetwork: network,
-			expectedFixtureSeed: resolvedFixtureSeed,
-			expectedRunNonce: runNonce,
-			expectedProvenance: provenance,
-			expectedInvocation: invocation,
-		});
-		assertInvocationUnchanged(
-			await getPeerbitProvenance({
-				root: repoRoot,
-				requestedRef: "harness-worktree",
-			}),
-			harnessProvenance,
-			"Harness provenance",
-		);
-		assertInvocationUnchanged(
-			await getPeerbitProvenance({
-				root: peerbitRoot,
-				requestedRef: peerbitRefLabel,
-				requireClean: Boolean(args["require-clean-peerbit"]),
-				expectedResolvedCommit: expectedPeerbitCommit,
-			}),
-			peerbitProvenance,
-			"Peerbit provenance",
-		);
 		results.push({
-			...result,
+			...failedResult,
 			run: runIndex,
 			invocationSequence: sequence,
-			resultFile,
-			playwrightWallTimeMs: wallTimeMs,
-			playwrightExitCode: exitCode,
+			playwrightWallTimeMs: context.processOutcome?.wallTimeMs ?? null,
 		});
-		benchmarkInvocationCount++;
 	}
 
 	console.log("\nPer-run results");
@@ -851,8 +993,14 @@ const main = async () => {
 			playwrightWallTimeMs: result.playwrightWallTimeMs,
 			playwrightExitCode: result.playwrightExitCode,
 			droppedSeeders: result.droppedSeeders,
+			errorCollectionComplete: result.errorCollectionComplete === true,
 			errorCount: result.errorCount,
-			failure: result.failure?.message ?? "",
+			requestFailureCount: result.requestFailureCount ?? null,
+			failure:
+				result.browserFailure?.message ??
+				result.runnerFailure?.message ??
+				result.failure?.message ??
+				"",
 		})),
 	);
 	console.log("\nSummary");
@@ -863,11 +1011,16 @@ const main = async () => {
 		console.log("\nAdaptive vs fixed1");
 		console.table([comparison]);
 	}
+	const outcomeCounts = countBenchmarkOutcomes(results, executionOrder.length);
+	console.log("\nOutcome counts");
+	console.table([outcomeCounts]);
 	const summary = {
-		schema: {
-			id: "peerbit-file-share-benchmark-summary",
-			version: 2,
-		},
+		schema: BENCHMARK_SUMMARY_SCHEMA,
+		status: outcomeCounts.failed === 0 ? "passed" : "failed",
+		outcomeCounts,
+		errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
+		knownPeerbitFailureSignatures: KNOWN_PEERBIT_FAILURE_SIGNATURES,
+		requestFailureCollectionDefinition: REQUEST_FAILURE_COLLECTION_DEFINITION,
 		sessionNonce,
 		harnessProvenance,
 		peerbitRoot,
@@ -885,14 +1038,17 @@ const main = async () => {
 		executionOrder,
 		resultsRoot,
 		resultsDir,
+		aggregateSummaryFile,
 		results,
 		summary: summarizeResults(results, scenario),
 		comparison,
 	};
-	if (requestedSummaryFile) {
-		await writeJsonAtomic(requestedSummaryFile, summary);
-	}
+	await writeJsonAtomic(aggregateSummaryFile, summary);
 	console.log(`\nRaw results: ${resultsDir}`);
+	console.log(`Aggregate summary: ${aggregateSummaryFile}`);
+	if (outcomeCounts.failed > 0) {
+		process.exitCode = 1;
+	}
 };
 
 main().catch((error) => {

--- a/scripts/file-share/template-contract.test.mjs
+++ b/scripts/file-share/template-contract.test.mjs
@@ -2,6 +2,11 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
+import {
+	ERROR_COLLECTION_DEFINITION,
+	KNOWN_PEERBIT_FAILURE_SIGNATURES,
+	REQUEST_FAILURE_COLLECTION_DEFINITION,
+} from "./benchmark-orchestration.mjs";
 import { repoRoot } from "./common.mjs";
 
 const templates = [
@@ -10,14 +15,14 @@ const templates = [
 ];
 
 for (const name of templates) {
-	test(`${name} emits the atomic v2 invocation envelope`, async () => {
+	test(`${name} emits the atomic v3 invocation envelope`, async () => {
 		const contents = await readFile(
 			path.join(repoRoot, "scripts", "file-share", "templates", name),
 			"utf8",
 		);
 		for (const required of [
 			'id: "peerbit-file-share-benchmark"',
-			"version: 2",
+			"version: 3",
 			"PW_BENCHMARK_RUN_NONCE",
 			"PW_BENCHMARK_INVOCATION",
 			"PW_BENCHMARK_PROVENANCE",
@@ -27,6 +32,14 @@ for (const name of templates) {
 			"runNonce: RUN_NONCE",
 			"invocation: INVOCATION",
 			"provenance: PROVENANCE",
+			"errorCollectionDefinition: ERROR_COLLECTION_DEFINITION",
+			"knownPeerbitFailureSignatures: KNOWN_PEERBIT_FAILURE_SIGNATURES",
+			"errorCollectionComplete: true",
+			"requestFailureCollectionDefinition:",
+			"requestFailureCollectionComplete: true",
+			"requestFailureCount:",
+			"requestFailures:",
+			'page.on("requestfailed"',
 			"await rename(temporaryPath, RESULT_FILE)",
 			"await rm(temporaryPath, { force: true })",
 		]) {
@@ -58,6 +71,21 @@ for (const name of templates) {
 		assert.ok(
 			!contents.includes("`error:${error.message}`"),
 			"seeder-count failures must reject instead of becoming sample strings",
+		);
+		assert.ok(contents.includes(ERROR_COLLECTION_DEFINITION));
+		assert.ok(contents.includes(REQUEST_FAILURE_COLLECTION_DEFINITION));
+		for (const signature of KNOWN_PEERBIT_FAILURE_SIGNATURES) {
+			assert.ok(contents.includes(`"${signature}"`));
+		}
+		assert.match(
+			contents,
+			/page\.on\("pageerror", \(error\) => \{[\s\S]*?errors\.push\(`\$\{label\}:pageerror:/,
+			"every uncaught page error must be recorded without signature filtering",
+		);
+		assert.match(
+			contents,
+			/message\.type\(\) === "error" \|\|[\s\S]*?KNOWN_PEERBIT_FAILURE_SIGNATURES\.some/,
+			"every console.error and matched Peerbit signature must be recorded",
 		);
 	});
 }
@@ -135,4 +163,50 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 			`${peer} readiness must use the invocation timeout`,
 		);
 	}
+});
+
+test("matrix fail-closes every result envelope and fully validates passes", async () => {
+	const contents = await readFile(
+		path.join(
+			repoRoot,
+			"scripts",
+			"file-share",
+			"run-file-share-benchmark-matrix.mjs",
+		),
+		"utf8",
+	);
+	for (const required of [
+		"validateBenchmarkResultEnvelope(rawResult",
+		"validateBenchmarkResult(rawResult",
+		"expectedInvocation = createBenchmarkInvocation",
+		"expectedProvenance",
+		"invocation: expectedInvocation ?? null",
+		"provenance: expectedProvenance",
+		"peerbitProvenance: prepared.peerbitProvenance",
+	]) {
+		assert.ok(contents.includes(required), `missing ${required}`);
+	}
+	assert.ok(
+		!contents.includes("results[0]?.provenance?.peerbit"),
+		"rejected result provenance must not become canonical variant provenance",
+	);
+});
+
+test("standalone runner rechecks provenance even after result failure", async () => {
+	const contents = await readFile(
+		path.join(
+			repoRoot,
+			"scripts",
+			"file-share",
+			"run-file-share-benchmark.mjs",
+		),
+		"utf8",
+	);
+	assert.ok(contents.includes("readAndAssertSafeInvocationUnchanged"));
+	assert.ok(contents.includes("unsafeProvenanceFailure ??= error"));
+	assert.ok(
+		contents.indexOf("if (unsafeProvenanceFailure)") <
+			contents.indexOf("if (invocationFailure)"),
+		"unsafe provenance drift must supersede an ordinary result failure",
+	);
 });

--- a/scripts/file-share/templates/seeder-probe.e2e.spec.ts
+++ b/scripts/file-share/templates/seeder-probe.e2e.spec.ts
@@ -14,13 +14,17 @@ const SAMPLE_COUNT = Number(process.env.PW_SAMPLE_COUNT || "4");
 const TARGET_SEEDERS = Number(process.env.PW_TARGET_SEEDERS || "2");
 const SAMPLE_COUNT_DEFINITION =
 	"observation-density divisor: planned interval is min(sampleMs, floor(readyTimeoutMs/sampleCount)) clamped to 1ms; convergence may finish early";
+const ERROR_COLLECTION_DEFINITION =
+	"from collector attachment through result snapshot: every uncaught pageerror; every console.error; every console message at any level containing a known Peerbit failure signature; plus scenario-recorded operation failures";
+const REQUEST_FAILURE_COLLECTION_DEFINITION =
+	"from collector attachment through result snapshot: every Playwright requestfailed event, retained as non-fatal diagnostics and excluded from errorCount";
 const EFFECTIVE_SAMPLE_INTERVAL_MS = Math.max(
 	1,
 	Math.min(SAMPLE_MS, Math.max(1, Math.floor(READY_TIMEOUT_MS / SAMPLE_COUNT))),
 );
 const RESULT_SCHEMA = {
 	id: "peerbit-file-share-benchmark",
-	version: 2,
+	version: 3,
 } as const;
 const RUN_NONCE = process.env.PW_BENCHMARK_RUN_NONCE;
 const parseJsonEnvironment = (name: string) => {
@@ -104,7 +108,7 @@ const ROLE_BY_MODE: Record<string, any> = {
 	observer: false,
 };
 
-const MATCHED_ERRORS = [
+const KNOWN_PEERBIT_FAILURE_SIGNATURES = [
 	"Failed to resolve block",
 	"DeliveryError",
 	"Failed to get message",
@@ -123,18 +127,34 @@ const getRole = () => {
 	return role;
 };
 
-const attachErrorCollector = (page: Page, label: string, output: string[]) => {
+const attachErrorCollector = (
+	page: Page,
+	label: string,
+	errors: string[],
+	requestFailures: string[],
+) => {
 	page.on("pageerror", (error) => {
 		const text = String(error?.message || error);
-		if (MATCHED_ERRORS.some((match) => text.includes(match))) {
-			output.push(`${label}:pageerror:${text}`);
-		}
+		errors.push(`${label}:pageerror:${text}`);
 	});
 	page.on("console", (message) => {
 		const text = message.text();
-		if (MATCHED_ERRORS.some((match) => text.includes(match))) {
-			output.push(`${label}:console.${message.type()}:${text}`);
+		if (
+			message.type() === "error" ||
+			KNOWN_PEERBIT_FAILURE_SIGNATURES.some((match) => text.includes(match))
+		) {
+			errors.push(`${label}:console.${message.type()}:${text}`);
 		}
+	});
+	page.on("requestfailed", (request) => {
+		requestFailures.push(
+			`${label}:requestfailed:${JSON.stringify({
+				method: request.method(),
+				resourceType: request.resourceType(),
+				url: request.url(),
+				errorText: request.failure()?.errorText ?? null,
+			})}`,
+		);
 	});
 };
 
@@ -294,6 +314,7 @@ test.describe("generated seeder probe", () => {
 		const writer = await writerContext.newPage();
 		const reader = await readerContext.newPage();
 		const errors: string[] = [];
+		const requestFailures: string[] = [];
 		const samples: Array<Record<string, unknown>> = [];
 		let stage = "setup";
 		let shareUrl: string | undefined;
@@ -303,8 +324,8 @@ test.describe("generated seeder probe", () => {
 		let probeStartedAt: number | undefined;
 		let readyDeadlineAt: number | undefined;
 		let probeFinishedAt: number | undefined;
-		attachErrorCollector(writer, "writer", errors);
-		attachErrorCollector(reader, "reader", errors);
+		attachErrorCollector(writer, "writer", errors, requestFailures);
+		attachErrorCollector(reader, "reader", errors, requestFailures);
 
 		const readSeederCount = async (page: Page, label: string) => {
 			try {
@@ -433,6 +454,8 @@ test.describe("generated seeder probe", () => {
 					`Observed seeder probe errors: ${JSON.stringify(errors)}`,
 				);
 			}
+			const collectedErrors = [...errors];
+			const collectedRequestFailures = [...requestFailures];
 
 			const result = {
 				schema: RESULT_SCHEMA,
@@ -457,8 +480,16 @@ test.describe("generated seeder probe", () => {
 				reachedTarget,
 				timeToTargetMs,
 				targetSampleLabel,
-				errorCount: errors.length,
-				errors,
+				errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
+				knownPeerbitFailureSignatures: KNOWN_PEERBIT_FAILURE_SIGNATURES,
+				errorCollectionComplete: true,
+				errorCount: collectedErrors.length,
+				errors: collectedErrors,
+				requestFailureCollectionDefinition:
+					REQUEST_FAILURE_COLLECTION_DEFINITION,
+				requestFailureCollectionComplete: true,
+				requestFailureCount: collectedRequestFailures.length,
+				requestFailures: collectedRequestFailures,
 				samples,
 			};
 
@@ -472,6 +503,8 @@ test.describe("generated seeder probe", () => {
 			}
 		} catch (error: any) {
 			probeFinishedAt ??= Date.now();
+			const collectedErrors = [...errors];
+			const collectedRequestFailures = [...requestFailures];
 			const result = {
 				schema: RESULT_SCHEMA,
 				runNonce: RUN_NONCE,
@@ -496,8 +529,16 @@ test.describe("generated seeder probe", () => {
 				reachedTarget,
 				timeToTargetMs,
 				targetSampleLabel,
-				errorCount: errors.length,
-				errors,
+				errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
+				knownPeerbitFailureSignatures: KNOWN_PEERBIT_FAILURE_SIGNATURES,
+				errorCollectionComplete: true,
+				errorCount: collectedErrors.length,
+				errors: collectedErrors,
+				requestFailureCollectionDefinition:
+					REQUEST_FAILURE_COLLECTION_DEFINITION,
+				requestFailureCollectionComplete: true,
+				requestFailureCount: collectedRequestFailures.length,
+				requestFailures: collectedRequestFailures,
 				samples,
 				failure: {
 					message:

--- a/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
+++ b/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
@@ -44,11 +44,15 @@ const TIME_TO_READER_READY_DEFINITION =
 	"upload-input-set-to-reader-ready-manifest-listed";
 const LISTING_DURATION_DEFINITION =
 	"post-upload-settlement-to-both-writer-and-reader-ready-manifests-listed; excludes upload time";
+const ERROR_COLLECTION_DEFINITION =
+	"from collector attachment through result snapshot: every uncaught pageerror; every console.error; every console message at any level containing a known Peerbit failure signature; plus scenario-recorded operation failures";
+const REQUEST_FAILURE_COLLECTION_DEFINITION =
+	"from collector attachment through result snapshot: every Playwright requestfailed event, retained as non-fatal diagnostics and excluded from errorCount";
 const FIXTURE_SEED =
 	process.env.PW_FIXTURE_SEED || "peerbit-file-share-benchmark-v1";
 const RESULT_SCHEMA = {
 	id: "peerbit-file-share-benchmark",
-	version: 2,
+	version: 3,
 } as const;
 const RUN_NONCE = process.env.PW_BENCHMARK_RUN_NONCE;
 const parseJsonEnvironment = (name: string) => {
@@ -151,11 +155,15 @@ const ROLE_BY_MODE: Record<string, any> = {
 	observer: false,
 };
 
-const MATCHED_ERRORS = [
+const KNOWN_PEERBIT_FAILURE_SIGNATURES = [
 	"Failed to resolve block",
 	"DeliveryError",
 	"Failed to get message",
 	"delivery acknowledges",
+	"Failed to bootstrap",
+	"failed to open",
+	"BorshError",
+	"Failed to create space",
 ];
 
 const getRole = () => {
@@ -169,19 +177,31 @@ const getRole = () => {
 const attachTransferErrorCollector = (
 	page: Page,
 	label: string,
-	output: string[],
+	errors: string[],
+	requestFailures: string[],
 ) => {
 	page.on("pageerror", (error) => {
 		const text = String(error?.message || error);
-		if (MATCHED_ERRORS.some((match) => text.includes(match))) {
-			output.push(`${label}:pageerror:${text}`);
-		}
+		errors.push(`${label}:pageerror:${text}`);
 	});
 	page.on("console", (message) => {
 		const text = message.text();
-		if (MATCHED_ERRORS.some((match) => text.includes(match))) {
-			output.push(`${label}:console.${message.type()}:${text}`);
+		if (
+			message.type() === "error" ||
+			KNOWN_PEERBIT_FAILURE_SIGNATURES.some((match) => text.includes(match))
+		) {
+			errors.push(`${label}:console.${message.type()}:${text}`);
 		}
+	});
+	page.on("requestfailed", (request) => {
+		requestFailures.push(
+			`${label}:requestfailed:${JSON.stringify({
+				method: request.method(),
+				resourceType: request.resourceType(),
+				url: request.url(),
+				errorText: request.failure()?.errorText ?? null,
+			})}`,
+		);
 	});
 };
 
@@ -408,6 +428,7 @@ test.describe("generated transfer-validity benchmark", () => {
 		const writer = await writerContext.newPage();
 		const reader = await readerContext.newPage();
 		const errors: string[] = [];
+		const requestFailures: string[] = [];
 		const snapshots: Array<Record<string, unknown>> = [];
 		let preparedFile:
 			| Awaited<ReturnType<typeof createSyntheticFileOnDisk>>
@@ -435,8 +456,8 @@ test.describe("generated transfer-validity benchmark", () => {
 		let dropped = false;
 		let baselineWriterSeeders = MIN_READY_SEEDERS;
 		let baselineReaderSeeders = MIN_READY_SEEDERS;
-		attachTransferErrorCollector(writer, "writer", errors);
-		attachTransferErrorCollector(reader, "reader", errors);
+		attachTransferErrorCollector(writer, "writer", errors, requestFailures);
+		attachTransferErrorCollector(reader, "reader", errors, requestFailures);
 
 		const readSeederCount = async (page: Page, label: string) => {
 			try {
@@ -831,6 +852,15 @@ test.describe("generated transfer-validity benchmark", () => {
 					"Measured transfer duration exceeded its requested timeout and scheduling tolerance",
 				);
 			}
+			const writerDiagnostics = await getDiagnostics(writer);
+			const readerDiagnostics = await getDiagnostics(reader);
+			if (errors.length > 0) {
+				throw new Error(
+					`Observed transfer/delivery errors while collecting diagnostics: ${JSON.stringify(errors)}`,
+				);
+			}
+			const collectedErrors = [...errors];
+			const collectedRequestFailures = [...requestFailures];
 			const result = {
 				schema: RESULT_SCHEMA,
 				runNonce: RUN_NONCE,
@@ -897,16 +927,28 @@ test.describe("generated transfer-validity benchmark", () => {
 				droppedSeeders: dropped,
 				writerVisibilityProbe,
 				readerVisibilityProbe,
-				errorCount: errors.length,
-				errors,
+				errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
+				knownPeerbitFailureSignatures: KNOWN_PEERBIT_FAILURE_SIGNATURES,
+				errorCollectionComplete: true,
+				errorCount: collectedErrors.length,
+				errors: collectedErrors,
+				requestFailureCollectionDefinition:
+					REQUEST_FAILURE_COLLECTION_DEFINITION,
+				requestFailureCollectionComplete: true,
+				requestFailureCount: collectedRequestFailures.length,
+				requestFailures: collectedRequestFailures,
 				snapshots,
-				writerDiagnostics: await getDiagnostics(writer),
-				readerDiagnostics: await getDiagnostics(reader),
+				writerDiagnostics,
+				readerDiagnostics,
 			};
 			await persistResult(result);
 			console.log(`FILE_SHARE_BENCHMARK_RESULT ${JSON.stringify(result)}`);
 		} catch (error: any) {
 			await snapshot(`failure-${stage}`).catch(() => {});
+			const writerDiagnostics = await getDiagnostics(writer);
+			const readerDiagnostics = await getDiagnostics(reader);
+			const collectedErrors = [...errors];
+			const collectedRequestFailures = [...requestFailures];
 			const result = {
 				schema: RESULT_SCHEMA,
 				runNonce: RUN_NONCE,
@@ -939,11 +981,19 @@ test.describe("generated transfer-validity benchmark", () => {
 				droppedSeeders: dropped,
 				writerVisibilityProbe,
 				readerVisibilityProbe,
-				errorCount: errors.length,
-				errors,
+				errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
+				knownPeerbitFailureSignatures: KNOWN_PEERBIT_FAILURE_SIGNATURES,
+				errorCollectionComplete: true,
+				errorCount: collectedErrors.length,
+				errors: collectedErrors,
+				requestFailureCollectionDefinition:
+					REQUEST_FAILURE_COLLECTION_DEFINITION,
+				requestFailureCollectionComplete: true,
+				requestFailureCount: collectedRequestFailures.length,
+				requestFailures: collectedRequestFailures,
 				snapshots,
-				writerDiagnostics: await getDiagnostics(writer),
-				readerDiagnostics: await getDiagnostics(reader),
+				writerDiagnostics,
+				readerDiagnostics,
 				failure: {
 					message:
 						typeof error?.message === "string" ? error.message : String(error),


### PR DESCRIPTION
## Summary

- retain structured evidence for failed, missing, malformed, signaled, and nonzero benchmark invocations
- continue safe counterbalanced repetitions and write honest standalone and matrix outcome counts before exiting nonzero
- fail closed on the complete v3 result, integrity, error-collection, invocation, and independently pinned provenance contracts
- keep Playwright request failures as non-fatal diagnostics while capturing every page error, console error, and known Peerbit failure signature
- recheck harness and Peerbit provenance after every started invocation, including ordinary invocation failures

Follow-up to #1083.

## Verification

- node --test scripts/file-share/*.test.mjs (105/105)
- node --check on benchmark orchestration, validity, standalone runner, and matrix runner
- Prettier check for all changed benchmark files
- git diff --check
- independent exact-commit review: no P0/P1/P2 findings

No changeset: benchmark tooling only.