### PR TITLE
fix(deps): update linkify-it to 5.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
 			"istanbul-lib-processinfo@2>uuid": "11.1.1",
 			"js-yaml@3": "3.15.0",
 			"js-yaml@4": "4.3.0",
-			"linkify-it": "5.0.1",
+			"linkify-it": "5.0.2",
 			"lodash": "4.18.1",
 			"lodash-es": "4.18.1",
 			"markdown-it": "14.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ overrides:
   istanbul-lib-processinfo@2>uuid: 11.1.1
   js-yaml@3: 3.15.0
   js-yaml@4: 4.3.0
-  linkify-it: 5.0.1
+  linkify-it: 5.0.2
   lodash: 4.18.1
   lodash-es: 4.18.1
   markdown-it: 14.2.0
@@ -8762,8 +8762,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  linkify-it@5.0.1:
-    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   listr-silent-renderer@1.1.1:
     resolution: {integrity: sha512-L26cIFm7/oZeSNVhWB6faeorXhMg4HNlb/dS/7jHhr708jxlXrtrBWo4YUxZQkc6dGoxEAe6J/D3juTRBUzjtA==}
@@ -19145,7 +19145,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkify-it@5.0.1:
+  linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
 
@@ -19330,7 +19330,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.1
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0


### PR DESCRIPTION
## Summary

- pin `linkify-it` to the patched 5.0.2 release
- refresh only the corresponding lockfile resolution
- unblock the fail-closed dependency audit triggered by GHSA-v245-v573-v5vm

## Adversarial review

- exact npm tarball integrity matches the lockfile
- npm registry signature verifies with the same publisher/key lineage as 5.0.1
- shipped tracked files match the upstream 5.0.2 tag; rebuilt CJS output matched byte-for-byte
- no install hooks, new runtime dependencies, process spawning, or network/filesystem behavior
- Markdown-It 14.2.0 explicitly accepts `linkify-it ^5.0.1`; CJS, ESM, rendering, and all 176 upstream runtime tests passed

The package has no Sigstore provenance and the upstream tag is unsigned; the registry signature, publisher continuity, source/tarball match, and reproducible bundle are the compensating evidence.

## Verification

- `pnpm install --lockfile-only --frozen-lockfile`
- production audit: no known vulnerabilities
- full audit: no known vulnerabilities
- Peerbit release/dependency/published-closure security contracts passed

Advisory: https://github.com/advisories/GHSA-v245-v573-v5vm