### PR TITLE
feat(peerbit): configure pubsub upload limits

### DIFF
--- a/.changeset/wise-fanout-budgets.md
+++ b/.changeset/wise-fanout-budgets.md
@@ -1,0 +1,7 @@
+---
+"peerbit": patch
+"@peerbit/react": patch
+"@peerbit/shared-log": patch
+---
+
+Expose a validated `pubsubUploadLimitBps` runtime option through `Peerbit.create` and the browser node `PeerProvider`, applying it to root and node pubsub shard channels and as the overridable default for opted-in SharedLog fanout channels.

--- a/docs/scalable-fanout.md
+++ b/docs/scalable-fanout.md
@@ -76,6 +76,29 @@ See wire-level details in:
 - Channel helper: `peer.fanoutChannel(topic, root)`
 - Root resolution helper: topic root control plane
 
+Peerbit-created runtimes can set the local per-channel budget for pubsub
+fanout with `Peerbit.create({ pubsubUploadLimitBps: 20_000_000 })`. Browser
+node runtimes use the same option on `PeerProvider`:
+
+```tsx
+<PeerProvider
+	config={{
+		runtime: "node",
+		network: "remote",
+		pubsubUploadLimitBps: 20_000_000,
+	}}
+>
+	{children}
+</PeerProvider>
+```
+
+The value must be a positive safe integer in bytes per second and defaults to
+`5_000_000`. It applies independently to every pubsub shard channel opened in
+the root or node role. It also becomes the default for SharedLog fanout
+channels that a program explicitly enables; a per-open
+`fanout.channel.uploadLimitBps` still wins. The setting is local runtime policy
+and does not change the wire protocol or advertise capacity to remote peers.
+
 Minimal channel usage pattern:
 - Root: `openChannel(topic, rootId, { role: "root", ... })`, then `publishData(...)`
 - Subscriber/relay: `joinChannel(topic, rootId, { ... })`, consume `"fanout:data"`

--- a/packages/clients/peerbit-react/src/usePeer.tsx
+++ b/packages/clients/peerbit-react/src/usePeer.tsx
@@ -102,6 +102,11 @@ export type PeerRuntime = "node" | "canonical";
 export type NodePeerProviderConfig = {
 	runtime: "node";
 	network: "local" | "remote" | NetworkOption;
+	/**
+	 * Local per-channel upload budget for pubsub and opted-in SharedLog fanout
+	 * channels. Defaults to 5_000_000 bytes per second.
+	 */
+	pubsubUploadLimitBps?: number;
 	waitForConnected?: boolean | "in-flight";
 	keypair?: Ed25519Keypair;
 	singleton?: boolean;
@@ -496,6 +501,7 @@ export const PeerProvider = ({ config, children }: PeerProviderProps) => {
 
 			clientLog("create", { directory });
 			const created = await Peerbit.create({
+				pubsubUploadLimitBps: nodeOptions.pubsubUploadLimitBps,
 				libp2p: {
 					privateKey,
 					streamMuxers: [yamux()],

--- a/packages/clients/peerbit-react/vitest/usePeer.test.tsx
+++ b/packages/clients/peerbit-react/vitest/usePeer.test.tsx
@@ -173,7 +173,10 @@ describe("PeerProvider bootstrap handling", () => {
 		}
 	});
 
-	const renderStorageProvider = async (inMemory?: boolean) => {
+	const renderStorageProvider = async (
+		inMemory?: boolean,
+		pubsubUploadLimitBps?: number,
+	) => {
 		mocks.create.mockResolvedValue(createPeerInstance());
 
 		await act(async () => {
@@ -185,6 +188,9 @@ describe("PeerProvider bootstrap handling", () => {
 						waitForConnected: true,
 						keypair: createFakeKeypair(),
 						...(inMemory === undefined ? {} : { inMemory }),
+						...(pubsubUploadLimitBps === undefined
+							? {}
+							: { pubsubUploadLimitBps }),
 					}}
 				>
 					<StatusView />
@@ -473,6 +479,14 @@ describe("PeerProvider bootstrap handling", () => {
 		expect(mocks.persist).not.toHaveBeenCalled();
 		expect(mocks.create).toHaveBeenCalledWith(
 			expect.objectContaining({ directory: undefined }),
+		);
+	});
+
+	it("forwards the pubsub upload limit through the browser node provider", async () => {
+		await renderStorageProvider(true, 20_000_000);
+
+		expect(mocks.create).toHaveBeenCalledWith(
+			expect.objectContaining({ pubsubUploadLimitBps: 20_000_000 }),
 		);
 	});
 

--- a/packages/clients/peerbit/src/peer.ts
+++ b/packages/clients/peerbit/src/peer.ts
@@ -119,9 +119,10 @@ export type NativeWireSyncSessionLike = {
 };
 
 /**
- * Native shared-log defaults advertised to programs opened on this client
- * (the `SharedLogNativeDefaults` hook of `@peerbit/shared-log`). Structural
- * copy so the client does not depend on the shared-log package.
+ * Shared-log runtime defaults advertised to programs opened on this client
+ * (the historically named `SharedLogNativeDefaults` hook of
+ * `@peerbit/shared-log`). Structural copy so the client does not depend on the
+ * shared-log package.
  */
 export type SharedLogNativeDefaultsLike = {
 	nativeBackbone?:
@@ -136,6 +137,13 @@ export type SharedLogNativeDefaultsLike = {
 	sync?: {
 		rawExchangeHeads?: boolean;
 		nativeWireSync?: NativeWireSyncSessionLike;
+	};
+	/**
+	 * Per-channel defaults for SharedLog fanout data planes that a program opts
+	 * into. Explicit `fanout.channel` open options take precedence.
+	 */
+	fanout?: {
+		channel?: Partial<Omit<FanoutTreeChannelOptions, "role">>;
 	};
 };
 
@@ -174,6 +182,16 @@ export type CreateInstanceOptions = (SimpleLibp2pOptions | Libp2pOptions) & {
 	directory?: string;
 	indexer?: (directory?: string) => Promise<Indices> | Indices;
 	storage?: StorageCreateOptions;
+	/**
+	 * Local upload budget, in bytes per second, for each pubsub fanout channel
+	 * opened in either the root or node role. The same default also applies to
+	 * SharedLog fanout channels unless an explicit per-open
+	 * `fanout.channel.uploadLimitBps` is provided.
+	 *
+	 * This is local runtime policy and does not change any wire protocol.
+	 * Default: 5_000_000 B/s.
+	 */
+	pubsubUploadLimitBps?: number;
 	network?: NativeNetworkCreateOptions;
 	/**
 	 * Opt-in automatic bootstrap recovery. `true` uses bounded defaults; an
@@ -182,6 +200,23 @@ export type CreateInstanceOptions = (SimpleLibp2pOptions | Libp2pOptions) & {
 	 */
 	bootstrapRecovery?: boolean | BootstrapRecoveryOptions;
 } & OptionalCreateOptions;
+
+const DEFAULT_PUBSUB_UPLOAD_LIMIT_BPS = 5_000_000;
+
+const resolvePubsubUploadLimitBps = (value: unknown): number => {
+	const resolved =
+		value === undefined ? DEFAULT_PUBSUB_UPLOAD_LIMIT_BPS : value;
+	if (
+		typeof resolved !== "number" ||
+		!Number.isSafeInteger(resolved) ||
+		resolved <= 0
+	) {
+		throw new RangeError(
+			"pubsubUploadLimitBps must be a positive safe integer in bytes per second",
+		);
+	}
+	return resolved;
+};
 
 export type DialReadiness =
 	| "connection"
@@ -258,9 +293,11 @@ export class Peerbit implements ProgramClient {
 	private _bootstrapRecoveryPaused = false;
 
 	/**
-	 * Native shared-log defaults advertised to programs opened on this
-	 * client; read by `@peerbit/shared-log` (`SharedLogNativeDefaults`).
-	 * Set by `CreateInstanceOptions.network` (the `peerbit/rust` preset).
+	 * Shared-log runtime defaults advertised to programs opened on this client;
+	 * read by `@peerbit/shared-log` (`SharedLogNativeDefaults`, whose historical
+	 * name is retained for compatibility). Native defaults come from
+	 * `CreateInstanceOptions.network`; explicit pubsub upload policy contributes
+	 * the fanout channel default.
 	 */
 	public readonly sharedLogNativeDefaults?: SharedLogNativeDefaultsLike;
 
@@ -299,6 +336,37 @@ export class Peerbit implements ProgramClient {
 	}
 
 	static async create(options: CreateInstanceOptions = {}): Promise<Peerbit> {
+		const configuredPubsubUploadLimitBps = options.pubsubUploadLimitBps;
+		const pubsubUploadLimitBps = resolvePubsubUploadLimitBps(
+			configuredPubsubUploadLimitBps,
+		);
+
+		let libp2pExtended: Libp2pExtended | undefined = (options as Libp2pOptions)
+			.libp2p as Libp2pExtended;
+		const suppliedExternalLibp2p =
+			libp2pExtended && isLibp2pInstance(libp2pExtended);
+		if (configuredPubsubUploadLimitBps !== undefined) {
+			if (suppliedExternalLibp2p) {
+				throw new Error(
+					"The 'pubsubUploadLimitBps' option requires Peerbit.create to build the pubsub service; it cannot be combined with an external libp2p instance.",
+				);
+			}
+			const configuredServices = (
+				libp2pExtended as unknown as ClientCreateOptions | undefined
+			)?.services;
+			const hasOwnPubsubService =
+				configuredServices !== undefined &&
+				Object.prototype.hasOwnProperty.call(configuredServices, "pubsub");
+			const configuredPubsubService = hasOwnPubsubService
+				? (configuredServices as { pubsub?: unknown }).pubsub
+				: undefined;
+			if (configuredPubsubService !== undefined) {
+				throw new Error(
+					"The 'pubsubUploadLimitBps' option requires 'libp2p.services.pubsub' to be omitted or undefined; custom, null, and false values are not supported.",
+				);
+			}
+		}
+
 		const bootstrapRecoveryOptions = options.bootstrapRecovery;
 		if (
 			bootstrapRecoveryOptions &&
@@ -308,9 +376,6 @@ export class Peerbit implements ProgramClient {
 			validateBootstrapRecoveryOptions(bootstrapRecoveryOptions);
 		}
 		await sodium.ready; // Some of the modules depends on sodium to be readyy
-
-		let libp2pExtended: Libp2pExtended | undefined = (options as Libp2pOptions)
-			.libp2p as Libp2pExtended;
 
 		const asRelay = (options as SimpleLibp2pOptions).relay ?? true;
 
@@ -445,6 +510,19 @@ export class Peerbit implements ProgramClient {
 					}
 				}
 
+				if (configuredPubsubUploadLimitBps !== undefined) {
+					sharedLogNativeDefaults = {
+						...sharedLogNativeDefaults,
+						fanout: {
+							...sharedLogNativeDefaults?.fanout,
+							channel: {
+								...sharedLogNativeDefaults?.fanout?.channel,
+								uploadLimitBps: pubsubUploadLimitBps,
+							},
+						},
+					};
+				}
+
 				const topicRootControlPlane = new TopicRootControlPlane();
 
 				// Keep a single FanoutTree instance per peer so pubsub sharding + provider
@@ -466,6 +544,24 @@ export class Peerbit implements ProgramClient {
 				};
 
 				const blockProviderNamespace = (cid: string) => `cid:${cid}`;
+
+				const createDefaultPubsubService = (c: any) =>
+					new TopicControlPlane(c, {
+						canRelayMessage: asRelay,
+						topicRootControlPlane,
+						fanout: getOrCreateFanout(c),
+						fanoutRootChannel: {
+							uploadLimitBps: pubsubUploadLimitBps,
+						},
+						fanoutNodeChannel: {
+							uploadLimitBps: pubsubUploadLimitBps,
+						},
+						rustCore: nativeNetwork?.rustCore,
+						// The wire-sync session decodes+verifies inbound
+						// frames natively and stashes shared-log raw
+						// exchange-head payloads for the fused receive.
+						nativeWire: nativeNetwork?.wireSync,
+					});
 
 				const services: any = {
 					keychain: (components: KeychainComponents) =>
@@ -555,18 +651,14 @@ export class Peerbit implements ProgramClient {
 						});
 						return blocksService;
 					},
-					pubsub: (c: any) =>
-						new TopicControlPlane(c, {
-							canRelayMessage: asRelay,
-							topicRootControlPlane,
-							fanout: getOrCreateFanout(c),
-							rustCore: nativeNetwork?.rustCore,
-							// The wire-sync session decodes+verifies inbound
-							// frames natively and stashes shared-log raw
-							// exchange-head payloads for the fused receive.
-							nativeWire: nativeNetwork?.wireSync,
-						}),
+					pubsub: createDefaultPubsubService,
 					...extendedOptions?.services,
+					// With an explicit upload policy, an own `pubsub: undefined`
+					// is treated as absent. Re-apply our factory after the spread
+					// so the configured limit cannot be silently bypassed.
+					...(configuredPubsubUploadLimitBps !== undefined
+						? { pubsub: createDefaultPubsubService }
+						: {}),
 				};
 
 			if (!asRelay) {

--- a/packages/clients/peerbit/test/connect.spec.ts
+++ b/packages/clients/peerbit/test/connect.spec.ts
@@ -17,6 +17,44 @@ describe(`dial`, function () {
 	});
 
 	if (isNode) {
+		it("applies the configured upload limit to live root and node shard channels", async function () {
+			this.timeout(60_000);
+			const root = await Peerbit.create({
+				pubsubUploadLimitBps: 20_000_000,
+			});
+			const node = await Peerbit.create({
+				pubsubUploadLimitBps: 20_000_000,
+			});
+
+			try {
+				await node.dial(root.getMultiaddrs()[0]!);
+				const rootHash = root.services.fanout.publicKeyHash;
+				root.services.pubsub.setTopicRootCandidates([rootHash]);
+				node.services.pubsub.setTopicRootCandidates([rootHash]);
+				node.services.fanout.setBootstraps(root.getMultiaddrs());
+
+				const topic = "configured-upload-limit";
+				await root.services.pubsub.subscribe(topic);
+				await node.services.pubsub.subscribe(topic);
+				const shardTopic = (
+					root.services.pubsub as any
+				).getShardTopicForUserTopic(topic);
+
+				await waitForResolved(() => {
+					expect(
+						root.services.fanout.getChannelStats(shardTopic, rootHash)
+							?.uploadLimitBps,
+					).to.equal(20_000_000);
+					expect(
+						node.services.fanout.getChannelStats(shardTopic, rootHash)
+							?.uploadLimitBps,
+					).to.equal(20_000_000);
+				});
+			} finally {
+				await Promise.all([root.stop(), node.stop()]);
+			}
+		});
+
 		it("waits for blocks", async () => {
 			const cid = await clients[0].services.blocks.put(new Uint8Array([1]));
 			await clients[1].dial(clients[0].getMultiaddrs()[0]);

--- a/packages/clients/peerbit/test/create.ts
+++ b/packages/clients/peerbit/test/create.ts
@@ -137,6 +137,160 @@ describe("Create", function () {
 		}
 	});
 
+	it("uses the default pubsub upload limit for root and node fanout channels", async () => {
+		const client = await Peerbit.create();
+		try {
+			const pubsub = client.services.pubsub as any;
+			expect(pubsub.fanoutRootChannelOptions.uploadLimitBps).to.equal(
+				5_000_000,
+			);
+			expect(pubsub.fanoutNodeChannelOptions.uploadLimitBps).to.equal(
+				5_000_000,
+			);
+			expect(client.sharedLogNativeDefaults).to.equal(undefined);
+		} finally {
+			await client.stop();
+		}
+	});
+
+	it("propagates an explicit pubsub upload limit to all local fanout defaults", async () => {
+		const client = await Peerbit.create({
+			pubsubUploadLimitBps: 20_000_000,
+		});
+		try {
+			const pubsub = client.services.pubsub as any;
+			expect(pubsub.fanoutRootChannelOptions.uploadLimitBps).to.equal(
+				20_000_000,
+			);
+			expect(pubsub.fanoutNodeChannelOptions.uploadLimitBps).to.equal(
+				20_000_000,
+			);
+			expect(
+				client.sharedLogNativeDefaults?.fanout?.channel?.uploadLimitBps,
+			).to.equal(20_000_000);
+		} finally {
+			await client.stop();
+		}
+	});
+
+	it("rejects invalid pubsub upload limits before creating a client", async () => {
+		for (const value of [
+			0,
+			-1,
+			null as unknown as number,
+			Number.NaN,
+			Number.POSITIVE_INFINITY,
+			Number.NEGATIVE_INFINITY,
+			1.5,
+			Number.MAX_SAFE_INTEGER + 1,
+		]) {
+			await expect(
+				Peerbit.create({ pubsubUploadLimitBps: value }),
+			).to.be.rejectedWith(
+				RangeError,
+				"pubsubUploadLimitBps must be a positive safe integer",
+			);
+		}
+	});
+
+	it("normalizes an own undefined pubsub service as absent", async () => {
+		const client = await Peerbit.create({
+			pubsubUploadLimitBps: 20_000_000,
+			libp2p: {
+				services: {
+					pubsub: undefined,
+				},
+			},
+		});
+		try {
+			const pubsub = client.services.pubsub as any;
+			expect(pubsub).to.exist;
+			expect(pubsub.fanoutRootChannelOptions.uploadLimitBps).to.equal(
+				20_000_000,
+			);
+			expect(pubsub.fanoutNodeChannelOptions.uploadLimitBps).to.equal(
+				20_000_000,
+			);
+		} finally {
+			await client.stop();
+		}
+	});
+
+	it("accepts the positive safe-integer pubsub upload limit boundaries", async () => {
+		for (const value of [1, Number.MAX_SAFE_INTEGER]) {
+			const client = await Peerbit.create({ pubsubUploadLimitBps: value });
+			try {
+				expect(
+					(client.services.pubsub as any).fanoutRootChannelOptions
+						.uploadLimitBps,
+				).to.equal(value);
+				expect(
+					(client.services.pubsub as any).fanoutNodeChannelOptions
+						.uploadLimitBps,
+				).to.equal(value);
+			} finally {
+				await client.stop();
+			}
+		}
+	});
+
+	it("rejects a pubsub upload limit that an external libp2p would ignore", async () => {
+		const external = await Peerbit.create();
+		try {
+			await expect(
+				Peerbit.create({
+					libp2p: external.libp2p,
+					pubsubUploadLimitBps: 20_000_000,
+				}),
+			).to.be.rejectedWith(
+				Error,
+				"The 'pubsubUploadLimitBps' option requires Peerbit.create to build the pubsub service",
+			);
+		} finally {
+			await external.stop();
+		}
+	});
+
+	it("rejects defined pubsub service overrides before opening resources", async () => {
+		for (const [label, pubsub] of [
+			["custom", (): undefined => undefined],
+			["null", null],
+			["false", false],
+		] as const) {
+			const clientDirectory = path.join(
+				"tmp",
+				"peerbit",
+				"tests",
+				`create-reject-pubsub-${label}-${uuid()}`,
+			);
+			let storeFactoryCalls = 0;
+			await expect(
+				Peerbit.create({
+					directory: clientDirectory,
+					pubsubUploadLimitBps: 20_000_000,
+					libp2p: {
+						services: { pubsub } as any,
+					},
+					storage: {
+						storeFactory: (directory) => {
+							storeFactoryCalls++;
+							return createStore(directory);
+						},
+					},
+				}),
+			).to.be.rejectedWith(
+				Error,
+				"The 'pubsubUploadLimitBps' option requires 'libp2p.services.pubsub' to be omitted or undefined",
+			);
+			expect(storeFactoryCalls, label).to.equal(0);
+
+			// A retry proves the rejected call did not leave any directory store
+			// open or locked.
+			const retry = await Peerbit.create({ directory: clientDirectory });
+			await retry.stop();
+		}
+	});
+
 	it("throws when network options are combined with an external libp2p", async () => {
 		const external = await Peerbit.create();
 		try {

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2575,20 +2575,48 @@ export type SharedLogOptions<
 };
 
 /**
- * Native defaults a client can advertise for shared-log programs opened on
- * it (the peerbit client's native network preset sets these; see
- * `peerbit/rust`). They fill in open options the caller left undefined;
- * explicit per-open options (including `false`) always win. Without the
- * property on the client, behavior is unchanged.
+ * Runtime defaults a client can advertise for shared-log programs opened on
+ * it. The historical name is retained because the peerbit native network
+ * preset introduced this hook. Defaults fill in open options the caller left
+ * undefined; explicit per-open options (including `false`) always win.
+ * Without the property on the client, behavior is unchanged.
  */
 export type SharedLogNativeDefaults = {
 	nativeBackbone?: SharedLogOptions<any, any, any>["nativeBackbone"];
 	nativeGraph?: LogProperties<any>["nativeGraph"];
 	sync?: Pick<SyncOptions<any>, "rawExchangeHeads" | "nativeWireSync">;
+	/**
+	 * Per-channel defaults applied only when the caller opts into SharedLog
+	 * fanout. Explicit per-open channel options take precedence.
+	 */
+	fanout?: Pick<SharedLogFanoutOptions, "channel">;
 };
 
 type NodeWithSharedLogNativeDefaults = {
 	sharedLogNativeDefaults?: SharedLogNativeDefaults;
+};
+
+type SharedLogFanoutChannelOptions = NonNullable<
+	SharedLogFanoutOptions["channel"]
+>;
+
+const mergeDefinedFanoutChannelOptions = (
+	...sources: Array<SharedLogFanoutChannelOptions | undefined>
+): SharedLogFanoutChannelOptions | undefined => {
+	let merged: Record<string, unknown> | undefined;
+	for (const source of sources) {
+		if (!source) {
+			continue;
+		}
+		for (const [key, value] of Object.entries(source)) {
+			if (value === undefined) {
+				continue;
+			}
+			merged ??= {};
+			merged[key] = value;
+		}
+	}
+	return merged as SharedLogFanoutChannelOptions | undefined;
 };
 
 const applySharedLogNativeDefaults = <
@@ -2596,6 +2624,7 @@ const applySharedLogNativeDefaults = <
 		nativeBackbone?: SharedLogOptions<any, any, any>["nativeBackbone"];
 		nativeGraph?: LogProperties<any>["nativeGraph"];
 		sync?: SyncOptions<any>;
+		fanout?: SharedLogFanoutOptions;
 	},
 >(
 	options: O | undefined,
@@ -2614,11 +2643,21 @@ const applySharedLogNativeDefaults = <
 						options?.sync?.nativeWireSync ?? defaults.sync?.nativeWireSync,
 				}
 			: undefined;
+	const fanout = options?.fanout
+		? {
+				...options.fanout,
+				channel: mergeDefinedFanoutChannelOptions(
+					defaults.fanout?.channel,
+					options.fanout.channel,
+				),
+			}
+		: undefined;
 	return {
 		...options,
 		nativeBackbone: options?.nativeBackbone ?? defaults.nativeBackbone,
 		nativeGraph: options?.nativeGraph ?? defaults.nativeGraph,
 		sync,
+		fanout,
 	} as O;
 };
 

--- a/packages/programs/data/shared-log/test/delivery.spec.ts
+++ b/packages/programs/data/shared-log/test/delivery.spec.ts
@@ -10,6 +10,7 @@ import { TestSession } from "@peerbit/test-utils";
 import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
 import pDefer from "p-defer";
+import { Peerbit } from "peerbit";
 import { ExchangeHeadsMessage } from "../src/exchange-heads.js";
 import { NoPeersError } from "../src/index.js";
 import { EventStore } from "./utils/stores/index.js";
@@ -27,6 +28,127 @@ describe("append delivery options", () => {
 
 	afterEach(async () => {
 		await session?.stop();
+	});
+
+	it("carries the top-level client upload limit into an opened SharedLog fanout channel", async () => {
+		const peer = await Peerbit.create({
+			pubsubUploadLimitBps: 20_000_000,
+		});
+		try {
+			const fanout = peer.services.fanout;
+			const root = fanout.publicKeyHash;
+			const store = await peer.open(new EventStore<string, any>(), {
+				args: { fanout: { root } },
+			});
+			const channel = (store.log as any)._fanoutChannel;
+
+			expect(
+				fanout.getChannelStats(channel.topic, channel.root)?.uploadLimitBps,
+			).to.equal(20_000_000);
+		} finally {
+			await peer.stop();
+		}
+	});
+
+	it("merges defined fanout channel overrides without mutation or implicit opt-in", async () => {
+		session = await TestSession.connected(1);
+		const peer = session.peers[0] as any;
+		const defaults = {
+			fanout: {
+				channel: {
+					uploadLimitBps: 20_000_000,
+					msgRate: 30,
+					repair: true,
+				},
+			},
+		};
+		const defaultsSnapshot = structuredClone(defaults);
+		peer.sharedLogNativeDefaults = defaults;
+		const fanout = getDeliveryServices(session.peers[0]).fanout;
+		const root = fanout.publicKeyHash;
+
+		const inherited = await peer.open(new EventStore<string, any>(), {
+			args: { fanout: { root } },
+		});
+		const inheritedChannel = (inherited.log as any)._fanoutChannel;
+		expect(
+			fanout.getChannelStats(inheritedChannel.topic, inheritedChannel.root)
+				?.uploadLimitBps,
+		).to.equal(20_000_000);
+
+		const numbered = await peer.open(new EventStore<string, any>(), {
+			args: {
+				fanout: { root, channel: { uploadLimitBps: 7_000_000 } },
+			},
+		});
+		const numberedChannel = (numbered.log as any)._fanoutChannel;
+		expect(
+			fanout.getChannelStats(numberedChannel.topic, numberedChannel.root)
+				?.uploadLimitBps,
+		).to.equal(7_000_000);
+
+		const zeroAndFalseArgs = {
+			fanout: {
+				root,
+				channel: {
+					uploadLimitBps: 0,
+					msgRate: undefined,
+					repair: false,
+				},
+			},
+		};
+		const zeroAndFalseSnapshot = structuredClone(zeroAndFalseArgs);
+		const zeroAndFalse = await peer.open(new EventStore<string, any>(), {
+			args: zeroAndFalseArgs,
+		});
+		const zeroAndFalseChannel = (zeroAndFalse.log as any)._fanoutChannel;
+		const zeroAndFalseProperties = (zeroAndFalse.log as any)._logProperties
+			.fanout.channel;
+		expect(
+			fanout.getChannelStats(
+				zeroAndFalseChannel.topic,
+				zeroAndFalseChannel.root,
+			)?.uploadLimitBps,
+		).to.equal(0);
+		expect(zeroAndFalseProperties.msgRate).to.equal(30);
+		expect(zeroAndFalseProperties.repair).to.equal(false);
+
+		const undefinedOverrideArgs = {
+			fanout: { root, channel: { uploadLimitBps: undefined } },
+		};
+		const undefinedOverride = await peer.open(new EventStore<string, any>(), {
+			args: undefinedOverrideArgs,
+		});
+		const undefinedOverrideChannel = (undefinedOverride.log as any)
+			._fanoutChannel;
+		expect(
+			fanout.getChannelStats(
+				undefinedOverrideChannel.topic,
+				undefinedOverrideChannel.root,
+			)?.uploadLimitBps,
+		).to.equal(20_000_000);
+		expect(
+			Object.prototype.hasOwnProperty.call(
+				undefinedOverrideArgs.fanout.channel,
+				"uploadLimitBps",
+			),
+		).to.equal(true);
+		expect(undefinedOverrideArgs.fanout.channel.uploadLimitBps).to.equal(
+			undefined,
+		);
+
+		const noFanout = await peer.open(new EventStore<string, any>());
+		expect((noFanout.log as any)._fanoutChannel).to.equal(undefined);
+		expect((noFanout.log as any)._logProperties.fanout).to.equal(undefined);
+
+		expect(defaults).to.deep.equal(defaultsSnapshot);
+		expect(zeroAndFalseArgs).to.deep.equal(zeroAndFalseSnapshot);
+		expect((zeroAndFalse.log as any)._logProperties.fanout).not.to.equal(
+			zeroAndFalseArgs.fanout,
+		);
+		expect(zeroAndFalseProperties).not.to.equal(
+			zeroAndFalseArgs.fanout.channel,
+		);
 	});
 
 	it("awaits transport acks and applies an explicit priority for target=replicators", async () => {


### PR DESCRIPTION
## Summary

- add a validated `pubsubUploadLimitBps` option to `Peerbit.create` and the React `PeerProvider`
- apply it consistently to root and node pubsub fanout channels
- inherit it as an overridable default only when SharedLog fanout is explicitly enabled
- reject invalid values and service configurations that would otherwise ignore the option

This is local runtime policy only. It does not change a wire protocol, and it does not control DirectBlock file bytes or claim to fix file-transfer throughput.

## Validation

- Peerbit Node: 105 passing, 1 existing pending
- React: 43 passing
- focused SharedLog inheritance and live-channel integration: 2 passing
- affected package builds and changeset validation pass
- independent post-fix review: approved

Tests cover numeric inheritance and override, `0`, `false`, `undefined`, `null`, immutability, no implicit fanout opt-in, custom-service rejection before resource acquisition, and a real top-level option to opened SharedLog channel path.