### PR TITLE
perf(file-share): capture runtime and retention evidence

### DIFF
--- a/.changeset/calm-shared-log-eager-telemetry.md
+++ b/.changeset/calm-shared-log-eager-telemetry.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Expose bounded eager block-cache telemetry and a detached native-graph runtime snapshot through the public shared-log API.

--- a/.changeset/tiny-pubsub-runtime-snapshot.md
+++ b/.changeset/tiny-pubsub-runtime-snapshot.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/pubsub": patch
+---
+
+Expose a bounded, read-only runtime snapshot for effective root and node fanout upload limits.

--- a/packages/clients/peerbit/test/create.ts
+++ b/packages/clients/peerbit/test/create.ts
@@ -140,13 +140,17 @@ describe("Create", function () {
 	it("uses the default pubsub upload limit for root and node fanout channels", async () => {
 		const client = await Peerbit.create();
 		try {
-			const pubsub = client.services.pubsub as any;
-			expect(pubsub.fanoutRootChannelOptions.uploadLimitBps).to.equal(
-				5_000_000,
-			);
-			expect(pubsub.fanoutNodeChannelOptions.uploadLimitBps).to.equal(
-				5_000_000,
-			);
+			const snapshot = client.services.pubsub.getRuntimeSnapshot();
+			expect(snapshot).to.deep.equal({
+				fanout: {
+					root: { uploadLimitBps: 5_000_000 },
+					node: { uploadLimitBps: 5_000_000 },
+				},
+			});
+			expect(Object.isFrozen(snapshot)).to.equal(true);
+			expect(Object.isFrozen(snapshot.fanout)).to.equal(true);
+			expect(Object.isFrozen(snapshot.fanout.root)).to.equal(true);
+			expect(Object.isFrozen(snapshot.fanout.node)).to.equal(true);
 			expect(client.sharedLogNativeDefaults).to.equal(undefined);
 		} finally {
 			await client.stop();
@@ -158,13 +162,12 @@ describe("Create", function () {
 			pubsubUploadLimitBps: 20_000_000,
 		});
 		try {
-			const pubsub = client.services.pubsub as any;
-			expect(pubsub.fanoutRootChannelOptions.uploadLimitBps).to.equal(
-				20_000_000,
-			);
-			expect(pubsub.fanoutNodeChannelOptions.uploadLimitBps).to.equal(
-				20_000_000,
-			);
+			expect(client.services.pubsub.getRuntimeSnapshot()).to.deep.equal({
+				fanout: {
+					root: { uploadLimitBps: 20_000_000 },
+					node: { uploadLimitBps: 20_000_000 },
+				},
+			});
 			expect(
 				client.sharedLogNativeDefaults?.fanout?.channel?.uploadLimitBps,
 			).to.equal(20_000_000);
@@ -203,14 +206,13 @@ describe("Create", function () {
 			},
 		});
 		try {
-			const pubsub = client.services.pubsub as any;
-			expect(pubsub).to.exist;
-			expect(pubsub.fanoutRootChannelOptions.uploadLimitBps).to.equal(
-				20_000_000,
-			);
-			expect(pubsub.fanoutNodeChannelOptions.uploadLimitBps).to.equal(
-				20_000_000,
-			);
+			expect(client.services.pubsub).to.exist;
+			expect(client.services.pubsub.getRuntimeSnapshot()).to.deep.equal({
+				fanout: {
+					root: { uploadLimitBps: 20_000_000 },
+					node: { uploadLimitBps: 20_000_000 },
+				},
+			});
 		} finally {
 			await client.stop();
 		}
@@ -220,14 +222,9 @@ describe("Create", function () {
 		for (const value of [1, Number.MAX_SAFE_INTEGER]) {
 			const client = await Peerbit.create({ pubsubUploadLimitBps: value });
 			try {
-				expect(
-					(client.services.pubsub as any).fanoutRootChannelOptions
-						.uploadLimitBps,
-				).to.equal(value);
-				expect(
-					(client.services.pubsub as any).fanoutNodeChannelOptions
-						.uploadLimitBps,
-				).to.equal(value);
+				const snapshot = client.services.pubsub.getRuntimeSnapshot();
+				expect(snapshot.fanout.root.uploadLimitBps).to.equal(value);
+				expect(snapshot.fanout.node.uploadLimitBps).to.equal(value);
 			} finally {
 				await client.stop();
 			}

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -3216,6 +3216,13 @@ export interface SharedLogEvents extends ProgramEvents {
 	"replicator:mature": CustomEvent<ReplicatorMatureEvent>;
 }
 
+export type SharedLogRuntimeSnapshot = Readonly<{
+	nativeGraph: Readonly<{
+		active: boolean;
+		useHeads: boolean;
+	}>;
+}>;
+
 @variant("shared_log")
 export class SharedLog<
 	T,
@@ -14170,6 +14177,26 @@ export class SharedLog<
 	async getMemoryUsage() {
 		return this.log.blocks.size();
 		/* ((await this.log.entryIndex?.getMemoryUsage()) || 0) */ // + (await this.log.blocks.size())
+	}
+
+	/** Return a detached snapshot of effective shared-log runtime settings. */
+	getRuntimeSnapshot(): SharedLogRuntimeSnapshot {
+		const nativeGraph = this.log.entryIndex.properties.nativeGraph;
+		const active = nativeGraph?.graph != null;
+		return Object.freeze({
+			nativeGraph: Object.freeze({
+				active,
+				useHeads: active && nativeGraph?.useHeads === true,
+			}),
+		});
+	}
+
+	/**
+	 * Return a detached snapshot of the optional eager-response cache.
+	 * Undefined means eager response retention is disabled for this log.
+	 */
+	getEagerBlockCacheTelemetry() {
+		return this.remoteBlocks?.getEagerBlockCacheTelemetry();
 	}
 
 	private clampReplicas(value: number) {

--- a/packages/programs/data/shared-log/test/blocks-publish.spec.ts
+++ b/packages/programs/data/shared-log/test/blocks-publish.spec.ts
@@ -41,8 +41,15 @@ describe("shared-log block publish adapter", () => {
 	it("does not retain unsolicited blocks unless eager mode is explicit", async () => {
 		session = await TestSession.connected(1);
 		db = await session.peers[0].open(new EventStore<string, any>());
-		const remoteBlocks = (db.log as any).remoteBlocks;
-		expect(remoteBlocks.getEagerBlockCacheTelemetry()).to.equal(undefined);
+		expect(db.log.getEagerBlockCacheTelemetry()).to.equal(undefined);
+		const runtime = db.log.getRuntimeSnapshot();
+		expect(runtime.nativeGraph.active).to.be.a("boolean");
+		expect(runtime.nativeGraph.useHeads).to.equal(
+			runtime.nativeGraph.active &&
+				db.log.log.entryIndex.properties.nativeGraph?.useHeads === true,
+		);
+		expect(Object.isFrozen(runtime)).to.equal(true);
+		expect(Object.isFrozen(runtime.nativeGraph)).to.equal(true);
 	});
 
 	it("keeps explicit eager mode available with bounded defaults", async () => {
@@ -50,8 +57,7 @@ describe("shared-log block publish adapter", () => {
 		db = await session.peers[0].open(new EventStore<string, any>(), {
 			args: { eagerBlocks: true },
 		});
-		const remoteBlocks = (db.log as any).remoteBlocks;
-		const telemetry = remoteBlocks.getEagerBlockCacheTelemetry();
+		const telemetry = db.log.getEagerBlockCacheTelemetry()!;
 		expect(telemetry.limits).to.include({
 			maxEntries: 1_000,
 			maxBytes: 32 * 1024 * 1024,

--- a/packages/transport/pubsub/src/index.ts
+++ b/packages/transport/pubsub/src/index.ts
@@ -234,6 +234,20 @@ export type TopicControlPlaneComponents = DirectStreamComponents;
 
 export type PeerId = Libp2pPeerId | PublicSignKey;
 
+/**
+ * Bounded, serializable snapshot of effective topic-control-plane settings.
+ *
+ * The snapshot intentionally contains values rather than the live fanout
+ * option objects so diagnostics can expose it without leaking mutable runtime
+ * state or native/WASM handles.
+ */
+export type TopicControlPlaneRuntimeSnapshot = Readonly<{
+	fanout: Readonly<{
+		root: Readonly<{ uploadLimitBps: number }>;
+		node: Readonly<{ uploadLimitBps: number }>;
+	}>;
+}>;
+
 const topicHash32 = (topic: string) => {
 	let hash = 0x811c9dc5; // FNV-1a
 	for (let index = 0; index < topic.length; index++) {
@@ -451,6 +465,28 @@ export class TopicControlPlane
 					`Debounced unsubscribe announce failed: ${error?.message ?? error}`,
 				),
 		);
+	}
+
+	/**
+	 * Return a detached, read-only snapshot of effective runtime settings.
+	 */
+	public getRuntimeSnapshot(): TopicControlPlaneRuntimeSnapshot {
+		return Object.freeze({
+			fanout: Object.freeze({
+				root: Object.freeze({
+					uploadLimitBps: Math.max(
+						0,
+						Math.floor(this.fanoutRootChannelOptions.uploadLimitBps),
+					),
+				}),
+				node: Object.freeze({
+					uploadLimitBps: Math.max(
+						0,
+						Math.floor(this.fanoutNodeChannelOptions.uploadLimitBps),
+					),
+				}),
+			}),
+		});
 	}
 
 	/**

--- a/packages/transport/pubsub/test/fanout-topics.spec.ts
+++ b/packages/transport/pubsub/test/fanout-topics.spec.ts
@@ -245,6 +245,46 @@ describe("pubsub (fanout topics)", function () {
 		});
 	};
 
+	it("reports the same normalized upload limits that fanout channels enforce", async () => {
+		const { session, configureBootstraps, configureShards } =
+			await createSession(2, {
+				pubsub: {
+					fanoutRootChannel: { uploadLimitBps: 1_000_000.75 },
+					fanoutNodeChannel: { uploadLimitBps: -1 },
+				},
+			});
+
+		try {
+			const root = session.peers[0]!.services.pubsub;
+			const node = session.peers[1]!.services.pubsub;
+			const expectedSnapshot = {
+				fanout: {
+					root: { uploadLimitBps: 1_000_000 },
+					node: { uploadLimitBps: 0 },
+				},
+			};
+			expect(root.getRuntimeSnapshot()).to.deep.equal(expectedSnapshot);
+			expect(node.getRuntimeSnapshot()).to.deep.equal(expectedSnapshot);
+
+			await configureShards([0]);
+			configureBootstraps([0]);
+			const topic = "normalized-runtime-upload-limits";
+			await Promise.all([root.subscribe(topic), node.subscribe(topic)]);
+			const shardTopic = (root as any).getShardTopicForUserTopic(topic);
+			const rootHash = root.publicKeyHash;
+			await waitForResolved(() => {
+				expect(
+					root.fanout.getChannelStats(shardTopic, rootHash)?.uploadLimitBps,
+				).to.equal(expectedSnapshot.fanout.root.uploadLimitBps);
+				expect(
+					node.fanout.getChannelStats(shardTopic, rootHash)?.uploadLimitBps,
+				).to.equal(expectedSnapshot.fanout.node.uploadLimitBps);
+			});
+		} finally {
+			await session.stop();
+		}
+	});
+
 	it("delivers over sharded fanout (no direct subscription gossip)", async () => {
 		const { session, configureBootstraps, configureShards } =
 			await createSession(4);
@@ -924,7 +964,10 @@ describe("pubsub (fanout topics)", function () {
 					rootHash,
 				);
 				expect(statsAfterDirect?.parent).to.equal(relayHash);
-				const metrics = publisher.fanout.getChannelMetrics(shardTopic, rootHash);
+				const metrics = publisher.fanout.getChannelMetrics(
+					shardTopic,
+					rootHash,
+				);
 				expect(metrics.reparentUpgrade).to.equal(0);
 				if (options.parentUpgradeIntervalMs === undefined) {
 					expect(metrics.parentProbeReqSent).to.equal(0);
@@ -1128,7 +1171,9 @@ describe("pubsub (fanout topics)", function () {
 				expect(rootFanout.peers.has(publisherHash)).to.equal(true),
 			);
 			await waitForResolved(() =>
-				expect(publisherPeer.services.fanout.peers.has(rootHash)).to.equal(true),
+				expect(publisherPeer.services.fanout.peers.has(rootHash)).to.equal(
+					true,
+				),
 			);
 			await waitForResolved(() => {
 				const metrics = publisherPeer.services.fanout.getChannelMetrics(
@@ -1157,7 +1202,9 @@ describe("pubsub (fanout topics)", function () {
 						parentDataLatencyMaxMs: ch?.parentDataLatencyMaxMs,
 						rootChildren: rootStats?.children,
 						rootChildHashes:
-							rootChannel == null ? undefined : [...rootChannel.children.keys()],
+							rootChannel == null
+								? undefined
+								: [...rootChannel.children.keys()],
 						rootEffectiveMaxChildren: rootStats?.effectiveMaxChildren,
 						sampleScore:
 							ch == null

--- a/scripts/file-share/README.md
+++ b/scripts/file-share/README.md
@@ -3,7 +3,14 @@
 Run a single checkout with `pnpm bench:file-share:local` or compare pinned
 Peerbit revisions with `pnpm bench:file-share:matrix`.
 
-Result schema v9 defines `errorCount` as every uncaught browser `pageerror`,
+Result schema v10, summary and matrix-summary schema v6, and invocation schema
+v5 bind each result to the exact effective benchmark inputs. Invocation v5 adds
+`postTransferSoakMs`; uploads default to 60,000 ms and preserve an explicit
+`--post-transfer-soak-ms 0` for
+fast smoke runs, while seeder probes resolve zero and reject a nonzero soak
+because they have no transfer. The value is exported as
+`PW_POST_TRANSFER_SOAK_MS`. Result schema v10 defines
+`errorCount` as every uncaught browser `pageerror`,
 every browser `console.error`, every console message at any level that contains
 a declared Peerbit failure signature, and scenario-recorded operation failures.
 Each result embeds the exact `errorCollectionDefinition` and signature list.
@@ -11,7 +18,7 @@ Playwright `requestfailed` events are retained separately under
 `requestFailures`; they are diagnostics and are not automatically fatal because
 peer-to-peer discovery can legitimately exercise failed network candidates.
 
-Passed schema v9 upload results require `writerDiagnostics.lastUploadDiagnostics`
+Passed schema v10 upload results require `writerDiagnostics.lastUploadDiagnostics`
 to contain exactly 21 bounded progress milestones from 0% through 100% in 5%
 increments. Each point records the aggregate bytes whose application-level
 chunk puts completed, using the library upload clock and exact ceil-rounded byte
@@ -47,38 +54,129 @@ sinks only in separate benchmark sessions; aggregate comparison objects fail
 closed on mixed sinks, and every passed result and aggregate labels
 non-hash-only cohorts non-authoritative.
 
-Schema v9 upload results also record the `download-memory-v2` bounded
-download-window memory telemetry contract. After any
-controlled-locality prefix stabilization, the harness arms serial samplers
-before the bounded pre-read transport-counter gate and timed click, then forces
-a final sample as soon as the selected sink completion is observed, before
-post-read counter stabilization, integrity readback, or terminal-topology
-checks.
-Reader and writer renderer JavaScript heaps use CDP `JSHeapUsedSize` samples.
+`readTransfer.receiverProgress` keeps three receiver boundaries separate over
+the exact 0%, 5%, …, 100% milestone set.
+`available` means a contiguous file prefix was materialized and available to
+the receiver library (`chunkMaterializeFinishedAt`). `peerbitDurable` means the
+exact signed manifest-entry blocks for a contiguous prefix were confirmed in
+the receiver's local Peerbit block store (`chunkPersistenceConfirmedAt`), with
+the confirmation sources counted separately. Observer/non-persisting reads
+therefore make no `peerbitDurable` claim. This is local Peerbit persistence
+evidence, not remote replication, remote acknowledgement, filesystem `fsync`,
+or stable-media proof.
+
+`sinkAccepted` means a contiguous prefix was accepted by the configured
+benchmark sink (`chunkWriteFinishedAt`) and always carries `durable: false`. For
+the hash-only sink it means the bytes were accepted by the streaming
+SHA-256/CRC-32 consumer; for OPFS or Node-file it means the configured sink write
+resolved. The later persisted readback is a whole-file benchmark integrity gate,
+but the `sinkAccepted` milestones themselves are neither Peerbit nor filesystem
+durability evidence. None of these three series is a wire acknowledgement or
+proof that another peer retained the bytes.
+
+Schema v10 upload results record the `download-memory-v3` bounded telemetry
+contract. After any controlled-locality prefix stabilization, the harness arms
+serial samplers before the bounded pre-read transport-counter gate and timed
+click. Sampling remains armed through sink completion, integrity and terminal
+topology checks, the requested post-transfer soak, final diagnostics, and
+explicit writer/reader Peerbit shutdown. Cleanup then forces the terminal sample
+before detaching the CDP sessions. The default soak is 60 seconds, so retained
+memory and storage that keep growing or fail to settle are visible separately
+from transfer-time peaks.
+
+Result v10 records bounded `shutdownOutcomes` for writer and reader separately;
+a passed upload requires both shutdown hooks to prove that the program closed
+and the Peerbit/libp2p peer stopped. Each shutdown outcome repeats the exact
+program, peer, and per-page session identity captured by that role's four
+resource snapshots, preventing a stale or replaced hook from satisfying the
+gate. The memory terminal sample is captured only after both hooks finish,
+allowing the live-peer after-soak checkpoint and the post-shutdown endpoint to
+be distinguished.
+
+Reader and writer renderers use CDP `Runtime.getHeapUsage`. Every sample records
+V8 used and total bytes, embedder heap used bytes, and backing-storage bytes.
 Host RSS combines all Chromium processes, grouped by Chromium process role,
 with the Playwright worker Node process; for local runs that Node value also
 includes the in-process bootstrap peer. Chromium RSS cannot be assigned
 reliably to one page and RSS is not PSS or USS, so page-level comparisons should
-use the renderer heap series. Samples run serially every five seconds, include
-forced initial/final endpoints, reserve one endpoint slot, cap each series at
-4,096 entries, and cap sampling errors. Passed evidence requires at least two
-error-free samples in every series and coverage of the canonical library read
-window. The validator recomputes all start, end, peak, process-role, and combined
-RSS summaries and rejects reordered, oversized, partial, or contradictory
-telemetry. Failed runs retain whatever bounded telemetry was collected, but are
-never accepted as performance evidence.
+use the renderer series. Node `external` and `arrayBuffers` are recorded as
+overlapping allocation diagnostics; neither is added to Node or combined RSS.
+Samples run serially, scheduling the next periodic read five seconds after the
+previous read completes, and reserve three endpoints: the initial sample, one
+live manual checkpoint immediately after the exact requested soak timer and
+before the `afterSoak` resource capture, and one terminal checkpoint after peer
+shutdown. For both the transfer and soak phase, passed evidence must have a live
+sample at or before the phase start and another at or after the phase finish,
+with no adjacent live-sample gap above the exact five-second interval plus the
+four-second sampling-operation deadline plus the recorded scheduling tolerance.
+Consequently a short phase may validly have no periodic sample, while a long
+phase cannot pass on endpoint samples alone. Capacity is derived from the full
+Playwright lifecycle timeout, not just the download deadline, and is capped at
+4,096 entries per series. Premature exhaustion is explicit and fatal. Passed
+evidence requires all three ordered, error-free checkpoint kinds plus bounded
+coverage of the canonical transfer, soak, and shutdown window. The validator
+recomputes all start, end, peak,
+process-role, and combined RSS summaries and rejects reordered, oversized,
+partial, or contradictory telemetry. Failed runs retain whatever bounded
+telemetry was collected, but are never accepted as performance evidence.
 
 Every CDP sample and setup operation has a four-second deadline; sampler
 cleanup has a nine-second aggregate deadline, late-created CDP sessions are
 detached best-effort, and a timed-out probe becomes terminal so another sample
-cannot overlap it. Sampling is finalized at sink completion. CDP disable and
-detach run only after transfer integrity is finalized; cleanup timeouts are
-bounded warnings, while setup, sampling, and non-timeout cleanup errors remain
-fatal. Result validation binds every series to the actual click and
-completion-observation timestamps: setup may begin at most 30 seconds before
-the click, and the terminal sample must finish within 30 seconds after
-completion is observed. Host samples are additionally capped at 256 Chromium
-processes and 32 process-role groups.
+cannot overlap it. Cleanup timeouts are bounded warnings, while setup, sampling,
+and non-timeout cleanup errors remain fatal. Host samples are additionally
+capped at 256 Chromium processes and 32 process-role groups.
+
+Four resource checkpoints—`beforeTimedRead`, `afterSink`, `beforeSoak`, and
+`afterSoak`—also record writer and reader storage and effective runtime state.
+Resource-evidence schema v2 derives four later-minus-earlier intervals:
+`timedReadEnvelope` is `beforeTimedRead`→`afterSink`, `postTransferWork` is
+`afterSink`→`beforeSoak`, `soak` is `beforeSoak`→`afterSoak`, and `total` is
+`beforeTimedRead`→`afterSoak`. `timedReadEnvelope` deliberately includes the
+bounded pre-read and post-read transport-counter gates around the primary timed
+read, so it must not be mislabeled as the exact download window. The exact
+memory phase remains `downloadStartedAt`→`downloadFinishedAt`. The resource
+`soak` interval begins at the dedicated `beforeSoak` checkpoint after integrity
+and terminal-topology work, while the memory soak phase uses the exact requested
+soak timestamps. Because `afterSoak` is intentionally captured only after the
+manual memory checkpoint completes, the resource `soak` interval envelopes the
+requested timer plus that bounded checkpoint operation; it is not an exact
+timer-duration metric.
+
+Storage intervals report Peerbit logical-log usage and browser origin-wide
+`navigator.storage` estimates; these are distinct scopes and should not be
+added together. Runtime evidence preserves each page's effective
+`nativeGraph.active`/`useHeads`, eager-cache enabled/availability state and
+limits, and root/node pubsub upload limits. Writer and reader configurations are
+kept separate and normalized as one ordered writer/reader pair. Each role must
+retain one browser origin and one exact program/peer/session identity across all
+four snapshots; the roles must share the program address while exposing distinct
+peer IDs, peer hashes, and session IDs. Upload timing
+rows are split by that pair in addition to reader locality. A runtime cohort key
+is emitted only when every passed repetition has the same complete pair; mode
+comparisons return no value when pairs differ or runtime-evidence availability
+is mixed. If every result predates runtime evidence, the legacy grouping and
+comparison shape is preserved. When eager telemetry is enabled, aggregate
+summaries include after-soak current entries, bytes, pending entries, and
+pending bytes; lifetime peaks; and `timedReadEnvelope`, `postTransferWork`,
+`soak`, and `total` deltas for admitted blocks, hits, evictions, expirations, and
+every rejection category.
+
+Aggregate upload summaries expose this evidence under `runtimeEvidence`.
+`memoryPhases` reports the exact transfer and soak peak and end-minus-start
+distributions for renderer used/embedder/backing storage, combined host RSS, and
+Node external/ArrayBuffer bytes. Because telemetry is sampled every five
+seconds, each phase uses the last live sample at or before its start through the
+first live sample at or after its end and records that boundary-overhang
+definition. The same recorded maximum-gap contract bounds the boundary
+overhang and every adjacent captured-sample gap. Terminal post-shutdown samples
+are excluded from both transfer and soak summaries; the required live manual
+checkpoint after soak supplies the soak endpoint without folding teardown into
+the phase.
+`resourceStorageDeltas`, `effectiveRuntimeConfiguration`, and `eagerCache`
+retain the corresponding storage, effective-policy, and eager-cache summaries.
+Older result objects that do not carry v10/v3 resource evidence retain the
+pre-existing aggregate output shape without empty placeholder fields.
 
 For a controlled reader-locality download cohort, run an upload with
 `--mode fixed1`, `--reader-local-chunk-target <N>`, and
@@ -123,8 +221,8 @@ final accepted sample becomes
 click must start within the recorded one-second handoff tolerance. This excludes
 late preload control traffic from the measured counter delta.
 
-Immediately after sink completion is observed and download-memory sampling has
-stopped, the same bounded gate captures post-read topology before integrity
+Immediately after sink completion is observed, while download-memory sampling
+remains armed, the same bounded gate captures post-read topology before integrity
 readback, idle waiting, terminal-topology stabilization, or the transport's
 ten-second inbound idle pruning. Its deadline is capped so an accepted gate
 finishes no later than nine seconds after sink completion, leaving one second
@@ -170,7 +268,7 @@ per-chunk timings remain in each result and can be rebucketed into 5% progress
 windows without losing the underlying samples. Without the paired locality
 options, roles, persistence policy, and seeder-drop gates are unchanged.
 
-Schema v9 records the exact versioned `seederDropPolicy` and a final numeric
+Schema v10 records the exact versioned `seederDropPolicy` and a final numeric
 `terminal` seeder snapshot after download and integrity verification. Every
 upload cohort also records top-level `integrityVerifiedAt`: it remains `null`
 until the aggregate size, SHA-256, CRC-32, manifest, and persistence gates have

--- a/scripts/file-share/benchmark-invocation.mjs
+++ b/scripts/file-share/benchmark-invocation.mjs
@@ -3,7 +3,7 @@ import { isDeepStrictEqual } from "node:util";
 
 export const BENCHMARK_INVOCATION_SCHEMA = {
 	id: "peerbit-file-share-benchmark-invocation",
-	version: 4,
+	version: 5,
 };
 
 export const TINY_FILE_CUTOFF_BYTES = 5_000_000;
@@ -26,6 +26,7 @@ const DEPLOYED_APP_HARNESS_MESSAGE =
 
 const DEFAULTS = {
 	uploadTimeoutMs: 600_000,
+	postTransferSoakMs: 60_000,
 	postUploadMonitorMs: 5_000,
 	pollMs: 1_000,
 	readyTimeoutMs: 180_000,
@@ -164,6 +165,7 @@ export const createBenchmarkInvocation = ({
 	downloadSink,
 	uploadTimeoutMs,
 	downloadTimeoutMs,
+	postTransferSoakMs,
 	postUploadMonitorMs,
 	pollMs,
 	minReadySeeders,
@@ -218,6 +220,16 @@ export const createBenchmarkInvocation = ({
 		downloadTimeoutMs ?? resolvedUploadTimeoutMs,
 		"downloadTimeoutMs",
 	);
+	const resolvedPostTransferSoakMs = requireNonNegativeSafeInteger(
+		postTransferSoakMs ??
+			(scenario === "upload" ? DEFAULTS.postTransferSoakMs : 0),
+		"postTransferSoakMs",
+	);
+	if (scenario !== "upload" && resolvedPostTransferSoakMs !== 0) {
+		throw new Error(
+			"postTransferSoakMs is only supported by upload benchmarks",
+		);
+	}
 	const resolvedPostUploadMonitorMs = requireNonNegativeSafeInteger(
 		postUploadMonitorMs ?? DEFAULTS.postUploadMonitorMs,
 		"postUploadMonitorMs",
@@ -331,6 +343,7 @@ export const createBenchmarkInvocation = ({
 		downloadSink: resolvedDownloadSink,
 		uploadTimeoutMs: resolvedUploadTimeoutMs,
 		downloadTimeoutMs: resolvedDownloadTimeoutMs,
+		postTransferSoakMs: resolvedPostTransferSoakMs,
 		postUploadMonitorMs: resolvedPostUploadMonitorMs,
 		pollMs: resolvedPollMs,
 		minReadySeeders: resolvedMinReadySeeders,
@@ -390,6 +403,7 @@ export const createPlaywrightBenchmarkEnvironment = ({
 		PW_MIN_READY_SEEDERS: String(invocation.minReadySeeders),
 		PW_NETWORK_MODE: invocation.networkMode,
 		PW_POLL_MS: String(invocation.pollMs),
+		PW_POST_TRANSFER_SOAK_MS: String(invocation.postTransferSoakMs),
 		PW_POST_UPLOAD_MONITOR_MS: String(invocation.postUploadMonitorMs),
 		PW_PROTOCOL: stringValue(invocation.protocol),
 		PW_READY_TIMEOUT_MS: String(invocation.readyTimeoutMs),
@@ -404,9 +418,7 @@ export const createPlaywrightBenchmarkEnvironment = ({
 		PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT: stringValue(
 			invocation.readerLocalChunkMaxOvershoot,
 		),
-		PW_READER_TERMINAL_TOPOLOGY: stringValue(
-			invocation.readerTerminalTopology,
-		),
+		PW_READER_TERMINAL_TOPOLOGY: stringValue(invocation.readerTerminalTopology),
 		PW_UPLOAD_TIMEOUT_MS: String(invocation.uploadTimeoutMs),
 		PW_VERBOSE: invocation.verbose ? "1" : "0",
 		PW_VITE_CONFIG: stringValue(invocation.viteConfig),

--- a/scripts/file-share/benchmark-invocation.test.mjs
+++ b/scripts/file-share/benchmark-invocation.test.mjs
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import {
+	BENCHMARK_INVOCATION_SCHEMA,
 	TINY_FILE_CUTOFF_BYTES,
 	assertBenchmarkFileSize,
 	assertMatrixInvocationUsesLocalApp,
@@ -31,6 +32,7 @@ test("resolves every default and requested optional knob", () => {
 	const resolved = invocation({
 		uploadTimeoutMs: 101,
 		downloadTimeoutMs: 202,
+		postTransferSoakMs: 0,
 		postUploadMonitorMs: 303,
 		pollMs: 4,
 		minReadySeeders: 5,
@@ -48,6 +50,7 @@ test("resolves every default and requested optional knob", () => {
 			downloadSink: resolved.downloadSink,
 			uploadTimeoutMs: resolved.uploadTimeoutMs,
 			downloadTimeoutMs: resolved.downloadTimeoutMs,
+			postTransferSoakMs: resolved.postTransferSoakMs,
 			postUploadMonitorMs: resolved.postUploadMonitorMs,
 			pollMs: resolved.pollMs,
 			minReadySeeders: resolved.minReadySeeders,
@@ -71,6 +74,7 @@ test("resolves every default and requested optional knob", () => {
 			downloadSink: "hash-only",
 			uploadTimeoutMs: 101,
 			downloadTimeoutMs: 202,
+			postTransferSoakMs: 0,
 			postUploadMonitorMs: 303,
 			pollMs: 4,
 			minReadySeeders: 5,
@@ -91,6 +95,7 @@ test("resolves every default and requested optional knob", () => {
 			serverHost: "127.0.0.1",
 		},
 	);
+	assert.equal(BENCHMARK_INVOCATION_SCHEMA.version, 5);
 });
 
 test("uses the same ready-seeder baseline for comparable replication modes", () => {
@@ -114,6 +119,7 @@ test("removes all ambient PW variables and installs the exact invocation", () =>
 			PW_BASE_URL: "https://attacker.invalid",
 			PW_FILE_MB: "999",
 			PW_DOWNLOAD_SINK: "node-file",
+			PW_POST_TRANSFER_SOAK_MS: "1",
 			PW_POST_UPLOAD_MONITOR_MS: "0",
 			PW_PORT: "4444",
 			PW_PROTOCOL: "https",
@@ -134,6 +140,7 @@ test("removes all ambient PW variables and installs the exact invocation", () =>
 	assert.equal(environment.HOST, "127.0.0.1");
 	assert.equal(environment.PW_FILE_MB, "5");
 	assert.equal(environment.PW_DOWNLOAD_SINK, "hash-only");
+	assert.equal(environment.PW_POST_TRANSFER_SOAK_MS, "60000");
 	assert.equal(environment.PW_POST_UPLOAD_MONITOR_MS, "5000");
 	assert.equal(environment.PW_READER_LOCAL_CHUNK_TARGET, "");
 	assert.equal(environment.PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT, "");
@@ -280,6 +287,19 @@ test("defaults to the hash-only sink and validates explicit sink cohorts", () =>
 		invocation({ scenario: "seeder-probe", fileMb: 1 }).downloadSink,
 		null,
 	);
+	assert.equal(
+		invocation({ scenario: "seeder-probe", fileMb: 1 }).postTransferSoakMs,
+		0,
+	);
+	assert.throws(
+		() =>
+			invocation({
+				scenario: "seeder-probe",
+				fileMb: 1,
+				postTransferSoakMs: 1,
+			}),
+		/only supported by upload benchmarks/,
+	);
 	assert.throws(
 		() =>
 			invocation({
@@ -357,6 +377,14 @@ test("rejects non-comparable timeout and seeder knobs before Playwright", () => 
 			{ downloadTimeoutMs: 1.5 },
 			/downloadTimeoutMs must be a positive safe integer/,
 		],
+		[
+			{ postTransferSoakMs: 0.5 },
+			/postTransferSoakMs must be a non-negative safe integer/,
+		],
+		[
+			{ postTransferSoakMs: -1 },
+			/postTransferSoakMs must be a non-negative safe integer/,
+		],
 		[{ pollMs: 0 }, /pollMs must be a positive safe integer/],
 		[
 			{ postUploadMonitorMs: 0.5 },
@@ -425,7 +453,7 @@ test("standalone runner rejects external origins before mutating outputs", async
 	}
 });
 
-test("standalone runner rejects invalid integration modes before mutating outputs", async () => {
+test("standalone runner rejects invalid benchmark knobs before mutating outputs", async () => {
 	const temporaryRoot = await mkdtemp(
 		path.join(os.tmpdir(), "peerbit-integration-preflight-"),
 	);
@@ -434,6 +462,10 @@ test("standalone runner rejects invalid integration modes before mutating output
 	try {
 		for (const [args, error] of [
 			[["--integration-mode", "overlay"], /Unsupported --integration-mode/],
+			[
+				["--post-transfer-soak-ms", "-1"],
+				/--post-transfer-soak-ms must be a non-negative safe integer/,
+			],
 			[
 				["--download-sink", "browser-download"],
 				/Unsupported benchmark download sink/,

--- a/scripts/file-share/benchmark-orchestration.mjs
+++ b/scripts/file-share/benchmark-orchestration.mjs
@@ -2,7 +2,7 @@ import fsp from "node:fs/promises";
 
 export const BENCHMARK_RESULT_SCHEMA = Object.freeze({
 	id: "peerbit-file-share-benchmark",
-	version: 9,
+	version: 10,
 });
 
 export const SEEDER_DROP_POLICY = Object.freeze({
@@ -19,12 +19,12 @@ export const SEEDER_DROP_POLICY = Object.freeze({
 
 export const BENCHMARK_SUMMARY_SCHEMA = Object.freeze({
 	id: "peerbit-file-share-benchmark-summary",
-	version: 5,
+	version: 6,
 });
 
 export const MATRIX_SUMMARY_SCHEMA = Object.freeze({
 	id: "peerbit-file-share-matrix-summary",
-	version: 5,
+	version: 6,
 });
 
 export const KNOWN_PEERBIT_FAILURE_SIGNATURES = Object.freeze([

--- a/scripts/file-share/benchmark-summary.mjs
+++ b/scripts/file-share/benchmark-summary.mjs
@@ -55,13 +55,27 @@ export const uploadLocalityCohortDimensions = (result) => ({
 
 /**
  * Read-ahead may make repeated controlled-locality runs settle at different
- * exact block/index prefixes. Keep those cohorts separate so an aggregate can
- * never hide that difference in a single timing distribution.
+ * exact block/index prefixes. Effective writer/reader policies can also differ
+ * from requested inputs. Keep both dimensions separate so one timing
+ * distribution can never hide either difference.
  */
 export const groupUploadResultsByLocalityCohort = (results) => {
+	const runtimeEvidence = results.map((result) =>
+		extractRuntimeConfigurationPairEvidence(result),
+	);
+	const anyRuntimeEvidence = runtimeEvidence.some(
+		(evidence) => evidence.present,
+	);
 	const grouped = new Map();
-	for (const result of results) {
-		const dimensions = uploadLocalityCohortDimensions(result);
+	for (const [index, result] of results.entries()) {
+		const dimensions = {
+			...uploadLocalityCohortDimensions(result),
+			...(anyRuntimeEvidence
+				? {
+						runtimeConfigurationCohortKey: runtimeEvidence[index].cohortKey,
+					}
+				: {}),
+		};
 		const key = JSON.stringify(dimensions);
 		const group = grouped.get(key) ?? { dimensions, results: [] };
 		group.results.push(result);
@@ -92,6 +106,512 @@ const flattenDistribution = (prefix, distribution) => ({
 	[`${prefix}Min`]: distribution.min,
 	[`${prefix}Max`]: distribution.max,
 });
+
+const isRecord = (value) =>
+	value != null && typeof value === "object" && !Array.isArray(value);
+
+const finiteValues = (values) =>
+	values.filter((value) => typeof value === "number" && Number.isFinite(value));
+
+const optionalDistribution = (values) => {
+	const numbers = finiteValues(values);
+	return numbers.length > 0 ? summarizeDistribution(numbers) : null;
+};
+
+const phaseMemoryWindow = (series, startedAt, finishedAt, metrics) => {
+	if (
+		!Array.isArray(series?.samples) ||
+		!Number.isSafeInteger(startedAt) ||
+		!Number.isSafeInteger(finishedAt) ||
+		finishedAt < startedAt
+	) {
+		return null;
+	}
+	const samples = series.samples.filter(
+		(sample) => sample?.sampleKind !== "terminal",
+	);
+	if (samples.length === 0) {
+		return null;
+	}
+	let startIndex = -1;
+	for (let index = 0; index < samples.length; index += 1) {
+		if (samples[index]?.capturedAt <= startedAt) {
+			startIndex = index;
+		} else {
+			break;
+		}
+	}
+	if (startIndex < 0) {
+		startIndex = samples.findIndex((sample) => sample?.capturedAt >= startedAt);
+	}
+	if (startIndex < 0) {
+		return null;
+	}
+	let endIndex = samples.findIndex(
+		(sample, index) => index >= startIndex && sample?.capturedAt >= finishedAt,
+	);
+	if (endIndex < 0) {
+		return null;
+	}
+	if (endIndex < startIndex) {
+		return null;
+	}
+	const windowSamples = samples.slice(startIndex, endIndex + 1);
+	const summary = {};
+	for (const [metricName, sampleField] of Object.entries(metrics)) {
+		const values = finiteValues(
+			windowSamples.map((sample) => sample?.[sampleField]),
+		);
+		const startValue = samples[startIndex]?.[sampleField];
+		const endValue = samples[endIndex]?.[sampleField];
+		if (
+			values.length !== windowSamples.length ||
+			typeof startValue !== "number" ||
+			!Number.isFinite(startValue) ||
+			typeof endValue !== "number" ||
+			!Number.isFinite(endValue)
+		) {
+			continue;
+		}
+		summary[metricName] = {
+			peakBytes: Math.max(...values),
+			endDeltaBytes: endValue - startValue,
+		};
+	}
+	return Object.keys(summary).length > 0 ? summary : null;
+};
+
+const MEMORY_SERIES = {
+	readerRenderer: {
+		seriesName: "readerJsHeap",
+		metrics: {
+			usedBytes: "usedBytes",
+			embedderHeapUsedBytes: "embedderHeapUsedBytes",
+			backingStorageBytes: "backingStorageBytes",
+		},
+	},
+	writerRenderer: {
+		seriesName: "writerJsHeap",
+		metrics: {
+			usedBytes: "usedBytes",
+			embedderHeapUsedBytes: "embedderHeapUsedBytes",
+			backingStorageBytes: "backingStorageBytes",
+		},
+	},
+	host: {
+		seriesName: "hostRss",
+		metrics: {
+			rssBytes: "combinedBytes",
+			nodeExternalBytes: "nodeExternalBytes",
+			nodeArrayBuffersBytes: "nodeArrayBuffersBytes",
+		},
+	},
+};
+
+const extractMemoryPhases = (result) => {
+	const telemetry = result?.downloadMemoryTelemetry;
+	if (telemetry?.profile !== "download-memory-v3") {
+		return null;
+	}
+	const timestamps = result.timestamps;
+	const boundaries = {
+		transfer: [timestamps?.downloadStartedAt, timestamps?.downloadFinishedAt],
+		soak: [
+			timestamps?.postTransferSoakStartedAt,
+			timestamps?.postTransferSoakFinishedAt,
+		],
+	};
+	const phases = {};
+	for (const [phaseName, [startedAt, finishedAt]] of Object.entries(
+		boundaries,
+	)) {
+		const phase = {};
+		for (const [scope, { seriesName, metrics }] of Object.entries(
+			MEMORY_SERIES,
+		)) {
+			const window = phaseMemoryWindow(
+				telemetry[seriesName],
+				startedAt,
+				finishedAt,
+				metrics,
+			);
+			if (window) {
+				phase[scope] = window;
+			}
+		}
+		if (Object.keys(phase).length > 0) {
+			phases[phaseName] = phase;
+		}
+	}
+	return Object.keys(phases).length > 0 ? phases : null;
+};
+
+const summarizeMemoryPhases = (results) => {
+	const records = results
+		.filter((result) => result.status === "passed")
+		.map((result) => extractMemoryPhases(result))
+		.filter(Boolean);
+	if (records.length === 0) {
+		return null;
+	}
+	const phases = {};
+	for (const phaseName of ["transfer", "soak"]) {
+		const phase = {};
+		for (const [scope, { metrics }] of Object.entries(MEMORY_SERIES)) {
+			const scopeSummary = {};
+			for (const metricName of Object.keys(metrics)) {
+				const peakBytes = optionalDistribution(
+					records.map(
+						(record) => record?.[phaseName]?.[scope]?.[metricName]?.peakBytes,
+					),
+				);
+				const endDeltaBytes = optionalDistribution(
+					records.map(
+						(record) =>
+							record?.[phaseName]?.[scope]?.[metricName]?.endDeltaBytes,
+					),
+				);
+				if (peakBytes || endDeltaBytes) {
+					scopeSummary[metricName] = { peakBytes, endDeltaBytes };
+				}
+			}
+			if (Object.keys(scopeSummary).length > 0) {
+				phase[scope] = scopeSummary;
+			}
+		}
+		if (Object.keys(phase).length > 0) {
+			phases[phaseName] = phase;
+		}
+	}
+	return {
+		profile: "download-memory-v3",
+		unit: "bytes",
+		evidenceRunCount: records.length,
+		phaseBoundaryDefinition:
+			"last live sample at or before the phase start through the first live sample at or after the phase end; terminal post-shutdown samples are excluded, exact sample timestamps retain the boundary overhang, and validated evidence bounds every adjacent capturedAt gap by sampleIntervalMs + operationTimeoutMs + schedulingToleranceMs",
+		...phases,
+	};
+};
+
+const summarizeResourceStorage = (results) => {
+	const records = results
+		.filter((result) => result.status === "passed")
+		.map((result) => result?.resourceEvidence)
+		.filter((evidence) => isRecord(evidence?.intervals));
+	if (records.length === 0) {
+		return null;
+	}
+	const phases = {};
+	for (const phaseName of [
+		"timedReadEnvelope",
+		"postTransferWork",
+		"soak",
+		"total",
+	]) {
+		const phase = {};
+		for (const role of ["writer", "reader"]) {
+			const storageKey = `${role}Storage`;
+			const peerbitLogUsageDeltaBytes = optionalDistribution(
+				records.map(
+					(record) =>
+						record.intervals?.[phaseName]?.[storageKey]
+							?.peerbitLogUsageDeltaBytes,
+				),
+			);
+			const backingStorageUsageDeltaBytes = optionalDistribution(
+				records.map(
+					(record) =>
+						record.intervals?.[phaseName]?.[storageKey]
+							?.backingStorageUsageDeltaBytes,
+				),
+			);
+			if (peerbitLogUsageDeltaBytes || backingStorageUsageDeltaBytes) {
+				phase[role] = {
+					peerbitLogUsageDeltaBytes,
+					backingStorageUsageDeltaBytes,
+				};
+			}
+		}
+		if (Object.keys(phase).length > 0) {
+			phases[phaseName] = phase;
+		}
+	}
+	return {
+		unit: "bytes",
+		evidenceRunCount: records.length,
+		definition:
+			"later-minus-earlier deltas over resource-evidence v2 checkpoints; peerbitLog is Peerbit logical storage while backingStorage is the browser origin-wide navigator.storage estimate",
+		...phases,
+	};
+};
+
+const EAGER_LIMIT_KEYS = [
+	"maxEntries",
+	"maxBytes",
+	"maxBlockBytes",
+	"ttlMs",
+	"validationConcurrency",
+	"maxPendingBytes",
+	"maxPendingEntries",
+];
+
+const orderedEagerLimits = (limits) =>
+	isRecord(limits)
+		? Object.fromEntries(
+				EAGER_LIMIT_KEYS.map((key) => [key, limits[key] ?? null]),
+			)
+		: null;
+
+const extractRuntimeConfiguration = (result, role) => {
+	const runtime =
+		result?.resourceEvidence?.snapshots?.beforeTimedRead?.[role]?.runtime;
+	if (
+		!isRecord(runtime?.nativeGraph) ||
+		!isRecord(runtime?.eagerBlocks) ||
+		!isRecord(runtime?.pubsub)
+	) {
+		return null;
+	}
+	const fanout = runtime.pubsub.snapshot?.fanout;
+	const telemetry = runtime.eagerBlocks.telemetry;
+	return {
+		nativeGraph: {
+			active: runtime.nativeGraph.active ?? null,
+			useHeads: runtime.nativeGraph.useHeads ?? null,
+		},
+		eagerBlocks: {
+			telemetryAvailable: runtime.eagerBlocks.telemetryAvailable ?? null,
+			enabled: runtime.eagerBlocks.enabled ?? null,
+			limits: orderedEagerLimits(telemetry?.limits),
+		},
+		pubsub: {
+			runtimeSnapshotAvailable: runtime.pubsub.runtimeSnapshotAvailable ?? null,
+			error: runtime.pubsub.error ?? null,
+			rootUploadLimitBps: fanout?.root?.uploadLimitBps ?? null,
+			nodeUploadLimitBps: fanout?.node?.uploadLimitBps ?? null,
+		},
+	};
+};
+
+const extractRuntimeConfigurationPairEvidence = (result) => {
+	const beforeTimedRead = result?.resourceEvidence?.snapshots?.beforeTimedRead;
+	const present =
+		beforeTimedRead?.writer?.runtime != null ||
+		beforeTimedRead?.reader?.runtime != null;
+	const writer = extractRuntimeConfiguration(result, "writer");
+	const reader = extractRuntimeConfiguration(result, "reader");
+	const pair = writer && reader ? { writer, reader } : null;
+	return {
+		present,
+		pair,
+		cohortKey: pair ? JSON.stringify(pair) : null,
+	};
+};
+
+const groupedConfigurations = (configurations) => {
+	const grouped = new Map();
+	for (const configuration of configurations) {
+		if (!configuration) {
+			continue;
+		}
+		const key = JSON.stringify(configuration);
+		const group = grouped.get(key) ?? { configuration, runCount: 0 };
+		group.runCount += 1;
+		grouped.set(key, group);
+	}
+	return [...grouped.entries()]
+		.toSorted(([left], [right]) => left.localeCompare(right))
+		.map(([, group]) => group);
+};
+
+const summarizeRuntimeConfigurations = (results) => {
+	const passedRecords = results
+		.filter((result) => result.status === "passed")
+		.map((result) => {
+			const evidence = extractRuntimeConfigurationPairEvidence(result);
+			return {
+				writer: extractRuntimeConfiguration(result, "writer"),
+				reader: extractRuntimeConfiguration(result, "reader"),
+				pair: evidence.pair,
+				cohortKey: evidence.cohortKey,
+			};
+		});
+	const records = passedRecords.filter(
+		(record) => record.writer || record.reader,
+	);
+	if (records.length === 0) {
+		return null;
+	}
+	const writer = groupedConfigurations(records.map((record) => record.writer));
+	const reader = groupedConfigurations(records.map((record) => record.reader));
+	const pairKeys = new Set(passedRecords.map((record) => record.cohortKey));
+	const cohortKey =
+		passedRecords.every((record) => record.pair) && pairKeys.size === 1
+			? passedRecords[0].cohortKey
+			: null;
+	return {
+		definition:
+			"normalized effective writer/reader pair of native graph, eager-cache limits, and pubsub fanout upload policy captured before the timed read",
+		evidenceRunCount: records.length,
+		writer,
+		reader,
+		...(cohortKey == null ? {} : { cohortKey }),
+	};
+};
+
+const EAGER_REJECTION_KEYS = [
+	"rejectedCid",
+	"rejectedCodec",
+	"rejectedSize",
+	"rejectedPending",
+	"rejectedIntegrity",
+	"rejectedLifecycle",
+];
+
+const extractAfterSoakEagerTelemetry = (result, role) =>
+	result?.resourceEvidence?.snapshots?.afterSoak?.[role]?.runtime?.eagerBlocks
+		?.telemetry ?? null;
+
+const eagerIntervalSummary = (results, role, phaseName) => {
+	const eagerKey = `${role}Eager`;
+	const deltas = results.map(
+		(result) => result?.resourceEvidence?.intervals?.[phaseName]?.[eagerKey],
+	);
+	const evictions = optionalDistribution(
+		deltas.map((delta) => delta?.evictions),
+	);
+	const expirations = optionalDistribution(
+		deltas.map((delta) => delta?.expirations),
+	);
+	const admitted = optionalDistribution(deltas.map((delta) => delta?.admitted));
+	const hits = optionalDistribution(deltas.map((delta) => delta?.hits));
+	const rejections = {};
+	for (const key of EAGER_REJECTION_KEYS) {
+		const distribution = optionalDistribution(
+			deltas.map((delta) => delta?.[key]),
+		);
+		if (distribution) {
+			rejections[key] = distribution;
+		}
+	}
+	const rejectionTotals = deltas.map((delta) => {
+		const values = EAGER_REJECTION_KEYS.map((key) => delta?.[key]);
+		return values.every(
+			(value) => typeof value === "number" && Number.isFinite(value),
+		)
+			? values.reduce((total, value) => total + value, 0)
+			: null;
+	});
+	const total = optionalDistribution(rejectionTotals);
+	if (
+		!admitted &&
+		!hits &&
+		!evictions &&
+		!expirations &&
+		Object.keys(rejections).length === 0
+	) {
+		return null;
+	}
+	return {
+		admitted,
+		hits,
+		evictions,
+		expirations,
+		rejections: { total, ...rejections },
+	};
+};
+
+const eagerRoleSummary = (results, role) => {
+	const telemetry = results.map((result) =>
+		extractAfterSoakEagerTelemetry(result, role),
+	);
+	const lifetimePeaksAfterSoak = {};
+	for (const key of [
+		"peakEntries",
+		"peakBytes",
+		"peakPendingEntries",
+		"peakPendingBytes",
+	]) {
+		const distribution = optionalDistribution(
+			telemetry.map((value) => value?.[key]),
+		);
+		if (distribution) {
+			lifetimePeaksAfterSoak[key] = distribution;
+		}
+	}
+	const currentAfterSoak = {};
+	for (const key of ["entries", "bytes", "pendingEntries", "pendingBytes"]) {
+		const distribution = optionalDistribution(
+			telemetry.map((value) => value?.[key]),
+		);
+		if (distribution) {
+			currentAfterSoak[key] = distribution;
+		}
+	}
+	const intervals = {};
+	for (const phaseName of [
+		"timedReadEnvelope",
+		"postTransferWork",
+		"soak",
+		"total",
+	]) {
+		const summary = eagerIntervalSummary(results, role, phaseName);
+		if (summary) {
+			intervals[phaseName] = summary;
+		}
+	}
+	if (
+		Object.keys(lifetimePeaksAfterSoak).length === 0 &&
+		Object.keys(currentAfterSoak).length === 0 &&
+		Object.keys(intervals).length === 0
+	) {
+		return null;
+	}
+	return { currentAfterSoak, lifetimePeaksAfterSoak, ...intervals };
+};
+
+const summarizeEagerCache = (results) => {
+	const passed = results.filter((result) => result.status === "passed");
+	const writer = eagerRoleSummary(passed, "writer");
+	const reader = eagerRoleSummary(passed, "reader");
+	if (!writer && !reader) {
+		return null;
+	}
+	const evidenceRunCount = passed.filter(
+		(result) =>
+			extractAfterSoakEagerTelemetry(result, "writer") ||
+			extractAfterSoakEagerTelemetry(result, "reader"),
+	).length;
+	return {
+		unit: "entries-or-bytes-as-named",
+		evidenceRunCount,
+		definition:
+			"current occupancy and lifetime peaks at the after-soak snapshot plus per-interval deltas of admitted blocks, hits, evictions, expirations, and rejection counters",
+		...(writer ? { writer } : {}),
+		...(reader ? { reader } : {}),
+	};
+};
+
+const summarizeRuntimeEvidence = (results) => {
+	const memoryPhases = summarizeMemoryPhases(results);
+	const resourceStorageDeltas = summarizeResourceStorage(results);
+	const effectiveRuntimeConfiguration = summarizeRuntimeConfigurations(results);
+	const eagerCache = summarizeEagerCache(results);
+	if (
+		!memoryPhases &&
+		!resourceStorageDeltas &&
+		!effectiveRuntimeConfiguration &&
+		!eagerCache
+	) {
+		return null;
+	}
+	return {
+		...(memoryPhases ? { memoryPhases } : {}),
+		...(resourceStorageDeltas ? { resourceStorageDeltas } : {}),
+		...(effectiveRuntimeConfiguration ? { effectiveRuntimeConfiguration } : {}),
+		...(eagerCache ? { eagerCache } : {}),
+	};
+};
 
 /**
  * Keep the end-to-end readiness timings next to the legacy post-settlement
@@ -130,6 +650,7 @@ export const summarizeUploadPerformance = (results) => {
 	);
 	const downloadSink =
 		passedDownloadSinks.size === 1 ? [...passedDownloadSinks][0] : null;
+	const runtimeEvidence = summarizeRuntimeEvidence(results);
 	return {
 		timingDistributionDefinition: TIMING_DISTRIBUTION_DEFINITION,
 		primaryDownloadMetric: PRIMARY_DOWNLOAD_METRIC,
@@ -152,6 +673,7 @@ export const summarizeUploadPerformance = (results) => {
 			"sinkAwaitSubtractedDiagnosticMs",
 			sinkAwaitSubtractedDiagnostic,
 		),
+		...(runtimeEvidence ? { runtimeEvidence } : {}),
 	};
 };
 
@@ -171,12 +693,33 @@ const compareModeMetric = (adaptiveResults, fixedResults, getter) => {
 	};
 };
 
+const comparableRuntimeConfigurationCohortKey = (passedResults) => {
+	const evidence = passedResults.map((result) =>
+		extractRuntimeConfigurationPairEvidence(result),
+	);
+	if (evidence.every((value) => !value.present)) {
+		return { legacy: true, cohortKey: null };
+	}
+	if (
+		evidence.some((value) => !value.present || value.pair == null) ||
+		new Set(evidence.map((value) => value.cohortKey)).size !== 1
+	) {
+		return null;
+	}
+	return { legacy: false, cohortKey: evidence[0].cohortKey };
+};
+
 export const compareUploadPerformanceModes = (results) => {
 	const passedResults = results.filter((result) => result.status === "passed");
 	const downloadSinks = new Set(
 		passedResults.map((result) => result.downloadSink),
 	);
 	if (downloadSinks.size !== 1) {
+		return null;
+	}
+	const runtimeConfiguration =
+		comparableRuntimeConfigurationCohortKey(passedResults);
+	if (!runtimeConfiguration) {
 		return null;
 	}
 	const downloadSink = [...downloadSinks][0];
@@ -207,6 +750,11 @@ export const compareUploadPerformanceModes = (results) => {
 	}
 	return {
 		downloadSink,
+		...(runtimeConfiguration.legacy
+			? {}
+			: {
+					runtimeConfigurationCohortKey: runtimeConfiguration.cohortKey,
+				}),
 		primaryDownloadMetric: PRIMARY_DOWNLOAD_METRIC,
 		primaryDownloadAuthoritative:
 			downloadSink === STANDARD_PRIMARY_DOWNLOAD_SINK,

--- a/scripts/file-share/benchmark-summary.test.mjs
+++ b/scripts/file-share/benchmark-summary.test.mjs
@@ -209,6 +209,433 @@ test("propagates end-to-end readiness and labels post-settlement listing", () =>
 	});
 });
 
+const memorySamples = (base, host = false) =>
+	[900, 1_500, 2_100, 2_900, 3_500, 4_100, 5_000].map((capturedAt, index) =>
+		host
+			? {
+					capturedAt,
+					combinedBytes: base + 1_000 + index * 100,
+					nodeExternalBytes: base + 2_000 + index * 20,
+					nodeArrayBuffersBytes: base + 3_000 + index * 5,
+				}
+			: {
+					capturedAt,
+					usedBytes: base + index * 10,
+					embedderHeapUsedBytes: base + 100 + index * 20,
+					backingStorageBytes: base + 200 + index * 30,
+				},
+	);
+
+const eagerTelemetry = (overrides = {}) => ({
+	entries: 8,
+	bytes: 400,
+	peakEntries: 20,
+	peakBytes: 1_000,
+	pendingEntries: 1,
+	pendingBytes: 100,
+	peakPendingEntries: 3,
+	peakPendingBytes: 300,
+	admitted: 12,
+	hits: 7,
+	limits: {
+		maxEntries: 1_000,
+		maxBytes: 32 * 1024 * 1024,
+		maxBlockBytes: 10 * 1024 * 1024,
+		ttlMs: 10_000,
+		validationConcurrency: 2,
+		maxPendingBytes: 20 * 1024 * 1024,
+		maxPendingEntries: 64,
+	},
+	...overrides,
+});
+
+const runtimeSnapshot = (overrides = {}) => ({
+	nativeGraph: { active: true, useHeads: false },
+	eagerBlocks: {
+		telemetryAvailable: true,
+		enabled: true,
+		telemetry: eagerTelemetry(),
+	},
+	pubsub: {
+		runtimeSnapshotAvailable: true,
+		error: null,
+		snapshot: {
+			fanout: {
+				root: { uploadLimitBps: 5_000_000 },
+				node: { uploadLimitBps: 5_000_000 },
+			},
+		},
+	},
+	...overrides,
+});
+
+const eagerDelta = (overrides = {}) => ({
+	admitted: 5,
+	hits: 3,
+	evictions: 2,
+	expirations: 1,
+	rejectedCid: 1,
+	rejectedCodec: 2,
+	rejectedSize: 0,
+	rejectedPending: 0,
+	rejectedIntegrity: 0,
+	rejectedLifecycle: 0,
+	...overrides,
+});
+
+const storageDelta = (
+	role,
+	peerbitLogUsageDeltaBytes,
+	backingStorageUsageDeltaBytes,
+) => ({
+	role,
+	peerbitLogUsageDeltaBytes,
+	backingStorageUsageDeltaBytes,
+});
+
+const runtimeEvidenceResult = () => ({
+	status: "passed",
+	mode: "fixed1",
+	downloadSink: "hash-only",
+	uploadDurationMs: 10,
+	timeToWriterReadyMs: 20,
+	timeToReaderReadyMs: 30,
+	listingDurationMs: 5,
+	downloadDurationMs: 1_000,
+	libraryStreamWallMs: 900,
+	sinkWriteAwaitMs: 10,
+	sinkAwaitSubtractedDiagnosticMs: 890,
+	timestamps: {
+		downloadStartedAt: 1_000,
+		downloadFinishedAt: 2_000,
+		postTransferSoakStartedAt: 3_000,
+		postTransferSoakFinishedAt: 4_000,
+	},
+	downloadMemoryTelemetry: {
+		profile: "download-memory-v3",
+		readerJsHeap: { samples: memorySamples(100) },
+		writerJsHeap: { samples: memorySamples(200) },
+		hostRss: { samples: memorySamples(300, true) },
+	},
+	resourceEvidence: {
+		schemaVersion: 2,
+		snapshots: {
+			beforeTimedRead: {
+				writer: { runtime: runtimeSnapshot() },
+				reader: { runtime: runtimeSnapshot() },
+			},
+			afterSink: {
+				writer: { runtime: runtimeSnapshot() },
+				reader: { runtime: runtimeSnapshot() },
+			},
+			beforeSoak: {
+				writer: { runtime: runtimeSnapshot() },
+				reader: { runtime: runtimeSnapshot() },
+			},
+			afterSoak: {
+				writer: { runtime: runtimeSnapshot() },
+				reader: {
+					runtime: runtimeSnapshot({
+						eagerBlocks: {
+							telemetryAvailable: true,
+							enabled: true,
+							telemetry: eagerTelemetry({
+								peakEntries: 10,
+								peakBytes: 500,
+							}),
+						},
+					}),
+				},
+			},
+		},
+		intervals: {
+			timedReadEnvelope: {
+				writerStorage: storageDelta("writer", 100, 200),
+				readerStorage: storageDelta("reader", 300, 400),
+				writerEager: eagerDelta(),
+				readerEager: eagerDelta({ evictions: 1, rejectedCodec: 0 }),
+			},
+			postTransferWork: {
+				writerStorage: storageDelta("writer", 5, 10),
+				readerStorage: storageDelta("reader", 15, 20),
+				writerEager: eagerDelta({ admitted: 1, hits: 0, evictions: 0 }),
+				readerEager: eagerDelta({ admitted: 0, hits: 1, evictions: 0 }),
+			},
+			soak: {
+				writerStorage: storageDelta("writer", -10, 20),
+				readerStorage: storageDelta("reader", -30, 40),
+				writerEager: eagerDelta({ evictions: 0, rejectedCid: 0 }),
+				readerEager: eagerDelta({ evictions: 0, rejectedCid: 0 }),
+			},
+			total: {
+				writerStorage: storageDelta("writer", 95, 230),
+				readerStorage: storageDelta("reader", 285, 460),
+				writerEager: eagerDelta({ evictions: 2 }),
+				readerEager: eagerDelta({ evictions: 1, rejectedCodec: 0 }),
+			},
+		},
+	},
+});
+
+test("summarizes v3 memory, resource, runtime, and eager evidence", () => {
+	const summary = summarizeUploadPerformance([runtimeEvidenceResult()]);
+	const evidence = summary.runtimeEvidence;
+	assert.equal(evidence.memoryPhases.evidenceRunCount, 1);
+	assert.equal(
+		evidence.memoryPhases.transfer.readerRenderer.usedBytes.peakBytes.avg,
+		120,
+	);
+	assert.equal(
+		evidence.memoryPhases.transfer.readerRenderer.embedderHeapUsedBytes
+			.endDeltaBytes.avg,
+		40,
+	);
+	assert.equal(
+		evidence.memoryPhases.soak.writerRenderer.backingStorageBytes.peakBytes.avg,
+		550,
+	);
+	assert.equal(
+		evidence.memoryPhases.transfer.host.rssBytes.endDeltaBytes.avg,
+		200,
+	);
+	assert.equal(
+		evidence.memoryPhases.soak.host.nodeExternalBytes.peakBytes.avg,
+		2_400,
+	);
+	assert.equal(
+		evidence.memoryPhases.soak.host.nodeArrayBuffersBytes.endDeltaBytes.avg,
+		10,
+	);
+
+	assert.equal(
+		evidence.resourceStorageDeltas.timedReadEnvelope.writer
+			.peerbitLogUsageDeltaBytes.avg,
+		100,
+	);
+	assert.equal(
+		evidence.resourceStorageDeltas.postTransferWork.reader
+			.backingStorageUsageDeltaBytes.avg,
+		20,
+	);
+	assert.equal(
+		evidence.resourceStorageDeltas.soak.reader.backingStorageUsageDeltaBytes
+			.avg,
+		40,
+	);
+	assert.equal(
+		evidence.resourceStorageDeltas.total.writer.peerbitLogUsageDeltaBytes.avg,
+		95,
+	);
+
+	const runtime = evidence.effectiveRuntimeConfiguration;
+	assert.equal(runtime.writer.length, 1);
+	assert.equal(runtime.writer[0].runCount, 1);
+	assert.deepEqual(runtime.writer[0].configuration, {
+		nativeGraph: { active: true, useHeads: false },
+		eagerBlocks: {
+			telemetryAvailable: true,
+			enabled: true,
+			limits: eagerTelemetry().limits,
+		},
+		pubsub: {
+			runtimeSnapshotAvailable: true,
+			error: null,
+			rootUploadLimitBps: 5_000_000,
+			nodeUploadLimitBps: 5_000_000,
+		},
+	});
+	assert.equal(
+		runtime.cohortKey,
+		JSON.stringify({
+			writer: runtime.writer[0].configuration,
+			reader: runtime.reader[0].configuration,
+		}),
+	);
+
+	assert.equal(evidence.eagerCache.writer.currentAfterSoak.entries.avg, 8);
+	assert.equal(evidence.eagerCache.writer.currentAfterSoak.bytes.avg, 400);
+	assert.equal(
+		evidence.eagerCache.writer.currentAfterSoak.pendingEntries.avg,
+		1,
+	);
+	assert.equal(
+		evidence.eagerCache.writer.currentAfterSoak.pendingBytes.avg,
+		100,
+	);
+	assert.equal(
+		evidence.eagerCache.writer.lifetimePeaksAfterSoak.peakBytes.avg,
+		1_000,
+	);
+	assert.equal(
+		evidence.eagerCache.reader.lifetimePeaksAfterSoak.peakEntries.avg,
+		10,
+	);
+	assert.equal(evidence.eagerCache.writer.timedReadEnvelope.admitted.avg, 5);
+	assert.equal(evidence.eagerCache.writer.timedReadEnvelope.hits.avg, 3);
+	assert.equal(evidence.eagerCache.writer.timedReadEnvelope.evictions.avg, 2);
+	assert.equal(
+		evidence.eagerCache.writer.timedReadEnvelope.rejections.total.avg,
+		3,
+	);
+	assert.equal(evidence.eagerCache.writer.postTransferWork.admitted.avg, 1);
+	assert.equal(
+		evidence.eagerCache.reader.timedReadEnvelope.rejections.rejectedCodec.avg,
+		0,
+	);
+});
+
+test("excludes terminal teardown samples from soak memory summaries", () => {
+	const result = runtimeEvidenceResult();
+	const readerSamples = result.downloadMemoryTelemetry.readerJsHeap.samples;
+	const manualSample = readerSamples.find(
+		(sample) => sample.capturedAt === 4_100,
+	);
+	manualSample.sampleKind = "manual";
+	readerSamples.splice(readerSamples.indexOf(manualSample), 0, {
+		capturedAt: 4_050,
+		sampleKind: "terminal",
+		usedBytes: 9_999_999,
+		embedderHeapUsedBytes: 9_999_999,
+		backingStorageBytes: 9_999_999,
+	});
+
+	const soak = summarizeUploadPerformance([result]).runtimeEvidence.memoryPhases
+		.soak.readerRenderer;
+	assert.equal(soak.usedBytes.peakBytes.avg, 150);
+	assert.equal(soak.usedBytes.endDeltaBytes.avg, 20);
+
+	const missingLiveEndpoint = runtimeEvidenceResult();
+	missingLiveEndpoint.downloadMemoryTelemetry.readerJsHeap.samples =
+		missingLiveEndpoint.downloadMemoryTelemetry.readerJsHeap.samples.filter(
+			(sample) => sample.capturedAt < 4_000,
+		);
+	assert.equal(
+		summarizeUploadPerformance([missingLiveEndpoint]).runtimeEvidence
+			.memoryPhases.soak.readerRenderer,
+		undefined,
+	);
+});
+
+test("normalizes a writer-reader runtime pair even when the roles differ", () => {
+	const result = runtimeEvidenceResult();
+	result.resourceEvidence.snapshots.beforeTimedRead.reader.runtime.nativeGraph.active = false;
+	const runtime = summarizeUploadPerformance([result]).runtimeEvidence
+		.effectiveRuntimeConfiguration;
+	assert.equal(
+		runtime.cohortKey,
+		JSON.stringify({
+			writer: runtime.writer[0].configuration,
+			reader: runtime.reader[0].configuration,
+		}),
+	);
+	assert.equal(runtime.writer.length, 1);
+	assert.equal(runtime.reader.length, 1);
+});
+
+test("groups timing rows by runtime pair in addition to locality", () => {
+	const first = runtimeEvidenceResult();
+	const samePair = structuredClone(first);
+	const differentPair = structuredClone(first);
+	differentPair.resourceEvidence.snapshots.beforeTimedRead.writer.runtime.pubsub.snapshot.fanout.root.uploadLimitBps = 4_000_000;
+	const legacy = {
+		status: "failed",
+		mode: "fixed1",
+	};
+	const groups = groupUploadResultsByLocalityCohort([
+		first,
+		samePair,
+		differentPair,
+		legacy,
+	]);
+
+	assert.equal(groups.length, 3);
+	assert.deepEqual(
+		groups.map(({ dimensions, results }) => ({
+			cohortKey: dimensions.runtimeConfigurationCohortKey,
+			runs: results.length,
+		})),
+		[
+			{
+				cohortKey: summarizeUploadPerformance([first]).runtimeEvidence
+					.effectiveRuntimeConfiguration.cohortKey,
+				runs: 2,
+			},
+			{
+				cohortKey: summarizeUploadPerformance([differentPair]).runtimeEvidence
+					.effectiveRuntimeConfiguration.cohortKey,
+				runs: 1,
+			},
+			{ cohortKey: null, runs: 1 },
+		],
+	);
+	assert.equal(
+		Object.hasOwn(
+			summarizeUploadPerformance([first, differentPair]).runtimeEvidence
+				.effectiveRuntimeConfiguration,
+			"cohortKey",
+		),
+		false,
+	);
+});
+
+const comparableRuntimeModeResults = () => {
+	const adaptive = runtimeEvidenceResult();
+	adaptive.mode = "adaptive";
+	adaptive.uploadDurationMs = 80;
+	adaptive.timeToWriterReadyMs = 70;
+	adaptive.timeToReaderReadyMs = 120;
+	adaptive.libraryStreamWallMs = 40;
+	const fixed1 = runtimeEvidenceResult();
+	fixed1.mode = "fixed1";
+	fixed1.uploadDurationMs = 100;
+	fixed1.timeToWriterReadyMs = 80;
+	fixed1.timeToReaderReadyMs = 150;
+	fixed1.libraryStreamWallMs = 50;
+	return { adaptive, fixed1 };
+};
+
+test("compares modes only inside one exact runtime pair", () => {
+	const { adaptive, fixed1 } = comparableRuntimeModeResults();
+	const comparison = compareUploadPerformanceModes([adaptive, fixed1]);
+	assert.equal(
+		comparison.runtimeConfigurationCohortKey,
+		summarizeUploadPerformance([adaptive]).runtimeEvidence
+			.effectiveRuntimeConfiguration.cohortKey,
+	);
+});
+
+test("rejects a mode comparison across an upload-limit mismatch", () => {
+	const { adaptive, fixed1 } = comparableRuntimeModeResults();
+	fixed1.resourceEvidence.snapshots.beforeTimedRead.reader.runtime.pubsub.snapshot.fanout.root.uploadLimitBps = 4_999_999;
+	assert.equal(compareUploadPerformanceModes([adaptive, fixed1]), null);
+});
+
+test("rejects a mode comparison across a native-graph mismatch", () => {
+	const { adaptive, fixed1 } = comparableRuntimeModeResults();
+	fixed1.resourceEvidence.snapshots.beforeTimedRead.writer.runtime.nativeGraph.active = false;
+	assert.equal(compareUploadPerformanceModes([adaptive, fixed1]), null);
+});
+
+test("rejects a mode comparison across an eager-limit mismatch", () => {
+	const { adaptive, fixed1 } = comparableRuntimeModeResults();
+	fixed1.resourceEvidence.snapshots.beforeTimedRead.reader.runtime.eagerBlocks.telemetry.limits.maxBytes -= 1;
+	assert.equal(compareUploadPerformanceModes([adaptive, fixed1]), null);
+});
+
+test("rejects a mode comparison with mixed runtime-evidence availability", () => {
+	const { adaptive, fixed1 } = comparableRuntimeModeResults();
+	delete fixed1.resourceEvidence;
+	assert.equal(compareUploadPerformanceModes([adaptive, fixed1]), null);
+	assert.equal(
+		Object.hasOwn(
+			summarizeUploadPerformance([adaptive, fixed1]).runtimeEvidence
+				.effectiveRuntimeConfiguration,
+			"cohortKey",
+		),
+		false,
+	);
+});
+
 test("suppresses mode comparisons unless the entire planned cohort passed", () => {
 	const passed = [
 		{

--- a/scripts/file-share/benchmark-validity.mjs
+++ b/scripts/file-share/benchmark-validity.mjs
@@ -9,9 +9,11 @@ import {
 	projectUploadIntegrityEvidence,
 } from "./benchmark-orchestration.mjs";
 import {
+	DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE,
 	DOWNLOAD_MEMORY_HOST_ATTRIBUTION,
 	DOWNLOAD_MEMORY_HOST_ATTRIBUTION_LIMITATIONS,
 	DOWNLOAD_MEMORY_HOST_SCOPE,
+	DOWNLOAD_MEMORY_LIVE_SAMPLE_COVERAGE_DEFINITION,
 	DOWNLOAD_MEMORY_MAX_BROWSER_PROCESSES,
 	DOWNLOAD_MEMORY_MAX_BROWSER_ROLES,
 	DOWNLOAD_MEMORY_MAX_BROWSER_ROLE_NAME_LENGTH,
@@ -19,11 +21,14 @@ import {
 	DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH,
 	DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS,
 	DOWNLOAD_MEMORY_NODE_SCOPE,
+	DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS,
 	DOWNLOAD_MEMORY_PROFILE,
 	DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
 	DOWNLOAD_MEMORY_SETUP_ALLOWANCE_MS,
 	DOWNLOAD_MEMORY_TERMINAL_ALLOWANCE_MS,
 	DOWNLOAD_MEMORY_WINDOW_DEFINITION,
+	assertDownloadMemoryLiveSampleCoverage,
+	calculateDownloadMemoryMaxLiveSampleGapMs,
 	calculateDownloadMemoryMaxSamples,
 } from "./templates/download-memory-telemetry.mjs";
 
@@ -37,6 +42,10 @@ const SAMPLE_COUNT_DEFINITION =
 	"observation-density divisor: planned interval is min(sampleMs, floor(readyTimeoutMs/sampleCount)) clamped to 1ms; convergence may finish early";
 const POST_MONITOR_SCHEDULING_TOLERANCE_DEFINITION =
 	"max(250ms, pollMs + 250ms) for the final poll and event-loop scheduling";
+const POST_TRANSFER_SOAK_SCHEDULING_TOLERANCE_DEFINITION =
+	"max(250ms, pollMs + 250ms) for the requested post-transfer timer and event-loop scheduling";
+const POST_TRANSFER_SOAK_DEFINITION =
+	"idle observation window beginning after transfer integrity and any requested terminal-topology validation, ending before terminal resource capture and peer shutdown";
 const TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION =
 	"max(5000ms, pollMs + 1000ms) for browser actions and event-loop scheduling";
 const TIME_TO_WRITER_READY_DEFINITION =
@@ -70,6 +79,91 @@ const TRANSPORT_COUNTER_POST_READ_CAPTURE_MAX_DELAY_MS = 9_000;
 const PUBSUB_PROTOCOL = "/peerbit/topic-control-plane/2.0.0";
 const DEMAND_WAIT_DEFINITION =
 	"wall-clock time each sequential stream consumer awaited its scheduled chunk";
+const RECEIVER_PROGRESS_PERCENTAGES = Object.freeze(
+	Array.from({ length: 21 }, (_, index) => index * 5),
+);
+const RECEIVER_PROGRESS_MILESTONE_KEYS = Object.freeze([
+	"percent",
+	"targetBytes",
+	"contiguousBytes",
+	"chunkIndex",
+	"confirmedAt",
+	"elapsedMs",
+]);
+const PERSISTENCE_CONFIRMATION_SOURCES = new Set([
+	"manifest-head-batch-local",
+	"manifest-head-batch-remote",
+	"manifest-entry-local",
+	"manifest-entry-import",
+]);
+const RESOURCE_SNAPSHOT_TIMEOUT_MS = 15_000;
+const PAGE_SHUTDOWN_TIMEOUT_MS = 30_000;
+const RESOURCE_STORAGE_DEFINITION =
+	"Peerbit logical usage and browser origin-wide navigator.storage estimates; deltas are later minus earlier";
+const RESOURCE_EAGER_DEFINITION =
+	"deltas of monotonic eager-cache admission, hit, eviction, expiration, and rejection counters; null when eager telemetry is disabled or unavailable";
+const RESOURCE_MAX_STORAGE_DETAIL_KEYS = 64;
+const RESOURCE_MAX_STORAGE_DETAIL_KEY_LENGTH = 128;
+const EAGER_MONOTONIC_COUNTERS = Object.freeze([
+	"evictions",
+	"expirations",
+	"admitted",
+	"hits",
+	"rejectedCid",
+	"rejectedCodec",
+	"rejectedSize",
+	"rejectedPending",
+	"rejectedIntegrity",
+	"rejectedLifecycle",
+]);
+const EAGER_TELEMETRY_KEYS = Object.freeze([
+	"entries",
+	"bytes",
+	"peakEntries",
+	"peakBytes",
+	...EAGER_MONOTONIC_COUNTERS.slice(0, 2),
+	"pendingEntries",
+	"pendingBytes",
+	"peakPendingEntries",
+	"peakPendingBytes",
+	...EAGER_MONOTONIC_COUNTERS.slice(2),
+	"limits",
+]);
+const EAGER_LIMIT_KEYS = Object.freeze([
+	"maxEntries",
+	"maxBytes",
+	"maxBlockBytes",
+	"ttlMs",
+	"validationConcurrency",
+	"maxPendingBytes",
+	"maxPendingEntries",
+]);
+const BENCHMARK_MIN_OUTER_TIMEOUT_MS = 20 * 60 * 1_000;
+const BENCHMARK_OUTER_TIMEOUT_SAFETY_MS = 5 * 60 * 1_000;
+
+const calculateUploadSamplingWindowBudgetMs = (invocation) => {
+	const transferToleranceMs = Math.max(5_000, invocation.pollMs + 1_000);
+	const localityBudgetMs =
+		invocation.readerLocalChunkTarget === null
+			? 0
+			: 3 * invocation.readyTimeoutMs +
+				2 * TRANSPORT_COUNTER_STABILITY_TIMEOUT_MS +
+				(invocation.readerLocalChunkTarget > 0
+					? invocation.downloadTimeoutMs + transferToleranceMs
+					: 0);
+	const requestedBudgetMs =
+		3 * invocation.readyTimeoutMs +
+		invocation.uploadTimeoutMs +
+		invocation.downloadTimeoutMs +
+		localityBudgetMs +
+		invocation.postUploadMonitorMs +
+		invocation.postTransferSoakMs +
+		BENCHMARK_OUTER_TIMEOUT_SAFETY_MS;
+	return requirePositiveSafeInteger(
+		Math.max(BENCHMARK_MIN_OUTER_TIMEOUT_MS, requestedBudgetMs),
+		"download memory sampling window budget",
+	);
+};
 // Date.now() endpoints can undercount the nested performance.now() helper
 // interval by less than one millisecond for each chunk.
 const SINK_WRITE_QUANTIZATION_ALLOWANCE_MS_PER_CHUNK = 1;
@@ -151,6 +245,13 @@ const requirePositiveNumber = (value, label) => {
 
 const requireFiniteNumber = (value, label) => {
 	if (typeof value !== "number" || !Number.isFinite(value)) {
+		throw new Error(`Benchmark result has invalid ${label}`);
+	}
+	return value;
+};
+
+const requireSafeInteger = (value, label) => {
+	if (!Number.isSafeInteger(value)) {
 		throw new Error(`Benchmark result has invalid ${label}`);
 	}
 	return value;
@@ -492,6 +593,69 @@ const requireBoundedDiagnosticIntervals = ({
 	return { started, finished, durations };
 };
 
+const buildReceiverProgressMilestones = ({
+	chunkBytes,
+	confirmedAt,
+	readStartedAt,
+	readFinishedAt,
+	label,
+}) => {
+	if (confirmedAt.length !== chunkBytes.length) {
+		throw new Error(`Benchmark ${label} must cover every read chunk`);
+	}
+	const prefixBytes = [];
+	const prefixConfirmedAt = [];
+	let cumulativeBytes = 0;
+	let cumulativeConfirmedAt = readStartedAt;
+	for (const [index, bytes] of chunkBytes.entries()) {
+		const timestamp = requireNonNegativeSafeInteger(
+			confirmedAt[index],
+			`${label}[${index}]`,
+		);
+		if (timestamp < readStartedAt || timestamp > readFinishedAt) {
+			throw new Error(
+				`Benchmark ${label}[${index}] is outside the canonical library read window`,
+			);
+		}
+		cumulativeBytes += bytes;
+		cumulativeConfirmedAt = Math.max(cumulativeConfirmedAt, timestamp);
+		prefixBytes.push(cumulativeBytes);
+		prefixConfirmedAt.push(cumulativeConfirmedAt);
+	}
+	const totalBytes = sum(chunkBytes);
+	return RECEIVER_PROGRESS_PERCENTAGES.map((percent) => {
+		if (percent === 0) {
+			return {
+				percent,
+				targetBytes: 0,
+				contiguousBytes: 0,
+				chunkIndex: null,
+				confirmedAt: readStartedAt,
+				elapsedMs: 0,
+			};
+		}
+		const targetBytes = Math.ceil((totalBytes * percent) / 100);
+		const chunkIndex = prefixBytes.findIndex((bytes) => bytes >= targetBytes);
+		if (chunkIndex < 0) {
+			throw new Error(`Benchmark ${label} did not reach ${percent}%`);
+		}
+		const milestone = {
+			percent,
+			targetBytes,
+			contiguousBytes: prefixBytes[chunkIndex],
+			chunkIndex,
+			confirmedAt: prefixConfirmedAt[chunkIndex],
+			elapsedMs: prefixConfirmedAt[chunkIndex] - readStartedAt,
+		};
+		requireExactRecordKeys(
+			milestone,
+			RECEIVER_PROGRESS_MILESTONE_KEYS,
+			`${label} ${percent}% milestone`,
+		);
+		return milestone;
+	});
+};
+
 const validateReadTransferEvidence = (
 	result,
 	invocation,
@@ -605,6 +769,14 @@ const validateReadTransferEvidence = (
 		indices,
 		requireNonNegativeSafeInteger,
 	);
+	const resolveIntervals = requireBoundedDiagnosticIntervals({
+		diagnostics,
+		indices,
+		startedName: "chunkResolveStartedAt",
+		finishedName: "chunkResolveFinishedAt",
+		readStartedAt: startedAt,
+		readFinishedAt: finishedAt,
+	});
 	const writeIntervals = requireBoundedDiagnosticIntervals({
 		diagnostics,
 		indices,
@@ -630,6 +802,21 @@ const validateReadTransferEvidence = (
 		readStartedAt: startedAt,
 		readFinishedAt: finishedAt,
 	});
+	for (const [offset, index] of indices.entries()) {
+		if (
+			resolveIntervals.finished[offset] >
+				materializeIntervals.started[offset] ||
+			materializeIntervals.finished[offset] > hashIntervals.started[offset] ||
+			hashIntervals.finished[offset] > writeIntervals.started[offset] ||
+			(offset > 0 &&
+				materializeIntervals.started[offset] <
+					writeIntervals.finished[offset - 1])
+		) {
+			throw new Error(
+				`Benchmark chunk ${index} resolve/materialize/hash/write lifecycle is not causal`,
+			);
+		}
+	}
 	const libraryStreamWallMs = finishedAt - startedAt;
 	const sinkWriteAwaitMs = sum(writeIntervals.durations);
 	const sinkAwaitSubtractedDiagnosticMs =
@@ -645,6 +832,75 @@ const validateReadTransferEvidence = (
 			left.localeCompare(right),
 		),
 	);
+	if (typeof diagnostics.persistChunkReads !== "boolean") {
+		throw new Error(
+			"Benchmark readerDiagnostics.persistChunkReads must be a boolean",
+		);
+	}
+	const availableMilestones = buildReceiverProgressMilestones({
+		chunkBytes,
+		confirmedAt: materializeIntervals.finished,
+		readStartedAt: startedAt,
+		readFinishedAt: finishedAt,
+		label: "readerDiagnostics.chunkMaterializeFinishedAt",
+	});
+	const sinkAcceptedMilestones = buildReceiverProgressMilestones({
+		chunkBytes,
+		confirmedAt: writeIntervals.finished,
+		readStartedAt: startedAt,
+		readFinishedAt: finishedAt,
+		label: "readerDiagnostics.chunkWriteFinishedAt",
+	});
+	let peerbitDurableMilestones = null;
+	const peerbitDurableSourceCounts = {};
+	if (diagnostics.persistChunkReads) {
+		const peerbitDurableAt = requireExactDiagnosticSeries(
+			diagnostics,
+			"chunkPersistenceConfirmedAt",
+			indices,
+			requireNonNegativeSafeInteger,
+		);
+		const persistenceSources = requireRecord(
+			diagnostics.chunkPersistenceConfirmationSource,
+			"readerDiagnostics.chunkPersistenceConfirmationSource",
+		);
+		requireExactRecordKeys(
+			persistenceSources,
+			indices.map(String),
+			"readerDiagnostics.chunkPersistenceConfirmationSource",
+		);
+		for (const index of indices) {
+			const source = requireString(
+				persistenceSources[index],
+				`readerDiagnostics.chunkPersistenceConfirmationSource[${index}]`,
+			);
+			if (!PERSISTENCE_CONFIRMATION_SOURCES.has(source)) {
+				throw new Error(
+					`Benchmark readerDiagnostics.chunkPersistenceConfirmationSource[${index}] is not a recognized persistence source`,
+				);
+			}
+			peerbitDurableSourceCounts[source] =
+				(peerbitDurableSourceCounts[source] ?? 0) + 1;
+		}
+		peerbitDurableMilestones = buildReceiverProgressMilestones({
+			chunkBytes,
+			confirmedAt: peerbitDurableAt,
+			readStartedAt: startedAt,
+			readFinishedAt: finishedAt,
+			label: "readerDiagnostics.chunkPersistenceConfirmedAt",
+		});
+	} else {
+		for (const name of [
+			"chunkPersistenceConfirmedAt",
+			"chunkPersistenceConfirmationSource",
+		]) {
+			requireExactRecordKeys(
+				requireRecord(diagnostics[name], `readerDiagnostics.${name}`),
+				[],
+				`readerDiagnostics.${name}`,
+			);
+		}
+	}
 	const expectedReadTransfer = {
 		chunkCount: indices.length,
 		totalBytes,
@@ -675,6 +931,35 @@ const validateReadTransferEvidence = (
 					materializeSumMs -
 					contentHashSumMs,
 			),
+		},
+		receiverProgress: {
+			percentages: [...RECEIVER_PROGRESS_PERCENTAGES],
+			available: {
+				definition:
+					"contiguous file-prefix bytes materialized and available to the receiver library",
+				source: "chunkMaterializeFinishedAt",
+				milestones: availableMilestones,
+			},
+			peerbitDurable: {
+				definition:
+					"contiguous file-prefix bytes whose exact signed manifest-entry blocks were confirmed in the receiver's local Peerbit block store",
+				source: "chunkPersistenceConfirmedAt",
+				claimed: diagnostics.persistChunkReads,
+				sourceCounts: Object.fromEntries(
+					Object.entries(peerbitDurableSourceCounts).sort(([left], [right]) =>
+						left.localeCompare(right),
+					),
+				),
+				milestones: peerbitDurableMilestones,
+			},
+			sinkAccepted: {
+				definition:
+					"contiguous file-prefix bytes accepted by the configured benchmark sink; this is not a Peerbit or filesystem durability claim",
+				source: "chunkWriteFinishedAt",
+				sink: invocation.downloadSink,
+				durable: false,
+				milestones: sinkAcceptedMilestones,
+			},
 		},
 	};
 	if (
@@ -829,6 +1114,12 @@ const validateMemorySeriesWindow = (
 		downloadStartedAt,
 		downloadFinishedAt,
 		downloadCompletionObservedAt,
+		postTransferSoakStartedAt,
+		postTransferSoakFinishedAt,
+		afterSoakStartedAt,
+		shutdownStartedAt,
+		shutdownFinishedAt,
+		liveSampleMaxGapMs,
 	},
 ) => {
 	const startedAt = requirePositiveSafeInteger(
@@ -844,13 +1135,30 @@ const validateMemorySeriesWindow = (
 		!Array.isArray(series.samples) ||
 		series.sampleCount !== series.samples.length ||
 		!Number.isSafeInteger(series.sampleCount) ||
-		series.sampleCount < 2 ||
+		series.sampleCount < DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE ||
 		series.sampleCount > maxSamples ||
+		series.maxSamples !== maxSamples ||
+		series.periodicSampleLimit !==
+			maxSamples - DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE ||
+		!Number.isSafeInteger(series.periodicSampleCount) ||
+		series.periodicSampleCount < 0 ||
+		series.periodicSampleCount > series.periodicSampleLimit ||
+		series.sampleCount !==
+			series.periodicSampleCount + DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE ||
+		series.capacityExhaustedBeforeTerminal !== false ||
+		series.samplingCapacitySufficient !== true ||
+		series.manualSampleCount !== 1 ||
+		series.terminalSampleAttempted !== true ||
+		series.terminalSampleCaptured !== true ||
 		finishedAt < startedAt
 	) {
 		throw new Error(`Benchmark ${label} has an invalid bounded sample series`);
 	}
 	let previousCapturedAt = null;
+	let initialSampleCount = 0;
+	let periodicSampleCount = 0;
+	let manualSample = null;
+	let terminalSample = null;
 	for (const [index, sampleValue] of series.samples.entries()) {
 		const sample = requireRecord(sampleValue, `${label}.samples[${index}]`);
 		const capturedAt = requirePositiveSafeInteger(
@@ -866,7 +1174,58 @@ const validateMemorySeriesWindow = (
 				`Benchmark ${label} sample timestamps are outside or reorder the sampler window`,
 			);
 		}
+		if (sample.sampleKind === "initial") {
+			initialSampleCount += 1;
+		} else if (sample.sampleKind === "periodic") {
+			periodicSampleCount += 1;
+		} else if (sample.sampleKind === "manual") {
+			if (manualSample !== null) {
+				throw new Error(`Benchmark ${label} contains duplicate manual samples`);
+			}
+			manualSample = { index, capturedAt };
+		} else if (sample.sampleKind === "terminal") {
+			if (terminalSample !== null) {
+				throw new Error(
+					`Benchmark ${label} contains duplicate terminal samples`,
+				);
+			}
+			terminalSample = { index, capturedAt };
+		} else {
+			throw new Error(`Benchmark ${label} contains an invalid sample kind`);
+		}
 		previousCapturedAt = capturedAt;
+	}
+	const lastManualSampleAt = requirePositiveSafeInteger(
+		series.lastManualSampleAt,
+		`${label}.lastManualSampleAt`,
+	);
+	const terminalSampleAt = requirePositiveSafeInteger(
+		series.terminalSampleAt,
+		`${label}.terminalSampleAt`,
+	);
+	if (
+		initialSampleCount !== 1 ||
+		series.samples[0].sampleKind !== "initial" ||
+		periodicSampleCount !== series.periodicSampleCount ||
+		manualSample === null ||
+		manualSample.index === 0 ||
+		manualSample.index === series.samples.length - 1 ||
+		manualSample.capturedAt !== lastManualSampleAt ||
+		manualSample.capturedAt < postTransferSoakFinishedAt ||
+		manualSample.capturedAt > afterSoakStartedAt ||
+		manualSample.capturedAt - postTransferSoakFinishedAt >
+			liveSampleMaxGapMs - DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS ||
+		manualSample.capturedAt > shutdownStartedAt ||
+		terminalSample === null ||
+		terminalSample.index !== series.samples.length - 1 ||
+		series.samples.at(-1).sampleKind !== "terminal" ||
+		terminalSample.capturedAt !== terminalSampleAt ||
+		terminalSample.capturedAt < shutdownFinishedAt ||
+		manualSample.index >= terminalSample.index
+	) {
+		throw new Error(
+			`Benchmark ${label} has invalid live or terminal checkpoint ordering`,
+		);
 	}
 	const firstCapturedAt = series.samples[0].capturedAt;
 	const lastCapturedAt = series.samples.at(-1).capturedAt;
@@ -874,10 +1233,12 @@ const validateMemorySeriesWindow = (
 		startedAt > downloadStartedAt ||
 		firstCapturedAt > downloadStartedAt ||
 		lastCapturedAt < downloadCompletionObservedAt ||
-		finishedAt < downloadCompletionObservedAt
+		finishedAt < downloadCompletionObservedAt ||
+		lastCapturedAt < shutdownFinishedAt ||
+		finishedAt < shutdownFinishedAt
 	) {
 		throw new Error(
-			`Benchmark ${label} does not bracket the click-to-sink observation window`,
+			`Benchmark ${label} does not bracket the click-to-post-shutdown observation window`,
 		);
 	}
 	if (
@@ -890,9 +1251,8 @@ const validateMemorySeriesWindow = (
 	}
 	if (
 		lastCapturedAt >
-			downloadCompletionObservedAt + DOWNLOAD_MEMORY_TERMINAL_ALLOWANCE_MS ||
-		finishedAt >
-			downloadCompletionObservedAt + DOWNLOAD_MEMORY_TERMINAL_ALLOWANCE_MS
+			shutdownFinishedAt + DOWNLOAD_MEMORY_TERMINAL_ALLOWANCE_MS ||
+		finishedAt > shutdownFinishedAt + DOWNLOAD_MEMORY_TERMINAL_ALLOWANCE_MS
 	) {
 		throw new Error(
 			`Benchmark ${label} ends after the bounded telemetry cleanup window`,
@@ -909,6 +1269,18 @@ const validateMemorySeriesWindow = (
 		);
 	}
 	validateMemorySamplingErrors(series, label);
+	for (const [phase, phaseStartedAt, phaseFinishedAt] of [
+		["transfer", downloadStartedAt, downloadFinishedAt],
+		["soak", postTransferSoakStartedAt, postTransferSoakFinishedAt],
+	]) {
+		assertDownloadMemoryLiveSampleCoverage({
+			samples: series.samples,
+			phaseStartedAt,
+			phaseFinishedAt,
+			maxGapMs: liveSampleMaxGapMs,
+			label: `${label}.${phase}`,
+		});
+	}
 	return { startedAt, finishedAt };
 };
 
@@ -934,18 +1306,40 @@ const validateHeapMemorySeries = (
 			"startBytes",
 			"endBytes",
 			"peakBytes",
+			"startUsedBytes",
+			"endUsedBytes",
+			"peakUsedBytes",
+			"startTotalBytes",
+			"endTotalBytes",
+			"peakTotalBytes",
+			"startEmbedderHeapUsedBytes",
+			"endEmbedderHeapUsedBytes",
+			"peakEmbedderHeapUsedBytes",
+			"startBackingStorageBytes",
+			"endBackingStorageBytes",
+			"peakBackingStorageBytes",
 			"samples",
 			"samplingErrors",
 			"samplingErrorOverflowCount",
 			"cleanupWarnings",
 			"cleanupWarningOverflowCount",
+			"maxSamples",
+			"periodicSampleLimit",
+			"periodicSampleCount",
+			"capacityExhaustedBeforeTerminal",
+			"samplingCapacitySufficient",
+			"manualSampleCount",
+			"lastManualSampleAt",
+			"terminalSampleAttempted",
+			"terminalSampleCaptured",
+			"terminalSampleAt",
 		],
 		label,
 	);
 	if (
-		series.memoryKind !== "javascript-heap" ||
+		series.memoryKind !== "runtime-heap" ||
 		series.scope !== expectedScope ||
-		series.metric !== "JSHeapUsedSize" ||
+		series.metric !== "Runtime.getHeapUsage" ||
 		series.unit !== "bytes"
 	) {
 		throw new Error(`Benchmark ${label} has invalid heap attribution`);
@@ -956,21 +1350,62 @@ const validateHeapMemorySeries = (
 		maxSamples,
 		readWindow,
 	);
-	const values = series.samples.map((sample, index) => {
+	const samples = series.samples.map((sample, index) => {
 		requireExactRecordKeys(
 			sample,
-			["capturedAt", "usedBytes"],
+			[
+				"capturedAt",
+				"sampleKind",
+				"usedBytes",
+				"totalBytes",
+				"embedderHeapUsedBytes",
+				"backingStorageBytes",
+			],
 			`${label}.samples[${index}]`,
 		);
-		return requireNonNegativeNumber(
-			sample.usedBytes,
-			`${label}.samples[${index}].usedBytes`,
-		);
+		const sampleLabel = `${label}.samples[${index}]`;
+		const values = {
+			usedBytes: requireNonNegativeSafeInteger(
+				sample.usedBytes,
+				`${sampleLabel}.usedBytes`,
+			),
+			totalBytes: requireNonNegativeSafeInteger(
+				sample.totalBytes,
+				`${sampleLabel}.totalBytes`,
+			),
+			embedderHeapUsedBytes: requireNonNegativeSafeInteger(
+				sample.embedderHeapUsedBytes,
+				`${sampleLabel}.embedderHeapUsedBytes`,
+			),
+			backingStorageBytes: requireNonNegativeSafeInteger(
+				sample.backingStorageBytes,
+				`${sampleLabel}.backingStorageBytes`,
+			),
+		};
+		if (values.usedBytes > values.totalBytes) {
+			throw new Error(`Benchmark ${sampleLabel} heap totals are inconsistent`);
+		}
+		return values;
 	});
+	const first = samples[0];
+	const last = samples.at(-1);
+	const peak = (name) => Math.max(...samples.map((sample) => sample[name]));
 	if (
-		series.startBytes !== values[0] ||
-		series.endBytes !== values.at(-1) ||
-		series.peakBytes !== Math.max(...values)
+		series.startBytes !== first.usedBytes ||
+		series.endBytes !== last.usedBytes ||
+		series.peakBytes !== peak("usedBytes") ||
+		series.startUsedBytes !== first.usedBytes ||
+		series.endUsedBytes !== last.usedBytes ||
+		series.peakUsedBytes !== peak("usedBytes") ||
+		series.startTotalBytes !== first.totalBytes ||
+		series.endTotalBytes !== last.totalBytes ||
+		series.peakTotalBytes !== peak("totalBytes") ||
+		series.startEmbedderHeapUsedBytes !== first.embedderHeapUsedBytes ||
+		series.endEmbedderHeapUsedBytes !== last.embedderHeapUsedBytes ||
+		series.peakEmbedderHeapUsedBytes !== peak("embedderHeapUsedBytes") ||
+		series.startBackingStorageBytes !== first.backingStorageBytes ||
+		series.endBackingStorageBytes !== last.backingStorageBytes ||
+		series.peakBackingStorageBytes !== peak("backingStorageBytes")
 	) {
 		throw new Error(`Benchmark ${label} heap summaries are inconsistent`);
 	}
@@ -1023,6 +1458,12 @@ const validateHostRssSeries = (seriesValue, maxSamples, readWindow) => {
 			"startNodeBytes",
 			"endNodeBytes",
 			"peakNodeBytes",
+			"startNodeExternalBytes",
+			"endNodeExternalBytes",
+			"peakNodeExternalBytes",
+			"startNodeArrayBuffersBytes",
+			"endNodeArrayBuffersBytes",
+			"peakNodeArrayBuffersBytes",
 			"startCombinedBytes",
 			"endCombinedBytes",
 			"peakCombinedBytes",
@@ -1037,6 +1478,16 @@ const validateHostRssSeries = (seriesValue, maxSamples, readWindow) => {
 			"samplingErrorOverflowCount",
 			"cleanupWarnings",
 			"cleanupWarningOverflowCount",
+			"maxSamples",
+			"periodicSampleLimit",
+			"periodicSampleCount",
+			"capacityExhaustedBeforeTerminal",
+			"samplingCapacitySufficient",
+			"manualSampleCount",
+			"lastManualSampleAt",
+			"terminalSampleAttempted",
+			"terminalSampleCaptured",
+			"terminalSampleAt",
 		],
 		label,
 	);
@@ -1065,8 +1516,11 @@ const validateHostRssSeries = (seriesValue, maxSamples, readWindow) => {
 			sample,
 			[
 				"capturedAt",
+				"sampleKind",
 				"browserBytes",
 				"nodeBytes",
+				"nodeExternalBytes",
+				"nodeArrayBuffersBytes",
 				"combinedBytes",
 				"browserProcessCount",
 				"browserRoleBytes",
@@ -1080,6 +1534,14 @@ const validateHostRssSeries = (seriesValue, maxSamples, readWindow) => {
 		const nodeBytes = requirePositiveSafeInteger(
 			sample.nodeBytes,
 			`${sampleLabel}.nodeBytes`,
+		);
+		const nodeExternalBytes = requireNonNegativeSafeInteger(
+			sample.nodeExternalBytes,
+			`${sampleLabel}.nodeExternalBytes`,
+		);
+		const nodeArrayBuffersBytes = requireNonNegativeSafeInteger(
+			sample.nodeArrayBuffersBytes,
+			`${sampleLabel}.nodeArrayBuffersBytes`,
 		);
 		const combinedBytes = requirePositiveSafeInteger(
 			sample.combinedBytes,
@@ -1114,6 +1576,8 @@ const validateHostRssSeries = (seriesValue, maxSamples, readWindow) => {
 		return {
 			browserBytes,
 			nodeBytes,
+			nodeExternalBytes,
+			nodeArrayBuffersBytes,
 			combinedBytes,
 			browserProcessCount,
 			browserRoleBytes,
@@ -1129,6 +1593,12 @@ const validateHostRssSeries = (seriesValue, maxSamples, readWindow) => {
 		series.startNodeBytes !== first.nodeBytes ||
 		series.endNodeBytes !== last.nodeBytes ||
 		series.peakNodeBytes !== peak("nodeBytes") ||
+		series.startNodeExternalBytes !== first.nodeExternalBytes ||
+		series.endNodeExternalBytes !== last.nodeExternalBytes ||
+		series.peakNodeExternalBytes !== peak("nodeExternalBytes") ||
+		series.startNodeArrayBuffersBytes !== first.nodeArrayBuffersBytes ||
+		series.endNodeArrayBuffersBytes !== last.nodeArrayBuffersBytes ||
+		series.peakNodeArrayBuffersBytes !== peak("nodeArrayBuffersBytes") ||
 		series.startCombinedBytes !== first.combinedBytes ||
 		series.endCombinedBytes !== last.combinedBytes ||
 		series.peakCombinedBytes !== peak("combinedBytes") ||
@@ -1159,7 +1629,19 @@ export const validateDownloadMemoryTelemetry = (
 			"profile",
 			"sampleIntervalMs",
 			"windowDefinition",
+			"downloadTimeoutMs",
+			"schedulingToleranceMs",
+			"operationTimeoutMs",
+			"postTransferSoakMs",
+			"samplingWindowBudgetMs",
+			"liveSampleMaxGapMs",
+			"liveSampleCoverageDefinition",
+			"endpointSampleAllowance",
 			"maxSamplesPerSeries",
+			"capacityExhaustedBeforeTerminal",
+			"samplingCapacitySufficient",
+			"manualCheckpointComplete",
+			"terminalCheckpointComplete",
 			"complete",
 			"cleanupComplete",
 			"startedAt",
@@ -1170,15 +1652,37 @@ export const validateDownloadMemoryTelemetry = (
 		],
 		"downloadMemoryTelemetry",
 	);
+	const expectedSchedulingToleranceMs = Math.max(
+		5_000,
+		invocation.pollMs + 1_000,
+	);
+	const expectedSamplingWindowBudgetMs =
+		calculateUploadSamplingWindowBudgetMs(invocation);
+	const expectedLiveSampleMaxGapMs = calculateDownloadMemoryMaxLiveSampleGapMs({
+		schedulingToleranceMs: expectedSchedulingToleranceMs,
+	});
 	const expectedMaxSamples = calculateDownloadMemoryMaxSamples({
-		downloadTimeoutMs: invocation.downloadTimeoutMs,
-		schedulingToleranceMs: Math.max(5_000, invocation.pollMs + 1_000),
+		samplingWindowBudgetMs: expectedSamplingWindowBudgetMs,
 	});
 	if (
 		telemetry.profile !== DOWNLOAD_MEMORY_PROFILE ||
 		telemetry.sampleIntervalMs !== DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS ||
 		telemetry.windowDefinition !== DOWNLOAD_MEMORY_WINDOW_DEFINITION ||
+		telemetry.downloadTimeoutMs !== invocation.downloadTimeoutMs ||
+		telemetry.schedulingToleranceMs !== expectedSchedulingToleranceMs ||
+		telemetry.operationTimeoutMs !== DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS ||
+		telemetry.postTransferSoakMs !== invocation.postTransferSoakMs ||
+		telemetry.samplingWindowBudgetMs !== expectedSamplingWindowBudgetMs ||
+		telemetry.liveSampleMaxGapMs !== expectedLiveSampleMaxGapMs ||
+		telemetry.liveSampleCoverageDefinition !==
+			DOWNLOAD_MEMORY_LIVE_SAMPLE_COVERAGE_DEFINITION ||
+		telemetry.endpointSampleAllowance !==
+			DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE ||
 		telemetry.maxSamplesPerSeries !== expectedMaxSamples ||
+		telemetry.capacityExhaustedBeforeTerminal !== false ||
+		telemetry.samplingCapacitySufficient !== true ||
+		telemetry.manualCheckpointComplete !== true ||
+		telemetry.terminalCheckpointComplete !== true ||
 		telemetry.complete !== true ||
 		telemetry.cleanupComplete !== true
 	) {
@@ -1189,19 +1693,19 @@ export const validateDownloadMemoryTelemetry = (
 		"downloadMemoryTelemetry.readerJsHeap",
 		"reader-renderer",
 		expectedMaxSamples,
-		readWindow,
+		{ ...readWindow, liveSampleMaxGapMs: expectedLiveSampleMaxGapMs },
 	);
 	const writerWindow = validateHeapMemorySeries(
 		telemetry.writerJsHeap,
 		"downloadMemoryTelemetry.writerJsHeap",
 		"writer-renderer",
 		expectedMaxSamples,
-		readWindow,
+		{ ...readWindow, liveSampleMaxGapMs: expectedLiveSampleMaxGapMs },
 	);
 	const hostWindow = validateHostRssSeries(
 		telemetry.hostRss,
 		expectedMaxSamples,
-		readWindow,
+		{ ...readWindow, liveSampleMaxGapMs: expectedLiveSampleMaxGapMs },
 	);
 	const expectedStartedAt = Math.min(
 		readerWindow.startedAt,
@@ -1224,7 +1728,7 @@ export const validateDownloadMemoryTelemetry = (
 	return telemetry;
 };
 
-const validateUploadTimings = (result, invocation) => {
+const validateUploadTimings = (result, invocation, integrityVerifiedAt) => {
 	if (result.downloadDurationDefinition !== DOWNLOAD_DURATION_DEFINITION) {
 		throw new Error("Benchmark download duration definition is invalid");
 	}
@@ -1319,6 +1823,14 @@ const validateUploadTimings = (result, invocation) => {
 	const downloadCompletionObservedAt = requirePositiveSafeInteger(
 		timestamps.downloadCompletionObservedAt,
 		"timestamps.downloadCompletionObservedAt",
+	);
+	const postTransferSoakStartedAt = requirePositiveSafeInteger(
+		timestamps.postTransferSoakStartedAt,
+		"timestamps.postTransferSoakStartedAt",
+	);
+	const postTransferSoakFinishedAt = requirePositiveSafeInteger(
+		timestamps.postTransferSoakFinishedAt,
+		"timestamps.postTransferSoakFinishedAt",
 	);
 	if (
 		uploadSettledAt <= uploadStartedAt ||
@@ -1429,11 +1941,42 @@ const validateUploadTimings = (result, invocation) => {
 			"Measured transfer duration exceeded its requested timeout and scheduling tolerance",
 		);
 	}
-	return validateReadTransferEvidence(result, invocation, {
-		downloadStartedAt,
-		downloadFinishedAt,
-		downloadCompletionObservedAt,
-	});
+	const expectedPostTransferSoakTolerance = Math.max(
+		250,
+		invocation.pollMs + 250,
+	);
+	const postTransferSoakActualMs = requireNonNegativeSafeInteger(
+		result.postTransferSoakActualMs,
+		"postTransferSoakActualMs",
+	);
+	if (
+		postTransferSoakStartedAt < downloadCompletionObservedAt ||
+		postTransferSoakStartedAt < integrityVerifiedAt ||
+		postTransferSoakFinishedAt < postTransferSoakStartedAt ||
+		result.postTransferSoakDefinition !== POST_TRANSFER_SOAK_DEFINITION ||
+		result.postTransferSoakSchedulingToleranceMs !==
+			expectedPostTransferSoakTolerance ||
+		result.postTransferSoakSchedulingToleranceDefinition !==
+			POST_TRANSFER_SOAK_SCHEDULING_TOLERANCE_DEFINITION ||
+		postTransferSoakActualMs !==
+			postTransferSoakFinishedAt - postTransferSoakStartedAt ||
+		postTransferSoakActualMs < invocation.postTransferSoakMs ||
+		postTransferSoakActualMs >
+			invocation.postTransferSoakMs + expectedPostTransferSoakTolerance
+	) {
+		throw new Error(
+			"Benchmark post-transfer soak duration or scheduling contract is invalid",
+		);
+	}
+	return {
+		...validateReadTransferEvidence(result, invocation, {
+			downloadStartedAt,
+			downloadFinishedAt,
+			downloadCompletionObservedAt,
+		}),
+		postTransferSoakStartedAt,
+		postTransferSoakFinishedAt,
+	};
 };
 
 const validateUploadProgressTelemetry = (result, invocation) => {
@@ -1881,7 +2424,7 @@ const validateEnvelope = (
 	);
 	if (
 		invocationSchema.id !== "peerbit-file-share-benchmark-invocation" ||
-		invocationSchema.version !== 4
+		invocationSchema.version !== 5
 	) {
 		throw new Error("Benchmark result has an unsupported invocation schema");
 	}
@@ -1910,6 +2453,7 @@ const validateEnvelope = (
 const validateRequestedUploadKnobs = (result, invocation) => {
 	for (const [resultKey, invocationKey] of [
 		["postUploadMonitorMs", "postUploadMonitorMs"],
+		["postTransferSoakMs", "postTransferSoakMs"],
 		["pollMs", "pollMs"],
 		["uploadTimeoutMs", "uploadTimeoutMs"],
 		["downloadTimeoutMs", "downloadTimeoutMs"],
@@ -1940,6 +2484,645 @@ const validateRequestedUploadKnobs = (result, invocation) => {
 			"Benchmark result readerTerminalTopology does not match the requested invocation",
 		);
 	}
+};
+
+const validateStorageUsageDetails = (value, label) => {
+	if (value === null) {
+		return null;
+	}
+	const details = requireRecord(value, label);
+	const entries = Object.entries(details);
+	if (entries.length > RESOURCE_MAX_STORAGE_DETAIL_KEYS) {
+		throw new Error(`Benchmark ${label} contains too many storage categories`);
+	}
+	for (const [key, bytes] of entries) {
+		if (
+			key.length === 0 ||
+			key.length > RESOURCE_MAX_STORAGE_DETAIL_KEY_LENGTH ||
+			!/^\S(?:.*\S)?$/.test(key)
+		) {
+			throw new Error(
+				`Benchmark ${label} contains an invalid storage category`,
+			);
+		}
+		requireNonNegativeSafeInteger(bytes, `${label}.${key}`);
+	}
+	return details;
+};
+
+const validateStorageResourceSnapshot = (
+	value,
+	label,
+	{ setStartedAt, pageCapturedAt },
+) => {
+	const storage = requireExactRecordKeys(
+		requireRecord(value, label),
+		["capturedAt", "origin", "peerbitLog", "backingStorage"],
+		label,
+	);
+	const capturedAt = requirePositiveSafeInteger(
+		storage.capturedAt,
+		`${label}.capturedAt`,
+	);
+	if (capturedAt < setStartedAt || capturedAt > pageCapturedAt) {
+		throw new Error(
+			`Benchmark ${label} is outside its resource capture window`,
+		);
+	}
+	const origin = requireString(storage.origin, `${label}.origin`);
+	let parsedOrigin;
+	try {
+		parsedOrigin = new URL(origin).origin;
+	} catch {
+		throw new Error(`Benchmark result has invalid ${label}.origin`);
+	}
+	if (parsedOrigin !== origin) {
+		throw new Error(`Benchmark result has invalid ${label}.origin`);
+	}
+	const peerbitLog = requireExactRecordKeys(
+		requireRecord(storage.peerbitLog, `${label}.peerbitLog`),
+		["api", "scope", "available", "usageBytes", "error"],
+		`${label}.peerbitLog`,
+	);
+	if (
+		peerbitLog.api !== "SharedLog.getMemoryUsage" ||
+		peerbitLog.scope !== "file-share-log-logical-usage" ||
+		peerbitLog.available !== true ||
+		peerbitLog.error !== null
+	) {
+		throw new Error(`Benchmark ${label}.peerbitLog contract is invalid`);
+	}
+	requireNonNegativeSafeInteger(
+		peerbitLog.usageBytes,
+		`${label}.peerbitLog.usageBytes`,
+	);
+	const backingStorage = requireExactRecordKeys(
+		requireRecord(storage.backingStorage, `${label}.backingStorage`),
+		[
+			"api",
+			"scope",
+			"available",
+			"usageBytes",
+			"quotaBytes",
+			"usageDetails",
+			"error",
+		],
+		`${label}.backingStorage`,
+	);
+	if (
+		backingStorage.api !== "navigator.storage.estimate" ||
+		backingStorage.scope !== "browser-origin-aggregate" ||
+		backingStorage.available !== true ||
+		backingStorage.error !== null
+	) {
+		throw new Error(`Benchmark ${label}.backingStorage contract is invalid`);
+	}
+	const usageBytes = requireNonNegativeSafeInteger(
+		backingStorage.usageBytes,
+		`${label}.backingStorage.usageBytes`,
+	);
+	const quotaBytes = requireNonNegativeSafeInteger(
+		backingStorage.quotaBytes,
+		`${label}.backingStorage.quotaBytes`,
+	);
+	if (quotaBytes < usageBytes) {
+		throw new Error(`Benchmark ${label}.backingStorage exceeds its quota`);
+	}
+	validateStorageUsageDetails(
+		backingStorage.usageDetails,
+		`${label}.backingStorage.usageDetails`,
+	);
+	return storage;
+};
+
+const validateEagerTelemetry = (value, label) => {
+	const telemetry = requireExactRecordKeys(
+		requireRecord(value, label),
+		EAGER_TELEMETRY_KEYS,
+		label,
+	);
+	for (const key of EAGER_TELEMETRY_KEYS.filter((key) => key !== "limits")) {
+		requireNonNegativeSafeInteger(telemetry[key], `${label}.${key}`);
+	}
+	const limits = requireExactRecordKeys(
+		requireRecord(telemetry.limits, `${label}.limits`),
+		EAGER_LIMIT_KEYS,
+		`${label}.limits`,
+	);
+	for (const key of EAGER_LIMIT_KEYS) {
+		requirePositiveSafeInteger(limits[key], `${label}.limits.${key}`);
+	}
+	if (
+		telemetry.entries > telemetry.peakEntries ||
+		telemetry.peakEntries > limits.maxEntries ||
+		telemetry.bytes > telemetry.peakBytes ||
+		telemetry.peakBytes > limits.maxBytes ||
+		telemetry.pendingEntries > telemetry.peakPendingEntries ||
+		telemetry.peakPendingEntries > limits.maxPendingEntries ||
+		telemetry.pendingBytes > telemetry.peakPendingBytes ||
+		telemetry.peakPendingBytes > limits.maxPendingBytes
+	) {
+		throw new Error(
+			`Benchmark ${label} eager-cache gauges exceed their bounds`,
+		);
+	}
+	return telemetry;
+};
+
+const RUNTIME_IDENTITY_KEYS = Object.freeze([
+	"programAddress",
+	"peerId",
+	"peerHash",
+	"sessionId",
+]);
+
+const validateRuntimeIdentity = (value, label) => {
+	const identity = requireExactRecordKeys(
+		requireRecord(value, label),
+		RUNTIME_IDENTITY_KEYS,
+		label,
+	);
+	for (const key of RUNTIME_IDENTITY_KEYS) {
+		requireString(identity[key], `${label}.${key}`);
+	}
+	return identity;
+};
+
+const validateRuntimeResourceSnapshot = (
+	value,
+	label,
+	{ setStartedAt, pageCapturedAt },
+) => {
+	const runtime = requireExactRecordKeys(
+		requireRecord(value, label),
+		[
+			"capturedAt",
+			"programReady",
+			"identity",
+			"nativeGraph",
+			"eagerBlocks",
+			"pubsub",
+		],
+		label,
+	);
+	const capturedAt = requirePositiveSafeInteger(
+		runtime.capturedAt,
+		`${label}.capturedAt`,
+	);
+	if (capturedAt < setStartedAt || capturedAt > pageCapturedAt) {
+		throw new Error(
+			`Benchmark ${label} is outside its resource capture window`,
+		);
+	}
+	if (runtime.programReady !== true) {
+		throw new Error(`Benchmark ${label} did not capture a ready program`);
+	}
+	validateRuntimeIdentity(runtime.identity, `${label}.identity`);
+	const nativeGraph = requireExactRecordKeys(
+		requireRecord(runtime.nativeGraph, `${label}.nativeGraph`),
+		["active", "useHeads"],
+		`${label}.nativeGraph`,
+	);
+	if (
+		typeof nativeGraph.active !== "boolean" ||
+		typeof nativeGraph.useHeads !== "boolean" ||
+		(nativeGraph.active === false && nativeGraph.useHeads !== false)
+	) {
+		throw new Error(`Benchmark ${label}.nativeGraph contract is invalid`);
+	}
+	const eagerBlocks = requireExactRecordKeys(
+		requireRecord(runtime.eagerBlocks, `${label}.eagerBlocks`),
+		["telemetryAvailable", "enabled", "telemetry"],
+		`${label}.eagerBlocks`,
+	);
+	if (
+		eagerBlocks.telemetryAvailable !== true ||
+		typeof eagerBlocks.enabled !== "boolean"
+	) {
+		throw new Error(`Benchmark ${label}.eagerBlocks contract is invalid`);
+	}
+	if (eagerBlocks.enabled) {
+		validateEagerTelemetry(
+			eagerBlocks.telemetry,
+			`${label}.eagerBlocks.telemetry`,
+		);
+	} else if (eagerBlocks.telemetry !== null) {
+		throw new Error(
+			`Benchmark ${label}.eagerBlocks disabled state contains telemetry`,
+		);
+	}
+	const pubsub = requireExactRecordKeys(
+		requireRecord(runtime.pubsub, `${label}.pubsub`),
+		["runtimeSnapshotAvailable", "snapshot", "error"],
+		`${label}.pubsub`,
+	);
+	if (pubsub.runtimeSnapshotAvailable !== true || pubsub.error !== null) {
+		throw new Error(
+			`Benchmark ${label}.pubsub runtime evidence is unavailable`,
+		);
+	}
+	const pubsubSnapshot = requireExactRecordKeys(
+		requireRecord(pubsub.snapshot, `${label}.pubsub.snapshot`),
+		["fanout"],
+		`${label}.pubsub.snapshot`,
+	);
+	const fanout = requireExactRecordKeys(
+		requireRecord(pubsubSnapshot.fanout, `${label}.pubsub.snapshot.fanout`),
+		["root", "node"],
+		`${label}.pubsub.snapshot.fanout`,
+	);
+	for (const tier of ["root", "node"]) {
+		const tierSnapshot = requireExactRecordKeys(
+			requireRecord(fanout[tier], `${label}.pubsub.snapshot.fanout.${tier}`),
+			["uploadLimitBps"],
+			`${label}.pubsub.snapshot.fanout.${tier}`,
+		);
+		requirePositiveSafeInteger(
+			tierSnapshot.uploadLimitBps,
+			`${label}.pubsub.snapshot.fanout.${tier}.uploadLimitBps`,
+		);
+	}
+	return runtime;
+};
+
+const validatePageResourceSnapshot = (
+	value,
+	role,
+	{ setStartedAt, setFinishedAt, setLabel },
+) => {
+	const label = `resourceEvidence.snapshots.${setLabel}.${role}`;
+	const page = requireExactRecordKeys(
+		requireRecord(value, label),
+		["role", "capturedAt", "storage", "runtime"],
+		label,
+	);
+	const capturedAt = requirePositiveSafeInteger(
+		page.capturedAt,
+		`${label}.capturedAt`,
+	);
+	if (
+		page.role !== role ||
+		capturedAt < setStartedAt ||
+		capturedAt > setFinishedAt
+	) {
+		throw new Error(`Benchmark ${label} capture ordering is invalid`);
+	}
+	validateStorageResourceSnapshot(page.storage, `${label}.storage`, {
+		setStartedAt,
+		pageCapturedAt: capturedAt,
+	});
+	validateRuntimeResourceSnapshot(page.runtime, `${label}.runtime`, {
+		setStartedAt,
+		pageCapturedAt: capturedAt,
+	});
+	return page;
+};
+
+const validateResourceSnapshotSet = (value, expectedLabel, invocation) => {
+	const label = `resourceEvidence.snapshots.${expectedLabel}`;
+	const snapshot = requireExactRecordKeys(
+		requireRecord(value, label),
+		["label", "startedAt", "finishedAt", "writer", "reader"],
+		label,
+	);
+	const startedAt = requirePositiveSafeInteger(
+		snapshot.startedAt,
+		`${label}.startedAt`,
+	);
+	const finishedAt = requirePositiveSafeInteger(
+		snapshot.finishedAt,
+		`${label}.finishedAt`,
+	);
+	const schedulingToleranceMs = Math.max(250, invocation.pollMs + 250);
+	if (
+		snapshot.label !== expectedLabel ||
+		finishedAt < startedAt ||
+		finishedAt - startedAt >
+			RESOURCE_SNAPSHOT_TIMEOUT_MS + schedulingToleranceMs
+	) {
+		throw new Error(
+			`Benchmark ${label} capture window is invalid or unbounded`,
+		);
+	}
+	validatePageResourceSnapshot(snapshot.writer, "writer", {
+		setStartedAt: startedAt,
+		setFinishedAt: finishedAt,
+		setLabel: expectedLabel,
+	});
+	validatePageResourceSnapshot(snapshot.reader, "reader", {
+		setStartedAt: startedAt,
+		setFinishedAt: finishedAt,
+		setLabel: expectedLabel,
+	});
+	return snapshot;
+};
+
+const validateResourceRoleSequence = (snapshots, role) => {
+	const pages = [
+		snapshots.beforeTimedRead[role],
+		snapshots.afterSink[role],
+		snapshots.beforeSoak[role],
+		snapshots.afterSoak[role],
+	];
+	const firstRuntime = pages[0].runtime;
+	const firstOrigin = pages[0].storage.origin;
+	for (const page of pages.slice(1)) {
+		if (
+			page.storage.origin !== firstOrigin ||
+			!isDeepStrictEqual(page.runtime.identity, firstRuntime.identity) ||
+			!isDeepStrictEqual(page.runtime.nativeGraph, firstRuntime.nativeGraph) ||
+			page.runtime.eagerBlocks.telemetryAvailable !==
+				firstRuntime.eagerBlocks.telemetryAvailable ||
+			page.runtime.eagerBlocks.enabled !== firstRuntime.eagerBlocks.enabled ||
+			!isDeepStrictEqual(
+				page.runtime.pubsub.snapshot,
+				firstRuntime.pubsub.snapshot,
+			) ||
+			(page.runtime.eagerBlocks.enabled &&
+				!isDeepStrictEqual(
+					page.runtime.eagerBlocks.telemetry.limits,
+					firstRuntime.eagerBlocks.telemetry.limits,
+				))
+		) {
+			throw new Error(
+				`Benchmark ${role} runtime provenance changed across resource snapshots`,
+			);
+		}
+	}
+	if (!firstRuntime.eagerBlocks.enabled) {
+		return;
+	}
+	for (let index = 1; index < pages.length; index += 1) {
+		const before = pages[index - 1].runtime.eagerBlocks.telemetry;
+		const after = pages[index].runtime.eagerBlocks.telemetry;
+		for (const key of [
+			...EAGER_MONOTONIC_COUNTERS,
+			"peakEntries",
+			"peakBytes",
+			"peakPendingEntries",
+			"peakPendingBytes",
+		]) {
+			if (after[key] < before[key]) {
+				throw new Error(
+					`Benchmark ${role} eager-cache ${key} regressed across resource snapshots`,
+				);
+			}
+		}
+	}
+};
+
+const buildStorageResourceDelta = (before, after, role) => ({
+	role,
+	peerbitLogUsageDeltaBytes:
+		after.storage.peerbitLog.usageBytes - before.storage.peerbitLog.usageBytes,
+	backingStorageUsageDeltaBytes:
+		after.storage.backingStorage.usageBytes -
+		before.storage.backingStorage.usageBytes,
+});
+
+const buildEagerResourceDelta = (before, after) => {
+	const beforeTelemetry = before.runtime.eagerBlocks.telemetry;
+	const afterTelemetry = after.runtime.eagerBlocks.telemetry;
+	if (beforeTelemetry === null && afterTelemetry === null) {
+		return null;
+	}
+	if (beforeTelemetry === null || afterTelemetry === null) {
+		throw new Error(
+			"Benchmark eager-cache availability changed across resource snapshots",
+		);
+	}
+	return Object.fromEntries(
+		EAGER_MONOTONIC_COUNTERS.map((key) => {
+			const delta = afterTelemetry[key] - beforeTelemetry[key];
+			requireNonNegativeSafeInteger(delta, `resource eager delta ${key}`);
+			return [key, delta];
+		}),
+	);
+};
+
+const buildResourceInterval = (before, after) => ({
+	from: before.label,
+	to: after.label,
+	writerStorage: buildStorageResourceDelta(
+		before.writer,
+		after.writer,
+		"writer",
+	),
+	readerStorage: buildStorageResourceDelta(
+		before.reader,
+		after.reader,
+		"reader",
+	),
+	writerEager: buildEagerResourceDelta(before.writer, after.writer),
+	readerEager: buildEagerResourceDelta(before.reader, after.reader),
+});
+
+const validateShutdownOutcome = (
+	value,
+	role,
+	{ terminalSeederCapturedAt, schedulingToleranceMs },
+) => {
+	const label = `shutdownOutcomes.${role}`;
+	const outcome = requireExactRecordKeys(
+		requireRecord(value, label),
+		[
+			"role",
+			"status",
+			"startedAt",
+			"finishedAt",
+			"durationMs",
+			"programClosed",
+			"peerStopped",
+			"identity",
+			"error",
+		],
+		label,
+	);
+	const startedAt = requirePositiveSafeInteger(
+		outcome.startedAt,
+		`${label}.startedAt`,
+	);
+	const finishedAt = requirePositiveSafeInteger(
+		outcome.finishedAt,
+		`${label}.finishedAt`,
+	);
+	const durationMs = requireNonNegativeSafeInteger(
+		outcome.durationMs,
+		`${label}.durationMs`,
+	);
+	const identity = validateRuntimeIdentity(
+		outcome.identity,
+		`${label}.identity`,
+	);
+	if (
+		outcome.role !== role ||
+		outcome.status !== "fulfilled" ||
+		outcome.programClosed !== true ||
+		outcome.peerStopped !== true ||
+		outcome.error !== null ||
+		startedAt < terminalSeederCapturedAt ||
+		finishedAt < startedAt ||
+		durationMs !== finishedAt - startedAt ||
+		durationMs > PAGE_SHUTDOWN_TIMEOUT_MS + schedulingToleranceMs
+	) {
+		throw new Error(`Benchmark ${label} is not a successful bounded shutdown`);
+	}
+	return { ...outcome, identity };
+};
+
+const validateResourceAndShutdownEvidence = (
+	result,
+	invocation,
+	readWindow,
+	{ integrityVerifiedAt, terminalTopologyFinishedAt },
+) => {
+	const evidence = requireExactRecordKeys(
+		requireRecord(result.resourceEvidence, "resourceEvidence"),
+		[
+			"schemaVersion",
+			"storageDefinition",
+			"eagerDefinition",
+			"snapshots",
+			"intervals",
+		],
+		"resourceEvidence",
+	);
+	if (
+		evidence.schemaVersion !== 2 ||
+		evidence.storageDefinition !== RESOURCE_STORAGE_DEFINITION ||
+		evidence.eagerDefinition !== RESOURCE_EAGER_DEFINITION
+	) {
+		throw new Error("Benchmark resource evidence contract is invalid");
+	}
+	const snapshotValues = requireExactRecordKeys(
+		requireRecord(evidence.snapshots, "resourceEvidence.snapshots"),
+		["beforeTimedRead", "afterSink", "beforeSoak", "afterSoak"],
+		"resourceEvidence.snapshots",
+	);
+	const snapshots = {
+		beforeTimedRead: validateResourceSnapshotSet(
+			snapshotValues.beforeTimedRead,
+			"beforeTimedRead",
+			invocation,
+		),
+		afterSink: validateResourceSnapshotSet(
+			snapshotValues.afterSink,
+			"afterSink",
+			invocation,
+		),
+		beforeSoak: validateResourceSnapshotSet(
+			snapshotValues.beforeSoak,
+			"beforeSoak",
+			invocation,
+		),
+		afterSoak: validateResourceSnapshotSet(
+			snapshotValues.afterSoak,
+			"afterSoak",
+			invocation,
+		),
+	};
+	const terminalSnapshot = Array.isArray(result.snapshots)
+		? result.snapshots.at(-1)
+		: null;
+	const terminalSeederCapturedAt = requirePositiveSafeInteger(
+		terminalSnapshot?.at,
+		"terminal seeder snapshot timestamp",
+	);
+	const downloadMemoryStartedAt = requirePositiveSafeInteger(
+		requireRecord(result.downloadMemoryTelemetry, "downloadMemoryTelemetry")
+			.startedAt,
+		"downloadMemoryTelemetry.startedAt",
+	);
+	if (
+		downloadMemoryStartedAt > snapshots.beforeTimedRead.startedAt ||
+		snapshots.beforeTimedRead.finishedAt > readWindow.downloadStartedAt ||
+		snapshots.afterSink.startedAt < readWindow.downloadCompletionObservedAt ||
+		snapshots.afterSink.finishedAt > integrityVerifiedAt ||
+		snapshots.afterSink.finishedAt > snapshots.beforeSoak.startedAt ||
+		snapshots.beforeSoak.startedAt < integrityVerifiedAt ||
+		(terminalTopologyFinishedAt !== null &&
+			snapshots.beforeSoak.startedAt < terminalTopologyFinishedAt) ||
+		snapshots.beforeSoak.finishedAt > readWindow.postTransferSoakStartedAt ||
+		readWindow.postTransferSoakFinishedAt > snapshots.afterSoak.startedAt ||
+		snapshots.afterSoak.finishedAt > terminalSeederCapturedAt
+	) {
+		throw new Error(
+			"Benchmark resource snapshots, soak, integrity, and terminal evidence are out of order",
+		);
+	}
+	validateResourceRoleSequence(snapshots, "writer");
+	validateResourceRoleSequence(snapshots, "reader");
+	const writerIdentity = snapshots.beforeTimedRead.writer.runtime.identity;
+	const readerIdentity = snapshots.beforeTimedRead.reader.runtime.identity;
+	if (
+		writerIdentity.programAddress !== readerIdentity.programAddress ||
+		writerIdentity.peerId === readerIdentity.peerId ||
+		writerIdentity.peerHash === readerIdentity.peerHash ||
+		writerIdentity.sessionId === readerIdentity.sessionId
+	) {
+		throw new Error(
+			"Benchmark resource evidence does not identify two distinct peers in one program",
+		);
+	}
+	const expectedIntervals = {
+		timedReadEnvelope: buildResourceInterval(
+			snapshots.beforeTimedRead,
+			snapshots.afterSink,
+		),
+		postTransferWork: buildResourceInterval(
+			snapshots.afterSink,
+			snapshots.beforeSoak,
+		),
+		soak: buildResourceInterval(snapshots.beforeSoak, snapshots.afterSoak),
+		total: buildResourceInterval(
+			snapshots.beforeTimedRead,
+			snapshots.afterSoak,
+		),
+	};
+	if (!isDeepStrictEqual(evidence.intervals, expectedIntervals)) {
+		throw new Error(
+			"Benchmark resource interval deltas contradict their snapshots",
+		);
+	}
+	for (const interval of Object.values(expectedIntervals)) {
+		for (const role of ["writerStorage", "readerStorage"]) {
+			requireSafeInteger(
+				interval[role].peerbitLogUsageDeltaBytes,
+				`resourceEvidence.intervals.${interval.from}-${interval.to}.${role}.peerbitLogUsageDeltaBytes`,
+			);
+			requireSafeInteger(
+				interval[role].backingStorageUsageDeltaBytes,
+				`resourceEvidence.intervals.${interval.from}-${interval.to}.${role}.backingStorageUsageDeltaBytes`,
+			);
+		}
+	}
+	const shutdownOutcomes = requireExactRecordKeys(
+		requireRecord(result.shutdownOutcomes, "shutdownOutcomes"),
+		["writer", "reader"],
+		"shutdownOutcomes",
+	);
+	const schedulingToleranceMs = Math.max(250, invocation.pollMs + 250);
+	const writer = validateShutdownOutcome(shutdownOutcomes.writer, "writer", {
+		terminalSeederCapturedAt,
+		schedulingToleranceMs,
+	});
+	const reader = validateShutdownOutcome(shutdownOutcomes.reader, "reader", {
+		terminalSeederCapturedAt,
+		schedulingToleranceMs,
+	});
+	if (
+		!isDeepStrictEqual(writer.identity, writerIdentity) ||
+		!isDeepStrictEqual(reader.identity, readerIdentity)
+	) {
+		throw new Error(
+			"Benchmark shutdown identities do not match their resource snapshot sessions",
+		);
+	}
+	return {
+		afterSoakStartedAt: snapshots.afterSoak.startedAt,
+		shutdownStartedAt: Math.min(writer.startedAt, reader.startedAt),
+		shutdownFinishedAt: Math.max(writer.finishedAt, reader.finishedAt),
+	};
 };
 
 const validateIdleDownloadScheduler = (value, label) => {
@@ -2075,17 +3258,16 @@ const validateTopologyEvidence = (value, label) => {
 
 const summarizeCounterpartPubsubTransport = (
 	topology,
-	{
-		direction,
-		expectedPeerHash,
-		expectedRemotePeerId,
-		label,
-	},
+	{ direction, expectedPeerHash, expectedRemotePeerId, label },
 ) => {
 	if (!Array.isArray(topology.observation.transportStreams)) {
-		throw new Error(`Benchmark ${label} is missing transport stream diagnostics`);
+		throw new Error(
+			`Benchmark ${label} is missing transport stream diagnostics`,
+		);
 	}
-	if (topology.observation.transportStreams.some((stream) => !isRecord(stream))) {
+	if (
+		topology.observation.transportStreams.some((stream) => !isRecord(stream))
+	) {
 		throw new Error(
 			`Benchmark ${label} contains malformed transport stream diagnostics`,
 		);
@@ -2320,13 +3502,15 @@ const validateTransportTopologyStability = ({
 					entry.writerSummary.totalBytes - entry.readerSummary.totalBytes,
 				) > TRANSPORT_COUNTER_MAX_COUNTERPART_BYTE_SKEW,
 		) ||
-		stable.slice(1).some(
-			(entry) =>
-				!isDeepStrictEqual(
-					stableSignature(entry),
-					stableSignature(stable[0]),
-				),
-		) ||
+		stable
+			.slice(1)
+			.some(
+				(entry) =>
+					!isDeepStrictEqual(
+						stableSignature(entry),
+						stableSignature(stable[0]),
+					),
+			) ||
 		!isDeepStrictEqual(
 			validated.at(-1).observation.writerTopology,
 			writerTopology.observation,
@@ -2519,8 +3703,10 @@ const validateReaderLocalityControl = (result, invocation) => {
 		readerTopologyBeforeUpload.peerHash !==
 			readerTopologyAfterTimedRead.peerHash ||
 		writerTopologyBeforeUpload.peerId === readerTopologyBeforeUpload.peerId ||
-		writerTopologyBeforeUpload.peerId !== writerTopologyBeforeTimedRead.peerId ||
-		readerTopologyBeforeUpload.peerId !== readerTopologyBeforeTimedRead.peerId ||
+		writerTopologyBeforeUpload.peerId !==
+			writerTopologyBeforeTimedRead.peerId ||
+		readerTopologyBeforeUpload.peerId !==
+			readerTopologyBeforeTimedRead.peerId ||
 		writerTopologyBeforeUpload.peerId !== writerTopologyAfterTimedRead.peerId ||
 		readerTopologyBeforeUpload.peerId !== readerTopologyAfterTimedRead.peerId
 	) {
@@ -2570,31 +3756,29 @@ const validateReaderLocalityControl = (result, invocation) => {
 			"Benchmark immediate post-read topology evidence is inconsistent",
 		);
 	}
-	const preTimedReadTransportStability =
-		validateTransportTopologyStability({
-			control,
-			phase: "pre",
-			writerTopology: writerTopologyBeforeTimedRead,
-			readerTopology: readerTopologyBeforeTimedRead,
-			expectedWriterPeerHash: writerTopologyBeforeUpload.peerHash,
-			expectedReaderPeerHash: readerTopologyBeforeUpload.peerHash,
-			expectedWriterPeerId: writerTopologyBeforeUpload.peerId,
-			expectedReaderPeerId: readerTopologyBeforeUpload.peerId,
-		});
-	const postTimedReadTransportStability =
-		validateTransportTopologyStability({
-			control,
-			phase: "post",
-			writerTopology: writerTopologyAfterTimedRead,
-			readerTopology: readerTopologyAfterTimedRead,
-			expectedWriterPeerHash: writerTopologyBeforeUpload.peerHash,
-			expectedReaderPeerHash: readerTopologyBeforeUpload.peerHash,
-			expectedWriterPeerId: writerTopologyBeforeUpload.peerId,
-			expectedReaderPeerId: readerTopologyBeforeUpload.peerId,
-			latestFinishedAt:
-				downloadCompletionObservedAt +
-				TRANSPORT_COUNTER_POST_READ_CAPTURE_MAX_DELAY_MS,
-		});
+	const preTimedReadTransportStability = validateTransportTopologyStability({
+		control,
+		phase: "pre",
+		writerTopology: writerTopologyBeforeTimedRead,
+		readerTopology: readerTopologyBeforeTimedRead,
+		expectedWriterPeerHash: writerTopologyBeforeUpload.peerHash,
+		expectedReaderPeerHash: readerTopologyBeforeUpload.peerHash,
+		expectedWriterPeerId: writerTopologyBeforeUpload.peerId,
+		expectedReaderPeerId: readerTopologyBeforeUpload.peerId,
+	});
+	const postTimedReadTransportStability = validateTransportTopologyStability({
+		control,
+		phase: "post",
+		writerTopology: writerTopologyAfterTimedRead,
+		readerTopology: readerTopologyAfterTimedRead,
+		expectedWriterPeerHash: writerTopologyBeforeUpload.peerHash,
+		expectedReaderPeerHash: readerTopologyBeforeUpload.peerHash,
+		expectedWriterPeerId: writerTopologyBeforeUpload.peerId,
+		expectedReaderPeerId: readerTopologyBeforeUpload.peerId,
+		latestFinishedAt:
+			downloadCompletionObservedAt +
+			TRANSPORT_COUNTER_POST_READ_CAPTURE_MAX_DELAY_MS,
+	});
 	const postTimedReadTopologyCaptureDelayMs = requireNonNegativeSafeInteger(
 		control.postTimedReadTopologyCaptureDelayMs,
 		"readerLocalityControl.postTimedReadTopologyCaptureDelayMs",
@@ -2872,10 +4056,6 @@ const validateReaderLocalityControl = (result, invocation) => {
 		downloadMemoryTelemetry.startedAt,
 		"downloadMemoryTelemetry.startedAt",
 	);
-	const downloadMemoryStoppedAt = requirePositiveSafeInteger(
-		downloadMemoryTelemetry.finishedAt,
-		"downloadMemoryTelemetry.finishedAt",
-	);
 	const terminalIdle = validateLocalChunkPrefixObservation(
 		control.terminalIdleObservation,
 		"readerLocalityControl.terminalIdleObservation",
@@ -2887,8 +4067,7 @@ const validateReaderLocalityControl = (result, invocation) => {
 		terminalIdle.chunkCount !== canonicalChunkCount ||
 		terminalIdle.blockCount !== canonicalChunkCount ||
 		terminalIdle.indexRowCount !== expectedTerminalIndexRowCount ||
-		terminalIdle.indexedChunkIndices.length !==
-			expectedTerminalIndexRowCount ||
+		terminalIdle.indexedChunkIndices.length !== expectedTerminalIndexRowCount ||
 		terminalIdle.persistChunkReads !== true ||
 		control.terminalTopologyRole !== expectedTerminalTopology ||
 		control.terminalTopologyExpectationSatisfied !== true
@@ -3011,14 +4190,10 @@ const validateReaderLocalityControl = (result, invocation) => {
 		writerTopologyBeforeTimedRead.capturedAt > downloadStartedAt ||
 		readerTopologyBeforeTimedRead.capturedAt > downloadStartedAt ||
 		downloadFinishedAt > downloadCompletionObservedAt ||
-		postTimedReadTransportStability.startedAt <
-			downloadCompletionObservedAt ||
-		postTimedReadTransportStability.startedAt < downloadMemoryStoppedAt ||
+		postTimedReadTransportStability.startedAt < downloadCompletionObservedAt ||
 		postTimedReadTransportStability.finishedAt > integrityVerifiedAt ||
 		writerTopologyAfterTimedRead.capturedAt < downloadCompletionObservedAt ||
 		readerTopologyAfterTimedRead.capturedAt < downloadCompletionObservedAt ||
-		writerTopologyAfterTimedRead.capturedAt < downloadMemoryStoppedAt ||
-		readerTopologyAfterTimedRead.capturedAt < downloadMemoryStoppedAt ||
 		writerTopologyAfterTimedRead.capturedAt > integrityVerifiedAt ||
 		readerTopologyAfterTimedRead.capturedAt > integrityVerifiedAt ||
 		integrityVerifiedAt !== result.integrityVerifiedAt ||
@@ -3526,14 +4701,17 @@ export const validateBenchmarkResult = (
 			expectedFixtureSeed,
 			expectedInvocation,
 		);
-		const readWindow = validateUploadTimings(result, expectedInvocation);
+		const readWindow = validateUploadTimings(
+			result,
+			expectedInvocation,
+			integrityVerifiedAt,
+		);
 		if (integrityVerifiedAt < readWindow.downloadCompletionObservedAt) {
 			throw new Error(
 				"Benchmark aggregate integrity gate precedes download completion",
 			);
 		}
 		validateUploadProgressTelemetry(result, expectedInvocation);
-		validateDownloadMemoryTelemetry(result, expectedInvocation, readWindow);
 		validateRequestedUploadKnobs(result, expectedInvocation);
 		validateZeroErrors(result, "upload result");
 		const readerLocalityControl = validateReaderLocalityControl(
@@ -3544,6 +4722,20 @@ export const validateBenchmarkResult = (
 			integrityVerifiedAt,
 			terminalTopologyFinishedAt:
 				readerLocalityControl?.terminalTopologyFinishedAt ?? null,
+		});
+		const shutdownWindow = validateResourceAndShutdownEvidence(
+			result,
+			expectedInvocation,
+			readWindow,
+			{
+				integrityVerifiedAt,
+				terminalTopologyFinishedAt:
+					readerLocalityControl?.terminalTopologyFinishedAt ?? null,
+			},
+		);
+		validateDownloadMemoryTelemetry(result, expectedInvocation, {
+			...readWindow,
+			...shutdownWindow,
 		});
 		if (result.unexpectedSeederDrop !== false) {
 			throw new Error(

--- a/scripts/file-share/benchmark-validity.test.mjs
+++ b/scripts/file-share/benchmark-validity.test.mjs
@@ -20,16 +20,20 @@ import {
 	validateBenchmarkResultEnvelope,
 } from "./benchmark-validity.mjs";
 import {
+	DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE,
 	DOWNLOAD_MEMORY_HOST_ATTRIBUTION,
 	DOWNLOAD_MEMORY_HOST_ATTRIBUTION_LIMITATIONS,
 	DOWNLOAD_MEMORY_HOST_SCOPE,
+	DOWNLOAD_MEMORY_LIVE_SAMPLE_COVERAGE_DEFINITION,
 	DOWNLOAD_MEMORY_MAX_BROWSER_PROCESSES,
 	DOWNLOAD_MEMORY_NODE_SCOPE,
+	DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS,
 	DOWNLOAD_MEMORY_PROFILE,
 	DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
 	DOWNLOAD_MEMORY_SETUP_ALLOWANCE_MS,
 	DOWNLOAD_MEMORY_TERMINAL_ALLOWANCE_MS,
 	DOWNLOAD_MEMORY_WINDOW_DEFINITION,
+	calculateDownloadMemoryMaxLiveSampleGapMs,
 	calculateDownloadMemoryMaxSamples,
 } from "./templates/download-memory-telemetry.mjs";
 
@@ -44,6 +48,10 @@ const SAMPLE_COUNT_DEFINITION =
 	"observation-density divisor: planned interval is min(sampleMs, floor(readyTimeoutMs/sampleCount)) clamped to 1ms; convergence may finish early";
 const POST_MONITOR_SCHEDULING_TOLERANCE_DEFINITION =
 	"max(250ms, pollMs + 250ms) for the final poll and event-loop scheduling";
+const POST_TRANSFER_SOAK_SCHEDULING_TOLERANCE_DEFINITION =
+	"max(250ms, pollMs + 250ms) for the requested post-transfer timer and event-loop scheduling";
+const POST_TRANSFER_SOAK_DEFINITION =
+	"idle observation window beginning after transfer integrity and any requested terminal-topology validation, ending before terminal resource capture and peer shutdown";
 const TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION =
 	"max(5000ms, pollMs + 1000ms) for browser actions and event-loop scheduling";
 const TIME_TO_WRITER_READY_DEFINITION =
@@ -66,6 +74,22 @@ const PRIMARY_DOWNLOAD_METRIC_DEFINITION =
 	"authoritative only within one fixed download-sink cohort; hash-only is the standardized primary cohort and includes awaited sink writes plus any overlapping read-ahead";
 const DEMAND_WAIT_DEFINITION =
 	"wall-clock time each sequential stream consumer awaited its scheduled chunk";
+const RESOURCE_STORAGE_DEFINITION =
+	"Peerbit logical usage and browser origin-wide navigator.storage estimates; deltas are later minus earlier";
+const RESOURCE_EAGER_DEFINITION =
+	"deltas of monotonic eager-cache admission, hit, eviction, expiration, and rejection counters; null when eager telemetry is disabled or unavailable";
+const EAGER_COUNTERS = [
+	"evictions",
+	"expirations",
+	"admitted",
+	"hits",
+	"rejectedCid",
+	"rejectedCodec",
+	"rejectedSize",
+	"rejectedPending",
+	"rejectedIntegrity",
+	"rejectedLifecycle",
+];
 const PROVENANCE = {
 	harness: {
 		requestedRef: "harness-worktree",
@@ -98,6 +122,7 @@ const INVOCATION = createBenchmarkInvocation({
 	uploadTimeoutMs: 600_000,
 	downloadTimeoutMs: 600_000,
 	postUploadMonitorMs: 50,
+	postTransferSoakMs: 50,
 	pollMs: 1_000,
 	minReadySeeders: 2,
 	readyTimeoutMs: 180_000,
@@ -114,54 +139,176 @@ const options = {
 	expectedInvocation: INVOCATION,
 };
 
+const calculateSamplingWindowBudgetMs = (invocation) => {
+	const transferToleranceMs = Math.max(5_000, invocation.pollMs + 1_000);
+	const localityBudgetMs =
+		invocation.readerLocalChunkTarget === null
+			? 0
+			: 3 * invocation.readyTimeoutMs +
+				2 * 5_000 +
+				(invocation.readerLocalChunkTarget > 0
+					? invocation.downloadTimeoutMs + transferToleranceMs
+					: 0);
+	return Math.max(
+		20 * 60 * 1_000,
+		3 * invocation.readyTimeoutMs +
+			invocation.uploadTimeoutMs +
+			invocation.downloadTimeoutMs +
+			localityBudgetMs +
+			invocation.postUploadMonitorMs +
+			invocation.postTransferSoakMs +
+			5 * 60 * 1_000,
+	);
+};
+
 const createDownloadMemoryTelemetry = (
 	readStartedAt,
 	readFinishedAt,
 	invocation = INVOCATION,
+	{
+		afterSoakStartedAt = readFinishedAt + 61,
+		shutdownFinishedAt = readFinishedAt + 73,
+	} = {},
 ) => {
+	const schedulingToleranceMs = Math.max(5_000, invocation.pollMs + 1_000);
+	const samplingWindowBudgetMs = calculateSamplingWindowBudgetMs(invocation);
 	const maxSamplesPerSeries = calculateDownloadMemoryMaxSamples({
-		downloadTimeoutMs: invocation.downloadTimeoutMs,
-		schedulingToleranceMs: Math.max(5_000, invocation.pollMs + 1_000),
+		samplingWindowBudgetMs,
 	});
-	const heap = (scope, startedOffset, finishedOffset, bytes) => ({
-		memoryKind: "javascript-heap",
-		scope,
-		metric: "JSHeapUsedSize",
-		unit: "bytes",
-		sampleIntervalMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
-		startedAt: readStartedAt - startedOffset,
-		finishedAt: readFinishedAt + finishedOffset,
-		sampleCount: 2,
-		startBytes: bytes,
-		endBytes: bytes + 20,
-		peakBytes: bytes + 20,
-		samples: [
-			{ capturedAt: readStartedAt - 1, usedBytes: bytes },
-			{ capturedAt: readFinishedAt + 1, usedBytes: bytes + 20 },
-		],
-		samplingErrors: [],
-		samplingErrorOverflowCount: 0,
-		cleanupWarnings: [],
-		cleanupWarningOverflowCount: 0,
+	const liveSampleMaxGapMs = calculateDownloadMemoryMaxLiveSampleGapMs({
+		schedulingToleranceMs,
 	});
-	const readerJsHeap = heap("reader-renderer", 3, 2, 100);
-	const writerJsHeap = heap("writer-renderer", 2, 3, 200);
+	const manualSampleAt = afterSoakStartedAt - 1;
+	const terminalSampleAt = shutdownFinishedAt + 1;
+	const seriesSamplingFields = {
+		maxSamples: maxSamplesPerSeries,
+		periodicSampleLimit:
+			maxSamplesPerSeries - DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE,
+		periodicSampleCount: 1,
+		capacityExhaustedBeforeTerminal: false,
+		samplingCapacitySufficient: true,
+		manualSampleCount: 1,
+		lastManualSampleAt: manualSampleAt,
+		terminalSampleAttempted: true,
+		terminalSampleCaptured: true,
+		terminalSampleAt,
+	};
+	const heap = (scope, startedOffset, finishedOffset, bytes) => {
+		const samples = [
+			{
+				capturedAt: readStartedAt - 1,
+				sampleKind: "initial",
+				usedBytes: bytes,
+				totalBytes: bytes + 200,
+				embedderHeapUsedBytes: bytes + 20,
+				backingStorageBytes: bytes + 30,
+			},
+			{
+				capturedAt: readFinishedAt + 1,
+				sampleKind: "periodic",
+				usedBytes: bytes + 20,
+				totalBytes: bytes + 240,
+				embedderHeapUsedBytes: bytes + 25,
+				backingStorageBytes: bytes + 35,
+			},
+			{
+				capturedAt: manualSampleAt,
+				sampleKind: "manual",
+				usedBytes: bytes + 15,
+				totalBytes: bytes + 230,
+				embedderHeapUsedBytes: bytes + 24,
+				backingStorageBytes: bytes + 34,
+			},
+			{
+				capturedAt: terminalSampleAt,
+				sampleKind: "terminal",
+				usedBytes: bytes + 10,
+				totalBytes: bytes + 220,
+				embedderHeapUsedBytes: bytes + 22,
+				backingStorageBytes: bytes + 32,
+			},
+		];
+		const first = samples[0];
+		const last = samples.at(-1);
+		const peak = (key) => Math.max(...samples.map((sample) => sample[key]));
+		return {
+			memoryKind: "runtime-heap",
+			scope,
+			metric: "Runtime.getHeapUsage",
+			unit: "bytes",
+			sampleIntervalMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
+			startedAt: readStartedAt - startedOffset,
+			finishedAt: shutdownFinishedAt + finishedOffset,
+			sampleCount: samples.length,
+			startBytes: first.usedBytes,
+			endBytes: last.usedBytes,
+			peakBytes: peak("usedBytes"),
+			startUsedBytes: first.usedBytes,
+			endUsedBytes: last.usedBytes,
+			peakUsedBytes: peak("usedBytes"),
+			startTotalBytes: first.totalBytes,
+			endTotalBytes: last.totalBytes,
+			peakTotalBytes: peak("totalBytes"),
+			startEmbedderHeapUsedBytes: first.embedderHeapUsedBytes,
+			endEmbedderHeapUsedBytes: last.embedderHeapUsedBytes,
+			peakEmbedderHeapUsedBytes: peak("embedderHeapUsedBytes"),
+			startBackingStorageBytes: first.backingStorageBytes,
+			endBackingStorageBytes: last.backingStorageBytes,
+			peakBackingStorageBytes: peak("backingStorageBytes"),
+			samples,
+			samplingErrors: [],
+			samplingErrorOverflowCount: 0,
+			cleanupWarnings: [],
+			cleanupWarningOverflowCount: 0,
+			...seriesSamplingFields,
+		};
+	};
+	const readerJsHeap = heap("reader-renderer", 3, 3, 100);
+	const writerJsHeap = heap("writer-renderer", 2, 4, 200);
 	const hostSamples = [
 		{
 			capturedAt: readStartedAt - 1,
+			sampleKind: "initial",
 			browserBytes: 1_000,
 			nodeBytes: 500,
+			nodeExternalBytes: 100,
+			nodeArrayBuffersBytes: 50,
 			combinedBytes: 1_500,
 			browserProcessCount: 2,
 			browserRoleBytes: { browser: 400, renderer: 600 },
 		},
 		{
 			capturedAt: readFinishedAt + 1,
+			sampleKind: "periodic",
 			browserBytes: 1_200,
 			nodeBytes: 550,
+			nodeExternalBytes: 120,
+			nodeArrayBuffersBytes: 60,
 			combinedBytes: 1_750,
 			browserProcessCount: 3,
 			browserRoleBytes: { browser: 450, renderer: 750 },
+		},
+		{
+			capturedAt: manualSampleAt,
+			sampleKind: "manual",
+			browserBytes: 1_150,
+			nodeBytes: 540,
+			nodeExternalBytes: 115,
+			nodeArrayBuffersBytes: 58,
+			combinedBytes: 1_690,
+			browserProcessCount: 3,
+			browserRoleBytes: { browser: 440, renderer: 710 },
+		},
+		{
+			capturedAt: terminalSampleAt,
+			sampleKind: "terminal",
+			browserBytes: 1_100,
+			nodeBytes: 525,
+			nodeExternalBytes: 110,
+			nodeArrayBuffersBytes: 55,
+			combinedBytes: 1_625,
+			browserProcessCount: 2,
+			browserRoleBytes: { browser: 425, renderer: 675 },
 		},
 	];
 	const hostRss = {
@@ -174,34 +321,54 @@ const createDownloadMemoryTelemetry = (
 		unit: "bytes",
 		sampleIntervalMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
 		startedAt: readStartedAt - 1,
-		finishedAt: readFinishedAt + 4,
+		finishedAt: shutdownFinishedAt + 5,
 		sampleCount: hostSamples.length,
 		startBrowserBytes: 1_000,
-		endBrowserBytes: 1_200,
+		endBrowserBytes: 1_100,
 		peakBrowserBytes: 1_200,
 		startNodeBytes: 500,
-		endNodeBytes: 550,
+		endNodeBytes: 525,
 		peakNodeBytes: 550,
+		startNodeExternalBytes: 100,
+		endNodeExternalBytes: 110,
+		peakNodeExternalBytes: 120,
+		startNodeArrayBuffersBytes: 50,
+		endNodeArrayBuffersBytes: 55,
+		peakNodeArrayBuffersBytes: 60,
 		startCombinedBytes: 1_500,
-		endCombinedBytes: 1_750,
+		endCombinedBytes: 1_625,
 		peakCombinedBytes: 1_750,
 		startBrowserProcessCount: 2,
-		endBrowserProcessCount: 3,
+		endBrowserProcessCount: 2,
 		peakBrowserProcessCount: 3,
 		startBrowserRoleBytes: { browser: 400, renderer: 600 },
-		endBrowserRoleBytes: { browser: 450, renderer: 750 },
+		endBrowserRoleBytes: { browser: 425, renderer: 675 },
 		peakBrowserRoleBytes: { browser: 450, renderer: 750 },
 		samples: hostSamples,
 		samplingErrors: [],
 		samplingErrorOverflowCount: 0,
 		cleanupWarnings: [],
 		cleanupWarningOverflowCount: 0,
+		...seriesSamplingFields,
 	};
 	return {
 		profile: DOWNLOAD_MEMORY_PROFILE,
 		sampleIntervalMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
 		windowDefinition: DOWNLOAD_MEMORY_WINDOW_DEFINITION,
+		downloadTimeoutMs: invocation.downloadTimeoutMs,
+		schedulingToleranceMs,
+		operationTimeoutMs: DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS,
+		postTransferSoakMs: invocation.postTransferSoakMs,
+		samplingWindowBudgetMs,
+		liveSampleMaxGapMs,
+		liveSampleCoverageDefinition:
+			DOWNLOAD_MEMORY_LIVE_SAMPLE_COVERAGE_DEFINITION,
+		endpointSampleAllowance: DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE,
 		maxSamplesPerSeries,
+		capacityExhaustedBeforeTerminal: false,
+		samplingCapacitySufficient: true,
+		manualCheckpointComplete: true,
+		terminalCheckpointComplete: true,
 		complete: true,
 		cleanupComplete: true,
 		startedAt: readerJsHeap.startedAt,
@@ -284,11 +451,314 @@ const createUploadDiagnostics = (fileName = FILE_NAME) => {
 	};
 };
 
+const createReceiverProgress = (diagnostics, downloadSink) => {
+	const indices = Object.keys(diagnostics.chunkByteLength)
+		.map(Number)
+		.toSorted((left, right) => left - right);
+	const chunkBytes = indices.map((index) => diagnostics.chunkByteLength[index]);
+	const totalBytes = chunkBytes.reduce((total, bytes) => total + bytes, 0);
+	const milestones = (source) => {
+		let contiguousBytes = 0;
+		let contiguousConfirmedAt = diagnostics.startedAt;
+		const prefixBytes = [];
+		const prefixConfirmedAt = [];
+		for (const [offset, index] of indices.entries()) {
+			contiguousBytes += chunkBytes[offset];
+			contiguousConfirmedAt = Math.max(
+				contiguousConfirmedAt,
+				diagnostics[source][index],
+			);
+			prefixBytes.push(contiguousBytes);
+			prefixConfirmedAt.push(contiguousConfirmedAt);
+		}
+		return Array.from({ length: 21 }, (_, index) => index * 5).map(
+			(percent) => {
+				if (percent === 0) {
+					return {
+						percent,
+						targetBytes: 0,
+						contiguousBytes: 0,
+						chunkIndex: null,
+						confirmedAt: diagnostics.startedAt,
+						elapsedMs: 0,
+					};
+				}
+				const targetBytes = Math.ceil((totalBytes * percent) / 100);
+				const chunkIndex = prefixBytes.findIndex(
+					(bytes) => bytes >= targetBytes,
+				);
+				return {
+					percent,
+					targetBytes,
+					contiguousBytes: prefixBytes[chunkIndex],
+					chunkIndex,
+					confirmedAt: prefixConfirmedAt[chunkIndex],
+					elapsedMs: prefixConfirmedAt[chunkIndex] - diagnostics.startedAt,
+				};
+			},
+		);
+	};
+	const sourceCounts = {};
+	if (diagnostics.persistChunkReads) {
+		for (const index of indices) {
+			const source = diagnostics.chunkPersistenceConfirmationSource[index];
+			sourceCounts[source] = (sourceCounts[source] ?? 0) + 1;
+		}
+	}
+	return {
+		percentages: Array.from({ length: 21 }, (_, index) => index * 5),
+		available: {
+			definition:
+				"contiguous file-prefix bytes materialized and available to the receiver library",
+			source: "chunkMaterializeFinishedAt",
+			milestones: milestones("chunkMaterializeFinishedAt"),
+		},
+		peerbitDurable: {
+			definition:
+				"contiguous file-prefix bytes whose exact signed manifest-entry blocks were confirmed in the receiver's local Peerbit block store",
+			source: "chunkPersistenceConfirmedAt",
+			claimed: diagnostics.persistChunkReads,
+			sourceCounts: Object.fromEntries(
+				Object.entries(sourceCounts).sort(([left], [right]) =>
+					left.localeCompare(right),
+				),
+			),
+			milestones: diagnostics.persistChunkReads
+				? milestones("chunkPersistenceConfirmedAt")
+				: null,
+		},
+		sinkAccepted: {
+			definition:
+				"contiguous file-prefix bytes accepted by the configured benchmark sink; this is not a Peerbit or filesystem durability claim",
+			source: "chunkWriteFinishedAt",
+			sink: downloadSink,
+			durable: false,
+			milestones: milestones("chunkWriteFinishedAt"),
+		},
+	};
+};
+
+const refreshReceiverProgress = (result) => {
+	result.readTransfer.receiverProgress = createReceiverProgress(
+		result.readerDiagnostics.lastReadDiagnostics,
+		result.downloadSink,
+	);
+};
+
+const createEagerTelemetry = (step) => ({
+	entries: 2 + step,
+	bytes: 2_000 + step * 100,
+	peakEntries: 3 + step,
+	peakBytes: 3_000 + step * 100,
+	evictions: step,
+	expirations: step,
+	pendingEntries: 0,
+	pendingBytes: 0,
+	peakPendingEntries: 1 + step,
+	peakPendingBytes: 500 + step * 10,
+	admitted: 5 + step,
+	hits: 3 + step,
+	rejectedCid: step,
+	rejectedCodec: step,
+	rejectedSize: step,
+	rejectedPending: step,
+	rejectedIntegrity: step,
+	rejectedLifecycle: step,
+	limits: {
+		maxEntries: 100,
+		maxBytes: 10_000,
+		maxBlockBytes: 5_000,
+		ttlMs: 10_000,
+		validationConcurrency: 2,
+		maxPendingBytes: 5_000,
+		maxPendingEntries: 10,
+	},
+});
+
+const createRuntimeIdentity = (role) => ({
+	programAddress: "benchmark-program-address",
+	peerId: `${role}-peer-id`,
+	peerHash: `${role}-peer-hash`,
+	sessionId: `${role}-session-id`,
+});
+
+const createResourcePage = ({ role, startedAt, capturedAt, step }) => ({
+	role,
+	capturedAt,
+	storage: {
+		capturedAt: startedAt,
+		origin: "http://127.0.0.1:4173",
+		peerbitLog: {
+			api: "SharedLog.getMemoryUsage",
+			scope: "file-share-log-logical-usage",
+			available: true,
+			usageBytes: (role === "writer" ? 100 : 80) + step * 10,
+			error: null,
+		},
+		backingStorage: {
+			api: "navigator.storage.estimate",
+			scope: "browser-origin-aggregate",
+			available: true,
+			usageBytes: (role === "writer" ? 1_000 : 900) + step * 50,
+			quotaBytes: 100_000,
+			usageDetails: { indexedDB: 500 + step * 25 },
+			error: null,
+		},
+	},
+	runtime: {
+		capturedAt: Math.min(startedAt + 1, capturedAt),
+		programReady: true,
+		identity: createRuntimeIdentity(role),
+		nativeGraph: { active: true, useHeads: true },
+		eagerBlocks: {
+			telemetryAvailable: true,
+			enabled: true,
+			telemetry: createEagerTelemetry(step),
+		},
+		pubsub: {
+			runtimeSnapshotAvailable: true,
+			snapshot: {
+				fanout: {
+					root: { uploadLimitBps: 5_000_000 },
+					node: { uploadLimitBps: 20_000_000 },
+				},
+			},
+			error: null,
+		},
+	},
+});
+
+const createResourceSnapshotSet = ({ label, startedAt, finishedAt, step }) => ({
+	label,
+	startedAt,
+	finishedAt,
+	writer: createResourcePage({
+		role: "writer",
+		startedAt,
+		capturedAt: finishedAt,
+		step,
+	}),
+	reader: createResourcePage({
+		role: "reader",
+		startedAt,
+		capturedAt: finishedAt,
+		step,
+	}),
+});
+
+const createResourceEvidence = ({
+	beforeTimedRead = [1_168, 1_170],
+	afterSink = [1_202, 1_204],
+	beforeSoak = [1_205, 1_210],
+	afterSoak = [1_261, 1_264],
+} = {}) => {
+	const snapshots = {
+		beforeTimedRead: createResourceSnapshotSet({
+			label: "beforeTimedRead",
+			startedAt: beforeTimedRead[0],
+			finishedAt: beforeTimedRead[1],
+			step: 0,
+		}),
+		afterSink: createResourceSnapshotSet({
+			label: "afterSink",
+			startedAt: afterSink[0],
+			finishedAt: afterSink[1],
+			step: 1,
+		}),
+		beforeSoak: createResourceSnapshotSet({
+			label: "beforeSoak",
+			startedAt: beforeSoak[0],
+			finishedAt: beforeSoak[1],
+			step: 2,
+		}),
+		afterSoak: createResourceSnapshotSet({
+			label: "afterSoak",
+			startedAt: afterSoak[0],
+			finishedAt: afterSoak[1],
+			step: 3,
+		}),
+	};
+	const interval = (before, after) => {
+		const storage = (role) => ({
+			role,
+			peerbitLogUsageDeltaBytes:
+				after[role].storage.peerbitLog.usageBytes -
+				before[role].storage.peerbitLog.usageBytes,
+			backingStorageUsageDeltaBytes:
+				after[role].storage.backingStorage.usageBytes -
+				before[role].storage.backingStorage.usageBytes,
+		});
+		const eager = (role) =>
+			Object.fromEntries(
+				EAGER_COUNTERS.map((key) => [
+					key,
+					after[role].runtime.eagerBlocks.telemetry[key] -
+						before[role].runtime.eagerBlocks.telemetry[key],
+				]),
+			);
+		return {
+			from: before.label,
+			to: after.label,
+			writerStorage: storage("writer"),
+			readerStorage: storage("reader"),
+			writerEager: eager("writer"),
+			readerEager: eager("reader"),
+		};
+	};
+	return {
+		schemaVersion: 2,
+		storageDefinition: RESOURCE_STORAGE_DEFINITION,
+		eagerDefinition: RESOURCE_EAGER_DEFINITION,
+		snapshots,
+		intervals: {
+			timedReadEnvelope: interval(
+				snapshots.beforeTimedRead,
+				snapshots.afterSink,
+			),
+			postTransferWork: interval(snapshots.afterSink, snapshots.beforeSoak),
+			soak: interval(snapshots.beforeSoak, snapshots.afterSoak),
+			total: interval(snapshots.beforeTimedRead, snapshots.afterSoak),
+		},
+	};
+};
+
+const createShutdownOutcomes = ({
+	writerStartedAt = 1_266,
+	writerFinishedAt = 1_271,
+	readerStartedAt = 1_266,
+	readerFinishedAt = 1_273,
+} = {}) => ({
+	writer: {
+		role: "writer",
+		status: "fulfilled",
+		startedAt: writerStartedAt,
+		finishedAt: writerFinishedAt,
+		durationMs: writerFinishedAt - writerStartedAt,
+		programClosed: true,
+		peerStopped: true,
+		identity: createRuntimeIdentity("writer"),
+		error: null,
+	},
+	reader: {
+		role: "reader",
+		status: "fulfilled",
+		startedAt: readerStartedAt,
+		finishedAt: readerFinishedAt,
+		durationMs: readerFinishedAt - readerStartedAt,
+		programClosed: true,
+		peerStopped: true,
+		identity: createRuntimeIdentity("reader"),
+		error: null,
+	},
+});
+
 const shiftTimedDownloadEvidence = (result, offset) => {
 	for (const key of [
 		"downloadStartedAt",
 		"downloadFinishedAt",
 		"downloadCompletionObservedAt",
+		"postTransferSoakStartedAt",
+		"postTransferSoakFinishedAt",
 	]) {
 		result.timestamps[key] += offset;
 	}
@@ -298,16 +768,36 @@ const shiftTimedDownloadEvidence = (result, offset) => {
 	diagnostics.startedAt += offset;
 	diagnostics.finishedAt += offset;
 	for (const key of [
+		"chunkResolveStartedAt",
+		"chunkResolveFinishedAt",
 		"chunkWriteStartedAt",
 		"chunkWriteFinishedAt",
 		"chunkMaterializeStartedAt",
 		"chunkMaterializeFinishedAt",
 		"chunkHashStartedAt",
 		"chunkHashFinishedAt",
+		"chunkPersistenceConfirmedAt",
 	]) {
+		if (!diagnostics[key]) {
+			continue;
+		}
 		for (const index of Object.keys(diagnostics[key])) {
 			diagnostics[key][index] += offset;
 		}
+	}
+	refreshReceiverProgress(result);
+	for (const snapshot of Object.values(result.resourceEvidence.snapshots)) {
+		snapshot.startedAt += offset;
+		snapshot.finishedAt += offset;
+		for (const role of ["writer", "reader"]) {
+			snapshot[role].capturedAt += offset;
+			snapshot[role].storage.capturedAt += offset;
+			snapshot[role].runtime.capturedAt += offset;
+		}
+	}
+	for (const outcome of Object.values(result.shutdownOutcomes)) {
+		outcome.startedAt += offset;
+		outcome.finishedAt += offset;
 	}
 	const telemetry = result.downloadMemoryTelemetry;
 	telemetry.startedAt += offset;
@@ -319,216 +809,237 @@ const shiftTimedDownloadEvidence = (result, offset) => {
 	]) {
 		series.startedAt += offset;
 		series.finishedAt += offset;
+		series.lastManualSampleAt += offset;
+		series.terminalSampleAt += offset;
 		for (const sample of series.samples) {
 			sample.capturedAt += offset;
 		}
 	}
 };
 
-const validResult = () => ({
-	schema: { ...BENCHMARK_RESULT_SCHEMA },
-	runNonce: RUN_NONCE,
-	invocation: structuredClone(INVOCATION),
-	provenance: structuredClone(PROVENANCE),
-	status: "passed",
-	mode: "adaptive",
-	readerLocalChunkTarget: null,
-	readerLocalChunkMaxOvershoot: null,
-	readerTerminalTopology: null,
-	readerLocalChunkBlockCount: null,
-	readerLocalChunkIndexRowCount: null,
-	readerLocalityCohortKey: null,
-	readerLocalityControl: null,
-	networkMode: "local",
-	fileName: FILE_NAME,
-	fileSizeMb: FILE_MB,
-	integrityVerified: true,
-	integrityVerifiedAt: 1_205,
-	integrity: {
-		fixtureMode: "deterministic",
-		fixtureFormat: "aes-256-ctr-v1",
-		fixtureSeed: "fixture-seed",
-		expectedSizeBytes: FILE_SIZE_BYTES,
-		sourceSizeBytes: FILE_SIZE_BYTES,
-		manifestSizeBytes: FILE_SIZE_BYTES,
-		downloadedSizeBytes: FILE_SIZE_BYTES,
-		sourceSha256Base64: SHA256,
-		manifestSha256Base64: SHA256,
-		libraryComputedSha256Base64: SHA256,
-		downloadedSha256Base64: null,
-		sourceCrc32Hex: "00000000",
-		downloadedCrc32Hex: "00000000",
+const validResult = () => {
+	const result = {
+		schema: { ...BENCHMARK_RESULT_SCHEMA },
+		runNonce: RUN_NONCE,
+		invocation: structuredClone(INVOCATION),
+		provenance: structuredClone(PROVENANCE),
+		status: "passed",
+		mode: "adaptive",
+		readerLocalChunkTarget: null,
+		readerLocalChunkMaxOvershoot: null,
+		readerTerminalTopology: null,
+		readerLocalChunkBlockCount: null,
+		readerLocalChunkIndexRowCount: null,
+		readerLocalityCohortKey: null,
+		readerLocalityControl: null,
+		networkMode: "local",
+		fileName: FILE_NAME,
+		fileSizeMb: FILE_MB,
+		integrityVerified: true,
+		integrityVerifiedAt: 1_205,
+		integrity: {
+			fixtureMode: "deterministic",
+			fixtureFormat: "aes-256-ctr-v1",
+			fixtureSeed: "fixture-seed",
+			expectedSizeBytes: FILE_SIZE_BYTES,
+			sourceSizeBytes: FILE_SIZE_BYTES,
+			manifestSizeBytes: FILE_SIZE_BYTES,
+			downloadedSizeBytes: FILE_SIZE_BYTES,
+			sourceSha256Base64: SHA256,
+			manifestSha256Base64: SHA256,
+			libraryComputedSha256Base64: SHA256,
+			downloadedSha256Base64: null,
+			sourceCrc32Hex: "00000000",
+			downloadedCrc32Hex: "00000000",
+			downloadSink: "hash-only",
+			sinkPersistence: "none",
+			sinkPersistenceVerified: null,
+			sizeVerified: true,
+			manifestVerified: true,
+			sha256Verified: true,
+			librarySha256Verified: true,
+			persistedSinkSha256Verified: null,
+			crc32Verified: true,
+			verified: true,
+		},
+		uploadDurationMs: 101,
+		timeToWriterReadyMs: 100,
+		timeToWriterReadyDefinition: TIME_TO_WRITER_READY_DEFINITION,
+		timeToReaderReadyMs: 120,
+		timeToReaderReadyDefinition: TIME_TO_READER_READY_DEFINITION,
+		listingDurationMs: 19,
+		listingDurationDefinition: LISTING_DURATION_DEFINITION,
+		postUploadMonitorDurationMs: 50,
+		postUploadMonitorSchedulingToleranceMs: 1_250,
+		postUploadMonitorSchedulingToleranceDefinition:
+			POST_MONITOR_SCHEDULING_TOLERANCE_DEFINITION,
+		postTransferSoakActualMs: 50,
+		postTransferSoakDefinition: POST_TRANSFER_SOAK_DEFINITION,
+		postTransferSoakSchedulingToleranceMs: 1_250,
+		postTransferSoakSchedulingToleranceDefinition:
+			POST_TRANSFER_SOAK_SCHEDULING_TOLERANCE_DEFINITION,
+		postUploadMonitorMs: 50,
+		postTransferSoakMs: 50,
+		pollMs: 1_000,
+		uploadTimeoutMs: 600_000,
+		downloadTimeoutMs: 600_000,
+		minReadySeeders: 2,
+		readyTimeoutMs: 180_000,
+		downloadDurationMs: 30,
+		downloadDurationDefinition: DOWNLOAD_DURATION_DEFINITION,
+		transferTimeoutSchedulingToleranceMs: 5_000,
+		transferTimeoutSchedulingToleranceDefinition:
+			TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION,
 		downloadSink: "hash-only",
-		sinkPersistence: "none",
-		sinkPersistenceVerified: null,
-		sizeVerified: true,
-		manifestVerified: true,
-		sha256Verified: true,
-		librarySha256Verified: true,
-		persistedSinkSha256Verified: null,
-		crc32Verified: true,
-		verified: true,
-	},
-	uploadDurationMs: 101,
-	timeToWriterReadyMs: 100,
-	timeToWriterReadyDefinition: TIME_TO_WRITER_READY_DEFINITION,
-	timeToReaderReadyMs: 120,
-	timeToReaderReadyDefinition: TIME_TO_READER_READY_DEFINITION,
-	listingDurationMs: 19,
-	listingDurationDefinition: LISTING_DURATION_DEFINITION,
-	postUploadMonitorDurationMs: 50,
-	postUploadMonitorSchedulingToleranceMs: 1_250,
-	postUploadMonitorSchedulingToleranceDefinition:
-		POST_MONITOR_SCHEDULING_TOLERANCE_DEFINITION,
-	postUploadMonitorMs: 50,
-	pollMs: 1_000,
-	uploadTimeoutMs: 600_000,
-	downloadTimeoutMs: 600_000,
-	minReadySeeders: 2,
-	readyTimeoutMs: 180_000,
-	downloadDurationMs: 30,
-	downloadDurationDefinition: DOWNLOAD_DURATION_DEFINITION,
-	transferTimeoutSchedulingToleranceMs: 5_000,
-	transferTimeoutSchedulingToleranceDefinition:
-		TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION,
-	downloadSink: "hash-only",
-	requestedDownloadSink: "hash-only",
-	downloadMemoryTelemetry: createDownloadMemoryTelemetry(1_170, 1_200),
-	sinkWriteCalls: 2,
-	sinkWriteDurationMs: 8.5,
-	sinkWriteDurationDefinition: SINK_WRITE_DURATION_DEFINITION,
-	sinkServerWriteCalls: null,
-	sinkServerWriteDurationMs: null,
-	sinkServerWriteDurationDefinition: null,
-	readTransfer: {
-		chunkCount: 2,
-		totalBytes: FILE_SIZE_BYTES,
-		sources: { remote: { chunkCount: 2, bytes: FILE_SIZE_BYTES } },
-		demandWait: {
-			definition: DEMAND_WAIT_DEFINITION,
-			sampleCount: 2,
-			sumMs: 12,
-			p50Ms: 4,
-			p95Ms: 8,
-			p99Ms: 8,
-			maxMs: 8,
-			over1sCount: 0,
-			over5sCount: 0,
-			over10sCount: 0,
+		requestedDownloadSink: "hash-only",
+		downloadMemoryTelemetry: createDownloadMemoryTelemetry(1_170, 1_200),
+		resourceEvidence: createResourceEvidence(),
+		shutdownOutcomes: createShutdownOutcomes(),
+		sinkWriteCalls: 2,
+		sinkWriteDurationMs: 8.5,
+		sinkWriteDurationDefinition: SINK_WRITE_DURATION_DEFINITION,
+		sinkServerWriteCalls: null,
+		sinkServerWriteDurationMs: null,
+		sinkServerWriteDurationDefinition: null,
+		readTransfer: {
+			chunkCount: 2,
+			totalBytes: FILE_SIZE_BYTES,
+			sources: { remote: { chunkCount: 2, bytes: FILE_SIZE_BYTES } },
+			demandWait: {
+				definition: DEMAND_WAIT_DEFINITION,
+				sampleCount: 2,
+				sumMs: 12,
+				p50Ms: 4,
+				p95Ms: 8,
+				p99Ms: 8,
+				maxMs: 8,
+				over1sCount: 0,
+				over5sCount: 0,
+				over10sCount: 0,
+			},
+			stages: {
+				libraryStreamWallMs: 30,
+				sinkWriteAwaitMs: 9,
+				sinkAwaitSubtractedDiagnosticMs: 21,
+				demandWaitMs: 12,
+				materializeMs: 4,
+				contentHashMs: 3,
+				otherStreamReadMs: 2,
+			},
 		},
-		stages: {
-			libraryStreamWallMs: 30,
-			sinkWriteAwaitMs: 9,
-			sinkAwaitSubtractedDiagnosticMs: 21,
-			demandWaitMs: 12,
-			materializeMs: 4,
-			contentHashMs: 3,
-			otherStreamReadMs: 2,
+		libraryStreamWallMs: 30,
+		libraryStreamWallDefinition: LIBRARY_STREAM_WALL_DEFINITION,
+		primaryDownloadMetric: "libraryStreamWallMs",
+		primaryDownloadAuthoritative: true,
+		primaryDownloadMetricDefinition: PRIMARY_DOWNLOAD_METRIC_DEFINITION,
+		sinkWriteAwaitMs: 9,
+		sinkWriteAwaitDefinition: SINK_WRITE_AWAIT_DEFINITION,
+		sinkAwaitSubtractedDiagnosticMs: 21,
+		sinkAwaitSubtractedDiagnosticDefinition:
+			SINK_AWAIT_SUBTRACTED_DIAGNOSTIC_DEFINITION,
+		phaseDurationsMs: {
+			timeToUploadSettled: 101,
+			timeToWriterReady: 100,
+			timeToReaderReady: 120,
+			writerListingLag: 0,
+			readerListingLag: 19,
+			readerAfterWriter: 20,
+			postUploadMonitor: 50,
+			download: 30,
 		},
-	},
-	libraryStreamWallMs: 30,
-	libraryStreamWallDefinition: LIBRARY_STREAM_WALL_DEFINITION,
-	primaryDownloadMetric: "libraryStreamWallMs",
-	primaryDownloadAuthoritative: true,
-	primaryDownloadMetricDefinition: PRIMARY_DOWNLOAD_METRIC_DEFINITION,
-	sinkWriteAwaitMs: 9,
-	sinkWriteAwaitDefinition: SINK_WRITE_AWAIT_DEFINITION,
-	sinkAwaitSubtractedDiagnosticMs: 21,
-	sinkAwaitSubtractedDiagnosticDefinition:
-		SINK_AWAIT_SUBTRACTED_DIAGNOSTIC_DEFINITION,
-	phaseDurationsMs: {
-		timeToUploadSettled: 101,
-		timeToWriterReady: 100,
-		timeToReaderReady: 120,
-		writerListingLag: 0,
-		readerListingLag: 19,
-		readerAfterWriter: 20,
-		postUploadMonitor: 50,
-		download: 30,
-	},
-	timestamps: {
-		uploadStartedAt: 1000,
-		progressSettledAt: 1090,
-		writerListedAt: 1100,
-		uploadSettledAt: 1101,
-		readerListedAt: 1120,
-		postMonitorStartedAt: 1120,
-		postMonitorFinishedAt: 1170,
-		downloadStartedAt: 1170,
-		downloadFinishedAt: 1200,
-		downloadCompletionObservedAt: 1201,
-	},
-	baselineWriterSeeders: 2,
-	baselineReaderSeeders: 2,
-	seederDropPolicy: { ...SEEDER_DROP_POLICY },
-	droppedSeeders: false,
-	unexpectedSeederDrop: false,
-	errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
-	knownPeerbitFailureSignatures: [...KNOWN_PEERBIT_FAILURE_SIGNATURES],
-	errorCollectionComplete: true,
-	errorCount: 0,
-	errors: [],
-	requestFailureCollectionDefinition: REQUEST_FAILURE_COLLECTION_DEFINITION,
-	requestFailureCollectionComplete: true,
-	requestFailureCount: 0,
-	requestFailures: [],
-	writerDiagnostics: {
-		lastUploadDiagnostics: createUploadDiagnostics(),
-	},
-	readerDiagnostics: {
-		lastReadDiagnostics: {
-			transferId: "benchmark-read-transfer-id",
+		timestamps: {
+			uploadStartedAt: 1000,
+			progressSettledAt: 1090,
+			writerListedAt: 1100,
+			uploadSettledAt: 1101,
+			readerListedAt: 1120,
+			postMonitorStartedAt: 1120,
+			postMonitorFinishedAt: 1170,
+			downloadStartedAt: 1170,
+			downloadFinishedAt: 1200,
+			downloadCompletionObservedAt: 1201,
+			postTransferSoakStartedAt: 1210,
+			postTransferSoakFinishedAt: 1260,
+		},
+		baselineWriterSeeders: 2,
+		baselineReaderSeeders: 2,
+		seederDropPolicy: { ...SEEDER_DROP_POLICY },
+		droppedSeeders: false,
+		unexpectedSeederDrop: false,
+		errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
+		knownPeerbitFailureSignatures: [...KNOWN_PEERBIT_FAILURE_SIGNATURES],
+		errorCollectionComplete: true,
+		errorCount: 0,
+		errors: [],
+		requestFailureCollectionDefinition: REQUEST_FAILURE_COLLECTION_DEFINITION,
+		requestFailureCollectionComplete: true,
+		requestFailureCount: 0,
+		requestFailures: [],
+		writerDiagnostics: {
+			lastUploadDiagnostics: createUploadDiagnostics(),
+		},
+		readerDiagnostics: {
+			lastReadDiagnostics: {
+				transferId: "benchmark-read-transfer-id",
+				fileId: FILE_ID,
+				fileName: FILE_NAME,
+				startedAt: 1_170,
+				finishedAt: 1_200,
+				persistChunkReads: false,
+				computedFinalHash: SHA256,
+				chunkResolved: { 0: "remote", 1: "remote" },
+				chunkByteLength: { 0: 3 * 1024 * 1024, 1: 2 * 1024 * 1024 },
+				chunkDemandWaitMs: { 0: 8, 1: 4 },
+				chunkResolveStartedAt: { 0: 1_170, 1: 1_185 },
+				chunkResolveFinishedAt: { 0: 1_171, 1: 1_186 },
+				chunkWriteStartedAt: { 0: 1_180, 1: 1_192 },
+				chunkWriteFinishedAt: { 0: 1_185, 1: 1_196 },
+				chunkMaterializeStartedAt: { 0: 1_171, 1: 1_186 },
+				chunkMaterializeFinishedAt: { 0: 1_173, 1: 1_188 },
+				chunkHashStartedAt: { 0: 1_173, 1: 1_188 },
+				chunkHashFinishedAt: { 0: 1_174, 1: 1_190 },
+				chunkPersistenceConfirmedAt: {},
+				chunkPersistenceConfirmationSource: {},
+			},
+		},
+		writerManifestEvidence: {
+			capturedAt: 1_100,
 			fileId: FILE_ID,
 			fileName: FILE_NAME,
-			startedAt: 1_170,
-			finishedAt: 1_200,
-			computedFinalHash: SHA256,
-			chunkResolved: { 0: "remote", 1: "remote" },
-			chunkByteLength: { 0: 3 * 1024 * 1024, 1: 2 * 1024 * 1024 },
-			chunkDemandWaitMs: { 0: 8, 1: 4 },
-			chunkWriteStartedAt: { 0: 1_180, 1: 1_192 },
-			chunkWriteFinishedAt: { 0: 1_185, 1: 1_196 },
-			chunkMaterializeStartedAt: { 0: 1_171, 1: 1_186 },
-			chunkMaterializeFinishedAt: { 0: 1_173, 1: 1_188 },
-			chunkHashStartedAt: { 0: 1_173, 1: 1_188 },
-			chunkHashFinishedAt: { 0: 1_174, 1: 1_190 },
+			sizeBytes: FILE_SIZE_BYTES,
+			finalHash: SHA256,
 		},
-	},
-	writerManifestEvidence: {
-		capturedAt: 1_100,
-		fileId: FILE_ID,
-		fileName: FILE_NAME,
-		sizeBytes: FILE_SIZE_BYTES,
-		finalHash: SHA256,
-	},
-	readerManifestEvidence: {
-		capturedAt: 1_120,
-		fileId: FILE_ID,
-		fileName: FILE_NAME,
-		sizeBytes: FILE_SIZE_BYTES,
-		finalHash: SHA256,
-	},
-	snapshots: [
-		{
-			label: "seeders-ready",
-			writerSeeders: 2,
-			readerSeeders: 2,
-			at: 900,
+		readerManifestEvidence: {
+			capturedAt: 1_120,
+			fileId: FILE_ID,
+			fileName: FILE_NAME,
+			sizeBytes: FILE_SIZE_BYTES,
+			finalHash: SHA256,
 		},
-		{
-			label: "after-1",
-			writerSeeders: 2,
-			readerSeeders: 2,
-			at: 1130,
-		},
-		{
-			label: "terminal",
-			writerSeeders: 2,
-			readerSeeders: 2,
-			at: 1210,
-		},
-	],
-});
+		snapshots: [
+			{
+				label: "seeders-ready",
+				writerSeeders: 2,
+				readerSeeders: 2,
+				at: 900,
+			},
+			{
+				label: "after-1",
+				writerSeeders: 2,
+				readerSeeders: 2,
+				at: 1130,
+			},
+			{
+				label: "terminal",
+				writerSeeders: 2,
+				readerSeeders: 2,
+				at: 1265,
+			},
+		],
+	};
+	refreshReceiverProgress(result);
+	return result;
+};
 
 const createSinkFixture = (downloadSink) => {
 	const invocation = createBenchmarkInvocation({
@@ -542,6 +1053,7 @@ const createSinkFixture = (downloadSink) => {
 		uploadTimeoutMs: 600_000,
 		downloadTimeoutMs: 600_000,
 		postUploadMonitorMs: 50,
+		postTransferSoakMs: 50,
 		pollMs: 1_000,
 		minReadySeeders: 2,
 		readyTimeoutMs: 180_000,
@@ -564,6 +1076,7 @@ const createSinkFixture = (downloadSink) => {
 		result.sinkServerWriteDurationDefinition =
 			"loopback-request-body-receive-and-node-filesystem-write-only";
 	}
+	refreshReceiverProgress(result);
 	return {
 		result,
 		options: { ...options, expectedInvocation: invocation },
@@ -587,6 +1100,7 @@ const createReaderLocalityFixture = ({
 		uploadTimeoutMs: 600_000,
 		downloadTimeoutMs: 600_000,
 		postUploadMonitorMs: 50,
+		postTransferSoakMs: 50,
 		pollMs: 1_000,
 		minReadySeeders: 1,
 		readyTimeoutMs: 180_000,
@@ -762,12 +1276,19 @@ const createReaderLocalityFixture = ({
 		initialLocalChunkBlockCount: actualBlockCount,
 		startedAt: 1_600,
 		finishedAt: 1_630,
+		chunkResolveStartedAt: { 0: 1_600, 1: 1_615 },
+		chunkResolveFinishedAt: { 0: 1_601, 1: 1_616 },
 		chunkWriteStartedAt: { 0: 1_610, 1: 1_622 },
 		chunkWriteFinishedAt: { 0: 1_615, 1: 1_626 },
 		chunkMaterializeStartedAt: { 0: 1_601, 1: 1_616 },
 		chunkMaterializeFinishedAt: { 0: 1_603, 1: 1_618 },
 		chunkHashStartedAt: { 0: 1_603, 1: 1_618 },
 		chunkHashFinishedAt: { 0: 1_604, 1: 1_620 },
+		chunkPersistenceConfirmedAt: { 0: 1_605, 1: 1_621 },
+		chunkPersistenceConfirmationSource: {
+			0: "manifest-head-batch-local",
+			1: "manifest-head-batch-remote",
+		},
 	});
 	result.writerManifestEvidence.fileName = fileName;
 	result.readerManifestEvidence.fileName = fileName;
@@ -778,20 +1299,35 @@ const createReaderLocalityFixture = ({
 	result.timestamps.downloadStartedAt = 1_600;
 	result.timestamps.downloadFinishedAt = 1_630;
 	result.timestamps.downloadCompletionObservedAt = 1_631;
+	result.timestamps.postTransferSoakStartedAt = 2_041;
+	result.timestamps.postTransferSoakFinishedAt = 2_091;
 	result.integrityVerifiedAt = 1_837;
 	result.downloadMemoryTelemetry = createDownloadMemoryTelemetry(
 		1_600,
 		1_630,
 		invocation,
+		{ afterSoakStartedAt: 2_092, shutdownFinishedAt: 2_101 },
 	);
-	result.downloadMemoryTelemetry.startedAt = 1_380;
+	result.resourceEvidence = createResourceEvidence({
+		beforeTimedRead: [1_377, 1_380],
+		afterSink: [1_836, 1_837],
+		beforeSoak: [2_040, 2_041],
+		afterSoak: [2_092, 2_094],
+	});
+	result.shutdownOutcomes = createShutdownOutcomes({
+		writerStartedAt: 2_096,
+		writerFinishedAt: 2_099,
+		readerStartedAt: 2_096,
+		readerFinishedAt: 2_101,
+	});
+	result.downloadMemoryTelemetry.startedAt = 1_375;
 	for (const series of [
 		result.downloadMemoryTelemetry.readerJsHeap,
 		result.downloadMemoryTelemetry.writerJsHeap,
 		result.downloadMemoryTelemetry.hostRss,
 	]) {
-		series.startedAt = 1_380;
-		series.samples[0].capturedAt = 1_381;
+		series.startedAt = 1_375;
+		series.samples[0].capturedAt = 1_376;
 	}
 	result.readerLocalityControl = {
 		profile: "observer-topology-exact-manifest-prefix",
@@ -823,26 +1359,22 @@ const createReaderLocalityFixture = ({
 		},
 		writerTopologyBeforeUpload: topology(990, true),
 		readerTopologyBeforeUpload: topology(991, false),
-		writerTopologyBeforeTimedRead:
-			structuredClone(
-				preTimedReadTopologyObservations.at(-1).writerTopology,
-			),
-		readerTopologyBeforeTimedRead:
-			structuredClone(
-				preTimedReadTopologyObservations.at(-1).readerTopology,
-			),
+		writerTopologyBeforeTimedRead: structuredClone(
+			preTimedReadTopologyObservations.at(-1).writerTopology,
+		),
+		readerTopologyBeforeTimedRead: structuredClone(
+			preTimedReadTopologyObservations.at(-1).readerTopology,
+		),
 		preTimedReadTopologyStartedAt: 1_381,
 		preTimedReadTopologyDeadlineAt: 6_381,
 		preTimedReadTopologyFinishedAt: 1_583,
 		preTimedReadTopologyObservations,
-		writerTopologyAfterTimedRead:
-			structuredClone(
-				postTimedReadTopologyObservations.at(-1).writerTopology,
-			),
-		readerTopologyAfterTimedRead:
-			structuredClone(
-				postTimedReadTopologyObservations.at(-1).readerTopology,
-			),
+		writerTopologyAfterTimedRead: structuredClone(
+			postTimedReadTopologyObservations.at(-1).writerTopology,
+		),
+		readerTopologyAfterTimedRead: structuredClone(
+			postTimedReadTopologyObservations.at(-1).readerTopology,
+		),
 		postTimedReadTopologyStartedAt: 1_634,
 		postTimedReadTopologyDeadlineAt: 6_634,
 		postTimedReadTopologyFinishedAt: 1_836,
@@ -935,13 +1467,14 @@ const createReaderLocalityFixture = ({
 			label: "terminal",
 			writerSeeders: 1,
 			readerSeeders: 1,
-			at: 2_041,
+			at: 2_095,
 		},
 	];
 	result.baselineWriterSeeders = 1;
 	result.baselineReaderSeeders = 1;
 	result.droppedSeeders = false;
 	result.unexpectedSeederDrop = false;
+	refreshReceiverProgress(result);
 	return {
 		result,
 		options: {
@@ -956,6 +1489,95 @@ test("accepts a complete deterministic transfer result", () => {
 	assert.equal(
 		validateBenchmarkResult(validResult(), options).status,
 		"passed",
+	);
+});
+
+test("requires exact receiver progress and rejects false durability claims", () => {
+	for (const mutate of [
+		(result) => {
+			result.readTransfer.receiverProgress.percentages[1] = 6;
+		},
+		(result) => {
+			result.readTransfer.receiverProgress.available.milestones[10].confirmedAt += 1;
+		},
+		(result) => {
+			delete result.readTransfer.receiverProgress.available.milestones[10]
+				.elapsedMs;
+		},
+		(result) => {
+			result.readTransfer.receiverProgress.available.source =
+				"chunkWriteFinishedAt";
+		},
+		(result) => {
+			result.readTransfer.receiverProgress.sinkAccepted.durable = true;
+		},
+		(result) => {
+			result.readTransfer.receiverProgress.sinkAccepted.sink = "opfs";
+		},
+		(result) => {
+			result.readTransfer.receiverProgress.peerbitDurable.sourceCounts = {
+				fabricated: 1,
+			};
+		},
+		(result) => {
+			result.readTransfer.receiverProgress.sinkAccepted.milestones.at(
+				-1,
+			).contiguousBytes -= 1;
+		},
+	]) {
+		const result = validResult();
+		mutate(result);
+		assert.throws(
+			() => validateBenchmarkResult(result, options),
+			/read-transfer timing decomposition is inconsistent/,
+		);
+	}
+
+	const observerWithDurability = validResult();
+	observerWithDurability.readerDiagnostics.lastReadDiagnostics.chunkPersistenceConfirmedAt =
+		{ 0: 1_180 };
+	observerWithDurability.readerDiagnostics.lastReadDiagnostics.chunkPersistenceConfirmationSource =
+		{ 0: "fabricated" };
+	assert.throws(
+		() => validateBenchmarkResult(observerWithDurability, options),
+		/chunkPersistenceConfirmedAt contains unexpected or missing fields/,
+	);
+
+	const durableSourceMismatch = createReaderLocalityFixture();
+	durableSourceMismatch.result.readTransfer.receiverProgress.peerbitDurable.sourceCounts =
+		{ fabricated: 2 };
+	assert.throws(
+		() =>
+			validateBenchmarkResult(
+				durableSourceMismatch.result,
+				durableSourceMismatch.options,
+			),
+		/read-transfer timing decomposition is inconsistent/,
+	);
+
+	const durableOutsideRead = createReaderLocalityFixture();
+	durableOutsideRead.result.readerDiagnostics.lastReadDiagnostics.chunkPersistenceConfirmedAt[1] =
+		durableOutsideRead.result.readerDiagnostics.lastReadDiagnostics.finishedAt +
+		1;
+	assert.throws(
+		() =>
+			validateBenchmarkResult(
+				durableOutsideRead.result,
+				durableOutsideRead.options,
+			),
+		/outside the canonical library read window/,
+	);
+
+	const unknownDurabilitySource = createReaderLocalityFixture();
+	unknownDurabilitySource.result.readerDiagnostics.lastReadDiagnostics.chunkPersistenceConfirmationSource[0] =
+		"unknown-source";
+	assert.throws(
+		() =>
+			validateBenchmarkResult(
+				unknownDurabilitySource.result,
+				unknownDurabilitySource.options,
+			),
+		/not a recognized persistence source/,
 	);
 });
 
@@ -1004,7 +1626,7 @@ test("requires a trustworthy aggregate-integrity timestamp before the final snap
 					label: "during-99",
 					writerSeeders: 2,
 					readerSeeders: 2,
-					at: 1_211,
+					at: 1_265,
 				});
 			},
 			/must end with exactly one terminal seeder snapshot/,
@@ -1033,8 +1655,8 @@ test("requires the terminal snapshot after controlled-locality topology", () => 
 	);
 
 	const sameMillisecond = createReaderLocalityFixture();
-	sameMillisecond.result.snapshots.at(-1).at =
-		sameMillisecond.result.readerLocalityControl.terminalTopologyFinishedAt;
+	sameMillisecond.result.readerLocalityControl.terminalTopologyFinishedAt =
+		sameMillisecond.result.resourceEvidence.snapshots.beforeSoak.startedAt;
 	assert.equal(
 		validateBenchmarkResult(sameMillisecond.result, sameMillisecond.options)
 			.status,
@@ -1042,7 +1664,287 @@ test("requires the terminal snapshot after controlled-locality topology", () => 
 	);
 });
 
-test("accepts one recovered seeder dip under the v9 policy", () => {
+test("accepts explicit disabled eager-cache evidence", () => {
+	const result = validResult();
+	for (const snapshot of Object.values(result.resourceEvidence.snapshots)) {
+		for (const role of ["writer", "reader"]) {
+			snapshot[role].runtime.eagerBlocks.enabled = false;
+			snapshot[role].runtime.eagerBlocks.telemetry = null;
+		}
+	}
+	for (const interval of Object.values(result.resourceEvidence.intervals)) {
+		interval.writerEager = null;
+		interval.readerEager = null;
+	}
+	assert.equal(validateBenchmarkResult(result, options).status, "passed");
+});
+
+test("requires ordered exact resource, soak, and shutdown evidence", () => {
+	for (const [mutate, pattern] of [
+		[
+			(result) => {
+				delete result.resourceEvidence;
+			},
+			/missing resourceEvidence/,
+		],
+		[
+			(result) => {
+				result.resourceEvidence.schemaVersion = 1;
+			},
+			/resource evidence contract is invalid/,
+		],
+		[
+			(result) => {
+				delete result.resourceEvidence.snapshots.beforeSoak;
+			},
+			/resourceEvidence\.snapshots contains unexpected or missing fields/,
+		],
+		[
+			(result) => {
+				result.resourceEvidence.snapshots.extra = {};
+			},
+			/resourceEvidence\.snapshots contains unexpected or missing fields/,
+		],
+		[
+			(result) => {
+				result.resourceEvidence.snapshots.beforeTimedRead.finishedAt =
+					result.timestamps.downloadStartedAt + 1;
+			},
+			/resource snapshots, soak, integrity, and terminal evidence are out of order/,
+		],
+		[
+			(result) => {
+				result.resourceEvidence.snapshots.beforeSoak.startedAt =
+					result.integrityVerifiedAt - 1;
+			},
+			/resource snapshots, soak, integrity, and terminal evidence are out of order/,
+		],
+		[
+			(result) => {
+				result.resourceEvidence.snapshots.beforeSoak.finishedAt =
+					result.timestamps.postTransferSoakStartedAt + 1;
+			},
+			/resource snapshots, soak, integrity, and terminal evidence are out of order/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.startedAt =
+					result.resourceEvidence.snapshots.beforeTimedRead.startedAt + 1;
+			},
+			/resource snapshots, soak, integrity, and terminal evidence are out of order/,
+		],
+		[
+			(result) => {
+				result.resourceEvidence.snapshots.beforeTimedRead.finishedAt =
+					result.resourceEvidence.snapshots.beforeTimedRead.startedAt + 20_000;
+			},
+			/capture window is invalid or unbounded/,
+		],
+		[
+			(result) => {
+				result.resourceEvidence.snapshots.afterSink.writer.storage.peerbitLog.scope =
+					"origin-wide";
+			},
+			/peerbitLog contract is invalid/,
+		],
+		[
+			(result) => {
+				result.resourceEvidence.snapshots.afterSink.reader.storage.backingStorage.available = false;
+			},
+			/backingStorage contract is invalid/,
+		],
+		[
+			(result) => {
+				result.resourceEvidence.snapshots.afterSink.reader.storage.backingStorage.usageDetails =
+					Object.fromEntries(
+						Array.from({ length: 65 }, (_, index) => [`kind-${index}`, 1]),
+					);
+			},
+			/too many storage categories/,
+		],
+		[
+			(result) => {
+				result.resourceEvidence.snapshots.afterSink.writer.runtime.nativeGraph.useHeads =
+					null;
+			},
+			/nativeGraph contract is invalid/,
+		],
+		[
+			(result) => {
+				delete result.resourceEvidence.snapshots.afterSink.writer.runtime
+					.identity.sessionId;
+			},
+			/identity contains unexpected or missing fields/,
+		],
+		[
+			(result) => {
+				result.resourceEvidence.snapshots.afterSink.writer.runtime.identity.sessionId =
+					"replacement-session";
+			},
+			/writer runtime provenance changed/,
+		],
+		[
+			(result) => {
+				result.resourceEvidence.snapshots.beforeSoak.reader.storage.origin =
+					"http://127.0.0.1:4174";
+			},
+			/reader runtime provenance changed/,
+		],
+		[
+			(result) => {
+				for (const snapshot of Object.values(
+					result.resourceEvidence.snapshots,
+				)) {
+					snapshot.reader.runtime.identity.peerId =
+						snapshot.writer.runtime.identity.peerId;
+				}
+				result.shutdownOutcomes.reader.identity.peerId =
+					result.shutdownOutcomes.writer.identity.peerId;
+			},
+			/does not identify two distinct peers/,
+		],
+		[
+			(result) => {
+				for (const snapshot of Object.values(
+					result.resourceEvidence.snapshots,
+				)) {
+					snapshot.reader.runtime.identity.sessionId =
+						snapshot.writer.runtime.identity.sessionId;
+				}
+				result.shutdownOutcomes.reader.identity.sessionId =
+					result.shutdownOutcomes.writer.identity.sessionId;
+			},
+			/does not identify two distinct peers/,
+		],
+		[
+			(result) => {
+				for (const snapshot of Object.values(
+					result.resourceEvidence.snapshots,
+				)) {
+					snapshot.reader.runtime.identity.programAddress = "different-program";
+				}
+				result.shutdownOutcomes.reader.identity.programAddress =
+					"different-program";
+			},
+			/does not identify two distinct peers in one program/,
+		],
+		[
+			(result) => {
+				result.resourceEvidence.snapshots.afterSink.reader.runtime.pubsub.snapshot.fanout.root.uploadLimitBps = 0;
+			},
+			/fanout\.root\.uploadLimitBps/,
+		],
+		[
+			(result) => {
+				result.resourceEvidence.snapshots.afterSink.writer.runtime.pubsub.snapshot.fanout.node.uploadLimitBps += 1;
+			},
+			/writer runtime provenance changed/,
+		],
+		[
+			(result) => {
+				result.resourceEvidence.snapshots.afterSink.writer.runtime.eagerBlocks.telemetry.admitted = 0;
+			},
+			/writer eager-cache admitted regressed/,
+		],
+		[
+			(result) => {
+				result.resourceEvidence.snapshots.beforeSoak.reader.runtime.eagerBlocks.telemetry.hits = 0;
+			},
+			/reader eager-cache hits regressed/,
+		],
+		[
+			(result) => {
+				result.resourceEvidence.intervals.timedReadEnvelope.writerStorage.peerbitLogUsageDeltaBytes += 1;
+			},
+			/resource interval deltas contradict/,
+		],
+		[
+			(result) => {
+				result.resourceEvidence.intervals.postTransferWork.from =
+					"beforeTimedRead";
+			},
+			/resource interval deltas contradict/,
+		],
+		[
+			(result) => {
+				result.resourceEvidence.intervals.soak.readerStorage.backingStorageUsageDeltaBytes += 1;
+			},
+			/resource interval deltas contradict/,
+		],
+		[
+			(result) => {
+				result.timestamps.postTransferSoakFinishedAt -= 1;
+				result.postTransferSoakActualMs -= 1;
+			},
+			/post-transfer soak duration or scheduling contract is invalid/,
+		],
+		[
+			(result) => {
+				result.timestamps.postTransferSoakStartedAt =
+					result.integrityVerifiedAt - 1;
+				result.timestamps.postTransferSoakFinishedAt =
+					result.timestamps.postTransferSoakStartedAt + 50;
+			},
+			/post-transfer soak duration or scheduling contract is invalid/,
+		],
+		[
+			(result) => {
+				result.postTransferSoakMs -= 1;
+			},
+			/postTransferSoakMs does not match the requested invocation/,
+		],
+		[
+			(result) => {
+				result.shutdownOutcomes.writer.status = "rejected";
+				result.shutdownOutcomes.writer.error = "failed";
+			},
+			/not a successful bounded shutdown/,
+		],
+		[
+			(result) => {
+				result.shutdownOutcomes.reader.durationMs += 1;
+			},
+			/not a successful bounded shutdown/,
+		],
+		[
+			(result) => {
+				result.shutdownOutcomes.writer.programClosed = false;
+			},
+			/not a successful bounded shutdown/,
+		],
+		[
+			(result) => {
+				result.shutdownOutcomes.reader.identity.sessionId = "stale-session";
+			},
+			/shutdown identities do not match/,
+		],
+		[
+			(result) => {
+				const outcome = result.shutdownOutcomes.reader;
+				outcome.finishedAt = outcome.startedAt + 31_251;
+				outcome.durationMs = 31_251;
+			},
+			/not a successful bounded shutdown/,
+		],
+		[
+			(result) => {
+				result.shutdownOutcomes.writer.startedAt = 1_278;
+				result.shutdownOutcomes.writer.finishedAt = 1_280;
+				result.shutdownOutcomes.writer.durationMs = 2;
+				result.shutdownOutcomes.reader.startedAt = 1_278;
+				result.shutdownOutcomes.reader.finishedAt = 1_285;
+				result.shutdownOutcomes.reader.durationMs = 7;
+			},
+			/invalid live or terminal checkpoint ordering/,
+		],
+	]) {
+		const result = validResult();
+		mutate(result);
+		assert.throws(() => validateBenchmarkResult(result, options), pattern);
+	}
+});
+
+test("accepts one recovered seeder dip under the v10 policy", () => {
 	const result = validResult();
 	result.snapshots[1].writerSeeders = 1;
 	result.droppedSeeders = true;
@@ -1077,7 +1979,7 @@ test("rejects a terminal below-baseline seeder snapshot", () => {
 	);
 });
 
-test("rejects missing, altered, and contradictory v9 seeder-drop evidence", () => {
+test("rejects missing, altered, and contradictory v10 seeder-drop evidence", () => {
 	for (const [mutate, pattern] of [
 		[
 			(result) => {
@@ -1401,6 +2303,8 @@ test("rejects milestones crossed before a partial-tail trigger", () => {
 		indices.map((index) => [index, 0]),
 	);
 	for (const key of [
+		"chunkResolveStartedAt",
+		"chunkResolveFinishedAt",
 		"chunkWriteStartedAt",
 		"chunkWriteFinishedAt",
 		"chunkMaterializeStartedAt",
@@ -1440,6 +2344,7 @@ test("rejects milestones crossed before a partial-tail trigger", () => {
 	result.sinkWriteDurationMs = 0;
 	result.sinkWriteAwaitMs = 0;
 	result.sinkAwaitSubtractedDiagnosticMs = 30;
+	refreshReceiverProgress(result);
 
 	const diagnostics = result.writerDiagnostics.lastUploadDiagnostics;
 	diagnostics.chunkSize = chunkSize;
@@ -1520,6 +2425,24 @@ test("requires bounded, error-free memory telemetry covering the canonical read"
 		],
 		[
 			(result) => {
+				result.downloadMemoryTelemetry.postTransferSoakMs += 1;
+			},
+			/telemetry contract is invalid/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.operationTimeoutMs += 1;
+			},
+			/telemetry contract is invalid/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.liveSampleMaxGapMs += 1;
+			},
+			/telemetry contract is invalid/,
+		],
+		[
+			(result) => {
 				result.downloadMemoryTelemetry.readerJsHeap.samplingErrors.push("boom");
 			},
 			/contains memory sampling errors/,
@@ -1551,7 +2474,7 @@ test("requires bounded, error-free memory telemetry covering the canonical read"
 		],
 		[
 			(result) => {
-				result.downloadMemoryTelemetry.readerJsHeap.sampleCount = 3;
+				result.downloadMemoryTelemetry.readerJsHeap.sampleCount = 5;
 			},
 			/invalid bounded sample series/,
 		],
@@ -1567,13 +2490,14 @@ test("requires bounded, error-free memory telemetry covering the canonical read"
 			(result) => {
 				result.downloadMemoryTelemetry.readerJsHeap.samples[0].capturedAt = 1_171;
 			},
-			/does not bracket the click-to-sink observation window/,
+			/does not bracket the click-to-post-shutdown observation window/,
 		],
 		[
 			(result) => {
-				result.downloadMemoryTelemetry.writerJsHeap.samples[1].capturedAt = 1_199;
+				result.downloadMemoryTelemetry.writerJsHeap.samples.at(-1).capturedAt =
+					1_201;
 			},
-			/does not bracket the click-to-sink observation window/,
+			/reorder the sampler window/,
 		],
 		[
 			(result) => {
@@ -1590,11 +2514,15 @@ test("requires bounded, error-free memory telemetry covering the canonical read"
 		[
 			(result) => {
 				const series = result.downloadMemoryTelemetry.writerJsHeap;
-				series.samples[1].capturedAt =
-					result.timestamps.downloadCompletionObservedAt +
+				series.samples.at(-1).capturedAt =
+					Math.max(
+						result.shutdownOutcomes.writer.finishedAt,
+						result.shutdownOutcomes.reader.finishedAt,
+					) +
 					DOWNLOAD_MEMORY_TERMINAL_ALLOWANCE_MS +
 					1;
-				series.finishedAt = series.samples[1].capturedAt + 1;
+				series.finishedAt = series.samples.at(-1).capturedAt + 1;
+				series.terminalSampleAt = series.samples.at(-1).capturedAt;
 			},
 			/ends after the bounded telemetry cleanup window/,
 		],
@@ -1606,9 +2534,41 @@ test("requires bounded, error-free memory telemetry covering the canonical read"
 		],
 		[
 			(result) => {
+				delete result.downloadMemoryTelemetry.readerJsHeap.startTotalBytes;
+			},
+			/unexpected or missing fields/,
+		],
+		[
+			(result) => {
+				const sample = result.downloadMemoryTelemetry.readerJsHeap.samples[0];
+				sample.totalBytes = sample.usedBytes - 1;
+			},
+			/heap totals are inconsistent/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.writerJsHeap.peakBackingStorageBytes += 1;
+			},
+			/heap summaries are inconsistent/,
+		],
+		[
+			(result) => {
 				result.downloadMemoryTelemetry.hostRss.samples[0].combinedBytes += 1;
 			},
 			/RSS totals are inconsistent/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.hostRss.peakNodeExternalBytes += 1;
+			},
+			/host RSS summaries are inconsistent/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.hostRss.samples[0].nodeArrayBuffersBytes =
+					-1;
+			},
+			/nodeArrayBuffersBytes/,
 		],
 		[
 			(result) => {
@@ -1662,6 +2622,186 @@ test("requires bounded, error-free memory telemetry covering the canonical read"
 	}
 });
 
+test("accepts a short phase with no periodic sample when live endpoints cover it", () => {
+	const result = validResult();
+	const series = result.downloadMemoryTelemetry.readerJsHeap;
+	series.samples = series.samples.filter(
+		(sample) => sample.sampleKind !== "periodic",
+	);
+	series.sampleCount = series.samples.length;
+	series.periodicSampleCount = 0;
+	const peak = (key) =>
+		Math.max(...series.samples.map((sample) => sample[key]));
+	series.peakBytes = peak("usedBytes");
+	series.peakUsedBytes = peak("usedBytes");
+	series.peakTotalBytes = peak("totalBytes");
+	series.peakEmbedderHeapUsedBytes = peak("embedderHeapUsedBytes");
+	series.peakBackingStorageBytes = peak("backingStorageBytes");
+	assert.equal(validateBenchmarkResult(result, options).status, "passed");
+});
+
+test("rejects a long live phase with an uncovered periodic-sampling gap", () => {
+	const result = validResult();
+	result.timestamps.postTransferSoakStartedAt = 20_000;
+	result.timestamps.postTransferSoakFinishedAt = 20_050;
+	result.resourceEvidence = createResourceEvidence({
+		beforeTimedRead: [1_168, 1_170],
+		afterSink: [1_202, 1_204],
+		beforeSoak: [19_995, 20_000],
+		afterSoak: [20_051, 20_054],
+	});
+	result.snapshots.at(-1).at = 20_055;
+	result.shutdownOutcomes = createShutdownOutcomes({
+		writerStartedAt: 20_056,
+		writerFinishedAt: 20_061,
+		readerStartedAt: 20_056,
+		readerFinishedAt: 20_063,
+	});
+	result.downloadMemoryTelemetry = createDownloadMemoryTelemetry(
+		1_170,
+		1_200,
+		INVOCATION,
+		{ afterSoakStartedAt: 20_051, shutdownFinishedAt: 20_063 },
+	);
+	assert.throws(
+		() => validateBenchmarkResult(result, options),
+		/live-sample gap/,
+	);
+});
+
+test("requires sufficient full-window capacity and distinct memory checkpoints", () => {
+	for (const [mutate, pattern] of [
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.samplingWindowBudgetMs += 1;
+			},
+			/telemetry contract is invalid/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.endpointSampleAllowance = 2;
+			},
+			/telemetry contract is invalid/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.capacityExhaustedBeforeTerminal = true;
+				result.downloadMemoryTelemetry.samplingCapacitySufficient = false;
+			},
+			/telemetry contract is invalid/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.manualCheckpointComplete = false;
+			},
+			/telemetry contract is invalid/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.terminalCheckpointComplete = false;
+			},
+			/telemetry contract is invalid/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.readerJsHeap.maxSamples -= 1;
+			},
+			/invalid bounded sample series/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.writerJsHeap.periodicSampleLimit += 1;
+			},
+			/invalid bounded sample series/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.hostRss.periodicSampleCount += 1;
+			},
+			/invalid bounded sample series/,
+		],
+		[
+			(result) => {
+				const series = result.downloadMemoryTelemetry.readerJsHeap;
+				series.capacityExhaustedBeforeTerminal = true;
+				series.samplingCapacitySufficient = false;
+			},
+			/invalid bounded sample series/,
+		],
+		[
+			(result) => {
+				delete result.downloadMemoryTelemetry.readerJsHeap.samples[0]
+					.sampleKind;
+			},
+			/invalid sample kind/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.readerJsHeap.samples[1].sampleKind =
+					"initial";
+			},
+			/invalid live or terminal checkpoint ordering/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.writerJsHeap.samples[1].sampleKind =
+					"manual";
+			},
+			/duplicate manual samples/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.hostRss.samples.at(-1).sampleKind =
+					"periodic";
+			},
+			/invalid live or terminal checkpoint ordering/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.hostRss.samples[1].sampleKind =
+					"terminal";
+			},
+			/duplicate terminal samples/,
+		],
+		[
+			(result) => {
+				const series = result.downloadMemoryTelemetry.readerJsHeap;
+				const manual = series.samples.find(
+					(sample) => sample.sampleKind === "manual",
+				);
+				manual.capturedAt = result.shutdownOutcomes.reader.finishedAt + 1;
+				series.lastManualSampleAt = manual.capturedAt;
+			},
+			/invalid live or terminal checkpoint ordering/,
+		],
+		[
+			(result) => {
+				const series = result.downloadMemoryTelemetry.writerJsHeap;
+				const manual = series.samples.find(
+					(sample) => sample.sampleKind === "manual",
+				);
+				manual.capturedAt =
+					result.resourceEvidence.snapshots.afterSoak.startedAt + 1;
+				series.lastManualSampleAt = manual.capturedAt;
+			},
+			/invalid live or terminal checkpoint ordering/,
+		],
+		[
+			(result) => {
+				const series = result.downloadMemoryTelemetry.hostRss;
+				const terminal = series.samples.at(-1);
+				terminal.capturedAt = result.shutdownOutcomes.reader.finishedAt - 1;
+				series.terminalSampleAt = terminal.capturedAt;
+			},
+			/invalid live or terminal checkpoint ordering/,
+		],
+	]) {
+		const result = validResult();
+		mutate(result);
+		assert.throws(() => validateBenchmarkResult(result, options), pattern);
+	}
+});
+
 test("accepts exact observer-locality control and rejects contradictory evidence", () => {
 	const fixture = createReaderLocalityFixture();
 	assert.equal(
@@ -1683,15 +2823,13 @@ test("accepts exact observer-locality control and rejects contradictory evidence
 		],
 		[
 			(result) => {
-				result.readerLocalityControl.transportCounterPreReadStartToleranceMs =
-					999;
+				result.readerLocalityControl.transportCounterPreReadStartToleranceMs = 999;
 			},
 			/locality control contract is invalid/,
 		],
 		[
 			(result) => {
-				result.readerLocalityControl.transportCounterPostReadCaptureMaxDelayMs =
-					10_000;
+				result.readerLocalityControl.transportCounterPostReadCaptureMaxDelayMs = 10_000;
 			},
 			/locality control contract is invalid/,
 		],
@@ -1761,8 +2899,7 @@ test("accepts exact observer-locality control and rejects contradictory evidence
 			(result) => {
 				result.readerLocalityControl.writerTopologyAfterTimedRead.replicatorHashes =
 					["reader-peer", "writer-peer"];
-				result.readerLocalityControl.writerTopologyAfterTimedRead.replicatorCount =
-					2;
+				result.readerLocalityControl.writerTopologyAfterTimedRead.replicatorCount = 2;
 			},
 			/immediate post-read topology evidence is inconsistent/,
 		],
@@ -1797,8 +2934,7 @@ test("accepts exact observer-locality control and rejects contradictory evidence
 		],
 		[
 			(result) => {
-				result.readerLocalityControl.preTimedReadTopologyObservations[1].writerTopology.transportStreams[0].peerHashIdentityMatch =
-					false;
+				result.readerLocalityControl.preTimedReadTopologyObservations[1].writerTopology.transportStreams[0].peerHashIdentityMatch = false;
 			},
 			/relevant pubsub stream 0 is not authoritative/,
 		],
@@ -2261,14 +3397,14 @@ test("bounds Node-file server timing against its browser sink timing", () => {
 	);
 });
 
-test("rejects a status-only passed payload at the v9 evidence envelope", () => {
+test("rejects a status-only passed payload at the v10 evidence envelope", () => {
 	assert.throws(
 		() => validateBenchmarkResultEnvelope({ status: "passed" }, options),
 		/missing schema/,
 	);
 });
 
-test("requires explicit error evidence on failed v9 envelopes", () => {
+test("requires explicit error evidence on failed v10 envelopes", () => {
 	const completeFailure = validResult();
 	completeFailure.status = "failed";
 	completeFailure.failure = { message: "synthetic browser failure" };
@@ -2605,6 +3741,34 @@ for (const [name, mutate, pattern] of [
 			result.readerDiagnostics.lastReadDiagnostics.chunkWriteStartedAt[1] = 1_184;
 		},
 		/ordered and non-overlapping/,
+	],
+	[
+		"resolve completes after materialization starts",
+		(result) => {
+			result.readerDiagnostics.lastReadDiagnostics.chunkResolveFinishedAt[0] = 1_172;
+		},
+		/lifecycle is not causal/,
+	],
+	[
+		"materialization completes after hashing starts",
+		(result) => {
+			result.readerDiagnostics.lastReadDiagnostics.chunkMaterializeFinishedAt[0] = 1_174;
+		},
+		/lifecycle is not causal/,
+	],
+	[
+		"hashing completes after sink writing starts",
+		(result) => {
+			result.readerDiagnostics.lastReadDiagnostics.chunkHashFinishedAt[0] = 1_181;
+		},
+		/lifecycle is not causal/,
+	],
+	[
+		"next chunk materializes before the previous sink write finishes",
+		(result) => {
+			result.readerDiagnostics.lastReadDiagnostics.chunkMaterializeStartedAt[1] = 1_184;
+		},
+		/lifecycle is not causal/,
 	],
 	[
 		"raw read byte coverage",

--- a/scripts/file-share/download-memory-telemetry.test.mjs
+++ b/scripts/file-share/download-memory-telemetry.test.mjs
@@ -2,60 +2,207 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { setTimeout as delay } from "node:timers/promises";
 import {
+	DOWNLOAD_MEMORY_LIVE_SAMPLE_COVERAGE_DEFINITION,
 	DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH,
 	DOWNLOAD_MEMORY_MAX_SAMPLES_PER_SERIES,
 	DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS,
+	DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS,
+	DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
+	assertDownloadMemoryLiveSampleCoverage,
+	calculateDownloadMemoryMaxLiveSampleGapMs,
 	calculateDownloadMemoryMaxSamples,
 	startBoundedSerialSampler,
 	startDownloadMemoryTelemetry,
 	withDownloadMemoryOperationDeadline,
 } from "./templates/download-memory-telemetry.mjs";
 
+test("requires bounded non-terminal coverage for each exact live phase", () => {
+	const maxGapMs = calculateDownloadMemoryMaxLiveSampleGapMs({
+		schedulingToleranceMs: 5_000,
+	});
+	assert.equal(
+		maxGapMs,
+		DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS +
+			DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS +
+			5_000,
+	);
+	assert.deepEqual(
+		assertDownloadMemoryLiveSampleCoverage({
+			samples: [
+				{ capturedAt: 99, sampleKind: "initial" },
+				{ capturedAt: 101, sampleKind: "manual" },
+				{ capturedAt: 102, sampleKind: "terminal" },
+			],
+			phaseStartedAt: 100,
+			phaseFinishedAt: 101,
+			maxGapMs,
+			label: "short phase",
+		}),
+		{
+			firstSampleAt: 99,
+			lastSampleAt: 101,
+			startOverhangMs: 1,
+			endOverhangMs: 0,
+			maxObservedGapMs: 2,
+			sampleCount: 2,
+		},
+	);
+	assert.throws(
+		() =>
+			assertDownloadMemoryLiveSampleCoverage({
+				samples: [
+					{ capturedAt: 1, sampleKind: "initial" },
+					{ capturedAt: maxGapMs + 2, sampleKind: "manual" },
+				],
+				phaseStartedAt: 2,
+				phaseFinishedAt: maxGapMs + 1,
+				maxGapMs,
+				label: "long phase",
+			}),
+		/live-sample gap/,
+	);
+	assert.throws(
+		() =>
+			assertDownloadMemoryLiveSampleCoverage({
+				samples: [
+					{ capturedAt: 1, sampleKind: "initial" },
+					{ capturedAt: 10, sampleKind: "terminal" },
+				],
+				phaseStartedAt: 2,
+				phaseFinishedAt: 9,
+				maxGapMs,
+				label: "terminal-only endpoint",
+			}),
+		/do not bracket/,
+	);
+});
+
+const createFakeTimerClock = () => {
+	let currentTime = 0;
+	let nextId = 1;
+	const timers = new Map();
+	return {
+		now: () => currentTime,
+		setTimer: (callback, timeoutMs) => {
+			const id = nextId++;
+			timers.set(id, { callback, dueAt: currentTime + timeoutMs });
+			return id;
+		},
+		clearTimer: (id) => timers.delete(id),
+		advanceBy: (durationMs) => {
+			currentTime += durationMs;
+		},
+		runNext: async () => {
+			const next = [...timers.entries()].sort(
+				([leftId, left], [rightId, right]) =>
+					left.dueAt - right.dueAt || leftId - rightId,
+			)[0];
+			assert.ok(next, "expected a scheduled fake timer");
+			const [id, { callback, dueAt }] = next;
+			timers.delete(id);
+			currentTime = Math.max(currentTime, dueAt);
+			callback();
+			await Promise.resolve();
+			await Promise.resolve();
+		},
+	};
+};
+
 test("derives a deadline-bounded sample cap with an absolute result-size ceiling", () => {
 	assert.equal(
 		calculateDownloadMemoryMaxSamples({
-			downloadTimeoutMs: 600_000,
-			schedulingToleranceMs: 5_000,
+			samplingWindowBudgetMs: 600_000,
 		}),
 		123,
 	);
 	assert.equal(
 		calculateDownloadMemoryMaxSamples({
-			downloadTimeoutMs: Number.MAX_SAFE_INTEGER - 10_000,
-			schedulingToleranceMs: 5_000,
+			samplingWindowBudgetMs: 665_001,
+		}),
+		137,
+	);
+	assert.equal(
+		calculateDownloadMemoryMaxSamples({
+			samplingWindowBudgetMs: Number.MAX_SAFE_INTEGER,
 		}),
 		DOWNLOAD_MEMORY_MAX_SAMPLES_PER_SERIES,
 	);
 	assert.throws(
 		() =>
 			calculateDownloadMemoryMaxSamples({
-				downloadTimeoutMs: 0,
-				schedulingToleranceMs: 5_000,
+				samplingWindowBudgetMs: 0,
 			}),
-		/bounded timeout values/,
+		/positive bounded sampling window budget/,
+	);
+	assert.throws(
+		() =>
+			calculateDownloadMemoryMaxSamples({
+				samplingWindowBudgetMs: -1,
+			}),
+		/positive bounded sampling window budget/,
+	);
+	assert.throws(
+		() => calculateDownloadMemoryMaxSamples({}),
+		/positive bounded sampling window budget/,
+	);
+	assert.equal(
+		calculateDownloadMemoryMaxSamples({
+			samplingWindowBudgetMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
+		}),
+		4,
 	);
 });
 
-test("serializes samples, reserves the forced endpoint, and cleans up once", async () => {
+test("serializes periodic and live samples while reserving the terminal endpoint", async () => {
+	const clock = createFakeTimerClock();
 	let active = 0;
 	let peakActive = 0;
 	let cleanupCount = 0;
 	let value = 0;
+	let releasePeriodic;
+	const periodicGate = new Promise((resolve) => {
+		releasePeriodic = resolve;
+	});
 	const sampler = await startBoundedSerialSampler({
 		intervalMs: 1,
-		maxSamples: 3,
+		maxSamples: 5,
+		now: clock.now,
+		setTimer: clock.setTimer,
+		clearTimer: clock.clearTimer,
 		readSample: async () => {
 			active += 1;
 			peakActive = Math.max(peakActive, active);
-			await delay(2);
+			const nextValue = (value += 1);
+			if (nextValue === 2) {
+				await periodicGate;
+			}
 			active -= 1;
-			return { value: (value += 1) };
+			return { value: nextValue };
 		},
 		cleanup: async () => {
 			cleanupCount += 1;
 		},
 	});
-	await delay(12);
+	await clock.runNext();
+	while (value < 2) {
+		await Promise.resolve();
+	}
+	const firstCheckpoint = sampler.sampleNow();
+	const secondCheckpoint = sampler.sampleNow();
+	assert.strictEqual(firstCheckpoint, secondCheckpoint);
+	assert.equal(peakActive, 1);
+	releasePeriodic();
+	const checkpoint = await firstCheckpoint;
+	assert.equal(peakActive, 1);
+	assert.deepEqual(
+		checkpoint.samples.map((sample) => sample.sampleKind),
+		["initial", "periodic", "manual"],
+	);
+	assert.equal(checkpoint.manualSampleCount, 1);
+	assert.equal(checkpoint.terminalSampleAttempted, false);
+	assert.deepEqual(await sampler.sampleNow(), checkpoint);
+	assert.equal(value, 3);
+	clock.advanceBy(1);
 	const [firstStop, secondStop] = await Promise.all([
 		sampler.stop(),
 		sampler.stop(),
@@ -63,15 +210,92 @@ test("serializes samples, reserves the forced endpoint, and cleans up once", asy
 	assert.deepEqual(firstStop, secondStop);
 	assert.equal(peakActive, 1);
 	assert.equal(cleanupCount, 1);
-	assert.equal(firstStop.samples.length, 3);
+	assert.deepEqual(
+		firstStop.samples.map((sample) => sample.sampleKind),
+		["initial", "periodic", "manual", "terminal"],
+	);
+	assert.equal(firstStop.lastManualSampleAt < firstStop.terminalSampleAt, true);
+	assert.equal(firstStop.terminalSampleAttempted, true);
+	assert.equal(firstStop.terminalSampleCaptured, true);
+	assert.equal(firstStop.capacityExhaustedBeforeTerminal, false);
 	assert.equal(firstStop.finishedAt >= firstStop.startedAt, true);
+});
+
+test("reports premature periodic capacity exhaustion and still captures terminal evidence", async () => {
+	const clock = createFakeTimerClock();
+	let value = 0;
+	const sampler = await startBoundedSerialSampler({
+		intervalMs: 5,
+		maxSamples: 3,
+		now: clock.now,
+		setTimer: clock.setTimer,
+		clearTimer: clock.clearTimer,
+		readSample: async () => ({ value: (value += 1) }),
+	});
+
+	await clock.runNext();
+	const exhausted = sampler.snapshot();
+	assert.equal(exhausted.capacityExhaustedBeforeTerminal, true);
+	assert.equal(exhausted.samplingCapacitySufficient, false);
+	assert.equal(exhausted.terminalSampleAttempted, false);
+
+	const live = await sampler.sampleNow();
+	assert.deepEqual(
+		live.samples.map((sample) => sample.sampleKind),
+		["initial", "manual"],
+	);
+	clock.advanceBy(1);
+	const terminal = await sampler.stopSampling();
+	assert.deepEqual(
+		terminal.samples.map((sample) => sample.sampleKind),
+		["initial", "manual", "terminal"],
+	);
+	assert.equal(terminal.capacityExhaustedBeforeTerminal, true);
+	assert.equal(terminal.terminalSampleAttempted, true);
+	assert.equal(terminal.terminalSampleCaptured, true);
+	assert.equal(terminal.lastManualSampleAt < terminal.terminalSampleAt, true);
+});
+
+test("cleanup waits for an in-flight live checkpoint before taking the terminal sample", async () => {
+	let sampleCalls = 0;
+	let releaseCheckpoint;
+	const checkpointGate = new Promise((resolve) => {
+		releaseCheckpoint = resolve;
+	});
+	let cleanupCount = 0;
+	const sampler = await startBoundedSerialSampler({
+		intervalMs: 60_000,
+		maxSamples: 3,
+		readSample: async () => {
+			sampleCalls += 1;
+			if (sampleCalls === 2) {
+				await checkpointGate;
+			}
+			return { value: sampleCalls };
+		},
+		cleanup: async () => {
+			cleanupCount += 1;
+		},
+	});
+	const checkpoint = sampler.sampleNow();
+	const cleanup = sampler.cleanup();
+	await Promise.resolve();
+	assert.equal(cleanupCount, 0);
+	releaseCheckpoint();
+	await checkpoint;
+	const result = await cleanup;
+	assert.equal(cleanupCount, 1);
+	assert.deepEqual(
+		result.samples.map((sample) => sample.sampleKind),
+		["initial", "manual", "terminal"],
+	);
 });
 
 test("bounds and truncates repeated sampling failures", async () => {
 	const longMessage = "x".repeat(DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH * 2);
 	const sampler = await startBoundedSerialSampler({
 		intervalMs: 1,
-		maxSamples: 2,
+		maxSamples: 20,
 		readSample: async () => {
 			throw new Error(longMessage);
 		},
@@ -215,20 +439,30 @@ test("absorbs late operation settlement and cleans late-created values", async (
 	assert.equal(lateCleanupCount, 1);
 });
 
-test("collects forced endpoint heap and attributed RSS samples", async () => {
+test("collects forced endpoint runtime-heap and attributed host samples", async () => {
 	let detachedPageSessions = 0;
 	let detachedBrowserSessions = 0;
-	const page = (usedBytes) => ({
+	const page = (initialUsedBytes) => ({
 		context: () => ({
-			newCDPSession: async () => ({
-				send: async (method) =>
-					method === "Performance.getMetrics"
-						? { metrics: [{ name: "JSHeapUsedSize", value: usedBytes }] }
-						: {},
-				detach: async () => {
-					detachedPageSessions += 1;
-				},
-			}),
+			newCDPSession: async () => {
+				let sampleIndex = 0;
+				return {
+					send: async (method) => {
+						assert.equal(method, "Runtime.getHeapUsage");
+						const usedBytes = initialUsedBytes + sampleIndex;
+						sampleIndex += 1;
+						return {
+							usedSize: usedBytes,
+							totalSize: usedBytes + 10,
+							embedderHeapUsedSize: usedBytes + 20,
+							backingStorageSize: usedBytes + 30,
+						};
+					},
+					detach: async () => {
+						detachedPageSessions += 1;
+					},
+				};
+			},
 		}),
 	});
 	const browser = {
@@ -250,14 +484,73 @@ test("collects forced endpoint heap and attributed RSS samples", async () => {
 		writer: page(200),
 		downloadTimeoutMs: 60_000,
 		schedulingToleranceMs: 5_000,
+		postTransferSoakMs: 60_000,
+		samplingWindowBudgetMs: 130_000,
 	});
+	const [firstCheckpoint, secondCheckpoint] = await Promise.all([
+		telemetry.sampleNow(),
+		telemetry.sampleNow(),
+	]);
+	assert.deepEqual(firstCheckpoint, secondCheckpoint);
+	assert.equal(firstCheckpoint.manualCheckpointComplete, true);
+	assert.equal(firstCheckpoint.terminalCheckpointComplete, false);
 	const result = await telemetry.stop();
 	assert.equal(result.complete, true);
 	assert.equal(result.cleanupComplete, true);
-	assert.equal(result.readerJsHeap.sampleCount, 2);
-	assert.equal(result.writerJsHeap.sampleCount, 2);
-	assert.equal(result.hostRss.sampleCount, 2);
+	assert.equal(result.readerJsHeap.sampleCount, 3);
+	assert.equal(result.writerJsHeap.sampleCount, 3);
+	assert.equal(result.hostRss.sampleCount, 3);
+	assert.equal(result.profile, "download-memory-v3");
+	assert.equal(result.operationTimeoutMs, DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS);
+	assert.equal(
+		result.liveSampleMaxGapMs,
+		DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS +
+			DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS +
+			5_000,
+	);
+	assert.equal(
+		result.liveSampleCoverageDefinition,
+		DOWNLOAD_MEMORY_LIVE_SAMPLE_COVERAGE_DEFINITION,
+	);
+	assert.equal(result.postTransferSoakMs, 60_000);
+	assert.equal(result.samplingWindowBudgetMs, 130_000);
+	assert.equal(result.samplingCapacitySufficient, true);
+	assert.equal(result.capacityExhaustedBeforeTerminal, false);
+	assert.equal(result.manualCheckpointComplete, true);
+	assert.equal(result.terminalCheckpointComplete, true);
+	assert.equal(result.readerJsHeap.metric, "Runtime.getHeapUsage");
+	assert.equal(result.readerJsHeap.startUsedBytes, 100);
+	assert.equal(result.readerJsHeap.endUsedBytes, 102);
+	assert.equal(result.readerJsHeap.peakTotalBytes, 112);
+	assert.equal(result.readerJsHeap.endEmbedderHeapUsedBytes, 122);
+	assert.equal(result.readerJsHeap.peakBackingStorageBytes, 132);
+	assert.deepEqual(
+		result.readerJsHeap.samples.map((sample) => sample.sampleKind),
+		["initial", "manual", "terminal"],
+	);
 	assert.equal(result.hostRss.samples[0].browserBytes > 0, true);
+	assert.equal(result.hostRss.samples[0].nodeExternalBytes >= 0, true);
+	assert.equal(result.hostRss.samples[0].nodeArrayBuffersBytes >= 0, true);
+	assert.equal(
+		result.hostRss.startNodeExternalBytes,
+		result.hostRss.samples[0].nodeExternalBytes,
+	);
+	assert.equal(
+		result.hostRss.endNodeArrayBuffersBytes,
+		result.hostRss.samples.at(-1).nodeArrayBuffersBytes,
+	);
+	assert.equal(
+		result.hostRss.peakNodeExternalBytes,
+		Math.max(
+			...result.hostRss.samples.map((sample) => sample.nodeExternalBytes),
+		),
+	);
+	assert.equal(
+		result.hostRss.peakNodeArrayBuffersBytes,
+		Math.max(
+			...result.hostRss.samples.map((sample) => sample.nodeArrayBuffersBytes),
+		),
+	);
 	assert.equal(
 		result.hostRss.samples[0].combinedBytes,
 		result.hostRss.samples[0].browserBytes +
@@ -273,13 +566,13 @@ test("records post-sampling CDP timeouts as cleanup warnings", async () => {
 		context: () => ({
 			newCDPSession: async () => ({
 				send: async (method) => {
-					if (method === "Performance.getMetrics") {
-						return { metrics: [{ name: "JSHeapUsedSize", value: 100 }] };
-					}
-					if (method === "Performance.disable" && hangOnCleanup) {
-						return await new Promise(() => {});
-					}
-					return {};
+					assert.equal(method, "Runtime.getHeapUsage");
+					return {
+						usedSize: 100,
+						totalSize: 110,
+						embedderHeapUsedSize: 120,
+						backingStorageSize: 130,
+					};
 				},
 				detach: async () => {
 					detachStarted += 1;
@@ -304,6 +597,8 @@ test("records post-sampling CDP timeouts as cleanup warnings", async () => {
 		writer: page(false),
 		downloadTimeoutMs: 60_000,
 		schedulingToleranceMs: 5_000,
+		postTransferSoakMs: 0,
+		samplingWindowBudgetMs: 65_000,
 		operationTimeoutMs: 3,
 		cleanupTimeoutMs: 8,
 	});
@@ -318,7 +613,7 @@ test("records post-sampling CDP timeouts as cleanup warnings", async () => {
 	assert.equal(result.readerJsHeap.cleanupWarnings.length, 1);
 	assert.match(
 		result.readerJsHeap.cleanupWarnings[0],
-		/Performance\.disable exceeded 3ms; Page JS heap CDP detach exceeded 3ms/,
+		/Page JS heap CDP detach exceeded 3ms/,
 	);
 	assert.equal(detachStarted, 2);
 });
@@ -326,10 +621,15 @@ test("records post-sampling CDP timeouts as cleanup warnings", async () => {
 test("bounds setup and detaches a CDP session created after its deadline", async () => {
 	let lateDetachCount = 0;
 	const session = (usedBytes, onDetach = () => {}) => ({
-		send: async (method) =>
-			method === "Performance.getMetrics"
-				? { metrics: [{ name: "JSHeapUsedSize", value: usedBytes }] }
-				: {},
+		send: async (method) => {
+			assert.equal(method, "Runtime.getHeapUsage");
+			return {
+				usedSize: usedBytes,
+				totalSize: usedBytes + 10,
+				embedderHeapUsedSize: usedBytes + 20,
+				backingStorageSize: usedBytes + 30,
+			};
+		},
 		detach: async () => onDetach(),
 	});
 	const lateReaderSession = session(100, () => {
@@ -362,6 +662,8 @@ test("bounds setup and detaches a CDP session created after its deadline", async
 		writer,
 		downloadTimeoutMs: 60_000,
 		schedulingToleranceMs: 5_000,
+		postTransferSoakMs: 0,
+		samplingWindowBudgetMs: 65_000,
 		operationTimeoutMs: 3,
 		cleanupTimeoutMs: 8,
 	});

--- a/scripts/file-share/matrix-summary.test.mjs
+++ b/scripts/file-share/matrix-summary.test.mjs
@@ -1,0 +1,288 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	compareAdaptiveAcrossVariants,
+	summarizeUploadMatrix,
+} from "./run-file-share-benchmark-matrix.mjs";
+
+const uploadRow = ({
+	mode,
+	runtimeKey,
+	uploadDurationMsAvg,
+	libraryStreamWallMsAvg,
+	readerLocalityCohortKey = null,
+}) => ({
+	mode,
+	...(runtimeKey === undefined
+		? {}
+		: { runtimeConfigurationCohortKey: runtimeKey }),
+	runs: 1,
+	passed: 1,
+	failed: 0,
+	errorCount: 0,
+	incompleteErrorCollections: 0,
+	requestFailureCount: 0,
+	downloadSink: "hash-only",
+	primaryDownloadMetric: "libraryStreamWallMs",
+	primaryDownloadAuthoritative: true,
+	uploadDurationMsAvg,
+	timeToWriterReadyMsAvg: uploadDurationMsAvg - 10,
+	timeToWriterReadyMsMedian: uploadDurationMsAvg - 10,
+	timeToReaderReadyMsAvg: uploadDurationMsAvg + 10,
+	timeToReaderReadyMsMedian: uploadDurationMsAvg + 10,
+	libraryStreamWallMsAvg,
+	libraryStreamWallMsMedian: libraryStreamWallMsAvg,
+	readerLocalChunkTarget:
+		mode === "fixed1" && readerLocalityCohortKey !== null ? 0 : null,
+	readerLocalChunkMaxOvershoot:
+		mode === "fixed1" && readerLocalityCohortKey !== null ? 0 : null,
+	readerLocalChunkBlockCount:
+		mode === "fixed1" && readerLocalityCohortKey !== null ? 0 : null,
+	readerLocalChunkIndexRowCount:
+		mode === "fixed1" && readerLocalityCohortKey !== null ? 0 : null,
+	readerLocalityCohortKey,
+});
+
+test("matrix upload summary preserves the legacy row shape", () => {
+	const rows = summarizeUploadMatrix([
+		{
+			variant: "baseline",
+			summary: [
+				uploadRow({
+					mode: "adaptive",
+					uploadDurationMsAvg: 80,
+					libraryStreamWallMsAvg: 40,
+				}),
+				uploadRow({
+					mode: "fixed1",
+					uploadDurationMsAvg: 100,
+					libraryStreamWallMsAvg: 50,
+				}),
+			],
+			comparison: {
+				downloadSink: "hash-only",
+				primaryDownloadMetric: "libraryStreamWallMs",
+				primaryDownloadAuthoritative: true,
+				adaptiveAvgMs: 80,
+				fixed1AvgMs: 100,
+				adaptiveVsFixed1Pct: -20,
+				libraryStreamWallDeltaMs: -10,
+				adaptiveVsFixed1LibraryStreamWallPct: -20,
+			},
+		},
+	]);
+
+	assert.equal(rows.length, 1);
+	assert.equal(Object.hasOwn(rows[0], "runtimeConfigurationCohortKey"), false);
+	assert.equal(rows[0].adaptiveAvgMs, 80);
+	assert.equal(rows[0].fixed1AvgMs, 100);
+	assert.equal(rows[0].adaptiveVsFixed1Pct, -20);
+});
+
+test("matrix upload summary preserves every legacy controlled-locality row", () => {
+	const rows = summarizeUploadMatrix([
+		{
+			variant: "baseline",
+			summary: [
+				uploadRow({
+					mode: "adaptive",
+					uploadDurationMsAvg: 80,
+					libraryStreamWallMsAvg: 40,
+				}),
+				uploadRow({
+					mode: "fixed1",
+					uploadDurationMsAvg: 100,
+					libraryStreamWallMsAvg: 50,
+					readerLocalityCohortKey: "observer-prefix-b0-i0",
+				}),
+				uploadRow({
+					mode: "fixed1",
+					uploadDurationMsAvg: 110,
+					libraryStreamWallMsAvg: 60,
+					readerLocalityCohortKey: "observer-prefix-b1-i1",
+				}),
+			],
+			comparison: null,
+		},
+	]);
+
+	assert.deepEqual(
+		rows.map((row) => [
+			row.readerLocalityCohortKey,
+			row.adaptiveAvgMs,
+			row.fixed1AvgMs,
+		]),
+		[
+			["observer-prefix-b0-i0", 80, 100],
+			["observer-prefix-b1-i1", 80, 110],
+		],
+	);
+	assert.ok(
+		rows.every((row) => !Object.hasOwn(row, "runtimeConfigurationCohortKey")),
+	);
+});
+
+test("matrix upload summary partitions and preserves every runtime cohort", () => {
+	const runtimeA = '{"pubsub":"a"}';
+	const runtimeB = '{"pubsub":"b"}';
+	const rows = summarizeUploadMatrix([
+		{
+			variant: "candidate",
+			summary: [
+				uploadRow({
+					mode: "adaptive",
+					runtimeKey: runtimeA,
+					uploadDurationMsAvg: 80,
+					libraryStreamWallMsAvg: 40,
+				}),
+				uploadRow({
+					mode: "fixed1",
+					runtimeKey: runtimeA,
+					uploadDurationMsAvg: 100,
+					libraryStreamWallMsAvg: 50,
+				}),
+				uploadRow({
+					mode: "adaptive",
+					runtimeKey: runtimeB,
+					uploadDurationMsAvg: 180,
+					libraryStreamWallMsAvg: 140,
+				}),
+				uploadRow({
+					mode: "fixed1",
+					runtimeKey: runtimeB,
+					uploadDurationMsAvg: 200,
+					libraryStreamWallMsAvg: 150,
+				}),
+			],
+			comparison: null,
+		},
+	]);
+
+	assert.deepEqual(
+		rows.map((row) => ({
+			runtimeKey: row.runtimeConfigurationCohortKey,
+			adaptiveAvgMs: row.adaptiveAvgMs,
+			fixed1AvgMs: row.fixed1AvgMs,
+			adaptiveVsFixed1Pct: row.adaptiveVsFixed1Pct,
+		})),
+		[
+			{
+				runtimeKey: runtimeA,
+				adaptiveAvgMs: 80,
+				fixed1AvgMs: 100,
+				adaptiveVsFixed1Pct: null,
+			},
+			{
+				runtimeKey: runtimeB,
+				adaptiveAvgMs: 180,
+				fixed1AvgMs: 200,
+				adaptiveVsFixed1Pct: null,
+			},
+		],
+	);
+});
+
+test("matrix upload summary never joins keyed and missing runtime evidence", () => {
+	const runtimeA = '{"pubsub":"a"}';
+	const rows = summarizeUploadMatrix([
+		{
+			variant: "candidate",
+			summary: [
+				uploadRow({
+					mode: "adaptive",
+					runtimeKey: runtimeA,
+					uploadDurationMsAvg: 80,
+					libraryStreamWallMsAvg: 40,
+				}),
+				uploadRow({
+					mode: "fixed1",
+					uploadDurationMsAvg: 100,
+					libraryStreamWallMsAvg: 50,
+				}),
+			],
+			comparison: {
+				runtimeConfigurationCohortKey: runtimeA,
+				adaptiveAvgMs: 80,
+				fixed1AvgMs: 100,
+				adaptiveVsFixed1Pct: -20,
+			},
+		},
+	]);
+
+	assert.equal(rows.length, 2);
+	assert.deepEqual(
+		rows.map((row) => [
+			row.runtimeConfigurationCohortKey,
+			row.adaptiveAvgMs,
+			row.fixed1AvgMs,
+			row.adaptiveVsFixed1Pct,
+		]),
+		[
+			[null, null, 100, null],
+			[runtimeA, 80, null, null],
+		],
+	);
+});
+
+test("cross-variant adaptive rows require one shared runtime cohort", () => {
+	const runtimeA = '{"pubsub":"a"}';
+	const summaries = ["baseline", "candidate"].map((variant, index) => ({
+		variant,
+		summary: [
+			uploadRow({
+				mode: "adaptive",
+				runtimeKey: runtimeA,
+				uploadDurationMsAvg: 80 + index,
+				libraryStreamWallMsAvg: 40 + index,
+			}),
+		],
+	}));
+
+	const comparison = compareAdaptiveAcrossVariants(summaries, "upload");
+	assert.equal(comparison.length, 2);
+	assert.ok(
+		comparison.every((row) => row.runtimeConfigurationCohortKey === runtimeA),
+	);
+
+	const mismatched = structuredClone(summaries);
+	mismatched[1].summary[0].runtimeConfigurationCohortKey = '{"pubsub":"b"}';
+	assert.equal(compareAdaptiveAcrossVariants(mismatched, "upload"), null);
+
+	const mixed = structuredClone(summaries);
+	delete mixed[1].summary[0].runtimeConfigurationCohortKey;
+	assert.equal(compareAdaptiveAcrossVariants(mixed, "upload"), null);
+
+	const split = structuredClone(summaries);
+	split[0].summary.push(
+		uploadRow({
+			mode: "adaptive",
+			runtimeKey: '{"pubsub":"b"}',
+			uploadDurationMsAvg: 180,
+			libraryStreamWallMsAvg: 140,
+		}),
+	);
+	assert.equal(compareAdaptiveAcrossVariants(split, "upload"), null);
+});
+
+test("cross-variant adaptive rows retain legacy behavior without evidence", () => {
+	const comparison = compareAdaptiveAcrossVariants(
+		["baseline", "candidate"].map((variant, index) => ({
+			variant,
+			summary: [
+				uploadRow({
+					mode: "adaptive",
+					uploadDurationMsAvg: 80 + index,
+					libraryStreamWallMsAvg: 40 + index,
+				}),
+			],
+		})),
+		"upload",
+	);
+
+	assert.equal(comparison.length, 2);
+	assert.ok(
+		comparison.every(
+			(row) => !Object.hasOwn(row, "runtimeConfigurationCohortKey"),
+		),
+	);
+});

--- a/scripts/file-share/run-file-share-benchmark-matrix.mjs
+++ b/scripts/file-share/run-file-share-benchmark-matrix.mjs
@@ -162,81 +162,168 @@ const resolveVariantSpecs = async (variantSpecs) => {
 	return assertUniqueResolvedVariantCommits(resolved);
 };
 
-const summarizeUploadMatrix = (variantSummaries) => {
+const hasRuntimeConfigurationCohortKey = (entry) =>
+	entry != null &&
+	typeof entry === "object" &&
+	Object.hasOwn(entry, "runtimeConfigurationCohortKey");
+
+const runtimeConfigurationCohortKey = (entry) =>
+	typeof entry?.runtimeConfigurationCohortKey === "string"
+		? entry.runtimeConfigurationCohortKey
+		: null;
+
+const createUploadMatrixRow = ({
+	summary,
+	adaptive,
+	fixed1,
+	runtimeAware,
+	runtimeKey,
+}) => {
+	const comparison = (() => {
+		if (!summary.comparison || !adaptive || !fixed1) {
+			return null;
+		}
+		if (!runtimeAware) {
+			return summary.comparison;
+		}
+		return runtimeKey !== null &&
+			summary.comparison.runtimeConfigurationCohortKey === runtimeKey
+			? summary.comparison
+			: null;
+	})();
+	return {
+		variant: summary.variant,
+		...(runtimeAware ? { runtimeConfigurationCohortKey: runtimeKey } : {}),
+		readerLocalChunkTarget: fixed1?.readerLocalChunkTarget ?? null,
+		readerLocalChunkMaxOvershoot: fixed1?.readerLocalChunkMaxOvershoot ?? null,
+		readerLocalChunkBlockCount: fixed1?.readerLocalChunkBlockCount ?? null,
+		readerLocalChunkIndexRowCount:
+			fixed1?.readerLocalChunkIndexRowCount ?? null,
+		readerLocalityCohortKey: fixed1?.readerLocalityCohortKey ?? null,
+		cohortRuns: fixed1?.runs ?? null,
+		cohortPassed: fixed1?.passed ?? null,
+		cohortFailed: fixed1?.failed ?? null,
+		downloadSink:
+			comparison?.downloadSink ??
+			adaptive?.downloadSink ??
+			fixed1?.downloadSink ??
+			null,
+		primaryDownloadMetric:
+			comparison?.primaryDownloadMetric ??
+			adaptive?.primaryDownloadMetric ??
+			fixed1?.primaryDownloadMetric ??
+			null,
+		primaryDownloadAuthoritative:
+			comparison?.primaryDownloadAuthoritative ??
+			adaptive?.primaryDownloadAuthoritative ??
+			fixed1?.primaryDownloadAuthoritative ??
+			null,
+		adaptiveAvgMs:
+			comparison?.adaptiveAvgMs ?? adaptive?.uploadDurationMsAvg ?? null,
+		fixed1AvgMs: comparison?.fixed1AvgMs ?? fixed1?.uploadDurationMsAvg ?? null,
+		adaptiveVsFixed1Pct: comparison?.adaptiveVsFixed1Pct ?? null,
+		adaptiveWriterReadyMsAvg: adaptive?.timeToWriterReadyMsAvg ?? null,
+		fixed1WriterReadyMsAvg: fixed1?.timeToWriterReadyMsAvg ?? null,
+		adaptiveWriterReadyMsMedian: adaptive?.timeToWriterReadyMsMedian ?? null,
+		fixed1WriterReadyMsMedian: fixed1?.timeToWriterReadyMsMedian ?? null,
+		adaptiveReaderReadyMsAvg: adaptive?.timeToReaderReadyMsAvg ?? null,
+		fixed1ReaderReadyMsAvg: fixed1?.timeToReaderReadyMsAvg ?? null,
+		adaptiveReaderReadyMsMedian: adaptive?.timeToReaderReadyMsMedian ?? null,
+		fixed1ReaderReadyMsMedian: fixed1?.timeToReaderReadyMsMedian ?? null,
+		adaptiveLibraryStreamWallMsAvg: adaptive?.libraryStreamWallMsAvg ?? null,
+		fixed1LibraryStreamWallMsAvg: fixed1?.libraryStreamWallMsAvg ?? null,
+		adaptiveLibraryStreamWallMsMedian:
+			adaptive?.libraryStreamWallMsMedian ?? null,
+		fixed1LibraryStreamWallMsMedian: fixed1?.libraryStreamWallMsMedian ?? null,
+		libraryStreamWallDeltaMs: comparison?.libraryStreamWallDeltaMs ?? null,
+		adaptiveVsFixed1LibraryStreamWallPct:
+			comparison?.adaptiveVsFixed1LibraryStreamWallPct ?? null,
+		adaptiveStatus:
+			adaptive == null ? null : adaptive.failed === 0 ? "passed" : "failed",
+		fixed1Status:
+			fixed1 == null ? null : fixed1.failed === 0 ? "passed" : "failed",
+		adaptiveErrorCount: adaptive?.errorCount ?? null,
+		fixed1ErrorCount: fixed1?.errorCount ?? null,
+		adaptiveIncompleteErrorCollections:
+			adaptive?.incompleteErrorCollections ?? null,
+		fixed1IncompleteErrorCollections:
+			fixed1?.incompleteErrorCollections ?? null,
+		adaptiveRequestFailureCount: adaptive?.requestFailureCount ?? null,
+		fixed1RequestFailureCount: fixed1?.requestFailureCount ?? null,
+	};
+};
+
+export const summarizeUploadMatrix = (variantSummaries) => {
 	return variantSummaries.flatMap((summary) => {
-		const adaptive = summary.summary.find((entry) => entry.mode === "adaptive");
+		const adaptiveEntries = summary.summary.filter(
+			(entry) => entry.mode === "adaptive",
+		);
 		const fixed1Entries = summary.summary.filter(
 			(entry) => entry.mode === "fixed1",
 		);
 		const controlledFixed1Entries = fixed1Entries.filter(
 			(entry) => entry.readerLocalChunkTarget != null,
 		);
-		const cohorts =
+		const fixed1Cohorts =
 			controlledFixed1Entries.length > 0
 				? controlledFixed1Entries
-				: [fixed1Entries[0]];
-		return cohorts.map((fixed1) => ({
-			variant: summary.variant,
-			readerLocalChunkTarget: fixed1?.readerLocalChunkTarget ?? null,
-			readerLocalChunkMaxOvershoot:
-				fixed1?.readerLocalChunkMaxOvershoot ?? null,
-			readerLocalChunkBlockCount: fixed1?.readerLocalChunkBlockCount ?? null,
-			readerLocalChunkIndexRowCount:
-				fixed1?.readerLocalChunkIndexRowCount ?? null,
-			readerLocalityCohortKey: fixed1?.readerLocalityCohortKey ?? null,
-			cohortRuns: fixed1?.runs ?? null,
-			cohortPassed: fixed1?.passed ?? null,
-			cohortFailed: fixed1?.failed ?? null,
-			downloadSink:
-				summary.comparison?.downloadSink ??
-				adaptive?.downloadSink ??
-				fixed1?.downloadSink ??
-				null,
-			primaryDownloadMetric:
-				summary.comparison?.primaryDownloadMetric ??
-				adaptive?.primaryDownloadMetric ??
-				fixed1?.primaryDownloadMetric ??
-				null,
-			primaryDownloadAuthoritative:
-				summary.comparison?.primaryDownloadAuthoritative ??
-				adaptive?.primaryDownloadAuthoritative ??
-				fixed1?.primaryDownloadAuthoritative ??
-				null,
-			adaptiveAvgMs: summary.comparison?.adaptiveAvgMs ?? null,
-			fixed1AvgMs:
-				summary.comparison?.fixed1AvgMs ?? fixed1?.uploadDurationMsAvg ?? null,
-			adaptiveVsFixed1Pct: summary.comparison?.adaptiveVsFixed1Pct ?? null,
-			adaptiveWriterReadyMsAvg: adaptive?.timeToWriterReadyMsAvg ?? null,
-			fixed1WriterReadyMsAvg: fixed1?.timeToWriterReadyMsAvg ?? null,
-			adaptiveWriterReadyMsMedian: adaptive?.timeToWriterReadyMsMedian ?? null,
-			fixed1WriterReadyMsMedian: fixed1?.timeToWriterReadyMsMedian ?? null,
-			adaptiveReaderReadyMsAvg: adaptive?.timeToReaderReadyMsAvg ?? null,
-			fixed1ReaderReadyMsAvg: fixed1?.timeToReaderReadyMsAvg ?? null,
-			adaptiveReaderReadyMsMedian: adaptive?.timeToReaderReadyMsMedian ?? null,
-			fixed1ReaderReadyMsMedian: fixed1?.timeToReaderReadyMsMedian ?? null,
-			adaptiveLibraryStreamWallMsAvg: adaptive?.libraryStreamWallMsAvg ?? null,
-			fixed1LibraryStreamWallMsAvg: fixed1?.libraryStreamWallMsAvg ?? null,
-			adaptiveLibraryStreamWallMsMedian:
-				adaptive?.libraryStreamWallMsMedian ?? null,
-			fixed1LibraryStreamWallMsMedian:
-				fixed1?.libraryStreamWallMsMedian ?? null,
-			libraryStreamWallDeltaMs:
-				summary.comparison?.libraryStreamWallDeltaMs ?? null,
-			adaptiveVsFixed1LibraryStreamWallPct:
-				summary.comparison?.adaptiveVsFixed1LibraryStreamWallPct ?? null,
-			adaptiveStatus:
-				adaptive == null ? null : adaptive.failed === 0 ? "passed" : "failed",
-			fixed1Status:
-				fixed1 == null ? null : fixed1.failed === 0 ? "passed" : "failed",
-			adaptiveErrorCount: adaptive?.errorCount ?? null,
-			fixed1ErrorCount: fixed1?.errorCount ?? null,
-			adaptiveIncompleteErrorCollections:
-				adaptive?.incompleteErrorCollections ?? null,
-			fixed1IncompleteErrorCollections:
-				fixed1?.incompleteErrorCollections ?? null,
-			adaptiveRequestFailureCount: adaptive?.requestFailureCount ?? null,
-			fixed1RequestFailureCount: fixed1?.requestFailureCount ?? null,
-		}));
+				: fixed1Entries;
+		const runtimeAware = [...adaptiveEntries, ...fixed1Cohorts].some(
+			hasRuntimeConfigurationCohortKey,
+		);
+		if (!runtimeAware) {
+			const legacyFixed1Cohorts =
+				fixed1Cohorts.length > 0 ? fixed1Cohorts : [undefined];
+			return legacyFixed1Cohorts.map((fixed1) =>
+				createUploadMatrixRow({
+					summary,
+					adaptive: adaptiveEntries[0],
+					fixed1,
+					runtimeAware: false,
+					runtimeKey: null,
+				}),
+			);
+		}
+
+		const rows = [];
+		const matchedAdaptiveEntries = new Set();
+		for (const fixed1 of fixed1Cohorts) {
+			const runtimeKey = runtimeConfigurationCohortKey(fixed1);
+			const matches =
+				runtimeKey === null
+					? []
+					: adaptiveEntries.filter(
+							(entry) => runtimeConfigurationCohortKey(entry) === runtimeKey,
+						);
+			const adaptive = matches.length === 1 ? matches[0] : undefined;
+			if (adaptive) {
+				matchedAdaptiveEntries.add(adaptive);
+			}
+			rows.push(
+				createUploadMatrixRow({
+					summary,
+					adaptive,
+					fixed1,
+					runtimeAware: true,
+					runtimeKey,
+				}),
+			);
+		}
+		for (const adaptive of adaptiveEntries) {
+			if (matchedAdaptiveEntries.has(adaptive)) {
+				continue;
+			}
+			rows.push(
+				createUploadMatrixRow({
+					summary,
+					adaptive,
+					fixed1: undefined,
+					runtimeAware: true,
+					runtimeKey: runtimeConfigurationCohortKey(adaptive),
+				}),
+			);
+		}
+		return rows;
 	});
 };
 
@@ -263,18 +350,37 @@ const summarizeMatrix = (variantSummaries, scenario) =>
 		? summarizeSeederProbeMatrix(variantSummaries)
 		: summarizeUploadMatrix(variantSummaries);
 
-const compareAdaptiveAcrossVariants = (variantSummaries, scenario) => {
-	return variantSummaries
-		.map((summary) => {
-			const adaptive = summary.summary.find(
-				(entry) => entry.mode === "adaptive",
-			);
+export const compareAdaptiveAcrossVariants = (variantSummaries, scenario) => {
+	const adaptiveByVariant = variantSummaries.map((summary) => ({
+		variant: summary.variant,
+		entries: summary.summary.filter((entry) => entry.mode === "adaptive"),
+	}));
+	const runtimeAware = adaptiveByVariant.some(({ entries }) =>
+		entries.some(hasRuntimeConfigurationCohortKey),
+	);
+	if (runtimeAware) {
+		if (adaptiveByVariant.some(({ entries }) => entries.length !== 1)) {
+			return null;
+		}
+		const runtimeKeys = adaptiveByVariant.map(({ entries }) =>
+			runtimeConfigurationCohortKey(entries[0]),
+		);
+		if (
+			runtimeKeys.some((runtimeKey) => runtimeKey === null) ||
+			new Set(runtimeKeys).size !== 1
+		) {
+			return null;
+		}
+	}
+	return adaptiveByVariant
+		.map(({ variant, entries }) => {
+			const adaptive = entries[0];
 			if (!adaptive) {
 				return null;
 			}
 			return scenario === "seeder-probe"
 				? {
-						variant: summary.variant,
+						variant,
 						reachedTargetRuns: adaptive.reachedTargetRuns ?? null,
 						writerSeedersLastAvg: adaptive.writerSeedersLastAvg ?? null,
 						readerSeedersLastAvg: adaptive.readerSeedersLastAvg ?? null,
@@ -282,7 +388,13 @@ const compareAdaptiveAcrossVariants = (variantSummaries, scenario) => {
 					}
 				: adaptive.uploadDurationMsAvg != null
 					? {
-							variant: summary.variant,
+							variant,
+							...(runtimeAware
+								? {
+										runtimeConfigurationCohortKey:
+											adaptive.runtimeConfigurationCohortKey,
+									}
+								: {}),
 							downloadSink: adaptive.downloadSink ?? null,
 							primaryDownloadMetric: adaptive.primaryDownloadMetric ?? null,
 							primaryDownloadAuthoritative:
@@ -442,6 +554,7 @@ const runVariantBenchmark = async ({
 	uploadTimeoutMs,
 	downloadTimeoutMs,
 	downloadSink,
+	postTransferSoakMs,
 	postUploadMonitorMs,
 	pollMs,
 	minReadySeeders,
@@ -511,6 +624,9 @@ const runVariantBenchmark = async ({
 			? ["--download-timeout-ms", String(downloadTimeoutMs)]
 			: []),
 		...(downloadSink != null ? ["--download-sink", downloadSink] : []),
+		...(postTransferSoakMs != null
+			? ["--post-transfer-soak-ms", String(postTransferSoakMs)]
+			: []),
 		...(postUploadMonitorMs != null
 			? ["--post-upload-monitor-ms", String(postUploadMonitorMs)]
 			: []),
@@ -665,6 +781,7 @@ const main = async () => {
 	const network = args.network ?? "local";
 	const uploadTimeoutMs = args["upload-timeout-ms"];
 	const downloadTimeoutMs = args["download-timeout-ms"];
+	const postTransferSoakMs = args["post-transfer-soak-ms"];
 	const postUploadMonitorMs = args["post-upload-monitor-ms"];
 	const pollMs = args["poll-ms"];
 	const minReadySeeders = args["min-ready-seeders"];
@@ -726,9 +843,7 @@ const main = async () => {
 			"--reader-local-chunk-target and --reader-local-chunk-max-overshoot must be provided together",
 		);
 	}
-	if (
-		(readerLocalChunkTarget == null) !== (readerTerminalTopology == null)
-	) {
+	if ((readerLocalChunkTarget == null) !== (readerTerminalTopology == null)) {
 		throw new Error(
 			"--reader-terminal-topology must be provided exactly when --reader-local-chunk-target is provided",
 		);
@@ -883,6 +998,7 @@ const main = async () => {
 				uploadTimeoutMs,
 				downloadTimeoutMs,
 				downloadSink,
+				postTransferSoakMs,
 				postUploadMonitorMs,
 				pollMs,
 				minReadySeeders,
@@ -931,6 +1047,7 @@ const main = async () => {
 				downloadSink,
 				uploadTimeoutMs: optionalNumber(uploadTimeoutMs),
 				downloadTimeoutMs: optionalNumber(downloadTimeoutMs),
+				postTransferSoakMs: optionalNumber(postTransferSoakMs),
 				postUploadMonitorMs: optionalNumber(postUploadMonitorMs),
 				pollMs: optionalNumber(pollMs),
 				minReadySeeders: optionalNumber(minReadySeeders),

--- a/scripts/file-share/run-file-share-benchmark.mjs
+++ b/scripts/file-share/run-file-share-benchmark.mjs
@@ -357,7 +357,11 @@ const maybeCopyFrontendCerts = async ({
 
 export const instrumentFileShareFrontend = async (
 	frontendRoot,
-	{ requireLocalityHook = false, requireUploadDiagnostics = false } = {},
+	{
+		requireLocalityHook = false,
+		requireUploadDiagnostics = false,
+		requireRuntimeEvidence = false,
+	} = {},
 ) => {
 	const dropPath = path.join(frontendRoot, "src", "Drop.tsx");
 	let contents = await fsp.readFile(dropPath, "utf8");
@@ -372,9 +376,18 @@ export const instrumentFileShareFrontend = async (
 	const hasUploadDiagnosticsHook = (source) =>
 		source.includes("lastUploadDiagnostics:") &&
 		source.includes(".lastUploadDiagnostics ?? null");
+	const hasRuntimeEvidenceHook =
+		contents.includes("getStorageSnapshot") &&
+		contents.includes("getBenchmarkRuntimeSnapshot") &&
+		contents.includes("shutdown:");
 	if (requireLocalityHook && !hasExistingBenchmarkHook) {
 		throw new Error(
 			`Controlled-locality benchmarks require the modern rich test-hook contract in ${dropPath}`,
+		);
+	}
+	if (requireRuntimeEvidence && !hasRuntimeEvidenceHook) {
+		throw new Error(
+			`Upload benchmarks require storage, runtime-provenance, and shutdown hooks in ${dropPath}`,
 		);
 	}
 	if (
@@ -382,6 +395,7 @@ export const instrumentFileShareFrontend = async (
 		(contents.includes(DROP_UPDATE_LIST_MARKER) ||
 			hasExistingUpdateListStats) &&
 		(!requireUploadDiagnostics || hasUploadDiagnosticsHook(contents)) &&
+		(!requireRuntimeEvidence || hasRuntimeEvidenceHook) &&
 		(!requireLocalityHook ||
 			(contents.includes(DROP_LOCALITY_HOOK_MARKER) &&
 				contents.includes(DROP_LOCALITY_PRELOAD_DEADLINE_MARKER) &&
@@ -1061,6 +1075,10 @@ const main = async () => {
 		args["download-timeout-ms"],
 		"--download-timeout-ms",
 	);
+	const postTransferSoakMs = parseNonNegativeInteger(
+		args["post-transfer-soak-ms"],
+		"--post-transfer-soak-ms",
+	);
 	const postUploadMonitorMs = parseNonNegativeInteger(
 		args["post-upload-monitor-ms"],
 		"--post-upload-monitor-ms",
@@ -1159,9 +1177,7 @@ const main = async () => {
 			"--reader-local-chunk-target and --reader-local-chunk-max-overshoot must be provided together",
 		);
 	}
-	if (
-		(readerLocalChunkTarget == null) !== (readerTerminalTopology == null)
-	) {
+	if ((readerLocalChunkTarget == null) !== (readerTerminalTopology == null)) {
 		throw new Error(
 			"--reader-terminal-topology must be provided exactly when --reader-local-chunk-target is provided",
 		);
@@ -1274,6 +1290,7 @@ const main = async () => {
 		await instrumentFileShareFrontend(frontendRoot, {
 			requireLocalityHook: readerLocalChunkTarget != null,
 			requireUploadDiagnostics: scenario === "upload",
+			requireRuntimeEvidence: scenario === "upload",
 		});
 		await instrumentFileShareViteConfigs(frontendRoot);
 		const generatedSpec = path.join(
@@ -1340,6 +1357,7 @@ const main = async () => {
 				downloadSink,
 				uploadTimeoutMs,
 				downloadTimeoutMs,
+				postTransferSoakMs,
 				postUploadMonitorMs,
 				pollMs,
 				minReadySeeders,

--- a/scripts/file-share/template-contract.test.mjs
+++ b/scripts/file-share/template-contract.test.mjs
@@ -17,14 +17,14 @@ const templates = [
 ];
 
 for (const name of templates) {
-	test(`${name} emits the atomic v9 result envelope`, async () => {
+	test(`${name} emits the atomic v10 result envelope`, async () => {
 		const contents = await readFile(
 			path.join(repoRoot, "scripts", "file-share", "templates", name),
 			"utf8",
 		);
 		for (const required of [
 			'id: "peerbit-file-share-benchmark"',
-			"version: 9",
+			"version: 10",
 			"PW_BENCHMARK_RUN_NONCE",
 			"PW_BENCHMARK_INVOCATION",
 			"PW_BENCHMARK_PROVENANCE",
@@ -115,9 +115,25 @@ test("seeder probe records enforceable convergence timing evidence", async () =>
 		"timeToTargetMs",
 		"targetSampleLabel",
 		"effectiveSampleIntervalMs",
+		"const remainingMs = deadlineAt - Date.now()",
+		"remainingMs,",
+		"timeoutMs: number",
 	]) {
 		assert.ok(contents.includes(required), `missing ${required}`);
 	}
+	assert.doesNotMatch(
+		contents,
+		/withDeadline\(\s*Promise\.all\([\s\S]*?\),\s*deadlineAt,/,
+		"the seeder sample must pass a relative remaining duration to withDeadline",
+	);
+	const deadlineHelper = contents.slice(
+		contents.indexOf("const withDeadline"),
+		contents.indexOf("const persistResult"),
+	);
+	assert.ok(
+		!deadlineHelper.includes("Date.now()"),
+		"withDeadline must not reinterpret a relative duration as an epoch",
+	);
 });
 
 test("upload probe fails closed and records bounded scheduling tolerances", async () => {
@@ -149,13 +165,18 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS",
 		"Measured transfer duration exceeded",
 		"PW_DOWNLOAD_SINK",
+		"PW_POST_TRANSFER_SOAK_MS",
 		"installHashOnlyMockSaveFilePicker",
 		"installMockSaveFilePicker",
 		"installNodeBackedMockSaveFilePicker",
 		"summarizeReadTransferDiagnostics",
 		"libraryComputedSha256Base64",
 		'import { withDeadline } from "./generated.promise-deadline.mjs"',
-		'import { startDownloadMemoryTelemetry } from "./generated.download-memory-telemetry.mjs"',
+		'from "./generated.download-memory-telemetry.mjs"',
+		"DOWNLOAD_MEMORY_LIVE_SAMPLE_COVERAGE_DEFINITION",
+		"DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS",
+		"assertDownloadMemoryLiveSampleCoverage",
+		"startDownloadMemoryTelemetry",
 		"UPLOAD_TIMEOUT_MS +",
 		"READY_TIMEOUT_MS +",
 		"const boundedReaderListedPromise =",
@@ -244,9 +265,30 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"unexpectedSeederDrop",
 		"downloadMemoryTelemetryController =",
 		"downloadMemoryTelemetryController.snapshot()",
-		"await downloadMemoryTelemetryController.stopSampling()",
 		"await downloadMemoryTelemetryController.cleanup()",
+		"postTransferSoakMs: POST_TRANSFER_SOAK_MS",
+		"samplingWindowBudgetMs: TEST_OUTER_TIMEOUT_MS",
+		'stage = "post-transfer-soak"',
+		"postTransferSoakStartedAt = Date.now()",
+		"postTransferSoakFinishedAt = Date.now()",
+		"await downloadMemoryTelemetryController.sampleNow()",
+		"resourceSnapshots.beforeSoak =",
+		"resourceSnapshots.afterSoak =",
+		'"programAddress",',
+		'"peerId",',
+		'"peerHash",',
+		'"sessionId",',
+		"shutdownEvidence.programClosed !== true",
+		"shutdownEvidence.peerStopped !== true",
+		"shutdownIdentityMatchesSnapshots",
+		"schemaVersion: 2",
+		"timedReadEnvelope:",
+		"postTransferWork:",
+		"soak: buildInterval(snapshots.beforeSoak, snapshots.afterSoak)",
 		"downloadMemoryTelemetry.complete !== true",
+		"downloadMemoryTelemetry.manualCheckpointComplete !== true",
+		"downloadMemoryTelemetry.terminalCheckpointComplete !== true",
+		"downloadMemoryTelemetry.samplingCapacitySufficient !== true",
 		"series.samplingErrors.length > 0",
 		"downloadMemoryTelemetry,",
 		"let integrityVerifiedAt: number | null = null",
@@ -318,7 +360,7 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 	);
 	assert.ok(
 		contents.lastIndexOf('phase: "pre-timed-read",') <
-				contents.indexOf("writerTopologyBeforeTimedRead =") &&
+			contents.indexOf("writerTopologyBeforeTimedRead =") &&
 			contents.indexOf("writerTopologyBeforeTimedRead =") <
 				contents.indexOf("const downloadCompletion = armSavedViaPicker(") &&
 			contents.indexOf("const downloadCompletion = armSavedViaPicker(") <
@@ -327,15 +369,10 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 	);
 	assert.ok(
 		contents.indexOf("const download = await downloadCompletion") <
-			contents.indexOf(
-				"await downloadMemoryTelemetryController.stopSampling()",
-			) &&
-			contents.indexOf(
-				"await downloadMemoryTelemetryController.stopSampling()",
-			) < contents.indexOf("writerTopologyAfterTimedRead =") &&
+			contents.indexOf("writerTopologyAfterTimedRead =") &&
 			contents.indexOf("writerTopologyAfterTimedRead =") <
 				contents.indexOf('stage = "verify-integrity"'),
-		"memory telemetry sampling must stop at sink completion before the immediate topology snapshot and integrity work",
+		"post-read topology must remain immediate while memory sampling continues",
 	);
 	assert.ok(
 		contents.indexOf("writerTopologyAfterTimedRead =") <
@@ -346,20 +383,17 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 	);
 	assert.ok(
 		contents.indexOf("writerTopologyAfterTimedRead =") <
-			contents.lastIndexOf(
-				"requireMonotonicTransportCounterDelta(",
-			) &&
+			contents.lastIndexOf("requireMonotonicTransportCounterDelta(") &&
 			contents.lastIndexOf("requireMonotonicTransportCounterDelta(") <
 				contents.indexOf('stage = "verify-integrity"'),
 		"the immediate post-read gate must enforce local per-key monotonicity before integrity work",
 	);
 	assert.ok(
-		contents.indexOf(
-			"await downloadMemoryTelemetryController.stopSampling()",
-		) < contents.lastIndexOf('phase: "post-timed-read",') &&
+		contents.indexOf("const download = await downloadCompletion") <
+			contents.lastIndexOf('phase: "post-timed-read",') &&
 			contents.lastIndexOf('phase: "post-timed-read",') <
 				contents.indexOf("writerTopologyAfterTimedRead ="),
-		"post-read pubsub counters must stabilize immediately after memory sampling stops",
+		"post-read pubsub counters must stabilize immediately after sink completion",
 	);
 	assert.match(
 		contents,
@@ -370,6 +404,29 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		contents.indexOf("integrityVerifiedAt = Date.now()") <
 			contents.indexOf("await downloadMemoryTelemetryController.cleanup()"),
 		"CDP cleanup must start only after transfer integrity evidence is finalized",
+	);
+	assert.ok(
+		contents.indexOf("resourceSnapshots.afterSink =") <
+			contents.indexOf("resourceSnapshots.beforeSoak =") &&
+			contents.indexOf("resourceSnapshots.beforeSoak =") <
+				contents.indexOf("postTransferSoakStartedAt = Date.now()") &&
+			contents.indexOf("postTransferSoakStartedAt = Date.now()") <
+				contents.indexOf("postTransferSoakFinishedAt = Date.now()") &&
+			contents.indexOf("postTransferSoakFinishedAt = Date.now()") <
+				contents.indexOf(
+					"await downloadMemoryTelemetryController.sampleNow()",
+				) &&
+			contents.indexOf("await downloadMemoryTelemetryController.sampleNow()") <
+				contents.indexOf("resourceSnapshots.afterSoak =") &&
+			contents.indexOf("resourceSnapshots.afterSoak =") <
+				contents.indexOf("const [writerShutdown, readerShutdown]") &&
+			contents.indexOf("const [writerShutdown, readerShutdown]") <
+				contents.indexOf("await downloadMemoryTelemetryController.cleanup()"),
+		"memory sampling must remain armed through the bounded soak and peer shutdown",
+	);
+	assert.ok(
+		!contents.includes("downloadMemoryTelemetryController.stopSampling()"),
+		"the template must not stop memory sampling before soak and shutdown cleanup",
 	);
 	assert.ok(
 		!contents.includes("MIN_READY_SEEDERS, 180_000"),
@@ -439,6 +496,10 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"lastUploadDiagnostics:",
 		"(program as any)?.lastUploadDiagnostics ?? null",
 		'requireUploadDiagnostics: scenario === "upload"',
+		'requireRuntimeEvidence: scenario === "upload"',
+		"getBenchmarkRuntimeSnapshot",
+		"getStorageSnapshot",
+		"shutdown:",
 		"peerbit-benchmark-locality-prefix-preload",
 		"peerbit-benchmark-locality-preload-aggregate-deadline",
 		"peerbit-benchmark-locality-exact-manifest-import",
@@ -452,7 +513,7 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"signal: aggregateController.signal",
 		"aggregateController.abort(aggregateTimeoutError)",
 		"const manifestEntryHeads = (file as any).chunkEntryHeads",
-		'const documentId = \\`\\${file.id}:\\${index}\\`',
+		"const documentId = \\`\\${file.id}:\\${index}\\`",
 		"program.retainChunkRead(documentId, file.id)",
 		"program.retainChunkEntryHead(\n\t\t\t\t\t\t\t\t\t\t\thead,\n\t\t\t\t\t\t\t\t\t\t\tfile.id,\n\t\t\t\t\t\t\t\t\t\t\tdocumentId",
 		"const rawEntry = await blocks.get(head",
@@ -742,7 +803,7 @@ test("download memory support is bounded, serial, and cleanup-safe", async () =>
 		"utf8",
 	);
 	for (const required of [
-		'DOWNLOAD_MEMORY_PROFILE = "download-memory-v2"',
+		'DOWNLOAD_MEMORY_PROFILE = "download-memory-v3"',
 		"DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS = 5_000",
 		"DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS = 4_000",
 		"DOWNLOAD_MEMORY_CLEANUP_TIMEOUT_MS = 9_000",
@@ -753,22 +814,37 @@ test("download memory support is bounded, serial, and cleanup-safe", async () =>
 		"DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS = 16",
 		"DOWNLOAD_MEMORY_MAX_CLEANUP_WARNINGS = 16",
 		"DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH = 512",
+		"DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE = 3",
 		"startBoundedSerialSampler",
 		"withDownloadMemoryOperationDeadline",
 		"onLateResolution",
-		"terminalSampleFailure = true",
-		"samples.length >= maxSamples - 1",
-		"await activeSample",
-		"await takeSample(true)",
+		"samplingWindowBudgetMs",
+		"sampleNow",
+		"serialSampleChain",
+		"capacityExhaustedBeforeTerminal",
+		"manualCheckpointComplete",
+		"terminalCheckpointComplete",
+		'await enqueueSample("terminal")',
+		'sampleKind === "manual"',
+		'sampleKind === "terminal"',
 		"newCDPSession(page)",
 		'"Page JS heap CDP session creation"',
-		"Performance.getMetrics",
-		'metric.name === "JSHeapUsedSize"',
+		"Runtime.getHeapUsage",
+		"embedderHeapUsedSize",
+		"backingStorageSize",
+		"startEmbedderHeapUsedBytes",
+		"peakBackingStorageBytes",
 		"newBrowserCDPSession()",
 		'"Browser RSS CDP session creation"',
 		"SystemInfo.getProcessInfo",
 		'"ps"',
-		"process.memoryUsage().rss",
+		"process.memoryUsage()",
+		"nodeExternalBytes",
+		"nodeArrayBuffersBytes",
+		"startNodeExternalBytes",
+		"peakNodeArrayBuffersBytes",
+		"never added to the combined RSS total",
+		"postTransferSoakMs",
 		"playwright-worker-node-including-in-process-local-bootstrap",
 		"samplingErrorOverflowCount",
 		"cleanupWarningOverflowCount",
@@ -780,10 +856,65 @@ test("download memory support is bounded, serial, and cleanup-safe", async () =>
 		);
 	}
 	assert.ok(
-		contents.indexOf("await activeSample") <
-			contents.indexOf("await takeSample(true)"),
-		"stop must drain an active sample before the forced terminal sample",
+		contents.indexOf("await scheduledSamplePromise") <
+			contents.indexOf('await enqueueSample("terminal")'),
+		"stop must drain a scheduled sample before the forced terminal sample",
 	);
+});
+
+test("post-transfer soak is invocation-bound and forwarded by both runners", async () => {
+	const [invocation, runner, matrix, uploadTemplate, seederTemplate] =
+		await Promise.all(
+			[
+				"benchmark-invocation.mjs",
+				"run-file-share-benchmark.mjs",
+				"run-file-share-benchmark-matrix.mjs",
+				path.join("templates", "upload-benchmark.local.e2e.spec.ts"),
+				path.join("templates", "seeder-probe.e2e.spec.ts"),
+			].map((file) =>
+				readFile(path.join(repoRoot, "scripts", "file-share", file), "utf8"),
+			),
+		);
+	for (const required of [
+		"version: 5",
+		"postTransferSoakMs: 60_000",
+		"postTransferSoakMs ??",
+		'scenario === "upload" ? DEFAULTS.postTransferSoakMs : 0',
+		"PW_POST_TRANSFER_SOAK_MS: String(invocation.postTransferSoakMs)",
+	]) {
+		assert.ok(invocation.includes(required), `invocation missing ${required}`);
+	}
+	for (const required of [
+		'args["post-transfer-soak-ms"]',
+		'"--post-transfer-soak-ms"',
+		"postTransferSoakMs,",
+	]) {
+		assert.ok(runner.includes(required), `runner missing ${required}`);
+	}
+	for (const required of [
+		'args["post-transfer-soak-ms"]',
+		'["--post-transfer-soak-ms", String(postTransferSoakMs)]',
+		"postTransferSoakMs: optionalNumber(postTransferSoakMs)",
+	]) {
+		assert.ok(matrix.includes(required), `matrix missing ${required}`);
+	}
+	for (const [label, contents] of [
+		["upload", uploadTemplate],
+		["seeder", seederTemplate],
+	]) {
+		assert.ok(
+			contents.includes("PW_POST_TRANSFER_SOAK_MS"),
+			`${label} template does not bind the soak environment`,
+		);
+		assert.ok(
+			contents.includes("postTransferSoakMs:"),
+			`${label} template does not check the invocation soak`,
+		);
+		assert.ok(
+			contents.includes("?.version !== 5"),
+			`${label} template does not require invocation schema v5`,
+		);
+	}
 });
 
 test("matrix fail-closes every result envelope and fully validates passes", async () => {

--- a/scripts/file-share/templates/download-memory-telemetry.mjs
+++ b/scripts/file-share/templates/download-memory-telemetry.mjs
@@ -3,16 +3,18 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
-export const DOWNLOAD_MEMORY_PROFILE = "download-memory-v2";
+export const DOWNLOAD_MEMORY_PROFILE = "download-memory-v3";
 export const DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS = 5_000;
 export const DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS = 4_000;
 export const DOWNLOAD_MEMORY_CLEANUP_TIMEOUT_MS = 9_000;
 export const DOWNLOAD_MEMORY_SETUP_ALLOWANCE_MS = 30_000;
 export const DOWNLOAD_MEMORY_TERMINAL_ALLOWANCE_MS = 30_000;
 export const DOWNLOAD_MEMORY_WINDOW_DEFINITION =
-	"samplers-armed-after-any-requested-reader-locality-prefix-stabilization-before-any-requested-bounded-pre-read-transport-counter-gate-and-download-click-through-selected-sink-completion";
+	"samplers-armed-after-any-requested-reader-locality-prefix-stabilization-before-any-requested-bounded-pre-read-transport-counter-gate-and-download-click-through-selected-sink-completion-requested-post-transfer-soak-live-checkpoint-bounded-peer-shutdown-and-terminal-sample";
+export const DOWNLOAD_MEMORY_LIVE_SAMPLE_COVERAGE_DEFINITION =
+	"for each exact transfer or soak phase, the last non-terminal sample at or before phase start through the first non-terminal sample at or after phase finish must exist and every adjacent capturedAt gap must be at most sampleIntervalMs + operationTimeoutMs + schedulingToleranceMs";
 export const DOWNLOAD_MEMORY_MAX_SAMPLES_PER_SERIES = 4_096;
-export const DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE = 2;
+export const DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE = 3;
 export const DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS = 16;
 export const DOWNLOAD_MEMORY_MAX_CLEANUP_WARNINGS = 16;
 export const DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH = 512;
@@ -26,27 +28,135 @@ export const DOWNLOAD_MEMORY_HOST_SCOPE =
 export const DOWNLOAD_MEMORY_NODE_SCOPE =
 	"playwright-worker-node-including-in-process-local-bootstrap";
 export const DOWNLOAD_MEMORY_HOST_ATTRIBUTION_LIMITATIONS =
-	"Chromium RSS is grouped by process role and cannot be attributed reliably to the reader or writer page; Node RSS is the Playwright worker process and includes the in-process bootstrap peer in local mode; RSS is not PSS or USS.";
+	"Chromium RSS is grouped by process role and cannot be attributed reliably to the reader or writer page; Node RSS is the Playwright worker process and includes the in-process bootstrap peer in local mode; RSS is not PSS or USS; Node external and ArrayBuffer bytes are overlapping allocation diagnostics that are not additive with RSS and are never added to the combined RSS total.";
 
 export const calculateDownloadMemoryMaxSamples = ({
-	downloadTimeoutMs,
-	schedulingToleranceMs,
+	samplingWindowBudgetMs,
 }) => {
 	if (
-		!Number.isSafeInteger(downloadTimeoutMs) ||
-		downloadTimeoutMs <= 0 ||
-		!Number.isSafeInteger(schedulingToleranceMs) ||
-		schedulingToleranceMs < 0
+		!Number.isSafeInteger(samplingWindowBudgetMs) ||
+		samplingWindowBudgetMs <= 0
 	) {
-		throw new Error("Download memory sampling requires bounded timeout values");
+		throw new Error(
+			"Download memory sampling requires a positive bounded sampling window budget",
+		);
 	}
-	return Math.min(
-		DOWNLOAD_MEMORY_MAX_SAMPLES_PER_SERIES,
-		Math.ceil(
-			(downloadTimeoutMs + schedulingToleranceMs) /
-				DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
-		) + DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE,
+	const totalWindowMs = BigInt(samplingWindowBudgetMs);
+	const intervalMs = BigInt(DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS);
+	const intervalSamples = (totalWindowMs + intervalMs - 1n) / intervalMs;
+	return Number(
+		intervalSamples + BigInt(DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE) >
+			BigInt(DOWNLOAD_MEMORY_MAX_SAMPLES_PER_SERIES)
+			? BigInt(DOWNLOAD_MEMORY_MAX_SAMPLES_PER_SERIES)
+			: intervalSamples + BigInt(DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE),
 	);
+};
+
+export const calculateDownloadMemoryMaxLiveSampleGapMs = ({
+	schedulingToleranceMs,
+	operationTimeoutMs = DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS,
+}) => {
+	if (
+		!Number.isSafeInteger(schedulingToleranceMs) ||
+		schedulingToleranceMs < 0 ||
+		!Number.isSafeInteger(operationTimeoutMs) ||
+		operationTimeoutMs <= 0
+	) {
+		throw new Error(
+			"Download memory live-sample coverage requires bounded scheduling and operation tolerances",
+		);
+	}
+	const maxGapMs =
+		DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS +
+		operationTimeoutMs +
+		schedulingToleranceMs;
+	if (!Number.isSafeInteger(maxGapMs) || maxGapMs <= 0) {
+		throw new Error("Download memory live-sample gap exceeds the safe range");
+	}
+	return maxGapMs;
+};
+
+export const assertDownloadMemoryLiveSampleCoverage = ({
+	samples,
+	phaseStartedAt,
+	phaseFinishedAt,
+	maxGapMs,
+	label,
+}) => {
+	if (
+		!Array.isArray(samples) ||
+		!Number.isSafeInteger(phaseStartedAt) ||
+		phaseStartedAt < 0 ||
+		!Number.isSafeInteger(phaseFinishedAt) ||
+		phaseFinishedAt < phaseStartedAt ||
+		!Number.isSafeInteger(maxGapMs) ||
+		maxGapMs <= 0 ||
+		typeof label !== "string" ||
+		label.length === 0
+	) {
+		throw new Error("Download memory live-sample coverage input is invalid");
+	}
+	const liveSamples = [];
+	let previousCapturedAt = null;
+	for (const [index, sample] of samples.entries()) {
+		if (sample == null || typeof sample !== "object" || Array.isArray(sample)) {
+			throw new Error(`${label} memory sample ${index} is invalid`);
+		}
+		if (
+			!Number.isSafeInteger(sample.capturedAt) ||
+			sample.capturedAt < 0 ||
+			(previousCapturedAt !== null && sample.capturedAt < previousCapturedAt)
+		) {
+			throw new Error(`${label} memory sample timestamps are invalid`);
+		}
+		if (
+			!new Set(["initial", "periodic", "manual", "terminal"]).has(
+				sample.sampleKind,
+			)
+		) {
+			throw new Error(`${label} memory sample kind is invalid`);
+		}
+		previousCapturedAt = sample.capturedAt;
+		if (sample.sampleKind !== "terminal") {
+			liveSamples.push(sample);
+		}
+	}
+	let firstIndex = -1;
+	for (let index = 0; index < liveSamples.length; index += 1) {
+		if (liveSamples[index].capturedAt <= phaseStartedAt) {
+			firstIndex = index;
+		} else {
+			break;
+		}
+	}
+	const lastIndex = liveSamples.findIndex(
+		(sample) => sample.capturedAt >= phaseFinishedAt,
+	);
+	if (firstIndex < 0 || lastIndex < firstIndex) {
+		throw new Error(
+			`${label} memory samples do not bracket the exact phase window`,
+		);
+	}
+	const coverageSamples = liveSamples.slice(firstIndex, lastIndex + 1);
+	let maxObservedGapMs = 0;
+	for (let index = 1; index < coverageSamples.length; index += 1) {
+		const gapMs =
+			coverageSamples[index].capturedAt - coverageSamples[index - 1].capturedAt;
+		maxObservedGapMs = Math.max(maxObservedGapMs, gapMs);
+		if (gapMs > maxGapMs) {
+			throw new Error(
+				`${label} memory live-sample gap ${gapMs}ms exceeds ${maxGapMs}ms`,
+			);
+		}
+	}
+	return {
+		firstSampleAt: coverageSamples[0].capturedAt,
+		lastSampleAt: coverageSamples.at(-1).capturedAt,
+		startOverhangMs: phaseStartedAt - coverageSamples[0].capturedAt,
+		endOverhangMs: coverageSamples.at(-1).capturedAt - phaseFinishedAt,
+		maxObservedGapMs,
+		sampleCount: coverageSamples.length,
+	};
 };
 
 const cloneValue = (value) => structuredClone(value);
@@ -112,10 +222,11 @@ export const withDownloadMemoryOperationDeadline = async (
 };
 
 /**
- * Runs one sample at a time, reserves one bounded slot for the forced terminal
- * sample, and makes stop idempotent. Errors are evidence rather than detached
- * promise rejections, and are themselves bounded so a failed probe cannot make
- * the benchmark result grow without limit.
+ * Runs one sample at a time, reserves one bounded slot for a live checkpoint and
+ * one for the forced terminal sample, and makes checkpoint/stop operations
+ * concurrency-safe. Errors are evidence rather than detached promise
+ * rejections, and are themselves bounded so a failed probe cannot make the
+ * benchmark result grow without limit.
  */
 export const startBoundedSerialSampler = async ({
 	intervalMs,
@@ -131,8 +242,13 @@ export const startBoundedSerialSampler = async ({
 	if (!Number.isSafeInteger(intervalMs) || intervalMs <= 0) {
 		throw new Error("Serial sampler interval must be a positive safe integer");
 	}
-	if (!Number.isSafeInteger(maxSamples) || maxSamples < 2) {
-		throw new Error("Serial sampler must reserve initial and final samples");
+	if (
+		!Number.isSafeInteger(maxSamples) ||
+		maxSamples < DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE
+	) {
+		throw new Error(
+			"Serial sampler must reserve initial, live checkpoint, and final samples",
+		);
 	}
 	if (typeof readSample !== "function" || typeof cleanup !== "function") {
 		throw new Error("Serial sampler requires read and cleanup functions");
@@ -154,11 +270,22 @@ export const startBoundedSerialSampler = async ({
 	let cleanupWarningOverflowCount = 0;
 	let finishedAt = null;
 	let timer;
-	let activeSample;
+	let serialSampleChain = Promise.resolve();
+	let scheduledSamplePromise;
+	let sampleNowPromise;
 	let stopped = false;
-	let terminalSampleFailure = false;
+	let samplingDisabledAfterTimeout = false;
+	let capacityExhaustedBeforeTerminal = false;
+	let periodicSampleCount = 0;
+	let manualSampleCount = 0;
+	let lastManualSampleAt = null;
+	let terminalSampleAttempted = false;
+	let terminalSampleCaptured = false;
+	let terminalSampleAt = null;
 	let stopSamplingPromise;
 	let cleanupPromise;
+	const periodicSampleLimit =
+		maxSamples - DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE;
 
 	const recordError = (error) => {
 		if (samplingErrors.length < DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS) {
@@ -179,10 +306,23 @@ export const startBoundedSerialSampler = async ({
 		}
 	};
 
-	const takeSample = async (forceTerminal = false) => {
-		const limit = forceTerminal ? maxSamples : maxSamples - 1;
-		if (samples.length >= limit || terminalSampleFailure) {
-			return;
+	const takeSample = async (sampleKind) => {
+		const terminal = sampleKind === "terminal";
+		if (terminal) {
+			terminalSampleAttempted = true;
+		}
+		const sampleCapacityReached =
+			sampleKind === "periodic"
+				? periodicSampleCount >= periodicSampleLimit
+				: samples.length >= (terminal ? maxSamples : maxSamples - 1);
+		if (sampleCapacityReached) {
+			if (!terminal) {
+				capacityExhaustedBeforeTerminal = true;
+			}
+			return false;
+		}
+		if (samplingDisabledAfterTimeout) {
+			return false;
 		}
 		try {
 			const values = await withDownloadMemoryOperationDeadline(
@@ -197,26 +337,64 @@ export const startBoundedSerialSampler = async ({
 			) {
 				throw new Error("Memory sampler returned a non-object sample");
 			}
-			samples.push({ capturedAt: now(), ...values });
+			const capturedAt = now();
+			samples.push({
+				...values,
+				capturedAt,
+				sampleKind,
+			});
+			if (sampleKind === "manual") {
+				manualSampleCount += 1;
+				lastManualSampleAt = capturedAt;
+			}
+			if (sampleKind === "periodic") {
+				periodicSampleCount += 1;
+			}
+			if (terminal) {
+				terminalSampleCaptured = true;
+				terminalSampleAt = capturedAt;
+			}
+			return true;
 		} catch (error) {
 			recordError(error);
 			if (error?.code === "DOWNLOAD_MEMORY_OPERATION_TIMEOUT") {
-				terminalSampleFailure = true;
+				samplingDisabledAfterTimeout = true;
 			}
+			return false;
 		}
 	};
 
+	const enqueueSample = (sampleKind) => {
+		const samplePromise = serialSampleChain.then(() => takeSample(sampleKind));
+		serialSampleChain = samplePromise.catch(recordError);
+		return samplePromise;
+	};
+
 	const schedule = () => {
-		if (stopped || terminalSampleFailure || samples.length >= maxSamples - 1) {
+		if (stopped || samplingDisabledAfterTimeout || timer !== undefined) {
 			return;
 		}
 		timer = setTimer(() => {
-			activeSample = takeSample()
-				.catch(recordError)
-				.finally(() => {
-					activeSample = undefined;
-					schedule();
-				});
+			timer = undefined;
+			if (stopped || samplingDisabledAfterTimeout) {
+				return;
+			}
+			if (periodicSampleCount >= periodicSampleLimit) {
+				capacityExhaustedBeforeTerminal = true;
+				return;
+			}
+			const currentSample = enqueueSample("periodic");
+			scheduledSamplePromise = currentSample;
+			const finishScheduledSample = () => {
+				if (scheduledSamplePromise === currentSample) {
+					scheduledSamplePromise = undefined;
+				}
+				schedule();
+			};
+			currentSample.then(finishScheduledSample, (error) => {
+				recordError(error);
+				finishScheduledSample();
+			});
 		}, intervalMs);
 	};
 
@@ -228,10 +406,41 @@ export const startBoundedSerialSampler = async ({
 		samplingErrorOverflowCount,
 		cleanupWarnings: [...cleanupWarnings],
 		cleanupWarningOverflowCount,
+		maxSamples,
+		periodicSampleLimit,
+		periodicSampleCount,
+		capacityExhaustedBeforeTerminal,
+		samplingCapacitySufficient: !capacityExhaustedBeforeTerminal,
+		manualSampleCount,
+		lastManualSampleAt,
+		terminalSampleAttempted,
+		terminalSampleCaptured,
+		terminalSampleAt,
 	});
 
-	await takeSample();
+	await takeSample("initial");
 	schedule();
+
+	const sampleNow = () => {
+		if (stopSamplingPromise) {
+			return stopSamplingPromise;
+		}
+		if (sampleNowPromise) {
+			return sampleNowPromise;
+		}
+		if (timer !== undefined) {
+			clearTimer(timer);
+			timer = undefined;
+		}
+		const currentSample = enqueueSample("manual");
+		const currentSnapshot = currentSample.then(() => snapshot());
+		sampleNowPromise = currentSnapshot;
+		currentSnapshot.then(schedule, (error) => {
+			recordError(error);
+			schedule();
+		});
+		return currentSnapshot;
+	};
 
 	const stopSampling = () => {
 		if (stopSamplingPromise) {
@@ -243,8 +452,9 @@ export const startBoundedSerialSampler = async ({
 				clearTimer(timer);
 				timer = undefined;
 			}
-			await activeSample;
-			await takeSample(true);
+			await sampleNowPromise;
+			await scheduledSamplePromise;
+			await enqueueSample("terminal");
 			finishedAt = now();
 			return snapshot();
 		})();
@@ -276,6 +486,7 @@ export const startBoundedSerialSampler = async ({
 
 	return {
 		snapshot,
+		sampleNow,
 		stopSampling,
 		cleanup: runCleanup,
 		stop: runCleanup,
@@ -283,24 +494,51 @@ export const startBoundedSerialSampler = async ({
 };
 
 const summarizeHeap = (scope, state) => {
-	const usedBytes = state.samples.map((sample) => sample.usedBytes);
+	const first = state.samples[0] ?? null;
+	const last = state.samples.at(-1) ?? null;
+	const peak = (name) =>
+		state.samples.length > 0
+			? Math.max(...state.samples.map((sample) => sample[name]))
+			: null;
 	return {
-		memoryKind: "javascript-heap",
+		memoryKind: "runtime-heap",
 		scope,
-		metric: "JSHeapUsedSize",
+		metric: "Runtime.getHeapUsage",
 		unit: "bytes",
 		sampleIntervalMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
 		startedAt: state.startedAt,
 		finishedAt: state.finishedAt,
 		sampleCount: state.samples.length,
-		startBytes: usedBytes[0] ?? null,
-		endBytes: usedBytes.at(-1) ?? null,
-		peakBytes: usedBytes.length > 0 ? Math.max(...usedBytes) : null,
+		startBytes: first?.usedBytes ?? null,
+		endBytes: last?.usedBytes ?? null,
+		peakBytes: peak("usedBytes"),
+		startUsedBytes: first?.usedBytes ?? null,
+		endUsedBytes: last?.usedBytes ?? null,
+		peakUsedBytes: peak("usedBytes"),
+		startTotalBytes: first?.totalBytes ?? null,
+		endTotalBytes: last?.totalBytes ?? null,
+		peakTotalBytes: peak("totalBytes"),
+		startEmbedderHeapUsedBytes: first?.embedderHeapUsedBytes ?? null,
+		endEmbedderHeapUsedBytes: last?.embedderHeapUsedBytes ?? null,
+		peakEmbedderHeapUsedBytes: peak("embedderHeapUsedBytes"),
+		startBackingStorageBytes: first?.backingStorageBytes ?? null,
+		endBackingStorageBytes: last?.backingStorageBytes ?? null,
+		peakBackingStorageBytes: peak("backingStorageBytes"),
 		samples: state.samples,
 		samplingErrors: state.samplingErrors,
 		samplingErrorOverflowCount: state.samplingErrorOverflowCount,
 		cleanupWarnings: state.cleanupWarnings,
 		cleanupWarningOverflowCount: state.cleanupWarningOverflowCount,
+		maxSamples: state.maxSamples,
+		periodicSampleLimit: state.periodicSampleLimit,
+		periodicSampleCount: state.periodicSampleCount,
+		capacityExhaustedBeforeTerminal: state.capacityExhaustedBeforeTerminal,
+		samplingCapacitySufficient: state.samplingCapacitySufficient,
+		manualSampleCount: state.manualSampleCount,
+		lastManualSampleAt: state.lastManualSampleAt,
+		terminalSampleAttempted: state.terminalSampleAttempted,
+		terminalSampleCaptured: state.terminalSampleCaptured,
+		terminalSampleAt: state.terminalSampleAt,
 	};
 };
 
@@ -328,11 +566,6 @@ const startPageJsHeapSampler = async ({
 				},
 			},
 		);
-		await withDownloadMemoryOperationDeadline(
-			session.send("Performance.enable"),
-			"Page JS heap Performance.enable",
-			operationTimeoutMs,
-		);
 	} catch (error) {
 		setupError = error;
 	}
@@ -348,33 +581,27 @@ const startPageJsHeapSampler = async ({
 			if (!session) {
 				throw new Error("Page JS heap CDP session is unavailable");
 			}
-			const response = await session.send("Performance.getMetrics");
-			const heapMetric = response.metrics.find(
-				(metric) => metric.name === "JSHeapUsedSize",
-			);
+			const response = await session.send("Runtime.getHeapUsage");
+			const values = {
+				usedBytes: response.usedSize,
+				totalBytes: response.totalSize,
+				embedderHeapUsedBytes: response.embedderHeapUsedSize,
+				backingStorageBytes: response.backingStorageSize,
+			};
 			if (
-				!heapMetric ||
-				!Number.isFinite(heapMetric.value) ||
-				heapMetric.value < 0
+				Object.values(values).some(
+					(value) => !Number.isSafeInteger(value) || value < 0,
+				)
 			) {
-				throw new Error("Performance.getMetrics omitted JSHeapUsedSize");
+				throw new Error("Runtime.getHeapUsage returned invalid heap values");
 			}
-			return { usedBytes: heapMetric.value };
+			return values;
 		},
 		cleanup: async () => {
 			if (!session) {
 				return;
 			}
 			const cleanupErrors = [];
-			try {
-				await withDownloadMemoryOperationDeadline(
-					session.send("Performance.disable"),
-					"Page JS heap Performance.disable",
-					operationTimeoutMs,
-				);
-			} catch (error) {
-				cleanupErrors.push(error);
-			}
 			try {
 				await withDownloadMemoryOperationDeadline(
 					session.detach(),
@@ -396,6 +623,7 @@ const startPageJsHeapSampler = async ({
 	});
 	return {
 		snapshot: () => summarizeHeap(scope, sampler.snapshot()),
+		sampleNow: async () => summarizeHeap(scope, await sampler.sampleNow()),
 		stopSampling: async () =>
 			summarizeHeap(scope, await sampler.stopSampling()),
 		cleanup: async () => summarizeHeap(scope, await sampler.cleanup()),
@@ -473,6 +701,12 @@ const summarizeHostRss = (state) => {
 		startNodeBytes: first?.nodeBytes ?? null,
 		endNodeBytes: last?.nodeBytes ?? null,
 		peakNodeBytes: peak("nodeBytes"),
+		startNodeExternalBytes: first?.nodeExternalBytes ?? null,
+		endNodeExternalBytes: last?.nodeExternalBytes ?? null,
+		peakNodeExternalBytes: peak("nodeExternalBytes"),
+		startNodeArrayBuffersBytes: first?.nodeArrayBuffersBytes ?? null,
+		endNodeArrayBuffersBytes: last?.nodeArrayBuffersBytes ?? null,
+		peakNodeArrayBuffersBytes: peak("nodeArrayBuffersBytes"),
 		startCombinedBytes: first?.combinedBytes ?? null,
 		endCombinedBytes: last?.combinedBytes ?? null,
 		peakCombinedBytes: peak("combinedBytes"),
@@ -487,6 +721,16 @@ const summarizeHostRss = (state) => {
 		samplingErrorOverflowCount: state.samplingErrorOverflowCount,
 		cleanupWarnings: state.cleanupWarnings,
 		cleanupWarningOverflowCount: state.cleanupWarningOverflowCount,
+		maxSamples: state.maxSamples,
+		periodicSampleLimit: state.periodicSampleLimit,
+		periodicSampleCount: state.periodicSampleCount,
+		capacityExhaustedBeforeTerminal: state.capacityExhaustedBeforeTerminal,
+		samplingCapacitySufficient: state.samplingCapacitySufficient,
+		manualSampleCount: state.manualSampleCount,
+		lastManualSampleAt: state.lastManualSampleAt,
+		terminalSampleAttempted: state.terminalSampleAttempted,
+		terminalSampleCaptured: state.terminalSampleCaptured,
+		terminalSampleAt: state.terminalSampleAt,
 	};
 };
 
@@ -542,9 +786,21 @@ const startHostRssSampler = async ({
 				throw new Error("Chromium process count exceeds the telemetry cap");
 			}
 			const browserProcessBytes = await readProcessRssBytes(processIds);
-			const nodeBytes = process.memoryUsage().rss;
-			if (!Number.isSafeInteger(nodeBytes) || nodeBytes <= 0) {
-				throw new Error("Playwright worker returned invalid Node RSS");
+			const nodeMemory = process.memoryUsage();
+			const nodeBytes = nodeMemory.rss;
+			const nodeExternalBytes = nodeMemory.external;
+			const nodeArrayBuffersBytes = nodeMemory.arrayBuffers;
+			if (
+				!Number.isSafeInteger(nodeBytes) ||
+				nodeBytes <= 0 ||
+				!Number.isSafeInteger(nodeExternalBytes) ||
+				nodeExternalBytes < 0 ||
+				!Number.isSafeInteger(nodeArrayBuffersBytes) ||
+				nodeArrayBuffersBytes < 0
+			) {
+				throw new Error(
+					"Playwright worker returned invalid Node memory values",
+				);
 			}
 			const browserRoleBytes = {};
 			for (const processEntry of processInfo) {
@@ -581,6 +837,8 @@ const startHostRssSampler = async ({
 			return {
 				browserBytes,
 				nodeBytes,
+				nodeExternalBytes,
+				nodeArrayBuffersBytes,
 				combinedBytes: browserBytes + nodeBytes,
 				browserProcessCount: browserProcessBytes.size,
 				browserRoleBytes,
@@ -602,6 +860,7 @@ const startHostRssSampler = async ({
 	});
 	return {
 		snapshot: () => summarizeHostRss(sampler.snapshot()),
+		sampleNow: async () => summarizeHostRss(await sampler.sampleNow()),
 		stopSampling: async () => summarizeHostRss(await sampler.stopSampling()),
 		cleanup: async () => summarizeHostRss(await sampler.cleanup()),
 		stop: async () => summarizeHostRss(await sampler.stop()),
@@ -614,12 +873,17 @@ export const startDownloadMemoryTelemetry = async ({
 	writer,
 	downloadTimeoutMs,
 	schedulingToleranceMs,
+	postTransferSoakMs,
+	samplingWindowBudgetMs,
 	operationTimeoutMs = DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS,
 	cleanupTimeoutMs = DOWNLOAD_MEMORY_CLEANUP_TIMEOUT_MS,
 }) => {
 	const maxSamplesPerSeries = calculateDownloadMemoryMaxSamples({
-		downloadTimeoutMs,
+		samplingWindowBudgetMs,
+	});
+	const liveSampleMaxGapMs = calculateDownloadMemoryMaxLiveSampleGapMs({
 		schedulingToleranceMs,
+		operationTimeoutMs,
 	});
 	const [readerSampler, writerSampler, hostSampler] = await Promise.all([
 		startPageJsHeapSampler({
@@ -645,34 +909,75 @@ export const startDownloadMemoryTelemetry = async ({
 	]);
 	let complete = false;
 	let cleanupComplete = false;
+	let sampleNowPromise;
 	let stopSamplingPromise;
 	let cleanupPromise;
-	const build = ({ readerJsHeap, writerJsHeap, hostRss }) => ({
-		profile: DOWNLOAD_MEMORY_PROFILE,
-		sampleIntervalMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
-		windowDefinition: DOWNLOAD_MEMORY_WINDOW_DEFINITION,
-		maxSamplesPerSeries,
-		complete,
-		cleanupComplete,
-		startedAt: Math.min(
-			readerJsHeap.startedAt,
-			writerJsHeap.startedAt,
-			hostRss.startedAt,
-		),
-		finishedAt:
-			readerJsHeap.finishedAt == null ||
-			writerJsHeap.finishedAt == null ||
-			hostRss.finishedAt == null
-				? null
-				: Math.max(
-						readerJsHeap.finishedAt,
-						writerJsHeap.finishedAt,
-						hostRss.finishedAt,
-					),
-		readerJsHeap,
-		writerJsHeap,
-		hostRss,
-	});
+	const build = ({ readerJsHeap, writerJsHeap, hostRss }) => {
+		const series = [readerJsHeap, writerJsHeap, hostRss];
+		const capacityExhaustedBeforeTerminal = series.some(
+			(value) => value.capacityExhaustedBeforeTerminal,
+		);
+		return {
+			profile: DOWNLOAD_MEMORY_PROFILE,
+			sampleIntervalMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
+			windowDefinition: DOWNLOAD_MEMORY_WINDOW_DEFINITION,
+			downloadTimeoutMs,
+			schedulingToleranceMs,
+			operationTimeoutMs,
+			postTransferSoakMs,
+			samplingWindowBudgetMs,
+			liveSampleMaxGapMs,
+			liveSampleCoverageDefinition:
+				DOWNLOAD_MEMORY_LIVE_SAMPLE_COVERAGE_DEFINITION,
+			endpointSampleAllowance: DOWNLOAD_MEMORY_ENDPOINT_SAMPLE_ALLOWANCE,
+			maxSamplesPerSeries,
+			capacityExhaustedBeforeTerminal,
+			samplingCapacitySufficient: !capacityExhaustedBeforeTerminal,
+			manualCheckpointComplete: series.every(
+				(value) => value.manualSampleCount > 0,
+			),
+			terminalCheckpointComplete: series.every(
+				(value) => value.terminalSampleCaptured,
+			),
+			complete,
+			cleanupComplete,
+			startedAt: Math.min(
+				readerJsHeap.startedAt,
+				writerJsHeap.startedAt,
+				hostRss.startedAt,
+			),
+			finishedAt:
+				readerJsHeap.finishedAt == null ||
+				writerJsHeap.finishedAt == null ||
+				hostRss.finishedAt == null
+					? null
+					: Math.max(
+							readerJsHeap.finishedAt,
+							writerJsHeap.finishedAt,
+							hostRss.finishedAt,
+						),
+			readerJsHeap,
+			writerJsHeap,
+			hostRss,
+		};
+	};
+	const sampleNow = () => {
+		if (stopSamplingPromise) {
+			return stopSamplingPromise;
+		}
+		if (sampleNowPromise) {
+			return sampleNowPromise;
+		}
+		const currentSample = Promise.all([
+			readerSampler.sampleNow(),
+			writerSampler.sampleNow(),
+			hostSampler.sampleNow(),
+		]).then(([readerJsHeap, writerJsHeap, hostRss]) =>
+			build({ readerJsHeap, writerJsHeap, hostRss }),
+		);
+		sampleNowPromise = currentSample;
+		return currentSample;
+	};
 	const stopSampling = () => {
 		if (stopSamplingPromise) {
 			return stopSamplingPromise;
@@ -709,6 +1014,7 @@ export const startDownloadMemoryTelemetry = async ({
 				writerJsHeap: writerSampler.snapshot(),
 				hostRss: hostSampler.snapshot(),
 			}),
+		sampleNow,
 		stopSampling,
 		cleanup: runCleanup,
 		stop: runCleanup,

--- a/scripts/file-share/templates/seeder-probe.e2e.spec.ts
+++ b/scripts/file-share/templates/seeder-probe.e2e.spec.ts
@@ -12,6 +12,9 @@ const READY_TIMEOUT_MS = Number(process.env.PW_READY_TIMEOUT_MS || "180000");
 const SAMPLE_MS = Number(process.env.PW_SAMPLE_MS || "15000");
 const SAMPLE_COUNT = Number(process.env.PW_SAMPLE_COUNT || "4");
 const TARGET_SEEDERS = Number(process.env.PW_TARGET_SEEDERS || "2");
+const POST_TRANSFER_SOAK_MS = Number(
+	process.env.PW_POST_TRANSFER_SOAK_MS ?? "0",
+);
 const SAMPLE_COUNT_DEFINITION =
 	"observation-density divisor: planned interval is min(sampleMs, floor(readyTimeoutMs/sampleCount)) clamped to 1ms; convergence may finish early";
 const ERROR_COLLECTION_DEFINITION =
@@ -24,7 +27,7 @@ const EFFECTIVE_SAMPLE_INTERVAL_MS = Math.max(
 );
 const RESULT_SCHEMA = {
 	id: "peerbit-file-share-benchmark",
-	version: 9,
+	version: 10,
 } as const;
 const RUN_NONCE = process.env.PW_BENCHMARK_RUN_NONCE;
 const parseJsonEnvironment = (name: string) => {
@@ -75,10 +78,13 @@ if (!Number.isSafeInteger(TARGET_SEEDERS) || TARGET_SEEDERS < 0) {
 		`Invalid PW_TARGET_SEEDERS='${process.env.PW_TARGET_SEEDERS}'`,
 	);
 }
+if (POST_TRANSFER_SOAK_MS !== 0) {
+	throw new Error("Seeder benchmarks require PW_POST_TRANSFER_SOAK_MS=0");
+}
 if (
 	(INVOCATION.schema as Record<string, unknown> | undefined)?.id !==
 		"peerbit-file-share-benchmark-invocation" ||
-	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 4
+	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 5
 ) {
 	throw new Error("Unsupported PW_BENCHMARK_INVOCATION schema");
 }
@@ -87,6 +93,7 @@ const expectedInvocationValues: Record<string, unknown> = {
 	mode: MODE,
 	networkMode: NETWORK_MODE,
 	readyTimeoutMs: READY_TIMEOUT_MS,
+	postTransferSoakMs: POST_TRANSFER_SOAK_MS,
 	sampleMs: SAMPLE_MS,
 	sampleCount: SAMPLE_COUNT,
 	targetSeeders: TARGET_SEEDERS,
@@ -249,11 +256,10 @@ const getBodyText = async (page: Page) =>
 
 const withDeadline = async <T>(
 	promise: Promise<T>,
-	deadlineAt: number,
+	timeoutMs: number,
 	label: string,
 ): Promise<T> => {
-	const remainingMs = deadlineAt - Date.now();
-	if (remainingMs <= 0) {
+	if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
 		throw new Error(`${label} exceeded the seeder convergence deadline`);
 	}
 	let timeout: ReturnType<typeof setTimeout> | undefined;
@@ -266,7 +272,7 @@ const withDeadline = async <T>(
 						reject(
 							new Error(`${label} exceeded the seeder convergence deadline`),
 						),
-					remainingMs,
+					timeoutMs,
 				);
 			}),
 		]);
@@ -361,6 +367,10 @@ test.describe("generated seeder probe", () => {
 			startedAt: number,
 			deadlineAt: number,
 		) => {
+			const remainingMs = deadlineAt - Date.now();
+			if (!Number.isSafeInteger(remainingMs) || remainingMs <= 0) {
+				throw new Error(`${label} began after the seeder convergence deadline`);
+			}
 			const [
 				writerSeeders,
 				readerSeeders,
@@ -377,7 +387,7 @@ test.describe("generated seeder probe", () => {
 					getBodyText(writer),
 					getBodyText(reader),
 				]),
-				deadlineAt,
+				remainingMs,
 				label,
 			);
 			const capturedAt = Date.now();

--- a/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
+++ b/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
@@ -4,7 +4,13 @@ import { randomUUID } from "node:crypto";
 import { mkdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { startBootstrapPeer } from "./bootstrapPeer";
-import { startDownloadMemoryTelemetry } from "./generated.download-memory-telemetry.mjs";
+import {
+	DOWNLOAD_MEMORY_LIVE_SAMPLE_COVERAGE_DEFINITION,
+	DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS,
+	DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
+	assertDownloadMemoryLiveSampleCoverage,
+	startDownloadMemoryTelemetry,
+} from "./generated.download-memory-telemetry.mjs";
 import { sha256AndCrc32OpfsSavedViaPicker } from "./generated.opfs-readback.mjs";
 import { withDeadline } from "./generated.promise-deadline.mjs";
 import {
@@ -52,6 +58,9 @@ const PUBSUB_PROTOCOL = "/peerbit/topic-control-plane/2.0.0";
 const POST_UPLOAD_MONITOR_MS = Number(
 	process.env.PW_POST_UPLOAD_MONITOR_MS || "5000",
 );
+const POST_TRANSFER_SOAK_MS = Number(
+	process.env.PW_POST_TRANSFER_SOAK_MS ?? "60000",
+);
 const UPLOAD_TIMEOUT_MS = Number(process.env.PW_UPLOAD_TIMEOUT_MS || "600000");
 const DOWNLOAD_TIMEOUT_MS = Number(
 	process.env.PW_DOWNLOAD_TIMEOUT_MS ||
@@ -62,6 +71,11 @@ const READY_TIMEOUT_MS = Number(process.env.PW_READY_TIMEOUT_MS);
 const POST_MONITOR_SCHEDULING_TOLERANCE_MS = Math.max(250, POLL_MS + 250);
 const POST_MONITOR_SCHEDULING_TOLERANCE_DEFINITION =
 	"max(250ms, pollMs + 250ms) for the final poll and event-loop scheduling";
+const POST_TRANSFER_SOAK_SCHEDULING_TOLERANCE_MS = Math.max(250, POLL_MS + 250);
+const POST_TRANSFER_SOAK_SCHEDULING_TOLERANCE_DEFINITION =
+	"max(250ms, pollMs + 250ms) for the requested post-transfer timer and event-loop scheduling";
+const RESOURCE_SNAPSHOT_TIMEOUT_MS = 15_000;
+const PAGE_SHUTDOWN_TIMEOUT_MS = 30_000;
 const TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS = Math.max(
 	5_000,
 	POLL_MS + 1_000,
@@ -88,6 +102,7 @@ const TEST_OUTER_TIMEOUT_MS = Math.max(
 		DOWNLOAD_TIMEOUT_MS +
 		LOCALITY_CONTROL_OUTER_TIMEOUT_BUDGET_MS +
 		POST_UPLOAD_MONITOR_MS +
+		POST_TRANSFER_SOAK_MS +
 		5 * 60 * 1000,
 );
 const TIME_TO_WRITER_READY_DEFINITION =
@@ -125,7 +140,7 @@ const FIXTURE_SEED =
 	process.env.PW_FIXTURE_SEED || "peerbit-file-share-benchmark-v1";
 const RESULT_SCHEMA = {
 	id: "peerbit-file-share-benchmark",
-	version: 9,
+	version: 10,
 } as const;
 const SEEDER_DROP_POLICY = {
 	id: "peerbit-file-share-seeder-drop-policy",
@@ -231,6 +246,17 @@ if (
 		`Invalid PW_READY_TIMEOUT_MS='${process.env.PW_READY_TIMEOUT_MS}'`,
 	);
 }
+if (!Number.isSafeInteger(POST_TRANSFER_SOAK_MS) || POST_TRANSFER_SOAK_MS < 0) {
+	throw new Error(
+		`Invalid PW_POST_TRANSFER_SOAK_MS='${process.env.PW_POST_TRANSFER_SOAK_MS}'`,
+	);
+}
+if (
+	!Number.isSafeInteger(TEST_OUTER_TIMEOUT_MS) ||
+	TEST_OUTER_TIMEOUT_MS <= 0
+) {
+	throw new Error("Benchmark lifecycle timeout exceeds the safe integer range");
+}
 if (process.env.PW_BENCH !== "1") {
 	throw new Error("Upload benchmark must run against the production preview");
 }
@@ -257,6 +283,7 @@ const expectedInvocationValues: Record<string, unknown> = {
 	uploadTimeoutMs: UPLOAD_TIMEOUT_MS,
 	downloadTimeoutMs: DOWNLOAD_TIMEOUT_MS,
 	postUploadMonitorMs: POST_UPLOAD_MONITOR_MS,
+	postTransferSoakMs: POST_TRANSFER_SOAK_MS,
 	pollMs: POLL_MS,
 	minReadySeeders: MIN_READY_SEEDERS,
 	readyTimeoutMs: READY_TIMEOUT_MS,
@@ -275,7 +302,7 @@ const expectedInvocationValues: Record<string, unknown> = {
 if (
 	(INVOCATION.schema as Record<string, unknown> | undefined)?.id !==
 		"peerbit-file-share-benchmark-invocation" ||
-	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 4
+	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 5
 ) {
 	throw new Error("Unsupported PW_BENCHMARK_INVOCATION schema");
 }
@@ -717,7 +744,9 @@ const requireMonotonicTransportCounterDelta = (
 	const beforeKeys = before.counters.map(({ key }) => key);
 	const afterKeys = after.counters.map(({ key }) => key);
 	if (JSON.stringify(beforeKeys) !== JSON.stringify(afterKeys)) {
-		throw new Error(`${label} pubsub counter key set changed during timed read`);
+		throw new Error(
+			`${label} pubsub counter key set changed during timed read`,
+		);
 	}
 	for (const [index, afterCounter] of after.counters.entries()) {
 		if (afterCounter.bytes < before.counters[index].bytes) {
@@ -769,10 +798,7 @@ const collectStableCounterpartTransportTopology = async ({
 	while (Date.now() <= deadlineAt) {
 		const remainingMs = Math.max(1, deadlineAt - Date.now());
 		const [writerTopology, readerTopology] = await withDeadline(
-			Promise.all([
-				getTopologySnapshot(writer),
-				getTopologySnapshot(reader),
-			]),
+			Promise.all([getTopologySnapshot(writer), getTopologySnapshot(reader)]),
 			remainingMs,
 			`${phase} transport topology capture exceeded its bounded deadline`,
 		);
@@ -798,31 +824,23 @@ const collectStableCounterpartTransportTopology = async ({
 				`${phase} topology capture does not preserve the controlled peer identities and window`,
 			);
 		}
-		const writerSummary = summarizeCounterpartPubsubTransport(
-			writerTopology,
-			{
-				direction: "outbound",
-				expectedPeerHash: expectedReaderPeerHash,
-				expectedRemotePeerId: expectedReaderPeerId,
-				label: `${phase} writer topology`,
-			},
-		);
-		const readerSummary = summarizeCounterpartPubsubTransport(
-			readerTopology,
-			{
-				direction: "inbound",
-				expectedPeerHash: expectedWriterPeerHash,
-				expectedRemotePeerId: expectedWriterPeerId,
-				label: `${phase} reader topology`,
-			},
-		);
+		const writerSummary = summarizeCounterpartPubsubTransport(writerTopology, {
+			direction: "outbound",
+			expectedPeerHash: expectedReaderPeerHash,
+			expectedRemotePeerId: expectedReaderPeerId,
+			label: `${phase} writer topology`,
+		});
+		const readerSummary = summarizeCounterpartPubsubTransport(readerTopology, {
+			direction: "inbound",
+			expectedPeerHash: expectedWriterPeerHash,
+			expectedRemotePeerId: expectedWriterPeerId,
+			label: `${phase} reader topology`,
+		});
 		lastSummaries = { writer: writerSummary, reader: readerSummary };
 		if (previous) {
 			for (const side of ["writer", "reader"] as const) {
 				const previousKeys = previous[side].counters.map(({ key }) => key);
-				const currentKeys = lastSummaries[side].counters.map(
-					({ key }) => key,
-				);
+				const currentKeys = lastSummaries[side].counters.map(({ key }) => key);
 				if (JSON.stringify(previousKeys) === JSON.stringify(currentKeys)) {
 					for (const [index, current] of lastSummaries[
 						side
@@ -842,11 +860,11 @@ const collectStableCounterpartTransportTopology = async ({
 		);
 		const signature =
 			counterpartByteSkew <= TRANSPORT_COUNTER_MAX_COUNTERPART_BYTE_SKEW
-			? JSON.stringify({
-					writer: writerSummary,
-					reader: readerSummary,
-				})
-			: null;
+				? JSON.stringify({
+						writer: writerSummary,
+						reader: readerSummary,
+					})
+				: null;
 		if (signature !== null && signature === stableSignature) {
 			stableCount += 1;
 		} else {
@@ -951,6 +969,403 @@ const getDiagnostics = async (page: Page) => {
 	} catch {
 		return null;
 	}
+};
+
+type BenchmarkPageRole = "writer" | "reader";
+
+const EAGER_MONOTONIC_COUNTERS = [
+	"evictions",
+	"expirations",
+	"admitted",
+	"hits",
+	"rejectedCid",
+	"rejectedCodec",
+	"rejectedSize",
+	"rejectedPending",
+	"rejectedIntegrity",
+	"rejectedLifecycle",
+] as const;
+const EAGER_TELEMETRY_KEYS = [
+	"entries",
+	"bytes",
+	"peakEntries",
+	"peakBytes",
+	"evictions",
+	"expirations",
+	"pendingEntries",
+	"pendingBytes",
+	"peakPendingEntries",
+	"peakPendingBytes",
+	"admitted",
+	"hits",
+	"rejectedCid",
+	"rejectedCodec",
+	"rejectedSize",
+	"rejectedPending",
+	"rejectedIntegrity",
+	"rejectedLifecycle",
+	"limits",
+] as const;
+const EAGER_LIMIT_KEYS = [
+	"maxEntries",
+	"maxBytes",
+	"maxBlockBytes",
+	"ttlMs",
+	"validationConcurrency",
+	"maxPendingBytes",
+	"maxPendingEntries",
+] as const;
+
+const hasExactRecordKeys = (value: unknown, expectedKeys: readonly string[]) =>
+	value != null &&
+	typeof value === "object" &&
+	!Array.isArray(value) &&
+	JSON.stringify(Object.keys(value).sort()) ===
+		JSON.stringify([...expectedKeys].sort());
+
+type BenchmarkPageResourceSnapshot = {
+	role: BenchmarkPageRole;
+	capturedAt: number;
+	storage: Record<string, unknown>;
+	runtime: Record<string, unknown>;
+};
+
+type BenchmarkResourceSnapshotSet = {
+	label: "beforeTimedRead" | "afterSink" | "beforeSoak" | "afterSoak";
+	startedAt: number;
+	finishedAt: number;
+	writer: BenchmarkPageResourceSnapshot;
+	reader: BenchmarkPageResourceSnapshot;
+};
+
+const capturePageResourceSnapshot = async (
+	page: Page,
+	role: BenchmarkPageRole,
+): Promise<BenchmarkPageResourceSnapshot> => {
+	const snapshot = await withDeadline(
+		page.evaluate(async () => {
+			const hooks = (window as any).__peerbitFileShareTestHooks;
+			if (typeof hooks?.getStorageSnapshot !== "function") {
+				throw new Error("Missing getStorageSnapshot benchmark hook");
+			}
+			if (typeof hooks?.getBenchmarkRuntimeSnapshot !== "function") {
+				throw new Error("Missing getBenchmarkRuntimeSnapshot benchmark hook");
+			}
+			const [storage, runtime] = await Promise.all([
+				hooks.getStorageSnapshot(),
+				hooks.getBenchmarkRuntimeSnapshot(),
+			]);
+			return { capturedAt: Date.now(), storage, runtime };
+		}),
+		RESOURCE_SNAPSHOT_TIMEOUT_MS,
+		`${role} resource snapshot exceeded ${RESOURCE_SNAPSHOT_TIMEOUT_MS}ms`,
+	);
+	if (
+		snapshot == null ||
+		typeof snapshot !== "object" ||
+		Array.isArray(snapshot) ||
+		!Number.isSafeInteger(snapshot.capturedAt) ||
+		snapshot.storage == null ||
+		typeof snapshot.storage !== "object" ||
+		Array.isArray(snapshot.storage) ||
+		snapshot.runtime == null ||
+		typeof snapshot.runtime !== "object" ||
+		Array.isArray(snapshot.runtime)
+	) {
+		throw new Error(`${role} resource snapshot is malformed`);
+	}
+	return { role, ...snapshot } as BenchmarkPageResourceSnapshot;
+};
+
+const captureResourceSnapshotSet = async (
+	writer: Page,
+	reader: Page,
+	label: BenchmarkResourceSnapshotSet["label"],
+): Promise<BenchmarkResourceSnapshotSet> => {
+	const startedAt = Date.now();
+	const [writerSnapshot, readerSnapshot] = await Promise.all([
+		capturePageResourceSnapshot(writer, "writer"),
+		capturePageResourceSnapshot(reader, "reader"),
+	]);
+	const finishedAt = Date.now();
+	for (const snapshot of [writerSnapshot, readerSnapshot]) {
+		if (snapshot.capturedAt < startedAt || snapshot.capturedAt > finishedAt) {
+			throw new Error(
+				`${snapshot.role} resource snapshot clock is inconsistent`,
+			);
+		}
+	}
+	return {
+		label,
+		startedAt,
+		finishedAt,
+		writer: writerSnapshot,
+		reader: readerSnapshot,
+	};
+};
+
+const requirePreTimedRuntimeEvidence = (
+	snapshot: BenchmarkResourceSnapshotSet,
+) => {
+	for (const role of ["writer", "reader"] as const) {
+		const runtime = snapshot[role].runtime as Record<string, any>;
+		const identity = runtime.identity;
+		const nativeGraph = runtime.nativeGraph;
+		const eagerBlocks = runtime.eagerBlocks;
+		const pubsub = runtime.pubsub;
+		const fanout = pubsub?.snapshot?.fanout;
+		if (
+			!hasExactRecordKeys(runtime, [
+				"capturedAt",
+				"programReady",
+				"identity",
+				"nativeGraph",
+				"eagerBlocks",
+				"pubsub",
+			]) ||
+			!Number.isSafeInteger(runtime.capturedAt) ||
+			runtime.capturedAt < snapshot.startedAt ||
+			runtime.capturedAt > snapshot[role].capturedAt ||
+			runtime.programReady !== true ||
+			!hasExactRecordKeys(identity, [
+				"programAddress",
+				"peerId",
+				"peerHash",
+				"sessionId",
+			]) ||
+			[
+				identity?.programAddress,
+				identity?.peerId,
+				identity?.peerHash,
+				identity?.sessionId,
+			].some((value) => typeof value !== "string" || value.length === 0) ||
+			!hasExactRecordKeys(nativeGraph, ["active", "useHeads"]) ||
+			typeof nativeGraph?.active !== "boolean" ||
+			typeof nativeGraph.useHeads !== "boolean" ||
+			(nativeGraph.active === false && nativeGraph.useHeads !== false) ||
+			!hasExactRecordKeys(eagerBlocks, [
+				"telemetryAvailable",
+				"enabled",
+				"telemetry",
+			]) ||
+			eagerBlocks.telemetryAvailable !== true ||
+			typeof eagerBlocks.enabled !== "boolean" ||
+			!hasExactRecordKeys(pubsub, [
+				"runtimeSnapshotAvailable",
+				"snapshot",
+				"error",
+			]) ||
+			pubsub?.runtimeSnapshotAvailable !== true ||
+			pubsub.error !== null ||
+			!hasExactRecordKeys(pubsub.snapshot, ["fanout"]) ||
+			!hasExactRecordKeys(fanout, ["root", "node"]) ||
+			!hasExactRecordKeys(fanout?.root, ["uploadLimitBps"]) ||
+			!hasExactRecordKeys(fanout?.node, ["uploadLimitBps"]) ||
+			!Number.isSafeInteger(fanout?.root?.uploadLimitBps) ||
+			fanout.root.uploadLimitBps <= 0 ||
+			!Number.isSafeInteger(fanout?.node?.uploadLimitBps) ||
+			fanout.node.uploadLimitBps <= 0
+		) {
+			throw new Error(
+				`${role} did not expose complete effective benchmark runtime evidence`,
+			);
+		}
+		if (eagerBlocks.enabled) {
+			const telemetry = eagerBlocks.telemetry;
+			const limits = telemetry?.limits;
+			if (
+				!hasExactRecordKeys(telemetry, EAGER_TELEMETRY_KEYS) ||
+				EAGER_TELEMETRY_KEYS.filter((key) => key !== "limits").some(
+					(key) => !Number.isSafeInteger(telemetry[key]) || telemetry[key] < 0,
+				) ||
+				!hasExactRecordKeys(limits, EAGER_LIMIT_KEYS) ||
+				EAGER_LIMIT_KEYS.some(
+					(key) => !Number.isSafeInteger(limits[key]) || limits[key] <= 0,
+				) ||
+				telemetry.entries > telemetry.peakEntries ||
+				telemetry.peakEntries > limits.maxEntries ||
+				telemetry.bytes > telemetry.peakBytes ||
+				telemetry.peakBytes > limits.maxBytes ||
+				telemetry.pendingEntries > telemetry.peakPendingEntries ||
+				telemetry.peakPendingEntries > limits.maxPendingEntries ||
+				telemetry.pendingBytes > telemetry.peakPendingBytes ||
+				telemetry.peakPendingBytes > limits.maxPendingBytes
+			) {
+				throw new Error(`${role} eager-cache runtime evidence is invalid`);
+			}
+		} else if (eagerBlocks.telemetry !== null) {
+			throw new Error(`${role} disabled eager-cache evidence is invalid`);
+		}
+	}
+	const writerIdentity = (snapshot.writer.runtime as Record<string, any>)
+		.identity;
+	const readerIdentity = (snapshot.reader.runtime as Record<string, any>)
+		.identity;
+	if (
+		writerIdentity.programAddress !== readerIdentity.programAddress ||
+		writerIdentity.peerId === readerIdentity.peerId ||
+		writerIdentity.peerHash === readerIdentity.peerHash ||
+		writerIdentity.sessionId === readerIdentity.sessionId
+	) {
+		throw new Error(
+			"Benchmark runtime evidence does not identify two distinct peers in one program",
+		);
+	}
+};
+
+const shutdownBenchmarkPage = async (page: Page, role: BenchmarkPageRole) => {
+	const startedAt = Date.now();
+	try {
+		const shutdownEvidence = await withDeadline(
+			page.evaluate(async () => {
+				const shutdown = (window as any).__peerbitFileShareTestHooks?.shutdown;
+				if (typeof shutdown !== "function") {
+					throw new Error("Missing shutdown benchmark hook");
+				}
+				return await shutdown();
+			}),
+			PAGE_SHUTDOWN_TIMEOUT_MS,
+			`${role} shutdown exceeded ${PAGE_SHUTDOWN_TIMEOUT_MS}ms`,
+		);
+		if (
+			!hasExactRecordKeys(shutdownEvidence, [
+				"programClosed",
+				"peerStopped",
+				"identity",
+			]) ||
+			shutdownEvidence.programClosed !== true ||
+			shutdownEvidence.peerStopped !== true ||
+			!hasExactRecordKeys(shutdownEvidence.identity, [
+				"programAddress",
+				"peerId",
+				"peerHash",
+				"sessionId",
+			]) ||
+			[
+				shutdownEvidence.identity?.programAddress,
+				shutdownEvidence.identity?.peerId,
+				shutdownEvidence.identity?.peerHash,
+				shutdownEvidence.identity?.sessionId,
+			].some((value) => typeof value !== "string" || value.length === 0)
+		) {
+			throw new Error(`${role} shutdown postconditions are malformed or false`);
+		}
+		const finishedAt = Date.now();
+		return {
+			role,
+			status: "fulfilled" as const,
+			startedAt,
+			finishedAt,
+			durationMs: finishedAt - startedAt,
+			programClosed: true,
+			peerStopped: true,
+			identity: shutdownEvidence.identity,
+			error: null,
+		};
+	} catch (error) {
+		const finishedAt = Date.now();
+		return {
+			role,
+			status: "rejected" as const,
+			startedAt,
+			finishedAt,
+			durationMs: finishedAt - startedAt,
+			programClosed: false,
+			peerStopped: false,
+			identity: null,
+			error: (error instanceof Error ? error.message : String(error)).slice(
+				0,
+				512,
+			),
+		};
+	}
+};
+
+const storageUsageDelta = (
+	before: BenchmarkPageResourceSnapshot,
+	after: BenchmarkPageResourceSnapshot,
+) => {
+	const beforeStorage = before.storage as Record<string, any>;
+	const afterStorage = after.storage as Record<string, any>;
+	const delta = (left: unknown, right: unknown) =>
+		typeof left === "number" &&
+		Number.isFinite(left) &&
+		typeof right === "number" &&
+		Number.isFinite(right)
+			? right - left
+			: null;
+	return {
+		role: before.role,
+		peerbitLogUsageDeltaBytes: delta(
+			beforeStorage.peerbitLog?.usageBytes,
+			afterStorage.peerbitLog?.usageBytes,
+		),
+		backingStorageUsageDeltaBytes: delta(
+			beforeStorage.backingStorage?.usageBytes,
+			afterStorage.backingStorage?.usageBytes,
+		),
+	};
+};
+
+const eagerTelemetryDelta = (
+	before: BenchmarkPageResourceSnapshot,
+	after: BenchmarkPageResourceSnapshot,
+) => {
+	const beforeTelemetry = (before.runtime as Record<string, any>).eagerBlocks
+		?.telemetry;
+	const afterTelemetry = (after.runtime as Record<string, any>).eagerBlocks
+		?.telemetry;
+	if (!beforeTelemetry || !afterTelemetry) {
+		return null;
+	}
+	return Object.fromEntries(
+		EAGER_MONOTONIC_COUNTERS.map((key) => [
+			key,
+			Number.isSafeInteger(beforeTelemetry[key]) &&
+			Number.isSafeInteger(afterTelemetry[key])
+				? afterTelemetry[key] - beforeTelemetry[key]
+				: null,
+		]),
+	);
+};
+
+const buildResourceEvidence = (snapshots: {
+	beforeTimedRead: BenchmarkResourceSnapshotSet;
+	afterSink: BenchmarkResourceSnapshotSet;
+	beforeSoak: BenchmarkResourceSnapshotSet;
+	afterSoak: BenchmarkResourceSnapshotSet;
+}) => {
+	const buildInterval = (
+		before: BenchmarkResourceSnapshotSet,
+		after: BenchmarkResourceSnapshotSet,
+	) => ({
+		from: before.label,
+		to: after.label,
+		writerStorage: storageUsageDelta(before.writer, after.writer),
+		readerStorage: storageUsageDelta(before.reader, after.reader),
+		writerEager: eagerTelemetryDelta(before.writer, after.writer),
+		readerEager: eagerTelemetryDelta(before.reader, after.reader),
+	});
+	return {
+		schemaVersion: 2,
+		storageDefinition:
+			"Peerbit logical usage and browser origin-wide navigator.storage estimates; deltas are later minus earlier",
+		eagerDefinition:
+			"deltas of monotonic eager-cache admission, hit, eviction, expiration, and rejection counters; null when eager telemetry is disabled or unavailable",
+		snapshots,
+		intervals: {
+			timedReadEnvelope: buildInterval(
+				snapshots.beforeTimedRead,
+				snapshots.afterSink,
+			),
+			postTransferWork: buildInterval(
+				snapshots.afterSink,
+				snapshots.beforeSoak,
+			),
+			soak: buildInterval(snapshots.beforeSoak, snapshots.afterSoak),
+			total: buildInterval(snapshots.beforeTimedRead, snapshots.afterSoak),
+		},
+	};
 };
 
 const probeVisibilityPath = async (page: Page) => {
@@ -1122,6 +1537,20 @@ test.describe("generated transfer-validity benchmark", () => {
 		let downloadStartedAt: number | undefined;
 		let downloadFinishedAt: number | undefined;
 		let downloadCompletionObservedAt: number | undefined;
+		let postTransferSoakStartedAt: number | undefined;
+		let postTransferSoakFinishedAt: number | undefined;
+		const resourceSnapshots: Partial<
+			Record<
+				BenchmarkResourceSnapshotSet["label"],
+				BenchmarkResourceSnapshotSet
+			>
+		> = {};
+		let resourceEvidence: ReturnType<typeof buildResourceEvidence> | null =
+			null;
+		let shutdownOutcomes: {
+			writer: Awaited<ReturnType<typeof shutdownBenchmarkPage>>;
+			reader: Awaited<ReturnType<typeof shutdownBenchmarkPage>>;
+		} | null = null;
 		let shareUrl: string | undefined;
 		let writerVisibilityProbe: Record<string, unknown> | null = null;
 		let readerVisibilityProbe: Record<string, unknown> | null = null;
@@ -1939,6 +2368,8 @@ test.describe("generated transfer-validity benchmark", () => {
 				writer,
 				downloadTimeoutMs: DOWNLOAD_TIMEOUT_MS,
 				schedulingToleranceMs: TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS,
+				postTransferSoakMs: POST_TRANSFER_SOAK_MS,
+				samplingWindowBudgetMs: TEST_OUTER_TIMEOUT_MS,
 			});
 			downloadMemoryTelemetry = downloadMemoryTelemetryController.snapshot();
 			const initialMemorySeries = [
@@ -1958,12 +2389,17 @@ test.describe("generated transfer-validity benchmark", () => {
 					"Download memory telemetry did not collect clean initial samples",
 				);
 			}
+			resourceSnapshots.beforeTimedRead = await captureResourceSnapshotSet(
+				writer,
+				reader,
+				"beforeTimedRead",
+			);
+			requirePreTimedRuntimeEvidence(resourceSnapshots.beforeTimedRead);
 			if (readerLocalityControl) {
 				stage = "stabilize-pre-timed-read-transport";
 				const identities = getControlledPeerIdentities();
 				const startedAt = Date.now();
-				const deadlineAt =
-					startedAt + TRANSPORT_COUNTER_STABILITY_TIMEOUT_MS;
+				const deadlineAt = startedAt + TRANSPORT_COUNTER_STABILITY_TIMEOUT_MS;
 				readerLocalityControl.preTimedReadTopologyStartedAt = startedAt;
 				readerLocalityControl.preTimedReadTopologyDeadlineAt = deadlineAt;
 				const finalObservation =
@@ -2026,8 +2462,6 @@ test.describe("generated transfer-validity benchmark", () => {
 			await downloadButton.click();
 			const download = await downloadCompletion;
 			downloadCompletionObservedAt = Date.now();
-			downloadMemoryTelemetry =
-				await downloadMemoryTelemetryController.stopSampling();
 			if (readerLocalityControl) {
 				stage = "stabilize-post-timed-read-transport";
 				const identities = getControlledPeerIdentities();
@@ -2059,12 +2493,12 @@ test.describe("generated transfer-validity benchmark", () => {
 					});
 				const finishedAt = Date.now();
 				const captureDelayMs = finishedAt - downloadCompletionObservedAt;
-				readerLocalityControl.postTimedReadTopologyCaptureDelayMs = captureDelayMs;
+				readerLocalityControl.postTimedReadTopologyCaptureDelayMs =
+					captureDelayMs;
 				if (
 					!Number.isSafeInteger(captureDelayMs) ||
 					captureDelayMs < 0 ||
-					captureDelayMs >
-						TRANSPORT_COUNTER_POST_READ_CAPTURE_MAX_DELAY_MS ||
+					captureDelayMs > TRANSPORT_COUNTER_POST_READ_CAPTURE_MAX_DELAY_MS ||
 					finishedAt > deadlineAt ||
 					finishedAt > latestAcceptedFinishedAt
 				) {
@@ -2133,25 +2567,11 @@ test.describe("generated transfer-validity benchmark", () => {
 				}
 				stage = "validate-download-completion";
 			}
-			const memorySeries = [
-				downloadMemoryTelemetry.readerJsHeap,
-				downloadMemoryTelemetry.writerJsHeap,
-				downloadMemoryTelemetry.hostRss,
-			];
-			if (
-				downloadMemoryTelemetry.complete !== true ||
-				downloadMemoryTelemetry.finishedAt == null ||
-				memorySeries.some(
-					(series) =>
-						series.sampleCount < 2 ||
-						series.samplingErrors.length > 0 ||
-						series.samplingErrorOverflowCount !== 0,
-				)
-			) {
-				throw new Error(
-					"Download memory telemetry did not complete without sampling errors",
-				);
-			}
+			resourceSnapshots.afterSink = await captureResourceSnapshotSet(
+				writer,
+				reader,
+				"afterSink",
+			);
 			if (
 				!Number.isSafeInteger(download.sinkCompletedAt) ||
 				download.sinkCompletedAt < downloadClickStartedAt ||
@@ -2247,6 +2667,7 @@ test.describe("generated transfer-validity benchmark", () => {
 			const summarizedReadTransfer = summarizeReadTransferDiagnostics(
 				rawReadDiagnostics,
 				expectedSizeBytes,
+				{ downloadSink: DOWNLOAD_SINK },
 			);
 			const {
 				streamReadExclusiveMs: sinkAwaitSubtractedDiagnosticMs,
@@ -2396,29 +2817,6 @@ test.describe("generated transfer-validity benchmark", () => {
 				);
 			}
 			integrityVerifiedAt = Date.now();
-			// Sampling is finalized at sink completion above, but CDP cleanup is
-			// deliberately deferred until the transfer and its SHA-256/CRC-32
-			// evidence are complete. A slow Performance.disable/detach must not
-			// erase an otherwise valid transfer result.
-			downloadMemoryTelemetry =
-				await downloadMemoryTelemetryController.cleanup();
-			const finalizedMemorySeries = [
-				downloadMemoryTelemetry.readerJsHeap,
-				downloadMemoryTelemetry.writerJsHeap,
-				downloadMemoryTelemetry.hostRss,
-			];
-			if (
-				downloadMemoryTelemetry.cleanupComplete !== true ||
-				finalizedMemorySeries.some(
-					(series) =>
-						series.samplingErrors.length > 0 ||
-						series.samplingErrorOverflowCount !== 0,
-				)
-			) {
-				throw new Error(
-					"Download memory telemetry cleanup reported a non-timeout failure",
-				);
-			}
 			if (readerLocalityControl) {
 				stage = "verify-terminal-reader-topology";
 				readerLocalityControl.integrityVerifiedAt = integrityVerifiedAt;
@@ -2446,8 +2844,7 @@ test.describe("generated transfer-validity benchmark", () => {
 					terminalTopologyFinishedAt;
 				readerLocalityControl.terminalTopologyObservations =
 					terminalTopologyObservations;
-				readerLocalityControl.terminalTopologyRole =
-					READER_TERMINAL_TOPOLOGY;
+				readerLocalityControl.terminalTopologyRole = READER_TERMINAL_TOPOLOGY;
 				readerLocalityControl.terminalTopologyExpectationSatisfied = true;
 				readerLocalityControl.status = "complete";
 				logStage("reader-terminal-topology-stable", {
@@ -2456,6 +2853,113 @@ test.describe("generated transfer-validity benchmark", () => {
 						readerLocalityControl.terminalTopologyExpectationSatisfied,
 				});
 			}
+			resourceSnapshots.beforeSoak = await captureResourceSnapshotSet(
+				writer,
+				reader,
+				"beforeSoak",
+			);
+			stage = "post-transfer-soak";
+			postTransferSoakStartedAt = Date.now();
+			logStage(stage, { postTransferSoakMs: POST_TRANSFER_SOAK_MS });
+			if (POST_TRANSFER_SOAK_MS > 0) {
+				await new Promise<void>((resolve) =>
+					setTimeout(resolve, POST_TRANSFER_SOAK_MS),
+				);
+			}
+			postTransferSoakFinishedAt = Date.now();
+			const actualPostTransferSoakMs =
+				postTransferSoakFinishedAt - postTransferSoakStartedAt;
+			if (
+				actualPostTransferSoakMs < POST_TRANSFER_SOAK_MS ||
+				actualPostTransferSoakMs >
+					POST_TRANSFER_SOAK_MS + POST_TRANSFER_SOAK_SCHEDULING_TOLERANCE_MS
+			) {
+				throw new Error(
+					"Post-transfer soak duration is outside its requested scheduling bound",
+				);
+			}
+			downloadMemoryTelemetry =
+				await downloadMemoryTelemetryController.sampleNow();
+			const liveCheckpointSeries = [
+				downloadMemoryTelemetry.readerJsHeap,
+				downloadMemoryTelemetry.writerJsHeap,
+				downloadMemoryTelemetry.hostRss,
+			];
+			if (
+				downloadMemoryTelemetry.downloadTimeoutMs !== DOWNLOAD_TIMEOUT_MS ||
+				downloadMemoryTelemetry.schedulingToleranceMs !==
+					TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS ||
+				downloadMemoryTelemetry.operationTimeoutMs !==
+					DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS ||
+				downloadMemoryTelemetry.postTransferSoakMs !== POST_TRANSFER_SOAK_MS ||
+				downloadMemoryTelemetry.samplingWindowBudgetMs !==
+					TEST_OUTER_TIMEOUT_MS ||
+				downloadMemoryTelemetry.liveSampleMaxGapMs !==
+					DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS +
+						DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS +
+						TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS ||
+				downloadMemoryTelemetry.liveSampleCoverageDefinition !==
+					DOWNLOAD_MEMORY_LIVE_SAMPLE_COVERAGE_DEFINITION ||
+				downloadMemoryTelemetry.endpointSampleAllowance !== 3 ||
+				downloadMemoryTelemetry.manualCheckpointComplete !== true ||
+				downloadMemoryTelemetry.samplingCapacitySufficient !== true ||
+				downloadMemoryTelemetry.capacityExhaustedBeforeTerminal !== false ||
+				liveCheckpointSeries.some(
+					(series) =>
+						series.manualSampleCount !== 1 ||
+						!Number.isSafeInteger(series.lastManualSampleAt) ||
+						series.lastManualSampleAt < postTransferSoakFinishedAt ||
+						series.lastManualSampleAt - postTransferSoakFinishedAt >
+							DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS +
+								TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS ||
+						series.samples.at(-1)?.sampleKind !== "manual",
+				)
+			) {
+				throw new Error(
+					"Download memory telemetry did not capture a live bounded after-soak checkpoint",
+				);
+			}
+			if (downloadStartedAt == null || downloadFinishedAt == null) {
+				throw new Error("Download memory phase boundaries are unavailable");
+			}
+			for (const [seriesName, series] of [
+				["readerJsHeap", downloadMemoryTelemetry.readerJsHeap],
+				["writerJsHeap", downloadMemoryTelemetry.writerJsHeap],
+				["hostRss", downloadMemoryTelemetry.hostRss],
+			] as const) {
+				for (const [phase, phaseStartedAt, phaseFinishedAt] of [
+					["transfer", downloadStartedAt, downloadFinishedAt],
+					["soak", postTransferSoakStartedAt, postTransferSoakFinishedAt],
+				] as const) {
+					assertDownloadMemoryLiveSampleCoverage({
+						samples: series.samples,
+						phaseStartedAt,
+						phaseFinishedAt,
+						maxGapMs: downloadMemoryTelemetry.liveSampleMaxGapMs,
+						label: `${seriesName}.${phase}`,
+					});
+				}
+			}
+			resourceSnapshots.afterSoak = await captureResourceSnapshotSet(
+				writer,
+				reader,
+				"afterSoak",
+			);
+			if (
+				!resourceSnapshots.beforeTimedRead ||
+				!resourceSnapshots.afterSink ||
+				!resourceSnapshots.beforeSoak ||
+				!resourceSnapshots.afterSoak
+			) {
+				throw new Error("Benchmark resource snapshot sequence is incomplete");
+			}
+			resourceEvidence = buildResourceEvidence({
+				beforeTimedRead: resourceSnapshots.beforeTimedRead,
+				afterSink: resourceSnapshots.afterSink,
+				beforeSoak: resourceSnapshots.beforeSoak,
+				afterSoak: resourceSnapshots.afterSoak,
+			});
+
 			const terminalSeederSnapshot = await snapshot(
 				SEEDER_DROP_POLICY.terminalSnapshotLabel,
 			);
@@ -2468,6 +2972,116 @@ test.describe("generated transfer-validity benchmark", () => {
 			if (errors.length > 0) {
 				throw new Error(
 					`Observed transfer/delivery errors: ${JSON.stringify(errors)}`,
+				);
+			}
+
+			const [writerDiagnostics, finalReaderDiagnostics] = await Promise.all([
+				getDiagnostics(writer),
+				getDiagnostics(reader),
+			]);
+			if (
+				readerLocalityControl &&
+				(!writerDiagnostics || !finalReaderDiagnostics)
+			) {
+				throw new Error(
+					"Controlled-locality benchmark is missing final peer diagnostics",
+				);
+			}
+			if (errors.length > 0) {
+				throw new Error(
+					`Observed transfer/delivery errors while collecting diagnostics: ${JSON.stringify(errors)}`,
+				);
+			}
+
+			stage = "shutdown";
+			const [writerShutdown, readerShutdown] = await Promise.all([
+				shutdownBenchmarkPage(writer, "writer"),
+				shutdownBenchmarkPage(reader, "reader"),
+			]);
+			shutdownOutcomes = {
+				writer: writerShutdown,
+				reader: readerShutdown,
+			};
+			const shutdownIdentityMatchesSnapshots = (
+				role: BenchmarkPageRole,
+				shutdown: typeof writerShutdown,
+			) => {
+				if (shutdown.status !== "fulfilled") {
+					return false;
+				}
+				return [
+					resourceSnapshots.beforeTimedRead,
+					resourceSnapshots.afterSink,
+					resourceSnapshots.beforeSoak,
+					resourceSnapshots.afterSoak,
+				].every((snapshotSet) => {
+					const identity = (snapshotSet?.[role].runtime as Record<string, any>)
+						?.identity;
+					return ["programAddress", "peerId", "peerHash", "sessionId"].every(
+						(key) => identity?.[key] === shutdown.identity[key],
+					);
+				});
+			};
+			if (
+				writerShutdown.status !== "fulfilled" ||
+				readerShutdown.status !== "fulfilled" ||
+				writerShutdown.programClosed !== true ||
+				writerShutdown.peerStopped !== true ||
+				readerShutdown.programClosed !== true ||
+				readerShutdown.peerStopped !== true ||
+				!shutdownIdentityMatchesSnapshots("writer", writerShutdown) ||
+				!shutdownIdentityMatchesSnapshots("reader", readerShutdown)
+			) {
+				throw new Error(
+					`Benchmark peer shutdown failed: ${JSON.stringify(shutdownOutcomes)}`,
+				);
+			}
+			downloadMemoryTelemetry =
+				await downloadMemoryTelemetryController.cleanup();
+			const finalizedMemorySeries = [
+				downloadMemoryTelemetry.readerJsHeap,
+				downloadMemoryTelemetry.writerJsHeap,
+				downloadMemoryTelemetry.hostRss,
+			];
+			if (
+				downloadMemoryTelemetry.complete !== true ||
+				downloadMemoryTelemetry.cleanupComplete !== true ||
+				downloadMemoryTelemetry.manualCheckpointComplete !== true ||
+				downloadMemoryTelemetry.terminalCheckpointComplete !== true ||
+				downloadMemoryTelemetry.samplingCapacitySufficient !== true ||
+				downloadMemoryTelemetry.capacityExhaustedBeforeTerminal !== false ||
+				downloadMemoryTelemetry.finishedAt == null ||
+				downloadMemoryTelemetry.finishedAt <
+					Math.max(writerShutdown.finishedAt, readerShutdown.finishedAt) ||
+				finalizedMemorySeries.some(
+					(series) =>
+						series.sampleCount < 3 ||
+						series.manualSampleCount !== 1 ||
+						!Number.isSafeInteger(series.lastManualSampleAt) ||
+						series.lastManualSampleAt < postTransferSoakFinishedAt! ||
+						series.lastManualSampleAt >
+							resourceSnapshots.afterSoak!.startedAt ||
+						series.lastManualSampleAt >
+							Math.min(writerShutdown.startedAt, readerShutdown.startedAt) ||
+						series.terminalSampleAttempted !== true ||
+						series.terminalSampleCaptured !== true ||
+						!Number.isSafeInteger(series.terminalSampleAt) ||
+						series.terminalSampleAt <
+							Math.max(writerShutdown.finishedAt, readerShutdown.finishedAt) ||
+						series.samples.at(-1)?.sampleKind !== "terminal" ||
+						series.samplingCapacitySufficient !== true ||
+						series.capacityExhaustedBeforeTerminal !== false ||
+						series.samplingErrors.length > 0 ||
+						series.samplingErrorOverflowCount !== 0,
+				)
+			) {
+				throw new Error(
+					"Download memory telemetry did not finalize cleanly after peer shutdown",
+				);
+			}
+			if (errors.length > 0) {
+				throw new Error(
+					`Observed transfer/delivery errors through peer shutdown: ${JSON.stringify(errors)}`,
 				);
 			}
 
@@ -2499,23 +3113,6 @@ test.describe("generated transfer-validity benchmark", () => {
 			) {
 				throw new Error(
 					"Measured transfer duration exceeded its requested timeout and scheduling tolerance",
-				);
-			}
-			const [writerDiagnostics, finalReaderDiagnostics] = await Promise.all([
-				getDiagnostics(writer),
-				getDiagnostics(reader),
-			]);
-			if (
-				readerLocalityControl &&
-				(!writerDiagnostics || !finalReaderDiagnostics)
-			) {
-				throw new Error(
-					"Controlled-locality benchmark is missing final peer diagnostics",
-				);
-			}
-			if (errors.length > 0) {
-				throw new Error(
-					`Observed transfer/delivery errors while collecting diagnostics: ${JSON.stringify(errors)}`,
 				);
 			}
 			const collectedErrors = [...errors];
@@ -2562,6 +3159,15 @@ test.describe("generated transfer-validity benchmark", () => {
 					POST_MONITOR_SCHEDULING_TOLERANCE_MS,
 				postUploadMonitorSchedulingToleranceDefinition:
 					POST_MONITOR_SCHEDULING_TOLERANCE_DEFINITION,
+				postTransferSoakMs: POST_TRANSFER_SOAK_MS,
+				postTransferSoakActualMs:
+					postTransferSoakFinishedAt! - postTransferSoakStartedAt!,
+				postTransferSoakDefinition:
+					"idle observation window beginning after transfer integrity and any requested terminal-topology validation, ending before terminal resource capture and peer shutdown",
+				postTransferSoakSchedulingToleranceMs:
+					POST_TRANSFER_SOAK_SCHEDULING_TOLERANCE_MS,
+				postTransferSoakSchedulingToleranceDefinition:
+					POST_TRANSFER_SOAK_SCHEDULING_TOLERANCE_DEFINITION,
 				downloadDurationMs: downloadFinishedAt - downloadStartedAt,
 				downloadDurationDefinition: DOWNLOAD_DURATION_DEFINITION,
 				transferTimeoutSchedulingToleranceMs:
@@ -2571,6 +3177,8 @@ test.describe("generated transfer-validity benchmark", () => {
 				downloadSink: download.sink,
 				requestedDownloadSink: DOWNLOAD_SINK,
 				downloadMemoryTelemetry,
+				resourceEvidence,
+				shutdownOutcomes,
 				sinkWriteCalls: download.sinkWriteCalls,
 				sinkWriteDurationMs: download.sinkWriteDurationMs,
 				sinkWriteDurationDefinition: SINK_WRITE_DURATION_DEFINITION,
@@ -2605,6 +3213,8 @@ test.describe("generated transfer-validity benchmark", () => {
 					downloadStartedAt,
 					downloadFinishedAt,
 					downloadCompletionObservedAt,
+					postTransferSoakStartedAt,
+					postTransferSoakFinishedAt,
 				},
 				writerManifestEvidence,
 				readerManifestEvidence,
@@ -2679,6 +3289,12 @@ test.describe("generated transfer-validity benchmark", () => {
 				stage,
 				requestedDownloadSink: DOWNLOAD_SINK,
 				downloadMemoryTelemetry,
+				resourceEvidence: resourceEvidence ?? {
+					schemaVersion: 2,
+					snapshots: resourceSnapshots,
+					intervals: null,
+				},
+				shutdownOutcomes,
 				integrity,
 				integrityVerified,
 				integrityVerifiedAt,
@@ -2692,6 +3308,16 @@ test.describe("generated transfer-validity benchmark", () => {
 				transferTimeoutSchedulingToleranceDefinition:
 					TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION,
 				postUploadMonitorMs: POST_UPLOAD_MONITOR_MS,
+				postTransferSoakMs: POST_TRANSFER_SOAK_MS,
+				postTransferSoakActualMs:
+					postTransferSoakStartedAt != null &&
+					postTransferSoakFinishedAt != null
+						? postTransferSoakFinishedAt - postTransferSoakStartedAt
+						: null,
+				postTransferSoakSchedulingToleranceMs:
+					POST_TRANSFER_SOAK_SCHEDULING_TOLERANCE_MS,
+				postTransferSoakSchedulingToleranceDefinition:
+					POST_TRANSFER_SOAK_SCHEDULING_TOLERANCE_DEFINITION,
 				pollMs: POLL_MS,
 				uploadTimeoutMs: UPLOAD_TIMEOUT_MS,
 				downloadTimeoutMs: DOWNLOAD_TIMEOUT_MS,


### PR DESCRIPTION
## Summary

- expose bounded, detached snapshots of effective pubsub fanout limits and shared-log native/eager-cache state
- strengthen file-share benchmark validity with stable runtime identities, resource intervals, exact shutdown proof, and bounded transfer/soak memory sampling
- preserve runtime and reader-locality cohorts in summaries and matrix comparisons so unlike runs cannot be combined
- validate causal per-chunk transfer ordering, deterministic integrity, live sample coverage, and error collection

## Validation

- 211/211 file-share harness tests passed
- focused pubsub, shared-log, and Peerbit client tests passed
- pnpm run build passed
- production-preview 64 MiB linked smoke passed with exact SHA-256, CRC-32, manifest, receiver persistence, memory, resource, and shutdown gates
- independent hostile/readiness reviews found no remaining issues

## Compatibility

This adds local diagnostic getters and benchmark result/schema evidence only. It does not change the Peerbit network or wire protocol.

Paired with the peerbit-examples perf/fileshare-runtime-evidence branch.