### PR TITLE
perf(blocks): avoid rehashing verified remote reads

### DIFF
--- a/.changeset/quick-blocks-rest.md
+++ b/.changeset/quick-blocks-rest.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/blocks": patch
+---
+
+Persist verified remote block responses with their known CID, avoiding a redundant full-block hash while retaining response integrity validation.

--- a/packages/transport/blocks/src/remote.ts
+++ b/packages/transport/blocks/src/remote.ts
@@ -697,7 +697,9 @@ export class RemoteBlocks implements IBlocks {
 				const cidObject = cidifyString(cid);
 				value = await this._readFromPeers(cid, cidObject, remoteOptions);
 				if (remoteOptions?.replicate && value) {
-					await this.put(value);
+					// _readFromPeers verifies the response bytes against cid before it
+					// resolves, so avoid hashing the full block a second time here.
+					await this.putKnown(cid, value);
 				}
 			}
 		}

--- a/packages/transport/blocks/test/libp2p.spec.ts
+++ b/packages/transport/blocks/test/libp2p.spec.ts
@@ -1,4 +1,5 @@
 import { serialize } from "@dao-xyz/borsh";
+import { createBlock, stringifyCid } from "@peerbit/blocks-interface";
 import { TestSession } from "@peerbit/libp2p-test-utils";
 import { waitForNeighbour } from "@peerbit/stream";
 import {
@@ -151,6 +152,139 @@ describe("transport", function () {
 			remote: { timeout: 5000 },
 		});
 		expect(new Uint8Array(readData!)).to.deep.equal(data);
+	});
+
+	it("persists verified remote reads through the known-CID path", async () => {
+		const onPut = sinon.spy();
+		session = await TestSession.connected(2, {
+			services: { blocks: (c) => new DirectBlock(c, { onPut }) },
+		});
+		await waitForNeighbour(store(session, 0), store(session, 1));
+
+		const data = new Uint8Array([5, 4, 3]);
+		const cid = await store(session, 0).put(data);
+		onPut.resetHistory();
+
+		const requesterRemoteBlocks = (store(session, 1) as any)[
+			"remoteBlocks"
+		] as RemoteBlocks;
+		const put = sinon.spy(requesterRemoteBlocks.localStore, "put");
+		const putKnown = sinon.spy(requesterRemoteBlocks.localStore, "putKnown");
+
+		try {
+			const readData = await store(session, 1).get(cid, {
+				remote: {
+					timeout: 5_000,
+					from: [store(session, 0).publicKeyHash],
+					replicate: true,
+				},
+			});
+
+			expect(new Uint8Array(readData!)).to.deep.equal(data);
+			expect(put.callCount).to.equal(0);
+			expect(putKnown.callCount).to.equal(1);
+			expect(putKnown.getCall(0).args[0]).to.equal(cid);
+			expect(putKnown.getCall(0).args[1]).to.deep.equal(data);
+			expect(onPut.callCount).to.equal(1);
+			expect(onPut.getCall(0).args[0]).to.equal(cid);
+			expect(await store(session, 1).has(cid)).to.equal(true);
+		} finally {
+			put.restore();
+			putKnown.restore();
+		}
+	});
+
+	it("preserves a verified DAG-CBOR CID when replicating remotely", async () => {
+		session = await TestSession.connected(2, {
+			services: { blocks: (c) => new DirectBlock(c) },
+		});
+		await waitForNeighbour(store(session, 0), store(session, 1));
+
+		const block = await createBlock({ hello: "world" }, "dag-cbor");
+		const cid = stringifyCid(block.cid);
+		await store(session, 0).put({ block, cid });
+
+		const requesterRemoteBlocks = (store(session, 1) as any)[
+			"remoteBlocks"
+		] as RemoteBlocks;
+		const put = sinon.spy(requesterRemoteBlocks.localStore, "put");
+		const putKnown = sinon.spy(requesterRemoteBlocks.localStore, "putKnown");
+
+		try {
+			const readData = await store(session, 1).get(cid, {
+				remote: {
+					timeout: 5_000,
+					from: [store(session, 0).publicKeyHash],
+					replicate: true,
+				},
+			});
+
+			expect(new Uint8Array(readData!)).to.deep.equal(block.bytes);
+			expect(put.callCount).to.equal(0);
+			expect(putKnown.callCount).to.equal(1);
+			expect(putKnown.getCall(0).args[0]).to.equal(cid);
+			expect(putKnown.getCall(0).args[1]).to.deep.equal(block.bytes);
+			expect(await store(session, 1).has(cid)).to.equal(true);
+		} finally {
+			put.restore();
+			putKnown.restore();
+		}
+	});
+
+	it("does not persist a corrupt remote response", async () => {
+		const onPut = sinon.spy();
+		session = await TestSession.connected(2, {
+			services: { blocks: (c) => new DirectBlock(c, { onPut }) },
+		});
+		await waitForNeighbour(store(session, 0), store(session, 1));
+
+		const data = new Uint8Array([5, 4, 3]);
+		const cid = await store(session, 0).put(data);
+		onPut.resetHistory();
+
+		const requesterRemoteBlocks = (store(session, 1) as any)[
+			"remoteBlocks"
+		] as RemoteBlocks;
+		const providerRemoteBlocks = (store(session, 0) as any)[
+			"remoteBlocks"
+		] as RemoteBlocks;
+		const put = sinon.spy(requesterRemoteBlocks.localStore, "put");
+		const putKnown = sinon.spy(requesterRemoteBlocks.localStore, "putKnown");
+		const originalPublish = providerRemoteBlocks.options.publish;
+		let corruptResponseCount = 0;
+
+		providerRemoteBlocks.options.publish = async (message, options) => {
+			if (message instanceof BlockResponse) {
+				corruptResponseCount++;
+				await requesterRemoteBlocks.onMessage(
+					new BlockResponse(message.cid, new Uint8Array([9, 9, 9])),
+					{ from: store(session, 0).publicKeyHash },
+				);
+				return;
+			}
+			return originalPublish(message, options);
+		};
+
+		try {
+			const readData = await store(session, 1).get(cid, {
+				remote: {
+					timeout: 250,
+					from: [store(session, 0).publicKeyHash],
+					replicate: true,
+				},
+			});
+
+			expect(readData).to.equal(undefined);
+			expect(corruptResponseCount).to.be.greaterThan(0);
+			expect(put.callCount).to.equal(0);
+			expect(putKnown.callCount).to.equal(0);
+			expect(onPut.callCount).to.equal(0);
+			expect(await store(session, 1).has(cid)).to.equal(false);
+		} finally {
+			providerRemoteBlocks.options.publish = originalPublish;
+			put.restore();
+			putKnown.restore();
+		}
 	});
 
 	it("puts known cid blocks through direct block storage", async () => {


### PR DESCRIPTION
## Summary

- persist bytes returned by `_readFromPeers` with `putKnown(cid, value)` after the existing CID verification
- avoid computing a second raw SHA-256 CID for every replicated remote block
- preserve the requested CID codec and multihash (including DAG-CBOR)
- cover raw replication, DAG-CBOR replication, and corrupt-response rejection

## Safety boundary

`_readFromPeers` validates returned bytes with `checkDecodeBlock` before this persistence path is reached. The corrupt-response regression asserts that an intercepted invalid response is actually delivered and that neither `put`, `putKnown`, `onPut`, nor local persistence occurs.

## Validation

- `pnpm run build`
- full `@peerbit/blocks` suite: 47 passing
- root lint: 0 errors (11 pre-existing warnings)
- focused remote replication tests: 3 passing
- Prettier, `git diff --check`, and changeset status

## Realistic file-share benchmark

Counterbalanced 4 x 1 GiB all-remote file-share matrix, using deterministic bytes and exact SHA-256 plus CRC-32 gates:

| Variant | Library stream wall (runs) | Average | Throughput |
| --- | ---: | ---: | ---: |
| `c3a1535e` baseline | 67.107 s, 75.507 s | 71.307 s | 14.36 MiB/s |
| `396dee2f` head | 69.187 s, 61.008 s | 65.098 s | 15.73 MiB/s |

All four runs passed with the same 1,073,741,824-byte digest, zero local reader chunks/index rows, exactly 2,048 physical remote requests, one attempt per chunk, read-ahead 8, and zero request failures. The head average was 8.7% lower, but `n=2` is noisy, so this is evidence of no regression plus a promising signal—not a definitive speedup claim.

Pinned examples commit: `15067098a33b47223fe55cd7853353c2c1097c3f`.
