### PR TITLE
feat(benchmarks): control file-share reader locality

### DIFF
--- a/scripts/file-share/README.md
+++ b/scripts/file-share/README.md
@@ -33,6 +33,48 @@ sinks only in separate benchmark sessions; aggregate comparison objects fail
 closed on mixed sinks, and every passed result and aggregate labels
 non-hash-only cohorts non-authoritative.
 
+For a controlled reader-locality download cohort, run an upload with
+`--mode fixed1`, `--reader-local-chunk-target <N>`, and
+`--reader-local-chunk-max-overshoot <M>`. The two locality options are a required
+pair, `M` is capped at eight chunks, and this profile uses a one-replicator
+readiness baseline. The writer is fixed at factor one and the reader is an
+observer before upload starts; topology evidence must show exactly one
+replicator, with the writer in and reader out of that set, both before upload and
+again immediately before the timed read. Both peers must report the same exact
+singleton replicator identity, and that identity must be the writer.
+
+After the normal upload and post-upload monitor finish, the harness enables
+persistent reader chunk reads and performs an untimed sequential prefix preload
+that yields exactly `N` chunks. It explicitly closes the iterator and requires
+no active transfer or queued download work afterward. `N=0` is the cold
+observer-persistent cohort and opens no preload stream. The harness then records
+three identical exact locality samples, spaced by
+`min(--poll-ms, 100ms)`. Each sample includes both the manifest-entry blocks
+available in the local block store (`K`) and the local Documents index rows
+(`J`). Both sets must be contiguous prefixes, `N <= K <= N + M`, `J <= K`, and
+`K` must remain smaller than the file's full chunk count. `K` can exceed `N`
+because Peerbit may read ahead; a cached entry block also need not have a local
+index row yet.
+
+The measured cohort key is therefore
+`observer-persistent-prefix-b<K>-i<J>`, not merely the requested target. Timed
+read diagnostics must report those exact initial block and index-row counts.
+Here, `observer` describes the upload and timed-read **start** topology, not the
+entire persistent transfer. A persistent timed read is expected to promote the
+reader into replication. After sink completion, integrity verification, and an
+idle transfer scheduler, the harness collects three additional stable topology
+samples outside the measured download duration. Both peers must then report the
+same exact sorted `[writer, reader]` replicator set, both must report themselves
+in that set, and the peer identities must match the pre-upload and pre-read
+checkpoints. Non-convergence fails the run rather than creating or mixing an
+implicit terminal-topology cohort.
+
+Repeated standalone and matrix results are grouped by the exact key, so timings
+from different read-ahead outcomes are never averaged together. Raw canonical
+per-chunk timings remain in each result and can be rebucketed into 5% progress
+windows without losing the underlying samples. Without the paired locality
+options, roles, persistence policy, and seeder-drop gates are unchanged.
+
 The standalone runner continues counterbalanced repetitions after an individual
 Playwright or result-validation failure when setup remains usable. Once
 invocation execution begins, it writes a summary with planned, completed,

--- a/scripts/file-share/README.md
+++ b/scripts/file-share/README.md
@@ -45,10 +45,12 @@ singleton replicator identity, and that identity must be the writer.
 
 After the normal upload and post-upload monitor finish, the harness enables
 persistent reader chunk reads and performs an untimed sequential prefix preload
-that yields exactly `N` chunks. It explicitly closes the iterator and requires
-no active transfer or queued download work afterward. `N=0` is the cold
-observer-persistent cohort and opens no preload stream. The harness then records
-three identical exact locality samples, spaced by
+that yields exactly `N` chunks. A nonzero preload has one aggregate download
+deadline enforced through an abort signal, rather than resetting the deadline
+for every chunk. It explicitly closes the iterator within the bounded cleanup
+tolerance and requires no active transfer or queued download work afterward.
+`N=0` is the cold observer-persistent cohort and opens no preload stream. The
+harness then records three identical exact locality samples, spaced by
 `min(--poll-ms, 100ms)`. Each sample includes both the manifest-entry blocks
 available in the local block store (`K`) and the local Documents index rows
 (`J`). Both sets must be contiguous prefixes, `N <= K <= N + M`, `J <= K`, and

--- a/scripts/file-share/benchmark-invocation.mjs
+++ b/scripts/file-share/benchmark-invocation.mjs
@@ -3,7 +3,7 @@ import { isDeepStrictEqual } from "node:util";
 
 export const BENCHMARK_INVOCATION_SCHEMA = {
 	id: "peerbit-file-share-benchmark-invocation",
-	version: 2,
+	version: 3,
 };
 
 export const TINY_FILE_CUTOFF_BYTES = 5_000_000;
@@ -15,6 +15,7 @@ export const BENCHMARK_DOWNLOAD_SINKS = Object.freeze([
 	"node-file",
 ]);
 export const DEFAULT_BENCHMARK_DOWNLOAD_SINK = "hash-only";
+export const MAX_READER_LOCAL_CHUNK_OVERSHOOT = 8;
 
 const DEPLOYED_APP_HARNESS_MESSAGE =
 	"The locally instrumented core benchmark harness cannot use --base-url because it cannot attribute an external deployment to the selected Peerbit checkout; use a dedicated deployed-app benchmark harness that records deployment provenance";
@@ -166,6 +167,8 @@ export const createBenchmarkInvocation = ({
 	sampleMs,
 	sampleCount,
 	targetSeeders,
+	readerLocalChunkTarget,
+	readerLocalChunkMaxOvershoot,
 	baseUrl,
 	protocol,
 	viteMode,
@@ -218,8 +221,43 @@ export const createBenchmarkInvocation = ({
 		pollMs ?? DEFAULTS.pollMs,
 		"pollMs",
 	);
+	const resolvedReaderLocalChunkTarget =
+		readerLocalChunkTarget == null
+			? null
+			: requireNonNegativeSafeInteger(
+					readerLocalChunkTarget,
+					"readerLocalChunkTarget",
+				);
+	const resolvedReaderLocalChunkMaxOvershoot =
+		readerLocalChunkMaxOvershoot == null
+			? null
+			: requireNonNegativeSafeInteger(
+					readerLocalChunkMaxOvershoot,
+					"readerLocalChunkMaxOvershoot",
+				);
+	if (
+		(resolvedReaderLocalChunkTarget === null) !==
+		(resolvedReaderLocalChunkMaxOvershoot === null)
+	) {
+		throw new Error(
+			"readerLocalChunkTarget and readerLocalChunkMaxOvershoot must be provided together",
+		);
+	}
+	if (
+		resolvedReaderLocalChunkMaxOvershoot !== null &&
+		resolvedReaderLocalChunkMaxOvershoot > MAX_READER_LOCAL_CHUNK_OVERSHOOT
+	) {
+		throw new Error(
+			`readerLocalChunkMaxOvershoot must not exceed ${MAX_READER_LOCAL_CHUNK_OVERSHOOT}`,
+		);
+	}
 	const resolvedMinReadySeeders = requireNonNegativeSafeInteger(
-		minReadySeeders ?? (mode === "observer" ? 0 : 2),
+		minReadySeeders ??
+			(mode === "observer"
+				? 0
+				: resolvedReaderLocalChunkTarget === null
+					? 2
+					: 1),
 		"minReadySeeders",
 	);
 	const resolvedReadyTimeoutMs = requirePositiveSafeInteger(
@@ -238,6 +276,23 @@ export const createBenchmarkInvocation = ({
 		targetSeeders ?? DEFAULTS.targetSeeders,
 		"targetSeeders",
 	);
+	if (resolvedReaderLocalChunkTarget !== null) {
+		if (scenario !== "upload") {
+			throw new Error(
+				"readerLocalChunkTarget is only supported by upload benchmarks",
+			);
+		}
+		if (mode !== "fixed1") {
+			throw new Error(
+				"readerLocalChunkTarget requires fixed1 mode for the writer baseline",
+			);
+		}
+		if (resolvedMinReadySeeders !== 1) {
+			throw new Error(
+				"readerLocalChunkTarget requires minReadySeeders = 1 because the reader starts as an observer",
+			);
+		}
+	}
 
 	return {
 		schema: BENCHMARK_INVOCATION_SCHEMA,
@@ -258,6 +313,8 @@ export const createBenchmarkInvocation = ({
 		sampleMs: resolvedSampleMs,
 		sampleCount: resolvedSampleCount,
 		targetSeeders: resolvedTargetSeeders,
+		readerLocalChunkTarget: resolvedReaderLocalChunkTarget,
+		readerLocalChunkMaxOvershoot: resolvedReaderLocalChunkMaxOvershoot,
 		baseUrl: resolvedBaseUrl,
 		protocol: previewOptions.protocol,
 		viteMode: previewOptions.viteMode,
@@ -315,6 +372,12 @@ export const createPlaywrightBenchmarkEnvironment = ({
 		PW_SAMPLE_COUNT: String(invocation.sampleCount),
 		PW_SAMPLE_MS: String(invocation.sampleMs),
 		PW_TARGET_SEEDERS: String(invocation.targetSeeders),
+		PW_READER_LOCAL_CHUNK_TARGET: stringValue(
+			invocation.readerLocalChunkTarget,
+		),
+		PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT: stringValue(
+			invocation.readerLocalChunkMaxOvershoot,
+		),
 		PW_UPLOAD_TIMEOUT_MS: String(invocation.uploadTimeoutMs),
 		PW_VERBOSE: invocation.verbose ? "1" : "0",
 		PW_VITE_CONFIG: stringValue(invocation.viteConfig),

--- a/scripts/file-share/benchmark-invocation.test.mjs
+++ b/scripts/file-share/benchmark-invocation.test.mjs
@@ -55,6 +55,8 @@ test("resolves every default and requested optional knob", () => {
 			sampleMs: resolved.sampleMs,
 			sampleCount: resolved.sampleCount,
 			targetSeeders: resolved.targetSeeders,
+			readerLocalChunkTarget: resolved.readerLocalChunkTarget,
+			readerLocalChunkMaxOvershoot: resolved.readerLocalChunkMaxOvershoot,
 			protocol: resolved.protocol,
 			viteMode: resolved.viteMode,
 			viteConfig: resolved.viteConfig,
@@ -75,6 +77,8 @@ test("resolves every default and requested optional knob", () => {
 			sampleMs: 7,
 			sampleCount: 8,
 			targetSeeders: 9,
+			readerLocalChunkTarget: null,
+			readerLocalChunkMaxOvershoot: null,
 			protocol: "http",
 			viteMode: null,
 			viteConfig: null,
@@ -129,6 +133,8 @@ test("removes all ambient PW variables and installs the exact invocation", () =>
 	assert.equal(environment.PW_FILE_MB, "5");
 	assert.equal(environment.PW_DOWNLOAD_SINK, "hash-only");
 	assert.equal(environment.PW_POST_UPLOAD_MONITOR_MS, "5000");
+	assert.equal(environment.PW_READER_LOCAL_CHUNK_TARGET, "");
+	assert.equal(environment.PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT, "");
 	assert.equal(environment.PW_FUTURE_BYPASS, undefined);
 	assert.equal(environment.PW_PORT, undefined);
 	assert.equal(environment.PW_BENCH, "1");
@@ -136,6 +142,84 @@ test("removes all ambient PW variables and installs the exact invocation", () =>
 	assert.equal(environment.PW_VITE_CONFIG, "");
 	assert.equal(environment.PW_VITE_MODE, "");
 	assert.deepEqual(JSON.parse(environment.PW_BENCHMARK_INVOCATION), resolved);
+});
+
+test("binds optional observer-prefix locality control to a fixed1 writer", () => {
+	const resolved = invocation({
+		mode: "fixed1",
+		readerLocalChunkTarget: 0,
+		readerLocalChunkMaxOvershoot: 0,
+	});
+	assert.equal(resolved.readerLocalChunkTarget, 0);
+	assert.equal(resolved.readerLocalChunkMaxOvershoot, 0);
+	assert.equal(resolved.minReadySeeders, 1);
+	const environment = createPlaywrightBenchmarkEnvironment({
+		baseEnvironment: {
+			PW_READER_LOCAL_CHUNK_TARGET: "attacker",
+			PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT: "attacker",
+		},
+		invocation: resolved,
+		resultFile: "/tmp/result.json",
+		runNonce: "123e4567-e89b-42d3-a456-426614174000",
+		provenance: { bound: true },
+	});
+	assert.equal(environment.PW_READER_LOCAL_CHUNK_TARGET, "0");
+	assert.equal(environment.PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT, "0");
+	for (const [overrides, pattern] of [
+		[
+			{
+				mode: "adaptive",
+				readerLocalChunkTarget: 4,
+				readerLocalChunkMaxOvershoot: 2,
+			},
+			/requires fixed1 mode/,
+		],
+		[
+			{
+				mode: "observer",
+				readerLocalChunkTarget: 4,
+				readerLocalChunkMaxOvershoot: 2,
+			},
+			/requires fixed1 mode/,
+		],
+		[
+			{
+				mode: "fixed1",
+				readerLocalChunkTarget: 4,
+				readerLocalChunkMaxOvershoot: 2,
+				minReadySeeders: 2,
+			},
+			/requires minReadySeeders = 1/,
+		],
+		[
+			{
+				scenario: "seeder-probe",
+				mode: "fixed1",
+				fileMb: 1,
+				readerLocalChunkTarget: 1,
+				readerLocalChunkMaxOvershoot: 1,
+			},
+			/only supported by upload benchmarks/,
+		],
+		[
+			{ mode: "fixed1", readerLocalChunkTarget: 4 },
+			/must be provided together/,
+		],
+		[
+			{ mode: "fixed1", readerLocalChunkMaxOvershoot: 2 },
+			/must be provided together/,
+		],
+		[
+			{
+				mode: "fixed1",
+				readerLocalChunkTarget: 4,
+				readerLocalChunkMaxOvershoot: 9,
+			},
+			/must not exceed 8/,
+		],
+	]) {
+		assert.throws(() => invocation(overrides), pattern);
+	}
 });
 
 test("defaults to the hash-only sink and validates explicit sink cohorts", () => {
@@ -315,6 +399,30 @@ test("standalone runner rejects invalid integration modes before mutating output
 			[
 				["--integration-mode", "link", "--local-packages", ","],
 				/link integration requires at least one local Peerbit package/,
+			],
+			[
+				[
+					"--reader-local-chunk-target",
+					"1",
+					"--reader-local-chunk-max-overshoot",
+					"1",
+					"--mode",
+					"adaptive",
+				],
+				/requires --scenario upload --mode fixed1/,
+			],
+			[
+				[
+					"--reader-local-chunk-target",
+					"1",
+					"--reader-local-chunk-max-overshoot",
+					"1",
+					"--mode",
+					"fixed1",
+					"--min-ready-seeders",
+					"2",
+				],
+				/requires --min-ready-seeders 1/,
 			],
 		]) {
 			const child = spawnSync(

--- a/scripts/file-share/benchmark-summary.mjs
+++ b/scripts/file-share/benchmark-summary.mjs
@@ -35,6 +35,41 @@ const passedNumbers = (results, getter) =>
 		.map(getter)
 		.filter((value) => typeof value === "number" && Number.isFinite(value));
 
+const optionalLocalityValue = (result, key) =>
+	result?.[key] ?? result?.invocation?.[key] ?? null;
+
+export const uploadLocalityCohortDimensions = (result) => ({
+	mode: result.mode,
+	readerLocalChunkTarget: optionalLocalityValue(
+		result,
+		"readerLocalChunkTarget",
+	),
+	readerLocalChunkMaxOvershoot: optionalLocalityValue(
+		result,
+		"readerLocalChunkMaxOvershoot",
+	),
+	readerLocalChunkBlockCount: result.readerLocalChunkBlockCount ?? null,
+	readerLocalChunkIndexRowCount: result.readerLocalChunkIndexRowCount ?? null,
+	readerLocalityCohortKey: result.readerLocalityCohortKey ?? null,
+});
+
+/**
+ * Read-ahead may make repeated controlled-locality runs settle at different
+ * exact block/index prefixes. Keep those cohorts separate so an aggregate can
+ * never hide that difference in a single timing distribution.
+ */
+export const groupUploadResultsByLocalityCohort = (results) => {
+	const grouped = new Map();
+	for (const result of results) {
+		const dimensions = uploadLocalityCohortDimensions(result);
+		const key = JSON.stringify(dimensions);
+		const group = grouped.get(key) ?? { dimensions, results: [] };
+		group.results.push(result);
+		grouped.set(key, group);
+	}
+	return [...grouped.values()];
+};
+
 export const summarizeDistribution = (values) => {
 	const sortedValues = values
 		.filter((value) => typeof value === "number" && Number.isFinite(value))

--- a/scripts/file-share/benchmark-summary.test.mjs
+++ b/scripts/file-share/benchmark-summary.test.mjs
@@ -3,10 +3,112 @@ import test from "node:test";
 import {
 	compareUploadPerformanceModes,
 	compareUploadPerformanceModesForCompletePlan,
+	groupUploadResultsByLocalityCohort,
 	isCompletePassedBenchmarkPlan,
 	summarizeUploadPerformance,
 	uploadTimingTableColumns,
 } from "./benchmark-summary.mjs";
+
+test("keeps exact observer-locality cohorts separate in aggregates", () => {
+	const uncontrolled = {
+		status: "passed",
+		mode: "adaptive",
+	};
+	const cold = {
+		status: "passed",
+		mode: "fixed1",
+		readerLocalChunkTarget: 0,
+		readerLocalChunkMaxOvershoot: 0,
+		readerLocalChunkBlockCount: 0,
+		readerLocalChunkIndexRowCount: 0,
+		readerLocalityCohortKey: "observer-persistent-prefix-b0-i0",
+	};
+	const warmBlockOnly = {
+		status: "passed",
+		mode: "fixed1",
+		readerLocalChunkTarget: 1,
+		readerLocalChunkMaxOvershoot: 1,
+		readerLocalChunkBlockCount: 1,
+		readerLocalChunkIndexRowCount: 0,
+		readerLocalityCohortKey: "observer-persistent-prefix-b1-i0",
+	};
+	const warmIndexed = {
+		...warmBlockOnly,
+		readerLocalChunkIndexRowCount: 1,
+		readerLocalityCohortKey: "observer-persistent-prefix-b1-i1",
+	};
+	const failedBeforeObservation = {
+		status: "failed",
+		mode: "fixed1",
+		invocation: {
+			readerLocalChunkTarget: 1,
+			readerLocalChunkMaxOvershoot: 1,
+		},
+	};
+	const groups = groupUploadResultsByLocalityCohort([
+		uncontrolled,
+		cold,
+		warmBlockOnly,
+		{ ...warmBlockOnly },
+		warmIndexed,
+		failedBeforeObservation,
+	]);
+
+	assert.equal(groups.length, 5);
+	assert.deepEqual(
+		groups.map(({ dimensions, results }) => ({
+			...dimensions,
+			runs: results.length,
+		})),
+		[
+			{
+				mode: "adaptive",
+				readerLocalChunkTarget: null,
+				readerLocalChunkMaxOvershoot: null,
+				readerLocalChunkBlockCount: null,
+				readerLocalChunkIndexRowCount: null,
+				readerLocalityCohortKey: null,
+				runs: 1,
+			},
+			{
+				mode: "fixed1",
+				readerLocalChunkTarget: 0,
+				readerLocalChunkMaxOvershoot: 0,
+				readerLocalChunkBlockCount: 0,
+				readerLocalChunkIndexRowCount: 0,
+				readerLocalityCohortKey: "observer-persistent-prefix-b0-i0",
+				runs: 1,
+			},
+			{
+				mode: "fixed1",
+				readerLocalChunkTarget: 1,
+				readerLocalChunkMaxOvershoot: 1,
+				readerLocalChunkBlockCount: 1,
+				readerLocalChunkIndexRowCount: 0,
+				readerLocalityCohortKey: "observer-persistent-prefix-b1-i0",
+				runs: 2,
+			},
+			{
+				mode: "fixed1",
+				readerLocalChunkTarget: 1,
+				readerLocalChunkMaxOvershoot: 1,
+				readerLocalChunkBlockCount: 1,
+				readerLocalChunkIndexRowCount: 1,
+				readerLocalityCohortKey: "observer-persistent-prefix-b1-i1",
+				runs: 1,
+			},
+			{
+				mode: "fixed1",
+				readerLocalChunkTarget: 1,
+				readerLocalChunkMaxOvershoot: 1,
+				readerLocalChunkBlockCount: null,
+				readerLocalChunkIndexRowCount: null,
+				readerLocalityCohortKey: null,
+				runs: 1,
+			},
+		],
+	);
+});
 
 test("propagates end-to-end readiness and labels post-settlement listing", () => {
 	const results = [

--- a/scripts/file-share/benchmark-validity.mjs
+++ b/scripts/file-share/benchmark-validity.mjs
@@ -883,7 +883,7 @@ const validateEnvelope = (
 	);
 	if (
 		invocationSchema.id !== "peerbit-file-share-benchmark-invocation" ||
-		invocationSchema.version !== 2
+		invocationSchema.version !== 3
 	) {
 		throw new Error("Benchmark result has an unsupported invocation schema");
 	}
@@ -921,6 +921,663 @@ const validateRequestedUploadKnobs = (result, invocation) => {
 			);
 		}
 	}
+	if (result.readerLocalChunkTarget !== invocation.readerLocalChunkTarget) {
+		throw new Error(
+			"Benchmark result readerLocalChunkTarget does not match the requested invocation",
+		);
+	}
+	if (
+		result.readerLocalChunkMaxOvershoot !==
+		invocation.readerLocalChunkMaxOvershoot
+	) {
+		throw new Error(
+			"Benchmark result readerLocalChunkMaxOvershoot does not match the requested invocation",
+		);
+	}
+};
+
+const validateIdleDownloadScheduler = (value, label) => {
+	const scheduler = requireRecord(value, label);
+	for (const key of ["activeCount", "activeBytes", "queuedCount"]) {
+		if (
+			requireNonNegativeSafeInteger(scheduler[key], `${label}.${key}`) !== 0
+		) {
+			throw new Error(`${label} is not idle`);
+		}
+	}
+};
+
+const validateExactChunkIndexSet = (value, chunkCount, label) => {
+	if (!Array.isArray(value)) {
+		throw new Error(`${label} must be an array`);
+	}
+	let previous = -1;
+	for (const [offset, index] of value.entries()) {
+		if (
+			!Number.isSafeInteger(index) ||
+			index < 0 ||
+			index >= chunkCount ||
+			index <= previous
+		) {
+			throw new Error(`${label}[${offset}] is not a sorted unique chunk index`);
+		}
+		previous = index;
+	}
+	return value;
+};
+
+const validateLocalChunkPrefixObservation = (value, label) => {
+	const observation = requireRecord(value, label);
+	const capturedAt = requirePositiveSafeInteger(
+		observation.capturedAt,
+		`${label}.capturedAt`,
+	);
+	const fileId = requireString(observation.fileId, `${label}.fileId`);
+	const chunkCount = requirePositiveSafeInteger(
+		observation.chunkCount,
+		`${label}.chunkCount`,
+	);
+	const indexRowCount = requireNonNegativeSafeInteger(
+		observation.indexRowCount,
+		`${label}.indexRowCount`,
+	);
+	const blockCount = requireNonNegativeSafeInteger(
+		observation.blockCount,
+		`${label}.blockCount`,
+	);
+	const indexedChunkIndices = validateExactChunkIndexSet(
+		observation.indexedChunkIndices,
+		chunkCount,
+		`${label}.indexedChunkIndices`,
+	);
+	const blockChunkIndices = validateExactChunkIndexSet(
+		observation.blockChunkIndices,
+		chunkCount,
+		`${label}.blockChunkIndices`,
+	);
+	if (
+		indexRowCount !== indexedChunkIndices.length ||
+		blockCount !== blockChunkIndices.length ||
+		typeof observation.persistChunkReads !== "boolean" ||
+		!Array.isArray(observation.activeTransfers) ||
+		observation.activeTransfers.length !== 0
+	) {
+		throw new Error(`${label} has inconsistent or non-idle locality evidence`);
+	}
+	validateIdleDownloadScheduler(
+		observation.downloadScheduler,
+		`${label}.downloadScheduler`,
+	);
+	return {
+		observation,
+		capturedAt,
+		fileId,
+		chunkCount,
+		indexRowCount,
+		blockCount,
+		indexedChunkIndices,
+		blockChunkIndices,
+		persistChunkReads: observation.persistChunkReads,
+	};
+};
+
+const validateTopology = (
+	value,
+	label,
+	expectedSelfInReplicatorSet,
+	expectedReplicatorCount = 1,
+) => {
+	const topology = requireRecord(value, label);
+	const capturedAt = requirePositiveSafeInteger(
+		topology.capturedAt,
+		`${label}.capturedAt`,
+	);
+	const peerHash = requireString(topology.peerHash, `${label}.peerHash`);
+	const replicatorCount = requireNonNegativeSafeInteger(
+		topology.replicatorCount,
+		`${label}.replicatorCount`,
+	);
+	if (
+		!Array.isArray(topology.replicatorHashes) ||
+		topology.replicatorHashes.length !== replicatorCount
+	) {
+		throw new Error(
+			`${label} does not contain the exact replicator identities`,
+		);
+	}
+	const replicatorHashes = topology.replicatorHashes.map((hash, index) =>
+		requireString(hash, `${label}.replicatorHashes[${index}]`),
+	);
+	if (
+		replicatorCount !== expectedReplicatorCount ||
+		topology.selfInReplicatorSet !== expectedSelfInReplicatorSet ||
+		!isDeepStrictEqual(
+			replicatorHashes,
+			[...replicatorHashes].toSorted((left, right) =>
+				left.localeCompare(right),
+			),
+		)
+	) {
+		throw new Error(`${label} does not prove the requested topology role`);
+	}
+	return { capturedAt, peerHash, replicatorCount, replicatorHashes };
+};
+
+const validateReaderLocalityControl = (result, invocation) => {
+	const target = invocation.readerLocalChunkTarget;
+	const maxOvershoot = invocation.readerLocalChunkMaxOvershoot;
+	if (target == null) {
+		if (
+			maxOvershoot !== null ||
+			result.readerLocalityControl !== null ||
+			result.readerLocalChunkBlockCount !== null ||
+			result.readerLocalChunkIndexRowCount !== null ||
+			result.readerLocalityCohortKey !== null
+		) {
+			throw new Error(
+				"Benchmark result contains unrequested reader locality control evidence",
+			);
+		}
+		return null;
+	}
+	if (
+		!Number.isSafeInteger(maxOvershoot) ||
+		maxOvershoot < 0 ||
+		invocation.mode !== "fixed1" ||
+		invocation.minReadySeeders !== 1
+	) {
+		throw new Error("Benchmark reader locality invocation is invalid");
+	}
+	const control = requireRecord(
+		result.readerLocalityControl,
+		"readerLocalityControl",
+	);
+	if (
+		control.profile !== "observer-topology-persistent-read-preloaded-prefix" ||
+		control.requestedYieldedChunkCount !== target ||
+		control.maxReadAheadOvershootChunkCount !== maxOvershoot ||
+		control.countMetric !==
+			"exact local Documents index rows and manifest entry blocks" ||
+		control.writerUploadRole !== "fixed1" ||
+		control.readerUploadRole !== "observer" ||
+		control.readerTimedReadPolicy !== "persist-chunk-reads" ||
+		control.stabilityPollIntervalMs !== Math.min(invocation.pollMs, 100) ||
+		control.requiredStableObservationCount !== 3 ||
+		control.status !== "complete" ||
+		control.failure !== null
+	) {
+		throw new Error("Benchmark reader locality control contract is invalid");
+	}
+	const timestamps = requireRecord(result.timestamps, "timestamps");
+	const uploadStartedAt = requirePositiveSafeInteger(
+		timestamps.uploadStartedAt,
+		"timestamps.uploadStartedAt",
+	);
+	const postMonitorFinishedAt = requirePositiveSafeInteger(
+		timestamps.postMonitorFinishedAt,
+		"timestamps.postMonitorFinishedAt",
+	);
+	const downloadStartedAt = requirePositiveSafeInteger(
+		timestamps.downloadStartedAt,
+		"timestamps.downloadStartedAt",
+	);
+	const downloadFinishedAt = requirePositiveSafeInteger(
+		timestamps.downloadFinishedAt,
+		"timestamps.downloadFinishedAt",
+	);
+	const downloadCompletionObservedAt = requirePositiveSafeInteger(
+		timestamps.downloadCompletionObservedAt,
+		"timestamps.downloadCompletionObservedAt",
+	);
+	const initialRoleEvidence = requireRecord(
+		control.readerInitialRoleEvidence,
+		"readerLocalityControl.readerInitialRoleEvidence",
+	);
+	const initialRoleCapturedAt = requirePositiveSafeInteger(
+		initialRoleEvidence.capturedAt,
+		"readerLocalityControl.readerInitialRoleEvidence.capturedAt",
+	);
+	const initialProgramAddress = requireString(
+		initialRoleEvidence.programAddress,
+		"readerLocalityControl.readerInitialRoleEvidence.programAddress",
+	);
+	if (
+		initialRoleEvidence.persistChunkReads !== false ||
+		initialRoleEvidence.initialRole !== "observer" ||
+		initialRoleEvidence.updateRoleCount !== 0 ||
+		initialRoleEvidence.lastAppliedRole !== null
+	) {
+		throw new Error(
+			"Benchmark reader locality did not initialize the reader as an observer",
+		);
+	}
+	const writerTopologyBeforeUpload = validateTopology(
+		control.writerTopologyBeforeUpload,
+		"readerLocalityControl.writerTopologyBeforeUpload",
+		true,
+	);
+	const readerTopologyBeforeUpload = validateTopology(
+		control.readerTopologyBeforeUpload,
+		"readerLocalityControl.readerTopologyBeforeUpload",
+		false,
+	);
+	const writerTopologyBeforeTimedRead = validateTopology(
+		control.writerTopologyBeforeTimedRead,
+		"readerLocalityControl.writerTopologyBeforeTimedRead",
+		true,
+	);
+	const readerTopologyBeforeTimedRead = validateTopology(
+		control.readerTopologyBeforeTimedRead,
+		"readerLocalityControl.readerTopologyBeforeTimedRead",
+		false,
+	);
+	if (
+		writerTopologyBeforeUpload.replicatorCount !==
+			readerTopologyBeforeUpload.replicatorCount ||
+		writerTopologyBeforeTimedRead.replicatorCount !==
+			readerTopologyBeforeTimedRead.replicatorCount ||
+		writerTopologyBeforeUpload.peerHash ===
+			readerTopologyBeforeUpload.peerHash ||
+		writerTopologyBeforeTimedRead.peerHash ===
+			readerTopologyBeforeTimedRead.peerHash ||
+		writerTopologyBeforeUpload.peerHash !==
+			writerTopologyBeforeTimedRead.peerHash ||
+		readerTopologyBeforeUpload.peerHash !==
+			readerTopologyBeforeTimedRead.peerHash
+	) {
+		throw new Error(
+			"Benchmark topology evidence does not preserve two distinct peer identities",
+		);
+	}
+	const expectedReplicatorHashes = [writerTopologyBeforeUpload.peerHash];
+	if (
+		[
+			writerTopologyBeforeUpload,
+			readerTopologyBeforeUpload,
+			writerTopologyBeforeTimedRead,
+			readerTopologyBeforeTimedRead,
+		].some(
+			(topology) =>
+				!isDeepStrictEqual(topology.replicatorHashes, expectedReplicatorHashes),
+		)
+	) {
+		throw new Error(
+			"Benchmark topology evidence does not agree on the writer as the exact singleton replicator",
+		);
+	}
+	const beforePreload = validateLocalChunkPrefixObservation(
+		control.beforePreloadObservation,
+		"readerLocalityControl.beforePreloadObservation",
+	);
+	const readerManifest = requireRecord(
+		result.readerManifestEvidence,
+		"readerManifestEvidence",
+	);
+	const manifestFileId = requireString(
+		readerManifest.fileId,
+		"readerManifestEvidence.fileId",
+	);
+	const canonicalChunkCount = requirePositiveSafeInteger(
+		requireRecord(result.readTransfer, "readTransfer").chunkCount,
+		"readTransfer.chunkCount",
+	);
+	if (beforePreload.chunkCount !== canonicalChunkCount) {
+		throw new Error(
+			"Benchmark reader locality manifest chunk count contradicts the canonical completed read",
+		);
+	}
+	if (target >= canonicalChunkCount) {
+		throw new Error(
+			"Benchmark reader locality target must be a partial prefix of the canonical completed read",
+		);
+	}
+	if (
+		beforePreload.fileId !== manifestFileId ||
+		beforePreload.indexRowCount !== 0 ||
+		beforePreload.blockCount !== 0 ||
+		beforePreload.indexedChunkIndices.length !== 0 ||
+		beforePreload.blockChunkIndices.length !== 0 ||
+		beforePreload.persistChunkReads !== false
+	) {
+		throw new Error(
+			"Benchmark reader locality did not begin as an empty observer cache",
+		);
+	}
+	const preload = requireRecord(
+		control.preloadEvidence,
+		"readerLocalityControl.preloadEvidence",
+	);
+	const preloadStartedAt = requirePositiveSafeInteger(
+		preload.startedAt,
+		"readerLocalityControl.preloadEvidence.startedAt",
+	);
+	const preloadFinishedAt = requirePositiveSafeInteger(
+		preload.finishedAt,
+		"readerLocalityControl.preloadEvidence.finishedAt",
+	);
+	const yieldedByteCount = requireNonNegativeSafeInteger(
+		preload.yieldedByteCount,
+		"readerLocalityControl.preloadEvidence.yieldedByteCount",
+	);
+	if (
+		preload.fileId !== manifestFileId ||
+		preload.yieldedChunkCount !== target ||
+		preload.persistChunkReads !== true ||
+		!Array.isArray(preload.activeTransfersAfterClose) ||
+		preload.activeTransfersAfterClose.length !== 0 ||
+		preloadFinishedAt < preloadStartedAt
+	) {
+		throw new Error("Benchmark reader locality preload evidence is invalid");
+	}
+	validateIdleDownloadScheduler(
+		preload.downloadSchedulerAfterClose,
+		"readerLocalityControl.preloadEvidence.downloadSchedulerAfterClose",
+	);
+	if (target === 0) {
+		if (
+			preload.transferId !== null ||
+			preload.readDiagnostics !== null ||
+			yieldedByteCount !== 0
+		) {
+			throw new Error("Zero-prefix locality preload opened a read transfer");
+		}
+	} else {
+		const preloadTransferId = requireString(
+			preload.transferId,
+			"readerLocalityControl.preloadEvidence.transferId",
+		);
+		const preloadDiagnostics = requireRecord(
+			preload.readDiagnostics,
+			"readerLocalityControl.preloadEvidence.readDiagnostics",
+		);
+		if (
+			preloadDiagnostics.transferId !== preloadTransferId ||
+			preloadDiagnostics.fileId !== manifestFileId ||
+			preloadDiagnostics.fileName !== result.fileName ||
+			preloadDiagnostics.persistChunkReads !== true ||
+			preloadDiagnostics.programPersistChunkReads !== true ||
+			preloadDiagnostics.initialLocalChunkIndexRowCount !== 0 ||
+			preloadDiagnostics.initialLocalChunkCount !== 0 ||
+			preloadDiagnostics.initialLocalChunkBlockCount !== 0 ||
+			preloadDiagnostics.finishedAt !== null ||
+			preloadDiagnostics.failureAt !== null ||
+			preloadDiagnostics.failureMessage !== null
+		) {
+			throw new Error(
+				"Benchmark partial preload diagnostics do not prove a clean persistent read",
+			);
+		}
+		const chunkBytes = requireRecord(
+			preloadDiagnostics.chunkByteLength,
+			"readerLocalityControl.preloadEvidence.readDiagnostics.chunkByteLength",
+		);
+		const expectedKeys = Array.from({ length: target }, (_, index) =>
+			String(index),
+		);
+		if (
+			Object.keys(chunkBytes).length !== target ||
+			expectedKeys.some((key) => !Object.hasOwn(chunkBytes, key))
+		) {
+			throw new Error(
+				"Benchmark partial preload did not yield the exact requested prefix",
+			);
+		}
+		const recomputedYieldedBytes = expectedKeys.reduce(
+			(total, key) =>
+				total +
+				requirePositiveSafeInteger(
+					chunkBytes[key],
+					`readerLocalityControl.preloadEvidence.readDiagnostics.chunkByteLength[${key}]`,
+				),
+			0,
+		);
+		if (recomputedYieldedBytes !== yieldedByteCount) {
+			throw new Error("Benchmark partial preload byte count is inconsistent");
+		}
+	}
+	if (
+		!Array.isArray(control.stabilityObservations) ||
+		control.stabilityObservations.length !== 3
+	) {
+		throw new Error(
+			"Benchmark reader locality requires exactly three stable observations",
+		);
+	}
+	const stable = control.stabilityObservations.map((observation, index) =>
+		validateLocalChunkPrefixObservation(
+			observation,
+			`readerLocalityControl.stabilityObservations[${index}]`,
+		),
+	);
+	const actualLocalChunkBlockCount = requireNonNegativeSafeInteger(
+		control.actualLocalChunkBlockCount,
+		"readerLocalityControl.actualLocalChunkBlockCount",
+	);
+	const actualLocalChunkIndexRowCount = requireNonNegativeSafeInteger(
+		control.actualLocalChunkIndexRowCount,
+		"readerLocalityControl.actualLocalChunkIndexRowCount",
+	);
+	const expectedBlockPrefix = Array.from(
+		{ length: actualLocalChunkBlockCount },
+		(_, index) => index,
+	);
+	const expectedIndexPrefix = Array.from(
+		{ length: actualLocalChunkIndexRowCount },
+		(_, index) => index,
+	);
+	for (const [index, observation] of stable.entries()) {
+		if (
+			observation.fileId !== manifestFileId ||
+			observation.chunkCount !== canonicalChunkCount ||
+			observation.indexRowCount !== actualLocalChunkIndexRowCount ||
+			observation.blockCount !== actualLocalChunkBlockCount ||
+			observation.persistChunkReads !== true ||
+			!isDeepStrictEqual(
+				observation.indexedChunkIndices,
+				expectedIndexPrefix,
+			) ||
+			!isDeepStrictEqual(observation.blockChunkIndices, expectedBlockPrefix) ||
+			(index > 0 &&
+				observation.capturedAt - stable[index - 1].capturedAt <
+					control.stabilityPollIntervalMs)
+		) {
+			throw new Error(
+				"Benchmark stable locality observations do not prove one exact prefix",
+			);
+		}
+	}
+	const preDownload = validateLocalChunkPrefixObservation(
+		control.preDownloadObservation,
+		"readerLocalityControl.preDownloadObservation",
+	);
+	const expectedCohortKey = `observer-persistent-prefix-b${actualLocalChunkBlockCount}-i${actualLocalChunkIndexRowCount}`;
+	if (
+		actualLocalChunkBlockCount < target ||
+		actualLocalChunkBlockCount > target + maxOvershoot ||
+		actualLocalChunkBlockCount >= canonicalChunkCount ||
+		actualLocalChunkIndexRowCount > actualLocalChunkBlockCount ||
+		control.readAheadOvershootChunkCount !==
+			actualLocalChunkBlockCount - target ||
+		control.cohortKey !== expectedCohortKey ||
+		result.readerLocalChunkBlockCount !== actualLocalChunkBlockCount ||
+		result.readerLocalChunkIndexRowCount !== actualLocalChunkIndexRowCount ||
+		result.readerLocalityCohortKey !== expectedCohortKey ||
+		preDownload.chunkCount !== canonicalChunkCount ||
+		!isDeepStrictEqual(preDownload.observation, stable.at(-1).observation)
+	) {
+		throw new Error(
+			"Benchmark reader locality cohort count or key is inconsistent",
+		);
+	}
+	const readerDiagnostics = requireRecord(
+		result.readerDiagnostics,
+		"readerDiagnostics",
+	);
+	const readerTimings = requireRecord(
+		readerDiagnostics.timings,
+		"readerDiagnostics.timings",
+	);
+	const timedRead = requireRecord(
+		readerDiagnostics.lastReadDiagnostics,
+		"readerDiagnostics.lastReadDiagnostics",
+	);
+	if (
+		readerDiagnostics.persistChunkReads !== true ||
+		readerDiagnostics.programAddress !== initialProgramAddress ||
+		readerTimings.initialRole !== initialRoleEvidence.initialRole ||
+		readerTimings.updateRoleCount !== initialRoleEvidence.updateRoleCount ||
+		readerTimings.lastAppliedRole !== initialRoleEvidence.lastAppliedRole
+	) {
+		throw new Error(
+			"Benchmark reader diagnostics contradict its initial observer-role evidence",
+		);
+	}
+	if (
+		timedRead.persistChunkReads !== true ||
+		timedRead.programPersistChunkReads !== true ||
+		timedRead.initialLocalChunkIndexRowCount !==
+			actualLocalChunkIndexRowCount ||
+		timedRead.initialLocalChunkCount !== actualLocalChunkIndexRowCount ||
+		timedRead.initialLocalChunkBlockCount !== actualLocalChunkBlockCount
+	) {
+		throw new Error(
+			"Benchmark timed read diagnostics do not match its exact locality cohort",
+		);
+	}
+	const integrityVerifiedAt = requirePositiveSafeInteger(
+		control.integrityVerifiedAt,
+		"readerLocalityControl.integrityVerifiedAt",
+	);
+	const terminalIdle = validateLocalChunkPrefixObservation(
+		control.terminalIdleObservation,
+		"readerLocalityControl.terminalIdleObservation",
+	);
+	if (
+		terminalIdle.fileId !== manifestFileId ||
+		terminalIdle.chunkCount !== canonicalChunkCount ||
+		terminalIdle.blockCount !== canonicalChunkCount ||
+		terminalIdle.persistChunkReads !== true ||
+		control.terminalTopologyRole !== "replicator" ||
+		control.readerJoinedReplicationDuringTimedRead !== true
+	) {
+		throw new Error(
+			"Benchmark terminal reader evidence does not prove an idle persistent replicator",
+		);
+	}
+	const terminalTopologyStartedAt = requirePositiveSafeInteger(
+		control.terminalTopologyStartedAt,
+		"readerLocalityControl.terminalTopologyStartedAt",
+	);
+	const terminalTopologyDeadlineAt = requirePositiveSafeInteger(
+		control.terminalTopologyDeadlineAt,
+		"readerLocalityControl.terminalTopologyDeadlineAt",
+	);
+	const terminalTopologyFinishedAt = requirePositiveSafeInteger(
+		control.terminalTopologyFinishedAt,
+		"readerLocalityControl.terminalTopologyFinishedAt",
+	);
+	if (
+		!Array.isArray(control.terminalTopologyObservations) ||
+		control.terminalTopologyObservations.length !== 3
+	) {
+		throw new Error(
+			"Benchmark reader locality requires exactly three stable terminal topology observations",
+		);
+	}
+	const expectedTerminalReplicatorHashes = [
+		writerTopologyBeforeUpload.peerHash,
+		readerTopologyBeforeUpload.peerHash,
+	].toSorted((left, right) => left.localeCompare(right));
+	const terminalTopologyObservations = control.terminalTopologyObservations.map(
+		(value, index) => {
+			const label = `readerLocalityControl.terminalTopologyObservations[${index}]`;
+			const observation = requireRecord(value, label);
+			const capturedAt = requirePositiveSafeInteger(
+				observation.capturedAt,
+				`${label}.capturedAt`,
+			);
+			const writerTopology = validateTopology(
+				observation.writerTopology,
+				`${label}.writerTopology`,
+				true,
+				2,
+			);
+			const readerTopology = validateTopology(
+				observation.readerTopology,
+				`${label}.readerTopology`,
+				true,
+				2,
+			);
+			if (
+				writerTopology.peerHash !== writerTopologyBeforeUpload.peerHash ||
+				readerTopology.peerHash !== readerTopologyBeforeUpload.peerHash ||
+				!isDeepStrictEqual(
+					writerTopology.replicatorHashes,
+					expectedTerminalReplicatorHashes,
+				) ||
+				!isDeepStrictEqual(
+					readerTopology.replicatorHashes,
+					expectedTerminalReplicatorHashes,
+				) ||
+				writerTopology.capturedAt > capturedAt ||
+				readerTopology.capturedAt > capturedAt ||
+				writerTopology.capturedAt < terminalTopologyStartedAt ||
+				readerTopology.capturedAt < terminalTopologyStartedAt ||
+				capturedAt > terminalTopologyFinishedAt ||
+				(index > 0 &&
+					capturedAt -
+						control.terminalTopologyObservations[index - 1].capturedAt <
+						control.stabilityPollIntervalMs)
+			) {
+				throw new Error(
+					"Benchmark terminal topology observations do not prove one stable writer-reader replicator pair",
+				);
+			}
+			return { capturedAt, writerTopology, readerTopology };
+		},
+	);
+	const writerDiagnostics = requireRecord(
+		result.writerDiagnostics,
+		"writerDiagnostics",
+	);
+	if (
+		writerDiagnostics.peerHash !== writerTopologyBeforeUpload.peerHash ||
+		readerDiagnostics.peerHash !== readerTopologyBeforeUpload.peerHash ||
+		writerDiagnostics.replicatorCount !== 2 ||
+		readerDiagnostics.replicatorCount !== 2
+	) {
+		throw new Error(
+			"Benchmark final peer diagnostics contradict the terminal topology evidence",
+		);
+	}
+	if (
+		initialRoleCapturedAt > uploadStartedAt ||
+		writerTopologyBeforeUpload.capturedAt > uploadStartedAt ||
+		readerTopologyBeforeUpload.capturedAt > uploadStartedAt ||
+		beforePreload.capturedAt < postMonitorFinishedAt ||
+		preloadStartedAt < beforePreload.capturedAt ||
+		preloadFinishedAt < preloadStartedAt ||
+		stable[0].capturedAt < preloadFinishedAt ||
+		preDownload.capturedAt > writerTopologyBeforeTimedRead.capturedAt ||
+		preDownload.capturedAt > readerTopologyBeforeTimedRead.capturedAt ||
+		writerTopologyBeforeTimedRead.capturedAt > downloadStartedAt ||
+		readerTopologyBeforeTimedRead.capturedAt > downloadStartedAt ||
+		downloadFinishedAt > downloadCompletionObservedAt ||
+		integrityVerifiedAt < downloadCompletionObservedAt ||
+		terminalIdle.capturedAt < integrityVerifiedAt ||
+		terminalTopologyStartedAt < terminalIdle.capturedAt ||
+		terminalTopologyDeadlineAt !==
+			terminalTopologyStartedAt + invocation.readyTimeoutMs ||
+		terminalTopologyFinishedAt < terminalTopologyStartedAt ||
+		terminalTopologyFinishedAt > terminalTopologyDeadlineAt ||
+		terminalTopologyObservations[0].capturedAt < terminalTopologyStartedAt ||
+		terminalTopologyObservations.at(-1).capturedAt > terminalTopologyFinishedAt
+	) {
+		throw new Error(
+			"Benchmark reader locality control timestamps are inconsistent",
+		);
+	}
+	return { actualLocalChunkBlockCount, actualLocalChunkIndexRowCount };
 };
 
 const validateCollectedStringEvidence = ({
@@ -1061,7 +1718,12 @@ const validateUploadSnapshots = (result, invocation) => {
 			}
 			hasPostMonitorSample = true;
 		}
-		parsedSnapshots.push({ label, writerSeeders, readerSeeders });
+		parsedSnapshots.push({
+			label,
+			writerSeeders,
+			readerSeeders,
+			capturedAt,
+		});
 		previousAt = capturedAt;
 	}
 	if (invocation.postUploadMonitorMs > 0 && !hasPostMonitorSample) {
@@ -1115,6 +1777,12 @@ const validateUploadSnapshots = (result, invocation) => {
 	if (result.droppedSeeders !== recomputedDroppedSeeders) {
 		throw new Error(
 			"Upload droppedSeeders claim contradicts its numeric snapshot evidence",
+		);
+	}
+	const recomputedUnexpectedSeederDrop = recomputedDroppedSeeders;
+	if (result.unexpectedSeederDrop !== recomputedUnexpectedSeederDrop) {
+		throw new Error(
+			"Upload unexpectedSeederDrop claim contradicts its numeric snapshot evidence",
 		);
 	}
 };
@@ -1339,7 +2007,13 @@ export const validateBenchmarkResult = (
 		validateUploadTimings(result, expectedInvocation);
 		validateRequestedUploadKnobs(result, expectedInvocation);
 		validateZeroErrors(result, "upload result");
+		validateReaderLocalityControl(result, expectedInvocation);
 		validateUploadSnapshots(result, expectedInvocation);
+		if (result.unexpectedSeederDrop !== false) {
+			throw new Error(
+				"Passed upload result contains an unexpected seeder drop",
+			);
+		}
 		if (result.droppedSeeders !== false) {
 			throw new Error("Passed upload result contains seeder drops");
 		}

--- a/scripts/file-share/benchmark-validity.mjs
+++ b/scripts/file-share/benchmark-validity.mjs
@@ -1273,15 +1273,44 @@ const validateReaderLocalityControl = (result, invocation) => {
 		preload.downloadSchedulerAfterClose,
 		"readerLocalityControl.preloadEvidence.downloadSchedulerAfterClose",
 	);
+	if (preload.aggregateTimedOut !== false) {
+		throw new Error(
+			"Benchmark reader locality preload aggregate deadline evidence is invalid",
+		);
+	}
 	if (target === 0) {
 		if (
 			preload.transferId !== null ||
 			preload.readDiagnostics !== null ||
+			preload.aggregateTimeoutMs !== null ||
+			preload.aggregateDeadlineAt !== null ||
 			yieldedByteCount !== 0
 		) {
 			throw new Error("Zero-prefix locality preload opened a read transfer");
 		}
 	} else {
+		const aggregateTimeoutMs = requirePositiveSafeInteger(
+			preload.aggregateTimeoutMs,
+			"readerLocalityControl.preloadEvidence.aggregateTimeoutMs",
+		);
+		const aggregateDeadlineAt = requirePositiveSafeInteger(
+			preload.aggregateDeadlineAt,
+			"readerLocalityControl.preloadEvidence.aggregateDeadlineAt",
+		);
+		const aggregateSchedulingToleranceMs = Math.max(
+			5_000,
+			invocation.pollMs + 1_000,
+		);
+		if (
+			aggregateTimeoutMs !== invocation.downloadTimeoutMs ||
+			aggregateDeadlineAt !== preloadStartedAt + aggregateTimeoutMs ||
+			preloadFinishedAt - preloadStartedAt >
+				aggregateTimeoutMs + aggregateSchedulingToleranceMs
+		) {
+			throw new Error(
+				"Benchmark reader locality preload aggregate deadline evidence is invalid",
+			);
+		}
 		const preloadTransferId = requireString(
 			preload.transferId,
 			"readerLocalityControl.preloadEvidence.transferId",

--- a/scripts/file-share/benchmark-validity.test.mjs
+++ b/scripts/file-share/benchmark-validity.test.mjs
@@ -107,6 +107,12 @@ const validResult = () => ({
 	provenance: structuredClone(PROVENANCE),
 	status: "passed",
 	mode: "adaptive",
+	readerLocalChunkTarget: null,
+	readerLocalChunkMaxOvershoot: null,
+	readerLocalChunkBlockCount: null,
+	readerLocalChunkIndexRowCount: null,
+	readerLocalityCohortKey: null,
+	readerLocalityControl: null,
 	networkMode: "local",
 	fileName: FILE_NAME,
 	fileSizeMb: FILE_MB,
@@ -227,6 +233,7 @@ const validResult = () => ({
 	baselineWriterSeeders: 2,
 	baselineReaderSeeders: 2,
 	droppedSeeders: false,
+	unexpectedSeederDrop: false,
 	errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
 	knownPeerbitFailureSignatures: [...KNOWN_PEERBIT_FAILURE_SIGNATURES],
 	errorCollectionComplete: true,
@@ -325,9 +332,463 @@ const createSinkFixture = (downloadSink) => {
 	};
 };
 
+const createReaderLocalityFixture = ({
+	target = 1,
+	maxOvershoot = 1,
+	actualBlockCount = 1,
+	actualIndexRowCount = 0,
+} = {}) => {
+	const invocation = createBenchmarkInvocation({
+		scenario: "upload",
+		mode: "fixed1",
+		network: "local",
+		integrationMode: "link",
+		fileMb: FILE_MB,
+		fixtureSeed: "fixture-seed",
+		uploadTimeoutMs: 600_000,
+		downloadTimeoutMs: 600_000,
+		postUploadMonitorMs: 50,
+		pollMs: 1_000,
+		minReadySeeders: 1,
+		readyTimeoutMs: 180_000,
+		readerLocalChunkTarget: target,
+		readerLocalChunkMaxOvershoot: maxOvershoot,
+	});
+	const result = validResult();
+	const fileName = `file-share-benchmark-fixed1-${RUN_NONCE}.bin`;
+	const idleScheduler = {
+		activeCount: 0,
+		activeBytes: 0,
+		queuedCount: 0,
+	};
+	const observation = ({
+		capturedAt,
+		persistChunkReads,
+		blocks = [],
+		indexed = [],
+	}) => ({
+		capturedAt,
+		fileId: FILE_ID,
+		chunkCount: 2,
+		indexRowCount: indexed.length,
+		indexedChunkIndices: indexed,
+		blockCount: blocks.length,
+		blockChunkIndices: blocks,
+		persistChunkReads,
+		activeTransfers: [],
+		downloadScheduler: { ...idleScheduler },
+	});
+	const topology = (
+		capturedAt,
+		selfInReplicatorSet,
+		{
+			peerHash = selfInReplicatorSet ? "writer-peer" : "reader-peer",
+			replicatorCount = 1,
+			replicatorHashes = ["writer-peer"],
+		} = {},
+	) => ({
+		capturedAt,
+		peerHash,
+		replicatorCount,
+		replicatorHashes,
+		selfInReplicatorSet,
+	});
+	const terminalTopology = (capturedAt, peerHash) =>
+		topology(capturedAt, true, {
+			peerHash,
+			replicatorCount: 2,
+			replicatorHashes: ["reader-peer", "writer-peer"],
+		});
+	result.invocation = structuredClone(invocation);
+	result.mode = "fixed1";
+	result.fileName = fileName;
+	result.readerLocalChunkTarget = target;
+	result.readerLocalChunkMaxOvershoot = maxOvershoot;
+	result.readerLocalChunkBlockCount = actualBlockCount;
+	result.readerLocalChunkIndexRowCount = actualIndexRowCount;
+	const cohortKey = `observer-persistent-prefix-b${actualBlockCount}-i${actualIndexRowCount}`;
+	result.readerLocalityCohortKey = cohortKey;
+	result.minReadySeeders = 1;
+	result.readerDiagnostics.lastReadDiagnostics.fileName = fileName;
+	result.readerDiagnostics.programAddress = "reader-program-address";
+	result.readerDiagnostics.persistChunkReads = true;
+	result.readerDiagnostics.peerHash = "reader-peer";
+	result.readerDiagnostics.replicatorCount = 2;
+	result.readerDiagnostics.timings = {
+		initialRole: "observer",
+		updateRoleCount: 0,
+		lastAppliedRole: null,
+	};
+	Object.assign(result.readerDiagnostics.lastReadDiagnostics, {
+		persistChunkReads: true,
+		programPersistChunkReads: true,
+		initialLocalChunkIndexRowCount: actualIndexRowCount,
+		initialLocalChunkCount: actualIndexRowCount,
+		initialLocalChunkBlockCount: actualBlockCount,
+		startedAt: 1_400,
+		finishedAt: 1_430,
+		chunkWriteStartedAt: { 0: 1_410, 1: 1_422 },
+		chunkWriteFinishedAt: { 0: 1_415, 1: 1_426 },
+		chunkMaterializeStartedAt: { 0: 1_401, 1: 1_416 },
+		chunkMaterializeFinishedAt: { 0: 1_403, 1: 1_418 },
+		chunkHashStartedAt: { 0: 1_403, 1: 1_418 },
+		chunkHashFinishedAt: { 0: 1_404, 1: 1_420 },
+	});
+	result.writerManifestEvidence.fileName = fileName;
+	result.readerManifestEvidence.fileName = fileName;
+	result.writerDiagnostics = {
+		peerHash: "writer-peer",
+		replicatorCount: 2,
+	};
+	result.timestamps.downloadStartedAt = 1_400;
+	result.timestamps.downloadFinishedAt = 1_430;
+	result.timestamps.downloadCompletionObservedAt = 1_431;
+	result.readerLocalityControl = {
+		profile: "observer-topology-persistent-read-preloaded-prefix",
+		requestedYieldedChunkCount: target,
+		maxReadAheadOvershootChunkCount: maxOvershoot,
+		countMetric: "exact local Documents index rows and manifest entry blocks",
+		writerUploadRole: "fixed1",
+		readerUploadRole: "observer",
+		readerTimedReadPolicy: "persist-chunk-reads",
+		stabilityPollIntervalMs: 100,
+		requiredStableObservationCount: 3,
+		status: "complete",
+		readerInitialRoleEvidence: {
+			capturedAt: 989,
+			programAddress: "reader-program-address",
+			persistChunkReads: false,
+			initialRole: "observer",
+			updateRoleCount: 0,
+			lastAppliedRole: null,
+		},
+		writerTopologyBeforeUpload: topology(990, true),
+		readerTopologyBeforeUpload: topology(991, false),
+		writerTopologyBeforeTimedRead: topology(1_380, true),
+		readerTopologyBeforeTimedRead: topology(1_381, false),
+		beforePreloadObservation: observation({
+			capturedAt: 1_171,
+			persistChunkReads: false,
+		}),
+		preloadEvidence: {
+			startedAt: 1_172,
+			finishedAt: 1_175,
+			fileId: FILE_ID,
+			transferId: target === 0 ? null : "locality-preload-transfer",
+			yieldedChunkCount: target,
+			yieldedByteCount: target === 0 ? 0 : 3 * 1024 * 1024,
+			persistChunkReads: true,
+			activeTransfersAfterClose: [],
+			downloadSchedulerAfterClose: { ...idleScheduler },
+			readDiagnostics:
+				target === 0
+					? null
+					: {
+							transferId: "locality-preload-transfer",
+							fileId: FILE_ID,
+							fileName,
+							persistChunkReads: true,
+							programPersistChunkReads: true,
+							initialLocalChunkIndexRowCount: 0,
+							initialLocalChunkCount: 0,
+							initialLocalChunkBlockCount: 0,
+							finishedAt: null,
+							failureAt: null,
+							failureMessage: null,
+							chunkByteLength: { 0: 3 * 1024 * 1024 },
+						},
+		},
+		stabilityObservations: [1_176, 1_276, 1_376].map((capturedAt) =>
+			observation({
+				capturedAt,
+				persistChunkReads: true,
+				blocks: Array.from({ length: actualBlockCount }, (_, index) => index),
+				indexed: Array.from(
+					{ length: actualIndexRowCount },
+					(_, index) => index,
+				),
+			}),
+		),
+		preDownloadObservation: observation({
+			capturedAt: 1_376,
+			persistChunkReads: true,
+			blocks: Array.from({ length: actualBlockCount }, (_, index) => index),
+			indexed: Array.from({ length: actualIndexRowCount }, (_, index) => index),
+		}),
+		integrityVerifiedAt: 1_432,
+		terminalIdleObservation: observation({
+			capturedAt: 1_433,
+			persistChunkReads: true,
+			blocks: [0, 1],
+		}),
+		terminalTopologyStartedAt: 1_433,
+		terminalTopologyDeadlineAt: 181_433,
+		terminalTopologyFinishedAt: 1_635,
+		terminalTopologyRole: "replicator",
+		readerJoinedReplicationDuringTimedRead: true,
+		terminalTopologyObservations: [1_434, 1_534, 1_634].map((capturedAt) => ({
+			capturedAt,
+			writerTopology: terminalTopology(capturedAt - 1, "writer-peer"),
+			readerTopology: terminalTopology(capturedAt - 1, "reader-peer"),
+		})),
+		actualLocalChunkBlockCount: actualBlockCount,
+		actualLocalChunkIndexRowCount: actualIndexRowCount,
+		readAheadOvershootChunkCount: 0,
+		cohortKey,
+		failure: null,
+	};
+	result.snapshots = [
+		{
+			...result.snapshots[0],
+			writerSeeders: 1,
+			readerSeeders: 1,
+		},
+		{
+			label: "after-1",
+			writerSeeders: 1,
+			readerSeeders: 1,
+			at: 1_130,
+		},
+	];
+	result.baselineWriterSeeders = 1;
+	result.baselineReaderSeeders = 1;
+	result.droppedSeeders = false;
+	result.unexpectedSeederDrop = false;
+	return {
+		result,
+		options: {
+			...options,
+			expectedMode: "fixed1",
+			expectedInvocation: invocation,
+		},
+	};
+};
+
 test("accepts a complete deterministic transfer result", () => {
 	assert.equal(
 		validateBenchmarkResult(validResult(), options).status,
+		"passed",
+	);
+});
+
+test("accepts exact observer-locality control and rejects contradictory evidence", () => {
+	const fixture = createReaderLocalityFixture();
+	assert.equal(
+		validateBenchmarkResult(fixture.result, fixture.options).status,
+		"passed",
+	);
+	for (const [mutate, pattern] of [
+		[
+			(result) => {
+				result.readerLocalityControl.beforePreloadObservation.chunkCount = 3;
+				for (const observation of [
+					...result.readerLocalityControl.stabilityObservations,
+					result.readerLocalityControl.preDownloadObservation,
+				]) {
+					observation.chunkCount = 3;
+				}
+			},
+			/manifest chunk count contradicts the canonical completed read/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.readerInitialRoleEvidence.initialRole =
+					"replicator-default";
+			},
+			/did not initialize the reader as an observer/,
+		],
+		[
+			(result) => {
+				result.readerDiagnostics.timings.updateRoleCount = 1;
+			},
+			/diagnostics contradict its initial observer-role evidence/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.readerTopologyBeforeTimedRead.peerHash =
+					"writer-peer";
+			},
+			/does not preserve two distinct peer identities/,
+		],
+		[
+			(result) => {
+				const control = result.readerLocalityControl;
+				control.writerTopologyBeforeTimedRead.peerHash = "new-writer";
+				control.writerTopologyBeforeTimedRead.replicatorHashes = ["new-writer"];
+				control.readerTopologyBeforeTimedRead.peerHash = "new-reader";
+				control.readerTopologyBeforeTimedRead.replicatorHashes = ["new-writer"];
+			},
+			/does not preserve two distinct peer identities/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.readerTopologyBeforeTimedRead.replicatorHashes =
+					["third-peer"];
+			},
+			/does not agree on the writer as the exact singleton replicator/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.stabilityObservations[1].capturedAt = 1_200;
+			},
+			/stable locality observations do not prove one exact prefix/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.stabilityObservations[0].blockChunkIndices =
+					[1];
+			},
+			/stable locality observations do not prove one exact prefix/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.readAheadOvershootChunkCount = 1;
+			},
+			/locality cohort count or key is inconsistent/,
+		],
+		[
+			(result) => {
+				const control = result.readerLocalityControl;
+				for (const observation of [
+					...control.stabilityObservations,
+					control.preDownloadObservation,
+				]) {
+					observation.blockCount = 2;
+					observation.blockChunkIndices = [0, 1];
+				}
+				control.actualLocalChunkBlockCount = 2;
+				control.readAheadOvershootChunkCount = 1;
+				control.cohortKey = "observer-persistent-prefix-b2-i0";
+				result.readerLocalChunkBlockCount = 2;
+				result.readerLocalityCohortKey = control.cohortKey;
+				result.readerDiagnostics.lastReadDiagnostics.initialLocalChunkBlockCount = 2;
+			},
+			/locality cohort count or key is inconsistent/,
+		],
+		[
+			(result) => {
+				result.readerDiagnostics.lastReadDiagnostics.initialLocalChunkBlockCount = 0;
+			},
+			/timed read diagnostics do not match its exact locality cohort/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.readerJoinedReplicationDuringTimedRead = false;
+			},
+			/terminal reader evidence does not prove an idle persistent replicator/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.terminalIdleObservation.activeTransfers = [
+					"still-active",
+				];
+			},
+			/terminalIdleObservation has inconsistent or non-idle locality evidence/,
+		],
+		[
+			(result) => {
+				const terminalIdle =
+					result.readerLocalityControl.terminalIdleObservation;
+				terminalIdle.blockCount = 1;
+				terminalIdle.blockChunkIndices = [0];
+			},
+			/terminal reader evidence does not prove an idle persistent replicator/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.terminalTopologyObservations.pop();
+			},
+			/exactly three stable terminal topology observations/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.terminalTopologyObservations[1].readerTopology.replicatorHashes =
+					["reader-peer", "third-peer"];
+			},
+			/terminal topology observations do not prove one stable writer-reader replicator pair/,
+		],
+		[
+			(result) => {
+				const observation =
+					result.readerLocalityControl.terminalTopologyObservations[1];
+				observation.capturedAt = 1_500;
+				observation.writerTopology.capturedAt = 1_499;
+				observation.readerTopology.capturedAt = 1_499;
+			},
+			/terminal topology observations do not prove one stable writer-reader replicator pair/,
+		],
+		[
+			(result) => {
+				result.writerDiagnostics.peerHash = "other-writer";
+			},
+			/final peer diagnostics contradict the terminal topology evidence/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.integrityVerifiedAt = 1_430;
+			},
+			/locality control timestamps are inconsistent/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.terminalTopologyDeadlineAt -= 1;
+			},
+			/locality control timestamps are inconsistent/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.readerTopologyBeforeTimedRead.selfInReplicatorSet = true;
+			},
+			/does not prove the requested topology role/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.preloadEvidence.activeTransfersAfterClose =
+					["still-active"];
+			},
+			/locality preload evidence is invalid/,
+		],
+		[
+			(result) => {
+				result.snapshots[1].writerSeeders = 0;
+				result.droppedSeeders = true;
+				result.unexpectedSeederDrop = true;
+			},
+			/seeder drop/i,
+		],
+	]) {
+		const rejected = createReaderLocalityFixture();
+		mutate(rejected.result);
+		assert.throws(
+			() => validateBenchmarkResult(rejected.result, rejected.options),
+			pattern,
+		);
+	}
+	const fullFileTarget = createReaderLocalityFixture();
+	for (const invocation of [
+		fullFileTarget.result.invocation,
+		fullFileTarget.options.expectedInvocation,
+	]) {
+		invocation.readerLocalChunkTarget = 2;
+	}
+	fullFileTarget.result.readerLocalChunkTarget = 2;
+	fullFileTarget.result.readerLocalityControl.requestedYieldedChunkCount = 2;
+	assert.throws(
+		() =>
+			validateBenchmarkResult(fullFileTarget.result, fullFileTarget.options),
+		/target must be a partial prefix of the canonical completed read/,
+	);
+});
+
+test("accepts the explicit cold observer-persistent b0-i0 locality cohort", () => {
+	const fixture = createReaderLocalityFixture({
+		target: 0,
+		maxOvershoot: 0,
+		actualBlockCount: 0,
+		actualIndexRowCount: 0,
+	});
+	assert.equal(
+		validateBenchmarkResult(fixture.result, fixture.options).status,
 		"passed",
 	);
 });
@@ -1061,8 +1522,9 @@ for (const [name, mutate, pattern] of [
 		(result) => {
 			result.snapshots[1].readerSeeders = 1;
 			result.droppedSeeders = true;
+			result.unexpectedSeederDrop = true;
 		},
-		/contains seeder drops/,
+		/contains an unexpected seeder drop/,
 	],
 ]) {
 	test(`rejects invalid ${name}`, () => {

--- a/scripts/file-share/benchmark-validity.test.mjs
+++ b/scripts/file-share/benchmark-validity.test.mjs
@@ -475,6 +475,10 @@ const createReaderLocalityFixture = ({
 			finishedAt: 1_175,
 			fileId: FILE_ID,
 			transferId: target === 0 ? null : "locality-preload-transfer",
+			aggregateTimeoutMs: target === 0 ? null : invocation.downloadTimeoutMs,
+			aggregateDeadlineAt:
+				target === 0 ? null : 1_172 + invocation.downloadTimeoutMs,
+			aggregateTimedOut: false,
 			yieldedChunkCount: target,
 			yieldedByteCount: target === 0 ? 0 : 3 * 1024 * 1024,
 			persistChunkReads: true,
@@ -747,6 +751,34 @@ test("accepts exact observer-locality control and rejects contradictory evidence
 					["still-active"];
 			},
 			/locality preload evidence is invalid/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.preloadEvidence.aggregateTimedOut = true;
+			},
+			/preload aggregate deadline evidence is invalid/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.preloadEvidence.aggregateTimeoutMs += 1;
+			},
+			/preload aggregate deadline evidence is invalid/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.preloadEvidence.aggregateDeadlineAt += 1;
+			},
+			/preload aggregate deadline evidence is invalid/,
+		],
+		[
+			(result) => {
+				const preload = result.readerLocalityControl.preloadEvidence;
+				preload.finishedAt =
+					preload.aggregateDeadlineAt +
+					result.transferTimeoutSchedulingToleranceMs +
+					1;
+			},
+			/preload aggregate deadline evidence is invalid/,
 		],
 		[
 			(result) => {

--- a/scripts/file-share/run-file-share-benchmark-matrix.mjs
+++ b/scripts/file-share/run-file-share-benchmark-matrix.mjs
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import {
+	MAX_READER_LOCAL_CHUNK_OVERSHOOT,
 	assertBenchmarkFileSize,
 	assertCoreBenchmarkUsesLocalApp,
 	createBenchmarkInvocation,
@@ -33,6 +34,7 @@ import {
 } from "./benchmark-provenance.mjs";
 import {
 	compareUploadPerformanceModesForCompletePlan,
+	groupUploadResultsByLocalityCohort,
 	isCompletePassedBenchmarkPlan,
 	summarizeUploadPerformance,
 } from "./benchmark-summary.mjs";
@@ -157,11 +159,30 @@ const resolveVariantSpecs = async (variantSpecs) => {
 };
 
 const summarizeUploadMatrix = (variantSummaries) => {
-	return variantSummaries.map((summary) => {
+	return variantSummaries.flatMap((summary) => {
 		const adaptive = summary.summary.find((entry) => entry.mode === "adaptive");
-		const fixed1 = summary.summary.find((entry) => entry.mode === "fixed1");
-		return {
+		const fixed1Entries = summary.summary.filter(
+			(entry) => entry.mode === "fixed1",
+		);
+		const controlledFixed1Entries = fixed1Entries.filter(
+			(entry) => entry.readerLocalChunkTarget != null,
+		);
+		const cohorts =
+			controlledFixed1Entries.length > 0
+				? controlledFixed1Entries
+				: [fixed1Entries[0]];
+		return cohorts.map((fixed1) => ({
 			variant: summary.variant,
+			readerLocalChunkTarget: fixed1?.readerLocalChunkTarget ?? null,
+			readerLocalChunkMaxOvershoot:
+				fixed1?.readerLocalChunkMaxOvershoot ?? null,
+			readerLocalChunkBlockCount: fixed1?.readerLocalChunkBlockCount ?? null,
+			readerLocalChunkIndexRowCount:
+				fixed1?.readerLocalChunkIndexRowCount ?? null,
+			readerLocalityCohortKey: fixed1?.readerLocalityCohortKey ?? null,
+			cohortRuns: fixed1?.runs ?? null,
+			cohortPassed: fixed1?.passed ?? null,
+			cohortFailed: fixed1?.failed ?? null,
 			downloadSink:
 				summary.comparison?.downloadSink ??
 				adaptive?.downloadSink ??
@@ -178,7 +199,8 @@ const summarizeUploadMatrix = (variantSummaries) => {
 				fixed1?.primaryDownloadAuthoritative ??
 				null,
 			adaptiveAvgMs: summary.comparison?.adaptiveAvgMs ?? null,
-			fixed1AvgMs: summary.comparison?.fixed1AvgMs ?? null,
+			fixed1AvgMs:
+				summary.comparison?.fixed1AvgMs ?? fixed1?.uploadDurationMsAvg ?? null,
 			adaptiveVsFixed1Pct: summary.comparison?.adaptiveVsFixed1Pct ?? null,
 			adaptiveWriterReadyMsAvg: adaptive?.timeToWriterReadyMsAvg ?? null,
 			fixed1WriterReadyMsAvg: fixed1?.timeToWriterReadyMsAvg ?? null,
@@ -198,8 +220,10 @@ const summarizeUploadMatrix = (variantSummaries) => {
 				summary.comparison?.libraryStreamWallDeltaMs ?? null,
 			adaptiveVsFixed1LibraryStreamWallPct:
 				summary.comparison?.adaptiveVsFixed1LibraryStreamWallPct ?? null,
-			adaptiveStatus: adaptive?.failed === 0 ? "passed" : "failed",
-			fixed1Status: fixed1?.failed === 0 ? "passed" : "failed",
+			adaptiveStatus:
+				adaptive == null ? null : adaptive.failed === 0 ? "passed" : "failed",
+			fixed1Status:
+				fixed1 == null ? null : fixed1.failed === 0 ? "passed" : "failed",
 			adaptiveErrorCount: adaptive?.errorCount ?? null,
 			fixed1ErrorCount: fixed1?.errorCount ?? null,
 			adaptiveIncompleteErrorCollections:
@@ -208,7 +232,7 @@ const summarizeUploadMatrix = (variantSummaries) => {
 				fixed1?.incompleteErrorCollections ?? null,
 			adaptiveRequestFailureCount: adaptive?.requestFailureCount ?? null,
 			fixed1RequestFailureCount: fixed1?.requestFailureCount ?? null,
-		};
+		}));
 	});
 };
 
@@ -283,15 +307,24 @@ const average = (values) =>
 			);
 
 const summarizeInvocationResults = (results, scenario) => {
-	const grouped = new Map();
-	for (const result of results) {
-		const items = grouped.get(result.mode) ?? [];
-		items.push(result);
-		grouped.set(result.mode, items);
-	}
-	return [...grouped.entries()].map(([mode, items]) => {
+	const groups =
+		scenario === "seeder-probe"
+			? (() => {
+					const grouped = new Map();
+					for (const result of results) {
+						const items = grouped.get(result.mode) ?? [];
+						items.push(result);
+						grouped.set(result.mode, items);
+					}
+					return [...grouped.entries()].map(([mode, items]) => ({
+						dimensions: { mode },
+						results: items,
+					}));
+				})()
+			: groupUploadResultsByLocalityCohort(results);
+	return groups.map(({ dimensions, results: items }) => {
 		const base = {
-			mode,
+			...dimensions,
 			runs: items.length,
 			passed: items.filter((item) => item.status === "passed").length,
 			failed: items.filter((item) => item.status !== "passed").length,
@@ -415,6 +448,8 @@ const runVariantBenchmark = async ({
 	sampleMs,
 	sampleCount,
 	targetSeeders,
+	readerLocalChunkTarget,
+	readerLocalChunkMaxOvershoot,
 	protocol,
 	fixtureSeed,
 	enableVisibilityProbe,
@@ -485,6 +520,15 @@ const runVariantBenchmark = async ({
 		...(sampleCount != null ? ["--sample-count", String(sampleCount)] : []),
 		...(targetSeeders != null
 			? ["--target-seeders", String(targetSeeders)]
+			: []),
+		...(readerLocalChunkTarget != null
+			? ["--reader-local-chunk-target", String(readerLocalChunkTarget)]
+			: []),
+		...(readerLocalChunkMaxOvershoot != null
+			? [
+					"--reader-local-chunk-max-overshoot",
+					String(readerLocalChunkMaxOvershoot),
+				]
 			: []),
 		...(protocol ? ["--protocol", protocol] : []),
 		...(fixtureSeed ? ["--fixture-seed", fixtureSeed] : []),
@@ -608,6 +652,8 @@ const main = async () => {
 	const sampleMs = args["sample-ms"];
 	const sampleCount = args["sample-count"];
 	const targetSeeders = args["target-seeders"];
+	const readerLocalChunkTarget = args["reader-local-chunk-target"];
+	const readerLocalChunkMaxOvershoot = args["reader-local-chunk-max-overshoot"];
 	const { protocol } = previewOptions;
 	const fixtureSeed = args["fixture-seed"];
 	const enableVisibilityProbe = Boolean(args["enable-visibility-probe"]);
@@ -632,6 +678,50 @@ const main = async () => {
 	) {
 		throw new Error(
 			`Unsupported --mode "${mode}". Expected adaptive, fixed1, observer, or both.`,
+		);
+	}
+	if (
+		readerLocalChunkTarget != null &&
+		(scenario !== "upload" || modes.length !== 1 || modes[0] !== "fixed1")
+	) {
+		throw new Error(
+			"--reader-local-chunk-target requires --scenario upload --mode fixed1",
+		);
+	}
+	if (
+		readerLocalChunkTarget != null &&
+		(!Number.isSafeInteger(Number(readerLocalChunkTarget)) ||
+			Number(readerLocalChunkTarget) < 0)
+	) {
+		throw new Error(
+			"--reader-local-chunk-target must be a non-negative safe integer",
+		);
+	}
+	if (
+		(readerLocalChunkTarget == null) !==
+		(readerLocalChunkMaxOvershoot == null)
+	) {
+		throw new Error(
+			"--reader-local-chunk-target and --reader-local-chunk-max-overshoot must be provided together",
+		);
+	}
+	if (
+		readerLocalChunkMaxOvershoot != null &&
+		(!Number.isSafeInteger(Number(readerLocalChunkMaxOvershoot)) ||
+			Number(readerLocalChunkMaxOvershoot) < 0 ||
+			Number(readerLocalChunkMaxOvershoot) > MAX_READER_LOCAL_CHUNK_OVERSHOOT)
+	) {
+		throw new Error(
+			`--reader-local-chunk-max-overshoot must be a non-negative safe integer no greater than ${MAX_READER_LOCAL_CHUNK_OVERSHOOT}`,
+		);
+	}
+	if (
+		readerLocalChunkTarget != null &&
+		minReadySeeders != null &&
+		Number(minReadySeeders) !== 1
+	) {
+		throw new Error(
+			"--reader-local-chunk-target requires --min-ready-seeders 1 because the reader starts as an observer",
 		);
 	}
 	if (!["upload", "seeder-probe"].includes(scenario)) {
@@ -764,6 +854,8 @@ const main = async () => {
 				sampleMs,
 				sampleCount,
 				targetSeeders,
+				readerLocalChunkTarget,
+				readerLocalChunkMaxOvershoot,
 				protocol,
 				fixtureSeed,
 				enableVisibilityProbe,
@@ -809,6 +901,10 @@ const main = async () => {
 				sampleMs: optionalNumber(sampleMs),
 				sampleCount: optionalNumber(sampleCount),
 				targetSeeders: optionalNumber(targetSeeders),
+				readerLocalChunkTarget: optionalNumber(readerLocalChunkTarget),
+				readerLocalChunkMaxOvershoot: optionalNumber(
+					readerLocalChunkMaxOvershoot,
+				),
 				baseUrl: null,
 				protocol,
 				viteMode: null,
@@ -981,6 +1077,18 @@ const main = async () => {
 		invocationRecords.push({
 			...plan,
 			status: result.status,
+			readerLocalChunkTarget:
+				result.readerLocalChunkTarget ??
+				result.invocation?.readerLocalChunkTarget ??
+				null,
+			readerLocalChunkMaxOvershoot:
+				result.readerLocalChunkMaxOvershoot ??
+				result.invocation?.readerLocalChunkMaxOvershoot ??
+				null,
+			readerLocalChunkBlockCount: result.readerLocalChunkBlockCount ?? null,
+			readerLocalChunkIndexRowCount:
+				result.readerLocalChunkIndexRowCount ?? null,
+			readerLocalityCohortKey: result.readerLocalityCohortKey ?? null,
 			runNonce: result.runNonce,
 			resultFile: result.resultFile ?? null,
 			subRunSummaryFile: summaryFile,
@@ -1014,6 +1122,7 @@ const main = async () => {
 			results,
 			variantPlanned,
 		);
+		const summary = summarizeInvocationResults(results, scenario);
 		return {
 			variant: variantSpec.name,
 			variantRef: prepared.variantRef,
@@ -1024,7 +1133,10 @@ const main = async () => {
 			examplesProvenance: benchmarkExamplesProvenance,
 			results,
 			outcomeCounts: variantOutcomeCounts,
-			summary: summarizeInvocationResults(results, scenario),
+			readerLocalityCohorts: summary
+				.map((row) => row.readerLocalityCohortKey)
+				.filter((value) => typeof value === "string"),
+			summary,
 			comparison:
 				scenario === "upload"
 					? compareUploadPerformanceModesForCompletePlan(
@@ -1048,6 +1160,16 @@ const main = async () => {
 		variants: variantSpecs,
 		network,
 		fileMb,
+		readerLocalChunkTarget: optionalNumber(readerLocalChunkTarget) ?? null,
+		readerLocalChunkMaxOvershoot:
+			optionalNumber(readerLocalChunkMaxOvershoot) ?? null,
+		readerLocalityCohorts: [
+			...new Set(
+				allResults
+					.map((result) => result.readerLocalityCohortKey)
+					.filter((value) => typeof value === "string"),
+			),
+		],
 		runs,
 		mode,
 		modes,

--- a/scripts/file-share/run-file-share-benchmark.mjs
+++ b/scripts/file-share/run-file-share-benchmark.mjs
@@ -4,7 +4,9 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
+	MAX_READER_LOCAL_CHUNK_OVERSHOOT,
 	assertBenchmarkFileSize,
 	assertCoreBenchmarkUsesLocalApp,
 	assertInvocationUnchanged,
@@ -31,6 +33,7 @@ import {
 } from "./benchmark-provenance.mjs";
 import {
 	compareUploadPerformanceModesForCompletePlan,
+	groupUploadResultsByLocalityCohort,
 	isCompletePassedBenchmarkPlan,
 	summarizeUploadPerformance,
 	uploadTimingTableColumns,
@@ -104,6 +107,12 @@ const SCENARIOS = {
 };
 const DROP_HOOK_MARKER = "/* peerbit-benchmark-hook */";
 const DROP_UPDATE_LIST_MARKER = "/* peerbit-benchmark-update-list */";
+const DROP_LOCALITY_HOOK_MARKER =
+	"/* peerbit-benchmark-locality-prefix-preload */";
+const DROP_LOCALITY_TOPOLOGY_MARKER =
+	"/* peerbit-benchmark-locality-replicator-hashes */";
+const DROP_LOCALITY_INDEXED_SEARCH_MARKER =
+	"/* peerbit-benchmark-locality-indexed-search */";
 const getScenarioConfig = (scenario) => {
 	const config = SCENARIOS[scenario];
 	if (!config) {
@@ -146,7 +155,10 @@ const maybeCopyFrontendCerts = async ({
 	}
 };
 
-const instrumentFileShareFrontend = async (frontendRoot) => {
+export const instrumentFileShareFrontend = async (
+	frontendRoot,
+	{ requireLocalityHook = false } = {},
+) => {
 	const dropPath = path.join(frontendRoot, "src", "Drop.tsx");
 	let contents = await fsp.readFile(dropPath, "utf8");
 	const hasExistingBenchmarkHook =
@@ -157,9 +169,19 @@ const instrumentFileShareFrontend = async (frontendRoot) => {
 		contents.includes("__peerbitFileShareBenchmarkStats") &&
 		contents.includes("updateListStats") &&
 		contents.includes("updateListCalls.push(updateListStats)");
+	if (requireLocalityHook && !hasExistingBenchmarkHook) {
+		throw new Error(
+			`Controlled-locality benchmarks require the modern rich test-hook contract in ${dropPath}`,
+		);
+	}
 	if (
 		(contents.includes(DROP_HOOK_MARKER) || hasExistingBenchmarkHook) &&
-		(contents.includes(DROP_UPDATE_LIST_MARKER) || hasExistingUpdateListStats)
+		(contents.includes(DROP_UPDATE_LIST_MARKER) ||
+			hasExistingUpdateListStats) &&
+		(!requireLocalityHook ||
+			(contents.includes(DROP_LOCALITY_HOOK_MARKER) &&
+				contents.includes(DROP_LOCALITY_TOPOLOGY_MARKER) &&
+				contents.includes(DROP_LOCALITY_INDEXED_SEARCH_MARKER)))
 	) {
 		return;
 	}
@@ -217,7 +239,7 @@ const instrumentFileShareFrontend = async (frontendRoot) => {
     }, [files.program?.address, files.program?.closed]);
 
 `;
-	if (!contents.includes(DROP_HOOK_MARKER)) {
+	if (!contents.includes(DROP_HOOK_MARKER) && !hasExistingBenchmarkHook) {
 		if (!contents.includes(anchor)) {
 			throw new Error(`Could not find benchmark hook anchor in ${dropPath}`);
 		}
@@ -244,7 +266,10 @@ const instrumentFileShareFrontend = async (frontendRoot) => {
         // TODO don't reload the whole list, just add the new elements..
         try {
 `;
-	if (!contents.includes(DROP_UPDATE_LIST_MARKER)) {
+	if (
+		!contents.includes(DROP_UPDATE_LIST_MARKER) &&
+		!hasExistingUpdateListStats
+	) {
 		if (!contents.includes(updateListAnchor)) {
 			throw new Error(`Could not find updateList anchor in ${dropPath}`);
 		}
@@ -302,6 +327,259 @@ const instrumentFileShareFrontend = async (frontendRoot) => {
             forceUpdate();
 `,
 	);
+	if (
+		requireLocalityHook &&
+		contents.includes(DROP_LOCALITY_HOOK_MARKER) &&
+		!contents.includes(DROP_LOCALITY_INDEXED_SEARCH_MARKER)
+	) {
+		const searchImportAnchor =
+			'import { IsNull, SearchRequest } from "@peerbit/document";';
+		const indexedSearchImport =
+			'import { IsNull, SearchRequest, SearchRequestIndexed } from "@peerbit/document";';
+		if (!contents.includes(indexedSearchImport)) {
+			if (!contents.includes(searchImportAnchor)) {
+				throw new Error(
+					`File-share benchmark locality migration requires the indexed-search import anchor in ${dropPath}`,
+				);
+			}
+			contents = contents.replace(searchImportAnchor, indexedSearchImport);
+		}
+		const legacySearchAnchor = "new SearchRequest({ fetch: 0xffffffff }),";
+		const indexedSearchAnchor =
+			"new SearchRequestIndexed({ fetch: 0xffffffff }),";
+		if (contents.includes(legacySearchAnchor)) {
+			contents = contents.replace(legacySearchAnchor, indexedSearchAnchor);
+		}
+		if (!contents.includes(indexedSearchAnchor)) {
+			throw new Error(
+				`File-share benchmark locality migration requires the exact indexed-search query in ${dropPath}`,
+			);
+		}
+		contents = contents.replace(
+			indexedSearchAnchor,
+			`${DROP_LOCALITY_INDEXED_SEARCH_MARKER}\n                    ${indexedSearchAnchor}`,
+		);
+	}
+	if (
+		requireLocalityHook &&
+		!contents.includes(DROP_LOCALITY_TOPOLOGY_MARKER)
+	) {
+		const topologyAnchor = `                    selfInReplicatorSet:
+                        peerHash && replicatorHashes
+                            ? replicatorHashes.includes(peerHash)
+                            : null,`;
+		if (!contents.includes(topologyAnchor)) {
+			throw new Error(
+				`File-share benchmark locality control requires the exact-replicator topology anchor in ${dropPath}`,
+			);
+		}
+		contents = contents.replace(
+			topologyAnchor,
+			`                    ${DROP_LOCALITY_TOPOLOGY_MARKER}
+                    replicatorHashes: replicatorHashes
+                        ? [...replicatorHashes].sort((left, right) =>
+                              left.localeCompare(right)
+                          )
+                        : null,
+${topologyAnchor}`,
+		);
+	}
+	if (requireLocalityHook && !contents.includes(DROP_LOCALITY_HOOK_MARKER)) {
+		const searchImportAnchor =
+			'import { IsNull, SearchRequest } from "@peerbit/document";';
+		if (!contents.includes(searchImportAnchor)) {
+			throw new Error(
+				`File-share benchmark locality control requires the indexed-search import anchor in ${dropPath}`,
+			);
+		}
+		contents = contents.replace(
+			searchImportAnchor,
+			'import { IsNull, SearchRequest, SearchRequestIndexed } from "@peerbit/document";',
+		);
+		const typeAnchor =
+			"                getLightweightSnapshot: () => Record<string, unknown>;";
+		const implementationAnchor = "            getLightweightSnapshot: () => ({";
+		if (
+			!contents.includes(typeAnchor) ||
+			!contents.includes(implementationAnchor)
+		) {
+			throw new Error(
+				`File-share benchmark locality control requires the rich test-hook contract in ${dropPath}`,
+			);
+		}
+		contents = contents.replace(
+			typeAnchor,
+			`${typeAnchor}\n                preloadLocalChunkPrefix: (fileName: string, target: number, timeoutMs: number) => Promise<Record<string, unknown>>;\n                getLocalChunkPrefixObservation: (fileName: string) => Promise<Record<string, unknown>>;`,
+		);
+		contents = contents.replace(
+			implementationAnchor,
+			`            preloadLocalChunkPrefix: async (fileName, target, timeoutMs) => {
+                ${DROP_LOCALITY_HOOK_MARKER}
+                if (!program || program.closed) {
+                    throw new Error("Program is not ready");
+                }
+                const file = list.find((candidate) => candidate.name === fileName);
+                if (!file) {
+                    throw new Error("Locality preload file is not listed");
+                }
+                if (!isLargeFileLike(file)) {
+                    throw new Error("Locality control target is not a large file");
+                }
+                if (
+                    !Number.isSafeInteger(target) ||
+                    target < 0 ||
+                    target >= file.chunkCount
+                ) {
+                    throw new Error(
+                        "Locality preload target must be a non-negative partial chunk prefix"
+                    );
+                }
+                program.persistChunkReads = true;
+                const startedAt = Date.now();
+                const transferId =
+                    target > 0
+                        ? "benchmark-locality-preload-" + startedAt + "-" + target
+                        : null;
+                let yieldedChunkCount = 0;
+                let yieldedByteCount = 0;
+                if (transferId) {
+                    const iterator = file
+                        .streamFile(program, { timeout: timeoutMs, transferId })
+                        [Symbol.asyncIterator]();
+                    try {
+                        while (yieldedChunkCount < target) {
+                            const next = await iterator.next();
+                            if (next.done) {
+                                throw new Error(
+                                    "Locality preload stream ended before the requested prefix"
+                                );
+                            }
+                            yieldedChunkCount += 1;
+                            yieldedByteCount += next.value.byteLength;
+                        }
+                    } finally {
+                        await iterator.return?.();
+                    }
+                }
+                return {
+                    startedAt,
+                    finishedAt: Date.now(),
+                    fileId: file.id,
+                    transferId,
+                    yieldedChunkCount,
+                    yieldedByteCount,
+                    persistChunkReads: program.persistChunkReads,
+                    activeTransfersAfterClose: program.getActiveTransfers(),
+                    downloadSchedulerAfterClose:
+                        program.getTransferSchedulerDiagnostics().download,
+                    readDiagnostics: transferId
+                        ? program.getReadDiagnostics(transferId) ?? null
+                        : null,
+                };
+            },
+            getLocalChunkPrefixObservation: async (fileName) => {
+                const capturedAt = Date.now();
+                if (!program || program.closed) {
+                    throw new Error("Program is not ready");
+                }
+                const file = list.find((candidate) => candidate.name === fileName);
+                if (!file) {
+                    return {
+                        capturedAt,
+                        fileId: null,
+                        chunkCount: null,
+                        indexRowCount: null,
+                        indexedChunkIndices: null,
+                        blockCount: null,
+                        blockChunkIndices: null,
+                    };
+                }
+                if (!isLargeFileLike(file)) {
+                    throw new Error("Locality control target is not a large file");
+                }
+				const local = await program.files.index.search(
+					${DROP_LOCALITY_INDEXED_SEARCH_MARKER}
+					new SearchRequestIndexed({ fetch: 0xffffffff }),
+                    { local: true, remote: false, resolve: false } as any
+                );
+                const indexedChunkIndices = Array.from(
+                    new Set<number>(
+                        local
+                            .filter((candidate) => candidate.parentId === file.id)
+                            .map((candidate) => {
+                                const prefix = file.name + "/";
+                                if (
+                                    typeof candidate.name !== "string" ||
+                                    !candidate.name.startsWith(prefix)
+                                ) {
+                                    throw new Error(
+                                        "Local chunk metadata has an invalid name"
+                                    );
+                                }
+                                const suffix = candidate.name.slice(
+                                    prefix.length
+                                );
+                                const index = Number(suffix);
+                                if (
+                                    !/^\\d+$/.test(suffix) ||
+                                    !Number.isSafeInteger(index) ||
+                                    index < 0 ||
+                                    index >= file.chunkCount
+                                ) {
+                                    throw new Error(
+                                        "Local chunk metadata has an invalid index suffix"
+                                    );
+                                }
+                                return index;
+                            })
+                    )
+                ).sort((left, right) => left - right);
+                const candidateHeads = (
+                    file as { chunkEntryHeads?: unknown }
+                ).chunkEntryHeads;
+                const heads =
+                    Array.isArray(candidateHeads) &&
+                    candidateHeads.length === file.chunkCount &&
+                    candidateHeads.every((head) => typeof head === "string")
+                        ? (candidateHeads as string[])
+                        : null;
+                const blockPresence = heads
+                    ? typeof program.files.log.log.blocks.hasMany === "function"
+                        ? await program.files.log.log.blocks.hasMany(heads)
+                        : await Promise.all(
+                              heads.map((head) =>
+                                  program.files.log.log.blocks.has(head)
+                              )
+                          )
+                    : null;
+                const blockChunkIndices = blockPresence
+                    ? blockPresence.flatMap((present, index) =>
+                          present ? [index] : []
+                      )
+                    : null;
+                const indexRowCount = await program.countLocalChunks(file);
+                if (indexRowCount !== indexedChunkIndices.length) {
+                    throw new Error(
+                        "Local indexed chunk count disagrees with the exact index set"
+                    );
+                }
+                return {
+                    capturedAt,
+                    fileId: file.id,
+                    chunkCount: file.chunkCount,
+                    indexRowCount,
+                    indexedChunkIndices,
+                    blockCount: blockChunkIndices?.length ?? null,
+                    blockChunkIndices,
+                    persistChunkReads: program.persistChunkReads,
+                    activeTransfers: program.getActiveTransfers(),
+                    downloadScheduler:
+                        program.getTransferSchedulerDiagnostics().download,
+                };
+            },
+${implementationAnchor}`,
+		);
+	}
 	await fsp.writeFile(dropPath, contents);
 };
 
@@ -332,54 +610,50 @@ const average = (values) =>
 		: null;
 
 const summarizeUploadResults = (results) => {
-	const grouped = new Map();
-	for (const result of results) {
-		const arr = grouped.get(result.mode) ?? [];
-		arr.push(result);
-		grouped.set(result.mode, arr);
-	}
-	return [...grouped.entries()].map(([mode, items]) => ({
-		mode,
-		runs: items.length,
-		passed: items.filter((item) => item.status === "passed").length,
-		failed: items.filter((item) => item.status !== "passed").length,
-		...summarizeUploadPerformance(items),
-		uploadSettledMsAvg: average(
-			items
-				.filter((item) => item.status === "passed")
-				.map((item) => item.phaseDurationsMs?.timeToUploadSettled)
-				.filter((value) => typeof value === "number"),
-		),
-		writerListingLagMsAvg: average(
-			items
-				.filter((item) => item.status === "passed")
-				.map((item) => item.phaseDurationsMs?.writerListingLag)
-				.filter((value) => typeof value === "number"),
-		),
-		readerListingLagMsAvg: average(
-			items
-				.filter((item) => item.status === "passed")
-				.map((item) => item.phaseDurationsMs?.readerListingLag)
-				.filter((value) => typeof value === "number"),
-		),
-		postUploadMonitorDurationMsAvg: average(
-			items
-				.map((item) => item.postUploadMonitorDurationMs)
-				.filter((value) => typeof value === "number"),
-		),
-		errorCount: items.reduce(
-			(sum, item) => sum + (Number(item.errorCount) || 0),
-			0,
-		),
-		incompleteErrorCollections: items.filter(
-			(item) => item.errorCollectionComplete !== true,
-		).length,
-		requestFailureCount: items.reduce(
-			(sum, item) => sum + (Number(item.requestFailureCount) || 0),
-			0,
-		),
-		seederDrops: items.filter((item) => item.droppedSeeders).length,
-	}));
+	return groupUploadResultsByLocalityCohort(results).map(
+		({ dimensions, results: items }) => ({
+			...dimensions,
+			runs: items.length,
+			passed: items.filter((item) => item.status === "passed").length,
+			failed: items.filter((item) => item.status !== "passed").length,
+			...summarizeUploadPerformance(items),
+			uploadSettledMsAvg: average(
+				items
+					.filter((item) => item.status === "passed")
+					.map((item) => item.phaseDurationsMs?.timeToUploadSettled)
+					.filter((value) => typeof value === "number"),
+			),
+			writerListingLagMsAvg: average(
+				items
+					.filter((item) => item.status === "passed")
+					.map((item) => item.phaseDurationsMs?.writerListingLag)
+					.filter((value) => typeof value === "number"),
+			),
+			readerListingLagMsAvg: average(
+				items
+					.filter((item) => item.status === "passed")
+					.map((item) => item.phaseDurationsMs?.readerListingLag)
+					.filter((value) => typeof value === "number"),
+			),
+			postUploadMonitorDurationMsAvg: average(
+				items
+					.map((item) => item.postUploadMonitorDurationMs)
+					.filter((value) => typeof value === "number"),
+			),
+			errorCount: items.reduce(
+				(sum, item) => sum + (Number(item.errorCount) || 0),
+				0,
+			),
+			incompleteErrorCollections: items.filter(
+				(item) => item.errorCollectionComplete !== true,
+			).length,
+			requestFailureCount: items.reduce(
+				(sum, item) => sum + (Number(item.requestFailureCount) || 0),
+				0,
+			),
+			seederDrops: items.filter((item) => item.droppedSeeders).length,
+		}),
+	);
 };
 
 const summarizeSeederProbeResults = (results) => {
@@ -630,6 +904,14 @@ const main = async () => {
 		args["target-seeders"],
 		"--target-seeders",
 	);
+	const readerLocalChunkTarget = parseNonNegativeInteger(
+		args["reader-local-chunk-target"],
+		"--reader-local-chunk-target",
+	);
+	const readerLocalChunkMaxOvershoot = parseNonNegativeInteger(
+		args["reader-local-chunk-max-overshoot"],
+		"--reader-local-chunk-max-overshoot",
+	);
 	const examplesSource = args.source ?? defaultExamplesSource();
 	const fixtureSeed = args["fixture-seed"];
 	const resolvedFixtureSeed = fixtureSeed ?? "peerbit-file-share-benchmark-v1";
@@ -674,6 +956,39 @@ const main = async () => {
 	) {
 		throw new Error(
 			`Unsupported --mode "${requestedMode}". Expected adaptive, fixed1, observer, or both.`,
+		);
+	}
+	if (
+		readerLocalChunkTarget != null &&
+		(scenario !== "upload" || modes.length !== 1 || modes[0] !== "fixed1")
+	) {
+		throw new Error(
+			"--reader-local-chunk-target requires --scenario upload --mode fixed1",
+		);
+	}
+	if (
+		(readerLocalChunkTarget == null) !==
+		(readerLocalChunkMaxOvershoot == null)
+	) {
+		throw new Error(
+			"--reader-local-chunk-target and --reader-local-chunk-max-overshoot must be provided together",
+		);
+	}
+	if (
+		readerLocalChunkMaxOvershoot != null &&
+		readerLocalChunkMaxOvershoot > MAX_READER_LOCAL_CHUNK_OVERSHOOT
+	) {
+		throw new Error(
+			`--reader-local-chunk-max-overshoot must not exceed ${MAX_READER_LOCAL_CHUNK_OVERSHOOT}`,
+		);
+	}
+	if (
+		readerLocalChunkTarget != null &&
+		minReadySeeders != null &&
+		minReadySeeders !== 1
+	) {
+		throw new Error(
+			"--reader-local-chunk-target requires --min-ready-seeders 1 because the reader starts as an observer",
 		);
 	}
 	if (!["none", "link"].includes(integrationMode)) {
@@ -756,7 +1071,9 @@ const main = async () => {
 			sourceRoot: examplesSource,
 			templateRoot: args.template,
 		});
-		await instrumentFileShareFrontend(frontendRoot);
+		await instrumentFileShareFrontend(frontendRoot, {
+			requireLocalityHook: readerLocalChunkTarget != null,
+		});
 		await instrumentFileShareViteConfigs(frontendRoot);
 		const generatedSpec = path.join(
 			frontendRoot,
@@ -829,6 +1146,8 @@ const main = async () => {
 				sampleMs,
 				sampleCount,
 				targetSeeders,
+				readerLocalChunkTarget,
+				readerLocalChunkMaxOvershoot,
 				baseUrl,
 				protocol,
 				viteMode,
@@ -1022,6 +1341,18 @@ const main = async () => {
 			writerListingLagMs: result.phaseDurationsMs?.writerListingLag ?? null,
 			readerListingLagMs: result.phaseDurationsMs?.readerListingLag ?? null,
 			postUploadMonitorDurationMs: result.postUploadMonitorDurationMs ?? null,
+			readerLocalChunkTarget:
+				result.readerLocalChunkTarget ??
+				result.invocation?.readerLocalChunkTarget ??
+				null,
+			readerLocalChunkMaxOvershoot:
+				result.readerLocalChunkMaxOvershoot ??
+				result.invocation?.readerLocalChunkMaxOvershoot ??
+				null,
+			readerLocalChunkBlockCount: result.readerLocalChunkBlockCount ?? null,
+			readerLocalChunkIndexRowCount:
+				result.readerLocalChunkIndexRowCount ?? null,
+			readerLocalityCohortKey: result.readerLocalityCohortKey ?? null,
 			downloadSink: result.downloadSink ?? null,
 			downloadDurationMs: result.downloadDurationMs ?? null,
 			libraryStreamWallMs: result.libraryStreamWallMs ?? null,
@@ -1042,8 +1373,9 @@ const main = async () => {
 				"",
 		})),
 	);
+	const aggregateRows = summarizeResults(results, scenario);
 	console.log("\nSummary");
-	console.table(summarizeResults(results, scenario));
+	console.table(aggregateRows);
 	const outcomeCounts = countBenchmarkOutcomes(results, executionOrder.length);
 	const planPassed = isCompletePassedBenchmarkPlan(results, outcomeCounts);
 	const comparison =
@@ -1076,6 +1408,14 @@ const main = async () => {
 		localPackageNames: effectiveLocalPackageNames,
 		network,
 		fileMb,
+		readerLocalChunkTarget: readerLocalChunkTarget ?? null,
+		readerLocalChunkMaxOvershoot: readerLocalChunkMaxOvershoot ?? null,
+		readerLocalityCohorts:
+			scenario === "upload"
+				? aggregateRows
+						.map((row) => row.readerLocalityCohortKey)
+						.filter((value) => typeof value === "string")
+				: [],
 		runs,
 		modes,
 		executionOrder,
@@ -1083,7 +1423,7 @@ const main = async () => {
 		resultsDir,
 		aggregateSummaryFile,
 		results,
-		summary: summarizeResults(results, scenario),
+		summary: aggregateRows,
 		comparison,
 	};
 	await writeJsonAtomic(aggregateSummaryFile, summary);
@@ -1094,7 +1434,12 @@ const main = async () => {
 	}
 };
 
-main().catch((error) => {
-	console.error(error);
-	process.exit(1);
-});
+if (
+	process.argv[1] &&
+	path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+	main().catch((error) => {
+		console.error(error);
+		process.exit(1);
+	});
+}

--- a/scripts/file-share/run-file-share-benchmark.mjs
+++ b/scripts/file-share/run-file-share-benchmark.mjs
@@ -113,6 +113,137 @@ const DROP_LOCALITY_TOPOLOGY_MARKER =
 	"/* peerbit-benchmark-locality-replicator-hashes */";
 const DROP_LOCALITY_INDEXED_SEARCH_MARKER =
 	"/* peerbit-benchmark-locality-indexed-search */";
+const DROP_LOCALITY_PRELOAD_DEADLINE_MARKER =
+	"/* peerbit-benchmark-locality-preload-aggregate-deadline */";
+const localityPreloadHookImplementation = `            preloadLocalChunkPrefix: async (fileName, target, timeoutMs) => {
+                ${DROP_LOCALITY_HOOK_MARKER}
+                ${DROP_LOCALITY_PRELOAD_DEADLINE_MARKER}
+                if (!program || program.closed) {
+                    throw new Error("Program is not ready");
+                }
+                const file = list.find((candidate) => candidate.name === fileName);
+                if (!file) {
+                    throw new Error("Locality preload file is not listed");
+                }
+                if (!isLargeFileLike(file)) {
+                    throw new Error("Locality control target is not a large file");
+                }
+                if (
+                    !Number.isSafeInteger(target) ||
+                    target < 0 ||
+                    target >= file.chunkCount
+                ) {
+                    throw new Error(
+                        "Locality preload target must be a non-negative partial chunk prefix"
+                    );
+                }
+                if (
+                    !Number.isSafeInteger(timeoutMs) ||
+                    timeoutMs <= 0
+                ) {
+                    throw new Error(
+                        "Locality preload timeout must be a positive safe integer"
+                    );
+                }
+                program.persistChunkReads = true;
+                const startedAt = Date.now();
+                const transferId =
+                    target > 0
+                        ? "benchmark-locality-preload-" + startedAt + "-" + target
+                        : null;
+                const aggregateTimeoutMs = transferId ? timeoutMs : null;
+                const aggregateDeadlineAt = transferId
+                    ? startedAt + timeoutMs
+                    : null;
+                if (
+                    aggregateDeadlineAt !== null &&
+                    !Number.isSafeInteger(aggregateDeadlineAt)
+                ) {
+                    throw new Error("Locality preload deadline is not a safe integer");
+                }
+                let aggregateTimedOut = false;
+                let yieldedChunkCount = 0;
+                let yieldedByteCount = 0;
+                if (transferId) {
+                    const aggregateController = new AbortController();
+                    const aggregateTimeoutError = new Error(
+                        "Locality prefix preload exceeded its aggregate deadline"
+                    );
+                    let aggregateTimeoutHandle: number | undefined;
+                    let iterator: AsyncIterator<Uint8Array> | undefined;
+                    aggregateTimeoutHandle = window.setTimeout(() => {
+                        aggregateTimedOut = true;
+                        if (!aggregateController.signal.aborted) {
+                            aggregateController.abort(aggregateTimeoutError);
+                        }
+                    }, Math.max(0, aggregateDeadlineAt! - Date.now()));
+                    try {
+                        iterator = file
+                            .streamFile(program, {
+                                timeout: timeoutMs,
+                                transferId,
+                                signal: aggregateController.signal,
+                            })
+                            [Symbol.asyncIterator]();
+                        while (yieldedChunkCount < target) {
+                            const next = await iterator.next();
+                            if (
+                                Date.now() > aggregateDeadlineAt! &&
+                                !aggregateController.signal.aborted
+                            ) {
+                                aggregateTimedOut = true;
+                                aggregateController.abort(aggregateTimeoutError);
+                            }
+                            if (aggregateController.signal.aborted) {
+                                throw (
+                                    aggregateController.signal.reason ??
+                                    aggregateTimeoutError
+                                );
+                            }
+                            if (next.done) {
+                                throw new Error(
+                                    "Locality preload stream ended before the requested prefix"
+                                );
+                            }
+                            yieldedChunkCount += 1;
+                            yieldedByteCount += next.value.byteLength;
+                        }
+                    } finally {
+                        try {
+                            await iterator?.return?.();
+                        } finally {
+                            if (aggregateTimeoutHandle !== undefined) {
+                                window.clearTimeout(aggregateTimeoutHandle);
+                            }
+                        }
+                    }
+                    if (aggregateController.signal.aborted) {
+                        throw (
+                            aggregateController.signal.reason ??
+                            aggregateTimeoutError
+                        );
+                    }
+                }
+                const finishedAt = Date.now();
+                return {
+                    startedAt,
+                    finishedAt,
+                    fileId: file.id,
+                    transferId,
+                    aggregateTimeoutMs,
+                    aggregateDeadlineAt,
+                    aggregateTimedOut,
+                    yieldedChunkCount,
+                    yieldedByteCount,
+                    persistChunkReads: program.persistChunkReads,
+                    activeTransfersAfterClose: program.getActiveTransfers(),
+                    downloadSchedulerAfterClose:
+                        program.getTransferSchedulerDiagnostics().download,
+                    readDiagnostics: transferId
+                        ? program.getReadDiagnostics(transferId) ?? null
+                        : null,
+                };
+            },`;
 const getScenarioConfig = (scenario) => {
 	const config = SCENARIOS[scenario];
 	if (!config) {
@@ -180,6 +311,7 @@ export const instrumentFileShareFrontend = async (
 			hasExistingUpdateListStats) &&
 		(!requireLocalityHook ||
 			(contents.includes(DROP_LOCALITY_HOOK_MARKER) &&
+				contents.includes(DROP_LOCALITY_PRELOAD_DEADLINE_MARKER) &&
 				contents.includes(DROP_LOCALITY_TOPOLOGY_MARKER) &&
 				contents.includes(DROP_LOCALITY_INDEXED_SEARCH_MARKER)))
 	) {
@@ -330,6 +462,27 @@ export const instrumentFileShareFrontend = async (
 	if (
 		requireLocalityHook &&
 		contents.includes(DROP_LOCALITY_HOOK_MARKER) &&
+		!contents.includes(DROP_LOCALITY_PRELOAD_DEADLINE_MARKER)
+	) {
+		const preloadHookAnchor =
+			"            preloadLocalChunkPrefix: async (fileName, target, timeoutMs) => {";
+		const observationHookAnchor =
+			"            getLocalChunkPrefixObservation: async (fileName) => {";
+		const preloadHookStart = contents.indexOf(preloadHookAnchor);
+		const observationHookStart = contents.indexOf(
+			observationHookAnchor,
+			preloadHookStart + preloadHookAnchor.length,
+		);
+		if (preloadHookStart < 0 || observationHookStart < 0) {
+			throw new Error(
+				`File-share benchmark locality migration requires the exact preload hook boundaries in ${dropPath}`,
+			);
+		}
+		contents = `${contents.slice(0, preloadHookStart)}${localityPreloadHookImplementation}\n${contents.slice(observationHookStart)}`;
+	}
+	if (
+		requireLocalityHook &&
+		contents.includes(DROP_LOCALITY_HOOK_MARKER) &&
 		!contents.includes(DROP_LOCALITY_INDEXED_SEARCH_MARKER)
 	) {
 		const searchImportAnchor =
@@ -413,70 +566,7 @@ ${topologyAnchor}`,
 		);
 		contents = contents.replace(
 			implementationAnchor,
-			`            preloadLocalChunkPrefix: async (fileName, target, timeoutMs) => {
-                ${DROP_LOCALITY_HOOK_MARKER}
-                if (!program || program.closed) {
-                    throw new Error("Program is not ready");
-                }
-                const file = list.find((candidate) => candidate.name === fileName);
-                if (!file) {
-                    throw new Error("Locality preload file is not listed");
-                }
-                if (!isLargeFileLike(file)) {
-                    throw new Error("Locality control target is not a large file");
-                }
-                if (
-                    !Number.isSafeInteger(target) ||
-                    target < 0 ||
-                    target >= file.chunkCount
-                ) {
-                    throw new Error(
-                        "Locality preload target must be a non-negative partial chunk prefix"
-                    );
-                }
-                program.persistChunkReads = true;
-                const startedAt = Date.now();
-                const transferId =
-                    target > 0
-                        ? "benchmark-locality-preload-" + startedAt + "-" + target
-                        : null;
-                let yieldedChunkCount = 0;
-                let yieldedByteCount = 0;
-                if (transferId) {
-                    const iterator = file
-                        .streamFile(program, { timeout: timeoutMs, transferId })
-                        [Symbol.asyncIterator]();
-                    try {
-                        while (yieldedChunkCount < target) {
-                            const next = await iterator.next();
-                            if (next.done) {
-                                throw new Error(
-                                    "Locality preload stream ended before the requested prefix"
-                                );
-                            }
-                            yieldedChunkCount += 1;
-                            yieldedByteCount += next.value.byteLength;
-                        }
-                    } finally {
-                        await iterator.return?.();
-                    }
-                }
-                return {
-                    startedAt,
-                    finishedAt: Date.now(),
-                    fileId: file.id,
-                    transferId,
-                    yieldedChunkCount,
-                    yieldedByteCount,
-                    persistChunkReads: program.persistChunkReads,
-                    activeTransfersAfterClose: program.getActiveTransfers(),
-                    downloadSchedulerAfterClose:
-                        program.getTransferSchedulerDiagnostics().download,
-                    readDiagnostics: transferId
-                        ? program.getReadDiagnostics(transferId) ?? null
-                        : null,
-                };
-            },
+			`${localityPreloadHookImplementation}
             getLocalChunkPrefixObservation: async (fileName) => {
                 const capturedAt = Date.now();
                 if (!program || program.closed) {

--- a/scripts/file-share/template-contract.test.mjs
+++ b/scripts/file-share/template-contract.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import {
@@ -8,6 +9,7 @@ import {
 	REQUEST_FAILURE_COLLECTION_DEFINITION,
 } from "./benchmark-orchestration.mjs";
 import { repoRoot } from "./common.mjs";
+import { instrumentFileShareFrontend } from "./run-file-share-benchmark.mjs";
 
 const templates = [
 	"upload-benchmark.local.e2e.spec.ts",
@@ -26,6 +28,7 @@ for (const name of templates) {
 			"PW_BENCHMARK_RUN_NONCE",
 			"PW_BENCHMARK_INVOCATION",
 			"PW_BENCHMARK_PROVENANCE",
+			"PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT",
 			'process.env.PW_BENCH !== "1"',
 			'serverMode: "production-preview"',
 			"schema: RESULT_SCHEMA",
@@ -168,9 +171,51 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"download.sinkCompletedAt > downloadCompletionObservedAt",
 		"SINK_WRITE_QUANTIZATION_ALLOWANCE_MS_PER_CHUNK",
 		"SINK_SERVER_CLOCK_TOLERANCE_MS_PER_CHUNK",
+		"PW_READER_LOCAL_CHUNK_TARGET",
+		"PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT",
+		"LOCALITY_CONTROL_POLL_MS",
+		"seedReplicationRole",
+		"openWithSeededReplicationRole",
+		"readerInitialRoleEvidence",
+		"preloadLocalChunkPrefix",
+		"readLocalChunkPrefixObservation",
+		"getTopologySnapshot",
+		"topologyHasExactWriterSingleton",
+		"topologyHasExactWriterReaderPair",
+		"writerTopology.replicatorHashes[0] === writerPeerHash",
+		"readerTopology.replicatorHashes[0] === writerPeerHash",
+		"writerTopologyBeforeUpload",
+		"readerTopologyBeforeTimedRead",
+		"requestedYieldedChunkCount",
+		"stabilityObservations",
+		"preDownloadObservation",
+		"waitForTerminalReaderIdle",
+		"collectStableTerminalTopology",
+		"terminalIdleObservation",
+		"terminalTopologyObservations",
+		'terminalTopologyRole = "replicator"',
+		"readerJoinedReplicationDuringTimedRead = true",
+		'readerLocalityControl.status = "complete"',
+		"exact contiguous prefix",
+		"unexpectedSeederDrop",
 	]) {
 		assert.ok(contents.includes(required), `missing ${required}`);
 	}
+	assert.match(
+		contents,
+		/hooks\.preloadLocalChunkPrefix\(\s*expectedFileName,\s*requestedTarget,\s*timeout,\s*\)/,
+		"the nonzero locality preload must pass the requested download timeout in the hook's third argument",
+	);
+	assert.match(
+		contents,
+		/const preloadLocalChunkPrefix = async \(\s*page: Page,\s*fileName: string,\s*target: number,\s*timeoutMs: number,\s*\)/,
+		"the Playwright locality helper must keep page, file, target, and timeout in a fixed order",
+	);
+	assert.match(
+		contents,
+		/preloadLocalChunkPrefix\(\s*reader,\s*fileName,\s*READER_LOCAL_CHUNK_TARGET,\s*DOWNLOAD_TIMEOUT_MS,\s*\)/,
+		"the nonzero locality call site must pass the configured download timeout after its target",
+	);
 	assert.ok(
 		contents.includes(
 			"const MIN_READY_SEEDERS = Number(process.env.PW_MIN_READY_SEEDERS)",
@@ -206,6 +251,71 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		contents,
 		/uploadSettledAt = writerReady\.readyAt;[\s\S]*?const boundedReaderListedPromise =[\s\S]*?withDeadline\(\s*readerListedPromise,\s*readerReadyRemainingMs,[\s\S]*?if \(ENABLE_VISIBILITY_PROBE\)/,
 		"reader listing must arm its Node-side deadline before optional diagnostics",
+	);
+	assert.match(
+		contents,
+		/await seedReplicationRole\(reader, shareAddress, false\);[\s\S]*?readerLocalityControl\s*\? openWithSeededReplicationRole\(reader, shareUrl\)\s*: applyRole\(reader, shareUrl\)[\s\S]*?readInitialReaderRoleEvidence\(reader\)[\s\S]*?writerTopologyBeforeUpload[\s\S]*?uploadStartedAt = Date\.now\(\);[\s\S]*?setInputFiles/,
+		"the reader observer role must be seeded before navigation and proven before upload",
+	);
+	assert.match(
+		contents,
+		/const openWithSeededReplicationRole =[\s\S]*?page\.goto\(shareUrl,[\s\S]*?await waitForTestHooks\(page\);\s*};/,
+		"the controlled reader must not invoke the post-open role setter",
+	);
+	assert.ok(
+		contents.includes("/[/?#]/.test(shareAddress)"),
+		"the seeded role key must come from exactly one non-empty share-address segment",
+	);
+	assert.match(
+		contents,
+		/postMonitorFinishedAt = Date\.now\(\);[\s\S]*?beforePreloadObservation[\s\S]*?preloadLocalChunkPrefix\([\s\S]*?collectStableReaderLocality\(\)[\s\S]*?writerTopologyBeforeTimedRead[\s\S]*?stage = "download-to-selected-sink"/,
+		"preload closure, stable exact-prefix evidence, and topology must precede the timed read",
+	);
+	assert.match(
+		contents,
+		/if \(!integrityVerified\)[\s\S]*?integrityVerifiedAt = Date\.now\(\);[\s\S]*?waitForTerminalReaderIdle\(\)[\s\S]*?collectStableTerminalTopology\(\s*terminalTopologyStartedAt,\s*terminalTopologyDeadlineAt,\s*\)[\s\S]*?readerJoinedReplicationDuringTimedRead = true[\s\S]*?stage = "complete"/,
+		"terminal topology must be collected after integrity and transfer-idle, outside the measured download",
+	);
+	assert.ok(
+		!contents.includes("monitorAndFreezeReaderLocality"),
+		"controlled locality must not race a role switch against upload replication",
+	);
+	const standalone = await readFile(
+		path.join(
+			repoRoot,
+			"scripts",
+			"file-share",
+			"run-file-share-benchmark.mjs",
+		),
+		"utf8",
+	);
+	for (const required of [
+		"peerbit-benchmark-locality-prefix-preload",
+		"peerbit-benchmark-locality-replicator-hashes",
+		"peerbit-benchmark-locality-indexed-search",
+		"replicatorHashes: replicatorHashes",
+		"preloadLocalChunkPrefix",
+		"getLocalChunkPrefixObservation",
+		"await iterator.return?.()",
+		"SearchRequestIndexed",
+		"new SearchRequestIndexed({ fetch: 0xffffffff })",
+		"resolve: false",
+		"program.countLocalChunks(file)",
+		"requireLocalityHook: readerLocalChunkTarget != null",
+	]) {
+		assert.ok(
+			standalone.includes(required),
+			`standalone locality instrumentation missing ${required}`,
+		);
+	}
+	assert.equal(
+		[
+			...standalone.matchAll(
+				/benchmarkStats: testWindow\.__peerbitFileShareBenchmarkStats \?\? null,/g,
+			),
+		].length,
+		1,
+		"the fallback benchmark hook must emit exactly one benchmarkStats field",
 	);
 	const opfsReadback = await readFile(
 		path.join(
@@ -245,6 +355,50 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 	}
 });
 
+test("locality instrumentation migrates a reused legacy query idempotently", async (t) => {
+	const frontendRoot = await mkdtemp(
+		path.join(os.tmpdir(), "peerbit-locality-instrumentation-"),
+	);
+	t.after(async () => rm(frontendRoot, { recursive: true, force: true }));
+	const src = path.join(frontendRoot, "src");
+	await mkdir(src);
+	const dropPath = path.join(src, "Drop.tsx");
+	await writeFile(
+		dropPath,
+		`import { IsNull, SearchRequest } from "@peerbit/document";
+const __peerbitFileShareTestHooks = { setReplicationRole, getDiagnostics };
+const __peerbitFileShareBenchmarkStats = { updateListStats };
+updateListCalls.push(updateListStats);
+/* peerbit-benchmark-locality-prefix-preload */
+/* peerbit-benchmark-locality-replicator-hashes */
+const local = await program.files.index.search(
+    new SearchRequest({ fetch: 0xffffffff }),
+    { local: true, remote: false, resolve: false }
+);
+`,
+	);
+	await instrumentFileShareFrontend(frontendRoot, {
+		requireLocalityHook: true,
+	});
+	const migrated = await readFile(dropPath, "utf8");
+	assert.ok(
+		migrated.includes(
+			'import { IsNull, SearchRequest, SearchRequestIndexed } from "@peerbit/document";',
+		),
+	);
+	assert.ok(
+		migrated.includes("/* peerbit-benchmark-locality-indexed-search */"),
+	);
+	assert.ok(
+		migrated.includes("new SearchRequestIndexed({ fetch: 0xffffffff })"),
+	);
+	assert.ok(!migrated.includes("new SearchRequest({ fetch: 0xffffffff })"));
+	await instrumentFileShareFrontend(frontendRoot, {
+		requireLocalityHook: true,
+	});
+	assert.equal(await readFile(dropPath, "utf8"), migrated);
+});
+
 test("aggregate comparisons require every planned invocation to pass", async () => {
 	const standalone = await readFile(
 		path.join(
@@ -257,6 +411,8 @@ test("aggregate comparisons require every planned invocation to pass", async () 
 	);
 	for (const required of [
 		"compareUploadPerformanceModesForCompletePlan(results, outcomeCounts)",
+		"groupUploadResultsByLocalityCohort(results)",
+		"readerLocalityCohorts",
 		"if (comparison)",
 		'generatedPath: path.join("tests", "generated.promise-deadline.mjs")',
 		'generatedPath: path.join("tests", "generated.opfs-readback.mjs")',
@@ -281,6 +437,9 @@ test("aggregate comparisons require every planned invocation to pass", async () 
 	);
 	for (const required of [
 		"compareUploadPerformanceModesForCompletePlan(",
+		"groupUploadResultsByLocalityCohort(results)",
+		"readerLocalityCohortKey",
+		"readerLocalityCohorts",
 		"variantOutcomeCounts",
 		"const matrixPlanPassed = isCompletePassedBenchmarkPlan(",
 		"adaptiveComparison: matrixPlanPassed",

--- a/scripts/file-share/template-contract.test.mjs
+++ b/scripts/file-share/template-contract.test.mjs
@@ -139,6 +139,11 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"readerListedAt - uploadStartedAt",
 		"readyTimeoutMs: READY_TIMEOUT_MS",
 		"3 * READY_TIMEOUT_MS +",
+		"const LOCALITY_CONTROL_OUTER_TIMEOUT_BUDGET_MS =",
+		"READER_LOCAL_CHUNK_TARGET > 0",
+		"DOWNLOAD_TIMEOUT_MS + TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS",
+		"LOCALITY_CONTROL_OUTER_TIMEOUT_BUDGET_MS +",
+		"test.setTimeout(TEST_OUTER_TIMEOUT_MS)",
 		"POST_MONITOR_SCHEDULING_TOLERANCE_MS",
 		"TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS",
 		"Measured transfer duration exceeded",
@@ -178,6 +183,9 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"openWithSeededReplicationRole",
 		"readerInitialRoleEvidence",
 		"preloadLocalChunkPrefix",
+		"Reader locality preload did not settle within ${timeoutMs}ms plus scheduling tolerance",
+		"aggregateTimeoutMs !== DOWNLOAD_TIMEOUT_MS",
+		"aggregateTimedOut !== false",
 		"readLocalChunkPrefixObservation",
 		"getTopologySnapshot",
 		"topologyHasExactWriterSingleton",
@@ -201,6 +209,11 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 	]) {
 		assert.ok(contents.includes(required), `missing ${required}`);
 	}
+	assert.match(
+		contents,
+		/const LOCALITY_CONTROL_OUTER_TIMEOUT_BUDGET_MS =\s*READER_LOCAL_CHUNK_TARGET === null\s*\? 0\s*:\s*3 \* READY_TIMEOUT_MS \+\s*\(READER_LOCAL_CHUNK_TARGET > 0\s*\? DOWNLOAD_TIMEOUT_MS \+ TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS\s*: 0\);/,
+		"controlled locality must reserve three readiness phases and a nonzero-prefix aggregate preload deadline plus cleanup tolerance",
+	);
 	assert.match(
 		contents,
 		/hooks\.preloadLocalChunkPrefix\(\s*expectedFileName,\s*requestedTarget,\s*timeout,\s*\)/,
@@ -291,12 +304,20 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 	);
 	for (const required of [
 		"peerbit-benchmark-locality-prefix-preload",
+		"peerbit-benchmark-locality-preload-aggregate-deadline",
 		"peerbit-benchmark-locality-replicator-hashes",
 		"peerbit-benchmark-locality-indexed-search",
 		"replicatorHashes: replicatorHashes",
 		"preloadLocalChunkPrefix",
 		"getLocalChunkPrefixObservation",
-		"await iterator.return?.()",
+		"const localityPreloadHookImplementation =",
+		"const aggregateController = new AbortController()",
+		"signal: aggregateController.signal",
+		"aggregateController.abort(aggregateTimeoutError)",
+		"await iterator?.return?.()",
+		"window.clearTimeout(aggregateTimeoutHandle)",
+		"aggregateDeadlineAt",
+		"aggregateTimedOut",
 		"SearchRequestIndexed",
 		"new SearchRequestIndexed({ fetch: 0xffffffff })",
 		"resolve: false",
@@ -366,15 +387,46 @@ test("locality instrumentation migrates a reused legacy query idempotently", asy
 	await writeFile(
 		dropPath,
 		`import { IsNull, SearchRequest } from "@peerbit/document";
-const __peerbitFileShareTestHooks = { setReplicationRole, getDiagnostics };
+const __peerbitFileShareTestHooks = {
+    setReplicationRole,
+    getDiagnostics,
+            preloadLocalChunkPrefix: async (fileName, target, timeoutMs) => {
+                /* peerbit-benchmark-locality-prefix-preload */
+                const startedAt = Date.now();
+                const transferId = "legacy-locality-preload";
+                let yieldedChunkCount = 0;
+                let yieldedByteCount = 0;
+                const iterator = file
+                    .streamFile(program, { timeout: timeoutMs, transferId })
+                    [Symbol.asyncIterator]();
+                try {
+                    while (yieldedChunkCount < target) {
+                        const next = await iterator.next();
+                        yieldedChunkCount += 1;
+                        yieldedByteCount += next.value.byteLength;
+                    }
+                } finally {
+                    await iterator.return?.();
+                }
+                return {
+                    startedAt,
+                    finishedAt: Date.now(),
+                    transferId,
+                    yieldedChunkCount,
+                    yieldedByteCount,
+                };
+            },
+            getLocalChunkPrefixObservation: async (fileName) => {
+                const local = await program.files.index.search(
+                    new SearchRequest({ fetch: 0xffffffff }),
+                    { local: true, remote: false, resolve: false }
+                );
+                return { fileName, local };
+            },
+};
 const __peerbitFileShareBenchmarkStats = { updateListStats };
 updateListCalls.push(updateListStats);
-/* peerbit-benchmark-locality-prefix-preload */
 /* peerbit-benchmark-locality-replicator-hashes */
-const local = await program.files.index.search(
-    new SearchRequest({ fetch: 0xffffffff }),
-    { local: true, remote: false, resolve: false }
-);
 `,
 	);
 	await instrumentFileShareFrontend(frontendRoot, {
@@ -393,6 +445,37 @@ const local = await program.files.index.search(
 		migrated.includes("new SearchRequestIndexed({ fetch: 0xffffffff })"),
 	);
 	assert.ok(!migrated.includes("new SearchRequest({ fetch: 0xffffffff })"));
+	for (const required of [
+		"/* peerbit-benchmark-locality-preload-aggregate-deadline */",
+		"const aggregateController = new AbortController()",
+		"signal: aggregateController.signal",
+		"aggregateTimeoutMs",
+		"aggregateDeadlineAt",
+		"aggregateTimedOut",
+	]) {
+		assert.ok(migrated.includes(required), `missing migrated ${required}`);
+	}
+	assert.ok(
+		migrated.indexOf("await iterator?.return?.()") <
+			migrated.indexOf("window.clearTimeout(aggregateTimeoutHandle)"),
+		"the aggregate timeout must remain armed through iterator cleanup",
+	);
+	assert.equal(
+		[...migrated.matchAll(/preloadLocalChunkPrefix: async/g)].length,
+		1,
+	);
+	assert.equal(
+		[...migrated.matchAll(/getLocalChunkPrefixObservation: async/g)].length,
+		1,
+	);
+	assert.equal(
+		[
+			...migrated.matchAll(
+				/import \{ IsNull, SearchRequest, SearchRequestIndexed \} from "@peerbit\/document";/g,
+			),
+		].length,
+		1,
+	);
 	await instrumentFileShareFrontend(frontendRoot, {
 		requireLocalityHook: true,
 	});

--- a/scripts/file-share/templates/seeder-probe.e2e.spec.ts
+++ b/scripts/file-share/templates/seeder-probe.e2e.spec.ts
@@ -40,6 +40,13 @@ const parseJsonEnvironment = (name: string) => {
 };
 const PROVENANCE = parseJsonEnvironment("PW_BENCHMARK_PROVENANCE");
 const INVOCATION = parseJsonEnvironment("PW_BENCHMARK_INVOCATION");
+const READER_LOCAL_CHUNK_TARGET = process.env.PW_READER_LOCAL_CHUNK_TARGET
+	? Number(process.env.PW_READER_LOCAL_CHUNK_TARGET)
+	: null;
+const READER_LOCAL_CHUNK_MAX_OVERSHOOT = process.env
+	.PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT
+	? Number(process.env.PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT)
+	: null;
 
 if (!["local", "remote"].includes(NETWORK_MODE)) {
 	throw new Error(`Unsupported PW_NETWORK_MODE='${NETWORK_MODE}'`);
@@ -69,7 +76,7 @@ if (!Number.isSafeInteger(TARGET_SEEDERS) || TARGET_SEEDERS < 0) {
 if (
 	(INVOCATION.schema as Record<string, unknown> | undefined)?.id !==
 		"peerbit-file-share-benchmark-invocation" ||
-	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 2
+	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 3
 ) {
 	throw new Error("Unsupported PW_BENCHMARK_INVOCATION schema");
 }
@@ -81,6 +88,8 @@ const expectedInvocationValues: Record<string, unknown> = {
 	sampleMs: SAMPLE_MS,
 	sampleCount: SAMPLE_COUNT,
 	targetSeeders: TARGET_SEEDERS,
+	readerLocalChunkTarget: READER_LOCAL_CHUNK_TARGET,
+	readerLocalChunkMaxOvershoot: READER_LOCAL_CHUNK_MAX_OVERSHOOT,
 	baseUrl: process.env.PW_BASE_URL || null,
 	protocol: process.env.PW_PROTOCOL || null,
 	viteMode: process.env.PW_VITE_MODE || null,

--- a/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
+++ b/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
@@ -57,6 +57,26 @@ const TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS = Math.max(
 );
 const TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION =
 	"max(5000ms, pollMs + 1000ms) for browser actions and event-loop scheduling";
+// Controlled locality can spend a full download deadline preloading the prefix,
+// then one readiness deadline each stabilizing that prefix, waiting for the
+// completed transfer to become idle, and stabilizing terminal topology. The
+// measured download retains its separate DOWNLOAD_TIMEOUT_MS budget below.
+const LOCALITY_CONTROL_OUTER_TIMEOUT_BUDGET_MS =
+	READER_LOCAL_CHUNK_TARGET === null
+		? 0
+		: 3 * READY_TIMEOUT_MS +
+			(READER_LOCAL_CHUNK_TARGET > 0
+				? DOWNLOAD_TIMEOUT_MS + TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS
+				: 0);
+const TEST_OUTER_TIMEOUT_MS = Math.max(
+	20 * 60 * 1000,
+	3 * READY_TIMEOUT_MS +
+		UPLOAD_TIMEOUT_MS +
+		DOWNLOAD_TIMEOUT_MS +
+		LOCALITY_CONTROL_OUTER_TIMEOUT_BUDGET_MS +
+		POST_UPLOAD_MONITOR_MS +
+		5 * 60 * 1000,
+);
 const TIME_TO_WRITER_READY_DEFINITION =
 	"upload-input-set-to-writer-ready-manifest-listed";
 const TIME_TO_READER_READY_DEFINITION =
@@ -502,8 +522,8 @@ const preloadLocalChunkPrefix = async (
 	fileName: string,
 	target: number,
 	timeoutMs: number,
-) =>
-	await page.evaluate(
+) => {
+	const evaluation = page.evaluate(
 		async ({ expectedFileName, requestedTarget, timeout }) => {
 			const hooks = (window as any).__peerbitFileShareTestHooks;
 			if (!hooks?.preloadLocalChunkPrefix) {
@@ -519,6 +539,14 @@ const preloadLocalChunkPrefix = async (
 		},
 		{ expectedFileName: fileName, requestedTarget: target, timeout: timeoutMs },
 	);
+	return target > 0
+		? await withDeadline(
+				evaluation,
+				timeoutMs + TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS,
+				`Reader locality preload did not settle within ${timeoutMs}ms plus scheduling tolerance`,
+			)
+		: await evaluation;
+};
 
 const getTopologySnapshot = async (page: Page) =>
 	await page.evaluate(async () => {
@@ -726,16 +754,7 @@ test.describe("generated transfer-validity benchmark", () => {
 		browser,
 		baseURL,
 	}) => {
-		test.setTimeout(
-			Math.max(
-				20 * 60 * 1000,
-				3 * READY_TIMEOUT_MS +
-					UPLOAD_TIMEOUT_MS +
-					DOWNLOAD_TIMEOUT_MS +
-					POST_UPLOAD_MONITOR_MS +
-					5 * 60 * 1000,
-			),
-		);
+		test.setTimeout(TEST_OUTER_TIMEOUT_MS);
 		if (!baseURL) {
 			throw new Error("Missing baseURL");
 		}
@@ -1406,6 +1425,8 @@ test.describe("generated transfer-validity benchmark", () => {
 					| undefined;
 				const preloadReadDiagnostics =
 					preloadEvidence.readDiagnostics as Record<string, unknown> | null;
+				const preloadStartedAt = preloadEvidence.startedAt as number;
+				const preloadFinishedAt = preloadEvidence.finishedAt as number;
 				if (
 					preloadEvidence.fileId !== readerManifestEvidence.fileId ||
 					preloadEvidence.yieldedChunkCount !== READER_LOCAL_CHUNK_TARGET ||
@@ -1419,8 +1440,8 @@ test.describe("generated transfer-validity benchmark", () => {
 					preloadScheduler.queuedCount !== 0 ||
 					!Number.isSafeInteger(preloadEvidence.startedAt) ||
 					!Number.isSafeInteger(preloadEvidence.finishedAt) ||
-					(preloadEvidence.finishedAt as number) <
-						(preloadEvidence.startedAt as number)
+					preloadFinishedAt < preloadStartedAt ||
+					preloadEvidence.aggregateTimedOut !== false
 				) {
 					throw new Error(
 						"Reader locality preload did not close with clean transfer resources",
@@ -1429,11 +1450,18 @@ test.describe("generated transfer-validity benchmark", () => {
 				if (READER_LOCAL_CHUNK_TARGET === 0) {
 					if (
 						preloadEvidence.transferId !== null ||
-						preloadReadDiagnostics !== null
+						preloadReadDiagnostics !== null ||
+						preloadEvidence.aggregateTimeoutMs !== null ||
+						preloadEvidence.aggregateDeadlineAt !== null
 					) {
 						throw new Error("Zero-prefix preload unexpectedly opened a read");
 					}
 				} else if (
+					preloadEvidence.aggregateTimeoutMs !== DOWNLOAD_TIMEOUT_MS ||
+					preloadEvidence.aggregateDeadlineAt !==
+						preloadStartedAt + DOWNLOAD_TIMEOUT_MS ||
+					preloadFinishedAt - preloadStartedAt >
+						DOWNLOAD_TIMEOUT_MS + TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS ||
 					typeof preloadEvidence.transferId !== "string" ||
 					preloadEvidence.transferId.length === 0 ||
 					!preloadReadDiagnostics ||
@@ -1444,7 +1472,7 @@ test.describe("generated transfer-validity benchmark", () => {
 					preloadReadDiagnostics.failureMessage !== null
 				) {
 					throw new Error(
-						"Partial-prefix preload diagnostics do not prove a clean iterator close",
+						"Partial-prefix preload diagnostics do not prove a bounded clean iterator close",
 					);
 				}
 

--- a/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
+++ b/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
@@ -29,6 +29,15 @@ import {
 const FILE_SIZE_MB = Number(process.env.PW_FILE_MB || "100");
 const FILE_SIZE_BYTES = FILE_SIZE_MB * 1024 * 1024;
 const POLL_MS = Number(process.env.PW_POLL_MS || "1000");
+const READER_LOCAL_CHUNK_TARGET = process.env.PW_READER_LOCAL_CHUNK_TARGET
+	? Number(process.env.PW_READER_LOCAL_CHUNK_TARGET)
+	: null;
+const READER_LOCAL_CHUNK_MAX_OVERSHOOT = process.env
+	.PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT
+	? Number(process.env.PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT)
+	: null;
+const LOCALITY_CONTROL_POLL_MS = Math.min(POLL_MS, 100);
+const LOCALITY_CONTROL_STABLE_SAMPLE_COUNT = 3;
 const POST_UPLOAD_MONITOR_MS = Number(
 	process.env.PW_POST_UPLOAD_MONITOR_MS || "5000",
 );
@@ -116,6 +125,33 @@ if (!RUN_NONCE) {
 	throw new Error("Missing PW_BENCHMARK_RUN_NONCE");
 }
 if (
+	READER_LOCAL_CHUNK_TARGET !== null &&
+	(!Number.isSafeInteger(READER_LOCAL_CHUNK_TARGET) ||
+		READER_LOCAL_CHUNK_TARGET < 0)
+) {
+	throw new Error(
+		`Invalid PW_READER_LOCAL_CHUNK_TARGET='${process.env.PW_READER_LOCAL_CHUNK_TARGET}'`,
+	);
+}
+if (
+	(READER_LOCAL_CHUNK_TARGET === null) !==
+	(READER_LOCAL_CHUNK_MAX_OVERSHOOT === null)
+) {
+	throw new Error(
+		"PW_READER_LOCAL_CHUNK_TARGET and PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT must be provided together",
+	);
+}
+if (
+	READER_LOCAL_CHUNK_MAX_OVERSHOOT !== null &&
+	(!Number.isSafeInteger(READER_LOCAL_CHUNK_MAX_OVERSHOOT) ||
+		READER_LOCAL_CHUNK_MAX_OVERSHOOT < 0 ||
+		READER_LOCAL_CHUNK_MAX_OVERSHOOT > 8)
+) {
+	throw new Error(
+		`Invalid PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT='${process.env.PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT}'`,
+	);
+}
+if (
 	process.env.PW_MIN_READY_SEEDERS == null ||
 	!Number.isSafeInteger(MIN_READY_SEEDERS) ||
 	MIN_READY_SEEDERS < 0
@@ -139,6 +175,14 @@ if (process.env.PW_BENCH !== "1") {
 if (!["local", "remote"].includes(NETWORK_MODE)) {
 	throw new Error(`Unsupported PW_NETWORK_MODE='${NETWORK_MODE}'`);
 }
+if (
+	READER_LOCAL_CHUNK_TARGET !== null &&
+	(MODE !== "fixed1" || MIN_READY_SEEDERS !== 1)
+) {
+	throw new Error(
+		"PW_READER_LOCAL_CHUNK_TARGET requires fixed1 writer mode and exactly one ready seeder because the reader starts as an observer",
+	);
+}
 
 const expectedInvocationValues: Record<string, unknown> = {
 	scenario: "upload",
@@ -154,6 +198,8 @@ const expectedInvocationValues: Record<string, unknown> = {
 	pollMs: POLL_MS,
 	minReadySeeders: MIN_READY_SEEDERS,
 	readyTimeoutMs: READY_TIMEOUT_MS,
+	readerLocalChunkTarget: READER_LOCAL_CHUNK_TARGET,
+	readerLocalChunkMaxOvershoot: READER_LOCAL_CHUNK_MAX_OVERSHOOT,
 	baseUrl: process.env.PW_BASE_URL || null,
 	protocol: process.env.PW_PROTOCOL || null,
 	viteMode: process.env.PW_VITE_MODE || null,
@@ -166,7 +212,7 @@ const expectedInvocationValues: Record<string, unknown> = {
 if (
 	(INVOCATION.schema as Record<string, unknown> | undefined)?.id !==
 		"peerbit-file-share-benchmark-invocation" ||
-	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 2
+	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 3
 ) {
 	throw new Error("Unsupported PW_BENCHMARK_INVOCATION schema");
 }
@@ -297,6 +343,240 @@ const applyRole = async (page: Page, shareUrl: string) => {
 		requireRoleSetter: true,
 		role: getRole(),
 	});
+};
+
+const seedReplicationRole = async (
+	page: Page,
+	shareAddress: string,
+	role: unknown,
+) => {
+	await page.addInitScript(
+		({ address, roleOptions }) => {
+			window.localStorage.setItem(
+				`${address}-role`,
+				JSON.stringify(roleOptions),
+			);
+		},
+		{ address: shareAddress, roleOptions: role },
+	);
+};
+
+const openWithSeededReplicationRole = async (page: Page, shareUrl: string) => {
+	await page.goto(shareUrl, { waitUntil: "domcontentloaded" });
+	await waitForTestHooks(page);
+};
+
+type InitialReaderRoleEvidence = {
+	capturedAt: number;
+	programAddress: unknown;
+	persistChunkReads: unknown;
+	initialRole: unknown;
+	updateRoleCount: unknown;
+	lastAppliedRole: unknown;
+};
+
+const readInitialReaderRoleEvidence = async (
+	page: Page,
+): Promise<InitialReaderRoleEvidence> =>
+	page.evaluate(async () => {
+		const hooks = (window as any).__peerbitFileShareTestHooks;
+		if (!hooks?.getDiagnostics) {
+			throw new Error("Benchmark diagnostics hook is unavailable");
+		}
+		const diagnostics = await hooks.getDiagnostics();
+		return {
+			capturedAt: Date.now(),
+			programAddress: diagnostics?.programAddress,
+			persistChunkReads: diagnostics?.persistChunkReads,
+			initialRole: diagnostics?.timings?.initialRole,
+			updateRoleCount: diagnostics?.timings?.updateRoleCount,
+			lastAppliedRole: diagnostics?.timings?.lastAppliedRole,
+		};
+	});
+
+type LocalitySchedulerObservation = {
+	activeCount: number;
+	activeBytes: number;
+	queuedCount: number;
+};
+
+type LocalChunkPrefixObservation = {
+	capturedAt: number;
+	fileId: string | null;
+	chunkCount: number | null;
+	indexRowCount: number | null;
+	indexedChunkIndices: number[] | null;
+	blockCount: number | null;
+	blockChunkIndices: number[] | null;
+	persistChunkReads?: boolean;
+	activeTransfers?: Array<Record<string, unknown>>;
+	downloadScheduler?: LocalitySchedulerObservation;
+};
+
+const readLocalChunkPrefixObservation = async (
+	page: Page,
+	fileName: string,
+): Promise<LocalChunkPrefixObservation> => {
+	const observation = await page.evaluate(async (expectedFileName) => {
+		const hooks = (window as any).__peerbitFileShareTestHooks;
+		if (!hooks?.getLocalChunkPrefixObservation) {
+			throw new Error(
+				"Benchmark getLocalChunkPrefixObservation hook is unavailable",
+			);
+		}
+		return await hooks.getLocalChunkPrefixObservation(expectedFileName);
+	}, fileName);
+	const validateIndices = (
+		value: unknown,
+		label: string,
+		chunkCount: number,
+	) => {
+		if (
+			!Array.isArray(value) ||
+			value.some(
+				(index, offset) =>
+					!Number.isSafeInteger(index) ||
+					index < 0 ||
+					index >= chunkCount ||
+					(offset > 0 && index <= value[offset - 1]),
+			)
+		) {
+			throw new Error(`${label} is not a sorted unique chunk-index set`);
+		}
+	};
+	if (
+		!observation ||
+		!Number.isSafeInteger(observation.capturedAt) ||
+		observation.capturedAt <= 0 ||
+		(observation.fileId !== null &&
+			(typeof observation.fileId !== "string" ||
+				observation.fileId.length === 0))
+	) {
+		throw new Error("Local chunk-prefix hook returned invalid evidence");
+	}
+	if (observation.fileId === null) {
+		if (
+			observation.chunkCount !== null ||
+			observation.indexRowCount !== null ||
+			observation.indexedChunkIndices !== null ||
+			observation.blockCount !== null ||
+			observation.blockChunkIndices !== null
+		) {
+			throw new Error(
+				"Missing file locality must use null count and set fields",
+			);
+		}
+		return observation;
+	}
+	if (
+		!Number.isSafeInteger(observation.chunkCount) ||
+		observation.chunkCount <= 0 ||
+		!Number.isSafeInteger(observation.indexRowCount) ||
+		observation.indexRowCount < 0 ||
+		!Number.isSafeInteger(observation.blockCount) ||
+		observation.blockCount < 0
+	) {
+		throw new Error("Local chunk-prefix hook returned invalid counts");
+	}
+	validateIndices(
+		observation.indexedChunkIndices,
+		"indexedChunkIndices",
+		observation.chunkCount,
+	);
+	validateIndices(
+		observation.blockChunkIndices,
+		"blockChunkIndices",
+		observation.chunkCount,
+	);
+	if (
+		observation.indexRowCount !== observation.indexedChunkIndices.length ||
+		observation.blockCount !== observation.blockChunkIndices.length
+	) {
+		throw new Error("Local chunk-prefix counts disagree with their exact sets");
+	}
+	return observation;
+};
+
+const preloadLocalChunkPrefix = async (
+	page: Page,
+	fileName: string,
+	target: number,
+	timeoutMs: number,
+) =>
+	await page.evaluate(
+		async ({ expectedFileName, requestedTarget, timeout }) => {
+			const hooks = (window as any).__peerbitFileShareTestHooks;
+			if (!hooks?.preloadLocalChunkPrefix) {
+				throw new Error(
+					"Benchmark preloadLocalChunkPrefix hook is unavailable",
+				);
+			}
+			return await hooks.preloadLocalChunkPrefix(
+				expectedFileName,
+				requestedTarget,
+				timeout,
+			);
+		},
+		{ expectedFileName: fileName, requestedTarget: target, timeout: timeoutMs },
+	);
+
+const getTopologySnapshot = async (page: Page) =>
+	await page.evaluate(async () => {
+		const hooks = (window as any).__peerbitFileShareTestHooks;
+		if (!hooks?.getTopologySnapshot) {
+			throw new Error("Benchmark topology hook is unavailable");
+		}
+		return await hooks.getTopologySnapshot();
+	});
+
+const topologyHasExactWriterSingleton = (
+	writerTopology: Record<string, any>,
+	readerTopology: Record<string, any>,
+) => {
+	const writerPeerHash = writerTopology?.peerHash;
+	return (
+		typeof writerPeerHash === "string" &&
+		writerPeerHash.length > 0 &&
+		typeof readerTopology?.peerHash === "string" &&
+		readerTopology.peerHash.length > 0 &&
+		readerTopology.peerHash !== writerPeerHash &&
+		writerTopology.selfInReplicatorSet === true &&
+		readerTopology.selfInReplicatorSet === false &&
+		writerTopology.replicatorCount === 1 &&
+		readerTopology.replicatorCount === 1 &&
+		Array.isArray(writerTopology.replicatorHashes) &&
+		writerTopology.replicatorHashes.length === 1 &&
+		writerTopology.replicatorHashes[0] === writerPeerHash &&
+		Array.isArray(readerTopology.replicatorHashes) &&
+		readerTopology.replicatorHashes.length === 1 &&
+		readerTopology.replicatorHashes[0] === writerPeerHash
+	);
+};
+
+const topologyHasExactWriterReaderPair = (
+	writerTopology: Record<string, any>,
+	readerTopology: Record<string, any>,
+	expectedWriterPeerHash: string,
+	expectedReaderPeerHash: string,
+) => {
+	const expectedReplicatorHashes = [
+		expectedWriterPeerHash,
+		expectedReaderPeerHash,
+	].sort((left, right) => left.localeCompare(right));
+	return (
+		writerTopology?.peerHash === expectedWriterPeerHash &&
+		readerTopology?.peerHash === expectedReaderPeerHash &&
+		writerTopology.selfInReplicatorSet === true &&
+		readerTopology.selfInReplicatorSet === true &&
+		writerTopology.replicatorCount === 2 &&
+		readerTopology.replicatorCount === 2 &&
+		Array.isArray(writerTopology.replicatorHashes) &&
+		JSON.stringify(writerTopology.replicatorHashes) ===
+			JSON.stringify(expectedReplicatorHashes) &&
+		Array.isArray(readerTopology.replicatorHashes) &&
+		JSON.stringify(readerTopology.replicatorHashes) ===
+			JSON.stringify(expectedReplicatorHashes)
+	);
 };
 
 const getDiagnostics = async (page: Page) => {
@@ -497,8 +777,59 @@ test.describe("generated transfer-validity benchmark", () => {
 		let writerManifestEvidence: ReadyManifestEvidence | undefined;
 		let readerManifestEvidence: ReadyManifestEvidence | undefined;
 		let dropped = false;
+		let unexpectedSeederDrop = false;
 		let baselineWriterSeeders = MIN_READY_SEEDERS;
 		let baselineReaderSeeders = MIN_READY_SEEDERS;
+		const readerLocalityControl =
+			READER_LOCAL_CHUNK_TARGET === null
+				? null
+				: {
+						profile: "observer-topology-persistent-read-preloaded-prefix",
+						requestedYieldedChunkCount: READER_LOCAL_CHUNK_TARGET,
+						maxReadAheadOvershootChunkCount: READER_LOCAL_CHUNK_MAX_OVERSHOOT!,
+						countMetric:
+							"exact local Documents index rows and manifest entry blocks",
+						writerUploadRole: "fixed1",
+						readerUploadRole: "observer",
+						readerTimedReadPolicy: "persist-chunk-reads",
+						stabilityPollIntervalMs: LOCALITY_CONTROL_POLL_MS,
+						requiredStableObservationCount:
+							LOCALITY_CONTROL_STABLE_SAMPLE_COUNT,
+						status: "pending",
+						readerInitialRoleEvidence: null as InitialReaderRoleEvidence | null,
+						writerTopologyBeforeUpload: null as Record<string, unknown> | null,
+						readerTopologyBeforeUpload: null as Record<string, unknown> | null,
+						writerTopologyBeforeTimedRead: null as Record<
+							string,
+							unknown
+						> | null,
+						readerTopologyBeforeTimedRead: null as Record<
+							string,
+							unknown
+						> | null,
+						beforePreloadObservation:
+							null as LocalChunkPrefixObservation | null,
+						preloadEvidence: null as Record<string, unknown> | null,
+						stabilityObservations: [] as LocalChunkPrefixObservation[],
+						preDownloadObservation: null as LocalChunkPrefixObservation | null,
+						integrityVerifiedAt: null as number | null,
+						terminalIdleObservation: null as LocalChunkPrefixObservation | null,
+						terminalTopologyStartedAt: null as number | null,
+						terminalTopologyDeadlineAt: null as number | null,
+						terminalTopologyFinishedAt: null as number | null,
+						terminalTopologyRole: null as string | null,
+						readerJoinedReplicationDuringTimedRead: null as boolean | null,
+						terminalTopologyObservations: [] as Array<{
+							capturedAt: number;
+							writerTopology: Record<string, unknown>;
+							readerTopology: Record<string, unknown>;
+						}>,
+						actualLocalChunkBlockCount: null as number | null,
+						actualLocalChunkIndexRowCount: null as number | null,
+						readAheadOvershootChunkCount: null as number | null,
+						cohortKey: null as string | null,
+						failure: null as string | null,
+					};
 		attachTransferErrorCollector(writer, "writer", errors, requestFailures);
 		attachTransferErrorCollector(reader, "reader", errors, requestFailures);
 
@@ -559,14 +890,190 @@ test.describe("generated transfer-validity benchmark", () => {
 			return state;
 		};
 
+		const isContiguousPrefix = (indices: number[]) =>
+			indices.every((index, offset) => index === offset);
+
+		const localityObservationIsIdle = (
+			observation: LocalChunkPrefixObservation,
+		) =>
+			Array.isArray(observation.activeTransfers) &&
+			observation.activeTransfers.length === 0 &&
+			observation.downloadScheduler?.activeCount === 0 &&
+			observation.downloadScheduler.activeBytes === 0 &&
+			observation.downloadScheduler.queuedCount === 0;
+
+		const collectStableReaderLocality = async () => {
+			if (
+				!readerLocalityControl ||
+				READER_LOCAL_CHUNK_TARGET === null ||
+				READER_LOCAL_CHUNK_MAX_OVERSHOOT === null ||
+				!readerManifestEvidence
+			) {
+				throw new Error("Reader locality control is not ready for sampling");
+			}
+			const deadline = Date.now() + READY_TIMEOUT_MS;
+			let stable: LocalChunkPrefixObservation[] = [];
+			let lastObservation: LocalChunkPrefixObservation | null = null;
+			while (Date.now() <= deadline) {
+				const observation = await readLocalChunkPrefixObservation(
+					reader,
+					fileName,
+				);
+				lastObservation = observation;
+				const exactSetsAreValid =
+					observation.fileId === readerManifestEvidence.fileId &&
+					observation.indexRowCount !== null &&
+					observation.blockCount !== null &&
+					observation.indexedChunkIndices !== null &&
+					observation.blockChunkIndices !== null &&
+					observation.indexRowCount <= observation.blockCount &&
+					isContiguousPrefix(observation.indexedChunkIndices) &&
+					isContiguousPrefix(observation.blockChunkIndices) &&
+					observation.blockCount >= READER_LOCAL_CHUNK_TARGET &&
+					observation.blockCount <=
+						READER_LOCAL_CHUNK_TARGET + READER_LOCAL_CHUNK_MAX_OVERSHOOT &&
+					observation.blockCount < observation.chunkCount! &&
+					observation.persistChunkReads === true &&
+					localityObservationIsIdle(observation);
+				if (!exactSetsAreValid) {
+					stable = [];
+				} else {
+					const signature = JSON.stringify({
+						fileId: observation.fileId,
+						indexedChunkIndices: observation.indexedChunkIndices,
+						blockChunkIndices: observation.blockChunkIndices,
+					});
+					const previous = stable.at(-1);
+					const previousSignature = previous
+						? JSON.stringify({
+								fileId: previous.fileId,
+								indexedChunkIndices: previous.indexedChunkIndices,
+								blockChunkIndices: previous.blockChunkIndices,
+							})
+						: null;
+					stable =
+						previousSignature === signature
+							? [...stable, observation]
+							: [observation];
+					if (stable.length >= LOCALITY_CONTROL_STABLE_SAMPLE_COUNT) {
+						return stable;
+					}
+				}
+				await reader.waitForTimeout(LOCALITY_CONTROL_POLL_MS);
+			}
+			throw new Error(
+				`Reader locality did not reach a stable exact contiguous prefix: ${JSON.stringify(lastObservation)}`,
+			);
+		};
+
+		const waitForTerminalReaderIdle = async () => {
+			const deadline = Date.now() + READY_TIMEOUT_MS;
+			let lastObservation: LocalChunkPrefixObservation | null = null;
+			while (Date.now() <= deadline) {
+				lastObservation = await readLocalChunkPrefixObservation(
+					reader,
+					fileName,
+				);
+				if (
+					localityObservationIsIdle(lastObservation) &&
+					lastObservation.fileId === readerManifestEvidence?.fileId &&
+					lastObservation.chunkCount !== null &&
+					lastObservation.blockCount !== null &&
+					lastObservation.blockChunkIndices !== null &&
+					lastObservation.blockCount === lastObservation.chunkCount &&
+					isContiguousPrefix(lastObservation.blockChunkIndices) &&
+					lastObservation.persistChunkReads === true
+				) {
+					return lastObservation;
+				}
+				await reader.waitForTimeout(LOCALITY_CONTROL_POLL_MS);
+			}
+			throw new Error(
+				`Timed reader did not become transfer-idle with every manifest chunk local: ${JSON.stringify(lastObservation)}`,
+			);
+		};
+
+		const collectStableTerminalTopology = async (
+			startedAt: number,
+			deadline: number,
+		) => {
+			if (!readerLocalityControl) {
+				throw new Error("Reader locality control is unavailable");
+			}
+			const writerBeforeUpload =
+				readerLocalityControl.writerTopologyBeforeUpload;
+			const readerBeforeUpload =
+				readerLocalityControl.readerTopologyBeforeUpload;
+			const expectedWriterPeerHash = writerBeforeUpload?.peerHash;
+			const expectedReaderPeerHash = readerBeforeUpload?.peerHash;
+			if (
+				typeof expectedWriterPeerHash !== "string" ||
+				typeof expectedReaderPeerHash !== "string"
+			) {
+				throw new Error("Pre-read topology peer identities are unavailable");
+			}
+			let stable: Array<{
+				capturedAt: number;
+				writerTopology: Record<string, unknown>;
+				readerTopology: Record<string, unknown>;
+			}> = [];
+			let lastObservation: Record<string, unknown> | null = null;
+			while (Date.now() <= deadline) {
+				const [writerTopology, readerTopology] = await Promise.all([
+					getTopologySnapshot(writer),
+					getTopologySnapshot(reader),
+				]);
+				const observation = {
+					capturedAt: Date.now(),
+					writerTopology,
+					readerTopology,
+				};
+				lastObservation = observation;
+				if (
+					observation.capturedAt < startedAt ||
+					observation.capturedAt > deadline
+				) {
+					break;
+				}
+				if (
+					topologyHasExactWriterReaderPair(
+						writerTopology,
+						readerTopology,
+						expectedWriterPeerHash,
+						expectedReaderPeerHash,
+					)
+				) {
+					stable = [...stable, observation];
+					if (stable.length >= LOCALITY_CONTROL_STABLE_SAMPLE_COUNT) {
+						return stable;
+					}
+				} else {
+					stable = [];
+				}
+				await reader.waitForTimeout(LOCALITY_CONTROL_POLL_MS);
+			}
+			throw new Error(
+				`Timed reader did not converge to the exact two-replicator topology: ${JSON.stringify(lastObservation)}`,
+			);
+		};
+
 		const noteSeederDrop = (current: Record<string, unknown>) => {
+			const writerDropped =
+				typeof current.writerSeeders === "number" &&
+				current.writerSeeders < baselineWriterSeeders;
+			const readerDropped =
+				typeof current.readerSeeders === "number" &&
+				current.readerSeeders < baselineReaderSeeders;
+			if (writerDropped || readerDropped) {
+				dropped = true;
+			}
 			if (
 				(typeof current.writerSeeders === "number" &&
 					current.writerSeeders < baselineWriterSeeders) ||
 				(typeof current.readerSeeders === "number" &&
 					current.readerSeeders < baselineReaderSeeders)
 			) {
-				dropped = true;
+				unexpectedSeederDrop = true;
 			}
 		};
 
@@ -645,9 +1152,23 @@ test.describe("generated transfer-validity benchmark", () => {
 
 			stage = "open-share";
 			logStage(stage, { shareUrl });
+			if (readerLocalityControl) {
+				const shareHash = new URL(shareUrl).hash;
+				const shareAddress = shareHash.replace(/^#\/s\//, "");
+				if (
+					!shareAddress ||
+					/[/?#]/.test(shareAddress) ||
+					shareHash !== `#/s/${shareAddress}`
+				) {
+					throw new Error(`Failed to derive share address from ${shareUrl}`);
+				}
+				await seedReplicationRole(reader, shareAddress, false);
+			}
 			await Promise.all([
 				applyRole(writer, shareUrl),
-				applyRole(reader, shareUrl),
+				readerLocalityControl
+					? openWithSeededReplicationRole(reader, shareUrl)
+					: applyRole(reader, shareUrl),
 			]);
 
 			stage = "wait-for-seeders";
@@ -675,6 +1196,33 @@ test.describe("generated transfer-validity benchmark", () => {
 				typeof ready.readerSeeders === "number"
 					? ready.readerSeeders
 					: MIN_READY_SEEDERS;
+			if (readerLocalityControl) {
+				const initialRoleEvidence = await readInitialReaderRoleEvidence(reader);
+				readerLocalityControl.readerInitialRoleEvidence = initialRoleEvidence;
+				if (
+					typeof initialRoleEvidence.programAddress !== "string" ||
+					initialRoleEvidence.programAddress.length === 0 ||
+					initialRoleEvidence.persistChunkReads !== false ||
+					initialRoleEvidence.initialRole !== "observer" ||
+					initialRoleEvidence.updateRoleCount !== 0 ||
+					initialRoleEvidence.lastAppliedRole !== null
+				) {
+					throw new Error(
+						"Controlled-locality reader was not initialized as an observer before upload",
+					);
+				}
+				const [writerTopology, readerTopology] = await Promise.all([
+					getTopologySnapshot(writer),
+					getTopologySnapshot(reader),
+				]);
+				readerLocalityControl.writerTopologyBeforeUpload = writerTopology;
+				readerLocalityControl.readerTopologyBeforeUpload = readerTopology;
+				if (!topologyHasExactWriterSingleton(writerTopology, readerTopology)) {
+					throw new Error(
+						"Controlled-locality reader did not start in an observer topology",
+					);
+				}
+			}
 
 			stage = "prepare-deterministic-fixture";
 			logStage(stage, { fixtureSeed: FIXTURE_SEED });
@@ -818,6 +1366,119 @@ test.describe("generated transfer-validity benchmark", () => {
 					`Post-upload monitor duration ${measuredPostMonitorMs}ms is outside ${POST_UPLOAD_MONITOR_MS}ms + ${POST_MONITOR_SCHEDULING_TOLERANCE_MS}ms scheduling tolerance`,
 				);
 			}
+			if (readerLocalityControl) {
+				stage = "prepare-reader-locality-cohort";
+				readerLocalityControl.status = "preparing";
+				const beforePreloadObservation = await readLocalChunkPrefixObservation(
+					reader,
+					fileName,
+				);
+				readerLocalityControl.beforePreloadObservation =
+					beforePreloadObservation;
+				if (
+					beforePreloadObservation.fileId !== readerManifestEvidence.fileId ||
+					beforePreloadObservation.chunkCount === null ||
+					READER_LOCAL_CHUNK_TARGET >= beforePreloadObservation.chunkCount ||
+					beforePreloadObservation.indexRowCount !== 0 ||
+					beforePreloadObservation.blockCount !== 0 ||
+					beforePreloadObservation.indexedChunkIndices?.length !== 0 ||
+					beforePreloadObservation.blockChunkIndices?.length !== 0 ||
+					beforePreloadObservation.persistChunkReads !== false ||
+					!localityObservationIsIdle(beforePreloadObservation)
+				) {
+					throw new Error(
+						"Controlled-locality reader was not an empty, idle observer before preload",
+					);
+				}
+				logStage("reader-locality-preload", {
+					requestedYieldedChunkCount: READER_LOCAL_CHUNK_TARGET,
+					maxReadAheadOvershootChunkCount: READER_LOCAL_CHUNK_MAX_OVERSHOOT,
+				});
+				const preloadEvidence = (await preloadLocalChunkPrefix(
+					reader,
+					fileName,
+					READER_LOCAL_CHUNK_TARGET,
+					DOWNLOAD_TIMEOUT_MS,
+				)) as Record<string, unknown>;
+				readerLocalityControl.preloadEvidence = preloadEvidence;
+				const preloadScheduler = preloadEvidence.downloadSchedulerAfterClose as
+					| LocalitySchedulerObservation
+					| undefined;
+				const preloadReadDiagnostics =
+					preloadEvidence.readDiagnostics as Record<string, unknown> | null;
+				if (
+					preloadEvidence.fileId !== readerManifestEvidence.fileId ||
+					preloadEvidence.yieldedChunkCount !== READER_LOCAL_CHUNK_TARGET ||
+					!Number.isSafeInteger(preloadEvidence.yieldedByteCount) ||
+					(preloadEvidence.yieldedByteCount as number) < 0 ||
+					preloadEvidence.persistChunkReads !== true ||
+					!Array.isArray(preloadEvidence.activeTransfersAfterClose) ||
+					preloadEvidence.activeTransfersAfterClose.length !== 0 ||
+					preloadScheduler?.activeCount !== 0 ||
+					preloadScheduler.activeBytes !== 0 ||
+					preloadScheduler.queuedCount !== 0 ||
+					!Number.isSafeInteger(preloadEvidence.startedAt) ||
+					!Number.isSafeInteger(preloadEvidence.finishedAt) ||
+					(preloadEvidence.finishedAt as number) <
+						(preloadEvidence.startedAt as number)
+				) {
+					throw new Error(
+						"Reader locality preload did not close with clean transfer resources",
+					);
+				}
+				if (READER_LOCAL_CHUNK_TARGET === 0) {
+					if (
+						preloadEvidence.transferId !== null ||
+						preloadReadDiagnostics !== null
+					) {
+						throw new Error("Zero-prefix preload unexpectedly opened a read");
+					}
+				} else if (
+					typeof preloadEvidence.transferId !== "string" ||
+					preloadEvidence.transferId.length === 0 ||
+					!preloadReadDiagnostics ||
+					preloadReadDiagnostics.transferId !== preloadEvidence.transferId ||
+					preloadReadDiagnostics.persistChunkReads !== true ||
+					preloadReadDiagnostics.finishedAt !== null ||
+					preloadReadDiagnostics.failureAt !== null ||
+					preloadReadDiagnostics.failureMessage !== null
+				) {
+					throw new Error(
+						"Partial-prefix preload diagnostics do not prove a clean iterator close",
+					);
+				}
+
+				const stabilityObservations = await collectStableReaderLocality();
+				readerLocalityControl.stabilityObservations = stabilityObservations;
+				const preDownloadObservation = stabilityObservations.at(-1)!;
+				readerLocalityControl.preDownloadObservation = preDownloadObservation;
+				readerLocalityControl.actualLocalChunkBlockCount =
+					preDownloadObservation.blockCount;
+				readerLocalityControl.actualLocalChunkIndexRowCount =
+					preDownloadObservation.indexRowCount;
+				readerLocalityControl.readAheadOvershootChunkCount =
+					preDownloadObservation.blockCount! - READER_LOCAL_CHUNK_TARGET;
+				readerLocalityControl.cohortKey = `observer-persistent-prefix-b${preDownloadObservation.blockCount}-i${preDownloadObservation.indexRowCount}`;
+				const [writerTopology, readerTopology] = await Promise.all([
+					getTopologySnapshot(writer),
+					getTopologySnapshot(reader),
+				]);
+				readerLocalityControl.writerTopologyBeforeTimedRead = writerTopology;
+				readerLocalityControl.readerTopologyBeforeTimedRead = readerTopology;
+				if (!topologyHasExactWriterSingleton(writerTopology, readerTopology)) {
+					throw new Error(
+						"Controlled-locality reader joined the replication set before the timed read",
+					);
+				}
+				readerLocalityControl.status = "stable";
+				logStage("reader-locality-stable", {
+					actualLocalChunkBlockCount:
+						readerLocalityControl.actualLocalChunkBlockCount,
+					actualLocalChunkIndexRowCount:
+						readerLocalityControl.actualLocalChunkIndexRowCount,
+					cohortKey: readerLocalityControl.cohortKey,
+				});
+			}
 
 			stage = "download-to-selected-sink";
 			logStage(stage, { downloadSink: DOWNLOAD_SINK });
@@ -909,6 +1570,28 @@ test.describe("generated transfer-validity benchmark", () => {
 				throw new Error(
 					"Library read diagnostics do not match the clicked file manifest",
 				);
+			}
+			if (readerLocalityControl) {
+				const actualLocalChunkBlockCount =
+					readerLocalityControl.actualLocalChunkBlockCount;
+				const actualLocalChunkIndexRowCount =
+					readerLocalityControl.actualLocalChunkIndexRowCount;
+				if (
+					!Number.isSafeInteger(actualLocalChunkBlockCount) ||
+					!Number.isSafeInteger(actualLocalChunkIndexRowCount) ||
+					rawReadDiagnostics.persistChunkReads !== true ||
+					rawReadDiagnostics.programPersistChunkReads !== true ||
+					rawReadDiagnostics.initialLocalChunkIndexRowCount !==
+						actualLocalChunkIndexRowCount ||
+					rawReadDiagnostics.initialLocalChunkCount !==
+						actualLocalChunkIndexRowCount ||
+					rawReadDiagnostics.initialLocalChunkBlockCount !==
+						actualLocalChunkBlockCount
+				) {
+					throw new Error(
+						"Timed read diagnostics do not match the controlled pre-download locality cohort",
+					);
+				}
 			}
 			const summarizedReadTransfer = summarizeReadTransferDiagnostics(
 				rawReadDiagnostics,
@@ -1061,8 +1744,46 @@ test.describe("generated transfer-validity benchmark", () => {
 					`Downloaded file failed integrity validation: ${JSON.stringify(integrity)}`,
 				);
 			}
-			if (dropped) {
-				throw new Error("Seeder counts dropped during benchmark");
+			if (readerLocalityControl) {
+				stage = "verify-terminal-reader-topology";
+				readerLocalityControl.integrityVerifiedAt = Date.now();
+				const terminalIdleObservation = await waitForTerminalReaderIdle();
+				readerLocalityControl.terminalIdleObservation = terminalIdleObservation;
+				const terminalTopologyStartedAt = Date.now();
+				const terminalTopologyDeadlineAt =
+					terminalTopologyStartedAt + READY_TIMEOUT_MS;
+				readerLocalityControl.terminalTopologyStartedAt =
+					terminalTopologyStartedAt;
+				readerLocalityControl.terminalTopologyDeadlineAt =
+					terminalTopologyDeadlineAt;
+				const terminalTopologyObservations =
+					await collectStableTerminalTopology(
+						terminalTopologyStartedAt,
+						terminalTopologyDeadlineAt,
+					);
+				const terminalTopologyFinishedAt = Date.now();
+				if (terminalTopologyFinishedAt > terminalTopologyDeadlineAt) {
+					throw new Error(
+						"Terminal topology converged after its bounded readiness deadline",
+					);
+				}
+				readerLocalityControl.terminalTopologyFinishedAt =
+					terminalTopologyFinishedAt;
+				readerLocalityControl.terminalTopologyObservations =
+					terminalTopologyObservations;
+				readerLocalityControl.terminalTopologyRole = "replicator";
+				readerLocalityControl.readerJoinedReplicationDuringTimedRead = true;
+				readerLocalityControl.status = "complete";
+				logStage("reader-terminal-topology-stable", {
+					terminalTopologyRole: readerLocalityControl.terminalTopologyRole,
+					readerJoinedReplicationDuringTimedRead:
+						readerLocalityControl.readerJoinedReplicationDuringTimedRead,
+				});
+			}
+			if (unexpectedSeederDrop) {
+				throw new Error(
+					"Seeder counts dropped outside the benchmark topology contract",
+				);
 			}
 			if (errors.length > 0) {
 				throw new Error(
@@ -1100,7 +1821,18 @@ test.describe("generated transfer-validity benchmark", () => {
 					"Measured transfer duration exceeded its requested timeout and scheduling tolerance",
 				);
 			}
-			const writerDiagnostics = await getDiagnostics(writer);
+			const [writerDiagnostics, finalReaderDiagnostics] = await Promise.all([
+				getDiagnostics(writer),
+				getDiagnostics(reader),
+			]);
+			if (
+				readerLocalityControl &&
+				(!writerDiagnostics || !finalReaderDiagnostics)
+			) {
+				throw new Error(
+					"Controlled-locality benchmark is missing final peer diagnostics",
+				);
+			}
 			if (errors.length > 0) {
 				throw new Error(
 					`Observed transfer/delivery errors while collecting diagnostics: ${JSON.stringify(errors)}`,
@@ -1115,6 +1847,14 @@ test.describe("generated transfer-validity benchmark", () => {
 				provenance: PROVENANCE,
 				status: "passed",
 				mode: MODE,
+				readerLocalChunkTarget: READER_LOCAL_CHUNK_TARGET,
+				readerLocalChunkMaxOvershoot: READER_LOCAL_CHUNK_MAX_OVERSHOOT,
+				readerLocalChunkBlockCount:
+					readerLocalityControl?.actualLocalChunkBlockCount ?? null,
+				readerLocalChunkIndexRowCount:
+					readerLocalityControl?.actualLocalChunkIndexRowCount ?? null,
+				readerLocalityCohortKey: readerLocalityControl?.cohortKey ?? null,
+				readerLocalityControl,
 				networkMode: NETWORK_MODE,
 				fileName,
 				fileSizeMb: FILE_SIZE_MB,
@@ -1195,6 +1935,7 @@ test.describe("generated transfer-validity benchmark", () => {
 				baselineReaderSeeders,
 				shareUrl,
 				droppedSeeders: dropped,
+				unexpectedSeederDrop,
 				writerVisibilityProbe,
 				readerVisibilityProbe,
 				errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
@@ -1209,11 +1950,16 @@ test.describe("generated transfer-validity benchmark", () => {
 				requestFailures: collectedRequestFailures,
 				snapshots,
 				writerDiagnostics,
-				readerDiagnostics,
+				readerDiagnostics: finalReaderDiagnostics,
 			};
 			await persistResult(result);
 			console.log(`FILE_SHARE_BENCHMARK_RESULT ${JSON.stringify(result)}`);
 		} catch (error: any) {
+			if (readerLocalityControl) {
+				readerLocalityControl.status = "failed";
+				readerLocalityControl.failure =
+					typeof error?.message === "string" ? error.message : String(error);
+			}
 			await snapshot(`failure-${stage}`).catch(() => {});
 			const writerDiagnostics = await getDiagnostics(writer);
 			const readerDiagnostics = await getDiagnostics(reader);
@@ -1226,6 +1972,14 @@ test.describe("generated transfer-validity benchmark", () => {
 				provenance: PROVENANCE,
 				status: "failed",
 				mode: MODE,
+				readerLocalChunkTarget: READER_LOCAL_CHUNK_TARGET,
+				readerLocalChunkMaxOvershoot: READER_LOCAL_CHUNK_MAX_OVERSHOOT,
+				readerLocalChunkBlockCount:
+					readerLocalityControl?.actualLocalChunkBlockCount ?? null,
+				readerLocalChunkIndexRowCount:
+					readerLocalityControl?.actualLocalChunkIndexRowCount ?? null,
+				readerLocalityCohortKey: readerLocalityControl?.cohortKey ?? null,
+				readerLocalityControl,
 				networkMode: NETWORK_MODE,
 				fileSizeMb: FILE_SIZE_MB,
 				stage,
@@ -1250,6 +2004,7 @@ test.describe("generated transfer-validity benchmark", () => {
 				baselineReaderSeeders,
 				shareUrl,
 				droppedSeeders: dropped,
+				unexpectedSeederDrop,
 				writerVisibilityProbe,
 				readerVisibilityProbe,
 				errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,


### PR DESCRIPTION
Summary
- add deterministic cold and preloaded-prefix reader-locality cohorts
- bind timed reads to exact block/index prefixes and writer-only starting topology
- require terminal transfer-idle state and stable writer+reader replication convergence
- enforce one aggregate nonzero-prefix preload deadline through AbortController, including bounded iterator cleanup
- migrate reused instrumented checkouts to the aggregate-deadline hook and preserve exact cohort/raw timing evidence

Validation
- node --test scripts/file-share/*.test.mjs (156 passed)
- Prettier, syntax, and git diff checks
- exact merged-master 8 MiB target-1 smoke: b3-i0, aggregate deadline arithmetic and cleanup passed
- exact merged-master 8 MiB cold smoke: b0-i0, all integrity/topology gates passed