### PR TITLE
fix(deps): patch protobufjs option parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
 			"picomatch@2": "2.3.2",
 			"picomatch@4": "4.0.5",
 			"postcss@8": "8.5.10",
-			"protobufjs": "7.6.3",
+			"protobufjs": "7.6.5",
 			"qs": "6.15.2",
 			"rollup@4": "4.59.0",
 			"shell-quote": "1.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ overrides:
   picomatch@2: 2.3.2
   picomatch@4: 4.0.5
   postcss@8: 8.5.10
-  protobufjs: 7.6.3
+  protobufjs: 7.6.5
   qs: 6.15.2
   rollup@4: 4.59.0
   shell-quote: 1.9.0
@@ -4660,9 +4660,6 @@ packages:
 
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
-
-  '@protobufjs/inquire@1.1.2':
-    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -10140,8 +10137,8 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
-  protobufjs@7.6.3:
-    resolution: {integrity: sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   protons-runtime@5.6.0:
@@ -13075,7 +13072,7 @@ snapshots:
       '@protobufjs/float': 1.0.2
       '@protobufjs/utf8': 1.1.2
       '@types/benchmark': 2.1.5
-      protobufjs: 7.6.3
+      protobufjs: 7.6.5
 
   '@dao-xyz/datastore-level@11.2.0':
     dependencies:
@@ -14257,8 +14254,6 @@ snapshots:
       '@protobufjs/aspromise': 1.1.2
 
   '@protobufjs/float@1.0.2': {}
-
-  '@protobufjs/inquire@1.1.2': {}
 
   '@protobufjs/path@1.1.2': {}
 
@@ -20932,7 +20927,7 @@ snapshots:
 
   proto-list@1.2.4: {}
 
-  protobufjs@7.6.3:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -20940,7 +20935,6 @@ snapshots:
       '@protobufjs/eventemitter': 1.1.1
       '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.2


### PR DESCRIPTION
## Summary
- pin protobufjs 7.6.5, the upstream fix for GHSA-j3f2-48v5-ccww
- remove the retired transitive @protobufjs/inquire entry from the lockfile

## Validation
- verified npm integrity, signature, and npm gitHead against upstream tag protobufjs-v7.6.5
- frozen pnpm install
- security dependency contracts
- production and full pnpm 11.13 audits: no known vulnerabilities
- full monorepo build