### PR TITLE
fix(shared-log): drain peer receives before cleanup

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -283,8 +283,18 @@ type PendingIHave<T> = {
 	resetTimeout: () => void;
 	requesting: Set<string>;
 	clear: () => void;
-	callback: (entry: Entry<T>) => void;
+	callback: (entry: Entry<T>) => MaybePromise<void>;
 	expiresAt?: number;
+};
+
+type PeerReceiveLeaseBucket = {
+	active: number;
+	drain?: DeferredPromise<void>;
+};
+
+type PeerReceiveLeaseState = {
+	current: PeerReceiveLeaseBucket;
+	activeBuckets: Set<PeerReceiveLeaseBucket>;
 };
 
 const toLocalPublicSignKey = (
@@ -3287,6 +3297,14 @@ export class SharedLog<
 	private _subscriptionChangeCallbacks?: Set<Promise<void>>;
 	private _acceptSubscriptionChangeCallbacks = false;
 	private _replicationLifecycleController?: AbortController;
+	private _activeReceiveHandlersByPeer!: Map<string, PeerReceiveLeaseState>;
+	private _receiveHandlerDrainByPeer!: Map<string, Set<Promise<void>>>;
+	private _receiveCleanupGateByPeer!: Map<string, number>;
+	private _subscriptionOpeningEpochByPeer!: Map<string, object>;
+	private _openingSyncCapabilitiesByPeer!: Map<
+		string,
+		{ epoch: object; capabilities: number }
+	>;
 	private _onFanoutDataFn?: (arg: any) => void;
 	private _onFanoutUnicastFn?: (arg: any) => void;
 	private _fanoutChannel?: FanoutChannel;
@@ -3302,6 +3320,7 @@ export class SharedLog<
 	private _closeController!: AbortController;
 	private _respondToIHaveTimeout!: any;
 	private _checkedPrune!: CheckedPruneCoordinator<T, R>;
+	private _pendingIHaveCallbacks!: Set<Promise<void>>;
 	private _pendingIHaveExpiryTimer?: ReturnType<typeof setTimeout>;
 	private _pendingIHaveExpiryDeadline = Number.POSITIVE_INFINITY;
 
@@ -4444,6 +4463,7 @@ export class SharedLog<
 		this.rpc = new RPC();
 		this._checkedPrune = new CheckedPruneCoordinator<T, R>();
 		this._pendingIHave = new Map();
+		this._pendingIHaveCallbacks = new Set();
 		this.latestReplicationInfoMessage = new Map();
 		this._replicationInfoBlockedPeers = new Set();
 		this._replicationInfoRequestByPeer = new Map();
@@ -4451,6 +4471,11 @@ export class SharedLog<
 		this._replicationInfoReceiveEpochByPeer = new Map();
 		this._subscriptionEpochByPeer = new Map();
 		this._pendingReplicatorLeaveByPeer = new Set();
+		this._activeReceiveHandlersByPeer = new Map();
+		this._receiveHandlerDrainByPeer = new Map();
+		this._receiveCleanupGateByPeer = new Map();
+		this._subscriptionOpeningEpochByPeer = new Map();
+		this._openingSyncCapabilitiesByPeer = new Map();
 		this._gidPeersHistory = new Map();
 		this._repairRetryTimers = new Set();
 		this._recentRepairDispatch = new Map();
@@ -5830,6 +5855,184 @@ export class SharedLog<
 		}
 	}
 
+	private isPeerReceiveAdmissionOpen(
+		peerHash: string,
+		replicationLifecycleController: AbortController | undefined,
+		subscriptionEpoch: object | null,
+		options?: {
+			allowReplicationInfoBlocked?: boolean;
+			allowCleanupGate?: boolean;
+		},
+	) {
+		return (
+			this.isReplicationLifecycleActive(replicationLifecycleController) &&
+			this.isCurrentSubscriptionEpoch(peerHash, subscriptionEpoch) &&
+			(options?.allowReplicationInfoBlocked === true ||
+				!this._replicationInfoBlockedPeers.has(peerHash)) &&
+			(options?.allowCleanupGate === true ||
+				(this._receiveCleanupGateByPeer.get(peerHash) ?? 0) === 0)
+		);
+	}
+
+	private acquirePeerReceiveLease(
+		peerHash: string,
+		replicationLifecycleController: AbortController | undefined,
+		subscriptionEpoch: object | null,
+		options?: {
+			allowReplicationInfoBlocked?: boolean;
+			allowCleanupGate?: boolean;
+		},
+	): (() => void) | undefined {
+		if (
+			!this.isPeerReceiveAdmissionOpen(
+				peerHash,
+				replicationLifecycleController,
+				subscriptionEpoch,
+				options,
+			)
+		) {
+			return;
+		}
+
+		let state = this._activeReceiveHandlersByPeer.get(peerHash);
+		if (!state) {
+			const current: PeerReceiveLeaseBucket = { active: 0 };
+			state = { current, activeBuckets: new Set() };
+			this._activeReceiveHandlersByPeer.set(peerHash, state);
+		}
+		const bucket = state.current;
+		bucket.active += 1;
+		state.activeBuckets.add(bucket);
+		let released = false;
+		return () => {
+			if (released) {
+				return;
+			}
+			released = true;
+			bucket.active -= 1;
+			if (bucket.active > 0) {
+				return;
+			}
+			state.activeBuckets.delete(bucket);
+			bucket.drain?.resolve();
+			if (
+				state.activeBuckets.size === 0 &&
+				state.current.active === 0 &&
+				this._activeReceiveHandlersByPeer.get(peerHash) === state
+			) {
+				this._activeReceiveHandlersByPeer.delete(peerHash);
+			}
+		};
+	}
+
+	private async drainPeerReceiveHandlers(peerHash: string): Promise<void> {
+		const state = this._activeReceiveHandlersByPeer.get(peerHash);
+		if (!state || state.activeBuckets.size === 0) {
+			return;
+		}
+
+		// Rotate before awaiting so a reconnect/opening generation can keep receiving
+		// sync traffic without joining the drain for the previous subscription. Cleanup
+		// callers gate admission first; terminal callers also repeat until empty.
+		const buckets = [...state.activeBuckets];
+		state.current = { active: 0 };
+		const drain = Promise.all(
+			buckets.map((bucket) => {
+				bucket.drain ??= pDefer<void>();
+				return bucket.drain.promise;
+			}),
+		).then(() => undefined);
+		let drains = this._receiveHandlerDrainByPeer.get(peerHash);
+		if (!drains) {
+			drains = new Set();
+			this._receiveHandlerDrainByPeer.set(peerHash, drains);
+		}
+		drains.add(drain);
+		try {
+			await drain;
+		} finally {
+			drains.delete(drain);
+			if (drains.size === 0) {
+				this._receiveHandlerDrainByPeer.delete(peerHash);
+			}
+		}
+	}
+
+	private async drainReceiveHandlers(): Promise<void> {
+		for (;;) {
+			const peers = [...this._activeReceiveHandlersByPeer.keys()];
+			if (peers.length === 0) {
+				return;
+			}
+			await Promise.all(
+				peers.map((peerHash) => this.drainPeerReceiveHandlers(peerHash)),
+			);
+		}
+	}
+
+	private runPendingIHaveCallback(
+		pending: PendingIHave<T>,
+		entry: Entry<T>,
+	): void {
+		const replicationLifecycleController =
+			this._replicationLifecycleController;
+		if (!this.isReplicationLifecycleActive(replicationLifecycleController)) {
+			if (this._pendingIHave.get(entry.hash) === pending) {
+				pending.clear();
+				this._pendingIHave.delete(entry.hash);
+			}
+			return;
+		}
+
+		// Register before invoking the callback so a synchronous terminal reentry
+		// cannot make close/drop miss work that has already been admitted.
+		const completion = pDefer<void>();
+		const observed = completion.promise.catch((error) => {
+			if (!(this.isTerminating() && isNotStartedError(error as Error))) {
+				logger.error(error?.toString?.() ?? String(error));
+			}
+		});
+		this._pendingIHaveCallbacks.add(observed);
+		void observed.finally(() => {
+			this._pendingIHaveCallbacks.delete(observed);
+			if (this._pendingIHave.get(entry.hash) === pending) {
+				pending.clear();
+				this._pendingIHave.delete(entry.hash);
+			}
+		});
+
+		try {
+			Promise.resolve(pending.callback(entry)).then(
+				() => completion.resolve(),
+				(error) => completion.reject(error),
+			);
+		} catch (error) {
+			completion.reject(error);
+		}
+	}
+
+	private async drainPendingIHaveCallbacks(): Promise<void> {
+		while (this._pendingIHaveCallbacks.size > 0) {
+			await Promise.all([...this._pendingIHaveCallbacks]);
+		}
+	}
+
+	private blockPeerReceiveAdmission(peerHash: string) {
+		this._receiveCleanupGateByPeer.set(
+			peerHash,
+			(this._receiveCleanupGateByPeer.get(peerHash) ?? 0) + 1,
+		);
+	}
+
+	private unblockPeerReceiveAdmission(peerHash: string) {
+		const remaining = (this._receiveCleanupGateByPeer.get(peerHash) ?? 1) - 1;
+		if (remaining > 0) {
+			this._receiveCleanupGateByPeer.set(peerHash, remaining);
+		} else {
+			this._receiveCleanupGateByPeer.delete(peerHash);
+		}
+	}
+
 	private handleReplicationLifecycleSendError(
 		error: unknown,
 		controller = this._replicationLifecycleController,
@@ -6851,7 +7054,16 @@ export class SharedLog<
 				options.replicationLifecycleController,
 			);
 		const isMe = this.node.identity.publicKey.hashcode() === keyHash;
+		let receiveAdmissionBlocked = false;
+		const blockAndDrainPeerReceives = async () => {
+			if (!receiveAdmissionBlocked) {
+				this.blockPeerReceiveAdmission(keyHash);
+				receiveAdmissionBlocked = true;
+			}
+			await this.drainPeerReceiveHandlers(keyHash);
+		};
 		const cleanupDisconnectedPeer = async () => {
+			await blockAndDrainPeerReceives();
 			this.removePeerFromGidPeerHistory(keyHash);
 			this.cleanupPeerDisconnectTracking(keyHash);
 			this.removeRepairFrontierTarget(keyHash);
@@ -6889,8 +7101,9 @@ export class SharedLog<
 				})
 				.all();
 			// Liveness evidence can arrive without a subscription transition while
-			// this scan is pending. Revalidate immediately before the first
-			// destructive mutation; subscription removals omit this predicate.
+			// this scan is pending. Stop new receives, drain those already admitted,
+			// then revalidate immediately before the first destructive mutation.
+			await blockAndDrainPeerReceives();
 			if (options?.shouldRemove && !options.shouldRemove()) {
 				return;
 			}
@@ -6950,10 +7163,19 @@ export class SharedLog<
 			await cleanupDisconnectedPeer();
 
 			if (!isMe) {
+				// Replication-info handlers release their receive lease before joining
+				// this lane. Fence every handler queued behind this successful removal,
+				// regardless of whether it came from liveness, startup pruning, or an
+				// unsubscribe transition.
+				this.advanceReplicationInfoRecoveryEpoch(keyHash);
 				this.rebalanceParticipationDebounced?.call();
 			}
 			removed = true;
 			options?.onRemoved?.({ wasReplicator });
+		}).finally(() => {
+			if (receiveAdmissionBlocked) {
+				this.unblockPeerReceiveAdmission(keyHash);
+			}
 		});
 		return removed;
 	}
@@ -9052,10 +9274,22 @@ export class SharedLog<
 			return;
 		}
 
-		void Promise.allSettled(this.prune(toPrune));
+		const pruneTasks = this.prune(toPrune);
+		const confirmationTasks: Promise<void>[] = [];
 		for (const hash of responseStillApplies) {
-			void this._checkedPrune.getPendingDelete(hash)?.resolve(publicKeyHash);
+			const pendingDelete = this._checkedPrune.getPendingDelete(hash);
+			if (pendingDelete) {
+				confirmationTasks.push(
+					Promise.resolve(pendingDelete.resolve(publicKeyHash)),
+				);
+			}
 		}
+		// The restarted prune session owns its own bounded timeout and revalidates
+		// before deletion. Only the peer-derived confirmations must remain inside
+		// this receive lease; waiting for the whole prune session could stall close
+		// or disconnect until its background timeout.
+		void Promise.allSettled(pruneTasks);
+		await Promise.allSettled(confirmationTasks);
 	}
 
 	async append(
@@ -12650,6 +12884,7 @@ export class SharedLog<
 		this._respondToIHaveTimeout = options?.respondToIHaveTimeout ?? 2e4;
 		this._checkedPrune = new CheckedPruneCoordinator<T, R>();
 		this._pendingIHave = new Map();
+		this._pendingIHaveCallbacks = new Set();
 		this.latestReplicationInfoMessage = new Map();
 		this._replicationInfoBlockedPeers = new Set();
 		this._replicationInfoRequestByPeer = new Map();
@@ -12659,6 +12894,11 @@ export class SharedLog<
 		this._replicationInfoReceiveEpochByPeer = new Map();
 		this._subscriptionEpochByPeer = new Map();
 		this._pendingReplicatorLeaveByPeer = new Set();
+		this._activeReceiveHandlersByPeer = new Map();
+		this._receiveHandlerDrainByPeer = new Map();
+		this._receiveCleanupGateByPeer = new Map();
+		this._subscriptionOpeningEpochByPeer = new Map();
+		this._openingSyncCapabilitiesByPeer = new Map();
 		this._repairRetryTimers = new Set();
 		this._recentRepairDispatch = new Map();
 		this._repairSweepRunning = false;
@@ -14075,7 +14315,18 @@ export class SharedLog<
 		this._replicatorLivenessFailures.delete(peerHash);
 		this._replicatorLastActivityAt.delete(peerHash);
 		this._peerSyncCapabilities.delete(peerHash);
+		this.cleanupPendingIHavePeer(peerHash);
 		this._checkedPrune.cleanupPeer(peerHash);
+	}
+
+	private cleanupPendingIHavePeer(peerHash: string) {
+		for (const [hash, pending] of this._pendingIHave) {
+			pending.requesting.delete(peerHash);
+			if (pending.requesting.size === 0) {
+				pending.clear();
+				this._pendingIHave.delete(hash);
+			}
+		}
 	}
 
 	private markReplicatorActivity(peerHash: string, now = Date.now()) {
@@ -14101,8 +14352,8 @@ export class SharedLog<
 	}
 
 	private advanceReplicationInfoRecoveryEpoch(peerHash: string) {
-		// Handlers admitted before a successful liveness removal must not restore
-		// state when they eventually reach the apply lane. Reset the sender's
+		// Handlers admitted before a successful peer removal must not restore state
+		// when they eventually reach the apply lane. Reset the sender's
 		// ordering watermark with the local epoch so a later arrival can be
 		// accepted without comparing its clock to this receiver's clock.
 		this.advanceReplicationInfoReceiveEpoch(peerHash);
@@ -14137,7 +14388,6 @@ export class SharedLog<
 					) {
 						return;
 					}
-					this.advanceReplicationInfoRecoveryEpoch(peerHash);
 					if (this._pendingReplicatorLeaveByPeer.delete(peerHash)) {
 						this.events.dispatchEvent(
 							new CustomEvent<ReplicatorLeaveEvent>("replicator:leave", {
@@ -14324,7 +14574,6 @@ export class SharedLog<
 						if (!ownsProbe()) {
 							return;
 						}
-						this.advanceReplicationInfoRecoveryEpoch(peerHash);
 						this._replicatorLivenessTargetsSize = -1;
 					},
 				});
@@ -15259,8 +15508,14 @@ export class SharedLog<
 		}
 		captureSync(() => {
 			this._pendingIHave?.clear();
+			this._pendingIHaveCallbacks?.clear();
 			this.latestReplicationInfoMessage?.clear();
 			this._replicationInfoReceiveEpochByPeer?.clear();
+			this._activeReceiveHandlersByPeer?.clear();
+			this._receiveHandlerDrainByPeer?.clear();
+			this._receiveCleanupGateByPeer?.clear();
+			this._subscriptionOpeningEpochByPeer?.clear();
+			this._openingSyncCapabilitiesByPeer?.clear();
 			this._gidPeersHistory?.clear();
 			this._peerSyncCapabilities?.clear();
 			this._liveRawGossipBatches?.clear();
@@ -15334,7 +15589,9 @@ export class SharedLog<
 		this.preventParentAttachments();
 		this.stopSubscriptionChangeCallbackAdmission();
 		await this.drainSubscriptionChangeCallbacks();
+		await this.drainReceiveHandlers();
 		await this.drainReplicationInfoApplyQueues();
+		await this.drainPendingIHaveCallbacks();
 		this.ensureNativeDurabilityRuntimeState();
 		this.cancelCurrentReplicationStateAnnouncementRetry();
 		// Best-effort: announce that we are going offline before tearing down
@@ -15456,7 +15713,9 @@ export class SharedLog<
 		this.preventParentAttachments();
 		this.stopSubscriptionChangeCallbackAdmission();
 		await this.drainSubscriptionChangeCallbacks();
+		await this.drainReceiveHandlers();
 		await this.drainReplicationInfoApplyQueues();
+		await this.drainPendingIHaveCallbacks();
 		this.cancelCurrentReplicationStateAnnouncementRetry();
 		// Best-effort: announce that we are going offline before tearing down
 		// RPC/subscription state (same reasoning as in `close()`).
@@ -15673,6 +15932,7 @@ export class SharedLog<
 		const stashBackedRawMessage = isStashBackedRawExchangeHeadsMessage(msg)
 			? msg
 			: undefined;
+		let releasePeerReceiveLease: (() => void) | undefined;
 		try {
 			this.throwIfNativeDurableCommitFailed();
 			if (!context.from) {
@@ -15686,6 +15946,27 @@ export class SharedLog<
 				this._replicationLifecycleController;
 			const receiveSubscriptionEpoch =
 				this.getSubscriptionEpoch(receiveFromHash);
+			const isOpeningSubscriptionReceive =
+				this._subscriptionOpeningEpochByPeer.get(receiveFromHash) ===
+				receiveSubscriptionEpoch;
+			const isOpeningCapabilityAdvertisement =
+				msg instanceof SyncCapabilitiesMessage && isOpeningSubscriptionReceive;
+			releasePeerReceiveLease = this.acquirePeerReceiveLease(
+				receiveFromHash,
+				receiveReplicationLifecycleController,
+				receiveSubscriptionEpoch,
+				{
+					// The replication-info fence existed before receive leases and is
+					// intentionally narrower than the subscription itself. Keep admitting
+					// sync negotiation/data while the new subscription drains the previous
+					// apply generation; replication-info branches recheck the fence below.
+					allowReplicationInfoBlocked: isOpeningSubscriptionReceive,
+					allowCleanupGate: isOpeningCapabilityAdvertisement,
+				},
+			);
+			if (!releasePeerReceiveLease) {
+				return;
+			}
 			const receiveReplicationInfoReceiveEpoch =
 				this.getReplicationInfoReceiveEpoch(receiveFromHash);
 			if (!context.from.equals(this.node.identity.publicKey)) {
@@ -17664,6 +17945,13 @@ export class SharedLog<
 				let pendingIHaveExtended = 0;
 				const leaderResponseHashes: string[] = [];
 				for (let i = 0; i < msg.hashes.length; i++) {
+					if (
+						!this.isReplicationLifecycleActive(
+							receiveReplicationLifecycleController,
+						)
+					) {
+						return;
+					}
 					const hash = msg.hashes[i]!;
 
 					const nativeEntryGid = nativeLeaderHints.nativeEntryGids?.[i];
@@ -17799,8 +18087,21 @@ export class SharedLog<
 								resetTimeout: () => this.resetPendingIHaveTimeout(pendingIHave),
 								clear: () => this.clearPendingIHaveTimeout(pendingIHave),
 								callback: async (entry: Entry<T>) => {
-									this.removePeerFromGidPeerHistory(from, entry.meta.gid);
-									this.removePruneRequestSent(entry.hash, from);
+									if (
+										!this.isReplicationLifecycleActive(
+											receiveReplicationLifecycleController,
+										) ||
+										requesting.size === 0
+									) {
+										return;
+									}
+									for (const requester of requesting) {
+										this.removePeerFromGidPeerHistory(
+											requester,
+											entry.meta.gid,
+										);
+										this.removePruneRequestSent(entry.hash, requester);
+									}
 									let isLeader = false;
 									await this._waitForEntryReplicators(
 										entry,
@@ -17819,12 +18120,19 @@ export class SharedLog<
 											},
 										},
 									);
+									if (
+										!this.isReplicationLifecycleActive(
+											receiveReplicationLifecycleController,
+										) ||
+										requesting.size === 0
+									) {
+										return;
+									}
 									if (isLeader) {
 										this.responseToPruneDebouncedFn.add({
 											hashes: [entry.hash],
-											peers: requesting,
+											peers: new Set(requesting),
 										});
-										this._pendingIHave.delete(hash);
 									}
 								},
 							};
@@ -17867,19 +18175,32 @@ export class SharedLog<
 				}
 			} else if (msg instanceof ResponseIPrune) {
 				const lateResponses: string[] = [];
+				const responseTasks: Promise<void>[] = [];
 				for (const hash of msg.hashes) {
 					const pendingDelete = this._checkedPrune.getPendingDelete(hash);
 					if (pendingDelete) {
-						void pendingDelete.resolve(context.from.hashcode());
+						responseTasks.push(
+							Promise.resolve(
+								pendingDelete.resolve(context.from.hashcode()),
+							),
+						);
 					} else {
 						lateResponses.push(hash);
 					}
 				}
 				if (lateResponses.length > 0) {
-					void this.recoverCheckedPruneFromLateResponses(
-						lateResponses,
-						context.from.hashcode(),
-					).catch((error) => logger.error(error.toString()));
+					responseTasks.push(
+						this.recoverCheckedPruneFromLateResponses(
+							lateResponses,
+							context.from.hashcode(),
+						),
+					);
+				}
+				const results = await Promise.allSettled(responseTasks);
+				for (const result of results) {
+					if (result.status === "rejected") {
+						logger.error(result.reason?.toString?.() ?? String(result.reason));
+					}
 				}
 			} else if (msg instanceof ConfirmEntriesMessage) {
 				this.markEntriesKnownByPeer(msg.hashes, context.from.hashcode());
@@ -17887,10 +18208,25 @@ export class SharedLog<
 				return;
 			} else if (msg instanceof SyncCapabilitiesMessage) {
 				if (!context.from.equals(this.node.identity.publicKey)) {
-					this._peerSyncCapabilities.set(
-						context.from.hashcode(),
-						msg.capabilities,
-					);
+					const openingEpoch =
+						this._subscriptionOpeningEpochByPeer.get(receiveFromHash);
+					if (
+						this._replicationInfoBlockedPeers.has(receiveFromHash) &&
+						openingEpoch === receiveSubscriptionEpoch
+					) {
+						// A prior unsubscribe cleanup may still be ahead of this reconnect
+						// barrier. Stage the new generation's one-shot advertisement so that
+						// cleanup cannot erase it before the opening transition commits.
+						this._openingSyncCapabilitiesByPeer.set(receiveFromHash, {
+							epoch: openingEpoch,
+							capabilities: msg.capabilities,
+						});
+					} else {
+						this._peerSyncCapabilities.set(
+							receiveFromHash,
+							msg.capabilities,
+						);
+					}
 				}
 				return;
 			} else if (await this.syncronizer.onMessage(msg, context)) {
@@ -17907,10 +18243,14 @@ export class SharedLog<
 					return;
 				}
 				const replicationLifecycleController =
-					this._replicationLifecycleController;
+					receiveReplicationLifecycleController;
 				if (
 					!replicationLifecycleController ||
-					!this.isReplicationLifecycleActive(replicationLifecycleController)
+					!this.isPeerReceiveAdmissionOpen(
+						receiveFromHash,
+						replicationLifecycleController,
+						receiveSubscriptionEpoch,
+					)
 				) {
 					return;
 				}
@@ -17920,8 +18260,10 @@ export class SharedLog<
 					replicationSegments = await this.getMyReplicationSegments();
 				} catch (error) {
 					if (
-						!this.isReplicationLifecycleActive(
+						!this.isPeerReceiveAdmissionOpen(
+							receiveFromHash,
 							replicationLifecycleController,
+							receiveSubscriptionEpoch,
 						) &&
 						isNotStartedError(error as Error)
 					) {
@@ -17930,7 +18272,11 @@ export class SharedLog<
 					throw error;
 				}
 				if (
-					!this.isReplicationLifecycleActive(replicationLifecycleController)
+					!this.isPeerReceiveAdmissionOpen(
+						receiveFromHash,
+						replicationLifecycleController,
+						receiveSubscriptionEpoch,
+					)
 				) {
 					return;
 				}
@@ -17951,7 +18297,11 @@ export class SharedLog<
 						),
 					);
 				if (
-					!this.isReplicationLifecycleActive(replicationLifecycleController)
+					!this.isPeerReceiveAdmissionOpen(
+						receiveFromHash,
+						replicationLifecycleController,
+						receiveSubscriptionEpoch,
+					)
 				) {
 					return;
 				}
@@ -18014,6 +18364,8 @@ export class SharedLog<
 					return;
 				}
 				const messageTimestamp = context.message.header.timestamp;
+				releasePeerReceiveLease?.();
+				releasePeerReceiveLease = undefined;
 				await this.withReplicationInfoApplyQueue(fromHash, async () => {
 					try {
 						// The peer may have unsubscribed after this message was queued.
@@ -18097,6 +18449,8 @@ export class SharedLog<
 					return;
 				}
 				const messageTimestamp = context.message.header.timestamp;
+				releasePeerReceiveLease?.();
+				releasePeerReceiveLease = undefined;
 				await this.withReplicationInfoApplyQueue(fromHash, async () => {
 					if (
 						!this.isReplicationLifecycleActive(
@@ -18195,6 +18549,8 @@ export class SharedLog<
 				// Every return and every locally swallowed receive error passes this
 				// boundary. Release a native wire stash exactly once first, then surface
 				// any durable mutation poison that arose while handling the message.
+				releasePeerReceiveLease?.();
+				releasePeerReceiveLease = undefined;
 				this.throwIfNativeDurableCommitFailed();
 			}
 		}
@@ -18837,30 +19193,35 @@ export class SharedLog<
 		checkLeaders: (options: WaitForReplicatorsOptions<R>) => Promise<LeaderMap>,
 	): Promise<LeaderMap | false> {
 		const timeout = options.timeout ?? this.waitForReplicatorTimeout;
+		const closeSignal = this._closeController.signal;
+		const replicationLifecycleSignal =
+			this._replicationLifecycleController?.signal;
 
 		return new Promise((resolve, reject) => {
 			let settled = false;
+			const checks = new Set<Promise<void>>();
 			const removeListeners = () => {
 				this.events.removeEventListener("replication:change", roleListener);
 				this.events.removeEventListener("replicator:mature", roleListener);
-				this._closeController.signal.removeEventListener(
-					"abort",
-					abortListener,
-				);
+				closeSignal.removeEventListener("abort", abortListener);
+				replicationLifecycleSignal?.removeEventListener("abort", abortListener);
 			};
 			const settleResolve = (value: LeaderMap | false) => {
 				if (settled) return;
 				settled = true;
 				removeListeners();
 				clearTimeout(timer);
-				resolve(value);
+				// Leader planning may persist coordinates. Keep the caller (and any
+				// receive lease it owns) alive until checks admitted before this
+				// timeout/abort have finished their local side effects.
+				void Promise.allSettled([...checks]).then(() => resolve(value));
 			};
 			const settleReject = (error: unknown) => {
 				if (settled) return;
 				settled = true;
 				removeListeners();
 				clearTimeout(timer);
-				reject(error);
+				void Promise.allSettled([...checks]).then(() => reject(error));
 			};
 			const abortListener = () => {
 				settleResolve(false);
@@ -18894,9 +19255,14 @@ export class SharedLog<
 				settleResolve(leaders);
 			};
 			const runCheck = () => {
-				void check().catch((error) => {
-					settleReject(error);
-				});
+				if (settled) return;
+				let running!: Promise<void>;
+				running = check()
+					.catch((error) => {
+						settleReject(error);
+					})
+					.finally(() => checks.delete(running));
+				checks.add(running);
 			};
 
 			const roleListener = () => {
@@ -18905,7 +19271,15 @@ export class SharedLog<
 
 			this.events.addEventListener("replication:change", roleListener);
 			this.events.addEventListener("replicator:mature", roleListener);
-			this._closeController.signal.addEventListener("abort", abortListener);
+			closeSignal.addEventListener("abort", abortListener);
+			replicationLifecycleSignal?.addEventListener("abort", abortListener);
+			// AbortSignal does not replay an abort event to listeners added after it
+			// fired. Recheck after registration so work started concurrently with the
+			// terminal fence cannot wait for the full leader-selection timeout.
+			if (closeSignal.aborted || replicationLifecycleSignal?.aborted) {
+				abortListener();
+				return;
+			}
 			runCheck();
 		});
 	}
@@ -22066,25 +22440,64 @@ export class SharedLog<
 			return;
 		}
 		if (subscribed) {
-			// Fence replication-info messages immediately, then wait behind every
-			// previously admitted mutation for this identity. A reconnect must not
-			// create state that an older removal can erase halfway through.
-			this._replicationInfoBlockedPeers.add(peerHash);
-			await this.withReplicationInfoApplyQueue(peerHash, async () => {});
+			const pendingOpeningCapabilities =
+				this._openingSyncCapabilitiesByPeer.get(peerHash);
 			if (
-				!this.isReplicationLifecycleActive(replicationLifecycleController) ||
-				!ownsSubscriptionEpoch()
+				pendingOpeningCapabilities &&
+				pendingOpeningCapabilities.epoch !== expectedSubscriptionEpoch
 			) {
-				return;
+				this._openingSyncCapabilitiesByPeer.delete(peerHash);
 			}
-			// The timestamp watermark belongs to the previous subscription epoch.
-			// Sender clocks are not synchronized, so carrying a local unsubscribe
-			// timestamp forward could reject every valid announcement after reconnect.
-			this.latestReplicationInfoMessage.delete(peerHash);
-			this._pendingReplicatorLeaveByPeer.delete(peerHash);
-			this._replicationInfoBlockedPeers.delete(peerHash);
+			this._subscriptionOpeningEpochByPeer.set(
+				peerHash,
+				expectedSubscriptionEpoch,
+			);
+			// Fence new messages immediately, drain handlers admitted by the previous
+			// subscription, then wait behind every queued replication mutation. A
+			// reconnect must not inherit metadata or ranges from the old connection.
+			try {
+				this._replicationInfoBlockedPeers.add(peerHash);
+				await this.drainPeerReceiveHandlers(peerHash);
+				await this.withReplicationInfoApplyQueue(peerHash, async () => {});
+				if (
+					!this.isReplicationLifecycleActive(replicationLifecycleController) ||
+					!ownsSubscriptionEpoch()
+				) {
+					return;
+				}
+				// The timestamp watermark belongs to the previous subscription epoch.
+				// Sender clocks are not synchronized, so carrying a local unsubscribe
+				// timestamp forward could reject every valid announcement after reconnect.
+				this.latestReplicationInfoMessage.delete(peerHash);
+				this._pendingReplicatorLeaveByPeer.delete(peerHash);
+				const openingCapabilities =
+					this._openingSyncCapabilitiesByPeer.get(peerHash);
+				if (openingCapabilities?.epoch === expectedSubscriptionEpoch) {
+					this._peerSyncCapabilities.set(
+						peerHash,
+						openingCapabilities.capabilities,
+					);
+					this._openingSyncCapabilitiesByPeer.delete(peerHash);
+				}
+				this._replicationInfoBlockedPeers.delete(peerHash);
+			} finally {
+				if (
+					this._openingSyncCapabilitiesByPeer.get(peerHash)?.epoch ===
+					expectedSubscriptionEpoch
+				) {
+					this._openingSyncCapabilitiesByPeer.delete(peerHash);
+				}
+				if (
+					this._subscriptionOpeningEpochByPeer.get(peerHash) ===
+					expectedSubscriptionEpoch
+				) {
+					this._subscriptionOpeningEpochByPeer.delete(peerHash);
+				}
+			}
 		}
 		if (!subscribed) {
+			this._subscriptionOpeningEpochByPeer.delete(peerHash);
+			this._openingSyncCapabilitiesByPeer.delete(peerHash);
 			this._replicationInfoBlockedPeers.add(peerHash);
 
 			const now = BigInt(+new Date());
@@ -23291,7 +23704,7 @@ export class SharedLog<
 
 		if (ih) {
 			ih.clear();
-			ih.callback(entry);
+			this.runPendingIHaveCallback(ih, entry);
 		}
 
 		this.syncronizer.onEntryAdded(entry);
@@ -23305,7 +23718,7 @@ export class SharedLog<
 			}
 			const entry = materializeEntry();
 			ih.clear();
-			ih.callback(entry);
+			this.runPendingIHaveCallback(ih, entry);
 			this.syncronizer.onEntryAdded(entry);
 			return;
 		}

--- a/packages/programs/data/shared-log/test/domain-time.spec.ts
+++ b/packages/programs/data/shared-log/test/domain-time.spec.ts
@@ -311,14 +311,18 @@ describe(`e2e`, function () {
 			expect((await db2.log.getReplicators()).size).to.equal(2),
 		);
 
-		let eps = 10;
+		const eps = 10n;
+		// Keep the boundary offset in bigint arithmetic. At epoch-scale nanoseconds,
+		// a Number's ULP is larger than `eps`, which can round this back into db2's
+		// preceding millisecond range and make the expected leader nondeterministic.
+		const entry = toEntry(BigInt(someTimeInTheFuture) * 1_000_000n + eps);
 		const isLeader1 = await db1.log.isLeader({
-			entry: toEntry(someTimeInTheFuture * 1e6 + eps),
+			entry,
 			replicas: 1,
 		});
 		expect(isLeader1).to.be.true;
 		const isLeader2 = await db2.log.isLeader({
-			entry: toEntry(someTimeInTheFuture * 1e6 + eps),
+			entry,
 			replicas: 1,
 		});
 		expect(isLeader2).to.be.false;

--- a/packages/programs/data/shared-log/test/events.spec.ts
+++ b/packages/programs/data/shared-log/test/events.spec.ts
@@ -5,6 +5,7 @@ import { expect } from "chai";
 import pDefer from "p-defer";
 import sinon from "sinon";
 import { v4 as uuid } from "uuid";
+import { SyncCapabilitiesMessage } from "../src/exchange-heads.js";
 import {
 	AllReplicatingSegmentsMessage,
 	StoppedReplicating,
@@ -393,12 +394,18 @@ describe("events", () => {
 				._onSubscription({
 					detail: { from: remoteKey, topics: [db1.log.topic] },
 				})
-				.finally(() => {
-					reconnectSettled = true;
-				});
-
+					.finally(() => {
+						reconnectSettled = true;
+					});
 			releaseBlocker.resolve();
 			await cleanupStarted.promise;
+			expect(log._receiveCleanupGateByPeer.has(remoteHash)).to.be.true;
+			await db1.log.onMessage(new SyncCapabilitiesMessage(), {
+				from: remoteKey,
+			} as any);
+			expect(
+				log._openingSyncCapabilitiesByPeer.get(remoteHash)?.capabilities,
+			).to.equal(1);
 			await Promise.resolve();
 			expect(reconnectSettled).to.be.false;
 			releaseCleanup.resolve();
@@ -410,7 +417,8 @@ describe("events", () => {
 				await replicationIndex.count({ query: { hash: remoteHash } }),
 			).to.be.greaterThan(0);
 			expect(db1.log.uniqueReplicators.has(remoteHash)).to.be.true;
-			expect(log._peerSyncCapabilities.has(remoteHash)).to.be.false;
+			expect(log._peerSyncCapabilities.get(remoteHash)).to.equal(1);
+			expect(log._openingSyncCapabilitiesByPeer.has(remoteHash)).to.be.false;
 			expect(log._gidPeersHistory.has(gid)).to.be.false;
 			expect(disconnected.calledOnceWith(remoteHash)).to.be.true;
 			expect(leaves).to.deep.equal([]);
@@ -477,15 +485,14 @@ describe("events", () => {
 			} as any);
 			await synchronizerEntered.promise;
 
-			await log._onUnsubscription({
+			const unsubscribe = log._onUnsubscription({
 				detail: { from: remoteKey, topics: [db1.log.topic] },
 			});
+			releaseSynchronizer.resolve();
+			await Promise.all([delayedReceive, unsubscribe]);
 			await log._onSubscription({
 				detail: { from: remoteKey, topics: [db1.log.topic] },
 			});
-
-			releaseSynchronizer.resolve();
-			await delayedReceive;
 			expect(
 				await replicationIndex.count({ query: { hash: remoteHash } }),
 			).to.equal(0);
@@ -526,9 +533,9 @@ describe("events", () => {
 			await log._onUnsubscription({
 				detail: { from: remoteKey, topics: [db1.log.topic] },
 			});
-			expect(
-				(log.latestReplicationInfoMessage.get(remoteHash) ?? 0n) > 1n,
-			).to.be.true;
+			// Successful cleanup retires both the old receive generation and its
+			// sender-clock watermark; the unsubscribe fence rejects late traffic.
+			expect(log.latestReplicationInfoMessage.has(remoteHash)).to.be.false;
 
 			await log._onSubscription({
 				detail: { from: remoteKey, topics: [db1.log.topic] },

--- a/packages/programs/data/shared-log/test/lifecycle.spec.ts
+++ b/packages/programs/data/shared-log/test/lifecycle.spec.ts
@@ -298,29 +298,26 @@ describe("lifecycle", () => {
 			args: { replicate: { factor: 1 } },
 		});
 		const sharedLog = db.log;
-		const getMyReplicationSegments =
-			sharedLog.getMyReplicationSegments.bind(sharedLog);
-		const capturedSegments = await getMyReplicationSegments();
-		expect(capturedSegments).to.have.length(1);
-		let markLookupStarted!: () => void;
-		const lookupStarted = new Promise<void>((resolve) => {
-			markLookupStarted = resolve;
+		const requestMessage = new RequestReplicationInfoMessage();
+		let markSynchronizerEntered!: () => void;
+		const synchronizerEntered = new Promise<void>((resolve) => {
+			markSynchronizerEntered = resolve;
 		});
-		let releaseLookup!: () => void;
-		const lookupGate = new Promise<void>((resolve) => {
-			releaseLookup = resolve;
+		let releaseSynchronizer!: () => void;
+		const synchronizerGate = new Promise<void>((resolve) => {
+			releaseSynchronizer = resolve;
 		});
-		let gateFirstLookup = true;
-		const lookup = sinon
-			.stub(sharedLog, "getMyReplicationSegments")
-			.callsFake(async () => {
-				if (!gateFirstLookup) {
-					return getMyReplicationSegments();
+		const originalSynchronizerOnMessage =
+			sharedLog.syncronizer.onMessage.bind(sharedLog.syncronizer);
+		const synchronizer = sinon
+			.stub(sharedLog.syncronizer, "onMessage")
+			.callsFake(async (message: unknown, context: unknown) => {
+				if (message === requestMessage) {
+					markSynchronizerEntered();
+					await synchronizerGate;
+					return false;
 				}
-				gateFirstLookup = false;
-				markLookupStarted();
-				await lookupGate;
-				return capturedSegments;
+				return originalSynchronizerOnMessage(message as any, context as any);
 			});
 		const sent: unknown[] = [];
 		const send = sinon
@@ -331,34 +328,41 @@ describe("lifecycle", () => {
 			});
 		const requester = (await Ed25519Keypair.create()).publicKey;
 		let request: Promise<unknown> | undefined;
+		let closing: Promise<unknown> | undefined;
 
 		try {
-			request = sharedLog.onMessage(new RequestReplicationInfoMessage(), {
+			request = sharedLog.onMessage(requestMessage, {
 				from: requester,
 			} as any);
-			await lookupStarted;
+			await synchronizerEntered;
 
-			await db.close();
-			await session.peers[0].open(db);
-			const nonemptyBeforeRelease = sent.filter(
-				(message) =>
-					message instanceof AllReplicatingSegmentsMessage &&
-					message.segments.length > 0,
-			).length;
+			let closeSettled = false;
+			closing = db.close().then(() => {
+				closeSettled = true;
+			});
+			await waitForResolved(() =>
+				expect(sharedLog.acceptsParentAttachments).to.be.false,
+			);
+			await delay(20);
+			expect(closeSettled).to.be.false;
 
-			releaseLookup();
-			await request;
+			releaseSynchronizer();
+			await Promise.all([request, closing]);
 			expect(
 				sent.filter(
 					(message) =>
 						message instanceof AllReplicatingSegmentsMessage &&
 						message.segments.length > 0,
-				).length,
-			).to.equal(nonemptyBeforeRelease);
+				),
+			).to.have.length(0);
+
+			await session.peers[0].open(db);
+			expect((sharedLog as any)._activeReceiveHandlersByPeer.size).to.equal(0);
 		} finally {
-			releaseLookup();
+			releaseSynchronizer();
 			await request?.catch(() => {});
-			lookup.restore();
+			await closing?.catch(() => {});
+			synchronizer.restore();
 			send.restore();
 		}
 	});

--- a/packages/programs/data/shared-log/test/receive-admission.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission.spec.ts
@@ -1,11 +1,24 @@
 import { Entry } from "@peerbit/log";
 import { TestSession } from "@peerbit/test-utils";
+import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
+import pDefer, { type DeferredPromise } from "p-defer";
 import sinon from "sinon";
 import { v4 as uuid } from "uuid";
-import { EntryWithRefs, ExchangeHeadsMessage } from "../src/exchange-heads.js";
+import {
+	EntryWithRefs,
+	ExchangeHeadsMessage,
+	RequestIPrune,
+	ResponseIPrune,
+	SyncCapabilitiesMessage,
+} from "../src/exchange-heads.js";
 import { createReplicationDomainHash } from "../src/replication-domain-hash.js";
-import { SimpleSyncronizer } from "../src/sync/simple.js";
+import { AllReplicatingSegmentsMessage } from "../src/replication.js";
+import {
+	ConfirmEntriesMessage,
+	RequestMaybeSync,
+	SimpleSyncronizer,
+} from "../src/sync/simple.js";
 import { EventStore } from "./utils/stores/event-store.js";
 
 const setup = {
@@ -33,6 +46,791 @@ const makeParentUnavailable = (parentHash: string) => {
 };
 
 describe("receive admission", () => {
+	it("rejects metadata messages after unsubscribe cleanup starts", async () => {
+		const session = await TestSession.disconnected(2);
+		const cleanupEntered = pDefer<void>();
+		const releaseCleanup = pDefer<void>();
+		try {
+			const store = new EventStore<string, any>();
+			const source = await session.peers[0].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const sharedLog = target.log as any;
+			const sourceKey = source.node.identity.publicKey;
+			const sourceHash = sourceKey.hashcode();
+			const originalDisconnected =
+				sharedLog.syncronizer.onPeerDisconnected.bind(sharedLog.syncronizer);
+			const disconnected = sinon
+				.stub(sharedLog.syncronizer, "onPeerDisconnected")
+				.callsFake(async (...args: unknown[]) => {
+					const peerHash = args[0] as string;
+					if (peerHash === sourceHash) {
+						cleanupEntered.resolve();
+						await releaseCleanup.promise;
+					}
+					return originalDisconnected(peerHash);
+				});
+
+			try {
+				const unsubscribe = sharedLog._onUnsubscription({
+					detail: { from: sourceKey, topics: [target.log.topic] },
+				});
+				await cleanupEntered.promise;
+
+				await Promise.all([
+					target.log.onMessage(
+						new ConfirmEntriesMessage({ hashes: ["late-confirm"] }),
+						{ from: sourceKey } as any,
+					),
+					target.log.onMessage(new SyncCapabilitiesMessage(), {
+						from: sourceKey,
+					} as any),
+				]);
+
+				expect(sharedLog._entryKnownPeers.has("late-confirm")).to.be.false;
+				expect(sharedLog._entryKnownPeerObservedAt.has("late-confirm")).to.be
+					.false;
+				expect(sharedLog._peerSyncCapabilities.has(sourceHash)).to.be.false;
+				expect(sharedLog._replicatorLastActivityAt.has(sourceHash)).to.be.false;
+				expect(sharedLog._activeReceiveHandlersByPeer.has(sourceHash)).to.be
+					.false;
+
+				releaseCleanup.resolve();
+				await unsubscribe;
+				expect(sharedLog._receiveCleanupGateByPeer.has(sourceHash)).to.be.false;
+			} finally {
+				releaseCleanup.resolve();
+				disconnected.restore();
+			}
+		} finally {
+			releaseCleanup.resolve();
+			await session.stop();
+		}
+	});
+
+	it("accepts a capability advertisement during the opening subscription fence", async () => {
+		const session = await TestSession.disconnected(2);
+		try {
+			const store = new EventStore<string, any>();
+			const source = await session.peers[0].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const sharedLog = target.log as any;
+			const sourceKey = source.node.identity.publicKey;
+			const sourceHash = sourceKey.hashcode();
+			const scheduleRequests = sinon
+				.stub(sharedLog, "scheduleReplicationInfoRequests")
+				.callsFake(() => {});
+
+			try {
+				const subscription = sharedLog._onSubscription({
+					detail: { from: sourceKey, topics: [target.log.topic] },
+				});
+				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
+					.true;
+
+				await target.log.onMessage(new SyncCapabilitiesMessage(), {
+					from: sourceKey,
+				} as any);
+				await subscription;
+
+				expect(sharedLog._peerSyncCapabilities.get(sourceHash)).to.equal(1);
+				expect(sharedLog._subscriptionOpeningEpochByPeer.has(sourceHash)).to.be
+					.false;
+				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
+					.false;
+			} finally {
+				scheduleRequests.restore();
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("keeps sync negotiation live during the opening subscription fence", async () => {
+		const session = await TestSession.disconnected(2);
+		try {
+			const store = new EventStore<string, any>();
+			const source = await session.peers[0].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const sharedLog = target.log as any;
+			const sourceKey = source.node.identity.publicKey;
+			const sourceHash = sourceKey.hashcode();
+			const scheduleRequests = sinon
+				.stub(sharedLog, "scheduleReplicationInfoRequests")
+				.callsFake(() => {});
+			const synchronizerOnMessage = sinon.spy(
+				sharedLog.syncronizer,
+				"onMessage",
+			);
+
+			try {
+				const subscription = sharedLog._onSubscription({
+					detail: { from: sourceKey, topics: [target.log.topic] },
+				});
+				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
+					.true;
+
+				await target.log.onMessage(new RequestMaybeSync({ hashes: [] }), {
+					from: sourceKey,
+				} as any);
+				await subscription;
+
+				expect(synchronizerOnMessage.calledOnce).to.be.true;
+				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
+					.false;
+			} finally {
+				synchronizerOnMessage.restore();
+				scheduleRequests.restore();
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("drains only pre-transition receives while a subscription opens", async () => {
+		const session = await TestSession.disconnected(2);
+		const oldReceiveEntered = pDefer<void>();
+		const currentReceiveEntered = pDefer<void>();
+		const releaseOldReceive = pDefer<void>();
+		const releaseCurrentReceive = pDefer<void>();
+		let oldReceive: Promise<void> | undefined;
+		let currentReceive: Promise<void> | undefined;
+		let subscription: Promise<void> | undefined;
+		try {
+			const store = new EventStore<string, any>();
+			const source = await session.peers[0].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const sharedLog = target.log as any;
+			const sourceKey = source.node.identity.publicKey;
+			const sourceHash = sourceKey.hashcode();
+			const scheduleRequests = sinon
+				.stub(sharedLog, "scheduleReplicationInfoRequests")
+				.callsFake(() => {});
+			let receiveCount = 0;
+			const synchronizerOnMessage = sinon
+				.stub(sharedLog.syncronizer, "onMessage")
+				.callsFake(async () => {
+					receiveCount += 1;
+					if (receiveCount === 1) {
+						oldReceiveEntered.resolve();
+						await releaseOldReceive.promise;
+					} else {
+						currentReceiveEntered.resolve();
+						await releaseCurrentReceive.promise;
+					}
+					return true;
+				});
+
+			try {
+				oldReceive = target.log.onMessage(
+					new RequestMaybeSync({ hashes: [] }),
+					{ from: sourceKey } as any,
+				);
+				await oldReceiveEntered.promise;
+
+				let subscriptionSettled = false;
+				subscription = sharedLog
+					._onSubscription({
+						detail: { from: sourceKey, topics: [target.log.topic] },
+					})
+					.then(() => {
+						subscriptionSettled = true;
+					});
+				await waitForResolved(() =>
+					expect(sharedLog._receiveHandlerDrainByPeer.has(sourceHash)).to.be
+						.true,
+				);
+
+				let currentReceiveSettled = false;
+				currentReceive = target.log
+					.onMessage(new RequestMaybeSync({ hashes: [] }), {
+						from: sourceKey,
+					} as any)
+					.then(() => {
+						currentReceiveSettled = true;
+					});
+				await currentReceiveEntered.promise;
+
+				releaseOldReceive.resolve();
+				await waitForResolved(
+					() => expect(subscriptionSettled).to.be.true,
+					{ timeout: 2_000 },
+				);
+				expect(currentReceiveSettled).to.be.false;
+				expect(sharedLog._activeReceiveHandlersByPeer.has(sourceHash)).to.be
+					.true;
+
+				releaseCurrentReceive.resolve();
+				await Promise.all([oldReceive, currentReceive, subscription]);
+				expect(sharedLog._activeReceiveHandlersByPeer.has(sourceHash)).to.be
+					.false;
+				expect(sharedLog._receiveHandlerDrainByPeer.has(sourceHash)).to.be
+					.false;
+			} finally {
+				releaseOldReceive.resolve();
+				releaseCurrentReceive.resolve();
+				await Promise.allSettled(
+					[oldReceive, currentReceive, subscription].filter(
+						(value): value is Promise<void> => value != null,
+					),
+				);
+				synchronizerOnMessage.restore();
+				scheduleRequests.restore();
+			}
+		} finally {
+			releaseOldReceive.resolve();
+			releaseCurrentReceive.resolve();
+			await session.stop();
+		}
+	});
+
+	it("drains a previously admitted exchange before disconnect cleanup", async () => {
+		const session = await TestSession.disconnected(2);
+		const hasManyEntered = pDefer<void>();
+		const releaseHasMany = pDefer<void>();
+		try {
+			const store = new EventStore<string, any>();
+			const source = await session.peers[0].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const { entry } = await source.add(uuid(), { meta: { next: [] } });
+			await target.log.log.join([entry]);
+
+			const sharedLog = target.log as any;
+			const sourceKey = source.node.identity.publicKey;
+			const sourceHash = sourceKey.hashcode();
+			const originalHasMany = target.log.log.hasMany.bind(target.log.log);
+			const hasMany = sinon.stub(target.log.log, "hasMany").callsFake(async (...args) => {
+				hasManyEntered.resolve();
+				await releaseHasMany.promise;
+				return originalHasMany(...args);
+			});
+			const confirmation = sinon
+				.stub(sharedLog, "sendRepairConfirmation")
+				.resolves();
+
+			try {
+				const receive = target.log.onMessage(exchange(entry), {
+					from: sourceKey,
+				} as any);
+				await hasManyEntered.promise;
+
+				let unsubscribeSettled = false;
+				const unsubscribe = sharedLog
+					._onUnsubscription({
+						detail: { from: sourceKey, topics: [target.log.topic] },
+					})
+					.then(() => {
+						unsubscribeSettled = true;
+					});
+				await waitForResolved(() =>
+					expect(sharedLog._receiveHandlerDrainByPeer.has(sourceHash)).to.be
+						.true,
+				);
+				expect(unsubscribeSettled).to.be.false;
+
+				releaseHasMany.resolve();
+				await Promise.all([receive, unsubscribe]);
+
+				expect(sharedLog._entryKnownPeers.get(entry.hash)?.has(sourceHash)).to
+					.not.equal(true);
+				expect(
+					sharedLog._entryKnownPeerObservedAt.get(entry.hash)?.has(sourceHash),
+				).to.not.equal(true);
+				expect(sharedLog._replicatorLastActivityAt.has(sourceHash)).to.be.false;
+				expect(sharedLog._activeReceiveHandlersByPeer.has(sourceHash)).to.be
+					.false;
+				expect(sharedLog._receiveHandlerDrainByPeer.has(sourceHash)).to.be.false;
+				expect(sharedLog._receiveCleanupGateByPeer.has(sourceHash)).to.be.false;
+			} finally {
+				releaseHasMany.resolve();
+				confirmation.restore();
+				hasMany.restore();
+			}
+		} finally {
+			releaseHasMany.resolve();
+			await session.stop();
+		}
+	});
+
+	it("drains asynchronous prune-response side effects before cleanup", async () => {
+		const session = await TestSession.disconnected(2);
+		const pendingResolveEntered = pDefer<void>();
+		const lateResolveEntered = pDefer<void>();
+		const pendingResolveFinished = pDefer<void>();
+		const releasePendingResponse = pDefer<void>();
+		const releaseLateResponse = pDefer<void>();
+		try {
+			const store = new EventStore<string, any>();
+			const source = await session.peers[0].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const sharedLog = target.log as any;
+			const sourceKey = source.node.identity.publicKey;
+			const sourceHash = sourceKey.hashcode();
+			const pendingHash = "pending-prune-response";
+			const { entry: retryEntry } = await source.add(uuid(), {
+				meta: { next: [] },
+			});
+			const lateHash = retryEntry.hash;
+			const installPending = (
+				hash: string,
+				entered: DeferredPromise<void>,
+				release: DeferredPromise<void>,
+				finished?: DeferredPromise<void>,
+			) => {
+				const pendingPromise = pDefer<void>();
+				sharedLog._checkedPrune.pendingDeletes.set(hash, {
+					promise: pendingPromise,
+					clear: () => {},
+					reject: () => {},
+					resolve: async (peerHash: string) => {
+						entered.resolve();
+						await release.promise;
+						sharedLog._checkedPrune.addConfirmedReplicator(hash, peerHash);
+						finished?.resolve();
+					},
+				});
+			};
+			installPending(
+				pendingHash,
+				pendingResolveEntered,
+				releasePendingResponse,
+				pendingResolveFinished,
+			);
+			const leaders = new Map([[sourceHash, { intersecting: true }]]);
+			sharedLog._checkedPrune.setRetry(lateHash, {
+				attempts: 1,
+				entry: retryEntry,
+				leaders,
+			});
+			const findLeaders = sinon
+				.stub(sharedLog, "findLeadersFromEntry")
+				.resolves(leaders);
+			const prune = sinon.stub(sharedLog, "prune").callsFake((...args: unknown[]) => {
+				const entries = args[0] as Map<string, unknown>;
+				expect(entries.has(lateHash)).to.be.true;
+				installPending(lateHash, lateResolveEntered, releaseLateResponse);
+				return [Promise.resolve()];
+			});
+
+			try {
+				const receive = target.log.onMessage(
+					new ResponseIPrune({ hashes: [pendingHash, lateHash] }),
+					{ from: sourceKey } as any,
+				);
+				await Promise.all([
+					pendingResolveEntered.promise,
+					lateResolveEntered.promise,
+				]);
+
+				let unsubscribeSettled = false;
+				const unsubscribe = sharedLog
+					._onUnsubscription({
+						detail: { from: sourceKey, topics: [target.log.topic] },
+					})
+					.then(() => {
+						unsubscribeSettled = true;
+					});
+				await waitForResolved(() =>
+					expect(sharedLog._receiveHandlerDrainByPeer.has(sourceHash)).to.be
+						.true,
+				);
+				expect(unsubscribeSettled).to.be.false;
+
+				releasePendingResponse.resolve();
+				await pendingResolveFinished.promise;
+				await new Promise<void>((resolve) => setTimeout(resolve, 0));
+				expect(sharedLog._activeReceiveHandlersByPeer.has(sourceHash)).to.be.true;
+				expect(unsubscribeSettled).to.be.false;
+
+				releaseLateResponse.resolve();
+				await Promise.all([receive, unsubscribe]);
+				for (const hash of [pendingHash, lateHash]) {
+					expect(
+						sharedLog._checkedPrune
+							.getConfirmedReplicators(hash)
+							?.has(sourceHash),
+					).to.not.equal(true);
+				}
+				expect(sharedLog._activeReceiveHandlersByPeer.has(sourceHash)).to.be
+					.false;
+				expect(sharedLog._receiveCleanupGateByPeer.has(sourceHash)).to.be.false;
+			} finally {
+				releasePendingResponse.resolve();
+				releaseLateResponse.resolve();
+				prune.restore();
+				findLeaders.restore();
+			}
+		} finally {
+			releasePendingResponse.resolve();
+			releaseLateResponse.resolve();
+			await session.stop();
+		}
+	});
+
+	it("cancels leader waits before draining prune responses on close", async () => {
+		const session = await TestSession.disconnected(2);
+		const firstWaitEntered = pDefer<void>();
+		const secondWaitEntered = pDefer<void>();
+		const releaseFirstCheck = pDefer<void>();
+		try {
+			const store = new EventStore<string, any>();
+			const source = await session.peers[0].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const sharedLog = target.log as any;
+			const sourceKey = source.node.identity.publicKey;
+			const hash = "close-cancels-prune-response-leader-wait";
+			const pendingPromise = pDefer<void>();
+			let waitCount = 0;
+			let secondWaitHasEntered = false;
+			const waitForMissingLeader = () => {
+				waitCount += 1;
+				const currentWait = waitCount;
+				if (currentWait === 2) {
+					secondWaitHasEntered = true;
+					secondWaitEntered.resolve();
+				}
+				return sharedLog.waitForLeaderSelection(
+					[{ key: "missing-replicator", replicator: true }],
+					{ timeout: 60_000 },
+					async () => {
+						if (currentWait === 1) {
+							firstWaitEntered.resolve();
+							await releaseFirstCheck.promise;
+						}
+						return new Map();
+					},
+				);
+			};
+
+			sharedLog._checkedPrune.pendingDeletes.set(hash, {
+				promise: pendingPromise,
+				clear: () => {},
+				reject: () => {},
+				resolve: async () => {
+					expect(await waitForMissingLeader()).to.be.false;
+					// This wait begins after the close signal has already fired. It must
+					// observe the latched abort instead of waiting for its full timeout.
+					expect(await waitForMissingLeader()).to.be.false;
+				},
+			});
+
+			const receive = target.log.onMessage(
+				new ResponseIPrune({ hashes: [hash] }),
+				{ from: sourceKey } as any,
+			);
+			await firstWaitEntered.promise;
+
+			let closeSettled = false;
+			const close = target.close().then(() => {
+				closeSettled = true;
+			});
+			await waitForResolved(() =>
+				expect(sharedLog._replicationLifecycleController.signal.aborted).to.be
+					.true,
+			);
+			expect(sharedLog._closeController.signal.aborted).to.be.false;
+			await new Promise<void>((resolve) => setTimeout(resolve, 0));
+			// Aborting the outer wait must not release the receive lease while its
+			// already-admitted leader check can still perform local persistence.
+			expect(secondWaitHasEntered).to.be.false;
+			expect(closeSettled).to.be.false;
+			releaseFirstCheck.resolve();
+			await secondWaitEntered.promise;
+			await waitForResolved(() => expect(closeSettled).to.be.true, {
+				timeout: 2_000,
+			});
+			await Promise.all([receive, close]);
+		} finally {
+			releaseFirstCheck.resolve();
+			await session.stop();
+		}
+	});
+
+	it("drains an admitted pending-IHave callback before close", async () => {
+		const session = await TestSession.disconnected(1);
+		const callbackEntered = pDefer<void>();
+		const releaseCallback = pDefer<void>();
+		try {
+			const target = await session.peers[0].open(
+				new EventStore<string, any>(),
+				{
+					args: { replicate: false, setup },
+				},
+			);
+			const { entry } = await target.add(uuid(), { meta: { next: [] } });
+			const sharedLog = target.log as any;
+			let callbackFinished = false;
+			const synchronizerEntryAdded = sinon
+				.stub(sharedLog.syncronizer, "onEntryAdded")
+				.callsFake(() => {});
+
+			try {
+				sharedLog._pendingIHave.set(entry.hash, {
+					requesting: new Set(),
+					resetTimeout: () => {},
+					clear: () => {},
+					callback: async () => {
+						callbackEntered.resolve();
+						await releaseCallback.promise;
+						callbackFinished = true;
+					},
+				});
+				sharedLog.onEntryAdded(entry);
+				await callbackEntered.promise;
+				expect(sharedLog._pendingIHaveCallbacks.size).to.equal(1);
+
+				let closeSettled = false;
+				const close = target.close().then(() => {
+					closeSettled = true;
+				});
+				await waitForResolved(() =>
+					expect(sharedLog._replicationLifecycleController.signal.aborted).to.be
+						.true,
+				);
+				await new Promise<void>((resolve) => setTimeout(resolve, 0));
+				expect(closeSettled).to.be.false;
+				expect(callbackFinished).to.be.false;
+
+				releaseCallback.resolve();
+				await waitForResolved(() => expect(closeSettled).to.be.true, {
+					timeout: 2_000,
+				});
+				await close;
+				expect(callbackFinished).to.be.true;
+				expect(sharedLog._pendingIHaveCallbacks.size).to.equal(0);
+			} finally {
+				releaseCallback.resolve();
+				synchronizerEntryAdded.restore();
+			}
+		} finally {
+			releaseCallback.resolve();
+			await session.stop();
+		}
+	});
+
+	it("keeps coalesced pending-IHave requests for connected peers", async () => {
+		const session = await TestSession.disconnected(3);
+		try {
+			const target = await session.peers[0].open(
+				new EventStore<string, any>(),
+				{
+					args: { replicate: false, setup },
+				},
+			);
+			const source = await session.peers[2].open(
+				new EventStore<string, any>(),
+				{
+					args: { replicate: false, setup },
+				},
+			);
+			const { entry } = await source.add(uuid(), { meta: { next: [] } });
+			const sharedLog = target.log as any;
+			const firstKey = session.peers[1].identity.publicKey;
+			const firstHash = firstKey.hashcode();
+			const secondKey = session.peers[2].identity.publicKey;
+			const secondHash = secondKey.hashcode();
+
+			await target.log.onMessage(
+				new RequestIPrune({ hashes: [entry.hash] }),
+				{ from: firstKey } as any,
+			);
+			await target.log.onMessage(
+				new RequestIPrune({ hashes: [entry.hash] }),
+				{ from: secondKey } as any,
+			);
+			const pending = sharedLog._pendingIHave.get(entry.hash);
+			expect([...pending.requesting]).to.have.members([firstHash, secondHash]);
+
+			sharedLog.cleanupPeerDisconnectTracking(firstHash);
+			expect([...pending.requesting]).to.deep.equal([secondHash]);
+			expect(sharedLog._pendingIHave.get(entry.hash)).to.equal(pending);
+
+			const selfHash = target.node.identity.publicKey.hashcode();
+			const waitForEntryReplicators = sinon
+				.stub(sharedLog, "_waitForEntryReplicators")
+				.callsFake(async (...args: any[]) => {
+					args[3]?.onLeader?.(selfHash);
+					return new Map([[selfHash, { intersecting: true }]]);
+				});
+			const responseAdd = sinon.spy(sharedLog.responseToPruneDebouncedFn, "add");
+			const synchronizerEntryAdded = sinon
+				.stub(sharedLog.syncronizer, "onEntryAdded")
+				.callsFake(() => {});
+
+			try {
+				sharedLog.onEntryAdded(entry);
+				await waitForResolved(() => expect(responseAdd.calledOnce).to.be.true);
+				const response = responseAdd.firstCall.args[0];
+				expect([...response.peers]).to.deep.equal([secondHash]);
+				await waitForResolved(() =>
+					expect(sharedLog._pendingIHave.has(entry.hash)).to.be.false,
+				);
+				expect(sharedLog._pendingIHaveCallbacks.size).to.equal(0);
+			} finally {
+				synchronizerEntryAdded.restore();
+				responseAdd.restore();
+				waitForEntryReplicators.restore();
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("keeps concurrent exchanges from the same peer independent", async () => {
+		const session = await TestSession.disconnected(2);
+		const firstHasManyEntered = pDefer<void>();
+		const secondHasManyEntered = pDefer<void>();
+		const releaseFirstHasMany = pDefer<void>();
+		try {
+			const store = new EventStore<string, any>();
+			const source = await session.peers[0].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const originalHasMany = target.log.log.hasMany.bind(target.log.log);
+			let hasManyCalls = 0;
+			const hasMany = sinon.stub(target.log.log, "hasMany").callsFake(async (...args) => {
+				hasManyCalls += 1;
+				if (hasManyCalls === 1) {
+					firstHasManyEntered.resolve();
+					await releaseFirstHasMany.promise;
+				} else if (hasManyCalls === 2) {
+					secondHasManyEntered.resolve();
+				}
+				return originalHasMany(...args);
+			});
+
+			try {
+				const context = { from: source.node.identity.publicKey } as any;
+				const first = target.log.onMessage(
+					new ExchangeHeadsMessage({ heads: [] }),
+					context,
+				);
+				await firstHasManyEntered.promise;
+				const second = target.log.onMessage(
+					new ExchangeHeadsMessage({ heads: [] }),
+					context,
+				);
+
+				await secondHasManyEntered.promise;
+				expect(hasManyCalls).to.equal(2);
+
+				releaseFirstHasMany.resolve();
+				await Promise.all([first, second]);
+			} finally {
+				releaseFirstHasMany.resolve();
+				hasMany.restore();
+			}
+		} finally {
+			releaseFirstHasMany.resolve();
+			await session.stop();
+		}
+	});
+
+	it("fences a replication update queued behind generic peer cleanup", async () => {
+		const session = await TestSession.connected(2);
+		const synchronizerEntered = pDefer<void>();
+		const releaseSynchronizer = pDefer<void>();
+		try {
+			const store = new EventStore<string, any>();
+			const target = await session.peers[0].open(store, {
+				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+			});
+			await session.peers[1].open(store.clone(), {
+				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+			});
+			const sharedLog = target.log as any;
+			const sourceKey = session.peers[1].identity.publicKey;
+			const sourceHash = sourceKey.hashcode();
+			let remoteRange: any;
+			await waitForResolved(async () => {
+				const ranges = await target.log.replicationIndex
+					.iterate({ query: { hash: sourceHash } })
+					.all();
+				expect(ranges).to.have.length.greaterThan(0);
+				remoteRange = ranges[0].value;
+			});
+
+			const delayedMessage = new AllReplicatingSegmentsMessage({
+				segments: [remoteRange.toReplicationRange()],
+			});
+			const originalSynchronizerOnMessage =
+				sharedLog.syncronizer.onMessage.bind(sharedLog.syncronizer);
+			const synchronizer = sinon
+				.stub(sharedLog.syncronizer, "onMessage")
+				.callsFake(async (message: unknown, context: unknown) => {
+					if (message === delayedMessage) {
+						synchronizerEntered.resolve();
+						await releaseSynchronizer.promise;
+						return false;
+					}
+					return originalSynchronizerOnMessage(message, context);
+				});
+
+			try {
+				const receive = target.log.onMessage(delayedMessage, {
+					from: sourceKey,
+					message: { header: { timestamp: BigInt(Date.now()) } },
+				} as any);
+				await synchronizerEntered.promise;
+
+				const removal = sharedLog.removeReplicator(sourceKey, {
+					noEvent: true,
+				});
+				await waitForResolved(() =>
+					expect(sharedLog._receiveHandlerDrainByPeer.has(sourceHash)).to.be
+						.true,
+				);
+
+				releaseSynchronizer.resolve();
+				await Promise.all([receive, removal]);
+				expect(
+					await target.log.replicationIndex.count({
+						query: { hash: sourceHash },
+					}),
+				).to.equal(0);
+				expect(target.log.uniqueReplicators.has(sourceHash)).to.be.false;
+				expect(sharedLog.latestReplicationInfoMessage.has(sourceHash)).to.be
+					.false;
+			} finally {
+				releaseSynchronizer.resolve();
+				synchronizer.restore();
+			}
+		} finally {
+			releaseSynchronizer.resolve();
+			await session.stop();
+		}
+	});
+
 	it("only confirms and coordinates top-level entries admitted by the lower log", async () => {
 		const session = await TestSession.disconnected(2);
 		try {

--- a/packages/programs/data/shared-log/test/replication.spec.ts
+++ b/packages/programs/data/shared-log/test/replication.spec.ts
@@ -45,7 +45,6 @@ import {
 } from "../src/sync/simple.js";
 import {
 	type TestSetupConfig,
-	checkBounded,
 	checkReplicas,
 	collectMessages,
 	collectMessagesFn,
@@ -1106,7 +1105,14 @@ testSetups.forEach((setup) => {
 					);
 				});
 
-				const dataMessages1 = getReceivedHeads(message1);
+				// Authoritative join repair is intentionally allowed to resend entries
+				// until receipt confirmation. Keep this assertion scoped to ordinary sync,
+				// as the dynamic sibling above does, so repair timing cannot make it flaky.
+				const dataMessages1 = getReceivedHeads(
+					message1.filter(
+						([msg]) => !isRepairHintExchangeHeadsMessage(msg),
+					),
+				);
 				if (setup.name === "u64-iblt") {
 					const uniqueBounceBack = new Set(
 						dataMessages1.map((x) => x.entry.hash),

--- a/packages/programs/data/shared-log/test/replicator-liveness.spec.ts
+++ b/packages/programs/data/shared-log/test/replicator-liveness.spec.ts
@@ -810,18 +810,20 @@ describe("waitForReplicator liveness", () => {
 			// Exercise the separate hash-only removal path used after pubsub loses
 			// the public-key mapping for a previously learned/relayed replicator.
 			log._replicatorLastActivityAt.set(peerHash, Date.now() - 60_000);
-			await hooks.probeReplicatorLiveness(peerHash);
+			const eviction = hooks.probeReplicatorLiveness(peerHash);
+			releaseSnapshotSynchronizer.resolve();
+			releaseStoppedSynchronizer.resolve();
+			await Promise.all([
+				eviction,
+				delayedSnapshotReceive,
+				delayedStoppedReceive,
+			]);
 			expect(
 				await replicationIndex.count({ query: { hash: peerHash } }),
 			).to.equal(0);
 
-			// This handler entered before eviction and must not restore removed state
-			// merely because it reaches the apply lane afterward.
-			releaseSnapshotSynchronizer.resolve();
-			await delayedSnapshotReceive;
-			expect(
-				await replicationIndex.count({ query: { hash: peerHash } }),
-			).to.equal(0);
+			// Both handlers entered before eviction and reached the apply lane after
+			// the removal. Neither may restore or rewrite the removed generation.
 			expect(log.latestReplicationInfoMessage.has(peerHash)).to.be.false;
 
 			// A later arrival from the same slower-clock sender is authoritative and
@@ -840,10 +842,8 @@ describe("waitForReplicator liveness", () => {
 			).to.be.greaterThan(0);
 			expect(log.latestReplicationInfoMessage.get(peerHash)).to.equal(1n);
 
-			// A pre-eviction stopped message is fenced by the same local generation;
-			// it cannot delete the newly restored range or replace its watermark.
-			releaseStoppedSynchronizer.resolve();
-			await delayedStoppedReceive;
+			// The pre-eviction stopped message was fenced by the same local generation;
+			// it cannot have deleted the newly restored range or replaced its watermark.
 			expect(
 				await replicationIndex.count({ query: { hash: peerHash } }),
 			).to.be.greaterThan(0);


### PR DESCRIPTION
## Summary

- add per-peer receive leases so disconnect/removal cleanup drains handlers that were already admitted before deleting peer replication state
- snapshot admitted receives into rotating per-peer buckets so an opening subscription drains only pre-transition work; current-epoch sync traffic can no longer join and block the old-generation barrier
- fence queued replication-info mutations across unsubscribe, reconnect, liveness eviction, close, and drop generations
- drain subscription callbacks, receive handlers, apply queues, and pending-IHave callbacks during terminal shutdown; cancel leader waits with the narrow replication lifecycle signal
- preserve sync negotiation during the exact opening subscription epoch while keeping destructive cleanup gated; stage the one-shot capability advertisement until the opening barrier commits
- keep coalesced pending-IHave requesters independent and remove only the departed peer during cleanup
- make two pre-existing timing-sensitive tests deterministic: distinguish explicitly marked authoritative repair from ordinary sync, and preserve a 10 ns time-domain boundary with bigint arithmetic

## CI follow-up

The first CI run exposed a timing-sensitive native u64 prune-convergence failure: the origin pruned, but both half-range joiners still held the entry. Investigation found that the original scalar receive counter let a valid current-epoch sync handler extend the drain for the previous subscription generation. That could make opening wait on sync work that indirectly needed opening to finish.

The final implementation rotates lease buckets synchronously at the drain boundary. Reconnect/opening waits only the captured pre-transition buckets, while cleanup and terminal shutdown remain safe because admission is gated and terminal draining repeats until empty. A deterministic regression now holds one old receive and one current opening receive and proves that opening completes after only the old receive releases.

## Protocol impact

No wire format, message schema, or network protocol change. The runtime changes are local receive/lifecycle coordination only.

## Validation

- `pnpm run build`
- complete shared-log suite without fail-fast: **1,967 passing, 10 pending, 0 failing**
- exact CI-style mock + Rust-core shared-log conformance: **149 passing, 0 failing**
- lifecycle/events/receive/liveness matrix: **68 passing, 0 failing**
- receive-admission suite: **14 passing, 0 failing**
- new deterministic old/current-generation interleaving regression: **10/10 independent repetitions**
- focused exact mock + Rust-core u64 prune case: **9/9 local repetitions** plus the full ordered conformance pass
- opening-sync regression stress: **24/24 passing** after the opening-fence fix (the pre-fix tree reproduced 3/12 failures)
- focused u64 connect, redundancy, authoritative-repair, and domain-time stress tests
- ESLint on all seven changed files
- `git diff --check`

## Stack / known CI dependency

Stacked on #1120 (`fix/liveness-snapshot-generation-fence`). The stack still inherits `linkify-it` 5.0.1, so the fail-closed dependency audit is expected to stay red until the independent, fully-green #1118 is approved and merged. After #1118 lands, rebase #1119, then #1120, then this PR onto the updated chain.
