### PR TITLE
fix(shared-log): serialize join warmup retries

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2758,9 +2758,10 @@ const REPLICATOR_LIVENESS_PROBE_FAILURES_TO_EVICT = 2;
 const CHURN_REPAIR_RETRY_SCHEDULE_MS = [
 	0, 1_000, 3_000, 7_000, 15_000, 30_000, 45_000,
 ];
-const JOIN_WARMUP_RETRY_SCHEDULE_MS = [
-	0, 1_000, 3_000, 7_000, 15_000, 30_000, 60_000,
-];
+// Join warmup is a best-effort latency accelerator. Receipt-driven
+// join-authoritative repair owns loss recovery after the initial warmup sweep.
+// Retrying a fixed warmup snapshot can overlap large sends and amplify work.
+const JOIN_WARMUP_RETRY_SCHEDULE_MS = [0];
 const JOIN_AUTHORITATIVE_RETRY_SCHEDULE_MS = [
 	0, 1_000, 3_000, 7_000, 15_000, 30_000, 60_000,
 ];

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2758,10 +2758,13 @@ const REPLICATOR_LIVENESS_PROBE_FAILURES_TO_EVICT = 2;
 const CHURN_REPAIR_RETRY_SCHEDULE_MS = [
 	0, 1_000, 3_000, 7_000, 15_000, 30_000, 45_000,
 ];
-// Join warmup is a best-effort latency accelerator. Receipt-driven
-// join-authoritative repair owns loss recovery after the initial warmup sweep.
-// Retrying a fixed warmup snapshot can overlap large sends and amplify work.
-const JOIN_WARMUP_RETRY_SCHEDULE_MS = [0];
+// Preserve the bounded retry window for transient local misses, but serialize
+// delayed warmup sends per target so fixed snapshots cannot overlap and amplify
+// large transfers. Every queued pass re-checks current peer knowledge on entry.
+const JOIN_WARMUP_RETRY_SCHEDULE_MS = [
+	0, 1_000, 3_000, 7_000, 15_000, 30_000, 60_000,
+];
+const JOIN_WARMUP_SEND_SPACING_MS = 250;
 const JOIN_AUTHORITATIVE_RETRY_SCHEDULE_MS = [
 	0, 1_000, 3_000, 7_000, 15_000, 30_000, 60_000,
 ];
@@ -2791,6 +2794,48 @@ type RepairMetricBucket = {
 	simpleFallbackPasses: number;
 };
 type RepairMetrics = Record<RepairDispatchMode, RepairMetricBucket>;
+
+type JoinWarmupSendState<R extends "u32" | "u64"> = {
+	bypassKnownPeerHints: boolean;
+	entries: Map<string, RepairDispatchEntry<R>>;
+	generation: object;
+	lastCompletedAt: number;
+	pending: boolean;
+	running: boolean;
+};
+
+type JoinWarmupRetryTimer = {
+	handle: ReturnType<typeof setTimeout>;
+	resolve?: () => void;
+};
+
+type JoinWarmupScheduledRetryBatch<R extends "u32" | "u64"> = {
+	bypassKnownPeerHints: boolean;
+	entries: Map<string, RepairDispatchEntry<R>>;
+	remainingAttempts: number;
+};
+
+type JoinWarmupScheduledRetryCohort<R extends "u32" | "u64"> = {
+	batches: JoinWarmupScheduledRetryBatch<R>[];
+	dueAt: number;
+};
+
+type JoinWarmupScheduledRetrySlot<R extends "u32" | "u64"> = {
+	cohorts: JoinWarmupScheduledRetryCohort<R>[];
+	head: number;
+	timer?: JoinWarmupRetryTimer;
+	timerDueAt?: number;
+};
+
+type JoinWarmupScheduledRetries<R extends "u32" | "u64"> = {
+	generation: object;
+	slotsByDelay: Map<number, JoinWarmupScheduledRetrySlot<R>>;
+};
+
+type RepairSweepOptimisticPeerState = {
+	count: number;
+	generation: object;
+};
 
 const REPAIR_DISPATCH_MODES: RepairDispatchMode[] = [
 	"join-warmup",
@@ -4385,6 +4430,7 @@ export class SharedLog<
 	private _repairSweepRunning!: boolean;
 	private _repairSweepPendingModes!: Set<RepairDispatchMode>;
 	private _repairSweepPendingPeersByMode!: Map<RepairDispatchMode, Set<string>>;
+	private _repairSweepJoinWarmupGenerationByTarget!: Map<string, object>;
 	private _repairFrontierByMode!: Map<
 		RepairDispatchMode,
 		Map<string, Map<string, RepairDispatchEntry<R>>>
@@ -4397,10 +4443,24 @@ export class SharedLog<
 		RepairDispatchMode,
 		Set<string>
 	>;
+	private _joinWarmupGenerationByTarget!: Map<string, object>;
+	private _joinWarmupSendStateByTarget!: Map<
+		string,
+		JoinWarmupSendState<R>
+	>;
+	private _joinWarmupRetryTimersByTarget!: Map<
+		string,
+		Set<JoinWarmupRetryTimer>
+	>;
+	private _joinWarmupScheduledRetriesByTarget!: Map<
+		string,
+		JoinWarmupScheduledRetries<R>
+	>;
 	private _repairSweepOptimisticGidPeersPending!: Map<
 		string,
-		Map<string, number>
+		Map<string, RepairSweepOptimisticPeerState>
 	>;
+	private _repairSweepOptimisticGidsByPeer!: Map<string, Set<string>>;
 	private _entryKnownPeers!: Map<string, Set<string>>;
 	private _entryKnownPeerObservedAt!: Map<string, Map<string, number>>;
 	private _joinAuthoritativeRepairTimersByDelay!: Map<
@@ -4483,12 +4543,20 @@ export class SharedLog<
 		this._repairSweepRunning = false;
 		this._repairSweepPendingModes = new Set();
 		this._repairSweepPendingPeersByMode = createRepairPendingPeersByMode();
+		this._repairSweepJoinWarmupGenerationByTarget = new Map();
 		this._repairFrontierByMode = createRepairFrontierByMode() as Map<
 			RepairDispatchMode,
 			Map<string, Map<string, RepairDispatchEntry<R>>>
 		>;
 		this._repairFrontierActiveTargetsByMode = createRepairActiveTargetsByMode();
+		this._repairFrontierBypassKnownPeersByMode =
+			createRepairFrontierBypassKnownPeersByMode();
+		this._joinWarmupGenerationByTarget = new Map();
+		this._joinWarmupSendStateByTarget = new Map();
+		this._joinWarmupRetryTimersByTarget = new Map();
+		this._joinWarmupScheduledRetriesByTarget = new Map();
 		this._repairSweepOptimisticGidPeersPending = new Map();
+		this._repairSweepOptimisticGidsByPeer = new Map();
 		this._entryKnownPeers = new Map();
 		this._joinAuthoritativeRepairTimersByDelay = new Map();
 		this._joinAuthoritativeRepairPeersByDelay = new Map();
@@ -7038,6 +7106,7 @@ export class SharedLog<
 		key: PublicSignKey | string,
 		options?: {
 			cleanupIfSubscriptionSuperseded?: boolean;
+			expectedJoinWarmupGeneration?: object | null;
 			noEvent?: boolean;
 			onRemoved?: (state: { wasReplicator: boolean }) => void;
 			replicationLifecycleController?: AbortController;
@@ -7046,6 +7115,10 @@ export class SharedLog<
 		},
 	): Promise<boolean> {
 		const keyHash = typeof key === "string" ? key : key.hashcode();
+		const expectedJoinWarmupGeneration =
+			options?.expectedJoinWarmupGeneration !== undefined
+				? options.expectedJoinWarmupGeneration
+				: (this._joinWarmupGenerationByTarget.get(keyHash) ?? null);
 		const ownsSubscriptionEpoch = () =>
 			options?.subscriptionEpoch === undefined ||
 			this.isCurrentSubscriptionEpoch(keyHash, options.subscriptionEpoch);
@@ -7054,6 +7127,15 @@ export class SharedLog<
 			this.isReplicationLifecycleActive(
 				options.replicationLifecycleController,
 			);
+		const cancelExpectedJoinWarmupTarget = () => {
+			if (
+				expectedJoinWarmupGeneration !== null &&
+				this._joinWarmupGenerationByTarget.get(keyHash) ===
+					expectedJoinWarmupGeneration
+			) {
+				this.cancelJoinWarmupTarget(keyHash);
+			}
+		};
 		const isMe = this.node.identity.publicKey.hashcode() === keyHash;
 		let receiveAdmissionBlocked = false;
 		const blockAndDrainPeerReceives = async () => {
@@ -7067,7 +7149,9 @@ export class SharedLog<
 			await blockAndDrainPeerReceives();
 			this.removePeerFromGidPeerHistory(keyHash);
 			this.cleanupPeerDisconnectTracking(keyHash);
-			this.removeRepairFrontierTarget(keyHash);
+			this.removeRepairFrontierTarget(keyHash, {
+				expectedJoinWarmupGeneration,
+			});
 			this._recentRepairDispatch.delete(keyHash);
 			if (!isMe) {
 				await this.syncronizer.onPeerDisconnected(keyHash);
@@ -7108,6 +7192,9 @@ export class SharedLog<
 			if (options?.shouldRemove && !options.shouldRemove()) {
 				return;
 			}
+			// Liveness removal must not cancel a still-current warmup until fresh
+			// activity has been rechecked at the destructive boundary.
+			cancelExpectedJoinWarmupTarget();
 
 			await this.replicationIndex.del({ query: { hash: keyHash } });
 			for (const result of deleted) {
@@ -7141,7 +7228,6 @@ export class SharedLog<
 					throw new Error("Key was not a PublicSignKey");
 				}
 			}
-
 			const timestamp = BigInt(+new Date());
 			for (const x of deleted) {
 				this.replicationChangeDebounceFn.add({
@@ -7830,19 +7916,48 @@ export class SharedLog<
 		return observedAt != null && Date.now() - observedAt <= maxAgeMs;
 	}
 
-	private markRepairSweepOptimisticPeer(gid: string, peer: string) {
+	private markRepairSweepOptimisticPeer(
+		gid: string,
+		peer: string,
+		generation: object,
+	) {
 		let peers = this._repairSweepOptimisticGidPeersPending.get(gid);
 		if (!peers) {
 			peers = new Map();
 			this._repairSweepOptimisticGidPeersPending.set(gid, peers);
 		}
-		peers.set(peer, (peers.get(peer) || 0) + 1);
+		const current = peers.get(peer);
+		peers.set(peer, {
+			count: current?.generation === generation ? current.count + 1 : 1,
+			generation,
+		});
+		let gids = this._repairSweepOptimisticGidsByPeer.get(peer);
+		if (!gids) {
+			gids = new Set();
+			this._repairSweepOptimisticGidsByPeer.set(peer, gids);
+		}
+		gids.add(gid);
 	}
 
 	private hasPendingRepairSweepOptimisticPeer(gid: string, peer: string) {
 		return (
-			(this._repairSweepOptimisticGidPeersPending.get(gid)?.get(peer) || 0) > 0
+			(this._repairSweepOptimisticGidPeersPending.get(gid)?.get(peer)?.count ||
+				0) > 0
 		);
+	}
+
+	private clearRepairSweepOptimisticPeer(peer: string) {
+		for (const gid of this._repairSweepOptimisticGidsByPeer.get(peer) ?? []) {
+			const peers = this._repairSweepOptimisticGidPeersPending.get(gid);
+			if (!peers) {
+				continue;
+			}
+			peers.delete(peer);
+			if (peers.size === 0) {
+				this._repairSweepOptimisticGidPeersPending.delete(gid);
+			}
+		}
+		this._repairSweepOptimisticGidsByPeer.delete(peer);
 	}
 
 	private createEntryReplicatedForRepair(properties: {
@@ -7945,6 +8060,261 @@ export class SharedLog<
 		}
 	}
 
+	private getJoinWarmupGeneration(target: string) {
+		let generation = this._joinWarmupGenerationByTarget.get(target);
+		if (!generation) {
+			generation = {};
+			this._joinWarmupGenerationByTarget.set(target, generation);
+		}
+		return generation;
+	}
+
+	private trackJoinWarmupTimer(
+		target: string,
+		timer: JoinWarmupRetryTimer,
+	) {
+		let timers = this._joinWarmupRetryTimersByTarget.get(target);
+		if (!timers) {
+			timers = new Set();
+			this._joinWarmupRetryTimersByTarget.set(target, timers);
+		}
+		timers.add(timer);
+		this._repairRetryTimers.add(timer.handle);
+	}
+
+	private untrackJoinWarmupTimer(
+		target: string,
+		timer: JoinWarmupRetryTimer,
+	) {
+		this._repairRetryTimers.delete(timer.handle);
+		const timers = this._joinWarmupRetryTimersByTarget.get(target);
+		if (!timers) {
+			return;
+		}
+		timers.delete(timer);
+		if (timers.size === 0) {
+			this._joinWarmupRetryTimersByTarget.delete(target);
+		}
+	}
+
+	private cancelJoinWarmupTimers(target: string) {
+		const timers = this._joinWarmupRetryTimersByTarget.get(target);
+		if (!timers) {
+			return;
+		}
+		for (const timer of [...timers]) {
+			clearTimeout(timer.handle);
+			timer.resolve?.();
+			this.untrackJoinWarmupTimer(target, timer);
+		}
+	}
+
+	private cancelJoinWarmupTarget(target: string) {
+		this._joinWarmupGenerationByTarget.delete(target);
+		const pendingWarmupPeers =
+			this._repairSweepPendingPeersByMode.get("join-warmup");
+		pendingWarmupPeers?.delete(target);
+		if (pendingWarmupPeers?.size === 0) {
+			this._repairSweepPendingModes.delete("join-warmup");
+		}
+		this._repairSweepJoinWarmupGenerationByTarget.delete(target);
+		this.clearRepairSweepOptimisticPeer(target);
+		this.cancelJoinWarmupTimers(target);
+		this._joinWarmupScheduledRetriesByTarget.delete(target);
+		const state = this._joinWarmupSendStateByTarget.get(target);
+		if (!state) {
+			return;
+		}
+		state.bypassKnownPeerHints = false;
+		state.entries.clear();
+		state.pending = false;
+		if (!state.running) {
+			this._joinWarmupSendStateByTarget.delete(target);
+		}
+	}
+
+	private cancelAllJoinWarmupTargets() {
+		const targets = new Set([
+			...this._joinWarmupGenerationByTarget.keys(),
+			...this._joinWarmupRetryTimersByTarget.keys(),
+			...this._joinWarmupScheduledRetriesByTarget.keys(),
+			...this._joinWarmupSendStateByTarget.keys(),
+		]);
+		for (const target of targets) {
+			this.cancelJoinWarmupTarget(target);
+		}
+	}
+
+	private async sleepJoinWarmupTracked(target: string, delayMs: number) {
+		if (delayMs <= 0) {
+			return;
+		}
+		await new Promise<void>((resolve) => {
+			let settled = false;
+			let trackedTimer!: JoinWarmupRetryTimer;
+			const settle = () => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				this.untrackJoinWarmupTimer(target, trackedTimer);
+				resolve();
+			};
+			const handle = setTimeout(settle, delayMs);
+			handle.unref?.();
+			trackedTimer = { handle, resolve: settle };
+			this.trackJoinWarmupTimer(target, trackedTimer);
+		});
+	}
+
+	private scheduleJoinWarmupRetries(
+		target: string,
+		generation: object,
+		delaysMs: Iterable<number>,
+		entries: ReadonlyMap<string, RepairDispatchEntry<R>>,
+		bypassKnownPeerHints: boolean,
+	) {
+		if (
+			this.closed ||
+			this._joinWarmupGenerationByTarget.get(target) !== generation
+		) {
+			return;
+		}
+		let scheduled = this._joinWarmupScheduledRetriesByTarget.get(target);
+		if (scheduled?.generation !== generation) {
+			this.cancelJoinWarmupTimers(target);
+			this._joinWarmupScheduledRetriesByTarget.delete(target);
+			scheduled = undefined;
+		}
+		if (!scheduled) {
+			scheduled = {
+				generation,
+				slotsByDelay: new Map(),
+			};
+			this._joinWarmupScheduledRetriesByTarget.set(target, scheduled);
+		}
+		const delays = [...new Set(delaysMs)];
+		const batch: JoinWarmupScheduledRetryBatch<R> = {
+			bypassKnownPeerHints,
+			entries: new Map(entries),
+			remainingAttempts: delays.length,
+		};
+		const now = Date.now();
+		for (const delayMs of delays) {
+			let slot = scheduled.slotsByDelay.get(delayMs);
+			if (!slot) {
+				slot = { cohorts: [], head: 0 };
+				scheduled.slotsByDelay.set(delayMs, slot);
+			}
+			const tail = slot.cohorts.at(-1);
+			const dueAt = Math.max(tail?.dueAt ?? 0, now + delayMs);
+			if (tail?.dueAt === dueAt) {
+				tail.batches.push(batch);
+			} else {
+				slot.cohorts.push({
+					batches: [batch],
+					dueAt,
+				});
+			}
+			this.armJoinWarmupRetrySlot(
+				target,
+				scheduled,
+				delayMs,
+				slot,
+			);
+		}
+	}
+
+	private armJoinWarmupRetrySlot(
+		target: string,
+		scheduled: JoinWarmupScheduledRetries<R>,
+		delayMs: number,
+		slot: JoinWarmupScheduledRetrySlot<R>,
+	) {
+		const nextDueAt = slot.cohorts[slot.head]?.dueAt;
+		if (nextDueAt == null) {
+			return;
+		}
+		if (slot.timer && slot.timerDueAt === nextDueAt) {
+			return;
+		}
+		if (slot.timer) {
+			clearTimeout(slot.timer.handle);
+			this.untrackJoinWarmupTimer(target, slot.timer);
+		}
+		let trackedTimer!: JoinWarmupRetryTimer;
+		const handle = setTimeout(
+			() => {
+				this.untrackJoinWarmupTimer(target, trackedTimer);
+				if (slot.timer !== trackedTimer) {
+					return;
+				}
+				slot.timer = undefined;
+				slot.timerDueAt = undefined;
+				const current = this._joinWarmupScheduledRetriesByTarget.get(target);
+				if (
+					current !== scheduled ||
+					current.slotsByDelay.get(delayMs) !== slot
+				) {
+					return;
+				}
+
+				const dueEntries = new Map<string, RepairDispatchEntry<R>>();
+				let bypassKnownPeerHints = false;
+				const now = Date.now();
+				while (
+					slot.head < slot.cohorts.length &&
+					slot.cohorts[slot.head].dueAt <= now
+				) {
+					const cohort = slot.cohorts[slot.head++];
+					for (const batch of cohort.batches) {
+						for (const [hash, entry] of batch.entries) {
+							dueEntries.set(hash, entry);
+						}
+						bypassKnownPeerHints ||=
+							batch.bypassKnownPeerHints;
+						batch.remainingAttempts -= 1;
+						if (batch.remainingAttempts === 0) {
+							batch.entries.clear();
+						}
+					}
+					cohort.batches.length = 0;
+				}
+				if (
+					dueEntries.size > 0 &&
+					!this.closed &&
+					this._joinWarmupGenerationByTarget.get(target) ===
+						scheduled.generation
+				) {
+					this.queueJoinWarmupSend(
+						target,
+						scheduled.generation,
+						dueEntries,
+						bypassKnownPeerHints,
+					);
+				}
+				if (slot.head === slot.cohorts.length) {
+					current.slotsByDelay.delete(delayMs);
+					if (current.slotsByDelay.size === 0) {
+						this._joinWarmupScheduledRetriesByTarget.delete(target);
+					}
+					return;
+				}
+				if (slot.head >= 1_024 && slot.head * 2 >= slot.cohorts.length) {
+					slot.cohorts = slot.cohorts.slice(slot.head);
+					slot.head = 0;
+				}
+				this.armJoinWarmupRetrySlot(target, current, delayMs, slot);
+			},
+			Math.max(0, nextDueAt - Date.now()),
+		);
+		handle.unref?.();
+		trackedTimer = { handle };
+		slot.timer = trackedTimer;
+		slot.timerDueAt = nextDueAt;
+		this.trackJoinWarmupTimer(target, trackedTimer);
+	}
+
 	private async getFullReplicaRepairCandidates(
 		extraPeers?: Iterable<string>,
 		options?: { includeSubscribers?: boolean },
@@ -7978,7 +8348,18 @@ export class SharedLog<
 		return candidates;
 	}
 
-	private removeRepairFrontierTarget(target: string) {
+	private removeRepairFrontierTarget(
+		target: string,
+		options?: { expectedJoinWarmupGeneration?: object | null },
+	) {
+		if (
+			options?.expectedJoinWarmupGeneration === undefined ||
+			(options.expectedJoinWarmupGeneration !== null &&
+				this._joinWarmupGenerationByTarget.get(target) ===
+					options.expectedJoinWarmupGeneration)
+		) {
+			this.cancelJoinWarmupTarget(target);
+		}
 		for (const mode of REPAIR_DISPATCH_MODES) {
 			this._repairFrontierByMode.get(mode)?.delete(target);
 			this._repairFrontierActiveTargetsByMode.get(mode)?.delete(target);
@@ -8089,6 +8470,110 @@ export class SharedLog<
 			entries: syncEntries,
 			targets: [target],
 		});
+	}
+
+	private queueJoinWarmupSend(
+		target: string,
+		generation: object,
+		entries: ReadonlyMap<string, RepairDispatchEntry<R>>,
+		bypassKnownPeerHints: boolean,
+	) {
+		if (
+			this.closed ||
+			this._joinWarmupGenerationByTarget.get(target) !== generation
+		) {
+			return;
+		}
+		let state = this._joinWarmupSendStateByTarget.get(target);
+		if (!state) {
+			state = {
+				bypassKnownPeerHints: false,
+				entries: new Map(),
+				generation,
+				lastCompletedAt: Number.NEGATIVE_INFINITY,
+				pending: false,
+				running: false,
+			};
+			this._joinWarmupSendStateByTarget.set(target, state);
+		} else if (state.generation !== generation) {
+			state.bypassKnownPeerHints = false;
+			state.entries.clear();
+			state.pending = false;
+		}
+		for (const [hash, entry] of entries) {
+			state.entries.set(hash, entry);
+		}
+		state.bypassKnownPeerHints ||= bypassKnownPeerHints;
+		state.generation = generation;
+		state.pending = true;
+		if (state.running) {
+			return;
+		}
+		void this.drainJoinWarmupSends(target, state).catch((error: any) =>
+			logger.error(error),
+		);
+	}
+
+	private async drainJoinWarmupSends(
+		target: string,
+		state: JoinWarmupSendState<R>,
+	) {
+		if (state.running) {
+			return;
+		}
+		state.running = true;
+		try {
+			while (state.pending) {
+				state.pending = false;
+				const generation = state.generation;
+				const entries = new Map(state.entries);
+				state.entries.clear();
+				const bypassKnownPeerHints = state.bypassKnownPeerHints;
+				state.bypassKnownPeerHints = false;
+				const spacingMs = Math.max(
+					0,
+					state.lastCompletedAt + JOIN_WARMUP_SEND_SPACING_MS - Date.now(),
+				);
+				await this.sleepJoinWarmupTracked(target, spacingMs);
+				if (
+					this.closed ||
+					state.generation !== generation ||
+					this._joinWarmupGenerationByTarget.get(target) !== generation
+				) {
+					continue;
+				}
+				if (entries.size === 0) {
+					continue;
+				}
+				this._repairMetrics["join-warmup"].simpleFallbackPasses += 1;
+				try {
+					await this.sendRepairEntriesWithTransport(
+						target,
+						entries,
+						"simple",
+						{
+							bypassKnownPeers: bypassKnownPeerHints,
+							bypassRecentKnownPeers: bypassKnownPeerHints,
+						},
+					);
+				} catch (error: any) {
+					logger.error(error);
+				} finally {
+					state.lastCompletedAt = Date.now();
+				}
+			}
+		} finally {
+			state.running = false;
+			if (this._joinWarmupSendStateByTarget.get(target) === state) {
+				if (state.pending) {
+					void this.drainJoinWarmupSends(target, state).catch((error: any) =>
+						logger.error(error),
+					);
+				} else if (!this._joinWarmupGenerationByTarget.has(target)) {
+					this._joinWarmupSendStateByTarget.delete(target);
+				}
+			}
+		}
 	}
 
 	private async sendMaybeMissingEntriesNow(
@@ -8378,18 +8863,34 @@ export class SharedLog<
 		const bucket = this._repairMetrics[options.mode];
 		bucket.dispatches += 1;
 		bucket.entries += filteredEntries.size;
+		const joinWarmupGeneration =
+			options.mode === "join-warmup"
+				? this.getJoinWarmupGeneration(target)
+				: undefined;
+		const bypassKnownPeerHints = this.shouldBypassKnownPeerHints(
+			options.mode,
+			options.bypassKnownPeerHints,
+		);
 
 		const run = (transport: RepairTransportMode) => {
-			if (transport === "simple") {
-				bucket.simpleFallbackPasses += 1;
-			} else {
-				bucket.ratelessFirstPasses += 1;
+			if (
+				transport === "simple" &&
+				options.mode === "join-warmup" &&
+				joinWarmupGeneration
+			) {
+				this.queueJoinWarmupSend(
+					target,
+					joinWarmupGeneration,
+					filteredEntries,
+					bypassKnownPeerHints,
+				);
+				return;
 			}
-			const bypassKnownPeerHints = this.shouldBypassKnownPeerHints(
-				options.mode,
-				options.bypassKnownPeerHints,
-			);
-
+			if (transport === "rateless") {
+				bucket.ratelessFirstPasses += 1;
+			} else {
+				bucket.simpleFallbackPasses += 1;
+			}
 			return Promise.resolve(
 				this.sendRepairEntriesWithTransport(
 					target,
@@ -8403,10 +8904,19 @@ export class SharedLog<
 			).catch((error: any) => logger.error(error));
 		};
 
+		const delayedJoinWarmupRetries: number[] = [];
 		retrySchedule.forEach((delayMs, index) => {
 			const transport = getRepairTransportForAttempt(options.mode, index);
 			if (delayMs === 0) {
 				void run(transport);
+				return;
+			}
+			if (
+				options.mode === "join-warmup" &&
+				joinWarmupGeneration &&
+				transport === "simple"
+			) {
+				delayedJoinWarmupRetries.push(delayMs);
 				return;
 			}
 			const timer = setTimeout(() => {
@@ -8419,19 +8929,46 @@ export class SharedLog<
 			timer.unref?.();
 			this._repairRetryTimers.add(timer);
 		});
+		if (joinWarmupGeneration && delayedJoinWarmupRetries.length > 0) {
+			this.scheduleJoinWarmupRetries(
+				target,
+				joinWarmupGeneration,
+				delayedJoinWarmupRetries,
+				filteredEntries,
+				bypassKnownPeerHints,
+			);
+		}
 	}
 
 	private scheduleRepairSweep(options: {
 		mode: RepairDispatchMode;
 		peers?: Iterable<string>;
+		joinWarmupGenerations?: ReadonlyMap<string, object>;
 	}) {
-		this._repairSweepPendingModes.add(options.mode);
 		const pendingPeers = this._repairSweepPendingPeersByMode.get(options.mode);
 		if (pendingPeers) {
 			for (const peer of options.peers ?? []) {
+				if (options.mode === "join-warmup") {
+					const generation =
+						options.joinWarmupGenerations?.get(peer) ??
+						this.getJoinWarmupGeneration(peer);
+					if (
+						this._joinWarmupGenerationByTarget.get(peer) !== generation
+					) {
+						continue;
+					}
+					this._repairSweepJoinWarmupGenerationByTarget.set(
+						peer,
+						generation,
+					);
+				}
 				pendingPeers.add(peer);
 			}
 		}
+		if (!pendingPeers || pendingPeers.size === 0) {
+			return;
+		}
+		this._repairSweepPendingModes.add(options.mode);
 		if (!this._repairSweepRunning && !this.closed) {
 			this._repairSweepRunning = true;
 			void this.runRepairSweep();
@@ -8493,10 +9030,31 @@ export class SharedLog<
 				const pendingPeersByMode = cloneRepairPendingPeersByMode(
 					this._repairSweepPendingPeersByMode,
 				);
+				const pendingJoinWarmupGenerations = new Map(
+					this._repairSweepJoinWarmupGenerationByTarget,
+				);
 				this._repairSweepPendingModes.clear();
 				for (const peers of this._repairSweepPendingPeersByMode.values()) {
 					peers.clear();
 				}
+				this._repairSweepJoinWarmupGenerationByTarget.clear();
+				const pendingJoinWarmupPeers =
+					pendingPeersByMode.get("join-warmup");
+				const pruneStaleJoinWarmupPeers = () => {
+					for (const peer of [...(pendingJoinWarmupPeers ?? [])]) {
+						if (
+							this._joinWarmupGenerationByTarget.get(peer) !==
+							pendingJoinWarmupGenerations.get(peer)
+						) {
+							pendingJoinWarmupPeers?.delete(peer);
+						}
+					}
+					if (pendingJoinWarmupPeers?.size === 0) {
+						pendingModes.delete("join-warmup");
+					}
+					return pendingModes.size > 0;
+				};
+				pruneStaleJoinWarmupPeers();
 
 				if (pendingModes.size === 0) {
 					return;
@@ -8508,7 +9066,7 @@ export class SharedLog<
 				>();
 				const optimisticGidPeersConsumedByMode = new Map<
 					RepairDispatchMode,
-					Map<string, Map<string, number>>
+					Map<string, Map<string, RepairSweepOptimisticPeerState>>
 				>();
 				for (const mode of pendingModes) {
 					const modePeers = pendingPeersByMode.get(mode);
@@ -8518,20 +9076,22 @@ export class SharedLog<
 					const optimisticGidPeers = new Map<string, Set<string>>();
 					const optimisticGidPeersConsumed = new Map<
 						string,
-						Map<string, number>
+						Map<string, RepairSweepOptimisticPeerState>
 					>();
 					for (const [gid, peerCounts] of this
 						._repairSweepOptimisticGidPeersPending) {
 						let matchedPeers: Set<string> | undefined;
-						let matchedCounts: Map<string, number> | undefined;
-						for (const [peer, count] of peerCounts) {
+						let matchedCounts:
+							| Map<string, RepairSweepOptimisticPeerState>
+							| undefined;
+						for (const [peer, state] of peerCounts) {
 							if (!modePeers.has(peer)) {
 								continue;
 							}
 							matchedPeers ||= new Set();
 							matchedCounts ||= new Map();
 							matchedPeers.add(peer);
-							matchedCounts.set(peer, count);
+							matchedCounts.set(peer, { ...state });
 						}
 						if (matchedPeers && matchedCounts) {
 							optimisticGidPeers.set(gid, matchedPeers);
@@ -8561,6 +9121,7 @@ export class SharedLog<
 					await this.getFullReplicaRepairCandidates(pendingRepairPeers, {
 						includeSubscribers: false,
 					});
+				pruneStaleJoinWarmupPeers();
 				const fullReplicaRepairCandidateCount = Math.max(
 					1,
 					fullReplicaRepairCandidates.size,
@@ -8576,6 +9137,18 @@ export class SharedLog<
 					const targets = pendingByMode.get(mode);
 					const entries = targets?.get(target);
 					if (!entries || entries.size === 0) {
+						return;
+					}
+					if (
+						mode === "join-warmup" &&
+						this._joinWarmupGenerationByTarget.get(target) !==
+							pendingJoinWarmupGenerations.get(target)
+					) {
+						targets?.delete(target);
+						pendingJoinWarmupPeers?.delete(target);
+						if (pendingJoinWarmupPeers?.size === 0) {
+							pendingModes.delete("join-warmup");
+						}
 						return;
 					}
 					this.dispatchMaybeMissingEntries(target, entries, {
@@ -8594,6 +9167,17 @@ export class SharedLog<
 					target: string,
 					entry: RepairDispatchEntry<any>,
 				) => {
+					if (
+						mode === "join-warmup" &&
+						this._joinWarmupGenerationByTarget.get(target) !==
+							pendingJoinWarmupGenerations.get(target)
+					) {
+						pendingJoinWarmupPeers?.delete(target);
+						if (pendingJoinWarmupPeers?.size === 0) {
+							pendingModes.delete("join-warmup");
+						}
+						return;
+					}
 					const sweepTargets = nextFrontierByMode.get(mode);
 					if (sweepTargets) {
 						let sweepSet = sweepTargets.get(target);
@@ -8624,16 +9208,17 @@ export class SharedLog<
 					residentEntriesByHash &&
 					!this.hasCustomFindLeaders()
 				) {
-					const repairDispatchPlan = await this.planResidentRepairDispatchBatch(
-						{
+					const repairDispatchPlan = pruneStaleJoinWarmupPeers()
+						? await this.planResidentRepairDispatchBatch({
 							pendingModes,
 							pendingPeersByMode,
 							optimisticGidPeersByMode,
 							fullReplicaRepairCandidates,
 							fullReplicaRepairCandidateCount,
 							selfHash: this.node.identity.publicKey.hashcode(),
-						},
-					);
+							})
+						: new Map();
+					pruneStaleJoinWarmupPeers();
 					for (const [mode, targets] of repairDispatchPlan) {
 						for (const [target, hashes] of targets) {
 							for (const hash of hashes) {
@@ -8644,13 +9229,20 @@ export class SharedLog<
 							}
 						}
 					}
-				} else {
+				} else if (pruneStaleJoinWarmupPeers()) {
 					const iterator = this.entryCoordinatesIndex.iterate({});
 					try {
-						while (!this.closed && !iterator.done()) {
+						while (
+							!this.closed &&
+							!iterator.done() &&
+							pruneStaleJoinWarmupPeers()
+						) {
 							const entries = await iterator.next(
 								REPAIR_SWEEP_ENTRY_BATCH_SIZE,
 							);
+							if (!pruneStaleJoinWarmupPeers()) {
+								break;
+							}
 							const entryReplicatedBatch = entries.map((entry) => entry.value);
 							const requestedReplicasBatch = entryReplicatedBatch.map((entry) =>
 								decodeReplicas(entry).getValue(this),
@@ -8665,6 +9257,9 @@ export class SharedLog<
 								fullReplicaRepairCandidateCount,
 								selfHash: this.node.identity.publicKey.hashcode(),
 							});
+							if (!pruneStaleJoinWarmupPeers()) {
+								break;
+							}
 							const entriesByHash = new Map(
 								entryReplicatedBatch.map((entry) => [entry.hash, entry]),
 							);
@@ -8694,13 +9289,28 @@ export class SharedLog<
 						if (!pendingPeerCounts) {
 							continue;
 						}
-						for (const [peer, count] of peerCounts) {
-							const current = pendingPeerCounts.get(peer) || 0;
-							const next = current - count;
+						for (const [peer, consumed] of peerCounts) {
+							const current = pendingPeerCounts.get(peer);
+							if (
+								!current ||
+								current.generation !== consumed.generation
+							) {
+								continue;
+							}
+							const next = current.count - consumed.count;
 							if (next > 0) {
-								pendingPeerCounts.set(peer, next);
+								pendingPeerCounts.set(peer, {
+									count: next,
+									generation: current.generation,
+								});
 							} else {
 								pendingPeerCounts.delete(peer);
+								const gids =
+									this._repairSweepOptimisticGidsByPeer.get(peer);
+								gids?.delete(gid);
+								if (gids?.size === 0) {
+									this._repairSweepOptimisticGidsByPeer.delete(peer);
+								}
 							}
 						}
 						if (pendingPeerCounts.size === 0) {
@@ -12905,6 +13515,7 @@ export class SharedLog<
 		this._repairSweepRunning = false;
 		this._repairSweepPendingModes = new Set();
 		this._repairSweepPendingPeersByMode = createRepairPendingPeersByMode();
+		this._repairSweepJoinWarmupGenerationByTarget = new Map();
 		this._repairFrontierByMode = createRepairFrontierByMode() as Map<
 			RepairDispatchMode,
 			Map<string, Map<string, RepairDispatchEntry<R>>>
@@ -12912,7 +13523,12 @@ export class SharedLog<
 		this._repairFrontierActiveTargetsByMode = createRepairActiveTargetsByMode();
 		this._repairFrontierBypassKnownPeersByMode =
 			createRepairFrontierBypassKnownPeersByMode();
+		this._joinWarmupGenerationByTarget = new Map();
+		this._joinWarmupSendStateByTarget ??= new Map();
+		this._joinWarmupRetryTimersByTarget = new Map();
+		this._joinWarmupScheduledRetriesByTarget = new Map();
 		this._repairSweepOptimisticGidPeersPending = new Map();
+		this._repairSweepOptimisticGidsByPeer = new Map();
 		this._entryKnownPeers = new Map();
 		this._entryKnownPeerObservedAt = new Map();
 		this._joinAuthoritativeRepairTimersByDelay = new Map();
@@ -15465,6 +16081,7 @@ export class SharedLog<
 			),
 		);
 		captureSync(() => {
+			this.cancelAllJoinWarmupTargets();
 			for (const timer of this._repairRetryTimers ?? []) clearTimeout(timer);
 			this._repairRetryTimers?.clear();
 			this._recentRepairDispatch?.clear();
@@ -15472,7 +16089,9 @@ export class SharedLog<
 			this._repairSweepPendingModes?.clear();
 			for (const peers of this._repairSweepPendingPeersByMode?.values() ?? [])
 				peers.clear();
+			this._repairSweepJoinWarmupGenerationByTarget?.clear();
 			this._repairSweepOptimisticGidPeersPending?.clear();
+			this._repairSweepOptimisticGidsByPeer?.clear();
 			this._entryKnownPeers?.clear();
 			this._entryKnownPeerObservedAt?.clear();
 			this._nativeSharedLogState?.clearEntryKnownPeers();
@@ -15589,7 +16208,11 @@ export class SharedLog<
 		// SharedLog-specific await or observable teardown can admit a new owner.
 		this.preventParentAttachments();
 		this.stopSubscriptionChangeCallbackAdmission();
+		this.cancelAllJoinWarmupTargets();
 		await this.drainSubscriptionChangeCallbacks();
+		// An already-admitted subscription callback can create a fresh warmup
+		// generation while the first cancellation is draining.
+		this.cancelAllJoinWarmupTargets();
 		await this.drainReceiveHandlers();
 		await this.drainReplicationInfoApplyQueues();
 		await this.drainPendingIHaveCallbacks();
@@ -15713,7 +16336,11 @@ export class SharedLog<
 		// the terminal fence only after that precondition succeeds.
 		this.preventParentAttachments();
 		this.stopSubscriptionChangeCallbackAdmission();
+		this.cancelAllJoinWarmupTargets();
 		await this.drainSubscriptionChangeCallbacks();
+		// An already-admitted subscription callback can create a fresh warmup
+		// generation while the first cancellation is draining.
+		this.cancelAllJoinWarmupTargets();
 		await this.drainReceiveHandlers();
 		await this.drainReplicationInfoApplyQueues();
 		await this.drainPendingIHaveCallbacks();
@@ -22500,6 +23127,9 @@ export class SharedLog<
 			this._subscriptionOpeningEpochByPeer.delete(peerHash);
 			this._openingSyncCapabilitiesByPeer.delete(peerHash);
 			this._replicationInfoBlockedPeers.add(peerHash);
+			const disconnectedJoinWarmupGeneration =
+				this._joinWarmupGenerationByTarget.get(peerHash) ?? null;
+			this.cancelJoinWarmupTarget(peerHash);
 
 			const now = BigInt(+new Date());
 			const previous = this.latestReplicationInfoMessage.get(peerHash);
@@ -22513,6 +23143,8 @@ export class SharedLog<
 				// Proactively evict its ranges so leader selection doesn't keep stale owners.
 				removed = await this.removeReplicator(publicKey, {
 					cleanupIfSubscriptionSuperseded: true,
+					expectedJoinWarmupGeneration:
+						disconnectedJoinWarmupGeneration,
 					noEvent: true,
 					onRemoved: ({ wasReplicator }) => {
 						if (wasReplicator) {
@@ -23076,14 +23708,23 @@ export class SharedLog<
 		if (this.closed) {
 			return;
 		}
-
-		await this.log.trim();
-
 		const batchedChanges = Array.isArray(changeOrChanges[0])
 			? (changeOrChanges as ReplicationChanges<ReplicationRangeIndexable<R>>[])
 			: [changeOrChanges as ReplicationChanges<ReplicationRangeIndexable<R>>];
 		const changes = batchedChanges.flat();
 		const selfHash = this.node.identity.publicKey.hashcode();
+		const joinWarmupGenerations = new Map<string, object>();
+		for (const change of changes) {
+			if (change.type === "added" && change.range.hash !== selfHash) {
+				joinWarmupGenerations.set(
+					change.range.hash,
+					this.getJoinWarmupGeneration(change.range.hash),
+				);
+			}
+		}
+
+		await this.log.trim();
+
 		// On removed ranges (peer leaves / shrink), gid-level history can hide
 		// per-entry gaps. Force a fresh delivery pass for reassigned entries.
 		const forceFreshDelivery = changes.some(
@@ -23161,6 +23802,12 @@ export class SharedLog<
 						),
 				)
 			: changes;
+		const isCurrentJoinWarmupTarget = (target: string) =>
+			warmupPeers.has(target) &&
+			this._joinWarmupGenerationByTarget.get(target) ===
+				joinWarmupGenerations.get(target);
+		const areJoinWarmupGenerationsCurrent = () =>
+			[...warmupPeers].every(isCurrentJoinWarmupTarget);
 
 		try {
 			const uncheckedDeliver: Map<
@@ -23173,6 +23820,10 @@ export class SharedLog<
 					return;
 				}
 				const isWarmupTarget = warmupPeers.has(target);
+				if (isWarmupTarget && !isCurrentJoinWarmupTarget(target)) {
+					uncheckedDeliver.delete(target);
+					return;
+				}
 				const mode: RepairDispatchMode = forceFreshDelivery
 					? "churn"
 					: isWarmupTarget
@@ -23197,6 +23848,9 @@ export class SharedLog<
 				target: string,
 				entry: EntryReplicated<any>,
 			) => {
+				if (warmupPeers.has(target) && !isCurrentJoinWarmupTarget(target)) {
+					return;
+				}
 				churnRepairPeers.add(target);
 				let set = uncheckedDeliver.get(target);
 				if (!set) {
@@ -23221,7 +23875,11 @@ export class SharedLog<
 						forceFresh: forceFreshDelivery || useJoinWarmupFastPath,
 					},
 				)) {
-					if (this.closed) {
+					if (
+						this.closed ||
+						(useJoinWarmupFastPath &&
+							!areJoinWarmupGenerationsCurrent())
+					) {
 						break;
 					}
 
@@ -23241,7 +23899,9 @@ export class SharedLog<
 
 						const candidatePeers = new Set<string>([selfHash]);
 						for (const target of warmupPeers) {
-							candidatePeers.add(target);
+							if (isCurrentJoinWarmupTarget(target)) {
+								candidatePeers.add(target);
+							}
 						}
 						if (oldPeersSet) {
 							for (const oldPeer of oldPeersSet) {
@@ -23258,6 +23918,9 @@ export class SharedLog<
 								persist: false,
 							},
 						);
+						if (!areJoinWarmupGenerationsCurrent()) {
+							continue;
+						}
 
 						if (oldPeersSet) {
 							for (const oldPeer of oldPeersSet) {
@@ -23268,14 +23931,18 @@ export class SharedLog<
 						}
 
 						for (const [peer] of currentPeers) {
-							if (warmupPeers.has(peer)) {
-								this.markRepairSweepOptimisticPeer(entryReplicated.gid, peer);
+							if (isCurrentJoinWarmupTarget(peer)) {
+								this.markRepairSweepOptimisticPeer(
+									entryReplicated.gid,
+									peer,
+									joinWarmupGenerations.get(peer)!,
+								);
 							}
 						}
 
 						const authoritativePeers = [...currentPeers.keys()].filter(
 							(peer) =>
-								!warmupPeers.has(peer) &&
+								!isCurrentJoinWarmupTarget(peer) &&
 								!this.hasPendingRepairSweepOptimisticPeer(
 									entryReplicated.gid,
 									peer,
@@ -23341,8 +24008,12 @@ export class SharedLog<
 					}
 
 					for (const [peer] of currentPeers) {
-						if (addedPeers.has(peer)) {
-							this.markRepairSweepOptimisticPeer(entryReplicated.gid, peer);
+						if (isCurrentJoinWarmupTarget(peer)) {
+							this.markRepairSweepOptimisticPeer(
+								entryReplicated.gid,
+								peer,
+								joinWarmupGenerations.get(peer)!,
+							);
 						}
 					}
 
@@ -23394,6 +24065,7 @@ export class SharedLog<
 					this.scheduleRepairSweep({
 						mode: "join-warmup",
 						peers,
+						joinWarmupGenerations,
 					});
 				}, 250);
 				timer.unref?.();

--- a/packages/programs/data/shared-log/test/lifecycle.spec.ts
+++ b/packages/programs/data/shared-log/test/lifecycle.spec.ts
@@ -39,6 +39,101 @@ describe("lifecycle", () => {
 			expect(closeLog.called).to.be.true;
 		});
 
+		it("keeps a reopened warmup generation behind an active closing send", async () => {
+			session = await TestSession.connected(1);
+			const db = await session.peers[0].open(new EventStore());
+			const sharedLog = db.log as any;
+			let releaseOldSimple: (() => void) | undefined;
+			let markOldSimpleStarted!: () => void;
+			const oldSimpleStarted = new Promise<void>((resolve) => {
+				markOldSimpleStarted = resolve;
+			});
+			let activeSimpleSends = 0;
+			let maxActiveSimpleSends = 0;
+			const simpleEntryBatches: string[][] = [];
+			const send = sinon
+				.stub(sharedLog, "sendRepairEntriesWithTransport")
+				.callsFake(async (...args: unknown[]) => {
+					if (args[2] !== "simple") {
+						return;
+					}
+					activeSimpleSends += 1;
+					maxActiveSimpleSends = Math.max(
+						maxActiveSimpleSends,
+						activeSimpleSends,
+					);
+					simpleEntryBatches.push([
+						...(args[1] as Map<string, unknown>).keys(),
+					]);
+					try {
+						if (simpleEntryBatches.length === 1) {
+							markOldSimpleStarted();
+							await new Promise<void>((resolve) => {
+								releaseOldSimple = resolve;
+							});
+						}
+					} finally {
+						activeSimpleSends -= 1;
+					}
+				});
+
+			try {
+				sharedLog.dispatchMaybeMissingEntries(
+					"target",
+					new Map([["old", { hash: "old" }]]),
+					{
+						bypassRecentDedupe: true,
+						mode: "join-warmup",
+						retryScheduleMs: [0, 1],
+					},
+				);
+				await oldSimpleStarted;
+				const runningState = sharedLog._joinWarmupSendStateByTarget.get(
+					"target",
+				);
+				const oldGeneration = runningState.generation;
+
+				await db.close();
+				expect(
+					sharedLog._joinWarmupSendStateByTarget.get("target"),
+				).to.equal(runningState);
+				await session.peers[0].open(db);
+				expect(
+					sharedLog._joinWarmupSendStateByTarget.get("target"),
+				).to.equal(runningState);
+
+				sharedLog.dispatchMaybeMissingEntries(
+					"target",
+					new Map([["new", { hash: "new" }]]),
+					{
+						bypassRecentDedupe: true,
+						mode: "join-warmup",
+						retryScheduleMs: [0, 1],
+					},
+				);
+				await delay(20);
+				const reopenedState =
+					sharedLog._joinWarmupSendStateByTarget.get("target");
+				expect(reopenedState.generation).to.not.equal(oldGeneration);
+				expect(
+					sharedLog._joinWarmupGenerationByTarget.get("target"),
+				).to.equal(reopenedState.generation);
+				expect(simpleEntryBatches).to.deep.equal([["old"]]);
+				expect(maxActiveSimpleSends).to.equal(1);
+
+				expect(releaseOldSimple).to.be.a("function");
+				releaseOldSimple!();
+				await waitForResolved(() =>
+					expect(simpleEntryBatches).to.deep.equal([["old"], ["new"]]),
+				);
+				expect(maxActiveSimpleSends).to.equal(1);
+			} finally {
+				releaseOldSimple?.();
+				await delay(300);
+				send.restore();
+			}
+		});
+
 		for (const target of [
 			"entry coordinates index",
 			"replication range index",
@@ -162,6 +257,55 @@ describe("lifecycle", () => {
 				releaseLookup();
 				lookup.restore();
 				send.restore();
+			}
+		});
+	}
+
+	for (const operation of ["close", "drop"] as const) {
+		it(`${operation} cancels warmup work created while subscription callbacks drain`, async () => {
+			session = await TestSession.connected(1);
+			const db = await session.peers[0].open(new EventStore());
+			const sharedLog = db.log as any;
+			const target = "late-subscription-target";
+			const drainSubscriptionCallbacks = sinon
+				.stub(sharedLog, "drainSubscriptionChangeCallbacks")
+				.callsFake(async () => {
+					const generation = sharedLog.getJoinWarmupGeneration(target);
+					sharedLog.scheduleJoinWarmupRetries(
+						target,
+						generation,
+						[60_000],
+						new Map([["late-entry", { hash: "late-entry" }]]),
+						false,
+					);
+					expect(
+						sharedLog._joinWarmupGenerationByTarget.get(target),
+					).to.equal(generation);
+					expect(
+						sharedLog._joinWarmupRetryTimersByTarget.get(target)?.size,
+					).to.equal(1);
+				});
+			const drainReceiveHandlers = sinon
+				.stub(sharedLog, "drainReceiveHandlers")
+				.callsFake(async () => {
+					expect(
+						sharedLog._joinWarmupGenerationByTarget.has(target),
+					).to.be.false;
+					expect(
+						sharedLog._joinWarmupRetryTimersByTarget.has(target),
+					).to.be.false;
+					expect(
+						sharedLog._joinWarmupScheduledRetriesByTarget.has(target),
+					).to.be.false;
+				});
+
+			try {
+				await db[operation]();
+				expect(drainSubscriptionCallbacks.calledOnce).to.be.true;
+				expect(drainReceiveHandlers.calledOnce).to.be.true;
+			} finally {
+				drainSubscriptionCallbacks.restore();
+				drainReceiveHandlers.restore();
 			}
 		});
 	}

--- a/packages/programs/data/shared-log/test/replication.spec.ts
+++ b/packages/programs/data/shared-log/test/replication.spec.ts
@@ -2618,6 +2618,67 @@ testSetups.forEach((setup) => {
 							expect(getJoinRepairDispatches()).greaterThan(0);
 						});
 
+						it("control per commmit put before join recovers through scheduled authoritative repair when warmup is dropped", async () => {
+							const entryCount = 12;
+							let droppedWarmupEntries = 0;
+							let authoritativeDispatches = 0;
+							let dispatchStub: sinon.SinonStub | undefined;
+
+							try {
+								await init({
+									min: 1,
+									beforeOther: async () => {
+										for (let i = 0; i < entryCount; i++) {
+											await db1.add("hello", {
+												replicas: new AbsoluteReplicas(3),
+												meta: { next: [] },
+											});
+										}
+									},
+									beforeOpenJoiners: () => {
+										const originalDispatch = (
+											db1.log as any
+										).dispatchMaybeMissingEntries.bind(db1.log);
+										dispatchStub = sinon
+											.stub(db1.log as any, "dispatchMaybeMissingEntries")
+											.callsFake((...args: any[]) => {
+												const [target, entries, options] = args as [
+													string,
+													Map<string, any>,
+													{ mode?: string },
+												];
+												if (options?.mode === "join-warmup") {
+													droppedWarmupEntries += entries.size;
+													return;
+												}
+												if (options?.mode === "join-authoritative") {
+													authoritativeDispatches += 1;
+												}
+												return originalDispatch(target, entries, options);
+											});
+									},
+								});
+
+								await waitForDb1Replicators();
+								await waitForResolved(() => {
+									expect(authoritativeDispatches).greaterThan(0);
+								}, commitReplicationWait);
+
+								const check = async (store: EventStore<string, any>) => {
+									const entries = await store.log.log.toArray();
+									expect(entries.length).equal(entryCount);
+									for (const entry of entries) {
+										expect(decodeReplicas(entry).getValue(store.log)).equal(3);
+									}
+								};
+								await waitForResolved(() => check(db2), commitReplicationWait);
+								await waitForResolved(() => check(db3), commitReplicationWait);
+								expect(droppedWarmupEntries).greaterThan(0);
+							} finally {
+								dispatchStub?.restore();
+							}
+						});
+
 						it("control per commmit put before join converges under deterministic delayed repair traffic", async () => {
 							// Keep this as a convergence regression, not a throughput benchmark. The
 							// direct frontier regression below already covers the multi-flush repair

--- a/packages/programs/data/shared-log/test/sync-session.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-session.spec.ts
@@ -10,46 +10,610 @@ const emptyLog = {
 };
 
 describe("sync-repair-session", () => {
-	it("keeps join warmup bounded to one rateless pass per batch", async () => {
-		const log = new SharedLog<unknown>();
-		const internals = log as any;
-		internals._assumeSyncedRepairSuppressedUntil = 0;
-		internals._repairMetrics = {
-			"join-warmup": {
-				dispatches: 0,
-				entries: 0,
-				ratelessFirstPasses: 0,
-				simpleFallbackPasses: 0,
-			},
-		};
-		const send = sinon
-			.stub(internals, "sendRepairEntriesWithTransport")
-			.resolves();
+	it("coalesces join warmup retries behind one active simple send", async () => {
+		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+		let releaseFirstSimple: (() => void) | undefined;
+		try {
+			const log = new SharedLog<unknown>();
+			log.closed = false;
+			const internals = log as any;
+			internals._assumeSyncedRepairSuppressedUntil = 0;
+			internals._repairMetrics = {
+				"join-warmup": {
+					dispatches: 0,
+					entries: 0,
+					ratelessFirstPasses: 0,
+					simpleFallbackPasses: 0,
+				},
+			};
+			let activeSimpleSends = 0;
+			let maxActiveSimpleSends = 0;
+			const simpleEntryBatches: string[][] = [];
+			const send = sinon
+				.stub(internals, "sendRepairEntriesWithTransport")
+				.callsFake(async (...args: unknown[]) => {
+					const transport = args[2] as string;
+					if (transport !== "simple") {
+						return;
+					}
+					const entries = args[1] as Map<string, unknown>;
+					activeSimpleSends += 1;
+					maxActiveSimpleSends = Math.max(
+						maxActiveSimpleSends,
+						activeSimpleSends,
+					);
+					simpleEntryBatches.push([...entries.keys()]);
+					try {
+						if (simpleEntryBatches.length === 1) {
+							await new Promise<void>((resolve) => {
+								releaseFirstSimple = resolve;
+							});
+						}
+					} finally {
+						activeSimpleSends -= 1;
+					}
+				});
 
-		for (const hash of ["first", "second"]) {
+			for (const hash of ["first", "second"]) {
+				internals.dispatchMaybeMissingEntries(
+					"target",
+					new Map([[hash, { hash }]]),
+					{
+						bypassRecentDedupe: true,
+						mode: "join-warmup",
+						retryScheduleMs: [0, 10, 20, 30],
+					},
+				);
+			}
+			const scheduled =
+				internals._joinWarmupScheduledRetriesByTarget.get("target");
+			expect(scheduled.slotsByDelay.size).to.equal(3);
+			for (const slot of scheduled.slotsByDelay.values()) {
+				expect(slot.cohorts).to.have.length(1);
+				expect(slot.cohorts[0].batches).to.have.length(2);
+				expect(
+					slot.cohorts[0].batches.reduce(
+						(total: number, batch: any) => total + batch.entries.size,
+						0,
+					),
+				).to.equal(2);
+			}
+			expect(
+				internals._joinWarmupRetryTimersByTarget.get("target").size,
+			).to.equal(3);
+			await clock.tickAsync(30);
+
+			expect(
+				send
+					.getCalls()
+					.filter((call) => call.args[2] === "rateless"),
+			).to.have.length(2);
+			expect(simpleEntryBatches).to.have.length(1);
+			expect(maxActiveSimpleSends).to.equal(1);
+			const blockedState = internals._joinWarmupSendStateByTarget.get(
+				"target",
+			);
+			expect(blockedState.pending).to.be.true;
+			expect([...blockedState.entries.keys()]).to.have.members([
+				"first",
+				"second",
+			]);
+			expect(internals._joinWarmupRetryTimersByTarget.size).to.equal(0);
+
+			expect(releaseFirstSimple).to.be.a("function");
+			releaseFirstSimple!();
+			await clock.tickAsync(0);
+			await clock.tickAsync(249);
+			expect(simpleEntryBatches).to.have.length(1);
+			await clock.tickAsync(1);
+
+			expect(simpleEntryBatches).to.have.length(2);
+			expect(simpleEntryBatches[1]).to.have.members(["first", "second"]);
+			expect(maxActiveSimpleSends).to.equal(1);
+			const idleState = internals._joinWarmupSendStateByTarget.get("target");
+			expect(idleState.running).to.be.false;
+			expect(idleState.pending).to.be.false;
+			expect(idleState.entries.size).to.equal(0);
+			expect(internals._repairRetryTimers.size).to.equal(0);
+			expect(internals._repairMetrics["join-warmup"]).to.deep.equal({
+				dispatches: 2,
+				entries: 2,
+				ratelessFirstPasses: 2,
+				simpleFallbackPasses: 2,
+			});
+		} finally {
+			releaseFirstSimple?.();
+			await clock.tickAsync(1_000);
+			clock.restore();
+		}
+	});
+
+	it("releases each warmup delay slot without retaining earlier scan batches", async () => {
+		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+		try {
+			const log = new SharedLog<unknown>();
+			log.closed = false;
+			const internals = log as any;
+			internals._assumeSyncedRepairSuppressedUntil = 0;
+			internals._repairMetrics = {
+				"join-warmup": {
+					dispatches: 0,
+					entries: 0,
+					ratelessFirstPasses: 0,
+					simpleFallbackPasses: 0,
+				},
+			};
+			sinon.stub(internals, "sendRepairEntriesWithTransport").resolves();
+			const queued: string[][] = [];
+			sinon
+				.stub(internals, "queueJoinWarmupSend")
+				.callsFake((...args: unknown[]) => {
+					queued.push([...(args[2] as Map<string, unknown>).keys()]);
+				});
+
 			internals.dispatchMaybeMissingEntries(
 				"target",
-				new Map([[hash, { hash }]]),
+				new Map([["early", { hash: "early" }]]),
+				{
+					bypassRecentDedupe: true,
+					mode: "join-warmup",
+					retryScheduleMs: [0, 10],
+				},
+			);
+			await clock.tickAsync(9);
+			internals.dispatchMaybeMissingEntries(
+				"target",
+				new Map([["late", { hash: "late" }]]),
+				{
+					bypassRecentDedupe: true,
+					mode: "join-warmup",
+					retryScheduleMs: [0, 10],
+				},
+			);
+			expect(
+				internals._joinWarmupRetryTimersByTarget.get("target").size,
+			).to.equal(1);
+
+			await clock.tickAsync(1);
+			expect(queued).to.deep.equal([["early"]]);
+			const slot = internals._joinWarmupScheduledRetriesByTarget
+				.get("target")
+				.slotsByDelay.get(10);
+			expect(
+				slot.cohorts[slot.head].batches.flatMap((batch: any) => [
+					...batch.entries.keys(),
+				]),
+			).to.deep.equal(["late"]);
+			expect(
+				internals._joinWarmupRetryTimersByTarget.get("target").size,
+			).to.equal(1);
+
+			await clock.tickAsync(9);
+			expect(queued).to.deep.equal([["early"], ["late"]]);
+			expect(internals._joinWarmupScheduledRetriesByTarget.size).to.equal(0);
+			expect(internals._joinWarmupRetryTimersByTarget.size).to.equal(0);
+			expect(internals._repairRetryTimers.size).to.equal(0);
+		} finally {
+			await clock.tickAsync(1_000);
+			clock.restore();
+		}
+	});
+
+	it("keeps a reconnected warmup generation behind its active predecessor", async () => {
+		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+		let releaseOldSimple: (() => void) | undefined;
+		try {
+			const log = new SharedLog<unknown>();
+			log.closed = false;
+			const internals = log as any;
+			internals._assumeSyncedRepairSuppressedUntil = 0;
+			internals._repairMetrics = {
+				"join-warmup": {
+					dispatches: 0,
+					entries: 0,
+					ratelessFirstPasses: 0,
+					simpleFallbackPasses: 0,
+				},
+			};
+			let activeSimpleSends = 0;
+			let maxActiveSimpleSends = 0;
+			const simpleEntryBatches: string[][] = [];
+			sinon
+				.stub(internals, "sendRepairEntriesWithTransport")
+				.callsFake(async (...args: unknown[]) => {
+					if (args[2] !== "simple") {
+						return;
+					}
+					const entries = args[1] as Map<string, unknown>;
+					activeSimpleSends += 1;
+					maxActiveSimpleSends = Math.max(
+						maxActiveSimpleSends,
+						activeSimpleSends,
+					);
+					simpleEntryBatches.push([...entries.keys()]);
+					try {
+						if (simpleEntryBatches.length === 1) {
+							await new Promise<void>((resolve) => {
+								releaseOldSimple = resolve;
+							});
+						}
+					} finally {
+						activeSimpleSends -= 1;
+					}
+				});
+
+			internals.dispatchMaybeMissingEntries(
+				"target",
+				new Map([["old", { hash: "old" }]]),
+				{
+					bypassRecentDedupe: true,
+					mode: "join-warmup",
+					retryScheduleMs: [0, 10, 20, 30],
+				},
+			);
+			await clock.tickAsync(10);
+			expect(simpleEntryBatches).to.deep.equal([["old"]]);
+
+			const disconnectedGeneration =
+				internals._joinWarmupGenerationByTarget.get("target");
+			internals.removeRepairFrontierTarget("target");
+			expect(internals._joinWarmupRetryTimersByTarget.size).to.equal(0);
+			internals.dispatchMaybeMissingEntries(
+				"target",
+				new Map([["new", { hash: "new" }]]),
+				{
+					bypassRecentDedupe: true,
+					mode: "join-warmup",
+					retryScheduleMs: [0, 10],
+				},
+			);
+			await clock.tickAsync(10);
+			const reconnectedGeneration =
+				internals._joinWarmupGenerationByTarget.get("target");
+			internals.removeRepairFrontierTarget("target", {
+				expectedJoinWarmupGeneration: disconnectedGeneration,
+			});
+
+			expect(simpleEntryBatches).to.deep.equal([["old"]]);
+			expect(maxActiveSimpleSends).to.equal(1);
+			expect(
+				internals._joinWarmupGenerationByTarget.get("target"),
+			).to.equal(reconnectedGeneration);
+			expect(
+				[...internals._joinWarmupSendStateByTarget.get("target").entries.keys()],
+			).to.deep.equal(["new"]);
+
+			expect(releaseOldSimple).to.be.a("function");
+			releaseOldSimple!();
+			await clock.tickAsync(0);
+			await clock.tickAsync(249);
+			expect(simpleEntryBatches).to.have.length(1);
+			await clock.tickAsync(1);
+
+			expect(simpleEntryBatches).to.deep.equal([["old"], ["new"]]);
+			expect(maxActiveSimpleSends).to.equal(1);
+			expect(internals._repairRetryTimers.size).to.equal(0);
+			expect(internals._repairMetrics["join-warmup"]).to.deep.equal({
+				dispatches: 2,
+				entries: 2,
+				ratelessFirstPasses: 2,
+				simpleFallbackPasses: 2,
+			});
+		} finally {
+			releaseOldSimple?.();
+			await clock.tickAsync(1_000);
+			clock.restore();
+		}
+	});
+
+	it("continues a coalesced warmup after a simple send rejects", async () => {
+		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+		let rejectFirstSimple: ((error: Error) => void) | undefined;
+		try {
+			const log = new SharedLog<unknown>();
+			log.closed = false;
+			const internals = log as any;
+			internals._assumeSyncedRepairSuppressedUntil = 0;
+			internals._repairMetrics = {
+				"join-warmup": {
+					dispatches: 0,
+					entries: 0,
+					ratelessFirstPasses: 0,
+					simpleFallbackPasses: 0,
+				},
+			};
+			const simpleEntryBatches: string[][] = [];
+			sinon
+				.stub(internals, "sendRepairEntriesWithTransport")
+				.callsFake(async (...args: unknown[]) => {
+					if (args[2] !== "simple") {
+						return;
+					}
+					simpleEntryBatches.push([
+						...(args[1] as Map<string, unknown>).keys(),
+					]);
+					if (simpleEntryBatches.length === 1) {
+						await new Promise<void>((_resolve, reject) => {
+							rejectFirstSimple = reject;
+						});
+					}
+				});
+
+			internals.dispatchMaybeMissingEntries(
+				"target",
+				new Map([["entry", { hash: "entry" }]]),
+				{
+					bypassRecentDedupe: true,
+					mode: "join-warmup",
+					retryScheduleMs: [0, 10, 20],
+				},
+			);
+			await clock.tickAsync(20);
+			expect(simpleEntryBatches).to.have.length(1);
+			expect(
+				internals._joinWarmupSendStateByTarget.get("target").pending,
+			).to.be.true;
+			expect(rejectFirstSimple).to.be.a("function");
+			rejectFirstSimple!(new Error("injected warmup send failure"));
+			await clock.tickAsync(0);
+			await clock.tickAsync(249);
+			expect(simpleEntryBatches).to.have.length(1);
+			await clock.tickAsync(1);
+
+			expect(simpleEntryBatches).to.deep.equal([["entry"], ["entry"]]);
+			expect(
+				internals._repairMetrics["join-warmup"].simpleFallbackPasses,
+			).to.equal(2);
+			expect(internals._joinWarmupSendStateByTarget.get("target").running).to
+				.be.false;
+			expect(internals._repairRetryTimers.size).to.equal(0);
+		} finally {
+			await clock.tickAsync(1_000);
+			clock.restore();
+		}
+	});
+
+	it("retains the bounded default join warmup retry window", async () => {
+		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+		try {
+			const log = new SharedLog<unknown>();
+			log.closed = false;
+			const internals = log as any;
+			internals._assumeSyncedRepairSuppressedUntil = 0;
+			internals._repairMetrics = {
+				"join-warmup": {
+					dispatches: 0,
+					entries: 0,
+					ratelessFirstPasses: 0,
+					simpleFallbackPasses: 0,
+				},
+			};
+			const send = sinon
+				.stub(internals, "sendRepairEntriesWithTransport")
+				.resolves();
+
+			internals.dispatchMaybeMissingEntries(
+				"target",
+				new Map([["entry", { hash: "entry" }]]),
 				{
 					bypassRecentDedupe: true,
 					mode: "join-warmup",
 				},
 			);
-		}
-		await Promise.resolve();
+			expect(
+				internals._joinWarmupScheduledRetriesByTarget.get("target")
+					.slotsByDelay.size,
+			).to.equal(6);
+			await clock.tickAsync(60_000);
 
-		expect(send.callCount).to.equal(2);
-		expect(send.getCalls().map((call) => call.args[2])).to.deep.equal([
-			"rateless",
-			"rateless",
-		]);
-		expect(internals._repairRetryTimers.size).to.equal(0);
-		expect(internals._repairMetrics["join-warmup"]).to.deep.equal({
-			dispatches: 2,
-			entries: 2,
-			ratelessFirstPasses: 2,
-			simpleFallbackPasses: 0,
+			expect(
+				send
+					.getCalls()
+					.filter((call) => call.args[2] === "rateless"),
+			).to.have.length(1);
+			expect(
+				send.getCalls().filter((call) => call.args[2] === "simple"),
+			).to.have.length(6);
+			expect(internals._joinWarmupRetryTimersByTarget.size).to.equal(0);
+			expect(internals._repairRetryTimers.size).to.equal(0);
+
+			await clock.tickAsync(60_001);
+			expect(send.callCount).to.equal(7);
+		} finally {
+			await clock.tickAsync(1_000);
+			clock.restore();
+		}
+	});
+
+	it("does not let a stale warmup sweep adopt a reconnected target", () => {
+		const log = new SharedLog<unknown>();
+		log.closed = false;
+		const internals = log as any;
+		internals._repairSweepRunning = true;
+		const oldGeneration = internals.getJoinWarmupGeneration("target");
+		internals.cancelJoinWarmupTarget("target");
+		const currentGeneration = internals.getJoinWarmupGeneration("target");
+
+		internals.scheduleRepairSweep({
+			joinWarmupGenerations: new Map([["target", oldGeneration]]),
+			mode: "join-warmup",
+			peers: ["target"],
 		});
+		expect(
+			internals._repairSweepPendingPeersByMode
+				.get("join-warmup")
+				.has("target"),
+		).to.be.false;
+		expect(internals._repairSweepPendingModes.has("join-warmup")).to.be.false;
+
+		internals.scheduleRepairSweep({
+			joinWarmupGenerations: new Map([["target", currentGeneration]]),
+			mode: "join-warmup",
+			peers: ["target"],
+		});
+		expect(
+			internals._repairSweepPendingPeersByMode
+				.get("join-warmup")
+				.has("target"),
+		).to.be.true;
+		expect(
+			internals._repairSweepJoinWarmupGenerationByTarget.get("target"),
+		).to.equal(currentGeneration);
+
+		internals.cancelJoinWarmupTarget("target");
+		expect(internals._repairSweepPendingModes.has("join-warmup")).to.be.false;
+	});
+
+	it("stops an in-flight warmup sweep when its target reconnects", async () => {
+		const log = new SharedLog<unknown>();
+		log.closed = false;
+		const internals = log as any;
+		internals.node = {
+			identity: { publicKey: { hashcode: () => "self" } },
+		};
+		internals._nativeSharedLogState = {};
+		internals._residentEntryCoordinatesByHash = new Map([
+			["entry", { hash: "entry" }],
+		]);
+		internals.repairSweepTargetBufferSize = 100;
+		sinon.stub(internals, "hasCustomFindLeaders").returns(false);
+		let releasePlan!: () => void;
+		let markPlanEntered!: () => void;
+		const planEntered = new Promise<void>((resolve) => {
+			markPlanEntered = resolve;
+		});
+		sinon
+			.stub(internals, "planResidentRepairDispatchBatch")
+			.callsFake(async () => {
+				markPlanEntered();
+				await new Promise<void>((resolve) => {
+					releasePlan = resolve;
+				});
+				return new Map([
+					[
+						"join-warmup",
+						new Map([["target", new Set(["entry"])]]),
+					],
+				]);
+			});
+		sinon
+			.stub(internals, "getFullReplicaRepairCandidates")
+			.resolves(new Set(["self", "target"]));
+		const dispatch = sinon.stub(internals, "dispatchMaybeMissingEntries");
+		const oldGeneration = internals.getJoinWarmupGeneration("target");
+		internals.markRepairSweepOptimisticPeer(
+			"gid",
+			"target",
+			oldGeneration,
+		);
+		internals._repairSweepPendingModes.add("join-warmup");
+		internals._repairSweepPendingPeersByMode
+			.get("join-warmup")
+			.add("target");
+		internals._repairSweepJoinWarmupGenerationByTarget.set(
+			"target",
+			oldGeneration,
+		);
+		internals._repairSweepRunning = true;
+
+		const running = internals.runRepairSweep();
+		await planEntered;
+		internals.cancelJoinWarmupTarget("target");
+		const newGeneration = internals.getJoinWarmupGeneration("target");
+		internals.markRepairSweepOptimisticPeer(
+			"gid",
+			"target",
+			newGeneration,
+		);
+		releasePlan();
+		await running;
+
+		expect(dispatch.called).to.be.false;
+		expect(
+			internals._joinWarmupGenerationByTarget.get("target"),
+		).to.equal(newGeneration);
+		expect(
+			internals._repairSweepOptimisticGidPeersPending
+				.get("gid")
+				.get("target"),
+		).to.deep.equal({ count: 1, generation: newGeneration });
+		expect(
+			internals._repairSweepOptimisticGidsByPeer.get("target"),
+		).to.deep.equal(new Set(["gid"]));
+		expect(internals._repairSweepRunning).to.be.false;
+	});
+
+	it("captures warmup generation before an async rebalance starts", async () => {
+		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+		let releaseTrim: (() => void) | undefined;
+		try {
+			const log = new SharedLog<unknown>();
+			log.closed = false;
+			const internals = log as any;
+			internals.node = {
+				identity: { publicKey: { hashcode: () => "self" } },
+			};
+			internals._entryCoordinatesIndex = {
+				iterate: () => ({
+					close: async () => {},
+					done: () => true,
+					next: async () => [],
+				}),
+			};
+			internals.repairSweepTargetBufferSize = 100;
+			let markTrimEntered!: () => void;
+			const trimEntered = new Promise<void>((resolve) => {
+				markTrimEntered = resolve;
+			});
+			sinon.stub(log.log, "trim").callsFake(async () => {
+				markTrimEntered();
+				await new Promise<void>((resolve) => {
+					releaseTrim = resolve;
+				});
+				return undefined;
+			});
+			sinon.stub(internals, "scheduleJoinAuthoritativeRepair");
+			const changing = internals.onReplicationChange([
+				{
+					range: {
+						end1: 1n,
+						end2: 0n,
+						hash: "target",
+						idString: "id",
+						mode: 1,
+						rangeHash: "range",
+						start1: 0n,
+						start2: 0n,
+						timestamp: 0n,
+					},
+					timestamp: 0n,
+					type: "added",
+				},
+			]);
+
+			await trimEntered;
+			const oldGeneration =
+				internals._joinWarmupGenerationByTarget.get("target");
+			expect(oldGeneration).to.be.an("object");
+			internals.cancelJoinWarmupTarget("target");
+			const newGeneration = internals.getJoinWarmupGeneration("target");
+			releaseTrim!();
+			await changing;
+			await clock.tickAsync(250);
+
+			expect(
+				internals._joinWarmupGenerationByTarget.get("target"),
+			).to.equal(newGeneration);
+			expect(
+				internals._repairSweepPendingPeersByMode
+					.get("join-warmup")
+					.has("target"),
+			).to.be.false;
+		} finally {
+			releaseTrim?.();
+			await clock.tickAsync(1_000);
+			clock.restore();
+		}
 	});
 
 	it("deduplicates known hash aliases without changing coordinate requests", async () => {

--- a/packages/programs/data/shared-log/test/sync-session.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-session.spec.ts
@@ -1,6 +1,7 @@
 import { Cache } from "@peerbit/cache";
 import { expect } from "chai";
 import sinon from "sinon";
+import { SharedLog } from "../src/index.js";
 import { SimpleSyncronizer } from "../src/sync/simple.js";
 
 const emptyLog = {
@@ -9,6 +10,48 @@ const emptyLog = {
 };
 
 describe("sync-repair-session", () => {
+	it("keeps join warmup bounded to one rateless pass per batch", async () => {
+		const log = new SharedLog<unknown>();
+		const internals = log as any;
+		internals._assumeSyncedRepairSuppressedUntil = 0;
+		internals._repairMetrics = {
+			"join-warmup": {
+				dispatches: 0,
+				entries: 0,
+				ratelessFirstPasses: 0,
+				simpleFallbackPasses: 0,
+			},
+		};
+		const send = sinon
+			.stub(internals, "sendRepairEntriesWithTransport")
+			.resolves();
+
+		for (const hash of ["first", "second"]) {
+			internals.dispatchMaybeMissingEntries(
+				"target",
+				new Map([[hash, { hash }]]),
+				{
+					bypassRecentDedupe: true,
+					mode: "join-warmup",
+				},
+			);
+		}
+		await Promise.resolve();
+
+		expect(send.callCount).to.equal(2);
+		expect(send.getCalls().map((call) => call.args[2])).to.deep.equal([
+			"rateless",
+			"rateless",
+		]);
+		expect(internals._repairRetryTimers.size).to.equal(0);
+		expect(internals._repairMetrics["join-warmup"]).to.deep.equal({
+			dispatches: 2,
+			entries: 2,
+			ratelessFirstPasses: 2,
+			simpleFallbackPasses: 0,
+		});
+	});
+
 	it("deduplicates known hash aliases without changing coordinate requests", async () => {
 		const send = sinon.stub().resolves();
 		const coordinateToHash = new Cache<string>({ max: 10 });

--- a/packages/programs/data/shared-log/test/sync-session.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-session.spec.ts
@@ -128,6 +128,206 @@ describe("sync-repair-session", () => {
 		}
 	});
 
+	it("serializes join warmup sends per target without globalizing the lane", async () => {
+		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+		const releaseFirstSimpleByTarget = new Map<string, () => void>();
+		try {
+			const log = new SharedLog<unknown>();
+			log.closed = false;
+			const internals = log as any;
+			internals._assumeSyncedRepairSuppressedUntil = 0;
+			internals._repairMetrics = {
+				"join-warmup": {
+					dispatches: 0,
+					entries: 0,
+					ratelessFirstPasses: 0,
+					simpleFallbackPasses: 0,
+				},
+			};
+			let activeSimpleSends = 0;
+			let maxActiveSimpleSends = 0;
+			const activeSimpleSendsByTarget = new Map<string, number>();
+			const maxActiveSimpleSendsByTarget = new Map<string, number>();
+			const simpleCallsByTarget = new Map<string, number>();
+			sinon
+				.stub(internals, "sendRepairEntriesWithTransport")
+				.callsFake(async (...args: unknown[]) => {
+					if (args[2] !== "simple") {
+						return;
+					}
+					const target = args[0] as string;
+					const callNumber = (simpleCallsByTarget.get(target) ?? 0) + 1;
+					simpleCallsByTarget.set(target, callNumber);
+					activeSimpleSends += 1;
+					maxActiveSimpleSends = Math.max(
+						maxActiveSimpleSends,
+						activeSimpleSends,
+					);
+					const activeForTarget =
+						(activeSimpleSendsByTarget.get(target) ?? 0) + 1;
+					activeSimpleSendsByTarget.set(target, activeForTarget);
+					maxActiveSimpleSendsByTarget.set(
+						target,
+						Math.max(
+							maxActiveSimpleSendsByTarget.get(target) ?? 0,
+							activeForTarget,
+						),
+					);
+					try {
+						if (callNumber === 1) {
+							await new Promise<void>((resolve) => {
+								releaseFirstSimpleByTarget.set(target, resolve);
+							});
+						}
+					} finally {
+						activeSimpleSends -= 1;
+						activeSimpleSendsByTarget.set(target, activeForTarget - 1);
+					}
+				});
+
+			for (const target of ["target-a", "target-b"]) {
+				internals.dispatchMaybeMissingEntries(
+					target,
+					new Map([[`${target}-entry`, { hash: `${target}-entry` }]]),
+					{
+						bypassRecentDedupe: true,
+						mode: "join-warmup",
+						retryScheduleMs: [0, 10, 20],
+					},
+				);
+			}
+			await clock.tickAsync(20);
+
+			expect([...simpleCallsByTarget.entries()]).to.have.deep.members([
+				["target-a", 1],
+				["target-b", 1],
+			]);
+			expect(maxActiveSimpleSends).to.equal(2);
+			expect([...maxActiveSimpleSendsByTarget.entries()]).to.have.deep.members([
+				["target-a", 1],
+				["target-b", 1],
+			]);
+			expect(
+				internals._joinWarmupSendStateByTarget.get("target-a").pending,
+			).to.be.true;
+			expect(
+				internals._joinWarmupSendStateByTarget.get("target-b").pending,
+			).to.be.true;
+
+			for (const release of releaseFirstSimpleByTarget.values()) {
+				release();
+			}
+			await clock.tickAsync(0);
+			await clock.tickAsync(249);
+			expect([...simpleCallsByTarget.values()]).to.deep.equal([1, 1]);
+			await clock.tickAsync(1);
+
+			expect([...simpleCallsByTarget.entries()]).to.have.deep.members([
+				["target-a", 2],
+				["target-b", 2],
+			]);
+			expect(maxActiveSimpleSends).to.equal(2);
+			expect([...maxActiveSimpleSendsByTarget.entries()]).to.have.deep.members([
+				["target-a", 1],
+				["target-b", 1],
+			]);
+			expect(internals._repairRetryTimers.size).to.equal(0);
+		} finally {
+			for (const release of releaseFirstSimpleByTarget.values()) {
+				release();
+			}
+			await clock.tickAsync(1_000);
+			clock.restore();
+		}
+	});
+
+	it("rechecks peer knowledge before a coalesced warmup reaches transport", async () => {
+		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+		let releaseFirstSimple: (() => void) | undefined;
+		try {
+			const log = new SharedLog<unknown>();
+			log.closed = false;
+			const internals = log as any;
+			internals._assumeSyncedRepairSuppressedUntil = 0;
+			internals._repairMetrics = {
+				"join-warmup": {
+					dispatches: 0,
+					entries: 0,
+					ratelessFirstPasses: 0,
+					simpleFallbackPasses: 0,
+				},
+			};
+			internals._entryKnownPeerObservedAt = new Map();
+			const sendRepairEntriesWithTransport =
+				internals.sendRepairEntriesWithTransport.bind(internals);
+			sinon
+				.stub(internals, "sendRepairEntriesWithTransport")
+				.callsFake(async (...args: unknown[]) => {
+					if (args[2] !== "simple") {
+						return;
+					}
+					await sendRepairEntriesWithTransport(
+						args[0],
+						args[1],
+						args[2],
+						args[3],
+					);
+				});
+			const pushedEntryBatches: string[][] = [];
+			sinon
+				.stub(internals, "pushRepairEntries")
+				.callsFake(async (...args: unknown[]) => {
+					pushedEntryBatches.push([
+						...(args[1] as Map<string, unknown>).keys(),
+					]);
+					if (pushedEntryBatches.length === 1) {
+						await new Promise<void>((resolve) => {
+							releaseFirstSimple = resolve;
+						});
+					}
+				});
+
+			internals.dispatchMaybeMissingEntries(
+				"target",
+				new Map([
+					["still-missing", { hash: "still-missing" }],
+					["newly-known", { hash: "newly-known" }],
+				]),
+				{
+					bypassRecentDedupe: true,
+					mode: "join-warmup",
+					retryScheduleMs: [0, 10, 20],
+				},
+			);
+			await clock.tickAsync(20);
+
+			expect(pushedEntryBatches).to.deep.equal([
+				["still-missing", "newly-known"],
+			]);
+			expect(
+				internals._joinWarmupSendStateByTarget.get("target").pending,
+			).to.be.true;
+			internals.markEntriesKnownByPeer(["newly-known"], "target");
+
+			expect(releaseFirstSimple).to.be.a("function");
+			releaseFirstSimple!();
+			await clock.tickAsync(0);
+			await clock.tickAsync(249);
+			expect(pushedEntryBatches).to.have.length(1);
+			await clock.tickAsync(1);
+
+			expect(pushedEntryBatches).to.deep.equal([
+				["still-missing", "newly-known"],
+				["still-missing"],
+			]);
+			expect(internals._repairRetryTimers.size).to.equal(0);
+		} finally {
+			releaseFirstSimple?.();
+			await clock.tickAsync(1_000);
+			clock.restore();
+		}
+	});
+
 	it("releases each warmup delay slot without retaining earlier scan batches", async () => {
 		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
 		try {


### PR DESCRIPTION
## Summary

- preserve the existing 0/1/3/7/15/30/60 second join-recovery window
- serialize simple warmup fallbacks per target and coalesce work that becomes due behind an active send
- keep different targets concurrent while allowing at most one simple warmup send per target
- keep scheduling bounded to six retry timers plus one pacing timer per target
- use shared monotonic deadline cohorts so scheduled work is linear in entries and retains each batch only once
- make disconnect, reconnect, close/reopen, repair sweeps, and optimistic bookkeeping generation-safe on current `master`

## Why

A deterministic two-process late-join reproduction uses the downstream `distributed-backup-v2` file model: two isolated peers, a deterministic 1 GiB fixture split into 4,096 256 KiB documents, and a receiver that connects only after upload completes. The source is stopped before local-only reconstruction and SHA-256/CRC-32 validation.

The slowdown comes from overlapping fixed warmup snapshots. Each 0/1/3/7/15/30/60 second retry could begin another bulk simple send before the previous one finished. Confirmations can prevent future work, but cannot cancel a snapshot already being streamed.

The first commit reduced the schedule to a single attempt. CI correctly exposed that this removed required loss recovery. The final scheduler supersedes that approach: all retry times remain, but simple sends are serialized per target, due batches are coalesced, and peer knowledge is checked again when a send actually starts.

## Scaling properties

For each target, the final scheduler has at most six scheduled retry timers and one spacing timer. Incoming repair batches append in constant time to ordered deadline cohorts. A batch stores its entries once and is referenced by each retry slot, so total scheduled processing is `O(entries × retries)` and retained entry data is `O(entries)`, rather than retaining or rescanning a cumulative historical union.

## Controlled downstream performance

The release-graph comparison used an exact rebuild of published `@peerbit/shared-log@13.2.6`; its runtime is byte-identical to the npm artifact. The hotpatch changes only the scheduler core while keeping semantically identical package metadata and one identical Peerbit dependency cohort.

At 256 MiB, an alternating A/B/B/A campaign produced:

| Stack | Sync runs | Q4/Q1 | Second half / first half |
| --- | ---: | ---: | ---: |
| Released 13.2.6 | 10.60 s, 8.53 s | 1.82, 1.50 | 1.79, 1.53 |
| Scheduler hotpatch | 6.05 s, 7.06 s | 0.90, 1.01 | 0.98, 1.04 |

At 1 GiB:

| Stack | Ready | Quarter durations | Q4/Q1 | Second half / first half |
| --- | ---: | --- | ---: | ---: |
| Released 13.2.6 | 87.91 s | 8.86 / 12.16 / 13.51 / 24.16 s | 2.73 | 1.79 |
| Scheduler hotpatch | 41.71 s | 9.47 / 10.56 / 9.95 / 11.41 s | 1.21 | 1.07 |

That is a 52.6% reduction in full-size readiness time, while removing the progressive tail slowdown. Both runs reconstructed exactly 1,073,741,824 bytes after source shutdown with matching SHA-256 `ff8c8b03…492ad0` and CRC-32 `2e1e4b6d`.

## Exact current-`master` integration

A separately aligned current Peerbit cohort resolved every identity-sensitive package to one version and one realpath. At 256 MiB, current `master` took 46.74 s with Q4/Q1 2.67 and second-half/first-half 2.22. This PR's exact packed artifact took 13.32 s with Q4/Q1 0.57 and second-half/first-half 0.64, with exact integrity in both runs.

The exact PR artifact also completed an instrumented 1 GiB run in 52.25 s. Quarter durations were 11.63 / 17.73 / 11.64 / 10.95 s, Q4/Q1 was 0.94, and second-half/first-half was 0.77. Local-only SHA-256 and CRC-32 validation passed after source shutdown.

The current-stack 1 GiB run exposed a separate cleanup-performance gap: source shutdown took 21.68 s, exceeding the reproduction harness's original fixed 15 s shutdown ceiling. Repeating with an instrumented 60 s ceiling completed normally and passed integrity. This PR does not claim to fix that cleanup cost.

## Correctness and compatibility

This is local repair scheduling only. It does not change schemas, wire encoding, capability negotiation, protocol versions, or network messages. Receipt-driven authoritative repair remains independent of the warmup fast path.

Target generations prevent stale disconnect, sweep, unsubscribe, or close work from being adopted by a reconnected peer. An active old-generation send remains serialized ahead of a reopened generation. Close and drop cancel warmup work both before and after admitted subscription callbacks drain, so callbacks cannot recreate terminal timers or pending batches.

## Verification

- root workspace build: pass
- full `@peerbit/shared-log` Node suite: **1,982 passing, 10 intentionally pending, 0 failing** (19 minutes)
- focused `sync-repair-session`: **17 passing**
- new deterministic regressions: per-target serialization with cross-target concurrency; send-time known-peer filtering
- current-master lifecycle/reconnect/liveness/receive-drain regression matrix: pass
- targeted ESLint and `git diff --check`: pass
- deterministic 16 MiB, 256 MiB, and 1 GiB downstream integrity gates: pass where completed with the realistic shutdown bound
- adversarial scheduler/lifecycle audit after rebasing onto current `master`: no remaining P0/P1 findings
- all commits authored and committed by `peerbit-org`
