### PR TITLE
fix(blocks): prioritize foreground remote reads

### DIFF
--- a/.changeset/fast-blocks-focus.md
+++ b/.changeset/fast-blocks-focus.md
@@ -2,4 +2,4 @@
 "@peerbit/blocks": patch
 ---
 
-Preserve foreground read priority through queued and coalesced remote block requests.
+Preserve foreground read priority through queued, coalesced, and proxied remote block requests while reserving bounded provider capacity for demand reads.

--- a/.changeset/fast-blocks-focus.md
+++ b/.changeset/fast-blocks-focus.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/blocks": patch
+---
+
+Preserve foreground read priority through queued and coalesced remote block requests.

--- a/packages/transport/blocks/src/remote.ts
+++ b/packages/transport/blocks/src/remote.ts
@@ -18,6 +18,7 @@ import {
 	dontThrowIfDeliveryError,
 } from "@peerbit/stream";
 import {
+	BACKGROUND_MESSAGE_PRIORITY,
 	type PeerRefs,
 	type RequestTransportContext,
 	SilentDelivery,
@@ -70,6 +71,7 @@ type BlockMessageContext = {
 type InFlightRead = {
 	promise: Promise<Block<any, any, any, 1> | undefined>;
 	addProviders: (providers: string[]) => void;
+	promotePriority: (priority: number | undefined) => void;
 };
 
 type RemoteReadOptions = Exclude<GetOptions["remote"], boolean | undefined> & {
@@ -358,7 +360,14 @@ export class RemoteBlocks implements IBlocks {
 			try {
 				if (message instanceof BlockRequest && this.localStore) {
 					this._loadFetchQueue
-						.add(() => this.handleFetchRequest(message, localTimeout, context))
+						.add(
+							() => this.handleFetchRequest(message, localTimeout, context),
+							{
+								priority:
+									context?.transport?.requestPriority ??
+									BACKGROUND_MESSAGE_PRIORITY,
+							},
+						)
 						.catch((e) => {
 							try {
 								dontThrowIfDeliveryError(e);
@@ -878,6 +887,7 @@ export class RemoteBlocks implements IBlocks {
 
 		let inFlight = this._readFromPeersPromises.get(cidString);
 		if (!inFlight) {
+			let requestPriority = options.priority ?? BACKGROUND_MESSAGE_PRIORITY;
 			let publishAdditionalProviders: (providers: string[]) => void = () => {};
 			const promise = new Promise<Block<any, any, any, 1> | undefined>(
 				(resolve, reject) => {
@@ -976,8 +986,8 @@ export class RemoteBlocks implements IBlocks {
 							: this.pickRequestBatch(providers, requeryCount);
 					if (requestProviders.length === 0) return;
 					await this.options.publish(new BlockRequest(cidString), {
-						priority: options.priority,
-						responsePriority: options.priority,
+						priority: requestPriority,
+						responsePriority: requestPriority,
 						expiresAt,
 						mode: new SilentDelivery({
 							to: requestProviders,
@@ -1017,6 +1027,20 @@ export class RemoteBlocks implements IBlocks {
 				promise,
 				addProviders: (nextProviders) =>
 					publishAdditionalProviders(nextProviders),
+				promotePriority: (nextPriority) => {
+					if (!this._resolvers.has(cidString)) return;
+					// A background replication read may win CID coalescing before a
+					// foreground waiter arrives. Reissue only on a strict priority upgrade.
+					const promotedPriority = nextPriority ?? BACKGROUND_MESSAGE_PRIORITY;
+					if (
+						!Number.isFinite(promotedPriority) ||
+						promotedPriority <= requestPriority
+					) {
+						return;
+					}
+					requestPriority = promotedPriority;
+					tryPublishRequest({ force: true }).catch(dontThrowIfDeliveryError);
+				},
 			};
 			this._readFromPeersPromises.set(cidString, inFlight);
 
@@ -1101,6 +1125,7 @@ export class RemoteBlocks implements IBlocks {
 				}
 			}
 		} else {
+			inFlight.promotePriority(options.priority);
 			if (providers.length > 0) {
 				inFlight.addProviders(providers);
 			}

--- a/packages/transport/blocks/src/remote.ts
+++ b/packages/transport/blocks/src/remote.ts
@@ -19,6 +19,7 @@ import {
 } from "@peerbit/stream";
 import {
 	BACKGROUND_MESSAGE_PRIORITY,
+	FOREGROUND_READ_MESSAGE_PRIORITY,
 	type PeerRefs,
 	type RequestTransportContext,
 	SilentDelivery,
@@ -129,6 +130,7 @@ export class RemoteBlocks implements IBlocks {
 	private readonly maxRequeryOnReachable: number;
 
 	private _loadFetchQueue: PQueue;
+	private _backgroundLoadFetchQueue: PQueue;
 	private _readFromPeersPromises: Map<string, InFlightRead>;
 	private _deferredStoredNotificationCids?: Set<string>;
 	private _deferredStoredNotificationTimer?: ReturnType<typeof setTimeout>;
@@ -221,8 +223,19 @@ export class RemoteBlocks implements IBlocks {
 		const localTimeout = options?.localTimeout || 1000;
 		this.publicKeyHash = options.publicKey.hashcode();
 		this.rustExchange = options.rust?.exchange;
+		const messageProcessingConcurrency =
+			options?.messageProcessingConcurrency || 10;
 		this._loadFetchQueue = new PQueue({
-			concurrency: options?.messageProcessingConcurrency || 10,
+			concurrency: messageProcessingConcurrency,
+		});
+		// A provider handler includes the response publication. When every handler
+		// is publishing bulk/background blocks under backpressure, a single priority
+		// queue cannot preempt that already-active work. Admit at most N-1 background
+		// handlers so foreground reads can use the reserved slot whenever the
+		// configured concurrency is at least two. Foreground-only traffic can still
+		// use the full configured concurrency.
+		this._backgroundLoadFetchQueue = new PQueue({
+			concurrency: Math.max(1, messageProcessingConcurrency - 1),
 		});
 		this.localStore = options?.local;
 		const localPutKnownManyColumns = (
@@ -359,22 +372,34 @@ export class RemoteBlocks implements IBlocks {
 		) => {
 			try {
 				if (message instanceof BlockRequest && this.localStore) {
-					this._loadFetchQueue
-						.add(
-							() => this.handleFetchRequest(message, localTimeout, context),
+					const priority =
+						context?.transport?.requestPriority ?? BACKGROUND_MESSAGE_PRIORITY;
+					const queueSignal = this.closeController.signal;
+					const run = () =>
+						this._loadFetchQueue.add(
+							() =>
+								queueSignal.aborted
+									? undefined
+									: this.handleFetchRequest(message, localTimeout, context),
 							{
-								priority:
-									context?.transport?.requestPriority ??
-									BACKGROUND_MESSAGE_PRIORITY,
+								priority,
 							},
-						)
-						.catch((e) => {
-							try {
-								dontThrowIfDeliveryError(e);
-							} catch (error) {
-								logger.error("Got error for libp2p block transport: ", error);
-							}
-						});
+						);
+					const scheduled =
+						priority >= FOREGROUND_READ_MESSAGE_PRIORITY
+							? run()
+							: this._backgroundLoadFetchQueue.add(
+									() => (queueSignal.aborted ? undefined : run()),
+									{ priority },
+								);
+					scheduled.catch((e) => {
+						if (queueSignal.aborted) return;
+						try {
+							dontThrowIfDeliveryError(e);
+						} catch (error) {
+							logger.error("Got error for libp2p block transport: ", error);
+						}
+					});
 				} else if (message instanceof BlockResponse) {
 					// TODO make sure we are not storing too much bytes in ram (like filter large blocks)
 					if (context?.from) {
@@ -801,6 +826,7 @@ export class RemoteBlocks implements IBlocks {
 							signal: controller.signal,
 							timeout: proxyTimeoutMs,
 							from: providers,
+							priority: context?.transport?.requestPriority,
 						});
 					}
 				} finally {
@@ -1199,7 +1225,10 @@ export class RemoteBlocks implements IBlocks {
 			this._deferredStoredNotificationTimer = undefined;
 		}
 		await capture(() => this.flushDeferredStoredNotifications());
-		await capture(() => this._loadFetchQueue.clear());
+		// Queued wrappers observe the aborted generation and drain without starting
+		// new work. Avoid PQueue.clear(): it would strand promises already returned
+		// by the nested background-admission queue.
+		await capture(() => this._backgroundLoadFetchQueue.onIdle());
 		await capture(() => this._loadFetchQueue.onIdle());
 		await capture(() => this.localStore?.stop());
 		this._readFromPeersPromises.clear();

--- a/packages/transport/blocks/test/libp2p.spec.ts
+++ b/packages/transport/blocks/test/libp2p.spec.ts
@@ -1,7 +1,11 @@
 import { serialize } from "@dao-xyz/borsh";
 import { TestSession } from "@peerbit/libp2p-test-utils";
 import { waitForNeighbour } from "@peerbit/stream";
-import { CONVERGENCE_MESSAGE_PRIORITY } from "@peerbit/stream-interface";
+import {
+	BACKGROUND_MESSAGE_PRIORITY,
+	CONVERGENCE_MESSAGE_PRIORITY,
+	FOREGROUND_READ_MESSAGE_PRIORITY,
+} from "@peerbit/stream-interface";
 import { delay } from "@peerbit/time";
 import { expect } from "chai";
 import pDefer from "p-defer";
@@ -706,6 +710,67 @@ describe("transport", function () {
 		);
 	});
 
+	it("serves queued foreground block requests before background requests", async () => {
+		session = await TestSession.disconnected(1, {
+			services: {
+				blocks: (components) =>
+					new DirectBlock(components, { messageProcessingConcurrency: 1 }),
+			},
+		});
+		await store(session, 0).start();
+
+		const remoteBlocks = (store(session, 0) as any)[
+			"remoteBlocks"
+		] as RemoteBlocks;
+		const activeStarted = pDefer<void>();
+		const releaseActive = pDefer<void>();
+		const order: string[] = [];
+		const handleFetchRequest = sinon
+			.stub(remoteBlocks as any, "handleFetchRequest")
+			.callsFake(async (...args: unknown[]) => {
+				const request = args[0] as BlockRequest;
+				order.push(request.cid);
+				if (request.cid === "active") {
+					activeStarted.resolve();
+					await releaseActive.promise;
+				}
+			});
+		const context = (requestPriority: number) => ({
+			from: "requester",
+			transport: {
+				expiresAt: Date.now() + 5_000,
+				requestPriority,
+				responsePriority: requestPriority,
+				remainingTime: () => 5_000,
+				withResponseOptions: <T extends object>(options: T) => ({
+					...options,
+					priority: requestPriority,
+					expiresAt: Date.now() + 5_000,
+				}),
+			},
+		});
+
+		await remoteBlocks.onMessage(
+			new BlockRequest("active"),
+			context(BACKGROUND_MESSAGE_PRIORITY),
+		);
+		await activeStarted.promise;
+		await remoteBlocks.onMessage(
+			new BlockRequest("background"),
+			context(BACKGROUND_MESSAGE_PRIORITY),
+		);
+		await remoteBlocks.onMessage(
+			new BlockRequest("foreground"),
+			context(FOREGROUND_READ_MESSAGE_PRIORITY),
+		);
+
+		releaseActive.resolve();
+		await (remoteBlocks as any)._loadFetchQueue.onIdle();
+
+		expect(order).to.deep.equal(["active", "foreground", "background"]);
+		handleFetchRequest.restore();
+	});
+
 	it("relay proxy honors request timeout when upstream response is slow", async () => {
 		session = await TestSession.disconnected(3, {
 			services: { blocks: (c) => new DirectBlock(c) },
@@ -892,6 +957,78 @@ describe("transport", function () {
 		expect(secondRead).equal(undefined);
 		expect(t2 - t1).to.be.lessThan(500);
 		await firstRead;
+	});
+
+	it("promotes a shared in-flight block request for a foreground reader", async () => {
+		session = await TestSession.connected(2, {
+			services: { blocks: (c) => new DirectBlock(c) },
+		});
+		await waitForNeighbour(store(session, 0), store(session, 1));
+
+		const requesterRemoteBlocks = (store(session, 0) as any)[
+			"remoteBlocks"
+		] as RemoteBlocks;
+		const originalPublish = requesterRemoteBlocks.options.publish.bind(
+			requesterRemoteBlocks.options,
+		);
+		const firstRequestPublished = pDefer<void>();
+		const requestTransportOptions: Array<{
+			priority: number | undefined;
+			responsePriority: number | undefined;
+		}> = [];
+		requesterRemoteBlocks.options.publish = async (message, options) => {
+			if (message instanceof BlockRequest) {
+				requestTransportOptions.push({
+					priority: options.priority,
+					responsePriority: options.responsePriority,
+				});
+				if (requestTransportOptions.length === 1) {
+					firstRequestPublished.resolve();
+				}
+			}
+			return originalPublish(message, options);
+		};
+
+		const missingCid = "zb3we1BmfxpFg6bCXmrsuEo8JuQrGEf7RyFBdRxEHLuqc4CSr";
+		const backgroundRead = store(session, 0).get(missingCid, {
+			remote: {
+				timeout: 1_000,
+				from: [store(session, 1).publicKeyHash],
+				priority: BACKGROUND_MESSAGE_PRIORITY,
+			},
+		});
+		await firstRequestPublished.promise;
+
+		const foregroundRead = store(session, 0).get(missingCid, {
+			remote: {
+				timeout: 100,
+				from: [store(session, 1).publicKeyHash],
+				priority: FOREGROUND_READ_MESSAGE_PRIORITY,
+			},
+		});
+
+		expect(await foregroundRead).to.equal(undefined);
+		expect(requestTransportOptions.slice(0, 2)).to.deep.equal([
+			{
+				priority: BACKGROUND_MESSAGE_PRIORITY,
+				responsePriority: BACKGROUND_MESSAGE_PRIORITY,
+			},
+			{
+				priority: FOREGROUND_READ_MESSAGE_PRIORITY,
+				responsePriority: FOREGROUND_READ_MESSAGE_PRIORITY,
+			},
+		]);
+		expect(
+			await store(session, 0).get(missingCid, {
+				remote: {
+					timeout: 50,
+					from: [store(session, 1).publicKeyHash],
+					priority: CONVERGENCE_MESSAGE_PRIORITY,
+				},
+			}),
+		).to.equal(undefined);
+		expect(requestTransportOptions).to.have.length(2);
+		await backgroundRead;
 	});
 
 	it("iterate", async () => {

--- a/packages/transport/blocks/test/libp2p.spec.ts
+++ b/packages/transport/blocks/test/libp2p.spec.ts
@@ -11,7 +11,11 @@ import { expect } from "chai";
 import pDefer from "p-defer";
 import sinon from "sinon";
 import { DirectBlock } from "../src/libp2p.js";
-import { BlockRequest, BlockResponse, type RemoteBlocks } from "../src/remote.js";
+import {
+	BlockRequest,
+	BlockResponse,
+	type RemoteBlocks,
+} from "../src/remote.js";
 
 const store = (s: TestSession<{ blocks: DirectBlock }>, i: number) =>
 	s.peers[i].services.blocks;
@@ -143,7 +147,9 @@ describe("transport", function () {
 		const cid = await store(session, 0).put(data);
 		expect(cid).equal("zb2rhbnwihVzMMEGAPf9EwTZBsQz9fszCnM4Y8mJmBFgiyN7J");
 
-		const readData = await store(session, 1).get(cid, { remote: { timeout: 5000 } });
+		const readData = await store(session, 1).get(cid, {
+			remote: { timeout: 5000 },
+		});
 		expect(new Uint8Array(readData!)).to.deep.equal(data);
 	});
 
@@ -188,7 +194,8 @@ describe("transport", function () {
 		});
 		await store(session, 0).start();
 
-		const remoteBlocks = (store(session, 0) as any).remoteBlocks as RemoteBlocks;
+		const remoteBlocks = (store(session, 0) as any)
+			.remoteBlocks as RemoteBlocks;
 		const cid = "zb2rhbnwihVzMMEGAPf9EwTZBsQz9fszCnM4Y8mJmBFgiyN7J";
 		const secondCid = "zb2rhf3riC3q7Fxv2JtBMJw77QzZnDgNEQMk9GVK31qH4gcLx";
 
@@ -231,7 +238,9 @@ describe("transport", function () {
 		expect(new Uint8Array(read1!)).to.deep.equal(data);
 
 		// Second read uses the learned provider cache (no explicit `from`).
-		const read2 = await store(session, 2).get(cid, { remote: { timeout: 5000 } });
+		const read2 = await store(session, 2).get(cid, {
+			remote: { timeout: 5000 },
+		});
 		expect(new Uint8Array(read2!)).to.deep.equal(data);
 	});
 
@@ -253,7 +262,9 @@ describe("transport", function () {
 		const cid = await store(session, 0).put(data);
 		expect(cid).equal("zb2rhbnwihVzMMEGAPf9EwTZBsQz9fszCnM4Y8mJmBFgiyN7J");
 
-		const readPromise = store(session, 1).get(cid, { remote: { timeout: 10_000 } });
+		const readPromise = store(session, 1).get(cid, {
+			remote: { timeout: 10_000 },
+		});
 
 		// Connect after the get is already waiting (no explicit `remote.from`).
 		await session.connect([[session.peers[0], session.peers[1]]]);
@@ -429,7 +440,10 @@ describe("transport", function () {
 		let requestsToProvider = 0;
 		const staleRequestSeen = pDefer<void>();
 
-		requesterRemoteBlocks.options.publish = async (message: any, options: any) => {
+		requesterRemoteBlocks.options.publish = async (
+			message: any,
+			options: any,
+		) => {
 			if (message instanceof BlockRequest) {
 				const to = (options?.mode as any)?.to ?? [];
 				if (to.includes(store(session, 2).publicKeyHash)) {
@@ -446,9 +460,14 @@ describe("transport", function () {
 			return originalRequesterPublish(message, options);
 		};
 
-		providerRemoteBlocks.options.publish = async (message: any, options: any) => {
+		providerRemoteBlocks.options.publish = async (
+			message: any,
+			options: any,
+		) => {
 			if (message instanceof BlockResponse) {
-				const to = (options?.to ?? (options?.mode as any)?.to ?? []) as string[];
+				const to = (options?.to ??
+					(options?.mode as any)?.to ??
+					[]) as string[];
 				if (to.includes(store(session, 1).publicKeyHash)) {
 					await requesterRemoteBlocks.onMessage(message, {
 						from: store(session, 0).publicKeyHash,
@@ -508,35 +527,38 @@ describe("transport", function () {
 		const originalPublish = requesterRemoteBlocks.options.publish;
 		let forwardedToSource = 0;
 
-			requesterRemoteBlocks.options.publish = (message: any, options: any) => {
-				if (message instanceof BlockRequest) {
-					const to = (options?.mode as any)?.to ?? [];
-					const redundancy = Math.max(1, (options?.mode as any)?.redundancy ?? 1);
-					const selected = to.slice(0, redundancy);
-					return (async (): Promise<void> => {
-						const sourceRemoteBlocks = (store(session, 0) as any)[
-							"remoteBlocks"
-						] as RemoteBlocks;
-						await Promise.all(
-							selected.map(async (target: string): Promise<void> => {
-								if (target === store(session, 0).publicKeyHash) {
-									forwardedToSource++;
-									await sourceRemoteBlocks.onMessage(message, {
-										from: store(session, 1).publicKeyHash,
-									});
-								}
-							}),
-						);
-					})();
-				}
-				return originalPublish(message, options);
-			};
+		requesterRemoteBlocks.options.publish = (message: any, options: any) => {
+			if (message instanceof BlockRequest) {
+				const to = (options?.mode as any)?.to ?? [];
+				const redundancy = Math.max(1, (options?.mode as any)?.redundancy ?? 1);
+				const selected = to.slice(0, redundancy);
+				return (async (): Promise<void> => {
+					const sourceRemoteBlocks = (store(session, 0) as any)[
+						"remoteBlocks"
+					] as RemoteBlocks;
+					await Promise.all(
+						selected.map(async (target: string): Promise<void> => {
+							if (target === store(session, 0).publicKeyHash) {
+								forwardedToSource++;
+								await sourceRemoteBlocks.onMessage(message, {
+									from: store(session, 1).publicKeyHash,
+								});
+							}
+						}),
+					);
+				})();
+			}
+			return originalPublish(message, options);
+		};
 
 		try {
 			const read = await store(session, 1).get(cid, {
 				remote: {
 					timeout: 5_000,
-					from: [store(session, 2).publicKeyHash, store(session, 0).publicKeyHash],
+					from: [
+						store(session, 2).publicKeyHash,
+						store(session, 0).publicKeyHash,
+					],
 				},
 			});
 			expect(new Uint8Array(read!)).to.deep.equal(data);
@@ -669,8 +691,12 @@ describe("transport", function () {
 		const cid = await store(session, 0).put(data);
 		expect(cid).equal("zb2rhbnwihVzMMEGAPf9EwTZBsQz9fszCnM4Y8mJmBFgiyN7J");
 
-		const requesterRemoteBlocks = (store(session, 1) as any)["remoteBlocks"] as RemoteBlocks;
-		const providerRemoteBlocks = (store(session, 0) as any)["remoteBlocks"] as RemoteBlocks;
+		const requesterRemoteBlocks = (store(session, 1) as any)[
+			"remoteBlocks"
+		] as RemoteBlocks;
+		const providerRemoteBlocks = (store(session, 0) as any)[
+			"remoteBlocks"
+		] as RemoteBlocks;
 		const requestPublish = sinon.spy(requesterRemoteBlocks.options, "publish");
 		const responsePublish = sinon.spy(providerRemoteBlocks.options, "publish");
 
@@ -765,10 +791,173 @@ describe("transport", function () {
 		);
 
 		releaseActive.resolve();
-		await (remoteBlocks as any)._loadFetchQueue.onIdle();
+		await Promise.all([
+			(remoteBlocks as any)._backgroundLoadFetchQueue.onIdle(),
+			(remoteBlocks as any)._loadFetchQueue.onIdle(),
+		]);
 
 		expect(order).to.deep.equal(["active", "foreground", "background"]);
 		handleFetchRequest.restore();
+	});
+
+	it("reserves provider capacity for foreground block requests", async () => {
+		session = await TestSession.disconnected(1, {
+			services: {
+				blocks: (components) =>
+					new DirectBlock(components, { messageProcessingConcurrency: 2 }),
+			},
+		});
+		await store(session, 0).start();
+
+		const remoteBlocks = (store(session, 0) as any)[
+			"remoteBlocks"
+		] as RemoteBlocks;
+		const activeStarted = pDefer<void>();
+		const foregroundStarted = pDefer<void>();
+		const releaseBackground = pDefer<void>();
+		const order: string[] = [];
+		const handleFetchRequest = sinon
+			.stub(remoteBlocks as any, "handleFetchRequest")
+			.callsFake(async (...args: unknown[]) => {
+				const request = args[0] as BlockRequest;
+				order.push(request.cid);
+				if (request.cid === "active") {
+					activeStarted.resolve();
+				}
+				if (request.cid === "active" || request.cid === "background") {
+					await releaseBackground.promise;
+				}
+				if (request.cid === "foreground") {
+					foregroundStarted.resolve();
+				}
+			});
+		const context = (requestPriority: number) => ({
+			from: "requester",
+			transport: {
+				expiresAt: Date.now() + 5_000,
+				requestPriority,
+				responsePriority: requestPriority,
+				remainingTime: () => 5_000,
+				withResponseOptions: <T extends object>(options: T) => ({
+					...options,
+					priority: requestPriority,
+					expiresAt: Date.now() + 5_000,
+				}),
+			},
+		});
+
+		try {
+			await remoteBlocks.onMessage(
+				new BlockRequest("active"),
+				context(BACKGROUND_MESSAGE_PRIORITY),
+			);
+			await activeStarted.promise;
+			await remoteBlocks.onMessage(
+				new BlockRequest("background"),
+				context(BACKGROUND_MESSAGE_PRIORITY),
+			);
+			await remoteBlocks.onMessage(
+				new BlockRequest("foreground"),
+				context(FOREGROUND_READ_MESSAGE_PRIORITY),
+			);
+
+			const startedBeforeBackgroundReleased = await Promise.race([
+				foregroundStarted.promise.then(() => true),
+				delay(100).then(() => false),
+			]);
+			expect(startedBeforeBackgroundReleased).to.equal(true);
+			expect(order).to.deep.equal(["active", "foreground"]);
+		} finally {
+			releaseBackground.resolve();
+			await Promise.all([
+				(remoteBlocks as any)._backgroundLoadFetchQueue.onIdle(),
+				(remoteBlocks as any)._loadFetchQueue.onIdle(),
+			]);
+			handleFetchRequest.restore();
+		}
+
+		expect(order).to.deep.equal(["active", "foreground", "background"]);
+	});
+
+	it("drains nested provider queues without leaking work across restart", async () => {
+		session = await TestSession.disconnected(1, {
+			services: {
+				blocks: (components) =>
+					new DirectBlock(components, { messageProcessingConcurrency: 1 }),
+			},
+		});
+		await store(session, 0).start();
+
+		const remoteBlocks = (store(session, 0) as any)[
+			"remoteBlocks"
+		] as RemoteBlocks;
+		const activeStarted = pDefer<void>();
+		const releaseActive = pDefer<void>();
+		const handled: string[] = [];
+		const handleFetchRequest = sinon
+			.stub(remoteBlocks as any, "handleFetchRequest")
+			.callsFake(async (...args: unknown[]) => {
+				const request = args[0] as BlockRequest;
+				handled.push(request.cid);
+				if (request.cid === "active") {
+					activeStarted.resolve();
+					await releaseActive.promise;
+				}
+			});
+		const context = (requestPriority: number) => ({
+			from: "requester",
+			transport: {
+				expiresAt: Date.now() + 5_000,
+				requestPriority,
+				responsePriority: requestPriority,
+				remainingTime: () => 5_000,
+				withResponseOptions: <T extends object>(options: T) => ({
+					...options,
+					priority: requestPriority,
+					expiresAt: Date.now() + 5_000,
+				}),
+			},
+		});
+
+		let stopSettled = false;
+		let stopping: Promise<void> | undefined;
+		try {
+			await remoteBlocks.onMessage(
+				new BlockRequest("active"),
+				context(BACKGROUND_MESSAGE_PRIORITY),
+			);
+			await activeStarted.promise;
+			await remoteBlocks.onMessage(
+				new BlockRequest("queued-background"),
+				context(BACKGROUND_MESSAGE_PRIORITY),
+			);
+			await remoteBlocks.onMessage(
+				new BlockRequest("queued-foreground"),
+				context(FOREGROUND_READ_MESSAGE_PRIORITY),
+			);
+
+			stopping = remoteBlocks.stop().then(() => {
+				stopSettled = true;
+			});
+			await delay(25);
+			expect(stopSettled).to.equal(false);
+
+			releaseActive.resolve();
+			await stopping;
+			expect(handled).to.deep.equal(["active"]);
+
+			await remoteBlocks.start();
+			await remoteBlocks.onMessage(
+				new BlockRequest("after-restart"),
+				context(FOREGROUND_READ_MESSAGE_PRIORITY),
+			);
+			await (remoteBlocks as any)._loadFetchQueue.onIdle();
+			expect(handled).to.deep.equal(["active", "after-restart"]);
+		} finally {
+			releaseActive.resolve();
+			await stopping;
+			handleFetchRequest.restore();
+		}
 	});
 
 	it("relay proxy honors request timeout when upstream response is slow", async () => {
@@ -792,25 +981,50 @@ describe("transport", function () {
 		const cid = await store(session, 0).put(data);
 		expect(cid).equal("zb2rhbnwihVzMMEGAPf9EwTZBsQz9fszCnM4Y8mJmBFgiyN7J");
 
-		const providerRemoteBlocks = (store(session, 0) as any)["remoteBlocks"] as RemoteBlocks;
+		const providerRemoteBlocks = (store(session, 0) as any)[
+			"remoteBlocks"
+		] as RemoteBlocks;
+		const proxyRemoteBlocks = (store(session, 1) as any)[
+			"remoteBlocks"
+		] as RemoteBlocks;
 		const originalPublish = providerRemoteBlocks.options.publish.bind(
 			providerRemoteBlocks.options,
 		);
+		const originalProxyPublish = proxyRemoteBlocks.options.publish.bind(
+			proxyRemoteBlocks.options,
+		);
+		const proxiedRequestOptions: Array<{
+			priority: number | undefined;
+			responsePriority: number | undefined;
+		}> = [];
 		providerRemoteBlocks.options.publish = async (message, options) => {
 			if (message instanceof BlockResponse) {
 				await delay(1_500);
 			}
 			return originalPublish(message, options);
 		};
+		proxyRemoteBlocks.options.publish = async (message, options) => {
+			if (message instanceof BlockRequest) {
+				proxiedRequestOptions.push({
+					priority: options.priority,
+					responsePriority: options.responsePriority,
+				});
+			}
+			return originalProxyPublish(message, options);
+		};
 
 		const readData = await store(session, 2).get(cid, {
 			remote: {
 				timeout: 5_000,
 				from: [store(session, 1).publicKeyHash],
-				priority: CONVERGENCE_MESSAGE_PRIORITY,
+				priority: FOREGROUND_READ_MESSAGE_PRIORITY,
 			},
 		});
 		expect(new Uint8Array(readData!)).to.deep.equal(data);
+		expect(proxiedRequestOptions[0]).to.deep.equal({
+			priority: FOREGROUND_READ_MESSAGE_PRIORITY,
+			responsePriority: FOREGROUND_READ_MESSAGE_PRIORITY,
+		});
 	});
 
 	it("cancels a relay proxy read when its provider lookup outlives stop", async () => {
@@ -877,6 +1091,8 @@ describe("transport", function () {
 
 		expect(proxySignal?.aborted).to.equal(true);
 		expect(downstreamReadCalls).to.equal(0);
+		expect((remoteBlocks as any)._backgroundLoadFetchQueue.pending).to.equal(0);
+		expect((remoteBlocks as any)._backgroundLoadFetchQueue.size).to.equal(0);
 		expect((remoteBlocks as any)._loadFetchQueue.pending).to.equal(0);
 		expect((remoteBlocks as any)._loadFetchQueue.size).to.equal(0);
 		expect((remoteBlocks as any)._readFromPeersPromises.size).to.equal(0);
@@ -893,7 +1109,9 @@ describe("transport", function () {
 		const cid = await store(session, 0).put(data);
 		expect(cid).equal("zb2rhbnwihVzMMEGAPf9EwTZBsQz9fszCnM4Y8mJmBFgiyN7J");
 
-		const providerRemoteBlocks = (store(session, 0) as any)["remoteBlocks"] as RemoteBlocks;
+		const providerRemoteBlocks = (store(session, 0) as any)[
+			"remoteBlocks"
+		] as RemoteBlocks;
 		const originalPublish = providerRemoteBlocks.options.publish.bind(
 			providerRemoteBlocks.options,
 		);


### PR DESCRIPTION
## Summary
- preserve request priority when incoming block work enters the provider queue
- reissue a coalesced CID request only when a later waiter has a strictly higher priority
- cover provider queue ordering and same-CID promotion

## Why
A schema-v7 1 GiB file-share run showed foreground exact-head reads waiting behind background replication: the boundary chunk waited 44.1 seconds while replication filled the remaining heads. Transport priority was present on the wire but lost in the provider work queue and on same-CID coalescing.

## Validation
- `@peerbit/blocks`: 42 tests passing
- focused priority tests: 2 passing
- package TypeScript build
- changeset status