### PR TITLE
fix(stream): handle best-effort close rejections

### DIFF
--- a/.changeset/quiet-stream-closes.md
+++ b/.changeset/quiet-stream-closes.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/stream": patch
+---
+
+Handle rejected best-effort raw stream closes during stream pruning without emitting uncaught browser errors.

--- a/packages/transport/stream/src/index.ts
+++ b/packages/transport/stream/src/index.ts
@@ -163,6 +163,17 @@ const markPromiseHandled = <T>(promise: Promise<T>): Promise<T> => {
 	return promise;
 };
 
+const closeRawStreamBestEffort = (stream: Stream): void => {
+	try {
+		// WebRTC close can reject later while waiting for FIN_ACK. These lifecycle
+		// paths are intentionally fire-and-forget, so observe the rejection without
+		// delaying pruning or shutdown.
+		void Promise.resolve(stream.close?.()).catch(() => {});
+	} catch {
+		// Closing discarded streams is best-effort, including synchronous failures.
+	}
+};
+
 const logError = (e?: any) => {
 	if (e?.message === "Cannot push value onto an ended pushable") {
 		return; // ignore since we are trying to push to a closed stream
@@ -478,7 +489,7 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 						await waitForDrain(raw, this.outboundAbortController.signal);
 					}
 				}
-				raw.close?.();
+				closeRawStreamBestEffort(raw);
 			} catch (err) {
 				candidate.aborted = true;
 				try {
@@ -692,9 +703,7 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 					try {
 						f.raw.abort?.(new AbortError("Failed write" as any));
 					} catch {}
-					try {
-						f.raw.close?.();
-					} catch {}
+					closeRawStreamBestEffort(f.raw);
 				}
 				// If more than one remains schedule prune; else ensure outbound event raised
 				if (this.outboundStreams.length > 1) this._scheduleOutboundPrune(true);
@@ -805,11 +814,7 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 			} catch {
 				logger.error("Failed to abort inbound stream");
 			}
-			try {
-				drop.raw.close?.();
-			} catch {
-				logger.error("Failed to close inbound stream");
-			}
+			closeRawStreamBestEffort(drop.raw);
 		}
 		const abortController = new AbortController();
 		const decoded = pipe(stream, (source) =>
@@ -868,9 +873,7 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 			try {
 				candidate.abortController.abort();
 			} catch {}
-			try {
-				candidate.raw.close?.();
-			} catch {}
+			closeRawStreamBestEffort(candidate.raw);
 		}
 		this.inboundStreams = survivors;
 		// update legacy references if they were pruned
@@ -903,7 +906,7 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 			try {
 				record.raw.abort?.(reason);
 			} catch {}
-			void Promise.resolve(record.raw.close?.()).catch(() => {});
+			closeRawStreamBestEffort(record.raw);
 		}
 		if (this.rawInboundStream === record.raw) {
 			const next = this.inboundStreams[0];
@@ -971,11 +974,7 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 				} catch {
 					logger.error("Failed to close outbound pushable");
 				}
-				try {
-					c.raw.close?.();
-				} catch {
-					logger.error("Failed to close outbound stream");
-				}
+				closeRawStreamBestEffort(c.raw);
 			}
 			this.outboundStreams = [chosen];
 		} catch (e) {
@@ -1071,7 +1070,7 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 						} catch {
 							// ignore
 						}
-						void Promise.resolve(inbound.raw.close?.()).catch(() => {});
+						closeRawStreamBestEffort(inbound.raw);
 					} catch {
 						logger.error("Failed to close inbound stream");
 					}

--- a/packages/transport/stream/test/stream-cleanup.spec.ts
+++ b/packages/transport/stream/test/stream-cleanup.spec.ts
@@ -1,0 +1,60 @@
+import type { PeerId, Stream } from "@libp2p/interface";
+import { Ed25519Keypair } from "@peerbit/crypto";
+import { delay } from "@peerbit/time";
+import { expect } from "chai";
+import { PeerStreams } from "../src/index.js";
+
+const createInboundStream = (id: string, close: () => Promise<void>): Stream =>
+	({
+		id,
+		protocol: "/test",
+		[Symbol.asyncIterator]: async function* () {},
+		abort: () => {},
+		close,
+	}) as unknown as Stream;
+
+describe("peer stream cleanup", () => {
+	it("handles a rejected close while pruning an inactive inbound stream", async () => {
+		const keypair = await Ed25519Keypair.create();
+		const streams = new PeerStreams({
+			peerId: { toString: () => "remote-peer" } as PeerId,
+			publicKey: keypair.publicKey,
+			protocol: "/test",
+			connId: "test-connection",
+		});
+		const closeError = new AggregateError(
+			[new Error("FIN_ACK timed out")],
+			"All promises were rejected",
+		);
+		const unhandled: unknown[] = [];
+		const onUnhandledRejection = (reason: unknown) => {
+			unhandled.push(reason);
+		};
+		let staleCloseCalls = 0;
+
+		process.on("unhandledRejection", onUnhandledRejection);
+		try {
+			const survivor = streams.attachInboundStream(
+				createInboundStream("survivor", async () => {}),
+			);
+			const stale = streams.attachInboundStream(
+				createInboundStream("stale", () => {
+					staleCloseCalls += 1;
+					return Promise.reject(closeError);
+				}),
+			);
+
+			survivor.lastActivity = Date.now();
+			stale.lastActivity = 0;
+			streams.forcePruneInbound();
+
+			expect(staleCloseCalls).to.equal(1);
+			expect(streams.inboundStreams).to.deep.equal([survivor]);
+			await delay(25);
+			expect(unhandled).to.deep.equal([]);
+		} finally {
+			process.off("unhandledRejection", onUnhandledRejection);
+			await streams.close();
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- observe rejected best-effort raw stream closes without awaiting WebRTC FIN_ACK shutdown
- preserve existing pruning and shutdown ordering across inbound and outbound lifecycle paths
- add a deterministic regression for an AggregateError close rejection during inactive inbound pruning

## Why
A strict 1 GiB file-share run completed all chunks and matched SHA-256, but an unhandled WebRTC close timeout surfaced as a browser page error. Several fire-and-forget raw close calls discarded their returned promises.

## Validation
- deterministic close-rejection regression passed twice
- related cleanup cases: 5/5
- stream package tests and TypeScript build
- formatting and diff checks