### PR TITLE
fix(benchmarks): preserve file-share failure evidence

### DIFF
--- a/scripts/file-share/README.md
+++ b/scripts/file-share/README.md
@@ -3,7 +3,7 @@
 Run a single checkout with `pnpm bench:file-share:local` or compare pinned
 Peerbit revisions with `pnpm bench:file-share:matrix`.
 
-Result schema v6 defines `errorCount` as every uncaught browser `pageerror`,
+Result schema v7 defines `errorCount` as every uncaught browser `pageerror`,
 every browser `console.error`, every console message at any level that contains
 a declared Peerbit failure signature, and scenario-recorded operation failures.
 Each result embeds the exact `errorCollectionDefinition` and signature list.
@@ -11,7 +11,7 @@ Playwright `requestfailed` events are retained separately under
 `requestFailures`; they are diagnostics and are not automatically fatal because
 peer-to-peer discovery can legitimately exercise failed network candidates.
 
-Passed schema v6 upload results require `writerDiagnostics.lastUploadDiagnostics`
+Passed schema v7 upload results require `writerDiagnostics.lastUploadDiagnostics`
 to contain exactly 21 bounded progress milestones from 0% through 100% in 5%
 increments. Each point records the aggregate bytes whose application-level
 chunk puts completed, using the library upload clock and exact ceil-rounded byte
@@ -47,7 +47,7 @@ sinks only in separate benchmark sessions; aggregate comparison objects fail
 closed on mixed sinks, and every passed result and aggregate labels
 non-hash-only cohorts non-authoritative.
 
-Schema v6 upload results also record bounded download-window memory telemetry. After any
+Schema v7 upload results also record bounded download-window memory telemetry. After any
 controlled-locality stabilization, the harness arms serial samplers immediately
 before the timed click and forces a final sample as soon as the selected sink
 completion is observed, before integrity readback or terminal-topology checks.
@@ -118,6 +118,19 @@ per-chunk timings remain in each result and can be rebucketed into 5% progress
 windows without losing the underlying samples. Without the paired locality
 options, roles, persistence policy, and seeder-drop gates are unchanged.
 
+Schema v7 records the exact versioned `seederDropPolicy` and a final numeric
+`terminal` seeder snapshot after download and integrity verification. Every
+upload cohort also records top-level `integrityVerifiedAt`: it remains `null`
+until the aggregate size, SHA-256, CRC-32, manifest, and persistence gates have
+succeeded. The final snapshot must be at or after that timestamp and, for a
+controlled-locality cohort, at or after terminal-topology completion. The
+validator recomputes both drop flags from the ordered snapshots. A single
+below-baseline sample followed by recovery remains visible through
+`droppedSeeders: true` but does not invalidate an otherwise valid run. Two
+consecutive below-baseline samples, or a below-baseline terminal sample, set
+`unexpectedSeederDrop: true` and fail the run. Missing policy evidence,
+contradictory flags, and missing or non-final terminal snapshots fail closed.
+
 The standalone runner continues counterbalanced repetitions after an individual
 Playwright or result-validation failure when setup remains usable. Once
 invocation execution begins, it writes a summary with planned, completed,
@@ -128,6 +141,10 @@ before that
 summary exists. If browser evidence is missing or malformed, the synthetic
 failure uses `errorCount: null` and
 `errorCollectionComplete: false` instead of claiming that zero errors occurred.
+Upload failures likewise use a null/false/null integrity projection unless the
+browser result contains internally consistent integrity evidence. A completed
+browser integrity gate is projected with its original timestamp and is
+revalidated; malformed fields cannot be promoted into canonical evidence.
 
 The matrix runner also reads nonzero sub-run summaries, keeps their failure
 evidence in the matrix summary, continues later invocations, and exits nonzero

--- a/scripts/file-share/benchmark-orchestration.mjs
+++ b/scripts/file-share/benchmark-orchestration.mjs
@@ -2,7 +2,19 @@ import fsp from "node:fs/promises";
 
 export const BENCHMARK_RESULT_SCHEMA = Object.freeze({
 	id: "peerbit-file-share-benchmark",
-	version: 6,
+	version: 7,
+});
+
+export const SEEDER_DROP_POLICY = Object.freeze({
+	id: "peerbit-file-share-seeder-drop-policy",
+	version: 1,
+	belowBaselineDefinition:
+		"writerSeeders < baselineWriterSeeders || readerSeeders < baselineReaderSeeders",
+	evaluatedSnapshotDefinition:
+		"all chronological snapshots after the unique seeders-ready baseline snapshot",
+	consecutiveBelowBaselineSnapshotThreshold: 2,
+	terminalSnapshotLabel: "terminal",
+	terminalBelowBaselineIsUnexpected: true,
 });
 
 export const BENCHMARK_SUMMARY_SCHEMA = Object.freeze({
@@ -34,6 +46,103 @@ export const REQUEST_FAILURE_COLLECTION_DEFINITION =
 
 const isRecord = (value) =>
 	value != null && typeof value === "object" && !Array.isArray(value);
+
+const SHA256_BASE64_PATTERN = /^[A-Za-z0-9+/]{43}=$/;
+const CRC32_HEX_PATTERN = /^[0-9a-f]{8}$/;
+
+const hasCompleteVerifiedUploadIntegrityEvidence = (
+	integrity,
+	{ fileMb, fixtureSeed, downloadSink },
+) => {
+	const expectedSizeBytes = fileMb * 1024 * 1024;
+	if (
+		!isRecord(integrity) ||
+		!Number.isSafeInteger(expectedSizeBytes) ||
+		expectedSizeBytes <= 0 ||
+		!["hash-only", "opfs", "node-file"].includes(downloadSink) ||
+		integrity.fixtureMode !== "deterministic" ||
+		integrity.fixtureFormat !== "aes-256-ctr-v1" ||
+		integrity.fixtureSeed !== fixtureSeed ||
+		integrity.expectedSizeBytes !== expectedSizeBytes ||
+		integrity.sourceSizeBytes !== expectedSizeBytes ||
+		integrity.manifestSizeBytes !== expectedSizeBytes ||
+		integrity.downloadedSizeBytes !== expectedSizeBytes ||
+		integrity.sizeVerified !== true ||
+		integrity.manifestVerified !== true ||
+		integrity.downloadSink !== downloadSink ||
+		integrity.verified !== true
+	) {
+		return false;
+	}
+	const sourceSha256 = integrity.sourceSha256Base64;
+	const sourceCrc32 = integrity.sourceCrc32Hex;
+	if (
+		typeof sourceSha256 !== "string" ||
+		!SHA256_BASE64_PATTERN.test(sourceSha256) ||
+		integrity.manifestSha256Base64 !== sourceSha256 ||
+		integrity.libraryComputedSha256Base64 !== sourceSha256 ||
+		integrity.sha256Verified !== true ||
+		integrity.librarySha256Verified !== true ||
+		typeof sourceCrc32 !== "string" ||
+		!CRC32_HEX_PATTERN.test(sourceCrc32) ||
+		integrity.downloadedCrc32Hex !== sourceCrc32 ||
+		integrity.crc32Verified !== true
+	) {
+		return false;
+	}
+	if (downloadSink === "hash-only") {
+		return (
+			integrity.downloadedSha256Base64 === null &&
+			integrity.persistedSinkSha256Verified === null &&
+			integrity.sinkPersistence === "none" &&
+			integrity.sinkPersistenceVerified === null
+		);
+	}
+	return (
+		integrity.downloadedSha256Base64 === sourceSha256 &&
+		integrity.persistedSinkSha256Verified === true &&
+		integrity.sinkPersistence === downloadSink &&
+		integrity.sinkPersistenceVerified === true
+	);
+};
+
+export const projectUploadIntegrityEvidence = (
+	browserResult,
+	{ fileMb, fixtureSeed, downloadSink } = {},
+) => {
+	if (!isRecord(browserResult)) {
+		return {
+			integrity: null,
+			integrityVerified: false,
+			integrityVerifiedAt: null,
+		};
+	}
+	const integrity = browserResult.integrity ?? null;
+	const integrityVerified = browserResult.integrityVerified ?? false;
+	const integrityVerifiedAt = browserResult.integrityVerifiedAt ?? null;
+	const validUnverifiedEvidence =
+		integrityVerified === false &&
+		integrityVerifiedAt === null &&
+		(integrity === null ||
+			(isRecord(integrity) && integrity.verified === false));
+	const validVerifiedEvidence =
+		integrityVerified === true &&
+		Number.isSafeInteger(integrityVerifiedAt) &&
+		integrityVerifiedAt > 0 &&
+		hasCompleteVerifiedUploadIntegrityEvidence(integrity, {
+			fileMb,
+			fixtureSeed,
+			downloadSink,
+		});
+	if (!validUnverifiedEvidence && !validVerifiedEvidence) {
+		return {
+			integrity: null,
+			integrityVerified: false,
+			integrityVerifiedAt: null,
+		};
+	}
+	return { integrity, integrityVerified, integrityVerifiedAt };
+};
 
 export const serializeError = (error) => {
 	if (error instanceof Error) {
@@ -189,6 +298,17 @@ export const createInvocationFailureEvidence = ({
 					kind: "result-validation",
 					...serializeError(failure),
 				});
+	const uploadEvidence =
+		scenario === "upload"
+			? {
+					seederDropPolicy: SEEDER_DROP_POLICY,
+					...projectUploadIntegrityEvidence(browserResult, {
+						fileMb,
+						fixtureSeed: invocation?.fixtureSeed,
+						downloadSink: invocation?.downloadSink,
+					}),
+				}
+			: {};
 	return {
 		schema: BENCHMARK_RESULT_SCHEMA,
 		runNonce,
@@ -199,6 +319,7 @@ export const createInvocationFailureEvidence = ({
 		mode,
 		networkMode: network,
 		fileSizeMb: fileMb,
+		...uploadEvidence,
 		stage: "runner-evidence",
 		browserStatus: browserResult?.status ?? null,
 		browserStage: browserResult?.stage ?? null,

--- a/scripts/file-share/benchmark-orchestration.test.mjs
+++ b/scripts/file-share/benchmark-orchestration.test.mjs
@@ -3,20 +3,66 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { createBenchmarkInvocation } from "./benchmark-invocation.mjs";
 import {
 	BENCHMARK_RESULT_SCHEMA,
 	BENCHMARK_SUMMARY_SCHEMA,
+	ERROR_COLLECTION_DEFINITION,
+	KNOWN_PEERBIT_FAILURE_SIGNATURES,
+	REQUEST_FAILURE_COLLECTION_DEFINITION,
+	SEEDER_DROP_POLICY,
 	classifySubprocessSummary,
 	countBenchmarkOutcomes,
 	createInvocationFailureEvidence,
-	ERROR_COLLECTION_DEFINITION,
 	executePlanContinuing,
 	extractCollectedErrorEvidence,
 	inspectSingleInvocationSummary,
-	KNOWN_PEERBIT_FAILURE_SIGNATURES,
 	readJsonEvidence,
-	REQUEST_FAILURE_COLLECTION_DEFINITION,
 } from "./benchmark-orchestration.mjs";
+import { validateBenchmarkResultEnvelope } from "./benchmark-validity.mjs";
+import { createMatrixInvocationFailure } from "./run-file-share-benchmark-matrix.mjs";
+
+const RUN_NONCE = "123e4567-e89b-42d3-a456-426614174000";
+const FILE_MB = 5;
+const FILE_SIZE_BYTES = FILE_MB * 1024 * 1024;
+const SHA256 = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+const PROVENANCE = {
+	harness: {
+		requestedRef: "harness-worktree",
+		resolvedCommit: "d".repeat(40),
+		dirty: true,
+		worktreeDigest: "e".repeat(64),
+	},
+	peerbit: {
+		requestedRef: "candidate",
+		resolvedCommit: "a".repeat(40),
+		dirty: false,
+		worktreeDigest: null,
+	},
+	examples: {
+		requestedRef: "examples",
+		resolvedCommit: "b".repeat(40),
+		lockfileSha256: "c".repeat(64),
+		dirty: false,
+		worktreeDigest: null,
+	},
+};
+const UPLOAD_INVOCATION = createBenchmarkInvocation({
+	scenario: "upload",
+	mode: "adaptive",
+	network: "local",
+	integrationMode: "link",
+	fileMb: FILE_MB,
+	fixtureSeed: "fixture-seed",
+});
+const uploadEnvelopeOptions = {
+	expectedMode: "adaptive",
+	expectedFileMb: FILE_MB,
+	expectedNetwork: "local",
+	expectedRunNonce: RUN_NONCE,
+	expectedProvenance: PROVENANCE,
+	expectedInvocation: UPLOAD_INVOCATION,
+};
 
 test("reads parsed, missing, and malformed JSON evidence without throwing", async () => {
 	const root = await mkdtemp(path.join(os.tmpdir(), "peerbit-evidence-test-"));
@@ -80,8 +126,38 @@ test("stops a plan after an explicitly unsafe failure", async () => {
 	assert.equal(outcomes.at(-1).status, "rejected");
 });
 
-test("constructs honest failure evidence from a failed browser result", () => {
+test("constructs honest standalone and matrix failures from browser evidence", () => {
 	const browserResult = {
+		runNonce: RUN_NONCE,
+		status: "failed",
+		stage: "verify-terminal-reader-topology",
+		integrity: {
+			fixtureMode: "deterministic",
+			fixtureFormat: "aes-256-ctr-v1",
+			fixtureSeed: "fixture-seed",
+			expectedSizeBytes: FILE_SIZE_BYTES,
+			sourceSizeBytes: FILE_SIZE_BYTES,
+			manifestSizeBytes: FILE_SIZE_BYTES,
+			downloadedSizeBytes: FILE_SIZE_BYTES,
+			sourceSha256Base64: SHA256,
+			manifestSha256Base64: SHA256,
+			libraryComputedSha256Base64: SHA256,
+			downloadedSha256Base64: null,
+			sourceCrc32Hex: "00000000",
+			downloadedCrc32Hex: "00000000",
+			downloadSink: "hash-only",
+			sinkPersistence: "none",
+			sinkPersistenceVerified: null,
+			sizeVerified: true,
+			manifestVerified: true,
+			sha256Verified: true,
+			librarySha256Verified: true,
+			persistedSinkSha256Verified: null,
+			crc32Verified: true,
+			verified: true,
+		},
+		integrityVerified: true,
+		integrityVerifiedAt: 1_205,
 		errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
 		knownPeerbitFailureSignatures: KNOWN_PEERBIT_FAILURE_SIGNATURES,
 		errorCollectionComplete: true,
@@ -96,10 +172,10 @@ test("constructs honest failure evidence from a failed browser result", () => {
 		scenario: "upload",
 		mode: "adaptive",
 		network: "local",
-		fileMb: 5,
-		runNonce: "nonce",
-		invocation: { mode: "adaptive" },
-		provenance: { peerbit: { resolvedCommit: "a" } },
+		fileMb: FILE_MB,
+		runNonce: RUN_NONCE,
+		invocation: UPLOAD_INVOCATION,
+		provenance: PROVENANCE,
 		resultFile: "/tmp/result.json",
 		processOutcome: {
 			exitCode: 1,
@@ -115,7 +191,95 @@ test("constructs honest failure evidence from a failed browser result", () => {
 	assert.equal(result.errorCount, 1);
 	assert.equal(result.requestFailureCount, 1);
 	assert.equal(result.browserResult, browserResult);
+	assert.deepEqual(result.seederDropPolicy, SEEDER_DROP_POLICY);
+	assert.equal(result.integrity, browserResult.integrity);
+	assert.equal(result.integrityVerified, true);
+	assert.equal(result.integrityVerifiedAt, 1_205);
 	assert.equal(result.failure.kind, "nonzero-exit");
+	assert.equal(
+		validateBenchmarkResultEnvelope(result, uploadEnvelopeOptions).status,
+		"failed",
+	);
+
+	for (const key of ["integrity", "integrityVerified", "integrityVerifiedAt"]) {
+		const falsified = structuredClone(result);
+		if (key === "integrity") {
+			falsified.integrity = {
+				...falsified.integrity,
+				sourceCrc32Hex: "ffffffff",
+			};
+		} else if (key === "integrityVerified") {
+			falsified.integrityVerified = false;
+		} else {
+			falsified.integrityVerifiedAt += 1;
+		}
+		assert.throws(
+			() => validateBenchmarkResultEnvelope(falsified, uploadEnvelopeOptions),
+			/projection does not exactly match/,
+		);
+	}
+	for (const kind of ["missing", "malformed"]) {
+		const mislabeled = structuredClone(result);
+		mislabeled.resultEvidence = { kind };
+		assert.throws(
+			() => validateBenchmarkResultEnvelope(mislabeled, uploadEnvelopeOptions),
+			/without parsed browser evidence must use a null integrity projection/,
+		);
+	}
+
+	const contradictoryBrowserResult = structuredClone(browserResult);
+	contradictoryBrowserResult.integrity.sourceCrc32Hex = "ffffffff";
+	const sanitized = createInvocationFailureEvidence({
+		scenario: "upload",
+		mode: "adaptive",
+		network: "local",
+		fileMb: FILE_MB,
+		runNonce: RUN_NONCE,
+		invocation: UPLOAD_INVOCATION,
+		provenance: PROVENANCE,
+		resultFile: "/tmp/result.json",
+		processOutcome: { exitCode: 1, signal: null },
+		resultEvidence: { kind: "parsed", value: contradictoryBrowserResult },
+		failure: new Error("contradictory integrity evidence"),
+	});
+	assert.equal(sanitized.integrity, null);
+	assert.equal(sanitized.integrityVerified, false);
+	assert.equal(sanitized.integrityVerifiedAt, null);
+	assert.equal(
+		validateBenchmarkResultEnvelope(sanitized, uploadEnvelopeOptions).status,
+		"failed",
+	);
+
+	const matrixResult = createMatrixInvocationFailure({
+		plan: { mode: "adaptive", variant: "candidate", run: 1, sequence: 0 },
+		scenario: "upload",
+		network: "local",
+		fileMb: FILE_MB,
+		summaryFile: "/tmp/summary.json",
+		processOutcome: { exitCode: 1, signal: null },
+		expectedInvocation: UPLOAD_INVOCATION,
+		expectedProvenance: PROVENANCE,
+		failures: [{ kind: "nonzero-exit", message: "sub-run failed" }],
+		browserResult,
+	});
+	assert.deepEqual(matrixResult.seederDropPolicy, SEEDER_DROP_POLICY);
+	assert.equal(matrixResult.integrity, browserResult.integrity);
+	assert.equal(matrixResult.integrityVerified, true);
+	assert.equal(matrixResult.integrityVerifiedAt, 1_205);
+	assert.equal(
+		validateBenchmarkResultEnvelope(matrixResult, uploadEnvelopeOptions).status,
+		"failed",
+	);
+	const falsifiedMatrixResult = structuredClone(matrixResult);
+	falsifiedMatrixResult.integrityVerifiedAt += 1;
+	assert.throws(
+		() =>
+			validateBenchmarkResultEnvelope(
+				falsifiedMatrixResult,
+				uploadEnvelopeOptions,
+			),
+		/projection does not exactly match/,
+	);
 });
 
 test("rejects malformed error entries instead of treating collection as complete", () => {
@@ -141,10 +305,10 @@ test("uses null rather than claiming zero errors when result evidence is absent"
 		scenario: "upload",
 		mode: "adaptive",
 		network: "local",
-		fileMb: 5,
-		runNonce: "nonce",
-		invocation: {},
-		provenance: {},
+		fileMb: FILE_MB,
+		runNonce: RUN_NONCE,
+		invocation: UPLOAD_INVOCATION,
+		provenance: PROVENANCE,
 		resultFile: "/tmp/missing.json",
 		processOutcome: null,
 		resultEvidence: {
@@ -158,6 +322,137 @@ test("uses null rather than claiming zero errors when result evidence is absent"
 	assert.equal(result.errorCount, null);
 	assert.equal(result.errors, null);
 	assert.equal(result.failure.kind, "missing-result");
+	assert.deepEqual(result.seederDropPolicy, SEEDER_DROP_POLICY);
+	assert.equal(result.integrity, null);
+	assert.equal(result.integrityVerified, false);
+	assert.equal(result.integrityVerifiedAt, null);
+	assert.equal(
+		validateBenchmarkResultEnvelope(result, uploadEnvelopeOptions).status,
+		"failed",
+	);
+
+	const malformed = createInvocationFailureEvidence({
+		scenario: "upload",
+		mode: "adaptive",
+		network: "local",
+		fileMb: FILE_MB,
+		runNonce: RUN_NONCE,
+		invocation: UPLOAD_INVOCATION,
+		provenance: PROVENANCE,
+		resultFile: "/tmp/malformed.json",
+		processOutcome: null,
+		resultEvidence: {
+			kind: "malformed",
+			filePath: "/tmp/malformed.json",
+			failure: { message: "Unexpected end of JSON input" },
+		},
+		failure: new Error("malformed"),
+	});
+	assert.equal(malformed.integrity, null);
+	assert.equal(malformed.integrityVerified, false);
+	assert.equal(malformed.integrityVerifiedAt, null);
+	assert.equal(
+		validateBenchmarkResultEnvelope(malformed, uploadEnvelopeOptions).status,
+		"failed",
+	);
+});
+
+test("sanitizes malformed browser integrity evidence and rejects forged projections", () => {
+	const browserResult = {
+		status: "failed",
+		integrity: { verified: true, sourceCrc32Hex: "forged" },
+		integrityVerified: true,
+		integrityVerifiedAt: "now",
+		errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
+		knownPeerbitFailureSignatures: KNOWN_PEERBIT_FAILURE_SIGNATURES,
+		errorCollectionComplete: true,
+		errorCount: 0,
+		errors: [],
+		requestFailureCollectionDefinition: REQUEST_FAILURE_COLLECTION_DEFINITION,
+		requestFailureCollectionComplete: true,
+		requestFailureCount: 0,
+		requestFailures: [],
+	};
+	const result = createInvocationFailureEvidence({
+		scenario: "upload",
+		mode: "adaptive",
+		network: "local",
+		fileMb: FILE_MB,
+		runNonce: RUN_NONCE,
+		invocation: UPLOAD_INVOCATION,
+		provenance: PROVENANCE,
+		resultFile: "/tmp/result.json",
+		processOutcome: { exitCode: 1, signal: null },
+		resultEvidence: { kind: "parsed", value: browserResult },
+		failure: new Error("malformed integrity evidence"),
+	});
+	assert.equal(result.integrity, null);
+	assert.equal(result.integrityVerified, false);
+	assert.equal(result.integrityVerifiedAt, null);
+	assert.equal(
+		validateBenchmarkResultEnvelope(result, uploadEnvelopeOptions).status,
+		"failed",
+	);
+
+	const forged = structuredClone(result);
+	forged.integrity = structuredClone(browserResult.integrity);
+	forged.integrityVerified = true;
+	forged.integrityVerifiedAt = 1_205;
+	assert.throws(
+		() => validateBenchmarkResultEnvelope(forged, uploadEnvelopeOptions),
+		/projection does not exactly match/,
+	);
+});
+
+test("does not add upload-only evidence to seeder-probe failures", () => {
+	const invocation = createBenchmarkInvocation({
+		scenario: "seeder-probe",
+		mode: "adaptive",
+		network: "local",
+		integrationMode: "link",
+		fileMb: 1,
+		fixtureSeed: "fixture-seed",
+	});
+	const result = createInvocationFailureEvidence({
+		scenario: "seeder-probe",
+		mode: "adaptive",
+		network: "local",
+		fileMb: 1,
+		runNonce: RUN_NONCE,
+		invocation,
+		provenance: PROVENANCE,
+		resultFile: "/tmp/missing.json",
+		processOutcome: null,
+		resultEvidence: {
+			kind: "missing",
+			filePath: "/tmp/missing.json",
+			failure: { message: "ENOENT" },
+		},
+		failure: new Error("missing"),
+	});
+	for (const key of [
+		"seederDropPolicy",
+		"integrity",
+		"integrityVerified",
+		"integrityVerifiedAt",
+	]) {
+		assert.equal(
+			Object.hasOwn(result, key),
+			false,
+			`${key} must stay upload-only`,
+		);
+	}
+	assert.equal(
+		validateBenchmarkResultEnvelope(result, {
+			expectedMode: "adaptive",
+			expectedFileMb: 1,
+			expectedNetwork: "local",
+			expectedRunNonce: RUN_NONCE,
+			expectedProvenance: PROVENANCE,
+			expectedInvocation: invocation,
+		}).status,
+		"failed",
+	);
 });
 
 test("preserves a parsed sub-run summary while classifying nonzero exit", () => {

--- a/scripts/file-share/benchmark-validity.mjs
+++ b/scripts/file-share/benchmark-validity.mjs
@@ -5,6 +5,8 @@ import {
 	ERROR_COLLECTION_DEFINITION,
 	KNOWN_PEERBIT_FAILURE_SIGNATURES,
 	REQUEST_FAILURE_COLLECTION_DEFINITION,
+	SEEDER_DROP_POLICY,
+	projectUploadIntegrityEvidence,
 } from "./benchmark-orchestration.mjs";
 import {
 	DOWNLOAD_MEMORY_HOST_ATTRIBUTION,
@@ -81,6 +83,7 @@ const UPLOAD_PROGRESS_MILESTONE_KEYS = Object.freeze([
 	"reachedAt",
 	"chunkIndex",
 ]);
+const SEEDER_DROP_POLICY_KEYS = Object.freeze(Object.keys(SEEDER_DROP_POLICY));
 
 const isRecord = (value) =>
 	value != null && typeof value === "object" && !Array.isArray(value);
@@ -167,6 +170,18 @@ const requirePattern = (value, pattern, label) => {
 	return string;
 };
 
+const validateSeederDropPolicy = (result) => {
+	const policy = requireExactRecordKeys(
+		requireRecord(result.seederDropPolicy, "seederDropPolicy"),
+		SEEDER_DROP_POLICY_KEYS,
+		"seederDropPolicy",
+	);
+	if (!isDeepStrictEqual(policy, SEEDER_DROP_POLICY)) {
+		throw new Error("Benchmark result has an unsupported seeder-drop policy");
+	}
+	return policy;
+};
+
 export const assertPlaywrightSucceeded = (exitCode) => {
 	if (!Number.isInteger(exitCode) || exitCode !== 0) {
 		throw new Error(
@@ -196,6 +211,7 @@ const validateUploadIntegrity = (
 	expectedFileMb,
 	expectedFixtureSeed,
 	invocation,
+	{ requireCompletedEvidence = true } = {},
 ) => {
 	const integrity = requireRecord(result.integrity, "integrity");
 	if (integrity.fixtureMode !== "deterministic") {
@@ -246,8 +262,9 @@ const validateUploadIntegrity = (
 		throw new Error("Benchmark result failed its SHA-256 integrity gate");
 	}
 	if (
-		result.downloadSink !== invocation.downloadSink ||
-		result.requestedDownloadSink !== invocation.downloadSink ||
+		(requireCompletedEvidence &&
+			(result.downloadSink !== invocation.downloadSink ||
+				result.requestedDownloadSink !== invocation.downloadSink)) ||
 		integrity.downloadSink !== invocation.downloadSink
 	) {
 		throw new Error(
@@ -305,6 +322,91 @@ const validateUploadIntegrity = (
 	}
 	if (integrity.verified !== true || result.integrityVerified !== true) {
 		throw new Error("Benchmark result is missing the aggregate integrity gate");
+	}
+	const integrityVerifiedAt = requirePositiveSafeInteger(
+		result.integrityVerifiedAt,
+		"integrityVerifiedAt",
+	);
+	return integrityVerifiedAt;
+};
+
+const validateFailedUploadIntegrityEvidence = (
+	result,
+	expectedFileMb,
+	expectedInvocation,
+) => {
+	const hasRunnerProjection =
+		Object.hasOwn(result, "browserResult") ||
+		Object.hasOwn(result, "resultEvidence");
+	if (hasRunnerProjection) {
+		const hasExplicitResultEvidence = Object.hasOwn(result, "resultEvidence");
+		const hasParsedResultEvidence =
+			isRecord(result.resultEvidence) &&
+			result.resultEvidence.kind === "parsed";
+		if (hasExplicitResultEvidence && !hasParsedResultEvidence) {
+			if (
+				result.browserResult !== null ||
+				result.integrity !== null ||
+				result.integrityVerified !== false ||
+				result.integrityVerifiedAt !== null
+			) {
+				throw new Error(
+					"Runner failure without parsed browser evidence must use a null integrity projection",
+				);
+			}
+		} else if (isRecord(result.browserResult)) {
+			const projected = projectUploadIntegrityEvidence(result.browserResult, {
+				fileMb: expectedFileMb,
+				fixtureSeed: expectedInvocation.fixtureSeed,
+				downloadSink: expectedInvocation.downloadSink,
+			});
+			if (
+				!isDeepStrictEqual(result.integrity, projected.integrity) ||
+				result.integrityVerified !== projected.integrityVerified ||
+				result.integrityVerifiedAt !== projected.integrityVerifiedAt
+			) {
+				throw new Error(
+					"Runner failure integrity projection does not exactly match its parsed browser result",
+				);
+			}
+		} else if (
+			hasParsedResultEvidence ||
+			result.browserResult !== null ||
+			result.integrity !== null ||
+			result.integrityVerified !== false ||
+			result.integrityVerifiedAt !== null
+		) {
+			throw new Error(
+				"Runner failure without parsed browser evidence must use a null integrity projection",
+			);
+		}
+	}
+
+	if (typeof result.integrityVerified !== "boolean") {
+		throw new Error("Failed upload has an invalid integrityVerified claim");
+	}
+	if (result.integrityVerified) {
+		validateUploadIntegrity(
+			result,
+			expectedFileMb,
+			expectedInvocation.fixtureSeed,
+			expectedInvocation,
+			{ requireCompletedEvidence: false },
+		);
+		return;
+	}
+	if (result.integrityVerifiedAt !== null) {
+		throw new Error(
+			"Failed upload without verified integrity must use a null integrityVerifiedAt",
+		);
+	}
+	if (result.integrity !== null) {
+		const integrity = requireRecord(result.integrity, "integrity");
+		if (integrity.verified !== false) {
+			throw new Error(
+				"Failed upload integrity evidence contradicts its unverified claim",
+			);
+		}
 	}
 };
 
@@ -1751,6 +1853,9 @@ const validateEnvelope = (
 	) {
 		throw new Error("Benchmark result has an unsupported invocation schema");
 	}
+	if (invocation.scenario === "upload") {
+		validateSeederDropPolicy(result);
+	}
 	if (!isDeepStrictEqual(result.provenance, expectedProvenance)) {
 		throw new Error(
 			"Benchmark result provenance does not match the invocation",
@@ -2456,6 +2561,7 @@ const validateReaderLocalityControl = (result, invocation) => {
 		writerTopologyBeforeTimedRead.capturedAt > downloadStartedAt ||
 		readerTopologyBeforeTimedRead.capturedAt > downloadStartedAt ||
 		downloadFinishedAt > downloadCompletionObservedAt ||
+		integrityVerifiedAt !== result.integrityVerifiedAt ||
 		integrityVerifiedAt < downloadCompletionObservedAt ||
 		terminalIdle.capturedAt < integrityVerifiedAt ||
 		terminalTopologyStartedAt < terminalIdle.capturedAt ||
@@ -2470,7 +2576,11 @@ const validateReaderLocalityControl = (result, invocation) => {
 			"Benchmark reader locality control timestamps are inconsistent",
 		);
 	}
-	return { actualLocalChunkBlockCount, actualLocalChunkIndexRowCount };
+	return {
+		actualLocalChunkBlockCount,
+		actualLocalChunkIndexRowCount,
+		terminalTopologyFinishedAt,
+	};
 };
 
 const validateCollectedStringEvidence = ({
@@ -2556,7 +2666,11 @@ const validateZeroErrors = (result, label) => {
 	}
 };
 
-const validateUploadSnapshots = (result, invocation) => {
+const validateUploadSnapshots = (
+	result,
+	invocation,
+	{ integrityVerifiedAt, terminalTopologyFinishedAt },
+) => {
 	if (!Array.isArray(result.snapshots) || result.snapshots.length === 0) {
 		throw new Error("Passed upload result is missing seeder snapshots");
 	}
@@ -2569,6 +2683,10 @@ const validateUploadSnapshots = (result, invocation) => {
 		timestamps.postMonitorFinishedAt,
 		"timestamps.postMonitorFinishedAt",
 	);
+	const downloadCompletionObservedAt = requirePositiveNumber(
+		timestamps.downloadCompletionObservedAt,
+		"timestamps.downloadCompletionObservedAt",
+	);
 	let previousAt = -1;
 	let hasPostMonitorSample = false;
 	const labels = new Set();
@@ -2578,7 +2696,7 @@ const validateUploadSnapshots = (result, invocation) => {
 		const label = requireString(snapshot.label, `snapshots[${index}].label`);
 		if (
 			labels.has(label) ||
-			!/^(?:seeders-ready|during-\d+|after-\d+)$/.test(label)
+			!/^(?:seeders-ready|during-\d+|after-\d+|terminal)$/.test(label)
 		) {
 			throw new Error(
 				"Upload seeder snapshot labels are invalid or duplicated",
@@ -2635,6 +2753,36 @@ const validateUploadSnapshots = (result, invocation) => {
 			"Passed upload result must begin with exactly one ready-seeder baseline snapshot",
 		);
 	}
+	const terminalSnapshots = parsedSnapshots.filter(
+		(snapshot) => snapshot.label === SEEDER_DROP_POLICY.terminalSnapshotLabel,
+	);
+	if (
+		terminalSnapshots.length !== 1 ||
+		parsedSnapshots.at(-1)?.label !== SEEDER_DROP_POLICY.terminalSnapshotLabel
+	) {
+		throw new Error(
+			"Passed upload result must end with exactly one terminal seeder snapshot",
+		);
+	}
+	const terminalSnapshot = terminalSnapshots[0];
+	if (terminalSnapshot.capturedAt < downloadCompletionObservedAt) {
+		throw new Error(
+			"Upload terminal seeder snapshot precedes download completion",
+		);
+	}
+	if (terminalSnapshot.capturedAt < integrityVerifiedAt) {
+		throw new Error(
+			"Upload terminal seeder snapshot precedes aggregate integrity verification",
+		);
+	}
+	if (
+		terminalTopologyFinishedAt !== null &&
+		terminalSnapshot.capturedAt < terminalTopologyFinishedAt
+	) {
+		throw new Error(
+			"Upload terminal seeder snapshot precedes terminal topology completion",
+		);
+	}
 	const baselineWriterSeeders = requireNonNegativeSafeInteger(
 		result.baselineWriterSeeders,
 		"baselineWriterSeeders",
@@ -2660,19 +2808,33 @@ const validateUploadSnapshots = (result, invocation) => {
 			"Upload ready-seeder baseline is below the requested minimum",
 		);
 	}
-	const recomputedDroppedSeeders = parsedSnapshots
-		.slice(1)
-		.some(
-			(snapshot) =>
-				snapshot.writerSeeders < baselineWriterSeeders ||
-				snapshot.readerSeeders < baselineReaderSeeders,
-		);
+	let recomputedDroppedSeeders = false;
+	let recomputedUnexpectedSeederDrop = false;
+	let consecutiveBelowBaselineSnapshots = 0;
+	for (const snapshot of parsedSnapshots.slice(1)) {
+		const belowBaseline =
+			snapshot.writerSeeders < baselineWriterSeeders ||
+			snapshot.readerSeeders < baselineReaderSeeders;
+		if (belowBaseline) {
+			recomputedDroppedSeeders = true;
+			consecutiveBelowBaselineSnapshots += 1;
+			if (
+				consecutiveBelowBaselineSnapshots >=
+					SEEDER_DROP_POLICY.consecutiveBelowBaselineSnapshotThreshold ||
+				(SEEDER_DROP_POLICY.terminalBelowBaselineIsUnexpected &&
+					snapshot.label === SEEDER_DROP_POLICY.terminalSnapshotLabel)
+			) {
+				recomputedUnexpectedSeederDrop = true;
+			}
+		} else {
+			consecutiveBelowBaselineSnapshots = 0;
+		}
+	}
 	if (result.droppedSeeders !== recomputedDroppedSeeders) {
 		throw new Error(
 			"Upload droppedSeeders claim contradicts its numeric snapshot evidence",
 		);
 	}
-	const recomputedUnexpectedSeederDrop = recomputedDroppedSeeders;
 	if (result.unexpectedSeederDrop !== recomputedUnexpectedSeederDrop) {
 		throw new Error(
 			"Upload unexpectedSeederDrop claim contradicts its numeric snapshot evidence",
@@ -2859,6 +3021,13 @@ export const validateBenchmarkResultEnvelope = (
 	validateErrorCollection(result, {
 		allowIncomplete: result.status === "failed",
 	});
+	if (expectedInvocation.scenario === "upload" && result.status === "failed") {
+		validateFailedUploadIntegrityEvidence(
+			result,
+			expectedFileMb,
+			expectedInvocation,
+		);
+	}
 	return result;
 };
 
@@ -2891,26 +3060,35 @@ export const validateBenchmarkResult = (
 		throw new Error(`Benchmark result status is not passed${detail}`);
 	}
 	if (scenario === "upload") {
-		validateUploadIntegrity(
+		const integrityVerifiedAt = validateUploadIntegrity(
 			result,
 			expectedFileMb,
 			expectedFixtureSeed,
 			expectedInvocation,
 		);
 		const readWindow = validateUploadTimings(result, expectedInvocation);
+		if (integrityVerifiedAt < readWindow.downloadCompletionObservedAt) {
+			throw new Error(
+				"Benchmark aggregate integrity gate precedes download completion",
+			);
+		}
 		validateUploadProgressTelemetry(result, expectedInvocation);
 		validateDownloadMemoryTelemetry(result, expectedInvocation, readWindow);
 		validateRequestedUploadKnobs(result, expectedInvocation);
 		validateZeroErrors(result, "upload result");
-		validateReaderLocalityControl(result, expectedInvocation);
-		validateUploadSnapshots(result, expectedInvocation);
+		const readerLocalityControl = validateReaderLocalityControl(
+			result,
+			expectedInvocation,
+		);
+		validateUploadSnapshots(result, expectedInvocation, {
+			integrityVerifiedAt,
+			terminalTopologyFinishedAt:
+				readerLocalityControl?.terminalTopologyFinishedAt ?? null,
+		});
 		if (result.unexpectedSeederDrop !== false) {
 			throw new Error(
 				"Passed upload result contains an unexpected seeder drop",
 			);
-		}
-		if (result.droppedSeeders !== false) {
-			throw new Error("Passed upload result contains seeder drops");
 		}
 	} else if (scenario === "seeder-probe") {
 		validateSeederProbe(result, expectedInvocation);

--- a/scripts/file-share/benchmark-validity.test.mjs
+++ b/scripts/file-share/benchmark-validity.test.mjs
@@ -9,6 +9,7 @@ import {
 	ERROR_COLLECTION_DEFINITION,
 	KNOWN_PEERBIT_FAILURE_SIGNATURES,
 	REQUEST_FAILURE_COLLECTION_DEFINITION,
+	SEEDER_DROP_POLICY,
 } from "./benchmark-orchestration.mjs";
 import {
 	assertPlaywrightSucceeded,
@@ -286,6 +287,8 @@ const shiftTimedDownloadEvidence = (result, offset) => {
 	]) {
 		result.timestamps[key] += offset;
 	}
+	result.integrityVerifiedAt += offset;
+	result.snapshots.find(({ label }) => label === "terminal").at += offset;
 	const diagnostics = result.readerDiagnostics.lastReadDiagnostics;
 	diagnostics.startedAt += offset;
 	diagnostics.finishedAt += offset;
@@ -334,6 +337,7 @@ const validResult = () => ({
 	fileName: FILE_NAME,
 	fileSizeMb: FILE_MB,
 	integrityVerified: true,
+	integrityVerifiedAt: 1_205,
 	integrity: {
 		fixtureMode: "deterministic",
 		fixtureFormat: "aes-256-ctr-v1",
@@ -450,6 +454,7 @@ const validResult = () => ({
 	},
 	baselineWriterSeeders: 2,
 	baselineReaderSeeders: 2,
+	seederDropPolicy: { ...SEEDER_DROP_POLICY },
 	droppedSeeders: false,
 	unexpectedSeederDrop: false,
 	errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
@@ -509,6 +514,12 @@ const validResult = () => ({
 			writerSeeders: 2,
 			readerSeeders: 2,
 			at: 1130,
+		},
+		{
+			label: "terminal",
+			writerSeeders: 2,
+			readerSeeders: 2,
+			at: 1210,
 		},
 	],
 });
@@ -663,6 +674,7 @@ const createReaderLocalityFixture = ({
 	result.timestamps.downloadStartedAt = 1_400;
 	result.timestamps.downloadFinishedAt = 1_430;
 	result.timestamps.downloadCompletionObservedAt = 1_431;
+	result.integrityVerifiedAt = 1_432;
 	result.downloadMemoryTelemetry = createDownloadMemoryTelemetry(
 		1_400,
 		1_430,
@@ -778,6 +790,12 @@ const createReaderLocalityFixture = ({
 			readerSeeders: 1,
 			at: 1_130,
 		},
+		{
+			label: "terminal",
+			writerSeeders: 1,
+			readerSeeders: 1,
+			at: 1_640,
+		},
 	];
 	result.baselineWriterSeeders = 1;
 	result.baselineReaderSeeders = 1;
@@ -798,6 +816,160 @@ test("accepts a complete deterministic transfer result", () => {
 		validateBenchmarkResult(validResult(), options).status,
 		"passed",
 	);
+});
+
+test("requires a trustworthy aggregate-integrity timestamp before the final snapshot", () => {
+	for (const [mutate, pattern] of [
+		[
+			(result) => {
+				delete result.integrityVerifiedAt;
+			},
+			/integrityVerifiedAt/,
+		],
+		[
+			(result) => {
+				result.integrityVerifiedAt = 0;
+			},
+			/non-positive integrityVerifiedAt/,
+		],
+		[
+			(result) => {
+				result.integrityVerifiedAt = Number.MAX_SAFE_INTEGER + 1;
+			},
+			/invalid integrityVerifiedAt/,
+		],
+		[
+			(result) => {
+				result.integrityVerifiedAt =
+					result.timestamps.downloadCompletionObservedAt - 1;
+			},
+			/aggregate integrity gate precedes download completion/,
+		],
+		[
+			(result) => {
+				result.snapshots.at(-1).at = result.integrityVerifiedAt - 1;
+			},
+			/precedes aggregate integrity verification/,
+		],
+		[
+			(result) => {
+				result.snapshots.push({
+					label: "during-99",
+					writerSeeders: 2,
+					readerSeeders: 2,
+					at: 1_211,
+				});
+			},
+			/must end with exactly one terminal seeder snapshot/,
+		],
+		[
+			(result) => {
+				result.snapshots.pop();
+			},
+			/must end with exactly one terminal seeder snapshot/,
+		],
+	]) {
+		const result = validResult();
+		mutate(result);
+		assert.throws(() => validateBenchmarkResult(result, options), pattern);
+	}
+});
+
+test("requires the terminal snapshot after controlled-locality topology", () => {
+	const beforeTopology = createReaderLocalityFixture();
+	beforeTopology.result.snapshots.at(-1).at =
+		beforeTopology.result.readerLocalityControl.terminalTopologyFinishedAt - 1;
+	assert.throws(
+		() =>
+			validateBenchmarkResult(beforeTopology.result, beforeTopology.options),
+		/precedes terminal topology completion/,
+	);
+
+	const sameMillisecond = createReaderLocalityFixture();
+	sameMillisecond.result.snapshots.at(-1).at =
+		sameMillisecond.result.readerLocalityControl.terminalTopologyFinishedAt;
+	assert.equal(
+		validateBenchmarkResult(sameMillisecond.result, sameMillisecond.options)
+			.status,
+		"passed",
+	);
+});
+
+test("accepts one recovered seeder dip under the v7 policy", () => {
+	const result = validResult();
+	result.snapshots[1].writerSeeders = 1;
+	result.droppedSeeders = true;
+	assert.equal(validateBenchmarkResult(result, options).status, "passed");
+});
+
+test("rejects two consecutive below-baseline seeder snapshots", () => {
+	const result = validResult();
+	result.snapshots[1].writerSeeders = 1;
+	result.snapshots.splice(2, 0, {
+		label: "after-2",
+		writerSeeders: 1,
+		readerSeeders: 2,
+		at: 1140,
+	});
+	result.droppedSeeders = true;
+	result.unexpectedSeederDrop = true;
+	assert.throws(
+		() => validateBenchmarkResult(result, options),
+		/unexpected seeder drop/,
+	);
+});
+
+test("rejects a terminal below-baseline seeder snapshot", () => {
+	const result = validResult();
+	result.snapshots.at(-1).readerSeeders = 1;
+	result.droppedSeeders = true;
+	result.unexpectedSeederDrop = true;
+	assert.throws(
+		() => validateBenchmarkResult(result, options),
+		/unexpected seeder drop/,
+	);
+});
+
+test("rejects missing, altered, and contradictory v7 seeder-drop evidence", () => {
+	for (const [mutate, pattern] of [
+		[
+			(result) => {
+				delete result.seederDropPolicy;
+			},
+			/missing seederDropPolicy/,
+		],
+		[
+			(result) => {
+				result.seederDropPolicy.consecutiveBelowBaselineSnapshotThreshold = 1;
+			},
+			/unsupported seeder-drop policy/,
+		],
+		[
+			(result) => {
+				result.snapshots[1].writerSeeders = 1;
+				result.droppedSeeders = true;
+				result.unexpectedSeederDrop = true;
+			},
+			/unexpectedSeederDrop claim contradicts/,
+		],
+		[
+			(result) => {
+				result.snapshots[1].writerSeeders = 1;
+				result.snapshots.splice(2, 0, {
+					label: "after-2",
+					writerSeeders: 1,
+					readerSeeders: 2,
+					at: 1140,
+				});
+				result.droppedSeeders = true;
+			},
+			/unexpectedSeederDrop claim contradicts/,
+		],
+	]) {
+		const result = validResult();
+		mutate(result);
+		assert.throws(() => validateBenchmarkResult(result, options), pattern);
+	}
 });
 
 test("requires exact bounded upload chunk-commit progress telemetry", () => {
@@ -1529,6 +1701,7 @@ test("accepts exact observer-locality control and rejects contradictory evidence
 		[
 			(result) => {
 				result.snapshots[1].writerSeeders = 0;
+				result.snapshots[2].writerSeeders = 0;
 				result.droppedSeeders = true;
 				result.unexpectedSeederDrop = true;
 			},
@@ -1690,14 +1863,14 @@ test("bounds Node-file server timing against its browser sink timing", () => {
 	);
 });
 
-test("rejects a status-only passed payload at the v6 evidence envelope", () => {
+test("rejects a status-only passed payload at the v7 evidence envelope", () => {
 	assert.throws(
 		() => validateBenchmarkResultEnvelope({ status: "passed" }, options),
 		/missing schema/,
 	);
 });
 
-test("requires explicit error evidence on failed v6 envelopes", () => {
+test("requires explicit error evidence on failed v7 envelopes", () => {
 	const completeFailure = validResult();
 	completeFailure.status = "failed";
 	completeFailure.failure = { message: "synthetic browser failure" };
@@ -1734,6 +1907,63 @@ test("requires explicit error evidence on failed v6 envelopes", () => {
 	assert.throws(
 		() => validateBenchmarkResultEnvelope(incompleteFailure, options),
 		/incomplete error collection/,
+	);
+});
+
+test("validates early and late failed-upload integrity claims", () => {
+	const earlyFailure = validResult();
+	earlyFailure.status = "failed";
+	earlyFailure.failure = { message: "failed before integrity" };
+	earlyFailure.integrity = null;
+	earlyFailure.integrityVerified = false;
+	earlyFailure.integrityVerifiedAt = null;
+	assert.equal(
+		validateBenchmarkResultEnvelope(earlyFailure, options).status,
+		"failed",
+	);
+
+	const lateFailure = validResult();
+	lateFailure.status = "failed";
+	lateFailure.failure = { message: "terminal topology did not converge" };
+	assert.equal(
+		validateBenchmarkResultEnvelope(lateFailure, options).status,
+		"failed",
+	);
+
+	for (const [mutate, pattern] of [
+		[
+			(result) => {
+				result.integrityVerifiedAt = null;
+			},
+			/integrityVerifiedAt/,
+		],
+		[
+			(result) => {
+				result.integrity.sourceCrc32Hex = "ffffffff";
+			},
+			/CRC-32 integrity gate/,
+		],
+		[
+			(result) => {
+				result.integrityVerified = false;
+				result.integrityVerifiedAt = null;
+			},
+			/contradicts its unverified claim/,
+		],
+	]) {
+		const result = structuredClone(lateFailure);
+		mutate(result);
+		assert.throws(
+			() => validateBenchmarkResultEnvelope(result, options),
+			pattern,
+		);
+	}
+
+	const falseWithTimestamp = structuredClone(earlyFailure);
+	falseWithTimestamp.integrityVerifiedAt = 1_205;
+	assert.throws(
+		() => validateBenchmarkResultEnvelope(falseWithTimestamp, options),
+		/must use a null integrityVerifiedAt/,
 	);
 });
 
@@ -2265,9 +2495,12 @@ for (const [name, mutate, pattern] of [
 	[
 		"ready baseline not first",
 		(result) => {
-			result.snapshots.reverse();
-			result.snapshots[0].at = 1130;
-			result.snapshots[1].at = 1140;
+			[result.snapshots[0], result.snapshots[1]] = [
+				result.snapshots[1],
+				result.snapshots[0],
+			];
+			result.snapshots[0].at = 1120;
+			result.snapshots[1].at = 1130;
 		},
 		/exactly one ready-seeder baseline snapshot/,
 	],
@@ -2310,7 +2543,7 @@ for (const [name, mutate, pattern] of [
 	[
 		"observed seeder drop in passed result",
 		(result) => {
-			result.snapshots[1].readerSeeders = 1;
+			result.snapshots[2].readerSeeders = 1;
 			result.droppedSeeders = true;
 			result.unexpectedSeederDrop = true;
 		},

--- a/scripts/file-share/run-file-share-benchmark-matrix.mjs
+++ b/scripts/file-share/run-file-share-benchmark-matrix.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { isDeepStrictEqual } from "node:util";
 import {
 	MAX_READER_LOCAL_CHUNK_OVERSHOOT,
@@ -20,10 +21,12 @@ import {
 	KNOWN_PEERBIT_FAILURE_SIGNATURES,
 	MATRIX_SUMMARY_SCHEMA,
 	REQUEST_FAILURE_COLLECTION_DEFINITION,
+	SEEDER_DROP_POLICY,
 	classifySubprocessSummary,
 	countBenchmarkOutcomes,
 	extractCollectedErrorEvidence,
 	inspectSingleInvocationSummary,
+	projectUploadIntegrityEvidence,
 	readJsonEvidence,
 	serializeError,
 } from "./benchmark-orchestration.mjs";
@@ -567,7 +570,7 @@ const runVariantBenchmark = async ({
 	};
 };
 
-const createMatrixInvocationFailure = ({
+export const createMatrixInvocationFailure = ({
 	plan,
 	scenario,
 	network,
@@ -580,6 +583,17 @@ const createMatrixInvocationFailure = ({
 	browserResult,
 }) => {
 	const collectedErrorEvidence = extractCollectedErrorEvidence(browserResult);
+	const uploadEvidence =
+		scenario === "upload"
+			? {
+					seederDropPolicy: SEEDER_DROP_POLICY,
+					...projectUploadIntegrityEvidence(browserResult, {
+						fileMb,
+						fixtureSeed: expectedInvocation?.fixtureSeed,
+						downloadSink: expectedInvocation?.downloadSink,
+					}),
+				}
+			: {};
 	return {
 		schema: BENCHMARK_RESULT_SCHEMA,
 		runNonce: browserResult?.runNonce ?? null,
@@ -590,6 +604,7 @@ const createMatrixInvocationFailure = ({
 		mode: plan.mode,
 		networkMode: network,
 		fileSizeMb: fileMb,
+		...uploadEvidence,
 		stage: "matrix-orchestration",
 		errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
 		knownPeerbitFailureSignatures: KNOWN_PEERBIT_FAILURE_SIGNATURES,
@@ -1214,7 +1229,12 @@ const main = async () => {
 	}
 };
 
-main().catch((error) => {
-	console.error(error);
-	process.exit(1);
-});
+if (
+	process.argv[1] &&
+	path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+	main().catch((error) => {
+		console.error(error);
+		process.exit(1);
+	});
+}

--- a/scripts/file-share/template-contract.test.mjs
+++ b/scripts/file-share/template-contract.test.mjs
@@ -17,14 +17,14 @@ const templates = [
 ];
 
 for (const name of templates) {
-	test(`${name} emits the atomic v6 result envelope`, async () => {
+	test(`${name} emits the atomic v7 result envelope`, async () => {
 		const contents = await readFile(
 			path.join(repoRoot, "scripts", "file-share", "templates", name),
 			"utf8",
 		);
 		for (const required of [
 			'id: "peerbit-file-share-benchmark"',
-			"version: 6",
+			"version: 7",
 			"PW_BENCHMARK_RUN_NONCE",
 			"PW_BENCHMARK_INVOCATION",
 			"PW_BENCHMARK_PROVENANCE",
@@ -206,6 +206,10 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"readerJoinedReplicationDuringTimedRead = true",
 		'readerLocalityControl.status = "complete"',
 		"exact contiguous prefix",
+		"SEEDER_DROP_POLICY",
+		"consecutiveBelowBaselineSeederSnapshots",
+		"seederDropPolicy: SEEDER_DROP_POLICY",
+		"terminalSeederSnapshot",
 		"unexpectedSeederDrop",
 		"downloadMemoryTelemetryController =",
 		"downloadMemoryTelemetryController.snapshot()",
@@ -213,9 +217,28 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"downloadMemoryTelemetry.complete !== true",
 		"series.samplingErrors.length > 0",
 		"downloadMemoryTelemetry,",
+		"let integrityVerifiedAt: number | null = null",
 	]) {
 		assert.ok(contents.includes(required), `missing ${required}`);
 	}
+	assert.match(
+		contents,
+		/const terminalSeederSnapshot = await snapshot\([\s\S]*?noteSeederDrop\(terminalSeederSnapshot\);[\s\S]*?if \(unexpectedSeederDrop\)/,
+		"the final numeric seeder snapshot must participate in the v7 drop policy before acceptance",
+	);
+	const lateFailureCatch = contents.slice(
+		contents.lastIndexOf("\t\t} catch (error: any) {"),
+	);
+	assert.ok(
+		lateFailureCatch.includes(
+			"\n\t\t\t\tintegrity,\n\t\t\t\tintegrityVerified,\n\t\t\t\tintegrityVerifiedAt,",
+		),
+		"late failures must preserve completed integrity evidence and its gate timestamp",
+	);
+	assert.ok(
+		!lateFailureCatch.includes("integrityVerified: false"),
+		"the catch path must not overwrite completed integrity state",
+	);
 	assert.match(
 		contents,
 		/const LOCALITY_CONTROL_OUTER_TIMEOUT_BUDGET_MS =\s*READER_LOCAL_CHUNK_TARGET === null\s*\? 0\s*:\s*3 \* READY_TIMEOUT_MS \+\s*\(READER_LOCAL_CHUNK_TARGET > 0\s*\? DOWNLOAD_TIMEOUT_MS \+ TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS\s*: 0\);/,
@@ -309,8 +332,8 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 	);
 	assert.match(
 		contents,
-		/if \(!integrityVerified\)[\s\S]*?integrityVerifiedAt = Date\.now\(\);[\s\S]*?waitForTerminalReaderIdle\(\)[\s\S]*?collectStableTerminalTopology\(\s*terminalTopologyStartedAt,\s*terminalTopologyDeadlineAt,\s*\)[\s\S]*?readerJoinedReplicationDuringTimedRead = true[\s\S]*?stage = "complete"/,
-		"terminal topology must be collected after integrity and transfer-idle, outside the measured download",
+		/if \(!integrityVerified\)[\s\S]*?integrityVerifiedAt = Date\.now\(\);[\s\S]*?readerLocalityControl\.integrityVerifiedAt = integrityVerifiedAt;[\s\S]*?waitForTerminalReaderIdle\(\)[\s\S]*?collectStableTerminalTopology\(\s*terminalTopologyStartedAt,\s*terminalTopologyDeadlineAt,\s*\)[\s\S]*?readerJoinedReplicationDuringTimedRead = true[\s\S]*?const terminalSeederSnapshot = await snapshot\([\s\S]*?stage = "complete"/,
+		"terminal topology and the final seeder snapshot must follow the aggregate integrity gate outside the measured download",
 	);
 	assert.ok(
 		!contents.includes("monitorAndFreezeReaderLocality"),
@@ -680,6 +703,8 @@ test("matrix fail-closes every result envelope and fully validates passes", asyn
 		"invocation: expectedInvocation ?? null",
 		"provenance: expectedProvenance",
 		"peerbitProvenance: prepared.peerbitProvenance",
+		"projectUploadIntegrityEvidence(browserResult, {",
+		"seederDropPolicy: SEEDER_DROP_POLICY",
 	]) {
 		assert.ok(contents.includes(required), `missing ${required}`);
 	}

--- a/scripts/file-share/templates/seeder-probe.e2e.spec.ts
+++ b/scripts/file-share/templates/seeder-probe.e2e.spec.ts
@@ -24,7 +24,7 @@ const EFFECTIVE_SAMPLE_INTERVAL_MS = Math.max(
 );
 const RESULT_SCHEMA = {
 	id: "peerbit-file-share-benchmark",
-	version: 6,
+	version: 7,
 } as const;
 const RUN_NONCE = process.env.PW_BENCHMARK_RUN_NONCE;
 const parseJsonEnvironment = (name: string) => {

--- a/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
+++ b/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
@@ -113,7 +113,18 @@ const FIXTURE_SEED =
 	process.env.PW_FIXTURE_SEED || "peerbit-file-share-benchmark-v1";
 const RESULT_SCHEMA = {
 	id: "peerbit-file-share-benchmark",
-	version: 6,
+	version: 7,
+} as const;
+const SEEDER_DROP_POLICY = {
+	id: "peerbit-file-share-seeder-drop-policy",
+	version: 1,
+	belowBaselineDefinition:
+		"writerSeeders < baselineWriterSeeders || readerSeeders < baselineReaderSeeders",
+	evaluatedSnapshotDefinition:
+		"all chronological snapshots after the unique seeders-ready baseline snapshot",
+	consecutiveBelowBaselineSnapshotThreshold: 2,
+	terminalSnapshotLabel: "terminal",
+	terminalBelowBaselineIsUnexpected: true,
 } as const;
 const RUN_NONCE = process.env.PW_BENCHMARK_RUN_NONCE;
 const parseJsonEnvironment = (name: string) => {
@@ -800,8 +811,12 @@ test.describe("generated transfer-validity benchmark", () => {
 		let readerVisibilityProbe: Record<string, unknown> | null = null;
 		let writerManifestEvidence: ReadyManifestEvidence | undefined;
 		let readerManifestEvidence: ReadyManifestEvidence | undefined;
+		let integrity: Record<string, unknown> | null = null;
+		let integrityVerified = false;
+		let integrityVerifiedAt: number | null = null;
 		let dropped = false;
 		let unexpectedSeederDrop = false;
+		let consecutiveBelowBaselineSeederSnapshots = 0;
 		let baselineWriterSeeders = MIN_READY_SEEDERS;
 		let baselineReaderSeeders = MIN_READY_SEEDERS;
 		const readerLocalityControl =
@@ -1088,14 +1103,18 @@ test.describe("generated transfer-validity benchmark", () => {
 			const readerDropped =
 				typeof current.readerSeeders === "number" &&
 				current.readerSeeders < baselineReaderSeeders;
-			if (writerDropped || readerDropped) {
-				dropped = true;
+			const belowBaseline = writerDropped || readerDropped;
+			if (!belowBaseline) {
+				consecutiveBelowBaselineSeederSnapshots = 0;
+				return;
 			}
+			dropped = true;
+			consecutiveBelowBaselineSeederSnapshots += 1;
 			if (
-				(typeof current.writerSeeders === "number" &&
-					current.writerSeeders < baselineWriterSeeders) ||
-				(typeof current.readerSeeders === "number" &&
-					current.readerSeeders < baselineReaderSeeders)
+				consecutiveBelowBaselineSeederSnapshots >=
+					SEEDER_DROP_POLICY.consecutiveBelowBaselineSnapshotThreshold ||
+				(SEEDER_DROP_POLICY.terminalBelowBaselineIsUnexpected &&
+					current.label === SEEDER_DROP_POLICY.terminalSnapshotLabel)
 			) {
 				unexpectedSeederDrop = true;
 			}
@@ -1786,13 +1805,13 @@ test.describe("generated transfer-validity benchmark", () => {
 					: sizeVerified &&
 						crc32Verified &&
 						persistedSinkSha256Verified === true;
-			const integrityVerified =
+			integrityVerified =
 				sizeVerified &&
 				sha256Verified &&
 				crc32Verified &&
 				manifestVerified &&
 				sinkPersistenceVerified !== false;
-			const integrity = {
+			integrity = {
 				fixtureMode: "deterministic",
 				fixtureFormat: preparedFile.fixture.mode,
 				fixtureSeed: FIXTURE_SEED,
@@ -1822,9 +1841,10 @@ test.describe("generated transfer-validity benchmark", () => {
 					`Downloaded file failed integrity validation: ${JSON.stringify(integrity)}`,
 				);
 			}
+			integrityVerifiedAt = Date.now();
 			if (readerLocalityControl) {
 				stage = "verify-terminal-reader-topology";
-				readerLocalityControl.integrityVerifiedAt = Date.now();
+				readerLocalityControl.integrityVerifiedAt = integrityVerifiedAt;
 				const terminalIdleObservation = await waitForTerminalReaderIdle();
 				readerLocalityControl.terminalIdleObservation = terminalIdleObservation;
 				const terminalTopologyStartedAt = Date.now();
@@ -1858,6 +1878,10 @@ test.describe("generated transfer-validity benchmark", () => {
 						readerLocalityControl.readerJoinedReplicationDuringTimedRead,
 				});
 			}
+			const terminalSeederSnapshot = await snapshot(
+				SEEDER_DROP_POLICY.terminalSnapshotLabel,
+			);
+			noteSeederDrop(terminalSeederSnapshot);
 			if (unexpectedSeederDrop) {
 				throw new Error(
 					"Seeder counts dropped outside the benchmark topology contract",
@@ -1938,6 +1962,7 @@ test.describe("generated transfer-validity benchmark", () => {
 				fileSizeMb: FILE_SIZE_MB,
 				integrity,
 				integrityVerified,
+				integrityVerifiedAt,
 				uploadDurationMs: phaseDurationsMs.timeToUploadSettled,
 				uploadDurationDefinition:
 					"input-set-to-writer-ready-manifest-and-upload-progress-settled; excludes reader discovery, post-monitor, and download",
@@ -2013,6 +2038,7 @@ test.describe("generated transfer-validity benchmark", () => {
 				baselineWriterSeeders,
 				baselineReaderSeeders,
 				shareUrl,
+				seederDropPolicy: SEEDER_DROP_POLICY,
 				droppedSeeders: dropped,
 				unexpectedSeederDrop,
 				writerVisibilityProbe,
@@ -2043,7 +2069,12 @@ test.describe("generated transfer-validity benchmark", () => {
 				readerLocalityControl.failure =
 					typeof error?.message === "string" ? error.message : String(error);
 			}
-			await snapshot(`failure-${stage}`).catch(() => {});
+			const failureSnapshot = await snapshot(`failure-${stage}`).catch(
+				() => null,
+			);
+			if (failureSnapshot) {
+				noteSeederDrop(failureSnapshot);
+			}
 			const writerDiagnostics = await getDiagnostics(writer);
 			const readerDiagnostics = await getDiagnostics(reader);
 			const collectedErrors = [...errors];
@@ -2068,7 +2099,9 @@ test.describe("generated transfer-validity benchmark", () => {
 				stage,
 				requestedDownloadSink: DOWNLOAD_SINK,
 				downloadMemoryTelemetry,
-				integrityVerified: false,
+				integrity,
+				integrityVerified,
+				integrityVerifiedAt,
 				phaseDurationsMs: getPhaseDurations(),
 				postUploadMonitorSchedulingToleranceMs:
 					POST_MONITOR_SCHEDULING_TOLERANCE_MS,
@@ -2087,6 +2120,7 @@ test.describe("generated transfer-validity benchmark", () => {
 				baselineWriterSeeders,
 				baselineReaderSeeders,
 				shareUrl,
+				seederDropPolicy: SEEDER_DROP_POLICY,
 				droppedSeeders: dropped,
 				unexpectedSeederDrop,
 				writerVisibilityProbe,


### PR DESCRIPTION
## Summary

- bump file-share benchmark results to schema v7 with an exact, versioned seeder-drop policy and a final numeric terminal snapshot
- tolerate one recovered seeder-count dip while still failing two consecutive dips or a low terminal sample
- preserve validated integrity evidence and integrityVerifiedAt when a later browser, runner, or matrix failure occurs
- sanitize absent or malformed browser evidence to honest null/false/null values and reject contradictory projections
- require terminal evidence to follow download completion, aggregate integrity, and controlled-locality topology checks

This corrects the natural 1 GiB cohort where all bytes and hashes passed but a later transient seeder sample caused the wrapper to erase the successful integrity gate.

## Verification

- pnpm run bench:file-share:test (178/178)
- pnpm exec prettier --check on all changed files
- git diff --check
- independent adversarial audit completed with no remaining blocker
