### PR TITLE
feat(shared-log): prioritize directed delivery

### DIFF
--- a/.changeset/bright-reads-arrive.md
+++ b/.changeset/bright-reads-arrive.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Allow directed shared-log delivery to select a transport priority.

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2816,6 +2816,11 @@ export type DeliveryOptions = {
 	reliability?: DeliveryReliability;
 	minAcks?: number;
 	requireRecipients?: boolean;
+	/**
+	 * Transport priority for directed RPC delivery. Fanout unicast already uses
+	 * its control lane, so this only changes the direct/fallback RPC path.
+	 */
+	priority?: number;
 	timeout?: number;
 	signal?: AbortSignal;
 };
@@ -4689,9 +4694,11 @@ export class SharedLog<
 		peer: string;
 		message: ExchangeHeadsMessage<any>;
 		payload: Uint8Array;
+		priority?: number;
 		fanoutUnicastOptions?: { timeoutMs?: number; signal?: AbortSignal };
 	}): Promise<void> {
-		const { peer, message, payload, fanoutUnicastOptions } = properties;
+		const { peer, message, payload, priority, fanoutUnicastOptions } =
+			properties;
 		const hints = await this._getSortedRouteHints(peer);
 		const hasDirectHint = hints.some(
 			(hint) => hint.kind === "directstream-ack",
@@ -4708,6 +4715,7 @@ export class SharedLog<
 						redundancy: 1,
 						to: [peer],
 					}),
+					priority,
 				});
 				return;
 			} catch {
@@ -4746,6 +4754,7 @@ export class SharedLog<
 				redundancy: 1,
 				to: [peer],
 			}),
+			priority,
 		});
 	}
 
@@ -5146,6 +5155,7 @@ export class SharedLog<
 									peer,
 									message,
 									payload,
+									priority: delivery.priority,
 									fanoutUnicastOptions,
 								});
 							})(),
@@ -5160,6 +5170,7 @@ export class SharedLog<
 								redundancy: 1,
 								to: nativeDeliveryPlan.silentTo,
 							}),
+							priority: delivery.priority,
 						})
 						.catch((error) => logger.error(error));
 				}
@@ -5300,6 +5311,7 @@ export class SharedLog<
 								peer,
 								message,
 								payload,
+								priority: delivery.priority,
 								fanoutUnicastOptions,
 							});
 						})(),
@@ -5311,6 +5323,7 @@ export class SharedLog<
 				this.rpc
 					.send(message, {
 						mode: new SilentDelivery({ redundancy: 1, to: silentTo }),
+						priority: delivery.priority,
 					})
 					.catch((error) => logger.error(error));
 			}

--- a/packages/programs/data/shared-log/test/delivery.spec.ts
+++ b/packages/programs/data/shared-log/test/delivery.spec.ts
@@ -2,6 +2,7 @@ import {
 	ACK,
 	AcknowledgeDelivery,
 	DataMessage,
+	FOREGROUND_READ_MESSAGE_PRIORITY,
 	SilentDelivery,
 } from "@peerbit/stream-interface";
 import type { FanoutTree } from "@peerbit/pubsub";
@@ -28,7 +29,7 @@ describe("append delivery options", () => {
 		await session?.stop();
 	});
 
-	it("awaits transport acks when delivery is set for target=replicators", async () => {
+	it("awaits transport acks and applies an explicit priority for target=replicators", async () => {
 		session = await TestSession.connected(2);
 
 		const db1 = await session.peers[0].open(new EventStore<string, any>(), {
@@ -68,7 +69,9 @@ describe("append delivery options", () => {
 
 		const gate = pDefer<void>();
 		const ackAttempted = pDefer<void>();
-		const expectedAckedMessageIds = new Set<string>();
+		const deliveryPriorityByMessageId = new Map<string, number | undefined>();
+		let foregroundMessageId: string | undefined;
+		let foregroundAckedMessageId: string | undefined;
 		const toB64 = (id: Uint8Array) => Buffer.from(id).toString("base64");
 
 		const remotePubsub: any = session.peers[1].services.pubsub;
@@ -77,9 +80,14 @@ describe("append delivery options", () => {
 		remotePubsub.publishMessage = async (...args: any[]) => {
 			const message = args[1];
 			if (message instanceof ACK) {
-				// Only gate the ACKs that correspond to the message(s) produced by this test's `db1.add(...)`.
-				// There can be unrelated ACK traffic during session setup in the full test suite.
-				if (expectedAckedMessageIds.has(toB64(message.messageIdToAcknowledge))) {
+				const acknowledgedId = toB64(message.messageIdToAcknowledge);
+				// Native convergence can emit unrelated acknowledged traffic during
+				// this append. Gate only the exact foreground delivery under test.
+				if (
+					deliveryPriorityByMessageId.get(acknowledgedId) ===
+					FOREGROUND_READ_MESSAGE_PRIORITY
+				) {
+					foregroundAckedMessageId = acknowledgedId;
 					ackAttempted.resolve();
 					await gate.promise;
 				}
@@ -97,7 +105,11 @@ describe("append delivery options", () => {
 				message.header.mode instanceof AcknowledgeDelivery &&
 				message.header.mode.to?.includes(remoteHash)
 			) {
-				expectedAckedMessageIds.add(toB64(message.id));
+				const messageId = toB64(message.id);
+				deliveryPriorityByMessageId.set(messageId, message.header.priority);
+				if (message.header.priority === FOREGROUND_READ_MESSAGE_PRIORITY) {
+					foregroundMessageId = messageId;
+				}
 			}
 			return originalLocalPublishMessage(...args);
 		};
@@ -106,7 +118,7 @@ describe("append delivery options", () => {
 		const promise = db1
 			.add("hello", {
 				target: "replicators",
-				delivery: true,
+				delivery: { priority: FOREGROUND_READ_MESSAGE_PRIORITY },
 			})
 			.then((result) => {
 				resolved = true;
@@ -115,6 +127,10 @@ describe("append delivery options", () => {
 
 		await ackAttempted.promise;
 		expect(resolved).to.equal(false);
+		expect(foregroundAckedMessageId).to.equal(foregroundMessageId);
+		expect(deliveryPriorityByMessageId.get(foregroundAckedMessageId!)).to.equal(
+			FOREGROUND_READ_MESSAGE_PRIORITY,
+		);
 
 		gate.resolve();
 		await promise;

--- a/packages/transport/stream/test/priority-lanes.spec.ts
+++ b/packages/transport/stream/test/priority-lanes.spec.ts
@@ -1,5 +1,9 @@
 import { type PeerId } from "@libp2p/interface";
 import { Ed25519Keypair } from "@peerbit/crypto";
+import {
+	CONVERGENCE_MESSAGE_PRIORITY,
+	FOREGROUND_READ_MESSAGE_PRIORITY,
+} from "@peerbit/stream-interface";
 import { AbortError, delay, waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
 import { PeerStreams } from "../src/index.js";
@@ -72,6 +76,48 @@ describe("priority lanes", () => {
 
 		// Drain the rest (sanity).
 		for (let expected = 3; expected <= 6; expected++) {
+			outbound.dispatchEvent(new Event("drain"));
+			await waitForResolved(() =>
+				expect(outbound.sentPayloads.length).to.equal(expected),
+			);
+		}
+
+		await streams.close();
+	});
+
+	it("bounds foreground delivery behind a convergence backlog", async () => {
+		const keypair = await Ed25519Keypair.create();
+		const streams = new PeerStreams({
+			peerId: { toString: () => "test-peer" } as unknown as PeerId,
+			publicKey: keypair.publicKey,
+			protocol: "/test",
+			connId: "test-conn",
+		});
+
+		const outbound = new TestOutboundStream();
+		await streams.attachOutboundStream(outbound as any);
+
+		// Model queued shared-log repair messages followed by a ready manifest.
+		for (let i = 0; i < 5; i++) {
+			streams.write(new Uint8Array([i + 1]), CONVERGENCE_MESSAGE_PRIORITY);
+		}
+		await waitForResolved(() =>
+			expect(outbound.sentPayloads).to.deep.equal([1]),
+		);
+
+		streams.write(new Uint8Array([200]), FOREGROUND_READ_MESSAGE_PRIORITY);
+
+		// WRR may finish its current convergence slot, but the foreground frame
+		// must be selected before the remaining convergence backlog drains.
+		for (let expected = 2; expected <= 3; expected++) {
+			outbound.dispatchEvent(new Event("drain"));
+			await waitForResolved(() =>
+				expect(outbound.sentPayloads.length).to.equal(expected),
+			);
+		}
+		expect(outbound.sentPayloads).to.deep.equal([1, 2, 200]);
+
+		for (let expected = 4; expected <= 6; expected++) {
 			outbound.dispatchEvent(new Event("drain"));
 			await waitForResolved(() =>
 				expect(outbound.sentPayloads.length).to.equal(expected),


### PR DESCRIPTION
## Summary
- add an optional transport priority to directed shared-log delivery
- propagate it through TypeScript and native-planned ACK and silent RPC paths
- verify foreground delivery is selected ahead of queued convergence work without starving lower lanes

## Validation
- default append delivery suite: 11/11
- native append delivery suite: 11/11
- TypeScript and Rust-core priority-lane tests
- Rust lane scheduler unit tests: 5/5
- relevant builds and diff checks