### PR TITLE
fix(server): persist trust removals

### DIFF
--- a/.changeset/calm-admins-rest.md
+++ b/.changeset/calm-admins-rest.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/server": patch
+---
+
+Persist trust-list removals so revoked administrator keys remain revoked after a server restart, and report whether API revocation removed an existing key.

--- a/packages/clients/peerbit-server/node/src/server.ts
+++ b/packages/clients/peerbit-server/node/src/server.ts
@@ -884,8 +884,8 @@ export const startApiServer = async (
 							}
 							case "DELETE": {
 								const removed = properties.trust.remove(getPathValue(req, 1));
-								res.writeHead(200);
-								res.end(removed);
+								res.writeHead(removed ? 200 : 404);
+								res.end();
 								break;
 							}
 							default:

--- a/packages/clients/peerbit-server/node/src/trust.ts
+++ b/packages/clients/peerbit-server/node/src/trust.ts
@@ -32,6 +32,7 @@ export class Trust {
 		const existing = this.trusted.findIndex((x) => x === hashcode);
 		if (existing >= 0) {
 			this.trusted.splice(existing, 1);
+			this.save();
 			return true;
 		}
 		return false;

--- a/packages/clients/peerbit-server/node/test/api.spec.ts
+++ b/packages/clients/peerbit-server/node/test/api.spec.ts
@@ -146,17 +146,12 @@ describe("server", () => {
 		let session: TestSession, serverPeer: Peerbit, server: http.Server;
 		let db: PermissionedString;
 		let apiAddress: string;
+		let directory: string;
 		before(async () => {});
 
 		beforeEach(async () => {
 			const dirnameResolved = dirname(fileURLToPath(import.meta.url));
-			let directory = path.join(
-				dirnameResolved,
-				"tmp",
-				"api-test",
-				"api",
-				uuid(),
-			);
+			directory = path.join(dirnameResolved, "tmp", "api-test", "api", uuid());
 			session = await TestSession.disconnected(2, {
 				libp2p: { transports: [tcp(), webSockets()] },
 			});
@@ -252,6 +247,23 @@ describe("server", () => {
 					);
 					await c.access.allow(kp2.publicKey);
 					await c2.access.allow(kp3.publicKey); // now c2 can add since it is trusted by c
+				});
+
+				it("reports and persists access revocation", async () => {
+					const c = await client(session.peers[0].identity, apiAddress);
+					const revoked = (await Ed25519Keypair.create()).publicKey;
+					const revokedHash = revoked.hashcode();
+
+					expect(await c.access.allow(revoked)).to.equal(true);
+					expect(
+						new Trust(getTrustPath(directory)).isTrusted(revokedHash),
+					).to.equal(true);
+
+					expect(await c.access.deny(revoked)).to.equal(true);
+					expect(await c.access.deny(revoked)).to.equal(false);
+
+					const reloaded = new Trust(getTrustPath(directory));
+					expect(reloaded.isTrusted(revokedHash)).to.equal(false);
 				});
 			});
 			describe("close/drop", () => {

--- a/packages/clients/peerbit-server/node/test/trust.spec.ts
+++ b/packages/clients/peerbit-server/node/test/trust.spec.ts
@@ -1,0 +1,34 @@
+import { expect } from "chai";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { Trust } from "../src/trust.js";
+
+describe("trust", () => {
+	let directory: string;
+
+	beforeEach(() => {
+		directory = fs.mkdtempSync(path.join(os.tmpdir(), "peerbit-trust-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(directory, { recursive: true, force: true });
+	});
+
+	it("persists removals across reloads", () => {
+		const trustPath = path.join(directory, "trust.json");
+		const trust = new Trust(trustPath);
+		trust.add("revoked-admin");
+		trust.add("remaining-admin");
+
+		expect(trust.remove("revoked-admin")).to.equal(true);
+		expect(trust.remove("missing-admin")).to.equal(false);
+		expect(JSON.parse(fs.readFileSync(trustPath, "utf8"))).to.deep.equal([
+			"remaining-admin",
+		]);
+
+		const reloaded = new Trust(trustPath);
+		expect(reloaded.isTrusted("revoked-admin")).to.equal(false);
+		expect(reloaded.isTrusted("remaining-admin")).to.equal(true);
+	});
+});


### PR DESCRIPTION
## Summary

- persist successful trust-list removals before returning
- make `DELETE /trust/:key` return `200` when removed and `404` when absent
- preserve unrelated trusted keys across persistence and reload
- cover both direct `Trust` reload behavior and the public client API

## Why

`Trust.remove` previously changed only the in-memory list. A revoked administrator key therefore returned after restart. The endpoint also passed a boolean directly to `res.end`, which can throw after the removal has already happened and prevented the existing client from observing reliable true/false semantics.

## Validation

- full workspace build
- full `@peerbit/server` suite: 103 passing
- focused persistence/API regressions: 2 passing
- root lint: 0 errors (11 pre-existing warnings)
- Prettier, `git diff --check`, and changeset status
- independent review: no P0-P3 findings

Static keys configured through `--grant-access` remain intentionally authoritative and are re-added at startup; this change fixes dynamically persisted grants.
