### PR TITLE
feat(benchmarks): capture bounded download memory telemetry

### DIFF
--- a/scripts/file-share/README.md
+++ b/scripts/file-share/README.md
@@ -3,7 +3,7 @@
 Run a single checkout with `pnpm bench:file-share:local` or compare pinned
 Peerbit revisions with `pnpm bench:file-share:matrix`.
 
-Result schema v4 defines `errorCount` as every uncaught browser `pageerror`,
+Result schema v5 defines `errorCount` as every uncaught browser `pageerror`,
 every browser `console.error`, every console message at any level that contains
 a declared Peerbit failure signature, and scenario-recorded operation failures.
 Each result embeds the exact `errorCollectionDefinition` and signature list.
@@ -32,6 +32,33 @@ cohorts require persisted size, SHA-256, and CRC-32 readback. Compare different
 sinks only in separate benchmark sessions; aggregate comparison objects fail
 closed on mixed sinks, and every passed result and aggregate labels
 non-hash-only cohorts non-authoritative.
+
+Schema v5 upload results also record bounded download-window memory telemetry. After any
+controlled-locality stabilization, the harness arms serial samplers immediately
+before the timed click and forces a final sample as soon as the selected sink
+completion is observed, before integrity readback or terminal-topology checks.
+Reader and writer renderer JavaScript heaps use CDP `JSHeapUsedSize` samples.
+Host RSS combines all Chromium processes, grouped by Chromium process role,
+with the Playwright worker Node process; for local runs that Node value also
+includes the in-process bootstrap peer. Chromium RSS cannot be assigned
+reliably to one page and RSS is not PSS or USS, so page-level comparisons should
+use the renderer heap series. Samples run serially every five seconds, include
+forced initial/final endpoints, reserve one endpoint slot, cap each series at
+4,096 entries, and cap sampling errors. Passed evidence requires at least two
+error-free samples in every series and coverage of the canonical library read
+window. The validator recomputes all start, end, peak, process-role, and combined
+RSS summaries and rejects reordered, oversized, partial, or contradictory
+telemetry. Failed runs retain whatever bounded telemetry was collected, but are
+never accepted as performance evidence.
+
+Every CDP sample and setup operation has a four-second deadline; sampler
+cleanup has a nine-second aggregate deadline, late-created CDP sessions are
+detached best-effort, and a timed-out probe becomes terminal so another sample
+cannot overlap it. Result validation binds every series to the actual click and
+completion-observation timestamps: setup may begin at most 30 seconds before
+the click, and the terminal sample plus cleanup must finish within 30 seconds
+after completion is observed. Host samples are additionally capped at 256
+Chromium processes and 32 process-role groups.
 
 For a controlled reader-locality download cohort, run an upload with
 `--mode fixed1`, `--reader-local-chunk-target <N>`, and

--- a/scripts/file-share/benchmark-orchestration.mjs
+++ b/scripts/file-share/benchmark-orchestration.mjs
@@ -2,7 +2,7 @@ import fsp from "node:fs/promises";
 
 export const BENCHMARK_RESULT_SCHEMA = Object.freeze({
 	id: "peerbit-file-share-benchmark",
-	version: 4,
+	version: 5,
 });
 
 export const BENCHMARK_SUMMARY_SCHEMA = Object.freeze({

--- a/scripts/file-share/benchmark-validity.mjs
+++ b/scripts/file-share/benchmark-validity.mjs
@@ -6,6 +6,23 @@ import {
 	KNOWN_PEERBIT_FAILURE_SIGNATURES,
 	REQUEST_FAILURE_COLLECTION_DEFINITION,
 } from "./benchmark-orchestration.mjs";
+import {
+	DOWNLOAD_MEMORY_HOST_ATTRIBUTION,
+	DOWNLOAD_MEMORY_HOST_ATTRIBUTION_LIMITATIONS,
+	DOWNLOAD_MEMORY_HOST_SCOPE,
+	DOWNLOAD_MEMORY_MAX_BROWSER_PROCESSES,
+	DOWNLOAD_MEMORY_MAX_BROWSER_ROLES,
+	DOWNLOAD_MEMORY_MAX_BROWSER_ROLE_NAME_LENGTH,
+	DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH,
+	DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS,
+	DOWNLOAD_MEMORY_NODE_SCOPE,
+	DOWNLOAD_MEMORY_PROFILE,
+	DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
+	DOWNLOAD_MEMORY_SETUP_ALLOWANCE_MS,
+	DOWNLOAD_MEMORY_TERMINAL_ALLOWANCE_MS,
+	DOWNLOAD_MEMORY_WINDOW_DEFINITION,
+	calculateDownloadMemoryMaxSamples,
+} from "./templates/download-memory-telemetry.mjs";
 
 const SHA256_BASE64_PATTERN = /^[A-Za-z0-9+/]{43}=$/;
 const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/;
@@ -55,6 +72,15 @@ const isRecord = (value) =>
 const requireRecord = (value, label) => {
 	if (!isRecord(value)) {
 		throw new Error(`Benchmark result is missing ${label}`);
+	}
+	return value;
+};
+
+const requireExactRecordKeys = (value, expectedKeys, label) => {
+	const actualKeys = Object.keys(value).toSorted();
+	const sortedExpectedKeys = [...expectedKeys].toSorted();
+	if (!isDeepStrictEqual(actualKeys, sortedExpectedKeys)) {
+		throw new Error(`Benchmark ${label} contains unexpected or missing fields`);
 	}
 	return value;
 };
@@ -342,7 +368,11 @@ const requireBoundedDiagnosticIntervals = ({
 const validateReadTransferEvidence = (
 	result,
 	invocation,
-	{ downloadStartedAt, downloadFinishedAt },
+	{
+		downloadStartedAt,
+		downloadFinishedAt,
+		downloadCompletionObservedAt,
+	},
 ) => {
 	const readerDiagnostics = requireRecord(
 		result.readerDiagnostics,
@@ -617,6 +647,442 @@ const validateReadTransferEvidence = (
 			"Non-Node benchmark sink contains Node-only server timing evidence",
 		);
 	}
+	return {
+		startedAt,
+		finishedAt,
+		downloadStartedAt,
+		downloadFinishedAt,
+		downloadCompletionObservedAt,
+	};
+};
+
+const validateMemorySamplingErrors = (series, label) => {
+	if (
+		!Array.isArray(series.samplingErrors) ||
+		series.samplingErrors.length > DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS ||
+		series.samplingErrors.some(
+			(message) =>
+				typeof message !== "string" ||
+				message.length === 0 ||
+				message.length > DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH,
+		) ||
+		!Number.isSafeInteger(series.samplingErrorOverflowCount) ||
+		series.samplingErrorOverflowCount < 0
+	) {
+		throw new Error(`Benchmark ${label} contains unbounded sampling errors`);
+	}
+	if (
+		series.samplingErrors.length !== 0 ||
+		series.samplingErrorOverflowCount !== 0
+	) {
+		throw new Error(`Benchmark ${label} contains memory sampling errors`);
+	}
+};
+
+const validateMemorySeriesWindow = (
+	series,
+	label,
+	maxSamples,
+	{
+		startedAt: readStartedAt,
+		finishedAt: readFinishedAt,
+		downloadStartedAt,
+		downloadFinishedAt,
+		downloadCompletionObservedAt,
+	},
+) => {
+	const startedAt = requirePositiveSafeInteger(
+		series.startedAt,
+		`${label}.startedAt`,
+	);
+	const finishedAt = requirePositiveSafeInteger(
+		series.finishedAt,
+		`${label}.finishedAt`,
+	);
+	if (
+		series.sampleIntervalMs !== DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS ||
+		!Array.isArray(series.samples) ||
+		series.sampleCount !== series.samples.length ||
+		!Number.isSafeInteger(series.sampleCount) ||
+		series.sampleCount < 2 ||
+		series.sampleCount > maxSamples ||
+		finishedAt < startedAt
+	) {
+		throw new Error(`Benchmark ${label} has an invalid bounded sample series`);
+	}
+	let previousCapturedAt = null;
+	for (const [index, sampleValue] of series.samples.entries()) {
+		const sample = requireRecord(sampleValue, `${label}.samples[${index}]`);
+		const capturedAt = requirePositiveSafeInteger(
+			sample.capturedAt,
+			`${label}.samples[${index}].capturedAt`,
+		);
+		if (
+			capturedAt < startedAt ||
+			capturedAt > finishedAt ||
+			(previousCapturedAt !== null && capturedAt < previousCapturedAt)
+		) {
+			throw new Error(
+				`Benchmark ${label} sample timestamps are outside or reorder the sampler window`,
+			);
+		}
+		previousCapturedAt = capturedAt;
+	}
+	const firstCapturedAt = series.samples[0].capturedAt;
+	const lastCapturedAt = series.samples.at(-1).capturedAt;
+	if (
+		startedAt > downloadStartedAt ||
+		firstCapturedAt > downloadStartedAt ||
+		lastCapturedAt < downloadCompletionObservedAt ||
+		finishedAt < downloadCompletionObservedAt
+	) {
+		throw new Error(
+			`Benchmark ${label} does not bracket the click-to-sink observation window`,
+		);
+	}
+	if (
+		startedAt < downloadStartedAt - DOWNLOAD_MEMORY_SETUP_ALLOWANCE_MS ||
+		firstCapturedAt <
+			downloadStartedAt - DOWNLOAD_MEMORY_SETUP_ALLOWANCE_MS
+	) {
+		throw new Error(
+			`Benchmark ${label} begins before the bounded telemetry setup window`,
+		);
+	}
+	if (
+		lastCapturedAt >
+			downloadCompletionObservedAt + DOWNLOAD_MEMORY_TERMINAL_ALLOWANCE_MS ||
+		finishedAt >
+			downloadCompletionObservedAt + DOWNLOAD_MEMORY_TERMINAL_ALLOWANCE_MS
+	) {
+		throw new Error(
+			`Benchmark ${label} ends after the bounded telemetry cleanup window`,
+		);
+	}
+	if (lastCapturedAt < downloadFinishedAt) {
+		throw new Error(
+			`Benchmark ${label} does not cover the selected sink download window`,
+		);
+	}
+	if (firstCapturedAt > readStartedAt || lastCapturedAt < readFinishedAt) {
+		throw new Error(
+			`Benchmark ${label} does not cover the canonical library read window`,
+		);
+	}
+	validateMemorySamplingErrors(series, label);
+	return { startedAt, finishedAt };
+};
+
+const validateHeapMemorySeries = (
+	seriesValue,
+	label,
+	expectedScope,
+	maxSamples,
+	readWindow,
+) => {
+	const series = requireRecord(seriesValue, label);
+	requireExactRecordKeys(
+		series,
+		[
+			"memoryKind",
+			"scope",
+			"metric",
+			"unit",
+			"sampleIntervalMs",
+			"startedAt",
+			"finishedAt",
+			"sampleCount",
+			"startBytes",
+			"endBytes",
+			"peakBytes",
+			"samples",
+			"samplingErrors",
+			"samplingErrorOverflowCount",
+		],
+		label,
+	);
+	if (
+		series.memoryKind !== "javascript-heap" ||
+		series.scope !== expectedScope ||
+		series.metric !== "JSHeapUsedSize" ||
+		series.unit !== "bytes"
+	) {
+		throw new Error(`Benchmark ${label} has invalid heap attribution`);
+	}
+	const window = validateMemorySeriesWindow(
+		series,
+		label,
+		maxSamples,
+		readWindow,
+	);
+	const values = series.samples.map((sample, index) => {
+		requireExactRecordKeys(
+			sample,
+			["capturedAt", "usedBytes"],
+			`${label}.samples[${index}]`,
+		);
+		return requireNonNegativeNumber(
+			sample.usedBytes,
+			`${label}.samples[${index}].usedBytes`,
+		);
+	});
+	if (
+		series.startBytes !== values[0] ||
+		series.endBytes !== values.at(-1) ||
+		series.peakBytes !== Math.max(...values)
+	) {
+		throw new Error(`Benchmark ${label} heap summaries are inconsistent`);
+	}
+	return window;
+};
+
+const validateBrowserRoleBytes = (value, label) => {
+	const roles = requireRecord(value, label);
+	const entries = Object.entries(roles);
+	if (
+		entries.length === 0 ||
+		entries.length > DOWNLOAD_MEMORY_MAX_BROWSER_ROLES
+	) {
+		throw new Error(`Benchmark ${label} has an invalid browser-role count`);
+	}
+	let total = 0;
+	for (const [role, bytes] of entries) {
+		if (
+			role.length === 0 ||
+			role.length > DOWNLOAD_MEMORY_MAX_BROWSER_ROLE_NAME_LENGTH ||
+			!/^[\x20-\x7e]+$/.test(role)
+		) {
+			throw new Error(`Benchmark ${label} has an invalid browser-role name`);
+		}
+		total += requirePositiveSafeInteger(bytes, `${label}.${role}`);
+	}
+	return { roles, total };
+};
+
+const validateHostRssSeries = (
+	seriesValue,
+	maxSamples,
+	readWindow,
+) => {
+	const label = "downloadMemoryTelemetry.hostRss";
+	const series = requireRecord(seriesValue, label);
+	requireExactRecordKeys(
+		series,
+		[
+			"memoryKind",
+			"scope",
+			"nodeScope",
+			"metric",
+			"attribution",
+			"attributionLimitations",
+			"unit",
+			"sampleIntervalMs",
+			"startedAt",
+			"finishedAt",
+			"sampleCount",
+			"startBrowserBytes",
+			"endBrowserBytes",
+			"peakBrowserBytes",
+			"startNodeBytes",
+			"endNodeBytes",
+			"peakNodeBytes",
+			"startCombinedBytes",
+			"endCombinedBytes",
+			"peakCombinedBytes",
+			"startBrowserProcessCount",
+			"endBrowserProcessCount",
+			"peakBrowserProcessCount",
+			"startBrowserRoleBytes",
+			"endBrowserRoleBytes",
+			"peakBrowserRoleBytes",
+			"samples",
+			"samplingErrors",
+			"samplingErrorOverflowCount",
+		],
+		label,
+	);
+	if (
+		series.memoryKind !== "resident-set-size" ||
+		series.scope !== DOWNLOAD_MEMORY_HOST_SCOPE ||
+		series.nodeScope !== DOWNLOAD_MEMORY_NODE_SCOPE ||
+		series.metric !== "RSS" ||
+		series.attribution !== DOWNLOAD_MEMORY_HOST_ATTRIBUTION ||
+		series.attributionLimitations !==
+			DOWNLOAD_MEMORY_HOST_ATTRIBUTION_LIMITATIONS ||
+		series.unit !== "bytes"
+	) {
+		throw new Error("Benchmark host RSS attribution contract is invalid");
+	}
+	const window = validateMemorySeriesWindow(
+		series,
+		label,
+		maxSamples,
+		readWindow,
+	);
+	const peakBrowserRoleBytes = {};
+	const samples = series.samples.map((sample, index) => {
+		const sampleLabel = `${label}.samples[${index}]`;
+		requireExactRecordKeys(
+			sample,
+			[
+				"capturedAt",
+				"browserBytes",
+				"nodeBytes",
+				"combinedBytes",
+				"browserProcessCount",
+				"browserRoleBytes",
+			],
+			sampleLabel,
+		);
+		const browserBytes = requirePositiveSafeInteger(
+			sample.browserBytes,
+			`${sampleLabel}.browserBytes`,
+		);
+		const nodeBytes = requirePositiveSafeInteger(
+			sample.nodeBytes,
+			`${sampleLabel}.nodeBytes`,
+		);
+		const combinedBytes = requirePositiveSafeInteger(
+			sample.combinedBytes,
+			`${sampleLabel}.combinedBytes`,
+		);
+		const browserProcessCount = requirePositiveSafeInteger(
+			sample.browserProcessCount,
+			`${sampleLabel}.browserProcessCount`,
+		);
+		if (browserProcessCount > DOWNLOAD_MEMORY_MAX_BROWSER_PROCESSES) {
+			throw new Error(
+				`Benchmark ${sampleLabel} exceeds the browser-process count cap`,
+			);
+		}
+		const { roles: browserRoleBytes, total: roleTotal } =
+			validateBrowserRoleBytes(
+				sample.browserRoleBytes,
+				`${sampleLabel}.browserRoleBytes`,
+			);
+		if (
+			combinedBytes !== browserBytes + nodeBytes ||
+			roleTotal !== browserBytes
+		) {
+			throw new Error(
+				`Benchmark ${sampleLabel} RSS totals are inconsistent`,
+			);
+		}
+		for (const [role, bytes] of Object.entries(browserRoleBytes)) {
+			peakBrowserRoleBytes[role] = Math.max(
+				peakBrowserRoleBytes[role] ?? 0,
+				bytes,
+			);
+		}
+		return {
+			browserBytes,
+			nodeBytes,
+			combinedBytes,
+			browserProcessCount,
+			browserRoleBytes,
+		};
+	});
+	const first = samples[0];
+	const last = samples.at(-1);
+	const peak = (name) => Math.max(...samples.map((sample) => sample[name]));
+	if (
+		series.startBrowserBytes !== first.browserBytes ||
+		series.endBrowserBytes !== last.browserBytes ||
+		series.peakBrowserBytes !== peak("browserBytes") ||
+		series.startNodeBytes !== first.nodeBytes ||
+		series.endNodeBytes !== last.nodeBytes ||
+		series.peakNodeBytes !== peak("nodeBytes") ||
+		series.startCombinedBytes !== first.combinedBytes ||
+		series.endCombinedBytes !== last.combinedBytes ||
+		series.peakCombinedBytes !== peak("combinedBytes") ||
+		series.startBrowserProcessCount !== first.browserProcessCount ||
+		series.endBrowserProcessCount !== last.browserProcessCount ||
+		series.peakBrowserProcessCount !== peak("browserProcessCount") ||
+		!isDeepStrictEqual(series.startBrowserRoleBytes, first.browserRoleBytes) ||
+		!isDeepStrictEqual(series.endBrowserRoleBytes, last.browserRoleBytes) ||
+		!isDeepStrictEqual(series.peakBrowserRoleBytes, peakBrowserRoleBytes)
+	) {
+		throw new Error("Benchmark host RSS summaries are inconsistent");
+	}
+	return window;
+};
+
+export const validateDownloadMemoryTelemetry = (
+	result,
+	invocation,
+	readWindow,
+) => {
+	const telemetry = requireRecord(
+		result.downloadMemoryTelemetry,
+		"downloadMemoryTelemetry",
+	);
+	requireExactRecordKeys(
+		telemetry,
+		[
+			"profile",
+			"sampleIntervalMs",
+			"windowDefinition",
+			"maxSamplesPerSeries",
+			"complete",
+			"startedAt",
+			"finishedAt",
+			"readerJsHeap",
+			"writerJsHeap",
+			"hostRss",
+		],
+		"downloadMemoryTelemetry",
+	);
+	const expectedMaxSamples = calculateDownloadMemoryMaxSamples({
+		downloadTimeoutMs: invocation.downloadTimeoutMs,
+		schedulingToleranceMs: Math.max(5_000, invocation.pollMs + 1_000),
+	});
+	if (
+		telemetry.profile !== DOWNLOAD_MEMORY_PROFILE ||
+		telemetry.sampleIntervalMs !== DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS ||
+		telemetry.windowDefinition !== DOWNLOAD_MEMORY_WINDOW_DEFINITION ||
+		telemetry.maxSamplesPerSeries !== expectedMaxSamples ||
+		telemetry.complete !== true
+	) {
+		throw new Error("Benchmark download memory telemetry contract is invalid");
+	}
+	const readerWindow = validateHeapMemorySeries(
+		telemetry.readerJsHeap,
+		"downloadMemoryTelemetry.readerJsHeap",
+		"reader-renderer",
+		expectedMaxSamples,
+		readWindow,
+	);
+	const writerWindow = validateHeapMemorySeries(
+		telemetry.writerJsHeap,
+		"downloadMemoryTelemetry.writerJsHeap",
+		"writer-renderer",
+		expectedMaxSamples,
+		readWindow,
+	);
+	const hostWindow = validateHostRssSeries(
+		telemetry.hostRss,
+		expectedMaxSamples,
+		readWindow,
+	);
+	const expectedStartedAt = Math.min(
+		readerWindow.startedAt,
+		writerWindow.startedAt,
+		hostWindow.startedAt,
+	);
+	const expectedFinishedAt = Math.max(
+		readerWindow.finishedAt,
+		writerWindow.finishedAt,
+		hostWindow.finishedAt,
+	);
+	if (
+		telemetry.startedAt !== expectedStartedAt ||
+		telemetry.finishedAt !== expectedFinishedAt
+	) {
+		throw new Error(
+			"Benchmark download memory telemetry window summary is inconsistent",
+		);
+	}
+	return telemetry;
 };
 
 const validateUploadTimings = (result, invocation) => {
@@ -824,9 +1290,10 @@ const validateUploadTimings = (result, invocation) => {
 			"Measured transfer duration exceeded its requested timeout and scheduling tolerance",
 		);
 	}
-	validateReadTransferEvidence(result, invocation, {
+	return validateReadTransferEvidence(result, invocation, {
 		downloadStartedAt,
 		downloadFinishedAt,
+		downloadCompletionObservedAt,
 	});
 };
 
@@ -2033,7 +2500,12 @@ export const validateBenchmarkResult = (
 			expectedFixtureSeed,
 			expectedInvocation,
 		);
-		validateUploadTimings(result, expectedInvocation);
+		const readWindow = validateUploadTimings(result, expectedInvocation);
+		validateDownloadMemoryTelemetry(
+			result,
+			expectedInvocation,
+			readWindow,
+		);
 		validateRequestedUploadKnobs(result, expectedInvocation);
 		validateZeroErrors(result, "upload result");
 		validateReaderLocalityControl(result, expectedInvocation);

--- a/scripts/file-share/benchmark-validity.test.mjs
+++ b/scripts/file-share/benchmark-validity.test.mjs
@@ -18,6 +18,19 @@ import {
 	validateBenchmarkResult,
 	validateBenchmarkResultEnvelope,
 } from "./benchmark-validity.mjs";
+import {
+	DOWNLOAD_MEMORY_HOST_ATTRIBUTION,
+	DOWNLOAD_MEMORY_HOST_ATTRIBUTION_LIMITATIONS,
+	DOWNLOAD_MEMORY_HOST_SCOPE,
+	DOWNLOAD_MEMORY_MAX_BROWSER_PROCESSES,
+	DOWNLOAD_MEMORY_NODE_SCOPE,
+	DOWNLOAD_MEMORY_PROFILE,
+	DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
+	DOWNLOAD_MEMORY_SETUP_ALLOWANCE_MS,
+	DOWNLOAD_MEMORY_TERMINAL_ALLOWANCE_MS,
+	DOWNLOAD_MEMORY_WINDOW_DEFINITION,
+	calculateDownloadMemoryMaxSamples,
+} from "./templates/download-memory-telemetry.mjs";
 
 const RUN_NONCE = "123e4567-e89b-42d3-a456-426614174000";
 const FILE_NAME = `file-share-benchmark-adaptive-${RUN_NONCE}.bin`;
@@ -100,6 +113,138 @@ const options = {
 	expectedInvocation: INVOCATION,
 };
 
+const createDownloadMemoryTelemetry = (
+	readStartedAt,
+	readFinishedAt,
+	invocation = INVOCATION,
+) => {
+	const maxSamplesPerSeries = calculateDownloadMemoryMaxSamples({
+		downloadTimeoutMs: invocation.downloadTimeoutMs,
+		schedulingToleranceMs: Math.max(5_000, invocation.pollMs + 1_000),
+	});
+	const heap = (scope, startedOffset, finishedOffset, bytes) => ({
+		memoryKind: "javascript-heap",
+		scope,
+		metric: "JSHeapUsedSize",
+		unit: "bytes",
+		sampleIntervalMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
+		startedAt: readStartedAt - startedOffset,
+		finishedAt: readFinishedAt + finishedOffset,
+		sampleCount: 2,
+		startBytes: bytes,
+		endBytes: bytes + 20,
+		peakBytes: bytes + 20,
+		samples: [
+			{ capturedAt: readStartedAt - 1, usedBytes: bytes },
+			{ capturedAt: readFinishedAt + 1, usedBytes: bytes + 20 },
+		],
+		samplingErrors: [],
+		samplingErrorOverflowCount: 0,
+	});
+	const readerJsHeap = heap("reader-renderer", 3, 2, 100);
+	const writerJsHeap = heap("writer-renderer", 2, 3, 200);
+	const hostSamples = [
+		{
+			capturedAt: readStartedAt - 1,
+			browserBytes: 1_000,
+			nodeBytes: 500,
+			combinedBytes: 1_500,
+			browserProcessCount: 2,
+			browserRoleBytes: { browser: 400, renderer: 600 },
+		},
+		{
+			capturedAt: readFinishedAt + 1,
+			browserBytes: 1_200,
+			nodeBytes: 550,
+			combinedBytes: 1_750,
+			browserProcessCount: 3,
+			browserRoleBytes: { browser: 450, renderer: 750 },
+		},
+	];
+	const hostRss = {
+		memoryKind: "resident-set-size",
+		scope: DOWNLOAD_MEMORY_HOST_SCOPE,
+		nodeScope: DOWNLOAD_MEMORY_NODE_SCOPE,
+		metric: "RSS",
+		attribution: DOWNLOAD_MEMORY_HOST_ATTRIBUTION,
+		attributionLimitations: DOWNLOAD_MEMORY_HOST_ATTRIBUTION_LIMITATIONS,
+		unit: "bytes",
+		sampleIntervalMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
+		startedAt: readStartedAt - 1,
+		finishedAt: readFinishedAt + 4,
+		sampleCount: hostSamples.length,
+		startBrowserBytes: 1_000,
+		endBrowserBytes: 1_200,
+		peakBrowserBytes: 1_200,
+		startNodeBytes: 500,
+		endNodeBytes: 550,
+		peakNodeBytes: 550,
+		startCombinedBytes: 1_500,
+		endCombinedBytes: 1_750,
+		peakCombinedBytes: 1_750,
+		startBrowserProcessCount: 2,
+		endBrowserProcessCount: 3,
+		peakBrowserProcessCount: 3,
+		startBrowserRoleBytes: { browser: 400, renderer: 600 },
+		endBrowserRoleBytes: { browser: 450, renderer: 750 },
+		peakBrowserRoleBytes: { browser: 450, renderer: 750 },
+		samples: hostSamples,
+		samplingErrors: [],
+		samplingErrorOverflowCount: 0,
+	};
+	return {
+		profile: DOWNLOAD_MEMORY_PROFILE,
+		sampleIntervalMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
+		windowDefinition: DOWNLOAD_MEMORY_WINDOW_DEFINITION,
+		maxSamplesPerSeries,
+		complete: true,
+		startedAt: readerJsHeap.startedAt,
+		finishedAt: hostRss.finishedAt,
+		readerJsHeap,
+		writerJsHeap,
+		hostRss,
+	};
+};
+
+const shiftTimedDownloadEvidence = (result, offset) => {
+	for (const key of [
+		"downloadStartedAt",
+		"downloadFinishedAt",
+		"downloadCompletionObservedAt",
+	]) {
+		result.timestamps[key] += offset;
+	}
+	const diagnostics = result.readerDiagnostics.lastReadDiagnostics;
+	diagnostics.startedAt += offset;
+	diagnostics.finishedAt += offset;
+	for (const key of [
+		"chunkWriteStartedAt",
+		"chunkWriteFinishedAt",
+		"chunkMaterializeStartedAt",
+		"chunkMaterializeFinishedAt",
+		"chunkHashStartedAt",
+		"chunkHashFinishedAt",
+	]) {
+		for (const index of Object.keys(diagnostics[key])) {
+			diagnostics[key][index] += offset;
+		}
+	}
+	const telemetry = result.downloadMemoryTelemetry;
+	telemetry.startedAt += offset;
+	telemetry.finishedAt += offset;
+	for (const series of [
+		telemetry.readerJsHeap,
+		telemetry.writerJsHeap,
+		telemetry.hostRss,
+	]) {
+		series.startedAt += offset;
+		series.finishedAt += offset;
+		for (const sample of series.samples) {
+			sample.capturedAt += offset;
+		}
+	}
+};
+
 const validResult = () => ({
 	schema: { ...BENCHMARK_RESULT_SCHEMA },
 	runNonce: RUN_NONCE,
@@ -166,6 +311,7 @@ const validResult = () => ({
 		TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION,
 	downloadSink: "hash-only",
 	requestedDownloadSink: "hash-only",
+	downloadMemoryTelemetry: createDownloadMemoryTelemetry(1_170, 1_200),
 	sinkWriteCalls: 2,
 	sinkWriteDurationMs: 8.5,
 	sinkWriteDurationDefinition: SINK_WRITE_DURATION_DEFINITION,
@@ -443,6 +589,11 @@ const createReaderLocalityFixture = ({
 	result.timestamps.downloadStartedAt = 1_400;
 	result.timestamps.downloadFinishedAt = 1_430;
 	result.timestamps.downloadCompletionObservedAt = 1_431;
+	result.downloadMemoryTelemetry = createDownloadMemoryTelemetry(
+		1_400,
+		1_430,
+		invocation,
+	);
 	result.readerLocalityControl = {
 		profile: "observer-topology-persistent-read-preloaded-prefix",
 		requestedYieldedChunkCount: target,
@@ -573,6 +724,160 @@ test("accepts a complete deterministic transfer result", () => {
 		validateBenchmarkResult(validResult(), options).status,
 		"passed",
 	);
+});
+
+test("requires bounded, error-free memory telemetry covering the canonical read", () => {
+	for (const [mutate, pattern] of [
+		[
+			(result) => {
+				delete result.downloadMemoryTelemetry;
+			},
+			/missing downloadMemoryTelemetry/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.complete = false;
+			},
+			/telemetry contract is invalid/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.readerJsHeap.samplingErrors.push("boom");
+			},
+			/contains memory sampling errors/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.readerJsHeap.samplingErrors = Array.from(
+					{ length: 17 },
+					() => "bounded-message",
+				);
+			},
+			/contains unbounded sampling errors/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.readerJsHeap.samplingErrors = [
+					"x".repeat(513),
+				];
+			},
+			/contains unbounded sampling errors/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.readerJsHeap.sampleCount = 3;
+			},
+			/invalid bounded sample series/,
+		],
+		[
+			(result) => {
+				const samples = result.downloadMemoryTelemetry.readerJsHeap.samples;
+				samples[0].capturedAt = 1_199;
+				samples[1].capturedAt = 1_171;
+			},
+			/reorder the sampler window/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.readerJsHeap.samples[0].capturedAt =
+					1_171;
+			},
+			/does not bracket the click-to-sink observation window/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.writerJsHeap.samples[1].capturedAt =
+					1_199;
+			},
+			/does not bracket the click-to-sink observation window/,
+		],
+		[
+			(result) => {
+				shiftTimedDownloadEvidence(result, 100_000);
+				const series = result.downloadMemoryTelemetry.readerJsHeap;
+				series.startedAt =
+					result.timestamps.downloadStartedAt -
+					DOWNLOAD_MEMORY_SETUP_ALLOWANCE_MS -
+					1;
+				series.samples[0].capturedAt = series.startedAt;
+			},
+			/begins before the bounded telemetry setup window/,
+		],
+		[
+			(result) => {
+				const series = result.downloadMemoryTelemetry.writerJsHeap;
+				series.samples[1].capturedAt =
+					result.timestamps.downloadCompletionObservedAt +
+					DOWNLOAD_MEMORY_TERMINAL_ALLOWANCE_MS +
+					1;
+				series.finishedAt = series.samples[1].capturedAt + 1;
+			},
+			/ends after the bounded telemetry cleanup window/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.readerJsHeap.peakBytes += 1;
+			},
+			/heap summaries are inconsistent/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.hostRss.samples[0].combinedBytes += 1;
+			},
+			/RSS totals are inconsistent/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.hostRss.samples[0].browserRoleBytes.renderer +=
+					1;
+			},
+			/RSS totals are inconsistent/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.hostRss.samples[0].browserRoleBytes =
+					Object.fromEntries(
+						Array.from({ length: 33 }, (_, index) => [`role-${index}`, 1]),
+					);
+			},
+			/invalid browser-role count/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.hostRss.samples[0].browserProcessCount =
+					DOWNLOAD_MEMORY_MAX_BROWSER_PROCESSES + 1;
+			},
+			/browser-process count cap/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.finishedAt += 1;
+			},
+			/window summary is inconsistent/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.readerJsHeap.samples[0].unbounded =
+					"x";
+			},
+			/unexpected or missing fields/,
+		],
+		[
+			(result) => {
+				const series = result.downloadMemoryTelemetry.readerJsHeap;
+				series.samples = Array.from(
+					{ length: result.downloadMemoryTelemetry.maxSamplesPerSeries + 1 },
+					() => ({ capturedAt: 1_170, usedBytes: 100 }),
+				);
+				series.sampleCount = series.samples.length;
+			},
+			/invalid bounded sample series/,
+		],
+	]) {
+		const result = validResult();
+		mutate(result);
+		assert.throws(() => validateBenchmarkResult(result, options), pattern);
+	}
 });
 
 test("accepts exact observer-locality control and rejects contradictory evidence", () => {
@@ -944,14 +1249,14 @@ test("bounds Node-file server timing against its browser sink timing", () => {
 	);
 });
 
-test("rejects a status-only passed payload at the v4 evidence envelope", () => {
+test("rejects a status-only passed payload at the v5 evidence envelope", () => {
 	assert.throws(
 		() => validateBenchmarkResultEnvelope({ status: "passed" }, options),
 		/missing schema/,
 	);
 });
 
-test("requires explicit error evidence on failed v4 envelopes", () => {
+test("requires explicit error evidence on failed v5 envelopes", () => {
 	const completeFailure = validResult();
 	completeFailure.status = "failed";
 	completeFailure.failure = { message: "synthetic browser failure" };

--- a/scripts/file-share/download-memory-telemetry.test.mjs
+++ b/scripts/file-share/download-memory-telemetry.test.mjs
@@ -1,0 +1,286 @@
+import assert from "node:assert/strict";
+import { setTimeout as delay } from "node:timers/promises";
+import test from "node:test";
+import {
+	DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH,
+	DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS,
+	DOWNLOAD_MEMORY_MAX_SAMPLES_PER_SERIES,
+	calculateDownloadMemoryMaxSamples,
+	startBoundedSerialSampler,
+	startDownloadMemoryTelemetry,
+	withDownloadMemoryOperationDeadline,
+} from "./templates/download-memory-telemetry.mjs";
+
+test("derives a deadline-bounded sample cap with an absolute result-size ceiling", () => {
+	assert.equal(
+		calculateDownloadMemoryMaxSamples({
+			downloadTimeoutMs: 600_000,
+			schedulingToleranceMs: 5_000,
+		}),
+		123,
+	);
+	assert.equal(
+		calculateDownloadMemoryMaxSamples({
+			downloadTimeoutMs: Number.MAX_SAFE_INTEGER - 10_000,
+			schedulingToleranceMs: 5_000,
+		}),
+		DOWNLOAD_MEMORY_MAX_SAMPLES_PER_SERIES,
+	);
+	assert.throws(
+		() =>
+			calculateDownloadMemoryMaxSamples({
+				downloadTimeoutMs: 0,
+				schedulingToleranceMs: 5_000,
+			}),
+		/bounded timeout values/,
+	);
+});
+
+test("serializes samples, reserves the forced endpoint, and cleans up once", async () => {
+	let active = 0;
+	let peakActive = 0;
+	let cleanupCount = 0;
+	let value = 0;
+	const sampler = await startBoundedSerialSampler({
+		intervalMs: 1,
+		maxSamples: 3,
+		readSample: async () => {
+			active += 1;
+			peakActive = Math.max(peakActive, active);
+			await delay(2);
+			active -= 1;
+			return { value: (value += 1) };
+		},
+		cleanup: async () => {
+			cleanupCount += 1;
+		},
+	});
+	await delay(12);
+	const [firstStop, secondStop] = await Promise.all([
+		sampler.stop(),
+		sampler.stop(),
+	]);
+	assert.deepEqual(firstStop, secondStop);
+	assert.equal(peakActive, 1);
+	assert.equal(cleanupCount, 1);
+	assert.equal(firstStop.samples.length, 3);
+	assert.equal(firstStop.finishedAt >= firstStop.startedAt, true);
+});
+
+test("bounds and truncates repeated sampling failures", async () => {
+	const longMessage = "x".repeat(DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH * 2);
+	const sampler = await startBoundedSerialSampler({
+		intervalMs: 1,
+		maxSamples: 2,
+		readSample: async () => {
+			throw new Error(longMessage);
+		},
+	});
+	await delay(100);
+	const result = await sampler.stop();
+	assert.equal(
+		result.samplingErrors.length,
+		DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS,
+	);
+	assert.equal(result.samplingErrorOverflowCount > 0, true);
+	assert.equal(
+		result.samplingErrors.every(
+			(message) =>
+				message.length === DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH,
+		),
+		true,
+	);
+	assert.deepEqual(result.samples, []);
+});
+
+test("bounds never-settling initial, active, and cleanup operations", async () => {
+	let initialCleanupCount = 0;
+	const initial = await startBoundedSerialSampler({
+		intervalMs: 1,
+		maxSamples: 4,
+		operationTimeoutMs: 5,
+		cleanupTimeoutMs: 5,
+		readSample: async () => await new Promise(() => {}),
+		cleanup: async () => {
+			initialCleanupCount += 1;
+		},
+	});
+	const initialResult = await initial.stop();
+	assert.equal(initialResult.samples.length, 0);
+	assert.equal(initialResult.samplingErrors.length, 1);
+	assert.match(initialResult.samplingErrors[0], /Memory sample exceeded 5ms/);
+	assert.equal(initialCleanupCount, 1);
+
+	let activeCalls = 0;
+	let activeCleanupCount = 0;
+	const active = await startBoundedSerialSampler({
+		intervalMs: 1,
+		maxSamples: 4,
+		operationTimeoutMs: 5,
+		cleanupTimeoutMs: 5,
+		readSample: async () => {
+			activeCalls += 1;
+			return activeCalls === 1 ? { value: 1 } : await new Promise(() => {});
+		},
+		cleanup: async () => {
+			activeCleanupCount += 1;
+		},
+	});
+	await delay(2);
+	const activeResult = await active.stop();
+	await delay(8);
+	assert.equal(activeCalls, 2);
+	assert.equal(activeResult.samples.length, 1);
+	assert.equal(activeResult.samplingErrors.length, 1);
+	assert.equal(activeCleanupCount, 1);
+
+	const cleanup = await startBoundedSerialSampler({
+		intervalMs: 100,
+		maxSamples: 3,
+		operationTimeoutMs: 5,
+		cleanupTimeoutMs: 5,
+		readSample: async () => ({ value: 1 }),
+		cleanup: async () => await new Promise(() => {}),
+	});
+	const cleanupResult = await cleanup.stop();
+	assert.equal(cleanupResult.samples.length, 2);
+	assert.equal(cleanupResult.samplingErrors.length, 1);
+	assert.match(
+		cleanupResult.samplingErrors[0],
+		/Memory sampler cleanup exceeded 5ms/,
+	);
+});
+
+test("absorbs late operation settlement and cleans late-created values", async () => {
+	let lateCleanupCount = 0;
+	await assert.rejects(
+		withDownloadMemoryOperationDeadline(
+			new Promise((resolve) => setTimeout(() => resolve("late"), 12)),
+			"late operation",
+			2,
+			{
+				onLateResolution: async (value) => {
+					assert.equal(value, "late");
+					lateCleanupCount += 1;
+				},
+			},
+		),
+		/late operation exceeded 2ms/,
+	);
+	await assert.rejects(
+		withDownloadMemoryOperationDeadline(
+			new Promise((_, reject) =>
+				setTimeout(() => reject(new Error("late rejection")), 12),
+			),
+			"late rejection",
+			2,
+		),
+		/late rejection exceeded 2ms/,
+	);
+	await delay(20);
+	assert.equal(lateCleanupCount, 1);
+});
+
+test("collects forced endpoint heap and attributed RSS samples", async () => {
+	let detachedPageSessions = 0;
+	let detachedBrowserSessions = 0;
+	const page = (usedBytes) => ({
+		context: () => ({
+			newCDPSession: async () => ({
+				send: async (method) =>
+					method === "Performance.getMetrics"
+						? { metrics: [{ name: "JSHeapUsedSize", value: usedBytes }] }
+						: {},
+				detach: async () => {
+					detachedPageSessions += 1;
+				},
+			}),
+		}),
+	});
+	const browser = {
+		newBrowserCDPSession: async () => ({
+			send: async (method) => {
+				assert.equal(method, "SystemInfo.getProcessInfo");
+				return {
+					processInfo: [{ id: process.pid, type: "browser" }],
+				};
+			},
+			detach: async () => {
+				detachedBrowserSessions += 1;
+			},
+		}),
+	};
+	const telemetry = await startDownloadMemoryTelemetry({
+		browser,
+		reader: page(100),
+		writer: page(200),
+		downloadTimeoutMs: 60_000,
+		schedulingToleranceMs: 5_000,
+	});
+	const result = await telemetry.stop();
+	assert.equal(result.complete, true);
+	assert.equal(result.readerJsHeap.sampleCount, 2);
+	assert.equal(result.writerJsHeap.sampleCount, 2);
+	assert.equal(result.hostRss.sampleCount, 2);
+	assert.equal(result.hostRss.samples[0].browserBytes > 0, true);
+	assert.equal(
+		result.hostRss.samples[0].combinedBytes,
+		result.hostRss.samples[0].browserBytes +
+			result.hostRss.samples[0].nodeBytes,
+	);
+	assert.equal(detachedPageSessions, 2);
+	assert.equal(detachedBrowserSessions, 1);
+});
+
+test("bounds setup and detaches a CDP session created after its deadline", async () => {
+	let lateDetachCount = 0;
+	const session = (usedBytes, onDetach = () => {}) => ({
+		send: async (method) =>
+			method === "Performance.getMetrics"
+				? { metrics: [{ name: "JSHeapUsedSize", value: usedBytes }] }
+				: {},
+		detach: async () => onDetach(),
+	});
+	const lateReaderSession = session(100, () => {
+		lateDetachCount += 1;
+	});
+	const reader = {
+		context: () => ({
+			newCDPSession: async () =>
+				await new Promise((resolve) =>
+					setTimeout(() => resolve(lateReaderSession), 15),
+				),
+		}),
+	};
+	const writer = {
+		context: () => ({
+			newCDPSession: async () => session(200),
+		}),
+	};
+	const browser = {
+		newBrowserCDPSession: async () => ({
+			send: async () => ({
+				processInfo: [{ id: process.pid, type: "browser" }],
+			}),
+			detach: async () => {},
+		}),
+	};
+	const telemetry = await startDownloadMemoryTelemetry({
+		browser,
+		reader,
+		writer,
+		downloadTimeoutMs: 60_000,
+		schedulingToleranceMs: 5_000,
+		operationTimeoutMs: 3,
+		cleanupTimeoutMs: 8,
+	});
+	assert.equal(
+		telemetry.snapshot().readerJsHeap.samplingErrors.some((message) =>
+			message.includes("CDP session creation exceeded 3ms"),
+		),
+		true,
+	);
+	await telemetry.stop();
+	await delay(25);
+	assert.equal(lateDetachCount, 1);
+});

--- a/scripts/file-share/run-file-share-benchmark.mjs
+++ b/scripts/file-share/run-file-share-benchmark.mjs
@@ -78,6 +78,19 @@ const SCENARIOS = {
 					"scripts",
 					"file-share",
 					"templates",
+					"download-memory-telemetry.mjs",
+				),
+				generatedPath: path.join(
+					"tests",
+					"generated.download-memory-telemetry.mjs",
+				),
+			},
+			{
+				templatePath: path.join(
+					repoRoot,
+					"scripts",
+					"file-share",
+					"templates",
 					"promise-deadline.mjs",
 				),
 				generatedPath: path.join("tests", "generated.promise-deadline.mjs"),

--- a/scripts/file-share/template-contract.test.mjs
+++ b/scripts/file-share/template-contract.test.mjs
@@ -17,14 +17,14 @@ const templates = [
 ];
 
 for (const name of templates) {
-	test(`${name} emits the atomic v4 invocation envelope`, async () => {
+	test(`${name} emits the atomic v5 result envelope`, async () => {
 		const contents = await readFile(
 			path.join(repoRoot, "scripts", "file-share", "templates", name),
 			"utf8",
 		);
 		for (const required of [
 			'id: "peerbit-file-share-benchmark"',
-			"version: 4",
+			"version: 5",
 			"PW_BENCHMARK_RUN_NONCE",
 			"PW_BENCHMARK_INVOCATION",
 			"PW_BENCHMARK_PROVENANCE",
@@ -154,6 +154,7 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"summarizeReadTransferDiagnostics",
 		"libraryComputedSha256Base64",
 		'import { withDeadline } from "./generated.promise-deadline.mjs"',
+		'import { startDownloadMemoryTelemetry } from "./generated.download-memory-telemetry.mjs"',
 		"UPLOAD_TIMEOUT_MS +",
 		"READY_TIMEOUT_MS +",
 		"const boundedReaderListedPromise =",
@@ -206,6 +207,12 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		'readerLocalityControl.status = "complete"',
 		"exact contiguous prefix",
 		"unexpectedSeederDrop",
+		"downloadMemoryTelemetryController =",
+		"downloadMemoryTelemetryController.snapshot()",
+		"await downloadMemoryTelemetryController.stop()",
+		"downloadMemoryTelemetry.complete !== true",
+		"series.samplingErrors.length > 0",
+		"downloadMemoryTelemetry,",
 	]) {
 		assert.ok(contents.includes(required), `missing ${required}`);
 	}
@@ -238,6 +245,22 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 	assert.ok(
 		!contents.includes('MODE === "adaptive" ? "2" : "0"'),
 		"the template must not redefine mode-specific ready-seeder defaults",
+	);
+	assert.ok(
+		contents.indexOf("downloadMemoryTelemetryController =") <
+			contents.indexOf("const initialMemorySeries =") &&
+			contents.indexOf("const initialMemorySeries =") <
+				contents.indexOf("const downloadCompletion = armSavedViaPicker(") &&
+			contents.indexOf("const downloadCompletion = armSavedViaPicker(") <
+				contents.indexOf("const downloadClickStartedAt = Date.now()"),
+		"memory telemetry must collect clean initial samples before the sink waiter is armed and the timed click begins",
+	);
+	assert.ok(
+		contents.indexOf("const download = await downloadCompletion") <
+			contents.indexOf("await downloadMemoryTelemetryController.stop()") &&
+			contents.indexOf("await downloadMemoryTelemetryController.stop()") <
+				contents.indexOf('stage = "verify-integrity"'),
+		"memory telemetry must stop at sink completion before integrity and topology work",
 	);
 	assert.ok(
 		!contents.includes("MIN_READY_SEEDERS, 180_000"),
@@ -499,6 +522,7 @@ test("aggregate comparisons require every planned invocation to pass", async () 
 		"if (comparison)",
 		'generatedPath: path.join("tests", "generated.promise-deadline.mjs")',
 		'generatedPath: path.join("tests", "generated.opfs-readback.mjs")',
+		'"generated.download-memory-telemetry.mjs"',
 		"scenarioConfig.supportFiles ?? []",
 	]) {
 		assert.ok(standalone.includes(required), `standalone missing ${required}`);
@@ -533,6 +557,56 @@ test("aggregate comparisons require every planned invocation to pass", async () 
 	]) {
 		assert.ok(matrix.includes(required), `matrix missing ${required}`);
 	}
+});
+
+test("download memory support is bounded, serial, and cleanup-safe", async () => {
+	const contents = await readFile(
+		path.join(
+			repoRoot,
+			"scripts",
+			"file-share",
+			"templates",
+			"download-memory-telemetry.mjs",
+		),
+		"utf8",
+	);
+	for (const required of [
+		'DOWNLOAD_MEMORY_PROFILE = "download-memory-v1"',
+		"DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS = 5_000",
+		"DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS = 4_000",
+		"DOWNLOAD_MEMORY_CLEANUP_TIMEOUT_MS = 9_000",
+		"DOWNLOAD_MEMORY_SETUP_ALLOWANCE_MS = 30_000",
+		"DOWNLOAD_MEMORY_TERMINAL_ALLOWANCE_MS = 30_000",
+		"DOWNLOAD_MEMORY_MAX_SAMPLES_PER_SERIES = 4_096",
+		"DOWNLOAD_MEMORY_MAX_BROWSER_PROCESSES = 256",
+		"DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS = 16",
+		"DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH = 512",
+		"startBoundedSerialSampler",
+		"withDownloadMemoryOperationDeadline",
+		"onLateResolution",
+		"terminalSampleFailure = true",
+		"samples.length >= maxSamples - 1",
+		"await activeSample",
+		"await takeSample(true)",
+		'newCDPSession(page)',
+		'"Page JS heap CDP session creation"',
+		'Performance.getMetrics',
+		'metric.name === "JSHeapUsedSize"',
+		"newBrowserCDPSession()",
+		'"Browser RSS CDP session creation"',
+		'SystemInfo.getProcessInfo',
+		'"ps"',
+		"process.memoryUsage().rss",
+		"playwright-worker-node-including-in-process-local-bootstrap",
+		"samplingErrorOverflowCount",
+	]) {
+		assert.ok(contents.includes(required), `memory support missing ${required}`);
+	}
+	assert.ok(
+		contents.indexOf("await activeSample") <
+			contents.indexOf("await takeSample(true)"),
+		"stop must drain an active sample before the forced terminal sample",
+	);
 });
 
 test("matrix fail-closes every result envelope and fully validates passes", async () => {

--- a/scripts/file-share/templates/download-memory-telemetry.mjs
+++ b/scripts/file-share/templates/download-memory-telemetry.mjs
@@ -1,0 +1,641 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export const DOWNLOAD_MEMORY_PROFILE = "download-memory-v1";
+export const DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS = 5_000;
+export const DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS = 4_000;
+export const DOWNLOAD_MEMORY_CLEANUP_TIMEOUT_MS = 9_000;
+export const DOWNLOAD_MEMORY_SETUP_ALLOWANCE_MS = 30_000;
+export const DOWNLOAD_MEMORY_TERMINAL_ALLOWANCE_MS = 30_000;
+export const DOWNLOAD_MEMORY_WINDOW_DEFINITION =
+	"samplers-armed-after-reader-locality-stabilization-immediately-before-download-click-through-selected-sink-completion";
+export const DOWNLOAD_MEMORY_MAX_SAMPLES_PER_SERIES = 4_096;
+export const DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE = 2;
+export const DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS = 16;
+export const DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH = 512;
+export const DOWNLOAD_MEMORY_MAX_BROWSER_ROLES = 32;
+export const DOWNLOAD_MEMORY_MAX_BROWSER_PROCESSES = 256;
+export const DOWNLOAD_MEMORY_MAX_BROWSER_ROLE_NAME_LENGTH = 128;
+export const DOWNLOAD_MEMORY_HOST_ATTRIBUTION =
+	"aggregate-rss-with-chromium-process-role-groups";
+export const DOWNLOAD_MEMORY_HOST_SCOPE =
+	"chromium-processes-and-playwright-worker-node";
+export const DOWNLOAD_MEMORY_NODE_SCOPE =
+	"playwright-worker-node-including-in-process-local-bootstrap";
+export const DOWNLOAD_MEMORY_HOST_ATTRIBUTION_LIMITATIONS =
+	"Chromium RSS is grouped by process role and cannot be attributed reliably to the reader or writer page; Node RSS is the Playwright worker process and includes the in-process bootstrap peer in local mode; RSS is not PSS or USS.";
+
+export const calculateDownloadMemoryMaxSamples = ({
+	downloadTimeoutMs,
+	schedulingToleranceMs,
+}) => {
+	if (
+		!Number.isSafeInteger(downloadTimeoutMs) ||
+		downloadTimeoutMs <= 0 ||
+		!Number.isSafeInteger(schedulingToleranceMs) ||
+		schedulingToleranceMs < 0
+	) {
+		throw new Error("Download memory sampling requires bounded timeout values");
+	}
+	return Math.min(
+		DOWNLOAD_MEMORY_MAX_SAMPLES_PER_SERIES,
+		Math.ceil(
+			(downloadTimeoutMs + schedulingToleranceMs) /
+				DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
+		) + DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE,
+	);
+};
+
+const cloneValue = (value) => structuredClone(value);
+
+const boundedErrorMessage = (error) => {
+	const message = error instanceof Error ? error.message : String(error);
+	return message.slice(0, DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH);
+};
+
+export const withDownloadMemoryOperationDeadline = async (
+	operation,
+	label,
+	timeoutMs = DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS,
+	{ onLateResolution } = {},
+) => {
+	if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+		throw new Error("Memory operation timeout must be a positive safe integer");
+	}
+	return await new Promise((resolve, reject) => {
+		let settled = false;
+		const timer = setTimeout(() => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			const error = new Error(`${label} exceeded ${timeoutMs}ms`);
+			error.code = "DOWNLOAD_MEMORY_OPERATION_TIMEOUT";
+			reject(error);
+		}, timeoutMs);
+		Promise.resolve(operation).then(
+			(value) => {
+				if (settled) {
+					Promise.resolve()
+						.then(() => onLateResolution?.(value))
+						.catch(() => {});
+					return;
+				}
+				settled = true;
+				clearTimeout(timer);
+				resolve(value);
+			},
+			(error) => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				clearTimeout(timer);
+				reject(error);
+			},
+		);
+	});
+};
+
+/**
+ * Runs one sample at a time, reserves one bounded slot for the forced terminal
+ * sample, and makes stop idempotent. Errors are evidence rather than detached
+ * promise rejections, and are themselves bounded so a failed probe cannot make
+ * the benchmark result grow without limit.
+ */
+export const startBoundedSerialSampler = async ({
+	intervalMs,
+	maxSamples,
+	readSample,
+	cleanup = async () => {},
+	operationTimeoutMs = DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS,
+	cleanupTimeoutMs = DOWNLOAD_MEMORY_CLEANUP_TIMEOUT_MS,
+	now = Date.now,
+	setTimer = setTimeout,
+	clearTimer = clearTimeout,
+}) => {
+	if (!Number.isSafeInteger(intervalMs) || intervalMs <= 0) {
+		throw new Error("Serial sampler interval must be a positive safe integer");
+	}
+	if (!Number.isSafeInteger(maxSamples) || maxSamples < 2) {
+		throw new Error("Serial sampler must reserve initial and final samples");
+	}
+	if (typeof readSample !== "function" || typeof cleanup !== "function") {
+		throw new Error("Serial sampler requires read and cleanup functions");
+	}
+	if (
+		!Number.isSafeInteger(operationTimeoutMs) ||
+		operationTimeoutMs <= 0 ||
+		!Number.isSafeInteger(cleanupTimeoutMs) ||
+		cleanupTimeoutMs <= 0
+	) {
+		throw new Error("Serial sampler operation deadlines must be positive");
+	}
+
+	const startedAt = now();
+	const samples = [];
+	const samplingErrors = [];
+	let samplingErrorOverflowCount = 0;
+	let finishedAt = null;
+	let timer;
+	let activeSample;
+	let stopped = false;
+	let terminalSampleFailure = false;
+	let stopPromise;
+
+	const recordError = (error) => {
+		if (samplingErrors.length < DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS) {
+			samplingErrors.push(boundedErrorMessage(error));
+		} else {
+			samplingErrorOverflowCount += 1;
+		}
+	};
+
+	const takeSample = async (forceTerminal = false) => {
+		const limit = forceTerminal ? maxSamples : maxSamples - 1;
+		if (samples.length >= limit || terminalSampleFailure) {
+			return;
+		}
+		try {
+			const values = await withDownloadMemoryOperationDeadline(
+				Promise.resolve().then(() => readSample()),
+				"Memory sample",
+				operationTimeoutMs,
+			);
+			if (values == null || typeof values !== "object" || Array.isArray(values)) {
+				throw new Error("Memory sampler returned a non-object sample");
+			}
+			samples.push({ capturedAt: now(), ...values });
+		} catch (error) {
+			recordError(error);
+			if (error?.code === "DOWNLOAD_MEMORY_OPERATION_TIMEOUT") {
+				terminalSampleFailure = true;
+			}
+		}
+	};
+
+	const schedule = () => {
+		if (
+			stopped ||
+			terminalSampleFailure ||
+			samples.length >= maxSamples - 1
+		) {
+			return;
+		}
+		timer = setTimer(() => {
+			activeSample = takeSample()
+				.catch(recordError)
+				.finally(() => {
+					activeSample = undefined;
+					schedule();
+				});
+		}, intervalMs);
+	};
+
+	const snapshot = () => ({
+		startedAt,
+		finishedAt,
+		samples: cloneValue(samples),
+		samplingErrors: [...samplingErrors],
+		samplingErrorOverflowCount,
+	});
+
+	await takeSample();
+	schedule();
+
+	return {
+		snapshot,
+		stop: () => {
+			if (stopPromise) {
+				return stopPromise;
+			}
+			stopped = true;
+			stopPromise = (async () => {
+				if (timer !== undefined) {
+					clearTimer(timer);
+					timer = undefined;
+				}
+				await activeSample;
+				await takeSample(true);
+				try {
+					await withDownloadMemoryOperationDeadline(
+						Promise.resolve().then(() => cleanup()),
+						"Memory sampler cleanup",
+						cleanupTimeoutMs,
+					);
+				} catch (error) {
+					recordError(error);
+				}
+				finishedAt = now();
+				return snapshot();
+			})();
+			return stopPromise;
+		},
+	};
+};
+
+const summarizeHeap = (scope, state) => {
+	const usedBytes = state.samples.map((sample) => sample.usedBytes);
+	return {
+		memoryKind: "javascript-heap",
+		scope,
+		metric: "JSHeapUsedSize",
+		unit: "bytes",
+		sampleIntervalMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
+		startedAt: state.startedAt,
+		finishedAt: state.finishedAt,
+		sampleCount: state.samples.length,
+		startBytes: usedBytes[0] ?? null,
+		endBytes: usedBytes.at(-1) ?? null,
+		peakBytes: usedBytes.length > 0 ? Math.max(...usedBytes) : null,
+		samples: state.samples,
+		samplingErrors: state.samplingErrors,
+		samplingErrorOverflowCount: state.samplingErrorOverflowCount,
+	};
+};
+
+const startPageJsHeapSampler = async ({
+	page,
+	scope,
+	maxSamples,
+	operationTimeoutMs,
+	cleanupTimeoutMs,
+}) => {
+	let session;
+	let setupError;
+	try {
+		session = await withDownloadMemoryOperationDeadline(
+			page.context().newCDPSession(page),
+			"Page JS heap CDP session creation",
+			operationTimeoutMs,
+			{
+				onLateResolution: async (lateSession) => {
+					await withDownloadMemoryOperationDeadline(
+						lateSession.detach(),
+						"Late page JS heap CDP detach",
+						operationTimeoutMs,
+					);
+				},
+			},
+		);
+		await withDownloadMemoryOperationDeadline(
+			session.send("Performance.enable"),
+			"Page JS heap Performance.enable",
+			operationTimeoutMs,
+		);
+	} catch (error) {
+		setupError = error;
+	}
+	const sampler = await startBoundedSerialSampler({
+		intervalMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
+		maxSamples,
+		operationTimeoutMs,
+		cleanupTimeoutMs,
+		readSample: async () => {
+			if (setupError) {
+				throw setupError;
+			}
+			if (!session) {
+				throw new Error("Page JS heap CDP session is unavailable");
+			}
+			const response = await session.send("Performance.getMetrics");
+			const heapMetric = response.metrics.find(
+				(metric) => metric.name === "JSHeapUsedSize",
+			);
+			if (
+				!heapMetric ||
+				!Number.isFinite(heapMetric.value) ||
+				heapMetric.value < 0
+			) {
+				throw new Error("Performance.getMetrics omitted JSHeapUsedSize");
+			}
+			return { usedBytes: heapMetric.value };
+		},
+		cleanup: async () => {
+			if (!session) {
+				return;
+			}
+			const cleanupErrors = [];
+			try {
+				await withDownloadMemoryOperationDeadline(
+					session.send("Performance.disable"),
+					"Page JS heap Performance.disable",
+					operationTimeoutMs,
+				);
+			} catch (error) {
+				cleanupErrors.push(boundedErrorMessage(error));
+			}
+			try {
+				await withDownloadMemoryOperationDeadline(
+					session.detach(),
+					"Page JS heap CDP detach",
+					operationTimeoutMs,
+				);
+			} catch (error) {
+				cleanupErrors.push(boundedErrorMessage(error));
+			} finally {
+				session = undefined;
+			}
+			if (cleanupErrors.length > 0) {
+				throw new Error(cleanupErrors.join("; "));
+			}
+		},
+	});
+	return {
+		snapshot: () => summarizeHeap(scope, sampler.snapshot()),
+		stop: async () => summarizeHeap(scope, await sampler.stop()),
+	};
+};
+
+const readProcessRssBytes = async (processIds) => {
+	if (processIds.length === 0) {
+		throw new Error("Chromium did not expose operating-system process IDs");
+	}
+	const { stdout } = await execFileAsync(
+		"ps",
+		["-o", "pid=,rss=", "-p", processIds.join(",")],
+		{
+			maxBuffer: 1024 * 1024,
+			timeout: DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS,
+		},
+	);
+	const processBytes = new Map();
+	for (const line of String(stdout).trim().split(/\n+/).filter(Boolean)) {
+		const [processId, rssKiB, ...extra] = line.trim().split(/\s+/).map(Number);
+		if (
+			extra.length !== 0 ||
+			!Number.isSafeInteger(processId) ||
+			processId <= 0 ||
+			!Number.isFinite(rssKiB) ||
+			rssKiB <= 0
+		) {
+			throw new Error("ps did not return valid Chromium RSS values");
+		}
+		const rssBytes = rssKiB * 1024;
+		if (!Number.isSafeInteger(rssBytes) || rssBytes <= 0) {
+			throw new Error("ps returned Chromium RSS outside the safe byte range");
+		}
+		processBytes.set(processId, rssBytes);
+	}
+	if (processBytes.size === 0) {
+		throw new Error("ps did not return Chromium RSS values");
+	}
+	return processBytes;
+};
+
+const summarizeHostRss = (state) => {
+	const first = state.samples[0] ?? null;
+	const last = state.samples.at(-1) ?? null;
+	const peak = (name) =>
+		state.samples.length > 0
+			? Math.max(...state.samples.map((sample) => sample[name]))
+			: null;
+	const peakBrowserRoleBytes = {};
+	for (const sample of state.samples) {
+		for (const [role, bytes] of Object.entries(sample.browserRoleBytes)) {
+			peakBrowserRoleBytes[role] = Math.max(
+				peakBrowserRoleBytes[role] ?? 0,
+				bytes,
+			);
+		}
+	}
+	return {
+		memoryKind: "resident-set-size",
+		scope: DOWNLOAD_MEMORY_HOST_SCOPE,
+		nodeScope: DOWNLOAD_MEMORY_NODE_SCOPE,
+		metric: "RSS",
+		attribution: DOWNLOAD_MEMORY_HOST_ATTRIBUTION,
+		attributionLimitations: DOWNLOAD_MEMORY_HOST_ATTRIBUTION_LIMITATIONS,
+		unit: "bytes",
+		sampleIntervalMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
+		startedAt: state.startedAt,
+		finishedAt: state.finishedAt,
+		sampleCount: state.samples.length,
+		startBrowserBytes: first?.browserBytes ?? null,
+		endBrowserBytes: last?.browserBytes ?? null,
+		peakBrowserBytes: peak("browserBytes"),
+		startNodeBytes: first?.nodeBytes ?? null,
+		endNodeBytes: last?.nodeBytes ?? null,
+		peakNodeBytes: peak("nodeBytes"),
+		startCombinedBytes: first?.combinedBytes ?? null,
+		endCombinedBytes: last?.combinedBytes ?? null,
+		peakCombinedBytes: peak("combinedBytes"),
+		startBrowserProcessCount: first?.browserProcessCount ?? null,
+		endBrowserProcessCount: last?.browserProcessCount ?? null,
+		peakBrowserProcessCount: peak("browserProcessCount"),
+		startBrowserRoleBytes: first
+			? cloneValue(first.browserRoleBytes)
+			: null,
+		endBrowserRoleBytes: last ? cloneValue(last.browserRoleBytes) : null,
+		peakBrowserRoleBytes,
+		samples: state.samples,
+		samplingErrors: state.samplingErrors,
+		samplingErrorOverflowCount: state.samplingErrorOverflowCount,
+	};
+};
+
+const startHostRssSampler = async ({
+	browser,
+	maxSamples,
+	operationTimeoutMs,
+	cleanupTimeoutMs,
+}) => {
+	let session;
+	let setupError;
+	try {
+		session = await withDownloadMemoryOperationDeadline(
+			browser.newBrowserCDPSession(),
+			"Browser RSS CDP session creation",
+			operationTimeoutMs,
+			{
+				onLateResolution: async (lateSession) => {
+					await withDownloadMemoryOperationDeadline(
+						lateSession.detach(),
+						"Late browser RSS CDP detach",
+						operationTimeoutMs,
+					);
+				},
+			},
+		);
+	} catch (error) {
+		setupError = error;
+	}
+	const sampler = await startBoundedSerialSampler({
+		intervalMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
+		maxSamples,
+		operationTimeoutMs,
+		cleanupTimeoutMs,
+		readSample: async () => {
+			if (setupError) {
+				throw setupError;
+			}
+			if (!session) {
+				throw new Error("Browser RSS CDP session is unavailable");
+			}
+			const { processInfo } = await session.send("SystemInfo.getProcessInfo");
+			const processIds = [
+				...new Set(
+					processInfo
+						.map((process) => Number(process.id))
+						.filter(
+							(processId) =>
+								Number.isSafeInteger(processId) && processId > 0,
+						),
+				),
+			];
+			if (processIds.length > DOWNLOAD_MEMORY_MAX_BROWSER_PROCESSES) {
+				throw new Error("Chromium process count exceeds the telemetry cap");
+			}
+			const browserProcessBytes = await readProcessRssBytes(processIds);
+			const nodeBytes = process.memoryUsage().rss;
+			if (!Number.isSafeInteger(nodeBytes) || nodeBytes <= 0) {
+				throw new Error("Playwright worker returned invalid Node RSS");
+			}
+			const browserRoleBytes = {};
+			for (const processEntry of processInfo) {
+				const bytes = browserProcessBytes.get(Number(processEntry.id));
+				if (bytes == null) {
+					continue;
+				}
+				const role = String(processEntry.type || "unknown");
+				if (
+					role.length === 0 ||
+					role.length > DOWNLOAD_MEMORY_MAX_BROWSER_ROLE_NAME_LENGTH ||
+					!/^[\x20-\x7e]+$/.test(role)
+				) {
+					throw new Error("Chromium exposed an invalid process role name");
+				}
+				browserRoleBytes[role] = (browserRoleBytes[role] ?? 0) + bytes;
+			}
+			if (
+				Object.keys(browserRoleBytes).length === 0 ||
+				Object.keys(browserRoleBytes).length >
+					DOWNLOAD_MEMORY_MAX_BROWSER_ROLES
+			) {
+				throw new Error("Chromium process-role attribution is unbounded");
+			}
+			const browserBytes = Object.values(browserRoleBytes).reduce(
+				(total, bytes) => total + bytes,
+				0,
+			);
+			if (
+				!Number.isSafeInteger(browserBytes) ||
+				!Number.isSafeInteger(browserBytes + nodeBytes)
+			) {
+				throw new Error("Host RSS totals exceed the safe byte range");
+			}
+			return {
+				browserBytes,
+				nodeBytes,
+				combinedBytes: browserBytes + nodeBytes,
+				browserProcessCount: browserProcessBytes.size,
+				browserRoleBytes,
+			};
+		},
+		cleanup: async () => {
+			if (session) {
+				try {
+					await withDownloadMemoryOperationDeadline(
+						session.detach(),
+						"Browser RSS CDP detach",
+						operationTimeoutMs,
+					);
+				} finally {
+					session = undefined;
+				}
+			}
+		},
+	});
+	return {
+		snapshot: () => summarizeHostRss(sampler.snapshot()),
+		stop: async () => summarizeHostRss(await sampler.stop()),
+	};
+};
+
+export const startDownloadMemoryTelemetry = async ({
+	browser,
+	reader,
+	writer,
+	downloadTimeoutMs,
+	schedulingToleranceMs,
+	operationTimeoutMs = DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS,
+	cleanupTimeoutMs = DOWNLOAD_MEMORY_CLEANUP_TIMEOUT_MS,
+}) => {
+	const maxSamplesPerSeries = calculateDownloadMemoryMaxSamples({
+		downloadTimeoutMs,
+		schedulingToleranceMs,
+	});
+	const [readerSampler, writerSampler, hostSampler] = await Promise.all([
+		startPageJsHeapSampler({
+			page: reader,
+			scope: "reader-renderer",
+			maxSamples: maxSamplesPerSeries,
+			operationTimeoutMs,
+			cleanupTimeoutMs,
+		}),
+		startPageJsHeapSampler({
+			page: writer,
+			scope: "writer-renderer",
+			maxSamples: maxSamplesPerSeries,
+			operationTimeoutMs,
+			cleanupTimeoutMs,
+		}),
+		startHostRssSampler({
+			browser,
+			maxSamples: maxSamplesPerSeries,
+			operationTimeoutMs,
+			cleanupTimeoutMs,
+		}),
+	]);
+	let complete = false;
+	let stopPromise;
+	const build = ({ readerJsHeap, writerJsHeap, hostRss }) => ({
+		profile: DOWNLOAD_MEMORY_PROFILE,
+		sampleIntervalMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
+		windowDefinition: DOWNLOAD_MEMORY_WINDOW_DEFINITION,
+		maxSamplesPerSeries,
+		complete,
+		startedAt: Math.min(
+			readerJsHeap.startedAt,
+			writerJsHeap.startedAt,
+			hostRss.startedAt,
+		),
+		finishedAt:
+			readerJsHeap.finishedAt == null ||
+			writerJsHeap.finishedAt == null ||
+			hostRss.finishedAt == null
+				? null
+				: Math.max(
+						readerJsHeap.finishedAt,
+						writerJsHeap.finishedAt,
+						hostRss.finishedAt,
+					),
+		readerJsHeap,
+		writerJsHeap,
+		hostRss,
+	});
+	return {
+		snapshot: () =>
+			build({
+				readerJsHeap: readerSampler.snapshot(),
+				writerJsHeap: writerSampler.snapshot(),
+				hostRss: hostSampler.snapshot(),
+			}),
+		stop: () => {
+			if (stopPromise) {
+				return stopPromise;
+			}
+			stopPromise = Promise.all([
+				readerSampler.stop(),
+				writerSampler.stop(),
+				hostSampler.stop(),
+			]).then(([readerJsHeap, writerJsHeap, hostRss]) => {
+				complete = true;
+				return build({ readerJsHeap, writerJsHeap, hostRss });
+			});
+			return stopPromise;
+		},
+	};
+};

--- a/scripts/file-share/templates/seeder-probe.e2e.spec.ts
+++ b/scripts/file-share/templates/seeder-probe.e2e.spec.ts
@@ -24,7 +24,7 @@ const EFFECTIVE_SAMPLE_INTERVAL_MS = Math.max(
 );
 const RESULT_SCHEMA = {
 	id: "peerbit-file-share-benchmark",
-	version: 4,
+	version: 5,
 } as const;
 const RUN_NONCE = process.env.PW_BENCHMARK_RUN_NONCE;
 const parseJsonEnvironment = (name: string) => {

--- a/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
+++ b/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { startBootstrapPeer } from "./bootstrapPeer";
 import { sha256AndCrc32OpfsSavedViaPicker } from "./generated.opfs-readback.mjs";
 import { withDeadline } from "./generated.promise-deadline.mjs";
+import { startDownloadMemoryTelemetry } from "./generated.download-memory-telemetry.mjs";
 import {
 	armSavedViaPicker,
 	crc32SavedViaPicker,
@@ -112,7 +113,7 @@ const FIXTURE_SEED =
 	process.env.PW_FIXTURE_SEED || "peerbit-file-share-benchmark-v1";
 const RESULT_SCHEMA = {
 	id: "peerbit-file-share-benchmark",
-	version: 4,
+	version: 5,
 } as const;
 const RUN_NONCE = process.env.PW_BENCHMARK_RUN_NONCE;
 const parseJsonEnvironment = (name: string) => {
@@ -775,6 +776,10 @@ test.describe("generated transfer-validity benchmark", () => {
 			| Awaited<ReturnType<typeof createSyntheticFileOnDisk>>
 			| undefined;
 		let cleanupDownload: (() => Promise<void>) | undefined;
+		let downloadMemoryTelemetryController:
+			| Awaited<ReturnType<typeof startDownloadMemoryTelemetry>>
+			| undefined;
+		let downloadMemoryTelemetry: Record<string, any> | null = null;
 		let nodeSinkController:
 			| Awaited<ReturnType<typeof installNodeBackedMockSaveFilePicker>>
 			| undefined;
@@ -1518,6 +1523,34 @@ test.describe("generated transfer-validity benchmark", () => {
 			await expect(downloadButton).toBeEnabled({
 				timeout: DOWNLOAD_TIMEOUT_MS,
 			});
+			downloadMemoryTelemetryController =
+				await startDownloadMemoryTelemetry({
+					browser,
+					reader,
+					writer,
+					downloadTimeoutMs: DOWNLOAD_TIMEOUT_MS,
+					schedulingToleranceMs:
+						TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS,
+				});
+			downloadMemoryTelemetry =
+				downloadMemoryTelemetryController.snapshot();
+			const initialMemorySeries = [
+				downloadMemoryTelemetry.readerJsHeap,
+				downloadMemoryTelemetry.writerJsHeap,
+				downloadMemoryTelemetry.hostRss,
+			];
+			if (
+				initialMemorySeries.some(
+					(series) =>
+						series.sampleCount < 1 ||
+						series.samplingErrors.length > 0 ||
+						series.samplingErrorOverflowCount !== 0,
+				)
+			) {
+				throw new Error(
+					"Download memory telemetry did not collect clean initial samples",
+				);
+			}
 			const downloadCompletion = armSavedViaPicker(
 				reader,
 				fileName,
@@ -1529,6 +1562,27 @@ test.describe("generated transfer-validity benchmark", () => {
 			await downloadButton.click();
 			const download = await downloadCompletion;
 			downloadCompletionObservedAt = Date.now();
+			downloadMemoryTelemetry =
+				await downloadMemoryTelemetryController.stop();
+			const memorySeries = [
+				downloadMemoryTelemetry.readerJsHeap,
+				downloadMemoryTelemetry.writerJsHeap,
+				downloadMemoryTelemetry.hostRss,
+			];
+			if (
+				downloadMemoryTelemetry.complete !== true ||
+				downloadMemoryTelemetry.finishedAt == null ||
+				memorySeries.some(
+					(series) =>
+						series.sampleCount < 2 ||
+						series.samplingErrors.length > 0 ||
+						series.samplingErrorOverflowCount !== 0,
+				)
+			) {
+				throw new Error(
+					"Download memory telemetry did not complete without sampling errors",
+				);
+			}
 			if (
 				!Number.isSafeInteger(download.sinkCompletedAt) ||
 				download.sinkCompletedAt < downloadClickStartedAt ||
@@ -1916,6 +1970,7 @@ test.describe("generated transfer-validity benchmark", () => {
 					TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION,
 				downloadSink: download.sink,
 				requestedDownloadSink: DOWNLOAD_SINK,
+				downloadMemoryTelemetry,
 				sinkWriteCalls: download.sinkWriteCalls,
 				sinkWriteDurationMs: download.sinkWriteDurationMs,
 				sinkWriteDurationDefinition: SINK_WRITE_DURATION_DEFINITION,
@@ -1983,6 +2038,10 @@ test.describe("generated transfer-validity benchmark", () => {
 			await persistResult(result);
 			console.log(`FILE_SHARE_BENCHMARK_RESULT ${JSON.stringify(result)}`);
 		} catch (error: any) {
+			if (downloadMemoryTelemetryController) {
+				downloadMemoryTelemetry =
+					await downloadMemoryTelemetryController.stop();
+			}
 			if (readerLocalityControl) {
 				readerLocalityControl.status = "failed";
 				readerLocalityControl.failure =
@@ -2012,6 +2071,7 @@ test.describe("generated transfer-validity benchmark", () => {
 				fileSizeMb: FILE_SIZE_MB,
 				stage,
 				requestedDownloadSink: DOWNLOAD_SINK,
+				downloadMemoryTelemetry,
 				integrityVerified: false,
 				phaseDurationsMs: getPhaseDurations(),
 				postUploadMonitorSchedulingToleranceMs:
@@ -2058,6 +2118,7 @@ test.describe("generated transfer-validity benchmark", () => {
 			console.error(`FILE_SHARE_BENCHMARK_RESULT ${JSON.stringify(result)}`);
 			throw error;
 		} finally {
+			await downloadMemoryTelemetryController?.stop().catch(() => {});
 			await cleanupDownload?.().catch(() => {});
 			await nodeSinkController?.cleanup().catch(() => {});
 			if (preparedFile) {


### PR DESCRIPTION
## What

- capture bounded 5-second reader/writer JavaScript heap samples around the canonical timed download
- capture Chromium process-role RSS plus Playwright worker RSS, with explicit attribution limits
- require complete, error-free schema-v5 telemetry for passed results while retaining partial evidence on failures
- bound samples, errors, strings, process roles, setup, sampling, and cleanup deadlines
- keep WebSocket-frame capture out of the primary benchmark because it is incomplete for WebRTC and can perturb the transfer

## Validation

- `node --test scripts/file-share/*.test.mjs` — 165/165 passed
- real Chromium 8 MiB fixed1/hash-only smoke — passed
- exact locality cohort: `observer-persistent-prefix-b3-i0`
- deterministic SHA-256, CRC-32, and manifest gates — passed
- memory telemetry complete with 2 forced endpoint samples per series and zero sampling errors
- terminal download scheduler idle; zero browser errors and request failures

This is benchmark diagnostics only; it does not change the Peerbit network protocol.