### PR TITLE
test(file-share): distinguish reader retention cohorts

### DIFF
--- a/scripts/file-share/README.md
+++ b/scripts/file-share/README.md
@@ -3,13 +3,15 @@
 Run a single checkout with `pnpm bench:file-share:local` or compare pinned
 Peerbit revisions with `pnpm bench:file-share:matrix`.
 
-Result schema v10, summary and matrix-summary schema v6, and invocation schema
-v5 bind each result to the exact effective benchmark inputs. Invocation v5 adds
-`postTransferSoakMs`; uploads default to 60,000 ms and preserve an explicit
+Result schema v11, summary and matrix-summary schema v7, and invocation schema
+v6 bind each result to the exact effective benchmark inputs. Invocation v6
+binds the reader chunk-persistence policy and the actual browser-storage cohort
+in addition to the v5 `postTransferSoakMs` input. Uploads default to 60,000 ms
+and preserve an explicit
 `--post-transfer-soak-ms 0` for
 fast smoke runs, while seeder probes resolve zero and reject a nonzero soak
 because they have no transfer. The value is exported as
-`PW_POST_TRANSFER_SOAK_MS`. Result schema v10 defines
+`PW_POST_TRANSFER_SOAK_MS`. Result schema v11 defines
 `errorCount` as every uncaught browser `pageerror`,
 every browser `console.error`, every console message at any level that contains
 a declared Peerbit failure signature, and scenario-recorded operation failures.
@@ -18,7 +20,7 @@ Playwright `requestfailed` events are retained separately under
 `requestFailures`; they are diagnostics and are not automatically fatal because
 peer-to-peer discovery can legitimately exercise failed network candidates.
 
-Passed schema v10 upload results require `writerDiagnostics.lastUploadDiagnostics`
+Passed schema v11 upload results require `writerDiagnostics.lastUploadDiagnostics`
 to contain exactly 21 bounded progress milestones from 0% through 100% in 5%
 increments. Each point records the aggregate bytes whose application-level
 chunk puts completed, using the library upload clock and exact ceil-rounded byte
@@ -54,6 +56,19 @@ sinks only in separate benchmark sessions; aggregate comparison objects fail
 closed on mixed sinks, and every passed result and aggregate labels
 non-hash-only cohorts non-authoritative.
 
+`--browser-storage memory|opfs` selects Peerbit's own writer and reader backing
+stores and defaults to `memory`. This is independent of `--download-sink`: the
+former controls where Peerbit stores blocks and indexes, while the latter
+controls what consumes the completed downloaded byte stream. Every upload cell
+uses two separate persistent Chromium processes and fresh profile directories,
+including memory cells, so context topology is held constant. The page-init
+hook configures `PeerProvider` before it starts. Four resource checkpoints must
+then prove the requested mode, whether a Peerbit directory was configured, and
+the measured `persisted()` state of Peerbit storage, block storage, and indexer.
+An OPFS label is rejected unless all three Peerbit components report persistent;
+`navigator.storage.persisted()` is recorded separately because eviction
+protection can be false even when OPFS is available and in use.
+
 `readTransfer.receiverProgress` keeps three receiver boundaries separate over
 the exact 0%, 5%, …, 100% milestone set.
 `available` means a contiguous file prefix was materialized and available to
@@ -74,7 +89,7 @@ but the `sinkAccepted` milestones themselves are neither Peerbit nor filesystem
 durability evidence. None of these three series is a wire acknowledgement or
 proof that another peer retained the bytes.
 
-Schema v10 upload results record the `download-memory-v3` bounded telemetry
+Schema v11 upload results record the `download-memory-v3` bounded telemetry
 contract. After any controlled-locality prefix stabilization, the harness arms
 serial samplers before the bounded pre-read transport-counter gate and timed
 click. Sampling remains armed through sink completion, integrity and terminal
@@ -84,7 +99,7 @@ before detaching the CDP sessions. The default soak is 60 seconds, so retained
 memory and storage that keep growing or fail to settle are visible separately
 from transfer-time peaks.
 
-Result v10 records bounded `shutdownOutcomes` for writer and reader separately;
+Result v11 records bounded `shutdownOutcomes` for writer and reader separately;
 a passed upload requires both shutdown hooks to prove that the program closed
 and the Peerbit/libp2p peer stopped. Each shutdown outcome repeats the exact
 program, peer, and per-page session identity captured by that role's four
@@ -95,12 +110,16 @@ be distinguished.
 
 Reader and writer renderers use CDP `Runtime.getHeapUsage`. Every sample records
 V8 used and total bytes, embedder heap used bytes, and backing-storage bytes.
-Host RSS combines all Chromium processes, grouped by Chromium process role,
+Host RSS combines the deduplicated processes from both Chromium instances,
+grouped by Chromium process role,
 with the Playwright worker Node process; for local runs that Node value also
 includes the in-process bootstrap peer. Chromium RSS cannot be assigned
 reliably to one page and RSS is not PSS or USS, so page-level comparisons should
 use the renderer series. Node `external` and `arrayBuffers` are recorded as
 overlapping allocation diagnostics; neither is added to Node or combined RSS.
+Every accepted upload result must prove that exactly two unique browser CDP
+sessions exposed two distinct Chromium root PIDs and that both root processes
+were present in every host-RSS sample.
 Samples run serially, scheduling the next periodic read five seconds after the
 previous read completes, and reserve three endpoints: the initial sample, one
 live manual checkpoint immediately after the exact requested soak timer and
@@ -175,13 +194,15 @@ checkpoint after soak supplies the soak endpoint without folding teardown into
 the phase.
 `resourceStorageDeltas`, `effectiveRuntimeConfiguration`, and `eagerCache`
 retain the corresponding storage, effective-policy, and eager-cache summaries.
-Older result objects that do not carry v10/v3 resource evidence retain the
+Older result objects that do not carry v11/v3 resource evidence retain the
 pre-existing aggregate output shape without empty placeholder fields.
 
 For a controlled reader-locality download cohort, run an upload with
 `--mode fixed1`, `--reader-local-chunk-target <N>`, and
 `--reader-local-chunk-max-overshoot <M>`, and
-`--reader-terminal-topology <observer|replicator>`. All three locality options
+`--reader-terminal-topology <observer|replicator>`. Add
+`--reader-persist-chunk-reads false` for the transient-read cohort; omitting it
+preserves the historical persistent-read behavior. The three locality options
 are required together, `M` is capped at eight chunks, and this profile uses a one-replicator
 readiness baseline. The writer is fixed at factor one and the reader is an
 observer before upload starts; topology evidence must show exactly one
@@ -189,16 +210,19 @@ replicator, with the writer in and reader out of that set, both before upload an
 again immediately before the timed read. Both peers must report the same exact
 singleton replicator identity, and that identity must be the writer.
 
-After the normal upload and post-upload monitor finish, the harness enables
-persistent reader chunk reads and imports exactly the first `N` entry blocks
+After the normal upload and post-upload monitor finish, the harness applies the
+requested reader chunk-persistence policy and imports exactly the first `N`
+entry blocks
 from the ready root manifest. This benchmark-only provisioning bypasses the
 product stream read-ahead path, uses bounded batches of eight raw block
 requests, retains every imported head under its exact `${file.id}:${index}`
 document identity so adaptive pruning cannot classify a current manifest entry
 as stale, and applies one aggregate download deadline. It asserts that the
 only local manifest-entry heads afterward are indices `0..N-1` and that no
-active transfer or queued download work remains. `N=0` is the cold
-observer-persistent cohort and imports no entry block. The harness then records
+active transfer or queued download work remains. `N=0` with persistence enabled
+is the cold observer-persistent cohort and imports no entry block. Transient
+reads require `N=0` and terminal `observer`; they must retain zero manifest-entry
+blocks and zero local chunk index rows after the timed read. The harness then records
 three identical exact locality samples, spaced by
 `min(--poll-ms, 100ms)`. Each sample includes both the manifest-entry blocks
 available in the local block store (`K`) and the local Documents index rows
@@ -209,8 +233,13 @@ unexpected locality change before the timed read. A cached entry block need not
 have a local index row yet.
 
 The measured cohort key is therefore
-`observer-persistent-prefix-b<K>-i<J>`, not merely the requested target. Timed
-read diagnostics must report those exact initial block and index-row counts.
+`observer-<persistent|transient>-<memory|opfs>-prefix-b<K>-i<J>`, not merely the
+requested target. Timed
+read diagnostics must report those exact initial block and index-row counts for
+persistent reads. The product intentionally skips those count queries for a
+transient read, so its timed-read diagnostic fields remain null while the
+independent pre-download and terminal observations must each prove exact zero
+blocks and index rows.
 After download-memory telemetry is armed, a bounded pre-read gate samples
 writer and reader topology in parallel every 100 ms for at most five seconds.
 It requires three consecutive samples in which the writer's outbound and the
@@ -248,8 +277,9 @@ post-read checkpoint also preserves the original two peer identities, retains
 the writer in the replication set, and contains either the writer
 singleton or the exact writer+reader pair.
 
-After integrity verification and an idle transfer scheduler, the harness
-requires every manifest-entry block to be local. The explicit
+After integrity verification and an idle transfer scheduler, a persistent-read
+cohort requires every manifest-entry block to be local; a transient-read cohort
+requires none to be local. The explicit
 terminal expectation keeps historical and fixed implementations in separate,
 fail-closed cohorts: `observer` requires zero local chunk index rows and the
 writer as the exact singleton replicator; `replicator` requires the complete
@@ -266,9 +296,10 @@ Repeated standalone and matrix results are grouped by the exact key, so timings
 from different read-ahead outcomes are never averaged together. Raw canonical
 per-chunk timings remain in each result and can be rebucketed into 5% progress
 windows without losing the underlying samples. Without the paired locality
-options, roles, persistence policy, and seeder-drop gates are unchanged.
+options, reader chunk persistence is not changed by this control and its
+locality evidence fields remain null.
 
-Schema v10 records the exact versioned `seederDropPolicy` and a final numeric
+Schema v11 records the exact versioned `seederDropPolicy` and a final numeric
 `terminal` seeder snapshot after download and integrity verification. Every
 upload cohort also records top-level `integrityVerifiedAt`: it remains `null`
 until the aggregate size, SHA-256, CRC-32, manifest, and persistence gates have

--- a/scripts/file-share/benchmark-invocation.mjs
+++ b/scripts/file-share/benchmark-invocation.mjs
@@ -3,7 +3,7 @@ import { isDeepStrictEqual } from "node:util";
 
 export const BENCHMARK_INVOCATION_SCHEMA = {
 	id: "peerbit-file-share-benchmark-invocation",
-	version: 5,
+	version: 6,
 };
 
 export const TINY_FILE_CUTOFF_BYTES = 5_000_000;
@@ -15,6 +15,11 @@ export const BENCHMARK_DOWNLOAD_SINKS = Object.freeze([
 	"node-file",
 ]);
 export const DEFAULT_BENCHMARK_DOWNLOAD_SINK = "hash-only";
+export const BENCHMARK_BROWSER_STORAGE_MODES = Object.freeze([
+	"memory",
+	"opfs",
+]);
+export const DEFAULT_BENCHMARK_BROWSER_STORAGE_MODE = "memory";
 export const MAX_READER_LOCAL_CHUNK_OVERSHOOT = 8;
 export const READER_TERMINAL_TOPOLOGIES = Object.freeze([
 	"observer",
@@ -54,6 +59,28 @@ export const resolveBenchmarkDownloadSink = (requestedSink, { scenario }) => {
 	if (!BENCHMARK_DOWNLOAD_SINKS.includes(resolved)) {
 		throw new Error(
 			`Unsupported benchmark download sink ${JSON.stringify(resolved)}; expected one of ${BENCHMARK_DOWNLOAD_SINKS.join(", ")}`,
+		);
+	}
+	return resolved;
+};
+
+export const resolveBenchmarkBrowserStorageMode = (
+	requestedMode,
+	{ scenario },
+) => {
+	const mode = asNullableString(requestedMode);
+	if (scenario !== "upload") {
+		if (mode !== null) {
+			throw new Error(
+				"--browser-storage is only supported by upload benchmarks",
+			);
+		}
+		return null;
+	}
+	const resolved = mode ?? DEFAULT_BENCHMARK_BROWSER_STORAGE_MODE;
+	if (!BENCHMARK_BROWSER_STORAGE_MODES.includes(resolved)) {
+		throw new Error(
+			`Unsupported benchmark browser storage ${JSON.stringify(resolved)}; expected one of ${BENCHMARK_BROWSER_STORAGE_MODES.join(", ")}`,
 		);
 	}
 	return resolved;
@@ -163,6 +190,7 @@ export const createBenchmarkInvocation = ({
 	fileMb,
 	fixtureSeed,
 	downloadSink,
+	browserStorageMode,
 	uploadTimeoutMs,
 	downloadTimeoutMs,
 	postTransferSoakMs,
@@ -176,6 +204,7 @@ export const createBenchmarkInvocation = ({
 	readerLocalChunkTarget,
 	readerLocalChunkMaxOvershoot,
 	readerTerminalTopology,
+	readerPersistChunkReads,
 	baseUrl,
 	protocol,
 	viteMode,
@@ -208,6 +237,10 @@ export const createBenchmarkInvocation = ({
 	const resolvedDownloadSink = resolveBenchmarkDownloadSink(downloadSink, {
 		scenario,
 	});
+	const resolvedBrowserStorageMode = resolveBenchmarkBrowserStorageMode(
+		browserStorageMode,
+		{ scenario },
+	);
 	if (typeof fixtureSeed !== "string" || fixtureSeed.length === 0) {
 		throw new Error("fixtureSeed must be a non-empty string");
 	}
@@ -256,6 +289,18 @@ export const createBenchmarkInvocation = ({
 		readerTerminalTopology == null || readerTerminalTopology === ""
 			? null
 			: String(readerTerminalTopology);
+	const resolvedReaderPersistChunkReads =
+		readerPersistChunkReads == null
+			? resolvedReaderLocalChunkTarget === null
+				? null
+				: true
+			: readerPersistChunkReads;
+	if (
+		resolvedReaderPersistChunkReads !== null &&
+		typeof resolvedReaderPersistChunkReads !== "boolean"
+	) {
+		throw new Error("readerPersistChunkReads must be a boolean when provided");
+	}
 	if (
 		resolvedReaderTerminalTopology !== null &&
 		!READER_TERMINAL_TOPOLOGIES.includes(resolvedReaderTerminalTopology)
@@ -278,6 +323,14 @@ export const createBenchmarkInvocation = ({
 	) {
 		throw new Error(
 			"readerTerminalTopology must be provided exactly when readerLocalChunkTarget is provided",
+		);
+	}
+	if (
+		(resolvedReaderLocalChunkTarget === null) !==
+		(resolvedReaderPersistChunkReads === null)
+	) {
+		throw new Error(
+			"readerPersistChunkReads must be provided exactly when readerLocalChunkTarget is provided",
 		);
 	}
 	if (
@@ -329,6 +382,22 @@ export const createBenchmarkInvocation = ({
 				"readerLocalChunkTarget requires minReadySeeders = 1 because the reader starts as an observer",
 			);
 		}
+		if (
+			resolvedReaderPersistChunkReads === false &&
+			resolvedReaderLocalChunkTarget !== 0
+		) {
+			throw new Error(
+				"Transient reader benchmarks require readerLocalChunkTarget = 0",
+			);
+		}
+		if (
+			resolvedReaderPersistChunkReads === false &&
+			resolvedReaderTerminalTopology !== "observer"
+		) {
+			throw new Error(
+				"Transient reader benchmarks require readerTerminalTopology = observer",
+			);
+		}
 	}
 
 	return {
@@ -341,6 +410,7 @@ export const createBenchmarkInvocation = ({
 		fileSizeBytes: sizeBytes,
 		fixtureSeed,
 		downloadSink: resolvedDownloadSink,
+		browserStorageMode: resolvedBrowserStorageMode,
 		uploadTimeoutMs: resolvedUploadTimeoutMs,
 		downloadTimeoutMs: resolvedDownloadTimeoutMs,
 		postTransferSoakMs: resolvedPostTransferSoakMs,
@@ -354,6 +424,7 @@ export const createBenchmarkInvocation = ({
 		readerLocalChunkTarget: resolvedReaderLocalChunkTarget,
 		readerLocalChunkMaxOvershoot: resolvedReaderLocalChunkMaxOvershoot,
 		readerTerminalTopology: resolvedReaderTerminalTopology,
+		readerPersistChunkReads: resolvedReaderPersistChunkReads,
 		baseUrl: resolvedBaseUrl,
 		protocol: previewOptions.protocol,
 		viteMode: previewOptions.viteMode,
@@ -395,6 +466,7 @@ export const createPlaywrightBenchmarkEnvironment = ({
 		PW_BENCHMARK_RUN_NONCE: runNonce,
 		PW_BENCHMARK_SCENARIO: invocation.scenario,
 		PW_DOWNLOAD_SINK: stringValue(invocation.downloadSink),
+		PW_BROWSER_STORAGE_MODE: stringValue(invocation.browserStorageMode),
 		PW_DOWNLOAD_TIMEOUT_MS: String(invocation.downloadTimeoutMs),
 		PW_ENABLE_VISIBILITY_PROBE: invocation.enableVisibilityProbe ? "1" : "0",
 		PW_FILE_MB: String(invocation.fileSizeMb),
@@ -419,6 +491,12 @@ export const createPlaywrightBenchmarkEnvironment = ({
 			invocation.readerLocalChunkMaxOvershoot,
 		),
 		PW_READER_TERMINAL_TOPOLOGY: stringValue(invocation.readerTerminalTopology),
+		PW_READER_PERSIST_CHUNK_READS:
+			invocation.readerPersistChunkReads == null
+				? ""
+				: invocation.readerPersistChunkReads
+					? "1"
+					: "0",
 		PW_UPLOAD_TIMEOUT_MS: String(invocation.uploadTimeoutMs),
 		PW_VERBOSE: invocation.verbose ? "1" : "0",
 		PW_VITE_CONFIG: stringValue(invocation.viteConfig),

--- a/scripts/file-share/benchmark-invocation.test.mjs
+++ b/scripts/file-share/benchmark-invocation.test.mjs
@@ -12,6 +12,7 @@ import {
 	createBenchmarkInvocation,
 	createNonceIsolatedResultPath,
 	createPlaywrightBenchmarkEnvironment,
+	resolveBenchmarkBrowserStorageMode,
 	resolveBenchmarkDownloadSink,
 	resolveBenchmarkPreviewOptions,
 	resolveBenchmarkPreviewProtocol,
@@ -48,6 +49,7 @@ test("resolves every default and requested optional knob", () => {
 	assert.deepEqual(
 		{
 			downloadSink: resolved.downloadSink,
+			browserStorageMode: resolved.browserStorageMode,
 			uploadTimeoutMs: resolved.uploadTimeoutMs,
 			downloadTimeoutMs: resolved.downloadTimeoutMs,
 			postTransferSoakMs: resolved.postTransferSoakMs,
@@ -61,6 +63,7 @@ test("resolves every default and requested optional knob", () => {
 			readerLocalChunkTarget: resolved.readerLocalChunkTarget,
 			readerLocalChunkMaxOvershoot: resolved.readerLocalChunkMaxOvershoot,
 			readerTerminalTopology: resolved.readerTerminalTopology,
+			readerPersistChunkReads: resolved.readerPersistChunkReads,
 			protocol: resolved.protocol,
 			viteMode: resolved.viteMode,
 			viteConfig: resolved.viteConfig,
@@ -72,6 +75,7 @@ test("resolves every default and requested optional knob", () => {
 		},
 		{
 			downloadSink: "hash-only",
+			browserStorageMode: "memory",
 			uploadTimeoutMs: 101,
 			downloadTimeoutMs: 202,
 			postTransferSoakMs: 0,
@@ -85,6 +89,7 @@ test("resolves every default and requested optional knob", () => {
 			readerLocalChunkTarget: null,
 			readerLocalChunkMaxOvershoot: null,
 			readerTerminalTopology: null,
+			readerPersistChunkReads: null,
 			protocol: "http",
 			viteMode: null,
 			viteConfig: null,
@@ -95,7 +100,7 @@ test("resolves every default and requested optional knob", () => {
 			serverHost: "127.0.0.1",
 		},
 	);
-	assert.equal(BENCHMARK_INVOCATION_SCHEMA.version, 5);
+	assert.equal(BENCHMARK_INVOCATION_SCHEMA.version, 6);
 });
 
 test("uses the same ready-seeder baseline for comparable replication modes", () => {
@@ -140,11 +145,13 @@ test("removes all ambient PW variables and installs the exact invocation", () =>
 	assert.equal(environment.HOST, "127.0.0.1");
 	assert.equal(environment.PW_FILE_MB, "5");
 	assert.equal(environment.PW_DOWNLOAD_SINK, "hash-only");
+	assert.equal(environment.PW_BROWSER_STORAGE_MODE, "memory");
 	assert.equal(environment.PW_POST_TRANSFER_SOAK_MS, "60000");
 	assert.equal(environment.PW_POST_UPLOAD_MONITOR_MS, "5000");
 	assert.equal(environment.PW_READER_LOCAL_CHUNK_TARGET, "");
 	assert.equal(environment.PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT, "");
 	assert.equal(environment.PW_READER_TERMINAL_TOPOLOGY, "");
+	assert.equal(environment.PW_READER_PERSIST_CHUNK_READS, "");
 	assert.equal(environment.PW_FUTURE_BYPASS, undefined);
 	assert.equal(environment.PW_PORT, undefined);
 	assert.equal(environment.PW_BENCH, "1");
@@ -165,12 +172,14 @@ test("binds both terminal topology expectations to one observer-prefix cohort", 
 		assert.equal(resolved.readerLocalChunkTarget, 0);
 		assert.equal(resolved.readerLocalChunkMaxOvershoot, 0);
 		assert.equal(resolved.readerTerminalTopology, readerTerminalTopology);
+		assert.equal(resolved.readerPersistChunkReads, true);
 		assert.equal(resolved.minReadySeeders, 1);
 		const environment = createPlaywrightBenchmarkEnvironment({
 			baseEnvironment: {
 				PW_READER_LOCAL_CHUNK_TARGET: "attacker",
 				PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT: "attacker",
 				PW_READER_TERMINAL_TOPOLOGY: "attacker",
+				PW_READER_PERSIST_CHUNK_READS: "attacker",
 			},
 			invocation: resolved,
 			resultFile: "/tmp/result.json",
@@ -183,7 +192,25 @@ test("binds both terminal topology expectations to one observer-prefix cohort", 
 			environment.PW_READER_TERMINAL_TOPOLOGY,
 			readerTerminalTopology,
 		);
+		assert.equal(environment.PW_READER_PERSIST_CHUNK_READS, "1");
 	}
+	const transient = invocation({
+		mode: "fixed1",
+		readerLocalChunkTarget: 0,
+		readerLocalChunkMaxOvershoot: 0,
+		readerTerminalTopology: "observer",
+		readerPersistChunkReads: false,
+	});
+	assert.equal(transient.readerPersistChunkReads, false);
+	assert.equal(
+		createPlaywrightBenchmarkEnvironment({
+			invocation: transient,
+			resultFile: "/tmp/result.json",
+			runNonce: "123e4567-e89b-42d3-a456-426614174000",
+			provenance: { bound: true },
+		}).PW_READER_PERSIST_CHUNK_READS,
+		"0",
+	);
 	for (const [overrides, pattern] of [
 		[
 			{
@@ -266,6 +293,37 @@ test("binds both terminal topology expectations to one observer-prefix cohort", 
 			},
 			/Unsupported readerTerminalTopology/,
 		],
+		[
+			{
+				mode: "fixed1",
+				readerLocalChunkTarget: 1,
+				readerLocalChunkMaxOvershoot: 0,
+				readerTerminalTopology: "observer",
+				readerPersistChunkReads: false,
+			},
+			/requires? readerLocalChunkTarget = 0/i,
+		],
+		[
+			{
+				mode: "fixed1",
+				readerLocalChunkTarget: 0,
+				readerLocalChunkMaxOvershoot: 0,
+				readerTerminalTopology: "replicator",
+				readerPersistChunkReads: false,
+			},
+			/requires? readerTerminalTopology = observer/i,
+		],
+		[{ readerPersistChunkReads: false }, /provided exactly when/],
+		[
+			{
+				mode: "fixed1",
+				readerLocalChunkTarget: 0,
+				readerLocalChunkMaxOvershoot: 0,
+				readerTerminalTopology: "observer",
+				readerPersistChunkReads: "false",
+			},
+			/must be a boolean/,
+		],
 	]) {
 		assert.throws(() => invocation(overrides), pattern);
 	}
@@ -306,6 +364,43 @@ test("defaults to the hash-only sink and validates explicit sink cohorts", () =>
 				scenario: "seeder-probe",
 				fileMb: 1,
 				downloadSink: "hash-only",
+			}),
+		/only supported by upload benchmarks/,
+	);
+});
+
+test("binds the requested browser storage backend", () => {
+	assert.equal(
+		resolveBenchmarkBrowserStorageMode(undefined, { scenario: "upload" }),
+		"memory",
+	);
+	for (const mode of ["memory", "opfs"]) {
+		const resolved = invocation({ browserStorageMode: mode });
+		assert.equal(resolved.browserStorageMode, mode);
+		assert.equal(
+			createPlaywrightBenchmarkEnvironment({
+				invocation: resolved,
+				resultFile: "/tmp/result.json",
+				runNonce: "123e4567-e89b-42d3-a456-426614174000",
+				provenance: { bound: true },
+			}).PW_BROWSER_STORAGE_MODE,
+			mode,
+		);
+	}
+	assert.throws(
+		() => invocation({ browserStorageMode: "indexeddb" }),
+		/Unsupported benchmark browser storage/,
+	);
+	assert.equal(
+		invocation({ scenario: "seeder-probe", fileMb: 1 }).browserStorageMode,
+		null,
+	);
+	assert.throws(
+		() =>
+			invocation({
+				scenario: "seeder-probe",
+				fileMb: 1,
+				browserStorageMode: "memory",
 			}),
 		/only supported by upload benchmarks/,
 	);

--- a/scripts/file-share/benchmark-orchestration.mjs
+++ b/scripts/file-share/benchmark-orchestration.mjs
@@ -2,7 +2,7 @@ import fsp from "node:fs/promises";
 
 export const BENCHMARK_RESULT_SCHEMA = Object.freeze({
 	id: "peerbit-file-share-benchmark",
-	version: 10,
+	version: 11,
 });
 
 export const SEEDER_DROP_POLICY = Object.freeze({
@@ -19,12 +19,12 @@ export const SEEDER_DROP_POLICY = Object.freeze({
 
 export const BENCHMARK_SUMMARY_SCHEMA = Object.freeze({
 	id: "peerbit-file-share-benchmark-summary",
-	version: 6,
+	version: 7,
 });
 
 export const MATRIX_SUMMARY_SCHEMA = Object.freeze({
 	id: "peerbit-file-share-matrix-summary",
-	version: 6,
+	version: 7,
 });
 
 export const KNOWN_PEERBIT_FAILURE_SIGNATURES = Object.freeze([

--- a/scripts/file-share/benchmark-summary.mjs
+++ b/scripts/file-share/benchmark-summary.mjs
@@ -38,6 +38,13 @@ const passedNumbers = (results, getter) =>
 const optionalLocalityValue = (result, key) =>
 	result?.[key] ?? result?.invocation?.[key] ?? null;
 
+const explicitBenchmarkDimension = (result, key) => ({
+	present:
+		Object.hasOwn(result ?? {}, key) ||
+		Object.hasOwn(result?.invocation ?? {}, key),
+	value: optionalLocalityValue(result, key),
+});
+
 export const uploadLocalityCohortDimensions = (result) => ({
 	mode: result.mode,
 	readerLocalChunkTarget: optionalLocalityValue(
@@ -66,10 +73,30 @@ export const groupUploadResultsByLocalityCohort = (results) => {
 	const anyRuntimeEvidence = runtimeEvidence.some(
 		(evidence) => evidence.present,
 	);
+	const browserStorageEvidence = results.map((result) =>
+		explicitBenchmarkDimension(result, "browserStorageMode"),
+	);
+	const readerPersistenceEvidence = results.map((result) =>
+		explicitBenchmarkDimension(result, "readerPersistChunkReads"),
+	);
+	const anyBrowserStorageEvidence = browserStorageEvidence.some(
+		(evidence) => evidence.present,
+	);
+	const anyReaderPersistenceEvidence = readerPersistenceEvidence.some(
+		(evidence) => evidence.present,
+	);
 	const grouped = new Map();
 	for (const [index, result] of results.entries()) {
 		const dimensions = {
 			...uploadLocalityCohortDimensions(result),
+			...(anyBrowserStorageEvidence
+				? { browserStorageMode: browserStorageEvidence[index].value }
+				: {}),
+			...(anyReaderPersistenceEvidence
+				? {
+						readerPersistChunkReads: readerPersistenceEvidence[index].value,
+					}
+				: {}),
 			...(anyRuntimeEvidence
 				? {
 						runtimeConfigurationCohortKey: runtimeEvidence[index].cohortKey,
@@ -709,6 +736,22 @@ const comparableRuntimeConfigurationCohortKey = (passedResults) => {
 	return { legacy: false, cohortKey: evidence[0].cohortKey };
 };
 
+const comparableExplicitBenchmarkDimension = (passedResults, key) => {
+	const evidence = passedResults.map((result) =>
+		explicitBenchmarkDimension(result, key),
+	);
+	if (evidence.every((entry) => !entry.present)) {
+		return { legacy: true, value: null };
+	}
+	if (
+		evidence.some((entry) => !entry.present) ||
+		new Set(evidence.map((entry) => JSON.stringify(entry.value))).size !== 1
+	) {
+		return null;
+	}
+	return { legacy: false, value: evidence[0].value };
+};
+
 export const compareUploadPerformanceModes = (results) => {
 	const passedResults = results.filter((result) => result.status === "passed");
 	const downloadSinks = new Set(
@@ -720,6 +763,17 @@ export const compareUploadPerformanceModes = (results) => {
 	const runtimeConfiguration =
 		comparableRuntimeConfigurationCohortKey(passedResults);
 	if (!runtimeConfiguration) {
+		return null;
+	}
+	const browserStorage = comparableExplicitBenchmarkDimension(
+		passedResults,
+		"browserStorageMode",
+	);
+	const readerPersistence = comparableExplicitBenchmarkDimension(
+		passedResults,
+		"readerPersistChunkReads",
+	);
+	if (!browserStorage || !readerPersistence) {
 		return null;
 	}
 	const downloadSink = [...downloadSinks][0];
@@ -750,6 +804,12 @@ export const compareUploadPerformanceModes = (results) => {
 	}
 	return {
 		downloadSink,
+		...(browserStorage.legacy
+			? {}
+			: { browserStorageMode: browserStorage.value }),
+		...(readerPersistence.legacy
+			? {}
+			: { readerPersistChunkReads: readerPersistence.value }),
 		...(runtimeConfiguration.legacy
 			? {}
 			: {

--- a/scripts/file-share/benchmark-summary.test.mjs
+++ b/scripts/file-share/benchmark-summary.test.mjs
@@ -110,6 +110,80 @@ test("keeps exact observer-locality cohorts separate in aggregates", () => {
 	);
 });
 
+test("keeps storage and explicit reader-persistence cohorts separate in merged aggregates", () => {
+	const base = {
+		status: "passed",
+		mode: "fixed1",
+		readerLocalChunkTarget: 0,
+		readerLocalChunkMaxOvershoot: 0,
+		readerLocalChunkBlockCount: 0,
+		readerLocalChunkIndexRowCount: 0,
+		readerLocalityCohortKey: "reused-locality-key",
+		browserStorageMode: "memory",
+		readerPersistChunkReads: true,
+	};
+	const invocationOnly = {
+		...base,
+		browserStorageMode: undefined,
+		readerPersistChunkReads: undefined,
+		invocation: {
+			browserStorageMode: "memory",
+			readerPersistChunkReads: true,
+		},
+	};
+	delete invocationOnly.browserStorageMode;
+	delete invocationOnly.readerPersistChunkReads;
+	const differentStorage = {
+		...base,
+		browserStorageMode: "opfs",
+	};
+	const differentPersistence = {
+		...base,
+		readerPersistChunkReads: false,
+	};
+	const legacy = { ...base };
+	delete legacy.browserStorageMode;
+	delete legacy.readerPersistChunkReads;
+
+	const groups = groupUploadResultsByLocalityCohort([
+		base,
+		invocationOnly,
+		differentStorage,
+		differentPersistence,
+		legacy,
+	]);
+
+	assert.deepEqual(
+		groups.map(({ dimensions, results }) => ({
+			browserStorageMode: dimensions.browserStorageMode,
+			readerPersistChunkReads: dimensions.readerPersistChunkReads,
+			runs: results.length,
+		})),
+		[
+			{
+				browserStorageMode: "memory",
+				readerPersistChunkReads: true,
+				runs: 2,
+			},
+			{
+				browserStorageMode: "opfs",
+				readerPersistChunkReads: true,
+				runs: 1,
+			},
+			{
+				browserStorageMode: "memory",
+				readerPersistChunkReads: false,
+				runs: 1,
+			},
+			{
+				browserStorageMode: null,
+				readerPersistChunkReads: null,
+				runs: 1,
+			},
+		],
+	);
+});
+
 test("propagates end-to-end readiness and labels post-settlement listing", () => {
 	const results = [
 		{
@@ -602,6 +676,49 @@ test("compares modes only inside one exact runtime pair", () => {
 		summarizeUploadPerformance([adaptive]).runtimeEvidence
 			.effectiveRuntimeConfiguration.cohortKey,
 	);
+});
+
+test("compares modes only inside one storage and reader-persistence cohort", () => {
+	const { adaptive, fixed1 } = comparableRuntimeModeResults();
+	for (const result of [adaptive, fixed1]) {
+		result.browserStorageMode = "memory";
+		result.readerPersistChunkReads = true;
+	}
+
+	const comparison = compareUploadPerformanceModes([adaptive, fixed1]);
+	assert.deepEqual(
+		{
+			browserStorageMode: comparison.browserStorageMode,
+			readerPersistChunkReads: comparison.readerPersistChunkReads,
+		},
+		{
+			browserStorageMode: "memory",
+			readerPersistChunkReads: true,
+		},
+	);
+
+	for (const [key, value] of [
+		["browserStorageMode", "opfs"],
+		["readerPersistChunkReads", false],
+	]) {
+		const mutated = structuredClone(fixed1);
+		mutated[key] = value;
+		assert.equal(
+			compareUploadPerformanceModes([adaptive, mutated]),
+			null,
+			`comparison must reject a ${key} mutation`,
+		);
+	}
+
+	for (const key of ["browserStorageMode", "readerPersistChunkReads"]) {
+		const missingEvidence = structuredClone(fixed1);
+		delete missingEvidence[key];
+		assert.equal(
+			compareUploadPerformanceModes([adaptive, missingEvidence]),
+			null,
+			`comparison must reject mixed legacy/current ${key} evidence`,
+		);
+	}
 });
 
 test("rejects a mode comparison across an upload-limit mismatch", () => {

--- a/scripts/file-share/benchmark-validity.mjs
+++ b/scripts/file-share/benchmark-validity.mjs
@@ -1448,6 +1448,8 @@ const validateHostRssSeries = (seriesValue, maxSamples, readWindow) => {
 			"attribution",
 			"attributionLimitations",
 			"unit",
+			"browserInstanceCount",
+			"browserSessionCount",
 			"sampleIntervalMs",
 			"startedAt",
 			"finishedAt",
@@ -1499,7 +1501,9 @@ const validateHostRssSeries = (seriesValue, maxSamples, readWindow) => {
 		series.attribution !== DOWNLOAD_MEMORY_HOST_ATTRIBUTION ||
 		series.attributionLimitations !==
 			DOWNLOAD_MEMORY_HOST_ATTRIBUTION_LIMITATIONS ||
-		series.unit !== "bytes"
+		series.unit !== "bytes" ||
+		series.browserInstanceCount !== 2 ||
+		series.browserSessionCount !== 2
 	) {
 		throw new Error("Benchmark host RSS attribution contract is invalid");
 	}
@@ -1517,6 +1521,8 @@ const validateHostRssSeries = (seriesValue, maxSamples, readWindow) => {
 			[
 				"capturedAt",
 				"sampleKind",
+				"browserInstanceCount",
+				"browserRootProcessCount",
 				"browserBytes",
 				"nodeBytes",
 				"nodeExternalBytes",
@@ -1527,6 +1533,14 @@ const validateHostRssSeries = (seriesValue, maxSamples, readWindow) => {
 			],
 			sampleLabel,
 		);
+		if (
+			sample.browserInstanceCount !== 2 ||
+			sample.browserRootProcessCount !== 2
+		) {
+			throw new Error(
+				`Benchmark ${sampleLabel} does not prove both browser instances and root processes were sampled`,
+			);
+		}
 		const browserBytes = requirePositiveSafeInteger(
 			sample.browserBytes,
 			`${sampleLabel}.browserBytes`,
@@ -1556,6 +1570,11 @@ const validateHostRssSeries = (seriesValue, maxSamples, readWindow) => {
 				`Benchmark ${sampleLabel} exceeds the browser-process count cap`,
 			);
 		}
+		if (browserProcessCount < sample.browserRootProcessCount) {
+			throw new Error(
+				`Benchmark ${sampleLabel} browser-process count excludes a browser root`,
+			);
+		}
 		const { roles: browserRoleBytes, total: roleTotal } =
 			validateBrowserRoleBytes(
 				sample.browserRoleBytes,
@@ -1574,6 +1593,8 @@ const validateHostRssSeries = (seriesValue, maxSamples, readWindow) => {
 			);
 		}
 		return {
+			browserInstanceCount: sample.browserInstanceCount,
+			browserRootProcessCount: sample.browserRootProcessCount,
 			browserBytes,
 			nodeBytes,
 			nodeExternalBytes,
@@ -2424,7 +2445,7 @@ const validateEnvelope = (
 	);
 	if (
 		invocationSchema.id !== "peerbit-file-share-benchmark-invocation" ||
-		invocationSchema.version !== 5
+		invocationSchema.version !== 6
 	) {
 		throw new Error("Benchmark result has an unsupported invocation schema");
 	}
@@ -2484,6 +2505,11 @@ const validateRequestedUploadKnobs = (result, invocation) => {
 			"Benchmark result readerTerminalTopology does not match the requested invocation",
 		);
 	}
+	if (result.browserStorageMode !== invocation.browserStorageMode) {
+		throw new Error(
+			"Benchmark result browserStorageMode does not match the requested invocation",
+		);
+	}
 };
 
 const validateStorageUsageDetails = (value, label) => {
@@ -2513,11 +2539,11 @@ const validateStorageUsageDetails = (value, label) => {
 const validateStorageResourceSnapshot = (
 	value,
 	label,
-	{ setStartedAt, pageCapturedAt },
+	{ setStartedAt, pageCapturedAt, browserStorageMode },
 ) => {
 	const storage = requireExactRecordKeys(
 		requireRecord(value, label),
-		["capturedAt", "origin", "peerbitLog", "backingStorage"],
+		["capturedAt", "origin", "backend", "peerbitLog", "backingStorage"],
 		label,
 	);
 	const capturedAt = requirePositiveSafeInteger(
@@ -2539,6 +2565,76 @@ const validateStorageResourceSnapshot = (
 	if (parsedOrigin !== origin) {
 		throw new Error(`Benchmark result has invalid ${label}.origin`);
 	}
+	const backend = requireExactRecordKeys(
+		requireRecord(storage.backend, `${label}.backend`),
+		[
+			"requestedMode",
+			"directoryConfigured",
+			"directoryConfigurationError",
+			"persistence",
+		],
+		`${label}.backend`,
+	);
+	if (
+		!["memory", "opfs"].includes(browserStorageMode) ||
+		backend.requestedMode !== browserStorageMode ||
+		backend.directoryConfigured !== (browserStorageMode === "opfs") ||
+		backend.directoryConfigurationError !== null
+	) {
+		throw new Error(`Benchmark ${label}.backend contract is invalid`);
+	}
+	const persistence = requireExactRecordKeys(
+		requireRecord(backend.persistence, `${label}.backend.persistence`),
+		["navigatorStorage", "peerStorage", "peerBlocks", "peerIndexer"],
+		`${label}.backend.persistence`,
+	);
+	const validatePersistedProbe = (
+		value,
+		probeLabel,
+		expectedApi,
+		expectedPersisted,
+	) => {
+		const probe = requireExactRecordKeys(
+			requireRecord(value, probeLabel),
+			["api", "available", "persisted", "error"],
+			probeLabel,
+		);
+		if (
+			probe.api !== expectedApi ||
+			probe.available !== true ||
+			typeof probe.persisted !== "boolean" ||
+			probe.error !== null ||
+			(expectedPersisted !== null && probe.persisted !== expectedPersisted)
+		) {
+			throw new Error(`Benchmark ${probeLabel} contract is invalid`);
+		}
+		return probe;
+	};
+	validatePersistedProbe(
+		persistence.navigatorStorage,
+		`${label}.backend.persistence.navigatorStorage`,
+		"navigator.storage.persisted",
+		null,
+	);
+	const expectedPeerPersistence = browserStorageMode === "opfs";
+	validatePersistedProbe(
+		persistence.peerStorage,
+		`${label}.backend.persistence.peerStorage`,
+		"peer.storage.persisted",
+		expectedPeerPersistence,
+	);
+	validatePersistedProbe(
+		persistence.peerBlocks,
+		`${label}.backend.persistence.peerBlocks`,
+		"peer.services.blocks.persisted",
+		expectedPeerPersistence,
+	);
+	validatePersistedProbe(
+		persistence.peerIndexer,
+		`${label}.backend.persistence.peerIndexer`,
+		"peer.indexer.persisted",
+		expectedPeerPersistence,
+	);
 	const peerbitLog = requireExactRecordKeys(
 		requireRecord(storage.peerbitLog, `${label}.peerbitLog`),
 		["api", "scope", "available", "usageBytes", "error"],
@@ -2748,7 +2844,7 @@ const validateRuntimeResourceSnapshot = (
 const validatePageResourceSnapshot = (
 	value,
 	role,
-	{ setStartedAt, setFinishedAt, setLabel },
+	{ setStartedAt, setFinishedAt, setLabel, browserStorageMode },
 ) => {
 	const label = `resourceEvidence.snapshots.${setLabel}.${role}`;
 	const page = requireExactRecordKeys(
@@ -2770,6 +2866,7 @@ const validatePageResourceSnapshot = (
 	validateStorageResourceSnapshot(page.storage, `${label}.storage`, {
 		setStartedAt,
 		pageCapturedAt: capturedAt,
+		browserStorageMode,
 	});
 	validateRuntimeResourceSnapshot(page.runtime, `${label}.runtime`, {
 		setStartedAt,
@@ -2808,11 +2905,13 @@ const validateResourceSnapshotSet = (value, expectedLabel, invocation) => {
 		setStartedAt: startedAt,
 		setFinishedAt: finishedAt,
 		setLabel: expectedLabel,
+		browserStorageMode: invocation.browserStorageMode,
 	});
 	validatePageResourceSnapshot(snapshot.reader, "reader", {
 		setStartedAt: startedAt,
 		setFinishedAt: finishedAt,
 		setLabel: expectedLabel,
+		browserStorageMode: invocation.browserStorageMode,
 	});
 	return snapshot;
 };
@@ -3554,13 +3653,16 @@ const validateReaderLocalityControl = (result, invocation) => {
 	const target = invocation.readerLocalChunkTarget;
 	const maxOvershoot = invocation.readerLocalChunkMaxOvershoot;
 	const expectedTerminalTopology = invocation.readerTerminalTopology;
+	const persistChunkReads = invocation.readerPersistChunkReads;
 	if (target == null) {
 		if (
 			maxOvershoot !== null ||
 			expectedTerminalTopology !== null ||
+			persistChunkReads !== null ||
 			result.readerLocalityControl !== null ||
 			result.readerLocalChunkBlockCount !== null ||
 			result.readerLocalChunkIndexRowCount !== null ||
+			result.readerPersistChunkReads !== null ||
 			result.readerLocalityCohortKey !== null
 		) {
 			throw new Error(
@@ -3573,10 +3675,19 @@ const validateReaderLocalityControl = (result, invocation) => {
 		!Number.isSafeInteger(maxOvershoot) ||
 		maxOvershoot < 0 ||
 		!["observer", "replicator"].includes(expectedTerminalTopology) ||
+		typeof persistChunkReads !== "boolean" ||
 		invocation.mode !== "fixed1" ||
 		invocation.minReadySeeders !== 1
 	) {
 		throw new Error("Benchmark reader locality invocation is invalid");
+	}
+	if (
+		persistChunkReads === false &&
+		(target !== 0 || expectedTerminalTopology !== "observer")
+	) {
+		throw new Error(
+			"Benchmark transient reader invocation requires a zero prefix and observer topology",
+		);
 	}
 	const control = requireRecord(
 		result.readerLocalityControl,
@@ -3591,7 +3702,8 @@ const validateReaderLocalityControl = (result, invocation) => {
 			"exact local Documents index rows and manifest entry blocks" ||
 		control.writerUploadRole !== "fixed1" ||
 		control.readerUploadRole !== "observer" ||
-		control.readerTimedReadPolicy !== "persist-chunk-reads" ||
+		control.readerTimedReadPolicy !==
+			(persistChunkReads ? "persist-chunk-reads" : "transient-chunk-reads") ||
 		control.expectedTerminalTopology !== expectedTerminalTopology ||
 		control.stabilityPollIntervalMs !== Math.min(invocation.pollMs, 100) ||
 		control.requiredStableObservationCount !== 3 ||
@@ -3886,7 +3998,7 @@ const validateReaderLocalityControl = (result, invocation) => {
 			expectedImportedIndices,
 		) ||
 		preload.maxConcurrentImports !== 8 ||
-		preload.persistChunkReads !== true ||
+		preload.persistChunkReads !== persistChunkReads ||
 		!Array.isArray(preload.activeTransfersAfterClose) ||
 		preload.activeTransfersAfterClose.length !== 0 ||
 		preloadFinishedAt < preloadStartedAt
@@ -3971,7 +4083,7 @@ const validateReaderLocalityControl = (result, invocation) => {
 			observation.chunkCount !== canonicalChunkCount ||
 			observation.indexRowCount !== actualLocalChunkIndexRowCount ||
 			observation.blockCount !== actualLocalChunkBlockCount ||
-			observation.persistChunkReads !== true ||
+			observation.persistChunkReads !== persistChunkReads ||
 			!isDeepStrictEqual(
 				observation.indexedChunkIndices,
 				expectedIndexPrefix,
@@ -3990,7 +4102,7 @@ const validateReaderLocalityControl = (result, invocation) => {
 		control.preDownloadObservation,
 		"readerLocalityControl.preDownloadObservation",
 	);
-	const expectedCohortKey = `observer-persistent-prefix-b${actualLocalChunkBlockCount}-i${actualLocalChunkIndexRowCount}`;
+	const expectedCohortKey = `observer-${persistChunkReads ? "persistent" : "transient"}-${invocation.browserStorageMode}-prefix-b${actualLocalChunkBlockCount}-i${actualLocalChunkIndexRowCount}`;
 	if (
 		actualLocalChunkBlockCount < target ||
 		actualLocalChunkBlockCount > target + maxOvershoot ||
@@ -4001,6 +4113,7 @@ const validateReaderLocalityControl = (result, invocation) => {
 		control.cohortKey !== expectedCohortKey ||
 		result.readerLocalChunkBlockCount !== actualLocalChunkBlockCount ||
 		result.readerLocalChunkIndexRowCount !== actualLocalChunkIndexRowCount ||
+		result.readerPersistChunkReads !== persistChunkReads ||
 		result.readerLocalityCohortKey !== expectedCohortKey ||
 		preDownload.chunkCount !== canonicalChunkCount ||
 		!isDeepStrictEqual(preDownload.observation, stable.at(-1).observation)
@@ -4022,7 +4135,7 @@ const validateReaderLocalityControl = (result, invocation) => {
 		"readerDiagnostics.lastReadDiagnostics",
 	);
 	if (
-		readerDiagnostics.persistChunkReads !== true ||
+		readerDiagnostics.persistChunkReads !== persistChunkReads ||
 		readerDiagnostics.programAddress !== initialProgramAddress ||
 		readerTimings.initialRole !== initialRoleEvidence.initialRole ||
 		readerTimings.updateRoleCount !== initialRoleEvidence.updateRoleCount ||
@@ -4032,13 +4145,21 @@ const validateReaderLocalityControl = (result, invocation) => {
 			"Benchmark reader diagnostics contradict its initial observer-role evidence",
 		);
 	}
+	const expectedInitialDiagnosticIndexRowCount = persistChunkReads
+		? actualLocalChunkIndexRowCount
+		: null;
+	const expectedInitialDiagnosticBlockCount = persistChunkReads
+		? actualLocalChunkBlockCount
+		: null;
 	if (
-		timedRead.persistChunkReads !== true ||
-		timedRead.programPersistChunkReads !== true ||
+		timedRead.persistChunkReads !== persistChunkReads ||
+		timedRead.programPersistChunkReads !== persistChunkReads ||
 		timedRead.initialLocalChunkIndexRowCount !==
-			actualLocalChunkIndexRowCount ||
-		timedRead.initialLocalChunkCount !== actualLocalChunkIndexRowCount ||
-		timedRead.initialLocalChunkBlockCount !== actualLocalChunkBlockCount
+			expectedInitialDiagnosticIndexRowCount ||
+		timedRead.initialLocalChunkCount !==
+			expectedInitialDiagnosticIndexRowCount ||
+		timedRead.initialLocalChunkBlockCount !==
+			expectedInitialDiagnosticBlockCount
 	) {
 		throw new Error(
 			"Benchmark timed read diagnostics do not match its exact locality cohort",
@@ -4062,18 +4183,21 @@ const validateReaderLocalityControl = (result, invocation) => {
 	);
 	const expectedTerminalIndexRowCount =
 		expectedTerminalTopology === "replicator" ? canonicalChunkCount : 0;
+	const expectedTerminalBlockCount = persistChunkReads
+		? canonicalChunkCount
+		: 0;
 	if (
 		terminalIdle.fileId !== manifestFileId ||
 		terminalIdle.chunkCount !== canonicalChunkCount ||
-		terminalIdle.blockCount !== canonicalChunkCount ||
+		terminalIdle.blockCount !== expectedTerminalBlockCount ||
 		terminalIdle.indexRowCount !== expectedTerminalIndexRowCount ||
 		terminalIdle.indexedChunkIndices.length !== expectedTerminalIndexRowCount ||
-		terminalIdle.persistChunkReads !== true ||
+		terminalIdle.persistChunkReads !== persistChunkReads ||
 		control.terminalTopologyRole !== expectedTerminalTopology ||
 		control.terminalTopologyExpectationSatisfied !== true
 	) {
 		throw new Error(
-			"Benchmark terminal reader evidence does not match the requested persistent-reader topology",
+			"Benchmark terminal reader evidence does not match the requested persistence and topology policy",
 		);
 	}
 	const terminalTopologyStartedAt = requirePositiveSafeInteger(
@@ -4166,7 +4290,7 @@ const validateReaderLocalityControl = (result, invocation) => {
 		writerDiagnostics.replicatorCount !== expectedTerminalReplicatorCount ||
 		readerDiagnostics.replicatorCount !== expectedTerminalReplicatorCount ||
 		writerDiagnostics.replicationSetSize !== 1 ||
-		readerDiagnostics.replicationSetSize !== 1
+		readerDiagnostics.replicationSetSize !== (persistChunkReads ? 1 : 0)
 	) {
 		throw new Error(
 			"Benchmark final peer diagnostics contradict the terminal topology evidence",

--- a/scripts/file-share/benchmark-validity.test.mjs
+++ b/scripts/file-share/benchmark-validity.test.mjs
@@ -269,6 +269,8 @@ const createDownloadMemoryTelemetry = (
 		{
 			capturedAt: readStartedAt - 1,
 			sampleKind: "initial",
+			browserInstanceCount: 2,
+			browserRootProcessCount: 2,
 			browserBytes: 1_000,
 			nodeBytes: 500,
 			nodeExternalBytes: 100,
@@ -280,6 +282,8 @@ const createDownloadMemoryTelemetry = (
 		{
 			capturedAt: readFinishedAt + 1,
 			sampleKind: "periodic",
+			browserInstanceCount: 2,
+			browserRootProcessCount: 2,
 			browserBytes: 1_200,
 			nodeBytes: 550,
 			nodeExternalBytes: 120,
@@ -291,6 +295,8 @@ const createDownloadMemoryTelemetry = (
 		{
 			capturedAt: manualSampleAt,
 			sampleKind: "manual",
+			browserInstanceCount: 2,
+			browserRootProcessCount: 2,
 			browserBytes: 1_150,
 			nodeBytes: 540,
 			nodeExternalBytes: 115,
@@ -302,6 +308,8 @@ const createDownloadMemoryTelemetry = (
 		{
 			capturedAt: terminalSampleAt,
 			sampleKind: "terminal",
+			browserInstanceCount: 2,
+			browserRootProcessCount: 2,
 			browserBytes: 1_100,
 			nodeBytes: 525,
 			nodeExternalBytes: 110,
@@ -319,6 +327,8 @@ const createDownloadMemoryTelemetry = (
 		attribution: DOWNLOAD_MEMORY_HOST_ATTRIBUTION,
 		attributionLimitations: DOWNLOAD_MEMORY_HOST_ATTRIBUTION_LIMITATIONS,
 		unit: "bytes",
+		browserInstanceCount: 2,
+		browserSessionCount: 2,
 		sampleIntervalMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
 		startedAt: readStartedAt - 1,
 		finishedAt: shutdownFinishedAt + 5,
@@ -588,6 +598,37 @@ const createResourcePage = ({ role, startedAt, capturedAt, step }) => ({
 	storage: {
 		capturedAt: startedAt,
 		origin: "http://127.0.0.1:4173",
+		backend: {
+			requestedMode: "memory",
+			directoryConfigured: false,
+			directoryConfigurationError: null,
+			persistence: {
+				navigatorStorage: {
+					api: "navigator.storage.persisted",
+					available: true,
+					persisted: false,
+					error: null,
+				},
+				peerStorage: {
+					api: "peer.storage.persisted",
+					available: true,
+					persisted: false,
+					error: null,
+				},
+				peerBlocks: {
+					api: "peer.services.blocks.persisted",
+					available: true,
+					persisted: false,
+					error: null,
+				},
+				peerIndexer: {
+					api: "peer.indexer.persisted",
+					available: true,
+					persisted: false,
+					error: null,
+				},
+			},
+		},
 		peerbitLog: {
 			api: "SharedLog.getMemoryUsage",
 			scope: "file-share-log-logical-usage",
@@ -828,6 +869,8 @@ const validResult = () => {
 		readerLocalChunkTarget: null,
 		readerLocalChunkMaxOvershoot: null,
 		readerTerminalTopology: null,
+		readerPersistChunkReads: null,
+		browserStorageMode: "memory",
 		readerLocalChunkBlockCount: null,
 		readerLocalChunkIndexRowCount: null,
 		readerLocalityCohortKey: null,
@@ -1089,6 +1132,7 @@ const createReaderLocalityFixture = ({
 	actualBlockCount = 1,
 	actualIndexRowCount = 0,
 	readerTerminalTopology = "observer",
+	readerPersistChunkReads = true,
 } = {}) => {
 	const invocation = createBenchmarkInvocation({
 		scenario: "upload",
@@ -1107,6 +1151,7 @@ const createReaderLocalityFixture = ({
 		readerLocalChunkTarget: target,
 		readerLocalChunkMaxOvershoot: maxOvershoot,
 		readerTerminalTopology,
+		readerPersistChunkReads,
 	});
 	const result = validResult();
 	const fileName = `file-share-benchmark-fixed1-${RUN_NONCE}.bin`;
@@ -1252,28 +1297,35 @@ const createReaderLocalityFixture = ({
 	result.readerLocalChunkTarget = target;
 	result.readerLocalChunkMaxOvershoot = maxOvershoot;
 	result.readerTerminalTopology = readerTerminalTopology;
+	result.readerPersistChunkReads = readerPersistChunkReads;
 	result.readerLocalChunkBlockCount = actualBlockCount;
 	result.readerLocalChunkIndexRowCount = actualIndexRowCount;
-	const cohortKey = `observer-persistent-prefix-b${actualBlockCount}-i${actualIndexRowCount}`;
+	const cohortKey = `observer-${readerPersistChunkReads ? "persistent" : "transient"}-memory-prefix-b${actualBlockCount}-i${actualIndexRowCount}`;
 	result.readerLocalityCohortKey = cohortKey;
 	result.minReadySeeders = 1;
 	result.readerDiagnostics.lastReadDiagnostics.fileName = fileName;
 	result.readerDiagnostics.programAddress = "reader-program-address";
-	result.readerDiagnostics.persistChunkReads = true;
+	result.readerDiagnostics.persistChunkReads = readerPersistChunkReads;
 	result.readerDiagnostics.peerHash = "reader-peer";
 	result.readerDiagnostics.replicatorCount = terminalReplicatorCount;
-	result.readerDiagnostics.replicationSetSize = 1;
+	result.readerDiagnostics.replicationSetSize = readerPersistChunkReads ? 1 : 0;
 	result.readerDiagnostics.timings = {
 		initialRole: "observer",
 		updateRoleCount: 0,
 		lastAppliedRole: null,
 	};
 	Object.assign(result.readerDiagnostics.lastReadDiagnostics, {
-		persistChunkReads: true,
-		programPersistChunkReads: true,
-		initialLocalChunkIndexRowCount: actualIndexRowCount,
-		initialLocalChunkCount: actualIndexRowCount,
-		initialLocalChunkBlockCount: actualBlockCount,
+		persistChunkReads: readerPersistChunkReads,
+		programPersistChunkReads: readerPersistChunkReads,
+		initialLocalChunkIndexRowCount: readerPersistChunkReads
+			? actualIndexRowCount
+			: null,
+		initialLocalChunkCount: readerPersistChunkReads
+			? actualIndexRowCount
+			: null,
+		initialLocalChunkBlockCount: readerPersistChunkReads
+			? actualBlockCount
+			: null,
 		startedAt: 1_600,
 		finishedAt: 1_630,
 		chunkResolveStartedAt: { 0: 1_600, 1: 1_615 },
@@ -1284,11 +1336,15 @@ const createReaderLocalityFixture = ({
 		chunkMaterializeFinishedAt: { 0: 1_603, 1: 1_618 },
 		chunkHashStartedAt: { 0: 1_603, 1: 1_618 },
 		chunkHashFinishedAt: { 0: 1_604, 1: 1_620 },
-		chunkPersistenceConfirmedAt: { 0: 1_605, 1: 1_621 },
-		chunkPersistenceConfirmationSource: {
-			0: "manifest-head-batch-local",
-			1: "manifest-head-batch-remote",
-		},
+		chunkPersistenceConfirmedAt: readerPersistChunkReads
+			? { 0: 1_605, 1: 1_621 }
+			: {},
+		chunkPersistenceConfirmationSource: readerPersistChunkReads
+			? {
+					0: "manifest-head-batch-local",
+					1: "manifest-head-batch-remote",
+				}
+			: {},
 	});
 	result.writerManifestEvidence.fileName = fileName;
 	result.readerManifestEvidence.fileName = fileName;
@@ -1337,7 +1393,9 @@ const createReaderLocalityFixture = ({
 		countMetric: "exact local Documents index rows and manifest entry blocks",
 		writerUploadRole: "fixed1",
 		readerUploadRole: "observer",
-		readerTimedReadPolicy: "persist-chunk-reads",
+		readerTimedReadPolicy: readerPersistChunkReads
+			? "persist-chunk-reads"
+			: "transient-chunk-reads",
 		expectedTerminalTopology: readerTerminalTopology,
 		stabilityPollIntervalMs: 100,
 		requiredStableObservationCount: 3,
@@ -1406,7 +1464,7 @@ const createReaderLocalityFixture = ({
 			),
 			rawFetchedByteCount: target === 0 ? 0 : 3 * 1024 * 1024,
 			maxConcurrentImports: 8,
-			persistChunkReads: true,
+			persistChunkReads: readerPersistChunkReads,
 			activeTransfersAfterClose: [],
 			downloadSchedulerAfterClose: { ...idleScheduler },
 			readDiagnostics: null,
@@ -1414,7 +1472,7 @@ const createReaderLocalityFixture = ({
 		stabilityObservations: [1_176, 1_276, 1_376].map((capturedAt) =>
 			observation({
 				capturedAt,
-				persistChunkReads: true,
+				persistChunkReads: readerPersistChunkReads,
 				blocks: Array.from({ length: actualBlockCount }, (_, index) => index),
 				indexed: Array.from(
 					{ length: actualIndexRowCount },
@@ -1424,16 +1482,19 @@ const createReaderLocalityFixture = ({
 		),
 		preDownloadObservation: observation({
 			capturedAt: 1_376,
-			persistChunkReads: true,
+			persistChunkReads: readerPersistChunkReads,
 			blocks: Array.from({ length: actualBlockCount }, (_, index) => index),
 			indexed: Array.from({ length: actualIndexRowCount }, (_, index) => index),
 		}),
 		integrityVerifiedAt: 1_837,
 		terminalIdleObservation: observation({
 			capturedAt: 1_838,
-			persistChunkReads: true,
-			blocks: [0, 1],
-			indexed: readerTerminalTopology === "replicator" ? [0, 1] : [],
+			persistChunkReads: readerPersistChunkReads,
+			blocks: readerPersistChunkReads ? [0, 1] : [],
+			indexed:
+				readerPersistChunkReads && readerTerminalTopology === "replicator"
+					? [0, 1]
+					: [],
 		}),
 		terminalTopologyStartedAt: 1_838,
 		terminalTopologyDeadlineAt: 181_838,
@@ -1677,6 +1738,50 @@ test("accepts explicit disabled eager-cache evidence", () => {
 		interval.readerEager = null;
 	}
 	assert.equal(validateBenchmarkResult(result, options).status, "passed");
+});
+
+test("requires measured memory and OPFS backend evidence", () => {
+	const opfs = validResult();
+	const opfsInvocation = {
+		...structuredClone(INVOCATION),
+		browserStorageMode: "opfs",
+	};
+	opfs.invocation = structuredClone(opfsInvocation);
+	opfs.browserStorageMode = "opfs";
+	for (const snapshot of Object.values(opfs.resourceEvidence.snapshots)) {
+		for (const role of ["writer", "reader"]) {
+			const backend = snapshot[role].storage.backend;
+			backend.requestedMode = "opfs";
+			backend.directoryConfigured = true;
+			for (const key of ["peerStorage", "peerBlocks", "peerIndexer"]) {
+				backend.persistence[key].persisted = true;
+			}
+			// OPFS availability and eviction protection are separate facts.
+			backend.persistence.navigatorStorage.persisted = false;
+		}
+	}
+	const opfsOptions = { ...options, expectedInvocation: opfsInvocation };
+	assert.equal(validateBenchmarkResult(opfs, opfsOptions).status, "passed");
+
+	for (const mutate of [
+		(result) => {
+			result.resourceEvidence.snapshots.afterSink.reader.storage.backend.directoryConfigured = false;
+		},
+		(result) => {
+			result.resourceEvidence.snapshots.afterSink.reader.storage.backend.persistence.peerBlocks.persisted = false;
+		},
+		(result) => {
+			result.resourceEvidence.snapshots.afterSink.reader.storage.backend.requestedMode =
+				"memory";
+		},
+	]) {
+		const invalid = structuredClone(opfs);
+		mutate(invalid);
+		assert.throws(
+			() => validateBenchmarkResult(invalid, opfsOptions),
+			/backend.*contract is invalid|peerBlocks.*contract is invalid/,
+		);
+	}
 });
 
 test("requires ordered exact resource, soak, and shutdown evidence", () => {
@@ -1944,7 +2049,7 @@ test("requires ordered exact resource, soak, and shutdown evidence", () => {
 	}
 });
 
-test("accepts one recovered seeder dip under the v10 policy", () => {
+test("accepts one recovered seeder dip under the v11 policy", () => {
 	const result = validResult();
 	result.snapshots[1].writerSeeders = 1;
 	result.droppedSeeders = true;
@@ -1979,7 +2084,7 @@ test("rejects a terminal below-baseline seeder snapshot", () => {
 	);
 });
 
-test("rejects missing, altered, and contradictory v10 seeder-drop evidence", () => {
+test("rejects missing, altered, and contradictory v11 seeder-drop evidence", () => {
 	for (const [mutate, pattern] of [
 		[
 			(result) => {
@@ -2587,6 +2692,18 @@ test("requires bounded, error-free memory telemetry covering the canonical read"
 		],
 		[
 			(result) => {
+				result.downloadMemoryTelemetry.hostRss.browserSessionCount = 1;
+			},
+			/host RSS attribution contract is invalid/,
+		],
+		[
+			(result) => {
+				result.downloadMemoryTelemetry.hostRss.samples[0].browserRootProcessCount = 1;
+			},
+			/does not prove both browser instances and root processes were sampled/,
+		],
+		[
+			(result) => {
 				result.downloadMemoryTelemetry.hostRss.samples[0].browserProcessCount =
 					DOWNLOAD_MEMORY_MAX_BROWSER_PROCESSES + 1;
 			},
@@ -3081,7 +3198,7 @@ test("accepts exact observer-locality control and rejects contradictory evidence
 				}
 				control.actualLocalChunkBlockCount = 2;
 				control.speculativeOvershootChunkCount = 1;
-				control.cohortKey = "observer-persistent-prefix-b2-i0";
+				control.cohortKey = "observer-persistent-memory-prefix-b2-i0";
 				result.readerLocalChunkBlockCount = 2;
 				result.readerLocalityCohortKey = control.cohortKey;
 				result.readerDiagnostics.lastReadDiagnostics.initialLocalChunkBlockCount = 2;
@@ -3098,7 +3215,7 @@ test("accepts exact observer-locality control and rejects contradictory evidence
 			(result) => {
 				result.readerLocalityControl.terminalTopologyExpectationSatisfied = false;
 			},
-			/terminal reader evidence does not match the requested persistent-reader topology/,
+			/terminal reader evidence does not match the requested persistence and topology policy/,
 		],
 		[
 			(result) => {
@@ -3115,7 +3232,7 @@ test("accepts exact observer-locality control and rejects contradictory evidence
 				terminalIdle.blockCount = 1;
 				terminalIdle.blockChunkIndices = [0];
 			},
-			/terminal reader evidence does not match the requested persistent-reader topology/,
+			/terminal reader evidence does not match the requested persistence and topology policy/,
 		],
 		[
 			(result) => {
@@ -3124,7 +3241,7 @@ test("accepts exact observer-locality control and rejects contradictory evidence
 				terminalIdle.indexRowCount = 1;
 				terminalIdle.indexedChunkIndices = [0];
 			},
-			/terminal reader evidence does not match the requested persistent-reader topology/,
+			/terminal reader evidence does not match the requested persistence and topology policy/,
 		],
 		[
 			(result) => {
@@ -3278,6 +3395,44 @@ test("accepts the explicit cold observer-persistent b0-i0 locality cohort", () =
 	);
 });
 
+test("accepts the explicit cold observer-transient memory cohort", () => {
+	const fixture = createReaderLocalityFixture({
+		target: 0,
+		maxOvershoot: 0,
+		actualBlockCount: 0,
+		actualIndexRowCount: 0,
+		readerPersistChunkReads: false,
+	});
+	assert.equal(
+		validateBenchmarkResult(fixture.result, fixture.options).status,
+		"passed",
+	);
+	assert.equal(
+		fixture.result.readerLocalityCohortKey,
+		"observer-transient-memory-prefix-b0-i0",
+	);
+	assert.equal(
+		fixture.result.readTransfer.receiverProgress.peerbitDurable.claimed,
+		false,
+	);
+	assert.deepEqual(
+		fixture.result.readerDiagnostics.lastReadDiagnostics
+			.chunkPersistenceConfirmedAt,
+		{},
+	);
+	assert.equal(
+		fixture.result.readerDiagnostics.lastReadDiagnostics
+			.initialLocalChunkBlockCount,
+		null,
+	);
+	assert.equal(fixture.result.readerDiagnostics.replicationSetSize, 0);
+	fixture.result.readerDiagnostics.lastReadDiagnostics.initialLocalChunkBlockCount = 0;
+	assert.throws(
+		() => validateBenchmarkResult(fixture.result, fixture.options),
+		/timed read diagnostics do not match its exact locality cohort/,
+	);
+});
+
 test("rejects stale read diagnostics outside the clicked download window", () => {
 	for (const mutate of [
 		(result) => {
@@ -3397,14 +3552,14 @@ test("bounds Node-file server timing against its browser sink timing", () => {
 	);
 });
 
-test("rejects a status-only passed payload at the v10 evidence envelope", () => {
+test("rejects a status-only passed payload at the v11 evidence envelope", () => {
 	assert.throws(
 		() => validateBenchmarkResultEnvelope({ status: "passed" }, options),
 		/missing schema/,
 	);
 });
 
-test("requires explicit error evidence on failed v10 envelopes", () => {
+test("requires explicit error evidence on failed v11 envelopes", () => {
 	const completeFailure = validResult();
 	completeFailure.status = "failed";
 	completeFailure.failure = { message: "synthetic browser failure" };

--- a/scripts/file-share/common.mjs
+++ b/scripts/file-share/common.mjs
@@ -190,24 +190,31 @@ const loadWorkspacePeerbitPackages = async (peerbitRoot = repoRoot) => {
 	return workspacePackages;
 };
 
+const isPublishablePeerbitPackage = (info) =>
+	info?.packageJson?.private !== true;
+
 const expandWorkspacePackageSelection = ({
 	workspacePackages,
 	selectedNames,
 	includeTransitive = true,
 }) => {
-	if (selectedNames == null) {
-		return new Set(workspacePackages.keys());
-	}
-	if (selectedNames.size === 0) {
+	const effectiveSelectedNames =
+		selectedNames ??
+		new Set(
+			[...workspacePackages.entries()]
+				.filter(([, info]) => isPublishablePeerbitPackage(info))
+				.map(([name]) => name),
+		);
+	if (effectiveSelectedNames.size === 0) {
 		return new Set();
 	}
 	if (!includeTransitive) {
 		return new Set(
-			[...selectedNames].filter((name) => workspacePackages.has(name)),
+			[...effectiveSelectedNames].filter((name) => workspacePackages.has(name)),
 		);
 	}
 	const expanded = new Set();
-	const pending = [...selectedNames];
+	const pending = [...effectiveSelectedNames];
 	while (pending.length > 0) {
 		const name = pending.pop();
 		if (!name || expanded.has(name)) {
@@ -220,11 +227,17 @@ const expandWorkspacePackageSelection = ({
 		expanded.add(name);
 		for (const field of WORKSPACE_DEP_FIELDS) {
 			for (const depName of Object.keys(info.packageJson?.[field] ?? {})) {
+				const dependency = workspacePackages.get(depName);
 				if (
 					(depName === "peerbit" || depName.startsWith("@peerbit/")) &&
-					workspacePackages.has(depName) &&
+					dependency &&
 					!expanded.has(depName)
 				) {
+					if (!isPublishablePeerbitPackage(dependency)) {
+						throw new Error(
+							`Local Peerbit package ${name} depends on private workspace package ${depName}, which is not publishable or linkable`,
+						);
+					}
 					pending.push(depName);
 				}
 			}
@@ -263,6 +276,16 @@ export const collectLocalPeerbitPackages = async (
 				`Unknown local Peerbit package${unknownNames.length === 1 ? "" : "s"}: ${unknownNames.join(", ")}`,
 			);
 		}
+		const privateNames = [...selectedNames]
+			.filter(
+				(name) => workspacePackages.get(name)?.packageJson?.private === true,
+			)
+			.sort((left, right) => left.localeCompare(right));
+		if (privateNames.length > 0) {
+			throw new Error(
+				`Private local Peerbit package${privateNames.length === 1 ? " is" : "s are"} not publishable or linkable: ${privateNames.join(", ")}`,
+			);
+		}
 	}
 	const expandedSelection = expandWorkspacePackageSelection({
 		workspacePackages,
@@ -278,6 +301,92 @@ export const collectLocalPeerbitPackages = async (
 	return new Map(
 		[...mappings.entries()].sort(([a], [b]) => a.localeCompare(b)),
 	);
+};
+
+const BETTER_SQLITE3_PREFLIGHT_SCRIPT = String.raw`
+const { createRequire } = require("node:module");
+const packageJsonPath = process.argv[1];
+const requireFromPackage = createRequire(packageJsonPath);
+const resolvedPath = requireFromPackage.resolve("better-sqlite3");
+const Database = requireFromPackage("better-sqlite3");
+let database;
+try {
+	database = new Database(":memory:");
+	const row = database.prepare("SELECT 1 AS ok").get();
+	if (row?.ok !== 1) {
+		throw new Error("in-memory query returned an unexpected result");
+	}
+} finally {
+	database?.close();
+}
+process.stdout.write(JSON.stringify({
+	node: process.version,
+	modules: process.versions.modules,
+	napi: process.versions.napi,
+	resolvedPath,
+}));
+`;
+
+const childProcessOutput = (value) => {
+	if (typeof value === "string") {
+		return value.trim();
+	}
+	if (Buffer.isBuffer(value)) {
+		return value.toString("utf8").trim();
+	}
+	return "";
+};
+
+export const preflightBetterSqlite3Runtime = async (
+	peerbitRoot = repoRoot,
+	{ packageNames } = {},
+) => {
+	if (
+		Array.isArray(packageNames) &&
+		!packageNames.includes("@peerbit/indexer-sqlite3")
+	) {
+		return null;
+	}
+	const workspacePackages = await loadWorkspacePeerbitPackages(peerbitRoot);
+	const sqliteIndexer = workspacePackages.get("@peerbit/indexer-sqlite3");
+	if (!sqliteIndexer) {
+		throw new Error(
+			`better-sqlite3 runtime preflight could not find @peerbit/indexer-sqlite3 under ${peerbitRoot}`,
+		);
+	}
+	const packageJsonPath = path.join(sqliteIndexer.dir, "package.json");
+	try {
+		const output = execFileSync(
+			process.execPath,
+			["--eval", BETTER_SQLITE3_PREFLIGHT_SCRIPT, packageJsonPath],
+			{
+				cwd: sqliteIndexer.dir,
+				encoding: "utf8",
+				stdio: ["ignore", "pipe", "pipe"],
+			},
+		);
+		const evidence = JSON.parse(output);
+		if (
+			evidence.node !== process.version ||
+			evidence.modules !== process.versions.modules ||
+			typeof evidence.resolvedPath !== "string" ||
+			evidence.resolvedPath.length === 0
+		) {
+			throw new Error("child runtime evidence was incomplete or inconsistent");
+		}
+		return evidence;
+	} catch (error) {
+		const detail =
+			childProcessOutput(error?.stderr) ||
+			childProcessOutput(error?.stdout) ||
+			String(error?.message ?? error);
+		const failure = new Error(
+			`better-sqlite3 runtime preflight failed for ${process.version} (NODE_MODULE_VERSION ${process.versions.modules ?? "unknown"}) in ${sqliteIndexer.dir}. Reinstall the Peerbit workspace with this Node runtime before building. ${detail}`,
+			{ cause: error },
+		);
+		failure.stopBenchmarkPlan = true;
+		throw failure;
+	}
 };
 
 export const cleanPeerbitBuildArtifacts = async ({

--- a/scripts/file-share/common.test.mjs
+++ b/scripts/file-share/common.test.mjs
@@ -15,6 +15,7 @@ import {
 	cleanPeerbitBuildArtifacts,
 	collectLocalPeerbitPackages,
 	ensureExamplesAssetPackageLinks,
+	preflightBetterSqlite3Runtime,
 	prepareExamplesRepo,
 } from "./common.mjs";
 
@@ -141,6 +142,113 @@ test("local package selection is exact and rejects unknown names", async () => {
 		);
 	} finally {
 		await rm(fixture.root, { recursive: true, force: true });
+	}
+});
+
+test("automatic local package selection excludes private workspace packages", async () => {
+	const fixture = await createFixture();
+	const privatePackageDir = path.join(fixture.root, "packages", "private-e2e");
+	const publicPackageDir = path.join(fixture.root, "packages", "public");
+	try {
+		await mkdir(privatePackageDir, { recursive: true });
+		await mkdir(publicPackageDir, { recursive: true });
+		await writeFile(
+			path.join(privatePackageDir, "package.json"),
+			'{"name":"@peerbit/private-e2e","private":true}\n',
+		);
+		await writeFile(
+			path.join(publicPackageDir, "package.json"),
+			'{"name":"@peerbit/public"}\n',
+		);
+
+		assert.deepEqual(
+			[...(await collectLocalPeerbitPackages(fixture.root)).keys()],
+			["@peerbit/public", "peerbit"],
+		);
+		await assert.rejects(
+			collectLocalPeerbitPackages(fixture.root, {
+				names: ["@peerbit/private-e2e"],
+			}),
+			/Private local Peerbit package is not publishable or linkable: @peerbit\/private-e2e/,
+		);
+		await writeFile(
+			path.join(publicPackageDir, "package.json"),
+			'{"name":"@peerbit/public","dependencies":{"@peerbit/private-e2e":"workspace:*"}}\n',
+		);
+		await assert.rejects(
+			collectLocalPeerbitPackages(fixture.root, {
+				names: ["@peerbit/public"],
+			}),
+			/@peerbit\/public depends on private workspace package @peerbit\/private-e2e/,
+		);
+	} finally {
+		await rm(fixture.root, { recursive: true, force: true });
+	}
+});
+
+const createBetterSqlite3Fixture = async ({ loadFailure } = {}) => {
+	const root = await mkdtemp(
+		path.join(os.tmpdir(), "peerbit-sqlite-preflight-test-"),
+	);
+	const indexerDir = path.join(root, "packages", "indexer-sqlite3");
+	const moduleDir = path.join(indexerDir, "node_modules", "better-sqlite3");
+	await mkdir(moduleDir, { recursive: true });
+	await writeFile(
+		path.join(indexerDir, "package.json"),
+		'{"name":"@peerbit/indexer-sqlite3"}\n',
+	);
+	await writeFile(
+		path.join(moduleDir, "package.json"),
+		'{"name":"better-sqlite3","main":"index.js"}\n',
+	);
+	await writeFile(
+		path.join(moduleDir, "index.js"),
+		loadFailure
+			? `throw new Error(${JSON.stringify(loadFailure)});\n`
+			: `module.exports = class Database {
+	constructor(filename) {
+		if (filename !== ":memory:") throw new Error("unexpected filename");
+	}
+	prepare(sql) {
+		if (sql !== "SELECT 1 AS ok") throw new Error("unexpected query");
+		return { get: () => ({ ok: 1 }) };
+	}
+	close() {}
+};\n`,
+	);
+	return root;
+};
+
+test("better-sqlite3 preflight loads and queries the native runtime", async () => {
+	const root = await createBetterSqlite3Fixture();
+	try {
+		const evidence = await preflightBetterSqlite3Runtime(root);
+		assert.equal(evidence.node, process.version);
+		assert.equal(evidence.modules, process.versions.modules);
+		assert.match(evidence.resolvedPath, /better-sqlite3\/index\.js$/);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("better-sqlite3 preflight fails clearly on a runtime ABI load error", async () => {
+	const root = await createBetterSqlite3Fixture({
+		loadFailure:
+			"compiled against a different Node.js version using NODE_MODULE_VERSION 137",
+	});
+	try {
+		await assert.rejects(preflightBetterSqlite3Runtime(root), (error) => {
+			assert.match(error.message, /better-sqlite3 runtime preflight failed/);
+			assert.match(error.message, /NODE_MODULE_VERSION/);
+			assert.match(error.message, /Reinstall the Peerbit workspace/);
+			assert.match(
+				error.message,
+				/compiled against a different Node\.js version/,
+			);
+			return true;
+		});
+	} finally {
+		await rm(root, { recursive: true, force: true });
 	}
 });
 

--- a/scripts/file-share/download-memory-telemetry.test.mjs
+++ b/scripts/file-share/download-memory-telemetry.test.mjs
@@ -439,9 +439,193 @@ test("absorbs late operation settlement and cleans late-created values", async (
 	assert.equal(lateCleanupCount, 1);
 });
 
-test("collects forced endpoint runtime-heap and attributed host samples", async () => {
+const createRuntimeHeapPage = () => ({
+	context: () => ({
+		newCDPSession: async () => ({
+			send: async (method) => {
+				assert.equal(method, "Runtime.getHeapUsage");
+				return {
+					usedSize: 100,
+					totalSize: 110,
+					embedderHeapUsedSize: 120,
+					backingStorageSize: 130,
+				};
+			},
+			detach: async () => {},
+		}),
+	}),
+});
+
+test("requires one or two unique browser instances", async () => {
+	const browser = { newBrowserCDPSession: async () => ({}) };
+	const options = {
+		reader: createRuntimeHeapPage(),
+		writer: createRuntimeHeapPage(),
+		downloadTimeoutMs: 60_000,
+		schedulingToleranceMs: 5_000,
+		postTransferSoakMs: 0,
+		samplingWindowBudgetMs: 65_000,
+	};
+	await assert.rejects(
+		startDownloadMemoryTelemetry({
+			...options,
+			browsers: [],
+			expectedBrowserCount: 1,
+		}),
+		/requires exactly 1 browser/,
+	);
+	await assert.rejects(
+		startDownloadMemoryTelemetry({
+			...options,
+			browsers: [browser, browser],
+			expectedBrowserCount: 2,
+		}),
+		/requires unique browser instances/,
+	);
+	await assert.rejects(
+		startDownloadMemoryTelemetry({
+			...options,
+			browsers: [
+				browser,
+				{ newBrowserCDPSession: async () => ({}) },
+				{ newBrowserCDPSession: async () => ({}) },
+			],
+			expectedBrowserCount: 2,
+		}),
+		/requires exactly 2 browsers/,
+	);
+});
+
+test("fails closed on conflicting cross-browser PID types and detaches every session", async () => {
+	let detachedBrowserSessions = 0;
+	const browser = (processInfo, detachFails = false) => ({
+		newBrowserCDPSession: async () => ({
+			send: async (method) => {
+				assert.equal(method, "SystemInfo.getProcessInfo");
+				return { processInfo };
+			},
+			detach: async () => {
+				detachedBrowserSessions += 1;
+				if (detachFails) {
+					throw new Error("synthetic browser detach failure");
+				}
+			},
+		}),
+	});
+	const telemetry = await startDownloadMemoryTelemetry({
+		browsers: [
+			browser([{ id: process.pid, type: "browser" }], true),
+			browser([
+				{ id: process.ppid, type: "browser" },
+				{ id: process.pid, type: "renderer" },
+			]),
+		],
+		expectedBrowserCount: 2,
+		reader: createRuntimeHeapPage(),
+		writer: createRuntimeHeapPage(),
+		downloadTimeoutMs: 60_000,
+		schedulingToleranceMs: 5_000,
+		postTransferSoakMs: 0,
+		samplingWindowBudgetMs: 65_000,
+	});
+	const initial = telemetry.snapshot();
+	assert.equal(initial.hostRss.sampleCount, 0);
+	assert.equal(
+		initial.hostRss.samplingErrors.some((message) =>
+			message.includes("conflicting process types"),
+		),
+		true,
+	);
+	const result = await telemetry.stop();
+	assert.equal(detachedBrowserSessions, 2);
+	assert.equal(
+		result.hostRss.samplingErrors.includes("synthetic browser detach failure"),
+		true,
+	);
+});
+
+test("fails closed when separate sessions report the same browser root", async () => {
+	const browser = () => ({
+		newBrowserCDPSession: async () => ({
+			send: async (method) => {
+				assert.equal(method, "SystemInfo.getProcessInfo");
+				return {
+					processInfo: [{ id: process.pid, type: "browser" }],
+				};
+			},
+			detach: async () => {},
+		}),
+	});
+	const telemetry = await startDownloadMemoryTelemetry({
+		browsers: [browser(), browser()],
+		expectedBrowserCount: 2,
+		reader: createRuntimeHeapPage(),
+		writer: createRuntimeHeapPage(),
+		downloadTimeoutMs: 60_000,
+		schedulingToleranceMs: 5_000,
+		postTransferSoakMs: 0,
+		samplingWindowBudgetMs: 65_000,
+	});
+	assert.equal(
+		telemetry
+			.snapshot()
+			.hostRss.samplingErrors.some((message) =>
+				message.includes("distinct browser root processes"),
+			),
+		true,
+	);
+	await telemetry.stop();
+});
+
+test("applies the Chromium process cap after cross-browser PID deduplication", async () => {
+	let detachedBrowserSessions = 0;
+	const browser = (processInfo) => ({
+		newBrowserCDPSession: async () => ({
+			send: async () => ({ processInfo }),
+			detach: async () => {
+				detachedBrowserSessions += 1;
+			},
+		}),
+	});
+	const telemetry = await startDownloadMemoryTelemetry({
+		browsers: [
+			browser(
+				Array.from({ length: 128 }, (_, index) => ({
+					id: index + 1,
+					type: index === 0 ? "browser" : "renderer",
+				})),
+			),
+			browser(
+				Array.from({ length: 129 }, (_, index) => ({
+					id: index + 129,
+					type: index === 0 ? "browser" : "renderer",
+				})),
+			),
+		],
+		expectedBrowserCount: 2,
+		reader: createRuntimeHeapPage(),
+		writer: createRuntimeHeapPage(),
+		downloadTimeoutMs: 60_000,
+		schedulingToleranceMs: 5_000,
+		postTransferSoakMs: 0,
+		samplingWindowBudgetMs: 65_000,
+	});
+	assert.equal(
+		telemetry
+			.snapshot()
+			.hostRss.samplingErrors.some((message) =>
+				message.includes("process count exceeds the telemetry cap"),
+			),
+		true,
+	);
+	await telemetry.stop();
+	assert.equal(detachedBrowserSessions, 2);
+});
+
+test("collects forced endpoint heaps and deduplicated multi-browser host samples", async () => {
 	let detachedPageSessions = 0;
 	let detachedBrowserSessions = 0;
+	const browserSessionSendCounts = [0, 0];
 	const page = (initialUsedBytes) => ({
 		context: () => ({
 			newCDPSession: async () => {
@@ -465,21 +649,24 @@ test("collects forced endpoint runtime-heap and attributed host samples", async 
 			},
 		}),
 	});
-	const browser = {
+	const browser = (index, processInfo) => ({
 		newBrowserCDPSession: async () => ({
 			send: async (method) => {
 				assert.equal(method, "SystemInfo.getProcessInfo");
-				return {
-					processInfo: [{ id: process.pid, type: "browser" }],
-				};
+				browserSessionSendCounts[index] += 1;
+				return { processInfo };
 			},
 			detach: async () => {
 				detachedBrowserSessions += 1;
 			},
 		}),
-	};
+	});
 	const telemetry = await startDownloadMemoryTelemetry({
-		browser,
+		browsers: [
+			browser(0, [{ id: process.pid, type: "browser" }]),
+			browser(1, [{ id: process.ppid, type: "browser" }]),
+		],
+		expectedBrowserCount: 2,
 		reader: page(100),
 		writer: page(200),
 		downloadTimeoutMs: 60_000,
@@ -500,6 +687,8 @@ test("collects forced endpoint runtime-heap and attributed host samples", async 
 	assert.equal(result.readerJsHeap.sampleCount, 3);
 	assert.equal(result.writerJsHeap.sampleCount, 3);
 	assert.equal(result.hostRss.sampleCount, 3);
+	assert.equal(result.hostRss.browserInstanceCount, 2);
+	assert.equal(result.hostRss.browserSessionCount, 2);
 	assert.equal(result.profile, "download-memory-v3");
 	assert.equal(result.operationTimeoutMs, DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS);
 	assert.equal(
@@ -529,6 +718,12 @@ test("collects forced endpoint runtime-heap and attributed host samples", async 
 		["initial", "manual", "terminal"],
 	);
 	assert.equal(result.hostRss.samples[0].browserBytes > 0, true);
+	assert.equal(result.hostRss.samples[0].browserInstanceCount, 2);
+	assert.equal(result.hostRss.samples[0].browserRootProcessCount, 2);
+	assert.equal(result.hostRss.samples[0].browserProcessCount, 2);
+	assert.deepEqual(Object.keys(result.hostRss.samples[0].browserRoleBytes), [
+		"browser",
+	]);
 	assert.equal(result.hostRss.samples[0].nodeExternalBytes >= 0, true);
 	assert.equal(result.hostRss.samples[0].nodeArrayBuffersBytes >= 0, true);
 	assert.equal(
@@ -557,7 +752,8 @@ test("collects forced endpoint runtime-heap and attributed host samples", async 
 			result.hostRss.samples[0].nodeBytes,
 	);
 	assert.equal(detachedPageSessions, 2);
-	assert.equal(detachedBrowserSessions, 1);
+	assert.equal(detachedBrowserSessions, 2);
+	assert.deepEqual(browserSessionSendCounts, [3, 3]);
 });
 
 test("records post-sampling CDP timeouts as cleanup warnings", async () => {
@@ -592,7 +788,8 @@ test("records post-sampling CDP timeouts as cleanup warnings", async () => {
 		}),
 	};
 	const telemetry = await startDownloadMemoryTelemetry({
-		browser,
+		browsers: [browser],
+		expectedBrowserCount: 1,
 		reader: page(true),
 		writer: page(false),
 		downloadTimeoutMs: 60_000,
@@ -657,7 +854,8 @@ test("bounds setup and detaches a CDP session created after its deadline", async
 		}),
 	};
 	const telemetry = await startDownloadMemoryTelemetry({
-		browser,
+		browsers: [browser],
+		expectedBrowserCount: 1,
 		reader,
 		writer,
 		downloadTimeoutMs: 60_000,

--- a/scripts/file-share/prepare-peerbit-examples.mjs
+++ b/scripts/file-share/prepare-peerbit-examples.mjs
@@ -9,6 +9,7 @@ import {
 	getFileShareConsumerRoots,
 	installPinnedExamplesDependencies,
 	parseArgs,
+	preflightBetterSqlite3Runtime,
 	prepareExamplesRepo,
 	repoRoot,
 	run,
@@ -26,7 +27,7 @@ Options:
   --dest <path>              output directory (default: ${defaultExamplesDest()})
   --peerbit-root <path>      peerbit workspace root (default: ${repoRoot})
   --integration-mode <mode>  one of none, link (default: link)
-  --local-packages <csv>     package names to link (default: ${defaultFileShareLocalPackages.join(",")}; use "all" for every installed local package)
+  --local-packages <csv>     publishable package names to link (default: ${defaultFileShareLocalPackages.join(",")}; use "all" for every publishable local package; private workspace packages are rejected)
   --fresh                    delete the destination before cloning
 `);
 };
@@ -66,6 +67,9 @@ const main = async () => {
 	if (integrationMode === "link") {
 		run("pnpm", ["install", "--frozen-lockfile"], {
 			cwd: prepared.peerbitRoot,
+		});
+		await preflightBetterSqlite3Runtime(prepared.peerbitRoot, {
+			packageNames: effectiveLocalPackageNames,
 		});
 		await cleanPeerbitBuildArtifacts({
 			peerbitRoot: prepared.peerbitRoot,

--- a/scripts/file-share/run-file-share-benchmark-matrix.mjs
+++ b/scripts/file-share/run-file-share-benchmark-matrix.mjs
@@ -12,6 +12,7 @@ import {
 	assertBenchmarkFileSize,
 	assertCoreBenchmarkUsesLocalApp,
 	createBenchmarkInvocation,
+	resolveBenchmarkBrowserStorageMode,
 	resolveBenchmarkDownloadSink,
 	resolveBenchmarkPreviewOptions,
 } from "./benchmark-invocation.mjs";
@@ -51,6 +52,7 @@ import {
 	defaultExamplesSource,
 	defaultFileShareLocalPackages,
 	parseArgs,
+	preflightBetterSqlite3Runtime,
 	repoRoot,
 	run,
 } from "./common.mjs";
@@ -73,6 +75,18 @@ const RUNNER_PATH = path.join(
 const DEFAULT_FIXTURE_SEED = "peerbit-file-share-benchmark-v1";
 
 const optionalNumber = (value) => (value == null ? undefined : Number(value));
+const optionalBoolean = (value, label) => {
+	if (value == null) {
+		return undefined;
+	}
+	if (value === "true") {
+		return true;
+	}
+	if (value === "false") {
+		return false;
+	}
+	throw new Error(`${label} must be exactly "true" or "false"`);
+};
 
 const runGit = (args, { cwd = repoRoot, capture = false } = {}) => {
 	console.log(`$ git ${args.join(" ")}`);
@@ -554,6 +568,7 @@ const runVariantBenchmark = async ({
 	uploadTimeoutMs,
 	downloadTimeoutMs,
 	downloadSink,
+	browserStorageMode,
 	postTransferSoakMs,
 	postUploadMonitorMs,
 	pollMs,
@@ -568,6 +583,7 @@ const runVariantBenchmark = async ({
 	readerLocalChunkTarget,
 	readerLocalChunkMaxOvershoot,
 	readerTerminalTopology,
+	readerPersistChunkReads,
 	protocol,
 	fixtureSeed,
 	enableVisibilityProbe,
@@ -624,6 +640,9 @@ const runVariantBenchmark = async ({
 			? ["--download-timeout-ms", String(downloadTimeoutMs)]
 			: []),
 		...(downloadSink != null ? ["--download-sink", downloadSink] : []),
+		...(browserStorageMode != null
+			? ["--browser-storage", browserStorageMode]
+			: []),
 		...(postTransferSoakMs != null
 			? ["--post-transfer-soak-ms", String(postTransferSoakMs)]
 			: []),
@@ -653,6 +672,9 @@ const runVariantBenchmark = async ({
 			: []),
 		...(readerTerminalTopology != null
 			? ["--reader-terminal-topology", readerTerminalTopology]
+			: []),
+		...(readerPersistChunkReads != null
+			? ["--reader-persist-chunk-reads", readerPersistChunkReads]
 			: []),
 		...(protocol ? ["--protocol", protocol] : []),
 		...(fixtureSeed ? ["--fixture-seed", fixtureSeed] : []),
@@ -771,6 +793,10 @@ const main = async () => {
 	const downloadSink = resolveBenchmarkDownloadSink(args["download-sink"], {
 		scenario,
 	});
+	const browserStorageMode = resolveBenchmarkBrowserStorageMode(
+		args["browser-storage"],
+		{ scenario },
+	);
 	const integrationMode = args["integration-mode"] ?? "link";
 	const localPackages =
 		args["local-packages"] ?? defaultFileShareLocalPackages.join(",");
@@ -792,6 +818,7 @@ const main = async () => {
 	const readerLocalChunkTarget = args["reader-local-chunk-target"];
 	const readerLocalChunkMaxOvershoot = args["reader-local-chunk-max-overshoot"];
 	const readerTerminalTopology = args["reader-terminal-topology"];
+	const readerPersistChunkReads = args["reader-persist-chunk-reads"];
 	const { protocol } = previewOptions;
 	const fixtureSeed = args["fixture-seed"];
 	const enableVisibilityProbe = Boolean(args["enable-visibility-probe"]);
@@ -846,6 +873,24 @@ const main = async () => {
 	if ((readerLocalChunkTarget == null) !== (readerTerminalTopology == null)) {
 		throw new Error(
 			"--reader-terminal-topology must be provided exactly when --reader-local-chunk-target is provided",
+		);
+	}
+	const parsedReaderPersistChunkReads = optionalBoolean(
+		readerPersistChunkReads,
+		"--reader-persist-chunk-reads",
+	);
+	if (parsedReaderPersistChunkReads != null && readerLocalChunkTarget == null) {
+		throw new Error(
+			"--reader-persist-chunk-reads requires --reader-local-chunk-target",
+		);
+	}
+	if (
+		parsedReaderPersistChunkReads === false &&
+		(Number(readerLocalChunkTarget) !== 0 ||
+			readerTerminalTopology !== "observer")
+	) {
+		throw new Error(
+			"--reader-persist-chunk-reads false requires --reader-local-chunk-target 0 and --reader-terminal-topology observer",
 		);
 	}
 	if (
@@ -930,6 +975,9 @@ const main = async () => {
 				`Variant ${variant} cannot run the file-share matrix; missing effective packages: ${missingRequiredPackages.join(", ") || "all packages"}`,
 			);
 		}
+		await preflightBetterSqlite3Runtime(peerbitRoot, {
+			packageNames: effectiveLocalPackageNames,
+		});
 		preparedVariants.set(variant, {
 			variant,
 			variantRef:
@@ -998,6 +1046,7 @@ const main = async () => {
 				uploadTimeoutMs,
 				downloadTimeoutMs,
 				downloadSink,
+				browserStorageMode,
 				postTransferSoakMs,
 				postUploadMonitorMs,
 				pollMs,
@@ -1009,6 +1058,7 @@ const main = async () => {
 				readerLocalChunkTarget,
 				readerLocalChunkMaxOvershoot,
 				readerTerminalTopology,
+				readerPersistChunkReads,
 				protocol,
 				fixtureSeed,
 				enableVisibilityProbe,
@@ -1045,6 +1095,7 @@ const main = async () => {
 				fileMb,
 				fixtureSeed: fixtureSeed ?? DEFAULT_FIXTURE_SEED,
 				downloadSink,
+				browserStorageMode,
 				uploadTimeoutMs: optionalNumber(uploadTimeoutMs),
 				downloadTimeoutMs: optionalNumber(downloadTimeoutMs),
 				postTransferSoakMs: optionalNumber(postTransferSoakMs),
@@ -1060,6 +1111,7 @@ const main = async () => {
 					readerLocalChunkMaxOvershoot,
 				),
 				readerTerminalTopology,
+				readerPersistChunkReads: parsedReaderPersistChunkReads,
 				baseUrl: null,
 				protocol,
 				viteMode: null,
@@ -1323,6 +1375,10 @@ const main = async () => {
 		readerLocalChunkMaxOvershoot:
 			optionalNumber(readerLocalChunkMaxOvershoot) ?? null,
 		readerTerminalTopology: readerTerminalTopology ?? null,
+		readerPersistChunkReads:
+			readerLocalChunkTarget == null
+				? null
+				: (parsedReaderPersistChunkReads ?? true),
 		readerLocalityCohorts: [
 			...new Set(
 				allResults
@@ -1335,6 +1391,7 @@ const main = async () => {
 		modes,
 		scenario,
 		downloadSink,
+		browserStorageMode,
 		integrationMode,
 		localPackages,
 		requestedLocalPackageNames:

--- a/scripts/file-share/run-file-share-benchmark.mjs
+++ b/scripts/file-share/run-file-share-benchmark.mjs
@@ -14,6 +14,7 @@ import {
 	createBenchmarkInvocation,
 	createNonceIsolatedResultPath,
 	createPlaywrightBenchmarkEnvironment,
+	resolveBenchmarkBrowserStorageMode,
 	resolveBenchmarkDownloadSink,
 	resolveBenchmarkPreviewOptions,
 } from "./benchmark-invocation.mjs";
@@ -52,6 +53,7 @@ import {
 	getFileShareConsumerRoots,
 	installPinnedExamplesDependencies,
 	parseArgs,
+	preflightBetterSqlite3Runtime,
 	prepareExamplesRepo,
 	repoRoot,
 	run,
@@ -133,10 +135,13 @@ const DROP_LOCALITY_PRELOAD_DEADLINE_MARKER =
 	"/* peerbit-benchmark-locality-preload-aggregate-deadline */";
 const DROP_LOCALITY_EXACT_MANIFEST_MARKER =
 	"/* peerbit-benchmark-locality-exact-manifest-import */";
-const localityPreloadHookImplementation = `            preloadLocalChunkPrefix: async (fileName, target, timeoutMs) => {
+const DROP_READER_PERSISTENCE_POLICY_MARKER =
+	"/* peerbit-benchmark-reader-persistence-policy */";
+const localityPreloadHookImplementation = `            preloadLocalChunkPrefix: async (fileName, target, timeoutMs, persistChunkReads) => {
                 ${DROP_LOCALITY_HOOK_MARKER}
                 ${DROP_LOCALITY_PRELOAD_DEADLINE_MARKER}
 				${DROP_LOCALITY_EXACT_MANIFEST_MARKER}
+				${DROP_READER_PERSISTENCE_POLICY_MARKER}
                 if (!program || program.closed) {
                     throw new Error("Program is not ready");
                 }
@@ -164,6 +169,16 @@ const localityPreloadHookImplementation = `            preloadLocalChunkPrefix: 
                         "Locality preload timeout must be a positive safe integer"
                     );
                 }
+				if (typeof persistChunkReads !== "boolean") {
+					throw new Error(
+						"Reader persistence policy must be an explicit boolean"
+					);
+				}
+				if (!persistChunkReads && target !== 0) {
+					throw new Error(
+						"Transient reader locality requires a zero-chunk prefix"
+					);
+				}
 				const manifestEntryHeads = (file as any).chunkEntryHeads;
 				if (
 					!Array.isArray(manifestEntryHeads) ||
@@ -177,7 +192,7 @@ const localityPreloadHookImplementation = `            preloadLocalChunkPrefix: 
 						"Locality preload requires one unique manifest entry head per chunk"
 					);
 				}
-                program.persistChunkReads = true;
+                program.persistChunkReads = persistChunkReads;
                 const startedAt = Date.now();
                 const aggregateTimeoutMs = target > 0 ? timeoutMs : null;
                 const aggregateDeadlineAt = target > 0
@@ -400,6 +415,7 @@ export const instrumentFileShareFrontend = async (
 			(contents.includes(DROP_LOCALITY_HOOK_MARKER) &&
 				contents.includes(DROP_LOCALITY_PRELOAD_DEADLINE_MARKER) &&
 				contents.includes(DROP_LOCALITY_EXACT_MANIFEST_MARKER) &&
+				contents.includes(DROP_READER_PERSISTENCE_POLICY_MARKER) &&
 				contents.includes(DROP_LOCALITY_TOPOLOGY_MARKER) &&
 				contents.includes(DROP_LOCALITY_INDEXED_SEARCH_MARKER)))
 	) {
@@ -567,13 +583,19 @@ export const instrumentFileShareFrontend = async (
 		requireLocalityHook &&
 		contents.includes(DROP_LOCALITY_HOOK_MARKER) &&
 		(!contents.includes(DROP_LOCALITY_PRELOAD_DEADLINE_MARKER) ||
-			!contents.includes(DROP_LOCALITY_EXACT_MANIFEST_MARKER))
+			!contents.includes(DROP_LOCALITY_EXACT_MANIFEST_MARKER) ||
+			!contents.includes(DROP_READER_PERSISTENCE_POLICY_MARKER))
 	) {
 		const preloadHookAnchor =
 			"            preloadLocalChunkPrefix: async (fileName, target, timeoutMs) => {";
+		const currentPreloadHookAnchor =
+			"            preloadLocalChunkPrefix: async (fileName, target, timeoutMs, persistChunkReads) => {";
 		const observationHookAnchor =
 			"            getLocalChunkPrefixObservation: async (fileName) => {";
-		const preloadHookStart = contents.indexOf(preloadHookAnchor);
+		const preloadHookStart = Math.max(
+			contents.indexOf(preloadHookAnchor),
+			contents.indexOf(currentPreloadHookAnchor),
+		);
 		const observationHookStart = contents.indexOf(
 			observationHookAnchor,
 			preloadHookStart + preloadHookAnchor.length,
@@ -584,6 +606,10 @@ export const instrumentFileShareFrontend = async (
 			);
 		}
 		contents = `${contents.slice(0, preloadHookStart)}${localityPreloadHookImplementation}\n${contents.slice(observationHookStart)}`;
+		contents = contents.replace(
+			"preloadLocalChunkPrefix: (fileName: string, target: number, timeoutMs: number) => Promise<Record<string, unknown>>;",
+			"preloadLocalChunkPrefix: (fileName: string, target: number, timeoutMs: number, persistChunkReads: boolean) => Promise<Record<string, unknown>>;",
+		);
 	}
 	if (
 		requireLocalityHook &&
@@ -667,7 +693,7 @@ ${topologyAnchor}`,
 		}
 		contents = contents.replace(
 			typeAnchor,
-			`${typeAnchor}\n                preloadLocalChunkPrefix: (fileName: string, target: number, timeoutMs: number) => Promise<Record<string, unknown>>;\n                getLocalChunkPrefixObservation: (fileName: string) => Promise<Record<string, unknown>>;`,
+			`${typeAnchor}\n                preloadLocalChunkPrefix: (fileName: string, target: number, timeoutMs: number, persistChunkReads: boolean) => Promise<Record<string, unknown>>;\n                getLocalChunkPrefixObservation: (fileName: string) => Promise<Record<string, unknown>>;`,
 		);
 		contents = contents.replace(
 			implementationAnchor,
@@ -996,6 +1022,19 @@ const parseNonNegativeInteger = (value, label) => {
 const parseOptionalPositiveInteger = (value, label) =>
 	value == null ? undefined : parsePositiveInteger(value, label);
 
+const parseOptionalBoolean = (value, label) => {
+	if (value == null) {
+		return undefined;
+	}
+	if (value === "true") {
+		return true;
+	}
+	if (value === "false") {
+		return false;
+	}
+	throw new Error(`${label} must be exactly "true" or "false"`);
+};
+
 const writeJsonAtomic = async (filePath, value) => {
 	await fsp.mkdir(path.dirname(filePath), { recursive: true });
 	const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
@@ -1066,6 +1105,10 @@ const main = async () => {
 	const downloadSink = resolveBenchmarkDownloadSink(args["download-sink"], {
 		scenario,
 	});
+	const browserStorageMode = resolveBenchmarkBrowserStorageMode(
+		args["browser-storage"],
+		{ scenario },
+	);
 	const network = args.network ?? "local";
 	const uploadTimeoutMs = parseOptionalPositiveInteger(
 		args["upload-timeout-ms"],
@@ -1115,6 +1158,10 @@ const main = async () => {
 		args["reader-terminal-topology"] == null
 			? null
 			: String(args["reader-terminal-topology"]);
+	const readerPersistChunkReads = parseOptionalBoolean(
+		args["reader-persist-chunk-reads"],
+		"--reader-persist-chunk-reads",
+	);
 	const examplesSource = args.source ?? defaultExamplesSource();
 	const fixtureSeed = args["fixture-seed"];
 	const resolvedFixtureSeed = fixtureSeed ?? "peerbit-file-share-benchmark-v1";
@@ -1182,6 +1229,19 @@ const main = async () => {
 			"--reader-terminal-topology must be provided exactly when --reader-local-chunk-target is provided",
 		);
 	}
+	if (readerPersistChunkReads != null && readerLocalChunkTarget == null) {
+		throw new Error(
+			"--reader-persist-chunk-reads requires --reader-local-chunk-target",
+		);
+	}
+	if (
+		readerPersistChunkReads === false &&
+		(readerLocalChunkTarget !== 0 || readerTerminalTopology !== "observer")
+	) {
+		throw new Error(
+			"--reader-persist-chunk-reads false requires --reader-local-chunk-target 0 and --reader-terminal-topology observer",
+		);
+	}
 	if (
 		readerTerminalTopology != null &&
 		!READER_TERMINAL_TOPOLOGIES.includes(readerTerminalTopology)
@@ -1224,6 +1284,9 @@ const main = async () => {
 	const { protocol, viteMode, viteConfig } = previewOptions;
 	if (integrationMode === "link") {
 		run("pnpm", ["install", "--frozen-lockfile"], { cwd: peerbitRoot });
+		await preflightBetterSqlite3Runtime(peerbitRoot, {
+			packageNames: effectiveLocalPackageNames,
+		});
 		await cleanPeerbitBuildArtifacts({
 			peerbitRoot,
 			packageNames: effectiveLocalPackageNames,
@@ -1355,6 +1418,7 @@ const main = async () => {
 				fileMb,
 				fixtureSeed: resolvedFixtureSeed,
 				downloadSink,
+				browserStorageMode,
 				uploadTimeoutMs,
 				downloadTimeoutMs,
 				postTransferSoakMs,
@@ -1368,6 +1432,7 @@ const main = async () => {
 				readerLocalChunkTarget,
 				readerLocalChunkMaxOvershoot,
 				readerTerminalTopology,
+				readerPersistChunkReads,
 				baseUrl,
 				protocol,
 				viteMode,
@@ -1573,6 +1638,14 @@ const main = async () => {
 				result.readerTerminalTopology ??
 				result.invocation?.readerTerminalTopology ??
 				null,
+			readerPersistChunkReads:
+				result.readerPersistChunkReads ??
+				result.invocation?.readerPersistChunkReads ??
+				null,
+			browserStorageMode:
+				result.browserStorageMode ??
+				result.invocation?.browserStorageMode ??
+				null,
 			readerLocalChunkBlockCount: result.readerLocalChunkBlockCount ?? null,
 			readerLocalChunkIndexRowCount:
 				result.readerLocalChunkIndexRowCount ?? null,
@@ -1628,6 +1701,7 @@ const main = async () => {
 		frontendRoot,
 		scenario,
 		downloadSink,
+		browserStorageMode,
 		integrationMode,
 		localPackageNames: effectiveLocalPackageNames,
 		network,
@@ -1635,6 +1709,8 @@ const main = async () => {
 		readerLocalChunkTarget: readerLocalChunkTarget ?? null,
 		readerLocalChunkMaxOvershoot: readerLocalChunkMaxOvershoot ?? null,
 		readerTerminalTopology,
+		readerPersistChunkReads:
+			readerLocalChunkTarget == null ? null : (readerPersistChunkReads ?? true),
 		readerLocalityCohorts:
 			scenario === "upload"
 				? aggregateRows

--- a/scripts/file-share/template-contract.test.mjs
+++ b/scripts/file-share/template-contract.test.mjs
@@ -17,14 +17,14 @@ const templates = [
 ];
 
 for (const name of templates) {
-	test(`${name} emits the atomic v10 result envelope`, async () => {
+	test(`${name} emits the atomic v11 result envelope`, async () => {
 		const contents = await readFile(
 			path.join(repoRoot, "scripts", "file-share", "templates", name),
 			"utf8",
 		);
 		for (const required of [
 			'id: "peerbit-file-share-benchmark"',
-			"version: 10",
+			"version: 11",
 			"PW_BENCHMARK_RUN_NONCE",
 			"PW_BENCHMARK_INVOCATION",
 			"PW_BENCHMARK_PROVENANCE",
@@ -202,6 +202,8 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 		"PW_READER_LOCAL_CHUNK_TARGET",
 		"PW_READER_LOCAL_CHUNK_MAX_OVERSHOOT",
 		"PW_READER_TERMINAL_TOPOLOGY",
+		"PW_READER_PERSIST_CHUNK_READS",
+		"PW_BROWSER_STORAGE_MODE",
 		"LOCALITY_CONTROL_POLL_MS",
 		"seedReplicationRole",
 		"openWithSeededReplicationRole",
@@ -297,22 +299,101 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 	}
 	assert.match(
 		contents,
+		/const launchPersistentBenchmarkBrowsers = async \(\) => \{[\s\S]*?try \{\s*writerProfileDir = await mkdtemp\([\s\S]*?readerProfileDir = await mkdtemp\([\s\S]*?\} catch \(error\) \{[\s\S]*?await cleanupPersistentBenchmarkBrowsers\(/,
+		"persistent profile creation must be guarded from the first temporary directory onward",
+	);
+	const persistentBrowserCleanup = contents.slice(
+		contents.indexOf("const cleanupPersistentBenchmarkBrowsers ="),
+		contents.indexOf("const launchPersistentBenchmarkBrowsers ="),
+	);
+	const persistentContextCloseIndex = persistentBrowserCleanup.indexOf(
+		"contexts.map((context) => context.close())",
+	);
+	const persistentProfileRemoveIndex = persistentBrowserCleanup.indexOf(
+		"profileDirs.map((profileDir) =>",
+	);
+	const persistentBrowserCloseIndex = persistentBrowserCleanup.indexOf(
+		"fallbackBrowsers.map((browser)",
+	);
+	const persistentCleanupFailureIndex = persistentBrowserCleanup.indexOf(
+		"throwCleanupFailures(",
+	);
+	assert.ok(
+		persistentContextCloseIndex !== -1 &&
+			persistentBrowserCloseIndex !== -1 &&
+			persistentProfileRemoveIndex !== -1 &&
+			persistentCleanupFailureIndex !== -1 &&
+			persistentContextCloseIndex < persistentBrowserCloseIndex &&
+			persistentBrowserCloseIndex < persistentProfileRemoveIndex &&
+			persistentProfileRemoveIndex < persistentCleanupFailureIndex,
+		"persistent cleanup must close contexts, attempt browser fallback, remove profiles, and then surface every failure",
+	);
+	const pageAcquisitionOwnership = contents.slice(
+		contents.indexOf("\t\tlet writer: Page;"),
+		contents.indexOf("\t\tconst errors: string[]"),
+	);
+	for (const required of [
+		"writerContext.newPage()",
+		"readerContext.newPage()",
+		"Promise.allSettled([",
+		"cleanupPersistentBenchmarkBrowsers(browserPair)",
+		"bootstrap?.stop()",
+		"throw new AggregateError(",
+	]) {
+		assert.ok(
+			pageAcquisitionOwnership.includes(required),
+			`page acquisition ownership is missing ${required}`,
+		);
+	}
+	assert.equal(
+		pageAcquisitionOwnership.includes("bootstrap?.stop().catch(() => {})"),
+		false,
+		"page acquisition must not swallow bootstrap cleanup failures",
+	);
+	const finalOwnershipCleanup = contents.slice(
+		contents.lastIndexOf("\t\t} finally {"),
+		contents.lastIndexOf("\t});"),
+	);
+	for (const required of [
+		"throw new AggregateError(",
+		"benchmarkFailure",
+		"Promise.allSettled([",
+		"cleanupPersistentBenchmarkBrowsers(browserPair)",
+		"bootstrap?.stop()",
+	]) {
+		assert.ok(
+			finalOwnershipCleanup.includes(required),
+			`final ownership cleanup is missing ${required}`,
+		);
+	}
+	assert.match(
+		contents,
 		/const terminalSeederSnapshot = await snapshot\([\s\S]*?noteSeederDrop\(terminalSeederSnapshot\);[\s\S]*?if \(unexpectedSeederDrop\)/,
 		"the final numeric seeder snapshot must participate in the v9 drop policy before acceptance",
 	);
 	const lateFailureCatch = contents.slice(
 		contents.lastIndexOf("\t\t} catch (error: any) {"),
 	);
-	assert.ok(
-		lateFailureCatch.includes(
-			"\n\t\t\t\tintegrity,\n\t\t\t\tintegrityVerified,\n\t\t\t\tintegrityVerifiedAt,",
-		),
+	assert.match(
+		lateFailureCatch,
+		/integrity,\s+integrityVerified,\s+integrityVerifiedAt,/,
 		"late failures must preserve completed integrity evidence and its gate timestamp",
 	);
 	assert.ok(
 		!lateFailureCatch.includes("integrityVerified: false"),
 		"the catch path must not overwrite completed integrity state",
 	);
+	for (const required of [
+		"catch (failureHandlingError)",
+		"[error, failureHandlingError]",
+		"Benchmark execution and failed-result handling both failed",
+		"throw benchmarkFailure",
+	]) {
+		assert.ok(
+			lateFailureCatch.includes(required),
+			`late failure handling must preserve ${required}`,
+		);
+	}
 	assert.ok(
 		lateFailureCatch.includes("readerLocalityControl,") &&
 			!lateFailureCatch.includes("preTimedReadTopologyObservations = []") &&
@@ -326,18 +407,18 @@ test("upload probe fails closed and records bounded scheduling tolerances", asyn
 	);
 	assert.match(
 		contents,
-		/hooks\.preloadLocalChunkPrefix\(\s*expectedFileName,\s*requestedTarget,\s*timeout,\s*\)/,
-		"the nonzero locality preload must pass the requested download timeout in the hook's third argument",
+		/hooks\.preloadLocalChunkPrefix\(\s*expectedFileName,\s*requestedTarget,\s*timeout,\s*persist,\s*\)/,
+		"the locality preload must pass the requested download timeout and persistence policy",
 	);
 	assert.match(
 		contents,
-		/const preloadLocalChunkPrefix = async \(\s*page: Page,\s*fileName: string,\s*target: number,\s*timeoutMs: number,\s*\)/,
-		"the Playwright locality helper must keep page, file, target, and timeout in a fixed order",
+		/const preloadLocalChunkPrefix = async \(\s*page: Page,\s*fileName: string,\s*target: number,\s*timeoutMs: number,\s*persistChunkReads: boolean,\s*\)/,
+		"the Playwright locality helper must keep page, file, target, timeout, and persistence in a fixed order",
 	);
 	assert.match(
 		contents,
-		/preloadLocalChunkPrefix\(\s*reader,\s*fileName,\s*READER_LOCAL_CHUNK_TARGET,\s*DOWNLOAD_TIMEOUT_MS,\s*\)/,
-		"the nonzero locality call site must pass the configured download timeout after its target",
+		/preloadLocalChunkPrefix\(\s*reader,\s*fileName,\s*READER_LOCAL_CHUNK_TARGET,\s*DOWNLOAD_TIMEOUT_MS,\s*READER_PERSIST_CHUNK_READS!,\s*\)/,
+		"the locality call site must pass the configured download timeout and persistence policy",
 	);
 	assert.ok(
 		contents.includes(
@@ -811,6 +892,7 @@ test("download memory support is bounded, serial, and cleanup-safe", async () =>
 		"DOWNLOAD_MEMORY_TERMINAL_ALLOWANCE_MS = 30_000",
 		"DOWNLOAD_MEMORY_MAX_SAMPLES_PER_SERIES = 4_096",
 		"DOWNLOAD_MEMORY_MAX_BROWSER_PROCESSES = 256",
+		"DOWNLOAD_MEMORY_MAX_BROWSERS = 2",
 		"DOWNLOAD_MEMORY_MAX_SAMPLING_ERRORS = 16",
 		"DOWNLOAD_MEMORY_MAX_CLEANUP_WARNINGS = 16",
 		"DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH = 512",
@@ -835,6 +917,11 @@ test("download memory support is bounded, serial, and cleanup-safe", async () =>
 		"startEmbedderHeapUsedBytes",
 		"peakBackingStorageBytes",
 		"newBrowserCDPSession()",
+		"normalizeBrowsers",
+		"mergeChromiumProcessInfo",
+		"requires unique browser instances",
+		"conflicting process types",
+		"Promise.allSettled",
 		'"Browser RSS CDP session creation"',
 		"SystemInfo.getProcessInfo",
 		'"ps"',
@@ -876,7 +963,7 @@ test("post-transfer soak is invocation-bound and forwarded by both runners", asy
 			),
 		);
 	for (const required of [
-		"version: 5",
+		"version: 6",
 		"postTransferSoakMs: 60_000",
 		"postTransferSoakMs ??",
 		'scenario === "upload" ? DEFAULTS.postTransferSoakMs : 0',
@@ -911,7 +998,7 @@ test("post-transfer soak is invocation-bound and forwarded by both runners", asy
 			`${label} template does not check the invocation soak`,
 		);
 		assert.ok(
-			contents.includes("?.version !== 5"),
+			contents.includes("?.version !== 6"),
 			`${label} template does not require invocation schema v5`,
 		);
 	}

--- a/scripts/file-share/templates/download-memory-telemetry.mjs
+++ b/scripts/file-share/templates/download-memory-telemetry.mjs
@@ -20,6 +20,7 @@ export const DOWNLOAD_MEMORY_MAX_CLEANUP_WARNINGS = 16;
 export const DOWNLOAD_MEMORY_MAX_ERROR_MESSAGE_LENGTH = 512;
 export const DOWNLOAD_MEMORY_MAX_BROWSER_ROLES = 32;
 export const DOWNLOAD_MEMORY_MAX_BROWSER_PROCESSES = 256;
+export const DOWNLOAD_MEMORY_MAX_BROWSERS = 2;
 export const DOWNLOAD_MEMORY_MAX_BROWSER_ROLE_NAME_LENGTH = 128;
 export const DOWNLOAD_MEMORY_HOST_ATTRIBUTION =
 	"aggregate-rss-with-chromium-process-role-groups";
@@ -667,7 +668,10 @@ const readProcessRssBytes = async (processIds) => {
 	return processBytes;
 };
 
-const summarizeHostRss = (state) => {
+const summarizeHostRss = (
+	state,
+	{ browserInstanceCount, browserSessionCount },
+) => {
 	const first = state.samples[0] ?? null;
 	const last = state.samples.at(-1) ?? null;
 	const peak = (name) =>
@@ -691,6 +695,8 @@ const summarizeHostRss = (state) => {
 		attribution: DOWNLOAD_MEMORY_HOST_ATTRIBUTION,
 		attributionLimitations: DOWNLOAD_MEMORY_HOST_ATTRIBUTION_LIMITATIONS,
 		unit: "bytes",
+		browserInstanceCount,
+		browserSessionCount,
 		sampleIntervalMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
 		startedAt: state.startedAt,
 		finishedAt: state.finishedAt,
@@ -734,31 +740,143 @@ const summarizeHostRss = (state) => {
 	};
 };
 
+const normalizeBrowsers = (browsers, expectedBrowserCount) => {
+	if (
+		!Number.isSafeInteger(expectedBrowserCount) ||
+		expectedBrowserCount <= 0 ||
+		expectedBrowserCount > DOWNLOAD_MEMORY_MAX_BROWSERS ||
+		!Array.isArray(browsers) ||
+		browsers.length !== expectedBrowserCount
+	) {
+		throw new Error(
+			`Download memory telemetry requires exactly ${expectedBrowserCount} browser${expectedBrowserCount === 1 ? "" : "s"}`,
+		);
+	}
+	const uniqueBrowsers = new Set();
+	for (const browser of browsers) {
+		if (
+			browser == null ||
+			(typeof browser !== "object" && typeof browser !== "function") ||
+			typeof browser.newBrowserCDPSession !== "function"
+		) {
+			throw new Error("Download memory telemetry received an invalid browser");
+		}
+		if (uniqueBrowsers.has(browser)) {
+			throw new Error(
+				"Download memory telemetry requires unique browser instances",
+			);
+		}
+		uniqueBrowsers.add(browser);
+	}
+	return [...browsers];
+};
+
+const mergeChromiumProcessInfo = (responses) => {
+	const processInfoById = new Map();
+	const browserRootProcessIds = new Set();
+	for (const response of responses) {
+		if (!Array.isArray(response?.processInfo)) {
+			throw new Error("Chromium returned invalid process information");
+		}
+		const responseBrowserRootProcessIds = new Set();
+		for (const processEntry of response.processInfo) {
+			if (
+				processEntry == null ||
+				typeof processEntry !== "object" ||
+				Array.isArray(processEntry)
+			) {
+				throw new Error("Chromium returned an invalid process entry");
+			}
+			const processId = Number(processEntry.id);
+			if (!Number.isSafeInteger(processId) || processId <= 0) {
+				continue;
+			}
+			const role = String(processEntry.type || "unknown");
+			if (
+				role.length === 0 ||
+				role.length > DOWNLOAD_MEMORY_MAX_BROWSER_ROLE_NAME_LENGTH ||
+				!/^[\x20-\x7e]+$/.test(role)
+			) {
+				throw new Error("Chromium exposed an invalid process role name");
+			}
+			const existing = processInfoById.get(processId);
+			if (existing !== undefined && existing.type !== role) {
+				throw new Error(
+					`Chromium PID ${processId} has conflicting process types`,
+				);
+			}
+			if (existing === undefined) {
+				processInfoById.set(processId, { id: processId, type: role });
+				if (processInfoById.size > DOWNLOAD_MEMORY_MAX_BROWSER_PROCESSES) {
+					throw new Error("Chromium process count exceeds the telemetry cap");
+				}
+			}
+			if (role === "browser") {
+				responseBrowserRootProcessIds.add(processId);
+			}
+		}
+		if (responseBrowserRootProcessIds.size !== 1) {
+			throw new Error(
+				"Each Chromium CDP session must expose exactly one browser root process",
+			);
+		}
+		const [browserRootProcessId] = responseBrowserRootProcessIds;
+		if (browserRootProcessIds.has(browserRootProcessId)) {
+			throw new Error(
+				"Chromium CDP sessions must expose distinct browser root processes",
+			);
+		}
+		browserRootProcessIds.add(browserRootProcessId);
+	}
+	return {
+		processInfo: [...processInfoById.values()],
+		browserRootProcessIds: [...browserRootProcessIds],
+	};
+};
+
 const startHostRssSampler = async ({
-	browser,
+	browsers,
 	maxSamples,
 	operationTimeoutMs,
 	cleanupTimeoutMs,
 }) => {
-	let session;
+	let sessions = [];
 	let setupError;
-	try {
-		session = await withDownloadMemoryOperationDeadline(
-			browser.newBrowserCDPSession(),
-			"Browser RSS CDP session creation",
-			operationTimeoutMs,
-			{
-				onLateResolution: async (lateSession) => {
-					await withDownloadMemoryOperationDeadline(
-						lateSession.detach(),
-						"Late browser RSS CDP detach",
-						operationTimeoutMs,
-					);
-				},
-			},
+	const setupResults = await Promise.allSettled(
+		browsers.map(
+			async (browser) =>
+				await withDownloadMemoryOperationDeadline(
+					Promise.resolve().then(() => browser.newBrowserCDPSession()),
+					"Browser RSS CDP session creation",
+					operationTimeoutMs,
+					{
+						onLateResolution: async (lateSession) => {
+							await withDownloadMemoryOperationDeadline(
+								Promise.resolve().then(() => lateSession.detach()),
+								"Late browser RSS CDP detach",
+								operationTimeoutMs,
+							);
+						},
+					},
+				),
+		),
+	);
+	const setupErrors = [];
+	for (const result of setupResults) {
+		if (result.status === "fulfilled") {
+			sessions.push(result.value);
+		} else {
+			setupErrors.push(result.reason);
+		}
+	}
+	const browserSessionCount = sessions.length;
+	if (setupErrors.length === 1) {
+		[setupError] = setupErrors;
+	} else if (setupErrors.length > 1) {
+		setupError = new AggregateError(
+			setupErrors,
+			setupErrors.map(boundedErrorMessage).join("; "),
 		);
-	} catch (error) {
-		setupError = error;
 	}
 	const sampler = await startBoundedSerialSampler({
 		intervalMs: DOWNLOAD_MEMORY_SAMPLE_INTERVAL_MS,
@@ -769,23 +887,30 @@ const startHostRssSampler = async ({
 			if (setupError) {
 				throw setupError;
 			}
-			if (!session) {
-				throw new Error("Browser RSS CDP session is unavailable");
+			if (sessions.length !== browsers.length) {
+				throw new Error("Browser RSS CDP sessions are unavailable");
 			}
-			const { processInfo } = await session.send("SystemInfo.getProcessInfo");
-			const processIds = [
-				...new Set(
-					processInfo
-						.map((process) => Number(process.id))
-						.filter(
-							(processId) => Number.isSafeInteger(processId) && processId > 0,
-						),
+			const { processInfo, browserRootProcessIds } = mergeChromiumProcessInfo(
+				await Promise.all(
+					sessions.map((session) => session.send("SystemInfo.getProcessInfo")),
 				),
-			];
-			if (processIds.length > DOWNLOAD_MEMORY_MAX_BROWSER_PROCESSES) {
-				throw new Error("Chromium process count exceeds the telemetry cap");
+			);
+			if (browserRootProcessIds.length !== browsers.length) {
+				throw new Error(
+					"Browser RSS telemetry did not capture every browser root process",
+				);
 			}
+			const processIds = processInfo.map((processEntry) => processEntry.id);
 			const browserProcessBytes = await readProcessRssBytes(processIds);
+			if (
+				!browserRootProcessIds.every((processId) =>
+					browserProcessBytes.has(processId),
+				)
+			) {
+				throw new Error(
+					"Browser RSS telemetry is missing a browser root process",
+				);
+			}
 			const nodeMemory = process.memoryUsage();
 			const nodeBytes = nodeMemory.rss;
 			const nodeExternalBytes = nodeMemory.external;
@@ -804,18 +929,11 @@ const startHostRssSampler = async ({
 			}
 			const browserRoleBytes = {};
 			for (const processEntry of processInfo) {
-				const bytes = browserProcessBytes.get(Number(processEntry.id));
+				const bytes = browserProcessBytes.get(processEntry.id);
 				if (bytes == null) {
 					continue;
 				}
-				const role = String(processEntry.type || "unknown");
-				if (
-					role.length === 0 ||
-					role.length > DOWNLOAD_MEMORY_MAX_BROWSER_ROLE_NAME_LENGTH ||
-					!/^[\x20-\x7e]+$/.test(role)
-				) {
-					throw new Error("Chromium exposed an invalid process role name");
-				}
+				const role = processEntry.type;
 				browserRoleBytes[role] = (browserRoleBytes[role] ?? 0) + bytes;
 			}
 			if (
@@ -835,6 +953,8 @@ const startHostRssSampler = async ({
 				throw new Error("Host RSS totals exceed the safe byte range");
 			}
 			return {
+				browserInstanceCount: browsers.length,
+				browserRootProcessCount: browserRootProcessIds.length,
 				browserBytes,
 				nodeBytes,
 				nodeExternalBytes,
@@ -845,30 +965,49 @@ const startHostRssSampler = async ({
 			};
 		},
 		cleanup: async () => {
-			if (session) {
-				try {
-					await withDownloadMemoryOperationDeadline(
-						session.detach(),
-						"Browser RSS CDP detach",
-						operationTimeoutMs,
-					);
-				} finally {
-					session = undefined;
-				}
+			const sessionsToDetach = sessions;
+			sessions = [];
+			const detachResults = await Promise.allSettled(
+				sessionsToDetach.map(
+					async (session) =>
+						await withDownloadMemoryOperationDeadline(
+							Promise.resolve().then(() => session.detach()),
+							"Browser RSS CDP detach",
+							operationTimeoutMs,
+						),
+				),
+			);
+			const detachErrors = detachResults
+				.filter((result) => result.status === "rejected")
+				.map((result) => result.reason);
+			if (detachErrors.length === 1) {
+				throw detachErrors[0];
+			}
+			if (detachErrors.length > 1) {
+				throw new AggregateError(
+					detachErrors,
+					detachErrors.map(boundedErrorMessage).join("; "),
+				);
 			}
 		},
 	});
+	const summarize = (state) =>
+		summarizeHostRss(state, {
+			browserInstanceCount: browsers.length,
+			browserSessionCount,
+		});
 	return {
-		snapshot: () => summarizeHostRss(sampler.snapshot()),
-		sampleNow: async () => summarizeHostRss(await sampler.sampleNow()),
-		stopSampling: async () => summarizeHostRss(await sampler.stopSampling()),
-		cleanup: async () => summarizeHostRss(await sampler.cleanup()),
-		stop: async () => summarizeHostRss(await sampler.stop()),
+		snapshot: () => summarize(sampler.snapshot()),
+		sampleNow: async () => summarize(await sampler.sampleNow()),
+		stopSampling: async () => summarize(await sampler.stopSampling()),
+		cleanup: async () => summarize(await sampler.cleanup()),
+		stop: async () => summarize(await sampler.stop()),
 	};
 };
 
 export const startDownloadMemoryTelemetry = async ({
-	browser,
+	browsers,
+	expectedBrowserCount,
 	reader,
 	writer,
 	downloadTimeoutMs,
@@ -878,6 +1017,7 @@ export const startDownloadMemoryTelemetry = async ({
 	operationTimeoutMs = DOWNLOAD_MEMORY_OPERATION_TIMEOUT_MS,
 	cleanupTimeoutMs = DOWNLOAD_MEMORY_CLEANUP_TIMEOUT_MS,
 }) => {
+	const normalizedBrowsers = normalizeBrowsers(browsers, expectedBrowserCount);
 	const maxSamplesPerSeries = calculateDownloadMemoryMaxSamples({
 		samplingWindowBudgetMs,
 	});
@@ -901,7 +1041,7 @@ export const startDownloadMemoryTelemetry = async ({
 			cleanupTimeoutMs,
 		}),
 		startHostRssSampler({
-			browser,
+			browsers: normalizedBrowsers,
 			maxSamples: maxSamplesPerSeries,
 			operationTimeoutMs,
 			cleanupTimeoutMs,

--- a/scripts/file-share/templates/seeder-probe.e2e.spec.ts
+++ b/scripts/file-share/templates/seeder-probe.e2e.spec.ts
@@ -27,7 +27,7 @@ const EFFECTIVE_SAMPLE_INTERVAL_MS = Math.max(
 );
 const RESULT_SCHEMA = {
 	id: "peerbit-file-share-benchmark",
-	version: 10,
+	version: 11,
 } as const;
 const RUN_NONCE = process.env.PW_BENCHMARK_RUN_NONCE;
 const parseJsonEnvironment = (name: string) => {
@@ -84,7 +84,7 @@ if (POST_TRANSFER_SOAK_MS !== 0) {
 if (
 	(INVOCATION.schema as Record<string, unknown> | undefined)?.id !==
 		"peerbit-file-share-benchmark-invocation" ||
-	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 5
+	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 6
 ) {
 	throw new Error("Unsupported PW_BENCHMARK_INVOCATION schema");
 }
@@ -100,6 +100,8 @@ const expectedInvocationValues: Record<string, unknown> = {
 	readerLocalChunkTarget: READER_LOCAL_CHUNK_TARGET,
 	readerLocalChunkMaxOvershoot: READER_LOCAL_CHUNK_MAX_OVERSHOOT,
 	readerTerminalTopology: READER_TERMINAL_TOPOLOGY,
+	readerPersistChunkReads: null,
+	browserStorageMode: process.env.PW_BROWSER_STORAGE_MODE || null,
 	baseUrl: process.env.PW_BASE_URL || null,
 	protocol: process.env.PW_PROTOCOL || null,
 	viteMode: process.env.PW_VITE_MODE || null,

--- a/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
+++ b/scripts/file-share/templates/upload-benchmark.local.e2e.spec.ts
@@ -1,7 +1,8 @@
-import { type Page, expect, test } from "@playwright/test";
+import { type Page, chromium, expect, test } from "@playwright/test";
 import { SHA256 } from "@stablelib/sha256";
 import { randomUUID } from "node:crypto";
-import { mkdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rename, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { startBootstrapPeer } from "./bootstrapPeer";
 import {
@@ -45,6 +46,13 @@ const READER_LOCAL_CHUNK_MAX_OVERSHOOT = process.env
 	: null;
 const READER_TERMINAL_TOPOLOGY =
 	process.env.PW_READER_TERMINAL_TOPOLOGY || null;
+const READER_PERSIST_CHUNK_READS =
+	process.env.PW_READER_PERSIST_CHUNK_READS === "1"
+		? true
+		: process.env.PW_READER_PERSIST_CHUNK_READS === "0"
+			? false
+			: null;
+const BROWSER_STORAGE_MODE = process.env.PW_BROWSER_STORAGE_MODE;
 const LOCALITY_CONTROL_POLL_MS = Math.min(POLL_MS, 100);
 const LOCALITY_CONTROL_STABLE_SAMPLE_COUNT = 3;
 const TRANSPORT_COUNTER_STABILITY_POLL_MS = 100;
@@ -140,7 +148,7 @@ const FIXTURE_SEED =
 	process.env.PW_FIXTURE_SEED || "peerbit-file-share-benchmark-v1";
 const RESULT_SCHEMA = {
 	id: "peerbit-file-share-benchmark",
-	version: 10,
+	version: 11,
 } as const;
 const SEEDER_DROP_POLICY = {
 	id: "peerbit-file-share-seeder-drop-policy",
@@ -183,6 +191,11 @@ if (!Number.isSafeInteger(FILE_SIZE_BYTES) || FILE_SIZE_BYTES < 0) {
 if (!RUN_NONCE) {
 	throw new Error("Missing PW_BENCHMARK_RUN_NONCE");
 }
+if (BROWSER_STORAGE_MODE !== "memory" && BROWSER_STORAGE_MODE !== "opfs") {
+	throw new Error(
+		`Invalid PW_BROWSER_STORAGE_MODE='${process.env.PW_BROWSER_STORAGE_MODE}'`,
+	);
+}
 if (
 	READER_LOCAL_CHUNK_TARGET !== null &&
 	(!Number.isSafeInteger(READER_LOCAL_CHUNK_TARGET) ||
@@ -206,6 +219,22 @@ if (
 ) {
 	throw new Error(
 		"PW_READER_TERMINAL_TOPOLOGY must be provided exactly when PW_READER_LOCAL_CHUNK_TARGET is provided",
+	);
+}
+if (
+	(READER_LOCAL_CHUNK_TARGET === null) !==
+	(READER_PERSIST_CHUNK_READS === null)
+) {
+	throw new Error(
+		"PW_READER_PERSIST_CHUNK_READS must be provided exactly when PW_READER_LOCAL_CHUNK_TARGET is provided",
+	);
+}
+if (
+	process.env.PW_READER_PERSIST_CHUNK_READS !== "" &&
+	READER_PERSIST_CHUNK_READS === null
+) {
+	throw new Error(
+		`Invalid PW_READER_PERSIST_CHUNK_READS='${process.env.PW_READER_PERSIST_CHUNK_READS}'`,
 	);
 }
 if (
@@ -271,6 +300,14 @@ if (
 		"PW_READER_LOCAL_CHUNK_TARGET requires fixed1 writer mode and exactly one ready seeder because the reader starts as an observer",
 	);
 }
+if (
+	READER_PERSIST_CHUNK_READS === false &&
+	(READER_LOCAL_CHUNK_TARGET !== 0 || READER_TERMINAL_TOPOLOGY !== "observer")
+) {
+	throw new Error(
+		"Transient reader benchmarks require a zero local prefix and observer terminal topology",
+	);
+}
 
 const expectedInvocationValues: Record<string, unknown> = {
 	scenario: "upload",
@@ -280,6 +317,7 @@ const expectedInvocationValues: Record<string, unknown> = {
 	fileSizeBytes: FILE_SIZE_BYTES,
 	fixtureSeed: FIXTURE_SEED,
 	downloadSink: DOWNLOAD_SINK,
+	browserStorageMode: BROWSER_STORAGE_MODE,
 	uploadTimeoutMs: UPLOAD_TIMEOUT_MS,
 	downloadTimeoutMs: DOWNLOAD_TIMEOUT_MS,
 	postUploadMonitorMs: POST_UPLOAD_MONITOR_MS,
@@ -290,6 +328,7 @@ const expectedInvocationValues: Record<string, unknown> = {
 	readerLocalChunkTarget: READER_LOCAL_CHUNK_TARGET,
 	readerLocalChunkMaxOvershoot: READER_LOCAL_CHUNK_MAX_OVERSHOOT,
 	readerTerminalTopology: READER_TERMINAL_TOPOLOGY,
+	readerPersistChunkReads: READER_PERSIST_CHUNK_READS,
 	baseUrl: process.env.PW_BASE_URL || null,
 	protocol: process.env.PW_PROTOCOL || null,
 	viteMode: process.env.PW_VITE_MODE || null,
@@ -302,7 +341,7 @@ const expectedInvocationValues: Record<string, unknown> = {
 if (
 	(INVOCATION.schema as Record<string, unknown> | undefined)?.id !==
 		"peerbit-file-share-benchmark-invocation" ||
-	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 5
+	(INVOCATION.schema as Record<string, unknown> | undefined)?.version !== 6
 ) {
 	throw new Error("Unsupported PW_BENCHMARK_INVOCATION schema");
 }
@@ -592,9 +631,10 @@ const preloadLocalChunkPrefix = async (
 	fileName: string,
 	target: number,
 	timeoutMs: number,
+	persistChunkReads: boolean,
 ) => {
 	const evaluation = page.evaluate(
-		async ({ expectedFileName, requestedTarget, timeout }) => {
+		async ({ expectedFileName, requestedTarget, timeout, persist }) => {
 			const hooks = (window as any).__peerbitFileShareTestHooks;
 			if (!hooks?.preloadLocalChunkPrefix) {
 				throw new Error(
@@ -605,9 +645,15 @@ const preloadLocalChunkPrefix = async (
 				expectedFileName,
 				requestedTarget,
 				timeout,
+				persist,
 			);
 		},
-		{ expectedFileName: fileName, requestedTarget: target, timeout: timeoutMs },
+		{
+			expectedFileName: fileName,
+			requestedTarget: target,
+			timeout: timeoutMs,
+			persist: persistChunkReads,
+		},
 	);
 	return target > 0
 		? await withDeadline(
@@ -1492,9 +1538,146 @@ const logSnapshot = (snapshot: Record<string, unknown>) => {
 	}
 };
 
+type PersistentBenchmarkBrowserContext = Awaited<
+	ReturnType<typeof chromium.launchPersistentContext>
+>;
+
+const rejectedCleanupReasons = (
+	results: PromiseSettledResult<unknown>[],
+): unknown[] =>
+	results.flatMap((result) =>
+		result.status === "rejected" ? [result.reason] : [],
+	);
+
+const throwCleanupFailures = (failures: unknown[], message: string) => {
+	if (failures.length > 0) {
+		throw new AggregateError(failures, message);
+	}
+};
+
+const cleanupPersistentBenchmarkBrowsers = async ({
+	writerProfileDir,
+	readerProfileDir,
+	writerContext,
+	readerContext,
+}: {
+	writerProfileDir?: string;
+	readerProfileDir?: string;
+	writerContext?: PersistentBenchmarkBrowserContext;
+	readerContext?: PersistentBenchmarkBrowserContext;
+}) => {
+	const contexts = [writerContext, readerContext].filter(
+		(context): context is PersistentBenchmarkBrowserContext =>
+			context !== undefined,
+	);
+	const contextBrowsers = contexts.map((context) => context.browser());
+	const contextCloseResults = await Promise.allSettled(
+		contexts.map((context) => context.close()),
+	);
+	const failures = rejectedCleanupReasons(contextCloseResults);
+	// A persistent context normally owns and closes its browser. Calling close on
+	// the captured Browser object is a best-effort fallback only when that
+	// context's close rejected partway through.
+	const fallbackBrowsers = [
+		...new Set(
+			contextCloseResults.flatMap((result, index) => {
+				const browser = contextBrowsers[index];
+				return result.status === "rejected" && browser !== null
+					? [browser]
+					: [];
+			}),
+		),
+	];
+	failures.push(
+		...rejectedCleanupReasons(
+			await Promise.allSettled(
+				fallbackBrowsers.map((browser) => browser.close()),
+			),
+		),
+	);
+
+	const profileDirs = [writerProfileDir, readerProfileDir].filter(
+		(profileDir): profileDir is string => profileDir !== undefined,
+	);
+	failures.push(
+		...rejectedCleanupReasons(
+			await Promise.allSettled(
+				profileDirs.map((profileDir) =>
+					rm(profileDir, { recursive: true, force: true }),
+				),
+			),
+		),
+	);
+	throwCleanupFailures(
+		failures,
+		"Persistent benchmark browser cleanup did not complete",
+	);
+};
+
+const launchPersistentBenchmarkBrowsers = async () => {
+	let writerProfileDir: string | undefined;
+	let readerProfileDir: string | undefined;
+	let writerContext: PersistentBenchmarkBrowserContext | undefined;
+	let readerContext: PersistentBenchmarkBrowserContext | undefined;
+	try {
+		writerProfileDir = await mkdtemp(
+			path.join(os.tmpdir(), "peerbit-file-share-writer-profile-"),
+		);
+		readerProfileDir = await mkdtemp(
+			path.join(os.tmpdir(), "peerbit-file-share-reader-profile-"),
+		);
+		const persistentContextOptions = {
+			acceptDownloads: true,
+			headless: true,
+		};
+		writerContext = await chromium.launchPersistentContext(
+			writerProfileDir,
+			persistentContextOptions,
+		);
+		readerContext = await chromium.launchPersistentContext(
+			readerProfileDir,
+			persistentContextOptions,
+		);
+		for (const context of [writerContext, readerContext]) {
+			await context.addInitScript((storageMode) => {
+				(window as any).__peerbitFileShareBenchmarkStorageMode = storageMode;
+			}, BROWSER_STORAGE_MODE);
+		}
+		const writerBrowser = writerContext.browser();
+		const readerBrowser = readerContext.browser();
+		if (!writerBrowser || !readerBrowser || writerBrowser === readerBrowser) {
+			throw new Error(
+				"Persistent writer and reader contexts must expose separate browser instances",
+			);
+		}
+		return {
+			writerProfileDir,
+			readerProfileDir,
+			writerContext,
+			readerContext,
+			writerBrowser,
+			readerBrowser,
+		};
+	} catch (error) {
+		try {
+			await cleanupPersistentBenchmarkBrowsers({
+				writerProfileDir,
+				readerProfileDir,
+				writerContext,
+				readerContext,
+			});
+		} catch (cleanupError) {
+			throw new AggregateError(
+				[error, cleanupError],
+				"Persistent benchmark browser launch and cleanup failed",
+			);
+		}
+		throw error;
+	}
+};
+
 test.describe("generated transfer-validity benchmark", () => {
 	test("measures upload, discovery, monitoring, and persisted download", async ({
-		browser,
 		baseURL,
 	}) => {
 		test.setTimeout(TEST_OUTER_TIMEOUT_MS);
@@ -1507,10 +1690,45 @@ test.describe("generated transfer-validity benchmark", () => {
 			| Awaited<ReturnType<typeof startBootstrapPeer>>
 			| undefined = usesLocalBootstrap ? await startBootstrapPeer() : undefined;
 		const fileName = `file-share-benchmark-${MODE}-${RUN_NONCE}.bin`;
-		const writerContext = await browser.newContext({ acceptDownloads: true });
-		const readerContext = await browser.newContext({ acceptDownloads: true });
-		const writer = await writerContext.newPage();
-		const reader = await readerContext.newPage();
+		let browserPair: Awaited<
+			ReturnType<typeof launchPersistentBenchmarkBrowsers>
+		>;
+		try {
+			browserPair = await launchPersistentBenchmarkBrowsers();
+		} catch (error) {
+			const cleanupFailures = rejectedCleanupReasons(
+				await Promise.allSettled([bootstrap?.stop()]),
+			);
+			if (cleanupFailures.length > 0) {
+				throw new AggregateError(
+					[error, ...cleanupFailures],
+					"Benchmark browser launch and bootstrap cleanup failed",
+				);
+			}
+			throw error;
+		}
+		const { writerContext, readerContext, writerBrowser, readerBrowser } =
+			browserPair;
+		let writer: Page;
+		let reader: Page;
+		try {
+			writer = writerContext.pages()[0] ?? (await writerContext.newPage());
+			reader = readerContext.pages()[0] ?? (await readerContext.newPage());
+		} catch (error) {
+			const cleanupFailures = rejectedCleanupReasons(
+				await Promise.allSettled([
+					cleanupPersistentBenchmarkBrowsers(browserPair),
+					bootstrap?.stop(),
+				]),
+			);
+			if (cleanupFailures.length > 0) {
+				throw new AggregateError(
+					[error, ...cleanupFailures],
+					"Benchmark page acquisition and ownership cleanup failed",
+				);
+			}
+			throw error;
+		}
 		const errors: string[] = [];
 		const requestFailures: string[] = [];
 		const snapshots: Array<Record<string, unknown>> = [];
@@ -1526,6 +1744,7 @@ test.describe("generated transfer-validity benchmark", () => {
 			| Awaited<ReturnType<typeof installNodeBackedMockSaveFilePicker>>
 			| undefined;
 		let stage = "setup";
+		let benchmarkFailure: unknown;
 		let uploadStartedAt: number | undefined;
 		let uploadSettledAt: number | undefined;
 		let progressSettledAt: number | undefined;
@@ -1577,7 +1796,9 @@ test.describe("generated transfer-validity benchmark", () => {
 							"exact local Documents index rows and manifest entry blocks",
 						writerUploadRole: "fixed1",
 						readerUploadRole: "observer",
-						readerTimedReadPolicy: "persist-chunk-reads",
+						readerTimedReadPolicy: READER_PERSIST_CHUNK_READS
+							? "persist-chunk-reads"
+							: "transient-chunk-reads",
 						expectedTerminalTopology: READER_TERMINAL_TOPOLOGY,
 						stabilityPollIntervalMs: LOCALITY_CONTROL_POLL_MS,
 						requiredStableObservationCount:
@@ -1786,7 +2007,7 @@ test.describe("generated transfer-validity benchmark", () => {
 					observation.blockCount <=
 						READER_LOCAL_CHUNK_TARGET + READER_LOCAL_CHUNK_MAX_OVERSHOOT &&
 					observation.blockCount < observation.chunkCount! &&
-					observation.persistChunkReads === true &&
+					observation.persistChunkReads === READER_PERSIST_CHUNK_READS &&
 					localityObservationIsIdle(observation);
 				if (!exactSetsAreValid) {
 					stable = [];
@@ -1831,27 +2052,30 @@ test.describe("generated transfer-validity benchmark", () => {
 					READER_TERMINAL_TOPOLOGY === "replicator"
 						? lastObservation.chunkCount
 						: 0;
+				const expectedTerminalBlockCount = READER_PERSIST_CHUNK_READS
+					? lastObservation.chunkCount
+					: 0;
 				if (
 					localityObservationIsIdle(lastObservation) &&
 					lastObservation.fileId === readerManifestEvidence?.fileId &&
 					lastObservation.chunkCount !== null &&
 					lastObservation.blockCount !== null &&
 					lastObservation.blockChunkIndices !== null &&
-					lastObservation.blockCount === lastObservation.chunkCount &&
+					lastObservation.blockCount === expectedTerminalBlockCount &&
 					lastObservation.indexRowCount === expectedTerminalIndexRowCount &&
 					Array.isArray(lastObservation.indexedChunkIndices) &&
 					lastObservation.indexedChunkIndices.length ===
 						expectedTerminalIndexRowCount &&
 					isContiguousPrefix(lastObservation.indexedChunkIndices) &&
 					isContiguousPrefix(lastObservation.blockChunkIndices) &&
-					lastObservation.persistChunkReads === true
+					lastObservation.persistChunkReads === READER_PERSIST_CHUNK_READS
 				) {
 					return lastObservation;
 				}
 				await reader.waitForTimeout(LOCALITY_CONTROL_POLL_MS);
 			}
 			throw new Error(
-				`Timed reader did not become transfer-idle with every manifest chunk local: ${JSON.stringify(lastObservation)}`,
+				`Timed reader did not become transfer-idle with the requested persistence policy: ${JSON.stringify(lastObservation)}`,
 			);
 		};
 
@@ -2267,6 +2491,7 @@ test.describe("generated transfer-validity benchmark", () => {
 					fileName,
 					READER_LOCAL_CHUNK_TARGET,
 					DOWNLOAD_TIMEOUT_MS,
+					READER_PERSIST_CHUNK_READS!,
 				)) as Record<string, unknown>;
 				readerLocalityControl.preloadEvidence = preloadEvidence;
 				const preloadScheduler = preloadEvidence.downloadSchedulerAfterClose as
@@ -2293,7 +2518,7 @@ test.describe("generated transfer-validity benchmark", () => {
 					!Number.isSafeInteger(preloadEvidence.rawFetchedByteCount) ||
 					(preloadEvidence.rawFetchedByteCount as number) < 0 ||
 					preloadEvidence.maxConcurrentImports !== 8 ||
-					preloadEvidence.persistChunkReads !== true ||
+					preloadEvidence.persistChunkReads !== READER_PERSIST_CHUNK_READS ||
 					!Array.isArray(preloadEvidence.activeTransfersAfterClose) ||
 					preloadEvidence.activeTransfersAfterClose.length !== 0 ||
 					preloadScheduler?.activeCount !== 0 ||
@@ -2342,7 +2567,7 @@ test.describe("generated transfer-validity benchmark", () => {
 					preDownloadObservation.indexRowCount;
 				readerLocalityControl.speculativeOvershootChunkCount =
 					preDownloadObservation.blockCount! - READER_LOCAL_CHUNK_TARGET;
-				readerLocalityControl.cohortKey = `observer-persistent-prefix-b${preDownloadObservation.blockCount}-i${preDownloadObservation.indexRowCount}`;
+				readerLocalityControl.cohortKey = `observer-${READER_PERSIST_CHUNK_READS ? "persistent" : "transient"}-${BROWSER_STORAGE_MODE}-prefix-b${preDownloadObservation.blockCount}-i${preDownloadObservation.indexRowCount}`;
 				logStage("reader-locality-prefix-stable", {
 					actualLocalChunkBlockCount:
 						readerLocalityControl.actualLocalChunkBlockCount,
@@ -2363,7 +2588,8 @@ test.describe("generated transfer-validity benchmark", () => {
 				timeout: DOWNLOAD_TIMEOUT_MS,
 			});
 			downloadMemoryTelemetryController = await startDownloadMemoryTelemetry({
-				browser,
+				browsers: [writerBrowser, readerBrowser],
+				expectedBrowserCount: 2,
 				reader,
 				writer,
 				downloadTimeoutMs: DOWNLOAD_TIMEOUT_MS,
@@ -2647,17 +2873,23 @@ test.describe("generated transfer-validity benchmark", () => {
 					readerLocalityControl.actualLocalChunkBlockCount;
 				const actualLocalChunkIndexRowCount =
 					readerLocalityControl.actualLocalChunkIndexRowCount;
+				const expectedInitialDiagnosticIndexRowCount =
+					READER_PERSIST_CHUNK_READS ? actualLocalChunkIndexRowCount : null;
+				const expectedInitialDiagnosticBlockCount = READER_PERSIST_CHUNK_READS
+					? actualLocalChunkBlockCount
+					: null;
 				if (
 					!Number.isSafeInteger(actualLocalChunkBlockCount) ||
 					!Number.isSafeInteger(actualLocalChunkIndexRowCount) ||
-					rawReadDiagnostics.persistChunkReads !== true ||
-					rawReadDiagnostics.programPersistChunkReads !== true ||
+					rawReadDiagnostics.persistChunkReads !== READER_PERSIST_CHUNK_READS ||
+					rawReadDiagnostics.programPersistChunkReads !==
+						READER_PERSIST_CHUNK_READS ||
 					rawReadDiagnostics.initialLocalChunkIndexRowCount !==
-						actualLocalChunkIndexRowCount ||
+						expectedInitialDiagnosticIndexRowCount ||
 					rawReadDiagnostics.initialLocalChunkCount !==
-						actualLocalChunkIndexRowCount ||
+						expectedInitialDiagnosticIndexRowCount ||
 					rawReadDiagnostics.initialLocalChunkBlockCount !==
-						actualLocalChunkBlockCount
+						expectedInitialDiagnosticBlockCount
 				) {
 					throw new Error(
 						"Timed read diagnostics do not match the controlled pre-download locality cohort",
@@ -3127,6 +3359,8 @@ test.describe("generated transfer-validity benchmark", () => {
 				readerLocalChunkTarget: READER_LOCAL_CHUNK_TARGET,
 				readerLocalChunkMaxOvershoot: READER_LOCAL_CHUNK_MAX_OVERSHOOT,
 				readerTerminalTopology: READER_TERMINAL_TOPOLOGY,
+				readerPersistChunkReads: READER_PERSIST_CHUNK_READS,
+				browserStorageMode: BROWSER_STORAGE_MODE,
 				readerLocalChunkBlockCount:
 					readerLocalityControl?.actualLocalChunkBlockCount ?? null,
 				readerLocalChunkIndexRowCount:
@@ -3249,109 +3483,122 @@ test.describe("generated transfer-validity benchmark", () => {
 			await persistResult(result);
 			console.log(`FILE_SHARE_BENCHMARK_RESULT ${JSON.stringify(result)}`);
 		} catch (error: any) {
-			if (downloadMemoryTelemetryController) {
-				downloadMemoryTelemetry =
-					await downloadMemoryTelemetryController.cleanup();
+			benchmarkFailure = error;
+			try {
+				if (downloadMemoryTelemetryController) {
+					downloadMemoryTelemetry =
+						await downloadMemoryTelemetryController.cleanup();
+				}
+				if (readerLocalityControl) {
+					readerLocalityControl.status = "failed";
+					readerLocalityControl.failure =
+						typeof error?.message === "string" ? error.message : String(error);
+				}
+				const failureSnapshot = await snapshot(`failure-${stage}`).catch(
+					() => null,
+				);
+				if (failureSnapshot) {
+					noteSeederDrop(failureSnapshot);
+				}
+				const writerDiagnostics = await getDiagnostics(writer);
+				const readerDiagnostics = await getDiagnostics(reader);
+				const collectedErrors = [...errors];
+				const collectedRequestFailures = [...requestFailures];
+				const result = {
+					schema: RESULT_SCHEMA,
+					runNonce: RUN_NONCE,
+					invocation: INVOCATION,
+					provenance: PROVENANCE,
+					status: "failed",
+					mode: MODE,
+					readerLocalChunkTarget: READER_LOCAL_CHUNK_TARGET,
+					readerLocalChunkMaxOvershoot: READER_LOCAL_CHUNK_MAX_OVERSHOOT,
+					readerTerminalTopology: READER_TERMINAL_TOPOLOGY,
+					readerPersistChunkReads: READER_PERSIST_CHUNK_READS,
+					browserStorageMode: BROWSER_STORAGE_MODE,
+					readerLocalChunkBlockCount:
+						readerLocalityControl?.actualLocalChunkBlockCount ?? null,
+					readerLocalChunkIndexRowCount:
+						readerLocalityControl?.actualLocalChunkIndexRowCount ?? null,
+					readerLocalityCohortKey: readerLocalityControl?.cohortKey ?? null,
+					readerLocalityControl,
+					networkMode: NETWORK_MODE,
+					fileSizeMb: FILE_SIZE_MB,
+					stage,
+					requestedDownloadSink: DOWNLOAD_SINK,
+					downloadMemoryTelemetry,
+					resourceEvidence: resourceEvidence ?? {
+						schemaVersion: 2,
+						snapshots: resourceSnapshots,
+						intervals: null,
+					},
+					shutdownOutcomes,
+					integrity,
+					integrityVerified,
+					integrityVerifiedAt,
+					phaseDurationsMs: getPhaseDurations(),
+					postUploadMonitorSchedulingToleranceMs:
+						POST_MONITOR_SCHEDULING_TOLERANCE_MS,
+					postUploadMonitorSchedulingToleranceDefinition:
+						POST_MONITOR_SCHEDULING_TOLERANCE_DEFINITION,
+					transferTimeoutSchedulingToleranceMs:
+						TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS,
+					transferTimeoutSchedulingToleranceDefinition:
+						TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION,
+					postUploadMonitorMs: POST_UPLOAD_MONITOR_MS,
+					postTransferSoakMs: POST_TRANSFER_SOAK_MS,
+					postTransferSoakActualMs:
+						postTransferSoakStartedAt != null &&
+						postTransferSoakFinishedAt != null
+							? postTransferSoakFinishedAt - postTransferSoakStartedAt
+							: null,
+					postTransferSoakSchedulingToleranceMs:
+						POST_TRANSFER_SOAK_SCHEDULING_TOLERANCE_MS,
+					postTransferSoakSchedulingToleranceDefinition:
+						POST_TRANSFER_SOAK_SCHEDULING_TOLERANCE_DEFINITION,
+					pollMs: POLL_MS,
+					uploadTimeoutMs: UPLOAD_TIMEOUT_MS,
+					downloadTimeoutMs: DOWNLOAD_TIMEOUT_MS,
+					minReadySeeders: MIN_READY_SEEDERS,
+					readyTimeoutMs: READY_TIMEOUT_MS,
+					baselineWriterSeeders,
+					baselineReaderSeeders,
+					shareUrl,
+					seederDropPolicy: SEEDER_DROP_POLICY,
+					droppedSeeders: dropped,
+					unexpectedSeederDrop,
+					writerVisibilityProbe,
+					readerVisibilityProbe,
+					errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
+					knownPeerbitFailureSignatures: KNOWN_PEERBIT_FAILURE_SIGNATURES,
+					errorCollectionComplete: true,
+					errorCount: collectedErrors.length,
+					errors: collectedErrors,
+					requestFailureCollectionDefinition:
+						REQUEST_FAILURE_COLLECTION_DEFINITION,
+					requestFailureCollectionComplete: true,
+					requestFailureCount: collectedRequestFailures.length,
+					requestFailures: collectedRequestFailures,
+					snapshots,
+					writerDiagnostics,
+					readerDiagnostics,
+					failure: {
+						message:
+							typeof error?.message === "string"
+								? error.message
+								: String(error),
+						stack: typeof error?.stack === "string" ? error.stack : undefined,
+					},
+				};
+				await persistResult(result);
+				console.error(`FILE_SHARE_BENCHMARK_RESULT ${JSON.stringify(result)}`);
+			} catch (failureHandlingError) {
+				benchmarkFailure = new AggregateError(
+					[error, failureHandlingError],
+					"Benchmark execution and failed-result handling both failed",
+				);
+				throw benchmarkFailure;
 			}
-			if (readerLocalityControl) {
-				readerLocalityControl.status = "failed";
-				readerLocalityControl.failure =
-					typeof error?.message === "string" ? error.message : String(error);
-			}
-			const failureSnapshot = await snapshot(`failure-${stage}`).catch(
-				() => null,
-			);
-			if (failureSnapshot) {
-				noteSeederDrop(failureSnapshot);
-			}
-			const writerDiagnostics = await getDiagnostics(writer);
-			const readerDiagnostics = await getDiagnostics(reader);
-			const collectedErrors = [...errors];
-			const collectedRequestFailures = [...requestFailures];
-			const result = {
-				schema: RESULT_SCHEMA,
-				runNonce: RUN_NONCE,
-				invocation: INVOCATION,
-				provenance: PROVENANCE,
-				status: "failed",
-				mode: MODE,
-				readerLocalChunkTarget: READER_LOCAL_CHUNK_TARGET,
-				readerLocalChunkMaxOvershoot: READER_LOCAL_CHUNK_MAX_OVERSHOOT,
-				readerTerminalTopology: READER_TERMINAL_TOPOLOGY,
-				readerLocalChunkBlockCount:
-					readerLocalityControl?.actualLocalChunkBlockCount ?? null,
-				readerLocalChunkIndexRowCount:
-					readerLocalityControl?.actualLocalChunkIndexRowCount ?? null,
-				readerLocalityCohortKey: readerLocalityControl?.cohortKey ?? null,
-				readerLocalityControl,
-				networkMode: NETWORK_MODE,
-				fileSizeMb: FILE_SIZE_MB,
-				stage,
-				requestedDownloadSink: DOWNLOAD_SINK,
-				downloadMemoryTelemetry,
-				resourceEvidence: resourceEvidence ?? {
-					schemaVersion: 2,
-					snapshots: resourceSnapshots,
-					intervals: null,
-				},
-				shutdownOutcomes,
-				integrity,
-				integrityVerified,
-				integrityVerifiedAt,
-				phaseDurationsMs: getPhaseDurations(),
-				postUploadMonitorSchedulingToleranceMs:
-					POST_MONITOR_SCHEDULING_TOLERANCE_MS,
-				postUploadMonitorSchedulingToleranceDefinition:
-					POST_MONITOR_SCHEDULING_TOLERANCE_DEFINITION,
-				transferTimeoutSchedulingToleranceMs:
-					TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_MS,
-				transferTimeoutSchedulingToleranceDefinition:
-					TRANSFER_TIMEOUT_SCHEDULING_TOLERANCE_DEFINITION,
-				postUploadMonitorMs: POST_UPLOAD_MONITOR_MS,
-				postTransferSoakMs: POST_TRANSFER_SOAK_MS,
-				postTransferSoakActualMs:
-					postTransferSoakStartedAt != null &&
-					postTransferSoakFinishedAt != null
-						? postTransferSoakFinishedAt - postTransferSoakStartedAt
-						: null,
-				postTransferSoakSchedulingToleranceMs:
-					POST_TRANSFER_SOAK_SCHEDULING_TOLERANCE_MS,
-				postTransferSoakSchedulingToleranceDefinition:
-					POST_TRANSFER_SOAK_SCHEDULING_TOLERANCE_DEFINITION,
-				pollMs: POLL_MS,
-				uploadTimeoutMs: UPLOAD_TIMEOUT_MS,
-				downloadTimeoutMs: DOWNLOAD_TIMEOUT_MS,
-				minReadySeeders: MIN_READY_SEEDERS,
-				readyTimeoutMs: READY_TIMEOUT_MS,
-				baselineWriterSeeders,
-				baselineReaderSeeders,
-				shareUrl,
-				seederDropPolicy: SEEDER_DROP_POLICY,
-				droppedSeeders: dropped,
-				unexpectedSeederDrop,
-				writerVisibilityProbe,
-				readerVisibilityProbe,
-				errorCollectionDefinition: ERROR_COLLECTION_DEFINITION,
-				knownPeerbitFailureSignatures: KNOWN_PEERBIT_FAILURE_SIGNATURES,
-				errorCollectionComplete: true,
-				errorCount: collectedErrors.length,
-				errors: collectedErrors,
-				requestFailureCollectionDefinition:
-					REQUEST_FAILURE_COLLECTION_DEFINITION,
-				requestFailureCollectionComplete: true,
-				requestFailureCount: collectedRequestFailures.length,
-				requestFailures: collectedRequestFailures,
-				snapshots,
-				writerDiagnostics,
-				readerDiagnostics,
-				failure: {
-					message:
-						typeof error?.message === "string" ? error.message : String(error),
-					stack: typeof error?.stack === "string" ? error.stack : undefined,
-				},
-			};
-			await persistResult(result);
-			console.error(`FILE_SHARE_BENCHMARK_RESULT ${JSON.stringify(result)}`);
 			throw error;
 		} finally {
 			await downloadMemoryTelemetryController?.cleanup().catch(() => {});
@@ -3362,9 +3609,20 @@ test.describe("generated transfer-validity benchmark", () => {
 					() => {},
 				);
 			}
-			await writerContext.close().catch(() => {});
-			await readerContext.close().catch(() => {});
-			await bootstrap?.stop().catch(() => {});
+			const ownershipCleanupFailures = rejectedCleanupReasons(
+				await Promise.allSettled([
+					cleanupPersistentBenchmarkBrowsers(browserPair),
+					bootstrap?.stop(),
+				]),
+			);
+			if (ownershipCleanupFailures.length > 0) {
+				throw new AggregateError(
+					benchmarkFailure === undefined
+						? ownershipCleanupFailures
+						: [benchmarkFailure, ...ownershipCleanupFailures],
+					"Benchmark browser or bootstrap cleanup did not complete",
+				);
+			}
 		}
 	});
 });


### PR DESCRIPTION
## Summary

- make reader chunk persistence an explicit, fail-closed benchmark dimension independent of Peerbit browser storage
- add exact memory versus OPFS backend evidence and keep all four retention/storage cohorts separate in summaries
- launch writer and reader in fresh independent Chromium processes and prove two distinct browser roots in host telemetry
- harden local-package selection, better-sqlite3 ABI preflight, cleanup ownership, and multi-failure diagnostics

The required file-share app hooks landed and were independently reviewed in dao-xyz/peerbit-examples#216.

## Verification

- pnpm run bench:file-share:test: 223/223 passed
- pnpm run build: passed
- merged-examples 6 MiB real-browser smoke: OPFS + transient observer passed schema v11 with exact integrity, zero retained reader blocks/index rows, two Chromium roots, clean shutdown, and zero errors/request failures
- four earlier 6 MiB cells covered memory/OPFS crossed with persistent/transient reads
- independent hostile review: no P0/P1/P2 findings
