### PR TITLE
test(file-share): capture stable transport deltas

### DIFF
--- a/scripts/file-share/README.md
+++ b/scripts/file-share/README.md
@@ -3,7 +3,7 @@
 Run a single checkout with `pnpm bench:file-share:local` or compare pinned
 Peerbit revisions with `pnpm bench:file-share:matrix`.
 
-Result schema v8 defines `errorCount` as every uncaught browser `pageerror`,
+Result schema v9 defines `errorCount` as every uncaught browser `pageerror`,
 every browser `console.error`, every console message at any level that contains
 a declared Peerbit failure signature, and scenario-recorded operation failures.
 Each result embeds the exact `errorCollectionDefinition` and signature list.
@@ -11,7 +11,7 @@ Playwright `requestfailed` events are retained separately under
 `requestFailures`; they are diagnostics and are not automatically fatal because
 peer-to-peer discovery can legitimately exercise failed network candidates.
 
-Passed schema v8 upload results require `writerDiagnostics.lastUploadDiagnostics`
+Passed schema v9 upload results require `writerDiagnostics.lastUploadDiagnostics`
 to contain exactly 21 bounded progress milestones from 0% through 100% in 5%
 increments. Each point records the aggregate bytes whose application-level
 chunk puts completed, using the library upload clock and exact ceil-rounded byte
@@ -47,11 +47,13 @@ sinks only in separate benchmark sessions; aggregate comparison objects fail
 closed on mixed sinks, and every passed result and aggregate labels
 non-hash-only cohorts non-authoritative.
 
-Schema v8 upload results also record the `download-memory-v2` bounded
+Schema v9 upload results also record the `download-memory-v2` bounded
 download-window memory telemetry contract. After any
-controlled-locality stabilization, the harness arms serial samplers immediately
-before the timed click and forces a final sample as soon as the selected sink
-completion is observed, before integrity readback or terminal-topology checks.
+controlled-locality prefix stabilization, the harness arms serial samplers
+before the bounded pre-read transport-counter gate and timed click, then forces
+a final sample as soon as the selected sink completion is observed, before
+post-read counter stabilization, integrity readback, or terminal-topology
+checks.
 Reader and writer renderer JavaScript heaps use CDP `JSHeapUsedSize` samples.
 Host RSS combines all Chromium processes, grouped by Chromium process role,
 with the Playwright worker Node process; for local runs that Node value also
@@ -111,8 +113,45 @@ have a local index row yet.
 The measured cohort key is therefore
 `observer-persistent-prefix-b<K>-i<J>`, not merely the requested target. Timed
 read diagnostics must report those exact initial block and index-row counts.
-After sink completion, integrity verification, and an idle transfer scheduler,
-the harness requires every manifest-entry block to be local. The explicit
+After download-memory telemetry is armed, a bounded pre-read gate samples
+writer and reader topology in parallel every 100 ms for at most five seconds.
+It requires three consecutive samples in which the writer's outbound and the
+reader's inbound TopicControlPlane pubsub stream key sets and per-key byte
+counters are unchanged (with 1 ms of timestamp quantization tolerance). The
+final accepted sample becomes
+`writerTopologyBeforeTimedRead` and `readerTopologyBeforeTimedRead`; the timed
+click must start within the recorded one-second handoff tolerance. This excludes
+late preload control traffic from the measured counter delta.
+
+Immediately after sink completion is observed and download-memory sampling has
+stopped, the same bounded gate captures post-read topology before integrity
+readback, idle waiting, terminal-topology stabilization, or the transport's
+ten-second inbound idle pruning. Its deadline is capped so an accepted gate
+finishes no later than nine seconds after sink completion, leaving one second
+of pruning margin even when memory-telemetry shutdown is delayed; the actual
+completion-to-gate-finish delay is recorded and validated. The final accepted
+sample becomes
+`writerTopologyAfterTimedRead` and `readerTopologyAfterTimedRead`, so later
+convergence cannot erase the transport diagnostics visible at the end of the
+measured read. Both gates require exact counterpart peer hashes and peer IDs,
+the TopicControlPlane service and negotiated protocols, raw-counter/stream
+identity, and a unique live connection identity. They reject aborted outbound
+streams, duplicate audit keys, decreasing counters for an unchanged local key
+set, more than 1 MiB of aggregate writer/reader byte skew, malformed counters,
+capture errors, and deadline overruns. Each local audit key includes service,
+remote peer hash and ID, direction, connection and stream IDs, multiplexer, and
+protocol. Across the timed read, each endpoint must preserve its own exact key
+set and every post-read counter must be at least its pre-read value; only the
+writer-outbound and reader-inbound total deltas are compared, with at most 1 MiB
+of skew. Local stream, connection, and multiplexer identifiers are not compared
+across endpoints because libp2p assigns them independently. Every completed
+observation is retained in the result, including on a later failure. A valid
+post-read checkpoint also preserves the original two peer identities, retains
+the writer in the replication set, and contains either the writer
+singleton or the exact writer+reader pair.
+
+After integrity verification and an idle transfer scheduler, the harness
+requires every manifest-entry block to be local. The explicit
 terminal expectation keeps historical and fixed implementations in separate,
 fail-closed cohorts: `observer` requires zero local chunk index rows and the
 writer as the exact singleton replicator; `replicator` requires the complete
@@ -131,7 +170,7 @@ per-chunk timings remain in each result and can be rebucketed into 5% progress
 windows without losing the underlying samples. Without the paired locality
 options, roles, persistence policy, and seeder-drop gates are unchanged.
 
-Schema v8 records the exact versioned `seederDropPolicy` and a final numeric
+Schema v9 records the exact versioned `seederDropPolicy` and a final numeric
 `terminal` seeder snapshot after download and integrity verification. Every
 upload cohort also records top-level `integrityVerifiedAt`: it remains `null`
 until the aggregate size, SHA-256, CRC-32, manifest, and persistence gates have

--- a/scripts/file-share/benchmark-orchestration.mjs
+++ b/scripts/file-share/benchmark-orchestration.mjs
@@ -2,7 +2,7 @@ import fsp from "node:fs/promises";
 
 export const BENCHMARK_RESULT_SCHEMA = Object.freeze({
 	id: "peerbit-file-share-benchmark",
-	version: 8,
+	version: 9,
 });
 
 export const SEEDER_DROP_POLICY = Object.freeze({

--- a/scripts/file-share/benchmark-validity.mjs
+++ b/scripts/file-share/benchmark-validity.mjs
@@ -60,6 +60,14 @@ const SINK_AWAIT_SUBTRACTED_DIAGNOSTIC_DEFINITION =
 const PRIMARY_DOWNLOAD_METRIC = "libraryStreamWallMs";
 const PRIMARY_DOWNLOAD_METRIC_DEFINITION =
 	"authoritative only within one fixed download-sink cohort; hash-only is the standardized primary cohort and includes awaited sink writes plus any overlapping read-ahead";
+const TRANSPORT_COUNTER_STABILITY_POLL_MS = 100;
+const TRANSPORT_COUNTER_STABILITY_TIMEOUT_MS = 5_000;
+const TRANSPORT_COUNTER_STABLE_SAMPLE_COUNT = 3;
+const TRANSPORT_COUNTER_MAX_COUNTERPART_BYTE_SKEW = 1024 * 1024;
+const TRANSPORT_COUNTER_SAMPLE_CLOCK_TOLERANCE_MS = 1;
+const TRANSPORT_COUNTER_PRE_READ_START_TOLERANCE_MS = 1_000;
+const TRANSPORT_COUNTER_POST_READ_CAPTURE_MAX_DELAY_MS = 9_000;
+const PUBSUB_PROTOCOL = "/peerbit/topic-control-plane/2.0.0";
 const DEMAND_WAIT_DEFINITION =
 	"wall-clock time each sequential stream consumer awaited its scheduled chunk";
 // Date.now() endpoints can undercount the nested performance.now() helper
@@ -2019,18 +2027,14 @@ const validateLocalChunkPrefixObservation = (value, label) => {
 	};
 };
 
-const validateTopology = (
-	value,
-	label,
-	expectedSelfInReplicatorSet,
-	expectedReplicatorCount = 1,
-) => {
+const validateTopologyEvidence = (value, label) => {
 	const topology = requireRecord(value, label);
 	const capturedAt = requirePositiveSafeInteger(
 		topology.capturedAt,
 		`${label}.capturedAt`,
 	);
 	const peerHash = requireString(topology.peerHash, `${label}.peerHash`);
+	const peerId = requireString(topology.peerId, `${label}.peerId`);
 	const replicatorCount = requireNonNegativeSafeInteger(
 		topology.replicatorCount,
 		`${label}.replicatorCount`,
@@ -2047,18 +2051,319 @@ const validateTopology = (
 		requireString(hash, `${label}.replicatorHashes[${index}]`),
 	);
 	if (
-		replicatorCount !== expectedReplicatorCount ||
-		topology.selfInReplicatorSet !== expectedSelfInReplicatorSet ||
+		typeof topology.selfInReplicatorSet !== "boolean" ||
 		!isDeepStrictEqual(
 			replicatorHashes,
 			[...replicatorHashes].toSorted((left, right) =>
 				left.localeCompare(right),
 			),
+		) ||
+		new Set(replicatorHashes).size !== replicatorHashes.length
+	) {
+		throw new Error(`${label} contains inconsistent topology evidence`);
+	}
+	return {
+		observation: topology,
+		capturedAt,
+		peerHash,
+		peerId,
+		replicatorCount,
+		replicatorHashes,
+		selfInReplicatorSet: topology.selfInReplicatorSet,
+	};
+};
+
+const summarizeCounterpartPubsubTransport = (
+	topology,
+	{
+		direction,
+		expectedPeerHash,
+		expectedRemotePeerId,
+		label,
+	},
+) => {
+	if (!Array.isArray(topology.observation.transportStreams)) {
+		throw new Error(`Benchmark ${label} is missing transport stream diagnostics`);
+	}
+	if (topology.observation.transportStreams.some((stream) => !isRecord(stream))) {
+		throw new Error(
+			`Benchmark ${label} contains malformed transport stream diagnostics`,
+		);
+	}
+	const streams = topology.observation.transportStreams.filter(
+		(stream) =>
+			stream.service === "pubsub" &&
+			stream.direction === direction &&
+			(stream.remotePeerHash === expectedPeerHash ||
+				stream.remotePeer === expectedRemotePeerId),
+	);
+	if (streams.length === 0) {
+		throw new Error(
+			`Benchmark ${label} has no relevant counterpart pubsub stream`,
+		);
+	}
+	const counters = new Map();
+	let totalBytes = 0;
+	for (const [index, stream] of streams.entries()) {
+		if (
+			stream.remotePeerHash !== expectedPeerHash ||
+			stream.remotePeer !== expectedRemotePeerId ||
+			stream.peerHashIdentityMatch !== true ||
+			stream.serviceProtocol !== PUBSUB_PROTOCOL ||
+			stream.expectedProtocol !== PUBSUB_PROTOCOL ||
+			stream.protocol !== PUBSUB_PROTOCOL ||
+			stream.protocolIdentityMatch !== true ||
+			stream.counterStreamIdentityMatch !== true ||
+			stream.connectionIdentityMatchCount !== 1 ||
+			typeof stream.connectionId !== "string" ||
+			stream.connectionId.length === 0 ||
+			typeof stream.multiplexer !== "string" ||
+			stream.multiplexer.length === 0 ||
+			typeof stream.id !== "string" ||
+			stream.id.length === 0 ||
+			!Number.isSafeInteger(stream.bytes) ||
+			stream.bytes < 0 ||
+			(direction === "outbound"
+				? stream.aborted !== false
+				: stream.aborted !== null)
+		) {
+			throw new Error(
+				`Benchmark ${label} relevant pubsub stream ${index} is not authoritative`,
+			);
+		}
+		const key = JSON.stringify([
+			stream.service,
+			stream.remotePeerHash,
+			stream.remotePeer,
+			stream.direction,
+			stream.connectionId,
+			stream.id,
+			stream.multiplexer,
+			stream.protocol,
+		]);
+		if (counters.has(key)) {
+			throw new Error(
+				`Benchmark ${label} contains a duplicate pubsub counter key`,
+			);
+		}
+		counters.set(key, stream.bytes);
+		totalBytes += stream.bytes;
+	}
+	if (!Number.isSafeInteger(totalBytes)) {
+		throw new Error(`Benchmark ${label} has invalid pubsub counter totals`);
+	}
+	return {
+		counters: [...counters.entries()]
+			.map(([key, bytes]) => ({ key, bytes }))
+			.toSorted((left, right) => left.key.localeCompare(right.key)),
+		streamCount: streams.length,
+		totalBytes,
+	};
+};
+
+const requireMonotonicTransportCounterDelta = (before, after, label) => {
+	const beforeKeys = before.counters.map(({ key }) => key);
+	const afterKeys = after.counters.map(({ key }) => key);
+	if (!isDeepStrictEqual(beforeKeys, afterKeys)) {
+		throw new Error(
+			`Benchmark ${label} pubsub counter key set changed during timed read`,
+		);
+	}
+	for (const [index, afterCounter] of after.counters.entries()) {
+		if (afterCounter.bytes < before.counters[index].bytes) {
+			throw new Error(
+				`Benchmark ${label} pubsub counter decreased during timed read`,
+			);
+		}
+	}
+	return after.totalBytes - before.totalBytes;
+};
+
+const validateTransportTopologyStability = ({
+	control,
+	phase,
+	writerTopology,
+	readerTopology,
+	expectedWriterPeerHash,
+	expectedReaderPeerHash,
+	expectedWriterPeerId,
+	expectedReaderPeerId,
+	latestFinishedAt = null,
+}) => {
+	const phaseLabel = `${phase}TimedReadTopology`;
+	const startedAt = requirePositiveSafeInteger(
+		control[`${phaseLabel}StartedAt`],
+		`readerLocalityControl.${phaseLabel}StartedAt`,
+	);
+	const deadlineAt = requirePositiveSafeInteger(
+		control[`${phaseLabel}DeadlineAt`],
+		`readerLocalityControl.${phaseLabel}DeadlineAt`,
+	);
+	const finishedAt = requirePositiveSafeInteger(
+		control[`${phaseLabel}FinishedAt`],
+		`readerLocalityControl.${phaseLabel}FinishedAt`,
+	);
+	const observations = control[`${phaseLabel}Observations`];
+	if (latestFinishedAt !== null && finishedAt > latestFinishedAt) {
+		throw new Error(
+			`Benchmark ${phaseLabel} exceeded its bounded post-read capture delay`,
+		);
+	}
+	const expectedDeadlineAt =
+		latestFinishedAt === null
+			? startedAt + TRANSPORT_COUNTER_STABILITY_TIMEOUT_MS
+			: Math.min(
+					startedAt + TRANSPORT_COUNTER_STABILITY_TIMEOUT_MS,
+					latestFinishedAt,
+				);
+	const maxObservations =
+		Math.floor(
+			Math.max(0, deadlineAt - startedAt) /
+				(TRANSPORT_COUNTER_STABILITY_POLL_MS -
+					TRANSPORT_COUNTER_SAMPLE_CLOCK_TOLERANCE_MS),
+		) + 1;
+	if (
+		deadlineAt !== expectedDeadlineAt ||
+		deadlineAt <= startedAt ||
+		finishedAt < startedAt ||
+		finishedAt > deadlineAt ||
+		!Array.isArray(observations) ||
+		observations.length < TRANSPORT_COUNTER_STABLE_SAMPLE_COUNT ||
+		observations.length > maxObservations
+	) {
+		throw new Error(
+			`Benchmark ${phaseLabel} stability window is invalid or unbounded`,
+		);
+	}
+	let previous = null;
+	const validated = observations.map((value, index) => {
+		const label = `readerLocalityControl.${phaseLabel}Observations[${index}]`;
+		const observation = requireRecord(value, label);
+		const capturedAt = requirePositiveSafeInteger(
+			observation.capturedAt,
+			`${label}.capturedAt`,
+		);
+		const writer = validateTopologyEvidence(
+			observation.writerTopology,
+			`${label}.writerTopology`,
+		);
+		const reader = validateTopologyEvidence(
+			observation.readerTopology,
+			`${label}.readerTopology`,
+		);
+		if (
+			writer.peerHash !== expectedWriterPeerHash ||
+			reader.peerHash !== expectedReaderPeerHash ||
+			writer.peerId !== expectedWriterPeerId ||
+			reader.peerId !== expectedReaderPeerId ||
+			writer.capturedAt < startedAt ||
+			reader.capturedAt < startedAt ||
+			writer.capturedAt > capturedAt ||
+			reader.capturedAt > capturedAt ||
+			capturedAt > finishedAt ||
+			(index > 0 &&
+				capturedAt - observations[index - 1].capturedAt <
+					TRANSPORT_COUNTER_STABILITY_POLL_MS -
+						TRANSPORT_COUNTER_SAMPLE_CLOCK_TOLERANCE_MS)
+		) {
+			throw new Error(
+				`Benchmark ${phaseLabel} observations have inconsistent identities or timestamps`,
+			);
+		}
+		const writerSummary = summarizeCounterpartPubsubTransport(writer, {
+			direction: "outbound",
+			expectedPeerHash: expectedReaderPeerHash,
+			expectedRemotePeerId: expectedReaderPeerId,
+			label: `${label}.writerTopology`,
+		});
+		const readerSummary = summarizeCounterpartPubsubTransport(reader, {
+			direction: "inbound",
+			expectedPeerHash: expectedWriterPeerHash,
+			expectedRemotePeerId: expectedWriterPeerId,
+			label: `${label}.readerTopology`,
+		});
+		if (previous) {
+			for (const side of ["writer", "reader"]) {
+				const current = side === "writer" ? writerSummary : readerSummary;
+				const previousKeys = previous[side].counters.map(({ key }) => key);
+				const currentKeys = current.counters.map(({ key }) => key);
+				if (isDeepStrictEqual(previousKeys, currentKeys)) {
+					for (const [counterIndex, counter] of current.counters.entries()) {
+						if (counter.bytes < previous[side].counters[counterIndex].bytes) {
+							throw new Error(
+								`Benchmark ${phaseLabel} counters decrease for an unchanged key set`,
+							);
+						}
+					}
+				}
+			}
+		}
+		previous = { writer: writerSummary, reader: readerSummary };
+		return {
+			observation,
+			capturedAt,
+			writer,
+			reader,
+			writerSummary,
+			readerSummary,
+		};
+	});
+	const stable = validated.slice(-TRANSPORT_COUNTER_STABLE_SAMPLE_COUNT);
+	const stableSignature = (entry) => ({
+		writer: entry.writerSummary,
+		reader: entry.readerSummary,
+	});
+	if (
+		stable.some(
+			(entry) =>
+				Math.abs(
+					entry.writerSummary.totalBytes - entry.readerSummary.totalBytes,
+				) > TRANSPORT_COUNTER_MAX_COUNTERPART_BYTE_SKEW,
+		) ||
+		stable.slice(1).some(
+			(entry) =>
+				!isDeepStrictEqual(
+					stableSignature(entry),
+					stableSignature(stable[0]),
+				),
+		) ||
+		!isDeepStrictEqual(
+			validated.at(-1).observation.writerTopology,
+			writerTopology.observation,
+		) ||
+		!isDeepStrictEqual(
+			validated.at(-1).observation.readerTopology,
+			readerTopology.observation,
 		)
+	) {
+		throw new Error(
+			`Benchmark ${phaseLabel} observations do not prove stable counterpart pubsub counters`,
+		);
+	}
+	return {
+		startedAt,
+		deadlineAt,
+		finishedAt,
+		observations: validated,
+		writerSummary: stable.at(-1).writerSummary,
+		readerSummary: stable.at(-1).readerSummary,
+	};
+};
+
+const validateTopology = (
+	value,
+	label,
+	expectedSelfInReplicatorSet,
+	expectedReplicatorCount = 1,
+) => {
+	const topology = validateTopologyEvidence(value, label);
+	if (
+		topology.replicatorCount !== expectedReplicatorCount ||
+		topology.selfInReplicatorSet !== expectedSelfInReplicatorSet
 	) {
 		throw new Error(`${label} does not prove the requested topology role`);
 	}
-	return { capturedAt, peerHash, replicatorCount, replicatorHashes };
+	return topology;
 };
 
 const validateReaderLocalityControl = (result, invocation) => {
@@ -2106,6 +2411,20 @@ const validateReaderLocalityControl = (result, invocation) => {
 		control.expectedTerminalTopology !== expectedTerminalTopology ||
 		control.stabilityPollIntervalMs !== Math.min(invocation.pollMs, 100) ||
 		control.requiredStableObservationCount !== 3 ||
+		control.transportCounterStabilityPollIntervalMs !==
+			TRANSPORT_COUNTER_STABILITY_POLL_MS ||
+		control.transportCounterStabilityTimeoutMs !==
+			TRANSPORT_COUNTER_STABILITY_TIMEOUT_MS ||
+		control.transportCounterRequiredStableObservationCount !==
+			TRANSPORT_COUNTER_STABLE_SAMPLE_COUNT ||
+		control.transportCounterMaxCounterpartByteSkew !==
+			TRANSPORT_COUNTER_MAX_COUNTERPART_BYTE_SKEW ||
+		control.transportCounterSampleClockToleranceMs !==
+			TRANSPORT_COUNTER_SAMPLE_CLOCK_TOLERANCE_MS ||
+		control.transportCounterPreReadStartToleranceMs !==
+			TRANSPORT_COUNTER_PRE_READ_START_TOLERANCE_MS ||
+		control.transportCounterPostReadCaptureMaxDelayMs !==
+			TRANSPORT_COUNTER_POST_READ_CAPTURE_MAX_DELAY_MS ||
 		control.status !== "complete" ||
 		control.failure !== null
 	) {
@@ -2174,6 +2493,14 @@ const validateReaderLocalityControl = (result, invocation) => {
 		"readerLocalityControl.readerTopologyBeforeTimedRead",
 		false,
 	);
+	const writerTopologyAfterTimedRead = validateTopologyEvidence(
+		control.writerTopologyAfterTimedRead,
+		"readerLocalityControl.writerTopologyAfterTimedRead",
+	);
+	const readerTopologyAfterTimedRead = validateTopologyEvidence(
+		control.readerTopologyAfterTimedRead,
+		"readerLocalityControl.readerTopologyAfterTimedRead",
+	);
 	if (
 		writerTopologyBeforeUpload.replicatorCount !==
 			readerTopologyBeforeUpload.replicatorCount ||
@@ -2186,7 +2513,16 @@ const validateReaderLocalityControl = (result, invocation) => {
 		writerTopologyBeforeUpload.peerHash !==
 			writerTopologyBeforeTimedRead.peerHash ||
 		readerTopologyBeforeUpload.peerHash !==
-			readerTopologyBeforeTimedRead.peerHash
+			readerTopologyBeforeTimedRead.peerHash ||
+		writerTopologyBeforeUpload.peerHash !==
+			writerTopologyAfterTimedRead.peerHash ||
+		readerTopologyBeforeUpload.peerHash !==
+			readerTopologyAfterTimedRead.peerHash ||
+		writerTopologyBeforeUpload.peerId === readerTopologyBeforeUpload.peerId ||
+		writerTopologyBeforeUpload.peerId !== writerTopologyBeforeTimedRead.peerId ||
+		readerTopologyBeforeUpload.peerId !== readerTopologyBeforeTimedRead.peerId ||
+		writerTopologyBeforeUpload.peerId !== writerTopologyAfterTimedRead.peerId ||
+		readerTopologyBeforeUpload.peerId !== readerTopologyAfterTimedRead.peerId
 	) {
 		throw new Error(
 			"Benchmark topology evidence does not preserve two distinct peer identities",
@@ -2206,6 +2542,90 @@ const validateReaderLocalityControl = (result, invocation) => {
 	) {
 		throw new Error(
 			"Benchmark topology evidence does not agree on the writer as the exact singleton replicator",
+		);
+	}
+	const postTimedReadSingleton = [writerTopologyBeforeUpload.peerHash];
+	const postTimedReadPair = [
+		writerTopologyBeforeUpload.peerHash,
+		readerTopologyBeforeUpload.peerHash,
+	].toSorted((left, right) => left.localeCompare(right));
+	if (
+		!isDeepStrictEqual(
+			writerTopologyAfterTimedRead.replicatorHashes,
+			readerTopologyAfterTimedRead.replicatorHashes,
+		) ||
+		writerTopologyAfterTimedRead.selfInReplicatorSet !== true ||
+		readerTopologyAfterTimedRead.selfInReplicatorSet !==
+			readerTopologyAfterTimedRead.replicatorHashes.includes(
+				readerTopologyAfterTimedRead.peerHash,
+			) ||
+		![postTimedReadSingleton, postTimedReadPair].some((expectedHashes) =>
+			isDeepStrictEqual(
+				writerTopologyAfterTimedRead.replicatorHashes,
+				expectedHashes,
+			),
+		)
+	) {
+		throw new Error(
+			"Benchmark immediate post-read topology evidence is inconsistent",
+		);
+	}
+	const preTimedReadTransportStability =
+		validateTransportTopologyStability({
+			control,
+			phase: "pre",
+			writerTopology: writerTopologyBeforeTimedRead,
+			readerTopology: readerTopologyBeforeTimedRead,
+			expectedWriterPeerHash: writerTopologyBeforeUpload.peerHash,
+			expectedReaderPeerHash: readerTopologyBeforeUpload.peerHash,
+			expectedWriterPeerId: writerTopologyBeforeUpload.peerId,
+			expectedReaderPeerId: readerTopologyBeforeUpload.peerId,
+		});
+	const postTimedReadTransportStability =
+		validateTransportTopologyStability({
+			control,
+			phase: "post",
+			writerTopology: writerTopologyAfterTimedRead,
+			readerTopology: readerTopologyAfterTimedRead,
+			expectedWriterPeerHash: writerTopologyBeforeUpload.peerHash,
+			expectedReaderPeerHash: readerTopologyBeforeUpload.peerHash,
+			expectedWriterPeerId: writerTopologyBeforeUpload.peerId,
+			expectedReaderPeerId: readerTopologyBeforeUpload.peerId,
+			latestFinishedAt:
+				downloadCompletionObservedAt +
+				TRANSPORT_COUNTER_POST_READ_CAPTURE_MAX_DELAY_MS,
+		});
+	const postTimedReadTopologyCaptureDelayMs = requireNonNegativeSafeInteger(
+		control.postTimedReadTopologyCaptureDelayMs,
+		"readerLocalityControl.postTimedReadTopologyCaptureDelayMs",
+	);
+	if (
+		postTimedReadTopologyCaptureDelayMs !==
+			postTimedReadTransportStability.finishedAt -
+				downloadCompletionObservedAt ||
+		postTimedReadTopologyCaptureDelayMs >
+			TRANSPORT_COUNTER_POST_READ_CAPTURE_MAX_DELAY_MS
+	) {
+		throw new Error(
+			"Benchmark post-timed-read topology capture delay is inconsistent or unbounded",
+		);
+	}
+	const writerCounterDelta = requireMonotonicTransportCounterDelta(
+		preTimedReadTransportStability.writerSummary,
+		postTimedReadTransportStability.writerSummary,
+		"writer",
+	);
+	const readerCounterDelta = requireMonotonicTransportCounterDelta(
+		preTimedReadTransportStability.readerSummary,
+		postTimedReadTransportStability.readerSummary,
+		"reader",
+	);
+	if (
+		Math.abs(writerCounterDelta - readerCounterDelta) >
+		TRANSPORT_COUNTER_MAX_COUNTERPART_BYTE_SKEW
+	) {
+		throw new Error(
+			"Benchmark writer outbound and reader inbound pubsub counter deltas exceed the byte-skew bound",
 		);
 	}
 	const beforePreload = validateLocalChunkPrefixObservation(
@@ -2444,6 +2864,18 @@ const validateReaderLocalityControl = (result, invocation) => {
 		control.integrityVerifiedAt,
 		"readerLocalityControl.integrityVerifiedAt",
 	);
+	const downloadMemoryTelemetry = requireRecord(
+		result.downloadMemoryTelemetry,
+		"downloadMemoryTelemetry",
+	);
+	const downloadMemoryStartedAt = requirePositiveSafeInteger(
+		downloadMemoryTelemetry.startedAt,
+		"downloadMemoryTelemetry.startedAt",
+	);
+	const downloadMemoryStoppedAt = requirePositiveSafeInteger(
+		downloadMemoryTelemetry.finishedAt,
+		"downloadMemoryTelemetry.finishedAt",
+	);
 	const terminalIdle = validateLocalChunkPrefixObservation(
 		control.terminalIdleObservation,
 		"readerLocalityControl.terminalIdleObservation",
@@ -2569,11 +3001,26 @@ const validateReaderLocalityControl = (result, invocation) => {
 		preloadStartedAt < beforePreload.capturedAt ||
 		preloadFinishedAt < preloadStartedAt ||
 		stable[0].capturedAt < preloadFinishedAt ||
+		preTimedReadTransportStability.startedAt < preDownload.capturedAt ||
+		preTimedReadTransportStability.startedAt < downloadMemoryStartedAt ||
+		preTimedReadTransportStability.finishedAt > downloadStartedAt ||
+		downloadStartedAt - preTimedReadTransportStability.finishedAt >
+			TRANSPORT_COUNTER_PRE_READ_START_TOLERANCE_MS ||
 		preDownload.capturedAt > writerTopologyBeforeTimedRead.capturedAt ||
 		preDownload.capturedAt > readerTopologyBeforeTimedRead.capturedAt ||
 		writerTopologyBeforeTimedRead.capturedAt > downloadStartedAt ||
 		readerTopologyBeforeTimedRead.capturedAt > downloadStartedAt ||
 		downloadFinishedAt > downloadCompletionObservedAt ||
+		postTimedReadTransportStability.startedAt <
+			downloadCompletionObservedAt ||
+		postTimedReadTransportStability.startedAt < downloadMemoryStoppedAt ||
+		postTimedReadTransportStability.finishedAt > integrityVerifiedAt ||
+		writerTopologyAfterTimedRead.capturedAt < downloadCompletionObservedAt ||
+		readerTopologyAfterTimedRead.capturedAt < downloadCompletionObservedAt ||
+		writerTopologyAfterTimedRead.capturedAt < downloadMemoryStoppedAt ||
+		readerTopologyAfterTimedRead.capturedAt < downloadMemoryStoppedAt ||
+		writerTopologyAfterTimedRead.capturedAt > integrityVerifiedAt ||
+		readerTopologyAfterTimedRead.capturedAt > integrityVerifiedAt ||
 		integrityVerifiedAt !== result.integrityVerifiedAt ||
 		integrityVerifiedAt < downloadCompletionObservedAt ||
 		terminalIdle.capturedAt < integrityVerifiedAt ||

--- a/scripts/file-share/benchmark-validity.test.mjs
+++ b/scripts/file-share/benchmark-validity.test.mjs
@@ -623,16 +623,100 @@ const createReaderLocalityFixture = ({
 		selfInReplicatorSet,
 		{
 			peerHash = selfInReplicatorSet ? "writer-peer" : "reader-peer",
+			peerId = `${peerHash}-id`,
 			replicatorCount = 1,
 			replicatorHashes = ["writer-peer"],
+			transportStreams,
 		} = {},
 	) => ({
 		capturedAt,
 		peerHash,
+		peerId,
 		replicatorCount,
 		replicatorHashes,
 		selfInReplicatorSet,
+		...(transportStreams ? { transportStreams } : {}),
 	});
+	const pubsubTransportStream = ({
+		direction,
+		remotePeerHash,
+		remotePeer,
+		bytes,
+		connectionId,
+		id,
+		multiplexer = "/webrtc",
+	}) => ({
+		service: "pubsub",
+		remotePeerHash,
+		peerHashIdentityMatch: true,
+		serviceProtocol: "/peerbit/topic-control-plane/2.0.0",
+		protocol: "/peerbit/topic-control-plane/2.0.0",
+		expectedProtocol: "/peerbit/topic-control-plane/2.0.0",
+		protocolIdentityMatch: true,
+		remotePeer,
+		id,
+		direction,
+		bytes,
+		aborted: direction === "outbound" ? false : null,
+		counterStreamIdentityMatch: true,
+		connectionIdentityMatchCount: 1,
+		connectionId,
+		multiplexer,
+	});
+	const transportTopologyObservation = (capturedAt, bytes) => ({
+		capturedAt,
+		writerTopology: topology(capturedAt - 1, true, {
+			peerHash: "writer-peer",
+			transportStreams: [
+				pubsubTransportStream({
+					direction: "outbound",
+					remotePeerHash: "reader-peer",
+					remotePeer: "reader-peer-id",
+					bytes,
+					connectionId: "writer-connection",
+					id: "writer-stream-id",
+				}),
+				pubsubTransportStream({
+					direction: "outbound",
+					remotePeerHash: "reader-peer",
+					remotePeer: "reader-peer-id",
+					bytes: bytes + 50,
+					connectionId: "writer-connection-2",
+					id: "writer-stream-id-2",
+					multiplexer: "/peerbit/yamux/1.0.0",
+				}),
+			],
+		}),
+		readerTopology: topology(capturedAt - 1, false, {
+			peerHash: "reader-peer",
+			transportStreams: [
+				pubsubTransportStream({
+					direction: "inbound",
+					remotePeerHash: "writer-peer",
+					remotePeer: "writer-peer-id",
+					bytes,
+					connectionId: "reader-connection",
+					id: "reader-stream-id",
+					multiplexer: "/peerbit/yamux/1.0.0",
+				}),
+				pubsubTransportStream({
+					direction: "inbound",
+					remotePeerHash: "writer-peer",
+					remotePeer: "writer-peer-id",
+					bytes: bytes + 50,
+					connectionId: "reader-connection-2",
+					id: "reader-stream-id-2",
+					multiplexer: "/webrtc",
+				}),
+			],
+		}),
+	});
+	const preTimedReadTopologyObservations = [1_382, 1_481, 1_580].map(
+		(capturedAt) => transportTopologyObservation(capturedAt, 100),
+	);
+	const postTimedReadTopologyObservations = [1_635, 1_734, 1_833].map(
+		(capturedAt) => transportTopologyObservation(capturedAt, 200),
+	);
 	const terminalReplicatorHashes =
 		readerTerminalTopology === "replicator"
 			? ["reader-peer", "writer-peer"]
@@ -676,14 +760,14 @@ const createReaderLocalityFixture = ({
 		initialLocalChunkIndexRowCount: actualIndexRowCount,
 		initialLocalChunkCount: actualIndexRowCount,
 		initialLocalChunkBlockCount: actualBlockCount,
-		startedAt: 1_400,
-		finishedAt: 1_430,
-		chunkWriteStartedAt: { 0: 1_410, 1: 1_422 },
-		chunkWriteFinishedAt: { 0: 1_415, 1: 1_426 },
-		chunkMaterializeStartedAt: { 0: 1_401, 1: 1_416 },
-		chunkMaterializeFinishedAt: { 0: 1_403, 1: 1_418 },
-		chunkHashStartedAt: { 0: 1_403, 1: 1_418 },
-		chunkHashFinishedAt: { 0: 1_404, 1: 1_420 },
+		startedAt: 1_600,
+		finishedAt: 1_630,
+		chunkWriteStartedAt: { 0: 1_610, 1: 1_622 },
+		chunkWriteFinishedAt: { 0: 1_615, 1: 1_626 },
+		chunkMaterializeStartedAt: { 0: 1_601, 1: 1_616 },
+		chunkMaterializeFinishedAt: { 0: 1_603, 1: 1_618 },
+		chunkHashStartedAt: { 0: 1_603, 1: 1_618 },
+		chunkHashFinishedAt: { 0: 1_604, 1: 1_620 },
 	});
 	result.writerManifestEvidence.fileName = fileName;
 	result.readerManifestEvidence.fileName = fileName;
@@ -691,15 +775,24 @@ const createReaderLocalityFixture = ({
 	result.writerDiagnostics.replicatorCount = terminalReplicatorCount;
 	result.writerDiagnostics.replicationSetSize = 1;
 	result.writerDiagnostics.lastUploadDiagnostics.fileName = fileName;
-	result.timestamps.downloadStartedAt = 1_400;
-	result.timestamps.downloadFinishedAt = 1_430;
-	result.timestamps.downloadCompletionObservedAt = 1_431;
-	result.integrityVerifiedAt = 1_432;
+	result.timestamps.downloadStartedAt = 1_600;
+	result.timestamps.downloadFinishedAt = 1_630;
+	result.timestamps.downloadCompletionObservedAt = 1_631;
+	result.integrityVerifiedAt = 1_837;
 	result.downloadMemoryTelemetry = createDownloadMemoryTelemetry(
-		1_400,
-		1_430,
+		1_600,
+		1_630,
 		invocation,
 	);
+	result.downloadMemoryTelemetry.startedAt = 1_380;
+	for (const series of [
+		result.downloadMemoryTelemetry.readerJsHeap,
+		result.downloadMemoryTelemetry.writerJsHeap,
+		result.downloadMemoryTelemetry.hostRss,
+	]) {
+		series.startedAt = 1_380;
+		series.samples[0].capturedAt = 1_381;
+	}
 	result.readerLocalityControl = {
 		profile: "observer-topology-exact-manifest-prefix",
 		provisioningMethod: "exact-manifest-head-import",
@@ -712,6 +805,13 @@ const createReaderLocalityFixture = ({
 		expectedTerminalTopology: readerTerminalTopology,
 		stabilityPollIntervalMs: 100,
 		requiredStableObservationCount: 3,
+		transportCounterStabilityPollIntervalMs: 100,
+		transportCounterStabilityTimeoutMs: 5_000,
+		transportCounterRequiredStableObservationCount: 3,
+		transportCounterMaxCounterpartByteSkew: 1024 * 1024,
+		transportCounterSampleClockToleranceMs: 1,
+		transportCounterPreReadStartToleranceMs: 1_000,
+		transportCounterPostReadCaptureMaxDelayMs: 9_000,
 		status: "complete",
 		readerInitialRoleEvidence: {
 			capturedAt: 989,
@@ -723,8 +823,31 @@ const createReaderLocalityFixture = ({
 		},
 		writerTopologyBeforeUpload: topology(990, true),
 		readerTopologyBeforeUpload: topology(991, false),
-		writerTopologyBeforeTimedRead: topology(1_380, true),
-		readerTopologyBeforeTimedRead: topology(1_381, false),
+		writerTopologyBeforeTimedRead:
+			structuredClone(
+				preTimedReadTopologyObservations.at(-1).writerTopology,
+			),
+		readerTopologyBeforeTimedRead:
+			structuredClone(
+				preTimedReadTopologyObservations.at(-1).readerTopology,
+			),
+		preTimedReadTopologyStartedAt: 1_381,
+		preTimedReadTopologyDeadlineAt: 6_381,
+		preTimedReadTopologyFinishedAt: 1_583,
+		preTimedReadTopologyObservations,
+		writerTopologyAfterTimedRead:
+			structuredClone(
+				postTimedReadTopologyObservations.at(-1).writerTopology,
+			),
+		readerTopologyAfterTimedRead:
+			structuredClone(
+				postTimedReadTopologyObservations.at(-1).readerTopology,
+			),
+		postTimedReadTopologyStartedAt: 1_634,
+		postTimedReadTopologyDeadlineAt: 6_634,
+		postTimedReadTopologyFinishedAt: 1_836,
+		postTimedReadTopologyCaptureDelayMs: 205,
+		postTimedReadTopologyObservations,
 		beforePreloadObservation: observation({
 			capturedAt: 1_171,
 			persistChunkReads: false,
@@ -773,19 +896,19 @@ const createReaderLocalityFixture = ({
 			blocks: Array.from({ length: actualBlockCount }, (_, index) => index),
 			indexed: Array.from({ length: actualIndexRowCount }, (_, index) => index),
 		}),
-		integrityVerifiedAt: 1_432,
+		integrityVerifiedAt: 1_837,
 		terminalIdleObservation: observation({
-			capturedAt: 1_433,
+			capturedAt: 1_838,
 			persistChunkReads: true,
 			blocks: [0, 1],
 			indexed: readerTerminalTopology === "replicator" ? [0, 1] : [],
 		}),
-		terminalTopologyStartedAt: 1_433,
-		terminalTopologyDeadlineAt: 181_433,
-		terminalTopologyFinishedAt: 1_635,
+		terminalTopologyStartedAt: 1_838,
+		terminalTopologyDeadlineAt: 181_838,
+		terminalTopologyFinishedAt: 2_040,
 		terminalTopologyRole: readerTerminalTopology,
 		terminalTopologyExpectationSatisfied: true,
-		terminalTopologyObservations: [1_434, 1_534, 1_634].map((capturedAt) => ({
+		terminalTopologyObservations: [1_839, 1_939, 2_039].map((capturedAt) => ({
 			capturedAt,
 			writerTopology: terminalTopology(capturedAt - 1, "writer-peer"),
 			readerTopology: terminalTopology(capturedAt - 1, "reader-peer"),
@@ -812,7 +935,7 @@ const createReaderLocalityFixture = ({
 			label: "terminal",
 			writerSeeders: 1,
 			readerSeeders: 1,
-			at: 1_640,
+			at: 2_041,
 		},
 	];
 	result.baselineWriterSeeders = 1;
@@ -919,7 +1042,7 @@ test("requires the terminal snapshot after controlled-locality topology", () => 
 	);
 });
 
-test("accepts one recovered seeder dip under the v8 policy", () => {
+test("accepts one recovered seeder dip under the v9 policy", () => {
 	const result = validResult();
 	result.snapshots[1].writerSeeders = 1;
 	result.droppedSeeders = true;
@@ -954,7 +1077,7 @@ test("rejects a terminal below-baseline seeder snapshot", () => {
 	);
 });
 
-test("rejects missing, altered, and contradictory v8 seeder-drop evidence", () => {
+test("rejects missing, altered, and contradictory v9 seeder-drop evidence", () => {
 	for (const [mutate, pattern] of [
 		[
 			(result) => {
@@ -1554,6 +1677,26 @@ test("accepts exact observer-locality control and rejects contradictory evidence
 		],
 		[
 			(result) => {
+				result.readerLocalityControl.transportCounterSampleClockToleranceMs = 2;
+			},
+			/locality control contract is invalid/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.transportCounterPreReadStartToleranceMs =
+					999;
+			},
+			/locality control contract is invalid/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.transportCounterPostReadCaptureMaxDelayMs =
+					10_000;
+			},
+			/locality control contract is invalid/,
+		],
+		[
+			(result) => {
 				result.readerLocalityControl.beforePreloadObservation.chunkCount = 3;
 				for (const observation of [
 					...result.readerLocalityControl.stabilityObservations,
@@ -1600,6 +1743,176 @@ test("accepts exact observer-locality control and rejects contradictory evidence
 					["third-peer"];
 			},
 			/does not agree on the writer as the exact singleton replicator/,
+		],
+		[
+			(result) => {
+				delete result.readerLocalityControl.writerTopologyAfterTimedRead;
+			},
+			/writerTopologyAfterTimedRead/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.readerTopologyAfterTimedRead.peerHash =
+					"other-reader";
+			},
+			/does not preserve two distinct peer identities/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.writerTopologyAfterTimedRead.replicatorHashes =
+					["reader-peer", "writer-peer"];
+				result.readerLocalityControl.writerTopologyAfterTimedRead.replicatorCount =
+					2;
+			},
+			/immediate post-read topology evidence is inconsistent/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.preTimedReadTopologyObservations[1].writerTopology.transportStreams[0].protocol =
+					"/wrong/protocol";
+			},
+			/relevant pubsub stream 0 is not authoritative/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.preTimedReadTopologyObservations[1].readerTopology.transportStreams[0].remotePeerHash =
+					"wrong-writer-hash";
+			},
+			/relevant pubsub stream 0 is not authoritative/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.preTimedReadTopologyObservations[1].writerTopology.transportStreams[0].remotePeer =
+					"wrong-reader-id";
+			},
+			/relevant pubsub stream 0 is not authoritative/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.preTimedReadTopologyObservations[1].writerTopology.transportStreams.push(
+					null,
+				);
+			},
+			/contains malformed transport stream diagnostics/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.preTimedReadTopologyObservations[1].writerTopology.transportStreams[0].peerHashIdentityMatch =
+					false;
+			},
+			/relevant pubsub stream 0 is not authoritative/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.preTimedReadTopologyObservations[1].writerTopology.transportStreams[0].connectionId =
+					"changed-writer-connection";
+			},
+			/do not prove stable counterpart pubsub counters/,
+		],
+		[
+			(result) => {
+				const streams =
+					result.readerLocalityControl.preTimedReadTopologyObservations[1]
+						.writerTopology.transportStreams;
+				streams[1] = structuredClone(streams[0]);
+			},
+			/contains a duplicate pubsub counter key/,
+		],
+		[
+			(result) => {
+				const observations =
+					result.readerLocalityControl.preTimedReadTopologyObservations;
+				observations[0].writerTopology.transportStreams[0].bytes = 101;
+				observations[1].writerTopology.transportStreams[0].bytes = 100;
+			},
+			/counters decrease for an unchanged key set/,
+		],
+		[
+			(result) => {
+				const control = result.readerLocalityControl;
+				for (const observation of control.postTimedReadTopologyObservations) {
+					observation.writerTopology.transportStreams[0].connectionId =
+						"replacement-writer-connection";
+				}
+				control.writerTopologyAfterTimedRead.transportStreams[0].connectionId =
+					"replacement-writer-connection";
+			},
+			/writer pubsub counter key set changed during timed read/,
+		],
+		[
+			(result) => {
+				const control = result.readerLocalityControl;
+				for (const observation of control.postTimedReadTopologyObservations) {
+					observation.writerTopology.transportStreams[0].bytes = 90;
+					observation.writerTopology.transportStreams[1].bytes = 360;
+				}
+				control.writerTopologyAfterTimedRead.transportStreams[0].bytes = 90;
+				control.writerTopologyAfterTimedRead.transportStreams[1].bytes = 360;
+			},
+			/writer pubsub counter decreased during timed read/,
+		],
+		[
+			(result) => {
+				const control = result.readerLocalityControl;
+				for (const observation of control.postTimedReadTopologyObservations) {
+					observation.readerTopology.transportStreams[0].bytes =
+						2 * 1024 * 1024;
+				}
+				control.readerTopologyAfterTimedRead.transportStreams[0].bytes =
+					2 * 1024 * 1024;
+			},
+			/do not prove stable counterpart pubsub counters/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.postTimedReadTopologyObservations.pop();
+			},
+			/stability window is invalid or unbounded/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.preTimedReadTopologyDeadlineAt -= 1;
+			},
+			/stability window is invalid or unbounded/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.postTimedReadTopologyFinishedAt =
+					result.timestamps.downloadCompletionObservedAt + 9_001;
+			},
+			/exceeded its bounded post-read capture delay/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.postTimedReadTopologyCaptureDelayMs += 1;
+			},
+			/post-timed-read topology capture delay is inconsistent or unbounded/,
+		],
+		[
+			(result) => {
+				const observations =
+					result.readerLocalityControl.preTimedReadTopologyObservations;
+				observations[1].capturedAt = observations[0].capturedAt + 98;
+				observations[1].writerTopology.capturedAt =
+					observations[1].capturedAt - 1;
+				observations[1].readerTopology.capturedAt =
+					observations[1].capturedAt - 1;
+			},
+			/observations have inconsistent identities or timestamps/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.readerTopologyAfterTimedRead.capturedAt =
+					result.timestamps.downloadCompletionObservedAt - 1;
+			},
+			/postTimedReadTopology observations do not prove stable counterpart pubsub counters/,
+		],
+		[
+			(result) => {
+				result.readerLocalityControl.writerTopologyAfterTimedRead.capturedAt =
+					result.integrityVerifiedAt + 1;
+			},
+			/postTimedReadTopology observations do not prove stable counterpart pubsub counters/,
 		],
 		[
 			(result) => {
@@ -1948,14 +2261,14 @@ test("bounds Node-file server timing against its browser sink timing", () => {
 	);
 });
 
-test("rejects a status-only passed payload at the v8 evidence envelope", () => {
+test("rejects a status-only passed payload at the v9 evidence envelope", () => {
 	assert.throws(
 		() => validateBenchmarkResultEnvelope({ status: "passed" }, options),
 		/missing schema/,
 	);
 });
 
-test("requires explicit error evidence on failed v8 envelopes", () => {
+test("requires explicit error evidence on failed v9 envelopes", () => {
 	const completeFailure = validResult();
 	completeFailure.status = "failed";
 	completeFailure.failure = { message: "synthetic browser failure" };

--- a/scripts/file-share/template-contract.test.mjs
+++ b/scripts/file-share/template-contract.test.mjs
@@ -17,14 +17,14 @@ const templates = [
 ];
 
 for (const name of templates) {
-	test(`${name} emits the atomic v8 result envelope`, async () => {
+	test(`${name} emits the atomic v9 result envelope`, async () => {
 		const contents = await readFile(
 			path.join(repoRoot, "scripts", "file-share", "templates", name),
 			"utf8",
 		);
 		for (const required of [
 			'id: "peerbit-file-share-benchmark"',
-			"version: 8",
+			"version: 9",
 			"PW_BENCHMARK_RUN_NONCE",
 			"PW_BENCHMARK_INVOCATION",
 			"PW_BENCHMARK_PROVENANCE",
@@ -196,6 +196,34 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"readerTopology.replicatorHashes[0] === writerPeerHash",
 		"writerTopologyBeforeUpload",
 		"readerTopologyBeforeTimedRead",
+		"writerTopologyAfterTimedRead",
+		"readerTopologyAfterTimedRead",
+		"preTimedReadTopologyObservations",
+		"postTimedReadTopologyObservations",
+		"postTimedReadTopologyCaptureDelayMs",
+		"collectStableCounterpartTransportTopology",
+		"TRANSPORT_COUNTER_STABILITY_TIMEOUT_MS = 5_000",
+		"TRANSPORT_COUNTER_STABILITY_POLL_MS = 100",
+		"TRANSPORT_COUNTER_STABLE_SAMPLE_COUNT = 3",
+		"TRANSPORT_COUNTER_MAX_COUNTERPART_BYTE_SKEW = 1024 * 1024",
+		"TRANSPORT_COUNTER_SAMPLE_CLOCK_TOLERANCE_MS = 1",
+		"TRANSPORT_COUNTER_PRE_READ_START_TOLERANCE_MS = 1_000",
+		"TRANSPORT_COUNTER_POST_READ_CAPTURE_MAX_DELAY_MS = 9_000",
+		"transportCounterSampleClockToleranceMs:",
+		"transportCounterPreReadStartToleranceMs:",
+		"transportCounterPostReadCaptureMaxDelayMs:",
+		"requireMonotonicTransportCounterDelta",
+		"Timed read did not start within the bounded pre-read transport-counter handoff",
+		'stream.service === "pubsub"',
+		"stream.remotePeerHash === expectedPeerHash",
+		"stream.remotePeerHash !== expectedPeerHash",
+		"stream.remotePeer !== expectedRemotePeerId",
+		"contains malformed transport stream diagnostics",
+		"stream.peerHashIdentityMatch !== true",
+		"stream.serviceProtocol !== PUBSUB_PROTOCOL",
+		"stream.protocolIdentityMatch !== true",
+		"stream.counterStreamIdentityMatch !== true",
+		"stream.connectionIdentityMatchCount !== 1",
 		"requestedLocalChunkBlockCount",
 		'provisioningMethod: "exact-manifest-head-import"',
 		"stabilityObservations",
@@ -228,7 +256,7 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 	assert.match(
 		contents,
 		/const terminalSeederSnapshot = await snapshot\([\s\S]*?noteSeederDrop\(terminalSeederSnapshot\);[\s\S]*?if \(unexpectedSeederDrop\)/,
-		"the final numeric seeder snapshot must participate in the v8 drop policy before acceptance",
+		"the final numeric seeder snapshot must participate in the v9 drop policy before acceptance",
 	);
 	const lateFailureCatch = contents.slice(
 		contents.lastIndexOf("\t\t} catch (error: any) {"),
@@ -243,10 +271,16 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		!lateFailureCatch.includes("integrityVerified: false"),
 		"the catch path must not overwrite completed integrity state",
 	);
+	assert.ok(
+		lateFailureCatch.includes("readerLocalityControl,") &&
+			!lateFailureCatch.includes("preTimedReadTopologyObservations = []") &&
+			!lateFailureCatch.includes("postTimedReadTopologyObservations = []"),
+		"late failures must preserve every completed pre/post transport topology observation",
+	);
 	assert.match(
 		contents,
-		/const LOCALITY_CONTROL_OUTER_TIMEOUT_BUDGET_MS =\s*READER_LOCAL_CHUNK_TARGET === null\s*\? 0\s*:\s*3 \* READY_TIMEOUT_MS \+\s*\(READER_LOCAL_CHUNK_TARGET > 0\s*\? DOWNLOAD_TIMEOUT_MS \+ TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS\s*: 0\);/,
-		"controlled locality must reserve three readiness phases and a nonzero-prefix aggregate preload deadline plus cleanup tolerance",
+		/const LOCALITY_CONTROL_OUTER_TIMEOUT_BUDGET_MS =\s*READER_LOCAL_CHUNK_TARGET === null\s*\? 0\s*:\s*3 \* READY_TIMEOUT_MS \+\s*2 \* TRANSPORT_COUNTER_STABILITY_TIMEOUT_MS \+\s*\(READER_LOCAL_CHUNK_TARGET > 0\s*\? DOWNLOAD_TIMEOUT_MS \+ TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS\s*: 0\);/,
+		"controlled locality must reserve three readiness phases, both bounded transport gates, and a nonzero-prefix aggregate preload deadline plus cleanup tolerance",
 	);
 	assert.match(
 		contents,
@@ -283,14 +317,54 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"memory telemetry must collect clean initial samples before the sink waiter is armed and the timed click begins",
 	);
 	assert.ok(
+		contents.lastIndexOf('phase: "pre-timed-read",') <
+				contents.indexOf("writerTopologyBeforeTimedRead =") &&
+			contents.indexOf("writerTopologyBeforeTimedRead =") <
+				contents.indexOf("const downloadCompletion = armSavedViaPicker(") &&
+			contents.indexOf("const downloadCompletion = armSavedViaPicker(") <
+				contents.indexOf("const downloadClickStartedAt = Date.now()"),
+		"pre-read pubsub counters must stabilize after telemetry setup and immediately before the timed click",
+	);
+	assert.ok(
 		contents.indexOf("const download = await downloadCompletion") <
 			contents.indexOf(
 				"await downloadMemoryTelemetryController.stopSampling()",
 			) &&
 			contents.indexOf(
 				"await downloadMemoryTelemetryController.stopSampling()",
-			) < contents.indexOf('stage = "verify-integrity"'),
-		"memory telemetry sampling must stop at sink completion before integrity and topology work",
+			) < contents.indexOf("writerTopologyAfterTimedRead =") &&
+			contents.indexOf("writerTopologyAfterTimedRead =") <
+				contents.indexOf('stage = "verify-integrity"'),
+		"memory telemetry sampling must stop at sink completion before the immediate topology snapshot and integrity work",
+	);
+	assert.ok(
+		contents.indexOf("writerTopologyAfterTimedRead =") <
+			contents.indexOf("waitForTerminalReaderIdle()") &&
+			contents.indexOf("readerTopologyAfterTimedRead =") <
+				contents.indexOf("waitForTerminalReaderIdle()"),
+		"post-read topology must be captured before terminal locality waits can change the observed state",
+	);
+	assert.ok(
+		contents.indexOf("writerTopologyAfterTimedRead =") <
+			contents.lastIndexOf(
+				"requireMonotonicTransportCounterDelta(",
+			) &&
+			contents.lastIndexOf("requireMonotonicTransportCounterDelta(") <
+				contents.indexOf('stage = "verify-integrity"'),
+		"the immediate post-read gate must enforce local per-key monotonicity before integrity work",
+	);
+	assert.ok(
+		contents.indexOf(
+			"await downloadMemoryTelemetryController.stopSampling()",
+		) < contents.lastIndexOf('phase: "post-timed-read",') &&
+			contents.lastIndexOf('phase: "post-timed-read",') <
+				contents.indexOf("writerTopologyAfterTimedRead ="),
+		"post-read pubsub counters must stabilize immediately after memory sampling stops",
+	);
+	assert.match(
+		contents,
+		/const latestAcceptedFinishedAt =\s*downloadCompletionObservedAt \+\s*TRANSPORT_COUNTER_POST_READ_CAPTURE_MAX_DELAY_MS;[\s\S]*?const deadlineAt = Math\.min\(\s*startedAt \+ TRANSPORT_COUNTER_STABILITY_TIMEOUT_MS,\s*latestAcceptedFinishedAt,\s*\);/,
+		"the post-read gate deadline must retain a one-second margin before inbound pruning",
 	);
 	assert.ok(
 		contents.indexOf("integrityVerifiedAt = Date.now()") <
@@ -339,8 +413,8 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 	);
 	assert.match(
 		contents,
-		/postMonitorFinishedAt = Date\.now\(\);[\s\S]*?beforePreloadObservation[\s\S]*?preloadLocalChunkPrefix\([\s\S]*?collectStableReaderLocality\(\)[\s\S]*?writerTopologyBeforeTimedRead[\s\S]*?stage = "download-to-selected-sink"/,
-		"preload closure, stable exact-prefix evidence, and topology must precede the timed read",
+		/postMonitorFinishedAt = Date\.now\(\);[\s\S]*?beforePreloadObservation[\s\S]*?preloadLocalChunkPrefix\([\s\S]*?collectStableReaderLocality\(\)[\s\S]*?stage = "download-to-selected-sink"[\s\S]*?phase: "pre-timed-read"[\s\S]*?writerTopologyBeforeTimedRead[\s\S]*?downloadClickStartedAt = Date\.now\(\)/,
+		"preload closure and exact-prefix evidence must precede the final pre-read transport stability gate and timed read",
 	);
 	assert.match(
 		contents,

--- a/scripts/file-share/templates/download-memory-telemetry.mjs
+++ b/scripts/file-share/templates/download-memory-telemetry.mjs
@@ -10,7 +10,7 @@ export const DOWNLOAD_MEMORY_CLEANUP_TIMEOUT_MS = 9_000;
 export const DOWNLOAD_MEMORY_SETUP_ALLOWANCE_MS = 30_000;
 export const DOWNLOAD_MEMORY_TERMINAL_ALLOWANCE_MS = 30_000;
 export const DOWNLOAD_MEMORY_WINDOW_DEFINITION =
-	"samplers-armed-after-reader-locality-stabilization-immediately-before-download-click-through-selected-sink-completion";
+	"samplers-armed-after-any-requested-reader-locality-prefix-stabilization-before-any-requested-bounded-pre-read-transport-counter-gate-and-download-click-through-selected-sink-completion";
 export const DOWNLOAD_MEMORY_MAX_SAMPLES_PER_SERIES = 4_096;
 export const DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE = 2;
 export const DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS = 16;

--- a/scripts/file-share/templates/seeder-probe.e2e.spec.ts
+++ b/scripts/file-share/templates/seeder-probe.e2e.spec.ts
@@ -24,7 +24,7 @@ const EFFECTIVE_SAMPLE_INTERVAL_MS = Math.max(
 );
 const RESULT_SCHEMA = {
 	id: "peerbit-file-share-benchmark",
-	version: 8,
+	version: 9,
 } as const;
 const RUN_NONCE = process.env.PW_BENCHMARK_RUN_NONCE;
 const parseJsonEnvironment = (name: string) => {

--- a/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
+++ b/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
@@ -41,6 +41,14 @@ const READER_TERMINAL_TOPOLOGY =
 	process.env.PW_READER_TERMINAL_TOPOLOGY || null;
 const LOCALITY_CONTROL_POLL_MS = Math.min(POLL_MS, 100);
 const LOCALITY_CONTROL_STABLE_SAMPLE_COUNT = 3;
+const TRANSPORT_COUNTER_STABILITY_POLL_MS = 100;
+const TRANSPORT_COUNTER_STABILITY_TIMEOUT_MS = 5_000;
+const TRANSPORT_COUNTER_STABLE_SAMPLE_COUNT = 3;
+const TRANSPORT_COUNTER_MAX_COUNTERPART_BYTE_SKEW = 1024 * 1024;
+const TRANSPORT_COUNTER_SAMPLE_CLOCK_TOLERANCE_MS = 1;
+const TRANSPORT_COUNTER_PRE_READ_START_TOLERANCE_MS = 1_000;
+const TRANSPORT_COUNTER_POST_READ_CAPTURE_MAX_DELAY_MS = 9_000;
+const PUBSUB_PROTOCOL = "/peerbit/topic-control-plane/2.0.0";
 const POST_UPLOAD_MONITOR_MS = Number(
 	process.env.PW_POST_UPLOAD_MONITOR_MS || "5000",
 );
@@ -62,12 +70,14 @@ const TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION =
 	"max(5000ms, pollMs + 1000ms) for browser actions and event-loop scheduling";
 // Controlled locality can spend a full download deadline preloading the prefix,
 // then one readiness deadline each stabilizing that prefix, waiting for the
-// completed transfer to become idle, and stabilizing terminal topology. The
-// measured download retains its separate DOWNLOAD_TIMEOUT_MS budget below.
+// completed transfer to become idle, stabilizing terminal topology, and the
+// bounded pre/post timed-read transport-counter gates. The measured download
+// retains its separate DOWNLOAD_TIMEOUT_MS budget below.
 const LOCALITY_CONTROL_OUTER_TIMEOUT_BUDGET_MS =
 	READER_LOCAL_CHUNK_TARGET === null
 		? 0
 		: 3 * READY_TIMEOUT_MS +
+			2 * TRANSPORT_COUNTER_STABILITY_TIMEOUT_MS +
 			(READER_LOCAL_CHUNK_TARGET > 0
 				? DOWNLOAD_TIMEOUT_MS + TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS
 				: 0);
@@ -115,7 +125,7 @@ const FIXTURE_SEED =
 	process.env.PW_FIXTURE_SEED || "peerbit-file-share-benchmark-v1";
 const RESULT_SCHEMA = {
 	id: "peerbit-file-share-benchmark",
-	version: 8,
+	version: 9,
 } as const;
 const SEEDER_DROP_POLICY = {
 	id: "peerbit-file-share-seeder-drop-policy",
@@ -590,6 +600,276 @@ const getTopologySnapshot = async (page: Page) =>
 		return await hooks.getTopologySnapshot();
 	});
 
+type TransportCounter = {
+	key: string;
+	bytes: number;
+};
+
+type CounterpartTransportSummary = {
+	counters: TransportCounter[];
+	streamCount: number;
+	totalBytes: number;
+};
+
+type TransportTopologyObservation = {
+	capturedAt: number;
+	writerTopology: Record<string, any>;
+	readerTopology: Record<string, any>;
+};
+
+const summarizeCounterpartPubsubTransport = (
+	topology: Record<string, any>,
+	{
+		direction,
+		expectedPeerHash,
+		expectedRemotePeerId,
+		label,
+	}: {
+		direction: "inbound" | "outbound";
+		expectedPeerHash: string;
+		expectedRemotePeerId: string;
+		label: string;
+	},
+): CounterpartTransportSummary => {
+	if (!Array.isArray(topology.transportStreams)) {
+		throw new Error(`${label} is missing transport stream diagnostics`);
+	}
+	if (
+		topology.transportStreams.some(
+			(stream: unknown) =>
+				stream == null || typeof stream !== "object" || Array.isArray(stream),
+		)
+	) {
+		throw new Error(`${label} contains malformed transport stream diagnostics`);
+	}
+	const streams = topology.transportStreams.filter(
+		(stream: Record<string, unknown>) =>
+			stream.service === "pubsub" &&
+			stream.direction === direction &&
+			(stream.remotePeerHash === expectedPeerHash ||
+				stream.remotePeer === expectedRemotePeerId),
+	);
+	if (streams.length === 0) {
+		throw new Error(`${label} has no relevant counterpart pubsub stream`);
+	}
+	const counters = new Map<string, number>();
+	let totalBytes = 0;
+	for (const [index, stream] of streams.entries()) {
+		if (
+			stream.remotePeerHash !== expectedPeerHash ||
+			stream.remotePeer !== expectedRemotePeerId ||
+			stream.peerHashIdentityMatch !== true ||
+			stream.serviceProtocol !== PUBSUB_PROTOCOL ||
+			stream.expectedProtocol !== PUBSUB_PROTOCOL ||
+			stream.protocol !== PUBSUB_PROTOCOL ||
+			stream.protocolIdentityMatch !== true ||
+			stream.counterStreamIdentityMatch !== true ||
+			stream.connectionIdentityMatchCount !== 1 ||
+			typeof stream.connectionId !== "string" ||
+			stream.connectionId.length === 0 ||
+			typeof stream.multiplexer !== "string" ||
+			stream.multiplexer.length === 0 ||
+			typeof stream.id !== "string" ||
+			stream.id.length === 0 ||
+			!Number.isSafeInteger(stream.bytes) ||
+			stream.bytes < 0 ||
+			(direction === "outbound"
+				? stream.aborted !== false
+				: stream.aborted !== null)
+		) {
+			throw new Error(
+				`${label} relevant pubsub stream ${index} is not authoritative`,
+			);
+		}
+		const key = JSON.stringify([
+			stream.service,
+			stream.remotePeerHash,
+			stream.remotePeer,
+			stream.direction,
+			stream.connectionId,
+			stream.id,
+			stream.multiplexer,
+			stream.protocol,
+		]);
+		if (counters.has(key)) {
+			throw new Error(`${label} contains a duplicate pubsub counter key`);
+		}
+		counters.set(key, stream.bytes);
+		totalBytes += stream.bytes;
+	}
+	if (!Number.isSafeInteger(totalBytes)) {
+		throw new Error(`${label} has inconsistent pubsub counter totals`);
+	}
+	return {
+		counters: [...counters.entries()]
+			.map(([key, bytes]) => ({ key, bytes }))
+			.sort((left, right) => left.key.localeCompare(right.key)),
+		streamCount: streams.length,
+		totalBytes,
+	};
+};
+
+const requireMonotonicTransportCounterDelta = (
+	before: CounterpartTransportSummary,
+	after: CounterpartTransportSummary,
+	label: string,
+) => {
+	const beforeKeys = before.counters.map(({ key }) => key);
+	const afterKeys = after.counters.map(({ key }) => key);
+	if (JSON.stringify(beforeKeys) !== JSON.stringify(afterKeys)) {
+		throw new Error(`${label} pubsub counter key set changed during timed read`);
+	}
+	for (const [index, afterCounter] of after.counters.entries()) {
+		if (afterCounter.bytes < before.counters[index].bytes) {
+			throw new Error(`${label} pubsub counter decreased during timed read`);
+		}
+	}
+	return after.totalBytes - before.totalBytes;
+};
+
+const collectStableCounterpartTransportTopology = async ({
+	writer,
+	reader,
+	expectedWriterPeerHash,
+	expectedReaderPeerHash,
+	expectedWriterPeerId,
+	expectedReaderPeerId,
+	startedAt,
+	deadlineAt,
+	observations,
+	phase,
+}: {
+	writer: Page;
+	reader: Page;
+	expectedWriterPeerHash: string;
+	expectedReaderPeerHash: string;
+	expectedWriterPeerId: string;
+	expectedReaderPeerId: string;
+	startedAt: number;
+	deadlineAt: number;
+	observations: TransportTopologyObservation[];
+	phase: "pre-timed-read" | "post-timed-read";
+}) => {
+	if (
+		deadlineAt <= startedAt ||
+		deadlineAt > startedAt + TRANSPORT_COUNTER_STABILITY_TIMEOUT_MS ||
+		Date.now() < startedAt
+	) {
+		throw new Error(`${phase} transport topology deadline is invalid`);
+	}
+	let stableSignature: string | null = null;
+	let stableCount = 0;
+	let previous:
+		| {
+				writer: CounterpartTransportSummary;
+				reader: CounterpartTransportSummary;
+		  }
+		| undefined;
+	let lastSummaries: typeof previous;
+	while (Date.now() <= deadlineAt) {
+		const remainingMs = Math.max(1, deadlineAt - Date.now());
+		const [writerTopology, readerTopology] = await withDeadline(
+			Promise.all([
+				getTopologySnapshot(writer),
+				getTopologySnapshot(reader),
+			]),
+			remainingMs,
+			`${phase} transport topology capture exceeded its bounded deadline`,
+		);
+		const observation = {
+			capturedAt: Date.now(),
+			writerTopology,
+			readerTopology,
+		};
+		observations.push(observation);
+		if (
+			writerTopology.peerHash !== expectedWriterPeerHash ||
+			readerTopology.peerHash !== expectedReaderPeerHash ||
+			writerTopology.peerId !== expectedWriterPeerId ||
+			readerTopology.peerId !== expectedReaderPeerId ||
+			!Number.isSafeInteger(writerTopology.capturedAt) ||
+			!Number.isSafeInteger(readerTopology.capturedAt) ||
+			writerTopology.capturedAt < startedAt ||
+			readerTopology.capturedAt < startedAt ||
+			writerTopology.capturedAt > observation.capturedAt ||
+			readerTopology.capturedAt > observation.capturedAt
+		) {
+			throw new Error(
+				`${phase} topology capture does not preserve the controlled peer identities and window`,
+			);
+		}
+		const writerSummary = summarizeCounterpartPubsubTransport(
+			writerTopology,
+			{
+				direction: "outbound",
+				expectedPeerHash: expectedReaderPeerHash,
+				expectedRemotePeerId: expectedReaderPeerId,
+				label: `${phase} writer topology`,
+			},
+		);
+		const readerSummary = summarizeCounterpartPubsubTransport(
+			readerTopology,
+			{
+				direction: "inbound",
+				expectedPeerHash: expectedWriterPeerHash,
+				expectedRemotePeerId: expectedWriterPeerId,
+				label: `${phase} reader topology`,
+			},
+		);
+		lastSummaries = { writer: writerSummary, reader: readerSummary };
+		if (previous) {
+			for (const side of ["writer", "reader"] as const) {
+				const previousKeys = previous[side].counters.map(({ key }) => key);
+				const currentKeys = lastSummaries[side].counters.map(
+					({ key }) => key,
+				);
+				if (JSON.stringify(previousKeys) === JSON.stringify(currentKeys)) {
+					for (const [index, current] of lastSummaries[
+						side
+					].counters.entries()) {
+						if (current.bytes < previous[side].counters[index].bytes) {
+							throw new Error(
+								`${phase} ${side} pubsub counter decreased for an unchanged key set`,
+							);
+						}
+					}
+				}
+			}
+		}
+		previous = lastSummaries;
+		const counterpartByteSkew = Math.abs(
+			writerSummary.totalBytes - readerSummary.totalBytes,
+		);
+		const signature =
+			counterpartByteSkew <= TRANSPORT_COUNTER_MAX_COUNTERPART_BYTE_SKEW
+			? JSON.stringify({
+					writer: writerSummary,
+					reader: readerSummary,
+				})
+			: null;
+		if (signature !== null && signature === stableSignature) {
+			stableCount += 1;
+		} else {
+			stableSignature = signature;
+			stableCount = signature === null ? 0 : 1;
+		}
+		if (stableCount >= TRANSPORT_COUNTER_STABLE_SAMPLE_COUNT) {
+			return observation;
+		}
+		const waitMs = Math.min(
+			TRANSPORT_COUNTER_STABILITY_POLL_MS,
+			Math.max(0, deadlineAt - Date.now()),
+		);
+		if (waitMs === 0) {
+			break;
+		}
+		await reader.waitForTimeout(waitMs);
+	}
+	throw new Error(
+		`${phase} counterpart pubsub counters did not become stable within the byte-skew bound before the deadline: ${JSON.stringify(lastSummaries ?? null)}`,
+	);
+};
+
 const topologyHasExactWriterSingleton = (
 	writerTopology: Record<string, any>,
 	readerTopology: Record<string, any>,
@@ -873,6 +1153,20 @@ test.describe("generated transfer-validity benchmark", () => {
 						stabilityPollIntervalMs: LOCALITY_CONTROL_POLL_MS,
 						requiredStableObservationCount:
 							LOCALITY_CONTROL_STABLE_SAMPLE_COUNT,
+						transportCounterStabilityPollIntervalMs:
+							TRANSPORT_COUNTER_STABILITY_POLL_MS,
+						transportCounterStabilityTimeoutMs:
+							TRANSPORT_COUNTER_STABILITY_TIMEOUT_MS,
+						transportCounterRequiredStableObservationCount:
+							TRANSPORT_COUNTER_STABLE_SAMPLE_COUNT,
+						transportCounterMaxCounterpartByteSkew:
+							TRANSPORT_COUNTER_MAX_COUNTERPART_BYTE_SKEW,
+						transportCounterSampleClockToleranceMs:
+							TRANSPORT_COUNTER_SAMPLE_CLOCK_TOLERANCE_MS,
+						transportCounterPreReadStartToleranceMs:
+							TRANSPORT_COUNTER_PRE_READ_START_TOLERANCE_MS,
+						transportCounterPostReadCaptureMaxDelayMs:
+							TRANSPORT_COUNTER_POST_READ_CAPTURE_MAX_DELAY_MS,
 						status: "pending",
 						readerInitialRoleEvidence: null as InitialReaderRoleEvidence | null,
 						writerTopologyBeforeUpload: null as Record<string, unknown> | null,
@@ -885,6 +1179,25 @@ test.describe("generated transfer-validity benchmark", () => {
 							string,
 							unknown
 						> | null,
+						preTimedReadTopologyStartedAt: null as number | null,
+						preTimedReadTopologyDeadlineAt: null as number | null,
+						preTimedReadTopologyFinishedAt: null as number | null,
+						preTimedReadTopologyObservations:
+							[] as TransportTopologyObservation[],
+						writerTopologyAfterTimedRead: null as Record<
+							string,
+							unknown
+						> | null,
+						readerTopologyAfterTimedRead: null as Record<
+							string,
+							unknown
+						> | null,
+						postTimedReadTopologyStartedAt: null as number | null,
+						postTimedReadTopologyDeadlineAt: null as number | null,
+						postTimedReadTopologyFinishedAt: null as number | null,
+						postTimedReadTopologyCaptureDelayMs: null as number | null,
+						postTimedReadTopologyObservations:
+							[] as TransportTopologyObservation[],
 						beforePreloadObservation:
 							null as LocalChunkPrefixObservation | null,
 						preloadEvidence: null as Record<string, unknown> | null,
@@ -908,6 +1221,39 @@ test.describe("generated transfer-validity benchmark", () => {
 						cohortKey: null as string | null,
 						failure: null as string | null,
 					};
+		const getControlledPeerIdentities = () => {
+			if (!readerLocalityControl) {
+				throw new Error("Reader locality control is unavailable");
+			}
+			const writerBeforeUpload =
+				readerLocalityControl.writerTopologyBeforeUpload;
+			const readerBeforeUpload =
+				readerLocalityControl.readerTopologyBeforeUpload;
+			const expectedWriterPeerHash = writerBeforeUpload?.peerHash;
+			const expectedReaderPeerHash = readerBeforeUpload?.peerHash;
+			const expectedWriterPeerId = writerBeforeUpload?.peerId;
+			const expectedReaderPeerId = readerBeforeUpload?.peerId;
+			if (
+				typeof expectedWriterPeerHash !== "string" ||
+				expectedWriterPeerHash.length === 0 ||
+				typeof expectedReaderPeerHash !== "string" ||
+				expectedReaderPeerHash.length === 0 ||
+				typeof expectedWriterPeerId !== "string" ||
+				expectedWriterPeerId.length === 0 ||
+				typeof expectedReaderPeerId !== "string" ||
+				expectedReaderPeerId.length === 0
+			) {
+				throw new Error(
+					"Controlled-locality peer identities are unavailable for transport-counter stabilization",
+				);
+			}
+			return {
+				expectedWriterPeerHash,
+				expectedReaderPeerHash,
+				expectedWriterPeerId,
+				expectedReaderPeerId,
+			};
+		};
 		attachTransferErrorCollector(writer, "writer", errors, requestFailures);
 		attachTransferErrorCollector(reader, "reader", errors, requestFailures);
 
@@ -1568,19 +1914,7 @@ test.describe("generated transfer-validity benchmark", () => {
 				readerLocalityControl.speculativeOvershootChunkCount =
 					preDownloadObservation.blockCount! - READER_LOCAL_CHUNK_TARGET;
 				readerLocalityControl.cohortKey = `observer-persistent-prefix-b${preDownloadObservation.blockCount}-i${preDownloadObservation.indexRowCount}`;
-				const [writerTopology, readerTopology] = await Promise.all([
-					getTopologySnapshot(writer),
-					getTopologySnapshot(reader),
-				]);
-				readerLocalityControl.writerTopologyBeforeTimedRead = writerTopology;
-				readerLocalityControl.readerTopologyBeforeTimedRead = readerTopology;
-				if (!topologyHasExactWriterSingleton(writerTopology, readerTopology)) {
-					throw new Error(
-						"Controlled-locality reader joined the replication set before the timed read",
-					);
-				}
-				readerLocalityControl.status = "stable";
-				logStage("reader-locality-stable", {
+				logStage("reader-locality-prefix-stable", {
 					actualLocalChunkBlockCount:
 						readerLocalityControl.actualLocalChunkBlockCount,
 					actualLocalChunkIndexRowCount:
@@ -1624,6 +1958,48 @@ test.describe("generated transfer-validity benchmark", () => {
 					"Download memory telemetry did not collect clean initial samples",
 				);
 			}
+			if (readerLocalityControl) {
+				stage = "stabilize-pre-timed-read-transport";
+				const identities = getControlledPeerIdentities();
+				const startedAt = Date.now();
+				const deadlineAt =
+					startedAt + TRANSPORT_COUNTER_STABILITY_TIMEOUT_MS;
+				readerLocalityControl.preTimedReadTopologyStartedAt = startedAt;
+				readerLocalityControl.preTimedReadTopologyDeadlineAt = deadlineAt;
+				const finalObservation =
+					await collectStableCounterpartTransportTopology({
+						writer,
+						reader,
+						...identities,
+						startedAt,
+						deadlineAt,
+						observations:
+							readerLocalityControl.preTimedReadTopologyObservations,
+						phase: "pre-timed-read",
+					});
+				const finishedAt = Date.now();
+				if (finishedAt > deadlineAt) {
+					throw new Error(
+						"Pre-timed-read transport counters stabilized after their bounded deadline",
+					);
+				}
+				readerLocalityControl.preTimedReadTopologyFinishedAt = finishedAt;
+				readerLocalityControl.writerTopologyBeforeTimedRead =
+					finalObservation.writerTopology;
+				readerLocalityControl.readerTopologyBeforeTimedRead =
+					finalObservation.readerTopology;
+				if (
+					!topologyHasExactWriterSingleton(
+						finalObservation.writerTopology,
+						finalObservation.readerTopology,
+					)
+				) {
+					throw new Error(
+						"Controlled-locality reader joined the replication set before the timed read",
+					);
+				}
+				readerLocalityControl.status = "stable";
+			}
 			const downloadCompletion = armSavedViaPicker(
 				reader,
 				fileName,
@@ -1631,12 +2007,132 @@ test.describe("generated transfer-validity benchmark", () => {
 				DOWNLOAD_TIMEOUT_MS,
 			);
 			const downloadClickStartedAt = Date.now();
+			if (
+				readerLocalityControl &&
+				(!Number.isSafeInteger(
+					readerLocalityControl.preTimedReadTopologyFinishedAt,
+				) ||
+					downloadClickStartedAt <
+						(readerLocalityControl.preTimedReadTopologyFinishedAt as number) ||
+					downloadClickStartedAt -
+						(readerLocalityControl.preTimedReadTopologyFinishedAt as number) >
+						TRANSPORT_COUNTER_PRE_READ_START_TOLERANCE_MS)
+			) {
+				throw new Error(
+					"Timed read did not start within the bounded pre-read transport-counter handoff",
+				);
+			}
 			downloadStartedAt = downloadClickStartedAt;
 			await downloadButton.click();
 			const download = await downloadCompletion;
 			downloadCompletionObservedAt = Date.now();
 			downloadMemoryTelemetry =
 				await downloadMemoryTelemetryController.stopSampling();
+			if (readerLocalityControl) {
+				stage = "stabilize-post-timed-read-transport";
+				const identities = getControlledPeerIdentities();
+				const startedAt = Date.now();
+				const latestAcceptedFinishedAt =
+					downloadCompletionObservedAt +
+					TRANSPORT_COUNTER_POST_READ_CAPTURE_MAX_DELAY_MS;
+				const deadlineAt = Math.min(
+					startedAt + TRANSPORT_COUNTER_STABILITY_TIMEOUT_MS,
+					latestAcceptedFinishedAt,
+				);
+				readerLocalityControl.postTimedReadTopologyStartedAt = startedAt;
+				readerLocalityControl.postTimedReadTopologyDeadlineAt = deadlineAt;
+				if (deadlineAt <= startedAt) {
+					throw new Error(
+						"Post-timed-read transport capture started after its inbound-pruning safety window",
+					);
+				}
+				const finalObservation =
+					await collectStableCounterpartTransportTopology({
+						writer,
+						reader,
+						...identities,
+						startedAt,
+						deadlineAt,
+						observations:
+							readerLocalityControl.postTimedReadTopologyObservations,
+						phase: "post-timed-read",
+					});
+				const finishedAt = Date.now();
+				const captureDelayMs = finishedAt - downloadCompletionObservedAt;
+				readerLocalityControl.postTimedReadTopologyCaptureDelayMs = captureDelayMs;
+				if (
+					!Number.isSafeInteger(captureDelayMs) ||
+					captureDelayMs < 0 ||
+					captureDelayMs >
+						TRANSPORT_COUNTER_POST_READ_CAPTURE_MAX_DELAY_MS ||
+					finishedAt > deadlineAt ||
+					finishedAt > latestAcceptedFinishedAt
+				) {
+					throw new Error(
+						"Post-timed-read transport counters stabilized after their bounded inbound-pruning safety deadline",
+					);
+				}
+				readerLocalityControl.postTimedReadTopologyFinishedAt = finishedAt;
+				readerLocalityControl.writerTopologyAfterTimedRead =
+					finalObservation.writerTopology;
+				readerLocalityControl.readerTopologyAfterTimedRead =
+					finalObservation.readerTopology;
+				const preWriterSummary = summarizeCounterpartPubsubTransport(
+					readerLocalityControl.writerTopologyBeforeTimedRead!,
+					{
+						direction: "outbound",
+						expectedPeerHash: identities.expectedReaderPeerHash,
+						expectedRemotePeerId: identities.expectedReaderPeerId,
+						label: "pre-timed-read writer topology",
+					},
+				);
+				const postWriterSummary = summarizeCounterpartPubsubTransport(
+					finalObservation.writerTopology,
+					{
+						direction: "outbound",
+						expectedPeerHash: identities.expectedReaderPeerHash,
+						expectedRemotePeerId: identities.expectedReaderPeerId,
+						label: "post-timed-read writer topology",
+					},
+				);
+				const preReaderSummary = summarizeCounterpartPubsubTransport(
+					readerLocalityControl.readerTopologyBeforeTimedRead!,
+					{
+						direction: "inbound",
+						expectedPeerHash: identities.expectedWriterPeerHash,
+						expectedRemotePeerId: identities.expectedWriterPeerId,
+						label: "pre-timed-read reader topology",
+					},
+				);
+				const postReaderSummary = summarizeCounterpartPubsubTransport(
+					finalObservation.readerTopology,
+					{
+						direction: "inbound",
+						expectedPeerHash: identities.expectedWriterPeerHash,
+						expectedRemotePeerId: identities.expectedWriterPeerId,
+						label: "post-timed-read reader topology",
+					},
+				);
+				const writerCounterDelta = requireMonotonicTransportCounterDelta(
+					preWriterSummary,
+					postWriterSummary,
+					"Writer",
+				);
+				const readerCounterDelta = requireMonotonicTransportCounterDelta(
+					preReaderSummary,
+					postReaderSummary,
+					"Reader",
+				);
+				if (
+					Math.abs(writerCounterDelta - readerCounterDelta) >
+					TRANSPORT_COUNTER_MAX_COUNTERPART_BYTE_SKEW
+				) {
+					throw new Error(
+						"Writer outbound and reader inbound pubsub counter deltas exceed the byte-skew bound",
+					);
+				}
+				stage = "validate-download-completion";
+			}
 			const memorySeries = [
 				downloadMemoryTelemetry.readerJsHeap,
 				downloadMemoryTelemetry.writerJsHeap,


### PR DESCRIPTION
Capture authoritative pubsub carrier counters immediately before and after controlled file-share reads so pruning benchmarks can distinguish one healthy carrier from duplicate outbound candidates.

The schema-v9 evidence uses bounded three-sample stability gates, exact peer/protocol/raw-stream/live-connection identity, endpoint-local key continuity and monotonic counters, a 1 MiB writer/reader delta-skew bound, and a post-read deadline before inbound pruning. All observations survive later failures.

Validated locally:
- 182/182 file-share harness tests
- 118/118 focused validity and template-contract tests
- Prettier and git diff checks
- independent review: no P0-P2 findings