### PR TITLE
fix(shared-log): bound range rebalance queries

### DIFF
--- a/.changeset/steady-range-rebalance.md
+++ b/.changeset/steady-range-rebalance.md
@@ -2,4 +2,4 @@
 "@peerbit/shared-log": patch
 ---
 
-Bound replication-range rebalance work during rapid replacement bursts while preserving mode transitions and deterministic range history.
+Bound replication-range rebalance work during rapid replacement and full-reset bursts while preserving retired geometry, mode transitions, and deterministic range history.

--- a/.changeset/steady-range-rebalance.md
+++ b/.changeset/steady-range-rebalance.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Bound replication-range rebalance work during rapid replacement bursts while preserving mode transitions and deterministic range history.

--- a/packages/programs/data/shared-log/src/ranges.ts
+++ b/packages/programs/data/shared-log/src/ranges.ts
@@ -2649,10 +2649,12 @@ export const debounceAggregationChanges = <
 					// announcements have the same requirement: a queued A -> B -> C chain emits
 					// removed(A), added(B), removed(B), added(C), so collapsing removals by id
 					// would omit A-only entries.
+					// Segment ids are peer-supplied and only identify state within an owner, so
+					// live additions must include the owner hash to avoid cross-peer collisions.
 					const key =
 						change.type === "replaced" || change.type === "removed"
 							? `${change.type}:${change.range.idString}:${change.range.rangeHash}`
-							: `${change.type}:${change.range.idString}`;
+							: `${change.type}:${change.range.hash}:${change.range.idString}`;
 					const prev = aggregated.get(key);
 					if (prev) {
 						// Replication ingress rejects strictly stale observations, while equal

--- a/packages/programs/data/shared-log/src/ranges.ts
+++ b/packages/programs/data/shared-log/src/ranges.ts
@@ -141,7 +141,10 @@ export class EntryReplicatedU32 implements EntryReplicated<"u32"> {
 		if (!properties.meta && !properties.metaBytes) {
 			throw new Error("Expected meta or metaBytes");
 		}
-		if (!properties.meta && (properties.gid == null || properties.wallTime == null)) {
+		if (
+			!properties.meta &&
+			(properties.gid == null || properties.wallTime == null)
+		) {
 			throw new Error("Expected gid and wallTime with metaBytes");
 		}
 		this.coordinates = properties.coordinates;
@@ -211,7 +214,10 @@ export class EntryReplicatedU64 implements EntryReplicated<"u64"> {
 		if (!properties.meta && !properties.metaBytes) {
 			throw new Error("Expected meta or metaBytes");
 		}
-		if (!properties.meta && (properties.gid == null || properties.wallTime == null)) {
+		if (
+			!properties.meta &&
+			(properties.gid == null || properties.wallTime == null)
+		) {
 			throw new Error("Expected gid and wallTime with metaBytes");
 		}
 		this.coordinates = properties.coordinates;
@@ -841,6 +847,7 @@ export class ReplicationRangeIndexableU32
 	equalRange(other: ReplicationRangeIndexableU32) {
 		return (
 			this.hash === other.hash &&
+			this.mode === other.mode &&
 			this.start1 === other.start1 &&
 			this.end1 === other.end1 &&
 			this.start2 === other.start2 &&
@@ -1020,6 +1027,7 @@ export class ReplicationRangeIndexableU64
 	equalRange(other: ReplicationRangeIndexableU64) {
 		return (
 			this.hash === other.hash &&
+			this.mode === other.mode &&
 			this.start1 === other.start1 &&
 			this.end1 === other.end1 &&
 			this.start2 === other.start2 &&
@@ -2538,33 +2546,49 @@ export const createAssignedRangesQuery = (
 			end2: number | bigint;
 			mode: ReplicationIntent;
 		};
+		/** Internal query-only marker. This wrapper field is never serialized. */
+		rebalanceBoundaryOnly?: boolean;
 	}[],
-	options?: { strict?: boolean },
+	options?: { strict?: boolean; includeBoundaryWhenEmpty?: boolean },
 ) => {
 	let ors: Query[] = [];
-	let onlyStrict = true;
+	let includeBoundary =
+		changes.length === 0 && options?.includeBoundaryWhenEmpty !== false;
 	// TODO what if the ranges are many many?
 	for (const change of changes) {
+		if (change.rebalanceBoundaryOnly) {
+			includeBoundary = true;
+			continue;
+		}
 		const matchRange = matchEntriesInRangeQuery(change.range);
 		ors.push(matchRange);
 		if (change.range.mode === ReplicationIntent.NonStrict) {
-			onlyStrict = false;
+			includeBoundary = true;
 		}
 	}
 
 	// entry is assigned to a range boundary, meaning it is due to be inspected
-	if (!options?.strict) {
-		if (!onlyStrict || changes.length === 0) {
-			ors.push(
-				new BoolQuery({
-					key: "assignedToRangeBoundary",
-					value: true,
-				}),
-			);
-		}
+	if (!options?.strict && includeBoundary) {
+		ors.push(
+			new BoolQuery({
+				key: "assignedToRangeBoundary",
+				value: true,
+			}),
+		);
 	}
 
 	// entry is not sufficiently replicated, and we are to still keep it
+	if (ors.length === 0) {
+		// The index query language rejects Or([]). Use an explicit contradiction
+		// for a non-empty source batch that mergeReplicationChanges proved is a no-op.
+		// Keep the exported helper's historical Or return shape for source consumers.
+		return new Or([
+			new And([
+				new BoolQuery({ key: "assignedToRangeBoundary", value: true }),
+				new BoolQuery({ key: "assignedToRangeBoundary", value: false }),
+			]),
+		]);
+	}
 	return new Or(ors);
 };
 
@@ -2587,7 +2611,15 @@ export type ReplicationChange<
 			type: "replaced";
 			range: T;
 	  }
-) & { timestamp: bigint };
+) & {
+	timestamp: bigint;
+	/**
+	 * Internal, non-wire query intent emitted by mergeReplicationChanges.
+	 * When set, createAssignedRangesQuery performs only the global boundary
+	 * re-evaluation and deliberately ignores this wrapper's range geometry.
+	 */
+	rebalanceBoundaryOnly?: boolean;
+};
 
 export const debounceAggregationChanges = <
 	T extends ReplicationRangeIndexable<any>,
@@ -2620,7 +2652,12 @@ export const debounceAggregationChanges = <
 							: `${change.type}:${change.range.idString}`;
 					const prev = aggregated.get(key);
 					if (prev) {
-						if (prev.range.timestamp < change.range.timestamp) {
+						// Replication ingress rejects strictly stale observations, while equal
+						// timestamps are valid and ordered by arrival. Replace equal/newer keyed
+						// values and move them to the Map tail so a rapid A -> B -> C update
+						// emits replaced(A), replaced(B), added(C) in observed order.
+						if (prev.range.timestamp <= change.range.timestamp) {
+							aggregated.delete(key);
 							aggregated.set(key, change);
 						}
 					} else {
@@ -2639,115 +2676,393 @@ export const debounceAggregationChanges = <
 	);
 };
 
+type IndexedReplicationChange<R extends NumericType> = {
+	change: ReplicationChange<ReplicationRangeIndexable<R>>;
+	index: number;
+	wasInHistory: boolean;
+};
+
+const flattenReplicationChanges = <R extends NumericType>(
+	changesOrChangesArr:
+		| ReplicationChanges<ReplicationRangeIndexable<R>>
+		| ReplicationChanges<ReplicationRangeIndexable<R>>[],
+): ReplicationChange<ReplicationRangeIndexable<R>>[] => {
+	const first = changesOrChangesArr[0];
+	return Array.isArray(first)
+		? (
+				changesOrChangesArr as ReplicationChanges<
+					ReplicationRangeIndexable<R>
+				>[]
+			).flat()
+		: [
+				...(changesOrChangesArr as ReplicationChanges<
+					ReplicationRangeIndexable<R>
+				>),
+			];
+};
+
+type ReplicationProfileDelta = {
+	before: number;
+	beforeNonStrict: number;
+	after: number;
+	afterNonStrict: number;
+};
+
+const diffReplicationProfiles = <R extends NumericType>(
+	before: ReplicationRangeIndexable<R>[],
+	after: ReplicationRangeIndexable<R>[],
+): { geometry: Array<[bigint, bigint]>; boundary: boolean } => {
+	const events = new Map<bigint, ReplicationProfileDelta>();
+	const updateEvent = (
+		point: bigint,
+		property: keyof ReplicationProfileDelta,
+		delta: number,
+	) => {
+		let event = events.get(point);
+		if (!event) {
+			event = {
+				before: 0,
+				beforeNonStrict: 0,
+				after: 0,
+				afterNonStrict: 0,
+			};
+			events.set(point, event);
+		}
+		event[property] += delta;
+	};
+	const addRange = (range: ReplicationRangeIndexable<R>, isBefore: boolean) => {
+		const coverageProperty = isBefore ? "before" : "after";
+		const nonStrictProperty = isBefore ? "beforeNonStrict" : "afterNonStrict";
+		for (const [start, end] of toSegmentsBigInt(range)) {
+			if (start >= end) {
+				continue;
+			}
+			updateEvent(start, coverageProperty, 1);
+			updateEvent(end, coverageProperty, -1);
+			if (range.mode === ReplicationIntent.NonStrict) {
+				updateEvent(start, nonStrictProperty, 1);
+				updateEvent(end, nonStrictProperty, -1);
+			}
+		}
+	};
+	for (const range of before) {
+		addRange(range, true);
+	}
+	for (const range of after) {
+		addRange(range, false);
+	}
+
+	const points = [...events.keys()].sort((a, b) =>
+		a < b ? -1 : a > b ? 1 : 0,
+	);
+	const geometry: Array<[bigint, bigint]> = [];
+	let boundary = false;
+	let beforeCoverage = 0;
+	let beforeNonStrict = 0;
+	let afterCoverage = 0;
+	let afterNonStrict = 0;
+	for (let i = 0; i + 1 < points.length; i++) {
+		const point = points[i];
+		const event = events.get(point)!;
+		beforeCoverage += event.before;
+		beforeNonStrict += event.beforeNonStrict;
+		afterCoverage += event.after;
+		afterNonStrict += event.afterNonStrict;
+		const next = points[i + 1];
+		if (point >= next) {
+			continue;
+		}
+		if (beforeCoverage > 0 !== afterCoverage > 0) {
+			geometry.push([point, next]);
+		}
+		if (beforeNonStrict > 0 !== afterNonStrict > 0) {
+			boundary = true;
+		}
+	}
+	return { geometry: mergeBigIntSegments(geometry), boundary };
+};
+
+const buildStrictQueryRanges = <R extends NumericType>(
+	segments: Array<[bigint, bigint]>,
+	template: ReplicationRangeIndexable<R>,
+): ReplicationRangeIndexable<R>[] => {
+	const merged = mergeBigIntSegments(
+		segments
+			.filter(([start, end]) => start < end)
+			.map(([start, end]) => [start, end]),
+	);
+	if (merged.length === 0) {
+		return [];
+	}
+
+	const max = isU32Range(template) ? BigInt(MAX_U32) : MAX_U64;
+	const arcs: Array<{
+		first: [bigint, bigint];
+		second?: [bigint, bigint];
+	}> = [];
+	if (
+		merged.length > 1 &&
+		merged[0][0] === 0n &&
+		merged[merged.length - 1][1] === max
+	) {
+		arcs.push({
+			first: merged[merged.length - 1],
+			second: merged[0],
+		});
+		for (let i = 1; i + 1 < merged.length; i++) {
+			arcs.push({ first: merged[i] });
+		}
+	} else {
+		for (const segment of merged) {
+			arcs.push({ first: segment });
+		}
+	}
+
+	const proto = Object.getPrototypeOf(template);
+	return arcs.map(({ first, second }) => {
+		const [start1, end1] = toOriginalType(first, template);
+		const [start2, end2] = second
+			? toOriginalType(second, template)
+			: ([start1, end1] as [NumberFromType<R>, NumberFromType<R>]);
+		const widthBigInt =
+			first[1] - first[0] + (second ? second[1] - second[0] : 0n);
+		const width = (
+			isU32Range(template) ? Number(widthBigInt) : widthBigInt
+		) as NumberFromType<R>;
+		return Object.assign(Object.create(proto), {
+			...template,
+			start1,
+			end1,
+			start2,
+			end2,
+			width,
+			mode: ReplicationIntent.Strict,
+		}) as ReplicationRangeIndexable<R>;
+	});
+};
+
+const replicationRangeGeometryKey = <R extends NumericType>(
+	range: ReplicationRangeIndexable<R>,
+) =>
+	toSegmentsBigInt(range)
+		.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+		.map(([start, end]) => `${start}:${end}`)
+		.join("|");
+
 export const mergeReplicationChanges = <R extends NumericType>(
 	changesOrChangesArr:
 		| ReplicationChanges<ReplicationRangeIndexable<R>>
 		| ReplicationChanges<ReplicationRangeIndexable<R>>[],
 	rebalanceHistory: Cache<string>,
 ): ReplicationChange<ReplicationRangeIndexable<R>>[] => {
-	let first = changesOrChangesArr[0];
-	let changes: ReplicationChange<ReplicationRangeIndexable<R>>[];
-	if (!Array.isArray(first)) {
-		changes = changesOrChangesArr as ReplicationChange<
-			ReplicationRangeIndexable<R>
-		>[];
-	} else {
-		changes = changesOrChangesArr.flat() as ReplicationChange<
-			ReplicationRangeIndexable<R>
-		>[];
+	// Work from an immutable snapshot. In particular, synthetic difference ranges
+	// must never become input events or rebalance-history entries.
+	const changes = flattenReplicationChanges(changesOrChangesArr);
+	const originals: IndexedReplicationChange<R>[] = changes.map(
+		(change, index) => ({
+			change,
+			index,
+			wasInHistory: rebalanceHistory.has(change.range.rangeHash),
+		}),
+	);
+	if (originals.length === 0) {
+		return [];
 	}
 
-	// group by hash so we can cancel out changes
-	const grouped = new Map<
+	const consumed = new Set<number>();
+	const fragmentGroups = new Map<
 		string,
-		ReplicationChange<ReplicationRangeIndexable<R>>[]
+		{
+			segments: Array<[bigint, bigint]>;
+			template: IndexedReplicationChange<R>;
+		}
 	>();
-	for (const change of changes) {
-		const prev = grouped.get(change.range.hash);
-		if (prev) {
-			prev.push(change);
-		} else {
-			grouped.set(change.range.hash, [change]);
+	let boundarySource: IndexedReplicationChange<R> | undefined;
+	const addFragments = (
+		owner: string,
+		segments: Array<[bigint, bigint]>,
+		template: IndexedReplicationChange<R>,
+	) => {
+		if (segments.length === 0) {
+			return;
 		}
-	}
-
-	let all: ReplicationChange<ReplicationRangeIndexable<R>>[] = [];
-	for (const [_k, v] of grouped) {
-		if (v.length > 1) {
-			// sort by timestamp so newest is last
-			v.sort((a, b) =>
-				a.range.timestamp < b.range.timestamp
-					? -1
-					: a.range.timestamp > b.range.timestamp
-						? 1
-						: 0,
-			);
-
-			let results: ReplicationChange<ReplicationRangeIndexable<R>>[] = [];
-			let consumed: Set<number> = new Set();
-			for (let i = 0; i < v.length; i++) {
-				// If segment is removed and we have previously processed it then go over each
-				// overlapping added segment and remove the overlap. Equivalent to: (1 - 1 + 1) = 1.
-				if (v[i].type === "removed" || v[i].type === "replaced") {
-					if (rebalanceHistory.has(v[i].range.rangeHash)) {
-						let adjusted = false;
-						const vStart = v.length;
-						for (let j = i + 1; j < vStart; j++) {
-							const newer = v[j];
-							if (newer.type === "added" && !newer.matured) {
-								adjusted = true;
-								const {
-									rangesFromA: updatedRemoved,
-									rangesFromB: updatedNewer,
-								} = symmetricDifferenceRanges(v[i].range, newer.range);
-
-								for (const diff of updatedRemoved) {
-									results.push({
-										range: diff,
-										type: "removed" as const,
-										timestamp: v[i].timestamp,
-									});
-								}
-								for (const diff of updatedNewer) {
-									v.push({
-										range: diff,
-										type: "added" as const,
-										timestamp: newer.timestamp,
-									});
-								}
-								consumed.add(j);
-							}
-						}
-						rebalanceHistory.del(v[i].range.rangeHash);
-						if (!adjusted) {
-							results.push(v[i]);
-						}
-					} else {
-						results.push(v[i]);
-					}
-				} else if (v[i].type === "added") {
-					// TODO should the below clause be used?
-					// after testing it seems that certain changes are not propagating as expected using this
-					/* if (rebalanceHistory.has(v[i].range.rangeHash)) {
-						continue;
-					} */
-
-					rebalanceHistory.add(v[i].range.rangeHash);
-					if (!consumed.has(i)) {
-						results.push(v[i]);
-					}
-				} else {
-					results.push(v[i]);
-				}
+		const existing = fragmentGroups.get(owner);
+		if (existing) {
+			existing.segments.push(...segments);
+			if (
+				existing.template.change.range.timestamp <
+				template.change.range.timestamp
+			) {
+				existing.template = template;
 			}
-
-			all.push(...results);
 		} else {
-			rebalanceHistory.add(v[0].range.rangeHash);
-			all.push(v[0]);
+			fragmentGroups.set(owner, {
+				segments: [...segments],
+				template,
+			});
+		}
+	};
+	const requireBoundary = (source: IndexedReplicationChange<R>) => {
+		if (!boundarySource) {
+			boundarySource = source;
+		}
+	};
+
+	// Replacement provenance is exact: a segment id describes a sequence of real
+	// states. Compare each adjacent state once, then union the resulting query arcs.
+	const replacementGroups = new Map<string, IndexedReplicationChange<R>[]>();
+	for (const original of originals) {
+		if (
+			original.change.type !== "replaced" &&
+			(original.change.type !== "added" || original.change.matured)
+		) {
+			continue;
+		}
+		const key = `${original.change.range.hash}:${original.change.range.idString}`;
+		const group = replacementGroups.get(key);
+		if (group) {
+			group.push(original);
+		} else {
+			replacementGroups.set(key, [original]);
 		}
 	}
-	return all;
+	for (const statesUnsorted of replacementGroups.values()) {
+		if (
+			!statesUnsorted.some((state) => state.change.type === "replaced") ||
+			!statesUnsorted.some((state) => state.change.type === "added")
+		) {
+			continue;
+		}
+		// Range timestamps express role age and may intentionally stay fixed across
+		// adaptive geometry updates. The debounced batch order is the authoritative
+		// state-transition order.
+		const states = [...statesUnsorted].sort((a, b) => a.index - b.index);
+		if (states[states.length - 1].change.type !== "added") {
+			continue;
+		}
+		for (let i = 0; i + 1 < states.length; i++) {
+			const previous = states[i];
+			const next = states[i + 1];
+			const difference = diffReplicationProfiles(
+				[previous.change.range],
+				[next.change.range],
+			);
+			addFragments(previous.change.range.hash, difference.geometry, next);
+			if (difference.boundary) {
+				requireBoundary(next);
+			}
+		}
+		for (const state of states) {
+			consumed.add(state.index);
+		}
+	}
+
+	// Plain reset-style removals/additions have no id provenance. Only removals
+	// whose old state was actually processed may cancel new owner state. Compare
+	// their aggregate owner profiles; leave all unrelated/unmatched changes whole.
+	const plainGroups = new Map<string, IndexedReplicationChange<R>[]>();
+	for (const original of originals) {
+		if (
+			consumed.has(original.index) ||
+			(original.change.type !== "removed" && original.change.type !== "added")
+		) {
+			continue;
+		}
+		const group = plainGroups.get(original.change.range.hash);
+		if (group) {
+			group.push(original);
+		} else {
+			plainGroups.set(original.change.range.hash, [original]);
+		}
+	}
+	for (const ownerChanges of plainGroups.values()) {
+		const removed = ownerChanges.filter(
+			(original) => original.change.type === "removed" && original.wasInHistory,
+		);
+		const added = ownerChanges.filter(
+			(original) =>
+				original.change.type === "added" && !original.change.matured,
+		);
+		if (removed.length === 0 || added.length === 0) {
+			continue;
+		}
+		const difference = diffReplicationProfiles(
+			removed.map((original) => original.change.range),
+			added.map((original) => original.change.range),
+		);
+		const newestAdded = added.reduce((newest, current) =>
+			newest.change.range.timestamp >= current.change.range.timestamp
+				? newest
+				: current,
+		);
+		addFragments(
+			newestAdded.change.range.hash,
+			difference.geometry,
+			newestAdded,
+		);
+		if (difference.boundary) {
+			requireBoundary(newestAdded);
+		}
+		for (const original of [...removed, ...added]) {
+			consumed.add(original.index);
+		}
+	}
+
+	const results: ReplicationChange<ReplicationRangeIndexable<R>>[] = originals
+		.filter((original) => !consumed.has(original.index))
+		.map((original) => original.change);
+	for (const { segments, template } of fragmentGroups.values()) {
+		for (const range of buildStrictQueryRanges(
+			segments,
+			template.change.range,
+		)) {
+			results.push({
+				range,
+				type: "replaced",
+				timestamp: template.change.timestamp,
+			});
+		}
+	}
+
+	// History rotation is deliberately restricted to original source changes and
+	// follows their observed event order. This preserves the actual terminal state:
+	// add -> remove ends absent, while remove -> add ends present.
+	for (const original of originals) {
+		if (original.change.type === "added") {
+			rebalanceHistory.add(original.change.range.rangeHash);
+		} else {
+			rebalanceHistory.del(original.change.range.rangeHash);
+		}
+	}
+
+	// Query type and owner do not affect range matching. Remove exact geometry
+	// duplicates while preferring a non-strict original when it carries boundary
+	// semantics of its own.
+	const deduplicated: ReplicationChange<ReplicationRangeIndexable<R>>[] = [];
+	const positions = new Map<string, number>();
+	for (const result of results) {
+		if (result.rebalanceBoundaryOnly) {
+			continue;
+		}
+		const key = replicationRangeGeometryKey(result.range);
+		const previousPosition = positions.get(key);
+		if (previousPosition == null) {
+			positions.set(key, deduplicated.length);
+			deduplicated.push(result);
+		} else if (
+			deduplicated[previousPosition].range.mode === ReplicationIntent.Strict &&
+			result.range.mode === ReplicationIntent.NonStrict
+		) {
+			deduplicated[previousPosition] = result;
+		}
+	}
+	if (boundarySource) {
+		deduplicated.push({
+			...boundarySource.change,
+			rebalanceBoundaryOnly: true,
+		});
+	}
+	return deduplicated;
 };
 
 const REBALANCE_ITERATOR_BATCH_SIZE = 1048;
@@ -2760,17 +3075,18 @@ export const toRebalance = <R extends "u32" | "u64">(
 	rebalanceHistory: Cache<string>,
 	options?: { forceFresh?: boolean },
 ): AsyncIterable<EntryReplicated<R>> => {
+	const sourceChanges = flattenReplicationChanges(changeOrChanges);
 	const change = options?.forceFresh
-		? Array.isArray(changeOrChanges[0])
-			? (
-					changeOrChanges as ReplicationChanges<ReplicationRangeIndexable<R>>[]
-				).flat()
-			: (changeOrChanges as ReplicationChanges<ReplicationRangeIndexable<R>>)
-		: mergeReplicationChanges(changeOrChanges, rebalanceHistory);
+		? sourceChanges
+		: mergeReplicationChanges(sourceChanges, rebalanceHistory);
 	return {
 		[Symbol.asyncIterator]: async function* () {
 			const iterator = index.iterate({
-				query: createAssignedRangesQuery(change),
+				query: createAssignedRangesQuery(change, {
+					// An explicitly empty request is the existing "retry all boundary"
+					// operation. A non-empty batch optimized to no work must match none.
+					includeBoundaryWhenEmpty: sourceChanges.length === 0,
+				}),
 			});
 			try {
 				while (iterator.done() !== true) {

--- a/packages/programs/data/shared-log/src/ranges.ts
+++ b/packages/programs/data/shared-log/src/ranges.ts
@@ -2642,12 +2642,15 @@ export const debounceAggregationChanges = <
 					// updates produce a `replaced` + `added` pair; collapsing by id would drop the
 					// "removed" portion and prevent correct rebalancing/pruning.
 					//
-					// Preserve each distinct replaced range as well. Adaptive replication can
+					// Preserve each distinct retired range as well. Adaptive replication can
 					// shrink a segment several times before the debounced rebalance runs; if we
 					// keep only the newest `replaced` range, entries from earlier wider ranges are
-					// never revisited and can stay resident after they become prunable.
+					// never revisited and can stay resident after they become prunable. Full reset
+					// announcements have the same requirement: a queued A -> B -> C chain emits
+					// removed(A), added(B), removed(B), added(C), so collapsing removals by id
+					// would omit A-only entries.
 					const key =
-						change.type === "replaced"
+						change.type === "replaced" || change.type === "removed"
 							? `${change.type}:${change.range.idString}:${change.range.rangeHash}`
 							: `${change.type}:${change.range.idString}`;
 					const prev = aggregated.get(key);

--- a/packages/programs/data/shared-log/src/ranges.ts
+++ b/packages/programs/data/shared-log/src/ranges.ts
@@ -2849,11 +2849,155 @@ const replicationRangeGeometryKey = <R extends NumericType>(
 		.map(([start, end]) => `${start}:${end}`)
 		.join("|");
 
+// SQLite's query builder produces a left-deep OR expression. Keep a wide safety
+// margin below SQLite's default expression-depth limit (1000), including the
+// nested comparisons needed for wrapped ranges.
+const MAX_REBALANCE_QUERY_RANGES = 128;
+
+type RebalanceOwnedInterval = {
+	start: bigint;
+	end: bigint;
+	batch: number;
+};
+
+type RebalanceQueryPlan<R extends NumericType> = {
+	boundaryChanges?: ReplicationChange<ReplicationRangeIndexable<R>>[];
+	geometryBatches: ReplicationChange<ReplicationRangeIndexable<R>>[][];
+	ownedIntervals: RebalanceOwnedInterval[];
+};
+
+const createRebalanceQueryPlan = <R extends NumericType>(
+	changes: ReplicationChange<ReplicationRangeIndexable<R>>[],
+	includeBoundaryWhenEmpty: boolean,
+): RebalanceQueryPlan<R> => {
+	const boundarySource = changes.find(
+		(change) =>
+			change.rebalanceBoundaryOnly ||
+			change.range.mode === ReplicationIntent.NonStrict,
+	);
+	const boundaryChanges =
+		boundarySource || includeBoundaryWhenEmpty
+			? boundarySource
+				? [{ ...boundarySource, rebalanceBoundaryOnly: true }]
+				: []
+			: undefined;
+	const geometryChanges = changes.filter(
+		(change) => !change.rebalanceBoundaryOnly,
+	);
+	if (geometryChanges.length === 0) {
+		return { boundaryChanges, geometryBatches: [], ownedIntervals: [] };
+	}
+
+	const template = geometryChanges[geometryChanges.length - 1];
+	const exactSegments = mergeBigIntSegments(
+		geometryChanges
+			.flatMap((change) => toSegmentsBigInt(change.range))
+			.filter(([start, end]) => start < end)
+			.map(([start, end]) => [start, end]),
+	);
+	const exactRanges = buildStrictQueryRanges(exactSegments, template.range);
+	const exactChanges: ReplicationChange<ReplicationRangeIndexable<R>>[] =
+		exactRanges.map((range) => ({
+			range,
+			type: "replaced",
+			timestamp: template.timestamp,
+		}));
+	const geometryBatches: ReplicationChange<ReplicationRangeIndexable<R>>[][] =
+		[];
+	for (
+		let offset = 0;
+		offset < exactChanges.length;
+		offset += MAX_REBALANCE_QUERY_RANGES
+	) {
+		geometryBatches.push(
+			exactChanges.slice(offset, offset + MAX_REBALANCE_QUERY_RANGES),
+		);
+	}
+
+	// A row can contain coordinates in several query batches. Assign every exact
+	// linear interval to its batch up front so candidates can be de-duplicated with
+	// O(component-count) plan memory instead of an unbounded set of emitted hashes.
+	// The two linear pieces of a wrapped seam range inherit the same batch tag.
+	const ownedIntervals = exactRanges
+		.flatMap((range, rangeIndex) =>
+			toSegmentsBigInt(range)
+				.filter(([start, end]) => start < end)
+				.map(([start, end]) => ({
+					start,
+					end,
+					batch: Math.floor(rangeIndex / MAX_REBALANCE_QUERY_RANGES),
+				})),
+		)
+		.sort((a, b) =>
+			a.start < b.start
+				? -1
+				: a.start > b.start
+					? 1
+					: a.end < b.end
+						? -1
+						: a.end > b.end
+							? 1
+							: 0,
+		);
+	for (let i = 1; i < ownedIntervals.length; i++) {
+		if (ownedIntervals[i - 1].end > ownedIntervals[i].start) {
+			throw new Error("Rebalance query intervals must not overlap");
+		}
+	}
+
+	return { boundaryChanges, geometryBatches, ownedIntervals };
+};
+
+const findOwningRebalanceBatch = (
+	coordinates: Array<number | bigint>,
+	intervals: RebalanceOwnedInterval[],
+): number | undefined => {
+	let minimum: number | undefined;
+	for (const value of coordinates) {
+		const coordinate = typeof value === "number" ? BigInt(value) : value;
+		let low = 0;
+		let high = intervals.length - 1;
+		while (low <= high) {
+			const middle = low + Math.floor((high - low) / 2);
+			const interval = intervals[middle];
+			if (coordinate < interval.start) {
+				high = middle - 1;
+			} else if (coordinate >= interval.end) {
+				low = middle + 1;
+			} else {
+				minimum =
+					minimum == null ? interval.batch : Math.min(minimum, interval.batch);
+				break;
+			}
+		}
+		if (minimum === 0) {
+			break;
+		}
+	}
+	return minimum;
+};
+
+const rotateRebalanceHistory = <R extends NumericType>(
+	changes: ReplicationChange<ReplicationRangeIndexable<R>>[],
+	rebalanceHistory: Cache<string>,
+) => {
+	// Only original source changes may enter history, and observed order defines
+	// the terminal state: add -> remove ends absent; remove -> add ends present.
+	for (const change of changes) {
+		if (change.type === "added") {
+			rebalanceHistory.add(change.range.rangeHash);
+		} else {
+			rebalanceHistory.del(change.range.rangeHash);
+		}
+	}
+};
+
 export const mergeReplicationChanges = <R extends NumericType>(
 	changesOrChangesArr:
 		| ReplicationChanges<ReplicationRangeIndexable<R>>
 		| ReplicationChanges<ReplicationRangeIndexable<R>>[],
 	rebalanceHistory: Cache<string>,
+	options?: { updateHistory?: boolean },
 ): ReplicationChange<ReplicationRangeIndexable<R>>[] => {
 	// Work from an immutable snapshot. In particular, synthetic difference ranges
 	// must never become input events or rebalance-history entries.
@@ -2940,6 +3084,14 @@ export const mergeReplicationChanges = <R extends NumericType>(
 		if (states[states.length - 1].change.type !== "added") {
 			continue;
 		}
+		// The overlap between adjacent replacement states is safe to omit only if
+		// the first state was successfully processed before this batch. A replacement
+		// event describes retired geometry, not proof that its overlap was queried.
+		// Without that proof, leave the complete real states in the result so their
+		// union (including the overlap) is inspected.
+		if (!states[0].wasInHistory) {
+			continue;
+		}
 		for (let i = 0; i + 1 < states.length; i++) {
 			const previous = states[i];
 			const next = states[i + 1];
@@ -3024,17 +3176,6 @@ export const mergeReplicationChanges = <R extends NumericType>(
 		}
 	}
 
-	// History rotation is deliberately restricted to original source changes and
-	// follows their observed event order. This preserves the actual terminal state:
-	// add -> remove ends absent, while remove -> add ends present.
-	for (const original of originals) {
-		if (original.change.type === "added") {
-			rebalanceHistory.add(original.change.range.rangeHash);
-		} else {
-			rebalanceHistory.del(original.change.range.rangeHash);
-		}
-	}
-
 	// Query type and owner do not affect range matching. Remove exact geometry
 	// duplicates while preferring a non-strict original when it carries boundary
 	// semantics of its own.
@@ -3062,6 +3203,9 @@ export const mergeReplicationChanges = <R extends NumericType>(
 			rebalanceBoundaryOnly: true,
 		});
 	}
+	if (options?.updateHistory !== false) {
+		rotateRebalanceHistory(changes, rebalanceHistory);
+	}
 	return deduplicated;
 };
 
@@ -3076,30 +3220,86 @@ export const toRebalance = <R extends "u32" | "u64">(
 	options?: { forceFresh?: boolean },
 ): AsyncIterable<EntryReplicated<R>> => {
 	const sourceChanges = flattenReplicationChanges(changeOrChanges);
-	const change = options?.forceFresh
+	const queryChanges = options?.forceFresh
 		? sourceChanges
-		: mergeReplicationChanges(sourceChanges, rebalanceHistory);
+		: mergeReplicationChanges(sourceChanges, rebalanceHistory, {
+				updateHistory: false,
+			});
+	const plan = createRebalanceQueryPlan(
+		queryChanges,
+		sourceChanges.length === 0,
+	);
 	return {
 		[Symbol.asyncIterator]: async function* () {
-			const iterator = index.iterate({
-				query: createAssignedRangesQuery(change, {
-					// An explicitly empty request is the existing "retry all boundary"
-					// operation. A non-empty batch optimized to no work must match none.
-					includeBoundaryWhenEmpty: sourceChanges.length === 0,
-				}),
-			});
+			let completed = false;
 			try {
-				while (iterator.done() !== true) {
-					const entries = await iterator.next(REBALANCE_ITERATOR_BATCH_SIZE);
-					if (entries.length === 0) {
-						break;
+				const passes: Array<{
+					changes: ReplicationChange<ReplicationRangeIndexable<R>>[];
+					geometryBatch?: number;
+				}> = [];
+				if (plan.boundaryChanges) {
+					passes.push({ changes: plan.boundaryChanges });
+				}
+				for (let batch = 0; batch < plan.geometryBatches.length; batch++) {
+					passes.push({
+						changes: plan.geometryBatches[batch],
+						geometryBatch: batch,
+					});
+				}
+
+				for (const pass of passes) {
+					const isGeometry = pass.geometryBatch != null;
+					const iterator = index.iterate({
+						query: createAssignedRangesQuery(pass.changes, {
+							strict: isGeometry,
+							includeBoundaryWhenEmpty: !isGeometry,
+						}),
+					});
+					let passCompleted = false;
+					try {
+						while (iterator.done() !== true) {
+							const entries = await iterator.next(
+								REBALANCE_ITERATOR_BATCH_SIZE,
+							);
+							if (entries.length === 0) {
+								break;
+							}
+							for (const entry of entries) {
+								if (isGeometry) {
+									if (
+										plan.boundaryChanges &&
+										entry.value.assignedToRangeBoundary
+									) {
+										continue;
+									}
+									if (
+										findOwningRebalanceBatch(
+											entry.value.coordinates,
+											plan.ownedIntervals,
+										) !== pass.geometryBatch
+									) {
+										continue;
+									}
+								}
+								yield entry.value;
+							}
+						}
+						passCompleted = iterator.done() === true;
+					} finally {
+						await iterator.close();
 					}
-					for (const entry of entries) {
-						yield entry.value;
+					if (!passCompleted) {
+						return;
 					}
 				}
+				completed = true;
 			} finally {
-				await iterator.close();
+				// An early consumer return, iterator error, incomplete empty batch, or
+				// close failure in any sequential pass must leave history untouched so the
+				// next event retries the complete query. forceFresh preserves its bypass.
+				if (completed && !options?.forceFresh) {
+					rotateRebalanceHistory(sourceChanges, rebalanceHistory);
+				}
 			}
 		},
 	};

--- a/packages/programs/data/shared-log/test/ranges.spec.ts
+++ b/packages/programs/data/shared-log/test/ranges.spec.ts
@@ -2860,6 +2860,213 @@ resolutions.forEach((resolution) => {
 						meta: properties.meta,
 					} as any);
 				};
+				const observeIterationRequests = (
+					target: Index<EntryReplicated<R>>,
+				) => {
+					const requests: any[] = [];
+					return {
+						index: {
+							iterate: (request?: any, options?: any) => {
+								requests.push(request);
+								return target.iterate(request, options);
+							},
+						} as unknown as Index<EntryReplicated<R>>,
+						requests,
+					};
+				};
+				const createSparseRebalanceChanges = (
+					componentCount: number,
+					boundaryIndex?: number,
+				) => {
+					const step = 1 / componentCount;
+					const width = step / 4;
+					const seamOffset = 1 - width / 2;
+					const offsetAt = (index: number) => (seamOffset + index * step) % 1;
+					const centerAt = (index: number) => (offsetAt(index) + width / 2) % 1;
+					const gapAt = (index: number) =>
+						(offsetAt(index) + width + (step - width) / 2) % 1;
+					const ranges = Array.from({ length: componentCount }, (_, index) =>
+						createReplicationRangeFromNormalized({
+							publicKey: a,
+							offset: offsetAt(index),
+							width,
+							mode:
+								index === boundaryIndex
+									? ReplicationIntent.NonStrict
+									: ReplicationIntent.Strict,
+							timestamp: BigInt(index + 1),
+						}),
+					);
+					return {
+						changes: ranges.map(
+							(range): ReplicationChange<ReplicationRangeIndexable<R>> => ({
+								range,
+								type: "added",
+								timestamp: range.timestamp,
+							}),
+						),
+						centerAt,
+						gapAt,
+						ranges,
+					};
+				};
+				const createTestEntry = (
+					gid: string,
+					coordinate: number | number[],
+					assignedToRangeBoundary = false,
+				) =>
+					createEntryReplicated({
+						coordinate: (Array.isArray(coordinate)
+							? coordinate.map(denormalizeFn)
+							: denormalizeFn(coordinate)) as
+							| NumberFromType<R>
+							| NumberFromType<R>[],
+						assignedToRangeBoundary,
+						hash: gid,
+						meta: new Meta({
+							clock: new LamportClock({ id: randomBytes(32) }),
+							gid,
+							next: [],
+							type: 0,
+							data: undefined,
+						}),
+					});
+				const expectFilteredBoundedRequests = (requests: any[]) => {
+					for (const request of requests) {
+						expect(request?.query).to.not.equal(undefined);
+						expect(request.query.or).to.be.an("array");
+						expect(request.query.or.length).to.be.at.most(128);
+					}
+				};
+
+				it("processes replacement overlap accumulated while a debounce run is blocked", async () => {
+					await create(
+						createEntryReplicated({
+							coordinate: denormalizeFn(0.1),
+							assignedToRangeBoundary: false,
+							hash: "left",
+							meta: new Meta({
+								clock: new LamportClock({ id: randomBytes(32) }),
+								gid: "left",
+								next: [],
+								type: 0,
+								data: undefined,
+							}),
+						}),
+						createEntryReplicated({
+							coordinate: denormalizeFn(0.4),
+							assignedToRangeBoundary: false,
+							hash: "overlap",
+							meta: new Meta({
+								clock: new LamportClock({ id: randomBytes(32) }),
+								gid: "overlap",
+								next: [],
+								type: 0,
+								data: undefined,
+							}),
+						}),
+						createEntryReplicated({
+							coordinate: denormalizeFn(0.7),
+							assignedToRangeBoundary: false,
+							hash: "right",
+							meta: new Meta({
+								clock: new LamportClock({ id: randomBytes(32) }),
+								gid: "right",
+								next: [],
+								type: 0,
+								data: undefined,
+							}),
+						}),
+					);
+
+					let markBlocked!: () => void;
+					const blocked = new Promise<void>((resolve) => {
+						markBlocked = resolve;
+					});
+					let releaseBlocked!: () => void;
+					const release = new Promise<void>((resolve) => {
+						releaseBlocked = resolve;
+					});
+					const batches: ReplicationChange<ReplicationRangeIndexable<R>>[][] =
+						[];
+					const debounce = debounceAggregationChanges<
+						ReplicationRangeIndexable<R>
+					>(async (changes) => {
+						batches.push(changes);
+						if (batches.length === 1) {
+							markBlocked();
+							await release;
+						}
+					}, 60_000);
+					const blocker = createReplicationRangeFromNormalized({
+						publicKey: a,
+						offset: 0.9,
+						width: 0.01,
+						timestamp: 1n,
+					});
+					const previous = createReplicationRangeFromNormalized({
+						publicKey: a,
+						offset: 0,
+						width: 0.6,
+						timestamp: 2n,
+					});
+					const current = createReplicationRangeFromNormalized({
+						id: previous.id,
+						publicKey: a,
+						offset: 0.2,
+						width: 0.6,
+						timestamp: 3n,
+					});
+
+					try {
+						const firstRun = debounce.add({
+							range: blocker,
+							type: "added",
+							timestamp: blocker.timestamp,
+						});
+						await blocked;
+						const previousPending = debounce.add({
+							range: previous,
+							type: "replaced",
+							timestamp: previous.timestamp,
+						});
+						const currentPending = debounce.add({
+							range: current,
+							type: "added",
+							timestamp: current.timestamp,
+						});
+						const flushed = debounce.flush();
+						releaseBlocked();
+						await Promise.all([
+							firstRun,
+							previousPending,
+							currentPending,
+							flushed,
+						]);
+
+						expect(batches).to.have.length(2);
+						expect(batches[1].map((change) => change.type)).to.deep.equal([
+							"replaced",
+							"added",
+						]);
+						const result = await consumeAllFromAsyncIterator(
+							toRebalance(
+								batches[1],
+								index,
+								new Cache<string>({ max: 1000, ttl: 1e5 }),
+							),
+						);
+						expect(result.map((entry) => entry.gid)).to.have.members([
+							"left",
+							"overlap",
+							"right",
+						]);
+						expect(result).to.have.length(3);
+					} finally {
+						releaseBlocked();
+						debounce.close();
+					}
+				});
 
 				it("uses bounded batches and closes the rebalance iterator", async () => {
 					const entries = Array.from({ length: 1049 }, (_, i) =>
@@ -2912,6 +3119,342 @@ resolutions.forEach((resolution) => {
 					expect(nextCalls).to.deep.equal([1048, 1048]);
 					expect(allCalls).to.equal(0);
 					expect(closeCalls).to.equal(1);
+				});
+
+				it("commits rebalance history only after complete successful iteration", async () => {
+					const range = createReplicationRangeFromNormalized({
+						publicKey: a,
+						offset: 0.2,
+						width: 0.2,
+						mode: ReplicationIntent.Strict,
+						timestamp: 1n,
+					});
+					const entry = createEntryReplicated({
+						coordinate: denormalizeFn(0.25),
+						assignedToRangeBoundary: false,
+						hash: "entry",
+						meta: new Meta({
+							clock: new LamportClock({ id: randomBytes(32) }),
+							gid: "entry",
+							next: [],
+							type: 0,
+							data: undefined,
+						}),
+					});
+					const changes: ReplicationChange<ReplicationRangeIndexable<R>>[] = [
+						{ range, type: "added", timestamp: range.timestamp },
+					];
+					const makeIndex = (failure?: "next" | "close") => {
+						let offset = 0;
+						let closeCalls = 0;
+						const iterator = {
+							next: async () => {
+								if (failure === "next") {
+									throw new Error("query failed");
+								}
+								offset = 1;
+								return [{ value: entry }] as any;
+							},
+							all: async () => [{ value: entry }] as any,
+							done: () => offset >= 1,
+							close: async () => {
+								closeCalls++;
+								if (failure === "close") {
+									throw new Error("close failed");
+								}
+							},
+							pending: async () => 1 - offset,
+						};
+						return {
+							index: {
+								iterate: () => iterator,
+							} as unknown as Index<EntryReplicated<R>>,
+							get closeCalls() {
+								return closeCalls;
+							},
+						};
+					};
+
+					const failedCache = new Cache<string>({ max: 1000, ttl: 1e5 });
+					const failed = makeIndex("next");
+					let failedError: unknown;
+					try {
+						await consumeAllFromAsyncIterator(
+							toRebalance(changes, failed.index, failedCache),
+						);
+					} catch (error) {
+						failedError = error;
+					}
+					expect(failedError).to.be.instanceOf(Error);
+					expect(failed.closeCalls).to.equal(1);
+					expect(failedCache.has(range.rangeHash)).to.be.false;
+
+					const interruptedCache = new Cache<string>({ max: 1000, ttl: 1e5 });
+					const interrupted = makeIndex();
+					for await (const _entry of toRebalance(
+						changes,
+						interrupted.index,
+						interruptedCache,
+					)) {
+						break;
+					}
+					expect(interrupted.closeCalls).to.equal(1);
+					expect(interruptedCache.has(range.rangeHash)).to.be.false;
+
+					const closeFailureCache = new Cache<string>({ max: 1000, ttl: 1e5 });
+					const closeFailure = makeIndex("close");
+					let closeError: unknown;
+					try {
+						await consumeAllFromAsyncIterator(
+							toRebalance(changes, closeFailure.index, closeFailureCache),
+						);
+					} catch (error) {
+						closeError = error;
+					}
+					expect(closeError).to.be.instanceOf(Error);
+					expect(closeFailure.closeCalls).to.equal(1);
+					expect(closeFailureCache.has(range.rangeHash)).to.be.false;
+
+					const successfulCache = new Cache<string>({ max: 1000, ttl: 1e5 });
+					const successful = makeIndex();
+					await consumeAllFromAsyncIterator(
+						toRebalance(changes, successful.index, successfulCache),
+					);
+					expect(successful.closeCalls).to.equal(1);
+					expect(successfulCache.has(range.rangeHash)).to.be.true;
+				});
+
+				it("queries 1024 exact sparse components without filling their gaps", async () => {
+					const sparse = createSparseRebalanceChanges(1024, 512);
+					await create(
+						createTestEntry("seam", sparse.centerAt(0)),
+						createTestEntry("inside", sparse.centerAt(10)),
+						createTestEntry("multi", [
+							sparse.centerAt(10),
+							sparse.centerAt(300),
+						]),
+						createTestEntry("boundary", sparse.centerAt(700), true),
+						createTestEntry("gap", sparse.gapAt(10)),
+					);
+					const cache = new Cache<string>({ max: 5000, ttl: 1e5 });
+					const observed = observeIterationRequests(index);
+
+					const result = await consumeAllFromAsyncIterator(
+						toRebalance(sparse.changes, observed.index, cache),
+					);
+					expect(result.map((entry) => entry.gid)).to.have.members([
+						"seam",
+						"inside",
+						"multi",
+						"boundary",
+					]);
+					expect(result).to.have.length(4);
+					expect(
+						result.filter((entry) => entry.gid === "multi"),
+					).to.have.length(1);
+					expect(
+						result.filter((entry) => entry.gid === "boundary"),
+					).to.have.length(1);
+					expect(result.some((entry) => entry.gid === "gap")).to.be.false;
+
+					expect(observed.requests).to.have.length(9);
+					expectFilteredBoundedRequests(observed.requests);
+					expect(observed.requests[0].query.or).to.have.length(1);
+					expect(
+						observed.requests[1].query.or.some(
+							(query: any) => Array.isArray(query.or) && query.or.length === 2,
+						),
+					).to.be.true;
+					expect(cache.has(sparse.ranges[1023].rangeHash)).to.be.true;
+				});
+
+				it("queries 4096 evenly spaced components exactly in bounded batches", async () => {
+					const sparse = createSparseRebalanceChanges(4096);
+					await create(
+						createTestEntry("seam", sparse.centerAt(0)),
+						createTestEntry("middle", sparse.centerAt(2048)),
+						createTestEntry("multi", [
+							sparse.centerAt(127),
+							sparse.centerAt(128),
+						]),
+						createTestEntry("gap", sparse.gapAt(2048)),
+					);
+					const cache = new Cache<string>({ max: 5000, ttl: 1e5 });
+					const observed = observeIterationRequests(index);
+
+					const result = await consumeAllFromAsyncIterator(
+						toRebalance(sparse.changes, observed.index, cache),
+					);
+					expect(result.map((entry) => entry.gid)).to.have.members([
+						"seam",
+						"middle",
+						"multi",
+					]);
+					expect(result).to.have.length(3);
+					expect(
+						result.filter((entry) => entry.gid === "multi"),
+					).to.have.length(1);
+					expect(result.some((entry) => entry.gid === "gap")).to.be.false;
+					expect(observed.requests).to.have.length(32);
+					expectFilteredBoundedRequests(observed.requests);
+					expect(
+						observed.requests[0].query.or.some(
+							(query: any) => Array.isArray(query.or) && query.or.length === 2,
+						),
+					).to.be.true;
+					expect(cache.has(sparse.ranges[4095].rangeHash)).to.be.true;
+				});
+
+				it("does not commit history after a middle-batch failure or early return", async () => {
+					const sparse = createSparseRebalanceChanges(300);
+					const middleEntry = createTestEntry("middle", sparse.centerAt(200));
+					const makeSequentialIndex = (properties?: {
+						failure?: "next" | "close";
+						includeMiddleEntry?: boolean;
+					}) => {
+						const requests: any[] = [];
+						const closed: number[] = [];
+						let active = 0;
+						return {
+							index: {
+								iterate: (request?: any) => {
+									expect(active).to.equal(0);
+									active++;
+									const pass = requests.length;
+									requests.push(request);
+									let done = false;
+									return {
+										next: async () => {
+											if (pass === 1 && properties?.failure === "next") {
+												throw new Error("middle query failed");
+											}
+											done = true;
+											return pass === 1 && properties?.includeMiddleEntry
+												? ([{ value: middleEntry }] as any)
+												: [];
+										},
+										all: async () => {
+											throw new Error(
+												"unbounded iterator drain should not be used",
+											);
+										},
+										done: () => done,
+										close: async () => {
+											closed.push(pass);
+											active--;
+											if (pass === 1 && properties?.failure === "close") {
+												throw new Error("middle close failed");
+											}
+										},
+										pending: async () => (done ? 0 : 1),
+									};
+								},
+							} as unknown as Index<EntryReplicated<R>>,
+							requests,
+							closed,
+							get active() {
+								return active;
+							},
+						};
+					};
+
+					for (const failure of ["next", "close"] as const) {
+						const cache = new Cache<string>({ max: 5000, ttl: 1e5 });
+						const observed = makeSequentialIndex({ failure });
+						let caught: unknown;
+						try {
+							await consumeAllFromAsyncIterator(
+								toRebalance(sparse.changes, observed.index, cache),
+							);
+						} catch (error) {
+							caught = error;
+						}
+						expect(caught).to.be.instanceOf(Error);
+						expect(observed.closed).to.deep.equal([0, 1]);
+						expect(observed.active).to.equal(0);
+						expect(observed.requests).to.have.length(2);
+						expectFilteredBoundedRequests(observed.requests);
+						expect(cache.has(sparse.ranges[299].rangeHash)).to.be.false;
+					}
+
+					const interruptedCache = new Cache<string>({
+						max: 5000,
+						ttl: 1e5,
+					});
+					const interrupted = makeSequentialIndex({
+						includeMiddleEntry: true,
+					});
+					const iterator = toRebalance(
+						sparse.changes,
+						interrupted.index,
+						interruptedCache,
+					)[Symbol.asyncIterator]();
+					const first = await iterator.next();
+					expect(first.done).to.be.false;
+					expect(first.value?.gid).to.equal("middle");
+					await iterator.return?.();
+					expect(interrupted.closed).to.deep.equal([0, 1]);
+					expect(interrupted.active).to.equal(0);
+					expect(interrupted.requests).to.have.length(2);
+					expectFilteredBoundedRequests(interrupted.requests);
+					expect(interruptedCache.has(sparse.ranges[299].rangeHash)).to.be
+						.false;
+
+					const successfulCache = new Cache<string>({
+						max: 5000,
+						ttl: 1e5,
+					});
+					const successful = makeSequentialIndex();
+					expect(
+						await consumeAllFromAsyncIterator(
+							toRebalance(sparse.changes, successful.index, successfulCache),
+						),
+					).to.be.empty;
+					expect(successful.closed).to.deep.equal([0, 1, 2]);
+					expect(successful.active).to.equal(0);
+					expect(successful.requests).to.have.length(3);
+					expectFilteredBoundedRequests(successful.requests);
+					expect(successfulCache.has(sparse.ranges[299].rangeHash)).to.be.true;
+				});
+
+				it("keeps empty-source boundary retry separate from a proven no-op", async () => {
+					await create(
+						createTestEntry("ordinary", 0.2),
+						createTestEntry("boundary", 0.8, true),
+					);
+					const emptyCache = new Cache<string>({ max: 1000, ttl: 1e5 });
+					const emptyObserved = observeIterationRequests(index);
+					const retried = await consumeAllFromAsyncIterator(
+						toRebalance([], emptyObserved.index, emptyCache),
+					);
+					expect(retried.map((entry) => entry.gid)).to.deep.equal(["boundary"]);
+					expect(emptyObserved.requests).to.have.length(1);
+					expectFilteredBoundedRequests(emptyObserved.requests);
+					expect(emptyObserved.requests[0].query.or).to.have.length(1);
+
+					const range = createReplicationRangeFromNormalized({
+						publicKey: a,
+						offset: 0.1,
+						width: 0.2,
+						mode: ReplicationIntent.Strict,
+						timestamp: 1n,
+					});
+					const noOpCache = new Cache<string>({ max: 1000, ttl: 1e5 });
+					noOpCache.add(range.rangeHash);
+					const noOpObserved = observeIterationRequests(index);
+					const noOp = await consumeAllFromAsyncIterator(
+						toRebalance(
+							[
+								{ range, type: "removed", timestamp: 1n },
+								{ range, type: "added", timestamp: 2n },
+							],
+							noOpObserved.index,
+							noOpCache,
+						),
+					);
+					expect(noOp).to.be.empty;
+					expect(noOpObserved.requests).to.be.empty;
+					expect(noOpCache.has(range.rangeHash)).to.be.true;
 				});
 
 				it("bounds disjoint rapid replacement chains and keeps synthetic fragments out of history", () => {
@@ -3298,8 +3841,8 @@ resolutions.forEach((resolution) => {
 								);
 								expect(result.map((x) => x.gid)).to.deep.equal(["c"]);
 
-								// Replacement is self-describing: even an empty/expired bounded
-								// history must query only old△new, never their overlapping union.
+								// An empty/expired history cannot prove that the old overlap was ever
+								// processed, so replacement falls back to the correctness-safe union.
 								result = await consumeAllFromAsyncIterator(
 									toRebalance(
 										[
@@ -3318,7 +3861,12 @@ resolutions.forEach((resolution) => {
 										new Cache<string>({ max: 1, ttl: 1 }),
 									),
 								);
-								expect(result.map((x) => x.gid)).to.deep.equal(["c"]);
+								expect(result.map((x) => x.gid)).to.have.members([
+									"a",
+									"b",
+									"c",
+								]);
+								expect(result).to.have.length(3);
 
 								const third = createReplicationRangeFromNormalized({
 									id: first.id,
@@ -3350,8 +3898,12 @@ resolutions.forEach((resolution) => {
 										new Cache<string>({ max: 1, ttl: 1 }),
 									),
 								);
-								expect(result.map((x) => x.gid)).to.have.members(["b", "c"]);
-								expect(result).to.have.length(2);
+								expect(result.map((x) => x.gid)).to.have.members([
+									"a",
+									"b",
+									"c",
+								]);
+								expect(result).to.have.length(3);
 
 								const otherOld = createReplicationRangeFromNormalized({
 									publicKey: a,
@@ -3394,8 +3946,14 @@ resolutions.forEach((resolution) => {
 										new Cache<string>({ max: 1, ttl: 1 }),
 									),
 								);
-								expect(result.map((x) => x.gid)).to.have.members(["c", "e"]);
-								expect(result).to.have.length(2);
+								expect(result.map((x) => x.gid)).to.have.members([
+									"a",
+									"b",
+									"c",
+									"d",
+									"e",
+								]);
+								expect(result).to.have.length(5);
 
 								const unrelated = createReplicationRangeFromNormalized({
 									publicKey: a,
@@ -4069,6 +4627,11 @@ resolutions.forEach((resolution) => {
 								mode: ReplicationIntent.Strict,
 								timestamp: 2n,
 							});
+							const expansionHistory = new Cache<string>({
+								max: 1000,
+								ttl: 1e5,
+							});
+							expansionHistory.add(nonStrict.rangeHash);
 							let result = await consumeAllFromAsyncIterator(
 								toRebalance(
 									[
@@ -4084,7 +4647,7 @@ resolutions.forEach((resolution) => {
 										},
 									],
 									index,
-									new Cache<string>({ max: 1000, ttl: 1e5 }),
+									expansionHistory,
 								),
 							);
 							expect(result.map((entry) => entry.gid)).to.have.members([
@@ -4101,6 +4664,11 @@ resolutions.forEach((resolution) => {
 								mode: ReplicationIntent.NonStrict,
 								timestamp: 3n,
 							});
+							const contractionHistory = new Cache<string>({
+								max: 1000,
+								ttl: 1e5,
+							});
+							contractionHistory.add(expandedStrict.rangeHash);
 							result = await consumeAllFromAsyncIterator(
 								toRebalance(
 									[
@@ -4116,7 +4684,7 @@ resolutions.forEach((resolution) => {
 										},
 									],
 									index,
-									new Cache<string>({ max: 1000, ttl: 1e5 }),
+									contractionHistory,
 								),
 							);
 							expect(result.map((entry) => entry.gid)).to.have.members([
@@ -4178,6 +4746,11 @@ resolutions.forEach((resolution) => {
 								mode: ReplicationIntent.Strict,
 								timestamp: 3n,
 							});
+							const historyWith = (processed: ReplicationRangeIndexable<R>) => {
+								const history = new Cache<string>({ max: 1000, ttl: 1e5 });
+								history.add(processed.rangeHash);
+								return history;
+							};
 
 							// Equal geometry contributes only the independent boundary query;
 							// the ordinary in-range entry must not be replayed.
@@ -4198,7 +4771,7 @@ resolutions.forEach((resolution) => {
 												},
 											],
 											index,
-											new Cache<string>({ max: 1000, ttl: 1e5 }),
+											historyWith(range),
 										),
 									)
 								).map((x) => x.gid),
@@ -4221,7 +4794,7 @@ resolutions.forEach((resolution) => {
 												},
 											],
 											index,
-											new Cache<string>({ max: 1000, ttl: 1e5 }),
+											historyWith(rangeNonStrict),
 										),
 									)
 								).map((x) => x.gid),
@@ -4246,7 +4819,7 @@ resolutions.forEach((resolution) => {
 												},
 											],
 											index,
-											new Cache<string>({ max: 1000, ttl: 1e5 }),
+											historyWith(rangeNonStrict),
 										),
 									)
 								).map((x) => x.gid),
@@ -4269,7 +4842,7 @@ resolutions.forEach((resolution) => {
 												},
 											],
 											index,
-											new Cache<string>({ max: 1000, ttl: 1e5 }),
+											historyWith(rangeStrictAgain),
 										),
 									)
 								).map((x) => x.gid),

--- a/packages/programs/data/shared-log/test/ranges.spec.ts
+++ b/packages/programs/data/shared-log/test/ranges.spec.ts
@@ -2939,6 +2939,108 @@ resolutions.forEach((resolution) => {
 					}
 				};
 
+				it("preserves same-id additions from different owners while a debounce run is blocked", async () => {
+					const b = (await Ed25519Keypair.create()).publicKey;
+					await create(
+						createTestEntry("first-owner", 0.1),
+						createTestEntry("second-owner", 0.7),
+					);
+
+					let markBlocked!: () => void;
+					const blocked = new Promise<void>((resolve) => {
+						markBlocked = resolve;
+					});
+					let releaseBlocked!: () => void;
+					const release = new Promise<void>((resolve) => {
+						releaseBlocked = resolve;
+					});
+					const batches: ReplicationChange<ReplicationRangeIndexable<R>>[][] =
+						[];
+					const debounce = debounceAggregationChanges<
+						ReplicationRangeIndexable<R>
+					>(async (changes) => {
+						batches.push(changes);
+						if (batches.length === 1) {
+							markBlocked();
+							await release;
+						}
+					}, 60_000);
+					const blocker = createReplicationRangeFromNormalized({
+						publicKey: a,
+						offset: 0.9,
+						width: 0.01,
+						timestamp: 1n,
+					});
+					const sharedId = randomBytes(32);
+					const roleTimestamp = 7n;
+					const first = createReplicationRangeFromNormalized({
+						id: sharedId,
+						publicKey: a,
+						offset: 0.05,
+						width: 0.1,
+						mode: ReplicationIntent.Strict,
+						timestamp: roleTimestamp,
+					});
+					const second = createReplicationRangeFromNormalized({
+						id: sharedId,
+						publicKey: b,
+						offset: 0.65,
+						width: 0.1,
+						mode: ReplicationIntent.Strict,
+						timestamp: roleTimestamp,
+					});
+					expect(first.idString).to.equal(second.idString);
+					expect(first.hash).to.not.equal(second.hash);
+
+					try {
+						const firstRun = debounce.add({
+							range: blocker,
+							type: "added",
+							timestamp: blocker.timestamp,
+						});
+						await blocked;
+						const pending = [
+							debounce.add({
+								range: first,
+								type: "added",
+								timestamp: roleTimestamp,
+							}),
+							debounce.add({
+								range: second,
+								type: "added",
+								timestamp: roleTimestamp,
+							}),
+						];
+						const flushed = debounce.flush();
+						releaseBlocked();
+						await Promise.all([firstRun, ...pending, flushed]);
+
+						expect(batches).to.have.length(2);
+						expect(batches[1].map((change) => change.type)).to.deep.equal([
+							"added",
+							"added",
+						]);
+						expect(batches[1].map((change) => change.range.hash)).to.deep.equal(
+							[a.hashcode(), b.hashcode()],
+						);
+
+						const cache = new Cache<string>({ max: 1000, ttl: 1e5 });
+						const result = await consumeAllFromAsyncIterator(
+							toRebalance(batches[1], index, cache),
+						);
+						expect(result.map((entry) => entry.gid)).to.have.members([
+							"first-owner",
+							"second-owner",
+						]);
+						expect(result).to.have.length(2);
+						expect(cache.has(first.rangeHash)).to.be.true;
+						expect(cache.has(second.rangeHash)).to.be.true;
+					} finally {
+						releaseBlocked();
+						debounce.close();
+					}
+				});
+
 				it("processes replacement overlap accumulated while a debounce run is blocked", async () => {
 					await create(
 						createEntryReplicated({

--- a/packages/programs/data/shared-log/test/ranges.spec.ts
+++ b/packages/programs/data/shared-log/test/ranges.spec.ts
@@ -3068,6 +3068,123 @@ resolutions.forEach((resolution) => {
 					}
 				});
 
+				it("preserves chained reset removals accumulated while a debounce run is blocked", async () => {
+					await create(
+						createTestEntry("first-only", 0.1),
+						createTestEntry("second-only", 0.4),
+						createTestEntry("current-only", 0.7),
+					);
+
+					let markBlocked!: () => void;
+					const blocked = new Promise<void>((resolve) => {
+						markBlocked = resolve;
+					});
+					let releaseBlocked!: () => void;
+					const release = new Promise<void>((resolve) => {
+						releaseBlocked = resolve;
+					});
+					const batches: ReplicationChange<ReplicationRangeIndexable<R>>[][] =
+						[];
+					const debounce = debounceAggregationChanges<
+						ReplicationRangeIndexable<R>
+					>(async (changes) => {
+						batches.push(changes);
+						if (batches.length === 1) {
+							markBlocked();
+							await release;
+						}
+					}, 60_000);
+					const blocker = createReplicationRangeFromNormalized({
+						publicKey: a,
+						offset: 0.9,
+						width: 0.01,
+						timestamp: 1n,
+					});
+					const roleTimestamp = 7n;
+					const first = createReplicationRangeFromNormalized({
+						publicKey: a,
+						offset: 0.05,
+						width: 0.1,
+						timestamp: roleTimestamp,
+					});
+					const second = createReplicationRangeFromNormalized({
+						id: first.id,
+						publicKey: a,
+						offset: 0.35,
+						width: 0.1,
+						timestamp: roleTimestamp,
+					});
+					const current = createReplicationRangeFromNormalized({
+						id: first.id,
+						publicKey: a,
+						offset: 0.65,
+						width: 0.1,
+						timestamp: roleTimestamp,
+					});
+
+					try {
+						const firstRun = debounce.add({
+							range: blocker,
+							type: "added",
+							timestamp: blocker.timestamp,
+						});
+						await blocked;
+						const pending = [
+							debounce.add({
+								range: first,
+								type: "removed",
+								timestamp: roleTimestamp,
+							}),
+							debounce.add({
+								range: second,
+								type: "added",
+								timestamp: roleTimestamp,
+							}),
+							debounce.add({
+								range: second,
+								type: "removed",
+								timestamp: roleTimestamp,
+							}),
+							debounce.add({
+								range: current,
+								type: "added",
+								timestamp: roleTimestamp,
+							}),
+						];
+						const flushed = debounce.flush();
+						releaseBlocked();
+						await Promise.all([firstRun, ...pending, flushed]);
+
+						expect(batches).to.have.length(2);
+						expect(batches[1].map((change) => change.type)).to.deep.equal([
+							"removed",
+							"removed",
+							"added",
+						]);
+						expect(
+							batches[1]
+								.filter((change) => change.type === "removed")
+								.map((change) => change.range.rangeHash),
+						).to.deep.equal([first.rangeHash, second.rangeHash]);
+
+						const cache = new Cache<string>({ max: 1000, ttl: 1e5 });
+						cache.add(first.rangeHash);
+						const result = await consumeAllFromAsyncIterator(
+							toRebalance(batches[1], index, cache),
+						);
+						expect(result.map((entry) => entry.gid)).to.have.members([
+							"first-only",
+							"second-only",
+							"current-only",
+						]);
+						expect(result).to.have.length(3);
+						expect([...cache.map.keys()]).to.deep.equal([current.rangeHash]);
+					} finally {
+						releaseBlocked();
+						debounce.close();
+					}
+				});
+
 				it("uses bounded batches and closes the rebalance iterator", async () => {
 					const entries = Array.from({ length: 1049 }, (_, i) =>
 						createEntryReplicated({

--- a/packages/programs/data/shared-log/test/ranges.spec.ts
+++ b/packages/programs/data/shared-log/test/ranges.spec.ts
@@ -1,3 +1,4 @@
+import { serialize } from "@dao-xyz/borsh";
 import { Cache } from "@peerbit/cache";
 import {
 	Ed25519Keypair,
@@ -32,6 +33,7 @@ import {
 	getDistance,
 	getSamples as getSamplesMap,
 	mergeRanges,
+	mergeReplicationChanges,
 	toRebalance,
 } from "../src/ranges.js";
 
@@ -2732,6 +2734,107 @@ resolutions.forEach((resolution) => {
 					).to.deep.equal([0.1]);
 				});
 
+				it("keeps the latest equal-timestamp added state in observed order", async () => {
+					const emitted: ReplicationChange<ReplicationRangeIndexable<R>>[][] =
+						[];
+					let releaseFirstRun: () => void = undefined!;
+					const firstRunStarted = new Promise<void>((resolve) => {
+						releaseFirstRun = resolve;
+					});
+					const debounce = debounceAggregationChanges<
+						ReplicationRangeIndexable<R>
+					>(async (changes) => {
+						emitted.push(changes);
+						if (emitted.length === 1) {
+							await firstRunStarted;
+						}
+					}, 1_000);
+					const blocker = createReplicationRangeFromNormalized({
+						publicKey: a,
+						offset: 0.9,
+						width: 0.02,
+						mode: ReplicationIntent.Strict,
+						timestamp: 1n,
+					});
+					const roleTimestamp = 7n;
+					const first = createReplicationRangeFromNormalized({
+						publicKey: a,
+						offset: 0.05,
+						width: 0.1,
+						mode: ReplicationIntent.Strict,
+						timestamp: roleTimestamp,
+					});
+					const second = createReplicationRangeFromNormalized({
+						id: first.id,
+						publicKey: a,
+						offset: 0.35,
+						width: 0.1,
+						mode: ReplicationIntent.Strict,
+						timestamp: roleTimestamp,
+					});
+					const current = createReplicationRangeFromNormalized({
+						id: first.id,
+						publicKey: a,
+						offset: 0.65,
+						width: 0.1,
+						mode: ReplicationIntent.Strict,
+						timestamp: roleTimestamp,
+					});
+
+					void debounce.add({
+						range: blocker,
+						type: "added",
+						timestamp: blocker.timestamp,
+					});
+					void debounce.add({
+						range: first,
+						type: "replaced",
+						timestamp: roleTimestamp,
+					});
+					void debounce.add({
+						range: second,
+						type: "added",
+						timestamp: roleTimestamp,
+					});
+					void debounce.add({
+						range: second,
+						type: "replaced",
+						timestamp: roleTimestamp,
+					});
+					void debounce.add({
+						range: current,
+						type: "added",
+						timestamp: roleTimestamp,
+					});
+					releaseFirstRun();
+					await debounce.invoke();
+					debounce.close();
+
+					const batch = emitted[1];
+					expect(batch.map((change) => change.type)).to.deep.equal([
+						"replaced",
+						"replaced",
+						"added",
+					]);
+					const finalAdded = batch.filter((change) => change.type === "added");
+					expect(finalAdded).to.have.length(1);
+					expect(finalAdded[0].range.equalRange(current)).to.be.true;
+
+					const cache = new Cache<string>({ max: 1000, ttl: 1e5 });
+					cache.add(first.rangeHash);
+					cache.add(second.rangeHash);
+					const merged = mergeReplicationChanges(batch, cache);
+					const queryRanges = merged
+						.filter((change) => !change.rebalanceBoundaryOnly)
+						.map((change) => change.range);
+					for (const point of [0.1, 0.4, 0.7]) {
+						expect(
+							queryRanges.some((range) => range.contains(denormalizeFn(point))),
+						).to.be.true;
+					}
+					expect([...cache.map.keys()]).to.deep.equal([current.rangeHash]);
+				});
+
 				const consumeAllFromAsyncIterator = async (
 					iter: AsyncIterable<EntryReplicated<R>>,
 				): Promise<EntryReplicated<R>[]> => {
@@ -2809,6 +2912,100 @@ resolutions.forEach((resolution) => {
 					expect(nextCalls).to.deep.equal([1048, 1048]);
 					expect(allCalls).to.equal(0);
 					expect(closeCalls).to.equal(1);
+				});
+
+				it("bounds disjoint rapid replacement chains and keeps synthetic fragments out of history", () => {
+					const transitionCount = 64;
+					const id = randomBytes(32);
+					const states = Array.from(
+						{ length: transitionCount + 1 },
+						(_, index) =>
+							createReplicationRangeFromNormalized({
+								id,
+								publicKey: a,
+								offset: (0.91 + index / (transitionCount + 1)) % 1,
+								width: 0.004,
+								mode: ReplicationIntent.Strict,
+								timestamp: BigInt(index + 1),
+							}),
+					);
+					const changes: ReplicationChange<ReplicationRangeIndexable<R>>[] = [
+						...states.slice(0, -1).map(
+							(range): ReplicationChange<ReplicationRangeIndexable<R>> => ({
+								range,
+								type: "replaced",
+								timestamp: range.timestamp,
+							}),
+						),
+						{
+							range: states[states.length - 1],
+							type: "added",
+							timestamp: states[states.length - 1].timestamp,
+						},
+					];
+					const cache = new Cache<string>({ max: 1000, ttl: 1e5 });
+					cache.add(states[0].rangeHash);
+
+					const result = mergeReplicationChanges(changes, cache);
+					expect(result.some((change) => change.rebalanceBoundaryOnly)).to.be
+						.false;
+					expect(result).to.have.length(states.length);
+					const queryKeys = result.map((change) =>
+						[
+							change.range.start1,
+							change.range.end1,
+							change.range.start2,
+							change.range.end2,
+						].join(":"),
+					);
+					expect(new Set(queryKeys).size).to.equal(queryKeys.length);
+
+					for (const retired of states.slice(0, -1)) {
+						expect(cache.has(retired.rangeHash)).to.be.false;
+					}
+					const finalHash = states[states.length - 1].rangeHash;
+					expect(cache.has(finalHash)).to.be.true;
+					expect([...cache.map.keys()]).to.deep.equal([finalHash]);
+					for (const change of result) {
+						if (change.range.rangeHash !== finalHash) {
+							expect(cache.has(change.range.rangeHash)).to.be.false;
+						}
+					}
+				});
+
+				it("rotates rebalance history in observed terminal event order", () => {
+					const range = createReplicationRangeFromNormalized({
+						publicKey: a,
+						offset: 0.2,
+						width: 0.1,
+						mode: ReplicationIntent.Strict,
+						timestamp: 5n,
+					});
+
+					const addThenRemove = new Cache<string>({ max: 1000, ttl: 1e5 });
+					addThenRemove.add(range.rangeHash);
+					mergeReplicationChanges(
+						[
+							{ range, type: "added", timestamp: 5n },
+							{ range, type: "removed", timestamp: 6n },
+						],
+						addThenRemove,
+					);
+					expect(addThenRemove.has(range.rangeHash)).to.be.false;
+
+					const removeThenAdd = new Cache<string>({ max: 1000, ttl: 1e5 });
+					removeThenAdd.add(range.rangeHash);
+					mergeReplicationChanges(
+						[
+							{ range, type: "removed", timestamp: 6n },
+							{ range, type: "added", timestamp: 7n },
+						],
+						removeThenAdd,
+					);
+					expect(removeThenAdd.has(range.rangeHash)).to.be.true;
+					expect([...removeThenAdd.map.keys()]).to.deep.equal([
+						range.rangeHash,
+					]);
 				});
 
 				rotations.forEach((rotation) => {
@@ -3018,6 +3215,30 @@ resolutions.forEach((resolution) => {
 											data: undefined,
 										}),
 									}),
+									createEntryReplicated({
+										coordinate: denormalizeFn(rotate(0.45)),
+										assignedToRangeBoundary: false,
+										hash: "d",
+										meta: new Meta({
+											clock: new LamportClock({ id: randomBytes(32) }),
+											gid: "d",
+											next: [],
+											type: 0,
+											data: undefined,
+										}),
+									}),
+									createEntryReplicated({
+										coordinate: denormalizeFn(rotate(0.55)),
+										assignedToRangeBoundary: false,
+										hash: "e",
+										meta: new Meta({
+											clock: new LamportClock({ id: randomBytes(32) }),
+											gid: "e",
+											next: [],
+											type: 0,
+											data: undefined,
+										}),
+									}),
 								);
 
 								const first = createReplicationRangeFromNormalized({
@@ -3028,9 +3249,11 @@ resolutions.forEach((resolution) => {
 
 								// second covers first and a little bit more
 								const second = createReplicationRangeFromNormalized({
+									id: first.id,
 									publicKey: a,
 									offset: rotate(0),
 									width: 0.3,
+									timestamp: 2n,
 								});
 
 								// the differential makes it so that only range:
@@ -3074,6 +3297,169 @@ resolutions.forEach((resolution) => {
 									),
 								);
 								expect(result.map((x) => x.gid)).to.deep.equal(["c"]);
+
+								// Replacement is self-describing: even an empty/expired bounded
+								// history must query only old△new, never their overlapping union.
+								result = await consumeAllFromAsyncIterator(
+									toRebalance(
+										[
+											{
+												range: first,
+												type: "replaced",
+												timestamp: 1n,
+											},
+											{
+												range: second,
+												type: "added",
+												timestamp: 2n,
+											},
+										],
+										index,
+										new Cache<string>({ max: 1, ttl: 1 }),
+									),
+								);
+								expect(result.map((x) => x.gid)).to.deep.equal(["c"]);
+
+								const third = createReplicationRangeFromNormalized({
+									id: first.id,
+									publicKey: a,
+									offset: rotate(0),
+									width: 0.1,
+									timestamp: 3n,
+								});
+								result = await consumeAllFromAsyncIterator(
+									toRebalance(
+										[
+											{
+												range: first,
+												type: "replaced",
+												timestamp: 1n,
+											},
+											{
+												range: second,
+												type: "replaced",
+												timestamp: 2n,
+											},
+											{
+												range: third,
+												type: "added",
+												timestamp: 3n,
+											},
+										],
+										index,
+										new Cache<string>({ max: 1, ttl: 1 }),
+									),
+								);
+								expect(result.map((x) => x.gid)).to.have.members(["b", "c"]);
+								expect(result).to.have.length(2);
+
+								const otherOld = createReplicationRangeFromNormalized({
+									publicKey: a,
+									offset: rotate(0.4),
+									width: 0.2,
+									timestamp: 1n,
+								});
+								const otherNew = createReplicationRangeFromNormalized({
+									id: otherOld.id,
+									publicKey: a,
+									offset: rotate(0.4),
+									width: 0.1,
+									timestamp: 2n,
+								});
+								result = await consumeAllFromAsyncIterator(
+									toRebalance(
+										[
+											{
+												range: first,
+												type: "replaced",
+												timestamp: 1n,
+											},
+											{
+												range: second,
+												type: "added",
+												timestamp: 2n,
+											},
+											{
+												range: otherOld,
+												type: "replaced",
+												timestamp: 1n,
+											},
+											{
+												range: otherNew,
+												type: "added",
+												timestamp: 2n,
+											},
+										],
+										index,
+										new Cache<string>({ max: 1, ttl: 1 }),
+									),
+								);
+								expect(result.map((x) => x.gid)).to.have.members(["c", "e"]);
+								expect(result).to.have.length(2);
+
+								const unrelated = createReplicationRangeFromNormalized({
+									publicKey: a,
+									offset: rotate(0),
+									width: 0.2,
+									timestamp: 4n,
+								});
+								expect(unrelated.idString).to.not.equal(first.idString);
+
+								// A same-owner segment with a different id is independent. It must
+								// remain an ordinary add while only the matching old/new id is
+								// reduced to its symmetric difference.
+								result = await consumeAllFromAsyncIterator(
+									toRebalance(
+										[
+											{
+												range: first,
+												type: "replaced",
+												timestamp: 1n,
+											},
+											{
+												range: second,
+												type: "added",
+												timestamp: 2n,
+											},
+											{
+												range: unrelated,
+												type: "added",
+												timestamp: 4n,
+											},
+										],
+										index,
+										new Cache<string>({ max: 1, ttl: 1 }),
+									),
+								);
+								expect(result.map((x) => x.gid)).to.have.members([
+									"a",
+									"b",
+									"c",
+								]);
+								expect(result).to.have.length(3);
+
+								// With no matching added companion, keep the replacement range
+								// whole. An equal-looking range under another id cannot cancel it.
+								result = await consumeAllFromAsyncIterator(
+									toRebalance(
+										[
+											{
+												range: first,
+												type: "replaced",
+												timestamp: 1n,
+											},
+											{
+												range: unrelated,
+												type: "added",
+												timestamp: 4n,
+											},
+										],
+										index,
+										new Cache<string>({ max: 1, ttl: 1 }),
+									),
+								);
+								expect(result.map((x) => x.gid)).to.have.members(["a", "b"]);
+								expect(result).to.have.length(2);
 							});
 
 							it("removed still rebalances when previously processed", async () => {
@@ -3203,9 +3589,11 @@ resolutions.forEach((resolution) => {
 
 								// second covers first and a little bit more
 								const second = createReplicationRangeFromNormalized({
+									id: first.id,
 									publicKey: a,
 									offset: rotate(0),
 									width: 0.3,
+									timestamp: 2n,
 								});
 
 								// the differential makes it so that only range:
@@ -3506,6 +3894,238 @@ resolutions.forEach((resolution) => {
 							expect(result.map((x) => x.gid)).to.deep.eq(["a", "b"]);
 						});
 
+						it("preserves different-id equal-geometry mode transitions without replaying unchanged state", () => {
+							const strict = createReplicationRangeFromNormalized({
+								publicKey: a,
+								offset: rotate(0.5),
+								width: 0.2,
+								mode: ReplicationIntent.Strict,
+								timestamp: 1n,
+							});
+							const nonStrict = createReplicationRangeFromNormalized({
+								publicKey: a,
+								offset: rotate(0.5),
+								width: 0.2,
+								mode: ReplicationIntent.NonStrict,
+								timestamp: 2n,
+							});
+							expect(nonStrict.idString).to.not.equal(strict.idString);
+
+							const cache = new Cache<string>({ max: 1000, ttl: 1e5 });
+							cache.add(strict.rangeHash);
+							let merged = mergeReplicationChanges(
+								[
+									{ range: strict, type: "removed", timestamp: 1n },
+									{ range: nonStrict, type: "added", timestamp: 2n },
+								],
+								cache,
+							);
+							expect(merged).to.have.length(1);
+							expect(merged[0]).to.include({
+								range: nonStrict,
+								type: "added",
+								rebalanceBoundaryOnly: true,
+							});
+							expect(serialize(merged[0].range)).to.deep.equal(
+								serialize(nonStrict),
+							);
+							expect((merged[0].range as any).rebalanceBoundaryOnly).to.be
+								.undefined;
+							expect(cache.has(strict.rangeHash)).to.be.false;
+							expect(cache.has(nonStrict.rangeHash)).to.be.true;
+
+							const unchangedNonStrict = createReplicationRangeFromNormalized({
+								publicKey: a,
+								offset: rotate(0.5),
+								width: 0.2,
+								mode: ReplicationIntent.NonStrict,
+								timestamp: 3n,
+							});
+							expect(unchangedNonStrict.idString).to.not.equal(
+								nonStrict.idString,
+							);
+							merged = mergeReplicationChanges(
+								[
+									{ range: nonStrict, type: "removed", timestamp: 2n },
+									{
+										range: unchangedNonStrict,
+										type: "added",
+										timestamp: 3n,
+									},
+								],
+								cache,
+							);
+							expect(merged).to.be.empty;
+							expect(cache.has(nonStrict.rangeHash)).to.be.false;
+							expect(cache.has(unchangedNonStrict.rangeHash)).to.be.true;
+
+							const strictAgain = createReplicationRangeFromNormalized({
+								publicKey: a,
+								offset: rotate(0.5),
+								width: 0.2,
+								mode: ReplicationIntent.Strict,
+								timestamp: 4n,
+							});
+							expect(strictAgain.idString).to.not.equal(
+								unchangedNonStrict.idString,
+							);
+							merged = mergeReplicationChanges(
+								[
+									{
+										range: unchangedNonStrict,
+										type: "removed",
+										timestamp: 3n,
+									},
+									{ range: strictAgain, type: "added", timestamp: 4n },
+								],
+								cache,
+							);
+							expect(merged).to.have.length(1);
+							expect(merged[0]).to.include({
+								range: strictAgain,
+								type: "added",
+								rebalanceBoundaryOnly: true,
+							});
+							expect(serialize(merged[0].range)).to.deep.equal(
+								serialize(strictAgain),
+							);
+							expect(cache.has(unchangedNonStrict.rangeHash)).to.be.false;
+							expect(cache.has(strictAgain.rangeHash)).to.be.true;
+
+							const unchangedStrict = createReplicationRangeFromNormalized({
+								publicKey: a,
+								offset: rotate(0.5),
+								width: 0.2,
+								mode: ReplicationIntent.Strict,
+								timestamp: 5n,
+							});
+							expect(unchangedStrict.idString).to.not.equal(
+								strictAgain.idString,
+							);
+							merged = mergeReplicationChanges(
+								[
+									{ range: strictAgain, type: "removed", timestamp: 4n },
+									{ range: unchangedStrict, type: "added", timestamp: 5n },
+								],
+								cache,
+							);
+							expect(merged).to.be.empty;
+							expect(cache.has(strictAgain.rangeHash)).to.be.false;
+							expect(cache.has(unchangedStrict.rangeHash)).to.be.true;
+						});
+
+						it("keeps boundary work independent for same-id containment mode transitions", async () => {
+							await create(
+								createEntryReplicated({
+									coordinate: denormalizeFn(rotate(0.6)),
+									assignedToRangeBoundary: true,
+									hash: "boundary",
+									meta: new Meta({
+										clock: new LamportClock({ id: randomBytes(32) }),
+										gid: "boundary",
+										next: [],
+										type: 0,
+										data: undefined,
+									}),
+								}),
+								createEntryReplicated({
+									coordinate: denormalizeFn(rotate(0.05)),
+									assignedToRangeBoundary: false,
+									hash: "overlap",
+									meta: new Meta({
+										clock: new LamportClock({ id: randomBytes(32) }),
+										gid: "overlap",
+										next: [],
+										type: 0,
+										data: undefined,
+									}),
+								}),
+								createEntryReplicated({
+									coordinate: denormalizeFn(rotate(0.25)),
+									assignedToRangeBoundary: false,
+									hash: "delta",
+									meta: new Meta({
+										clock: new LamportClock({ id: randomBytes(32) }),
+										gid: "delta",
+										next: [],
+										type: 0,
+										data: undefined,
+									}),
+								}),
+							);
+
+							const nonStrict = createReplicationRangeFromNormalized({
+								publicKey: a,
+								offset: rotate(0),
+								width: 0.2,
+								mode: ReplicationIntent.NonStrict,
+								timestamp: 1n,
+							});
+							const expandedStrict = createReplicationRangeFromNormalized({
+								id: nonStrict.id,
+								publicKey: a,
+								offset: rotate(0),
+								width: 0.3,
+								mode: ReplicationIntent.Strict,
+								timestamp: 2n,
+							});
+							let result = await consumeAllFromAsyncIterator(
+								toRebalance(
+									[
+										{
+											range: nonStrict,
+											type: "replaced",
+											timestamp: 1n,
+										},
+										{
+											range: expandedStrict,
+											type: "added",
+											timestamp: 2n,
+										},
+									],
+									index,
+									new Cache<string>({ max: 1000, ttl: 1e5 }),
+								),
+							);
+							expect(result.map((entry) => entry.gid)).to.have.members([
+								"boundary",
+								"delta",
+							]);
+							expect(result).to.have.length(2);
+
+							const contractedNonStrict = createReplicationRangeFromNormalized({
+								id: nonStrict.id,
+								publicKey: a,
+								offset: rotate(0),
+								width: 0.2,
+								mode: ReplicationIntent.NonStrict,
+								timestamp: 3n,
+							});
+							result = await consumeAllFromAsyncIterator(
+								toRebalance(
+									[
+										{
+											range: expandedStrict,
+											type: "replaced",
+											timestamp: 2n,
+										},
+										{
+											range: contractedNonStrict,
+											type: "added",
+											timestamp: 3n,
+										},
+									],
+									index,
+									new Cache<string>({ max: 1000, ttl: 1e5 }),
+								),
+							);
+							expect(result.map((entry) => entry.gid)).to.have.members([
+								"boundary",
+								"delta",
+							]);
+							expect(result).to.have.length(2);
+						});
+
 						it("boundary assigned included when updated mixed strictness", async () => {
 							await create(
 								createEntryReplicated({
@@ -3539,15 +4159,28 @@ resolutions.forEach((resolution) => {
 								offset: rotate(0.5),
 								width: 0.2,
 								mode: ReplicationIntent.Strict,
+								timestamp: 1n,
 							});
 
 							const rangeNonStrict = createReplicationRangeFromNormalized({
+								id: range.id,
 								publicKey: a,
 								offset: rotate(0.5),
 								width: 0.2,
 								mode: ReplicationIntent.NonStrict,
+								timestamp: 2n,
+							});
+							const rangeStrictAgain = createReplicationRangeFromNormalized({
+								id: range.id,
+								publicKey: a,
+								offset: rotate(0.5),
+								width: 0.2,
+								mode: ReplicationIntent.Strict,
+								timestamp: 3n,
 							});
 
+							// Equal geometry contributes only the independent boundary query;
+							// the ordinary in-range entry must not be replayed.
 							expect(
 								(
 									await consumeAllFromAsyncIterator(
@@ -3556,13 +4189,12 @@ resolutions.forEach((resolution) => {
 												{
 													range: range,
 													type: "replaced",
-													timestamp: 0n,
+													timestamp: 1n,
 												},
-
 												{
 													range: rangeNonStrict,
 													type: "added",
-													timestamp: 1n,
+													timestamp: 2n,
 												},
 											],
 											index,
@@ -3570,31 +4202,7 @@ resolutions.forEach((resolution) => {
 										),
 									)
 								).map((x) => x.gid),
-							).to.deep.eq(["a", "b"]);
-
-							expect(
-								(
-									await consumeAllFromAsyncIterator(
-										toRebalance(
-											[
-												{
-													range: range,
-													type: "replaced",
-													timestamp: 0n,
-												},
-
-												{
-													range: rangeNonStrict,
-													type: "added",
-													timestamp: 1n,
-												},
-											],
-											index,
-											new Cache<string>({ max: 1000, ttl: 1e5 }),
-										),
-									)
-								).map((x) => x.gid),
-							).to.deep.eq(["a", "b"]);
+							).to.deep.eq(["a"]);
 
 							expect(
 								(
@@ -3604,13 +4212,12 @@ resolutions.forEach((resolution) => {
 												{
 													range: rangeNonStrict,
 													type: "replaced",
-													timestamp: 0n,
+													timestamp: 2n,
 												},
-
 												{
-													range: rangeNonStrict,
+													range: rangeStrictAgain,
 													type: "added",
-													timestamp: 1n,
+													timestamp: 3n,
 												},
 											],
 											index,
@@ -3618,7 +4225,32 @@ resolutions.forEach((resolution) => {
 										),
 									)
 								).map((x) => x.gid),
-							).to.deep.eq(["a", "b"]);
+							).to.deep.eq(["a"]);
+
+							// No semantic or geometric change is a genuine no-op, not the
+							// explicit empty-batch boundary retry operation.
+							expect(
+								(
+									await consumeAllFromAsyncIterator(
+										toRebalance(
+											[
+												{
+													range: rangeNonStrict,
+													type: "replaced",
+													timestamp: 2n,
+												},
+												{
+													range: rangeNonStrict,
+													type: "added",
+													timestamp: 2n,
+												},
+											],
+											index,
+											new Cache<string>({ max: 1000, ttl: 1e5 }),
+										),
+									)
+								).map((x) => x.gid),
+							).to.deep.eq([]);
 
 							expect(
 								(
@@ -3626,15 +4258,14 @@ resolutions.forEach((resolution) => {
 										toRebalance(
 											[
 												{
-													range: range,
+													range: rangeStrictAgain,
 													type: "replaced",
-													timestamp: 0n,
+													timestamp: 3n,
 												},
-
 												{
-													range: range,
+													range: rangeStrictAgain,
 													type: "added",
-													timestamp: 1n,
+													timestamp: 3n,
 												},
 											],
 											index,
@@ -3642,7 +4273,7 @@ resolutions.forEach((resolution) => {
 										),
 									)
 								).map((x) => x.gid),
-							).to.deep.eq(["b"]);
+							).to.deep.eq([]);
 						});
 
 						it("many items", async () => {


### PR DESCRIPTION
## Summary

- normalize replacement geometry into exact disjoint circular components without filling sparse gaps
- partition exact components into sequential SQLite query batches with at most 128 top-level range clauses
- assign seam, boundary, and multi-coordinate rows deterministically so every matching row is handled exactly once without an index-sized dedupe set
- open, drain, and close iterators sequentially, committing range history only after every pass closes successfully
- preserve every distinct retired geometry across blocked replacement and full-reset A → B → C debounce chains
- preserve empty-source, no-op, force-fresh, and boundary retry semantics

This bounds each query shape without turning sparse hostile ranges into a broad or whole-index scan. Total work remains proportional to the exact changed geometry. Sustained cross-message replication-change accumulation is handled separately rather than hidden inside this range-query patch.

## Validation

- shared-log ranges suite: 1,494 passing at the original reviewed head
- adversarial SQLite u32/u64 coverage for 1,024 and 4,096 evenly spaced ranges
- maximum 128 range clauses asserted from generated query ASTs
- seam, boundary, multi-coordinate, iterator failure, early-return, and history transaction regressions
- blocked equal-timestamp full-reset regression: 2/2 (u32/u64)
- neighboring debounce/replacement regressions: 8/8
- negative control without the reset fix fails by dropping A exactly as expected
- current-head full workspace build
- Prettier and `git diff --check`