### PR TITLE
ci: isolate Actions credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
       - "docs/**"
   pull_request:
     types: ["opened", "reopened", "synchronize"]
+
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -151,7 +155,6 @@ jobs:
     timeout-minutes: 30
     env:
       PEERBIT_TEST_SESSION: mock
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -254,11 +257,50 @@ jobs:
         run: |
           echo "No coverage files found under */.coverage/"
           exit 1
-      - name: Upload coverage reports to Codecov
-        if: always() && steps.coverage_files.outputs.count != '0' && env.CODECOV_TOKEN != ''
-        uses: codecov/codecov-action@v5
+      - name: Upload coverage artifact
+        if: always() && steps.coverage_files.outputs.count != '0'
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ env.CODECOV_TOKEN }}
+          name: coverage-${{ strategy.job-index }}
+          path: "**/.coverage/**"
+          include-hidden-files: true
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 1
+
+  coverage_push:
+    if: ${{ always() && github.event_name == 'push' && !cancelled() }}
+    name: Upload coverage
+    needs: test_push
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          path: coverage
+      - name: Collect coverage files
+        id: coverage_files
+        shell: bash
+        run: |
+          mapfile -d '' files < <(find coverage -type f -path '*/.coverage/*' -print0)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No downloaded coverage files found" >&2
+            exit 1
+          fi
+          printf -v joined '%s,' "${files[@]}"
+          echo "files=${joined%,}" >> "$GITHUB_OUTPUT"
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
+        with:
+          use_oidc: true
           slug: ${{ github.repository }}
           files: ${{ steps.coverage_files.outputs.files }}
           disable_search: true
@@ -273,7 +315,6 @@ jobs:
     timeout-minutes: 30
     env:
       PEERBIT_TEST_SESSION: mock
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -377,17 +418,6 @@ jobs:
         run: |
           echo "No coverage files found under */.coverage/"
           exit 1
-      - name: Upload coverage reports to Codecov
-        if: always() && steps.coverage_files.outputs.count != '0' && env.CODECOV_TOKEN != ''
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ env.CODECOV_TOKEN }}
-          slug: ${{ github.repository }}
-          files: ${{ steps.coverage_files.outputs.files }}
-          disable_search: true
-          fail_ci_if_error: false
-          verbose: true
-
   fanout_gate_pr:
     if: github.event_name == 'pull_request'
     name: Fanout Gate (PR)

--- a/.github/workflows/migrate-actions-secrets.yml
+++ b/.github/workflows/migrate-actions-secrets.yml
@@ -1,0 +1,93 @@
+name: Migrate Actions secrets
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: actions-secret-migration
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    if: github.ref == 'refs/heads/master' && vars.ACTIONS_SECRETS_MIGRATED != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: actions-secret-migration
+    steps:
+      - name: Move repository secrets into protected environments
+        env:
+          GH_TOKEN: ${{ secrets.ACTIONS_SECRET_MIGRATION_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "Migration requires a nonempty bot credential" >&2
+            exit 1
+          fi
+
+          authenticated_login=$(gh api user --jq .login)
+          if [ "$authenticated_login" != "peerbit-org" ]; then
+            echo "Migration token must authenticate as peerbit-org (got: $authenticated_login)" >&2
+            exit 1
+          fi
+
+          npm_release_secrets=$(gh secret list --repo dao-xyz/peerbit --env npm-release --json name --jq '.[].name')
+          if ! grep -Fxq NPM_TOKEN <<<"$npm_release_secrets"; then
+            if [ -z "${NPM_TOKEN:-}" ]; then
+              echo "Repository NPM_TOKEN is empty and npm-release has no migrated copy" >&2
+              exit 1
+            fi
+            printf '%s' "$NPM_TOKEN" |
+              gh secret set NPM_TOKEN --repo dao-xyz/peerbit --env npm-release
+            npm_release_secrets=$(gh secret list --repo dao-xyz/peerbit --env npm-release --json name --jq '.[].name')
+          fi
+
+          post_release_secrets=$(gh secret list --repo dao-xyz/peerbit --env post-release --json name --jq '.[].name')
+          for required in NPM_TOKEN RELEASE_PR_TOKEN; do
+            if ! grep -Fxq "$required" <<<"$npm_release_secrets"; then
+              echo "npm-release is missing $required" >&2
+              exit 1
+            fi
+          done
+          for required in RELEASE_PR_TOKEN PEERBIT_BOOTSTRAP_PR_TOKEN; do
+            if ! grep -Fxq "$required" <<<"$post_release_secrets"; then
+              echo "post-release is missing $required" >&2
+              exit 1
+            fi
+          done
+
+          repository_secrets=$(gh secret list --repo dao-xyz/peerbit --json name --jq '.[].name')
+          for secret in RELEASE_PR_TOKEN PEERBIT_BOOTSTRAP_PR_TOKEN CODECOV_TOKEN HCLOUD_TOKEN NPM_TOKEN; do
+            if grep -Fxq "$secret" <<<"$repository_secrets"; then
+              gh secret delete "$secret" --repo dao-xyz/peerbit
+            fi
+          done
+
+          remaining_repository_secrets=$(gh secret list --repo dao-xyz/peerbit --json name --jq '.[].name')
+          for removed in RELEASE_PR_TOKEN PEERBIT_BOOTSTRAP_PR_TOKEN CODECOV_TOKEN HCLOUD_TOKEN NPM_TOKEN; do
+            if grep -Fxq "$removed" <<<"$remaining_repository_secrets"; then
+              echo "Repository secret $removed still exists after migration" >&2
+              exit 1
+            fi
+          done
+
+          gh secret delete ACTIONS_SECRET_MIGRATION_TOKEN \
+            --repo dao-xyz/peerbit \
+            --env actions-secret-migration
+
+          # Deleting the environment copy does not revoke this job's already
+          # injected token, so it can safely persist the completion marker.
+          gh variable set ACTIONS_SECRETS_MIGRATED --repo dao-xyz/peerbit --body true
+          if [ "$(gh variable get ACTIONS_SECRETS_MIGRATED --repo dao-xyz/peerbit --json value --jq .value)" != "true" ]; then
+            echo "Migration completion marker was not persisted" >&2
+            exit 1
+          fi
+
+          echo "Actions secrets migrated to master-restricted environments."

--- a/.github/workflows/nightly-sims.yml
+++ b/.github/workflows/nightly-sims.yml
@@ -2,13 +2,16 @@ name: Nightly sims
 on:
   schedule:
     # 03:30 UTC every day
-    - cron: '30 3 * * *'
+    - cron: "30 3 * * *"
   workflow_dispatch:
     inputs:
       only:
-        description: 'Job filter: comma-separated subset of pubsub_sims, fanout_parent_upgrade_soak, shared_log_chaos. Empty runs all jobs.'
+        description: "Job filter: comma-separated subset of pubsub_sims, fanout_parent_upgrade_soak, shared_log_chaos. Empty runs all jobs."
         required: false
-        default: ''
+        default: ""
+
+permissions:
+  contents: read
 
 jobs:
   pubsub_sims:
@@ -89,8 +92,6 @@ jobs:
           # are the pass/fail gates for this job.
           mkdir -p sim-results
           pnpm -C packages/transport/pubsub run bench -- fanout-tree-sim --preset scale-5k --profile 1 --progress 1 --timeoutMs 1200000 2>&1 | tee sim-results/fanout-tree-scale-5k.txt || echo "fanout-tree-sim (trend leg) exited non-zero; see artifact"
-
-
 
       - name: Upload artifacts
         if: always()
@@ -213,7 +214,6 @@ jobs:
         with:
           name: nightly-${{ matrix.artifact }}-${{ github.run_id }}
           path: sim-results
-
 
   shared_log_chaos:
     name: SharedLog chaos

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -8,13 +8,13 @@ on:
       - completed
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   restore:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && vars.ENABLE_WORKSPACE_RESTORE == 'true' }}
+    if: ${{ vars.ACTIONS_SECRETS_MIGRATED == 'true' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master' && vars.ENABLE_WORKSPACE_RESTORE == 'true' }}
     runs-on: ubuntu-latest
+    environment: post-release
     steps:
       - name: Verify Peerbit Bot restore authentication
         env:
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PR_TOKEN }}
+          persist-credentials: false
 
       - name: Use Node.js
         uses: actions/setup-node@v4
@@ -48,7 +48,7 @@ jobs:
         run: node tools/restore-workspace-deps.mjs
 
       - name: Create workspace restore pull request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           token: ${{ secrets.RELEASE_PR_TOKEN }}
           author: "Peerbit Bot <273107789+peerbit-org@users.noreply.github.com>"
@@ -70,13 +70,15 @@ jobs:
             **/package.json
             tools/restore-workspace-deps.mjs
   bootstrap-rollout-pr:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && vars.ENABLE_BOOTSTRAP_ROLLOUT_PR == 'true' }}
+    if: ${{ vars.ACTIONS_SECRETS_MIGRATED == 'true' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master' && vars.ENABLE_BOOTSTRAP_ROLLOUT_PR == 'true' }}
     runs-on: ubuntu-latest
+    environment: post-release
     steps:
       - name: Checkout peerbit
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Detect released server version change
         id: server
@@ -115,11 +117,12 @@ jobs:
 
       - name: Checkout peerbit-bootstrap
         if: ${{ steps.server.outputs.changed == 'true' && steps.auth.outputs.enabled == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: dao-xyz/peerbit-bootstrap
           token: ${{ secrets.PEERBIT_BOOTSTRAP_PR_TOKEN }}
           path: peerbit-bootstrap
+          persist-credentials: false
 
       - name: Sync rollout target
         if: ${{ steps.server.outputs.changed == 'true' && steps.auth.outputs.enabled == 'true' }}
@@ -128,7 +131,7 @@ jobs:
 
       - name: Create bootstrap rollout pull request
         if: ${{ steps.server.outputs.changed == 'true' && steps.auth.outputs.enabled == 'true' }}
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           token: ${{ secrets.PEERBIT_BOOTSTRAP_PR_TOKEN }}
           path: peerbit-bootstrap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,7 @@ on:
           - stable
           - rc
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 name: Release
 jobs:
@@ -32,15 +30,14 @@ jobs:
   # creates the git tags. A manual workflow_dispatch with publish_mode=stable
   # re-runs the build + from-package publish as an escape hatch.
   release:
-    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_mode == 'stable') }}
+    if: ${{ vars.ACTIONS_SECRETS_MIGRATED == 'true' && github.ref == 'refs/heads/master' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_mode == 'stable')) }}
     runs-on: ubuntu-latest
+    environment: npm-release
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     permissions:
-      contents: write
-      issues: write
+      contents: read
       id-token: write
-      pull-requests: write
     steps:
       - name: Verify Peerbit Bot release authentication
         env:
@@ -63,11 +60,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # The changesets action pushes via the git CLI, which uses the
-          # credentials persisted here — so this must be the bot PAT (see the
-          # RELEASE_PR_TOKEN note below) for the version-branch push to be able
-          # to trigger CI on the Version Packages PR.
-          token: ${{ secrets.RELEASE_PR_TOKEN }}
+          persist-credentials: false
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -89,6 +82,8 @@ jobs:
         run: |
           git config --local user.name "Peerbit Bot"
           git config --local user.email "273107789+peerbit-org@users.noreply.github.com"
+          git config --local --unset-all credential.helper || true
+          git config --local credential.helper '!gh auth git-credential'
 
       # changesets/action opens the Version Packages PR (when changesets are
       # pending) and, once that PR is merged, runs the publish command below.
@@ -97,8 +92,8 @@ jobs:
       # on the Version Packages PR it opens, so the PR uses RELEASE_PR_TOKEN —
       # a peerbit-org bot PAT with repo + workflow scopes. The authentication
       # preflight above deliberately fails closed if the secret is missing or does
-      # not belong to peerbit-org. The checkout token (git pushes: version branch,
-      # release tags), action token, and environment token below all use that PAT.
+      # not belong to peerbit-org. Checkout never persists that PAT; the action
+      # receives it only for the version-branch/tag push and API calls below.
       #
       # createGithubReleases is disabled deliberately. changesets tags packages as
       # `<name>@<version>` (e.g. peerbit@5.2.21, @peerbit/crypto@3.2.0), whereas
@@ -140,6 +135,7 @@ jobs:
           title: "chore: version packages"
           createGithubReleases: false
         env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
           # Older changesets/action builds read the token from the environment
           # rather than the github-token input; set both to stay robust.
           GITHUB_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
@@ -151,18 +147,21 @@ jobs:
       - name: Build, gate, and publish stable packages
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.publish_mode == 'stable' }}
         env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm run release
 
   # Release candidate flow: manual dispatch only, builds and runs
   # `aegir release-rc` to publish prerelease versions to npm.
   release-rc:
-    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.publish_mode == 'rc' }}
+    if: ${{ vars.ACTIONS_SECRETS_MIGRATED == 'true' && github.ref == 'refs/heads/master' && github.event_name == 'workflow_dispatch' && github.event.inputs.publish_mode == 'rc' }}
     runs-on: ubuntu-latest
+    environment: npm-release
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     permissions:
-      contents: write
+      contents: read
       id-token: write
     steps:
       - name: Verify Peerbit Bot release authentication
@@ -186,7 +185,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PR_TOKEN }}
+          persist-credentials: false
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -206,6 +205,8 @@ jobs:
         run: |
           git config --local user.name "Peerbit Bot"
           git config --local user.email "273107789+peerbit-org@users.noreply.github.com"
+          git config --local --unset-all credential.helper || true
+          git config --local credential.helper '!gh auth git-credential'
 
       - name: Build, gate, and publish RC to NPM
         env:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -21,15 +21,14 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: "pages"
+  group: pages-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build:
+  build_pr:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
@@ -48,6 +47,37 @@ jobs:
         run: pnpm install --frozen-lockfile=false
 
       - name: Build site
+        run: pnpm --filter peerbit-org... build
+
+      - name: Typecheck site
+        run: pnpm --filter peerbit-org typecheck
+
+      - name: Test deployment preflight
+        run: node --test apps/peerbit-org/scripts/validateSiteDeployment.test.mjs
+
+  build:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    environment:
+      name: github-pages
+      deployment: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile=false
+
+      - name: Build production site
         env:
           SUPABASE_UPDATES_SYNC_URL: ${{ secrets.SUPABASE_UPDATES_SYNC_URL }}
         run: pnpm --filter peerbit-org... build
@@ -59,13 +89,12 @@ jobs:
         run: node --test apps/peerbit-org/scripts/validateSiteDeployment.test.mjs
 
       - name: Validate production site endpoint
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         env:
           SUPABASE_UPDATES_SYNC_URL: ${{ secrets.SUPABASE_UPDATES_SYNC_URL }}
         run: pnpm --filter peerbit-org validate:deployment
 
       - name: Sync Updates email
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && env.UPDATES_SYNC_URL != '' && env.UPDATES_SYNC_SECRET != ''
+        if: env.UPDATES_SYNC_URL != '' && env.UPDATES_SYNC_SECRET != ''
         env:
           UPDATES_SYNC_URL: ${{ secrets.SUPABASE_UPDATES_SYNC_URL }}
           UPDATES_SYNC_SECRET: ${{ secrets.SUPABASE_UPDATES_SYNC_SECRET }}
@@ -76,7 +105,6 @@ jobs:
             --data-binary @apps/peerbit-org/dist/content/docs/updates/index.json
 
       - name: Upload Pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/upload-pages-artifact@v3
         with:
           path: apps/peerbit-org/dist
@@ -86,6 +114,9 @@ jobs:
     needs: build
     runs-on: ubuntu-22.04
     timeout-minutes: 20
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/scripts/test-release-security-contracts.mjs
+++ b/scripts/test-release-security-contracts.mjs
@@ -11,6 +11,27 @@ import {
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const readRepositoryFile = (path) =>
 	readFile(resolve(repositoryRoot, path), "utf8");
+const workflowJob = (workflow, jobName) => {
+	const marker = `  ${jobName}:\n`;
+	const start = workflow.indexOf(marker);
+	assert(start >= 0, `workflow must contain the ${jobName} job`);
+	const remainder = workflow.slice(start + marker.length);
+	const nextJob = remainder.search(/^  [A-Za-z0-9_-]+:\n/m);
+	return nextJob < 0
+		? workflow.slice(start)
+		: workflow.slice(start, start + marker.length + nextJob);
+};
+const workflowSteps = (job) => {
+	const lines = job.split("\n");
+	const starts = lines.flatMap((line, index) =>
+		/^      - /.test(line) ? [index] : [],
+	);
+	return starts.map((start, index) =>
+		lines.slice(start, starts[index + 1] ?? lines.length).join("\n"),
+	);
+};
+const actionSteps = (job, action) =>
+	workflowSteps(job).filter((step) => step.includes(`uses: ${action}@`));
 
 const packageManifest = JSON.parse(await readRepositoryFile("package.json"));
 const scripts = packageManifest.scripts;
@@ -64,6 +85,59 @@ assert.equal(
 const releaseWorkflow = await readRepositoryFile(
 	".github/workflows/release.yml",
 );
+assert.match(
+	releaseWorkflow,
+	/^permissions:\n  contents: read$/m,
+	"release workflow jobs must inherit a read-only GITHUB_TOKEN by default",
+);
+assert.doesNotMatch(
+	releaseWorkflow,
+	/^\s+(?:contents|issues|pull-requests): write$/m,
+	"release jobs must perform GitHub writes only through the explicit bot PAT",
+);
+assert.match(
+	releaseWorkflow,
+	/release:\n    if: \$\{\{ vars\.ACTIONS_SECRETS_MIGRATED == 'true' && github\.ref == 'refs\/heads\/master'/,
+	"stable releases must require completed credential migration and the master ref",
+);
+assert.match(
+	releaseWorkflow,
+	/release-rc:\n    if: \$\{\{ vars\.ACTIONS_SECRETS_MIGRATED == 'true' && github\.ref == 'refs\/heads\/master'/,
+	"release candidates must require completed credential migration and the master ref",
+);
+const stableReleaseJob = workflowJob(releaseWorkflow, "release");
+const releaseCandidateJob = workflowJob(releaseWorkflow, "release-rc");
+for (const [name, job] of [
+	["stable", stableReleaseJob],
+	["release candidate", releaseCandidateJob],
+]) {
+	assert.match(
+		job,
+		/^    environment: npm-release$/m,
+		`${name} publication must obtain secrets from the master-restricted release environment`,
+	);
+	const checkouts = actionSteps(job, "actions/checkout");
+	assert.equal(
+		checkouts.length,
+		1,
+		`${name} publication must have one checkout`,
+	);
+	assert.match(
+		checkouts[0],
+		/persist-credentials: false/,
+		`${name} checkout must not persist the Peerbit Bot PAT`,
+	);
+	assert.doesNotMatch(
+		checkouts[0],
+		/^\s+token:/m,
+		`${name} checkout must use only the read-only workflow token`,
+	);
+	assert.match(
+		job,
+		/git config --local credential\.helper '!gh auth git-credential'/,
+		`${name} publication must resolve git credentials from the step-scoped bot token`,
+	);
+}
 const frozenInstalls = releaseWorkflow.match(
 	/pnpm install --frozen-lockfile(?:\s|$)/g,
 );
@@ -99,10 +173,60 @@ assert.doesNotMatch(
 );
 
 const ciWorkflow = await readRepositoryFile(".github/workflows/ci.yml");
-const securityJobStart = ciWorkflow.indexOf("  security_dependency_contracts:");
-const securityJobEnd = ciWorkflow.indexOf("\n  test_push:", securityJobStart);
-assert(securityJobStart >= 0 && securityJobEnd > securityJobStart);
-const securityJob = ciWorkflow.slice(securityJobStart, securityJobEnd);
+assert.match(
+	ciWorkflow,
+	/^permissions:\n  contents: read$/m,
+	"ordinary CI must use a read-only GITHUB_TOKEN",
+);
+assert.doesNotMatch(
+	ciWorkflow,
+	/\$\{\{\s*secrets\./,
+	"CI must not depend on long-lived repository secrets",
+);
+const pullRequestJob = workflowJob(ciWorkflow, "test_pr");
+assert.doesNotMatch(
+	pullRequestJob,
+	/\$\{\{\s*secrets\./,
+	"pull-request tests must not receive repository secrets",
+);
+assert.doesNotMatch(
+	pullRequestJob,
+	/codecov-action/,
+	"pull-request coverage must not upload with the repository Codecov token",
+);
+const pushTestJob = workflowJob(ciWorkflow, "test_push");
+assert.doesNotMatch(
+	pushTestJob,
+	/id-token: write|codecov-action/,
+	"repository tests and dependency installation must not receive an OIDC identity",
+);
+assert.match(
+	pushTestJob,
+	/name: Upload coverage artifact[\s\S]*?include-hidden-files: true/,
+	"trusted push tests must hand hidden coverage files to the isolated uploader",
+);
+const coverageJob = workflowJob(ciWorkflow, "coverage_push");
+assert.match(
+	coverageJob,
+	/permissions:\n      contents: read\n      id-token: write/,
+	"the isolated coverage upload must receive only read access and an OIDC identity",
+);
+assert.match(
+	coverageJob,
+	/uses: codecov\/codecov-action@[0-9a-f]{40} # v5[\s\S]*?use_oidc: true/,
+	"the isolated coverage upload must use a commit-pinned Codecov action with OIDC",
+);
+assert.doesNotMatch(
+	coverageJob,
+	/merge-multiple: true/,
+	"coverage artifacts must stay in separate directories to avoid filename collisions",
+);
+assert.doesNotMatch(
+	coverageJob,
+	/(?:CODECOV_TOKEN|^\s+token:)/m,
+	"the isolated coverage upload must not use a long-lived Codecov token",
+);
+const securityJob = workflowJob(ciWorkflow, "security_dependency_contracts");
 assert.match(securityJob, /needs: build_workspace/);
 assert.match(securityJob, /node-version: \[22\.x, 24\.x\]/);
 assert.match(securityJob, /node-version: \$\{\{ matrix\.node-version \}\}/);
@@ -112,6 +236,59 @@ const gateIndex = securityJob.indexOf("pnpm run release:security-gate");
 assert(
 	restoreIndex >= 0 && gateIndex > restoreIndex,
 	"CI must run the same release gate only after restoring built artifacts",
+);
+
+const nightlyWorkflow = await readRepositoryFile(
+	".github/workflows/nightly-sims.yml",
+);
+assert.match(
+	nightlyWorkflow,
+	/^permissions:\n  contents: read$/m,
+	"nightly simulations must use a read-only GITHUB_TOKEN",
+);
+
+const siteWorkflow = await readRepositoryFile(".github/workflows/site.yml");
+assert.match(
+	siteWorkflow,
+	/^permissions:\n  contents: read$/m,
+	"site builds must inherit only read access",
+);
+assert.match(
+	siteWorkflow,
+	/group: pages-\$\{\{ github\.event\.pull_request\.number \|\| github\.ref \}\}/,
+	"pull requests must not share a cancellation group with production deploys",
+);
+const sitePullRequestJob = workflowJob(siteWorkflow, "build_pr");
+assert.doesNotMatch(
+	sitePullRequestJob,
+	/^\s+(?:pages|id-token): write$/m,
+	"the pull-request site build must not receive deployment permissions",
+);
+assert.match(
+	sitePullRequestJob,
+	/^    if: github\.event_name == 'pull_request'$/m,
+	"the secret-free site build must be pull-request-only",
+);
+assert.doesNotMatch(
+	sitePullRequestJob,
+	/\$\{\{\s*secrets\./,
+	"the pull-request site build must not reference any secrets",
+);
+const siteProductionJob = workflowJob(siteWorkflow, "build");
+assert.match(
+	siteProductionJob,
+	/^    if: github\.event_name == 'push' && github\.ref == 'refs\/heads\/master'$/m,
+	"the secret-bearing production build must be push-only on master",
+);
+assert.match(
+	siteProductionJob,
+	/environment:\n      name: github-pages\n      deployment: false/,
+	"production site secrets must come from the master-restricted Pages environment",
+);
+const siteDeployJob = workflowJob(siteWorkflow, "deploy");
+assert.match(
+	siteDeployJob,
+	/permissions:\n      pages: write\n      id-token: write/,
 );
 
 const publishedSecuritySmoke = await readRepositoryFile(
@@ -171,6 +348,70 @@ for (const packagePath of [
 const postReleaseWorkflow = await readRepositoryFile(
 	".github/workflows/post-release.yml",
 );
+assert.match(
+	postReleaseWorkflow,
+	/^permissions:\n  contents: read$/m,
+	"post-release jobs must inherit only read access",
+);
+assert.doesNotMatch(
+	postReleaseWorkflow,
+	/^\s+(?:contents|pull-requests): write$/m,
+	"post-release GitHub writes must use the explicit bot PAT",
+);
+for (const [name, job] of [
+	["workspace restore", workflowJob(postReleaseWorkflow, "restore")],
+	[
+		"bootstrap rollout",
+		workflowJob(postReleaseWorkflow, "bootstrap-rollout-pr"),
+	],
+]) {
+	assert.match(
+		job,
+		/head_branch == 'master'/,
+		`${name} must require a successful master release`,
+	);
+	assert.match(
+		job,
+		/vars\.ACTIONS_SECRETS_MIGRATED == 'true'/,
+		`${name} must wait for repository-wide secret migration`,
+	);
+	assert.match(
+		job,
+		/^    environment: post-release$/m,
+		`${name} must obtain bot credentials from the master-restricted post-release environment`,
+	);
+}
+const postReleaseCheckouts = actionSteps(
+	postReleaseWorkflow,
+	"actions/checkout",
+);
+assert.equal(postReleaseCheckouts.length, 3);
+for (const checkout of postReleaseCheckouts) {
+	assert.match(
+		checkout,
+		/persist-credentials: false/,
+		"every post-release checkout must avoid persisting default or bot credentials",
+	);
+	if (checkout.includes("PEERBIT_BOOTSTRAP_PR_TOKEN")) {
+		assert.match(
+			checkout,
+			/uses: actions\/checkout@[0-9a-f]{40} # v4/,
+			"the token-bearing cross-repository checkout must be commit-pinned",
+		);
+	}
+}
+const pullRequestActions = actionSteps(
+	postReleaseWorkflow,
+	"peter-evans/create-pull-request",
+);
+assert.equal(pullRequestActions.length, 2);
+for (const pullRequestAction of pullRequestActions) {
+	assert.match(
+		pullRequestAction,
+		/uses: peter-evans\/create-pull-request@[0-9a-f]{40} # v6/,
+		"every bot-credentialed pull-request action must be commit-pinned",
+	);
+}
 assert.match(
 	postReleaseWorkflow,
 	/name: Use Node\.js[\s\S]*?node-version: 22/,


### PR DESCRIPTION
## Summary

- make ordinary Actions tokens read-only and confine Pages deployment permissions to the deploy job
- make pull-request CI and site builds secret-free; upload trusted-push coverage through a commit-pinned Codecov action using OIDC in an isolated job
- restrict stable/RC and post-release credentials to master-only environments, avoid persisted bot PATs, and pin token-bearing third-party actions
- add fail-closed security contracts for the new workflow boundaries
- migrate the existing NPM secret without revealing it, then remove all five repository-wide Actions secrets

## Migration safety

The required `npm-release`, `post-release`, and `actions-secret-migration` environments already exist with exact `master` branch policies. `ACTIONS_SECRETS_MIGRATED` is currently `false`, so merge-time Release and post-release jobs cannot race the migration. The one-time migration runs automatically on the merged master commit, verifies target state, deletes repository-wide secrets, removes its own admin secret, and only then marks migration complete.

The one-time workflow and empty migration/legacy environments will be removed immediately after successful migration.

## Validation

- `pnpm run build`
- `node scripts/test-release-security-contracts.mjs`
- `node --test apps/peerbit-org/scripts/validateSiteDeployment.test.mjs` (11/11)
- `actionlint` v1.7.12
- Prettier, YAML parsing, migration shell syntax, and `git diff --check`

No package behavior or published API changes; no changeset required.
