### PR TITLE
fix(blocks): bound eager response caching

### DIFF
--- a/.changeset/calm-eager-bounds.md
+++ b/.changeset/calm-eager-bounds.md
@@ -1,0 +1,14 @@
+---
+"@peerbit/blocks": patch
+"@peerbit/network-rust": patch
+"@peerbit/shared-log": patch
+"@peerbit/stream": patch
+---
+
+Bound unsolicited raw direct-block responses by retained and pending entries
+and bytes, copy only the block range, and require CID integrity validation
+before cache admission or provider learning. Decoding codecs such as DAG-CBOR
+remain on the requested-read path and are never eagerly materialized. Add
+matching TypeScript/rust-core accounting and TTL behavior plus local telemetry.
+SharedLog now leaves eager retention off unless callers explicitly enable it;
+the requested-read path and wire protocol are unchanged.

--- a/.changeset/fair-cache-deletes.md
+++ b/.changeset/fair-cache-deletes.md
@@ -1,0 +1,7 @@
+---
+"@peerbit/cache": patch
+---
+
+Release deleted cache values immediately and keep size accounting exact across
+delete/re-add and custom-size replacement cycles. Refresh replacement order so
+head-only FIFO/TTL trimming cannot retain older expired entries behind it.

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -6,7 +6,11 @@ import {
 	variant,
 } from "@dao-xyz/borsh";
 import type { AnyStore } from "@peerbit/any-store";
-import { AnyBlockStore, RemoteBlocks } from "@peerbit/blocks";
+import {
+	AnyBlockStore,
+	type EagerBlocksSetting,
+	RemoteBlocks,
+} from "@peerbit/blocks";
 import { cidifyString } from "@peerbit/blocks-interface";
 import { Cache } from "@peerbit/cache";
 import {
@@ -2570,7 +2574,7 @@ export type SharedLogOptions<
 	strictFullReplicaFallback?: boolean;
 	compatibility?: number;
 	domain?: ReplicationDomainConstructor<D>;
-	eagerBlocks?: boolean | { cacheSize?: number };
+	eagerBlocks?: EagerBlocksSetting;
 	fanout?: SharedLogFanoutOptions;
 };
 
@@ -12766,7 +12770,9 @@ export class SharedLog<
 				this.rpc.send(new BlocksMessage(message), options),
 			waitFor: this.rpc.waitFor.bind(this.rpc),
 			publicKey: this.node.identity.publicKey,
-			eagerBlocks: options?.eagerBlocks ?? true,
+			// Unsolicited block retention is opt-in. Explicit `true` retains the
+			// compatible eager path with bounded validation and storage budgets.
+			eagerBlocks: options?.eagerBlocks ?? false,
 			resolveProviders: async (cid, opts) => {
 				// 1) tracker-backed provider directory (best-effort, bounded)
 				try {

--- a/packages/programs/data/shared-log/test/blocks-publish.spec.ts
+++ b/packages/programs/data/shared-log/test/blocks-publish.spec.ts
@@ -37,4 +37,25 @@ describe("shared-log block publish adapter", () => {
 		]);
 		expect(sent[0].options.mode).to.equal(undefined);
 	});
+
+	it("does not retain unsolicited blocks unless eager mode is explicit", async () => {
+		session = await TestSession.connected(1);
+		db = await session.peers[0].open(new EventStore<string, any>());
+		const remoteBlocks = (db.log as any).remoteBlocks;
+		expect(remoteBlocks.getEagerBlockCacheTelemetry()).to.equal(undefined);
+	});
+
+	it("keeps explicit eager mode available with bounded defaults", async () => {
+		session = await TestSession.connected(1);
+		db = await session.peers[0].open(new EventStore<string, any>(), {
+			args: { eagerBlocks: true },
+		});
+		const remoteBlocks = (db.log as any).remoteBlocks;
+		const telemetry = remoteBlocks.getEagerBlockCacheTelemetry();
+		expect(telemetry.limits).to.include({
+			maxEntries: 1_000,
+			maxBytes: 32 * 1024 * 1024,
+			maxBlockBytes: 10 * 1024 * 1024,
+		});
+	});
 });

--- a/packages/programs/data/shared-log/test/utils/stores/event-store.ts
+++ b/packages/programs/data/shared-log/test/utils/stores/event-store.ts
@@ -82,6 +82,7 @@ export type Args<
 	nativeBackbone?: SharedLogOptions<Operation<T>, D, R>["nativeBackbone"];
 	nativeRangePlanner?: SharedLogOptions<Operation<T>, D, R>["nativeRangePlanner"];
 	strictFullReplicaFallback?: boolean;
+	eagerBlocks?: SharedLogOptions<Operation<T>, D, R>["eagerBlocks"];
 };
 @variant("event_store")
 export class EventStore<
@@ -159,6 +160,7 @@ export class EventStore<
 			nativeBackbone: properties?.nativeBackbone,
 			nativeRangePlanner: properties?.nativeRangePlanner,
 			strictFullReplicaFallback: properties?.strictFullReplicaFallback,
+			eagerBlocks: properties?.eagerBlocks,
 
 			// staticArgs was unused; keep open args explicit in tests
 		});

--- a/packages/transport/blocks/README.md
+++ b/packages/transport/blocks/README.md
@@ -6,3 +6,55 @@ Remote responses are treated as opaque bytes. Their CID is verified before a
 response can resolve a read, be persisted, or teach the provider cache about
 the sender. The transport does not decode DAG-CBOR responses while performing
 that integrity check.
+
+## Eager responses
+
+`eagerBlocks` is an optional receiver-local optimization. It retains a valid
+`BlockResponse` that arrived before a matching local read, so the next read can
+consume it without another request. It does not change the direct-block wire
+protocol, block addressing, or the normal requested-read path.
+
+The option is disabled by default in `DirectBlock` and `SharedLog`. Enable the
+compatible bounded behavior explicitly:
+
+```ts
+new DirectBlock(components, {
+	eagerBlocks: true,
+});
+```
+
+`true` applies these defaults:
+
+- at most 1,000 validated entries and 32 MiB of retained block bytes;
+- at most 10 MiB per unsolicited block and a 10-second TTL;
+- two simultaneous integrity checks;
+- at most 64 entries and 20 MiB waiting for or undergoing validation.
+
+The defaults can be overridden while retaining the old `cacheSize` option:
+
+```ts
+new DirectBlock(components, {
+	eagerBlocks: {
+		cacheSize: 256,
+		maxBytes: 16 * 1024 * 1024,
+		maxBlockBytes: 2 * 1024 * 1024,
+		ttlMs: 5_000,
+		validationConcurrency: 2,
+		maxPendingEntries: 32,
+		maxPendingBytes: 4 * 1024 * 1024,
+	},
+});
+```
+
+Unsolicited entries accept only raw blocks with SHA-256 CIDs. Peerbit copies
+only the exact block range, verifies the CID before cache admission, and learns
+the response sender as a provider only after validation. DAG-CBOR is excluded
+because logically decoding even hash-valid attacker-controlled object graphs
+can expand a small wire payload into unbounded transient heap use. DAG-CBOR,
+other codecs, and custom hashers remain available through the unchanged
+requested-read path; they simply miss this optimization.
+
+`getEagerBlockCacheTelemetry()` exposes current/peak entry, retained-byte and
+pending-validation budgets plus admission/rejection counters. The telemetry is
+local diagnostics and is not sent over the network. Byte counters cover block
+payload buffers.

--- a/packages/transport/blocks/src/eager-cache.ts
+++ b/packages/transport/blocks/src/eager-cache.ts
@@ -1,0 +1,256 @@
+import type {
+	RustEagerBlockCache,
+	RustEagerBlockCacheStats,
+} from "@peerbit/stream";
+
+/** Recipient-side eager-response limits. `cacheSize` is kept for API compatibility. */
+export type EagerBlocksOptions = {
+	/** Maximum number of validated blocks retained. */
+	cacheSize?: number;
+	/** Maximum combined byte length of retained blocks. */
+	maxBytes?: number;
+	/** Maximum byte length of one unsolicited block. */
+	maxBlockBytes?: number;
+	/** Time-to-live for a validated eager block, in milliseconds. */
+	ttlMs?: number;
+	/** Maximum number of simultaneous eager integrity checks. */
+	validationConcurrency?: number;
+	/** Maximum copied bytes waiting for, or undergoing, integrity checks. */
+	maxPendingBytes?: number;
+	/** Maximum blocks waiting for, or undergoing, integrity checks. */
+	maxPendingEntries?: number;
+};
+
+export type EagerBlocksSetting = boolean | EagerBlocksOptions;
+
+export const DEFAULT_EAGER_BLOCK_CACHE_ENTRIES = 1_000;
+export const DEFAULT_EAGER_BLOCK_CACHE_BYTES = 32 * 1024 * 1024;
+export const DEFAULT_EAGER_BLOCK_MAX_BYTES = 10 * 1024 * 1024;
+export const DEFAULT_EAGER_BLOCK_TTL_MS = 10_000;
+export const DEFAULT_EAGER_BLOCK_VALIDATION_CONCURRENCY = 2;
+export const DEFAULT_EAGER_BLOCK_PENDING_BYTES = 20 * 1024 * 1024;
+export const DEFAULT_EAGER_BLOCK_PENDING_ENTRIES = 64;
+export const MAX_EAGER_BLOCK_CID_LENGTH = 256;
+export const MAX_EAGER_BLOCK_TTL_MS = 0x7fff_ffff;
+
+export type NormalizedEagerBlocksOptions = {
+	maxEntries: number;
+	maxBytes: number;
+	maxBlockBytes: number;
+	ttlMs: number;
+	validationConcurrency: number;
+	maxPendingBytes: number;
+	maxPendingEntries: number;
+};
+
+const positiveSafeInteger = (value: number, name: string): number => {
+	if (!Number.isSafeInteger(value) || value <= 0) {
+		throw new RangeError(`${name} must be a positive safe integer`);
+	}
+	return value;
+};
+
+const positiveUint32 = (value: number, name: string): number => {
+	positiveSafeInteger(value, name);
+	if (value > 0xffff_ffff) {
+		throw new RangeError(`${name} must be at most 4294967295`);
+	}
+	return value;
+};
+
+const positiveTimerDelay = (value: number, name: string): number => {
+	positiveSafeInteger(value, name);
+	if (value > MAX_EAGER_BLOCK_TTL_MS) {
+		throw new RangeError(`${name} must be at most ${MAX_EAGER_BLOCK_TTL_MS}`);
+	}
+	return value;
+};
+
+export const normalizeEagerBlocksOptions = (
+	setting: Exclude<EagerBlocksSetting, false>,
+): NormalizedEagerBlocksOptions => {
+	const options = typeof setting === "boolean" ? {} : setting;
+	const maxEntries = positiveUint32(
+		options.cacheSize ?? DEFAULT_EAGER_BLOCK_CACHE_ENTRIES,
+		"eagerBlocks.cacheSize",
+	);
+	const maxBytes = positiveUint32(
+		options.maxBytes ?? DEFAULT_EAGER_BLOCK_CACHE_BYTES,
+		"eagerBlocks.maxBytes",
+	);
+	const maxBlockBytes = positiveUint32(
+		options.maxBlockBytes ?? DEFAULT_EAGER_BLOCK_MAX_BYTES,
+		"eagerBlocks.maxBlockBytes",
+	);
+	const ttlMs = positiveTimerDelay(
+		options.ttlMs ?? DEFAULT_EAGER_BLOCK_TTL_MS,
+		"eagerBlocks.ttlMs",
+	);
+	const validationConcurrency = positiveSafeInteger(
+		options.validationConcurrency ?? DEFAULT_EAGER_BLOCK_VALIDATION_CONCURRENCY,
+		"eagerBlocks.validationConcurrency",
+	);
+	const maxPendingBytes = positiveSafeInteger(
+		options.maxPendingBytes ?? DEFAULT_EAGER_BLOCK_PENDING_BYTES,
+		"eagerBlocks.maxPendingBytes",
+	);
+	const maxPendingEntries = positiveSafeInteger(
+		options.maxPendingEntries ?? DEFAULT_EAGER_BLOCK_PENDING_ENTRIES,
+		"eagerBlocks.maxPendingEntries",
+	);
+	return {
+		maxEntries,
+		maxBytes,
+		maxBlockBytes,
+		ttlMs,
+		validationConcurrency,
+		maxPendingBytes,
+		maxPendingEntries,
+	};
+};
+
+export interface EagerBlockCache extends RustEagerBlockCache {}
+
+type CacheEntry = {
+	bytes: Uint8Array;
+	expiresAt: number;
+};
+
+/**
+ * Exact FIFO/TTL cache used when the native block-exchange core is disabled.
+ * Deletion releases the byte buffer immediately and both entry and byte
+ * accounting remain exact across replacement and delete/re-add cycles.
+ */
+export class BoundedEagerBlockCache implements EagerBlockCache {
+	private readonly entries = new Map<string, CacheEntry>();
+	private currentBytes = 0;
+	private peakEntries = 0;
+	private peakBytes = 0;
+	private evictions = 0;
+	private expirations = 0;
+	private expiryTimer?: ReturnType<typeof setTimeout>;
+
+	constructor(
+		private readonly options: {
+			maxEntries: number;
+			maxBytes: number;
+			ttlMs: number;
+		},
+	) {
+		positiveUint32(options.maxEntries, "maxEntries");
+		positiveUint32(options.maxBytes, "maxBytes");
+		positiveTimerDelay(options.ttlMs, "ttlMs");
+	}
+
+	add(cid: string, bytes: Uint8Array): boolean {
+		this.sweepExpired(Date.now());
+		if (bytes.byteLength > this.options.maxBytes) {
+			return false;
+		}
+		const backing = bytes.buffer as ArrayBufferLike & {
+			readonly resizable?: boolean;
+			readonly growable?: boolean;
+		};
+		const retainedBytes =
+			bytes.byteOffset === 0 &&
+			backing.byteLength === bytes.byteLength &&
+			backing.resizable !== true &&
+			backing.growable !== true
+				? bytes
+				: bytes.slice();
+
+		this.remove(cid);
+		while (
+			this.entries.size >= this.options.maxEntries ||
+			this.currentBytes + retainedBytes.byteLength > this.options.maxBytes
+		) {
+			const oldest = this.entries.keys().next().value as string | undefined;
+			if (oldest == null) break;
+			this.remove(oldest);
+			this.evictions += 1;
+		}
+
+		this.entries.set(cid, {
+			bytes: retainedBytes,
+			expiresAt: Date.now() + this.options.ttlMs,
+		});
+		this.currentBytes += retainedBytes.byteLength;
+		this.peakEntries = Math.max(this.peakEntries, this.entries.size);
+		this.peakBytes = Math.max(this.peakBytes, this.currentBytes);
+		this.scheduleExpiry();
+		return true;
+	}
+
+	get(cid: string): Uint8Array | undefined {
+		this.sweepExpired(Date.now());
+		return this.entries.get(cid)?.bytes;
+	}
+
+	del(cid: string): void {
+		if (this.remove(cid)) {
+			this.scheduleExpiry();
+		}
+	}
+
+	clear(): void {
+		if (this.expiryTimer) {
+			clearTimeout(this.expiryTimer);
+			this.expiryTimer = undefined;
+		}
+		this.entries.clear();
+		this.currentBytes = 0;
+	}
+
+	stats(): RustEagerBlockCacheStats {
+		this.sweepExpired(Date.now());
+		return {
+			entries: this.entries.size,
+			bytes: this.currentBytes,
+			peakEntries: this.peakEntries,
+			peakBytes: this.peakBytes,
+			evictions: this.evictions,
+			expirations: this.expirations,
+		};
+	}
+
+	private remove(cid: string): boolean {
+		const entry = this.entries.get(cid);
+		if (!entry) return false;
+		this.entries.delete(cid);
+		this.currentBytes -= entry.bytes.byteLength;
+		return true;
+	}
+
+	private sweepExpired(now: number): void {
+		let expired = 0;
+		for (const [cid, entry] of this.entries) {
+			if (entry.expiresAt > now) break;
+			this.remove(cid);
+			expired += 1;
+		}
+		if (expired > 0) {
+			this.expirations += expired;
+			this.scheduleExpiry();
+		}
+	}
+
+	private scheduleExpiry(): void {
+		if (this.expiryTimer) {
+			clearTimeout(this.expiryTimer);
+			this.expiryTimer = undefined;
+		}
+		const oldest = this.entries.values().next().value as CacheEntry | undefined;
+		if (!oldest) return;
+		this.expiryTimer = setTimeout(
+			() => {
+				this.expiryTimer = undefined;
+				this.sweepExpired(Date.now());
+				this.scheduleExpiry();
+			},
+			Math.max(0, oldest.expiresAt - Date.now()),
+		);
+		if (typeof this.expiryTimer === "object" && "unref" in this.expiryTimer) {
+			this.expiryTimer.unref();
+		}
+	}
+}

--- a/packages/transport/blocks/src/index.ts
+++ b/packages/transport/blocks/src/index.ts
@@ -1,5 +1,6 @@
 export { DirectBlock } from "./libp2p.js";
 export * from "./interface.js";
 export * from "./any-blockstore.js";
+export * from "./eager-cache.js";
 export * from "./libp2p.js";
 export * from "./remote.js";

--- a/packages/transport/blocks/src/libp2p.ts
+++ b/packages/transport/blocks/src/libp2p.ts
@@ -15,6 +15,7 @@ import {
 } from "@peerbit/stream-interface";
 import type { Block } from "multiformats/block";
 import { AnyBlockStore } from "./any-blockstore.js";
+import type { EagerBlocksSetting } from "./eager-cache.js";
 import { BlockMessage, BlockRequest, BlockResponse, RemoteBlocks } from "./remote.js";
 
 export type DirectBlockComponents = DirectStreamComponents;
@@ -32,7 +33,7 @@ export class DirectBlock extends DirectStream implements IBlocks {
 			canRelayMessage?: boolean;
 			localTimeout?: number;
 			messageProcessingConcurrency?: number;
-			eagerBlocks?: boolean | { cacheSize?: number };
+			eagerBlocks?: EagerBlocksSetting;
 			resolveProviders?: (
 				cid: string,
 				options?: { signal?: AbortSignal },
@@ -173,6 +174,14 @@ export class DirectBlock extends DirectStream implements IBlocks {
 		};
 		this.onPeerConnectedFn = (evt: CustomEvent<PublicSignKey>) =>
 			this.remoteBlocks.onReachable(evt.detail);
+	}
+
+	getEagerBlockCacheTelemetry() {
+		return this.remoteBlocks.getEagerBlockCacheTelemetry();
+	}
+
+	waitForEagerBlockValidation(): Promise<void> {
+		return this.remoteBlocks.waitForEagerBlockValidation();
 	}
 
 	private encodeBlockMessage(message: BlockRequest | BlockResponse): Uint8Array {

--- a/packages/transport/blocks/src/remote.ts
+++ b/packages/transport/blocks/src/remote.ts
@@ -5,6 +5,8 @@ import {
 	type Blocks as IBlocks,
 	cidifyString,
 	codecCodes,
+	codecMap,
+	defaultHasher,
 	stringifyCid,
 	verifyBlockBytes,
 } from "@peerbit/blocks-interface";
@@ -31,6 +33,14 @@ import { AbortError } from "@peerbit/time";
 import { CID } from "multiformats";
 import { type Block } from "multiformats/block";
 import PQueue from "p-queue";
+import {
+	BoundedEagerBlockCache,
+	type EagerBlockCache,
+	type EagerBlocksSetting,
+	MAX_EAGER_BLOCK_CID_LENGTH,
+	type NormalizedEagerBlocksOptions,
+	normalizeEagerBlocksOptions,
+} from "./eager-cache.js";
 import type { BlockStore } from "./interface.js";
 
 export const logger = loggerFn("peerbit:transport:blocks");
@@ -79,16 +89,38 @@ type RemoteReadOptions = Exclude<GetOptions["remote"], boolean | undefined> & {
 	hasher?: any;
 };
 
-/**
- * Shared shape of the TS eager-block cache (`Cache<Uint8Array>`) and the
- * native-backed one (`RustEagerBlockCache`).
- */
-type EagerBlockCache = {
-	add(cid: string, bytes: Uint8Array): void;
-	get(cid: string): Uint8Array | null | undefined;
-	del(cid: string): unknown;
-	clear(): void;
+export type EagerBlockCacheTelemetry = {
+	entries: number;
+	bytes: number;
+	peakEntries: number;
+	peakBytes: number;
+	evictions: number;
+	expirations: number;
+	pendingEntries: number;
+	pendingBytes: number;
+	peakPendingEntries: number;
+	peakPendingBytes: number;
+	admitted: number;
+	hits: number;
+	rejectedCid: number;
+	rejectedCodec: number;
+	rejectedSize: number;
+	rejectedPending: number;
+	rejectedIntegrity: number;
+	rejectedLifecycle: number;
+	limits: NormalizedEagerBlocksOptions;
 };
+
+type EagerAdmissionCounters = Omit<
+	EagerBlockCacheTelemetry,
+	| "entries"
+	| "bytes"
+	| "peakEntries"
+	| "peakBytes"
+	| "evictions"
+	| "expirations"
+	| "limits"
+>;
 
 export class RemoteBlocks implements IBlocks {
 	localStore: BlockStore;
@@ -125,6 +157,22 @@ export class RemoteBlocks implements IBlocks {
 		(data: Uint8Array, providerHash?: string) => Promise<void>
 	>;
 	private _blockCache?: EagerBlockCache;
+	private _eagerBlocksOptions?: NormalizedEagerBlocksOptions;
+	private _eagerValidationQueue?: PQueue;
+	private _eagerAdmission: EagerAdmissionCounters = {
+		pendingEntries: 0,
+		pendingBytes: 0,
+		peakPendingEntries: 0,
+		peakPendingBytes: 0,
+		admitted: 0,
+		hits: 0,
+		rejectedCid: 0,
+		rejectedCodec: 0,
+		rejectedSize: 0,
+		rejectedPending: 0,
+		rejectedIntegrity: 0,
+		rejectedLifecycle: 0,
+	};
 	private _providerCache?: Cache<string[]>;
 	private _rustProviderCache?: RustBlockProviderCache;
 	private readonly rustExchange?: RustBlockExchange;
@@ -150,7 +198,7 @@ export class RemoteBlocks implements IBlocks {
 			localTimeout?: number;
 			messageProcessingConcurrency?: number;
 			publicKey: PublicSignKey;
-			eagerBlocks?: boolean | { cacheSize?: number };
+			eagerBlocks?: EagerBlocksSetting;
 			/**
 			 * Optional provider resolver used when `remote: true` is used without `remote.from`.
 			 *
@@ -332,13 +380,23 @@ export class RemoteBlocks implements IBlocks {
 		this._resolvers = new Map();
 		this._readFromPeersPromises = new Map();
 		if (options?.eagerBlocks) {
-			const eagerBlocksMax =
-				typeof options.eagerBlocks === "boolean"
-					? 1e3
-					: (options.eagerBlocks.cacheSize ?? 1e3);
+			this._eagerBlocksOptions = normalizeEagerBlocksOptions(
+				options.eagerBlocks,
+			);
+			this._eagerValidationQueue = new PQueue({
+				concurrency: this._eagerBlocksOptions.validationConcurrency,
+			});
 			this._blockCache = this.rustExchange
-				? this.rustExchange.createEagerCache({ max: eagerBlocksMax, ttl: 1e4 })
-				: new Cache<Uint8Array>({ max: eagerBlocksMax, ttl: 1e4 });
+				? this.rustExchange.createEagerCache({
+						maxEntries: this._eagerBlocksOptions.maxEntries,
+						maxBytes: this._eagerBlocksOptions.maxBytes,
+						ttlMs: this._eagerBlocksOptions.ttlMs,
+					})
+				: new BoundedEagerBlockCache({
+						maxEntries: this._eagerBlocksOptions.maxEntries,
+						maxBytes: this._eagerBlocksOptions.maxBytes,
+						ttlMs: this._eagerBlocksOptions.ttlMs,
+					});
 		}
 		type ProviderCacheOptions = {
 			maxEntries?: number;
@@ -404,13 +462,9 @@ export class RemoteBlocks implements IBlocks {
 						}
 					});
 				} else if (message instanceof BlockResponse) {
-					// TODO make sure we are not storing too much bytes in ram (like filter large blocks)
-					let resolver = this._resolvers.get(message.cid);
+					const resolver = this._resolvers.get(message.cid);
 					if (!resolver) {
-						if (options.eagerBlocks) {
-							// wait for the resolve to exist
-							this._blockCache!.add(message.cid, message.bytes);
-						}
+						this.queueEagerBlock(message.cid, message.bytes, context?.from);
 					} else {
 						await resolver(message.bytes, context?.from);
 					}
@@ -424,6 +478,170 @@ export class RemoteBlocks implements IBlocks {
 
 	getNativeLogBlockStoreHandle(): unknown {
 		return this.localStore.getNativeLogBlockStoreHandle?.();
+	}
+
+	/** Snapshot of bounded eager-response admission and retention state. */
+	getEagerBlockCacheTelemetry(): EagerBlockCacheTelemetry | undefined {
+		if (!this._blockCache || !this._eagerBlocksOptions) return undefined;
+		return {
+			...this._blockCache.stats(),
+			...this._eagerAdmission,
+			limits: { ...this._eagerBlocksOptions },
+		};
+	}
+
+	/** Primarily useful for diagnostics and deterministic tests. */
+	waitForEagerBlockValidation(): Promise<void> {
+		return this._eagerValidationQueue?.onIdle() ?? Promise.resolve();
+	}
+
+	private queueEagerBlock(
+		cidString: string,
+		incomingBytes: Uint8Array,
+		providerHash?: string,
+	): void {
+		const limits = this._eagerBlocksOptions;
+		const queue = this._eagerValidationQueue;
+		const cache = this._blockCache;
+		if (!limits || !queue || !cache) return;
+
+		const generationSignal = this.closeController.signal;
+		if (generationSignal.aborted) {
+			this._eagerAdmission.rejectedLifecycle += 1;
+			return;
+		}
+		if (!cidString || cidString.length > MAX_EAGER_BLOCK_CID_LENGTH) {
+			this._eagerAdmission.rejectedCid += 1;
+			return;
+		}
+
+		let cidObject: CID;
+		let canonicalCid: string;
+		try {
+			cidObject = cidifyString(cidString);
+			canonicalCid = stringifyCid(cidObject);
+			if (
+				cidObject.multihash.code !== defaultHasher.code ||
+				canonicalCid.length > MAX_EAGER_BLOCK_CID_LENGTH
+			) {
+				throw new Error("unsupported eager block cid");
+			}
+		} catch {
+			this._eagerAdmission.rejectedCid += 1;
+			return;
+		}
+		// Logical DAG-CBOR decoding can materialize even hash-valid attacker-
+		// controlled object graphs and expand a small wire payload by orders of
+		// magnitude. Eager admission therefore verifies only raw bytes; all other
+		// codecs remain available through the requested-response path.
+		if (cidObject.code !== codecMap.raw.code) {
+			this._eagerAdmission.rejectedCodec += 1;
+			return;
+		}
+		const codec = codecMap.raw;
+
+		const byteLength = incomingBytes.byteLength;
+		if (
+			byteLength > limits.maxBlockBytes ||
+			byteLength > limits.maxBytes ||
+			byteLength > limits.maxPendingBytes
+		) {
+			this._eagerAdmission.rejectedSize += 1;
+			return;
+		}
+		if (
+			this._eagerAdmission.pendingEntries >= limits.maxPendingEntries ||
+			this._eagerAdmission.pendingBytes + byteLength > limits.maxPendingBytes
+		) {
+			this._eagerAdmission.rejectedPending += 1;
+			return;
+		}
+
+		// The decoder commonly returns a subarray into the complete network frame.
+		// Copy exactly the block bytes before queuing so no larger backing buffer or
+		// response object remains retained while integrity validation is pending.
+		const bytes = new Uint8Array(byteLength);
+		bytes.set(incomingBytes);
+		this._eagerAdmission.pendingEntries += 1;
+		this._eagerAdmission.pendingBytes += byteLength;
+		this._eagerAdmission.peakPendingEntries = Math.max(
+			this._eagerAdmission.peakPendingEntries,
+			this._eagerAdmission.pendingEntries,
+		);
+		this._eagerAdmission.peakPendingBytes = Math.max(
+			this._eagerAdmission.peakPendingBytes,
+			this._eagerAdmission.pendingBytes,
+		);
+
+		let released = false;
+		const releaseReservation = () => {
+			if (released) return;
+			released = true;
+			this._eagerAdmission.pendingEntries -= 1;
+			this._eagerAdmission.pendingBytes -= byteLength;
+		};
+		const validateAndAdmit = async () => {
+			try {
+				if (generationSignal.aborted) {
+					this._eagerAdmission.rejectedLifecycle += 1;
+					return;
+				}
+				try {
+					await this.validateEagerBlock(cidObject, bytes, codec);
+				} catch {
+					this._eagerAdmission.rejectedIntegrity += 1;
+					return;
+				}
+				if (generationSignal.aborted) {
+					this._eagerAdmission.rejectedLifecycle += 1;
+					return;
+				}
+				const resolver =
+					this._resolvers.get(canonicalCid) ?? this._resolvers.get(cidString);
+				if (resolver) {
+					try {
+						// A read can install its resolver while eager validation is in
+						// progress. Let that resolver enforce its own (possibly custom)
+						// hasher contract and learn the provider only if it succeeds.
+						await resolver(bytes, providerHash);
+					} catch {
+						// Match an invalid active response: drop it and leave the read open.
+					}
+					return;
+				}
+				if (!cache.add(canonicalCid, bytes)) {
+					this._eagerAdmission.rejectedSize += 1;
+					return;
+				}
+				this._eagerAdmission.admitted += 1;
+				if (providerHash) {
+					// An unsolicited response is only a provider signal after both its
+					// CID and payload have passed the integrity gate.
+					this.rememberProvider(canonicalCid, providerHash);
+				}
+			} finally {
+				releaseReservation();
+			}
+		};
+		try {
+			void queue.add(validateAndAdmit).catch(() => {
+				releaseReservation();
+				if (!generationSignal.aborted) {
+					this._eagerAdmission.rejectedLifecycle += 1;
+				}
+			});
+		} catch {
+			releaseReservation();
+			this._eagerAdmission.rejectedLifecycle += 1;
+		}
+	}
+
+	private validateEagerBlock(
+		cid: CID,
+		bytes: Uint8Array,
+		codec: (typeof codecCodes)[keyof typeof codecCodes],
+	) {
+		return verifyBlockBytes(cid, bytes, { codec });
 	}
 
 	private normalizeProviderHints(
@@ -884,18 +1102,25 @@ export class RemoteBlocks implements IBlocks {
 				value: bytes,
 			} as Block<Uint8Array, any, any, 1>;
 		};
-		const cachedValue = this.options.eagerBlocks
-			? this._blockCache?.get(cidString)
-			: undefined;
-		if (cachedValue) {
-			this._blockCache!.del(cidString);
-			try {
-				const result = await tryVerify(cachedValue);
-				return result.bytes;
-			} catch (error) {
-				// ignore
+		const eagerCacheKey = stringifyCid(cidObject);
+		const consumeCachedValue = (): Uint8Array | undefined => {
+			if (options.hasher && options.hasher !== defaultHasher) {
+				// Eager admission proves the built-in SHA-256 contract only. Keep this
+				// lookup synchronous and leave custom hashers on the requested-response
+				// path; asynchronously revalidating cached entries would reopen a race
+				// before the read resolver is installed.
+				return undefined;
 			}
-		}
+			const cachedValue = this._blockCache?.get(eagerCacheKey);
+			if (cachedValue === undefined) return undefined;
+			this._blockCache!.del(eagerCacheKey);
+			this._eagerAdmission.hits += 1;
+			// Eager entries are inserted only after verifyBlockBytes succeeds. The
+			// one-shot cache hit therefore does not hash the full block a second time.
+			return cachedValue;
+		};
+		let cachedResult = consumeCachedValue();
+		if (cachedResult) return cachedResult;
 
 		const explicitFrom = this.normalizeProviderHints(options.from);
 		let providers =
@@ -907,6 +1132,11 @@ export class RemoteBlocks implements IBlocks {
 		// A resolver may observe abort and still complete normally. Do not create a
 		// timeout-backed read from the candidates it returns after shutdown.
 		throwIfReadWasAborted();
+		// Provider resolution is asynchronous. An eager validation can complete and
+		// cache the response during that await, so consume it before either returning
+		// for lack of providers or installing a resolver that would otherwise wait.
+		cachedResult = consumeCachedValue();
+		if (cachedResult) return cachedResult;
 		const canResolveLater = typeof this.options.resolveProviders === "function";
 		if (providers.length === 0 && !canResolveLater) {
 			// Without an explicit provider set (or a resolver), we intentionally do not
@@ -1244,6 +1474,7 @@ export class RemoteBlocks implements IBlocks {
 		// by the nested background-admission queue.
 		await capture(() => this._backgroundLoadFetchQueue.onIdle());
 		await capture(() => this._loadFetchQueue.onIdle());
+		await capture(() => this._eagerValidationQueue?.onIdle());
 		await capture(() => this.localStore?.stop());
 		this._readFromPeersPromises.clear();
 		this._resolvers.clear();

--- a/packages/transport/blocks/test/eager-cache.spec.ts
+++ b/packages/transport/blocks/test/eager-cache.spec.ts
@@ -1,0 +1,140 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import {
+	BoundedEagerBlockCache,
+	normalizeEagerBlocksOptions,
+} from "../src/eager-cache.js";
+
+describe("bounded eager-block cache", () => {
+	it("keeps byte and entry accounting exact across eviction and replacement", () => {
+		const cache = new BoundedEagerBlockCache({
+			maxEntries: 2,
+			maxBytes: 6,
+			ttlMs: 10_000,
+		});
+
+		expect(cache.add("a", new Uint8Array(4))).to.equal(true);
+		expect(cache.add("b", new Uint8Array(3))).to.equal(true);
+		expect(cache.get("a")).to.equal(undefined);
+		expect(cache.stats()).to.include({ entries: 1, bytes: 3, evictions: 1 });
+
+		expect(cache.add("b", new Uint8Array(5))).to.equal(true);
+		expect(cache.stats()).to.include({ entries: 1, bytes: 5 });
+		cache.del("b");
+		expect(cache.stats()).to.include({ entries: 0, bytes: 0 });
+
+		// The historical lazy-delete cache drifted after this cycle and could
+		// bypass its capacity. A fresh insert must still have exact accounting.
+		expect(cache.add("b", new Uint8Array(6))).to.equal(true);
+		cache.del("b");
+		expect(cache.add("c", new Uint8Array(6))).to.equal(true);
+		expect(cache.stats()).to.include({ entries: 1, bytes: 6 });
+		cache.clear();
+	});
+
+	it("releases expired buffers without requiring a later cache access", () => {
+		const clock = sinon.useFakeTimers({ now: 1_000 });
+		try {
+			const cache = new BoundedEagerBlockCache({
+				maxEntries: 2,
+				maxBytes: 8,
+				ttlMs: 100,
+			});
+			cache.add("a", new Uint8Array(4));
+			clock.tick(99);
+			expect(cache.stats().entries).to.equal(1);
+			clock.tick(1);
+			expect(cache.stats()).to.include({
+				entries: 0,
+				bytes: 0,
+				expirations: 1,
+			});
+		} finally {
+			clock.restore();
+		}
+	});
+
+	it("copies aliased views and bounds zero-byte duplicate entries", () => {
+		const cache = new BoundedEagerBlockCache({
+			maxEntries: 2,
+			maxBytes: 2,
+			ttlMs: 10_000,
+		});
+		const backing = new Uint8Array(1024);
+		backing.set([1, 2], 100);
+		expect(cache.add("aliased", backing.subarray(100, 102))).to.equal(true);
+		const retained = cache.get("aliased")!;
+		expect(retained).to.deep.equal(new Uint8Array([1, 2]));
+		expect(retained.buffer.byteLength).to.equal(2);
+
+		expect(cache.add("zero", new Uint8Array())).to.equal(true);
+		expect(cache.add("zero", new Uint8Array())).to.equal(true);
+		expect(cache.stats()).to.include({ entries: 2, bytes: 2 });
+		expect(cache.add("zero-2", new Uint8Array())).to.equal(true);
+		expect(cache.stats()).to.include({ entries: 2, bytes: 0 });
+		expect(cache.get("aliased")).to.equal(undefined);
+		cache.clear();
+	});
+
+	it("copies length-tracking views over resizable buffers", function () {
+		type ResizableBuffer = ArrayBuffer & {
+			readonly resizable: boolean;
+			resize(byteLength: number): void;
+		};
+		let backing: ResizableBuffer;
+		try {
+			const Constructor = ArrayBuffer as unknown as new (
+				byteLength: number,
+				options: { maxByteLength: number },
+			) => ResizableBuffer;
+			backing = new Constructor(2, { maxByteLength: 8 });
+		} catch {
+			this.skip();
+			return;
+		}
+		if (backing.resizable !== true || typeof backing.resize !== "function") {
+			this.skip();
+			return;
+		}
+
+		const source = new Uint8Array(backing);
+		source.set([1, 2]);
+		const cache = new BoundedEagerBlockCache({
+			maxEntries: 1,
+			maxBytes: 2,
+			ttlMs: 10_000,
+		});
+		expect(cache.add("resizable", source)).to.equal(true);
+		backing.resize(8);
+
+		const retained = cache.get("resizable")!;
+		expect(retained).to.deep.equal(new Uint8Array([1, 2]));
+		expect(retained.buffer.byteLength).to.equal(2);
+		expect(cache.stats()).to.include({ entries: 1, bytes: 2 });
+		cache.clear();
+	});
+
+	it("keeps the legacy true/cacheSize configuration compatible and validates bounds", () => {
+		expect(normalizeEagerBlocksOptions(true).maxEntries).to.equal(1_000);
+		expect(normalizeEagerBlocksOptions({ cacheSize: 7 }).maxEntries).to.equal(
+			7,
+		);
+		expect(() => normalizeEagerBlocksOptions({ maxBytes: 0 })).to.throw(
+			RangeError,
+		);
+		expect(() =>
+			normalizeEagerBlocksOptions({ cacheSize: 0x1_0000_0000 }),
+		).to.throw(RangeError);
+		expect(() => normalizeEagerBlocksOptions({ ttlMs: 0x8000_0000 })).to.throw(
+			RangeError,
+		);
+		expect(
+			() =>
+				new BoundedEagerBlockCache({
+					maxEntries: 0,
+					maxBytes: 1,
+					ttlMs: 1,
+				}),
+		).to.throw(RangeError);
+	});
+});

--- a/packages/transport/blocks/test/libp2p.spec.ts
+++ b/packages/transport/blocks/test/libp2p.spec.ts
@@ -1,5 +1,9 @@
 import { serialize } from "@dao-xyz/borsh";
-import { createBlock, stringifyCid } from "@peerbit/blocks-interface";
+import {
+	calculateRawCid,
+	createBlock,
+	stringifyCid,
+} from "@peerbit/blocks-interface";
 import { TestSession } from "@peerbit/libp2p-test-utils";
 import { waitForNeighbour } from "@peerbit/stream";
 import {
@@ -1440,6 +1444,7 @@ describe("transport", function () {
 			{ to: [session.peers[1].peerId] },
 		);
 		await db2ReceivedBlockResponse.promise;
+		await db2.waitForEagerBlockValidation();
 
 		// now try to fetch the block and make sure no requests are sent
 		let sent = false;
@@ -1453,6 +1458,96 @@ describe("transport", function () {
 		);
 		expect(bytes).to.deep.equal(data);
 		expect(sent).to.be.false;
+	});
+
+	it("bounds and integrity-gates unsolicited eager blocks", async () => {
+		session = await TestSession.disconnected(1, {
+			services: {
+				blocks: (components) =>
+					new DirectBlock(components, {
+						eagerBlocks: {
+							cacheSize: 2,
+							maxBytes: 8,
+							maxBlockBytes: 4,
+							ttlMs: 10_000,
+							validationConcurrency: 1,
+							maxPendingEntries: 1,
+							maxPendingBytes: 4,
+						},
+					}),
+			},
+		});
+		await store(session, 0).start();
+
+		const db = store(session, 0);
+		const remote = (db as any).remoteBlocks as RemoteBlocks;
+		const firstBytes = new Uint8Array([1, 2, 3, 4]);
+		const first = await calculateRawCid(firstBytes);
+		const backing = new Uint8Array(1024 * 1024);
+		backing.set(firstBytes, 123);
+		const aliased = backing.subarray(123, 127);
+
+		await remote.onMessage(new BlockResponse(first.cid, aliased), {
+			from: "validated-provider",
+		});
+		// Admission copied synchronously, before the decoder's large frame can be
+		// released or reused by the transport.
+		backing.fill(9);
+		await db.waitForEagerBlockValidation();
+		const cachedFirst = (remote as any)._blockCache.get(
+			first.cid,
+		) as Uint8Array;
+		expect(cachedFirst).to.deep.equal(firstBytes);
+		expect(cachedFirst.buffer.byteLength).to.equal(firstBytes.byteLength);
+
+		const secondBytes = new Uint8Array([5, 6, 7, 8]);
+		const thirdBytes = new Uint8Array([9, 10, 11, 12]);
+		const second = await calculateRawCid(secondBytes);
+		const third = await calculateRawCid(thirdBytes);
+		await Promise.all([
+			remote.onMessage(new BlockResponse(second.cid, secondBytes)),
+			remote.onMessage(new BlockResponse(third.cid, thirdBytes)),
+		]);
+		await db.waitForEagerBlockValidation();
+
+		let telemetry = db.getEagerBlockCacheTelemetry()!;
+		expect(telemetry.entries).to.equal(2);
+		expect(telemetry.bytes).to.equal(8);
+		expect(telemetry.peakBytes).to.equal(8);
+		expect(telemetry.rejectedPending).to.equal(1);
+		expect(telemetry.evictions).to.equal(0);
+
+		// Once the bounded validation slot drains, the rejected response can be
+		// retried and normal FIFO eviction still observes both retention limits.
+		await remote.onMessage(new BlockResponse(third.cid, thirdBytes));
+		await db.waitForEagerBlockValidation();
+		telemetry = db.getEagerBlockCacheTelemetry()!;
+		expect(telemetry.evictions).to.equal(1);
+		expect((remote as any)._blockCache.get(first.cid)).to.equal(undefined);
+
+		const invalidExpected = await calculateRawCid(
+			new Uint8Array([13, 14, 15, 16]),
+		);
+		await remote.onMessage(
+			new BlockResponse(invalidExpected.cid, new Uint8Array([0, 0, 0, 0])),
+		);
+		const oversizedBytes = new Uint8Array([1, 2, 3, 4, 5]);
+		const oversized = await calculateRawCid(oversizedBytes);
+		await remote.onMessage(new BlockResponse(oversized.cid, oversizedBytes));
+		await remote.onMessage(
+			new BlockResponse("x".repeat(257), new Uint8Array()),
+		);
+		await db.waitForEagerBlockValidation();
+
+		telemetry = db.getEagerBlockCacheTelemetry()!;
+		expect(telemetry.rejectedIntegrity).to.equal(1);
+		expect(telemetry.rejectedSize).to.equal(1);
+		expect(telemetry.rejectedCid).to.equal(1);
+		expect(telemetry.entries).to.equal(2);
+		expect(await db.get(second.cid, { remote: true })).to.deep.equal(
+			secondBytes,
+		);
+		expect(db.getEagerBlockCacheTelemetry()!.hits).to.equal(1);
 	});
 
 	/* it('can handle conurrent read/write', async () => {

--- a/packages/transport/blocks/test/provider-learning.spec.ts
+++ b/packages/transport/blocks/test/provider-learning.spec.ts
@@ -1,4 +1,9 @@
 import { createStore } from "@peerbit/any-store";
+import {
+	createBlock,
+	defaultHasher,
+	stringifyCid,
+} from "@peerbit/blocks-interface";
 import { Ed25519Keypair } from "@peerbit/crypto";
 import { expect } from "chai";
 import pDefer from "p-defer";
@@ -8,6 +13,7 @@ import { BlockRequest, BlockResponse, RemoteBlocks } from "../src/remote.js";
 const CID = "zb2rhbnwihVzMMEGAPf9EwTZBsQz9fszCnM4Y8mJmBFgiyN7J";
 const VALID_BYTES = new Uint8Array([5, 4, 3]);
 const INVALID_BYTES = new Uint8Array([3, 4, 5]);
+const CUSTOM_VALID_BYTES = new Uint8Array([7, 8, 9]);
 
 type ProviderCache = {
 	get(cid: string): string[] | undefined;
@@ -33,6 +39,10 @@ describe("validated block provider learning", () => {
 		maxProvidersPerCid?: number;
 		requestSeen?: ReturnType<typeof pDefer<void>>;
 		requestTargets?: string[][];
+		resolveProviders?: (
+			cid: string,
+			options?: { signal?: AbortSignal },
+		) => Promise<string[] | undefined> | string[] | undefined;
 	}) => {
 		const key = await Ed25519Keypair.create();
 		const remote = new RemoteBlocks({
@@ -47,6 +57,7 @@ describe("validated block provider learning", () => {
 			},
 			waitFor: async (): Promise<string[]> => [],
 			eagerBlocks: properties?.eagerBlocks,
+			resolveProviders: properties?.resolveProviders,
 			providerCache: {
 				maxProvidersPerCid: properties?.maxProvidersPerCid,
 			},
@@ -56,12 +67,15 @@ describe("validated block provider learning", () => {
 		return remote;
 	};
 
-	const cachedProviders = (remote: RemoteBlocks): string[] | undefined =>
+	const cachedProviders = (
+		remote: RemoteBlocks,
+		cid = CID,
+	): string[] | undefined =>
 		(
 			remote as unknown as {
 				_providerCache: ProviderCache;
 			}
-		)._providerCache.get(CID);
+		)._providerCache.get(cid);
 
 	it("does not learn the sender of an invalid active response", async () => {
 		const requestSeen = pDefer<void>();
@@ -108,8 +122,253 @@ describe("validated block provider learning", () => {
 		await remote.onMessage(new BlockResponse(CID, INVALID_BYTES), {
 			from: "unsolicited-invalid-responder",
 		});
+		await remote.waitForEagerBlockValidation();
 
 		expect(cachedProviders(remote)).to.equal(undefined);
+	});
+
+	it("learns an unsolicited sender only after eager integrity validation", async () => {
+		const remote = await createRemote({ eagerBlocks: true });
+
+		await remote.onMessage(new BlockResponse(CID, VALID_BYTES), {
+			from: "unsolicited-valid-responder",
+		});
+		await remote.waitForEagerBlockValidation();
+
+		expect(cachedProviders(remote)).to.deep.equal([
+			"unsolicited-valid-responder",
+		]);
+	});
+
+	it("rejects DAG-CBOR before eager decode but preserves requested reads", async () => {
+		const requestSeen = pDefer<void>();
+		const remote = await createRemote({ eagerBlocks: true, requestSeen });
+		const block = await createBlock(
+			{ nested: [[null], [null], [null]] },
+			"dag-cbor",
+		);
+		const cid = stringifyCid(block.cid);
+		let eagerValidationCalls = 0;
+		(remote as any).validateEagerBlock = async () => {
+			eagerValidationCalls += 1;
+			throw new Error("DAG-CBOR must not enter eager validation");
+		};
+
+		await remote.onMessage(new BlockResponse(cid, block.bytes), {
+			from: "unsolicited-dag-cbor-responder",
+		});
+		await remote.waitForEagerBlockValidation();
+		expect(eagerValidationCalls).to.equal(0);
+		expect(remote.getEagerBlockCacheTelemetry()).to.include({
+			entries: 0,
+			bytes: 0,
+			pendingEntries: 0,
+			pendingBytes: 0,
+			rejectedCodec: 1,
+		});
+		expect(cachedProviders(remote, cid)).to.equal(undefined);
+
+		const read = remote.get(cid, {
+			remote: { from: ["requested-provider"], timeout: 1_000 },
+		});
+		await requestSeen.promise;
+		await remote.onMessage(new BlockResponse(cid, block.bytes), {
+			from: "requested-dag-cbor-responder",
+		});
+		expect(await read).to.deep.equal(block.bytes);
+		expect(cachedProviders(remote, cid)).to.deep.equal([
+			"requested-dag-cbor-responder",
+			"requested-provider",
+		]);
+	});
+
+	it("hands a queued validated response to a resolver installed during hashing", async () => {
+		const validationStarted = pDefer<void>();
+		const releaseValidation = pDefer<void>();
+		const requestSeen = pDefer<void>();
+		const remote = await createRemote({ eagerBlocks: true, requestSeen });
+		const originalValidator = (remote as any).validateEagerBlock.bind(remote);
+		(remote as any).validateEagerBlock = async (...args: any[]) => {
+			validationStarted.resolve();
+			await releaseValidation.promise;
+			return originalValidator(...args);
+		};
+
+		await remote.onMessage(new BlockResponse(CID, VALID_BYTES), {
+			from: "queued-valid-responder",
+		});
+		await validationStarted.promise;
+		const read = remote.get(CID, {
+			remote: { from: ["requested-provider"], timeout: 1_000 },
+		});
+		await requestSeen.promise;
+		releaseValidation.resolve();
+
+		expect(await read).to.deep.equal(VALID_BYTES);
+		await remote.waitForEagerBlockValidation();
+		expect(remote.getEagerBlockCacheTelemetry()).to.include({
+			entries: 0,
+			pendingEntries: 0,
+			pendingBytes: 0,
+		});
+		expect(cachedProviders(remote)).to.deep.equal([
+			"queued-valid-responder",
+			"requested-provider",
+		]);
+	});
+
+	it("does not bypass an active read's custom hasher or learn its sender", async () => {
+		const validationStarted = pDefer<void>();
+		const releaseValidation = pDefer<void>();
+		const requestSeen = pDefer<void>();
+		const remote = await createRemote({ eagerBlocks: true, requestSeen });
+		const originalValidator = (remote as any).validateEagerBlock.bind(remote);
+		(remote as any).validateEagerBlock = async (...args: any[]) => {
+			validationStarted.resolve();
+			await releaseValidation.promise;
+			return originalValidator(...args);
+		};
+
+		await remote.onMessage(new BlockResponse(CID, VALID_BYTES), {
+			from: "default-valid-custom-invalid-responder",
+		});
+		await validationStarted.promise;
+		const customHasher = {
+			code: defaultHasher.code,
+			name: defaultHasher.name,
+			digest: async () => defaultHasher.digest(INVALID_BYTES),
+		};
+		const read = remote.get(CID, {
+			remote: {
+				from: ["requested-provider"],
+				timeout: 50,
+				hasher: customHasher,
+			} as any,
+		});
+		await requestSeen.promise;
+		releaseValidation.resolve();
+
+		expect(await read).to.equal(undefined);
+		await remote.waitForEagerBlockValidation();
+		expect(cachedProviders(remote)).to.deep.equal(["requested-provider"]);
+		expect(remote.getEagerBlockCacheTelemetry()).to.include({ entries: 0 });
+	});
+
+	it("keeps custom-hasher reads on the requested-response path", async () => {
+		const requestSeen = pDefer<void>();
+		const remote = await createRemote({ eagerBlocks: true, requestSeen });
+
+		// Admission proves the default SHA-256 CID, but that fact is not sufficient
+		// for a later caller that explicitly supplies another hasher contract.
+		await remote.onMessage(new BlockResponse(CID, VALID_BYTES));
+		await remote.waitForEagerBlockValidation();
+		expect(remote.getEagerBlockCacheTelemetry()).to.include({
+			entries: 1,
+			hits: 0,
+		});
+
+		const digestInputs: number[][] = [];
+		const customHasher = {
+			code: defaultHasher.code,
+			name: "test-custom-sha256",
+			digest: async (bytes: Uint8Array) => {
+				digestInputs.push(Array.from(bytes));
+				return defaultHasher.digest(
+					bytes.byteLength === CUSTOM_VALID_BYTES.byteLength &&
+						bytes.every((byte, index) => byte === CUSTOM_VALID_BYTES[index])
+						? VALID_BYTES
+						: INVALID_BYTES,
+				);
+			},
+		};
+		const read = remote.get(CID, {
+			remote: {
+				from: ["requested-provider"],
+				timeout: 1_000,
+				hasher: customHasher,
+			} as any,
+		});
+		await requestSeen.promise;
+
+		// The eager entry was neither returned nor asynchronously hashed before
+		// resolver installation, so there is no recursive cache/await race.
+		expect(digestInputs).to.deep.equal([]);
+		expect(remote.getEagerBlockCacheTelemetry()).to.include({
+			entries: 1,
+			hits: 0,
+		});
+
+		await remote.onMessage(new BlockResponse(CID, CUSTOM_VALID_BYTES), {
+			from: "custom-valid-responder",
+		});
+		expect(await read).to.deep.equal(CUSTOM_VALID_BYTES);
+		expect(digestInputs).to.deep.equal([Array.from(CUSTOM_VALID_BYTES)]);
+		expect(cachedProviders(remote)).to.deep.equal([
+			"custom-valid-responder",
+			"requested-provider",
+		]);
+	});
+
+	it("rechecks eager cache after asynchronous provider resolution", async () => {
+		const resolverStarted = pDefer<void>();
+		const resolverResult = pDefer<string[] | undefined>();
+		const requestTargets: string[][] = [];
+		const remote = await createRemote({
+			eagerBlocks: true,
+			requestTargets,
+			resolveProviders: async () => {
+				resolverStarted.resolve();
+				return resolverResult.promise;
+			},
+		});
+
+		const read = remote.get(CID, { remote: { timeout: 1_000 } });
+		await resolverStarted.promise;
+		await remote.onMessage(new BlockResponse(CID, VALID_BYTES));
+		await remote.waitForEagerBlockValidation();
+		resolverResult.resolve(undefined);
+
+		expect(await read).to.deep.equal(VALID_BYTES);
+		expect(requestTargets).to.deep.equal([]);
+		expect(remote.getEagerBlockCacheTelemetry()).to.include({
+			entries: 0,
+			hits: 1,
+		});
+	});
+
+	it("drains queued validation reservations before stop completes", async () => {
+		const validationStarted = pDefer<void>();
+		const releaseValidation = pDefer<void>();
+		const remote = await createRemote({ eagerBlocks: true });
+		const originalValidator = (remote as any).validateEagerBlock.bind(remote);
+		(remote as any).validateEagerBlock = async (...args: any[]) => {
+			validationStarted.resolve();
+			await releaseValidation.promise;
+			return originalValidator(...args);
+		};
+
+		await remote.onMessage(new BlockResponse(CID, VALID_BYTES));
+		await validationStarted.promise;
+		const stopping = remote.stop();
+		releaseValidation.resolve();
+		await stopping;
+		expect(remote.getEagerBlockCacheTelemetry()).to.include({
+			entries: 0,
+			pendingEntries: 0,
+			pendingBytes: 0,
+			admitted: 0,
+			rejectedLifecycle: 1,
+		});
+
+		await remote.start();
+		await remote.onMessage(new BlockResponse(CID, VALID_BYTES));
+		await remote.waitForEagerBlockValidation();
+		expect(remote.getEagerBlockCacheTelemetry()).to.include({
+			entries: 1,
+			pendingEntries: 0,
+			pendingBytes: 0,
+			admitted: 1,
+		});
 	});
 
 	it("does not let an invalid response evict a bounded provider hint", async () => {

--- a/packages/transport/network-rust/ARCHITECTURE.md
+++ b/packages/transport/network-rust/ARCHITECTURE.md
@@ -171,9 +171,12 @@ Same ingress as 2.2 (`rustCore` implies `nativeWire`). In addition:
   tracker/provider directories stay host-side.
 - **DirectBlock / RemoteBlocks**: `BlockMessage` codec, default provider
   resolution (negotiated→connected, capped 32), provider-hint cache and
-  eager-block index (FIFO cache port with the lazy-delete semantics and
-  verbatim constants of `@peerbit/cache`). Natively stored blocks are served
-  via `block_response_payload` (in `peerbit_log_rust`): the borsh
+  eager-block index. The native eager index keeps exact entry and byte
+  accounting with immediate delete/replacement and TTL eviction; the host
+  keeps exact-size byte buffers and owns the expiry timer. Unsolicited bytes
+  enter either cache only after the host's bounded CID integrity gate, and
+  provider learning occurs only after validation. Natively stored blocks are
+  served via `block_response_payload` (in `peerbit_log_rust`): the borsh
   `BlockResponse` is serialized inside wasm, so served block bytes never
   materialize as a JS value.
 

--- a/packages/transport/network-rust/src/block-exchange.ts
+++ b/packages/transport/network-rust/src/block-exchange.ts
@@ -12,6 +12,18 @@ import type {
 } from "@peerbit/stream";
 
 const BLOCK_MESSAGE_REQUEST = 0;
+const MAX_U32 = 0xffff_ffff;
+const MAX_TIMER_DELAY_MS = 0x7fff_ffff;
+
+const assertPositiveIntegerAtMost = (
+	value: number,
+	max: number,
+	name: string,
+): void => {
+	if (!Number.isSafeInteger(value) || value <= 0 || value > max) {
+		throw new RangeError(`${name} must be an integer between 1 and ${max}`);
+	}
+};
 
 type WasmDecodedBlockMessage = {
 	variant: number;
@@ -29,10 +41,12 @@ type WasmProviderCacheInstance = {
 };
 
 type WasmEagerIndexInstance = {
-	add(cid: string, nowMs: number): string[];
+	add(cid: string, size: number, nowMs: number): string[];
 	sweep(nowMs: number): string[];
 	contains(cid: string): boolean;
 	del(cid: string): void;
+	len(): number;
+	current_bytes(): number;
 	clear(): void;
 };
 
@@ -44,7 +58,8 @@ export type BlockExchangeWasmExports = {
 		maxProvidersPerCid: number,
 	) => WasmProviderCacheInstance;
 	DirectBlockEagerIndex: new (
-		max: number,
+		maxEntries: number,
+		maxBytes: number,
 		ttlMs: number,
 	) => WasmEagerIndexInstance;
 	db_decode_block_message(frame: Uint8Array): WasmDecodedBlockMessage;
@@ -111,28 +126,71 @@ class RustProviderCacheAdapter implements RustBlockProviderCache {
  */
 class RustEagerBlockCacheAdapter implements RustEagerBlockCache {
 	private readonly bytes = new Map<string, Uint8Array>();
+	private readonly expiries = new Map<string, number>();
 	private readonly wasm: WasmEagerIndexInstance;
+	private currentBytes = 0;
+	private peakEntries = 0;
+	private peakBytes = 0;
+	private evictions = 0;
+	private expirations = 0;
+	private expiryTimer?: ReturnType<typeof setTimeout>;
 
 	constructor(
 		module: BlockExchangeWasmExports,
-		init: { max: number; ttl: number },
+		private readonly init: {
+			maxEntries: number;
+			maxBytes: number;
+			ttlMs: number;
+		},
 	) {
-		this.wasm = new module.DirectBlockEagerIndex(init.max, init.ttl);
+		assertPositiveIntegerAtMost(init.maxEntries, MAX_U32, "maxEntries");
+		assertPositiveIntegerAtMost(init.maxBytes, MAX_U32, "maxBytes");
+		assertPositiveIntegerAtMost(init.ttlMs, MAX_TIMER_DELAY_MS, "ttlMs");
+		this.wasm = new module.DirectBlockEagerIndex(
+			init.maxEntries,
+			init.maxBytes,
+			init.ttlMs,
+		);
 	}
 
-	add(cid: string, value: Uint8Array): void {
-		for (const evicted of this.wasm.add(cid, Date.now())) {
-			this.bytes.delete(evicted);
+	add(cid: string, value: Uint8Array): boolean {
+		const now = Date.now();
+		this.sweep(now);
+		if (value.byteLength > this.init.maxBytes) {
+			this.scheduleExpiry();
+			return false;
 		}
-		this.bytes.set(cid, value);
+		const backing = value.buffer as ArrayBufferLike & {
+			readonly resizable?: boolean;
+			readonly growable?: boolean;
+		};
+		const retainedValue =
+			value.byteOffset === 0 &&
+			backing.byteLength === value.byteLength &&
+			backing.resizable !== true &&
+			backing.growable !== true
+				? value
+				: value.slice();
+
+		this.removeHostBytes(cid);
+		for (const evicted of this.wasm.add(cid, retainedValue.byteLength, now)) {
+			this.removeHostBytes(evicted);
+			this.evictions += 1;
+		}
+		this.bytes.set(cid, retainedValue);
+		this.expiries.set(cid, now + this.init.ttlMs);
+		this.currentBytes += retainedValue.byteLength;
+		this.peakEntries = Math.max(this.peakEntries, this.bytes.size);
+		this.peakBytes = Math.max(this.peakBytes, this.currentBytes);
+		this.scheduleExpiry();
+		return true;
 	}
 
 	get(cid: string): Uint8Array | undefined {
-		for (const evicted of this.wasm.sweep(Date.now())) {
-			this.bytes.delete(evicted);
-		}
+		this.sweep(Date.now());
+		this.scheduleExpiry();
 		if (!this.wasm.contains(cid)) {
-			this.bytes.delete(cid);
+			this.removeHostBytes(cid);
 			return undefined;
 		}
 		return this.bytes.get(cid);
@@ -140,12 +198,69 @@ class RustEagerBlockCacheAdapter implements RustEagerBlockCache {
 
 	del(cid: string): void {
 		this.wasm.del(cid);
-		this.bytes.delete(cid);
+		this.removeHostBytes(cid);
+		this.scheduleExpiry();
 	}
 
 	clear(): void {
+		if (this.expiryTimer) {
+			clearTimeout(this.expiryTimer);
+			this.expiryTimer = undefined;
+		}
 		this.wasm.clear();
 		this.bytes.clear();
+		this.expiries.clear();
+		this.currentBytes = 0;
+	}
+
+	stats() {
+		this.sweep(Date.now());
+		this.scheduleExpiry();
+		return {
+			entries: this.wasm.len(),
+			bytes: this.wasm.current_bytes(),
+			peakEntries: this.peakEntries,
+			peakBytes: this.peakBytes,
+			evictions: this.evictions,
+			expirations: this.expirations,
+		};
+	}
+
+	private removeHostBytes(cid: string): boolean {
+		const bytes = this.bytes.get(cid);
+		if (!bytes) return false;
+		this.bytes.delete(cid);
+		this.expiries.delete(cid);
+		this.currentBytes -= bytes.byteLength;
+		return true;
+	}
+
+	private sweep(now: number): void {
+		for (const expired of this.wasm.sweep(now)) {
+			if (this.removeHostBytes(expired)) {
+				this.expirations += 1;
+			}
+		}
+	}
+
+	private scheduleExpiry(): void {
+		if (this.expiryTimer) {
+			clearTimeout(this.expiryTimer);
+			this.expiryTimer = undefined;
+		}
+		const expiresAt = this.expiries.values().next().value as number | undefined;
+		if (expiresAt == null) return;
+		this.expiryTimer = setTimeout(
+			() => {
+				this.expiryTimer = undefined;
+				this.sweep(Date.now());
+				this.scheduleExpiry();
+			},
+			Math.max(0, expiresAt - Date.now()),
+		);
+		if (typeof this.expiryTimer === "object" && "unref" in this.expiryTimer) {
+			this.expiryTimer.unref();
+		}
 	}
 }
 
@@ -153,7 +268,8 @@ export const createRustBlockExchange = (
 	wasm: BlockExchangeWasmExports,
 ): RustBlockExchange => ({
 	encodeBlockRequest: (cid) => wasm.db_encode_block_request(cid),
-	encodeBlockResponse: (cid, bytes) => wasm.db_encode_block_response(cid, bytes),
+	encodeBlockResponse: (cid, bytes) =>
+		wasm.db_encode_block_response(cid, bytes),
 	decodeBlockMessage: (payload): RustDecodedBlockMessage => {
 		const decoded = wasm.db_decode_block_message(payload);
 		try {

--- a/packages/transport/network-rust/src/block_exchange.rs
+++ b/packages/transport/network-rust/src/block_exchange.rs
@@ -5,7 +5,7 @@
 //! host keeps sockets, promises and byte buffers; block bytes only cross the
 //! boundary inside serialized payloads.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, VecDeque};
 
 use crate::wire::{Reader, WireResult, Writer};
 
@@ -150,15 +150,13 @@ struct FifoEntry<V> {
     value: V,
 }
 
-/// Port of the `@peerbit/cache` FIFO cache (`packages/utils/cache`) with the
-/// lazy-delete set, specialized to string keys and per-entry size 1 (the
-/// only shape the block exchange uses).
+/// FIFO/TTL cache specialized to string keys and per-entry size 1 (the
+/// provider-hint cache is its only user).
 struct FifoCache<V> {
     max: usize,
     ttl_ms: u64,
     map: HashMap<String, FifoEntry<V>>,
     list: VecDeque<String>,
-    deleted: HashSet<String>,
     current_size: usize,
 }
 
@@ -169,7 +167,6 @@ impl<V> FifoCache<V> {
             ttl_ms: ttl_ms.max(1),
             map: HashMap::new(),
             list: VecDeque::new(),
-            deleted: HashSet::new(),
             current_size: 0,
         }
     }
@@ -191,17 +188,7 @@ impl<V> FifoCache<V> {
             if out_of_date || self.current_size > self.max {
                 let key = self.list.pop_front().expect("head exists");
                 self.map.remove(&key);
-                let was_deleted = self.deleted.remove(&key);
-                if !was_deleted {
-                    // saturating: the TS cache lets `currentSize` drift below
-                    // the live-entry count when a lazily-deleted key is
-                    // re-added (add() un-deletes without restoring the count),
-                    // and can even go negative. usize cannot go negative, so
-                    // saturate at 0 — matching TS's benign `currentSize > max`
-                    // stays-false effect instead of wrapping to usize::MAX
-                    // (which would evict every entry forever).
-                    self.current_size = self.current_size.saturating_sub(1);
-                }
+                self.current_size = self.current_size.saturating_sub(1);
                 if let Some(sink) = sink.as_mut() {
                     sink.push(key);
                 }
@@ -213,17 +200,18 @@ impl<V> FifoCache<V> {
 
     fn get(&mut self, key: &str, now_ms: u64) -> Option<&V> {
         self.trim(now_ms, None);
-        if self.deleted.contains(key) {
-            return None;
-        }
         self.map.get(key).map(|entry| &entry.value)
     }
 
     fn add(&mut self, key: &str, value: V, now_ms: u64) -> Vec<String> {
-        self.deleted.remove(key);
         if !self.map.contains_key(key) {
             self.list.push_back(key.to_string());
             self.current_size += 1;
+        } else {
+            // Refreshing the timestamp must also refresh FIFO/TTL order;
+            // otherwise a refreshed head can hide older expired entries.
+            self.list.retain(|existing| existing != key);
+            self.list.push_back(key.to_string());
         }
         self.map.insert(
             key.to_string(),
@@ -237,31 +225,9 @@ impl<V> FifoCache<V> {
         evicted
     }
 
-    fn del(&mut self, key: &str) {
-        if self.map.contains_key(key) && !self.deleted.contains(key) {
-            self.deleted.insert(key.to_string());
-            // saturating: see the note in trim(). A del/add/del cycle on the
-            // same key (add un-deletes without restoring the count) would
-            // otherwise drive this usize below 0 and wrap to usize::MAX,
-            // permanently breaking the cache.
-            self.current_size = self.current_size.saturating_sub(1);
-        }
-    }
-
-    fn contains(&self, key: &str) -> bool {
-        !self.deleted.contains(key) && self.map.contains_key(key)
-    }
-
-    fn sweep(&mut self, now_ms: u64) -> Vec<String> {
-        let mut evicted = Vec::new();
-        self.trim(now_ms, Some(&mut evicted));
-        evicted
-    }
-
     fn clear(&mut self) {
         self.map.clear();
         self.list.clear();
-        self.deleted.clear();
         self.current_size = 0;
     }
 }
@@ -322,39 +288,106 @@ impl ProviderHintCache {
     }
 }
 
-/// Eager-block bookkeeping (`_blockCache` in `RemoteBlocks`): which
-/// unresolved `BlockResponse` cids to keep and for how long. The block bytes
-/// themselves stay host-side; eviction notices tell the host which byte
-/// buffers to drop.
+struct EagerBlockEntry {
+    time: u64,
+    size: usize,
+}
+
+/// Exact eager-block bookkeeping (`_blockCache` in `RemoteBlocks`). The host
+/// owns the buffers; this index enforces the same entry/byte/TTL limits as the
+/// pure TypeScript cache and reports which host buffers must be released.
 pub struct EagerBlockIndex {
-    cache: FifoCache<()>,
+    max_entries: usize,
+    max_bytes: usize,
+    ttl_ms: u64,
+    entries: HashMap<String, EagerBlockEntry>,
+    order: VecDeque<String>,
+    current_bytes: usize,
 }
 
 impl EagerBlockIndex {
-    pub fn new(max: usize, ttl_ms: u64) -> Self {
+    pub fn new(max_entries: usize, max_bytes: usize, ttl_ms: u64) -> Self {
         EagerBlockIndex {
-            cache: FifoCache::new(max, ttl_ms),
+            max_entries: max_entries.max(1),
+            max_bytes: max_bytes.max(1),
+            ttl_ms: ttl_ms.max(1),
+            entries: HashMap::new(),
+            order: VecDeque::new(),
+            current_bytes: 0,
         }
     }
 
-    pub fn add(&mut self, cid: &str, now_ms: u64) -> Vec<String> {
-        self.cache.add(cid, (), now_ms)
+    fn remove(&mut self, cid: &str) -> bool {
+        let Some(entry) = self.entries.remove(cid) else {
+            return false;
+        };
+        self.current_bytes = self.current_bytes.saturating_sub(entry.size);
+        self.order.retain(|existing| existing != cid);
+        true
+    }
+
+    pub fn add(&mut self, cid: &str, size: usize, now_ms: u64) -> Vec<String> {
+        let mut evicted = self.sweep(now_ms);
+        if size > self.max_bytes {
+            return evicted;
+        }
+
+        self.remove(cid);
+        // Make room before adding so `current_bytes + size` cannot overflow the
+        // wasm32 `usize` when callers configure a near-u32 byte budget.
+        while self.entries.len() >= self.max_entries || self.current_bytes > self.max_bytes - size {
+            let Some(oldest) = self.order.front().cloned() else {
+                break;
+            };
+            self.remove(&oldest);
+            evicted.push(oldest);
+        }
+        self.entries
+            .insert(cid.to_string(), EagerBlockEntry { time: now_ms, size });
+        self.order.push_back(cid.to_string());
+        self.current_bytes += size;
+        evicted
     }
 
     pub fn sweep(&mut self, now_ms: u64) -> Vec<String> {
-        self.cache.sweep(now_ms)
+        let mut evicted = Vec::new();
+        loop {
+            let Some(cid) = self.order.front().cloned() else {
+                break;
+            };
+            let Some(entry) = self.entries.get(&cid) else {
+                self.order.pop_front();
+                continue;
+            };
+            if now_ms < entry.time.saturating_add(self.ttl_ms) {
+                break;
+            }
+            self.remove(&cid);
+            evicted.push(cid);
+        }
+        evicted
     }
 
     pub fn contains(&self, cid: &str) -> bool {
-        self.cache.contains(cid)
+        self.entries.contains_key(cid)
     }
 
     pub fn del(&mut self, cid: &str) {
-        self.cache.del(cid);
+        self.remove(cid);
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn current_bytes(&self) -> usize {
+        self.current_bytes
     }
 
     pub fn clear(&mut self) {
-        self.cache.clear();
+        self.entries.clear();
+        self.order.clear();
+        self.current_bytes = 0;
     }
 }
 
@@ -523,49 +556,91 @@ mod tests {
     }
 
     #[test]
+    fn provider_cache_refresh_preserves_ttl_order() {
+        let mut cache = ProviderHintCache::new("me".to_string(), 8, 1_000, 8);
+        cache.remember_hints("a", &strings(&["provider-a"]), NOW);
+        cache.remember_hints("b", &strings(&["provider-b"]), NOW + 500);
+        cache.remember_hints("a", &strings(&["provider-a2"]), NOW + 900);
+
+        assert_eq!(cache.get("b", NOW + 1_600), None);
+        assert_eq!(cache.get("a", NOW + 1_600), Some(strings(&["provider-a2"])));
+    }
+
+    #[test]
     fn eager_index_reports_evictions() {
-        let mut index = EagerBlockIndex::new(2, 10_000);
-        assert!(index.add("a", NOW).is_empty());
-        assert!(index.add("b", NOW).is_empty());
-        assert_eq!(index.add("c", NOW), strings(&["a"]));
+        let mut index = EagerBlockIndex::new(2, 8, 10_000);
+        assert!(index.add("a", 4, NOW).is_empty());
+        assert!(index.add("b", 4, NOW).is_empty());
+        assert_eq!(index.add("c", 4, NOW), strings(&["a"]));
         assert!(index.contains("b"));
         assert!(index.contains("c"));
         assert!(!index.contains("a"));
+        assert_eq!(index.len(), 2);
+        assert_eq!(index.current_bytes(), 8);
 
         // ttl expiry surfaces through sweep
-        assert_eq!(index.sweep(NOW + 10_001), strings(&["b", "c"]));
+        assert_eq!(index.sweep(NOW + 10_000), strings(&["b", "c"]));
         assert!(!index.contains("b"));
+        assert_eq!(index.current_bytes(), 0);
 
-        // lazy delete frees capacity without breaking fifo order
-        let mut index = EagerBlockIndex::new(2, 10_000);
-        index.add("a", NOW);
+        // Immediate delete frees both entry and byte capacity.
+        let mut index = EagerBlockIndex::new(2, 8, 10_000);
+        index.add("a", 8, NOW);
         index.del("a");
         assert!(!index.contains("a"));
-        assert!(index.add("b", NOW).is_empty());
-        assert!(index.add("c", NOW).is_empty());
+        assert_eq!(index.current_bytes(), 0);
+        assert!(index.add("b", 4, NOW).is_empty());
+        assert!(index.add("c", 4, NOW).is_empty());
+    }
+
+    #[test]
+    fn eager_index_enforces_byte_bound_and_replacement_accounting() {
+        let mut index = EagerBlockIndex::new(10, 6, 10_000);
+        assert!(index.add("a", 4, NOW).is_empty());
+        assert_eq!(index.add("b", 3, NOW), strings(&["a"]));
+        assert_eq!(index.current_bytes(), 3);
+
+        // Replacing a cid subtracts its previous byte length before admission.
+        assert!(index.add("b", 5, NOW + 1).is_empty());
+        assert_eq!(index.len(), 1);
+        assert_eq!(index.current_bytes(), 5);
+
+        // The native adapter rejects oversized inserts before calling add;
+        // direct callers still cannot make the index exceed its byte budget.
+        assert!(index.add("oversized", 7, NOW + 2).is_empty());
+        assert!(!index.contains("oversized"));
+        assert_eq!(index.current_bytes(), 5);
+    }
+
+    #[test]
+    fn eager_index_entry_bounds_zero_byte_replacements() {
+        let mut index = EagerBlockIndex::new(2, 2, 10_000);
+        assert!(index.add("bytes", 2, NOW).is_empty());
+        assert!(index.add("zero", 0, NOW).is_empty());
+        assert!(index.add("zero", 0, NOW + 1).is_empty());
+        assert_eq!(index.len(), 2);
+        assert_eq!(index.current_bytes(), 2);
+
+        assert_eq!(index.add("zero-2", 0, NOW + 2), strings(&["bytes"]));
+        assert_eq!(index.len(), 2);
+        assert_eq!(index.current_bytes(), 0);
+        assert!(index.contains("zero"));
+        assert!(index.contains("zero-2"));
     }
 
     #[test]
     fn add_del_readd_del_does_not_break_the_cache() {
-        // Regression: two providers answer the same BlockRequest, so the same
-        // cid is consumed (del) after being re-added by the second response.
-        // add() un-deletes the key without restoring current_size, so a
-        // second del of a now-live entry used to drive the usize below zero
-        // and wrap to usize::MAX — after which every trim() evicted the whole
-        // cache forever. current_size must stay bounded and the cache must
-        // keep serving.
-        let mut index = EagerBlockIndex::new(1, 10_000);
-        assert!(index.add("c", NOW).is_empty());
-        index.del("c"); // consumed by a read (size -> 0)
-        index.add("c", NOW); // second (duplicate) response re-adds it
-        index.del("c"); // consumed again — this used to underflow-wrap
+        let mut index = EagerBlockIndex::new(1, 8, 10_000);
+        assert!(index.add("c", 4, NOW).is_empty());
+        index.del("c");
+        index.add("c", 5, NOW);
+        index.del("c");
         assert!(!index.contains("c"));
+        assert_eq!(index.len(), 0);
+        assert_eq!(index.current_bytes(), 0);
 
-        // The cache is still usable: a freshly added entry is served rather
-        // than being evicted instantly (the wrap symptom was current_size >
-        // max on every trim, wiping the cache on the next add).
         assert!(
-            index.add("d", NOW).is_empty(),
+            index.add("d", 8, NOW).is_empty(),
             "add must not trigger a mass eviction after the del/add/del cycle"
         );
         assert!(index.contains("d"), "freshly added entry must be served");

--- a/packages/transport/network-rust/src/lib.rs
+++ b/packages/transport/network-rust/src/lib.rs
@@ -593,15 +593,19 @@ pub struct DirectBlockEagerIndex {
 #[wasm_bindgen]
 impl DirectBlockEagerIndex {
     #[wasm_bindgen(constructor)]
-    pub fn new(max: u32, ttl_ms: f64) -> DirectBlockEagerIndex {
+    pub fn new(max_entries: u32, max_bytes: f64, ttl_ms: f64) -> DirectBlockEagerIndex {
         DirectBlockEagerIndex {
-            inner: EagerBlockIndex::new(max as usize, ttl_ms.max(1.0) as u64),
+            inner: EagerBlockIndex::new(
+                max_entries as usize,
+                max_bytes.max(1.0) as usize,
+                ttl_ms.max(1.0) as u64,
+            ),
         }
     }
 
     /// Track a cid; returns the cids evicted by the insert (ttl/max bound).
-    pub fn add(&mut self, cid: &str, now_ms: f64) -> Vec<String> {
-        self.inner.add(cid, now_ms as u64)
+    pub fn add(&mut self, cid: &str, size: u32, now_ms: f64) -> Vec<String> {
+        self.inner.add(cid, size as usize, now_ms as u64)
     }
 
     /// Evict expired entries and return their cids.
@@ -615,6 +619,14 @@ impl DirectBlockEagerIndex {
 
     pub fn del(&mut self, cid: &str) {
         self.inner.del(cid);
+    }
+
+    pub fn len(&self) -> u32 {
+        self.inner.len() as u32
+    }
+
+    pub fn current_bytes(&self) -> f64 {
+        self.inner.current_bytes() as f64
     }
 
     pub fn clear(&mut self) {

--- a/packages/transport/network-rust/test/block-exchange.spec.ts
+++ b/packages/transport/network-rust/test/block-exchange.spec.ts
@@ -18,6 +18,7 @@ import {
 	waitForNeighbour,
 } from "@peerbit/stream";
 import { expect } from "chai";
+import sinon from "sinon";
 import { createRustCoreStream } from "../src/index.js";
 
 type Session = TestSession<{ blocks: DirectBlock }>;
@@ -132,6 +133,112 @@ describe("direct-block rust-core", () => {
 		});
 	});
 
+	describe("eager-cache contract", () => {
+		it("enforces byte/entry/ttl bounds with exact delete accounting", () => {
+			const clock = sinon.useFakeTimers({ now: 1_000 });
+			try {
+				const cache = exchange.createEagerCache({
+					maxEntries: 2,
+					maxBytes: 6,
+					ttlMs: 100,
+				});
+				expect(cache.add("a", new Uint8Array(4))).to.equal(true);
+				expect(cache.add("b", new Uint8Array(3))).to.equal(true);
+				expect(cache.get("a")).to.equal(undefined);
+				expect(cache.stats()).to.include({
+					entries: 1,
+					bytes: 3,
+					evictions: 1,
+				});
+
+				cache.del("b");
+				expect(cache.stats()).to.include({ entries: 0, bytes: 0 });
+				expect(cache.add("b", new Uint8Array(5))).to.equal(true);
+				cache.del("b");
+				expect(cache.add("c", new Uint8Array(6))).to.equal(true);
+				expect(cache.add("oversized", new Uint8Array(7))).to.equal(false);
+				expect(cache.stats()).to.include({ entries: 1, bytes: 6 });
+
+				clock.tick(100);
+				expect(cache.stats()).to.include({
+					entries: 0,
+					bytes: 0,
+					expirations: 1,
+				});
+			} finally {
+				clock.restore();
+			}
+		});
+
+		it("copies aliased views and entry-bounds zero-byte replacements", () => {
+			const cache = exchange.createEagerCache({
+				maxEntries: 2,
+				maxBytes: 2,
+				ttlMs: 10_000,
+			});
+			const backing = new Uint8Array(1024);
+			backing.set([1, 2], 100);
+			expect(cache.add("aliased", backing.subarray(100, 102))).to.equal(true);
+			const retained = cache.get("aliased")!;
+			expect(retained).to.deep.equal(new Uint8Array([1, 2]));
+			expect(retained.buffer.byteLength).to.equal(2);
+
+			expect(cache.add("zero", new Uint8Array())).to.equal(true);
+			expect(cache.add("zero", new Uint8Array())).to.equal(true);
+			expect(cache.stats()).to.include({ entries: 2, bytes: 2 });
+			expect(cache.add("zero-2", new Uint8Array())).to.equal(true);
+			expect(cache.stats()).to.include({ entries: 2, bytes: 0 });
+			expect(cache.get("aliased")).to.equal(undefined);
+			cache.clear();
+
+			expect(() =>
+				exchange.createEagerCache({
+					maxEntries: 1,
+					maxBytes: 1,
+					ttlMs: 0x8000_0000,
+				}),
+			).to.throw(RangeError);
+		});
+
+		it("copies length-tracking views over resizable buffers", function () {
+			type ResizableBuffer = ArrayBuffer & {
+				readonly resizable: boolean;
+				resize(byteLength: number): void;
+			};
+			let backing: ResizableBuffer;
+			try {
+				const Constructor = ArrayBuffer as unknown as new (
+					byteLength: number,
+					options: { maxByteLength: number },
+				) => ResizableBuffer;
+				backing = new Constructor(2, { maxByteLength: 8 });
+			} catch {
+				this.skip();
+				return;
+			}
+			if (backing.resizable !== true || typeof backing.resize !== "function") {
+				this.skip();
+				return;
+			}
+
+			const source = new Uint8Array(backing);
+			source.set([1, 2]);
+			const cache = exchange.createEagerCache({
+				maxEntries: 1,
+				maxBytes: 2,
+				ttlMs: 10_000,
+			});
+			expect(cache.add("resizable", source)).to.equal(true);
+			backing.resize(8);
+
+			const retained = cache.get("resizable")!;
+			expect(retained).to.deep.equal(new Uint8Array([1, 2]));
+			expect(retained.buffer.byteLength).to.equal(2);
+			expect(cache.stats()).to.include({ entries: 1, bytes: 2 });
+			cache.clear();
+		});
+	});
+
 	describe("mixed topology", () => {
 		let session: Session;
 
@@ -172,9 +279,8 @@ describe("direct-block rust-core", () => {
 			// routing table and the native provider cache
 			expect(store(session, 0).routes).to.not.be.instanceOf(Routes);
 			expect(store(session, 1).routes).to.be.instanceOf(Routes);
-			expect(
-				(store(session, 0) as any).remoteBlocks._rustProviderCache,
-			).to.exist;
+			expect((store(session, 0) as any).remoteBlocks._rustProviderCache).to
+				.exist;
 			expect((store(session, 2) as any).remoteBlocks._rustProviderCache).to.be
 				.undefined;
 

--- a/packages/transport/stream/src/index.ts
+++ b/packages/transport/stream/src/index.ts
@@ -126,6 +126,7 @@ export {
 	type RustDecodedFanoutUnicast,
 	type RustDecodedPubSubMessage,
 	type RustEagerBlockCache,
+	type RustEagerBlockCacheStats,
 	type RustFanoutTree,
 	type RustLanesInit,
 	type RustParentUpgradeGateOptions,

--- a/packages/transport/stream/src/rust-core.ts
+++ b/packages/transport/stream/src/rust-core.ts
@@ -112,15 +112,25 @@ export interface RustBlockProviderCache {
 	clear(): void;
 }
 
+export type RustEagerBlockCacheStats = {
+	entries: number;
+	bytes: number;
+	peakEntries: number;
+	peakBytes: number;
+	evictions: number;
+	expirations: number;
+};
+
 /**
  * Eager-block cache with native bookkeeping. Block bytes stay host-side;
  * the native index decides retention/eviction.
  */
 export interface RustEagerBlockCache {
-	add(cid: string, bytes: Uint8Array): void;
+	add(cid: string, bytes: Uint8Array): boolean;
 	get(cid: string): Uint8Array | undefined;
 	del(cid: string): void;
 	clear(): void;
+	stats(): RustEagerBlockCacheStats;
 }
 
 /**
@@ -150,7 +160,11 @@ export interface RustBlockExchange {
 		ttlMs: number;
 		maxProvidersPerCid: number;
 	}): RustBlockProviderCache;
-	createEagerCache(init: { max: number; ttl: number }): RustEagerBlockCache;
+	createEagerCache(init: {
+		maxEntries: number;
+		maxBytes: number;
+		ttlMs: number;
+	}): RustEagerBlockCache;
 }
 
 /**

--- a/packages/utils/cache/src/index.ts
+++ b/packages/utils/cache/src/index.ts
@@ -1,5 +1,5 @@
 // Fifo
-import { Yallist } from "yallist";
+import { Node, Yallist } from "yallist";
 
 export interface CacheData<T> {
 	value?: T | null;
@@ -9,10 +9,9 @@ export interface CacheData<T> {
 type Key = string | bigint | number;
 export class Cache<T = undefined> {
 	private _map: Map<Key, CacheData<T>>;
-	private deleted: Set<Key>;
 	private list: Yallist<Key>;
+	private nodes: Map<Key, Node<Key>>;
 	currentSize: number;
-	deletedSize: number;
 
 	max: number;
 	ttl?: number;
@@ -27,9 +26,6 @@ export class Cache<T = undefined> {
 
 	has(key: Key): boolean {
 		this.trim();
-		if (this.deleted.has(key)) {
-			return false;
-		}
 		return this._map.has(key);
 	}
 
@@ -39,9 +35,6 @@ export class Cache<T = undefined> {
 
 	get(key: Key): T | null | undefined {
 		this.trim();
-		if (this.deleted.has(key)) {
-			return undefined;
-		}
 		return this._map.get(key)?.value;
 	}
 
@@ -51,16 +44,14 @@ export class Cache<T = undefined> {
 			if (headKey?.value != null) {
 				const cacheValue = this._map.get(headKey.value);
 				if (!cacheValue) {
-					throw new Error("Cache value not found");
+					throw new Error("Cache list/map invariant broken");
 				}
 				const outOfDate = this.ttl != null && cacheValue.time < time - this.ttl;
 				if (outOfDate || this.currentSize > this.max) {
 					this.list.shift();
 					this._map.delete(headKey.value);
-					const wasDeleted = this.deleted.delete(headKey.value);
-					if (!wasDeleted) {
-						this.currentSize -= cacheValue.size;
-					}
+					this.nodes.delete(headKey.value);
+					this.currentSize -= cacheValue.size;
 				} else {
 					break;
 				}
@@ -72,33 +63,53 @@ export class Cache<T = undefined> {
 
 	del(key: Key): CacheData<T> | undefined {
 		const cacheValue = this._map.get(key);
-		if (cacheValue && !this.deleted.has(key)) {
-			this.deleted.add(key);
-			this.currentSize -= cacheValue.size;
-			return cacheValue;
-		}
-		return undefined;
+		if (!cacheValue) return undefined;
+		const node = this.nodes.get(key);
+		if (!node) throw new Error("Cache node not found");
+		this.list.removeNode(node);
+		this.nodes.delete(key);
+		this._map.delete(key);
+		this.currentSize -= cacheValue.size;
+		return cacheValue;
 	}
 
 	add(key: Key, value?: T, size = 1): void {
-		this.deleted.delete(key);
 		const time = Date.now();
-		if (!this._map.has(key)) {
-			this.list.push(key);
+		const previous = this._map.get(key);
+		if (!previous) {
+			const node = new Node(key);
+			this.list.pushNode(node);
+			this.nodes.set(key, node);
 			this.currentSize += size;
+		} else {
+			const node = this.nodes.get(key);
+			if (!node) throw new Error("Cache node not found");
+			this.list.removeNode(node);
+			this.list.pushNode(node);
+			this.currentSize += size - previous.size;
 		}
 		this._map.set(key, { time, value: value ?? null, size });
 		this.trim(time);
 	}
 
-	addMany(entries: Iterable<readonly [key: Key, value?: T, size?: number]>): void {
+	addMany(
+		entries: Iterable<readonly [key: Key, value?: T, size?: number]>,
+	): void {
 		const time = Date.now();
 		let changed = false;
 		for (const [key, value, size = 1] of entries) {
-			this.deleted.delete(key);
-			if (!this._map.has(key)) {
-				this.list.push(key);
+			const previous = this._map.get(key);
+			if (!previous) {
+				const node = new Node(key);
+				this.list.pushNode(node);
+				this.nodes.set(key, node);
 				this.currentSize += size;
+			} else {
+				const node = this.nodes.get(key);
+				if (!node) throw new Error("Cache node not found");
+				this.list.removeNode(node);
+				this.list.pushNode(node);
+				this.currentSize += size - previous.size;
 			}
 			this._map.set(key, { time, value: value ?? null, size });
 			changed = true;
@@ -111,7 +122,7 @@ export class Cache<T = undefined> {
 	clear(): void {
 		this.list = Yallist.create();
 		this._map = new Map();
-		this.deleted = new Set();
+		this.nodes = new Map();
 		this.currentSize = 0;
 	}
 

--- a/packages/utils/cache/test/cache.spec.ts
+++ b/packages/utils/cache/test/cache.spec.ts
@@ -119,4 +119,67 @@ describe("cache", () => {
 		cache.del("2");
 		expect(cache.size).equal(0);
 	});
+
+	it("delete releases values and delete/re-add accounting stays exact", () => {
+		const cache = new Cache<Uint8Array>({ max: 2, ttl: 1e6 });
+		const retained = new Uint8Array(1024);
+		cache.add("same", retained);
+		expect(cache.del("same")?.value).to.equal(retained);
+		expect(cache.map.has("same")).to.equal(false);
+		expect(cache.size).to.equal(0);
+
+		cache.add("same", new Uint8Array(1));
+		cache.del("same");
+		expect(cache.size).to.equal(0);
+		expect(cache.map.size).to.equal(0);
+
+		cache.add("a");
+		cache.add("b");
+		cache.add("c");
+		expect(cache.size).to.equal(2);
+		expect(cache.has("a")).to.equal(false);
+		expect(cache.has("b")).to.equal(true);
+		expect(cache.has("c")).to.equal(true);
+	});
+
+	it("replacement adjusts custom-size accounting", () => {
+		const cache = new Cache<string>({ max: 10, ttl: 1e6 });
+		cache.add("a", "small", 3);
+		cache.add("a", "large", 8);
+		expect(cache.size).to.equal(8);
+		expect(cache.get("a")).to.equal("large");
+		cache.add("b", "value", 3);
+		expect(cache.size).to.equal(3);
+		expect(cache.has("a")).to.equal(false);
+		expect(cache.has("b")).to.equal(true);
+	});
+
+	it("replacement refreshes FIFO/TTL order", async () => {
+		await withFakeNow(({ now }) => {
+			now(0);
+			const cache = new Cache<string>({ max: 2, ttl: 1_000 });
+			cache.add("a", "a-old");
+			now(500);
+			cache.add("b", "b");
+			now(900);
+			cache.add("a", "a-new");
+
+			// Refresh moves `a` behind `b`; a new entry evicts the true oldest.
+			cache.add("c", "c");
+			expect(cache.has("a")).to.equal(true);
+			expect(cache.has("b")).to.equal(false);
+			expect(cache.has("c")).to.equal(true);
+
+			const ttlCache = new Cache<string>({ max: 3, ttl: 1_000 });
+			now(0);
+			ttlCache.add("head", "old");
+			now(500);
+			ttlCache.add("behind", "expires-first");
+			now(900);
+			ttlCache.add("head", "refreshed");
+			now(1_600);
+			expect(ttlCache.has("behind")).to.equal(false);
+			expect(ttlCache.has("head")).to.equal(true);
+		});
+	});
 });


### PR DESCRIPTION
## Summary

- make SharedLog unsolicited eager retention opt-in while preserving explicit bounded mode
- admit only raw SHA-256 responses after CID verification, exact-range copying, and provider validation
- bound retained bytes/entries, block size, pending validation bytes/entries, concurrency, and TTL
- keep TypeScript and native/Rust accounting aligned and expose local eager-cache telemetry
- release generic cache values immediately and keep replacement/TTL accounting exact

## Compatibility

- receiver-local only; the block wire protocol is unchanged
- normal requested reads retain opaque CID verification and DAG-CBOR/custom-hasher support
- legacy eagerBlocks true and cacheSize configurations remain supported with safe defaults

## Validation

- full combined @peerbit/blocks suite: 69/69
- cache Node/browser/worker: 12/12 each
- Rust: 97/97 plus docs and formatting
- native eager: 3/3; rust-core blocks: 48/48; SharedLog focused: 3/3
- full root build, exact lint, changesets, and diff checks
- independent hostile review: no P0/P1/P2 findings

## Residuals

- logical consumers must still bound decoding of matching attacker-authored DAG content
- requested-response frame/hash work and native O(maxEntries) arbitrary eviction are separate follow-ups