### PR TITLE
perf(any-store): make memory size checks constant-time

### DIFF
--- a/.changeset/quick-stores-count.md
+++ b/.changeset/quick-stores-count.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/any-store": patch
+---
+
+Track insertion-time MemoryStore byte size during mutations so repeated size checks stay constant-time, including after caller-owned buffers are resized or detached.

--- a/.changeset/quick-stores-count.md
+++ b/.changeset/quick-stores-count.md
@@ -1,5 +1,6 @@
 ---
 "@peerbit/any-store": patch
+"@peerbit/any-store-interface": patch
 ---
 
-Track insertion-time MemoryStore byte size during mutations so repeated size checks stay constant-time, including after caller-owned buffers are resized or detached.
+Track insertion-time MemoryStore byte size during mutations so repeated size checks stay constant-time, reject aggregate counter overflow atomically, and document AnyStore's backend-accounted size contract, including caller-owned buffers that are later resized or detached.

--- a/packages/utils/any-store/any-store/src/memory.ts
+++ b/packages/utils/any-store/any-store/src/memory.ts
@@ -1,5 +1,13 @@
 import { type AnyStore } from "@peerbit/any-store-interface";
 
+/**
+ * An in-memory store that retains the Uint8Array instances supplied to put().
+ *
+ * A value's byteLength is credited when put() succeeds. Later caller-owned
+ * mutations, including resizing or detaching its backing buffer, can change the
+ * value returned by get() without retroactively changing size(). Put the value
+ * again to credit its new length.
+ */
 export class MemoryStore implements AnyStore {
 	private store: Map<string, Uint8Array>;
 	private sublevels: Map<string, MemoryStore>;
@@ -64,9 +72,16 @@ export class MemoryStore implements AnyStore {
 			);
 		}
 		const previousByteLength = this.storedByteLengths.get(key) ?? 0;
+		const nextStoredBytes = this.storedBytes - previousByteLength + byteLength;
+		if (!Number.isSafeInteger(nextStoredBytes) || nextStoredBytes < 0) {
+			throw new RangeError(
+				"MemoryStore aggregate size must be a non-negative safe integer",
+			);
+		}
+
 		this.store.set(key, value);
 		this.storedByteLengths.set(key, byteLength);
-		this.storedBytes += byteLength - previousByteLength;
+		this.storedBytes = nextStoredBytes;
 	}
 
 	// Remove a value and key from the cache

--- a/packages/utils/any-store/any-store/src/memory.ts
+++ b/packages/utils/any-store/any-store/src/memory.ts
@@ -4,9 +4,20 @@ export class MemoryStore implements AnyStore {
 	private store: Map<string, Uint8Array>;
 	private sublevels: Map<string, MemoryStore>;
 	private isOpen: boolean;
+	/**
+	 * Logical byte lengths captured when each value is stored. MemoryStore keeps
+	 * caller-owned Uint8Array references, whose live byteLength may later change
+	 * if their backing buffer is resized or detached. Tracking those external
+	 * mutations would require scanning all values, so size() reports the bytes
+	 * credited at put time instead.
+	 */
+	private storedByteLengths: Map<string, number>;
+	private storedBytes: number;
 	constructor() {
 		this.sublevels = new Map();
 		this.store = new Map();
+		this.storedByteLengths = new Map();
+		this.storedBytes = 0;
 	}
 
 	status() {
@@ -36,18 +47,35 @@ export class MemoryStore implements AnyStore {
 
 	clear(): void {
 		this.store.clear();
+		this.storedByteLengths.clear();
+		this.storedBytes = 0;
 		for (const [_s, sub] of this.sublevels) {
 			sub.clear();
 		}
 	}
 
 	put(key: string, value: Uint8Array) {
+		// Read and validate before either map is mutated. Uint8Array subclasses can
+		// override this getter, so it is part of the operation's failure boundary.
+		const byteLength = value.byteLength;
+		if (!Number.isSafeInteger(byteLength) || byteLength < 0) {
+			throw new RangeError(
+				"MemoryStore value byteLength must be a non-negative safe integer",
+			);
+		}
+		const previousByteLength = this.storedByteLengths.get(key) ?? 0;
 		this.store.set(key, value);
+		this.storedByteLengths.set(key, byteLength);
+		this.storedBytes += byteLength - previousByteLength;
 	}
 
 	// Remove a value and key from the cache
 	del(key: string) {
-		this.store.delete(key);
+		const previousByteLength = this.storedByteLengths.get(key);
+		if (previousByteLength !== undefined && this.store.delete(key)) {
+			this.storedByteLengths.delete(key);
+			this.storedBytes -= previousByteLength;
+		}
 	}
 
 	sublevel(name: string) {
@@ -66,11 +94,7 @@ export class MemoryStore implements AnyStore {
 	}
 
 	size() {
-		let size = 0;
-		for (const [_k, v] of this.store) {
-			size += v.byteLength;
-		}
-		return size;
+		return this.storedBytes;
 	}
 
 	persisted() {

--- a/packages/utils/any-store/any-store/test/memory.spec.ts
+++ b/packages/utils/any-store/any-store/test/memory.spec.ts
@@ -120,6 +120,54 @@ describe("MemoryStore", () => {
 		}
 	});
 
+	it("rejects aggregate overflow and deletes back to exact zero", () => {
+		const store = new MemoryStore();
+		const maximum = new Uint8Array(0);
+		Object.defineProperty(maximum, "byteLength", {
+			value: Number.MAX_SAFE_INTEGER,
+		});
+		store.put("maximum", maximum);
+		expect(store.size()).to.equal(Number.MAX_SAFE_INTEGER);
+
+		const extra = new Uint8Array(1);
+		expect(() => store.put("extra", extra)).to.throw(
+			RangeError,
+			"aggregate size",
+		);
+		expect(store.get("extra")).to.be.undefined;
+		expect(store.get("maximum")).to.equal(maximum);
+		expect(store.size()).to.equal(Number.MAX_SAFE_INTEGER);
+
+		store.del("maximum");
+		expect(store.size()).to.equal(0);
+	});
+
+	it("keeps the prior value and size when a replacement would overflow", () => {
+		const store = new MemoryStore();
+		const large = new Uint8Array(0);
+		Object.defineProperty(large, "byteLength", {
+			value: Number.MAX_SAFE_INTEGER - 2,
+		});
+		const original = new Uint8Array(2);
+		store.put("large", large);
+		store.put("replace", original);
+		expect(store.size()).to.equal(Number.MAX_SAFE_INTEGER);
+
+		const replacement = new Uint8Array(3);
+		expect(() => store.put("replace", replacement)).to.throw(
+			RangeError,
+			"aggregate size",
+		);
+		expect(store.get("replace")).to.equal(original);
+		expect(store.get("large")).to.equal(large);
+		expect(store.size()).to.equal(Number.MAX_SAFE_INTEGER);
+
+		store.del("replace");
+		expect(store.size()).to.equal(Number.MAX_SAFE_INTEGER - 2);
+		store.del("large");
+		expect(store.size()).to.equal(0);
+	});
+
 	if (isNode) {
 		it("uses credited length after a backing buffer is detached", function () {
 			if (typeof structuredClone !== "function") {
@@ -163,6 +211,8 @@ describe("MemoryStore", () => {
 			expect(value.byteLength).to.equal(12);
 			expect(store.size()).to.equal(4);
 
+			store.put("value", value);
+			expect(store.size()).to.equal(12);
 			store.put("value", new Uint8Array(3));
 			expect(store.size()).to.equal(3);
 			store.del("value");

--- a/packages/utils/any-store/any-store/test/memory.spec.ts
+++ b/packages/utils/any-store/any-store/test/memory.spec.ts
@@ -1,0 +1,172 @@
+import { expect } from "chai";
+import { MemoryStore } from "../src/memory.js";
+
+const isNode = typeof process !== "undefined" && !!process.versions?.node;
+
+describe("MemoryStore", () => {
+	it("keeps exact size through puts, replacements, and deletes", () => {
+		const store = new MemoryStore();
+
+		expect(store.size()).to.equal(0);
+		store.put("a", new Uint8Array(3));
+		store.put("b", new Uint8Array(5));
+		expect(store.size()).to.equal(8);
+
+		store.put("a", new Uint8Array(11));
+		expect(store.size()).to.equal(16);
+		store.put("b", new Uint8Array(1));
+		expect(store.size()).to.equal(12);
+		store.put("a", new Uint8Array(0));
+		expect(store.size()).to.equal(1);
+
+		store.del("missing");
+		expect(store.size()).to.equal(1);
+		store.del("a");
+		expect(store.size()).to.equal(1);
+		store.del("b");
+		expect(store.size()).to.equal(0);
+		store.del("b");
+		expect(store.size()).to.equal(0);
+	});
+
+	it("preserves size when the same instance closes and reopens", () => {
+		const store = new MemoryStore();
+		store.put("a", new Uint8Array(3));
+		store.put("b", new Uint8Array(5));
+
+		store.open();
+		store.close();
+		expect(store.size()).to.equal(8);
+		store.open();
+		expect(store.size()).to.equal(8);
+	});
+
+	it("tracks each level independently and clears descendants", () => {
+		const root = new MemoryStore();
+		const child = root.sublevel("child");
+		const grandchild = child.sublevel("grandchild");
+
+		root.put("root", new Uint8Array(2));
+		child.put("child", new Uint8Array(3));
+		grandchild.put("grandchild", new Uint8Array(5));
+
+		expect(root.size()).to.equal(2);
+		expect(child.size()).to.equal(3);
+		expect(grandchild.size()).to.equal(5);
+
+		child.clear();
+		expect(root.size()).to.equal(2);
+		expect(child.size()).to.equal(0);
+		expect(grandchild.size()).to.equal(0);
+
+		child.put("child", new Uint8Array(7));
+		grandchild.put("grandchild", new Uint8Array(11));
+		root.clear();
+		expect(root.size()).to.equal(0);
+		expect(child.size()).to.equal(0);
+		expect(grandchild.size()).to.equal(0);
+	});
+
+	it("answers repeated size queries without iterating stored values", () => {
+		const store = new MemoryStore();
+		for (let i = 0; i < 256; i++) {
+			store.put(String(i), new Uint8Array(i));
+		}
+		const expected = (255 * 256) / 2;
+		const entries = (store as unknown as { store: Map<string, Uint8Array> })
+			.store;
+		Object.defineProperty(entries, Symbol.iterator, {
+			value: () => {
+				throw new Error("size must not iterate entries");
+			},
+		});
+
+		for (let i = 0; i < 1_024; i++) {
+			expect(store.size()).to.equal(expected);
+		}
+	});
+
+	it("does not mutate when reading an incoming byte length throws", () => {
+		const store = new MemoryStore();
+		const original = new Uint8Array(3);
+		store.put("existing", original);
+		const hostile = new Uint8Array(5);
+		Object.defineProperty(hostile, "byteLength", {
+			get: () => {
+				throw new Error("hostile byteLength");
+			},
+		});
+
+		expect(() => store.put("existing", hostile)).to.throw("hostile byteLength");
+		expect(store.get("existing")).to.equal(original);
+		expect(store.size()).to.equal(3);
+
+		expect(() => store.put("new", hostile)).to.throw("hostile byteLength");
+		expect(store.get("new")).to.be.undefined;
+		expect(store.size()).to.equal(3);
+	});
+
+	it("rejects invalid byte lengths before mutating", () => {
+		const store = new MemoryStore();
+		const original = new Uint8Array(3);
+		store.put("existing", original);
+
+		for (const byteLength of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+			const hostile = new Uint8Array(5);
+			Object.defineProperty(hostile, "byteLength", { value: byteLength });
+			expect(() => store.put("existing", hostile)).to.throw(RangeError);
+			expect(store.get("existing")).to.equal(original);
+			expect(store.size()).to.equal(3);
+		}
+	});
+
+	if (isNode) {
+		it("uses credited length after a backing buffer is detached", function () {
+			if (typeof structuredClone !== "function") {
+				this.skip();
+			}
+			const store = new MemoryStore();
+			const buffer = new ArrayBuffer(8);
+			const value = new Uint8Array(buffer);
+			store.put("value", value);
+
+			structuredClone(buffer, { transfer: [buffer] });
+			expect(value.byteLength).to.equal(0);
+			expect(store.size()).to.equal(8);
+
+			store.del("value");
+			expect(store.size()).to.equal(0);
+		});
+
+		it("uses credited length after a backing buffer is resized", function () {
+			type ResizableBuffer = ArrayBuffer & {
+				resize: (byteLength: number) => void;
+			};
+			const ResizableArrayBuffer = ArrayBuffer as typeof ArrayBuffer & {
+				new (
+					byteLength: number,
+					options: { maxByteLength: number },
+				): ResizableBuffer;
+			};
+			if (
+				typeof (ArrayBuffer.prototype as Partial<ResizableBuffer>).resize !==
+				"function"
+			) {
+				this.skip();
+			}
+			const store = new MemoryStore();
+			const buffer = new ResizableArrayBuffer(4, { maxByteLength: 16 });
+			const value = new Uint8Array(buffer);
+			store.put("value", value);
+
+			buffer.resize(12);
+			expect(value.byteLength).to.equal(12);
+			expect(store.size()).to.equal(4);
+
+			store.put("value", new Uint8Array(3));
+			expect(store.size()).to.equal(3);
+			store.del("value");
+			expect(store.size()).to.equal(0);
+		});
+	}
+});

--- a/packages/utils/any-store/interface/src/index.ts
+++ b/packages/utils/any-store/interface/src/index.ts
@@ -16,6 +16,15 @@ export interface AnyStore {
 		>;
 	};
 	clear(): MaybePromise<void>;
+	/**
+	 * Returns the bytes this level's backend accounts to successful writes.
+	 *
+	 * The accounting is based on values when put() succeeds, not on later
+	 * mutations to caller-owned Uint8Array instances. Replacements, deletions,
+	 * and clears update the accounted size when those operations succeed.
+	 * Persistent backends may return an approximation and may include storage
+	 * overhead, so this is not necessarily the sum of current value byteLengths.
+	 */
 	size(): MaybePromise<number>;
 	persisted(): MaybePromise<boolean>;
 }


### PR DESCRIPTION
## Summary

- track MemoryStore logical byte size during mutations so repeated size checks are O(1)
- keep exact per-key insertion-time credits across replacements, deletes, clear, resize, and detachment
- preserve exception atomicity by validating byte length before mutation

This is an independent store-observability improvement. It can reduce repeated memory-usage polling overhead, but it is not the repair for the progressive SharedLog transfer slowdown.

## Validation

- package build
- full any-store tests: Node 38/38, browser 36/36, webworker 36/36
- canonical workspace lint: 0 errors
- independent adversarial review, including real resizable/detached ArrayBuffer and throwing byteLength cases
- git diff check