### PR TITLE
perf(peerbit): negotiate larger Yamux windows

### DIFF
--- a/.changeset/warm-streams-flow.md
+++ b/.changeset/warm-streams-flow.md
@@ -1,0 +1,9 @@
+---
+"peerbit": patch
+"@peerbit/react": patch
+---
+
+Negotiate a Peerbit Yamux profile with a 4 MiB initial stream window between
+updated peers, while retaining standard Yamux fallback for older peers. This
+removes repeated flow-control stalls during concurrent large block responses
+without breaking mixed-version connections.

--- a/packages/clients/peerbit-react/package.json
+++ b/packages/clients/peerbit-react/package.json
@@ -49,7 +49,6 @@
 	},
 	"dependencies": {
 		"@chainsafe/libp2p-noise": "^17.0.0",
-		"@chainsafe/libp2p-yamux": "^8.0.1",
 		"@dao-xyz/borsh": "^6.0.0",
 		"@libp2p/circuit-relay-v2": "^4.1.7",
 		"@libp2p/crypto": "^5.1.14",

--- a/packages/clients/peerbit-react/src/usePeer.tsx
+++ b/packages/clients/peerbit-react/src/usePeer.tsx
@@ -327,9 +327,13 @@ export const PeerProvider = ({ config, children }: PeerProviderProps) => {
 			const [
 				{ detectIncognito },
 				sodiumModule,
-				{ Peerbit, getBootstrapPeerId, resolveBootstrapAddresses },
+				{
+					Peerbit,
+					createPeerbitStreamMuxers,
+					getBootstrapPeerId,
+					resolveBootstrapAddresses,
+				},
 				{ noise },
-				{ yamux },
 				{ webSockets },
 				{ circuitRelayTransport },
 				{ webRTC },
@@ -339,7 +343,6 @@ export const PeerProvider = ({ config, children }: PeerProviderProps) => {
 				import("libsodium-wrappers"),
 				import("peerbit"),
 				import("@chainsafe/libp2p-noise"),
-				import("@chainsafe/libp2p-yamux"),
 				import("@libp2p/websockets"),
 				import("@libp2p/circuit-relay-v2"),
 				import("@libp2p/webrtc"),
@@ -498,7 +501,7 @@ export const PeerProvider = ({ config, children }: PeerProviderProps) => {
 			const created = await Peerbit.create({
 				libp2p: {
 					privateKey,
-					streamMuxers: [yamux()],
+					streamMuxers: createPeerbitStreamMuxers(),
 					connectionEncrypters: [noise()],
 					connectionManager: { maxConnections: 100 },
 					connectionMonitor: { enabled: false },

--- a/packages/clients/peerbit-react/vitest/usePeer.test.tsx
+++ b/packages/clients/peerbit-react/vitest/usePeer.test.tsx
@@ -23,7 +23,8 @@ const mocks = vi.hoisted(() => {
 		]),
 		privateKeyFromRaw: vi.fn(() => ({})),
 		noise: vi.fn(() => ({})),
-		yamux: vi.fn(() => ({})),
+		streamMuxers: [vi.fn(), vi.fn()],
+		createPeerbitStreamMuxers: vi.fn(),
 		webSockets: vi.fn(() => ({})),
 	};
 });
@@ -41,16 +42,13 @@ vi.mock("peerbit", () => ({
 	Peerbit: {
 		create: mocks.create,
 	},
+	createPeerbitStreamMuxers: mocks.createPeerbitStreamMuxers,
 	getBootstrapPeerId: mocks.getBootstrapPeerId,
 	resolveBootstrapAddresses: mocks.resolveBootstrapAddresses,
 }));
 
 vi.mock("@chainsafe/libp2p-noise", () => ({
 	noise: mocks.noise,
-}));
-
-vi.mock("@chainsafe/libp2p-yamux", () => ({
-	yamux: mocks.yamux,
 }));
 
 vi.mock("@libp2p/websockets", () => ({
@@ -137,6 +135,8 @@ describe("PeerProvider bootstrap handling", () => {
 	let originalStorage: PropertyDescriptor | undefined;
 
 	beforeEach(() => {
+		mocks.createPeerbitStreamMuxers.mockReset();
+		mocks.createPeerbitStreamMuxers.mockReturnValue(mocks.streamMuxers);
 		container = document.createElement("div");
 		document.body.appendChild(container);
 		root = ReactDOM.createRoot(container);
@@ -380,6 +380,19 @@ describe("PeerProvider bootstrap handling", () => {
 			"Browser storage is not protected from eviction; continuing with OPFS-backed storage.",
 		);
 		expect((window as any).__peerInfo.persisted).toBe(false);
+	});
+
+	it("uses the shared Peerbit stream-muxer profile", async () => {
+		await renderStorageProvider();
+
+		expect(mocks.createPeerbitStreamMuxers).toHaveBeenCalledTimes(1);
+		expect(mocks.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				libp2p: expect.objectContaining({
+					streamMuxers: mocks.streamMuxers,
+				}),
+			}),
+		);
 	});
 
 	it("reports granted eviction protection while using OPFS", async () => {

--- a/packages/clients/peerbit/src/index.ts
+++ b/packages/clients/peerbit/src/index.ts
@@ -3,6 +3,10 @@ export * from "./bootstrap.js";
 export type { BootstrapRecoveryOptions } from "./bootstrap-recovery.js";
 export {
 	createLibp2pExtended,
+	createPeerbitStreamMuxers,
+	PEERBIT_YAMUX_PROTOCOL,
+	PEERBIT_YAMUX_INITIAL_STREAM_WINDOW_SIZE,
+	PEERBIT_YAMUX_MAX_STREAM_WINDOW_SIZE,
 	type Libp2pExtendServices,
 	type Libp2pExtended,
 	type Libp2pCreateOptions,

--- a/packages/clients/peerbit/src/libp2p.ts
+++ b/packages/clients/peerbit/src/libp2p.ts
@@ -2,12 +2,14 @@ import { noise } from "@chainsafe/libp2p-noise";
 import { yamux } from "@chainsafe/libp2p-yamux";
 import type { CircuitRelayService } from "@libp2p/circuit-relay-v2";
 import { identify } from "@libp2p/identify";
+import type { StreamMuxerFactory } from "@libp2p/interface";
 import { DirectBlock } from "@peerbit/blocks";
+import { type IPeerbitKeychain, keychain } from "@peerbit/keychain";
 import {
-	type IPeerbitKeychain,
-	keychain,
-} from "@peerbit/keychain";
-import { FanoutTree, TopicControlPlane, TopicRootControlPlane } from "@peerbit/pubsub";
+	FanoutTree,
+	TopicControlPlane,
+	TopicRootControlPlane,
+} from "@peerbit/pubsub";
 import {
 	type Libp2p,
 	type Libp2pOptions,
@@ -38,6 +40,43 @@ export type Libp2pCreateOptionsWithServices = Libp2pCreateOptions & {
 	services: ServiceFactoryMap<Libp2pExtendServices>;
 };
 
+/**
+ * Yamux profile negotiated between Peerbit peers that starts each logical
+ * stream with enough credit for the default eight concurrent 512 KiB block
+ * responses.
+ *
+ * This must use a distinct protocol id. `@chainsafe/libp2p-yamux` applies a
+ * configured initial window to both send and receive credit without
+ * advertising it on `/yamux/1.0.0`, so using a larger value under the standard
+ * id can overrun an older peer's 256 KiB receive window. Keeping standard
+ * Yamux as the second choice preserves mixed-version interoperability.
+ */
+export const PEERBIT_YAMUX_PROTOCOL = "/peerbit/yamux/1.0.0";
+export const PEERBIT_YAMUX_INITIAL_STREAM_WINDOW_SIZE = 4 * 1024 * 1024;
+export const PEERBIT_YAMUX_MAX_STREAM_WINDOW_SIZE = 16 * 1024 * 1024;
+
+export const createPeerbitStreamMuxers = (): Array<
+	() => StreamMuxerFactory
+> => [
+	() => {
+		const factory = yamux({
+			streamOptions: {
+				initialStreamWindowSize: PEERBIT_YAMUX_INITIAL_STREAM_WINDOW_SIZE,
+				maxStreamWindowSize: PEERBIT_YAMUX_MAX_STREAM_WINDOW_SIZE,
+			},
+		})();
+		const createStreamMuxer = factory.createStreamMuxer.bind(factory);
+		factory.protocol = PEERBIT_YAMUX_PROTOCOL;
+		factory.createStreamMuxer = (connection) => {
+			const muxer = createStreamMuxer(connection);
+			muxer.protocol = PEERBIT_YAMUX_PROTOCOL;
+			return muxer;
+		};
+		return factory;
+	},
+	yamux(),
+];
+
 export const createLibp2pExtended = (
 	opts: PartialLibp2pCreateOptions = {},
 ): Promise<Libp2pExtended> => {
@@ -46,7 +85,8 @@ export const createLibp2pExtended = (
 	let fanoutInstance: FanoutTree | undefined;
 	const configuredFanoutFactory =
 		opts.services?.fanout ||
-		((c) => new FanoutTree(c, { connectionManager: false, topicRootControlPlane }));
+		((c) =>
+			new FanoutTree(c, { connectionManager: false, topicRootControlPlane }));
 	const getOrCreateFanout = (c: any) => {
 		if (!fanoutInstance) {
 			fanoutInstance = configuredFanoutFactory(c) as FanoutTree;
@@ -88,7 +128,7 @@ export const createLibp2pExtended = (
 
 		transports: opts.transports || transports(),
 		connectionEncrypters: opts.connectionEncrypters || [noise()],
-		streamMuxers: opts.streamMuxers || [yamux()],
+		streamMuxers: opts.streamMuxers || createPeerbitStreamMuxers(),
 		services: {
 			...opts.services,
 			pubsub:

--- a/packages/clients/peerbit/test/yamux.spec.ts
+++ b/packages/clients/peerbit/test/yamux.spec.ts
@@ -1,0 +1,106 @@
+import { yamux } from "@chainsafe/libp2p-yamux";
+import { sha256Sync } from "@peerbit/crypto";
+import { expect } from "chai";
+import {
+	PEERBIT_YAMUX_PROTOCOL,
+	Peerbit,
+	createPeerbitStreamMuxers,
+} from "../src/index.js";
+
+const STANDARD_YAMUX_PROTOCOL = "/yamux/1.0.0";
+const isNode = typeof process !== "undefined" && !!process.versions?.node;
+
+const deterministicBlock = (size: number): Uint8Array => {
+	const bytes = new Uint8Array(size);
+	for (let i = 0; i < bytes.length; i++) {
+		bytes[i] = (i * 31 + (i >>> 8) * 17 + 23) & 0xff;
+	}
+	return bytes;
+};
+
+const connectionMuxer = (
+	client: Peerbit,
+	remote: Peerbit,
+): string | undefined =>
+	client.libp2p
+		.getConnections()
+		.find((connection) => connection.remotePeer.equals(remote.peerId))
+		?.multiplexer;
+
+const expectBlockTransfer = async (provider: Peerbit, reader: Peerbit) => {
+	const source = deterministicBlock(5 * 1024 * 1024 + 17);
+	const cid = await provider.services.blocks.put(source);
+	const received = await reader.services.blocks.get(cid, {
+		remote: {
+			from: [provider.services.blocks.publicKeyHash],
+			timeout: 60_000,
+		},
+	});
+
+	expect(received).to.exist;
+	expect(received!.byteLength).to.equal(source.byteLength);
+	expect([...sha256Sync(received!)]).to.deep.equal([...sha256Sync(source)]);
+};
+
+describe("Peerbit Yamux profile", function () {
+	it("offers the Peerbit profile before standard Yamux", () => {
+		const factories = createPeerbitStreamMuxers();
+		expect(factories.map((factory) => factory().protocol)).to.deep.equal([
+			PEERBIT_YAMUX_PROTOCOL,
+			STANDARD_YAMUX_PROTOCOL,
+		]);
+	});
+
+	if (!isNode) return;
+
+	it("negotiates the larger-window profile between updated peers", async function () {
+		this.timeout(90_000);
+		const peers = [
+			await Peerbit.create({ relay: false }),
+			await Peerbit.create({ relay: false }),
+		] as const;
+
+		try {
+			await peers[0].dial(peers[1].getMultiaddrs()[0]!);
+			expect(connectionMuxer(peers[0], peers[1])).to.equal(
+				PEERBIT_YAMUX_PROTOCOL,
+			);
+			expect(connectionMuxer(peers[1], peers[0])).to.equal(
+				PEERBIT_YAMUX_PROTOCOL,
+			);
+			await expectBlockTransfer(peers[0], peers[1]);
+		} finally {
+			await Promise.all(peers.map((peer) => peer.stop()));
+		}
+	});
+
+	for (const legacyDialer of [false, true]) {
+		it(`falls back safely when the ${legacyDialer ? "legacy" : "updated"} peer dials`, async function () {
+			this.timeout(120_000);
+			const updated = await Peerbit.create({ relay: false });
+			const legacy = await Peerbit.create({
+				relay: false,
+				libp2p: { streamMuxers: [yamux()] },
+			});
+
+			try {
+				const dialer = legacyDialer ? legacy : updated;
+				const listener = legacyDialer ? updated : legacy;
+				await dialer.dial(listener.getMultiaddrs()[0]!);
+				expect(connectionMuxer(updated, legacy)).to.equal(
+					STANDARD_YAMUX_PROTOCOL,
+				);
+				expect(connectionMuxer(legacy, updated)).to.equal(
+					STANDARD_YAMUX_PROTOCOL,
+				);
+
+				// Exercise the standard 256 KiB flow-control path in both data
+				// directions with responses larger than either initial window.
+				await expectBlockTransfer(updated, legacy);
+				await expectBlockTransfer(legacy, updated);
+			} finally {
+				await Promise.all([updated.stop(), legacy.stop()]);
+			}
+		});
+	}
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -524,9 +524,6 @@ importers:
       '@chainsafe/libp2p-noise':
         specifier: ^17.0.0
         version: 17.0.0
-      '@chainsafe/libp2p-yamux':
-        specifier: ^8.0.1
-        version: 8.0.1
       '@dao-xyz/borsh':
         specifier: 6.0.1
         version: 6.0.1


### PR DESCRIPTION
## Summary

- negotiate a Peerbit-specific Yamux profile with a 4 MiB initial stream window
- keep standard `/yamux/1.0.0` as a fallback for mixed-version connections
- reuse the same muxer profile in `@peerbit/react`
- verify enhanced negotiation, both legacy dial directions, and SHA-256 integrity for responses larger than either initial window

## Why

DirectBlock serves concurrent large block responses over one Yamux stream. With the standard 256 KiB initial window, repeated flow-control stalls limited the file-share observer path to roughly 10 MiB/s. Eight concurrent 512 KiB responses make 4 MiB the measured knee.

Using a larger window under the standard Yamux protocol would be unsafe with older peers because the current Chainsafe implementation applies configured credit on both sides without advertising it. The distinct `/peerbit/yamux/1.0.0` protocol prevents that mixed-version receive-window mismatch; the standard protocol remains the second negotiation choice.

## Browser benchmark

Exact deterministic 256 MiB file-share observer case, hash-only sink, 256 local chunks plus 256 remote chunks:

- full stream: 16.145 s -> 12.183 s (24.5% less time)
- remote half: 12.606 s -> 8.797 s (30.2% less time)
- remote-half throughput: 10.15 -> 14.55 MiB/s
- all 512 chunks completed in one attempt
- exact SHA-256 and CRC-32 passed
- zero request, transfer, batch, collection, or topology errors
- reader retained heap increased by 1.07 MiB; full telemetry and cleanup gates passed

The two network-only 64 MiB windows were within about 9.5% throughput, with no progressive late-transfer collapse.

## Validation

- peerbit build
- @peerbit/react build
- peerbit Node suite: 94 passing, 1 pending
- @peerbit/react suite: 43 passing
- Peerbit Yamux integration tests: 4 passing, including updated-to-legacy and legacy-to-updated fallback
- changeset status and frozen lockfile checks
- independent code review approved

## Follow-up

A slow-link/control-traffic fairness benchmark can quantify transient head-of-line latency from earlier large DATA frames. This is not a compatibility blocker: standard fallback is retained, file-share messages remain about 512 KiB, and adaptive Yamux already permits growth up to 16 MiB.