### PR TITLE
fix(shared-log): repair dropped replication announcements

### DIFF
--- a/.changeset/steady-replicators-confirm.md
+++ b/.changeset/steady-replicators-confirm.md
@@ -1,0 +1,9 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Repair silently dropped best-effort replication announcements with an
+eight-peer, fairly rotating cohort of acknowledged full-state transport
+deliveries. Each mutation generation performs at most three attempts per
+target, and newer state preempts stale in-flight sends. Acknowledgement confirms
+delivery of the signed envelope rather than receiver-local application.

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -105,6 +105,7 @@ import {
 	BACKGROUND_MESSAGE_PRIORITY,
 	CONVERGENCE_MESSAGE_PRIORITY,
 	DataMessage,
+	DeliveryError,
 	MessageHeader,
 	NotStartedError,
 	type RouteHint,
@@ -2307,6 +2308,64 @@ const isTransientReplicationAnnouncementError = (
 	return constructorName === "TimeoutError" || name === "TimeoutError";
 };
 
+/**
+ * Directed transport-delivery repair is allowed to retry explicit delivery
+ * failures in addition to timeouts. A DirectStream ACK confirms receipt of the
+ * signed envelope, not successful application by the receiver. Keep this
+ * separate from the primary fanout classifier above so replicate() rejection
+ * semantics remain unchanged for programming, serialization, and lifecycle
+ * errors.
+ */
+const isTransientReplicationAnnouncementRepairError = (
+	error: unknown,
+	seen = new Set<unknown>(),
+): boolean => {
+	if (
+		error != null &&
+		(typeof error === "object" || typeof error === "function")
+	) {
+		if (seen.has(error)) {
+			return false;
+		}
+		seen.add(error);
+	}
+
+	if (error instanceof DeliveryError || error instanceof TimeoutError) {
+		return true;
+	}
+
+	const nested = (error as { errors?: unknown })?.errors;
+	if (Array.isArray(nested) && nested.length > 0) {
+		return nested.every((item) =>
+			isTransientReplicationAnnouncementRepairError(item, new Set(seen)),
+		);
+	}
+
+	const cause = (error as { cause?: unknown })?.cause;
+	if (
+		cause != null &&
+		isTransientReplicationAnnouncementRepairError(cause, seen)
+	) {
+		return true;
+	}
+
+	const constructorName =
+		typeof (error as { constructor?: { name?: unknown } })?.constructor
+			?.name === "string"
+			? (error as { constructor: { name: string } }).constructor.name
+			: "";
+	const name =
+		typeof (error as { name?: unknown })?.name === "string"
+			? (error as { name: string }).name
+			: "";
+	return (
+		constructorName === "DeliveryError" ||
+		name === "DeliveryError" ||
+		constructorName === "TimeoutError" ||
+		name === "TimeoutError"
+	);
+};
+
 interface IndexableDomain<R extends "u32" | "u64"> {
 	numbers: Numbers<R>;
 	constructorEntry: new (properties: {
@@ -2582,6 +2641,14 @@ const CHECKED_PRUNE_RETRY_MAX_DELAY_MS = 30_000;
 // DONT SET THIS ANY LOWER, because it will make the pid controller unstable as the system responses are not fast enough to updates from the pid controller
 const RECALCULATE_PARTICIPATION_DEBOUNCE_INTERVAL = 1000;
 const REPLICATION_ANNOUNCEMENT_RETRY_INTERVAL = 1000;
+const REPLICATION_ANNOUNCEMENT_REPAIR_INTERVAL = 1000;
+const REPLICATION_ANNOUNCEMENT_REPAIR_MAX_ATTEMPTS = 3;
+// Repair one bounded cohort per mutation generation. The subscriber snapshot
+// is a best-effort cache and can contain thousands of entries, so attempting
+// the whole cache after every role mutation would turn convergence repair into
+// an unbounded burst of separately signed, acknowledged messages. A cursor
+// retained across generations rotates best-effort coverage over later changes.
+const REPLICATION_ANNOUNCEMENT_REPAIR_TARGETS_PER_GENERATION = 8;
 const RECALCULATE_PARTICIPATION_MIN_RELATIVE_CHANGE = 0.01;
 const RECALCULATE_PARTICIPATION_MIN_RELATIVE_CHANGE_WITH_CPU_LIMIT = 0.005;
 const RECALCULATE_PARTICIPATION_MIN_RELATIVE_CHANGE_WITH_MEMORY_LIMIT = 0.001;
@@ -2618,6 +2685,13 @@ const NATIVE_ED25519_VERIFY_BATCH_MIN_ENTRIES = 16;
 const hasPreverifiedSignature = (entry: Entry<any>) =>
 	(entry as { __peerbitSignatureVerified?: unknown })
 		.__peerbitSignatureVerified === true;
+
+type ReplicationAnnouncementRepairTarget = {
+	key: PublicSignKey;
+	generation: number;
+	attempts: number;
+	done: boolean;
+};
 // In sparse topologies (browser/relay), peers can learn about replicators via broadcast
 // replication announcements without having a direct connection that emits unsubscribe
 // on abrupt churn. Probe conservatively so a single missed ACK does not evict a
@@ -4180,6 +4254,20 @@ export class SharedLog<
 	private _replicationAnnouncementRetryPending!: boolean;
 	private _replicationAnnouncementRetryGeneration!: number;
 	private _replicationAnnouncementRetryController!: AbortController;
+	private replicationAnnouncementRepairDebounced:
+		| ReturnType<typeof debounceFixedInterval>
+		| undefined;
+	private _replicationAnnouncementRepairPending!: boolean;
+	private _replicationAnnouncementRepairGeneration!: number;
+	private _replicationAnnouncementRepairGenerationController!: AbortController;
+	private _replicationAnnouncementRepairTargets!: Map<
+		string,
+		ReplicationAnnouncementRepairTarget
+	>;
+	private _replicationAnnouncementRepairCohortSelected!: boolean;
+	private _replicationAnnouncementRepairFairCursorHash!: string | undefined;
+	private _replicationAnnouncementRepairMaxAttempts!: number;
+	private _replicationAnnouncementRepairController!: AbortController;
 
 	// A fn for debouncing the calls for pruning
 	pruneDebouncedFn!: DebouncedAccumulatorMap<{
@@ -4332,6 +4420,16 @@ export class SharedLog<
 		this._replicationAnnouncementRetryPending = false;
 		this._replicationAnnouncementRetryGeneration = 0;
 		this._replicationAnnouncementRetryController = new AbortController();
+		this._replicationAnnouncementRepairPending = false;
+		this._replicationAnnouncementRepairGeneration = 0;
+		this._replicationAnnouncementRepairGenerationController =
+			new AbortController();
+		this._replicationAnnouncementRepairTargets = new Map();
+		this._replicationAnnouncementRepairCohortSelected = false;
+		this._replicationAnnouncementRepairFairCursorHash = undefined;
+		this._replicationAnnouncementRepairMaxAttempts =
+			REPLICATION_ANNOUNCEMENT_REPAIR_MAX_ATTEMPTS;
+		this._replicationAnnouncementRepairController = new AbortController();
 		this.pendingMaturity = new Map();
 		this._closeController = new AbortController();
 	}
@@ -5778,11 +5876,301 @@ export class SharedLog<
 		);
 	}
 
+	private setupReplicationAnnouncementRepairFunction(
+		interval = REPLICATION_ANNOUNCEMENT_REPAIR_INTERVAL,
+		maxAttempts = REPLICATION_ANNOUNCEMENT_REPAIR_MAX_ATTEMPTS,
+	): void {
+		if (!Number.isSafeInteger(maxAttempts) || maxAttempts <= 0) {
+			throw new RangeError(
+				"Replication announcement repair attempts must be positive",
+			);
+		}
+		this.replicationAnnouncementRepairDebounced?.close();
+		this._replicationAnnouncementRepairController?.abort();
+		this._replicationAnnouncementRepairGenerationController?.abort();
+		this._replicationAnnouncementRepairController = new AbortController();
+		this._replicationAnnouncementRepairGenerationController =
+			new AbortController();
+		this._replicationAnnouncementRepairPending = false;
+		this._replicationAnnouncementRepairGeneration =
+			this._replicationAnnouncementRetryGeneration;
+		this._replicationAnnouncementRepairTargets = new Map();
+		this._replicationAnnouncementRepairCohortSelected = false;
+		this._replicationAnnouncementRepairFairCursorHash = undefined;
+		this._replicationAnnouncementRepairMaxAttempts = maxAttempts;
+		this.replicationAnnouncementRepairDebounced = debounceFixedInterval(
+			() => this.runCurrentReplicationStateAnnouncementRepair(),
+			interval,
+			{
+				leading: false,
+				// The wrapper catches worker failures while it still owns the generation
+				// context. Keep this boundary visibility-only: it must never mutate a
+				// possibly newer generation's pending state.
+				onError: (error) => logger.error(error),
+			},
+		);
+	}
+
+	private cancelCurrentReplicationStateAnnouncementRepair(): void {
+		this._replicationAnnouncementRepairPending = false;
+		this._replicationAnnouncementRepairController?.abort();
+		this._replicationAnnouncementRepairGenerationController?.abort();
+		this.replicationAnnouncementRepairDebounced?.close();
+		this._replicationAnnouncementRepairTargets?.clear();
+	}
+
+	private advanceCurrentReplicationStateAnnouncementRepairGeneration(): void {
+		const generation = this._replicationAnnouncementRetryGeneration;
+		if (generation === this._replicationAnnouncementRepairGeneration) {
+			return;
+		}
+
+		// Abort acknowledged sends carrying the old full-state snapshot before the
+		// primary announcement for the new mutation waits on transport. Otherwise a
+		// stale batch can hold the current state behind DirectStream's seek timeout.
+		this._replicationAnnouncementRepairGenerationController?.abort();
+		this._replicationAnnouncementRepairGenerationController =
+			new AbortController();
+		this._replicationAnnouncementRepairGeneration = generation;
+		this._replicationAnnouncementRepairPending = false;
+		this._replicationAnnouncementRepairTargets.clear();
+		this._replicationAnnouncementRepairCohortSelected = false;
+	}
+
+	private queueCurrentReplicationStateAnnouncementRepair(): void {
+		if (
+			this.closed ||
+			this._closeController.signal.aborted ||
+			this._replicationAnnouncementRepairController.signal.aborted ||
+			!this.replicationAnnouncementRepairDebounced
+		) {
+			return;
+		}
+
+		this.advanceCurrentReplicationStateAnnouncementRepairGeneration();
+		this._replicationAnnouncementRepairPending = true;
+		void this.replicationAnnouncementRepairDebounced.call();
+	}
+
+	private async runCurrentReplicationStateAnnouncementRepair(): Promise<void> {
+		const generation = this._replicationAnnouncementRetryGeneration;
+		const lifecycleController = this._replicationAnnouncementRepairController;
+		const generationController =
+			this._replicationAnnouncementRepairGenerationController;
+		try {
+			await this.repairCurrentReplicationStateAnnouncement({
+				generation,
+				lifecycleController,
+				generationController,
+			});
+		} catch (error) {
+			if (
+				this.closed ||
+				this._closeController.signal.aborted ||
+				lifecycleController.signal.aborted ||
+				generationController.signal.aborted ||
+				generation !== this._replicationAnnouncementRetryGeneration ||
+				generationController !==
+					this._replicationAnnouncementRepairGenerationController
+			) {
+				return;
+			}
+			if (isNotStartedError(error as Error)) {
+				return;
+			}
+
+			// Only the worker that still owns the current generation may conclude
+			// that its repair failed. A stale worker must not clear a newer call's
+			// pending flag or attribute its error to the new generation.
+			this._replicationAnnouncementRepairPending = false;
+			logger.error(error);
+		}
+	}
+
+	private async repairCurrentReplicationStateAnnouncement(context?: {
+		generation: number;
+		lifecycleController: AbortController;
+		generationController: AbortController;
+	}): Promise<void> {
+		if (!this._replicationAnnouncementRepairPending) {
+			return;
+		}
+		const generation =
+			context?.generation ?? this._replicationAnnouncementRetryGeneration;
+		const lifecycleController =
+			context?.lifecycleController ??
+			this._replicationAnnouncementRepairController;
+		const generationController =
+			context?.generationController ??
+			this._replicationAnnouncementRepairGenerationController;
+		const segments = (await this.getMyReplicationSegments()).map((range) =>
+			range.toReplicationRange(),
+		);
+		if (
+			this.closed ||
+			this._closeController.signal.aborted ||
+			lifecycleController.signal.aborted ||
+			generationController.signal.aborted
+		) {
+			return;
+		}
+		if (generation !== this._replicationAnnouncementRetryGeneration) {
+			this.queueCurrentReplicationStateAnnouncementRepair();
+			return;
+		}
+
+		const subscribers =
+			(await this.node.services.pubsub.getSubscribers(this.topic)) ?? [];
+		if (
+			this.closed ||
+			this._closeController.signal.aborted ||
+			lifecycleController.signal.aborted ||
+			generationController.signal.aborted
+		) {
+			return;
+		}
+		if (generation !== this._replicationAnnouncementRetryGeneration) {
+			this.queueCurrentReplicationStateAnnouncementRepair();
+			return;
+		}
+
+		const selfHash = this.node.identity.publicKey.hashcode();
+		const currentTargets = new Map<string, PublicSignKey>();
+		for (const key of subscribers) {
+			const hash = key.hashcode();
+			if (
+				hash !== selfHash &&
+				!this._replicationInfoBlockedPeers.has(hash) &&
+				!currentTargets.has(hash)
+			) {
+				currentTargets.set(hash, key);
+			}
+		}
+
+		for (const [hash, target] of this._replicationAnnouncementRepairTargets) {
+			if (target.generation !== generation || !currentTargets.has(hash)) {
+				this._replicationAnnouncementRepairTargets.delete(hash);
+			} else {
+				target.key = currentTargets.get(hash)!;
+			}
+		}
+		if (!this._replicationAnnouncementRepairCohortSelected) {
+			const candidates = [...currentTargets.entries()].sort(([left], [right]) =>
+				left.localeCompare(right),
+			);
+			const cursorIndex = this._replicationAnnouncementRepairFairCursorHash
+				? candidates.findIndex(
+						([hash]) =>
+							hash.localeCompare(
+								this._replicationAnnouncementRepairFairCursorHash!,
+							) > 0,
+					)
+				: 0;
+			const fairStart = cursorIndex < 0 ? 0 : cursorIndex;
+			const fairOrder = [
+				...candidates.slice(fairStart),
+				...candidates.slice(0, fairStart),
+			];
+			const cohort = fairOrder.slice(
+				0,
+				REPLICATION_ANNOUNCEMENT_REPAIR_TARGETS_PER_GENERATION,
+			);
+			for (const [hash, key] of cohort) {
+				this._replicationAnnouncementRepairTargets.set(hash, {
+					key,
+					generation,
+					attempts: 0,
+					done: false,
+				});
+			}
+			if (cohort.length > 0) {
+				this._replicationAnnouncementRepairFairCursorHash =
+					cohort[cohort.length - 1][0];
+			}
+			this._replicationAnnouncementRepairCohortSelected = true;
+		}
+
+		const batch = [
+			...this._replicationAnnouncementRepairTargets.entries(),
+		].filter(([, target]) => !target.done);
+		const snapshot = new AllReplicatingSegmentsMessage({ segments });
+		const results = await Promise.allSettled(
+			batch.map(([, target]) =>
+				this.rpc.send(snapshot, {
+					mode: new AcknowledgeDelivery({
+						to: [target.key],
+						redundancy: 1,
+					}),
+					priority: CONVERGENCE_MESSAGE_PRIORITY,
+					signal: generationController.signal,
+				}),
+			),
+		);
+		if (
+			this.closed ||
+			this._closeController.signal.aborted ||
+			lifecycleController.signal.aborted ||
+			generationController.signal.aborted
+		) {
+			return;
+		}
+		if (generation !== this._replicationAnnouncementRetryGeneration) {
+			this.queueCurrentReplicationStateAnnouncementRepair();
+			return;
+		}
+
+		for (const [index, result] of results.entries()) {
+			const [hash, attemptedTarget] = batch[index];
+			const target = this._replicationAnnouncementRepairTargets.get(hash);
+			if (target !== attemptedTarget || target.generation !== generation) {
+				continue;
+			}
+			if (result.status === "fulfilled") {
+				// DirectStream ACKs confirm that the signed transport envelope reached
+				// the target. Applying the contained replication state remains a
+				// receiver-local, best-effort operation.
+				target.done = true;
+				continue;
+			}
+
+			target.attempts += 1;
+			if (!isTransientReplicationAnnouncementRepairError(result.reason)) {
+				target.done = true;
+				logger.error(result.reason);
+			} else if (
+				target.attempts >= this._replicationAnnouncementRepairMaxAttempts
+			) {
+				target.done = true;
+				logger.trace(
+					"Acknowledged replication announcement repair exhausted for %s",
+					hash,
+				);
+			}
+		}
+
+		if (generation !== this._replicationAnnouncementRetryGeneration) {
+			this.queueCurrentReplicationStateAnnouncementRepair();
+			return;
+		}
+		if (
+			[...this._replicationAnnouncementRepairTargets.values()].some(
+				(target) => !target.done,
+			)
+		) {
+			void this.replicationAnnouncementRepairDebounced?.call();
+			return;
+		}
+
+		this._replicationAnnouncementRepairPending = false;
+		this._replicationAnnouncementRepairTargets.clear();
+	}
+
 	private cancelCurrentReplicationStateAnnouncementRetry(): void {
 		this._replicationAnnouncementRetryGeneration += 1;
 		this._replicationAnnouncementRetryPending = false;
 		this._replicationAnnouncementRetryController?.abort();
 		this.replicationAnnouncementRetryDebounced?.close();
+		this.cancelCurrentReplicationStateAnnouncementRepair();
 	}
 
 	private async sendReplicationAnnouncement(
@@ -5796,10 +6184,12 @@ export class SharedLog<
 		// local state; the generation mismatch forces one more current snapshot
 		// after that stale send settles.
 		this._replicationAnnouncementRetryGeneration += 1;
+		this.advanceCurrentReplicationStateAnnouncementRepairGeneration();
 		try {
 			await this.rpc.send(message, {
 				priority: CONVERGENCE_MESSAGE_PRIORITY,
 			});
+			this.queueCurrentReplicationStateAnnouncementRepair();
 		} catch (error) {
 			// The local replication-index mutation precedes all calls to this
 			// wrapper. Preserve the explicit caller's rejection, but independently
@@ -5833,6 +6223,7 @@ export class SharedLog<
 				priority: CONVERGENCE_MESSAGE_PRIORITY,
 				signal: controller.signal,
 			});
+			this.queueCurrentReplicationStateAnnouncementRepair();
 		} catch (error) {
 			if (
 				this.closed ||
@@ -12229,6 +12620,7 @@ export class SharedLog<
 
 		this._closeController = new AbortController();
 		this.setupReplicationAnnouncementRetryFunction();
+		this.setupReplicationAnnouncementRepairFunction();
 		this._closeController.signal.addEventListener("abort", () => {
 			for (const [_peer, state] of this._replicationInfoRequestByPeer) {
 				if (state.timer) clearTimeout(state.timer);

--- a/packages/programs/data/shared-log/test/replication-announcement-retry.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-announcement-retry.spec.ts
@@ -1,3 +1,4 @@
+import { AcknowledgeDelivery, DeliveryError } from "@peerbit/stream-interface";
 import { TestSession } from "@peerbit/test-utils";
 import {
 	AbortError,
@@ -29,6 +30,10 @@ describe("replication announcement retries", () => {
 
 	const useFastAnnouncementRetry = (log: any) => {
 		log.setupReplicationAnnouncementRetryFunction(10);
+	};
+
+	const useFastAnnouncementRepair = (log: any, maxAttempts = 3) => {
+		log.setupReplicationAnnouncementRepairFunction(10, maxAttempts);
 	};
 
 	afterEach(async () => {
@@ -149,6 +154,419 @@ describe("replication announcement retries", () => {
 		await delay(40);
 		expect(snapshots).to.deep.equal([]);
 		expect(log._replicationAnnouncementRetryPending).to.equal(false);
+	});
+
+	it("repairs a silently dropped incremental through acknowledged transport delivery", async () => {
+		session = await TestSession.connected(2);
+		const writer = await session.peers[0].open(new EventStore<string, any>(), {
+			args: {
+				replicate: { factor: 1, offset: 0 },
+				timeUntilRoleMaturity: 0,
+				waitForReplicatorRequestIntervalMs: 25,
+				waitForReplicatorRequestMaxAttempts: 1,
+			},
+		});
+		const reader = await session.peers[1].open(writer.clone(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForReplicatorRequestIntervalMs: 25,
+				waitForReplicatorRequestMaxAttempts: 1,
+			},
+		});
+		const writerHash = writer.node.identity.publicKey.hashcode();
+		const readerHash = reader.node.identity.publicKey.hashcode();
+
+		await waitForResolved(
+			async () => {
+				const subscribers =
+					(await reader.node.services.pubsub.getSubscribers(
+						reader.log.topic,
+					)) ?? [];
+				expect(subscribers.map((key) => key.hashcode())).to.include(writerHash);
+			},
+			{ timeout: 5_000, delayInterval: 10 },
+		);
+		await delay(75);
+		await waitForResolved(
+			async () => {
+				expect([...(await writer.log.getReplicators())]).to.have.members([
+					writerHash,
+				]);
+			},
+			{ timeout: 5_000, delayInterval: 10 },
+		);
+
+		const readerLog = reader.log as any;
+		useFastAnnouncementRepair(readerLog);
+		const originalSend = reader.log.rpc.send.bind(reader.log.rpc);
+		let droppedIncrementals = 0;
+		const acknowledgedTargets: string[] = [];
+		sinon
+			.stub(reader.log.rpc, "send")
+			.callsFake(async (message: any, options?: any) => {
+				if (
+					message instanceof AddedReplicationSegmentMessage &&
+					!(options?.mode instanceof AcknowledgeDelivery) &&
+					droppedIncrementals === 0
+				) {
+					droppedIncrementals += 1;
+					return;
+				}
+				if (
+					message instanceof AllReplicatingSegmentsMessage &&
+					options?.mode instanceof AcknowledgeDelivery
+				) {
+					acknowledgedTargets.push(...options.mode.to);
+				}
+				return originalSend(message, options);
+			});
+
+		await reader.log.replicate({ factor: 1, offset: 0 });
+		await waitForResolved(
+			async () => {
+				expect([...(await writer.log.getReplicators())]).to.have.members([
+					writerHash,
+					readerHash,
+				]);
+			},
+			{ timeout: 5_000, delayInterval: 10 },
+		);
+		expect(droppedIncrementals).to.equal(1);
+		expect(acknowledgedTargets).to.include(writerHash);
+	});
+
+	it("retries only a subscriber that did not acknowledge", async () => {
+		session = await TestSession.disconnected(3);
+		const store = await session.peers[0].open(new EventStore<string, any>(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = store.log as any;
+		useFastAnnouncementRepair(log);
+		const first = session.peers[1].identity.publicKey;
+		const second = session.peers[2].identity.publicKey;
+		const firstHash = first.hashcode();
+		const secondHash = second.hashcode();
+		sinon
+			.stub(store.node.services.pubsub, "getSubscribers")
+			.callsFake(() => [first, second]);
+		const calls = new Map<string, number>();
+		sinon
+			.stub(store.log.rpc, "send")
+			.callsFake(async (message: any, options?: any) => {
+				if (
+					message instanceof AllReplicatingSegmentsMessage &&
+					options?.mode instanceof AcknowledgeDelivery
+				) {
+					const target = options.mode.to[0];
+					calls.set(target, (calls.get(target) ?? 0) + 1);
+					if (target === secondHash && calls.get(target) === 1) {
+						throw new DeliveryError("synthetic lost acknowledgement");
+					}
+				}
+			});
+
+		await store.log.replicate({ factor: 0.25, offset: 0.1 });
+		await waitForResolved(
+			() => expect(log._replicationAnnouncementRepairPending).to.equal(false),
+			{ timeout: 2_000, delayInterval: 5 },
+		);
+		expect(calls.get(firstHash)).to.equal(1);
+		expect(calls.get(secondHash)).to.equal(2);
+	});
+
+	it("caps acknowledged repair retries and coalesces newer mutations", async () => {
+		session = await TestSession.disconnected(2);
+		const store = await session.peers[0].open(new EventStore<string, any>(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = store.log as any;
+		log.setupReplicationAnnouncementRepairFunction(25, 3);
+		const target = session.peers[1].identity.publicKey;
+		sinon
+			.stub(store.node.services.pubsub, "getSubscribers")
+			.callsFake(() => [target]);
+		const firstRangeId = new Uint8Array(32).fill(21);
+		const secondRangeId = new Uint8Array(32).fill(22);
+		const snapshots: AllReplicatingSegmentsMessage[] = [];
+		let rejectRepairs = false;
+		sinon
+			.stub(store.log.rpc, "send")
+			.callsFake(async (message: any, options?: any) => {
+				if (
+					message instanceof AllReplicatingSegmentsMessage &&
+					options?.mode instanceof AcknowledgeDelivery
+				) {
+					snapshots.push(message);
+					if (rejectRepairs) {
+						throw new DeliveryError("synthetic unreachable subscriber");
+					}
+				}
+			});
+
+		await store.log.replicate({
+			id: firstRangeId,
+			factor: 0.25,
+			offset: 0.1,
+		});
+		await store.log.replicate({
+			id: secondRangeId,
+			factor: 0.2,
+			offset: 0.6,
+		});
+		await waitForResolved(
+			() => expect(log._replicationAnnouncementRepairPending).to.equal(false),
+			{ timeout: 2_000, delayInterval: 5 },
+		);
+		expect(snapshots).to.have.length(1);
+		expect(
+			snapshots[0].segments.map((segment) => Array.from(segment.id).join(",")),
+		).to.have.members([
+			Array.from(firstRangeId).join(","),
+			Array.from(secondRangeId).join(","),
+		]);
+
+		rejectRepairs = true;
+		snapshots.length = 0;
+		await store.log.replicate({ factor: 0.1, offset: 0.8 });
+		await waitForResolved(
+			() => expect(log._replicationAnnouncementRepairPending).to.equal(false),
+			{ timeout: 2_000, delayInterval: 5 },
+		);
+		expect(snapshots).to.have.length(3);
+		await delay(75);
+		expect(snapshots).to.have.length(3);
+	});
+
+	it("caps each generation at eight targets and rotates the next cohort", async () => {
+		session = await TestSession.disconnected(11);
+		const store = await session.peers[0].open(new EventStore<string, any>(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = store.log as any;
+		log.setupReplicationAnnouncementRepairFunction(10_000, 3);
+		const targets = session.peers
+			.slice(1)
+			.map((peer) => peer.identity.publicKey);
+		sinon
+			.stub(store.node.services.pubsub, "getSubscribers")
+			.callsFake(() => targets);
+		const firstGenerationAttempts: string[] = [];
+		const secondGenerationAttempts: string[] = [];
+		let generation = 1;
+		sinon
+			.stub(store.log.rpc, "send")
+			.callsFake(async (message: any, options?: any) => {
+				if (
+					message instanceof AllReplicatingSegmentsMessage &&
+					options?.mode instanceof AcknowledgeDelivery
+				) {
+					const attempts =
+						generation === 1
+							? firstGenerationAttempts
+							: secondGenerationAttempts;
+					attempts.push(options.mode.to[0]);
+					if (generation === 1) {
+						throw new DeliveryError("synthetic unreachable subscriber");
+					}
+				}
+			});
+
+		await store.log.replicate({ factor: 0.25, offset: 0.1 });
+		await log.repairCurrentReplicationStateAnnouncement();
+		await log.repairCurrentReplicationStateAnnouncement();
+		await log.repairCurrentReplicationStateAnnouncement();
+		await log.repairCurrentReplicationStateAnnouncement();
+		expect(firstGenerationAttempts).to.have.length(24);
+		const firstCohort = new Set(firstGenerationAttempts);
+		expect(firstCohort.size).to.equal(8);
+
+		generation = 2;
+		await store.log.replicate({ factor: 0.2, offset: 0.6 });
+		await log.repairCurrentReplicationStateAnnouncement();
+		expect(secondGenerationAttempts).to.have.length(8);
+		const secondCohort = new Set(secondGenerationAttempts);
+		expect(secondCohort.size).to.equal(8);
+		expect(
+			[...secondCohort].filter((hash) => !firstCohort.has(hash)),
+		).to.have.length(2);
+	});
+
+	it("preempts an in-flight stale repair with the next mutation generation", async () => {
+		session = await TestSession.disconnected(2);
+		const store = await session.peers[0].open(new EventStore<string, any>(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = store.log as any;
+		useFastAnnouncementRepair(log);
+		const target = session.peers[1].identity.publicKey;
+		sinon
+			.stub(store.node.services.pubsub, "getSubscribers")
+			.callsFake(() => [target]);
+
+		const firstRangeId = new Uint8Array(32).fill(31);
+		const secondRangeId = new Uint8Array(32).fill(32);
+		const snapshots: AllReplicatingSegmentsMessage[] = [];
+		let firstRepairSignal: AbortSignal | undefined;
+		let markFirstRepairStarted!: () => void;
+		const firstRepairStarted = new Promise<void>((resolve) => {
+			markFirstRepairStarted = resolve;
+		});
+		sinon
+			.stub(store.log.rpc, "send")
+			.callsFake(async (message: any, options?: any) => {
+				if (
+					message instanceof AllReplicatingSegmentsMessage &&
+					options?.mode instanceof AcknowledgeDelivery
+				) {
+					snapshots.push(message);
+					if (snapshots.length === 1) {
+						firstRepairSignal = options.signal;
+						markFirstRepairStarted();
+						await new Promise<void>((_resolve, reject) => {
+							const rejectAborted = () =>
+								reject(new AbortError("repair generation superseded"));
+							if (options.signal.aborted) {
+								rejectAborted();
+								return;
+							}
+							options.signal.addEventListener("abort", rejectAborted, {
+								once: true,
+							});
+						});
+					}
+				}
+			});
+
+		await store.log.replicate({
+			id: firstRangeId,
+			factor: 0.25,
+			offset: 0.1,
+		});
+		await firstRepairStarted;
+		await store.log.replicate({
+			id: secondRangeId,
+			factor: 0.2,
+			offset: 0.6,
+		});
+		expect(firstRepairSignal?.aborted).to.equal(true);
+
+		await waitForResolved(
+			() => {
+				expect(snapshots).to.have.length(2);
+				expect(log._replicationAnnouncementRepairPending).to.equal(false);
+			},
+			{ timeout: 2_000, delayInterval: 5 },
+		);
+		expect(snapshots[0].segments).to.have.length(1);
+		expect(
+			snapshots[1].segments.map((segment) => Array.from(segment.id).join(",")),
+		).to.have.members([
+			Array.from(firstRangeId).join(","),
+			Array.from(secondRangeId).join(","),
+		]);
+	});
+
+	it("does not let a stale collection failure clear a newer pending repair", async () => {
+		session = await TestSession.disconnected(2);
+		const store = await session.peers[0].open(new EventStore<string, any>(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = store.log as any;
+		useFastAnnouncementRepair(log);
+		const target = session.peers[1].identity.publicKey;
+
+		let rejectStaleCollection!: (error: Error) => void;
+		let markStaleCollectionStarted!: () => void;
+		const staleCollectionStarted = new Promise<void>((resolve) => {
+			markStaleCollectionStarted = resolve;
+		});
+		const staleCollection = new Promise<never>((_resolve, reject) => {
+			rejectStaleCollection = reject;
+		});
+		let subscriberCollections = 0;
+		sinon.stub(store.node.services.pubsub, "getSubscribers").callsFake(() => {
+			subscriberCollections += 1;
+			if (subscriberCollections === 1) {
+				markStaleCollectionStarted();
+				return staleCollection;
+			}
+			return [target];
+		});
+
+		const firstRangeId = new Uint8Array(32).fill(41);
+		const secondRangeId = new Uint8Array(32).fill(42);
+		const snapshots: AllReplicatingSegmentsMessage[] = [];
+		sinon
+			.stub(store.log.rpc, "send")
+			.callsFake(async (message: any, options?: any) => {
+				if (
+					message instanceof AllReplicatingSegmentsMessage &&
+					options?.mode instanceof AcknowledgeDelivery
+				) {
+					snapshots.push(message);
+				}
+			});
+
+		await store.log.replicate({
+			id: firstRangeId,
+			factor: 0.25,
+			offset: 0.1,
+		});
+		await staleCollectionStarted;
+		await store.log.replicate({
+			id: secondRangeId,
+			factor: 0.2,
+			offset: 0.6,
+		});
+		expect(log._replicationAnnouncementRepairPending).to.equal(true);
+		rejectStaleCollection(new Error("stale subscriber collection failed"));
+
+		await waitForResolved(
+			() => {
+				expect(subscriberCollections).to.equal(2);
+				expect(snapshots).to.have.length(1);
+				expect(log._replicationAnnouncementRepairPending).to.equal(false);
+			},
+			{ timeout: 2_000, delayInterval: 5 },
+		);
+		expect(
+			snapshots[0].segments.map((segment) => Array.from(segment.id).join(",")),
+		).to.have.members([
+			Array.from(firstRangeId).join(","),
+			Array.from(secondRangeId).join(","),
+		]);
+	});
+
+	it("cancels a queued acknowledged repair on close", async () => {
+		session = await TestSession.disconnected(2);
+		const store = await session.peers[0].open(new EventStore<string, any>(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = store.log as any;
+		log.setupReplicationAnnouncementRepairFunction(100, 3);
+		const target = session.peers[1].identity.publicKey;
+		sinon
+			.stub(store.node.services.pubsub, "getSubscribers")
+			.callsFake(() => [target]);
+		let acknowledgedSnapshots = 0;
+		sinon
+			.stub(store.log.rpc, "send")
+			.callsFake(async (message: any, options?: any) => {
+				if (
+					message instanceof AllReplicatingSegmentsMessage &&
+					options?.mode instanceof AcknowledgeDelivery
+				) {
+					acknowledgedSnapshots += 1;
+				}
+			});
+
+		await store.log.replicate({ factor: 0.25, offset: 0.1 });
+		expect(log._replicationAnnouncementRepairPending).to.equal(true);
+		await store.close();
+		await delay(150);
+		expect(acknowledgedSnapshots).to.equal(0);
+		expect(log._replicationAnnouncementRepairPending).to.equal(false);
 	});
 
 	it("uses exact timeout branding without retrying generic closed or mixed aggregate failures", async () => {


### PR DESCRIPTION
## Summary

- repair silently dropped best-effort replication announcements after a successful primary fanout with bounded acknowledged delivery
- select at most eight subscribers per mutation generation, rotate the cohort fairly across later generations, and cap each target at three attempts
- abort stale in-flight repair when newer replication state is announced while preserving the existing primary-send rejection semantics

This changes network convergence behavior but introduces no new wire message or protocol schema. It reuses `AllReplicatingSegmentsMessage`; the acknowledgement proves signed-envelope delivery, not receiver-local application.

## Evidence

The deterministic 1 GiB fileshare run completed byte transfer and SHA-256/CRC-32 integrity but exposed a terminal topology failure: the writer could miss the reader role after the original best-effort announcement was silently dropped.

## Verification

- focused replication-announcement repair suite: 16 passing
- full `@peerbit/shared-log` suite: 1,941 passing, 10 pending
- shared-log build passed
- Prettier and `git diff --check` passed

Built on the request-queue capacity repair from #1095, now merged.