### PR TITLE
fix(blocks): verify bytes before DAG decoding

### DIFF
--- a/.changeset/tidy-block-verification.md
+++ b/.changeset/tidy-block-verification.md
@@ -1,0 +1,6 @@
+---
+"@peerbit/blocks-interface": patch
+"@peerbit/blocks": patch
+---
+
+Verify remote block bytes against their CID without decoding DAG-CBOR in the transport.

--- a/packages/transport/blocks-interface/README.md
+++ b/packages/transport/blocks-interface/README.md
@@ -1,3 +1,15 @@
 # Direct block interface
 
 Message types for the Block swap/share protocol
+
+## Verifying opaque block bytes
+
+Use `verifyBlockBytes` when a transport or store only needs to validate and
+forward opaque bytes. It checks the CID version, codec code, and multihash
+without decoding the block value. Logical decoding should happen later, at the
+consumer boundary, after the bytes are authenticated.
+
+`checkDecodeBlock` also verifies the digest before invoking a codec. A matching
+DAG-CBOR block can still allocate its decoded object graph, so callers handling
+attacker-selected CIDs should prefer `verifyBlockBytes` unless they explicitly
+need the logical value and enforce suitable resource bounds.

--- a/packages/transport/blocks-interface/src/block.ts
+++ b/packages/transport/blocks-interface/src/block.ts
@@ -1,7 +1,7 @@
 import * as dagCbor from "@ipld/dag-cbor";
 import { CID } from "multiformats";
 import { base58btc } from "multiformats/bases/base58";
-import { type Block, decode, encode } from "multiformats/block";
+import { type Block, createUnsafe, encode } from "multiformats/block";
 import * as raw from "multiformats/codecs/raw";
 import type { MultihashHasher } from "multiformats/hashes/interface";
 import { sha256 } from "multiformats/hashes/sha2";
@@ -19,6 +19,15 @@ export const codecCodes = {
 export const codecMap = {
 	raw,
 	"dag-cbor": dagCbor,
+};
+
+export type VerifyBlockBytesOptions = {
+	hasher?: MultihashHasher<number>;
+	/**
+	 * The codec expected by the caller. Only its multicodec code is consulted;
+	 * verification deliberately does not decode untrusted block bytes.
+	 */
+	codec?: { code: number };
 };
 
 export const cidifyString = (str: string): CID => {
@@ -40,6 +49,37 @@ export const stringifyCid = (cid: any): string => {
 	return cid.toString(defaultBase);
 };
 
+/**
+ * Verify that bytes match a CID without decoding their logical value.
+ *
+ * This is the appropriate boundary for transports and block stores that only
+ * move opaque bytes. In particular, it prevents a mismatching DAG-CBOR payload
+ * from allocating a decoded object graph before its digest is rejected.
+ */
+export const verifyBlockBytes = async (
+	expectedCID: CID | string,
+	bytes: Uint8Array,
+	options: VerifyBlockBytesOptions = {},
+): Promise<CID> => {
+	const cidObject =
+		typeof expectedCID === "string" ? cidifyString(expectedCID) : expectedCID;
+	const codec =
+		options.codec || codecCodes[cidObject.code as keyof typeof codecCodes];
+	if (!codec) {
+		throw unsupportedCodecError();
+	}
+	if (codec.code !== cidObject.code) {
+		throw new Error("CID codec does not match");
+	}
+
+	const digest = await (options.hasher || defaultHasher).digest(bytes);
+	const resolved = CID.create(cidObject.version, codec.code, digest);
+	if (!resolved.equals(cidObject)) {
+		throw new Error("CID does not match");
+	}
+	return resolved;
+};
+
 export const checkDecodeBlock = async (
 	expectedCID: CID | string,
 	bytes: Uint8Array,
@@ -49,28 +89,22 @@ export const checkDecodeBlock = async (
 		typeof expectedCID === "string" ? cidifyString(expectedCID) : expectedCID;
 	const codec =
 		options.codec || codecCodes[cidObject.code as keyof typeof codecCodes];
+	const resolved = await verifyBlockBytes(cidObject, bytes, {
+		codec,
+		hasher: options.hasher,
+	});
 	if (codec?.code === raw.code) {
-		const hasher = options?.hasher || defaultHasher;
-		const digest = await hasher.digest(bytes);
-		const resolved = CID.create(cidObject.version, raw.code, digest);
-		if (!resolved.equals(cidObject)) {
-			throw new Error("CID does not match");
-		}
 		return {
 			bytes,
 			cid: resolved,
 			value: bytes,
 		} as Block<Uint8Array, typeof raw.code, number, 1>;
 	}
-	const block = await decode({
+	return createUnsafe({
 		bytes,
+		cid: resolved,
 		codec,
-		hasher: options?.hasher || defaultHasher,
-	});
-	if (!block.cid.equals(cidObject)) {
-		throw new Error("CID does not match");
-	}
-	return block as Block<any, any, any, 1>;
+	}) as Block<any, any, any, 1>;
 };
 export const getBlockValue = async <T>(
 	block: Block<T, any, any, any>,

--- a/packages/transport/blocks-interface/src/index.ts
+++ b/packages/transport/blocks-interface/src/index.ts
@@ -65,7 +65,9 @@ export {
 	getBlockValue,
 	calculateRawCid,
 	checkDecodeBlock,
+	verifyBlockBytes,
 	codecCodes,
 	defaultHasher,
 	codecMap,
 } from "./block.js";
+export type { VerifyBlockBytesOptions } from "./block.js";

--- a/packages/transport/blocks/README.md
+++ b/packages/transport/blocks/README.md
@@ -1,3 +1,8 @@
 # Direct block
 
 Block swap/share protocol built on top of [Direct Stream](./../direct-stream/README.md)
+
+Remote responses are treated as opaque bytes. Their CID is verified before a
+response can resolve a read, be persisted, or teach the provider cache about
+the sender. The transport does not decode DAG-CBOR responses while performing
+that integrity check.

--- a/packages/transport/blocks/src/remote.ts
+++ b/packages/transport/blocks/src/remote.ts
@@ -3,10 +3,10 @@ import { TypedEventEmitter } from "@libp2p/interface";
 import {
 	type GetOptions,
 	type Blocks as IBlocks,
-	checkDecodeBlock,
 	cidifyString,
 	codecCodes,
 	stringifyCid,
+	verifyBlockBytes,
 } from "@peerbit/blocks-interface";
 import { Cache } from "@peerbit/cache";
 import { PublicSignKey } from "@peerbit/crypto";
@@ -871,13 +871,18 @@ export class RemoteBlocks implements IBlocks {
 
 		const codec = codecCodes[cidObject.code as keyof typeof codecCodes];
 
-		const tryDecode = async (bytes: Uint8Array) => {
-			const value = await checkDecodeBlock(cidObject, bytes, {
+		const tryVerify = async (bytes: Uint8Array) => {
+			const verifiedCid = await verifyBlockBytes(cidObject, bytes, {
 				codec,
 				hasher: options?.hasher,
 			});
-
-			return value;
+			// This block-shaped value is internal bookkeeping only. RemoteBlocks moves
+			// opaque bytes and must not invoke the logical codec at this boundary.
+			return {
+				bytes,
+				cid: verifiedCid,
+				value: bytes,
+			} as Block<Uint8Array, any, any, 1>;
 		};
 		const cachedValue = this.options.eagerBlocks
 			? this._blockCache?.get(cidString)
@@ -885,7 +890,7 @@ export class RemoteBlocks implements IBlocks {
 		if (cachedValue) {
 			this._blockCache!.del(cidString);
 			try {
-				const result = await tryDecode(cachedValue);
+				const result = await tryVerify(cachedValue);
 				return result.bytes;
 			} catch (error) {
 				// ignore
@@ -962,7 +967,7 @@ export class RemoteBlocks implements IBlocks {
 					);
 
 					resolver = async (bytes: Uint8Array, providerHash?: string) => {
-						const value = await tryDecode(bytes);
+						const value = await tryVerify(bytes);
 						if (settled) return;
 						if (providerHash) {
 							// A response is only evidence that its sender can provide this CID

--- a/packages/transport/blocks/test/verify-response.spec.ts
+++ b/packages/transport/blocks/test/verify-response.spec.ts
@@ -1,0 +1,235 @@
+import * as dagCbor from "@ipld/dag-cbor";
+import { createStore } from "@peerbit/any-store";
+import {
+	calculateRawCid,
+	checkDecodeBlock,
+	codecCodes,
+	createBlock,
+	stringifyCid,
+	verifyBlockBytes,
+} from "@peerbit/blocks-interface";
+import { Ed25519Keypair } from "@peerbit/crypto";
+import { expect } from "chai";
+import { sha256 } from "multiformats/hashes/sha2";
+import pDefer from "p-defer";
+import { AnyBlockStore } from "../src/any-blockstore.js";
+import { BlockRequest, BlockResponse, RemoteBlocks } from "../src/remote.js";
+
+type Codec = {
+	code: number;
+	decode(bytes: Uint8Array): unknown;
+};
+
+type ProviderCache = {
+	get(cid: string): string[] | undefined;
+};
+
+describe("opaque remote block verification", () => {
+	const remotes: RemoteBlocks[] = [];
+
+	afterEach(async () => {
+		for (const remote of remotes.splice(0).reverse()) {
+			if (remote.status !== "closed") {
+				await remote.stop();
+			}
+		}
+	});
+
+	const createRemote = async (requestSeen: ReturnType<typeof pDefer<void>>) => {
+		const key = await Ed25519Keypair.create();
+		const remote = new RemoteBlocks({
+			local: new AnyBlockStore(createStore()),
+			publicKey: key.publicKey,
+			publish: async (message) => {
+				if (message instanceof BlockRequest) {
+					requestSeen.resolve();
+				}
+			},
+			waitFor: async (): Promise<string[]> => [],
+		});
+		remotes.push(remote);
+		await remote.start();
+		return remote;
+	};
+
+	const cachedProviders = (remote: RemoteBlocks, cid: string) =>
+		(
+			remote as unknown as {
+				_providerCache: ProviderCache;
+			}
+		)._providerCache.get(cid);
+
+	const replaceDagDecoder = (onDecode: () => void) => {
+		const codecs = codecCodes as unknown as Record<number, Codec>;
+		const original = codecs[dagCbor.code]!;
+		codecs[dagCbor.code] = {
+			...original,
+			decode: (bytes) => {
+				onDecode();
+				return original.decode(bytes);
+			},
+		};
+		return () => {
+			codecs[dagCbor.code] = original;
+		};
+	};
+
+	it("verifies CID semantics with a custom hasher without decoding", async () => {
+		const block = await createBlock({ hello: "world" }, "dag-cbor");
+		const operations: string[] = [];
+		const hasher = {
+			...sha256,
+			digest: async (bytes: Uint8Array) => {
+				operations.push("hash");
+				return sha256.digest(bytes);
+			},
+		};
+		const codec = {
+			code: dagCbor.code,
+			decode: () => {
+				operations.push("decode");
+			},
+		};
+
+		const verified = await verifyBlockBytes(block.cid, block.bytes, {
+			codec,
+			hasher,
+		});
+
+		expect(verified.equals(block.cid)).to.equal(true);
+		expect(verified.version).to.equal(block.cid.version);
+		expect(verified.code).to.equal(block.cid.code);
+		expect(operations).to.deep.equal(["hash"]);
+	});
+
+	it("checks a DAG-CBOR digest before invoking its decoder", async () => {
+		const expected = await createBlock({ expected: true }, "dag-cbor");
+		const mismatching = await createBlock({ expected: false }, "dag-cbor");
+		const operations: string[] = [];
+		const hasher = {
+			...sha256,
+			digest: async (bytes: Uint8Array) => {
+				operations.push("hash");
+				return sha256.digest(bytes);
+			},
+		};
+		const codec = {
+			...dagCbor,
+			decode: (bytes: Uint8Array) => {
+				operations.push("decode");
+				return dagCbor.decode(bytes);
+			},
+		};
+
+		let rejected: unknown;
+		try {
+			await checkDecodeBlock(expected.cid, mismatching.bytes, {
+				codec,
+				hasher,
+			});
+		} catch (error) {
+			rejected = error;
+		}
+		expect((rejected as Error)?.message).to.equal("CID does not match");
+		expect(operations).to.deep.equal(["hash"]);
+
+		operations.length = 0;
+		const decoded = await checkDecodeBlock(expected.cid, expected.bytes, {
+			codec,
+			hasher,
+		});
+		expect(decoded.value).to.deep.equal({ expected: true });
+		expect(operations).to.deep.equal(["hash", "decode"]);
+	});
+
+	it("preserves raw block bytes and CID semantics", async () => {
+		const bytes = new Uint8Array([5, 4, 3]);
+		const { block } = await calculateRawCid(bytes);
+
+		const checked = await checkDecodeBlock(block.cid, bytes, {});
+
+		expect(checked.cid.equals(block.cid)).to.equal(true);
+		expect(checked.cid.version).to.equal(block.cid.version);
+		expect(checked.cid.code).to.equal(block.cid.code);
+		expect(checked.bytes).to.equal(bytes);
+		expect(checked.value).to.equal(bytes);
+	});
+
+	it("rejects mismatching DAG-CBOR before decode or provider learning", async () => {
+		const expected = await createBlock({ expected: true }, "dag-cbor");
+		const mismatching = await createBlock(
+			{
+				untrusted: Array.from({ length: 256 }, (_, index) => ({
+					index,
+					value: `value-${index}`,
+				})),
+			},
+			"dag-cbor",
+		);
+		const cid = stringifyCid(expected.cid);
+		const requestSeen = pDefer<void>();
+		const remote = await createRemote(requestSeen);
+		let decodeCalls = 0;
+		const restore = replaceDagDecoder(() => decodeCalls++);
+
+		try {
+			const read = remote.get(cid, {
+				remote: { from: ["requested-provider"], timeout: 100 },
+			});
+			await requestSeen.promise;
+			await remote.onMessage(new BlockResponse(cid, mismatching.bytes), {
+				from: "invalid-responder",
+			});
+
+			expect(await read).to.equal(undefined);
+			expect(decodeCalls).to.equal(0);
+			expect(cachedProviders(remote, cid)).to.deep.equal([
+				"requested-provider",
+			]);
+		} finally {
+			restore();
+		}
+	});
+
+	it("returns valid requested DAG-CBOR bytes without transport decoding", async () => {
+		const operations: string[] = [];
+		const hasher = {
+			...sha256,
+			digest: async (bytes: Uint8Array) => {
+				operations.push("hash");
+				return sha256.digest(bytes);
+			},
+		};
+		const block = await createBlock({ hello: "remote" }, "dag-cbor", {
+			hasher,
+		});
+		operations.length = 0;
+		const cid = stringifyCid(block.cid);
+		const requestSeen = pDefer<void>();
+		const remote = await createRemote(requestSeen);
+		const restore = replaceDagDecoder(() => operations.push("decode"));
+
+		try {
+			const read = remote.get(cid, {
+				remote: {
+					from: ["requested-provider"],
+					timeout: 1_000,
+					hasher,
+				} as any,
+			});
+			await requestSeen.promise;
+			await remote.onMessage(new BlockResponse(cid, block.bytes), {
+				from: "valid-responder",
+			});
+
+			expect(await read).to.deep.equal(block.bytes);
+			expect(operations).to.deep.equal(["hash"]);
+			expect(cachedProviders(remote, cid)).to.deep.equal([
+				"valid-responder",
+				"requested-provider",
+			]);
+		} finally {
+			restore();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- verify opaque remote block bytes against the requested CID without decoding DAG-CBOR in the transport
- make checkDecodeBlock verify the digest before invoking a logical codec
- keep provider learning and persistence behind successful integrity verification

## Security properties

- mismatching DAG-CBOR responses are rejected before structural allocation
- valid remote reads retain raw and DAG-CBOR compatibility, including custom hashers
- explicit structural consumers must still bound decoding of matching attacker-authored DAG content

## Validation

- full @peerbit/blocks node suite: 56/56
- affected package builds
- exact ESLint, Prettier, changeset, and diff checks
- three independent hostile reviews: no P0/P1/P2 findings