### PR TITLE
fix(shared-log): harden sync and ownership lifecycles

### DIFF
--- a/.changeset/calm-owners-reconcile.md
+++ b/.changeset/calm-owners-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Serialize replication-range mutations, validate bounded owner snapshots, and reconcile ambiguous durable writes before publishing ownership changes. Fence append planning, pruning, repair, warmup, and announcements across ownership failure and close or reopen boundaries.

--- a/.changeset/calm-owners-reconcile.md
+++ b/.changeset/calm-owners-reconcile.md
@@ -2,4 +2,4 @@
 "@peerbit/shared-log": patch
 ---
 
-Serialize replication-range mutations, validate bounded owner snapshots, and reconcile ambiguous durable writes before publishing ownership changes. Fence append planning, pruning, repair, warmup, and announcements across ownership failure and close or reopen boundaries.
+Serialize replication-range mutations, validate bounded owner snapshots, and reconcile ambiguous durable writes before publishing ownership changes. Fence append planning, checked-prune deletion and callbacks, adaptive role changes, explicit fixed-role replacements, repair, warmup, and announcements across ownership failure and close or reopen boundaries.

--- a/.changeset/clean-rateless-lifecycles.md
+++ b/.changeset/clean-rateless-lifecycles.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Isolate Rateless IBLT synchronization by target and sender, cancel stale processes and retries, and reliably release native encoder and decoder resources.

--- a/.changeset/clean-rateless-lifecycles.md
+++ b/.changeset/clean-rateless-lifecycles.md
@@ -2,4 +2,4 @@
 "@peerbit/shared-log": patch
 ---
 
-Isolate Rateless IBLT synchronization by target and sender, cancel stale processes and retries, and reliably release native encoder and decoder resources.
+Isolate Rateless IBLT synchronization by target and sender, bound process admissions, sequence gaps, symbol work, response inspection, and active response delivery, fall back to Simple sync on exhaustion or timeout, and reliably release native encoder and decoder resources. Oversized coded-symbol batches are rejected during deserialization before allocation.

--- a/.changeset/clean-rateless-lifecycles.md
+++ b/.changeset/clean-rateless-lifecycles.md
@@ -2,4 +2,4 @@
 "@peerbit/shared-log": patch
 ---
 
-Isolate Rateless IBLT synchronization by target and sender, bound process admissions, sequence gaps, symbol work, response inspection, and active response delivery, fall back to Simple sync on exhaustion or timeout, and reliably release native encoder and decoder resources. Oversized coded-symbol batches are rejected during deserialization before allocation.
+Isolate Rateless IBLT synchronization by target and sender, route oversized boundary batches directly through Rateless sync, preserve an active per-target transfer across overlapping repair batches, bound process admissions, sequence gaps, symbol work, response inspection, and active response delivery, fall back to Simple sync on exhaustion or timeout, and reliably release native encoder and decoder resources. Oversized coded-symbol batches are rejected during deserialization before allocation.

--- a/.changeset/steady-simple-sync.md
+++ b/.changeset/steady-simple-sync.md
@@ -2,4 +2,4 @@
 "@peerbit/shared-log": patch
 ---
 
-Bound Simple sync response authorization, propagate cancellation through response delivery, and release pending leases on timeout, disconnect, or close.
+Bound Simple sync response authorization and active delivery, capacity waiters, coordinate resolution, incoming claim and resolver work, retry scans, and per-target retry fanout; give admitted new claimants a prompt request, propagate cancellation through delivery, and use indexed expiry and cleanup paths for abandoned work. Response authorization now follows cross-caller conflicts through request delivery and payload success or failure, retains non-abortable transport work across lifecycle rollover, and starts its response deadline only after a request is sent. Coordinate request frames are now limited to 1,024 symbols, and larger custom sender chunk settings are clamped to that receiver work limit.

--- a/.changeset/steady-simple-sync.md
+++ b/.changeset/steady-simple-sync.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Bound Simple sync response authorization, propagate cancellation through response delivery, and release pending leases on timeout, disconnect, or close.

--- a/apps/peerbit-org/package.json
+++ b/apps/peerbit-org/package.json
@@ -24,7 +24,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-markdown": "^9.0.3",
-		"react-router-dom": "^6.30.4",
+		"react-router-dom": "^7.18.1",
 		"rehype-raw": "^7.0.0",
 		"remark-gfm": "^4.0.1"
 	},

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
 			"patch-package@6>tmp": "0.2.7",
 			"picomatch@2": "2.3.2",
 			"picomatch@4": "4.0.5",
-			"postcss@8": "8.5.10",
+			"postcss@8": "8.5.22",
 			"protobufjs": "7.6.5",
 			"qs": "6.15.2",
 			"rollup@4": "4.59.0",

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -3425,9 +3425,14 @@ export class SharedLog<
 	private _checkedPruneRemoveBlocksLocalRangeMutationAdmission = 0;
 	// Reject public local role/terminal operations invoked directly by that
 	// program callback rather than letting it await the lane that is awaiting the
-	// callback. Remote/internal mutations and unrelated external callers remain
-	// queued/drained normally.
+	// callback. Keep the guard for the callback's full async lifetime: a callback
+	// that yields before re-entering is still part of the same deadlock cycle.
+	// Remote/internal mutations bypass these public-operation admission checks.
 	private _checkedPruneRemovalCallbackInvocationDepth = 0;
+	// Explicit changes to the local replication role invalidate adaptive planners
+	// that were admitted under the previous role. The ownership lifecycle alone
+	// is insufficient because unreplicate() deliberately keeps the store open.
+	private _localReplicationRoleGeneration = 0;
 	// If durable post-state cannot be reconciled to every native/runtime mirror,
 	// reject later writers and planners until reopen rehydrates those mirrors.
 	private _replicationRangeMutationFailure?: unknown;
@@ -4518,6 +4523,13 @@ export class SharedLog<
 	private _replicationAnnouncementRetryPending!: boolean;
 	private _replicationAnnouncementRetryGeneration!: number;
 	private _replicationAnnouncementRetryController!: AbortController;
+	// Publish local ownership announcements in committed mutation order. This
+	// prevents an older Added message with a delayed transport completion from
+	// overtaking a newer authoritative empty snapshot.
+	private _replicationAnnouncementSendTails?: WeakMap<
+		AbortController,
+		Promise<void>
+	>;
 	private replicationAnnouncementRepairDebounced:
 		| ReturnType<typeof debounceFixedInterval>
 		| undefined;
@@ -4581,10 +4593,7 @@ export class SharedLog<
 		Set<string>
 	>;
 	private _joinWarmupGenerationByTarget!: Map<string, object>;
-	private _joinWarmupSendStateByTarget!: Map<
-		string,
-		JoinWarmupSendState<R>
-	>;
+	private _joinWarmupSendStateByTarget!: Map<string, JoinWarmupSendState<R>>;
 	private _joinWarmupRetryTimersByTarget!: Map<
 		string,
 		Set<JoinWarmupRetryTimer>
@@ -4717,6 +4726,7 @@ export class SharedLog<
 		this._replicationAnnouncementRetryPending = false;
 		this._replicationAnnouncementRetryGeneration = 0;
 		this._replicationAnnouncementRetryController = new AbortController();
+		this._replicationAnnouncementSendTails = new WeakMap();
 		this._replicationAnnouncementRepairPending = false;
 		this._replicationAnnouncementRepairGeneration = 0;
 		this._replicationAnnouncementRepairGenerationController =
@@ -6278,8 +6288,7 @@ export class SharedLog<
 		pending: PendingIHave<T>,
 		entry: Entry<T>,
 	): void {
-		const replicationLifecycleController =
-			this._replicationLifecycleController;
+		const replicationLifecycleController = this._replicationLifecycleController;
 		if (!this.isReplicationLifecycleActive(replicationLifecycleController)) {
 			if (this._pendingIHave.get(entry.hash) === pending) {
 				pending.clear();
@@ -6762,38 +6771,58 @@ export class SharedLog<
 			| AddedReplicationSegmentMessage
 			| StoppedReplicating,
 		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+		options?: { shouldSend?: () => boolean },
 	): Promise<void> {
-		this.throwIfReplicationOwnershipLifecycleInactive(
-			ownershipLifecycleController,
-		);
-		// Advance before every post-mutation send, including successful ones. An
-		// authoritative retry already in flight may have captured the previous
-		// local state; the generation mismatch forces one more current snapshot
-		// after that stale send settles.
-		this._replicationAnnouncementRetryGeneration += 1;
-		this.advanceCurrentReplicationStateAnnouncementRepairGeneration();
-		try {
-			await this.rpc.send(message, {
-				priority: CONVERGENCE_MESSAGE_PRIORITY,
-				signal: ownershipLifecycleController.signal,
+		const tails = (this._replicationAnnouncementSendTails ??= new WeakMap<
+			AbortController,
+			Promise<void>
+		>());
+		const previous =
+			tails.get(ownershipLifecycleController) ?? Promise.resolve();
+		const send = previous
+			.catch(() => {})
+			.then(async () => {
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
+				if (options?.shouldSend && !options.shouldSend()) {
+					return;
+				}
+				// Advance before every post-mutation send, including successful ones. An
+				// authoritative retry already in flight may have captured the previous
+				// local state; the generation mismatch forces one more current snapshot
+				// after that stale send settles.
+				this._replicationAnnouncementRetryGeneration += 1;
+				this.advanceCurrentReplicationStateAnnouncementRepairGeneration();
+				try {
+					await this.rpc.send(message, {
+						priority: CONVERGENCE_MESSAGE_PRIORITY,
+						signal: ownershipLifecycleController.signal,
+					});
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						ownershipLifecycleController,
+					);
+					this.queueCurrentReplicationStateAnnouncementRepair();
+				} catch (error) {
+					// An old send can reject only after poison or close has installed a new
+					// ownership generation. Never enqueue its retry work into that generation.
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						ownershipLifecycleController,
+					);
+					// The local replication-index mutation precedes all calls to this
+					// wrapper. Preserve the explicit caller's rejection, but independently
+					// schedule an authoritative snapshot so peers eventually observe the
+					// already-committed local state.
+					this.queueCurrentReplicationStateAnnouncementRetry(error);
+					throw error;
+				}
 			});
-			this.throwIfReplicationOwnershipLifecycleInactive(
-				ownershipLifecycleController,
-			);
-			this.queueCurrentReplicationStateAnnouncementRepair();
-		} catch (error) {
-			// An old send can reject only after poison or close has installed a new
-			// ownership generation. Never enqueue its retry work into that generation.
-			this.throwIfReplicationOwnershipLifecycleInactive(
-				ownershipLifecycleController,
-			);
-			// The local replication-index mutation precedes all calls to this
-			// wrapper. Preserve the explicit caller's rejection, but independently
-			// schedule an authoritative snapshot so peers eventually observe the
-			// already-committed local state.
-			this.queueCurrentReplicationStateAnnouncementRetry(error);
-			throw error;
-		}
+		// Keep the ordering barrier usable after a caller-observed send rejection.
+		tails.set(
+			ownershipLifecycleController,
+			send.catch(() => {}),
+		);
+		return send;
 	}
 
 	private async retryCurrentReplicationStateAnnouncement(): Promise<void> {
@@ -7376,6 +7405,44 @@ export class SharedLog<
 		);
 		const replicationOwnershipLifecycleController =
 			this.captureReplicationOwnershipLifecycle();
+		const requestedRole =
+			rangeOrEntry &&
+			(rangeOrEntry as ExistingReplicationOptions<R>).type === "resume"
+				? (rangeOrEntry as ExistingReplicationOptions<R>).default
+				: (rangeOrEntry ?? true);
+		const requestsAdaptiveRole =
+			requestedRole === true ||
+			(!(requestedRole instanceof Entry) &&
+				!(requestedRole instanceof ReplicationRangeMessage) &&
+				isAdaptiveReplicatorOption(requestedRole as ReplicationOptions<R>));
+		const requestedFixedRoleIsEmpty =
+			Array.isArray(requestedRole) && requestedRole.length === 0;
+		const finalRequestedRange = Array.isArray(requestedRole)
+			? requestedRole[requestedRole.length - 1]
+			: requestedRole;
+		const fixedRoleOffsetWasProvided =
+			finalRequestedRange instanceof Entry ||
+			finalRequestedRange instanceof ReplicationRangeMessage ||
+			(typeof finalRequestedRange === "object" &&
+				finalRequestedRange !== null &&
+				(finalRequestedRange as FixedReplicationOptions).offset != null);
+		if (
+			!isUnreplicationOptions(requestedRole as ReplicationOptions<R>) &&
+			!requestsAdaptiveRole &&
+			!requestedFixedRoleIsEmpty &&
+			(options?.reset === true || !fixedRoleOffsetWasProvided)
+		) {
+			// A fixed replacement is a local role transition, not an additive
+			// per-entry replication request. Match _replicate's implicit reset for
+			// fixed options without an offset as well as an explicit reset.
+			// Invalidate already-admitted adaptive planners synchronously, before
+			// entry-coordinate resolution or the ownership lane can yield, and
+			// prevent a new adaptive planner from starting while the fixed
+			// replacement is being committed.
+			this._localReplicationRoleGeneration =
+				(this._localReplicationRoleGeneration ?? 0) + 1;
+			this._isAdaptiveReplicating = false;
+		}
 		const entryRangeId = (entry: Entry<T>) =>
 			sha256Sync(
 				concat([
@@ -7490,6 +7557,12 @@ export class SharedLog<
 				return;
 			}
 		} else {
+			// Invalidate already-admitted adaptive planners synchronously, before
+			// this operation waits for the ownership lane. Otherwise a planner
+			// that passed its preliminary role checks can enqueue a stale dynamic
+			// range after this full unreplication removes the previous role.
+			this._localReplicationRoleGeneration =
+				(this._localReplicationRoleGeneration ?? 0) + 1;
 			this._isReplicating = false;
 			this._isAdaptiveReplicating = false;
 			await this.removeReplicator(this.node.identity.publicKey, {
@@ -8057,6 +8130,7 @@ export class SharedLog<
 			timestamp?: number;
 			allowLegacyOrderedReplacementPairs?: boolean;
 			onConfirmedDurableStateChanged?: () => void;
+			shouldApply?: () => boolean;
 		} = {},
 		replicationOwnershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	) {
@@ -8097,6 +8171,7 @@ export class SharedLog<
 			rebalance,
 			allowLegacyOrderedReplacementPairs,
 			onConfirmedDurableStateChanged,
+			shouldApply,
 		}: {
 			reset?: boolean;
 			rebalance?: boolean;
@@ -8104,6 +8179,7 @@ export class SharedLog<
 			timestamp?: number;
 			allowLegacyOrderedReplacementPairs?: boolean;
 			onConfirmedDurableStateChanged?: () => void;
+			shouldApply?: () => boolean;
 		} = {},
 		replicationOwnershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	) {
@@ -8111,6 +8187,12 @@ export class SharedLog<
 		this.throwIfReplicationOwnershipLifecycleInactive(
 			replicationOwnershipLifecycleController,
 		);
+		// This predicate is intentionally checked inside the global ownership lane.
+		// An adaptive update delayed by authorization must not commit after a newer
+		// full unreplication already completed in that lane.
+		if (shouldApply && !shouldApply()) {
+			return [];
+		}
 		const fromHash = from.hashcode();
 		const incomingRangesById = new Map<
 			string,
@@ -8642,6 +8724,7 @@ export class SharedLog<
 			reset?: boolean;
 			checkDuplicates?: boolean;
 			rebalance?: boolean;
+			shouldApply?: () => boolean;
 			announce?: (
 				msg: AllReplicatingSegmentsMessage | AddedReplicationSegmentMessage,
 			) => void;
@@ -8713,6 +8796,9 @@ export class SharedLog<
 		}
 
 		if (change) {
+			if (options.shouldApply && !options.shouldApply()) {
+				return;
+			}
 			// Local replacements are represented as a negative `replaced` fact for
 			// the retired geometry followed by an `added` fact for the durable
 			// replacement. Only the positive/current fact belongs on the wire:
@@ -8756,6 +8842,7 @@ export class SharedLog<
 					await this.sendReplicationAnnouncement(
 						message,
 						replicationOwnershipLifecycleController,
+						{ shouldSend: options.shouldApply },
 					);
 					this.throwIfReplicationOwnershipLifecycleInactive(
 						replicationOwnershipLifecycleController,
@@ -9131,10 +9218,7 @@ export class SharedLog<
 		return generation;
 	}
 
-	private trackJoinWarmupTimer(
-		target: string,
-		timer: JoinWarmupRetryTimer,
-	) {
+	private trackJoinWarmupTimer(target: string, timer: JoinWarmupRetryTimer) {
 		let timers = this._joinWarmupRetryTimersByTarget.get(target);
 		if (!timers) {
 			timers = new Set();
@@ -9144,10 +9228,7 @@ export class SharedLog<
 		this._repairRetryTimers.add(timer.handle);
 	}
 
-	private untrackJoinWarmupTimer(
-		target: string,
-		timer: JoinWarmupRetryTimer,
-	) {
+	private untrackJoinWarmupTimer(target: string, timer: JoinWarmupRetryTimer) {
 		this._repairRetryTimers.delete(timer.handle);
 		const timers = this._joinWarmupRetryTimersByTarget.get(target);
 		if (!timers) {
@@ -9349,8 +9430,7 @@ export class SharedLog<
 						for (const [hash, entry] of batch.entries) {
 							dueEntries.set(hash, entry);
 						}
-						bypassKnownPeerHints ||=
-							batch.bypassKnownPeerHints;
+						bypassKnownPeerHints ||= batch.bypassKnownPeerHints;
 						batch.remainingAttempts -= 1;
 						if (batch.remainingAttempts === 0) {
 							batch.entries.clear();
@@ -10195,15 +10275,10 @@ export class SharedLog<
 					const generation =
 						options.joinWarmupGenerations?.get(peer) ??
 						this.getJoinWarmupGeneration(peer);
-					if (
-						this._joinWarmupGenerationByTarget.get(peer) !== generation
-					) {
+					if (this._joinWarmupGenerationByTarget.get(peer) !== generation) {
 						continue;
 					}
-					this._repairSweepJoinWarmupGenerationByTarget.set(
-						peer,
-						generation,
-					);
+					this._repairSweepJoinWarmupGenerationByTarget.set(peer, generation);
 				}
 				pendingPeers.add(peer);
 			}
@@ -10581,10 +10656,7 @@ export class SharedLog<
 						}
 						for (const [peer, consumed] of peerCounts) {
 							const current = pendingPeerCounts.get(peer);
-							if (
-								!current ||
-								current.generation !== consumed.generation
-							) {
+							if (!current || current.generation !== consumed.generation) {
 								continue;
 							}
 							const next = current.count - consumed.count;
@@ -10595,8 +10667,7 @@ export class SharedLog<
 								});
 							} else {
 								pendingPeerCounts.delete(peer);
-								const gids =
-									this._repairSweepOptimisticGidsByPeer.get(peer);
+								const gids = this._repairSweepOptimisticGidsByPeer.get(peer);
 								gids?.delete(gid);
 								if (gids?.size === 0) {
 									this._repairSweepOptimisticGidsByPeer.delete(peer);
@@ -10775,6 +10846,11 @@ export class SharedLog<
 
 		throwIfInactive();
 		if (!checkedPruneCoordinator.hasActiveWork(args.hash)) {
+			if (args.requireFreshLeaderDecision) {
+				throw new TerminalOperationNotStartedError(
+					"Checked prune work is no longer active at the delete boundary",
+				);
+			}
 			return { leaders: args.leaders, localLeader: false };
 		}
 
@@ -15475,6 +15551,7 @@ export class SharedLog<
 		this._replicationRangeMutationsClosing = false;
 		this._checkedPruneRemoveBlocksLocalRangeMutationAdmission = 0;
 		this._checkedPruneRemovalCallbackInvocationDepth = 0;
+		this._localReplicationRoleGeneration = 0;
 		this._pruneRemovesClosing = false;
 		this._replicationRangeMutationFailure = undefined;
 		this.startRepairLifecycle();
@@ -16907,15 +16984,12 @@ export class SharedLog<
 	async afterOpen(): Promise<void> {
 		await super.afterOpen();
 		const existingSubscribersPromise = this._getTopicSubscribers(this.topic);
-		const replicationLifecycleController =
-			this._replicationLifecycleController;
+		const replicationLifecycleController = this._replicationLifecycleController;
 
 		// We do this here, because these calls requires this.closed == false
 		void this.pruneOfflineReplicators()
 			.then(() => {
-				if (
-					this.isReplicationLifecycleActive(replicationLifecycleController)
-				) {
+				if (this.isReplicationLifecycleActive(replicationLifecycleController)) {
 					this._replicatorsReconciled = true;
 				}
 			})
@@ -16951,8 +17025,7 @@ export class SharedLog<
 	async pruneOfflineReplicators() {
 		// Go through all segments and wait for replicators to become reachable;
 		// otherwise prune them away from the local membership view.
-		const replicationLifecycleController =
-			this._replicationLifecycleController;
+		const replicationLifecycleController = this._replicationLifecycleController;
 		try {
 			if (
 				!replicationLifecycleController ||
@@ -16966,7 +17039,9 @@ export class SharedLog<
 
 			while (!iterator.done()) {
 				const segments = await iterator.next(1000);
-				if (!this.isReplicationLifecycleActive(replicationLifecycleController)) {
+				if (
+					!this.isReplicationLifecycleActive(replicationLifecycleController)
+				) {
 					return;
 				}
 				for (const segment of segments) {
@@ -16998,8 +17073,7 @@ export class SharedLog<
 								const key = await this._resolvePublicKeyFromHash(peerHash);
 								if (!key) {
 									throw new Error(
-										"Failed to resolve public key from hash: " +
-											peerHash,
+										"Failed to resolve public key from hash: " + peerHash,
 									);
 								}
 
@@ -17007,54 +17081,50 @@ export class SharedLog<
 								if (keyHash !== peerHash) {
 									return;
 								}
-								return this.withReplicationInfoApplyQueue(
-									keyHash,
-									async () => {
-										// A successful reachability check may legitimately span a
-										// subscribe event during startup. The current lane's blocked
-										// state plus an extant index row are the authoritative guard;
-										// only the destructive catch path remains tied to the old token.
-										if (
-											!this.isReplicationLifecycleActive(
-												replicationLifecycleController,
-											) ||
-											this.closed ||
-											this._replicationInfoBlockedPeers.has(keyHash)
-										) {
-											return;
-										}
-										const hasReplicationRange =
-											(await this.replicationIndex.count({
-												query: { hash: keyHash },
-											})) > 0;
-										if (
-											!hasReplicationRange ||
-											!this.isReplicationLifecycleActive(
-												replicationLifecycleController,
-											) ||
-											this._replicationInfoBlockedPeers.has(keyHash)
-										) {
-											return;
-										}
-										this.uniqueReplicators.add(keyHash);
+								return this.withReplicationInfoApplyQueue(keyHash, async () => {
+									// A successful reachability check may legitimately span a
+									// subscribe event during startup. The current lane's blocked
+									// state plus an extant index row are the authoritative guard;
+									// only the destructive catch path remains tied to the old token.
+									if (
+										!this.isReplicationLifecycleActive(
+											replicationLifecycleController,
+										) ||
+										this.closed ||
+										this._replicationInfoBlockedPeers.has(keyHash)
+									) {
+										return;
+									}
+									const hasReplicationRange =
+										(await this.replicationIndex.count({
+											query: { hash: keyHash },
+										})) > 0;
+									if (
+										!hasReplicationRange ||
+										!this.isReplicationLifecycleActive(
+											replicationLifecycleController,
+										) ||
+										this._replicationInfoBlockedPeers.has(keyHash)
+									) {
+										return;
+									}
+									this.uniqueReplicators.add(keyHash);
 
-										if (!this._replicatorJoinEmitted.has(keyHash)) {
-											this._replicatorJoinEmitted.add(keyHash);
-											this.events.dispatchEvent(
-												new CustomEvent<ReplicatorJoinEvent>(
-													"replicator:join",
-													{ detail: { publicKey: key } },
-												),
-											);
-											this.events.dispatchEvent(
-												new CustomEvent<ReplicationChangeEvent>(
-													"replication:change",
-													{ detail: { publicKey: key } },
-												),
-											);
-										}
-									},
-								);
+									if (!this._replicatorJoinEmitted.has(keyHash)) {
+										this._replicatorJoinEmitted.add(keyHash);
+										this.events.dispatchEvent(
+											new CustomEvent<ReplicatorJoinEvent>("replicator:join", {
+												detail: { publicKey: key },
+											}),
+										);
+										this.events.dispatchEvent(
+											new CustomEvent<ReplicationChangeEvent>(
+												"replication:change",
+												{ detail: { publicKey: key } },
+											),
+										);
+									}
+								});
 							})
 							.catch(async (error) => {
 								if (
@@ -17080,9 +17150,7 @@ export class SharedLog<
 		} catch (error) {
 			if (
 				isNotStartedError(error as Error) ||
-				!this.isReplicationLifecycleActive(
-					replicationLifecycleController,
-				)
+				!this.isReplicationLifecycleActive(replicationLifecycleController)
 			) {
 				return;
 			}
@@ -17329,8 +17397,7 @@ export class SharedLog<
 	}
 
 	private async runReplicatorLivenessSweep() {
-		const replicationLifecycleController =
-			this._replicationLifecycleController;
+		const replicationLifecycleController = this._replicationLifecycleController;
 		if (
 			this.closed ||
 			this._closeController.signal.aborted ||
@@ -17362,8 +17429,7 @@ export class SharedLog<
 			}
 		} finally {
 			if (
-				this._replicationLifecycleController ===
-				replicationLifecycleController
+				this._replicationLifecycleController === replicationLifecycleController
 			) {
 				this._replicatorLivenessSweepRunning = false;
 			}
@@ -17371,8 +17437,7 @@ export class SharedLog<
 	}
 
 	private async probeReplicatorLiveness(peerHash: string) {
-		const replicationLifecycleController =
-			this._replicationLifecycleController;
+		const replicationLifecycleController = this._replicationLifecycleController;
 		if (
 			this.closed ||
 			this._closeController.signal.aborted ||
@@ -17407,8 +17472,7 @@ export class SharedLog<
 					noEvent: true,
 					replicationLifecycleController,
 					shouldRemove: () =>
-						this._replicatorLastActivityAt.get(peerHash) ===
-						observedActivityAt,
+						this._replicatorLastActivityAt.get(peerHash) === observedActivityAt,
 					subscriptionEpoch,
 					onRemoved: () => {
 						if (!ownsProbe()) {
@@ -21144,9 +21208,7 @@ export class SharedLog<
 					const pendingDelete = this._checkedPrune.getPendingDelete(hash);
 					if (pendingDelete) {
 						responseTasks.push(
-							Promise.resolve(
-								pendingDelete.resolve(context.from.hashcode()),
-							),
+							Promise.resolve(pendingDelete.resolve(context.from.hashcode())),
 						);
 					} else {
 						lateResponses.push(hash);
@@ -21186,10 +21248,7 @@ export class SharedLog<
 							capabilities: msg.capabilities,
 						});
 					} else {
-						this._peerSyncCapabilities.set(
-							receiveFromHash,
-							msg.capabilities,
-						);
+						this._peerSyncCapabilities.set(receiveFromHash, msg.capabilities);
 					}
 				}
 				return;
@@ -21448,10 +21507,7 @@ export class SharedLog<
 					}
 
 					const rangesToRemove =
-						await this.resolveReplicationRangesFromIdsAndKey(
-							segmentIds,
-							from,
-						);
+						await this.resolveReplicationRangesFromIdsAndKey(segmentIds, from);
 
 					await this.removeReplicationRanges(rangesToRemove, from);
 					const timestamp = BigInt(+new Date());
@@ -25641,15 +25697,20 @@ export class SharedLog<
 		}
 
 		this._checkedPruneRemovalCallbackInvocationDepth++;
+		let result: ReturnType<NonNullable<typeof onChange>>;
 		try {
-			// Deliberately return the callback promise without awaiting it. The
-			// reentrancy guard covers the callback's immediate invocation, while an
-			// independent operation started during a later async suspension must be
-			// allowed to queue/drain behind the admitted lower-log removal.
-			return onChange(change);
-		} finally {
+			result = onChange(change);
+		} catch (error) {
 			this._checkedPruneRemovalCallbackInvocationDepth--;
+			throw error;
 		}
+		if (isPromiseLike(result)) {
+			return Promise.resolve(result).finally(() => {
+				this._checkedPruneRemovalCallbackInvocationDepth--;
+			});
+		}
+		this._checkedPruneRemovalCallbackInvocationDepth--;
+		return result;
 	}
 
 	private withReplicationRangeMutationQueue<T>(
@@ -25713,7 +25774,9 @@ export class SharedLog<
 
 	private async drainReplicationInfoApplyQueues(): Promise<void> {
 		for (;;) {
-			const tails = [...(this._replicationInfoApplyQueueByPeer?.values() ?? [])];
+			const tails = [
+				...(this._replicationInfoApplyQueueByPeer?.values() ?? []),
+			];
 			if (tails.length === 0) {
 				return;
 			}
@@ -26346,8 +26409,7 @@ export class SharedLog<
 				// Proactively evict its ranges so leader selection doesn't keep stale owners.
 				removed = await this.removeReplicator(publicKey, {
 					cleanupIfSubscriptionSuperseded: true,
-					expectedJoinWarmupGeneration:
-						disconnectedJoinWarmupGeneration,
+					expectedJoinWarmupGeneration: disconnectedJoinWarmupGeneration,
 					noEvent: true,
 					onRemoved: ({ wasReplicator }) => {
 						if (wasReplicator) {
@@ -26678,6 +26740,14 @@ export class SharedLog<
 								const removed = await this.withReplicationRangeMutationQueue(
 									async () => {
 										throwIfCheckedPruneLifecycleInactive();
+										if (
+											checkedPruneCoordinator.getPendingDelete(entry.hash)
+												?.promise !== deferredPromise
+										) {
+											throw new TerminalOperationNotStartedError(
+												"Checked prune session is no longer active at the delete boundary",
+											);
+										}
 										// The network confirmation and preliminary planner check
 										// deliberately happen outside the global ownership lane. Once
 										// admitted here, re-read leadership and keep the lower-log
@@ -26703,6 +26773,14 @@ export class SharedLog<
 											throw error;
 										}
 										throwIfCheckedPruneLifecycleInactive();
+										if (
+											checkedPruneCoordinator.getPendingDelete(entry.hash)
+												?.promise !== deferredPromise
+										) {
+											throw new TerminalOperationNotStartedError(
+												"Checked prune session changed before removal",
+											);
+										}
 										if (finalOwnership.localLeader) {
 											return false;
 										}
@@ -27647,11 +27725,15 @@ export class SharedLog<
 		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 		rebalanceParticipationDebounced = this.rebalanceParticipationDebounced,
 	) {
+		const localReplicationRoleGeneration =
+			this._localReplicationRoleGeneration ?? 0;
 		// update more participation rate to converge to the average expected rate or bounded by
 		// resources such as memory and or cpu
 		const isCurrent = () =>
 			this.isRepairLifecycleActive(ownershipLifecycleController) &&
-			this.rebalanceParticipationDebounced === rebalanceParticipationDebounced;
+			this.rebalanceParticipationDebounced ===
+				rebalanceParticipationDebounced &&
+			this._localReplicationRoleGeneration === localReplicationRoleGeneration;
 
 		const isClosedStoreRace = (error: any) => {
 			const message =
@@ -27767,6 +27849,7 @@ export class SharedLog<
 							{
 								checkDuplicates: false,
 								reset: false,
+								shouldApply: isCurrent,
 							},
 							ownershipLifecycleController,
 						);

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -5162,7 +5162,11 @@ export class SharedLog<
 	private async sendFusedRawExchangeHeadsPlan(
 		plan: RawExchangeHeadSendPlan,
 		to: string[] | Set<string>,
-		options?: { priority?: number; reserved?: Uint8Array },
+		options?: {
+			priority?: number;
+			reserved?: Uint8Array;
+			signal?: AbortSignal;
+		},
 	): Promise<number | undefined> {
 		const backbone = this._nativeBackbone;
 		if (!backbone?.encodeRawExchangeSyncPayload) {
@@ -5175,6 +5179,7 @@ export class SharedLog<
 				options: {
 					mode: SilentDelivery;
 					priority?: number;
+					signal?: AbortSignal;
 				},
 			) => Promise<Uint8Array | undefined>;
 		};
@@ -5190,8 +5195,16 @@ export class SharedLog<
 		}
 
 		const topic = this.rpc.topic;
-		const payloads: Uint8Array[] = [];
-		const encodeChunk = (from: number, until: number): boolean => {
+		const payloads: {
+			payload: Uint8Array;
+			entries: number;
+			bytes: number;
+		}[] = [];
+		const encodeChunk = (
+			from: number,
+			until: number,
+			bytes: number,
+		): boolean => {
 			const payload = backbone.encodeRawExchangeSyncPayload!({
 				topic,
 				hashes:
@@ -5207,7 +5220,7 @@ export class SharedLog<
 			if (!payload) {
 				return false;
 			}
-			payloads.push(payload);
+			payloads.push({ payload, entries: until - from, bytes });
 			return true;
 		};
 		// Same greedy chunking rule as `createRawExchangeHeadsMessages`: close
@@ -5223,7 +5236,7 @@ export class SharedLog<
 			size += length;
 			totalBytes += length;
 			if (size > MAX_RAW_EXCHANGE_MESSAGE_SIZE) {
-				if (!encodeChunk(chunkStart, i + 1)) {
+				if (!encodeChunk(chunkStart, i + 1, size)) {
 					return undefined;
 				}
 				chunkStart = i + 1;
@@ -5231,33 +5244,55 @@ export class SharedLog<
 			}
 		}
 		if (chunkStart < plan.hashes.length) {
-			if (!encodeChunk(chunkStart, plan.hashes.length)) {
+			if (!encodeChunk(chunkStart, plan.hashes.length, size)) {
 				return undefined;
 			}
 		}
 		// Every payload is encoded before anything is published, so a caller
 		// falling back on `undefined` never double-sends part of a plan.
 		const profile = this._logProperties?.sync?.profile;
-		if (profile) {
-			emitSyncProfileEvent(profile, {
-				name: "sharedLog.rawSend.fused",
-				component: "shared-log",
-				entries: plan.hashes.length,
-				bytes: totalBytes,
-				messages: payloads.length,
-			});
+		let attemptedMessages = 0;
+		let sentMessages = 0;
+		let sentEntries = 0;
+		let sentBytes = 0;
+		try {
+			for (const item of payloads) {
+				if (options?.signal?.aborted) {
+					break;
+				}
+				attemptedMessages += 1;
+				await pubsub.publishPreEncodedData(
+					item.payload,
+					{ topics: [topic] },
+					{
+						mode: new SilentDelivery({ redundancy: 1, to: [...to] }),
+						priority: options?.priority,
+						signal: options?.signal,
+					},
+				);
+				sentMessages += 1;
+				sentEntries += item.entries;
+				sentBytes += item.bytes;
+			}
+		} finally {
+			if (profile) {
+				emitSyncProfileEvent(profile, {
+					name: "sharedLog.rawSend.fused",
+					component: "shared-log",
+					entries: sentEntries,
+					bytes: sentBytes,
+					messages: sentMessages,
+					details: {
+						attemptedMessages,
+						cancelled: options?.signal?.aborted || undefined,
+						plannedBytes: totalBytes,
+						plannedEntries: plan.hashes.length,
+						plannedMessages: payloads.length,
+					},
+				});
+			}
 		}
-		for (const payload of payloads) {
-			await pubsub.publishPreEncodedData(
-				payload,
-				{ topics: [topic] },
-				{
-					mode: new SilentDelivery({ redundancy: 1, to: [...to] }),
-					priority: options?.priority,
-				},
-			);
-		}
-		return payloads.length;
+		return sentMessages;
 	}
 
 	/**
@@ -5268,7 +5303,11 @@ export class SharedLog<
 	private async trySendFusedRawExchangeHeads(
 		hashes: string[],
 		to: string[],
-		options?: { priority?: number; reserved?: Uint8Array },
+		options?: {
+			priority?: number;
+			reserved?: Uint8Array;
+			signal?: AbortSignal;
+		},
 	): Promise<number | undefined> {
 		if (!this._nativeBackbone?.encodeRawExchangeSyncPayload) {
 			return undefined;
@@ -14039,7 +14078,7 @@ export class SharedLog<
 		const sendRawExchangeHeads = (
 			hashes: string[],
 			to: string[],
-			sendOptions?: { priority?: number },
+			sendOptions?: { priority?: number; signal?: AbortSignal },
 		) => this.trySendFusedRawExchangeHeads(hashes, to, sendOptions);
 		if (options?.syncronizer) {
 			this.syncronizer = new options.syncronizer({

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -1627,6 +1627,22 @@ type WaitForReplicatorsOptions<R extends "u32" | "u64"> =
 
 type WaitForReplicator = { key: string; replicator: boolean };
 
+type PendingMaturityRecord<R extends "u32" | "u64"> = {
+	range: ReplicationChange<ReplicationRangeIndexable<R>>;
+	timeout: ReturnType<typeof setTimeout>;
+	expiresAt: number;
+	from: PublicSignKey;
+	rebalance: boolean;
+	ownershipLifecycleController: AbortController;
+};
+
+type ReplicationRangeDeletionOutcome<R extends "u32" | "u64"> = {
+	removed: ReplicationRangeIndexable<R>[];
+	retained: ReplicationRangeIndexable<R>[];
+	ownerHasRanges: boolean;
+	error?: unknown;
+};
+
 type EntryLeaderPlan<R extends "u32" | "u64"> = {
 	coordinates: NumberFromType<R>[];
 	coordinateStrings?: string[];
@@ -2702,6 +2718,14 @@ const REPLICATION_ANNOUNCEMENT_REPAIR_MAX_ATTEMPTS = 3;
 // an unbounded burst of separately signed, acknowledged messages. A cursor
 // retained across generations rotates best-effort coverage over later changes.
 const REPLICATION_ANNOUNCEMENT_REPAIR_TARGETS_PER_GENERATION = 8;
+// Index backends flatten logical queries before execution and have practical
+// expression limits well below a large local range set. Keep exact range
+// lookups/deletes bounded while the mutation lane preserves operation ordering.
+const REPLICATION_RANGE_ID_QUERY_BATCH_SIZE = 100;
+// A normal peer owns far fewer ranges. This intentionally generous ceiling keeps
+// decoded, untrusted announcements from forcing unbounded conversion/query work
+// without changing the wire schema or constraining ordinary replication plans.
+const MAX_REPLICATION_RANGES_PER_ANNOUNCEMENT = 4096;
 const RECALCULATE_PARTICIPATION_MIN_RELATIVE_CHANGE = 0.01;
 const RECALCULATE_PARTICIPATION_MIN_RELATIVE_CHANGE_WITH_CPU_LIMIT = 0.005;
 const RECALCULATE_PARTICIPATION_MIN_RELATIVE_CHANGE_WITH_MEMORY_LIMIT = 0.001;
@@ -3366,6 +3390,8 @@ export class SharedLog<
 	private _closeController!: AbortController;
 	private _respondToIHaveTimeout!: any;
 	private _checkedPrune!: CheckedPruneCoordinator<T, R>;
+	private _admittedPruneRemoves!: Set<Promise<unknown>>;
+	private _pruneRemovesClosing = false;
 	private _pendingIHaveCallbacks!: Set<Promise<void>>;
 	private _pendingIHaveExpiryTimer?: ReturnType<typeof setTimeout>;
 	private _pendingIHaveExpiryDeadline = Number.POSITIVE_INFINITY;
@@ -3377,16 +3403,7 @@ export class SharedLog<
 	private _pendingIHave!: Map<string, PendingIHave<T>>;
 
 	// public key hash to range id to range
-	pendingMaturity!: Map<
-		string,
-		Map<
-			string,
-			{
-				range: ReplicationChange;
-				timeout: ReturnType<typeof setTimeout>;
-			}
-		>
-	>; // map of peerId to timeout
+	pendingMaturity!: Map<string, Map<string, PendingMaturityRecord<R>>>; // map of peerId to timeout
 
 	private latestReplicationInfoMessage!: Map<string, bigint>;
 	// Peers that have unsubscribed from this log's topic. We ignore replication-info
@@ -3398,6 +3415,26 @@ export class SharedLog<
 		{ attempts: number; timer?: ReturnType<typeof setTimeout> }
 	>;
 	private _replicationInfoApplyQueueByPeer!: Map<string, Promise<void>>;
+	// Range ids are global primary keys while receive lanes are per peer. Keep
+	// reads and writes that decide one mutation in a single global lane.
+	private _replicationRangeMutationTail: Promise<void> = Promise.resolve();
+	private _replicationRangeMutationsClosing = false;
+	// Log.remove awaits program onChange callbacks before its physical delete.
+	// Track when checked prune holds the ownership lane across that lower-log
+	// removal so the callback wrapper can identify its direct invocation.
+	private _checkedPruneRemoveBlocksLocalRangeMutationAdmission = 0;
+	// Reject public local role/terminal operations invoked directly by that
+	// program callback rather than letting it await the lane that is awaiting the
+	// callback. Remote/internal mutations and unrelated external callers remain
+	// queued/drained normally.
+	private _checkedPruneRemovalCallbackInvocationDepth = 0;
+	// If durable post-state cannot be reconciled to every native/runtime mirror,
+	// reject later writers and planners until reopen rehydrates those mirrors.
+	private _replicationRangeMutationFailure?: unknown;
+	// Background repair work can outlive the await that admitted it. Replace this
+	// opaque token on poison and every terminal/open boundary so an older runner
+	// can neither dispatch nor mutate a freshly opened lifecycle.
+	private _repairLifecycleController = new AbortController();
 	// Local receive generations fence replication-info handlers that were admitted
 	// before a liveness eviction but reach the per-peer apply lane after it. Unlike
 	// message timestamps, these tokens never compare clocks from different peers.
@@ -3420,7 +3457,107 @@ export class SharedLog<
 
 	private remoteBlocks!: RemoteBlocks;
 
+	private throwIfReplicationOwnershipPoisoned(): void {
+		if (this._replicationRangeMutationFailure !== undefined) {
+			throw new Error(
+				"Replication ownership recovery is required before further planning",
+				{ cause: this._replicationRangeMutationFailure },
+			);
+		}
+	}
+
+	private startRepairLifecycle(): AbortController {
+		this._repairLifecycleController?.abort();
+		this._repairLifecycleController = new AbortController();
+		return this._repairLifecycleController;
+	}
+
+	private stopRepairLifecycle(): void {
+		this._repairLifecycleController?.abort();
+	}
+
+	private isRepairLifecycleActive(controller: AbortController): boolean {
+		return (
+			controller === this._repairLifecycleController &&
+			!controller.signal.aborted &&
+			this._replicationRangeMutationFailure === undefined &&
+			!this.closed
+		);
+	}
+
+	private captureReplicationOwnershipLifecycle(): AbortController {
+		const controller = this._repairLifecycleController;
+		this.throwIfReplicationOwnershipLifecycleInactive(controller);
+		return controller;
+	}
+
+	private throwIfReplicationOwnershipLifecycleInactive(
+		controller: AbortController,
+	): void {
+		this.throwIfReplicationOwnershipPoisoned();
+		if (!this.isRepairLifecycleActive(controller)) {
+			throw new TerminalOperationNotStartedError(
+				"Replication ownership lifecycle is no longer active",
+			);
+		}
+	}
+
+	private poisonReplicationOwnership(failure: unknown): unknown {
+		this._replicationRangeMutationFailure ??= failure;
+		this.stopRepairLifecycle();
+		// Pending aggregate changes belong to the poisoned ownership generation.
+		// Closing also resolves ignored `add()` promises, while the guarded
+		// callback below observes any already-running rejection.
+		this.replicationChangeDebounceFn?.close?.();
+		this.pruneDebouncedFn?.close?.();
+		this.rebalanceParticipationDebounced?.close();
+		for (const hash of this._checkedPrune?.retries.keys() ?? []) {
+			this._checkedPrune.clearRetry(hash);
+		}
+		this.cancelCurrentReplicationStateAnnouncementRetry();
+		this.cancelAllJoinWarmupTargets();
+		for (const timer of this._repairRetryTimers) {
+			clearTimeout(timer);
+		}
+		this._repairRetryTimers.clear();
+		for (const timer of this._joinAuthoritativeRepairTimersByDelay.values()) {
+			clearTimeout(timer);
+		}
+		this._joinAuthoritativeRepairTimersByDelay.clear();
+		this._joinAuthoritativeRepairPeersByDelay.clear();
+		this._repairSweepPendingModes.clear();
+		for (const peers of this._repairSweepPendingPeersByMode.values()) {
+			peers.clear();
+		}
+		this._repairSweepJoinWarmupGenerationByTarget.clear();
+		this._repairSweepOptimisticGidPeersPending.clear();
+		this._repairSweepOptimisticGidsByPeer.clear();
+		for (const targets of this._repairFrontierByMode.values()) {
+			targets.clear();
+		}
+		for (const targets of this._repairFrontierActiveTargetsByMode.values()) {
+			targets.clear();
+		}
+		for (const targets of this._repairFrontierBypassKnownPeersByMode.values()) {
+			targets.clear();
+		}
+		if (this._appendBackfillTimer) {
+			clearTimeout(this._appendBackfillTimer);
+			this._appendBackfillTimer = undefined;
+		}
+		this._appendBackfillPendingByTarget.clear();
+		for (const pendingRanges of this.pendingMaturity?.values() ?? []) {
+			for (const pending of pendingRanges.values()) {
+				clearTimeout(pending.timeout);
+			}
+			pendingRanges.clear();
+		}
+		this.pendingMaturity?.clear();
+		return this._replicationRangeMutationFailure;
+	}
+
 	private throwIfNativeDurableCommitFailed(): void {
+		this.throwIfReplicationOwnershipPoisoned();
 		if (this._nativeStrictDurableTransactionFailure !== undefined) {
 			throw new Error(
 				"Native durable transaction recovery is required before another mutation",
@@ -4523,6 +4660,7 @@ export class SharedLog<
 		this.log = new Log(properties);
 		this.rpc = new RPC();
 		this._checkedPrune = new CheckedPruneCoordinator<T, R>();
+		this._admittedPruneRemoves = new Set();
 		this._pendingIHave = new Map();
 		this._pendingIHaveCallbacks = new Set();
 		this.latestReplicationInfoMessage = new Map();
@@ -5331,7 +5469,13 @@ export class SharedLog<
 		isLeader: boolean,
 		deliveryArg: false | true | DeliveryOptions | undefined,
 		nativeDeliveryPlan?: AppendDeliveryPlan,
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	) {
+		const throwIfInactive = () =>
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+		throwIfInactive();
 		const { delivery, reliability, requireRecipients, minAcks, wrap } =
 			this._parseDeliveryOptions(deliveryArg);
 		const pending: Promise<void>[] = [];
@@ -5357,6 +5501,7 @@ export class SharedLog<
 			}
 			try {
 				const subscribers = await this._getTopicSubscribers(this.topic);
+				throwIfInactive();
 				const hasRemoteSubscriber = subscribers?.some(
 					(subscriber) => subscriber.hashcode() !== selfHash,
 				);
@@ -5364,6 +5509,7 @@ export class SharedLog<
 					return;
 				}
 			} catch {
+				throwIfInactive();
 				return;
 			}
 		}
@@ -5373,6 +5519,7 @@ export class SharedLog<
 				await this.getFullReplicaRepairCandidates(undefined, {
 					includeSubscribers: false,
 				});
+			throwIfInactive();
 			if (minReplicasValue >= Math.max(1, fullReplicaDeliveryCandidates.size)) {
 				for (const peer of fullReplicaDeliveryCandidates) {
 					if (!leaders.has(peer)) {
@@ -5391,12 +5538,15 @@ export class SharedLog<
 		for await (const message of createExchangeHeadsMessages(this.log, [
 			entry,
 		])) {
+			throwIfInactive();
 			const leaderCountBeforeReferenceMerge = leaders.size;
 			await this._mergeLeadersFromGidReferences(
 				message,
 				minReplicasValue,
 				leaders,
+				ownershipLifecycleController,
 			);
+			throwIfInactive();
 			const canUseNativeDeliveryPlan =
 				!!nativeDeliveryPlan &&
 				nativeDeliveryPlan.hasRemoteRecipients &&
@@ -5404,6 +5554,7 @@ export class SharedLog<
 			if (canUseNativeDeliveryPlan) {
 				if (!delivery) {
 					for (const peer of nativeDeliveryPlan.repairTargets) {
+						throwIfInactive();
 						this.queueAppendBackfill(peer, entryReplicatedForRepair);
 					}
 					if (nativeDeliveryPlan.defaultSendSilent) {
@@ -5412,6 +5563,7 @@ export class SharedLog<
 							selfHash,
 						);
 						if (rawTargets) {
+							throwIfInactive();
 							this.queueLiveRawGossip(
 								entry.hash,
 								message.heads[0]?.gidRefrences ?? [],
@@ -5421,6 +5573,7 @@ export class SharedLog<
 							continue;
 						}
 					}
+					throwIfInactive();
 					this.emitPlainLiveSendProfile(message);
 					this.rpc
 						.send(message, {
@@ -5447,6 +5600,7 @@ export class SharedLog<
 					for (const peer of nativeDeliveryPlan.ackTo) {
 						track(
 							(async () => {
+								throwIfInactive();
 								await this._sendAckWithUnifiedHints({
 									peer,
 									message,
@@ -5454,12 +5608,14 @@ export class SharedLog<
 									priority: delivery.priority,
 									fanoutUnicastOptions,
 								});
+								throwIfInactive();
 							})(),
 						);
 					}
 				}
 
 				if (nativeDeliveryPlan.silentTo.length > 0) {
+					throwIfInactive();
 					this.rpc
 						.send(message, {
 							mode: new SilentDelivery({
@@ -5471,6 +5627,7 @@ export class SharedLog<
 						.catch((error) => logger.error(error));
 				}
 				for (const peer of nativeDeliveryPlan.repairTargets) {
+					throwIfInactive();
 					this.queueAppendBackfill(peer, entryReplicatedForRepair);
 				}
 				continue;
@@ -5492,6 +5649,7 @@ export class SharedLog<
 			if (!hasRemotePeers && allowSubscriberFallback) {
 				try {
 					const subscribers = await this._getTopicSubscribers(this.topic);
+					throwIfInactive();
 					if (subscribers && subscribers.length > 0) {
 						for (const subscriber of subscribers) {
 							const hash = subscriber.hashcode();
@@ -5504,6 +5662,7 @@ export class SharedLog<
 						hasRemotePeers = set.has(selfHash) ? set.size > 1 : set.size > 0;
 					}
 				} catch {
+					throwIfInactive();
 					// Best-effort only; keep discovered recipients as-is.
 				}
 			}
@@ -5516,6 +5675,7 @@ export class SharedLog<
 
 			if (!delivery) {
 				for (const peer of authoritativeRecipients) {
+					throwIfInactive();
 					if (peer === selfHash) {
 						continue;
 					}
@@ -5529,6 +5689,7 @@ export class SharedLog<
 				if (isLeader) {
 					const rawTargets = this.canUseLiveRawGossip(set, selfHash);
 					if (rawTargets) {
+						throwIfInactive();
 						this.queueLiveRawGossip(
 							entry.hash,
 							message.heads[0]?.gidRefrences ?? [],
@@ -5538,6 +5699,7 @@ export class SharedLog<
 						continue;
 					}
 				}
+				throwIfInactive();
 				this.emitPlainLiveSendProfile(message);
 				this.rpc
 					.send(message, {
@@ -5603,6 +5765,7 @@ export class SharedLog<
 				for (const peer of ackTo) {
 					track(
 						(async () => {
+							throwIfInactive();
 							await this._sendAckWithUnifiedHints({
 								peer,
 								message,
@@ -5610,12 +5773,14 @@ export class SharedLog<
 								priority: delivery.priority,
 								fanoutUnicastOptions,
 							});
+							throwIfInactive();
 						})(),
 					);
 				}
 			}
 
 			if (silentTo?.length) {
+				throwIfInactive();
 				this.rpc
 					.send(message, {
 						mode: new SilentDelivery({ redundancy: 1, to: silentTo }),
@@ -5624,6 +5789,7 @@ export class SharedLog<
 					.catch((error) => logger.error(error));
 			}
 			for (const peer of repairTargets) {
+				throwIfInactive();
 				// Direct append delivery is intentionally optimistic. Queue one delayed,
 				// batched maybe-sync pass for the intended recipients so stable 3-peer
 				// append workloads do not depend on perfect first-try delivery ordering.
@@ -5633,6 +5799,7 @@ export class SharedLog<
 
 		if (pending.length > 0) {
 			await Promise.all(pending);
+			throwIfInactive();
 		}
 	}
 
@@ -5640,22 +5807,41 @@ export class SharedLog<
 		message: ExchangeHeadsMessage<any>,
 		minReplicasValue: number,
 		leaders: LeaderMap,
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	) {
+		const throwIfInactive = () =>
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+		throwIfInactive();
 		const gidReferences = message.heads[0]?.gidRefrences;
 		if (!gidReferences || gidReferences.length === 0) {
 			return;
 		}
 
 		for (const gidReference of gidReferences) {
+			throwIfInactive();
 			const entryFromGid = this.log.entryIndex.getHeads(gidReference, false);
 			for (const gidEntry of await entryFromGid.all()) {
+				throwIfInactive();
 				let coordinates = await this.getCoordinates(gidEntry);
+				throwIfInactive();
 				let found: Map<string, { intersecting: boolean }>;
 				if (coordinates == null) {
-					found = await this.findLeadersFromEntry(gidEntry, minReplicasValue);
+					found = await this.findLeadersFromEntry(
+						gidEntry,
+						minReplicasValue,
+						undefined,
+						ownershipLifecycleController,
+					);
 				} else {
-					found = await this._findLeaders(coordinates);
+					found = await this._findLeaders(
+						coordinates,
+						undefined,
+						ownershipLifecycleController,
+					);
 				}
+				throwIfInactive();
 
 				for (const [key, value] of found) {
 					leaders.set(key, value);
@@ -5664,11 +5850,21 @@ export class SharedLog<
 		}
 	}
 
-	private async _appendDeliverToAllFanout(entry: Entry<T>) {
+	private async _appendDeliverToAllFanout(
+		entry: Entry<T>,
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	) {
+		const throwIfInactive = () =>
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+		throwIfInactive();
 		for await (const message of createExchangeHeadsMessages(this.log, [
 			entry,
 		])) {
+			throwIfInactive();
 			await this._publishExchangeHeadsViaFanout(message);
+			throwIfInactive();
 		}
 	}
 
@@ -6178,8 +6374,17 @@ export class SharedLog<
 		this.rebalanceParticipationDebounced?.close();
 		this.rebalanceParticipationDebounced = undefined;
 
-		this.rebalanceParticipationDebounced = debounceFixedInterval(
-			() => this.rebalanceParticipation(),
+		const ownershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
+		let rebalanceParticipationDebounced!: ReturnType<
+			typeof debounceFixedInterval
+		>;
+		rebalanceParticipationDebounced = debounceFixedInterval(
+			() =>
+				this.rebalanceParticipation(
+					ownershipLifecycleController,
+					rebalanceParticipationDebounced,
+				),
 			/* Math.max(
 				REBALANCE_DEBOUNCE_INTERVAL,
 				Math.log(
@@ -6192,6 +6397,7 @@ export class SharedLog<
 				onError: (error) => this.onRebalanceParticipationError(error),
 			},
 		);
+		this.rebalanceParticipationDebounced = rebalanceParticipationDebounced;
 	}
 
 	private queueCurrentReplicationStateAnnouncementRetry(
@@ -6394,6 +6600,7 @@ export class SharedLog<
 			this.queueCurrentReplicationStateAnnouncementRepair();
 			return;
 		}
+		this.validatePersistedReplicationRangeSnapshot(segments);
 
 		const subscribers =
 			(await this.node.services.pubsub.getSubscribers(this.topic)) ?? [];
@@ -6554,7 +6761,11 @@ export class SharedLog<
 			| AllReplicatingSegmentsMessage
 			| AddedReplicationSegmentMessage
 			| StoppedReplicating,
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<void> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		// Advance before every post-mutation send, including successful ones. An
 		// authoritative retry already in flight may have captured the previous
 		// local state; the generation mismatch forces one more current snapshot
@@ -6564,9 +6775,18 @@ export class SharedLog<
 		try {
 			await this.rpc.send(message, {
 				priority: CONVERGENCE_MESSAGE_PRIORITY,
+				signal: ownershipLifecycleController.signal,
 			});
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			this.queueCurrentReplicationStateAnnouncementRepair();
 		} catch (error) {
+			// An old send can reject only after poison or close has installed a new
+			// ownership generation. Never enqueue its retry work into that generation.
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			// The local replication-index mutation precedes all calls to this
 			// wrapper. Preserve the explicit caller's rejection, but independently
 			// schedule an authoritative snapshot so peers eventually observe the
@@ -6594,6 +6814,7 @@ export class SharedLog<
 				void this.replicationAnnouncementRetryDebounced?.call();
 				return;
 			}
+			this.validatePersistedReplicationRangeSnapshot(segments);
 
 			await this.rpc.send(new AllReplicatingSegmentsMessage({ segments }), {
 				priority: CONVERGENCE_MESSAGE_PRIORITY,
@@ -6669,7 +6890,13 @@ export class SharedLog<
 
 	private deleteCoordinatesForHashes(
 		hashes: Iterable<string>,
+		ownershipLifecycleController?: AbortController,
 	): MaybePromise<void> {
+		if (ownershipLifecycleController) {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+		}
 		const values = normalizedHashValues(hashes);
 		if (values.length === 0) {
 			return;
@@ -6679,13 +6906,22 @@ export class SharedLog<
 			EntryReplicated<R>
 		>;
 		if (coordinateIndex.delIdsNoReturn) {
-			return mapMaybePromise(
-				coordinateIndex.delIdsNoReturn(values),
-				() => undefined,
-			);
+			return mapMaybePromise(coordinateIndex.delIdsNoReturn(values), () => {
+				if (ownershipLifecycleController) {
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						ownershipLifecycleController,
+					);
+				}
+			});
 		}
 		if (coordinateIndex.delIds) {
-			return mapMaybePromise(coordinateIndex.delIds(values), () => undefined);
+			return mapMaybePromise(coordinateIndex.delIds(values), () => {
+				if (ownershipLifecycleController) {
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						ownershipLifecycleController,
+					);
+				}
+			});
 		}
 		return mapMaybePromise(
 			this.entryCoordinatesIndex.del({
@@ -6698,7 +6934,13 @@ export class SharedLog<
 								),
 							),
 			}),
-			() => undefined,
+			() => {
+				if (ownershipLifecycleController) {
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						ownershipLifecycleController,
+					);
+				}
+			},
 		);
 	}
 
@@ -6732,8 +6974,16 @@ export class SharedLog<
 		}
 	}
 
-	private async ensureCurrentHeadCoordinatesIndexed() {
+	private async ensureCurrentHeadCoordinatesIndexed(
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	) {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const heads = await this.log.getHeads(true).all();
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const headsByHash = new Map(heads.map((head) => [head.hash, head]));
 		const nativeCoordinateState =
 			this._nativeBackbone ?? this._nativeSharedLogState;
@@ -6747,12 +6997,21 @@ export class SharedLog<
 							.all()
 					).map((entry) => entry.value.hash),
 				);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const staleHashes = [...indexedHashes].filter(
 			(hash) => !headsByHash.has(hash),
 		);
 
 		if (staleHashes.length > 0) {
-			await this.deleteCoordinatesForHashes(staleHashes);
+			await this.deleteCoordinatesForHashes(
+				staleHashes,
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		}
 
 		const missingHeads: EntryLeaderBatchItem<R>[] = [];
@@ -6768,7 +7027,13 @@ export class SharedLog<
 		}
 
 		if (missingHeads.length > 0) {
-			await this.planEntryLeaderBatch(missingHeads);
+			await this.planEntryLeaderBatch(
+				missingHeads,
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		}
 	}
 
@@ -6789,10 +7054,17 @@ export class SharedLog<
 				msg: AddedReplicationSegmentMessage | AllReplicatingSegmentsMessage,
 			) => void;
 		} = {},
+		replicationOwnershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<ReplicationRangeIndexable<R>[]> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			replicationOwnershipLifecycleController,
+		);
 		let offsetWasProvided = false;
 		if (isUnreplicationOptions(options)) {
-			await this.unreplicate();
+			await this._unreplicate(
+				undefined,
+				replicationOwnershipLifecycleController,
+			);
 			return [];
 		}
 		if ((options as ExistingReplicationOptions).type === "resume") {
@@ -6817,6 +7089,9 @@ export class SharedLog<
 
 			// initial role in a dynamic setup
 			const maybeRange = await this.getDynamicRange();
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				replicationOwnershipLifecycleController,
+			);
 			if (!maybeRange) {
 				// not allowed
 				return [];
@@ -6859,6 +7134,9 @@ export class SharedLog<
 					const indexed = await this.replicationIndex.get(toId(rangeArg.id), {
 						shape: { id: true, timestamp: true },
 					});
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						replicationOwnershipLifecycleController,
+					);
 					if (indexed) {
 						timestamp = indexed.value.timestamp;
 					}
@@ -6913,6 +7191,9 @@ export class SharedLog<
 						range,
 						this.indexableDomain.numbers,
 					);
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						replicationOwnershipLifecycleController,
+					);
 					const mergeableFiltered: ReplicationRangeIndexable<R>[] = [];
 					const toKeep: Set<string> = new Set();
 
@@ -6959,26 +7240,90 @@ export class SharedLog<
 			// but ({ replicate: 0.5, offset: 0.5 }) means that we want to add a range
 			// TODO make behaviour more clear
 		}
-		if (rangesToUnreplicate.length > 0) {
-			await this.removeReplicationRanges(
-				rangesToUnreplicate,
-				this.node.identity.publicKey,
-			);
-		}
+		const confirmedPreliminaryRemovals: ReplicationRangeIndexable<R>[] = [];
+		try {
+			if (rangesToUnreplicate.length > 0) {
+				await this.removeReplicationRanges(
+					rangesToUnreplicate,
+					this.node.identity.publicKey,
+					{
+						onRemoved: (removed) => {
+							confirmedPreliminaryRemovals.push(...removed);
+						},
+					},
+					replicationOwnershipLifecycleController,
+				);
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					replicationOwnershipLifecycleController,
+				);
+				if (confirmedPreliminaryRemovals.length > 0 && rebalance !== false) {
+					const timestamp = BigInt(Date.now());
+					for (const range of confirmedPreliminaryRemovals) {
+						this.replicationChangeDebounceFn.add({
+							range,
+							type: "removed",
+							timestamp,
+						});
+					}
+				}
+			}
 
-		await this.startAnnounceReplicating(rangesToReplicate, {
-			reset: resetRanges ?? false,
-			checkDuplicates,
-			announce,
-			rebalance,
-		});
-
-		if (rangesToUnreplicate.length > 0) {
-			await this.sendReplicationAnnouncement(
-				new StoppedReplicating({
-					segmentIds: rangesToUnreplicate.map((x) => x.id),
-				}),
+			await this.startAnnounceReplicating(
+				rangesToReplicate,
+				{
+					reset: resetRanges ?? false,
+					checkDuplicates,
+					announce,
+					rebalance,
+				},
+				replicationOwnershipLifecycleController,
 			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				replicationOwnershipLifecycleController,
+			);
+
+			if (confirmedPreliminaryRemovals.length > 0) {
+				await this.sendReplicationAnnouncement(
+					new StoppedReplicating({
+						segmentIds: confirmedPreliminaryRemovals.map((x) => x.id),
+					}),
+					replicationOwnershipLifecycleController,
+				);
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					replicationOwnershipLifecycleController,
+				);
+			}
+		} catch (operationError) {
+			if (
+				confirmedPreliminaryRemovals.length === 0 ||
+				!this.isRepairLifecycleActive(replicationOwnershipLifecycleController)
+			) {
+				throw operationError;
+			}
+
+			let announcementError: unknown;
+			try {
+				const segments = (await this.getMyReplicationSegments()).map((range) =>
+					range.toReplicationRange(),
+				);
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					replicationOwnershipLifecycleController,
+				);
+				this.validatePersistedReplicationRangeSnapshot(segments);
+				await this.sendReplicationAnnouncement(
+					new AllReplicatingSegmentsMessage({ segments }),
+					replicationOwnershipLifecycleController,
+				);
+			} catch (error) {
+				announcementError = error;
+			}
+			if (announcementError !== undefined) {
+				throw new AggregateError(
+					[operationError, announcementError],
+					"Replication ranges changed durably but their corrective announcement failed",
+				);
+			}
+			throw operationError;
 		}
 
 		return rangesToReplicate;
@@ -7026,6 +7371,11 @@ export class SharedLog<
 			) => void;
 		},
 	) {
+		this.throwIfCheckedPruneRemoveBlocksLocalOperation(
+			"replication range mutation",
+		);
+		const replicationOwnershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
 		const entryRangeId = (entry: Entry<T>) =>
 			sha256Sync(
 				concat([
@@ -7048,6 +7398,9 @@ export class SharedLog<
 				offset: await this.domain.fromEntry(rangeOrEntry),
 				normalized: false,
 			};
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				replicationOwnershipLifecycleController,
+			);
 		} else if (Array.isArray(rangeOrEntry)) {
 			let ranges: (ReplicationRangeMessage<any> | FixedReplicationOptions)[] =
 				[];
@@ -7060,6 +7413,9 @@ export class SharedLog<
 						normalized: false,
 						strict: true,
 					});
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						replicationOwnershipLifecycleController,
+					);
 				} else {
 					ranges.push(entry);
 				}
@@ -7074,16 +7430,44 @@ export class SharedLog<
 			range = rangeOrEntry ?? true;
 		}
 
-		return this._replicate(range, options);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			replicationOwnershipLifecycleController,
+		);
+		return this._replicate(
+			range,
+			options,
+			replicationOwnershipLifecycleController,
+		);
 	}
 
 	async unreplicate(rangeOrEntry?: Entry<T> | { id: Uint8Array }[]) {
+		this.throwIfCheckedPruneRemoveBlocksLocalOperation(
+			"replication range mutation",
+		);
+		const replicationOwnershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
+		return this._unreplicate(
+			rangeOrEntry,
+			replicationOwnershipLifecycleController,
+		);
+	}
+
+	private async _unreplicate(
+		rangeOrEntry: Entry<T> | { id: Uint8Array }[] | undefined,
+		replicationOwnershipLifecycleController: AbortController,
+	) {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			replicationOwnershipLifecycleController,
+		);
 		let segmentIds: Uint8Array[];
 		if (rangeOrEntry instanceof Entry) {
 			let range: FixedReplicationOptions = {
 				factor: 1,
 				offset: await this.domain.fromEntry(rangeOrEntry),
 			};
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				replicationOwnershipLifecycleController,
+			);
 			const indexed = this.replicationIndex.iterate({
 				query: {
 					width: 1,
@@ -7092,6 +7476,9 @@ export class SharedLog<
 				},
 			});
 			segmentIds = (await indexed.all()).map((x) => x.id.key as Uint8Array);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				replicationOwnershipLifecycleController,
+			);
 			if (segmentIds.length === 0) {
 				warn("No segment found to unreplicate");
 				return;
@@ -7105,7 +7492,12 @@ export class SharedLog<
 		} else {
 			this._isReplicating = false;
 			this._isAdaptiveReplicating = false;
-			await this.removeReplicator(this.node.identity.publicKey);
+			await this.removeReplicator(this.node.identity.publicKey, {
+				replicationOwnershipLifecycleController,
+			});
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				replicationOwnershipLifecycleController,
+			);
 			try {
 				await this.replicationChangeDebounceFn.flush?.();
 			} catch (error: any) {
@@ -7113,12 +7505,21 @@ export class SharedLog<
 					throw error;
 				}
 			}
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				replicationOwnershipLifecycleController,
+			);
 			await this.pruneIndexedEntriesNoLongerLed({
 				useDefaultRoleAge: true,
 			});
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				replicationOwnershipLifecycleController,
+			);
 			await this.pruneCurrentHeadsNoLongerLed({
 				useDefaultRoleAge: true,
 			});
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				replicationOwnershipLifecycleController,
+			);
 			return;
 		}
 
@@ -7132,13 +7533,57 @@ export class SharedLog<
 			segmentIds,
 			this.node.identity.publicKey,
 		);
-		await this.removeReplicationRanges(
-			rangesToRemove,
-			this.node.identity.publicKey,
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			replicationOwnershipLifecycleController,
 		);
-		await this.sendReplicationAnnouncement(
-			new StoppedReplicating({ segmentIds }),
+		if (rangesToRemove.length === 0) {
+			return;
+		}
+		const removedSegmentIds: Uint8Array[] = [];
+		let mutationError: unknown;
+		try {
+			await this.removeReplicationRanges(
+				rangesToRemove,
+				this.node.identity.publicKey,
+				{
+					onRemoved: (ranges) => {
+						removedSegmentIds.push(...ranges.map((range) => range.id));
+					},
+				},
+				replicationOwnershipLifecycleController,
+			);
+		} catch (error) {
+			mutationError = error;
+		}
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			replicationOwnershipLifecycleController,
 		);
+		if (removedSegmentIds.length === 0) {
+			if (mutationError !== undefined) {
+				throw mutationError;
+			}
+			return;
+		}
+		try {
+			await this.sendReplicationAnnouncement(
+				new StoppedReplicating({ segmentIds: removedSegmentIds }),
+				replicationOwnershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				replicationOwnershipLifecycleController,
+			);
+		} catch (announcementError) {
+			if (mutationError !== undefined) {
+				throw new AggregateError(
+					[mutationError, announcementError],
+					"Replication ranges were removed but their announcement failed",
+				);
+			}
+			throw announcementError;
+		}
+		if (mutationError !== undefined) {
+			throw mutationError;
+		}
 	}
 
 	private async removeReplicator(
@@ -7149,10 +7594,17 @@ export class SharedLog<
 			noEvent?: boolean;
 			onRemoved?: (state: { wasReplicator: boolean }) => void;
 			replicationLifecycleController?: AbortController;
+			replicationOwnershipLifecycleController?: AbortController;
 			shouldRemove?: () => boolean;
 			subscriptionEpoch?: object | null;
 		},
 	): Promise<boolean> {
+		const replicationOwnershipLifecycleController =
+			options?.replicationOwnershipLifecycleController ??
+			this.captureReplicationOwnershipLifecycle();
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			replicationOwnershipLifecycleController,
+		);
 		const keyHash = typeof key === "string" ? key : key.hashcode();
 		const expectedJoinWarmupGeneration =
 			options?.expectedJoinWarmupGeneration !== undefined
@@ -7163,9 +7615,9 @@ export class SharedLog<
 			this.isCurrentSubscriptionEpoch(keyHash, options.subscriptionEpoch);
 		const ownsReplicationLifecycle = () =>
 			options?.replicationLifecycleController === undefined ||
-			this.isReplicationLifecycleActive(
-				options.replicationLifecycleController,
-			);
+			this.isReplicationLifecycleActive(options.replicationLifecycleController);
+		const ownsReplicationOwnershipLifecycle = () =>
+			this.isRepairLifecycleActive(replicationOwnershipLifecycleController);
 		const cancelExpectedJoinWarmupTarget = () => {
 			if (
 				expectedJoinWarmupGeneration !== null &&
@@ -7177,14 +7629,24 @@ export class SharedLog<
 		};
 		const isMe = this.node.identity.publicKey.hashcode() === keyHash;
 		let receiveAdmissionBlocked = false;
+		const receiveCleanupGateByPeer = this._receiveCleanupGateByPeer;
 		const blockAndDrainPeerReceives = async () => {
 			if (!receiveAdmissionBlocked) {
-				this.blockPeerReceiveAdmission(keyHash);
+				receiveCleanupGateByPeer.set(
+					keyHash,
+					(receiveCleanupGateByPeer.get(keyHash) ?? 0) + 1,
+				);
 				receiveAdmissionBlocked = true;
 			}
 			await this.drainPeerReceiveHandlers(keyHash);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				replicationOwnershipLifecycleController,
+			);
 		};
 		const cleanupDisconnectedPeer = async () => {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				replicationOwnershipLifecycleController,
+			);
 			await blockAndDrainPeerReceives();
 			this.removePeerFromGidPeerHistory(keyHash);
 			this.cleanupPeerDisconnectTracking(keyHash);
@@ -7194,6 +7656,9 @@ export class SharedLog<
 			this._recentRepairDispatch.delete(keyHash);
 			if (!isMe) {
 				await this.syncronizer.onPeerDisconnected(keyHash);
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					replicationOwnershipLifecycleController,
+				);
 			}
 		};
 		let removed = false;
@@ -7202,6 +7667,9 @@ export class SharedLog<
 		// removal on the same queue so a newer reset cannot be deleted underneath
 		// itself by an older unsubscribe callback.
 		await this.withReplicationInfoApplyQueue(keyHash, async () => {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				replicationOwnershipLifecycleController,
+			);
 			if (!ownsReplicationLifecycle()) {
 				return;
 			}
@@ -7217,45 +7685,86 @@ export class SharedLog<
 			if (options?.shouldRemove && !options.shouldRemove()) {
 				return;
 			}
-			const wasReplicator = this.uniqueReplicators.has(keyHash);
-
-			const deleted = await this.replicationIndex
-				.iterate({
-					query: { hash: keyHash },
-				})
-				.all();
-			// Liveness evidence can arrive without a subscription transition while
-			// this scan is pending. Stop new receives, drain those already admitted,
-			// then revalidate immediately before the first destructive mutation.
+			// Stop and drain admitted receives before taking the global range lane.
+			// User receive hooks may re-enter replicate()/unreplicate(); holding the
+			// range lane while waiting for such a hook would deadlock on our own tail.
 			await blockAndDrainPeerReceives();
-			if (options?.shouldRemove && !options.shouldRemove()) {
+			if (
+				!ownsReplicationOwnershipLifecycle() ||
+				!ownsReplicationLifecycle() ||
+				!ownsSubscriptionEpoch() ||
+				(options?.shouldRemove && !options.shouldRemove())
+			) {
+				if (
+					!ownsSubscriptionEpoch() &&
+					options?.cleanupIfSubscriptionSuperseded
+				) {
+					await cleanupDisconnectedPeer();
+				}
 				return;
 			}
-			// Liveness removal must not cancel a still-current warmup until fresh
-			// activity has been rechecked at the destructive boundary.
-			cancelExpectedJoinWarmupTarget();
-
-			await this.replicationIndex.del({ query: { hash: keyHash } });
-			for (const result of deleted) {
-				this.deleteNativeReplicationRange(result.value);
+			let wasReplicator = false;
+			let deleted: ReplicationRangeIndexable<R>[] = [];
+			let ownerHasRanges = false;
+			let mutationError: unknown;
+			const mutationCommitted = await this.withReplicationRangeMutationQueue(
+				async () => {
+					if (
+						!ownsReplicationOwnershipLifecycle() ||
+						!ownsReplicationLifecycle() ||
+						!ownsSubscriptionEpoch() ||
+						(options?.shouldRemove && !options.shouldRemove())
+					) {
+						return false;
+					}
+					wasReplicator = this.uniqueReplicators.has(keyHash);
+					deleted = (
+						await this.replicationIndex
+							.iterate({
+								query: { hash: keyHash },
+							})
+							.all()
+					).map((result) => result.value);
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						replicationOwnershipLifecycleController,
+					);
+					// Liveness evidence can arrive while the scan is pending. Admission is
+					// already blocked and older receives are drained; revalidate immediately
+					// before destructive mutation.
+					if (
+						!ownsReplicationOwnershipLifecycle() ||
+						!ownsReplicationLifecycle() ||
+						!ownsSubscriptionEpoch() ||
+						(options?.shouldRemove && !options.shouldRemove())
+					) {
+						return false;
+					}
+					cancelExpectedJoinWarmupTarget();
+					const deletion = await this.deleteReplicationRangesCoherently(
+						deleted,
+						keyHash,
+					);
+					deleted = deletion.removed;
+					ownerHasRanges = deletion.ownerHasRanges;
+					mutationError = deletion.error;
+					return true;
+				},
+				replicationOwnershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				replicationOwnershipLifecycleController,
+			);
+			if (!mutationCommitted) {
+				if (
+					!ownsSubscriptionEpoch() &&
+					options?.cleanupIfSubscriptionSuperseded
+				) {
+					await cleanupDisconnectedPeer();
+				}
+				return;
 			}
 
-			// Once the range indexes have removed the peer, make membership agree
-			// before any later awaited bookkeeping can fail.
-			this.uniqueReplicators.delete(keyHash);
-			this._replicatorJoinEmitted.delete(keyHash);
-
-			await this.updateOldestTimestampFromIndex();
-
-			if (isMe) {
-				// announce that we are no longer replicating
-
-				await this.sendReplicationAnnouncement(
-					new AllReplicatingSegmentsMessage({ segments: [] }),
-				);
-			}
-
-			if (options?.noEvent !== true) {
+			if (options?.noEvent !== true && deleted.length > 0) {
 				const publicKey = toLocalPublicSignKey(key);
 				if (publicKey) {
 					this.events.dispatchEvent(
@@ -7270,17 +7779,18 @@ export class SharedLog<
 			const timestamp = BigInt(+new Date());
 			for (const x of deleted) {
 				this.replicationChangeDebounceFn.add({
-					range: x.value,
+					range: x,
 					type: "removed",
 					timestamp,
 				});
 			}
 
 			const pendingMaturity = this.pendingMaturity.get(keyHash);
-			if (pendingMaturity) {
+			if (!ownerHasRanges && pendingMaturity) {
 				for (const [_k, v] of pendingMaturity) {
 					clearTimeout(v.timeout);
 				}
+				pendingMaturity.clear();
 				this.pendingMaturity.delete(keyHash);
 			}
 
@@ -7297,10 +7807,40 @@ export class SharedLog<
 				this.rebalanceParticipationDebounced?.call();
 			}
 			removed = true;
-			options?.onRemoved?.({ wasReplicator });
+			if (!ownerHasRanges) {
+				options?.onRemoved?.({ wasReplicator });
+			}
+			let announcementError: unknown;
+			if (isMe && !ownerHasRanges) {
+				try {
+					await this.sendReplicationAnnouncement(
+						new AllReplicatingSegmentsMessage({ segments: [] }),
+						replicationOwnershipLifecycleController,
+					);
+				} catch (error) {
+					announcementError = error;
+				}
+			}
+			if (mutationError !== undefined && announcementError !== undefined) {
+				throw new AggregateError(
+					[mutationError, announcementError],
+					"Replication ranges were removed but their announcement failed",
+				);
+			}
+			if (mutationError !== undefined) {
+				throw mutationError;
+			}
+			if (announcementError !== undefined) {
+				throw announcementError;
+			}
 		}).finally(() => {
 			if (receiveAdmissionBlocked) {
-				this.unblockPeerReceiveAdmission(keyHash);
+				const remaining = (receiveCleanupGateByPeer.get(keyHash) ?? 1) - 1;
+				if (remaining > 0) {
+					receiveCleanupGateByPeer.set(keyHash, remaining);
+				} else {
+					receiveCleanupGateByPeer.delete(keyHash);
+				}
 			}
 		});
 		return removed;
@@ -7326,75 +7866,228 @@ export class SharedLog<
 		ids: Uint8Array[],
 		from: PublicSignKey,
 	) {
-		let idMatcher = new Or(
-			ids.map((x) => new ByteMatchQuery({ key: "id", value: x })),
-		);
-
-		// make sure we are not removing something that is owned by the replicator
-		let identityMatcher = new StringMatch({
-			key: "hash",
-			value: from.hashcode(),
-		});
-
-		let query = new And([idMatcher, identityMatcher]);
-		return (await this.replicationIndex.iterate({ query }).all()).map(
-			(x) => x.value,
-		);
+		const uniqueIds = [
+			...new Map(ids.map((id) => [toHexString(id), id])).values(),
+		];
+		const resolvedById = new Map<string, ReplicationRangeIndexable<R>>();
+		const ownerHash = from.hashcode();
+		for (
+			let i = 0;
+			i < uniqueIds.length;
+			i += REPLICATION_RANGE_ID_QUERY_BATCH_SIZE
+		) {
+			const query = new And([
+				new StringMatch({ key: "hash", value: ownerHash }),
+				new Or(
+					uniqueIds
+						.slice(i, i + REPLICATION_RANGE_ID_QUERY_BATCH_SIZE)
+						.map((id) => new ByteMatchQuery({ key: "id", value: id })),
+				),
+			]);
+			for (const result of await this.replicationIndex
+				.iterate({ query })
+				.all()) {
+				resolvedById.set(result.value.idString, result.value);
+			}
+		}
+		return [...resolvedById.values()];
 	}
-	private async removeReplicationRanges(
+	private removeReplicationRanges(
 		ranges: ReplicationRangeIndexable<R>[],
 		from: PublicSignKey,
-	) {
+		options?: {
+			onRemoved?: (ranges: ReplicationRangeIndexable<R>[]) => void;
+			shouldRemove?: () => boolean;
+		},
+		replicationOwnershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	): Promise<boolean> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			replicationOwnershipLifecycleController,
+		);
+		return this.withReplicationRangeMutationQueue(
+			() => this.removeReplicationRangesUnlocked(ranges, from, options),
+			replicationOwnershipLifecycleController,
+		);
+	}
+
+	private async removeReplicationRangesUnlocked(
+		ranges: ReplicationRangeIndexable<R>[],
+		from: PublicSignKey,
+		options?: {
+			onRemoved?: (ranges: ReplicationRangeIndexable<R>[]) => void;
+			shouldRemove?: () => boolean;
+		},
+	): Promise<boolean> {
 		if (ranges.length === 0) {
-			return;
+			return false;
 		}
-		const pendingMaturity = this.pendingMaturity.get(from.hashcode());
-		if (pendingMaturity) {
-			for (const id of ranges) {
-				const info = pendingMaturity.get(id.toString());
-				if (info) {
-					clearTimeout(info.timeout);
-					pendingMaturity.delete(id.toString());
+		if (options?.shouldRemove && !options.shouldRemove()) {
+			return false;
+		}
+		const expectedRangeById = new Map(
+			ranges.map((range) => [range.idString, range]),
+		);
+		const expectedRanges = [...expectedRangeById.values()];
+		const refreshedRanges: ReplicationRangeIndexable<R>[] = [];
+		const ownerHash = from.hashcode();
+		for (
+			let i = 0;
+			i < expectedRanges.length;
+			i += REPLICATION_RANGE_ID_QUERY_BATCH_SIZE
+		) {
+			const results = await this.replicationIndex
+				.iterate({
+					query: new And([
+						new StringMatch({ key: "hash", value: ownerHash }),
+						new Or(
+							expectedRanges
+								.slice(i, i + REPLICATION_RANGE_ID_QUERY_BATCH_SIZE)
+								.map(
+									(range) =>
+										new ByteMatchQuery({
+											key: "id",
+											value: range.id,
+										}),
+								),
+						),
+					]),
+				})
+				.all();
+			for (const result of results) {
+				const expected = expectedRangeById.get(result.value.idString);
+				if (expected?.rangeHash === result.value.rangeHash) {
+					refreshedRanges.push(result.value);
 				}
 			}
-			if (pendingMaturity.size === 0) {
-				this.pendingMaturity.delete(from.hashcode());
+		}
+		ranges = refreshedRanges;
+		if (
+			ranges.length === 0 ||
+			(options?.shouldRemove && !options.shouldRemove())
+		) {
+			return false;
+		}
+		const deletion = await this.deleteReplicationRangesCoherently(
+			ranges,
+			ownerHash,
+		);
+		ranges = deletion.removed;
+		options?.onRemoved?.(ranges);
+
+		if (ranges.length > 0) {
+			this.events.dispatchEvent(
+				new CustomEvent<ReplicationChangeEvent>("replication:change", {
+					detail: { publicKey: from },
+				}),
+			);
+		}
+
+		if (ranges.length > 0 && !from.equals(this.node.identity.publicKey)) {
+			this.rebalanceParticipationDebounced?.call();
+		}
+		if (deletion.error !== undefined) {
+			// The caller will observe the failure and cannot publish its normal
+			// negative work. Queue only rows proven absent by the durable probe.
+			const timestamp = BigInt(Date.now());
+			for (const range of ranges) {
+				this.replicationChangeDebounceFn.add({
+					range,
+					type: "removed",
+					timestamp,
+				});
+			}
+			throw deletion.error;
+		}
+		return ranges.length > 0;
+	}
+
+	private validateReplicationRangeAnnouncement(
+		ranges: readonly { mode: unknown }[],
+	): void {
+		if (ranges.length > MAX_REPLICATION_RANGES_PER_ANNOUNCEMENT) {
+			throw new Error(
+				`Replication range announcement exceeds the ${MAX_REPLICATION_RANGES_PER_ANNOUNCEMENT}-range limit`,
+			);
+		}
+		for (let index = 0; index < ranges.length; index++) {
+			const mode = ranges[index].mode;
+			if (
+				mode !== ReplicationIntent.Strict &&
+				mode !== ReplicationIntent.NonStrict
+			) {
+				throw new Error(
+					`Invalid replication range mode at index ${index}: ${String(mode)}`,
+				);
 			}
 		}
+	}
 
-		await this.replicationIndex.del({
-			query: new Or(
-				ranges.map((x) => new ByteMatchQuery({ key: "id", value: x.id })),
-			),
-		});
-		for (const range of ranges) {
-			this.deleteNativeReplicationRange(range);
+	private validatePersistedReplicationRangeSnapshot(
+		ranges: readonly { mode: unknown }[],
+	): void {
+		try {
+			this.validateReplicationRangeAnnouncement(ranges);
+		} catch (cause) {
+			const failure = new Error(
+				"Persisted replication ownership is invalid and cannot be announced",
+				{ cause },
+			);
+			this.poisonReplicationOwnership(failure);
+			throw failure;
 		}
+	}
 
-		const otherSegmentsIterator = this.replicationIndex.iterate(
-			{ query: { hash: from.hashcode() } },
-			{ shape: { id: true } },
-		);
-		if ((await otherSegmentsIterator.next(1)).length === 0) {
-			this.uniqueReplicators.delete(from.hashcode());
-			this._replicatorJoinEmitted.delete(from.hashcode());
-		}
-		await otherSegmentsIterator.close();
-
-		await this.updateOldestTimestampFromIndex();
-
-		this.events.dispatchEvent(
-			new CustomEvent<ReplicationChangeEvent>("replication:change", {
-				detail: { publicKey: from },
-			}),
-		);
-
-		if (!from.equals(this.node.identity.publicKey)) {
-			this.rebalanceParticipationDebounced?.call();
+	private validateStoppedReplicationAnnouncement(
+		segmentIds: readonly Uint8Array[],
+	): void {
+		if (segmentIds.length > MAX_REPLICATION_RANGES_PER_ANNOUNCEMENT) {
+			throw new Error(
+				`Stopped-replication announcement exceeds the ${MAX_REPLICATION_RANGES_PER_ANNOUNCEMENT}-segment limit`,
+			);
 		}
 	}
 
 	private async addReplicationRange(
+		ranges: ReplicationRangeIndexable<any>[],
+		from: PublicSignKey,
+		options: {
+			reset?: boolean;
+			rebalance?: boolean;
+			checkDuplicates?: boolean;
+			timestamp?: number;
+			allowLegacyOrderedReplacementPairs?: boolean;
+			onConfirmedDurableStateChanged?: () => void;
+		} = {},
+		replicationOwnershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	) {
+		this.validateReplicationRangeAnnouncement(ranges);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			replicationOwnershipLifecycleController,
+		);
+		// Authorization can be asynchronous or re-entrant. Never invoke it while
+		// holding the global mutation lane.
+		if (this._isTrustedReplicator && !(await this._isTrustedReplicator(from))) {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				replicationOwnershipLifecycleController,
+			);
+			return undefined;
+		}
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			replicationOwnershipLifecycleController,
+		);
+		return this.withReplicationRangeMutationQueue(
+			() =>
+				this.addReplicationRangeUnlocked(
+					ranges,
+					from,
+					options,
+					replicationOwnershipLifecycleController,
+				),
+			replicationOwnershipLifecycleController,
+		);
+	}
+
+	private async addReplicationRangeUnlocked(
 		ranges: ReplicationRangeIndexable<any>[],
 		from: PublicSignKey,
 		{
@@ -7402,16 +8095,88 @@ export class SharedLog<
 			checkDuplicates,
 			timestamp: ts,
 			rebalance,
+			allowLegacyOrderedReplacementPairs,
+			onConfirmedDurableStateChanged,
 		}: {
 			reset?: boolean;
 			rebalance?: boolean;
 			checkDuplicates?: boolean;
 			timestamp?: number;
+			allowLegacyOrderedReplacementPairs?: boolean;
+			onConfirmedDurableStateChanged?: () => void;
 		} = {},
+		replicationOwnershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	) {
-		if (this._isTrustedReplicator && !(await this._isTrustedReplicator(from))) {
-			return undefined;
+		this.validateReplicationRangeAnnouncement(ranges);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			replicationOwnershipLifecycleController,
+		);
+		const fromHash = from.hashcode();
+		const incomingRangesById = new Map<
+			string,
+			ReplicationRangeIndexable<any>
+		>();
+		const incomingRangeCountsById = new Map<string, number>();
+		for (const range of ranges) {
+			if (range.hash !== fromHash) {
+				throw new Error(
+					`Replication range owner mismatch for id ${range.idString}: expected ${fromHash}, received ${range.hash}`,
+				);
+			}
+			const count = (incomingRangeCountsById.get(range.idString) ?? 0) + 1;
+			incomingRangeCountsById.set(range.idString, count);
+			if (
+				count > 1 &&
+				(!allowLegacyOrderedReplacementPairs || reset === true || count > 2)
+			) {
+				throw new Error(
+					`Duplicate replication range id in announcement: ${range.idString}`,
+				);
+			}
+			// Released peers represented a non-reset replacement as the retired
+			// geometry followed by the current geometry under the same id. The
+			// sender is already authorized to replace that id with the final item,
+			// so collapsing an exact two-item incremental pair to its last item
+			// preserves rolling-upgrade compatibility without broadening authority.
+			incomingRangesById.set(range.idString, range);
 		}
+		const incomingRanges = [...incomingRangesById.values()];
+		for (
+			let i = 0;
+			i < incomingRanges.length;
+			i += REPLICATION_RANGE_ID_QUERY_BATCH_SIZE
+		) {
+			const existing = await this.replicationIndex
+				.iterate(
+					{
+						query: new Or(
+							incomingRanges
+								.slice(i, i + REPLICATION_RANGE_ID_QUERY_BATCH_SIZE)
+								.map(
+									(range) =>
+										new ByteMatchQuery({
+											key: "id",
+											value: range.id,
+										}),
+								),
+						),
+					},
+					{ reference: true },
+				)
+				.all();
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				replicationOwnershipLifecycleController,
+			);
+			const conflicting = existing.find(
+				(result) => result.value.hash !== fromHash,
+			)?.value;
+			if (conflicting) {
+				throw new Error(
+					`Replication range id is already owned by another replicator: ${conflicting.idString}`,
+				);
+			}
+		}
+		ranges = incomingRanges;
 		// Preserve what the peer announced before duplicate filtering can empty the
 		// working array. A repeated authoritative/non-empty announcement is still
 		// proof of live membership after this process reopens.
@@ -7419,10 +8184,40 @@ export class SharedLog<
 		let isNewReplicator = false;
 		let timestamp = BigInt(ts ?? +new Date());
 		rebalance = rebalance == null ? true : rebalance;
+		// Complete every fallible policy lookup before a reset crosses its
+		// destructive boundary. Later failures are handled by the positive-write
+		// rollback path and publish confirmed negative state.
+		const now = +new Date();
+		const minRoleAge =
+			ranges.length > 0 ? await this.getDefaultMinRoleAge() : 0;
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			replicationOwnershipLifecycleController,
+		);
 
 		let diffs: ReplicationChanges<ReplicationRangeIndexable<R>>;
 		let deleted: ReplicationRangeIndexable<R>[] | undefined = undefined;
+		let previousRangesById = new Map<string, ReplicationRangeIndexable<R>>();
 		let isStoppedReplicating = false;
+		let wasReplicatorBeforeDestructiveReset = false;
+		let resetFailureLeaveEmitted = false;
+		const publishConfirmedResetStop = (ownerHasRanges: boolean) => {
+			if (ownerHasRanges || resetFailureLeaveEmitted) {
+				return;
+			}
+			const stoppedTransition =
+				wasReplicatorBeforeDestructiveReset ||
+				this.uniqueReplicators.has(fromHash);
+			this.uniqueReplicators.delete(fromHash);
+			this._replicatorJoinEmitted.delete(fromHash);
+			if (stoppedTransition) {
+				resetFailureLeaveEmitted = true;
+				this.events.dispatchEvent(
+					new CustomEvent<ReplicatorLeaveEvent>("replicator:leave", {
+						detail: { publicKey: from },
+					}),
+				);
+			}
+		};
 		if (reset) {
 			deleted = (
 				await this.replicationIndex
@@ -7431,6 +8226,9 @@ export class SharedLog<
 					})
 					.all()
 			).map((x) => x.value);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				replicationOwnershipLifecycleController,
+			);
 
 			let prevCount = deleted.length;
 
@@ -7439,7 +8237,11 @@ export class SharedLog<
 				deleted.length === ranges.length &&
 				ranges.every((range) => {
 					const existing = existingById.get(range.idString);
-					return existing != null && existing.equalRange(range);
+					return (
+						existing != null &&
+						existing.equalRange(range) &&
+						existing.mode === range.mode
+					);
 				});
 
 			// Avoid churn on repeated full-state announcements that don't change any
@@ -7448,16 +8250,50 @@ export class SharedLog<
 			if (hasSameRanges) {
 				diffs = [];
 			} else {
-				await this.replicationIndex.del({ query: { hash: from.hashcode() } });
+				wasReplicatorBeforeDestructiveReset =
+					this.uniqueReplicators.has(fromHash);
+				const deletion = await this.deleteReplicationRangesCoherently(
+					deleted,
+					fromHash,
+					{ preserveOwnerMembership: ranges.length > 0 },
+				);
+				deleted = deletion.removed;
 
 				diffs = [
 					...deleted.map((x) => {
 						return { range: x, type: "removed" as const, timestamp };
 					}),
-					...ranges.map((x) => {
-						return { range: x, type: "added" as const, timestamp };
-					}),
+					...(deletion.error === undefined
+						? ranges.map((x) => {
+								return { range: x, type: "added" as const, timestamp };
+							})
+						: []),
 				];
+				if (deletion.error !== undefined) {
+					if (diffs.length > 0) {
+						this.events.dispatchEvent(
+							new CustomEvent<ReplicationChangeEvent>("replication:change", {
+								detail: { publicKey: from },
+							}),
+						);
+						if (rebalance) {
+							for (const diff of diffs) {
+								this.replicationChangeDebounceFn.add(diff);
+							}
+						}
+						if (!from.equals(this.node.identity.publicKey)) {
+							this.rebalanceParticipationDebounced?.call();
+						}
+						if (
+							from.equals(this.node.identity.publicKey) &&
+							this._replicationRangeMutationFailure === undefined
+						) {
+							onConfirmedDurableStateChanged?.();
+						}
+					}
+					publishConfirmedResetStop(deletion.ownerHasRanges);
+					throw deletion.error;
+				}
 			}
 
 			isNewReplicator = prevCount === 0 && ranges.length > 0;
@@ -7477,47 +8313,62 @@ export class SharedLog<
 						{ reference: true },
 					)
 					.all();
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					replicationOwnershipLifecycleController,
+				);
 				for (const result of results) {
 					existing.push(result.value);
 				}
 			}
 
-			let prevCountForOwner: number | undefined = undefined;
-			if (existing.length === 0) {
-				prevCountForOwner = await this.replicationIndex.count({
-					query: new StringMatch({ key: "hash", value: from.hashcode() }),
-				});
-				isNewReplicator = prevCountForOwner === 0;
-			} else {
-				isNewReplicator = false;
-			}
+			const prevCountForOwner = await this.replicationIndex.count({
+				query: new StringMatch({ key: "hash", value: fromHash }),
+			});
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				replicationOwnershipLifecycleController,
+			);
+			isNewReplicator = prevCountForOwner === 0;
 
-			if (
-				checkDuplicates &&
-				(existing.length > 0 || (prevCountForOwner ?? 0) > 0)
-			) {
+			if (checkDuplicates && prevCountForOwner > 0) {
 				let deduplicated: ReplicationRangeIndexable<any>[] = [];
 
 				// TODO also deduplicate/de-overlap among the ranges that ought to be inserted?
 				for (const range of ranges) {
-					if (
-						!(await countCoveringRangesSameOwner(this.replicationIndex, range))
-					) {
+					const hasCoveringRange = await countCoveringRangesSameOwner(
+						this.replicationIndex,
+						range,
+					);
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						replicationOwnershipLifecycleController,
+					);
+					if (!hasCoveringRange) {
 						deduplicated.push(range);
 					}
 				}
 				ranges = deduplicated;
 			}
-			let existingMap = new Map<string, ReplicationRangeIndexable<any>>();
+			let existingMap = new Map<string, ReplicationRangeIndexable<R>>();
 			for (const result of existing) {
 				existingMap.set(result.idString, result);
 			}
+			const projectedCount =
+				prevCountForOwner +
+				ranges.reduce(
+					(count, range) => count + (existingMap.has(range.idString) ? 0 : 1),
+					0,
+				);
+			if (projectedCount > MAX_REPLICATION_RANGES_PER_ANNOUNCEMENT) {
+				throw new Error(
+					`Replication range ownership exceeds the ${MAX_REPLICATION_RANGES_PER_ANNOUNCEMENT}-range limit`,
+				);
+			}
+			previousRangesById = existingMap;
 
 			let changes: ReplicationChanges<ReplicationRangeIndexable<R>> = ranges
 				.map((x) => {
 					const prev = existingMap.get(x.idString);
 					if (prev) {
-						if (prev.equalRange(x)) {
+						if (prev.equalRange(x) && prev.mode === x.mode) {
 							return [];
 						}
 						return [
@@ -7545,17 +8396,180 @@ export class SharedLog<
 			diffs = changes;
 		}
 
-		const fromHash = from.hashcode();
-		// Track replicator membership transitions synchronously so join/leave events are
-		// idempotent even if we process concurrent reset messages/unsubscribes.
-		// Only a full-state (reset) announcement can signal that a peer stopped
-		// replicating: a non-reset message whose segments deduplicate to nothing
-		// means "nothing new", not "stopped". Removing the peer here would let
-		// uniqueReplicators diverge from replicationIndex while the peer's
-		// ranges stay indexed.
+		let isAllMature = true;
+
+		const appliedPositiveRanges: ReplicationChange<
+			ReplicationRangeIndexable<R>
+		>[] = [];
+		const rollbackAppliedPositiveRanges = async () => {
+			for (const applied of [...appliedPositiveRanges].reverse()) {
+				const range = applied.range;
+				const current = (
+					await this.replicationIndex
+						.iterate({
+							query: new And([
+								new StringMatch({ key: "hash", value: range.hash }),
+								new ByteMatchQuery({ key: "id", value: range.id }),
+							]),
+						})
+						.all()
+				)[0]?.value;
+				if (!current || current.rangeHash !== range.rangeHash) {
+					continue;
+				}
+				const previous = reset
+					? undefined
+					: previousRangesById.get(range.idString);
+				if (previous) {
+					await this.replicationIndex.put(previous);
+					this.putNativeReplicationRange(previous);
+				} else {
+					await this.replicationIndex.del({
+						query: new And([
+							new StringMatch({ key: "hash", value: range.hash }),
+							new ByteMatchQuery({ key: "id", value: range.id }),
+						]),
+					});
+					this.deleteNativeReplicationRange(range);
+				}
+			}
+			appliedPositiveRanges.length = 0;
+			await this.updateOldestTimestampFromIndex();
+		};
+		const poisonFromPositiveRollback = (
+			rollbackError: unknown,
+			primaryError?: unknown,
+		) => {
+			const errors =
+				primaryError === undefined || primaryError === rollbackError
+					? [rollbackError]
+					: [primaryError, rollbackError];
+			const failure = new AggregateError(
+				errors,
+				"Replication-range positive mutation rollback failed",
+			);
+			this.poisonReplicationOwnership(failure);
+			return failure;
+		};
+
+		try {
+			for (const diff of diffs) {
+				if (diff.type !== "added") {
+					continue;
+				}
+				appliedPositiveRanges.push(diff);
+				await this.replicationIndex.put(diff.range);
+				this.putNativeReplicationRange(diff.range);
+			}
+			if (reset && diffs.length > 0) {
+				await this.updateOldestTimestampFromIndex();
+			}
+		} catch (error) {
+			let outcomeError = error;
+			if (appliedPositiveRanges.length > 0) {
+				try {
+					await rollbackAppliedPositiveRanges();
+				} catch (rollbackError) {
+					outcomeError = poisonFromPositiveRollback(rollbackError, error);
+				}
+			}
+			if (reset) {
+				const negativeDiffs = diffs.filter((diff) => diff.type !== "added");
+				if (negativeDiffs.length > 0) {
+					this.events.dispatchEvent(
+						new CustomEvent<ReplicationChangeEvent>("replication:change", {
+							detail: { publicKey: from },
+						}),
+					);
+					if (rebalance) {
+						for (const diff of negativeDiffs) {
+							this.replicationChangeDebounceFn.add(diff);
+						}
+					}
+					if (
+						from.equals(this.node.identity.publicKey) &&
+						this._replicationRangeMutationFailure === undefined
+					) {
+						onConfirmedDurableStateChanged?.();
+					}
+				}
+				if (!from.equals(this.node.identity.publicKey)) {
+					this.rebalanceParticipationDebounced?.call();
+				}
+				try {
+					const ownerHasRanges =
+						(await this.replicationIndex.count({
+							query: { hash: fromHash },
+						})) > 0;
+					publishConfirmedResetStop(ownerHasRanges);
+				} catch (membershipProbeError) {
+					const failure = new AggregateError(
+						outcomeError === membershipProbeError
+							? [membershipProbeError]
+							: [outcomeError, membershipProbeError],
+						"Could not determine replication membership after failed reset rollback",
+					);
+					this.poisonReplicationOwnership(failure);
+					outcomeError = failure;
+				}
+			}
+			throw outcomeError;
+		}
+		if (diffs.length > 0) {
+			// From this point onward the durable/native range mutation has
+			// committed and its rollback window has closed. If any later local
+			// bookkeeping fails, the caller must publish an authoritative snapshot
+			// instead of leaving peers on the pre-mutation geometry.
+			onConfirmedDurableStateChanged?.();
+		}
+
+		const clearPendingMaturityForRange = (
+			range: ReplicationRangeIndexable<R>,
+		) => {
+			const pendingFromPeer = this.pendingMaturity.get(range.hash);
+			const pending = pendingFromPeer?.get(range.idString);
+			if (!pending || !pendingFromPeer) {
+				return;
+			}
+			clearTimeout(pending.timeout);
+			pendingFromPeer.delete(range.idString);
+			if (pendingFromPeer.size === 0) {
+				this.pendingMaturity.delete(range.hash);
+			}
+		};
+		for (const diff of diffs) {
+			if (diff.type !== "added") {
+				clearPendingMaturityForRange(diff.range);
+			}
+		}
+		for (const applied of appliedPositiveRanges) {
+			const range = applied.range;
+			if (!reset) {
+				this.oldestOpenTime = Math.min(
+					Number(range.timestamp),
+					this.oldestOpenTime,
+				);
+			}
+			if (!isMatured(range, now, minRoleAge)) {
+				isAllMature = false;
+				this.schedulePendingMaturity(
+					applied,
+					from,
+					{
+						rebalance,
+						waitMs: Math.max(minRoleAge - (now - Number(range.timestamp)), 0),
+					},
+					replicationOwnershipLifecycleController,
+				);
+			}
+		}
+
+		// Membership becomes visible only after every awaited positive mutation has
+		// completed. A non-reset duplicate remains positive liveness evidence.
 		const announcedStopped = reset === true && !announcedReplication;
 		const stoppedTransition = announcedStopped
-			? this.uniqueReplicators.delete(fromHash)
+			? wasReplicatorBeforeDestructiveReset ||
+				this.uniqueReplicators.delete(fromHash)
 			: false;
 		if (announcedStopped) {
 			this._replicatorJoinEmitted.delete(fromHash);
@@ -7563,97 +8577,7 @@ export class SharedLog<
 			this.uniqueReplicators.add(fromHash);
 		}
 
-		let now = +new Date();
-		let minRoleAge = await this.getDefaultMinRoleAge();
-		let isAllMature = true;
-
-		for (const diff of diffs) {
-			if (diff.type === "added") {
-				/* if (this.closed) {
-					return;
-				} */
-				await this.replicationIndex.put(diff.range);
-				this.putNativeReplicationRange(diff.range);
-
-				if (!reset) {
-					this.oldestOpenTime = Math.min(
-						Number(diff.range.timestamp),
-						this.oldestOpenTime,
-					);
-				}
-
-				const isMature = isMatured(diff.range, now, minRoleAge);
-
-				if (
-					!isMature /* && diff.range.hash !== this.node.identity.publicKey.hashcode() */
-				) {
-					// second condition is to avoid the case where we are adding a range that we own
-					isAllMature = false;
-					let pendingRanges = this.pendingMaturity.get(diff.range.hash);
-					if (!pendingRanges) {
-						pendingRanges = new Map();
-						this.pendingMaturity.set(diff.range.hash, pendingRanges);
-					}
-
-					let waitForMaturityTime = Math.max(
-						minRoleAge - (now - Number(diff.range.timestamp)),
-						0,
-					);
-
-					const setupTimeout = () =>
-						setTimeout(async () => {
-							this.events.dispatchEvent(
-								new CustomEvent<ReplicationChangeEvent>("replicator:mature", {
-									detail: { publicKey: from },
-								}),
-							);
-
-							if (rebalance && diff.range.mode !== ReplicationIntent.Strict) {
-								this.replicationChangeDebounceFn.add({
-									...diff,
-									matured: true,
-								});
-							}
-							pendingRanges.delete(diff.range.idString);
-							if (pendingRanges.size === 0) {
-								this.pendingMaturity.delete(diff.range.hash);
-							}
-						}, waitForMaturityTime);
-
-					let prevPendingMaturity = pendingRanges.get(diff.range.idString);
-					if (prevPendingMaturity) {
-						// only reset the timer if the new range is older than the previous one, this means that waitForMaturityTime less than the previous one
-						clearTimeout(prevPendingMaturity.timeout);
-						prevPendingMaturity.timeout = setupTimeout();
-					} else {
-						pendingRanges.set(diff.range.idString, {
-							range: diff,
-							timeout: setupTimeout(),
-						});
-					}
-				}
-			} else if (diff.type === "removed") {
-				this.deleteNativeReplicationRange(diff.range);
-				const pendingFromPeer = this.pendingMaturity.get(diff.range.hash);
-				if (pendingFromPeer) {
-					const prev = pendingFromPeer.get(diff.range.idString);
-					if (prev) {
-						clearTimeout(prev.timeout);
-						pendingFromPeer.delete(diff.range.idString);
-					}
-					if (pendingFromPeer.size === 0) {
-						this.pendingMaturity.delete(diff.range.hash);
-					}
-				}
-			}
-			// else replaced, do nothing
-		}
-
 		if (diffs.length > 0) {
-			if (reset) {
-				await this.updateOldestTimestampFromIndex();
-			}
-
 			this.events.dispatchEvent(
 				new CustomEvent<ReplicationChangeEvent>("replication:change", {
 					detail: { publicKey: from },
@@ -7722,13 +8646,66 @@ export class SharedLog<
 				msg: AllReplicatingSegmentsMessage | AddedReplicationSegmentMessage,
 			) => void;
 		} = {},
+		replicationOwnershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	) {
-		await this.ensureCurrentHeadCoordinatesIndexed();
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			replicationOwnershipLifecycleController,
+		);
+		await this.ensureCurrentHeadCoordinatesIndexed(
+			replicationOwnershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			replicationOwnershipLifecycleController,
+		);
 
-		const change = await this.addReplicationRange(
-			range,
-			this.node.identity.publicKey,
-			options,
+		let confirmedDurableStateChanged = false;
+		let change: ReplicationChanges<ReplicationRangeIndexable<R>> | undefined;
+		try {
+			change = await this.addReplicationRange(
+				range,
+				this.node.identity.publicKey,
+				{
+					...options,
+					onConfirmedDurableStateChanged: () => {
+						confirmedDurableStateChanged = true;
+					},
+				},
+				replicationOwnershipLifecycleController,
+			);
+		} catch (mutationError) {
+			if (
+				!confirmedDurableStateChanged ||
+				!this.isRepairLifecycleActive(replicationOwnershipLifecycleController)
+			) {
+				throw mutationError;
+			}
+
+			let announcementError: unknown;
+			try {
+				const segments = (await this.getMyReplicationSegments()).map((range) =>
+					range.toReplicationRange(),
+				);
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					replicationOwnershipLifecycleController,
+				);
+				this.validatePersistedReplicationRangeSnapshot(segments);
+				await this.sendReplicationAnnouncement(
+					new AllReplicatingSegmentsMessage({ segments }),
+					replicationOwnershipLifecycleController,
+				);
+			} catch (error) {
+				announcementError = error;
+			}
+			if (announcementError !== undefined) {
+				throw new AggregateError(
+					[mutationError, announcementError],
+					"Replication state changed durably but its corrective announcement failed",
+				);
+			}
+			throw mutationError;
+		}
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			replicationOwnershipLifecycleController,
 		);
 
 		if (!change) {
@@ -7736,8 +8713,13 @@ export class SharedLog<
 		}
 
 		if (change) {
-			let addedOrReplaced = change.filter((x) => x.type !== "removed");
-			if (addedOrReplaced.length > 0) {
+			// Local replacements are represented as a negative `replaced` fact for
+			// the retired geometry followed by an `added` fact for the durable
+			// replacement. Only the positive/current fact belongs on the wire:
+			// announcing both would send the same range id twice, which receivers
+			// correctly reject as an ambiguous ownership announcement.
+			const added = change.filter((x) => x.type === "added");
+			if (added.length > 0) {
 				// Provider discovery keep-alive (best-effort). This enables bounded targeted fetches
 				// without relying on any global subscriber list.
 				try {
@@ -7761,17 +8743,23 @@ export class SharedLog<
 					| undefined = undefined;
 				if (options.reset) {
 					message = new AllReplicatingSegmentsMessage({
-						segments: addedOrReplaced.map((x) => x.range.toReplicationRange()),
+						segments: added.map((x) => x.range.toReplicationRange()),
 					});
 				} else {
 					message = new AddedReplicationSegmentMessage({
-						segments: addedOrReplaced.map((x) => x.range.toReplicationRange()),
+						segments: added.map((x) => x.range.toReplicationRange()),
 					});
 				}
 				if (options.announce) {
 					return options.announce(message);
 				} else {
-					await this.sendReplicationAnnouncement(message);
+					await this.sendReplicationAnnouncement(
+						message,
+						replicationOwnershipLifecycleController,
+					);
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						replicationOwnershipLifecycleController,
+					);
 				}
 			}
 		}
@@ -8041,18 +9029,39 @@ export class SharedLog<
 		return mode === "churn" || bypassKnownPeerHints === true;
 	}
 
-	private async sleepTracked(delayMs: number) {
+	private async sleepTracked(
+		delayMs: number,
+		repairLifecycleController: AbortController,
+	) {
 		if (delayMs <= 0) {
-			return;
+			return this.isRepairLifecycleActive(repairLifecycleController);
+		}
+		if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+			return false;
 		}
 		await new Promise<void>((resolve) => {
-			const timer = setTimeout(() => {
+			let settled = false;
+			const settle = () => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				clearTimeout(timer);
 				this._repairRetryTimers.delete(timer);
+				repairLifecycleController.signal.removeEventListener("abort", settle);
 				resolve();
-			}, delayMs);
+			};
+			const timer = setTimeout(settle, delayMs);
 			timer.unref?.();
 			this._repairRetryTimers.add(timer);
+			repairLifecycleController.signal.addEventListener("abort", settle, {
+				once: true,
+			});
+			if (repairLifecycleController.signal.aborted) {
+				settle();
+			}
 		});
+		return this.isRepairLifecycleActive(repairLifecycleController);
 	}
 
 	private queueRepairFrontierEntries(
@@ -8060,7 +9069,12 @@ export class SharedLog<
 		target: string,
 		entries: ReadonlyMap<string, RepairDispatchEntry<R>>,
 		options?: { bypassKnownPeerHints?: boolean },
-	) {
+		repairLifecycleController: AbortController = this
+			._repairLifecycleController,
+	): boolean {
+		if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+			return false;
+		}
 		let targets = this._repairFrontierByMode.get(mode);
 		if (!targets) {
 			targets = new Map();
@@ -8077,9 +9091,18 @@ export class SharedLog<
 		if (options?.bypassKnownPeerHints === true) {
 			this._repairFrontierBypassKnownPeersByMode.get(mode)?.add(target);
 		}
+		return true;
 	}
 
-	private clearRepairFrontierHashes(target: string, hashes: Iterable<string>) {
+	private clearRepairFrontierHashes(
+		target: string,
+		hashes: Iterable<string>,
+		repairLifecycleController: AbortController = this
+			._repairLifecycleController,
+	) {
+		if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+			return;
+		}
 		const hashList = [...hashes];
 		if (hashList.length === 0) {
 			return;
@@ -8184,7 +9207,11 @@ export class SharedLog<
 		}
 	}
 
-	private async sleepJoinWarmupTracked(target: string, delayMs: number) {
+	private async sleepJoinWarmupTracked(
+		target: string,
+		delayMs: number,
+		repairLifecycleController: AbortController,
+	) {
 		if (delayMs <= 0) {
 			return;
 		}
@@ -8196,7 +9223,9 @@ export class SharedLog<
 					return;
 				}
 				settled = true;
-				this.untrackJoinWarmupTimer(target, trackedTimer);
+				if (repairLifecycleController === this._repairLifecycleController) {
+					this.untrackJoinWarmupTimer(target, trackedTimer);
+				}
 				resolve();
 			};
 			const handle = setTimeout(settle, delayMs);
@@ -8212,9 +9241,11 @@ export class SharedLog<
 		delaysMs: Iterable<number>,
 		entries: ReadonlyMap<string, RepairDispatchEntry<R>>,
 		bypassKnownPeerHints: boolean,
+		repairLifecycleController: AbortController = this
+			._repairLifecycleController,
 	) {
 		if (
-			this.closed ||
+			!this.isRepairLifecycleActive(repairLifecycleController) ||
 			this._joinWarmupGenerationByTarget.get(target) !== generation
 		) {
 			return;
@@ -8260,6 +9291,7 @@ export class SharedLog<
 				scheduled,
 				delayMs,
 				slot,
+				repairLifecycleController,
 			);
 		}
 	}
@@ -8269,7 +9301,11 @@ export class SharedLog<
 		scheduled: JoinWarmupScheduledRetries<R>,
 		delayMs: number,
 		slot: JoinWarmupScheduledRetrySlot<R>,
+		repairLifecycleController: AbortController,
 	) {
+		if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+			return;
+		}
 		const nextDueAt = slot.cohorts[slot.head]?.dueAt;
 		if (nextDueAt == null) {
 			return;
@@ -8284,6 +9320,9 @@ export class SharedLog<
 		let trackedTimer!: JoinWarmupRetryTimer;
 		const handle = setTimeout(
 			() => {
+				if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+					return;
+				}
 				this.untrackJoinWarmupTimer(target, trackedTimer);
 				if (slot.timer !== trackedTimer) {
 					return;
@@ -8330,6 +9369,7 @@ export class SharedLog<
 						scheduled.generation,
 						dueEntries,
 						bypassKnownPeerHints,
+						repairLifecycleController,
 					);
 				}
 				if (slot.head === slot.cohorts.length) {
@@ -8343,7 +9383,13 @@ export class SharedLog<
 					slot.cohorts = slot.cohorts.slice(slot.head);
 					slot.head = 0;
 				}
-				this.armJoinWarmupRetrySlot(target, current, delayMs, slot);
+				this.armJoinWarmupRetrySlot(
+					target,
+					current,
+					delayMs,
+					slot,
+					repairLifecycleController,
+				);
 			},
 			Math.max(0, nextDueAt - Date.now()),
 		);
@@ -8430,7 +9476,12 @@ export class SharedLog<
 	private async pushRepairEntries(
 		target: string,
 		entries: ReadonlyMap<string, RepairDispatchEntry<R>>,
+		isStillCurrent: () => boolean = () => true,
+		signal?: AbortSignal,
 	) {
+		if (!isStillCurrent()) {
+			return;
+		}
 		const hashes = [...entries.keys()];
 		if (
 			this._logProperties?.sync?.rawExchangeHeads === true &&
@@ -8441,8 +9492,11 @@ export class SharedLog<
 			const sentMessages = await this.trySendFusedRawExchangeHeads(
 				hashes,
 				[target],
-				{ priority: SYNC_MESSAGE_PRIORITY, reserved },
+				{ priority: SYNC_MESSAGE_PRIORITY, reserved, signal },
 			);
+			if (!isStillCurrent()) {
+				return;
+			}
 			if (sentMessages !== undefined) {
 				return;
 			}
@@ -8451,19 +9505,27 @@ export class SharedLog<
 				hashes,
 				this._logProperties?.sync?.profile,
 			)) {
+				if (!isStillCurrent()) {
+					return;
+				}
 				message.reserved[0] |= EXCHANGE_HEADS_REPAIR_HINT;
 				await this.rpc.send(message, {
 					priority: SYNC_MESSAGE_PRIORITY,
 					mode: new SilentDelivery({ to: [target], redundancy: 1 }),
+					signal,
 				});
 			}
 			return;
 		}
 		for await (const message of createExchangeHeadsMessages(this.log, hashes)) {
+			if (!isStillCurrent()) {
+				return;
+			}
 			message.reserved[0] |= EXCHANGE_HEADS_REPAIR_HINT;
 			await this.rpc.send(message, {
 				priority: SYNC_MESSAGE_PRIORITY,
 				mode: new SilentDelivery({ to: [target], redundancy: 1 }),
+				signal,
 			});
 		}
 	}
@@ -8472,8 +9534,17 @@ export class SharedLog<
 		target: string,
 		entries: ReadonlyMap<string, RepairDispatchEntry<R>>,
 		transport: RepairTransportMode,
-		options?: { bypassKnownPeers?: boolean; bypassRecentKnownPeers?: boolean },
+		options?: {
+			bypassKnownPeers?: boolean;
+			bypassRecentKnownPeers?: boolean;
+			isStillCurrent?: () => boolean;
+			signal?: AbortSignal;
+		},
 	) {
+		const isStillCurrent = options?.isStillCurrent ?? (() => true);
+		if (!isStillCurrent()) {
+			return;
+		}
 		const unknownEntries = new Map<string, RepairDispatchEntry<R>>();
 		const knownHashes: string[] = [];
 		for (const [hash, entry] of entries) {
@@ -8491,6 +9562,9 @@ export class SharedLog<
 				knownHashes.push(hash);
 			}
 		}
+		if (!isStillCurrent()) {
+			return;
+		}
 		this.clearRepairFrontierHashes(target, knownHashes);
 		if (unknownEntries.size === 0) {
 			return;
@@ -8498,16 +9572,25 @@ export class SharedLog<
 		if (transport === "simple") {
 			// Fallback repair should not depend on the target completing the
 			// RequestMaybeSync -> ResponseMaybeSync round trip.
-			await this.pushRepairEntries(target, unknownEntries);
+			await this.pushRepairEntries(
+				target,
+				unknownEntries,
+				isStillCurrent,
+				options?.signal,
+			);
 			return;
 		}
 
 		const syncEntries = this._logProperties?.sync?.priority
 			? this.materializeRepairDispatchEntries(unknownEntries)
 			: (unknownEntries as Map<string, SyncEntryCoordinates<R>>);
+		if (!isStillCurrent()) {
+			return;
+		}
 		await this.syncronizer.onMaybeMissingEntries({
 			entries: syncEntries,
 			targets: [target],
+			signal: options?.signal,
 		});
 	}
 
@@ -8516,9 +9599,11 @@ export class SharedLog<
 		generation: object,
 		entries: ReadonlyMap<string, RepairDispatchEntry<R>>,
 		bypassKnownPeerHints: boolean,
+		repairLifecycleController: AbortController = this
+			._repairLifecycleController,
 	) {
 		if (
-			this.closed ||
+			!this.isRepairLifecycleActive(repairLifecycleController) ||
 			this._joinWarmupGenerationByTarget.get(target) !== generation
 		) {
 			return;
@@ -8548,21 +9633,34 @@ export class SharedLog<
 		if (state.running) {
 			return;
 		}
-		void this.drainJoinWarmupSends(target, state).catch((error: any) =>
-			logger.error(error),
-		);
+		void this.drainJoinWarmupSends(
+			target,
+			state,
+			repairLifecycleController,
+		).catch((error: any) => {
+			if (this.isRepairLifecycleActive(repairLifecycleController)) {
+				logger.error(error);
+			}
+		});
 	}
 
 	private async drainJoinWarmupSends(
 		target: string,
 		state: JoinWarmupSendState<R>,
+		repairLifecycleController: AbortController,
 	) {
-		if (state.running) {
+		if (
+			state.running ||
+			!this.isRepairLifecycleActive(repairLifecycleController)
+		) {
 			return;
 		}
 		state.running = true;
 		try {
 			while (state.pending) {
+				if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+					return;
+				}
 				state.pending = false;
 				const generation = state.generation;
 				const entries = new Map(state.entries);
@@ -8573,9 +9671,13 @@ export class SharedLog<
 					0,
 					state.lastCompletedAt + JOIN_WARMUP_SEND_SPACING_MS - Date.now(),
 				);
-				await this.sleepJoinWarmupTracked(target, spacingMs);
+				await this.sleepJoinWarmupTracked(
+					target,
+					spacingMs,
+					repairLifecycleController,
+				);
 				if (
-					this.closed ||
+					!this.isRepairLifecycleActive(repairLifecycleController) ||
 					state.generation !== generation ||
 					this._joinWarmupGenerationByTarget.get(target) !== generation
 				) {
@@ -8586,28 +9688,37 @@ export class SharedLog<
 				}
 				this._repairMetrics["join-warmup"].simpleFallbackPasses += 1;
 				try {
-					await this.sendRepairEntriesWithTransport(
-						target,
-						entries,
-						"simple",
-						{
-							bypassKnownPeers: bypassKnownPeerHints,
-							bypassRecentKnownPeers: bypassKnownPeerHints,
-						},
-					);
+					await this.sendRepairEntriesWithTransport(target, entries, "simple", {
+						bypassKnownPeers: bypassKnownPeerHints,
+						bypassRecentKnownPeers: bypassKnownPeerHints,
+						isStillCurrent: () =>
+							this.isRepairLifecycleActive(repairLifecycleController),
+						signal: repairLifecycleController.signal,
+					});
 				} catch (error: any) {
-					logger.error(error);
+					if (this.isRepairLifecycleActive(repairLifecycleController)) {
+						logger.error(error);
+					}
 				} finally {
-					state.lastCompletedAt = Date.now();
+					if (this.isRepairLifecycleActive(repairLifecycleController)) {
+						state.lastCompletedAt = Date.now();
+					}
 				}
 			}
 		} finally {
 			state.running = false;
 			if (this._joinWarmupSendStateByTarget.get(target) === state) {
-				if (state.pending) {
-					void this.drainJoinWarmupSends(target, state).catch((error: any) =>
-						logger.error(error),
-					);
+				const currentRepairLifecycleController =
+					this._repairLifecycleController;
+				if (
+					state.pending &&
+					this.isRepairLifecycleActive(currentRepairLifecycleController)
+				) {
+					void this.drainJoinWarmupSends(
+						target,
+						state,
+						currentRepairLifecycleController,
+					).catch((error: any) => logger.error(error));
 				} else if (!this._joinWarmupGenerationByTarget.has(target)) {
 					this._joinWarmupSendStateByTarget.delete(target);
 				}
@@ -8624,8 +9735,13 @@ export class SharedLog<
 			bypassRecentDedupe?: boolean;
 			bypassKnownPeerHints?: boolean;
 		},
+		repairLifecycleController: AbortController = this
+			._repairLifecycleController,
 	) {
-		if (entries.size === 0) {
+		if (
+			entries.size === 0 ||
+			!this.isRepairLifecycleActive(repairLifecycleController)
+		) {
 			return;
 		}
 
@@ -8675,6 +9791,9 @@ export class SharedLog<
 			options.mode,
 			options.bypassKnownPeerHints,
 		);
+		if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+			return;
+		}
 
 		await Promise.resolve(
 			this.sendRepairEntriesWithTransport(
@@ -8684,6 +9803,9 @@ export class SharedLog<
 				{
 					bypassKnownPeers: bypassKnownPeerHints,
 					bypassRecentKnownPeers: bypassKnownPeerHints,
+					isStillCurrent: () =>
+						this.isRepairLifecycleActive(repairLifecycleController),
+					signal: repairLifecycleController.signal,
 				},
 			),
 		).catch((error: any) => logger.error(error));
@@ -8693,9 +9815,15 @@ export class SharedLog<
 		mode: RepairDispatchMode,
 		target: string,
 		retryScheduleMs?: number[],
+		repairLifecycleController: AbortController = this
+			._repairLifecycleController,
 	) {
 		const activeTargets = this._repairFrontierActiveTargetsByMode.get(mode);
-		if (!activeTargets || activeTargets.has(target) || this.closed) {
+		if (
+			!activeTargets ||
+			activeTargets.has(target) ||
+			!this.isRepairLifecycleActive(repairLifecycleController)
+		) {
 			return;
 		}
 		activeTargets.add(target);
@@ -8717,11 +9845,14 @@ export class SharedLog<
 			let attemptIndex = 0;
 			try {
 				for (;;) {
-					if (this.closed) {
+					if (!this.isRepairLifecycleActive(repairLifecycleController)) {
 						return;
 					}
 					const pending = this._repairFrontierByMode.get(mode)?.get(target);
 					if (!pending || pending.size === 0) {
+						if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+							return;
+						}
 						this._repairFrontierBypassKnownPeersByMode
 							.get(mode)
 							?.delete(target);
@@ -8732,24 +9863,40 @@ export class SharedLog<
 						(mode === "join-warmup" || mode === "join-authoritative") &&
 						this.isAssumeSyncedRepairSuppressed()
 					) {
-						await this.sleepTracked(
-							Math.max(
-								250,
-								this._assumeSyncedRepairSuppressedUntil - Date.now(),
-							),
-						);
+						if (
+							!(await this.sleepTracked(
+								Math.max(
+									250,
+									this._assumeSyncedRepairSuppressedUntil - Date.now(),
+								),
+								repairLifecycleController,
+							))
+						) {
+							return;
+						}
 						continue;
 					}
 
-					await this.sendMaybeMissingEntriesNow(target, pending, {
-						mode,
-						transport: getRepairTransportForAttempt(mode, attemptIndex),
-						bypassRecentDedupe: true,
-						bypassKnownPeerHints:
-							this._repairFrontierBypassKnownPeersByMode
-								.get(mode)
-								?.has(target) === true,
-					});
+					if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+						return;
+					}
+					await this.sendMaybeMissingEntriesNow(
+						target,
+						pending,
+						{
+							mode,
+							transport: getRepairTransportForAttempt(mode, attemptIndex),
+							bypassRecentDedupe: true,
+							bypassKnownPeerHints:
+								this._repairFrontierBypassKnownPeersByMode
+									.get(mode)
+									?.has(target) === true,
+						},
+						repairLifecycleController,
+					);
+					if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+						return;
+					}
 
 					const remaining = this._repairFrontierByMode.get(mode)?.get(target);
 					if (!remaining || remaining.size === 0) {
@@ -8764,37 +9911,61 @@ export class SharedLog<
 								)
 							: steadyStateDelay;
 					attemptIndex = Math.min(attemptIndex + 1, retrySchedule.length - 1);
-					await this.sleepTracked(waitMs);
+					if (!(await this.sleepTracked(waitMs, repairLifecycleController))) {
+						return;
+					}
 				}
 			} finally {
 				activeTargets.delete(target);
 				if (
-					!this.closed &&
+					this.isRepairLifecycleActive(repairLifecycleController) &&
 					(this._repairFrontierByMode.get(mode)?.get(target)?.size || 0) > 0
 				) {
-					this.ensureRepairFrontierRunner(mode, target, retryScheduleMs);
+					this.ensureRepairFrontierRunner(
+						mode,
+						target,
+						retryScheduleMs,
+						repairLifecycleController,
+					);
 				}
 			}
 		})().catch((error: any) => {
 			activeTargets.delete(target);
-			logger.error(error);
+			if (this.isRepairLifecycleActive(repairLifecycleController)) {
+				logger.error(error);
+			}
 		});
 	}
 
-	private flushAppendBackfill() {
-		if (this._appendBackfillPendingByTarget.size === 0) {
+	private flushAppendBackfill(
+		repairLifecycleController: AbortController = this
+			._repairLifecycleController,
+	) {
+		if (
+			!this.isRepairLifecycleActive(repairLifecycleController) ||
+			this._appendBackfillPendingByTarget.size === 0
+		) {
 			return;
 		}
 		const pending = this._appendBackfillPendingByTarget;
 		this._appendBackfillPendingByTarget = new Map();
 		for (const [target, entries] of pending) {
-			this.dispatchMaybeMissingEntries(target, entries, {
-				mode: "append-backfill",
-			});
+			this.dispatchMaybeMissingEntries(
+				target,
+				entries,
+				{
+					mode: "append-backfill",
+				},
+				repairLifecycleController,
+			);
 		}
 	}
 
 	private queueAppendBackfill(target: string, entry: EntryReplicated<R>) {
+		const repairLifecycleController = this._repairLifecycleController;
+		if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+			return;
+		}
 		let entries = this._appendBackfillPendingByTarget.get(target);
 		if (!entries) {
 			entries = new Map();
@@ -8802,7 +9973,7 @@ export class SharedLog<
 		}
 		entries.set(entry.hash, entry);
 		if (entries.size >= this.repairSweepTargetBufferSize) {
-			this.flushAppendBackfill();
+			this.flushAppendBackfill(repairLifecycleController);
 			return;
 		}
 		if (this._appendBackfillTimer || this.closed) {
@@ -8813,10 +9984,10 @@ export class SharedLog<
 			if (this._appendBackfillTimer === timer) {
 				this._appendBackfillTimer = undefined;
 			}
-			if (this.closed) {
+			if (!this.isRepairLifecycleActive(repairLifecycleController)) {
 				return;
 			}
-			this.flushAppendBackfill();
+			this.flushAppendBackfill(repairLifecycleController);
 		}, APPEND_BACKFILL_DELAY_MS);
 		timer.unref?.();
 		this._repairRetryTimers.add(timer);
@@ -8832,22 +10003,38 @@ export class SharedLog<
 			bypassKnownPeerHints?: boolean;
 			retryScheduleMs?: number[];
 		},
+		repairLifecycleController: AbortController = this
+			._repairLifecycleController,
 	) {
-		if (entries.size === 0) {
+		if (
+			entries.size === 0 ||
+			!this.isRepairLifecycleActive(repairLifecycleController)
+		) {
 			return;
 		}
 
 		if (this.isFrontierTrackedRepairMode(options.mode)) {
-			this.queueRepairFrontierEntries(options.mode, target, entries, {
-				bypassKnownPeerHints: this.shouldBypassKnownPeerHints(
+			if (
+				!this.queueRepairFrontierEntries(
 					options.mode,
-					options.bypassKnownPeerHints,
-				),
-			});
+					target,
+					entries,
+					{
+						bypassKnownPeerHints: this.shouldBypassKnownPeerHints(
+							options.mode,
+							options.bypassKnownPeerHints,
+						),
+					},
+					repairLifecycleController,
+				)
+			) {
+				return;
+			}
 			this.ensureRepairFrontierRunner(
 				options.mode,
 				target,
 				options.retryScheduleMs,
+				repairLifecycleController,
 			);
 			return;
 		}
@@ -8912,6 +10099,9 @@ export class SharedLog<
 		);
 
 		const run = (transport: RepairTransportMode) => {
+			if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+				return;
+			}
 			if (
 				transport === "simple" &&
 				options.mode === "join-warmup" &&
@@ -8922,6 +10112,7 @@ export class SharedLog<
 					joinWarmupGeneration,
 					filteredEntries,
 					bypassKnownPeerHints,
+					repairLifecycleController,
 				);
 				return;
 			}
@@ -8938,6 +10129,9 @@ export class SharedLog<
 					{
 						bypassKnownPeers: bypassKnownPeerHints,
 						bypassRecentKnownPeers: bypassKnownPeerHints,
+						isStillCurrent: () =>
+							this.isRepairLifecycleActive(repairLifecycleController),
+						signal: repairLifecycleController.signal,
 					},
 				),
 			).catch((error: any) => logger.error(error));
@@ -8959,8 +10153,10 @@ export class SharedLog<
 				return;
 			}
 			const timer = setTimeout(() => {
-				this._repairRetryTimers.delete(timer);
-				if (this.closed) {
+				if (repairLifecycleController === this._repairLifecycleController) {
+					this._repairRetryTimers.delete(timer);
+				}
+				if (!this.isRepairLifecycleActive(repairLifecycleController)) {
 					return;
 				}
 				void run(transport);
@@ -8975,15 +10171,23 @@ export class SharedLog<
 				delayedJoinWarmupRetries,
 				filteredEntries,
 				bypassKnownPeerHints,
+				repairLifecycleController,
 			);
 		}
 	}
 
-	private scheduleRepairSweep(options: {
-		mode: RepairDispatchMode;
-		peers?: Iterable<string>;
-		joinWarmupGenerations?: ReadonlyMap<string, object>;
-	}) {
+	private scheduleRepairSweep(
+		options: {
+			mode: RepairDispatchMode;
+			peers?: Iterable<string>;
+			joinWarmupGenerations?: ReadonlyMap<string, object>;
+		},
+		repairLifecycleController: AbortController = this
+			._repairLifecycleController,
+	) {
+		if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+			return;
+		}
 		const pendingPeers = this._repairSweepPendingPeersByMode.get(options.mode);
 		if (pendingPeers) {
 			for (const peer of options.peers ?? []) {
@@ -9010,12 +10214,19 @@ export class SharedLog<
 		this._repairSweepPendingModes.add(options.mode);
 		if (!this._repairSweepRunning && !this.closed) {
 			this._repairSweepRunning = true;
-			void this.runRepairSweep();
+			void this.runRepairSweep(repairLifecycleController);
 		}
 	}
 
-	private scheduleJoinAuthoritativeRepair(peers: Set<string>) {
-		if (this.closed || peers.size === 0) {
+	private scheduleJoinAuthoritativeRepair(
+		peers: Set<string>,
+		repairLifecycleController: AbortController = this
+			._repairLifecycleController,
+	) {
+		if (
+			!this.isRepairLifecycleActive(repairLifecycleController) ||
+			peers.size === 0
+		) {
 			return;
 		}
 
@@ -9034,11 +10245,11 @@ export class SharedLog<
 			}
 
 			const timer = setTimeout(() => {
-				this._repairRetryTimers.delete(timer);
-				this._joinAuthoritativeRepairTimersByDelay.delete(delayMs);
-				if (this.closed) {
+				if (!this.isRepairLifecycleActive(repairLifecycleController)) {
 					return;
 				}
+				this._repairRetryTimers.delete(timer);
+				this._joinAuthoritativeRepairTimersByDelay.delete(delayMs);
 
 				const peersForSweep = new Set(
 					this._joinAuthoritativeRepairPeersByDelay.get(delayMs) ?? [],
@@ -9062,9 +10273,15 @@ export class SharedLog<
 		}
 	}
 
-	private async runRepairSweep() {
+	private async runRepairSweep(
+		repairLifecycleController: AbortController = this
+			._repairLifecycleController,
+	) {
 		try {
-			while (!this.closed) {
+			while (this.isRepairLifecycleActive(repairLifecycleController)) {
+				if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+					return;
+				}
 				const pendingModes = new Set(this._repairSweepPendingModes);
 				const pendingPeersByMode = cloneRepairPendingPeersByMode(
 					this._repairSweepPendingPeersByMode,
@@ -9077,9 +10294,11 @@ export class SharedLog<
 					peers.clear();
 				}
 				this._repairSweepJoinWarmupGenerationByTarget.clear();
-				const pendingJoinWarmupPeers =
-					pendingPeersByMode.get("join-warmup");
+				const pendingJoinWarmupPeers = pendingPeersByMode.get("join-warmup");
 				const pruneStaleJoinWarmupPeers = () => {
+					if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+						return false;
+					}
 					for (const peer of [...(pendingJoinWarmupPeers ?? [])]) {
 						if (
 							this._joinWarmupGenerationByTarget.get(peer) !==
@@ -9160,6 +10379,9 @@ export class SharedLog<
 					await this.getFullReplicaRepairCandidates(pendingRepairPeers, {
 						includeSubscribers: false,
 					});
+				if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+					return;
+				}
 				pruneStaleJoinWarmupPeers();
 				const fullReplicaRepairCandidateCount = Math.max(
 					1,
@@ -9173,6 +10395,9 @@ export class SharedLog<
 					["churn", new Map()],
 				]);
 				const flushTarget = (mode: RepairDispatchMode, target: string) => {
+					if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+						return;
+					}
 					const targets = pendingByMode.get(mode);
 					const entries = targets?.get(target);
 					if (!entries || entries.size === 0) {
@@ -9190,15 +10415,20 @@ export class SharedLog<
 						}
 						return;
 					}
-					this.dispatchMaybeMissingEntries(target, entries, {
-						bypassRecentDedupe: true,
-						bypassKnownPeerHints:
-							mode === "churn" ||
-							this._repairFrontierBypassKnownPeersByMode
-								.get(mode)
-								?.has(target) === true,
-						mode,
-					});
+					this.dispatchMaybeMissingEntries(
+						target,
+						entries,
+						{
+							bypassRecentDedupe: true,
+							bypassKnownPeerHints:
+								mode === "churn" ||
+								this._repairFrontierBypassKnownPeersByMode
+									.get(mode)
+									?.has(target) === true,
+							mode,
+						},
+						repairLifecycleController,
+					);
 					targets?.delete(target);
 				};
 				const queueEntryForTarget = (
@@ -9206,6 +10436,9 @@ export class SharedLog<
 					target: string,
 					entry: RepairDispatchEntry<any>,
 				) => {
+					if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+						return;
+					}
 					if (
 						mode === "join-warmup" &&
 						this._joinWarmupGenerationByTarget.get(target) !==
@@ -9248,15 +10481,21 @@ export class SharedLog<
 					!this.hasCustomFindLeaders()
 				) {
 					const repairDispatchPlan = pruneStaleJoinWarmupPeers()
-						? await this.planResidentRepairDispatchBatch({
-							pendingModes,
-							pendingPeersByMode,
-							optimisticGidPeersByMode,
-							fullReplicaRepairCandidates,
-							fullReplicaRepairCandidateCount,
-							selfHash: this.node.identity.publicKey.hashcode(),
-							})
+						? await this.planResidentRepairDispatchBatch(
+								{
+									pendingModes,
+									pendingPeersByMode,
+									optimisticGidPeersByMode,
+									fullReplicaRepairCandidates,
+									fullReplicaRepairCandidateCount,
+									selfHash: this.node.identity.publicKey.hashcode(),
+								},
+								repairLifecycleController,
+							)
 						: new Map();
+					if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+						return;
+					}
 					pruneStaleJoinWarmupPeers();
 					for (const [mode, targets] of repairDispatchPlan) {
 						for (const [target, hashes] of targets) {
@@ -9272,13 +10511,16 @@ export class SharedLog<
 					const iterator = this.entryCoordinatesIndex.iterate({});
 					try {
 						while (
-							!this.closed &&
+							this.isRepairLifecycleActive(repairLifecycleController) &&
 							!iterator.done() &&
 							pruneStaleJoinWarmupPeers()
 						) {
 							const entries = await iterator.next(
 								REPAIR_SWEEP_ENTRY_BATCH_SIZE,
 							);
+							if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+								return;
+							}
 							if (!pruneStaleJoinWarmupPeers()) {
 								break;
 							}
@@ -9286,16 +10528,22 @@ export class SharedLog<
 							const requestedReplicasBatch = entryReplicatedBatch.map((entry) =>
 								decodeReplicas(entry).getValue(this),
 							);
-							const repairDispatchPlan = await this.planRepairDispatchBatch({
-								entries: entryReplicatedBatch,
-								requestedReplicasBatch,
-								pendingModes,
-								pendingPeersByMode,
-								optimisticGidPeersByMode,
-								fullReplicaRepairCandidates,
-								fullReplicaRepairCandidateCount,
-								selfHash: this.node.identity.publicKey.hashcode(),
-							});
+							const repairDispatchPlan = await this.planRepairDispatchBatch(
+								{
+									entries: entryReplicatedBatch,
+									requestedReplicasBatch,
+									pendingModes,
+									pendingPeersByMode,
+									optimisticGidPeersByMode,
+									fullReplicaRepairCandidates,
+									fullReplicaRepairCandidateCount,
+									selfHash: this.node.identity.publicKey.hashcode(),
+								},
+								repairLifecycleController,
+							);
+							if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+								return;
+							}
 							if (!pruneStaleJoinWarmupPeers()) {
 								break;
 							}
@@ -9318,6 +10566,9 @@ export class SharedLog<
 					}
 				}
 
+				if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+					return;
+				}
 				for (const [
 					,
 					optimisticGidPeersConsumed,
@@ -9359,6 +10610,9 @@ export class SharedLog<
 				}
 
 				for (const mode of pendingModes) {
+					if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+						return;
+					}
 					if (mode !== "join-authoritative" && mode !== "churn") {
 						continue;
 					}
@@ -9383,32 +10637,56 @@ export class SharedLog<
 				}
 
 				for (const [mode, targets] of pendingByMode) {
+					if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+						return;
+					}
 					for (const target of [...targets.keys()]) {
 						flushTarget(mode, target);
 					}
 				}
 			}
 		} catch (error: any) {
-			if (!isNotStartedError(error)) {
+			if (
+				this.isRepairLifecycleActive(repairLifecycleController) &&
+				!isNotStartedError(error)
+			) {
 				logger.error(`Repair sweep failed: ${error?.message ?? error}`);
 			}
 		} finally {
+			if (repairLifecycleController !== this._repairLifecycleController) {
+				return;
+			}
 			this._repairSweepRunning = false;
-			if (!this.closed && this._repairSweepPendingModes.size > 0) {
+			if (
+				this.isRepairLifecycleActive(repairLifecycleController) &&
+				this._repairSweepPendingModes.size > 0
+			) {
 				this._repairSweepRunning = true;
-				void this.runRepairSweep();
+				void this.runRepairSweep(repairLifecycleController);
 			}
 		}
 	}
 
-	private async pruneDebouncedFnAddIfNotKeeping(args: {
-		key: string;
-		value: {
-			entry: CheckedPruneEntry<T, R>;
-			leaders: CheckedPruneLeaderMap;
-		};
-	}): Promise<boolean> {
+	private async pruneDebouncedFnAddIfNotKeeping(
+		args: {
+			key: string;
+			value: {
+				entry: CheckedPruneEntry<T, R>;
+				leaders: CheckedPruneLeaderMap;
+			};
+		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	): Promise<boolean> {
 		if (this.closed || !this.pruneDebouncedFn) {
+			return false;
+		}
+		const checkedPruneCoordinator = this._checkedPrune;
+		const pruneDebouncedFn = this.pruneDebouncedFn;
+		const isCurrent = () =>
+			this.isRepairLifecycleActive(ownershipLifecycleController) &&
+			this._checkedPrune === checkedPruneCoordinator &&
+			this.pruneDebouncedFn === pruneDebouncedFn;
+		if (!isCurrent()) {
 			return false;
 		}
 		if (this.keep) {
@@ -9416,13 +10694,20 @@ export class SharedLog<
 			if (isPromiseLike(keepResult) ? await keepResult : keepResult) {
 				return false;
 			}
+			if (!isCurrent()) {
+				return false;
+			}
 		}
-		this._checkedPrune.trackCandidate(
+		checkedPruneCoordinator.trackCandidate(
 			args.key,
 			args.value.entry,
 			args.value.leaders,
 		);
-		void this.pruneDebouncedFn.add(args);
+		void pruneDebouncedFn.add(args).catch((error) => {
+			if (isCurrent() && !isNotStartedError(error as Error)) {
+				logger.error(error);
+			}
+		});
 		return true;
 	}
 
@@ -9447,48 +10732,92 @@ export class SharedLog<
 		entry: CheckedPruneEntry<T, R>;
 		leaders: CheckedPruneLeaderMap;
 		selfReplicating?: boolean;
+		requireFreshLeaderDecision?: boolean;
+		ownershipLifecycleController?: AbortController;
+		checkedPruneCoordinator?: CheckedPruneCoordinator<T, R>;
 	}): Promise<{
 		leaders: CheckedPruneLeaderMap;
 		localLeader: boolean;
 	}> {
+		const checkedPruneCoordinator =
+			args.checkedPruneCoordinator ?? this._checkedPrune;
+		const throwIfInactive = () => {
+			if (args.ownershipLifecycleController) {
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					args.ownershipLifecycleController,
+				);
+				if (this._checkedPrune !== checkedPruneCoordinator) {
+					throw new TerminalOperationNotStartedError(
+						"Checked prune lifecycle is no longer active",
+					);
+				}
+				return;
+			}
+			this.throwIfReplicationOwnershipPoisoned();
+		};
+		throwIfInactive();
 		const selfHash = this.node.identity.publicKey.hashcode();
 		if (args.leaders.has(selfHash)) {
 			if (args.selfReplicating === false) {
 				return { leaders: args.leaders, localLeader: false };
 			}
-			if (args.selfReplicating == null && !(await this.isReplicating())) {
-				return { leaders: args.leaders, localLeader: false };
+			if (args.selfReplicating == null) {
+				throwIfInactive();
+				const selfReplicating = await this.isReplicating();
+				throwIfInactive();
+				if (!selfReplicating) {
+					return { leaders: args.leaders, localLeader: false };
+				}
 			}
+			throwIfInactive();
 			return { leaders: args.leaders, localLeader: true };
 		}
 
-		if (!this.hasActiveCheckedPruneWork(args.hash)) {
+		throwIfInactive();
+		if (!checkedPruneCoordinator.hasActiveWork(args.hash)) {
 			return { leaders: args.leaders, localLeader: false };
 		}
 
 		if (args.selfReplicating === false) {
 			return { leaders: args.leaders, localLeader: false };
 		}
-		if (args.selfReplicating == null && !(await this.isReplicating())) {
-			return { leaders: args.leaders, localLeader: false };
+		if (args.selfReplicating == null) {
+			throwIfInactive();
+			const selfReplicating = await this.isReplicating();
+			throwIfInactive();
+			if (!selfReplicating) {
+				return { leaders: args.leaders, localLeader: false };
+			}
 		}
 
 		try {
+			throwIfInactive();
 			const currentLeaders = await this.findLeadersFromEntry(
 				args.entry,
 				decodeReplicas(args.entry).getValue(this),
 			);
+			throwIfInactive();
 			if (currentLeaders.size > 0) {
 				return {
 					leaders: currentLeaders,
 					localLeader: currentLeaders.has(selfHash),
 				};
 			}
-		} catch {
+			if (args.requireFreshLeaderDecision) {
+				throw new Error(
+					"Could not establish current leaders at the checked-prune delete boundary",
+				);
+			}
+		} catch (error) {
+			throwIfInactive();
+			if (args.requireFreshLeaderDecision) {
+				throw error;
+			}
 			// Best-effort only. If the fresh check fails, keep the original prune
 			// decision instead of hiding a legitimately prunable entry.
 		}
 
+		throwIfInactive();
 		return { leaders: args.leaders, localLeader: false };
 	}
 
@@ -9502,8 +10831,12 @@ export class SharedLog<
 			>;
 			profile?: SyncProfileFn;
 		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	) {
-		if (entries.length === 0 || this.closed) {
+		if (
+			entries.length === 0 ||
+			!this.isRepairLifecycleActive(ownershipLifecycleController)
+		) {
 			return;
 		}
 		const selfHash = this.node.identity.publicKey.hashcode();
@@ -9552,9 +10885,15 @@ export class SharedLog<
 			nativeBackboneLeaderMaps?.planLeaderSamplesForGidsBatch
 		) {
 			const firstOptions = leaderItems[0]?.options;
-			const context = await this.createLeaderSelectionContext({
-				roleAge: firstOptions?.roleAge,
-			});
+			const context = await this.createLeaderSelectionContext(
+				{
+					roleAge: firstOptions?.roleAge,
+				},
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			nativeLeaderMaps = nativeBackboneLeaderMaps.planLeaderSamplesForGidsBatch(
 				leaderItems.map((item) => ({
 					gid: this.getEntryGid(item.entry),
@@ -9574,7 +10913,13 @@ export class SharedLog<
 				};
 			}
 		} else if (leaderItems.length > 0) {
-			const missingPlans = await this.planEntryLeaderBatch(leaderItems);
+			const missingPlans = await this.planEntryLeaderBatch(
+				leaderItems,
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			for (let i = 0; i < missingPlans.length; i++) {
 				plans[leaderItemIndexes[i]!] = missingPlans[i];
 			}
@@ -9592,7 +10937,7 @@ export class SharedLog<
 		let enqueuedPrune = 0;
 		let cancelledLocalLeader = 0;
 		for (let i = 0; i < entries.length; i++) {
-			if (this.closed) {
+			if (!this.isRepairLifecycleActive(ownershipLifecycleController)) {
 				continue;
 			}
 			const entry = entries[i]!;
@@ -9600,6 +10945,9 @@ export class SharedLog<
 
 			if (leaders.has(selfHash)) {
 				await this.cancelCheckedPruneForLocalLeader(entry.hash);
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
 				cancelledLocalLeader++;
 				continue;
 			}
@@ -9612,10 +10960,16 @@ export class SharedLog<
 				continue;
 			}
 
-			await this.pruneDebouncedFnAddIfNotKeeping({
-				key: entry.hash,
-				value: { entry, leaders },
-			});
+			await this.pruneDebouncedFnAddIfNotKeeping(
+				{
+					key: entry.hash,
+					value: { entry, leaders },
+				},
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			enqueuedPrune++;
 			this.responseToPruneDebouncedFn.delete(entry.hash);
 		}
@@ -9629,18 +10983,30 @@ export class SharedLog<
 		});
 	}
 
-	private async pruneIndexedEntriesNoLongerLed(options?: {
-		useDefaultRoleAge?: boolean;
-	}) {
+	private async pruneIndexedEntriesNoLongerLed(
+		options?: {
+			useDefaultRoleAge?: boolean;
+		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	) {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const selfHash = this.node.identity.publicKey.hashcode();
 		const iterator = this.entryCoordinatesIndex.iterate({});
 		let enqueuedPrune = false;
 		try {
-			while (!this.closed && !iterator.done()) {
+			while (
+				this.isRepairLifecycleActive(ownershipLifecycleController) &&
+				!iterator.done()
+			) {
 				const entries = await iterator.next(REPAIR_SWEEP_ENTRY_BATCH_SIZE);
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
 				for (const entry of entries) {
 					const entryReplicated = entry.value;
-					if (this.closed) {
+					if (!this.isRepairLifecycleActive(ownershipLifecycleController)) {
 						continue;
 					}
 
@@ -9648,10 +11014,17 @@ export class SharedLog<
 						entryReplicated.coordinates,
 						entryReplicated,
 						options?.useDefaultRoleAge ? undefined : { roleAge: 0 },
+						ownershipLifecycleController,
+					);
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						ownershipLifecycleController,
 					);
 
 					if (leaders.has(selfHash)) {
 						await this.cancelCheckedPruneForLocalLeader(entryReplicated.hash);
+						this.throwIfReplicationOwnershipLifecycleInactive(
+							ownershipLifecycleController,
+						);
 						continue;
 					}
 
@@ -9664,33 +11037,57 @@ export class SharedLog<
 					}
 
 					enqueuedPrune =
-						(await this.pruneDebouncedFnAddIfNotKeeping({
-							key: entryReplicated.hash,
-							value: { entry: entryReplicated, leaders },
-						})) || enqueuedPrune;
+						(await this.pruneDebouncedFnAddIfNotKeeping(
+							{
+								key: entryReplicated.hash,
+								value: { entry: entryReplicated, leaders },
+							},
+							ownershipLifecycleController,
+						)) || enqueuedPrune;
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						ownershipLifecycleController,
+					);
 					this.responseToPruneDebouncedFn.delete(entryReplicated.hash);
 				}
 			}
 		} finally {
 			await iterator.close();
 		}
-		if (enqueuedPrune && !this.closed) {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
+		if (enqueuedPrune) {
 			await this.pruneDebouncedFn.flush();
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		}
 	}
 
-	private async pruneCurrentHeadsNoLongerLed(options?: {
-		useDefaultRoleAge?: boolean;
-	}) {
+	private async pruneCurrentHeadsNoLongerLed(
+		options?: {
+			useDefaultRoleAge?: boolean;
+		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	) {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const selfHash = this.node.identity.publicKey.hashcode();
 		const nativeHeads = this.log.entryIndex.getHeadsForAppend();
 		const heads: ShallowOrFullEntry<T>[] = nativeHeads
-			? await this.pruneHeadEntriesFromNativeHeadFacts(nativeHeads)
+			? await this.pruneHeadEntriesFromNativeHeadFacts(
+					nativeHeads,
+					ownershipLifecycleController,
+				)
 			: await this.log.getHeads(true).all();
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		let enqueuedPrune = false;
 
 		for (const head of heads) {
-			if (this.closed) {
+			if (!this.isRepairLifecycleActive(ownershipLifecycleController)) {
 				break;
 			}
 
@@ -9698,10 +11095,17 @@ export class SharedLog<
 				head,
 				maxReplicas(this, [head]),
 				options?.useDefaultRoleAge ? undefined : { roleAge: 0 },
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
 			);
 
 			if (leaders.has(selfHash)) {
 				await this.cancelCheckedPruneForLocalLeader(head.hash);
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
 				continue;
 			}
 
@@ -9714,15 +11118,24 @@ export class SharedLog<
 			}
 
 			enqueuedPrune =
-				(await this.pruneDebouncedFnAddIfNotKeeping({
-					key: head.hash,
-					value: { entry: head, leaders },
-				})) || enqueuedPrune;
+				(await this.pruneDebouncedFnAddIfNotKeeping(
+					{
+						key: head.hash,
+						value: { entry: head, leaders },
+					},
+					ownershipLifecycleController,
+				)) || enqueuedPrune;
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			this.responseToPruneDebouncedFn.delete(head.hash);
 		}
 
-		if (enqueuedPrune && !this.closed) {
+		if (enqueuedPrune) {
 			await this.pruneDebouncedFn.flush();
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		}
 	}
 
@@ -9731,7 +11144,11 @@ export class SharedLog<
 			hash: string;
 			meta: { gid: string; clock: { timestamp: Timestamp } };
 		}>,
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<ShallowEntry[]> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		if (heads.length === 0) {
 			return [];
 		}
@@ -9741,6 +11158,9 @@ export class SharedLog<
 				shape: { hash: true, meta: { data: true } },
 			})
 			.all()) as Array<{ hash: string; meta: { data?: Uint8Array } }>;
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const dataByHash = new Map(
 			headDataRows
 				.filter((entry) => entry.meta.data)
@@ -9793,16 +11213,23 @@ export class SharedLog<
 		this._checkedPrune.clearRetry(hash);
 	}
 
-	private scheduleCheckedPruneRetry(args: {
-		entry: CheckedPruneEntry<T, R>;
-		leaders: CheckedPruneLeaderMap | Set<string>;
-	}) {
-		if (this.closed) return;
-		if (this._checkedPrune.hasPendingDelete(args.entry.hash)) return;
+	private scheduleCheckedPruneRetry(
+		args: {
+			entry: CheckedPruneEntry<T, R>;
+			leaders: CheckedPruneLeaderMap | Set<string>;
+		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	) {
+		const checkedPruneCoordinator = this._checkedPrune;
+		const isCurrent = () =>
+			this.isRepairLifecycleActive(ownershipLifecycleController) &&
+			this._checkedPrune === checkedPruneCoordinator;
+		if (!isCurrent()) return;
+		if (checkedPruneCoordinator.hasPendingDelete(args.entry.hash)) return;
 
 		const hash = args.entry.hash;
 		const state =
-			this._checkedPrune.getRetry(hash) ??
+			checkedPruneCoordinator.getRetry(hash) ??
 			({
 				attempts: 0,
 				entry: args.entry,
@@ -9826,41 +11253,55 @@ export class SharedLog<
 		);
 
 		state.attempts = attempt;
-		state.timer = setTimeout(async () => {
-			const st = this._checkedPrune.getRetry(hash);
-			if (st) st.timer = undefined;
-			if (this.closed) return;
-			if (this._checkedPrune.hasPendingDelete(hash)) return;
-			const retryEntry = st?.entry ?? args.entry;
-			const retryLeaders = st?.leaders ?? args.leaders;
+		state.timer = setTimeout(() => {
+			const run = async () => {
+				const st = checkedPruneCoordinator.getRetry(hash);
+				if (st) st.timer = undefined;
+				if (!isCurrent()) return;
+				if (checkedPruneCoordinator.hasPendingDelete(hash)) return;
+				const retryEntry = st?.entry ?? args.entry;
+				const retryLeaders = st?.leaders ?? args.leaders;
 
-			let leadersMap: CheckedPruneLeaderMap | undefined;
-			try {
-				const replicas = decodeReplicas(retryEntry).getValue(this);
-				leadersMap = await this.findLeadersFromEntry(retryEntry, replicas, {
-					roleAge: 0,
-				});
-			} catch {
-				// Best-effort only.
-			}
+				let leadersMap: CheckedPruneLeaderMap | undefined;
+				try {
+					const replicas = decodeReplicas(retryEntry).getValue(this);
+					leadersMap = await this.findLeadersFromEntry(
+						retryEntry,
+						replicas,
+						{ roleAge: 0 },
+						ownershipLifecycleController,
+					);
+				} catch {
+					if (!isCurrent()) {
+						return;
+					}
+					// A current-generation planning failure is best-effort; fall back
+					// to the last confirmed leader set below.
+				}
+				if (!isCurrent()) return;
 
-			if (!leadersMap || leadersMap.size === 0) {
-				leadersMap = this.checkedPruneLeadersToMap(retryLeaders);
-			}
+				if (!leadersMap || leadersMap.size === 0) {
+					leadersMap = this.checkedPruneLeadersToMap(retryLeaders);
+				}
 
-			try {
 				const leadersForRetry =
 					leadersMap ?? new Map<string, { intersecting: boolean }>();
-				await this.pruneDebouncedFnAddIfNotKeeping({
-					key: hash,
-					value: { entry: retryEntry, leaders: leadersForRetry },
-				});
-			} catch {
-				// Best-effort only; pruning will be re-attempted on future changes.
-			}
+				await this.pruneDebouncedFnAddIfNotKeeping(
+					{
+						key: hash,
+						value: { entry: retryEntry, leaders: leadersForRetry },
+					},
+					ownershipLifecycleController,
+				);
+			};
+			void run().catch((error) => {
+				if (isCurrent() && !isNotStartedError(error as Error)) {
+					logger.error(error);
+				}
+			});
 		}, delayMs);
 		state.timer.unref?.();
-		this._checkedPrune.setRetry(hash, state);
+		checkedPruneCoordinator.setRetry(hash, state);
 	}
 
 	private async recoverCheckedPruneFromLateResponses(
@@ -9950,16 +11391,27 @@ export class SharedLog<
 		removed: ShallowOrFullEntry<T>[];
 	}> {
 		this.throwIfNativeDurableCommitFailed();
+		const ownershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
 		if (this._isAdaptiveReplicating) {
 			this.markLocalAppendActivity();
 		}
 
-		const { appendOptions, minReplicasValue } =
-			this.createLogAppendOptions(options);
+		const { appendOptions, minReplicasValue } = this.createLogAppendOptions(
+			options,
+			ownershipLifecycleController,
+		);
 		const result = await this.log.append(data, appendOptions);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		await this.processLocalAppend(result.entry, result.removed, options, {
 			minReplicasValue,
+			ownershipLifecycleController,
 		});
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		return result;
 	}
 
@@ -9972,6 +11424,8 @@ export class SharedLog<
 		removed: ShallowOrFullEntry<T>[];
 	}> {
 		this.throwIfNativeDurableCommitFailed();
+		const ownershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
 		if (options?.canAppend || options?.onChange) {
 			throw new Error(
 				"appendLocallyValidated does not accept canAppend or onChange hooks",
@@ -9981,14 +11435,24 @@ export class SharedLog<
 			this.markLocalAppendActivity();
 		}
 
-		const { appendOptions, minReplicasValue } =
-			this.createLogAppendOptions(options);
+		const { appendOptions, minReplicasValue } = this.createLogAppendOptions(
+			options,
+			ownershipLifecycleController,
+		);
 		appendOptions.__peerbitCanAppendAlreadyValidated = true;
-		appendOptions.onChange = (change) => this.onChange(change);
+		appendOptions.onChange = (change) =>
+			this.onChange(change, ownershipLifecycleController);
 		const result = await this.log.append(data, appendOptions);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		await this.processLocalAppend(result.entry, result.removed, options, {
 			minReplicasValue,
+			ownershipLifecycleController,
 		});
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		return result;
 	}
 
@@ -10007,6 +11471,8 @@ export class SharedLog<
 		appendCommit: PreparedLocalAppendCommit<R>;
 	}> {
 		this.throwIfNativeDurableCommitFailed();
+		const ownershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
 		if (options?.canAppend || options?.onChange) {
 			throw new Error(
 				"appendLocallyPrepared does not accept canAppend or onChange hooks",
@@ -10028,10 +11494,17 @@ export class SharedLog<
 				payloadData: properties?.payloadData,
 			},
 		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const nativePreparedCommit =
 			await this.processNativePreparedTargetNoneAppend(result, options, {
 				minReplicasValue,
+				ownershipLifecycleController,
 			});
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		if (nativePreparedCommit) {
 			return {
 				entry: result.entry,
@@ -10043,21 +11516,39 @@ export class SharedLog<
 		let deferredCoordinateDeleteHashes: string[] | undefined;
 		if (this.canCoalescePreparedAppendCoordinateDeletes(result, options)) {
 			deferredCoordinateDeleteHashes =
-				this.applyChangeWithDeferredCoordinateDeletes(result.change);
+				this.applyChangeWithDeferredCoordinateDeletes(result.change, {
+					ownershipLifecycleController,
+				});
 			nativeAppendPlan = await this.planNativeLocalAppendFacts(
 				result.appendFacts,
 				minReplicasValue,
+				undefined,
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
 			);
 			if (!nativeAppendPlan) {
 				if (deferredCoordinateDeleteHashes) {
-					await this.deleteCoordinatesForHashes(deferredCoordinateDeleteHashes);
+					await this.deleteCoordinatesForHashes(
+						deferredCoordinateDeleteHashes,
+						ownershipLifecycleController,
+					);
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						ownershipLifecycleController,
+					);
 				}
 				deferredCoordinateDeleteHashes = undefined;
 			}
 		} else {
-			const changeResult = this.applyChange(result.change);
+			const changeResult = this.applyChange(result.change, {
+				ownershipLifecycleController,
+			});
 			if (isPromiseLike(changeResult)) {
 				await changeResult;
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
 			}
 		}
 		try {
@@ -10067,13 +11558,20 @@ export class SharedLog<
 					appendFacts: result.appendFacts,
 					nativeAppendPlan,
 					extraCoordinateDeleteHashes: deferredCoordinateDeleteHashes,
+					ownershipLifecycleController,
 				})) ?? nativeAppendPlan;
 		} catch (error) {
 			if (deferredCoordinateDeleteHashes) {
-				await this.deleteCoordinatesForHashes(deferredCoordinateDeleteHashes);
+				await this.deleteCoordinatesForHashes(
+					deferredCoordinateDeleteHashes,
+					ownershipLifecycleController,
+				);
 			}
 			throw error;
 		}
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		return {
 			entry: result.entry,
 			removed: result.removed,
@@ -10093,8 +11591,17 @@ export class SharedLog<
 			appendFacts: PreparedAppendFacts;
 		},
 		options: SharedAppendOptions<T> | undefined,
-		properties: { minReplicasValue: number },
+		properties: {
+			minReplicasValue: number;
+			ownershipLifecycleController?: AbortController;
+		},
 	): Promise<PreparedLocalAppendCommit<R> | undefined> {
+		const ownershipLifecycleController =
+			properties.ownershipLifecycleController ??
+			this.captureReplicationOwnershipLifecycle();
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		if (
 			options?.target !== "none" ||
 			options?.replicate === true ||
@@ -10117,6 +11624,10 @@ export class SharedLog<
 						? plannedCoordinateDeleteHashes
 						: undefined,
 			},
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
 		);
 		if (!nativeAppendPlan) {
 			return undefined;
@@ -10128,6 +11639,7 @@ export class SharedLog<
 				? this.applyChangeWithDeferredCoordinateDeletes(result.change, {
 						forgetNativeCoordinates:
 							!nativeAppendPlan.committedNativeCoordinateDeletes,
+						ownershipLifecycleController,
 					})
 				: this.applyPreparedAppendFactsWithDeferredCoordinateDeletes(
 						result.appendFacts,
@@ -10136,22 +11648,33 @@ export class SharedLog<
 						{
 							forgetNativeCoordinates:
 								!nativeAppendPlan.committedNativeCoordinateDeletes,
+							ownershipLifecycleController,
 						},
 					);
-			await this.persistPreparedCoordinate({
-				prepared: nativeAppendPlan.preparedCoordinate,
-				hash: result.appendFacts.hash,
-				nextHashes: result.appendFacts.next,
-				deleteHashes: deferredCoordinateDeleteHashes,
-				coordinates: nativeAppendPlan.coordinates,
-				replicas: nativeAppendPlan.coordinates.length,
-				commitNative: nativeAppendPlan.committedNativeCoordinateState !== true,
-				commitNativeBackbone:
-					nativeAppendPlan.committedNativeBackboneCoordinateState !== true,
-			});
+			await this.persistPreparedCoordinate(
+				{
+					prepared: nativeAppendPlan.preparedCoordinate,
+					hash: result.appendFacts.hash,
+					nextHashes: result.appendFacts.next,
+					deleteHashes: deferredCoordinateDeleteHashes,
+					coordinates: nativeAppendPlan.coordinates,
+					replicas: nativeAppendPlan.coordinates.length,
+					commitNative:
+						nativeAppendPlan.committedNativeCoordinateState !== true,
+					commitNativeBackbone:
+						nativeAppendPlan.committedNativeBackboneCoordinateState !== true,
+				},
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		} catch (error) {
 			if (deferredCoordinateDeleteHashes) {
-				await this.deleteCoordinatesForHashes(deferredCoordinateDeleteHashes);
+				await this.deleteCoordinatesForHashes(
+					deferredCoordinateDeleteHashes,
+					ownershipLifecycleController,
+				);
 			}
 			throw error;
 		}
@@ -10165,18 +11688,32 @@ export class SharedLog<
 					nativeAppendPlan.preparedCoordinate,
 				);
 				leaders = (
-					await this.planEntryLeaders(pruneEntry, properties.minReplicasValue, {
-						persist: false,
-					})
+					await this.planEntryLeaders(
+						pruneEntry,
+						properties.minReplicasValue,
+						{
+							persist: false,
+						},
+						ownershipLifecycleController,
+					)
 				).leaders;
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
 			}
 			pruneEntry ??= this.materializePreparedCoordinateEntry(
 				nativeAppendPlan.preparedCoordinate,
 			);
-			this.pruneDebouncedFnAddIfNotKeeping({
-				key: pruneEntry.hash,
-				value: { entry: pruneEntry, leaders },
-			});
+			await this.pruneDebouncedFnAddIfNotKeeping(
+				{
+					key: pruneEntry.hash,
+					value: { entry: pruneEntry, leaders },
+				},
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		}
 		if (!delayAdaptiveRebalance) {
 			this.rebalanceParticipationDebounced?.call();
@@ -10220,6 +11757,8 @@ export class SharedLog<
 		) {
 			return undefined;
 		}
+		const ownershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
 		if (this._isAdaptiveReplicating) {
 			this.markLocalAppendActivity();
 		}
@@ -10237,9 +11776,13 @@ export class SharedLog<
 				properties,
 				minReplicasValue,
 				deferHeadCoordinatePersistence,
+				ownershipLifecycleController,
 			);
 		if (nativeBackboneResult) {
 			return mapMaybePromise(nativeBackboneResult, (result) => {
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
 				if (result) {
 					return result;
 				}
@@ -10250,6 +11793,7 @@ export class SharedLog<
 					properties,
 					minReplicasValue,
 					deferHeadCoordinatePersistence,
+					ownershipLifecycleController,
 				);
 			});
 		}
@@ -10260,6 +11804,7 @@ export class SharedLog<
 			properties,
 			minReplicasValue,
 			deferHeadCoordinatePersistence,
+			ownershipLifecycleController,
 		);
 	}
 
@@ -10284,6 +11829,8 @@ export class SharedLog<
 		) {
 			return undefined;
 		}
+		const ownershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
 		if (this._isAdaptiveReplicating) {
 			this.markLocalAppendActivity();
 		}
@@ -10298,8 +11845,14 @@ export class SharedLog<
 			properties,
 			minReplicasValue,
 			this.shouldDeferHeadCoordinatePersistence(options),
+			ownershipLifecycleController,
 		);
-		return mapMaybePromise(result, (commitOnly) => commitOnly ?? undefined);
+		return mapMaybePromise(result, (commitOnly) => {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+			return commitOnly ?? undefined;
+		});
 	}
 
 	private appendLocallyPreparedPayloadCommitOnlyFallback(
@@ -10309,7 +11862,11 @@ export class SharedLog<
 		properties: PreparedPayloadCommitOnlyProperties | undefined,
 		minReplicasValue: number,
 		deferHeadCoordinatePersistence: boolean,
+		ownershipLifecycleController: AbortController,
 	): MaybePromise<PreparedPayloadCommitOnlyResult<T, R> | undefined> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const resultMaybe = asTrustedLowerLog(
 			this.log,
 		).appendLocallyPreparedCommitOnly(undefined as T, appendOptions, {
@@ -10319,13 +11876,17 @@ export class SharedLog<
 			includeMaterializationBytes: false,
 			includeAppendFactsBytes: !deferHeadCoordinatePersistence,
 		});
-		return mapMaybePromise(resultMaybe, (result) =>
-			this.finishPreparedPayloadCommitOnlyAppend(
+		return mapMaybePromise(resultMaybe, (result) => {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+			return this.finishPreparedPayloadCommitOnlyAppend(
 				result,
 				options,
 				minReplicasValue,
-			),
-		);
+				ownershipLifecycleController,
+			);
+		});
 	}
 
 	private appendLocallyPreparedPayloadNativeBackboneCommitOnly(
@@ -10335,9 +11896,13 @@ export class SharedLog<
 		properties: PreparedPayloadCommitOnlyProperties | undefined,
 		minReplicasValue: number,
 		deferHeadCoordinatePersistence: boolean,
+		ownershipLifecycleController: AbortController,
 	):
 		| MaybePromise<PreparedPayloadCommitOnlyResult<T, R> | undefined>
 		| undefined {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		if (
 			!this._nativeBackbone ||
 			options?.target !== "none" ||
@@ -10352,6 +11917,7 @@ export class SharedLog<
 				properties,
 				minReplicasValue,
 				options?.replicate === false,
+				ownershipLifecycleController,
 			);
 		}
 		const hasDocumentIndexCommit =
@@ -10369,6 +11935,7 @@ export class SharedLog<
 				properties,
 				minReplicasValue,
 				true,
+				ownershipLifecycleController,
 			);
 		}
 		if (
@@ -10384,6 +11951,7 @@ export class SharedLog<
 				properties,
 				minReplicasValue,
 				true,
+				ownershipLifecycleController,
 			);
 		}
 		if (options?.replicate !== false) {
@@ -10889,7 +12457,11 @@ export class SharedLog<
 		properties: PreparedPayloadCommitOnlyProperties | undefined,
 		minReplicasValue: number,
 		runtimeOnlyCoordinates: boolean,
+		ownershipLifecycleController: AbortController,
 	): MaybePromise<PreparedPayloadCommitOnlyResult<T, R> | undefined> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const backbone = this._nativeBackbone;
 		if (!backbone || !this.canUseNativeBackboneResidentCoordinateState()) {
 			return undefined;
@@ -10900,224 +12472,379 @@ export class SharedLog<
 		) {
 			return undefined;
 		}
-		return mapMaybePromise(this.createLeaderSelectionContext(), (context) => {
-			const nativeLeaderOptions = this.createNativeLeaderOptions(context);
-			let backboneAppend:
-				| ReturnType<
-						NativePeerbitBackbone["preparePlainStorageAppendTransaction"]
-				  >
-				| ReturnType<
-						NativePeerbitBackbone["preparePlainCommittedStorageAppendTransaction"]
-				  >
-				| ReturnType<
-						NativePeerbitBackbone["preparePlainCommittedNoNextStorageAppendTransaction"]
-				  >
-				| undefined;
-			// The write-through durable wrapper, when active, is captured here so a
-			// just-committed block can be mirrored to durable without disturbing the
-			// strict-native commit path. When the wrapper is active the log's block
-			// store is the wrapper (not the raw wasm map), so `localStore ===
-			// backbone.blocks` is false — but the store is still native-backed, so we
-			// must commit blocks in the backbone (the committed native prepare variant
-			// is the one that emits the document-signer journal record; the
-			// block-deferring variant does not, which would otherwise leave
-			// document-signers.wal unwritten and break same-signer facts after
-			// reopen). The block is then mirrored to durable out-of-band below.
-			const durableWrapperActive =
-				this.remoteBlocks?.localStore !== backbone.blocks;
-			const durableWrapper = durableWrapperActive
-				? (this.remoteBlocks?.localStore as unknown as {
-						beginNativeDeleteCleanup?: (cids: string[]) => number | undefined;
-						cancelNativeDeleteCleanup?: (cleanupToken: unknown) => void;
-						mirrorToDurable?: (
-							cid: string,
-							bytes: Uint8Array,
-							options?: { nativeTrimmed?: boolean },
-						) => Promise<unknown>;
-						rollbackFailedNativeCommits?: (
-							cids: string[],
-							restoreNativeCids?: string[],
-						) => Promise<void>;
-					})
-				: undefined;
-			const commitBlocksInBackbone =
-				this.remoteBlocks?.localStore === backbone.blocks ||
-				durableWrapperActive;
-			let nativeBackboneDocumentIndexCommitted = false;
-			let nativeBackboneDocumentDeleteCommitted = false;
-			let nativeDocumentRollback: NativeBackboneDocumentRollback | undefined;
-			let nativeCoordinateRollback:
-				| NativeBackboneCoordinateRollback<R>
-				| undefined;
-			let nativeDeleteCleanupToken: unknown;
-			let nativeStrictTransaction:
-				| NativeStrictDurableTransactionHandle
-				| undefined;
-			const prepareBackboneAppend = async (input: {
-				wallTime: bigint;
-				logical: number;
-				gid: string;
-				next?: string[];
-				type: number;
-				metaData?: Uint8Array;
-				payloadData: Uint8Array;
-				trimLengthTo?: number;
-			}) => {
-				const next = input.next ?? [];
-				const appendInput = {
-					wallTime: input.wallTime,
-					logical: input.logical,
-					gid: input.gid,
-					next,
-					type: input.type,
-					metaData: input.metaData,
-					payloadData: input.payloadData,
-					replicas: minReplicasValue,
-					roleAgeMs: nativeLeaderOptions.roleAge,
-					now: nativeLeaderOptions.now,
-					selfHash: nativeLeaderOptions.selfHash,
-					selfReplicating: nativeLeaderOptions.selfReplicating,
-					trimLengthTo: input.trimLengthTo,
-					resolveTrimmedEntries: properties?.resolveTrimmedEntries,
-				};
-				const nativeBackboneDocumentIndex =
-					properties?.nativeBackboneDocumentIndex ??
-					properties?.prepareNativeBackboneDocumentIndex?.({
+		return mapMaybePromise(
+			this.createLeaderSelectionContext(
+				undefined,
+				ownershipLifecycleController,
+			),
+			(context) => {
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
+				const nativeLeaderOptions = this.createNativeLeaderOptions(context);
+				let backboneAppend:
+					| ReturnType<
+							NativePeerbitBackbone["preparePlainStorageAppendTransaction"]
+					  >
+					| ReturnType<
+							NativePeerbitBackbone["preparePlainCommittedStorageAppendTransaction"]
+					  >
+					| ReturnType<
+							NativePeerbitBackbone["preparePlainCommittedNoNextStorageAppendTransaction"]
+					  >
+					| undefined;
+				// The write-through durable wrapper, when active, is captured here so a
+				// just-committed block can be mirrored to durable without disturbing the
+				// strict-native commit path. When the wrapper is active the log's block
+				// store is the wrapper (not the raw wasm map), so `localStore ===
+				// backbone.blocks` is false — but the store is still native-backed, so we
+				// must commit blocks in the backbone (the committed native prepare variant
+				// is the one that emits the document-signer journal record; the
+				// block-deferring variant does not, which would otherwise leave
+				// document-signers.wal unwritten and break same-signer facts after
+				// reopen). The block is then mirrored to durable out-of-band below.
+				const durableWrapperActive =
+					this.remoteBlocks?.localStore !== backbone.blocks;
+				const durableWrapper = durableWrapperActive
+					? (this.remoteBlocks?.localStore as unknown as {
+							beginNativeDeleteCleanup?: (cids: string[]) => number | undefined;
+							cancelNativeDeleteCleanup?: (cleanupToken: unknown) => void;
+							mirrorToDurable?: (
+								cid: string,
+								bytes: Uint8Array,
+								options?: { nativeTrimmed?: boolean },
+							) => Promise<unknown>;
+							rollbackFailedNativeCommits?: (
+								cids: string[],
+								restoreNativeCids?: string[],
+							) => Promise<void>;
+						})
+					: undefined;
+				const commitBlocksInBackbone =
+					this.remoteBlocks?.localStore === backbone.blocks ||
+					durableWrapperActive;
+				let nativeBackboneDocumentIndexCommitted = false;
+				let nativeBackboneDocumentDeleteCommitted = false;
+				let nativeDocumentRollback: NativeBackboneDocumentRollback | undefined;
+				let nativeCoordinateRollback:
+					| NativeBackboneCoordinateRollback<R>
+					| undefined;
+				let nativeDeleteCleanupToken: unknown;
+				let nativeStrictTransaction:
+					| NativeStrictDurableTransactionHandle
+					| undefined;
+				const prepareBackboneAppend = async (input: {
+					wallTime: bigint;
+					logical: number;
+					gid: string;
+					next?: string[];
+					type: number;
+					metaData?: Uint8Array;
+					payloadData: Uint8Array;
+					trimLengthTo?: number;
+				}) => {
+					const next = input.next ?? [];
+					const appendInput = {
 						wallTime: input.wallTime,
+						logical: input.logical,
 						gid: input.gid,
-						payloadSize: input.payloadData.byteLength,
-					});
-				const nativeBackboneDocumentIndexForAppend =
-					nativeBackboneDocumentIndex &&
-					input.trimLengthTo == null &&
-					nativeBackboneDocumentIndex.deleteTrimmedHeads === true
-						? {
-								...nativeBackboneDocumentIndex,
-								deleteTrimmedHeads: false,
-							}
-						: nativeBackboneDocumentIndex;
-				const nativeBackboneDocumentDeleteKey =
-					properties?.nativeBackboneDocumentDeleteKey;
-				if (
-					nativeBackboneDocumentDeleteKey &&
-					nativeBackboneDocumentIndexForAppend
-				) {
-					throw new Error(
-						"Native backbone append cannot both put and delete a document index row",
-					);
-				}
-				const appendInputWithDocumentIndex =
-					nativeBackboneDocumentIndexForAppend
-						? {
-								...appendInput,
-								documentIndex: {
-									...nativeBackboneDocumentIndexForAppend,
-									useLatestContext:
-										properties?.useNativeExistingDocumentContext === true,
-								},
-							}
-						: nativeBackboneDocumentDeleteKey
+						next,
+						type: input.type,
+						metaData: input.metaData,
+						payloadData: input.payloadData,
+						replicas: minReplicasValue,
+						roleAgeMs: nativeLeaderOptions.roleAge,
+						now: nativeLeaderOptions.now,
+						selfHash: nativeLeaderOptions.selfHash,
+						selfReplicating: nativeLeaderOptions.selfReplicating,
+						trimLengthTo: input.trimLengthTo,
+						resolveTrimmedEntries: properties?.resolveTrimmedEntries,
+					};
+					const nativeBackboneDocumentIndex =
+						properties?.nativeBackboneDocumentIndex ??
+						properties?.prepareNativeBackboneDocumentIndex?.({
+							wallTime: input.wallTime,
+							gid: input.gid,
+							payloadSize: input.payloadData.byteLength,
+						});
+					const nativeBackboneDocumentIndexForAppend =
+						nativeBackboneDocumentIndex &&
+						input.trimLengthTo == null &&
+						nativeBackboneDocumentIndex.deleteTrimmedHeads === true
+							? {
+									...nativeBackboneDocumentIndex,
+									deleteTrimmedHeads: false,
+								}
+							: nativeBackboneDocumentIndex;
+					const nativeBackboneDocumentDeleteKey =
+						properties?.nativeBackboneDocumentDeleteKey;
+					if (
+						nativeBackboneDocumentDeleteKey &&
+						nativeBackboneDocumentIndexForAppend
+					) {
+						throw new Error(
+							"Native backbone append cannot both put and delete a document index row",
+						);
+					}
+					const appendInputWithDocumentIndex =
+						nativeBackboneDocumentIndexForAppend
 							? {
 									...appendInput,
-									documentDeleteKey: nativeBackboneDocumentDeleteKey,
-								}
-							: appendInput;
-				nativeDocumentRollback = this.snapshotNativeBackboneDocument(
-					nativeBackboneDocumentIndexForAppend ??
-						(nativeBackboneDocumentDeleteKey
-							? { key: nativeBackboneDocumentDeleteKey }
-							: undefined),
-				);
-				nativeStrictTransaction =
-					await this.beginNativeStrictDurableTransaction(
-						nativeDocumentRollback ? [nativeDocumentRollback] : [],
-					);
-				if (next.length === 0) {
-					if (commitBlocksInBackbone) {
-						if (
-							nativeBackboneDocumentIndex &&
-							properties?.useNativeExistingDocumentContext === true
-						) {
-							backboneAppend =
-								backbone.preparePlainCommittedStorageAppendTransaction(
-									appendInputWithDocumentIndex,
-								);
-						} else if (
-							nativeBackboneDocumentIndex &&
-							properties?.resolveTrimmedEntries === false
-						) {
-							backboneAppend =
-								backbone.preparePlainCommittedNoNextStorageAppendDocumentIndexCompactTransaction(
-									{
-										...appendInput,
-										documentIndex: nativeBackboneDocumentIndexForAppend,
+									documentIndex: {
+										...nativeBackboneDocumentIndexForAppend,
+										useLatestContext:
+											properties?.useNativeExistingDocumentContext === true,
 									},
-								);
+								}
+							: nativeBackboneDocumentDeleteKey
+								? {
+										...appendInput,
+										documentDeleteKey: nativeBackboneDocumentDeleteKey,
+									}
+								: appendInput;
+					nativeDocumentRollback = this.snapshotNativeBackboneDocument(
+						nativeBackboneDocumentIndexForAppend ??
+							(nativeBackboneDocumentDeleteKey
+								? { key: nativeBackboneDocumentDeleteKey }
+								: undefined),
+					);
+					nativeStrictTransaction =
+						await this.beginNativeStrictDurableTransaction(
+							nativeDocumentRollback ? [nativeDocumentRollback] : [],
+						);
+					this.throwIfReplicationOwnershipPoisoned();
+					if (next.length === 0) {
+						if (commitBlocksInBackbone) {
+							if (
+								nativeBackboneDocumentIndex &&
+								properties?.useNativeExistingDocumentContext === true
+							) {
+								backboneAppend =
+									backbone.preparePlainCommittedStorageAppendTransaction(
+										appendInputWithDocumentIndex,
+									);
+							} else if (
+								nativeBackboneDocumentIndex &&
+								properties?.resolveTrimmedEntries === false
+							) {
+								backboneAppend =
+									backbone.preparePlainCommittedNoNextStorageAppendDocumentIndexCompactTransaction(
+										{
+											...appendInput,
+											documentIndex: nativeBackboneDocumentIndexForAppend,
+										},
+									);
+							} else {
+								backboneAppend =
+									backbone.preparePlainCommittedNoNextStorageAppendTransaction(
+										appendInputWithDocumentIndex,
+									);
+							}
 						} else {
 							backboneAppend =
-								backbone.preparePlainCommittedNoNextStorageAppendTransaction(
+								backbone.preparePlainNoNextStorageAppendTransaction(
 									appendInputWithDocumentIndex,
 								);
 						}
 					} else {
-						backboneAppend =
-							backbone.preparePlainNoNextStorageAppendTransaction(
-								appendInputWithDocumentIndex,
+						backboneAppend = commitBlocksInBackbone
+							? backbone.preparePlainCommittedStorageAppendTransaction(
+									appendInputWithDocumentIndex,
+								)
+							: backbone.preparePlainStorageAppendTransaction(
+									appendInputWithDocumentIndex,
+								);
+					}
+					if (nativeBackboneDocumentIndex) {
+						nativeBackboneDocumentIndexCommitted = true;
+					}
+					nativeBackboneDocumentDeleteCommitted =
+						!!nativeBackboneDocumentDeleteKey;
+					const useTrimmedHashesOnly =
+						properties?.resolveTrimmedEntries === false;
+					const nativeTrimmedHashes =
+						backboneAppend.trimmedHashes ??
+						backboneAppend.trimmed.map((entry) => entry.hash);
+					const committedHash =
+						backboneAppend.entry.cid ?? backboneAppend.entry.hash;
+					const committedNext = backboneAppend.entry.next ?? next;
+					nativeCoordinateRollback = this.snapshotResidentCoordinateEntries([
+						...(committedHash ? [committedHash] : []),
+						...committedNext,
+						...nativeTrimmedHashes,
+					]);
+					await this.setNativeStrictDurableTransactionOperation(
+						nativeStrictTransaction,
+						committedHash ? [committedHash] : [],
+						nativeTrimmedHashes,
+						nativeCoordinateRollback,
+						combineCoordinateDeleteHashes(committedNext, nativeTrimmedHashes),
+					);
+					const rollbackCommitted = async (
+						cause: unknown,
+						committedCids: string[],
+					): Promise<never> => {
+						durableWrapper?.cancelNativeDeleteCleanup?.(
+							nativeDeleteCleanupToken,
+						);
+						let compensated = false;
+						try {
+							await this.rollbackFailedNativeBackboneTransaction({
+								committedHashes: committedCids,
+								trimmedEntries: backboneAppend?.trimmed,
+								coordinateEntries: nativeCoordinateRollback,
+								documents: nativeDocumentRollback
+									? [nativeDocumentRollback]
+									: undefined,
+								durableWrapper,
+							});
+							compensated = true;
+						} catch {
+							// close/reopen completes recovery if durable compensation failed
+						}
+						if (compensated) {
+							await this.completeNativeStrictDurableTransaction(
+								nativeStrictTransaction,
+							);
+						} else {
+							this.releaseNativeStrictDurableTransaction(
+								nativeStrictTransaction,
+							);
+						}
+						return this.failNativeDurableCommit(cause, {
+							committedCids,
+							failedCids: committedCids,
+						});
+					};
+					if (
+						durableWrapper &&
+						commitBlocksInBackbone &&
+						nativeTrimmedHashes.length > 0 &&
+						!durableWrapper.beginNativeDeleteCleanup
+					) {
+						return rollbackCommitted(
+							new Error(
+								"Native durable block wrapper cannot preannounce trim cleanup",
+							),
+							committedHash ? [committedHash] : [],
+						);
+					}
+					nativeDeleteCleanupToken = commitBlocksInBackbone
+						? durableWrapper?.beginNativeDeleteCleanup?.(nativeTrimmedHashes)
+						: undefined;
+					const preparedResult = {
+						...backboneAppend.entry,
+						nativeIndexMutationLockOwner:
+							nativeStrictTransaction?.lowerHashMutationLockOwner,
+						gid: backboneAppend.coordinate.gid,
+						getBytes: commitBlocksInBackbone
+							? (hash: string) => backbone.blocks.get(hash)
+							: undefined,
+						trimmedEntries: useTrimmedHashesOnly
+							? undefined
+							: backboneAppend.trimmed,
+						trimmedEntryHashes: useTrimmedHashesOnly
+							? backboneAppend.trimmedHashes
+							: undefined,
+						nativeBlocksDeleted: commitBlocksInBackbone,
+						nativeDeleteCleanupToken,
+						documentPreviousContext: backboneAppend.documentPreviousContext,
+					};
+					if (durableWrapper?.mirrorToDurable) {
+						// The block was committed into the wasm map (commitBlocksInBackbone is
+						// true) but not into durable, because the log's finishBlocks path is
+						// left UNCHANGED for strict-native mode (getBytes only, no bytes, so
+						// no putKnown* through the wrapper). Returning the promise here prevents
+						// lower-log index/head/trim publication until the mirror settles.
+						if (!committedHash) {
+							durableWrapper.cancelNativeDeleteCleanup?.(
+								nativeDeleteCleanupToken,
+							);
+							return rollbackCommitted(
+								new Error("Native commit returned no entry CID to mirror"),
+								[],
+							);
+						}
+						const committedBytes =
+							backboneAppend.entry.bytes ?? backbone.blocks.get(committedHash);
+						if (!committedBytes) {
+							durableWrapper.cancelNativeDeleteCleanup?.(
+								nativeDeleteCleanupToken,
+							);
+							return rollbackCommitted(
+								new Error(
+									`Native committed block ${committedHash} is missing from the hot store`,
+								),
+								[committedHash],
+							);
+						}
+						return durableWrapper
+							.mirrorToDurable(committedHash, committedBytes, {
+								nativeTrimmed: nativeTrimmedHashes.includes(committedHash),
+							})
+							.then(
+								(nativeCommitOwnershipToken) => ({
+									...preparedResult,
+									nativeCommitOwnershipToken,
+								}),
+								(error) => {
+									durableWrapper.cancelNativeDeleteCleanup?.(
+										nativeDeleteCleanupToken,
+									);
+									return rollbackCommitted(error, [committedHash]);
+								},
 							);
 					}
-				} else {
-					backboneAppend = commitBlocksInBackbone
-						? backbone.preparePlainCommittedStorageAppendTransaction(
-								appendInputWithDocumentIndex,
-							)
-						: backbone.preparePlainStorageAppendTransaction(
-								appendInputWithDocumentIndex,
-							);
-				}
-				if (nativeBackboneDocumentIndex) {
-					nativeBackboneDocumentIndexCommitted = true;
-				}
-				nativeBackboneDocumentDeleteCommitted =
-					!!nativeBackboneDocumentDeleteKey;
-				const useTrimmedHashesOnly =
-					properties?.resolveTrimmedEntries === false;
-				const nativeTrimmedHashes =
-					backboneAppend.trimmedHashes ??
-					backboneAppend.trimmed.map((entry) => entry.hash);
-				const committedHash =
-					backboneAppend.entry.cid ?? backboneAppend.entry.hash;
-				const committedNext = backboneAppend.entry.next ?? next;
-				nativeCoordinateRollback = this.snapshotResidentCoordinateEntries([
-					...(committedHash ? [committedHash] : []),
-					...committedNext,
-					...nativeTrimmedHashes,
-				]);
-				await this.setNativeStrictDurableTransactionOperation(
-					nativeStrictTransaction,
-					committedHash ? [committedHash] : [],
-					nativeTrimmedHashes,
-					nativeCoordinateRollback,
-					combineCoordinateDeleteHashes(committedNext, nativeTrimmedHashes),
-				);
-				const rollbackCommitted = async (
-					cause: unknown,
-					committedCids: string[],
+					if (durableWrapper) {
+						durableWrapper.cancelNativeDeleteCleanup?.(
+							nativeDeleteCleanupToken,
+						);
+						return rollbackCommitted(
+							new Error("Native durable block wrapper has no mirror method"),
+							committedHash ? [committedHash] : [],
+						);
+					}
+					return preparedResult;
+				};
+				const hasKnownNoNext =
+					appendOptions.meta?.next != null &&
+					appendOptions.meta.next.length === 0;
+				const appendGenericNativeCommit = () =>
+					asTrustedLowerLog(this.log).appendLocallyPreparedNativeCommitOnly(
+						undefined as T,
+						appendOptions,
+						{
+							payloadData,
+							resolveTrimmedEntries: properties?.resolveTrimmedEntries,
+							skipMissingNextJoin: properties?.skipMissingNextJoin,
+							retainMaterializationBytes: this._logProperties?.trim != null,
+							deferNativeTransactionAcknowledgement: true,
+						},
+						prepareBackboneAppend,
+					);
+				const rollbackLowerPublication = async (
+					error: unknown,
 				): Promise<never> => {
 					durableWrapper?.cancelNativeDeleteCleanup?.(nativeDeleteCleanupToken);
-					let compensated = false;
-					try {
-						await this.rollbackFailedNativeBackboneTransaction({
-							committedHashes: committedCids,
-							trimmedEntries: backboneAppend?.trimmed,
-							coordinateEntries: nativeCoordinateRollback,
-							documents: nativeDocumentRollback
-								? [nativeDocumentRollback]
-								: undefined,
-							durableWrapper,
-						});
-						compensated = true;
-					} catch {
-						// close/reopen completes recovery if durable compensation failed
+					let compensated = !backboneAppend;
+					if (backboneAppend && !(error instanceof NativeDurableCommitError)) {
+						const committedHash =
+							backboneAppend.entry.cid ?? backboneAppend.entry.hash;
+						try {
+							await this.rollbackFailedNativeBackboneTransaction({
+								committedHashes: committedHash ? [committedHash] : [],
+								coordinateEntries: nativeCoordinateRollback,
+								documents: nativeDocumentRollback
+									? [nativeDocumentRollback]
+									: undefined,
+								skipBlockCompensation: true,
+								restoreGraphFromIndex: true,
+							});
+							compensated = true;
+						} catch {
+							// Lower-log compensation already handled durable/native blocks.
+							// Preserve the index publication error for this caller.
+						}
 					}
 					if (compensated) {
 						await this.completeNativeStrictDurableTransaction(
@@ -11126,384 +12853,246 @@ export class SharedLog<
 					} else {
 						this.releaseNativeStrictDurableTransaction(nativeStrictTransaction);
 					}
-					return this.failNativeDurableCommit(cause, {
-						committedCids,
-						failedCids: committedCids,
-					});
+					throw error;
 				};
-				if (
-					durableWrapper &&
-					commitBlocksInBackbone &&
-					nativeTrimmedHashes.length > 0 &&
-					!durableWrapper.beginNativeDeleteCleanup
-				) {
-					return rollbackCommitted(
-						new Error(
-							"Native durable block wrapper cannot preannounce trim cleanup",
-						),
-						committedHash ? [committedHash] : [],
-					);
-				}
-				nativeDeleteCleanupToken = commitBlocksInBackbone
-					? durableWrapper?.beginNativeDeleteCleanup?.(nativeTrimmedHashes)
-					: undefined;
-				const preparedResult = {
-					...backboneAppend.entry,
-					nativeIndexMutationLockOwner:
-						nativeStrictTransaction?.lowerHashMutationLockOwner,
-					gid: backboneAppend.coordinate.gid,
-					getBytes: commitBlocksInBackbone
-						? (hash: string) => backbone.blocks.get(hash)
-						: undefined,
-					trimmedEntries: useTrimmedHashesOnly
-						? undefined
-						: backboneAppend.trimmed,
-					trimmedEntryHashes: useTrimmedHashesOnly
-						? backboneAppend.trimmedHashes
-						: undefined,
-					nativeBlocksDeleted: commitBlocksInBackbone,
-					nativeDeleteCleanupToken,
-					documentPreviousContext: backboneAppend.documentPreviousContext,
-				};
-				if (durableWrapper?.mirrorToDurable) {
-					// The block was committed into the wasm map (commitBlocksInBackbone is
-					// true) but not into durable, because the log's finishBlocks path is
-					// left UNCHANGED for strict-native mode (getBytes only, no bytes, so
-					// no putKnown* through the wrapper). Returning the promise here prevents
-					// lower-log index/head/trim publication until the mirror settles.
-					if (!committedHash) {
-						durableWrapper.cancelNativeDeleteCleanup?.(
-							nativeDeleteCleanupToken,
-						);
-						return rollbackCommitted(
-							new Error("Native commit returned no entry CID to mirror"),
-							[],
-						);
-					}
-					const committedBytes =
-						backboneAppend.entry.bytes ?? backbone.blocks.get(committedHash);
-					if (!committedBytes) {
-						durableWrapper.cancelNativeDeleteCleanup?.(
-							nativeDeleteCleanupToken,
-						);
-						return rollbackCommitted(
-							new Error(
-								`Native committed block ${committedHash} is missing from the hot store`,
-							),
-							[committedHash],
-						);
-					}
-					return durableWrapper
-						.mirrorToDurable(committedHash, committedBytes, {
-							nativeTrimmed: nativeTrimmedHashes.includes(committedHash),
-						})
-						.then(
-							(nativeCommitOwnershipToken) => ({
-								...preparedResult,
-								nativeCommitOwnershipToken,
-							}),
-							(error) => {
-								durableWrapper.cancelNativeDeleteCleanup?.(
-									nativeDeleteCleanupToken,
-								);
-								return rollbackCommitted(error, [committedHash]);
-							},
-						);
-				}
-				if (durableWrapper) {
-					durableWrapper.cancelNativeDeleteCleanup?.(nativeDeleteCleanupToken);
-					return rollbackCommitted(
-						new Error("Native durable block wrapper has no mirror method"),
-						committedHash ? [committedHash] : [],
-					);
-				}
-				return preparedResult;
-			};
-			const hasKnownNoNext =
-				appendOptions.meta?.next != null &&
-				appendOptions.meta.next.length === 0;
-			const appendGenericNativeCommit = () =>
-				asTrustedLowerLog(this.log).appendLocallyPreparedNativeCommitOnly(
-					undefined as T,
-					appendOptions,
-					{
-						payloadData,
-						resolveTrimmedEntries: properties?.resolveTrimmedEntries,
-						skipMissingNextJoin: properties?.skipMissingNextJoin,
-						retainMaterializationBytes: this._logProperties?.trim != null,
-						deferNativeTransactionAcknowledgement: true,
-					},
-					prepareBackboneAppend,
-				);
-			const rollbackLowerPublication = async (
-				error: unknown,
-			): Promise<never> => {
-				durableWrapper?.cancelNativeDeleteCleanup?.(nativeDeleteCleanupToken);
-				let compensated = !backboneAppend;
-				if (backboneAppend && !(error instanceof NativeDurableCommitError)) {
-					const committedHash =
-						backboneAppend.entry.cid ?? backboneAppend.entry.hash;
-					try {
-						await this.rollbackFailedNativeBackboneTransaction({
-							committedHashes: committedHash ? [committedHash] : [],
-							coordinateEntries: nativeCoordinateRollback,
-							documents: nativeDocumentRollback
-								? [nativeDocumentRollback]
-								: undefined,
-							skipBlockCompensation: true,
-							restoreGraphFromIndex: true,
-						});
-						compensated = true;
-					} catch {
-						// Lower-log compensation already handled durable/native blocks.
-						// Preserve the index publication error for this caller.
-					}
-				}
-				if (compensated) {
-					await this.completeNativeStrictDurableTransaction(
-						nativeStrictTransaction,
-					);
-				} else {
-					this.releaseNativeStrictDurableTransaction(nativeStrictTransaction);
-				}
-				throw error;
-			};
-			let result: MaybePromise<
-				TrustedLowerLogCommitOnlyAppendResult<T> | undefined
-			>;
-			try {
-				const directNoNextResult = hasKnownNoNext
-					? asTrustedLowerLog(
-							this.log,
-						).appendLocallyPreparedNativeKnownNoNextCommitOnly(
-							undefined as T,
-							appendOptions,
-							{
-								payloadData,
-								resolveTrimmedEntries: properties?.resolveTrimmedEntries,
-								retainMaterializationBytes: this._logProperties?.trim != null,
-								deferNativeTransactionAcknowledgement: true,
-							},
-							prepareBackboneAppend,
-						)
-					: undefined;
-				result =
-					directNoNextResult === undefined
-						? appendGenericNativeCommit()
-						: directNoNextResult;
-				if (isPromiseLike(result)) {
-					result = result.catch(rollbackLowerPublication);
-				}
-			} catch (error) {
-				return rollbackLowerPublication(error);
-			}
-			return mapMaybePromise(result, async (prepared) => {
-				if (!prepared || !backboneAppend) {
-					await this.completeNativeStrictDurableTransaction(
-						nativeStrictTransaction,
-					);
-					return undefined;
-				}
-				const coordinateFields = this.createCoordinateFieldsFromNativePlanFacts(
-					{
-						appendFacts: prepared.appendFacts,
-						plan: backboneAppend.coordinate,
-					},
-				);
-				if (!coordinateFields) {
-					throw new Error(
-						"Native backbone append transaction returned mismatched coordinate facts",
-					);
-				}
-				let preparedCoordinate: PreparedCoordinatePersistence<R> | undefined;
-				const getPreparedCoordinate = (): PreparedCoordinatePersistence<R> =>
-					(preparedCoordinate ??= {
-						assignedToRangeBoundary: coordinateFields.assignedToRangeBoundary,
-						fields: coordinateFields,
-					});
-				const plannedCoordinateDeleteHashes = combineCoordinateDeleteHashes(
-					prepared.appendFacts.next,
-					prepared.removedHashes ?? prepared.removed.map((entry) => entry.hash),
-				);
-				const rollbackCoordinateEntries =
-					nativeCoordinateRollback ??
-					this.snapshotResidentCoordinateEntries([
-						prepared.appendFacts.hash,
-						...plannedCoordinateDeleteHashes,
-					]);
-				const finish = (): PreparedPayloadCommitOnlyResult<T, R> => {
-					const appendCommit = this.createPreparedLocalAppendCommitFromFacts(
-						prepared.appendFacts,
-						{
-							hashNumber: backboneAppend!.coordinate
-								.hashNumber as NumberFromType<R>,
-							coordinateFields,
-						},
-					);
-					if (nativeBackboneDocumentIndexCommitted) {
-						appendCommit.nativeBackboneDocumentIndexCommitted = true;
-						appendCommit.nativeBackboneDocumentIndexTrimmedHeadsProcessed =
-							backboneAppend!.documentTrimmedHeadsProcessed;
-					}
-					if (nativeBackboneDocumentDeleteCommitted) {
-						appendCommit.nativeBackboneDocumentDeleteCommitted = true;
-						appendCommit.nativeBackboneDocumentIndexCommitted = true;
-					}
-					appendCommit.documentPreviousContext =
-						prepared.documentPreviousContext;
-					return {
-						get entry() {
-							return prepared.entry;
-						},
-						removed: prepared.removed,
-						removedHashes: prepared.removedHashes,
-						appendCommit,
-					};
-				};
-				const coordinateIndex = this.entryCoordinatesIndex as PutAndDeleteIndex<
-					EntryReplicated<R>
+				let result: MaybePromise<
+					TrustedLowerLogCommitOnlyAppendResult<T> | undefined
 				>;
-				const rollback = async (error: unknown): Promise<never> => {
-					const rollbackFailures: unknown[] = [];
-					try {
-						await this.markNativeStrictDurableTransactionRollback(
+				try {
+					const directNoNextResult = hasKnownNoNext
+						? asTrustedLowerLog(
+								this.log,
+							).appendLocallyPreparedNativeKnownNoNextCommitOnly(
+								undefined as T,
+								appendOptions,
+								{
+									payloadData,
+									resolveTrimmedEntries: properties?.resolveTrimmedEntries,
+									retainMaterializationBytes: this._logProperties?.trim != null,
+									deferNativeTransactionAcknowledgement: true,
+								},
+								prepareBackboneAppend,
+							)
+						: undefined;
+					result =
+						directNoNextResult === undefined
+							? appendGenericNativeCommit()
+							: directNoNextResult;
+					if (isPromiseLike(result)) {
+						result = result.catch(rollbackLowerPublication);
+					}
+				} catch (error) {
+					return rollbackLowerPublication(error);
+				}
+				return mapMaybePromise(result, async (prepared) => {
+					if (!prepared || !backboneAppend) {
+						await this.completeNativeStrictDurableTransaction(
 							nativeStrictTransaction,
 						);
-					} catch (rollbackError) {
-						const retentionFailures =
-							this.retainNativeStrictDurableTransactionAfterMarkerFailure(
-								nativeStrictTransaction,
-								prepared.nativeCommittedAppendFinalizer,
-								rollbackError,
-							);
-						throw new AggregateError(
-							[error, ...retentionFailures],
-							"Native rollback marker could not be persisted; recovery is required",
+						return undefined;
+					}
+					const coordinateFields =
+						this.createCoordinateFieldsFromNativePlanFacts({
+							appendFacts: prepared.appendFacts,
+							plan: backboneAppend.coordinate,
+						});
+					if (!coordinateFields) {
+						throw new Error(
+							"Native backbone append transaction returned mismatched coordinate facts",
 						);
 					}
-					try {
-						await prepared.nativeCommittedAppendFinalizer?.rollback();
-					} catch (rollbackError) {
-						rollbackFailures.push(rollbackError);
-					}
-					try {
-						await this.rollbackNativeBackboneCoordinateAppendDurably(
+					let preparedCoordinate: PreparedCoordinatePersistence<R> | undefined;
+					const getPreparedCoordinate = (): PreparedCoordinatePersistence<R> =>
+						(preparedCoordinate ??= {
+							assignedToRangeBoundary: coordinateFields.assignedToRangeBoundary,
+							fields: coordinateFields,
+						});
+					const plannedCoordinateDeleteHashes = combineCoordinateDeleteHashes(
+						prepared.appendFacts.next,
+						prepared.removedHashes ??
+							prepared.removed.map((entry) => entry.hash),
+					);
+					const rollbackCoordinateEntries =
+						nativeCoordinateRollback ??
+						this.snapshotResidentCoordinateEntries([
 							prepared.appendFacts.hash,
-							rollbackCoordinateEntries,
+							...plannedCoordinateDeleteHashes,
+						]);
+					const finish = (): PreparedPayloadCommitOnlyResult<T, R> => {
+						const appendCommit = this.createPreparedLocalAppendCommitFromFacts(
+							prepared.appendFacts,
+							{
+								hashNumber: backboneAppend!.coordinate
+									.hashNumber as NumberFromType<R>,
+								coordinateFields,
+							},
 						);
-					} catch (rollbackError) {
-						rollbackFailures.push(rollbackError);
-					}
-					if (nativeDocumentRollback) {
+						if (nativeBackboneDocumentIndexCommitted) {
+							appendCommit.nativeBackboneDocumentIndexCommitted = true;
+							appendCommit.nativeBackboneDocumentIndexTrimmedHeadsProcessed =
+								backboneAppend!.documentTrimmedHeadsProcessed;
+						}
+						if (nativeBackboneDocumentDeleteCommitted) {
+							appendCommit.nativeBackboneDocumentDeleteCommitted = true;
+							appendCommit.nativeBackboneDocumentIndexCommitted = true;
+						}
+						appendCommit.documentPreviousContext =
+							prepared.documentPreviousContext;
+						return {
+							get entry() {
+								return prepared.entry;
+							},
+							removed: prepared.removed,
+							removedHashes: prepared.removedHashes,
+							appendCommit,
+						};
+					};
+					const coordinateIndex = this
+						.entryCoordinatesIndex as PutAndDeleteIndex<EntryReplicated<R>>;
+					const rollback = async (error: unknown): Promise<never> => {
+						const rollbackFailures: unknown[] = [];
 						try {
-							this.restoreNativeBackboneDocument(nativeDocumentRollback);
-							const flushed = this.flushNativeBackboneCoordinateJournal();
-							if (isPromiseLike(flushed)) {
-								await flushed;
-							}
+							await this.markNativeStrictDurableTransactionRollback(
+								nativeStrictTransaction,
+							);
+						} catch (rollbackError) {
+							const retentionFailures =
+								this.retainNativeStrictDurableTransactionAfterMarkerFailure(
+									nativeStrictTransaction,
+									prepared.nativeCommittedAppendFinalizer,
+									rollbackError,
+								);
+							throw new AggregateError(
+								[error, ...retentionFailures],
+								"Native rollback marker could not be persisted; recovery is required",
+							);
+						}
+						try {
+							await prepared.nativeCommittedAppendFinalizer?.rollback();
 						} catch (rollbackError) {
 							rollbackFailures.push(rollbackError);
 						}
-					}
-					if (rollbackFailures.length > 0) {
-						this.releaseNativeStrictDurableTransaction(nativeStrictTransaction);
-						throw new AggregateError(
-							[error, ...rollbackFailures],
-							"Shared-log append and compensation both failed",
-						);
-					}
-					await this.completeNativeStrictDurableTransaction(
-						nativeStrictTransaction,
-					);
-					throw error;
-				};
-				try {
-					await this.setNativeStrictDurableTransactionExpectedRows(
-						nativeStrictTransaction,
-						[prepared.shallowEntry],
-					);
-					const hasNativeCoordinatePut =
-						this.canUseBackboneOnlyCoordinatePersistence() ||
-						coordinateIndex.putSharedLogCoordinateFieldsEncodedAndDeleteHashesNoReturn ||
-						coordinateIndex.putSharedLogCoordinateFieldsAndDeleteHashesNoReturn;
-					const persisted = hasNativeCoordinatePut
-						? this.persistBackboneCoordinateFieldsNativeTransaction({
-								coordinateIndex,
-								fields: coordinateFields,
-								hash: prepared.appendFacts.hash,
-								deleteHashes: [],
-								coordinates: backboneAppend.coordinate
-									.coordinates as NumberFromType<R>[],
-								skipGenericTransientCoordinateIndex: runtimeOnlyCoordinates,
-							})
-						: this.persistPreparedCoordinate({
-								prepared: getPreparedCoordinate(),
-								hash: prepared.appendFacts.hash,
-								nextHashes: [],
-								deleteHashes: [],
-								coordinates: backboneAppend.coordinate
-									.coordinates as NumberFromType<R>[],
-								replicas: backboneAppend.coordinate.coordinates.length,
-								commitNative: true,
-								commitNativeBackbone: false,
-							});
-					if (isPromiseLike(persisted)) {
-						await persisted;
-					}
-					if (!prepared.nativeCommittedAppendFinalizer) {
-						throw new Error("Missing deferred native append finalizer");
-					}
-					await this.flushNativeBackboneCoordinateJournal();
-					await prepared.nativeCommittedAppendFinalizer.acknowledge(() =>
-						this.markNativeStrictDurableTransactionLowerMarker(
+						try {
+							await this.rollbackNativeBackboneCoordinateAppendDurably(
+								prepared.appendFacts.hash,
+								rollbackCoordinateEntries,
+							);
+						} catch (rollbackError) {
+							rollbackFailures.push(rollbackError);
+						}
+						if (nativeDocumentRollback) {
+							try {
+								this.restoreNativeBackboneDocument(nativeDocumentRollback);
+								const flushed = this.flushNativeBackboneCoordinateJournal();
+								if (isPromiseLike(flushed)) {
+									await flushed;
+								}
+							} catch (rollbackError) {
+								rollbackFailures.push(rollbackError);
+							}
+						}
+						if (rollbackFailures.length > 0) {
+							this.releaseNativeStrictDurableTransaction(
+								nativeStrictTransaction,
+							);
+							throw new AggregateError(
+								[error, ...rollbackFailures],
+								"Shared-log append and compensation both failed",
+							);
+						}
+						await this.completeNativeStrictDurableTransaction(
 							nativeStrictTransaction,
-						),
-					);
-				} catch (error) {
-					return rollback(error);
-				}
-				this.applyPreparedAppendFactsWithDeferredCoordinateDeletes(
-					prepared.appendFacts,
-					prepared.removed,
-					prepared.materializeEntry,
-					{
-						forgetNativeCoordinates: false,
-						removedHashes: prepared.removedHashes,
-					},
-				);
-				try {
-					await this.completeNativeStrictDurableTransaction(
-						nativeStrictTransaction,
-					);
-				} catch (error) {
-					warn(`Failed to retire committed native intent: ${String(error)}`);
-				}
-				if (
-					commitBlocksInBackbone &&
-					!runtimeOnlyCoordinates &&
-					this.remoteBlocks.hasNotifyStoredHook()
-				) {
-					this.remoteBlocks.notifyStoredDeferred(prepared.appendFacts.hash);
-				}
-				const delayAdaptiveRebalance = this.shouldDelayAdaptiveRebalance();
-				if (!backboneAppend.isLeader && !delayAdaptiveRebalance) {
-					const leaders = backboneAppend.leaders;
-					if (leaders) {
-						const pruneEntry = this.materializePreparedCoordinateEntry(
-							getPreparedCoordinate(),
 						);
-						this.pruneDebouncedFnAddIfNotKeeping({
-							key: pruneEntry.hash,
-							value: { entry: pruneEntry, leaders },
-						});
+						throw error;
+					};
+					try {
+						await this.setNativeStrictDurableTransactionExpectedRows(
+							nativeStrictTransaction,
+							[prepared.shallowEntry],
+						);
+						const hasNativeCoordinatePut =
+							this.canUseBackboneOnlyCoordinatePersistence() ||
+							coordinateIndex.putSharedLogCoordinateFieldsEncodedAndDeleteHashesNoReturn ||
+							coordinateIndex.putSharedLogCoordinateFieldsAndDeleteHashesNoReturn;
+						const persisted = hasNativeCoordinatePut
+							? this.persistBackboneCoordinateFieldsNativeTransaction({
+									coordinateIndex,
+									fields: coordinateFields,
+									hash: prepared.appendFacts.hash,
+									deleteHashes: [],
+									coordinates: backboneAppend.coordinate
+										.coordinates as NumberFromType<R>[],
+									skipGenericTransientCoordinateIndex: runtimeOnlyCoordinates,
+								})
+							: this.persistPreparedCoordinate({
+									prepared: getPreparedCoordinate(),
+									hash: prepared.appendFacts.hash,
+									nextHashes: [],
+									deleteHashes: [],
+									coordinates: backboneAppend.coordinate
+										.coordinates as NumberFromType<R>[],
+									replicas: backboneAppend.coordinate.coordinates.length,
+									commitNative: true,
+									commitNativeBackbone: false,
+								});
+						if (isPromiseLike(persisted)) {
+							await persisted;
+						}
+						if (!prepared.nativeCommittedAppendFinalizer) {
+							throw new Error("Missing deferred native append finalizer");
+						}
+						await this.flushNativeBackboneCoordinateJournal();
+						await prepared.nativeCommittedAppendFinalizer.acknowledge(() =>
+							this.markNativeStrictDurableTransactionLowerMarker(
+								nativeStrictTransaction,
+							),
+						);
+					} catch (error) {
+						return rollback(error);
 					}
-				}
-				if (!delayAdaptiveRebalance) {
-					this.rebalanceParticipationDebounced?.call();
-				}
-				return finish();
-			});
-		});
+					this.applyPreparedAppendFactsWithDeferredCoordinateDeletes(
+						prepared.appendFacts,
+						prepared.removed,
+						prepared.materializeEntry,
+						{
+							forgetNativeCoordinates: false,
+							removedHashes: prepared.removedHashes,
+						},
+					);
+					try {
+						await this.completeNativeStrictDurableTransaction(
+							nativeStrictTransaction,
+						);
+					} catch (error) {
+						warn(`Failed to retire committed native intent: ${String(error)}`);
+					}
+					if (
+						commitBlocksInBackbone &&
+						!runtimeOnlyCoordinates &&
+						this.remoteBlocks.hasNotifyStoredHook()
+					) {
+						this.remoteBlocks.notifyStoredDeferred(prepared.appendFacts.hash);
+					}
+					const delayAdaptiveRebalance = this.shouldDelayAdaptiveRebalance();
+					if (!backboneAppend.isLeader && !delayAdaptiveRebalance) {
+						const leaders = backboneAppend.leaders;
+						if (leaders) {
+							const pruneEntry = this.materializePreparedCoordinateEntry(
+								getPreparedCoordinate(),
+							);
+							this.pruneDebouncedFnAddIfNotKeeping({
+								key: pruneEntry.hash,
+								value: { entry: pruneEntry, leaders },
+							});
+						}
+					}
+					if (!delayAdaptiveRebalance) {
+						this.rebalanceParticipationDebounced?.call();
+					}
+					return finish();
+				});
+			},
+		);
 	}
 
 	private finishPreparedPayloadCommitOnlyAppend(
@@ -11518,7 +13107,11 @@ export class SharedLog<
 			| undefined,
 		options: SharedAppendOptions<T> | undefined,
 		minReplicasValue: number,
+		ownershipLifecycleController: AbortController,
 	): MaybePromise<PreparedPayloadCommitOnlyResult<T, R> | undefined> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		if (!result) {
 			return undefined;
 		}
@@ -11529,7 +13122,10 @@ export class SharedLog<
 					result.appendFacts,
 					result.removed,
 					result.materializeEntry,
-					{ removedHashes: result.removedHashes },
+					{
+						removedHashes: result.removedHashes,
+						ownershipLifecycleController,
+					},
 				);
 			const deleteHashes =
 				deferredCoordinateDeleteHashes &&
@@ -11543,17 +13139,25 @@ export class SharedLog<
 					: result.appendFacts.next;
 			if (deleteHashes.length > 0) {
 				return mapMaybePromise(
-					this.deleteCoordinatesForHashes(deleteHashes),
-					() => ({
-						get entry() {
-							return result.entry;
-						},
-						removed: result.removed,
-						removedHashes: result.removedHashes,
-						appendCommit: this.createPreparedLocalAppendCommitFromFacts(
-							result.appendFacts,
-						),
-					}),
+					this.deleteCoordinatesForHashes(
+						deleteHashes,
+						ownershipLifecycleController,
+					),
+					() => {
+						this.throwIfReplicationOwnershipLifecycleInactive(
+							ownershipLifecycleController,
+						);
+						return {
+							get entry() {
+								return result.entry;
+							},
+							removed: result.removed,
+							removedHashes: result.removedHashes,
+							appendCommit: this.createPreparedLocalAppendCommitFromFacts(
+								result.appendFacts,
+							),
+						};
+					},
 				);
 			}
 			return {
@@ -11572,6 +13176,7 @@ export class SharedLog<
 			result,
 			options,
 			minReplicasValue,
+			ownershipLifecycleController,
 		);
 		if (nativeTransaction) {
 			return nativeTransaction;
@@ -11581,6 +13186,7 @@ export class SharedLog<
 			result,
 			options,
 			minReplicasValue,
+			ownershipLifecycleController,
 		);
 	}
 
@@ -11594,7 +13200,11 @@ export class SharedLog<
 		},
 		options: SharedAppendOptions<T> | undefined,
 		minReplicasValue: number,
+		ownershipLifecycleController: AbortController,
 	): MaybePromise<PreparedPayloadCommitOnlyResult<T, R> | undefined> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const coordinateIndex = this.getNativeTransactionCoordinateIndex(
 			result,
 			options,
@@ -11606,6 +13216,7 @@ export class SharedLog<
 			result,
 			minReplicasValue,
 			coordinateIndex,
+			ownershipLifecycleController,
 		);
 	}
 
@@ -11641,12 +13252,17 @@ export class SharedLog<
 		},
 		minReplicasValue: number,
 		coordinateIndex: PutAndDeleteIndex<EntryReplicated<R>>,
+		ownershipLifecycleController: AbortController,
 	): Promise<PreparedPayloadCommitOnlyResult<T, R> | undefined> {
 		const nativePreparedCommit =
 			await this.processNativePreparedTargetNoneAppendTransaction(result, {
 				minReplicasValue,
 				coordinateIndex,
+				ownershipLifecycleController,
 			});
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		if (!nativePreparedCommit) {
 			return undefined;
 		}
@@ -11673,8 +13289,14 @@ export class SharedLog<
 		properties: {
 			minReplicasValue: number;
 			coordinateIndex: PutAndDeleteIndex<EntryReplicated<R>>;
+			ownershipLifecycleController: AbortController;
 		},
 	): Promise<PreparedLocalAppendCommit<R> | undefined> {
+		const ownershipLifecycleController =
+			properties.ownershipLifecycleController;
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const plannedCoordinateDeleteHashes =
 			result.change?.removed.map((entry) => entry.hash) ??
 			result.removed.map((entry) => entry.hash);
@@ -11687,6 +13309,10 @@ export class SharedLog<
 						? plannedCoordinateDeleteHashes
 						: undefined,
 			},
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
 		);
 		if (!nativeAppendPlan) {
 			return undefined;
@@ -11698,6 +13324,7 @@ export class SharedLog<
 				? this.applyChangeWithDeferredCoordinateDeletes(result.change, {
 						forgetNativeCoordinates:
 							!nativeAppendPlan.committedNativeCoordinateDeletes,
+						ownershipLifecycleController,
 					})
 				: this.applyPreparedAppendFactsWithDeferredCoordinateDeletes(
 						result.appendFacts,
@@ -11707,22 +13334,33 @@ export class SharedLog<
 							forgetNativeCoordinates:
 								!nativeAppendPlan.committedNativeCoordinateDeletes,
 							removedHashes: result.removedHashes,
+							ownershipLifecycleController,
 						},
 					);
-			await this.persistPreparedCoordinateNativeTransaction({
-				coordinateIndex: properties.coordinateIndex,
-				prepared: nativeAppendPlan.preparedCoordinate,
-				hash: result.appendFacts.hash,
-				nextHashes: result.appendFacts.next,
-				deleteHashes: deferredCoordinateDeleteHashes,
-				coordinates: nativeAppendPlan.coordinates,
-				commitNative: nativeAppendPlan.committedNativeCoordinateState !== true,
-				commitNativeBackbone:
-					nativeAppendPlan.committedNativeBackboneCoordinateState !== true,
-			});
+			await this.persistPreparedCoordinateNativeTransaction(
+				{
+					coordinateIndex: properties.coordinateIndex,
+					prepared: nativeAppendPlan.preparedCoordinate,
+					hash: result.appendFacts.hash,
+					nextHashes: result.appendFacts.next,
+					deleteHashes: deferredCoordinateDeleteHashes,
+					coordinates: nativeAppendPlan.coordinates,
+					commitNative:
+						nativeAppendPlan.committedNativeCoordinateState !== true,
+					commitNativeBackbone:
+						nativeAppendPlan.committedNativeBackboneCoordinateState !== true,
+				},
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		} catch (error) {
 			if (deferredCoordinateDeleteHashes) {
-				await this.deleteCoordinatesForHashes(deferredCoordinateDeleteHashes);
+				await this.deleteCoordinatesForHashes(
+					deferredCoordinateDeleteHashes,
+					ownershipLifecycleController,
+				);
 			}
 			throw error;
 		}
@@ -11736,18 +13374,32 @@ export class SharedLog<
 					nativeAppendPlan.preparedCoordinate,
 				);
 				leaders = (
-					await this.planEntryLeaders(pruneEntry, properties.minReplicasValue, {
-						persist: false,
-					})
+					await this.planEntryLeaders(
+						pruneEntry,
+						properties.minReplicasValue,
+						{
+							persist: false,
+						},
+						ownershipLifecycleController,
+					)
 				).leaders;
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
 			}
 			pruneEntry ??= this.materializePreparedCoordinateEntry(
 				nativeAppendPlan.preparedCoordinate,
 			);
-			this.pruneDebouncedFnAddIfNotKeeping({
-				key: pruneEntry.hash,
-				value: { entry: pruneEntry, leaders },
-			});
+			await this.pruneDebouncedFnAddIfNotKeeping(
+				{
+					key: pruneEntry.hash,
+					value: { entry: pruneEntry, leaders },
+				},
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		}
 		if (!delayAdaptiveRebalance) {
 			this.rebalanceParticipationDebounced?.call();
@@ -11768,11 +13420,16 @@ export class SharedLog<
 		},
 		options: SharedAppendOptions<T> | undefined,
 		minReplicasValue: number,
+		ownershipLifecycleController: AbortController,
 	): Promise<PreparedPayloadCommitOnlyResult<T, R>> {
 		const nativePreparedCommit =
 			await this.processNativePreparedTargetNoneAppend(result, options, {
 				minReplicasValue,
+				ownershipLifecycleController,
 			});
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		if (nativePreparedCommit) {
 			return {
 				get entry() {
@@ -11791,22 +13448,39 @@ export class SharedLog<
 					result.appendFacts,
 					result.removed,
 					result.materializeEntry,
-					{ removedHashes: result.removedHashes },
+					{
+						removedHashes: result.removedHashes,
+						ownershipLifecycleController,
+					},
 				);
 			nativeAppendPlan = await this.planNativeLocalAppendFacts(
 				result.appendFacts,
 				minReplicasValue,
+				undefined,
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
 			);
 			if (!nativeAppendPlan) {
 				if (deferredCoordinateDeleteHashes) {
-					await this.deleteCoordinatesForHashes(deferredCoordinateDeleteHashes);
+					await this.deleteCoordinatesForHashes(
+						deferredCoordinateDeleteHashes,
+						ownershipLifecycleController,
+					);
 				}
 				deferredCoordinateDeleteHashes = undefined;
 			}
 		} else {
 			this.onEntryAddedHash(result.appendFacts.hash, result.materializeEntry);
 			if (result.removed.length > 0) {
-				await this.applyRemovedChange(result.removed);
+				await this.applyRemovedChange(
+					result.removed,
+					ownershipLifecycleController,
+				);
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
 			}
 		}
 		const entry = result.entry;
@@ -11817,13 +13491,20 @@ export class SharedLog<
 					appendFacts: result.appendFacts,
 					nativeAppendPlan,
 					extraCoordinateDeleteHashes: deferredCoordinateDeleteHashes,
+					ownershipLifecycleController,
 				})) ?? nativeAppendPlan;
 		} catch (error) {
 			if (deferredCoordinateDeleteHashes) {
-				await this.deleteCoordinatesForHashes(deferredCoordinateDeleteHashes);
+				await this.deleteCoordinatesForHashes(
+					deferredCoordinateDeleteHashes,
+					ownershipLifecycleController,
+				);
 			}
 			throw error;
 		}
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		return {
 			get entry() {
 				return result.entry;
@@ -11856,6 +13537,7 @@ export class SharedLog<
 		options: SharedAppendOptions<T> | undefined,
 		properties: PreparedPayloadsManyIndependentProperties<T> | undefined,
 		minReplicasValue: number,
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<
 		| {
 				entries: Entry<T>[];
@@ -11865,6 +13547,9 @@ export class SharedLog<
 		  }
 		| undefined
 	> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const backbone = this._nativeBackbone;
 		const payloadDatas = properties?.payloadDatas;
 		const documentIndexes = properties?.nativeBackboneDocumentIndexes;
@@ -11941,7 +13626,13 @@ export class SharedLog<
 		) {
 			return undefined;
 		}
-		const context = await this.createLeaderSelectionContext();
+		const context = await this.createLeaderSelectionContext(
+			undefined,
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const nativeLeaderOptions = this.createNativeLeaderOptions(context);
 		let backboneAppends: NativeBackboneAppendResult[] | undefined;
 		let batchDocumentRollbacks: NativeBackboneDocumentRollback[] = [];
@@ -11954,6 +13645,9 @@ export class SharedLog<
 			| undefined;
 		let appended: TrustedLowerLogCommitOnlyAppendBatchResult<T> | undefined;
 		try {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			appended = await asTrustedLowerLog(
 				this.log,
 			).appendLocallyPreparedNativeKnownNoNextCommitOnlyBatch(
@@ -11969,6 +13663,9 @@ export class SharedLog<
 					deferNativeTransactionAcknowledgement: true,
 				},
 				async (inputs) => {
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						ownershipLifecycleController,
+					);
 					batchDocumentRollbacks = documentIndexes
 						.map((index) => this.snapshotNativeBackboneDocument(index))
 						.filter(
@@ -11978,8 +13675,14 @@ export class SharedLog<
 						await this.beginNativeStrictDurableTransaction(
 							batchDocumentRollbacks,
 						);
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						ownershipLifecycleController,
+					);
 					const documentDeleteTrimmedHeadsForAppend =
 						deleteTrimmedHeads && inputs[0]?.trimLengthTo != null;
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						ownershipLifecycleController,
+					);
 					backboneAppends = usesLatestDocumentContext
 						? backbone.preparePlainCommittedStorageAppendDocumentIndexLatestBatchTransaction(
 								{
@@ -12030,6 +13733,9 @@ export class SharedLog<
 						await this.completeNativeStrictDurableTransaction(
 							nativeStrictTransaction,
 						);
+						this.throwIfReplicationOwnershipLifecycleInactive(
+							ownershipLifecycleController,
+						);
 						return undefined;
 					}
 					const committedAppends = backboneAppends;
@@ -12064,6 +13770,9 @@ export class SharedLog<
 							...(append.trimmedHashes ??
 								append.trimmed.map((entry) => entry.hash)),
 						]),
+					);
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						ownershipLifecycleController,
 					);
 					const rollbackCommitted = async (cause: unknown): Promise<never> => {
 						durableWrapper?.cancelNativeDeleteCleanup?.(
@@ -12111,6 +13820,9 @@ export class SharedLog<
 					}
 					nativeDeleteCleanupToken =
 						durableWrapper?.beginNativeDeleteCleanup?.(nativeTrimmedHashes);
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						ownershipLifecycleController,
+					);
 					const preparedRows = committedAppends.map((append) => ({
 						cid: append.entry.hash,
 						hash: append.entry.hash,
@@ -12175,6 +13887,9 @@ export class SharedLog<
 								})
 							: Promise.resolve();
 					return Promise.allSettled([durableMirror]).then(async (settled) => {
+						this.throwIfReplicationOwnershipLifecycleInactive(
+							ownershipLifecycleController,
+						);
 						const rejected =
 							settled[0]?.status === "rejected"
 								? (settled[0] as PromiseRejectedResult).reason
@@ -12218,6 +13933,9 @@ export class SharedLog<
 					});
 				},
 			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		} catch (error) {
 			durableWrapper?.cancelNativeDeleteCleanup?.(nativeDeleteCleanupToken);
 			let compensated = !backboneAppends;
@@ -12251,6 +13969,9 @@ export class SharedLog<
 		if (!appended || !backboneAppends) {
 			await this.completeNativeStrictDurableTransaction(
 				nativeStrictTransaction,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
 			);
 			return undefined;
 		}
@@ -12343,6 +14064,9 @@ export class SharedLog<
 						}),
 				),
 			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			for (let i = 0; i < appended.appendFacts.length; i++) {
 				const facts = appended.appendFacts[i]!;
 				const backboneAppend = backboneAppends[i]!;
@@ -12379,24 +14103,40 @@ export class SharedLog<
 							.coordinates as NumberFromType<R>[],
 						skipGenericTransientCoordinateIndex: runtimeOnlyCoordinates,
 					},
+					ownershipLifecycleController,
 				);
 				if (isPromiseLike(persisted)) {
 					await persisted;
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						ownershipLifecycleController,
+					);
 				}
 			}
 			if (!appended.nativeCommittedAppendFinalizer) {
 				throw new Error("Missing deferred native append batch finalizer");
 			}
 			await this.flushNativeBackboneCoordinateJournal();
-			await appended.nativeCommittedAppendFinalizer.acknowledge(() =>
-				this.markNativeStrictDurableTransactionLowerMarker(
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+			await appended.nativeCommittedAppendFinalizer.acknowledge(() => {
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
+				return this.markNativeStrictDurableTransactionLowerMarker(
 					nativeStrictTransaction,
-				),
+				);
+			});
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
 			);
 		} catch (error) {
 			return rollbackBatch(error);
 		}
 
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const appendCommits: PreparedLocalAppendCommit<R>[] = [];
 		for (let i = 0; i < coordinateRows.length; i++) {
 			const {
@@ -12435,9 +14175,18 @@ export class SharedLog<
 			await this.completeNativeStrictDurableTransaction(
 				nativeStrictTransaction,
 			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		} catch (error) {
+			if (!this.isRepairLifecycleActive(ownershipLifecycleController)) {
+				throw error;
+			}
 			warn(`Failed to retire committed native intent: ${String(error)}`);
 		}
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const delayAdaptiveRebalance = this.shouldDelayAdaptiveRebalance();
 		if (!delayAdaptiveRebalance) {
 			this.rebalanceParticipationDebounced?.call();
@@ -12469,6 +14218,8 @@ export class SharedLog<
 		if (data.length === 0) {
 			return { entries: [], removed: [], appendCommits: [] };
 		}
+		const ownershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
 		if (options?.canAppend || options?.onChange) {
 			throw new Error(
 				"appendLocallyPreparedManyIndependent does not accept canAppend or onChange hooks",
@@ -12488,7 +14239,11 @@ export class SharedLog<
 				options,
 				properties,
 				minReplicasValue,
+				ownershipLifecycleController,
 			);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		if (nativeBackboneBatch) {
 			return nativeBackboneBatch;
 		}
@@ -12499,22 +14254,36 @@ export class SharedLog<
 			payloadDatas: properties?.payloadDatas,
 			nexts: properties?.nexts,
 		});
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		if (!result) {
 			return undefined;
 		}
 
-		const changeResult = this.applyChange(result.change);
+		const changeResult = this.applyChange(result.change, {
+			ownershipLifecycleController,
+		});
 		if (isPromiseLike(changeResult)) {
 			await changeResult;
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		}
 		const deferHeadCoordinatePersistence =
 			this.shouldDeferHeadCoordinatePersistence(options);
 
 		if (deferHeadCoordinatePersistence) {
-			await this.deleteCoordinatesForHashes([
-				...result.entries.flatMap((entry) => entry.meta.next),
-				...result.removed.map((entry) => entry.hash),
-			]);
+			await this.deleteCoordinatesForHashes(
+				[
+					...result.entries.flatMap((entry) => entry.meta.next),
+					...result.removed.map((entry) => entry.hash),
+				],
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			return {
 				entries: result.entries,
 				removed: result.removed,
@@ -12532,19 +14301,28 @@ export class SharedLog<
 					? await this.planNativeLocalAppendEntries(
 							result.entries,
 							minReplicasValue,
+							ownershipLifecycleController,
 						)
 					: await this.planNativeAppendEntries(
 							result.entries,
 							minReplicasValue,
 							options?.delivery,
 							options,
+							ownershipLifecycleController,
 						);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		if (
 			nativeAppendPlans &&
 			(await this.processLocalAppendManyNativePlanned(result.entries, options, {
 				nativeAppendPlans,
+				ownershipLifecycleController,
 			}))
 		) {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			return {
 				entries: result.entries,
 				removed: result.removed,
@@ -12564,7 +14342,11 @@ export class SharedLog<
 					minReplicasValue,
 					deferHeadCoordinatePersistence: false,
 					nativeAppendPlan: nativeAppendPlans?.[i],
+					ownershipLifecycleController,
 				},
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
 			);
 			if (processedPlan) {
 				nativeAppendPlans ??= [];
@@ -12616,28 +14398,45 @@ export class SharedLog<
 		if (data.length === 0) {
 			return { entries: [], removed: [] };
 		}
+		const ownershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
 		if (this._isAdaptiveReplicating) {
 			this.markLocalAppendActivity();
 		}
 
-		const { appendOptions, minReplicasValue } =
-			this.createLogAppendOptions(options);
+		const { appendOptions, minReplicasValue } = this.createLogAppendOptions(
+			options,
+			ownershipLifecycleController,
+		);
 		const result = await this.log.appendMany(data, appendOptions);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const deferHeadCoordinatePersistence =
 			this.shouldDeferHeadCoordinatePersistence(options);
 
 		if (deferHeadCoordinatePersistence) {
-			await this.deleteCoordinatesForHashes([
-				...result.entries.flatMap((entry) => entry.meta.next),
-				...result.removed.map((entry) => entry.hash),
-			]);
+			await this.deleteCoordinatesForHashes(
+				[
+					...result.entries.flatMap((entry) => entry.meta.next),
+					...result.removed.map((entry) => entry.hash),
+				],
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			return result;
 		}
 
 		if (this.canCoalesceLocalAppendMany(result.entries, options)) {
 			await this.processLocalAppendManyCoalesced(result, options, {
 				minReplicasValue,
+				ownershipLifecycleController,
 			});
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			return result;
 		}
 
@@ -12648,20 +14447,29 @@ export class SharedLog<
 					? await this.planNativeLocalAppendEntries(
 							result.entries,
 							minReplicasValue,
+							ownershipLifecycleController,
 						)
 					: await this.planNativeAppendEntries(
 							result.entries,
 							minReplicasValue,
 							options?.delivery,
 							options,
+							ownershipLifecycleController,
 						);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		for (let i = 0; i < result.entries.length; i++) {
 			const entry = result.entries[i]!;
 			await this.processLocalAppend(entry, [], options, {
 				minReplicasValue,
 				deferHeadCoordinatePersistence: false,
 				nativeAppendPlan: nativeAppendPlans?.[i],
+				ownershipLifecycleController,
 			});
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		}
 		return result;
 	}
@@ -12702,18 +14510,34 @@ export class SharedLog<
 		options: SharedAppendOptions<T> | undefined,
 		properties: {
 			minReplicasValue: number;
+			ownershipLifecycleController: AbortController;
 		},
 	): Promise<void> {
+		const ownershipLifecycleController =
+			properties.ownershipLifecycleController;
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const head = result.entries[result.entries.length - 1]!;
-		await this.deleteCoordinatesForHashes([
-			...result.entries[0]!.meta.next,
-			...result.entries.slice(0, -1).map((entry) => entry.hash),
-			...result.removed.map((entry) => entry.hash),
-		]);
+		await this.deleteCoordinatesForHashes(
+			[
+				...result.entries[0]!.meta.next,
+				...result.entries.slice(0, -1).map((entry) => entry.hash),
+				...result.removed.map((entry) => entry.hash),
+			],
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		await this.processLocalAppend(head, result.removed, options, {
 			minReplicasValue: properties.minReplicasValue,
 			deferHeadCoordinatePersistence: false,
+			ownershipLifecycleController,
 		});
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 	}
 
 	private async processLocalAppendManyNativePlanned(
@@ -12721,8 +14545,14 @@ export class SharedLog<
 		options: SharedAppendOptions<T> | undefined,
 		properties: {
 			nativeAppendPlans: NativeAppendEntryPlan<R>[];
+			ownershipLifecycleController: AbortController;
 		},
 	): Promise<boolean> {
+		const ownershipLifecycleController =
+			properties.ownershipLifecycleController;
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		if (
 			entries.length === 0 ||
 			options?.target !== "none" ||
@@ -12749,16 +14579,26 @@ export class SharedLog<
 					prepared: plan.preparedCoordinate,
 				};
 			}),
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
 		);
 
 		if (!delayAdaptiveRebalance) {
 			for (let i = 0; i < entries.length; i++) {
 				const plan = properties.nativeAppendPlans[i]!;
 				if (!plan.isLeader) {
-					this.pruneDebouncedFnAddIfNotKeeping({
-						key: entries[i]!.hash,
-						value: { entry: entries[i]!, leaders: plan.leaders! },
-					});
+					await this.pruneDebouncedFnAddIfNotKeeping(
+						{
+							key: entries[i]!.hash,
+							value: { entry: entries[i]!, leaders: plan.leaders! },
+						},
+						ownershipLifecycleController,
+					);
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						ownershipLifecycleController,
+					);
 				}
 			}
 			this.rebalanceParticipationDebounced?.call();
@@ -12766,7 +14606,10 @@ export class SharedLog<
 		return true;
 	}
 
-	private createLogAppendOptions(options?: SharedAppendOptions<T>): {
+	private createLogAppendOptions(
+		options?: SharedAppendOptions<T>,
+		ownershipLifecycleController?: AbortController,
+	): {
 		appendOptions: TrustedLogAppendOptions<T>;
 		minReplicasValue: number;
 	} {
@@ -12790,7 +14633,15 @@ export class SharedLog<
 			};
 		}
 
-		if (options?.onChange) {
+		if (ownershipLifecycleController) {
+			appendOptions.onChange = async (change) => {
+				await this.onChange(change, ownershipLifecycleController);
+				if (options?.onChange) {
+					return options.onChange(change);
+				}
+				return this._logProperties?.onChange?.(change);
+			};
+		} else if (options?.onChange) {
 			appendOptions.onChange = async (change) => {
 				await this.onChange(change);
 				return options.onChange!(change);
@@ -12906,17 +14757,30 @@ export class SharedLog<
 		appendFacts: PreparedAppendFacts,
 		replicas: number,
 		deliveryArg: false | true | DeliveryOptions | undefined,
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<NativeAppendEntryPlan<R> | undefined> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const nativePlanner = this._nativeBackbone ?? this._nativeSharedLogState;
 		if (!nativePlanner || !this.canPlanNativeAppendFacts(appendFacts)) {
 			return undefined;
 		}
 
-		const context = await this.createLeaderSelectionContext();
+		const context = await this.createLeaderSelectionContext(
+			undefined,
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const fullReplicaDeliveryCandidates =
 			await this.getFullReplicaRepairCandidates(undefined, {
 				includeSubscribers: false,
 			});
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const { delivery, reliability, requireRecipients, minAcks } =
 			this._parseDeliveryOptions(deliveryArg);
 		const hashNumber = this.getAppendFactsHashNumber(appendFacts);
@@ -12965,13 +14829,23 @@ export class SharedLog<
 		appendFacts: PreparedAppendFacts,
 		replicas: number,
 		options?: { deleteHashes?: string[] },
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<NativeAppendEntryPlan<R> | undefined> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const nativePlanner = this._nativeBackbone ?? this._nativeSharedLogState;
 		if (!nativePlanner || !this.canPlanNativeAppendFacts(appendFacts)) {
 			return undefined;
 		}
 
-		const context = await this.createLeaderSelectionContext();
+		const context = await this.createLeaderSelectionContext(
+			undefined,
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const hashNumber = this.getAppendFactsHashNumber(appendFacts);
 		const nativeLeaderOptions = this.createNativeLeaderOptions(context);
 		const plan =
@@ -13029,17 +14903,30 @@ export class SharedLog<
 		entry: Entry<T>,
 		replicas: number,
 		deliveryArg: false | true | DeliveryOptions | undefined,
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<NativeAppendEntryPlan<R> | undefined> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const nativePlanner = this._nativeBackbone ?? this._nativeSharedLogState;
 		if (!nativePlanner || !this.canPlanNativeHashGid(entry)) {
 			return undefined;
 		}
 
-		const context = await this.createLeaderSelectionContext();
+		const context = await this.createLeaderSelectionContext(
+			undefined,
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const fullReplicaDeliveryCandidates =
 			await this.getFullReplicaRepairCandidates(undefined, {
 				includeSubscribers: false,
 			});
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const { delivery, reliability, requireRecipients, minAcks } =
 			this._parseDeliveryOptions(deliveryArg);
 		const hashNumber = this.getEntryHashNumber(entry);
@@ -13087,13 +14974,23 @@ export class SharedLog<
 	private async planNativeLocalAppendEntry(
 		entry: Entry<T>,
 		replicas: number,
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<NativeAppendEntryPlan<R> | undefined> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const nativePlanner = this._nativeBackbone ?? this._nativeSharedLogState;
 		if (!nativePlanner || !this.canPlanNativeHashGid(entry)) {
 			return undefined;
 		}
 
-		const context = await this.createLeaderSelectionContext();
+		const context = await this.createLeaderSelectionContext(
+			undefined,
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const hashNumber = this.getEntryHashNumber(entry);
 		const plan = nativePlanner.planLocalAppendForGidCompact(
 			{
@@ -13133,7 +15030,11 @@ export class SharedLog<
 	private async planNativeLocalAppendEntries(
 		entries: Entry<T>[],
 		replicas: number,
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<NativeAppendEntryPlan<R>[] | undefined> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const nativePlanner = this._nativeBackbone ?? this._nativeSharedLogState;
 		if (
 			!nativePlanner ||
@@ -13143,7 +15044,13 @@ export class SharedLog<
 			return undefined;
 		}
 
-		const context = await this.createLeaderSelectionContext();
+		const context = await this.createLeaderSelectionContext(
+			undefined,
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const entriesWithHashNumbers = entries.map((entry) => ({
 			entry,
 			hashNumber: this.getEntryHashNumber(entry),
@@ -13201,7 +15108,11 @@ export class SharedLog<
 		replicas: number,
 		deliveryArg: false | true | DeliveryOptions | undefined,
 		options: SharedAppendOptions<T> | undefined,
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<NativeAppendEntryPlan<R>[] | undefined> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const target = options?.target;
 		const nativePlanner = this._nativeBackbone ?? this._nativeSharedLogState;
 		if (
@@ -13214,11 +15125,20 @@ export class SharedLog<
 			return undefined;
 		}
 
-		const context = await this.createLeaderSelectionContext();
+		const context = await this.createLeaderSelectionContext(
+			undefined,
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const fullReplicaDeliveryCandidates =
 			await this.getFullReplicaRepairCandidates(undefined, {
 				includeSubscribers: false,
 			});
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const { delivery, reliability, requireRecipients, minAcks } =
 			this._parseDeliveryOptions(deliveryArg);
 		const entriesWithHashNumbers = entries.map((entry) => ({
@@ -13285,8 +15205,15 @@ export class SharedLog<
 			deferHeadCoordinatePersistence?: boolean;
 			nativeAppendPlan?: NativeAppendEntryPlan<R>;
 			extraCoordinateDeleteHashes?: string[];
+			ownershipLifecycleController?: AbortController;
 		},
 	): Promise<NativeAppendEntryPlan<R> | undefined> {
+		const ownershipLifecycleController =
+			properties.ownershipLifecycleController ??
+			this.captureReplicationOwnershipLifecycle();
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const deferHeadCoordinatePersistence =
 			properties.deferHeadCoordinatePersistence ??
 			(entry.meta.type !== EntryType.CUT &&
@@ -13294,13 +15221,22 @@ export class SharedLog<
 
 		if (options?.replicate) {
 			await this.replicate(entry, { checkDuplicates: true });
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		}
 
 		if (deferHeadCoordinatePersistence) {
-			await this.deleteCoordinatesForHashes([
-				...(properties.appendFacts?.next ?? entry.meta.next),
-				...removed.map((entry) => entry.hash),
-			]);
+			await this.deleteCoordinatesForHashes(
+				[
+					...(properties.appendFacts?.next ?? entry.meta.next),
+					...removed.map((entry) => entry.hash),
+				],
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			return;
 		}
 
@@ -13315,23 +15251,31 @@ export class SharedLog<
 						? await this.planNativeLocalAppendFacts(
 								properties.appendFacts,
 								properties.minReplicasValue,
+								undefined,
+								ownershipLifecycleController,
 							)
 						: await this.planNativeLocalAppendEntry(
 								entry,
 								properties.minReplicasValue,
+								ownershipLifecycleController,
 							)
 					: properties.appendFacts
 						? await this.planNativeAppendFacts(
 								properties.appendFacts,
 								properties.minReplicasValue,
 								deliveryArg,
+								ownershipLifecycleController,
 							)
 						: await this.planNativeAppendEntry(
 								entry,
 								properties.minReplicasValue,
 								deliveryArg,
+								ownershipLifecycleController,
 							);
 		}
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		let coordinates: NumberFromType<R>[];
 		let leaders: LeaderMap | undefined;
 		let isLeader: boolean;
@@ -13343,39 +15287,50 @@ export class SharedLog<
 			nativeDeliveryPlan = nativeAppendPlan.delivery;
 			if (!isLeader && !leaders) {
 				leaders = (
-					await this.planEntryLeaders(entry, properties.minReplicasValue, {
-						persist: false,
-					})
+					await this.planEntryLeaders(
+						entry,
+						properties.minReplicasValue,
+						{
+							persist: false,
+						},
+						ownershipLifecycleController,
+					)
 				).leaders;
 			}
 			if (properties.appendFacts) {
-				await this.persistPreparedCoordinate({
-					prepared: nativeAppendPlan.preparedCoordinate,
-					hash: properties.appendFacts.hash,
-					nextHashes: properties.appendFacts.next,
-					deleteHashes: properties.extraCoordinateDeleteHashes,
-					coordinates,
-					replicas: coordinates.length,
-					commitNative:
-						nativeAppendPlan.committedNativeCoordinateState !== true,
-					commitNativeBackbone:
-						nativeAppendPlan.committedNativeBackboneCoordinateState !== true,
-				});
+				await this.persistPreparedCoordinate(
+					{
+						prepared: nativeAppendPlan.preparedCoordinate,
+						hash: properties.appendFacts.hash,
+						nextHashes: properties.appendFacts.next,
+						deleteHashes: properties.extraCoordinateDeleteHashes,
+						coordinates,
+						replicas: coordinates.length,
+						commitNative:
+							nativeAppendPlan.committedNativeCoordinateState !== true,
+						commitNativeBackbone:
+							nativeAppendPlan.committedNativeBackboneCoordinateState !== true,
+					},
+					ownershipLifecycleController,
+				);
 			} else {
-				await this.persistCoordinate({
-					leaders: leaders ?? false,
-					coordinates,
-					replicas: coordinates.length,
-					entry,
-					assignedToRangeBoundary: nativeAppendPlan.assignedToRangeBoundary,
-					commitNative:
-						nativeAppendPlan.committedNativeCoordinateState !== true,
-					commitNativeBackbone:
-						nativeAppendPlan.committedNativeBackboneCoordinateState !== true,
-					deleteHashes: properties.extraCoordinateDeleteHashes,
-					hashNumber: nativeAppendPlan.hashNumber,
-					prepared: nativeAppendPlan.preparedCoordinate,
-				});
+				await this.persistCoordinate(
+					{
+						leaders: leaders ?? false,
+						coordinates,
+						replicas: coordinates.length,
+						entry,
+						assignedToRangeBoundary: nativeAppendPlan.assignedToRangeBoundary,
+						commitNative:
+							nativeAppendPlan.committedNativeCoordinateState !== true,
+						commitNativeBackbone:
+							nativeAppendPlan.committedNativeBackboneCoordinateState !== true,
+						deleteHashes: properties.extraCoordinateDeleteHashes,
+						hashNumber: nativeAppendPlan.hashNumber,
+						prepared: nativeAppendPlan.preparedCoordinate,
+					},
+					ownershipLifecycleController,
+				);
 			}
 		} else {
 			({ coordinates, leaders, isLeader } = await this.planEntryLeaders(
@@ -13384,8 +15339,12 @@ export class SharedLog<
 				{
 					persist: {},
 				},
+				ownershipLifecycleController,
 			));
 		}
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 
 		if (options?.target !== "none") {
 			const hasDelivery = !(deliveryArg === undefined || deliveryArg === false);
@@ -13402,7 +15361,10 @@ export class SharedLog<
 			}
 
 			if (target === "all") {
-				await this._appendDeliverToAllFanout(entry);
+				await this._appendDeliverToAllFanout(
+					entry,
+					ownershipLifecycleController,
+				);
 			} else {
 				await this._appendDeliverToReplicators(
 					entry,
@@ -13413,16 +15375,26 @@ export class SharedLog<
 					isLeader,
 					deliveryArg,
 					nativeDeliveryPlan,
+					ownershipLifecycleController,
 				);
 			}
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		}
 
 		const delayAdaptiveRebalance = this.shouldDelayAdaptiveRebalance();
 		if (!isLeader && !delayAdaptiveRebalance) {
-			this.pruneDebouncedFnAddIfNotKeeping({
-				key: entry.hash,
-				value: { entry, leaders: leaders! },
-			});
+			await this.pruneDebouncedFnAddIfNotKeeping(
+				{
+					key: entry.hash,
+					value: { entry, leaders: leaders! },
+				},
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		}
 		// Keep the debounced rebalance loop alive even when the current write
 		// burst delays the actual rebalance; the loop will wake after the idle
@@ -13500,6 +15472,13 @@ export class SharedLog<
 	async open(options?: Args<T, D, R>): Promise<void> {
 		this.ensureNativeDurabilityRuntimeState();
 		this._nativeStrictDurableTransactionsClosing = false;
+		this._replicationRangeMutationsClosing = false;
+		this._checkedPruneRemoveBlocksLocalRangeMutationAdmission = 0;
+		this._checkedPruneRemovalCallbackInvocationDepth = 0;
+		this._pruneRemovesClosing = false;
+		this._replicationRangeMutationFailure = undefined;
+		this.startRepairLifecycle();
+		this._replicationRangeMutationTail = Promise.resolve();
 		this.resetSubscriptionChangeCallbackTracking();
 		const recoveringNativeDurableFailure =
 			this._nativeDurableCommitFailure !== undefined;
@@ -13533,6 +15512,7 @@ export class SharedLog<
 		);
 		this._respondToIHaveTimeout = options?.respondToIHaveTimeout ?? 2e4;
 		this._checkedPrune = new CheckedPruneCoordinator<T, R>();
+		this._admittedPruneRemoves = new Set();
 		this._pendingIHave = new Map();
 		this._pendingIHaveCallbacks = new Set();
 		this.latestReplicationInfoMessage = new Map();
@@ -13563,7 +15543,7 @@ export class SharedLog<
 		this._repairFrontierBypassKnownPeersByMode =
 			createRepairFrontierBypassKnownPeersByMode();
 		this._joinWarmupGenerationByTarget = new Map();
-		this._joinWarmupSendStateByTarget ??= new Map();
+		this._joinWarmupSendStateByTarget = new Map();
 		this._joinWarmupRetryTimersByTarget = new Map();
 		this._joinWarmupScheduledRetriesByTarget = new Map();
 		this._repairSweepOptimisticGidPeersPending = new Map();
@@ -13835,54 +15815,113 @@ export class SharedLog<
 			})) > 0;
 
 		this._gidPeersHistory = new Map();
-		this.replicationChangeDebounceFn = debounceAggregationChanges<
+		const replicationChangeOwnershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
+		let replicationChangeDebounceFn!: typeof this.replicationChangeDebounceFn;
+		replicationChangeDebounceFn = debounceAggregationChanges<
 			ReplicationRangeIndexable<R>
-		>(
-			(change) =>
-				this.onReplicationChange(change).then(() =>
-					this.rebalanceParticipationDebounced?.call(),
-				),
-			this.distributionDebounceTime,
-		);
-
-		this.pruneDebouncedFn = debouncedAccumulatorMap(
-			async (map) => {
-				const current = new Map<
-					string,
-					{
-						entry: CheckedPruneEntry<T, R>;
-						leaders: CheckedPruneLeaderMap;
-					}
-				>();
-				const selfReplicating = await this.isReplicating();
-				for (const [hash, value] of map) {
-					const checkedPruneLeaders =
-						await this.revalidateCheckedPruneOwnership({
-							hash,
-							entry: value.entry,
-							leaders: value.leaders,
-							selfReplicating,
-						});
-					if (checkedPruneLeaders.localLeader) {
-						const preserveRetry = this._checkedPrune.hasRetry(hash);
-						await this.cancelCheckedPruneForLocalLeader(hash, {
-							preserveRetry,
-						});
-						if (preserveRetry) {
-							this.scheduleCheckedPruneRetry({
-								entry: value.entry,
-								leaders: checkedPruneLeaders.leaders,
-							});
-						}
-						continue;
-					}
-					current.set(hash, {
-						...value,
-						leaders: checkedPruneLeaders.leaders,
-					});
+		>(async (change) => {
+			if (
+				this.replicationChangeDebounceFn !== replicationChangeDebounceFn ||
+				!this.isRepairLifecycleActive(
+					replicationChangeOwnershipLifecycleController,
+				)
+			) {
+				return;
+			}
+			try {
+				await this.onReplicationChange(change);
+				if (
+					this.replicationChangeDebounceFn === replicationChangeDebounceFn &&
+					this.isRepairLifecycleActive(
+						replicationChangeOwnershipLifecycleController,
+					)
+				) {
+					this.rebalanceParticipationDebounced?.call();
 				}
-				if (current.size > 0) {
-					this.prune(current);
+			} catch (error: any) {
+				if (
+					this.replicationChangeDebounceFn === replicationChangeDebounceFn &&
+					this.isRepairLifecycleActive(
+						replicationChangeOwnershipLifecycleController,
+					) &&
+					!isNotStartedError(error)
+				) {
+					logger.error(error?.toString?.() ?? String(error));
+				}
+			}
+		}, this.distributionDebounceTime);
+		this.replicationChangeDebounceFn = replicationChangeDebounceFn;
+
+		const pruneOwnershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
+		const checkedPruneCoordinator = this._checkedPrune;
+		let pruneDebouncedFn!: typeof this.pruneDebouncedFn;
+		const isPruneDebounceCurrent = () =>
+			this.isRepairLifecycleActive(pruneOwnershipLifecycleController) &&
+			this._checkedPrune === checkedPruneCoordinator &&
+			this.pruneDebouncedFn === pruneDebouncedFn;
+		pruneDebouncedFn = debouncedAccumulatorMap(
+			async (map) => {
+				if (!isPruneDebounceCurrent()) {
+					return;
+				}
+				try {
+					const current = new Map<
+						string,
+						{
+							entry: CheckedPruneEntry<T, R>;
+							leaders: CheckedPruneLeaderMap;
+						}
+					>();
+					const selfReplicating = await this.isReplicating();
+					if (!isPruneDebounceCurrent()) {
+						return;
+					}
+					for (const [hash, value] of map) {
+						const checkedPruneLeaders =
+							await this.revalidateCheckedPruneOwnership({
+								hash,
+								entry: value.entry,
+								leaders: value.leaders,
+								selfReplicating,
+								ownershipLifecycleController: pruneOwnershipLifecycleController,
+								checkedPruneCoordinator,
+							});
+						if (!isPruneDebounceCurrent()) {
+							return;
+						}
+						if (checkedPruneLeaders.localLeader) {
+							const preserveRetry = checkedPruneCoordinator.hasRetry(hash);
+							await this.cancelCheckedPruneForLocalLeader(hash, {
+								preserveRetry,
+							});
+							if (!isPruneDebounceCurrent()) {
+								return;
+							}
+							if (preserveRetry) {
+								this.scheduleCheckedPruneRetry(
+									{
+										entry: value.entry,
+										leaders: checkedPruneLeaders.leaders,
+									},
+									pruneOwnershipLifecycleController,
+								);
+							}
+							continue;
+						}
+						current.set(hash, {
+							...value,
+							leaders: checkedPruneLeaders.leaders,
+						});
+					}
+					if (current.size > 0 && isPruneDebounceCurrent()) {
+						this.prune(current, undefined, pruneOwnershipLifecycleController);
+					}
+				} catch (error) {
+					if (isPruneDebounceCurrent() && !isNotStartedError(error as Error)) {
+						logger.error(error);
+					}
 				}
 			},
 			PRUNE_DEBOUNCE_INTERVAL,
@@ -13894,6 +15933,7 @@ export class SharedLog<
 				}
 			},
 		);
+		this.pruneDebouncedFn = pruneDebouncedFn;
 
 		this.responseToPruneDebouncedFn = debounceAccumulator<
 			string,
@@ -13988,7 +16028,7 @@ export class SharedLog<
 				: (this._logProperties?.nativeGraph ?? { optional: true }),
 			onChange: async (change) => {
 				await this.onChange(change);
-				return this._logProperties?.onChange?.(change);
+				return this.invokeProgramOnChange(change);
 			},
 			canAppend: async (entry) => {
 				if (!(await this.canAppend(entry))) {
@@ -14209,7 +16249,7 @@ export class SharedLog<
 		await this.syncronizer.open();
 
 		this.interval = setInterval(() => {
-			this.rebalanceParticipationDebounced?.call();
+			void this.rebalanceParticipationDebounced?.call();
 		}, RECALCULATE_PARTICIPATION_DEBOUNCE_INTERVAL);
 	}
 
@@ -14231,17 +16271,53 @@ export class SharedLog<
 
 	private putNativeReplicationRange(range: ReplicationRangeIndexable<R>): void {
 		const nativeRange = this.toNativeReplicationRange(range);
-		this._nativeRangePlanner?.put(nativeRange);
-		this._nativeSharedLogState?.put(nativeRange);
-		this._nativeBackbone?.putRange(nativeRange);
+		const errors: unknown[] = [];
+		for (const operation of [
+			() => this._nativeRangePlanner?.put(nativeRange),
+			() => this._nativeSharedLogState?.put(nativeRange),
+			() => this._nativeBackbone?.putRange(nativeRange),
+		]) {
+			try {
+				operation();
+			} catch (error) {
+				errors.push(error);
+			}
+		}
+		if (errors.length === 1) {
+			throw errors[0];
+		}
+		if (errors.length > 1) {
+			throw new AggregateError(
+				errors,
+				"Failed to publish a replication range to every native mirror",
+			);
+		}
 	}
 
 	private deleteNativeReplicationRange(
 		range: ReplicationRangeIndexable<R>,
 	): void {
-		this._nativeRangePlanner?.delete(range.idString);
-		this._nativeSharedLogState?.delete(range.idString);
-		this._nativeBackbone?.deleteRange(range.idString);
+		const errors: unknown[] = [];
+		for (const operation of [
+			() => this._nativeRangePlanner?.delete(range.idString),
+			() => this._nativeSharedLogState?.delete(range.idString),
+			() => this._nativeBackbone?.deleteRange(range.idString),
+		]) {
+			try {
+				operation();
+			} catch (error) {
+				errors.push(error);
+			}
+		}
+		if (errors.length === 1) {
+			throw errors[0];
+		}
+		if (errors.length > 1) {
+			throw new AggregateError(
+				errors,
+				"Failed to remove a replication range from every native mirror",
+			);
+		}
 	}
 
 	private async hydrateNativeRangePlanner(
@@ -14690,34 +16766,142 @@ export class SharedLog<
 	private async updateTimestampOfOwnedReplicationRanges(
 		timestamp: number = +new Date(),
 	) {
-		const all = await this.replicationIndex
-			.iterate({
-				query: { hash: this.node.identity.publicKey.hashcode() },
-			})
-			.all();
-		let bnTimestamp = BigInt(timestamp);
-		for (const x of all) {
-			x.value.timestamp = bnTimestamp;
-			await this.replicationIndex.put(x.value);
-			this.putNativeReplicationRange(x.value);
-		}
-
-		if (all.length > 0) {
-			// emit mature event
-			const maturityTimeout = setTimeout(
-				() => {
-					this.events.dispatchEvent(
-						new CustomEvent<ReplicationChangeEvent>("replicator:mature", {
-							detail: { publicKey: this.node.identity.publicKey },
-						}),
-					);
-				},
-				await this.getDefaultMinRoleAge(),
+		const ownershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
+		return this.withReplicationRangeMutationQueue(async () => {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
 			);
-			this._closeController.signal.addEventListener("abort", () => {
+			const all = await this.replicationIndex
+				.iterate({
+					query: { hash: this.node.identity.publicKey.hashcode() },
+				})
+				.all();
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+			this.validatePersistedReplicationRangeSnapshot(
+				all.map((result) => result.value),
+			);
+			const minRoleAge = all.length > 0 ? await this.getDefaultMinRoleAge() : 0;
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+
+			const previousRanges = all.map((result) => result.value);
+			const bnTimestamp = BigInt(timestamp);
+			const updatedRanges = previousRanges.map(
+				(range) =>
+					Object.assign(Object.create(Object.getPrototypeOf(range)), range, {
+						timestamp: bnTimestamp,
+					}) as ReplicationRangeIndexable<R>,
+			);
+			let crossedWriteBoundary = false;
+			try {
+				for (const range of updatedRanges) {
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						ownershipLifecycleController,
+					);
+					// `put` may commit and then throw, so crossing the call boundary is
+					// already an ambiguous durable outcome.
+					crossedWriteBoundary = true;
+					await this.replicationIndex.put(range);
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						ownershipLifecycleController,
+					);
+					this.putNativeReplicationRange(range);
+				}
+				if (updatedRanges.length > 0) {
+					await this.updateOldestTimestampFromIndex();
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						ownershipLifecycleController,
+					);
+				}
+			} catch (primaryError) {
+				if (!crossedWriteBoundary) {
+					throw primaryError;
+				}
+				const recoveryErrors: unknown[] = [primaryError];
+				let durableRangesById:
+					| Map<string, ReplicationRangeIndexable<R>>
+					| undefined;
+				try {
+					const durableRanges =
+						await this.resolveReplicationRangesFromIdsAndKey(
+							updatedRanges.map((range) => range.id),
+							this.node.identity.publicKey,
+						);
+					durableRangesById = new Map(
+						durableRanges.map((range) => [range.idString, range]),
+					);
+				} catch (probeError) {
+					recoveryErrors.push(probeError);
+				}
+
+				if (durableRangesById) {
+					for (const previousRange of previousRanges) {
+						const durableRange = durableRangesById.get(previousRange.idString);
+						try {
+							if (durableRange) {
+								this.putNativeReplicationRange(durableRange);
+							} else {
+								this.deleteNativeReplicationRange(previousRange);
+							}
+						} catch (reconcileError) {
+							recoveryErrors.push(reconcileError);
+						}
+					}
+					try {
+						await this.updateOldestTimestampFromIndex();
+					} catch (oldestTimestampError) {
+						recoveryErrors.push(oldestTimestampError);
+					}
+				}
+
+				const failure = new AggregateError(
+					recoveryErrors,
+					"Failed to update owned replication-range timestamps coherently",
+				);
+				this.poisonReplicationOwnership(failure);
+				throw failure;
+			}
+
+			if (updatedRanges.length === 0) {
+				return;
+			}
+			const repairTimers = this._repairRetryTimers;
+			let maturityTimeout: ReturnType<typeof setTimeout>;
+			const cancelMaturity = () => {
 				clearTimeout(maturityTimeout);
-			});
-		}
+				repairTimers.delete(maturityTimeout);
+				ownershipLifecycleController.signal.removeEventListener(
+					"abort",
+					cancelMaturity,
+				);
+			};
+			maturityTimeout = setTimeout(() => {
+				repairTimers.delete(maturityTimeout);
+				ownershipLifecycleController.signal.removeEventListener(
+					"abort",
+					cancelMaturity,
+				);
+				if (!this.isRepairLifecycleActive(ownershipLifecycleController)) {
+					return;
+				}
+				this.events.dispatchEvent(
+					new CustomEvent<ReplicationChangeEvent>("replicator:mature", {
+						detail: { publicKey: this.node.identity.publicKey },
+					}),
+				);
+			}, minRoleAge);
+			maturityTimeout.unref?.();
+			repairTimers.add(maturityTimeout);
+			ownershipLifecycleController.signal.addEventListener(
+				"abort",
+				cancelMaturity,
+				{ once: true },
+			);
+		}, ownershipLifecycleController);
 	}
 
 	async afterOpen(): Promise<void> {
@@ -15464,19 +17648,44 @@ export class SharedLog<
 		return this.log.idString;
 	}
 
-	async onChange(change: Change<T>): Promise<void> {
-		const result = this.applyChange(change);
+	async onChange(
+		change: Change<T>,
+		ownershipLifecycleController?: AbortController,
+	): Promise<void> {
+		if (ownershipLifecycleController) {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+		}
+		const result = this.applyChange(change, {
+			ownershipLifecycleController,
+		});
 		if (isPromiseLike(result)) {
 			await result;
+		}
+		if (ownershipLifecycleController) {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		}
 	}
 
 	private applyChange(
 		change: Change<T>,
-		options?: { deferCoordinateIndexDeletes?: boolean },
+		options?: {
+			deferCoordinateIndexDeletes?: boolean;
+			ownershipLifecycleController?: AbortController;
+		},
 	): MaybePromise<string[] | undefined> {
+		if (options?.ownershipLifecycleController) {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				options.ownershipLifecycleController,
+			);
+		}
 		if (options?.deferCoordinateIndexDeletes) {
-			return this.applyChangeWithDeferredCoordinateDeletes(change);
+			return this.applyChangeWithDeferredCoordinateDeletes(change, {
+				ownershipLifecycleController: options.ownershipLifecycleController,
+			});
 		}
 		for (const added of change.added) {
 			this.onEntryAdded(added.entry);
@@ -15484,13 +17693,24 @@ export class SharedLog<
 		if (change.removed.length === 0) {
 			return undefined;
 		}
-		return this.applyRemovedChange(change.removed);
+		return this.applyRemovedChange(
+			change.removed,
+			options?.ownershipLifecycleController,
+		);
 	}
 
 	private applyChangeWithDeferredCoordinateDeletes(
 		change: Change<T>,
-		options?: { forgetNativeCoordinates?: boolean },
+		options?: {
+			forgetNativeCoordinates?: boolean;
+			ownershipLifecycleController?: AbortController;
+		},
 	): string[] | undefined {
+		if (options?.ownershipLifecycleController) {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				options.ownershipLifecycleController,
+			);
+		}
 		for (const added of change.added) {
 			this.onEntryAdded(added.entry);
 		}
@@ -15526,8 +17746,17 @@ export class SharedLog<
 		appendFacts: PreparedAppendFacts,
 		removed: ShallowOrFullEntry<T>[],
 		materializeEntry: () => Entry<T>,
-		options?: { forgetNativeCoordinates?: boolean; removedHashes?: string[] },
+		options?: {
+			forgetNativeCoordinates?: boolean;
+			removedHashes?: string[];
+			ownershipLifecycleController?: AbortController;
+		},
 	): string[] | undefined {
+		if (options?.ownershipLifecycleController) {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				options.ownershipLifecycleController,
+			);
+		}
 		this.onEntryAddedHash(appendFacts.hash, materializeEntry);
 		const removedHashes = options?.removedHashes;
 		if (
@@ -15552,9 +17781,23 @@ export class SharedLog<
 
 	private async applyRemovedChange(
 		removedEntries: ShallowOrFullEntry<T>[],
+		ownershipLifecycleController?: AbortController,
 	): Promise<undefined> {
 		for (const removed of removedEntries) {
-			await this.deleteCoordinates({ hash: removed.hash });
+			if (ownershipLifecycleController) {
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
+			}
+			await this.deleteCoordinates(
+				{ hash: removed.hash },
+				ownershipLifecycleController,
+			);
+			if (ownershipLifecycleController) {
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
+			}
 			this.onEntryRemoved(removed.hash);
 		}
 		return undefined;
@@ -16060,6 +18303,7 @@ export class SharedLog<
 	}
 
 	private async _close(options?: { preserveDropRetryResources?: boolean }) {
+		this.stopRepairLifecycle();
 		const preserveDropRetryResources =
 			options?.preserveDropRetryResources === true;
 		let firstError: unknown;
@@ -16091,6 +18335,7 @@ export class SharedLog<
 		captureSync(() => {
 			for (const [_key, peerMap] of this.pendingMaturity ?? []) {
 				for (const [_key2, info] of peerMap) clearTimeout(info.timeout);
+				peerMap.clear();
 			}
 			this.pendingMaturity?.clear();
 			this.distributeQueue?.clear();
@@ -16180,6 +18425,7 @@ export class SharedLog<
 			this._liveRawGossipBatches?.clear();
 			this._nativeSharedLogState?.clearGidPeers();
 			this._nativeBackbone?.clearGidPeers();
+			this._replicationRangeMutationTail = Promise.resolve();
 		});
 		// Cancel every debounce independently so one faulty close hook cannot keep
 		// the remaining timers or indexes alive.
@@ -16243,20 +18489,33 @@ export class SharedLog<
 		if (this.classifyTerminalOwnership(from) === "nonterminal") {
 			return super.close(from);
 		}
+		this.throwIfCheckedPruneRemoveBlocksLocalOperation("close");
 		// Match Program.end()'s synchronous terminal admission fence before any
 		// SharedLog-specific await or observable teardown can admit a new owner.
 		this.preventParentAttachments();
-		this.stopSubscriptionChangeCallbackAdmission();
-		this.cancelAllJoinWarmupTargets();
-		await this.drainSubscriptionChangeCallbacks();
-		// An already-admitted subscription callback can create a fresh warmup
-		// generation while the first cancellation is draining.
-		this.cancelAllJoinWarmupTargets();
-		await this.drainReceiveHandlers();
-		await this.drainReplicationInfoApplyQueues();
-		await this.drainPendingIHaveCallbacks();
-		this.ensureNativeDurabilityRuntimeState();
-		this.cancelCurrentReplicationStateAnnouncementRetry();
+		this.stopRepairLifecycle();
+		const replicationRangeTerminalFence =
+			this.acquireReplicationRangeMutationTerminalFence();
+		const pruneRemoveTerminalFence = this.acquirePruneRemoveTerminalFence();
+		try {
+			this.stopSubscriptionChangeCallbackAdmission();
+			this.cancelAllJoinWarmupTargets();
+			await this.drainSubscriptionChangeCallbacks();
+			// An already-admitted subscription callback can create a fresh warmup
+			// generation while the first cancellation is draining.
+			this.cancelAllJoinWarmupTargets();
+			await this.drainReceiveHandlers();
+			await this.drainReplicationInfoApplyQueues();
+			await replicationRangeTerminalFence.drained;
+			await pruneRemoveTerminalFence.drained;
+			await this.drainPendingIHaveCallbacks();
+			this.ensureNativeDurabilityRuntimeState();
+			this.cancelCurrentReplicationStateAnnouncementRetry();
+		} catch (error) {
+			// The terminal preamble has already disabled parent attachments and the
+			// network lifecycle. Keep mutation admission fenced for an exact retry.
+			throw error;
+		}
 		// Best-effort: announce that we are going offline before tearing down
 		// RPC/subscription state.
 		//
@@ -16357,6 +18616,7 @@ export class SharedLog<
 		if (this.classifyTerminalOwnership(from) === "nonterminal") {
 			return super.drop(from);
 		}
+		this.throwIfCheckedPruneRemoveBlocksLocalOperation("drop");
 		this.ensureNativeDurabilityRuntimeState();
 		const nativePersistence = this._nativeBackboneCoordinatePersistence;
 		if (
@@ -16374,16 +18634,28 @@ export class SharedLog<
 		// Adapter capability validation above is explicitly unstarted. Establish
 		// the terminal fence only after that precondition succeeds.
 		this.preventParentAttachments();
-		this.stopSubscriptionChangeCallbackAdmission();
-		this.cancelAllJoinWarmupTargets();
-		await this.drainSubscriptionChangeCallbacks();
-		// An already-admitted subscription callback can create a fresh warmup
-		// generation while the first cancellation is draining.
-		this.cancelAllJoinWarmupTargets();
-		await this.drainReceiveHandlers();
-		await this.drainReplicationInfoApplyQueues();
-		await this.drainPendingIHaveCallbacks();
-		this.cancelCurrentReplicationStateAnnouncementRetry();
+		this.stopRepairLifecycle();
+		const replicationRangeTerminalFence =
+			this.acquireReplicationRangeMutationTerminalFence();
+		const pruneRemoveTerminalFence = this.acquirePruneRemoveTerminalFence();
+		try {
+			this.stopSubscriptionChangeCallbackAdmission();
+			this.cancelAllJoinWarmupTargets();
+			await this.drainSubscriptionChangeCallbacks();
+			// An already-admitted subscription callback can create a fresh warmup
+			// generation while the first cancellation is draining.
+			this.cancelAllJoinWarmupTargets();
+			await this.drainReceiveHandlers();
+			await this.drainReplicationInfoApplyQueues();
+			await replicationRangeTerminalFence.drained;
+			await pruneRemoveTerminalFence.drained;
+			await this.drainPendingIHaveCallbacks();
+			this.cancelCurrentReplicationStateAnnouncementRetry();
+		} catch (error) {
+			// The terminal preamble is not safely reversible. Preserve the fence until
+			// a retry finishes cleanup.
+			throw error;
+		}
 		// Best-effort: announce that we are going offline before tearing down
 		// RPC/subscription state (same reasoning as in `close()`).
 		try {
@@ -16636,12 +18908,23 @@ export class SharedLog<
 			}
 			const receiveReplicationInfoReceiveEpoch =
 				this.getReplicationInfoReceiveEpoch(receiveFromHash);
-			if (!context.from.equals(this.node.identity.publicKey)) {
-				this.markReplicatorActivity(receiveFromHash);
-			}
-
 			if (msg instanceof ResponseRoleMessage) {
 				msg = msg.toReplicationInfoMessage(); // migration
+			}
+			if (
+				msg instanceof AllReplicatingSegmentsMessage ||
+				msg instanceof AddedReplicationSegmentMessage
+			) {
+				// Bound decoded untrusted vectors before per-peer/global mutation
+				// queues, trusted-replicator authorization, or liveness side effects.
+				this.validateReplicationRangeAnnouncement(msg.segments);
+			} else if (msg instanceof StoppedReplicating) {
+				// Bound the raw decoded vector before deduplication can hide the
+				// allocation cost, and before liveness or apply-queue side effects.
+				this.validateStoppedReplicationAnnouncement(msg.segmentIds);
+			}
+			if (!context.from.equals(this.node.identity.publicKey)) {
+				this.markReplicatorActivity(receiveFromHash);
 			}
 
 			const syncProfile = this._logProperties?.sync?.profile;
@@ -16868,6 +19151,7 @@ export class SharedLog<
 								);
 								return { columns: prepared.columns };
 							} catch {
+								this.throwIfReplicationOwnershipPoisoned();
 								return undefined;
 							}
 						};
@@ -17182,6 +19466,7 @@ export class SharedLog<
 										);
 								}
 							} catch {
+								this.throwIfReplicationOwnershipPoisoned();
 								nativeRawGroupAssignmentPlans = undefined;
 								nativeRawGroupLeaderPlans = undefined;
 							}
@@ -18047,7 +20332,19 @@ export class SharedLog<
 						};
 						const onAppendHashes = (hashes: string[]) => {
 							if (batchHashOnlyEntryAdded) {
-								this.syncronizer.onEntryAddedHashes?.(hashes);
+								let hashesWithoutWaiters: string[] | undefined;
+								for (const hash of hashes) {
+									if (this._pendingIHave.has(hash)) {
+										this.onEntryAddedHash(hash, () =>
+											materializeMergedEntry(hash),
+										);
+										continue;
+									}
+									(hashesWithoutWaiters ??= []).push(hash);
+								}
+								if (hashesWithoutWaiters) {
+									this.syncronizer.onEntryAddedHashes?.(hashesWithoutWaiters);
+								}
 								return;
 							}
 							for (const hash of hashes) {
@@ -18948,6 +21245,7 @@ export class SharedLog<
 					return;
 				}
 				const segments = replicationSegments.map((x) => x.toReplicationRange());
+				this.validatePersistedReplicationRangeSnapshot(segments);
 
 				await this.rpc
 					.send(new AllReplicatingSegmentsMessage({ segments }), {
@@ -19077,6 +21375,8 @@ export class SharedLog<
 								reset,
 								checkDuplicates: true,
 								timestamp: Number(messageTimestamp),
+								allowLegacyOrderedReplacementPairs:
+									msg instanceof AddedReplicationSegmentMessage,
 							},
 						);
 
@@ -19376,6 +21676,13 @@ export class SharedLog<
 		},
 	): Promise<void> {
 		this.throwIfNativeDurableCommitFailed();
+		const ownershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
+		const throwIfInactive = () =>
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+		throwIfInactive();
 		let entriesToReplicate: Entry<T>[] = [];
 		const localHashes =
 			options?.replicate && this.log.length > 0
@@ -19385,12 +21692,15 @@ export class SharedLog<
 						),
 					)
 				: new Set<string>();
+		throwIfInactive();
 		if (options?.replicate && this.log.length > 0) {
 			// Replicate entries that are already joined locally; join ignores them.
 			for (const element of entries) {
+				throwIfInactive();
 				if (typeof element === "string") {
 					if (localHashes.has(element)) {
 						const entry = await this.log.get(element);
+						throwIfInactive();
 						if (entry) {
 							entriesToReplicate.push(entry);
 						}
@@ -19402,6 +21712,7 @@ export class SharedLog<
 				} else {
 					if (localHashes.has(element.hash)) {
 						const entry = await this.log.get(element.hash);
+						throwIfInactive();
 						if (entry) {
 							entriesToReplicate.push(entry);
 						}
@@ -19412,13 +21723,16 @@ export class SharedLog<
 
 		const onChangeForReplication = options?.replicate
 			? async (change: Change<T>) => {
+					throwIfInactive();
 					if (change.added) {
 						for (const entry of change.added) {
+							throwIfInactive();
 							if (entry.head) {
 								entriesToReplicate.push(entry.entry);
 							}
 						}
 					}
+					throwIfInactive();
 				}
 			: undefined;
 
@@ -19427,24 +21741,38 @@ export class SharedLog<
 			typeof options.replicate !== "boolean" &&
 			options.replicate.assumeSynced;
 		const seedAssumeSyncedPeerHistory = async (entry: Entry<T>) => {
+			throwIfInactive();
 			if (!assumeSynced) {
 				return;
 			}
 
 			const minReplicas = decodeReplicas(entry).getValue(this);
-			const { leaders } = await this.planEntryLeaders(entry, minReplicas, {
-				roleAge: 0,
-				persist: false,
-			});
+			const { leaders } = await this.planEntryLeaders(
+				entry,
+				minReplicas,
+				{
+					roleAge: 0,
+					persist: false,
+				},
+				ownershipLifecycleController,
+			);
 
+			throwIfInactive();
 			this.addPeersToGidPeerHistory(entry.meta.gid, leaders.keys());
 		};
 		const persistCoordinate = async (entry: Entry<T>) => {
+			throwIfInactive();
 			const minReplicas = decodeReplicas(entry).getValue(this);
-			const { leaders } = await this.planEntryLeaders(entry, minReplicas, {
-				persist: {},
-			});
+			const { leaders } = await this.planEntryLeaders(
+				entry,
+				minReplicas,
+				{
+					persist: {},
+				},
+				ownershipLifecycleController,
+			);
 
+			throwIfInactive();
 			if (assumeSynced) {
 				// make sure we dont start to initate syncing process outwards for this entry
 				this.addPeersToGidPeerHistory(entry.meta.gid, leaders.keys());
@@ -19454,8 +21782,11 @@ export class SharedLog<
 		let joinOptions = {
 			...options,
 			onChange: async (change: Change<T>) => {
+				throwIfInactive();
 				await onChangeForReplication?.(change);
+				throwIfInactive();
 				for (const entry of change.added) {
+					throwIfInactive();
 					if (!entry.head) {
 						continue;
 					}
@@ -19464,6 +21795,7 @@ export class SharedLog<
 						// we persist coordinates for all added entries here
 
 						await persistCoordinate(entry.entry);
+						throwIfInactive();
 					} else {
 						// else we persist after replication range update has been done so that
 						// the indexed info becomes up to date
@@ -19473,12 +21805,15 @@ export class SharedLog<
 			},
 		};
 
+		throwIfInactive();
 		await this.log.join(entries, joinOptions);
+		throwIfInactive();
 
 		if (options?.replicate) {
 			let messageToSend: AddedReplicationSegmentMessage | undefined = undefined;
 
 			if (assumeSynced) {
+				throwIfInactive();
 				// `assumeSynced` is an explicit contract that this join should trust the
 				// supplied history and avoid initiating outbound repair while the local
 				// replication ranges settle.
@@ -19486,9 +21821,11 @@ export class SharedLog<
 					Date.now() + ASSUME_SYNCED_REPAIR_SUPPRESSION_MS;
 				for (const entry of entriesToReplicate) {
 					await seedAssumeSyncedPeerHistory(entry);
+					throwIfInactive();
 				}
 			}
 
+			throwIfInactive();
 			await this.replicate(entriesToReplicate, {
 				rebalance: assumeSynced ? false : true,
 				checkDuplicates: assumeSynced ? false : true,
@@ -19500,6 +21837,7 @@ export class SharedLog<
 				// we override the announce step here to make sure we announce all new replication info
 				// in one large message instead
 				announce: (msg) => {
+					throwIfInactive();
 					if (msg instanceof AllReplicatingSegmentsMessage) {
 						throw new Error("Unexpected");
 					}
@@ -19514,16 +21852,23 @@ export class SharedLog<
 					}
 				},
 			});
+			throwIfInactive();
 
 			// it is importat that we call persistCoordinate after this.replicate(entries) as else there might be a prune job deleting the entry before replication duties has been assigned to self
 			for (const entry of entriesToPersist) {
 				await persistCoordinate(entry);
+				throwIfInactive();
 			}
 
 			if (messageToSend) {
-				await this.sendReplicationAnnouncement(messageToSend);
+				await this.sendReplicationAnnouncement(
+					messageToSend,
+					ownershipLifecycleController,
+				);
+				throwIfInactive();
 			}
 		}
+		throwIfInactive();
 	}
 
 	async waitForReplicator(
@@ -20494,6 +22839,7 @@ export class SharedLog<
 			trustedMissing,
 			validatePlan,
 		}) => {
+			this.throwIfReplicationOwnershipPoisoned();
 			if (!trustedMissing || entries.length === 0) {
 				return false;
 			}
@@ -20947,16 +23293,22 @@ export class SharedLog<
 		}
 	}
 
-	private persistPreparedCoordinate(properties: {
-		prepared: PreparedCoordinatePersistence<R>;
-		hash: string;
-		nextHashes: string[];
-		coordinates: NumberFromType<R>[];
-		replicas: number;
-		commitNative?: boolean;
-		commitNativeBackbone?: boolean;
-		deleteHashes?: string[];
-	}): MaybePromise<boolean> {
+	private persistPreparedCoordinate(
+		properties: {
+			prepared: PreparedCoordinatePersistence<R>;
+			hash: string;
+			nextHashes: string[];
+			coordinates: NumberFromType<R>[];
+			replicas: number;
+			commitNative?: boolean;
+			commitNativeBackbone?: boolean;
+			deleteHashes?: string[];
+		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	): MaybePromise<boolean> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const { assignedToRangeBoundary, fields } = properties.prepared;
 		const deleteHashes = combineCoordinateDeleteHashes(
 			properties.nextHashes,
@@ -21029,6 +23381,9 @@ export class SharedLog<
 		}
 
 		const finish = (): MaybePromise<boolean> => {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			const nativeDeleteHashes = combineCoordinateDeleteHashes(
 				properties.nextHashes,
 				properties.deleteHashes,
@@ -21080,16 +23435,22 @@ export class SharedLog<
 		return mapMaybePromise(putResult, finish);
 	}
 
-	private persistPreparedCoordinateNativeTransaction(properties: {
-		coordinateIndex: PutAndDeleteIndex<EntryReplicated<R>>;
-		prepared: PreparedCoordinatePersistence<R>;
-		hash: string;
-		nextHashes: string[];
-		coordinates: NumberFromType<R>[];
-		deleteHashes?: string[];
-		commitNative?: boolean;
-		commitNativeBackbone?: boolean;
-	}): MaybePromise<boolean> {
+	private persistPreparedCoordinateNativeTransaction(
+		properties: {
+			coordinateIndex: PutAndDeleteIndex<EntryReplicated<R>>;
+			prepared: PreparedCoordinatePersistence<R>;
+			hash: string;
+			nextHashes: string[];
+			coordinates: NumberFromType<R>[];
+			deleteHashes?: string[];
+			commitNative?: boolean;
+			commitNativeBackbone?: boolean;
+		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	): MaybePromise<boolean> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const { fields } = properties.prepared;
 		const putNative =
 			properties.coordinateIndex
@@ -21108,6 +23469,9 @@ export class SharedLog<
 			),
 		);
 		const finish = () => {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			const nativeDeleteHashes = combineCoordinateDeleteHashes(
 				properties.nextHashes,
 				properties.deleteHashes,
@@ -21151,18 +23515,27 @@ export class SharedLog<
 		return mapMaybePromise(putResult, finish);
 	}
 
-	private persistBackboneCoordinateFieldsNativeTransaction(properties: {
-		coordinateIndex: PutAndDeleteIndex<EntryReplicated<R>>;
-		fields: SharedLogCoordinateNativeFields<R>;
-		hash: string;
-		coordinates: NumberFromType<R>[];
-		deleteHashes: string[];
-		skipGenericTransientCoordinateIndex?: boolean;
-	}): MaybePromise<boolean> {
+	private persistBackboneCoordinateFieldsNativeTransaction(
+		properties: {
+			coordinateIndex: PutAndDeleteIndex<EntryReplicated<R>>;
+			fields: SharedLogCoordinateNativeFields<R>;
+			hash: string;
+			coordinates: NumberFromType<R>[];
+			deleteHashes: string[];
+			skipGenericTransientCoordinateIndex?: boolean;
+		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	): MaybePromise<boolean> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const { fields } = properties;
 		const useBackboneOnlyCoordinatePersistence =
 			this.canUseBackboneOnlyCoordinatePersistence();
 		const finish = (): MaybePromise<boolean> => {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			this._nativeSharedLogState?.commitEntryCoordinates(
 				properties.hash,
 				fields.gid,
@@ -21345,47 +23718,60 @@ export class SharedLog<
 		return persisted === false;
 	}
 
-	private async persistCoordinate(properties: {
-		coordinates: NumberFromType<R>[];
-		entry: ShallowOrFullEntry<any> | EntryReplicated<R>;
-		leaders:
-			| Map<
-					string,
-					{
-						intersecting: boolean;
-					}
-			  >
-			| false;
-		replicas: number;
-		prev?: EntryReplicated<R>;
-		assignedToRangeBoundary?: boolean;
-		commitNative?: boolean;
-		commitNativeBackbone?: boolean;
-		deleteHashes?: string[];
-		hashNumber?: NumberFromType<R>;
-		nextHashes?: string[];
-		prepared?: PreparedCoordinatePersistence<R>;
-	}) {
+	private async persistCoordinate(
+		properties: {
+			coordinates: NumberFromType<R>[];
+			entry: ShallowOrFullEntry<any> | EntryReplicated<R>;
+			leaders:
+				| Map<
+						string,
+						{
+							intersecting: boolean;
+						}
+				  >
+				| false;
+			replicas: number;
+			prev?: EntryReplicated<R>;
+			assignedToRangeBoundary?: boolean;
+			commitNative?: boolean;
+			commitNativeBackbone?: boolean;
+			deleteHashes?: string[];
+			hashNumber?: NumberFromType<R>;
+			nextHashes?: string[];
+			prepared?: PreparedCoordinatePersistence<R>;
+		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	) {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const prepared =
 			properties.prepared ?? this.createCoordinatePersistenceEntry(properties);
 		if (!prepared) {
 			return false;
 		}
-		return this.persistPreparedCoordinate({
-			prepared,
-			hash: properties.entry.hash,
-			nextHashes: properties.nextHashes ?? properties.entry.meta.next,
-			coordinates: properties.coordinates,
-			replicas: properties.replicas,
-			commitNative: properties.commitNative,
-			commitNativeBackbone: properties.commitNativeBackbone,
-			deleteHashes: properties.deleteHashes,
-		});
+		return this.persistPreparedCoordinate(
+			{
+				prepared,
+				hash: properties.entry.hash,
+				nextHashes: properties.nextHashes ?? properties.entry.meta.next,
+				coordinates: properties.coordinates,
+				replicas: properties.replicas,
+				commitNative: properties.commitNative,
+				commitNativeBackbone: properties.commitNativeBackbone,
+				deleteHashes: properties.deleteHashes,
+			},
+			ownershipLifecycleController,
+		);
 	}
 
 	private async persistCoordinatesBatch(
 		items: CoordinatePersistBatchItem<R>[],
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<boolean[]> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		if (items.length === 0) {
 			return [];
 		}
@@ -21457,10 +23843,18 @@ export class SharedLog<
 		} else {
 			const results: boolean[] = [];
 			for (const item of items) {
-				results.push(await this.persistCoordinate(item));
+				results.push(
+					await this.persistCoordinate(item, ownershipLifecycleController),
+				);
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
 			}
 			return results;
 		}
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 
 		const nativeCoordinateCommits = changed.filter(
 			({ item }) => item.commitNative !== false,
@@ -21545,7 +23939,15 @@ export class SharedLog<
 		return items.map((item) => changedHashes.has(item.entry.hash));
 	}
 
-	private async deleteCoordinates(properties: { hash: string }) {
+	private async deleteCoordinates(
+		properties: { hash: string },
+		ownershipLifecycleController?: AbortController,
+	) {
+		if (ownershipLifecycleController) {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+		}
 		this._nativeSharedLogState?.deleteEntryCoordinates(properties.hash);
 		this._nativeBackbone?.deleteEntryCoordinates(properties.hash);
 		this._residentEntryCoordinatesByHash?.delete(properties.hash);
@@ -21556,6 +23958,11 @@ export class SharedLog<
 			await coordinateIndex.delIds([properties.hash]);
 		} else {
 			await this.entryCoordinatesIndex.del({ query: properties });
+		}
+		if (ownershipLifecycleController) {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		}
 	}
 
@@ -21627,10 +24034,31 @@ export class SharedLog<
 				  }
 				| false;
 		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<Map<string, { intersecting: boolean }>> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		// we consume a list of coordinates in this method since if we are leader of one coordinate we want to persist all of them
-		const set = await this._findLeaders(cursors, options);
-		await this.applyLeaderSelection(cursors, entry, set, options);
+		const set = await this._findLeaders(
+			cursors,
+			options,
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
+		await this.applyLeaderSelection(
+			cursors,
+			entry,
+			set,
+			options,
+			undefined,
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		return set;
 	}
 
@@ -21731,7 +24159,11 @@ export class SharedLog<
 				| false;
 		},
 		assignedToRangeBoundary?: boolean,
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<boolean> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const selfHash = this.node.identity.publicKey.hashcode();
 		const isLeader = leaders.has(selfHash);
 		let shouldPersistLocalLeader = false;
@@ -21746,15 +24178,24 @@ export class SharedLog<
 			options?.persist !== false &&
 			(shouldPersistLocalLeader || options?.persist)
 		) {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			!this.closed &&
-				(await this.persistCoordinate({
-					leaders,
-					coordinates: cursors,
-					replicas: cursors.length,
-					entry,
-					prev: options?.persist?.prev,
-					assignedToRangeBoundary,
-				}));
+				(await this.persistCoordinate(
+					{
+						leaders,
+						coordinates: cursors,
+						replicas: cursors.length,
+						entry,
+						prev: options?.persist?.prev,
+						assignedToRangeBoundary,
+					},
+					ownershipLifecycleController,
+				));
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		}
 
 		return isLeader;
@@ -21764,7 +24205,11 @@ export class SharedLog<
 		entry: ShallowOrFullEntry<any> | EntryReplicated<R>,
 		replicas: number,
 		options?: LeaderSelectionOptions<R>,
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<EntryLeaderPlan<R>> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		let coordinates: NumberFromType<R>[];
 		let leaders: LeaderMap;
 		let assignedToRangeBoundary: boolean | undefined;
@@ -21776,8 +24221,18 @@ export class SharedLog<
 					gid,
 					replicas,
 					options,
-				)) ?? (await this._findLeaderPlanFromHashGid(gid, replicas, options));
+					ownershipLifecycleController,
+				)) ??
+				(await this._findLeaderPlanFromHashGid(
+					gid,
+					replicas,
+					options,
+					ownershipLifecycleController,
+				));
 			if (plan) {
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
 				coordinates = plan.coordinates as NumberFromType<R>[];
 				leaders = plan.leaders;
 				assignedToRangeBoundary =
@@ -21790,6 +24245,7 @@ export class SharedLog<
 					leaders,
 					options,
 					assignedToRangeBoundary,
+					ownershipLifecycleController,
 				);
 				return {
 					coordinates,
@@ -21801,19 +24257,38 @@ export class SharedLog<
 		}
 
 		coordinates = await this.createCoordinates(entry, replicas);
-		leaders = await this._findLeaders(coordinates, options);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
+		leaders = await this._findLeaders(
+			coordinates,
+			options,
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const isLeader = await this.applyLeaderSelection(
 			coordinates,
 			entry,
 			leaders,
 			options,
+			undefined,
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
 		);
 		return { coordinates, leaders, isLeader };
 	}
 
 	private async planEntryLeaderBatch(
 		items: Iterable<EntryLeaderBatchItem<R>>,
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<EntryLeaderPlan<R>[]> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const itemArray = [...items];
 		const firstItem = itemArray[0];
 		if (!firstItem) {
@@ -21823,6 +24298,10 @@ export class SharedLog<
 		if (this.canPlanNativeEntryLeaderBatch(itemArray)) {
 			const context = await this.createLeaderSelectionContext(
 				firstItem.options,
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
 			);
 			const nativeReceivePlanner =
 				this._nativeBackbone ?? this._nativeSharedLogState;
@@ -21890,8 +24369,14 @@ export class SharedLog<
 					}
 				}
 				if (!this.closed && persistItems.length > 0) {
-					await this.persistCoordinatesBatch(persistItems);
+					await this.persistCoordinatesBatch(
+						persistItems,
+						ownershipLifecycleController,
+					);
 				}
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
 				return plans;
 			}
 
@@ -21945,15 +24430,29 @@ export class SharedLog<
 				}
 			}
 			if (!this.closed && persistItems.length > 0) {
-				await this.persistCoordinatesBatch(persistItems);
+				await this.persistCoordinatesBatch(
+					persistItems,
+					ownershipLifecycleController,
+				);
 			}
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			return plans;
 		}
 
 		const plans: EntryLeaderPlan<R>[] = [];
 		for (const item of itemArray) {
 			plans.push(
-				await this.planEntryLeaders(item.entry, item.replicas, item.options),
+				await this.planEntryLeaders(
+					item.entry,
+					item.replicas,
+					item.options,
+					ownershipLifecycleController,
+				),
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
 			);
 		}
 		return plans;
@@ -21963,6 +24462,8 @@ export class SharedLog<
 		groups: Iterable<{ gid: string; maxMaxReplicas: number }>,
 		options?: { roleAge?: number; candidates?: Iterable<string> },
 	): Promise<EntryLeaderPlan<R>[] | undefined> {
+		const ownershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
 		const backbone = this._nativeBackbone;
 		if (!backbone) {
 			return undefined;
@@ -21972,7 +24473,13 @@ export class SharedLog<
 			return [];
 		}
 		try {
-			const context = await this.createLeaderSelectionContext(options);
+			const context = await this.createLeaderSelectionContext(
+				options,
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			const nativePlans = backbone.planLeadersForGidsBatch(
 				groupArray.map((group) => ({
 					gid: group.gid,
@@ -21999,6 +24506,9 @@ export class SharedLog<
 				};
 			});
 		} catch {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			return undefined;
 		}
 	}
@@ -22021,13 +24531,21 @@ export class SharedLog<
 			return undefined;
 		}
 
+		const ownershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
 		const fromHash = properties.from.hashcode();
 		try {
 			const replicaOptions = {
 				minReplicas: this.replicas.min?.getValue(this) || 1,
 				maxReplicas: this.replicas.max?.getValue(this),
 			};
-			const leaderSelectionContext = await this.createLeaderSelectionContext();
+			const leaderSelectionContext = await this.createLeaderSelectionContext(
+				undefined,
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			if (backbone.planPreparedRawReceiveSelection) {
 				const nativeSelection = backbone.planPreparedRawReceiveSelection(
 					properties.hashes,
@@ -22153,6 +24671,9 @@ export class SharedLog<
 				usedLeaderSamplePlans,
 			};
 		} catch {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			return undefined;
 		}
 	}
@@ -22328,16 +24849,25 @@ export class SharedLog<
 		return plan.isLeader;
 	}
 
-	private async createLeaderSelectionContext(options?: {
-		roleAge?: number;
-		candidates?: Iterable<string>;
-	}): Promise<LeaderSelectionContext> {
+	private async createLeaderSelectionContext(
+		options?: {
+			roleAge?: number;
+			candidates?: Iterable<string>;
+		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	): Promise<LeaderSelectionContext> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const cached = this.getCachedLeaderSelectionContext(options);
 		if (cached) {
 			return cached;
 		}
 		const selfHash = this.node.identity.publicKey.hashcode();
 		const roleAge = options?.roleAge ?? (await this.getDefaultMinRoleAge());
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 
 		// Prefer `uniqueReplicators` (replicator cache) as soon as it has any data.
 		// If it is still warming up (for example, only contains self), supplement with
@@ -22349,6 +24879,9 @@ export class SharedLog<
 		} else {
 			selfReplicating =
 				this.knownSelfReplicating(selfHash) ?? (await this.isReplicating());
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			if (this.uniqueReplicators.size > 0) {
 				peerFilter = new Set(this.uniqueReplicators);
 				if (selfReplicating) {
@@ -22372,6 +24905,9 @@ export class SharedLog<
 				} catch {
 					// Best-effort only; keep current peerFilter.
 				}
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
 			} else {
 				try {
 					const subscribers =
@@ -22387,6 +24923,9 @@ export class SharedLog<
 				} catch {
 					// Best-effort only; if pubsub isn't ready, do a full scan.
 				}
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
 			}
 		}
 
@@ -22397,6 +24936,11 @@ export class SharedLog<
 			peerFilter,
 			peerFilterArray: peerFilter ? [...peerFilter] : undefined,
 		};
+		// Every lookup above can yield while a mutation discovers an incoherent
+		// ownership mirror. Do not cache or publish that stale context.
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		this.setCachedLeaderSelectionContext(options, context);
 		return context;
 	}
@@ -22432,15 +24976,29 @@ export class SharedLog<
 			roleAge?: number;
 			candidates?: Iterable<string>;
 		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<Map<string, { intersecting: boolean }>> {
-		const context = await this.createLeaderSelectionContext(options);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
+		const context = await this.createLeaderSelectionContext(
+			options,
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		let peerFilter = context.peerFilter;
 
 		const nativePlanner = this._nativeBackbone ?? this._nativeRangePlanner;
 		if (nativePlanner) {
-			return nativePlanner.findLeaders(cursors, cursors.length, {
+			const leaders = nativePlanner.findLeaders(cursors, cursors.length, {
 				...this.createNativeLeaderOptions(context, options),
 			});
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+			return leaders;
 		}
 
 		if (!options?.candidates) {
@@ -22452,6 +25010,9 @@ export class SharedLog<
 				cursors.length,
 				context.selfReplicating,
 			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		}
 
 		if (!options?.candidates) {
@@ -22460,12 +25021,15 @@ export class SharedLog<
 				context.roleAge,
 				peerFilter,
 			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			if (fullReplicaLeaders) {
 				return fullReplicaLeaders;
 			}
 		}
 
-		return getSamples<R>(
+		const leaders = await getSamples<R>(
 			cursors,
 			this.replicationIndex,
 			context.roleAge,
@@ -22475,6 +25039,10 @@ export class SharedLog<
 				uniqueReplicators: peerFilter,
 			},
 		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
+		return leaders;
 	}
 
 	private async includeIndexedLeaderCandidatesWhenUnderfilled(
@@ -22578,26 +25146,50 @@ export class SharedLog<
 			roleAge?: number;
 			candidates?: Iterable<string>;
 		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<LeaderMap[]> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		if (entries.length === 0) {
 			return [];
 		}
 
 		const nativePlanner = this._nativeBackbone ?? this._nativeRangePlanner;
 		if (nativePlanner && !this.hasCustomFindLeaders()) {
-			const context = await this.createLeaderSelectionContext(options);
-			return nativePlanner.findLeadersBatch(
+			const context = await this.createLeaderSelectionContext(
+				options,
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+			const leaders = nativePlanner.findLeadersBatch(
 				entries.map((entry) => ({
 					cursors: entry.coordinates,
 					replicas: entry.coordinates.length,
 				})),
 				this.createNativeLeaderOptions(context, options),
 			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+			return leaders;
 		}
 
 		const leaders: LeaderMap[] = [];
 		for (const entry of entries) {
-			leaders.push(await this.findLeaders(entry.coordinates, entry, options));
+			leaders.push(
+				await this.findLeaders(
+					entry.coordinates,
+					entry,
+					options,
+					ownershipLifecycleController,
+				),
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		}
 		return leaders;
 	}
@@ -22606,14 +25198,23 @@ export class SharedLog<
 		return this.findLeaders !== SharedLog.prototype.findLeaders;
 	}
 
-	private async planResidentRepairDispatchBatch(properties: {
-		pendingModes: Set<RepairDispatchMode>;
-		pendingPeersByMode: Map<RepairDispatchMode, Set<string>>;
-		optimisticGidPeersByMode: Map<RepairDispatchMode, Map<string, Set<string>>>;
-		fullReplicaRepairCandidates: Set<string>;
-		fullReplicaRepairCandidateCount: number;
-		selfHash: string;
-	}): Promise<Map<RepairDispatchMode, Map<string, string[]>>> {
+	private async planResidentRepairDispatchBatch(
+		properties: {
+			pendingModes: Set<RepairDispatchMode>;
+			pendingPeersByMode: Map<RepairDispatchMode, Set<string>>;
+			optimisticGidPeersByMode: Map<
+				RepairDispatchMode,
+				Map<string, Set<string>>
+			>;
+			fullReplicaRepairCandidates: Set<string>;
+			fullReplicaRepairCandidateCount: number;
+			selfHash: string;
+		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	): Promise<Map<RepairDispatchMode, Map<string, string[]>>> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const nativeRepairPlanner =
 			this._nativeBackbone ?? this._nativeSharedLogState;
 		const pendingPeersByMode = new Map<string, Iterable<string>>();
@@ -22636,7 +25237,13 @@ export class SharedLog<
 			}
 		}
 
-		const context = await this.createLeaderSelectionContext({ roleAge: 0 });
+		const context = await this.createLeaderSelectionContext(
+			{ roleAge: 0 },
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const nativePlan =
 			nativeRepairPlanner!.planRepairDispatchForResidentEntries(
 				{
@@ -22658,16 +25265,25 @@ export class SharedLog<
 		return plan;
 	}
 
-	private async planRepairDispatchBatch(properties: {
-		entries: EntryReplicated<R>[];
-		requestedReplicasBatch: number[];
-		pendingModes: Set<RepairDispatchMode>;
-		pendingPeersByMode: Map<RepairDispatchMode, Set<string>>;
-		optimisticGidPeersByMode: Map<RepairDispatchMode, Map<string, Set<string>>>;
-		fullReplicaRepairCandidates: Set<string>;
-		fullReplicaRepairCandidateCount: number;
-		selfHash: string;
-	}): Promise<Map<RepairDispatchMode, Map<string, string[]>>> {
+	private async planRepairDispatchBatch(
+		properties: {
+			entries: EntryReplicated<R>[];
+			requestedReplicasBatch: number[];
+			pendingModes: Set<RepairDispatchMode>;
+			pendingPeersByMode: Map<RepairDispatchMode, Set<string>>;
+			optimisticGidPeersByMode: Map<
+				RepairDispatchMode,
+				Map<string, Set<string>>
+			>;
+			fullReplicaRepairCandidates: Set<string>;
+			fullReplicaRepairCandidateCount: number;
+			selfHash: string;
+		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	): Promise<Map<RepairDispatchMode, Map<string, string[]>>> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const add = (
 			plan: Map<RepairDispatchMode, Map<string, string[]>>,
 			mode: RepairDispatchMode,
@@ -22712,7 +25328,13 @@ export class SharedLog<
 				}
 			}
 
-			const context = await this.createLeaderSelectionContext({ roleAge: 0 });
+			const context = await this.createLeaderSelectionContext(
+				{ roleAge: 0 },
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 			const nativePlan = nativeRepairPlanner.planRepairDispatchForEntries(
 				{
 					entries: properties.entries.map((entry, i) => ({
@@ -22742,6 +25364,10 @@ export class SharedLog<
 		const currentPeersBatch = await this.findEntryReplicatedLeaderBatch(
 			properties.entries,
 			{ roleAge: 0 },
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
 		);
 		const plan = new Map<RepairDispatchMode, Map<string, string[]>>();
 		for (let i = 0; i < properties.entries.length; i++) {
@@ -22801,7 +25427,11 @@ export class SharedLog<
 			roleAge?: number;
 			candidates?: Iterable<string>;
 		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<Map<string, { intersecting: boolean }> | undefined> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		if (
 			!this._nativeBackbone &&
 			!this._nativeSharedLogState &&
@@ -22810,7 +25440,13 @@ export class SharedLog<
 			return undefined;
 		}
 
-		const context = await this.createLeaderSelectionContext(options);
+		const context = await this.createLeaderSelectionContext(
+			options,
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		if (this._nativeBackbone) {
 			return this._nativeBackbone.planLeadersForGid(
 				gid,
@@ -22844,6 +25480,7 @@ export class SharedLog<
 			roleAge?: number;
 			candidates?: Iterable<string>;
 		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<
 		| {
 				coordinates: Array<number | bigint>;
@@ -22858,7 +25495,13 @@ export class SharedLog<
 		if (!planner) {
 			return undefined;
 		}
-		const context = await this.createLeaderSelectionContext(options);
+		const context = await this.createLeaderSelectionContext(
+			options,
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		return planner.planLeadersForGid(
 			gid,
 			replicas,
@@ -22873,6 +25516,7 @@ export class SharedLog<
 			roleAge?: number;
 			candidates?: Iterable<string>;
 		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<
 		| {
 				coordinates: Array<number | bigint>;
@@ -22885,7 +25529,13 @@ export class SharedLog<
 		if (!planner) {
 			return undefined;
 		}
-		const context = await this.createLeaderSelectionContext(options);
+		const context = await this.createLeaderSelectionContext(
+			options,
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		return planner.planEntryAssignmentForGid(
 			gid,
 			replicas,
@@ -22899,12 +25549,20 @@ export class SharedLog<
 		options?: {
 			roleAge?: number;
 		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<Map<string, { intersecting: boolean }>> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		if (this.canPlanNativeHashGid(entry)) {
 			const nativeResult = await this._findLeadersFromHashGid(
 				entry.meta.gid,
 				replicas,
 				options,
+				ownershipLifecycleController,
+			);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
 			);
 			if (nativeResult) {
 				return nativeResult;
@@ -22912,7 +25570,17 @@ export class SharedLog<
 		}
 
 		const coordinates = await this.createCoordinates(entry, replicas);
-		const result = await this._findLeaders(coordinates, options);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
+		const result = await this._findLeaders(
+			coordinates,
+			options,
+			ownershipLifecycleController,
+		);
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		return result;
 	}
 
@@ -22950,6 +25618,99 @@ export class SharedLog<
 		});
 	}
 
+	private throwIfCheckedPruneRemoveBlocksLocalOperation(
+		operation: "replication range mutation" | "close" | "drop",
+	): void {
+		if (this._checkedPruneRemovalCallbackInvocationDepth > 0) {
+			throw new TerminalOperationNotStartedError(
+				`${operation} cannot start during a checked-prune removal callback`,
+			);
+		}
+	}
+
+	private invokeProgramOnChange(change: Change<T>) {
+		const onChange = this._logProperties?.onChange;
+		if (!onChange) {
+			return;
+		}
+		if (
+			change.removed.length === 0 ||
+			this._checkedPruneRemoveBlocksLocalRangeMutationAdmission === 0
+		) {
+			return onChange(change);
+		}
+
+		this._checkedPruneRemovalCallbackInvocationDepth++;
+		try {
+			// Deliberately return the callback promise without awaiting it. The
+			// reentrancy guard covers the callback's immediate invocation, while an
+			// independent operation started during a later async suspension must be
+			// allowed to queue/drain behind the admitted lower-log removal.
+			return onChange(change);
+		} finally {
+			this._checkedPruneRemovalCallbackInvocationDepth--;
+		}
+	}
+
+	private withReplicationRangeMutationQueue<T>(
+		fn: () => Promise<T>,
+		replicationOwnershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	): Promise<T> {
+		try {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				replicationOwnershipLifecycleController,
+			);
+		} catch (error) {
+			return Promise.reject(error);
+		}
+		if (this._replicationRangeMutationsClosing) {
+			return Promise.reject(
+				new TerminalOperationNotStartedError(
+					"Replication range mutations are closing",
+				),
+			);
+		}
+		const run = (this._replicationRangeMutationTail ?? Promise.resolve())
+			.catch(() => {
+				// A failed predecessor must not leave the queue permanently rejected.
+			})
+			.then(() => {
+				// A predecessor can poison ownership, or close/reopen can replace the
+				// ownership generation, after this mutation was admitted. Recheck the
+				// exact captured generation before a queued follower touches state.
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					replicationOwnershipLifecycleController,
+				);
+				return fn();
+			});
+		this._replicationRangeMutationTail = run.then(
+			() => undefined,
+			() => undefined,
+		);
+		return run;
+	}
+
+	private acquireReplicationRangeMutationTerminalFence(): {
+		drained: Promise<void>;
+	} {
+		this._replicationRangeMutationsClosing = true;
+		return { drained: this.drainReplicationRangeMutationQueue() };
+	}
+
+	private async drainReplicationRangeMutationQueue(): Promise<void> {
+		for (;;) {
+			const tail = this._replicationRangeMutationTail;
+			if (!tail) {
+				return;
+			}
+			await tail.catch(() => {});
+			await Promise.resolve();
+			if (this._replicationRangeMutationTail === tail) {
+				return;
+			}
+		}
+	}
+
 	private async drainReplicationInfoApplyQueues(): Promise<void> {
 		for (;;) {
 			const tails = [...(this._replicationInfoApplyQueueByPeer?.values() ?? [])];
@@ -22961,6 +25722,409 @@ export class SharedLog<
 			// tails admitted while the previous snapshot was settling.
 			await Promise.resolve();
 		}
+	}
+
+	private trackAdmittedPruneRemove<T>(
+		remove: () => Promise<T>,
+		ownershipLifecycleController: AbortController,
+	): Promise<T> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
+		if (this._pruneRemovesClosing) {
+			return Promise.reject(
+				new TerminalOperationNotStartedError("Prune removals are closing"),
+			);
+		}
+
+		let operation: Promise<T>;
+		try {
+			// Invoke synchronously after admission so terminal close cannot establish
+			// its fence between the lifecycle check and the lower-log mutation.
+			operation = Promise.resolve(remove());
+		} catch (error) {
+			return Promise.reject(error);
+		}
+		this._admittedPruneRemoves.add(operation);
+		void operation.then(
+			() => {
+				this._admittedPruneRemoves.delete(operation);
+			},
+			() => {
+				this._admittedPruneRemoves.delete(operation);
+			},
+		);
+		return operation;
+	}
+
+	private acquirePruneRemoveTerminalFence(): { drained: Promise<void> } {
+		this._pruneRemovesClosing = true;
+		return { drained: this.drainAdmittedPruneRemoves() };
+	}
+
+	private async drainAdmittedPruneRemoves(): Promise<void> {
+		for (;;) {
+			const admitted = [...(this._admittedPruneRemoves ?? [])];
+			if (admitted.length === 0) {
+				return;
+			}
+			await Promise.allSettled(admitted);
+			await Promise.resolve();
+		}
+	}
+
+	private schedulePendingMaturity(
+		change: ReplicationChange<ReplicationRangeIndexable<R>>,
+		from: PublicSignKey,
+		options: { rebalance: boolean; waitMs: number },
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	) {
+		if (!this.isRepairLifecycleActive(ownershipLifecycleController)) {
+			return;
+		}
+		let pendingRanges = this.pendingMaturity.get(change.range.hash);
+		if (!pendingRanges) {
+			pendingRanges = new Map();
+			this.pendingMaturity.set(change.range.hash, pendingRanges);
+		}
+		const previous = pendingRanges.get(change.range.idString);
+		if (previous) {
+			clearTimeout(previous.timeout);
+		}
+
+		const pendingMaturity: PendingMaturityRecord<R> = {
+			range: change,
+			timeout: undefined as unknown as ReturnType<typeof setTimeout>,
+			expiresAt: Date.now() + options.waitMs,
+			from,
+			rebalance: options.rebalance,
+			ownershipLifecycleController,
+		};
+		const rangeHash = change.range.hash;
+		const rangeIdString = change.range.idString;
+		pendingMaturity.timeout = setTimeout(() => {
+			if (
+				!this.isRepairLifecycleActive(
+					pendingMaturity.ownershipLifecycleController,
+				)
+			) {
+				if (pendingRanges.get(rangeIdString) === pendingMaturity) {
+					pendingRanges.delete(rangeIdString);
+					if (
+						pendingRanges.size === 0 &&
+						this.pendingMaturity.get(rangeHash) === pendingRanges
+					) {
+						this.pendingMaturity.delete(rangeHash);
+					}
+				}
+				return;
+			}
+			// Clearing or replacing the exact range invalidates this object. A timer
+			// already queued by the event loop must become a no-op.
+			if (pendingRanges.get(rangeIdString) !== pendingMaturity) {
+				return;
+			}
+			pendingRanges.delete(rangeIdString);
+			if (
+				pendingRanges.size === 0 &&
+				this.pendingMaturity.get(rangeHash) === pendingRanges
+			) {
+				this.pendingMaturity.delete(rangeHash);
+			}
+
+			this.events.dispatchEvent(
+				new CustomEvent<ReplicationChangeEvent>("replicator:mature", {
+					detail: { publicKey: pendingMaturity.from },
+				}),
+			);
+
+			if (
+				this.isRepairLifecycleActive(
+					pendingMaturity.ownershipLifecycleController,
+				) &&
+				pendingMaturity.rebalance &&
+				change.range.mode !== ReplicationIntent.Strict &&
+				change.type === "added"
+			) {
+				this.replicationChangeDebounceFn.add({
+					...change,
+					matured: true,
+				});
+			}
+		}, options.waitMs);
+		pendingRanges.set(rangeIdString, pendingMaturity);
+	}
+
+	/**
+	 * Delete exact durable ranges, then reconcile every native/runtime mirror to
+	 * the observed durable post-state. Backends may reject after committing all
+	 * or part of a delete, so a blind compensating put could resurrect data.
+	 *
+	 * This method must run inside the global replication-range mutation lane.
+	 */
+	private async deleteReplicationRangesCoherently(
+		ranges: ReplicationRangeIndexable<R>[],
+		ownerHash: string,
+		options?: { preserveOwnerMembership?: boolean },
+	): Promise<ReplicationRangeDeletionOutcome<R>> {
+		if (ranges.length === 0) {
+			const ownerHasRanges =
+				(await this.replicationIndex.count({ query: { hash: ownerHash } })) > 0;
+			if (!ownerHasRanges) {
+				this.uniqueReplicators.delete(ownerHash);
+				this._replicatorJoinEmitted.delete(ownerHash);
+			}
+			return {
+				removed: [],
+				retained: [],
+				ownerHasRanges,
+			};
+		}
+
+		const uniqueRanges = [
+			...new Map(ranges.map((range) => [range.idString, range])).values(),
+		];
+		const wasReplicator = this.uniqueReplicators.has(ownerHash);
+		const joinWasEmitted = this._replicatorJoinEmitted.has(ownerHash);
+		type Snapshot = {
+			range: ReplicationRangeIndexable<R>;
+			pending?: PendingMaturityRecord<R>;
+		};
+		const snapshots: Snapshot[] = uniqueRanges.map((range) => {
+			const pending = this.pendingMaturity.get(ownerHash)?.get(range.idString);
+			return {
+				range,
+				pending:
+					pending?.range.range.rangeHash === range.rangeHash
+						? pending
+						: undefined,
+			};
+		});
+
+		// Suspend exact maturity timers before the durable operation becomes
+		// ambiguous; confirmed survivors are restored below with their remaining age.
+		for (const snapshot of snapshots) {
+			if (snapshot.pending) {
+				clearTimeout(snapshot.pending.timeout);
+				const peerPending = this.pendingMaturity.get(ownerHash);
+				if (peerPending?.get(snapshot.range.idString) === snapshot.pending) {
+					peerPending.delete(snapshot.range.idString);
+					if (peerPending.size === 0) {
+						this.pendingMaturity.delete(ownerHash);
+					}
+				}
+			}
+		}
+
+		let primaryError: unknown;
+		const deletionErrors: unknown[] = [];
+		const reconciliationErrors: unknown[] = [];
+		// No backend transaction spans bounded calls. Attempt every batch and probe
+		// the exact post-state even after an ambiguous failure.
+		for (
+			let i = 0;
+			i < uniqueRanges.length;
+			i += REPLICATION_RANGE_ID_QUERY_BATCH_SIZE
+		) {
+			try {
+				await this.replicationIndex.del({
+					query: new And([
+						new StringMatch({ key: "hash", value: ownerHash }),
+						new Or(
+							uniqueRanges
+								.slice(i, i + REPLICATION_RANGE_ID_QUERY_BATCH_SIZE)
+								.map(
+									(range) =>
+										new ByteMatchQuery({
+											key: "id",
+											value: range.id,
+										}),
+								),
+						),
+					]),
+				});
+			} catch (error) {
+				deletionErrors.push(error);
+			}
+		}
+		if (deletionErrors.length === 1) {
+			primaryError = deletionErrors[0];
+		} else if (deletionErrors.length > 1) {
+			primaryError = new AggregateError(
+				deletionErrors,
+				"Multiple replication-range deletion batches failed",
+			);
+		}
+
+		const probeCurrentRows = async () => {
+			const currentById = new Map<string, ReplicationRangeIndexable<R>>();
+			for (
+				let i = 0;
+				i < uniqueRanges.length;
+				i += REPLICATION_RANGE_ID_QUERY_BATCH_SIZE
+			) {
+				const current = await this.replicationIndex
+					.iterate(
+						{
+							query: new Or(
+								uniqueRanges
+									.slice(i, i + REPLICATION_RANGE_ID_QUERY_BATCH_SIZE)
+									.map(
+										(range) =>
+											new ByteMatchQuery({
+												key: "id",
+												value: range.id,
+											}),
+									),
+							),
+						},
+						{ reference: true },
+					)
+					.all();
+				for (const result of current) {
+					currentById.set(result.value.idString, result.value);
+				}
+			}
+			return currentById;
+		};
+
+		let currentById: Map<string, ReplicationRangeIndexable<R>>;
+		try {
+			currentById = await probeCurrentRows();
+		} catch (error) {
+			primaryError ??= error;
+			try {
+				currentById = await probeCurrentRows();
+			} catch (retryError) {
+				const failure = new AggregateError(
+					primaryError === retryError
+						? [retryError]
+						: [primaryError, retryError],
+					"Could not determine durable replication-range state after deletion",
+				);
+				this.poisonReplicationOwnership(failure);
+				throw failure;
+			}
+		}
+
+		const removed: ReplicationRangeIndexable<R>[] = [];
+		const retained: ReplicationRangeIndexable<R>[] = [];
+		for (const snapshot of snapshots) {
+			const current = currentById.get(snapshot.range.idString);
+			if (
+				current?.hash === snapshot.range.hash &&
+				current.rangeHash === snapshot.range.rangeHash
+			) {
+				retained.push(snapshot.range);
+			} else {
+				removed.push(snapshot.range);
+			}
+		}
+		if (primaryError === undefined && retained.length > 0) {
+			primaryError = new Error(
+				"Replication-range deletion resolved without removing every selected row",
+			);
+		}
+		const retainedIds = new Set(retained.map((range) => range.idString));
+
+		const reconcileNative = (
+			snapshot: Snapshot,
+			current: ReplicationRangeIndexable<R> | undefined,
+		) => {
+			if (current) {
+				this.putNativeReplicationRange(current);
+			} else {
+				this.deleteNativeReplicationRange(snapshot.range);
+			}
+		};
+		for (const snapshot of snapshots) {
+			const current = currentById.get(snapshot.range.idString);
+			try {
+				reconcileNative(snapshot, current);
+			} catch (error) {
+				primaryError ??= error;
+				try {
+					reconcileNative(snapshot, current);
+				} catch (retryError) {
+					reconciliationErrors.push(retryError);
+				}
+			}
+
+			if (
+				snapshot.pending &&
+				retainedIds.has(snapshot.range.idString) &&
+				!this.pendingMaturity.get(ownerHash)?.has(snapshot.range.idString)
+			) {
+				this.schedulePendingMaturity(
+					snapshot.pending.range,
+					snapshot.pending.from,
+					{
+						rebalance: snapshot.pending.rebalance,
+						waitMs: Math.max(0, snapshot.pending.expiresAt - Date.now()),
+					},
+					snapshot.pending.ownershipLifecycleController,
+				);
+			}
+		}
+
+		let ownerHasRanges = wasReplicator;
+		let ownerStateKnown = false;
+		try {
+			ownerHasRanges =
+				(await this.replicationIndex.count({ query: { hash: ownerHash } })) > 0;
+			ownerStateKnown = true;
+		} catch (error) {
+			primaryError ??= error;
+			reconciliationErrors.push(error);
+		}
+		try {
+			await this.updateOldestTimestampFromIndex();
+		} catch (error) {
+			primaryError ??= error;
+			reconciliationErrors.push(error);
+		}
+		if (ownerStateKnown) {
+			try {
+				// Preserve membership only for a successful destructive reset that is
+				// immediately installing replacement rows.
+				const canPreserveOwnerMembership =
+					options?.preserveOwnerMembership === true &&
+					primaryError === undefined;
+				if (ownerHasRanges || canPreserveOwnerMembership) {
+					if (ownerHasRanges || wasReplicator) {
+						this.uniqueReplicators.add(ownerHash);
+					}
+					if (joinWasEmitted) {
+						this._replicatorJoinEmitted.add(ownerHash);
+					}
+				} else {
+					this.uniqueReplicators.delete(ownerHash);
+					this._replicatorJoinEmitted.delete(ownerHash);
+				}
+			} catch (error) {
+				primaryError ??= error;
+				reconciliationErrors.push(error);
+			}
+		}
+
+		let outcomeError = primaryError;
+		if (reconciliationErrors.length > 0) {
+			const errors = [
+				...(primaryError === undefined ? [] : [primaryError]),
+				...reconciliationErrors.filter((error) => error !== primaryError),
+			];
+			outcomeError = new AggregateError(
+				errors,
+				"Replication-range deletion and post-state reconciliation failed",
+			);
+			this.poisonReplicationOwnership(outcomeError);
+		}
+		return {
+			removed,
+			retained,
+			ownerHasRanges,
+			error: outcomeError,
+		};
 	}
 
 	private advanceReplicationInfoReceiveEpoch(peerHash: string): object {
@@ -23261,10 +26425,12 @@ export class SharedLog<
 			return;
 		}
 		if (replicationSegments.length > 0) {
+			const segments = replicationSegments.map((x) => x.toReplicationRange());
+			this.validatePersistedReplicationRangeSnapshot(segments);
 			await this.rpc
 				.send(
 					new AllReplicatingSegmentsMessage({
-						segments: replicationSegments.map((x) => x.toReplicationRange()),
+						segments,
 					}),
 					{
 						mode: new AcknowledgeDelivery({ redundancy: 1, to: [publicKey] }),
@@ -23354,21 +26520,53 @@ export class SharedLog<
 			}
 		>,
 		options?: { timeout?: number; unchecked?: boolean },
+		ownershipLifecycleController?: AbortController,
 	): Promise<any>[] {
+		if (!options?.unchecked && this.closed) {
+			return [];
+		}
+		ownershipLifecycleController ??=
+			this.captureReplicationOwnershipLifecycle();
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		if (options?.unchecked) {
 			return [...entries.values()].map((x) => {
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
 				this.deleteGidPeerHistory(x.entry.meta.gid);
 				this.removePruneRequestSent(x.entry.hash);
 				this._checkedPrune.clearConfirmedReplicators(x.entry.hash);
-				return this.log.remove(x.entry, {
-					recursively: true,
-				});
+				return this.trackAdmittedPruneRemove(
+					() =>
+						this.log.remove(x.entry, {
+							recursively: true,
+						}),
+					ownershipLifecycleController,
+				);
 			});
 		}
 
-		if (this.closed) {
-			return [];
-		}
+		const checkedPruneCoordinator = this._checkedPrune;
+		const closeController = this._closeController;
+		const isCheckedPruneLifecycleCurrent = () =>
+			this.isRepairLifecycleActive(ownershipLifecycleController) &&
+			this._checkedPrune === checkedPruneCoordinator &&
+			this._closeController === closeController;
+		const throwIfCheckedPruneLifecycleInactive = () => {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+			if (
+				this._checkedPrune !== checkedPruneCoordinator ||
+				this._closeController !== closeController
+			) {
+				throw new TerminalOperationNotStartedError(
+					"Checked prune lifecycle is no longer active",
+				);
+			}
+		};
 
 		// ask network if they have they entry,
 		// so I can delete it
@@ -23396,7 +26594,7 @@ export class SharedLog<
 				set.push(entry.hash);
 			}
 
-			const pendingPrev = this._checkedPrune.getPendingDelete(entry.hash);
+			const pendingPrev = checkedPruneCoordinator.getPendingDelete(entry.hash);
 			if (pendingPrev) {
 				// If a background prune is already in-flight, an explicit prune request should
 				// still respect the caller's timeout. Otherwise, tests (and user calls) can
@@ -23430,73 +26628,178 @@ export class SharedLog<
 
 			const minReplicas = decodeReplicas(entry);
 			const deferredPromise: DeferredPromise<void> = pDefer();
+			let finalOwnershipRevalidationFailed = false;
 
 			const clear = () => {
-				const pending = this._checkedPrune.getPendingDelete(entry.hash);
+				const pending = checkedPruneCoordinator.getPendingDelete(entry.hash);
 				if (pending?.promise === deferredPromise) {
-					this._checkedPrune.deletePendingDelete(entry.hash, pending);
+					checkedPruneCoordinator.deletePendingDelete(entry.hash, pending);
 				}
 				clearTimeout(timeout);
 			};
 
 			const resolve = () => {
+				try {
+					throwIfCheckedPruneLifecycleInactive();
+				} catch (error) {
+					reject(error);
+					return;
+				}
 				clearTimeout(timeout);
-				this.clearCheckedPruneRetry(entry.hash);
+				checkedPruneCoordinator.clearRetry(entry.hash);
 				cleanupTimer.push(
-					setTimeout(async () => {
-						this.deleteGidPeerHistory(entry.meta.gid);
-						this.removePruneRequestSent(entry.hash);
-						this._checkedPrune.clearConfirmedReplicators(entry.hash);
-
-						const ownership = await this.revalidateCheckedPruneOwnership({
-							hash: entry.hash,
-							entry,
-							leaders: this.checkedPruneLeadersToMap(leaders),
-							selfReplicating: true,
-						});
-						if (ownership.localLeader) {
-							clear();
-							if (!explicitTimeout) {
-								this.scheduleCheckedPruneRetry({ entry, leaders });
+					setTimeout(() => {
+						const run = async () => {
+							throwIfCheckedPruneLifecycleInactive();
+							const ownership = await this.revalidateCheckedPruneOwnership({
+								hash: entry.hash,
+								entry,
+								leaders: this.checkedPruneLeadersToMap(leaders),
+								selfReplicating: true,
+								ownershipLifecycleController,
+								checkedPruneCoordinator,
+							});
+							throwIfCheckedPruneLifecycleInactive();
+							if (ownership.localLeader) {
+								clear();
+								if (!explicitTimeout) {
+									this.scheduleCheckedPruneRetry(
+										{ entry, leaders },
+										ownershipLifecycleController,
+									);
+								}
+								deferredPromise.reject(
+									new Error("Failed to delete, is leader again"),
+								);
+								return;
 							}
-							deferredPromise.reject(
-								new Error("Failed to delete, is leader again"),
-							);
-							return;
-						}
 
-						this._checkedPrune.markRemoving(entry.hash);
-						return this.log
-							.remove(entry, {
-								recursively: true,
-							})
-							.then(() => {
+							try {
+								const removed = await this.withReplicationRangeMutationQueue(
+									async () => {
+										throwIfCheckedPruneLifecycleInactive();
+										// The network confirmation and preliminary planner check
+										// deliberately happen outside the global ownership lane. Once
+										// admitted here, re-read leadership and keep the lower-log
+										// delete in the same lane so a durable range mutation cannot
+										// commit between the decision and the destructive operation.
+										let finalOwnership: {
+											leaders: CheckedPruneLeaderMap;
+											localLeader: boolean;
+										};
+										try {
+											finalOwnership =
+												await this.revalidateCheckedPruneOwnership({
+													hash: entry.hash,
+													entry,
+													leaders: this.checkedPruneLeadersToMap(leaders),
+													selfReplicating: true,
+													requireFreshLeaderDecision: true,
+													ownershipLifecycleController,
+													checkedPruneCoordinator,
+												});
+										} catch (error) {
+											finalOwnershipRevalidationFailed = true;
+											throw error;
+										}
+										throwIfCheckedPruneLifecycleInactive();
+										if (finalOwnership.localLeader) {
+											return false;
+										}
+
+										this.deleteGidPeerHistory(entry.meta.gid);
+										checkedPruneCoordinator.removeRequestSent(entry.hash);
+										checkedPruneCoordinator.clearConfirmedReplicators(
+											entry.hash,
+										);
+										throwIfCheckedPruneLifecycleInactive();
+										checkedPruneCoordinator.markRemoving(entry.hash);
+										this._checkedPruneRemoveBlocksLocalRangeMutationAdmission++;
+										try {
+											await this.trackAdmittedPruneRemove(
+												() =>
+													this.log.remove(entry, {
+														recursively: true,
+													}),
+												ownershipLifecycleController,
+											);
+										} finally {
+											this
+												._checkedPruneRemoveBlocksLocalRangeMutationAdmission--;
+										}
+										clear();
+										checkedPruneCoordinator.markDone(entry.hash);
+										deferredPromise.resolve();
+										return true;
+									},
+									ownershipLifecycleController,
+								);
+								if (!removed) {
+									clear();
+									if (!explicitTimeout) {
+										this.scheduleCheckedPruneRetry(
+											{ entry, leaders },
+											ownershipLifecycleController,
+										);
+									}
+									deferredPromise.reject(
+										new Error("Failed to delete, is leader again"),
+									);
+									return;
+								}
+							} catch (error) {
 								clear();
-								this._checkedPrune.markDone(entry.hash);
-								deferredPromise.resolve();
-							})
-							.catch((e) => {
-								clear();
-								this._checkedPrune.markCancelled(entry.hash, {
-									preserveRetry: false,
+								checkedPruneCoordinator.markCancelled(entry.hash, {
+									preserveRetry:
+										!explicitTimeout && finalOwnershipRevalidationFailed,
 								});
-								deferredPromise.reject(e);
-							})
-							.finally(async () => {
+								if (!explicitTimeout && finalOwnershipRevalidationFailed) {
+									this.scheduleCheckedPruneRetry(
+										{ entry, leaders },
+										ownershipLifecycleController,
+									);
+								}
+								deferredPromise.reject(error);
+								return;
+							}
+
+							// The delete has already settled. Diagnostics are best-effort:
+							// poison/close/reopen must not turn an ignored timer callback into
+							// an unhandled rejection or mutate the next lifecycle.
+							if (!isCheckedPruneLifecycleCurrent()) {
+								return;
+							}
+							try {
 								this.deleteGidPeerHistory(entry.meta.gid);
-								this.removePruneRequestSent(entry.hash);
-								this._checkedPrune.clearConfirmedReplicators(entry.hash);
-
-								const ownership = await this.revalidateCheckedPruneOwnership({
-									hash: entry.hash,
-									entry,
-									leaders: this.checkedPruneLeadersToMap(leaders),
-									selfReplicating: true,
-								});
-								if (ownership.localLeader) {
+								checkedPruneCoordinator.removeRequestSent(entry.hash);
+								checkedPruneCoordinator.clearConfirmedReplicators(entry.hash);
+								const postRemoveOwnership =
+									await this.revalidateCheckedPruneOwnership({
+										hash: entry.hash,
+										entry,
+										leaders: this.checkedPruneLeadersToMap(leaders),
+										selfReplicating: true,
+										ownershipLifecycleController,
+										checkedPruneCoordinator,
+									});
+								if (
+									isCheckedPruneLifecycleCurrent() &&
+									postRemoveOwnership.localLeader
+								) {
 									logger.error("Unexpected: Is leader after delete");
 								}
-							});
+							} catch (error) {
+								if (
+									isCheckedPruneLifecycleCurrent() &&
+									!isNotStartedError(error as Error)
+								) {
+									logger.error(error);
+								}
+							}
+						};
+						void run().catch((error) => {
+							reject(error);
+						});
 					}, this.waitForPruneDelay),
 				);
 			};
@@ -23507,7 +26810,7 @@ export class SharedLog<
 					e instanceof Error &&
 					typeof e.message === "string" &&
 					e.message.startsWith("Timeout for checked pruning");
-				this._checkedPrune.markCancelled(entry.hash, {
+				checkedPruneCoordinator.markCancelled(entry.hash, {
 					preserveRetry: !explicitTimeout && isCheckedPruneTimeout,
 				});
 				deferredPromise.reject(e);
@@ -23531,8 +26834,11 @@ export class SharedLog<
 				// For internal/background prune flows (no explicit timeout), retry a few times
 				// to avoid "permanently prunable" entries when `_pendingIHave` expires under
 				// heavy load.
-				if (!explicitTimeout) {
-					this.scheduleCheckedPruneRetry({ entry, leaders });
+				if (!explicitTimeout && isCheckedPruneLifecycleCurrent()) {
+					this.scheduleCheckedPruneRetry(
+						{ entry, leaders },
+						ownershipLifecycleController,
+					);
 				}
 				reject(
 					new Error(
@@ -23542,13 +26848,19 @@ export class SharedLog<
 			}, checkedPruneTimeoutMs);
 			timeout.unref?.();
 
-			this._checkedPrune.setPendingDelete(
+			checkedPruneCoordinator.setPendingDelete(
 				entry.hash,
 				{
 					promise: deferredPromise,
 					clear,
 					reject,
 					resolve: async (publicKeyHash: string) => {
+						try {
+							throwIfCheckedPruneLifecycleInactive();
+						} catch (error) {
+							reject(error);
+							return;
+						}
 						const minReplicasObj = this.getClampedReplicas(minReplicas);
 						const minReplicasValue = minReplicasObj.getValue(this);
 
@@ -23571,8 +26883,14 @@ export class SharedLog<
 						) {
 							return;
 						}
+						try {
+							throwIfCheckedPruneLifecycleInactive();
+						} catch (error) {
+							reject(error);
+							return;
+						}
 
-						const existCounter = this._checkedPrune.addConfirmedReplicator(
+						const existCounter = checkedPruneCoordinator.addConfirmedReplicator(
 							entry.hash,
 							publicKeyHash,
 						);
@@ -23592,17 +26910,18 @@ export class SharedLog<
 		}
 
 		const emitMessages = async (entries: string[], to: string) => {
+			throwIfCheckedPruneLifecycleInactive();
 			const filteredSet: string[] = [];
 			for (const entry of entries) {
 				/* TODO why can we not have this statement? 
 				if (set.has(to)) {
 					continue;
 				} */
-				this._checkedPrune.addRequestSent(entry, to);
+				checkedPruneCoordinator.addRequestSent(entry, to);
 				filteredSet.push(entry);
 			}
 			if (filteredSet.length > 0) {
-				return this.rpc.send(
+				const result = await this.rpc.send(
 					new RequestIPrune({
 						hashes: filteredSet,
 					}),
@@ -23614,6 +26933,8 @@ export class SharedLog<
 						priority: CONVERGENCE_MESSAGE_PRIORITY,
 					},
 				);
+				throwIfCheckedPruneLifecycleInactive();
+				return result;
 			}
 		};
 
@@ -23636,12 +26957,15 @@ export class SharedLog<
 			let inFlight = false;
 			const timer = setInterval(() => {
 				if (inFlight) return;
-				if (this.closed) return;
+				if (!isCheckedPruneLifecycleCurrent()) {
+					clearInterval(timer);
+					return;
+				}
 
 				const pendingByPeer: [string, string[]][] = [];
 				for (const [peer, hashes] of peerToEntries) {
 					const pending = hashes.filter((h) =>
-						this._checkedPrune.hasPendingDelete(h),
+						checkedPruneCoordinator.hasPendingDelete(h),
 					);
 					if (pending.length > 0) {
 						pendingByPeer.push([peer, pending]);
@@ -23658,7 +26982,9 @@ export class SharedLog<
 						emitMessages(hashes, peer).catch(() => {}),
 					),
 				).finally(() => {
-					inFlight = false;
+					if (isCheckedPruneLifecycleCurrent()) {
+						inFlight = false;
+					}
 				});
 			}, resendIntervalMs);
 			timer.unref?.();
@@ -23669,11 +26995,11 @@ export class SharedLog<
 			for (const timer of cleanupTimer) {
 				clearTimeout(timer);
 			}
-			this._closeController.signal.removeEventListener("abort", cleanup);
+			closeController.signal.removeEventListener("abort", cleanup);
 		};
 
 		Promise.allSettled(promises).finally(cleanup);
-		this._closeController.signal.addEventListener("abort", cleanup);
+		closeController.signal.addEventListener("abort", cleanup);
 		return promises;
 	}
 
@@ -23681,6 +27007,7 @@ export class SharedLog<
 	 * For debugging
 	 */
 	async getPrunable(roleAge?: number) {
+		this.throwIfReplicationOwnershipPoisoned();
 		const heads = await this.log.getHeads(true).all();
 		let prunable: Entry<any>[] = [];
 		for (const head of heads) {
@@ -23696,6 +27023,7 @@ export class SharedLog<
 	}
 
 	async getNonPrunable(roleAge?: number) {
+		this.throwIfReplicationOwnershipPoisoned();
 		const heads = await this.log.getHeads(true).all();
 		let nonPrunable: Entry<any>[] = [];
 		for (const head of heads) {
@@ -23739,6 +27067,14 @@ export class SharedLog<
 			| ReplicationChanges<ReplicationRangeIndexable<R>>
 			| ReplicationChanges<ReplicationRangeIndexable<R>>[],
 	) {
+		const ownershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
+		const isOwnershipLifecycleCurrent = () =>
+			this.isRepairLifecycleActive(ownershipLifecycleController);
+		const throwIfOwnershipLifecycleInactive = () =>
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
 		/**
 		 * TODO use information of new joined/leaving peer to create a subset of heads
 		 * that we potentially need to share with other peers
@@ -23763,6 +27099,9 @@ export class SharedLog<
 		}
 
 		await this.log.trim();
+		if (!isOwnershipLifecycleCurrent()) {
+			return false;
+		}
 
 		// On removed ranges (peer leaves / shrink), gid-level history can hide
 		// per-entry gaps. Force a fresh delivery pass for reassigned entries.
@@ -23772,6 +27111,9 @@ export class SharedLog<
 		const gidPeersHistorySnapshot = new Map<string, Set<string> | undefined>();
 		const dedupeCutoff = Date.now() - RECENT_REPAIR_DISPATCH_TTL_MS;
 		for (const [target, hashes] of this._recentRepairDispatch) {
+			if (!isOwnershipLifecycleCurrent()) {
+				return false;
+			}
 			for (const [hash, ts] of hashes) {
 				if (ts <= dedupeCutoff) {
 					hashes.delete(hash);
@@ -23798,6 +27140,9 @@ export class SharedLog<
 				(change.type === "removed" || change.type === "replaced"),
 		);
 		for (const change of changes) {
+			if (!isOwnershipLifecycleCurrent()) {
+				return false;
+			}
 			if (
 				change.range.hash !== selfHash &&
 				(change.type === "removed" || change.type === "replaced")
@@ -23842,10 +27187,12 @@ export class SharedLog<
 				)
 			: changes;
 		const isCurrentJoinWarmupTarget = (target: string) =>
+			isOwnershipLifecycleCurrent() &&
 			warmupPeers.has(target) &&
 			this._joinWarmupGenerationByTarget.get(target) ===
 				joinWarmupGenerations.get(target);
 		const areJoinWarmupGenerationsCurrent = () =>
+			isOwnershipLifecycleCurrent() &&
 			[...warmupPeers].every(isCurrentJoinWarmupTarget);
 
 		try {
@@ -23854,6 +27201,9 @@ export class SharedLog<
 				Map<string, EntryReplicated<any>>
 			> = new Map();
 			const flushUncheckedDeliverTarget = (target: string) => {
+				if (!isOwnershipLifecycleCurrent()) {
+					return;
+				}
 				const entries = uncheckedDeliver.get(target);
 				if (!entries || entries.size === 0) {
 					return;
@@ -23868,25 +27218,33 @@ export class SharedLog<
 					: isWarmupTarget
 						? "join-warmup"
 						: "join-authoritative";
-				this.dispatchMaybeMissingEntries(target, entries, {
-					bypassRecentDedupe: isWarmupTarget || forceFreshDelivery,
-					bypassKnownPeerHints:
-						forceFreshDelivery ||
-						(mode === "join-authoritative" && addedPeers.has(target)),
-					mode,
-					retryScheduleMs:
-						mode === "join-warmup"
-							? JOIN_WARMUP_RETRY_SCHEDULE_MS
-							: mode === "join-authoritative"
-								? [0]
-								: undefined,
-				});
+				this.dispatchMaybeMissingEntries(
+					target,
+					entries,
+					{
+						bypassRecentDedupe: isWarmupTarget || forceFreshDelivery,
+						bypassKnownPeerHints:
+							forceFreshDelivery ||
+							(mode === "join-authoritative" && addedPeers.has(target)),
+						mode,
+						retryScheduleMs:
+							mode === "join-warmup"
+								? JOIN_WARMUP_RETRY_SCHEDULE_MS
+								: mode === "join-authoritative"
+									? [0]
+									: undefined,
+					},
+					ownershipLifecycleController,
+				);
 				uncheckedDeliver.delete(target);
 			};
 			const queueUncheckedDeliver = (
 				target: string,
 				entry: EntryReplicated<any>,
 			) => {
+				if (!isOwnershipLifecycleCurrent()) {
+					return;
+				}
 				if (warmupPeers.has(target) && !isCurrentJoinWarmupTarget(target)) {
 					return;
 				}
@@ -23915,9 +27273,8 @@ export class SharedLog<
 					},
 				)) {
 					if (
-						this.closed ||
-						(useJoinWarmupFastPath &&
-							!areJoinWarmupGenerationsCurrent())
+						!isOwnershipLifecycleCurrent() ||
+						(useJoinWarmupFastPath && !areJoinWarmupGenerationsCurrent())
 					) {
 						break;
 					}
@@ -23957,6 +27314,9 @@ export class SharedLog<
 								persist: false,
 							},
 						);
+						if (!isOwnershipLifecycleCurrent()) {
+							return false;
+						}
 						if (!areJoinWarmupGenerationsCurrent()) {
 							continue;
 						}
@@ -23994,14 +27354,25 @@ export class SharedLog<
 						);
 
 						if (!currentPeers.has(selfHash)) {
-							this.pruneDebouncedFnAddIfNotKeeping({
-								key: entryReplicated.hash,
-								value: { entry: entryReplicated, leaders: currentPeers },
-							});
+							throwIfOwnershipLifecycleInactive();
+							await this.pruneDebouncedFnAddIfNotKeeping(
+								{
+									key: entryReplicated.hash,
+									value: { entry: entryReplicated, leaders: currentPeers },
+								},
+								ownershipLifecycleController,
+							);
+							if (!isOwnershipLifecycleCurrent()) {
+								return false;
+							}
 
 							this.responseToPruneDebouncedFn.delete(entryReplicated.hash);
 						} else {
+							throwIfOwnershipLifecycleInactive();
 							await this.cancelCheckedPruneForLocalLeader(entryReplicated.hash);
+							if (!isOwnershipLifecycleCurrent()) {
+								return false;
+							}
 						}
 						continue;
 					}
@@ -24026,6 +27397,9 @@ export class SharedLog<
 							roleAge: 0,
 						},
 					);
+					if (!isOwnershipLifecycleCurrent()) {
+						return false;
+					}
 
 					for (const [currentPeer] of currentPeers) {
 						if (currentPeer === this.node.identity.publicKey.hashcode()) {
@@ -24071,56 +27445,87 @@ export class SharedLog<
 					);
 
 					if (!isLeader) {
-						this.pruneDebouncedFnAddIfNotKeeping({
-							key: entryReplicated.hash,
-							value: { entry: entryReplicated, leaders: currentPeers },
-						});
+						throwIfOwnershipLifecycleInactive();
+						await this.pruneDebouncedFnAddIfNotKeeping(
+							{
+								key: entryReplicated.hash,
+								value: { entry: entryReplicated, leaders: currentPeers },
+							},
+							ownershipLifecycleController,
+						);
+						if (!isOwnershipLifecycleCurrent()) {
+							return false;
+						}
 
 						this.responseToPruneDebouncedFn.delete(entryReplicated.hash); // don't allow others to prune because of expecting me to replicating this entry
 					} else {
+						throwIfOwnershipLifecycleInactive();
 						await this.cancelCheckedPruneForLocalLeader(entryReplicated.hash);
+						if (!isOwnershipLifecycleCurrent()) {
+							return false;
+						}
 					}
 				}
 			}
 
 			if (forceFreshDelivery) {
+				throwIfOwnershipLifecycleInactive();
 				// Pure leave/shrink churn can have zero `addedPeers`, but the peers that
 				// received redistributed entries still need a follow-up repair pass if the
 				// immediate maybe-sync misses one entry.
-				this.scheduleRepairSweep({
-					mode: "churn",
-					peers: churnRepairPeers,
-				});
+				this.scheduleRepairSweep(
+					{
+						mode: "churn",
+						peers: churnRepairPeers,
+					},
+					ownershipLifecycleController,
+				);
 			} else if (useJoinWarmupFastPath) {
+				throwIfOwnershipLifecycleInactive();
 				// Pure join warmup uses the cheap immediate maybe-missing dispatch above,
 				// then defers the authoritative sweep so it does not compete with the
 				// write burst itself.
 				const peers = new Set(addedPeers);
+				const repairTimers = this._repairRetryTimers;
 				const timer = setTimeout(() => {
-					this._repairRetryTimers.delete(timer);
-					if (this.closed) {
+					repairTimers.delete(timer);
+					if (!isOwnershipLifecycleCurrent()) {
 						return;
 					}
-					this.scheduleRepairSweep({
-						mode: "join-warmup",
-						peers,
-						joinWarmupGenerations,
-					});
+					this.scheduleRepairSweep(
+						{
+							mode: "join-warmup",
+							peers,
+							joinWarmupGenerations,
+						},
+						ownershipLifecycleController,
+					);
 				}, 250);
 				timer.unref?.();
-				this._repairRetryTimers.add(timer);
+				repairTimers.add(timer);
 			} else if (authoritativeRepairPeers.size > 0) {
-				this.scheduleRepairSweep({
-					mode: "join-authoritative",
-					peers: authoritativeRepairPeers,
-				});
+				throwIfOwnershipLifecycleInactive();
+				this.scheduleRepairSweep(
+					{
+						mode: "join-authoritative",
+						peers: authoritativeRepairPeers,
+					},
+					ownershipLifecycleController,
+				);
 			}
 
 			if (!forceFreshDelivery && authoritativeRepairPeers.size > 0) {
-				this.scheduleJoinAuthoritativeRepair(authoritativeRepairPeers);
+				throwIfOwnershipLifecycleInactive();
+				this.scheduleJoinAuthoritativeRepair(
+					authoritativeRepairPeers,
+					ownershipLifecycleController,
+				);
 			}
 
 			for (const target of [...uncheckedDeliver.keys()]) {
+				if (!isOwnershipLifecycleCurrent()) {
+					return false;
+				}
 				flushUncheckedDeliverTarget(target);
 			}
 
@@ -24128,6 +27533,9 @@ export class SharedLog<
 				hasSelfRangeRemoval && !this._isAdaptiveReplicating
 					? await this.getMyReplicationSegments()
 					: undefined;
+			if (!isOwnershipLifecycleCurrent()) {
+				return false;
+			}
 			const hasFixedSelfRangeRemovalToZero =
 				localSegmentsAfterChange != null &&
 				localSegmentsAfterChange.length > 0 &&
@@ -24145,6 +27553,7 @@ export class SharedLog<
 					));
 
 			if (shouldRunLocalPruneScan) {
+				throwIfOwnershipLifecycleInactive();
 				// Adaptive range changes and fixed zero-width updates can make already-indexed
 				// local heads prunable even when the incremental rebalance scan misses them
 				// under churn or timing pressure. Re-scan after repair dispatches are flushed
@@ -24152,13 +27561,22 @@ export class SharedLog<
 				await this.pruneIndexedEntriesNoLongerLed({
 					useDefaultRoleAge: true,
 				});
+				if (!isOwnershipLifecycleCurrent()) {
+					return false;
+				}
 				await this.pruneCurrentHeadsNoLongerLed({
 					useDefaultRoleAge: true,
 				});
+				if (!isOwnershipLifecycleCurrent()) {
+					return false;
+				}
 			}
 
 			return changed;
 		} catch (error: any) {
+			if (!isOwnershipLifecycleCurrent()) {
+				return false;
+			}
 			if (isNotStartedError(error)) {
 				return false; // we are not started yet, so no changes
 			}
@@ -24225,9 +27643,15 @@ export class SharedLog<
 		);
 	}
 
-	async rebalanceParticipation() {
+	async rebalanceParticipation(
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+		rebalanceParticipationDebounced = this.rebalanceParticipationDebounced,
+	) {
 		// update more participation rate to converge to the average expected rate or bounded by
 		// resources such as memory and or cpu
+		const isCurrent = () =>
+			this.isRepairLifecycleActive(ownershipLifecycleController) &&
+			this.rebalanceParticipationDebounced === rebalanceParticipationDebounced;
 
 		const isClosedStoreRace = (error: any) => {
 			const message =
@@ -24241,7 +27665,7 @@ export class SharedLog<
 		};
 
 		const fn = async () => {
-			if (this.closed) {
+			if (!isCurrent()) {
 				return false;
 			}
 
@@ -24252,13 +27676,17 @@ export class SharedLog<
 
 			if (this._isAdaptiveReplicating) {
 				if (this.shouldDelayAdaptiveRebalance()) {
-					this.rebalanceParticipationDebounced?.call();
+					if (isCurrent()) {
+						void rebalanceParticipationDebounced?.call();
+					}
 					return false;
 				}
 
 				const peers = this.replicationIndex;
 				const usedMemory = await this.getMemoryUsage();
+				if (!isCurrent()) return false;
 				let dynamicRange = await this.getDynamicRange();
+				if (!isCurrent()) return false;
 
 				if (!dynamicRange) {
 					return; // not allowed to replicate
@@ -24270,12 +27698,22 @@ export class SharedLog<
 				) {
 					// Memory pressure can leave prunable frontier heads even when the
 					// coordinate-index scan has no pending prune candidates.
-					await this.pruneIndexedEntriesNoLongerLed();
-					await this.pruneCurrentHeadsNoLongerLed();
+					await this.pruneIndexedEntriesNoLongerLed(
+						undefined,
+						ownershipLifecycleController,
+					);
+					if (!isCurrent()) return false;
+					await this.pruneCurrentHeadsNoLongerLed(
+						undefined,
+						ownershipLifecycleController,
+					);
+					if (!isCurrent()) return false;
 				}
 
 				const peersSize = (await peers.getSize()) || 1;
+				if (!isCurrent()) return false;
 				const totalParticipation = await this.calculateTotalParticipation();
+				if (!isCurrent()) return false;
 
 				const newFactor = this.replicationController.step({
 					memoryUsage: usedMemory,
@@ -24318,15 +27756,21 @@ export class SharedLog<
 					const canReplicate =
 						!this._isTrustedReplicator ||
 						(await this._isTrustedReplicator(this.node.identity.publicKey));
+					if (!isCurrent()) return false;
 					if (!canReplicate) {
 						return false;
 					}
 
 					try {
-						await this.startAnnounceReplicating([dynamicRange], {
-							checkDuplicates: false,
-							reset: false,
-						});
+						await this.startAnnounceReplicating(
+							[dynamicRange],
+							{
+								checkDuplicates: false,
+								reset: false,
+							},
+							ownershipLifecycleController,
+						);
+						if (!isCurrent()) return false;
 					} catch (error) {
 						if (
 							isTransientReplicationAnnouncementError(error) &&
@@ -24338,11 +27782,15 @@ export class SharedLog<
 					}
 
 					/* await this._updateRole(newRole, onRoleChange); */
-					this.rebalanceParticipationDebounced?.call();
+					if (isCurrent()) {
+						void rebalanceParticipationDebounced?.call();
+					}
 
 					return true;
 				} else {
-					this.rebalanceParticipationDebounced?.call();
+					if (isCurrent()) {
+						void rebalanceParticipationDebounced?.call();
+					}
 				}
 				return false;
 			}

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -10724,16 +10724,15 @@ export class SharedLog<
 				logger.error(`Repair sweep failed: ${error?.message ?? error}`);
 			}
 		} finally {
-			if (repairLifecycleController !== this._repairLifecycleController) {
-				return;
-			}
-			this._repairSweepRunning = false;
-			if (
-				this.isRepairLifecycleActive(repairLifecycleController) &&
-				this._repairSweepPendingModes.size > 0
-			) {
-				this._repairSweepRunning = true;
-				void this.runRepairSweep(repairLifecycleController);
+			if (repairLifecycleController === this._repairLifecycleController) {
+				this._repairSweepRunning = false;
+				if (
+					this.isRepairLifecycleActive(repairLifecycleController) &&
+					this._repairSweepPendingModes.size > 0
+				) {
+					this._repairSweepRunning = true;
+					void this.runRepairSweep(repairLifecycleController);
+				}
 			}
 		}
 	}

--- a/packages/programs/data/shared-log/src/sync/index.ts
+++ b/packages/programs/data/shared-log/src/sync/index.ts
@@ -127,7 +127,7 @@ export type SharedLogNativeWireSync = {
 export type RawExchangeHeadsSender = (
 	hashes: string[],
 	to: string[],
-	options?: { priority?: number },
+	options?: { priority?: number; signal?: AbortSignal },
 ) => Promise<number | undefined>;
 
 export type HashSymbolInput = readonly bigint[] | BigUint64Array;
@@ -212,6 +212,7 @@ export interface Syncronizer<R extends "u32" | "u64"> {
 	onMaybeMissingEntries(properties: {
 		entries: Map<string, SyncEntryCoordinates<R>>;
 		targets: string[];
+		signal?: AbortSignal;
 	}): Promise<void> | void;
 
 	onMessage(

--- a/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
+++ b/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
@@ -1754,7 +1754,20 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			}
 		}
 
-		if (naiveHashes.length > 0) {
+		const useAllCoordinatesForIblt =
+			allCoordinatesToSyncWithIblt.length === 0 ||
+			naiveHashes.length > maxSyncWithSimpleMethod;
+		if (useAllCoordinatesForIblt) {
+			// If every entry is a range-boundary special case, or the special-case
+			// set itself is too large for the Simple prelude, use one bounded
+			// Rateless process for the full set. Sending the oversized Simple
+			// prelude first can complete or abort the repair lifecycle before
+			// StartSync is ever dispatched.
+			allCoordinatesToSyncWithIblt = [];
+			for (const entry of properties.entries.values()) {
+				allCoordinatesToSyncWithIblt.push(coerceBigInt(entry.hashNumber));
+			}
+		} else if (naiveHashes.length > 0) {
 			// If there are special-case entries, sync them simply in parallel
 			if (priorityFn && naiveEntriesForPriority) {
 				await this.simple.onMaybeMissingEntries({
@@ -1775,16 +1788,9 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			}
 		}
 
-		if (
-			allCoordinatesToSyncWithIblt.length === 0 ||
-			naiveHashes.length > maxSyncWithSimpleMethod
-		) {
-			// Fallback: if nothing left for IBLT (or simple set is too large), include all in IBLT
-			allCoordinatesToSyncWithIblt = [];
-			for (const entry of properties.entries.values()) {
-				allCoordinatesToSyncWithIblt.push(coerceBigInt(entry.hashNumber));
-			}
-		}
+		const simplePreludeEntries = useAllCoordinatesForIblt
+			? 0
+			: naiveHashes.length;
 
 		if (profile) {
 			emitSyncProfileDuration(profile, selectStartedAt, {
@@ -1793,7 +1799,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				symbols: allCoordinatesToSyncWithIblt.length,
 				targets: properties.targets.length,
 				details: {
-					naiveEntries: naiveHashes.length,
+					naiveEntries: simplePreludeEntries,
 					priority: priorityFn != null,
 				},
 			});
@@ -1852,6 +1858,33 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			if (!this.isRatelessDispatchLifecycleActive(lifecycle, target)) {
 				continue;
 			}
+			const activeProcess = this.outgoingSyncProcessByTarget.get(target);
+			if (
+				activeProcess &&
+				!activeProcess.signal.aborted &&
+				this.isRatelessDispatchLifecycleActive(
+					activeProcess.targetLifecycle.lifecycle,
+					target,
+				)
+			) {
+				// A repair sweep can flush adjacent batches for the same target
+				// faster than its first StartSync reaches the transport. Replacing
+				// that process here aborts the in-flight send; repeated large
+				// batches can therefore starve Rateless sync entirely. Keep the
+				// unambiguous active process and use bounded Simple sync only for
+				// hashes that it does not already authorize.
+				const uncoveredHashes = outgoingHashes.filter(
+					(hash) => !activeProcess.authorizedHashes.has(hash),
+				);
+				if (uncoveredHashes.length > 0) {
+					await this.simple.onMaybeMissingHashes({
+						hashes: uncoveredHashes,
+						targets: [target],
+						signal,
+					});
+				}
+				continue;
+			}
 			const startedSymbols = this.startOutgoingRatelessSyncForTarget({
 				targetLifecycle,
 				coordinates: allCoordinatesToSyncWithIblt,
@@ -1872,7 +1905,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 					phase: "start-sync-send",
 					cancelled: true,
 					ibltEntries: allCoordinatesToSyncWithIblt.length,
-					naiveEntries: naiveHashes.length,
+					naiveEntries: simplePreludeEntries,
 				},
 				{ messages, symbols },
 			);
@@ -1882,7 +1915,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			{
 				mode: "rateless",
 				ibltEntries: allCoordinatesToSyncWithIblt.length,
-				naiveEntries: naiveHashes.length,
+				naiveEntries: simplePreludeEntries,
 			},
 			{ messages, symbols },
 		);

--- a/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
+++ b/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
@@ -81,6 +81,7 @@ class SymbolSerialized implements SSymbol {
 const CODED_SYMBOL_WORDS = 3;
 const CODED_SYMBOL_WORD_BYTES = 8;
 const CODED_SYMBOL_BYTES = CODED_SYMBOL_WORDS * CODED_SYMBOL_WORD_BYTES;
+const MAX_CODED_SYMBOL_BATCH_SIZE = 1_024;
 const BIG_UINT64_ARRAY_IS_LITTLE_ENDIAN =
 	typeof BigUint64Array !== "undefined" &&
 	new Uint8Array(new BigUint64Array([1n]).buffer)[0] === 1;
@@ -226,6 +227,9 @@ const codedSymbolBatchField = {
 	},
 	deserialize: (reader: BinaryReader): CodedSymbolBatch => {
 		const length = reader.u32();
+		if (length > MAX_CODED_SYMBOL_BATCH_SIZE) {
+			throw new Error("RIBLT coded symbol batch exceeds the receiver limit");
+		}
 		const wordLength = length * CODED_SYMBOL_WORDS;
 		const byteLength = length * CODED_SYMBOL_BYTES;
 
@@ -468,7 +472,47 @@ const DEFAULT_CONVERGENT_REPAIR_TIMEOUT_MS = 30_000;
 const DEFAULT_CONVERGENT_RETRY_INTERVALS_MS = [0, 1_000, 3_000, 7_000];
 const DEFAULT_MAX_CONVERGENT_TRACKED_HASHES = 4_096;
 const MIN_MORE_SYMBOLS_BATCH_SIZE = 64;
-const MAX_MORE_SYMBOLS_BATCH_SIZE = 1_024;
+const MAX_MORE_SYMBOLS_BATCH_SIZE = MAX_CODED_SYMBOL_BATCH_SIZE;
+const MAX_INCOMING_RATELESS_PROCESSES = 32;
+const MAX_INCOMING_RATELESS_PROCESSES_PER_SENDER = 4;
+const MAX_INCOMING_RATELESS_QUEUED_BATCHES = 8;
+const MAX_INCOMING_RATELESS_SEQUENCE_GAP = BigInt(
+	MAX_INCOMING_RATELESS_QUEUED_BATCHES,
+);
+const MIN_RATELESS_SYMBOL_BUDGET = 4_096;
+const MAX_RATELESS_SYMBOL_BUDGET = 262_144;
+const RATELESS_SYMBOL_BUDGET_MULTIPLIER = 4;
+const INCOMING_RATELESS_IDLE_TIMEOUT_MS = 20_000;
+const OUTGOING_RATELESS_IDLE_TIMEOUT_MS = 10_000;
+const RATELESS_PROCESS_ABSOLUTE_TIMEOUT_MS = 120_000;
+const INCOMING_RATELESS_FALLBACK_GRACE_MS = 5_000;
+const MAX_RATELESS_RESPONSE_HASHES_INSPECTED = 10_000;
+export const MAX_ACTIVE_RATELESS_RESPONSES_PER_PEER = 4;
+export const MAX_ACTIVE_RATELESS_RESPONSES_GLOBAL = 32;
+
+const getIncomingRatelessSymbolBudget = (initialSymbols: number): number =>
+	Math.min(
+		MAX_RATELESS_SYMBOL_BUDGET,
+		Math.max(
+			MIN_RATELESS_SYMBOL_BUDGET,
+			initialSymbols * initialSymbols * RATELESS_SYMBOL_BUDGET_MULTIPLIER,
+		),
+	);
+
+const getOutgoingRatelessSymbolBudget = (
+	entries: number,
+	initialSymbols: number,
+): number =>
+	Math.min(
+		MAX_RATELESS_SYMBOL_BUDGET,
+		Math.max(
+			MIN_RATELESS_SYMBOL_BUDGET,
+			initialSymbols,
+			entries * RATELESS_SYMBOL_BUDGET_MULTIPLIER,
+		),
+	);
+
+type IncomingRatelessProcessResult = boolean | undefined | "fallback-to-simple";
 
 @variant([3, 0])
 export class StartSync extends TransportMessage {
@@ -719,8 +763,13 @@ type OutgoingRatelessSyncProcess = {
 	consumedResponseHashes: Set<string>;
 	encoder: EncoderWrapper;
 	timeout?: ReturnType<typeof setTimeout>;
+	deadlineTimeout?: ReturnType<typeof setTimeout>;
 	refresh: () => void;
-	next: (message: { lastSeqNo: bigint }) => CodedSymbolBatch;
+	next: (message: {
+		lastSeqNo: bigint;
+	}) => { symbols: CodedSymbolBatch; exhaustedAfterSend: boolean } | undefined;
+	startSimpleFallback: () => Promise<void>;
+	simpleFallbackStarted: boolean;
 	free: (reason?: unknown) => void;
 	processController: AbortController;
 	signal: AbortSignal;
@@ -745,13 +794,25 @@ type IncomingRatelessSyncProcess = {
 	decoder?: DecoderWrapper;
 	completedSynchronizations: Cache<string>;
 	timeout?: ReturnType<typeof setTimeout>;
+	deadlineTimeout?: ReturnType<typeof setTimeout>;
 	refresh: () => void;
+	lastSeqNo: bigint;
+	processedSymbols: number;
+	queuedSymbols: number;
+	symbolBudget: number;
 	process: (message: {
 		seqNo: bigint;
 		symbols: CodedSymbolInput;
-	}) => Promise<boolean | undefined>;
+	}) => Promise<IncomingRatelessProcessResult>;
+	requestAll: () => Promise<void>;
+	fallbackToSimple: (reason?: unknown) => Promise<void>;
 	free: (reason?: unknown) => void;
 	complete: () => void;
+};
+
+type IncomingRatelessProcessAdmission = {
+	key: string;
+	sender: string;
 };
 
 type RatelessRepairSessionLifecycle = {
@@ -781,6 +842,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 	private localRangeEncoderCacheMax = 2;
 
 	ingoingSyncProcesses: Map<string, IncomingRatelessSyncProcess>;
+	private incomingRatelessProcessAdmissions: Set<IncomingRatelessProcessAdmission>;
 
 	outgoingSyncProcesses: Map<string, OutgoingRatelessSyncProcess>;
 	private outgoingSyncProcessByTarget: Map<string, OutgoingRatelessSyncProcess>;
@@ -789,6 +851,8 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 		string,
 		Set<RatelessDispatchTargetLifecycle>
 	>;
+	private activeRatelessResponseCount: number;
+	private activeRatelessResponseCountByPeer: Map<string, number>;
 	private ratelessClosed: boolean;
 
 	constructor(readonly properties: SynchronizerComponents<D>) {
@@ -799,15 +863,18 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 		this.outgoingSyncProcessByTarget = new Map();
 		this.ratelessDispatchLifecycleController = new AbortController();
 		this.ratelessDispatchTargets = new Map();
+		this.activeRatelessResponseCount = 0;
+		this.activeRatelessResponseCountByPeer = new Map();
 		this.ratelessClosed = false;
 		this.ingoingSyncProcesses = new Map();
+		this.incomingRatelessProcessAdmissions = new Set();
 		this.startedOrCompletedSynchronizations = new Cache({ max: 1e4 });
 	}
 
 	private get maxConvergentTrackedHashes() {
 		const value = this.properties.sync?.maxConvergentTrackedHashes;
 		return value && Number.isFinite(value) && value > 0
-			? Math.floor(value)
+			? Math.max(1, Math.floor(value))
 			: DEFAULT_MAX_CONVERGENT_TRACKED_HASHES;
 	}
 
@@ -1767,7 +1834,10 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 		let initialSymbolCount = Math.round(
 			Math.sqrt(allCoordinatesToSyncWithIblt.length),
 		); // TODO choose better
-		initialSymbolCount = Math.max(64, initialSymbolCount);
+		initialSymbolCount = Math.min(
+			MAX_MORE_SYMBOLS_BATCH_SIZE,
+			Math.max(64, initialSymbolCount),
+		);
 		if (signal?.aborted) {
 			emitCancelledTopLevelProfile("before-encoder-prepare");
 			return;
@@ -1899,6 +1969,13 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			const processSignal = processController.signal;
 			let cleared = false;
 			let lastSeqNo = -1n;
+			let symbolsProduced = startSyncSymbols.length;
+			let symbolBudgetExhausted = false;
+			let simpleFallbackPromise: Promise<void> | undefined;
+			const symbolBudget = getOutgoingRatelessSymbolBudget(
+				properties.coordinates.length,
+				startSyncSymbols.length,
+			);
 			let onTargetAbort: (() => void) | undefined;
 			const clear = (
 				reason: unknown = new Error("rateless outgoing process closed"),
@@ -1919,6 +1996,9 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				if (obj.timeout) {
 					clearTimeout(obj.timeout);
 				}
+				if (obj.deadlineTimeout) {
+					clearTimeout(obj.deadlineTimeout);
+				}
 				if (this.outgoingSyncProcesses.get(syncId) === obj) {
 					this.outgoingSyncProcesses.delete(syncId);
 				}
@@ -1929,11 +2009,43 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				freeEncoder();
 				this.maybeDisposeRatelessDispatchLifecycle(lifecycle);
 			};
+			const startSimpleFallback = () => {
+				if (!simpleFallbackPromise) {
+					// From this point overlapping ResponseMaybeSync authorization
+					// belongs to Simple. Keeping Rateless first would ship the response
+					// while leaving the duplicate Simple lease charged until its TTL.
+					obj.simpleFallbackStarted = true;
+					simpleFallbackPromise = Promise.resolve(
+						this.simple.onMaybeMissingHashes({
+							hashes: properties.outgoingHashes,
+							targets: [target],
+							signal: lifecycle.callerSignal,
+						}),
+					);
+				}
+				return simpleFallbackPromise;
+			};
+			const fallbackAndClear = (reason: Error) => {
+				void startSimpleFallback().catch((error) => logger.error(error));
+				clear(reason);
+			};
 			const createTimeout = () => {
 				const timeout = setTimeout(
-					() => clear(new Error("rateless outgoing process timed out")),
-					1e4,
-				); // TODO arg
+					() =>
+						fallbackAndClear(new Error("rateless outgoing process timed out")),
+					OUTGOING_RATELESS_IDLE_TIMEOUT_MS,
+				);
+				timeout.unref?.();
+				return timeout;
+			};
+			const createDeadlineTimeout = () => {
+				const timeout = setTimeout(
+					() =>
+						fallbackAndClear(
+							new Error("rateless outgoing process deadline exceeded"),
+						),
+					RATELESS_PROCESS_ABSOLUTE_TIMEOUT_MS,
+				);
 				timeout.unref?.();
 				return timeout;
 			};
@@ -1954,24 +2066,43 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				targetLifecycle: properties.targetLifecycle,
 				encoder,
 				timeout: undefined,
+				deadlineTimeout: undefined,
 				refresh: () => {
 					if (obj.timeout) {
 						clearTimeout(obj.timeout);
 					}
 					obj.timeout = createTimeout();
 				},
-				next: (message: { lastSeqNo: bigint }): CodedSymbolBatch => {
-					if (processSignal.aborted) {
-						return CodedSymbolBatch.fromSymbols([]);
+				next: (message: { lastSeqNo: bigint }) => {
+					if (processSignal.aborted || symbolBudgetExhausted) {
+						return undefined;
 					}
-					if (message.lastSeqNo <= lastSeqNo) {
-						return CodedSymbolBatch.fromSymbols([]);
+					if (message.lastSeqNo !== lastSeqNo + 1n) {
+						return undefined;
 					}
-					lastSeqNo++;
-					obj.refresh(); // TODO use timestamp instead and collective pruning/refresh
+					lastSeqNo = message.lastSeqNo;
+
+					const remainingBudget = symbolBudget - symbolsProduced;
+					if (remainingBudget <= 0) {
+						symbolBudgetExhausted = true;
+						return {
+							symbols: CodedSymbolBatch.fromSymbols([]),
+							exhaustedAfterSend: true,
+						};
+					}
 
 					const produceStartedAt = syncProfileStart(profile);
-					const symbols = produceNextCodedSymbols(encoder, nextBatch);
+					const symbols = produceNextCodedSymbols(
+						encoder,
+						Math.min(nextBatch, remainingBudget),
+					);
+					symbolsProduced += symbols.length;
+					const exhaustedAfterSend = symbols.length === 0;
+					if (exhaustedAfterSend) {
+						symbolBudgetExhausted = true;
+					} else {
+						obj.refresh();
+					}
 					if (profile) {
 						emitSyncProfileDuration(profile, produceStartedAt, {
 							name: "rateless.produceMoreSymbols",
@@ -1980,8 +2111,10 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 							targets: 1,
 						});
 					}
-					return symbols;
+					return { symbols, exhaustedAfterSend };
 				},
+				startSimpleFallback,
+				simpleFallbackStarted: false,
 				free: clear,
 				outgoingHashes: properties.outgoingHashes,
 				authorizedHashes: properties.authorizedHashes,
@@ -2009,6 +2142,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			this.outgoingSyncProcesses.set(syncId, obj);
 			this.outgoingSyncProcessByTarget.set(target, obj);
 			obj.timeout = createTimeout();
+			obj.deadlineTimeout = createDeadlineTimeout();
 			targetSignal.addEventListener("abort", onTargetAbort, { once: true });
 			encoderTransferred = true;
 			if (targetSignal.aborted) {
@@ -2104,6 +2238,14 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 		) {
 			return undefined;
 		}
+		if (
+			this.activeRatelessResponseCount >=
+				MAX_ACTIVE_RATELESS_RESPONSES_GLOBAL ||
+			(this.activeRatelessResponseCountByPeer.get(target) ?? 0) >=
+				MAX_ACTIVE_RATELESS_RESPONSES_PER_PEER
+		) {
+			return undefined;
+		}
 		const authorized: string[] = [];
 		const remaining: string[] = [];
 		const seen = new Set<string>();
@@ -2134,6 +2276,11 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 
 		const targetLifecycle = process.targetLifecycle;
 		targetLifecycle.responseLeases += 1;
+		this.activeRatelessResponseCount += 1;
+		this.activeRatelessResponseCountByPeer.set(
+			target,
+			(this.activeRatelessResponseCountByPeer.get(target) ?? 0) + 1,
+		);
 		let released = false;
 		return {
 			process,
@@ -2151,6 +2298,14 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 					}
 				}
 				targetLifecycle.responseLeases -= 1;
+				this.activeRatelessResponseCount -= 1;
+				const activeForPeer =
+					(this.activeRatelessResponseCountByPeer.get(target) ?? 1) - 1;
+				if (activeForPeer === 0) {
+					this.activeRatelessResponseCountByPeer.delete(target);
+				} else {
+					this.activeRatelessResponseCountByPeer.set(target, activeForPeer);
+				}
 				this.maybeDisposeRatelessDispatchLifecycle(targetLifecycle.lifecycle);
 			},
 		};
@@ -2175,6 +2330,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			const syncId = getSyncIdString(message);
 			const key = this.getIncomingSyncProcessKey(sender, syncId);
 			const completedSynchronizations = this.startedOrCompletedSynchronizations;
+			const admissionSet = this.incomingRatelessProcessAdmissions;
 			if (this.ingoingSyncProcesses.has(key)) {
 				return true;
 			}
@@ -2183,11 +2339,45 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				return true;
 			}
 
+			let admissionsForSender = 0;
+			for (const admission of admissionSet) {
+				if (admission.key === key) {
+					return true;
+				}
+				if (admission.sender === sender) {
+					admissionsForSender += 1;
+				}
+			}
+			if (
+				admissionSet.size >= MAX_INCOMING_RATELESS_PROCESSES ||
+				admissionsForSender >= MAX_INCOMING_RATELESS_PROCESSES_PER_SENDER
+			) {
+				return true;
+			}
+			const admission = { key, sender };
+			admissionSet.add(admission);
+
 			const controller = new AbortController();
 			let freed = false;
 			let completed = false;
+			let initializationPending = false;
+			let fallbackSendPending = false;
+			let admissionReleased = false;
+			let fallbackGraceTimeout: ReturnType<typeof setTimeout> | undefined;
 			let onOwnershipAbort: (() => void) | undefined;
 			let obj!: IncomingRatelessSyncProcess;
+			const releaseAdmissionIfSettled = () => {
+				if (
+					admissionReleased ||
+					!freed ||
+					initializationPending ||
+					fallbackSendPending
+				) {
+					return;
+				}
+				admissionReleased = true;
+				admissionSet.delete(admission);
+			};
 			const free = (
 				reason: unknown = new Error("incoming rateless process closed"),
 			) => {
@@ -2208,12 +2398,21 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 					clearTimeout(obj.timeout);
 					obj.timeout = undefined;
 				}
+				if (obj.deadlineTimeout) {
+					clearTimeout(obj.deadlineTimeout);
+					obj.deadlineTimeout = undefined;
+				}
+				if (fallbackGraceTimeout) {
+					clearTimeout(fallbackGraceTimeout);
+					fallbackGraceTimeout = undefined;
+				}
 				if (this.ingoingSyncProcesses.get(key) === obj) {
 					this.ingoingSyncProcesses.delete(key);
 				}
 				const ownedDecoder = obj.decoder;
 				obj.decoder = undefined;
 				ownedDecoder?.free();
+				releaseAdmissionIfSettled();
 			};
 			const complete = () => {
 				if (completed || !this.isIncomingSyncProcessActive(obj)) {
@@ -2232,8 +2431,15 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				controller,
 				completedSynchronizations,
 				timeout: undefined,
+				deadlineTimeout: undefined,
 				refresh: () => {},
+				lastSeqNo: -1n,
+				processedSymbols: 0,
+				queuedSymbols: 0,
+				symbolBudget: getIncomingRatelessSymbolBudget(message.symbols.length),
 				process: async () => undefined,
+				requestAll: async () => {},
+				fallbackToSimple: async () => {},
 				free,
 				complete,
 			};
@@ -2244,14 +2450,110 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				onOwnershipAbort,
 				{ once: true },
 			);
+			obj.deadlineTimeout = setTimeout(() => {
+				void obj.fallbackToSimple(
+					new Error("incoming rateless process deadline exceeded"),
+				);
+			}, RATELESS_PROCESS_ABSOLUTE_TIMEOUT_MS);
+			obj.deadlineTimeout.unref?.();
 			if (!this.isIncomingSyncProcessActive(obj)) {
 				free(ownershipLifecycleController.signal.reason);
+				return true;
+			}
+
+			let requestAllPromise: Promise<void> | undefined;
+			obj.requestAll = () => {
+				if (requestAllPromise) {
+					return requestAllPromise;
+				}
+				requestAllPromise = (async () => {
+					if (!this.isIncomingSyncProcessActive(obj)) {
+						return;
+					}
+					fallbackSendPending = true;
+					const sendStartedAt = syncProfileStart(profile);
+					try {
+						await this.simple.rpc.send(
+							new RequestAll({
+								syncId: message.syncId,
+							}),
+							{
+								mode: new SilentDelivery({
+									to: [obj.sender],
+									redundancy: 1,
+								}),
+								priority: SYNC_MESSAGE_PRIORITY,
+								signal: controller.signal,
+							},
+						);
+						if (this.isIncomingSyncProcessActive(obj) && profile) {
+							emitSyncProfileDuration(profile, sendStartedAt, {
+								name: "rateless.sendRequestAll",
+								messages: 1,
+								targets: 1,
+								syncId,
+							});
+						}
+					} finally {
+						fallbackSendPending = false;
+						if (this.isIncomingSyncProcessActive(obj)) {
+							complete();
+						}
+						releaseAdmissionIfSettled();
+					}
+				})();
+				return requestAllPromise;
+			};
+			let boundedFallbackPromise: Promise<void> | undefined;
+			obj.fallbackToSimple = (
+				reason: unknown = new Error("incoming rateless fallback timed out"),
+			) => {
+				if (boundedFallbackPromise) {
+					return boundedFallbackPromise;
+				}
+				const requestAll = obj.requestAll();
+				boundedFallbackPromise = new Promise<void>((resolve) => {
+					let settled = false;
+					const settle = () => {
+						if (settled) {
+							return;
+						}
+						settled = true;
+						controller.signal.removeEventListener("abort", onAbort);
+						if (fallbackGraceTimeout) {
+							clearTimeout(fallbackGraceTimeout);
+							fallbackGraceTimeout = undefined;
+						}
+						resolve();
+					};
+					const onAbort = () => settle();
+					controller.signal.addEventListener("abort", onAbort, {
+						once: true,
+					});
+					fallbackGraceTimeout = setTimeout(() => {
+						free(reason);
+						settle();
+					}, INCOMING_RATELESS_FALLBACK_GRACE_MS);
+					fallbackGraceTimeout.unref?.();
+					void requestAll.then(settle, settle);
+					if (controller.signal.aborted) {
+						onAbort();
+					}
+				});
+				return boundedFallbackPromise;
+			};
+
+			if (message.symbols.length > MAX_MORE_SYMBOLS_BATCH_SIZE) {
+				await obj.fallbackToSimple(
+					new Error("oversized incoming rateless initial batch"),
+				);
 				return true;
 			}
 
 			const wrapped = message.end < message.start;
 			const decoderStartedAt = syncProfileStart(profile);
 			let decoder: DecoderWrapper | false;
+			initializationPending = true;
 			try {
 				decoder = await this.getLocalDecoderForRange(
 					{
@@ -2266,13 +2568,18 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 					},
 				);
 			} catch (error) {
+				const processAborted = controller.signal.aborted;
 				free(error);
 				if (
+					processAborted ||
 					!this.isIncomingSyncGenerationActive(ownershipLifecycleController)
 				) {
 					return true;
 				}
 				throw error;
+			} finally {
+				initializationPending = false;
+				releaseAdmissionIfSettled();
 			}
 			if (!this.isIncomingSyncProcessActive(obj)) {
 				decoder && decoder.free();
@@ -2299,46 +2606,25 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			}
 
 			if (!decoder) {
-				const sendStartedAt = syncProfileStart(profile);
 				try {
-					await this.simple.rpc.send(
-						new RequestAll({
-							syncId: message.syncId,
-						}),
-						{
-							mode: new SilentDelivery({ to: [obj.from], redundancy: 1 }),
-							priority: SYNC_MESSAGE_PRIORITY,
-							signal: controller.signal,
-						},
+					await obj.fallbackToSimple(
+						new Error("incoming rateless decoder unavailable"),
 					);
-					if (!this.isIncomingSyncProcessActive(obj)) {
-						return true;
-					}
-					if (profile) {
-						emitSyncProfileDuration(profile, sendStartedAt, {
-							name: "rateless.sendRequestAll",
-							messages: 1,
-							targets: 1,
-							syncId,
-						});
-					}
 				} catch (error) {
-					const wasActive = this.isIncomingSyncProcessActive(obj);
-					free(error);
-					if (!wasActive) {
+					if (controller.signal.aborted) {
 						return true;
 					}
 					throw error;
 				}
-				complete();
 				return true;
 			}
 
 			const createTimeout = () => {
-				const timeout = setTimeout(
-					() => free(new Error("incoming rateless process timed out")),
-					2e4,
-				); // TODO arg
+				const timeout = setTimeout(() => {
+					void obj.fallbackToSimple(
+						new Error("incoming rateless process timed out"),
+					);
+				}, INCOMING_RATELESS_IDLE_TIMEOUT_MS);
 				timeout.unref?.();
 				return timeout;
 			};
@@ -2346,8 +2632,8 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			let messageQueue: {
 				seqNo: bigint;
 				symbols: CodedSymbolInput;
+				symbolCount: number;
 			}[] = [];
-			let lastSeqNo = -1n;
 			obj.refresh = () => {
 				if (!this.isIncomingSyncProcessActive(obj)) {
 					return;
@@ -2360,19 +2646,48 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			obj.process = async (newMessage: {
 				seqNo: bigint;
 				symbols: CodedSymbolInput;
-			}): Promise<boolean | undefined> => {
+			}): Promise<IncomingRatelessProcessResult> => {
 				if (!this.isIncomingSyncProcessActive(obj)) {
 					return undefined;
 				}
-				obj.refresh(); // TODO use timestamp instead and collective pruning/refresh
 
-				if (newMessage.seqNo <= lastSeqNo) {
+				const symbolCount = CodedSymbolBatch.from(newMessage.symbols).length;
+				if (symbolCount > MAX_MORE_SYMBOLS_BATCH_SIZE) {
+					free(new Error("incoming rateless symbol batch exceeds limit"));
 					return undefined;
 				}
+				if (newMessage.seqNo <= obj.lastSeqNo) {
+					return undefined;
+				}
+				if (
+					newMessage.seqNo >
+					obj.lastSeqNo + MAX_INCOMING_RATELESS_SEQUENCE_GAP
+				) {
+					return undefined;
+				}
+				if (messageQueue.some((queued) => queued.seqNo === newMessage.seqNo)) {
+					return undefined;
+				}
+				if (
+					newMessage.seqNo !== obj.lastSeqNo + 1n &&
+					messageQueue.length >= MAX_INCOMING_RATELESS_QUEUED_BATCHES
+				) {
+					return undefined;
+				}
+				if (
+					obj.processedSymbols + obj.queuedSymbols + symbolCount >
+					obj.symbolBudget
+				) {
+					return "fallback-to-simple";
+				}
+				if (newMessage.seqNo > 0n && symbolCount === 0) {
+					return "fallback-to-simple";
+				}
 
-				messageQueue.push(newMessage);
+				messageQueue.push({ ...newMessage, symbolCount });
+				obj.queuedSymbols += symbolCount;
 				messageQueue.sort((a, b) => Number(a.seqNo - b.seqNo));
-				if (messageQueue[0].seqNo !== lastSeqNo + 1n) {
+				if (messageQueue[0].seqNo !== obj.lastSeqNo + 1n) {
 					return;
 				}
 
@@ -2407,14 +2722,19 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 
 				while (
 					messageQueue.length > 0 &&
-					messageQueue[0].seqNo === lastSeqNo + 1n
+					messageQueue[0].seqNo === obj.lastSeqNo + 1n
 				) {
 					const symbolMessage = messageQueue.shift();
 					if (!symbolMessage) {
 						break;
 					}
 
-					lastSeqNo = symbolMessage.seqNo;
+					obj.queuedSymbols -= symbolMessage.symbolCount;
+					obj.lastSeqNo = symbolMessage.seqNo;
+					obj.processedSymbols += symbolMessage.symbolCount;
+					// Only an authenticated, previously unseen contiguous sequence advances
+					// the idle deadline. Replays and speculative future batches do not.
+					obj.refresh();
 
 					const addBatchAndDecode:
 						| ((symbols: BigUint64Array) => boolean)
@@ -2490,7 +2810,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				return false;
 			};
 			obj.timeout = createTimeout();
-			let initialResult: boolean | undefined;
+			let initialResult: IncomingRatelessProcessResult;
 			try {
 				initialResult = await obj.process({
 					seqNo: 0n,
@@ -2507,6 +2827,12 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			if (initialResult === true) {
 				return true;
 			}
+			if (initialResult === "fallback-to-simple") {
+				await obj.fallbackToSimple(
+					new Error("incoming rateless symbol budget exhausted"),
+				);
+				return true;
+			}
 			if (!this.isIncomingSyncProcessActive(obj)) {
 				return true;
 			}
@@ -2516,11 +2842,11 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			try {
 				await this.simple.rpc.send(
 					new RequestMoreSymbols({
-						lastSeqNo: 0n,
+						lastSeqNo: obj.lastSeqNo,
 						syncId: message.syncId,
 					}),
 					{
-						mode: new SilentDelivery({ to: [obj.from], redundancy: 1 }),
+						mode: new SilentDelivery({ to: [obj.sender], redundancy: 1 }),
 						priority: SYNC_MESSAGE_PRIORITY,
 						signal: controller.signal,
 					},
@@ -2561,7 +2887,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			) {
 				return true;
 			}
-			let outProcess: boolean | undefined;
+			let outProcess: IncomingRatelessProcessResult;
 			try {
 				outProcess = await obj.process(message);
 			} catch (error) {
@@ -2574,6 +2900,16 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			}
 
 			if (outProcess === true) {
+				return true;
+			} else if (outProcess === "fallback-to-simple") {
+				try {
+					await obj.fallbackToSimple(
+						new Error("incoming rateless symbol budget exhausted"),
+					);
+				} catch {
+					// The bounded rateless process is already complete or aborted. A
+					// later repair round may retry if the fallback request was lost.
+				}
 				return true;
 			} else if (outProcess === undefined) {
 				return true; // we don't have enough information, or received information that is redundant
@@ -2588,11 +2924,11 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			try {
 				await this.simple.rpc.send(
 					new RequestMoreSymbols({
-						lastSeqNo: message.seqNo,
+						lastSeqNo: obj.lastSeqNo,
 						syncId: message.syncId,
 					}),
 					{
-						mode: new SilentDelivery({ to: [obj.from], redundancy: 1 }),
+						mode: new SilentDelivery({ to: [obj.sender], redundancy: 1 }),
 						priority: SYNC_MESSAGE_PRIORITY,
 						signal: obj.controller.signal,
 					},
@@ -2635,7 +2971,11 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			if (signal.aborted) {
 				return true;
 			}
-			const symbols = obj.next(message);
+			const next = obj.next(message);
+			if (!next) {
+				return true;
+			}
+			const { symbols, exhaustedAfterSend } = next;
 			if (signal.aborted) {
 				return true;
 			}
@@ -2668,6 +3008,13 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 					syncId,
 				});
 			}
+			if (exhaustedAfterSend) {
+				// Latch exhaustion in next() before the send begins, then retain this
+				// bounded process long enough for RequestAll. Starting Simple eagerly
+				// also keeps fallback working with older receivers that ignore an empty
+				// terminal symbol batch.
+				void obj.startSimpleFallback().catch((error) => logger.error(error));
+			}
 			return true;
 		} else if (message instanceof RequestAll) {
 			const p = this.outgoingSyncProcesses.get(getSyncIdString(message));
@@ -2680,81 +3027,107 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			if (p.signal.aborted) {
 				return true;
 			}
-			const callerSignal = p.callerSignal;
 			// RequestAll ends only this target's rateless attempt. Other target
 			// encoders and response authorizations remain independently owned.
+			const fallback = p.startSimpleFallback();
 			p.free();
-			await this.simple.onMaybeMissingHashes({
-				hashes: p.outgoingHashes,
-				targets: [p.target],
-				signal: callerSignal,
-			});
+			await fallback;
 			return true;
 		} else if (
 			message instanceof ResponseMaybeSync ||
 			message instanceof ResponseMaybeSyncCapabilities
 		) {
 			const from = context.from!;
-			const response = this.consumeAuthorizedRatelessResponse(
+			// Simple authorizations are exact request leases and take precedence
+			// over Rateless' broader process authorization. This also handles a
+			// delayed fallback/prelude response after the Rateless process for the
+			// same target has been replaced.
+			const simpleLeases = this.simple.consumeAuthorizedMaybeSyncResponse(
 				message.hashes,
 				from,
 			);
-			if (!response || response.authorized.length === 0) {
-				return this.simple.onMessage(message, context);
+			const simpleHashes = simpleLeases.flatMap((lease) => lease.hashes);
+			const simpleHashSet = new Set(simpleHashes);
+			const ratelessCandidateHashes: string[] = [];
+			let inspected = 0;
+			const iterator = message.hashes[Symbol.iterator]();
+			let exhausted = false;
+			try {
+				while (inspected < MAX_RATELESS_RESPONSE_HASHES_INSPECTED) {
+					const next = iterator.next();
+					if (next.done) {
+						exhausted = true;
+						break;
+					}
+					inspected += 1;
+					if (!simpleHashSet.has(next.value)) {
+						ratelessCandidateHashes.push(next.value);
+					}
+				}
+			} finally {
+				if (!exhausted) {
+					iterator.return?.();
+				}
 			}
-
-			const remainingMessage =
-				message instanceof ResponseMaybeSyncCapabilities
-					? new ResponseMaybeSyncCapabilities({
-							hashes: response.remaining,
-							capabilities: message.capabilities,
-						})
-					: new ResponseMaybeSync({ hashes: response.remaining });
-			// Consume both authorization domains synchronously. In particular, a
-			// slow rateless shipment must not leave the Simple remainder sitting in
-			// its expiring pending-response window until after the first await.
-			const simpleLeases =
-				response.remaining.length > 0
-					? this.simple.consumeAuthorizedMaybeSyncResponse(
-							response.remaining,
+			const response =
+				ratelessCandidateHashes.length > 0
+					? this.consumeAuthorizedRatelessResponse(
+							ratelessCandidateHashes,
 							from,
 						)
-					: [];
+					: undefined;
+			if (
+				simpleLeases.length === 0 &&
+				(!response || response.authorized.length === 0)
+			) {
+				response?.release();
+				return true;
+			}
 
 			let firstError: unknown;
 			let rollbackRatelessAuthorization = false;
 			try {
-				const responseStartedAt = syncProfileStart(profile);
-				let responseShipment = {
-					messages: 0,
-					fused: false,
-					entries: 0,
-				};
-				try {
-					responseShipment = await this.simple.shipAuthorizedMaybeSyncResponse({
-						hashes: response.authorized,
-						from,
-						response: message,
-						signal: response.signal,
-					});
-				} catch (error) {
-					firstError = error;
-					rollbackRatelessAuthorization = true;
-				}
-				if (profile) {
+				const simpleMessage =
+					message instanceof ResponseMaybeSyncCapabilities
+						? new ResponseMaybeSyncCapabilities({
+								hashes: simpleHashes,
+								capabilities: message.capabilities,
+							})
+						: new ResponseMaybeSync({ hashes: simpleHashes });
+				if (response && response.authorized.length > 0) {
+					const responseStartedAt = syncProfileStart(profile);
+					let responseShipment = {
+						messages: 0,
+						fused: false,
+						entries: 0,
+					};
 					try {
-						emitSyncProfileDuration(profile, responseStartedAt, {
-							name: "simple.exchangeHeads",
-							entries: responseShipment.entries,
-							messages: responseShipment.messages,
-							targets: 1,
-							details: {
-								source: "ratelessResponseMaybeSync",
-								fused: responseShipment.fused,
-							},
-						});
+						responseShipment =
+							await this.simple.shipAuthorizedMaybeSyncResponse({
+								hashes: response.authorized,
+								from,
+								response: message,
+								signal: response.signal,
+							});
 					} catch (error) {
-						firstError ??= error;
+						firstError = error;
+						rollbackRatelessAuthorization = true;
+					}
+					if (profile) {
+						try {
+							emitSyncProfileDuration(profile, responseStartedAt, {
+								name: "simple.exchangeHeads",
+								entries: responseShipment.entries,
+								messages: responseShipment.messages,
+								targets: 1,
+								details: {
+									source: "ratelessResponseMaybeSync",
+									fused: responseShipment.fused,
+								},
+							});
+						} catch (error) {
+							firstError ??= error;
+						}
 					}
 				}
 
@@ -2763,7 +3136,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 						await this.simple.shipAuthorizedMaybeSyncResponseLeases({
 							leases: simpleLeases,
 							from,
-							response: remainingMessage,
+							response: simpleMessage,
 						});
 					} catch (error) {
 						firstError ??= error;
@@ -2774,7 +3147,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				}
 				return true;
 			} finally {
-				response.release({ rollback: rollbackRatelessAuthorization });
+				response?.release({ rollback: rollbackRatelessAuthorization });
 				// The Simple helper owns these leases once entered and releases each
 				// one in its own finally. Keep this outer ownership release as the
 				// final safety net for diagnostics or setup failures that happen
@@ -2850,6 +3223,9 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 		this.ratelessDispatchLifecycleController.abort(reason);
 		this.ratelessDispatchLifecycleController = new AbortController();
 		this.startedOrCompletedSynchronizations = new Cache({ max: 1e4 });
+		// Admission accounting intentionally spans local generations: native range
+		// initialization and fallback delivery are not guaranteed to stop merely
+		// because their logical process was aborted.
 		this.ratelessClosed = false;
 		return this.simple.open();
 	}

--- a/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
+++ b/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
@@ -42,6 +42,8 @@ import {
 	syncProfileStart,
 } from "./profile.js";
 import {
+	ResponseMaybeSync,
+	ResponseMaybeSyncCapabilities,
 	SYNC_MESSAGE_PRIORITY,
 	SimpleSyncronizer,
 } from "./simple.js";
@@ -607,81 +609,160 @@ const buildEncoderOrDecoderFromRange = async <
 	await ribltReady;
 	const encoder =
 		type === "encoder" ? new EncoderWrapper() : new DecoderWrapper();
-
-	const rangeQueryStartedAt = syncProfileStart(profile);
-	let hashNumbers: Array<bigint | number> | BigUint64Array | undefined;
-	let source = "index";
-	const resolved = await resolveHashNumbersInRange?.({
-		end1: ranges.end1,
-		start1: ranges.start1,
-		end2: ranges.end2,
-		start2: ranges.start2,
-	});
-	if (resolved) {
-		source = "native";
-		hashNumbers =
-			typeof BigUint64Array !== "undefined" &&
-			resolved instanceof BigUint64Array
-				? resolved
-				: [...resolved];
-	} else {
-		const entries = await entryIndex
-			.iterate(
-				{
-					// Range sync for IBLT is done in hashNumber space.
-					query: matchEntriesByHashNumberInRangeQuery({
-						end1: ranges.end1,
-						start1: ranges.start1,
-						end2: ranges.end2,
-						start2: ranges.start2,
-					}),
-				},
-				{
-					shape: {
-						hash: true,
-						hashNumber: true,
-					},
-				},
-			)
-			.all();
-		hashNumbers = entries.map((entry) => entry.value.hashNumber);
-	}
-	if (profile) {
-		emitSyncProfileDuration(profile, rangeQueryStartedAt, {
-			name: "rateless.rangeQuery",
-			entries: hashNumbers.length,
-			details: { type, source },
+	let transferred = false;
+	try {
+		const rangeQueryStartedAt = syncProfileStart(profile);
+		let hashNumbers: Array<bigint | number> | BigUint64Array | undefined;
+		let source = "index";
+		const resolved = await resolveHashNumbersInRange?.({
+			end1: ranges.end1,
+			start1: ranges.start1,
+			end2: ranges.end2,
+			start2: ranges.start2,
 		});
-	}
+		if (resolved) {
+			source = "native";
+			hashNumbers =
+				typeof BigUint64Array !== "undefined" &&
+				resolved instanceof BigUint64Array
+					? resolved
+					: [...resolved];
+		} else {
+			const entries = await entryIndex
+				.iterate(
+					{
+						// Range sync for IBLT is done in hashNumber space.
+						query: matchEntriesByHashNumberInRangeQuery({
+							end1: ranges.end1,
+							start1: ranges.start1,
+							end2: ranges.end2,
+							start2: ranges.start2,
+						}),
+					},
+					{
+						shape: {
+							hash: true,
+							hashNumber: true,
+						},
+					},
+				)
+				.all();
+			hashNumbers = entries.map((entry) => entry.value.hashNumber);
+		}
+		if (profile) {
+			emitSyncProfileDuration(profile, rangeQueryStartedAt, {
+				name: "rateless.rangeQuery",
+				entries: hashNumbers.length,
+				details: { type, source },
+			});
+		}
 
-	if (hashNumbers.length === 0) {
-		return false;
-	}
+		if (hashNumbers.length === 0) {
+			return false;
+		}
 
-	const addSymbolsStartedAt = syncProfileStart(profile);
-	if (
-		typeof BigUint64Array !== "undefined" &&
-		typeof (encoder as RibltSymbolAdder).add_symbols === "function"
-	) {
-		const symbols =
-			hashNumbers instanceof BigUint64Array
-				? hashNumbers
-				: BigUint64Array.from(hashNumbers, coerceBigInt);
-		addSymbolsToRiblt(encoder as RibltSymbolAdder, symbols);
-	} else {
-		for (const hashNumber of hashNumbers) {
-			encoder.add_symbol(coerceBigInt(hashNumber));
+		const addSymbolsStartedAt = syncProfileStart(profile);
+		if (
+			typeof BigUint64Array !== "undefined" &&
+			typeof (encoder as RibltSymbolAdder).add_symbols === "function"
+		) {
+			const symbols =
+				hashNumbers instanceof BigUint64Array
+					? hashNumbers
+					: BigUint64Array.from(hashNumbers, coerceBigInt);
+			addSymbolsToRiblt(encoder as RibltSymbolAdder, symbols);
+		} else {
+			for (const hashNumber of hashNumbers) {
+				encoder.add_symbol(coerceBigInt(hashNumber));
+			}
+		}
+		if (profile) {
+			emitSyncProfileDuration(profile, addSymbolsStartedAt, {
+				name: "rateless.rangeAddSymbols",
+				entries: hashNumbers.length,
+				symbols: hashNumbers.length,
+				details: { type },
+			});
+		}
+		transferred = true;
+		return encoder as E;
+	} finally {
+		if (!transferred) {
+			encoder.free();
 		}
 	}
-	if (profile) {
-		emitSyncProfileDuration(profile, addSymbolsStartedAt, {
-			name: "rateless.rangeAddSymbols",
-			entries: hashNumbers.length,
-			symbols: hashNumbers.length,
-			details: { type },
-		});
-	}
-	return encoder as E;
+};
+
+type RatelessDispatchLifecycle = {
+	ownershipLifecycleController: AbortController;
+	callerSignal?: AbortSignal;
+	controller: AbortController;
+	targets: Map<string, RatelessDispatchTargetLifecycle>;
+	onOwnerOrCallerAbort: () => void;
+	dispatchFinished: boolean;
+	disposed: boolean;
+};
+
+type RatelessDispatchTargetLifecycle = {
+	lifecycle: RatelessDispatchLifecycle;
+	target: string;
+	controller: AbortController;
+	retainedByProcess: boolean;
+	responseLeases: number;
+};
+
+type OutgoingRatelessSyncProcess = {
+	target: string;
+	targetLifecycle: RatelessDispatchTargetLifecycle;
+	outgoingHashes: string[];
+	authorizedHashes: ReadonlySet<string>;
+	consumedResponseHashes: Set<string>;
+	encoder: EncoderWrapper;
+	timeout?: ReturnType<typeof setTimeout>;
+	refresh: () => void;
+	next: (message: { lastSeqNo: bigint }) => CodedSymbolBatch;
+	free: (reason?: unknown) => void;
+	processController: AbortController;
+	signal: AbortSignal;
+	callerSignal?: AbortSignal;
+};
+
+type AuthorizedRatelessResponseLease = {
+	process: OutgoingRatelessSyncProcess;
+	authorized: string[];
+	remaining: string[];
+	signal: AbortSignal;
+	release: (options?: { rollback?: boolean }) => void;
+};
+
+type IncomingRatelessSyncProcess = {
+	key: string;
+	syncId: string;
+	sender: string;
+	from: PublicSignKey;
+	ownershipLifecycleController: AbortController;
+	controller: AbortController;
+	decoder?: DecoderWrapper;
+	completedSynchronizations: Cache<string>;
+	timeout?: ReturnType<typeof setTimeout>;
+	refresh: () => void;
+	process: (message: {
+		seqNo: bigint;
+		symbols: CodedSymbolInput;
+	}) => Promise<boolean | undefined>;
+	free: (reason?: unknown) => void;
+	complete: () => void;
+};
+
+type RatelessRepairSessionLifecycle = {
+	id: string;
+	ownershipLifecycleController: AbortController;
+	controller: AbortController;
+	trackedSession: RepairSession;
+	onOwnershipAbort: () => void;
+	cancelled: boolean;
+	settled: boolean;
+	deadlineTimer?: ReturnType<typeof setTimeout>;
 };
 
 export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
@@ -689,6 +770,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 {
 	simple: SimpleSyncronizer<D>;
 	private repairSessionCounter: number;
+	private ratelessRepairSessions: Map<string, RatelessRepairSessionLifecycle>;
 
 	startedOrCompletedSynchronizations: Cache<string>;
 	private localRangeEncoderCacheVersion = 0;
@@ -698,36 +780,26 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 	> = new Map();
 	private localRangeEncoderCacheMax = 2;
 
-	ingoingSyncProcesses: Map<
-		string,
-		{
-			decoder: DecoderWrapper;
-			timeout: ReturnType<typeof setTimeout>;
-			refresh: () => void;
-			process: (message: {
-				seqNo: bigint;
-				symbols: CodedSymbolInput;
-			}) => Promise<boolean | undefined>;
-			free: () => void;
-		}
-	>;
+	ingoingSyncProcesses: Map<string, IncomingRatelessSyncProcess>;
 
-	outgoingSyncProcesses: Map<
+	outgoingSyncProcesses: Map<string, OutgoingRatelessSyncProcess>;
+	private outgoingSyncProcessByTarget: Map<string, OutgoingRatelessSyncProcess>;
+	private ratelessDispatchLifecycleController: AbortController;
+	private ratelessDispatchTargets: Map<
 		string,
-		{
-			outgoingHashes: string[];
-			encoder: EncoderWrapper;
-			timeout: ReturnType<typeof setTimeout>;
-			refresh: () => void;
-			next: (message: { lastSeqNo: bigint }) => CodedSymbolBatch;
-			free: () => void;
-		}
+		Set<RatelessDispatchTargetLifecycle>
 	>;
+	private ratelessClosed: boolean;
 
 	constructor(readonly properties: SynchronizerComponents<D>) {
 		this.simple = new SimpleSyncronizer(properties);
 		this.repairSessionCounter = 0;
+		this.ratelessRepairSessions = new Map();
 		this.outgoingSyncProcesses = new Map();
+		this.outgoingSyncProcessByTarget = new Map();
+		this.ratelessDispatchLifecycleController = new AbortController();
+		this.ratelessDispatchTargets = new Map();
+		this.ratelessClosed = false;
 		this.ingoingSyncProcesses = new Map();
 		this.startedOrCompletedSynchronizations = new Cache({ max: 1e4 });
 	}
@@ -775,6 +847,121 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 		return scored.map((x) => x.entry);
 	}
 
+	private isRatelessRepairSessionActive(
+		session: RatelessRepairSessionLifecycle,
+	): boolean {
+		return (
+			!this.ratelessClosed &&
+			!session.cancelled &&
+			!session.controller.signal.aborted &&
+			!session.ownershipLifecycleController.signal.aborted &&
+			session.ownershipLifecycleController ===
+				this.ratelessDispatchLifecycleController &&
+			this.ratelessRepairSessions.get(session.id) === session
+		);
+	}
+
+	private cancelRatelessRepairSession(
+		session: RatelessRepairSessionLifecycle,
+		reason: unknown = new Error("rateless repair session cancelled"),
+	): void {
+		if (session.cancelled) {
+			return;
+		}
+		session.cancelled = true;
+		if (session.deadlineTimer !== undefined) {
+			clearTimeout(session.deadlineTimer);
+			session.deadlineTimer = undefined;
+		}
+		session.controller.abort(reason);
+		session.trackedSession.cancel();
+	}
+
+	private disposeRatelessRepairSession(
+		session: RatelessRepairSessionLifecycle,
+	): void {
+		if (session.settled) {
+			return;
+		}
+		session.settled = true;
+		if (session.deadlineTimer !== undefined) {
+			clearTimeout(session.deadlineTimer);
+			session.deadlineTimer = undefined;
+		}
+		session.ownershipLifecycleController.signal.removeEventListener(
+			"abort",
+			session.onOwnershipAbort,
+		);
+		if (this.ratelessRepairSessions.get(session.id) === session) {
+			this.ratelessRepairSessions.delete(session.id);
+		}
+	}
+
+	private cancelRatelessRepairSessions(reason: unknown): void {
+		for (const session of [...this.ratelessRepairSessions.values()]) {
+			this.cancelRatelessRepairSession(session, reason);
+		}
+	}
+
+	private waitForRatelessRepairRetry(
+		delayMs: number,
+		signal: AbortSignal,
+	): Promise<boolean> {
+		if (delayMs <= 0) {
+			return Promise.resolve(!signal.aborted);
+		}
+		if (signal.aborted) {
+			return Promise.resolve(false);
+		}
+		return new Promise<boolean>((resolve) => {
+			let settled = false;
+			let timer: ReturnType<typeof setTimeout>;
+			const settle = (elapsed: boolean) => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				clearTimeout(timer);
+				signal.removeEventListener("abort", onAbort);
+				resolve(elapsed);
+			};
+			const onAbort = () => settle(false);
+			timer = setTimeout(() => settle(true), delayMs);
+			timer.unref?.();
+			signal.addEventListener("abort", onAbort, { once: true });
+			if (signal.aborted) {
+				onAbort();
+			}
+		});
+	}
+
+	private waitForRatelessRepairDispatch(
+		dispatch: Promise<void> | void,
+		signal: AbortSignal,
+	): Promise<boolean> {
+		const dispatchPromise = Promise.resolve(dispatch);
+		return new Promise<boolean>((resolve) => {
+			let settled = false;
+			const settle = (completed: boolean) => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				signal.removeEventListener("abort", onAbort);
+				resolve(completed);
+			};
+			const onAbort = () => settle(false);
+			signal.addEventListener("abort", onAbort, { once: true });
+			void dispatchPromise.then(
+				() => settle(true),
+				() => settle(true),
+			);
+			if (signal.aborted) {
+				onAbort();
+			}
+		});
+	}
+
 	startRepairSession(properties: {
 		entries: Map<string, SyncEntryCoordinates<D>>;
 		targets: string[];
@@ -814,7 +1001,6 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				trackedEntries.set(entry.hash, entry);
 			}
 
-			let cancelled = false;
 			const trackedSession = this.simple.startRepairSession({
 				entries: trackedEntries,
 				targets,
@@ -822,33 +1008,91 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				timeoutMs,
 				retryIntervalsMs,
 			});
+			const ownershipLifecycleController =
+				this.ratelessDispatchLifecycleController;
+			let session!: RatelessRepairSessionLifecycle;
+			const cancel = (
+				reason: unknown = new Error("rateless repair session cancelled"),
+			) => this.cancelRatelessRepairSession(session, reason);
+			session = {
+				id,
+				ownershipLifecycleController,
+				controller: new AbortController(),
+				trackedSession,
+				onOwnershipAbort: () =>
+					cancel(
+						ownershipLifecycleController.signal.reason ??
+							new Error("rateless repair generation ended"),
+					),
+				cancelled: false,
+				settled: false,
+				deadlineTimer: undefined,
+			};
+			this.ratelessRepairSessions.set(id, session);
+			session.deadlineTimer = setTimeout(
+				() => cancel(new Error("rateless convergent repair session timed out")),
+				Math.max(0, timeoutMs - (Date.now() - startedAt)),
+			);
+			session.deadlineTimer.unref?.();
+			ownershipLifecycleController.signal.addEventListener(
+				"abort",
+				session.onOwnershipAbort,
+				{ once: true },
+			);
+			if (
+				this.ratelessClosed ||
+				ownershipLifecycleController.signal.aborted ||
+				ownershipLifecycleController !==
+					this.ratelessDispatchLifecycleController
+			) {
+				cancel(
+					ownershipLifecycleController.signal.reason ??
+						new Error("rateless repair generation is not active"),
+				);
+			}
 
 			const runDispatchSchedule = async () => {
 				let previousDelay = 0;
 				for (const delayMs of retryIntervalsMs) {
-					if (cancelled) {
+					if (!this.isRatelessRepairSessionActive(session)) {
 						return;
 					}
 					const elapsed = Date.now() - startedAt;
 					if (elapsed >= timeoutMs) {
 						return;
 					}
-					const waitMs = Math.max(0, delayMs - previousDelay);
+					const waitMs = Math.min(
+						Math.max(0, delayMs - previousDelay),
+						timeoutMs - elapsed,
+					);
 					previousDelay = delayMs;
-					if (waitMs > 0) {
-						await new Promise<void>((resolve) => {
-							const timer = setTimeout(resolve, waitMs);
-							timer.unref?.();
-						});
+					if (
+						!(await this.waitForRatelessRepairRetry(
+							waitMs,
+							session.controller.signal,
+						))
+					) {
+						return;
 					}
-					if (cancelled) {
+					if (
+						!this.isRatelessRepairSessionActive(session) ||
+						Date.now() - startedAt >= timeoutMs
+					) {
 						return;
 					}
 					try {
-						await this.onMaybeMissingEntries({
-							entries: properties.entries,
-							targets,
-						});
+						if (
+							!(await this.waitForRatelessRepairDispatch(
+								this.onMaybeMissingEntries({
+									entries: properties.entries,
+									targets,
+									signal: session.controller.signal,
+								}),
+								session.controller.signal,
+							))
+						) {
+							return;
+						}
 					} catch {
 						// Best-effort schedule: tracked session timeout/result decides completion.
 					}
@@ -856,22 +1100,23 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			};
 
 			const done = (async (): Promise<RepairSessionResult[]> => {
-				await runDispatchSchedule();
-				const trackedResults = await trackedSession.done;
-				return trackedResults.map((result) => ({
-					...result,
-					requestedTotal: requestedHashes.length,
-					truncated: true,
-				}));
+				try {
+					await runDispatchSchedule();
+					const trackedResults = await trackedSession.done;
+					return trackedResults.map((result) => ({
+						...result,
+						requestedTotal: requestedHashes.length,
+						truncated: true,
+					}));
+				} finally {
+					this.disposeRatelessRepairSession(session);
+				}
 			})();
 
 			return {
 				id,
 				done,
-				cancel: () => {
-					cancelled = true;
-					trackedSession.cancel();
-				},
+				cancel: () => cancel(),
 			};
 		}
 
@@ -927,38 +1172,77 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 		)}:${String(ranges.end2)}`;
 	}
 
-	private decoderFromCachedEncoder(encoder: EncoderWrapper): DecoderWrapper {
+	private decoderFromCachedEncoder(
+		encoder: EncoderWrapper,
+		beforeDecoderTransfer?: () => void,
+	): DecoderWrapper {
 		const clone = encoder.clone();
-		const decoder = clone.to_decoder();
-		clone.free();
-		return decoder;
+		let cloneFreed = false;
+		let decoder: DecoderWrapper | undefined;
+		let decoderTransferred = false;
+		const freeClone = () => {
+			if (cloneFreed) {
+				return;
+			}
+			cloneFreed = true;
+			clone.free();
+		};
+		try {
+			decoder = clone.to_decoder();
+			beforeDecoderTransfer?.();
+			freeClone();
+			decoderTransferred = true;
+			return decoder;
+		} finally {
+			try {
+				freeClone();
+			} finally {
+				if (!decoderTransferred) {
+					decoder?.free();
+				}
+			}
+		}
 	}
 
-	private async getLocalDecoderForRange(ranges: {
-		start1: NumberOrBigint;
-		end1: NumberOrBigint;
-		start2: NumberOrBigint;
-		end2: NumberOrBigint;
-	}): Promise<DecoderWrapper | false> {
+	private async getLocalDecoderForRange(
+		ranges: {
+			start1: NumberOrBigint;
+			end1: NumberOrBigint;
+			start2: NumberOrBigint;
+			end2: NumberOrBigint;
+		},
+		options?: {
+			ownershipLifecycleController?: AbortController;
+			signal?: AbortSignal;
+		},
+	): Promise<DecoderWrapper | false> {
+		const isActive = () =>
+			options?.signal?.aborted !== true &&
+			(options?.ownershipLifecycleController === undefined ||
+				this.isIncomingSyncGenerationActive(
+					options.ownershipLifecycleController,
+				));
+		if (!isActive()) {
+			return false;
+		}
 		const profile = this.properties.sync?.profile;
 		const key = this.localRangeEncoderCacheKey(ranges);
 		const cached = this.localRangeEncoderCache.get(key);
 		if (cached && cached.version === this.localRangeEncoderCacheVersion) {
 			const startedAt = syncProfileStart(profile);
 			cached.lastUsed = Date.now();
-			try {
-				return this.decoderFromCachedEncoder(cached.encoder);
-			} finally {
+			return this.decoderFromCachedEncoder(cached.encoder, () => {
 				if (profile) {
 					emitSyncProfileDuration(profile, startedAt, {
 						name: "rateless.localDecoder",
 						cacheHit: true,
 					});
 				}
-			}
+			});
 		}
 
 		const startedAt = syncProfileStart(profile);
+		const cacheVersion = this.localRangeEncoderCacheVersion;
 		const encoder = (await buildEncoderOrDecoderFromRange(
 			ranges,
 			this.properties.entryIndex,
@@ -975,6 +1259,25 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				});
 			}
 			return false;
+		}
+		if (!isActive()) {
+			encoder.free();
+			return false;
+		}
+		if (cacheVersion !== this.localRangeEncoderCacheVersion) {
+			try {
+				return this.decoderFromCachedEncoder(encoder, () => {
+					if (profile) {
+						emitSyncProfileDuration(profile, startedAt, {
+							name: "rateless.localDecoder",
+							cacheHit: false,
+							details: { cacheInvalidated: true },
+						});
+					}
+				});
+			} finally {
+				encoder.free();
+			}
 		}
 
 		const now = Date.now();
@@ -1007,24 +1310,256 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			this.localRangeEncoderCache.delete(oldestKey);
 		}
 
-		try {
-			return this.decoderFromCachedEncoder(encoder);
-		} finally {
+		return this.decoderFromCachedEncoder(encoder, () => {
 			if (profile) {
 				emitSyncProfileDuration(profile, startedAt, {
 					name: "rateless.localDecoder",
 					cacheHit: false,
 				});
 			}
+		});
+	}
+
+	private captureRatelessDispatchLifecycle(
+		targets: string[],
+		callerSignal?: AbortSignal,
+	): RatelessDispatchLifecycle {
+		const ownershipLifecycleController =
+			this.ratelessDispatchLifecycleController;
+		const lifecycle = {
+			ownershipLifecycleController,
+			callerSignal,
+			controller: new AbortController(),
+			targets: new Map<string, RatelessDispatchTargetLifecycle>(),
+			onOwnerOrCallerAbort: () => {
+				const reason =
+					callerSignal?.aborted === true
+						? callerSignal.reason
+						: ownershipLifecycleController.signal.reason;
+				this.abortRatelessDispatchLifecycle(lifecycle, reason);
+			},
+			dispatchFinished: false,
+			disposed: false,
+		} satisfies RatelessDispatchLifecycle;
+
+		for (const target of [...new Set(targets)]) {
+			const targetLifecycle: RatelessDispatchTargetLifecycle = {
+				lifecycle,
+				target,
+				controller: new AbortController(),
+				retainedByProcess: false,
+				responseLeases: 0,
+			};
+			lifecycle.targets.set(target, targetLifecycle);
+			let activeForTarget = this.ratelessDispatchTargets.get(target);
+			if (!activeForTarget) {
+				activeForTarget = new Set();
+				this.ratelessDispatchTargets.set(target, activeForTarget);
+			}
+			activeForTarget.add(targetLifecycle);
 		}
+
+		ownershipLifecycleController.signal.addEventListener(
+			"abort",
+			lifecycle.onOwnerOrCallerAbort,
+			{ once: true },
+		);
+		if (callerSignal && callerSignal !== ownershipLifecycleController.signal) {
+			callerSignal.addEventListener("abort", lifecycle.onOwnerOrCallerAbort, {
+				once: true,
+			});
+		}
+		if (
+			this.ratelessClosed ||
+			ownershipLifecycleController !==
+				this.ratelessDispatchLifecycleController ||
+			ownershipLifecycleController.signal.aborted ||
+			callerSignal?.aborted
+		) {
+			lifecycle.onOwnerOrCallerAbort();
+		}
+		return lifecycle;
+	}
+
+	private abortRatelessDispatchTarget(
+		targetLifecycle: RatelessDispatchTargetLifecycle,
+		reason?: unknown,
+	): void {
+		if (!targetLifecycle.controller.signal.aborted) {
+			targetLifecycle.controller.abort(reason);
+		}
+		this.maybeDisposeRatelessDispatchLifecycle(targetLifecycle.lifecycle);
+	}
+
+	private abortRatelessDispatchLifecycle(
+		lifecycle: RatelessDispatchLifecycle,
+		reason?: unknown,
+	): void {
+		if (!lifecycle.controller.signal.aborted) {
+			lifecycle.controller.abort(reason);
+		}
+		for (const targetLifecycle of lifecycle.targets.values()) {
+			this.abortRatelessDispatchTarget(targetLifecycle, reason);
+		}
+		this.maybeDisposeRatelessDispatchLifecycle(lifecycle);
+	}
+
+	private finishRatelessDispatchLifecycle(
+		lifecycle: RatelessDispatchLifecycle,
+	): void {
+		lifecycle.dispatchFinished = true;
+		this.maybeDisposeRatelessDispatchLifecycle(lifecycle);
+	}
+
+	private maybeDisposeRatelessDispatchLifecycle(
+		lifecycle: RatelessDispatchLifecycle,
+	): void {
+		if (
+			lifecycle.disposed ||
+			!lifecycle.dispatchFinished ||
+			[...lifecycle.targets.values()].some(
+				(target) => target.retainedByProcess || target.responseLeases > 0,
+			)
+		) {
+			return;
+		}
+		lifecycle.disposed = true;
+		lifecycle.ownershipLifecycleController.signal.removeEventListener(
+			"abort",
+			lifecycle.onOwnerOrCallerAbort,
+		);
+		if (
+			lifecycle.callerSignal &&
+			lifecycle.callerSignal !== lifecycle.ownershipLifecycleController.signal
+		) {
+			lifecycle.callerSignal.removeEventListener(
+				"abort",
+				lifecycle.onOwnerOrCallerAbort,
+			);
+		}
+		for (const targetLifecycle of lifecycle.targets.values()) {
+			const activeForTarget = this.ratelessDispatchTargets.get(
+				targetLifecycle.target,
+			);
+			activeForTarget?.delete(targetLifecycle);
+			if (activeForTarget?.size === 0) {
+				this.ratelessDispatchTargets.delete(targetLifecycle.target);
+			}
+		}
+	}
+
+	private isRatelessDispatchLifecycleActive(
+		lifecycle: RatelessDispatchLifecycle,
+		target?: string,
+	): boolean {
+		if (
+			this.ratelessClosed ||
+			lifecycle.disposed ||
+			lifecycle.ownershipLifecycleController !==
+				this.ratelessDispatchLifecycleController ||
+			lifecycle.ownershipLifecycleController.signal.aborted ||
+			lifecycle.callerSignal?.aborted ||
+			lifecycle.controller.signal.aborted
+		) {
+			return false;
+		}
+		if (target === undefined) {
+			return true;
+		}
+		const targetLifecycle = lifecycle.targets.get(target);
+		return (
+			targetLifecycle !== undefined &&
+			!targetLifecycle.controller.signal.aborted &&
+			this.ratelessDispatchTargets.get(target)?.has(targetLifecycle) === true
+		);
+	}
+
+	private getIncomingSyncProcessKey(sender: string, syncId: string): string {
+		return `${sender.length}:${sender}${syncId}`;
+	}
+
+	private isIncomingSyncGenerationActive(
+		ownershipLifecycleController: AbortController,
+	): boolean {
+		return (
+			!this.ratelessClosed &&
+			ownershipLifecycleController ===
+				this.ratelessDispatchLifecycleController &&
+			!ownershipLifecycleController.signal.aborted
+		);
+	}
+
+	private isIncomingSyncProcessActive(
+		process: IncomingRatelessSyncProcess,
+	): boolean {
+		return (
+			this.isIncomingSyncGenerationActive(
+				process.ownershipLifecycleController,
+			) &&
+			!process.controller.signal.aborted &&
+			this.ingoingSyncProcesses.get(process.key) === process
+		);
 	}
 
 	async onMaybeMissingEntries(properties: {
 		entries: Map<string, SyncEntryCoordinates<D>>;
 		targets: string[];
+		signal?: AbortSignal;
 	}): Promise<void> {
+		// Capture this rateless open generation synchronously, before any await.
+		// In particular, signal-less internal repair work must not resume after
+		// close/open and borrow the newly opened Simple generation.
+		const lifecycle = this.captureRatelessDispatchLifecycle(
+			properties.targets,
+			properties.signal,
+		);
+		try {
+			await this.onMaybeMissingEntriesWithLifecycle(properties, lifecycle);
+		} finally {
+			this.finishRatelessDispatchLifecycle(lifecycle);
+		}
+	}
+
+	private async onMaybeMissingEntriesWithLifecycle(
+		properties: {
+			entries: Map<string, SyncEntryCoordinates<D>>;
+			targets: string[];
+			signal?: AbortSignal;
+		},
+		lifecycle: RatelessDispatchLifecycle,
+	): Promise<void> {
+		const signal = lifecycle.controller.signal;
 		const profile = this.properties.sync?.profile;
 		const startedAt = syncProfileStart(profile);
+		let topLevelProfileEmitted = false;
+		const emitTopLevelProfile = (
+			details: Record<string, string | number | boolean | undefined>,
+			measurements: { messages?: number; symbols?: number } = {},
+		) => {
+			if (!profile || topLevelProfileEmitted) {
+				return;
+			}
+			topLevelProfileEmitted = true;
+			emitSyncProfileDuration(profile, startedAt, {
+				name: "rateless.onMaybeMissingEntries",
+				entries: properties.entries.size,
+				targets: properties.targets.length,
+				...measurements,
+				details,
+			});
+		};
+		const emitCancelledTopLevelProfile = (
+			phase: string,
+			mode: "simple-small" | "rateless" = "rateless",
+		) =>
+			emitTopLevelProfile(
+				{
+					mode,
+					phase,
+					cancelled: true,
+				},
+				{ messages: 0, symbols: 0 },
+			);
 		// NOTE: this method is best-effort dispatch, not a per-hash convergence API.
 		// It may require follow-up repair rounds under churn/loss to fully close all gaps.
 		// Strategy:
@@ -1035,6 +1570,15 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 
 		let minSyncIbltSize = 333; // TODO: make configurable
 		let maxSyncWithSimpleMethod = 1e3;
+		if (signal?.aborted) {
+			emitCancelledTopLevelProfile(
+				"before-dispatch",
+				properties.entries.size <= minSyncIbltSize
+					? "simple-small"
+					: "rateless",
+			);
+			return;
+		}
 		const priorityFn = this.properties.sync?.priority;
 		const maxSimpleEntries = this.properties.sync?.maxSimpleEntries;
 
@@ -1052,16 +1596,16 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				await this.simple.onMaybeMissingEntries({
 					entries: properties.entries,
 					targets: properties.targets,
+					signal,
 				});
-			} finally {
-				if (profile) {
-					emitSyncProfileDuration(profile, startedAt, {
-						name: "rateless.onMaybeMissingEntries",
-						entries: properties.entries.size,
-						targets: properties.targets.length,
-						details: { mode: "simple-small" },
-					});
+				if (signal?.aborted) {
+					return;
 				}
+			} finally {
+				emitTopLevelProfile({
+					mode: "simple-small",
+					cancelled: signal?.aborted || undefined,
+				});
 			}
 			return;
 		}
@@ -1149,12 +1693,18 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				await this.simple.onMaybeMissingEntries({
 					entries: naiveEntriesForPriority,
 					targets: properties.targets,
+					signal,
 				});
 			} else {
 				await this.simple.onMaybeMissingHashes({
 					hashes: naiveHashes,
 					targets: properties.targets,
+					signal,
 				});
+			}
+			if (signal?.aborted) {
+				emitCancelledTopLevelProfile("simple-prelude");
+				return;
 			}
 		}
 
@@ -1181,6 +1731,10 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				},
 			});
 		}
+		if (signal?.aborted) {
+			emitCancelledTopLevelProfile("entry-selection");
+			return;
+		}
 
 		if (allCoordinatesToSyncWithIblt.length === 0) {
 			if (profile) {
@@ -1190,13 +1744,8 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 					targets: properties.targets.length,
 					details: { mode: "simple-only" },
 				});
-				emitSyncProfileDuration(profile, startedAt, {
-					name: "rateless.onMaybeMissingEntries",
-					entries: properties.entries.size,
-					targets: properties.targets.length,
-					details: { mode: "simple-only" },
-				});
 			}
+			emitTopLevelProfile({ mode: "simple-only" });
 			return;
 		}
 
@@ -1207,6 +1756,10 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 						(entry) => entry.hash,
 					);
 		await ribltReady;
+		if (signal?.aborted) {
+			emitCancelledTopLevelProfile("riblt-ready");
+			return;
+		}
 
 		// For smaller sets, the original `sqrt(n)` heuristic can occasionally under-provision
 		// low-degree symbols early, causing an unnecessary `MoreSymbols` round-trip. Use a
@@ -1215,146 +1768,392 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			Math.sqrt(allCoordinatesToSyncWithIblt.length),
 		); // TODO choose better
 		initialSymbolCount = Math.max(64, initialSymbolCount);
-		const prepareStartedAt = syncProfileStart(profile);
-		const { encoder, start, end, initialSymbols } = prepareStartSyncEncoder(
-			allCoordinatesToSyncWithIblt,
-			this.properties.numbers.maxValue,
-			initialSymbolCount,
-		);
-		if (profile) {
-			emitSyncProfileDuration(profile, prepareStartedAt, {
-				name: "rateless.prepareStartSyncEncoder",
-				entries: allCoordinatesToSyncWithIblt.length,
-				symbols: initialSymbols?.length,
-				details: {
-					initialSymbolCount,
-					includesInitialSymbols: initialSymbols != null,
-				},
-			});
+		if (signal?.aborted) {
+			emitCancelledTopLevelProfile("before-encoder-prepare");
+			return;
 		}
-
-		let startSyncSymbols = initialSymbols;
-		if (!startSyncSymbols) {
-			const produceStartedAt = syncProfileStart(profile);
-			startSyncSymbols = produceNextCodedSymbols(encoder, initialSymbolCount);
-			if (profile) {
-				emitSyncProfileDuration(profile, produceStartedAt, {
-					name: "rateless.produceStartSyncSymbols",
-					symbols: startSyncSymbols.length,
-				});
+		const authorizedHashes = new Set(outgoingHashes);
+		let messages = 0;
+		let symbols = 0;
+		for (const [target, targetLifecycle] of lifecycle.targets) {
+			if (!this.isRatelessDispatchLifecycleActive(lifecycle)) {
+				break;
+			}
+			if (!this.isRatelessDispatchLifecycleActive(lifecycle, target)) {
+				continue;
+			}
+			const startedSymbols = this.startOutgoingRatelessSyncForTarget({
+				targetLifecycle,
+				coordinates: allCoordinatesToSyncWithIblt,
+				outgoingHashes,
+				authorizedHashes,
+				initialSymbolCount,
+				entryCount: properties.entries.size,
+			});
+			if (startedSymbols !== undefined) {
+				messages += 1;
+				symbols += startedSymbols;
 			}
 		}
-
-		const startSync = new StartSync({
-			from: start,
-			to: end,
-			symbols: startSyncSymbols,
-		});
-		const syncId = getSyncIdString(startSync);
-
-		const clear = () => {
-			encoder.free();
-			clearTimeout(this.outgoingSyncProcesses.get(syncId)?.timeout);
-			this.outgoingSyncProcesses.delete(syncId);
-		};
-		const createTimeout = () => {
-			return setTimeout(clear, 1e4); // TODO arg
-		};
-
-		let lastSeqNo = -1n;
-		// Keep follow-up symbol payloads bounded. Each symbol is serialized as an
-		// object with three bigint fields, so very large batches can dominate heap under
-		// concurrent churn even though the native RIBLT encoder itself is compact.
-		const nextBatch = Math.max(
-			MIN_MORE_SYMBOLS_BATCH_SIZE,
-			Math.min(
-				MAX_MORE_SYMBOLS_BATCH_SIZE,
-				Math.ceil(allCoordinatesToSyncWithIblt.length / 4),
-			),
-		);
-		const obj = {
-			encoder,
-			timeout: createTimeout(),
-			refresh: () => {
-				let prevTimeout = obj.timeout;
-				if (prevTimeout) {
-					clearTimeout(prevTimeout);
-				}
-				obj.timeout = createTimeout();
-			},
-			next: (properties: { lastSeqNo: bigint }): CodedSymbolBatch => {
-				if (properties.lastSeqNo <= lastSeqNo) {
-					return CodedSymbolBatch.fromSymbols([]);
-				}
-				lastSeqNo++;
-				obj.refresh(); // TODO use timestamp instead and collective pruning/refresh
-
-				const produceStartedAt = syncProfileStart(profile);
-				const symbols = produceNextCodedSymbols(encoder, nextBatch);
-				if (profile) {
-					emitSyncProfileDuration(profile, produceStartedAt, {
-						name: "rateless.produceMoreSymbols",
-						syncId,
-						symbols: symbols.length,
-					});
-				}
-				return symbols;
-			},
-			free: clear,
-			outgoingHashes,
-		};
-
-		this.outgoingSyncProcesses.set(syncId, obj);
-		if (profile) {
-			emitSyncProfileEvent(profile, {
-				name: "rateless.dispatchMode",
-				entries: properties.entries.size,
-				symbols: startSyncSymbols.length,
-				targets: properties.targets.length,
-				syncId,
-				details: { mode: "rateless" },
-			});
-		}
-		const sendStartedAt = syncProfileStart(profile);
-		const sendResult = this.simple.rpc.send(startSync, {
-			mode: new SilentDelivery({ to: properties.targets, redundancy: 1 }),
-			priority: SYNC_MESSAGE_PRIORITY,
-		});
-		if (profile) {
-			void Promise.resolve(sendResult).then(
-				() =>
-					emitSyncProfileDuration(profile, sendStartedAt, {
-						name: "rateless.sendStartSync",
-						messages: 1,
-						symbols: startSyncSymbols.length,
-						targets: properties.targets.length,
-						syncId,
-					}),
-				() =>
-					emitSyncProfileDuration(profile, sendStartedAt, {
-						name: "rateless.sendStartSync",
-						messages: 1,
-						symbols: startSyncSymbols.length,
-						targets: properties.targets.length,
-						syncId,
-						details: { rejected: true },
-					}),
-			);
-		}
-		if (profile) {
-			emitSyncProfileDuration(profile, startedAt, {
-				name: "rateless.onMaybeMissingEntries",
-				entries: properties.entries.size,
-				messages: 1,
-				symbols: startSyncSymbols.length,
-				targets: properties.targets.length,
-				details: {
+		if (signal.aborted) {
+			emitTopLevelProfile(
+				{
 					mode: "rateless",
+					phase: "start-sync-send",
+					cancelled: true,
 					ibltEntries: allCoordinatesToSyncWithIblt.length,
 					naiveEntries: naiveHashes.length,
 				},
-			});
+				{ messages, symbols },
+			);
+			return;
 		}
+		emitTopLevelProfile(
+			{
+				mode: "rateless",
+				ibltEntries: allCoordinatesToSyncWithIblt.length,
+				naiveEntries: naiveHashes.length,
+			},
+			{ messages, symbols },
+		);
+	}
+
+	private startOutgoingRatelessSyncForTarget(properties: {
+		targetLifecycle: RatelessDispatchTargetLifecycle;
+		coordinates: bigint[];
+		outgoingHashes: string[];
+		authorizedHashes: ReadonlySet<string>;
+		initialSymbolCount: number;
+		entryCount: number;
+	}): number | undefined {
+		const lifecycle = properties.targetLifecycle.lifecycle;
+		const target = properties.targetLifecycle.target;
+		const profile = this.properties.sync?.profile;
+		if (!this.isRatelessDispatchLifecycleActive(lifecycle, target)) {
+			return undefined;
+		}
+
+		const prepareStartedAt = syncProfileStart(profile);
+		const { encoder, start, end, initialSymbols } = prepareStartSyncEncoder(
+			properties.coordinates,
+			this.properties.numbers.maxValue,
+			properties.initialSymbolCount,
+		);
+		let encoderFreed = false;
+		let encoderTransferred = false;
+		let obj!: OutgoingRatelessSyncProcess;
+		let processConstructed = false;
+		const freeEncoder = () => {
+			if (encoderFreed) {
+				return;
+			}
+			encoderFreed = true;
+			encoder.free();
+		};
+		try {
+			if (profile) {
+				emitSyncProfileDuration(profile, prepareStartedAt, {
+					name: "rateless.prepareStartSyncEncoder",
+					entries: properties.coordinates.length,
+					symbols: initialSymbols?.length,
+					targets: 1,
+					details: {
+						initialSymbolCount: properties.initialSymbolCount,
+						includesInitialSymbols: initialSymbols != null,
+					},
+				});
+			}
+			if (!this.isRatelessDispatchLifecycleActive(lifecycle, target)) {
+				freeEncoder();
+				return undefined;
+			}
+
+			let startSyncSymbols = initialSymbols;
+			if (!startSyncSymbols) {
+				const produceStartedAt = syncProfileStart(profile);
+				startSyncSymbols = produceNextCodedSymbols(
+					encoder,
+					properties.initialSymbolCount,
+				);
+				if (profile) {
+					emitSyncProfileDuration(profile, produceStartedAt, {
+						name: "rateless.produceStartSyncSymbols",
+						symbols: startSyncSymbols.length,
+						targets: 1,
+					});
+				}
+			}
+			if (!this.isRatelessDispatchLifecycleActive(lifecycle, target)) {
+				freeEncoder();
+				return undefined;
+			}
+
+			const startSync = new StartSync({
+				from: start,
+				to: end,
+				symbols: startSyncSymbols,
+			});
+			const syncId = getSyncIdString(startSync);
+			const targetSignal = properties.targetLifecycle.controller.signal;
+			const processController = new AbortController();
+			const processSignal = processController.signal;
+			let cleared = false;
+			let lastSeqNo = -1n;
+			let onTargetAbort: (() => void) | undefined;
+			const clear = (
+				reason: unknown = new Error("rateless outgoing process closed"),
+			) => {
+				if (cleared) {
+					return;
+				}
+				cleared = true;
+
+				// Timeout/replacement owns only the encoder process. Response leases
+				// retain the original open/caller/target lifecycle independently, so a
+				// response already accepted for delivery can finish after this process
+				// expires while close, caller abort, and disconnect still cancel it.
+				processController.abort(reason);
+				if (onTargetAbort) {
+					targetSignal.removeEventListener("abort", onTargetAbort);
+				}
+				if (obj.timeout) {
+					clearTimeout(obj.timeout);
+				}
+				if (this.outgoingSyncProcesses.get(syncId) === obj) {
+					this.outgoingSyncProcesses.delete(syncId);
+				}
+				if (this.outgoingSyncProcessByTarget.get(target) === obj) {
+					this.outgoingSyncProcessByTarget.delete(target);
+				}
+				properties.targetLifecycle.retainedByProcess = false;
+				freeEncoder();
+				this.maybeDisposeRatelessDispatchLifecycle(lifecycle);
+			};
+			const createTimeout = () => {
+				const timeout = setTimeout(
+					() => clear(new Error("rateless outgoing process timed out")),
+					1e4,
+				); // TODO arg
+				timeout.unref?.();
+				return timeout;
+			};
+			onTargetAbort = () => clear(targetSignal.reason);
+
+			// Keep follow-up symbol payloads bounded. Each symbol is serialized as an
+			// object with three bigint fields, so very large batches can dominate heap under
+			// concurrent churn even though the native RIBLT encoder itself is compact.
+			const nextBatch = Math.max(
+				MIN_MORE_SYMBOLS_BATCH_SIZE,
+				Math.min(
+					MAX_MORE_SYMBOLS_BATCH_SIZE,
+					Math.ceil(properties.coordinates.length / 4),
+				),
+			);
+			obj = {
+				target,
+				targetLifecycle: properties.targetLifecycle,
+				encoder,
+				timeout: undefined,
+				refresh: () => {
+					if (obj.timeout) {
+						clearTimeout(obj.timeout);
+					}
+					obj.timeout = createTimeout();
+				},
+				next: (message: { lastSeqNo: bigint }): CodedSymbolBatch => {
+					if (processSignal.aborted) {
+						return CodedSymbolBatch.fromSymbols([]);
+					}
+					if (message.lastSeqNo <= lastSeqNo) {
+						return CodedSymbolBatch.fromSymbols([]);
+					}
+					lastSeqNo++;
+					obj.refresh(); // TODO use timestamp instead and collective pruning/refresh
+
+					const produceStartedAt = syncProfileStart(profile);
+					const symbols = produceNextCodedSymbols(encoder, nextBatch);
+					if (profile) {
+						emitSyncProfileDuration(profile, produceStartedAt, {
+							name: "rateless.produceMoreSymbols",
+							syncId,
+							symbols: symbols.length,
+							targets: 1,
+						});
+					}
+					return symbols;
+				},
+				free: clear,
+				outgoingHashes: properties.outgoingHashes,
+				authorizedHashes: properties.authorizedHashes,
+				consumedResponseHashes: new Set(),
+				processController,
+				signal: processSignal,
+				callerSignal: lifecycle.callerSignal,
+			};
+			processConstructed = true;
+
+			if (!this.isRatelessDispatchLifecycleActive(lifecycle, target)) {
+				clear();
+				return undefined;
+			}
+			// Without a wire process id on ResponseMaybeSync, retaining at most one
+			// process per target keeps sender/hash authorization unambiguous.
+			this.outgoingSyncProcessByTarget
+				.get(target)
+				?.free(new Error("rateless outgoing process replaced"));
+			if (!this.isRatelessDispatchLifecycleActive(lifecycle, target)) {
+				clear();
+				return undefined;
+			}
+			properties.targetLifecycle.retainedByProcess = true;
+			this.outgoingSyncProcesses.set(syncId, obj);
+			this.outgoingSyncProcessByTarget.set(target, obj);
+			obj.timeout = createTimeout();
+			targetSignal.addEventListener("abort", onTargetAbort, { once: true });
+			encoderTransferred = true;
+			if (targetSignal.aborted) {
+				clear(targetSignal.reason);
+				return undefined;
+			}
+			if (profile) {
+				emitSyncProfileEvent(profile, {
+					name: "rateless.dispatchMode",
+					entries: properties.entryCount,
+					symbols: startSyncSymbols.length,
+					targets: 1,
+					syncId,
+					details: { mode: "rateless" },
+				});
+			}
+
+			const sendStartedAt = syncProfileStart(profile);
+			let sendResult: Promise<unknown>;
+			try {
+				sendResult = Promise.resolve(
+					this.simple.rpc.send(startSync, {
+						mode: new SilentDelivery({
+							to: [target],
+							redundancy: 1,
+						}),
+						priority: SYNC_MESSAGE_PRIORITY,
+						signal: processSignal,
+					}),
+				);
+			} catch (error) {
+				sendResult = Promise.reject(error);
+			}
+			void sendResult.then(
+				() => {
+					if (profile) {
+						emitSyncProfileDuration(profile, sendStartedAt, {
+							name: "rateless.sendStartSync",
+							messages: 1,
+							symbols: startSyncSymbols.length,
+							targets: 1,
+							syncId,
+						});
+					}
+				},
+				() => {
+					clear();
+					if (profile) {
+						emitSyncProfileDuration(profile, sendStartedAt, {
+							name: "rateless.sendStartSync",
+							messages: 1,
+							symbols: startSyncSymbols.length,
+							targets: 1,
+							syncId,
+							details: {
+								rejected: true,
+								cancelled: processSignal.aborted || undefined,
+							},
+						});
+					}
+				},
+			);
+			if (processSignal.aborted) {
+				clear();
+				return undefined;
+			}
+			return startSyncSymbols.length;
+		} catch (error) {
+			if (processConstructed) {
+				obj.free(error);
+			}
+			throw error;
+		} finally {
+			if (!encoderTransferred) {
+				freeEncoder();
+			}
+		}
+	}
+
+	private consumeAuthorizedRatelessResponse(
+		hashes: Iterable<string>,
+		from: PublicSignKey,
+	): AuthorizedRatelessResponseLease | undefined {
+		const target = from.hashcode();
+		const process = this.outgoingSyncProcessByTarget.get(target);
+		if (
+			!process ||
+			process.signal.aborted ||
+			!this.isRatelessDispatchLifecycleActive(
+				process.targetLifecycle.lifecycle,
+				target,
+			)
+		) {
+			return undefined;
+		}
+		const authorized: string[] = [];
+		const remaining: string[] = [];
+		const seen = new Set<string>();
+		for (const hash of hashes) {
+			if (seen.has(hash)) {
+				continue;
+			}
+			seen.add(hash);
+			if (
+				!process.authorizedHashes.has(hash) ||
+				process.consumedResponseHashes.has(hash)
+			) {
+				remaining.push(hash);
+				continue;
+			}
+			process.consumedResponseHashes.add(hash);
+			authorized.push(hash);
+		}
+		if (authorized.length === 0) {
+			return {
+				process,
+				authorized,
+				remaining,
+				signal: process.targetLifecycle.controller.signal,
+				release: () => {},
+			};
+		}
+
+		const targetLifecycle = process.targetLifecycle;
+		targetLifecycle.responseLeases += 1;
+		let released = false;
+		return {
+			process,
+			authorized,
+			remaining,
+			signal: targetLifecycle.controller.signal,
+			release: (options) => {
+				if (released) {
+					return;
+				}
+				released = true;
+				if (options?.rollback) {
+					for (const hash of authorized) {
+						process.consumedResponseHashes.delete(hash);
+					}
+				}
+				targetLifecycle.responseLeases -= 1;
+				this.maybeDisposeRatelessDispatchLifecycle(targetLifecycle.lifecycle);
+			},
+		};
 	}
 
 	async onMessage(
@@ -1363,60 +2162,185 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 	): Promise<boolean> {
 		const profile = this.properties.sync?.profile;
 		if (message instanceof StartSync) {
+			const from = context.from;
+			const ownershipLifecycleController =
+				this.ratelessDispatchLifecycleController;
+			if (
+				!from ||
+				!this.isIncomingSyncGenerationActive(ownershipLifecycleController)
+			) {
+				return true;
+			}
+			const sender = from.hashcode();
 			const syncId = getSyncIdString(message);
-			if (this.ingoingSyncProcesses.has(syncId)) {
+			const key = this.getIncomingSyncProcessKey(sender, syncId);
+			const completedSynchronizations = this.startedOrCompletedSynchronizations;
+			if (this.ingoingSyncProcesses.has(key)) {
 				return true;
 			}
 
-			if (this.startedOrCompletedSynchronizations.has(syncId)) {
+			if (completedSynchronizations.has(key)) {
 				return true;
 			}
 
-			this.startedOrCompletedSynchronizations.add(syncId);
+			const controller = new AbortController();
+			let freed = false;
+			let completed = false;
+			let onOwnershipAbort: (() => void) | undefined;
+			let obj!: IncomingRatelessSyncProcess;
+			const free = (
+				reason: unknown = new Error("incoming rateless process closed"),
+			) => {
+				if (freed) {
+					return;
+				}
+				freed = true;
+				// Abort first: no queued process/send continuation may observe the
+				// object detached while its native decoder is still usable.
+				controller.abort(reason);
+				if (onOwnershipAbort) {
+					ownershipLifecycleController.signal.removeEventListener(
+						"abort",
+						onOwnershipAbort,
+					);
+				}
+				if (obj.timeout) {
+					clearTimeout(obj.timeout);
+					obj.timeout = undefined;
+				}
+				if (this.ingoingSyncProcesses.get(key) === obj) {
+					this.ingoingSyncProcesses.delete(key);
+				}
+				const ownedDecoder = obj.decoder;
+				obj.decoder = undefined;
+				ownedDecoder?.free();
+			};
+			const complete = () => {
+				if (completed || !this.isIncomingSyncProcessActive(obj)) {
+					return;
+				}
+				completed = true;
+				completedSynchronizations.add(key);
+				free(new Error("incoming rateless process completed"));
+			};
+			obj = {
+				key,
+				syncId,
+				sender,
+				from,
+				ownershipLifecycleController,
+				controller,
+				completedSynchronizations,
+				timeout: undefined,
+				refresh: () => {},
+				process: async () => undefined,
+				free,
+				complete,
+			};
+			this.ingoingSyncProcesses.set(key, obj);
+			onOwnershipAbort = () => free(ownershipLifecycleController.signal.reason);
+			ownershipLifecycleController.signal.addEventListener(
+				"abort",
+				onOwnershipAbort,
+				{ once: true },
+			);
+			if (!this.isIncomingSyncProcessActive(obj)) {
+				free(ownershipLifecycleController.signal.reason);
+				return true;
+			}
 
 			const wrapped = message.end < message.start;
 			const decoderStartedAt = syncProfileStart(profile);
-			const decoder = await this.getLocalDecoderForRange({
-				start1: message.start,
-				end1: wrapped ? this.properties.numbers.maxValue : message.end,
-				start2: 0n,
-				end2: wrapped ? message.end : 0n,
-			});
-			if (profile) {
-				emitSyncProfileDuration(profile, decoderStartedAt, {
-					name: "rateless.getLocalDecoderForRange",
-					syncId,
-					details: { wrapped, found: decoder !== false },
-				});
+			let decoder: DecoderWrapper | false;
+			try {
+				decoder = await this.getLocalDecoderForRange(
+					{
+						start1: message.start,
+						end1: wrapped ? this.properties.numbers.maxValue : message.end,
+						start2: 0n,
+						end2: wrapped ? message.end : 0n,
+					},
+					{
+						ownershipLifecycleController,
+						signal: controller.signal,
+					},
+				);
+			} catch (error) {
+				free(error);
+				if (
+					!this.isIncomingSyncGenerationActive(ownershipLifecycleController)
+				) {
+					return true;
+				}
+				throw error;
+			}
+			if (!this.isIncomingSyncProcessActive(obj)) {
+				decoder && decoder.free();
+				free(controller.signal.reason);
+				return true;
+			}
+			if (decoder) {
+				// Transfer the native decoder before invoking diagnostics. A profile
+				// sink is caller code and may throw; from this point process cleanup
+				// owns the decoder on every exit.
+				obj.decoder = decoder;
+			}
+			try {
+				if (profile) {
+					emitSyncProfileDuration(profile, decoderStartedAt, {
+						name: "rateless.getLocalDecoderForRange",
+						syncId,
+						details: { wrapped, found: decoder !== false },
+					});
+				}
+			} catch (error) {
+				free(error);
+				throw error;
 			}
 
 			if (!decoder) {
 				const sendStartedAt = syncProfileStart(profile);
-				await this.simple.rpc.send(
-					new RequestAll({
-						syncId: message.syncId,
-					}),
-					{
-						mode: new SilentDelivery({ to: [context.from!], redundancy: 1 }),
-						priority: SYNC_MESSAGE_PRIORITY,
-					},
-				);
-				if (profile) {
-					emitSyncProfileDuration(profile, sendStartedAt, {
-						name: "rateless.sendRequestAll",
-						messages: 1,
-						targets: 1,
-						syncId,
-					});
+				try {
+					await this.simple.rpc.send(
+						new RequestAll({
+							syncId: message.syncId,
+						}),
+						{
+							mode: new SilentDelivery({ to: [obj.from], redundancy: 1 }),
+							priority: SYNC_MESSAGE_PRIORITY,
+							signal: controller.signal,
+						},
+					);
+					if (!this.isIncomingSyncProcessActive(obj)) {
+						return true;
+					}
+					if (profile) {
+						emitSyncProfileDuration(profile, sendStartedAt, {
+							name: "rateless.sendRequestAll",
+							messages: 1,
+							targets: 1,
+							syncId,
+						});
+					}
+				} catch (error) {
+					const wasActive = this.isIncomingSyncProcessActive(obj);
+					free(error);
+					if (!wasActive) {
+						return true;
+					}
+					throw error;
 				}
+				complete();
 				return true;
 			}
 
 			const createTimeout = () => {
-				return setTimeout(() => {
-					decoder.free();
-					this.ingoingSyncProcesses.delete(syncId);
-				}, 2e4); // TODO arg
+				const timeout = setTimeout(
+					() => free(new Error("incoming rateless process timed out")),
+					2e4,
+				); // TODO arg
+				timeout.unref?.();
+				return timeout;
 			};
 
 			let messageQueue: {
@@ -1424,165 +2348,193 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				symbols: CodedSymbolInput;
 			}[] = [];
 			let lastSeqNo = -1n;
-			const obj = {
-				decoder,
-				timeout: createTimeout(),
-				refresh: () => {
-					let prevTimeout = obj.timeout;
-					if (prevTimeout) {
-						clearTimeout(prevTimeout);
+			obj.refresh = () => {
+				if (!this.isIncomingSyncProcessActive(obj)) {
+					return;
+				}
+				if (obj.timeout) {
+					clearTimeout(obj.timeout);
+				}
+				obj.timeout = createTimeout();
+			};
+			obj.process = async (newMessage: {
+				seqNo: bigint;
+				symbols: CodedSymbolInput;
+			}): Promise<boolean | undefined> => {
+				if (!this.isIncomingSyncProcessActive(obj)) {
+					return undefined;
+				}
+				obj.refresh(); // TODO use timestamp instead and collective pruning/refresh
+
+				if (newMessage.seqNo <= lastSeqNo) {
+					return undefined;
+				}
+
+				messageQueue.push(newMessage);
+				messageQueue.sort((a, b) => Number(a.seqNo - b.seqNo));
+				if (messageQueue[0].seqNo !== lastSeqNo + 1n) {
+					return;
+				}
+
+				const finalizeIfDecoded = (): boolean => {
+					if (!this.isIncomingSyncProcessActive(obj)) {
+						return true;
 					}
-					obj.timeout = createTimeout();
-				},
-				process: async (newMessage: {
-					seqNo: bigint;
-					symbols: CodedSymbolInput;
-				}): Promise<boolean | undefined> => {
-					obj.refresh(); // TODO use timestamp instead and collective pruning/refresh
-
-					if (newMessage.seqNo <= lastSeqNo) {
-						return undefined;
+					if (!decoder.decoded()) {
+						return false;
 					}
 
-					messageQueue.push(newMessage);
-					messageQueue.sort((a, b) => Number(a.seqNo - b.seqNo));
-					if (messageQueue[0].seqNo !== lastSeqNo + 1n) {
-						return;
+					const remoteStartedAt = syncProfileStart(profile);
+					const allMissingSymbolsInRemote = getRemoteSymbolValues(decoder);
+					if (profile) {
+						emitSyncProfileDuration(profile, remoteStartedAt, {
+							name: "rateless.remoteSymbols",
+							entries: allMissingSymbolsInRemote.length,
+							symbols: allMissingSymbolsInRemote.length,
+							syncId,
+						});
 					}
 
-					const finalizeIfDecoded = (): boolean => {
-						if (!decoder.decoded()) {
-							return false;
-						}
+					// The IBLT decoder is based on a local snapshot. Entries can arrive via
+					// overlapping repair before we issue the follow-up simple request, so
+					// re-check local presence to avoid stale duplicate bounce-back.
+					void this.simple
+						.queueSync(allMissingSymbolsInRemote, obj.from)
+						.catch((error) => logger.error(error));
+					obj.complete();
+					return true;
+				};
 
-						const remoteStartedAt = syncProfileStart(profile);
-						const allMissingSymbolsInRemote = getRemoteSymbolValues(decoder);
+				while (
+					messageQueue.length > 0 &&
+					messageQueue[0].seqNo === lastSeqNo + 1n
+				) {
+					const symbolMessage = messageQueue.shift();
+					if (!symbolMessage) {
+						break;
+					}
+
+					lastSeqNo = symbolMessage.seqNo;
+
+					const addBatchAndDecode:
+						| ((symbols: BigUint64Array) => boolean)
+						| undefined = (decoder as BatchDecoderWrapper)
+						.add_coded_symbols_and_try_decode;
+					if (typeof BigUint64Array !== "undefined" && addBatchAndDecode) {
+						const flatStartedAt = syncProfileStart(profile);
+						const flatSymbols = flatFromCodedSymbols(symbolMessage.symbols);
 						if (profile) {
-							emitSyncProfileDuration(profile, remoteStartedAt, {
-								name: "rateless.remoteSymbols",
-								entries: allMissingSymbolsInRemote.length,
-								symbols: allMissingSymbolsInRemote.length,
+							emitSyncProfileDuration(profile, flatStartedAt, {
+								name: "rateless.symbolBatchToFlat",
+								symbols: flatSymbols.length / CODED_SYMBOL_WORDS,
 								syncId,
 							});
 						}
 
-						// The IBLT decoder is based on a local snapshot. Entries can arrive via
-						// overlapping repair before we issue the follow-up simple request, so
-						// re-check local presence to avoid stale duplicate bounce-back.
-						this.simple.queueSync(allMissingSymbolsInRemote, context.from!);
-						obj.free();
-						return true;
-					};
-
-					while (
-						messageQueue.length > 0 &&
-						messageQueue[0].seqNo === lastSeqNo + 1n
-					) {
-						const symbolMessage = messageQueue.shift();
-						if (!symbolMessage) {
-							break;
+						const decodeStartedAt = syncProfileStart(profile);
+						const decoded = addBatchAndDecode.call(decoder, flatSymbols);
+						if (profile) {
+							emitSyncProfileDuration(profile, decodeStartedAt, {
+								name: "rateless.decodeBatch",
+								symbols: flatSymbols.length / CODED_SYMBOL_WORDS,
+								syncId,
+								details: { decoded },
+							});
 						}
+						if (decoded && finalizeIfDecoded()) {
+							return true;
+						}
+						continue;
+					}
 
-						lastSeqNo = symbolMessage.seqNo;
+					const decodeLoopStartedAt = syncProfileStart(profile);
+					let symbolsProcessed = 0;
+					for (const symbol of CodedSymbolBatch.from(symbolMessage.symbols)) {
+						symbolsProcessed += 1;
+						const normalizedSymbol =
+							symbol instanceof SymbolSerialized
+								? symbol
+								: new SymbolSerialized({
+										count: symbol.count,
+										hash: symbol.hash,
+										symbol: symbol.symbol,
+									});
 
-						const addBatchAndDecode:
-							| ((symbols: BigUint64Array) => boolean)
-							| undefined = (decoder as BatchDecoderWrapper)
-							.add_coded_symbols_and_try_decode;
-						if (typeof BigUint64Array !== "undefined" && addBatchAndDecode) {
-							const flatStartedAt = syncProfileStart(profile);
-							const flatSymbols = flatFromCodedSymbols(symbolMessage.symbols);
-							if (profile) {
-								emitSyncProfileDuration(profile, flatStartedAt, {
-									name: "rateless.symbolBatchToFlat",
-									symbols: flatSymbols.length / CODED_SYMBOL_WORDS,
-									syncId,
-								});
-							}
-
-							const decodeStartedAt = syncProfileStart(profile);
-							const decoded = addBatchAndDecode.call(decoder, flatSymbols);
-							if (profile) {
-								emitSyncProfileDuration(profile, decodeStartedAt, {
-									name: "rateless.decodeBatch",
-									symbols: flatSymbols.length / CODED_SYMBOL_WORDS,
-									syncId,
-									details: { decoded },
-								});
-							}
-							if (decoded && finalizeIfDecoded()) {
+						decoder.add_coded_symbol(normalizedSymbol);
+						try {
+							decoder.try_decode();
+							if (finalizeIfDecoded()) {
 								return true;
 							}
-							continue;
-						}
-
-						const decodeLoopStartedAt = syncProfileStart(profile);
-						let symbolsProcessed = 0;
-						for (const symbol of CodedSymbolBatch.from(symbolMessage.symbols)) {
-							symbolsProcessed += 1;
-							const normalizedSymbol =
-								symbol instanceof SymbolSerialized
-									? symbol
-									: new SymbolSerialized({
-											count: symbol.count,
-											hash: symbol.hash,
-											symbol: symbol.symbol,
-										});
-
-							decoder.add_coded_symbol(normalizedSymbol);
-							try {
-								decoder.try_decode();
-								if (finalizeIfDecoded()) {
-									return true;
-								}
-							} catch (error: any) {
-								if (
-									error?.message === "Invalid degree" ||
-									error === "Invalid degree"
-								) {
-									logger.trace(
-										"Decoder reported invalid degree; waiting for more symbols",
-									);
-									continue;
-								}
-								throw error;
+						} catch (error: any) {
+							if (
+								error?.message === "Invalid degree" ||
+								error === "Invalid degree"
+							) {
+								logger.trace(
+									"Decoder reported invalid degree; waiting for more symbols",
+								);
+								continue;
 							}
-						}
-						if (profile) {
-							emitSyncProfileDuration(profile, decodeLoopStartedAt, {
-								name: "rateless.decodeSymbolLoop",
-								symbols: symbolsProcessed,
-								syncId,
-							});
+							throw error;
 						}
 					}
-					return false;
-				},
-				free: () => {
-					decoder.free();
-					clearTimeout(this.ingoingSyncProcesses.get(syncId)?.timeout);
-					this.ingoingSyncProcesses.delete(syncId);
-				},
+					if (profile) {
+						emitSyncProfileDuration(profile, decodeLoopStartedAt, {
+							name: "rateless.decodeSymbolLoop",
+							symbols: symbolsProcessed,
+							syncId,
+						});
+					}
+				}
+				return false;
 			};
-
-			this.ingoingSyncProcesses.set(syncId, obj);
-
-			if (await obj.process({ seqNo: 0n, symbols: message.symbols })) {
+			obj.timeout = createTimeout();
+			let initialResult: boolean | undefined;
+			try {
+				initialResult = await obj.process({
+					seqNo: 0n,
+					symbols: message.symbols,
+				});
+			} catch (error) {
+				const wasActive = this.isIncomingSyncProcessActive(obj);
+				free(error);
+				if (!wasActive) {
+					return true;
+				}
+				throw error;
+			}
+			if (initialResult === true) {
+				return true;
+			}
+			if (!this.isIncomingSyncProcessActive(obj)) {
 				return true;
 			}
 
 			// not done, request more symbols
 			const sendStartedAt = syncProfileStart(profile);
-			await this.simple.rpc.send(
-				new RequestMoreSymbols({
-					lastSeqNo: 0n,
-					syncId: message.syncId,
-				}),
-				{
-					mode: new SilentDelivery({ to: [context.from!], redundancy: 1 }),
-					priority: SYNC_MESSAGE_PRIORITY,
-				},
-			);
+			try {
+				await this.simple.rpc.send(
+					new RequestMoreSymbols({
+						lastSeqNo: 0n,
+						syncId: message.syncId,
+					}),
+					{
+						mode: new SilentDelivery({ to: [obj.from], redundancy: 1 }),
+						priority: SYNC_MESSAGE_PRIORITY,
+						signal: controller.signal,
+					},
+				);
+			} catch (error) {
+				if (!this.isIncomingSyncProcessActive(obj)) {
+					return true;
+				}
+				free(error);
+				throw error;
+			}
+			if (!this.isIncomingSyncProcessActive(obj)) {
+				return true;
+			}
 			if (profile) {
 				emitSyncProfileDuration(profile, sendStartedAt, {
 					name: "rateless.sendRequestMoreSymbols",
@@ -1594,50 +2546,79 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 
 			return true;
 		} else if (message instanceof MoreSymbols) {
-			const syncId = getSyncIdString(message);
-			const obj = this.ingoingSyncProcesses.get(syncId);
-			if (!obj) {
+			const from = context.from;
+			if (!from) {
 				return true;
 			}
-			const outProcess = await obj.process(message);
+			const sender = from.hashcode();
+			const syncId = getSyncIdString(message);
+			const key = this.getIncomingSyncProcessKey(sender, syncId);
+			const obj = this.ingoingSyncProcesses.get(key);
+			if (
+				!obj ||
+				obj.sender !== sender ||
+				!this.isIncomingSyncProcessActive(obj)
+			) {
+				return true;
+			}
+			let outProcess: boolean | undefined;
+			try {
+				outProcess = await obj.process(message);
+			} catch (error) {
+				const wasActive = this.isIncomingSyncProcessActive(obj);
+				obj.free(error);
+				if (!wasActive) {
+					return true;
+				}
+				throw error;
+			}
 
 			if (outProcess === true) {
 				return true;
 			} else if (outProcess === undefined) {
 				return true; // we don't have enough information, or received information that is redundant
 			}
+			if (!this.isIncomingSyncProcessActive(obj)) {
+				return true;
+			}
 
 			// we are not done
 
 			const sendStartedAt = syncProfileStart(profile);
-			const sendResult = this.simple.rpc.send(
-				new RequestMoreSymbols({
-					lastSeqNo: message.seqNo,
-					syncId: message.syncId,
-				}),
-				{
-					mode: new SilentDelivery({ to: [context.from!], redundancy: 1 }),
-					priority: SYNC_MESSAGE_PRIORITY,
-				},
-			);
-			if (profile) {
-				void Promise.resolve(sendResult).then(
-					() =>
-						emitSyncProfileDuration(profile, sendStartedAt, {
-							name: "rateless.sendRequestMoreSymbols",
-							messages: 1,
-							targets: 1,
-							syncId,
-						}),
-					() =>
-						emitSyncProfileDuration(profile, sendStartedAt, {
-							name: "rateless.sendRequestMoreSymbols",
-							messages: 1,
-							targets: 1,
-							syncId,
-							details: { rejected: true },
-						}),
+			try {
+				await this.simple.rpc.send(
+					new RequestMoreSymbols({
+						lastSeqNo: message.seqNo,
+						syncId: message.syncId,
+					}),
+					{
+						mode: new SilentDelivery({ to: [obj.from], redundancy: 1 }),
+						priority: SYNC_MESSAGE_PRIORITY,
+						signal: obj.controller.signal,
+					},
 				);
+			} catch {
+				if (profile) {
+					emitSyncProfileDuration(profile, sendStartedAt, {
+						name: "rateless.sendRequestMoreSymbols",
+						messages: 1,
+						targets: 1,
+						syncId,
+						details: { rejected: true },
+					});
+				}
+				return true;
+			}
+			if (!this.isIncomingSyncProcessActive(obj)) {
+				return true;
+			}
+			if (profile) {
+				emitSyncProfileDuration(profile, sendStartedAt, {
+					name: "rateless.sendRequestMoreSymbols",
+					messages: 1,
+					targets: 1,
+					syncId,
+				});
 			}
 
 			return true;
@@ -1647,19 +2628,37 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			if (!obj) {
 				return true;
 			}
+			if (context.from?.hashcode() !== obj.target) {
+				return true;
+			}
+			const signal = obj.signal;
+			if (signal.aborted) {
+				return true;
+			}
 			const symbols = obj.next(message);
+			if (signal.aborted) {
+				return true;
+			}
 			const sendStartedAt = syncProfileStart(profile);
-			await this.properties.rpc.send(
-				new MoreSymbols({
-					lastSeqNo: message.lastSeqNo,
-					syncId: message.syncId,
-					symbols,
-				}),
-				{
-					mode: new SilentDelivery({ to: [context.from!], redundancy: 1 }),
-					priority: SYNC_MESSAGE_PRIORITY,
-				},
-			);
+			try {
+				await this.properties.rpc.send(
+					new MoreSymbols({
+						lastSeqNo: message.lastSeqNo,
+						syncId: message.syncId,
+						symbols,
+					}),
+					{
+						mode: new SilentDelivery({ to: [obj.target], redundancy: 1 }),
+						priority: SYNC_MESSAGE_PRIORITY,
+						signal,
+					},
+				);
+			} catch (error) {
+				if (signal?.aborted) {
+					return true;
+				}
+				throw error;
+			}
 			if (profile) {
 				emitSyncProfileDuration(profile, sendStartedAt, {
 					name: "rateless.sendMoreSymbols",
@@ -1675,11 +2674,115 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			if (!p) {
 				return true;
 			}
+			if (context.from?.hashcode() !== p.target) {
+				return true;
+			}
+			if (p.signal.aborted) {
+				return true;
+			}
+			const callerSignal = p.callerSignal;
+			// RequestAll ends only this target's rateless attempt. Other target
+			// encoders and response authorizations remain independently owned.
+			p.free();
 			await this.simple.onMaybeMissingHashes({
 				hashes: p.outgoingHashes,
-				targets: [context.from!.hashcode()],
+				targets: [p.target],
+				signal: callerSignal,
 			});
 			return true;
+		} else if (
+			message instanceof ResponseMaybeSync ||
+			message instanceof ResponseMaybeSyncCapabilities
+		) {
+			const from = context.from!;
+			const response = this.consumeAuthorizedRatelessResponse(
+				message.hashes,
+				from,
+			);
+			if (!response || response.authorized.length === 0) {
+				return this.simple.onMessage(message, context);
+			}
+
+			const remainingMessage =
+				message instanceof ResponseMaybeSyncCapabilities
+					? new ResponseMaybeSyncCapabilities({
+							hashes: response.remaining,
+							capabilities: message.capabilities,
+						})
+					: new ResponseMaybeSync({ hashes: response.remaining });
+			// Consume both authorization domains synchronously. In particular, a
+			// slow rateless shipment must not leave the Simple remainder sitting in
+			// its expiring pending-response window until after the first await.
+			const simpleLeases =
+				response.remaining.length > 0
+					? this.simple.consumeAuthorizedMaybeSyncResponse(
+							response.remaining,
+							from,
+						)
+					: [];
+
+			let firstError: unknown;
+			let rollbackRatelessAuthorization = false;
+			try {
+				const responseStartedAt = syncProfileStart(profile);
+				let responseShipment = {
+					messages: 0,
+					fused: false,
+					entries: 0,
+				};
+				try {
+					responseShipment = await this.simple.shipAuthorizedMaybeSyncResponse({
+						hashes: response.authorized,
+						from,
+						response: message,
+						signal: response.signal,
+					});
+				} catch (error) {
+					firstError = error;
+					rollbackRatelessAuthorization = true;
+				}
+				if (profile) {
+					try {
+						emitSyncProfileDuration(profile, responseStartedAt, {
+							name: "simple.exchangeHeads",
+							entries: responseShipment.entries,
+							messages: responseShipment.messages,
+							targets: 1,
+							details: {
+								source: "ratelessResponseMaybeSync",
+								fused: responseShipment.fused,
+							},
+						});
+					} catch (error) {
+						firstError ??= error;
+					}
+				}
+
+				if (simpleLeases.length > 0) {
+					try {
+						await this.simple.shipAuthorizedMaybeSyncResponseLeases({
+							leases: simpleLeases,
+							from,
+							response: remainingMessage,
+						});
+					} catch (error) {
+						firstError ??= error;
+					}
+				}
+				if (firstError !== undefined) {
+					throw firstError;
+				}
+				return true;
+			} finally {
+				response.release({ rollback: rollbackRatelessAuthorization });
+				// The Simple helper owns these leases once entered and releases each
+				// one in its own finally. Keep this outer ownership release as the
+				// final safety net for diagnostics or setup failures that happen
+				// before the helper can take responsibility.
+				for (const lease of simpleLeases) {
+					lease.release();
+				}
+			}
 		}
 		return this.simple.onMessage(message, context);
 	}
@@ -1724,18 +2827,44 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 	}
 
 	onPeerDisconnected(key: PublicSignKey | string) {
-		return this.simple.onPeerDisconnected(key);
+		const target = typeof key === "string" ? key : key.hashcode();
+		for (const process of [...this.ingoingSyncProcesses.values()]) {
+			if (process.sender === target) {
+				process.free(new Error("incoming rateless peer disconnected"));
+			}
+		}
+		for (const targetLifecycle of [
+			...(this.ratelessDispatchTargets.get(target) ?? []),
+		]) {
+			this.abortRatelessDispatchTarget(
+				targetLifecycle,
+				new Error("rateless sync target disconnected"),
+			);
+		}
+		return this.simple.onPeerDisconnected(target);
 	}
 
 	open(): Promise<void> | void {
+		const reason = new Error("rateless sync generation replaced");
+		this.cancelRatelessRepairSessions(reason);
+		this.ratelessDispatchLifecycleController.abort(reason);
+		this.ratelessDispatchLifecycleController = new AbortController();
+		this.startedOrCompletedSynchronizations = new Cache({ max: 1e4 });
+		this.ratelessClosed = false;
 		return this.simple.open();
 	}
 
 	close(): Promise<void> | void {
-		for (const [, obj] of this.ingoingSyncProcesses) {
+		this.ratelessClosed = true;
+		// Abort ownership first. Process abort listeners then cancel any in-flight
+		// StartSync/MoreSymbols send before they detach or free native state.
+		const reason = new Error("rateless synchronizer closed");
+		this.cancelRatelessRepairSessions(reason);
+		this.ratelessDispatchLifecycleController.abort(reason);
+		for (const obj of [...this.ingoingSyncProcesses.values()]) {
 			obj.free();
 		}
-		for (const [, obj] of this.outgoingSyncProcesses) {
+		for (const obj of [...this.outgoingSyncProcesses.values()]) {
 			obj.free();
 		}
 		this.clearLocalRangeEncoderCache();

--- a/packages/programs/data/shared-log/src/sync/simple.ts
+++ b/packages/programs/data/shared-log/src/sync/simple.ts
@@ -21,8 +21,8 @@ import {
 import { TransportMessage } from "../message.js";
 import type { EntryReplicated } from "../ranges.js";
 import type {
-	HashSymbolResolver,
 	HashSymbolHashListResolver,
+	HashSymbolResolver,
 	RawExchangeHeadsSender,
 	RepairSession,
 	RepairSessionMode,
@@ -135,15 +135,26 @@ const getHashesFromSymbols = async (
 	coordinateToHash: Cache<string>,
 	resolveHashesForSymbols?: HashSymbolResolver,
 	resolveHashListForSymbols?: HashSymbolHashListResolver,
+	maxHashes = 10_000,
 ): Promise<Set<string> | string[]> => {
 	let queries: IntegerCompare[] = [];
 	let batchSize = 128; // TODO arg
 	let results = new Set<string>();
 	let missingSymbols: bigint[] = [];
+	const addHash = (hash: string) => {
+		if (results.has(hash)) {
+			return true;
+		}
+		if (results.size >= maxHashes) {
+			return false;
+		}
+		results.add(hash);
+		return true;
+	};
 	const addMissingUnlessCached = (symbol: bigint) => {
 		const fromCache = coordinateToHash.get(symbol);
 		if (fromCache) {
-			results.add(fromCache);
+			addHash(fromCache);
 			return;
 		}
 		missingSymbols.push(symbol);
@@ -159,8 +170,13 @@ const getHashesFromSymbols = async (
 			queries = [];
 
 			for (const entry of entries) {
-				results.add(entry.value.hash);
+				if (!addHash(entry.value.hash)) {
+					break;
+				}
 				coordinateToHash.add(entry.value.hashNumber, entry.value.hash);
+				if (results.size >= maxHashes) {
+					break;
+				}
 			}
 		}
 	};
@@ -168,15 +184,31 @@ const getHashesFromSymbols = async (
 	if (resolveHashListForSymbols) {
 		const resolvedHashes = await resolveHashListForSymbols(symbols);
 		if (resolvedHashes) {
-			const resolvedHashList = Array.isArray(resolvedHashes)
-				? resolvedHashes
-				: [...resolvedHashes];
+			const resolvedHashList: string[] = [];
+			const iterator = resolvedHashes[Symbol.iterator]();
+			let exhausted = false;
+			try {
+				while (resolvedHashList.length < maxHashes) {
+					const next = iterator.next();
+					if (next.done) {
+						exhausted = true;
+						break;
+					}
+					resolvedHashList.push(next.value);
+				}
+			} finally {
+				if (!exhausted) {
+					iterator.return?.();
+				}
+			}
 			let mergedHashes: Set<string> | undefined;
 			for (const symbol of symbols) {
 				const fromCache = coordinateToHash.get(symbol);
 				if (fromCache) {
 					mergedHashes ??= new Set(resolvedHashList);
-					mergedHashes.add(fromCache);
+					if (mergedHashes.size < maxHashes) {
+						mergedHashes.add(fromCache);
+					}
 				}
 			}
 			return mergedHashes ?? resolvedHashList;
@@ -186,7 +218,11 @@ const getHashesFromSymbols = async (
 	if (resolveHashesForSymbols) {
 		const resolved = await resolveHashesForSymbols(symbols);
 		if (resolved) {
+			let resolvedItemCount = 0;
 			for (const symbol of symbols) {
+				if (resolvedItemCount >= maxHashes) {
+					break;
+				}
 				const hashes = resolved.get(symbol);
 				if (!hashes) {
 					addMissingUnlessCached(symbol);
@@ -194,14 +230,37 @@ const getHashesFromSymbols = async (
 				}
 				let singleHash: string | undefined;
 				let count = 0;
-				for (const hash of hashes) {
-					results.add(hash);
-					singleHash = hash;
-					count += 1;
+				let truncated = false;
+				const iterator = hashes[Symbol.iterator]();
+				let exhausted = false;
+				try {
+					while (resolvedItemCount < maxHashes) {
+						const next = iterator.next();
+						if (next.done) {
+							exhausted = true;
+							break;
+						}
+						resolvedItemCount += 1;
+						if (!addHash(next.value)) {
+							truncated = true;
+							break;
+						}
+						singleHash = next.value;
+						count += 1;
+						if (results.size >= maxHashes) {
+							truncated = true;
+							break;
+						}
+					}
+				} finally {
+					if (!exhausted) {
+						truncated = true;
+						iterator.return?.();
+					}
 				}
 				if (count === 0) {
 					addMissingUnlessCached(symbol);
-				} else if (count === 1) {
+				} else if (count === 1 && !truncated) {
 					coordinateToHash.add(symbol, singleHash!);
 				}
 			}
@@ -217,6 +276,9 @@ const getHashesFromSymbols = async (
 	}
 
 	for (const symbol of missingSymbols) {
+		if (results.size >= maxHashes) {
+			break;
+		}
 		const matchQuery = new IntegerCompare({
 			key: "hashNumber",
 			compare: Compare.Equal,
@@ -241,6 +303,10 @@ const SESSION_POLL_INTERVAL_MS = 100;
 const DEFAULT_MAX_HASHES_PER_MESSAGE = 1_024;
 const DEFAULT_MAX_COORDINATES_PER_MESSAGE = 1_024;
 const DEFAULT_MAX_CONVERGENT_TRACKED_HASHES = 4_096;
+export const MAX_SIMPLE_COORDINATE_REQUEST_SYMBOLS = 1_024;
+export const MAX_SIMPLE_COORDINATE_RESPONSE_HASHES = 10_000;
+export const MAX_PENDING_SIMPLE_COORDINATE_RESPONSES_PER_PEER = 4;
+export const MAX_PENDING_SIMPLE_COORDINATE_RESPONSES_GLOBAL = 32;
 // Keep convergence sync above the default/background lane. Dropping it to the
 // background priority lets repair traffic starve behind foreground work.
 export const SYNC_MESSAGE_PRIORITY = CONVERGENCE_MESSAGE_PRIORITY;
@@ -251,34 +317,125 @@ const SIMPLE_SYNC_RETRY_AFTER_MS = 10_000;
 const EXCHANGE_HEAD_RESPONSE_DEDUPE_TTL_MS = SIMPLE_SYNC_RETRY_AFTER_MS - 1_000;
 const RECENT_KNOWN_EXCHANGE_HEAD_SUPPRESSION_MS = 30_000;
 const PENDING_MAYBE_SYNC_RESPONSE_TTL_MS = 30_000;
+// An incoming maybe-sync claim keeps one retry candidate in both
+// syncInFlightQueue and syncInFlightQueueInverted. Bound associations rather
+// than only unique keys: otherwise many peers can grow the claimant array for
+// the same keys without changing syncInFlightQueue.size.
+// The per-peer allowance matches one full 10,000-hash response-authorization
+// window; the global allowance lets four peers make full bounded progress.
+export const MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER = 10_000;
+export const MAX_PENDING_SIMPLE_SYNC_KEYS_GLOBAL = 40_000;
+// Storage presence resolution is not universally abortable. Keep the number of
+// live resolver calls small even when requests use only one key each.
+export const MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER = 4;
+export const MAX_PENDING_SIMPLE_SYNC_LOOKUPS_GLOBAL = 32;
+// Retry scanning can touch persistent indexes. Bound each pass so a full
+// adversarial queue cannot force 40,000 lookups in one event-loop turn.
+export const MAX_SIMPLE_SYNC_RETRY_KEYS_PER_TICK = 4_096;
+// Late coordinate-to-hash cache fills are discovered incrementally. Keep this
+// independent of retained queue size so an empty or repeated request cannot
+// force an O(global pending keys) reverse-alias rebuild.
+const MAX_PENDING_SIMPLE_SYNC_ALIAS_REFRESH_PER_MESSAGE = 128;
+const QUEUED_SYNC_ALIAS_REFRESH_PENDING = Symbol(
+	"queued-sync-alias-refresh-pending",
+);
+// This is an absolute first-seen lifetime. Repeated claims and additional peers
+// deliberately do not slide the deadline.
+export const PENDING_SIMPLE_SYNC_KEY_TTL_MS = 60_000;
 // Bound retained request/response associations globally. Ten thousand hashes
 // covers several full default-size request batches while keeping adversarial or
 // abandoned requests to a small, predictable amount of heap.
 const MAX_PENDING_MAYBE_SYNC_RESPONSE_HASHES = 10_000;
+export const MAX_ACTIVE_SIMPLE_SYNC_RESPONSES_PER_PEER = 4;
+export const MAX_ACTIVE_SIMPLE_SYNC_RESPONSES_GLOBAL = 32;
+const MAX_PENDING_MAYBE_SYNC_RESPONSE_WAITER_BYPASSES = 32;
+const MAX_PENDING_MAYBE_SYNC_RESPONSE_WAITERS = 10_000;
+
+type PendingSyncAdmissionReservation = {
+	peer: string;
+	remaining: number;
+	active: boolean;
+	released: boolean;
+	expiresAt: number;
+	identities: Set<SyncableKey>;
+	retainedSettled: number;
+};
+
+type PendingSyncExpiryNode =
+	| {
+			kind: "key";
+			key: SyncableKey;
+			expiresAt: number;
+			heapIndex: number;
+	  }
+	| {
+			kind: "admission";
+			reservation: PendingSyncAdmissionReservation;
+			expiresAt: number;
+			heapIndex: number;
+	  };
 
 type PendingMaybeSyncResponse = {
 	hashes: Set<string>;
 	target: string;
 	targetLifecycle: SyncDispatchTargetLifecycle;
 	expiresAt: number;
+	heapIndex: number;
 };
+
+type PendingMaybeSyncResponseAuthorizationEvent =
+	| "delivered"
+	| "fulfilled"
+	| "released";
 
 type PendingMaybeSyncResponseAuthorization = {
 	batch: PendingMaybeSyncResponse;
 	hash: string;
+	waiters: Set<(event: PendingMaybeSyncResponseAuthorizationEvent) => void>;
+	requestDelivered?: boolean;
+	deliveryInFlight?: boolean;
+	settled?: "fulfilled" | "released";
+	active?: boolean;
 };
 
 type PendingMaybeSyncResponseReservation = {
 	release: () => void;
+	beginDelivery: () => void;
+	finishDelivery: () => void;
+	markDelivered: () => void;
 	newlyAuthorizedByTarget: Map<string, string[]>;
 	retained: () => boolean;
 	signal: AbortSignal;
 };
 
+type PendingMaybeSyncResponseReservationAttempt =
+	| {
+			kind: "reserved";
+			reservation: PendingMaybeSyncResponseReservation;
+			conflicts: PendingMaybeSyncResponseAuthorization[];
+	  }
+	| {
+			kind: "capacity";
+			required: number;
+	  }
+	| {
+			kind: "inactive";
+	  };
+
+type PendingMaybeSyncResponseWaiter = {
+	required: number;
+	associations: number;
+	order: number;
+	bypasses: number;
+	heapIndex: number;
+	fitHeapIndex: number;
+	wake: () => void;
+};
+
 export type AuthorizedMaybeSyncResponseLease = {
 	hashes: string[];
 	signal: AbortSignal;
-	release: () => void;
+	release: (options?: { fulfilled?: boolean }) => void;
 };
 
 type SyncDispatchLifecycle = {
@@ -286,6 +443,7 @@ type SyncDispatchLifecycle = {
 	callerSignal?: AbortSignal;
 	controller: AbortController;
 	targets: Map<string, SyncDispatchTargetLifecycle>;
+	retainedWork: number;
 	onOwnerOrCallerAbort: () => void;
 	dispatchFinished: boolean;
 	disposed: boolean;
@@ -343,9 +501,50 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 	// map of hash to public keys that we can ask for entries
 	syncInFlightQueue: Map<SyncableKey, PublicSignKey[]>;
 	syncInFlightQueueInverted: Map<string, Set<SyncableKey>>;
+	private syncInFlightQueueExpiresAt: Map<SyncableKey, number>;
+	private syncInFlightQueueExpiryTimer?: ReturnType<typeof setTimeout>;
+	private pendingSyncExpiryHeap: PendingSyncExpiryNode[];
+	private pendingSyncKeyExpiryNodes: Map<SyncableKey, PendingSyncExpiryNode>;
+	private pendingSyncAdmissionExpiryNodes: Map<
+		PendingSyncAdmissionReservation,
+		PendingSyncExpiryNode
+	>;
+	private syncInFlightRetryIterator?: IterableIterator<
+		[SyncableKey, PublicSignKey[]]
+	>;
+	private syncInFlightRetryRemaining = 0;
+	private syncInFlightQueueClaimants: Map<SyncableKey, Set<string>>;
+	private syncInFlightQueueClaimantIndexes: Map<
+		SyncableKey,
+		Map<string, number>
+	>;
+	private syncInFlightQueueRoundRobinCursor: Map<SyncableKey, number>;
+	private syncInFlightQueuedCoordinates: Set<bigint>;
+	private syncInFlightQueuedHashByCoordinate: Map<bigint, string>;
+	private syncInFlightQueuedCoordinatesByHash: Map<string, Set<bigint>>;
+	private syncInFlightQueuedCoordinateRefreshIterator?: IterableIterator<bigint>;
+	private pendingSyncClaimCount: number;
+	private pendingSyncAdmissionCount: number;
+	private pendingSyncActiveAdmissionReservations: number;
+	private pendingSyncAdmissionCountByPeer: Map<string, number>;
+	private pendingSyncAdmissionIdentitiesByPeer: Map<string, Set<SyncableKey>>;
+	private pendingSyncAdmissionReservations: Set<PendingSyncAdmissionReservation>;
+	private pendingSyncAdmissionReservationsByPeer: Map<
+		string,
+		Set<PendingSyncAdmissionReservation>
+	>;
+	private pendingSyncAdmissionReservationsByIdentity: Map<
+		SyncableKey,
+		Set<PendingSyncAdmissionReservation>
+	>;
+	private pendingCoordinateLookupCount: number;
+	private pendingCoordinateLookupCountByPeer: Map<string, number>;
+	private pendingCoordinateResponseCount: number;
+	private pendingCoordinateResponseCountByPeer: Map<string, number>;
 
 	// map of hash to public keys that we have asked for entries
 	syncInFlight!: Map<string, Map<SyncableKey, { timestamp: number }>>;
+	private syncInFlightTargetsByKey: Map<SyncableKey, Set<string>>;
 
 	rpc: RPC<TransportMessage, TransportMessage>;
 	log: Log<any>;
@@ -366,9 +565,18 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		Map<string, PendingMaybeSyncResponseAuthorization>
 	>;
 	private pendingMaybeSyncResponseCount: number;
-	private pendingMaybeSyncResponseWaiters: Set<() => void>;
+	private pendingMaybeSyncResponseWaiters: Set<PendingMaybeSyncResponseWaiter>;
+	private pendingMaybeSyncResponseWaiterHeap: PendingMaybeSyncResponseWaiter[];
+	private pendingMaybeSyncResponseWaiterFitHeap: PendingMaybeSyncResponseWaiter[];
+	private pendingMaybeSyncResponseWaiterOrder: number;
+	private pendingMaybeSyncResponseWaiterAssociationCount: number;
+	private pendingMaybeSyncResponseWakeScheduled: boolean;
+	private pendingMaybeSyncResponseConflictWaiterCount: number;
 	private pendingMaybeSyncResponseBatches: Set<PendingMaybeSyncResponse>;
 	private pendingMaybeSyncResponseExpiryTimer?: ReturnType<typeof setTimeout>;
+	private pendingMaybeSyncResponseExpiryHeap: PendingMaybeSyncResponse[];
+	private activeMaybeSyncResponseCount: number;
+	private activeMaybeSyncResponseCountByPeer: Map<string, number>;
 	private syncDispatchLifecycleController: AbortController;
 	private syncDispatchTargetEpochCounter: number;
 	private syncDispatchTargetEpochs: Map<string, SyncDispatchTargetEpoch>;
@@ -398,7 +606,30 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 	}) {
 		this.syncInFlightQueue = new Map();
 		this.syncInFlightQueueInverted = new Map();
+		this.syncInFlightQueueExpiresAt = new Map();
+		this.pendingSyncExpiryHeap = [];
+		this.pendingSyncKeyExpiryNodes = new Map();
+		this.pendingSyncAdmissionExpiryNodes = new Map();
+		this.syncInFlightQueueClaimants = new Map();
+		this.syncInFlightQueueClaimantIndexes = new Map();
+		this.syncInFlightQueueRoundRobinCursor = new Map();
+		this.syncInFlightQueuedCoordinates = new Set();
+		this.syncInFlightQueuedHashByCoordinate = new Map();
+		this.syncInFlightQueuedCoordinatesByHash = new Map();
+		this.pendingSyncClaimCount = 0;
+		this.pendingSyncAdmissionCount = 0;
+		this.pendingSyncActiveAdmissionReservations = 0;
+		this.pendingSyncAdmissionCountByPeer = new Map();
+		this.pendingSyncAdmissionIdentitiesByPeer = new Map();
+		this.pendingSyncAdmissionReservations = new Set();
+		this.pendingSyncAdmissionReservationsByPeer = new Map();
+		this.pendingSyncAdmissionReservationsByIdentity = new Map();
+		this.pendingCoordinateLookupCount = 0;
+		this.pendingCoordinateLookupCountByPeer = new Map();
+		this.pendingCoordinateResponseCount = 0;
+		this.pendingCoordinateResponseCountByPeer = new Map();
 		this.syncInFlight = new Map();
+		this.syncInFlightTargetsByKey = new Map();
 		this.rpc = properties.rpc;
 		this.log = properties.log;
 		this.entryIndex = properties.entryIndex;
@@ -412,7 +643,16 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		this.pendingMaybeSyncResponses = new Map();
 		this.pendingMaybeSyncResponseCount = 0;
 		this.pendingMaybeSyncResponseWaiters = new Set();
+		this.pendingMaybeSyncResponseWaiterHeap = [];
+		this.pendingMaybeSyncResponseWaiterFitHeap = [];
+		this.pendingMaybeSyncResponseWaiterOrder = 0;
+		this.pendingMaybeSyncResponseWaiterAssociationCount = 0;
+		this.pendingMaybeSyncResponseWakeScheduled = false;
+		this.pendingMaybeSyncResponseConflictWaiterCount = 0;
 		this.pendingMaybeSyncResponseBatches = new Set();
+		this.pendingMaybeSyncResponseExpiryHeap = [];
+		this.activeMaybeSyncResponseCount = 0;
+		this.activeMaybeSyncResponseCountByPeer = new Map();
 		this.syncDispatchLifecycleController = new AbortController();
 		this.syncDispatchTargetEpochCounter = 0;
 		this.syncDispatchTargetEpochs = new Map();
@@ -465,21 +705,24 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 	private get maxHashesPerMessage() {
 		const value = this.syncOptions?.maxSimpleHashesPerMessage;
 		return value && Number.isFinite(value) && value > 0
-			? Math.floor(value)
+			? Math.max(1, Math.floor(value))
 			: DEFAULT_MAX_HASHES_PER_MESSAGE;
 	}
 
 	private get maxCoordinatesPerMessage() {
 		const value = this.syncOptions?.maxSimpleCoordinatesPerMessage;
 		return value && Number.isFinite(value) && value > 0
-			? Math.floor(value)
+			? Math.min(
+					MAX_SIMPLE_COORDINATE_REQUEST_SYMBOLS,
+					Math.max(1, Math.floor(value)),
+				)
 			: DEFAULT_MAX_COORDINATES_PER_MESSAGE;
 	}
 
 	private get maxConvergentTrackedHashes() {
 		const value = this.syncOptions?.maxConvergentTrackedHashes;
 		return value && Number.isFinite(value) && value > 0
-			? Math.floor(value)
+			? Math.max(1, Math.floor(value))
 			: DEFAULT_MAX_CONVERGENT_TRACKED_HASHES;
 	}
 
@@ -580,6 +823,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			callerSignal,
 			controller: new AbortController(),
 			targets: new Map<string, SyncDispatchTargetLifecycle>(),
+			retainedWork: 0,
 			onOwnerOrCallerAbort: () => {
 				const reason =
 					callerSignal?.aborted === true
@@ -659,7 +903,6 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		for (const batch of [...targetLifecycle.batches]) {
 			this.removePendingMaybeSyncResponseBatch(batch);
 		}
-		this.notifyPendingMaybeSyncResponseWaiters();
 		this.maybeDisposeSyncDispatchLifecycle(targetLifecycle.lifecycle);
 	}
 
@@ -673,7 +916,6 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		for (const targetLifecycle of lifecycle.targets.values()) {
 			this.abortSyncDispatchTarget(targetLifecycle, reason);
 		}
-		this.notifyPendingMaybeSyncResponseWaiters();
 		this.maybeDisposeSyncDispatchLifecycle(lifecycle);
 	}
 
@@ -688,12 +930,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		if (
 			lifecycle.disposed ||
 			!lifecycle.dispatchFinished ||
-			[...lifecycle.targets.values()].some(
-				(target) =>
-					target.batches.size > 0 ||
-					target.responseLeases > 0 ||
-					target.activeWaiters > 0,
-			)
+			lifecycle.retainedWork > 0
 		) {
 			return;
 		}
@@ -758,39 +995,502 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		);
 	}
 
-	private notifyPendingMaybeSyncResponseWaiters(): void {
-		const waiters = [...this.pendingMaybeSyncResponseWaiters];
-		this.pendingMaybeSyncResponseWaiters.clear();
-		for (const wake of waiters) {
-			wake();
+	private pendingMaybeSyncResponseWaiterBefore(
+		left: PendingMaybeSyncResponseWaiter,
+		right: PendingMaybeSyncResponseWaiter,
+	): boolean {
+		return left.order < right.order;
+	}
+
+	private swapPendingMaybeSyncResponseWaiters(
+		left: number,
+		right: number,
+	): void {
+		const leftWaiter = this.pendingMaybeSyncResponseWaiterHeap[left]!;
+		const rightWaiter = this.pendingMaybeSyncResponseWaiterHeap[right]!;
+		this.pendingMaybeSyncResponseWaiterHeap[left] = rightWaiter;
+		this.pendingMaybeSyncResponseWaiterHeap[right] = leftWaiter;
+		rightWaiter.heapIndex = left;
+		leftWaiter.heapIndex = right;
+	}
+
+	private pushPendingMaybeSyncResponseWaiter(
+		waiter: PendingMaybeSyncResponseWaiter,
+	): void {
+		waiter.heapIndex = this.pendingMaybeSyncResponseWaiterHeap.length;
+		this.pendingMaybeSyncResponseWaiterHeap.push(waiter);
+		let index = waiter.heapIndex;
+		while (index > 0) {
+			const parent = Math.floor((index - 1) / 2);
+			if (
+				this.pendingMaybeSyncResponseWaiterBefore(
+					this.pendingMaybeSyncResponseWaiterHeap[parent]!,
+					this.pendingMaybeSyncResponseWaiterHeap[index]!,
+				)
+			) {
+				break;
+			}
+			this.swapPendingMaybeSyncResponseWaiters(parent, index);
+			index = parent;
+		}
+		this.pushPendingMaybeSyncResponseFitWaiter(waiter);
+	}
+
+	private removePendingMaybeSyncResponseWaiter(
+		waiter: PendingMaybeSyncResponseWaiter,
+	): void {
+		this.removePendingMaybeSyncResponseFitWaiter(waiter);
+		const index = waiter.heapIndex;
+		if (
+			index < 0 ||
+			index >= this.pendingMaybeSyncResponseWaiterHeap.length ||
+			this.pendingMaybeSyncResponseWaiterHeap[index] !== waiter
+		) {
+			return;
+		}
+		const last = this.pendingMaybeSyncResponseWaiterHeap.pop()!;
+		waiter.heapIndex = -1;
+		if (index >= this.pendingMaybeSyncResponseWaiterHeap.length) {
+			return;
+		}
+		this.pendingMaybeSyncResponseWaiterHeap[index] = last;
+		last.heapIndex = index;
+		let current = index;
+		while (current > 0) {
+			const parent = Math.floor((current - 1) / 2);
+			if (
+				this.pendingMaybeSyncResponseWaiterBefore(
+					this.pendingMaybeSyncResponseWaiterHeap[parent]!,
+					this.pendingMaybeSyncResponseWaiterHeap[current]!,
+				)
+			) {
+				break;
+			}
+			this.swapPendingMaybeSyncResponseWaiters(parent, current);
+			current = parent;
+		}
+		for (;;) {
+			const left = current * 2 + 1;
+			const right = left + 1;
+			let smallest = current;
+			if (
+				left < this.pendingMaybeSyncResponseWaiterHeap.length &&
+				this.pendingMaybeSyncResponseWaiterBefore(
+					this.pendingMaybeSyncResponseWaiterHeap[left]!,
+					this.pendingMaybeSyncResponseWaiterHeap[smallest]!,
+				)
+			) {
+				smallest = left;
+			}
+			if (
+				right < this.pendingMaybeSyncResponseWaiterHeap.length &&
+				this.pendingMaybeSyncResponseWaiterBefore(
+					this.pendingMaybeSyncResponseWaiterHeap[right]!,
+					this.pendingMaybeSyncResponseWaiterHeap[smallest]!,
+				)
+			) {
+				smallest = right;
+			}
+			if (smallest === current) {
+				break;
+			}
+			this.swapPendingMaybeSyncResponseWaiters(current, smallest);
+			current = smallest;
+		}
+	}
+
+	private pendingMaybeSyncResponseFitWaiterBefore(
+		left: PendingMaybeSyncResponseWaiter,
+		right: PendingMaybeSyncResponseWaiter,
+	): boolean {
+		return (
+			left.required < right.required ||
+			(left.required === right.required && left.order < right.order)
+		);
+	}
+
+	private swapPendingMaybeSyncResponseFitWaiters(
+		left: number,
+		right: number,
+	): void {
+		const leftWaiter = this.pendingMaybeSyncResponseWaiterFitHeap[left]!;
+		const rightWaiter = this.pendingMaybeSyncResponseWaiterFitHeap[right]!;
+		this.pendingMaybeSyncResponseWaiterFitHeap[left] = rightWaiter;
+		this.pendingMaybeSyncResponseWaiterFitHeap[right] = leftWaiter;
+		rightWaiter.fitHeapIndex = left;
+		leftWaiter.fitHeapIndex = right;
+	}
+
+	private pushPendingMaybeSyncResponseFitWaiter(
+		waiter: PendingMaybeSyncResponseWaiter,
+	): void {
+		waiter.fitHeapIndex = this.pendingMaybeSyncResponseWaiterFitHeap.length;
+		this.pendingMaybeSyncResponseWaiterFitHeap.push(waiter);
+		let index = waiter.fitHeapIndex;
+		while (index > 0) {
+			const parent = Math.floor((index - 1) / 2);
+			if (
+				this.pendingMaybeSyncResponseFitWaiterBefore(
+					this.pendingMaybeSyncResponseWaiterFitHeap[parent]!,
+					this.pendingMaybeSyncResponseWaiterFitHeap[index]!,
+				)
+			) {
+				break;
+			}
+			this.swapPendingMaybeSyncResponseFitWaiters(parent, index);
+			index = parent;
+		}
+	}
+
+	private removePendingMaybeSyncResponseFitWaiter(
+		waiter: PendingMaybeSyncResponseWaiter,
+	): void {
+		const index = waiter.fitHeapIndex;
+		if (
+			index < 0 ||
+			index >= this.pendingMaybeSyncResponseWaiterFitHeap.length ||
+			this.pendingMaybeSyncResponseWaiterFitHeap[index] !== waiter
+		) {
+			return;
+		}
+		const last = this.pendingMaybeSyncResponseWaiterFitHeap.pop()!;
+		waiter.fitHeapIndex = -1;
+		if (index >= this.pendingMaybeSyncResponseWaiterFitHeap.length) {
+			return;
+		}
+		this.pendingMaybeSyncResponseWaiterFitHeap[index] = last;
+		last.fitHeapIndex = index;
+		let current = index;
+		while (current > 0) {
+			const parent = Math.floor((current - 1) / 2);
+			if (
+				this.pendingMaybeSyncResponseFitWaiterBefore(
+					this.pendingMaybeSyncResponseWaiterFitHeap[parent]!,
+					this.pendingMaybeSyncResponseWaiterFitHeap[current]!,
+				)
+			) {
+				break;
+			}
+			this.swapPendingMaybeSyncResponseFitWaiters(parent, current);
+			current = parent;
+		}
+		for (;;) {
+			const left = current * 2 + 1;
+			const right = left + 1;
+			let smallest = current;
+			if (
+				left < this.pendingMaybeSyncResponseWaiterFitHeap.length &&
+				this.pendingMaybeSyncResponseFitWaiterBefore(
+					this.pendingMaybeSyncResponseWaiterFitHeap[left]!,
+					this.pendingMaybeSyncResponseWaiterFitHeap[smallest]!,
+				)
+			) {
+				smallest = left;
+			}
+			if (
+				right < this.pendingMaybeSyncResponseWaiterFitHeap.length &&
+				this.pendingMaybeSyncResponseFitWaiterBefore(
+					this.pendingMaybeSyncResponseWaiterFitHeap[right]!,
+					this.pendingMaybeSyncResponseWaiterFitHeap[smallest]!,
+				)
+			) {
+				smallest = right;
+			}
+			if (smallest === current) {
+				break;
+			}
+			this.swapPendingMaybeSyncResponseFitWaiters(current, smallest);
+			current = smallest;
+		}
+	}
+
+	private notifyPendingMaybeSyncResponseWaiter(): void {
+		const waiter = this.pendingMaybeSyncResponseWaiterHeap[0];
+		const available =
+			MAX_PENDING_MAYBE_SYNC_RESPONSE_HASHES -
+			this.pendingMaybeSyncResponseCount;
+		if (!waiter) {
+			return;
+		}
+		if (waiter.required <= available) {
+			waiter.wake();
+			return;
+		}
+		if (waiter.bypasses >= MAX_PENDING_MAYBE_SYNC_RESPONSE_WAITER_BYPASSES) {
+			// Reserve newly freed capacity for the oldest large request after a
+			// bounded number of smaller requests have bypassed it.
+			return;
+		}
+		const candidate = this.pendingMaybeSyncResponseWaiterFitHeap[0];
+		if (candidate && candidate.required <= available) {
+			waiter.bypasses += 1;
+			candidate.wake();
+		}
+	}
+
+	private schedulePendingMaybeSyncResponseWaiter(): void {
+		if (this.pendingMaybeSyncResponseWakeScheduled) {
+			return;
+		}
+		this.pendingMaybeSyncResponseWakeScheduled = true;
+		queueMicrotask(() => {
+			this.pendingMaybeSyncResponseWakeScheduled = false;
+			this.notifyPendingMaybeSyncResponseWaiter();
+		});
+	}
+
+	private swapPendingMaybeSyncResponseExpiry(
+		left: number,
+		right: number,
+	): void {
+		const leftBatch = this.pendingMaybeSyncResponseExpiryHeap[left]!;
+		const rightBatch = this.pendingMaybeSyncResponseExpiryHeap[right]!;
+		this.pendingMaybeSyncResponseExpiryHeap[left] = rightBatch;
+		this.pendingMaybeSyncResponseExpiryHeap[right] = leftBatch;
+		rightBatch.heapIndex = left;
+		leftBatch.heapIndex = right;
+	}
+
+	private pushPendingMaybeSyncResponseExpiry(
+		batch: PendingMaybeSyncResponse,
+	): void {
+		batch.heapIndex = this.pendingMaybeSyncResponseExpiryHeap.length;
+		this.pendingMaybeSyncResponseExpiryHeap.push(batch);
+		let index = batch.heapIndex;
+		while (index > 0) {
+			const parent = Math.floor((index - 1) / 2);
+			if (
+				this.pendingMaybeSyncResponseExpiryHeap[parent]!.expiresAt <=
+				this.pendingMaybeSyncResponseExpiryHeap[index]!.expiresAt
+			) {
+				break;
+			}
+			this.swapPendingMaybeSyncResponseExpiry(parent, index);
+			index = parent;
+		}
+	}
+
+	private removePendingMaybeSyncResponseExpiry(
+		batch: PendingMaybeSyncResponse,
+	): void {
+		const index = batch.heapIndex;
+		if (
+			index < 0 ||
+			index >= this.pendingMaybeSyncResponseExpiryHeap.length ||
+			this.pendingMaybeSyncResponseExpiryHeap[index] !== batch
+		) {
+			return;
+		}
+		const last = this.pendingMaybeSyncResponseExpiryHeap.pop()!;
+		batch.heapIndex = -1;
+		if (index >= this.pendingMaybeSyncResponseExpiryHeap.length) {
+			return;
+		}
+		this.pendingMaybeSyncResponseExpiryHeap[index] = last;
+		last.heapIndex = index;
+		let current = index;
+		while (current > 0) {
+			const parent = Math.floor((current - 1) / 2);
+			if (
+				this.pendingMaybeSyncResponseExpiryHeap[parent]!.expiresAt <=
+				this.pendingMaybeSyncResponseExpiryHeap[current]!.expiresAt
+			) {
+				break;
+			}
+			this.swapPendingMaybeSyncResponseExpiry(parent, current);
+			current = parent;
+		}
+		for (;;) {
+			const left = current * 2 + 1;
+			const right = left + 1;
+			let smallest = current;
+			if (
+				left < this.pendingMaybeSyncResponseExpiryHeap.length &&
+				this.pendingMaybeSyncResponseExpiryHeap[left]!.expiresAt <
+					this.pendingMaybeSyncResponseExpiryHeap[smallest]!.expiresAt
+			) {
+				smallest = left;
+			}
+			if (
+				right < this.pendingMaybeSyncResponseExpiryHeap.length &&
+				this.pendingMaybeSyncResponseExpiryHeap[right]!.expiresAt <
+					this.pendingMaybeSyncResponseExpiryHeap[smallest]!.expiresAt
+			) {
+				smallest = right;
+			}
+			if (smallest === current) {
+				break;
+			}
+			this.swapPendingMaybeSyncResponseExpiry(current, smallest);
+			current = smallest;
 		}
 	}
 
 	private schedulePendingMaybeSyncResponseExpiry(): void {
 		if (
 			this.pendingMaybeSyncResponseExpiryTimer ||
-			this.pendingMaybeSyncResponseBatches.size === 0
+			this.pendingMaybeSyncResponseExpiryHeap.length === 0
 		) {
 			return;
 		}
-		let earliest = Number.POSITIVE_INFINITY;
-		for (const batch of this.pendingMaybeSyncResponseBatches) {
-			earliest = Math.min(earliest, batch.expiresAt);
-		}
+		const earliest = this.pendingMaybeSyncResponseExpiryHeap[0]!.expiresAt;
 		this.pendingMaybeSyncResponseExpiryTimer = setTimeout(
 			() => {
 				this.pendingMaybeSyncResponseExpiryTimer = undefined;
-				const now = Date.now();
-				for (const batch of [...this.pendingMaybeSyncResponseBatches]) {
-					if (batch.expiresAt <= now) {
-						this.removePendingMaybeSyncResponseBatch(batch);
-					}
-				}
+				this.expirePendingMaybeSyncResponses();
 				this.schedulePendingMaybeSyncResponseExpiry();
 			},
 			Math.max(0, earliest - Date.now()),
 		);
 		this.pendingMaybeSyncResponseExpiryTimer.unref?.();
+	}
+
+	private expirePendingMaybeSyncResponses(now = Date.now()): void {
+		for (;;) {
+			const batch = this.pendingMaybeSyncResponseExpiryHeap[0];
+			if (!batch || batch.expiresAt > now) {
+				break;
+			}
+			this.removePendingMaybeSyncResponseBatch(batch);
+		}
+	}
+
+	private settlePendingMaybeSyncResponseAuthorization(
+		authorization: PendingMaybeSyncResponseAuthorization,
+		fulfilled: boolean,
+	): void {
+		if (authorization.settled) {
+			return;
+		}
+		authorization.settled = fulfilled ? "fulfilled" : "released";
+		const waiters = [...authorization.waiters];
+		authorization.waiters.clear();
+		for (const waiter of waiters) {
+			waiter(fulfilled ? "fulfilled" : "released");
+		}
+	}
+
+	private doesPendingMaybeSyncResponseScopeMatch(
+		authorization: PendingMaybeSyncResponseAuthorization,
+		lifecycle: SyncDispatchLifecycle,
+		target: string,
+	): boolean {
+		const owner = authorization.batch.targetLifecycle;
+		return (
+			owner.epoch === lifecycle.targets.get(target)?.epoch &&
+			owner.lifecycle.ownershipLifecycleController ===
+				lifecycle.ownershipLifecycleController &&
+			owner.lifecycle.callerSignal === lifecycle.callerSignal
+		);
+	}
+
+	private waitForPendingMaybeSyncResponseConflicts(
+		conflicts: PendingMaybeSyncResponseAuthorization[],
+		lifecycle: SyncDispatchLifecycle,
+		target: string,
+		retainedAssociations: number,
+	): Promise<string[]> {
+		const unique = [...new Set(conflicts)];
+		if (
+			this.pendingMaybeSyncResponseWaiterAssociationCount +
+				retainedAssociations >
+			MAX_PENDING_MAYBE_SYNC_RESPONSE_HASHES
+		) {
+			return Promise.resolve([]);
+		}
+		const available =
+			MAX_PENDING_MAYBE_SYNC_RESPONSE_HASHES -
+			this.pendingMaybeSyncResponseConflictWaiterCount;
+		const admitted = unique.slice(0, Math.max(0, available));
+		if (admitted.length === 0) {
+			return Promise.resolve([]);
+		}
+		this.pendingMaybeSyncResponseConflictWaiterCount += admitted.length;
+		this.pendingMaybeSyncResponseWaiterAssociationCount += retainedAssociations;
+		const targetSignal =
+			lifecycle.targets.get(target)?.controller.signal ??
+			lifecycle.controller.signal;
+		return new Promise<string[]>((resolve) => {
+			const retry = new Set<string>();
+			const callbacks = new Map<
+				PendingMaybeSyncResponseAuthorization,
+				(event: PendingMaybeSyncResponseAuthorizationEvent) => void
+			>();
+			let remaining = admitted.length;
+			let groupSettled = false;
+			const finishGroup = () => {
+				if (groupSettled || remaining !== 0) {
+					return;
+				}
+				groupSettled = true;
+				lifecycle.controller.signal.removeEventListener("abort", abort);
+				if (targetSignal !== lifecycle.controller.signal) {
+					targetSignal.removeEventListener("abort", abort);
+				}
+				this.pendingMaybeSyncResponseWaiterAssociationCount -=
+					retainedAssociations;
+				resolve([...retry]);
+			};
+			const finishOne = (
+				authorization: PendingMaybeSyncResponseAuthorization,
+				event: PendingMaybeSyncResponseAuthorizationEvent,
+			) => {
+				if (
+					event === "delivered" &&
+					(authorization.active === true ||
+						!this.doesPendingMaybeSyncResponseScopeMatch(
+							authorization,
+							lifecycle,
+							target,
+						))
+				) {
+					return;
+				}
+				const callback = callbacks.get(authorization);
+				if (!callback) {
+					return;
+				}
+				callbacks.delete(authorization);
+				authorization.waiters.delete(callback);
+				this.pendingMaybeSyncResponseConflictWaiterCount -= 1;
+				if (
+					event === "released" &&
+					this.isSyncDispatchLifecycleActive(lifecycle, target)
+				) {
+					retry.add(authorization.hash);
+				}
+				remaining -= 1;
+				finishGroup();
+			};
+			const abort = () => {
+				for (const authorization of [...callbacks.keys()]) {
+					finishOne(authorization, "fulfilled");
+				}
+			};
+			lifecycle.controller.signal.addEventListener("abort", abort, {
+				once: true,
+			});
+			if (targetSignal !== lifecycle.controller.signal) {
+				targetSignal.addEventListener("abort", abort, { once: true });
+			}
+			for (const authorization of admitted) {
+				const callback = (event: PendingMaybeSyncResponseAuthorizationEvent) =>
+					finishOne(authorization, event);
+				callbacks.set(authorization, callback);
+				authorization.waiters.add(callback);
+				if (authorization.settled) {
+					callback(authorization.settled);
+				} else if (
+					authorization.requestDelivered === true &&
+					authorization.active !== true
+				) {
+					callback("delivered");
+				}
+			}
+			if (!this.isSyncDispatchLifecycleActive(lifecycle, target)) {
+				abort();
+			}
+		});
 	}
 
 	private removePendingMaybeSyncResponseBatch(
@@ -800,11 +1500,15 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		let removed = 0;
 		if (pendingForTarget) {
 			for (const hash of batch.hashes) {
-				if (pendingForTarget.get(hash)?.batch !== batch) {
+				const authorization = pendingForTarget.get(hash);
+				if (authorization?.batch !== batch) {
 					continue;
 				}
+				this.settlePendingMaybeSyncResponseAuthorization(authorization, false);
 				pendingForTarget.delete(hash);
-				removed += 1;
+				if (authorization.deliveryInFlight !== true) {
+					removed += 1;
+				}
 			}
 			if (pendingForTarget.size === 0) {
 				this.pendingMaybeSyncResponses.delete(batch.target);
@@ -812,16 +1516,21 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		}
 		this.pendingMaybeSyncResponseCount -= removed;
 		this.pendingMaybeSyncResponseBatches.delete(batch);
-		batch.targetLifecycle.batches.delete(batch);
+		this.removePendingMaybeSyncResponseExpiry(batch);
+		if (batch.targetLifecycle.batches.delete(batch)) {
+			batch.targetLifecycle.lifecycle.retainedWork -= 1;
+		}
 		batch.hashes.clear();
 		if (
-			this.pendingMaybeSyncResponseBatches.size === 0 &&
+			this.pendingMaybeSyncResponseExpiryHeap.length === 0 &&
 			this.pendingMaybeSyncResponseExpiryTimer
 		) {
 			clearTimeout(this.pendingMaybeSyncResponseExpiryTimer);
 			this.pendingMaybeSyncResponseExpiryTimer = undefined;
 		}
-		this.notifyPendingMaybeSyncResponseWaiters();
+		if (removed > 0) {
+			this.schedulePendingMaybeSyncResponseWaiter();
+		}
 		this.maybeDisposeSyncDispatchLifecycle(batch.targetLifecycle.lifecycle);
 	}
 
@@ -839,14 +1548,16 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		for (const batch of batches) {
 			this.removePendingMaybeSyncResponseBatch(batch);
 		}
-		this.notifyPendingMaybeSyncResponseWaiters();
 	}
 
 	private tryReservePendingMaybeSyncResponse(properties: {
 		hashes: Iterable<string>;
 		targets: string[];
 		lifecycle: SyncDispatchLifecycle;
-	}): PendingMaybeSyncResponseReservation | undefined {
+	}): PendingMaybeSyncResponseReservationAttempt {
+		// Timers are only a cleanup aid. Enforce absolute deadlines at the
+		// admission boundary as well, including for unrelated fresh hashes.
+		this.expirePendingMaybeSyncResponses();
 		const hashes = [...new Set(properties.hashes)];
 		const targets = [...new Set(properties.targets)];
 		if (
@@ -856,22 +1567,24 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 					!this.isSyncDispatchLifecycleActive(properties.lifecycle, target),
 			)
 		) {
-			return undefined;
+			return { kind: "inactive" };
 		}
 
 		const hashesToAddByTarget = new Map<string, string[]>();
+		const conflicts: PendingMaybeSyncResponseAuthorization[] = [];
 		let required = 0;
 		for (const target of targets) {
-			const targetLifecycle = properties.lifecycle.targets.get(target)!;
 			const hashesToAdd: string[] = [];
 			for (const hash of hashes) {
 				let existing = this.pendingMaybeSyncResponses.get(target)?.get(hash);
 				if (
 					existing &&
-					!this.isSyncDispatchLifecycleActive(
-						existing.batch.targetLifecycle.lifecycle,
-						target,
-					)
+					existing.active !== true &&
+					(existing.batch.expiresAt <= Date.now() ||
+						!this.isSyncDispatchLifecycleActive(
+							existing.batch.targetLifecycle.lifecycle,
+							target,
+						))
 				) {
 					this.removePendingMaybeSyncResponseBatch(existing.batch);
 					existing = undefined;
@@ -879,15 +1592,23 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				if (existing) {
 					const existingTarget = existing.batch.targetLifecycle;
 					if (
-						existingTarget.epoch === targetLifecycle.epoch &&
-						existingTarget.lifecycle.ownershipLifecycleController ===
-							properties.lifecycle.ownershipLifecycleController &&
-						existingTarget.lifecycle.callerSignal ===
-							properties.lifecycle.callerSignal
+						existingTarget.lifecycle === properties.lifecycle ||
+						(existing.active !== true &&
+							existing.requestDelivered === true &&
+							this.doesPendingMaybeSyncResponseScopeMatch(
+								existing,
+								properties.lifecycle,
+								target,
+							))
 					) {
 						continue;
 					}
-					return undefined;
+					// Another live caller already owns the authorization for this
+					// exact target/hash. Send unrelated hashes now, then wait for this
+					// authorization to be fulfilled or released before deciding
+					// whether this caller must retry it.
+					conflicts.push(existing);
+					continue;
 				}
 				hashesToAdd.push(hash);
 			}
@@ -902,17 +1623,22 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			MAX_PENDING_MAYBE_SYNC_RESPONSE_HASHES -
 				this.pendingMaybeSyncResponseCount
 		) {
-			return undefined;
+			return { kind: "capacity", required };
 		}
 
 		const addedBatches: PendingMaybeSyncResponse[] = [];
+		const addedAuthorizations: PendingMaybeSyncResponseAuthorization[] = [];
 		for (const [target, hashesToAdd] of hashesToAddByTarget) {
 			const targetLifecycle = properties.lifecycle.targets.get(target)!;
 			const batch: PendingMaybeSyncResponse = {
 				hashes: new Set(hashesToAdd),
 				target,
 				targetLifecycle,
-				expiresAt: Date.now() + PENDING_MAYBE_SYNC_RESPONSE_TTL_MS,
+				// Start the response deadline only after rpc.send succeeds. Keeping
+				// pre-delivery work charged prevents a slow/non-abortable transport
+				// from rolling over an unbounded number of sends.
+				expiresAt: Infinity,
+				heapIndex: -1,
 			};
 			let pendingForTarget = this.pendingMaybeSyncResponses.get(target);
 			if (!pendingForTarget) {
@@ -920,14 +1646,24 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				this.pendingMaybeSyncResponses.set(target, pendingForTarget);
 			}
 			for (const hash of hashesToAdd) {
-				pendingForTarget.set(hash, { batch, hash });
+				const authorization: PendingMaybeSyncResponseAuthorization = {
+					batch,
+					hash,
+					waiters: new Set(),
+				};
+				pendingForTarget.set(hash, authorization);
+				addedAuthorizations.push(authorization);
 			}
 			this.pendingMaybeSyncResponseCount += hashesToAdd.length;
 			this.pendingMaybeSyncResponseBatches.add(batch);
 			targetLifecycle.batches.add(batch);
+			targetLifecycle.lifecycle.retainedWork += 1;
 			addedBatches.push(batch);
 		}
 		this.schedulePendingMaybeSyncResponseExpiry();
+		if (this.pendingMaybeSyncResponseWaiters.size > 0) {
+			this.schedulePendingMaybeSyncResponseWaiter();
+		}
 
 		let released = false;
 		const release = () => {
@@ -944,23 +1680,94 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			addedBatches.every(
 				(batch) =>
 					this.pendingMaybeSyncResponseBatches.has(batch) &&
+					batch.expiresAt > Date.now() &&
 					batch.hashes.size > 0,
 			);
 		if (!this.isSyncDispatchLifecycleActive(properties.lifecycle)) {
 			release();
-			return undefined;
+			return { kind: "inactive" };
 		}
 		return {
-			release,
-			newlyAuthorizedByTarget: hashesToAddByTarget,
-			retained,
-			signal: properties.lifecycle.controller.signal,
+			kind: "reserved",
+			reservation: {
+				release,
+				beginDelivery: () => {
+					for (const authorization of addedAuthorizations) {
+						if (!authorization.settled) {
+							authorization.deliveryInFlight = true;
+						}
+					}
+				},
+				finishDelivery: () => {
+					let releasedCount = 0;
+					for (const authorization of addedAuthorizations) {
+						if (authorization.deliveryInFlight !== true) {
+							continue;
+						}
+						authorization.deliveryInFlight = false;
+						if (
+							authorization.settled ||
+							this.pendingMaybeSyncResponses
+								.get(authorization.batch.target)
+								?.get(authorization.hash) !== authorization
+						) {
+							releasedCount += 1;
+						}
+					}
+					if (releasedCount > 0) {
+						this.pendingMaybeSyncResponseCount -= releasedCount;
+						this.schedulePendingMaybeSyncResponseWaiter();
+					}
+				},
+				markDelivered: () => {
+					const delivered: PendingMaybeSyncResponseAuthorization[] = [];
+					const deliveredBatches = new Set<PendingMaybeSyncResponse>();
+					for (const authorization of addedAuthorizations) {
+						if (
+							authorization.settled ||
+							authorization.active === true ||
+							this.pendingMaybeSyncResponses
+								.get(authorization.batch.target)
+								?.get(authorization.hash) !== authorization ||
+							!this.pendingMaybeSyncResponseBatches.has(authorization.batch)
+						) {
+							continue;
+						}
+						authorization.requestDelivered = true;
+						delivered.push(authorization);
+						deliveredBatches.add(authorization.batch);
+					}
+					const expiresAt = Date.now() + PENDING_MAYBE_SYNC_RESPONSE_TTL_MS;
+					for (const batch of deliveredBatches) {
+						if (batch.heapIndex >= 0) {
+							this.removePendingMaybeSyncResponseExpiry(batch);
+						}
+						batch.expiresAt = expiresAt;
+						this.pushPendingMaybeSyncResponseExpiry(batch);
+					}
+					this.schedulePendingMaybeSyncResponseExpiry();
+					for (const authorization of delivered) {
+						if (authorization.settled || authorization.active === true) {
+							continue;
+						}
+						for (const waiter of [...authorization.waiters]) {
+							waiter("delivered");
+						}
+					}
+				},
+				newlyAuthorizedByTarget: hashesToAddByTarget,
+				retained,
+				signal: properties.lifecycle.controller.signal,
+			},
+			conflicts,
 		};
 	}
 
 	private waitForPendingMaybeSyncResponseChange(
 		lifecycle: SyncDispatchLifecycle,
 		targets: string[],
+		required: number,
+		associations: number,
 	): Promise<void> {
 		if (
 			!this.isSyncDispatchLifecycleActive(lifecycle) ||
@@ -977,22 +1784,62 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			);
 		for (const targetLifecycle of targetLifecycles) {
 			targetLifecycle.activeWaiters += 1;
+			targetLifecycle.lifecycle.retainedWork += 1;
 		}
 		return new Promise<void>((resolve) => {
 			let settled = false;
+			let waiter!: PendingMaybeSyncResponseWaiter;
+			const abortSignals = [
+				lifecycle.controller.signal,
+				...targetLifecycles.map(
+					(targetLifecycle) => targetLifecycle.controller.signal,
+				),
+			];
 			const wake = () => {
 				if (settled) {
 					return;
 				}
+				const advanceWaiters =
+					!this.isSyncDispatchLifecycleActive(lifecycle) ||
+					targets.some(
+						(target) => !this.isSyncDispatchLifecycleActive(lifecycle, target),
+					);
 				settled = true;
-				this.pendingMaybeSyncResponseWaiters.delete(wake);
+				this.pendingMaybeSyncResponseWaiters.delete(waiter);
+				this.removePendingMaybeSyncResponseWaiter(waiter);
+				this.pendingMaybeSyncResponseWaiterAssociationCount -=
+					waiter.associations;
+				for (const signal of abortSignals) {
+					signal.removeEventListener("abort", wake);
+				}
 				for (const targetLifecycle of targetLifecycles) {
 					targetLifecycle.activeWaiters -= 1;
+					targetLifecycle.lifecycle.retainedWork -= 1;
 				}
 				resolve();
 				this.maybeDisposeSyncDispatchLifecycle(lifecycle);
+				if (advanceWaiters) {
+					this.schedulePendingMaybeSyncResponseWaiter();
+				}
 			};
-			this.pendingMaybeSyncResponseWaiters.add(wake);
+			waiter = {
+				required,
+				associations,
+				order: ++this.pendingMaybeSyncResponseWaiterOrder,
+				bypasses: 0,
+				heapIndex: -1,
+				fitHeapIndex: -1,
+				wake,
+			};
+			this.pendingMaybeSyncResponseWaiters.add(waiter);
+			this.pendingMaybeSyncResponseWaiterAssociationCount += associations;
+			this.pushPendingMaybeSyncResponseWaiter(waiter);
+			// This exact request does not fit, but an older/stale requirement may
+			// have changed and another smaller waiter can still use the capacity.
+			this.schedulePendingMaybeSyncResponseWaiter();
+			for (const signal of abortSignals) {
+				signal.addEventListener("abort", wake, { once: true });
+			}
 			if (
 				!this.isSyncDispatchLifecycleActive(lifecycle) ||
 				targets.some(
@@ -1008,20 +1855,54 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		hashes: Iterable<string>;
 		targets: string[];
 		lifecycle: SyncDispatchLifecycle;
-	}): Promise<PendingMaybeSyncResponseReservation | undefined> {
+	}): Promise<
+		| {
+				reservation: PendingMaybeSyncResponseReservation;
+				conflicts: PendingMaybeSyncResponseAuthorization[];
+		  }
+		| undefined
+	> {
+		const hashes = [...new Set(properties.hashes)];
+		const targets = [...new Set(properties.targets)];
+		const associations = Math.max(
+			1,
+			Math.min(MAX_PENDING_MAYBE_SYNC_RESPONSE_HASHES, hashes.length) *
+				Math.min(MAX_PENDING_MAYBE_SYNC_RESPONSE_HASHES, targets.length),
+		);
 		while (
 			this.isSyncDispatchLifecycleActive(properties.lifecycle) &&
-			properties.targets.every((target) =>
+			targets.every((target) =>
 				this.isSyncDispatchLifecycleActive(properties.lifecycle, target),
 			)
 		) {
-			const reservation = this.tryReservePendingMaybeSyncResponse(properties);
-			if (reservation) {
-				return reservation;
+			const attempt = this.tryReservePendingMaybeSyncResponse({
+				hashes,
+				targets,
+				lifecycle: properties.lifecycle,
+			});
+			if (attempt.kind === "reserved") {
+				return {
+					reservation: attempt.reservation,
+					conflicts: attempt.conflicts,
+				};
+			}
+			if (attempt.kind !== "capacity") {
+				this.schedulePendingMaybeSyncResponseWaiter();
+				return undefined;
+			}
+			if (
+				this.pendingMaybeSyncResponseWaiters.size >=
+					MAX_PENDING_MAYBE_SYNC_RESPONSE_WAITERS ||
+				this.pendingMaybeSyncResponseWaiterAssociationCount + associations >
+					MAX_PENDING_MAYBE_SYNC_RESPONSE_HASHES
+			) {
+				return undefined;
 			}
 			await this.waitForPendingMaybeSyncResponseChange(
 				properties.lifecycle,
-				properties.targets,
+				targets,
+				attempt.required,
+				associations,
 			);
 		}
 		return undefined;
@@ -1038,16 +1919,21 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			properties.signal,
 			{ abortAllOnTargetDisconnect: true },
 		);
-		const reservation = this.tryReservePendingMaybeSyncResponse({
+		const attempt = this.tryReservePendingMaybeSyncResponse({
 			hashes: properties.hashes,
 			targets,
 			lifecycle,
 		});
+		const reservation =
+			attempt.kind === "reserved" ? attempt.reservation : undefined;
 		let retainedReservation: PendingMaybeSyncResponseReservation | undefined;
 		if (reservation) {
+			// This synchronous helper represents an already-issued request.
+			reservation.markDelivered();
 			const leasedTargets = [...lifecycle.targets.values()];
 			for (const targetLifecycle of leasedTargets) {
 				targetLifecycle.responseLeases += 1;
+				targetLifecycle.lifecycle.retainedWork += 1;
 			}
 			let released = false;
 			retainedReservation = {
@@ -1060,6 +1946,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 					reservation.release();
 					for (const targetLifecycle of leasedTargets) {
 						targetLifecycle.responseLeases -= 1;
+						targetLifecycle.lifecycle.retainedWork -= 1;
 					}
 					this.maybeDisposeSyncDispatchLifecycle(lifecycle);
 				},
@@ -1078,64 +1965,143 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		if (!pendingForTarget) {
 			return [];
 		}
+		if (
+			this.activeMaybeSyncResponseCount >=
+				MAX_ACTIVE_SIMPLE_SYNC_RESPONSES_GLOBAL ||
+			(this.activeMaybeSyncResponseCountByPeer.get(fromHash) ?? 0) >=
+				MAX_ACTIVE_SIMPLE_SYNC_RESPONSES_PER_PEER
+		) {
+			return [];
+		}
 		const acceptedByLifecycle = new Map<
 			SyncDispatchTargetLifecycle,
-			string[]
+			{
+				hashes: string[];
+				authorizations: PendingMaybeSyncResponseAuthorization[];
+			}
 		>();
 		const seen = new Set<string>();
-		for (const hash of hashes) {
-			if (seen.has(hash)) {
-				continue;
-			}
-			seen.add(hash);
-			const authorization = pendingForTarget.get(hash);
-			if (!authorization) {
-				continue;
-			}
-			const batch = authorization.batch;
-			const targetLifecycle = batch.targetLifecycle;
-			if (
-				!this.isSyncDispatchLifecycleActive(targetLifecycle.lifecycle, fromHash)
+		let inspected = 0;
+		const iterator = hashes[Symbol.iterator]();
+		let exhausted = false;
+		try {
+			while (
+				inspected < MAX_PENDING_MAYBE_SYNC_RESPONSE_HASHES &&
+				pendingForTarget.size > 0
 			) {
-				this.removePendingMaybeSyncResponseBatch(batch);
-				continue;
+				const next = iterator.next();
+				if (next.done) {
+					exhausted = true;
+					break;
+				}
+				inspected += 1;
+				const hash = next.value;
+				if (seen.has(hash)) {
+					continue;
+				}
+				seen.add(hash);
+				const authorization = pendingForTarget.get(hash);
+				if (!authorization || authorization.active === true) {
+					continue;
+				}
+				const batch = authorization.batch;
+				const targetLifecycle = batch.targetLifecycle;
+				if (
+					batch.expiresAt <= Date.now() ||
+					!this.isSyncDispatchLifecycleActive(
+						targetLifecycle.lifecycle,
+						fromHash,
+					)
+				) {
+					this.removePendingMaybeSyncResponseBatch(batch);
+					continue;
+				}
+				if (pendingForTarget.get(hash)?.batch !== batch) {
+					continue;
+				}
+				let accepted = acceptedByLifecycle.get(targetLifecycle);
+				if (!accepted) {
+					accepted = { hashes: [], authorizations: [] };
+					acceptedByLifecycle.set(targetLifecycle, accepted);
+					targetLifecycle.responseLeases += 1;
+					targetLifecycle.lifecycle.retainedWork += 1;
+				}
+				authorization.active = true;
+				batch.hashes.delete(hash);
+				accepted.hashes.push(hash);
+				accepted.authorizations.push(authorization);
+				if (batch.hashes.size === 0) {
+					this.removePendingMaybeSyncResponseBatch(batch);
+				}
 			}
-			if (pendingForTarget.get(hash)?.batch !== batch) {
-				continue;
-			}
-			let accepted = acceptedByLifecycle.get(targetLifecycle);
-			if (!accepted) {
-				accepted = [];
-				acceptedByLifecycle.set(targetLifecycle, accepted);
-				targetLifecycle.responseLeases += 1;
-			}
-			pendingForTarget.delete(hash);
-			batch.hashes.delete(hash);
-			this.pendingMaybeSyncResponseCount -= 1;
-			accepted.push(hash);
-			if (batch.hashes.size === 0) {
-				this.removePendingMaybeSyncResponseBatch(batch);
+		} finally {
+			if (!exhausted) {
+				iterator.return?.();
 			}
 		}
 		if (pendingForTarget.size === 0) {
 			this.pendingMaybeSyncResponses.delete(fromHash);
 		}
-		this.notifyPendingMaybeSyncResponseWaiters();
-		return [...acceptedByLifecycle].map(([targetLifecycle, acceptedHashes]) => {
-			let released = false;
-			return {
-				hashes: acceptedHashes,
-				signal: targetLifecycle.controller.signal,
-				release: () => {
-					if (released) {
-						return;
-					}
-					released = true;
-					targetLifecycle.responseLeases -= 1;
-					this.maybeDisposeSyncDispatchLifecycle(targetLifecycle.lifecycle);
-				},
-			};
-		});
+		if (acceptedByLifecycle.size === 0) {
+			return [];
+		}
+		this.activeMaybeSyncResponseCount += 1;
+		this.activeMaybeSyncResponseCountByPeer.set(
+			fromHash,
+			(this.activeMaybeSyncResponseCountByPeer.get(fromHash) ?? 0) + 1,
+		);
+		let remainingLeases = acceptedByLifecycle.size;
+		return [...acceptedByLifecycle].map(
+			([targetLifecycle, { hashes: acceptedHashes, authorizations }]) => {
+				let released = false;
+				return {
+					hashes: acceptedHashes,
+					signal: targetLifecycle.controller.signal,
+					release: (options?: { fulfilled?: boolean }) => {
+						if (released) {
+							return;
+						}
+						released = true;
+						const pendingForTarget =
+							this.pendingMaybeSyncResponses.get(fromHash);
+						for (const authorization of authorizations) {
+							this.settlePendingMaybeSyncResponseAuthorization(
+								authorization,
+								options?.fulfilled === true,
+							);
+							if (pendingForTarget?.get(authorization.hash) === authorization) {
+								pendingForTarget.delete(authorization.hash);
+							}
+						}
+						if (pendingForTarget?.size === 0) {
+							this.pendingMaybeSyncResponses.delete(fromHash);
+						}
+						this.pendingMaybeSyncResponseCount -= authorizations.filter(
+							(authorization) => authorization.deliveryInFlight !== true,
+						).length;
+						targetLifecycle.responseLeases -= 1;
+						targetLifecycle.lifecycle.retainedWork -= 1;
+						remainingLeases -= 1;
+						if (remainingLeases === 0) {
+							this.activeMaybeSyncResponseCount -= 1;
+							const activeForPeer =
+								(this.activeMaybeSyncResponseCountByPeer.get(fromHash) ?? 1) -
+								1;
+							if (activeForPeer === 0) {
+								this.activeMaybeSyncResponseCountByPeer.delete(fromHash);
+							} else {
+								this.activeMaybeSyncResponseCountByPeer.set(
+									fromHash,
+									activeForPeer,
+								);
+							}
+						}
+						this.schedulePendingMaybeSyncResponseWaiter();
+						this.maybeDisposeSyncDispatchLifecycle(targetLifecycle.lifecycle);
+					},
+				};
+			},
+		);
 	}
 
 	private isRepairSessionComplete(session: RepairSessionState): boolean {
@@ -1501,51 +2467,65 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 					if (!this.isSyncDispatchLifecycleActive(lifecycle, target)) {
 						continue;
 					}
-					const reservation = await this.reservePendingMaybeSyncResponse({
-						hashes: chunk,
-						targets: [target],
-						lifecycle,
-					});
-					if (
-						!reservation ||
-						!this.isSyncDispatchLifecycleActive(lifecycle, target)
+					let hashesToAuthorize = chunk;
+					while (
+						hashesToAuthorize.length > 0 &&
+						this.isSyncDispatchLifecycleActive(lifecycle, target)
 					) {
-						continue;
-					}
-					const hashesToSend =
-						reservation.newlyAuthorizedByTarget.get(target) ?? [];
-					if (hashesToSend.length === 0) {
-						continue;
-					}
-					if (!reservation.retained()) {
-						reservation.release();
-						continue;
-					}
-					try {
-						await this.rpc.send(
-							new RequestMaybeSync({ hashes: hashesToSend }),
-							{
-								priority: SYNC_MESSAGE_PRIORITY,
-								mode: new SilentDelivery({
-									to: [target],
-									redundancy: 1,
-								}),
-								signal: this.getSyncDispatchSignal(lifecycle, target),
-							},
-						);
-						messages += 1;
-					} catch (error) {
-						reservation.release();
+						const reserved = await this.reservePendingMaybeSyncResponse({
+							hashes: hashesToAuthorize,
+							targets: [target],
+							lifecycle,
+						});
 						if (
-							!this.isSyncDispatchLifecycleActive(lifecycle) ||
+							!reserved ||
 							!this.isSyncDispatchLifecycleActive(lifecycle, target)
 						) {
-							continue;
+							break;
 						}
-						throw error;
-					}
-					if (!this.isSyncDispatchLifecycleActive(lifecycle, target)) {
-						break;
+						const { reservation, conflicts } = reserved;
+						const hashesToSend =
+							reservation.newlyAuthorizedByTarget.get(target) ?? [];
+						if (!reservation.retained()) {
+							reservation.release();
+							break;
+						}
+						if (hashesToSend.length > 0) {
+							reservation.beginDelivery();
+							try {
+								await this.rpc.send(
+									new RequestMaybeSync({ hashes: hashesToSend }),
+									{
+										priority: SYNC_MESSAGE_PRIORITY,
+										mode: new SilentDelivery({
+											to: [target],
+											redundancy: 1,
+										}),
+										signal: this.getSyncDispatchSignal(lifecycle, target),
+									},
+								);
+								reservation.markDelivered();
+								messages += 1;
+							} catch (error) {
+								reservation.release();
+								if (
+									!this.isSyncDispatchLifecycleActive(lifecycle) ||
+									!this.isSyncDispatchLifecycleActive(lifecycle, target)
+								) {
+									break;
+								}
+								throw error;
+							} finally {
+								reservation.finishDelivery();
+							}
+						}
+						hashesToAuthorize =
+							await this.waitForPendingMaybeSyncResponseConflicts(
+								conflicts,
+								lifecycle,
+								target,
+								hashesToAuthorize.length,
+							);
 					}
 				}
 				if (!this.isSyncDispatchLifecycleActive(lifecycle)) {
@@ -1684,6 +2664,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		let entries = 0;
 		let firstError: unknown;
 		for (const lease of properties.leases) {
+			let fulfilled = false;
 			try {
 				const shipped = await this.shipAuthorizedMaybeSyncResponse({
 					hashes: lease.hashes,
@@ -1694,10 +2675,11 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				messages += shipped.messages;
 				fused ||= shipped.fused;
 				entries += shipped.entries;
+				fulfilled = !lease.signal.aborted;
 			} catch (error) {
 				firstError ??= error;
 			} finally {
-				lease.release();
+				lease.release({ fulfilled });
 			}
 		}
 		if (profile) {
@@ -1747,21 +2729,42 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			msg instanceof RequestMaybeSyncCoordinate ||
 			msg instanceof RequestMaybeSyncCoordinateCapabilities
 		) {
+			if (
+				msg.hashNumbers.length === 0 ||
+				msg.hashNumbers.length > MAX_SIMPLE_COORDINATE_REQUEST_SYMBOLS
+			) {
+				return true;
+			}
 			const target = from.hashcode();
+			const releaseLookup = this.tryAcquireCoordinateLookup(target);
+			if (!releaseLookup) {
+				return true;
+			}
 			const lifecycle = this.captureSyncDispatchLifecycle([target]);
+			let lookupReleased = false;
+			const finishLookup = () => {
+				if (lookupReleased) {
+					return;
+				}
+				lookupReleased = true;
+				releaseLookup();
+			};
 			try {
 				if (!this.isSyncDispatchLifecycleActive(lifecycle, target)) {
 					return true;
 				}
+				const symbols = [...new Set(msg.hashNumbers)];
 				const profile = this.syncOptions?.profile;
 				const lookupStartedAt = syncProfileStart(profile);
 				const hashes = await getHashesFromSymbols(
-					msg.hashNumbers,
+					symbols,
 					this.entryIndex,
 					this.coordinateToHash,
 					this.resolveHashesForSymbols,
 					this.resolveHashListForSymbols,
+					MAX_SIMPLE_COORDINATE_RESPONSE_HASHES,
 				);
+				finishLookup();
 				if (!this.isSyncDispatchLifecycleActive(lifecycle, target)) {
 					return true;
 				}
@@ -1769,15 +2772,20 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 					emitSyncProfileDuration(profile, lookupStartedAt, {
 						name: "simple.coordinateLookup",
 						entries: hashLookupResultSize(hashes),
-						symbols: msg.hashNumbers.length,
+						symbols: symbols.length,
 					});
 				}
 
+				const releaseResponse = this.tryAcquireCoordinateResponse(target);
+				if (!releaseResponse) {
+					return true;
+				}
 				const exchangeStartedAt = syncProfileStart(profile);
-				const hashesToSend = this.filterRecentlySentExchangeHeads(hashes, from);
+				let hashesToSend: string[] = [];
 				let messages = 0;
 				let fused = false;
 				try {
+					hashesToSend = this.filterRecentlySentExchangeHeads(hashes, from);
 					// dont set priority 1 here because this will block other messages that should higher priority
 					({ messages, fused } = await this.shipExchangeHeads(
 						hashesToSend,
@@ -1786,6 +2794,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 						this.getSyncDispatchSignal(lifecycle, target),
 					));
 				} finally {
+					releaseResponse();
 					if (profile) {
 						emitSyncProfileDuration(profile, exchangeStartedAt, {
 							name: "simple.exchangeHeads",
@@ -1802,6 +2811,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 
 				return true;
 			} finally {
+				finishLookup();
 				this.finishSyncDispatchLifecycle(lifecycle);
 			}
 		} else {
@@ -1830,12 +2840,818 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		this.markRepairSessionResolvedHashes(properties.hashes);
 	}
 
+	private getPendingSyncKeyIdentity(key: SyncableKey): SyncableKey {
+		if (typeof key === "string") {
+			return key;
+		}
+		const hash = this.coordinateToHash.get(key);
+		return hash ?? key;
+	}
+
+	private removeQueuedSyncCoordinateAlias(key: bigint): void {
+		this.syncInFlightQueuedCoordinates.delete(key);
+		if (this.syncInFlightQueuedCoordinates.size === 0) {
+			this.syncInFlightQueuedCoordinateRefreshIterator = undefined;
+		}
+		const previousHash = this.syncInFlightQueuedHashByCoordinate.get(key);
+		this.syncInFlightQueuedHashByCoordinate.delete(key);
+		if (previousHash != null) {
+			const coordinates =
+				this.syncInFlightQueuedCoordinatesByHash.get(previousHash);
+			coordinates?.delete(key);
+			if (coordinates?.size === 0) {
+				this.syncInFlightQueuedCoordinatesByHash.delete(previousHash);
+			}
+		}
+	}
+
+	private refreshQueuedSyncCoordinateAlias(key: bigint): void {
+		if (!this.syncInFlightQueue.has(key)) {
+			this.removeQueuedSyncCoordinateAlias(key);
+			return;
+		}
+		this.syncInFlightQueuedCoordinates.add(key);
+		const hash = this.coordinateToHash.get(key) ?? undefined;
+		const previousHash = this.syncInFlightQueuedHashByCoordinate.get(key);
+		if (previousHash !== hash) {
+			if (previousHash != null) {
+				const coordinates =
+					this.syncInFlightQueuedCoordinatesByHash.get(previousHash);
+				coordinates?.delete(key);
+				if (coordinates?.size === 0) {
+					this.syncInFlightQueuedCoordinatesByHash.delete(previousHash);
+				}
+			}
+			if (hash == null) {
+				this.syncInFlightQueuedHashByCoordinate.delete(key);
+			} else {
+				this.syncInFlightQueuedHashByCoordinate.set(key, hash);
+			}
+		}
+		if (hash != null) {
+			let coordinates = this.syncInFlightQueuedCoordinatesByHash.get(hash);
+			if (!coordinates) {
+				coordinates = new Set();
+				this.syncInFlightQueuedCoordinatesByHash.set(hash, coordinates);
+			}
+			coordinates.add(key);
+			this.reconcileQueuedSyncCoordinateAlias(key, hash);
+		}
+	}
+
+	private reconcileQueuedSyncCoordinateAlias(
+		coordinate: bigint,
+		hash: string,
+	): void {
+		const now = Date.now();
+		const coordinateExpiresAt = this.syncInFlightQueueExpiresAt.get(coordinate);
+		if (coordinateExpiresAt != null && coordinateExpiresAt <= now) {
+			this.clearSyncProcessKey(coordinate);
+			return;
+		}
+		const hashExpiresAt = this.syncInFlightQueueExpiresAt.get(hash);
+		if (hashExpiresAt != null && hashExpiresAt <= now) {
+			this.clearSyncProcessKey(hash);
+			return;
+		}
+		const hashClaimants = this.syncInFlightQueue.get(hash);
+		if (!hashClaimants || !this.syncInFlightQueue.has(coordinate)) {
+			return;
+		}
+		const expiresAt = Math.min(
+			this.syncInFlightQueueExpiresAt.get(coordinate) ?? Infinity,
+			this.syncInFlightQueueExpiresAt.get(hash) ?? Infinity,
+		);
+		for (const claimant of [...hashClaimants]) {
+			this.addPendingSyncClaim(coordinate, claimant, expiresAt);
+		}
+		if (Number.isFinite(expiresAt)) {
+			this.movePendingSyncKeyExpiryEarlier(coordinate, expiresAt);
+		}
+		for (const target of [...(this.syncInFlightTargetsByKey.get(hash) ?? [])]) {
+			const state = this.syncInFlight.get(target)?.get(hash);
+			if (state) {
+				this.setSyncInFlightTargetKey(target, coordinate, state.timestamp);
+			}
+		}
+		this.clearSyncProcessKey(hash);
+	}
+
+	private refreshQueuedSyncCoordinateAliases(): void {
+		if (
+			this.syncInFlightQueuedCoordinates.size === 0 &&
+			this.syncInFlightQueueClaimants.size < this.syncInFlightQueue.size
+		) {
+			// Defensive compatibility for callers/tests that seed the public queue
+			// directly. Keep hydration bounded; internal writes register coordinates
+			// when the key is first admitted.
+			let inspected = 0;
+			for (const key of this.syncInFlightQueue.keys()) {
+				if (typeof key === "bigint") {
+					this.syncInFlightQueuedCoordinates.add(key);
+				}
+				inspected += 1;
+				if (inspected >= MAX_PENDING_SIMPLE_SYNC_ALIAS_REFRESH_PER_MESSAGE) {
+					break;
+				}
+			}
+		}
+		if (this.syncInFlightQueuedCoordinates.size === 0) {
+			this.syncInFlightQueuedCoordinateRefreshIterator = undefined;
+			return;
+		}
+		this.syncInFlightQueuedCoordinateRefreshIterator ??=
+			this.syncInFlightQueuedCoordinates.values();
+		for (
+			let refreshed = 0;
+			refreshed < MAX_PENDING_SIMPLE_SYNC_ALIAS_REFRESH_PER_MESSAGE;
+			refreshed += 1
+		) {
+			const next = this.syncInFlightQueuedCoordinateRefreshIterator.next();
+			if (next.done) {
+				this.syncInFlightQueuedCoordinateRefreshIterator = undefined;
+				break;
+			}
+			this.refreshQueuedSyncCoordinateAlias(next.value);
+		}
+	}
+
+	private getQueuedSyncKeyForAdmission(
+		key: SyncableKey,
+	): SyncableKey | typeof QUEUED_SYNC_ALIAS_REFRESH_PENDING | undefined {
+		const getValidQueuedKey = (
+			candidate: SyncableKey,
+		): SyncableKey | undefined => {
+			if (!this.syncInFlightQueue.has(candidate)) {
+				return undefined;
+			}
+			const expiresAt = this.syncInFlightQueueExpiresAt.get(candidate);
+			if (expiresAt != null && expiresAt <= Date.now()) {
+				this.clearSyncProcessKey(candidate);
+				return undefined;
+			}
+			return candidate;
+		};
+		if (getValidQueuedKey(key) != null) {
+			if (typeof key === "bigint") {
+				this.refreshQueuedSyncCoordinateAlias(key);
+				return getValidQueuedKey(key);
+			}
+			return key;
+		}
+		if (typeof key === "string") {
+			const aliases = this.syncInFlightQueuedCoordinatesByHash.get(key);
+			if (aliases) {
+				let inspected = 0;
+				for (const alias of aliases) {
+					if (inspected >= MAX_PENDING_SIMPLE_SYNC_ALIAS_REFRESH_PER_MESSAGE) {
+						return QUEUED_SYNC_ALIAS_REFRESH_PENDING;
+					}
+					inspected += 1;
+					this.refreshQueuedSyncCoordinateAlias(alias);
+					if (
+						this.syncInFlightQueuedCoordinatesByHash.get(key)?.has(alias) ===
+						true
+					) {
+						const validAlias = getValidQueuedKey(alias);
+						if (validAlias != null) {
+							return validAlias;
+						}
+					}
+				}
+				if (
+					(this.syncInFlightQueuedCoordinatesByHash.get(key)?.size ?? 0) > 0
+				) {
+					return QUEUED_SYNC_ALIAS_REFRESH_PENDING;
+				}
+			}
+			return undefined;
+		}
+		const hash = this.coordinateToHash.get(key);
+		return hash != null ? getValidQueuedKey(hash) : undefined;
+	}
+
+	private addPendingSyncClaim(
+		key: SyncableKey,
+		from: PublicSignKey,
+		expiresAt?: number,
+	): boolean {
+		const fromHash = from.hashcode();
+		let peers = this.syncInFlightQueue.get(key);
+		let claimants = this.syncInFlightQueueClaimants.get(key);
+		let claimantIndexes = this.syncInFlightQueueClaimantIndexes.get(key);
+		if (!peers) {
+			peers = [];
+			this.syncInFlightQueue.set(key, peers);
+			claimants = new Set();
+			this.syncInFlightQueueClaimants.set(key, claimants);
+			claimantIndexes = new Map();
+			this.syncInFlightQueueClaimantIndexes.set(key, claimantIndexes);
+			const deadline = expiresAt ?? Date.now() + PENDING_SIMPLE_SYNC_KEY_TTL_MS;
+			this.syncInFlightQueueExpiresAt.set(key, deadline);
+			const expiryNode: PendingSyncExpiryNode = {
+				kind: "key",
+				key,
+				expiresAt: deadline,
+				heapIndex: -1,
+			};
+			this.pendingSyncKeyExpiryNodes.set(key, expiryNode);
+			this.pushPendingSyncExpiry(expiryNode);
+			if (typeof key === "bigint") {
+				this.refreshQueuedSyncCoordinateAlias(key);
+			}
+		} else if (!claimants) {
+			// Defensive compatibility for callers/tests that seed the public queue
+			// maps directly. Internally every retained key gets this set at creation.
+			claimants = new Set(peers.map((peer) => peer.hashcode()));
+			this.syncInFlightQueueClaimants.set(key, claimants);
+			this.pendingSyncClaimCount += claimants.size;
+		}
+		if (!claimantIndexes) {
+			claimantIndexes = new Map();
+			for (let index = 0; index < peers.length; index += 1) {
+				claimantIndexes.set(peers[index]!.hashcode(), index);
+			}
+			this.syncInFlightQueueClaimantIndexes.set(key, claimantIndexes);
+		}
+		if (claimants.has(fromHash)) {
+			return false;
+		}
+
+		claimantIndexes.set(fromHash, peers.length);
+		peers.push(from);
+		claimants.add(fromHash);
+		let inverted = this.syncInFlightQueueInverted.get(fromHash);
+		if (!inverted) {
+			inverted = new Set();
+			this.syncInFlightQueueInverted.set(fromHash, inverted);
+		}
+		inverted.add(key);
+		this.pendingSyncClaimCount += 1;
+		this.schedulePendingSyncKeyExpiry();
+		return true;
+	}
+
+	private hasPendingSyncClaim(key: SyncableKey, peer: string): boolean {
+		const claimants = this.syncInFlightQueueClaimants.get(key);
+		if (claimants) {
+			return claimants.has(peer);
+		}
+		const peers = this.syncInFlightQueue.get(key);
+		if (!peers) {
+			return false;
+		}
+		const hydrated = new Set(peers.map((candidate) => candidate.hashcode()));
+		this.syncInFlightQueueClaimants.set(key, hydrated);
+		const indexes = new Map<string, number>();
+		for (let index = 0; index < peers.length; index += 1) {
+			indexes.set(peers[index]!.hashcode(), index);
+		}
+		this.syncInFlightQueueClaimantIndexes.set(key, indexes);
+		this.pendingSyncClaimCount += hydrated.size;
+		return hydrated.has(peer);
+	}
+
+	private filterDispatchablePendingSyncClaims(
+		keys: SyncableKey[],
+		peer: string,
+		epoch: SyncDispatchTargetEpoch,
+	): SyncableKey[] {
+		if (this.syncDispatchTargetEpochs.get(peer) !== epoch) {
+			return [];
+		}
+		const now = Date.now();
+		const dispatchable: SyncableKey[] = [];
+		for (const key of keys) {
+			const expiresAt = this.syncInFlightQueueExpiresAt.get(key);
+			if (expiresAt != null && expiresAt <= now) {
+				this.clearSyncProcessKey(key);
+				continue;
+			}
+			if (
+				this.syncInFlightQueue.has(key) &&
+				this.hasPendingSyncClaim(key, peer)
+			) {
+				dispatchable.push(key);
+			}
+		}
+		return dispatchable;
+	}
+
+	private canStartPendingSyncLookup(peer: string): boolean {
+		return (
+			this.pendingSyncAdmissionReservations.size +
+				this.pendingCoordinateLookupCount <
+				MAX_PENDING_SIMPLE_SYNC_LOOKUPS_GLOBAL &&
+			(this.pendingSyncAdmissionReservationsByPeer.get(peer)?.size ?? 0) +
+				(this.pendingCoordinateLookupCountByPeer.get(peer) ?? 0) <
+				MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER
+		);
+	}
+
+	private tryAcquireCoordinateLookup(peer: string): (() => void) | undefined {
+		if (!this.canStartPendingSyncLookup(peer)) {
+			return undefined;
+		}
+		this.pendingCoordinateLookupCount += 1;
+		this.pendingCoordinateLookupCountByPeer.set(
+			peer,
+			(this.pendingCoordinateLookupCountByPeer.get(peer) ?? 0) + 1,
+		);
+		let released = false;
+		return () => {
+			if (released) {
+				return;
+			}
+			released = true;
+			this.pendingCoordinateLookupCount -= 1;
+			const remaining =
+				(this.pendingCoordinateLookupCountByPeer.get(peer) ?? 1) - 1;
+			if (remaining === 0) {
+				this.pendingCoordinateLookupCountByPeer.delete(peer);
+			} else {
+				this.pendingCoordinateLookupCountByPeer.set(peer, remaining);
+			}
+		};
+	}
+
+	private tryAcquireCoordinateResponse(peer: string): (() => void) | undefined {
+		if (
+			this.pendingCoordinateResponseCount >=
+				MAX_PENDING_SIMPLE_COORDINATE_RESPONSES_GLOBAL ||
+			(this.pendingCoordinateResponseCountByPeer.get(peer) ?? 0) >=
+				MAX_PENDING_SIMPLE_COORDINATE_RESPONSES_PER_PEER
+		) {
+			return undefined;
+		}
+		this.pendingCoordinateResponseCount += 1;
+		this.pendingCoordinateResponseCountByPeer.set(
+			peer,
+			(this.pendingCoordinateResponseCountByPeer.get(peer) ?? 0) + 1,
+		);
+		let released = false;
+		return () => {
+			if (released) {
+				return;
+			}
+			released = true;
+			this.pendingCoordinateResponseCount -= 1;
+			const remaining =
+				(this.pendingCoordinateResponseCountByPeer.get(peer) ?? 1) - 1;
+			if (remaining === 0) {
+				this.pendingCoordinateResponseCountByPeer.delete(peer);
+			} else {
+				this.pendingCoordinateResponseCountByPeer.set(peer, remaining);
+			}
+		};
+	}
+
+	private reservePendingSyncAdmission(
+		peer: string,
+		identities: SyncableKey[],
+	): PendingSyncAdmissionReservation | undefined {
+		const count = identities.length;
+		if (count <= 0) {
+			return undefined;
+		}
+		const reservation: PendingSyncAdmissionReservation = {
+			peer,
+			remaining: count,
+			active: true,
+			released: false,
+			expiresAt: Date.now() + PENDING_SIMPLE_SYNC_KEY_TTL_MS,
+			identities: new Set(identities),
+			retainedSettled: 0,
+		};
+		this.pendingSyncAdmissionReservations.add(reservation);
+		let peerReservations =
+			this.pendingSyncAdmissionReservationsByPeer.get(peer);
+		if (!peerReservations) {
+			peerReservations = new Set();
+			this.pendingSyncAdmissionReservationsByPeer.set(peer, peerReservations);
+		}
+		peerReservations.add(reservation);
+		this.pendingSyncActiveAdmissionReservations += 1;
+		this.pendingSyncAdmissionCount += count;
+		this.pendingSyncAdmissionCountByPeer.set(
+			peer,
+			(this.pendingSyncAdmissionCountByPeer.get(peer) ?? 0) + count,
+		);
+		let reservedIdentities =
+			this.pendingSyncAdmissionIdentitiesByPeer.get(peer);
+		if (!reservedIdentities) {
+			reservedIdentities = new Set();
+			this.pendingSyncAdmissionIdentitiesByPeer.set(peer, reservedIdentities);
+		}
+		for (const identity of identities) {
+			reservedIdentities.add(identity);
+			let reservationsForIdentity =
+				this.pendingSyncAdmissionReservationsByIdentity.get(identity);
+			if (!reservationsForIdentity) {
+				reservationsForIdentity = new Set();
+				this.pendingSyncAdmissionReservationsByIdentity.set(
+					identity,
+					reservationsForIdentity,
+				);
+			}
+			reservationsForIdentity.add(reservation);
+		}
+		const expiryNode: PendingSyncExpiryNode = {
+			kind: "admission",
+			reservation,
+			expiresAt: reservation.expiresAt,
+			heapIndex: -1,
+		};
+		this.pendingSyncAdmissionExpiryNodes.set(reservation, expiryNode);
+		this.pushPendingSyncExpiry(expiryNode);
+		this.schedulePendingSyncKeyExpiry();
+		return reservation;
+	}
+
+	private removePendingSyncAdmissionIdentity(
+		reservation: PendingSyncAdmissionReservation,
+		identity: SyncableKey,
+		options?: { retainQuota?: boolean },
+	): boolean {
+		if (!reservation.identities.delete(identity)) {
+			return false;
+		}
+		if (options?.retainQuota === true) {
+			reservation.retainedSettled += 1;
+		} else {
+			reservation.remaining -= 1;
+			this.pendingSyncAdmissionCount -= 1;
+			const peerCount =
+				(this.pendingSyncAdmissionCountByPeer.get(reservation.peer) ?? 0) - 1;
+			if (peerCount === 0) {
+				this.pendingSyncAdmissionCountByPeer.delete(reservation.peer);
+			} else {
+				this.pendingSyncAdmissionCountByPeer.set(reservation.peer, peerCount);
+			}
+		}
+		const reservedIdentities = this.pendingSyncAdmissionIdentitiesByPeer.get(
+			reservation.peer,
+		);
+		reservedIdentities?.delete(identity);
+		if (reservedIdentities?.size === 0) {
+			this.pendingSyncAdmissionIdentitiesByPeer.delete(reservation.peer);
+		}
+		const reservationsForIdentity =
+			this.pendingSyncAdmissionReservationsByIdentity.get(identity);
+		reservationsForIdentity?.delete(reservation);
+		if (reservationsForIdentity?.size === 0) {
+			this.pendingSyncAdmissionReservationsByIdentity.delete(identity);
+		}
+		return true;
+	}
+
+	private clearPendingSyncAdmissionIdentity(identity: SyncableKey): void {
+		const reservations =
+			this.pendingSyncAdmissionReservationsByIdentity.get(identity);
+		if (!reservations) {
+			return;
+		}
+		for (const reservation of [...reservations]) {
+			this.removePendingSyncAdmissionIdentity(reservation, identity, {
+				retainQuota: true,
+			});
+		}
+	}
+
+	private consumePendingSyncAdmission(
+		reservation: PendingSyncAdmissionReservation,
+		identity: SyncableKey,
+	): "consumed" | "settled" | "invalid" {
+		if (!reservation.active || reservation.expiresAt <= Date.now()) {
+			if (reservation.expiresAt <= Date.now()) {
+				this.invalidatePendingSyncAdmission(reservation);
+			}
+			return "invalid";
+		}
+		if (!reservation.identities.has(identity)) {
+			return "settled";
+		}
+		this.removePendingSyncAdmissionIdentity(reservation, identity);
+		if (reservation.remaining === 0) {
+			this.removePendingSyncAdmissionExpiry(reservation);
+			reservation.active = false;
+			reservation.released = true;
+			this.pendingSyncActiveAdmissionReservations -= 1;
+			this.pendingSyncAdmissionReservations.delete(reservation);
+			const peerReservations = this.pendingSyncAdmissionReservationsByPeer.get(
+				reservation.peer,
+			);
+			peerReservations?.delete(reservation);
+			if (peerReservations?.size === 0) {
+				this.pendingSyncAdmissionReservationsByPeer.delete(reservation.peer);
+			}
+			this.clearPendingSyncExpiryTimerIfIdle();
+		}
+		return "consumed";
+	}
+
+	private transferPendingSyncAdmissionIdentity(
+		peer: string,
+		identity: SyncableKey,
+	): number | undefined {
+		const reservations =
+			this.pendingSyncAdmissionReservationsByIdentity.get(identity);
+		if (!reservations) {
+			return undefined;
+		}
+		for (const reservation of reservations) {
+			if (
+				reservation.peer !== peer ||
+				reservation.released ||
+				reservation.expiresAt <= Date.now() ||
+				!this.removePendingSyncAdmissionIdentity(reservation, identity, {
+					retainQuota: true,
+				})
+			) {
+				continue;
+			}
+			// The original resolver may be non-abortable and still retains its input
+			// arrays. Keep that reservation charged until its queueSync finally
+			// settles; the queued claim is counted separately and can disappear
+			// without returning the resolver's quota early.
+			return reservation.expiresAt;
+		}
+		return undefined;
+	}
+
+	private invalidatePendingSyncAdmission(
+		reservation?: PendingSyncAdmissionReservation,
+	): void {
+		if (!reservation || reservation.released || !reservation.active) {
+			return;
+		}
+		// Expiry/disconnect invalidates late lookup results, but it must not return
+		// the quota slot while the underlying storage/index work is still alive.
+		// Those lookups are not generally abortable; only queueSync's finally block
+		// may release their active-work accounting.
+		this.removePendingSyncAdmissionExpiry(reservation);
+		reservation.active = false;
+		this.pendingSyncActiveAdmissionReservations -= 1;
+		this.clearPendingSyncExpiryTimerIfIdle();
+	}
+
+	private releasePendingSyncAdmission(
+		reservation?: PendingSyncAdmissionReservation,
+	): void {
+		if (!reservation || reservation.released) {
+			return;
+		}
+		this.removePendingSyncAdmissionExpiry(reservation);
+		for (const identity of [...reservation.identities]) {
+			this.removePendingSyncAdmissionIdentity(reservation, identity);
+		}
+		if (reservation.retainedSettled > 0) {
+			const retainedSettled = reservation.retainedSettled;
+			reservation.retainedSettled = 0;
+			reservation.remaining -= retainedSettled;
+			this.pendingSyncAdmissionCount -= retainedSettled;
+			const peerCount =
+				(this.pendingSyncAdmissionCountByPeer.get(reservation.peer) ?? 0) -
+				retainedSettled;
+			if (peerCount === 0) {
+				this.pendingSyncAdmissionCountByPeer.delete(reservation.peer);
+			} else {
+				this.pendingSyncAdmissionCountByPeer.set(reservation.peer, peerCount);
+			}
+		}
+		if (reservation.active) {
+			this.pendingSyncActiveAdmissionReservations -= 1;
+		}
+		reservation.active = false;
+		reservation.released = true;
+		this.pendingSyncAdmissionReservations.delete(reservation);
+		const peerReservations = this.pendingSyncAdmissionReservationsByPeer.get(
+			reservation.peer,
+		);
+		peerReservations?.delete(reservation);
+		if (peerReservations?.size === 0) {
+			this.pendingSyncAdmissionReservationsByPeer.delete(reservation.peer);
+		}
+		this.clearPendingSyncExpiryTimerIfIdle();
+	}
+
+	private clearPendingSyncAdmissions(peer?: string): void {
+		const reservations =
+			peer == null
+				? this.pendingSyncAdmissionReservations
+				: this.pendingSyncAdmissionReservationsByPeer.get(peer);
+		if (!reservations) {
+			return;
+		}
+		for (const reservation of [...reservations]) {
+			this.invalidatePendingSyncAdmission(reservation);
+		}
+	}
+
+	private swapPendingSyncExpiry(left: number, right: number): void {
+		const leftNode = this.pendingSyncExpiryHeap[left]!;
+		const rightNode = this.pendingSyncExpiryHeap[right]!;
+		this.pendingSyncExpiryHeap[left] = rightNode;
+		this.pendingSyncExpiryHeap[right] = leftNode;
+		rightNode.heapIndex = left;
+		leftNode.heapIndex = right;
+	}
+
+	private pushPendingSyncExpiry(node: PendingSyncExpiryNode): void {
+		node.heapIndex = this.pendingSyncExpiryHeap.length;
+		this.pendingSyncExpiryHeap.push(node);
+		let index = node.heapIndex;
+		while (index > 0) {
+			const parent = Math.floor((index - 1) / 2);
+			if (
+				this.pendingSyncExpiryHeap[parent]!.expiresAt <=
+				this.pendingSyncExpiryHeap[index]!.expiresAt
+			) {
+				break;
+			}
+			this.swapPendingSyncExpiry(parent, index);
+			index = parent;
+		}
+	}
+
+	private removePendingSyncExpiry(node: PendingSyncExpiryNode): void {
+		const index = node.heapIndex;
+		if (
+			index < 0 ||
+			index >= this.pendingSyncExpiryHeap.length ||
+			this.pendingSyncExpiryHeap[index] !== node
+		) {
+			return;
+		}
+		const last = this.pendingSyncExpiryHeap.pop()!;
+		node.heapIndex = -1;
+		if (index >= this.pendingSyncExpiryHeap.length) {
+			return;
+		}
+		this.pendingSyncExpiryHeap[index] = last;
+		last.heapIndex = index;
+
+		let current = index;
+		while (current > 0) {
+			const parent = Math.floor((current - 1) / 2);
+			if (
+				this.pendingSyncExpiryHeap[parent]!.expiresAt <=
+				this.pendingSyncExpiryHeap[current]!.expiresAt
+			) {
+				break;
+			}
+			this.swapPendingSyncExpiry(parent, current);
+			current = parent;
+		}
+		for (;;) {
+			const left = current * 2 + 1;
+			const right = left + 1;
+			let smallest = current;
+			if (
+				left < this.pendingSyncExpiryHeap.length &&
+				this.pendingSyncExpiryHeap[left]!.expiresAt <
+					this.pendingSyncExpiryHeap[smallest]!.expiresAt
+			) {
+				smallest = left;
+			}
+			if (
+				right < this.pendingSyncExpiryHeap.length &&
+				this.pendingSyncExpiryHeap[right]!.expiresAt <
+					this.pendingSyncExpiryHeap[smallest]!.expiresAt
+			) {
+				smallest = right;
+			}
+			if (smallest === current) {
+				break;
+			}
+			this.swapPendingSyncExpiry(current, smallest);
+			current = smallest;
+		}
+	}
+
+	private removePendingSyncKeyExpiry(key: SyncableKey): void {
+		const node = this.pendingSyncKeyExpiryNodes.get(key);
+		if (!node) {
+			return;
+		}
+		this.pendingSyncKeyExpiryNodes.delete(key);
+		this.removePendingSyncExpiry(node);
+	}
+
+	private movePendingSyncKeyExpiryEarlier(
+		key: SyncableKey,
+		expiresAt: number,
+	): void {
+		const current = this.syncInFlightQueueExpiresAt.get(key);
+		if (current == null || current <= expiresAt) {
+			return;
+		}
+		this.removePendingSyncKeyExpiry(key);
+		this.syncInFlightQueueExpiresAt.set(key, expiresAt);
+		const node: PendingSyncExpiryNode = {
+			kind: "key",
+			key,
+			expiresAt,
+			heapIndex: -1,
+		};
+		this.pendingSyncKeyExpiryNodes.set(key, node);
+		this.pushPendingSyncExpiry(node);
+		this.schedulePendingSyncKeyExpiry();
+	}
+
+	private removePendingSyncAdmissionExpiry(
+		reservation: PendingSyncAdmissionReservation,
+	): void {
+		const node = this.pendingSyncAdmissionExpiryNodes.get(reservation);
+		if (!node) {
+			return;
+		}
+		this.pendingSyncAdmissionExpiryNodes.delete(reservation);
+		this.removePendingSyncExpiry(node);
+	}
+
+	private expirePendingSyncKeys(now = Date.now()): void {
+		for (;;) {
+			const node = this.pendingSyncExpiryHeap[0];
+			if (!node || node.expiresAt > now) {
+				break;
+			}
+			this.removePendingSyncExpiry(node);
+			if (node.kind === "key") {
+				if (this.pendingSyncKeyExpiryNodes.get(node.key) !== node) {
+					continue;
+				}
+				this.pendingSyncKeyExpiryNodes.delete(node.key);
+				this.clearSyncProcessKey(node.key);
+			} else {
+				if (
+					this.pendingSyncAdmissionExpiryNodes.get(node.reservation) !== node
+				) {
+					continue;
+				}
+				this.pendingSyncAdmissionExpiryNodes.delete(node.reservation);
+				this.invalidatePendingSyncAdmission(node.reservation);
+			}
+		}
+	}
+
+	private clearPendingSyncExpiryTimerIfIdle(): void {
+		if (
+			this.pendingSyncExpiryHeap.length === 0 &&
+			this.syncInFlightQueueExpiryTimer != null
+		) {
+			clearTimeout(this.syncInFlightQueueExpiryTimer);
+			this.syncInFlightQueueExpiryTimer = undefined;
+		}
+	}
+
+	private schedulePendingSyncKeyExpiry(): void {
+		if (
+			this.syncInFlightQueueExpiryTimer != null ||
+			this.pendingSyncExpiryHeap.length === 0
+		) {
+			return;
+		}
+		const expiresAt = this.pendingSyncExpiryHeap[0]!.expiresAt;
+		this.syncInFlightQueueExpiryTimer = setTimeout(
+			() => {
+				this.syncInFlightQueueExpiryTimer = undefined;
+				this.expirePendingSyncKeys();
+				this.schedulePendingSyncKeyExpiry();
+			},
+			Math.max(0, expiresAt - Date.now()),
+		);
+		this.syncInFlightQueueExpiryTimer.unref?.();
+	}
+
 	async queueSync(
 		keys: SyncableKey[],
 		from: PublicSignKey,
 		options?: { skipCheck?: boolean },
 	) {
+		if (this.closed === true || keys.length === 0) {
+			return;
+		}
+		// A delayed timer must not let expired claims or admission reservations
+		// keep the exact per-peer/global quota closed to fresh work.
+		this.expirePendingSyncKeys();
+		this.clearPendingSyncExpiryTimerIfIdle();
 		const fromHash = from.hashcode();
+		const canStartLookup =
+			options?.skipCheck === true || this.canStartPendingSyncLookup(fromHash);
+		const peerClaimCount =
+			this.syncInFlightQueueInverted.get(fromHash)?.size ?? 0;
+		let availableClaims = Math.max(
+			0,
+			Math.min(
+				MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER -
+					peerClaimCount -
+					(this.pendingSyncAdmissionCountByPeer.get(fromHash) ?? 0),
+				MAX_PENDING_SIMPLE_SYNC_KEYS_GLOBAL -
+					this.pendingSyncClaimCount -
+					this.pendingSyncAdmissionCount,
+			),
+		);
 		const targetEpoch = this.getOrCreateSyncDispatchTargetEpoch(fromHash);
 		const ownershipLifecycleController = this.syncDispatchLifecycleController;
 		const isCapturedLifecycleActive = () =>
@@ -1844,69 +3660,177 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			!ownershipLifecycleController.signal.aborted &&
 			this.syncDispatchTargetEpochs.get(fromHash) === targetEpoch;
 		const requestHashes: SyncableKey[] = [];
+		const existingRequestHashes: SyncableKey[] = [];
 		const profile = this.syncOptions?.profile;
 		const startedAt = syncProfileStart(profile);
-		const resolveKnownStartedAt = syncProfileStart(profile);
-		const knownKeys =
-			options?.skipCheck === true
-				? undefined
-				: await this.resolveKnownSyncKeys(keys);
 		if (!isCapturedLifecycleActive()) {
 			return;
 		}
-		if (profile) {
-			emitSyncProfileDuration(profile, resolveKnownStartedAt, {
-				name: "simple.queueSync.resolveKnown",
-				entries: keys.length,
-				count: knownKeys?.keys.size ?? 0,
-				details: {
-					checkedCoordinates: knownKeys?.checkedCoordinates === true,
-					checkedHashes: knownKeys?.checkedHashes === true,
-					skipCheck: options?.skipCheck === true,
-				},
-			});
+		if (availableClaims === 0) {
+			return;
 		}
-		let queuedHashAliases: Map<string, SyncableKey> | undefined;
-		const getQueuedSyncKeyForBatch = (key: SyncableKey) => {
-			if (this.syncInFlightQueue.has(key)) {
-				return key;
+		this.refreshQueuedSyncCoordinateAliases();
+		const keysToCheck: SyncableKey[] = [];
+		const identitiesToCheck: SyncableKey[] = [];
+		const seen = new Set<SyncableKey>();
+		const pendingAdmissionIdentities =
+			this.pendingSyncAdmissionIdentitiesByPeer.get(fromHash);
+		// Default senders use 1,024-key messages. Capping examined input at the
+		// entire per-peer allowance prevents a duplicate-filled oversized vector
+		// from turning admission itself into unbounded work.
+		const inspectionLimit = canStartLookup
+			? MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER
+			: Math.min(DEFAULT_MAX_HASHES_PER_MESSAGE, keys.length);
+		for (
+			let index = 0;
+			index < keys.length && index < inspectionLimit;
+			index += 1
+		) {
+			const key = keys[index]!;
+			const queuedKeyResult = this.getQueuedSyncKeyForAdmission(key);
+			if (queuedKeyResult === QUEUED_SYNC_ALIAS_REFRESH_PENDING) {
+				continue;
 			}
-			if (typeof key === "string") {
-				if (!queuedHashAliases) {
-					queuedHashAliases = new Map();
-					for (const queuedKey of this.syncInFlightQueue.keys()) {
-						if (typeof queuedKey !== "bigint") {
-							continue;
-						}
-						const hash = this.coordinateToHash.get(queuedKey);
-						if (hash) {
-							queuedHashAliases.set(hash, queuedKey);
-						}
+			const queuedKey = queuedKeyResult;
+			const coordinateOrHash = queuedKey ?? key;
+			const identity = this.getPendingSyncKeyIdentity(coordinateOrHash);
+			if (seen.has(identity)) {
+				continue;
+			}
+			seen.add(identity);
+
+			if (queuedKey != null) {
+				let transferredDeadline: number | undefined;
+				if (
+					availableClaims > 0 &&
+					pendingAdmissionIdentities?.has(identity) &&
+					!this.hasPendingSyncClaim(queuedKey, fromHash)
+				) {
+					transferredDeadline = this.transferPendingSyncAdmissionIdentity(
+						fromHash,
+						identity,
+					);
+					if (transferredDeadline != null) {
+						this.movePendingSyncKeyExpiryEarlier(
+							queuedKey,
+							transferredDeadline,
+						);
 					}
 				}
-				return queuedHashAliases.get(key);
+				if (availableClaims === 0) {
+					continue;
+				}
+				if (this.addPendingSyncClaim(queuedKey, from)) {
+					availableClaims -= 1;
+					existingRequestHashes.push(queuedKey);
+				}
+				continue;
 			}
-			const hash = this.coordinateToHash.get(key);
-			return hash && this.syncInFlightQueue.has(hash) ? hash : undefined;
-		};
 
+			if (
+				pendingAdmissionIdentities?.has(identity) ||
+				!canStartLookup ||
+				availableClaims === 0
+			) {
+				continue;
+			}
+			keysToCheck.push(key);
+			identitiesToCheck.push(identity);
+			availableClaims -= 1;
+		}
+		const admission = this.reservePendingSyncAdmission(
+			fromHash,
+			identitiesToCheck,
+		);
+		const dispatchableExistingRequestHashes =
+			this.filterDispatchablePendingSyncClaims(
+				existingRequestHashes,
+				fromHash,
+				targetEpoch,
+			);
+		const existingRequest =
+			dispatchableExistingRequestHashes.length > 0
+				? this.requestSync(dispatchableExistingRequestHashes, [fromHash], {
+						ownershipLifecycleController,
+						targetEpochs: new Map([[fromHash, targetEpoch]]),
+						createTargetEpochs: false,
+					})
+				: undefined;
+		// Existing queued claims must not wait behind a potentially blocked storage
+		// lookup for unrelated new keys. Observe this eagerly-started request even
+		// when a later lifecycle check returns before joining it.
+		void existingRequest?.catch(() => {});
+		const resolveKnownStartedAt = syncProfileStart(profile);
 		try {
+			const knownKeys =
+				options?.skipCheck === true || keysToCheck.length === 0
+					? undefined
+					: await this.resolveKnownSyncKeys(keysToCheck);
+			if (!isCapturedLifecycleActive()) {
+				return;
+			}
+			if (profile) {
+				emitSyncProfileDuration(profile, resolveKnownStartedAt, {
+					name: "simple.queueSync.resolveKnown",
+					entries: keysToCheck.length,
+					count: knownKeys?.keys.size ?? 0,
+					details: {
+						checkedCoordinates: knownKeys?.checkedCoordinates === true,
+						checkedHashes: knownKeys?.checkedHashes === true,
+						skipCheck: options?.skipCheck === true,
+					},
+				});
+			}
+
+			if (keysToCheck.length > 0) {
+				// A resolver/index lookup may have populated coordinateToHash while
+				// it yielded. Refresh another fixed-size slice, never the full queue.
+				this.refreshQueuedSyncCoordinateAliases();
+			}
 			const loopStartedAt = syncProfileStart(profile);
-			for (const key of keys) {
+			for (let index = 0; index < keysToCheck.length; index += 1) {
+				const key = keysToCheck[index]!;
+				const identity = identitiesToCheck[index]!;
 				if (!isCapturedLifecycleActive()) {
 					return;
 				}
-				const coordinateOrHash = getQueuedSyncKeyForBatch(key) ?? key;
+				const queuedKeyResult = this.getQueuedSyncKeyForAdmission(key);
+				if (queuedKeyResult === QUEUED_SYNC_ALIAS_REFRESH_PENDING) {
+					const consumption = this.consumePendingSyncAdmission(
+						admission!,
+						identity,
+					);
+					if (consumption === "invalid") {
+						return;
+					}
+					continue;
+				}
+				const coordinateOrHash = queuedKeyResult ?? key;
 				const inFlight = this.syncInFlightQueue.get(coordinateOrHash);
 				if (inFlight) {
-					if (!inFlight.find((x) => x.hashcode() === fromHash)) {
-						inFlight.push(from);
-						let inverted = this.syncInFlightQueueInverted.get(fromHash);
-						if (!inverted) {
-							inverted = new Set();
-							this.syncInFlightQueueInverted.set(fromHash, inverted);
+					if (!this.hasPendingSyncClaim(coordinateOrHash, fromHash)) {
+						const consumption = this.consumePendingSyncAdmission(
+							admission!,
+							identity,
+						);
+						if (consumption === "invalid") {
+							return;
 						}
-						inverted.add(coordinateOrHash);
+						if (consumption === "settled") {
+							continue;
+						}
+						this.movePendingSyncKeyExpiryEarlier(
+							coordinateOrHash,
+							admission!.expiresAt,
+						);
+						const added = this.addPendingSyncClaim(
+							coordinateOrHash,
+							from,
+							admission!.expiresAt,
+						);
+						if (added) {
+							requestHashes.push(coordinateOrHash);
+						}
 					}
 				} else {
 					const has =
@@ -1916,50 +3840,62 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 						return;
 					}
 					if (has) {
+						this.clearPendingSyncAdmissionIdentity(identity);
+						continue;
+					}
+					const consumption = this.consumePendingSyncAdmission(
+						admission!,
+						identity,
+					);
+					if (consumption === "invalid") {
+						return;
+					}
+					if (consumption === "settled") {
 						continue;
 					}
 					// Track the initial sender so we can retry if the first request is lost.
-					this.syncInFlightQueue.set(coordinateOrHash, [from]);
-					let inverted = this.syncInFlightQueueInverted.get(fromHash);
-					if (!inverted) {
-						inverted = new Set();
-						this.syncInFlightQueueInverted.set(fromHash, inverted);
-					}
-					inverted.add(coordinateOrHash);
+					this.addPendingSyncClaim(
+						coordinateOrHash,
+						from,
+						admission!.expiresAt,
+					);
 					requestHashes.push(coordinateOrHash); // request immediately (first time we have seen this hash)
-					if (
-						queuedHashAliases &&
-						typeof coordinateOrHash === "bigint"
-					) {
-						const hash = this.coordinateToHash.get(coordinateOrHash);
-						if (hash) {
-							queuedHashAliases.set(hash, coordinateOrHash);
-						}
-					}
 				}
 			}
 			if (profile) {
 				emitSyncProfileDuration(profile, loopStartedAt, {
 					name: "simple.queueSync.plan",
-					entries: keys.length,
+					entries: keysToCheck.length,
 					count: requestHashes.length,
 					targets: 1,
 				});
 			}
 
-			requestHashes.length > 0 &&
-				(await this.requestSync(requestHashes, [fromHash], {
+			// Persistent admission work is complete. Do not let an unrelated
+			// blocked transport send retain unused quota.
+			this.releasePendingSyncAdmission(admission);
+			const dispatchableRequestHashes =
+				this.filterDispatchablePendingSyncClaims(
+					requestHashes,
+					fromHash,
+					targetEpoch,
+				);
+			dispatchableRequestHashes.length > 0 &&
+				(await this.requestSync(dispatchableRequestHashes, [fromHash], {
 					ownershipLifecycleController,
 					targetEpochs: new Map([[fromHash, targetEpoch]]),
 					createTargetEpochs: false,
 				}));
+			await existingRequest;
 		} finally {
+			this.releasePendingSyncAdmission(admission);
 			if (profile) {
 				emitSyncProfileDuration(profile, startedAt, {
 					name: "simple.queueSync",
 					entries: keys.length,
 					targets: 1,
 					details: {
+						admitted: keysToCheck.length,
 						requested: requestHashes.length,
 						skipCheck: options?.skipCheck === true,
 					},
@@ -1999,13 +3935,8 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				if (!this.isSyncDispatchLifecycleActive(lifecycle, node)) {
 					continue;
 				}
-				let map = this.syncInFlight.get(node);
-				if (!map) {
-					map = new Map();
-					this.syncInFlight.set(node, map);
-				}
 				for (const hash of hashes) {
-					map.set(hash, { timestamp: now });
+					this.setSyncInFlightTargetKey(node, hash, now);
 				}
 			}
 
@@ -2154,6 +4085,12 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		key: string | bigint,
 		knownKeys?: KnownSyncKeys,
 	) {
+		if (typeof key === "bigint") {
+			const mappedHash = this.coordinateToHash.get(key);
+			if (mappedHash != null && (await this.log.has(mappedHash))) {
+				return true;
+			}
+		}
 		if (knownKeys) {
 			if (knownKeys.keys.has(key)) {
 				return true;
@@ -2174,6 +4111,8 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		this.clearPendingMaybeSyncResponses();
 		this.syncDispatchTargetEpochs.clear();
 		this.syncDispatchLifecycleController = new AbortController();
+		this.syncInFlightRetryIterator = undefined;
+		this.syncInFlightRetryRemaining = 0;
 		const openLifecycleController = this.syncDispatchLifecycleController;
 		this.closed = false;
 		const isOpenLifecycleActive = () =>
@@ -2205,12 +4144,36 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				return;
 			}
 			try {
-				const requestHashes: SyncableKey[] = [];
-				const from: Set<string> = new Set();
+				const requestHashesByEpoch = new Map<
+					SyncDispatchTargetEpoch,
+					{ target: string; hashes: SyncableKey[] }
+				>();
 				const now = Date.now();
-				for (const [key] of this.syncInFlightQueue) {
+				if (!this.syncInFlightRetryIterator) {
+					this.syncInFlightRetryIterator = this.syncInFlightQueue.entries();
+					this.syncInFlightRetryRemaining = this.syncInFlightQueue.size;
+				}
+				for (
+					let inspected = 0;
+					inspected < MAX_SIMPLE_SYNC_RETRY_KEYS_PER_TICK &&
+					this.syncInFlightRetryRemaining > 0;
+					inspected += 1
+				) {
+					const next = this.syncInFlightRetryIterator.next();
+					if (next.done) {
+						this.syncInFlightRetryIterator = undefined;
+						this.syncInFlightRetryRemaining = 0;
+						break;
+					}
+					this.syncInFlightRetryRemaining -= 1;
+					const [key] = next.value;
 					if (!isOpenLifecycleActive()) {
 						return;
+					}
+					const expiresAt = this.syncInFlightQueueExpiresAt.get(key);
+					if (expiresAt != null && expiresAt <= Date.now()) {
+						this.clearSyncProcessKey(key);
+						continue;
 					}
 
 					const has = await this.checkHasCoordinateOrHash(key);
@@ -2221,6 +4184,11 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 					if (!value) {
 						continue;
 					}
+					const currentExpiresAt = this.syncInFlightQueueExpiresAt.get(key);
+					if (currentExpiresAt != null && currentExpiresAt <= Date.now()) {
+						this.clearSyncProcessKey(key);
+						continue;
+					}
 
 					if (!has) {
 						if (value.length === 0) {
@@ -2228,7 +4196,10 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 							continue;
 						}
 
-						const candidate = value[0]!;
+						const cursor =
+							(this.syncInFlightQueueRoundRobinCursor.get(key) ?? 0) %
+							value.length;
+						const candidate = value[cursor]!;
 						const publicKeyHash = candidate.hashcode();
 						const inflightTimestamp = this.syncInFlight
 							.get(publicKeyHash)
@@ -2237,46 +4208,71 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 							inflightTimestamp == null ||
 							now - inflightTimestamp >= SIMPLE_SYNC_RETRY_AFTER_MS
 						) {
-							requestHashes.push(key);
-							from.add(publicKeyHash);
+							const epoch = this.syncDispatchTargetEpochs.get(publicKeyHash);
+							if (!epoch) {
+								continue;
+							}
+							let request = requestHashesByEpoch.get(epoch);
+							if (!request) {
+								request = { target: publicKeyHash, hashes: [] };
+								requestHashesByEpoch.set(epoch, request);
+							}
+							request.hashes.push(key);
 							if (value.length > 1) {
-								value.push(value.shift()!);
+								this.syncInFlightQueueRoundRobinCursor.set(
+									key,
+									(cursor + 1) % value.length,
+								);
 							}
 						}
 					} else {
 						this.clearSyncProcessKey(key);
 					}
 				}
+				if (this.syncInFlightRetryRemaining === 0) {
+					this.syncInFlightRetryIterator = undefined;
+				}
 
 				if (!isOpenLifecycleActive()) {
 					return;
 				}
 				const nowMin10s = +new Date() - 2e4;
-				for (const [key, map] of this.syncInFlight) {
-					for (const [hash, { timestamp }] of map) {
+				for (const [target, map] of this.syncInFlight) {
+					for (const [key, { timestamp }] of map) {
 						if (timestamp < nowMin10s) {
-							map.delete(hash);
+							this.removeSyncInFlightTargetKey(target, key);
 						}
-					}
-					if (map.size === 0) {
-						this.syncInFlight.delete(key);
 					}
 				}
 				if (!isOpenLifecycleActive()) {
 					return;
 				}
-				const targetEpochs = new Map<string, SyncDispatchTargetEpoch>();
-				for (const target of from) {
-					const epoch = this.syncDispatchTargetEpochs.get(target);
-					if (epoch) {
-						targetEpochs.set(target, epoch);
+				for (const [epoch, request] of requestHashesByEpoch) {
+					if (!isOpenLifecycleActive()) {
+						return;
+					}
+					const requestHashes = this.filterDispatchablePendingSyncClaims(
+						request.hashes,
+						request.target,
+						epoch,
+					);
+					if (requestHashes.length === 0) {
+						continue;
+					}
+					try {
+						await this.requestSync(requestHashes, [request.target], {
+							ownershipLifecycleController: openLifecycleController,
+							targetEpochs: new Map([[request.target, epoch]]),
+							createTargetEpochs: false,
+						});
+					} catch {
+						if (!isOpenLifecycleActive()) {
+							return;
+						}
+						// A failed target must not prevent bounded retries for unrelated
+						// peers in this pass.
 					}
 				}
-				await this.requestSync(requestHashes, from, {
-					ownershipLifecycleController: openLifecycleController,
-					targetEpochs,
-					createTargetEpochs: false,
-				});
 				if (!isOpenLifecycleActive()) {
 					return;
 				}
@@ -2298,9 +4294,29 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		this.closed = true;
 		this.syncDispatchLifecycleController.abort();
 		this.syncDispatchTargetEpochs.clear();
+		this.clearPendingSyncAdmissions();
 		this.syncInFlightQueue.clear();
 		this.syncInFlightQueueInverted.clear();
+		this.syncInFlightRetryIterator = undefined;
+		this.syncInFlightRetryRemaining = 0;
+		this.syncInFlightQueueExpiresAt.clear();
+		this.pendingSyncExpiryHeap.length = 0;
+		this.pendingSyncKeyExpiryNodes.clear();
+		this.pendingSyncAdmissionExpiryNodes.clear();
+		this.syncInFlightQueueClaimants.clear();
+		this.syncInFlightQueueClaimantIndexes.clear();
+		this.syncInFlightQueueRoundRobinCursor.clear();
+		this.syncInFlightQueuedCoordinates.clear();
+		this.syncInFlightQueuedHashByCoordinate.clear();
+		this.syncInFlightQueuedCoordinatesByHash.clear();
+		this.syncInFlightQueuedCoordinateRefreshIterator = undefined;
+		this.pendingSyncClaimCount = 0;
+		if (this.syncInFlightQueueExpiryTimer != null) {
+			clearTimeout(this.syncInFlightQueueExpiryTimer);
+			this.syncInFlightQueueExpiryTimer = undefined;
+		}
 		this.syncInFlight.clear();
+		this.syncInFlightTargetsByKey.clear();
 		this.recentlySentExchangeHeads.clear();
 		this.clearPendingMaybeSyncResponses();
 		for (const sessionId of [...this.repairSessions.keys()]) {
@@ -2316,6 +4332,9 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		if (hashes.length === 0 || !this.hasEntryAddedState()) {
 			return;
 		}
+		for (const hash of hashes) {
+			this.clearPendingSyncAdmissionIdentity(hash);
+		}
 		this.clearSyncProcesses(hashes);
 		this.markRepairSessionResolvedHashes(hashes);
 	}
@@ -2324,6 +4343,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		if (!this.hasEntryAddedState()) {
 			return;
 		}
+		this.clearPendingSyncAdmissionIdentity(hash);
 		this.clearSyncProcess(hash);
 		this.markRepairSessionResolvedHash(hash);
 	}
@@ -2350,6 +4370,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		return (
 			this.syncInFlightQueue.size > 0 ||
 			this.syncInFlightQueueInverted.size > 0 ||
+			this.pendingSyncAdmissionCount > 0 ||
 			this.syncInFlight.size > 0
 		);
 	}
@@ -2367,18 +4388,159 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				}
 			}
 
+			const trackedClaimants = this.syncInFlightQueueClaimants.get(key);
+			this.pendingSyncClaimCount = Math.max(
+				0,
+				this.pendingSyncClaimCount -
+					(trackedClaimants?.size ?? inflight.length),
+			);
 			this.syncInFlightQueue.delete(key);
 		}
+		this.syncInFlightQueueClaimants.delete(key);
+		this.syncInFlightQueueClaimantIndexes.delete(key);
+		this.syncInFlightQueueRoundRobinCursor.delete(key);
+		if (typeof key === "bigint") {
+			this.removeQueuedSyncCoordinateAlias(key);
+		}
+		this.removePendingSyncKeyExpiry(key);
+		this.syncInFlightQueueExpiresAt.delete(key);
+		this.clearPendingSyncExpiryTimerIfIdle();
 
 		this.clearSyncInFlightKey(key);
 	}
 
-	private clearSyncInFlightKey(key: SyncableKey) {
-		for (const [peer, map] of this.syncInFlight) {
-			map.delete(key);
-			if (map.size === 0) {
-				this.syncInFlight.delete(peer);
+	private removePendingSyncClaim(key: SyncableKey, peer: string): void {
+		const inflight = this.syncInFlightQueue.get(key);
+		if (!inflight) {
+			return;
+		}
+		let claimants = this.syncInFlightQueueClaimants.get(key);
+		let claimantIndexes = this.syncInFlightQueueClaimantIndexes.get(key);
+		if (!claimants || !claimantIndexes) {
+			claimants = new Set();
+			claimantIndexes = new Map();
+			for (let index = 0; index < inflight.length; index += 1) {
+				const claimant = inflight[index]!.hashcode();
+				claimants.add(claimant);
+				claimantIndexes.set(claimant, index);
 			}
+			if (!this.syncInFlightQueueClaimants.has(key)) {
+				this.pendingSyncClaimCount += claimants.size;
+			}
+			this.syncInFlightQueueClaimants.set(key, claimants);
+			this.syncInFlightQueueClaimantIndexes.set(key, claimantIndexes);
+		}
+		const index = claimantIndexes.get(peer);
+		if (index == null) {
+			return;
+		}
+
+		const lastIndex = inflight.length - 1;
+		if (index !== lastIndex) {
+			const lastClaimant = inflight[lastIndex]!;
+			const lastClaimantHash = lastClaimant.hashcode();
+			inflight[index] = lastClaimant;
+			claimantIndexes.set(lastClaimantHash, index);
+		}
+		inflight.pop();
+		claimantIndexes.delete(peer);
+		claimants.delete(peer);
+		this.pendingSyncClaimCount = Math.max(0, this.pendingSyncClaimCount - 1);
+		const inverted = this.syncInFlightQueueInverted.get(peer);
+		inverted?.delete(key);
+		if (inverted?.size === 0) {
+			this.syncInFlightQueueInverted.delete(peer);
+		}
+		if (inflight.length > 0) {
+			const cursor = this.syncInFlightQueueRoundRobinCursor.get(key) ?? 0;
+			this.syncInFlightQueueRoundRobinCursor.set(
+				key,
+				cursor === lastIndex
+					? index % inflight.length
+					: cursor % inflight.length,
+			);
+			return;
+		}
+
+		this.syncInFlightQueue.delete(key);
+		this.syncInFlightQueueClaimants.delete(key);
+		this.syncInFlightQueueClaimantIndexes.delete(key);
+		this.syncInFlightQueueRoundRobinCursor.delete(key);
+		if (typeof key === "bigint") {
+			this.removeQueuedSyncCoordinateAlias(key);
+		}
+		this.removePendingSyncKeyExpiry(key);
+		this.syncInFlightQueueExpiresAt.delete(key);
+		this.clearSyncInFlightKey(key);
+		this.clearPendingSyncExpiryTimerIfIdle();
+	}
+
+	private removeSyncInFlightTargetKey(peer: string, key: SyncableKey): void {
+		const map = this.syncInFlight.get(peer);
+		if (!map?.delete(key)) {
+			return;
+		}
+		if (map.size === 0) {
+			this.syncInFlight.delete(peer);
+		}
+		const targets = this.syncInFlightTargetsByKey.get(key);
+		targets?.delete(peer);
+		if (targets?.size === 0) {
+			this.syncInFlightTargetsByKey.delete(key);
+		}
+	}
+
+	private setSyncInFlightTargetKey(
+		peer: string,
+		key: SyncableKey,
+		timestamp: number,
+	): void {
+		let map = this.syncInFlight.get(peer);
+		if (!map) {
+			map = new Map();
+			this.syncInFlight.set(peer, map);
+		}
+		const existing = map.get(key);
+		if (!existing || existing.timestamp < timestamp) {
+			map.set(key, { timestamp });
+		}
+		let targets = this.syncInFlightTargetsByKey.get(key);
+		if (!targets) {
+			targets = new Set();
+			this.syncInFlightTargetsByKey.set(key, targets);
+		}
+		targets.add(peer);
+	}
+
+	private clearSyncInFlightTarget(peer: string): void {
+		const map = this.syncInFlight.get(peer);
+		if (!map) {
+			return;
+		}
+		for (const key of map.keys()) {
+			const targets = this.syncInFlightTargetsByKey.get(key);
+			targets?.delete(peer);
+			if (targets?.size === 0) {
+				this.syncInFlightTargetsByKey.delete(key);
+			}
+		}
+		this.syncInFlight.delete(peer);
+	}
+
+	private clearSyncInFlightKey(key: SyncableKey) {
+		const targets = this.syncInFlightTargetsByKey.get(key);
+		if (!targets) {
+			// Defensive compatibility for tests or integrations that seed the public
+			// syncInFlight map directly. Internal writes always populate the index.
+			for (const [peer, map] of this.syncInFlight) {
+				if (map.has(key)) {
+					this.removeSyncInFlightTargetKey(peer, key);
+				}
+			}
+			return;
+		}
+		for (const peer of [...targets]) {
+			this.removeSyncInFlightTargetKey(peer, key);
 		}
 	}
 
@@ -2387,23 +4549,10 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		callback: (key: SyncableKey) => void,
 	): void {
 		callback(hash);
-		if (this.syncInFlightQueue.size === 0 && this.syncInFlight.size === 0) {
-			return;
-		}
-		for (const key of this.syncInFlightQueue.keys()) {
-			if (typeof key === "bigint" && this.coordinateToHash.get(key) === hash) {
-				callback(key);
-			}
-		}
-		for (const map of this.syncInFlight.values()) {
-			for (const key of map.keys()) {
-				if (
-					typeof key === "bigint" &&
-					this.coordinateToHash.get(key) === hash
-				) {
-					callback(key);
-				}
-			}
+		for (const coordinate of [
+			...(this.syncInFlightQueuedCoordinatesByHash.get(hash) ?? []),
+		]) {
+			callback(coordinate);
 		}
 	}
 
@@ -2412,10 +4561,10 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		if (!map) {
 			return;
 		}
-		this.forEachKnownAlias(hash, (key) => map.delete(key));
-		if (map.size === 0) {
-			this.syncInFlight.delete(publicKeyHash);
-		}
+		this.refreshQueuedSyncCoordinateAliases();
+		this.forEachKnownAlias(hash, (key) =>
+			this.removeSyncInFlightTargetKey(publicKeyHash, key),
+		);
 	}
 
 	private clearSyncInFlightForPeerHashes(
@@ -2426,26 +4575,16 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		if (!map || hashes.length === 0) {
 			return;
 		}
-		const keys = new Set<SyncableKey>(hashes);
-		const hashSet = new Set(hashes);
-		for (const key of map.keys()) {
-			if (typeof key !== "bigint") {
-				continue;
-			}
-			const hash = this.coordinateToHash.get(key);
-			if (hash != null && hashSet.has(hash)) {
-				keys.add(key);
-			}
-		}
-		for (const key of keys) {
-			map.delete(key);
-		}
-		if (map.size === 0) {
-			this.syncInFlight.delete(publicKeyHash);
+		this.refreshQueuedSyncCoordinateAliases();
+		for (const hash of hashes) {
+			this.forEachKnownAlias(hash, (key) =>
+				this.removeSyncInFlightTargetKey(publicKeyHash, key),
+			);
 		}
 	}
 
 	private clearSyncProcess(hash: string) {
+		this.refreshQueuedSyncCoordinateAliases();
 		this.forEachKnownAlias(hash, (key) => this.clearSyncProcessKey(key));
 	}
 
@@ -2453,24 +4592,10 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		if (hashes.length === 0) {
 			return;
 		}
-		const keys = new Set<SyncableKey>(hashes);
-		const hashSet = new Set(hashes);
-		const maybeAddAlias = (key: SyncableKey) => {
-			if (typeof key !== "bigint") {
-				return;
-			}
-			const hash = this.coordinateToHash.get(key);
-			if (hash != null && hashSet.has(hash)) {
-				keys.add(key);
-			}
-		};
-		for (const key of this.syncInFlightQueue.keys()) {
-			maybeAddAlias(key);
-		}
-		for (const map of this.syncInFlight.values()) {
-			for (const key of map.keys()) {
-				maybeAddAlias(key);
-			}
+		this.refreshQueuedSyncCoordinateAliases();
+		const keys = new Set<SyncableKey>();
+		for (const hash of hashes) {
+			this.forEachKnownAlias(hash, (key) => keys.add(key));
 		}
 		for (const key of keys) {
 			this.clearSyncProcessKey(key);
@@ -2483,6 +4608,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 	}
 	private clearSyncProcessPublicKeyHash(publicKeyHash: string) {
 		this.syncDispatchTargetEpochs.delete(publicKeyHash);
+		this.clearPendingSyncAdmissions(publicKeyHash);
 		for (const targetLifecycle of [
 			...(this.syncDispatchTargets.get(publicKeyHash) ?? []),
 		]) {
@@ -2498,21 +4624,13 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				);
 			}
 		}
-		this.syncInFlight.delete(publicKeyHash);
+		this.clearSyncInFlightTarget(publicKeyHash);
 		this.recentlySentExchangeHeads.delete(publicKeyHash);
 		this.clearPendingMaybeSyncResponses(publicKeyHash);
 		const map = this.syncInFlightQueueInverted.get(publicKeyHash);
 		if (map) {
-			for (const hash of map) {
-				const arr = this.syncInFlightQueue.get(hash);
-				if (arr) {
-					const filtered = arr.filter((x) => x.hashcode() !== publicKeyHash);
-					if (filtered.length > 0) {
-						this.syncInFlightQueue.set(hash, filtered);
-					} else {
-						this.syncInFlightQueue.delete(hash);
-					}
-				}
+			for (const hash of [...map]) {
+				this.removePendingSyncClaim(hash, publicKeyHash);
 			}
 			this.syncInFlightQueueInverted.delete(publicKeyHash);
 		}

--- a/packages/programs/data/shared-log/src/sync/simple.ts
+++ b/packages/programs/data/shared-log/src/sync/simple.ts
@@ -250,6 +250,61 @@ export const SYNC_MESSAGE_PRIORITY = CONVERGENCE_MESSAGE_PRIORITY;
 const SIMPLE_SYNC_RETRY_AFTER_MS = 10_000;
 const EXCHANGE_HEAD_RESPONSE_DEDUPE_TTL_MS = SIMPLE_SYNC_RETRY_AFTER_MS - 1_000;
 const RECENT_KNOWN_EXCHANGE_HEAD_SUPPRESSION_MS = 30_000;
+const PENDING_MAYBE_SYNC_RESPONSE_TTL_MS = 30_000;
+// Bound retained request/response associations globally. Ten thousand hashes
+// covers several full default-size request batches while keeping adversarial or
+// abandoned requests to a small, predictable amount of heap.
+const MAX_PENDING_MAYBE_SYNC_RESPONSE_HASHES = 10_000;
+
+type PendingMaybeSyncResponse = {
+	hashes: Set<string>;
+	target: string;
+	targetLifecycle: SyncDispatchTargetLifecycle;
+	expiresAt: number;
+};
+
+type PendingMaybeSyncResponseAuthorization = {
+	batch: PendingMaybeSyncResponse;
+	hash: string;
+};
+
+type PendingMaybeSyncResponseReservation = {
+	release: () => void;
+	newlyAuthorizedByTarget: Map<string, string[]>;
+	retained: () => boolean;
+	signal: AbortSignal;
+};
+
+export type AuthorizedMaybeSyncResponseLease = {
+	hashes: string[];
+	signal: AbortSignal;
+	release: () => void;
+};
+
+type SyncDispatchLifecycle = {
+	ownershipLifecycleController: AbortController;
+	callerSignal?: AbortSignal;
+	controller: AbortController;
+	targets: Map<string, SyncDispatchTargetLifecycle>;
+	onOwnerOrCallerAbort: () => void;
+	dispatchFinished: boolean;
+	disposed: boolean;
+	abortAllOnTargetDisconnect: boolean;
+};
+
+type SyncDispatchTargetEpoch = {
+	id: number;
+};
+
+type SyncDispatchTargetLifecycle = {
+	lifecycle: SyncDispatchLifecycle;
+	target: string;
+	epoch: SyncDispatchTargetEpoch;
+	controller: AbortController;
+	batches: Set<PendingMaybeSyncResponse>;
+	responseLeases: number;
+	activeWaiters: number;
+};
 
 const createDeferred = <T>() => {
 	let resolve!: (value: T | PromiseLike<T>) => void;
@@ -266,6 +321,7 @@ type RepairSessionTargetState = {
 	requestedCount: number;
 	requestedTotalCount: number;
 	attempts: number;
+	targetEpoch: SyncDispatchTargetEpoch;
 };
 
 type RepairSessionState = {
@@ -305,6 +361,18 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 	) => boolean;
 	private sendRawExchangeHeads?: RawExchangeHeadsSender;
 	private recentlySentExchangeHeads: Map<string, Map<string, number>>;
+	private pendingMaybeSyncResponses: Map<
+		string,
+		Map<string, PendingMaybeSyncResponseAuthorization>
+	>;
+	private pendingMaybeSyncResponseCount: number;
+	private pendingMaybeSyncResponseWaiters: Set<() => void>;
+	private pendingMaybeSyncResponseBatches: Set<PendingMaybeSyncResponse>;
+	private pendingMaybeSyncResponseExpiryTimer?: ReturnType<typeof setTimeout>;
+	private syncDispatchLifecycleController: AbortController;
+	private syncDispatchTargetEpochCounter: number;
+	private syncDispatchTargetEpochs: Map<string, SyncDispatchTargetEpoch>;
+	private syncDispatchTargets: Map<string, Set<SyncDispatchTargetLifecycle>>;
 	private repairSessionCounter: number;
 	private repairSessions: Map<string, RepairSessionState>;
 
@@ -341,6 +409,14 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		this.isEntryRecentlyKnownByPeer = properties.isEntryRecentlyKnownByPeer;
 		this.sendRawExchangeHeads = properties.sendRawExchangeHeads;
 		this.recentlySentExchangeHeads = new Map();
+		this.pendingMaybeSyncResponses = new Map();
+		this.pendingMaybeSyncResponseCount = 0;
+		this.pendingMaybeSyncResponseWaiters = new Set();
+		this.pendingMaybeSyncResponseBatches = new Set();
+		this.syncDispatchLifecycleController = new AbortController();
+		this.syncDispatchTargetEpochCounter = 0;
+		this.syncDispatchTargetEpochs = new Map();
+		this.syncDispatchTargets = new Map();
 		this.repairSessionCounter = 0;
 		this.repairSessions = new Map();
 	}
@@ -457,6 +533,609 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			out.push(hash);
 		}
 		return out;
+	}
+
+	private forgetRecentlySentExchangeHeads(
+		hashes: Iterable<string>,
+		peer: PublicSignKey,
+	): void {
+		const recentlySent = this.recentlySentExchangeHeads.get(peer.hashcode());
+		if (!recentlySent) {
+			return;
+		}
+		for (const hash of hashes) {
+			recentlySent.delete(hash);
+		}
+		if (recentlySent.size === 0) {
+			this.recentlySentExchangeHeads.delete(peer.hashcode());
+		}
+	}
+
+	private getOrCreateSyncDispatchTargetEpoch(
+		target: string,
+	): SyncDispatchTargetEpoch {
+		let epoch = this.syncDispatchTargetEpochs.get(target);
+		if (!epoch) {
+			epoch = { id: ++this.syncDispatchTargetEpochCounter };
+			this.syncDispatchTargetEpochs.set(target, epoch);
+		}
+		return epoch;
+	}
+
+	private captureSyncDispatchLifecycle(
+		targets: string[],
+		callerSignal?: AbortSignal,
+		options?: {
+			abortAllOnTargetDisconnect?: boolean;
+			ownershipLifecycleController?: AbortController;
+			targetEpochs?: Map<string, SyncDispatchTargetEpoch>;
+			createTargetEpochs?: boolean;
+		},
+	): SyncDispatchLifecycle {
+		const ownershipLifecycleController =
+			options?.ownershipLifecycleController ??
+			this.syncDispatchLifecycleController;
+		const lifecycle = {
+			ownershipLifecycleController,
+			callerSignal,
+			controller: new AbortController(),
+			targets: new Map<string, SyncDispatchTargetLifecycle>(),
+			onOwnerOrCallerAbort: () => {
+				const reason =
+					callerSignal?.aborted === true
+						? callerSignal.reason
+						: ownershipLifecycleController.signal.reason;
+				this.abortSyncDispatchLifecycle(lifecycle, reason);
+			},
+			dispatchFinished: false,
+			disposed: false,
+			abortAllOnTargetDisconnect: options?.abortAllOnTargetDisconnect === true,
+		} satisfies SyncDispatchLifecycle;
+
+		for (const target of [...new Set(targets)]) {
+			const expectedEpoch = options?.targetEpochs?.get(target);
+			const currentEpoch = this.syncDispatchTargetEpochs.get(target);
+			const epoch =
+				expectedEpoch ??
+				currentEpoch ??
+				(options?.createTargetEpochs === false
+					? undefined
+					: this.getOrCreateSyncDispatchTargetEpoch(target));
+			if (!epoch) {
+				continue;
+			}
+			const targetLifecycle: SyncDispatchTargetLifecycle = {
+				lifecycle,
+				target,
+				epoch,
+				controller: new AbortController(),
+				batches: new Set(),
+				responseLeases: 0,
+				activeWaiters: 0,
+			};
+			lifecycle.targets.set(target, targetLifecycle);
+			let activeForTarget = this.syncDispatchTargets.get(target);
+			if (!activeForTarget) {
+				activeForTarget = new Set();
+				this.syncDispatchTargets.set(target, activeForTarget);
+			}
+			activeForTarget.add(targetLifecycle);
+			if (this.syncDispatchTargetEpochs.get(target) !== epoch) {
+				this.abortSyncDispatchTarget(
+					targetLifecycle,
+					new Error("sync target lifecycle is stale"),
+				);
+			}
+		}
+
+		ownershipLifecycleController.signal.addEventListener(
+			"abort",
+			lifecycle.onOwnerOrCallerAbort,
+			{ once: true },
+		);
+		if (callerSignal && callerSignal !== ownershipLifecycleController.signal) {
+			callerSignal.addEventListener("abort", lifecycle.onOwnerOrCallerAbort, {
+				once: true,
+			});
+		}
+		if (
+			this.closed === true ||
+			ownershipLifecycleController !== this.syncDispatchLifecycleController ||
+			ownershipLifecycleController.signal.aborted ||
+			callerSignal?.aborted
+		) {
+			lifecycle.onOwnerOrCallerAbort();
+		}
+		return lifecycle;
+	}
+
+	private abortSyncDispatchTarget(
+		targetLifecycle: SyncDispatchTargetLifecycle,
+		reason?: unknown,
+	): void {
+		if (!targetLifecycle.controller.signal.aborted) {
+			targetLifecycle.controller.abort(reason);
+		}
+		for (const batch of [...targetLifecycle.batches]) {
+			this.removePendingMaybeSyncResponseBatch(batch);
+		}
+		this.notifyPendingMaybeSyncResponseWaiters();
+		this.maybeDisposeSyncDispatchLifecycle(targetLifecycle.lifecycle);
+	}
+
+	private abortSyncDispatchLifecycle(
+		lifecycle: SyncDispatchLifecycle,
+		reason?: unknown,
+	): void {
+		if (!lifecycle.controller.signal.aborted) {
+			lifecycle.controller.abort(reason);
+		}
+		for (const targetLifecycle of lifecycle.targets.values()) {
+			this.abortSyncDispatchTarget(targetLifecycle, reason);
+		}
+		this.notifyPendingMaybeSyncResponseWaiters();
+		this.maybeDisposeSyncDispatchLifecycle(lifecycle);
+	}
+
+	private finishSyncDispatchLifecycle(lifecycle: SyncDispatchLifecycle): void {
+		lifecycle.dispatchFinished = true;
+		this.maybeDisposeSyncDispatchLifecycle(lifecycle);
+	}
+
+	private maybeDisposeSyncDispatchLifecycle(
+		lifecycle: SyncDispatchLifecycle,
+	): void {
+		if (
+			lifecycle.disposed ||
+			!lifecycle.dispatchFinished ||
+			[...lifecycle.targets.values()].some(
+				(target) =>
+					target.batches.size > 0 ||
+					target.responseLeases > 0 ||
+					target.activeWaiters > 0,
+			)
+		) {
+			return;
+		}
+		lifecycle.disposed = true;
+		lifecycle.ownershipLifecycleController.signal.removeEventListener(
+			"abort",
+			lifecycle.onOwnerOrCallerAbort,
+		);
+		if (
+			lifecycle.callerSignal &&
+			lifecycle.callerSignal !== lifecycle.ownershipLifecycleController.signal
+		) {
+			lifecycle.callerSignal.removeEventListener(
+				"abort",
+				lifecycle.onOwnerOrCallerAbort,
+			);
+		}
+		for (const targetLifecycle of lifecycle.targets.values()) {
+			const activeForTarget = this.syncDispatchTargets.get(
+				targetLifecycle.target,
+			);
+			activeForTarget?.delete(targetLifecycle);
+			if (activeForTarget?.size === 0) {
+				this.syncDispatchTargets.delete(targetLifecycle.target);
+			}
+		}
+	}
+
+	private isSyncDispatchLifecycleActive(
+		lifecycle: SyncDispatchLifecycle,
+		target?: string,
+	): boolean {
+		if (
+			this.closed === true ||
+			lifecycle.disposed ||
+			lifecycle.ownershipLifecycleController !==
+				this.syncDispatchLifecycleController ||
+			lifecycle.ownershipLifecycleController.signal.aborted ||
+			lifecycle.callerSignal?.aborted ||
+			lifecycle.controller.signal.aborted
+		) {
+			return false;
+		}
+		if (target === undefined) {
+			return true;
+		}
+		const targetLifecycle = lifecycle.targets.get(target);
+		return (
+			targetLifecycle !== undefined &&
+			!targetLifecycle.controller.signal.aborted &&
+			this.syncDispatchTargetEpochs.get(target) === targetLifecycle.epoch
+		);
+	}
+
+	private getSyncDispatchSignal(
+		lifecycle: SyncDispatchLifecycle,
+		target: string,
+	): AbortSignal {
+		return (
+			lifecycle.targets.get(target)?.controller.signal ??
+			lifecycle.controller.signal
+		);
+	}
+
+	private notifyPendingMaybeSyncResponseWaiters(): void {
+		const waiters = [...this.pendingMaybeSyncResponseWaiters];
+		this.pendingMaybeSyncResponseWaiters.clear();
+		for (const wake of waiters) {
+			wake();
+		}
+	}
+
+	private schedulePendingMaybeSyncResponseExpiry(): void {
+		if (
+			this.pendingMaybeSyncResponseExpiryTimer ||
+			this.pendingMaybeSyncResponseBatches.size === 0
+		) {
+			return;
+		}
+		let earliest = Number.POSITIVE_INFINITY;
+		for (const batch of this.pendingMaybeSyncResponseBatches) {
+			earliest = Math.min(earliest, batch.expiresAt);
+		}
+		this.pendingMaybeSyncResponseExpiryTimer = setTimeout(
+			() => {
+				this.pendingMaybeSyncResponseExpiryTimer = undefined;
+				const now = Date.now();
+				for (const batch of [...this.pendingMaybeSyncResponseBatches]) {
+					if (batch.expiresAt <= now) {
+						this.removePendingMaybeSyncResponseBatch(batch);
+					}
+				}
+				this.schedulePendingMaybeSyncResponseExpiry();
+			},
+			Math.max(0, earliest - Date.now()),
+		);
+		this.pendingMaybeSyncResponseExpiryTimer.unref?.();
+	}
+
+	private removePendingMaybeSyncResponseBatch(
+		batch: PendingMaybeSyncResponse,
+	): void {
+		const pendingForTarget = this.pendingMaybeSyncResponses.get(batch.target);
+		let removed = 0;
+		if (pendingForTarget) {
+			for (const hash of batch.hashes) {
+				if (pendingForTarget.get(hash)?.batch !== batch) {
+					continue;
+				}
+				pendingForTarget.delete(hash);
+				removed += 1;
+			}
+			if (pendingForTarget.size === 0) {
+				this.pendingMaybeSyncResponses.delete(batch.target);
+			}
+		}
+		this.pendingMaybeSyncResponseCount -= removed;
+		this.pendingMaybeSyncResponseBatches.delete(batch);
+		batch.targetLifecycle.batches.delete(batch);
+		batch.hashes.clear();
+		if (
+			this.pendingMaybeSyncResponseBatches.size === 0 &&
+			this.pendingMaybeSyncResponseExpiryTimer
+		) {
+			clearTimeout(this.pendingMaybeSyncResponseExpiryTimer);
+			this.pendingMaybeSyncResponseExpiryTimer = undefined;
+		}
+		this.notifyPendingMaybeSyncResponseWaiters();
+		this.maybeDisposeSyncDispatchLifecycle(batch.targetLifecycle.lifecycle);
+	}
+
+	private clearPendingMaybeSyncResponses(target?: string): void {
+		const batches =
+			target === undefined
+				? [...this.pendingMaybeSyncResponseBatches]
+				: [
+						...new Set(
+							[
+								...(this.pendingMaybeSyncResponses.get(target)?.values() ?? []),
+							].map((authorization) => authorization.batch),
+						),
+					];
+		for (const batch of batches) {
+			this.removePendingMaybeSyncResponseBatch(batch);
+		}
+		this.notifyPendingMaybeSyncResponseWaiters();
+	}
+
+	private tryReservePendingMaybeSyncResponse(properties: {
+		hashes: Iterable<string>;
+		targets: string[];
+		lifecycle: SyncDispatchLifecycle;
+	}): PendingMaybeSyncResponseReservation | undefined {
+		const hashes = [...new Set(properties.hashes)];
+		const targets = [...new Set(properties.targets)];
+		if (
+			!this.isSyncDispatchLifecycleActive(properties.lifecycle) ||
+			targets.some(
+				(target) =>
+					!this.isSyncDispatchLifecycleActive(properties.lifecycle, target),
+			)
+		) {
+			return undefined;
+		}
+
+		const hashesToAddByTarget = new Map<string, string[]>();
+		let required = 0;
+		for (const target of targets) {
+			const targetLifecycle = properties.lifecycle.targets.get(target)!;
+			const hashesToAdd: string[] = [];
+			for (const hash of hashes) {
+				let existing = this.pendingMaybeSyncResponses.get(target)?.get(hash);
+				if (
+					existing &&
+					!this.isSyncDispatchLifecycleActive(
+						existing.batch.targetLifecycle.lifecycle,
+						target,
+					)
+				) {
+					this.removePendingMaybeSyncResponseBatch(existing.batch);
+					existing = undefined;
+				}
+				if (existing) {
+					const existingTarget = existing.batch.targetLifecycle;
+					if (
+						existingTarget.epoch === targetLifecycle.epoch &&
+						existingTarget.lifecycle.ownershipLifecycleController ===
+							properties.lifecycle.ownershipLifecycleController &&
+						existingTarget.lifecycle.callerSignal ===
+							properties.lifecycle.callerSignal
+					) {
+						continue;
+					}
+					return undefined;
+				}
+				hashesToAdd.push(hash);
+			}
+			if (hashesToAdd.length > 0) {
+				hashesToAddByTarget.set(target, hashesToAdd);
+				required += hashesToAdd.length;
+			}
+		}
+
+		if (
+			required >
+			MAX_PENDING_MAYBE_SYNC_RESPONSE_HASHES -
+				this.pendingMaybeSyncResponseCount
+		) {
+			return undefined;
+		}
+
+		const addedBatches: PendingMaybeSyncResponse[] = [];
+		for (const [target, hashesToAdd] of hashesToAddByTarget) {
+			const targetLifecycle = properties.lifecycle.targets.get(target)!;
+			const batch: PendingMaybeSyncResponse = {
+				hashes: new Set(hashesToAdd),
+				target,
+				targetLifecycle,
+				expiresAt: Date.now() + PENDING_MAYBE_SYNC_RESPONSE_TTL_MS,
+			};
+			let pendingForTarget = this.pendingMaybeSyncResponses.get(target);
+			if (!pendingForTarget) {
+				pendingForTarget = new Map();
+				this.pendingMaybeSyncResponses.set(target, pendingForTarget);
+			}
+			for (const hash of hashesToAdd) {
+				pendingForTarget.set(hash, { batch, hash });
+			}
+			this.pendingMaybeSyncResponseCount += hashesToAdd.length;
+			this.pendingMaybeSyncResponseBatches.add(batch);
+			targetLifecycle.batches.add(batch);
+			addedBatches.push(batch);
+		}
+		this.schedulePendingMaybeSyncResponseExpiry();
+
+		let released = false;
+		const release = () => {
+			if (released) {
+				return;
+			}
+			released = true;
+			for (const batch of addedBatches) {
+				this.removePendingMaybeSyncResponseBatch(batch);
+			}
+		};
+		const retained = () =>
+			this.isSyncDispatchLifecycleActive(properties.lifecycle) &&
+			addedBatches.every(
+				(batch) =>
+					this.pendingMaybeSyncResponseBatches.has(batch) &&
+					batch.hashes.size > 0,
+			);
+		if (!this.isSyncDispatchLifecycleActive(properties.lifecycle)) {
+			release();
+			return undefined;
+		}
+		return {
+			release,
+			newlyAuthorizedByTarget: hashesToAddByTarget,
+			retained,
+			signal: properties.lifecycle.controller.signal,
+		};
+	}
+
+	private waitForPendingMaybeSyncResponseChange(
+		lifecycle: SyncDispatchLifecycle,
+		targets: string[],
+	): Promise<void> {
+		if (
+			!this.isSyncDispatchLifecycleActive(lifecycle) ||
+			targets.some(
+				(target) => !this.isSyncDispatchLifecycleActive(lifecycle, target),
+			)
+		) {
+			return Promise.resolve();
+		}
+		const targetLifecycles = targets
+			.map((target) => lifecycle.targets.get(target))
+			.filter(
+				(target): target is SyncDispatchTargetLifecycle => target !== undefined,
+			);
+		for (const targetLifecycle of targetLifecycles) {
+			targetLifecycle.activeWaiters += 1;
+		}
+		return new Promise<void>((resolve) => {
+			let settled = false;
+			const wake = () => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				this.pendingMaybeSyncResponseWaiters.delete(wake);
+				for (const targetLifecycle of targetLifecycles) {
+					targetLifecycle.activeWaiters -= 1;
+				}
+				resolve();
+				this.maybeDisposeSyncDispatchLifecycle(lifecycle);
+			};
+			this.pendingMaybeSyncResponseWaiters.add(wake);
+			if (
+				!this.isSyncDispatchLifecycleActive(lifecycle) ||
+				targets.some(
+					(target) => !this.isSyncDispatchLifecycleActive(lifecycle, target),
+				)
+			) {
+				wake();
+			}
+		});
+	}
+
+	private async reservePendingMaybeSyncResponse(properties: {
+		hashes: Iterable<string>;
+		targets: string[];
+		lifecycle: SyncDispatchLifecycle;
+	}): Promise<PendingMaybeSyncResponseReservation | undefined> {
+		while (
+			this.isSyncDispatchLifecycleActive(properties.lifecycle) &&
+			properties.targets.every((target) =>
+				this.isSyncDispatchLifecycleActive(properties.lifecycle, target),
+			)
+		) {
+			const reservation = this.tryReservePendingMaybeSyncResponse(properties);
+			if (reservation) {
+				return reservation;
+			}
+			await this.waitForPendingMaybeSyncResponseChange(
+				properties.lifecycle,
+				properties.targets,
+			);
+		}
+		return undefined;
+	}
+
+	expectMaybeSyncResponse(properties: {
+		hashes: Iterable<string>;
+		targets: string[];
+		signal?: AbortSignal;
+	}): PendingMaybeSyncResponseReservation | undefined {
+		const targets = [...new Set(properties.targets)];
+		const lifecycle = this.captureSyncDispatchLifecycle(
+			targets,
+			properties.signal,
+			{ abortAllOnTargetDisconnect: true },
+		);
+		const reservation = this.tryReservePendingMaybeSyncResponse({
+			hashes: properties.hashes,
+			targets,
+			lifecycle,
+		});
+		let retainedReservation: PendingMaybeSyncResponseReservation | undefined;
+		if (reservation) {
+			const leasedTargets = [...lifecycle.targets.values()];
+			for (const targetLifecycle of leasedTargets) {
+				targetLifecycle.responseLeases += 1;
+			}
+			let released = false;
+			retainedReservation = {
+				...reservation,
+				release: () => {
+					if (released) {
+						return;
+					}
+					released = true;
+					reservation.release();
+					for (const targetLifecycle of leasedTargets) {
+						targetLifecycle.responseLeases -= 1;
+					}
+					this.maybeDisposeSyncDispatchLifecycle(lifecycle);
+				},
+			};
+		}
+		this.finishSyncDispatchLifecycle(lifecycle);
+		return retainedReservation;
+	}
+
+	consumeAuthorizedMaybeSyncResponse(
+		hashes: Iterable<string>,
+		from: PublicSignKey,
+	): AuthorizedMaybeSyncResponseLease[] {
+		const fromHash = from.hashcode();
+		const pendingForTarget = this.pendingMaybeSyncResponses.get(fromHash);
+		if (!pendingForTarget) {
+			return [];
+		}
+		const acceptedByLifecycle = new Map<
+			SyncDispatchTargetLifecycle,
+			string[]
+		>();
+		const seen = new Set<string>();
+		for (const hash of hashes) {
+			if (seen.has(hash)) {
+				continue;
+			}
+			seen.add(hash);
+			const authorization = pendingForTarget.get(hash);
+			if (!authorization) {
+				continue;
+			}
+			const batch = authorization.batch;
+			const targetLifecycle = batch.targetLifecycle;
+			if (
+				!this.isSyncDispatchLifecycleActive(targetLifecycle.lifecycle, fromHash)
+			) {
+				this.removePendingMaybeSyncResponseBatch(batch);
+				continue;
+			}
+			if (pendingForTarget.get(hash)?.batch !== batch) {
+				continue;
+			}
+			let accepted = acceptedByLifecycle.get(targetLifecycle);
+			if (!accepted) {
+				accepted = [];
+				acceptedByLifecycle.set(targetLifecycle, accepted);
+				targetLifecycle.responseLeases += 1;
+			}
+			pendingForTarget.delete(hash);
+			batch.hashes.delete(hash);
+			this.pendingMaybeSyncResponseCount -= 1;
+			accepted.push(hash);
+			if (batch.hashes.size === 0) {
+				this.removePendingMaybeSyncResponseBatch(batch);
+			}
+		}
+		if (pendingForTarget.size === 0) {
+			this.pendingMaybeSyncResponses.delete(fromHash);
+		}
+		this.notifyPendingMaybeSyncResponseWaiters();
+		return [...acceptedByLifecycle].map(([targetLifecycle, acceptedHashes]) => {
+			let released = false;
+			return {
+				hashes: acceptedHashes,
+				signal: targetLifecycle.controller.signal,
+				release: () => {
+					if (released) {
+						return;
+					}
+					released = true;
+					targetLifecycle.responseLeases -= 1;
+					this.maybeDisposeSyncDispatchLifecycle(targetLifecycle.lifecycle);
+				},
+			};
+		});
 	}
 
 	private isRepairSessionComplete(session: RepairSessionState): boolean {
@@ -602,7 +1281,10 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				}
 				state.attempts += 1;
 				try {
-					await this.requestSync([...state.unresolved], [target]);
+					await this.requestSync([...state.unresolved], [target], {
+						targetEpochs: new Map([[target, state.targetEpoch]]),
+						createTargetEpochs: false,
+					});
 				} catch {
 					// Best-effort: keep unresolved and let retries/timeout determine outcome.
 				}
@@ -703,6 +1385,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				requestedCount: trackedHashes.length,
 				requestedTotalCount: allHashes.length,
 				attempts: 0,
+				targetEpoch: this.getOrCreateSyncDispatchTargetEpoch(target),
 			});
 		}
 
@@ -762,42 +1445,124 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 	async onMaybeMissingEntries(properties: {
 		entries: Map<string, SyncEntryCoordinates<R>>;
 		targets: string[];
+		signal?: AbortSignal;
 	}): Promise<void> {
+		if (properties.signal?.aborted) {
+			return;
+		}
 		await this.onMaybeMissingHashes({
 			hashes: this.getPrioritizedHashes(properties.entries),
 			targets: properties.targets,
+			signal: properties.signal,
 		});
 	}
 
 	async onMaybeMissingHashes(properties: {
 		hashes: Iterable<string>;
 		targets: string[];
+		signal?: AbortSignal;
 	}): Promise<void> {
+		const targets = [...new Set(properties.targets)];
+		const lifecycle = this.captureSyncDispatchLifecycle(
+			targets,
+			properties.signal,
+		);
+		if (!this.isSyncDispatchLifecycleActive(lifecycle)) {
+			this.finishSyncDispatchLifecycle(lifecycle);
+			return;
+		}
 		const profile = this.syncOptions?.profile;
 		const startedAt = syncProfileStart(profile);
-		const hashes = [...properties.hashes];
-		const chunks = this.chunk(hashes, this.maxHashesPerMessage);
-		try {
-			await chunks.reduce(
-				(promise, chunk) =>
-					promise.then(() =>
-						this.rpc.send(new RequestMaybeSync({ hashes: chunk }), {
-							priority: SYNC_MESSAGE_PRIORITY,
-							mode: new SilentDelivery({
-								to: properties.targets,
-								redundancy: 1,
-							}),
-						}),
+		const hashes = [...new Set(properties.hashes)];
+		const targetsPerAuthorizationWindow = Math.max(
+			1,
+			Math.min(targets.length, MAX_PENDING_MAYBE_SYNC_RESPONSE_HASHES),
+		);
+		const chunks = this.chunk(
+			hashes,
+			Math.max(
+				1,
+				Math.min(
+					this.maxHashesPerMessage,
+					Math.floor(
+						MAX_PENDING_MAYBE_SYNC_RESPONSE_HASHES /
+							targetsPerAuthorizationWindow,
 					),
-				Promise.resolve(),
-			);
+				),
+			),
+		);
+		let messages = 0;
+		try {
+			for (const chunk of chunks) {
+				if (!this.isSyncDispatchLifecycleActive(lifecycle)) {
+					break;
+				}
+				for (const target of targets) {
+					if (!this.isSyncDispatchLifecycleActive(lifecycle, target)) {
+						continue;
+					}
+					const reservation = await this.reservePendingMaybeSyncResponse({
+						hashes: chunk,
+						targets: [target],
+						lifecycle,
+					});
+					if (
+						!reservation ||
+						!this.isSyncDispatchLifecycleActive(lifecycle, target)
+					) {
+						continue;
+					}
+					const hashesToSend =
+						reservation.newlyAuthorizedByTarget.get(target) ?? [];
+					if (hashesToSend.length === 0) {
+						continue;
+					}
+					if (!reservation.retained()) {
+						reservation.release();
+						continue;
+					}
+					try {
+						await this.rpc.send(
+							new RequestMaybeSync({ hashes: hashesToSend }),
+							{
+								priority: SYNC_MESSAGE_PRIORITY,
+								mode: new SilentDelivery({
+									to: [target],
+									redundancy: 1,
+								}),
+								signal: this.getSyncDispatchSignal(lifecycle, target),
+							},
+						);
+						messages += 1;
+					} catch (error) {
+						reservation.release();
+						if (
+							!this.isSyncDispatchLifecycleActive(lifecycle) ||
+							!this.isSyncDispatchLifecycleActive(lifecycle, target)
+						) {
+							continue;
+						}
+						throw error;
+					}
+					if (!this.isSyncDispatchLifecycleActive(lifecycle, target)) {
+						break;
+					}
+				}
+				if (!this.isSyncDispatchLifecycleActive(lifecycle)) {
+					break;
+				}
+			}
 		} finally {
+			this.finishSyncDispatchLifecycle(lifecycle);
 			if (profile) {
 				emitSyncProfileDuration(profile, startedAt, {
 					name: "simple.onMaybeMissingEntries",
 					entries: hashes.length,
-					messages: chunks.length,
-					targets: properties.targets.length,
+					messages,
+					targets: targets.length,
+					details: !this.isSyncDispatchLifecycleActive(lifecycle)
+						? { cancelled: true }
+						: undefined,
 				});
 			}
 		}
@@ -813,11 +1578,25 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		hashes: string[],
 		to: PublicSignKey,
 		canReceiveRaw: boolean,
+		signal?: AbortSignal,
 	): Promise<{ messages: number; fused: boolean }> {
+		if (signal?.aborted) {
+			return { messages: 0, fused: false };
+		}
 		if (canReceiveRaw && this.sendRawExchangeHeads) {
-			const sentMessages = await this.sendRawExchangeHeads(hashes, [
-				to.hashcode(),
-			]);
+			let sentMessages: number | undefined;
+			try {
+				sentMessages = await this.sendRawExchangeHeads(
+					hashes,
+					[to.hashcode()],
+					{ signal },
+				);
+			} catch (error) {
+				if (signal?.aborted) {
+					return { messages: 0, fused: true };
+				}
+				throw error;
+			}
 			if (sentMessages !== undefined) {
 				return { messages: sentMessages, fused: true };
 			}
@@ -831,12 +1610,112 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				)
 			: createExchangeHeadsMessages(this.log, hashes);
 		for await (const message of messageGenerator) {
-			messages += 1;
-			await this.rpc.send(message, {
-				mode: new SilentDelivery({ to: [to], redundancy: 1 }),
-			});
+			if (signal?.aborted) {
+				break;
+			}
+			try {
+				await this.rpc.send(message, {
+					mode: new SilentDelivery({ to: [to], redundancy: 1 }),
+					signal,
+				});
+				messages += 1;
+			} catch (error) {
+				if (signal?.aborted) {
+					break;
+				}
+				throw error;
+			}
 		}
 		return { messages, fused: false };
+	}
+
+	/**
+	 * Ships hashes that the caller has already authorized for this exact sender.
+	 *
+	 * This deliberately does not consult or extend Simple's bounded pending-response
+	 * window. Rateless sync owns a separate, target-scoped authorization lifecycle
+	 * and uses this helper only after intersecting the response with that process's
+	 * exact advertised hash set.
+	 */
+	async shipAuthorizedMaybeSyncResponse(properties: {
+		hashes: string[];
+		from: PublicSignKey;
+		response: ResponseMaybeSync | ResponseMaybeSyncCapabilities;
+		signal: AbortSignal;
+	}): Promise<{ messages: number; fused: boolean; entries: number }> {
+		const hashes = this.filterRecentlySentExchangeHeads(
+			properties.hashes,
+			properties.from,
+		);
+		try {
+			const shipped = await this.shipExchangeHeads(
+				hashes,
+				properties.from,
+				canReceiveRawExchangeHeads(properties.response),
+				properties.signal,
+			);
+			return {
+				...shipped,
+				entries: hashes.length,
+			};
+		} catch (error) {
+			this.forgetRecentlySentExchangeHeads(hashes, properties.from);
+			throw error;
+		} finally {
+			if (properties.signal.aborted) {
+				this.forgetRecentlySentExchangeHeads(hashes, properties.from);
+			}
+		}
+	}
+
+	async shipAuthorizedMaybeSyncResponseLeases(properties: {
+		leases: AuthorizedMaybeSyncResponseLease[];
+		from: PublicSignKey;
+		response: ResponseMaybeSync | ResponseMaybeSyncCapabilities;
+		source?: string;
+	}): Promise<{ messages: number; fused: boolean; entries: number }> {
+		if (properties.leases.length === 0) {
+			return { messages: 0, fused: false, entries: 0 };
+		}
+		const profile = this.syncOptions?.profile;
+		const startedAt = syncProfileStart(profile);
+		let messages = 0;
+		let fused = false;
+		let entries = 0;
+		let firstError: unknown;
+		for (const lease of properties.leases) {
+			try {
+				const shipped = await this.shipAuthorizedMaybeSyncResponse({
+					hashes: lease.hashes,
+					from: properties.from,
+					response: properties.response,
+					signal: lease.signal,
+				});
+				messages += shipped.messages;
+				fused ||= shipped.fused;
+				entries += shipped.entries;
+			} catch (error) {
+				firstError ??= error;
+			} finally {
+				lease.release();
+			}
+		}
+		if (profile) {
+			emitSyncProfileDuration(profile, startedAt, {
+				name: "simple.exchangeHeads",
+				entries,
+				messages,
+				targets: 1,
+				details: {
+					source: properties.source ?? "responseMaybeSync",
+					fused,
+				},
+			});
+		}
+		if (firstError !== undefined) {
+			throw firstError;
+		}
+		return { messages, fused, entries };
 	}
 
 	async onMessage(
@@ -854,74 +1733,77 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			// TODO perhaps send less messages to more receivers for performance reasons?
 			// TODO wait for previous send to target before trying to send more?
 
-			const profile = this.syncOptions?.profile;
-			const startedAt = syncProfileStart(profile);
-			const hashes = this.filterRecentlySentExchangeHeads(msg.hashes, from);
-			let messages = 0;
-			let fused = false;
-			try {
-				({ messages, fused } = await this.shipExchangeHeads(
-					hashes,
-					context.from!,
-					canReceiveRawExchangeHeads(msg),
-				));
-			} finally {
-				if (profile) {
-					emitSyncProfileDuration(profile, startedAt, {
-						name: "simple.exchangeHeads",
-						entries: hashes.length,
-						messages,
-						targets: 1,
-						details: { source: "responseMaybeSync", fused },
-					});
-				}
+			const pending = this.consumeAuthorizedMaybeSyncResponse(msg.hashes, from);
+			if (pending.length === 0) {
+				return true;
 			}
+			await this.shipAuthorizedMaybeSyncResponseLeases({
+				leases: pending,
+				from,
+				response: msg,
+			});
 			return true;
 		} else if (
 			msg instanceof RequestMaybeSyncCoordinate ||
 			msg instanceof RequestMaybeSyncCoordinateCapabilities
 		) {
-			const profile = this.syncOptions?.profile;
-			const lookupStartedAt = syncProfileStart(profile);
-			const hashes = await getHashesFromSymbols(
-				msg.hashNumbers,
-				this.entryIndex,
-				this.coordinateToHash,
-				this.resolveHashesForSymbols,
-				this.resolveHashListForSymbols,
-			);
-			if (profile) {
-				emitSyncProfileDuration(profile, lookupStartedAt, {
-					name: "simple.coordinateLookup",
-					entries: hashLookupResultSize(hashes),
-					symbols: msg.hashNumbers.length,
-				});
-			}
-
-			const exchangeStartedAt = syncProfileStart(profile);
-			const hashesToSend = this.filterRecentlySentExchangeHeads(hashes, from);
-			let messages = 0;
-			let fused = false;
+			const target = from.hashcode();
+			const lifecycle = this.captureSyncDispatchLifecycle([target]);
 			try {
-				// dont set priority 1 here because this will block other messages that should higher priority
-				({ messages, fused } = await this.shipExchangeHeads(
-					hashesToSend,
-					context.from!,
-					canReceiveRawExchangeHeads(msg),
-				));
-			} finally {
+				if (!this.isSyncDispatchLifecycleActive(lifecycle, target)) {
+					return true;
+				}
+				const profile = this.syncOptions?.profile;
+				const lookupStartedAt = syncProfileStart(profile);
+				const hashes = await getHashesFromSymbols(
+					msg.hashNumbers,
+					this.entryIndex,
+					this.coordinateToHash,
+					this.resolveHashesForSymbols,
+					this.resolveHashListForSymbols,
+				);
+				if (!this.isSyncDispatchLifecycleActive(lifecycle, target)) {
+					return true;
+				}
 				if (profile) {
-					emitSyncProfileDuration(profile, exchangeStartedAt, {
-						name: "simple.exchangeHeads",
-						entries: hashesToSend.length,
-						messages,
-						targets: 1,
-						details: { source: "requestMaybeSyncCoordinate", fused },
+					emitSyncProfileDuration(profile, lookupStartedAt, {
+						name: "simple.coordinateLookup",
+						entries: hashLookupResultSize(hashes),
+						symbols: msg.hashNumbers.length,
 					});
 				}
-			}
 
-			return true;
+				const exchangeStartedAt = syncProfileStart(profile);
+				const hashesToSend = this.filterRecentlySentExchangeHeads(hashes, from);
+				let messages = 0;
+				let fused = false;
+				try {
+					// dont set priority 1 here because this will block other messages that should higher priority
+					({ messages, fused } = await this.shipExchangeHeads(
+						hashesToSend,
+						context.from!,
+						canReceiveRawExchangeHeads(msg),
+						this.getSyncDispatchSignal(lifecycle, target),
+					));
+				} finally {
+					if (profile) {
+						emitSyncProfileDuration(profile, exchangeStartedAt, {
+							name: "simple.exchangeHeads",
+							entries: hashesToSend.length,
+							messages,
+							targets: 1,
+							details: {
+								source: "requestMaybeSyncCoordinate",
+								fused,
+							},
+						});
+					}
+				}
+
+				return true;
+			} finally {
+				this.finishSyncDispatchLifecycle(lifecycle);
+			}
 		} else {
 			return false; // no message was consumed
 		}
@@ -953,6 +1835,14 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		from: PublicSignKey,
 		options?: { skipCheck?: boolean },
 	) {
+		const fromHash = from.hashcode();
+		const targetEpoch = this.getOrCreateSyncDispatchTargetEpoch(fromHash);
+		const ownershipLifecycleController = this.syncDispatchLifecycleController;
+		const isCapturedLifecycleActive = () =>
+			this.closed !== true &&
+			this.syncDispatchLifecycleController === ownershipLifecycleController &&
+			!ownershipLifecycleController.signal.aborted &&
+			this.syncDispatchTargetEpochs.get(fromHash) === targetEpoch;
 		const requestHashes: SyncableKey[] = [];
 		const profile = this.syncOptions?.profile;
 		const startedAt = syncProfileStart(profile);
@@ -961,6 +1851,9 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			options?.skipCheck === true
 				? undefined
 				: await this.resolveKnownSyncKeys(keys);
+		if (!isCapturedLifecycleActive()) {
+			return;
+		}
 		if (profile) {
 			emitSyncProfileDuration(profile, resolveKnownStartedAt, {
 				name: "simple.queueSync.resolveKnown",
@@ -973,7 +1866,6 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				},
 			});
 		}
-		const fromHash = from.hashcode();
 		let queuedHashAliases: Map<string, SyncableKey> | undefined;
 		const getQueuedSyncKeyForBatch = (key: SyncableKey) => {
 			if (this.syncInFlightQueue.has(key)) {
@@ -1001,6 +1893,9 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		try {
 			const loopStartedAt = syncProfileStart(profile);
 			for (const key of keys) {
+				if (!isCapturedLifecycleActive()) {
+					return;
+				}
 				const coordinateOrHash = getQueuedSyncKeyForBatch(key) ?? key;
 				const inFlight = this.syncInFlightQueue.get(coordinateOrHash);
 				if (inFlight) {
@@ -1013,13 +1908,16 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 						}
 						inverted.add(coordinateOrHash);
 					}
-				} else if (
-					options?.skipCheck ||
-					!(await this.checkHasCoordinateOrHash(
-						coordinateOrHash,
-						knownKeys,
-					))
-				) {
+				} else {
+					const has =
+						options?.skipCheck !== true &&
+						(await this.checkHasCoordinateOrHash(coordinateOrHash, knownKeys));
+					if (!isCapturedLifecycleActive()) {
+						return;
+					}
+					if (has) {
+						continue;
+					}
 					// Track the initial sender so we can retry if the first request is lost.
 					this.syncInFlightQueue.set(coordinateOrHash, [from]);
 					let inverted = this.syncInFlightQueueInverted.get(fromHash);
@@ -1050,7 +1948,11 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			}
 
 			requestHashes.length > 0 &&
-				(await this.requestSync(requestHashes, [fromHash]));
+				(await this.requestSync(requestHashes, [fromHash], {
+					ownershipLifecycleController,
+					targetEpochs: new Map([[fromHash, targetEpoch]]),
+					createTargetEpochs: false,
+				}));
 		} finally {
 			if (profile) {
 				emitSyncProfileDuration(profile, startedAt, {
@@ -1066,10 +1968,24 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		}
 	}
 
-	private async requestSync(hashes: SyncableKey[], to: Set<string> | string[]) {
-		if (hashes.length === 0) {
+	private async requestSync(
+		hashes: SyncableKey[],
+		to: Set<string> | string[],
+		options?: {
+			ownershipLifecycleController?: AbortController;
+			targetEpochs?: Map<string, SyncDispatchTargetEpoch>;
+			createTargetEpochs?: boolean;
+		},
+	) {
+		const targets = [...new Set(to)];
+		if (hashes.length === 0 || targets.length === 0) {
 			return;
 		}
+		const lifecycle = this.captureSyncDispatchLifecycle(targets, undefined, {
+			ownershipLifecycleController: options?.ownershipLifecycleController,
+			targetEpochs: options?.targetEpochs,
+			createTargetEpochs: options?.createTargetEpochs,
+		});
 		const profile = this.syncOptions?.profile;
 		const startedAt = syncProfileStart(profile);
 		let coordinateMessages = 0;
@@ -1079,7 +1995,10 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 
 		try {
 			const now = +new Date();
-			for (const node of to) {
+			for (const node of targets) {
+				if (!this.isSyncDispatchLifecycleActive(lifecycle, node)) {
+					continue;
+				}
 				let map = this.syncInFlight.get(node);
 				if (!map) {
 					map = new Map();
@@ -1102,48 +2021,85 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			coordinateHashCount = coordinateHashes.length;
 			stringHashCount = stringHashes.length;
 
-				if (coordinateHashes.length > 0) {
-					const chunks = this.chunk(
-						coordinateHashes,
-						this.maxCoordinatesPerMessage,
-					);
-					coordinateMessages = chunks.length;
+			if (coordinateHashes.length > 0) {
+				const chunks = this.chunk(
+					coordinateHashes,
+					this.maxCoordinatesPerMessage,
+				);
+				for (const target of targets) {
 					for (const chunk of chunks) {
-						await this.rpc.send(
-							this.syncOptions?.rawExchangeHeads
-								? new RequestMaybeSyncCoordinateCapabilities({
-										hashNumbers: chunk,
-									})
-								: new RequestMaybeSyncCoordinate({ hashNumbers: chunk }),
-							{
-								mode: new SilentDelivery({ to, redundancy: 1 }),
-								priority: SYNC_MESSAGE_PRIORITY,
-							},
-						);
+						if (!this.isSyncDispatchLifecycleActive(lifecycle, target)) {
+							break;
+						}
+						try {
+							await this.rpc.send(
+								this.syncOptions?.rawExchangeHeads
+									? new RequestMaybeSyncCoordinateCapabilities({
+											hashNumbers: chunk,
+										})
+									: new RequestMaybeSyncCoordinate({
+											hashNumbers: chunk,
+										}),
+								{
+									mode: new SilentDelivery({
+										to: [target],
+										redundancy: 1,
+									}),
+									priority: SYNC_MESSAGE_PRIORITY,
+									signal: this.getSyncDispatchSignal(lifecycle, target),
+								},
+							);
+							coordinateMessages += 1;
+						} catch (error) {
+							if (!this.isSyncDispatchLifecycleActive(lifecycle, target)) {
+								break;
+							}
+							throw error;
+						}
 					}
 				}
-				if (stringHashes.length > 0) {
-					const chunks = this.chunk(stringHashes, this.maxHashesPerMessage);
-					stringMessages = chunks.length;
+			}
+			if (stringHashes.length > 0) {
+				const chunks = this.chunk(stringHashes, this.maxHashesPerMessage);
+				for (const target of targets) {
 					for (const chunk of chunks) {
-						await this.rpc.send(
-							this.syncOptions?.rawExchangeHeads
-								? new ResponseMaybeSyncCapabilities({ hashes: chunk })
-								: new ResponseMaybeSync({ hashes: chunk }),
-							{
-								mode: new SilentDelivery({ to, redundancy: 1 }),
-								priority: SYNC_MESSAGE_PRIORITY,
-							},
-						);
+						if (!this.isSyncDispatchLifecycleActive(lifecycle, target)) {
+							break;
+						}
+						try {
+							await this.rpc.send(
+								this.syncOptions?.rawExchangeHeads
+									? new ResponseMaybeSyncCapabilities({
+											hashes: chunk,
+										})
+									: new ResponseMaybeSync({ hashes: chunk }),
+								{
+									mode: new SilentDelivery({
+										to: [target],
+										redundancy: 1,
+									}),
+									priority: SYNC_MESSAGE_PRIORITY,
+									signal: this.getSyncDispatchSignal(lifecycle, target),
+								},
+							);
+							stringMessages += 1;
+						} catch (error) {
+							if (!this.isSyncDispatchLifecycleActive(lifecycle, target)) {
+								break;
+							}
+							throw error;
+						}
 					}
 				}
+			}
 		} finally {
+			this.finishSyncDispatchLifecycle(lifecycle);
 			if (profile) {
 				emitSyncProfileDuration(profile, startedAt, {
 					name: "simple.requestSync",
 					entries: hashes.length,
 					messages: coordinateMessages + stringMessages,
-					targets: Array.isArray(to) ? to.length : to.size,
+					targets: targets.length,
 					details: {
 						coordinateHashes: coordinateHashCount,
 						stringHashes: stringHashCount,
@@ -1214,8 +2170,29 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			: this.log.has(key);
 	}
 	async open() {
+		this.syncDispatchLifecycleController.abort();
+		this.clearPendingMaybeSyncResponses();
+		this.syncDispatchTargetEpochs.clear();
+		this.syncDispatchLifecycleController = new AbortController();
+		const openLifecycleController = this.syncDispatchLifecycleController;
 		this.closed = false;
-		const requestSyncLoop = async () => {
+		const isOpenLifecycleActive = () =>
+			this.closed !== true &&
+			this.syncDispatchLifecycleController === openLifecycleController &&
+			!openLifecycleController.signal.aborted;
+		let requestSyncLoop!: () => Promise<void>;
+		const scheduleRequestSyncLoop = () => {
+			if (!isOpenLifecycleActive()) {
+				return;
+			}
+			this.syncMoreInterval = setTimeout(() => {
+				void requestSyncLoop().catch(() => {
+					// The loop is best-effort. Observe all failures so a transport or
+					// storage rejection cannot become an unhandled process rejection.
+				});
+			}, 3e3);
+		};
+		requestSyncLoop = async () => {
 			/**
 			 * This method fetches entries that we potentially want.
 			 * In a case in which we become replicator of a segment,
@@ -1224,75 +2201,108 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			 * so we don't get flooded with the same entry
 			 */
 
-			const requestHashes: SyncableKey[] = [];
-			const from: Set<string> = new Set();
-			const now = Date.now();
-			for (const [key, value] of this.syncInFlightQueue) {
-				if (this.closed) {
-					return;
-				}
+			if (!isOpenLifecycleActive()) {
+				return;
+			}
+			try {
+				const requestHashes: SyncableKey[] = [];
+				const from: Set<string> = new Set();
+				const now = Date.now();
+				for (const [key] of this.syncInFlightQueue) {
+					if (!isOpenLifecycleActive()) {
+						return;
+					}
 
-				const has = await this.checkHasCoordinateOrHash(key);
-
-				if (!has) {
-					if (value.length === 0) {
-						// No remaining peers to ask; drop the pending key to avoid leaking.
-						this.clearSyncProcessKey(key);
+					const has = await this.checkHasCoordinateOrHash(key);
+					if (!isOpenLifecycleActive()) {
+						return;
+					}
+					const value = this.syncInFlightQueue.get(key);
+					if (!value) {
 						continue;
 					}
 
-					// Ask one peer per key per loop. If a previous request is still considered
-					// "recent", wait until the retry window elapses.
-					const candidate = value[0]!;
-					const publicKeyHash = candidate.hashcode();
-					const inflightTimestamp = this.syncInFlight
-						.get(publicKeyHash)
-						?.get(key)?.timestamp;
-					if (
-						inflightTimestamp == null ||
-						now - inflightTimestamp >= SIMPLE_SYNC_RETRY_AFTER_MS
-					) {
-						requestHashes.push(key);
-						from.add(publicKeyHash);
-						if (value.length > 1) {
-							// Rotate for fairness across multiple possible sources.
-							value.push(value.shift()!);
+					if (!has) {
+						if (value.length === 0) {
+							this.clearSyncProcessKey(key);
+							continue;
 						}
-					}
-				} else {
-					this.clearSyncProcessKey(key);
-				}
-			}
 
-			const nowMin10s = +new Date() - 2e4;
-			for (const [key, map] of this.syncInFlight) {
-				// cleanup "old" missing syncs
-				for (const [hash, { timestamp }] of map) {
-					if (timestamp < nowMin10s) {
-						map.delete(hash);
+						const candidate = value[0]!;
+						const publicKeyHash = candidate.hashcode();
+						const inflightTimestamp = this.syncInFlight
+							.get(publicKeyHash)
+							?.get(key)?.timestamp;
+						if (
+							inflightTimestamp == null ||
+							now - inflightTimestamp >= SIMPLE_SYNC_RETRY_AFTER_MS
+						) {
+							requestHashes.push(key);
+							from.add(publicKeyHash);
+							if (value.length > 1) {
+								value.push(value.shift()!);
+							}
+						}
+					} else {
+						this.clearSyncProcessKey(key);
 					}
 				}
-				if (map.size === 0) {
-					this.syncInFlight.delete(key);
-				}
-			}
-			this.requestSync(requestHashes, from).finally(() => {
-				if (this.closed) {
+
+				if (!isOpenLifecycleActive()) {
 					return;
 				}
-				this.syncMoreInterval = setTimeout(requestSyncLoop, 3e3);
-			});
+				const nowMin10s = +new Date() - 2e4;
+				for (const [key, map] of this.syncInFlight) {
+					for (const [hash, { timestamp }] of map) {
+						if (timestamp < nowMin10s) {
+							map.delete(hash);
+						}
+					}
+					if (map.size === 0) {
+						this.syncInFlight.delete(key);
+					}
+				}
+				if (!isOpenLifecycleActive()) {
+					return;
+				}
+				const targetEpochs = new Map<string, SyncDispatchTargetEpoch>();
+				for (const target of from) {
+					const epoch = this.syncDispatchTargetEpochs.get(target);
+					if (epoch) {
+						targetEpochs.set(target, epoch);
+					}
+				}
+				await this.requestSync(requestHashes, from, {
+					ownershipLifecycleController: openLifecycleController,
+					targetEpochs,
+					createTargetEpochs: false,
+				});
+				if (!isOpenLifecycleActive()) {
+					return;
+				}
+			} catch {
+				if (!isOpenLifecycleActive()) {
+					return;
+				}
+				// Retry on the next interval; the rejection is deliberately observed.
+			}
+			scheduleRequestSyncLoop();
 		};
 
-		requestSyncLoop();
+		void requestSyncLoop().catch(() => {
+			// Defensive observation for failures outside the loop's best-effort body.
+		});
 	}
 
 	async close() {
 		this.closed = true;
+		this.syncDispatchLifecycleController.abort();
+		this.syncDispatchTargetEpochs.clear();
 		this.syncInFlightQueue.clear();
 		this.syncInFlightQueueInverted.clear();
 		this.syncInFlight.clear();
 		this.recentlySentExchangeHeads.clear();
+		this.clearPendingMaybeSyncResponses();
 		for (const sessionId of [...this.repairSessions.keys()]) {
 			this.finalizeRepairSession(sessionId, false);
 		}
@@ -1472,8 +2482,25 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		return this.clearSyncProcessPublicKeyHash(publicKeyHash);
 	}
 	private clearSyncProcessPublicKeyHash(publicKeyHash: string) {
+		this.syncDispatchTargetEpochs.delete(publicKeyHash);
+		for (const targetLifecycle of [
+			...(this.syncDispatchTargets.get(publicKeyHash) ?? []),
+		]) {
+			if (targetLifecycle.lifecycle.abortAllOnTargetDisconnect) {
+				this.abortSyncDispatchLifecycle(
+					targetLifecycle.lifecycle,
+					new Error("sync target disconnected"),
+				);
+			} else {
+				this.abortSyncDispatchTarget(
+					targetLifecycle,
+					new Error("sync target disconnected"),
+				);
+			}
+		}
 		this.syncInFlight.delete(publicKeyHash);
 		this.recentlySentExchangeHeads.delete(publicKeyHash);
+		this.clearPendingMaybeSyncResponses(publicKeyHash);
 		const map = this.syncInFlightQueueInverted.get(publicKeyHash);
 		if (map) {
 			for (const hash of map) {

--- a/packages/programs/data/shared-log/test/delivery.spec.ts
+++ b/packages/programs/data/shared-log/test/delivery.spec.ts
@@ -11,7 +11,10 @@ import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
 import pDefer from "p-defer";
 import { Peerbit } from "peerbit";
-import { ExchangeHeadsMessage } from "../src/exchange-heads.js";
+import {
+	EXCHANGE_HEADS_REPAIR_HINT,
+	ExchangeHeadsMessage,
+} from "../src/exchange-heads.js";
 import { NoPeersError } from "../src/index.js";
 import { EventStore } from "./utils/stores/index.js";
 
@@ -22,6 +25,16 @@ type DeliveryPeerServices = TestSession["peers"][number]["services"] & {
 const getDeliveryServices = (
 	peer: TestSession["peers"][number],
 ): DeliveryPeerServices => peer.services as DeliveryPeerServices;
+
+const hasNonRepairExchangeHeadsForEntry = (
+	messages: ExchangeHeadsMessage<any>[],
+	hash: string,
+) =>
+	messages.some(
+		(message) =>
+			(message.reserved[0] & EXCHANGE_HEADS_REPAIR_HINT) === 0 &&
+			message.heads.some(({ entry }) => entry.hash === hash),
+	);
 
 describe("append delivery options", () => {
 	let session: TestSession;
@@ -517,17 +530,17 @@ describe("append delivery options", () => {
 			},
 		);
 
-		let exchangeHeadsRpcSends = 0;
+		const exchangeHeadsRpcMessages: ExchangeHeadsMessage<any>[] = [];
 		const rpcAny: any = db1.log.rpc;
 		const originalSend = rpcAny.send.bind(rpcAny);
 		rpcAny.send = async (...args: any[]) => {
 			if (args[0] instanceof ExchangeHeadsMessage) {
-				exchangeHeadsRpcSends++;
+				exchangeHeadsRpcMessages.push(args[0]);
 			}
 			return originalSend(...args);
 		};
 
-		await db1.add("fanout-delivery", { target: "all" });
+		const { entry } = await db1.add("fanout-delivery", { target: "all" });
 
 		await waitForResolved(async () => {
 			const values = (await db2.log.log.toArray()).map(
@@ -536,66 +549,70 @@ describe("append delivery options", () => {
 			expect(values).to.include("fanout-delivery");
 		});
 
-		expect(exchangeHeadsRpcSends).to.equal(0);
+		expect(
+			hasNonRepairExchangeHeadsForEntry(exchangeHeadsRpcMessages, entry.hash),
+		).to.equal(false);
 	});
 
-		it("resolves fanout root via topic-root-control-plane when root is omitted", async () => {
-			session = await TestSession.connected(2);
+	it("resolves fanout root via topic-root-control-plane when root is omitted", async () => {
+		session = await TestSession.connected(2);
 
-			const writerRoot = getDeliveryServices(session.peers[0]).fanout.publicKeyHash;
-			// Configure a deterministic root for this log topic without mutating the
-			// pubsub shard-root candidate set (which can otherwise break RPC delivery).
-			const store = new EventStore<string, any>();
-			const topic = store.log.topic;
-			for (const peer of session.peers) {
-				const plane = getDeliveryServices(peer).fanout.topicRootControlPlane;
-				expect(plane, "expected fanout to expose topicRootControlPlane").to.exist;
-				plane.setTopicRoot(topic, writerRoot);
-				expect(await plane.resolveTopicRoot(topic)).to.equal(writerRoot);
-			}
+		const writerRoot = getDeliveryServices(session.peers[0]).fanout
+			.publicKeyHash;
+		// Configure a deterministic root for this log topic without mutating the
+		// pubsub shard-root candidate set (which can otherwise break RPC delivery).
+		const store = new EventStore<string, any>();
+		const topic = store.log.topic;
+		for (const peer of session.peers) {
+			const plane = getDeliveryServices(peer).fanout.topicRootControlPlane;
+			expect(plane, "expected fanout to expose topicRootControlPlane").to.exist;
+			plane.setTopicRoot(topic, writerRoot);
+			expect(await plane.resolveTopicRoot(topic)).to.equal(writerRoot);
+		}
 
-			const fanout = {
-				channel: {
-					msgRate: 10,
+		const fanout = {
+			channel: {
+				msgRate: 10,
 				msgSize: 256,
 				uploadLimitBps: 1_000_000,
 				maxChildren: 8,
 				repair: true,
-				},
-				join: { timeoutMs: 10_000 },
-			};
+			},
+			join: { timeoutMs: 10_000 },
+		};
 
-			const db1 = await session.peers[0].open(store, {
-				args: { fanout },
-			});
-			const db2 = await EventStore.open<EventStore<string, any>>(
-				db1.address!,
+		const db1 = await session.peers[0].open(store, {
+			args: { fanout },
+		});
+		const db2 = await EventStore.open<EventStore<string, any>>(
+			db1.address!,
 			session.peers[1],
 			{
 				args: { fanout },
-				},
-			);
+			},
+		);
 
-			await waitForResolved(async () => {
-				const ch: any = (db1.log as any)._fanoutChannel;
-				expect(ch, "expected shared-log to open a fanout channel").to.exist;
-				const peers = ch.getPeerHashes({ includeSelf: true });
-				expect(peers, "expected fanout overlay to include remote peer").to.include(
-					session.peers[1].identity.publicKey.hashcode(),
-				);
-			});
+		await waitForResolved(async () => {
+			const ch: any = (db1.log as any)._fanoutChannel;
+			expect(ch, "expected shared-log to open a fanout channel").to.exist;
+			const peers = ch.getPeerHashes({ includeSelf: true });
+			expect(
+				peers,
+				"expected fanout overlay to include remote peer",
+			).to.include(session.peers[1].identity.publicKey.hashcode());
+		});
 
-			let exchangeHeadsRpcSends = 0;
-			const rpcAny: any = db1.log.rpc;
-			const originalSend = rpcAny.send.bind(rpcAny);
-			rpcAny.send = async (...args: any[]) => {
+		const exchangeHeadsRpcMessages: ExchangeHeadsMessage<any>[] = [];
+		const rpcAny: any = db1.log.rpc;
+		const originalSend = rpcAny.send.bind(rpcAny);
+		rpcAny.send = async (...args: any[]) => {
 			if (args[0] instanceof ExchangeHeadsMessage) {
-				exchangeHeadsRpcSends++;
+				exchangeHeadsRpcMessages.push(args[0]);
 			}
 			return originalSend(...args);
 		};
 
-		await db1.add("fanout-root-auto", { target: "all" });
+		const { entry } = await db1.add("fanout-root-auto", { target: "all" });
 
 		await waitForResolved(async () => {
 			const values = (await db2.log.log.toArray()).map(
@@ -604,7 +621,9 @@ describe("append delivery options", () => {
 			expect(values).to.include("fanout-root-auto");
 		});
 
-		expect(exchangeHeadsRpcSends).to.equal(0);
+		expect(
+			hasNonRepairExchangeHeadsForEntry(exchangeHeadsRpcMessages, entry.hash),
+		).to.equal(false);
 	});
 
 	it("does not fall back to rpc on target=all when a fanout member drops", async () => {
@@ -633,30 +652,34 @@ describe("append delivery options", () => {
 				args: { fanout },
 			},
 		);
-		await EventStore.open<EventStore<string, any>>(db1.address!, session.peers[2], {
-			args: { fanout },
-		});
+		await EventStore.open<EventStore<string, any>>(
+			db1.address!,
+			session.peers[2],
+			{
+				args: { fanout },
+			},
+		);
 
 		const fanoutChannel: any = (db1.log as any)._fanoutChannel;
 		await waitForResolved(() => {
 			const peers = new Set(fanoutChannel.getPeerHashes());
-			expect(peers.has(session.peers[1].identity.publicKey.hashcode())).to.equal(
-				true,
-			);
+			expect(
+				peers.has(session.peers[1].identity.publicKey.hashcode()),
+			).to.equal(true);
 		});
 
-		let exchangeHeadsRpcSends = 0;
+		const exchangeHeadsRpcMessages: ExchangeHeadsMessage<any>[] = [];
 		const rpcAny: any = db1.log.rpc;
 		const originalSend = rpcAny.send.bind(rpcAny);
 		rpcAny.send = async (...args: any[]) => {
 			if (args[0] instanceof ExchangeHeadsMessage) {
-				exchangeHeadsRpcSends++;
+				exchangeHeadsRpcMessages.push(args[0]);
 			}
 			return originalSend(...args);
 		};
 
 		await session.peers[2].stop();
-		await db1.add("fanout-churn", { target: "all" });
+		const { entry } = await db1.add("fanout-churn", { target: "all" });
 
 		await waitForResolved(
 			async () => {
@@ -668,7 +691,9 @@ describe("append delivery options", () => {
 			{ timeout: 30_000 },
 		);
 
-		expect(exchangeHeadsRpcSends).to.equal(0);
+		expect(
+			hasNonRepairExchangeHeadsForEntry(exchangeHeadsRpcMessages, entry.hash),
+		).to.equal(false);
 	});
 
 	it("does not fall back to rpc when fanout publish fails", async () => {
@@ -698,7 +723,10 @@ describe("append delivery options", () => {
 		const rpcAny: any = db1.log.rpc;
 		const originalSend = rpcAny.send.bind(rpcAny);
 		rpcAny.send = async (...args: any[]) => {
-			if (args[0] instanceof ExchangeHeadsMessage) {
+			if (
+				args[0] instanceof ExchangeHeadsMessage &&
+				(args[0].reserved[0] & EXCHANGE_HEADS_REPAIR_HINT) === 0
+			) {
 				exchangeHeadsRpcSends++;
 			}
 			return originalSend(...args);

--- a/packages/programs/data/shared-log/test/events.spec.ts
+++ b/packages/programs/data/shared-log/test/events.spec.ts
@@ -1671,6 +1671,238 @@ describe("events", () => {
 		}
 	});
 
+	it("does not let an authorized adaptive rebalance resurrect ownership after full unreplication", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const [currentRange] = await db.log.replicate({
+			factor: 0.2,
+			offset: 0.1,
+		});
+		log._isAdaptiveReplicating = true;
+		log.setupDebouncedRebalancing({ limits: { interval: 60_000 } });
+
+		const secondAuthorizationStarted = pDefer<void>();
+		const releaseSecondAuthorization = pDefer<void>();
+		let authorizationCalls = 0;
+		log._isTrustedReplicator = async () => {
+			authorizationCalls++;
+			if (authorizationCalls === 2) {
+				secondAuthorizationStarted.resolve();
+				await releaseSecondAuthorization.promise;
+			}
+			return true;
+		};
+		const getMemoryUsage = sinon.stub(log, "getMemoryUsage").resolves(0);
+		const getDynamicRange = sinon
+			.stub(log, "getDynamicRange")
+			.resolves(currentRange);
+		const calculateTotalParticipation = sinon
+			.stub(log, "calculateTotalParticipation")
+			.resolves(currentRange.widthNormalized);
+		const step = sinon
+			.stub(log.replicationController, "step")
+			.returns(Math.min(1, currentRange.widthNormalized + 0.25));
+		const ensureCoordinates = sinon
+			.stub(log, "ensureCurrentHeadCoordinatesIndexed")
+			.resolves();
+		const send = sinon.stub(log.rpc, "send").resolves();
+
+		try {
+			const balancing = log.rebalanceParticipation();
+			await secondAuthorizationStarted.promise;
+
+			// The rebalance has passed its outer role checks and is delayed in the
+			// authorization path immediately before it queues its range mutation.
+			// Full unreplication must invalidate that admitted planner.
+			await db.log.unreplicate();
+			expect(log._isReplicating).to.be.false;
+			expect(log._isAdaptiveReplicating).to.be.false;
+			expect(await db.log.countReplicationSegments()).to.equal(0);
+
+			releaseSecondAuthorization.resolve();
+			expect(await balancing).to.equal(false);
+			expect(await db.log.countReplicationSegments()).to.equal(0);
+			expect(authorizationCalls).to.equal(2);
+		} finally {
+			releaseSecondAuthorization.resolve();
+			getMemoryUsage.restore();
+			getDynamicRange.restore();
+			calculateTotalParticipation.restore();
+			step.restore();
+			ensureCoordinates.restore();
+			send.restore();
+			log.rebalanceParticipationDebounced?.close();
+		}
+	});
+
+	for (const fixedReplacement of [
+		{
+			name: "explicit fixed reset",
+			range: { factor: 0.3, offset: 0.6 },
+			options: { reset: true, rebalance: false },
+		},
+		{
+			name: "implicit fixed reset",
+			range: { factor: 0.3 },
+			options: { rebalance: false },
+		},
+	]) {
+		it(`does not let an authorized adaptive rebalance augment an ${fixedReplacement.name}`, async () => {
+			const { db, log } = await openDisconnectedLog(1);
+			const [currentRange] = await db.log.replicate({
+				factor: 0.2,
+				offset: 0.1,
+			});
+			log._isAdaptiveReplicating = true;
+			log.setupDebouncedRebalancing({ limits: { interval: 60_000 } });
+
+			const secondAuthorizationStarted = pDefer<void>();
+			const releaseSecondAuthorization = pDefer<void>();
+			let authorizationCalls = 0;
+			log._isTrustedReplicator = async () => {
+				authorizationCalls++;
+				if (authorizationCalls === 2) {
+					secondAuthorizationStarted.resolve();
+					await releaseSecondAuthorization.promise;
+				}
+				return true;
+			};
+			const getMemoryUsage = sinon.stub(log, "getMemoryUsage").resolves(0);
+			const getDynamicRange = sinon
+				.stub(log, "getDynamicRange")
+				.resolves(currentRange);
+			const calculateTotalParticipation = sinon
+				.stub(log, "calculateTotalParticipation")
+				.resolves(currentRange.widthNormalized);
+			const step = sinon
+				.stub(log.replicationController, "step")
+				.returns(Math.min(1, currentRange.widthNormalized + 0.25));
+			const ensureCoordinates = sinon
+				.stub(log, "ensureCurrentHeadCoordinatesIndexed")
+				.resolves();
+			const send = sinon.stub(log.rpc, "send").resolves();
+
+			try {
+				const balancing = log.rebalanceParticipation();
+				await secondAuthorizationStarted.promise;
+
+				// The adaptive update is authorized and delayed immediately before its
+				// mutation. A newer public fixed replacement must fence that stale
+				// output even though the store remains open.
+				const [fixedRange] = await db.log.replicate(
+					fixedReplacement.range,
+					fixedReplacement.options,
+				);
+				expect(log._isReplicating).to.be.true;
+				expect(log._isAdaptiveReplicating).to.be.false;
+				let durable = await db.log.getMyReplicationSegments();
+				expect(durable).to.have.length(1);
+				expect(durable[0].rangeHash).to.equal(fixedRange.rangeHash);
+
+				releaseSecondAuthorization.resolve();
+				expect(await balancing).to.equal(false);
+				durable = await db.log.getMyReplicationSegments();
+				expect(durable).to.have.length(1);
+				expect(durable[0].rangeHash).to.equal(fixedRange.rangeHash);
+				expect(authorizationCalls).to.equal(3);
+			} finally {
+				releaseSecondAuthorization.resolve();
+				getMemoryUsage.restore();
+				getDynamicRange.restore();
+				calculateTotalParticipation.restore();
+				step.restore();
+				ensureCoordinates.restore();
+				send.restore();
+				log.rebalanceParticipationDebounced?.close();
+			}
+		});
+	}
+
+	it("orders a delayed adaptive Added announcement before the authoritative empty snapshot", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const [currentRange] = await db.log.replicate({
+			factor: 0.2,
+			offset: 0.1,
+		});
+		log._isAdaptiveReplicating = true;
+		log.setupDebouncedRebalancing({ limits: { interval: 60_000 } });
+
+		log._isTrustedReplicator = async () => true;
+		const getMemoryUsage = sinon.stub(log, "getMemoryUsage").resolves(0);
+		const getDynamicRange = sinon
+			.stub(log, "getDynamicRange")
+			.resolves(currentRange);
+		const calculateTotalParticipation = sinon
+			.stub(log, "calculateTotalParticipation")
+			.resolves(currentRange.widthNormalized);
+		const step = sinon
+			.stub(log.replicationController, "step")
+			.returns(Math.min(1, currentRange.widthNormalized + 0.25));
+		const ensureCoordinates = sinon
+			.stub(log, "ensureCurrentHeadCoordinatesIndexed")
+			.resolves();
+		const addedStarted = pDefer<void>();
+		const releaseAdded = pDefer<void>();
+		const announcements: unknown[] = [];
+		const send = sinon.stub(log.rpc, "send").callsFake(async (message) => {
+			announcements.push(message);
+			if (message instanceof AddedReplicationSegmentMessage) {
+				addedStarted.resolve();
+				await releaseAdded.promise;
+			}
+		});
+
+		try {
+			const balancing = log.rebalanceParticipation();
+			await addedStarted.promise;
+			expect(
+				announcements.filter(
+					(message) => message instanceof AddedReplicationSegmentMessage,
+				),
+			).to.have.length(1);
+
+			const unreplicating = db.log.unreplicate();
+			await waitForResolved(
+				async () => {
+					expect(await db.log.countReplicationSegments()).to.equal(0);
+				},
+				{ timeout: 2_000, delayInterval: 5 },
+			);
+			expect(
+				announcements.filter(
+					(message) => message instanceof AllReplicatingSegmentsMessage,
+				),
+			).to.have.length(0);
+
+			releaseAdded.resolve();
+			expect(await balancing).to.equal(false);
+			await unreplicating;
+
+			const ownershipAnnouncements = announcements.filter(
+				(message) =>
+					message instanceof AddedReplicationSegmentMessage ||
+					message instanceof AllReplicatingSegmentsMessage,
+			);
+			expect(ownershipAnnouncements[0]).to.be.instanceOf(
+				AddedReplicationSegmentMessage,
+			);
+			expect(ownershipAnnouncements[1]).to.be.instanceOf(
+				AllReplicatingSegmentsMessage,
+			);
+			expect(
+				(ownershipAnnouncements[1] as AllReplicatingSegmentsMessage).segments,
+			).to.have.length(0);
+		} finally {
+			releaseAdded.resolve();
+			getMemoryUsage.restore();
+			getDynamicRange.restore();
+			calculateTotalParticipation.restore();
+			step.restore();
+			ensureCoordinates.restore();
+			send.restore();
+			log.rebalanceParticipationDebounced?.close();
+		}
+	});
+
 	it("captures append ownership before the lower append can cross reopen", async () => {
 		const { db, log } = await openDisconnectedLog(1);
 		const { entry } = await db.add("append-generation-seed");
@@ -3976,9 +4208,7 @@ describe("events", () => {
 		const replicationIndex = db1.log.replicationIndex as any;
 		await waitForResolved(async () => {
 			expect(
-				await replicationIndex
-					.iterate({ query: { hash: remoteHash } })
-					.all(),
+				await replicationIndex.iterate({ query: { hash: remoteHash } }).all(),
 			).to.have.length.greaterThan(0);
 			expect(db1.log.uniqueReplicators.has(remoteHash)).to.be.true;
 		});
@@ -4035,9 +4265,7 @@ describe("events", () => {
 			await Promise.all([oldUnsubscribe, reconnect]);
 			await waitForResolved(async () => {
 				expect(
-					await replicationIndex
-						.iterate({ query: { hash: remoteHash } })
-						.all(),
+					await replicationIndex.iterate({ query: { hash: remoteHash } }).all(),
 				).to.have.length.greaterThan(0);
 				expect(log.uniqueReplicators.has(remoteHash)).to.be.true;
 				expect(log._replicatorJoinEmitted.has(remoteHash)).to.be.true;
@@ -4058,9 +4286,7 @@ describe("events", () => {
 			// complete removal, including sync-related cleanup and one leave event.
 			await log._onUnsubscription(unsubscribeEvent);
 			expect(
-				await replicationIndex
-					.iterate({ query: { hash: remoteHash } })
-					.all(),
+				await replicationIndex.iterate({ query: { hash: remoteHash } }).all(),
 			).to.have.length(0);
 			expect(log.uniqueReplicators.has(remoteHash)).to.be.false;
 			expect(log._replicatorJoinEmitted.has(remoteHash)).to.be.false;
@@ -4093,9 +4319,7 @@ describe("events", () => {
 		const replicationIndex = db1.log.replicationIndex as any;
 		await waitForResolved(async () => {
 			expect(
-				await replicationIndex
-					.iterate({ query: { hash: remoteHash } })
-					.all(),
+				await replicationIndex.iterate({ query: { hash: remoteHash } }).all(),
 			).to.have.length.greaterThan(0);
 			expect(db1.log.uniqueReplicators.has(remoteHash)).to.be.true;
 		});
@@ -4153,9 +4377,7 @@ describe("events", () => {
 			]);
 
 			expect(
-				await replicationIndex
-					.iterate({ query: { hash: remoteHash } })
-					.all(),
+				await replicationIndex.iterate({ query: { hash: remoteHash } }).all(),
 			).to.have.length(0);
 			expect(log.uniqueReplicators.has(remoteHash)).to.be.false;
 			expect(log._replicatorJoinEmitted.has(remoteHash)).to.be.false;
@@ -4196,19 +4418,17 @@ describe("events", () => {
 
 		const blockerStarted = pDefer<void>();
 		const releaseBlocker = pDefer<void>();
-		const blocker = log.withReplicationInfoApplyQueue(
-			remoteHash,
-			async () => {
-				blockerStarted.resolve();
-				await releaseBlocker.promise;
-			},
-		);
+		const blocker = log.withReplicationInfoApplyQueue(remoteHash, async () => {
+			blockerStarted.resolve();
+			await releaseBlocker.promise;
+		});
 		await blockerStarted.promise;
 
 		const cleanupStarted = pDefer<void>();
 		const releaseCleanup = pDefer<void>();
-		const originalDisconnect =
-			log.syncronizer.onPeerDisconnected.bind(log.syncronizer);
+		const originalDisconnect = log.syncronizer.onPeerDisconnected.bind(
+			log.syncronizer,
+		);
 		const disconnected = sinon
 			.stub(log.syncronizer, "onPeerDisconnected")
 			.callsFake(async (...args: unknown[]) => {
@@ -4234,9 +4454,9 @@ describe("events", () => {
 				._onSubscription({
 					detail: { from: remoteKey, topics: [db1.log.topic] },
 				})
-					.finally(() => {
-						reconnectSettled = true;
-					});
+				.finally(() => {
+					reconnectSettled = true;
+				});
 			releaseBlocker.resolve();
 			await cleanupStarted.promise;
 			expect(log._receiveCleanupGateByPeer.has(remoteHash)).to.be.true;
@@ -4302,8 +4522,9 @@ describe("events", () => {
 		});
 		const synchronizerEntered = pDefer<void>();
 		const releaseSynchronizer = pDefer<void>();
-		const originalSynchronizerOnMessage =
-			log.syncronizer.onMessage.bind(log.syncronizer);
+		const originalSynchronizerOnMessage = log.syncronizer.onMessage.bind(
+			log.syncronizer,
+		);
 		const synchronizer = sinon
 			.stub(log.syncronizer, "onMessage")
 			.callsFake(async (message: unknown, context: unknown) => {

--- a/packages/programs/data/shared-log/test/events.spec.ts
+++ b/packages/programs/data/shared-log/test/events.spec.ts
@@ -5,8 +5,13 @@ import { expect } from "chai";
 import pDefer from "p-defer";
 import sinon from "sinon";
 import { v4 as uuid } from "uuid";
-import { SyncCapabilitiesMessage } from "../src/exchange-heads.js";
 import {
+	ExchangeHeadsMessage,
+	SyncCapabilitiesMessage,
+} from "../src/exchange-heads.js";
+import { ReplicationIntent } from "../src/ranges.js";
+import {
+	AddedReplicationSegmentMessage,
 	AllReplicatingSegmentsMessage,
 	StoppedReplicating,
 } from "../src/replication.js";
@@ -17,6 +22,3717 @@ describe("events", () => {
 
 	afterEach(async () => {
 		await session.stop();
+	});
+
+	const openDisconnectedLog = async (peers = 2) => {
+		session = await TestSession.disconnected(peers);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		return {
+			db,
+			log: db.log as any,
+			replicationIndex: db.log.replicationIndex as any,
+		};
+	};
+
+	const makeReplicationRange = (
+		log: any,
+		properties: {
+			id: Uint8Array;
+			ownerHash: string;
+			offset: number;
+			mode?: ReplicationIntent;
+			timestamp?: bigint;
+		},
+	) =>
+		new log.indexableDomain.constructorRange({
+			id: properties.id,
+			offset: log.indexableDomain.numbers.denormalize(properties.offset),
+			width: log.indexableDomain.numbers.denormalize(0.2),
+			publicKeyHash: properties.ownerHash,
+			mode: properties.mode ?? ReplicationIntent.NonStrict,
+			timestamp: properties.timestamp ?? 1n,
+		});
+
+	const observeRejectedReplicationMutation = (
+		log: any,
+		options?: { allowLifecycleClear?: boolean },
+	) => {
+		const emittedEvents: { type: string; hash: string }[] = [];
+		const eventTypes = [
+			"replication:change",
+			"replicator:join",
+			"replicator:mature",
+			"replicator:leave",
+		];
+		const listeners = eventTypes.map((type) => {
+			const listener = (event: any) => {
+				emittedEvents.push({
+					type,
+					hash: event.detail.publicKey.hashcode(),
+				});
+			};
+			log.events.addEventListener(type, listener);
+			return { type, listener };
+		});
+		const debouncedChanges = sinon.spy(log.replicationChangeDebounceFn, "add");
+		const membershipAdd = sinon.spy(log.uniqueReplicators, "add");
+		const membershipDelete = sinon.spy(log.uniqueReplicators, "delete");
+		const emittedMembershipAdd = sinon.spy(log._replicatorJoinEmitted, "add");
+		const emittedMembershipDelete = sinon.spy(
+			log._replicatorJoinEmitted,
+			"delete",
+		);
+		const membershipBefore = [...log.uniqueReplicators].sort();
+		const emittedMembershipBefore = [...log._replicatorJoinEmitted].sort();
+		return {
+			assertNoEffects: () => {
+				expect(emittedEvents).to.deep.equal([]);
+				expect(debouncedChanges.called).to.be.false;
+				expect(membershipAdd.called).to.be.false;
+				expect(membershipDelete.called).to.be.false;
+				expect(emittedMembershipAdd.called).to.be.false;
+				expect(emittedMembershipDelete.called).to.be.false;
+				if (!options?.allowLifecycleClear) {
+					expect([...log.uniqueReplicators].sort()).to.deep.equal(
+						membershipBefore,
+					);
+					expect([...log._replicatorJoinEmitted].sort()).to.deep.equal(
+						emittedMembershipBefore,
+					);
+				}
+			},
+			restore: () => {
+				for (const { type, listener } of listeners) {
+					log.events.removeEventListener(type, listener);
+				}
+				debouncedChanges.restore();
+				membershipAdd.restore();
+				membershipDelete.restore();
+				emittedMembershipAdd.restore();
+				emittedMembershipDelete.restore();
+			},
+		};
+	};
+
+	it("announces the authoritative empty snapshot after a reset put commits then throws", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(1);
+		const selfKey = session.peers[0].identity.publicKey;
+		const selfHash = selfKey.hashcode();
+		const numbers = log.indexableDomain.numbers;
+		const makeRange = (offset: number, id: number) =>
+			new log.indexableDomain.constructorRange({
+				id: new Uint8Array([id]),
+				offset: numbers.denormalize(offset),
+				width: numbers.denormalize(0.2),
+				publicKeyHash: selfHash,
+				timestamp: BigInt(id),
+			});
+		const previous = makeRange(0.1, 1);
+		const replacement = makeRange(0.6, 2);
+		await log.addReplicationRange([previous], selfKey, {
+			checkDuplicates: false,
+			rebalance: false,
+		});
+
+		const durableFailure = new Error("forced reset put commit-then-throw");
+		const originalPut = replicationIndex.put.bind(replicationIndex);
+		const put = sinon.stub(replicationIndex, "put").callsFake((async (
+			value: any,
+			options?: any,
+		) => {
+			const result = await originalPut(value, options);
+			if (value === replacement) {
+				throw durableFailure;
+			}
+			return result;
+		}) as any);
+		const sent: unknown[] = [];
+		const send = sinon.stub(log.rpc, "send").callsFake(async (message: any) => {
+			sent.push(message);
+			return [] as any;
+		});
+
+		try {
+			await expect(
+				log.startAnnounceReplicating([replacement], {
+					reset: true,
+					checkDuplicates: false,
+					rebalance: false,
+				}),
+			).to.be.rejectedWith(durableFailure.message);
+
+			expect(
+				await replicationIndex.count({ query: { hash: selfHash } }),
+			).to.equal(0);
+			const snapshots = sent.filter(
+				(message) => message instanceof AllReplicatingSegmentsMessage,
+			) as AllReplicatingSegmentsMessage[];
+			expect(snapshots).to.have.length(1);
+			expect(snapshots[0].segments).to.deep.equal([]);
+			expect(log._replicationRangeMutationFailure).to.be.undefined;
+		} finally {
+			put.restore();
+			send.restore();
+		}
+	});
+
+	it("emits leave before rejoin when a failed reset rollback confirms zero rows", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(2);
+		const ownerKey = session.peers[1].identity.publicKey;
+		const ownerHash = ownerKey.hashcode();
+		const lifecycle: string[] = [];
+		log.events.addEventListener("replicator:join", () => {
+			lifecycle.push("join");
+		});
+		log.events.addEventListener("replicator:leave", () => {
+			lifecycle.push("leave");
+		});
+		const initial = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash,
+			offset: 0.1,
+			timestamp: 1n,
+		});
+		await log.addReplicationRange([initial], ownerKey, {
+			checkDuplicates: false,
+			rebalance: false,
+		});
+		expect(lifecycle).to.deep.equal(["join"]);
+
+		const replacement = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash,
+			offset: 0.5,
+			timestamp: 2n,
+		});
+		const putFailure = new Error("forced reset replacement put failure");
+		const put = sinon.stub(replicationIndex, "put").rejects(putFailure);
+		try {
+			await expect(
+				log.addReplicationRange([replacement], ownerKey, {
+					reset: true,
+					checkDuplicates: false,
+					rebalance: false,
+				}),
+			).to.be.rejectedWith(putFailure.message);
+		} finally {
+			put.restore();
+		}
+
+		expect(
+			await replicationIndex.count({ query: { hash: ownerHash } }),
+		).to.equal(0);
+		expect(log.uniqueReplicators.has(ownerHash)).to.be.false;
+		expect(log._replicatorJoinEmitted.has(ownerHash)).to.be.false;
+		expect(lifecycle).to.deep.equal(["join", "leave"]);
+
+		const rejoined = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash,
+			offset: 0.8,
+			timestamp: 3n,
+		});
+		await log.addReplicationRange([rejoined], ownerKey, {
+			checkDuplicates: false,
+			rebalance: false,
+		});
+		expect(lifecycle).to.deep.equal(["join", "leave", "join"]);
+	});
+
+	it("emits leave only when an ambiguous reset deletion is confirmed empty", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(3);
+		const removedOwner = session.peers[1].identity.publicKey;
+		const retainedOwner = session.peers[2].identity.publicKey;
+		const makeOwnerRange = (
+			ownerKey: PublicSignKey,
+			offset: number,
+			timestamp: bigint,
+		) =>
+			makeReplicationRange(log, {
+				id: randomBytes(32),
+				ownerHash: ownerKey.hashcode(),
+				offset,
+				timestamp,
+			});
+		await log.addReplicationRange(
+			[makeOwnerRange(removedOwner, 0.1, 1n)],
+			removedOwner,
+			{ checkDuplicates: false, rebalance: false },
+		);
+		await log.addReplicationRange(
+			[makeOwnerRange(retainedOwner, 0.4, 1n)],
+			retainedOwner,
+			{ checkDuplicates: false, rebalance: false },
+		);
+		const leaves: string[] = [];
+		log.events.addEventListener("replicator:leave", (event: any) => {
+			leaves.push(event.detail.publicKey.hashcode());
+		});
+		const originalDel = replicationIndex.del.bind(replicationIndex);
+		const committedDeleteFailure = new Error(
+			"forced committed reset deletion failure",
+		);
+		const committedDelete = sinon
+			.stub(replicationIndex, "del")
+			.callsFake((async (...args: any[]) => {
+				await originalDel(...args);
+				throw committedDeleteFailure;
+			}) as any);
+		try {
+			await expect(
+				log.addReplicationRange(
+					[makeOwnerRange(removedOwner, 0.7, 2n)],
+					removedOwner,
+					{
+						reset: true,
+						checkDuplicates: false,
+						rebalance: false,
+					},
+				),
+			).to.be.rejectedWith(committedDeleteFailure.message);
+		} finally {
+			committedDelete.restore();
+		}
+
+		const retainedDeleteFailure = new Error(
+			"forced retained reset deletion failure",
+		);
+		const retainedDelete = sinon
+			.stub(replicationIndex, "del")
+			.rejects(retainedDeleteFailure);
+		try {
+			await expect(
+				log.addReplicationRange(
+					[makeOwnerRange(retainedOwner, 0.8, 2n)],
+					retainedOwner,
+					{
+						reset: true,
+						checkDuplicates: false,
+						rebalance: false,
+					},
+				),
+			).to.be.rejectedWith(retainedDeleteFailure.message);
+		} finally {
+			retainedDelete.restore();
+		}
+
+		expect(
+			await replicationIndex.count({
+				query: { hash: removedOwner.hashcode() },
+			}),
+		).to.equal(0);
+		expect(
+			await replicationIndex.count({
+				query: { hash: retainedOwner.hashcode() },
+			}),
+		).to.equal(1);
+		expect(log.uniqueReplicators.has(removedOwner.hashcode())).to.be.false;
+		expect(log.uniqueReplicators.has(retainedOwner.hashcode())).to.be.true;
+		expect(leaves).to.deep.equal([removedOwner.hashcode()]);
+	});
+
+	it("rejects a non-reset range id collision without replacing the existing owner", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(3);
+		const victimKey = session.peers[1].identity.publicKey;
+		const attackerKey = session.peers[2].identity.publicKey;
+		const sharedId = randomBytes(32);
+		const victimRange = makeReplicationRange(log, {
+			id: sharedId,
+			ownerHash: victimKey.hashcode(),
+			offset: 0.1,
+		});
+		await log.addReplicationRange([victimRange], victimKey, {
+			checkDuplicates: false,
+			rebalance: false,
+		});
+		const effects = observeRejectedReplicationMutation(log);
+		const collidingRange = makeReplicationRange(log, {
+			id: sharedId,
+			ownerHash: attackerKey.hashcode(),
+			offset: 0.6,
+			timestamp: 2n,
+		});
+
+		try {
+			await expect(
+				log.addReplicationRange([collidingRange], attackerKey, {
+					checkDuplicates: false,
+					rebalance: false,
+				}),
+			).to.be.rejectedWith(
+				"Replication range id is already owned by another replicator",
+			);
+
+			const durable = await replicationIndex.iterate().all();
+			expect(durable).to.have.length(1);
+			expect(durable[0].value.rangeHash).to.equal(victimRange.rangeHash);
+			expect(durable[0].value.hash).to.equal(victimKey.hashcode());
+			expect(log.uniqueReplicators.has(victimKey.hashcode())).to.be.true;
+			expect(log.uniqueReplicators.has(attackerKey.hashcode())).to.be.false;
+			effects.assertNoEffects();
+		} finally {
+			effects.restore();
+		}
+	});
+
+	it("rejects a reset range id collision before deleting the sender's prior ranges", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(3);
+		const victimKey = session.peers[1].identity.publicKey;
+		const attackerKey = session.peers[2].identity.publicKey;
+		const victimRange = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash: victimKey.hashcode(),
+			offset: 0.1,
+		});
+		const attackerPreviousRange = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash: attackerKey.hashcode(),
+			offset: 0.4,
+		});
+		await log.addReplicationRange([victimRange], victimKey, {
+			checkDuplicates: false,
+			rebalance: false,
+		});
+		await log.addReplicationRange([attackerPreviousRange], attackerKey, {
+			checkDuplicates: false,
+			rebalance: false,
+		});
+		const effects = observeRejectedReplicationMutation(log);
+		const collidingRange = makeReplicationRange(log, {
+			id: victimRange.id,
+			ownerHash: attackerKey.hashcode(),
+			offset: 0.7,
+			timestamp: 2n,
+		});
+
+		try {
+			await expect(
+				log.addReplicationRange([collidingRange], attackerKey, {
+					reset: true,
+					checkDuplicates: false,
+					rebalance: false,
+				}),
+			).to.be.rejectedWith(
+				"Replication range id is already owned by another replicator",
+			);
+
+			const durable = (await replicationIndex.iterate().all()).map(
+				(result: any) => result.value,
+			);
+			expect(durable.map((range: any) => range.rangeHash)).to.have.members([
+				victimRange.rangeHash,
+				attackerPreviousRange.rangeHash,
+			]);
+			expect(durable).to.have.length(2);
+			expect(log.uniqueReplicators.has(victimKey.hashcode())).to.be.true;
+			expect(log.uniqueReplicators.has(attackerKey.hashcode())).to.be.true;
+			effects.assertNoEffects();
+		} finally {
+			effects.restore();
+		}
+	});
+
+	it("rejects duplicate range ids before a reset can write or delete", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(2);
+		const ownerKey = session.peers[1].identity.publicKey;
+		const previousRange = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash: ownerKey.hashcode(),
+			offset: 0.1,
+		});
+		await log.addReplicationRange([previousRange], ownerKey, {
+			checkDuplicates: false,
+			rebalance: false,
+		});
+		const effects = observeRejectedReplicationMutation(log);
+		const duplicateId = randomBytes(32);
+		const duplicateRanges = [0.4, 0.7].map((offset, index) =>
+			makeReplicationRange(log, {
+				id: duplicateId,
+				ownerHash: ownerKey.hashcode(),
+				offset,
+				timestamp: BigInt(index + 2),
+			}),
+		);
+
+		try {
+			await expect(
+				log.addReplicationRange(duplicateRanges, ownerKey, {
+					reset: true,
+					checkDuplicates: false,
+					rebalance: false,
+				}),
+			).to.be.rejectedWith("Duplicate replication range id in announcement");
+
+			const durable = await replicationIndex.iterate().all();
+			expect(durable).to.have.length(1);
+			expect(durable[0].value.rangeHash).to.equal(previousRange.rangeHash);
+			effects.assertNoEffects();
+		} finally {
+			effects.restore();
+		}
+	});
+
+	it("accepts only an ordered legacy replacement pair and applies its final range", async () => {
+		const { db, log, replicationIndex } = await openDisconnectedLog(2);
+		const ownerKey = session.peers[1].identity.publicKey;
+		const ownerHash = ownerKey.hashcode();
+		const id = randomBytes(32);
+		const previous = makeReplicationRange(log, {
+			id,
+			ownerHash,
+			offset: 0.1,
+			timestamp: 1n,
+		});
+		const current = makeReplicationRange(log, {
+			id,
+			ownerHash,
+			offset: 0.5,
+			timestamp: 2n,
+		});
+		const unexpectedThird = makeReplicationRange(log, {
+			id,
+			ownerHash,
+			offset: 0.8,
+			timestamp: 3n,
+		});
+		const changes: string[] = [];
+		log.events.addEventListener("replication:change", (event: any) => {
+			changes.push(event.detail.publicKey.hashcode());
+		});
+		const receive = (segments: any[], timestamp: bigint) =>
+			db.log.onMessage(new AddedReplicationSegmentMessage({ segments }), {
+				from: ownerKey,
+				message: { header: { timestamp } },
+			} as any);
+		const pair = [previous.toReplicationRange(), current.toReplicationRange()];
+
+		await receive(pair, 10n);
+		let durable = (
+			await replicationIndex.iterate({ query: { hash: ownerHash } }).all()
+		).map((result: any) => result.value);
+		expect(durable).to.have.length(1);
+		expect(durable[0].rangeHash).to.equal(current.rangeHash);
+		expect(changes).to.deep.equal([ownerHash]);
+
+		await receive(pair, 11n);
+		durable = (
+			await replicationIndex.iterate({ query: { hash: ownerHash } }).all()
+		).map((result: any) => result.value);
+		expect(durable).to.have.length(1);
+		expect(durable[0].rangeHash).to.equal(current.rangeHash);
+		expect(changes).to.deep.equal([ownerHash]);
+
+		await receive([...pair, unexpectedThird.toReplicationRange()], 12n);
+		durable = (
+			await replicationIndex.iterate({ query: { hash: ownerHash } }).all()
+		).map((result: any) => result.value);
+		expect(durable).to.have.length(1);
+		expect(durable[0].rangeHash).to.equal(current.rangeHash);
+		expect(changes).to.deep.equal([ownerHash]);
+	});
+
+	it("rejects a forged range owner before a reset can write or delete", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(3);
+		const senderKey = session.peers[1].identity.publicKey;
+		const forgedOwnerHash = session.peers[2].identity.publicKey.hashcode();
+		const previousRange = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash: senderKey.hashcode(),
+			offset: 0.1,
+		});
+		await log.addReplicationRange([previousRange], senderKey, {
+			checkDuplicates: false,
+			rebalance: false,
+		});
+		const effects = observeRejectedReplicationMutation(log);
+		const forgedRange = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash: forgedOwnerHash,
+			offset: 0.6,
+			timestamp: 2n,
+		});
+
+		try {
+			await expect(
+				log.addReplicationRange([forgedRange], senderKey, {
+					reset: true,
+					checkDuplicates: false,
+					rebalance: false,
+				}),
+			).to.be.rejectedWith("Replication range owner mismatch");
+
+			const durable = await replicationIndex.iterate().all();
+			expect(durable).to.have.length(1);
+			expect(durable[0].value.rangeHash).to.equal(previousRange.rangeHash);
+			expect(log.uniqueReplicators.has(senderKey.hashcode())).to.be.true;
+			expect(log.uniqueReplicators.has(forgedOwnerHash)).to.be.false;
+			effects.assertNoEffects();
+		} finally {
+			effects.restore();
+		}
+	});
+
+	it("applies mode-only replacements but keeps timestamp-only announcements as no-ops", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(2);
+		const ownerKey = session.peers[1].identity.publicKey;
+		const ownerHash = ownerKey.hashcode();
+		const id = randomBytes(32);
+		const makeModeRange = (mode: ReplicationIntent, timestamp: bigint) =>
+			makeReplicationRange(log, {
+				id,
+				ownerHash,
+				offset: 0.25,
+				mode,
+				timestamp,
+			});
+		const initial = makeModeRange(ReplicationIntent.NonStrict, 1n);
+		await log.addReplicationRange([initial], ownerKey, {
+			checkDuplicates: false,
+			rebalance: false,
+		});
+		const replicationChanges: string[] = [];
+		log.events.addEventListener("replication:change", (event: any) => {
+			replicationChanges.push(event.detail.publicKey.hashcode());
+		});
+
+		const strict = makeModeRange(ReplicationIntent.Strict, 2n);
+		const nonResetDiffs = await log.addReplicationRange([strict], ownerKey, {
+			checkDuplicates: false,
+			rebalance: false,
+		});
+		expect(nonResetDiffs.map((diff: any) => diff.type)).to.deep.equal([
+			"replaced",
+			"added",
+		]);
+		let durable = (await replicationIndex.iterate().all())[0].value;
+		expect(durable.mode).to.equal(ReplicationIntent.Strict);
+		expect(durable.timestamp).to.equal(2n);
+
+		const nonStrict = makeModeRange(ReplicationIntent.NonStrict, 3n);
+		const resetDiffs = await log.addReplicationRange([nonStrict], ownerKey, {
+			reset: true,
+			checkDuplicates: false,
+			rebalance: false,
+		});
+		expect(resetDiffs.map((diff: any) => diff.type)).to.deep.equal([
+			"removed",
+			"added",
+		]);
+		durable = (await replicationIndex.iterate().all())[0].value;
+		expect(durable.mode).to.equal(ReplicationIntent.NonStrict);
+		expect(durable.timestamp).to.equal(3n);
+
+		const timestampOnlyNonReset = makeModeRange(
+			ReplicationIntent.NonStrict,
+			4n,
+		);
+		expect(
+			await log.addReplicationRange([timestampOnlyNonReset], ownerKey, {
+				checkDuplicates: false,
+				rebalance: false,
+			}),
+		).to.deep.equal([]);
+		const timestampOnlyReset = makeModeRange(ReplicationIntent.NonStrict, 5n);
+		expect(
+			await log.addReplicationRange([timestampOnlyReset], ownerKey, {
+				reset: true,
+				checkDuplicates: false,
+				rebalance: false,
+			}),
+		).to.deep.equal([]);
+		durable = (await replicationIndex.iterate().all())[0].value;
+		expect(durable.mode).to.equal(ReplicationIntent.NonStrict);
+		expect(durable.timestamp).to.equal(3n);
+		expect(replicationChanges).to.deep.equal([ownerHash, ownerHash]);
+	});
+
+	it("announces only the durable range after a non-reset replacement", async () => {
+		const { log } = await openDisconnectedLog(1);
+		const selfHash = session.peers[0].identity.publicKey.hashcode();
+		const id = randomBytes(32);
+		const initial = makeReplicationRange(log, {
+			id,
+			ownerHash: selfHash,
+			offset: 0.1,
+			timestamp: 1n,
+		});
+		const replacement = makeReplicationRange(log, {
+			id,
+			ownerHash: selfHash,
+			offset: 0.6,
+			timestamp: 2n,
+		});
+		const announced: unknown[] = [];
+		const announce = (message: unknown) => {
+			announced.push(message);
+		};
+
+		await log.startAnnounceReplicating([initial], {
+			checkDuplicates: false,
+			rebalance: false,
+			announce,
+		});
+		announced.length = 0;
+
+		await log.startAnnounceReplicating([replacement], {
+			checkDuplicates: false,
+			rebalance: false,
+			announce,
+		});
+
+		expect(announced).to.have.length(1);
+		expect(announced[0]).to.be.instanceOf(AddedReplicationSegmentMessage);
+		const segments = (announced[0] as AddedReplicationSegmentMessage).segments;
+		expect(segments).to.have.length(1);
+		expect(segments[0].id).to.deep.equal(id);
+		expect(segments[0].offset).to.equal(replacement.start1);
+		expect(segments[0].factor).to.equal(replacement.width);
+		expect(segments[0].timestamp).to.equal(replacement.timestamp);
+	});
+
+	it("recomputes the oldest timestamp once per durable reset phase before announcing", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(1);
+		const selfKey = session.peers[0].identity.publicKey;
+		const selfHash = selfKey.hashcode();
+		const previous = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash: selfHash,
+			offset: 0.1,
+			timestamp: 1n,
+		});
+		const replacement = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash: selfHash,
+			offset: 0.6,
+			timestamp: 2n,
+		});
+		await log.addReplicationRange([previous], selfKey, {
+			checkDuplicates: false,
+			rebalance: false,
+		});
+		const recomputeOldest = sinon.spy(log, "updateOldestTimestampFromIndex");
+		const announced: unknown[] = [];
+
+		try {
+			await log.startAnnounceReplicating([replacement], {
+				reset: true,
+				checkDuplicates: false,
+				rebalance: false,
+				announce: (message: unknown) => announced.push(message),
+			});
+
+			expect(recomputeOldest.callCount).to.equal(2);
+			expect(announced).to.have.length(1);
+			expect(announced[0]).to.be.instanceOf(AllReplicatingSegmentsMessage);
+			const snapshot = announced[0] as AllReplicatingSegmentsMessage;
+			expect(snapshot.segments).to.have.length(1);
+			expect(snapshot.segments[0].id).to.deep.equal(replacement.id);
+			const durable = await replicationIndex
+				.iterate({ query: { hash: selfHash } })
+				.all();
+			expect(durable).to.have.length(1);
+			expect(durable[0].value.rangeHash).to.equal(replacement.rangeHash);
+		} finally {
+			recomputeOldest.restore();
+		}
+	});
+
+	it("announces the authoritative snapshot when a merge removal precedes a failed replacement", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(1);
+		const selfKey = session.peers[0].identity.publicKey;
+		const selfHash = selfKey.hashcode();
+		const first = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash: selfHash,
+			offset: 0.1,
+			timestamp: 1n,
+		});
+		const removed = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash: selfHash,
+			offset: 0.6,
+			timestamp: 2n,
+		});
+		await log.addReplicationRange([first, removed], selfKey, {
+			checkDuplicates: false,
+			rebalance: false,
+		});
+		log.domain.canMerge = () => true;
+
+		const durableFailure = new Error("forced merged replacement put failure");
+		const originalPut = replicationIndex.put.bind(replicationIndex);
+		let failedReplacement = false;
+		const put = sinon.stub(replicationIndex, "put").callsFake((async (
+			value: any,
+			options?: any,
+		) => {
+			const result = await originalPut(value, options);
+			if (!failedReplacement) {
+				failedReplacement = true;
+				throw durableFailure;
+			}
+			return result;
+		}) as any);
+		const sent: unknown[] = [];
+		const send = sinon.stub(log.rpc, "send").callsFake(async (message: any) => {
+			sent.push(message);
+			return [] as any;
+		});
+		const rebalanceAdd = sinon.spy(log.replicationChangeDebounceFn, "add");
+
+		try {
+			await expect(
+				log._replicate(
+					{ offset: 0.3, factor: 0.2 },
+					{ mergeSegments: true, rebalance: true },
+				),
+			).to.be.rejectedWith(durableFailure.message);
+
+			expect(failedReplacement).to.be.true;
+			const durable = (
+				await replicationIndex.iterate({ query: { hash: selfHash } }).all()
+			).map((result: any) => result.value);
+			expect(durable).to.have.length(1);
+			expect(durable[0].rangeHash).to.equal(first.rangeHash);
+			expect(durable.some((range: any) => range.idString === removed.idString))
+				.to.be.false;
+			expect(
+				(await log.getMyReplicationSegments()).map(
+					(range: any) => range.rangeHash,
+				),
+			).to.deep.equal([first.rangeHash]);
+
+			const snapshots = sent.filter(
+				(message) => message instanceof AllReplicatingSegmentsMessage,
+			) as AllReplicatingSegmentsMessage[];
+			expect(snapshots).to.have.length(1);
+			expect(snapshots[0].segments).to.have.length(1);
+			expect(snapshots[0].segments[0].id).to.deep.equal(first.id);
+			expect(sent.some((message) => message instanceof StoppedReplicating)).to
+				.be.false;
+			const removedDiffs = rebalanceAdd
+				.getCalls()
+				.map((call) => call.args[0])
+				.filter((diff: any) => diff.type === "removed");
+			expect(removedDiffs).to.have.length(1);
+			expect(removedDiffs[0].range.rangeHash).to.equal(removed.rangeHash);
+			expect(log._replicationRangeMutationFailure).to.be.undefined;
+		} finally {
+			rebalanceAdd.restore();
+			put.restore();
+			send.restore();
+		}
+	});
+
+	it("queues a preliminary removal once when its delete commits then throws", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(1);
+		const selfKey = session.peers[0].identity.publicKey;
+		const selfHash = selfKey.hashcode();
+		const first = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash: selfHash,
+			offset: 0.1,
+			timestamp: 1n,
+		});
+		const removed = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash: selfHash,
+			offset: 0.6,
+			timestamp: 2n,
+		});
+		await log.addReplicationRange([first, removed], selfKey, {
+			checkDuplicates: false,
+			rebalance: false,
+		});
+		log.domain.canMerge = () => true;
+
+		const deletionFailure = new Error(
+			"forced committed preliminary removal failure",
+		);
+		const originalDel = replicationIndex.del.bind(replicationIndex);
+		const del = sinon.stub(replicationIndex, "del").callsFake((async (
+			...args: any[]
+		) => {
+			await originalDel(...args);
+			throw deletionFailure;
+		}) as any);
+		const rebalanceAdd = sinon.spy(log.replicationChangeDebounceFn, "add");
+		const sent: unknown[] = [];
+		const send = sinon.stub(log.rpc, "send").callsFake(async (message: any) => {
+			sent.push(message);
+			return [] as any;
+		});
+
+		try {
+			await expect(
+				log._replicate(
+					{ offset: 0.3, factor: 0.2 },
+					{ mergeSegments: true, rebalance: true },
+				),
+			).to.be.rejectedWith(deletionFailure.message);
+
+			const removedDiffs = rebalanceAdd
+				.getCalls()
+				.map((call) => call.args[0])
+				.filter((diff: any) => diff.type === "removed");
+			expect(removedDiffs).to.have.length(1);
+			expect(removedDiffs[0].range.rangeHash).to.equal(removed.rangeHash);
+			const snapshots = sent.filter(
+				(message) => message instanceof AllReplicatingSegmentsMessage,
+			) as AllReplicatingSegmentsMessage[];
+			expect(snapshots).to.have.length(1);
+			expect(snapshots[0].segments).to.have.length(1);
+			expect(snapshots[0].segments[0].id).to.deep.equal(first.id);
+		} finally {
+			send.restore();
+			rebalanceAdd.restore();
+			del.restore();
+		}
+	});
+
+	it("announces the current snapshot when post-write maturity bookkeeping fails", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(1);
+		const selfHash = session.peers[0].identity.publicKey.hashcode();
+		const range = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash: selfHash,
+			offset: 0.35,
+			timestamp: BigInt(Date.now()),
+		});
+		const minRoleAge = sinon.stub(log, "getDefaultMinRoleAge").resolves(60_000);
+		const bookkeepingFailure = new Error(
+			"forced post-write maturity bookkeeping failure",
+		);
+		const scheduleMaturity = sinon
+			.stub(log, "schedulePendingMaturity")
+			.throws(bookkeepingFailure);
+		const sent: unknown[] = [];
+		const send = sinon.stub(log.rpc, "send").callsFake(async (message: any) => {
+			sent.push(message);
+			return [] as any;
+		});
+
+		try {
+			await expect(
+				log.startAnnounceReplicating([range], {
+					checkDuplicates: false,
+					rebalance: false,
+				}),
+			).to.be.rejectedWith(bookkeepingFailure.message);
+
+			expect(scheduleMaturity.calledOnce).to.be.true;
+			const durable = await replicationIndex
+				.iterate({ query: { hash: selfHash } })
+				.all();
+			expect(durable).to.have.length(1);
+			expect(durable[0].value.rangeHash).to.equal(range.rangeHash);
+			const snapshots = sent.filter(
+				(message) => message instanceof AllReplicatingSegmentsMessage,
+			) as AllReplicatingSegmentsMessage[];
+			expect(snapshots).to.have.length(1);
+			expect(snapshots[0].segments).to.have.length(1);
+			expect(snapshots[0].segments[0].id).to.deep.equal(range.id);
+			expect(
+				sent.some(
+					(message) => message instanceof AddedReplicationSegmentMessage,
+				),
+			).to.be.false;
+		} finally {
+			send.restore();
+			scheduleMaturity.restore();
+			minRoleAge.restore();
+		}
+	});
+
+	it("poisons ownership instead of announcing an invalid persisted snapshot", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(2);
+		const selfKey = session.peers[0].identity.publicKey;
+		const selfHash = selfKey.hashcode();
+		const invalid = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash: selfHash,
+			offset: 0.2,
+			mode: 255 as ReplicationIntent,
+		});
+		await replicationIndex.put(invalid);
+		const send = sinon.spy(log.rpc, "send");
+		const remoteKey = session.peers[1].identity.publicKey;
+		const validMutation = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash: selfHash,
+			offset: 0.7,
+		});
+
+		try {
+			await expect(
+				log._onSubscription({
+					detail: { from: remoteKey, topics: [log.topic] },
+				} as any),
+			).to.be.rejectedWith(
+				"Persisted replication ownership is invalid and cannot be announced",
+			);
+			expect(send.called).to.be.false;
+			expect(log._replicationRangeMutationFailure).to.be.instanceOf(Error);
+			await expect(
+				log._findLeaders([log.indexableDomain.numbers.denormalize(0.5)]),
+			).to.be.rejectedWith("Replication ownership recovery is required");
+			await expect(
+				log.addReplicationRange([validMutation], selfKey, {
+					checkDuplicates: false,
+					rebalance: false,
+				}),
+			).to.be.rejectedWith("Replication ownership recovery is required");
+		} finally {
+			send.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("fences a reset after min-role-age planning crosses close", async () => {
+		const { db, log, replicationIndex } = await openDisconnectedLog(2);
+		const ownerKey = session.peers[1].identity.publicKey;
+		const ownerHash = ownerKey.hashcode();
+		const id = randomBytes(32);
+		const previous = makeReplicationRange(log, {
+			id,
+			ownerHash,
+			offset: 0.1,
+		});
+		const replacement = makeReplicationRange(log, {
+			id,
+			ownerHash,
+			offset: 0.6,
+			timestamp: 2n,
+		});
+		await log.addReplicationRange([previous], ownerKey, {
+			checkDuplicates: false,
+			rebalance: false,
+		});
+
+		const readStarted = pDefer<void>();
+		const releaseRead = pDefer<void>();
+		const minRoleAge = sinon
+			.stub(log, "getDefaultMinRoleAge")
+			.callsFake(async () => {
+				readStarted.resolve();
+				await releaseRead.promise;
+				return 0;
+			});
+		const put = sinon.spy(replicationIndex, "put");
+		const del = sinon.spy(replicationIndex, "del");
+		const effects = observeRejectedReplicationMutation(log, {
+			allowLifecycleClear: true,
+		});
+
+		try {
+			const adding = log.addReplicationRange([replacement], ownerKey, {
+				reset: true,
+				checkDuplicates: false,
+				rebalance: false,
+			});
+			await readStarted.promise;
+			const rejected = expect(adding).to.be.rejectedWith(
+				"Replication ownership lifecycle is no longer active",
+			);
+			const closing = db.close();
+			releaseRead.resolve();
+			await Promise.all([rejected, closing]);
+
+			expect(put.called).to.be.false;
+			expect(del.called).to.be.false;
+			effects.assertNoEffects();
+		} finally {
+			releaseRead.resolve();
+			minRoleAge.restore();
+			put.restore();
+			del.restore();
+			effects.restore();
+		}
+
+		await session.peers[0].open(db, {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const durable = await replicationIndex.iterate().all();
+		expect(durable).to.have.length(1);
+		expect(durable[0].value.rangeHash).to.equal(previous.rangeHash);
+	});
+
+	it("fences a reset after its owner inventory read crosses close", async () => {
+		const { db, log, replicationIndex } = await openDisconnectedLog(2);
+		const ownerKey = session.peers[1].identity.publicKey;
+		const ownerHash = ownerKey.hashcode();
+		const id = randomBytes(32);
+		const previous = makeReplicationRange(log, {
+			id,
+			ownerHash,
+			offset: 0.1,
+		});
+		const replacement = makeReplicationRange(log, {
+			id,
+			ownerHash,
+			offset: 0.6,
+			timestamp: 2n,
+		});
+		await log.addReplicationRange([previous], ownerKey, {
+			checkDuplicates: false,
+			rebalance: false,
+		});
+
+		const readStarted = pDefer<void>();
+		const releaseRead = pDefer<void>();
+		const originalIterate = replicationIndex.iterate.bind(replicationIndex);
+		let blockInventory = true;
+		const iterate = sinon.stub(replicationIndex, "iterate").callsFake(((
+			request?: any,
+			options?: any,
+		) => {
+			const iterator = originalIterate(request, options);
+			if (blockInventory && request?.query?.hash === ownerHash) {
+				blockInventory = false;
+				const originalAll = iterator.all.bind(iterator);
+				iterator.all = async () => {
+					readStarted.resolve();
+					await releaseRead.promise;
+					return originalAll();
+				};
+			}
+			return iterator;
+		}) as any);
+		const put = sinon.spy(replicationIndex, "put");
+		const del = sinon.spy(replicationIndex, "del");
+		const effects = observeRejectedReplicationMutation(log, {
+			allowLifecycleClear: true,
+		});
+
+		try {
+			const adding = log.addReplicationRange([replacement], ownerKey, {
+				reset: true,
+				checkDuplicates: false,
+				rebalance: false,
+			});
+			await readStarted.promise;
+			const rejected = expect(adding).to.be.rejectedWith(
+				"Replication ownership lifecycle is no longer active",
+			);
+			const closing = db.close();
+			releaseRead.resolve();
+			await Promise.all([rejected, closing]);
+
+			expect(put.called).to.be.false;
+			expect(del.called).to.be.false;
+			effects.assertNoEffects();
+		} finally {
+			releaseRead.resolve();
+			iterate.restore();
+			put.restore();
+			del.restore();
+			effects.restore();
+		}
+
+		await session.peers[0].open(db, {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const durable = await replicationIndex.iterate().all();
+		expect(durable).to.have.length(1);
+		expect(durable[0].value.rangeHash).to.equal(previous.rangeHash);
+	});
+
+	it("fences a non-reset mutation after its id lookup crosses close", async () => {
+		const { db, log, replicationIndex } = await openDisconnectedLog(2);
+		const ownerKey = session.peers[1].identity.publicKey;
+		const ownerHash = ownerKey.hashcode();
+		const id = randomBytes(32);
+		const previous = makeReplicationRange(log, {
+			id,
+			ownerHash,
+			offset: 0.1,
+		});
+		const replacement = makeReplicationRange(log, {
+			id,
+			ownerHash,
+			offset: 0.6,
+			timestamp: 2n,
+		});
+		await log.addReplicationRange([previous], ownerKey, {
+			checkDuplicates: false,
+			rebalance: false,
+		});
+
+		const readStarted = pDefer<void>();
+		const releaseRead = pDefer<void>();
+		const originalIterate = replicationIndex.iterate.bind(replicationIndex);
+		let blockLookup = true;
+		const iterate = sinon.stub(replicationIndex, "iterate").callsFake(((
+			request?: any,
+			options?: any,
+		) => {
+			const iterator = originalIterate(request, options);
+			if (blockLookup && Array.isArray(request?.query)) {
+				blockLookup = false;
+				const originalAll = iterator.all.bind(iterator);
+				iterator.all = async () => {
+					readStarted.resolve();
+					await releaseRead.promise;
+					return originalAll();
+				};
+			}
+			return iterator;
+		}) as any);
+		const put = sinon.spy(replicationIndex, "put");
+		const del = sinon.spy(replicationIndex, "del");
+		const effects = observeRejectedReplicationMutation(log, {
+			allowLifecycleClear: true,
+		});
+
+		try {
+			const adding = log.addReplicationRange([replacement], ownerKey, {
+				checkDuplicates: false,
+				rebalance: false,
+			});
+			await readStarted.promise;
+			const rejected = expect(adding).to.be.rejectedWith(
+				"Replication ownership lifecycle is no longer active",
+			);
+			const closing = db.close();
+			releaseRead.resolve();
+			await Promise.all([rejected, closing]);
+
+			expect(put.called).to.be.false;
+			expect(del.called).to.be.false;
+			effects.assertNoEffects();
+		} finally {
+			releaseRead.resolve();
+			iterate.restore();
+			put.restore();
+			del.restore();
+			effects.restore();
+		}
+
+		await session.peers[0].open(db, {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const durable = await replicationIndex.iterate().all();
+		expect(durable).to.have.length(1);
+		expect(durable[0].value.rangeHash).to.equal(previous.rangeHash);
+	});
+
+	it("fences a non-reset mutation after its owner count crosses close", async () => {
+		const { db, log, replicationIndex } = await openDisconnectedLog(2);
+		const ownerKey = session.peers[1].identity.publicKey;
+		const incoming = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash: ownerKey.hashcode(),
+			offset: 0.4,
+		});
+		const readStarted = pDefer<void>();
+		const releaseRead = pDefer<void>();
+		const originalCount = replicationIndex.count.bind(replicationIndex);
+		let blockOwnerCount = true;
+		const count = sinon.stub(replicationIndex, "count").callsFake((async (
+			request?: any,
+			options?: any,
+		) => {
+			if (blockOwnerCount) {
+				blockOwnerCount = false;
+				readStarted.resolve();
+				await releaseRead.promise;
+			}
+			return originalCount(request, options);
+		}) as any);
+		const put = sinon.spy(replicationIndex, "put");
+		const del = sinon.spy(replicationIndex, "del");
+		const effects = observeRejectedReplicationMutation(log, {
+			allowLifecycleClear: true,
+		});
+
+		try {
+			const adding = log.addReplicationRange([incoming], ownerKey, {
+				checkDuplicates: false,
+				rebalance: false,
+			});
+			await readStarted.promise;
+			const rejected = expect(adding).to.be.rejectedWith(
+				"Replication ownership lifecycle is no longer active",
+			);
+			const closing = db.close();
+			releaseRead.resolve();
+			await Promise.all([rejected, closing]);
+
+			expect(put.called).to.be.false;
+			expect(del.called).to.be.false;
+			effects.assertNoEffects();
+		} finally {
+			releaseRead.resolve();
+			count.restore();
+			put.restore();
+			del.restore();
+			effects.restore();
+		}
+
+		await session.peers[0].open(db, {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		expect(await replicationIndex.count()).to.equal(0);
+	});
+
+	it("fences duplicate filtering after its covering-range lookup crosses close", async () => {
+		const { db, log, replicationIndex } = await openDisconnectedLog(2);
+		const ownerKey = session.peers[1].identity.publicKey;
+		const ownerHash = ownerKey.hashcode();
+		const previous = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash,
+			offset: 0.1,
+		});
+		const incoming = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash,
+			offset: 0.7,
+			timestamp: 2n,
+		});
+		await log.addReplicationRange([previous], ownerKey, {
+			checkDuplicates: false,
+			rebalance: false,
+		});
+
+		const readStarted = pDefer<void>();
+		const releaseRead = pDefer<void>();
+		const originalCount = replicationIndex.count.bind(replicationIndex);
+		let blockCoveringLookup = true;
+		const count = sinon.stub(replicationIndex, "count").callsFake((async (
+			request?: any,
+			options?: any,
+		) => {
+			if (blockCoveringLookup && Array.isArray(request?.query)) {
+				blockCoveringLookup = false;
+				readStarted.resolve();
+				await releaseRead.promise;
+			}
+			return originalCount(request, options);
+		}) as any);
+		const put = sinon.spy(replicationIndex, "put");
+		const del = sinon.spy(replicationIndex, "del");
+		const effects = observeRejectedReplicationMutation(log, {
+			allowLifecycleClear: true,
+		});
+
+		try {
+			const adding = log.addReplicationRange([incoming], ownerKey, {
+				checkDuplicates: true,
+				rebalance: false,
+			});
+			await readStarted.promise;
+			const rejected = expect(adding).to.be.rejectedWith(
+				"Replication ownership lifecycle is no longer active",
+			);
+			const closing = db.close();
+			releaseRead.resolve();
+			await Promise.all([rejected, closing]);
+
+			expect(put.called).to.be.false;
+			expect(del.called).to.be.false;
+			effects.assertNoEffects();
+		} finally {
+			releaseRead.resolve();
+			count.restore();
+			put.restore();
+			del.restore();
+			effects.restore();
+		}
+
+		await session.peers[0].open(db, {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const durable = await replicationIndex.iterate().all();
+		expect(durable).to.have.length(1);
+		expect(durable[0].value.rangeHash).to.equal(previous.rangeHash);
+	});
+
+	it("rejects an invalid replication mode before reads or reset mutation", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(2);
+		const ownerKey = session.peers[1].identity.publicKey;
+		const ownerHash = ownerKey.hashcode();
+		const previous = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash,
+			offset: 0.1,
+		});
+		await log.addReplicationRange([previous], ownerKey, {
+			checkDuplicates: false,
+			rebalance: false,
+		});
+		const forged = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash,
+			offset: 0.6,
+			mode: 2 as ReplicationIntent,
+			timestamp: 2n,
+		});
+		const originalTrustedReplicator = log._isTrustedReplicator;
+		const authorization = sinon.stub().resolves(true);
+		log._isTrustedReplicator = authorization;
+		const mutationLane = sinon.spy(log, "withReplicationRangeMutationQueue");
+		const iterate = sinon.spy(replicationIndex, "iterate");
+		const count = sinon.spy(replicationIndex, "count");
+		const put = sinon.spy(replicationIndex, "put");
+		const del = sinon.spy(replicationIndex, "del");
+		const effects = observeRejectedReplicationMutation(log);
+
+		try {
+			await expect(
+				log.addReplicationRange([forged], ownerKey, {
+					reset: true,
+					checkDuplicates: false,
+					rebalance: false,
+				}),
+			).to.be.rejectedWith("Invalid replication range mode at index 0: 2");
+
+			expect(authorization.called).to.be.false;
+			expect(mutationLane.called).to.be.false;
+			expect(iterate.called).to.be.false;
+			expect(count.called).to.be.false;
+			expect(put.called).to.be.false;
+			expect(del.called).to.be.false;
+			effects.assertNoEffects();
+		} finally {
+			log._isTrustedReplicator = originalTrustedReplicator;
+			mutationLane.restore();
+			iterate.restore();
+			count.restore();
+			put.restore();
+			del.restore();
+			effects.restore();
+		}
+
+		const durable = await replicationIndex.iterate().all();
+		expect(durable).to.have.length(1);
+		expect(durable[0].value.rangeHash).to.equal(previous.rangeHash);
+	});
+
+	it("rejects over-limit range announcements before authorization or mutation admission", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(2);
+		const ownerKey = session.peers[1].identity.publicKey;
+		const range = makeReplicationRange(log, {
+			id: randomBytes(32),
+			ownerHash: ownerKey.hashcode(),
+			offset: 0.1,
+		});
+		const ranges = new Array(4097).fill(range);
+		const originalTrustedReplicator = log._isTrustedReplicator;
+		const authorization = sinon.stub().resolves(true);
+		log._isTrustedReplicator = authorization;
+		const mutationLane = sinon.spy(log, "withReplicationRangeMutationQueue");
+		const iterate = sinon.spy(replicationIndex, "iterate");
+		const count = sinon.spy(replicationIndex, "count");
+		const put = sinon.spy(replicationIndex, "put");
+		const del = sinon.spy(replicationIndex, "del");
+		const effects = observeRejectedReplicationMutation(log);
+
+		try {
+			await expect(
+				log.addReplicationRange(ranges, ownerKey, {
+					reset: true,
+					checkDuplicates: false,
+					rebalance: false,
+				}),
+			).to.be.rejectedWith(
+				"Replication range announcement exceeds the 4096-range limit",
+			);
+
+			expect(authorization.called).to.be.false;
+			expect(mutationLane.called).to.be.false;
+			expect(iterate.called).to.be.false;
+			expect(count.called).to.be.false;
+			expect(put.called).to.be.false;
+			expect(del.called).to.be.false;
+			effects.assertNoEffects();
+		} finally {
+			log._isTrustedReplicator = originalTrustedReplicator;
+			mutationLane.restore();
+			iterate.restore();
+			count.restore();
+			put.restore();
+			del.restore();
+			effects.restore();
+		}
+
+		expect(await replicationIndex.count()).to.equal(0);
+	});
+
+	it("keeps incremental owner state within the snapshot limit and reconnects at the limit", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(2);
+		const selfKey = session.peers[0].identity.publicKey;
+		const selfHash = selfKey.hashcode();
+		const ranges = Array.from({ length: 4096 }, (_, index) =>
+			makeReplicationRange(log, {
+				id: new Uint8Array([index >>> 24, index >>> 16, index >>> 8, index]),
+				ownerHash: selfHash,
+				offset: (index % 100) / 100,
+				timestamp: BigInt(index + 1),
+			}),
+		);
+		for (let index = 0; index < ranges.length; index += 64) {
+			await Promise.all(
+				ranges
+					.slice(index, index + 64)
+					.map((range) => replicationIndex.put(range)),
+			);
+		}
+
+		const extra = makeReplicationRange(log, {
+			id: new Uint8Array([0xff, 0xff, 0xff, 0xff]),
+			ownerHash: selfHash,
+			offset: 0.5,
+			timestamp: 4097n,
+		});
+		const put = sinon.spy(replicationIndex, "put");
+		const effects = observeRejectedReplicationMutation(log);
+		try {
+			await expect(
+				log.addReplicationRange([extra], selfKey, {
+					checkDuplicates: false,
+					rebalance: false,
+				}),
+			).to.be.rejectedWith(
+				"Replication range ownership exceeds the 4096-range limit",
+			);
+			expect(put.called).to.be.false;
+			expect(
+				await replicationIndex.count({ query: { hash: selfHash } }),
+			).to.equal(4096);
+			effects.assertNoEffects();
+		} finally {
+			put.restore();
+			effects.restore();
+		}
+
+		const sent: unknown[] = [];
+		const send = sinon
+			.stub(log.rpc, "send")
+			.callsFake(async (message: unknown) => {
+				sent.push(message);
+				return [] as any;
+			});
+		try {
+			await log.handleSubscriptionChange(
+				session.peers[1].identity.publicKey,
+				[log.topic],
+				true,
+			);
+			const snapshots = sent.filter(
+				(message) => message instanceof AllReplicatingSegmentsMessage,
+			) as AllReplicatingSegmentsMessage[];
+			expect(snapshots).to.have.length(1);
+			expect(snapshots[0].segments).to.have.length(4096);
+			expect(log._replicationRangeMutationFailure).to.be.undefined;
+		} finally {
+			send.restore();
+		}
+	});
+
+	it("rejects over-limit stopped announcements before liveness, queues, or queries", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(2);
+		const remoteKey = session.peers[1].identity.publicKey;
+		const duplicateId = randomBytes(32);
+		const markActivity = sinon.spy(log, "markReplicatorActivity");
+		const applyQueue = sinon.spy(log, "withReplicationInfoApplyQueue");
+		const mutationLane = sinon.spy(log, "withReplicationRangeMutationQueue");
+		const resolveRanges = sinon.spy(
+			log,
+			"resolveReplicationRangesFromIdsAndKey",
+		);
+		const iterate = sinon.spy(replicationIndex, "iterate");
+		const count = sinon.spy(replicationIndex, "count");
+		const effects = observeRejectedReplicationMutation(log);
+
+		try {
+			await log.onMessage(
+				new StoppedReplicating({
+					segmentIds: new Array(4097).fill(duplicateId),
+				}),
+				{
+					from: remoteKey,
+					message: { header: { timestamp: 1n } },
+				} as any,
+			);
+
+			expect(markActivity.called).to.be.false;
+			expect(applyQueue.called).to.be.false;
+			expect(mutationLane.called).to.be.false;
+			expect(resolveRanges.called).to.be.false;
+			expect(iterate.called).to.be.false;
+			expect(count.called).to.be.false;
+			effects.assertNoEffects();
+		} finally {
+			markActivity.restore();
+			applyQueue.restore();
+			mutationLane.restore();
+			resolveRanges.restore();
+			iterate.restore();
+			count.restore();
+			effects.restore();
+		}
+	});
+
+	it("does not let an old prune debounce resume into the reopened coordinator", async () => {
+		const { db, log } = await openDisconnectedLog(2);
+		const callbackStarted = pDefer<void>();
+		const releaseCallback = pDefer<void>();
+		let blockFirstCall = true;
+		const isReplicating = sinon
+			.stub(log, "isReplicating")
+			.callsFake(async () => {
+				if (blockFirstCall) {
+					blockFirstCall = false;
+					callbackStarted.resolve();
+					await releaseCallback.promise;
+				}
+				return false;
+			});
+		const prune = sinon.spy(log, "prune");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const staleEntry = { hash: "stale-prune-debounce" } as any;
+		const oldDebounce = log.pruneDebouncedFn;
+
+		try {
+			const pendingOutcome = oldDebounce
+				.add({
+					key: staleEntry.hash,
+					value: {
+						entry: staleEntry,
+						leaders: new Map([[remoteHash, { intersecting: true }]]),
+					},
+				})
+				.then(
+					() => ({ status: "fulfilled" as const }),
+					(error: unknown) => ({ status: "rejected" as const, error }),
+				);
+			await callbackStarted.promise;
+			const oldCoordinator = log._checkedPrune;
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+			const freshCoordinator = log._checkedPrune;
+			expect(freshCoordinator).to.not.equal(oldCoordinator);
+			prune.resetHistory();
+
+			releaseCallback.resolve();
+			expect((await pendingOutcome).status).to.equal("fulfilled");
+			await delay(25);
+			expect(prune.called).to.be.false;
+			expect(freshCoordinator.hasActiveWork(staleEntry.hash)).to.be.false;
+		} finally {
+			releaseCallback.resolve();
+			isReplicating.restore();
+			prune.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("does not let an old adaptive rebalance continue after reopen", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const memoryReadStarted = pDefer<void>();
+		const releaseMemoryRead = pDefer<void>();
+		log._isReplicating = true;
+		log._isAdaptiveReplicating = true;
+		const getMemoryUsage = sinon
+			.stub(log, "getMemoryUsage")
+			.callsFake(async () => {
+				memoryReadStarted.resolve();
+				await releaseMemoryRead.promise;
+				return 0;
+			});
+		const getDynamicRange = sinon.stub(log, "getDynamicRange").resolves();
+
+		try {
+			const balancing = log.rebalanceParticipation();
+			await memoryReadStarted.promise;
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+
+			releaseMemoryRead.resolve();
+			expect(await balancing).to.equal(false);
+			expect(getDynamicRange.called).to.be.false;
+		} finally {
+			releaseMemoryRead.resolve();
+			getMemoryUsage.restore();
+			getDynamicRange.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("captures append ownership before the lower append can cross reopen", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const { entry } = await db.add("append-generation-seed");
+		const lowerAppendStarted = pDefer<void>();
+		const releaseLowerAppend = pDefer<void>();
+		const lowerAppend = sinon.stub(log.log, "append").callsFake(async () => {
+			lowerAppendStarted.resolve();
+			await releaseLowerAppend.promise;
+			return { entry, removed: [] };
+		});
+		const processLocalAppend = sinon.spy(log, "processLocalAppend");
+
+		try {
+			const appending = log.append("blocked-across-reopen", {
+				target: "none",
+				replicate: false,
+				delivery: false,
+			});
+			await lowerAppendStarted.promise;
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+			processLocalAppend.resetHistory();
+
+			releaseLowerAppend.resolve();
+			await expect(appending).to.be.rejectedWith(
+				"Replication ownership lifecycle is no longer active",
+			);
+			expect(processLocalAppend.called).to.be.false;
+		} finally {
+			releaseLowerAppend.resolve();
+			lowerAppend.restore();
+			processLocalAppend.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("captures appendMany ownership before the lower batch can cross reopen", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const { entry } = await db.add("append-many-generation-seed");
+		const lowerAppendStarted = pDefer<void>();
+		const releaseLowerAppend = pDefer<void>();
+		const lowerAppendMany = sinon
+			.stub(log.log, "appendMany")
+			.callsFake(async () => {
+				lowerAppendStarted.resolve();
+				await releaseLowerAppend.promise;
+				return { entries: [entry], removed: [] };
+			});
+		const deleteCoordinates = sinon.spy(log, "deleteCoordinatesForHashes");
+		const coalesced = sinon.spy(log, "processLocalAppendManyCoalesced");
+		const planLocal = sinon.spy(log, "planNativeLocalAppendEntries");
+		const planDelivery = sinon.spy(log, "planNativeAppendEntries");
+		const processLocalAppend = sinon.spy(log, "processLocalAppend");
+
+		try {
+			const appending = log.appendMany(["blocked-batch-across-reopen"], {
+				target: "none",
+				replicate: false,
+				delivery: false,
+			});
+			await lowerAppendStarted.promise;
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+			deleteCoordinates.resetHistory();
+			coalesced.resetHistory();
+			planLocal.resetHistory();
+			planDelivery.resetHistory();
+			processLocalAppend.resetHistory();
+
+			releaseLowerAppend.resolve();
+			await expect(appending).to.be.rejectedWith(
+				"Replication ownership lifecycle is no longer active",
+			);
+			expect(deleteCoordinates.called).to.be.false;
+			expect(coalesced.called).to.be.false;
+			expect(planLocal.called).to.be.false;
+			expect(planDelivery.called).to.be.false;
+			expect(processLocalAppend.called).to.be.false;
+		} finally {
+			releaseLowerAppend.resolve();
+			lowerAppendMany.restore();
+			deleteCoordinates.restore();
+			coalesced.restore();
+			planLocal.restore();
+			planDelivery.restore();
+			processLocalAppend.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("captures validated append ownership before its lower append crosses reopen", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const { entry } = await db.add("validated-generation-seed");
+		const lowerAppendStarted = pDefer<void>();
+		const releaseLowerAppend = pDefer<void>();
+		const lowerAppend = sinon.stub(log.log, "append").callsFake(async () => {
+			lowerAppendStarted.resolve();
+			await releaseLowerAppend.promise;
+			return { entry, removed: [] };
+		});
+		const onChange = sinon.spy(log, "onChange");
+		const processLocalAppend = sinon.spy(log, "processLocalAppend");
+
+		try {
+			const appending = log.appendLocallyValidated(
+				"validated-blocked-across-reopen",
+				{
+					target: "none",
+					replicate: false,
+					delivery: false,
+				},
+			);
+			await lowerAppendStarted.promise;
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+			onChange.resetHistory();
+			processLocalAppend.resetHistory();
+
+			releaseLowerAppend.resolve();
+			await expect(appending).to.be.rejectedWith(
+				"Replication ownership lifecycle is no longer active",
+			);
+			expect(onChange.called).to.be.false;
+			expect(processLocalAppend.called).to.be.false;
+		} finally {
+			releaseLowerAppend.resolve();
+			lowerAppend.restore();
+			onChange.restore();
+			processLocalAppend.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("captures prepared append ownership before its trusted lower append crosses reopen", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const lowerAppendStarted = pDefer<void>();
+		const releaseLowerAppend = pDefer<void>();
+		const lowerAppend = sinon
+			.stub(log.log, "appendLocallyPrepared")
+			.callsFake(async () => {
+				lowerAppendStarted.resolve();
+				await releaseLowerAppend.promise;
+				return {} as any;
+			});
+		const processNative = sinon.spy(
+			log,
+			"processNativePreparedTargetNoneAppend",
+		);
+		const applyChange = sinon.spy(log, "applyChange");
+		const processLocalAppend = sinon.spy(log, "processLocalAppend");
+
+		try {
+			const appending = log.appendLocallyPrepared(
+				"prepared-blocked-across-reopen",
+				{
+					target: "none",
+					replicate: false,
+					delivery: false,
+				},
+			);
+			await lowerAppendStarted.promise;
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+			processNative.resetHistory();
+			applyChange.resetHistory();
+			processLocalAppend.resetHistory();
+
+			releaseLowerAppend.resolve();
+			await expect(appending).to.be.rejectedWith(
+				"Replication ownership lifecycle is no longer active",
+			);
+			expect(processNative.called).to.be.false;
+			expect(applyChange.called).to.be.false;
+			expect(processLocalAppend.called).to.be.false;
+		} finally {
+			releaseLowerAppend.resolve();
+			lowerAppend.restore();
+			processNative.restore();
+			applyChange.restore();
+			processLocalAppend.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("captures commit-only fallback ownership before its trusted lower append crosses reopen", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const lowerAppendStarted = pDefer<void>();
+		const releaseLowerAppend = pDefer<void>();
+		const lowerAppend = sinon
+			.stub(log.log, "appendLocallyPreparedCommitOnly")
+			.callsFake(async () => {
+				lowerAppendStarted.resolve();
+				await releaseLowerAppend.promise;
+				return {} as any;
+			});
+		const finishAppend = sinon.spy(
+			log,
+			"finishPreparedPayloadCommitOnlyAppend",
+		);
+
+		try {
+			const appending = log.appendLocallyPreparedPayloadCommitOnly(
+				new Uint8Array([1, 2, 3]),
+				{
+					target: "none",
+					replicate: false,
+					delivery: false,
+				},
+			);
+			await lowerAppendStarted.promise;
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+			finishAppend.resetHistory();
+
+			releaseLowerAppend.resolve();
+			await expect(appending).to.be.rejectedWith(
+				"Replication ownership lifecycle is no longer active",
+			);
+			expect(finishAppend.called).to.be.false;
+		} finally {
+			releaseLowerAppend.resolve();
+			lowerAppend.restore();
+			finishAppend.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("captures prepared-many fallback ownership before its trusted batch crosses reopen", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const lowerAppendStarted = pDefer<void>();
+		const releaseLowerAppend = pDefer<void>();
+		const nativeBatch = sinon
+			.stub(
+				log,
+				"appendLocallyPreparedPayloadsManyNativeBackboneDocumentIndexBatch",
+			)
+			.resolves(undefined);
+		const lowerAppend = sinon
+			.stub(log.log, "appendLocallyPreparedManyIndependent")
+			.callsFake(async () => {
+				lowerAppendStarted.resolve();
+				await releaseLowerAppend.promise;
+				return {} as any;
+			});
+		const applyChange = sinon.spy(log, "applyChange");
+		const deleteCoordinates = sinon.spy(log, "deleteCoordinatesForHashes");
+		const planLocal = sinon.spy(log, "planNativeLocalAppendEntries");
+		const planDelivery = sinon.spy(log, "planNativeAppendEntries");
+		const processLocalAppend = sinon.spy(log, "processLocalAppend");
+
+		try {
+			const appending = log.appendLocallyPreparedManyIndependent(
+				["prepared-many-blocked-across-reopen"],
+				{
+					target: "none",
+					replicate: false,
+					delivery: false,
+				},
+			);
+			await lowerAppendStarted.promise;
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+			applyChange.resetHistory();
+			deleteCoordinates.resetHistory();
+			planLocal.resetHistory();
+			planDelivery.resetHistory();
+			processLocalAppend.resetHistory();
+
+			releaseLowerAppend.resolve();
+			await expect(appending).to.be.rejectedWith(
+				"Replication ownership lifecycle is no longer active",
+			);
+			expect(applyChange.called).to.be.false;
+			expect(deleteCoordinates.called).to.be.false;
+			expect(planLocal.called).to.be.false;
+			expect(planDelivery.called).to.be.false;
+			expect(processLocalAppend.called).to.be.false;
+		} finally {
+			releaseLowerAppend.resolve();
+			nativeBatch.restore();
+			lowerAppend.restore();
+			applyChange.restore();
+			deleteCoordinates.restore();
+			planLocal.restore();
+			planDelivery.restore();
+			processLocalAppend.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("captures join ownership before the lower join can cross reopen", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const { entry } = await db.add("join-generation-seed");
+		const lowerJoinStarted = pDefer<void>();
+		const releaseLowerJoin = pDefer<void>();
+		const lowerJoin = sinon.stub(log.log, "join").callsFake(async () => {
+			lowerJoinStarted.resolve();
+			await releaseLowerJoin.promise;
+		});
+
+		try {
+			const joining = log.join([entry]);
+			await lowerJoinStarted.promise;
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+
+			releaseLowerJoin.resolve();
+			await expect(joining).to.be.rejectedWith(
+				"Replication ownership lifecycle is no longer active",
+			);
+		} finally {
+			releaseLowerJoin.resolve();
+			lowerJoin.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("continues bounded deletion after a failed batch and reconciles durable state", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog();
+		const remoteKey = session.peers[1].identity.publicKey;
+		const remoteHash = remoteKey.hashcode();
+		const numbers = log.indexableDomain.numbers;
+		const ranges = Array.from(
+			{ length: 201 },
+			(_, index) =>
+				new log.indexableDomain.constructorRange({
+					id: new Uint8Array([index >>> 8, index & 0xff, 1]),
+					offset: numbers.denormalize((index % 100) / 100),
+					width: numbers.denormalize(0.005),
+					publicKeyHash: remoteHash,
+					timestamp: BigInt(index + 1),
+				}),
+		);
+		const idKey = (id: Uint8Array) => Array.from(id).join(",");
+		const retainedById = new Map(
+			ranges.slice(0, 100).map((range: any) => [idKey(range.id), range]),
+		);
+		const idMatcher = (request: any) =>
+			request?.query?.and?.find((part: any) => Array.isArray(part?.or)) ??
+			(Array.isArray(request?.query?.or) ? request.query : undefined);
+		const iterateBatchSizes: number[] = [];
+		const deleteBatchSizes: number[] = [];
+		const durableFailure = new Error("forced first delete-batch failure");
+		let deleteAttempt = 0;
+		const del = sinon.stub(replicationIndex, "del").callsFake((async (
+			request: any,
+		) => {
+			deleteAttempt += 1;
+			deleteBatchSizes.push(idMatcher(request).or.length);
+			if (deleteAttempt === 1) {
+				throw durableFailure;
+			}
+		}) as any);
+		const iterate = sinon.stub(replicationIndex, "iterate").callsFake(((
+			request?: any,
+		) => {
+			const matcher = idMatcher(request);
+			if (matcher) {
+				iterateBatchSizes.push(matcher.or.length);
+			}
+			const current = matcher
+				? matcher.or
+						.map((part: any) => retainedById.get(idKey(part.value)))
+						.filter((range: any) => range !== undefined)
+						.map((value: any) => ({ value }))
+				: [];
+			return {
+				all: async () => current,
+				next: async () => [],
+				close: async () => {},
+			};
+		}) as any);
+		const count = sinon.stub(replicationIndex, "count").resolves(100);
+		const putNative = sinon.stub(log, "putNativeReplicationRange");
+		const deleteNative = sinon.stub(log, "deleteNativeReplicationRange");
+
+		try {
+			const resolved = await log.resolveReplicationRangesFromIdsAndKey(
+				ranges.map((range: any) => range.id),
+				remoteKey,
+			);
+			expect(resolved).to.have.length(100);
+			expect(iterateBatchSizes).to.deep.equal([100, 100, 1]);
+			iterateBatchSizes.length = 0;
+
+			const outcome = await log.deleteReplicationRangesCoherently(
+				ranges,
+				remoteHash,
+			);
+			expect(outcome.error).to.equal(durableFailure);
+			expect(outcome.retained).to.deep.equal(ranges.slice(0, 100));
+			expect(outcome.removed).to.deep.equal(ranges.slice(100));
+			expect(deleteBatchSizes).to.deep.equal([100, 100, 1]);
+			expect(iterateBatchSizes).to.deep.equal([100, 100, 1]);
+			expect(putNative.callCount).to.equal(100);
+			expect(deleteNative.callCount).to.equal(101);
+			expect(log.uniqueReplicators.has(remoteHash)).to.be.true;
+		} finally {
+			del.restore();
+			iterate.restore();
+			count.restore();
+			putNative.restore();
+			deleteNative.restore();
+		}
+	});
+
+	it("serializes admitted range mutations and fences terminal admission", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog();
+		const remoteKey = session.peers[1].identity.publicKey;
+		const remoteHash = remoteKey.hashcode();
+		const numbers = log.indexableDomain.numbers;
+		const makeRange = (offset: number) =>
+			new log.indexableDomain.constructorRange({
+				id: randomBytes(32),
+				offset: numbers.denormalize(offset),
+				width: numbers.denormalize(0.2),
+				publicKeyHash: remoteHash,
+				timestamp: 1n,
+			});
+		const admittedRange = makeRange(0.1);
+		const rejectedRange = makeRange(0.6);
+		const rangePersisted = pDefer<void>();
+		const releaseRangePut = pDefer<void>();
+		const originalPut = replicationIndex.put.bind(replicationIndex);
+		const put = sinon.stub(replicationIndex, "put").callsFake((async (
+			value: any,
+			options?: any,
+		) => {
+			const result = await originalPut(value, options);
+			if (value === admittedRange) {
+				rangePersisted.resolve();
+				await releaseRangePut.promise;
+			}
+			return result;
+		}) as any);
+
+		try {
+			const adding = log.addReplicationRange([admittedRange], remoteKey, {
+				checkDuplicates: false,
+				rebalance: false,
+			});
+			await rangePersisted.promise;
+
+			let removalEntered = false;
+			const removing = log.removeReplicationRanges([admittedRange], remoteKey, {
+				shouldRemove: () => {
+					removalEntered = true;
+					return true;
+				},
+			});
+			await Promise.resolve();
+			expect(removalEntered).to.be.false;
+
+			const terminalFence = log.acquireReplicationRangeMutationTerminalFence();
+			await expect(
+				log.addReplicationRange([rejectedRange], remoteKey, {
+					checkDuplicates: false,
+					rebalance: false,
+				}),
+			).to.be.rejectedWith("Replication range mutations are closing");
+
+			releaseRangePut.resolve();
+			const [changes, removed] = await Promise.all([adding, removing]);
+			await terminalFence.drained;
+			expect(changes).to.have.length(1);
+			expect(removed).to.be.true;
+			expect(removalEntered).to.be.true;
+			expect(
+				await replicationIndex.count({ query: { hash: remoteHash } }),
+			).to.equal(0);
+		} finally {
+			releaseRangePut.resolve();
+			put.restore();
+		}
+	});
+
+	it("fences entry replication before the mutation lane across reopen", async () => {
+		const { db, log, replicationIndex } = await openDisconnectedLog(1);
+		const { entry } = await db.add("blocked-replicate");
+		const fromEntryStarted = pDefer<void>();
+		const releaseFromEntry = pDefer<void>();
+		const originalFromEntry = log.domain.fromEntry.bind(log.domain);
+		const fromEntry = sinon
+			.stub(log.domain, "fromEntry")
+			.callsFake(async (value: unknown) => {
+				fromEntryStarted.resolve();
+				await releaseFromEntry.promise;
+				return originalFromEntry(value);
+			});
+
+		try {
+			const replicating = db.log.replicate(entry);
+			await fromEntryStarted.promise;
+			const oldOwnershipLifecycle = log._repairLifecycleController;
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+			expect(log._repairLifecycleController).to.not.equal(
+				oldOwnershipLifecycle,
+			);
+
+			releaseFromEntry.resolve();
+			await expect(replicating).to.be.rejectedWith(
+				"Replication ownership lifecycle is no longer active",
+			);
+			expect(
+				await replicationIndex.count({
+					query: {
+						hash: session.peers[0].identity.publicKey.hashcode(),
+					},
+				}),
+			).to.equal(0);
+		} finally {
+			releaseFromEntry.resolve();
+			fromEntry.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("fences ID-based unreplication before the mutation lane across reopen", async () => {
+		const { db, log, replicationIndex } = await openDisconnectedLog(1);
+		const [range] = await db.log.replicate({
+			factor: 0.2,
+			offset: 0.1,
+		});
+		const resolutionStarted = pDefer<void>();
+		const releaseResolution = pDefer<void>();
+		const originalResolve = log.resolveReplicationRangesFromIdsAndKey.bind(log);
+		let blockNextResolution = true;
+		const resolve = sinon
+			.stub(log, "resolveReplicationRangesFromIdsAndKey")
+			.callsFake(async (...args: unknown[]) => {
+				if (blockNextResolution) {
+					blockNextResolution = false;
+					resolutionStarted.resolve();
+					await releaseResolution.promise;
+				}
+				return originalResolve(...args);
+			});
+
+		try {
+			const unreplicating = db.log.unreplicate([{ id: range.id }]);
+			await resolutionStarted.promise;
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: {
+					replicate: {
+						type: "resume",
+						default: { factor: 0.2, offset: 0.1 },
+					},
+					timeUntilRoleMaturity: 0,
+				},
+			});
+
+			releaseResolution.resolve();
+			await expect(unreplicating).to.be.rejectedWith(
+				"Replication ownership lifecycle is no longer active",
+			);
+			expect(
+				await replicationIndex.count({
+					query: {
+						hash: session.peers[0].identity.publicKey.hashcode(),
+					},
+				}),
+			).to.equal(1);
+		} finally {
+			releaseResolution.resolve();
+			resolve.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("fences trusted-replicator authorization before lane admission", async () => {
+		const { db, log, replicationIndex } = await openDisconnectedLog();
+		const remoteKey = session.peers[1].identity.publicKey;
+		const numbers = log.indexableDomain.numbers;
+		const range = new log.indexableDomain.constructorRange({
+			id: randomBytes(32),
+			offset: numbers.denormalize(0.2),
+			width: numbers.denormalize(0.3),
+			publicKeyHash: remoteKey.hashcode(),
+			timestamp: 1n,
+		});
+		const authorizationStarted = pDefer<void>();
+		const releaseAuthorization = pDefer<void>();
+		const originalTrustedReplicator = log._isTrustedReplicator;
+		log._isTrustedReplicator = async () => {
+			authorizationStarted.resolve();
+			await releaseAuthorization.promise;
+			return true;
+		};
+
+		try {
+			const adding = log.addReplicationRange([range], remoteKey, {
+				checkDuplicates: false,
+				rebalance: false,
+			});
+			await authorizationStarted.promise;
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+
+			releaseAuthorization.resolve();
+			await expect(adding).to.be.rejectedWith(
+				"Replication ownership lifecycle is no longer active",
+			);
+			expect(
+				await replicationIndex.count({
+					query: { hash: remoteKey.hashcode() },
+				}),
+			).to.equal(0);
+		} finally {
+			releaseAuthorization.resolve();
+			log._isTrustedReplicator = originalTrustedReplicator;
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("fences full-owner removal after its receive drain is poisoned", async () => {
+		const { db, log, replicationIndex } = await openDisconnectedLog(1);
+		await db.log.replicate({ factor: 0.2, offset: 0.1 });
+		const drainStarted = pDefer<void>();
+		const releaseDrain = pDefer<void>();
+		const originalDrain = log.drainPeerReceiveHandlers.bind(log);
+		let blockNextDrain = true;
+		const drain = sinon
+			.stub(log, "drainPeerReceiveHandlers")
+			.callsFake(async (...args: unknown[]) => {
+				if (blockNextDrain) {
+					blockNextDrain = false;
+					drainStarted.resolve();
+					await releaseDrain.promise;
+				}
+				return originalDrain(args[0] as string);
+			});
+
+		try {
+			const unreplicating = db.log.unreplicate();
+			await drainStarted.promise;
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			releaseDrain.resolve();
+			await expect(unreplicating).to.be.rejectedWith(
+				"Replication ownership recovery is required",
+			);
+
+			await db.close();
+			await session.peers[0].open(db, {
+				args: {
+					replicate: {
+						type: "resume",
+						default: { factor: 0.2, offset: 0.1 },
+					},
+					timeUntilRoleMaturity: 0,
+				},
+			});
+			expect(
+				await replicationIndex.count({
+					query: {
+						hash: session.peers[0].identity.publicKey.hashcode(),
+					},
+				}),
+			).to.equal(1);
+		} finally {
+			releaseDrain.resolve();
+			drain.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("rolls back every staged positive row after a commit-then-throw put", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog();
+		const remoteKey = session.peers[1].identity.publicKey;
+		const remoteHash = remoteKey.hashcode();
+		const numbers = log.indexableDomain.numbers;
+		const makeRange = (offset: number) =>
+			new log.indexableDomain.constructorRange({
+				id: randomBytes(32),
+				offset: numbers.denormalize(offset),
+				width: numbers.denormalize(0.2),
+				publicKeyHash: remoteHash,
+				timestamp: 1n,
+			});
+		const first = makeRange(0.1);
+		const second = makeRange(0.6);
+		const durableFailure = new Error("forced second positive put failure");
+		const originalPut = replicationIndex.put.bind(replicationIndex);
+		const put = sinon.stub(replicationIndex, "put").callsFake((async (
+			value: any,
+			options?: any,
+		) => {
+			const result = await originalPut(value, options);
+			if (value === second) {
+				throw durableFailure;
+			}
+			return result;
+		}) as any);
+
+		try {
+			await expect(
+				log.addReplicationRange([first, second], remoteKey, {
+					checkDuplicates: false,
+					rebalance: false,
+				}),
+			).to.be.rejectedWith(durableFailure.message);
+			expect(
+				await replicationIndex.count({ query: { hash: remoteHash } }),
+			).to.equal(0);
+			expect(log.uniqueReplicators.has(remoteHash)).to.be.false;
+			expect(log._replicationRangeMutationFailure).to.be.undefined;
+		} finally {
+			put.restore();
+		}
+	});
+
+	it("poisons mutation and planning when positive rollback cannot recover", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog();
+		const remoteKey = session.peers[1].identity.publicKey;
+		const remoteHash = remoteKey.hashcode();
+		const numbers = log.indexableDomain.numbers;
+		const range = new log.indexableDomain.constructorRange({
+			id: randomBytes(32),
+			offset: numbers.denormalize(0.2),
+			width: numbers.denormalize(0.3),
+			publicKeyHash: remoteHash,
+			timestamp: 1n,
+		});
+		const publicationFailure = new Error("forced native publication failure");
+		const rollbackFailure = new Error("forced positive rollback failure");
+		const putNative = sinon
+			.stub(log, "putNativeReplicationRange")
+			.throws(publicationFailure);
+		const del = sinon.stub(replicationIndex, "del").rejects(rollbackFailure);
+
+		try {
+			let observed: unknown;
+			try {
+				await log.addReplicationRange([range], remoteKey, {
+					checkDuplicates: false,
+					rebalance: false,
+				});
+			} catch (error) {
+				observed = error;
+			}
+			expect(observed).to.be.instanceOf(AggregateError);
+			expect((observed as AggregateError).errors).to.deep.equal([
+				publicationFailure,
+				rollbackFailure,
+			]);
+			expect(log._replicationRangeMutationFailure).to.equal(observed);
+			expect(() => log.prune(new Map())).to.throw(
+				"Replication ownership recovery is required",
+			);
+			await expect(
+				log._findLeaders([numbers.denormalize(0.5)]),
+			).to.be.rejectedWith("Replication ownership recovery is required");
+		} finally {
+			putNative.restore();
+			del.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("rejects planning that was awaiting context when ownership poisons", async () => {
+		const { log } = await openDisconnectedLog(1);
+		const numbers = log.indexableDomain.numbers;
+		const subscribersStarted = pDefer<void>();
+		const releaseSubscribers = pDefer<void>();
+		const subscribers = sinon
+			.stub(log, "_getTopicSubscribers")
+			.callsFake(async () => {
+				subscribersStarted.resolve();
+				await releaseSubscribers.promise;
+				return [];
+			});
+		const planner = sinon.stub().returns(new Map());
+		const originalBackbone = log._nativeBackbone;
+		const originalPlanner = log._nativeRangePlanner;
+		log._nativeBackbone = undefined;
+		log._nativeRangePlanner = { findLeaders: planner };
+		log.invalidateLeaderSelectionContextCache();
+
+		try {
+			const planning = log._findLeaders([numbers.denormalize(0.5)], {
+				roleAge: 0,
+			});
+			await subscribersStarted.promise;
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			releaseSubscribers.resolve();
+			await expect(planning).to.be.rejectedWith(
+				"Replication ownership recovery is required",
+			);
+			expect(planner.called).to.be.false;
+		} finally {
+			releaseSubscribers.resolve();
+			subscribers.restore();
+			log._nativeBackbone = originalBackbone;
+			log._nativeRangePlanner = originalPlanner;
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("rejects an old planner after reopen without caching fresh lifecycle state", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const numbers = log.indexableDomain.numbers;
+		const subscribersStarted = pDefer<void>();
+		const releaseSubscribers = pDefer<void>();
+		const originalGetSubscribers = log._getTopicSubscribers.bind(log);
+		const subscribers = sinon
+			.stub(log, "_getTopicSubscribers")
+			.callsFake(async (...args: any[]) => {
+				if (subscribers.callCount === 1) {
+					subscribersStarted.resolve();
+					await releaseSubscribers.promise;
+					return [];
+				}
+				return originalGetSubscribers(...args);
+			});
+		const planner = sinon.stub().returns(new Map());
+		const originalBackbone = log._nativeBackbone;
+		const originalPlanner = log._nativeRangePlanner;
+		log._nativeBackbone = undefined;
+		log._nativeRangePlanner = { findLeaders: planner };
+		log.invalidateLeaderSelectionContextCache();
+
+		try {
+			const planning = log._findLeaders([numbers.denormalize(0.5)], {
+				roleAge: 0,
+			});
+			await subscribersStarted.promise;
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+			log._nativeBackbone = undefined;
+			log._nativeRangePlanner = { findLeaders: planner };
+			log.invalidateLeaderSelectionContextCache();
+			planner.resetHistory();
+
+			releaseSubscribers.resolve();
+			await expect(planning).to.be.rejectedWith(
+				"Replication ownership lifecycle is no longer active",
+			);
+			expect(planner.called).to.be.false;
+			expect(log._leaderSelectionContextCache).to.be.undefined;
+		} finally {
+			releaseSubscribers.resolve();
+			subscribers.restore();
+			log._nativeBackbone = originalBackbone;
+			log._nativeRangePlanner = originalPlanner;
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("fences native append planning across its second await and reopen", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const { entry } = await db.add("native-append-planner-generation");
+		const candidatesStarted = pDefer<void>();
+		const releaseCandidates = pDefer<void>();
+		const originalBackbone = log._nativeBackbone;
+		const staleNativePlanner = {
+			planAppendForGid: sinon.stub(),
+		};
+		const canPlan = sinon.stub(log, "canPlanNativeHashGid").returns(true);
+		const context = sinon.stub(log, "createLeaderSelectionContext").resolves({
+			roleAge: 0,
+			selfHash: session.peers[0].identity.publicKey.hashcode(),
+			selfReplicating: false,
+			peerFilter: undefined,
+		});
+		const candidates = sinon
+			.stub(log, "getFullReplicaRepairCandidates")
+			.callsFake(async () => {
+				candidatesStarted.resolve();
+				await releaseCandidates.promise;
+				return new Set<string>();
+			});
+		log._nativeBackbone = staleNativePlanner;
+		let restored = false;
+		const restoreAdmissionStubs = () => {
+			if (restored) {
+				return;
+			}
+			restored = true;
+			canPlan.restore();
+			context.restore();
+			candidates.restore();
+			if (log._nativeBackbone === staleNativePlanner) {
+				log._nativeBackbone = originalBackbone;
+			}
+		};
+
+		try {
+			const planning = log.planNativeAppendEntry(entry, 1, false);
+			await candidatesStarted.promise;
+			restoreAdmissionStubs();
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+
+			releaseCandidates.resolve();
+			await expect(planning).to.be.rejectedWith(
+				"Replication ownership lifecycle is no longer active",
+			);
+			expect(staleNativePlanner.planAppendForGid.called).to.be.false;
+		} finally {
+			releaseCandidates.resolve();
+			restoreAdmissionStubs();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("fences the native document batch callback before a captured backbone commit after reopen", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const transactionStarted = pDefer<void>();
+		const releaseTransaction = pDefer<void>();
+		const originalBackbone = log._nativeBackbone;
+		const staleCompactCommit = sinon
+			.stub()
+			.throws(new Error("stale native document batch commit ran"));
+		const staleLatestCommit = sinon
+			.stub()
+			.throws(new Error("stale native latest-document batch commit ran"));
+		const staleBackbone = {
+			blocks: {},
+			preparePlainCommittedNoNextStorageAppendDocumentIndexCompactBatchTransaction:
+				staleCompactCommit,
+			preparePlainCommittedStorageAppendDocumentIndexLatestBatchTransaction:
+				staleLatestCommit,
+		};
+		const canUseResidentState = sinon
+			.stub(log, "canUseNativeBackboneResidentCoordinateState")
+			.returns(true);
+		const context = sinon.stub(log, "createLeaderSelectionContext").resolves({
+			roleAge: 0,
+			selfHash: session.peers[0].identity.publicKey.hashcode(),
+			selfReplicating: false,
+			peerFilter: undefined,
+		});
+		const snapshot = sinon
+			.stub(log, "snapshotNativeBackboneDocument")
+			.returns(undefined);
+		const beginTransaction = sinon
+			.stub(log, "beginNativeStrictDurableTransaction")
+			.callsFake(async () => {
+				transactionStarted.resolve();
+				await releaseTransaction.promise;
+				return undefined;
+			});
+		const appendBatch = sinon
+			.stub(log.log, "appendLocallyPreparedNativeKnownNoNextCommitOnlyBatch")
+			.callsFake(async (...args: unknown[]) => {
+				const prepare = args[3] as (inputs: unknown[]) => Promise<unknown>;
+				return prepare([{}]);
+			});
+		log._nativeBackbone = staleBackbone;
+		let restored = false;
+		const restoreAdmissionStubs = () => {
+			if (restored) {
+				return;
+			}
+			restored = true;
+			canUseResidentState.restore();
+			context.restore();
+			snapshot.restore();
+			beginTransaction.restore();
+			appendBatch.restore();
+			if (log._nativeBackbone === staleBackbone) {
+				log._nativeBackbone = originalBackbone;
+			}
+		};
+
+		try {
+			const appending =
+				log.appendLocallyPreparedPayloadsManyNativeBackboneDocumentIndexBatch(
+					["native-document-batch"],
+					{},
+					{ target: "none", replicate: false, delivery: false },
+					{
+						payloadDatas: [new Uint8Array([1])],
+						nativeBackboneDocumentIndexes: [{ projection: {} }],
+					},
+					1,
+				);
+			await transactionStarted.promise;
+			restoreAdmissionStubs();
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+
+			releaseTransaction.resolve();
+			await expect(appending).to.be.rejectedWith(
+				"Replication ownership lifecycle is no longer active",
+			);
+			expect(staleCompactCommit.called).to.be.false;
+			expect(staleLatestCommit.called).to.be.false;
+		} finally {
+			releaseTransaction.resolve();
+			restoreAdmissionStubs();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("fences blocked head-coordinate reconciliation from reopened indexes", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const { entry } = await db.add("head-coordinate-generation");
+		const iterateStarted = pDefer<void>();
+		const releaseIterate = pDefer<void>();
+		const originalBackbone = log._nativeBackbone;
+		const originalNativeState = log._nativeSharedLogState;
+		log._nativeBackbone = undefined;
+		log._nativeSharedLogState = undefined;
+		let nativeStateRestored = false;
+		const coordinateIndex = log.entryCoordinatesIndex;
+		const iterate = sinon.stub(coordinateIndex, "iterate").returns({
+			all: async () => {
+				iterateStarted.resolve();
+				await releaseIterate.promise;
+				return [{ value: { hash: "stale-old-coordinate" } }];
+			},
+		} as any);
+
+		try {
+			const reconciling = log.ensureCurrentHeadCoordinatesIndexed();
+			await iterateStarted.promise;
+			iterate.restore();
+			log._nativeBackbone = originalBackbone;
+			log._nativeSharedLogState = originalNativeState;
+			nativeStateRestored = true;
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+			const deleteCoordinates = sinon.spy(log, "deleteCoordinatesForHashes");
+			const planHeads = sinon.spy(log, "planEntryLeaderBatch");
+
+			try {
+				releaseIterate.resolve();
+				await expect(reconciling).to.be.rejectedWith(
+					"Replication ownership lifecycle is no longer active",
+				);
+				expect(deleteCoordinates.called).to.be.false;
+				expect(planHeads.called).to.be.false;
+				expect(entry.hash).to.not.equal("stale-old-coordinate");
+			} finally {
+				deleteCoordinates.restore();
+				planHeads.restore();
+			}
+		} finally {
+			releaseIterate.resolve();
+			if ((iterate as any).wrappedMethod) {
+				iterate.restore();
+			}
+			if (!nativeStateRestored) {
+				log._nativeBackbone = originalBackbone;
+				log._nativeSharedLogState = originalNativeState;
+			}
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("fences a blocked replication announcement from reopened repair queues", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const announcementStarted = pDefer<void>();
+		const releaseAnnouncement = pDefer<void>();
+		let announcementSignal: AbortSignal | undefined;
+		const send = sinon
+			.stub(log.rpc, "send")
+			.callsFake(async (...args: unknown[]) => {
+				const message = args[0];
+				const options = args[1] as { signal?: AbortSignal } | undefined;
+				if (message instanceof StoppedReplicating) {
+					announcementSignal = options?.signal;
+					announcementStarted.resolve();
+					await releaseAnnouncement.promise;
+				}
+				return [] as any;
+			});
+		const queueRepair = sinon.spy(
+			log,
+			"queueCurrentReplicationStateAnnouncementRepair",
+		);
+		const queueRetry = sinon.spy(
+			log,
+			"queueCurrentReplicationStateAnnouncementRetry",
+		);
+		const ownershipLifecycleController = log._repairLifecycleController;
+
+		try {
+			const announcing = log.sendReplicationAnnouncement(
+				new StoppedReplicating({ segmentIds: [] }),
+			);
+			await announcementStarted.promise;
+			expect(announcementSignal).to.equal(ownershipLifecycleController.signal);
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			expect(announcementSignal?.aborted).to.be.true;
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+			queueRepair.resetHistory();
+			queueRetry.resetHistory();
+
+			releaseAnnouncement.resolve();
+			await expect(announcing).to.be.rejectedWith(
+				"Replication ownership lifecycle is no longer active",
+			);
+			expect(queueRepair.called).to.be.false;
+			expect(queueRetry.called).to.be.false;
+		} finally {
+			releaseAnnouncement.resolve();
+			queueRepair.restore();
+			queueRetry.restore();
+			send.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("does not let a stale announcement retry poison reopened ownership", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const snapshotReadStarted = pDefer<void>();
+		const releaseSnapshotRead = pDefer<void>();
+		const getMyReplicationSegments = sinon
+			.stub(log, "getMyReplicationSegments")
+			.callsFake(async () => {
+				snapshotReadStarted.resolve();
+				await releaseSnapshotRead.promise;
+				return [
+					{
+						toReplicationRange: () => ({ mode: "invalid-stale-mode" }),
+					},
+				];
+			});
+
+		try {
+			const retrying = log.retryCurrentReplicationStateAnnouncement();
+			await snapshotReadStarted.promise;
+			getMyReplicationSegments.restore();
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+			const reopenedLifecycle = log._repairLifecycleController;
+
+			releaseSnapshotRead.resolve();
+			await retrying;
+
+			expect(log._replicationRangeMutationFailure).to.be.undefined;
+			expect(log._repairLifecycleController).to.equal(reopenedLifecycle);
+			expect(reopenedLifecycle.signal.aborted).to.be.false;
+		} finally {
+			releaseSnapshotRead.resolve();
+			if ((getMyReplicationSegments as any).wrappedMethod) {
+				getMyReplicationSegments.restore();
+			}
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("does not let a stale announcement repair poison reopened ownership", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const snapshotReadStarted = pDefer<void>();
+		const releaseSnapshotRead = pDefer<void>();
+		const getMyReplicationSegments = sinon
+			.stub(log, "getMyReplicationSegments")
+			.callsFake(async () => {
+				snapshotReadStarted.resolve();
+				await releaseSnapshotRead.promise;
+				return [
+					{
+						toReplicationRange: () => ({ mode: "invalid-stale-mode" }),
+					},
+				];
+			});
+		log._replicationAnnouncementRepairPending = true;
+
+		try {
+			const repairing = log.runCurrentReplicationStateAnnouncementRepair();
+			await snapshotReadStarted.promise;
+			getMyReplicationSegments.restore();
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+			const reopenedLifecycle = log._repairLifecycleController;
+
+			releaseSnapshotRead.resolve();
+			await repairing;
+
+			expect(log._replicationRangeMutationFailure).to.be.undefined;
+			expect(log._repairLifecycleController).to.equal(reopenedLifecycle);
+			expect(reopenedLifecycle.signal.aborted).to.be.false;
+		} finally {
+			releaseSnapshotRead.resolve();
+			if ((getMyReplicationSegments as any).wrappedMethod) {
+				getMyReplicationSegments.restore();
+			}
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("fences a blocked repair runner from poison and reopened frontier state", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const firstSendStarted = pDefer<void>();
+		const secondSendStarted = pDefer<void>();
+		const releaseFirstSend = pDefer<void>();
+		const sentBatches: string[][] = [];
+		const send = sinon
+			.stub(log, "sendMaybeMissingEntriesNow")
+			.callsFake(async (...args: unknown[]) => {
+				const entries = args[1] as Map<string, unknown>;
+				sentBatches.push([...entries.keys()]);
+				if (sentBatches.length === 1) {
+					firstSendStarted.resolve();
+					await releaseFirstSend.promise;
+				} else {
+					secondSendStarted.resolve();
+				}
+			});
+
+		try {
+			log.queueRepairFrontierEntries(
+				"churn",
+				"target",
+				new Map([["old", { hash: "old" }]]),
+			);
+			log.ensureRepairFrontierRunner("churn", "target", [0, 5]);
+			await firstSendStarted.promise;
+
+			const oldRepairLifecycle = log._repairLifecycleController;
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			expect(oldRepairLifecycle.signal.aborted).to.be.true;
+			expect(log._repairRetryTimers.size).to.equal(0);
+
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+			log.queueRepairFrontierEntries(
+				"churn",
+				"target",
+				new Map([["new", { hash: "new" }]]),
+			);
+
+			releaseFirstSend.resolve();
+			await delay(30);
+			expect(sentBatches).to.deep.equal([["old"]]);
+			expect(log._repairRetryTimers.size).to.equal(0);
+			expect([
+				...(log._repairFrontierByMode.get("churn")?.get("target")?.keys() ??
+					[]),
+			]).to.deep.equal(["new"]);
+
+			log.ensureRepairFrontierRunner("churn", "target", [0, 1_000]);
+			await secondSendStarted.promise;
+			expect(sentBatches).to.deep.equal([["old"], ["new"]]);
+		} finally {
+			releaseFirstSend.resolve();
+			log.poisonReplicationOwnership(new Error("test cleanup"));
+			send.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("stops a fused repair send before its next publish after poison", async () => {
+		const { log } = await openDisconnectedLog(1);
+		const publishStarted = pDefer<void>();
+		const abortError = new Error("fused repair publish aborted");
+		let capturedSignal: AbortSignal | undefined;
+		const pubsub = session.peers[0].services.pubsub as any;
+		const publish = sinon
+			.stub(pubsub, "publishPreEncodedData")
+			.callsFake(async (...args: unknown[]) => {
+				const options = args[2] as { signal?: AbortSignal } | undefined;
+				capturedSignal = options?.signal;
+				publishStarted.resolve();
+				await new Promise<void>((_resolve, reject) => {
+					const rejectForAbort = () => reject(abortError);
+					if (capturedSignal?.aborted) {
+						rejectForAbort();
+					} else {
+						capturedSignal?.addEventListener("abort", rejectForAbort, {
+							once: true,
+						});
+					}
+				});
+				return undefined;
+			});
+		const originalBackbone = log._nativeBackbone;
+		const profileEvents: any[] = [];
+		log._logProperties.sync = {
+			...(log._logProperties.sync ?? {}),
+			profile: (event: any) => profileEvents.push(event),
+		};
+		let encoded = 0;
+		log._nativeBackbone = {
+			encodeRawExchangeSyncPayload: () => new Uint8Array([++encoded]),
+			syncSendBlockByteLengths: () => [600_000, 600_000],
+		};
+		const ownershipLifecycleController = log._repairLifecycleController;
+
+		try {
+			const sending = log.sendFusedRawExchangeHeadsPlan(
+				{
+					hashes: ["first", "second"],
+					gidRefrences: [[], []],
+				},
+				["target"],
+				{ signal: ownershipLifecycleController.signal },
+			);
+			await publishStarted.promise;
+			expect(capturedSignal).to.equal(ownershipLifecycleController.signal);
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+
+			await expect(sending).to.be.rejectedWith(abortError.message);
+			expect(publish.callCount).to.equal(1);
+			expect(encoded).to.equal(2);
+			const profile = profileEvents.find(
+				(event) => event.name === "sharedLog.rawSend.fused",
+			);
+			expect(profile).to.include({
+				entries: 0,
+				bytes: 0,
+				messages: 0,
+			});
+			expect(profile.details).to.include({
+				attemptedMessages: 1,
+				cancelled: true,
+				plannedEntries: 2,
+				plannedMessages: 2,
+			});
+		} finally {
+			publish.restore();
+			log._nativeBackbone = originalBackbone;
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("aborts an in-flight TS repair fallback send when ownership is poisoned", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const { entry } = await db.add(uuid(), { meta: { next: [] } });
+		const sendStarted = pDefer<void>();
+		const releaseSend = pDefer<void>();
+		const abortError = new Error("repair fallback send aborted");
+		let capturedSignal: AbortSignal | undefined;
+		const originalSend = log.rpc.send.bind(log.rpc);
+		const send = sinon.stub(log.rpc, "send").callsFake((async (
+			message: unknown,
+			options?: { signal?: AbortSignal },
+		) => {
+			if (!(message instanceof ExchangeHeadsMessage)) {
+				return originalSend(message, options);
+			}
+			capturedSignal = options?.signal;
+			sendStarted.resolve();
+			if (!capturedSignal) {
+				await releaseSend.promise;
+				return;
+			}
+			await new Promise<void>((_resolve, reject) => {
+				const rejectForAbort = () => reject(abortError);
+				if (capturedSignal?.aborted) {
+					rejectForAbort();
+				} else {
+					capturedSignal?.addEventListener("abort", rejectForAbort, {
+						once: true,
+					});
+				}
+			});
+		}) as any);
+		const ownershipLifecycleController = log._repairLifecycleController;
+
+		try {
+			const sending = log.sendRepairEntriesWithTransport(
+				"target",
+				new Map([[entry.hash, { hash: entry.hash }]]),
+				"simple",
+				{
+					bypassKnownPeers: true,
+					bypassRecentKnownPeers: true,
+					isStillCurrent: () =>
+						log.isRepairLifecycleActive(ownershipLifecycleController),
+					signal: ownershipLifecycleController.signal,
+				},
+			);
+			await sendStarted.promise;
+			expect(capturedSignal).to.equal(ownershipLifecycleController.signal);
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await expect(sending).to.be.rejectedWith(abortError.message);
+			expect(send.callCount).to.equal(1);
+		} finally {
+			releaseSend.resolve();
+			send.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("fences a blocked replication-change callback from reopened state", async () => {
+		const { db, log } = await openDisconnectedLog(2);
+		const numbers = log.indexableDomain.numbers;
+		const remoteKey = session.peers[1].identity.publicKey;
+		const range = new log.indexableDomain.constructorRange({
+			id: randomBytes(32),
+			offset: numbers.denormalize(0.2),
+			width: numbers.denormalize(0.2),
+			publicKeyHash: remoteKey.hashcode(),
+			timestamp: 1n,
+		});
+		const trimStarted = pDefer<void>();
+		const releaseTrim = pDefer<void>();
+		const originalTrim = log.log.trim.bind(log.log);
+		const trim = sinon
+			.stub(log.log, "trim")
+			.callsFake(async (...args: any[]) => {
+				if (trim.callCount === 1) {
+					trimStarted.resolve();
+					await releaseTrim.promise;
+					return;
+				}
+				return originalTrim(...args);
+			});
+
+		try {
+			const changing = log.onReplicationChange([
+				{ range, type: "removed", timestamp: 2n },
+			]);
+			await trimStarted.promise;
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+			const freshCheckedPrune = log._checkedPrune;
+			const freshRecentRepairDispatch = log._recentRepairDispatch;
+			const freshRepairTimers = log._repairRetryTimers;
+			const freshGidHistory = log._gidPeersHistory;
+			const freshFrontier = log._repairFrontierByMode;
+
+			releaseTrim.resolve();
+			expect(await changing).to.equal(false);
+			await delay(275);
+			expect(log._checkedPrune).to.equal(freshCheckedPrune);
+			expect(log._recentRepairDispatch).to.equal(freshRecentRepairDispatch);
+			expect(log._repairRetryTimers).to.equal(freshRepairTimers);
+			expect(log._gidPeersHistory).to.equal(freshGidHistory);
+			expect(log._repairFrontierByMode).to.equal(freshFrontier);
+			expect(freshRecentRepairDispatch.size).to.equal(0);
+			expect(freshRepairTimers.size).to.equal(0);
+			expect(freshGidHistory.size).to.equal(0);
+			for (const targets of freshFrontier.values()) {
+				expect(targets.size).to.equal(0);
+			}
+		} finally {
+			releaseTrim.resolve();
+			trim.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("cancels an admitted prune poisoned during ownership revalidation", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: 1, timeUntilRoleMaturity: 0 },
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("prune-race");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const plannerStarted = pDefer<void>();
+		const releasePlanner = pDefer<void>();
+		const waitForReplicators = sinon
+			.stub(log, "_waitForEntryReplicators")
+			.resolves(true);
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const findLeaders = sinon
+			.stub(log, "findLeadersFromEntry")
+			.callsFake(async () => {
+				plannerStarted.resolve();
+				await releasePlanner.promise;
+				return new Map();
+			});
+		const remove = sinon.stub(log.log, "remove").resolves();
+
+		try {
+			const [pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 2_000,
+			});
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			expect(pending).to.exist;
+			await pending.resolve(remoteHash);
+			await plannerStarted.promise;
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			releasePlanner.resolve();
+
+			await expect(pruning).to.be.rejectedWith(
+				"Replication ownership recovery is required",
+			);
+			expect(remove.called).to.be.false;
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
+		} finally {
+			releasePlanner.resolve();
+			waitForReplicators.restore();
+			getClampedReplicas.restore();
+			send.restore();
+			findLeaders.restore();
+			remove.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("keeps a stale checked prune out of the reopened coordinator", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: 1, timeUntilRoleMaturity: 0 },
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("prune-reopen-race");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const plannerStarted = pDefer<void>();
+		const releasePlanner = pDefer<void>();
+		const waitForReplicators = sinon
+			.stub(log, "_waitForEntryReplicators")
+			.resolves(true);
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const findLeaders = sinon
+			.stub(log, "findLeadersFromEntry")
+			.callsFake(async () => {
+				if (findLeaders.callCount === 1) {
+					plannerStarted.resolve();
+					await releasePlanner.promise;
+				}
+				return new Map();
+			});
+		const remove = sinon.stub(log.log, "remove").resolves();
+		let freshMarkRemoving: any;
+
+		try {
+			const [pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 2_000,
+			});
+			const pruningOutcome = pruning.then(
+				() => ({ status: "fulfilled" as const }),
+				(error: unknown) => ({ status: "rejected" as const, error }),
+			);
+			const oldCoordinator = log._checkedPrune;
+			const pending = oldCoordinator.getPendingDelete(entry.hash);
+			expect(pending).to.exist;
+			await pending.resolve(remoteHash);
+			await plannerStarted.promise;
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			await db.close();
+			await session.peers[0].open(db, {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+			const freshCoordinator = log._checkedPrune;
+			expect(freshCoordinator).to.not.equal(oldCoordinator);
+			const freshPendingBeforeRelease = freshCoordinator.getPendingDelete(
+				entry.hash,
+			);
+			freshMarkRemoving = sinon.spy(freshCoordinator, "markRemoving");
+
+			releasePlanner.resolve();
+			const outcome = await pruningOutcome;
+			// Terminal close deliberately settles old pending prunes so callers do
+			// not hang; the important boundary is that the resumed callback cannot
+			// perform the delete or touch the newly opened coordinator.
+			expect(outcome.status).to.equal("fulfilled");
+			await delay(25);
+			expect(remove.called).to.be.false;
+			expect(freshMarkRemoving.called).to.be.false;
+			expect(freshCoordinator.getPendingDelete(entry.hash)).to.equal(
+				freshPendingBeforeRelease,
+			);
+		} finally {
+			releasePlanner.resolve();
+			waitForReplicators.restore();
+			getClampedReplicas.restore();
+			send.restore();
+			findLeaders.restore();
+			remove.restore();
+			freshMarkRemoving?.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("settles a successful admitted prune without a post-remove poison rejection", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: 1, timeUntilRoleMaturity: 0 },
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("prune-post-remove-race");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const removeStarted = pDefer<void>();
+		const releaseRemove = pDefer<void>();
+		const waitForReplicators = sinon
+			.stub(log, "_waitForEntryReplicators")
+			.resolves(true);
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const findLeaders = sinon
+			.stub(log, "findLeadersFromEntry")
+			.resolves(leaders);
+		const remove = sinon.stub(log.log, "remove").callsFake(async () => {
+			removeStarted.resolve();
+			await releaseRemove.promise;
+		});
+		const unhandledRejections: unknown[] = [];
+		const onUnhandledRejection = (reason: unknown) => {
+			unhandledRejections.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandledRejection);
+
+		try {
+			const [pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 2_000,
+			});
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			expect(pending).to.exist;
+			await pending.resolve(remoteHash);
+			await removeStarted.promise;
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			releaseRemove.resolve();
+
+			await pruning;
+			await delay(25);
+			expect(remove.calledOnce).to.be.true;
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
+			expect(unhandledRejections).to.deep.equal([]);
+		} finally {
+			process.removeListener("unhandledRejection", onUnhandledRejection);
+			releaseRemove.resolve();
+			waitForReplicators.restore();
+			getClampedReplicas.restore();
+			send.restore();
+			findLeaders.restore();
+			remove.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	for (const unchecked of [false, true]) {
+		it(`drains an admitted ${unchecked ? "unchecked" : "checked"} lower-log remove before reopen`, async () => {
+			session = await TestSession.disconnected(2);
+			const db = await session.peers[0].open(new EventStore(), {
+				args: { replicate: 1, timeUntilRoleMaturity: 0 },
+			});
+			const log = db.log as any;
+			const { entry } = await db.add(
+				unchecked ? "unchecked-prune-drain" : "checked-prune-drain",
+			);
+			const remoteHash = session.peers[1].identity.publicKey.hashcode();
+			const leaders = new Map([[remoteHash, { intersecting: true }]]);
+			const removeStarted = pDefer<void>();
+			const releaseRemove = pDefer<void>();
+			const waitForReplicators = sinon
+				.stub(log, "_waitForEntryReplicators")
+				.resolves(true);
+			const getClampedReplicas = sinon
+				.stub(log, "getClampedReplicas")
+				.returns({ getValue: () => 1 });
+			const send = sinon.stub(log.rpc, "send").resolves();
+			const findLeaders = sinon
+				.stub(log, "findLeadersFromEntry")
+				.resolves(leaders);
+			const remove = sinon.stub(log.log, "remove").callsFake(async () => {
+				removeStarted.resolve();
+				await releaseRemove.promise;
+			});
+
+			try {
+				const [pruning] = log.prune(
+					new Map([[entry.hash, { entry, leaders }]]),
+					{ timeout: 2_000, unchecked },
+				);
+				if (!unchecked) {
+					const pending = log._checkedPrune.getPendingDelete(entry.hash);
+					expect(pending).to.exist;
+					await pending.resolve(remoteHash);
+				}
+				await removeStarted.promise;
+				expect(log._admittedPruneRemoves.size).to.equal(1);
+
+				log.poisonReplicationOwnership(new Error("forced ownership poison"));
+				let closeSettled = false;
+				const closing = db.close().finally(() => {
+					closeSettled = true;
+				});
+				await delay(25);
+				expect(closeSettled).to.be.false;
+
+				releaseRemove.resolve();
+				await Promise.all([pruning, closing]);
+				expect(log._admittedPruneRemoves.size).to.equal(0);
+				await session.peers[0].open(db, {
+					args: { replicate: false, timeUntilRoleMaturity: 0 },
+				});
+				const callsAtReopen = remove.callCount;
+				await delay(25);
+
+				expect(callsAtReopen).to.equal(1);
+				expect(remove.callCount).to.equal(callsAtReopen);
+				expect(log._admittedPruneRemoves.size).to.equal(0);
+			} finally {
+				releaseRemove.resolve();
+				waitForReplicators.restore();
+				getClampedReplicas.restore();
+				send.restore();
+				findLeaders.restore();
+				remove.restore();
+				log._replicationRangeMutationFailure = undefined;
+			}
+		});
+	}
+
+	it("cancels pending maturity without emitting after ownership poison", async () => {
+		const { log } = await openDisconnectedLog();
+		const remoteKey = session.peers[1].identity.publicKey;
+		const numbers = log.indexableDomain.numbers;
+		const range = new log.indexableDomain.constructorRange({
+			id: randomBytes(32),
+			offset: numbers.denormalize(0.2),
+			width: numbers.denormalize(0.3),
+			publicKeyHash: remoteKey.hashcode(),
+			timestamp: BigInt(Date.now()),
+		});
+		let matureEvents = 0;
+		log.events.addEventListener("replicator:mature", () => {
+			matureEvents += 1;
+		});
+		const rebalance = sinon.spy(log.replicationChangeDebounceFn, "add");
+
+		try {
+			log.schedulePendingMaturity(
+				{ type: "added", range, timestamp: range.timestamp },
+				remoteKey,
+				{ rebalance: true, waitMs: 20 },
+			);
+			expect(log.pendingMaturity.size).to.equal(1);
+
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			expect(log.pendingMaturity.size).to.equal(0);
+			await delay(50);
+
+			expect(matureEvents).to.equal(0);
+			expect(rebalance.called).to.be.false;
+		} finally {
+			rebalance.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("suppresses pending maturity while terminal close is still in progress", async () => {
+		const { db, log } = await openDisconnectedLog();
+		const remoteKey = session.peers[1].identity.publicKey;
+		const numbers = log.indexableDomain.numbers;
+		const range = new log.indexableDomain.constructorRange({
+			id: randomBytes(32),
+			offset: numbers.denormalize(0.2),
+			width: numbers.denormalize(0.3),
+			publicKeyHash: remoteKey.hashcode(),
+			timestamp: BigInt(Date.now()),
+		});
+		const closeAnnouncementStarted = pDefer<void>();
+		const releaseCloseAnnouncement = pDefer<void>();
+		let matureEvents = 0;
+		log.events.addEventListener("replicator:mature", () => {
+			matureEvents += 1;
+		});
+		const rebalance = sinon.spy(log.replicationChangeDebounceFn, "add");
+		const send = sinon
+			.stub(log.rpc, "send")
+			.callsFake(async (message: unknown) => {
+				if (
+					message instanceof AllReplicatingSegmentsMessage &&
+					message.segments.length === 0
+				) {
+					closeAnnouncementStarted.resolve();
+					await releaseCloseAnnouncement.promise;
+				}
+				return [] as any;
+			});
+		const ownershipLifecycleController = log._repairLifecycleController;
+
+		try {
+			log.schedulePendingMaturity(
+				{ type: "added", range, timestamp: range.timestamp },
+				remoteKey,
+				{ rebalance: true, waitMs: 20 },
+			);
+			expect(log.pendingMaturity.size).to.equal(1);
+
+			const closing = db.close();
+			await closeAnnouncementStarted.promise;
+			expect(ownershipLifecycleController.signal.aborted).to.be.true;
+			await delay(50);
+
+			expect(matureEvents).to.equal(0);
+			expect(rebalance.called).to.be.false;
+			expect(log.pendingMaturity.size).to.equal(0);
+
+			releaseCloseAnnouncement.resolve();
+			await closing;
+		} finally {
+			releaseCloseAnnouncement.resolve();
+			rebalance.restore();
+			send.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("reconciles committed timestamp rows, poisons, and rejects a queued follower", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(1);
+		const numbers = log.indexableDomain.numbers;
+		const selfKey = session.peers[0].identity.publicKey;
+		const ranges = [0.1, 0.6].map(
+			(offset, index) =>
+				new log.indexableDomain.constructorRange({
+					id: new Uint8Array([index + 1, 42]),
+					offset: numbers.denormalize(offset),
+					width: numbers.denormalize(0.2),
+					publicKeyHash: selfKey.hashcode(),
+					timestamp: 1n,
+				}),
+		);
+		for (const range of ranges) {
+			await replicationIndex.put(range);
+		}
+		const durableFailure = new Error("forced timestamp commit-then-throw");
+		const originalPut = replicationIndex.put.bind(replicationIndex);
+		const put = sinon.stub(replicationIndex, "put").callsFake((async (
+			value: any,
+			options?: any,
+		) => {
+			const result = await originalPut(value, options);
+			if (value.idString === ranges[1].idString && value.timestamp === 9n) {
+				throw durableFailure;
+			}
+			return result;
+		}) as any);
+		const nativePut = sinon.stub(log, "putNativeReplicationRange");
+
+		try {
+			const first = log.updateTimestampOfOwnedReplicationRanges(9);
+			const follower = log.updateTimestampOfOwnedReplicationRanges(10);
+			const [firstResult, followerResult] = await Promise.allSettled([
+				first,
+				follower,
+			]);
+			expect(firstResult.status).to.equal("rejected");
+			expect(followerResult.status).to.equal("rejected");
+			expect((firstResult as PromiseRejectedResult).reason).to.be.instanceOf(
+				AggregateError,
+			);
+			expect((firstResult as PromiseRejectedResult).reason.errors).to.include(
+				durableFailure,
+			);
+			expect(
+				(followerResult as PromiseRejectedResult).reason.message,
+			).to.contain("Replication ownership recovery is required");
+			const durable = await replicationIndex
+				.iterate({ query: { hash: selfKey.hashcode() } })
+				.all();
+			expect(
+				durable.map((result: any) => result.value.timestamp),
+			).to.deep.equal([9n, 9n]);
+			expect(
+				nativePut.calledWithMatch(
+					sinon.match.has("idString", ranges[0].idString),
+				),
+			).to.be.true;
+			expect(
+				nativePut.calledWithMatch(
+					sinon.match.has("idString", ranges[1].idString),
+				),
+			).to.be.true;
+			expect(log._replicationRangeMutationFailure).to.equal(
+				(firstResult as PromiseRejectedResult).reason,
+			);
+		} finally {
+			put.restore();
+			nativePut.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("poisons and reconciles timestamp state after a native publication failure", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(1);
+		const numbers = log.indexableDomain.numbers;
+		const selfKey = session.peers[0].identity.publicKey;
+		const range = new log.indexableDomain.constructorRange({
+			id: new Uint8Array([7, 42]),
+			offset: numbers.denormalize(0.25),
+			width: numbers.denormalize(0.2),
+			publicKeyHash: selfKey.hashcode(),
+			timestamp: 1n,
+		});
+		await replicationIndex.put(range);
+		const nativeFailure = new Error("forced timestamp native failure");
+		const nativePut = sinon
+			.stub(log, "putNativeReplicationRange")
+			.onFirstCall()
+			.throws(nativeFailure);
+
+		try {
+			let observed: any;
+			try {
+				await log.updateTimestampOfOwnedReplicationRanges(12);
+			} catch (error) {
+				observed = error;
+			}
+			expect(observed).to.be.instanceOf(AggregateError);
+			expect(observed.errors).to.include(nativeFailure);
+			expect(log._replicationRangeMutationFailure).to.equal(observed);
+			expect(nativePut.callCount).to.equal(2);
+			const durable = await replicationIndex
+				.iterate({ query: { hash: selfKey.hashcode() } })
+				.all();
+			expect(durable[0].value.timestamp).to.equal(12n);
+		} finally {
+			nativePut.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("cancels delayed owned-range maturity after ownership poison", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog(1);
+		const numbers = log.indexableDomain.numbers;
+		const selfKey = session.peers[0].identity.publicKey;
+		const range = new log.indexableDomain.constructorRange({
+			id: new Uint8Array([8, 42]),
+			offset: numbers.denormalize(0.35),
+			width: numbers.denormalize(0.2),
+			publicKeyHash: selfKey.hashcode(),
+			timestamp: 1n,
+		});
+		await replicationIndex.put(range);
+		const minRoleAge = sinon.stub(log, "getDefaultMinRoleAge").resolves(30);
+		let matureEvents = 0;
+		log.events.addEventListener("replicator:mature", () => {
+			matureEvents += 1;
+		});
+
+		try {
+			await log.updateTimestampOfOwnedReplicationRanges(13);
+			expect(log._repairRetryTimers.size).to.equal(1);
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			expect(log._repairRetryTimers.size).to.equal(0);
+			await delay(60);
+			expect(matureEvents).to.equal(0);
+		} finally {
+			minRoleAge.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("observes an in-flight replication debounce rejection after poison", async () => {
+		const { log } = await openDisconnectedLog();
+		const remoteKey = session.peers[1].identity.publicKey;
+		const numbers = log.indexableDomain.numbers;
+		const range = new log.indexableDomain.constructorRange({
+			id: randomBytes(32),
+			offset: numbers.denormalize(0.2),
+			width: numbers.denormalize(0.3),
+			publicKeyHash: remoteKey.hashcode(),
+			timestamp: 1n,
+		});
+		const callbackStarted = pDefer<void>();
+		const releaseCallback = pDefer<void>();
+		const callbackFailure = new Error("forced debounced callback failure");
+		const onReplicationChange = sinon
+			.stub(log, "onReplicationChange")
+			.callsFake(async () => {
+				callbackStarted.resolve();
+				await releaseCallback.promise;
+				throw callbackFailure;
+			});
+		const unhandledRejections: unknown[] = [];
+		const onUnhandledRejection = (reason: unknown) => {
+			unhandledRejections.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandledRejection);
+
+		try {
+			void log.replicationChangeDebounceFn.add({
+				range,
+				type: "removed",
+				timestamp: 1n,
+			});
+			await callbackStarted.promise;
+			log.poisonReplicationOwnership(new Error("forced ownership poison"));
+			releaseCallback.resolve();
+			await delay(25);
+
+			expect(onReplicationChange.calledOnce).to.be.true;
+			expect(unhandledRejections).to.deep.equal([]);
+		} finally {
+			process.removeListener("unhandledRejection", onUnhandledRejection);
+			releaseCallback.resolve();
+			onReplicationChange.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
 	});
 
 	it("replicator:(join|leave)", async () => {
@@ -113,6 +3829,18 @@ describe("events", () => {
 				return peerKey.bytes;
 			},
 		} as unknown as PublicSignKey;
+		const log = db1.log as any;
+		const numbers = log.indexableDomain.numbers;
+		await log.replicationIndex.put(
+			new log.indexableDomain.constructorRange({
+				id: randomBytes(32),
+				offset: numbers.denormalize(0.1),
+				width: numbers.denormalize(0.2),
+				publicKeyHash: peerKey.hashcode(),
+				timestamp: 1n,
+			}),
+		);
+		log.uniqueReplicators.add(peerKey.hashcode());
 
 		const changes: string[] = [];
 		db1.log.events.addEventListener("replication:change", (event) => {
@@ -126,6 +3854,110 @@ describe("events", () => {
 		).removeReplicator(foreignKey);
 
 		expect(changes).to.deep.equal([peerKey.hashcode()]);
+	});
+
+	it("does not publish deletion or leave effects for retained owner ranges", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog();
+		const remoteKey = session.peers[1].identity.publicKey;
+		const remoteHash = remoteKey.hashcode();
+		const numbers = log.indexableDomain.numbers;
+		const ranges = [0.1, 0.6].map(
+			(offset) =>
+				new log.indexableDomain.constructorRange({
+					id: randomBytes(32),
+					offset: numbers.denormalize(offset),
+					width: numbers.denormalize(0.2),
+					publicKeyHash: remoteHash,
+					timestamp: 1n,
+				}),
+		);
+		for (const range of ranges) {
+			await replicationIndex.put(range);
+		}
+		log.uniqueReplicators.add(remoteHash);
+		const deletionFailure = new Error("forced retained deletion");
+		const deletion = sinon
+			.stub(log, "deleteReplicationRangesCoherently")
+			.resolves({
+				removed: [],
+				retained: ranges,
+				ownerHasRanges: true,
+				error: deletionFailure,
+			});
+		const rebalance = sinon
+			.stub(log.replicationChangeDebounceFn, "add")
+			.resolves();
+		const onRemoved = sinon.spy();
+		const changes: string[] = [];
+		log.events.addEventListener("replication:change", (event: any) => {
+			changes.push(event.detail.publicKey.hashcode());
+		});
+
+		try {
+			await expect(
+				log.removeReplicator(remoteKey, { onRemoved }),
+			).to.be.rejectedWith(deletionFailure.message);
+			expect(changes).to.deep.equal([]);
+			expect(rebalance.called).to.be.false;
+			expect(onRemoved.called).to.be.false;
+		} finally {
+			deletion.restore();
+			rebalance.restore();
+		}
+	});
+
+	it("publishes only confirmed partial deletions without a full-owner leave", async () => {
+		const { log, replicationIndex } = await openDisconnectedLog();
+		const remoteKey = session.peers[1].identity.publicKey;
+		const remoteHash = remoteKey.hashcode();
+		const numbers = log.indexableDomain.numbers;
+		const ranges = [0.1, 0.6].map(
+			(offset) =>
+				new log.indexableDomain.constructorRange({
+					id: randomBytes(32),
+					offset: numbers.denormalize(offset),
+					width: numbers.denormalize(0.2),
+					publicKeyHash: remoteHash,
+					timestamp: 1n,
+				}),
+		);
+		for (const range of ranges) {
+			await replicationIndex.put(range);
+		}
+		log.uniqueReplicators.add(remoteHash);
+		const deletionFailure = new Error("forced partial deletion");
+		const deletion = sinon
+			.stub(log, "deleteReplicationRangesCoherently")
+			.resolves({
+				removed: [ranges[0]],
+				retained: [ranges[1]],
+				ownerHasRanges: true,
+				error: deletionFailure,
+			});
+		const rebalance = sinon
+			.stub(log.replicationChangeDebounceFn, "add")
+			.resolves();
+		const onRemoved = sinon.spy();
+		const changes: string[] = [];
+		log.events.addEventListener("replication:change", (event: any) => {
+			changes.push(event.detail.publicKey.hashcode());
+		});
+
+		try {
+			await expect(
+				log.removeReplicator(remoteKey, { onRemoved }),
+			).to.be.rejectedWith(deletionFailure.message);
+			expect(changes).to.deep.equal([remoteHash]);
+			expect(rebalance.calledOnce).to.be.true;
+			expect(rebalance.firstCall.args[0]).to.include({
+				range: ranges[0],
+				type: "removed",
+			});
+			expect(onRemoved.called).to.be.false;
+		} finally {
+			deletion.restore();
+			rebalance.restore();
+		}
 	});
 
 	it("fences a reconnect until an in-flight unsubscribe removal is coherent", async () => {
@@ -155,19 +3987,23 @@ describe("events", () => {
 		const releaseDelete = pDefer<void>();
 		const originalDel = replicationIndex.del.bind(replicationIndex);
 		let blockNextRemovalDelete = true;
-		const del = sinon
-			.stub(replicationIndex, "del")
-			.callsFake((async (query: any, options?: any) => {
-				if (
-					blockNextRemovalDelete &&
-					query?.query?.hash === remoteHash
-				) {
-					blockNextRemovalDelete = false;
-					deleteStarted.resolve();
-					await releaseDelete.promise;
-				}
-				return originalDel(query, options);
-			}) as any);
+		const del = sinon.stub(replicationIndex, "del").callsFake((async (
+			query: any,
+			options?: any,
+		) => {
+			const ownerScopedDelete =
+				query?.query?.hash === remoteHash ||
+				query?.query?.and?.some(
+					(part: any) =>
+						part?.value === remoteHash && part?.key?.includes("hash"),
+				);
+			if (blockNextRemovalDelete && ownerScopedDelete) {
+				blockNextRemovalDelete = false;
+				deleteStarted.resolve();
+				await releaseDelete.promise;
+			}
+			return originalDel(query, options);
+		}) as any);
 		const disconnected = sinon.spy(log.syncronizer, "onPeerDisconnected");
 		const leaves: string[] = [];
 		db1.log.events.addEventListener("replicator:leave", (event) => {
@@ -268,19 +4104,23 @@ describe("events", () => {
 		const releaseDelete = pDefer<void>();
 		const originalDel = replicationIndex.del.bind(replicationIndex);
 		let blockNextRemovalDelete = true;
-		const del = sinon
-			.stub(replicationIndex, "del")
-			.callsFake((async (query: any, options?: any) => {
-				if (
-					blockNextRemovalDelete &&
-					query?.query?.hash === remoteHash
-				) {
-					blockNextRemovalDelete = false;
-					deleteStarted.resolve();
-					await releaseDelete.promise;
-				}
-				return originalDel(query, options);
-			}) as any);
+		const del = sinon.stub(replicationIndex, "del").callsFake((async (
+			query: any,
+			options?: any,
+		) => {
+			const ownerScopedDelete =
+				query?.query?.hash === remoteHash ||
+				query?.query?.and?.some(
+					(part: any) =>
+						part?.value === remoteHash && part?.key?.includes("hash"),
+				);
+			if (blockNextRemovalDelete && ownerScopedDelete) {
+				blockNextRemovalDelete = false;
+				deleteStarted.resolve();
+				await releaseDelete.promise;
+			}
+			return originalDel(query, options);
+		}) as any);
 		const unblock = sinon.spy(log._replicationInfoBlockedPeers, "delete");
 		const scheduleRequests = sinon.spy(log, "scheduleReplicationInfoRequests");
 		const disconnected = sinon.spy(log.syncronizer, "onPeerDisconnected");

--- a/packages/programs/data/shared-log/test/lifecycle.spec.ts
+++ b/packages/programs/data/shared-log/test/lifecycle.spec.ts
@@ -39,7 +39,7 @@ describe("lifecycle", () => {
 			expect(closeLog.called).to.be.true;
 		});
 
-		it("keeps a reopened warmup generation behind an active closing send", async () => {
+		it("starts a reopened warmup independently of a blocked old send", async () => {
 			session = await TestSession.connected(1);
 			const db = await session.peers[0].open(new EventStore());
 			const sharedLog = db.log as any;
@@ -88,19 +88,20 @@ describe("lifecycle", () => {
 					},
 				);
 				await oldSimpleStarted;
-				const runningState = sharedLog._joinWarmupSendStateByTarget.get(
-					"target",
-				);
+				const runningState =
+					sharedLog._joinWarmupSendStateByTarget.get("target");
 				const oldGeneration = runningState.generation;
 
+				sharedLog.poisonReplicationOwnership(
+					new Error("forced ownership poison"),
+				);
 				await db.close();
-				expect(
-					sharedLog._joinWarmupSendStateByTarget.get("target"),
-				).to.equal(runningState);
+				expect(sharedLog._joinWarmupSendStateByTarget.get("target")).to.equal(
+					runningState,
+				);
 				await session.peers[0].open(db);
-				expect(
-					sharedLog._joinWarmupSendStateByTarget.get("target"),
-				).to.equal(runningState);
+				expect(sharedLog._joinWarmupSendStateByTarget.get("target")).to.be
+					.undefined;
 
 				sharedLog.dispatchMaybeMissingEntries(
 					"target",
@@ -111,22 +112,21 @@ describe("lifecycle", () => {
 						retryScheduleMs: [0, 1],
 					},
 				);
-				await delay(20);
-				const reopenedState =
-					sharedLog._joinWarmupSendStateByTarget.get("target");
-				expect(reopenedState.generation).to.not.equal(oldGeneration);
-				expect(
-					sharedLog._joinWarmupGenerationByTarget.get("target"),
-				).to.equal(reopenedState.generation);
-				expect(simpleEntryBatches).to.deep.equal([["old"]]);
-				expect(maxActiveSimpleSends).to.equal(1);
-
-				expect(releaseOldSimple).to.be.a("function");
-				releaseOldSimple!();
 				await waitForResolved(() =>
 					expect(simpleEntryBatches).to.deep.equal([["old"], ["new"]]),
 				);
-				expect(maxActiveSimpleSends).to.equal(1);
+				const reopenedState =
+					sharedLog._joinWarmupSendStateByTarget.get("target");
+				expect(reopenedState.generation).to.not.equal(oldGeneration);
+				expect(sharedLog._joinWarmupGenerationByTarget.get("target")).to.equal(
+					reopenedState.generation,
+				);
+				expect(maxActiveSimpleSends).to.equal(2);
+
+				expect(releaseOldSimple).to.be.a("function");
+				releaseOldSimple!();
+				await delay(20);
+				expect(simpleEntryBatches).to.deep.equal([["old"], ["new"]]);
 			} finally {
 				releaseOldSimple?.();
 				await delay(300);
@@ -262,7 +262,7 @@ describe("lifecycle", () => {
 	}
 
 	for (const operation of ["close", "drop"] as const) {
-		it(`${operation} cancels warmup work created while subscription callbacks drain`, async () => {
+		it(`${operation} prevents warmup work while subscription callbacks drain`, async () => {
 			session = await TestSession.connected(1);
 			const db = await session.peers[0].open(new EventStore());
 			const sharedLog = db.log as any;
@@ -278,12 +278,13 @@ describe("lifecycle", () => {
 						new Map([["late-entry", { hash: "late-entry" }]]),
 						false,
 					);
-					expect(
-						sharedLog._joinWarmupGenerationByTarget.get(target),
-					).to.equal(generation);
-					expect(
-						sharedLog._joinWarmupRetryTimersByTarget.get(target)?.size,
-					).to.equal(1);
+					expect(sharedLog._joinWarmupGenerationByTarget.get(target)).to.equal(
+						generation,
+					);
+					expect(sharedLog._joinWarmupRetryTimersByTarget.has(target)).to.be
+						.false;
+					expect(sharedLog._joinWarmupScheduledRetriesByTarget.has(target)).to
+						.be.false;
 				});
 			const drainReceiveHandlers = sinon
 				.stub(sharedLog, "drainReceiveHandlers")

--- a/packages/programs/data/shared-log/test/prune-ownership-coherence.spec.ts
+++ b/packages/programs/data/shared-log/test/prune-ownership-coherence.spec.ts
@@ -1,6 +1,7 @@
 import { Ed25519Keypair, randomBytes } from "@peerbit/crypto";
 import { TerminalOperationNotStartedError } from "@peerbit/program";
 import { TestSession } from "@peerbit/test-utils";
+import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
 import pDefer from "p-defer";
 import sinon from "sinon";
@@ -240,6 +241,82 @@ describe("checked prune ownership coherence", () => {
 		}
 	});
 
+	it("does not delete when a queued final prune is cancelled before entering the ownership lane", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-cancelled-at-lane");
+		const remoteHash = (await Ed25519Keypair.create()).publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const laneEntered = pDefer<void>();
+		const releaseLane = pDefer<void>();
+
+		const waitForReplicators = sinon
+			.stub(log, "_waitForEntryReplicators")
+			.resolves(true);
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.resolves({ leaders, localLeader: false });
+		const remove = sinon.spy(log.log, "remove");
+		const laneBlocker = log.withReplicationRangeMutationQueue(async () => {
+			laneEntered.resolve();
+			await releaseLane.promise;
+		});
+
+		try {
+			await laneEntered.promise;
+			const [pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			const pruningOutcome = pruning.then(
+				() => ({ status: "fulfilled" as const }),
+				(error: unknown) => ({ status: "rejected" as const, error }),
+			);
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			expect(pending).to.exist;
+			await pending.resolve(remoteHash);
+			await waitForResolved(
+				() => {
+					expect(revalidate.calledOnce).to.be.true;
+				},
+				{ timeout: 2_000, delayInterval: 5 },
+			);
+
+			await log.cancelCheckedPruneForLocalLeader(entry.hash);
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
+			releaseLane.resolve();
+			await laneBlocker;
+
+			const outcome = await pruningOutcome;
+			expect(outcome.status).to.equal("rejected");
+			expect("error" in outcome ? outcome.error : undefined).to.be.instanceOf(
+				Error,
+			);
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			expect(remove.called).to.be.false;
+			expect(await log.log.has(entry.hash)).to.be.true;
+			expect(await log.log.blocks.has(entry.hash)).to.be.true;
+		} finally {
+			releaseLane.resolve();
+			await laneBlocker.catch(() => {});
+			waitForReplicators.restore();
+			getClampedReplicas.restore();
+			send.restore();
+			revalidate.restore();
+			remove.restore();
+		}
+	});
+
 	it("rejects a reentrant local mutation while preserving queued remote ownership", async () => {
 		session = await TestSession.disconnected(2);
 		const reentrantAttempted = pDefer<void>();
@@ -256,6 +333,10 @@ describe("checked prune ownership coherence", () => {
 					if (change.removed.length === 0 || !log) {
 						return;
 					}
+					// Re-entry after an async suspension is still part of this
+					// removal callback and must fail instead of waiting on the lane
+					// that is waiting for the callback itself.
+					await Promise.resolve();
 					try {
 						await log.replicate(
 							{ factor: 1, offset: 0 },
@@ -369,6 +450,7 @@ describe("checked prune ownership coherence", () => {
 						if (change.removed.length === 0 || !log) {
 							return;
 						}
+						await Promise.resolve();
 						try {
 							await log[operation]();
 						} catch (error) {

--- a/packages/programs/data/shared-log/test/prune-ownership-coherence.spec.ts
+++ b/packages/programs/data/shared-log/test/prune-ownership-coherence.spec.ts
@@ -1,0 +1,450 @@
+import { Ed25519Keypair, randomBytes } from "@peerbit/crypto";
+import { TerminalOperationNotStartedError } from "@peerbit/program";
+import { TestSession } from "@peerbit/test-utils";
+import { expect } from "chai";
+import pDefer from "p-defer";
+import sinon from "sinon";
+import { EventStore } from "./utils/stores/index.js";
+
+describe("checked prune ownership coherence", () => {
+	let session: TestSession | undefined;
+
+	afterEach(async () => {
+		await session?.stop();
+	});
+
+	it("retains an entry when local ownership commits at the final prune boundary", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-ownership-race");
+		const selfHash = session.peers[0].identity.publicKey.hashcode();
+		const remoteHash = (await Ed25519Keypair.create()).publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const preliminaryCheckFinished = pDefer<void>();
+		const releasePreliminaryCheck = pDefer<void>();
+
+		const waitForReplicators = sinon
+			.stub(log, "_waitForEntryReplicators")
+			.resolves(true);
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const remove = sinon.spy(log.log, "remove");
+		let revalidationCount = 0;
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.callsFake(async (args: any) => {
+				revalidationCount++;
+				if (revalidationCount === 1) {
+					preliminaryCheckFinished.resolve();
+					await releasePreliminaryCheck.promise;
+					return { leaders: args.leaders, localLeader: false };
+				}
+				expect(await db.log.countReplicationSegments()).to.equal(1);
+				return {
+					leaders: new Map([[selfHash, { intersecting: true }]]),
+					localLeader: true,
+				};
+			});
+
+		try {
+			expect(await log.log.has(entry.hash)).to.be.true;
+			expect(await log.log.blocks.has(entry.hash)).to.be.true;
+
+			const [pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			expect(pending).to.exist;
+			await pending.resolve(remoteHash);
+			await preliminaryCheckFinished.promise;
+
+			// Commit authoritative local ownership while the prune callback is
+			// paused after its preliminary planner result. The destructive path
+			// must revalidate in the range-mutation lane after this commit.
+			await db.log.replicate(
+				{ factor: 1, offset: 0 },
+				{ reset: true, rebalance: false },
+			);
+			expect(await db.log.countReplicationSegments()).to.equal(1);
+
+			releasePreliminaryCheck.resolve();
+			await expect(pruning).to.be.rejectedWith(
+				"Failed to delete, is leader again",
+			);
+
+			expect(revalidationCount).to.equal(2);
+			expect(remove.called).to.be.false;
+			expect(await log.log.has(entry.hash)).to.be.true;
+			expect(await log.log.blocks.has(entry.hash)).to.be.true;
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
+		} finally {
+			releasePreliminaryCheck.resolve();
+			waitForReplicators.restore();
+			getClampedReplicas.restore();
+			send.restore();
+			remove.restore();
+			revalidate.restore();
+		}
+	});
+
+	it("retains an entry when the final ownership planner rejects", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-final-planner-rejection");
+		const remoteHash = (await Ed25519Keypair.create()).publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const plannerError = new Error("forced final ownership planner rejection");
+
+		const waitForReplicators = sinon
+			.stub(log, "_waitForEntryReplicators")
+			.resolves(true);
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const cancelLocalLeader = sinon
+			.stub(log, "cancelCheckedPruneForLocalLeader")
+			.resolves();
+		const findLeaders = sinon
+			.stub(log, "findLeadersFromEntry")
+			.rejects(plannerError);
+		const originalRevalidate = log.revalidateCheckedPruneOwnership.bind(log);
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.callsFake((args: any) =>
+				args.requireFreshLeaderDecision
+					? originalRevalidate({
+							...args,
+							leaders: new Map([[remoteHash, { intersecting: true }]]),
+						})
+					: Promise.resolve({ leaders: args.leaders, localLeader: false }),
+			);
+		const remove = sinon.spy(log.log, "remove");
+
+		try {
+			const [pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			expect(pending).to.exist;
+			await pending.resolve(remoteHash);
+
+			await expect(pruning).to.be.rejectedWith(plannerError.message);
+			expect(revalidate.callCount).to.equal(2);
+			expect(revalidate.secondCall.args[0].requireFreshLeaderDecision).to.be
+				.true;
+			expect(findLeaders.calledOnce).to.be.true;
+			expect(remove.called).to.be.false;
+			expect(await log.log.has(entry.hash)).to.be.true;
+			expect(await log.log.blocks.has(entry.hash)).to.be.true;
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
+		} finally {
+			waitForReplicators.restore();
+			getClampedReplicas.restore();
+			send.restore();
+			cancelLocalLeader.restore();
+			findLeaders.restore();
+			revalidate.restore();
+			remove.restore();
+		}
+	});
+
+	it("retains and retries a background prune when final ownership is empty", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-final-empty-ownership");
+		const remoteHash = (await Ed25519Keypair.create()).publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+
+		const waitForReplicators = sinon
+			.stub(log, "_waitForEntryReplicators")
+			.resolves(true);
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const cancelLocalLeader = sinon
+			.stub(log, "cancelCheckedPruneForLocalLeader")
+			.resolves();
+		const findLeaders = sinon
+			.stub(log, "findLeadersFromEntry")
+			.resolves(new Map());
+		const originalRevalidate = log.revalidateCheckedPruneOwnership.bind(log);
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.callsFake((args: any) =>
+				args.requireFreshLeaderDecision
+					? originalRevalidate({
+							...args,
+							leaders: new Map([[remoteHash, { intersecting: true }]]),
+						})
+					: Promise.resolve({ leaders: args.leaders, localLeader: false }),
+			);
+		const scheduleRetry = sinon.spy(log, "scheduleCheckedPruneRetry");
+		const remove = sinon.spy(log.log, "remove");
+
+		try {
+			const [pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]));
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			expect(pending).to.exist;
+			await pending.resolve(remoteHash);
+
+			await expect(pruning).to.be.rejectedWith(
+				"Could not establish current leaders at the checked-prune delete boundary",
+			);
+			expect(revalidate.callCount).to.equal(2);
+			expect(revalidate.secondCall.args[0].requireFreshLeaderDecision).to.be
+				.true;
+			expect(findLeaders.calledOnce).to.be.true;
+			expect(scheduleRetry.callCount).to.be.greaterThanOrEqual(1);
+			expect(log._checkedPrune.getRetry(entry.hash)).to.exist;
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
+			log._checkedPrune.clearRetry(entry.hash);
+
+			expect(remove.called).to.be.false;
+			expect(await log.log.has(entry.hash)).to.be.true;
+			expect(await log.log.blocks.has(entry.hash)).to.be.true;
+		} finally {
+			log._checkedPrune.clearRetry(entry.hash);
+			waitForReplicators.restore();
+			getClampedReplicas.restore();
+			send.restore();
+			cancelLocalLeader.restore();
+			findLeaders.restore();
+			revalidate.restore();
+			scheduleRetry.restore();
+			remove.restore();
+		}
+	});
+
+	it("rejects a reentrant local mutation while preserving queued remote ownership", async () => {
+		session = await TestSession.disconnected(2);
+		const reentrantAttempted = pDefer<void>();
+		const removalCallbackHoldingLane = pDefer<void>();
+		const releaseRemovalCallback = pDefer<void>();
+		let reentrantError: unknown;
+		let log: any;
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+				onChange: async (change) => {
+					if (change.removed.length === 0 || !log) {
+						return;
+					}
+					try {
+						await log.replicate(
+							{ factor: 1, offset: 0 },
+							{ reset: true, rebalance: false },
+						);
+					} catch (error) {
+						reentrantError = error;
+					} finally {
+						reentrantAttempted.resolve();
+					}
+					removalCallbackHoldingLane.resolve();
+					await releaseRemovalCallback.promise;
+				},
+			},
+		});
+		log = db.log as any;
+		const { entry } = await db.add("checked-prune-reentrant-callback");
+		const remoteKey = (await Ed25519Keypair.create()).publicKey;
+		const remoteHash = remoteKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const remoteRange = new log.indexableDomain.constructorRange({
+			id: randomBytes(32),
+			offset: log.indexableDomain.numbers.denormalize(0.25),
+			width: log.indexableDomain.numbers.denormalize(0.25),
+			publicKeyHash: remoteHash,
+			timestamp: 1n,
+		});
+
+		const waitForReplicators = sinon
+			.stub(log, "_waitForEntryReplicators")
+			.resolves(true);
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.resolves({ leaders, localLeader: false });
+
+		try {
+			const [pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			expect(pending).to.exist;
+			await pending.resolve(remoteHash);
+			await Promise.all([
+				reentrantAttempted.promise,
+				removalCallbackHoldingLane.promise,
+			]);
+
+			expect(reentrantError).to.be.instanceOf(Error);
+			expect((reentrantError as Error).message).to.include(
+				"cannot start during a checked-prune removal callback",
+			);
+			expect(await log.countReplicationSegments()).to.equal(0);
+			expect(log._isReplicating).to.be.false;
+
+			let remoteMutationSettled = false;
+			const remoteMutation = log
+				.addReplicationRange([remoteRange], remoteKey, {
+					checkDuplicates: false,
+					rebalance: false,
+				})
+				.then(
+					(result: unknown) => {
+						remoteMutationSettled = true;
+						return result;
+					},
+					(error: unknown) => {
+						remoteMutationSettled = true;
+						throw error;
+					},
+				);
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(remoteMutationSettled).to.be.false;
+
+			releaseRemovalCallback.resolve();
+			await Promise.all([pruning, remoteMutation]);
+
+			const durableRanges = await log.getAllReplicationSegments();
+			expect(durableRanges).to.have.length(1);
+			expect(durableRanges[0].hash).to.equal(remoteHash);
+			expect(durableRanges[0].rangeHash).to.equal(remoteRange.rangeHash);
+			expect(await log.log.has(entry.hash)).to.be.false;
+			expect(await log.log.blocks.has(entry.hash)).to.be.false;
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
+		} finally {
+			releaseRemovalCallback.resolve();
+			waitForReplicators.restore();
+			getClampedReplicas.restore();
+			send.restore();
+			revalidate.restore();
+		}
+	});
+
+	for (const operation of ["close", "drop"] as const) {
+		it(`rejects reentrant ${operation} before terminal fences and permits a later ${operation}`, async () => {
+			session = await TestSession.disconnected(2);
+			const terminalAttempted = pDefer<void>();
+			const releaseRemovalCallback = pDefer<void>();
+			let terminalError: unknown;
+			let log: any;
+			const db = await session.peers[0].open(new EventStore(), {
+				args: {
+					replicate: false,
+					timeUntilRoleMaturity: 0,
+					waitForPruneDelay: 0,
+					onChange: async (change) => {
+						if (change.removed.length === 0 || !log) {
+							return;
+						}
+						try {
+							await log[operation]();
+						} catch (error) {
+							terminalError = error;
+						} finally {
+							terminalAttempted.resolve();
+						}
+						await releaseRemovalCallback.promise;
+					},
+				},
+			});
+			log = db.log as any;
+			const { entry } = await db.add(
+				`checked-prune-reentrant-${operation}-callback`,
+			);
+			const remoteHash = (await Ed25519Keypair.create()).publicKey.hashcode();
+			const leaders = new Map([[remoteHash, { intersecting: true }]]);
+
+			const waitForReplicators = sinon
+				.stub(log, "_waitForEntryReplicators")
+				.resolves(true);
+			const getClampedReplicas = sinon
+				.stub(log, "getClampedReplicas")
+				.returns({ getValue: () => 1 });
+			const send = sinon.stub(log.rpc, "send").resolves();
+			const revalidate = sinon
+				.stub(log, "revalidateCheckedPruneOwnership")
+				.resolves({ leaders, localLeader: false });
+			const lowerClose = sinon.spy(log.log, "close");
+			const lowerDrop = sinon.spy(log.log, "drop");
+
+			try {
+				const [pruning] = log.prune(
+					new Map([[entry.hash, { entry, leaders }]]),
+					{ timeout: 5_000 },
+				);
+				const pending = log._checkedPrune.getPendingDelete(entry.hash);
+				expect(pending).to.exist;
+				await pending.resolve(remoteHash);
+				await terminalAttempted.promise;
+
+				expect(terminalError).to.be.instanceOf(
+					TerminalOperationNotStartedError,
+				);
+				expect((terminalError as Error).message).to.include(
+					`${operation} cannot start during a checked-prune removal callback`,
+				);
+				expect(log.closed).to.be.false;
+				expect(log._replicationRangeMutationsClosing).to.be.false;
+				expect(log._pruneRemovesClosing).to.be.false;
+				expect(lowerClose.called).to.be.false;
+				expect(lowerDrop.called).to.be.false;
+
+				releaseRemovalCallback.resolve();
+				await pruning;
+				expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
+				expect(await log.log.has(entry.hash)).to.be.false;
+				expect(await log.log.blocks.has(entry.hash)).to.be.false;
+
+				expect(await log[operation]()).to.be.true;
+				expect(log.closed).to.be.true;
+				if (operation === "close") {
+					expect(lowerClose.calledOnce).to.be.true;
+					expect(lowerDrop.called).to.be.false;
+				} else {
+					expect(lowerDrop.calledOnce).to.be.true;
+				}
+			} finally {
+				releaseRemovalCallback.resolve();
+				waitForReplicators.restore();
+				getClampedReplicas.restore();
+				send.restore();
+				revalidate.restore();
+				lowerClose.restore();
+				lowerDrop.restore();
+			}
+		});
+	}
+});

--- a/packages/programs/data/shared-log/test/rateless-iblt-cache.spec.ts
+++ b/packages/programs/data/shared-log/test/rateless-iblt-cache.spec.ts
@@ -1,4 +1,6 @@
 import { Cache } from "@peerbit/cache";
+import { Ed25519Keypair, type PublicSignKey } from "@peerbit/crypto";
+import { EncoderWrapper } from "@peerbit/riblt";
 import { expect } from "chai";
 import sinon from "sinon";
 import {
@@ -7,6 +9,12 @@ import {
 } from "../src/sync/rateless-iblt.js";
 
 describe("rateless-iblt-syncronizer cache", () => {
+	let peer: PublicSignKey;
+
+	before(async () => {
+		peer = (await Ed25519Keypair.create()).publicKey;
+	});
+
 	it("reuses cached local range encoder across StartSync", async () => {
 		const iterate = sinon.stub().returns({
 			all: async () => [
@@ -29,7 +37,7 @@ describe("rateless-iblt-syncronizer cache", () => {
 			numbers: { maxValue: 2n ** 64n - 1n } as any,
 		});
 
-		const context = { from: "p" } as any;
+		const context = { from: peer } as any;
 		const createStartSync = () =>
 			new StartSync({ from: 0n, to: 10n, symbols: [] });
 
@@ -57,10 +65,9 @@ describe("rateless-iblt-syncronizer cache", () => {
 		});
 
 		expect(
-			await sync.onMessage(
-				new StartSync({ from: 0n, to: 10n, symbols: [] }),
-				{ from: "p" } as any,
-			),
+			await sync.onMessage(new StartSync({ from: 0n, to: 10n, symbols: [] }), {
+				from: peer,
+			} as any),
 		).to.equal(true);
 
 		expect(iterate.called).to.equal(false);
@@ -73,6 +80,206 @@ describe("rateless-iblt-syncronizer cache", () => {
 		});
 
 		await sync.close();
+	});
+
+	it("frees an empty native range encoder before requesting all", async () => {
+		const free = sinon.spy(EncoderWrapper.prototype, "free");
+		const send = sinon.stub().resolves();
+		const sync = new RatelessIBLTSynchronizer<"u64">({
+			rpc: { send } as any,
+			rangeIndex: {} as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			numbers: { maxValue: 2n ** 64n - 1n } as any,
+			resolveHashNumbersInRange: async () => [],
+		});
+
+		try {
+			await sync.onMessage(new StartSync({ from: 0n, to: 10n, symbols: [] }), {
+				from: peer,
+			} as any);
+
+			expect(free.calledOnce).to.equal(true);
+			expect(send.calledOnce).to.equal(true);
+		} finally {
+			await sync.close();
+			free.restore();
+		}
+	});
+
+	it("frees the native range encoder when resolution rejects", async () => {
+		const free = sinon.spy(EncoderWrapper.prototype, "free");
+		const sync = new RatelessIBLTSynchronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			rangeIndex: {} as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			numbers: { maxValue: 2n ** 64n - 1n } as any,
+			resolveHashNumbersInRange: async () => {
+				throw new Error("native resolver failed");
+			},
+		});
+
+		try {
+			await expect(
+				sync.onMessage(new StartSync({ from: 0n, to: 10n, symbols: [] }), {
+					from: peer,
+				} as any),
+			).to.be.rejectedWith("native resolver failed");
+			expect(free.calledOnce).to.equal(true);
+		} finally {
+			await sync.close();
+			free.restore();
+		}
+	});
+
+	it("does not cache a decoder initializer released after close and reopen", async () => {
+		let release!: (values: bigint[]) => void;
+		const resolved = new Promise<bigint[]>((resolve) => {
+			release = resolve;
+		});
+		let markStarted!: () => void;
+		const started = new Promise<void>((resolve) => {
+			markStarted = resolve;
+		});
+		const free = sinon.spy(EncoderWrapper.prototype, "free");
+		const send = sinon.stub().resolves();
+		const sync = new RatelessIBLTSynchronizer<"u64">({
+			rpc: { send } as any,
+			rangeIndex: {} as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			numbers: { maxValue: 2n ** 64n - 1n } as any,
+			resolveHashNumbersInRange: async () => {
+				markStarted();
+				return resolved;
+			},
+		});
+
+		try {
+			const handling = sync.onMessage(
+				new StartSync({ from: 0n, to: 10n, symbols: [] }),
+				{ from: peer } as any,
+			);
+			await started;
+			await sync.close();
+			await sync.open();
+			release([1n]);
+			expect(await handling).to.equal(true);
+
+			expect(free.calledOnce).to.equal(true);
+			expect((sync as any).localRangeEncoderCache.size).to.equal(0);
+			expect(send.called).to.equal(false);
+		} finally {
+			release([]);
+			await sync.close();
+			free.restore();
+		}
+	});
+
+	it("frees a cached encoder clone once when decoder conversion throws", async () => {
+		const conversionError = new Error("decoder conversion failed");
+		const clone = {
+			to_decoder: sinon.stub().throws(conversionError),
+			free: sinon.spy(),
+		};
+		const encoder = {
+			clone: sinon.stub().returns(clone),
+			free: sinon.spy(),
+		};
+		const sync = new RatelessIBLTSynchronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			rangeIndex: {} as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			numbers: { maxValue: 2n ** 64n - 1n } as any,
+		});
+		const ranges = {
+			start1: 0n,
+			end1: 10n,
+			start2: 0n,
+			end2: 0n,
+		};
+		(sync as any).localRangeEncoderCache.set(
+			(sync as any).localRangeEncoderCacheKey(ranges),
+			{ encoder, version: 0, lastUsed: 0 },
+		);
+
+		try {
+			await expect(
+				(sync as any).getLocalDecoderForRange(ranges),
+			).to.be.rejectedWith(conversionError.message);
+
+			expect(encoder.clone.calledOnce).to.equal(true);
+			expect(clone.to_decoder.calledOnce).to.equal(true);
+			expect(clone.free.calledOnce).to.equal(true);
+			expect(encoder.free.called).to.equal(false);
+			await sync.close();
+			expect(clone.free.calledOnce).to.equal(true);
+			expect(encoder.free.calledOnce).to.equal(true);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("frees a produced cached decoder when local-decoder profiling throws", async () => {
+		const profileError = new Error("local decoder profile failed");
+		const decoder = { free: sinon.spy() };
+		const clone = {
+			to_decoder: sinon.stub().returns(decoder),
+			free: sinon.spy(),
+		};
+		const encoder = {
+			clone: sinon.stub().returns(clone),
+			free: sinon.spy(),
+		};
+		const sync = new RatelessIBLTSynchronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			rangeIndex: {} as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			numbers: { maxValue: 2n ** 64n - 1n } as any,
+			sync: {
+				profile: (event) => {
+					if (event.name === "rateless.localDecoder") {
+						throw profileError;
+					}
+				},
+			},
+		});
+		const ranges = {
+			start1: 0n,
+			end1: 10n,
+			start2: 0n,
+			end2: 0n,
+		};
+		(sync as any).localRangeEncoderCache.set(
+			(sync as any).localRangeEncoderCacheKey(ranges),
+			{ encoder, version: 0, lastUsed: 0 },
+		);
+
+		try {
+			await expect(
+				(sync as any).getLocalDecoderForRange(ranges),
+			).to.be.rejectedWith(profileError.message);
+
+			expect(encoder.clone.calledOnce).to.equal(true);
+			expect(clone.to_decoder.calledOnce).to.equal(true);
+			expect(clone.free.calledOnce).to.equal(true);
+			expect(decoder.free.calledOnce).to.equal(true);
+			expect(encoder.free.called).to.equal(false);
+			await sync.close();
+			expect(clone.free.calledOnce).to.equal(true);
+			expect(decoder.free.calledOnce).to.equal(true);
+			expect(encoder.free.calledOnce).to.equal(true);
+		} finally {
+			await sync.close();
+		}
 	});
 
 	it("invalidates cached range encoder on entry removal", async () => {
@@ -97,7 +304,7 @@ describe("rateless-iblt-syncronizer cache", () => {
 			numbers: { maxValue: 2n ** 64n - 1n } as any,
 		});
 
-		const context = { from: "p" } as any;
+		const context = { from: peer } as any;
 		const createStartSync = () =>
 			new StartSync({ from: 0n, to: 10n, symbols: [] });
 

--- a/packages/programs/data/shared-log/test/rateless-iblt.spec.ts
+++ b/packages/programs/data/shared-log/test/rateless-iblt.spec.ts
@@ -1,20 +1,29 @@
 import { deserialize, serialize } from "@dao-xyz/borsh";
 import { Cache } from "@peerbit/cache";
+import { Ed25519Keypair } from "@peerbit/crypto";
+import { EncoderWrapper } from "@peerbit/riblt";
 import { TestSession } from "@peerbit/test-utils";
 import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
+import sinon from "sinon";
 import {
 	type ReplicationDomainHash,
 	createReplicationDomainHash,
 } from "../src/index.js";
 import { TransportMessage } from "../src/message.js";
 import {
+	CodedSymbolBatch,
 	MoreSymbols,
 	RatelessIBLTSynchronizer,
 	RequestAll,
+	RequestMoreSymbols,
 	StartSync,
 } from "../src/sync/rateless-iblt.js";
-import { RequestMaybeSyncCoordinate } from "../src/sync/simple.js";
+import {
+	RequestMaybeSync,
+	RequestMaybeSyncCoordinate,
+	ResponseMaybeSync,
+} from "../src/sync/simple.js";
 import { EventStore } from "./utils/stores/index.js";
 
 const setup = {
@@ -52,6 +61,68 @@ describe("rateless-iblt-syncronizer", () => {
 		type: new (...args: any[]) => TransportMessage,
 	) => {
 		return messages.filter((x) => x instanceof type).length;
+	};
+
+	const createDispatchTestSynchronizer = (
+		send: (
+			message: TransportMessage,
+			options?: { signal?: AbortSignal },
+		) => Promise<void> | void,
+		sync?: any,
+	) =>
+		new RatelessIBLTSynchronizer<"u64">({
+			rpc: { send } as any,
+			rangeIndex: {} as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 1000, ttl: 1000 }),
+			numbers: { maxValue: 2n ** 64n - 1n } as any,
+			sync,
+		});
+
+	const createDispatchTestEntries = (boundaryIndex?: number, count = 400) => {
+		const entries = new Map<string, any>();
+		for (let i = 0; i < count; i++) {
+			const hash = `hash-${i}`;
+			entries.set(hash, {
+				hash,
+				hashNumber: BigInt(i + 1),
+				assignedToRangeBoundary: i === boundaryIndex,
+			});
+		}
+		return entries;
+	};
+
+	const stubTrackedRepairSession = (
+		sync: RatelessIBLTSynchronizer<"u64">,
+		target = "target",
+	) => {
+		const result = {
+			target,
+			requested: 1,
+			resolved: 0,
+			unresolved: ["hash-0"],
+			attempts: 1,
+			durationMs: 0,
+			completed: false,
+		};
+		let settled = false;
+		let resolveDone!: (results: (typeof result)[]) => void;
+		const done = new Promise<(typeof result)[]>((resolve) => {
+			resolveDone = resolve;
+		});
+		const settle = () => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			resolveDone([result]);
+		};
+		const cancel = sinon.spy(settle);
+		const start = sinon
+			.stub(sync.simple, "startRepairSession")
+			.returns({ id: "tracked-repair", done, cancel });
+		return { cancel, settle, start };
 	};
 
 	it("roundtrips coded symbol batches through existing transport variants", () => {
@@ -278,6 +349,1562 @@ describe("rateless-iblt-syncronizer", () => {
 			const profileNames = profileEvents.map((event) => event.name);
 			expect(profileNames).to.include("rateless.prepareStartSyncEncoder");
 			expect(profileNames).to.include("rateless.onMaybeMissingEntries");
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("frees an outgoing encoder once when post-prepare profiling throws", async () => {
+		const profileError = new Error("prepare profile failed");
+		const free = sinon.spy(EncoderWrapper.prototype, "free");
+		const sync = createDispatchTestSynchronizer(() => {}, {
+			profile: (event: { name: string }) => {
+				if (event.name === "rateless.prepareStartSyncEncoder") {
+					throw profileError;
+				}
+			},
+		});
+
+		try {
+			await expect(
+				sync.onMaybeMissingEntries({
+					entries: createDispatchTestEntries(),
+					targets: ["target"],
+				}),
+			).to.be.rejectedWith(profileError.message);
+
+			expect(free.calledOnce).to.equal(true);
+			expect(sync.outgoingSyncProcesses.size).to.equal(0);
+			await sync.close();
+			expect(free.calledOnce).to.equal(true);
+		} finally {
+			await sync.close();
+			free.restore();
+		}
+	});
+
+	it("cleans a registered outgoing encoder once when dispatch profiling throws", async () => {
+		const profileError = new Error("dispatch profile failed");
+		const free = sinon.spy(EncoderWrapper.prototype, "free");
+		const sync = createDispatchTestSynchronizer(() => {}, {
+			profile: (event: { name: string }) => {
+				if (event.name === "rateless.dispatchMode") {
+					throw profileError;
+				}
+			},
+		});
+
+		try {
+			await expect(
+				sync.onMaybeMissingEntries({
+					entries: createDispatchTestEntries(),
+					targets: ["target"],
+				}),
+			).to.be.rejectedWith(profileError.message);
+
+			expect(free.calledOnce).to.equal(true);
+			expect(sync.outgoingSyncProcesses.size).to.equal(0);
+			expect((sync as any).outgoingSyncProcessByTarget.size).to.equal(0);
+			await sync.close();
+			expect(free.calledOnce).to.equal(true);
+		} finally {
+			await sync.close();
+			free.restore();
+		}
+	});
+
+	it("frees an outgoing encoder once when initial symbol production throws", async () => {
+		const producerError = new Error("initial symbol producer failed");
+		const prepareAndProduce = sinon
+			.stub(
+				EncoderWrapper.prototype,
+				"add_symbols_sorted_find_range_and_produce",
+			)
+			.value(undefined);
+		const produce = sinon
+			.stub(EncoderWrapper.prototype, "produce_next_coded_symbols")
+			.throws(producerError);
+		const free = sinon.spy(EncoderWrapper.prototype, "free");
+		const sync = createDispatchTestSynchronizer(() => {});
+
+		try {
+			await expect(
+				sync.onMaybeMissingEntries({
+					entries: createDispatchTestEntries(),
+					targets: ["target"],
+				}),
+			).to.be.rejectedWith(producerError.message);
+
+			expect(produce.calledOnce).to.equal(true);
+			expect(free.calledOnce).to.equal(true);
+			expect(sync.outgoingSyncProcesses.size).to.equal(0);
+			await sync.close();
+			expect(free.calledOnce).to.equal(true);
+		} finally {
+			await sync.close();
+			free.restore();
+			produce.restore();
+			prepareAndProduce.restore();
+		}
+	});
+
+	it("does not start rateless sync when aborted at its readiness boundary", async () => {
+		const sentMessages: TransportMessage[] = [];
+		const profileEvents: any[] = [];
+		const sync = createDispatchTestSynchronizer(
+			(message) => {
+				sentMessages.push(message);
+			},
+			{ profile: (event: any) => profileEvents.push(event) },
+		);
+		const controller = new AbortController();
+
+		try {
+			const dispatch = sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["target"],
+				signal: controller.signal,
+			});
+			controller.abort();
+			await dispatch;
+
+			expect(
+				sentMessages.some((message) => message instanceof StartSync),
+			).to.equal(false);
+			expect(sync.outgoingSyncProcesses.size).to.equal(0);
+			const topLevelEvents = profileEvents.filter(
+				(event) => event.name === "rateless.onMaybeMissingEntries",
+			);
+			expect(topLevelEvents).to.have.length(1);
+			expect(topLevelEvents[0].messages).to.equal(0);
+			expect(topLevelEvents[0].symbols).to.equal(0);
+			expect(topLevelEvents[0].details).to.include({
+				mode: "rateless",
+				phase: "riblt-ready",
+				cancelled: true,
+			});
+		} finally {
+			controller.abort();
+			await sync.close();
+		}
+	});
+
+	it("does not register or start rateless sync after its simple prelude is aborted", async () => {
+		const sentMessages: TransportMessage[] = [];
+		const profileEvents: any[] = [];
+		let releaseSimpleSend!: () => void;
+		const simpleSendReleased = new Promise<void>((resolve) => {
+			releaseSimpleSend = resolve;
+		});
+		let markSimpleSendStarted!: () => void;
+		const simpleSendStarted = new Promise<void>((resolve) => {
+			markSimpleSendStarted = resolve;
+		});
+		const sync = createDispatchTestSynchronizer(
+			async (message) => {
+				sentMessages.push(message);
+				if (message instanceof RequestMaybeSync) {
+					markSimpleSendStarted();
+					await simpleSendReleased;
+				}
+			},
+			{ profile: (event: any) => profileEvents.push(event) },
+		);
+		const controller = new AbortController();
+
+		try {
+			const dispatch = sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(0),
+				targets: ["target"],
+				signal: controller.signal,
+			});
+			await simpleSendStarted;
+			controller.abort();
+			releaseSimpleSend();
+			await dispatch;
+
+			expect(
+				sentMessages.filter((message) => message instanceof RequestMaybeSync),
+			).to.have.length(1);
+			expect(
+				sentMessages.some((message) => message instanceof StartSync),
+			).to.equal(false);
+			expect(sync.outgoingSyncProcesses.size).to.equal(0);
+			const topLevelEvents = profileEvents.filter(
+				(event) => event.name === "rateless.onMaybeMissingEntries",
+			);
+			expect(topLevelEvents).to.have.length(1);
+			expect(topLevelEvents[0].details).to.include({
+				mode: "rateless",
+				phase: "simple-prelude",
+				cancelled: true,
+			});
+		} finally {
+			releaseSimpleSend();
+			await sync.close();
+		}
+	});
+
+	it("does not let a signal-less blocked prelude cross close and reopen", async () => {
+		const sends: {
+			message: TransportMessage;
+			options?: { signal?: AbortSignal };
+		}[] = [];
+		let releasePrelude!: () => void;
+		const preludeReleased = new Promise<void>((resolve) => {
+			releasePrelude = resolve;
+		});
+		let markPreludeStarted!: () => void;
+		const preludeStarted = new Promise<void>((resolve) => {
+			markPreludeStarted = resolve;
+		});
+		const sync = createDispatchTestSynchronizer(async (message, options) => {
+			sends.push({ message, options });
+			if (message instanceof RequestMaybeSync) {
+				markPreludeStarted();
+				await preludeReleased;
+			}
+		});
+
+		try {
+			const dispatch = sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(0),
+				targets: ["target"],
+			});
+			await preludeStarted;
+			const preludeSignal = sends.find(
+				(send) => send.message instanceof RequestMaybeSync,
+			)?.options?.signal;
+			expect(preludeSignal?.aborted).to.equal(false);
+
+			await sync.close();
+			expect(preludeSignal?.aborted).to.equal(true);
+			await sync.open();
+			releasePrelude();
+			await dispatch;
+
+			expect(sends.some((send) => send.message instanceof StartSync)).to.equal(
+				false,
+			);
+			expect(sync.outgoingSyncProcesses.size).to.equal(0);
+		} finally {
+			releasePrelude();
+			await sync.close();
+		}
+	});
+
+	it("runs delayed full-set retries for a capped convergent repair", async () => {
+		const clock = sinon.useFakeTimers();
+		const sync = createDispatchTestSynchronizer(() => {}, {
+			maxConvergentTrackedHashes: 1,
+		});
+		const tracked = stubTrackedRepairSession(sync);
+		const dispatch = sinon.stub(sync, "onMaybeMissingEntries").resolves();
+
+		try {
+			const repair = sync.startRepairSession({
+				entries: createDispatchTestEntries(undefined, 2),
+				targets: ["target"],
+				mode: "convergent",
+				timeoutMs: 1_000,
+				retryIntervalsMs: [100, 300],
+			});
+
+			await clock.tickAsync(99);
+			expect(dispatch.called).to.equal(false);
+			await clock.tickAsync(1);
+			expect(dispatch.calledOnce).to.equal(true);
+			const retrySignal = dispatch.firstCall.args[0].signal;
+			expect(retrySignal).to.be.instanceOf(AbortSignal);
+			expect(retrySignal?.aborted).to.equal(false);
+
+			await clock.tickAsync(200);
+			expect(dispatch.callCount).to.equal(2);
+			tracked.settle();
+			const results = await repair.done;
+			expect(results[0]).to.include({
+				requestedTotal: 2,
+				truncated: true,
+			});
+			expect((sync as any).ratelessRepairSessions.size).to.equal(0);
+		} finally {
+			tracked.settle();
+			dispatch.restore();
+			tracked.start.restore();
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("does not dispatch an old delayed repair after close and reopen", async () => {
+		const clock = sinon.useFakeTimers();
+		const sends: TransportMessage[] = [];
+		const sync = createDispatchTestSynchronizer(
+			(message) => {
+				sends.push(message);
+			},
+			{ maxConvergentTrackedHashes: 1 },
+		);
+		const tracked = stubTrackedRepairSession(sync);
+		const dispatch = sinon.stub(sync, "onMaybeMissingEntries").resolves();
+
+		try {
+			const repair = sync.startRepairSession({
+				entries: createDispatchTestEntries(undefined, 2),
+				targets: ["target"],
+				mode: "convergent",
+				timeoutMs: 10_000,
+				retryIntervalsMs: [1_000],
+			});
+
+			await clock.tickAsync(999);
+			expect(dispatch.called).to.equal(false);
+			await sync.close();
+			await sync.open();
+			await repair.done;
+			await clock.tickAsync(10_000);
+
+			expect(tracked.cancel.calledOnce).to.equal(true);
+			expect(dispatch.called).to.equal(false);
+			expect(
+				sends.some(
+					(message) =>
+						message instanceof StartSync || message instanceof RequestMaybeSync,
+				),
+			).to.equal(false);
+			expect((sync as any).ratelessRepairSessions.size).to.equal(0);
+		} finally {
+			tracked.settle();
+			dispatch.restore();
+			tracked.start.restore();
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("aborts an in-flight capped convergent retry when cancelled", async () => {
+		const clock = sinon.useFakeTimers();
+		const sync = createDispatchTestSynchronizer(() => {}, {
+			maxConvergentTrackedHashes: 1,
+		});
+		const tracked = stubTrackedRepairSession(sync);
+		let retrySignal: AbortSignal | undefined;
+		let markRetryStarted!: () => void;
+		const retryStarted = new Promise<void>((resolve) => {
+			markRetryStarted = resolve;
+		});
+		const dispatch = sinon
+			.stub(sync, "onMaybeMissingEntries")
+			.callsFake(({ signal }: { signal?: AbortSignal }) => {
+				retrySignal = signal;
+				markRetryStarted();
+				// Model a transport that ignores abort and never settles. The repair
+				// lifecycle itself must still release session.done.
+				return new Promise<void>(() => {});
+			});
+
+		try {
+			const repair = sync.startRepairSession({
+				entries: createDispatchTestEntries(undefined, 2),
+				targets: ["target"],
+				mode: "convergent",
+				timeoutMs: 10_000,
+				retryIntervalsMs: [0, 1_000],
+			});
+			await retryStarted;
+			expect(retrySignal?.aborted).to.equal(false);
+
+			repair.cancel();
+			expect(retrySignal?.aborted).to.equal(true);
+			await repair.done;
+			await clock.tickAsync(10_000);
+
+			expect(tracked.cancel.calledOnce).to.equal(true);
+			expect(dispatch.calledOnce).to.equal(true);
+			expect((sync as any).ratelessRepairSessions.size).to.equal(0);
+		} finally {
+			tracked.settle();
+			dispatch.restore();
+			tracked.start.restore();
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("times out a never-settling capped convergent retry", async () => {
+		const clock = sinon.useFakeTimers();
+		const sync = createDispatchTestSynchronizer(() => {}, {
+			maxConvergentTrackedHashes: 1,
+		});
+		const tracked = stubTrackedRepairSession(sync);
+		let retrySignal: AbortSignal | undefined;
+		let markRetryStarted!: () => void;
+		const retryStarted = new Promise<void>((resolve) => {
+			markRetryStarted = resolve;
+		});
+		const dispatch = sinon
+			.stub(sync, "onMaybeMissingEntries")
+			.callsFake(({ signal }: { signal?: AbortSignal }) => {
+				retrySignal = signal;
+				markRetryStarted();
+				return new Promise<void>(() => {});
+			});
+
+		try {
+			const repair = sync.startRepairSession({
+				entries: createDispatchTestEntries(undefined, 2),
+				targets: ["target"],
+				mode: "convergent",
+				timeoutMs: 500,
+				retryIntervalsMs: [0],
+			});
+			await retryStarted;
+			expect(retrySignal?.aborted).to.equal(false);
+
+			await clock.tickAsync(500);
+			const results = await repair.done;
+
+			expect(retrySignal?.aborted).to.equal(true);
+			expect(tracked.cancel.calledOnce).to.equal(true);
+			expect(results[0].completed).to.equal(false);
+			expect(dispatch.calledOnce).to.equal(true);
+			expect((sync as any).ratelessRepairSessions.size).to.equal(0);
+			expect(clock.countTimers()).to.equal(0);
+
+			await clock.tickAsync(10_000);
+			expect(dispatch.calledOnce).to.equal(true);
+			expect(clock.countTimers()).to.equal(0);
+		} finally {
+			tracked.settle();
+			dispatch.restore();
+			tracked.start.restore();
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("cleans registered rateless state when its dispatch signal is aborted", async () => {
+		const sentMessages: TransportMessage[] = [];
+		let startSyncSignal: AbortSignal | undefined;
+		const sync = createDispatchTestSynchronizer((message, options) => {
+			sentMessages.push(message);
+			if (message instanceof StartSync) {
+				startSyncSignal = options?.signal;
+			}
+		});
+		const controller = new AbortController();
+		const entries = createDispatchTestEntries();
+		const expectMaybeSyncResponse = sinon.spy(
+			sync.simple,
+			"expectMaybeSyncResponse",
+		);
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries,
+				targets: ["target"],
+				signal: controller.signal,
+			});
+
+			expect(
+				sentMessages.filter((message) => message instanceof StartSync),
+			).to.have.length(1);
+			expect(sync.outgoingSyncProcesses.size).to.equal(1);
+			expect(startSyncSignal).not.to.equal(controller.signal);
+			expect(startSyncSignal?.aborted).to.equal(false);
+			expect(
+				[...sync.outgoingSyncProcesses.values()][0].authorizedHashes,
+			).to.deep.equal(new Set(entries.keys()));
+			expect(expectMaybeSyncResponse.called).to.equal(false);
+
+			controller.abort();
+
+			expect(startSyncSignal?.aborted).to.equal(true);
+			expect(sync.outgoingSyncProcesses.size).to.equal(0);
+		} finally {
+			controller.abort();
+			expectMaybeSyncResponse.restore();
+			await sync.close();
+		}
+	});
+
+	it("keeps each target independent across RequestAll and RequestMoreSymbols", async () => {
+		const sends: { message: TransportMessage; options?: any }[] = [];
+		const sync = createDispatchTestSynchronizer((message, options) => {
+			sends.push({ message, options });
+		});
+		const peer = (target: string) => ({ hashcode: () => target }) as any;
+		const startFor = (target: string) =>
+			sends.find(
+				(send) =>
+					send.message instanceof StartSync &&
+					send.options?.mode?.to?.[0] === target,
+			)?.message as StartSync | undefined;
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["peer-a", "peer-b"],
+			});
+			const startA = startFor("peer-a");
+			const startB = startFor("peer-b");
+			expect(startA).to.be.instanceOf(StartSync);
+			expect(startB).to.be.instanceOf(StartSync);
+			expect(startA!.syncId).not.to.deep.equal(startB!.syncId);
+			expect(sync.outgoingSyncProcesses.size).to.equal(2);
+
+			await sync.onMessage(new RequestAll({ syncId: startA!.syncId }), {
+				from: peer("peer-a"),
+			} as any);
+			expect(sync.outgoingSyncProcesses.size).to.equal(1);
+			expect(
+				sends.filter(
+					(send) =>
+						send.message instanceof RequestMaybeSync &&
+						send.options?.mode?.to?.[0] === "peer-a",
+				),
+			).to.have.length(1);
+
+			await sync.onMessage(
+				new RequestMoreSymbols({
+					syncId: startB!.syncId,
+					lastSeqNo: 0n,
+				}),
+				{ from: peer("peer-b") } as any,
+			);
+			expect(
+				sends.filter(
+					(send) =>
+						send.message instanceof MoreSymbols &&
+						send.options?.mode?.to?.[0] === "peer-b",
+				),
+			).to.have.length(1);
+
+			await sync.onMessage(new RequestAll({ syncId: startB!.syncId }), {
+				from: peer("peer-b"),
+			} as any);
+			expect(sync.outgoingSyncProcesses.size).to.equal(0);
+			expect(
+				sends.filter(
+					(send) =>
+						send.message instanceof RequestMaybeSync &&
+						send.options?.mode?.to?.[0] === "peer-b",
+				),
+			).to.have.length(1);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("disconnecting one target leaves the other rateless process live", async () => {
+		const sends: { message: TransportMessage; options?: any }[] = [];
+		const sync = createDispatchTestSynchronizer((message, options) => {
+			sends.push({ message, options });
+		});
+		const peerB = { hashcode: () => "peer-b" } as any;
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["peer-a", "peer-b"],
+			});
+			const startB = sends.find(
+				(send) =>
+					send.message instanceof StartSync &&
+					send.options?.mode?.to?.[0] === "peer-b",
+			)?.message as StartSync;
+
+			await sync.onPeerDisconnected("peer-a");
+			expect(sync.outgoingSyncProcesses.size).to.equal(1);
+			expect([...sync.outgoingSyncProcesses.values()][0].target).to.equal(
+				"peer-b",
+			);
+
+			await sync.onMessage(
+				new RequestMoreSymbols({
+					syncId: startB.syncId,
+					lastSeqNo: 0n,
+				}),
+				{ from: peerB } as any,
+			);
+			expect(
+				sends.some(
+					(send) =>
+						send.message instanceof MoreSymbols &&
+						send.options?.mode?.to?.[0] === "peer-b",
+				),
+			).to.equal(true);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("keeps rateless authorization direct above the Simple 10,000-hash cap", async () => {
+		const sends: { message: TransportMessage; options?: any }[] = [];
+		const sync = createDispatchTestSynchronizer((message, options) => {
+			sends.push({ message, options });
+		});
+		const expectMaybeSyncResponse = sinon.spy(
+			sync.simple,
+			"expectMaybeSyncResponse",
+		);
+		const shipAuthorized = sinon
+			.stub(sync.simple, "shipAuthorizedMaybeSyncResponse")
+			.resolves({ messages: 0, fused: false, entries: 1 });
+		const target = { hashcode: () => "peer-a" } as any;
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(undefined, 10_001),
+				targets: ["peer-a"],
+			});
+
+			expect(
+				sends.filter((send) => send.message instanceof StartSync),
+			).to.have.length(1);
+			expect(
+				sends.filter((send) => send.message instanceof RequestMaybeSync),
+			).to.have.length(0);
+			expect(expectMaybeSyncResponse.called).to.equal(false);
+			expect(sync.outgoingSyncProcesses.size).to.equal(1);
+
+			await sync.onMessage(
+				new ResponseMaybeSync({
+					hashes: ["hash-10000", "not-advertised"],
+				}),
+				{ from: target } as any,
+			);
+			expect(shipAuthorized.calledOnce).to.equal(true);
+			expect(shipAuthorized.firstCall.args[0].hashes).to.deep.equal([
+				"hash-10000",
+			]);
+			expect(shipAuthorized.firstCall.args[0].from).to.equal(target);
+
+			await sync.onMessage(new ResponseMaybeSync({ hashes: ["hash-9999"] }), {
+				from: { hashcode: () => "foreign-peer" },
+			} as any);
+			expect(shipAuthorized.calledOnce).to.equal(true);
+		} finally {
+			shipAuthorized.restore();
+			expectMaybeSyncResponse.restore();
+			await sync.close();
+		}
+	});
+
+	it("lets an accepted >10,000-hash response finish after its process timeout", async () => {
+		const clock = sinon.useFakeTimers();
+		let releaseShipment!: () => void;
+		const shipmentReleased = new Promise<void>((resolve) => {
+			releaseShipment = resolve;
+		});
+		let markShipmentStarted!: () => void;
+		const shipmentStarted = new Promise<void>((resolve) => {
+			markShipmentStarted = resolve;
+		});
+		const sync = createDispatchTestSynchronizer(() => {});
+		let leaseSignal: AbortSignal | undefined;
+		const ship = sinon
+			.stub(sync.simple, "shipAuthorizedMaybeSyncResponse")
+			.callsFake(async ({ signal }: { signal: AbortSignal }) => {
+				leaseSignal = signal;
+				markShipmentStarted();
+				await shipmentReleased;
+				return { messages: 1, fused: false, entries: 1 };
+			});
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(undefined, 10_001),
+				targets: ["peer-a"],
+			});
+			const handling = sync.onMessage(
+				new ResponseMaybeSync({ hashes: ["hash-10000"] }),
+				{ from: { hashcode: () => "peer-a" } } as any,
+			);
+			await shipmentStarted;
+
+			await clock.tickAsync(10_001);
+			expect(sync.outgoingSyncProcesses.size).to.equal(0);
+			expect(leaseSignal?.aborted).to.equal(false);
+
+			releaseShipment();
+			expect(await handling).to.equal(true);
+			expect(ship.calledOnce).to.equal(true);
+		} finally {
+			releaseShipment();
+			await sync.close();
+			ship.restore();
+			clock.restore();
+		}
+	});
+
+	it("does not abort an accepted response when a newer target process replaces it", async () => {
+		let releaseShipment!: () => void;
+		const shipmentReleased = new Promise<void>((resolve) => {
+			releaseShipment = resolve;
+		});
+		let markShipmentStarted!: () => void;
+		const shipmentStarted = new Promise<void>((resolve) => {
+			markShipmentStarted = resolve;
+		});
+		const sync = createDispatchTestSynchronizer(() => {});
+		let leaseSignal: AbortSignal | undefined;
+		const ship = sinon
+			.stub(sync.simple, "shipAuthorizedMaybeSyncResponse")
+			.callsFake(async ({ signal }: { signal: AbortSignal }) => {
+				leaseSignal = signal;
+				markShipmentStarted();
+				await shipmentReleased;
+				return { messages: 1, fused: false, entries: 1 };
+			});
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["peer-a"],
+			});
+			const handling = sync.onMessage(
+				new ResponseMaybeSync({ hashes: ["hash-399"] }),
+				{ from: { hashcode: () => "peer-a" } } as any,
+			);
+			await shipmentStarted;
+
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(undefined, 401),
+				targets: ["peer-a"],
+			});
+			expect(sync.outgoingSyncProcesses.size).to.equal(1);
+			expect(leaseSignal?.aborted).to.equal(false);
+
+			releaseShipment();
+			expect(await handling).to.equal(true);
+		} finally {
+			releaseShipment();
+			await sync.close();
+			ship.restore();
+		}
+	});
+
+	it("aborts an accepted response lease on close", async () => {
+		let releaseShipment!: () => void;
+		const shipmentReleased = new Promise<void>((resolve) => {
+			releaseShipment = resolve;
+		});
+		let markShipmentStarted!: () => void;
+		const shipmentStarted = new Promise<void>((resolve) => {
+			markShipmentStarted = resolve;
+		});
+		const sync = createDispatchTestSynchronizer(() => {});
+		let leaseSignal: AbortSignal | undefined;
+		const ship = sinon
+			.stub(sync.simple, "shipAuthorizedMaybeSyncResponse")
+			.callsFake(async ({ signal }: { signal: AbortSignal }) => {
+				leaseSignal = signal;
+				markShipmentStarted();
+				await shipmentReleased;
+				return { messages: 0, fused: false, entries: 0 };
+			});
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["peer-a"],
+			});
+			const handling = sync.onMessage(
+				new ResponseMaybeSync({ hashes: ["hash-399"] }),
+				{ from: { hashcode: () => "peer-a" } } as any,
+			);
+			await shipmentStarted;
+
+			await sync.close();
+			expect(leaseSignal?.aborted).to.equal(true);
+			releaseShipment();
+			expect(await handling).to.equal(true);
+		} finally {
+			releaseShipment();
+			ship.restore();
+			await sync.close();
+		}
+	});
+
+	it("rolls back rateless response consumption after an ordinary ship failure", async () => {
+		const sync = createDispatchTestSynchronizer(() => {});
+		const ship = sinon.stub(sync.simple, "shipAuthorizedMaybeSyncResponse");
+		ship.onFirstCall().rejects(new Error("ship failed"));
+		ship.onSecondCall().resolves({ messages: 1, fused: false, entries: 1 });
+		const from = { hashcode: () => "peer-a" } as any;
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["peer-a"],
+			});
+			const process = [...sync.outgoingSyncProcesses.values()][0];
+
+			await expect(
+				sync.onMessage(new ResponseMaybeSync({ hashes: ["hash-399"] }), {
+					from,
+				} as any),
+			).to.be.rejectedWith("ship failed");
+			expect(process.consumedResponseHashes.has("hash-399")).to.equal(false);
+
+			expect(
+				await sync.onMessage(new ResponseMaybeSync({ hashes: ["hash-399"] }), {
+					from,
+				} as any),
+			).to.equal(true);
+			expect(ship.callCount).to.equal(2);
+		} finally {
+			ship.restore();
+			await sync.close();
+		}
+	});
+
+	it("preleases a mixed Simple remainder and profiles direct rateless shipping", async () => {
+		const clock = sinon.useFakeTimers();
+		const profileEvents: any[] = [];
+		let releaseRateless!: () => void;
+		const ratelessReleased = new Promise<void>((resolve) => {
+			releaseRateless = resolve;
+		});
+		let markRatelessStarted!: () => void;
+		const ratelessStarted = new Promise<void>((resolve) => {
+			markRatelessStarted = resolve;
+		});
+		const sync = createDispatchTestSynchronizer(() => {}, {
+			profile: (event: any) => profileEvents.push(event),
+		});
+		const ship = sinon
+			.stub(sync.simple, "shipAuthorizedMaybeSyncResponse")
+			.callsFake(async ({ hashes }: { hashes: string[] }) => {
+				if (hashes[0] === "hash-399") {
+					markRatelessStarted();
+					await ratelessReleased;
+					return { messages: 2, fused: true, entries: 1 };
+				}
+				return { messages: 1, fused: false, entries: hashes.length };
+			});
+		const consumeSimple = sinon.spy(
+			sync.simple,
+			"consumeAuthorizedMaybeSyncResponse",
+		);
+		const from = { hashcode: () => "peer-a" } as any;
+
+		try {
+			await sync.simple.onMaybeMissingHashes({
+				hashes: ["simple-remainder"],
+				targets: ["peer-a"],
+			});
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["peer-a"],
+			});
+
+			const handling = sync.onMessage(
+				new ResponseMaybeSync({
+					hashes: ["hash-399", "simple-remainder"],
+				}),
+				{ from } as any,
+			);
+			await ratelessStarted;
+			expect(consumeSimple.calledOnce).to.equal(true);
+			expect(consumeSimple.firstCall.args[0]).to.deep.equal([
+				"simple-remainder",
+			]);
+
+			await clock.tickAsync(30_001);
+			releaseRateless();
+			expect(await handling).to.equal(true);
+			expect(ship.getCalls().map((call) => call.args[0].hashes)).to.deep.equal([
+				["hash-399"],
+				["simple-remainder"],
+			]);
+
+			const directProfile = profileEvents.find(
+				(event) =>
+					event.name === "simple.exchangeHeads" &&
+					event.details?.source === "ratelessResponseMaybeSync",
+			);
+			expect(directProfile).to.include({
+				entries: 1,
+				messages: 2,
+				targets: 1,
+			});
+			expect(directProfile.details.fused).to.equal(true);
+		} finally {
+			releaseRateless();
+			consumeSimple.restore();
+			ship.restore();
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("ships and releases a preleased Simple remainder when direct profiling throws", async () => {
+		const profileError = new Error("direct profile failed");
+		const profileEvents: any[] = [];
+		const sync = createDispatchTestSynchronizer(() => {}, {
+			profile: (event: any) => {
+				profileEvents.push(event);
+				if (
+					event.name === "simple.exchangeHeads" &&
+					event.details?.source === "ratelessResponseMaybeSync"
+				) {
+					throw profileError;
+				}
+			},
+		});
+		const ship = sinon
+			.stub(sync.simple, "shipAuthorizedMaybeSyncResponse")
+			.resolves({ messages: 1, fused: false, entries: 1 });
+		const from = { hashcode: () => "peer-a" } as any;
+
+		try {
+			await sync.simple.onMaybeMissingHashes({
+				hashes: ["simple-remainder"],
+				targets: ["peer-a"],
+			});
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["peer-a"],
+			});
+
+			await expect(
+				sync.onMessage(
+					new ResponseMaybeSync({
+						hashes: ["hash-399", "simple-remainder"],
+					}),
+					{ from } as any,
+				),
+			).to.be.rejectedWith(profileError.message);
+
+			expect(ship.getCalls().map((call) => call.args[0].hashes)).to.deep.equal([
+				["hash-399"],
+				["simple-remainder"],
+			]);
+			expect(
+				profileEvents.some(
+					(event) =>
+						event.name === "simple.exchangeHeads" &&
+						event.details?.source === "responseMaybeSync",
+				),
+			).to.equal(true);
+			expect((sync.simple as any).pendingMaybeSyncResponseCount).to.equal(0);
+			expect((sync.simple as any).syncDispatchTargets.size).to.equal(0);
+		} finally {
+			ship.restore();
+			await sync.close();
+		}
+	});
+
+	it("does not let a foreign target drive an outgoing rateless process", async () => {
+		const sends: TransportMessage[] = [];
+		const sync = createDispatchTestSynchronizer((message) => {
+			sends.push(message);
+		});
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["peer-a"],
+			});
+			const startSync = sends.find(
+				(message) => message instanceof StartSync,
+			) as StartSync;
+			const sendsBeforeForeignRequests = sends.length;
+			const foreignContext = {
+				from: { hashcode: () => "peer-b" },
+			} as any;
+
+			await sync.onMessage(
+				new RequestMoreSymbols({
+					syncId: startSync.syncId,
+					lastSeqNo: 0n,
+				}),
+				foreignContext,
+			);
+			await sync.onMessage(
+				new RequestAll({ syncId: startSync.syncId }),
+				foreignContext,
+			);
+
+			expect(sends).to.have.length(sendsBeforeForeignRequests);
+			expect(sync.outgoingSyncProcesses.size).to.equal(1);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("isolates the same incoming sync id by sender and frees only a disconnected sender", async () => {
+		const peerA = (await Ed25519Keypair.create()).publicKey;
+		const peerB = (await Ed25519Keypair.create()).publicKey;
+		const peerC = (await Ed25519Keypair.create()).publicKey;
+		const peerAHash = peerA.hashcode();
+		const peerBHash = peerB.hashcode();
+		const sends: { message: TransportMessage; options?: any }[] = [];
+		const sync = createDispatchTestSynchronizer((message, options) => {
+			sends.push({ message, options });
+		});
+		const addA = sinon.spy();
+		const addB = sinon.spy();
+		const freeA = sinon.spy();
+		let peerBProcess: any;
+		let peerBWasAbortedWhenFreed = false;
+		const decoderA = {
+			add_coded_symbol: addA,
+			try_decode: () => {},
+			decoded: () => false,
+			get_remote_symbols: () => [],
+			free: freeA,
+		};
+		const decoderB = {
+			add_coded_symbol: addB,
+			try_decode: () => {},
+			decoded: () => false,
+			get_remote_symbols: () => [],
+			free: () => {
+				peerBWasAbortedWhenFreed =
+					peerBProcess?.controller.signal.aborted === true;
+			},
+		};
+		const getDecoder = sinon
+			.stub(sync as any, "getLocalDecoderForRange")
+			.onFirstCall()
+			.resolves(decoderA)
+			.onSecondCall()
+			.resolves(decoderB);
+		const start = new StartSync({ from: 0n, to: 10n, symbols: [] });
+		const more = new MoreSymbols({
+			syncId: start.syncId,
+			lastSeqNo: 0n,
+			symbols: [{ count: 0n, hash: 0n, symbol: 0n } as any],
+		});
+
+		try {
+			await sync.onMessage(start, { from: peerA } as any);
+			await sync.onMessage(start, { from: peerB } as any);
+			expect(sync.ingoingSyncProcesses.size).to.equal(2);
+			expect(getDecoder.callCount).to.equal(2);
+			peerBProcess = [...sync.ingoingSyncProcesses.values()].find(
+				(process) => process.sender === peerBHash,
+			);
+
+			const sendsBeforeForeign = sends.length;
+			await sync.onMessage(more, { from: peerC } as any);
+			expect(sends).to.have.length(sendsBeforeForeign);
+			expect(addA.called).to.equal(false);
+			expect(addB.called).to.equal(false);
+
+			await sync.onMessage(more, { from: peerA } as any);
+			expect(addA.calledOnce).to.equal(true);
+			expect(addB.called).to.equal(false);
+			expect(
+				sends.some(
+					(send) =>
+						send.message instanceof RequestMoreSymbols &&
+						send.options?.mode?.to?.[0] === peerAHash,
+				),
+			).to.equal(true);
+
+			sync.onPeerDisconnected(peerAHash);
+			expect(freeA.calledOnce).to.equal(true);
+			expect(sync.ingoingSyncProcesses.size).to.equal(1);
+			expect([...sync.ingoingSyncProcesses.values()][0]).to.equal(peerBProcess);
+
+			await sync.close();
+			expect(peerBWasAbortedWhenFreed).to.equal(true);
+		} finally {
+			getDecoder.restore();
+			await sync.close();
+		}
+	});
+
+	it("frees a decoder initializer that resumes after close and reopen without sending", async () => {
+		const peer = (await Ed25519Keypair.create()).publicKey;
+		let releaseDecoder!: (decoder: any) => void;
+		const decoderReleased = new Promise<any>((resolve) => {
+			releaseDecoder = resolve;
+		});
+		let markDecoderStarted!: () => void;
+		const decoderStarted = new Promise<void>((resolve) => {
+			markDecoderStarted = resolve;
+		});
+		const sends: TransportMessage[] = [];
+		const sync = createDispatchTestSynchronizer((message) => {
+			sends.push(message);
+		});
+		const free = sinon.spy();
+		const getDecoder = sinon
+			.stub(sync as any, "getLocalDecoderForRange")
+			.callsFake(async () => {
+				markDecoderStarted();
+				return decoderReleased;
+			});
+		const start = new StartSync({ from: 0n, to: 10n, symbols: [] });
+
+		try {
+			const handling = sync.onMessage(start, {
+				from: peer,
+			} as any);
+			await decoderStarted;
+			const oldProcess = [...sync.ingoingSyncProcesses.values()][0];
+			expect(oldProcess.controller.signal.aborted).to.equal(false);
+
+			await sync.close();
+			expect(oldProcess.controller.signal.aborted).to.equal(true);
+			expect(sync.ingoingSyncProcesses.size).to.equal(0);
+			await sync.open();
+
+			releaseDecoder({
+				add_coded_symbol: () => {},
+				try_decode: () => {},
+				decoded: () => false,
+				get_remote_symbols: () => [],
+				free,
+			});
+			expect(await handling).to.equal(true);
+			expect(free.calledOnce).to.equal(true);
+			expect(sync.ingoingSyncProcesses.size).to.equal(0);
+			expect(
+				sends.some(
+					(message) =>
+						message instanceof RequestAll ||
+						message instanceof RequestMoreSymbols,
+				),
+			).to.equal(false);
+		} finally {
+			releaseDecoder({
+				free: () => {},
+			});
+			getDecoder.restore();
+			await sync.close();
+		}
+	});
+
+	for (const decoderFound of [true, false]) {
+		it(`cleans the incoming ${decoderFound ? "decoder" : "no-decoder process"} when outer decoder profiling throws`, async () => {
+			const peer = (await Ed25519Keypair.create()).publicKey;
+			const profileError = new Error("incoming decoder profile failed");
+			const send = sinon.spy();
+			const decoderFree = sinon.spy();
+			let trackedProcess: any;
+			let processAbort: sinon.SinonSpy | undefined;
+			const sync = createDispatchTestSynchronizer(send, {
+				profile: (event: { name: string }) => {
+					if (event.name !== "rateless.getLocalDecoderForRange") {
+						return;
+					}
+					trackedProcess = [...sync.ingoingSyncProcesses.values()][0];
+					processAbort = sinon.spy(trackedProcess.controller, "abort");
+					throw profileError;
+				},
+			});
+			const getDecoder = sinon
+				.stub(sync as any, "getLocalDecoderForRange")
+				.resolves(decoderFound ? ({ free: decoderFree } as any) : false);
+
+			try {
+				await expect(
+					sync.onMessage(new StartSync({ from: 0n, to: 10n, symbols: [] }), {
+						from: peer,
+					} as any),
+				).to.be.rejectedWith(profileError.message);
+
+				expect(trackedProcess).not.to.equal(undefined);
+				expect(processAbort?.calledOnce).to.equal(true);
+				expect(trackedProcess.controller.signal.aborted).to.equal(true);
+				expect(trackedProcess.timeout).to.equal(undefined);
+				expect(trackedProcess.decoder).to.equal(undefined);
+				expect(sync.ingoingSyncProcesses.size).to.equal(0);
+				expect(send.called).to.equal(false);
+				expect(decoderFree.callCount).to.equal(decoderFound ? 1 : 0);
+
+				await sync.close();
+				expect(processAbort?.calledOnce).to.equal(true);
+				expect(decoderFree.callCount).to.equal(decoderFound ? 1 : 0);
+			} finally {
+				processAbort?.restore();
+				getDecoder.restore();
+				await sync.close();
+			}
+		});
+	}
+
+	it("consumes an asynchronous StartSync send rejection", async () => {
+		let rejectStartSync!: (error: Error) => void;
+		const startSyncSend = new Promise<void>((_resolve, reject) => {
+			rejectStartSync = reject;
+		});
+		let startSyncSignal: AbortSignal | undefined;
+		const sync = createDispatchTestSynchronizer((message, options) => {
+			if (message instanceof StartSync) {
+				startSyncSignal = options?.signal;
+				return startSyncSend;
+			}
+		});
+		const controller = new AbortController();
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["target"],
+				signal: controller.signal,
+			});
+			expect(sync.outgoingSyncProcesses.size).to.equal(1);
+			expect(startSyncSignal).not.to.equal(controller.signal);
+			expect(startSyncSignal?.aborted).to.equal(false);
+
+			rejectStartSync(new Error("transport failed"));
+			await Promise.resolve();
+
+			expect(sync.outgoingSyncProcesses.size).to.equal(0);
+		} finally {
+			controller.abort();
+			rejectStartSync(new Error("cancelled"));
+			await sync.close();
+		}
+	});
+
+	it("aborts an in-flight StartSync send when closed", async () => {
+		let startSyncSignal: AbortSignal | undefined;
+		const sync = createDispatchTestSynchronizer((message, options) => {
+			if (!(message instanceof StartSync)) {
+				return;
+			}
+			startSyncSignal = options?.signal;
+			return new Promise<void>((_resolve, reject) => {
+				const rejectForAbort = () =>
+					reject(startSyncSignal?.reason ?? new Error("transport aborted"));
+				if (startSyncSignal?.aborted) {
+					rejectForAbort();
+				} else {
+					startSyncSignal?.addEventListener("abort", rejectForAbort, {
+						once: true,
+					});
+				}
+			});
+		});
+		const unhandledRejections: unknown[] = [];
+		const onUnhandledRejection = (reason: unknown) => {
+			unhandledRejections.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandledRejection);
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["target"],
+			});
+			expect(startSyncSignal?.aborted).to.equal(false);
+			expect(sync.outgoingSyncProcesses.size).to.equal(1);
+
+			await sync.close();
+			await new Promise<void>((resolve) => setImmediate(resolve));
+
+			expect(startSyncSignal?.aborted).to.equal(true);
+			expect(sync.outgoingSyncProcesses.size).to.equal(0);
+			expect(unhandledRejections).to.deep.equal([]);
+		} finally {
+			process.removeListener("unhandledRejection", onUnhandledRejection);
+			await sync.close();
+		}
+	});
+
+	it("consumes an asynchronous RequestMoreSymbols follow-up rejection without profiling", async () => {
+		const peer = (await Ed25519Keypair.create()).publicKey;
+		let rejectFollowUp!: (error: Error) => void;
+		const followUpSend = new Promise<void>((_resolve, reject) => {
+			rejectFollowUp = reject;
+		});
+		let followUpSendCount = 0;
+		const sync = createDispatchTestSynchronizer((message) => {
+			if (message instanceof RequestMoreSymbols) {
+				followUpSendCount += 1;
+				if (followUpSendCount > 1) {
+					return followUpSend;
+				}
+			}
+		});
+		const getDecoder = sinon
+			.stub(sync as any, "getLocalDecoderForRange")
+			.resolves({
+				add_coded_symbol: () => {},
+				try_decode: () => {},
+				decoded: () => false,
+				get_remote_symbols: () => [],
+				free: () => {},
+			});
+		const unhandledRejections: unknown[] = [];
+		const onUnhandledRejection = (reason: unknown) => {
+			unhandledRejections.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandledRejection);
+
+		try {
+			const start = new StartSync({ from: 0n, to: 10n, symbols: [] });
+			await sync.onMessage(start, {
+				from: peer,
+			} as any);
+			expect(followUpSendCount).to.equal(1);
+			const handling = sync.onMessage(
+				new MoreSymbols({
+					syncId: start.syncId,
+					lastSeqNo: 0n,
+					symbols: CodedSymbolBatch.fromSymbols([]),
+				}),
+				{ from: peer } as any,
+			);
+			await waitForResolved(() => expect(followUpSendCount).to.equal(2));
+
+			rejectFollowUp(new Error("transport failed"));
+			expect(await handling).to.equal(true);
+			await new Promise<void>((resolve) => setImmediate(resolve));
+
+			expect(unhandledRejections).to.deep.equal([]);
+		} finally {
+			process.removeListener("unhandledRejection", onUnhandledRejection);
+			rejectFollowUp(new Error("test cleanup"));
+			getDecoder.restore();
+			await sync.close();
+		}
+	});
+
+	it("stops a captured RequestAll after its first chunk is aborted", async () => {
+		const sends: {
+			message: TransportMessage;
+			options?: { signal?: AbortSignal };
+		}[] = [];
+		let releaseFirstChunk!: () => void;
+		const firstChunkReleased = new Promise<void>((resolve) => {
+			releaseFirstChunk = resolve;
+		});
+		let markFirstChunkStarted!: () => void;
+		const firstChunkStarted = new Promise<void>((resolve) => {
+			markFirstChunkStarted = resolve;
+		});
+		const sync = createDispatchTestSynchronizer(async (message, options) => {
+			sends.push({ message, options });
+			if (
+				message instanceof RequestMaybeSync &&
+				sends.filter((send) => send.message instanceof RequestMaybeSync)
+					.length === 1
+			) {
+				markFirstChunkStarted();
+				await firstChunkReleased;
+			}
+		});
+		const controller = new AbortController();
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(undefined, 3000),
+				targets: ["target"],
+				signal: controller.signal,
+			});
+			const startSync = sends.find((send) => send.message instanceof StartSync)
+				?.message as StartSync;
+
+			const requestAll = sync.onMessage(
+				new RequestAll({ syncId: startSync.syncId }),
+				{
+					from: { hashcode: () => "target" },
+				} as any,
+			);
+			await firstChunkStarted;
+			controller.abort();
+			releaseFirstChunk();
+			await requestAll;
+
+			const chunks = sends.filter(
+				(send) => send.message instanceof RequestMaybeSync,
+			);
+			expect(chunks).to.have.length(1);
+			expect(chunks[0].options?.signal).not.to.equal(controller.signal);
+			expect(chunks[0].options?.signal?.aborted).to.equal(true);
+			expect((chunks[0].message as RequestMaybeSync).hashes).to.have.length(
+				1024,
+			);
+		} finally {
+			controller.abort();
+			releaseFirstChunk();
+			await sync.close();
+		}
+	});
+
+	it("does not send MoreSymbols after a captured process aborts", async () => {
+		const sends: TransportMessage[] = [];
+		const sync = createDispatchTestSynchronizer((message) => {
+			sends.push(message);
+		});
+		const controller = new AbortController();
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["target"],
+				signal: controller.signal,
+			});
+			const startSync = sends.find(
+				(message) => message instanceof StartSync,
+			) as StartSync;
+			const process = [...sync.outgoingSyncProcesses.values()][0];
+			let nextCalled = false;
+			process.next = () => {
+				nextCalled = true;
+				controller.abort();
+				return CodedSymbolBatch.fromSymbols([]);
+			};
+
+			await sync.onMessage(
+				new RequestMoreSymbols({
+					syncId: startSync.syncId,
+					lastSeqNo: 0n,
+				}),
+				{
+					from: { hashcode: () => "target" },
+				} as any,
+			);
+
+			expect(nextCalled).to.equal(true);
+			expect(sends.some((message) => message instanceof MoreSymbols)).to.equal(
+				false,
+			);
+			expect(sync.outgoingSyncProcesses.size).to.equal(0);
+		} finally {
+			controller.abort();
+			await sync.close();
+		}
+	});
+
+	it("cancels an in-flight MoreSymbols send without an unhandled rejection", async () => {
+		const sends: {
+			message: TransportMessage;
+			options?: { signal?: AbortSignal };
+		}[] = [];
+		let moreSymbolsSignal: AbortSignal | undefined;
+		const sync = createDispatchTestSynchronizer((message, options) => {
+			sends.push({ message, options });
+			if (message instanceof MoreSymbols) {
+				moreSymbolsSignal = options?.signal;
+				return new Promise<void>((_resolve, reject) => {
+					const rejectForAbort = () =>
+						reject(moreSymbolsSignal?.reason ?? new Error("transport aborted"));
+					if (moreSymbolsSignal?.aborted) {
+						rejectForAbort();
+					} else {
+						moreSymbolsSignal?.addEventListener("abort", rejectForAbort, {
+							once: true,
+						});
+					}
+				});
+			}
+		});
+		const controller = new AbortController();
+		const unhandledRejections: unknown[] = [];
+		const onUnhandledRejection = (reason: unknown) => {
+			unhandledRejections.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandledRejection);
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["target"],
+				signal: controller.signal,
+			});
+			const startSync = sends.find((send) => send.message instanceof StartSync)
+				?.message as StartSync;
+			expect(startSync).to.be.instanceOf(StartSync);
+			const outgoingProcess = [...sync.outgoingSyncProcesses.values()][0];
+			expect(outgoingProcess).to.not.equal(undefined);
+			outgoingProcess.next = () => CodedSymbolBatch.fromSymbols([]);
+			const handling = sync.onMessage(
+				new RequestMoreSymbols({
+					syncId: startSync.syncId,
+					lastSeqNo: 0n,
+				}),
+				{ from: { hashcode: () => "target" } } as any,
+			);
+			expect(moreSymbolsSignal).not.to.equal(controller.signal);
+			expect(moreSymbolsSignal?.aborted).to.equal(false);
+
+			controller.abort(new Error("repair lifecycle cancelled"));
+			expect(await handling).to.equal(true);
+			expect(moreSymbolsSignal?.aborted).to.equal(true);
+			await new Promise<void>((resolve) => setImmediate(resolve));
+
+			expect(
+				sends.filter((send) => send.message instanceof MoreSymbols),
+			).to.have.length(1);
+			expect(sync.outgoingSyncProcesses.size).to.equal(0);
+			expect(unhandledRejections).to.deep.equal([]);
+		} finally {
+			controller.abort(new Error("test cleanup"));
+			process.removeListener("unhandledRejection", onUnhandledRejection);
+			await sync.close();
+		}
+	});
+
+	it("aborts an in-flight MoreSymbols send before RequestAll fallback", async () => {
+		const sends: {
+			message: TransportMessage;
+			options?: { signal?: AbortSignal };
+		}[] = [];
+		let moreSymbolsSignal: AbortSignal | undefined;
+		let markMoreSymbolsStarted!: () => void;
+		const moreSymbolsStarted = new Promise<void>((resolve) => {
+			markMoreSymbolsStarted = resolve;
+		});
+		const sync = createDispatchTestSynchronizer((message, options) => {
+			sends.push({ message, options });
+			if (!(message instanceof MoreSymbols)) {
+				return;
+			}
+			moreSymbolsSignal = options?.signal;
+			markMoreSymbolsStarted();
+			return new Promise<void>((_resolve, reject) => {
+				const rejectForAbort = () =>
+					reject(moreSymbolsSignal?.reason ?? new Error("transport aborted"));
+				if (moreSymbolsSignal?.aborted) {
+					rejectForAbort();
+				} else {
+					moreSymbolsSignal?.addEventListener("abort", rejectForAbort, {
+						once: true,
+					});
+				}
+			});
+		});
+		const from = { hashcode: () => "target" } as any;
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["target"],
+			});
+			const startSync = sends.find((send) => send.message instanceof StartSync)
+				?.message as StartSync;
+			const handlingMore = sync.onMessage(
+				new RequestMoreSymbols({
+					syncId: startSync.syncId,
+					lastSeqNo: 0n,
+				}),
+				{ from } as any,
+			);
+			await moreSymbolsStarted;
+			expect(moreSymbolsSignal?.aborted).to.equal(false);
+
+			const handlingAll = sync.onMessage(
+				new RequestAll({ syncId: startSync.syncId }),
+				{ from } as any,
+			);
+			expect(await handlingMore).to.equal(true);
+			expect(await handlingAll).to.equal(true);
+
+			expect(moreSymbolsSignal?.aborted).to.equal(true);
+			expect(sync.outgoingSyncProcesses.size).to.equal(0);
+			expect(
+				sends.filter((send) => send.message instanceof RequestMaybeSync),
+			).to.have.length(1);
 		} finally {
 			await sync.close();
 		}

--- a/packages/programs/data/shared-log/test/rateless-iblt.spec.ts
+++ b/packages/programs/data/shared-log/test/rateless-iblt.spec.ts
@@ -369,6 +369,59 @@ describe("rateless-iblt-syncronizer", () => {
 		}
 	});
 
+	it("skips an oversized all-boundary Simple prelude and dispatches Rateless", async () => {
+		const sentMessages: TransportMessage[] = [];
+		const sync = createDispatchTestSynchronizer((message) => {
+			sentMessages.push(message);
+		});
+		const entries = createDispatchTestEntries(undefined, 1_001);
+		for (const entry of entries.values()) {
+			entry.assignedToRangeBoundary = true;
+		}
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries,
+				targets: ["target"],
+			});
+
+			expect(
+				sentMessages.filter((message) => message instanceof RequestMaybeSync),
+			).to.have.length(0);
+			expect(
+				sentMessages.filter((message) => message instanceof StartSync),
+			).to.have.length(1);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("keeps a bounded mixed-boundary Simple prelude before Rateless", async () => {
+		const sentMessages: TransportMessage[] = [];
+		const sync = createDispatchTestSynchronizer((message) => {
+			sentMessages.push(message);
+		});
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(0),
+				targets: ["target"],
+			});
+
+			const simpleRequests = sentMessages.filter(
+				(message): message is RequestMaybeSync =>
+					message instanceof RequestMaybeSync,
+			);
+			expect(simpleRequests).to.have.length(1);
+			expect(simpleRequests[0].hashes).to.deep.equal(["hash-0"]);
+			expect(
+				sentMessages.filter((message) => message instanceof StartSync),
+			).to.have.length(1);
+		} finally {
+			await sync.close();
+		}
+	});
+
 	it("frees an outgoing encoder once when post-prepare profiling throws", async () => {
 		const profileError = new Error("prepare profile failed");
 		const free = sinon.spy(EncoderWrapper.prototype, "free");
@@ -1142,7 +1195,7 @@ describe("rateless-iblt-syncronizer", () => {
 		}
 	});
 
-	it("does not abort an accepted response when a newer target process replaces it", async () => {
+	it("does not replace an active target process while its response is shipping", async () => {
 		let releaseShipment!: () => void;
 		const shipmentReleased = new Promise<void>((resolve) => {
 			releaseShipment = resolve;
@@ -1167,6 +1220,7 @@ describe("rateless-iblt-syncronizer", () => {
 				entries: createDispatchTestEntries(),
 				targets: ["peer-a"],
 			});
+			const process = [...sync.outgoingSyncProcesses.values()][0];
 			const handling = sync.onMessage(
 				new ResponseMaybeSync({ hashes: ["hash-399"] }),
 				{ from: { hashcode: () => "peer-a" } } as any,
@@ -1178,6 +1232,7 @@ describe("rateless-iblt-syncronizer", () => {
 				targets: ["peer-a"],
 			});
 			expect(sync.outgoingSyncProcesses.size).to.equal(1);
+			expect([...sync.outgoingSyncProcesses.values()][0]).to.equal(process);
 			expect(leaseSignal?.aborted).to.equal(false);
 
 			releaseShipment();
@@ -2086,7 +2141,7 @@ describe("rateless-iblt-syncronizer", () => {
 		}
 	});
 
-	it("prefers delayed Simple fallback authorization after rateless replacement", async () => {
+	it("keeps an active target process and sends only uncovered hashes simply", async () => {
 		const sends: TransportMessage[] = [];
 		const sync = createDispatchTestSynchronizer((message) => {
 			sends.push(message);
@@ -2099,19 +2154,25 @@ describe("rateless-iblt-syncronizer", () => {
 				targets: ["peer-a"],
 			});
 			const process = [...sync.outgoingSyncProcesses.values()][0];
-			await process.startSimpleFallback();
-			expect(process.simpleFallbackStarted).to.equal(true);
-			expect(sync.outgoingSyncProcesses.size).to.equal(1);
-			expect((sync.simple as any).pendingMaybeSyncResponseCount).to.equal(400);
 
 			await sync.onMaybeMissingEntries({
-				entries: createDispatchTestEntries(),
+				entries: createDispatchTestEntries(undefined, 401),
 				targets: ["peer-a"],
 			});
-			const replacement = [...sync.outgoingSyncProcesses.values()][0];
-			expect(replacement).not.to.equal(process);
-			expect(replacement.simpleFallbackStarted).to.equal(false);
-			const replacementStart = sends
+			const retained = [...sync.outgoingSyncProcesses.values()][0];
+			expect(retained).to.equal(process);
+			expect(
+				sends.filter(
+					(message): message is StartSync => message instanceof StartSync,
+				),
+			).to.have.length(1);
+			const simpleRequest = sends.find(
+				(message): message is RequestMaybeSync =>
+					message instanceof RequestMaybeSync,
+			);
+			expect(simpleRequest?.hashes).to.deep.equal(["hash-400"]);
+			expect((sync.simple as any).pendingMaybeSyncResponseCount).to.equal(1);
+			const retainedStart = sends
 				.filter((message): message is StartSync => message instanceof StartSync)
 				.at(-1)!;
 
@@ -2128,26 +2189,21 @@ describe("rateless-iblt-syncronizer", () => {
 					return { messages: 0, fused: false, entries: leases.length };
 				});
 			try {
-				await sync.onMessage(new ResponseMaybeSync({ hashes: ["hash-0"] }), {
+				await sync.onMessage(new ResponseMaybeSync({ hashes: ["hash-400"] }), {
 					from,
 				} as any);
 
 				expect(directRatelessShip.called).to.equal(false);
 				expect(simpleShip.calledOnce).to.equal(true);
-				expect((sync.simple as any).pendingMaybeSyncResponseCount).to.equal(
-					399,
-				);
+				expect((sync.simple as any).pendingMaybeSyncResponseCount).to.equal(0);
 			} finally {
 				directRatelessShip.restore();
 				simpleShip.restore();
 			}
 
-			await sync.onMessage(
-				new RequestAll({ syncId: replacementStart.syncId }),
-				{
-					from,
-				} as any,
-			);
+			await sync.onMessage(new RequestAll({ syncId: retainedStart.syncId }), {
+				from,
+			} as any);
 			expect(sync.outgoingSyncProcesses.size).to.equal(0);
 		} finally {
 			await sync.close();

--- a/packages/programs/data/shared-log/test/rateless-iblt.spec.ts
+++ b/packages/programs/data/shared-log/test/rateless-iblt.spec.ts
@@ -13,6 +13,7 @@ import {
 import { TransportMessage } from "../src/message.js";
 import {
 	CodedSymbolBatch,
+	MAX_ACTIVE_RATELESS_RESPONSES_PER_PEER,
 	MoreSymbols,
 	RatelessIBLTSynchronizer,
 	RequestAll,
@@ -169,6 +170,20 @@ describe("rateless-iblt-syncronizer", () => {
 		expect(
 			Array.from((moreSymbols as MoreSymbols).symbols.toFlat()),
 		).to.deep.equal(expectedFlat);
+	});
+
+	it("rejects an oversized coded-symbol batch during deserialization", () => {
+		const bytes = serialize(
+			new StartSync({
+				from: 0n,
+				to: 10n,
+				symbols: CodedSymbolBatch.fromFlat(new BigUint64Array(1_025 * 3)),
+			}),
+		);
+
+		expect(() => deserialize(bytes, TransportMessage)).to.throw(
+			"receiver limit",
+		);
 	});
 
 	const setupLogs = async (
@@ -596,7 +611,7 @@ describe("rateless-iblt-syncronizer", () => {
 	it("runs delayed full-set retries for a capped convergent repair", async () => {
 		const clock = sinon.useFakeTimers();
 		const sync = createDispatchTestSynchronizer(() => {}, {
-			maxConvergentTrackedHashes: 1,
+			maxConvergentTrackedHashes: 0.5,
 		});
 		const tracked = stubTrackedRepairSession(sync);
 		const dispatch = sinon.stub(sync, "onMaybeMissingEntries").resolves();
@@ -991,6 +1006,95 @@ describe("rateless-iblt-syncronizer", () => {
 		}
 	});
 
+	it("bounds inspected hashes before splitting a mixed response", async () => {
+		const sync = createDispatchTestSynchronizer(() => {});
+		const shipAuthorized = sinon
+			.stub(sync.simple, "shipAuthorizedMaybeSyncResponse")
+			.resolves({ messages: 1, fused: false, entries: 1 });
+		const hashes = Array.from({ length: 10_001 }, (_, index) =>
+			index === 0 ? "hash-399" : `untrusted-${index}`,
+		);
+		Object.defineProperty(hashes, "filter", {
+			configurable: true,
+			value: () => {
+				throw new Error("the full response vector must not be filtered");
+			},
+		});
+		Object.defineProperty(hashes, Symbol.iterator, {
+			configurable: true,
+			value: function* () {
+				for (let index = 0; index < hashes.length; index += 1) {
+					if (index >= 10_000) {
+						throw new Error("response inspection exceeded its bound");
+					}
+					yield hashes[index]!;
+				}
+			},
+		});
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["peer-a"],
+			});
+			expect(
+				await sync.onMessage(new ResponseMaybeSync({ hashes }), {
+					from: { hashcode: () => "peer-a" },
+				} as any),
+			).to.equal(true);
+
+			expect(shipAuthorized.calledOnce).to.equal(true);
+			expect(shipAuthorized.firstCall.args[0].hashes).to.deep.equal([
+				"hash-399",
+			]);
+		} finally {
+			shipAuthorized.restore();
+			await sync.close();
+		}
+	});
+
+	it("keeps unleased hashes rateless-authorized during a capacity-blocked Simple fallback", async () => {
+		const sync = createDispatchTestSynchronizer(() => {});
+		const shipAuthorized = sinon
+			.stub(sync.simple, "shipAuthorizedMaybeSyncResponse")
+			.resolves({ messages: 0, fused: false, entries: 1 });
+		const from = { hashcode: () => "peer-a" } as any;
+		let fallback: Promise<void> | undefined;
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(undefined, 10_001),
+				targets: ["peer-a"],
+			});
+			const process = [...sync.outgoingSyncProcesses.values()][0];
+			fallback = process.startSimpleFallback();
+			void fallback.catch(() => {});
+			await waitForResolved(
+				() => {
+					expect((sync.simple as any).pendingMaybeSyncResponseCount).to.equal(
+						9_216,
+					);
+				},
+				{ timeout: 2_000, delayInterval: 1 },
+			);
+
+			await sync.onMessage(new ResponseMaybeSync({ hashes: ["hash-10000"] }), {
+				from,
+			} as any);
+			expect(shipAuthorized.calledOnce).to.equal(true);
+			expect(shipAuthorized.firstCall.args[0].hashes).to.deep.equal([
+				"hash-10000",
+			]);
+			expect((sync.simple as any).pendingMaybeSyncResponseCount).to.equal(
+				9_216,
+			);
+		} finally {
+			shipAuthorized.restore();
+			await sync.close();
+			await fallback?.catch(() => {});
+		}
+	});
+
 	it("lets an accepted >10,000-hash response finish after its process timeout", async () => {
 		const clock = sinon.useFakeTimers();
 		let releaseShipment!: () => void;
@@ -1127,6 +1231,105 @@ describe("rateless-iblt-syncronizer", () => {
 		}
 	});
 
+	it("retains bounded active response work across close and reopen", async () => {
+		const releases: (() => void)[] = [];
+		let blockShipments = true;
+		const sync = createDispatchTestSynchronizer(() => {});
+		const ship = sinon
+			.stub(sync.simple, "shipAuthorizedMaybeSyncResponse")
+			.callsFake(async () => {
+				if (blockShipments) {
+					await new Promise<void>((resolve) => releases.push(resolve));
+				}
+				return { messages: 1, fused: false, entries: 1 };
+			});
+		const from = { hashcode: () => "peer-a" } as any;
+		const handlings: Promise<boolean>[] = [];
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["peer-a"],
+			});
+			for (
+				let index = 0;
+				index < MAX_ACTIVE_RATELESS_RESPONSES_PER_PEER;
+				index += 1
+			) {
+				handlings.push(
+					sync.onMessage(new ResponseMaybeSync({ hashes: [`hash-${index}`] }), {
+						from,
+					} as any),
+				);
+				await waitForResolved(
+					() => {
+						expect(ship.callCount).to.equal(index + 1);
+					},
+					{ timeout: 2_000, delayInterval: 1 },
+				);
+			}
+			expect((sync as any).activeRatelessResponseCount).to.equal(
+				MAX_ACTIVE_RATELESS_RESPONSES_PER_PEER,
+			);
+
+			expect(
+				await sync.onMessage(
+					new ResponseMaybeSync({
+						hashes: [`hash-${MAX_ACTIVE_RATELESS_RESPONSES_PER_PEER}`],
+					}),
+					{ from } as any,
+				),
+			).to.equal(true);
+			expect(ship.callCount).to.equal(MAX_ACTIVE_RATELESS_RESPONSES_PER_PEER);
+
+			await sync.close();
+			await sync.open();
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["peer-a"],
+			});
+			expect(
+				await sync.onMessage(
+					new ResponseMaybeSync({
+						hashes: [`hash-${MAX_ACTIVE_RATELESS_RESPONSES_PER_PEER}`],
+					}),
+					{ from } as any,
+				),
+			).to.equal(true);
+			expect(ship.callCount).to.equal(MAX_ACTIVE_RATELESS_RESPONSES_PER_PEER);
+
+			blockShipments = false;
+			for (const release of releases) {
+				release();
+			}
+			expect(await Promise.all(handlings)).to.have.length(
+				MAX_ACTIVE_RATELESS_RESPONSES_PER_PEER,
+			);
+			expect((sync as any).activeRatelessResponseCount).to.equal(0);
+			expect((sync as any).activeRatelessResponseCountByPeer.size).to.equal(0);
+
+			expect(
+				await sync.onMessage(
+					new ResponseMaybeSync({
+						hashes: [`hash-${MAX_ACTIVE_RATELESS_RESPONSES_PER_PEER}`],
+					}),
+					{ from } as any,
+				),
+			).to.equal(true);
+			expect(ship.callCount).to.equal(
+				MAX_ACTIVE_RATELESS_RESPONSES_PER_PEER + 1,
+			);
+		} finally {
+			blockShipments = false;
+			for (const release of releases) {
+				release();
+			}
+			await Promise.allSettled(handlings);
+			ship.restore();
+			await sync.close();
+		}
+	});
+
 	it("rolls back rateless response consumption after an ordinary ship failure", async () => {
 		const sync = createDispatchTestSynchronizer(() => {});
 		const ship = sinon.stub(sync.simple, "shipAuthorizedMaybeSyncResponse");
@@ -1209,6 +1412,7 @@ describe("rateless-iblt-syncronizer", () => {
 			await ratelessStarted;
 			expect(consumeSimple.calledOnce).to.equal(true);
 			expect(consumeSimple.firstCall.args[0]).to.deep.equal([
+				"hash-399",
 				"simple-remainder",
 			]);
 
@@ -1331,6 +1535,700 @@ describe("rateless-iblt-syncronizer", () => {
 			expect(sends).to.have.length(sendsBeforeForeignRequests);
 			expect(sync.outgoingSyncProcesses.size).to.equal(1);
 		} finally {
+			await sync.close();
+		}
+	});
+
+	it("bounds incoming process admission before decoder construction", async () => {
+		const sync = createDispatchTestSynchronizer(() => {});
+		const releases: ((decoder: any) => void)[] = [];
+		const decoderFree = sinon.spy();
+		const getDecoder = sinon
+			.stub(sync as any, "getLocalDecoderForRange")
+			.callsFake(
+				() =>
+					new Promise<any>((resolve) => {
+						releases.push(resolve);
+					}),
+			);
+		const handlings: Promise<boolean>[] = [];
+		const startFor = (sender: string) =>
+			sync.onMessage(new StartSync({ from: 0n, to: 10n, symbols: [] }), {
+				from: { hashcode: () => sender },
+			} as any);
+
+		try {
+			for (let i = 0; i < 4; i++) {
+				handlings.push(startFor("peer-0"));
+			}
+			expect(await startFor("peer-0")).to.equal(true);
+			expect(getDecoder.callCount).to.equal(4);
+
+			for (let peer = 1; peer < 8; peer++) {
+				for (let i = 0; i < 4; i++) {
+					handlings.push(startFor(`peer-${peer}`));
+				}
+			}
+			expect(sync.ingoingSyncProcesses.size).to.equal(32);
+			expect(getDecoder.callCount).to.equal(32);
+
+			expect(await startFor("peer-8")).to.equal(true);
+			expect(sync.ingoingSyncProcesses.size).to.equal(32);
+			expect(getDecoder.callCount).to.equal(32);
+
+			await sync.close();
+			expect((sync as any).incomingRatelessProcessAdmissions.size).to.equal(32);
+			await sync.open();
+			expect(await startFor("peer-8")).to.equal(true);
+			expect(getDecoder.callCount).to.equal(32);
+			for (const release of releases) {
+				release({ free: decoderFree });
+			}
+			expect(await Promise.all(handlings)).to.have.length(32);
+			expect(decoderFree.callCount).to.equal(32);
+			expect((sync as any).incomingRatelessProcessAdmissions.size).to.equal(0);
+		} finally {
+			for (const release of releases) {
+				release({ free: () => {} });
+			}
+			getDecoder.restore();
+			await sync.close();
+		}
+	});
+
+	it("starts the incoming absolute deadline before decoder initialization", async () => {
+		const clock = sinon.useFakeTimers();
+		const sends: TransportMessage[] = [];
+		const sync = createDispatchTestSynchronizer((message) => {
+			sends.push(message);
+		});
+		const releases: ((decoder: any) => void)[] = [];
+		const decoderFree = sinon.spy();
+		const getDecoder = sinon
+			.stub(sync as any, "getLocalDecoderForRange")
+			.callsFake(
+				() =>
+					new Promise<any>((resolve) => {
+						releases.push(resolve);
+					}),
+			);
+		const starts = Array.from(
+			{ length: 4 },
+			() => new StartSync({ from: 0n, to: 10n, symbols: [] }),
+		);
+		const from = { hashcode: () => "peer-a" };
+
+		try {
+			const handlings = starts.map((start) =>
+				sync.onMessage(start, { from } as any),
+			);
+			const process = [...sync.ingoingSyncProcesses.values()][0];
+			expect(process.controller.signal.aborted).to.equal(false);
+			expect(getDecoder.callCount).to.equal(4);
+
+			await clock.tickAsync(120_000);
+			expect(process.controller.signal.aborted).to.equal(true);
+			expect(sync.ingoingSyncProcesses.size).to.equal(0);
+			expect((sync as any).incomingRatelessProcessAdmissions.size).to.equal(4);
+			expect(
+				sends.filter((message) => message instanceof RequestAll),
+			).to.have.length(4);
+
+			expect(
+				await sync.onMessage(
+					new StartSync({ from: 0n, to: 10n, symbols: [] }),
+					{ from } as any,
+				),
+			).to.equal(true);
+			expect(getDecoder.callCount).to.equal(4);
+
+			for (const release of releases) {
+				release({ free: decoderFree });
+			}
+			expect(await Promise.all(handlings)).to.deep.equal([
+				true,
+				true,
+				true,
+				true,
+			]);
+			expect(decoderFree.callCount).to.equal(4);
+			expect((sync as any).incomingRatelessProcessAdmissions.size).to.equal(0);
+		} finally {
+			for (const release of releases) {
+				release({ free: () => {} });
+			}
+			getDecoder.restore();
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("retains incoming admission while disconnected decoder initialization settles", async () => {
+		const sync = createDispatchTestSynchronizer(() => {});
+		const releases: ((decoder: any) => void)[] = [];
+		const getDecoder = sinon
+			.stub(sync as any, "getLocalDecoderForRange")
+			.callsFake(
+				() =>
+					new Promise<any>((resolve) => {
+						releases.push(resolve);
+					}),
+			);
+		const from = { hashcode: () => "peer-a" };
+		const handlings = Array.from({ length: 4 }, () =>
+			sync.onMessage(new StartSync({ from: 0n, to: 10n, symbols: [] }), {
+				from,
+			} as any),
+		);
+
+		try {
+			expect(getDecoder.callCount).to.equal(4);
+			await sync.onPeerDisconnected("peer-a");
+			expect(sync.ingoingSyncProcesses.size).to.equal(0);
+			expect((sync as any).incomingRatelessProcessAdmissions.size).to.equal(4);
+
+			expect(
+				await sync.onMessage(
+					new StartSync({ from: 0n, to: 10n, symbols: [] }),
+					{ from } as any,
+				),
+			).to.equal(true);
+			expect(getDecoder.callCount).to.equal(4);
+
+			for (const release of releases) {
+				release({ free: () => {} });
+			}
+			expect(await Promise.all(handlings)).to.have.length(4);
+			expect((sync as any).incomingRatelessProcessAdmissions.size).to.equal(0);
+		} finally {
+			for (const release of releases) {
+				release({ free: () => {} });
+			}
+			getDecoder.restore();
+			await sync.close();
+		}
+	});
+
+	it("falls back before constructing a decoder for an oversized initial batch", async () => {
+		const sends: TransportMessage[] = [];
+		const sync = createDispatchTestSynchronizer((message) => {
+			sends.push(message);
+		});
+		const getDecoder = sinon.spy(sync as any, "getLocalDecoderForRange");
+		const oversized = CodedSymbolBatch.fromFlat(new BigUint64Array(1_025 * 3));
+
+		try {
+			expect(
+				await sync.onMessage(
+					new StartSync({ from: 0n, to: 10n, symbols: oversized }),
+					{ from: { hashcode: () => "peer-a" } } as any,
+				),
+			).to.equal(true);
+			expect(getDecoder.called).to.equal(false);
+			expect(sync.ingoingSyncProcesses.size).to.equal(0);
+			expect(
+				sends.filter((message) => message instanceof RequestAll),
+			).to.have.length(1);
+		} finally {
+			getDecoder.restore();
+			await sync.close();
+		}
+	});
+
+	it("bounds a stalled incoming RequestAll fallback after its grace period", async () => {
+		const clock = sinon.useFakeTimers();
+		const sends: TransportMessage[] = [];
+		const sync = createDispatchTestSynchronizer((message) => {
+			sends.push(message);
+			if (message instanceof RequestAll) {
+				// Model a transport implementation that ignores abort and never
+				// settles. The logical process must still leave the active map, while
+				// its admission remains charged so repeated waves cannot accumulate.
+				return new Promise<void>(() => {});
+			}
+		});
+		const getDecoder = sinon.spy(sync as any, "getLocalDecoderForRange");
+		const oversized = CodedSymbolBatch.fromFlat(new BigUint64Array(1_025 * 3));
+		const from = { hashcode: () => "peer-a" };
+
+		try {
+			const handlings = Array.from({ length: 4 }, () =>
+				sync.onMessage(
+					new StartSync({ from: 0n, to: 10n, symbols: oversized }),
+					{ from } as any,
+				),
+			);
+			expect(sync.ingoingSyncProcesses.size).to.equal(4);
+			expect(
+				sends.filter((message) => message instanceof RequestAll),
+			).to.have.length(4);
+			expect(getDecoder.called).to.equal(false);
+
+			await clock.tickAsync(5_000);
+			expect(await Promise.all(handlings)).to.deep.equal([
+				true,
+				true,
+				true,
+				true,
+			]);
+			expect(sync.ingoingSyncProcesses.size).to.equal(0);
+			expect((sync as any).incomingRatelessProcessAdmissions.size).to.equal(4);
+
+			expect(
+				await sync.onMessage(
+					new StartSync({ from: 0n, to: 10n, symbols: oversized }),
+					{ from } as any,
+				),
+			).to.equal(true);
+			expect(
+				sends.filter((message) => message instanceof RequestAll),
+			).to.have.length(4);
+		} finally {
+			getDecoder.restore();
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("does not refresh incoming idle time for stale replay", async () => {
+		const clock = sinon.useFakeTimers();
+		const sync = createDispatchTestSynchronizer(() => {});
+		const decoderFree = sinon.spy();
+		const getDecoder = sinon
+			.stub(sync as any, "getLocalDecoderForRange")
+			.resolves({
+				add_coded_symbol: () => {},
+				try_decode: () => {},
+				decoded: () => false,
+				get_remote_symbols: () => [],
+				free: decoderFree,
+			});
+		const start = new StartSync({ from: 0n, to: 10n, symbols: [] });
+		const from = { hashcode: () => "peer-a" };
+
+		try {
+			await sync.onMessage(start, { from } as any);
+			expect(sync.ingoingSyncProcesses.size).to.equal(1);
+
+			await clock.tickAsync(19_000);
+			await sync.onMessage(
+				new MoreSymbols({
+					syncId: start.syncId,
+					lastSeqNo: -1n,
+					symbols: [{ count: 0n, hash: 0n, symbol: 0n } as any],
+				}),
+				{ from } as any,
+			);
+			await clock.tickAsync(1_001);
+
+			expect(sync.ingoingSyncProcesses.size).to.equal(0);
+			expect(decoderFree.calledOnce).to.equal(true);
+		} finally {
+			getDecoder.restore();
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("deduplicates and bounds future incoming symbol batches", async () => {
+		const sends: TransportMessage[] = [];
+		const sync = createDispatchTestSynchronizer((message) => {
+			sends.push(message);
+		});
+		const addSymbol = sinon.spy();
+		const getDecoder = sinon
+			.stub(sync as any, "getLocalDecoderForRange")
+			.resolves({
+				add_coded_symbol: addSymbol,
+				try_decode: () => {},
+				decoded: () => false,
+				get_remote_symbols: () => [],
+				free: () => {},
+			});
+		const start = new StartSync({ from: 0n, to: 10n, symbols: [] });
+		const from = { hashcode: () => "peer-a" };
+		const symbols = [{ count: 0n, hash: 0n, symbol: 0n } as any];
+		const more = (seqNo: bigint) =>
+			new MoreSymbols({
+				syncId: start.syncId,
+				lastSeqNo: seqNo - 1n,
+				symbols,
+			});
+
+		try {
+			await sync.onMessage(start, { from } as any);
+			const process = [...sync.ingoingSyncProcesses.values()][0];
+
+			for (let seqNo = 2n; seqNo <= 8n; seqNo++) {
+				await sync.onMessage(more(seqNo), { from } as any);
+			}
+			await sync.onMessage(more(2n), { from } as any);
+			await sync.onMessage(more(9n), { from } as any);
+			expect(process.queuedSymbols).to.equal(7);
+			expect(addSymbol.called).to.equal(false);
+
+			await sync.onMessage(more(1n), { from } as any);
+			expect(process.lastSeqNo).to.equal(8n);
+			expect(process.queuedSymbols).to.equal(0);
+			expect(process.processedSymbols).to.equal(8);
+			expect(addSymbol.callCount).to.equal(8);
+			expect(
+				sends
+					.filter(
+						(message): message is RequestMoreSymbols =>
+							message instanceof RequestMoreSymbols,
+					)
+					.at(-1)?.lastSeqNo,
+			).to.equal(8n);
+		} finally {
+			getDecoder.restore();
+			await sync.close();
+		}
+	});
+
+	it("falls back after the incoming cumulative symbol budget", async () => {
+		const sends: TransportMessage[] = [];
+		const sync = createDispatchTestSynchronizer((message) => {
+			sends.push(message);
+		});
+		const addBatch = sinon.stub().returns(false);
+		const decoderFree = sinon.spy();
+		const getDecoder = sinon
+			.stub(sync as any, "getLocalDecoderForRange")
+			.resolves({
+				add_coded_symbols_and_try_decode: addBatch,
+				decoded: () => false,
+				get_remote_symbols: () => [],
+				free: decoderFree,
+			});
+		const start = new StartSync({ from: 0n, to: 10n, symbols: [] });
+		const from = { hashcode: () => "peer-a" };
+		const fullBatch = CodedSymbolBatch.fromFlat(new BigUint64Array(1_024 * 3));
+
+		try {
+			await sync.onMessage(start, { from } as any);
+			const process = [...sync.ingoingSyncProcesses.values()][0];
+			expect(process.symbolBudget).to.equal(4_096);
+
+			for (let seqNo = 1n; seqNo <= 4n; seqNo++) {
+				await sync.onMessage(
+					new MoreSymbols({
+						syncId: start.syncId,
+						lastSeqNo: seqNo - 1n,
+						symbols: fullBatch,
+					}),
+					{ from } as any,
+				);
+			}
+			expect(process.processedSymbols).to.equal(4_096);
+			expect(sync.ingoingSyncProcesses.size).to.equal(1);
+
+			await sync.onMessage(
+				new MoreSymbols({
+					syncId: start.syncId,
+					lastSeqNo: 4n,
+					symbols: [{ count: 0n, hash: 0n, symbol: 0n } as any],
+				}),
+				{ from } as any,
+			);
+
+			expect(sync.ingoingSyncProcesses.size).to.equal(0);
+			expect(decoderFree.calledOnce).to.equal(true);
+			expect(
+				sends.filter((message) => message instanceof RequestAll),
+			).to.have.length(1);
+		} finally {
+			getDecoder.restore();
+			await sync.close();
+		}
+	});
+
+	it("does not refresh outgoing idle time for replayed symbol requests", async () => {
+		const clock = sinon.useFakeTimers();
+		const sends: TransportMessage[] = [];
+		const sync = createDispatchTestSynchronizer((message) => {
+			sends.push(message);
+		});
+		const fallback = sinon.spy(sync.simple, "onMaybeMissingHashes");
+		const from = { hashcode: () => "peer-a" };
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["peer-a"],
+			});
+			const start = sends.find(
+				(message): message is StartSync => message instanceof StartSync,
+			)!;
+
+			await clock.tickAsync(9_000);
+			const request = new RequestMoreSymbols({
+				syncId: start.syncId,
+				lastSeqNo: 0n,
+			});
+			await sync.onMessage(request, { from } as any);
+			await clock.tickAsync(9_000);
+			await sync.onMessage(request, { from } as any);
+			await clock.tickAsync(1_001);
+
+			expect(sync.outgoingSyncProcesses.size).to.equal(0);
+			expect(
+				sends.filter((message) => message instanceof MoreSymbols),
+			).to.have.length(1);
+			expect(fallback.calledOnce).to.equal(true);
+		} finally {
+			fallback.restore();
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("enforces an outgoing absolute deadline despite real progress", async () => {
+		const clock = sinon.useFakeTimers();
+		const sends: TransportMessage[] = [];
+		const sync = createDispatchTestSynchronizer((message) => {
+			sends.push(message);
+		});
+		const fallback = sinon.spy(sync.simple, "onMaybeMissingHashes");
+		const from = { hashcode: () => "peer-a" };
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["peer-a"],
+			});
+			const start = sends.find(
+				(message): message is StartSync => message instanceof StartSync,
+			)!;
+
+			for (let seqNo = 0n; seqNo < 13n; seqNo++) {
+				await clock.tickAsync(9_000);
+				await sync.onMessage(
+					new RequestMoreSymbols({
+						syncId: start.syncId,
+						lastSeqNo: seqNo,
+					}),
+					{ from } as any,
+				);
+			}
+			expect(sync.outgoingSyncProcesses.size).to.equal(1);
+
+			await clock.tickAsync(3_001);
+			expect(sync.outgoingSyncProcesses.size).to.equal(0);
+			expect(fallback.calledOnce).to.equal(true);
+		} finally {
+			fallback.restore();
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("caps cumulative outgoing RequestMoreSymbols work", async () => {
+		const sends: TransportMessage[] = [];
+		const sync = createDispatchTestSynchronizer((message) => {
+			sends.push(message);
+		});
+		const fallback = sinon.spy(sync.simple, "onMaybeMissingHashes");
+		const from = { hashcode: () => "peer-a" };
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["peer-a"],
+			});
+			const start = sends.find(
+				(message): message is StartSync => message instanceof StartSync,
+			)!;
+			let lastSeqNo = 0n;
+			while (
+				!sends.some(
+					(message) =>
+						message instanceof MoreSymbols && message.symbols.length === 0,
+				)
+			) {
+				await sync.onMessage(
+					new RequestMoreSymbols({
+						syncId: start.syncId,
+						lastSeqNo,
+					}),
+					{ from } as any,
+				);
+				expect(lastSeqNo < 100n).to.equal(true);
+				lastSeqNo += 1n;
+			}
+
+			const moreSymbols = sends.filter(
+				(message): message is MoreSymbols => message instanceof MoreSymbols,
+			);
+			const totalSymbols =
+				start.symbols.length +
+				moreSymbols.reduce(
+					(total, message) => total + message.symbols.length,
+					0,
+				);
+			expect(totalSymbols).to.equal(4_096);
+			expect(moreSymbols.at(-1)?.symbols.length).to.equal(0);
+			expect(sync.outgoingSyncProcesses.size).to.equal(1);
+			expect(fallback.calledOnce).to.equal(true);
+			expect(fallback.firstCall.args[0].hashes).to.deep.equal([
+				...createDispatchTestEntries().keys(),
+			]);
+			expect(fallback.firstCall.args[0].targets).to.deep.equal(["peer-a"]);
+
+			await sync.onMessage(new RequestAll({ syncId: start.syncId }), {
+				from,
+			} as any);
+			expect(fallback.calledOnce).to.equal(true);
+			expect(sync.outgoingSyncProcesses.size).to.equal(0);
+		} finally {
+			fallback.restore();
+			await sync.close();
+		}
+	});
+
+	it("prefers delayed Simple fallback authorization after rateless replacement", async () => {
+		const sends: TransportMessage[] = [];
+		const sync = createDispatchTestSynchronizer((message) => {
+			sends.push(message);
+		});
+		const from = { hashcode: () => "peer-a" };
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["peer-a"],
+			});
+			const process = [...sync.outgoingSyncProcesses.values()][0];
+			await process.startSimpleFallback();
+			expect(process.simpleFallbackStarted).to.equal(true);
+			expect(sync.outgoingSyncProcesses.size).to.equal(1);
+			expect((sync.simple as any).pendingMaybeSyncResponseCount).to.equal(400);
+
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["peer-a"],
+			});
+			const replacement = [...sync.outgoingSyncProcesses.values()][0];
+			expect(replacement).not.to.equal(process);
+			expect(replacement.simpleFallbackStarted).to.equal(false);
+			const replacementStart = sends
+				.filter((message): message is StartSync => message instanceof StartSync)
+				.at(-1)!;
+
+			const directRatelessShip = sinon.spy(
+				sync.simple,
+				"shipAuthorizedMaybeSyncResponse",
+			);
+			const simpleShip = sinon
+				.stub(sync.simple, "shipAuthorizedMaybeSyncResponseLeases")
+				.callsFake(async ({ leases }: any) => {
+					for (const lease of leases) {
+						lease.release();
+					}
+					return { messages: 0, fused: false, entries: leases.length };
+				});
+			try {
+				await sync.onMessage(new ResponseMaybeSync({ hashes: ["hash-0"] }), {
+					from,
+				} as any);
+
+				expect(directRatelessShip.called).to.equal(false);
+				expect(simpleShip.calledOnce).to.equal(true);
+				expect((sync.simple as any).pendingMaybeSyncResponseCount).to.equal(
+					399,
+				);
+			} finally {
+				directRatelessShip.restore();
+				simpleShip.restore();
+			}
+
+			await sync.onMessage(
+				new RequestAll({ syncId: replacementStart.syncId }),
+				{
+					from,
+				} as any,
+			);
+			expect(sync.outgoingSyncProcesses.size).to.equal(0);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("latches outgoing exhaustion before a terminal symbol send settles", async () => {
+		const sends: TransportMessage[] = [];
+		let releaseTerminalSend!: () => void;
+		const terminalSendReleased = new Promise<void>((resolve) => {
+			releaseTerminalSend = resolve;
+		});
+		let markTerminalSendStarted!: () => void;
+		const terminalSendStarted = new Promise<void>((resolve) => {
+			markTerminalSendStarted = resolve;
+		});
+		let terminalSendPending = false;
+		const sync = createDispatchTestSynchronizer((message) => {
+			sends.push(message);
+			if (message instanceof MoreSymbols && message.symbols.length === 0) {
+				terminalSendPending = true;
+				markTerminalSendStarted();
+				return terminalSendReleased;
+			}
+		});
+		const fallback = sinon.spy(sync.simple, "onMaybeMissingHashes");
+		const from = { hashcode: () => "peer-a" };
+
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createDispatchTestEntries(),
+				targets: ["peer-a"],
+			});
+			const start = sends.find(
+				(message): message is StartSync => message instanceof StartSync,
+			)!;
+			let terminalHandling: Promise<boolean> | undefined;
+			let lastSeqNo = 0n;
+			while (!terminalHandling) {
+				const handling = sync.onMessage(
+					new RequestMoreSymbols({
+						syncId: start.syncId,
+						lastSeqNo,
+					}),
+					{ from } as any,
+				);
+				if (terminalSendPending) {
+					terminalHandling = handling;
+					break;
+				}
+				await handling;
+				expect(lastSeqNo < 100n).to.equal(true);
+				lastSeqNo += 1n;
+			}
+			await terminalSendStarted;
+
+			await Promise.all(
+				Array.from({ length: 100 }, (_, offset) =>
+					sync.onMessage(
+						new RequestMoreSymbols({
+							syncId: start.syncId,
+							lastSeqNo: lastSeqNo + BigInt(offset + 1),
+						}),
+						{ from } as any,
+					),
+				),
+			);
+			expect(
+				sends.filter(
+					(message) =>
+						message instanceof MoreSymbols && message.symbols.length === 0,
+				),
+			).to.have.length(1);
+
+			releaseTerminalSend();
+			expect(await terminalHandling).to.equal(true);
+			expect(fallback.calledOnce).to.equal(true);
+			expect(sync.outgoingSyncProcesses.size).to.equal(1);
+		} finally {
+			releaseTerminalSend();
+			fallback.restore();
 			await sync.close();
 		}
 	});
@@ -1650,7 +2548,9 @@ describe("rateless-iblt-syncronizer", () => {
 				new MoreSymbols({
 					syncId: start.syncId,
 					lastSeqNo: 0n,
-					symbols: CodedSymbolBatch.fromSymbols([]),
+					symbols: CodedSymbolBatch.fromSymbols([
+						{ count: 0n, hash: 0n, symbol: 0n } as any,
+					]),
 				}),
 				{ from: peer } as any,
 			);
@@ -1752,7 +2652,10 @@ describe("rateless-iblt-syncronizer", () => {
 			process.next = () => {
 				nextCalled = true;
 				controller.abort();
-				return CodedSymbolBatch.fromSymbols([]);
+				return {
+					symbols: CodedSymbolBatch.fromSymbols([]),
+					exhaustedAfterSend: false,
+				};
 			};
 
 			await sync.onMessage(
@@ -1817,7 +2720,10 @@ describe("rateless-iblt-syncronizer", () => {
 			expect(startSync).to.be.instanceOf(StartSync);
 			const outgoingProcess = [...sync.outgoingSyncProcesses.values()][0];
 			expect(outgoingProcess).to.not.equal(undefined);
-			outgoingProcess.next = () => CodedSymbolBatch.fromSymbols([]);
+			outgoingProcess.next = () => ({
+				symbols: CodedSymbolBatch.fromSymbols([]),
+				exhaustedAfterSend: false,
+			});
 			const handling = sync.onMessage(
 				new RequestMoreSymbols({
 					syncId: startSync.syncId,

--- a/packages/programs/data/shared-log/test/sync-chunking.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-chunking.spec.ts
@@ -5,12 +5,21 @@ import { expect } from "chai";
 import sinon from "sinon";
 import { RawExchangeHeadsMessage } from "../src/exchange-heads.js";
 import {
+	MAX_ACTIVE_SIMPLE_SYNC_RESPONSES_PER_PEER,
+	MAX_PENDING_SIMPLE_COORDINATE_RESPONSES_PER_PEER,
+	MAX_PENDING_SIMPLE_SYNC_KEYS_GLOBAL,
+	MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER,
+	MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
+	MAX_SIMPLE_COORDINATE_REQUEST_SYMBOLS,
+	MAX_SIMPLE_COORDINATE_RESPONSE_HASHES,
+	MAX_SIMPLE_SYNC_RETRY_KEYS_PER_TICK,
+	PENDING_SIMPLE_SYNC_KEY_TTL_MS,
 	RequestMaybeSync,
-	RequestMaybeSyncCoordinateCapabilities,
 	RequestMaybeSyncCoordinate,
+	RequestMaybeSyncCoordinateCapabilities,
 	ResponseMaybeSync,
-	SYNC_MESSAGE_PRIORITY,
 	ResponseMaybeSyncCapabilities,
+	SYNC_MESSAGE_PRIORITY,
 	SimpleSyncronizer,
 } from "../src/sync/simple.js";
 
@@ -74,6 +83,383 @@ describe("sync-chunking", () => {
 			expect(sentHashes.map((x) => x.length)).to.deep.equal([2, 2, 1]);
 		} finally {
 			await sync.close();
+		}
+	});
+
+	it("expires staggered response authorizations without scanning batch sets", async () => {
+		const clock = sinon.useFakeTimers({
+			now: 100_000,
+			toFake: ["Date", "setTimeout", "clearTimeout"],
+		});
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+		});
+		const batches = (sync as any)
+			.pendingMaybeSyncResponseBatches as Set<unknown>;
+		const reservations: { release: () => void }[] = [];
+
+		try {
+			for (let index = 0; index < 64; index += 1) {
+				const reservation = sync.expectMaybeSyncResponse({
+					hashes: [`response-expiry-${index}`],
+					targets: [peerA.hashcode()],
+				});
+				expect(reservation).to.not.equal(undefined);
+				reservations.push(reservation!);
+				await clock.tickAsync(1);
+			}
+			expect((sync as any).pendingMaybeSyncResponseExpiryHeap).to.have.length(
+				64,
+			);
+			Object.defineProperty(batches, Symbol.iterator, {
+				configurable: true,
+				value: () => {
+					throw new Error("response batch set must not be scanned");
+				},
+			});
+
+			await clock.tickAsync(30_000);
+			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(0);
+			expect((sync as any).pendingMaybeSyncResponseExpiryHeap).to.have.length(
+				0,
+			);
+		} finally {
+			delete (batches as any)[Symbol.iterator];
+			for (const reservation of reservations) {
+				reservation.release();
+			}
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("enforces response authorization TTL without waiting for its timer", async () => {
+		const clock = sinon.useFakeTimers({
+			now: 100_000,
+			toFake: ["Date", "setTimeout", "clearTimeout"],
+		});
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+		});
+		let expired: ReturnType<typeof sync.expectMaybeSyncResponse> | undefined;
+		let replaced: ReturnType<typeof sync.expectMaybeSyncResponse> | undefined;
+
+		try {
+			expired = sync.expectMaybeSyncResponse({
+				hashes: ["expired-response"],
+				targets: [peerA.hashcode()],
+			});
+			replaced = sync.expectMaybeSyncResponse({
+				hashes: ["replace-response"],
+				targets: [peerA.hashcode()],
+			});
+			expect(expired).to.not.equal(undefined);
+			expect(replaced).to.not.equal(undefined);
+
+			clock.setSystemTime(130_001);
+			expect(expired!.retained()).to.equal(false);
+			expect(
+				sync.consumeAuthorizedMaybeSyncResponse(["expired-response"], peerA),
+			).to.deep.equal([]);
+
+			const fresh = sync.expectMaybeSyncResponse({
+				hashes: ["replace-response"],
+				targets: [peerA.hashcode()],
+			});
+			expect(replaced!.retained()).to.equal(false);
+			expect(fresh).to.not.equal(undefined);
+			expect(fresh!.retained()).to.equal(true);
+			const leases = sync.consumeAuthorizedMaybeSyncResponse(
+				["replace-response"],
+				peerA,
+			);
+			expect(leases.map((lease) => lease.hashes)).to.deep.equal([
+				["replace-response"],
+			]);
+			for (const lease of leases) {
+				lease.release();
+			}
+			fresh!.release();
+		} finally {
+			expired?.release();
+			replaced?.release();
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("reclaims an expired full response quota before admitting an unrelated hash", async () => {
+		const clock = sinon.useFakeTimers({
+			now: 100_000,
+			toFake: ["Date", "setTimeout", "clearTimeout"],
+		});
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+		});
+		let full: ReturnType<typeof sync.expectMaybeSyncResponse> | undefined;
+		let fresh: ReturnType<typeof sync.expectMaybeSyncResponse> | undefined;
+
+		try {
+			full = sync.expectMaybeSyncResponse({
+				hashes: Array.from(
+					{ length: 10_000 },
+					(_, index) => `expired-cap-${index}`,
+				),
+				targets: [peerA.hashcode()],
+			});
+			expect(full).to.not.equal(undefined);
+			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(10_000);
+
+			// Move wall time past the deadline without running the timer queue.
+			clock.setSystemTime(130_001);
+			fresh = sync.expectMaybeSyncResponse({
+				hashes: ["fresh-unrelated"],
+				targets: [peerA.hashcode()],
+			});
+
+			expect(fresh).to.not.equal(undefined);
+			expect(fresh!.retained()).to.equal(true);
+			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(1);
+		} finally {
+			fresh?.release();
+			full?.release();
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("bounds inspected hashes in an unauthorized maybe-sync response", async () => {
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+		});
+		const reservation = sync.expectMaybeSyncResponse({
+			hashes: ["authorized-tail"],
+			targets: [peerA.hashcode()],
+		});
+		let yielded = 0;
+		const adversarial = {
+			*[Symbol.iterator]() {
+				for (let index = 0; index < 20_000; index += 1) {
+					yielded += 1;
+					yield `unauthorized-${index}`;
+				}
+				yielded += 1;
+				yield "authorized-tail";
+			},
+		};
+
+		try {
+			expect(
+				sync.consumeAuthorizedMaybeSyncResponse(adversarial, peerA),
+			).to.deep.equal([]);
+			expect(yielded).to.equal(MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER);
+			expect(reservation!.retained()).to.equal(true);
+		} finally {
+			reservation?.release();
+			await sync.close();
+		}
+	});
+
+	it("retains bounded active response work across close and reopen", async () => {
+		const releases: (() => void)[] = [];
+		const sendRawExchangeHeads = sinon.stub().callsFake(
+			() =>
+				new Promise<number>((resolve) => {
+					releases.push(() => resolve(1));
+				}),
+		);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sendRawExchangeHeads,
+		});
+		const hashes = Array.from(
+			{ length: MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER },
+			(_, index) => `active-response-${index}`,
+		);
+		const reservation = sync.expectMaybeSyncResponse({
+			hashes,
+			targets: [peerA.hashcode()],
+		});
+		const active: Promise<boolean>[] = [];
+
+		try {
+			for (
+				let index = 0;
+				index < MAX_ACTIVE_SIMPLE_SYNC_RESPONSES_PER_PEER;
+				index += 1
+			) {
+				active.push(
+					sync.onMessage(
+						new ResponseMaybeSyncCapabilities({ hashes: [hashes[index]!] }),
+						{ from: peerA } as any,
+					),
+				);
+			}
+			await waitFor(
+				() =>
+					sendRawExchangeHeads.callCount ===
+					MAX_ACTIVE_SIMPLE_SYNC_RESPONSES_PER_PEER,
+			);
+
+			await sync.onMessage(
+				new ResponseMaybeSyncCapabilities({
+					hashes: [hashes[MAX_ACTIVE_SIMPLE_SYNC_RESPONSES_PER_PEER]!],
+				}),
+				{ from: peerA } as any,
+			);
+			expect(sendRawExchangeHeads.callCount).to.equal(
+				MAX_ACTIVE_SIMPLE_SYNC_RESPONSES_PER_PEER,
+			);
+			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(
+				MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER,
+			);
+
+			await sync.close();
+			await sync.open();
+			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(
+				MAX_ACTIVE_SIMPLE_SYNC_RESPONSES_PER_PEER,
+			);
+			expect((sync as any).activeMaybeSyncResponseCount).to.equal(
+				MAX_ACTIVE_SIMPLE_SYNC_RESPONSES_PER_PEER,
+			);
+			expect(
+				sync.expectMaybeSyncResponse({
+					hashes: Array.from(
+						{
+							length:
+								MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER -
+								MAX_ACTIVE_SIMPLE_SYNC_RESPONSES_PER_PEER +
+								1,
+						},
+						(_, index) => `blocked-reopen-${index}`,
+					),
+					targets: [peerB.hashcode()],
+				}),
+			).to.equal(undefined);
+
+			for (const release of releases) {
+				release();
+			}
+			await Promise.all(active);
+			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(0);
+			expect((sync as any).activeMaybeSyncResponseCount).to.equal(0);
+
+			const reclaimed = sync.expectMaybeSyncResponse({
+				hashes: Array.from(
+					{ length: MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER },
+					(_, index) => `reclaimed-response-${index}`,
+				),
+				targets: [peerB.hashcode()],
+			});
+			expect(reclaimed).to.not.equal(undefined);
+			reclaimed!.release();
+			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(0);
+		} finally {
+			for (const release of releases) {
+				release();
+			}
+			await Promise.all(active);
+			reservation?.release();
+			await sync.close();
+		}
+	});
+
+	it("disposes many-target response lifecycles without per-batch target scans", async () => {
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+		});
+		const reservation = sync.expectMaybeSyncResponse({
+			hashes: ["many-target-response"],
+			targets: Array.from({ length: 512 }, (_, index) => `target-${index}`),
+		});
+		const batch = [...(sync as any).pendingMaybeSyncResponseBatches][0] as any;
+		const targets = batch.targetLifecycle.lifecycle.targets as Map<
+			string,
+			unknown
+		>;
+		const originalValues = targets.values.bind(targets);
+		let valuesCalls = 0;
+		Object.defineProperty(targets, "values", {
+			configurable: true,
+			value: () => {
+				valuesCalls += 1;
+				return originalValues();
+			},
+		});
+
+		try {
+			reservation!.release();
+			expect(valuesCalls).to.be.lessThan(3);
+			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(0);
+		} finally {
+			delete (targets as any).values;
+			await sync.close();
+		}
+	});
+
+	it("wakes bounded response waiters as charged capacity is released", async () => {
+		const send = sinon.stub().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+		});
+		const occupyingHashes = Array.from(
+			{ length: MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER },
+			(_, index) => `waiter-occupant-${index}`,
+		);
+		const occupying = sync.expectMaybeSyncResponse({
+			hashes: occupyingHashes,
+			targets: [peerA.hashcode()],
+		});
+		const blocked = Array.from({ length: 64 }, (_, index) =>
+			sync.onMaybeMissingHashes({
+				hashes: [`waiter-${index}`],
+				targets: [`waiter-target-${index}`],
+			}),
+		);
+		let reserve: ReturnType<typeof sinon.spy> | undefined;
+
+		try {
+			await waitFor(
+				() => (sync as any).pendingMaybeSyncResponseWaiters.size === 64,
+			);
+			reserve = sinon.spy(sync as any, "tryReservePendingMaybeSyncResponse");
+			const leases = sync.consumeAuthorizedMaybeSyncResponse(
+				[occupyingHashes[0]!],
+				peerA,
+			);
+			expect(leases).to.have.length(1);
+			reserve.resetHistory();
+			leases[0]!.release();
+
+			await waitFor(() => send.calledOnce);
+			expect(reserve.callCount).to.equal(1);
+			expect((sync as any).pendingMaybeSyncResponseWaiters.size).to.equal(63);
+		} finally {
+			reserve?.restore();
+			await sync.close();
+			await Promise.all(blocked);
+			occupying?.release();
 		}
 	});
 
@@ -237,6 +623,58 @@ describe("sync-chunking", () => {
 		expect(send.callCount).to.equal(1);
 		expect((sync as any).pendingMaybeSyncResponseCount).to.equal(0);
 		await sync.close();
+	});
+
+	it("retains blocked request-send quota across close and reopen", async () => {
+		let releaseFirstSend!: () => void;
+		const firstSendReleased = new Promise<void>((resolve) => {
+			releaseFirstSend = resolve;
+		});
+		const send = sinon.stub();
+		send.onFirstCall().returns(firstSendReleased);
+		send.onSecondCall().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sync: { maxSimpleHashesPerMessage: 10_000 },
+		});
+		const fullWindow = Array.from(
+			{ length: 10_000 },
+			(_, index) => `blocked-generation-${index}`,
+		);
+
+		try {
+			const staleDispatch = sync.onMaybeMissingHashes({
+				hashes: fullWindow,
+				targets: [peerA.hashcode()],
+			});
+			await waitFor(() => send.callCount === 1);
+
+			await sync.close();
+			await sync.open();
+			const freshDispatch = sync.onMaybeMissingHashes({
+				hashes: ["fresh-generation"],
+				targets: [peerA.hashcode()],
+			});
+			await Promise.resolve();
+
+			expect(send.callCount).to.equal(1);
+			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(10_000);
+
+			releaseFirstSend();
+			await Promise.all([staleDispatch, freshDispatch]);
+
+			expect(send.callCount).to.equal(2);
+			expect(send.secondCall.args[0].hashes).to.deep.equal([
+				"fresh-generation",
+			]);
+			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(1);
+		} finally {
+			releaseFirstSend();
+			await sync.close();
+		}
 	});
 
 	it("aborts a live-caller fused response when the synchronizer closes", async () => {
@@ -480,6 +918,361 @@ describe("sync-chunking", () => {
 			new ResponseMaybeSyncCapabilities({ hashes: ["hash"] }),
 			{ from: peerA } as any,
 		);
+	});
+
+	it("keeps unrelated hashes when another caller owns an overlapping authorization", async () => {
+		const send = sinon.stub().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+		});
+		const callerA = new AbortController();
+		const callerB = new AbortController();
+
+		try {
+			await sync.onMaybeMissingHashes({
+				hashes: ["overlap"],
+				targets: [peerA.hashcode()],
+				signal: callerA.signal,
+			});
+			const secondDispatch = sync.onMaybeMissingHashes({
+				hashes: ["overlap", "new-b", "new-c"],
+				targets: [peerA.hashcode()],
+				signal: callerB.signal,
+			});
+			await waitFor(() => send.callCount === 2);
+
+			expect(send.callCount).to.equal(2);
+			expect(send.firstCall.args[0].hashes).to.deep.equal(["overlap"]);
+			expect(send.secondCall.args[0].hashes).to.deep.equal(["new-b", "new-c"]);
+			const overlapLeases = sync.consumeAuthorizedMaybeSyncResponse(
+				["overlap"],
+				peerA,
+			);
+			for (const lease of overlapLeases) {
+				lease.release({ fulfilled: true });
+			}
+			await secondDispatch;
+			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(2);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("retries a conflicting hash when its pending authorization is aborted", async () => {
+		const send = sinon.stub().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+		});
+		const callerA = new AbortController();
+		const callerB = new AbortController();
+
+		try {
+			await sync.onMaybeMissingHashes({
+				hashes: ["contended"],
+				targets: [peerA.hashcode()],
+				signal: callerA.signal,
+			});
+			const follower = sync.onMaybeMissingHashes({
+				hashes: ["contended"],
+				targets: [peerA.hashcode()],
+				signal: callerB.signal,
+			});
+			await Promise.resolve();
+			expect(send.callCount).to.equal(1);
+
+			callerA.abort(new Error("first caller stopped"));
+			await follower;
+
+			expect(send.callCount).to.equal(2);
+			expect(send.secondCall.args[0]).to.be.instanceOf(RequestMaybeSync);
+			expect(send.secondCall.args[0].hashes).to.deep.equal(["contended"]);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("retries a no-signal conflict when the first transport send fails", async () => {
+		let rejectFirstSend!: (error: Error) => void;
+		const firstSend = new Promise<void>((_resolve, reject) => {
+			rejectFirstSend = reject;
+		});
+		const send = sinon.stub();
+		send.onFirstCall().returns(firstSend);
+		send.onSecondCall().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+		});
+
+		try {
+			const firstDispatch = sync
+				.onMaybeMissingHashes({
+					hashes: ["no-signal-conflict"],
+					targets: [peerA.hashcode()],
+				})
+				.catch((error) => error);
+			await waitFor(() => send.callCount === 1);
+			const follower = sync.onMaybeMissingHashes({
+				hashes: ["no-signal-conflict"],
+				targets: [peerA.hashcode()],
+			});
+			await waitFor(
+				() => (sync as any).pendingMaybeSyncResponseConflictWaiterCount === 1,
+			);
+			expect(send.callCount).to.equal(1);
+
+			const failure = new Error("first transport failed");
+			rejectFirstSend(failure);
+			expect(await firstDispatch).to.equal(failure);
+			await follower;
+
+			expect(send.callCount).to.equal(2);
+			expect(send.secondCall.args[0]).to.be.instanceOf(RequestMaybeSync);
+			expect(send.secondCall.args[0].hashes).to.deep.equal([
+				"no-signal-conflict",
+			]);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("wakes a same-scope follower when the first transport send commits", async () => {
+		let releaseFirstSend!: () => void;
+		const firstSend = new Promise<void>((resolve) => {
+			releaseFirstSend = resolve;
+		});
+		const send = sinon.stub();
+		send.onFirstCall().returns(firstSend);
+		send.onSecondCall().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+		});
+
+		try {
+			const firstDispatch = sync.onMaybeMissingHashes({
+				hashes: ["committed-conflict"],
+				targets: [peerA.hashcode()],
+			});
+			await waitFor(() => send.callCount === 1);
+			const follower = sync.onMaybeMissingHashes({
+				hashes: ["committed-conflict"],
+				targets: [peerA.hashcode()],
+			});
+			await waitFor(
+				() => (sync as any).pendingMaybeSyncResponseConflictWaiterCount === 1,
+			);
+
+			releaseFirstSend();
+			await Promise.all([firstDispatch, follower]);
+
+			expect(send.callCount).to.equal(1);
+			expect(
+				(sync as any).pendingMaybeSyncResponseConflictWaiterCount,
+			).to.equal(0);
+			expect(
+				(sync as any).pendingMaybeSyncResponseWaiterAssociationCount,
+			).to.equal(0);
+			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(1);
+		} finally {
+			releaseFirstSend();
+			await sync.close();
+		}
+	});
+
+	it("retries a conflicting hash when its accepted response shipment aborts", async () => {
+		const send = sinon.stub().resolves();
+		let markShipmentStarted!: () => void;
+		const shipmentStarted = new Promise<void>((resolve) => {
+			markShipmentStarted = resolve;
+		});
+		const sendRawExchangeHeads = sinon
+			.stub()
+			.callsFake(
+				async (
+					_hashes: string[],
+					_targets: string[],
+					options?: { signal?: AbortSignal },
+				) => {
+					markShipmentStarted();
+					await new Promise<void>((_resolve, reject) => {
+						const rejectForAbort = () =>
+							reject(options?.signal?.reason ?? new Error("aborted"));
+						if (options?.signal?.aborted) {
+							rejectForAbort();
+						} else {
+							options?.signal?.addEventListener("abort", rejectForAbort, {
+								once: true,
+							});
+						}
+					});
+					return 1;
+				},
+			);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sendRawExchangeHeads,
+		});
+		const callerA = new AbortController();
+		const callerB = new AbortController();
+
+		try {
+			await sync.onMaybeMissingHashes({
+				hashes: ["contended-active"],
+				targets: [peerA.hashcode()],
+				signal: callerA.signal,
+			});
+			const follower = sync.onMaybeMissingHashes({
+				hashes: ["contended-active"],
+				targets: [peerA.hashcode()],
+				signal: callerB.signal,
+			});
+			const response = sync.onMessage(
+				new ResponseMaybeSyncCapabilities({
+					hashes: ["contended-active"],
+				}),
+				{ from: peerA } as any,
+			);
+			await shipmentStarted;
+			expect(send.callCount).to.equal(1);
+
+			callerA.abort(new Error("accepted shipment stopped"));
+			await response.catch(() => undefined);
+			await follower;
+
+			expect(send.callCount).to.equal(2);
+			expect(send.secondCall.args[0]).to.be.instanceOf(RequestMaybeSync);
+			expect(send.secondCall.args[0].hashes).to.deep.equal([
+				"contended-active",
+			]);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("retries a same-scope conflict when an active response shipment fails", async () => {
+		const send = sinon.stub().resolves();
+		let rejectShipment!: (error: Error) => void;
+		let markShipmentStarted!: () => void;
+		const shipmentStarted = new Promise<void>((resolve) => {
+			markShipmentStarted = resolve;
+		});
+		const shipment = new Promise<number>((_resolve, reject) => {
+			rejectShipment = reject;
+		});
+		const sendRawExchangeHeads = sinon.stub().callsFake(async () => {
+			markShipmentStarted();
+			return shipment;
+		});
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sendRawExchangeHeads,
+		});
+
+		try {
+			await sync.onMaybeMissingHashes({
+				hashes: ["active-no-signal"],
+				targets: [peerA.hashcode()],
+			});
+			const response = sync.onMessage(
+				new ResponseMaybeSyncCapabilities({
+					hashes: ["active-no-signal"],
+				}),
+				{ from: peerA } as any,
+			);
+			await shipmentStarted;
+			const follower = sync.onMaybeMissingHashes({
+				hashes: ["active-no-signal"],
+				targets: [peerA.hashcode()],
+			});
+			await waitFor(
+				() => (sync as any).pendingMaybeSyncResponseConflictWaiterCount === 1,
+			);
+
+			const failure = new Error("payload shipment failed");
+			rejectShipment(failure);
+			expect(await response.catch((error) => error)).to.equal(failure);
+			await follower;
+
+			expect(send.callCount).to.equal(2);
+			expect(send.secondCall.args[0].hashes).to.deep.equal([
+				"active-no-signal",
+			]);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("starts the response TTL only after a blocked request send commits", async () => {
+		const clock = sinon.useFakeTimers({
+			now: 100_000,
+			toFake: ["Date", "setTimeout", "clearTimeout"],
+		});
+		let releaseSend!: () => void;
+		const blockedSend = new Promise<void>((resolve) => {
+			releaseSend = resolve;
+		});
+		const send = sinon.stub().returns(blockedSend);
+		const sendRawExchangeHeads = sinon.stub().resolves(1);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sendRawExchangeHeads,
+		});
+
+		try {
+			const dispatch = sync.onMaybeMissingHashes({
+				hashes: ["slow-request"],
+				targets: [peerA.hashcode()],
+			});
+			await waitFor(() => send.calledOnce);
+
+			// Move wall time past the normal response deadline without resolving
+			// the transport send or running its timer queue.
+			clock.setSystemTime(130_001);
+			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(1);
+			expect((sync as any).pendingMaybeSyncResponseExpiryHeap).to.have.length(
+				0,
+			);
+
+			releaseSend();
+			await dispatch;
+			expect((sync as any).pendingMaybeSyncResponseExpiryHeap).to.have.length(
+				1,
+			);
+
+			clock.setSystemTime(160_000);
+			expect(
+				await sync.onMessage(
+					new ResponseMaybeSyncCapabilities({ hashes: ["slow-request"] }),
+					{ from: peerA } as any,
+				),
+			).to.equal(true);
+			expect(sendRawExchangeHeads.calledOnce).to.equal(true);
+			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(0);
+		} finally {
+			releaseSend();
+			await sync.close();
+			clock.restore();
+		}
 	});
 
 	it("advances a 10,001-hash window as soon as a response frees capacity", async () => {
@@ -880,6 +1673,1286 @@ describe("sync-chunking", () => {
 		}
 	});
 
+	it("retries only each selected peer's hashes without a cross product", async () => {
+		const clock = sinon.useFakeTimers({
+			now: 100_000,
+			toFake: ["Date", "setTimeout", "clearTimeout"],
+		});
+		const send = sinon.stub().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: { has: sinon.stub().resolves(false) } as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+		});
+
+		try {
+			await sync.open();
+			await waitFor(() => (sync as any).syncMoreInterval !== undefined);
+			await sync.queueSync(["from-a"], peerA, { skipCheck: true });
+			await sync.queueSync(["from-b"], peerB, { skipCheck: true });
+			sync.syncInFlight.get(peerA.hashcode())!.get("from-a")!.timestamp = 0;
+			sync.syncInFlight.get(peerB.hashcode())!.get("from-b")!.timestamp = 0;
+			send.resetHistory();
+
+			await clock.tickAsync(3_000);
+			await waitFor(() => send.callCount === 2);
+
+			const hashesByTarget = new Map<string, string[]>();
+			for (const call of send.getCalls()) {
+				const message = call.args[0] as ResponseMaybeSync;
+				const targets = call.args[1].mode.to as string[];
+				expect(targets).to.have.length(1);
+				hashesByTarget.set(targets[0]!, message.hashes);
+			}
+			expect(hashesByTarget.get(peerA.hashcode())).to.deep.equal(["from-a"]);
+			expect(hashesByTarget.get(peerB.hashcode())).to.deep.equal(["from-b"]);
+			expect([
+				...sync.syncInFlight.get(peerA.hashcode())!.keys(),
+			]).to.deep.equal(["from-a"]);
+			expect([
+				...sync.syncInFlight.get(peerB.hashcode())!.keys(),
+			]).to.deep.equal(["from-b"]);
+		} finally {
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("drops retry work captured before a peer disconnects and reconnects", async () => {
+		const clock = sinon.useFakeTimers({
+			now: 100_000,
+			toFake: ["Date", "setTimeout", "clearTimeout"],
+		});
+		let releaseSecond!: (present: boolean) => void;
+		const blockedSecond = new Promise<boolean>((resolve) => {
+			releaseSecond = resolve;
+		});
+		const has = sinon.stub();
+		has.onFirstCall().resolves(false);
+		has.onSecondCall().returns(blockedSecond);
+		const send = sinon.stub().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: { has } as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+		});
+		const hashes = ["stale-retry", "satisfied-retry"];
+
+		try {
+			await sync.open();
+			await waitFor(() => (sync as any).syncMoreInterval !== undefined);
+			await sync.queueSync(hashes, peerA, { skipCheck: true });
+			await sync.queueSync(hashes, peerB, { skipCheck: true });
+			for (const state of sync.syncInFlight.get(peerA.hashcode())!.values()) {
+				state.timestamp = 0;
+			}
+			const oldEpoch = (sync as any).syncDispatchTargetEpochs.get(
+				peerA.hashcode(),
+			);
+			send.resetHistory();
+
+			await clock.tickAsync(3_000);
+			await waitFor(() => has.callCount === 2);
+
+			sync.onPeerDisconnected(peerA);
+			await sync.queueSync(hashes, peerA, { skipCheck: true });
+			expect(
+				(sync as any).syncDispatchTargetEpochs.get(peerA.hashcode()),
+			).to.not.equal(oldEpoch);
+			send.resetHistory();
+
+			releaseSecond(true);
+			await new Promise<void>((resolve) => setImmediate(resolve));
+
+			expect(send.callCount).to.equal(0);
+			expect(sync.syncInFlightQueue.has("satisfied-retry")).to.equal(false);
+		} finally {
+			releaseSecond?.(true);
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("bounds persistent retry index checks per timer tick", async () => {
+		const clock = sinon.useFakeTimers({
+			now: 100_000,
+			toFake: ["Date", "setTimeout", "clearTimeout"],
+		});
+		const send = sinon.stub().resolves();
+		const has = sinon.stub().resolves(false);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: { has } as any,
+			coordinateToHash: new Cache<string>({
+				max: MAX_SIMPLE_SYNC_RETRY_KEYS_PER_TICK + 1,
+			}),
+		});
+		const hashes = Array.from(
+			{ length: MAX_SIMPLE_SYNC_RETRY_KEYS_PER_TICK + 1 },
+			(_, index) => `retry-budget-${index}`,
+		);
+
+		try {
+			await sync.open();
+			await waitFor(() => (sync as any).syncMoreInterval !== undefined);
+			await sync.queueSync(hashes, peerA, { skipCheck: true });
+			for (const state of sync.syncInFlight.get(peerA.hashcode())!.values()) {
+				state.timestamp = 0;
+			}
+			has.resetHistory();
+			send.resetHistory();
+
+			await clock.tickAsync(3_000);
+			expect(has.callCount).to.equal(MAX_SIMPLE_SYNC_RETRY_KEYS_PER_TICK);
+
+			await clock.tickAsync(3_000);
+			expect(has.callCount).to.equal(hashes.length);
+		} finally {
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("caps incoming maybe-sync claims per peer before persistent lookup", async () => {
+		const send = sinon.stub().resolves();
+		const hasMany = sinon.stub().resolves([]);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: { hasMany } as any,
+			coordinateToHash: new Cache<string>({
+				max: MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER + 1,
+			}),
+		});
+		const hashes = Array.from(
+			{ length: MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER + 1 },
+			(_, index) => `peer-cap-${index}`,
+		);
+
+		try {
+			expect(
+				await sync.onMessage(new RequestMaybeSync({ hashes }), {
+					from: peerA,
+				} as any),
+			).to.equal(true);
+
+			expect(hasMany.calledOnce).to.equal(true);
+			expect(hasMany.firstCall.args[0]).to.have.length(
+				MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER,
+			);
+			expect(sync.pending).to.equal(MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER);
+			expect(
+				sync.syncInFlightQueueInverted.get(peerA.hashcode())?.size,
+			).to.equal(MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER);
+			expect((sync as any).pendingSyncClaimCount).to.equal(
+				MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER,
+			);
+			expect(sync.syncInFlightQueue.has(hashes.at(-1)!)).to.equal(false);
+
+			const refreshAliases = sinon.spy(
+				sync as any,
+				"refreshQueuedSyncCoordinateAliases",
+			);
+			await sync.queueSync([], peerA);
+			await sync.queueSync(["over-cap"], peerA);
+			expect(refreshAliases.called).to.equal(false);
+			expect(hasMany.calledOnce).to.equal(true);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("refreshes late coordinate aliases with bounded per-message work", async () => {
+		const send = sinon.stub().resolves();
+		const coordinateToHash = new Cache<string>({ max: 1_000 });
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash,
+		});
+		const coordinates = Array.from({ length: 512 }, (_, index) =>
+			BigInt(index),
+		);
+		const aliasPeer = { hashcode: () => "alias-peer" } as any;
+
+		try {
+			await sync.queueSync(coordinates, peerA, { skipCheck: true });
+			coordinateToHash.add(0n, "late-coordinate-hash");
+			const get = sinon.spy(coordinateToHash, "get");
+			send.resetHistory();
+
+			await sync.queueSync(["late-coordinate-hash"], aliasPeer, {
+				skipCheck: true,
+			});
+
+			expect(get.callCount).to.be.lessThanOrEqual(132);
+			expect(send.calledOnce).to.equal(true);
+			expect(send.firstCall.args[0]).to.be.instanceOf(
+				RequestMaybeSyncCoordinate,
+			);
+			expect(send.firstCall.args[0].hashNumbers).to.deep.equal([0n]);
+			expect(
+				sync.syncInFlightQueue.get(0n)?.map((peer) => peer.hashcode()),
+			).to.deep.equal([peerA.hashcode(), aliasPeer.hashcode()]);
+			expect(sync.syncInFlightQueue.has("late-coordinate-hash")).to.equal(
+				false,
+			);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("bounds stale reverse-alias inspection and resumes at a valid alias", async () => {
+		const send = sinon.stub().resolves();
+		const coordinateToHash = new Cache<string>({ max: 1_000 });
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash,
+		});
+		const coordinates = Array.from({ length: 129 }, (_, index) =>
+			BigInt(index),
+		);
+		const alias = "bounded-reverse-alias";
+
+		try {
+			await sync.queueSync(coordinates, peerA, { skipCheck: true });
+			coordinateToHash.add(coordinates.at(-1)!, alias);
+			(sync as any).syncInFlightQueuedCoordinatesByHash.set(
+				alias,
+				new Set(coordinates),
+			);
+			for (const coordinate of coordinates) {
+				(sync as any).syncInFlightQueuedHashByCoordinate.set(coordinate, alias);
+			}
+			const get = sinon.spy(coordinateToHash, "get");
+
+			const deferred = (sync as any).getQueuedSyncKeyForAdmission(alias);
+			expect(typeof deferred).to.equal("symbol");
+			expect(get.callCount).to.equal(128);
+			expect(sync.syncInFlightQueue.has(alias)).to.equal(false);
+
+			get.resetHistory();
+			expect((sync as any).getQueuedSyncKeyForAdmission(alias)).to.equal(
+				coordinates.at(-1),
+			);
+			expect(get.callCount).to.be.lessThanOrEqual(2);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("reconciles a late coordinate alias discovered across bounded refreshes", async () => {
+		const send = sinon.stub().resolves();
+		const coordinateToHash = new Cache<string>({ max: 1_000 });
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash,
+		});
+		const coordinates = Array.from({ length: 512 }, (_, index) =>
+			BigInt(index),
+		);
+		const lateCoordinate = coordinates[300]!;
+		const lateHash = "late-bounded-alias";
+
+		try {
+			await sync.queueSync(coordinates, peerA, { skipCheck: true });
+			coordinateToHash.add(lateCoordinate, lateHash);
+			await sync.queueSync([lateHash], peerB, { skipCheck: true });
+			expect(sync.syncInFlightQueue.has(lateHash)).to.equal(true);
+			expect(sync.pending).to.equal(coordinates.length + 1);
+
+			await sync.queueSync([lateHash], peerB, { skipCheck: true });
+			await sync.queueSync([lateHash], peerB, { skipCheck: true });
+
+			expect(sync.syncInFlightQueue.has(lateHash)).to.equal(false);
+			expect(
+				sync.syncInFlightQueue
+					.get(lateCoordinate)
+					?.map((peer) => peer.hashcode()),
+			).to.deep.equal([peerA.hashcode(), peerB.hashcode()]);
+			expect(sync.pending).to.equal(coordinates.length);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("requests a newly admitted shared-key source before unrelated lookup work settles", async () => {
+		let releaseLookup!: (hashes: string[]) => void;
+		const hasMany = sinon.stub().returns(
+			new Promise<string[]>((resolve) => {
+				releaseLookup = resolve;
+			}),
+		);
+		const send = sinon.stub().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: { hasMany } as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+		});
+
+		try {
+			await sync.queueSync(["shared-key"], peerA, { skipCheck: true });
+			send.resetHistory();
+
+			const handling = sync.queueSync(["shared-key", "new-key"], peerB);
+			await waitFor(() => hasMany.calledOnce && send.calledOnce);
+
+			expect(send.firstCall.args[0]).to.be.instanceOf(ResponseMaybeSync);
+			expect(send.firstCall.args[0].hashes).to.deep.equal(["shared-key"]);
+			expect(send.firstCall.args[1].mode.to).to.deep.equal([peerB.hashcode()]);
+
+			releaseLookup([]);
+			await handling;
+			expect(send.callCount).to.equal(2);
+			expect(send.secondCall.args[0].hashes).to.deep.equal(["new-key"]);
+		} finally {
+			releaseLookup?.([]);
+			await sync.close();
+		}
+	});
+
+	it("filters locally satisfied keys before a delayed initial dispatch", async () => {
+		let releaseSecond!: (count: number) => void;
+		const secondCount = new Promise<number>((resolve) => {
+			releaseSecond = resolve;
+		});
+		const count = sinon.stub();
+		count.onFirstCall().resolves(0);
+		count.onSecondCall().returns(secondCount);
+		const send = sinon.stub().resolves();
+		const coordinateToHash = new Cache<string>({ max: 10 });
+		coordinateToHash.add(1n, "satisfied-before-dispatch");
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: { count } as any,
+			log: { has: sinon.stub().resolves(false) } as any,
+			coordinateToHash,
+		});
+
+		try {
+			const handling = sync.queueSync([1n, 2n], peerA);
+			await waitFor(() => count.callCount === 2);
+			sync.onEntryAddedHash("satisfied-before-dispatch");
+			releaseSecond(0);
+			await handling;
+
+			expect(send.calledOnce).to.equal(true);
+			expect(send.firstCall.args[0]).to.be.instanceOf(
+				RequestMaybeSyncCoordinate,
+			);
+			expect(send.firstCall.args[0].hashNumbers).to.deep.equal([2n]);
+			expect(sync.syncInFlightQueue.has(1n)).to.equal(false);
+		} finally {
+			releaseSecond?.(0);
+			await sync.close();
+		}
+	});
+
+	it("checks repeated shared-key claimants in constant time", async () => {
+		const send = sinon.stub().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+		});
+		const claimantHashes = Array.from({ length: 256 }, (_, index) =>
+			sinon.spy(() => `shared-claimant-${index}`),
+		);
+		const claimants = claimantHashes.map((hashcode) => ({ hashcode }) as any);
+
+		try {
+			for (const claimant of claimants) {
+				await sync.queueSync(["shared-key"], claimant, { skipCheck: true });
+			}
+			for (const hashcode of claimantHashes) {
+				hashcode.resetHistory();
+			}
+
+			await sync.queueSync(["shared-key"], claimants.at(-1)!, {
+				skipCheck: true,
+			});
+
+			expect(
+				claimantHashes.slice(0, -1).every((hashcode) => hashcode.notCalled),
+			).to.equal(true);
+			expect(claimantHashes.at(-1)!.callCount).to.equal(2);
+
+			for (const hashcode of claimantHashes) {
+				hashcode.resetHistory();
+			}
+			sync.onPeerDisconnected(claimants[100]!);
+			expect(claimantHashes[100]!.callCount).to.equal(1);
+			expect(claimantHashes.at(-1)!.callCount).to.equal(1);
+			expect(
+				claimantHashes
+					.filter((_, index) => index !== 100 && index !== 255)
+					.every((hashcode) => hashcode.notCalled),
+			).to.equal(true);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("caps global maybe-sync peer-key claims even when keys are shared", async () => {
+		const send = sinon.stub().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({
+				max: MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER,
+			}),
+		});
+		const hashes = Array.from(
+			{ length: MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER },
+			(_, index) => `global-cap-${index}`,
+		);
+		const peerCount =
+			MAX_PENDING_SIMPLE_SYNC_KEYS_GLOBAL /
+			MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER;
+		const peers = Array.from({ length: peerCount + 1 }, (_, index) => {
+			return { hashcode: () => `claimant-${index}` } as any;
+		});
+
+		try {
+			for (const peer of peers) {
+				await sync.queueSync(hashes, peer, { skipCheck: true });
+			}
+
+			expect(sync.pending).to.equal(MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER);
+			expect((sync as any).pendingSyncClaimCount).to.equal(
+				MAX_PENDING_SIMPLE_SYNC_KEYS_GLOBAL,
+			);
+			for (const peer of peers.slice(0, peerCount)) {
+				expect(
+					sync.syncInFlightQueueInverted.get(peer.hashcode())?.size,
+				).to.equal(MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER);
+			}
+			expect(
+				sync.syncInFlightQueueInverted.has(peers.at(-1)!.hashcode()),
+			).to.equal(false);
+			expect(sync.syncInFlightQueue.get(hashes[0]!)).to.have.length(peerCount);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("does not refresh repeated claims and expires all retry state for reuse", async () => {
+		const clock = sinon.useFakeTimers({
+			now: 100_000,
+			toFake: ["Date", "setTimeout", "clearTimeout"],
+		});
+		const send = sinon.stub().resolves();
+		const hasMany = sinon.stub().resolves([]);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: { hasMany } as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+		});
+
+		try {
+			await sync.onMessage(new RequestMaybeSync({ hashes: ["claim"] }), {
+				from: peerA,
+			} as any);
+			const firstDeadline = (sync as any).syncInFlightQueueExpiresAt.get(
+				"claim",
+			);
+			expect(firstDeadline).to.equal(100_000 + PENDING_SIMPLE_SYNC_KEY_TTL_MS);
+			expect(sync.syncInFlight.get(peerA.hashcode())?.has("claim")).to.equal(
+				true,
+			);
+
+			await clock.tickAsync(PENDING_SIMPLE_SYNC_KEY_TTL_MS - 1);
+			await sync.onMessage(
+				new RequestMaybeSync({ hashes: ["claim", "claim"] }),
+				{
+					from: peerA,
+				} as any,
+			);
+			expect(hasMany.calledOnce).to.equal(true);
+			expect(send.calledOnce).to.equal(true);
+			expect((sync as any).syncInFlightQueueExpiresAt.get("claim")).to.equal(
+				firstDeadline,
+			);
+			expect((sync as any).pendingSyncClaimCount).to.equal(1);
+
+			await clock.tickAsync(1);
+			expect(sync.pending).to.equal(0);
+			expect(sync.syncInFlightQueueInverted.size).to.equal(0);
+			expect(sync.syncInFlight.size).to.equal(0);
+			expect((sync as any).pendingSyncClaimCount).to.equal(0);
+
+			await sync.onMessage(new RequestMaybeSync({ hashes: ["claim"] }), {
+				from: peerA,
+			} as any);
+			expect(hasMany.callCount).to.equal(2);
+			expect(send.callCount).to.equal(2);
+			expect(sync.pending).to.equal(1);
+			expect((sync as any).syncInFlightQueueExpiresAt.get("claim")).to.equal(
+				firstDeadline + PENDING_SIMPLE_SYNC_KEY_TTL_MS,
+			);
+		} finally {
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("reclaims an expired full claim quota before checking fresh admission", async () => {
+		const clock = sinon.useFakeTimers({
+			now: 100_000,
+			toFake: ["Date", "setTimeout", "clearTimeout"],
+		});
+		const send = sinon.stub().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({
+				max: MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER,
+			}),
+		});
+
+		try {
+			await sync.queueSync(
+				Array.from(
+					{ length: MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER },
+					(_, index) => `expired-claim-${index}`,
+				),
+				peerA,
+				{ skipCheck: true },
+			);
+			expect(sync.pending).to.equal(MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER);
+
+			// Advance Date without letting the scheduled expiry callback run.
+			clock.setSystemTime(100_000 + PENDING_SIMPLE_SYNC_KEY_TTL_MS + 1);
+			await sync.queueSync(["fresh-claim"], peerA, { skipCheck: true });
+
+			expect(sync.pending).to.equal(1);
+			expect(sync.syncInFlightQueue.has("fresh-claim")).to.equal(true);
+			expect((sync as any).pendingSyncClaimCount).to.equal(1);
+		} finally {
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("expires staggered keys from the indexed deadline heap without map rescans", async () => {
+		const clock = sinon.useFakeTimers({
+			now: 100_000,
+			toFake: ["Date", "setTimeout", "clearTimeout"],
+		});
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 100 }),
+		});
+		const expiryMap = (sync as any).syncInFlightQueueExpiresAt as Map<
+			string,
+			number
+		>;
+
+		try {
+			for (let index = 0; index < 64; index += 1) {
+				await sync.queueSync([`staggered-${index}`], peerA, {
+					skipCheck: true,
+				});
+				await clock.tickAsync(1);
+			}
+			expect((sync as any).pendingSyncExpiryHeap).to.have.length(64);
+			Object.defineProperty(expiryMap, Symbol.iterator, {
+				configurable: true,
+				value: () => {
+					throw new Error("expiry map must not be scanned");
+				},
+			});
+
+			await clock.tickAsync(PENDING_SIMPLE_SYNC_KEY_TTL_MS);
+			expect(sync.pending).to.equal(0);
+			expect((sync as any).pendingSyncExpiryHeap).to.have.length(0);
+		} finally {
+			delete (expiryMap as any)[Symbol.iterator];
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("clears a received hash through reverse indexes without scanning targets", async () => {
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 1_000 }),
+		});
+		const hashes = Array.from(
+			{ length: 512 },
+			(_, index) => `reverse-cleanup-${index}`,
+		);
+
+		try {
+			await sync.queueSync(hashes, peerA, { skipCheck: true });
+			Object.defineProperty(sync.syncInFlight, Symbol.iterator, {
+				configurable: true,
+				value: () => {
+					throw new Error("target maps must not be scanned");
+				},
+			});
+
+			sync.onEntryAddedHash(hashes[0]!);
+			expect(sync.pending).to.equal(hashes.length - 1);
+			expect(sync.syncInFlight.get(peerA.hashcode())?.has(hashes[0]!)).to.equal(
+				false,
+			);
+		} finally {
+			delete (sync.syncInFlight as any)[Symbol.iterator];
+			await sync.close();
+		}
+	});
+
+	it("expires lookup reservations and rejects their late results", async () => {
+		const clock = sinon.useFakeTimers({
+			now: 100_000,
+			toFake: ["Date", "setTimeout", "clearTimeout"],
+		});
+		let resolveLookup!: (hashes: string[]) => void;
+		const blockedLookup = new Promise<string[]>((resolve) => {
+			resolveLookup = resolve;
+		});
+		const hasMany = sinon.stub();
+		hasMany.onFirstCall().returns(blockedLookup);
+		hasMany.onSecondCall().resolves([]);
+		const send = sinon.stub().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: { hasMany } as any,
+			coordinateToHash: new Cache<string>({
+				max: MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER + 1,
+			}),
+		});
+		const blockedHashes = Array.from(
+			{ length: MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER },
+			(_, index) => `late-${index}`,
+		);
+
+		try {
+			const handling = sync.onMessage(
+				new RequestMaybeSync({ hashes: blockedHashes }),
+				{ from: peerA } as any,
+			);
+			await waitFor(() => hasMany.calledOnce);
+			expect((sync as any).pendingSyncAdmissionCount).to.equal(
+				MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER,
+			);
+
+			await clock.tickAsync(PENDING_SIMPLE_SYNC_KEY_TTL_MS);
+			// Expiry invalidates the late result but cannot release the quota slot
+			// while the non-abortable lookup is still consuming resources.
+			expect((sync as any).pendingSyncAdmissionCount).to.equal(
+				MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER,
+			);
+			await sync.onMessage(new RequestMaybeSync({ hashes: ["fresh"] }), {
+				from: peerA,
+			} as any);
+			expect(hasMany.calledOnce).to.equal(true);
+			resolveLookup([]);
+			await handling;
+			expect((sync as any).pendingSyncAdmissionCount).to.equal(0);
+			expect(sync.pending).to.equal(0);
+			expect(send.called).to.equal(false);
+
+			await sync.onMessage(new RequestMaybeSync({ hashes: ["fresh"] }), {
+				from: peerA,
+			} as any);
+			expect(hasMany.callCount).to.equal(2);
+			expect(sync.pending).to.equal(1);
+			expect(send.calledOnce).to.equal(true);
+		} finally {
+			resolveLookup([]);
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("retains locally settled admission quota until blocked lookup work settles", async () => {
+		let resolveLookup!: (hashes: string[]) => void;
+		const hasMany = sinon.stub();
+		hasMany.onFirstCall().returns(
+			new Promise<string[]>((resolve) => {
+				resolveLookup = resolve;
+			}),
+		);
+		hasMany.onSecondCall().resolves([]);
+		const send = sinon.stub().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: { hasMany } as any,
+			coordinateToHash: new Cache<string>({
+				max: MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER + 1,
+			}),
+		});
+		const hashes = Array.from(
+			{ length: MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER },
+			(_, index) => `locally-settled-${index}`,
+		);
+
+		try {
+			const handling = sync.onMessage(new RequestMaybeSync({ hashes }), {
+				from: peerA,
+			} as any);
+			await waitFor(() => hasMany.calledOnce);
+
+			sync.onEntryAddedHashes(hashes);
+			expect((sync as any).pendingSyncAdmissionCount).to.equal(
+				MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER,
+			);
+			expect(
+				(sync as any).pendingSyncAdmissionReservationsByIdentity.size,
+			).to.equal(0);
+
+			await sync.onMessage(
+				new RequestMaybeSync({ hashes: ["must-wait-for-old-lookup"] }),
+				{ from: peerA } as any,
+			);
+			expect(hasMany.calledOnce).to.equal(true);
+
+			resolveLookup(hashes);
+			await handling;
+			expect((sync as any).pendingSyncAdmissionCount).to.equal(0);
+			expect((sync as any).pendingSyncAdmissionCountByPeer.size).to.equal(0);
+
+			await sync.onMessage(
+				new RequestMaybeSync({ hashes: ["after-old-lookup"] }),
+				{ from: peerA } as any,
+			);
+			expect(hasMany.callCount).to.equal(2);
+			expect(send.calledOnce).to.equal(true);
+		} finally {
+			resolveLookup?.(hashes);
+			await sync.close();
+		}
+	});
+
+	it("counts a promoted claimant separately until its blocked resolver settles", async () => {
+		let resolveLookup!: (hashes: string[]) => void;
+		const hasMany = sinon.stub().returns(
+			new Promise<string[]>((resolve) => {
+				resolveLookup = resolve;
+			}),
+		);
+		const send = sinon.stub().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: { hasMany } as any,
+			coordinateToHash: new Cache<string>({
+				max: MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER,
+			}),
+		});
+		const shared = "promoted-shared";
+		const reserved = [
+			shared,
+			...Array.from(
+				{ length: MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER - 2 },
+				(_, index) => `promoted-reserved-${index}`,
+			),
+		];
+
+		try {
+			const blocked = sync.onMessage(
+				new RequestMaybeSync({ hashes: reserved }),
+				{ from: peerA } as any,
+			);
+			await waitFor(() => hasMany.calledOnce);
+			await sync.queueSync([shared], peerB, { skipCheck: true });
+			send.resetHistory();
+
+			await sync.onMessage(new RequestMaybeSync({ hashes: [shared] }), {
+				from: peerA,
+			} as any);
+
+			expect(
+				sync.syncInFlightQueue.get(shared)?.map((peer) => peer.hashcode()),
+			).to.deep.equal([peerB.hashcode(), peerA.hashcode()]);
+			expect((sync as any).pendingSyncAdmissionCount).to.equal(reserved.length);
+			expect((sync as any).pendingSyncClaimCount).to.equal(2);
+			expect(
+				(sync as any).pendingSyncAdmissionCountByPeer.get(peerA.hashcode()) +
+					(sync.syncInFlightQueueInverted.get(peerA.hashcode())?.size ?? 0),
+			).to.equal(MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER);
+			expect(send.calledOnce).to.equal(true);
+			expect(send.firstCall.args[1].mode.to).to.deep.equal([peerA.hashcode()]);
+
+			sync.onEntryAddedHash(shared);
+			expect((sync as any).pendingSyncClaimCount).to.equal(0);
+			expect((sync as any).pendingSyncAdmissionCount).to.equal(reserved.length);
+
+			resolveLookup(reserved);
+			await blocked;
+			expect((sync as any).pendingSyncAdmissionCount).to.equal(0);
+			expect(sync.pending).to.equal(0);
+		} finally {
+			resolveLookup?.(reserved);
+			await sync.close();
+		}
+	});
+
+	it("bounds concurrent lookup reservations and reclaims them on disconnect", async () => {
+		let resolveLookup!: (hashes: string[]) => void;
+		const blockedLookup = new Promise<string[]>((resolve) => {
+			resolveLookup = resolve;
+		});
+		const hasMany = sinon.stub();
+		hasMany.onFirstCall().returns(blockedLookup);
+		hasMany.onSecondCall().resolves([]);
+		const send = sinon.stub().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: { hasMany } as any,
+			coordinateToHash: new Cache<string>({
+				max: MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER * 2,
+			}),
+		});
+		const first = Array.from(
+			{ length: MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER },
+			(_, index) => `blocked-${index}`,
+		);
+		const second = Array.from(
+			{ length: MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER },
+			(_, index) => `rejected-while-blocked-${index}`,
+		);
+
+		try {
+			const blocked = sync.onMessage(new RequestMaybeSync({ hashes: first }), {
+				from: peerA,
+			} as any);
+			await waitFor(() => hasMany.calledOnce);
+			await sync.onMessage(new RequestMaybeSync({ hashes: first }), {
+				from: peerA,
+			} as any);
+			await sync.onMessage(new RequestMaybeSync({ hashes: second }), {
+				from: peerA,
+			} as any);
+
+			expect(hasMany.calledOnce).to.equal(true);
+			expect(sync.pending).to.equal(0);
+			expect((sync as any).pendingSyncAdmissionCount).to.equal(
+				MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER,
+			);
+
+			sync.onPeerDisconnected(peerA);
+			expect((sync as any).pendingSyncAdmissionCount).to.equal(
+				MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER,
+			);
+			await sync.onMessage(new RequestMaybeSync({ hashes: second }), {
+				from: peerA,
+			} as any);
+			expect(hasMany.calledOnce).to.equal(true);
+			resolveLookup([]);
+			await blocked;
+			expect((sync as any).pendingSyncAdmissionCount).to.equal(0);
+			expect(sync.pending).to.equal(0);
+
+			await sync.onMessage(new RequestMaybeSync({ hashes: ["reclaimed"] }), {
+				from: peerA,
+			} as any);
+			expect(hasMany.callCount).to.equal(2);
+			expect(sync.pending).to.equal(1);
+		} finally {
+			resolveLookup([]);
+			await sync.close();
+		}
+	});
+
+	it("bounds one-key resolver calls across disconnect until they settle", async () => {
+		const releases: ((hashes: string[]) => void)[] = [];
+		let blockLookups = true;
+		const hasMany = sinon.stub().callsFake(() =>
+			blockLookups
+				? new Promise<string[]>((resolve) => {
+						releases.push(resolve);
+					})
+				: Promise.resolve([]),
+		);
+		const send = sinon.stub().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: { hasMany } as any,
+			coordinateToHash: new Cache<string>({ max: 100 }),
+		});
+
+		try {
+			const blocked = Array.from(
+				{ length: MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER },
+				(_, index) =>
+					sync.onMessage(
+						new RequestMaybeSync({ hashes: [`blocked-call-${index}`] }),
+						{ from: peerA } as any,
+					),
+			);
+			await waitFor(
+				() => hasMany.callCount === MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
+			);
+
+			await sync.onMessage(
+				new RequestMaybeSync({ hashes: ["over-call-cap"] }),
+				{ from: peerA } as any,
+			);
+			expect(hasMany.callCount).to.equal(
+				MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
+			);
+
+			sync.onPeerDisconnected(peerA);
+			await sync.onMessage(
+				new RequestMaybeSync({ hashes: ["over-call-cap-after-disconnect"] }),
+				{ from: peerA } as any,
+			);
+			expect(hasMany.callCount).to.equal(
+				MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
+			);
+
+			blockLookups = false;
+			for (const release of releases) {
+				release([]);
+			}
+			await Promise.all(blocked);
+			expect((sync as any).pendingSyncAdmissionReservations.size).to.equal(0);
+
+			await sync.onMessage(
+				new RequestMaybeSync({ hashes: ["after-call-cap"] }),
+				{ from: peerA } as any,
+			);
+			expect(hasMany.callCount).to.equal(
+				MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER + 1,
+			);
+		} finally {
+			blockLookups = false;
+			for (const release of releases) {
+				release([]);
+			}
+			await sync.close();
+		}
+	});
+
+	it("rejects oversized coordinate requests before resolver work", async () => {
+		const resolveHashListForSymbols = sinon.stub().returns([]);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			resolveHashListForSymbols,
+		});
+		const ship = sinon.stub(sync as any, "shipExchangeHeads").resolves({
+			messages: 0,
+			fused: false,
+		});
+
+		try {
+			await sync.onMessage(
+				new RequestMaybeSyncCoordinate({
+					hashNumbers: Array.from(
+						{ length: MAX_SIMPLE_COORDINATE_REQUEST_SYMBOLS + 1 },
+						(_, index) => BigInt(index),
+					),
+				}),
+				{ from: peerA } as any,
+			);
+
+			expect(resolveHashListForSymbols.called).to.equal(false);
+			expect(ship.called).to.equal(false);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("retains coordinate lookup permits across disconnect until work settles", async () => {
+		const releases: ((hashes: string[]) => void)[] = [];
+		const resolveHashListForSymbols = sinon.stub().callsFake(
+			() =>
+				new Promise<string[]>((resolve) => {
+					releases.push(resolve);
+				}),
+		);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			resolveHashListForSymbols,
+		});
+		const pending: Promise<boolean>[] = [];
+
+		try {
+			for (
+				let index = 0;
+				index < MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER;
+				index += 1
+			) {
+				pending.push(
+					sync.onMessage(
+						new RequestMaybeSyncCoordinate({
+							hashNumbers: [BigInt(index)],
+						}),
+						{ from: peerA } as any,
+					),
+				);
+			}
+			await waitFor(
+				() =>
+					resolveHashListForSymbols.callCount ===
+					MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
+			);
+
+			await sync.onMessage(
+				new RequestMaybeSyncCoordinate({ hashNumbers: [100n] }),
+				{ from: peerA } as any,
+			);
+			sync.onPeerDisconnected(peerA);
+			await sync.onMessage(
+				new RequestMaybeSyncCoordinate({ hashNumbers: [101n] }),
+				{ from: peerA } as any,
+			);
+			expect(resolveHashListForSymbols.callCount).to.equal(
+				MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
+			);
+			expect((sync as any).pendingCoordinateLookupCount).to.equal(
+				MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
+			);
+
+			releases.shift()!([]);
+			await pending.shift();
+			pending.push(
+				sync.onMessage(
+					new RequestMaybeSyncCoordinate({ hashNumbers: [102n] }),
+					{ from: peerA } as any,
+				),
+			);
+			await waitFor(
+				() =>
+					resolveHashListForSymbols.callCount ===
+					MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER + 1,
+			);
+		} finally {
+			for (const release of releases) {
+				release([]);
+			}
+			await Promise.all(pending);
+			await sync.close();
+		}
+	});
+
+	it("caps coordinate response hashes before shipping", async () => {
+		const hashes = Array.from(
+			{ length: MAX_SIMPLE_COORDINATE_RESPONSE_HASHES + 1 },
+			(_, index) => `head-${index}`,
+		);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			resolveHashListForSymbols: sinon.stub().returns(hashes),
+		});
+		const ship = sinon.stub(sync as any, "shipExchangeHeads").resolves({
+			messages: 1,
+			fused: false,
+		});
+
+		try {
+			await sync.onMessage(
+				new RequestMaybeSyncCoordinate({ hashNumbers: [1n] }),
+				{ from: peerA } as any,
+			);
+
+			expect(ship.calledOnce).to.equal(true);
+			expect(ship.firstCall.args[0]).to.have.length(
+				MAX_SIMPLE_COORDINATE_RESPONSE_HASHES,
+			);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("bounds duplicate-yielding coordinate resolver work", async () => {
+		let yielded = 0;
+		const duplicateHashes = {
+			*[Symbol.iterator]() {
+				for (let index = 0; index < 20_000; index += 1) {
+					yielded += 1;
+					yield "duplicate-head";
+				}
+			},
+		};
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			resolveHashesForSymbols: sinon
+				.stub()
+				.returns(new Map([[1n, duplicateHashes]])),
+		});
+		const ship = sinon.stub(sync as any, "shipExchangeHeads").resolves({
+			messages: 1,
+			fused: false,
+		});
+
+		try {
+			await sync.onMessage(
+				new RequestMaybeSyncCoordinate({ hashNumbers: [1n] }),
+				{ from: peerA } as any,
+			);
+
+			expect(yielded).to.equal(MAX_SIMPLE_COORDINATE_RESPONSE_HASHES);
+			expect(ship.calledOnce).to.equal(true);
+			expect(ship.firstCall.args[0]).to.deep.equal(["duplicate-head"]);
+			expect(sync.coordinateToHash.get(1n)).to.equal(undefined);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("does not cache a boundary-truncated coordinate as uniquely resolved", async () => {
+		let boundaryYields = 0;
+		const first = Array.from(
+			{ length: MAX_SIMPLE_COORDINATE_RESPONSE_HASHES - 1 },
+			(_, index) => `head-${index}`,
+		);
+		const boundary = {
+			*[Symbol.iterator]() {
+				boundaryYields += 1;
+				yield "boundary-first";
+				boundaryYields += 1;
+				yield "boundary-second";
+			},
+		};
+		const coordinateToHash = new Cache<string>({ max: 10 });
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash,
+			resolveHashesForSymbols: sinon.stub().returns(
+				new Map<bigint, Iterable<string>>([
+					[1n, first],
+					[2n, boundary],
+				]),
+			),
+		});
+		const ship = sinon.stub(sync as any, "shipExchangeHeads").resolves({
+			messages: 1,
+			fused: false,
+		});
+
+		try {
+			await sync.onMessage(
+				new RequestMaybeSyncCoordinate({ hashNumbers: [1n, 2n] }),
+				{ from: peerA } as any,
+			);
+
+			expect(boundaryYields).to.equal(1);
+			expect(ship.firstCall.args[0]).to.have.length(
+				MAX_SIMPLE_COORDINATE_RESPONSE_HASHES,
+			);
+			expect(coordinateToHash.get(2n)).to.equal(undefined);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("releases coordinate lookups before bounded response sends settle", async () => {
+		const resolveHashListForSymbols = sinon.stub().returns(["head"]);
+		const releases: ((result: { messages: number; fused: boolean }) => void)[] =
+			[];
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			resolveHashListForSymbols,
+		});
+		const ship = sinon.stub(sync as any, "shipExchangeHeads").callsFake(
+			() =>
+				new Promise<{ messages: number; fused: boolean }>((resolve) => {
+					releases.push(resolve);
+				}),
+		);
+		const pending: Promise<boolean>[] = [];
+
+		try {
+			for (
+				let index = 0;
+				index < MAX_PENDING_SIMPLE_COORDINATE_RESPONSES_PER_PEER;
+				index += 1
+			) {
+				pending.push(
+					sync.onMessage(
+						new RequestMaybeSyncCoordinate({
+							hashNumbers: [BigInt(index)],
+						}),
+						{ from: peerA } as any,
+					),
+				);
+			}
+			await waitFor(
+				() =>
+					ship.callCount === MAX_PENDING_SIMPLE_COORDINATE_RESPONSES_PER_PEER,
+			);
+			expect((sync as any).pendingCoordinateLookupCount).to.equal(0);
+			expect((sync as any).pendingCoordinateResponseCount).to.equal(
+				MAX_PENDING_SIMPLE_COORDINATE_RESPONSES_PER_PEER,
+			);
+
+			await sync.close();
+			await sync.open();
+			await sync.onMessage(
+				new RequestMaybeSyncCoordinate({ hashNumbers: [100n] }),
+				{ from: peerA } as any,
+			);
+			expect(resolveHashListForSymbols.callCount).to.equal(
+				MAX_PENDING_SIMPLE_COORDINATE_RESPONSES_PER_PEER + 1,
+			);
+			expect(ship.callCount).to.equal(
+				MAX_PENDING_SIMPLE_COORDINATE_RESPONSES_PER_PEER,
+			);
+
+			releases.shift()!({ messages: 1, fused: false });
+			await pending.shift();
+			pending.push(
+				sync.onMessage(
+					new RequestMaybeSyncCoordinate({ hashNumbers: [101n] }),
+					{ from: peerA } as any,
+				),
+			);
+			await waitFor(
+				() =>
+					ship.callCount ===
+					MAX_PENDING_SIMPLE_COORDINATE_RESPONSES_PER_PEER + 1,
+			);
+		} finally {
+			for (const release of releases) {
+				release({ messages: 1, fused: false });
+			}
+			await Promise.all(pending);
+			await sync.close();
+		}
+	});
+
 	it("chunks coordinate maybe-sync requests", async () => {
 		const send = sinon.stub().resolves();
 		const rpc = { send } as any;
@@ -913,9 +2986,41 @@ describe("sync-chunking", () => {
 		expect(sentCoordinates.map((x) => x.length)).to.deep.equal([2, 2, 1]);
 	});
 
+	it("clamps configured coordinate chunks to the receiver work limit", async () => {
+		const send = sinon.stub().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sync: {
+				maxSimpleCoordinatesPerMessage:
+					MAX_SIMPLE_COORDINATE_REQUEST_SYMBOLS * 2,
+			},
+		});
+		const coordinates = Array.from(
+			{ length: MAX_SIMPLE_COORDINATE_REQUEST_SYMBOLS + 1 },
+			(_, index) => BigInt(index),
+		);
+
+		try {
+			await sync.queueSync(coordinates, peerA, { skipCheck: true });
+
+			expect(send.callCount).to.equal(2);
+			expect(send.firstCall.args[0].hashNumbers).to.have.length(
+				MAX_SIMPLE_COORDINATE_REQUEST_SYMBOLS,
+			);
+			expect(send.secondCall.args[0].hashNumbers).to.have.length(1);
+		} finally {
+			await sync.close();
+		}
+	});
+
 	it("uses native resolver for coordinate queue preflight", async () => {
 		const send = sinon.stub().resolves();
-		const count = sinon.stub().throws(new Error("entry index should not be used"));
+		const count = sinon
+			.stub()
+			.throws(new Error("entry index should not be used"));
 		const resolveHashesForSymbols = sinon
 			.stub()
 			.returns(new Map([[42n, ["head-a"]]]));
@@ -927,13 +3032,10 @@ describe("sync-chunking", () => {
 			resolveHashesForSymbols,
 		});
 
-		await sync.queueSync(
-			[42n, 7n],
-			{
-				hashcode: () => "peer-a",
-				equals: () => false,
-			} as any,
-		);
+		await sync.queueSync([42n, 7n], {
+			hashcode: () => "peer-a",
+			equals: () => false,
+		} as any);
 
 		expect(count.called).to.equal(false);
 		expect(resolveHashesForSymbols.firstCall.args[0]).to.deep.equal([42n, 7n]);
@@ -944,7 +3046,9 @@ describe("sync-chunking", () => {
 
 	it("uses native coordinate symbol resolver before index lookup", async () => {
 		const send = sinon.stub().resolves();
-		const iterate = sinon.stub().throws(new Error("entry index should not be used"));
+		const iterate = sinon
+			.stub()
+			.throws(new Error("entry index should not be used"));
 		const rpc = { send } as any;
 		const sync = new SimpleSyncronizer<"u64">({
 			rpc,
@@ -971,14 +3075,16 @@ describe("sync-chunking", () => {
 
 		expect(iterate.called).to.equal(false);
 		expect(send.callCount).to.equal(1);
-		expect(send.firstCall.args[0].heads.map((x: any) => x.entry.hash)).to.deep.equal([
-			"head-a",
-		]);
+		expect(
+			send.firstCall.args[0].heads.map((x: any) => x.entry.hash),
+		).to.deep.equal(["head-a"]);
 	});
 
 	it("uses native flat coordinate symbol resolver for response lookup", async () => {
 		const send = sinon.stub().resolves();
-		const iterate = sinon.stub().throws(new Error("entry index should not be used"));
+		const iterate = sinon
+			.stub()
+			.throws(new Error("entry index should not be used"));
 		const resolveHashesForSymbols = sinon
 			.stub()
 			.throws(new Error("map resolver should not be used"));
@@ -1009,9 +3115,9 @@ describe("sync-chunking", () => {
 		expect(resolveHashListForSymbols.firstCall.args[0]).to.deep.equal([42n]);
 		expect(resolveHashesForSymbols.called).to.equal(false);
 		expect(send.callCount).to.equal(1);
-		expect(send.firstCall.args[0].heads.map((x: any) => x.entry.hash)).to.deep.equal([
-			"head-a",
-		]);
+		expect(
+			send.firstCall.args[0].heads.map((x: any) => x.entry.hash),
+		).to.deep.equal(["head-a"]);
 	});
 
 	it("splits mixed hash and coordinate maybe-sync batches by type", async () => {
@@ -1056,6 +3162,43 @@ describe("sync-chunking", () => {
 		).to.deep.equal([2n, 4n]);
 	});
 
+	it("normalizes fractional hash and coordinate chunk settings", async () => {
+		const send = sinon.stub().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sync: {
+				maxSimpleHashesPerMessage: 0.5,
+				maxSimpleCoordinatesPerMessage: 0.5,
+			},
+		});
+
+		try {
+			await (sync as any).requestSync(
+				["fractional-hash-1", "fractional-hash-2", 1n, 2n],
+				[peerA.hashcode()],
+			);
+
+			expect(send.callCount).to.equal(4);
+			expect(
+				send
+					.getCalls()
+					.filter((call) => call.args[0] instanceof ResponseMaybeSync)
+					.map((call) => call.args[0].hashes),
+			).to.deep.equal([["fractional-hash-1"], ["fractional-hash-2"]]);
+			expect(
+				send
+					.getCalls()
+					.filter((call) => call.args[0] instanceof RequestMaybeSyncCoordinate)
+					.map((call) => call.args[0].hashNumbers),
+			).to.deep.equal([[1n], [2n]]);
+		} finally {
+			await sync.close();
+		}
+	});
+
 	it("advertises raw exchange-head support when enabled", async () => {
 		const send = sinon.stub().resolves();
 		const sync = new SimpleSyncronizer<"u64">({
@@ -1085,7 +3228,9 @@ describe("sync-chunking", () => {
 
 	it("responds with raw exchange heads only to capable requests", async () => {
 		const send = sinon.stub().resolves();
-		const get = sinon.stub().throws(new Error("full entry get should not be used"));
+		const get = sinon
+			.stub()
+			.throws(new Error("full entry get should not be used"));
 		const getMany = sinon.stub().resolves([new Uint8Array([1, 2, 3])]);
 		const sync = new SimpleSyncronizer<"u64">({
 			rpc: { send } as any,
@@ -1112,9 +3257,9 @@ describe("sync-chunking", () => {
 
 		expect(send.callCount).to.equal(1);
 		expect(send.firstCall.args[0]).to.be.instanceOf(RawExchangeHeadsMessage);
-		expect(send.firstCall.args[0].heads.map((head: any) => head.hash)).to.deep.equal(
-			["head-a"],
-		);
+		expect(
+			send.firstCall.args[0].heads.map((head: any) => head.hash),
+		).to.deep.equal(["head-a"]);
 		expect(get.called).to.equal(false);
 		expect(getMany.calledOnceWithExactly(["head-a"])).to.equal(true);
 	});

--- a/packages/programs/data/shared-log/test/sync-chunking.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-chunking.spec.ts
@@ -16,10 +16,24 @@ import {
 
 describe("sync-chunking", () => {
 	let peerA: Awaited<ReturnType<typeof Ed25519Keypair.create>>["publicKey"];
+	let peerB: Awaited<ReturnType<typeof Ed25519Keypair.create>>["publicKey"];
 
 	before(async () => {
-		peerA = (await Ed25519Keypair.create()).publicKey;
+		[peerA, peerB] = await Promise.all([
+			Ed25519Keypair.create().then((keypair) => keypair.publicKey),
+			Ed25519Keypair.create().then((keypair) => keypair.publicKey),
+		]);
 	});
+
+	const waitFor = async (condition: () => boolean) => {
+		for (let i = 0; i < 1_000; i++) {
+			if (condition()) {
+				return;
+			}
+			await Promise.resolve();
+		}
+		throw new Error("condition was not reached");
+	};
 
 	it("uses the convergence transport priority for sync messages", () => {
 		expect(SYNC_MESSAGE_PRIORITY).to.equal(CONVERGENCE_MESSAGE_PRIORITY);
@@ -38,25 +52,832 @@ describe("sync-chunking", () => {
 			},
 		});
 
+		try {
+			const entries = new Map<string, any>();
+			for (let i = 0; i < 5; i++) {
+				entries.set(`h${i}`, { hash: `h${i}` });
+			}
+
+			await sync.onMaybeMissingEntries({
+				entries: entries as any,
+				targets: ["p"],
+			});
+
+			expect(send.callCount).to.equal(3);
+			const sentHashes = send.getCalls().map((call) => {
+				const message = call.args[0];
+				expect(call.args[1].priority).to.equal(SYNC_MESSAGE_PRIORITY);
+				expect(message).to.be.instanceOf(RequestMaybeSync);
+				return (message as RequestMaybeSync).hashes;
+			});
+			expect(sentHashes.flat()).to.deep.equal(["h0", "h1", "h2", "h3", "h4"]);
+			expect(sentHashes.map((x) => x.length)).to.deep.equal([2, 2, 1]);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("retains authorization for a 10,001-hash tail-only response", async () => {
+		const clock = sinon.useFakeTimers();
+		try {
+			const send = sinon.stub().resolves();
+			const sendRawExchangeHeads = sinon.stub().resolves(1);
+			const sync = new SimpleSyncronizer<"u64">({
+				rpc: { send } as any,
+				entryIndex: {} as any,
+				log: {} as any,
+				coordinateToHash: new Cache<string>({ max: 10 }),
+				sendRawExchangeHeads,
+				sync: {
+					maxSimpleHashesPerMessage: 10_000,
+				},
+			});
+			const hashes = Array.from({ length: 10_001 }, (_, index) => `h${index}`);
+
+			const dispatch = sync.onMaybeMissingHashes({
+				hashes,
+				targets: [peerA.hashcode()],
+			});
+			await waitFor(() => send.callCount === 1);
+			expect(send.firstCall.args[0].hashes).to.have.length(10_000);
+			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(10_000);
+
+			await clock.tickAsync(30_001);
+			await dispatch;
+			expect(send.callCount).to.equal(2);
+			expect(send.secondCall.args[0].hashes).to.deep.equal(["h10000"]);
+
+			await sync.onMessage(
+				new ResponseMaybeSyncCapabilities({ hashes: ["h10000"] }),
+				{ from: peerA } as any,
+			);
+			expect(sendRawExchangeHeads.calledOnce).to.equal(true);
+			expect(sendRawExchangeHeads.firstCall.args[0]).to.deep.equal(["h10000"]);
+			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(0);
+		} finally {
+			clock.restore();
+		}
+	});
+
+	it("rotates a bounded response window across two 6,000-hash targets", async () => {
+		const send = sinon.stub().resolves();
+		const sendRawExchangeHeads = sinon.stub().resolves(1);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sendRawExchangeHeads,
+			sync: {
+				maxSimpleHashesPerMessage: 6_000,
+			},
+		});
+		const hashes = Array.from({ length: 6_000 }, (_, index) => `h${index}`);
+
+		const dispatch = sync.onMaybeMissingHashes({
+			hashes,
+			targets: [peerA.hashcode(), peerB.hashcode()],
+		});
+		await waitFor(() => send.callCount === 2);
+		expect(send.firstCall.args[1].mode.to).to.deep.equal([peerA.hashcode()]);
+		expect(send.secondCall.args[1].mode.to).to.deep.equal([peerB.hashcode()]);
+		expect(send.firstCall.args[0].hashes).to.have.length(5_000);
+		expect(send.secondCall.args[0].hashes).to.have.length(5_000);
+		expect((sync as any).pendingMaybeSyncResponseCount).to.equal(10_000);
+
+		const firstWindow = hashes.slice(0, 5_000);
+		await Promise.all([
+			sync.onMessage(
+				new ResponseMaybeSyncCapabilities({ hashes: firstWindow }),
+				{ from: peerA } as any,
+			),
+			sync.onMessage(
+				new ResponseMaybeSyncCapabilities({ hashes: firstWindow }),
+				{ from: peerB } as any,
+			),
+		]);
+		await waitFor(() => send.callCount === 4);
+		expect(send.thirdCall.args[1].mode.to).to.deep.equal([peerA.hashcode()]);
+		expect(send.getCall(3).args[1].mode.to).to.deep.equal([peerB.hashcode()]);
+		expect(send.thirdCall.args[0].hashes).to.deep.equal(hashes.slice(5_000));
+		expect(send.getCall(3).args[0].hashes).to.deep.equal(hashes.slice(5_000));
+		expect((sync as any).pendingMaybeSyncResponseCount).to.equal(2_000);
+
+		const tail = hashes.slice(5_000);
+		await Promise.all([
+			sync.onMessage(new ResponseMaybeSyncCapabilities({ hashes: tail }), {
+				from: peerA,
+			} as any),
+			sync.onMessage(new ResponseMaybeSyncCapabilities({ hashes: tail }), {
+				from: peerB,
+			} as any),
+		]);
+		await dispatch;
+
+		expect(sendRawExchangeHeads.callCount).to.equal(4);
+		expect(sendRawExchangeHeads.firstCall.args[1]).to.deep.equal([
+			peerA.hashcode(),
+		]);
+		expect(sendRawExchangeHeads.secondCall.args[1]).to.deep.equal([
+			peerB.hashcode(),
+		]);
+		expect(sendRawExchangeHeads.thirdCall.args[1]).to.deep.equal([
+			peerA.hashcode(),
+		]);
+		expect(sendRawExchangeHeads.getCall(3).args[1]).to.deep.equal([
+			peerB.hashcode(),
+		]);
+		expect((sync as any).pendingMaybeSyncResponseCount).to.equal(0);
+	});
+
+	it("fences a blocked signal-less dispatch across close and reopen", async () => {
+		let releaseSend!: () => void;
+		const sendReleased = new Promise<void>((resolve) => {
+			releaseSend = resolve;
+		});
+		let markSendStarted!: () => void;
+		const sendStarted = new Promise<void>((resolve) => {
+			markSendStarted = resolve;
+		});
+		let dispatchSignal: AbortSignal | undefined;
+		const send = sinon
+			.stub()
+			.callsFake(
+				async (
+					_message: RequestMaybeSync,
+					options: { signal?: AbortSignal },
+				) => {
+					dispatchSignal = options.signal;
+					markSendStarted();
+					await sendReleased;
+				},
+			);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: { has: async () => false } as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sync: {
+				maxSimpleHashesPerMessage: 2,
+			},
+		});
+
+		const dispatch = sync.onMaybeMissingHashes({
+			hashes: ["h0", "h1", "h2"],
+			targets: [peerA.hashcode()],
+		});
+		await sendStarted;
+		await sync.close();
+		await sync.open();
+		releaseSend();
+		await dispatch;
+
+		expect(dispatchSignal).not.to.equal(undefined);
+		expect(dispatchSignal?.aborted).to.equal(true);
+		expect(send.callCount).to.equal(1);
+		expect((sync as any).pendingMaybeSyncResponseCount).to.equal(0);
+		await sync.close();
+	});
+
+	it("aborts a live-caller fused response when the synchronizer closes", async () => {
+		const send = sinon.stub().resolves();
+		let markResponseStarted!: () => void;
+		const responseStarted = new Promise<void>((resolve) => {
+			markResponseStarted = resolve;
+		});
+		let responseSignal: AbortSignal | undefined;
+		const sendRawExchangeHeads = sinon
+			.stub()
+			.callsFake(
+				async (
+					_hashes: string[],
+					_targets: string[],
+					options?: { signal?: AbortSignal },
+				) => {
+					responseSignal = options?.signal;
+					markResponseStarted();
+					await new Promise<void>((_resolve, reject) => {
+						const rejectForAbort = () =>
+							reject(responseSignal?.reason ?? new Error("aborted"));
+						if (responseSignal?.aborted) {
+							rejectForAbort();
+						} else {
+							responseSignal?.addEventListener("abort", rejectForAbort, {
+								once: true,
+							});
+						}
+					});
+					return 1;
+				},
+			);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sendRawExchangeHeads,
+		});
+		const caller = new AbortController();
+
+		await sync.onMaybeMissingHashes({
+			hashes: ["hash"],
+			targets: [peerA.hashcode()],
+			signal: caller.signal,
+		});
+		const handling = sync.onMessage(
+			new ResponseMaybeSyncCapabilities({ hashes: ["hash"] }),
+			{ from: peerA } as any,
+		);
+		await responseStarted;
+		await sync.close();
+
+		expect(await handling).to.equal(true);
+		expect(caller.signal.aborted).to.equal(false);
+		expect(responseSignal).not.to.equal(caller.signal);
+		expect(responseSignal?.aborted).to.equal(true);
+	});
+
+	it("invalidates a capacity waiter on disconnect until a fresh dispatch", async () => {
+		const send = sinon.stub().resolves();
+		const sendRawExchangeHeads = sinon.stub().resolves(1);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sendRawExchangeHeads,
+			sync: { maxSimpleHashesPerMessage: 10_000 },
+		});
+		const occupyingHashes = Array.from(
+			{ length: 10_000 },
+			(_, index) => `occupying-${index}`,
+		);
+		await sync.onMaybeMissingHashes({
+			hashes: occupyingHashes,
+			targets: [peerA.hashcode()],
+		});
+
+		const staleDispatch = sync.onMaybeMissingHashes({
+			hashes: ["stale"],
+			targets: [peerB.hashcode()],
+		});
+		await waitFor(
+			() => (sync as any).pendingMaybeSyncResponseWaiters.size === 1,
+		);
+		sync.onPeerDisconnected(peerB);
+		await staleDispatch;
+
+		await sync.onMessage(
+			new ResponseMaybeSyncCapabilities({ hashes: occupyingHashes }),
+			{ from: peerA } as any,
+		);
+		expect(send.callCount).to.equal(1);
+
+		await sync.onMaybeMissingHashes({
+			hashes: ["fresh"],
+			targets: [peerB.hashcode()],
+		});
+		expect(send.callCount).to.equal(2);
+		expect(send.secondCall.args[0].hashes).to.deep.equal(["fresh"]);
+		await sync.onMessage(
+			new ResponseMaybeSyncCapabilities({ hashes: ["fresh"] }),
+			{ from: peerB } as any,
+		);
+		expect((sync as any).pendingMaybeSyncResponseCount).to.equal(0);
+	});
+
+	it("aborts an in-flight target send on disconnect and fences later chunks", async () => {
+		let blockSend = true;
+		let markSendStarted!: () => void;
+		const sendStarted = new Promise<void>((resolve) => {
+			markSendStarted = resolve;
+		});
+		const send = sinon
+			.stub()
+			.callsFake(
+				async (
+					_message: RequestMaybeSync,
+					options: { signal?: AbortSignal },
+				) => {
+					if (!blockSend) {
+						return;
+					}
+					markSendStarted();
+					await new Promise<void>((_resolve, reject) => {
+						const rejectForAbort = () =>
+							reject(options.signal?.reason ?? new Error("aborted"));
+						if (options.signal?.aborted) {
+							rejectForAbort();
+						} else {
+							options.signal?.addEventListener("abort", rejectForAbort, {
+								once: true,
+							});
+						}
+					});
+				},
+			);
+		const sendRawExchangeHeads = sinon.stub().resolves(1);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sendRawExchangeHeads,
+			sync: { maxSimpleHashesPerMessage: 1 },
+		});
+
+		const staleDispatch = sync.onMaybeMissingHashes({
+			hashes: ["stale-0", "stale-1"],
+			targets: [peerB.hashcode()],
+		});
+		await sendStarted;
+		const staleSignal = send.firstCall.args[1].signal as AbortSignal;
+		sync.onPeerDisconnected(peerB);
+		await staleDispatch;
+		expect(staleSignal.aborted).to.equal(true);
+		expect(send.callCount).to.equal(1);
+		expect((sync as any).pendingMaybeSyncResponseCount).to.equal(0);
+
+		blockSend = false;
+		await sync.onMaybeMissingHashes({
+			hashes: ["fresh"],
+			targets: [peerB.hashcode()],
+		});
+		expect(send.callCount).to.equal(2);
+		await sync.onMessage(
+			new ResponseMaybeSyncCapabilities({ hashes: ["fresh"] }),
+			{ from: peerB } as any,
+		);
+	});
+
+	it("releases first-chunk authorization after an ordinary send failure", async () => {
+		const failure = new Error("transport failed");
+		const send = sinon.stub();
+		send.onFirstCall().rejects(failure);
+		send.onSecondCall().resolves();
+		const sendRawExchangeHeads = sinon.stub().resolves(1);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sendRawExchangeHeads,
+			sync: {
+				maxSimpleHashesPerMessage: 2,
+			},
+		});
+
+		let thrown: unknown;
+		try {
+			await sync.onMaybeMissingHashes({
+				hashes: ["h0", "h1", "h2", "h3", "h4"],
+				targets: [peerA.hashcode()],
+			});
+		} catch (error) {
+			thrown = error;
+		}
+		expect(thrown).to.equal(failure);
+		expect(send.callCount).to.equal(1);
+		expect((sync as any).pendingMaybeSyncResponseCount).to.equal(0);
+
+		await sync.onMaybeMissingHashes({
+			hashes: ["recovery"],
+			targets: [peerA.hashcode()],
+		});
+		expect(send.callCount).to.equal(2);
+		expect(send.secondCall.args[0].hashes).to.deep.equal(["recovery"]);
+		await sync.onMessage(
+			new ResponseMaybeSyncCapabilities({ hashes: ["recovery"] }),
+			{ from: peerA } as any,
+		);
+		expect(sendRawExchangeHeads.calledOnce).to.equal(true);
+		expect((sync as any).pendingMaybeSyncResponseCount).to.equal(0);
+	});
+
+	it("does not resend hashes that already retain matching authorization", async () => {
+		const send = sinon.stub().resolves();
+		const sendRawExchangeHeads = sinon.stub().resolves(1);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sendRawExchangeHeads,
+		});
+
+		await sync.onMaybeMissingHashes({
+			hashes: ["hash"],
+			targets: [peerA.hashcode()],
+		});
+		await sync.onMaybeMissingHashes({
+			hashes: ["hash"],
+			targets: [peerA.hashcode()],
+		});
+
+		expect(send.callCount).to.equal(1);
+		expect((sync as any).pendingMaybeSyncResponseCount).to.equal(1);
+		await sync.onMessage(
+			new ResponseMaybeSyncCapabilities({ hashes: ["hash"] }),
+			{ from: peerA } as any,
+		);
+	});
+
+	it("advances a 10,001-hash window as soon as a response frees capacity", async () => {
+		const send = sinon.stub().resolves();
+		const sendRawExchangeHeads = sinon.stub().resolves(1);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sendRawExchangeHeads,
+			sync: { maxSimpleHashesPerMessage: 10_000 },
+		});
+		const hashes = Array.from({ length: 10_001 }, (_, index) => `h${index}`);
+
+		const dispatch = sync.onMaybeMissingHashes({
+			hashes,
+			targets: [peerA.hashcode()],
+		});
+		await waitFor(() => send.callCount === 1);
+		await sync.onMessage(
+			new ResponseMaybeSyncCapabilities({ hashes: ["h0"] }),
+			{ from: peerA } as any,
+		);
+		await dispatch;
+
+		expect(send.callCount).to.equal(2);
+		expect(send.secondCall.args[0].hashes).to.deep.equal(["h10000"]);
+		await sync.onMessage(
+			new ResponseMaybeSyncCapabilities({
+				hashes: [...hashes.slice(1, 10_000), "h10000"],
+			}),
+			{ from: peerA } as any,
+		);
+		expect((sync as any).pendingMaybeSyncResponseCount).to.equal(0);
+	});
+
+	it("stops hash chunk dispatch after an in-flight send is aborted", async () => {
+		const profileEvents: any[] = [];
+		let releaseFirstSend!: () => void;
+		const firstSendReleased = new Promise<void>((resolve) => {
+			releaseFirstSend = resolve;
+		});
+		let markFirstSendStarted!: () => void;
+		const firstSendStarted = new Promise<void>((resolve) => {
+			markFirstSendStarted = resolve;
+		});
+		const send = sinon.stub().callsFake(async () => {
+			markFirstSendStarted();
+			await firstSendReleased;
+		});
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: { has: async () => false } as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sync: {
+				maxSimpleHashesPerMessage: 2,
+				profile: (event) => profileEvents.push(event),
+			},
+		});
 		const entries = new Map<string, any>();
 		for (let i = 0; i < 5; i++) {
 			entries.set(`h${i}`, { hash: `h${i}` });
 		}
+		const controller = new AbortController();
 
-		await sync.onMaybeMissingEntries({
-			entries: entries as any,
+		const dispatch = sync.onMaybeMissingEntries({
+			entries,
 			targets: ["p"],
+			signal: controller.signal,
+		});
+		await firstSendStarted;
+		controller.abort();
+		releaseFirstSend();
+		await dispatch;
+
+		expect(send.callCount).to.equal(1);
+		expect(send.firstCall.args[0]).to.be.instanceOf(RequestMaybeSync);
+		expect(send.firstCall.args[0].hashes).to.deep.equal(["h0", "h1"]);
+		expect(send.firstCall.args[1].signal).not.to.equal(controller.signal);
+		expect(send.firstCall.args[1].signal.aborted).to.equal(true);
+		const profile = profileEvents.find(
+			(event) => event.name === "simple.onMaybeMissingEntries",
+		);
+		expect(profile.messages).to.equal(1);
+		expect(profile.details?.cancelled).to.equal(true);
+	});
+
+	it("handles transport abort rejection during hash chunk dispatch", async () => {
+		let markSendStarted!: () => void;
+		const sendStarted = new Promise<void>((resolve) => {
+			markSendStarted = resolve;
+		});
+		const send = sinon
+			.stub()
+			.callsFake(
+				async (
+					_message: RequestMaybeSync,
+					options: { signal?: AbortSignal },
+				) => {
+					markSendStarted();
+					await new Promise<void>((_resolve, reject) => {
+						options.signal?.addEventListener(
+							"abort",
+							() => reject(options.signal?.reason),
+							{ once: true },
+						);
+					});
+				},
+			);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: { has: async () => false } as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sync: {
+				maxSimpleHashesPerMessage: 2,
+			},
+		});
+		const entries = new Map<string, any>();
+		for (let i = 0; i < 5; i++) {
+			entries.set(`h${i}`, { hash: `h${i}` });
+		}
+		const controller = new AbortController();
+
+		const dispatch = sync.onMaybeMissingEntries({
+			entries,
+			targets: ["p"],
+			signal: controller.signal,
+		});
+		await sendStarted;
+		controller.abort(new Error("cancelled"));
+		await dispatch;
+
+		expect(send.callCount).to.equal(1);
+		expect(send.firstCall.args[1].signal).not.to.equal(controller.signal);
+		expect(send.firstCall.args[1].signal.aborted).to.equal(true);
+	});
+
+	it("does not count an aborted TypeScript exchange-head send as sent", async () => {
+		const controller = new AbortController();
+		const failure = new Error("cancelled");
+		const send = sinon
+			.stub()
+			.callsFake(
+				async (_message: unknown, options: { signal?: AbortSignal }) => {
+					controller.abort(failure);
+					throw options.signal?.reason;
+				},
+			);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {
+				get: async (hash: string) => ({
+					hash,
+					size: 1,
+					meta: { gid: `gid-${hash}` },
+				}),
+				entryIndex: { getUniqueReferenceGids: () => [] },
+			} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
 		});
 
-		expect(send.callCount).to.equal(3);
-		const sentHashes = send.getCalls().map((call) => {
-			const message = call.args[0];
-			expect(call.args[1].priority).to.equal(SYNC_MESSAGE_PRIORITY);
-			expect(message).to.be.instanceOf(RequestMaybeSync);
-			return (message as RequestMaybeSync).hashes;
+		const shipped = await (sync as any).shipExchangeHeads(
+			["head-a"],
+			peerA,
+			false,
+			controller.signal,
+		);
+
+		expect(send.calledOnce).to.equal(true);
+		expect(shipped).to.deep.equal({ messages: 0, fused: false });
+	});
+
+	it("does not let a delayed simple response borrow a newer lifecycle signal", async () => {
+		const send = sinon.stub().resolves();
+		const sendRawExchangeHeads = sinon.stub().resolves(1);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sendRawExchangeHeads,
 		});
-		expect(sentHashes.flat()).to.deep.equal(["h0", "h1", "h2", "h3", "h4"]);
-		expect(sentHashes.map((x) => x.length)).to.deep.equal([2, 2, 1]);
+		const target = peerA.hashcode();
+		const oldController = new AbortController();
+
+		await sync.onMaybeMissingHashes({
+			hashes: ["old-hash"],
+			targets: [target],
+			signal: oldController.signal,
+		});
+		oldController.abort(new Error("old ownership lifecycle closed"));
+		expect(
+			await sync.onMessage(
+				new ResponseMaybeSyncCapabilities({ hashes: ["old-hash"] }),
+				{ from: peerA } as any,
+			),
+		).to.equal(true);
+		expect(sendRawExchangeHeads.called).to.equal(false);
+
+		const currentController = new AbortController();
+		await sync.onMaybeMissingHashes({
+			hashes: ["current-hash"],
+			targets: [target],
+			signal: currentController.signal,
+		});
+		expect(
+			await sync.onMessage(
+				new ResponseMaybeSyncCapabilities({
+					hashes: ["old-hash", "current-hash"],
+				}),
+				{ from: peerA } as any,
+			),
+		).to.equal(true);
+
+		expect(sendRawExchangeHeads.calledOnce).to.equal(true);
+		expect(sendRawExchangeHeads.firstCall.args[0]).to.deep.equal([
+			"current-hash",
+		]);
+		const responseSignal = sendRawExchangeHeads.firstCall.args[2].signal;
+		expect(responseSignal).not.to.equal(currentController.signal);
+		expect(responseSignal.aborted).to.equal(false);
+		currentController.abort();
+	});
+
+	it("cancels an in-flight simple response payload with its request signal", async () => {
+		const send = sinon.stub().resolves();
+		let responseStarted!: () => void;
+		const responseStart = new Promise<void>((resolve) => {
+			responseStarted = resolve;
+		});
+		let capturedSignal: AbortSignal | undefined;
+		const sendRawExchangeHeads = sinon
+			.stub()
+			.callsFake(
+				async (
+					_hashes: string[],
+					_targets: string[],
+					options?: { signal?: AbortSignal },
+				) => {
+					capturedSignal = options?.signal;
+					responseStarted();
+					await new Promise<void>((_resolve, reject) => {
+						const rejectForAbort = () =>
+							reject(capturedSignal?.reason ?? new Error("aborted"));
+						if (capturedSignal?.aborted) {
+							rejectForAbort();
+						} else {
+							capturedSignal?.addEventListener("abort", rejectForAbort, {
+								once: true,
+							});
+						}
+					});
+					return 1;
+				},
+			);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sendRawExchangeHeads,
+		});
+		const controller = new AbortController();
+
+		await sync.onMaybeMissingHashes({
+			hashes: ["hash"],
+			targets: [peerA.hashcode()],
+			signal: controller.signal,
+		});
+		const handling = sync.onMessage(
+			new ResponseMaybeSyncCapabilities({ hashes: ["hash"] }),
+			{ from: peerA } as any,
+		);
+		await responseStart;
+		expect(capturedSignal).not.to.equal(controller.signal);
+
+		controller.abort(new Error("ownership lifecycle closed"));
+		expect(await handling).to.equal(true);
+		expect(capturedSignal?.aborted).to.equal(true);
+		expect(sendRawExchangeHeads.calledOnce).to.equal(true);
+	});
+
+	it("rejects a delayed simple response after its peer disconnects", async () => {
+		const send = sinon.stub().resolves();
+		const sendRawExchangeHeads = sinon.stub().resolves(1);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sendRawExchangeHeads,
+		});
+
+		await sync.onMaybeMissingHashes({
+			hashes: ["old-hash"],
+			targets: [peerA.hashcode()],
+		});
+		sync.onPeerDisconnected(peerA);
+		expect(
+			await sync.onMessage(
+				new ResponseMaybeSyncCapabilities({ hashes: ["old-hash"] }),
+				{ from: peerA } as any,
+			),
+		).to.equal(true);
+
+		expect(sendRawExchangeHeads.called).to.equal(false);
+	});
+
+	it("does not let a blocked old open loop resume after close and reopen", async () => {
+		const clock = sinon.useFakeTimers({
+			now: 100_000,
+			toFake: ["Date", "setTimeout", "clearTimeout"],
+		});
+		let releaseHas!: (value: boolean) => void;
+		const blockedHas = new Promise<boolean>((resolve) => {
+			releaseHas = resolve;
+		});
+		let markHasStarted!: () => void;
+		const hasStarted = new Promise<void>((resolve) => {
+			markHasStarted = resolve;
+		});
+		const has = sinon.stub().callsFake(() => {
+			markHasStarted();
+			return blockedHas;
+		});
+		const send = sinon.stub().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: { has } as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+		});
+
+		try {
+			await sync.open();
+			await waitFor(() => (sync as any).syncMoreInterval !== undefined);
+			await sync.queueSync(["hash"], peerA, { skipCheck: true });
+			sync.syncInFlight.get(peerA.hashcode())!.get("hash")!.timestamp = 0;
+			send.resetHistory();
+
+			await clock.tickAsync(3_000);
+			await hasStarted;
+			await sync.close();
+			await sync.open();
+			releaseHas(false);
+			await Promise.resolve();
+			await clock.tickAsync(3_000);
+
+			expect(send.called).to.equal(false);
+			expect(has.calledOnce).to.equal(true);
+			expect(sync.pending).to.equal(0);
+		} finally {
+			releaseHas(false);
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("observes a background request rejection without an unhandled rejection", async () => {
+		const clock = sinon.useFakeTimers({
+			now: 100_000,
+			toFake: ["Date", "setTimeout", "clearTimeout"],
+		});
+		const send = sinon.stub();
+		send.onFirstCall().resolves();
+		send.onSecondCall().rejects(new Error("background transport failed"));
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: { has: async () => false } as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+		});
+		const unhandledRejections: unknown[] = [];
+		const onUnhandledRejection = (reason: unknown) => {
+			unhandledRejections.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandledRejection);
+
+		try {
+			await sync.open();
+			await waitFor(() => (sync as any).syncMoreInterval !== undefined);
+			await sync.queueSync(["hash"], peerA, { skipCheck: true });
+			sync.syncInFlight.get(peerA.hashcode())!.get("hash")!.timestamp = 0;
+
+			await clock.tickAsync(3_000);
+			await new Promise<void>((resolve) => setImmediate(resolve));
+
+			expect(send.callCount).to.equal(2);
+			expect(unhandledRejections).to.deep.equal([]);
+		} finally {
+			process.removeListener("unhandledRejection", onUnhandledRejection);
+			await sync.close();
+			clock.restore();
+		}
 	});
 
 	it("chunks coordinate maybe-sync requests", async () => {
@@ -279,6 +1100,11 @@ describe("sync-chunking", () => {
 			coordinateToHash: new Cache<string>({ max: 10 }),
 		});
 
+		await sync.onMaybeMissingHashes({
+			hashes: ["head-a"],
+			targets: [peerA.hashcode()],
+		});
+		send.resetHistory();
 		await sync.onMessage(
 			new ResponseMaybeSyncCapabilities({ hashes: ["head-a"] }),
 			{ from: peerA } as any,

--- a/packages/programs/data/shared-log/test/sync-raw-exchange-heads.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-raw-exchange-heads.spec.ts
@@ -215,11 +215,12 @@ describe("raw exchange-head sync", () => {
 			await waitForResolved(() =>
 				session.peers[0].dial(session.peers[1].getMultiaddrs()),
 			);
-			await (db2.log.syncronizer as SimpleSyncronizer<any>).queueSync(
+			await (
+				db1.log.syncronizer as SimpleSyncronizer<any>
+			).onMaybeMissingHashes({
 				hashes,
-				db1.node.identity.publicKey,
-				{ skipCheck: true },
-			);
+				targets: [db2.node.identity.publicKey.hashcode()],
+			});
 			await waitForResolved(
 				() => {
 					expect(db2.log.log.length).to.equal(entryCount);
@@ -3326,11 +3327,10 @@ describe("raw exchange-head sync", () => {
 		await waitForResolved(() =>
 			session.peers[0].dial(session.peers[1].getMultiaddrs()),
 		);
-		await (db2.log.syncronizer as SimpleSyncronizer<any>).queueSync(
+		await (db1.log.syncronizer as SimpleSyncronizer<any>).onMaybeMissingHashes({
 			hashes,
-			db1.node.identity.publicKey,
-			{ skipCheck: true },
-		);
+			targets: [db2.node.identity.publicKey.hashcode()],
+		});
 		await waitForResolved(
 			() => {
 				expect(db2.log.log.length).to.equal(entryCount);
@@ -3841,11 +3841,12 @@ describe("raw exchange-head sync", () => {
 			await waitForResolved(() =>
 				session.peers[0].dial(session.peers[1].getMultiaddrs()),
 			);
-			await (db2.log.syncronizer as SimpleSyncronizer<any>).queueSync(
+			await (
+				db1.log.syncronizer as SimpleSyncronizer<any>
+			).onMaybeMissingHashes({
 				hashes,
-				db1.node.identity.publicKey,
-				{ skipCheck: true },
-			);
+				targets: [db2.node.identity.publicKey.hashcode()],
+			});
 			await waitForResolved(
 				() => {
 					expect(db2.log.log.length).to.equal(entryCount);

--- a/packages/programs/data/shared-log/test/sync-raw-exchange-heads.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-raw-exchange-heads.spec.ts
@@ -13,6 +13,7 @@ import { RequestV0 } from "@peerbit/rpc";
 import { TestSession } from "@peerbit/test-utils";
 import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
+import pDefer from "p-defer";
 import sinon from "sinon";
 import { v4 as uuid } from "uuid";
 import {
@@ -2391,6 +2392,152 @@ describe("raw exchange-head sync", () => {
 				receivedEntryHashesSpy.restore();
 				receivedEntriesSpy.restore();
 				prepareMultihashSpy.restore();
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("materializes a raw batch hash when a waiter registers during the lower join", async () => {
+		const session = await TestSession.disconnected(2, {
+			indexer: (directory) => createRustIndexer(directory),
+		});
+
+		try {
+			const setup = {
+				domain: createReplicationDomainHash("u32"),
+				type: "u32" as const,
+				syncronizer: SimpleSyncronizer,
+				name: "u32-simple-raw",
+			};
+			const store = new EventStore<string, any>();
+			const baseArgs: any = {
+				setup,
+				nativeGraph: true,
+				nativeBackbone: { optional: false },
+				replicate: false,
+				sync: {
+					rawExchangeHeads: true,
+				},
+				timeUntilRoleMaturity: 0,
+			};
+			const source = await session.peers[0].open(store.clone(), {
+				args: {
+					...baseArgs,
+					keep: () => true,
+				},
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: baseArgs,
+			});
+
+			const entries: { hash: string; gid: string }[] = [];
+			for (let i = 0; i < 2; i++) {
+				const { entry } = await source.add(uuid(), {
+					meta: {
+						next: [],
+						gidSeed: new Uint8Array([i & 0xff, (i >>> 8) & 0xff]),
+					},
+				});
+				entries.push({ hash: entry.hash, gid: entry.meta.gid });
+			}
+
+			const sharedLog = target.log as any;
+			const backbone = sharedLog._nativeBackbone;
+			const targetHash = target.node.identity.publicKey.hashcode();
+			for (let i = 0; i < entries.length; i++) {
+				for (const [coordinateIndex, coordinate] of backbone
+					.getGidCoordinates(entries[i]!.gid, 2)
+					.entries()) {
+					const start = BigInt(String(coordinate));
+					backbone.putRange({
+						id: `target-late-waiter-${i}-${coordinateIndex}`,
+						hash: targetHash,
+						timestamp: 0,
+						start1: start,
+						end1: start + 1n,
+						start2: start,
+						end2: start + 1n,
+						width: 1,
+						mode: 0,
+					});
+				}
+			}
+
+			let message: RawExchangeHeadsMessage | undefined;
+			for await (const generated of createRawExchangeHeadsMessages(
+				source.log.log,
+				entries.map((entry) => entry.hash),
+			)) {
+				message = generated as RawExchangeHeadsMessage;
+				break;
+			}
+			expect(message).to.be.instanceOf(RawExchangeHeadsMessage);
+
+			const lowerJoinEntered = pDefer<void>();
+			const releaseLowerJoin = pDefer<void>();
+			const lowerLog = target.log.log as any;
+			const originalJoinPrepared =
+				lowerLog.joinPreparedAppendFactsBatch.bind(lowerLog);
+			const lowerJoinStub = sinon
+				.stub(lowerLog, "joinPreparedAppendFactsBatch")
+				.callsFake(async (...args: any[]) => {
+					lowerJoinEntered.resolve();
+					await releaseLowerJoin.promise;
+					return originalJoinPrepared(...args);
+				});
+			const prepareLazySpy = sinon.spy(Entry, "prepareMultihashBytesLazy");
+			const entryAddedHashSpy = sinon.spy(sharedLog, "onEntryAddedHash");
+			const entryAddedSpy = sinon.spy(
+				target.log.syncronizer as any,
+				"onEntryAdded",
+			);
+			const entryAddedHashesSpy = sinon.spy(
+				target.log.syncronizer as any,
+				"onEntryAddedHashes",
+			);
+			let waiterCallbackCount = 0;
+			let waiterEntry: Entry<any> | undefined;
+			try {
+				const receiving = target.log.onMessage(message!, {
+					from: source.node.identity.publicKey,
+				} as any);
+				await lowerJoinEntered.promise;
+
+				const waiterHash = entries[0]!.hash;
+				sharedLog._pendingIHave.set(waiterHash, {
+					requesting: new Set(["requester"]),
+					resetTimeout: () => {},
+					clear: () => {},
+					callback: (entry: Entry<any>) => {
+						waiterCallbackCount++;
+						waiterEntry = entry;
+					},
+				});
+				releaseLowerJoin.resolve();
+				await receiving;
+				await waitForResolved(() =>
+					expect(sharedLog._pendingIHave.has(waiterHash)).to.equal(false),
+				);
+
+				expect(waiterCallbackCount).to.equal(1);
+				expect(waiterEntry?.hash).to.equal(waiterHash);
+				expect(prepareLazySpy.callCount).to.equal(1);
+				expect(entryAddedHashSpy.callCount).to.equal(1);
+				expect(entryAddedHashSpy.firstCall.args[0]).to.equal(waiterHash);
+				expect(entryAddedSpy.callCount).to.equal(1);
+				expect(entryAddedSpy.firstCall.args[0]).to.equal(waiterEntry);
+				expect(entryAddedHashesSpy.callCount).to.equal(1);
+				expect(entryAddedHashesSpy.firstCall.args[0]).to.deep.equal([
+					entries[1]!.hash,
+				]);
+			} finally {
+				releaseLowerJoin.resolve();
+				entryAddedHashesSpy.restore();
+				entryAddedSpy.restore();
+				entryAddedHashSpy.restore();
+				prepareLazySpy.restore();
+				lowerJoinStub.restore();
 			}
 		} finally {
 			await session.stop();

--- a/packages/programs/data/shared-log/test/sync-session.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-session.spec.ts
@@ -2,7 +2,10 @@ import { Cache } from "@peerbit/cache";
 import { expect } from "chai";
 import sinon from "sinon";
 import { SharedLog } from "../src/index.js";
-import { SimpleSyncronizer } from "../src/sync/simple.js";
+import {
+	RequestMaybeSyncCoordinate,
+	SimpleSyncronizer,
+} from "../src/sync/simple.js";
 
 const emptyLog = {
 	has: async () => false,
@@ -84,15 +87,11 @@ describe("sync-repair-session", () => {
 			await clock.tickAsync(30);
 
 			expect(
-				send
-					.getCalls()
-					.filter((call) => call.args[2] === "rateless"),
+				send.getCalls().filter((call) => call.args[2] === "rateless"),
 			).to.have.length(2);
 			expect(simpleEntryBatches).to.have.length(1);
 			expect(maxActiveSimpleSends).to.equal(1);
-			const blockedState = internals._joinWarmupSendStateByTarget.get(
-				"target",
-			);
+			const blockedState = internals._joinWarmupSendStateByTarget.get("target");
 			expect(blockedState.pending).to.be.true;
 			expect([...blockedState.entries.keys()]).to.have.members([
 				"first",
@@ -207,12 +206,10 @@ describe("sync-repair-session", () => {
 				["target-a", 1],
 				["target-b", 1],
 			]);
-			expect(
-				internals._joinWarmupSendStateByTarget.get("target-a").pending,
-			).to.be.true;
-			expect(
-				internals._joinWarmupSendStateByTarget.get("target-b").pending,
-			).to.be.true;
+			expect(internals._joinWarmupSendStateByTarget.get("target-a").pending).to
+				.be.true;
+			expect(internals._joinWarmupSendStateByTarget.get("target-b").pending).to
+				.be.true;
 
 			for (const release of releaseFirstSimpleByTarget.values()) {
 				release();
@@ -304,9 +301,8 @@ describe("sync-repair-session", () => {
 			expect(pushedEntryBatches).to.deep.equal([
 				["still-missing", "newly-known"],
 			]);
-			expect(
-				internals._joinWarmupSendStateByTarget.get("target").pending,
-			).to.be.true;
+			expect(internals._joinWarmupSendStateByTarget.get("target").pending).to.be
+				.true;
 			internals.markEntriesKnownByPeer(["newly-known"], "target");
 
 			expect(releaseFirstSimple).to.be.a("function");
@@ -476,12 +472,12 @@ describe("sync-repair-session", () => {
 
 			expect(simpleEntryBatches).to.deep.equal([["old"]]);
 			expect(maxActiveSimpleSends).to.equal(1);
-			expect(
-				internals._joinWarmupGenerationByTarget.get("target"),
-			).to.equal(reconnectedGeneration);
-			expect(
-				[...internals._joinWarmupSendStateByTarget.get("target").entries.keys()],
-			).to.deep.equal(["new"]);
+			expect(internals._joinWarmupGenerationByTarget.get("target")).to.equal(
+				reconnectedGeneration,
+			);
+			expect([
+				...internals._joinWarmupSendStateByTarget.get("target").entries.keys(),
+			]).to.deep.equal(["new"]);
 
 			expect(releaseOldSimple).to.be.a("function");
 			releaseOldSimple!();
@@ -550,9 +546,8 @@ describe("sync-repair-session", () => {
 			);
 			await clock.tickAsync(20);
 			expect(simpleEntryBatches).to.have.length(1);
-			expect(
-				internals._joinWarmupSendStateByTarget.get("target").pending,
-			).to.be.true;
+			expect(internals._joinWarmupSendStateByTarget.get("target").pending).to.be
+				.true;
 			expect(rejectFirstSimple).to.be.a("function");
 			rejectFirstSimple!(new Error("injected warmup send failure"));
 			await clock.tickAsync(0);
@@ -564,8 +559,8 @@ describe("sync-repair-session", () => {
 			expect(
 				internals._repairMetrics["join-warmup"].simpleFallbackPasses,
 			).to.equal(2);
-			expect(internals._joinWarmupSendStateByTarget.get("target").running).to
-				.be.false;
+			expect(internals._joinWarmupSendStateByTarget.get("target").running).to.be
+				.false;
 			expect(internals._repairRetryTimers.size).to.equal(0);
 		} finally {
 			await clock.tickAsync(1_000);
@@ -601,15 +596,13 @@ describe("sync-repair-session", () => {
 				},
 			);
 			expect(
-				internals._joinWarmupScheduledRetriesByTarget.get("target")
-					.slotsByDelay.size,
+				internals._joinWarmupScheduledRetriesByTarget.get("target").slotsByDelay
+					.size,
 			).to.equal(6);
 			await clock.tickAsync(60_000);
 
 			expect(
-				send
-					.getCalls()
-					.filter((call) => call.args[2] === "rateless"),
+				send.getCalls().filter((call) => call.args[2] === "rateless"),
 			).to.have.length(1);
 			expect(
 				send.getCalls().filter((call) => call.args[2] === "simple"),
@@ -640,9 +633,7 @@ describe("sync-repair-session", () => {
 			peers: ["target"],
 		});
 		expect(
-			internals._repairSweepPendingPeersByMode
-				.get("join-warmup")
-				.has("target"),
+			internals._repairSweepPendingPeersByMode.get("join-warmup").has("target"),
 		).to.be.false;
 		expect(internals._repairSweepPendingModes.has("join-warmup")).to.be.false;
 
@@ -652,9 +643,7 @@ describe("sync-repair-session", () => {
 			peers: ["target"],
 		});
 		expect(
-			internals._repairSweepPendingPeersByMode
-				.get("join-warmup")
-				.has("target"),
+			internals._repairSweepPendingPeersByMode.get("join-warmup").has("target"),
 		).to.be.true;
 		expect(
 			internals._repairSweepJoinWarmupGenerationByTarget.get("target"),
@@ -690,10 +679,7 @@ describe("sync-repair-session", () => {
 					releasePlan = resolve;
 				});
 				return new Map([
-					[
-						"join-warmup",
-						new Map([["target", new Set(["entry"])]]),
-					],
+					["join-warmup", new Map([["target", new Set(["entry"])]])],
 				]);
 			});
 		sinon
@@ -701,15 +687,9 @@ describe("sync-repair-session", () => {
 			.resolves(new Set(["self", "target"]));
 		const dispatch = sinon.stub(internals, "dispatchMaybeMissingEntries");
 		const oldGeneration = internals.getJoinWarmupGeneration("target");
-		internals.markRepairSweepOptimisticPeer(
-			"gid",
-			"target",
-			oldGeneration,
-		);
+		internals.markRepairSweepOptimisticPeer("gid", "target", oldGeneration);
 		internals._repairSweepPendingModes.add("join-warmup");
-		internals._repairSweepPendingPeersByMode
-			.get("join-warmup")
-			.add("target");
+		internals._repairSweepPendingPeersByMode.get("join-warmup").add("target");
 		internals._repairSweepJoinWarmupGenerationByTarget.set(
 			"target",
 			oldGeneration,
@@ -720,22 +700,16 @@ describe("sync-repair-session", () => {
 		await planEntered;
 		internals.cancelJoinWarmupTarget("target");
 		const newGeneration = internals.getJoinWarmupGeneration("target");
-		internals.markRepairSweepOptimisticPeer(
-			"gid",
-			"target",
-			newGeneration,
-		);
+		internals.markRepairSweepOptimisticPeer("gid", "target", newGeneration);
 		releasePlan();
 		await running;
 
 		expect(dispatch.called).to.be.false;
+		expect(internals._joinWarmupGenerationByTarget.get("target")).to.equal(
+			newGeneration,
+		);
 		expect(
-			internals._joinWarmupGenerationByTarget.get("target"),
-		).to.equal(newGeneration);
-		expect(
-			internals._repairSweepOptimisticGidPeersPending
-				.get("gid")
-				.get("target"),
+			internals._repairSweepOptimisticGidPeersPending.get("gid").get("target"),
 		).to.deep.equal({ count: 1, generation: newGeneration });
 		expect(
 			internals._repairSweepOptimisticGidsByPeer.get("target"),
@@ -801,9 +775,9 @@ describe("sync-repair-session", () => {
 			await changing;
 			await clock.tickAsync(250);
 
-			expect(
-				internals._joinWarmupGenerationByTarget.get("target"),
-			).to.equal(newGeneration);
+			expect(internals._joinWarmupGenerationByTarget.get("target")).to.equal(
+				newGeneration,
+			);
 			expect(
 				internals._repairSweepPendingPeersByMode
 					.get("join-warmup")
@@ -875,7 +849,12 @@ describe("sync-repair-session", () => {
 		expect(sync.syncInFlightQueueInverted.get("p2")).to.deep.equal(
 			new Set([42n]),
 		);
-		expect(send.calledOnce).to.equal(true);
+		expect(send.calledTwice).to.equal(true);
+		expect(send.secondCall.args[0]).to.be.instanceOf(
+			RequestMaybeSyncCoordinate,
+		);
+		expect(send.secondCall.args[0].hashNumbers).to.deep.equal([42n]);
+		expect(send.secondCall.args[1].mode.to).to.deep.equal(["p2"]);
 	});
 
 	it("clears in-flight coordinate aliases when an entry is received by hash", () => {
@@ -1030,7 +1009,7 @@ describe("sync-repair-session", () => {
 			log: emptyLog as any,
 			coordinateToHash: new Cache<string>({ max: 10 }),
 			sync: {
-				maxConvergentTrackedHashes: 1,
+				maxConvergentTrackedHashes: 0.5,
 			},
 		});
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ overrides:
   patch-package@6>tmp: 0.2.7
   picomatch@2: 2.3.2
   picomatch@4: 4.0.5
-  postcss@8: 8.5.10
+  postcss@8: 8.5.22
   protobufjs: 7.6.5
   qs: 6.15.2
   rollup@4: 4.59.0
@@ -223,8 +223,8 @@ importers:
         specifier: ^9.0.3
         version: 9.1.0(@types/react@18.3.26)(react@18.3.1)
       react-router-dom:
-        specifier: ^6.30.4
-        version: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^7.18.1
+        version: 7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
@@ -4726,10 +4726,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@remix-run/router@1.23.3':
-    resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
-    engines: {node: '>=14.0.0'}
-
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -6498,6 +6494,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   core-js-compat@3.46.0:
     resolution: {integrity: sha512-p9hObIIEENxSV8xIu+V68JjSeARg6UVMG5mR+JEUguG3sI6MsiS1njz2jHmyJDvA+8jX/sytkBHup6kxhM9law==}
@@ -9343,8 +9343,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -10056,8 +10056,8 @@ packages:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.5.22:
+    resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
@@ -10288,18 +10288,22 @@ packages:
     resolution: {integrity: sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA==}
     engines: {node: '>=0.10.0'}
 
-  react-router-dom@6.30.4:
-    resolution: {integrity: sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==}
-    engines: {node: '>=14.0.0'}
+  react-router-dom@7.18.1:
+    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
+      react: '>=18'
+      react-dom: '>=18'
 
-  react-router@6.30.4:
-    resolution: {integrity: sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==}
-    engines: {node: '>=14.0.0'}
+  react-router@7.18.1:
+    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: '>=16.8'
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react-test-renderer@19.2.0:
     resolution: {integrity: sha512-zLCFMHFE9vy/w3AxO0zNxy6aAupnCuLSVOJYDe/Tp+ayGI1f2PLQsFVPANSD42gdSbmYx5oN+1VWDhcXtq7hAQ==}
@@ -10671,6 +10675,9 @@ packages:
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -14337,8 +14344,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.4
 
-  '@remix-run/router@1.23.3': {}
-
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rolldown/pluginutils@1.0.0-beta.47': {}
@@ -15396,7 +15401,7 @@ snapshots:
       '@vue/shared': 3.5.24
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.10
+      postcss: 8.5.22
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.24':
@@ -16360,6 +16365,8 @@ snapshots:
   convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
 
   core-js-compat@3.46.0:
     dependencies:
@@ -20107,7 +20114,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.16: {}
 
   nanoid@5.1.16: {}
 
@@ -20840,9 +20847,9 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.10:
+  postcss@8.5.22:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -21206,17 +21213,19 @@ snapshots:
 
   react-refresh@0.4.3: {}
 
-  react-router-dom@6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.30.4(react@18.3.1)
+      react-router: 7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  react-router@6.30.4(react@18.3.1):
+  react-router@7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.3
+      cookie: 1.1.1
       react: 18.3.1
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
 
   react-test-renderer@19.2.0(react@19.2.0):
     dependencies:
@@ -21708,6 +21717,8 @@ snapshots:
       - supports-color
 
   set-blocking@2.0.0: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -22808,7 +22819,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.10
+      postcss: 8.5.22
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -22824,7 +22835,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.10
+      postcss: 8.5.22
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
## Summary

- serialize and durably reconcile shared-log ownership mutations, including adaptive-to-fixed role replacement and checked-prune lifecycle fencing
- bound Simple sync authorization, delivery, resolver, coordinate, retry, and conflict-following work across disconnect and reopen races
- bound Rateless IBLT process admission, coded-symbol decoding, response inspection, active delivery, and fallback cleanup
- preserve active Rateless progress across overlapping repair batches and route oversized boundary sets directly through Rateless
- update PostCSS and React Router to patched releases after new advisories began failing the fail-closed security gate
- add deterministic race, exhaustion, malformed-input, quota-rollover, path-selection, and lifecycle regressions

## Why

Several synchronization and replication paths could retain, cancel, or multiply work across close/reopen, stalled transport, conflicting callers, malformed frames, delayed ownership planning, or adjacent repair batches. That could create stale ownership state, unbounded resource use, or failed recovery under adversarial and long-running workloads.

The dependency updates remove a high-severity PostCSS advisory and a React Router open-redirect advisory detected by the repository's live audit gate.

## Validation

- `pnpm run build`
- `pnpm run lint`
- full shared-log Node suite: **2240 passing, 10 pending**
- Simple sync focused suite: **69 passing**
- Rateless/cache focused suite: **66 passing**
- owner-mutation race regressions: **3 passing**
- deterministic 600-step Simple lifecycle/quota stress test
- exact three-size shared-log CI sweep: 512, 1024, and 16384 all pass in about 29.5-30.0s with delivered `StartSync`
- `pnpm --filter peerbit-org typecheck`
- `pnpm --filter peerbit-org test`
- `pnpm --filter peerbit-org build`
- `pnpm run release:security-gate`: zero production or full-audit findings
- frozen lockfile install and `git diff --check`
