### PR TITLE
fix(benchmarks): bound reader manifest readiness

### DIFF
--- a/scripts/file-share/benchmark-validity.mjs
+++ b/scripts/file-share/benchmark-validity.mjs
@@ -731,6 +731,11 @@ const validateUploadTimings = (result, invocation) => {
 	) {
 		throw new Error("Benchmark phase timestamps are not monotonic");
 	}
+	if (readerListedAt > uploadSettledAt + invocation.readyTimeoutMs) {
+		throw new Error(
+			"Benchmark reader readiness exceeded the requested post-writer deadline",
+		);
+	}
 	const progressVisibleAt =
 		timestamps.progressVisibleAt == null
 			? undefined

--- a/scripts/file-share/benchmark-validity.test.mjs
+++ b/scripts/file-share/benchmark-validity.test.mjs
@@ -827,6 +827,30 @@ for (const [name, mutate, pattern] of [
 		/readyTimeoutMs does not match the requested invocation/,
 	],
 	[
+		"reader readiness after the post-writer deadline",
+		(result) => {
+			const readerListedAt =
+				result.timestamps.uploadSettledAt +
+				result.invocation.readyTimeoutMs +
+				1;
+			result.timestamps.readerListedAt = readerListedAt;
+			result.timeToReaderReadyMs =
+				readerListedAt - result.timestamps.uploadStartedAt;
+			result.phaseDurationsMs.timeToReaderReady = result.timeToReaderReadyMs;
+			result.phaseDurationsMs.readerListingLag =
+				readerListedAt - result.timestamps.uploadSettledAt;
+			result.phaseDurationsMs.readerAfterWriter =
+				readerListedAt - result.timestamps.writerListedAt;
+			result.listingDurationMs = result.phaseDurationsMs.readerListingLag;
+			result.timestamps.postMonitorStartedAt = readerListedAt;
+			result.timestamps.postMonitorFinishedAt = readerListedAt + 50;
+			result.timestamps.downloadStartedAt = readerListedAt + 50;
+			result.timestamps.downloadFinishedAt = readerListedAt + 80;
+			result.timestamps.downloadCompletionObservedAt = readerListedAt + 81;
+		},
+		/requested post-writer deadline/,
+	],
+	[
 		"short monitor",
 		(result) => {
 			result.postUploadMonitorDurationMs = 49;

--- a/scripts/file-share/promise-deadline.test.mjs
+++ b/scripts/file-share/promise-deadline.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withDeadline } from "./templates/promise-deadline.mjs";
+
+test("withDeadline preserves a promise that settles before its deadline", async () => {
+	assert.equal(
+		await withDeadline(Promise.resolve("ready"), 1_000, "late"),
+		"ready",
+	);
+});
+
+test("withDeadline rejects a promise that remains pending", async () => {
+	const startedAt = performance.now();
+	await assert.rejects(
+		withDeadline(new Promise(() => {}), 20, "reader listing expired"),
+		/reader listing expired/,
+	);
+	const elapsedMs = performance.now() - startedAt;
+	assert.ok(elapsedMs >= 10, `deadline fired too early after ${elapsedMs}ms`);
+	assert.ok(
+		elapsedMs < 1_000,
+		`deadline failed to bound the wait: ${elapsedMs}ms`,
+	);
+});
+
+test("withDeadline validates its deadline contract", async () => {
+	await assert.rejects(
+		withDeadline(Promise.resolve(), 0, "expired"),
+		/timeoutMs must be a positive safe integer/,
+	);
+	await assert.rejects(
+		withDeadline(Promise.resolve(), 1, ""),
+		/deadline message must be a non-empty string/,
+	);
+});

--- a/scripts/file-share/run-file-share-benchmark.mjs
+++ b/scripts/file-share/run-file-share-benchmark.mjs
@@ -75,6 +75,16 @@ const SCENARIOS = {
 					"scripts",
 					"file-share",
 					"templates",
+					"promise-deadline.mjs",
+				),
+				generatedPath: path.join("tests", "generated.promise-deadline.mjs"),
+			},
+			{
+				templatePath: path.join(
+					repoRoot,
+					"scripts",
+					"file-share",
+					"templates",
 					"opfs-readback.mjs",
 				),
 				generatedPath: path.join("tests", "generated.opfs-readback.mjs"),

--- a/scripts/file-share/template-contract.test.mjs
+++ b/scripts/file-share/template-contract.test.mjs
@@ -51,7 +51,9 @@ for (const name of templates) {
 			"diagnostics.programClosed === false",
 			"await hooks.setReplicationRole(role)",
 			"timeout: READY_TIMEOUT_MS",
-			"2 * READY_TIMEOUT_MS",
+			name === "upload-benchmark.local.e2e.spec.ts"
+				? "3 * READY_TIMEOUT_MS"
+				: "2 * READY_TIMEOUT_MS",
 		]) {
 			assert.ok(
 				contents.includes(required),
@@ -133,7 +135,7 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"writerListedAt - uploadStartedAt",
 		"readerListedAt - uploadStartedAt",
 		"readyTimeoutMs: READY_TIMEOUT_MS",
-		"2 * READY_TIMEOUT_MS +",
+		"3 * READY_TIMEOUT_MS +",
 		"POST_MONITOR_SCHEDULING_TOLERANCE_MS",
 		"TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS",
 		"Measured transfer duration exceeded",
@@ -143,6 +145,14 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"installNodeBackedMockSaveFilePicker",
 		"summarizeReadTransferDiagnostics",
 		"libraryComputedSha256Base64",
+		'import { withDeadline } from "./generated.promise-deadline.mjs"',
+		"UPLOAD_TIMEOUT_MS +",
+		"READY_TIMEOUT_MS +",
+		"const boundedReaderListedPromise =",
+		"const readerManifest = await boundedReaderListedPromise",
+		"readerListedPromise,",
+		"readerReadyRemainingMs,",
+		"Reader ready manifest was not listed within ${READY_TIMEOUT_MS}ms after writer readiness",
 		"sinkAwaitSubtractedDiagnosticMs",
 		"primaryDownloadMetric: PRIMARY_DOWNLOAD_METRIC",
 		'primaryDownloadAuthoritative: DOWNLOAD_SINK === "hash-only"',
@@ -186,6 +196,16 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 	assert.ok(
 		!contents.includes('crypto.subtle.digest("SHA-256"'),
 		"OPFS SHA-256 readback must remain bounded rather than buffering the file",
+	);
+	assert.match(
+		contents,
+		/const readerListedPromise = waitForReadyManifest\(\s*reader,\s*fileName,\s*expectedSizeBytes,\s*preparedFile\.fixture\.sha256Base64,\s*UPLOAD_TIMEOUT_MS \+\s*READY_TIMEOUT_MS \+\s*TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS,\s*\)/,
+		"the early reader observation must remain alive through upload plus the post-writer readiness window",
+	);
+	assert.match(
+		contents,
+		/uploadSettledAt = writerReady\.readyAt;[\s\S]*?const boundedReaderListedPromise =[\s\S]*?withDeadline\(\s*readerListedPromise,\s*readerReadyRemainingMs,[\s\S]*?if \(ENABLE_VISIBILITY_PROBE\)/,
+		"reader listing must arm its Node-side deadline before optional diagnostics",
 	);
 	const opfsReadback = await readFile(
 		path.join(
@@ -238,6 +258,7 @@ test("aggregate comparisons require every planned invocation to pass", async () 
 	for (const required of [
 		"compareUploadPerformanceModesForCompletePlan(results, outcomeCounts)",
 		"if (comparison)",
+		'generatedPath: path.join("tests", "generated.promise-deadline.mjs")',
 		'generatedPath: path.join("tests", "generated.opfs-readback.mjs")',
 		"scenarioConfig.supportFiles ?? []",
 	]) {

--- a/scripts/file-share/templates/promise-deadline.mjs
+++ b/scripts/file-share/templates/promise-deadline.mjs
@@ -1,0 +1,18 @@
+export const withDeadline = async (promise, timeoutMs, message) => {
+	if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+		throw new Error("timeoutMs must be a positive safe integer");
+	}
+	if (typeof message !== "string" || message.length === 0) {
+		throw new Error("deadline message must be a non-empty string");
+	}
+
+	let timer;
+	const deadline = new Promise((_, reject) => {
+		timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+	});
+	try {
+		return await Promise.race([promise, deadline]);
+	} finally {
+		clearTimeout(timer);
+	}
+};

--- a/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
+++ b/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
@@ -5,6 +5,7 @@ import { mkdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { startBootstrapPeer } from "./bootstrapPeer";
 import { sha256AndCrc32OpfsSavedViaPicker } from "./generated.opfs-readback.mjs";
+import { withDeadline } from "./generated.promise-deadline.mjs";
 import {
 	armSavedViaPicker,
 	crc32SavedViaPicker,
@@ -448,7 +449,7 @@ test.describe("generated transfer-validity benchmark", () => {
 		test.setTimeout(
 			Math.max(
 				20 * 60 * 1000,
-				2 * READY_TIMEOUT_MS +
+				3 * READY_TIMEOUT_MS +
 					UPLOAD_TIMEOUT_MS +
 					DOWNLOAD_TIMEOUT_MS +
 					POST_UPLOAD_MONITOR_MS +
@@ -717,7 +718,9 @@ test.describe("generated transfer-validity benchmark", () => {
 				fileName,
 				expectedSizeBytes,
 				preparedFile.fixture.sha256Base64,
-				UPLOAD_TIMEOUT_MS,
+				UPLOAD_TIMEOUT_MS +
+					READY_TIMEOUT_MS +
+					TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS,
 			).then((evidence) => ({ evidence, listedAt: evidence.capturedAt }));
 			void readerListedPromise.catch(() => {});
 			const writerReadyPromise = Promise.all([
@@ -760,6 +763,18 @@ test.describe("generated transfer-validity benchmark", () => {
 			// Writer readiness is the primary endpoint. A hidden progress element is
 			// only diagnostic because it can disappear before a ready manifest exists.
 			uploadSettledAt = writerReady.readyAt;
+			const readerReadyDeadlineAt = writerReady.readyAt + READY_TIMEOUT_MS;
+			const readerReadyDeadlineMessage = `Reader ready manifest was not listed within ${READY_TIMEOUT_MS}ms after writer readiness`;
+			const readerReadyRemainingMs = readerReadyDeadlineAt - Date.now();
+			const boundedReaderListedPromise =
+				readerReadyRemainingMs > 0
+					? withDeadline(
+							readerListedPromise,
+							readerReadyRemainingMs,
+							readerReadyDeadlineMessage,
+						)
+					: Promise.reject(new Error(readerReadyDeadlineMessage));
+			void boundedReaderListedPromise.catch(() => {});
 
 			if (ENABLE_VISIBILITY_PROBE) {
 				stage = "probe-visibility-path";
@@ -771,7 +786,12 @@ test.describe("generated transfer-validity benchmark", () => {
 
 			stage = "wait-for-reader-listing";
 			logStage(stage);
-			const readerManifest = await readerListedPromise;
+			const readerManifest = await boundedReaderListedPromise;
+			if (readerManifest.listedAt > readerReadyDeadlineAt) {
+				throw new Error(
+					`Reader ready manifest evidence was captured after its writer-readiness deadline (${readerManifest.listedAt} > ${readerReadyDeadlineAt})`,
+				);
+			}
 			readerManifestEvidence = readerManifest.evidence;
 			readerListedAt = readerManifest.listedAt;
 


### PR DESCRIPTION
## Summary

- preserve the early reader observation while bounding its post-writer wait with a Node-side deadline
- arm that deadline immediately at writer readiness, before optional diagnostics
- reject passed evidence captured outside the configured reader-readiness window
- include the added readiness window in the Playwright test budget

## Verification

- `pnpm run bench:file-share:test` (151/151)
- Node syntax checks for the runner and generated deadline helper
- Prettier and `git diff --check`

This closes an observability gap found during the deterministic 1 GiB file-share investigation: the reader previously inherited the one-hour upload timeout, so a missing ready root could hang far beyond `--ready-timeout-ms` and lose live diagnostics when manually interrupted.
