### PR TITLE
fix(benchmarks): isolate file-share transfer sink timing

### DIFF
--- a/scripts/file-share/README.md
+++ b/scripts/file-share/README.md
@@ -3,7 +3,7 @@
 Run a single checkout with `pnpm bench:file-share:local` or compare pinned
 Peerbit revisions with `pnpm bench:file-share:matrix`.
 
-Result schema v3 defines `errorCount` as every uncaught browser `pageerror`,
+Result schema v4 defines `errorCount` as every uncaught browser `pageerror`,
 every browser `console.error`, every console message at any level that contains
 a declared Peerbit failure signature, and scenario-recorded operation failures.
 Each result embeds the exact `errorCollectionDefinition` and signature list.
@@ -11,15 +11,40 @@ Playwright `requestfailed` events are retained separately under
 `requestFailures`; they are diagnostics and are not automatically fatal because
 peer-to-peer discovery can legitimately exercise failed network candidates.
 
+Upload benchmarks default to `--download-sink hash-only`, which verifies the
+deterministic stream with library SHA-256 plus an independent browser CRC-32
+while discarding each chunk. This keeps one loopback request and filesystem
+write per 512 KiB chunk out of the standardized measurement cohort. Use
+`--download-sink opfs` for browser-native persistence or
+`--download-sink node-file` for the loopback Node-file diagnostic cohort.
+`libraryStreamWallMs` is the authoritative primary download metric only within
+one fixed sink cohort; `hash-only` is the standardized cohort used for revision
+and replication-mode comparisons. Results also retain click-to-sink duration,
+sink-write timing, and `sinkAwaitSubtractedDiagnosticMs`. The latter is only the
+arithmetic wall time minus awaited writes: read-ahead can progress during those
+waits, so it is overlap-sensitive and must not be interpreted as sink-free or
+Peerbit-only time. The validator reconstructs every `readTransfer` field from
+exact canonical per-chunk library series and binds those diagnostics to the
+nonce-derived file name, manifest file ID, and click-to-sink time window.
+Click-to-sink duration ends at the sink's recorded completion epoch, not when
+Playwright later observes the resolved completion promise. OPFS and Node-file
+cohorts require persisted size, SHA-256, and CRC-32 readback. Compare different
+sinks only in separate benchmark sessions; aggregate comparison objects fail
+closed on mixed sinks, and every passed result and aggregate labels
+non-hash-only cohorts non-authoritative.
+
 The standalone runner continues counterbalanced repetitions after an individual
 Playwright or result-validation failure when setup remains usable. Once
 invocation execution begins, it writes a summary with planned, completed,
 passed, and failed counts, then exits nonzero if any repetition failed. A
-preflight, dependency-installation, or build failure can still stop before that
+mode comparison is emitted only when every planned repetition completed and
+passed. A preflight, dependency-installation, or build failure can still stop
+before that
 summary exists. If browser evidence is missing or malformed, the synthetic
 failure uses `errorCount: null` and
 `errorCollectionComplete: false` instead of claiming that zero errors occurred.
 
 The matrix runner also reads nonzero sub-run summaries, keeps their failure
 evidence in the matrix summary, continues later invocations, and exits nonzero
-after writing the aggregate matrix summary when any invocation failed.
+after writing the aggregate matrix summary when any invocation failed. Its
+per-variant and cross-variant comparisons use the same complete-plan gate.

--- a/scripts/file-share/benchmark-invocation.mjs
+++ b/scripts/file-share/benchmark-invocation.mjs
@@ -3,12 +3,18 @@ import { isDeepStrictEqual } from "node:util";
 
 export const BENCHMARK_INVOCATION_SCHEMA = {
 	id: "peerbit-file-share-benchmark-invocation",
-	version: 1,
+	version: 2,
 };
 
 export const TINY_FILE_CUTOFF_BYTES = 5_000_000;
 export const BENCHMARK_SERVER_MODE = "production-preview";
 export const BENCHMARK_SERVER_HOST = "127.0.0.1";
+export const BENCHMARK_DOWNLOAD_SINKS = Object.freeze([
+	"hash-only",
+	"opfs",
+	"node-file",
+]);
+export const DEFAULT_BENCHMARK_DOWNLOAD_SINK = "hash-only";
 
 const DEPLOYED_APP_HARNESS_MESSAGE =
 	"The locally instrumented core benchmark harness cannot use --base-url because it cannot attribute an external deployment to the selected Peerbit checkout; use a dedicated deployed-app benchmark harness that records deployment provenance";
@@ -28,6 +34,23 @@ const asNullableString = (value) => {
 		return null;
 	}
 	return String(value);
+};
+
+export const resolveBenchmarkDownloadSink = (requestedSink, { scenario }) => {
+	const sink = asNullableString(requestedSink);
+	if (scenario !== "upload") {
+		if (sink !== null) {
+			throw new Error("--download-sink is only supported by upload benchmarks");
+		}
+		return null;
+	}
+	const resolved = sink ?? DEFAULT_BENCHMARK_DOWNLOAD_SINK;
+	if (!BENCHMARK_DOWNLOAD_SINKS.includes(resolved)) {
+		throw new Error(
+			`Unsupported benchmark download sink ${JSON.stringify(resolved)}; expected one of ${BENCHMARK_DOWNLOAD_SINKS.join(", ")}`,
+		);
+	}
+	return resolved;
 };
 
 export const resolveBenchmarkPreviewProtocol = (requestedProtocol) => {
@@ -133,6 +156,7 @@ export const createBenchmarkInvocation = ({
 	integrationMode,
 	fileMb,
 	fixtureSeed,
+	downloadSink,
 	uploadTimeoutMs,
 	downloadTimeoutMs,
 	postUploadMonitorMs,
@@ -171,6 +195,9 @@ export const createBenchmarkInvocation = ({
 		viteConfig,
 	});
 	const sizeBytes = assertBenchmarkFileSize({ scenario, fileMb });
+	const resolvedDownloadSink = resolveBenchmarkDownloadSink(downloadSink, {
+		scenario,
+	});
 	if (typeof fixtureSeed !== "string" || fixtureSeed.length === 0) {
 		throw new Error("fixtureSeed must be a non-empty string");
 	}
@@ -221,6 +248,7 @@ export const createBenchmarkInvocation = ({
 		fileSizeMb: fileMb,
 		fileSizeBytes: sizeBytes,
 		fixtureSeed,
+		downloadSink: resolvedDownloadSink,
 		uploadTimeoutMs: resolvedUploadTimeoutMs,
 		downloadTimeoutMs: resolvedDownloadTimeoutMs,
 		postUploadMonitorMs: resolvedPostUploadMonitorMs,
@@ -270,6 +298,7 @@ export const createPlaywrightBenchmarkEnvironment = ({
 		PW_BENCHMARK_PROVENANCE: JSON.stringify(provenance),
 		PW_BENCHMARK_RUN_NONCE: runNonce,
 		PW_BENCHMARK_SCENARIO: invocation.scenario,
+		PW_DOWNLOAD_SINK: stringValue(invocation.downloadSink),
 		PW_DOWNLOAD_TIMEOUT_MS: String(invocation.downloadTimeoutMs),
 		PW_ENABLE_VISIBILITY_PROBE: invocation.enableVisibilityProbe ? "1" : "0",
 		PW_FILE_MB: String(invocation.fileSizeMb),

--- a/scripts/file-share/benchmark-invocation.test.mjs
+++ b/scripts/file-share/benchmark-invocation.test.mjs
@@ -11,6 +11,7 @@ import {
 	createBenchmarkInvocation,
 	createNonceIsolatedResultPath,
 	createPlaywrightBenchmarkEnvironment,
+	resolveBenchmarkDownloadSink,
 	resolveBenchmarkPreviewOptions,
 	resolveBenchmarkPreviewProtocol,
 } from "./benchmark-invocation.mjs";
@@ -44,6 +45,7 @@ test("resolves every default and requested optional knob", () => {
 	});
 	assert.deepEqual(
 		{
+			downloadSink: resolved.downloadSink,
 			uploadTimeoutMs: resolved.uploadTimeoutMs,
 			downloadTimeoutMs: resolved.downloadTimeoutMs,
 			postUploadMonitorMs: resolved.postUploadMonitorMs,
@@ -63,6 +65,7 @@ test("resolves every default and requested optional knob", () => {
 			serverHost: resolved.serverHost,
 		},
 		{
+			downloadSink: "hash-only",
 			uploadTimeoutMs: 101,
 			downloadTimeoutMs: 202,
 			postUploadMonitorMs: 303,
@@ -104,6 +107,7 @@ test("removes all ambient PW variables and installs the exact invocation", () =>
 			E2E_PORT: "9998",
 			PW_BASE_URL: "https://attacker.invalid",
 			PW_FILE_MB: "999",
+			PW_DOWNLOAD_SINK: "node-file",
 			PW_POST_UPLOAD_MONITOR_MS: "0",
 			PW_PORT: "4444",
 			PW_PROTOCOL: "https",
@@ -123,6 +127,7 @@ test("removes all ambient PW variables and installs the exact invocation", () =>
 	assert.equal(environment.PW_BASE_URL, "");
 	assert.equal(environment.HOST, "127.0.0.1");
 	assert.equal(environment.PW_FILE_MB, "5");
+	assert.equal(environment.PW_DOWNLOAD_SINK, "hash-only");
 	assert.equal(environment.PW_POST_UPLOAD_MONITOR_MS, "5000");
 	assert.equal(environment.PW_FUTURE_BYPASS, undefined);
 	assert.equal(environment.PW_PORT, undefined);
@@ -131,6 +136,33 @@ test("removes all ambient PW variables and installs the exact invocation", () =>
 	assert.equal(environment.PW_VITE_CONFIG, "");
 	assert.equal(environment.PW_VITE_MODE, "");
 	assert.deepEqual(JSON.parse(environment.PW_BENCHMARK_INVOCATION), resolved);
+});
+
+test("defaults to the hash-only sink and validates explicit sink cohorts", () => {
+	assert.equal(
+		resolveBenchmarkDownloadSink(undefined, { scenario: "upload" }),
+		"hash-only",
+	);
+	for (const sink of ["hash-only", "opfs", "node-file"]) {
+		assert.equal(invocation({ downloadSink: sink }).downloadSink, sink);
+	}
+	assert.throws(
+		() => invocation({ downloadSink: "browser-download" }),
+		/Unsupported benchmark download sink/,
+	);
+	assert.equal(
+		invocation({ scenario: "seeder-probe", fileMb: 1 }).downloadSink,
+		null,
+	);
+	assert.throws(
+		() =>
+			invocation({
+				scenario: "seeder-probe",
+				fileMb: 1,
+				downloadSink: "hash-only",
+			}),
+		/only supported by upload benchmarks/,
+	);
 });
 
 test("upload benchmarks cannot exercise the TinyFile path", () => {
@@ -276,6 +308,10 @@ test("standalone runner rejects invalid integration modes before mutating output
 	try {
 		for (const [args, error] of [
 			[["--integration-mode", "overlay"], /Unsupported --integration-mode/],
+			[
+				["--download-sink", "browser-download"],
+				/Unsupported benchmark download sink/,
+			],
 			[
 				["--integration-mode", "link", "--local-packages", ","],
 				/link integration requires at least one local Peerbit package/,

--- a/scripts/file-share/benchmark-orchestration.mjs
+++ b/scripts/file-share/benchmark-orchestration.mjs
@@ -2,17 +2,17 @@ import fsp from "node:fs/promises";
 
 export const BENCHMARK_RESULT_SCHEMA = Object.freeze({
 	id: "peerbit-file-share-benchmark",
-	version: 3,
+	version: 4,
 });
 
 export const BENCHMARK_SUMMARY_SCHEMA = Object.freeze({
 	id: "peerbit-file-share-benchmark-summary",
-	version: 3,
+	version: 4,
 });
 
 export const MATRIX_SUMMARY_SCHEMA = Object.freeze({
 	id: "peerbit-file-share-matrix-summary",
-	version: 3,
+	version: 4,
 });
 
 export const KNOWN_PEERBIT_FAILURE_SIGNATURES = Object.freeze([

--- a/scripts/file-share/benchmark-provenance.mjs
+++ b/scripts/file-share/benchmark-provenance.mjs
@@ -110,6 +110,13 @@ export const assertExamplesBenchmarkContract = async (examplesRoot) => {
 		"package.json",
 		"pnpm-lock.yaml",
 		path.join("packages", "file-share", "frontend", "tests", "helpers.ts"),
+		path.join(
+			"packages",
+			"file-share",
+			"frontend",
+			"tests",
+			"transfer-benchmark.ts",
+		),
 		path.join("packages", "file-share", "frontend", "src", "Drop.tsx"),
 	];
 	for (const relativePath of requiredFiles) {
@@ -134,6 +141,9 @@ export const assertExamplesBenchmarkContract = async (examplesRoot) => {
 		"createSyntheticFileOnDisk",
 		"sha256AndCrc32File",
 		"armSavedViaPicker",
+		"crc32SavedViaPicker",
+		"installHashOnlyMockSaveFilePicker",
+		"installMockSaveFilePicker",
 		"installNodeBackedMockSaveFilePicker",
 		"waitForUploadComplete",
 	]) {
@@ -143,6 +153,31 @@ export const assertExamplesBenchmarkContract = async (examplesRoot) => {
 			).test(helpers)
 		) {
 			throw new Error(`Examples source is missing benchmark helper ${helper}`);
+		}
+	}
+	const transferBenchmark = await fsp.readFile(
+		path.join(
+			examplesRoot,
+			"packages",
+			"file-share",
+			"frontend",
+			"tests",
+			"transfer-benchmark.ts",
+		),
+		"utf8",
+	);
+	for (const helper of [
+		"resolveBenchmarkDownloadSink",
+		"summarizeReadTransferDiagnostics",
+	]) {
+		if (
+			!new RegExp(
+				`export\\s+(?:async\\s+)?(?:function|const)\\s+${helper}\\b`,
+			).test(transferBenchmark)
+		) {
+			throw new Error(
+				`Examples source is missing benchmark transfer helper ${helper}`,
+			);
 		}
 	}
 	const drop = await fsp.readFile(

--- a/scripts/file-share/benchmark-provenance.test.mjs
+++ b/scripts/file-share/benchmark-provenance.test.mjs
@@ -33,8 +33,19 @@ const createExamplesRepository = async () => {
 			"export const createSyntheticFileOnDisk = () => {};",
 			"export const sha256AndCrc32File = () => {};",
 			"export const armSavedViaPicker = () => {};",
+			"export const crc32SavedViaPicker = () => {};",
+			"export const installHashOnlyMockSaveFilePicker = () => {};",
+			"export const installMockSaveFilePicker = () => {};",
 			"export const installNodeBackedMockSaveFilePicker = () => {};",
 			"export const waitForUploadComplete = () => {};",
+			"",
+		].join("\n"),
+	);
+	await writeFile(
+		path.join(frontend, "tests", "transfer-benchmark.ts"),
+		[
+			"export const resolveBenchmarkDownloadSink = () => 'hash-only';",
+			"export const summarizeReadTransferDiagnostics = () => ({});",
 			"",
 		].join("\n"),
 	);

--- a/scripts/file-share/benchmark-summary.mjs
+++ b/scripts/file-share/benchmark-summary.mjs
@@ -1,6 +1,8 @@
 const round = (value) => Number(value.toFixed(1));
 const TIMING_DISTRIBUTION_DEFINITION =
 	"avg/min/max and linearly interpolated p25/median/p75 over passed runs only";
+export const PRIMARY_DOWNLOAD_METRIC = "libraryStreamWallMs";
+export const STANDARD_PRIMARY_DOWNLOAD_SINK = "hash-only";
 
 const average = (values) =>
 	values.length > 0
@@ -77,8 +79,28 @@ export const summarizeUploadPerformance = (results) => {
 	const downloadDuration = summarizeDistribution(
 		passedNumbers(results, (result) => result.downloadDurationMs),
 	);
+	const libraryStreamWall = summarizeDistribution(
+		passedNumbers(results, (result) => result.libraryStreamWallMs),
+	);
+	const sinkWriteAwait = summarizeDistribution(
+		passedNumbers(results, (result) => result.sinkWriteAwaitMs),
+	);
+	const sinkAwaitSubtractedDiagnostic = summarizeDistribution(
+		passedNumbers(results, (result) => result.sinkAwaitSubtractedDiagnosticMs),
+	);
+	const passedDownloadSinks = new Set(
+		results
+			.filter((result) => result.status === "passed")
+			.map((result) => result.downloadSink),
+	);
+	const downloadSink =
+		passedDownloadSinks.size === 1 ? [...passedDownloadSinks][0] : null;
 	return {
 		timingDistributionDefinition: TIMING_DISTRIBUTION_DEFINITION,
+		primaryDownloadMetric: PRIMARY_DOWNLOAD_METRIC,
+		downloadSink,
+		primaryDownloadAuthoritative:
+			downloadSink === STANDARD_PRIMARY_DOWNLOAD_SINK,
 		...flattenDistribution("uploadDurationMs", uploadDuration),
 		...flattenDistribution("timeToWriterReadyMs", timeToWriterReady),
 		...flattenDistribution("timeToReaderReadyMs", timeToReaderReady),
@@ -89,6 +111,12 @@ export const summarizeUploadPerformance = (results) => {
 			postSettlementListingDuration,
 		),
 		...flattenDistribution("downloadDurationMs", downloadDuration),
+		...flattenDistribution("libraryStreamWallMs", libraryStreamWall),
+		...flattenDistribution("sinkWriteAwaitMs", sinkWriteAwait),
+		...flattenDistribution(
+			"sinkAwaitSubtractedDiagnosticMs",
+			sinkAwaitSubtractedDiagnostic,
+		),
 	};
 };
 
@@ -109,6 +137,14 @@ const compareModeMetric = (adaptiveResults, fixedResults, getter) => {
 };
 
 export const compareUploadPerformanceModes = (results) => {
+	const passedResults = results.filter((result) => result.status === "passed");
+	const downloadSinks = new Set(
+		passedResults.map((result) => result.downloadSink),
+	);
+	if (downloadSinks.size !== 1) {
+		return null;
+	}
+	const downloadSink = [...downloadSinks][0];
 	const adaptive = results.filter((result) => result.mode === "adaptive");
 	const fixed1 = results.filter((result) => result.mode === "fixed1");
 	const upload = compareModeMetric(
@@ -126,10 +162,19 @@ export const compareUploadPerformanceModes = (results) => {
 		fixed1,
 		(result) => result.timeToReaderReadyMs,
 	);
-	if (!upload || !writerReady || !readerReady) {
+	const primaryDownload = compareModeMetric(
+		adaptive,
+		fixed1,
+		(result) => result.libraryStreamWallMs,
+	);
+	if (!upload || !writerReady || !readerReady || !primaryDownload) {
 		return null;
 	}
 	return {
+		downloadSink,
+		primaryDownloadMetric: PRIMARY_DOWNLOAD_METRIC,
+		primaryDownloadAuthoritative:
+			downloadSink === STANDARD_PRIMARY_DOWNLOAD_SINK,
 		adaptiveAvgMs: upload.adaptiveAvgMs,
 		fixed1AvgMs: upload.fixed1AvgMs,
 		deltaMs: upload.deltaMs,
@@ -142,8 +187,30 @@ export const compareUploadPerformanceModes = (results) => {
 		fixed1ReaderReadyAvgMs: readerReady.fixed1AvgMs,
 		readerReadyDeltaMs: readerReady.deltaMs,
 		adaptiveVsFixed1ReaderReadyPct: readerReady.adaptiveVsFixed1Pct,
+		adaptiveLibraryStreamWallAvgMs: primaryDownload.adaptiveAvgMs,
+		fixed1LibraryStreamWallAvgMs: primaryDownload.fixed1AvgMs,
+		libraryStreamWallDeltaMs: primaryDownload.deltaMs,
+		adaptiveVsFixed1LibraryStreamWallPct: primaryDownload.adaptiveVsFixed1Pct,
 	};
 };
+
+export const isCompletePassedBenchmarkPlan = (results, outcomeCounts) =>
+	Array.isArray(results) &&
+	Number.isSafeInteger(outcomeCounts?.planned) &&
+	outcomeCounts.planned > 0 &&
+	outcomeCounts.completed === outcomeCounts.planned &&
+	outcomeCounts.passed === outcomeCounts.planned &&
+	outcomeCounts.failed === 0 &&
+	results.length === outcomeCounts.planned &&
+	results.every((result) => result.status === "passed");
+
+export const compareUploadPerformanceModesForCompletePlan = (
+	results,
+	outcomeCounts,
+) =>
+	isCompletePassedBenchmarkPlan(results, outcomeCounts)
+		? compareUploadPerformanceModes(results)
+		: null;
 
 export const uploadTimingTableColumns = (result) => ({
 	timeToWriterReadyMs: result.timeToWriterReadyMs ?? null,

--- a/scripts/file-share/benchmark-summary.test.mjs
+++ b/scripts/file-share/benchmark-summary.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
 	compareUploadPerformanceModes,
+	compareUploadPerformanceModesForCompletePlan,
+	isCompletePassedBenchmarkPlan,
 	summarizeUploadPerformance,
 	uploadTimingTableColumns,
 } from "./benchmark-summary.mjs";
@@ -15,6 +17,11 @@ test("propagates end-to-end readiness and labels post-settlement listing", () =>
 			timeToReaderReadyMs: 140,
 			listingDurationMs: 20,
 			downloadDurationMs: 50,
+			libraryStreamWallMs: 45,
+			sinkWriteAwaitMs: 5,
+			sinkAwaitSubtractedDiagnosticMs: 40,
+			downloadSink: "hash-only",
+			sinkWriteDurationMs: 4,
 		},
 		{
 			status: "passed",
@@ -23,6 +30,11 @@ test("propagates end-to-end readiness and labels post-settlement listing", () =>
 			timeToReaderReadyMs: 260,
 			listingDurationMs: 40,
 			downloadDurationMs: 70,
+			libraryStreamWallMs: 65,
+			sinkWriteAwaitMs: 15,
+			sinkAwaitSubtractedDiagnosticMs: 50,
+			downloadSink: "hash-only",
+			sinkWriteDurationMs: 14,
 		},
 		{
 			status: "failed",
@@ -35,6 +47,9 @@ test("propagates end-to-end readiness and labels post-settlement listing", () =>
 	assert.deepEqual(summarizeUploadPerformance(results), {
 		timingDistributionDefinition:
 			"avg/min/max and linearly interpolated p25/median/p75 over passed runs only",
+		primaryDownloadMetric: "libraryStreamWallMs",
+		downloadSink: "hash-only",
+		primaryDownloadAuthoritative: true,
 		uploadDurationMsAvg: 100,
 		uploadDurationMsP25: 90,
 		uploadDurationMsMedian: 100,
@@ -66,12 +81,79 @@ test("propagates end-to-end readiness and labels post-settlement listing", () =>
 		downloadDurationMsP75: 65,
 		downloadDurationMsMin: 50,
 		downloadDurationMsMax: 70,
+		libraryStreamWallMsAvg: 55,
+		libraryStreamWallMsP25: 50,
+		libraryStreamWallMsMedian: 55,
+		libraryStreamWallMsP75: 60,
+		libraryStreamWallMsMin: 45,
+		libraryStreamWallMsMax: 65,
+		sinkWriteAwaitMsAvg: 10,
+		sinkWriteAwaitMsP25: 7.5,
+		sinkWriteAwaitMsMedian: 10,
+		sinkWriteAwaitMsP75: 12.5,
+		sinkWriteAwaitMsMin: 5,
+		sinkWriteAwaitMsMax: 15,
+		sinkAwaitSubtractedDiagnosticMsAvg: 45,
+		sinkAwaitSubtractedDiagnosticMsP25: 42.5,
+		sinkAwaitSubtractedDiagnosticMsMedian: 45,
+		sinkAwaitSubtractedDiagnosticMsP75: 47.5,
+		sinkAwaitSubtractedDiagnosticMsMin: 40,
+		sinkAwaitSubtractedDiagnosticMsMax: 50,
 	});
 	assert.deepEqual(uploadTimingTableColumns(results[0]), {
 		timeToWriterReadyMs: 100,
 		timeToReaderReadyMs: 140,
 		postSettlementListingMs: 20,
 	});
+});
+
+test("suppresses mode comparisons unless the entire planned cohort passed", () => {
+	const passed = [
+		{
+			status: "passed",
+			mode: "adaptive",
+			uploadDurationMs: 80,
+			timeToWriterReadyMs: 70,
+			timeToReaderReadyMs: 120,
+			libraryStreamWallMs: 40,
+			downloadSink: "hash-only",
+		},
+		{
+			status: "passed",
+			mode: "fixed1",
+			uploadDurationMs: 100,
+			timeToWriterReadyMs: 80,
+			timeToReaderReadyMs: 150,
+			libraryStreamWallMs: 50,
+			downloadSink: "hash-only",
+		},
+	];
+	const complete = { planned: 2, completed: 2, passed: 2, failed: 0 };
+	assert.equal(isCompletePassedBenchmarkPlan(passed, complete), true);
+	assert.deepEqual(
+		compareUploadPerformanceModesForCompletePlan(passed, complete),
+		compareUploadPerformanceModes(passed),
+	);
+
+	const failed = [passed[0], { ...passed[1], status: "failed" }];
+	assert.equal(
+		compareUploadPerformanceModesForCompletePlan(failed, {
+			planned: 2,
+			completed: 2,
+			passed: 1,
+			failed: 1,
+		}),
+		null,
+	);
+	assert.equal(
+		compareUploadPerformanceModesForCompletePlan([passed[0]], {
+			planned: 2,
+			completed: 1,
+			passed: 1,
+			failed: 0,
+		}),
+		null,
+	);
 });
 
 test("compares modes using upload and end-to-end readiness", () => {
@@ -83,6 +165,8 @@ test("compares modes using upload and end-to-end readiness", () => {
 				uploadDurationMs: 80,
 				timeToWriterReadyMs: 70,
 				timeToReaderReadyMs: 120,
+				libraryStreamWallMs: 40,
+				downloadSink: "hash-only",
 			},
 			{
 				status: "passed",
@@ -90,9 +174,14 @@ test("compares modes using upload and end-to-end readiness", () => {
 				uploadDurationMs: 100,
 				timeToWriterReadyMs: 80,
 				timeToReaderReadyMs: 150,
+				libraryStreamWallMs: 50,
+				downloadSink: "hash-only",
 			},
 		]),
 		{
+			downloadSink: "hash-only",
+			primaryDownloadMetric: "libraryStreamWallMs",
+			primaryDownloadAuthoritative: true,
 			adaptiveAvgMs: 80,
 			fixed1AvgMs: 100,
 			deltaMs: -20,
@@ -105,6 +194,36 @@ test("compares modes using upload and end-to-end readiness", () => {
 			fixed1ReaderReadyAvgMs: 150,
 			readerReadyDeltaMs: -30,
 			adaptiveVsFixed1ReaderReadyPct: -20,
+			adaptiveLibraryStreamWallAvgMs: 40,
+			fixed1LibraryStreamWallAvgMs: 50,
+			libraryStreamWallDeltaMs: -10,
+			adaptiveVsFixed1LibraryStreamWallPct: -20,
 		},
+	);
+});
+
+test("never compares primary downloads across sink cohorts", () => {
+	assert.equal(
+		compareUploadPerformanceModes([
+			{
+				status: "passed",
+				mode: "adaptive",
+				downloadSink: "hash-only",
+				uploadDurationMs: 80,
+				timeToWriterReadyMs: 70,
+				timeToReaderReadyMs: 120,
+				libraryStreamWallMs: 40,
+			},
+			{
+				status: "passed",
+				mode: "fixed1",
+				downloadSink: "opfs",
+				uploadDurationMs: 100,
+				timeToWriterReadyMs: 80,
+				timeToReaderReadyMs: 150,
+				libraryStreamWallMs: 50,
+			},
+		]),
+		null,
 	);
 });

--- a/scripts/file-share/benchmark-validity.mjs
+++ b/scripts/file-share/benchmark-validity.mjs
@@ -25,6 +25,29 @@ const TIME_TO_READER_READY_DEFINITION =
 	"upload-input-set-to-reader-ready-manifest-listed";
 const LISTING_DURATION_DEFINITION =
 	"post-upload-settlement-to-both-writer-and-reader-ready-manifests-listed; excludes upload time";
+const DOWNLOAD_DURATION_DEFINITION =
+	"reader-download-click-to-selected-backpressured-sink-complete";
+const SINK_WRITE_DURATION_DEFINITION =
+	"sum of browser writable.write wall-clock durations; library read diagnostics provide the authoritative awaited sink-write interval";
+const SINK_SERVER_WRITE_DURATION_DEFINITION =
+	"loopback-request-body-receive-and-node-filesystem-write-only";
+const LIBRARY_STREAM_WALL_DEFINITION =
+	"library-large-file-stream-start-to-finish including awaited sink writes";
+const SINK_WRITE_AWAIT_DEFINITION =
+	"sum of per-chunk library wall-clock intervals awaiting writable.write";
+const SINK_AWAIT_SUBTRACTED_DIAGNOSTIC_DEFINITION =
+	"arithmetic library stream wall-clock duration minus summed awaited writable.write intervals; overlap-sensitive and not a sink-independent Peerbit duration";
+const PRIMARY_DOWNLOAD_METRIC = "libraryStreamWallMs";
+const PRIMARY_DOWNLOAD_METRIC_DEFINITION =
+	"authoritative only within one fixed download-sink cohort; hash-only is the standardized primary cohort and includes awaited sink writes plus any overlapping read-ahead";
+const DEMAND_WAIT_DEFINITION =
+	"wall-clock time each sequential stream consumer awaited its scheduled chunk";
+// Date.now() endpoints can undercount the nested performance.now() helper
+// interval by less than one millisecond for each chunk.
+const SINK_WRITE_QUANTIZATION_ALLOWANCE_MS_PER_CHUNK = 1;
+// Browser performance.now() and Node hrtime measure nested intervals on
+// independent monotonic clocks; keep their aggregate drift finite per call.
+const SINK_SERVER_CLOCK_TOLERANCE_MS_PER_CHUNK = 1;
 
 const isRecord = (value) =>
 	value != null && typeof value === "object" && !Array.isArray(value);
@@ -50,6 +73,20 @@ const requireNonNegativeNumber = (value, label) => {
 	return value;
 };
 
+export const calculateSinkAwaitSubtractedDiagnosticMs = ({
+	libraryStreamWallMs,
+	sinkWriteAwaitMs,
+}) => {
+	requireNonNegativeNumber(libraryStreamWallMs, "libraryStreamWallMs");
+	requireNonNegativeNumber(sinkWriteAwaitMs, "sinkWriteAwaitMs");
+	if (sinkWriteAwaitMs > libraryStreamWallMs) {
+		throw new Error(
+			"Benchmark sink-write intervals exceed the library stream wall time",
+		);
+	}
+	return libraryStreamWallMs - sinkWriteAwaitMs;
+};
+
 const requirePositiveNumber = (value, label) => {
 	const parsed = requireNonNegativeNumber(value, label);
 	if (parsed <= 0) {
@@ -70,6 +107,14 @@ const requireNonNegativeSafeInteger = (value, label) => {
 		throw new Error(`Benchmark result has invalid ${label}`);
 	}
 	return value;
+};
+
+const requirePositiveSafeInteger = (value, label) => {
+	const parsed = requireNonNegativeSafeInteger(value, label);
+	if (parsed <= 0) {
+		throw new Error(`Benchmark result has non-positive ${label}`);
+	}
+	return parsed;
 };
 
 const requirePattern = (value, pattern, label) => {
@@ -108,6 +153,7 @@ const validateUploadIntegrity = (
 	result,
 	expectedFileMb,
 	expectedFixtureSeed,
+	invocation,
 ) => {
 	const integrity = requireRecord(result.integrity, "integrity");
 	if (integrity.fixtureMode !== "deterministic") {
@@ -144,17 +190,62 @@ const validateUploadIntegrity = (
 		SHA256_BASE64_PATTERN,
 		"integrity.manifestSha256Base64",
 	);
-	const downloadedSha256 = requirePattern(
-		integrity.downloadedSha256Base64,
+	const librarySha256 = requirePattern(
+		integrity.libraryComputedSha256Base64,
 		SHA256_BASE64_PATTERN,
-		"integrity.downloadedSha256Base64",
+		"integrity.libraryComputedSha256Base64",
 	);
 	if (
 		integrity.sha256Verified !== true ||
+		integrity.librarySha256Verified !== true ||
 		sourceSha256 !== manifestSha256 ||
-		sourceSha256 !== downloadedSha256
+		sourceSha256 !== librarySha256
 	) {
 		throw new Error("Benchmark result failed its SHA-256 integrity gate");
+	}
+	if (
+		result.downloadSink !== invocation.downloadSink ||
+		result.requestedDownloadSink !== invocation.downloadSink ||
+		integrity.downloadSink !== invocation.downloadSink
+	) {
+		throw new Error(
+			"Benchmark result download sink does not match the requested invocation",
+		);
+	}
+	if (["opfs", "node-file"].includes(invocation.downloadSink)) {
+		const downloadedSha256 = requirePattern(
+			integrity.downloadedSha256Base64,
+			SHA256_BASE64_PATTERN,
+			"integrity.downloadedSha256Base64",
+		);
+		if (
+			downloadedSha256 !== sourceSha256 ||
+			integrity.persistedSinkSha256Verified !== true ||
+			integrity.sinkPersistence !== invocation.downloadSink ||
+			integrity.sinkPersistenceVerified !== true
+		) {
+			throw new Error(
+				`Benchmark result failed its persisted ${invocation.downloadSink} SHA-256 integrity gate`,
+			);
+		}
+	} else {
+		if (
+			integrity.downloadedSha256Base64 !== null ||
+			integrity.persistedSinkSha256Verified !== null
+		) {
+			throw new Error(
+				"Hash-only benchmark sink must not claim persisted SHA-256 evidence",
+			);
+		}
+		if (
+			invocation.downloadSink !== "hash-only" ||
+			integrity.sinkPersistence !== "none" ||
+			integrity.sinkPersistenceVerified !== null
+		) {
+			throw new Error(
+				"Hash-only benchmark sink must not claim file persistence",
+			);
+		}
 	}
 
 	const sourceCrc32 = requirePattern(
@@ -175,11 +266,362 @@ const validateUploadIntegrity = (
 	}
 };
 
-const validateUploadTimings = (result, invocation) => {
-	if (result.downloadSink !== "node-file") {
+const requireExactDiagnosticSeries = (
+	diagnostics,
+	name,
+	indices,
+	requireValue = requireNonNegativeNumber,
+) => {
+	const record = requireRecord(diagnostics[name], `readerDiagnostics.${name}`);
+	const expectedKeys = indices.map(String);
+	const expectedKeySet = new Set(expectedKeys);
+	const actualKeys = Object.keys(record);
+	if (
+		actualKeys.length !== expectedKeys.length ||
+		expectedKeys.some((key) => !Object.hasOwn(record, key)) ||
+		actualKeys.some((key) => !expectedKeySet.has(key))
+	) {
 		throw new Error(
-			"Benchmark result did not use the persisted Node file sink",
+			`Benchmark readerDiagnostics.${name} must use the exact canonical chunk keys`,
 		);
+	}
+	return indices.map((index) =>
+		requireValue(record[index], `readerDiagnostics.${name}[${index}]`),
+	);
+};
+
+const nearestRank = (values, percentile) => {
+	const sorted = [...values].toSorted((left, right) => left - right);
+	return sorted[Math.ceil((percentile / 100) * sorted.length) - 1];
+};
+
+const sum = (values) => values.reduce((total, value) => total + value, 0);
+
+const requireBoundedDiagnosticIntervals = ({
+	diagnostics,
+	indices,
+	startedName,
+	finishedName,
+	readStartedAt,
+	readFinishedAt,
+	ordered = false,
+}) => {
+	const started = requireExactDiagnosticSeries(
+		diagnostics,
+		startedName,
+		indices,
+		requireNonNegativeSafeInteger,
+	);
+	const finished = requireExactDiagnosticSeries(
+		diagnostics,
+		finishedName,
+		indices,
+		requireNonNegativeSafeInteger,
+	);
+	const durations = [];
+	for (const [offset, index] of indices.entries()) {
+		if (
+			started[offset] < readStartedAt ||
+			finished[offset] > readFinishedAt ||
+			finished[offset] < started[offset]
+		) {
+			throw new Error(
+				`Benchmark ${startedName}/${finishedName} interval for chunk ${index} is outside the library read window`,
+			);
+		}
+		if (ordered && offset > 0 && started[offset] < finished[offset - 1]) {
+			throw new Error(
+				"Benchmark chunk sink-write intervals must be ordered and non-overlapping",
+			);
+		}
+		durations.push(finished[offset] - started[offset]);
+	}
+	return { started, finished, durations };
+};
+
+const validateReadTransferEvidence = (
+	result,
+	invocation,
+	{ downloadStartedAt, downloadFinishedAt },
+) => {
+	const readerDiagnostics = requireRecord(
+		result.readerDiagnostics,
+		"readerDiagnostics",
+	);
+	const diagnostics = requireRecord(
+		readerDiagnostics.lastReadDiagnostics,
+		"readerDiagnostics.lastReadDiagnostics",
+	);
+	const resolved = requireRecord(
+		diagnostics.chunkResolved,
+		"readerDiagnostics.chunkResolved",
+	);
+	const resolvedKeys = Object.keys(resolved);
+	const indices = resolvedKeys
+		.map((key) => Number(key))
+		.toSorted((left, right) => left - right);
+	if (
+		indices.length < 2 ||
+		resolvedKeys.some((key) => !/^(?:0|[1-9]\d*)$/.test(key)) ||
+		indices.some(
+			(index, offset) => !Number.isSafeInteger(index) || index !== offset,
+		)
+	) {
+		throw new Error(
+			"Benchmark large-file read diagnostics must contain at least two contiguous canonical chunk indices",
+		);
+	}
+	const startedAt = requirePositiveSafeInteger(
+		diagnostics.startedAt,
+		"readerDiagnostics.startedAt",
+	);
+	const finishedAt = requirePositiveSafeInteger(
+		diagnostics.finishedAt,
+		"readerDiagnostics.finishedAt",
+	);
+	if (
+		startedAt < downloadStartedAt ||
+		finishedAt < startedAt ||
+		finishedAt > downloadFinishedAt
+	) {
+		throw new Error(
+			"Benchmark library read window is outside the clicked download window",
+		);
+	}
+	const expectedFileName = `file-share-benchmark-${result.mode}-${result.runNonce}.bin`;
+	const writerManifest = requireRecord(
+		result.writerManifestEvidence,
+		"writerManifestEvidence",
+	);
+	const readerManifest = requireRecord(
+		result.readerManifestEvidence,
+		"readerManifestEvidence",
+	);
+	const writerFileId = requireString(
+		writerManifest.fileId,
+		"writerManifestEvidence.fileId",
+	);
+	const readerFileId = requireString(
+		readerManifest.fileId,
+		"readerManifestEvidence.fileId",
+	);
+	if (
+		result.fileName !== expectedFileName ||
+		diagnostics.fileName !== expectedFileName ||
+		writerManifest.fileName !== expectedFileName ||
+		readerManifest.fileName !== expectedFileName ||
+		writerFileId !== readerFileId ||
+		diagnostics.fileId !== readerFileId
+	) {
+		throw new Error(
+			"Benchmark library read identity does not match the clicked file manifest",
+		);
+	}
+	requireString(diagnostics.transferId, "readerDiagnostics.transferId");
+
+	const chunkBytes = requireExactDiagnosticSeries(
+		diagnostics,
+		"chunkByteLength",
+		indices,
+		requireNonNegativeSafeInteger,
+	);
+	if (chunkBytes.some((value) => value <= 0)) {
+		throw new Error(
+			"Benchmark read diagnostics contain invalid chunk byte lengths",
+		);
+	}
+	const totalBytes = chunkBytes.reduce((sum, value) => sum + value, 0);
+	if (totalBytes !== invocation.fileSizeBytes) {
+		throw new Error(
+			"Benchmark read diagnostics do not cover the requested file size",
+		);
+	}
+	const sourceSummary = {};
+	for (const [offset, index] of indices.entries()) {
+		const source = requireString(
+			resolved[index],
+			`readerDiagnostics.chunkResolved[${index}]`,
+		);
+		const current = (sourceSummary[source] ??= { chunkCount: 0, bytes: 0 });
+		current.chunkCount += 1;
+		current.bytes += chunkBytes[offset];
+	}
+	const demandWaitMs = requireExactDiagnosticSeries(
+		diagnostics,
+		"chunkDemandWaitMs",
+		indices,
+		requireNonNegativeSafeInteger,
+	);
+	const writeIntervals = requireBoundedDiagnosticIntervals({
+		diagnostics,
+		indices,
+		startedName: "chunkWriteStartedAt",
+		finishedName: "chunkWriteFinishedAt",
+		readStartedAt: startedAt,
+		readFinishedAt: finishedAt,
+		ordered: true,
+	});
+	const materializeIntervals = requireBoundedDiagnosticIntervals({
+		diagnostics,
+		indices,
+		startedName: "chunkMaterializeStartedAt",
+		finishedName: "chunkMaterializeFinishedAt",
+		readStartedAt: startedAt,
+		readFinishedAt: finishedAt,
+	});
+	const hashIntervals = requireBoundedDiagnosticIntervals({
+		diagnostics,
+		indices,
+		startedName: "chunkHashStartedAt",
+		finishedName: "chunkHashFinishedAt",
+		readStartedAt: startedAt,
+		readFinishedAt: finishedAt,
+	});
+	const libraryStreamWallMs = finishedAt - startedAt;
+	const sinkWriteAwaitMs = sum(writeIntervals.durations);
+	const sinkAwaitSubtractedDiagnosticMs =
+		calculateSinkAwaitSubtractedDiagnosticMs({
+			libraryStreamWallMs,
+			sinkWriteAwaitMs,
+		});
+	const demandWaitSumMs = sum(demandWaitMs);
+	const materializeSumMs = sum(materializeIntervals.durations);
+	const contentHashSumMs = sum(hashIntervals.durations);
+	const sortedSourceSummary = Object.fromEntries(
+		Object.entries(sourceSummary).sort(([left], [right]) =>
+			left.localeCompare(right),
+		),
+	);
+	const expectedReadTransfer = {
+		chunkCount: indices.length,
+		totalBytes,
+		sources: sortedSourceSummary,
+		demandWait: {
+			definition: DEMAND_WAIT_DEFINITION,
+			sampleCount: demandWaitMs.length,
+			sumMs: demandWaitSumMs,
+			p50Ms: nearestRank(demandWaitMs, 50),
+			p95Ms: nearestRank(demandWaitMs, 95),
+			p99Ms: nearestRank(demandWaitMs, 99),
+			maxMs: Math.max(...demandWaitMs),
+			over1sCount: demandWaitMs.filter((value) => value > 1_000).length,
+			over5sCount: demandWaitMs.filter((value) => value > 5_000).length,
+			over10sCount: demandWaitMs.filter((value) => value > 10_000).length,
+		},
+		stages: {
+			libraryStreamWallMs,
+			sinkWriteAwaitMs,
+			sinkAwaitSubtractedDiagnosticMs,
+			demandWaitMs: demandWaitSumMs,
+			materializeMs: materializeSumMs,
+			contentHashMs: contentHashSumMs,
+			otherStreamReadMs: Math.max(
+				0,
+				sinkAwaitSubtractedDiagnosticMs -
+					demandWaitSumMs -
+					materializeSumMs -
+					contentHashSumMs,
+			),
+		},
+	};
+	if (
+		!isDeepStrictEqual(result.readTransfer, expectedReadTransfer) ||
+		result.libraryStreamWallMs !== libraryStreamWallMs ||
+		result.sinkWriteAwaitMs !== sinkWriteAwaitMs ||
+		result.sinkAwaitSubtractedDiagnosticMs !== sinkAwaitSubtractedDiagnosticMs
+	) {
+		throw new Error(
+			"Benchmark result read-transfer timing decomposition is inconsistent",
+		);
+	}
+	const computedFinalHash = requirePattern(
+		diagnostics.computedFinalHash,
+		SHA256_BASE64_PATTERN,
+		"readerDiagnostics.computedFinalHash",
+	);
+	if (computedFinalHash !== result.integrity.libraryComputedSha256Base64) {
+		throw new Error(
+			"Benchmark raw reader SHA-256 contradicts its integrity evidence",
+		);
+	}
+	if (
+		result.libraryStreamWallDefinition !== LIBRARY_STREAM_WALL_DEFINITION ||
+		result.sinkWriteAwaitDefinition !== SINK_WRITE_AWAIT_DEFINITION ||
+		result.sinkAwaitSubtractedDiagnosticDefinition !==
+			SINK_AWAIT_SUBTRACTED_DIAGNOSTIC_DEFINITION ||
+		result.primaryDownloadMetric !== PRIMARY_DOWNLOAD_METRIC ||
+		result.primaryDownloadAuthoritative !==
+			(invocation.downloadSink === "hash-only") ||
+		result.primaryDownloadMetricDefinition !==
+			PRIMARY_DOWNLOAD_METRIC_DEFINITION
+	) {
+		throw new Error(
+			"Benchmark result read-transfer timing definitions are invalid",
+		);
+	}
+	const sinkWriteCalls = requireNonNegativeSafeInteger(
+		result.sinkWriteCalls,
+		"sinkWriteCalls",
+	);
+	if (sinkWriteCalls !== indices.length || sinkWriteCalls === 0) {
+		throw new Error(
+			"Benchmark sink write count does not match the read chunk count",
+		);
+	}
+	if (result.sinkWriteDurationDefinition !== SINK_WRITE_DURATION_DEFINITION) {
+		throw new Error("Benchmark sink-write duration definition is invalid");
+	}
+	const sinkWriteDurationMs = requireNonNegativeNumber(
+		result.sinkWriteDurationMs,
+		"sinkWriteDurationMs",
+	);
+	if (
+		sinkWriteDurationMs >
+		sinkWriteAwaitMs +
+			indices.length * SINK_WRITE_QUANTIZATION_ALLOWANCE_MS_PER_CHUNK
+	) {
+		throw new Error(
+			"Benchmark sink-write helper duration exceeds canonical read evidence plus its per-chunk clock allowance",
+		);
+	}
+	if (invocation.downloadSink === "node-file") {
+		if (
+			requireNonNegativeSafeInteger(
+				result.sinkServerWriteCalls,
+				"sinkServerWriteCalls",
+			) !== sinkWriteCalls ||
+			result.sinkServerWriteDurationDefinition !==
+				SINK_SERVER_WRITE_DURATION_DEFINITION
+		) {
+			throw new Error("Benchmark Node-file server write evidence is invalid");
+		}
+		const sinkServerWriteDurationMs = requireNonNegativeNumber(
+			result.sinkServerWriteDurationMs,
+			"sinkServerWriteDurationMs",
+		);
+		if (
+			sinkServerWriteDurationMs >
+			sinkWriteDurationMs +
+				indices.length * SINK_SERVER_CLOCK_TOLERANCE_MS_PER_CHUNK
+		) {
+			throw new Error(
+				"Benchmark Node-file server duration exceeds its browser sink duration plus the bounded clock tolerance",
+			);
+		}
+	} else if (
+		result.sinkServerWriteCalls !== null ||
+		result.sinkServerWriteDurationMs !== null ||
+		result.sinkServerWriteDurationDefinition !== null
+	) {
+		throw new Error(
+			"Non-Node benchmark sink contains Node-only server timing evidence",
+		);
+	}
+};
+
+const validateUploadTimings = (result, invocation) => {
+	if (result.downloadDurationDefinition !== DOWNLOAD_DURATION_DEFINITION) {
+		throw new Error("Benchmark download duration definition is invalid");
 	}
 	const phases = requireRecord(result.phaseDurationsMs, "phaseDurationsMs");
 	const uploadSettledMs = requireNonNegativeNumber(
@@ -261,13 +703,17 @@ const validateUploadTimings = (result, invocation) => {
 		timestamps.postMonitorFinishedAt,
 		"timestamps.postMonitorFinishedAt",
 	);
-	const downloadStartedAt = requirePositiveNumber(
+	const downloadStartedAt = requirePositiveSafeInteger(
 		timestamps.downloadStartedAt,
 		"timestamps.downloadStartedAt",
 	);
-	const downloadFinishedAt = requirePositiveNumber(
+	const downloadFinishedAt = requirePositiveSafeInteger(
 		timestamps.downloadFinishedAt,
 		"timestamps.downloadFinishedAt",
+	);
+	const downloadCompletionObservedAt = requirePositiveSafeInteger(
+		timestamps.downloadCompletionObservedAt,
+		"timestamps.downloadCompletionObservedAt",
 	);
 	if (
 		uploadSettledAt <= uploadStartedAt ||
@@ -280,7 +726,8 @@ const validateUploadTimings = (result, invocation) => {
 			Math.max(uploadSettledAt, writerListedAt, readerListedAt) ||
 		postMonitorFinishedAt < postMonitorStartedAt ||
 		downloadStartedAt < postMonitorFinishedAt ||
-		downloadFinishedAt <= downloadStartedAt
+		downloadFinishedAt < downloadStartedAt ||
+		downloadFinishedAt > downloadCompletionObservedAt
 	) {
 		throw new Error("Benchmark phase timestamps are not monotonic");
 	}
@@ -372,6 +819,10 @@ const validateUploadTimings = (result, invocation) => {
 			"Measured transfer duration exceeded its requested timeout and scheduling tolerance",
 		);
 	}
+	validateReadTransferEvidence(result, invocation, {
+		downloadStartedAt,
+		downloadFinishedAt,
+	});
 };
 
 const validateGitProvenance = (value, label) => {
@@ -427,7 +878,7 @@ const validateEnvelope = (
 	);
 	if (
 		invocationSchema.id !== "peerbit-file-share-benchmark-invocation" ||
-		invocationSchema.version !== 1
+		invocationSchema.version !== 2
 	) {
 		throw new Error("Benchmark result has an unsupported invocation schema");
 	}
@@ -874,7 +1325,12 @@ export const validateBenchmarkResult = (
 		throw new Error(`Benchmark result status is not passed${detail}`);
 	}
 	if (scenario === "upload") {
-		validateUploadIntegrity(result, expectedFileMb, expectedFixtureSeed);
+		validateUploadIntegrity(
+			result,
+			expectedFileMb,
+			expectedFixtureSeed,
+			expectedInvocation,
+		);
 		validateUploadTimings(result, expectedInvocation);
 		validateRequestedUploadKnobs(result, expectedInvocation);
 		validateZeroErrors(result, "upload result");

--- a/scripts/file-share/benchmark-validity.test.mjs
+++ b/scripts/file-share/benchmark-validity.test.mjs
@@ -12,6 +12,7 @@ import {
 } from "./benchmark-orchestration.mjs";
 import {
 	assertPlaywrightSucceeded,
+	calculateSinkAwaitSubtractedDiagnosticMs,
 	loadAndValidateBenchmarkResult,
 	parseBenchmarkResult,
 	validateBenchmarkResult,
@@ -19,7 +20,10 @@ import {
 } from "./benchmark-validity.mjs";
 
 const RUN_NONCE = "123e4567-e89b-42d3-a456-426614174000";
+const FILE_NAME = `file-share-benchmark-adaptive-${RUN_NONCE}.bin`;
+const FILE_ID = "benchmark-large-file-id";
 const SHA256 = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+const OTHER_SHA256 = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
 const FILE_MB = 5;
 const FILE_SIZE_BYTES = FILE_MB * 1024 * 1024;
 const SAMPLE_COUNT_DEFINITION =
@@ -34,6 +38,20 @@ const TIME_TO_READER_READY_DEFINITION =
 	"upload-input-set-to-reader-ready-manifest-listed";
 const LISTING_DURATION_DEFINITION =
 	"post-upload-settlement-to-both-writer-and-reader-ready-manifests-listed; excludes upload time";
+const DOWNLOAD_DURATION_DEFINITION =
+	"reader-download-click-to-selected-backpressured-sink-complete";
+const SINK_WRITE_DURATION_DEFINITION =
+	"sum of browser writable.write wall-clock durations; library read diagnostics provide the authoritative awaited sink-write interval";
+const LIBRARY_STREAM_WALL_DEFINITION =
+	"library-large-file-stream-start-to-finish including awaited sink writes";
+const SINK_WRITE_AWAIT_DEFINITION =
+	"sum of per-chunk library wall-clock intervals awaiting writable.write";
+const SINK_AWAIT_SUBTRACTED_DIAGNOSTIC_DEFINITION =
+	"arithmetic library stream wall-clock duration minus summed awaited writable.write intervals; overlap-sensitive and not a sink-independent Peerbit duration";
+const PRIMARY_DOWNLOAD_METRIC_DEFINITION =
+	"authoritative only within one fixed download-sink cohort; hash-only is the standardized primary cohort and includes awaited sink writes plus any overlapping read-ahead";
+const DEMAND_WAIT_DEFINITION =
+	"wall-clock time each sequential stream consumer awaited its scheduled chunk";
 const PROVENANCE = {
 	harness: {
 		requestedRef: "harness-worktree",
@@ -90,6 +108,7 @@ const validResult = () => ({
 	status: "passed",
 	mode: "adaptive",
 	networkMode: "local",
+	fileName: FILE_NAME,
 	fileSizeMb: FILE_MB,
 	integrityVerified: true,
 	integrity: {
@@ -102,12 +121,18 @@ const validResult = () => ({
 		downloadedSizeBytes: FILE_SIZE_BYTES,
 		sourceSha256Base64: SHA256,
 		manifestSha256Base64: SHA256,
-		downloadedSha256Base64: SHA256,
+		libraryComputedSha256Base64: SHA256,
+		downloadedSha256Base64: null,
 		sourceCrc32Hex: "00000000",
 		downloadedCrc32Hex: "00000000",
+		downloadSink: "hash-only",
+		sinkPersistence: "none",
+		sinkPersistenceVerified: null,
 		sizeVerified: true,
 		manifestVerified: true,
 		sha256Verified: true,
+		librarySha256Verified: true,
+		persistedSinkSha256Verified: null,
 		crc32Verified: true,
 		verified: true,
 	},
@@ -129,10 +154,54 @@ const validResult = () => ({
 	minReadySeeders: 2,
 	readyTimeoutMs: 180_000,
 	downloadDurationMs: 30,
+	downloadDurationDefinition: DOWNLOAD_DURATION_DEFINITION,
 	transferTimeoutSchedulingToleranceMs: 5_000,
 	transferTimeoutSchedulingToleranceDefinition:
 		TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION,
-	downloadSink: "node-file",
+	downloadSink: "hash-only",
+	requestedDownloadSink: "hash-only",
+	sinkWriteCalls: 2,
+	sinkWriteDurationMs: 8.5,
+	sinkWriteDurationDefinition: SINK_WRITE_DURATION_DEFINITION,
+	sinkServerWriteCalls: null,
+	sinkServerWriteDurationMs: null,
+	sinkServerWriteDurationDefinition: null,
+	readTransfer: {
+		chunkCount: 2,
+		totalBytes: FILE_SIZE_BYTES,
+		sources: { remote: { chunkCount: 2, bytes: FILE_SIZE_BYTES } },
+		demandWait: {
+			definition: DEMAND_WAIT_DEFINITION,
+			sampleCount: 2,
+			sumMs: 12,
+			p50Ms: 4,
+			p95Ms: 8,
+			p99Ms: 8,
+			maxMs: 8,
+			over1sCount: 0,
+			over5sCount: 0,
+			over10sCount: 0,
+		},
+		stages: {
+			libraryStreamWallMs: 30,
+			sinkWriteAwaitMs: 9,
+			sinkAwaitSubtractedDiagnosticMs: 21,
+			demandWaitMs: 12,
+			materializeMs: 4,
+			contentHashMs: 3,
+			otherStreamReadMs: 2,
+		},
+	},
+	libraryStreamWallMs: 30,
+	libraryStreamWallDefinition: LIBRARY_STREAM_WALL_DEFINITION,
+	primaryDownloadMetric: "libraryStreamWallMs",
+	primaryDownloadAuthoritative: true,
+	primaryDownloadMetricDefinition: PRIMARY_DOWNLOAD_METRIC_DEFINITION,
+	sinkWriteAwaitMs: 9,
+	sinkWriteAwaitDefinition: SINK_WRITE_AWAIT_DEFINITION,
+	sinkAwaitSubtractedDiagnosticMs: 21,
+	sinkAwaitSubtractedDiagnosticDefinition:
+		SINK_AWAIT_SUBTRACTED_DIAGNOSTIC_DEFINITION,
 	phaseDurationsMs: {
 		timeToUploadSettled: 101,
 		timeToWriterReady: 100,
@@ -153,6 +222,7 @@ const validResult = () => ({
 		postMonitorFinishedAt: 1170,
 		downloadStartedAt: 1170,
 		downloadFinishedAt: 1200,
+		downloadCompletionObservedAt: 1201,
 	},
 	baselineWriterSeeders: 2,
 	baselineReaderSeeders: 2,
@@ -166,6 +236,39 @@ const validResult = () => ({
 	requestFailureCollectionComplete: true,
 	requestFailureCount: 0,
 	requestFailures: [],
+	readerDiagnostics: {
+		lastReadDiagnostics: {
+			transferId: "benchmark-read-transfer-id",
+			fileId: FILE_ID,
+			fileName: FILE_NAME,
+			startedAt: 1_170,
+			finishedAt: 1_200,
+			computedFinalHash: SHA256,
+			chunkResolved: { 0: "remote", 1: "remote" },
+			chunkByteLength: { 0: 3 * 1024 * 1024, 1: 2 * 1024 * 1024 },
+			chunkDemandWaitMs: { 0: 8, 1: 4 },
+			chunkWriteStartedAt: { 0: 1_180, 1: 1_192 },
+			chunkWriteFinishedAt: { 0: 1_185, 1: 1_196 },
+			chunkMaterializeStartedAt: { 0: 1_171, 1: 1_186 },
+			chunkMaterializeFinishedAt: { 0: 1_173, 1: 1_188 },
+			chunkHashStartedAt: { 0: 1_173, 1: 1_188 },
+			chunkHashFinishedAt: { 0: 1_174, 1: 1_190 },
+		},
+	},
+	writerManifestEvidence: {
+		capturedAt: 1_100,
+		fileId: FILE_ID,
+		fileName: FILE_NAME,
+		sizeBytes: FILE_SIZE_BYTES,
+		finalHash: SHA256,
+	},
+	readerManifestEvidence: {
+		capturedAt: 1_120,
+		fileId: FILE_ID,
+		fileName: FILE_NAME,
+		sizeBytes: FILE_SIZE_BYTES,
+		finalHash: SHA256,
+	},
 	snapshots: [
 		{
 			label: "seeders-ready",
@@ -182,6 +285,46 @@ const validResult = () => ({
 	],
 });
 
+const createSinkFixture = (downloadSink) => {
+	const invocation = createBenchmarkInvocation({
+		scenario: "upload",
+		mode: "adaptive",
+		network: "local",
+		integrationMode: "link",
+		fileMb: FILE_MB,
+		fixtureSeed: "fixture-seed",
+		downloadSink,
+		uploadTimeoutMs: 600_000,
+		downloadTimeoutMs: 600_000,
+		postUploadMonitorMs: 50,
+		pollMs: 1_000,
+		minReadySeeders: 2,
+		readyTimeoutMs: 180_000,
+	});
+	const result = validResult();
+	result.invocation = structuredClone(invocation);
+	result.downloadSink = downloadSink;
+	result.requestedDownloadSink = downloadSink;
+	result.integrity.downloadSink = downloadSink;
+	result.primaryDownloadAuthoritative = downloadSink === "hash-only";
+	if (["opfs", "node-file"].includes(downloadSink)) {
+		result.integrity.downloadedSha256Base64 = SHA256;
+		result.integrity.persistedSinkSha256Verified = true;
+		result.integrity.sinkPersistence = downloadSink;
+		result.integrity.sinkPersistenceVerified = true;
+	}
+	if (downloadSink === "node-file") {
+		result.sinkServerWriteCalls = 2;
+		result.sinkServerWriteDurationMs = 7;
+		result.sinkServerWriteDurationDefinition =
+			"loopback-request-body-receive-and-node-filesystem-write-only";
+	}
+	return {
+		result,
+		options: { ...options, expectedInvocation: invocation },
+	};
+};
+
 test("accepts a complete deterministic transfer result", () => {
 	assert.equal(
 		validateBenchmarkResult(validResult(), options).status,
@@ -189,14 +332,133 @@ test("accepts a complete deterministic transfer result", () => {
 	);
 });
 
-test("rejects a status-only passed payload at the v3 evidence envelope", () => {
+test("rejects stale read diagnostics outside the clicked download window", () => {
+	for (const mutate of [
+		(result) => {
+			result.readerDiagnostics.lastReadDiagnostics.startedAt = 1_100;
+			result.readerDiagnostics.lastReadDiagnostics.finishedAt = 1_130;
+		},
+		(result) => {
+			result.readerDiagnostics.lastReadDiagnostics.finishedAt = 1_201;
+		},
+	]) {
+		const result = validResult();
+		mutate(result);
+		assert.throws(
+			() => validateBenchmarkResult(result, options),
+			/outside the clicked download window/,
+		);
+	}
+});
+
+test("rejects read diagnostics for a different file name or manifest id", () => {
+	for (const mutate of [
+		(result) => {
+			result.readerDiagnostics.lastReadDiagnostics.fileName = "other.bin";
+		},
+		(result) => {
+			result.readerDiagnostics.lastReadDiagnostics.fileId = "other-file-id";
+		},
+	]) {
+		const result = validResult();
+		mutate(result);
+		assert.throws(
+			() => validateBenchmarkResult(result, options),
+			/read identity does not match the clicked file manifest/,
+		);
+	}
+});
+
+test("accepts hash-only, OPFS, and Node-file integrity cohorts", () => {
+	for (const downloadSink of ["hash-only", "opfs", "node-file"]) {
+		const fixture = createSinkFixture(downloadSink);
+		assert.equal(
+			validateBenchmarkResult(fixture.result, fixture.options).status,
+			"passed",
+		);
+	}
+});
+
+test("enforces hash-only result-level primary download authority", () => {
+	for (const [downloadSink, invalidAuthority] of [
+		["hash-only", false],
+		["opfs", true],
+		["node-file", true],
+	]) {
+		const fixture = createSinkFixture(downloadSink);
+		fixture.result.primaryDownloadAuthoritative = invalidAuthority;
+		assert.throws(
+			() => validateBenchmarkResult(fixture.result, fixture.options),
+			/read-transfer timing definitions are invalid/,
+		);
+	}
+});
+
+test("requires persisted SHA-256 for OPFS and Node-file cohorts", () => {
+	for (const downloadSink of ["opfs", "node-file"]) {
+		const fixture = createSinkFixture(downloadSink);
+		fixture.result.integrity.downloadedSha256Base64 = null;
+		assert.throws(
+			() => validateBenchmarkResult(fixture.result, fixture.options),
+			/integrity.downloadedSha256Base64/,
+		);
+	}
+});
+
+test("rejects a tampered persisted OPFS SHA-256 readback", () => {
+	const fixture = createSinkFixture("opfs");
+	fixture.result.integrity.downloadedSha256Base64 = OTHER_SHA256;
+	assert.throws(
+		() => validateBenchmarkResult(fixture.result, fixture.options),
+		/persisted opfs SHA-256 integrity gate/,
+	);
+});
+
+test("rejects an unverified persisted OPFS readback", () => {
+	const fixture = createSinkFixture("opfs");
+	fixture.result.integrity.persistedSinkSha256Verified = false;
+	fixture.result.integrity.sinkPersistenceVerified = false;
+	assert.throws(
+		() => validateBenchmarkResult(fixture.result, fixture.options),
+		/persisted opfs SHA-256 integrity gate/,
+	);
+});
+
+test("models sink-await subtraction as an overlap-sensitive diagnostic", () => {
+	const noSinkDelay = calculateSinkAwaitSubtractedDiagnosticMs({
+		libraryStreamWallMs: 50,
+		sinkWriteAwaitMs: 0,
+	});
+	// In this controlled timeline, 30ms of the same 50ms read path progresses
+	// during a 40ms sink wait. Wall time becomes 60ms, not 90ms; subtracting the
+	// whole wait therefore reports 20ms and proves this is not a counterfactual
+	// sink-free duration.
+	const overlappingSinkDelay = calculateSinkAwaitSubtractedDiagnosticMs({
+		libraryStreamWallMs: 60,
+		sinkWriteAwaitMs: 40,
+	});
+	assert.equal(noSinkDelay, 50);
+	assert.equal(overlappingSinkDelay, 20);
+	assert.ok(overlappingSinkDelay < noSinkDelay);
+});
+
+test("bounds Node-file server timing against its browser sink timing", () => {
+	const fixture = createSinkFixture("node-file");
+	fixture.result.sinkServerWriteDurationMs = 10.501;
+	assert.throws(
+		() => validateBenchmarkResult(fixture.result, fixture.options),
+		/Node-file server duration exceeds its browser sink duration/,
+	);
+});
+
+test("rejects a status-only passed payload at the v4 evidence envelope", () => {
 	assert.throws(
 		() => validateBenchmarkResultEnvelope({ status: "passed" }, options),
 		/missing schema/,
 	);
 });
 
-test("requires explicit error evidence on failed v3 envelopes", () => {
+test("requires explicit error evidence on failed v4 envelopes", () => {
 	const completeFailure = validResult();
 	completeFailure.status = "failed";
 	completeFailure.failure = { message: "synthetic browser failure" };
@@ -321,6 +583,166 @@ for (const [name, mutate, pattern] of [
 		/aggregate integrity/,
 	],
 	[
+		"download sink mismatch",
+		(result) => {
+			result.downloadSink = "opfs";
+		},
+		/download sink does not match/,
+	],
+	[
+		"library SHA-256 evidence",
+		(result) => {
+			result.integrity.libraryComputedSha256Base64 = null;
+		},
+		/integrity.libraryComputedSha256Base64/,
+	],
+	[
+		"hash-only persistence claim",
+		(result) => {
+			result.integrity.downloadedSha256Base64 = SHA256;
+			result.integrity.persistedSinkSha256Verified = true;
+		},
+		/must not claim persisted SHA-256/,
+	],
+	[
+		"non-Node server timing",
+		(result) => {
+			result.sinkServerWriteCalls = 1;
+		},
+		/Node-only server timing/,
+	],
+	[
+		"sink write count",
+		(result) => {
+			result.sinkWriteCalls = 3;
+		},
+		/sink write count/,
+	],
+	[
+		"inflated sink helper timing",
+		(result) => {
+			result.sinkWriteDurationMs = 11.001;
+		},
+		/helper duration exceeds canonical read evidence/,
+	],
+	[
+		"stream timing decomposition",
+		(result) => {
+			result.sinkAwaitSubtractedDiagnosticMs += 1;
+		},
+		/timing decomposition is inconsistent/,
+	],
+	[
+		"raw demand-tail summary",
+		(result) => {
+			result.readTransfer.demandWait.p95Ms += 1;
+		},
+		/timing decomposition is inconsistent/,
+	],
+	[
+		"raw demand-tail threshold count",
+		(result) => {
+			result.readTransfer.demandWait.over1sCount += 1;
+		},
+		/timing decomposition is inconsistent/,
+	],
+	[
+		"read source byte attribution",
+		(result) => {
+			result.readTransfer.sources.remote.bytes -= 1;
+		},
+		/timing decomposition is inconsistent/,
+	],
+	[
+		"raw materialization summary",
+		(result) => {
+			result.readTransfer.stages.materializeMs += 1;
+		},
+		/timing decomposition is inconsistent/,
+	],
+	[
+		"extra read-transfer field",
+		(result) => {
+			result.readTransfer.unverified = true;
+		},
+		/timing decomposition is inconsistent/,
+	],
+	[
+		"noncanonical resolved chunk key",
+		(result) => {
+			const resolved =
+				result.readerDiagnostics.lastReadDiagnostics.chunkResolved;
+			resolved["01"] = resolved[1];
+			delete resolved[1];
+		},
+		/contiguous canonical chunk indices/,
+	],
+	[
+		"single giant large-file chunk",
+		(result) => {
+			delete result.readerDiagnostics.lastReadDiagnostics.chunkResolved[1];
+		},
+		/at least two contiguous canonical chunk indices/,
+	],
+	[
+		"empty resolved chunk source",
+		(result) => {
+			result.readerDiagnostics.lastReadDiagnostics.chunkResolved[0] = "";
+		},
+		/invalid readerDiagnostics\.chunkResolved\[0\]/,
+	],
+	[
+		"missing canonical demand key",
+		(result) => {
+			delete result.readerDiagnostics.lastReadDiagnostics.chunkDemandWaitMs[1];
+		},
+		/exact canonical chunk keys/,
+	],
+	[
+		"extra noncanonical timing key",
+		(result) => {
+			result.readerDiagnostics.lastReadDiagnostics.chunkHashStartedAt["01"] =
+				1_188;
+		},
+		/exact canonical chunk keys/,
+	],
+	[
+		"chunk write before read window",
+		(result) => {
+			result.readerDiagnostics.lastReadDiagnostics.chunkWriteStartedAt[0] = 1_169;
+		},
+		/outside the library read window/,
+	],
+	[
+		"chunk write after read window",
+		(result) => {
+			result.readerDiagnostics.lastReadDiagnostics.chunkWriteFinishedAt[1] = 1_201;
+		},
+		/outside the library read window/,
+	],
+	[
+		"overlapping chunk writes",
+		(result) => {
+			result.readerDiagnostics.lastReadDiagnostics.chunkWriteStartedAt[1] = 1_184;
+		},
+		/ordered and non-overlapping/,
+	],
+	[
+		"raw read byte coverage",
+		(result) => {
+			result.readerDiagnostics.lastReadDiagnostics.chunkByteLength[0] -= 1;
+		},
+		/do not cover the requested file size/,
+	],
+	[
+		"raw reader SHA-256 contradiction",
+		(result) => {
+			result.readerDiagnostics.lastReadDiagnostics.computedFinalHash =
+				SHA256.replace(/^A/, "B");
+		},
+		/raw reader SHA-256 contradicts/,
+	],
+	[
 		"upload arithmetic",
 		(result) => {
 			result.uploadDurationMs += result.postUploadMonitorDurationMs;
@@ -331,6 +753,34 @@ for (const [name, mutate, pattern] of [
 		"phase ordering",
 		(result) => {
 			result.timestamps.downloadStartedAt = 1100;
+		},
+		/not monotonic/,
+	],
+	[
+		"missing completion-observation timestamp",
+		(result) => {
+			delete result.timestamps.downloadCompletionObservedAt;
+		},
+		/downloadCompletionObservedAt/,
+	],
+	[
+		"unsafe sink-completion epoch",
+		(result) => {
+			result.timestamps.downloadFinishedAt = Number.MAX_SAFE_INTEGER + 1;
+		},
+		/invalid timestamps.downloadFinishedAt/,
+	],
+	[
+		"sink completion after observation",
+		(result) => {
+			result.timestamps.downloadFinishedAt = 1_202;
+		},
+		/not monotonic/,
+	],
+	[
+		"sink completion before download start",
+		(result) => {
+			result.timestamps.downloadFinishedAt = 1_169;
 		},
 		/not monotonic/,
 	],
@@ -395,6 +845,7 @@ for (const [name, mutate, pattern] of [
 			result.timestamps.postMonitorFinishedAt = 2_421;
 			result.timestamps.downloadStartedAt = 2_421;
 			result.timestamps.downloadFinishedAt = 2_451;
+			result.timestamps.downloadCompletionObservedAt = 2_452;
 		},
 		/outside the requested duration/,
 	],
@@ -418,6 +869,7 @@ for (const [name, mutate, pattern] of [
 			result.timestamps.postMonitorFinishedAt = 606_051;
 			result.timestamps.downloadStartedAt = 606_051;
 			result.timestamps.downloadFinishedAt = 606_081;
+			result.timestamps.downloadCompletionObservedAt = 606_082;
 		},
 		/requested timeout/,
 	],
@@ -428,6 +880,8 @@ for (const [name, mutate, pattern] of [
 			result.phaseDurationsMs.download = 605_001;
 			result.timestamps.downloadFinishedAt =
 				result.timestamps.downloadStartedAt + 605_001;
+			result.timestamps.downloadCompletionObservedAt =
+				result.timestamps.downloadFinishedAt + 1;
 		},
 		/requested timeout/,
 	],

--- a/scripts/file-share/opfs-readback.test.mjs
+++ b/scripts/file-share/opfs-readback.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+import {
+	OPFS_READBACK_CHUNK_BYTES,
+	sha256AndCrc32OpfsSavedViaPicker,
+} from "./templates/opfs-readback.mjs";
+
+const createNodeSha256 = () => {
+	const hash = createHash("sha256");
+	return {
+		update(bytes) {
+			hash.update(bytes);
+			return this;
+		},
+		digest() {
+			return new Uint8Array(hash.digest());
+		},
+	};
+};
+
+const sha256Base64 = (bytes) =>
+	createHash("sha256").update(bytes).digest("base64");
+
+const createFakeOpfsPage = ({ bytes, truncateOffset = null }) => {
+	const readSlices = [];
+	return {
+		readSlices,
+		async evaluate(_callback, argument) {
+			if (typeof argument === "string") {
+				return { storageName: "fixture.opfs", sizeBytes: bytes.byteLength };
+			}
+			assert.equal(argument.storageName, "fixture.opfs");
+			assert.equal(argument.expectedSize, bytes.byteLength);
+			readSlices.push([argument.offset, argument.end]);
+			const chunk = bytes.slice(argument.offset, argument.end);
+			return argument.offset === truncateOffset ? chunk.subarray(0, -1) : chunk;
+		},
+	};
+};
+
+const readback = (page, bytes) =>
+	sha256AndCrc32OpfsSavedViaPicker(
+		page,
+		"fixture.bin",
+		bytes.byteLength,
+		createNodeSha256,
+	);
+
+test("bounded OPFS readback computes standard SHA-256 and CRC-32", async () => {
+	const bytes = new TextEncoder().encode("123456789");
+	const page = createFakeOpfsPage({ bytes });
+	assert.deepEqual(await readback(page, bytes), {
+		sizeBytes: bytes.byteLength,
+		sha256Base64: sha256Base64(bytes),
+		crc32Hex: "cbf43926",
+	});
+	assert.deepEqual(page.readSlices, [[0, bytes.byteLength]]);
+});
+
+test("bounded OPFS readback detects same-size persisted-byte tampering", async () => {
+	const bytes = new Uint8Array(OPFS_READBACK_CHUNK_BYTES * 2 + 17);
+	for (let index = 0; index < bytes.length; index++) {
+		bytes[index] = (index * 31 + 7) & 0xff;
+	}
+	const originalPage = createFakeOpfsPage({ bytes });
+	const original = await readback(originalPage, bytes);
+	assert.equal(original.sha256Base64, sha256Base64(bytes));
+	assert.deepEqual(originalPage.readSlices, [
+		[0, OPFS_READBACK_CHUNK_BYTES],
+		[OPFS_READBACK_CHUNK_BYTES, OPFS_READBACK_CHUNK_BYTES * 2],
+		[OPFS_READBACK_CHUNK_BYTES * 2, bytes.byteLength],
+	]);
+
+	const tamperedBytes = bytes.slice();
+	tamperedBytes[OPFS_READBACK_CHUNK_BYTES + 123] ^= 0xff;
+	assert.equal(tamperedBytes.byteLength, bytes.byteLength);
+	const tampered = await readback(
+		createFakeOpfsPage({ bytes: tamperedBytes }),
+		tamperedBytes,
+	);
+	assert.equal(tampered.sha256Base64, sha256Base64(tamperedBytes));
+	assert.notEqual(tampered.sha256Base64, original.sha256Base64);
+	assert.notEqual(tampered.crc32Hex, original.crc32Hex);
+});
+
+test("bounded OPFS readback rejects a truncated persisted slice", async () => {
+	const bytes = new Uint8Array(OPFS_READBACK_CHUNK_BYTES + 1);
+	const page = createFakeOpfsPage({
+		bytes,
+		truncateOffset: OPFS_READBACK_CHUNK_BYTES,
+	});
+	await assert.rejects(readback(page, bytes), /truncated chunk/);
+});

--- a/scripts/file-share/run-file-share-benchmark-matrix.mjs
+++ b/scripts/file-share/run-file-share-benchmark-matrix.mjs
@@ -9,20 +9,21 @@ import {
 	assertBenchmarkFileSize,
 	assertCoreBenchmarkUsesLocalApp,
 	createBenchmarkInvocation,
+	resolveBenchmarkDownloadSink,
 	resolveBenchmarkPreviewOptions,
 } from "./benchmark-invocation.mjs";
 import {
 	BENCHMARK_RESULT_SCHEMA,
 	BENCHMARK_SUMMARY_SCHEMA,
-	classifySubprocessSummary,
-	countBenchmarkOutcomes,
 	ERROR_COLLECTION_DEFINITION,
-	extractCollectedErrorEvidence,
-	inspectSingleInvocationSummary,
 	KNOWN_PEERBIT_FAILURE_SIGNATURES,
 	MATRIX_SUMMARY_SCHEMA,
-	readJsonEvidence,
 	REQUEST_FAILURE_COLLECTION_DEFINITION,
+	classifySubprocessSummary,
+	countBenchmarkOutcomes,
+	extractCollectedErrorEvidence,
+	inspectSingleInvocationSummary,
+	readJsonEvidence,
 	serializeError,
 } from "./benchmark-orchestration.mjs";
 import {
@@ -31,7 +32,8 @@ import {
 	resolveGitCommitAt,
 } from "./benchmark-provenance.mjs";
 import {
-	compareUploadPerformanceModes,
+	compareUploadPerformanceModesForCompletePlan,
+	isCompletePassedBenchmarkPlan,
 	summarizeUploadPerformance,
 } from "./benchmark-summary.mjs";
 import {
@@ -160,6 +162,21 @@ const summarizeUploadMatrix = (variantSummaries) => {
 		const fixed1 = summary.summary.find((entry) => entry.mode === "fixed1");
 		return {
 			variant: summary.variant,
+			downloadSink:
+				summary.comparison?.downloadSink ??
+				adaptive?.downloadSink ??
+				fixed1?.downloadSink ??
+				null,
+			primaryDownloadMetric:
+				summary.comparison?.primaryDownloadMetric ??
+				adaptive?.primaryDownloadMetric ??
+				fixed1?.primaryDownloadMetric ??
+				null,
+			primaryDownloadAuthoritative:
+				summary.comparison?.primaryDownloadAuthoritative ??
+				adaptive?.primaryDownloadAuthoritative ??
+				fixed1?.primaryDownloadAuthoritative ??
+				null,
 			adaptiveAvgMs: summary.comparison?.adaptiveAvgMs ?? null,
 			fixed1AvgMs: summary.comparison?.fixed1AvgMs ?? null,
 			adaptiveVsFixed1Pct: summary.comparison?.adaptiveVsFixed1Pct ?? null,
@@ -171,6 +188,16 @@ const summarizeUploadMatrix = (variantSummaries) => {
 			fixed1ReaderReadyMsAvg: fixed1?.timeToReaderReadyMsAvg ?? null,
 			adaptiveReaderReadyMsMedian: adaptive?.timeToReaderReadyMsMedian ?? null,
 			fixed1ReaderReadyMsMedian: fixed1?.timeToReaderReadyMsMedian ?? null,
+			adaptiveLibraryStreamWallMsAvg: adaptive?.libraryStreamWallMsAvg ?? null,
+			fixed1LibraryStreamWallMsAvg: fixed1?.libraryStreamWallMsAvg ?? null,
+			adaptiveLibraryStreamWallMsMedian:
+				adaptive?.libraryStreamWallMsMedian ?? null,
+			fixed1LibraryStreamWallMsMedian:
+				fixed1?.libraryStreamWallMsMedian ?? null,
+			libraryStreamWallDeltaMs:
+				summary.comparison?.libraryStreamWallDeltaMs ?? null,
+			adaptiveVsFixed1LibraryStreamWallPct:
+				summary.comparison?.adaptiveVsFixed1LibraryStreamWallPct ?? null,
 			adaptiveStatus: adaptive?.failed === 0 ? "passed" : "failed",
 			fixed1Status: fixed1?.failed === 0 ? "passed" : "failed",
 			adaptiveErrorCount: adaptive?.errorCount ?? null,
@@ -228,11 +255,18 @@ const compareAdaptiveAcrossVariants = (variantSummaries, scenario) => {
 				: adaptive.uploadDurationMsAvg != null
 					? {
 							variant: summary.variant,
+							downloadSink: adaptive.downloadSink ?? null,
+							primaryDownloadMetric: adaptive.primaryDownloadMetric ?? null,
+							primaryDownloadAuthoritative:
+								adaptive.primaryDownloadAuthoritative ?? null,
 							adaptiveAvgMs: adaptive.uploadDurationMsAvg,
 							adaptiveWriterReadyMsAvg: adaptive.timeToWriterReadyMsAvg,
 							adaptiveWriterReadyMsMedian: adaptive.timeToWriterReadyMsMedian,
 							adaptiveReaderReadyMsAvg: adaptive.timeToReaderReadyMsAvg,
 							adaptiveReaderReadyMsMedian: adaptive.timeToReaderReadyMsMedian,
+							adaptiveLibraryStreamWallMsAvg: adaptive.libraryStreamWallMsAvg,
+							adaptiveLibraryStreamWallMsMedian:
+								adaptive.libraryStreamWallMsMedian,
 						}
 					: null;
 		})
@@ -370,6 +404,7 @@ const runVariantBenchmark = async ({
 	installExamples,
 	uploadTimeoutMs,
 	downloadTimeoutMs,
+	downloadSink,
 	postUploadMonitorMs,
 	pollMs,
 	minReadySeeders,
@@ -435,6 +470,7 @@ const runVariantBenchmark = async ({
 		...(downloadTimeoutMs != null
 			? ["--download-timeout-ms", String(downloadTimeoutMs)]
 			: []),
+		...(downloadSink != null ? ["--download-sink", downloadSink] : []),
 		...(postUploadMonitorMs != null
 			? ["--post-upload-monitor-ms", String(postUploadMonitorMs)]
 			: []),
@@ -552,6 +588,9 @@ const main = async () => {
 	const mode = args.mode ?? "both";
 	const modes = mode === "both" ? ["adaptive", "fixed1"] : [mode];
 	const scenario = args.scenario ?? "upload";
+	const downloadSink = resolveBenchmarkDownloadSink(args["download-sink"], {
+		scenario,
+	});
 	const integrationMode = args["integration-mode"] ?? "link";
 	const localPackages =
 		args["local-packages"] ?? defaultFileShareLocalPackages.join(",");
@@ -717,6 +756,7 @@ const main = async () => {
 				installExamples: false,
 				uploadTimeoutMs,
 				downloadTimeoutMs,
+				downloadSink,
 				postUploadMonitorMs,
 				pollMs,
 				minReadySeeders,
@@ -759,6 +799,7 @@ const main = async () => {
 				integrationMode,
 				fileMb,
 				fixtureSeed: fixtureSeed ?? DEFAULT_FIXTURE_SEED,
+				downloadSink,
 				uploadTimeoutMs: optionalNumber(uploadTimeoutMs),
 				downloadTimeoutMs: optionalNumber(downloadTimeoutMs),
 				postUploadMonitorMs: optionalNumber(postUploadMonitorMs),
@@ -952,11 +993,27 @@ const main = async () => {
 		});
 	}
 
+	const allResults = [...resultsByVariant.values()].flat();
+	const outcomeCounts = countBenchmarkOutcomes(
+		allResults,
+		executionOrder.length,
+	);
+	const matrixPlanPassed = isCompletePassedBenchmarkPlan(
+		allResults,
+		outcomeCounts,
+	);
 	const variantSummaries = variantSpecs.map((variantSpec) => {
 		const prepared = preparedVariants.get(variantSpec.name);
 		const results = resultsByVariant
 			.get(variantSpec.name)
 			.toSorted((left, right) => left.matrixSequence - right.matrixSequence);
+		const variantPlanned = executionOrder.filter(
+			(plan) => plan.variant === variantSpec.name,
+		).length;
+		const variantOutcomeCounts = countBenchmarkOutcomes(
+			results,
+			variantPlanned,
+		);
 		return {
 			variant: variantSpec.name,
 			variantRef: prepared.variantRef,
@@ -966,20 +1023,20 @@ const main = async () => {
 			peerbitProvenance: prepared.peerbitProvenance,
 			examplesProvenance: benchmarkExamplesProvenance,
 			results,
+			outcomeCounts: variantOutcomeCounts,
 			summary: summarizeInvocationResults(results, scenario),
 			comparison:
-				scenario === "upload" ? compareUploadPerformanceModes(results) : null,
+				scenario === "upload"
+					? compareUploadPerformanceModesForCompletePlan(
+							results,
+							variantOutcomeCounts,
+						)
+					: null,
 		};
 	});
-
-	const allResults = [...resultsByVariant.values()].flat();
-	const outcomeCounts = countBenchmarkOutcomes(
-		allResults,
-		executionOrder.length,
-	);
 	const matrixSummary = {
 		schema: MATRIX_SUMMARY_SCHEMA,
-		status: outcomeCounts.failed === 0 ? "passed" : "failed",
+		status: matrixPlanPassed ? "passed" : "failed",
 		outcomeCounts,
 		errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
 		knownPeerbitFailureSignatures: KNOWN_PEERBIT_FAILURE_SIGNATURES,
@@ -995,6 +1052,7 @@ const main = async () => {
 		mode,
 		modes,
 		scenario,
+		downloadSink,
 		integrationMode,
 		localPackages,
 		requestedLocalPackageNames:
@@ -1009,10 +1067,9 @@ const main = async () => {
 		executionOrder: invocationRecords,
 		variantSummaries,
 		summary: summarizeMatrix(variantSummaries, scenario),
-		adaptiveComparison: compareAdaptiveAcrossVariants(
-			variantSummaries,
-			scenario,
-		),
+		adaptiveComparison: matrixPlanPassed
+			? compareAdaptiveAcrossVariants(variantSummaries, scenario)
+			: null,
 	};
 	const matrixSummaryFile = path.join(
 		matrixRoot,
@@ -1025,10 +1082,12 @@ const main = async () => {
 	console.table(matrixSummary.summary);
 	console.log("\nOutcome counts");
 	console.table([outcomeCounts]);
-	console.log("\nAdaptive across variants");
-	console.table(matrixSummary.adaptiveComparison);
+	if (matrixSummary.adaptiveComparison) {
+		console.log("\nAdaptive across variants");
+		console.table(matrixSummary.adaptiveComparison);
+	}
 	console.log(`\nMatrix summary: ${matrixSummaryFile}`);
-	if (outcomeCounts.failed > 0) {
+	if (!matrixPlanPassed) {
 		process.exitCode = 1;
 	}
 };

--- a/scripts/file-share/run-file-share-benchmark.mjs
+++ b/scripts/file-share/run-file-share-benchmark.mjs
@@ -11,17 +11,18 @@ import {
 	createBenchmarkInvocation,
 	createNonceIsolatedResultPath,
 	createPlaywrightBenchmarkEnvironment,
+	resolveBenchmarkDownloadSink,
 	resolveBenchmarkPreviewOptions,
 } from "./benchmark-invocation.mjs";
 import {
 	BENCHMARK_SUMMARY_SCHEMA,
+	ERROR_COLLECTION_DEFINITION,
+	KNOWN_PEERBIT_FAILURE_SIGNATURES,
+	REQUEST_FAILURE_COLLECTION_DEFINITION,
 	countBenchmarkOutcomes,
 	createInvocationFailureEvidence,
-	ERROR_COLLECTION_DEFINITION,
 	executePlanContinuing,
-	KNOWN_PEERBIT_FAILURE_SIGNATURES,
 	readJsonEvidence,
-	REQUEST_FAILURE_COLLECTION_DEFINITION,
 } from "./benchmark-orchestration.mjs";
 import {
 	getExamplesProvenance,
@@ -29,7 +30,8 @@ import {
 	resolveGitCommitAt,
 } from "./benchmark-provenance.mjs";
 import {
-	compareUploadPerformanceModes,
+	compareUploadPerformanceModesForCompletePlan,
+	isCompletePassedBenchmarkPlan,
 	summarizeUploadPerformance,
 	uploadTimingTableColumns,
 } from "./benchmark-summary.mjs";
@@ -66,6 +68,18 @@ const SCENARIOS = {
 			"tests",
 			"generated.upload-benchmark.e2e.spec.ts",
 		),
+		supportFiles: [
+			{
+				templatePath: path.join(
+					repoRoot,
+					"scripts",
+					"file-share",
+					"templates",
+					"opfs-readback.mjs",
+				),
+				generatedPath: path.join("tests", "generated.opfs-readback.mjs"),
+			},
+		],
 	},
 	"seeder-probe": {
 		templatePath: path.join(
@@ -570,6 +584,9 @@ const main = async () => {
 		requestedMode === "both" ? ["adaptive", "fixed1"] : [requestedMode];
 	const scenario = args.scenario ?? "upload";
 	assertBenchmarkFileSize({ scenario, fileMb });
+	const downloadSink = resolveBenchmarkDownloadSink(args["download-sink"], {
+		scenario,
+	});
 	const network = args.network ?? "local";
 	const uploadTimeoutMs = parseOptionalPositiveInteger(
 		args["upload-timeout-ms"],
@@ -739,6 +756,12 @@ const main = async () => {
 			templatePath: scenarioConfig.templatePath,
 			outputPath: generatedSpec,
 		});
+		for (const supportFile of scenarioConfig.supportFiles ?? []) {
+			await copyTemplate({
+				templatePath: supportFile.templatePath,
+				outputPath: path.join(frontendRoot, supportFile.generatedPath),
+			});
+		}
 
 		if (integrationMode === "link") {
 			await ensureExamplesAssetPackageLinks({
@@ -786,6 +809,7 @@ const main = async () => {
 				integrationMode,
 				fileMb,
 				fixtureSeed: resolvedFixtureSeed,
+				downloadSink,
 				uploadTimeoutMs,
 				downloadTimeoutMs,
 				postUploadMonitorMs,
@@ -988,7 +1012,12 @@ const main = async () => {
 			writerListingLagMs: result.phaseDurationsMs?.writerListingLag ?? null,
 			readerListingLagMs: result.phaseDurationsMs?.readerListingLag ?? null,
 			postUploadMonitorDurationMs: result.postUploadMonitorDurationMs ?? null,
+			downloadSink: result.downloadSink ?? null,
 			downloadDurationMs: result.downloadDurationMs ?? null,
+			libraryStreamWallMs: result.libraryStreamWallMs ?? null,
+			sinkWriteAwaitMs: result.sinkWriteAwaitMs ?? null,
+			sinkAwaitSubtractedDiagnosticMs:
+				result.sinkAwaitSubtractedDiagnosticMs ?? null,
 			integrityVerified: result.integrityVerified ?? null,
 			playwrightWallTimeMs: result.playwrightWallTimeMs,
 			playwrightExitCode: result.playwrightExitCode,
@@ -1005,18 +1034,21 @@ const main = async () => {
 	);
 	console.log("\nSummary");
 	console.table(summarizeResults(results, scenario));
+	const outcomeCounts = countBenchmarkOutcomes(results, executionOrder.length);
+	const planPassed = isCompletePassedBenchmarkPlan(results, outcomeCounts);
 	const comparison =
-		scenario === "upload" ? compareUploadPerformanceModes(results) : null;
+		scenario === "upload"
+			? compareUploadPerformanceModesForCompletePlan(results, outcomeCounts)
+			: null;
 	if (comparison) {
 		console.log("\nAdaptive vs fixed1");
 		console.table([comparison]);
 	}
-	const outcomeCounts = countBenchmarkOutcomes(results, executionOrder.length);
 	console.log("\nOutcome counts");
 	console.table([outcomeCounts]);
 	const summary = {
 		schema: BENCHMARK_SUMMARY_SCHEMA,
-		status: outcomeCounts.failed === 0 ? "passed" : "failed",
+		status: planPassed ? "passed" : "failed",
 		outcomeCounts,
 		errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
 		knownPeerbitFailureSignatures: KNOWN_PEERBIT_FAILURE_SIGNATURES,
@@ -1029,6 +1061,7 @@ const main = async () => {
 		examplesProvenance: expectedExamplesProvenance,
 		frontendRoot,
 		scenario,
+		downloadSink,
 		integrationMode,
 		localPackageNames: effectiveLocalPackageNames,
 		network,
@@ -1046,7 +1079,7 @@ const main = async () => {
 	await writeJsonAtomic(aggregateSummaryFile, summary);
 	console.log(`\nRaw results: ${resultsDir}`);
 	console.log(`Aggregate summary: ${aggregateSummaryFile}`);
-	if (outcomeCounts.failed > 0) {
+	if (!planPassed) {
 		process.exitCode = 1;
 	}
 };

--- a/scripts/file-share/template-contract.test.mjs
+++ b/scripts/file-share/template-contract.test.mjs
@@ -15,14 +15,14 @@ const templates = [
 ];
 
 for (const name of templates) {
-	test(`${name} emits the atomic v3 invocation envelope`, async () => {
+	test(`${name} emits the atomic v4 invocation envelope`, async () => {
 		const contents = await readFile(
 			path.join(repoRoot, "scripts", "file-share", "templates", name),
 			"utf8",
 		);
 		for (const required of [
 			'id: "peerbit-file-share-benchmark"',
-			"version: 3",
+			"version: 4",
 			"PW_BENCHMARK_RUN_NONCE",
 			"PW_BENCHMARK_INVOCATION",
 			"PW_BENCHMARK_PROVENANCE",
@@ -137,6 +137,27 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"POST_MONITOR_SCHEDULING_TOLERANCE_MS",
 		"TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS",
 		"Measured transfer duration exceeded",
+		"PW_DOWNLOAD_SINK",
+		"installHashOnlyMockSaveFilePicker",
+		"installMockSaveFilePicker",
+		"installNodeBackedMockSaveFilePicker",
+		"summarizeReadTransferDiagnostics",
+		"libraryComputedSha256Base64",
+		"sinkAwaitSubtractedDiagnosticMs",
+		"primaryDownloadMetric: PRIMARY_DOWNLOAD_METRIC",
+		'primaryDownloadAuthoritative: DOWNLOAD_SINK === "hash-only"',
+		"sinkWriteAwaitMs",
+		"file-share-benchmark-${MODE}-${RUN_NONCE}.bin",
+		"fileId: file.id",
+		"sha256AndCrc32OpfsSavedViaPicker",
+		'import { SHA256 } from "@stablelib/sha256"',
+		"() => new SHA256()",
+		"downloadCompletionObservedAt = Date.now()",
+		"downloadFinishedAt = download.sinkCompletedAt",
+		"download.sinkCompletedAt < downloadClickStartedAt",
+		"download.sinkCompletedAt > downloadCompletionObservedAt",
+		"SINK_WRITE_QUANTIZATION_ALLOWANCE_MS_PER_CHUNK",
+		"SINK_SERVER_CLOCK_TOLERANCE_MS_PER_CHUNK",
 	]) {
 		assert.ok(contents.includes(required), `missing ${required}`);
 	}
@@ -154,6 +175,45 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		!contents.includes("MIN_READY_SEEDERS, 180_000"),
 		"the upload probe must honor the invocation readiness timeout",
 	);
+	assert.ok(
+		!contents.includes("downloadFinishedAt = Date.now()"),
+		"download duration must end at the primary sink's completion timestamp",
+	);
+	assert.ok(
+		!contents.includes("createHash"),
+		"the browser Playwright template must use a browser-compatible incremental SHA-256 implementation",
+	);
+	assert.ok(
+		!contents.includes('crypto.subtle.digest("SHA-256"'),
+		"OPFS SHA-256 readback must remain bounded rather than buffering the file",
+	);
+	const opfsReadback = await readFile(
+		path.join(
+			repoRoot,
+			"scripts",
+			"file-share",
+			"templates",
+			"opfs-readback.mjs",
+		),
+		"utf8",
+	);
+	for (const required of [
+		"OPFS_READBACK_CHUNK_BYTES",
+		"file.slice(start, finish).arrayBuffer()",
+		"totalBytes !== expectedSizeBytes",
+		"sha256.update(chunk)",
+		"updateCrc32State(crc32State, chunk)",
+	]) {
+		assert.ok(
+			opfsReadback.includes(required),
+			`OPFS helper missing ${required}`,
+		);
+	}
+	assert.ok(
+		!opfsReadback.includes("createHash") &&
+			!opfsReadback.includes("crypto.subtle.digest"),
+		"the OPFS helper must use its browser-compatible incremental SHA factory",
+	);
 	for (const peer of ["writer", "reader"]) {
 		assert.match(
 			contents,
@@ -162,6 +222,53 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 			),
 			`${peer} readiness must use the invocation timeout`,
 		);
+	}
+});
+
+test("aggregate comparisons require every planned invocation to pass", async () => {
+	const standalone = await readFile(
+		path.join(
+			repoRoot,
+			"scripts",
+			"file-share",
+			"run-file-share-benchmark.mjs",
+		),
+		"utf8",
+	);
+	for (const required of [
+		"compareUploadPerformanceModesForCompletePlan(results, outcomeCounts)",
+		"if (comparison)",
+		'generatedPath: path.join("tests", "generated.opfs-readback.mjs")',
+		"scenarioConfig.supportFiles ?? []",
+	]) {
+		assert.ok(standalone.includes(required), `standalone missing ${required}`);
+	}
+	assert.ok(
+		standalone.indexOf("const outcomeCounts = countBenchmarkOutcomes") <
+			standalone.indexOf("const comparison ="),
+		"standalone comparison must be gated by complete outcome counts",
+	);
+
+	const matrix = await readFile(
+		path.join(
+			repoRoot,
+			"scripts",
+			"file-share",
+			"run-file-share-benchmark-matrix.mjs",
+		),
+		"utf8",
+	);
+	for (const required of [
+		"compareUploadPerformanceModesForCompletePlan(",
+		"variantOutcomeCounts",
+		"const matrixPlanPassed = isCompletePassedBenchmarkPlan(",
+		"adaptiveComparison: matrixPlanPassed",
+		"if (matrixSummary.adaptiveComparison)",
+		"adaptiveLibraryStreamWallMsAvg",
+		"libraryStreamWallDeltaMs",
+		"primaryDownloadAuthoritative",
+	]) {
+		assert.ok(matrix.includes(required), `matrix missing ${required}`);
 	}
 });
 

--- a/scripts/file-share/templates/opfs-readback.mjs
+++ b/scripts/file-share/templates/opfs-readback.mjs
@@ -1,0 +1,110 @@
+export const OPFS_READBACK_CHUNK_BYTES = 4 * 1024 * 1024;
+
+const CRC32_INITIAL_STATE = 0xffffffff;
+const CRC32_TABLE = (() => {
+	const table = new Uint32Array(256);
+	for (let index = 0; index < table.length; index++) {
+		let value = index;
+		for (let bit = 0; bit < 8; bit++) {
+			value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+		}
+		table[index] = value >>> 0;
+	}
+	return table;
+})();
+
+const updateCrc32State = (state, bytes) => {
+	let next = state >>> 0;
+	for (const byte of bytes) {
+		next = CRC32_TABLE[(next ^ byte) & 0xff] ^ (next >>> 8);
+	}
+	return next >>> 0;
+};
+
+const formatCrc32State = (state) =>
+	((state ^ CRC32_INITIAL_STATE) >>> 0).toString(16).padStart(8, "0");
+
+const toBase64 = (bytes) => btoa(String.fromCharCode(...bytes));
+
+// OPFS is an explicit persistence-diagnostic cohort. Its bounded cryptographic
+// readback runs after the measured sink has closed, so it cannot extend the
+// download timing or materialize the whole benchmark file in renderer memory.
+export const sha256AndCrc32OpfsSavedViaPicker = async (
+	page,
+	fileName,
+	expectedSizeBytes,
+	createSha256,
+) => {
+	if (typeof createSha256 !== "function") {
+		throw new TypeError(
+			"OPFS readback requires an incremental SHA-256 factory",
+		);
+	}
+	const saved = await page.evaluate(async (expectedName) => {
+		const files = window.__mockSavedFiles ?? [];
+		const match = [...files]
+			.reverse()
+			.find((file) => file.name === expectedName && file.sink === "opfs");
+		if (!match) {
+			throw new Error(`No completed OPFS sink named "${expectedName}"`);
+		}
+		const root = await navigator.storage.getDirectory();
+		const handle = await root.getFileHandle(match.storageName);
+		const file = await handle.getFile();
+		return { storageName: match.storageName, sizeBytes: file.size };
+	}, fileName);
+	if (saved.sizeBytes !== expectedSizeBytes) {
+		throw new Error("Persisted OPFS readback size does not match fixture");
+	}
+
+	const sha256 = createSha256();
+	let crc32State = CRC32_INITIAL_STATE;
+	let totalBytes = 0;
+	for (
+		let offset = 0;
+		offset < expectedSizeBytes;
+		offset += OPFS_READBACK_CHUNK_BYTES
+	) {
+		const end = Math.min(expectedSizeBytes, offset + OPFS_READBACK_CHUNK_BYTES);
+		const chunk = await page.evaluate(
+			async ({ storageName, offset: start, end: finish, expectedSize }) => {
+				const root = await navigator.storage.getDirectory();
+				const handle = await root.getFileHandle(storageName);
+				const file = await handle.getFile();
+				if (file.size !== expectedSize) {
+					throw new Error("Persisted OPFS file changed during readback");
+				}
+				return new Uint8Array(await file.slice(start, finish).arrayBuffer());
+			},
+			{
+				storageName: saved.storageName,
+				offset,
+				end,
+				expectedSize: expectedSizeBytes,
+			},
+		);
+		if (!(chunk instanceof Uint8Array)) {
+			throw new Error("Persisted OPFS readback returned invalid bytes");
+		}
+		if (chunk.byteLength !== end - offset) {
+			throw new Error("Persisted OPFS readback returned a truncated chunk");
+		}
+		sha256.update(chunk);
+		crc32State = updateCrc32State(crc32State, chunk);
+		totalBytes += chunk.byteLength;
+	}
+	if (totalBytes !== expectedSizeBytes) {
+		throw new Error(
+			"Persisted OPFS readback byte count does not match fixture",
+		);
+	}
+	const digest = sha256.digest();
+	if (!(digest instanceof Uint8Array) || digest.byteLength !== 32) {
+		throw new Error("Incremental OPFS SHA-256 returned an invalid digest");
+	}
+	return {
+		sizeBytes: totalBytes,
+		sha256Base64: toBase64(digest),
+		crc32Hex: formatCrc32State(crc32State),
+	};
+};

--- a/scripts/file-share/templates/seeder-probe.e2e.spec.ts
+++ b/scripts/file-share/templates/seeder-probe.e2e.spec.ts
@@ -24,7 +24,7 @@ const EFFECTIVE_SAMPLE_INTERVAL_MS = Math.max(
 );
 const RESULT_SCHEMA = {
 	id: "peerbit-file-share-benchmark",
-	version: 3,
+	version: 4,
 } as const;
 const RUN_NONCE = process.env.PW_BENCHMARK_RUN_NONCE;
 const parseJsonEnvironment = (name: string) => {
@@ -69,7 +69,7 @@ if (!Number.isSafeInteger(TARGET_SEEDERS) || TARGET_SEEDERS < 0) {
 if (
 	(INVOCATION.schema as Record<string, unknown> | undefined)?.id !==
 		"peerbit-file-share-benchmark-invocation" ||
-	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 1
+	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 2
 ) {
 	throw new Error("Unsupported PW_BENCHMARK_INVOCATION schema");
 }

--- a/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
+++ b/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
@@ -1,20 +1,29 @@
 import { type Page, expect, test } from "@playwright/test";
+import { SHA256 } from "@stablelib/sha256";
 import { randomUUID } from "node:crypto";
 import { mkdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { startBootstrapPeer } from "./bootstrapPeer";
+import { sha256AndCrc32OpfsSavedViaPicker } from "./generated.opfs-readback.mjs";
 import {
 	armSavedViaPicker,
+	crc32SavedViaPicker,
 	createSpace,
 	createSyntheticFileOnDisk,
 	expectSeedersAtLeast,
 	getSeederCount,
+	installHashOnlyMockSaveFilePicker,
+	installMockSaveFilePicker,
 	installNodeBackedMockSaveFilePicker,
 	rootUrl,
 	sha256AndCrc32File,
 	waitForUploadComplete,
 	withBootstrap,
 } from "./helpers";
+import {
+	resolveBenchmarkDownloadSink,
+	summarizeReadTransferDiagnostics,
+} from "./transfer-benchmark";
 
 const FILE_SIZE_MB = Number(process.env.PW_FILE_MB || "100");
 const FILE_SIZE_BYTES = FILE_SIZE_MB * 1024 * 1024;
@@ -48,11 +57,32 @@ const ERROR_COLLECTION_DEFINITION =
 	"from collector attachment through result snapshot: every uncaught pageerror; every console.error; every console message at any level containing a known Peerbit failure signature; plus scenario-recorded operation failures";
 const REQUEST_FAILURE_COLLECTION_DEFINITION =
 	"from collector attachment through result snapshot: every Playwright requestfailed event, retained as non-fatal diagnostics and excluded from errorCount";
+const DOWNLOAD_DURATION_DEFINITION =
+	"reader-download-click-to-selected-backpressured-sink-complete";
+const SINK_WRITE_DURATION_DEFINITION =
+	"sum of browser writable.write wall-clock durations; library read diagnostics provide the authoritative awaited sink-write interval";
+const SINK_SERVER_WRITE_DURATION_DEFINITION =
+	"loopback-request-body-receive-and-node-filesystem-write-only";
+const LIBRARY_STREAM_WALL_DEFINITION =
+	"library-large-file-stream-start-to-finish including awaited sink writes";
+const SINK_WRITE_AWAIT_DEFINITION =
+	"sum of per-chunk library wall-clock intervals awaiting writable.write";
+const SINK_AWAIT_SUBTRACTED_DIAGNOSTIC_DEFINITION =
+	"arithmetic library stream wall-clock duration minus summed awaited writable.write intervals; overlap-sensitive and not a sink-independent Peerbit duration";
+const PRIMARY_DOWNLOAD_METRIC = "libraryStreamWallMs";
+const PRIMARY_DOWNLOAD_METRIC_DEFINITION =
+	"authoritative only within one fixed download-sink cohort; hash-only is the standardized primary cohort and includes awaited sink writes plus any overlapping read-ahead";
+// Date.now() endpoints can undercount the nested performance.now() helper
+// interval by less than one millisecond for each chunk.
+const SINK_WRITE_QUANTIZATION_ALLOWANCE_MS_PER_CHUNK = 1;
+// Browser performance.now() and Node hrtime measure nested intervals on
+// independent monotonic clocks; keep their aggregate drift finite per call.
+const SINK_SERVER_CLOCK_TOLERANCE_MS_PER_CHUNK = 1;
 const FIXTURE_SEED =
 	process.env.PW_FIXTURE_SEED || "peerbit-file-share-benchmark-v1";
 const RESULT_SCHEMA = {
 	id: "peerbit-file-share-benchmark",
-	version: 3,
+	version: 4,
 } as const;
 const RUN_NONCE = process.env.PW_BENCHMARK_RUN_NONCE;
 const parseJsonEnvironment = (name: string) => {
@@ -70,6 +100,9 @@ const PROVENANCE = parseJsonEnvironment("PW_BENCHMARK_PROVENANCE");
 const INVOCATION = parseJsonEnvironment("PW_BENCHMARK_INVOCATION");
 const MODE = process.env.PW_REPLICATION_MODE || "adaptive";
 const NETWORK_MODE = process.env.PW_NETWORK_MODE || "local";
+const DOWNLOAD_SINK = resolveBenchmarkDownloadSink(
+	process.env.PW_DOWNLOAD_SINK,
+);
 const RESULT_FILE = process.env.PW_RESULT_FILE;
 const ENABLE_VISIBILITY_PROBE = process.env.PW_ENABLE_VISIBILITY_PROBE === "1";
 const MIN_READY_SEEDERS = Number(process.env.PW_MIN_READY_SEEDERS);
@@ -113,6 +146,7 @@ const expectedInvocationValues: Record<string, unknown> = {
 	fileSizeMb: FILE_SIZE_MB,
 	fileSizeBytes: FILE_SIZE_BYTES,
 	fixtureSeed: FIXTURE_SEED,
+	downloadSink: DOWNLOAD_SINK,
 	uploadTimeoutMs: UPLOAD_TIMEOUT_MS,
 	downloadTimeoutMs: DOWNLOAD_TIMEOUT_MS,
 	postUploadMonitorMs: POST_UPLOAD_MONITOR_MS,
@@ -131,7 +165,7 @@ const expectedInvocationValues: Record<string, unknown> = {
 if (
 	(INVOCATION.schema as Record<string, unknown> | undefined)?.id !==
 		"peerbit-file-share-benchmark-invocation" ||
-	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 1
+	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 2
 ) {
 	throw new Error("Unsupported PW_BENCHMARK_INVOCATION schema");
 }
@@ -297,6 +331,8 @@ const probeVisibilityPath = async (page: Page) => {
 
 type ReadyManifestEvidence = {
 	capturedAt: number;
+	fileId: string;
+	fileName: string;
 	sizeBytes: number;
 	finalHash: string;
 };
@@ -329,6 +365,9 @@ const waitForReadyManifest = async (
 			if (file.finalHash !== expectedHash) {
 				throw new Error("Ready manifest hash does not match fixture SHA-256");
 			}
+			if (typeof file.id !== "string" || file.id.length === 0) {
+				throw new Error("Ready manifest is missing its stable file id");
+			}
 			const row = Array.from(document.querySelectorAll("li")).find(
 				(candidate) =>
 					Array.from(candidate.querySelectorAll("span")).some(
@@ -345,6 +384,8 @@ const waitForReadyManifest = async (
 			}
 			return {
 				capturedAt: Date.now(),
+				fileId: file.id,
+				fileName: expectedName,
 				sizeBytes: expectedSize,
 				finalHash: file.finalHash,
 			};
@@ -422,7 +463,7 @@ test.describe("generated transfer-validity benchmark", () => {
 		const bootstrap:
 			| Awaited<ReturnType<typeof startBootstrapPeer>>
 			| undefined = usesLocalBootstrap ? await startBootstrapPeer() : undefined;
-		const fileName = `file-share-benchmark-${MODE}-${Date.now()}.bin`;
+		const fileName = `file-share-benchmark-${MODE}-${RUN_NONCE}.bin`;
 		const writerContext = await browser.newContext({ acceptDownloads: true });
 		const readerContext = await browser.newContext({ acceptDownloads: true });
 		const writer = await writerContext.newPage();
@@ -448,6 +489,7 @@ test.describe("generated transfer-validity benchmark", () => {
 		let postMonitorFinishedAt: number | undefined;
 		let downloadStartedAt: number | undefined;
 		let downloadFinishedAt: number | undefined;
+		let downloadCompletionObservedAt: number | undefined;
 		let shareUrl: string | undefined;
 		let writerVisibilityProbe: Record<string, unknown> | null = null;
 		let readerVisibilityProbe: Record<string, unknown> | null = null;
@@ -574,11 +616,20 @@ test.describe("generated transfer-validity benchmark", () => {
 					};
 
 		try {
-			stage = "install-node-download-sink";
-			nodeSinkController = await installNodeBackedMockSaveFilePicker(reader, {
-				expectedName: fileName,
-				expectedSizeBytes: FILE_SIZE_BYTES,
-			});
+			stage = `install-${DOWNLOAD_SINK}-download-sink`;
+			if (DOWNLOAD_SINK === "node-file") {
+				nodeSinkController = await installNodeBackedMockSaveFilePicker(reader, {
+					expectedName: fileName,
+					expectedSizeBytes: FILE_SIZE_BYTES,
+				});
+			} else if (DOWNLOAD_SINK === "hash-only") {
+				await installHashOnlyMockSaveFilePicker(reader, {
+					expectedName: fileName,
+					expectedSizeBytes: FILE_SIZE_BYTES,
+				});
+			} else {
+				await installMockSaveFilePicker(reader);
+			}
 			stage = "create-space";
 			logStage(stage, { networkMode: NETWORK_MODE });
 			const entryUrl =
@@ -748,8 +799,8 @@ test.describe("generated transfer-validity benchmark", () => {
 				);
 			}
 
-			stage = "persisted-download";
-			logStage(stage);
+			stage = "download-to-selected-sink";
+			logStage(stage, { downloadSink: DOWNLOAD_SINK });
 			const row = reader.locator("li", { hasText: fileName }).first();
 			await expect(row).toBeVisible({ timeout: DOWNLOAD_TIMEOUT_MS });
 			const byTestId = row.getByTestId("download-file");
@@ -764,32 +815,202 @@ test.describe("generated transfer-validity benchmark", () => {
 				FILE_SIZE_MB,
 				DOWNLOAD_TIMEOUT_MS,
 			);
-			downloadStartedAt = Date.now();
+			const downloadClickStartedAt = Date.now();
+			downloadStartedAt = downloadClickStartedAt;
 			await downloadButton.click();
 			const download = await downloadCompletion;
-			downloadFinishedAt = Date.now();
-			cleanupDownload = download.cleanup;
-			if (download.sink !== "node-file" || !download.downloadPath) {
+			downloadCompletionObservedAt = Date.now();
+			if (
+				!Number.isSafeInteger(download.sinkCompletedAt) ||
+				download.sinkCompletedAt < downloadClickStartedAt ||
+				download.sinkCompletedAt > downloadCompletionObservedAt
+			) {
 				throw new Error(
-					"Download did not complete through the persisted Node file sink",
+					"Download sink completion timestamp is outside the click-to-observation window",
+				);
+			}
+			downloadFinishedAt = download.sinkCompletedAt;
+			cleanupDownload = download.cleanup;
+			if (download.sink !== DOWNLOAD_SINK) {
+				throw new Error(
+					`Download completed through ${download.sink}, expected ${DOWNLOAD_SINK}`,
+				);
+			}
+			if (DOWNLOAD_SINK === "node-file" && !download.downloadPath) {
+				throw new Error("Node-file download did not expose its persisted path");
+			}
+			if (DOWNLOAD_SINK !== "node-file" && download.downloadPath != null) {
+				throw new Error(
+					`${DOWNLOAD_SINK} download unexpectedly exposed a Node file path`,
 				);
 			}
 
 			stage = "verify-integrity";
-			const downloadedDigests = await sha256AndCrc32File(download.downloadPath);
+			const readerDiagnostics = await getDiagnostics(reader);
+			if (!readerDiagnostics) {
+				throw new Error("Missing reader diagnostics after sink completion");
+			}
+			const rawReadDiagnosticsValue = (
+				readerDiagnostics as Record<string, unknown>
+			).lastReadDiagnostics;
+			if (
+				rawReadDiagnosticsValue == null ||
+				typeof rawReadDiagnosticsValue !== "object" ||
+				Array.isArray(rawReadDiagnosticsValue)
+			) {
+				throw new Error("Missing completed library read diagnostics");
+			}
+			const rawReadDiagnostics = rawReadDiagnosticsValue as Record<
+				string,
+				unknown
+			>;
+			const libraryReadStartedAt = rawReadDiagnostics.startedAt;
+			const libraryReadFinishedAt = rawReadDiagnostics.finishedAt;
+			if (
+				!Number.isSafeInteger(libraryReadStartedAt) ||
+				!Number.isSafeInteger(libraryReadFinishedAt) ||
+				downloadStartedAt == null ||
+				downloadFinishedAt == null ||
+				(libraryReadStartedAt as number) < downloadStartedAt ||
+				(libraryReadFinishedAt as number) < (libraryReadStartedAt as number) ||
+				(libraryReadFinishedAt as number) > downloadFinishedAt
+			) {
+				throw new Error(
+					"Library read diagnostics are outside the clicked download window",
+				);
+			}
+			if (
+				rawReadDiagnostics.fileName !== fileName ||
+				rawReadDiagnostics.fileId !== readerManifestEvidence?.fileId ||
+				writerManifestEvidence?.fileId !== readerManifestEvidence?.fileId ||
+				typeof rawReadDiagnostics.transferId !== "string" ||
+				rawReadDiagnostics.transferId.length === 0
+			) {
+				throw new Error(
+					"Library read diagnostics do not match the clicked file manifest",
+				);
+			}
+			const summarizedReadTransfer = summarizeReadTransferDiagnostics(
+				rawReadDiagnostics,
+				expectedSizeBytes,
+			);
+			const {
+				streamReadExclusiveMs: sinkAwaitSubtractedDiagnosticMs,
+				...readTransferStages
+			} = summarizedReadTransfer.stages;
+			const readTransfer = {
+				...summarizedReadTransfer,
+				stages: {
+					...readTransferStages,
+					sinkAwaitSubtractedDiagnosticMs,
+				},
+			};
+			const libraryComputedSha256Base64 = rawReadDiagnostics.computedFinalHash;
+			if (typeof libraryComputedSha256Base64 !== "string") {
+				throw new Error("Missing library-computed download SHA-256");
+			}
+			if (
+				!Number.isSafeInteger(download.sinkWriteCalls) ||
+				(download.sinkWriteCalls ?? -1) <= 0 ||
+				download.sinkWriteCalls !== readTransfer.chunkCount ||
+				typeof download.sinkWriteDurationMs !== "number" ||
+				!Number.isFinite(download.sinkWriteDurationMs) ||
+				download.sinkWriteDurationMs < 0
+			) {
+				throw new Error("Download sink timing evidence is incomplete");
+			}
+			if (
+				download.sinkWriteDurationMs >
+				readTransfer.stages.sinkWriteAwaitMs +
+					readTransfer.chunkCount *
+						SINK_WRITE_QUANTIZATION_ALLOWANCE_MS_PER_CHUNK
+			) {
+				throw new Error(
+					"Download sink helper duration exceeds canonical read evidence plus its bounded clock allowance",
+				);
+			}
+			if (DOWNLOAD_SINK === "node-file") {
+				if (
+					!Number.isSafeInteger(download.serverWriteCalls) ||
+					download.serverWriteCalls !== download.sinkWriteCalls ||
+					typeof download.serverWriteDurationMs !== "number" ||
+					!Number.isFinite(download.serverWriteDurationMs) ||
+					download.serverWriteDurationMs < 0
+				) {
+					throw new Error("Node-file server timing evidence is incomplete");
+				}
+				if (
+					download.serverWriteDurationMs >
+					download.sinkWriteDurationMs +
+						readTransfer.chunkCount * SINK_SERVER_CLOCK_TOLERANCE_MS_PER_CHUNK
+				) {
+					throw new Error(
+						"Node-file server duration exceeds its browser sink duration plus the bounded clock tolerance",
+					);
+				}
+			} else if (
+				download.serverWriteCalls != null ||
+				download.serverWriteDurationMs != null
+			) {
+				throw new Error(
+					`${DOWNLOAD_SINK} download reported Node-only server timing evidence`,
+				);
+			}
+			const nodePersistedSinkDigests = download.downloadPath
+				? await sha256AndCrc32File(download.downloadPath)
+				: null;
+			const opfsPersistedSinkDigests =
+				DOWNLOAD_SINK === "opfs"
+					? await sha256AndCrc32OpfsSavedViaPicker(
+							reader,
+							fileName,
+							expectedSizeBytes,
+							() => new SHA256(),
+						)
+					: null;
+			if (
+				opfsPersistedSinkDigests &&
+				opfsPersistedSinkDigests.sizeBytes !== expectedSizeBytes
+			) {
+				throw new Error("Persisted OPFS readback size does not match fixture");
+			}
+			const persistedSinkDigests =
+				nodePersistedSinkDigests ?? opfsPersistedSinkDigests;
+			const downloadedCrc32Hex = persistedSinkDigests
+				? persistedSinkDigests.crc32Hex
+				: await crc32SavedViaPicker(reader, fileName);
 			const sizeVerified = download.size === expectedSizeBytes;
+			const librarySha256Verified =
+				libraryComputedSha256Base64 === preparedFile.fixture.sha256Base64;
+			const persistedSinkSha256Verified = persistedSinkDigests
+				? persistedSinkDigests.sha256Base64 ===
+					preparedFile.fixture.sha256Base64
+				: null;
 			const sha256Verified =
-				downloadedDigests.sha256Base64 === preparedFile.fixture.sha256Base64;
+				librarySha256Verified &&
+				(DOWNLOAD_SINK === "hash-only" || persistedSinkSha256Verified === true);
 			const crc32Verified =
-				downloadedDigests.crc32Hex === preparedFile.fixture.crc32Hex;
+				downloadedCrc32Hex === preparedFile.fixture.crc32Hex;
 			const manifestVerified =
 				writerManifestEvidence?.sizeBytes === expectedSizeBytes &&
 				readerManifestEvidence?.sizeBytes === expectedSizeBytes &&
 				writerManifestEvidence?.finalHash ===
 					preparedFile.fixture.sha256Base64 &&
 				readerManifestEvidence?.finalHash === preparedFile.fixture.sha256Base64;
+			const sinkPersistence =
+				DOWNLOAD_SINK === "hash-only" ? "none" : DOWNLOAD_SINK;
+			const sinkPersistenceVerified =
+				DOWNLOAD_SINK === "hash-only"
+					? null
+					: sizeVerified &&
+						crc32Verified &&
+						persistedSinkSha256Verified === true;
 			const integrityVerified =
-				sizeVerified && sha256Verified && crc32Verified && manifestVerified;
+				sizeVerified &&
+				sha256Verified &&
+				crc32Verified &&
+				manifestVerified &&
+				sinkPersistenceVerified !== false;
 			const integrity = {
 				fixtureMode: "deterministic",
 				fixtureFormat: preparedFile.fixture.mode,
@@ -799,12 +1020,18 @@ test.describe("generated transfer-validity benchmark", () => {
 				manifestSizeBytes: readerManifestEvidence?.sizeBytes,
 				downloadedSizeBytes: download.size,
 				sourceSha256Base64: preparedFile.fixture.sha256Base64,
-				downloadedSha256Base64: downloadedDigests.sha256Base64,
+				libraryComputedSha256Base64,
+				downloadedSha256Base64: persistedSinkDigests?.sha256Base64 ?? null,
 				manifestSha256Base64: readerManifestEvidence?.finalHash,
 				sourceCrc32Hex: preparedFile.fixture.crc32Hex,
-				downloadedCrc32Hex: downloadedDigests.crc32Hex,
+				downloadedCrc32Hex,
+				downloadSink: DOWNLOAD_SINK,
+				sinkPersistence,
+				sinkPersistenceVerified,
 				sizeVerified,
 				sha256Verified,
+				librarySha256Verified,
+				persistedSinkSha256Verified,
 				crc32Verified,
 				manifestVerified,
 				verified: integrityVerified,
@@ -834,7 +1061,8 @@ test.describe("generated transfer-validity benchmark", () => {
 				postMonitorStartedAt == null ||
 				postMonitorFinishedAt == null ||
 				downloadStartedAt == null ||
-				downloadFinishedAt == null
+				downloadFinishedAt == null ||
+				downloadCompletionObservedAt == null
 			) {
 				throw new Error("Benchmark completed without all phase timestamps");
 			}
@@ -853,7 +1081,6 @@ test.describe("generated transfer-validity benchmark", () => {
 				);
 			}
 			const writerDiagnostics = await getDiagnostics(writer);
-			const readerDiagnostics = await getDiagnostics(reader);
 			if (errors.length > 0) {
 				throw new Error(
 					`Observed transfer/delivery errors while collecting diagnostics: ${JSON.stringify(errors)}`,
@@ -869,6 +1096,7 @@ test.describe("generated transfer-validity benchmark", () => {
 				status: "passed",
 				mode: MODE,
 				networkMode: NETWORK_MODE,
+				fileName,
 				fileSizeMb: FILE_SIZE_MB,
 				integrity,
 				integrityVerified,
@@ -893,13 +1121,34 @@ test.describe("generated transfer-validity benchmark", () => {
 				postUploadMonitorSchedulingToleranceDefinition:
 					POST_MONITOR_SCHEDULING_TOLERANCE_DEFINITION,
 				downloadDurationMs: downloadFinishedAt - downloadStartedAt,
-				downloadDurationDefinition:
-					"reader-download-click-to-backpressured-node-file-sink-complete",
+				downloadDurationDefinition: DOWNLOAD_DURATION_DEFINITION,
 				transferTimeoutSchedulingToleranceMs:
 					TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS,
 				transferTimeoutSchedulingToleranceDefinition:
 					TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION,
 				downloadSink: download.sink,
+				requestedDownloadSink: DOWNLOAD_SINK,
+				sinkWriteCalls: download.sinkWriteCalls,
+				sinkWriteDurationMs: download.sinkWriteDurationMs,
+				sinkWriteDurationDefinition: SINK_WRITE_DURATION_DEFINITION,
+				sinkServerWriteCalls: download.serverWriteCalls ?? null,
+				sinkServerWriteDurationMs: download.serverWriteDurationMs ?? null,
+				sinkServerWriteDurationDefinition:
+					download.sink === "node-file"
+						? SINK_SERVER_WRITE_DURATION_DEFINITION
+						: null,
+				readTransfer,
+				libraryStreamWallMs: readTransfer.stages.libraryStreamWallMs,
+				libraryStreamWallDefinition: LIBRARY_STREAM_WALL_DEFINITION,
+				primaryDownloadMetric: PRIMARY_DOWNLOAD_METRIC,
+				primaryDownloadAuthoritative: DOWNLOAD_SINK === "hash-only",
+				primaryDownloadMetricDefinition: PRIMARY_DOWNLOAD_METRIC_DEFINITION,
+				sinkWriteAwaitMs: readTransfer.stages.sinkWriteAwaitMs,
+				sinkWriteAwaitDefinition: SINK_WRITE_AWAIT_DEFINITION,
+				sinkAwaitSubtractedDiagnosticMs:
+					readTransfer.stages.sinkAwaitSubtractedDiagnosticMs,
+				sinkAwaitSubtractedDiagnosticDefinition:
+					SINK_AWAIT_SUBTRACTED_DIAGNOSTIC_DEFINITION,
 				phaseDurationsMs,
 				timestamps: {
 					uploadStartedAt,
@@ -912,6 +1161,7 @@ test.describe("generated transfer-validity benchmark", () => {
 					postMonitorFinishedAt,
 					downloadStartedAt,
 					downloadFinishedAt,
+					downloadCompletionObservedAt,
 				},
 				writerManifestEvidence,
 				readerManifestEvidence,
@@ -959,6 +1209,7 @@ test.describe("generated transfer-validity benchmark", () => {
 				networkMode: NETWORK_MODE,
 				fileSizeMb: FILE_SIZE_MB,
 				stage,
+				requestedDownloadSink: DOWNLOAD_SINK,
 				integrityVerified: false,
 				phaseDurationsMs: getPhaseDurations(),
 				postUploadMonitorSchedulingToleranceMs:


### PR DESCRIPTION
## Summary
- make hash-only the standardized primary download cohort and use `libraryStreamWallMs` as the authoritative same-sink metric
- label sink-await subtraction as overlap-sensitive diagnostic evidence and reject mixed-sink/partial-plan comparisons
- bind read diagnostics to the nonce-derived filename, stable manifest file ID, and clicked download time window
- require persisted size, incremental SHA-256, and CRC-32 readback for OPFS and Node-file diagnostic sinks
- strengthen schema-v4 evidence, canonical per-chunk reconstruction, provenance, and aggregate gates

## Validation
- `pnpm bench:file-share:test` (147/147)
- Node syntax, Prettier, and `git diff --check`
- exact linked 6 MiB Chromium hash-only smoke: passed, authoritative, deterministic SHA-256/CRC-32, zero browser/request failures
- exact linked 6 MiB Chromium OPFS smoke: passed as a non-authoritative persistence cohort; persisted SHA-256/CRC-32/size all matched, zero browser/request failures
- immutable Peerbit `aedde54a…` and examples `106f54be…` checkouts remained clean
- independent final review found no actionable issues