### PR TITLE
fix(blocks): validate responses before learning providers

### DIFF
--- a/.changeset/quiet-blocks-trust.md
+++ b/.changeset/quiet-blocks-trust.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/blocks": patch
+---
+
+Only learn block response senders as providers after their payload validates against the requested CID.

--- a/packages/transport/blocks/src/remote.ts
+++ b/packages/transport/blocks/src/remote.ts
@@ -120,7 +120,10 @@ export class RemoteBlocks implements IBlocks {
 		data: BlockMessage,
 		context?: BlockMessageContext,
 	) => any;
-	private _resolvers: Map<string, (data: Uint8Array) => Promise<void>>;
+	private _resolvers: Map<
+		string,
+		(data: Uint8Array, providerHash?: string) => Promise<void>
+	>;
 	private _blockCache?: EagerBlockCache;
 	private _providerCache?: Cache<string[]>;
 	private _rustProviderCache?: RustBlockProviderCache;
@@ -402,9 +405,6 @@ export class RemoteBlocks implements IBlocks {
 					});
 				} else if (message instanceof BlockResponse) {
 					// TODO make sure we are not storing too much bytes in ram (like filter large blocks)
-					if (context?.from) {
-						this.rememberProvider(message.cid, context.from);
-					}
 					let resolver = this._resolvers.get(message.cid);
 					if (!resolver) {
 						if (options.eagerBlocks) {
@@ -412,7 +412,7 @@ export class RemoteBlocks implements IBlocks {
 							this._blockCache!.add(message.cid, message.bytes);
 						}
 					} else {
-						await resolver(message.bytes);
+						await resolver(message.bytes, context?.from);
 					}
 				}
 			} catch (error) {
@@ -920,7 +920,9 @@ export class RemoteBlocks implements IBlocks {
 			const promise = new Promise<Block<any, any, any, 1> | undefined>(
 				(resolve, reject) => {
 					let timeoutCallback: ReturnType<typeof setTimeout> | undefined;
-					let resolver: ((bytes: Uint8Array) => Promise<void>) | undefined;
+					let resolver:
+						| ((bytes: Uint8Array, providerHash?: string) => Promise<void>)
+						| undefined;
 					let settled = false;
 					const abortHandler = () => {
 						cleanup();
@@ -959,9 +961,14 @@ export class RemoteBlocks implements IBlocks {
 						options.timeout || 30 * 1000,
 					);
 
-					resolver = async (bytes: Uint8Array) => {
+					resolver = async (bytes: Uint8Array, providerHash?: string) => {
 						const value = await tryDecode(bytes);
 						if (settled) return;
+						if (providerHash) {
+							// A response is only evidence that its sender can provide this CID
+							// after the payload has passed the requested CID's integrity check.
+							this.rememberProvider(cidString, providerHash);
+						}
 						settled = true;
 						cleanup();
 						resolve(value);

--- a/packages/transport/blocks/test/provider-learning.spec.ts
+++ b/packages/transport/blocks/test/provider-learning.spec.ts
@@ -1,0 +1,145 @@
+import { createStore } from "@peerbit/any-store";
+import { Ed25519Keypair } from "@peerbit/crypto";
+import { expect } from "chai";
+import pDefer from "p-defer";
+import { AnyBlockStore } from "../src/any-blockstore.js";
+import { BlockRequest, BlockResponse, RemoteBlocks } from "../src/remote.js";
+
+const CID = "zb2rhbnwihVzMMEGAPf9EwTZBsQz9fszCnM4Y8mJmBFgiyN7J";
+const VALID_BYTES = new Uint8Array([5, 4, 3]);
+const INVALID_BYTES = new Uint8Array([3, 4, 5]);
+
+type ProviderCache = {
+	get(cid: string): string[] | undefined;
+};
+
+describe("validated block provider learning", () => {
+	let remotes: RemoteBlocks[];
+
+	beforeEach(() => {
+		remotes = [];
+	});
+
+	afterEach(async () => {
+		for (const remote of remotes.reverse()) {
+			if (remote.status !== "closed") {
+				await remote.stop();
+			}
+		}
+	});
+
+	const createRemote = async (properties?: {
+		eagerBlocks?: boolean;
+		maxProvidersPerCid?: number;
+		requestSeen?: ReturnType<typeof pDefer<void>>;
+		requestTargets?: string[][];
+	}) => {
+		const key = await Ed25519Keypair.create();
+		const remote = new RemoteBlocks({
+			local: new AnyBlockStore(createStore()),
+			publicKey: key.publicKey,
+			publish: async (message, options) => {
+				if (message instanceof BlockRequest) {
+					const to = ((options as any).mode?.to ?? []) as string[];
+					properties?.requestTargets?.push([...to]);
+					properties?.requestSeen?.resolve();
+				}
+			},
+			waitFor: async (): Promise<string[]> => [],
+			eagerBlocks: properties?.eagerBlocks,
+			providerCache: {
+				maxProvidersPerCid: properties?.maxProvidersPerCid,
+			},
+		});
+		remotes.push(remote);
+		await remote.start();
+		return remote;
+	};
+
+	const cachedProviders = (remote: RemoteBlocks): string[] | undefined =>
+		(
+			remote as unknown as {
+				_providerCache: ProviderCache;
+			}
+		)._providerCache.get(CID);
+
+	it("does not learn the sender of an invalid active response", async () => {
+		const requestSeen = pDefer<void>();
+		const remote = await createRemote({ requestSeen });
+		const requestedProvider = "requested-provider";
+		const invalidResponder = "invalid-responder";
+
+		const read = remote.get(CID, {
+			remote: { from: [requestedProvider], timeout: 50 },
+		});
+		await requestSeen.promise;
+		await remote.onMessage(new BlockResponse(CID, INVALID_BYTES), {
+			from: invalidResponder,
+		});
+
+		expect(await read).to.equal(undefined);
+		expect(cachedProviders(remote)).to.deep.equal([requestedProvider]);
+	});
+
+	it("learns the sender of a valid active response", async () => {
+		const requestSeen = pDefer<void>();
+		const remote = await createRemote({ requestSeen });
+		const requestedProvider = "requested-provider";
+		const validResponder = "valid-responder";
+
+		const read = remote.get(CID, {
+			remote: { from: [requestedProvider], timeout: 1_000 },
+		});
+		await requestSeen.promise;
+		await remote.onMessage(new BlockResponse(CID, VALID_BYTES), {
+			from: validResponder,
+		});
+
+		expect(await read).to.deep.equal(VALID_BYTES);
+		expect(cachedProviders(remote)).to.deep.equal([
+			validResponder,
+			requestedProvider,
+		]);
+	});
+
+	it("does not learn the sender of an unsolicited invalid response", async () => {
+		const remote = await createRemote({ eagerBlocks: true });
+
+		await remote.onMessage(new BlockResponse(CID, INVALID_BYTES), {
+			from: "unsolicited-invalid-responder",
+		});
+
+		expect(cachedProviders(remote)).to.equal(undefined);
+	});
+
+	it("does not let an invalid response evict a bounded provider hint", async () => {
+		const requestSeen = pDefer<void>();
+		const requestTargets: string[][] = [];
+		const remote = await createRemote({
+			maxProvidersPerCid: 1,
+			requestSeen,
+			requestTargets,
+		});
+		const trustedProvider = "trusted-provider";
+		remote.hintProviders(CID, [trustedProvider]);
+
+		const read = remote.get(CID, { remote: { timeout: 50 } });
+		await requestSeen.promise;
+		await remote.onMessage(new BlockResponse(CID, INVALID_BYTES), {
+			from: "invalid-responder",
+		});
+
+		expect(await read).to.equal(undefined);
+		expect(cachedProviders(remote)).to.deep.equal([trustedProvider]);
+
+		// A subsequent read without explicit providers must still target the trusted
+		// cached hint rather than the invalid response sender.
+		expect(await remote.get(CID, { remote: { timeout: 50 } })).to.equal(
+			undefined,
+		);
+		expect(requestTargets).to.deep.equal([
+			[trustedProvider],
+			[trustedProvider],
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

- learn a block-response sender as a provider only after its payload validates against the requested CID
- stop unsolicited or invalid responses from changing provider routing hints
- retain the validated sender-learning behavior for successful active reads
- add bounded-cache regression coverage so an invalid sender cannot replace the only trusted hint

## Why

Previously, `BlockResponse` handling remembered `context.from` before the in-flight resolver ran `checkDecodeBlock`. Invalid bytes were correctly rejected, but their sender could still be cached as the preferred provider. This change moves learning behind the existing integrity boundary.

## Validation

- full root build
- full `@peerbit/blocks` suite: 48 passing
- focused provider-learning regressions: 4 passing
- root lint: 0 errors (11 pre-existing warnings)
- Prettier, `git diff --check`, and changeset status
- independent review: no P0-P2 findings

## Scope

This intentionally does not change the eager byte-cache policy. Unsolicited payloads may still be retained in that bounded cache and are validated when read; byte-budget hardening belongs in a separate change.
