### PR TITLE
test(file-share): harden exact transfer benchmark

### DIFF
--- a/scripts/file-share/README.md
+++ b/scripts/file-share/README.md
@@ -3,7 +3,7 @@
 Run a single checkout with `pnpm bench:file-share:local` or compare pinned
 Peerbit revisions with `pnpm bench:file-share:matrix`.
 
-Result schema v7 defines `errorCount` as every uncaught browser `pageerror`,
+Result schema v8 defines `errorCount` as every uncaught browser `pageerror`,
 every browser `console.error`, every console message at any level that contains
 a declared Peerbit failure signature, and scenario-recorded operation failures.
 Each result embeds the exact `errorCollectionDefinition` and signature list.
@@ -11,7 +11,7 @@ Playwright `requestfailed` events are retained separately under
 `requestFailures`; they are diagnostics and are not automatically fatal because
 peer-to-peer discovery can legitimately exercise failed network candidates.
 
-Passed schema v7 upload results require `writerDiagnostics.lastUploadDiagnostics`
+Passed schema v8 upload results require `writerDiagnostics.lastUploadDiagnostics`
 to contain exactly 21 bounded progress milestones from 0% through 100% in 5%
 increments. Each point records the aggregate bytes whose application-level
 chunk puts completed, using the library upload clock and exact ceil-rounded byte
@@ -47,7 +47,8 @@ sinks only in separate benchmark sessions; aggregate comparison objects fail
 closed on mixed sinks, and every passed result and aggregate labels
 non-hash-only cohorts non-authoritative.
 
-Schema v7 upload results also record bounded download-window memory telemetry. After any
+Schema v8 upload results also record the `download-memory-v2` bounded
+download-window memory telemetry contract. After any
 controlled-locality stabilization, the harness arms serial samplers immediately
 before the timed click and forces a final sample as soon as the selected sink
 completion is observed, before integrity readback or terminal-topology checks.
@@ -68,16 +69,20 @@ never accepted as performance evidence.
 Every CDP sample and setup operation has a four-second deadline; sampler
 cleanup has a nine-second aggregate deadline, late-created CDP sessions are
 detached best-effort, and a timed-out probe becomes terminal so another sample
-cannot overlap it. Result validation binds every series to the actual click and
+cannot overlap it. Sampling is finalized at sink completion. CDP disable and
+detach run only after transfer integrity is finalized; cleanup timeouts are
+bounded warnings, while setup, sampling, and non-timeout cleanup errors remain
+fatal. Result validation binds every series to the actual click and
 completion-observation timestamps: setup may begin at most 30 seconds before
-the click, and the terminal sample plus cleanup must finish within 30 seconds
-after completion is observed. Host samples are additionally capped at 256
-Chromium processes and 32 process-role groups.
+the click, and the terminal sample must finish within 30 seconds after
+completion is observed. Host samples are additionally capped at 256 Chromium
+processes and 32 process-role groups.
 
 For a controlled reader-locality download cohort, run an upload with
 `--mode fixed1`, `--reader-local-chunk-target <N>`, and
-`--reader-local-chunk-max-overshoot <M>`. The two locality options are a required
-pair, `M` is capped at eight chunks, and this profile uses a one-replicator
+`--reader-local-chunk-max-overshoot <M>`, and
+`--reader-terminal-topology <observer|replicator>`. All three locality options
+are required together, `M` is capped at eight chunks, and this profile uses a one-replicator
 readiness baseline. The writer is fixed at factor one and the reader is an
 observer before upload starts; topology evidence must show exactly one
 replicator, with the writer in and reader out of that set, both before upload and
@@ -85,32 +90,40 @@ again immediately before the timed read. Both peers must report the same exact
 singleton replicator identity, and that identity must be the writer.
 
 After the normal upload and post-upload monitor finish, the harness enables
-persistent reader chunk reads and performs an untimed sequential prefix preload
-that yields exactly `N` chunks. A nonzero preload has one aggregate download
-deadline enforced through an abort signal, rather than resetting the deadline
-for every chunk. It explicitly closes the iterator within the bounded cleanup
-tolerance and requires no active transfer or queued download work afterward.
-`N=0` is the cold observer-persistent cohort and opens no preload stream. The
-harness then records three identical exact locality samples, spaced by
+persistent reader chunk reads and imports exactly the first `N` entry blocks
+from the ready root manifest. This benchmark-only provisioning bypasses the
+product stream read-ahead path, uses bounded batches of eight raw block
+requests, retains every imported head under its exact `${file.id}:${index}`
+document identity so adaptive pruning cannot classify a current manifest entry
+as stale, and applies one aggregate download deadline. It asserts that the
+only local manifest-entry heads afterward are indices `0..N-1` and that no
+active transfer or queued download work remains. `N=0` is the cold
+observer-persistent cohort and imports no entry block. The harness then records
+three identical exact locality samples, spaced by
 `min(--poll-ms, 100ms)`. Each sample includes both the manifest-entry blocks
 available in the local block store (`K`) and the local Documents index rows
 (`J`). Both sets must be contiguous prefixes, `N <= K <= N + M`, `J <= K`, and
-`K` must remain smaller than the file's full chunk count. `K` can exceed `N`
-because Peerbit may read ahead; a cached entry block also need not have a local
-index row yet.
+`K` must remain smaller than the file's full chunk count. The direct provisioning
+step itself requires `K=N` with zero speculative imports; `M` only bounds any
+unexpected locality change before the timed read. A cached entry block need not
+have a local index row yet.
 
 The measured cohort key is therefore
 `observer-persistent-prefix-b<K>-i<J>`, not merely the requested target. Timed
 read diagnostics must report those exact initial block and index-row counts.
-Here, `observer` describes the upload and timed-read **start** topology, not the
-entire persistent transfer. A persistent timed read is expected to promote the
-reader into replication. After sink completion, integrity verification, and an
-idle transfer scheduler, the harness collects three additional stable topology
-samples outside the measured download duration. Both peers must then report the
-same exact sorted `[writer, reader]` replicator set, both must report themselves
-in that set, and the peer identities must match the pre-upload and pre-read
-checkpoints. Non-convergence fails the run rather than creating or mixing an
-implicit terminal-topology cohort.
+After sink completion, integrity verification, and an idle transfer scheduler,
+the harness requires every manifest-entry block to be local. The explicit
+terminal expectation keeps historical and fixed implementations in separate,
+fail-closed cohorts: `observer` requires zero local chunk index rows and the
+writer as the exact singleton replicator; `replicator` requires the complete
+chunk index prefix and the exact writer+reader replication pair. The harness
+collects three stable topology samples outside the measured download duration;
+both peer identities must match the pre-upload and pre-read checkpoints. This
+terminal endpoint evidence does not claim the reader held one role continuously
+during the timed window. Final diagnostics must report the requested replicator
+count and one locally indexed root on both peers (`replicationSetSize=1`).
+Non-convergence fails the run rather than creating or mixing an implicit
+terminal-topology cohort.
 
 Repeated standalone and matrix results are grouped by the exact key, so timings
 from different read-ahead outcomes are never averaged together. Raw canonical
@@ -118,7 +131,7 @@ per-chunk timings remain in each result and can be rebucketed into 5% progress
 windows without losing the underlying samples. Without the paired locality
 options, roles, persistence policy, and seeder-drop gates are unchanged.
 
-Schema v7 records the exact versioned `seederDropPolicy` and a final numeric
+Schema v8 records the exact versioned `seederDropPolicy` and a final numeric
 `terminal` seeder snapshot after download and integrity verification. Every
 upload cohort also records top-level `integrityVerifiedAt`: it remains `null`
 until the aggregate size, SHA-256, CRC-32, manifest, and persistence gates have

--- a/scripts/file-share/benchmark-invocation.mjs
+++ b/scripts/file-share/benchmark-invocation.mjs
@@ -3,7 +3,7 @@ import { isDeepStrictEqual } from "node:util";
 
 export const BENCHMARK_INVOCATION_SCHEMA = {
 	id: "peerbit-file-share-benchmark-invocation",
-	version: 3,
+	version: 4,
 };
 
 export const TINY_FILE_CUTOFF_BYTES = 5_000_000;
@@ -16,6 +16,10 @@ export const BENCHMARK_DOWNLOAD_SINKS = Object.freeze([
 ]);
 export const DEFAULT_BENCHMARK_DOWNLOAD_SINK = "hash-only";
 export const MAX_READER_LOCAL_CHUNK_OVERSHOOT = 8;
+export const READER_TERMINAL_TOPOLOGIES = Object.freeze([
+	"observer",
+	"replicator",
+]);
 
 const DEPLOYED_APP_HARNESS_MESSAGE =
 	"The locally instrumented core benchmark harness cannot use --base-url because it cannot attribute an external deployment to the selected Peerbit checkout; use a dedicated deployed-app benchmark harness that records deployment provenance";
@@ -169,6 +173,7 @@ export const createBenchmarkInvocation = ({
 	targetSeeders,
 	readerLocalChunkTarget,
 	readerLocalChunkMaxOvershoot,
+	readerTerminalTopology,
 	baseUrl,
 	protocol,
 	viteMode,
@@ -235,12 +240,32 @@ export const createBenchmarkInvocation = ({
 					readerLocalChunkMaxOvershoot,
 					"readerLocalChunkMaxOvershoot",
 				);
+	const resolvedReaderTerminalTopology =
+		readerTerminalTopology == null || readerTerminalTopology === ""
+			? null
+			: String(readerTerminalTopology);
+	if (
+		resolvedReaderTerminalTopology !== null &&
+		!READER_TERMINAL_TOPOLOGIES.includes(resolvedReaderTerminalTopology)
+	) {
+		throw new Error(
+			`Unsupported readerTerminalTopology ${JSON.stringify(resolvedReaderTerminalTopology)}; expected one of ${READER_TERMINAL_TOPOLOGIES.join(", ")}`,
+		);
+	}
 	if (
 		(resolvedReaderLocalChunkTarget === null) !==
 		(resolvedReaderLocalChunkMaxOvershoot === null)
 	) {
 		throw new Error(
 			"readerLocalChunkTarget and readerLocalChunkMaxOvershoot must be provided together",
+		);
+	}
+	if (
+		(resolvedReaderLocalChunkTarget === null) !==
+		(resolvedReaderTerminalTopology === null)
+	) {
+		throw new Error(
+			"readerTerminalTopology must be provided exactly when readerLocalChunkTarget is provided",
 		);
 	}
 	if (
@@ -315,6 +340,7 @@ export const createBenchmarkInvocation = ({
 		targetSeeders: resolvedTargetSeeders,
 		readerLocalChunkTarget: resolvedReaderLocalChunkTarget,
 		readerLocalChunkMaxOvershoot: resolvedReaderLocalChunkMaxOvershoot,
+		readerTerminalTopology: resolvedReaderTerminalTopology,
 		baseUrl: resolvedBaseUrl,
 		protocol: previewOptions.protocol,
 		viteMode: previewOptions.viteMode,
@@ -377,6 +403,9 @@ export const createPlaywrightBenchmarkEnvironment = ({
 		),
 		PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT: stringValue(
 			invocation.readerLocalChunkMaxOvershoot,
+		),
+		PW_READER_TERMINAL_TOPOLOGY: stringValue(
+			invocation.readerTerminalTopology,
 		),
 		PW_UPLOAD_TIMEOUT_MS: String(invocation.uploadTimeoutMs),
 		PW_VERBOSE: invocation.verbose ? "1" : "0",

--- a/scripts/file-share/benchmark-invocation.test.mjs
+++ b/scripts/file-share/benchmark-invocation.test.mjs
@@ -57,6 +57,7 @@ test("resolves every default and requested optional knob", () => {
 			targetSeeders: resolved.targetSeeders,
 			readerLocalChunkTarget: resolved.readerLocalChunkTarget,
 			readerLocalChunkMaxOvershoot: resolved.readerLocalChunkMaxOvershoot,
+			readerTerminalTopology: resolved.readerTerminalTopology,
 			protocol: resolved.protocol,
 			viteMode: resolved.viteMode,
 			viteConfig: resolved.viteConfig,
@@ -79,6 +80,7 @@ test("resolves every default and requested optional knob", () => {
 			targetSeeders: 9,
 			readerLocalChunkTarget: null,
 			readerLocalChunkMaxOvershoot: null,
+			readerTerminalTopology: null,
 			protocol: "http",
 			viteMode: null,
 			viteConfig: null,
@@ -135,6 +137,7 @@ test("removes all ambient PW variables and installs the exact invocation", () =>
 	assert.equal(environment.PW_POST_UPLOAD_MONITOR_MS, "5000");
 	assert.equal(environment.PW_READER_LOCAL_CHUNK_TARGET, "");
 	assert.equal(environment.PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT, "");
+	assert.equal(environment.PW_READER_TERMINAL_TOPOLOGY, "");
 	assert.equal(environment.PW_FUTURE_BYPASS, undefined);
 	assert.equal(environment.PW_PORT, undefined);
 	assert.equal(environment.PW_BENCH, "1");
@@ -144,33 +147,43 @@ test("removes all ambient PW variables and installs the exact invocation", () =>
 	assert.deepEqual(JSON.parse(environment.PW_BENCHMARK_INVOCATION), resolved);
 });
 
-test("binds optional observer-prefix locality control to a fixed1 writer", () => {
-	const resolved = invocation({
-		mode: "fixed1",
-		readerLocalChunkTarget: 0,
-		readerLocalChunkMaxOvershoot: 0,
-	});
-	assert.equal(resolved.readerLocalChunkTarget, 0);
-	assert.equal(resolved.readerLocalChunkMaxOvershoot, 0);
-	assert.equal(resolved.minReadySeeders, 1);
-	const environment = createPlaywrightBenchmarkEnvironment({
-		baseEnvironment: {
-			PW_READER_LOCAL_CHUNK_TARGET: "attacker",
-			PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT: "attacker",
-		},
-		invocation: resolved,
-		resultFile: "/tmp/result.json",
-		runNonce: "123e4567-e89b-42d3-a456-426614174000",
-		provenance: { bound: true },
-	});
-	assert.equal(environment.PW_READER_LOCAL_CHUNK_TARGET, "0");
-	assert.equal(environment.PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT, "0");
+test("binds both terminal topology expectations to one observer-prefix cohort", () => {
+	for (const readerTerminalTopology of ["observer", "replicator"]) {
+		const resolved = invocation({
+			mode: "fixed1",
+			readerLocalChunkTarget: 0,
+			readerLocalChunkMaxOvershoot: 0,
+			readerTerminalTopology,
+		});
+		assert.equal(resolved.readerLocalChunkTarget, 0);
+		assert.equal(resolved.readerLocalChunkMaxOvershoot, 0);
+		assert.equal(resolved.readerTerminalTopology, readerTerminalTopology);
+		assert.equal(resolved.minReadySeeders, 1);
+		const environment = createPlaywrightBenchmarkEnvironment({
+			baseEnvironment: {
+				PW_READER_LOCAL_CHUNK_TARGET: "attacker",
+				PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT: "attacker",
+				PW_READER_TERMINAL_TOPOLOGY: "attacker",
+			},
+			invocation: resolved,
+			resultFile: "/tmp/result.json",
+			runNonce: "123e4567-e89b-42d3-a456-426614174000",
+			provenance: { bound: true },
+		});
+		assert.equal(environment.PW_READER_LOCAL_CHUNK_TARGET, "0");
+		assert.equal(environment.PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT, "0");
+		assert.equal(
+			environment.PW_READER_TERMINAL_TOPOLOGY,
+			readerTerminalTopology,
+		);
+	}
 	for (const [overrides, pattern] of [
 		[
 			{
 				mode: "adaptive",
 				readerLocalChunkTarget: 4,
 				readerLocalChunkMaxOvershoot: 2,
+				readerTerminalTopology: "observer",
 			},
 			/requires fixed1 mode/,
 		],
@@ -179,6 +192,7 @@ test("binds optional observer-prefix locality control to a fixed1 writer", () =>
 				mode: "observer",
 				readerLocalChunkTarget: 4,
 				readerLocalChunkMaxOvershoot: 2,
+				readerTerminalTopology: "observer",
 			},
 			/requires fixed1 mode/,
 		],
@@ -187,6 +201,7 @@ test("binds optional observer-prefix locality control to a fixed1 writer", () =>
 				mode: "fixed1",
 				readerLocalChunkTarget: 4,
 				readerLocalChunkMaxOvershoot: 2,
+				readerTerminalTopology: "observer",
 				minReadySeeders: 2,
 			},
 			/requires minReadySeeders = 1/,
@@ -198,15 +213,24 @@ test("binds optional observer-prefix locality control to a fixed1 writer", () =>
 				fileMb: 1,
 				readerLocalChunkTarget: 1,
 				readerLocalChunkMaxOvershoot: 1,
+				readerTerminalTopology: "observer",
 			},
 			/only supported by upload benchmarks/,
 		],
 		[
-			{ mode: "fixed1", readerLocalChunkTarget: 4 },
+			{
+				mode: "fixed1",
+				readerLocalChunkTarget: 4,
+				readerTerminalTopology: "observer",
+			},
 			/must be provided together/,
 		],
 		[
-			{ mode: "fixed1", readerLocalChunkMaxOvershoot: 2 },
+			{
+				mode: "fixed1",
+				readerLocalChunkMaxOvershoot: 2,
+				readerTerminalTopology: "observer",
+			},
 			/must be provided together/,
 		],
 		[
@@ -214,8 +238,26 @@ test("binds optional observer-prefix locality control to a fixed1 writer", () =>
 				mode: "fixed1",
 				readerLocalChunkTarget: 4,
 				readerLocalChunkMaxOvershoot: 9,
+				readerTerminalTopology: "observer",
 			},
 			/must not exceed 8/,
+		],
+		[
+			{
+				mode: "fixed1",
+				readerLocalChunkTarget: 4,
+				readerLocalChunkMaxOvershoot: 2,
+			},
+			/readerTerminalTopology must be provided/,
+		],
+		[
+			{
+				mode: "fixed1",
+				readerLocalChunkTarget: 4,
+				readerLocalChunkMaxOvershoot: 2,
+				readerTerminalTopology: "adaptive",
+			},
+			/Unsupported readerTerminalTopology/,
 		],
 	]) {
 		assert.throws(() => invocation(overrides), pattern);
@@ -406,6 +448,8 @@ test("standalone runner rejects invalid integration modes before mutating output
 					"1",
 					"--reader-local-chunk-max-overshoot",
 					"1",
+					"--reader-terminal-topology",
+					"observer",
 					"--mode",
 					"adaptive",
 				],
@@ -417,12 +461,38 @@ test("standalone runner rejects invalid integration modes before mutating output
 					"1",
 					"--reader-local-chunk-max-overshoot",
 					"1",
+					"--reader-terminal-topology",
+					"observer",
 					"--mode",
 					"fixed1",
 					"--min-ready-seeders",
 					"2",
 				],
 				/requires --min-ready-seeders 1/,
+			],
+			[
+				[
+					"--reader-local-chunk-target",
+					"1",
+					"--reader-local-chunk-max-overshoot",
+					"0",
+					"--mode",
+					"fixed1",
+				],
+				/--reader-terminal-topology must be provided/,
+			],
+			[
+				[
+					"--reader-local-chunk-target",
+					"1",
+					"--reader-local-chunk-max-overshoot",
+					"0",
+					"--reader-terminal-topology",
+					"adaptive",
+					"--mode",
+					"fixed1",
+				],
+				/Unsupported --reader-terminal-topology/,
 			],
 		]) {
 			const child = spawnSync(

--- a/scripts/file-share/benchmark-orchestration.mjs
+++ b/scripts/file-share/benchmark-orchestration.mjs
@@ -2,7 +2,7 @@ import fsp from "node:fs/promises";
 
 export const BENCHMARK_RESULT_SCHEMA = Object.freeze({
 	id: "peerbit-file-share-benchmark",
-	version: 7,
+	version: 8,
 });
 
 export const SEEDER_DROP_POLICY = Object.freeze({
@@ -19,12 +19,12 @@ export const SEEDER_DROP_POLICY = Object.freeze({
 
 export const BENCHMARK_SUMMARY_SCHEMA = Object.freeze({
 	id: "peerbit-file-share-benchmark-summary",
-	version: 4,
+	version: 5,
 });
 
 export const MATRIX_SUMMARY_SCHEMA = Object.freeze({
 	id: "peerbit-file-share-matrix-summary",
-	version: 4,
+	version: 5,
 });
 
 export const KNOWN_PEERBIT_FAILURE_SIGNATURES = Object.freeze([

--- a/scripts/file-share/benchmark-validity.mjs
+++ b/scripts/file-share/benchmark-validity.mjs
@@ -15,6 +15,7 @@ import {
 	DOWNLOAD_MEMORY_MAX_BROWSER_PROCESSES,
 	DOWNLOAD_MEMORY_MAX_BROWSER_ROLES,
 	DOWNLOAD_MEMORY_MAX_BROWSER_ROLE_NAME_LENGTH,
+	DOWNLOAD_MEMORY_MAX_CLEANUP_WARNINGS,
 	DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH,
 	DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS,
 	DOWNLOAD_MEMORY_NODE_SCOPE,
@@ -791,6 +792,23 @@ const validateMemorySamplingErrors = (series, label) => {
 	) {
 		throw new Error(`Benchmark ${label} contains memory sampling errors`);
 	}
+	if (
+		!Array.isArray(series.cleanupWarnings) ||
+		series.cleanupWarnings.length > DOWNLOAD_MEMORY_MAX_CLEANUP_WARNINGS ||
+		series.cleanupWarnings.some(
+			(message) =>
+				typeof message !== "string" ||
+				message.length === 0 ||
+				message.length > DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH ||
+				!/^cleanup-timeout: .+ exceeded [1-9]\d*ms(?:; .+ exceeded [1-9]\d*ms)*$/.test(
+					message,
+				),
+		) ||
+		!Number.isSafeInteger(series.cleanupWarningOverflowCount) ||
+		series.cleanupWarningOverflowCount < 0
+	) {
+		throw new Error(`Benchmark ${label} contains invalid cleanup warnings`);
+	}
 };
 
 const validateMemorySeriesWindow = (
@@ -911,6 +929,8 @@ const validateHeapMemorySeries = (
 			"samples",
 			"samplingErrors",
 			"samplingErrorOverflowCount",
+			"cleanupWarnings",
+			"cleanupWarningOverflowCount",
 		],
 		label,
 	);
@@ -1007,6 +1027,8 @@ const validateHostRssSeries = (seriesValue, maxSamples, readWindow) => {
 			"samples",
 			"samplingErrors",
 			"samplingErrorOverflowCount",
+			"cleanupWarnings",
+			"cleanupWarningOverflowCount",
 		],
 		label,
 	);
@@ -1131,6 +1153,7 @@ export const validateDownloadMemoryTelemetry = (
 			"windowDefinition",
 			"maxSamplesPerSeries",
 			"complete",
+			"cleanupComplete",
 			"startedAt",
 			"finishedAt",
 			"readerJsHeap",
@@ -1148,7 +1171,8 @@ export const validateDownloadMemoryTelemetry = (
 		telemetry.sampleIntervalMs !== DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS ||
 		telemetry.windowDefinition !== DOWNLOAD_MEMORY_WINDOW_DEFINITION ||
 		telemetry.maxSamplesPerSeries !== expectedMaxSamples ||
-		telemetry.complete !== true
+		telemetry.complete !== true ||
+		telemetry.cleanupComplete !== true
 	) {
 		throw new Error("Benchmark download memory telemetry contract is invalid");
 	}
@@ -1849,7 +1873,7 @@ const validateEnvelope = (
 	);
 	if (
 		invocationSchema.id !== "peerbit-file-share-benchmark-invocation" ||
-		invocationSchema.version !== 3
+		invocationSchema.version !== 4
 	) {
 		throw new Error("Benchmark result has an unsupported invocation schema");
 	}
@@ -1901,6 +1925,11 @@ const validateRequestedUploadKnobs = (result, invocation) => {
 	) {
 		throw new Error(
 			"Benchmark result readerLocalChunkMaxOvershoot does not match the requested invocation",
+		);
+	}
+	if (result.readerTerminalTopology !== invocation.readerTerminalTopology) {
+		throw new Error(
+			"Benchmark result readerTerminalTopology does not match the requested invocation",
 		);
 	}
 };
@@ -2035,9 +2064,11 @@ const validateTopology = (
 const validateReaderLocalityControl = (result, invocation) => {
 	const target = invocation.readerLocalChunkTarget;
 	const maxOvershoot = invocation.readerLocalChunkMaxOvershoot;
+	const expectedTerminalTopology = invocation.readerTerminalTopology;
 	if (target == null) {
 		if (
 			maxOvershoot !== null ||
+			expectedTerminalTopology !== null ||
 			result.readerLocalityControl !== null ||
 			result.readerLocalChunkBlockCount !== null ||
 			result.readerLocalChunkIndexRowCount !== null ||
@@ -2052,6 +2083,7 @@ const validateReaderLocalityControl = (result, invocation) => {
 	if (
 		!Number.isSafeInteger(maxOvershoot) ||
 		maxOvershoot < 0 ||
+		!["observer", "replicator"].includes(expectedTerminalTopology) ||
 		invocation.mode !== "fixed1" ||
 		invocation.minReadySeeders !== 1
 	) {
@@ -2062,14 +2094,16 @@ const validateReaderLocalityControl = (result, invocation) => {
 		"readerLocalityControl",
 	);
 	if (
-		control.profile !== "observer-topology-persistent-read-preloaded-prefix" ||
-		control.requestedYieldedChunkCount !== target ||
-		control.maxReadAheadOvershootChunkCount !== maxOvershoot ||
+		control.profile !== "observer-topology-exact-manifest-prefix" ||
+		control.provisioningMethod !== "exact-manifest-head-import" ||
+		control.requestedLocalChunkBlockCount !== target ||
+		control.maxSpeculativeOvershootChunkCount !== maxOvershoot ||
 		control.countMetric !==
 			"exact local Documents index rows and manifest entry blocks" ||
 		control.writerUploadRole !== "fixed1" ||
 		control.readerUploadRole !== "observer" ||
 		control.readerTimedReadPolicy !== "persist-chunk-reads" ||
+		control.expectedTerminalTopology !== expectedTerminalTopology ||
 		control.stabilityPollIntervalMs !== Math.min(invocation.pollMs, 100) ||
 		control.requiredStableObservationCount !== 3 ||
 		control.status !== "complete" ||
@@ -2224,13 +2258,30 @@ const validateReaderLocalityControl = (result, invocation) => {
 		preload.finishedAt,
 		"readerLocalityControl.preloadEvidence.finishedAt",
 	);
-	const yieldedByteCount = requireNonNegativeSafeInteger(
-		preload.yieldedByteCount,
-		"readerLocalityControl.preloadEvidence.yieldedByteCount",
+	const rawFetchedByteCount = requireNonNegativeSafeInteger(
+		preload.rawFetchedByteCount,
+		"readerLocalityControl.preloadEvidence.rawFetchedByteCount",
+	);
+	const expectedImportedIndices = Array.from(
+		{ length: target },
+		(_, index) => index,
 	);
 	if (
 		preload.fileId !== manifestFileId ||
-		preload.yieldedChunkCount !== target ||
+		preload.provisioningMethod !== "exact-manifest-head-import" ||
+		preload.transferId !== null ||
+		preload.readDiagnostics !== null ||
+		preload.requestedManifestEntryCount !== target ||
+		preload.importedManifestEntryCount !== target ||
+		!isDeepStrictEqual(
+			preload.importedManifestEntryIndices,
+			expectedImportedIndices,
+		) ||
+		!isDeepStrictEqual(
+			preload.localManifestEntryIndicesAfter,
+			expectedImportedIndices,
+		) ||
+		preload.maxConcurrentImports !== 8 ||
 		preload.persistChunkReads !== true ||
 		!Array.isArray(preload.activeTransfersAfterClose) ||
 		preload.activeTransfersAfterClose.length !== 0 ||
@@ -2249,13 +2300,11 @@ const validateReaderLocalityControl = (result, invocation) => {
 	}
 	if (target === 0) {
 		if (
-			preload.transferId !== null ||
-			preload.readDiagnostics !== null ||
 			preload.aggregateTimeoutMs !== null ||
 			preload.aggregateDeadlineAt !== null ||
-			yieldedByteCount !== 0
+			rawFetchedByteCount !== 0
 		) {
-			throw new Error("Zero-prefix locality preload opened a read transfer");
+			throw new Error("Zero-prefix locality preload imported a manifest entry");
 		}
 	} else {
 		const aggregateTimeoutMs = requirePositiveSafeInteger(
@@ -2274,63 +2323,12 @@ const validateReaderLocalityControl = (result, invocation) => {
 			aggregateTimeoutMs !== invocation.downloadTimeoutMs ||
 			aggregateDeadlineAt !== preloadStartedAt + aggregateTimeoutMs ||
 			preloadFinishedAt - preloadStartedAt >
-				aggregateTimeoutMs + aggregateSchedulingToleranceMs
+				aggregateTimeoutMs + aggregateSchedulingToleranceMs ||
+			rawFetchedByteCount === 0
 		) {
 			throw new Error(
 				"Benchmark reader locality preload aggregate deadline evidence is invalid",
 			);
-		}
-		const preloadTransferId = requireString(
-			preload.transferId,
-			"readerLocalityControl.preloadEvidence.transferId",
-		);
-		const preloadDiagnostics = requireRecord(
-			preload.readDiagnostics,
-			"readerLocalityControl.preloadEvidence.readDiagnostics",
-		);
-		if (
-			preloadDiagnostics.transferId !== preloadTransferId ||
-			preloadDiagnostics.fileId !== manifestFileId ||
-			preloadDiagnostics.fileName !== result.fileName ||
-			preloadDiagnostics.persistChunkReads !== true ||
-			preloadDiagnostics.programPersistChunkReads !== true ||
-			preloadDiagnostics.initialLocalChunkIndexRowCount !== 0 ||
-			preloadDiagnostics.initialLocalChunkCount !== 0 ||
-			preloadDiagnostics.initialLocalChunkBlockCount !== 0 ||
-			preloadDiagnostics.finishedAt !== null ||
-			preloadDiagnostics.failureAt !== null ||
-			preloadDiagnostics.failureMessage !== null
-		) {
-			throw new Error(
-				"Benchmark partial preload diagnostics do not prove a clean persistent read",
-			);
-		}
-		const chunkBytes = requireRecord(
-			preloadDiagnostics.chunkByteLength,
-			"readerLocalityControl.preloadEvidence.readDiagnostics.chunkByteLength",
-		);
-		const expectedKeys = Array.from({ length: target }, (_, index) =>
-			String(index),
-		);
-		if (
-			Object.keys(chunkBytes).length !== target ||
-			expectedKeys.some((key) => !Object.hasOwn(chunkBytes, key))
-		) {
-			throw new Error(
-				"Benchmark partial preload did not yield the exact requested prefix",
-			);
-		}
-		const recomputedYieldedBytes = expectedKeys.reduce(
-			(total, key) =>
-				total +
-				requirePositiveSafeInteger(
-					chunkBytes[key],
-					`readerLocalityControl.preloadEvidence.readDiagnostics.chunkByteLength[${key}]`,
-				),
-			0,
-		);
-		if (recomputedYieldedBytes !== yieldedByteCount) {
-			throw new Error("Benchmark partial preload byte count is inconsistent");
 		}
 	}
 	if (
@@ -2394,7 +2392,7 @@ const validateReaderLocalityControl = (result, invocation) => {
 		actualLocalChunkBlockCount > target + maxOvershoot ||
 		actualLocalChunkBlockCount >= canonicalChunkCount ||
 		actualLocalChunkIndexRowCount > actualLocalChunkBlockCount ||
-		control.readAheadOvershootChunkCount !==
+		control.speculativeOvershootChunkCount !==
 			actualLocalChunkBlockCount - target ||
 		control.cohortKey !== expectedCohortKey ||
 		result.readerLocalChunkBlockCount !== actualLocalChunkBlockCount ||
@@ -2450,16 +2448,21 @@ const validateReaderLocalityControl = (result, invocation) => {
 		control.terminalIdleObservation,
 		"readerLocalityControl.terminalIdleObservation",
 	);
+	const expectedTerminalIndexRowCount =
+		expectedTerminalTopology === "replicator" ? canonicalChunkCount : 0;
 	if (
 		terminalIdle.fileId !== manifestFileId ||
 		terminalIdle.chunkCount !== canonicalChunkCount ||
 		terminalIdle.blockCount !== canonicalChunkCount ||
+		terminalIdle.indexRowCount !== expectedTerminalIndexRowCount ||
+		terminalIdle.indexedChunkIndices.length !==
+			expectedTerminalIndexRowCount ||
 		terminalIdle.persistChunkReads !== true ||
-		control.terminalTopologyRole !== "replicator" ||
-		control.readerJoinedReplicationDuringTimedRead !== true
+		control.terminalTopologyRole !== expectedTerminalTopology ||
+		control.terminalTopologyExpectationSatisfied !== true
 	) {
 		throw new Error(
-			"Benchmark terminal reader evidence does not prove an idle persistent replicator",
+			"Benchmark terminal reader evidence does not match the requested persistent-reader topology",
 		);
 	}
 	const terminalTopologyStartedAt = requirePositiveSafeInteger(
@@ -2482,10 +2485,18 @@ const validateReaderLocalityControl = (result, invocation) => {
 			"Benchmark reader locality requires exactly three stable terminal topology observations",
 		);
 	}
-	const expectedTerminalReplicatorHashes = [
-		writerTopologyBeforeUpload.peerHash,
-		readerTopologyBeforeUpload.peerHash,
-	].toSorted((left, right) => left.localeCompare(right));
+	const expectedTerminalReplicatorCount =
+		expectedTerminalTopology === "replicator" ? 2 : 1;
+	const expectedReaderSelfInReplicatorSet =
+		expectedTerminalTopology === "replicator";
+	const expectedTerminalReplicatorHashes = (
+		expectedTerminalTopology === "replicator"
+			? [
+					writerTopologyBeforeUpload.peerHash,
+					readerTopologyBeforeUpload.peerHash,
+				]
+			: [writerTopologyBeforeUpload.peerHash]
+	).toSorted((left, right) => left.localeCompare(right));
 	const terminalTopologyObservations = control.terminalTopologyObservations.map(
 		(value, index) => {
 			const label = `readerLocalityControl.terminalTopologyObservations[${index}]`;
@@ -2498,13 +2509,13 @@ const validateReaderLocalityControl = (result, invocation) => {
 				observation.writerTopology,
 				`${label}.writerTopology`,
 				true,
-				2,
+				expectedTerminalReplicatorCount,
 			);
 			const readerTopology = validateTopology(
 				observation.readerTopology,
 				`${label}.readerTopology`,
-				true,
-				2,
+				expectedReaderSelfInReplicatorSet,
+				expectedTerminalReplicatorCount,
 			);
 			if (
 				writerTopology.peerHash !== writerTopologyBeforeUpload.peerHash ||
@@ -2528,7 +2539,7 @@ const validateReaderLocalityControl = (result, invocation) => {
 						control.stabilityPollIntervalMs)
 			) {
 				throw new Error(
-					"Benchmark terminal topology observations do not prove one stable writer-reader replicator pair",
+					"Benchmark terminal topology observations do not prove the requested stable topology",
 				);
 			}
 			return { capturedAt, writerTopology, readerTopology };
@@ -2541,8 +2552,10 @@ const validateReaderLocalityControl = (result, invocation) => {
 	if (
 		writerDiagnostics.peerHash !== writerTopologyBeforeUpload.peerHash ||
 		readerDiagnostics.peerHash !== readerTopologyBeforeUpload.peerHash ||
-		writerDiagnostics.replicatorCount !== 2 ||
-		readerDiagnostics.replicatorCount !== 2
+		writerDiagnostics.replicatorCount !== expectedTerminalReplicatorCount ||
+		readerDiagnostics.replicatorCount !== expectedTerminalReplicatorCount ||
+		writerDiagnostics.replicationSetSize !== 1 ||
+		readerDiagnostics.replicationSetSize !== 1
 	) {
 		throw new Error(
 			"Benchmark final peer diagnostics contradict the terminal topology evidence",

--- a/scripts/file-share/benchmark-validity.test.mjs
+++ b/scripts/file-share/benchmark-validity.test.mjs
@@ -141,6 +141,8 @@ const createDownloadMemoryTelemetry = (
 		],
 		samplingErrors: [],
 		samplingErrorOverflowCount: 0,
+		cleanupWarnings: [],
+		cleanupWarningOverflowCount: 0,
 	});
 	const readerJsHeap = heap("reader-renderer", 3, 2, 100);
 	const writerJsHeap = heap("writer-renderer", 2, 3, 200);
@@ -192,6 +194,8 @@ const createDownloadMemoryTelemetry = (
 		samples: hostSamples,
 		samplingErrors: [],
 		samplingErrorOverflowCount: 0,
+		cleanupWarnings: [],
+		cleanupWarningOverflowCount: 0,
 	};
 	return {
 		profile: DOWNLOAD_MEMORY_PROFILE,
@@ -199,6 +203,7 @@ const createDownloadMemoryTelemetry = (
 		windowDefinition: DOWNLOAD_MEMORY_WINDOW_DEFINITION,
 		maxSamplesPerSeries,
 		complete: true,
+		cleanupComplete: true,
 		startedAt: readerJsHeap.startedAt,
 		finishedAt: hostRss.finishedAt,
 		readerJsHeap,
@@ -329,6 +334,7 @@ const validResult = () => ({
 	mode: "adaptive",
 	readerLocalChunkTarget: null,
 	readerLocalChunkMaxOvershoot: null,
+	readerTerminalTopology: null,
 	readerLocalChunkBlockCount: null,
 	readerLocalChunkIndexRowCount: null,
 	readerLocalityCohortKey: null,
@@ -569,6 +575,7 @@ const createReaderLocalityFixture = ({
 	maxOvershoot = 1,
 	actualBlockCount = 1,
 	actualIndexRowCount = 0,
+	readerTerminalTopology = "observer",
 } = {}) => {
 	const invocation = createBenchmarkInvocation({
 		scenario: "upload",
@@ -585,6 +592,7 @@ const createReaderLocalityFixture = ({
 		readyTimeoutMs: 180_000,
 		readerLocalChunkTarget: target,
 		readerLocalChunkMaxOvershoot: maxOvershoot,
+		readerTerminalTopology,
 	});
 	const result = validResult();
 	const fileName = `file-share-benchmark-fixed1-${RUN_NONCE}.bin`;
@@ -625,17 +633,27 @@ const createReaderLocalityFixture = ({
 		replicatorHashes,
 		selfInReplicatorSet,
 	});
+	const terminalReplicatorHashes =
+		readerTerminalTopology === "replicator"
+			? ["reader-peer", "writer-peer"]
+			: ["writer-peer"];
+	const terminalReplicatorCount = terminalReplicatorHashes.length;
 	const terminalTopology = (capturedAt, peerHash) =>
-		topology(capturedAt, true, {
-			peerHash,
-			replicatorCount: 2,
-			replicatorHashes: ["reader-peer", "writer-peer"],
-		});
+		topology(
+			capturedAt,
+			peerHash === "writer-peer" || readerTerminalTopology === "replicator",
+			{
+				peerHash,
+				replicatorCount: terminalReplicatorCount,
+				replicatorHashes: terminalReplicatorHashes,
+			},
+		);
 	result.invocation = structuredClone(invocation);
 	result.mode = "fixed1";
 	result.fileName = fileName;
 	result.readerLocalChunkTarget = target;
 	result.readerLocalChunkMaxOvershoot = maxOvershoot;
+	result.readerTerminalTopology = readerTerminalTopology;
 	result.readerLocalChunkBlockCount = actualBlockCount;
 	result.readerLocalChunkIndexRowCount = actualIndexRowCount;
 	const cohortKey = `observer-persistent-prefix-b${actualBlockCount}-i${actualIndexRowCount}`;
@@ -645,7 +663,8 @@ const createReaderLocalityFixture = ({
 	result.readerDiagnostics.programAddress = "reader-program-address";
 	result.readerDiagnostics.persistChunkReads = true;
 	result.readerDiagnostics.peerHash = "reader-peer";
-	result.readerDiagnostics.replicatorCount = 2;
+	result.readerDiagnostics.replicatorCount = terminalReplicatorCount;
+	result.readerDiagnostics.replicationSetSize = 1;
 	result.readerDiagnostics.timings = {
 		initialRole: "observer",
 		updateRoleCount: 0,
@@ -669,7 +688,8 @@ const createReaderLocalityFixture = ({
 	result.writerManifestEvidence.fileName = fileName;
 	result.readerManifestEvidence.fileName = fileName;
 	result.writerDiagnostics.peerHash = "writer-peer";
-	result.writerDiagnostics.replicatorCount = 2;
+	result.writerDiagnostics.replicatorCount = terminalReplicatorCount;
+	result.writerDiagnostics.replicationSetSize = 1;
 	result.writerDiagnostics.lastUploadDiagnostics.fileName = fileName;
 	result.timestamps.downloadStartedAt = 1_400;
 	result.timestamps.downloadFinishedAt = 1_430;
@@ -681,13 +701,15 @@ const createReaderLocalityFixture = ({
 		invocation,
 	);
 	result.readerLocalityControl = {
-		profile: "observer-topology-persistent-read-preloaded-prefix",
-		requestedYieldedChunkCount: target,
-		maxReadAheadOvershootChunkCount: maxOvershoot,
+		profile: "observer-topology-exact-manifest-prefix",
+		provisioningMethod: "exact-manifest-head-import",
+		requestedLocalChunkBlockCount: target,
+		maxSpeculativeOvershootChunkCount: maxOvershoot,
 		countMetric: "exact local Documents index rows and manifest entry blocks",
 		writerUploadRole: "fixed1",
 		readerUploadRole: "observer",
 		readerTimedReadPolicy: "persist-chunk-reads",
+		expectedTerminalTopology: readerTerminalTopology,
 		stabilityPollIntervalMs: 100,
 		requiredStableObservationCount: 3,
 		status: "complete",
@@ -711,33 +733,28 @@ const createReaderLocalityFixture = ({
 			startedAt: 1_172,
 			finishedAt: 1_175,
 			fileId: FILE_ID,
-			transferId: target === 0 ? null : "locality-preload-transfer",
+			provisioningMethod: "exact-manifest-head-import",
+			transferId: null,
 			aggregateTimeoutMs: target === 0 ? null : invocation.downloadTimeoutMs,
 			aggregateDeadlineAt:
 				target === 0 ? null : 1_172 + invocation.downloadTimeoutMs,
 			aggregateTimedOut: false,
-			yieldedChunkCount: target,
-			yieldedByteCount: target === 0 ? 0 : 3 * 1024 * 1024,
+			requestedManifestEntryCount: target,
+			importedManifestEntryCount: target,
+			importedManifestEntryIndices: Array.from(
+				{ length: target },
+				(_, index) => index,
+			),
+			localManifestEntryIndicesAfter: Array.from(
+				{ length: target },
+				(_, index) => index,
+			),
+			rawFetchedByteCount: target === 0 ? 0 : 3 * 1024 * 1024,
+			maxConcurrentImports: 8,
 			persistChunkReads: true,
 			activeTransfersAfterClose: [],
 			downloadSchedulerAfterClose: { ...idleScheduler },
-			readDiagnostics:
-				target === 0
-					? null
-					: {
-							transferId: "locality-preload-transfer",
-							fileId: FILE_ID,
-							fileName,
-							persistChunkReads: true,
-							programPersistChunkReads: true,
-							initialLocalChunkIndexRowCount: 0,
-							initialLocalChunkCount: 0,
-							initialLocalChunkBlockCount: 0,
-							finishedAt: null,
-							failureAt: null,
-							failureMessage: null,
-							chunkByteLength: { 0: 3 * 1024 * 1024 },
-						},
+			readDiagnostics: null,
 		},
 		stabilityObservations: [1_176, 1_276, 1_376].map((capturedAt) =>
 			observation({
@@ -761,12 +778,13 @@ const createReaderLocalityFixture = ({
 			capturedAt: 1_433,
 			persistChunkReads: true,
 			blocks: [0, 1],
+			indexed: readerTerminalTopology === "replicator" ? [0, 1] : [],
 		}),
 		terminalTopologyStartedAt: 1_433,
 		terminalTopologyDeadlineAt: 181_433,
 		terminalTopologyFinishedAt: 1_635,
-		terminalTopologyRole: "replicator",
-		readerJoinedReplicationDuringTimedRead: true,
+		terminalTopologyRole: readerTerminalTopology,
+		terminalTopologyExpectationSatisfied: true,
 		terminalTopologyObservations: [1_434, 1_534, 1_634].map((capturedAt) => ({
 			capturedAt,
 			writerTopology: terminalTopology(capturedAt - 1, "writer-peer"),
@@ -774,7 +792,7 @@ const createReaderLocalityFixture = ({
 		})),
 		actualLocalChunkBlockCount: actualBlockCount,
 		actualLocalChunkIndexRowCount: actualIndexRowCount,
-		readAheadOvershootChunkCount: 0,
+		speculativeOvershootChunkCount: 0,
 		cohortKey,
 		failure: null,
 	};
@@ -820,6 +838,12 @@ test("accepts a complete deterministic transfer result", () => {
 
 test("requires a trustworthy aggregate-integrity timestamp before the final snapshot", () => {
 	for (const [mutate, pattern] of [
+		[
+			(result) => {
+				result.readerTerminalTopology = "replicator";
+			},
+			/readerTerminalTopology does not match the requested invocation/,
+		],
 		[
 			(result) => {
 				delete result.integrityVerifiedAt;
@@ -895,7 +919,7 @@ test("requires the terminal snapshot after controlled-locality topology", () => 
 	);
 });
 
-test("accepts one recovered seeder dip under the v7 policy", () => {
+test("accepts one recovered seeder dip under the v8 policy", () => {
 	const result = validResult();
 	result.snapshots[1].writerSeeders = 1;
 	result.droppedSeeders = true;
@@ -930,7 +954,7 @@ test("rejects a terminal below-baseline seeder snapshot", () => {
 	);
 });
 
-test("rejects missing, altered, and contradictory v7 seeder-drop evidence", () => {
+test("rejects missing, altered, and contradictory v8 seeder-drop evidence", () => {
 	for (const [mutate, pattern] of [
 		[
 			(result) => {
@@ -1344,6 +1368,14 @@ test("rejects milestones crossed before a partial-tail trigger", () => {
 });
 
 test("requires bounded, error-free memory telemetry covering the canonical read", () => {
+	const cleanupTimeoutWarning = validResult();
+	cleanupTimeoutWarning.downloadMemoryTelemetry.readerJsHeap.cleanupWarnings.push(
+		"cleanup-timeout: Page JS heap Performance.disable exceeded 4000ms",
+	);
+	assert.equal(
+		validateBenchmarkResult(cleanupTimeoutWarning, options).status,
+		"passed",
+	);
 	for (const [mutate, pattern] of [
 		[
 			(result) => {
@@ -1354,6 +1386,12 @@ test("requires bounded, error-free memory telemetry covering the canonical read"
 		[
 			(result) => {
 				result.downloadMemoryTelemetry.complete = false;
+			},
+			/telemetry contract is invalid/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.cleanupComplete = false;
 			},
 			/telemetry contract is invalid/,
 		],
@@ -1379,6 +1417,14 @@ test("requires bounded, error-free memory telemetry covering the canonical read"
 				];
 			},
 			/contains unbounded sampling errors/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.readerJsHeap.cleanupWarnings = [
+					"ordinary cleanup failure",
+				];
+			},
+			/contains invalid cleanup warnings/,
 		],
 		[
 			(result) => {
@@ -1502,6 +1548,12 @@ test("accepts exact observer-locality control and rejects contradictory evidence
 	for (const [mutate, pattern] of [
 		[
 			(result) => {
+				result.readerLocalityControl.expectedTerminalTopology = "replicator";
+			},
+			/locality control contract is invalid/,
+		],
+		[
+			(result) => {
 				result.readerLocalityControl.beforePreloadObservation.chunkCount = 3;
 				for (const observation of [
 					...result.readerLocalityControl.stabilityObservations,
@@ -1564,7 +1616,7 @@ test("accepts exact observer-locality control and rejects contradictory evidence
 		],
 		[
 			(result) => {
-				result.readerLocalityControl.readAheadOvershootChunkCount = 1;
+				result.readerLocalityControl.speculativeOvershootChunkCount = 1;
 			},
 			/locality cohort count or key is inconsistent/,
 		],
@@ -1579,7 +1631,7 @@ test("accepts exact observer-locality control and rejects contradictory evidence
 					observation.blockChunkIndices = [0, 1];
 				}
 				control.actualLocalChunkBlockCount = 2;
-				control.readAheadOvershootChunkCount = 1;
+				control.speculativeOvershootChunkCount = 1;
 				control.cohortKey = "observer-persistent-prefix-b2-i0";
 				result.readerLocalChunkBlockCount = 2;
 				result.readerLocalityCohortKey = control.cohortKey;
@@ -1595,9 +1647,9 @@ test("accepts exact observer-locality control and rejects contradictory evidence
 		],
 		[
 			(result) => {
-				result.readerLocalityControl.readerJoinedReplicationDuringTimedRead = false;
+				result.readerLocalityControl.terminalTopologyExpectationSatisfied = false;
 			},
-			/terminal reader evidence does not prove an idle persistent replicator/,
+			/terminal reader evidence does not match the requested persistent-reader topology/,
 		],
 		[
 			(result) => {
@@ -1614,7 +1666,16 @@ test("accepts exact observer-locality control and rejects contradictory evidence
 				terminalIdle.blockCount = 1;
 				terminalIdle.blockChunkIndices = [0];
 			},
-			/terminal reader evidence does not prove an idle persistent replicator/,
+			/terminal reader evidence does not match the requested persistent-reader topology/,
+		],
+		[
+			(result) => {
+				const terminalIdle =
+					result.readerLocalityControl.terminalIdleObservation;
+				terminalIdle.indexRowCount = 1;
+				terminalIdle.indexedChunkIndices = [0];
+			},
+			/terminal reader evidence does not match the requested persistent-reader topology/,
 		],
 		[
 			(result) => {
@@ -1625,9 +1686,9 @@ test("accepts exact observer-locality control and rejects contradictory evidence
 		[
 			(result) => {
 				result.readerLocalityControl.terminalTopologyObservations[1].readerTopology.replicatorHashes =
-					["reader-peer", "third-peer"];
+					["reader-peer"];
 			},
-			/terminal topology observations do not prove one stable writer-reader replicator pair/,
+			/terminal topology observations do not prove the requested stable topology/,
 		],
 		[
 			(result) => {
@@ -1637,11 +1698,17 @@ test("accepts exact observer-locality control and rejects contradictory evidence
 				observation.writerTopology.capturedAt = 1_499;
 				observation.readerTopology.capturedAt = 1_499;
 			},
-			/terminal topology observations do not prove one stable writer-reader replicator pair/,
+			/terminal topology observations do not prove the requested stable topology/,
 		],
 		[
 			(result) => {
 				result.writerDiagnostics.peerHash = "other-writer";
+			},
+			/final peer diagnostics contradict the terminal topology evidence/,
+		],
+		[
+			(result) => {
+				result.readerDiagnostics.replicationSetSize = 2;
 			},
 			/final peer diagnostics contradict the terminal topology evidence/,
 		],
@@ -1723,11 +1790,29 @@ test("accepts exact observer-locality control and rejects contradictory evidence
 		invocation.readerLocalChunkTarget = 2;
 	}
 	fullFileTarget.result.readerLocalChunkTarget = 2;
-	fullFileTarget.result.readerLocalityControl.requestedYieldedChunkCount = 2;
+	fullFileTarget.result.readerLocalityControl.requestedLocalChunkBlockCount = 2;
 	assert.throws(
 		() =>
 			validateBenchmarkResult(fullFileTarget.result, fullFileTarget.options),
 		/target must be a partial prefix of the canonical completed read/,
+	);
+});
+
+test("accepts the historical reader-replicator terminal topology as an explicit cohort", () => {
+	const fixture = createReaderLocalityFixture({
+		readerTerminalTopology: "replicator",
+	});
+	assert.equal(
+		validateBenchmarkResult(fixture.result, fixture.options).status,
+		"passed",
+	);
+	assert.equal(
+		fixture.result.readerLocalityControl.preDownloadObservation.indexRowCount,
+		0,
+	);
+	assert.equal(
+		fixture.result.readerLocalityControl.terminalIdleObservation.indexRowCount,
+		2,
 	);
 });
 
@@ -1863,14 +1948,14 @@ test("bounds Node-file server timing against its browser sink timing", () => {
 	);
 });
 
-test("rejects a status-only passed payload at the v7 evidence envelope", () => {
+test("rejects a status-only passed payload at the v8 evidence envelope", () => {
 	assert.throws(
 		() => validateBenchmarkResultEnvelope({ status: "passed" }, options),
 		/missing schema/,
 	);
 });
 
-test("requires explicit error evidence on failed v7 envelopes", () => {
+test("requires explicit error evidence on failed v8 envelopes", () => {
 	const completeFailure = validResult();
 	completeFailure.status = "failed";
 	completeFailure.failure = { message: "synthetic browser failure" };

--- a/scripts/file-share/download-memory-telemetry.test.mjs
+++ b/scripts/file-share/download-memory-telemetry.test.mjs
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
-import { setTimeout as delay } from "node:timers/promises";
 import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 import {
 	DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH,
-	DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS,
 	DOWNLOAD_MEMORY_MAX_SAMPLES_PER_SERIES,
+	DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS,
 	calculateDownloadMemoryMaxSamples,
 	startBoundedSerialSampler,
 	startDownloadMemoryTelemetry,
@@ -85,8 +85,7 @@ test("bounds and truncates repeated sampling failures", async () => {
 	assert.equal(result.samplingErrorOverflowCount > 0, true);
 	assert.equal(
 		result.samplingErrors.every(
-			(message) =>
-				message.length === DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH,
+			(message) => message.length === DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH,
 		),
 		true,
 	);
@@ -144,11 +143,46 @@ test("bounds never-settling initial, active, and cleanup operations", async () =
 	});
 	const cleanupResult = await cleanup.stop();
 	assert.equal(cleanupResult.samples.length, 2);
-	assert.equal(cleanupResult.samplingErrors.length, 1);
+	assert.deepEqual(cleanupResult.samplingErrors, []);
+	assert.equal(cleanupResult.cleanupWarnings.length, 1);
 	assert.match(
-		cleanupResult.samplingErrors[0],
+		cleanupResult.cleanupWarnings[0],
 		/Memory sampler cleanup exceeded 5ms/,
 	);
+});
+
+test("finalizes the terminal sample before post-sampling cleanup", async () => {
+	let cleanupCount = 0;
+	const sampler = await startBoundedSerialSampler({
+		intervalMs: 100,
+		maxSamples: 3,
+		readSample: async () => ({ value: 1 }),
+		cleanup: async () => {
+			cleanupCount += 1;
+		},
+	});
+	const sampled = await sampler.stopSampling();
+	assert.equal(sampled.samples.length, 2);
+	assert.equal(sampled.finishedAt >= sampled.startedAt, true);
+	assert.equal(cleanupCount, 0);
+
+	const cleaned = await sampler.cleanup();
+	assert.equal(cleaned.finishedAt, sampled.finishedAt);
+	assert.equal(cleanupCount, 1);
+});
+
+test("keeps non-timeout cleanup failures fatal", async () => {
+	const sampler = await startBoundedSerialSampler({
+		intervalMs: 100,
+		maxSamples: 3,
+		readSample: async () => ({ value: 1 }),
+		cleanup: async () => {
+			throw new Error("detach rejected");
+		},
+	});
+	const result = await sampler.cleanup();
+	assert.deepEqual(result.cleanupWarnings, []);
+	assert.deepEqual(result.samplingErrors, ["detach rejected"]);
 });
 
 test("absorbs late operation settlement and cleans late-created values", async () => {
@@ -219,6 +253,7 @@ test("collects forced endpoint heap and attributed RSS samples", async () => {
 	});
 	const result = await telemetry.stop();
 	assert.equal(result.complete, true);
+	assert.equal(result.cleanupComplete, true);
 	assert.equal(result.readerJsHeap.sampleCount, 2);
 	assert.equal(result.writerJsHeap.sampleCount, 2);
 	assert.equal(result.hostRss.sampleCount, 2);
@@ -230,6 +265,62 @@ test("collects forced endpoint heap and attributed RSS samples", async () => {
 	);
 	assert.equal(detachedPageSessions, 2);
 	assert.equal(detachedBrowserSessions, 1);
+});
+
+test("records post-sampling CDP timeouts as cleanup warnings", async () => {
+	let detachStarted = 0;
+	const page = (hangOnCleanup) => ({
+		context: () => ({
+			newCDPSession: async () => ({
+				send: async (method) => {
+					if (method === "Performance.getMetrics") {
+						return { metrics: [{ name: "JSHeapUsedSize", value: 100 }] };
+					}
+					if (method === "Performance.disable" && hangOnCleanup) {
+						return await new Promise(() => {});
+					}
+					return {};
+				},
+				detach: async () => {
+					detachStarted += 1;
+					if (hangOnCleanup) {
+						return await new Promise(() => {});
+					}
+				},
+			}),
+		}),
+	});
+	const browser = {
+		newBrowserCDPSession: async () => ({
+			send: async () => ({
+				processInfo: [{ id: process.pid, type: "browser" }],
+			}),
+			detach: async () => {},
+		}),
+	};
+	const telemetry = await startDownloadMemoryTelemetry({
+		browser,
+		reader: page(true),
+		writer: page(false),
+		downloadTimeoutMs: 60_000,
+		schedulingToleranceMs: 5_000,
+		operationTimeoutMs: 3,
+		cleanupTimeoutMs: 8,
+	});
+	const sampled = await telemetry.stopSampling();
+	assert.equal(sampled.complete, true);
+	assert.equal(sampled.cleanupComplete, false);
+	assert.equal(detachStarted, 0);
+
+	const result = await telemetry.cleanup();
+	assert.equal(result.cleanupComplete, true);
+	assert.deepEqual(result.readerJsHeap.samplingErrors, []);
+	assert.equal(result.readerJsHeap.cleanupWarnings.length, 1);
+	assert.match(
+		result.readerJsHeap.cleanupWarnings[0],
+		/Performance\.disable exceeded 3ms; Page JS heap CDP detach exceeded 3ms/,
+	);
+	assert.equal(detachStarted, 2);
 });
 
 test("bounds setup and detaches a CDP session created after its deadline", async () => {
@@ -275,9 +366,11 @@ test("bounds setup and detaches a CDP session created after its deadline", async
 		cleanupTimeoutMs: 8,
 	});
 	assert.equal(
-		telemetry.snapshot().readerJsHeap.samplingErrors.some((message) =>
-			message.includes("CDP session creation exceeded 3ms"),
-		),
+		telemetry
+			.snapshot()
+			.readerJsHeap.samplingErrors.some((message) =>
+				message.includes("CDP session creation exceeded 3ms"),
+			),
 		true,
 	);
 	await telemetry.stop();

--- a/scripts/file-share/run-file-share-benchmark-matrix.mjs
+++ b/scripts/file-share/run-file-share-benchmark-matrix.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 import { isDeepStrictEqual } from "node:util";
 import {
 	MAX_READER_LOCAL_CHUNK_OVERSHOOT,
+	READER_TERMINAL_TOPOLOGIES,
 	assertBenchmarkFileSize,
 	assertCoreBenchmarkUsesLocalApp,
 	createBenchmarkInvocation,
@@ -453,6 +454,7 @@ const runVariantBenchmark = async ({
 	targetSeeders,
 	readerLocalChunkTarget,
 	readerLocalChunkMaxOvershoot,
+	readerTerminalTopology,
 	protocol,
 	fixtureSeed,
 	enableVisibilityProbe,
@@ -532,6 +534,9 @@ const runVariantBenchmark = async ({
 					"--reader-local-chunk-max-overshoot",
 					String(readerLocalChunkMaxOvershoot),
 				]
+			: []),
+		...(readerTerminalTopology != null
+			? ["--reader-terminal-topology", readerTerminalTopology]
 			: []),
 		...(protocol ? ["--protocol", protocol] : []),
 		...(fixtureSeed ? ["--fixture-seed", fixtureSeed] : []),
@@ -669,6 +674,7 @@ const main = async () => {
 	const targetSeeders = args["target-seeders"];
 	const readerLocalChunkTarget = args["reader-local-chunk-target"];
 	const readerLocalChunkMaxOvershoot = args["reader-local-chunk-max-overshoot"];
+	const readerTerminalTopology = args["reader-terminal-topology"];
 	const { protocol } = previewOptions;
 	const fixtureSeed = args["fixture-seed"];
 	const enableVisibilityProbe = Boolean(args["enable-visibility-probe"]);
@@ -718,6 +724,21 @@ const main = async () => {
 	) {
 		throw new Error(
 			"--reader-local-chunk-target and --reader-local-chunk-max-overshoot must be provided together",
+		);
+	}
+	if (
+		(readerLocalChunkTarget == null) !== (readerTerminalTopology == null)
+	) {
+		throw new Error(
+			"--reader-terminal-topology must be provided exactly when --reader-local-chunk-target is provided",
+		);
+	}
+	if (
+		readerTerminalTopology != null &&
+		!READER_TERMINAL_TOPOLOGIES.includes(readerTerminalTopology)
+	) {
+		throw new Error(
+			`Unsupported --reader-terminal-topology ${JSON.stringify(readerTerminalTopology)}. Expected one of ${READER_TERMINAL_TOPOLOGIES.join(", ")}`,
 		);
 	}
 	if (
@@ -871,6 +892,7 @@ const main = async () => {
 				targetSeeders,
 				readerLocalChunkTarget,
 				readerLocalChunkMaxOvershoot,
+				readerTerminalTopology,
 				protocol,
 				fixtureSeed,
 				enableVisibilityProbe,
@@ -920,6 +942,7 @@ const main = async () => {
 				readerLocalChunkMaxOvershoot: optionalNumber(
 					readerLocalChunkMaxOvershoot,
 				),
+				readerTerminalTopology,
 				baseUrl: null,
 				protocol,
 				viteMode: null,
@@ -1100,6 +1123,10 @@ const main = async () => {
 				result.readerLocalChunkMaxOvershoot ??
 				result.invocation?.readerLocalChunkMaxOvershoot ??
 				null,
+			readerTerminalTopology:
+				result.readerTerminalTopology ??
+				result.invocation?.readerTerminalTopology ??
+				null,
 			readerLocalChunkBlockCount: result.readerLocalChunkBlockCount ?? null,
 			readerLocalChunkIndexRowCount:
 				result.readerLocalChunkIndexRowCount ?? null,
@@ -1178,6 +1205,7 @@ const main = async () => {
 		readerLocalChunkTarget: optionalNumber(readerLocalChunkTarget) ?? null,
 		readerLocalChunkMaxOvershoot:
 			optionalNumber(readerLocalChunkMaxOvershoot) ?? null,
+		readerTerminalTopology: readerTerminalTopology ?? null,
 		readerLocalityCohorts: [
 			...new Set(
 				allResults

--- a/scripts/file-share/run-file-share-benchmark.mjs
+++ b/scripts/file-share/run-file-share-benchmark.mjs
@@ -7,6 +7,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
 	MAX_READER_LOCAL_CHUNK_OVERSHOOT,
+	READER_TERMINAL_TOPOLOGIES,
 	assertBenchmarkFileSize,
 	assertCoreBenchmarkUsesLocalApp,
 	assertInvocationUnchanged,
@@ -130,9 +131,12 @@ const DROP_LOCALITY_INDEXED_SEARCH_MARKER =
 	"/* peerbit-benchmark-locality-indexed-search */";
 const DROP_LOCALITY_PRELOAD_DEADLINE_MARKER =
 	"/* peerbit-benchmark-locality-preload-aggregate-deadline */";
+const DROP_LOCALITY_EXACT_MANIFEST_MARKER =
+	"/* peerbit-benchmark-locality-exact-manifest-import */";
 const localityPreloadHookImplementation = `            preloadLocalChunkPrefix: async (fileName, target, timeoutMs) => {
                 ${DROP_LOCALITY_HOOK_MARKER}
                 ${DROP_LOCALITY_PRELOAD_DEADLINE_MARKER}
+				${DROP_LOCALITY_EXACT_MANIFEST_MARKER}
                 if (!program || program.closed) {
                     throw new Error("Program is not ready");
                 }
@@ -160,14 +164,23 @@ const localityPreloadHookImplementation = `            preloadLocalChunkPrefix: 
                         "Locality preload timeout must be a positive safe integer"
                     );
                 }
+				const manifestEntryHeads = (file as any).chunkEntryHeads;
+				if (
+					!Array.isArray(manifestEntryHeads) ||
+					manifestEntryHeads.length !== file.chunkCount ||
+					manifestEntryHeads.some(
+						(head) => typeof head !== "string" || head.length === 0
+					) ||
+					new Set(manifestEntryHeads).size !== manifestEntryHeads.length
+				) {
+					throw new Error(
+						"Locality preload requires one unique manifest entry head per chunk"
+					);
+				}
                 program.persistChunkReads = true;
                 const startedAt = Date.now();
-                const transferId =
-                    target > 0
-                        ? "benchmark-locality-preload-" + startedAt + "-" + target
-                        : null;
-                const aggregateTimeoutMs = transferId ? timeoutMs : null;
-                const aggregateDeadlineAt = transferId
+                const aggregateTimeoutMs = target > 0 ? timeoutMs : null;
+                const aggregateDeadlineAt = target > 0
                     ? startedAt + timeoutMs
                     : null;
                 if (
@@ -177,15 +190,16 @@ const localityPreloadHookImplementation = `            preloadLocalChunkPrefix: 
                     throw new Error("Locality preload deadline is not a safe integer");
                 }
                 let aggregateTimedOut = false;
-                let yieldedChunkCount = 0;
-                let yieldedByteCount = 0;
-                if (transferId) {
+				let rawFetchedByteCount = 0;
+				const importedManifestEntryIndices: number[] = [];
+				const maxConcurrentImports = 8;
+				const blocks = program.files.log.log.blocks;
+				if (target > 0) {
                     const aggregateController = new AbortController();
                     const aggregateTimeoutError = new Error(
                         "Locality prefix preload exceeded its aggregate deadline"
                     );
                     let aggregateTimeoutHandle: number | undefined;
-                    let iterator: AsyncIterator<Uint8Array> | undefined;
                     aggregateTimeoutHandle = window.setTimeout(() => {
                         aggregateTimedOut = true;
                         if (!aggregateController.signal.aborted) {
@@ -193,15 +207,11 @@ const localityPreloadHookImplementation = `            preloadLocalChunkPrefix: 
                         }
                     }, Math.max(0, aggregateDeadlineAt! - Date.now()));
                     try {
-                        iterator = file
-                            .streamFile(program, {
-                                timeout: timeoutMs,
-                                transferId,
-                                signal: aggregateController.signal,
-                            })
-                            [Symbol.asyncIterator]();
-                        while (yieldedChunkCount < target) {
-                            const next = await iterator.next();
+						for (
+							let batchStart = 0;
+							batchStart < target;
+							batchStart += maxConcurrentImports
+						) {
                             if (
                                 Date.now() > aggregateDeadlineAt! &&
                                 !aggregateController.signal.aborted
@@ -215,21 +225,51 @@ const localityPreloadHookImplementation = `            preloadLocalChunkPrefix: 
                                     aggregateTimeoutError
                                 );
                             }
-                            if (next.done) {
-                                throw new Error(
-                                    "Locality preload stream ended before the requested prefix"
-                                );
-                            }
-                            yieldedChunkCount += 1;
-                            yieldedByteCount += next.value.byteLength;
+							const batchEnd = Math.min(
+								target,
+								batchStart + maxConcurrentImports
+							);
+							await Promise.all(
+								manifestEntryHeads
+									.slice(batchStart, batchEnd)
+									.map(async (head, offset) => {
+										const index = batchStart + offset;
+										const remainingMs = aggregateDeadlineAt! - Date.now();
+										if (remainingMs <= 0) {
+											aggregateTimedOut = true;
+											aggregateController.abort(aggregateTimeoutError);
+											throw aggregateTimeoutError;
+										}
+										const documentId = \`\${file.id}:\${index}\`;
+										program.retainChunkRead(documentId, file.id);
+										program.retainChunkEntryHead(
+											head,
+											file.id,
+											documentId
+										);
+										const rawEntry = await blocks.get(head, {
+											remote: {
+												timeout: remainingMs,
+												replicate: true,
+												signal: aggregateController.signal,
+											},
+										});
+										if (!rawEntry || !(await blocks.has(head))) {
+											throw new Error(
+												"Exact manifest entry import did not persist chunk " +
+													(index + 1) +
+													"/" +
+													file.chunkCount
+											);
+										}
+										rawFetchedByteCount += rawEntry.byteLength ?? 0;
+										importedManifestEntryIndices.push(index);
+									})
+							);
                         }
                     } finally {
-                        try {
-                            await iterator?.return?.();
-                        } finally {
-                            if (aggregateTimeoutHandle !== undefined) {
-                                window.clearTimeout(aggregateTimeoutHandle);
-                            }
+						if (aggregateTimeoutHandle !== undefined) {
+							window.clearTimeout(aggregateTimeoutHandle);
                         }
                     }
                     if (aggregateController.signal.aborted) {
@@ -239,24 +279,38 @@ const localityPreloadHookImplementation = `            preloadLocalChunkPrefix: 
                         );
                     }
                 }
+				importedManifestEntryIndices.sort((left, right) => left - right);
+				const localManifestHeadPresence =
+					typeof blocks.hasMany === "function"
+						? await blocks.hasMany(manifestEntryHeads)
+						: await Promise.all(
+							  manifestEntryHeads.map((head) => blocks.has(head))
+						  );
+				const localManifestEntryIndicesAfter = localManifestHeadPresence.flatMap(
+					(present, index) => (present ? [index] : [])
+				);
                 const finishedAt = Date.now();
                 return {
                     startedAt,
                     finishedAt,
                     fileId: file.id,
-                    transferId,
+					provisioningMethod: "exact-manifest-head-import",
+					transferId: null,
                     aggregateTimeoutMs,
                     aggregateDeadlineAt,
                     aggregateTimedOut,
-                    yieldedChunkCount,
-                    yieldedByteCount,
+					requestedManifestEntryCount: target,
+					importedManifestEntryCount:
+						importedManifestEntryIndices.length,
+					importedManifestEntryIndices,
+					localManifestEntryIndicesAfter,
+					rawFetchedByteCount,
+					maxConcurrentImports,
                     persistChunkReads: program.persistChunkReads,
                     activeTransfersAfterClose: program.getActiveTransfers(),
                     downloadSchedulerAfterClose:
                         program.getTransferSchedulerDiagnostics().download,
-                    readDiagnostics: transferId
-                        ? program.getReadDiagnostics(transferId) ?? null
-                        : null,
+					readDiagnostics: null,
                 };
             },`;
 const getScenarioConfig = (scenario) => {
@@ -331,6 +385,7 @@ export const instrumentFileShareFrontend = async (
 		(!requireLocalityHook ||
 			(contents.includes(DROP_LOCALITY_HOOK_MARKER) &&
 				contents.includes(DROP_LOCALITY_PRELOAD_DEADLINE_MARKER) &&
+				contents.includes(DROP_LOCALITY_EXACT_MANIFEST_MARKER) &&
 				contents.includes(DROP_LOCALITY_TOPOLOGY_MARKER) &&
 				contents.includes(DROP_LOCALITY_INDEXED_SEARCH_MARKER)))
 	) {
@@ -497,7 +552,8 @@ export const instrumentFileShareFrontend = async (
 	if (
 		requireLocalityHook &&
 		contents.includes(DROP_LOCALITY_HOOK_MARKER) &&
-		!contents.includes(DROP_LOCALITY_PRELOAD_DEADLINE_MARKER)
+		(!contents.includes(DROP_LOCALITY_PRELOAD_DEADLINE_MARKER) ||
+			!contents.includes(DROP_LOCALITY_EXACT_MANIFEST_MARKER))
 	) {
 		const preloadHookAnchor =
 			"            preloadLocalChunkPrefix: async (fileName, target, timeoutMs) => {";
@@ -1037,6 +1093,10 @@ const main = async () => {
 		args["reader-local-chunk-max-overshoot"],
 		"--reader-local-chunk-max-overshoot",
 	);
+	const readerTerminalTopology =
+		args["reader-terminal-topology"] == null
+			? null
+			: String(args["reader-terminal-topology"]);
 	const examplesSource = args.source ?? defaultExamplesSource();
 	const fixtureSeed = args["fixture-seed"];
 	const resolvedFixtureSeed = fixtureSeed ?? "peerbit-file-share-benchmark-v1";
@@ -1097,6 +1157,21 @@ const main = async () => {
 	) {
 		throw new Error(
 			"--reader-local-chunk-target and --reader-local-chunk-max-overshoot must be provided together",
+		);
+	}
+	if (
+		(readerLocalChunkTarget == null) !== (readerTerminalTopology == null)
+	) {
+		throw new Error(
+			"--reader-terminal-topology must be provided exactly when --reader-local-chunk-target is provided",
+		);
+	}
+	if (
+		readerTerminalTopology != null &&
+		!READER_TERMINAL_TOPOLOGIES.includes(readerTerminalTopology)
+	) {
+		throw new Error(
+			`Unsupported --reader-terminal-topology ${JSON.stringify(readerTerminalTopology)}. Expected one of ${READER_TERMINAL_TOPOLOGIES.join(", ")}`,
 		);
 	}
 	if (
@@ -1274,6 +1349,7 @@ const main = async () => {
 				targetSeeders,
 				readerLocalChunkTarget,
 				readerLocalChunkMaxOvershoot,
+				readerTerminalTopology,
 				baseUrl,
 				protocol,
 				viteMode,
@@ -1475,6 +1551,10 @@ const main = async () => {
 				result.readerLocalChunkMaxOvershoot ??
 				result.invocation?.readerLocalChunkMaxOvershoot ??
 				null,
+			readerTerminalTopology:
+				result.readerTerminalTopology ??
+				result.invocation?.readerTerminalTopology ??
+				null,
 			readerLocalChunkBlockCount: result.readerLocalChunkBlockCount ?? null,
 			readerLocalChunkIndexRowCount:
 				result.readerLocalChunkIndexRowCount ?? null,
@@ -1536,6 +1616,7 @@ const main = async () => {
 		fileMb,
 		readerLocalChunkTarget: readerLocalChunkTarget ?? null,
 		readerLocalChunkMaxOvershoot: readerLocalChunkMaxOvershoot ?? null,
+		readerTerminalTopology,
 		readerLocalityCohorts:
 			scenario === "upload"
 				? aggregateRows

--- a/scripts/file-share/template-contract.test.mjs
+++ b/scripts/file-share/template-contract.test.mjs
@@ -17,18 +17,19 @@ const templates = [
 ];
 
 for (const name of templates) {
-	test(`${name} emits the atomic v7 result envelope`, async () => {
+	test(`${name} emits the atomic v8 result envelope`, async () => {
 		const contents = await readFile(
 			path.join(repoRoot, "scripts", "file-share", "templates", name),
 			"utf8",
 		);
 		for (const required of [
 			'id: "peerbit-file-share-benchmark"',
-			"version: 7",
+			"version: 8",
 			"PW_BENCHMARK_RUN_NONCE",
 			"PW_BENCHMARK_INVOCATION",
 			"PW_BENCHMARK_PROVENANCE",
 			"PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT",
+			"PW_READER_TERMINAL_TOPOLOGY",
 			'process.env.PW_BENCH !== "1"',
 			'serverMode: "production-preview"',
 			"schema: RESULT_SCHEMA",
@@ -179,6 +180,7 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"SINK_SERVER_CLOCK_TOLERANCE_MS_PER_CHUNK",
 		"PW_READER_LOCAL_CHUNK_TARGET",
 		"PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT",
+		"PW_READER_TERMINAL_TOPOLOGY",
 		"LOCALITY_CONTROL_POLL_MS",
 		"seedReplicationRole",
 		"openWithSeededReplicationRole",
@@ -190,20 +192,21 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"readLocalChunkPrefixObservation",
 		"getTopologySnapshot",
 		"topologyHasExactWriterSingleton",
-		"topologyHasExactWriterReaderPair",
 		"writerTopology.replicatorHashes[0] === writerPeerHash",
 		"readerTopology.replicatorHashes[0] === writerPeerHash",
 		"writerTopologyBeforeUpload",
 		"readerTopologyBeforeTimedRead",
-		"requestedYieldedChunkCount",
+		"requestedLocalChunkBlockCount",
+		'provisioningMethod: "exact-manifest-head-import"',
 		"stabilityObservations",
 		"preDownloadObservation",
 		"waitForTerminalReaderIdle",
 		"collectStableTerminalTopology",
 		"terminalIdleObservation",
 		"terminalTopologyObservations",
-		'terminalTopologyRole = "replicator"',
-		"readerJoinedReplicationDuringTimedRead = true",
+		"expectedTerminalTopology: READER_TERMINAL_TOPOLOGY",
+		"topologyMatchesTerminalExpectation",
+		"terminalTopologyExpectationSatisfied = true",
 		'readerLocalityControl.status = "complete"',
 		"exact contiguous prefix",
 		"SEEDER_DROP_POLICY",
@@ -213,7 +216,8 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"unexpectedSeederDrop",
 		"downloadMemoryTelemetryController =",
 		"downloadMemoryTelemetryController.snapshot()",
-		"await downloadMemoryTelemetryController.stop()",
+		"await downloadMemoryTelemetryController.stopSampling()",
+		"await downloadMemoryTelemetryController.cleanup()",
 		"downloadMemoryTelemetry.complete !== true",
 		"series.samplingErrors.length > 0",
 		"downloadMemoryTelemetry,",
@@ -224,7 +228,7 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 	assert.match(
 		contents,
 		/const terminalSeederSnapshot = await snapshot\([\s\S]*?noteSeederDrop\(terminalSeederSnapshot\);[\s\S]*?if \(unexpectedSeederDrop\)/,
-		"the final numeric seeder snapshot must participate in the v7 drop policy before acceptance",
+		"the final numeric seeder snapshot must participate in the v8 drop policy before acceptance",
 	);
 	const lateFailureCatch = contents.slice(
 		contents.lastIndexOf("\t\t} catch (error: any) {"),
@@ -280,10 +284,18 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 	);
 	assert.ok(
 		contents.indexOf("const download = await downloadCompletion") <
-			contents.indexOf("await downloadMemoryTelemetryController.stop()") &&
-			contents.indexOf("await downloadMemoryTelemetryController.stop()") <
-				contents.indexOf('stage = "verify-integrity"'),
-		"memory telemetry must stop at sink completion before integrity and topology work",
+			contents.indexOf(
+				"await downloadMemoryTelemetryController.stopSampling()",
+			) &&
+			contents.indexOf(
+				"await downloadMemoryTelemetryController.stopSampling()",
+			) < contents.indexOf('stage = "verify-integrity"'),
+		"memory telemetry sampling must stop at sink completion before integrity and topology work",
+	);
+	assert.ok(
+		contents.indexOf("integrityVerifiedAt = Date.now()") <
+			contents.indexOf("await downloadMemoryTelemetryController.cleanup()"),
+		"CDP cleanup must start only after transfer integrity evidence is finalized",
 	);
 	assert.ok(
 		!contents.includes("MIN_READY_SEEDERS, 180_000"),
@@ -332,7 +344,7 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 	);
 	assert.match(
 		contents,
-		/if \(!integrityVerified\)[\s\S]*?integrityVerifiedAt = Date\.now\(\);[\s\S]*?readerLocalityControl\.integrityVerifiedAt = integrityVerifiedAt;[\s\S]*?waitForTerminalReaderIdle\(\)[\s\S]*?collectStableTerminalTopology\(\s*terminalTopologyStartedAt,\s*terminalTopologyDeadlineAt,\s*\)[\s\S]*?readerJoinedReplicationDuringTimedRead = true[\s\S]*?const terminalSeederSnapshot = await snapshot\([\s\S]*?stage = "complete"/,
+		/if \(!integrityVerified\)[\s\S]*?integrityVerifiedAt = Date\.now\(\);[\s\S]*?readerLocalityControl\.integrityVerifiedAt = integrityVerifiedAt;[\s\S]*?waitForTerminalReaderIdle\(\)[\s\S]*?collectStableTerminalTopology\(\s*terminalTopologyStartedAt,\s*terminalTopologyDeadlineAt,\s*\)[\s\S]*?terminalTopologyExpectationSatisfied = true[\s\S]*?const terminalSeederSnapshot = await snapshot\([\s\S]*?stage = "complete"/,
 		"terminal topology and the final seeder snapshot must follow the aggregate integrity gate outside the measured download",
 	);
 	assert.ok(
@@ -355,6 +367,7 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		'requireUploadDiagnostics: scenario === "upload"',
 		"peerbit-benchmark-locality-prefix-preload",
 		"peerbit-benchmark-locality-preload-aggregate-deadline",
+		"peerbit-benchmark-locality-exact-manifest-import",
 		"peerbit-benchmark-locality-replicator-hashes",
 		"peerbit-benchmark-locality-indexed-search",
 		"replicatorHashes: replicatorHashes",
@@ -364,7 +377,12 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"const aggregateController = new AbortController()",
 		"signal: aggregateController.signal",
 		"aggregateController.abort(aggregateTimeoutError)",
-		"await iterator?.return?.()",
+		"const manifestEntryHeads = (file as any).chunkEntryHeads",
+		'const documentId = \\`\\${file.id}:\\${index}\\`',
+		"program.retainChunkRead(documentId, file.id)",
+		"program.retainChunkEntryHead(\n\t\t\t\t\t\t\t\t\t\t\thead,\n\t\t\t\t\t\t\t\t\t\t\tfile.id,\n\t\t\t\t\t\t\t\t\t\t\tdocumentId",
+		"const rawEntry = await blocks.get(head",
+		"localManifestEntryIndicesAfter",
 		"window.clearTimeout(aggregateTimeoutHandle)",
 		"aggregateDeadlineAt",
 		"aggregateTimedOut",
@@ -497,8 +515,15 @@ updateListCalls.push(updateListStats);
 	assert.ok(!migrated.includes("new SearchRequest({ fetch: 0xffffffff })"));
 	for (const required of [
 		"/* peerbit-benchmark-locality-preload-aggregate-deadline */",
+		"/* peerbit-benchmark-locality-exact-manifest-import */",
 		"const aggregateController = new AbortController()",
 		"signal: aggregateController.signal",
+		"const manifestEntryHeads = (file as any).chunkEntryHeads",
+		"const documentId = `${file.id}:${index}`",
+		"program.retainChunkRead(documentId, file.id)",
+		"program.retainChunkEntryHead(",
+		"const rawEntry = await blocks.get(head",
+		"localManifestEntryIndicesAfter",
 		"aggregateTimeoutMs",
 		"aggregateDeadlineAt",
 		"aggregateTimedOut",
@@ -506,9 +531,8 @@ updateListCalls.push(updateListStats);
 		assert.ok(migrated.includes(required), `missing migrated ${required}`);
 	}
 	assert.ok(
-		migrated.indexOf("await iterator?.return?.()") <
-			migrated.indexOf("window.clearTimeout(aggregateTimeoutHandle)"),
-		"the aggregate timeout must remain armed through iterator cleanup",
+		!migrated.includes(".streamFile(program"),
+		"exact locality provisioning must not start the product stream read-ahead path",
 	);
 	assert.equal(
 		[...migrated.matchAll(/preloadLocalChunkPrefix: async/g)].length,
@@ -644,7 +668,7 @@ test("download memory support is bounded, serial, and cleanup-safe", async () =>
 		"utf8",
 	);
 	for (const required of [
-		'DOWNLOAD_MEMORY_PROFILE = "download-memory-v1"',
+		'DOWNLOAD_MEMORY_PROFILE = "download-memory-v2"',
 		"DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS = 5_000",
 		"DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS = 4_000",
 		"DOWNLOAD_MEMORY_CLEANUP_TIMEOUT_MS = 9_000",
@@ -653,6 +677,7 @@ test("download memory support is bounded, serial, and cleanup-safe", async () =>
 		"DOWNLOAD_MEMORY_MAX_SAMPLES_PER_SERIES = 4_096",
 		"DOWNLOAD_MEMORY_MAX_BROWSER_PROCESSES = 256",
 		"DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS = 16",
+		"DOWNLOAD_MEMORY_MAX_CLEANUP_WARNINGS = 16",
 		"DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH = 512",
 		"startBoundedSerialSampler",
 		"withDownloadMemoryOperationDeadline",
@@ -672,6 +697,8 @@ test("download memory support is bounded, serial, and cleanup-safe", async () =>
 		"process.memoryUsage().rss",
 		"playwright-worker-node-including-in-process-local-bootstrap",
 		"samplingErrorOverflowCount",
+		"cleanupWarningOverflowCount",
+		"stopSampling",
 	]) {
 		assert.ok(
 			contents.includes(required),

--- a/scripts/file-share/templates/download-memory-telemetry.mjs
+++ b/scripts/file-share/templates/download-memory-telemetry.mjs
@@ -3,7 +3,7 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
-export const DOWNLOAD_MEMORY_PROFILE = "download-memory-v1";
+export const DOWNLOAD_MEMORY_PROFILE = "download-memory-v2";
 export const DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS = 5_000;
 export const DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS = 4_000;
 export const DOWNLOAD_MEMORY_CLEANUP_TIMEOUT_MS = 9_000;
@@ -14,6 +14,7 @@ export const DOWNLOAD_MEMORY_WINDOW_DEFINITION =
 export const DOWNLOAD_MEMORY_MAX_SAMPLES_PER_SERIES = 4_096;
 export const DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE = 2;
 export const DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS = 16;
+export const DOWNLOAD_MEMORY_MAX_CLEANUP_WARNINGS = 16;
 export const DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH = 512;
 export const DOWNLOAD_MEMORY_MAX_BROWSER_ROLES = 32;
 export const DOWNLOAD_MEMORY_MAX_BROWSER_PROCESSES = 256;
@@ -53,6 +54,17 @@ const cloneValue = (value) => structuredClone(value);
 const boundedErrorMessage = (error) => {
 	const message = error instanceof Error ? error.message : String(error);
 	return message.slice(0, DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH);
+};
+
+const isOnlyOperationTimeouts = (error) => {
+	if (error?.code === "DOWNLOAD_MEMORY_OPERATION_TIMEOUT") {
+		return true;
+	}
+	return (
+		error instanceof AggregateError &&
+		error.errors.length > 0 &&
+		error.errors.every(isOnlyOperationTimeouts)
+	);
 };
 
 export const withDownloadMemoryOperationDeadline = async (
@@ -137,19 +149,33 @@ export const startBoundedSerialSampler = async ({
 	const startedAt = now();
 	const samples = [];
 	const samplingErrors = [];
+	const cleanupWarnings = [];
 	let samplingErrorOverflowCount = 0;
+	let cleanupWarningOverflowCount = 0;
 	let finishedAt = null;
 	let timer;
 	let activeSample;
 	let stopped = false;
 	let terminalSampleFailure = false;
-	let stopPromise;
+	let stopSamplingPromise;
+	let cleanupPromise;
 
 	const recordError = (error) => {
 		if (samplingErrors.length < DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS) {
 			samplingErrors.push(boundedErrorMessage(error));
 		} else {
 			samplingErrorOverflowCount += 1;
+		}
+	};
+	const recordCleanupWarning = (error) => {
+		const message = `cleanup-timeout: ${boundedErrorMessage(error)}`.slice(
+			0,
+			DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH,
+		);
+		if (cleanupWarnings.length < DOWNLOAD_MEMORY_MAX_CLEANUP_WARNINGS) {
+			cleanupWarnings.push(message);
+		} else {
+			cleanupWarningOverflowCount += 1;
 		}
 	};
 
@@ -164,7 +190,11 @@ export const startBoundedSerialSampler = async ({
 				"Memory sample",
 				operationTimeoutMs,
 			);
-			if (values == null || typeof values !== "object" || Array.isArray(values)) {
+			if (
+				values == null ||
+				typeof values !== "object" ||
+				Array.isArray(values)
+			) {
 				throw new Error("Memory sampler returned a non-object sample");
 			}
 			samples.push({ capturedAt: now(), ...values });
@@ -177,11 +207,7 @@ export const startBoundedSerialSampler = async ({
 	};
 
 	const schedule = () => {
-		if (
-			stopped ||
-			terminalSampleFailure ||
-			samples.length >= maxSamples - 1
-		) {
+		if (stopped || terminalSampleFailure || samples.length >= maxSamples - 1) {
 			return;
 		}
 		timer = setTimer(() => {
@@ -200,39 +226,59 @@ export const startBoundedSerialSampler = async ({
 		samples: cloneValue(samples),
 		samplingErrors: [...samplingErrors],
 		samplingErrorOverflowCount,
+		cleanupWarnings: [...cleanupWarnings],
+		cleanupWarningOverflowCount,
 	});
 
 	await takeSample();
 	schedule();
 
-	return {
-		snapshot,
-		stop: () => {
-			if (stopPromise) {
-				return stopPromise;
+	const stopSampling = () => {
+		if (stopSamplingPromise) {
+			return stopSamplingPromise;
+		}
+		stopped = true;
+		stopSamplingPromise = (async () => {
+			if (timer !== undefined) {
+				clearTimer(timer);
+				timer = undefined;
 			}
-			stopped = true;
-			stopPromise = (async () => {
-				if (timer !== undefined) {
-					clearTimer(timer);
-					timer = undefined;
-				}
-				await activeSample;
-				await takeSample(true);
-				try {
-					await withDownloadMemoryOperationDeadline(
-						Promise.resolve().then(() => cleanup()),
-						"Memory sampler cleanup",
-						cleanupTimeoutMs,
-					);
-				} catch (error) {
+			await activeSample;
+			await takeSample(true);
+			finishedAt = now();
+			return snapshot();
+		})();
+		return stopSamplingPromise;
+	};
+	const runCleanup = () => {
+		if (cleanupPromise) {
+			return cleanupPromise;
+		}
+		cleanupPromise = (async () => {
+			await stopSampling();
+			try {
+				await withDownloadMemoryOperationDeadline(
+					Promise.resolve().then(() => cleanup()),
+					"Memory sampler cleanup",
+					cleanupTimeoutMs,
+				);
+			} catch (error) {
+				if (isOnlyOperationTimeouts(error)) {
+					recordCleanupWarning(error);
+				} else {
 					recordError(error);
 				}
-				finishedAt = now();
-				return snapshot();
-			})();
-			return stopPromise;
-		},
+			}
+			return snapshot();
+		})();
+		return cleanupPromise;
+	};
+
+	return {
+		snapshot,
+		stopSampling,
+		cleanup: runCleanup,
+		stop: runCleanup,
 	};
 };
 
@@ -253,6 +299,8 @@ const summarizeHeap = (scope, state) => {
 		samples: state.samples,
 		samplingErrors: state.samplingErrors,
 		samplingErrorOverflowCount: state.samplingErrorOverflowCount,
+		cleanupWarnings: state.cleanupWarnings,
+		cleanupWarningOverflowCount: state.cleanupWarningOverflowCount,
 	};
 };
 
@@ -325,7 +373,7 @@ const startPageJsHeapSampler = async ({
 					operationTimeoutMs,
 				);
 			} catch (error) {
-				cleanupErrors.push(boundedErrorMessage(error));
+				cleanupErrors.push(error);
 			}
 			try {
 				await withDownloadMemoryOperationDeadline(
@@ -334,17 +382,23 @@ const startPageJsHeapSampler = async ({
 					operationTimeoutMs,
 				);
 			} catch (error) {
-				cleanupErrors.push(boundedErrorMessage(error));
+				cleanupErrors.push(error);
 			} finally {
 				session = undefined;
 			}
 			if (cleanupErrors.length > 0) {
-				throw new Error(cleanupErrors.join("; "));
+				throw new AggregateError(
+					cleanupErrors,
+					cleanupErrors.map(boundedErrorMessage).join("; "),
+				);
 			}
 		},
 	});
 	return {
 		snapshot: () => summarizeHeap(scope, sampler.snapshot()),
+		stopSampling: async () =>
+			summarizeHeap(scope, await sampler.stopSampling()),
+		cleanup: async () => summarizeHeap(scope, await sampler.cleanup()),
 		stop: async () => summarizeHeap(scope, await sampler.stop()),
 	};
 };
@@ -425,14 +479,14 @@ const summarizeHostRss = (state) => {
 		startBrowserProcessCount: first?.browserProcessCount ?? null,
 		endBrowserProcessCount: last?.browserProcessCount ?? null,
 		peakBrowserProcessCount: peak("browserProcessCount"),
-		startBrowserRoleBytes: first
-			? cloneValue(first.browserRoleBytes)
-			: null,
+		startBrowserRoleBytes: first ? cloneValue(first.browserRoleBytes) : null,
 		endBrowserRoleBytes: last ? cloneValue(last.browserRoleBytes) : null,
 		peakBrowserRoleBytes,
 		samples: state.samples,
 		samplingErrors: state.samplingErrors,
 		samplingErrorOverflowCount: state.samplingErrorOverflowCount,
+		cleanupWarnings: state.cleanupWarnings,
+		cleanupWarningOverflowCount: state.cleanupWarningOverflowCount,
 	};
 };
 
@@ -480,8 +534,7 @@ const startHostRssSampler = async ({
 					processInfo
 						.map((process) => Number(process.id))
 						.filter(
-							(processId) =>
-								Number.isSafeInteger(processId) && processId > 0,
+							(processId) => Number.isSafeInteger(processId) && processId > 0,
 						),
 				),
 			];
@@ -511,8 +564,7 @@ const startHostRssSampler = async ({
 			}
 			if (
 				Object.keys(browserRoleBytes).length === 0 ||
-				Object.keys(browserRoleBytes).length >
-					DOWNLOAD_MEMORY_MAX_BROWSER_ROLES
+				Object.keys(browserRoleBytes).length > DOWNLOAD_MEMORY_MAX_BROWSER_ROLES
 			) {
 				throw new Error("Chromium process-role attribution is unbounded");
 			}
@@ -550,6 +602,8 @@ const startHostRssSampler = async ({
 	});
 	return {
 		snapshot: () => summarizeHostRss(sampler.snapshot()),
+		stopSampling: async () => summarizeHostRss(await sampler.stopSampling()),
+		cleanup: async () => summarizeHostRss(await sampler.cleanup()),
 		stop: async () => summarizeHostRss(await sampler.stop()),
 	};
 };
@@ -590,13 +644,16 @@ export const startDownloadMemoryTelemetry = async ({
 		}),
 	]);
 	let complete = false;
-	let stopPromise;
+	let cleanupComplete = false;
+	let stopSamplingPromise;
+	let cleanupPromise;
 	const build = ({ readerJsHeap, writerJsHeap, hostRss }) => ({
 		profile: DOWNLOAD_MEMORY_PROFILE,
 		sampleIntervalMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
 		windowDefinition: DOWNLOAD_MEMORY_WINDOW_DEFINITION,
 		maxSamplesPerSeries,
 		complete,
+		cleanupComplete,
 		startedAt: Math.min(
 			readerJsHeap.startedAt,
 			writerJsHeap.startedAt,
@@ -616,6 +673,35 @@ export const startDownloadMemoryTelemetry = async ({
 		writerJsHeap,
 		hostRss,
 	});
+	const stopSampling = () => {
+		if (stopSamplingPromise) {
+			return stopSamplingPromise;
+		}
+		stopSamplingPromise = Promise.all([
+			readerSampler.stopSampling(),
+			writerSampler.stopSampling(),
+			hostSampler.stopSampling(),
+		]).then(([readerJsHeap, writerJsHeap, hostRss]) => {
+			complete = true;
+			return build({ readerJsHeap, writerJsHeap, hostRss });
+		});
+		return stopSamplingPromise;
+	};
+	const runCleanup = () => {
+		if (cleanupPromise) {
+			return cleanupPromise;
+		}
+		cleanupPromise = Promise.all([
+			readerSampler.cleanup(),
+			writerSampler.cleanup(),
+			hostSampler.cleanup(),
+		]).then(([readerJsHeap, writerJsHeap, hostRss]) => {
+			complete = true;
+			cleanupComplete = true;
+			return build({ readerJsHeap, writerJsHeap, hostRss });
+		});
+		return cleanupPromise;
+	};
 	return {
 		snapshot: () =>
 			build({
@@ -623,19 +709,8 @@ export const startDownloadMemoryTelemetry = async ({
 				writerJsHeap: writerSampler.snapshot(),
 				hostRss: hostSampler.snapshot(),
 			}),
-		stop: () => {
-			if (stopPromise) {
-				return stopPromise;
-			}
-			stopPromise = Promise.all([
-				readerSampler.stop(),
-				writerSampler.stop(),
-				hostSampler.stop(),
-			]).then(([readerJsHeap, writerJsHeap, hostRss]) => {
-				complete = true;
-				return build({ readerJsHeap, writerJsHeap, hostRss });
-			});
-			return stopPromise;
-		},
+		stopSampling,
+		cleanup: runCleanup,
+		stop: runCleanup,
 	};
 };

--- a/scripts/file-share/templates/seeder-probe.e2e.spec.ts
+++ b/scripts/file-share/templates/seeder-probe.e2e.spec.ts
@@ -24,7 +24,7 @@ const EFFECTIVE_SAMPLE_INTERVAL_MS = Math.max(
 );
 const RESULT_SCHEMA = {
 	id: "peerbit-file-share-benchmark",
-	version: 7,
+	version: 8,
 } as const;
 const RUN_NONCE = process.env.PW_BENCHMARK_RUN_NONCE;
 const parseJsonEnvironment = (name: string) => {
@@ -47,6 +47,8 @@ const READER_LOCAL_CHUNK_MAX_OVERSHOOT = process.env
 	.PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT
 	? Number(process.env.PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT)
 	: null;
+const READER_TERMINAL_TOPOLOGY =
+	process.env.PW_READER_TERMINAL_TOPOLOGY || null;
 
 if (!["local", "remote"].includes(NETWORK_MODE)) {
 	throw new Error(`Unsupported PW_NETWORK_MODE='${NETWORK_MODE}'`);
@@ -76,7 +78,7 @@ if (!Number.isSafeInteger(TARGET_SEEDERS) || TARGET_SEEDERS < 0) {
 if (
 	(INVOCATION.schema as Record<string, unknown> | undefined)?.id !==
 		"peerbit-file-share-benchmark-invocation" ||
-	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 3
+	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 4
 ) {
 	throw new Error("Unsupported PW_BENCHMARK_INVOCATION schema");
 }
@@ -90,6 +92,7 @@ const expectedInvocationValues: Record<string, unknown> = {
 	targetSeeders: TARGET_SEEDERS,
 	readerLocalChunkTarget: READER_LOCAL_CHUNK_TARGET,
 	readerLocalChunkMaxOvershoot: READER_LOCAL_CHUNK_MAX_OVERSHOOT,
+	readerTerminalTopology: READER_TERMINAL_TOPOLOGY,
 	baseUrl: process.env.PW_BASE_URL || null,
 	protocol: process.env.PW_PROTOCOL || null,
 	viteMode: process.env.PW_VITE_MODE || null,

--- a/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
+++ b/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
@@ -37,6 +37,8 @@ const READER_LOCAL_CHUNK_MAX_OVERSHOOT = process.env
 	.PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT
 	? Number(process.env.PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT)
 	: null;
+const READER_TERMINAL_TOPOLOGY =
+	process.env.PW_READER_TERMINAL_TOPOLOGY || null;
 const LOCALITY_CONTROL_POLL_MS = Math.min(POLL_MS, 100);
 const LOCALITY_CONTROL_STABLE_SAMPLE_COUNT = 3;
 const POST_UPLOAD_MONITOR_MS = Number(
@@ -113,7 +115,7 @@ const FIXTURE_SEED =
 	process.env.PW_FIXTURE_SEED || "peerbit-file-share-benchmark-v1";
 const RESULT_SCHEMA = {
 	id: "peerbit-file-share-benchmark",
-	version: 7,
+	version: 8,
 } as const;
 const SEEDER_DROP_POLICY = {
 	id: "peerbit-file-share-seeder-drop-policy",
@@ -171,6 +173,24 @@ if (
 ) {
 	throw new Error(
 		"PW_READER_LOCAL_CHUNK_TARGET and PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT must be provided together",
+	);
+}
+if (
+	(READER_LOCAL_CHUNK_TARGET === null) !==
+	(READER_TERMINAL_TOPOLOGY === null)
+) {
+	throw new Error(
+		"PW_READER_TERMINAL_TOPOLOGY must be provided exactly when PW_READER_LOCAL_CHUNK_TARGET is provided",
+	);
+}
+if (
+	READER_TERMINAL_TOPOLOGY !== null &&
+	!(["observer", "replicator"] as const).includes(
+		READER_TERMINAL_TOPOLOGY as "observer" | "replicator",
+	)
+) {
+	throw new Error(
+		`Invalid PW_READER_TERMINAL_TOPOLOGY='${process.env.PW_READER_TERMINAL_TOPOLOGY}'`,
 	);
 }
 if (
@@ -232,6 +252,7 @@ const expectedInvocationValues: Record<string, unknown> = {
 	readyTimeoutMs: READY_TIMEOUT_MS,
 	readerLocalChunkTarget: READER_LOCAL_CHUNK_TARGET,
 	readerLocalChunkMaxOvershoot: READER_LOCAL_CHUNK_MAX_OVERSHOOT,
+	readerTerminalTopology: READER_TERMINAL_TOPOLOGY,
 	baseUrl: process.env.PW_BASE_URL || null,
 	protocol: process.env.PW_PROTOCOL || null,
 	viteMode: process.env.PW_VITE_MODE || null,
@@ -244,7 +265,7 @@ const expectedInvocationValues: Record<string, unknown> = {
 if (
 	(INVOCATION.schema as Record<string, unknown> | undefined)?.id !==
 		"peerbit-file-share-benchmark-invocation" ||
-	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 3
+	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 4
 ) {
 	throw new Error("Unsupported PW_BENCHMARK_INVOCATION schema");
 }
@@ -619,6 +640,21 @@ const topologyHasExactWriterReaderPair = (
 	);
 };
 
+const topologyMatchesTerminalExpectation = (
+	writerTopology: Record<string, any>,
+	readerTopology: Record<string, any>,
+	expectedWriterPeerHash: string,
+	expectedReaderPeerHash: string,
+) =>
+	READER_TERMINAL_TOPOLOGY === "observer"
+		? topologyHasExactWriterSingleton(writerTopology, readerTopology)
+		: topologyHasExactWriterReaderPair(
+				writerTopology,
+				readerTopology,
+				expectedWriterPeerHash,
+				expectedReaderPeerHash,
+			);
+
 const getDiagnostics = async (page: Page) => {
 	try {
 		return await page.evaluate(async () => {
@@ -823,14 +859,17 @@ test.describe("generated transfer-validity benchmark", () => {
 			READER_LOCAL_CHUNK_TARGET === null
 				? null
 				: {
-						profile: "observer-topology-persistent-read-preloaded-prefix",
-						requestedYieldedChunkCount: READER_LOCAL_CHUNK_TARGET,
-						maxReadAheadOvershootChunkCount: READER_LOCAL_CHUNK_MAX_OVERSHOOT!,
+						profile: "observer-topology-exact-manifest-prefix",
+						provisioningMethod: "exact-manifest-head-import",
+						requestedLocalChunkBlockCount: READER_LOCAL_CHUNK_TARGET,
+						maxSpeculativeOvershootChunkCount:
+							READER_LOCAL_CHUNK_MAX_OVERSHOOT!,
 						countMetric:
 							"exact local Documents index rows and manifest entry blocks",
 						writerUploadRole: "fixed1",
 						readerUploadRole: "observer",
 						readerTimedReadPolicy: "persist-chunk-reads",
+						expectedTerminalTopology: READER_TERMINAL_TOPOLOGY,
 						stabilityPollIntervalMs: LOCALITY_CONTROL_POLL_MS,
 						requiredStableObservationCount:
 							LOCALITY_CONTROL_STABLE_SAMPLE_COUNT,
@@ -857,7 +896,7 @@ test.describe("generated transfer-validity benchmark", () => {
 						terminalTopologyDeadlineAt: null as number | null,
 						terminalTopologyFinishedAt: null as number | null,
 						terminalTopologyRole: null as string | null,
-						readerJoinedReplicationDuringTimedRead: null as boolean | null,
+						terminalTopologyExpectationSatisfied: null as boolean | null,
 						terminalTopologyObservations: [] as Array<{
 							capturedAt: number;
 							writerTopology: Record<string, unknown>;
@@ -865,7 +904,7 @@ test.describe("generated transfer-validity benchmark", () => {
 						}>,
 						actualLocalChunkBlockCount: null as number | null,
 						actualLocalChunkIndexRowCount: null as number | null,
-						readAheadOvershootChunkCount: null as number | null,
+						speculativeOvershootChunkCount: null as number | null,
 						cohortKey: null as string | null,
 						failure: null as string | null,
 					};
@@ -1013,6 +1052,10 @@ test.describe("generated transfer-validity benchmark", () => {
 					reader,
 					fileName,
 				);
+				const expectedTerminalIndexRowCount =
+					READER_TERMINAL_TOPOLOGY === "replicator"
+						? lastObservation.chunkCount
+						: 0;
 				if (
 					localityObservationIsIdle(lastObservation) &&
 					lastObservation.fileId === readerManifestEvidence?.fileId &&
@@ -1020,6 +1063,11 @@ test.describe("generated transfer-validity benchmark", () => {
 					lastObservation.blockCount !== null &&
 					lastObservation.blockChunkIndices !== null &&
 					lastObservation.blockCount === lastObservation.chunkCount &&
+					lastObservation.indexRowCount === expectedTerminalIndexRowCount &&
+					Array.isArray(lastObservation.indexedChunkIndices) &&
+					lastObservation.indexedChunkIndices.length ===
+						expectedTerminalIndexRowCount &&
+					isContiguousPrefix(lastObservation.indexedChunkIndices) &&
 					isContiguousPrefix(lastObservation.blockChunkIndices) &&
 					lastObservation.persistChunkReads === true
 				) {
@@ -1075,7 +1123,9 @@ test.describe("generated transfer-validity benchmark", () => {
 					break;
 				}
 				if (
-					topologyHasExactWriterReaderPair(
+					writerTopology?.peerHash === expectedWriterPeerHash &&
+					readerTopology?.peerHash === expectedReaderPeerHash &&
+					topologyMatchesTerminalExpectation(
 						writerTopology,
 						readerTopology,
 						expectedWriterPeerHash,
@@ -1092,7 +1142,7 @@ test.describe("generated transfer-validity benchmark", () => {
 				await reader.waitForTimeout(LOCALITY_CONTROL_POLL_MS);
 			}
 			throw new Error(
-				`Timed reader did not converge to the exact two-replicator topology: ${JSON.stringify(lastObservation)}`,
+				`Timed reader did not converge to requested terminal topology ${READER_TERMINAL_TOPOLOGY}: ${JSON.stringify(lastObservation)}`,
 			);
 		};
 
@@ -1434,8 +1484,8 @@ test.describe("generated transfer-validity benchmark", () => {
 					);
 				}
 				logStage("reader-locality-preload", {
-					requestedYieldedChunkCount: READER_LOCAL_CHUNK_TARGET,
-					maxReadAheadOvershootChunkCount: READER_LOCAL_CHUNK_MAX_OVERSHOOT,
+					requestedLocalChunkBlockCount: READER_LOCAL_CHUNK_TARGET,
+					maxSpeculativeOvershootChunkCount: READER_LOCAL_CHUNK_MAX_OVERSHOOT,
 				});
 				const preloadEvidence = (await preloadLocalChunkPrefix(
 					reader,
@@ -1447,15 +1497,27 @@ test.describe("generated transfer-validity benchmark", () => {
 				const preloadScheduler = preloadEvidence.downloadSchedulerAfterClose as
 					| LocalitySchedulerObservation
 					| undefined;
-				const preloadReadDiagnostics =
-					preloadEvidence.readDiagnostics as Record<string, unknown> | null;
 				const preloadStartedAt = preloadEvidence.startedAt as number;
 				const preloadFinishedAt = preloadEvidence.finishedAt as number;
+				const expectedImportedIndices = Array.from(
+					{ length: READER_LOCAL_CHUNK_TARGET },
+					(_, index) => index,
+				);
 				if (
 					preloadEvidence.fileId !== readerManifestEvidence.fileId ||
-					preloadEvidence.yieldedChunkCount !== READER_LOCAL_CHUNK_TARGET ||
-					!Number.isSafeInteger(preloadEvidence.yieldedByteCount) ||
-					(preloadEvidence.yieldedByteCount as number) < 0 ||
+					preloadEvidence.provisioningMethod !== "exact-manifest-head-import" ||
+					preloadEvidence.transferId !== null ||
+					preloadEvidence.requestedManifestEntryCount !==
+						READER_LOCAL_CHUNK_TARGET ||
+					preloadEvidence.importedManifestEntryCount !==
+						READER_LOCAL_CHUNK_TARGET ||
+					JSON.stringify(preloadEvidence.importedManifestEntryIndices) !==
+						JSON.stringify(expectedImportedIndices) ||
+					JSON.stringify(preloadEvidence.localManifestEntryIndicesAfter) !==
+						JSON.stringify(expectedImportedIndices) ||
+					!Number.isSafeInteger(preloadEvidence.rawFetchedByteCount) ||
+					(preloadEvidence.rawFetchedByteCount as number) < 0 ||
+					preloadEvidence.maxConcurrentImports !== 8 ||
 					preloadEvidence.persistChunkReads !== true ||
 					!Array.isArray(preloadEvidence.activeTransfersAfterClose) ||
 					preloadEvidence.activeTransfersAfterClose.length !== 0 ||
@@ -1465,7 +1527,8 @@ test.describe("generated transfer-validity benchmark", () => {
 					!Number.isSafeInteger(preloadEvidence.startedAt) ||
 					!Number.isSafeInteger(preloadEvidence.finishedAt) ||
 					preloadFinishedAt < preloadStartedAt ||
-					preloadEvidence.aggregateTimedOut !== false
+					preloadEvidence.aggregateTimedOut !== false ||
+					preloadEvidence.readDiagnostics !== null
 				) {
 					throw new Error(
 						"Reader locality preload did not close with clean transfer resources",
@@ -1473,12 +1536,13 @@ test.describe("generated transfer-validity benchmark", () => {
 				}
 				if (READER_LOCAL_CHUNK_TARGET === 0) {
 					if (
-						preloadEvidence.transferId !== null ||
-						preloadReadDiagnostics !== null ||
 						preloadEvidence.aggregateTimeoutMs !== null ||
-						preloadEvidence.aggregateDeadlineAt !== null
+						preloadEvidence.aggregateDeadlineAt !== null ||
+						preloadEvidence.rawFetchedByteCount !== 0
 					) {
-						throw new Error("Zero-prefix preload unexpectedly opened a read");
+						throw new Error(
+							"Zero-prefix preload unexpectedly imported a manifest entry",
+						);
 					}
 				} else if (
 					preloadEvidence.aggregateTimeoutMs !== DOWNLOAD_TIMEOUT_MS ||
@@ -1486,17 +1550,10 @@ test.describe("generated transfer-validity benchmark", () => {
 						preloadStartedAt + DOWNLOAD_TIMEOUT_MS ||
 					preloadFinishedAt - preloadStartedAt >
 						DOWNLOAD_TIMEOUT_MS + TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS ||
-					typeof preloadEvidence.transferId !== "string" ||
-					preloadEvidence.transferId.length === 0 ||
-					!preloadReadDiagnostics ||
-					preloadReadDiagnostics.transferId !== preloadEvidence.transferId ||
-					preloadReadDiagnostics.persistChunkReads !== true ||
-					preloadReadDiagnostics.finishedAt !== null ||
-					preloadReadDiagnostics.failureAt !== null ||
-					preloadReadDiagnostics.failureMessage !== null
+					(preloadEvidence.rawFetchedByteCount as number) <= 0
 				) {
 					throw new Error(
-						"Partial-prefix preload diagnostics do not prove a bounded clean iterator close",
+						"Exact manifest-prefix import did not prove a bounded clean preload",
 					);
 				}
 
@@ -1508,7 +1565,7 @@ test.describe("generated transfer-validity benchmark", () => {
 					preDownloadObservation.blockCount;
 				readerLocalityControl.actualLocalChunkIndexRowCount =
 					preDownloadObservation.indexRowCount;
-				readerLocalityControl.readAheadOvershootChunkCount =
+				readerLocalityControl.speculativeOvershootChunkCount =
 					preDownloadObservation.blockCount! - READER_LOCAL_CHUNK_TARGET;
 				readerLocalityControl.cohortKey = `observer-persistent-prefix-b${preDownloadObservation.blockCount}-i${preDownloadObservation.indexRowCount}`;
 				const [writerTopology, readerTopology] = await Promise.all([
@@ -1578,7 +1635,8 @@ test.describe("generated transfer-validity benchmark", () => {
 			await downloadButton.click();
 			const download = await downloadCompletion;
 			downloadCompletionObservedAt = Date.now();
-			downloadMemoryTelemetry = await downloadMemoryTelemetryController.stop();
+			downloadMemoryTelemetry =
+				await downloadMemoryTelemetryController.stopSampling();
 			const memorySeries = [
 				downloadMemoryTelemetry.readerJsHeap,
 				downloadMemoryTelemetry.writerJsHeap,
@@ -1842,6 +1900,29 @@ test.describe("generated transfer-validity benchmark", () => {
 				);
 			}
 			integrityVerifiedAt = Date.now();
+			// Sampling is finalized at sink completion above, but CDP cleanup is
+			// deliberately deferred until the transfer and its SHA-256/CRC-32
+			// evidence are complete. A slow Performance.disable/detach must not
+			// erase an otherwise valid transfer result.
+			downloadMemoryTelemetry =
+				await downloadMemoryTelemetryController.cleanup();
+			const finalizedMemorySeries = [
+				downloadMemoryTelemetry.readerJsHeap,
+				downloadMemoryTelemetry.writerJsHeap,
+				downloadMemoryTelemetry.hostRss,
+			];
+			if (
+				downloadMemoryTelemetry.cleanupComplete !== true ||
+				finalizedMemorySeries.some(
+					(series) =>
+						series.samplingErrors.length > 0 ||
+						series.samplingErrorOverflowCount !== 0,
+				)
+			) {
+				throw new Error(
+					"Download memory telemetry cleanup reported a non-timeout failure",
+				);
+			}
 			if (readerLocalityControl) {
 				stage = "verify-terminal-reader-topology";
 				readerLocalityControl.integrityVerifiedAt = integrityVerifiedAt;
@@ -1869,13 +1950,14 @@ test.describe("generated transfer-validity benchmark", () => {
 					terminalTopologyFinishedAt;
 				readerLocalityControl.terminalTopologyObservations =
 					terminalTopologyObservations;
-				readerLocalityControl.terminalTopologyRole = "replicator";
-				readerLocalityControl.readerJoinedReplicationDuringTimedRead = true;
+				readerLocalityControl.terminalTopologyRole =
+					READER_TERMINAL_TOPOLOGY;
+				readerLocalityControl.terminalTopologyExpectationSatisfied = true;
 				readerLocalityControl.status = "complete";
 				logStage("reader-terminal-topology-stable", {
 					terminalTopologyRole: readerLocalityControl.terminalTopologyRole,
-					readerJoinedReplicationDuringTimedRead:
-						readerLocalityControl.readerJoinedReplicationDuringTimedRead,
+					terminalTopologyExpectationSatisfied:
+						readerLocalityControl.terminalTopologyExpectationSatisfied,
 				});
 			}
 			const terminalSeederSnapshot = await snapshot(
@@ -1951,6 +2033,7 @@ test.describe("generated transfer-validity benchmark", () => {
 				mode: MODE,
 				readerLocalChunkTarget: READER_LOCAL_CHUNK_TARGET,
 				readerLocalChunkMaxOvershoot: READER_LOCAL_CHUNK_MAX_OVERSHOOT,
+				readerTerminalTopology: READER_TERMINAL_TOPOLOGY,
 				readerLocalChunkBlockCount:
 					readerLocalityControl?.actualLocalChunkBlockCount ?? null,
 				readerLocalChunkIndexRowCount:
@@ -2062,7 +2145,7 @@ test.describe("generated transfer-validity benchmark", () => {
 		} catch (error: any) {
 			if (downloadMemoryTelemetryController) {
 				downloadMemoryTelemetry =
-					await downloadMemoryTelemetryController.stop();
+					await downloadMemoryTelemetryController.cleanup();
 			}
 			if (readerLocalityControl) {
 				readerLocalityControl.status = "failed";
@@ -2088,6 +2171,7 @@ test.describe("generated transfer-validity benchmark", () => {
 				mode: MODE,
 				readerLocalChunkTarget: READER_LOCAL_CHUNK_TARGET,
 				readerLocalChunkMaxOvershoot: READER_LOCAL_CHUNK_MAX_OVERSHOOT,
+				readerTerminalTopology: READER_TERMINAL_TOPOLOGY,
 				readerLocalChunkBlockCount:
 					readerLocalityControl?.actualLocalChunkBlockCount ?? null,
 				readerLocalChunkIndexRowCount:
@@ -2148,7 +2232,7 @@ test.describe("generated transfer-validity benchmark", () => {
 			console.error(`FILE_SHARE_BENCHMARK_RESULT ${JSON.stringify(result)}`);
 			throw error;
 		} finally {
-			await downloadMemoryTelemetryController?.stop().catch(() => {});
+			await downloadMemoryTelemetryController?.cleanup().catch(() => {});
 			await cleanupDownload?.().catch(() => {});
 			await nodeSinkController?.cleanup().catch(() => {});
 			if (preparedFile) {


### PR DESCRIPTION
## Summary

- preload an exact contiguous manifest prefix without read-ahead overshoot
- validate deterministic SHA-256/CRC-32 evidence and explicit observer/replicator terminal topology
- separate timed memory sampling from integrity cleanup and gate bounded telemetry
- bump incompatible benchmark contracts to result v8, invocation v4, summary v5, and memory v2

## Validation

- full file-share harness suite: 182/182
- changed focused suites: 120/120
- generated exact-1024 Playwright spec: 1/1 listed
- Node syntax, Prettier, and diff checks pass