### PR TITLE
fix(shared-log): confirm only admitted entries

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -16269,6 +16269,7 @@ export class SharedLog<
 						);
 						return allToMergeMaterializedEntries;
 					};
+					let admittedMergeHashes: ReadonlySet<string> = new Set();
 					let nativePreparedCommittedHashes: Set<string> | undefined;
 					if (allToMerge.length > 0) {
 						const validateStartedAt = syncProfileStart(syncProfile);
@@ -16377,9 +16378,9 @@ export class SharedLog<
 						const entriesToPersist = usedNativeAllKeptJoinPlan
 							? allToMergeShallowEntries
 							: joinPlans.flatMap((plan) => plan.toPersist);
-						const coordinatePersistFallbackEntries: ShallowOrFullEntry<any>[] =
+						let coordinatePersistFallbackEntries: ShallowOrFullEntry<any>[] =
 							[];
-						const reusableCoordinatePersistItems: CoordinatePersistBatchItem<R>[] =
+						let reusableCoordinatePersistItems: CoordinatePersistBatchItem<R>[] =
 							[];
 						for (const entry of entriesToPersist) {
 							const reusablePlan = reusableCoordinatePlans.get(entry.hash);
@@ -16397,8 +16398,6 @@ export class SharedLog<
 								prepared: reusablePlan.prepared,
 							});
 						}
-						const reusableCoordinatePersistItemCount =
-							reusableCoordinatePersistItems.length;
 						let nativePreparedCoordinateBatch:
 							| NativeBackboneReceiveCoordinateBatch<R>
 							| undefined;
@@ -16501,6 +16500,34 @@ export class SharedLog<
 								__peerbitProfile: syncProfile,
 							});
 						}
+						// A recursive lower-log join can resolve successfully while declining
+						// an individual top-level entry (for example, when one of its parents
+						// is temporarily unavailable). The public Log.join() API intentionally
+						// does not expose that per-entry result, so make local index presence the
+						// authority before publishing any SharedLog-side effects. A successful
+						// prepared-facts batch is atomic and already proves every input hash.
+						const admittedHashes = joinedPreparedFacts
+							? new Set(allToMergeHashes)
+							: await this.log.hasMany(allToMergeHashes);
+						admittedMergeHashes = admittedHashes;
+						const admittedShallowEntries =
+							admittedHashes.size === allToMergeShallowEntries.length
+								? allToMergeShallowEntries
+								: allToMergeShallowEntries.filter((entry) =>
+										admittedHashes.has(entry.hash),
+									);
+						if (!joinedPreparedFacts) {
+							reusableCoordinatePersistItems =
+								reusableCoordinatePersistItems.filter((item) =>
+									admittedHashes.has(item.entry.hash),
+								);
+							coordinatePersistFallbackEntries =
+								coordinatePersistFallbackEntries.filter((entry) =>
+									admittedHashes.has(entry.hash),
+								);
+						}
+						const reusableCoordinatePersistItemCount =
+							reusableCoordinatePersistItems.length;
 						if (syncProfile) {
 							emitSyncProfileDuration(syncProfile, lowerLogJoinStartedAt, {
 								name: "sharedLog.receive.lowerLogJoin",
@@ -16512,6 +16539,7 @@ export class SharedLog<
 									batchHashOnlyEntryAdded,
 									programOnChange,
 									joinedPreparedFacts,
+									admittedEntries: admittedHashes.size,
 									nativePreparedCoordinatesFinished,
 								},
 							});
@@ -16586,11 +16614,11 @@ export class SharedLog<
 								},
 							});
 						}
-						for (const hash of allToMergeHashes) {
+						for (const hash of admittedHashes) {
 							confirmedHashes.add(hash);
 						}
 						const checkedPruneStartedAt = syncProfileStart(syncProfile);
-						await this.pruneJoinedEntriesNoLongerLed(allToMergeShallowEntries, {
+						await this.pruneJoinedEntriesNoLongerLed(admittedShallowEntries, {
 							decodedReplicaCounts: receiveReplicaCounts,
 							reusableLeaderPlans: reusableCoordinatePlans,
 							profile: syncProfile,
@@ -16605,15 +16633,17 @@ export class SharedLog<
 						}
 
 						for (const plan of joinPlans) {
-							plan.toDelete?.map((x) =>
-								this.pruneDebouncedFnAddIfNotKeeping({
-									key: x.hash,
-									value: {
-										entry: x,
-										leaders: plan.leaders as Map<string, any>,
-									},
-								}),
-							);
+							plan.toDelete
+								?.filter((entry) => admittedMergeHashes.has(entry.hash))
+								.map((entry) =>
+									this.pruneDebouncedFnAddIfNotKeeping({
+										key: entry.hash,
+										value: {
+											entry,
+											leaders: plan.leaders as Map<string, any>,
+										},
+									}),
+								);
 						}
 						this.rebalanceParticipationDebounced?.call();
 					}
@@ -16623,17 +16653,23 @@ export class SharedLog<
 							continue;
 						}
 						for (const entries of plan.maybeDelete) {
+							const admittedEntries = entries.filter((entry) =>
+								admittedMergeHashes.has(getExchangeHeadHash(entry)),
+							);
+							if (admittedEntries.length === 0) {
+								continue;
+							}
 							const minReplicas = await this.getMaxReplicasFromHeads(
-								this.getEntryGid(entries[0].entry),
+								this.getEntryGid(admittedEntries[0].entry),
 							);
 							if (minReplicas != null) {
 								const isLeader = await this.isLeader({
-									entry: entries[0].entry,
+									entry: admittedEntries[0].entry,
 									replicas: minReplicas,
 								});
 
 								if (!isLeader) {
-									for (const x of entries) {
+									for (const x of admittedEntries) {
 										this.pruneDebouncedFnAddIfNotKeeping({
 											key: x.entry.hash,
 											value: {

--- a/packages/programs/data/shared-log/test/receive-admission.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission.spec.ts
@@ -1,0 +1,262 @@
+import { Entry } from "@peerbit/log";
+import { TestSession } from "@peerbit/test-utils";
+import { expect } from "chai";
+import sinon from "sinon";
+import { v4 as uuid } from "uuid";
+import { EntryWithRefs, ExchangeHeadsMessage } from "../src/exchange-heads.js";
+import { createReplicationDomainHash } from "../src/replication-domain-hash.js";
+import { SimpleSyncronizer } from "../src/sync/simple.js";
+import { EventStore } from "./utils/stores/event-store.js";
+
+const setup = {
+	domain: createReplicationDomainHash("u32"),
+	type: "u32" as const,
+	syncronizer: SimpleSyncronizer,
+	name: "u32-simple-receive-admission",
+};
+
+const exchange = (entry: Entry<any>, gidRefrences: string[] = []) =>
+	new ExchangeHeadsMessage({
+		heads: [new EntryWithRefs({ entry, gidRefrences })],
+	});
+
+const makeParentUnavailable = (parentHash: string) => {
+	const originalFromMultihash = Entry.fromMultihash;
+	return sinon.stub(Entry, "fromMultihash").callsFake((...args: any[]) => {
+		if (args[1] === parentHash) {
+			throw Object.assign(new Error("parent intentionally unavailable"), {
+				name: "AbortError",
+			});
+		}
+		return (originalFromMultihash as any)(...args);
+	});
+};
+
+describe("receive admission", () => {
+	it("only confirms and coordinates top-level entries admitted by the lower log", async () => {
+		const session = await TestSession.disconnected(2);
+		try {
+			const store = new EventStore<string, any>();
+			const source = await session.peers[0].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: {
+					replicate: false,
+					keep: () => true,
+					setup,
+					timeUntilRoleMaturity: 0,
+				},
+			});
+
+			const { entry: parent } = await source.add(uuid(), {
+				meta: { next: [] },
+			});
+			const { entry: child } = await source.add(uuid(), {
+				meta: { next: [parent] },
+			});
+			const context = { from: source.node.identity.publicKey } as any;
+			const sharedLog = target.log as any;
+			const confirmationStub = sinon
+				.stub(sharedLog, "sendRepairConfirmation")
+				.resolves();
+			const pruneSpy = sinon.spy(sharedLog, "pruneJoinedEntriesNoLongerLed");
+			let missingParentStub: sinon.SinonStub | undefined =
+				makeParentUnavailable(parent.hash);
+			try {
+				await target.log.onMessage(exchange(child), context);
+
+				expect(await target.log.log.has(child.hash)).to.equal(false);
+				expect(await target.log.entryCoordinatesIndex.count()).to.equal(0);
+				expect(confirmationStub.callCount).to.equal(0);
+				expect(pruneSpy.callCount).to.equal(1);
+				expect(pruneSpy.firstCall.args[0]).to.deep.equal([]);
+
+				missingParentStub.restore();
+				missingParentStub = undefined;
+				await target.log.onMessage(exchange(parent), context);
+				await target.log.onMessage(exchange(child), context);
+
+				expect(await target.log.log.has(parent.hash)).to.equal(true);
+				expect(await target.log.log.has(child.hash)).to.equal(true);
+				const coordinateHashes = (
+					await target.log.entryCoordinatesIndex.iterate({}).all()
+				).map((result) => result.value.hash);
+				expect(coordinateHashes).to.include(child.hash);
+				const confirmedHashes = confirmationStub
+					.getCalls()
+					.flatMap((call) => [...(call.args[1] as Set<string>)]);
+				expect(confirmedHashes).to.include(parent.hash);
+				expect(confirmedHashes).to.include(child.hash);
+				expect(
+					pruneSpy.lastCall.args[0].map((entry: any) => entry.hash),
+				).to.deep.equal([child.hash]);
+			} finally {
+				missingParentStub?.restore();
+				pruneSpy.restore();
+				confirmationStub.restore();
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("does not enqueue a rejected reference-only child through toDelete", async () => {
+		const session = await TestSession.disconnected(2);
+		try {
+			const store = new EventStore<string, any>();
+			const source = await session.peers[0].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: {
+					replicate: false,
+					keep: () => false,
+					setup,
+					timeUntilRoleMaturity: 0,
+				},
+			});
+			const { entry: parent } = await source.add(uuid(), {
+				meta: { next: [] },
+			});
+			const { entry: child } = await source.add(uuid(), {
+				meta: { next: [parent] },
+			});
+
+			const sharedLog = target.log as any;
+			const sourceHash = source.node.identity.publicKey.hashcode();
+			const leaderPlanStub = sinon
+				.stub(sharedLog, "planEntryLeaderBatch")
+				.resolves([
+					{
+						coordinates: [1, 2],
+						leaders: new Map([[sourceHash, { intersecting: true }]]),
+						isLeader: false,
+					},
+				]);
+			const referenceHeadStub = sinon
+				.stub(sharedLog, "hasAnyHeadForGidSets")
+				.resolves([true]);
+			const rebalanceStub = sharedLog.rebalanceParticipationDebounced
+				? sinon
+						.stub(sharedLog.rebalanceParticipationDebounced, "call")
+						.returns(undefined)
+				: undefined;
+			const pruneSpy = sinon.spy(sharedLog, "pruneDebouncedFnAddIfNotKeeping");
+			let missingParentStub: sinon.SinonStub | undefined =
+				makeParentUnavailable(parent.hash);
+			try {
+				await target.log.onMessage(exchange(child, ["referenced-gid"]), {
+					from: source.node.identity.publicKey,
+				} as any);
+
+				expect(referenceHeadStub.callCount).to.equal(1);
+				expect(leaderPlanStub.callCount).to.equal(1);
+				expect(await target.log.log.has(child.hash)).to.equal(false);
+				expect(pruneSpy.callCount).to.equal(0);
+
+				missingParentStub.restore();
+				missingParentStub = undefined;
+				await target.log.log.join([parent]);
+				await sharedLog.pruneDebouncedFn.flush();
+				expect(await target.log.log.has(parent.hash)).to.equal(true);
+				expect(sharedLog._checkedPrune.hasActiveWork(child.hash)).to.equal(
+					false,
+				);
+			} finally {
+				missingParentStub?.restore();
+				pruneSpy.restore();
+				rebalanceStub?.restore();
+				referenceHeadStub.restore();
+				leaderPlanStub.restore();
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("does not enqueue a rejected lower-replica child through maybeDelete", async () => {
+		const session = await TestSession.disconnected(2);
+		try {
+			const store = new EventStore<string, any>();
+			const source = await session.peers[0].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: {
+					replicate: false,
+					setup,
+					timeUntilRoleMaturity: 0,
+				},
+			});
+			const { entry: parent } = await source.add(uuid(), {
+				meta: { next: [] },
+			});
+			const { entry: child } = await source.add(uuid(), {
+				meta: { next: [parent] },
+			});
+
+			const sharedLog = target.log as any;
+			const targetHash = target.node.identity.publicKey.hashcode();
+			const maxReplicasBatchStub = sinon
+				.stub(sharedLog, "getMaxReplicasFromHeadsBatch")
+				.callsFake(async (...args: unknown[]) => {
+					const gids = args[0] as Iterable<string>;
+					return new Map([...gids].map((gid) => [gid, 3]));
+				});
+			const leaderPlanStub = sinon
+				.stub(sharedLog, "planEntryLeaderBatch")
+				.resolves([
+					{
+						coordinates: [1, 2, 3],
+						leaders: new Map([[targetHash, { intersecting: true }]]),
+						isLeader: true,
+					},
+				]);
+			const maxReplicasStub = sinon
+				.stub(sharedLog, "getMaxReplicasFromHeads")
+				.resolves(3);
+			const isLeaderStub = sinon.stub(sharedLog, "isLeader").resolves(false);
+			const rebalanceStub = sharedLog.rebalanceParticipationDebounced
+				? sinon
+						.stub(sharedLog.rebalanceParticipationDebounced, "call")
+						.returns(undefined)
+				: undefined;
+			const pruneSpy = sinon.spy(sharedLog, "pruneDebouncedFnAddIfNotKeeping");
+			let missingParentStub: sinon.SinonStub | undefined =
+				makeParentUnavailable(parent.hash);
+			try {
+				await target.log.onMessage(exchange(child), {
+					from: source.node.identity.publicKey,
+				} as any);
+
+				expect(maxReplicasBatchStub.callCount).to.equal(1);
+				expect(leaderPlanStub.callCount).to.equal(1);
+				expect(leaderPlanStub.firstCall.args[0][0].replicas).to.equal(3);
+				expect(await target.log.log.has(child.hash)).to.equal(false);
+				expect(maxReplicasStub.callCount).to.equal(0);
+				expect(isLeaderStub.callCount).to.equal(0);
+				expect(pruneSpy.callCount).to.equal(0);
+
+				missingParentStub.restore();
+				missingParentStub = undefined;
+				await target.log.log.join([parent]);
+				await sharedLog.pruneDebouncedFn.flush();
+				expect(await target.log.log.has(parent.hash)).to.equal(true);
+				expect(sharedLog._checkedPrune.hasActiveWork(child.hash)).to.equal(
+					false,
+				);
+			} finally {
+				missingParentStub?.restore();
+				pruneSpy.restore();
+				rebalanceStub?.restore();
+				isLeaderStub.restore();
+				maxReplicasStub.restore();
+				leaderPlanStub.restore();
+				maxReplicasBatchStub.restore();
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- derive the actually admitted top-level hashes after fallback lower-log joins
- confirm and persist coordinates only for entries present in the lower log
- exclude rejected entries from checked-prune and deferred recursive-prune paths
- preserve the atomic prepared/native fast path without an extra presence lookup

## Why
Log.join intentionally treats a temporarily missing parent as recoverable and can resolve without storing the child. SharedLog previously confirmed every intended child anyway, causing the sender to clear its repair frontier. At replication factor 1 this could permanently suppress the only repair path. Rejected children could also enter recursive-prune queues and later remove a parent that arrived after the failed join.

## Verification
- receive admission regressions: 3 passing
- related reference and prepared/native receive tests: 7 passing
- shared-log build
- ESLint and Prettier
- git diff check
- two independent P0-P2 reviews; final review found no remaining P0-P2