### PR TITLE
fix(stream): prune duplicate outbound candidates

### DIFF
--- a/.changeset/steady-stream-candidates.md
+++ b/.changeset/steady-stream-candidates.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/stream": patch
+---
+
+Keep distinct outbound streams when mux-local IDs collide, and reliably reschedule candidate pruning as connections arrive during the grace period.

--- a/packages/transport/stream/src/index.ts
+++ b/packages/transport/stream/src/index.ts
@@ -529,12 +529,13 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 		if (this.outboundStreams.length <= 1) return;
 		if (reset && this._outboundPruneTimer) {
 			clearTimeout(this._outboundPruneTimer);
+			this._outboundPruneTimer = undefined;
 		}
 		if (!this._outboundPruneTimer) {
-			this._outboundPruneTimer = setTimeout(
-				() => this.pruneOutboundCandidates(),
-				PeerStreams.OUTBOUND_GRACE_MS,
-			);
+			this._outboundPruneTimer = setTimeout(() => {
+				this._outboundPruneTimer = undefined;
+				this.pruneOutboundCandidates();
+			}, PeerStreams.OUTBOUND_GRACE_MS);
 		}
 	}
 	constructor(init: PeerStreamsInit) {
@@ -926,8 +927,9 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
 	 */
 
 	async attachOutboundStream(stream: Stream) {
-		if (this.outboundStreams[0] && stream.id === this.outboundStreams[0].raw.id)
+		if (this.outboundStreams.some((candidate) => candidate.raw === stream)) {
 			return; // duplicate
+		}
 		this._addOutboundCandidate(stream);
 		if (this.outboundStreams.length === 1) {
 			this.dispatchEvent(new CustomEvent("stream:outbound"));

--- a/packages/transport/stream/test/priority-lanes.spec.ts
+++ b/packages/transport/stream/test/priority-lanes.spec.ts
@@ -6,13 +6,19 @@ import {
 } from "@peerbit/stream-interface";
 import { AbortError, delay, waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
+import sinon from "sinon";
 import { PeerStreams } from "../src/index.js";
 
 class TestOutboundStream extends EventTarget {
-	id = "test-outbound";
+	id: string;
 	sentPayloads: number[] = [];
 	private expectedLength?: number;
 	private currentPayloadLength = 0;
+
+	constructor(id = "test-outbound") {
+		super();
+		this.id = id;
+	}
 
 	send(bytes: Uint8Array): boolean {
 		let completedFrame = false;
@@ -40,6 +46,71 @@ class TestOutboundStream extends EventTarget {
 }
 
 describe("priority lanes", () => {
+	it("distinguishes outbound streams with the same mux-local id", async () => {
+		const keypair = await Ed25519Keypair.create();
+		const streams = new PeerStreams({
+			peerId: { toString: () => "test-peer" } as unknown as PeerId,
+			publicKey: keypair.publicKey,
+			protocol: "/test",
+			connId: "test-conn",
+		});
+		const first = new TestOutboundStream();
+		const second = new TestOutboundStream();
+
+		try {
+			expect(first.id).to.equal(second.id);
+
+			await streams.attachOutboundStream(first as any);
+			await streams.attachOutboundStream(first as any);
+			expect(streams.rawOutboundStreams).to.have.length(1);
+			expect(streams.rawOutboundStreams[0]).to.equal(first);
+
+			await streams.attachOutboundStream(second as any);
+			await streams.attachOutboundStream(second as any);
+			expect(streams.rawOutboundStreams).to.have.length(2);
+			expect(streams.rawOutboundStreams[0]).to.equal(first);
+			expect(streams.rawOutboundStreams[1]).to.equal(second);
+		} finally {
+			await streams.close();
+		}
+	});
+
+	it("reschedules outbound pruning when candidates arrive during the grace period", async () => {
+		const keypair = await Ed25519Keypair.create();
+		const clock = sinon.useFakeTimers();
+		const streams = new PeerStreams({
+			peerId: { toString: () => "test-peer" } as unknown as PeerId,
+			publicKey: keypair.publicKey,
+			protocol: "/test",
+			connId: "test-conn",
+		});
+		const first = new TestOutboundStream("first");
+		const second = new TestOutboundStream("second");
+		const third = new TestOutboundStream("third");
+		const fourth = new TestOutboundStream("fourth");
+
+		try {
+			await streams.attachOutboundStream(first as any);
+			await streams.attachOutboundStream(second as any);
+			await clock.tickAsync(250);
+			await streams.attachOutboundStream(third as any);
+
+			await clock.tickAsync(499);
+			expect(streams.rawOutboundStreams).to.deep.equal([first, second, third]);
+
+			await clock.tickAsync(1);
+			expect(streams.rawOutboundStreams).to.deep.equal([third]);
+
+			await streams.attachOutboundStream(fourth as any);
+			expect(streams.rawOutboundStreams).to.deep.equal([third, fourth]);
+			await clock.tickAsync(500);
+			expect(streams.rawOutboundStreams).to.deep.equal([fourth]);
+		} finally {
+			await streams.close();
+			clock.restore();
+		}
+	});
+
 	it("preempts queued low-priority traffic with higher priority", async () => {
 		const keypair = await Ed25519Keypair.create();
 		const streams = new PeerStreams({


### PR DESCRIPTION
## Summary

- distinguish outbound streams by object identity because stream IDs are local to a muxer
- reliably restart the 500 ms prune timer when more connection candidates arrive
- clear the timer handle before pruning so later candidates can schedule another election
- add deterministic regressions for same-ID streams and repeated grace-period elections

## Why

With several simultaneous Yamux/WebRTC connections, clearing the previous timer without clearing its handle canceled pruning permanently. DirectStream could then retain every outbound candidate and duplicate large responses over all of them.

## Validation

- `@peerbit/stream` build
- focused regressions (2/2)
- priority-lane suite (9/9)
- outbound-related integration tests (10/10)
- `git diff --check`