### PR TITLE
chore(shared-log): add warmup scheduler release note

### DIFF
--- a/.changeset/steady-warmup-retries.md
+++ b/.changeset/steady-warmup-retries.md
@@ -2,4 +2,4 @@
 "@peerbit/shared-log": patch
 ---
 
-Serialize and coalesce delayed join-warmup retries per peer so large late-join synchronization does not accumulate overlapping full-backlog sends. The retry window and wire protocol remain unchanged.
+Serialize and coalesce delayed join-warmup retries per peer so large late-join synchronization does not accumulate overlapping full-backlog sends. The retry window and wire protocol remain unchanged. This releases the Peerbit-side fix from #1117.

--- a/.changeset/steady-warmup-retries.md
+++ b/.changeset/steady-warmup-retries.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Serialize and coalesce delayed join-warmup retries per peer so large late-join synchronization does not accumulate overlapping full-backlog sends. The retry window and wire protocol remain unchanged.


### PR DESCRIPTION
Adds the missing patch changeset for #1117 so the performance fix is documented in the generated `@peerbit/shared-log` release.

Release metadata only; no runtime source changes.