### PR TITLE
feat(benchmarks): validate upload progress telemetry

### DIFF
--- a/scripts/file-share/README.md
+++ b/scripts/file-share/README.md
@@ -3,13 +3,27 @@
 Run a single checkout with `pnpm bench:file-share:local` or compare pinned
 Peerbit revisions with `pnpm bench:file-share:matrix`.
 
-Result schema v5 defines `errorCount` as every uncaught browser `pageerror`,
+Result schema v6 defines `errorCount` as every uncaught browser `pageerror`,
 every browser `console.error`, every console message at any level that contains
 a declared Peerbit failure signature, and scenario-recorded operation failures.
 Each result embeds the exact `errorCollectionDefinition` and signature list.
 Playwright `requestfailed` events are retained separately under
 `requestFailures`; they are diagnostics and are not automatically fatal because
 peer-to-peer discovery can legitimately exercise failed network candidates.
+
+Passed schema v6 upload results require `writerDiagnostics.lastUploadDiagnostics`
+to contain exactly 21 bounded progress milestones from 0% through 100% in 5%
+increments. Each point records the aggregate bytes whose application-level
+chunk puts completed, using the library upload clock and exact ceil-rounded byte
+target. This is local chunk-commit throughput, not wire-byte progress, remote
+acknowledgement throughput, or a contiguous source prefix. Concurrent puts may
+finish out of index order, and one completion may cross multiple milestones.
+The 0% point includes manifest/startup overhead; the 100% point precedes the
+ready-manifest commit. The validator binds the series to the canonical file,
+requires a clean completed upload lifecycle, and rejects missing, partial,
+unbounded, stale, reordered-byte, or contradictory passed evidence. Failed
+runs may retain a bounded partial milestone prefix for diagnosis but are never
+accepted as performance evidence.
 
 Upload benchmarks default to `--download-sink hash-only`, which verifies the
 deterministic stream with library SHA-256 plus an independent browser CRC-32
@@ -33,7 +47,7 @@ sinks only in separate benchmark sessions; aggregate comparison objects fail
 closed on mixed sinks, and every passed result and aggregate labels
 non-hash-only cohorts non-authoritative.
 
-Schema v5 upload results also record bounded download-window memory telemetry. After any
+Schema v6 upload results also record bounded download-window memory telemetry. After any
 controlled-locality stabilization, the harness arms serial samplers immediately
 before the timed click and forces a final sample as soon as the selected sink
 completion is observed, before integrity readback or terminal-topology checks.

--- a/scripts/file-share/benchmark-orchestration.mjs
+++ b/scripts/file-share/benchmark-orchestration.mjs
@@ -2,7 +2,7 @@ import fsp from "node:fs/promises";
 
 export const BENCHMARK_RESULT_SCHEMA = Object.freeze({
 	id: "peerbit-file-share-benchmark",
-	version: 5,
+	version: 6,
 });
 
 export const BENCHMARK_SUMMARY_SCHEMA = Object.freeze({

--- a/scripts/file-share/benchmark-validity.mjs
+++ b/scripts/file-share/benchmark-validity.mjs
@@ -65,6 +65,22 @@ const SINK_WRITE_QUANTIZATION_ALLOWANCE_MS_PER_CHUNK = 1;
 // Browser performance.now() and Node hrtime measure nested intervals on
 // independent monotonic clocks; keep their aggregate drift finite per call.
 const SINK_SERVER_CLOCK_TOLERANCE_MS_PER_CHUNK = 1;
+const UPLOAD_PROGRESS_MILESTONE_BASIS_POINTS = Object.freeze(
+	Array.from({ length: 21 }, (_, index) => index * 500),
+);
+const UPLOAD_PROGRESS_TELEMETRY_KEYS = Object.freeze([
+	"schemaVersion",
+	"kind",
+	"clock",
+	"milestones",
+]);
+const UPLOAD_PROGRESS_MILESTONE_KEYS = Object.freeze([
+	"basisPoints",
+	"targetBytes",
+	"completedBytes",
+	"reachedAt",
+	"chunkIndex",
+]);
 
 const isRecord = (value) =>
 	value != null && typeof value === "object" && !Array.isArray(value);
@@ -368,11 +384,7 @@ const requireBoundedDiagnosticIntervals = ({
 const validateReadTransferEvidence = (
 	result,
 	invocation,
-	{
-		downloadStartedAt,
-		downloadFinishedAt,
-		downloadCompletionObservedAt,
-	},
+	{ downloadStartedAt, downloadFinishedAt, downloadCompletionObservedAt },
 ) => {
 	const readerDiagnostics = requireRecord(
 		result.readerDiagnostics,
@@ -742,8 +754,7 @@ const validateMemorySeriesWindow = (
 	}
 	if (
 		startedAt < downloadStartedAt - DOWNLOAD_MEMORY_SETUP_ALLOWANCE_MS ||
-		firstCapturedAt <
-			downloadStartedAt - DOWNLOAD_MEMORY_SETUP_ALLOWANCE_MS
+		firstCapturedAt < downloadStartedAt - DOWNLOAD_MEMORY_SETUP_ALLOWANCE_MS
 	) {
 		throw new Error(
 			`Benchmark ${label} begins before the bounded telemetry setup window`,
@@ -859,11 +870,7 @@ const validateBrowserRoleBytes = (value, label) => {
 	return { roles, total };
 };
 
-const validateHostRssSeries = (
-	seriesValue,
-	maxSamples,
-	readWindow,
-) => {
+const validateHostRssSeries = (seriesValue, maxSamples, readWindow) => {
 	const label = "downloadMemoryTelemetry.hostRss";
 	const series = requireRecord(seriesValue, label);
 	requireExactRecordKeys(
@@ -964,9 +971,7 @@ const validateHostRssSeries = (
 			combinedBytes !== browserBytes + nodeBytes ||
 			roleTotal !== browserBytes
 		) {
-			throw new Error(
-				`Benchmark ${sampleLabel} RSS totals are inconsistent`,
-			);
+			throw new Error(`Benchmark ${sampleLabel} RSS totals are inconsistent`);
 		}
 		for (const [role, bytes] of Object.entries(browserRoleBytes)) {
 			peakBrowserRoleBytes[role] = Math.max(
@@ -1295,6 +1300,398 @@ const validateUploadTimings = (result, invocation) => {
 		downloadFinishedAt,
 		downloadCompletionObservedAt,
 	});
+};
+
+const validateUploadProgressTelemetry = (result, invocation) => {
+	const writerDiagnostics = requireRecord(
+		result.writerDiagnostics,
+		"writerDiagnostics",
+	);
+	const diagnostics = requireRecord(
+		writerDiagnostics.lastUploadDiagnostics,
+		"writerDiagnostics.lastUploadDiagnostics",
+	);
+	const writerManifest = requireRecord(
+		result.writerManifestEvidence,
+		"writerManifestEvidence",
+	);
+	const timestamps = requireRecord(result.timestamps, "timestamps");
+	const manifestFileId = requireString(
+		writerManifest.fileId,
+		"writerManifestEvidence.fileId",
+	);
+	const resultFileName = requireString(result.fileName, "fileName");
+	requireString(
+		diagnostics.transferId,
+		"writerDiagnostics.lastUploadDiagnostics.transferId",
+	);
+	const uploadId = requireString(
+		diagnostics.uploadId,
+		"writerDiagnostics.lastUploadDiagnostics.uploadId",
+	);
+	const fileName = requireString(
+		diagnostics.fileName,
+		"writerDiagnostics.lastUploadDiagnostics.fileName",
+	);
+	const sizeBytes = requirePositiveSafeInteger(
+		invocation.fileSizeBytes,
+		"invocation.fileSizeBytes",
+	);
+	const chunkSize = requirePositiveSafeInteger(
+		diagnostics.chunkSize,
+		"writerDiagnostics.lastUploadDiagnostics.chunkSize",
+	);
+	const chunkCount = requirePositiveSafeInteger(
+		diagnostics.chunkCount,
+		"writerDiagnostics.lastUploadDiagnostics.chunkCount",
+	);
+	const chunkPutCount = requireNonNegativeSafeInteger(
+		diagnostics.chunkPutCount,
+		"writerDiagnostics.lastUploadDiagnostics.chunkPutCount",
+	);
+	const readTransfer = requireRecord(result.readTransfer, "readTransfer");
+	const readChunkCount = requirePositiveSafeInteger(
+		readTransfer.chunkCount,
+		"readTransfer.chunkCount",
+	);
+	const readerDiagnostics = requireRecord(
+		result.readerDiagnostics,
+		"readerDiagnostics",
+	);
+	const lastReadDiagnostics = requireRecord(
+		readerDiagnostics.lastReadDiagnostics,
+		"readerDiagnostics.lastReadDiagnostics",
+	);
+	const readChunkByteLength = requireRecord(
+		lastReadDiagnostics.chunkByteLength,
+		"readerDiagnostics.lastReadDiagnostics.chunkByteLength",
+	);
+	const uploadStartedAt = requirePositiveSafeInteger(
+		timestamps.uploadStartedAt,
+		"timestamps.uploadStartedAt",
+	);
+	const uploadSettledAt = requirePositiveSafeInteger(
+		timestamps.uploadSettledAt,
+		"timestamps.uploadSettledAt",
+	);
+	const startedAt = requirePositiveSafeInteger(
+		diagnostics.startedAt,
+		"writerDiagnostics.lastUploadDiagnostics.startedAt",
+	);
+	const manifestStartedAt = requirePositiveSafeInteger(
+		diagnostics.manifestStartedAt,
+		"writerDiagnostics.lastUploadDiagnostics.manifestStartedAt",
+	);
+	const manifestFinishedAt = requirePositiveSafeInteger(
+		diagnostics.manifestFinishedAt,
+		"writerDiagnostics.lastUploadDiagnostics.manifestFinishedAt",
+	);
+	const firstChunkStartedAt = requirePositiveSafeInteger(
+		diagnostics.firstChunkStartedAt,
+		"writerDiagnostics.lastUploadDiagnostics.firstChunkStartedAt",
+	);
+	const firstChunkFinishedAt = requirePositiveSafeInteger(
+		diagnostics.firstChunkFinishedAt,
+		"writerDiagnostics.lastUploadDiagnostics.firstChunkFinishedAt",
+	);
+	const lastChunkFinishedAt = requirePositiveSafeInteger(
+		diagnostics.lastChunkFinishedAt,
+		"writerDiagnostics.lastUploadDiagnostics.lastChunkFinishedAt",
+	);
+	const readyManifestStartedAt = requirePositiveSafeInteger(
+		diagnostics.readyManifestStartedAt,
+		"writerDiagnostics.lastUploadDiagnostics.readyManifestStartedAt",
+	);
+	const readyManifestFinishedAt = requirePositiveSafeInteger(
+		diagnostics.readyManifestFinishedAt,
+		"writerDiagnostics.lastUploadDiagnostics.readyManifestFinishedAt",
+	);
+	const finishedAt = requirePositiveSafeInteger(
+		diagnostics.finishedAt,
+		"writerDiagnostics.lastUploadDiagnostics.finishedAt",
+	);
+	if (
+		uploadId !== manifestFileId ||
+		fileName !== resultFileName ||
+		diagnostics.sizeBytes !== sizeBytes
+	) {
+		throw new Error(
+			"Benchmark upload diagnostics do not identify the canonical uploaded file",
+		);
+	}
+	if (
+		chunkCount !== Math.ceil(sizeBytes / chunkSize) ||
+		chunkPutCount !== chunkCount ||
+		diagnostics.failureAt !== null ||
+		diagnostics.failureMessage !== null
+	) {
+		throw new Error(
+			"Benchmark upload diagnostics do not prove a successful complete chunk upload",
+		);
+	}
+	if (chunkCount !== readChunkCount) {
+		throw new Error(
+			"Benchmark upload chunk geometry contradicts canonical read evidence",
+		);
+	}
+	for (let index = 0; index < chunkCount; index++) {
+		const expectedChunkBytes =
+			index === chunkCount - 1 ? sizeBytes - index * chunkSize : chunkSize;
+		const observedChunkBytes = requirePositiveSafeInteger(
+			readChunkByteLength[index],
+			`readerDiagnostics.lastReadDiagnostics.chunkByteLength[${index}]`,
+		);
+		if (observedChunkBytes !== expectedChunkBytes) {
+			throw new Error(
+				"Benchmark upload chunk geometry contradicts canonical read evidence",
+			);
+		}
+	}
+	if (
+		uploadStartedAt > startedAt ||
+		startedAt > manifestStartedAt ||
+		manifestStartedAt > manifestFinishedAt ||
+		manifestFinishedAt > firstChunkStartedAt ||
+		firstChunkStartedAt > firstChunkFinishedAt ||
+		firstChunkFinishedAt > lastChunkFinishedAt ||
+		lastChunkFinishedAt > readyManifestStartedAt ||
+		readyManifestStartedAt > readyManifestFinishedAt ||
+		readyManifestFinishedAt > finishedAt ||
+		// The DOM progress helper may return before React renders the progress
+		// element. Writer readiness also awaits the canonical ready manifest, so
+		// uploadSettledAt is the reliable harness-side upper bound.
+		finishedAt > uploadSettledAt
+	) {
+		throw new Error(
+			"Benchmark upload diagnostics lifecycle timestamps are inconsistent",
+		);
+	}
+
+	const telemetry = requireExactRecordKeys(
+		requireRecord(
+			diagnostics.progressTelemetry,
+			"writerDiagnostics.lastUploadDiagnostics.progressTelemetry",
+		),
+		UPLOAD_PROGRESS_TELEMETRY_KEYS,
+		"upload progress telemetry",
+	);
+	if (
+		telemetry.schemaVersion !== 1 ||
+		telemetry.kind !== "upload-chunk-commit" ||
+		telemetry.clock !== "unix-epoch-ms"
+	) {
+		throw new Error("Benchmark upload progress telemetry contract is invalid");
+	}
+	if (
+		!Array.isArray(telemetry.milestones) ||
+		telemetry.milestones.length !==
+			UPLOAD_PROGRESS_MILESTONE_BASIS_POINTS.length
+	) {
+		throw new Error(
+			"Benchmark upload progress telemetry must contain exactly 21 milestones",
+		);
+	}
+
+	const partialTailBytes = sizeBytes % chunkSize;
+	const hasPartialTail = partialTailBytes !== 0;
+	const fullChunkCount = chunkCount - (hasPartialTail ? 1 : 0);
+	const decodeCompletionState = (completedBytes, label) => {
+		if (completedBytes === 0) {
+			return { includedFullChunks: 0, tailIncluded: false };
+		}
+		const remainder = completedBytes % chunkSize;
+		let includedFullChunks;
+		let tailIncluded;
+		if (remainder === 0) {
+			includedFullChunks = completedBytes / chunkSize;
+			tailIncluded = false;
+		} else if (hasPartialTail && remainder === partialTailBytes) {
+			includedFullChunks = (completedBytes - partialTailBytes) / chunkSize;
+			tailIncluded = true;
+		} else {
+			throw new Error(
+				`Benchmark ${label} is not a possible aggregate of completed chunks`,
+			);
+		}
+		if (
+			!Number.isSafeInteger(includedFullChunks) ||
+			includedFullChunks < 0 ||
+			includedFullChunks > fullChunkCount
+		) {
+			throw new Error(
+				`Benchmark ${label} is not a possible aggregate of completed chunks`,
+			);
+		}
+		return { includedFullChunks, tailIncluded };
+	};
+
+	let previousCompletedBytes = 0;
+	let previousReachedAt = startedAt;
+	let previousChunkIndex = null;
+	let previousCompletionState = {
+		includedFullChunks: 0,
+		tailIncluded: false,
+	};
+	const recordedTriggerEvents = new Map();
+	for (const [index, value] of telemetry.milestones.entries()) {
+		const label = `upload progress milestone ${index}`;
+		const milestone = requireExactRecordKeys(
+			requireRecord(value, label),
+			UPLOAD_PROGRESS_MILESTONE_KEYS,
+			label,
+		);
+		const basisPoints = UPLOAD_PROGRESS_MILESTONE_BASIS_POINTS[index];
+		const expectedTargetBytes = Number(
+			(BigInt(sizeBytes) * BigInt(basisPoints) + 9_999n) / 10_000n,
+		);
+		const targetBytes = requireNonNegativeSafeInteger(
+			milestone.targetBytes,
+			`${label}.targetBytes`,
+		);
+		const completedBytes = requireNonNegativeSafeInteger(
+			milestone.completedBytes,
+			`${label}.completedBytes`,
+		);
+		const reachedAt = requirePositiveSafeInteger(
+			milestone.reachedAt,
+			`${label}.reachedAt`,
+		);
+		if (
+			milestone.basisPoints !== basisPoints ||
+			targetBytes !== expectedTargetBytes
+		) {
+			throw new Error(`Benchmark ${label} does not use the exact 5% target`);
+		}
+		if (
+			completedBytes < targetBytes ||
+			completedBytes > sizeBytes ||
+			completedBytes - targetBytes >= chunkSize ||
+			completedBytes < previousCompletedBytes
+		) {
+			throw new Error(
+				`Benchmark ${label} has invalid aggregate completed bytes`,
+			);
+		}
+		if (
+			reachedAt < startedAt ||
+			reachedAt > lastChunkFinishedAt ||
+			reachedAt < previousReachedAt
+		) {
+			throw new Error(`Benchmark ${label} has invalid completion time`);
+		}
+		const completionState = decodeCompletionState(completedBytes, label);
+		if (index === 0) {
+			if (
+				targetBytes !== 0 ||
+				completedBytes !== 0 ||
+				reachedAt !== startedAt ||
+				milestone.chunkIndex !== null
+			) {
+				throw new Error(
+					"Benchmark upload progress telemetry has an invalid zero milestone",
+				);
+			}
+		} else {
+			if (reachedAt < firstChunkFinishedAt) {
+				throw new Error(
+					`Benchmark ${label} predates the first completed chunk`,
+				);
+			}
+			const chunkIndex = requireNonNegativeSafeInteger(
+				milestone.chunkIndex,
+				`${label}.chunkIndex`,
+			);
+			if (chunkIndex >= chunkCount) {
+				throw new Error(`Benchmark ${label} has an out-of-range chunk index`);
+			}
+			if (
+				completedBytes === previousCompletedBytes &&
+				(reachedAt !== previousReachedAt || chunkIndex !== previousChunkIndex)
+			) {
+				throw new Error(
+					`Benchmark ${label} contradicts its shared chunk-completion event`,
+				);
+			}
+			const triggerChunkBytes = requirePositiveSafeInteger(
+				readChunkByteLength[chunkIndex],
+				`readerDiagnostics.lastReadDiagnostics.chunkByteLength[${chunkIndex}]`,
+			);
+			const preTriggerBytes = completedBytes - triggerChunkBytes;
+			if (preTriggerBytes >= targetBytes) {
+				throw new Error(
+					`Benchmark ${label} was already crossed before its triggering chunk completion`,
+				);
+			}
+			if (
+				completedBytes !== previousCompletedBytes &&
+				preTriggerBytes === 0 &&
+				reachedAt !== firstChunkFinishedAt
+			) {
+				throw new Error(
+					`Benchmark ${label} contradicts the first completed chunk timestamp`,
+				);
+			}
+			if (
+				previousCompletedBytes >= targetBytes &&
+				completedBytes !== previousCompletedBytes
+			) {
+				throw new Error(
+					`Benchmark ${label} was not recorded at its first qualifying chunk-completion event`,
+				);
+			}
+			if (completedBytes !== previousCompletedBytes) {
+				if (
+					completionState.includedFullChunks <
+						previousCompletionState.includedFullChunks ||
+					(previousCompletionState.tailIncluded &&
+						!completionState.tailIncluded)
+				) {
+					throw new Error(
+						`Benchmark ${label} regresses its completed-chunk set`,
+					);
+				}
+				const triggersPartialTail =
+					hasPartialTail && chunkIndex === chunkCount - 1;
+				if (
+					triggersPartialTail
+						? !completionState.tailIncluded ||
+							previousCompletionState.tailIncluded
+						: chunkIndex >= fullChunkCount ||
+							completionState.includedFullChunks <=
+								previousCompletionState.includedFullChunks
+				) {
+					throw new Error(
+						`Benchmark ${label} contradicts its triggering chunk completion`,
+					);
+				}
+				if (recordedTriggerEvents.has(chunkIndex)) {
+					throw new Error(
+						`Benchmark ${label} reuses a completed chunk as a later trigger`,
+					);
+				}
+				recordedTriggerEvents.set(chunkIndex, {
+					completedBytes,
+					reachedAt,
+				});
+				previousCompletionState = completionState;
+			}
+		}
+		previousCompletedBytes = completedBytes;
+		previousReachedAt = reachedAt;
+		previousChunkIndex = milestone.chunkIndex;
+	}
+
+	const finalMilestone = telemetry.milestones.at(-1);
+	if (
+		finalMilestone.targetBytes !== sizeBytes ||
+		finalMilestone.completedBytes !== sizeBytes ||
+		finalMilestone.reachedAt !== lastChunkFinishedAt
+	) {
+		throw new Error(
+			"Benchmark upload progress telemetry has an invalid completion milestone",
+		);
+	}
+	return telemetry;
 };
 
 const validateGitProvenance = (value, label) => {
@@ -2501,11 +2898,8 @@ export const validateBenchmarkResult = (
 			expectedInvocation,
 		);
 		const readWindow = validateUploadTimings(result, expectedInvocation);
-		validateDownloadMemoryTelemetry(
-			result,
-			expectedInvocation,
-			readWindow,
-		);
+		validateUploadProgressTelemetry(result, expectedInvocation);
+		validateDownloadMemoryTelemetry(result, expectedInvocation, readWindow);
 		validateRequestedUploadKnobs(result, expectedInvocation);
 		validateZeroErrors(result, "upload result");
 		validateReaderLocalityControl(result, expectedInvocation);

--- a/scripts/file-share/benchmark-validity.test.mjs
+++ b/scripts/file-share/benchmark-validity.test.mjs
@@ -206,6 +206,78 @@ const createDownloadMemoryTelemetry = (
 	};
 };
 
+const createUploadDiagnostics = (fileName = FILE_NAME) => {
+	const chunkSize = 3 * 1024 * 1024;
+	const chunkCount = Math.ceil(FILE_SIZE_BYTES / chunkSize);
+	const startedAt = 1_001;
+	const firstChunkFinishedAt = 1_030;
+	const lastChunkFinishedAt = 1_040;
+	const milestones = [
+		{
+			basisPoints: 0,
+			targetBytes: 0,
+			completedBytes: 0,
+			reachedAt: startedAt,
+			chunkIndex: null,
+		},
+	];
+	let completedBytes = 0;
+	let nextMilestoneIndex = 1;
+	for (const completion of [
+		{ chunkIndex: 0, bytes: chunkSize, reachedAt: firstChunkFinishedAt },
+		{
+			chunkIndex: 1,
+			bytes: FILE_SIZE_BYTES - chunkSize,
+			reachedAt: lastChunkFinishedAt,
+		},
+	]) {
+		completedBytes += completion.bytes;
+		while (nextMilestoneIndex < 21) {
+			const basisPoints = nextMilestoneIndex * 500;
+			const targetBytes = Number(
+				(BigInt(FILE_SIZE_BYTES) * BigInt(basisPoints) + 9_999n) / 10_000n,
+			);
+			if (completedBytes < targetBytes) {
+				break;
+			}
+			milestones.push({
+				basisPoints,
+				targetBytes,
+				completedBytes,
+				reachedAt: completion.reachedAt,
+				chunkIndex: completion.chunkIndex,
+			});
+			nextMilestoneIndex += 1;
+		}
+	}
+	return {
+		transferId: FILE_ID,
+		uploadId: FILE_ID,
+		fileName,
+		sizeBytes: FILE_SIZE_BYTES,
+		chunkSize,
+		chunkCount,
+		startedAt,
+		manifestStartedAt: 1_002,
+		manifestFinishedAt: 1_003,
+		firstChunkStartedAt: 1_004,
+		firstChunkFinishedAt,
+		lastChunkFinishedAt,
+		chunkPutCount: chunkCount,
+		readyManifestStartedAt: 1_041,
+		readyManifestFinishedAt: 1_042,
+		finishedAt: 1_043,
+		failureAt: null,
+		failureMessage: null,
+		progressTelemetry: {
+			schemaVersion: 1,
+			kind: "upload-chunk-commit",
+			clock: "unix-epoch-ms",
+			milestones,
+		},
+	};
+};
+
 const shiftTimedDownloadEvidence = (result, offset) => {
 	for (const key of [
 		"downloadStartedAt",
@@ -389,6 +461,9 @@ const validResult = () => ({
 	requestFailureCollectionComplete: true,
 	requestFailureCount: 0,
 	requestFailures: [],
+	writerDiagnostics: {
+		lastUploadDiagnostics: createUploadDiagnostics(),
+	},
 	readerDiagnostics: {
 		lastReadDiagnostics: {
 			transferId: "benchmark-read-transfer-id",
@@ -582,10 +657,9 @@ const createReaderLocalityFixture = ({
 	});
 	result.writerManifestEvidence.fileName = fileName;
 	result.readerManifestEvidence.fileName = fileName;
-	result.writerDiagnostics = {
-		peerHash: "writer-peer",
-		replicatorCount: 2,
-	};
+	result.writerDiagnostics.peerHash = "writer-peer";
+	result.writerDiagnostics.replicatorCount = 2;
+	result.writerDiagnostics.lastUploadDiagnostics.fileName = fileName;
 	result.timestamps.downloadStartedAt = 1_400;
 	result.timestamps.downloadFinishedAt = 1_430;
 	result.timestamps.downloadCompletionObservedAt = 1_431;
@@ -726,6 +800,377 @@ test("accepts a complete deterministic transfer result", () => {
 	);
 });
 
+test("requires exact bounded upload chunk-commit progress telemetry", () => {
+	for (const [mutate, pattern] of [
+		[
+			(result) => {
+				delete result.writerDiagnostics;
+			},
+			/missing writerDiagnostics/,
+		],
+		[
+			(result) => {
+				delete result.writerDiagnostics.lastUploadDiagnostics;
+			},
+			/missing writerDiagnostics\.lastUploadDiagnostics/,
+		],
+		[
+			(result) => {
+				delete result.writerDiagnostics.lastUploadDiagnostics.progressTelemetry;
+			},
+			/missing writerDiagnostics\.lastUploadDiagnostics\.progressTelemetry/,
+		],
+		[
+			(result) => {
+				result.writerDiagnostics.lastUploadDiagnostics.progressTelemetry.extra = true;
+			},
+			/upload progress telemetry contains unexpected or missing fields/,
+		],
+		[
+			(result) => {
+				result.writerDiagnostics.lastUploadDiagnostics.progressTelemetry.milestones[1].extra = true;
+			},
+			/upload progress milestone 1 contains unexpected or missing fields/,
+		],
+		[
+			(result) => {
+				result.writerDiagnostics.lastUploadDiagnostics.progressTelemetry.schemaVersion = 2;
+			},
+			/telemetry contract is invalid/,
+		],
+		[
+			(result) => {
+				result.writerDiagnostics.lastUploadDiagnostics.progressTelemetry.kind =
+					"wire-bytes";
+			},
+			/telemetry contract is invalid/,
+		],
+		[
+			(result) => {
+				result.writerDiagnostics.lastUploadDiagnostics.progressTelemetry.milestones.pop();
+			},
+			/exactly 21 milestones/,
+		],
+		[
+			(result) => {
+				const telemetry =
+					result.writerDiagnostics.lastUploadDiagnostics.progressTelemetry;
+				telemetry.milestones.push(structuredClone(telemetry.milestones.at(-1)));
+			},
+			/exactly 21 milestones/,
+		],
+		[
+			(result) => {
+				result.writerDiagnostics.lastUploadDiagnostics.progressTelemetry.milestones[5].basisPoints += 1;
+			},
+			/exact 5% target/,
+		],
+		[
+			(result) => {
+				result.writerDiagnostics.lastUploadDiagnostics.progressTelemetry.milestones[5].targetBytes += 1;
+			},
+			/exact 5% target/,
+		],
+		[
+			(result) => {
+				const milestone =
+					result.writerDiagnostics.lastUploadDiagnostics.progressTelemetry
+						.milestones[5];
+				milestone.completedBytes = milestone.targetBytes - 1;
+			},
+			/invalid aggregate completed bytes/,
+		],
+		[
+			(result) => {
+				const milestone =
+					result.writerDiagnostics.lastUploadDiagnostics.progressTelemetry
+						.milestones[1];
+				milestone.completedBytes = milestone.targetBytes;
+			},
+			/not a possible aggregate of completed chunks/,
+		],
+		[
+			(result) => {
+				const diagnostics = result.writerDiagnostics.lastUploadDiagnostics;
+				const milestone = diagnostics.progressTelemetry.milestones[1];
+				milestone.completedBytes =
+					milestone.targetBytes + diagnostics.chunkSize;
+			},
+			/invalid aggregate completed bytes/,
+		],
+		[
+			(result) => {
+				const milestones =
+					result.writerDiagnostics.lastUploadDiagnostics.progressTelemetry
+						.milestones;
+				milestones[2].completedBytes = 2 * 1024 * 1024;
+			},
+			/invalid aggregate completed bytes/,
+		],
+		[
+			(result) => {
+				const milestones =
+					result.writerDiagnostics.lastUploadDiagnostics.progressTelemetry
+						.milestones;
+				milestones[2].reachedAt = milestones[0].reachedAt;
+			},
+			/invalid completion time/,
+		],
+		[
+			(result) => {
+				const diagnostics = result.writerDiagnostics.lastUploadDiagnostics;
+				diagnostics.progressTelemetry.milestones[1].reachedAt =
+					diagnostics.startedAt;
+			},
+			/predates the first completed chunk/,
+		],
+		[
+			(result) => {
+				const diagnostics = result.writerDiagnostics.lastUploadDiagnostics;
+				for (const milestone of diagnostics.progressTelemetry.milestones.slice(
+					1,
+					13,
+				)) {
+					milestone.reachedAt = diagnostics.firstChunkFinishedAt + 5;
+				}
+			},
+			/contradicts the first completed chunk timestamp/,
+		],
+		[
+			(result) => {
+				const diagnostics = result.writerDiagnostics.lastUploadDiagnostics;
+				const milestone = diagnostics.progressTelemetry.milestones[1];
+				milestone.completedBytes = 2 * 1024 * 1024;
+				milestone.chunkIndex = 0;
+			},
+			/contradicts its triggering chunk completion/,
+		],
+		[
+			(result) => {
+				result.writerDiagnostics.lastUploadDiagnostics.progressTelemetry.milestones[2].chunkIndex = 1;
+			},
+			/contradicts its shared chunk-completion event/,
+		],
+		[
+			(result) => {
+				const diagnostics = result.writerDiagnostics.lastUploadDiagnostics;
+				for (const milestone of diagnostics.progressTelemetry.milestones.slice(
+					9,
+				)) {
+					milestone.completedBytes = FILE_SIZE_BYTES;
+					milestone.reachedAt = diagnostics.lastChunkFinishedAt;
+					milestone.chunkIndex = 1;
+				}
+			},
+			/already crossed before its triggering chunk completion/,
+		],
+		[
+			(result) => {
+				result.writerDiagnostics.lastUploadDiagnostics.progressTelemetry.milestones[1].chunkIndex =
+					null;
+			},
+			/invalid upload progress milestone 1\.chunkIndex/,
+		],
+		[
+			(result) => {
+				const diagnostics = result.writerDiagnostics.lastUploadDiagnostics;
+				diagnostics.progressTelemetry.milestones[1].chunkIndex =
+					diagnostics.chunkCount;
+			},
+			/out-of-range chunk index/,
+		],
+		[
+			(result) => {
+				result.writerDiagnostics.lastUploadDiagnostics.lastChunkFinishedAt += 1;
+			},
+			/invalid completion milestone/,
+		],
+		[
+			(result) => {
+				result.writerDiagnostics.lastUploadDiagnostics.uploadId = "stale-file";
+			},
+			/do not identify the canonical uploaded file/,
+		],
+		[
+			(result) => {
+				result.writerDiagnostics.lastUploadDiagnostics.fileName = "stale.bin";
+			},
+			/do not identify the canonical uploaded file/,
+		],
+		[
+			(result) => {
+				result.writerDiagnostics.lastUploadDiagnostics.sizeBytes -= 1;
+			},
+			/do not identify the canonical uploaded file/,
+		],
+		[
+			(result) => {
+				result.writerDiagnostics.lastUploadDiagnostics.chunkPutCount -= 1;
+			},
+			/do not prove a successful complete chunk upload/,
+		],
+		[
+			(result) => {
+				const diagnostics = result.writerDiagnostics.lastUploadDiagnostics;
+				diagnostics.chunkSize = FILE_SIZE_BYTES;
+				diagnostics.chunkCount = 1;
+				diagnostics.chunkPutCount = 1;
+				for (const milestone of diagnostics.progressTelemetry.milestones.slice(
+					1,
+				)) {
+					milestone.completedBytes = FILE_SIZE_BYTES;
+					milestone.reachedAt = diagnostics.lastChunkFinishedAt;
+					milestone.chunkIndex = 0;
+				}
+			},
+			/upload chunk geometry contradicts canonical read evidence/,
+		],
+		[
+			(result) => {
+				result.writerDiagnostics.lastUploadDiagnostics.failureAt = 1_044;
+			},
+			/do not prove a successful complete chunk upload/,
+		],
+		[
+			(result) => {
+				result.writerDiagnostics.lastUploadDiagnostics.finishedAt =
+					result.timestamps.uploadSettledAt + 1;
+			},
+			/lifecycle timestamps are inconsistent/,
+		],
+	]) {
+		const result = validResult();
+		mutate(result);
+		assert.throws(() => validateBenchmarkResult(result, options), pattern);
+	}
+});
+
+test("accepts upload progress milestones with out-of-order chunk completion", () => {
+	const result = validResult();
+	const diagnostics = result.writerDiagnostics.lastUploadDiagnostics;
+	const milestones = diagnostics.progressTelemetry.milestones;
+	for (let index = 1; index <= 8; index++) {
+		milestones[index].completedBytes = 2 * 1024 * 1024;
+		milestones[index].chunkIndex = 1;
+	}
+	for (let index = 9; index < milestones.length; index++) {
+		milestones[index].completedBytes = FILE_SIZE_BYTES;
+		milestones[index].reachedAt = diagnostics.lastChunkFinishedAt;
+		milestones[index].chunkIndex = 0;
+	}
+	assert.equal(validateBenchmarkResult(result, options).status, "passed");
+});
+
+test("rejects milestones crossed before a partial-tail trigger", () => {
+	const result = validResult();
+	const chunkSize = 1_700_000;
+	const chunkByteLengths = [
+		chunkSize,
+		chunkSize,
+		chunkSize,
+		FILE_SIZE_BYTES - 3 * chunkSize,
+	];
+	const reader = result.readerDiagnostics.lastReadDiagnostics;
+	const indices = chunkByteLengths.map((_, index) => index);
+	reader.chunkResolved = Object.fromEntries(
+		indices.map((index) => [index, "remote"]),
+	);
+	reader.chunkByteLength = Object.fromEntries(
+		chunkByteLengths.map((bytes, index) => [index, bytes]),
+	);
+	reader.chunkDemandWaitMs = Object.fromEntries(
+		indices.map((index) => [index, 0]),
+	);
+	for (const key of [
+		"chunkWriteStartedAt",
+		"chunkWriteFinishedAt",
+		"chunkMaterializeStartedAt",
+		"chunkMaterializeFinishedAt",
+		"chunkHashStartedAt",
+		"chunkHashFinishedAt",
+	]) {
+		reader[key] = Object.fromEntries(indices.map((index) => [index, 1_171]));
+	}
+	result.readTransfer = {
+		chunkCount: 4,
+		totalBytes: FILE_SIZE_BYTES,
+		sources: { remote: { chunkCount: 4, bytes: FILE_SIZE_BYTES } },
+		demandWait: {
+			definition: DEMAND_WAIT_DEFINITION,
+			sampleCount: 4,
+			sumMs: 0,
+			p50Ms: 0,
+			p95Ms: 0,
+			p99Ms: 0,
+			maxMs: 0,
+			over1sCount: 0,
+			over5sCount: 0,
+			over10sCount: 0,
+		},
+		stages: {
+			libraryStreamWallMs: 30,
+			sinkWriteAwaitMs: 0,
+			sinkAwaitSubtractedDiagnosticMs: 30,
+			demandWaitMs: 0,
+			materializeMs: 0,
+			contentHashMs: 0,
+			otherStreamReadMs: 30,
+		},
+	};
+	result.sinkWriteCalls = 4;
+	result.sinkWriteDurationMs = 0;
+	result.sinkWriteAwaitMs = 0;
+	result.sinkAwaitSubtractedDiagnosticMs = 30;
+
+	const diagnostics = result.writerDiagnostics.lastUploadDiagnostics;
+	diagnostics.chunkSize = chunkSize;
+	diagnostics.chunkCount = 4;
+	diagnostics.chunkPutCount = 4;
+	diagnostics.firstChunkFinishedAt = 1_029;
+	diagnostics.lastChunkFinishedAt = 1_040;
+	const completionEvents = [
+		{
+			completedBytes: chunkSize + chunkByteLengths[3],
+			reachedAt: 1_030,
+			chunkIndex: 3,
+		},
+		{
+			completedBytes: 2 * chunkSize + chunkByteLengths[3],
+			reachedAt: 1_035,
+			chunkIndex: 1,
+		},
+		{
+			completedBytes: FILE_SIZE_BYTES,
+			reachedAt: 1_040,
+			chunkIndex: 2,
+		},
+	];
+	diagnostics.progressTelemetry.milestones = [
+		{
+			basisPoints: 0,
+			targetBytes: 0,
+			completedBytes: 0,
+			reachedAt: diagnostics.startedAt,
+			chunkIndex: null,
+		},
+		...Array.from({ length: 20 }, (_, offset) => {
+			const basisPoints = (offset + 1) * 500;
+			const targetBytes = Number(
+				(BigInt(FILE_SIZE_BYTES) * BigInt(basisPoints) + 9_999n) / 10_000n,
+			);
+			const event = completionEvents.find(
+				(value) => value.completedBytes >= targetBytes,
+			);
+			return { basisPoints, targetBytes, ...event };
+		}),
+	];
+
+	assert.throws(
+		() => validateBenchmarkResult(result, options),
+		/already crossed before its triggering chunk completion/,
+	);
+});
+
 test("requires bounded, error-free memory telemetry covering the canonical read", () => {
 	for (const [mutate, pattern] of [
 		[
@@ -779,15 +1224,13 @@ test("requires bounded, error-free memory telemetry covering the canonical read"
 		],
 		[
 			(result) => {
-				result.downloadMemoryTelemetry.readerJsHeap.samples[0].capturedAt =
-					1_171;
+				result.downloadMemoryTelemetry.readerJsHeap.samples[0].capturedAt = 1_171;
 			},
 			/does not bracket the click-to-sink observation window/,
 		],
 		[
 			(result) => {
-				result.downloadMemoryTelemetry.writerJsHeap.samples[1].capturedAt =
-					1_199;
+				result.downloadMemoryTelemetry.writerJsHeap.samples[1].capturedAt = 1_199;
 			},
 			/does not bracket the click-to-sink observation window/,
 		],
@@ -828,8 +1271,7 @@ test("requires bounded, error-free memory telemetry covering the canonical read"
 		],
 		[
 			(result) => {
-				result.downloadMemoryTelemetry.hostRss.samples[0].browserRoleBytes.renderer +=
-					1;
+				result.downloadMemoryTelemetry.hostRss.samples[0].browserRoleBytes.renderer += 1;
 			},
 			/RSS totals are inconsistent/,
 		],
@@ -857,8 +1299,7 @@ test("requires bounded, error-free memory telemetry covering the canonical read"
 		],
 		[
 			(result) => {
-				result.downloadMemoryTelemetry.readerJsHeap.samples[0].unbounded =
-					"x";
+				result.downloadMemoryTelemetry.readerJsHeap.samples[0].unbounded = "x";
 			},
 			/unexpected or missing fields/,
 		],
@@ -1249,19 +1690,31 @@ test("bounds Node-file server timing against its browser sink timing", () => {
 	);
 });
 
-test("rejects a status-only passed payload at the v5 evidence envelope", () => {
+test("rejects a status-only passed payload at the v6 evidence envelope", () => {
 	assert.throws(
 		() => validateBenchmarkResultEnvelope({ status: "passed" }, options),
 		/missing schema/,
 	);
 });
 
-test("requires explicit error evidence on failed v5 envelopes", () => {
+test("requires explicit error evidence on failed v6 envelopes", () => {
 	const completeFailure = validResult();
 	completeFailure.status = "failed";
 	completeFailure.failure = { message: "synthetic browser failure" };
 	assert.equal(
 		validateBenchmarkResultEnvelope(completeFailure, options).status,
+		"failed",
+	);
+	const partialUploadFailure = structuredClone(completeFailure);
+	const partialDiagnostics =
+		partialUploadFailure.writerDiagnostics.lastUploadDiagnostics;
+	partialDiagnostics.progressTelemetry.milestones =
+		partialDiagnostics.progressTelemetry.milestones.slice(0, 4);
+	partialDiagnostics.failureAt = 1_020;
+	partialDiagnostics.failureMessage = "synthetic chunk failure";
+	partialDiagnostics.finishedAt = null;
+	assert.equal(
+		validateBenchmarkResultEnvelope(partialUploadFailure, options).status,
 		"failed",
 	);
 

--- a/scripts/file-share/run-file-share-benchmark.mjs
+++ b/scripts/file-share/run-file-share-benchmark.mjs
@@ -120,6 +120,8 @@ const SCENARIOS = {
 };
 const DROP_HOOK_MARKER = "/* peerbit-benchmark-hook */";
 const DROP_UPDATE_LIST_MARKER = "/* peerbit-benchmark-update-list */";
+const DROP_UPLOAD_DIAGNOSTICS_MARKER =
+	"/* peerbit-benchmark-upload-diagnostics */";
 const DROP_LOCALITY_HOOK_MARKER =
 	"/* peerbit-benchmark-locality-prefix-preload */";
 const DROP_LOCALITY_TOPOLOGY_MARKER =
@@ -301,7 +303,7 @@ const maybeCopyFrontendCerts = async ({
 
 export const instrumentFileShareFrontend = async (
 	frontendRoot,
-	{ requireLocalityHook = false } = {},
+	{ requireLocalityHook = false, requireUploadDiagnostics = false } = {},
 ) => {
 	const dropPath = path.join(frontendRoot, "src", "Drop.tsx");
 	let contents = await fsp.readFile(dropPath, "utf8");
@@ -313,6 +315,9 @@ export const instrumentFileShareFrontend = async (
 		contents.includes("__peerbitFileShareBenchmarkStats") &&
 		contents.includes("updateListStats") &&
 		contents.includes("updateListCalls.push(updateListStats)");
+	const hasUploadDiagnosticsHook = (source) =>
+		source.includes("lastUploadDiagnostics:") &&
+		source.includes(".lastUploadDiagnostics ?? null");
 	if (requireLocalityHook && !hasExistingBenchmarkHook) {
 		throw new Error(
 			`Controlled-locality benchmarks require the modern rich test-hook contract in ${dropPath}`,
@@ -322,6 +327,7 @@ export const instrumentFileShareFrontend = async (
 		(contents.includes(DROP_HOOK_MARKER) || hasExistingBenchmarkHook) &&
 		(contents.includes(DROP_UPDATE_LIST_MARKER) ||
 			hasExistingUpdateListStats) &&
+		(!requireUploadDiagnostics || hasUploadDiagnosticsHook(contents)) &&
 		(!requireLocalityHook ||
 			(contents.includes(DROP_LOCALITY_HOOK_MARKER) &&
 				contents.includes(DROP_LOCALITY_PRELOAD_DEADLINE_MARKER) &&
@@ -364,9 +370,12 @@ export const instrumentFileShareFrontend = async (
                     programAddress: program?.address ?? null,
                     programClosed: program?.closed ?? null,
                     peerHash: peer?.identity?.publicKey?.hashcode?.() ?? null,
-                    connectionCount: connections.length,
-                    connectionPeers: connections,
-                    replicatorCount:
+					connectionCount: connections.length,
+					connectionPeers: connections,
+					${DROP_UPLOAD_DIAGNOSTICS_MARKER}
+					lastUploadDiagnostics:
+						(program as any)?.lastUploadDiagnostics ?? null,
+					replicatorCount:
                         replicators && typeof replicators.size === "number"
                             ? replicators.size
                             : null,
@@ -389,6 +398,19 @@ export const instrumentFileShareFrontend = async (
 			throw new Error(`Could not find benchmark hook anchor in ${dropPath}`);
 		}
 		contents = contents.replace(anchor, `${hook}${anchor}`);
+	}
+	if (requireUploadDiagnostics && !hasUploadDiagnosticsHook(contents)) {
+		const uploadDiagnosticsAnchor =
+			"                    connectionPeers: connections,\n";
+		if (!contents.includes(uploadDiagnosticsAnchor)) {
+			throw new Error(
+				`File-share upload benchmarks require the upload-diagnostics hook in ${dropPath}`,
+			);
+		}
+		contents = contents.replace(
+			uploadDiagnosticsAnchor,
+			`${uploadDiagnosticsAnchor}                    ${DROP_UPLOAD_DIAGNOSTICS_MARKER}\n                    lastUploadDiagnostics:\n                        (program as any)?.lastUploadDiagnostics ?? null,\n`,
+		);
 	}
 
 	const updateListAnchor = `    const updateList = async () => {\n        if (files.program.files.log.closed) {\n            return;\n        }\n\n        // TODO don't reload the whole list, just add the new elements..\n        try {\n`;
@@ -1176,6 +1198,7 @@ const main = async () => {
 		});
 		await instrumentFileShareFrontend(frontendRoot, {
 			requireLocalityHook: readerLocalChunkTarget != null,
+			requireUploadDiagnostics: scenario === "upload",
 		});
 		await instrumentFileShareViteConfigs(frontendRoot);
 		const generatedSpec = path.join(

--- a/scripts/file-share/template-contract.test.mjs
+++ b/scripts/file-share/template-contract.test.mjs
@@ -17,14 +17,14 @@ const templates = [
 ];
 
 for (const name of templates) {
-	test(`${name} emits the atomic v5 result envelope`, async () => {
+	test(`${name} emits the atomic v6 result envelope`, async () => {
 		const contents = await readFile(
 			path.join(repoRoot, "scripts", "file-share", "templates", name),
 			"utf8",
 		);
 		for (const required of [
 			'id: "peerbit-file-share-benchmark"',
-			"version: 5",
+			"version: 6",
 			"PW_BENCHMARK_RUN_NONCE",
 			"PW_BENCHMARK_INVOCATION",
 			"PW_BENCHMARK_PROVENANCE",
@@ -326,6 +326,10 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"utf8",
 	);
 	for (const required of [
+		"peerbit-benchmark-upload-diagnostics",
+		"lastUploadDiagnostics:",
+		"(program as any)?.lastUploadDiagnostics ?? null",
+		'requireUploadDiagnostics: scenario === "upload"',
 		"peerbit-benchmark-locality-prefix-preload",
 		"peerbit-benchmark-locality-preload-aggregate-deadline",
 		"peerbit-benchmark-locality-replicator-hashes",
@@ -505,6 +509,52 @@ updateListCalls.push(updateListStats);
 	assert.equal(await readFile(dropPath, "utf8"), migrated);
 });
 
+test("upload diagnostics instrumentation migrates a reused v5 fallback idempotently", async (t) => {
+	const frontendRoot = await mkdtemp(
+		path.join(os.tmpdir(), "peerbit-upload-diagnostics-instrumentation-"),
+	);
+	t.after(async () => rm(frontendRoot, { recursive: true, force: true }));
+	const src = path.join(frontendRoot, "src");
+	await mkdir(src);
+	const dropPath = path.join(src, "Drop.tsx");
+	await writeFile(
+		dropPath,
+		`/* peerbit-benchmark-hook */
+const __peerbitFileShareTestHooks = {
+    setReplicationRole,
+    getDiagnostics: async () => {
+        const program = files.program;
+        const connections = [];
+        return {
+                    programAddress: program?.address ?? null,
+                    programClosed: program?.closed ?? null,
+                    connectionCount: connections.length,
+                    connectionPeers: connections,
+                    replicatorCount: null,
+        };
+    },
+};
+/* peerbit-benchmark-update-list */
+const __peerbitFileShareBenchmarkStats = { updateListStats };
+const updateListStats = {};
+updateListCalls.push(updateListStats);
+`,
+	);
+	await instrumentFileShareFrontend(frontendRoot, {
+		requireUploadDiagnostics: true,
+	});
+	const migrated = await readFile(dropPath, "utf8");
+	assert.ok(migrated.includes("/* peerbit-benchmark-upload-diagnostics */"));
+	assert.ok(
+		migrated.includes("(program as any)?.lastUploadDiagnostics ?? null"),
+	);
+	assert.equal([...migrated.matchAll(/lastUploadDiagnostics:/g)].length, 1);
+	await instrumentFileShareFrontend(frontendRoot, {
+		requireUploadDiagnostics: true,
+	});
+	assert.equal(await readFile(dropPath, "utf8"), migrated);
+});
+
 test("aggregate comparisons require every planned invocation to pass", async () => {
 	const standalone = await readFile(
 		path.join(
@@ -588,19 +638,22 @@ test("download memory support is bounded, serial, and cleanup-safe", async () =>
 		"samples.length >= maxSamples - 1",
 		"await activeSample",
 		"await takeSample(true)",
-		'newCDPSession(page)',
+		"newCDPSession(page)",
 		'"Page JS heap CDP session creation"',
-		'Performance.getMetrics',
+		"Performance.getMetrics",
 		'metric.name === "JSHeapUsedSize"',
 		"newBrowserCDPSession()",
 		'"Browser RSS CDP session creation"',
-		'SystemInfo.getProcessInfo',
+		"SystemInfo.getProcessInfo",
 		'"ps"',
 		"process.memoryUsage().rss",
 		"playwright-worker-node-including-in-process-local-bootstrap",
 		"samplingErrorOverflowCount",
 	]) {
-		assert.ok(contents.includes(required), `memory support missing ${required}`);
+		assert.ok(
+			contents.includes(required),
+			`memory support missing ${required}`,
+		);
 	}
 	assert.ok(
 		contents.indexOf("await activeSample") <

--- a/scripts/file-share/templates/seeder-probe.e2e.spec.ts
+++ b/scripts/file-share/templates/seeder-probe.e2e.spec.ts
@@ -24,7 +24,7 @@ const EFFECTIVE_SAMPLE_INTERVAL_MS = Math.max(
 );
 const RESULT_SCHEMA = {
 	id: "peerbit-file-share-benchmark",
-	version: 5,
+	version: 6,
 } as const;
 const RUN_NONCE = process.env.PW_BENCHMARK_RUN_NONCE;
 const parseJsonEnvironment = (name: string) => {

--- a/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
+++ b/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
@@ -4,9 +4,9 @@ import { randomUUID } from "node:crypto";
 import { mkdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { startBootstrapPeer } from "./bootstrapPeer";
+import { startDownloadMemoryTelemetry } from "./generated.download-memory-telemetry.mjs";
 import { sha256AndCrc32OpfsSavedViaPicker } from "./generated.opfs-readback.mjs";
 import { withDeadline } from "./generated.promise-deadline.mjs";
-import { startDownloadMemoryTelemetry } from "./generated.download-memory-telemetry.mjs";
 import {
 	armSavedViaPicker,
 	crc32SavedViaPicker,
@@ -113,7 +113,7 @@ const FIXTURE_SEED =
 	process.env.PW_FIXTURE_SEED || "peerbit-file-share-benchmark-v1";
 const RESULT_SCHEMA = {
 	id: "peerbit-file-share-benchmark",
-	version: 5,
+	version: 6,
 } as const;
 const RUN_NONCE = process.env.PW_BENCHMARK_RUN_NONCE;
 const parseJsonEnvironment = (name: string) => {
@@ -1523,17 +1523,14 @@ test.describe("generated transfer-validity benchmark", () => {
 			await expect(downloadButton).toBeEnabled({
 				timeout: DOWNLOAD_TIMEOUT_MS,
 			});
-			downloadMemoryTelemetryController =
-				await startDownloadMemoryTelemetry({
-					browser,
-					reader,
-					writer,
-					downloadTimeoutMs: DOWNLOAD_TIMEOUT_MS,
-					schedulingToleranceMs:
-						TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS,
-				});
-			downloadMemoryTelemetry =
-				downloadMemoryTelemetryController.snapshot();
+			downloadMemoryTelemetryController = await startDownloadMemoryTelemetry({
+				browser,
+				reader,
+				writer,
+				downloadTimeoutMs: DOWNLOAD_TIMEOUT_MS,
+				schedulingToleranceMs: TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS,
+			});
+			downloadMemoryTelemetry = downloadMemoryTelemetryController.snapshot();
 			const initialMemorySeries = [
 				downloadMemoryTelemetry.readerJsHeap,
 				downloadMemoryTelemetry.writerJsHeap,
@@ -1562,8 +1559,7 @@ test.describe("generated transfer-validity benchmark", () => {
 			await downloadButton.click();
 			const download = await downloadCompletion;
 			downloadCompletionObservedAt = Date.now();
-			downloadMemoryTelemetry =
-				await downloadMemoryTelemetryController.stop();
+			downloadMemoryTelemetry = await downloadMemoryTelemetryController.stop();
 			const memorySeries = [
 				downloadMemoryTelemetry.readerJsHeap,
 				downloadMemoryTelemetry.writerJsHeap,


### PR DESCRIPTION
## Summary

- advance file-share benchmark results to schema v6 and require exactly 21 application-level upload chunk-commit milestones (0% through 100% in 5% increments)
- fail closed on stale, partial, reordered, delayed, geometrically impossible, or read-contradictory passed telemetry while retaining bounded failed-run diagnostics
- require the file-share diagnostics hook for upload scenarios, including idempotent migration of reused v5 fallback instrumentation
- document that the metric measures completed library chunk puts, not wire bytes or remote acknowledgements

This consumes the upload telemetry merged in dao-xyz/peerbit-examples#207.

## Validation

- `pnpm bench:file-share:test` — 169/169 passed
- Prettier check and `git diff --check` passed
- independent correctness and adversarial reviews found no remaining P0/P1/P2 issues
- generated-validity fuzz: 180 concurrent completion permutations across nine exact/partial-tail chunk geometries accepted; malformed timing/geometry repros rejected
- real deterministic Chromium smoke passed 1/1 against peerbit-examples `0b5ce3eeabd3f48fcefdee832e7b3d7e8176797b`: schema v6, 16 upload/read chunks, 21 milestones, SHA-256/CRC integrity verified, zero collected errors/request failures (8 MiB fixed1 local cohort; 244 ms upload, 792 ms library stream wall)
