### PR TITLE
feat(server)!: add strict signed requests v2

### DIFF
--- a/.changeset/strict-signed-requests.md
+++ b/.changeset/strict-signed-requests.md
@@ -1,0 +1,15 @@
+---
+"@peerbit/server": major
+---
+
+Replace the legacy replayable HTTP administration signature with strict
+signed-request v2. Requests are now framed unambiguously, bound to a pinned
+server identity and per-process boot ID, freshness checked, protected by
+single-use nonces, and verified against the exact request target and raw body
+digest. Remote records persist the server identity used for audience pinning.
+Existing remote names retain that pin until explicitly removed, so routine
+re-enrollment cannot silently accept a substituted server identity.
+
+Legacy signed requests are intentionally rejected. Upgrade remote servers
+before their administrator clients, then reconnect with the server peer ID
+pinned.

--- a/docs/modules/deploy/manage/README.md
+++ b/docs/modules/deploy/manage/README.md
@@ -1,50 +1,72 @@
 # Managing remote nodes
+
 The CLI allows you to connect to and manage multiple remote nodes simultaneously.
 
-
 ## Linking remote nodes
+
 To connect to remote nodes, you need to instruct the CLI on how to establish a connection with them and optionally assign them to specific groups. Groups facilitate convenient connections to subsets of your nodes.
 
-
 ### Link a new remote
+
 ```sh
-peerbit remote add <name> <address>
+peerbit remote add <name> <address> --peer-id <server-peer-id>
 ```
 
+Use the peer ID printed by the server and verify it out of band. If
+`--peer-id` is omitted, enrollment uses trust on first use (TOFU): the CLI pins
+the identity returned by that TLS endpoint and prints it for verification.
+An existing remote name keeps its pin across re-enrollment; an unexpected
+identity change is rejected without modifying the saved record. To rotate a
+server identity, remove the old remote and add it again only after verifying
+the replacement peer ID out of band.
+
 ### View nodes and their statuses
+
 ```sh
 peerbit remote ls
 ```
 
-### Connecting to nodes so you can perform actions on them 
+### Connecting to nodes so you can perform actions on them
 
 ```sh
 peerbit remote connect YOUR_NAMED_NODE
 ```
+
 or for a group
 
 ```sh
 peerbit remote connect --group GROUP_NAME
 ```
 
-
 ### Allow more machines to access your remote nodes
+
 Remote administration is authorized with Peerbit identities. Each request is
 signed by your private key, and the server checks the corresponding public key
-against its trust list. Grant the identity you use for administration when you
-start the server, or add it from an already trusted session as described below.
+against its trust list. Requests also carry a short-lived timestamp, a
+single-use random nonce, the pinned server peer ID, and a per-process server
+boot ID. This prevents a captured request from being reused later, after a
+restart, or against another server. Grant the identity you use for
+administration when you start the server, or add it from an already trusted
+session as described below.
+
+Clients also freshness-check the server-signed authentication descriptor. Keep
+administrator and server clocks synchronized; a stale cached or replayed
+descriptor is rejected during discovery.
+
+Authenticated management request bodies are limited to 64 MiB and are checked
+against the exact signed byte length and SHA-256 digest before they are decoded.
 
 If you need to modify permissions for which nodes that can perform actions, do follow these steps:
 
-1. 
+1.
 
 Go to the machine which you want to add and learn its publickey by invoking
+
 ```sh
 peerbit id
 ```
 
 2.
-
 
 Get access to the nodes you want to modify directly. In their terminals run:
 
@@ -56,20 +78,18 @@ OR
 
 Connect to the nodes you want to modify (see previous section)
 
-
 3.
-
 
 To give a peer-id admin capabilities
 
-```sh 
-access grant <peer-id>  
+```sh
+access grant <peer-id>
 ```
 
 To revoke admin capabilities from a peer-id
+
 ```sh
 access deny <peer-id>
-```  
+```
 
 Where <peer-id> is the id you obtained in step 1.
-

--- a/docs/modules/deploy/server/custom.md
+++ b/docs/modules/deploy/server/custom.md
@@ -152,10 +152,39 @@ This setup is currently supported on Linux and has been tested on Ubuntu 22.04.
 5. Back on the administrator machine, register the authenticated endpoint:
 
    ```sh
-   peerbit remote add production https://node.example.com
+   peerbit remote add production https://node.example.com \
+     --peer-id <server-peer-id>
    ```
 
-   `remote add` verifies authenticated access before saving the entry, so a
-   missing or different `--grant-access` identity will be rejected.
+   Use the server peer ID printed when the node starts. `remote add` verifies
+   the signed authentication descriptor and authenticated access before saving
+   the entry, so a substituted server identity or a missing/different
+   `--grant-access` identity is rejected. If `--peer-id` is omitted, the CLI
+   pins the identity returned over the configured TLS connection and prints it;
+   compare that value out of band before administering a server you do not
+   operate yourself. Re-running `remote add` for an existing name retains its
+   saved identity pin and rejects a different server. Remove and re-add the
+   remote only for an intentional, independently verified identity rotation.
+
+## Signed-management protocol upgrades
+
+Server releases using signed-request v2 reject the replayable legacy signature
+format. Upgrade a remote server first with the old client (the existing
+`self update` command completes before the server restarts), then upgrade the
+administrator CLI and reconnect with the server peer ID pinned. Existing remote
+records without a peer ID are pinned on their first successful connection and
+the CLI prints the pinned value. There is no automatic downgrade to the legacy
+protocol.
+
+Signed requests are valid only for a short clock-skew window and one server
+process lifetime. The signed `/peer/auth` descriptor is generated on discovery,
+briefly cached to bound signing work, and is itself freshness checked. Keep
+client and server clocks synchronized. A multi-process API behind a load
+balancer requires sticky routing to the process that issued `/peer/auth`; the
+standard Peerbit deployment runs one API process.
+These signatures authenticate management traffic but do not encrypt it; use
+HTTPS for remote administration. An intermediary that can continuously block
+or replace traffic can still deny service even though it cannot forge a valid
+server descriptor or management request.
 
 Run `peerbit --help` or `peerbit start --help` for more options.

--- a/packages/clients/peerbit-server/node/src/cli.ts
+++ b/packages/clients/peerbit-server/node/src/cli.ts
@@ -482,13 +482,51 @@ export const cli = async (args?: string[]) => {
 								createClient(await getKeypair(args.directory), remote),
 							),
 						);
-						const resolvedOrRejected = await Promise.allSettled(
-							apis.map((x) => x.peer.id.get()),
+						const identityStatuses = await Promise.all(
+							apis.map(async (api, index) => {
+								let observed: string;
+								try {
+									observed = peerIdFromString(
+										await api.peer.id.get(),
+									).toString();
+								} catch {
+									return "offline" as const;
+								}
+								const pinned = all[index].peerId;
+								if (!pinned) return "unpinned" as const;
+								let expected: string;
+								try {
+									expected = peerIdFromString(pinned).toString();
+								} catch {
+									return "mismatch" as const;
+								}
+								if (observed !== expected) return "mismatch" as const;
+								try {
+									const verified = peerIdFromString(
+										await api.peer.id.verify(),
+									).toString();
+									return verified === expected
+										? ("verified" as const)
+										: ("mismatch" as const);
+								} catch {
+									return "unverified" as const;
+								}
+							}),
 						);
 
 						if (all.length > 0) {
 							const rows: string[][] = [];
 							for (const [ix, remote] of all.entries()) {
+								const status =
+									identityStatuses[ix] === "verified"
+										? chalk.green("Y")
+										: identityStatuses[ix] === "unpinned"
+											? chalk.yellow("Y (unpinned)")
+											: identityStatuses[ix] === "mismatch"
+												? chalk.red("ID MISMATCH")
+												: identityStatuses[ix] === "unverified"
+													? chalk.red("ID UNVERIFIED")
+													: chalk.red("N");
 								const row = [
 									remote.name,
 									remote.group || "",
@@ -497,15 +535,13 @@ export const cli = async (args?: string[]) => {
 										: remote.origin?.type === "hetzner"
 											? `hetzner\n${remote.origin.location}\n${remote.origin.serverId}`
 											: "",
-									resolvedOrRejected[ix].status === "fulfilled"
-										? chalk.green("Y")
-										: chalk.red("N"),
+									status,
 									remote.address,
 								];
 								rows.push(row);
 							}
 							const table = Table(
-								["Name", "Group", "Origin", "Online", "Address"].map((x) => {
+								["Name", "Group", "Origin", "Status", "Address"].map((x) => {
 									return { value: x, align: "left" };
 								}),
 								rows,
@@ -537,6 +573,11 @@ export const cli = async (args?: string[]) => {
 								alias: "g",
 								default: DEFAULT_REMOTE_GROUP,
 							})
+							.option("peer-id", {
+								describe:
+									"Expected server peer ID for first enrollment (an existing pin cannot be replaced)",
+								type: "string",
+							})
 							.option("directory", {
 								describe: "Peerbit directory",
 								defaultDescription: "~.peerbit",
@@ -551,8 +592,40 @@ export const cli = async (args?: string[]) => {
 						if (args.name === "localhost") {
 							throw new Error("Remote can not be named 'localhost'");
 						}
-						const api = await createClient(await getKeypair(args.directory), {
+						const remotes = new Remotes(getRemotesPath(args.directory));
+						const existing = remotes.getByName(args.name);
+						const pinnedPeerId = existing?.peerId
+							? peerIdFromString(existing.peerId).toString()
+							: undefined;
+						const suppliedPeerId = args["peer-id"]
+							? peerIdFromString(args["peer-id"]).toString()
+							: undefined;
+						if (
+							pinnedPeerId &&
+							suppliedPeerId &&
+							pinnedPeerId !== suppliedPeerId
+						) {
+							throw new Error(
+								`Remote '${args.name}' is already pinned to ${pinnedPeerId}. Remove it before enrolling a different server identity.`,
+							);
+						}
+						const keypair = await getKeypair(args.directory);
+						const discovery = await createClient(keypair, {
 							address: args.address,
+						});
+						const discoveredPeerId = peerIdFromString(
+							await discovery.peer.id.get(),
+						).toString();
+						const expectedPeerId =
+							pinnedPeerId ?? suppliedPeerId ?? discoveredPeerId;
+						if (expectedPeerId !== discoveredPeerId) {
+							throw new Error(
+								`Server peer ID mismatch: expected ${expectedPeerId}, received ${discoveredPeerId}`,
+							);
+						}
+						const api = await createClient(keypair, {
+							address: args.address,
+							peerId: expectedPeerId,
 						});
 						try {
 							await api.program.list();
@@ -562,12 +635,13 @@ export const cli = async (args?: string[]) => {
 						if (!fs.existsSync(args.directory)) {
 							fs.mkdirSync(args.directory, { recursive: true });
 						}
-						const remotes = new Remotes(getRemotesPath(args.directory));
 						remotes.add({
 							name: args.name,
 							address: args.address,
 							group: args.group,
+							peerId: expectedPeerId,
 						});
+						console.log(`Pinned server peer ID: ${expectedPeerId}`);
 					},
 				})
 				.command({
@@ -666,6 +740,7 @@ export const cli = async (args?: string[]) => {
 										address: "http://localhost:" + LOCAL_API_PORT,
 										name: "localhost",
 										group: DEFAULT_REMOTE_GROUP,
+										peerId: (await keypair.publicKey.toPeerId()).toString(),
 									});
 								} else {
 									const remote = remotes.getByName(name);
@@ -684,6 +759,19 @@ export const cli = async (args?: string[]) => {
 									selectedRemotes.push(remote);
 								}
 							}
+						}
+
+						const newlyPinned: RemoteObject[] = [];
+						for (const remote of selectedRemotes) {
+							if (remote.peerId) continue;
+							const discovery = await createClient(keypair, {
+								address: remote.address,
+								origin: remote.origin,
+							});
+							remote.peerId = peerIdFromString(
+								await discovery.peer.id.get(),
+							).toString();
+							newlyPinned.push(remote);
 						}
 
 						const maxNameLength = selectedRemotes
@@ -730,6 +818,12 @@ export const cli = async (args?: string[]) => {
 										`Failed to connect to '${api.name}': ${error?.toString()}`,
 									);
 								}
+							}
+							for (const remote of newlyPinned) {
+								remotes.add(remote);
+								console.warn(
+									`Pinned existing remote '${remote.name}' to server peer ID ${remote.peerId}`,
+								);
 							}
 
 							const rl = readline.createInterface({

--- a/packages/clients/peerbit-server/node/src/client.ts
+++ b/packages/clients/peerbit-server/node/src/client.ts
@@ -12,6 +12,7 @@ import { waitForResolved } from "@peerbit/time";
 import { type RemoteOrigin, getRetiredAWSManagementError } from "./remotes.js";
 import {
 	ADDRESS_PATH,
+	AUTH_PATH,
 	BOOTSTRAP_PATH,
 	INSTALL_PATH,
 	LOCAL_API_PORT,
@@ -28,13 +29,18 @@ import {
 	TRUST_PATH,
 	VERSIONS_PATH,
 } from "./routes.js";
-import { signRequest } from "./signed-request.js";
+import {
+	type AuthDescriptor,
+	signRequest,
+	verifyAuthDescriptor,
+} from "./signed-request.js";
 import type { InstallDependency, StartProgram } from "./types.js";
 
 export const createClient = async (
 	keypair: Identity<Ed25519PublicKey>,
-	remote: { address: string; origin?: RemoteOrigin } = {
+	remote: { address: string; origin?: RemoteOrigin; peerId?: string } = {
 		address: "http://localhost:" + LOCAL_API_PORT,
+		peerId: keypair.publicKey.toPeerId().toString(),
 	},
 ) => {
 	// Add missing protocol
@@ -58,18 +64,100 @@ export const createClient = async (
 	}
 
 	const { default: axios } = await import("axios");
-	const axiosInstance = axios.create();
+	const axiosInstance = axios.create({
+		adapter: ["http", "fetch"],
+		maxRedirects: 0,
+		fetchOptions: { redirect: "manual" },
+		// The signature covers these exact bytes, so no later Axios transform may
+		// serialize or otherwise rewrite the request body.
+		transformRequest: [(data) => data],
+	});
+	const unsignedAxiosInstance = axios.create({
+		adapter: ["http", "fetch"],
+		maxRedirects: 0,
+		fetchOptions: { redirect: "manual" },
+	});
+	const endpointUrl = (path: string) => new URL(path, endpoint).toString();
+	let descriptorPromise: Promise<AuthDescriptor> | undefined;
+	const getAuthDescriptor = () => {
+		if (!remote.peerId) {
+			throw new Error(
+				"A pinned server peer ID is required for authenticated requests",
+			);
+		}
+		if (!descriptorPromise) {
+			descriptorPromise = unsignedAxiosInstance
+				.get(endpointUrl(AUTH_PATH), {
+					timeout: 5000,
+					maxContentLength: 16 * 1024,
+					maxBodyLength: 16 * 1024,
+					validateStatus: (status) => status === 200,
+				})
+				.then((response) => verifyAuthDescriptor(response.data, remote.peerId!))
+				.catch((error) => {
+					descriptorPromise = undefined;
+					throw new Error(
+						"Server does not support signed-request v2 or its identity does not match: " +
+							error?.toString(),
+					);
+				});
+		}
+		return descriptorPromise;
+	};
 	axiosInstance.interceptors.request.use(async (config) => {
-		const url = new URL(config.url!);
+		const url = new URL(config.url!, config.baseURL);
+		const method = config.method!.toUpperCase();
+		const target = url.pathname + url.search;
+		config.method = method;
+		if (
+			method === "GET" &&
+			(target === PEER_ID_PATH ||
+				target === ADDRESS_PATH ||
+				target === AUTH_PATH)
+		) {
+			return config;
+		}
+		let signedBody: string | Uint8Array | undefined;
+		if (config.data == null) {
+			config.data = undefined;
+			signedBody = undefined;
+		} else if (typeof config.data === "string") {
+			signedBody = config.data;
+		} else if (config.data instanceof Uint8Array) {
+			// Copy only this view (not its possibly larger backing buffer), then use a
+			// standalone ArrayBuffer accepted unchanged by both HTTP and fetch adapters.
+			signedBody = Uint8Array.from(config.data);
+			config.data = signedBody.buffer;
+		} else {
+			throw new Error("Authenticated request bodies must be strings or bytes");
+		}
+		const descriptor = await getAuthDescriptor();
 		await signRequest(
-			config.headers,
-			config.method!,
-			url.pathname + url.search,
-			config.data,
+			config.headers as unknown as Record<string, string>,
+			method,
+			target,
+			signedBody,
 			keypair,
+			{
+				serverPeerId: descriptor.serverPeerId,
+				bootId: descriptor.bootId,
+			},
 		);
 		return config;
 	});
+	axiosInstance.interceptors.response.use(
+		(response) => response,
+		(error) => {
+			if (error?.response?.status === 401 || error?.response == null) {
+				// A server restart changes the boot audience. Do not replay the failed
+				// operation; only force the next operation to discover a new descriptor.
+				// Network failure is included because an old keep-alive connection can be
+				// the first observable symptom of a process restart.
+				descriptorPromise = undefined;
+			}
+			return Promise.reject(error);
+		},
+	);
 
 	const validateStatus = (status: number) => {
 		return (status >= 200 && status < 300) || status === 404;
@@ -81,8 +169,6 @@ export const createClient = async (
 		}
 		return resp;
 	};
-
-	const endpointUrl = (path: string) => new URL(path, endpoint).toString();
 
 	const getId = async () =>
 		(
@@ -102,6 +188,7 @@ export const createClient = async (
 				},
 			)
 		).toString();
+	const verifyId = async () => (await getAuthDescriptor()).serverPeerId;
 
 	const close = async (address: string) => {
 		return throwIfNot200(
@@ -133,6 +220,7 @@ export const createClient = async (
 		peer: {
 			id: {
 				get: getId,
+				verify: verifyId,
 			},
 			addresses: {
 				get: async () => {

--- a/packages/clients/peerbit-server/node/src/remotes.ts
+++ b/packages/clients/peerbit-server/node/src/remotes.ts
@@ -25,6 +25,8 @@ export interface RemoteObject {
 	address: string;
 	name: string;
 	group: string;
+	/** Stable server identity pinned when the remote is enrolled. */
+	peerId?: string;
 	origin?: RemoteOrigin;
 }
 
@@ -66,7 +68,16 @@ export class Remotes {
 	add(remote: RemoteObject) {
 		const existing = this.data.remotes.findIndex((x) => x.name === remote.name);
 		if (existing >= 0) {
-			this.data.remotes[existing] = remote;
+			const current = this.data.remotes[existing];
+			if (current.peerId && remote.peerId && current.peerId !== remote.peerId) {
+				throw new Error(
+					`Remote '${remote.name}' is pinned to a different server identity. Remove it before replacing the pin.`,
+				);
+			}
+			this.data.remotes[existing] = {
+				...remote,
+				peerId: current.peerId ?? remote.peerId,
+			};
 		} else {
 			this.data.remotes.push(remote);
 		}

--- a/packages/clients/peerbit-server/node/src/routes.ts
+++ b/packages/clients/peerbit-server/node/src/routes.ts
@@ -14,6 +14,7 @@ export const LOCAL_API_PORT = 8082;
 export const TRUST_PATH = "/trust";
 export const PEER_ID_PATH = "/peer/id";
 export const ADDRESS_PATH = "/peer/address";
+export const AUTH_PATH = "/peer/auth";
 export const STATS_PATH = "/peer/stats";
 export const PROGRAM_PATH = "/program";
 export const PROGRAMS_PATH = "/programs";

--- a/packages/clients/peerbit-server/node/src/server.ts
+++ b/packages/clients/peerbit-server/node/src/server.ts
@@ -1,7 +1,12 @@
 /* eslint-disable no-console */
 import { deserialize, getSchema } from "@dao-xyz/borsh";
 import { peerIdFromString } from "@libp2p/peer-id";
-import { fromBase64, getPublicKeyFromPeerId } from "@peerbit/crypto";
+import {
+	fromBase64,
+	getPublicKeyFromPeerId,
+	randomBytes,
+	toBase64,
+} from "@peerbit/crypto";
 import {
 	Program,
 	getProgramFromVariant,
@@ -25,6 +30,7 @@ import { getKeypair, getNodePath, getTrustPath } from "./config.js";
 import { create } from "./peerbit.js";
 import {
 	ADDRESS_PATH,
+	AUTH_PATH,
 	BOOTSTRAP_PATH,
 	INSTALL_PATH,
 	LOCAL_API_PORT,
@@ -41,7 +47,14 @@ import {
 	VERSIONS_PATH,
 } from "./routes.js";
 import { JSONArgs, Session } from "./session.js";
-import { getBody, verifyRequest } from "./signed-request.js";
+import {
+	ReplayCapacityError,
+	RequestAuthenticator,
+	RequestBodyTooLargeError,
+	createAuthDescriptor,
+	getBody,
+	verifyRequestBody,
+} from "./signed-request.js";
 import { Trust } from "./trust.js";
 import type {
 	InstallDependency,
@@ -51,6 +64,7 @@ import type {
 } from "./types.js";
 
 const MAX_LISTENER_LIMIT = 1e5;
+const AUTH_DESCRIPTOR_CACHE_MS = 30_000;
 
 const getInstallDir = (): string | null => {
 	return (
@@ -332,6 +346,14 @@ export const startApiServer = async (
 		trust: Trust;
 		session?: Session;
 		port?: number;
+		signedRequests?: {
+			maxPastAgeSeconds?: number;
+			maxFutureSkewSeconds?: number;
+			maxBodyBytes?: number;
+			maxReplayEntries?: number;
+			wallClockMs?: () => number;
+			monotonicClockMs?: () => number;
+		};
 	},
 ): Promise<http.Server> => {
 	const port = properties?.port ?? LOCAL_API_PORT;
@@ -371,22 +393,69 @@ export const startApiServer = async (
 	if (!client.peerId.equals(await client.identity.publicKey.toPeerId())) {
 		throw new Error("Expecting node identity to equal peerId");
 	}
+	const audience = {
+		serverPeerId: client.peerId.toString(),
+		bootId: toBase64(randomBytes(32)),
+	};
+	const wallClockMs = properties.signedRequests?.wallClockMs ?? Date.now;
+	let cachedAuthDescriptor:
+		| {
+				descriptor: Awaited<ReturnType<typeof createAuthDescriptor>>;
+				at: number;
+		  }
+		| undefined;
+	let authDescriptorPromise:
+		| Promise<Awaited<ReturnType<typeof createAuthDescriptor>>>
+		| undefined;
+	const getAuthDescriptor = () => {
+		const now = wallClockMs();
+		if (
+			cachedAuthDescriptor &&
+			now >= cachedAuthDescriptor.at &&
+			now - cachedAuthDescriptor.at < AUTH_DESCRIPTOR_CACHE_MS
+		) {
+			return Promise.resolve(cachedAuthDescriptor.descriptor);
+		}
+		if (!authDescriptorPromise) {
+			authDescriptorPromise = createAuthDescriptor(
+				client.identity,
+				audience,
+				now,
+			)
+				.then((descriptor) => {
+					cachedAuthDescriptor = { descriptor, at: now };
+					return descriptor;
+				})
+				.finally(() => {
+					authDescriptorPromise = undefined;
+				});
+		}
+		return authDescriptorPromise;
+	};
+	const authenticator = new RequestAuthenticator({
+		...audience,
+		...properties.signedRequests,
+		isTrusted: (key) =>
+			key.equals(client.identity.publicKey) ||
+			properties.trust.isTrusted(key.hashcode()),
+	});
 
 	const getVerifiedBody = async (req: http.IncomingMessage) => {
-		const body = await getBody(req);
-		const result = await verifyRequest(
+		const verified = await authenticator.verify(
 			req.headers,
 			req.method!,
 			req.url!,
-			body,
 		);
-		if (result.equals(client.identity.publicKey)) {
-			return body;
-		}
-		if (properties.trust.isTrusted(result.hashcode())) {
-			return body;
-		}
-		throw new Error("Not trusted");
+		const body = await getBody(req, verified.bodyLength);
+		const decoded = verifyRequestBody(verified, body);
+		// Consume only after the signed bytes have arrived and matched. This keeps a
+		// raced bad body from burning the nonce while remaining atomic before dispatch.
+		authenticator.consume(verified);
+		return decoded;
+	};
+	const closeResponseConnection = (res: http.ServerResponse) => {
+		res.shouldKeepAlive = false;
+		res.setHeader("Connection", "close");
 	};
 
 	const e404 = "404";
@@ -406,14 +475,41 @@ export const startApiServer = async (
 				if (req.url) {
 					let body: string;
 					try {
-						body =
-							req.url.startsWith(PEER_ID_PATH) ||
-							req.url.startsWith(ADDRESS_PATH)
-								? await getBody(req)
-								: await getVerifiedBody(req);
+						const isPublicRequest =
+							req.method === "GET" &&
+							(req.url === PEER_ID_PATH ||
+								req.url === ADDRESS_PATH ||
+								req.url === AUTH_PATH);
+						if (
+							isPublicRequest &&
+							(req.headers["transfer-encoding"] != null ||
+								(req.headers["content-length"] != null &&
+									req.headers["content-length"] !== "0"))
+						) {
+							closeResponseConnection(res);
+							res.writeHead(400);
+							res.end("Public GET endpoints do not accept a request body");
+							return;
+						}
+						body = isPublicRequest ? "" : await getVerifiedBody(req);
 					} catch (error: any) {
-						res.writeHead(401);
-						res.end("Not authorized: " + error.toString());
+						const status =
+							error instanceof RequestBodyTooLargeError
+								? 413
+								: error instanceof ReplayCapacityError
+									? 503
+									: 401;
+						// Authentication can fail before the body is read. Disable keep-alive so
+						// an attacker cannot retain this connection by continuing to stream it.
+						closeResponseConnection(res);
+						res.writeHead(status);
+						res.end(
+							status === 413
+								? "Request body is too large"
+								: status === 503
+									? "Authentication is temporarily unavailable"
+									: "Not authorized",
+						);
 						return;
 					}
 
@@ -996,6 +1092,12 @@ export const startApiServer = async (
 						} else {
 							r404();
 						}
+					} else if (req.url === AUTH_PATH && req.method === "GET") {
+						const authDescriptor = await getAuthDescriptor();
+						res.setHeader("Cache-Control", "no-store");
+						res.setHeader("Content-Type", "application/json");
+						res.writeHead(200);
+						res.end(JSON.stringify(authDescriptor));
 					} else if (req.url.startsWith(PEER_ID_PATH)) {
 						res.writeHead(200);
 						res.end(client.peerId.toString());

--- a/packages/clients/peerbit-server/node/src/signed-request.ts
+++ b/packages/clients/peerbit-server/node/src/signed-request.ts
@@ -5,80 +5,594 @@ import {
 	type PublicSignKey,
 	SignatureWithKey,
 	fromBase64,
+	randomBytes,
+	sha256Sync,
 	toBase64,
 	verify,
 } from "@peerbit/crypto";
 import type http from "http";
 
-const SIGNATURE_KEY = "X-Peerbit-Signature";
-const SIGNATURE_TIME_KEY = "X-Peerbit-Signature-Time";
+export const SIGNED_REQUEST_VERSION = "2";
+
+export const SIGNATURE_KEY = "X-Peerbit-Signature";
+export const SIGNATURE_VERSION_KEY = "X-Peerbit-Signature-Version";
+export const SIGNATURE_TIME_KEY = "X-Peerbit-Signature-Time";
+export const SIGNATURE_NONCE_KEY = "X-Peerbit-Signature-Nonce";
+export const SIGNATURE_SERVER_KEY = "X-Peerbit-Signature-Server";
+export const SIGNATURE_BOOT_KEY = "X-Peerbit-Signature-Boot";
+export const SIGNED_CONTENT_LENGTH_KEY = "X-Peerbit-Content-Length";
+export const SIGNED_CONTENT_SHA256_KEY = "X-Peerbit-Content-SHA256";
+
+const REQUEST_DOMAIN = "peerbit/server/http-request/v2";
+const DESCRIPTOR_DOMAIN = "peerbit/server/http-auth-descriptor/v2";
+const DECIMAL_PATTERN = /^(0|[1-9][0-9]{0,15})$/;
+const BASE64_32_PATTERN = /^[A-Za-z0-9+/]{43}=$/;
+const METHOD_PATTERN = /^[A-Z]+$/;
+const encoder = new TextEncoder();
+const decoder = new TextDecoder("utf-8", { fatal: true });
+
+const DEFAULT_MAX_PAST_AGE_SECONDS = 5 * 60;
+const DEFAULT_MAX_FUTURE_SKEW_SECONDS = 60;
+export const DEFAULT_MAX_SIGNED_BODY_BYTES = 64 * 1024 * 1024;
+const DEFAULT_MAX_REPLAY_ENTRIES = 10_000;
+
+export class SignedRequestError extends Error {}
+export class ReplayRequestError extends SignedRequestError {}
+export class ReplayCapacityError extends SignedRequestError {}
+export class RequestBodyTooLargeError extends SignedRequestError {}
+
+export interface RequestAudience {
+	serverPeerId: string;
+	bootId: string;
+}
+
+export interface AuthDescriptor extends RequestAudience {
+	version: typeof SIGNED_REQUEST_VERSION;
+	serverTime: string;
+	signature: string;
+}
+
+export interface VerifiedRequest {
+	publicKey: PublicSignKey;
+	bodyLength: number;
+	bodyHash: Uint8Array;
+	nonce: string;
+	timestamp: bigint;
+}
+
+export interface VerifyAuthDescriptorOptions {
+	nowMs?: number;
+	maxPastAgeSeconds?: number;
+	maxFutureSkewSeconds?: number;
+}
+
+export interface RequestAuthenticatorOptions extends RequestAudience {
+	isTrusted: (key: PublicSignKey) => boolean;
+	maxPastAgeSeconds?: number;
+	maxFutureSkewSeconds?: number;
+	maxBodyBytes?: number;
+	maxReplayEntries?: number;
+	wallClockMs?: () => number;
+	monotonicClockMs?: () => number;
+}
+
+const frame = (domain: string, fields: readonly string[]): Uint8Array => {
+	const writer = new BinaryWriter();
+	writer.string(domain);
+	for (const value of fields) {
+		writer.string(value);
+	}
+	return writer.finalize();
+};
+
+const requestFrame = (properties: {
+	serverPeerId: string;
+	bootId: string;
+	timestamp: string;
+	nonce: string;
+	method: string;
+	target: string;
+	bodyLength: string;
+	bodyHash: string;
+}): Uint8Array =>
+	frame(REQUEST_DOMAIN, [
+		SIGNED_REQUEST_VERSION,
+		properties.serverPeerId,
+		properties.bootId,
+		properties.timestamp,
+		properties.nonce,
+		properties.method,
+		properties.target,
+		properties.bodyLength,
+		properties.bodyHash,
+	]);
+
+const descriptorFrame = (descriptor: Omit<AuthDescriptor, "signature">) =>
+	frame(DESCRIPTOR_DOMAIN, [
+		descriptor.version,
+		descriptor.serverPeerId,
+		descriptor.bootId,
+		descriptor.serverTime,
+	]);
+
+const bodyBytes = (data: string | Uint8Array | undefined): Uint8Array => {
+	if (data == null) return new Uint8Array();
+	return typeof data === "string" ? encoder.encode(data) : data;
+};
+
+const parseCanonicalUnsigned = (
+	value: string,
+	name: string,
+	maximum?: bigint,
+): bigint => {
+	if (!DECIMAL_PATTERN.test(value)) {
+		throw new SignedRequestError(`Invalid ${name}`);
+	}
+	const parsed = BigInt(value);
+	if (maximum != null && parsed > maximum) {
+		throw new SignedRequestError(`Invalid ${name}`);
+	}
+	return parsed;
+};
+
+const decodeCanonical32 = (value: string, name: string): Uint8Array => {
+	if (!BASE64_32_PATTERN.test(value)) {
+		throw new SignedRequestError(`Invalid ${name}`);
+	}
+	const bytes = fromBase64(value);
+	if (bytes.length !== 32 || toBase64(bytes) !== value) {
+		throw new SignedRequestError(`Invalid ${name}`);
+	}
+	return bytes;
+};
+
+const readHeader = (
+	headers: Record<string, string | string[] | undefined>,
+	name: string,
+	maxLength: number,
+): string => {
+	const matches = Object.entries(headers).filter(
+		([key]) => key.toLowerCase() === name.toLowerCase(),
+	);
+	if (matches.length !== 1 || typeof matches[0][1] !== "string") {
+		throw new SignedRequestError(`Missing or duplicate ${name} header`);
+	}
+	const value = matches[0][1] as string;
+	if (value.length === 0 || value.length > maxLength || value.includes(",")) {
+		throw new SignedRequestError(`Invalid ${name} header`);
+	}
+	return value;
+};
+
+const validateMethodAndTarget = (method: string, target: string) => {
+	if (!METHOD_PATTERN.test(method)) {
+		throw new SignedRequestError("Invalid request method");
+	}
+	if (!target.startsWith("/") || target.includes("#") || target.length > 8192) {
+		throw new SignedRequestError("Invalid request target");
+	}
+};
+
+const equalBytes = (left: Uint8Array, right: Uint8Array) => {
+	if (left.length !== right.length) return false;
+	let difference = 0;
+	for (let index = 0; index < left.length; index++) {
+		difference |= left[index] ^ right[index];
+	}
+	return difference === 0;
+};
+
+export const createAuthDescriptor = async (
+	identity: Identity<Ed25519PublicKey>,
+	audience: RequestAudience,
+	nowMs: number = Date.now(),
+): Promise<AuthDescriptor> => {
+	decodeCanonical32(audience.bootId, "boot ID");
+	if (!audience.serverPeerId || audience.serverPeerId.length > 256) {
+		throw new SignedRequestError("Invalid server peer ID");
+	}
+	const unsigned: Omit<AuthDescriptor, "signature"> = {
+		version: SIGNED_REQUEST_VERSION,
+		serverPeerId: audience.serverPeerId,
+		bootId: audience.bootId,
+		serverTime: Math.floor(nowMs / 1000).toString(),
+	};
+	const signature = await identity.sign(descriptorFrame(unsigned));
+	return { ...unsigned, signature: toBase64(serialize(signature)) };
+};
+
+export const verifyAuthDescriptor = async (
+	value: unknown,
+	expectedServerPeerId: string,
+	options?: VerifyAuthDescriptorOptions,
+): Promise<AuthDescriptor> => {
+	if (!value || typeof value !== "object") {
+		throw new SignedRequestError("Invalid authentication descriptor");
+	}
+	const input = value as Partial<AuthDescriptor>;
+	if (
+		input.version !== SIGNED_REQUEST_VERSION ||
+		typeof input.serverPeerId !== "string" ||
+		typeof input.bootId !== "string" ||
+		typeof input.serverTime !== "string" ||
+		typeof input.signature !== "string"
+	) {
+		throw new SignedRequestError("Invalid authentication descriptor");
+	}
+	if (
+		input.serverPeerId !== expectedServerPeerId ||
+		input.serverPeerId.length > 256
+	) {
+		throw new SignedRequestError("Server peer ID does not match the pinned ID");
+	}
+	decodeCanonical32(input.bootId, "boot ID");
+	const serverTime = parseCanonicalUnsigned(input.serverTime, "server time");
+	const nowMs = options?.nowMs ?? Date.now();
+	const maxPastAgeSeconds =
+		options?.maxPastAgeSeconds ?? DEFAULT_MAX_PAST_AGE_SECONDS;
+	const maxFutureSkewSeconds =
+		options?.maxFutureSkewSeconds ?? DEFAULT_MAX_FUTURE_SKEW_SECONDS;
+	if (
+		!Number.isFinite(nowMs) ||
+		nowMs < 0 ||
+		nowMs > Number.MAX_SAFE_INTEGER ||
+		!Number.isSafeInteger(maxPastAgeSeconds) ||
+		maxPastAgeSeconds < 0 ||
+		!Number.isSafeInteger(maxFutureSkewSeconds) ||
+		maxFutureSkewSeconds < 0
+	) {
+		throw new SignedRequestError("Invalid descriptor freshness policy");
+	}
+	const now = BigInt(Math.floor(nowMs / 1000));
+	if (
+		serverTime < now - BigInt(maxPastAgeSeconds) ||
+		serverTime > now + BigInt(maxFutureSkewSeconds)
+	) {
+		throw new SignedRequestError(
+			"Authentication descriptor timestamp is outside the window",
+		);
+	}
+	if (input.signature.length > 2048 || input.signature.includes(",")) {
+		throw new SignedRequestError("Invalid descriptor signature");
+	}
+	let signature: SignatureWithKey;
+	try {
+		const bytes = fromBase64(input.signature);
+		if (toBase64(bytes) !== input.signature) {
+			throw new Error("Non-canonical base64");
+		}
+		signature = deserialize(bytes, SignatureWithKey);
+		if (!equalBytes(serialize(signature), bytes)) {
+			throw new Error("Non-canonical signature encoding");
+		}
+	} catch {
+		throw new SignedRequestError("Invalid descriptor signature");
+	}
+	if (signature.publicKey.toPeerId().toString() !== input.serverPeerId) {
+		throw new SignedRequestError(
+			"Descriptor signer does not match server peer ID",
+		);
+	}
+	const descriptor: AuthDescriptor = input as AuthDescriptor;
+	if (!(await verify(signature, descriptorFrame(descriptor)))) {
+		throw new SignedRequestError("Invalid descriptor signature");
+	}
+	return descriptor;
+};
 
 export const signRequest = async (
 	headers: Record<string, string>,
 	method: string,
-	path: string,
-	data: string | undefined,
+	target: string,
+	data: string | Uint8Array | undefined,
 	keypair: Identity<Ed25519PublicKey>,
+	audience: RequestAudience,
+	options?: { nowMs?: number; nonce?: Uint8Array },
 ) => {
-	const sigTimestamp = Math.round(new Date().getTime() / 1000).toString();
-	const write = new BinaryWriter();
-	if (!method) {
-		throw new Error("Expecting method");
+	validateMethodAndTarget(method, target);
+	if (!audience.serverPeerId || audience.serverPeerId.length > 256) {
+		throw new SignedRequestError("Invalid server peer ID");
 	}
-	if (!path) {
-		throw new Error("Expecting path");
+	decodeCanonical32(audience.bootId, "boot ID");
+	const bytes = bodyBytes(data);
+	const timestamp = Math.floor(
+		(options?.nowMs ?? Date.now()) / 1000,
+	).toString();
+	const nonceBytes = options?.nonce ?? randomBytes(32);
+	if (nonceBytes.length !== 32) {
+		throw new SignedRequestError("Nonce must contain 32 bytes");
 	}
-
-	write.string(
-		method.toLowerCase() + path.toLowerCase() + sigTimestamp + (data || ""),
-	);
-	const signature = await keypair.sign(write.finalize());
-	headers[SIGNATURE_TIME_KEY] = sigTimestamp;
+	const nonce = toBase64(nonceBytes);
+	const length = bytes.length.toString();
+	const hash = toBase64(sha256Sync(bytes));
+	const signable = requestFrame({
+		...audience,
+		timestamp,
+		nonce,
+		method,
+		target,
+		bodyLength: length,
+		bodyHash: hash,
+	});
+	const signature = await keypair.sign(signable);
+	headers[SIGNATURE_VERSION_KEY] = SIGNED_REQUEST_VERSION;
+	headers[SIGNATURE_TIME_KEY] = timestamp;
+	headers[SIGNATURE_NONCE_KEY] = nonce;
+	headers[SIGNATURE_SERVER_KEY] = audience.serverPeerId;
+	headers[SIGNATURE_BOOT_KEY] = audience.bootId;
+	headers[SIGNED_CONTENT_LENGTH_KEY] = length;
+	headers[SIGNED_CONTENT_SHA256_KEY] = hash;
 	headers[SIGNATURE_KEY] = toBase64(serialize(signature));
 };
 
-export const getBody = (req: http.IncomingMessage): Promise<string> => {
+export class RequestAuthenticator {
+	readonly maxBodyBytes: number;
+	private readonly maxPastAgeSeconds: bigint;
+	private readonly maxFutureSkewSeconds: bigint;
+	private readonly maxReplayEntries: number;
+	private readonly wallClockMs: () => number;
+	private readonly monotonicClockMs: () => number;
+	private readonly replays = new Map<
+		string,
+		{ monotonicUntil: number; wallUntil: bigint }
+	>();
+	private lastWallSeconds?: bigint;
+
+	constructor(readonly options: RequestAuthenticatorOptions) {
+		this.maxPastAgeSeconds = BigInt(
+			options.maxPastAgeSeconds ?? DEFAULT_MAX_PAST_AGE_SECONDS,
+		);
+		this.maxFutureSkewSeconds = BigInt(
+			options.maxFutureSkewSeconds ?? DEFAULT_MAX_FUTURE_SKEW_SECONDS,
+		);
+		this.maxBodyBytes = options.maxBodyBytes ?? DEFAULT_MAX_SIGNED_BODY_BYTES;
+		this.maxReplayEntries =
+			options.maxReplayEntries ?? DEFAULT_MAX_REPLAY_ENTRIES;
+		this.wallClockMs = options.wallClockMs ?? Date.now;
+		this.monotonicClockMs =
+			options.monotonicClockMs ?? (() => performance.now());
+		if (
+			this.maxPastAgeSeconds < 0n ||
+			this.maxFutureSkewSeconds < 0n ||
+			!Number.isSafeInteger(this.maxBodyBytes) ||
+			this.maxBodyBytes < 0 ||
+			!Number.isSafeInteger(this.maxReplayEntries) ||
+			this.maxReplayEntries < 1
+		) {
+			throw new SignedRequestError("Invalid signed-request policy");
+		}
+		decodeCanonical32(options.bootId, "boot ID");
+	}
+
+	private effectiveWallSeconds(): bigint {
+		const current = BigInt(Math.floor(this.wallClockMs() / 1000));
+		if (this.lastWallSeconds == null || current > this.lastWallSeconds) {
+			this.lastWallSeconds = current;
+		}
+		return this.lastWallSeconds;
+	}
+
+	private precheckReplay(
+		publicKey: PublicSignKey,
+		nonce: string,
+		wallNow: bigint,
+	) {
+		const monotonicNow = this.monotonicClockMs();
+		const key = `${publicKey.hashcode()}\0${nonce}`;
+		const expired = (entry: { monotonicUntil: number; wallUntil: bigint }) =>
+			monotonicNow >= entry.monotonicUntil && wallNow > entry.wallUntil;
+		const existing = this.replays.get(key);
+		if (existing != null && !expired(existing)) {
+			throw new ReplayRequestError("Request has already been used");
+		}
+		if (this.replays.size < this.maxReplayEntries || existing != null) return;
+		for (const entry of this.replays.values()) {
+			if (expired(entry)) return;
+		}
+		throw new ReplayCapacityError("Replay protection is at capacity");
+	}
+
+	private consumeReplay(
+		publicKey: PublicSignKey,
+		nonce: string,
+		timestamp: bigint,
+		wallNow: bigint,
+	) {
+		const now = this.monotonicClockMs();
+		const key = `${publicKey.hashcode()}\0${nonce}`;
+		const existing = this.replays.get(key);
+		const expired = (entry: { monotonicUntil: number; wallUntil: bigint }) =>
+			now >= entry.monotonicUntil && wallNow > entry.wallUntil;
+		if (existing != null && !expired(existing)) {
+			throw new ReplayRequestError("Request has already been used");
+		}
+		if (existing != null) this.replays.delete(key);
+		if (this.replays.size >= this.maxReplayEntries) {
+			for (const [candidate, entry] of this.replays) {
+				if (expired(entry)) this.replays.delete(candidate);
+			}
+		}
+		if (this.replays.size >= this.maxReplayEntries) {
+			throw new ReplayCapacityError("Replay protection is at capacity");
+		}
+		const retentionSeconds =
+			Number(this.maxPastAgeSeconds + this.maxFutureSkewSeconds) + 1;
+		this.replays.set(key, {
+			monotonicUntil: now + retentionSeconds * 1000,
+			wallUntil: timestamp + this.maxPastAgeSeconds,
+		});
+	}
+
+	/**
+	 * Atomically consume a verified nonce immediately before dispatch. Call this
+	 * only after the exact request body has passed verifyRequestBody().
+	 */
+	consume(verified: VerifiedRequest) {
+		const now = this.effectiveWallSeconds();
+		if (
+			verified.timestamp < now - this.maxPastAgeSeconds ||
+			verified.timestamp > now + this.maxFutureSkewSeconds
+		) {
+			throw new SignedRequestError("Request timestamp is outside the window");
+		}
+		if (!this.options.isTrusted(verified.publicKey)) {
+			throw new SignedRequestError("Request signer is not trusted");
+		}
+		this.consumeReplay(
+			verified.publicKey,
+			verified.nonce,
+			verified.timestamp,
+			now,
+		);
+	}
+
+	async verify(
+		headers: Record<string, string | string[] | undefined>,
+		method: string,
+		target: string,
+	): Promise<VerifiedRequest> {
+		validateMethodAndTarget(method, target);
+		const version = readHeader(headers, SIGNATURE_VERSION_KEY, 8);
+		if (version !== SIGNED_REQUEST_VERSION) {
+			throw new SignedRequestError("Unsupported signed-request version");
+		}
+		const timestampValue = readHeader(headers, SIGNATURE_TIME_KEY, 16);
+		const timestamp = parseCanonicalUnsigned(timestampValue, "timestamp");
+		const now = this.effectiveWallSeconds();
+		if (
+			timestamp < now - this.maxPastAgeSeconds ||
+			timestamp > now + this.maxFutureSkewSeconds
+		) {
+			throw new SignedRequestError("Request timestamp is outside the window");
+		}
+		const nonce = readHeader(headers, SIGNATURE_NONCE_KEY, 44);
+		decodeCanonical32(nonce, "nonce");
+		const serverPeerId = readHeader(headers, SIGNATURE_SERVER_KEY, 256);
+		const bootId = readHeader(headers, SIGNATURE_BOOT_KEY, 44);
+		if (
+			serverPeerId !== this.options.serverPeerId ||
+			bootId !== this.options.bootId
+		) {
+			throw new SignedRequestError(
+				"Request audience does not match this server",
+			);
+		}
+		decodeCanonical32(bootId, "boot ID");
+		const bodyLengthValue = readHeader(headers, SIGNED_CONTENT_LENGTH_KEY, 16);
+		const bodyLengthBig = parseCanonicalUnsigned(
+			bodyLengthValue,
+			"body length",
+			BigInt(this.maxBodyBytes),
+		);
+		const bodyLength = Number(bodyLengthBig);
+		const bodyHashValue = readHeader(headers, SIGNED_CONTENT_SHA256_KEY, 44);
+		const bodyHash = decodeCanonical32(bodyHashValue, "body hash");
+		const signatureValue = readHeader(headers, SIGNATURE_KEY, 2048);
+		let signature: SignatureWithKey;
+		try {
+			const signatureBytes = fromBase64(signatureValue);
+			if (toBase64(signatureBytes) !== signatureValue) {
+				throw new Error("Non-canonical base64");
+			}
+			signature = deserialize(signatureBytes, SignatureWithKey);
+			if (!equalBytes(serialize(signature), signatureBytes)) {
+				throw new Error("Non-canonical signature encoding");
+			}
+		} catch {
+			throw new SignedRequestError("Invalid request signature encoding");
+		}
+		if (!this.options.isTrusted(signature.publicKey)) {
+			throw new SignedRequestError("Request signer is not trusted");
+		}
+		const signable = requestFrame({
+			serverPeerId,
+			bootId,
+			timestamp: timestampValue,
+			nonce,
+			method,
+			target,
+			bodyLength: bodyLengthValue,
+			bodyHash: bodyHashValue,
+		});
+		if (!(await verify(signature, signable))) {
+			throw new SignedRequestError("Invalid request signature");
+		}
+		// Reject already-committed replays and a full cache before reading a
+		// potentially large body. This check is deliberately non-mutating; consume()
+		// remains the authoritative atomic check-and-insert after body verification.
+		this.precheckReplay(
+			signature.publicKey,
+			nonce,
+			this.effectiveWallSeconds(),
+		);
+		return {
+			publicKey: signature.publicKey,
+			bodyLength,
+			bodyHash,
+			nonce,
+			timestamp,
+		};
+	}
+}
+
+export const getBody = (
+	req: http.IncomingMessage,
+	maxBytes: number = DEFAULT_MAX_SIGNED_BODY_BYTES,
+): Promise<Uint8Array> => {
 	return new Promise((resolve, reject) => {
-		let body = "";
-		req.on("data", (d) => {
-			body += d;
+		const chunks: Uint8Array[] = [];
+		let length = 0;
+		let settled = false;
+		const fail = (error: Error) => {
+			if (settled) return;
+			settled = true;
+			chunks.length = 0;
+			reject(error);
+		};
+		req.on("data", (chunk: Uint8Array | string) => {
+			if (settled) return;
+			const bytes =
+				typeof chunk === "string"
+					? encoder.encode(chunk)
+					: new Uint8Array(chunk);
+			length += bytes.length;
+			if (length > maxBytes) {
+				fail(new RequestBodyTooLargeError("Request body is too large"));
+				return;
+			}
+			chunks.push(bytes);
 		});
 		req.on("end", () => {
+			if (settled) return;
+			settled = true;
+			const body = new Uint8Array(length);
+			let offset = 0;
+			for (const chunk of chunks) {
+				body.set(chunk, offset);
+				offset += chunk.length;
+			}
 			resolve(body);
 		});
-		req.on("error", (e) => reject(e));
+		req.on("aborted", () =>
+			fail(new SignedRequestError("Request was aborted")),
+		);
+		req.on("error", fail);
 	});
 };
 
-export const verifyRequest = async (
-	headers: Record<string, string | string[] | undefined>,
-	method: string,
-	path: string,
-	body = "",
-): Promise<PublicSignKey> => {
-	const timestamp =
-		headers[SIGNATURE_TIME_KEY] || headers[SIGNATURE_TIME_KEY.toLowerCase()];
-	if (typeof timestamp !== "string") {
-		throw new Error("Unexpected timestamp type: " + typeof timestamp);
+export const verifyRequestBody = (
+	verified: VerifiedRequest,
+	body: Uint8Array,
+): string => {
+	if (
+		body.length !== verified.bodyLength ||
+		!equalBytes(sha256Sync(body), verified.bodyHash)
+	) {
+		throw new SignedRequestError("Request body does not match its signature");
 	}
-
-	const write = new BinaryWriter();
-	if (!method) {
-		throw new Error("Expecting method");
+	try {
+		return decoder.decode(body);
+	} catch {
+		throw new SignedRequestError("Request body is not valid UTF-8");
 	}
-	if (!path) {
-		throw new Error("Expecting path");
-	}
-
-	write.string(method.toLowerCase() + path.toLowerCase() + timestamp + body);
-	const signature =
-		headers[SIGNATURE_KEY] || headers[SIGNATURE_KEY.toLowerCase()];
-	if (typeof signature !== "string") {
-		throw new Error("Unexpected signature type: " + typeof signature);
-	}
-	const signatureWithKey = deserialize(fromBase64(signature), SignatureWithKey);
-	if (await verify(signatureWithKey, write.finalize())) {
-		return signatureWithKey.publicKey;
-	}
-	throw new Error("Invalid signature");
 };

--- a/packages/clients/peerbit-server/node/test/api.spec.ts
+++ b/packages/clients/peerbit-server/node/test/api.spec.ts
@@ -14,7 +14,7 @@ import { waitForResolved } from "@peerbit/time";
 import type { AbstractLevel } from "abstract-level";
 import { expect } from "chai";
 import fs from "fs";
-import type http from "http";
+import http from "http";
 import { Level } from "level";
 import { MemoryLevel } from "memory-level";
 import path, { dirname } from "path";
@@ -24,12 +24,32 @@ import { fileURLToPath } from "url";
 import { v4 as uuid } from "uuid";
 import { createClient } from "../src/client.js";
 import { getTrustPath } from "../src/config.js";
+import {
+	AUTH_PATH,
+	PEER_ID_PATH,
+	PROGRAMS_PATH,
+	PROGRAM_PATH,
+} from "../src/routes.js";
 import { startApiServer, startServerWithNode } from "../src/server.js";
 import { Session } from "../src/session.js";
+import {
+	type AuthDescriptor,
+	RequestAuthenticator,
+	createAuthDescriptor,
+	getBody,
+	signRequest,
+	verifyAuthDescriptor,
+	verifyRequestBody,
+} from "../src/signed-request.js";
 import { Trust } from "../src/trust.js";
 
 const client = (keypair: Identity<Ed25519PublicKey>, address?: string) => {
-	return createClient(keypair, address ? { address } : undefined);
+	return createClient(
+		keypair,
+		address
+			? { address, peerId: keypair.publicKey.toPeerId().toString() }
+			: undefined,
+	);
 };
 describe("libp2p only", () => {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -198,6 +218,436 @@ describe("server", () => {
 					(await serverPeer.getMultiaddrs()).map((x) => x.toString()),
 				);
 			});
+
+			it("requires an exact public route", async () => {
+				expect((await fetch(apiAddress + PEER_ID_PATH)).status).to.equal(200);
+				expect(
+					(await fetch(apiAddress + PEER_ID_PATH + "?extra=1")).status,
+				).to.equal(401);
+				expect(
+					(await fetch(apiAddress + PEER_ID_PATH + "-extra")).status,
+				).to.equal(401);
+			});
+
+			it("closes unauthorized connections and rejects bodies on public GETs", async () => {
+				const unauthorized = await fetch(apiAddress + PROGRAMS_PATH);
+				expect(unauthorized.status).to.equal(401);
+				expect(unauthorized.headers.get("connection")).to.equal("close");
+
+				const publicWithBody = await new Promise<{
+					status: number | undefined;
+					connection: string | undefined;
+					body: string;
+				}>((resolve, reject) => {
+					const request = http.request(
+						apiAddress + PEER_ID_PATH,
+						{
+							method: "GET",
+							headers: { "Content-Length": "1" },
+						},
+						(response) => {
+							let body = "";
+							response.setEncoding("utf8");
+							response.on("data", (chunk) => (body += chunk));
+							response.on("end", () =>
+								resolve({
+									status: response.statusCode,
+									connection: response.headers.connection,
+									body,
+								}),
+							);
+						},
+					);
+					request.once("error", reject);
+					request.end("x");
+				});
+				expect(publicWithBody).to.deep.equal({
+					status: 400,
+					connection: "close",
+					body: "Public GET endpoints do not accept a request body",
+				});
+			});
+
+			it("requires the client to pin the server identity", async () => {
+				const unpinned = await createClient(session.peers[0].identity, {
+					address: apiAddress,
+				});
+				await expect(unpinned.program.list()).rejectedWith(
+					"pinned server peer ID",
+				);
+
+				const other = await Ed25519Keypair.create();
+				const wronglyPinned = await createClient(session.peers[0].identity, {
+					address: apiAddress,
+					peerId: other.publicKey.toPeerId().toString(),
+				});
+				await expect(wronglyPinned.program.list()).rejectedWith(
+					"identity does not match",
+				);
+			});
+
+			it("accepts exactly one concurrent copy of a signed request", async () => {
+				const descriptorResponse = await fetch(apiAddress + AUTH_PATH);
+				expect(descriptorResponse.headers.get("cache-control")).to.equal(
+					"no-store",
+				);
+				const descriptor = (await descriptorResponse.json()) as AuthDescriptor;
+				const headers: Record<string, string> = {};
+				await signRequest(
+					headers,
+					"GET",
+					PROGRAMS_PATH,
+					undefined,
+					session.peers[0].identity,
+					descriptor,
+				);
+				const responses = await Promise.all([
+					fetch(apiAddress + PROGRAMS_PATH, { headers }),
+					fetch(apiAddress + PROGRAMS_PATH, { headers }),
+				]);
+				expect(
+					responses.map((response) => response.status).sort(),
+				).to.deep.equal([200, 401]);
+			});
+
+			it("does not let a mismatched body burn a valid nonce", async () => {
+				const descriptor = (await (
+					await fetch(apiAddress + AUTH_PATH)
+				).json()) as AuthDescriptor;
+				const target = PROGRAM_PATH + "/missing";
+				const headers: Record<string, string> = {};
+				await signRequest(
+					headers,
+					"DELETE",
+					target,
+					"right",
+					session.peers[0].identity,
+					descriptor,
+				);
+				const raced = await fetch(apiAddress + target, {
+					method: "DELETE",
+					headers,
+					body: "wrong",
+				});
+				expect(raced.status).to.equal(401);
+				const legitimate = await fetch(apiAddress + target, {
+					method: "DELETE",
+					headers,
+					body: "right",
+				});
+				expect(legitimate.status).to.equal(404);
+			});
+
+			it("single-flights descriptor discovery for concurrent requests", async () => {
+				let descriptorRequests = 0;
+				const observeDescriptor: http.RequestListener = (request) => {
+					if (request.method === "GET" && request.url === AUTH_PATH) {
+						descriptorRequests += 1;
+					}
+				};
+				server.prependListener("request", observeDescriptor);
+				try {
+					const c = await client(session.peers[0].identity, apiAddress);
+					await Promise.all([c.program.list(), c.peer.stats.get()]);
+					expect(descriptorRequests).to.equal(1);
+				} finally {
+					server.removeListener("request", observeDescriptor);
+				}
+			});
+
+			it("briefly caches and then refreshes the signed descriptor", async () => {
+				let wallClockMs = 1_750_000_000_000;
+				const timedDirectory = path.join(
+					process.cwd(),
+					"tmp",
+					"api-test",
+					"timed-auth",
+					uuid(),
+				);
+				fs.mkdirSync(timedDirectory, { recursive: true });
+				const timed = await startApiServer(serverPeer, {
+					trust: new Trust(getTrustPath(timedDirectory)),
+					port: 0,
+					signedRequests: { wallClockMs: () => wallClockMs },
+				});
+				try {
+					const address = timed.address();
+					if (!address || typeof address === "string") {
+						throw new Error("Failed to resolve timed API server address");
+					}
+					const endpoint = `http://127.0.0.1:${address.port}${AUTH_PATH}`;
+					const first = (await (
+						await fetch(endpoint)
+					).json()) as AuthDescriptor;
+					wallClockMs += 1_000;
+					const second = (await (
+						await fetch(endpoint)
+					).json()) as AuthDescriptor;
+					wallClockMs += 30_000;
+					const third = (await (
+						await fetch(endpoint)
+					).json()) as AuthDescriptor;
+					expect(first.serverTime).to.equal("1750000000");
+					expect(second).to.deep.equal(first);
+					expect(third.serverTime).to.equal("1750000031");
+					expect(third.bootId).to.equal(first.bootId);
+					await verifyAuthDescriptor(third, serverPeer.peerId.toString(), {
+						nowMs: wallClockMs,
+					});
+				} finally {
+					await new Promise<void>((resolve) => timed.close(() => resolve()));
+				}
+			});
+
+			it("does not forward signed requests across redirects", async () => {
+				const descriptor = await (await fetch(apiAddress + AUTH_PATH)).text();
+				let sinkRequests = 0;
+				const sink = http.createServer((request, response) => {
+					sinkRequests += 1;
+					request.resume();
+					response.writeHead(200);
+					response.end("captured");
+				});
+				const listen = (target: http.Server) =>
+					new Promise<number>((resolve, reject) => {
+						target.once("error", reject);
+						target.listen(0, "127.0.0.1", () => {
+							const address = target.address();
+							if (!address || typeof address === "string") {
+								reject(new Error("Failed to resolve test server address"));
+								return;
+							}
+							resolve(address.port);
+						});
+					});
+				const close = (target: http.Server) =>
+					new Promise<void>((resolve) => target.close(() => resolve()));
+				let proxy: http.Server | undefined;
+				try {
+					const sinkPort = await listen(sink);
+					proxy = http.createServer((request, response) => {
+						request.resume();
+						if (request.method === "GET" && request.url === AUTH_PATH) {
+							response.setHeader("Content-Type", "application/json");
+							response.end(descriptor);
+							return;
+						}
+						response.writeHead(307, {
+							Location: `http://127.0.0.1:${sinkPort}/captured`,
+						});
+						response.end();
+					});
+					const proxyPort = await listen(proxy);
+					const c = await createClient(session.peers[0].identity, {
+						address: `http://127.0.0.1:${proxyPort}`,
+						peerId: serverPeer.peerId.toString(),
+					});
+					await expect(c.program.list()).rejectedWith("status code 307");
+					expect(sinkRequests).to.equal(0);
+				} finally {
+					if (proxy?.listening) await close(proxy);
+					if (sink.listening) await close(sink);
+				}
+			});
+
+			it("sends exactly an offset Uint8Array view over Axios HTTP", async () => {
+				const descriptor = await createAuthDescriptor(serverPeer.identity, {
+					serverPeerId: serverPeer.peerId.toString(),
+					bootId: toBase64(new Uint8Array(32).fill(9)),
+				});
+				const authenticator = new RequestAuthenticator({
+					...descriptor,
+					isTrusted: (key) => key.equals(serverPeer.identity.publicKey),
+				});
+				let received: Uint8Array | undefined;
+				const wireServer = http.createServer(async (request, response) => {
+					if (request.method === "GET" && request.url === AUTH_PATH) {
+						response.setHeader("Content-Type", "application/json");
+						response.end(JSON.stringify(descriptor));
+						return;
+					}
+					try {
+						const verified = await authenticator.verify(
+							request.headers,
+							request.method!,
+							request.url!,
+						);
+						received = await getBody(request, verified.bodyLength);
+						verifyRequestBody(verified, received);
+						authenticator.consume(verified);
+						response.writeHead(200);
+						response.end();
+					} catch (error: any) {
+						response.writeHead(500);
+						response.end(error?.toString());
+					}
+				});
+				await new Promise<void>((resolve, reject) => {
+					wireServer.once("error", reject);
+					wireServer.listen(0, "127.0.0.1", () => resolve());
+				});
+				try {
+					const address = wireServer.address();
+					if (!address || typeof address === "string") {
+						throw new Error("Failed to resolve wire server address");
+					}
+					const { default: axios } = await import("axios");
+					const originalCreate = axios.create.bind(axios);
+					const instances: ReturnType<typeof axios.create>[] = [];
+					const createStub = sinon.stub(axios, "create");
+					createStub.callsFake(((config: any) => {
+						const instance = originalCreate(config);
+						instances.push(instance);
+						return instance;
+					}) as typeof axios.create);
+					try {
+						await createClient(serverPeer.identity, {
+							address: `http://127.0.0.1:${address.port}`,
+							peerId: serverPeer.peerId.toString(),
+						});
+					} finally {
+						createStub.restore();
+					}
+					expect(instances).to.have.length(2);
+
+					const backing = new TextEncoder().encode("xxwire 🌍 bytesyy");
+					const view = backing.subarray(2, backing.length - 2);
+					await instances[0].put(`http://127.0.0.1:${address.port}/wire`, view);
+					expect(received).to.deep.equal(view);
+				} finally {
+					await new Promise<void>((resolve) =>
+						wireServer.close(() => resolve()),
+					);
+				}
+			});
+
+			it("does not verify an endpoint that only echoes the pinned ID", async () => {
+				const fake = http.createServer((request, response) => {
+					if (request.url === PEER_ID_PATH) {
+						response.end(serverPeer.peerId.toString());
+						return;
+					}
+					response.setHeader("Content-Type", "application/json");
+					response.end(
+						JSON.stringify({
+							version: "2",
+							serverPeerId: serverPeer.peerId.toString(),
+							bootId: toBase64(new Uint8Array(32).fill(1)),
+							serverTime: "1750000000",
+							signature: "invalid",
+						}),
+					);
+				});
+				await new Promise<void>((resolve, reject) => {
+					fake.once("error", reject);
+					fake.listen(0, "127.0.0.1", () => resolve());
+				});
+				try {
+					const address = fake.address();
+					if (!address || typeof address === "string") {
+						throw new Error("Failed to resolve fake server address");
+					}
+					const c = await createClient(serverPeer.identity, {
+						address: `http://127.0.0.1:${address.port}`,
+						peerId: serverPeer.peerId.toString(),
+					});
+					expect(await c.peer.id.get()).to.equal(serverPeer.peerId.toString());
+					await expect(c.peer.id.verify()).rejectedWith(
+						"identity does not match",
+					);
+				} finally {
+					await new Promise<void>((resolve) => fake.close(() => resolve()));
+				}
+			});
+
+			it("refreshes a restarted server on the next call without retrying", async () => {
+				const c = await client(session.peers[0].identity, apiAddress);
+				await c.program.list();
+				const firstAddress = server.address();
+				if (!firstAddress || typeof firstAddress === "string") {
+					throw new Error("Failed to resolve API server address");
+				}
+				await new Promise<void>((resolve) => server.close(() => resolve()));
+				const restartDirectory = path.join(
+					process.cwd(),
+					"tmp",
+					"api-test",
+					"restart",
+					uuid(),
+				);
+				fs.mkdirSync(restartDirectory, { recursive: true });
+				server = await startApiServer(serverPeer, {
+					trust: new Trust(getTrustPath(restartDirectory)),
+					port: firstAddress.port,
+				});
+
+				let descriptorRequests = 0;
+				let protectedRequests = 0;
+				const observeRequests: http.RequestListener = (request) => {
+					if (request.url === AUTH_PATH) descriptorRequests += 1;
+					if (request.url === PROGRAMS_PATH) protectedRequests += 1;
+				};
+				server.prependListener("request", observeRequests);
+				try {
+					await expect(c.program.list()).to.be.rejected;
+					const failedProtectedRequests = protectedRequests;
+					expect(failedProtectedRequests).to.be.at.most(1);
+					expect(descriptorRequests).to.equal(0);
+
+					await c.program.list();
+					expect(protectedRequests).to.equal(failedProtectedRequests + 1);
+					expect(descriptorRequests).to.equal(1);
+				} finally {
+					server.removeListener("request", observeRequests);
+				}
+			});
+
+			it("uses a distinct boot audience for each API server", async () => {
+				const secondDirectory = path.join(
+					process.cwd(),
+					"tmp",
+					"api-test",
+					"second-api",
+					uuid(),
+				);
+				fs.mkdirSync(secondDirectory, { recursive: true });
+				const second = await startApiServer(serverPeer, {
+					trust: new Trust(getTrustPath(secondDirectory)),
+					port: 0,
+				});
+				try {
+					const secondAddress = second.address();
+					if (!secondAddress || typeof secondAddress === "string") {
+						throw new Error("Failed to resolve second API address");
+					}
+					const firstDescriptor = (await (
+						await fetch(apiAddress + AUTH_PATH)
+					).json()) as AuthDescriptor;
+					const secondBase = `http://localhost:${secondAddress.port}`;
+					const secondDescriptor = (await (
+						await fetch(secondBase + AUTH_PATH)
+					).json()) as AuthDescriptor;
+					expect(secondDescriptor.serverPeerId).to.equal(
+						firstDescriptor.serverPeerId,
+					);
+					expect(secondDescriptor.bootId).not.to.equal(firstDescriptor.bootId);
+
+					const headers: Record<string, string> = {};
+					await signRequest(
+						headers,
+						"GET",
+						PROGRAMS_PATH,
+						undefined,
+						session.peers[0].identity,
+						firstDescriptor,
+					);
+					expect(
+						(await fetch(secondBase + PROGRAMS_PATH, { headers })).status,
+					).to.equal(401);
+				} finally {
+					await new Promise<void>((resolve) => second.close(() => resolve()));
+				}
+			});
 		});
 
 		describe("program", () => {
@@ -241,7 +691,10 @@ describe("server", () => {
 					const kp2 = await Ed25519Keypair.create();
 					const kp3 = await Ed25519Keypair.create();
 
-					const c2 = await client(kp2, apiAddress);
+					const c2 = await createClient(kp2, {
+						address: apiAddress,
+						peerId: serverPeer.peerId.toString(),
+					});
 					await expect(c2.access.allow(kp3.publicKey)).rejectedWith(
 						"Request failed with status code 401",
 					);

--- a/packages/clients/peerbit-server/node/test/cli.spec.ts
+++ b/packages/clients/peerbit-server/node/test/cli.spec.ts
@@ -6,10 +6,12 @@ import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
 import { type ChildProcess, exec, execSync } from "child_process";
 import fs from "fs";
+import http from "http";
 import path from "path";
 import readline from "readline";
 import { v4 as uuid } from "uuid";
-import { getTrustPath } from "../src/config.js";
+import { getRemotesPath, getTrustPath } from "../src/config.js";
+import { Remotes } from "../src/remotes.js";
 import { Trust } from "../src/trust.js";
 import { __dirname, modulesPath } from "./utils.js";
 
@@ -225,6 +227,24 @@ describe("cli", () => {
 			}
 			expect(rejected).to.be.true;
 
+			const legacyRemotes = new Remotes(getRemotesPath(strangerDirectory));
+			legacyRemotes.add({
+				name: "legacy",
+				address: `http://localhost:${PORT}`,
+				group: "default",
+			});
+			rejected = false;
+			try {
+				runCommand(`remote connect legacy --directory ${strangerDirectory}`);
+			} catch {
+				rejected = true;
+			}
+			expect(rejected).to.be.true;
+			expect(
+				new Remotes(getRemotesPath(strangerDirectory)).getByName("legacy")
+					?.peerId,
+			).to.equal(undefined);
+
 			runCommand(
 				`remote add authorized http://localhost:${PORT} --directory ${adminDirectory}`,
 			);
@@ -259,6 +279,55 @@ describe("cli", () => {
 	});
 
 	describe("remote", () => {
+		it("does not mark an echo-only pinned identity as verified", async () => {
+			const expected = (await Ed25519Keypair.create()).publicKey
+				.toPeerId()
+				.toString();
+			const fake = http.createServer((request, response) => {
+				if (request.url === "/peer/id") {
+					response.end(expected);
+					return;
+				}
+				response.setHeader("Content-Type", "application/json");
+				response.end(
+					JSON.stringify({
+						version: "2",
+						serverPeerId: expected,
+						bootId: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+						serverTime: "1750000000",
+						signature: "invalid",
+					}),
+				);
+			});
+			await new Promise<void>((resolve, reject) => {
+				fake.once("error", reject);
+				fake.listen(0, "127.0.0.1", () => resolve());
+			});
+			try {
+				const address = fake.address();
+				if (!address || typeof address === "string") {
+					throw new Error("Failed to resolve fake server address");
+				}
+				fs.mkdirSync(configDirectory, { recursive: true });
+				new Remotes(getRemotesPath(configDirectory)).add({
+					name: "echo",
+					address: `http://127.0.0.1:${address.port}`,
+					group: "default",
+					peerId: expected,
+				});
+				const terminal = runCommandProcess(
+					`remote ls --directory ${configDirectory}`,
+				);
+				await new Promise<void>((resolve, reject) => {
+					terminal.process.once("error", reject);
+					terminal.process.once("close", () => resolve());
+				});
+				expect(terminal.out.join("\n")).to.include("UNVERIFIED");
+			} finally {
+				await new Promise<void>((resolve) => fake.close(() => resolve()));
+			}
+		});
+
 		it("rejets on invalid remote", async () => {
 			let rejected = false;
 			try {
@@ -277,6 +346,55 @@ describe("cli", () => {
 			);
 			const terminal = await connect("xyz123");
 			await checkPeerId(terminal);
+
+			const remotes = new Remotes(getRemotesPath(configDirectory));
+			const saved = remotes.getByName("xyz123")!;
+			const other = await Ed25519Keypair.create();
+			expect(remotes.remove("xyz123")).to.equal(true);
+			remotes.add({ ...saved, peerId: other.publicKey.toPeerId().toString() });
+			expect(runCommand(`remote ls --directory ${configDirectory}`)).to.include(
+				"MISMATCH",
+			);
+		});
+
+		it("keeps an existing identity pin when re-adding the name", async () => {
+			await start();
+			runCommand(
+				`remote add stable http://localhost:${PORT} --directory ${configDirectory}`,
+			);
+			const before = new Remotes(getRemotesPath(configDirectory)).getByName(
+				"stable",
+			)!;
+
+			const administratorId = runCommand(
+				`id --directory ${configDirectory}`,
+			).trim();
+			const replacementPort = PORT + 20_000;
+			const replacement = runCommandProcess(
+				`start --reset --port-api ${replacementPort} --port-node 0 --directory ${path.join(configDirectory, "replacement-server")} --grant-access ${administratorId}`,
+			);
+			processes.push(replacement);
+			await waitForResolved(() =>
+				expect(
+					replacement.out.some((line) => line.includes("API available")),
+				).to.equal(true),
+			);
+
+			let rejected = false;
+			try {
+				runCommand(
+					`remote add stable http://localhost:${replacementPort} --directory ${configDirectory}`,
+				);
+			} catch (error: any) {
+				rejected = true;
+				expect(`${error?.message || ""}${error?.stderr || ""}`).to.include(
+					"Server peer ID mismatch",
+				);
+			}
+			expect(rejected).to.equal(true);
+			expect(
+				new Remotes(getRemotesPath(configDirectory)).getByName("stable"),
+			).to.deep.equal(before);
 		});
 
 		describe("connect", () => {

--- a/packages/clients/peerbit-server/node/test/remotes.spec.ts
+++ b/packages/clients/peerbit-server/node/test/remotes.spec.ts
@@ -1,5 +1,8 @@
 import { expect } from "chai";
-import { getRetiredAWSManagementError } from "../src/remotes.js";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { Remotes, getRetiredAWSManagementError } from "../src/remotes.js";
 
 describe("legacy remote origins", () => {
 	it("gives actionable cleanup details for an AWS origin", () => {
@@ -12,5 +15,81 @@ describe("legacy remote origins", () => {
 		expect(error.message).to.include("i-0123456789");
 		expect(error.message).to.include("eu-north-1");
 		expect(error.message).to.include("AWS console");
+	});
+});
+
+describe("remote identity pinning", () => {
+	it("persists a server peer ID while still reading legacy entries", async () => {
+		const directory = fs.mkdtempSync(
+			path.join(os.tmpdir(), "peerbit-remotes-"),
+		);
+		const remotesPath = path.join(directory, "remotes.json");
+		try {
+			fs.writeFileSync(
+				remotesPath,
+				JSON.stringify({
+					remotes: [
+						{
+							name: "legacy",
+							address: "https://legacy.example",
+							group: "default",
+						},
+					],
+				}),
+			);
+			const remotes = new Remotes(remotesPath);
+			const legacy = remotes.getByName("legacy")!;
+			expect(legacy.peerId).to.equal(undefined);
+			remotes.add({ ...legacy, peerId: "12D3KooWPinned" });
+			expect(new Remotes(remotesPath).getByName("legacy")?.peerId).to.equal(
+				"12D3KooWPinned",
+			);
+		} finally {
+			fs.rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("requires removal before replacing a pinned identity", () => {
+		const directory = fs.mkdtempSync(
+			path.join(os.tmpdir(), "peerbit-remotes-"),
+		);
+		const remotesPath = path.join(directory, "remotes.json");
+		try {
+			const remotes = new Remotes(remotesPath);
+			remotes.add({
+				name: "production",
+				address: "https://node-a.example",
+				group: "default",
+				peerId: "server-a",
+			});
+
+			expect(() =>
+				remotes.add({
+					name: "production",
+					address: "https://node-b.example",
+					group: "default",
+					peerId: "server-b",
+				}),
+			).to.throw("Remove it before replacing the pin");
+			expect(new Remotes(remotesPath).getByName("production")).to.deep.equal({
+				name: "production",
+				address: "https://node-a.example",
+				group: "default",
+				peerId: "server-a",
+			});
+
+			expect(remotes.remove("production")).to.equal(true);
+			remotes.add({
+				name: "production",
+				address: "https://node-b.example",
+				group: "default",
+				peerId: "server-b",
+			});
+			expect(new Remotes(remotesPath).getByName("production")?.peerId).to.equal(
+				"server-b",
+			);
+		} finally {
+			fs.rmSync(directory, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/clients/peerbit-server/node/test/signed-request.spec.ts
+++ b/packages/clients/peerbit-server/node/test/signed-request.spec.ts
@@ -1,85 +1,390 @@
-import { Ed25519Keypair } from "@peerbit/crypto";
+import { Ed25519Keypair, toBase64 } from "@peerbit/crypto";
 import { expect } from "chai";
-import { signRequest, verifyRequest } from "../src/signed-request.js";
+import type http from "http";
+import { PassThrough } from "stream";
+import {
+	ReplayCapacityError,
+	ReplayRequestError,
+	RequestAuthenticator,
+	RequestBodyTooLargeError,
+	SIGNATURE_TIME_KEY,
+	SIGNATURE_VERSION_KEY,
+	SignedRequestError,
+	createAuthDescriptor,
+	getBody,
+	signRequest,
+	verifyAuthDescriptor,
+	verifyRequestBody,
+} from "../src/signed-request.js";
 
-describe("signed-request", () => {
-	let signedRequest: {
-		headers: Record<string, string>;
-		method: string;
-		data: string;
-		url: string;
+describe("signed-request v2", () => {
+	const nowMs = 1_750_000_000_000;
+	const bootId = toBase64(new Uint8Array(32).fill(7));
+	const audience = {
+		serverPeerId: "12D3KooWTestServerIdentity",
+		bootId,
 	};
-	const data = "hello";
+	const body = "hello 🌍";
 	let keypair: Ed25519Keypair;
+	let headers: Record<string, string>;
+
+	const authenticator = (
+		properties: Partial<
+			ConstructorParameters<typeof RequestAuthenticator>[0]
+		> = {},
+	) =>
+		new RequestAuthenticator({
+			...audience,
+			isTrusted: (key) => key.equals(keypair.publicKey),
+			wallClockMs: () => nowMs,
+			...properties,
+		});
+
 	beforeEach(async () => {
 		keypair = await Ed25519Keypair.create();
-		signedRequest = {
-			data,
-			headers: {},
-			method: "POST",
-			url: "https://example.com/hello",
-		};
+		headers = {};
 		await signRequest(
-			signedRequest.headers,
-			signedRequest.method,
-			new URL(signedRequest.url).pathname,
-			data,
+			headers,
+			"POST",
+			"/hello?Case=Kept",
+			body,
 			keypair,
+			audience,
+			{ nowMs, nonce: new Uint8Array(32).fill(3) },
 		);
 	});
 
-	it("verifies", async () => {
+	it("verifies an audience-bound request and its exact body", async () => {
+		const verifier = authenticator();
+		const verified = await verifier.verify(headers, "POST", "/hello?Case=Kept");
+		expect(verified.publicKey.equals(keypair.publicKey)).to.equal(true);
 		expect(
-			(
-				await verifyRequest(
-					signedRequest.headers,
-					signedRequest.method,
-					new URL(signedRequest.url).pathname,
-					data,
-				)
-			).equals(keypair.publicKey),
-		).to.be.true;
+			verifyRequestBody(verified, new TextEncoder().encode(body)),
+		).to.equal(body);
+		verifier.consume(verified);
 	});
 
-	it("invalid time", async () => {
-		signedRequest.headers["X-Peerbit-Signature-Time"] = String(
-			Number(signedRequest.headers["X-Peerbit-Signature-Time"] as string) + 1,
+	it("rejects an exact replay", async () => {
+		const verifier = authenticator();
+		const first = await verifier.verify(headers, "POST", "/hello?Case=Kept");
+		verifyRequestBody(first, new TextEncoder().encode(body));
+		verifier.consume(first);
+		await expect(
+			verifier.verify(headers, "POST", "/hello?Case=Kept"),
+		).rejectedWith(ReplayRequestError);
+	});
+
+	it("atomically accepts only one concurrent duplicate", async () => {
+		const verifier = authenticator();
+		const verifyBodyAndConsume = () =>
+			verifier.verify(headers, "POST", "/hello?Case=Kept").then((verified) => {
+				verifyRequestBody(verified, new TextEncoder().encode(body));
+				verifier.consume(verified);
+			});
+		const results = await Promise.allSettled([
+			verifyBodyAndConsume(),
+			verifyBodyAndConsume(),
+		]);
+		expect(
+			results.filter((result) => result.status === "fulfilled"),
+		).to.have.length(1);
+		expect(
+			results.filter((result) => result.status === "rejected"),
+		).to.have.length(1);
+	});
+
+	it("preserves method, path, query, and case exactly", async () => {
+		for (const [method, target] of [
+			["GET", "/hello?Case=Kept"],
+			["POST", "/Hello?Case=Kept"],
+			["POST", "/hello?case=Kept"],
+			["POST", "/hello?Case=kept"],
+			["POST", "/hello?Case=Kept&extra=1"],
+		] as const) {
+			await expect(
+				authenticator().verify(headers, method, target),
+			).rejectedWith(SignedRequestError);
+		}
+	});
+
+	it("rejects a request signed for another server or boot", async () => {
+		await expect(
+			authenticator({ serverPeerId: "another-server" }).verify(
+				headers,
+				"POST",
+				"/hello?Case=Kept",
+			),
+		).rejectedWith("audience");
+		await expect(
+			authenticator({ bootId: toBase64(new Uint8Array(32).fill(8)) }).verify(
+				headers,
+				"POST",
+				"/hello?Case=Kept",
+			),
+		).rejectedWith("audience");
+	});
+
+	it("strictly rejects malformed, stale, and future timestamps", async () => {
+		for (const timestamp of ["", "01", "+1", "1.0", "1e3", " 1", "1 "]) {
+			const changed = { ...headers, [SIGNATURE_TIME_KEY]: timestamp };
+			await expect(
+				authenticator().verify(changed, "POST", "/hello?Case=Kept"),
+			).rejectedWith(SignedRequestError);
+		}
+
+		const stale: Record<string, string> = {};
+		await signRequest(stale, "GET", "/programs", undefined, keypair, audience, {
+			nowMs: nowMs - 301_000,
+		});
+		await expect(
+			authenticator().verify(stale, "GET", "/programs"),
+		).rejectedWith("outside the window");
+
+		const future: Record<string, string> = {};
+		await signRequest(
+			future,
+			"GET",
+			"/programs",
+			undefined,
+			keypair,
+			audience,
+			{
+				nowMs: nowMs + 61_000,
+			},
 		);
 		await expect(
-			verifyRequest(
-				signedRequest.headers,
-				signedRequest.method,
-				new URL(signedRequest.url).pathname,
-				data,
-			),
-		).rejectedWith("Invalid signature");
+			authenticator().verify(future, "GET", "/programs"),
+		).rejectedWith("outside the window");
 	});
 
-	it("invalid method", async () => {
+	it("rejects duplicate and unsupported version headers", async () => {
 		await expect(
-			verifyRequest(
-				signedRequest.headers,
-				"?",
-				new URL(signedRequest.url).pathname,
-				data,
+			authenticator().verify(
+				{
+					...headers,
+					[SIGNATURE_VERSION_KEY.toLowerCase()]: "2",
+				},
+				"POST",
+				"/hello?Case=Kept",
 			),
-		).rejectedWith("Invalid signature");
+		).rejectedWith("duplicate");
+		await expect(
+			authenticator().verify(
+				{ ...headers, [SIGNATURE_VERSION_KEY]: "1" },
+				"POST",
+				"/hello?Case=Kept",
+			),
+		).rejectedWith("Unsupported");
 	});
 
-	it("invalid url", async () => {
-		await expect(
-			verifyRequest(signedRequest.headers, signedRequest.method, "?", data),
-		).rejectedWith("Invalid signature");
+	it("fails closed when the replay cache is full", async () => {
+		const verifier = authenticator({ maxReplayEntries: 1 });
+		const first = await verifier.verify(headers, "POST", "/hello?Case=Kept");
+		verifier.consume(first);
+		const second: Record<string, string> = {};
+		await signRequest(
+			second,
+			"GET",
+			"/programs",
+			undefined,
+			keypair,
+			audience,
+			{
+				nowMs,
+				nonce: new Uint8Array(32).fill(4),
+			},
+		);
+		await expect(verifier.verify(second, "GET", "/programs")).rejectedWith(
+			ReplayCapacityError,
+		);
 	});
 
-	it("invalid data", async () => {
+	it("does not allocate replay capacity for an untrusted signer", async () => {
+		const stranger = await Ed25519Keypair.create();
+		const untrusted: Record<string, string> = {};
+		await signRequest(
+			untrusted,
+			"GET",
+			"/programs",
+			undefined,
+			stranger,
+			audience,
+			{ nowMs },
+		);
+		const verifier = authenticator({ maxReplayEntries: 1 });
+		await expect(verifier.verify(untrusted, "GET", "/programs")).rejectedWith(
+			"not trusted",
+		);
+		const trusted = await verifier.verify(headers, "POST", "/hello?Case=Kept");
+		verifier.consume(trusted);
+	});
+
+	it("expires cache entries without resurrecting timestamps after clock rollback", async () => {
+		let wall = nowMs;
+		let monotonic = 0;
+		const verifier = authenticator({
+			maxReplayEntries: 1,
+			wallClockMs: () => wall,
+			monotonicClockMs: () => monotonic,
+		});
+		const first = await verifier.verify(headers, "POST", "/hello?Case=Kept");
+		verifier.consume(first);
+		wall += 400_000;
+		monotonic += 400_000;
+		const fresh: Record<string, string> = {};
+		await signRequest(fresh, "GET", "/programs", undefined, keypair, audience, {
+			nowMs: wall,
+			nonce: new Uint8Array(32).fill(5),
+		});
+		const verifiedFresh = await verifier.verify(fresh, "GET", "/programs");
+		verifier.consume(verifiedFresh);
+		wall = nowMs;
 		await expect(
-			verifyRequest(
-				signedRequest.headers,
-				signedRequest.method,
-				new URL(signedRequest.url).pathname,
-				"bye",
+			verifier.verify(headers, "POST", "/hello?Case=Kept"),
+		).rejectedWith("outside the window");
+	});
+
+	it("does not burn a nonce for a mismatched body", async () => {
+		const verifier = authenticator();
+		const verified = await verifier.verify(headers, "POST", "/hello?Case=Kept");
+		expect(() =>
+			verifyRequestBody(verified, new TextEncoder().encode("hello")),
+		).to.throw("does not match");
+
+		const retried = await verifier.verify(headers, "POST", "/hello?Case=Kept");
+		expect(verifyRequestBody(retried, new TextEncoder().encode(body))).to.equal(
+			body,
+		);
+		verifier.consume(retried);
+	});
+
+	it("rechecks freshness and trust immediately before consuming", async () => {
+		let wallClockMs = nowMs;
+		let trusted = true;
+		const verifier = authenticator({
+			wallClockMs: () => wallClockMs,
+			isTrusted: () => trusted,
+		});
+		const verified = await verifier.verify(headers, "POST", "/hello?Case=Kept");
+		verifyRequestBody(verified, new TextEncoder().encode(body));
+		trusted = false;
+		expect(() => verifier.consume(verified)).to.throw("not trusted");
+
+		trusted = true;
+		wallClockMs += 301_000;
+		expect(() => verifier.consume(verified)).to.throw("outside the window");
+	});
+
+	it("signs only the bytes in an offset Uint8Array view", async () => {
+		const backing = new TextEncoder().encode('xx{ "message": "hello 🌍" }\nyy');
+		const view = backing.subarray(2, backing.length - 2);
+		const viewHeaders: Record<string, string> = {};
+		await signRequest(viewHeaders, "PUT", "/program", view, keypair, audience, {
+			nowMs,
+		});
+		const verifier = authenticator();
+		const verified = await verifier.verify(viewHeaders, "PUT", "/program");
+		expect(verified.bodyLength).to.equal(view.byteLength);
+		expect(verifyRequestBody(verified, view)).to.equal(
+			'{ "message": "hello 🌍" }\n',
+		);
+		verifier.consume(verified);
+	});
+
+	it("rejects signed body bytes that are not valid UTF-8", async () => {
+		const invalid = new Uint8Array([0xff]);
+		const invalidHeaders: Record<string, string> = {};
+		await signRequest(
+			invalidHeaders,
+			"PUT",
+			"/program",
+			invalid,
+			keypair,
+			audience,
+			{ nowMs },
+		);
+		const verified = await authenticator().verify(
+			invalidHeaders,
+			"PUT",
+			"/program",
+		);
+		expect(() => verifyRequestBody(verified, invalid)).to.throw("valid UTF-8");
+	});
+
+	it("collects exact raw bytes across UTF-8 chunk boundaries", async () => {
+		const stream = new PassThrough();
+		const received = getBody(stream as unknown as http.IncomingMessage);
+		const expected = new TextEncoder().encode("before 🌍 after");
+		stream.write(expected.subarray(0, 8));
+		stream.write(expected.subarray(8, 9));
+		stream.end(expected.subarray(9));
+		expect(await received).to.deep.equal(expected);
+	});
+
+	it("rejects a streamed body that exceeds the configured bound", async () => {
+		const stream = new PassThrough();
+		const received = getBody(stream as unknown as http.IncomingMessage, 3);
+		stream.write(new Uint8Array([1, 2]));
+		stream.write(new Uint8Array([3, 4]));
+		await expect(received).rejectedWith(RequestBodyTooLargeError);
+		stream.end();
+	});
+
+	it("authenticates and pins the signed boot descriptor", async () => {
+		const server = await Ed25519Keypair.create();
+		const serverPeerId = server.publicKey.toPeerId().toString();
+		const descriptor = await createAuthDescriptor(
+			server,
+			{ serverPeerId, bootId },
+			nowMs,
+		);
+		expect(
+			(await verifyAuthDescriptor(descriptor, serverPeerId, { nowMs }))
+				.serverPeerId,
+		).to.equal(serverPeerId);
+		await expect(
+			verifyAuthDescriptor(
+				descriptor,
+				keypair.publicKey.toPeerId().toString(),
+				{
+					nowMs,
+				},
 			),
-		).rejectedWith("Invalid signature");
+		).rejectedWith("pinned ID");
+
+		await expect(
+			verifyAuthDescriptor(
+				{ ...descriptor, bootId: toBase64(new Uint8Array(32).fill(8)) },
+				serverPeerId,
+				{ nowMs },
+			),
+		).rejectedWith("signature");
+		await expect(
+			verifyAuthDescriptor({ ...descriptor, serverTime: "01" }, serverPeerId, {
+				nowMs,
+			}),
+		).rejectedWith("server time");
+	});
+
+	it("rejects stale and future signed authentication descriptors", async () => {
+		const server = await Ed25519Keypair.create();
+		const serverPeerId = server.publicKey.toPeerId().toString();
+		const stale = await createAuthDescriptor(
+			server,
+			{ serverPeerId, bootId },
+			nowMs - 301_000,
+		);
+		await expect(
+			verifyAuthDescriptor(stale, serverPeerId, { nowMs }),
+		).rejectedWith("outside the window");
+
+		const future = await createAuthDescriptor(
+			server,
+			{ serverPeerId, bootId },
+			nowMs + 61_000,
+		);
+		await expect(
+			verifyAuthDescriptor(future, serverPeerId, { nowMs }),
+		).rejectedWith("outside the window");
 	});
 });


### PR DESCRIPTION
## Summary

- replace the legacy administration-request signature with a strictly framed v2 format bound to the server peer ID and process boot ID
- enforce freshness, single-use nonces, exact method/target/body integrity, bounded request bodies, and fail-closed replay capacity
- serve and verify a signed authentication descriptor, block redirects, and persist/retain stable remote identity pins
- document the breaking migration and operational requirements

## Breaking migration

Legacy signed requests are intentionally rejected. Upgrade each remote server first with the old administrator client, then upgrade the administrator client and reconnect with the server peer ID pinned. Existing unpinned remote records are pinned only after authenticated access succeeds. An existing pin cannot be replaced without explicitly removing and re-enrolling that remote.

Replay state and boot identity are process-local, so multi-process deployments need sticky routing or shared replay/audience state. HTTPS remains required for confidentiality and response integrity.

## Validation

- `@peerbit/server`: 132 passing
- full monorepo build: passing
- lint: 0 errors (11 unrelated pre-existing warnings)
- Prettier and diff checks: passing
- two adversarial reviews of the frozen commit: no remaining P0/P1/P2 findings

Includes a major changeset for `@peerbit/server`.
