### PR TITLE
fix(deps): patch shell-quote denial of service

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
 			"protobufjs": "7.6.3",
 			"qs": "6.15.2",
 			"rollup@4": "4.59.0",
-			"shell-quote": "1.8.4",
+			"shell-quote": "1.9.0",
 			"smol-toml": "1.6.1",
 			"tmp@0.2": "0.2.7",
 			"vite@7.3.6>esbuild": "0.28.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ overrides:
   protobufjs: 7.6.3
   qs: 6.15.2
   rollup@4: 4.59.0
-  shell-quote: 1.8.4
+  shell-quote: 1.9.0
   smol-toml: 1.6.1
   tmp@0.2: 0.2.7
   vite@7.3.6>esbuild: 0.28.1
@@ -10706,8 +10706,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.9.0:
+    resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
   shelljs@0.8.5:
@@ -21019,7 +21019,7 @@ snapshots:
 
   react-devtools-core@6.1.5:
     dependencies:
-      shell-quote: 1.8.4
+      shell-quote: 1.9.0
       ws: 7.5.11
     transitivePeerDependencies:
       - bufferutil
@@ -21751,7 +21751,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.9.0: {}
 
   shelljs@0.8.5:
     dependencies:


### PR DESCRIPTION
## Summary

- override `shell-quote` 1.8.4 with patched 1.9.0
- update only the corresponding lockfile resolution and consumer edge
- address GHSA-395f-4hp3-45gv, a quadratic-complexity denial of service in `parse()`

## Verification

- registry integrity and npm signature verified
- npm gitHead matches the official `v1.9.0` tag
- frozen pnpm install passes
- production and full audits report no known vulnerabilities
- security dependency contracts pass

No workflow files are changed.