### PR TITLE
fix(shared-log): fence liveness recovery by arrival

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -3333,6 +3333,10 @@ export class SharedLog<
 		{ attempts: number; timer?: ReturnType<typeof setTimeout> }
 	>;
 	private _replicationInfoApplyQueueByPeer!: Map<string, Promise<void>>;
+	// Local receive generations fence replication-info handlers that were admitted
+	// before a liveness eviction but reach the per-peer apply lane after it. Unlike
+	// message timestamps, these tokens never compare clocks from different peers.
+	private _replicationInfoReceiveEpochByPeer!: Map<string, object>;
 	// Subscription callbacks can overlap because removing a replicator mutates the
 	// replication index asynchronously. Keep that lifecycle separate from message
 	// timestamps so a reconnect can synchronously revoke an older unsubscribe.
@@ -4444,6 +4448,7 @@ export class SharedLog<
 		this._replicationInfoBlockedPeers = new Set();
 		this._replicationInfoRequestByPeer = new Map();
 		this._replicationInfoApplyQueueByPeer = new Map();
+		this._replicationInfoReceiveEpochByPeer = new Map();
 		this._subscriptionEpochByPeer = new Map();
 		this._pendingReplicatorLeaveByPeer = new Set();
 		this._gidPeersHistory = new Map();
@@ -12651,6 +12656,7 @@ export class SharedLog<
 		// Terminal close/drop drains the previous lifecycle before another open can
 		// install fresh lanes and opaque per-subscription ownership tokens.
 		this._replicationInfoApplyQueueByPeer = new Map();
+		this._replicationInfoReceiveEpochByPeer = new Map();
 		this._subscriptionEpochByPeer = new Map();
 		this._pendingReplicatorLeaveByPeer = new Set();
 		this._repairRetryTimers = new Set();
@@ -14094,6 +14100,15 @@ export class SharedLog<
 		return false;
 	}
 
+	private advanceReplicationInfoRecoveryEpoch(peerHash: string) {
+		// Handlers admitted before a successful liveness removal must not restore
+		// state when they eventually reach the apply lane. Reset the sender's
+		// ordering watermark with the local epoch so a later arrival can be
+		// accepted without comparing its clock to this receiver's clock.
+		this.advanceReplicationInfoReceiveEpoch(peerHash);
+		this.latestReplicationInfoMessage.delete(peerHash);
+	}
+
 	private async evictReplicatorFromLiveness(
 		peerHash: string,
 		publicKey: PublicSignKey,
@@ -14101,8 +14116,6 @@ export class SharedLog<
 		subscriptionEpoch: object | null,
 		observedActivityAt: number | undefined,
 	) {
-		const watermark = BigInt(+new Date());
-
 		try {
 			await this.removeReplicator(publicKey, {
 				noEvent: true,
@@ -14124,12 +14137,7 @@ export class SharedLog<
 					) {
 						return;
 					}
-					const previousWatermark =
-						this.latestReplicationInfoMessage.get(peerHash);
-					if (!previousWatermark || previousWatermark < watermark) {
-						this.latestReplicationInfoMessage.set(peerHash, watermark);
-					}
-
+					this.advanceReplicationInfoRecoveryEpoch(peerHash);
 					if (this._pendingReplicatorLeaveByPeer.delete(peerHash)) {
 						this.events.dispatchEvent(
 							new CustomEvent<ReplicatorLeaveEvent>("replicator:leave", {
@@ -14313,6 +14321,10 @@ export class SharedLog<
 						observedActivityAt,
 					subscriptionEpoch,
 					onRemoved: () => {
+						if (!ownsProbe()) {
+							return;
+						}
+						this.advanceReplicationInfoRecoveryEpoch(peerHash);
 						this._replicatorLivenessTargetsSize = -1;
 					},
 				});
@@ -15248,6 +15260,7 @@ export class SharedLog<
 		captureSync(() => {
 			this._pendingIHave?.clear();
 			this.latestReplicationInfoMessage?.clear();
+			this._replicationInfoReceiveEpochByPeer?.clear();
 			this._gidPeersHistory?.clear();
 			this._peerSyncCapabilities?.clear();
 			this._liveRawGossipBatches?.clear();
@@ -15673,6 +15686,8 @@ export class SharedLog<
 				this._replicationLifecycleController;
 			const receiveSubscriptionEpoch =
 				this.getSubscriptionEpoch(receiveFromHash);
+			const receiveReplicationInfoReceiveEpoch =
+				this.getReplicationInfoReceiveEpoch(receiveFromHash);
 			if (!context.from.equals(this.node.identity.publicKey)) {
 				this.markReplicatorActivity(receiveFromHash);
 			}
@@ -17990,6 +18005,10 @@ export class SharedLog<
 					!this.isReplicationLifecycleActive(
 						receiveReplicationLifecycleController,
 					) ||
+					!this.isCurrentReplicationInfoReceiveEpoch(
+						receiveFromHash,
+						receiveReplicationInfoReceiveEpoch,
+					) ||
 					this._replicationInfoBlockedPeers.has(fromHash)
 				) {
 					return;
@@ -18005,6 +18024,10 @@ export class SharedLog<
 							!this.isCurrentSubscriptionEpoch(
 								fromHash,
 								receiveSubscriptionEpoch,
+							) ||
+							!this.isCurrentReplicationInfoReceiveEpoch(
+								fromHash,
+								receiveReplicationInfoReceiveEpoch,
 							) ||
 							this._replicationInfoBlockedPeers.has(fromHash)
 						) {
@@ -18065,6 +18088,10 @@ export class SharedLog<
 					!this.isReplicationLifecycleActive(
 						receiveReplicationLifecycleController,
 					) ||
+					!this.isCurrentReplicationInfoReceiveEpoch(
+						receiveFromHash,
+						receiveReplicationInfoReceiveEpoch,
+					) ||
 					this._replicationInfoBlockedPeers.has(fromHash)
 				) {
 					return;
@@ -18078,6 +18105,10 @@ export class SharedLog<
 						!this.isCurrentSubscriptionEpoch(
 							fromHash,
 							receiveSubscriptionEpoch,
+						) ||
+						!this.isCurrentReplicationInfoReceiveEpoch(
+							fromHash,
+							receiveReplicationInfoReceiveEpoch,
 						) ||
 						this._replicationInfoBlockedPeers.has(fromHash)
 					) {
@@ -21889,6 +21920,23 @@ export class SharedLog<
 			// tails admitted while the previous snapshot was settling.
 			await Promise.resolve();
 		}
+	}
+
+	private advanceReplicationInfoReceiveEpoch(peerHash: string): object {
+		const next = {};
+		this._replicationInfoReceiveEpochByPeer.set(peerHash, next);
+		return next;
+	}
+
+	private getReplicationInfoReceiveEpoch(peerHash: string): object | null {
+		return this._replicationInfoReceiveEpochByPeer.get(peerHash) ?? null;
+	}
+
+	private isCurrentReplicationInfoReceiveEpoch(
+		peerHash: string,
+		epoch: object | null,
+	): boolean {
+		return this.getReplicationInfoReceiveEpoch(peerHash) === epoch;
 	}
 
 	private advanceSubscriptionEpoch(peerHash: string): object {

--- a/packages/programs/data/shared-log/test/replicator-liveness.spec.ts
+++ b/packages/programs/data/shared-log/test/replicator-liveness.spec.ts
@@ -5,8 +5,10 @@ import { expect } from "chai";
 import pDefer from "p-defer";
 import sinon from "sinon";
 import {
+	AllReplicatingSegmentsMessage,
 	ReplicationPingMessage,
 	RequestReplicationInfoMessage,
+	StoppedReplicating,
 } from "../src/replication.js";
 import { EventStore } from "./utils/stores/index.js";
 
@@ -721,6 +723,136 @@ describe("waitForReplicator liveness", () => {
 			db0.log.rpc.send = originalSend;
 			hooks.confirmReplicatorSubscriberPresence =
 				originalConfirmSubscriberPresence;
+		}
+	});
+
+	it("uses a local receive generation when relearning an unresolved liveness-evicted peer", async () => {
+		session = await TestSession.connected(2);
+
+		const store = new EventStore<string, any>();
+		const db0 = await session.peers[0].open(store, {
+			args: {
+				replicate: { factor: 1 },
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		await session.peers[1].open(store.clone(), {
+			args: {
+				replicate: { factor: 1 },
+				timeUntilRoleMaturity: 0,
+			},
+		});
+
+		const remoteKey = session.peers[1].identity.publicKey;
+		const peerHash = remoteKey.hashcode();
+		const hooks = getLivenessTestHooks(db0);
+		const log = db0.log as any;
+		const replicationIndex = db0.log.replicationIndex as any;
+		let remoteRange: any;
+		await waitForResolved(async () => {
+			const ranges = await replicationIndex
+				.iterate({ query: { hash: peerHash } })
+				.all();
+			expect(ranges).to.have.length.greaterThan(0);
+			remoteRange = ranges[0].value;
+		});
+
+		// Model a sender whose clock trails this receiver with tiny timestamps. The
+		// delayed old-generation messages deliberately carry later values than the
+		// recovery snapshot, proving that the local epoch owns the eviction boundary.
+		log.latestReplicationInfoMessage.set(peerHash, 1n);
+		const delayedSnapshot = new AllReplicatingSegmentsMessage({
+			segments: [remoteRange.toReplicationRange()],
+		});
+		const delayedStopped = new StoppedReplicating({
+			segmentIds: [remoteRange.id],
+		});
+		const snapshotSynchronizerEntered = pDefer<void>();
+		const stoppedSynchronizerEntered = pDefer<void>();
+		const releaseSnapshotSynchronizer = pDefer<void>();
+		const releaseStoppedSynchronizer = pDefer<void>();
+		const originalSynchronizerOnMessage = log.syncronizer.onMessage.bind(
+			log.syncronizer,
+		);
+		const synchronizer = sinon
+			.stub(log.syncronizer, "onMessage")
+			.callsFake(async (message: unknown, context: unknown) => {
+				if (message === delayedSnapshot) {
+					snapshotSynchronizerEntered.resolve();
+					await releaseSnapshotSynchronizer.promise;
+					return false;
+				}
+				if (message === delayedStopped) {
+					stoppedSynchronizerEntered.resolve();
+					await releaseStoppedSynchronizer.promise;
+					return false;
+				}
+				return originalSynchronizerOnMessage(message, context);
+			});
+		const resolvePublicKey = sinon
+			.stub(log, "_resolvePublicKeyFromHash")
+			.resolves(undefined);
+
+		try {
+			const delayedSnapshotReceive = db0.log.onMessage(delayedSnapshot, {
+				from: remoteKey,
+				message: { header: { timestamp: 2n } },
+			} as any);
+			const delayedStoppedReceive = db0.log.onMessage(delayedStopped, {
+				from: remoteKey,
+				message: { header: { timestamp: 3n } },
+			} as any);
+			await Promise.all([
+				snapshotSynchronizerEntered.promise,
+				stoppedSynchronizerEntered.promise,
+			]);
+
+			// Exercise the separate hash-only removal path used after pubsub loses
+			// the public-key mapping for a previously learned/relayed replicator.
+			log._replicatorLastActivityAt.set(peerHash, Date.now() - 60_000);
+			await hooks.probeReplicatorLiveness(peerHash);
+			expect(
+				await replicationIndex.count({ query: { hash: peerHash } }),
+			).to.equal(0);
+
+			// This handler entered before eviction and must not restore removed state
+			// merely because it reaches the apply lane afterward.
+			releaseSnapshotSynchronizer.resolve();
+			await delayedSnapshotReceive;
+			expect(
+				await replicationIndex.count({ query: { hash: peerHash } }),
+			).to.equal(0);
+			expect(log.latestReplicationInfoMessage.has(peerHash)).to.be.false;
+
+			// A later arrival from the same slower-clock sender is authoritative and
+			// must be accepted without comparing its timestamp to the receiver clock.
+			await db0.log.onMessage(
+				new AllReplicatingSegmentsMessage({
+					segments: [remoteRange.toReplicationRange()],
+				}),
+				{
+					from: remoteKey,
+					message: { header: { timestamp: 1n } },
+				} as any,
+			);
+			expect(
+				await replicationIndex.count({ query: { hash: peerHash } }),
+			).to.be.greaterThan(0);
+			expect(log.latestReplicationInfoMessage.get(peerHash)).to.equal(1n);
+
+			// A pre-eviction stopped message is fenced by the same local generation;
+			// it cannot delete the newly restored range or replace its watermark.
+			releaseStoppedSynchronizer.resolve();
+			await delayedStoppedReceive;
+			expect(
+				await replicationIndex.count({ query: { hash: peerHash } }),
+			).to.be.greaterThan(0);
+			expect(log.latestReplicationInfoMessage.get(peerHash)).to.equal(1n);
+		} finally {
+			releaseSnapshotSynchronizer.resolve();
+			releaseStoppedSynchronizer.resolve();
+			synchronizer.restore();
+			resolvePublicKey.restore();
 		}
 	});
 });


### PR DESCRIPTION
## Summary

- replace the liveness-eviction receiver-clock watermark with a local receive epoch
- reject All/Added/Stopped handlers admitted before a successful eviction
- reset sender ordering only at the successful eviction boundary
- allow the next authoritative snapshot even when the sender clock trails the receiver
- cover both resolved-key and hash-only liveness removal paths

## Why

The previous liveness path wrote receiver Date.now() into a watermark compared against sender message timestamps. A live peer with a slower clock could then have every requested snapshot rejected until resubscription or clock catch-up.

This fix uses an opaque local arrival generation for the eviction boundary. Sender timestamps still order messages within the new generation. This is local shared-log state handling only; it does not change message encoding or the network protocol.

## Validation

- focused delayed All/Stopped plus unresolved-key regression: passing
- full liveness suite: 12 passing
- full events suite: 22 passing
- full workspace build: passing
- shared-log package build: passing
- ESLint and git diff --check: passing
- independent adversarial review: SHIP, no P0/P1/P2 findings

## Stack

Depends on #1119 because it uses the per-peer mutation lane and successful-removal callback introduced there. Review this PR against its configured base branch to see only the clock-skew fix.