### PR TITLE
test(peerbit): isolate bootstrap recovery timers

### DIFF
--- a/packages/clients/peerbit/src/bootstrap-recovery.ts
+++ b/packages/clients/peerbit/src/bootstrap-recovery.ts
@@ -176,6 +176,11 @@ export class BootstrapRecoveryController {
 		return this.running;
 	}
 
+	/** Whether this controller currently owns a pending recovery timer. */
+	get hasScheduledRecovery(): boolean {
+		return this.timer !== undefined;
+	}
+
 	start(): void {
 		if (this.running) return;
 		this.running = true;

--- a/packages/clients/peerbit/test/bootstrap-recovery.spec.ts
+++ b/packages/clients/peerbit/test/bootstrap-recovery.spec.ts
@@ -102,13 +102,13 @@ describe("bootstrap recovery policy", () => {
 		controller.start();
 		await clock.tickAsync(0);
 		expect(attempts).to.equal(0);
-		expect(clock.countTimers()).to.equal(1);
+		expect(controller.hasScheduledRecovery).to.equal(true);
 
 		online = true;
 		onlineEvents.dispatchEvent(new Event("online"));
 		await clock.tickAsync(0);
 		expect(attempts).to.equal(1);
-		expect(clock.countTimers()).to.equal(0);
+		expect(controller.hasScheduledRecovery).to.equal(false);
 	});
 
 	it("recovers after the last connection closes while respecting cooldown", async () => {
@@ -230,15 +230,17 @@ describe("bootstrap recovery policy", () => {
 		}
 		await clock.tickAsync(1_000);
 		expect(attempts).to.equal(1);
-		expect(clock.countTimers()).to.equal(0);
+		expect(controller.hasScheduledRecovery).to.equal(false);
 
 		rejectAttempt(new Error("offline"));
 		await clock.tickAsync(0);
-		expect(clock.countTimers()).to.equal(1);
+		expect(controller.hasScheduledRecovery).to.equal(true);
+		const timerCountBeforeStorm = clock.countTimers();
 		for (let index = 0; index < 20; index++) {
 			connectionEvents.dispatchEvent(new Event("connection:close"));
 		}
-		expect(clock.countTimers()).to.equal(1);
+		expect(controller.hasScheduledRecovery).to.equal(true);
+		expect(clock.countTimers()).to.equal(timerCountBeforeStorm);
 	});
 
 	it("preserves exponential backoff across online event storms", async () => {
@@ -342,7 +344,7 @@ describe("bootstrap recovery policy", () => {
 		controller.stop();
 		await clock.tickAsync(0);
 		expect(attemptSignal?.aborted).to.equal(true);
-		expect(clock.countTimers()).to.equal(0);
+		expect(controller.hasScheduledRecovery).to.equal(false);
 
 		connectionEvents.dispatchEvent(new Event("connection:close"));
 		onlineEvents.dispatchEvent(new Event("online"));


### PR DESCRIPTION
## Summary

- expose controller-local pending recovery timer state for internal lifecycle tests
- replace flaky process-global fake-timer totals with controller-owned assertions
- preserve the event-storm duplicate-timer check using a synchronous before/after delta

## Why

Master CI run 29952603388 failed after a successful online recovery because the test counted unrelated timers from the shared Mocha process. The bootstrap attempt had completed and connected; the production retry path was not faulty.

## Validation

- bootstrap recovery policy: 9 passing
- full peerbit Node coverage suite: 109 passing, 1 pending
- full workspace build
- Prettier and git diff --check
- independent review: no P0/P1 findings; P2 duplicate-timer coverage note addressed