### PR TITLE
fix(shared-log): harden checked prune handoffs

### DIFF
--- a/.changeset/safe-checked-prune-handoffs.md
+++ b/.changeset/safe-checked-prune-handoffs.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Make checked pruning use request-correlated, acknowledged handoffs with monotonic capability repair, exact-generation completion and resends, and responder ordering so stale responses, lost grants, and circular handoffs cannot authorize deletion. Revalidate block presence, responder leadership, requester ownership, and exact confirmation quorums at the final grant and deletion boundaries; use non-recursive removal and fail closed for legacy peers. Bound inbound correlated-prune vectors and hash lengths, retained missing-entry and retry state, and concurrent request/grant delivery; cap per-peer and global handler/callback work, keeping deadline-abandoned non-cancellable reads charged to their original lifecycle admission until they settle. Retire exhausted retries and debounce-only candidates instead of retaining entry state.

--- a/packages/programs/data/shared-log/benchmark/receive-prune.ts
+++ b/packages/programs/data/shared-log/benchmark/receive-prune.ts
@@ -4,7 +4,7 @@
 //   RECEIVE_PRUNE_COUNTS=100,1000,5000 RECEIVE_PRUNE_WARMUP_RUNS=1 RECEIVE_PRUNE_RUNS=1 BENCH_JSON=1 pnpm run benchmark:receive-prune
 //   RECEIVE_PRUNE_SCENARIOS=raw-receive-native,raw-receive-native-backbone,raw-receive-native-coordinate-wal,raw-receive-native-backbone-replicating,raw-receive-native-coordinate-wal-replicating,raw-receive-native-coordinate-wal-replicating-defer-verify,raw-receive-native-coordinate-wal-half,raw-receive-native-coordinate-wal-verify-prepare,raw-receive-native-backbone-select-all,raw-receive-native-coordinate-wal-select-all,raw-receive-native-backbone-select-half,raw-receive-native-coordinate-wal-select-half,raw-receive-native-backbone-drop,raw-receive-native-backbone-drop-verify-prepare,request-prune-native-confirm,request-prune-native-backbone-confirm RECEIVE_PRUNE_COUNTS=1000 pnpm run benchmark:receive-prune
 import { deserialize, serialize } from "@dao-xyz/borsh";
-import { DecryptedThing, PreHash } from "@peerbit/crypto";
+import { DecryptedThing, PreHash, randomBytes } from "@peerbit/crypto";
 import { create as createRustIndexer } from "@peerbit/indexer-rust";
 import {
 	NativeBackboneCoordinatePersistence,
@@ -24,7 +24,8 @@ import { performance } from "node:perf_hooks";
 import { v4 as uuid } from "uuid";
 import {
 	type RawExchangeHeadsMessage,
-	RequestIPrune,
+	RequestIPruneV2,
+	ResponseIPruneV2,
 	createRawExchangeHeadsMessages,
 } from "../src/exchange-heads.js";
 import { TransportMessage } from "../src/message.js";
@@ -719,23 +720,37 @@ const installFastLeaderWaits = (store: EventStore<string, any>) => {
 };
 
 const suppressPruneResponses = (store: EventStore<string, any>) => {
-	const debounced = (store.log as any).responseToPruneDebouncedFn;
-	const originalAdd = debounced.add;
-	debounced.add = () => undefined;
+	const rpc = (store.log as any).rpc;
+	const originalSend = rpc.send;
+	rpc.send = async (message: unknown, ...args: unknown[]) => {
+		if (message instanceof ResponseIPruneV2) {
+			return;
+		}
+		return originalSend.call(rpc, message, ...args);
+	};
 	return () => {
-		debounced.add = originalAdd;
+		rpc.send = originalSend;
 	};
 };
 
-const clearPendingIHaves = (store: EventStore<string, any>) => {
-	const pending = (store.log as any)._pendingIHave as Map<
-		string,
-		{ clear?: () => void }
-	>;
-	for (const value of pending.values()) {
-		value.clear?.();
+const createCheckedPruneRequestBatches = (hashes: string[]) => {
+	const requests = hashes.map((hash) => ({
+		hash,
+		requestId: randomBytes(32),
+	}));
+	const batches: RequestIPruneV2[] = [];
+	for (let offset = 0; offset < requests.length; offset += 1_024) {
+		batches.push(
+			new RequestIPruneV2({
+				requests: requests.slice(offset, offset + 1_024),
+			}),
+		);
 	}
-	pending.clear();
+	return batches;
+};
+
+const clearPendingIHaves = (store: EventStore<string, any>) => {
+	(store.log as any).clearPendingIHaves();
 };
 
 const runRequestPruneNativeConfirm = async (
@@ -755,13 +770,16 @@ const runRequestPruneNativeConfirm = async (
 			},
 		});
 		const hashes = await appendIndependentEntries(db, count);
+		const requestBatches = createCheckedPruneRequestBatches(hashes);
 		const restoreWaits = installFastLeaderWaits(db);
 		const restoreResponses = suppressPruneResponses(db);
 		try {
 			const started = performance.now();
-			await db.log.onMessage(new RequestIPrune({ hashes }), {
-				from: session.peers[0].identity.publicKey,
-			} as any);
+			for (const request of requestBatches) {
+				await db.log.onMessage(request, {
+					from: session.peers[0].identity.publicKey,
+				} as any);
+			}
 			const elapsed = performance.now() - started;
 
 			return {
@@ -790,6 +808,7 @@ const runRequestPrunePendingIHave = async (
 	count: number,
 	run: number,
 ): Promise<BenchRow> => {
+	const acceptedCount = Math.min(count, 1_024);
 	const session = await TestSession.disconnected(2, {
 		indexer: (directory) => createRustIndexer(directory),
 	});
@@ -802,21 +821,24 @@ const runRequestPrunePendingIHave = async (
 		const target = await session.peers[1].open(new EventStore<string, any>(), {
 			args: createOpenArgs(targetProfileEvents),
 		});
-		const hashes = await appendIndependentEntries(source, count);
+		const hashes = await appendIndependentEntries(source, acceptedCount);
+		const requestBatches = createCheckedPruneRequestBatches(hashes);
 
 		try {
 			const started = performance.now();
-			await target.log.onMessage(new RequestIPrune({ hashes }), {
-				from: source.node.identity.publicKey,
-			} as any);
+			for (const request of requestBatches) {
+				await target.log.onMessage(request, {
+					from: source.node.identity.publicKey,
+				} as any);
+			}
 			const elapsed = performance.now() - started;
 
 			return {
 				scenario: "request-prune-pending-ihave",
-				count,
+				count: acceptedCount,
 				run,
 				elapsedMs: elapsed,
-				opsPerSecond: (count / elapsed) * 1000,
+				opsPerSecond: (acceptedCount / elapsed) * 1000,
 				profile: summarizeProfileEvents(targetProfileEvents),
 			};
 		} finally {
@@ -1014,7 +1036,11 @@ for (const scenario of scenarios) {
 
 const aggregateRows = [...new Set(rows.map((row) => row.scenario))].flatMap(
 	(scenario) =>
-		counts.map((count) => {
+		[
+			...new Set(
+				rows.filter((row) => row.scenario === scenario).map((row) => row.count),
+			),
+		].map((count) => {
 			const samples = rows.filter(
 				(row) => row.scenario === scenario && row.count === count,
 			);

--- a/packages/programs/data/shared-log/src/checked-prune.ts
+++ b/packages/programs/data/shared-log/src/checked-prune.ts
@@ -11,8 +11,10 @@ export type CheckedPruneEntry<T, R extends "u32" | "u64"> =
 
 export type CheckedPrunePendingDelete = {
 	promise: DeferredPromise<void>;
+	background: boolean;
+	promoteToBackground: () => void;
 	clear: () => void;
-	resolve: (publicKeyHash: string) => Promise<void> | void;
+	resolve: (publicKeyHash: string, requestId: string) => Promise<void> | void;
 	reject(reason: any): Promise<void> | void;
 };
 
@@ -24,7 +26,6 @@ export type CheckedPruneRetryState<T, R extends "u32" | "u64"> = {
 };
 
 type CheckedPruneSessionPhase =
-	| "candidate"
 	| "requested"
 	| "confirmed"
 	| "removing"
@@ -45,15 +46,22 @@ type CheckedPruneSession<T, R extends "u32" | "u64"> = {
 export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 	readonly pendingDeletes = new Map<string, CheckedPrunePendingDelete>();
 	readonly requestIPruneSent = new Map<string, Set<string>>();
+	readonly requestIds = new Map<string, Map<string, string>>();
 	readonly responseReplicatorSet = new Map<string, Set<string>>();
+	readonly confirmationIds = new Map<string, Map<string, string>>();
 	readonly retries = new Map<string, CheckedPruneRetryState<T, R>>();
+	private readonly autoResendClaims = new Map<
+		string,
+		Map<string, { pending: CheckedPrunePendingDelete; requestId: string }>
+	>();
+	private readonly grantSends = new Map<string, Set<Promise<void>>>();
 	private readonly sessions = new Map<string, CheckedPruneSession<T, R>>();
 
 	private getOrCreateSession(hash: string): CheckedPruneSession<T, R> {
 		let session = this.sessions.get(hash);
 		if (!session) {
 			session = {
-				phase: "candidate",
+				phase: "requested",
 				contacted: new Set(),
 				confirmed: new Set(),
 			};
@@ -89,17 +97,6 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 		this.sessions.delete(hash);
 	}
 
-	trackCandidate(
-		hash: string,
-		entry: CheckedPruneEntry<T, R>,
-		leaders: CheckedPruneLeaderMap | Set<string>,
-	) {
-		const session = this.remember(hash, entry, leaders);
-		if (!this.hasActiveWork(hash)) {
-			session.phase = "candidate";
-		}
-	}
-
 	hasActiveWork(hash: string) {
 		return (
 			this.pendingDeletes.has(hash) ||
@@ -123,9 +120,18 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 		entry: CheckedPruneEntry<T, R>,
 		leaders: CheckedPruneLeaderMap | Set<string>,
 	) {
+		// A new request id starts a new authorization generation. No peer or
+		// confirmation from an older generation may survive into it.
+		this.requestIPruneSent.delete(hash);
+		this.requestIds.delete(hash);
+		this.responseReplicatorSet.delete(hash);
+		this.confirmationIds.delete(hash);
+		this.autoResendClaims.delete(hash);
 		this.pendingDeletes.set(hash, pending);
 		const session = this.remember(hash, entry, leaders);
 		session.pending = pending;
+		session.contacted.clear();
+		session.confirmed.clear();
 		session.phase = "requested";
 	}
 
@@ -149,6 +155,13 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 		return this.retries.has(hash);
 	}
 
+	isCurrentRetry(hash: string, state: CheckedPruneRetryState<T, R>) {
+		return (
+			this.retries.get(hash) === state &&
+			this.sessions.get(hash)?.retry === state
+		);
+	}
+
 	setRetry(hash: string, state: CheckedPruneRetryState<T, R>) {
 		this.retries.set(hash, state);
 		const session = this.remember(hash, state.entry, state.leaders);
@@ -156,8 +169,11 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 		session.phase = "retrying";
 	}
 
-	clearRetry(hash: string) {
+	clearRetry(hash: string, expected?: CheckedPruneRetryState<T, R>) {
 		const state = this.retries.get(hash);
+		if (expected && state !== expected) {
+			return false;
+		}
 		if (state?.timer) {
 			clearTimeout(state.timer);
 		}
@@ -167,6 +183,7 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 			session.retry = undefined;
 		}
 		this.deleteSessionIfIdle(hash);
+		return true;
 	}
 
 	clearRetryTimer(hash: string) {
@@ -178,36 +195,137 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 		return state;
 	}
 
-	addRequestSent(hash: string, peer: string) {
+	isCurrentRequest(hash: string, pending: CheckedPrunePendingDelete) {
+		const session = this.sessions.get(hash);
+		return (
+			this.pendingDeletes.get(hash) === pending && session?.pending === pending
+		);
+	}
+
+	promoteToBackground(hash: string, pending: CheckedPrunePendingDelete) {
+		if (!this.isCurrentRequest(hash, pending)) {
+			return false;
+		}
+		pending.promoteToBackground();
+		return true;
+	}
+
+	isCurrentRequestForPeer(
+		hash: string,
+		pending: CheckedPrunePendingDelete,
+		peer: string,
+		requestId: string,
+	) {
+		return (
+			this.isCurrentRequest(hash, pending) &&
+			this.requestIPruneSent.get(hash)?.has(peer) === true &&
+			this.requestIds.get(hash)?.get(peer) === requestId
+		);
+	}
+
+	addRequestSent(hash: string, peer: string, requestId: string) {
+		const pending = this.pendingDeletes.get(hash);
+		if (!pending || !this.isCurrentRequest(hash, pending)) {
+			return false;
+		}
+		const previousRequestId = this.requestIds.get(hash)?.get(peer);
+		if (previousRequestId != null && previousRequestId !== requestId) {
+			// Changing the contact generation intrinsically revokes any grant
+			// attached to the previous id. Callers must not be able to preserve an
+			// authorization accidentally by overwriting only the request id.
+			this.removeConfirmedReplicator(hash, peer);
+			this.removeAutoResendClaim(hash, peer);
+		}
 		let set = this.requestIPruneSent.get(hash);
 		if (!set) {
 			set = new Set();
 			this.requestIPruneSent.set(hash, set);
 		}
 		set.add(peer);
+		let ids = this.requestIds.get(hash);
+		if (!ids) {
+			ids = new Map();
+			this.requestIds.set(hash, ids);
+		}
+		ids.set(peer, requestId);
 		const session = this.getOrCreateSession(hash);
 		session.contacted.add(peer);
-		if (session.phase === "candidate") {
-			session.phase = "requested";
+		session.phase = "requested";
+		return true;
+	}
+
+	claimRequestSent(
+		hash: string,
+		peer: string,
+		pending: CheckedPrunePendingDelete,
+		requestId: string,
+	) {
+		if (
+			!this.isCurrentRequest(hash, pending) ||
+			this.requestIPruneSent.get(hash)?.has(peer) === true ||
+			this.requestIds.get(hash)?.has(peer) === true
+		) {
+			return false;
+		}
+		return this.addRequestSent(hash, peer, requestId);
+	}
+
+	claimAutoResend(
+		hash: string,
+		peer: string,
+		pending: CheckedPrunePendingDelete,
+		requestId: string,
+	) {
+		if (
+			!this.isCurrentRequestForPeer(hash, pending, peer, requestId) ||
+			!pending.background
+		) {
+			return false;
+		}
+		let claims = this.autoResendClaims.get(hash);
+		if (!claims) {
+			claims = new Map();
+			this.autoResendClaims.set(hash, claims);
+		}
+		const existing = claims.get(peer);
+		if (existing?.pending === pending && existing.requestId === requestId) {
+			return false;
+		}
+		claims.set(peer, { pending, requestId });
+		return true;
+	}
+
+	private removeAutoResendClaim(hash: string, peer: string) {
+		const claims = this.autoResendClaims.get(hash);
+		claims?.delete(peer);
+		if (claims?.size === 0) {
+			this.autoResendClaims.delete(hash);
 		}
 	}
 
 	removeRequestSent(hash: string, peer?: string) {
 		if (!peer) {
 			this.requestIPruneSent.delete(hash);
+			this.requestIds.delete(hash);
+			this.autoResendClaims.delete(hash);
+			this.clearConfirmedReplicators(hash);
 			const session = this.sessions.get(hash);
 			session?.contacted.clear();
 			this.deleteSessionIfIdle(hash);
 			return;
 		}
 		const set = this.requestIPruneSent.get(hash);
-		if (!set) {
-			return;
+		set?.delete(peer);
+		this.removeConfirmedReplicator(hash, peer);
+		this.removeAutoResendClaim(hash, peer);
+		const ids = this.requestIds.get(hash);
+		ids?.delete(peer);
+		if (ids?.size === 0) {
+			this.requestIds.delete(hash);
 		}
-		set.delete(peer);
 		const session = this.sessions.get(hash);
 		session?.contacted.delete(peer);
-		if (set.size === 0) {
+		if (set?.size === 0) {
 			this.requestIPruneSent.delete(hash);
 			this.deleteSessionIfIdle(hash);
 		}
@@ -222,13 +340,27 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 		}
 	}
 
-	addConfirmedReplicator(hash: string, peer: string) {
+	addConfirmedReplicator(
+		hash: string,
+		peer: string,
+		pending: CheckedPrunePendingDelete,
+		requestId: string,
+	) {
+		if (!this.isCurrentRequestForPeer(hash, pending, peer, requestId)) {
+			return undefined;
+		}
 		let set = this.responseReplicatorSet.get(hash);
 		if (!set) {
 			set = new Set();
 			this.responseReplicatorSet.set(hash, set);
 		}
 		set.add(peer);
+		let ids = this.confirmationIds.get(hash);
+		if (!ids) {
+			ids = new Map();
+			this.confirmationIds.set(hash, ids);
+		}
+		ids.set(peer, requestId);
 		const session = this.getOrCreateSession(hash);
 		session.confirmed.add(peer);
 		session.phase = "confirmed";
@@ -241,6 +373,11 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 			return;
 		}
 		set.delete(peer);
+		const ids = this.confirmationIds.get(hash);
+		ids?.delete(peer);
+		if (ids?.size === 0) {
+			this.confirmationIds.delete(hash);
+		}
 		const session = this.sessions.get(hash);
 		session?.confirmed.delete(peer);
 		if (set.size === 0) {
@@ -260,6 +397,7 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 
 	clearConfirmedReplicators(hash: string) {
 		this.responseReplicatorSet.delete(hash);
+		this.confirmationIds.delete(hash);
 		const session = this.sessions.get(hash);
 		session?.confirmed.clear();
 		this.deleteSessionIfIdle(hash);
@@ -278,8 +416,52 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 		return this.responseReplicatorSet.get(hash);
 	}
 
+	getConfirmedRequestId(hash: string, peer: string) {
+		return this.confirmationIds.get(hash)?.get(peer);
+	}
+
 	getContactedReplicators(hash: string) {
 		return this.requestIPruneSent.get(hash);
+	}
+
+	getRequestId(hash: string, peer: string) {
+		return this.requestIds.get(hash)?.get(peer);
+	}
+
+	trackGrantSend(hashes: Iterable<string>, send: Promise<void>) {
+		const uniqueHashes = [...new Set(hashes)];
+		const observed = send.then(
+			() => undefined,
+			() => undefined,
+		);
+		for (const hash of uniqueHashes) {
+			let sends = this.grantSends.get(hash);
+			if (!sends) {
+				sends = new Set();
+				this.grantSends.set(hash, sends);
+			}
+			sends.add(observed);
+		}
+		void observed.finally(() => {
+			for (const hash of uniqueHashes) {
+				const sends = this.grantSends.get(hash);
+				sends?.delete(observed);
+				if (sends?.size === 0) {
+					this.grantSends.delete(hash);
+				}
+			}
+		});
+		return observed;
+	}
+
+	async waitForGrantSends(hash?: string) {
+		if (hash) {
+			await Promise.all(this.grantSends.get(hash) ?? []);
+			return;
+		}
+		await Promise.all(
+			[...this.grantSends.values()].flatMap((sends) => [...sends]),
+		);
 	}
 
 	markRemoving(hash: string) {
@@ -287,16 +469,23 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 		session.phase = "removing";
 	}
 
-	markDone(hash: string) {
+	markDone(hash: string, pending: CheckedPrunePendingDelete) {
+		if (!this.isCurrentRequest(hash, pending)) {
+			return false;
+		}
 		const session = this.sessions.get(hash);
 		if (session) {
 			session.phase = "done";
 		}
 		this.pendingDeletes.delete(hash);
 		this.requestIPruneSent.delete(hash);
+		this.requestIds.delete(hash);
 		this.responseReplicatorSet.delete(hash);
+		this.confirmationIds.delete(hash);
+		this.autoResendClaims.delete(hash);
 		this.clearRetry(hash);
 		this.sessions.delete(hash);
+		return true;
 	}
 
 	markCancelled(hash: string, options?: { preserveRetry?: boolean }) {
@@ -312,7 +501,10 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 			}
 		}
 		this.requestIPruneSent.delete(hash);
+		this.requestIds.delete(hash);
 		this.responseReplicatorSet.delete(hash);
+		this.confirmationIds.delete(hash);
+		this.autoResendClaims.delete(hash);
 		if (!options?.preserveRetry) {
 			this.clearRetry(hash);
 		}
@@ -320,8 +512,42 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 	}
 
 	cleanupPeer(peer: string) {
+		const affected = new Map<
+			string,
+			{
+				hash: string;
+				pending: CheckedPrunePendingDelete;
+				entry: CheckedPruneEntry<T, R>;
+				leaders: CheckedPruneLeaderMap | Set<string>;
+			}
+		>();
+		for (const [hash, peers] of this.requestIPruneSent) {
+			if (!peers.has(peer)) {
+				continue;
+			}
+			const session = this.sessions.get(hash);
+			const pending = this.pendingDeletes.get(hash);
+			if (
+				pending &&
+				session?.pending === pending &&
+				session.entry &&
+				session.leaders
+			) {
+				affected.set(hash, {
+					hash,
+					pending,
+					entry: session.entry,
+					leaders: session.leaders,
+				});
+			}
+		}
 		for (const [hash, peers] of this.requestIPruneSent) {
 			peers.delete(peer);
+			const ids = this.requestIds.get(hash);
+			ids?.delete(peer);
+			if (ids?.size === 0) {
+				this.requestIds.delete(hash);
+			}
 			this.sessions.get(hash)?.contacted.delete(peer);
 			if (peers.size === 0) {
 				this.requestIPruneSent.delete(hash);
@@ -331,12 +557,24 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 
 		for (const [hash, peers] of this.responseReplicatorSet) {
 			peers.delete(peer);
+			const ids = this.confirmationIds.get(hash);
+			ids?.delete(peer);
+			if (ids?.size === 0) {
+				this.confirmationIds.delete(hash);
+			}
 			this.sessions.get(hash)?.confirmed.delete(peer);
 			if (peers.size === 0) {
 				this.responseReplicatorSet.delete(hash);
 				this.deleteSessionIfIdle(hash);
 			}
 		}
+		for (const [hash, claims] of this.autoResendClaims) {
+			claims.delete(peer);
+			if (claims.size === 0) {
+				this.autoResendClaims.delete(hash);
+			}
+		}
+		return [...affected.values()];
 	}
 
 	close() {
@@ -351,7 +589,10 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 		}
 		this.pendingDeletes.clear();
 		this.requestIPruneSent.clear();
+		this.requestIds.clear();
 		this.responseReplicatorSet.clear();
+		this.confirmationIds.clear();
+		this.autoResendClaims.clear();
 		this.retries.clear();
 		this.sessions.clear();
 	}

--- a/packages/programs/data/shared-log/src/exchange-heads.ts
+++ b/packages/programs/data/shared-log/src/exchange-heads.ts
@@ -349,10 +349,19 @@ export const EXCHANGE_HEADS_REPAIR_HINT = 1;
 export const SYNC_CAPABILITY_RAW_EXCHANGE_HEADS = 1;
 
 /**
+ * Capability bit: the peer supports request-correlated checked-prune handoffs.
+ *
+ * A correlated response can authorize deletion only for the exact random
+ * request id that is still active locally. Peers that do not advertise this
+ * capability are excluded from checked-prune confirmation quorums.
+ */
+export const SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF = 1 << 1;
+
+/**
  * One-shot capability advertisement, sent to a peer when it (or we) subscribe
- * to the program topic and `sync.rawExchangeHeads` is enabled. Peers that do
- * not know this message drop it as an unknown variant; peers that never
- * advertise keep receiving the plain `ExchangeHeadsMessage` path.
+ * to the program topic. Peers that do not know this message drop it as an
+ * unknown variant. Optional protocol paths remain disabled until their
+ * corresponding bit is observed.
  */
 @variant([0, 10])
 export class SyncCapabilitiesMessage extends TransportMessage {
@@ -1103,6 +1112,66 @@ export class ResponseIPrune extends TransportMessage {
 	constructor(props: { hashes: string[] }) {
 		super();
 		this.hashes = props.hashes;
+	}
+}
+
+@variant(0)
+export class CheckedPruneRequest {
+	@field({ type: "string" })
+	hash: string;
+
+	@field({ type: fixedArray("u8", 32) })
+	requestId: Uint8Array;
+
+	constructor(props: { hash: string; requestId: Uint8Array }) {
+		this.hash = props.hash;
+		this.requestId = props.requestId;
+	}
+}
+
+/**
+ * Checked-prune request whose random id distinguishes this attempt from every
+ * earlier or later attempt for the same entry and peer.
+ */
+@variant([0, 11])
+export class RequestIPruneV2 extends TransportMessage {
+	@field({ type: vec(CheckedPruneRequest) })
+	requests: CheckedPruneRequest[];
+
+	constructor(props: {
+		requests: Array<
+			CheckedPruneRequest | { hash: string; requestId: Uint8Array }
+		>;
+	}) {
+		super();
+		this.requests = props.requests.map((request) =>
+			request instanceof CheckedPruneRequest
+				? request
+				: new CheckedPruneRequest(request),
+		);
+	}
+}
+
+/**
+ * Exact echo of the checked-prune attempts for which this responder currently
+ * accepts responsibility.
+ */
+@variant([0, 12])
+export class ResponseIPruneV2 extends TransportMessage {
+	@field({ type: vec(CheckedPruneRequest) })
+	requests: CheckedPruneRequest[];
+
+	constructor(props: {
+		requests: Array<
+			CheckedPruneRequest | { hash: string; requestId: Uint8Array }
+		>;
+	}) {
+		super();
+		this.requests = props.requests.map((request) =>
+			request instanceof CheckedPruneRequest
+				? request
+				: new CheckedPruneRequest(request),
+		);
 	}
 }
 

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -19,7 +19,9 @@ import {
 	Ed25519PublicKey,
 	PublicSignKey,
 	Secp256k1PublicKey,
+	fromHexString,
 	getPublicKeyFromPeerId,
+	randomBytes,
 	sha256Base64Sync,
 	sha256Sync,
 	toHexString,
@@ -119,7 +121,6 @@ import {
 import {
 	AbortError,
 	TimeoutError,
-	debounceAccumulator,
 	debounceFixedInterval,
 	waitFor,
 } from "@peerbit/time";
@@ -131,6 +132,7 @@ import {
 	CheckedPruneCoordinator,
 	type CheckedPruneEntry,
 	type CheckedPruneLeaderMap,
+	type CheckedPrunePendingDelete,
 	type CheckedPruneRetryState,
 } from "./checked-prune.js";
 import { type CPUUsage, CPUUsageIntervalLag } from "./cpu.js";
@@ -149,7 +151,10 @@ import {
 	RawExchangeHeadsMessage,
 	type RawReceiveHashSelection,
 	RequestIPrune,
+	RequestIPruneV2,
 	ResponseIPrune,
+	ResponseIPruneV2,
+	SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
 	SYNC_CAPABILITY_RAW_EXCHANGE_HEADS,
 	StashBackedRawExchangeHeadsMessage,
 	SyncCapabilitiesMessage,
@@ -282,9 +287,28 @@ const mapMaybePromise = <T, R>(
 type PendingIHave<T> = {
 	resetTimeout: () => void;
 	requesting: Set<string>;
+	requestIdsByPeer?: Map<string, Uint8Array>;
 	clear: () => void;
-	callback: (entry: Entry<T>) => MaybePromise<void>;
+	callbackActive?: boolean;
+	callbackController?: AbortController;
+	callback: (
+		entry: Entry<T>,
+		work: PendingIHaveCallbackWork,
+	) => MaybePromise<void>;
 	expiresAt?: number;
+};
+
+type PendingIHaveCallbackWork = {
+	deadline: number;
+	signal: AbortSignal;
+	isActive: () => boolean;
+	remainingMs: () => number;
+	settlingWork: CheckedPruneSettlingWork;
+};
+
+type CheckedPruneGrantRequest = {
+	hash: string;
+	requestId: Uint8Array;
 };
 
 type PeerReceiveLeaseBucket = {
@@ -295,6 +319,77 @@ type PeerReceiveLeaseBucket = {
 type PeerReceiveLeaseState = {
 	current: PeerReceiveLeaseBucket;
 	activeBuckets: Set<PeerReceiveLeaseBucket>;
+};
+
+type CheckedPruneRequestWorkAdmissionState = {
+	replicationLifecycleController: AbortController;
+	activeByPeer: Map<string, object>;
+};
+
+type PendingIHaveCallbackWorkAdmissionState = {
+	replicationLifecycleController: AbortController;
+	active: number;
+};
+
+type CheckedPruneSettlingWork = {
+	track: (work: PromiseLike<unknown>) => void;
+};
+
+/**
+ * Tracks operations whose result can be abandoned at a protocol deadline but
+ * whose underlying implementation cannot necessarily be cancelled.
+ *
+ * The admission lease is released only after the tracker is sealed and every
+ * operation admitted before that boundary has actually settled. A tracker is
+ * captured by one lifecycle generation, so close/reopen can retire the old
+ * admission map without waiting for a permanently stuck storage implementation.
+ */
+class CheckedPruneSettlingWorkTracker implements CheckedPruneSettlingWork {
+	private pending = 0;
+	private sealed = false;
+	private readonly settled = pDefer<void>();
+
+	track(work: PromiseLike<unknown>): void {
+		// A tracked outer operation may start a nested planner check after the
+		// protocol deadline sealed the lease. Accept that nested work while the
+		// outer operation still keeps the tracker non-empty; once fully drained,
+		// starting more work would violate the admission boundary.
+		if (this.sealed && this.pending === 0) {
+			throw new Error("Cannot add checked-prune work after admission release");
+		}
+		this.pending++;
+		void Promise.resolve(work).then(
+			() => this.finish(),
+			() => this.finish(),
+		);
+	}
+
+	sealAndWait(): Promise<void> {
+		this.sealed = true;
+		if (this.pending === 0) {
+			this.settled.resolve();
+		}
+		return this.settled.promise;
+	}
+
+	private finish(): void {
+		this.pending = Math.max(0, this.pending - 1);
+		if (this.sealed && this.pending === 0) {
+			this.settled.resolve();
+		}
+	}
+}
+
+type CheckedPruneRequestWorkLease = {
+	settlingWork: CheckedPruneSettlingWorkTracker;
+	release: () => void;
+};
+
+type SyncCapabilityRepairState = {
+	subscriptionEpoch: object;
+	attempts: number;
+	controller: AbortController;
+	timer?: ReturnType<typeof setTimeout>;
 };
 
 const toLocalPublicSignKey = (
@@ -1623,6 +1718,9 @@ type LeaderSelectionOptions<R extends "u32" | "u64"> = {
 type WaitForReplicatorsOptions<R extends "u32" | "u64"> =
 	LeaderSelectionOptions<R> & {
 		timeout?: number;
+		signal?: AbortSignal;
+		drainInFlightChecks?: boolean;
+		settlingWork?: CheckedPruneSettlingWork;
 	};
 
 type WaitForReplicator = { key: string; replicator: boolean };
@@ -2706,6 +2804,145 @@ const CHECKED_PRUNE_RESEND_INTERVAL_MAX_MS = 5_000;
 const CHECKED_PRUNE_BACKGROUND_TIMEOUT_MIN_MS = 120_000;
 const CHECKED_PRUNE_RETRY_MAX_ATTEMPTS = 3;
 const CHECKED_PRUNE_RETRY_MAX_DELAY_MS = 30_000;
+const CHECKED_PRUNE_REQUEST_ID_BYTES = 32;
+const CHECKED_PRUNE_MAX_REQUESTS_PER_MESSAGE = 1_024;
+const CHECKED_PRUNE_MAX_HASH_CODE_UNITS = 256;
+const CHECKED_PRUNE_MAX_CONCURRENT_REQUEST_SENDS = 4;
+const CHECKED_PRUNE_MAX_CONCURRENT_GRANT_SENDS = 4;
+const CHECKED_PRUNE_MAX_ACTIVE_REQUEST_HANDLERS = 4;
+const CHECKED_PRUNE_REQUEST_HANDLER_MAX_WAIT_MS = 5_000;
+const CHECKED_PRUNE_MAX_PENDING_IHAVE_PER_PEER = 1_024;
+const CHECKED_PRUNE_MAX_PENDING_IHAVE_GLOBAL = 4_096;
+const CHECKED_PRUNE_MAX_ACTIVE_PENDING_IHAVE_CALLBACKS = 4;
+const CHECKED_PRUNE_PENDING_IHAVE_CALLBACK_MAX_WAIT_MS = 5_000;
+const SYNC_CAPABILITY_REPAIR_MIN_DELAY_MS = 250;
+const SYNC_CAPABILITY_REPAIR_MAX_DELAY_MS = 30_000;
+
+type AbortableQueueTask<T> = {
+	run: () => MaybePromise<T>;
+	resolve: (value: T | PromiseLike<T>) => void;
+	reject: (reason?: unknown) => void;
+	signal?: AbortSignal;
+	onAbort?: () => void;
+	started: boolean;
+	settled: boolean;
+};
+
+class AbortableFixedConcurrencyQueue {
+	private active = 0;
+	private readonly pending: AbortableQueueTask<unknown>[] = [];
+	private readonly idleWaiters = new Set<() => void>();
+
+	constructor(private readonly concurrency: number) {}
+
+	get size() {
+		return this.pending.length;
+	}
+
+	get running() {
+		return this.active;
+	}
+
+	add<T>(run: () => MaybePromise<T>, signal?: AbortSignal): Promise<T> {
+		return new Promise<T>((resolve, reject) => {
+			const task: AbortableQueueTask<T> = {
+				run,
+				resolve,
+				reject,
+				signal,
+				started: false,
+				settled: false,
+			};
+			const rejectOnce = (reason?: unknown) => {
+				if (task.settled) {
+					return;
+				}
+				task.settled = true;
+				task.reject(reason);
+			};
+			task.onAbort = () => {
+				if (task.started) {
+					// The running operation owns the signal and must settle before
+					// its caller can release a checked-prune ordering barrier.
+					return;
+				}
+				const index = this.pending.indexOf(task as AbortableQueueTask<unknown>);
+				if (index >= 0) {
+					this.pending.splice(index, 1);
+				}
+				task.signal?.removeEventListener("abort", task.onAbort!);
+				rejectOnce(task.signal?.reason ?? new AbortError());
+				this.drain();
+				this.resolveIdleIfNeeded();
+			};
+			if (signal?.aborted) {
+				task.onAbort();
+				return;
+			}
+			signal?.addEventListener("abort", task.onAbort, { once: true });
+			this.pending.push(task as AbortableQueueTask<unknown>);
+			this.drain();
+		});
+	}
+
+	onIdle(): Promise<void> {
+		if (this.active === 0 && this.pending.length === 0) {
+			return Promise.resolve();
+		}
+		return new Promise((resolve) => this.idleWaiters.add(resolve));
+	}
+
+	private drain() {
+		while (this.active < this.concurrency && this.pending.length > 0) {
+			const task = this.pending.shift()!;
+			if (task.signal?.aborted) {
+				task.onAbort?.();
+				continue;
+			}
+			task.started = true;
+			this.active++;
+			void Promise.resolve()
+				.then(task.run)
+				.then(
+					(value) => {
+						if (!task.settled) {
+							task.settled = true;
+							task.resolve(value);
+						}
+					},
+					(error) => {
+						if (!task.settled) {
+							task.settled = true;
+							task.reject(error);
+						}
+					},
+				)
+				.finally(() => {
+					task.signal?.removeEventListener("abort", task.onAbort!);
+					this.active--;
+					this.drain();
+					this.resolveIdleIfNeeded();
+				});
+		}
+	}
+
+	private resolveIdleIfNeeded() {
+		if (this.active !== 0 || this.pending.length !== 0) {
+			return;
+		}
+		for (const resolve of this.idleWaiters) {
+			resolve();
+		}
+		this.idleWaiters.clear();
+	}
+}
+
+class CheckedPruneTargetUnavailableError extends Error {
+	constructor(readonly peer: string) {
+		super(`Checked prune target became unavailable: ${peer}`);
+		this.name = "CheckedPruneTargetUnavailableError";
+	}
+}
 
 // DONT SET THIS ANY LOWER, because it will make the pid controller unstable as the system responses are not fast enough to updates from the pid controller
 const RECALCULATE_PARTICIPATION_DEBOUNCE_INTERVAL = 1000;
@@ -3370,6 +3607,9 @@ export class SharedLog<
 	private _activeReceiveHandlersByPeer!: Map<string, PeerReceiveLeaseState>;
 	private _receiveHandlerDrainByPeer!: Map<string, Set<Promise<void>>>;
 	private _receiveCleanupGateByPeer!: Map<string, number>;
+	private _checkedPruneRequestWorkAdmission?:
+		| CheckedPruneRequestWorkAdmissionState
+		| undefined;
 	private _subscriptionOpeningEpochByPeer!: Map<string, object>;
 	private _openingSyncCapabilitiesByPeer!: Map<
 		string,
@@ -3393,6 +3633,10 @@ export class SharedLog<
 	private _admittedPruneRemoves!: Set<Promise<unknown>>;
 	private _pruneRemovesClosing = false;
 	private _pendingIHaveCallbacks!: Set<Promise<void>>;
+	private _pendingIHaveActiveCallbacks!: number;
+	private _pendingIHaveCallbackWorkAdmission?:
+		| PendingIHaveCallbackWorkAdmissionState
+		| undefined;
 	private _pendingIHaveExpiryTimer?: ReturnType<typeof setTimeout>;
 	private _pendingIHaveExpiryDeadline = Number.POSITIVE_INFINITY;
 
@@ -3401,6 +3645,8 @@ export class SharedLog<
 	}
 
 	private _pendingIHave!: Map<string, PendingIHave<T>>;
+	private _pendingIHaveCountByPeer!: Map<string, number>;
+	private _pendingIHaveRequesterCount!: number;
 
 	// public key hash to range id to range
 	pendingMaturity!: Map<string, Map<string, PendingMaturityRecord<R>>>; // map of peerId to timeout
@@ -3414,6 +3660,7 @@ export class SharedLog<
 		string,
 		{ attempts: number; timer?: ReturnType<typeof setTimeout> }
 	>;
+	private _syncCapabilityRepairByPeer!: Map<string, SyncCapabilityRepairState>;
 	private _replicationInfoApplyQueueByPeer!: Map<string, Promise<void>>;
 	// Range ids are global primary keys while receive lanes are per peer. Keep
 	// reads and writes that decide one mutation in a single global lane.
@@ -4550,16 +4797,6 @@ export class SharedLog<
 		entry: CheckedPruneEntry<T, R>;
 		leaders: CheckedPruneLeaderMap;
 	}>;
-	private responseToPruneDebouncedFn!: ReturnType<
-		typeof debounceAccumulator<
-			string,
-			{
-				hashes: string[];
-				peers: string[] | Set<string>;
-			},
-			Map<string, Set<string>>
-		>
-	>;
 
 	private get _requestIPruneSent() {
 		return this._checkedPrune.requestIPruneSent;
@@ -4640,6 +4877,8 @@ export class SharedLog<
 
 	// regular distribution checks
 	private distributeQueue?: PQueue;
+	private _checkedPruneRequestSendQueue!: PQueue;
+	private _checkedPruneGrantSendQueue!: AbortableFixedConcurrencyQueue;
 
 	syncronizer!: Syncronizer<R>;
 
@@ -4669,12 +4908,23 @@ export class SharedLog<
 		this.log = new Log(properties);
 		this.rpc = new RPC();
 		this._checkedPrune = new CheckedPruneCoordinator<T, R>();
+		this._checkedPruneRequestSendQueue = new PQueue({
+			concurrency: CHECKED_PRUNE_MAX_CONCURRENT_REQUEST_SENDS,
+		});
+		this._checkedPruneGrantSendQueue = new AbortableFixedConcurrencyQueue(
+			CHECKED_PRUNE_MAX_CONCURRENT_GRANT_SENDS,
+		);
 		this._admittedPruneRemoves = new Set();
 		this._pendingIHave = new Map();
+		this._pendingIHaveCountByPeer = new Map();
+		this._pendingIHaveRequesterCount = 0;
 		this._pendingIHaveCallbacks = new Set();
+		this._pendingIHaveActiveCallbacks = 0;
+		this._pendingIHaveCallbackWorkAdmission = undefined;
 		this.latestReplicationInfoMessage = new Map();
 		this._replicationInfoBlockedPeers = new Set();
 		this._replicationInfoRequestByPeer = new Map();
+		this._syncCapabilityRepairByPeer = new Map();
 		this._replicationInfoApplyQueueByPeer = new Map();
 		this._replicationInfoReceiveEpochByPeer = new Map();
 		this._subscriptionEpochByPeer = new Map();
@@ -4682,6 +4932,7 @@ export class SharedLog<
 		this._activeReceiveHandlersByPeer = new Map();
 		this._receiveHandlerDrainByPeer = new Map();
 		this._receiveCleanupGateByPeer = new Map();
+		this._checkedPruneRequestWorkAdmission = undefined;
 		this._subscriptionOpeningEpochByPeer = new Map();
 		this._openingSyncCapabilitiesByPeer = new Map();
 		this._gidPeersHistory = new Map();
@@ -5182,6 +5433,93 @@ export class SharedLog<
 				SYNC_CAPABILITY_RAW_EXCHANGE_HEADS) !==
 			0
 		);
+	}
+
+	private peerSupportsCheckedPruneHandoff(peerHash: string): boolean {
+		return (
+			((this._peerSyncCapabilities.get(peerHash) ?? 0) &
+				SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF) !==
+			0
+		);
+	}
+
+	private recordPeerSyncCapabilities(peerHash: string, capabilities: number) {
+		// Capabilities are immutable for a live subscription. Treat repeated
+		// advertisements as a monotonic union so a peer cannot flap one bit and
+		// repeatedly reset every matching checked-prune retry generation. A real
+		// reconnect clears this map and starts a fresh negotiation epoch.
+		const previousCapabilities = this._peerSyncCapabilities.get(peerHash) ?? 0;
+		const nextCapabilities = (previousCapabilities | capabilities) >>> 0;
+		const supportedCheckedPruneBefore =
+			(previousCapabilities & SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF) !== 0;
+		this._peerSyncCapabilities.set(peerHash, nextCapabilities);
+		if (
+			!supportedCheckedPruneBefore &&
+			(nextCapabilities & SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF) !== 0
+		) {
+			this.wakeCheckedPruneRetriesForPeer(peerHash);
+		}
+	}
+
+	private wakeCheckedPruneRetriesForPeer(peerHash: string) {
+		const checkedPruneCoordinator = this._checkedPrune;
+		const ownershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
+		const isCurrent = () =>
+			this.isRepairLifecycleActive(ownershipLifecycleController) &&
+			this._checkedPrune === checkedPruneCoordinator;
+		if (!isCurrent()) {
+			return;
+		}
+
+		for (const [hash, state] of checkedPruneCoordinator.retries) {
+			if (
+				checkedPruneCoordinator.hasPendingDelete(hash) ||
+				!state.leaders.has(peerHash)
+			) {
+				continue;
+			}
+			checkedPruneCoordinator.clearRetryTimer(hash);
+			// The missing protocol capability was the reason this candidate could
+			// not start. Treat its first advertisement as fresh progress rather
+			// than making it consume the old backoff budget.
+			state.attempts = 0;
+			void this.pruneDebouncedFnAddIfNotKeeping(
+				{
+					key: hash,
+					value: {
+						entry: state.entry,
+						leaders: this.checkedPruneLeadersToMap(state.leaders),
+					},
+				},
+				ownershipLifecycleController,
+			).then(
+				(enqueued) => {
+					if (
+						!enqueued &&
+						isCurrent() &&
+						checkedPruneCoordinator.isCurrentRetry(hash, state)
+					) {
+						checkedPruneCoordinator.clearRetry(hash, state);
+					}
+				},
+				(error) => {
+					if (
+						!isCurrent() ||
+						!checkedPruneCoordinator.isCurrentRetry(hash, state)
+					) {
+						return;
+					}
+					if (!isNotStartedError(error as Error)) {
+						logger.error(error);
+					}
+					this.scheduleCheckedPruneRetry(
+						{ entry: state.entry, leaders: state.leaders },
+						ownershipLifecycleController,
+					);
+				},
+			);
+		}
 	}
 
 	/**
@@ -6143,6 +6481,7 @@ export class SharedLog<
 
 	private stopSubscriptionChangeCallbackAdmission() {
 		this._acceptSubscriptionChangeCallbacks = false;
+		this.cancelAllSyncCapabilityRepairs();
 		if (!this._replicationLifecycleController?.signal.aborted) {
 			this._replicationLifecycleController?.abort(
 				new AbortError("SharedLog is terminating"),
@@ -6239,6 +6578,49 @@ export class SharedLog<
 		};
 	}
 
+	private acquireCheckedPruneRequestWork(
+		peerHash: string,
+		replicationLifecycleController: AbortController | undefined,
+		subscriptionEpoch: object | null,
+	): CheckedPruneRequestWorkLease | undefined {
+		const state = this._checkedPruneRequestWorkAdmission;
+		if (
+			!state ||
+			state.replicationLifecycleController !== replicationLifecycleController ||
+			!this.isPeerReceiveAdmissionOpen(
+				peerHash,
+				replicationLifecycleController,
+				subscriptionEpoch,
+			) ||
+			state.activeByPeer.has(peerHash) ||
+			state.activeByPeer.size >= CHECKED_PRUNE_MAX_ACTIVE_REQUEST_HANDLERS
+		) {
+			return;
+		}
+
+		const token = {};
+		const settlingWork = new CheckedPruneSettlingWorkTracker();
+		state.activeByPeer.set(peerHash, token);
+		let releaseRequested = false;
+		return {
+			settlingWork,
+			release: () => {
+				if (releaseRequested) {
+					return;
+				}
+				releaseRequested = true;
+				// Do not await this from the receive handler: its protocol deadline
+				// remains bounded. The captured generation retains its capacity token
+				// until every abandoned non-cancellable operation really settles.
+				void settlingWork.sealAndWait().then(() => {
+					if (state.activeByPeer.get(peerHash) === token) {
+						state.activeByPeer.delete(peerHash);
+					}
+				});
+			},
+		};
+	}
+
 	private async drainPeerReceiveHandlers(peerHash: string): Promise<void> {
 		const state = this._activeReceiveHandlersByPeer.get(peerHash);
 		if (!state || state.activeBuckets.size === 0) {
@@ -6284,44 +6666,189 @@ export class SharedLog<
 		}
 	}
 
+	private canCreatePendingIHave(peerHash: string): boolean {
+		return (
+			this._pendingIHave.size < CHECKED_PRUNE_MAX_PENDING_IHAVE_GLOBAL &&
+			this._pendingIHaveRequesterCount <
+				CHECKED_PRUNE_MAX_PENDING_IHAVE_GLOBAL &&
+			(this._pendingIHaveCountByPeer.get(peerHash) ?? 0) <
+				CHECKED_PRUNE_MAX_PENDING_IHAVE_PER_PEER
+		);
+	}
+
+	private addPendingIHaveRequester(
+		pending: PendingIHave<T>,
+		peerHash: string,
+	): boolean {
+		if (pending.requesting.has(peerHash)) {
+			return true;
+		}
+		const count = this._pendingIHaveCountByPeer.get(peerHash) ?? 0;
+		if (
+			count >= CHECKED_PRUNE_MAX_PENDING_IHAVE_PER_PEER ||
+			this._pendingIHaveRequesterCount >= CHECKED_PRUNE_MAX_PENDING_IHAVE_GLOBAL
+		) {
+			return false;
+		}
+		pending.requesting.add(peerHash);
+		this._pendingIHaveCountByPeer.set(peerHash, count + 1);
+		this._pendingIHaveRequesterCount++;
+		return true;
+	}
+
+	private removePendingIHaveRequester(
+		pending: PendingIHave<T>,
+		peerHash: string,
+	): void {
+		if (!pending.requesting.delete(peerHash)) {
+			return;
+		}
+		pending.requestIdsByPeer?.delete(peerHash);
+		const count = this._pendingIHaveCountByPeer.get(peerHash) ?? 0;
+		if (count <= 1) {
+			this._pendingIHaveCountByPeer.delete(peerHash);
+		} else {
+			this._pendingIHaveCountByPeer.set(peerHash, count - 1);
+		}
+		this._pendingIHaveRequesterCount = Math.max(
+			0,
+			this._pendingIHaveRequesterCount - 1,
+		);
+	}
+
+	private deletePendingIHave(
+		hash: string,
+		expected?: PendingIHave<T>,
+	): boolean {
+		const pending = this._pendingIHave.get(hash);
+		if (!pending || (expected && pending !== expected)) {
+			return false;
+		}
+		this._pendingIHave.delete(hash);
+		pending.callbackController?.abort(
+			new AbortError("Pending checked-prune handoff was cancelled"),
+		);
+		pending.clear();
+		for (const peerHash of [...pending.requesting]) {
+			this.removePendingIHaveRequester(pending, peerHash);
+		}
+		return true;
+	}
+
+	private clearPendingIHaves(): void {
+		for (const [hash, pending] of [...this._pendingIHave]) {
+			this.deletePendingIHave(hash, pending);
+		}
+		this._pendingIHaveCountByPeer.clear();
+		this._pendingIHaveRequesterCount = 0;
+	}
+
 	private runPendingIHaveCallback(
 		pending: PendingIHave<T>,
 		entry: Entry<T>,
-	): void {
+	): boolean {
 		const replicationLifecycleController = this._replicationLifecycleController;
-		if (!this.isReplicationLifecycleActive(replicationLifecycleController)) {
-			if (this._pendingIHave.get(entry.hash) === pending) {
-				pending.clear();
-				this._pendingIHave.delete(entry.hash);
-			}
-			return;
+		const callbackWorkAdmission = this._pendingIHaveCallbackWorkAdmission;
+		if (
+			!replicationLifecycleController ||
+			!callbackWorkAdmission ||
+			callbackWorkAdmission.replicationLifecycleController !==
+				replicationLifecycleController ||
+			!this.isReplicationLifecycleActive(replicationLifecycleController)
+		) {
+			this.deletePendingIHave(entry.hash, pending);
+			return false;
 		}
+		if (pending.callbackActive) {
+			return true;
+		}
+		if (
+			callbackWorkAdmission.active >=
+			CHECKED_PRUNE_MAX_ACTIVE_PENDING_IHAVE_CALLBACKS
+		) {
+			// Do not queue every retained missing hash. Keep this pending request
+			// intact so a later entry notification or the requester's correlated
+			// retry can recover after one of the fixed callback slots is released.
+			return false;
+		}
+
+		const deadline =
+			Date.now() + CHECKED_PRUNE_PENDING_IHAVE_CALLBACK_MAX_WAIT_MS;
+		const deadlineController = new AbortController();
+		const signal = AbortSignal.any([
+			replicationLifecycleController.signal,
+			deadlineController.signal,
+		]);
+		const isActive = () =>
+			this._pendingIHave.get(entry.hash) === pending &&
+			this.isReplicationLifecycleActive(replicationLifecycleController) &&
+			!signal.aborted &&
+			Date.now() < deadline;
+		const deadlineTimer = setTimeout(() => {
+			deadlineController.abort(
+				new TimeoutError("Pending checked-prune handoff work timed out"),
+			);
+		}, CHECKED_PRUNE_PENDING_IHAVE_CALLBACK_MAX_WAIT_MS);
+		deadlineTimer.unref?.();
+		const settlingWork = new CheckedPruneSettlingWorkTracker();
+		const work: PendingIHaveCallbackWork = {
+			deadline,
+			signal,
+			isActive,
+			remainingMs: () => Math.max(0, deadline - Date.now()),
+			settlingWork,
+		};
 
 		// Register before invoking the callback so a synchronous terminal reentry
 		// cannot make close/drop miss work that has already been admitted.
+		pending.callbackActive = true;
+		pending.callbackController = deadlineController;
+		pending.clear();
+		callbackWorkAdmission.active++;
+		if (this._pendingIHaveCallbackWorkAdmission === callbackWorkAdmission) {
+			this._pendingIHaveActiveCallbacks = callbackWorkAdmission.active;
+		}
 		const completion = pDefer<void>();
 		const observed = completion.promise.catch((error) => {
-			if (!(this.isTerminating() && isNotStartedError(error as Error))) {
+			if (
+				!signal.aborted &&
+				!(this.isTerminating() && isNotStartedError(error as Error))
+			) {
 				logger.error(error?.toString?.() ?? String(error));
 			}
 		});
 		this._pendingIHaveCallbacks.add(observed);
 		void observed.finally(() => {
+			clearTimeout(deadlineTimer);
 			this._pendingIHaveCallbacks.delete(observed);
-			if (this._pendingIHave.get(entry.hash) === pending) {
-				pending.clear();
-				this._pendingIHave.delete(entry.hash);
+			pending.callbackActive = false;
+			if (pending.callbackController === deadlineController) {
+				pending.callbackController = undefined;
 			}
+			this.deletePendingIHave(entry.hash, pending);
+			// The callback's protocol deadline may abandon a non-cancellable
+			// planner read. Keep this generation's slot occupied until all such
+			// work settles, while allowing close/reopen to install a fresh state.
+			void settlingWork.sealAndWait().then(() => {
+				callbackWorkAdmission.active = Math.max(
+					0,
+					callbackWorkAdmission.active - 1,
+				);
+				if (this._pendingIHaveCallbackWorkAdmission === callbackWorkAdmission) {
+					this._pendingIHaveActiveCallbacks = callbackWorkAdmission.active;
+				}
+			});
 		});
 
 		try {
-			Promise.resolve(pending.callback(entry)).then(
+			Promise.resolve(pending.callback(entry, work)).then(
 				() => completion.resolve(),
 				(error) => completion.reject(error),
 			);
 		} catch (error) {
 			completion.reject(error);
 		}
+		return true;
 	}
 
 	private async drainPendingIHaveCallbacks(): Promise<void> {
@@ -10768,11 +11295,6 @@ export class SharedLog<
 				return false;
 			}
 		}
-		checkedPruneCoordinator.trackCandidate(
-			args.key,
-			args.value.entry,
-			args.value.leaders,
-		);
 		void pruneDebouncedFn.add(args).catch((error) => {
 			if (isCurrent() && !isNotStartedError(error as Error)) {
 				logger.error(error);
@@ -10793,8 +11315,378 @@ export class SharedLog<
 		await pendingDelete?.reject(new Error("Failed to delete, is leader again"));
 	}
 
-	private hasActiveCheckedPruneWork(hash: string) {
-		return this._checkedPrune.hasActiveWork(hash);
+	/**
+	 * Bound read-only checked-prune request work by the receive lease. The
+	 * underlying storage/planner promise may not expose cancellation, so keep an
+	 * observer attached and abandon only its result after the signal fires.
+	 */
+	private async awaitCheckedPruneRequestRead<T>(
+		read: () => PromiseLike<T> | T,
+		signal: AbortSignal,
+		isActive: () => boolean,
+		settlingWork?: CheckedPruneSettlingWork,
+	): Promise<{ active: true; value: T } | { active: false }> {
+		if (signal.aborted || !isActive()) {
+			return { active: false };
+		}
+
+		let operation: Promise<T>;
+		try {
+			operation = Promise.resolve(read());
+		} catch (error) {
+			if (signal.aborted || !isActive()) {
+				return { active: false };
+			}
+			throw error;
+		}
+		settlingWork?.track(operation);
+
+		return new Promise((resolve, reject) => {
+			let settled = false;
+			const finish = (
+				result: { active: true; value: T } | { active: false },
+			) => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				signal.removeEventListener("abort", onAbort);
+				resolve(result);
+			};
+			const onAbort = () => finish({ active: false });
+			signal.addEventListener("abort", onAbort, { once: true });
+			operation.then(
+				(value) => {
+					if (signal.aborted || !isActive()) {
+						finish({ active: false });
+						return;
+					}
+					finish({ active: true, value });
+				},
+				(error) => {
+					if (settled) {
+						return;
+					}
+					settled = true;
+					signal.removeEventListener("abort", onAbort);
+					if (signal.aborted || !isActive()) {
+						resolve({ active: false });
+						return;
+					}
+					reject(error);
+				},
+			);
+		});
+	}
+
+	/**
+	 * Recompute responder ownership at grant admission without publishing any
+	 * coordinate state. The surrounding range-mutation lane keeps the ownership
+	 * snapshot stable until the caller has installed the grant-send barrier.
+	 */
+	private async revalidateCheckedPruneGrantLocalLeaders(
+		hashes: string[],
+		ownershipLifecycleController: AbortController,
+		requestWork?: {
+			signal: AbortSignal;
+			isActive: () => boolean;
+			settlingWork?: CheckedPruneSettlingWork;
+		},
+	): Promise<Set<string> | undefined> {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
+		if (
+			requestWork &&
+			(requestWork.signal.aborted || !requestWork.isActive())
+		) {
+			return undefined;
+		}
+		const localLeaderHashes = new Set<string>();
+		const unresolvedHashes = new Set(hashes);
+		const nativePlanner = this._nativeBackbone ?? this._nativeRangePlanner;
+		const nativeEntryMetadata = this.getNativeLogEntryMetadataBatch(hashes);
+
+		if (nativePlanner && !this.hasCustomFindLeaders() && nativeEntryMetadata) {
+			const nativeItems: Array<{
+				hash: string;
+				gid: string;
+				replicas: number;
+			}> = [];
+			for (let index = 0; index < hashes.length; index++) {
+				const entry = nativeEntryMetadata[index];
+				if (!entry) {
+					continue;
+				}
+				nativeItems.push({
+					hash: hashes[index]!,
+					gid: entry.gid,
+					replicas:
+						entry.replicas ??
+						decodeReplicas({
+							meta: { data: entry.data },
+						}).getValue(this),
+				});
+			}
+
+			if (nativeItems.length > 0) {
+				const contextResult = requestWork
+					? await this.awaitCheckedPruneRequestRead(
+							() =>
+								this.createLeaderSelectionContext(
+									undefined,
+									ownershipLifecycleController,
+								),
+							requestWork.signal,
+							requestWork.isActive,
+							requestWork.settlingWork,
+						)
+					: {
+							active: true as const,
+							value: await this.createLeaderSelectionContext(
+								undefined,
+								ownershipLifecycleController,
+							),
+						};
+				if (!contextResult.active) {
+					return undefined;
+				}
+				const context = contextResult.value;
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
+				const plans = nativePlanner.planLeadersForGidsBatch(
+					nativeItems.map(({ gid, replicas }) => ({ gid, replicas })),
+					this.createNativeLeaderOptions(context),
+				);
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
+				for (let index = 0; index < nativeItems.length; index++) {
+					const item = nativeItems[index]!;
+					unresolvedHashes.delete(item.hash);
+					if (plans[index]?.leaders.has(context.selfHash)) {
+						localLeaderHashes.add(item.hash);
+					}
+				}
+			}
+		}
+
+		// Custom leader selection and entries without native metadata use the
+		// ordinary planner, explicitly disabling coordinate persistence.
+		for (const hash of unresolvedHashes) {
+			const indexedEntryResult = requestWork
+				? await this.awaitCheckedPruneRequestRead(
+						() => this.log.entryIndex.getShallow(hash),
+						requestWork.signal,
+						requestWork.isActive,
+						requestWork.settlingWork,
+					)
+				: {
+						active: true as const,
+						value: await this.log.entryIndex.getShallow(hash),
+					};
+			if (!indexedEntryResult.active) {
+				return undefined;
+			}
+			const indexedEntry = indexedEntryResult.value;
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+			if (!indexedEntry) {
+				continue;
+			}
+			const planResult = requestWork
+				? await this.awaitCheckedPruneRequestRead(
+						() =>
+							this.planEntryLeaders(
+								indexedEntry.value,
+								decodeReplicas(indexedEntry.value).getValue(this),
+								{ persist: false },
+								ownershipLifecycleController,
+							),
+						requestWork.signal,
+						requestWork.isActive,
+						requestWork.settlingWork,
+					)
+				: {
+						active: true as const,
+						value: await this.planEntryLeaders(
+							indexedEntry.value,
+							decodeReplicas(indexedEntry.value).getValue(this),
+							{ persist: false },
+							ownershipLifecycleController,
+						),
+					};
+			if (!planResult.active) {
+				return undefined;
+			}
+			const plan = planResult.value;
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+			if (plan.isLeader) {
+				localLeaderHashes.add(hash);
+			}
+		}
+		return localLeaderHashes;
+	}
+
+	/**
+	 * Admit responder grants in the same global lane as checked-prune removal.
+	 *
+	 * A grant first cancels every older outbound prune for the hash. Its send is
+	 * then tracked before this method yields; every later outbound prune request
+	 * waits for that send. This gives the causal order needed to rule out a
+	 * circular handoff without relying on timing or a long-lived retention pin.
+	 */
+	private async admitCheckedPruneGrants(
+		requests: Iterable<CheckedPruneGrantRequest>,
+		peer: string,
+		receiveStillActive?: () => boolean,
+		sendSignal?: AbortSignal,
+		settlingWork?: CheckedPruneSettlingWork,
+	): Promise<string[]> {
+		const latestByHash = new Map<string, CheckedPruneGrantRequest>();
+		for (const request of requests) {
+			latestByHash.set(request.hash, request);
+		}
+		if (latestByHash.size === 0) {
+			return Promise.resolve([]);
+		}
+
+		const checkedPruneCoordinator = this._checkedPrune;
+		const ownershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
+		const signal = sendSignal
+			? AbortSignal.any([ownershipLifecycleController.signal, sendSignal])
+			: ownershipLifecycleController.signal;
+		const requestWorkIsActive = () =>
+			this._checkedPrune === checkedPruneCoordinator &&
+			!signal.aborted &&
+			(!receiveStillActive || receiveStillActive());
+		const admission = await this.withReplicationRangeMutationQueue(async () => {
+			if (!requestWorkIsActive()) {
+				return { admitted: [] as CheckedPruneGrantRequest[] };
+			}
+
+			const hashes = [...latestByHash.keys()];
+			const presentResult = await this.awaitCheckedPruneRequestRead(
+				async () =>
+					(await this.log.blocks.hasMany?.(hashes)) ??
+					(await Promise.all(hashes.map((hash) => this.log.blocks.has(hash)))),
+				signal,
+				requestWorkIsActive,
+				settlingWork,
+			);
+			if (!presentResult.active) {
+				return { admitted: [] as CheckedPruneGrantRequest[] };
+			}
+			const present = presentResult.value;
+
+			const presentHashes: string[] = [];
+			for (let index = 0; index < hashes.length; index++) {
+				if (present[index] === true) {
+					presentHashes.push(hashes[index]!);
+				}
+			}
+			const currentLocalLeaderHashes =
+				await this.revalidateCheckedPruneGrantLocalLeaders(
+					presentHashes,
+					ownershipLifecycleController,
+					{
+						signal,
+						isActive: requestWorkIsActive,
+						settlingWork,
+					},
+				);
+			if (!currentLocalLeaderHashes || !requestWorkIsActive()) {
+				return { admitted: [] as CheckedPruneGrantRequest[] };
+			}
+
+			const admitted: CheckedPruneGrantRequest[] = [];
+			for (const hash of presentHashes) {
+				if (currentLocalLeaderHashes.has(hash)) {
+					admitted.push(latestByHash.get(hash)!);
+				}
+			}
+			if (admitted.length === 0) {
+				return { admitted };
+			}
+
+			// Register the ordering barrier before rejecting any old pending prune.
+			// Rejecting settles a user-visible promise and can immediately queue a
+			// replacement prune in a microtask. There must be no await between
+			// cancellation admission and making that replacement wait for this grant.
+			const barrier = pDefer<void>();
+			const observedBarrier = checkedPruneCoordinator.trackGrantSend(
+				admitted.map(({ hash }) => hash),
+				barrier.promise,
+			);
+			const pendingRejections: Promise<unknown>[] = [];
+			for (const request of admitted) {
+				const pendingDelete = checkedPruneCoordinator.getPendingDelete(
+					request.hash,
+				);
+				this.pruneDebouncedFn.delete(request.hash);
+				checkedPruneCoordinator.markCancelled(request.hash);
+				try {
+					pendingRejections.push(
+						Promise.resolve(
+							pendingDelete?.reject(
+								new Error(
+									"Failed to delete, granted checked prune to another peer",
+								),
+							),
+						),
+					);
+				} catch (error) {
+					pendingRejections.push(Promise.reject(error));
+				}
+			}
+			await Promise.allSettled(pendingRejections);
+			return { admitted, barrier, observedBarrier };
+		}, ownershipLifecycleController);
+
+		const admittedHashes = admission.admitted.map(({ hash }) => hash);
+		if (!admission.barrier) {
+			return admittedHashes;
+		}
+		try {
+			try {
+				await this._checkedPruneGrantSendQueue.add(async () => {
+					if (
+						this._checkedPrune !== checkedPruneCoordinator ||
+						(receiveStillActive && !receiveStillActive()) ||
+						signal.aborted
+					) {
+						return;
+					}
+					await this.rpc.send(
+						new ResponseIPruneV2({ requests: admission.admitted }),
+						{
+							mode: new AcknowledgeDelivery({
+								to: [peer],
+								redundancy: 1,
+							}),
+							priority: CONVERGENCE_MESSAGE_PRIORITY,
+							signal,
+						},
+					);
+				}, signal);
+			} catch (error) {
+				// A receive deadline or terminal lifecycle abort is an expected
+				// fail-closed outcome. The correlated requester can retry with the
+				// same generation if it remains connected.
+				if (!signal.aborted) {
+					throw error;
+				}
+			}
+		} finally {
+			admission.barrier.resolve();
+			await admission.observedBarrier;
+		}
+		return admittedHashes;
 	}
 
 	private async revalidateCheckedPruneOwnership(args: {
@@ -11038,7 +11930,10 @@ export class SharedLog<
 			await this.pruneDebouncedFnAddIfNotKeeping(
 				{
 					key: entry.hash,
-					value: { entry, leaders },
+					value: {
+						entry,
+						leaders,
+					},
 				},
 				ownershipLifecycleController,
 			);
@@ -11046,7 +11941,6 @@ export class SharedLog<
 				ownershipLifecycleController,
 			);
 			enqueuedPrune++;
-			this.responseToPruneDebouncedFn.delete(entry.hash);
 		}
 		emitSyncProfileDuration(options?.profile, loopStartedAt, {
 			name: "sharedLog.receive.checkedPrune.loop",
@@ -11122,7 +12016,6 @@ export class SharedLog<
 					this.throwIfReplicationOwnershipLifecycleInactive(
 						ownershipLifecycleController,
 					);
-					this.responseToPruneDebouncedFn.delete(entryReplicated.hash);
 				}
 			}
 		} finally {
@@ -11203,7 +12096,6 @@ export class SharedLog<
 			this.throwIfReplicationOwnershipLifecycleInactive(
 				ownershipLifecycleController,
 			);
-			this.responseToPruneDebouncedFn.delete(head.hash);
 		}
 
 		if (enqueuedPrune) {
@@ -11315,8 +12207,10 @@ export class SharedLog<
 
 		if (state.timer) return;
 		if (state.attempts >= CHECKED_PRUNE_RETRY_MAX_ATTEMPTS) {
-			// Avoid unbounded background retries; a new replication-change event can
-			// always re-enqueue pruning with fresh leader info.
+			// A terminal retry must not remain active forever. Dropping the exact
+			// exhausted generation lets a later ownership scan rediscover the entry
+			// with fresh leader/capability information.
+			checkedPruneCoordinator.clearRetry(hash, state);
 			return;
 		}
 
@@ -11331,11 +12225,17 @@ export class SharedLog<
 		state.timer = setTimeout(() => {
 			const run = async () => {
 				const st = checkedPruneCoordinator.getRetry(hash);
-				if (st) st.timer = undefined;
+				if (
+					st !== state ||
+					!checkedPruneCoordinator.isCurrentRetry(hash, state)
+				) {
+					return;
+				}
+				state.timer = undefined;
 				if (!isCurrent()) return;
 				if (checkedPruneCoordinator.hasPendingDelete(hash)) return;
-				const retryEntry = st?.entry ?? args.entry;
-				const retryLeaders = st?.leaders ?? args.leaders;
+				const retryEntry = state.entry;
+				const retryLeaders = state.leaders;
 
 				let leadersMap: CheckedPruneLeaderMap | undefined;
 				try {
@@ -11353,7 +12253,12 @@ export class SharedLog<
 					// A current-generation planning failure is best-effort; fall back
 					// to the last confirmed leader set below.
 				}
-				if (!isCurrent()) return;
+				if (
+					!isCurrent() ||
+					!checkedPruneCoordinator.isCurrentRetry(hash, state)
+				) {
+					return;
+				}
 
 				if (!leadersMap || leadersMap.size === 0) {
 					leadersMap = this.checkedPruneLeadersToMap(retryLeaders);
@@ -11361,101 +12266,42 @@ export class SharedLog<
 
 				const leadersForRetry =
 					leadersMap ?? new Map<string, { intersecting: boolean }>();
-				await this.pruneDebouncedFnAddIfNotKeeping(
+				const enqueued = await this.pruneDebouncedFnAddIfNotKeeping(
 					{
 						key: hash,
-						value: { entry: retryEntry, leaders: leadersForRetry },
+						value: {
+							entry: retryEntry,
+							leaders: leadersForRetry,
+						},
 					},
 					ownershipLifecycleController,
 				);
+				if (
+					!enqueued &&
+					isCurrent() &&
+					checkedPruneCoordinator.isCurrentRetry(hash, state)
+				) {
+					checkedPruneCoordinator.clearRetry(hash, state);
+				}
 			};
 			void run().catch((error) => {
-				if (isCurrent() && !isNotStartedError(error as Error)) {
+				if (
+					!isCurrent() ||
+					!checkedPruneCoordinator.isCurrentRetry(hash, state)
+				) {
+					return;
+				}
+				if (!isNotStartedError(error as Error)) {
 					logger.error(error);
 				}
+				this.scheduleCheckedPruneRetry(
+					{ entry: state.entry, leaders: state.leaders },
+					ownershipLifecycleController,
+				);
 			});
 		}, delayMs);
 		state.timer.unref?.();
 		checkedPruneCoordinator.setRetry(hash, state);
-	}
-
-	private async recoverCheckedPruneFromLateResponses(
-		hashes: string[],
-		publicKeyHash: string,
-	) {
-		if (this.closed) return;
-		const selfHash = this.node.identity.publicKey.hashcode();
-		const toPrune = new Map<
-			string,
-			{
-				entry: CheckedPruneEntry<T, R>;
-				leaders: CheckedPruneLeaderMap;
-			}
-		>();
-		const responseStillApplies: string[] = [];
-
-		for (const hash of hashes) {
-			if (this.closed) {
-				break;
-			}
-			if (this._checkedPrune.hasPendingDelete(hash)) {
-				continue;
-			}
-			const retry = this._checkedPrune.clearRetryTimer(hash);
-			if (!retry) {
-				continue;
-			}
-
-			const entry = retry.entry;
-			let leaders = this.checkedPruneLeadersToMap(retry.leaders);
-			try {
-				const currentLeaders = await this.findLeadersFromEntry(
-					entry,
-					decodeReplicas(entry).getValue(this),
-					{ roleAge: 0 },
-				);
-				if (currentLeaders.size > 0) {
-					leaders = currentLeaders;
-				}
-			} catch {
-				// Best-effort only; the stored retry leaders came from a previous
-				// checked-prune decision for this exact entry.
-			}
-
-			if (leaders.has(selfHash)) {
-				await this.cancelCheckedPruneForLocalLeader(hash);
-				continue;
-			}
-			if (leaders.size === 0) {
-				continue;
-			}
-
-			toPrune.set(hash, { entry, leaders });
-			if (leaders.has(publicKeyHash)) {
-				responseStillApplies.push(hash);
-			}
-		}
-
-		if (toPrune.size === 0) {
-			return;
-		}
-
-		const pruneTasks = this.prune(toPrune);
-		const confirmationTasks: Promise<void>[] = [];
-		for (const hash of responseStillApplies) {
-			const pendingDelete = this._checkedPrune.getPendingDelete(hash);
-			if (pendingDelete) {
-				confirmationTasks.push(
-					Promise.resolve(pendingDelete.resolve(publicKeyHash)),
-				);
-			}
-		}
-		// The restarted prune session owns its own bounded timeout and revalidates
-		// before deletion. Only the peer-derived confirmations must remain inside
-		// this receive lease; waiting for the whole prune session could stall close
-		// or disconnect until its background timeout.
-		void Promise.allSettled(pruneTasks);
-		await Promise.allSettled(confirmationTasks);
 	}
 
 	async append(
@@ -15588,12 +16434,26 @@ export class SharedLog<
 		);
 		this._respondToIHaveTimeout = options?.respondToIHaveTimeout ?? 2e4;
 		this._checkedPrune = new CheckedPruneCoordinator<T, R>();
+		this._checkedPruneRequestSendQueue = new PQueue({
+			concurrency: CHECKED_PRUNE_MAX_CONCURRENT_REQUEST_SENDS,
+		});
+		this._checkedPruneGrantSendQueue = new AbortableFixedConcurrencyQueue(
+			CHECKED_PRUNE_MAX_CONCURRENT_GRANT_SENDS,
+		);
 		this._admittedPruneRemoves = new Set();
 		this._pendingIHave = new Map();
+		this._pendingIHaveCountByPeer = new Map();
+		this._pendingIHaveRequesterCount = 0;
 		this._pendingIHaveCallbacks = new Set();
+		this._pendingIHaveActiveCallbacks = 0;
+		this._pendingIHaveCallbackWorkAdmission = {
+			replicationLifecycleController: this._replicationLifecycleController!,
+			active: 0,
+		};
 		this.latestReplicationInfoMessage = new Map();
 		this._replicationInfoBlockedPeers = new Set();
 		this._replicationInfoRequestByPeer = new Map();
+		this._syncCapabilityRepairByPeer = new Map();
 		// Terminal close/drop drains the previous lifecycle before another open can
 		// install fresh lanes and opaque per-subscription ownership tokens.
 		this._replicationInfoApplyQueueByPeer = new Map();
@@ -15603,6 +16463,10 @@ export class SharedLog<
 		this._activeReceiveHandlersByPeer = new Map();
 		this._receiveHandlerDrainByPeer = new Map();
 		this._receiveCleanupGateByPeer = new Map();
+		this._checkedPruneRequestWorkAdmission = {
+			replicationLifecycleController: this._replicationLifecycleController!,
+			activeByPeer: new Map(),
+		};
 		this._subscriptionOpeningEpochByPeer = new Map();
 		this._openingSyncCapabilitiesByPeer = new Map();
 		this._repairRetryTimers = new Set();
@@ -15718,6 +16582,7 @@ export class SharedLog<
 				if (state.timer) clearTimeout(state.timer);
 			}
 			this._replicationInfoRequestByPeer.clear();
+			this.cancelAllSyncCapabilityRepairs();
 		});
 		const invalidateLeaderSelectionContext = () =>
 			this.invalidateLeaderSelectionContextCache();
@@ -16010,63 +16875,6 @@ export class SharedLog<
 			},
 		);
 		this.pruneDebouncedFn = pruneDebouncedFn;
-
-		this.responseToPruneDebouncedFn = debounceAccumulator<
-			string,
-			{
-				hashes: string[];
-				peers: string[] | Set<string>;
-			},
-			Map<string, Set<string>>
-		>(
-			(result) => {
-				let allRequestingPeers = new Set<string>();
-				let hashes: string[] = [];
-				for (const [hash, requestingPeers] of result) {
-					for (const peer of requestingPeers) {
-						allRequestingPeers.add(peer);
-					}
-					hashes.push(hash);
-				}
-
-				if (hashes.length > 0 && allRequestingPeers.size > 0) {
-					this.rpc
-						.send(new ResponseIPrune({ hashes }), {
-							mode: new AcknowledgeDelivery({
-								to: allRequestingPeers,
-								redundancy: 1,
-							}),
-							priority: CONVERGENCE_MESSAGE_PRIORITY,
-						})
-						.catch(() => {});
-				}
-			},
-			() => {
-				let accumulator = new Map<string, Set<string>>();
-				return {
-					add: (props: { hashes: string[]; peers: string[] | Set<string> }) => {
-						for (const hash of props.hashes) {
-							let prev = accumulator.get(hash);
-							if (!prev) {
-								prev = new Set<string>();
-								accumulator.set(hash, prev);
-							}
-							for (const peer of props.peers) {
-								prev.add(peer);
-							}
-						}
-					},
-					delete: (hash: string) => {
-						accumulator.delete(hash);
-					},
-					size: () => accumulator.size,
-					clear: () => accumulator.clear(),
-					value: accumulator,
-					has: (hash: string) => accumulator.has(hash),
-				};
-			},
-			PRUNE_DEBOUNCE_INTERVAL,
-		);
 
 		await remoteBlocksStartPromise;
 		// Failed native prepares can leave content-addressed bytes behind. Recovery
@@ -17223,15 +18031,55 @@ export class SharedLog<
 		this._replicatorLastActivityAt.delete(peerHash);
 		this._peerSyncCapabilities.delete(peerHash);
 		this.cleanupPendingIHavePeer(peerHash);
-		this._checkedPrune.cleanupPeer(peerHash);
+		const checkedPruneCoordinator = this._checkedPrune;
+		const affected = checkedPruneCoordinator.cleanupPeer(peerHash);
+		const ownershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
+		for (const generation of affected) {
+			const resilient = generation.pending.background;
+			const retry = () => {
+				if (!resilient || this._checkedPrune !== checkedPruneCoordinator) {
+					return;
+				}
+				this.scheduleCheckedPruneRetry(
+					{
+						entry: generation.entry,
+						leaders: generation.leaders,
+					},
+					ownershipLifecycleController,
+				);
+			};
+			try {
+				void Promise.resolve(
+					generation.pending.reject(
+						new CheckedPruneTargetUnavailableError(peerHash),
+					),
+				).then(retry, (error) => {
+					if (
+						this._checkedPrune === checkedPruneCoordinator &&
+						!isNotStartedError(error as Error)
+					) {
+						logger.error(error);
+					}
+					retry();
+				});
+			} catch (error) {
+				if (
+					this._checkedPrune === checkedPruneCoordinator &&
+					!isNotStartedError(error as Error)
+				) {
+					logger.error(error);
+				}
+				retry();
+			}
+		}
 	}
 
 	private cleanupPendingIHavePeer(peerHash: string) {
 		for (const [hash, pending] of this._pendingIHave) {
-			pending.requesting.delete(peerHash);
+			this.removePendingIHaveRequester(pending, peerHash);
 			if (pending.requesting.size === 0) {
-				pending.clear();
-				this._pendingIHave.delete(hash);
+				this.deletePendingIHave(hash, pending);
 			}
 		}
 	}
@@ -18366,6 +19214,8 @@ export class SharedLog<
 	}
 
 	private async _close(options?: { preserveDropRetryResources?: boolean }) {
+		const checkedPruneRequestSendQueue = this._checkedPruneRequestSendQueue;
+		const checkedPruneGrantSendQueue = this._checkedPruneGrantSendQueue;
 		this.stopRepairLifecycle();
 		const preserveDropRetryResources =
 			options?.preserveDropRetryResources === true;
@@ -18385,6 +19235,7 @@ export class SharedLog<
 			}
 		};
 		captureSync(() => this.cancelCurrentReplicationStateAnnouncementRetry());
+		captureSync(() => this.cancelAllSyncCapabilityRepairs());
 		this.replicationAnnouncementRetryDebounced = undefined;
 		captureSync(() => {
 			if (this._wireSyncSession) {
@@ -18468,14 +19319,22 @@ export class SharedLog<
 				this._pendingIHaveExpiryDeadline = Number.POSITIVE_INFINITY;
 			}
 		});
+		// Reopen must not publish a fresh prune request ahead of a response
+		// admitted by the previous lifecycle.
+		await capture(() => this._checkedPrune.waitForGrantSends());
+		await capture(() => checkedPruneRequestSendQueue?.onIdle());
+		await capture(() => checkedPruneGrantSendQueue?.onIdle());
 		captureSync(() => this._checkedPrune.close());
 
 		if (!preserveDropRetryResources) {
 			await capture(() => this.remoteBlocks?.stop?.());
 		}
 		captureSync(() => {
-			this._pendingIHave?.clear();
+			this.clearPendingIHaves();
 			this._pendingIHaveCallbacks?.clear();
+			this._pendingIHaveActiveCallbacks = 0;
+			this._pendingIHaveCallbackWorkAdmission = undefined;
+			this._checkedPruneRequestWorkAdmission = undefined;
 			this.latestReplicationInfoMessage?.clear();
 			this._replicationInfoReceiveEpochByPeer?.clear();
 			this._activeReceiveHandlersByPeer?.clear();
@@ -18495,7 +19354,6 @@ export class SharedLog<
 		captureSync(() => this.rebalanceParticipationDebounced?.close());
 		captureSync(() => this.replicationChangeDebounceFn?.close?.());
 		captureSync(() => this.pruneDebouncedFn?.close?.());
-		captureSync(() => this.responseToPruneDebouncedFn?.close?.());
 		this.pruneDebouncedFn = undefined as any;
 		this.rebalanceParticipationDebounced = undefined;
 		if (!preserveDropRetryResources) {
@@ -18600,7 +19458,6 @@ export class SharedLog<
 				this.rebalanceParticipationDebounced?.close();
 				this.replicationChangeDebounceFn?.close?.();
 				this.pruneDebouncedFn?.close?.();
-				this.responseToPruneDebouncedFn?.close?.();
 
 				// Ensure the "I'm leaving" replication reset is actually published before
 				// the RPC child program closes and unsubscribes from its topic. If we fire
@@ -18729,7 +19586,6 @@ export class SharedLog<
 				this.rebalanceParticipationDebounced?.close();
 				this.replicationChangeDebounceFn?.close?.();
 				this.pruneDebouncedFn?.close?.();
-				this.responseToPruneDebouncedFn?.close?.();
 
 				const abort = new AbortController();
 				const abortTimer = setTimeout(() => {
@@ -18935,6 +19791,11 @@ export class SharedLog<
 			? msg
 			: undefined;
 		let releasePeerReceiveLease: (() => void) | undefined;
+		let checkedPruneRequestWork: CheckedPruneRequestWorkLease | undefined;
+		let checkedPruneRequestDeadlineTimer:
+			| ReturnType<typeof setTimeout>
+			| undefined;
+		let checkedPruneRequestDeadlineController: AbortController | undefined;
 		try {
 			this.throwIfNativeDurableCommitFailed();
 			if (!context.from) {
@@ -20778,19 +21639,98 @@ export class SharedLog<
 					}
 				}
 			} else if (msg instanceof RequestIPrune) {
+				// Hash-only legacy requests are unauthenticated and uncorrelated.
+				// They cannot authorize deletion or mutate checked-prune/peer state.
+				return;
+			} else if (msg instanceof RequestIPruneV2) {
 				const requestPruneStartedAt = syncProfileStart(syncProfile);
 				const from = context.from.hashcode();
+				if (
+					msg.requests.length === 0 ||
+					msg.requests.length > CHECKED_PRUNE_MAX_REQUESTS_PER_MESSAGE
+				) {
+					return;
+				}
+				const requestsByHash = new Map<string, CheckedPruneGrantRequest>();
+				for (const request of msg.requests) {
+					if (
+						request.hash.length === 0 ||
+						request.hash.length > CHECKED_PRUNE_MAX_HASH_CODE_UNITS ||
+						request.requestId.length !== CHECKED_PRUNE_REQUEST_ID_BYTES ||
+						requestsByHash.has(request.hash)
+					) {
+						return;
+					}
+					requestsByHash.set(request.hash, {
+						hash: request.hash,
+						requestId: request.requestId,
+					});
+				}
+				checkedPruneRequestWork = this.acquireCheckedPruneRequestWork(
+					from,
+					receiveReplicationLifecycleController,
+					receiveSubscriptionEpoch,
+				);
+				if (!checkedPruneRequestWork) {
+					return;
+				}
+				const requestWorkDeadline =
+					Date.now() + CHECKED_PRUNE_REQUEST_HANDLER_MAX_WAIT_MS;
+				checkedPruneRequestDeadlineController = new AbortController();
+				checkedPruneRequestDeadlineTimer = setTimeout(() => {
+					checkedPruneRequestDeadlineController?.abort(
+						new TimeoutError("Checked-prune request handling timed out"),
+					);
+				}, CHECKED_PRUNE_REQUEST_HANDLER_MAX_WAIT_MS);
+				checkedPruneRequestDeadlineTimer.unref?.();
+				const requestHashes = [...requestsByHash.keys()];
+				if (requestHashes.length === 0) {
+					return;
+				}
+				const receiveStillActive = () =>
+					this.isPeerReceiveAdmissionOpen(
+						from,
+						receiveReplicationLifecycleController,
+						receiveSubscriptionEpoch,
+					) &&
+					!checkedPruneRequestDeadlineController?.signal.aborted &&
+					Date.now() < requestWorkDeadline;
+				const awaitRequestRead = <V>(read: () => PromiseLike<V> | V) =>
+					this.awaitCheckedPruneRequestRead(
+						read,
+						checkedPruneRequestDeadlineController!.signal,
+						receiveStillActive,
+						checkedPruneRequestWork!.settlingWork,
+					);
+				const remainingRequestWorkMs = () =>
+					Math.max(
+						0,
+						Math.min(
+							this.waitForReplicatorTimeout,
+							requestWorkDeadline - Date.now(),
+						),
+					);
+				const requestsFor = (hashes: Iterable<string>) => {
+					const requests: CheckedPruneGrantRequest[] = [];
+					for (const hash of hashes) {
+						const request = requestsByHash.get(hash);
+						if (request) {
+							requests.push(request);
+						}
+					}
+					return requests;
+				};
 				const coordinatorCleanupStartedAt = syncProfileStart(syncProfile);
-				this.removeEntriesKnownByPeer(msg.hashes, from);
-				this.removePruneRequestsSent(msg.hashes, from);
-				this._checkedPrune.removeConfirmedReplicators(msg.hashes, from);
+				this.removeEntriesKnownByPeer(requestHashes, from);
+				this.removePruneRequestsSent(requestHashes, from);
+				this._checkedPrune.removeConfirmedReplicators(requestHashes, from);
 				if (syncProfile) {
 					emitSyncProfileDuration(syncProfile, coordinatorCleanupStartedAt, {
 						name: "sharedLog.receive.requestPrune.coordinatorCleanup",
 						component: "shared-log",
-						entries: msg.hashes.length,
+						entries: requestHashes.length,
 						messages: 1,
-						details: { hashes: msg.hashes.length },
+						details: { hashes: requestHashes.length },
 					});
 				}
 				let nativeEntryMetadata:
@@ -20802,22 +21742,28 @@ export class SharedLog<
 					| undefined;
 				let presentBlocks: boolean[] | undefined;
 				const nativeBackbonePlanStartedAt = syncProfileStart(syncProfile);
-				let nativeLeaderHints =
-					await this.planCurrentNativeBackboneRequestPruneLeaderHints(
-						msg.hashes,
+				const nativeBackbonePlanResult = await awaitRequestRead(() =>
+					this.planCurrentNativeBackboneRequestPruneLeaderHints(
+						requestHashes,
 						from,
-					);
+						receiveStillActive,
+					),
+				);
+				if (!nativeBackbonePlanResult.active) {
+					return;
+				}
+				let nativeLeaderHints = nativeBackbonePlanResult.value;
 				if (nativeLeaderHints) {
 					if (syncProfile) {
 						emitSyncProfileDuration(syncProfile, nativeBackbonePlanStartedAt, {
 							name: "sharedLog.receive.requestPrune.nativeBackbonePlan",
 							component: "shared-log",
-							entries: msg.hashes.length,
+							entries: requestHashes.length,
 							messages: 1,
 							details: {
 								nativeEntries:
 									(nativeLeaderHints.nativeAllConfirmed
-										? msg.hashes.length
+										? requestHashes.length
 										: undefined) ??
 									nativeLeaderHints.nativeEntries?.size ??
 									countPresentValues(
@@ -20827,18 +21773,18 @@ export class SharedLog<
 									0,
 								presentBlocks:
 									(nativeLeaderHints.nativeAllConfirmed
-										? msg.hashes.length
+										? requestHashes.length
 										: undefined) ??
 									nativeLeaderHints.presentBlockHashes?.size ??
 									countTruthyValues(nativeLeaderHints.presentBlocks) ??
 									0,
 								localLeaders: nativeLeaderHints.nativeAllConfirmed
-									? msg.hashes.length
+									? requestHashes.length
 									: nativeLeaderHints.localLeaderHashes.size ||
 										countTruthyValues(nativeLeaderHints.localLeaderFlags) ||
 										0,
 								plannedEntries: nativeLeaderHints.nativeAllConfirmed
-									? msg.hashes.length
+									? requestHashes.length
 									: nativeLeaderHints.replicaCounts.size ||
 										countPositiveValues(
 											nativeLeaderHints.replicaCountsByIndex,
@@ -20850,12 +21796,13 @@ export class SharedLog<
 					}
 				} else {
 					const metadataStartedAt = syncProfileStart(syncProfile);
-					nativeEntryMetadata = this.getNativeLogEntryMetadataBatch(msg.hashes);
+					nativeEntryMetadata =
+						this.getNativeLogEntryMetadataBatch(requestHashes);
 					if (syncProfile) {
 						emitSyncProfileDuration(syncProfile, metadataStartedAt, {
 							name: "sharedLog.receive.requestPrune.nativeMetadata",
 							component: "shared-log",
-							entries: msg.hashes.length,
+							entries: requestHashes.length,
 							messages: 1,
 							details: {
 								nativeEntries:
@@ -20867,12 +21814,18 @@ export class SharedLog<
 						});
 					}
 					const blockHasManyStartedAt = syncProfileStart(syncProfile);
-					presentBlocks = await this.log.blocks.hasMany?.(msg.hashes);
+					const presentBlocksResult = await awaitRequestRead(() =>
+						this.log.blocks.hasMany?.(requestHashes),
+					);
+					if (!presentBlocksResult.active) {
+						return;
+					}
+					presentBlocks = presentBlocksResult.value;
 					if (syncProfile) {
 						emitSyncProfileDuration(syncProfile, blockHasManyStartedAt, {
 							name: "sharedLog.receive.requestPrune.blockHasMany",
 							component: "shared-log",
-							entries: msg.hashes.length,
+							entries: requestHashes.length,
 							messages: 1,
 							details: {
 								batched: presentBlocks != null,
@@ -20885,17 +21838,22 @@ export class SharedLog<
 						});
 					}
 					const nativeLeaderPlanStartedAt = syncProfileStart(syncProfile);
-					nativeLeaderHints =
-						await this.planCurrentNativeRequestPruneLeaderHints({
-							hashes: msg.hashes,
+					const nativeLeaderPlanResult = await awaitRequestRead(() =>
+						this.planCurrentNativeRequestPruneLeaderHints({
+							hashes: requestHashes,
 							nativeEntryMetadata,
 							presentBlocks,
-						});
+						}),
+					);
+					if (!nativeLeaderPlanResult.active) {
+						return;
+					}
+					nativeLeaderHints = nativeLeaderPlanResult.value;
 					if (syncProfile) {
 						emitSyncProfileDuration(syncProfile, nativeLeaderPlanStartedAt, {
 							name: "sharedLog.receive.requestPrune.nativeLeaderPlan",
 							component: "shared-log",
-							entries: msg.hashes.length,
+							entries: requestHashes.length,
 							messages: 1,
 							details: {
 								localLeaders: nativeLeaderHints.localLeaderHashes.size,
@@ -20906,6 +21864,9 @@ export class SharedLog<
 					}
 				}
 				const gidCleanupStartedAt = syncProfileStart(syncProfile);
+				if (!receiveStillActive()) {
+					return;
+				}
 				this.removePeerFromGidPeerHistoryBatch(
 					from,
 					nativeLeaderHints.peerHistoryGids,
@@ -20927,26 +21888,29 @@ export class SharedLog<
 				if (
 					canConfirmNativeRequestPruneBatch(
 						nativeLeaderHints,
-						msg.hashes.length,
+						requestHashes.length,
 					)
 				) {
-					this.responseToPruneDebouncedFn.add({
-						hashes: msg.hashes,
-						peers: [from],
-					});
+					const admitted = await this.admitCheckedPruneGrants(
+						requestsFor(requestHashes),
+						from,
+						receiveStillActive,
+						checkedPruneRequestDeadlineController.signal,
+						checkedPruneRequestWork.settlingWork,
+					);
 					if (syncProfile) {
 						emitSyncProfileDuration(syncProfile, requestPruneLoopStartedAt, {
 							name: "sharedLog.receive.requestPrune.loop",
 							component: "shared-log",
-							entries: msg.hashes.length,
+							entries: requestHashes.length,
 							messages: 1,
 							details: {
-								presentEntries: msg.hashes.length,
+								presentEntries: requestHashes.length,
 								indexedFallbackLookups: 0,
 								fallbackBlockChecks: 0,
 								pendingDeleteEntries: 0,
-								leaderResponses: msg.hashes.length,
-								leaderResponseBatches: 1,
+								leaderResponses: admitted.length,
+								leaderResponseBatches: admitted.length > 0 ? 1 : 0,
 								pendingIHaveCreated: 0,
 								pendingIHaveExtended: 0,
 								skippedIndexedLookupsForMissingBlocks: 0,
@@ -20956,7 +21920,7 @@ export class SharedLog<
 						emitSyncProfileDuration(syncProfile, requestPruneStartedAt, {
 							name: "sharedLog.receive.requestPrune.total",
 							component: "shared-log",
-							entries: msg.hashes.length,
+							entries: requestHashes.length,
 							messages: 1,
 						});
 					}
@@ -20971,15 +21935,11 @@ export class SharedLog<
 				let pendingIHaveCreated = 0;
 				let pendingIHaveExtended = 0;
 				const leaderResponseHashes: string[] = [];
-				for (let i = 0; i < msg.hashes.length; i++) {
-					if (
-						!this.isReplicationLifecycleActive(
-							receiveReplicationLifecycleController,
-						)
-					) {
+				for (let i = 0; i < requestHashes.length; i++) {
+					if (!receiveStillActive()) {
 						return;
 					}
-					const hash = msg.hashes[i]!;
+					const hash = requestHashes[i]!;
 
 					const nativeEntryGid = nativeLeaderHints.nativeEntryGids?.[i];
 					const nativeEntryData = nativeLeaderHints.nativeEntryDataByIndex?.[i];
@@ -20993,22 +21953,37 @@ export class SharedLog<
 						| undefined;
 					let isLeader = false;
 
-					const hasPresentBlock = nativeLeaderHints.presentBlockHashes
-						? nativeLeaderHints.presentBlockHashes.has(hash)
-						: nativeLeaderHints.presentBlocks
-							? !!nativeLeaderHints.presentBlocks[i]
-							: presentBlocks
-								? presentBlocks[i] === true
-								: await this.log.blocks.has(hash);
-					if (
+					let hasPresentBlock: boolean;
+					const needsFallbackBlockCheck =
 						!presentBlocks &&
 						!nativeLeaderHints.presentBlockHashes &&
-						!nativeLeaderHints.presentBlocks
-					) {
+						!nativeLeaderHints.presentBlocks;
+					if (nativeLeaderHints.presentBlockHashes) {
+						hasPresentBlock = nativeLeaderHints.presentBlockHashes.has(hash);
+					} else if (nativeLeaderHints.presentBlocks) {
+						hasPresentBlock = !!nativeLeaderHints.presentBlocks[i];
+					} else if (presentBlocks) {
+						hasPresentBlock = presentBlocks[i] === true;
+					} else {
+						const blockPresentResult = await awaitRequestRead(() =>
+							this.log.blocks.has(hash),
+						);
+						if (!blockPresentResult.active) {
+							return;
+						}
+						hasPresentBlock = blockPresentResult.value;
+					}
+					if (needsFallbackBlockCheck) {
 						fallbackBlockChecks += 1;
 					}
 					if (!hasNativeEntry && hasPresentBlock) {
-						indexedEntry = await this.log.entryIndex.getShallow(hash);
+						const indexedEntryResult = await awaitRequestRead(() =>
+							this.log.entryIndex.getShallow(hash),
+						);
+						if (!indexedEntryResult.active) {
+							return;
+						}
+						indexedEntry = indexedEntryResult.value;
 						indexedFallbackLookups += 1;
 					} else if (!hasNativeEntry) {
 						skippedIndexedLookupsForMissingBlocks += 1;
@@ -21018,17 +21993,33 @@ export class SharedLog<
 						const pendingDelete = this._checkedPrune.getPendingDelete(hash);
 						if (pendingDelete) {
 							pendingDeleteEntries += 1;
-							const pendingEntry =
-								indexedEntry?.value ??
-								(await this.log.entryIndex.getShallow(hash))?.value;
+							let pendingEntry = indexedEntry?.value;
+							if (!pendingEntry) {
+								const pendingEntryResult = await awaitRequestRead(() =>
+									this.log.entryIndex.getShallow(hash),
+								);
+								if (!pendingEntryResult.active) {
+									return;
+								}
+								pendingEntry = pendingEntryResult.value?.value;
+							}
 							if (pendingEntry) {
-								const ownership = await this.revalidateCheckedPruneOwnership({
-									hash,
-									entry: pendingEntry,
-									leaders: new Map(),
-								});
+								const ownershipResult = await awaitRequestRead(() =>
+									this.revalidateCheckedPruneOwnership({
+										hash,
+										entry: pendingEntry,
+										leaders: new Map(),
+									}),
+								);
+								if (!ownershipResult.active) {
+									return;
+								}
+								const ownership = ownershipResult.value;
 								if (ownership.localLeader) {
 									await this.cancelCheckedPruneForLocalLeader(hash);
+									if (!receiveStillActive()) {
+										return;
+									}
 									isLeader = true;
 								}
 							}
@@ -21072,25 +22063,44 @@ export class SharedLog<
 										replicator: true,
 									},
 								];
+								const remainingWaitMs = remainingRequestWorkMs();
+								if (remainingWaitMs <= 0) {
+									return;
+								}
 								const waitOptions: WaitForReplicatorsOptions<R> = {
+									timeout: remainingWaitMs,
+									signal: checkedPruneRequestDeadlineController.signal,
+									persist: false,
+									drainInFlightChecks: false,
+									settlingWork: checkedPruneRequestWork.settlingWork,
 									onLeader: (key) => {
 										isLeader = isLeader || key === selfHash;
 									},
 								};
 								if (hasNativeEntry) {
-									await this._waitForGidReplicators(
-										gid,
-										replicas,
-										waitFor,
-										waitOptions,
+									const waitResult = await awaitRequestRead(() =>
+										this._waitForGidReplicators(
+											gid,
+											replicas,
+											waitFor,
+											waitOptions,
+										),
 									);
+									if (!waitResult.active) {
+										return;
+									}
 								} else {
-									await this._waitForEntryReplicators(
-										indexedEntry!.value,
-										replicas,
-										waitFor,
-										waitOptions,
+									const waitResult = await awaitRequestRead(() =>
+										this._waitForEntryReplicators(
+											indexedEntry!.value,
+											replicas,
+											waitFor,
+											waitOptions,
+										),
 									);
+									if (!waitResult.active) {
+										return;
+									}
 								}
 							}
 						}
@@ -21102,19 +22112,34 @@ export class SharedLog<
 					} else {
 						const prevPendingIHave = this._pendingIHave.get(hash);
 						if (prevPendingIHave) {
+							if (!this.addPendingIHaveRequester(prevPendingIHave, from)) {
+								continue;
+							}
 							pendingIHaveExtended += 1;
-							prevPendingIHave.requesting.add(from);
+							(prevPendingIHave.requestIdsByPeer ??= new Map()).set(
+								from,
+								requestsByHash.get(hash)!.requestId,
+							);
 							prevPendingIHave.resetTimeout();
 						} else {
+							if (!this.canCreatePendingIHave(from)) {
+								continue;
+							}
 							pendingIHaveCreated += 1;
-							const requesting = new Set([from]);
+							const requesting = new Set<string>();
+							const requestIdsByPeer = new Map<string, Uint8Array>();
 							let pendingIHave!: PendingIHave<T>;
 							pendingIHave = {
 								requesting,
+								requestIdsByPeer,
 								resetTimeout: () => this.resetPendingIHaveTimeout(pendingIHave),
 								clear: () => this.clearPendingIHaveTimeout(pendingIHave),
-								callback: async (entry: Entry<T>) => {
+								callback: async (
+									entry: Entry<T>,
+									work: PendingIHaveCallbackWork,
+								) => {
 									if (
+										!work.isActive() ||
 										!this.isReplicationLifecycleActive(
 											receiveReplicationLifecycleController,
 										) ||
@@ -21127,27 +22152,45 @@ export class SharedLog<
 											requester,
 											entry.meta.gid,
 										);
-										this.removePruneRequestSent(entry.hash, requester);
 									}
 									let isLeader = false;
-									await this._waitForEntryReplicators(
-										entry,
-										decodeReplicas(entry).getValue(this),
-										[
-											{
-												key: this.node.identity.publicKey.hashcode(),
-												replicator: true,
-											},
-										],
-										{
-											onLeader: (key) => {
-												isLeader =
-													isLeader ||
-													key === this.node.identity.publicKey.hashcode();
-											},
-										},
+									const remainingWaitMs = work.remainingMs();
+									if (remainingWaitMs <= 0) {
+										return;
+									}
+									const waitResult = await this.awaitCheckedPruneRequestRead(
+										() =>
+											this._waitForEntryReplicators(
+												entry,
+												decodeReplicas(entry).getValue(this),
+												[
+													{
+														key: this.node.identity.publicKey.hashcode(),
+														replicator: true,
+													},
+												],
+												{
+													timeout: remainingWaitMs,
+													signal: work.signal,
+													persist: false,
+													drainInFlightChecks: false,
+													settlingWork: work.settlingWork,
+													onLeader: (key) => {
+														isLeader =
+															isLeader ||
+															key === this.node.identity.publicKey.hashcode();
+													},
+												},
+											),
+										work.signal,
+										work.isActive,
+										work.settlingWork,
 									);
+									if (!waitResult.active) {
+										return;
+									}
 									if (
+										!work.isActive() ||
 										!this.isReplicationLifecycleActive(
 											receiveReplicationLifecycleController,
 										) ||
@@ -21156,30 +22199,62 @@ export class SharedLog<
 										return;
 									}
 									if (isLeader) {
-										this.responseToPruneDebouncedFn.add({
-											hashes: [entry.hash],
-											peers: new Set(requesting),
-										});
+										// Process requesters serially. A single retained hash can
+										// have thousands of requesters; launching every ACK at once
+										// would defeat the instance-wide callback admission bound.
+										for (const requester of [...requesting]) {
+											if (!work.isActive()) {
+												return;
+											}
+											const requestId = requestIdsByPeer.get(requester);
+											if (!requestId) {
+												continue;
+											}
+											const requestStillActive = () =>
+												work.isActive() &&
+												this.isReplicationLifecycleActive(
+													receiveReplicationLifecycleController,
+												) &&
+												requesting.has(requester) &&
+												requestIdsByPeer.get(requester) === requestId;
+											await this.admitCheckedPruneGrants(
+												[{ hash: entry.hash, requestId }],
+												requester,
+												requestStillActive,
+												work.signal,
+												work.settlingWork,
+											);
+										}
 									}
 								},
 							};
 
+							if (!this.addPendingIHaveRequester(pendingIHave, from)) {
+								continue;
+							}
+							requestIdsByPeer.set(from, requestsByHash.get(hash)!.requestId);
 							this._pendingIHave.set(hash, pendingIHave);
 							this.resetPendingIHaveTimeout(pendingIHave);
 						}
 					}
 				}
 				if (leaderResponseHashes.length > 0) {
-					this.responseToPruneDebouncedFn.add({
-						hashes: leaderResponseHashes,
-						peers: [from],
-					});
+					if (!receiveStillActive()) {
+						return;
+					}
+					await this.admitCheckedPruneGrants(
+						requestsFor(leaderResponseHashes),
+						from,
+						receiveStillActive,
+						checkedPruneRequestDeadlineController.signal,
+						checkedPruneRequestWork.settlingWork,
+					);
 				}
 				if (syncProfile) {
 					emitSyncProfileDuration(syncProfile, requestPruneLoopStartedAt, {
 						name: "sharedLog.receive.requestPrune.loop",
 						component: "shared-log",
-						entries: msg.hashes.length,
+						entries: requestHashes.length,
 						messages: 1,
 						details: {
 							presentEntries,
@@ -21196,30 +22271,53 @@ export class SharedLog<
 					emitSyncProfileDuration(syncProfile, requestPruneStartedAt, {
 						name: "sharedLog.receive.requestPrune.total",
 						component: "shared-log",
-						entries: msg.hashes.length,
+						entries: requestHashes.length,
 						messages: 1,
 					});
 				}
 			} else if (msg instanceof ResponseIPrune) {
-				const lateResponses: string[] = [];
+				// Legacy responses are never deletion authorization. Their hashes
+				// are not correlated to an exact attempt and may arrive a week late.
+				return;
+			} else if (msg instanceof ResponseIPruneV2) {
 				const responseTasks: Promise<void>[] = [];
-				for (const hash of msg.hashes) {
-					const pendingDelete = this._checkedPrune.getPendingDelete(hash);
-					if (pendingDelete) {
-						responseTasks.push(
-							Promise.resolve(pendingDelete.resolve(context.from.hashcode())),
-						);
-					} else {
-						lateResponses.push(hash);
-					}
+				const from = context.from.hashcode();
+				if (
+					msg.requests.length === 0 ||
+					msg.requests.length > CHECKED_PRUNE_MAX_REQUESTS_PER_MESSAGE
+				) {
+					return;
 				}
-				if (lateResponses.length > 0) {
-					responseTasks.push(
-						this.recoverCheckedPruneFromLateResponses(
-							lateResponses,
-							context.from.hashcode(),
-						),
+				const responseHashes = new Set<string>();
+				for (const request of msg.requests) {
+					if (
+						request.hash.length === 0 ||
+						request.hash.length > CHECKED_PRUNE_MAX_HASH_CODE_UNITS ||
+						request.requestId.length !== CHECKED_PRUNE_REQUEST_ID_BYTES ||
+						responseHashes.has(request.hash)
+					) {
+						return;
+					}
+					responseHashes.add(request.hash);
+				}
+				for (const request of msg.requests) {
+					const requestId = toHexString(request.requestId);
+					const pendingDelete = this._checkedPrune.getPendingDelete(
+						request.hash,
 					);
+					if (
+						pendingDelete &&
+						this._checkedPrune.isCurrentRequestForPeer(
+							request.hash,
+							pendingDelete,
+							from,
+							requestId,
+						)
+					) {
+						responseTasks.push(
+							Promise.resolve(pendingDelete.resolve(from, requestId)),
+						);
+					}
 				}
 				const results = await Promise.allSettled(responseTasks);
 				for (const result of results) {
@@ -21240,14 +22338,21 @@ export class SharedLog<
 						openingEpoch === receiveSubscriptionEpoch
 					) {
 						// A prior unsubscribe cleanup may still be ahead of this reconnect
-						// barrier. Stage the new generation's one-shot advertisement so that
-						// cleanup cannot erase it before the opening transition commits.
+						// barrier. Stage the new generation's advertisement so that cleanup
+						// cannot erase it before the opening transition commits. Merge
+						// repeated frames monotonically for the same epoch, matching the
+						// committed capability state.
+						const previous =
+							this._openingSyncCapabilitiesByPeer.get(receiveFromHash);
 						this._openingSyncCapabilitiesByPeer.set(receiveFromHash, {
 							epoch: openingEpoch,
-							capabilities: msg.capabilities,
+							capabilities:
+								previous?.epoch === openingEpoch
+									? (previous.capabilities | msg.capabilities) >>> 0
+									: msg.capabilities,
 						});
 					} else {
-						this._peerSyncCapabilities.set(receiveFromHash, msg.capabilities);
+						this.recordPeerSyncCapabilities(receiveFromHash, msg.capabilities);
 					}
 				}
 				return;
@@ -21571,6 +22676,12 @@ export class SharedLog<
 				// Every return and every locally swallowed receive error passes this
 				// boundary. Release a native wire stash exactly once first, then surface
 				// any durable mutation poison that arose while handling the message.
+				if (checkedPruneRequestDeadlineTimer) {
+					clearTimeout(checkedPruneRequestDeadlineTimer);
+					checkedPruneRequestDeadlineTimer = undefined;
+				}
+				checkedPruneRequestWork?.release();
+				checkedPruneRequestWork = undefined;
 				releasePeerReceiveLease?.();
 				releasePeerReceiveLease = undefined;
 				this.throwIfNativeDurableCommitFailed();
@@ -22259,6 +23370,9 @@ export class SharedLog<
 		options: WaitForReplicatorsOptions<R>,
 		checkLeaders: (options: WaitForReplicatorsOptions<R>) => Promise<LeaderMap>,
 	): Promise<LeaderMap | false> {
+		if (options.drainInFlightChecks === false && options.persist !== false) {
+			throw new Error("Non-draining leader waits require persist=false");
+		}
 		const timeout = options.timeout ?? this.waitForReplicatorTimeout;
 		const closeSignal = this._closeController.signal;
 		const replicationLifecycleSignal =
@@ -22272,12 +23386,17 @@ export class SharedLog<
 				this.events.removeEventListener("replicator:mature", roleListener);
 				closeSignal.removeEventListener("abort", abortListener);
 				replicationLifecycleSignal?.removeEventListener("abort", abortListener);
+				options.signal?.removeEventListener("abort", abortListener);
 			};
 			const settleResolve = (value: LeaderMap | false) => {
 				if (settled) return;
 				settled = true;
 				removeListeners();
 				clearTimeout(timer);
+				if (options.drainInFlightChecks === false) {
+					resolve(value);
+					return;
+				}
 				// Leader planning may persist coordinates. Keep the caller (and any
 				// receive lease it owns) alive until checks admitted before this
 				// timeout/abort have finished their local side effects.
@@ -22307,6 +23426,11 @@ export class SharedLog<
 						leaderKeys.add(key);
 					},
 				});
+				// Custom/native planners may return the authoritative leader map
+				// without replaying every key through the optional callback.
+				for (const key of leaders.keys()) {
+					leaderKeys.add(key);
+				}
 
 				for (const waitForKey of waitFor) {
 					if (waitForKey.replicator && !leaderKeys!.has(waitForKey.key)) {
@@ -22321,15 +23445,30 @@ export class SharedLog<
 
 				settleResolve(leaders);
 			};
+			let checkRunning = false;
+			let rerunRequested = false;
 			const runCheck = () => {
 				if (settled) return;
+				if (checkRunning) {
+					rerunRequested = true;
+					return;
+				}
+				checkRunning = true;
 				let running!: Promise<void>;
 				running = check()
 					.catch((error) => {
 						settleReject(error);
 					})
-					.finally(() => checks.delete(running));
+					.finally(() => {
+						checks.delete(running);
+						checkRunning = false;
+						if (rerunRequested && !settled) {
+							rerunRequested = false;
+							runCheck();
+						}
+					});
 				checks.add(running);
+				options.settlingWork?.track(running);
 			};
 
 			const roleListener = () => {
@@ -22340,10 +23479,15 @@ export class SharedLog<
 			this.events.addEventListener("replicator:mature", roleListener);
 			closeSignal.addEventListener("abort", abortListener);
 			replicationLifecycleSignal?.addEventListener("abort", abortListener);
+			options.signal?.addEventListener("abort", abortListener);
 			// AbortSignal does not replay an abort event to listeners added after it
 			// fired. Recheck after registration so work started concurrently with the
 			// terminal fence cannot wait for the full leader-selection timeout.
-			if (closeSignal.aborted || replicationLifecycleSignal?.aborted) {
+			if (
+				closeSignal.aborted ||
+				replicationLifecycleSignal?.aborted ||
+				options.signal?.aborted
+			) {
 				abortListener();
 				return;
 			}
@@ -22521,11 +23665,19 @@ export class SharedLog<
 	private async planCurrentNativeBackboneRequestPruneLeaderHints(
 		hashes: string[],
 		from: string,
+		isActive: () => boolean = () => true,
 	): Promise<NativeRequestPruneLeaderHints | undefined> {
-		if (!this._nativeBackbone) {
+		if (!this._nativeBackbone || !isActive()) {
 			return undefined;
 		}
 		const context = await this.createLeaderSelectionContext();
+		// The all-confirmed native fast path also removes the pruning peer from
+		// native gid history. Fence that synchronous mutation after the only
+		// asynchronous boundary so a timed-out or superseded receive cannot
+		// resume and alter the current subscription generation.
+		if (!isActive()) {
+			return undefined;
+		}
 		const skipHashes =
 			this._checkedPrune.pendingDeletes.size > 0
 				? [...this._checkedPrune.pendingDeletes.keys()]
@@ -22561,6 +23713,9 @@ export class SharedLog<
 					nativeBackbonePeerHistoryCleaned: true,
 				};
 			}
+		}
+		if (!isActive()) {
+			return undefined;
 		}
 		const hintColumns =
 			nativeBackboneHintArrays.planRequestPruneLeaderHintColumns?.(
@@ -26207,6 +27362,7 @@ export class SharedLog<
 	}
 
 	private advanceSubscriptionEpoch(peerHash: string): object {
+		this.cancelSyncCapabilityRepair(peerHash);
 		const next = {};
 		this._subscriptionEpochByPeer.set(peerHash, next);
 		return next;
@@ -26230,6 +27386,112 @@ export class SharedLog<
 			clearTimeout(state.timer);
 		}
 		this._replicationInfoRequestByPeer.delete(peerHash);
+	}
+
+	private cancelSyncCapabilityRepair(
+		peerHash: string,
+		expected?: SyncCapabilityRepairState,
+	): void {
+		const state = this._syncCapabilityRepairByPeer.get(peerHash);
+		if (!state || (expected && state !== expected)) {
+			return;
+		}
+		if (state.timer) {
+			clearTimeout(state.timer);
+		}
+		this._syncCapabilityRepairByPeer.delete(peerHash);
+		state.controller.abort();
+	}
+
+	private cancelAllSyncCapabilityRepairs(): void {
+		for (const peerHash of [...this._syncCapabilityRepairByPeer.keys()]) {
+			this.cancelSyncCapabilityRepair(peerHash);
+		}
+	}
+
+	private scheduleSyncCapabilityRepair(
+		peer: PublicSignKey,
+		capabilities: number,
+		replicationLifecycleController: AbortController,
+		subscriptionEpoch: object,
+	): void {
+		const peerHash = peer.hashcode();
+		if (
+			!this.isReplicationLifecycleActive(replicationLifecycleController) ||
+			!this.isCurrentSubscriptionEpoch(peerHash, subscriptionEpoch)
+		) {
+			return;
+		}
+		const existing = this._syncCapabilityRepairByPeer.get(peerHash);
+		if (existing?.subscriptionEpoch === subscriptionEpoch) {
+			return;
+		}
+		this.cancelSyncCapabilityRepair(peerHash);
+
+		const state: SyncCapabilityRepairState = {
+			subscriptionEpoch,
+			attempts: 0,
+			controller: new AbortController(),
+		};
+		this._syncCapabilityRepairByPeer.set(peerHash, state);
+		const signal = AbortSignal.any([
+			replicationLifecycleController.signal,
+			state.controller.signal,
+		]);
+		const isCurrent = () =>
+			this._syncCapabilityRepairByPeer.get(peerHash) === state &&
+			this.isReplicationLifecycleActive(replicationLifecycleController) &&
+			this.isCurrentSubscriptionEpoch(peerHash, subscriptionEpoch) &&
+			!signal.aborted;
+
+		const scheduleNext = () => {
+			if (!isCurrent()) {
+				this.cancelSyncCapabilityRepair(peerHash, state);
+				return;
+			}
+			const delay = Math.min(
+				SYNC_CAPABILITY_REPAIR_MAX_DELAY_MS,
+				SYNC_CAPABILITY_REPAIR_MIN_DELAY_MS * 2 ** Math.min(state.attempts, 16),
+			);
+			state.timer = setTimeout(() => {
+				state.timer = undefined;
+				if (!isCurrent()) {
+					this.cancelSyncCapabilityRepair(peerHash, state);
+					return;
+				}
+				state.attempts++;
+				void this.rpc
+					.send(
+						new SyncCapabilitiesMessage({
+							capabilities,
+						}),
+						{
+							mode: new AcknowledgeDelivery({
+								redundancy: 1,
+								to: [peer],
+							}),
+							signal,
+						},
+					)
+					.then(() => {
+						this.cancelSyncCapabilityRepair(peerHash, state);
+					})
+					.catch((error) => {
+						if (!isCurrent()) {
+							this.cancelSyncCapabilityRepair(peerHash, state);
+							return;
+						}
+						this.handleReplicationLifecycleSendError(
+							error,
+							replicationLifecycleController,
+						);
+						scheduleNext();
+					});
+			}, delay);
+			state.timer.unref?.();
+		};
+
+		scheduleNext();
 	}
 
 	private scheduleReplicationInfoRequests(
@@ -26366,7 +27628,7 @@ export class SharedLog<
 				const openingCapabilities =
 					this._openingSyncCapabilitiesByPeer.get(peerHash);
 				if (openingCapabilities?.epoch === expectedSubscriptionEpoch) {
-					this._peerSyncCapabilities.set(
+					this.recordPeerSyncCapabilities(
 						peerHash,
 						openingCapabilities.capabilities,
 					);
@@ -26445,28 +27707,6 @@ export class SharedLog<
 		this._replicatorLivenessFailures.delete(peerHash);
 		this.markReplicatorActivity(peerHash);
 
-		if (this._logProperties?.sync?.rawExchangeHeads === true) {
-			// One-shot capability advertisement so live append gossip can pick
-			// the raw exchange-heads path for this peer without a per-request
-			// round trip. Peers that do not know the message drop it.
-			this.rpc
-				.send(
-					new SyncCapabilitiesMessage({
-						capabilities: SYNC_CAPABILITY_RAW_EXCHANGE_HEADS,
-					}),
-					{
-						mode: new SilentDelivery({ redundancy: 1, to: [publicKey] }),
-						signal: replicationLifecycleController.signal,
-					},
-				)
-				.catch((error) =>
-					this.handleReplicationLifecycleSendError(
-						error,
-						replicationLifecycleController,
-					),
-				);
-		}
-
 		let replicationSegments: ReplicationRangeIndexable<R>[];
 		try {
 			replicationSegments = await this.getMyReplicationSegments();
@@ -26485,9 +27725,53 @@ export class SharedLog<
 		) {
 			return;
 		}
-		if (replicationSegments.length > 0) {
-			const segments = replicationSegments.map((x) => x.toReplicationRange());
+		const segments =
+			replicationSegments.length > 0
+				? replicationSegments.map((x) => x.toReplicationRange())
+				: undefined;
+		if (segments) {
 			this.validatePersistedReplicationRangeSnapshot(segments);
+		}
+
+		// Checked-prune correlation is always supported by this version. Raw
+		// exchange-heads remains opt-in. Validate local ownership first, then
+		// publish this capability before any ownership announcement.
+		const syncCapabilities =
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF |
+			(this._logProperties?.sync?.rawExchangeHeads === true
+				? SYNC_CAPABILITY_RAW_EXCHANGE_HEADS
+				: 0);
+		const sendSyncCapabilities = () =>
+			this.rpc.send(
+				new SyncCapabilitiesMessage({
+					capabilities: syncCapabilities,
+				}),
+				{
+					mode: new AcknowledgeDelivery({
+						redundancy: 1,
+						to: [publicKey],
+					}),
+					signal: replicationLifecycleController.signal,
+				},
+			);
+		let syncCapabilitiesAdvertised = false;
+		try {
+			await sendSyncCapabilities();
+			syncCapabilitiesAdvertised = true;
+		} catch (error) {
+			this.handleReplicationLifecycleSendError(
+				error,
+				replicationLifecycleController,
+			);
+		}
+		if (
+			!this.isReplicationLifecycleActive(replicationLifecycleController) ||
+			!ownsSubscriptionEpoch()
+		) {
+			return;
+		}
+
+		if (segments) {
 			await this.rpc
 				.send(
 					new AllReplicatingSegmentsMessage({
@@ -26533,6 +27817,18 @@ export class SharedLog<
 						),
 					);
 			}
+		}
+
+		if (!syncCapabilitiesAdvertised) {
+			// A failed first ACK must not permanently strand this subscription in
+			// fail-closed mode after the following ownership ACK discovers a route.
+			// Keep repairing with bounded backoff for exactly this subscription epoch.
+			this.scheduleSyncCapabilityRepair(
+				publicKey,
+				syncCapabilities,
+				replicationLifecycleController,
+				expectedSubscriptionEpoch,
+			);
 		}
 
 		// Request the remote peer's replication info. This makes joins resilient to
@@ -26640,47 +27936,141 @@ export class SharedLog<
 
 		const promises: Promise<any>[] = [];
 
-		let peerToEntries: Map<string, string[]> = new Map();
-		let cleanupTimer: ReturnType<typeof setTimeout>[] = [];
+		type ClaimedCheckedPruneRequest = {
+			hash: string;
+			pendingDelete: CheckedPrunePendingDelete;
+			requestId: string;
+			ownsResend: boolean;
+		};
+		const peerToEntries = new Map<string, ClaimedCheckedPruneRequest[]>();
 		const explicitTimeout = options?.timeout != null;
 
 		for (const { entry, leaders } of entries.values()) {
+			const capableLeaders: string[] = [];
 			for (const leader of leaders.keys()) {
-				let set = peerToEntries.get(leader);
-				if (!set) {
-					set = [];
-					peerToEntries.set(leader, set);
+				// Unknown/older peers cannot provide replay-safe authorization.
+				// Excluding them keeps mixed-version operation fail-closed.
+				if (this.peerSupportsCheckedPruneHandoff(leader)) {
+					capableLeaders.push(leader);
 				}
-
-				set.push(entry.hash);
 			}
+			const claimCapableLeaderRequests = (
+				pendingDelete: CheckedPrunePendingDelete,
+			) => {
+				for (const leader of capableLeaders) {
+					let activeRequestId = checkedPruneCoordinator.getRequestId(
+						entry.hash,
+						leader,
+					);
+					let claimed = false;
+					if (activeRequestId == null) {
+						const requestId = toHexString(
+							randomBytes(CHECKED_PRUNE_REQUEST_ID_BYTES),
+						);
+						claimed = checkedPruneCoordinator.claimRequestSent(
+							entry.hash,
+							leader,
+							pendingDelete,
+							requestId,
+						);
+						activeRequestId = claimed
+							? requestId
+							: checkedPruneCoordinator.getRequestId(entry.hash, leader);
+					}
+					const ownsResend =
+						pendingDelete.background &&
+						activeRequestId != null &&
+						checkedPruneCoordinator.claimAutoResend(
+							entry.hash,
+							leader,
+							pendingDelete,
+							activeRequestId,
+						);
+					// Preserve the explicit caller's one-shot retry behavior without
+					// giving it a second periodic resend owner. Background duplicates
+					// only emit for newly claimed targets or when promoting an
+					// explicit-first generation to its sole periodic resend owner.
+					if (
+						!claimed &&
+						!ownsResend &&
+						(!explicitTimeout ||
+							activeRequestId == null ||
+							!checkedPruneCoordinator.isCurrentRequestForPeer(
+								entry.hash,
+								pendingDelete,
+								leader,
+								activeRequestId,
+							))
+					) {
+						continue;
+					}
+					if (activeRequestId == null) {
+						continue;
+					}
+					let set = peerToEntries.get(leader);
+					if (!set) {
+						set = [];
+						peerToEntries.set(leader, set);
+					}
+					set.push({
+						hash: entry.hash,
+						pendingDelete,
+						requestId: activeRequestId,
+						ownsResend,
+					});
+				}
+			};
+			const wrapExplicitPending = (
+				pendingDelete: CheckedPrunePendingDelete,
+			) => {
+				const timeoutMs = Math.max(0, Math.floor(options?.timeout ?? 0));
+				return new Promise<void>((resolve, reject) => {
+					const timer = setTimeout(() => {
+						const error = new Error(
+							`Timeout for checked pruning after ${timeoutMs}ms (pending=true closed=${this.closed})`,
+						);
+						reject(error);
+						if (
+							checkedPruneCoordinator.isCurrentRequest(
+								entry.hash,
+								pendingDelete,
+							) &&
+							!pendingDelete.background
+						) {
+							try {
+								void Promise.resolve(pendingDelete.reject(error)).catch(
+									() => {},
+								);
+							} catch {}
+						}
+					}, timeoutMs);
+					timer.unref?.();
+					void pendingDelete.promise.promise.then(
+						() => {
+							clearTimeout(timer);
+							resolve();
+						},
+						(error) => {
+							clearTimeout(timer);
+							reject(error);
+						},
+					);
+				});
+			};
 
 			const pendingPrev = checkedPruneCoordinator.getPendingDelete(entry.hash);
 			if (pendingPrev) {
+				if (!explicitTimeout) {
+					checkedPruneCoordinator.promoteToBackground(entry.hash, pendingPrev);
+				}
+				claimCapableLeaderRequests(pendingPrev);
 				// If a background prune is already in-flight, an explicit prune request should
 				// still respect the caller's timeout. Otherwise, tests (and user calls) can
 				// block on the longer "checked prune" timeout derived from
 				// `_respondToIHaveTimeout + waitForReplicatorTimeout`, which is intentionally
 				// large for resiliency.
 				if (explicitTimeout) {
-					const timeoutMs = Math.max(0, Math.floor(options?.timeout ?? 0));
-					promises.push(
-						new Promise((resolve, reject) => {
-							// Mirror the checked-prune error prefix so existing callers/tests can
-							// match on the message substring.
-							const timer = setTimeout(() => {
-								reject(
-									new Error(
-										`Timeout for checked pruning after ${timeoutMs}ms (pending=true closed=${this.closed})`,
-									),
-								);
-							}, timeoutMs);
-							timer.unref?.();
-							pendingPrev.promise.promise
-								.then(resolve, reject)
-								.finally(() => clearTimeout(timer));
-						}),
-					);
+					promises.push(wrapExplicitPending(pendingPrev));
 				} else {
 					promises.push(pendingPrev.promise.promise);
 				}
@@ -26688,15 +28078,57 @@ export class SharedLog<
 			}
 
 			const minReplicas = decodeReplicas(entry);
+			const minReplicasValue =
+				this.getClampedReplicas(minReplicas).getValue(this);
+			if (capableLeaders.length < minReplicasValue) {
+				const error = new Error(
+					`Insufficient checked-prune capable leaders (${capableLeaders.length}/${minReplicasValue})`,
+				);
+				if (!explicitTimeout) {
+					this.scheduleCheckedPruneRetry(
+						{ entry, leaders },
+						ownershipLifecycleController,
+					);
+				}
+				const failed = Promise.reject(error);
+				// Background pruning intentionally ignores the returned promise array.
+				// Attach an observer here while preserving rejection for explicit callers.
+				void failed.catch(() => {});
+				promises.push(failed);
+				continue;
+			}
 			const deferredPromise: DeferredPromise<void> = pDefer();
-			let finalOwnershipRevalidationFailed = false;
+			// Background pruning is intentionally fire-and-forget. Keep an internal
+			// observer attached so an expected timeout or peer disconnect cannot
+			// become a process-level unhandled rejection; explicit callers still
+			// receive and observe the original rejecting promise below.
+			void deferredPromise.promise.catch(() => {});
+			let pendingDelete!: CheckedPrunePendingDelete;
+			let pruneDeleteStarted = false;
+			const checkedPruneBackgroundTimeoutMs = Math.max(
+				CHECKED_PRUNE_BACKGROUND_TIMEOUT_MIN_MS,
+				Number(this._respondToIHaveTimeout ?? 0) +
+					this.waitForReplicatorTimeout +
+					PRUNE_DEBOUNCE_INTERVAL * 2,
+			);
+			const generationTimeoutMs = Math.max(
+				checkedPruneBackgroundTimeoutMs,
+				Math.max(0, Math.floor(options?.timeout ?? 0)),
+			);
+			let generationTimeout: ReturnType<typeof setTimeout>;
+			let removalTimer: ReturnType<typeof setTimeout> | undefined;
+			let removalScheduled = false;
 
 			const clear = () => {
 				const pending = checkedPruneCoordinator.getPendingDelete(entry.hash);
 				if (pending?.promise === deferredPromise) {
 					checkedPruneCoordinator.deletePendingDelete(entry.hash, pending);
 				}
-				clearTimeout(timeout);
+				clearTimeout(generationTimeout);
+				if (removalTimer) {
+					clearTimeout(removalTimer);
+					removalTimer = undefined;
+				}
 			};
 
 			const resolve = () => {
@@ -26706,24 +28138,167 @@ export class SharedLog<
 					reject(error);
 					return;
 				}
-				clearTimeout(timeout);
+				if (removalScheduled) {
+					return;
+				}
+				removalScheduled = true;
+				clearTimeout(generationTimeout);
 				checkedPruneCoordinator.clearRetry(entry.hash);
-				cleanupTimer.push(
-					setTimeout(() => {
-						const run = async () => {
-							throwIfCheckedPruneLifecycleInactive();
-							const ownership = await this.revalidateCheckedPruneOwnership({
-								hash: entry.hash,
-								entry,
-								leaders: this.checkedPruneLeadersToMap(leaders),
-								selfReplicating: true,
+				removalTimer = setTimeout(() => {
+					const run = async () => {
+						throwIfCheckedPruneLifecycleInactive();
+						const ownership = await this.revalidateCheckedPruneOwnership({
+							hash: entry.hash,
+							entry,
+							leaders: this.checkedPruneLeadersToMap(leaders),
+							selfReplicating: true,
+							ownershipLifecycleController,
+							checkedPruneCoordinator,
+						});
+						throwIfCheckedPruneLifecycleInactive();
+						if (
+							checkedPruneCoordinator.getPendingDelete(entry.hash) !==
+							pendingDelete
+						) {
+							throw new TerminalOperationNotStartedError(
+								"Checked prune session changed during ownership revalidation",
+							);
+						}
+						if (ownership.localLeader) {
+							const resilient = pendingDelete.background;
+							const isCurrentGeneration =
+								checkedPruneCoordinator.isCurrentRequest(
+									entry.hash,
+									pendingDelete,
+								);
+							clear();
+							if (isCurrentGeneration) {
+								checkedPruneCoordinator.markCancelled(entry.hash, {
+									preserveRetry: resilient,
+								});
+							}
+							if (resilient && isCurrentGeneration) {
+								this.scheduleCheckedPruneRetry(
+									{ entry, leaders },
+									ownershipLifecycleController,
+								);
+							}
+							deferredPromise.reject(
+								new Error("Failed to delete, is leader again"),
+							);
+							return;
+						}
+
+						try {
+							const removed = await this.withReplicationRangeMutationQueue(
+								async () => {
+									throwIfCheckedPruneLifecycleInactive();
+									if (
+										checkedPruneCoordinator.getPendingDelete(entry.hash) !==
+										pendingDelete
+									) {
+										throw new TerminalOperationNotStartedError(
+											"Checked prune session is no longer active at the delete boundary",
+										);
+									}
+									// The network confirmation and preliminary planner check
+									// deliberately happen outside the global ownership lane. Once
+									// admitted here, re-read leadership and keep the lower-log
+									// delete in the same lane so a durable range mutation cannot
+									// commit between the decision and the destructive operation.
+									const finalOwnership =
+										await this.revalidateCheckedPruneOwnership({
+											hash: entry.hash,
+											entry,
+											leaders: this.checkedPruneLeadersToMap(leaders),
+											selfReplicating: true,
+											requireFreshLeaderDecision: true,
+											ownershipLifecycleController,
+											checkedPruneCoordinator,
+										});
+									throwIfCheckedPruneLifecycleInactive();
+									if (
+										checkedPruneCoordinator.getPendingDelete(entry.hash) !==
+										pendingDelete
+									) {
+										throw new TerminalOperationNotStartedError(
+											"Checked prune session changed before removal",
+										);
+									}
+									if (finalOwnership.localLeader) {
+										return false;
+									}
+									const contactedReplicators =
+										checkedPruneCoordinator.getContactedReplicators(entry.hash);
+									const confirmedReplicators =
+										checkedPruneCoordinator.getConfirmedReplicators(entry.hash);
+									let activeConfirmedReplicators = 0;
+									for (const peer of confirmedReplicators ?? []) {
+										const requestId = checkedPruneCoordinator.getRequestId(
+											entry.hash,
+											peer,
+										);
+										if (
+											contactedReplicators?.has(peer) &&
+											requestId != null &&
+											checkedPruneCoordinator.getConfirmedRequestId(
+												entry.hash,
+												peer,
+											) === requestId &&
+											finalOwnership.leaders.has(peer)
+										) {
+											activeConfirmedReplicators++;
+										}
+									}
+									if (activeConfirmedReplicators < minReplicasValue) {
+										throw new Error(
+											"Checked prune confirmation is no longer active at the delete boundary",
+										);
+									}
+
+									this.deleteGidPeerHistory(entry.meta.gid);
+									checkedPruneCoordinator.removeRequestSent(entry.hash);
+									checkedPruneCoordinator.clearConfirmedReplicators(entry.hash);
+									throwIfCheckedPruneLifecycleInactive();
+									checkedPruneCoordinator.markRemoving(entry.hash);
+									this._checkedPruneRemoveBlocksLocalRangeMutationAdmission++;
+									pruneDeleteStarted = true;
+									try {
+										await this.trackAdmittedPruneRemove(
+											() =>
+												this.log.remove(entry, {
+													recursively: false,
+												}),
+											ownershipLifecycleController,
+										);
+									} finally {
+										this._checkedPruneRemoveBlocksLocalRangeMutationAdmission--;
+									}
+									// Complete only the exact generation that admitted this
+									// lower-log removal. An explicit timeout or disconnect can
+									// retire it while the admitted remove is still settling and
+									// allow a replacement generation to start.
+									checkedPruneCoordinator.markDone(entry.hash, pendingDelete);
+									clear();
+									deferredPromise.resolve();
+									return true;
+								},
 								ownershipLifecycleController,
-								checkedPruneCoordinator,
-							});
-							throwIfCheckedPruneLifecycleInactive();
-							if (ownership.localLeader) {
+							);
+							if (!removed) {
+								const resilient = pendingDelete.background;
+								const isCurrentGeneration =
+									checkedPruneCoordinator.isCurrentRequest(
+										entry.hash,
+										pendingDelete,
+									);
 								clear();
-								if (!explicitTimeout) {
+								if (isCurrentGeneration) {
+									checkedPruneCoordinator.markCancelled(entry.hash, {
+										preserveRetry: resilient,
+									});
+								}
+								if (resilient && isCurrentGeneration) {
 									this.scheduleCheckedPruneRetry(
 										{ entry, leaders },
 										ownershipLifecycleController,
@@ -26734,295 +28309,386 @@ export class SharedLog<
 								);
 								return;
 							}
-
-							try {
-								const removed = await this.withReplicationRangeMutationQueue(
-									async () => {
-										throwIfCheckedPruneLifecycleInactive();
-										if (
-											checkedPruneCoordinator.getPendingDelete(entry.hash)
-												?.promise !== deferredPromise
-										) {
-											throw new TerminalOperationNotStartedError(
-												"Checked prune session is no longer active at the delete boundary",
-											);
-										}
-										// The network confirmation and preliminary planner check
-										// deliberately happen outside the global ownership lane. Once
-										// admitted here, re-read leadership and keep the lower-log
-										// delete in the same lane so a durable range mutation cannot
-										// commit between the decision and the destructive operation.
-										let finalOwnership: {
-											leaders: CheckedPruneLeaderMap;
-											localLeader: boolean;
-										};
-										try {
-											finalOwnership =
-												await this.revalidateCheckedPruneOwnership({
-													hash: entry.hash,
-													entry,
-													leaders: this.checkedPruneLeadersToMap(leaders),
-													selfReplicating: true,
-													requireFreshLeaderDecision: true,
-													ownershipLifecycleController,
-													checkedPruneCoordinator,
-												});
-										} catch (error) {
-											finalOwnershipRevalidationFailed = true;
-											throw error;
-										}
-										throwIfCheckedPruneLifecycleInactive();
-										if (
-											checkedPruneCoordinator.getPendingDelete(entry.hash)
-												?.promise !== deferredPromise
-										) {
-											throw new TerminalOperationNotStartedError(
-												"Checked prune session changed before removal",
-											);
-										}
-										if (finalOwnership.localLeader) {
-											return false;
-										}
-
-										this.deleteGidPeerHistory(entry.meta.gid);
-										checkedPruneCoordinator.removeRequestSent(entry.hash);
-										checkedPruneCoordinator.clearConfirmedReplicators(
-											entry.hash,
-										);
-										throwIfCheckedPruneLifecycleInactive();
-										checkedPruneCoordinator.markRemoving(entry.hash);
-										this._checkedPruneRemoveBlocksLocalRangeMutationAdmission++;
-										try {
-											await this.trackAdmittedPruneRemove(
-												() =>
-													this.log.remove(entry, {
-														recursively: true,
-													}),
-												ownershipLifecycleController,
-											);
-										} finally {
-											this
-												._checkedPruneRemoveBlocksLocalRangeMutationAdmission--;
-										}
-										clear();
-										checkedPruneCoordinator.markDone(entry.hash);
-										deferredPromise.resolve();
-										return true;
-									},
+						} catch (error) {
+							const resilient = pendingDelete.background;
+							const isCurrentGeneration =
+								checkedPruneCoordinator.isCurrentRequest(
+									entry.hash,
+									pendingDelete,
+								);
+							clear();
+							if (isCurrentGeneration) {
+								checkedPruneCoordinator.markCancelled(entry.hash, {
+									// Everything before the lower-log delete starts is a
+									// definite no-delete failure and can be retried safely. A
+									// lower-log rejection may follow a partial commit, so do not
+									// guess by replaying it.
+									preserveRetry: resilient && !pruneDeleteStarted,
+								});
+							}
+							if (isCurrentGeneration && resilient && !pruneDeleteStarted) {
+								this.scheduleCheckedPruneRetry(
+									{ entry, leaders },
 									ownershipLifecycleController,
 								);
-								if (!removed) {
-									clear();
-									if (!explicitTimeout) {
-										this.scheduleCheckedPruneRetry(
-											{ entry, leaders },
-											ownershipLifecycleController,
-										);
-									}
-									deferredPromise.reject(
-										new Error("Failed to delete, is leader again"),
-									);
-									return;
-								}
-							} catch (error) {
-								clear();
-								checkedPruneCoordinator.markCancelled(entry.hash, {
-									preserveRetry:
-										!explicitTimeout && finalOwnershipRevalidationFailed,
-								});
-								if (!explicitTimeout && finalOwnershipRevalidationFailed) {
-									this.scheduleCheckedPruneRetry(
-										{ entry, leaders },
-										ownershipLifecycleController,
-									);
-								}
-								deferredPromise.reject(error);
-								return;
 							}
+							deferredPromise.reject(error);
+							return;
+						}
 
-							// The delete has already settled. Diagnostics are best-effort:
-							// poison/close/reopen must not turn an ignored timer callback into
-							// an unhandled rejection or mutate the next lifecycle.
-							if (!isCheckedPruneLifecycleCurrent()) {
-								return;
+						// The delete has already settled. Diagnostics are best-effort:
+						// poison/close/reopen must not turn an ignored timer callback into
+						// an unhandled rejection or mutate the next lifecycle.
+						if (!isCheckedPruneLifecycleCurrent()) {
+							return;
+						}
+						try {
+							this.deleteGidPeerHistory(entry.meta.gid);
+							const postRemoveOwnership =
+								await this.revalidateCheckedPruneOwnership({
+									hash: entry.hash,
+									entry,
+									leaders: this.checkedPruneLeadersToMap(leaders),
+									selfReplicating: true,
+									ownershipLifecycleController,
+									checkedPruneCoordinator,
+								});
+							if (
+								isCheckedPruneLifecycleCurrent() &&
+								postRemoveOwnership.localLeader
+							) {
+								logger.error("Unexpected: Is leader after delete");
 							}
-							try {
-								this.deleteGidPeerHistory(entry.meta.gid);
-								checkedPruneCoordinator.removeRequestSent(entry.hash);
-								checkedPruneCoordinator.clearConfirmedReplicators(entry.hash);
-								const postRemoveOwnership =
-									await this.revalidateCheckedPruneOwnership({
-										hash: entry.hash,
-										entry,
-										leaders: this.checkedPruneLeadersToMap(leaders),
-										selfReplicating: true,
-										ownershipLifecycleController,
-										checkedPruneCoordinator,
-									});
-								if (
-									isCheckedPruneLifecycleCurrent() &&
-									postRemoveOwnership.localLeader
-								) {
-									logger.error("Unexpected: Is leader after delete");
-								}
-							} catch (error) {
-								if (
-									isCheckedPruneLifecycleCurrent() &&
-									!isNotStartedError(error as Error)
-								) {
-									logger.error(error);
-								}
+						} catch (error) {
+							if (
+								isCheckedPruneLifecycleCurrent() &&
+								!isNotStartedError(error as Error)
+							) {
+								logger.error(error);
 							}
-						};
-						void run().catch((error) => {
-							reject(error);
-						});
-					}, this.waitForPruneDelay),
-				);
+						}
+					};
+					void run().catch((error) => {
+						const resilient = pendingDelete.background;
+						const isCurrentGeneration =
+							checkedPruneCoordinator.isCurrentRequest(
+								entry.hash,
+								pendingDelete,
+							);
+						if (isCurrentGeneration && resilient && !pruneDeleteStarted) {
+							clear();
+							checkedPruneCoordinator.markCancelled(entry.hash, {
+								preserveRetry: true,
+							});
+							deferredPromise.reject(error);
+							this.scheduleCheckedPruneRetry(
+								{ entry, leaders },
+								ownershipLifecycleController,
+							);
+							return;
+						}
+						reject(error);
+					});
+				}, this.waitForPruneDelay);
 			};
 
 			const reject = (e: any) => {
+				const resilient = pendingDelete.background;
+				const isCurrentGeneration = checkedPruneCoordinator.isCurrentRequest(
+					entry.hash,
+					pendingDelete,
+				);
 				clear();
 				const isCheckedPruneTimeout =
 					e instanceof Error &&
 					typeof e.message === "string" &&
 					e.message.startsWith("Timeout for checked pruning");
-				checkedPruneCoordinator.markCancelled(entry.hash, {
-					preserveRetry: !explicitTimeout && isCheckedPruneTimeout,
-				});
+				if (isCurrentGeneration) {
+					checkedPruneCoordinator.markCancelled(entry.hash, {
+						preserveRetry: resilient && isCheckedPruneTimeout,
+					});
+				}
 				deferredPromise.reject(e);
 			};
 
-			// Checked prune requests can legitimately take longer than a fixed 10s:
-			// - The remote may not have the entry yet and will wait up to `_respondToIHaveTimeout`
-			// - Leadership/replicator information may take up to `waitForReplicatorTimeout` to settle
-			// If we time out too early we can end up with permanently prunable heads that never
-			// get retried (a common CI flake in "prune before join" tests).
-			const checkedPruneTimeoutMs =
-				options?.timeout ??
-				Math.max(
-					CHECKED_PRUNE_BACKGROUND_TIMEOUT_MIN_MS,
-					Number(this._respondToIHaveTimeout ?? 0) +
-						this.waitForReplicatorTimeout +
-						PRUNE_DEBOUNCE_INTERVAL * 2,
-				);
+			pendingDelete = {
+				promise: deferredPromise,
+				background: !explicitTimeout,
+				promoteToBackground: () => {
+					pendingDelete.background = true;
+				},
+				clear,
+				reject,
+				resolve: async (publicKeyHash: string, requestId: string) => {
+					try {
+						throwIfCheckedPruneLifecycleInactive();
+					} catch (error) {
+						reject(error);
+						return;
+					}
+					if (
+						!checkedPruneCoordinator.isCurrentRequestForPeer(
+							entry.hash,
+							pendingDelete,
+							publicKeyHash,
+							requestId,
+						)
+					) {
+						return;
+					}
+					// Confirmation recording below is synchronous up to the request-id
+					// commit, so exact replays cannot interleave before this guard changes.
+					if (
+						checkedPruneCoordinator.getConfirmedRequestId(
+							entry.hash,
+							publicKeyHash,
+						) === requestId
+					) {
+						return;
+					}
+					// The authenticated responder admitted this exact request only
+					// after verifying that it holds the block and is a leader. Do not
+					// wait for the requester's membership view to converge here: the
+					// destructive boundary below re-plans under the global ownership
+					// lane and counts only still-current confirmed peers that remain
+					// leaders.
+					const existCounter = checkedPruneCoordinator.addConfirmedReplicator(
+						entry.hash,
+						publicKeyHash,
+						pendingDelete,
+						requestId,
+					);
+					if (!existCounter) {
+						return;
+					}
+					// Seed provider hints so future remote reads can avoid extra round-trips.
+					this.remoteBlocks.hintProviders(entry.hash, [publicKeyHash]);
 
-			const timeout = setTimeout(() => {
-				// For internal/background prune flows (no explicit timeout), retry a few times
-				// to avoid "permanently prunable" entries when `_pendingIHave` expires under
-				// heavy load.
-				if (!explicitTimeout && isCheckedPruneLifecycleCurrent()) {
+					if (minReplicasValue <= existCounter.size) {
+						resolve();
+					}
+				},
+			};
+			// Every generation retains a background-sized internal deadline. An
+			// explicit caller has its own shorter wrapper below; promotion makes
+			// that wrapper caller-only while this generation remains retryable.
+			generationTimeout = setTimeout(() => {
+				if (
+					!isCheckedPruneLifecycleCurrent() ||
+					!checkedPruneCoordinator.isCurrentRequest(entry.hash, pendingDelete)
+				) {
+					return;
+				}
+				const resilient = pendingDelete.background;
+				const error = new Error(
+					`Timeout for checked pruning after ${generationTimeoutMs}ms (closed=${this.closed})`,
+				);
+				reject(error);
+				if (resilient && isCheckedPruneLifecycleCurrent()) {
 					this.scheduleCheckedPruneRetry(
 						{ entry, leaders },
 						ownershipLifecycleController,
 					);
 				}
-				reject(
-					new Error(
-						`Timeout for checked pruning after ${checkedPruneTimeoutMs}ms (closed=${this.closed})`,
-					),
-				);
-			}, checkedPruneTimeoutMs);
-			timeout.unref?.();
-
+			}, generationTimeoutMs);
+			generationTimeout.unref?.();
 			checkedPruneCoordinator.setPendingDelete(
 				entry.hash,
-				{
-					promise: deferredPromise,
-					clear,
-					reject,
-					resolve: async (publicKeyHash: string) => {
-						try {
-							throwIfCheckedPruneLifecycleInactive();
-						} catch (error) {
-							reject(error);
-							return;
-						}
-						const minReplicasObj = this.getClampedReplicas(minReplicas);
-						const minReplicasValue = minReplicasObj.getValue(this);
-
-						// TODO is this check necessary
-						if (
-							!(await this._waitForEntryReplicators(
-								entry,
-								minReplicasValue,
-								[
-									{ key: publicKeyHash, replicator: true },
-									{
-										key: this.node.identity.publicKey.hashcode(),
-										replicator: false,
-									},
-								],
-								{
-									persist: false,
-								},
-							))
-						) {
-							return;
-						}
-						try {
-							throwIfCheckedPruneLifecycleInactive();
-						} catch (error) {
-							reject(error);
-							return;
-						}
-
-						const existCounter = checkedPruneCoordinator.addConfirmedReplicator(
-							entry.hash,
-							publicKeyHash,
-						);
-						// Seed provider hints so future remote reads can avoid extra round-trips.
-						this.remoteBlocks.hintProviders(entry.hash, [publicKeyHash]);
-
-						if (minReplicasValue <= existCounter.size) {
-							resolve();
-						}
-					},
-				},
+				pendingDelete,
 				entry,
 				leaders,
 			);
+			claimCapableLeaderRequests(pendingDelete);
 
-			promises.push(deferredPromise.promise);
+			promises.push(
+				explicitTimeout
+					? wrapExplicitPending(pendingDelete)
+					: deferredPromise.promise,
+			);
 		}
 
-		const emitMessages = async (entries: string[], to: string) => {
+		const emitMessages = async (
+			entries: ClaimedCheckedPruneRequest[],
+			to: string,
+		) => {
 			throwIfCheckedPruneLifecycleInactive();
-			const filteredSet: string[] = [];
-			for (const entry of entries) {
-				/* TODO why can we not have this statement? 
-				if (set.has(to)) {
+			// A responder grant cancels every older outbound session before its
+			// response is sent. Waiting here orders any later request publish
+			// after that response publish, which makes circular delete handoffs
+			// impossible.
+			await Promise.all(
+				[...new Set(entries.map(({ hash }) => hash))].map((hash) =>
+					checkedPruneCoordinator.waitForGrantSends(hash),
+				),
+			);
+			throwIfCheckedPruneLifecycleInactive();
+
+			const requests: Array<
+				ClaimedCheckedPruneRequest & { requestIdBytes: Uint8Array }
+			> = [];
+			const uniqueEntries = new Map(
+				entries.map((entry) => [entry.hash, entry]),
+			);
+			for (const entry of uniqueEntries.values()) {
+				if (
+					!checkedPruneCoordinator.isCurrentRequestForPeer(
+						entry.hash,
+						entry.pendingDelete,
+						to,
+						entry.requestId,
+					)
+				) {
 					continue;
-				} */
-				checkedPruneCoordinator.addRequestSent(entry, to);
-				filteredSet.push(entry);
+				}
+				requests.push({
+					...entry,
+					requestIdBytes: fromHexString(entry.requestId),
+				});
 			}
-			if (filteredSet.length > 0) {
-				const result = await this.rpc.send(
-					new RequestIPrune({
-						hashes: filteredSet,
-					}),
-					{
-						mode: new AcknowledgeDelivery({
-							to: [to], // TODO group by peers?
-							redundancy: 1,
-						}),
-						priority: CONVERGENCE_MESSAGE_PRIORITY,
-					},
-				);
+			if (requests.length > 0) {
+				let firstFailure: unknown;
+				for (
+					let offset = 0;
+					offset < requests.length;
+					offset += CHECKED_PRUNE_MAX_REQUESTS_PER_MESSAGE
+				) {
+					const chunk = requests.slice(
+						offset,
+						offset + CHECKED_PRUNE_MAX_REQUESTS_PER_MESSAGE,
+					);
+					try {
+						await this._checkedPruneRequestSendQueue.add(async () => {
+							throwIfCheckedPruneLifecycleInactive();
+							const currentRequests = chunk.filter(
+								({ hash, pendingDelete, requestId }) =>
+									checkedPruneCoordinator.isCurrentRequestForPeer(
+										hash,
+										pendingDelete,
+										to,
+										requestId,
+									),
+							);
+							if (currentRequests.length === 0) {
+								return;
+							}
+							// Admission to this instance-wide queue bounds acknowledged
+							// prune sends across destinations, chunks, concurrent prune
+							// calls, and resend passes. Revalidate the exact generation
+							// only after the slot is acquired.
+							await this.rpc.send(
+								new RequestIPruneV2({
+									requests: currentRequests.map(({ hash, requestIdBytes }) => ({
+										hash,
+										requestId: requestIdBytes,
+									})),
+								}),
+								{
+									mode: new AcknowledgeDelivery({
+										to: [to], // TODO group by peers?
+										redundancy: 1,
+									}),
+									priority: CONVERGENCE_MESSAGE_PRIORITY,
+									signal: ownershipLifecycleController.signal,
+								},
+							);
+						});
+					} catch (error) {
+						// Keep this bounded producer moving so one failed ACK cannot
+						// starve later chunks or destinations in the same wave.
+						firstFailure ??= error;
+					}
+				}
 				throwIfCheckedPruneLifecycleInactive();
-				return result;
+				if (firstFailure !== undefined) {
+					throw firstFailure;
+				}
 			}
 		};
 
-		for (const [k, v] of peerToEntries) {
-			emitMessages(v, k).catch(() => {});
-		}
+		const runEmitWave = async (
+			pendingByPeer: [string, ClaimedCheckedPruneRequest[]][],
+		) => {
+			const destinations = pendingByPeer.map(([peer, requests]) => ({
+				peer,
+				requests,
+				offset: 0,
+			}));
+			let nextDestination = 0;
+			let firstFailure: unknown;
+			const takeChunk = () => {
+				for (let inspected = 0; inspected < destinations.length; inspected++) {
+					const destination = destinations[nextDestination]!;
+					nextDestination = (nextDestination + 1) % destinations.length;
+					if (destination.offset >= destination.requests.length) {
+						continue;
+					}
+					const requests = destination.requests.slice(
+						destination.offset,
+						destination.offset + CHECKED_PRUNE_MAX_REQUESTS_PER_MESSAGE,
+					);
+					destination.offset += requests.length;
+					return { peer: destination.peer, requests };
+				}
+				return undefined;
+			};
+			const sendChunks = async () => {
+				for (;;) {
+					const next = takeChunk();
+					if (!next) {
+						return;
+					}
+					try {
+						await emitMessages(next.requests, next.peer);
+					} catch (error) {
+						firstFailure ??= error;
+					}
+				}
+			};
+			await Promise.all(
+				Array.from(
+					{
+						length: Math.min(
+							CHECKED_PRUNE_MAX_CONCURRENT_REQUEST_SENDS,
+							pendingByPeer.length,
+						),
+					},
+					() => sendChunks(),
+				),
+			);
+			if (firstFailure !== undefined) {
+				throw firstFailure;
+			}
+		};
+
+		let emitWaveInFlight: Promise<void> | undefined;
+		const startEmitWave = (
+			pendingByPeer: [string, ClaimedCheckedPruneRequest[]][],
+		) => {
+			if (emitWaveInFlight || pendingByPeer.length === 0) {
+				return;
+			}
+			const wave = runEmitWave(pendingByPeer)
+				.catch(() => {})
+				.finally(() => {
+					if (emitWaveInFlight === wave) {
+						emitWaveInFlight = undefined;
+					}
+				});
+			emitWaveInFlight = wave;
+		};
+		startEmitWave([...peerToEntries]);
 
 		// Keep remote `_pendingIHave` alive in the common "leader doesn't have entry yet"
-		// case. This is intentionally disabled when an explicit timeout is provided to
-		// preserve unit tests that assert remote `_pendingIHave` clears promptly.
-		if (!explicitTimeout && peerToEntries.size > 0) {
+		// case. Resend ownership belongs to the pending generation that first claimed
+		// each exact target, not to a later caller that happens to observe it.
+		const resendPeerToEntries = new Map<string, ClaimedCheckedPruneRequest[]>();
+		for (const [peer, requests] of peerToEntries) {
+			const resendRequests = requests.filter(({ ownsResend }) => ownsResend);
+			if (resendRequests.length > 0) {
+				resendPeerToEntries.set(peer, resendRequests);
+			}
+		}
+		if (resendPeerToEntries.size > 0) {
 			const respondToIHaveTimeout = Number(this._respondToIHaveTimeout ?? 0);
 			const resendIntervalMs = Math.min(
 				CHECKED_PRUNE_RESEND_INTERVAL_MAX_MS,
@@ -27031,18 +28697,23 @@ export class SharedLog<
 					Math.floor(respondToIHaveTimeout / 2) || 1_000,
 				),
 			);
-			let inFlight = false;
 			const timer = setInterval(() => {
-				if (inFlight) return;
+				if (emitWaveInFlight) return;
 				if (!isCheckedPruneLifecycleCurrent()) {
 					clearInterval(timer);
 					return;
 				}
 
-				const pendingByPeer: [string, string[]][] = [];
-				for (const [peer, hashes] of peerToEntries) {
-					const pending = hashes.filter((h) =>
-						checkedPruneCoordinator.hasPendingDelete(h),
+				const pendingByPeer: [string, ClaimedCheckedPruneRequest[]][] = [];
+				for (const [peer, requests] of resendPeerToEntries) {
+					const pending = requests.filter(
+						({ hash, pendingDelete, requestId }) =>
+							checkedPruneCoordinator.isCurrentRequestForPeer(
+								hash,
+								pendingDelete,
+								peer,
+								requestId,
+							),
 					);
 					if (pending.length > 0) {
 						pendingByPeer.push([peer, pending]);
@@ -27053,30 +28724,27 @@ export class SharedLog<
 					return;
 				}
 
-				inFlight = true;
-				Promise.allSettled(
-					pendingByPeer.map(([peer, hashes]) =>
-						emitMessages(hashes, peer).catch(() => {}),
-					),
-				).finally(() => {
-					if (isCheckedPruneLifecycleCurrent()) {
-						inFlight = false;
-					}
-				});
+				startEmitWave(pendingByPeer);
 			}, resendIntervalMs);
 			timer.unref?.();
-			cleanupTimer.push(timer as any);
+			let resendCleaned = false;
+			const cleanupResend = () => {
+				if (resendCleaned) {
+					return;
+				}
+				resendCleaned = true;
+				clearInterval(timer);
+				closeController.signal.removeEventListener("abort", cleanupResend);
+			};
+			const pendingPromises = new Set(
+				[...resendPeerToEntries.values()]
+					.flat()
+					.map(({ pendingDelete }) => pendingDelete.promise.promise),
+			);
+			void Promise.allSettled([...pendingPromises]).finally(cleanupResend);
+			closeController.signal.addEventListener("abort", cleanupResend);
 		}
 
-		let cleanup = () => {
-			for (const timer of cleanupTimer) {
-				clearTimeout(timer);
-			}
-			closeController.signal.removeEventListener("abort", cleanup);
-		};
-
-		Promise.allSettled(promises).finally(cleanup);
-		closeController.signal.addEventListener("abort", cleanup);
 		return promises;
 	}
 
@@ -27442,8 +29110,6 @@ export class SharedLog<
 							if (!isOwnershipLifecycleCurrent()) {
 								return false;
 							}
-
-							this.responseToPruneDebouncedFn.delete(entryReplicated.hash);
 						} else {
 							throwIfOwnershipLifecycleInactive();
 							await this.cancelCheckedPruneForLocalLeader(entryReplicated.hash);
@@ -27533,8 +29199,6 @@ export class SharedLog<
 						if (!isOwnershipLifecycleCurrent()) {
 							return false;
 						}
-
-						this.responseToPruneDebouncedFn.delete(entryReplicated.hash); // don't allow others to prune because of expecting me to replicating this entry
 					} else {
 						throwIfOwnershipLifecycleInactive();
 						await this.cancelCheckedPruneForLocalLeader(entryReplicated.hash);
@@ -27945,7 +29609,6 @@ export class SharedLog<
 		const ih = this._pendingIHave.get(entry.hash);
 
 		if (ih) {
-			ih.clear();
 			this.runPendingIHaveCallback(ih, entry);
 		}
 
@@ -27959,7 +29622,6 @@ export class SharedLog<
 				throw new Error("Missing entry materializer for pending IHave");
 			}
 			const entry = materializeEntry();
-			ih.clear();
 			this.runPendingIHaveCallback(ih, entry);
 			this.syncronizer.onEntryAdded(entry);
 			return;
@@ -28014,7 +29676,7 @@ export class SharedLog<
 			}
 			if (expiresAt <= now) {
 				pending.expiresAt = undefined;
-				this._pendingIHave.delete(hash);
+				this.deletePendingIHave(hash, pending);
 				continue;
 			}
 			if (expiresAt < nextDeadline) {
@@ -28026,13 +29688,22 @@ export class SharedLog<
 		}
 	}
 
+	private clearCheckedPruneRetryForRemovedEntry(hash: string) {
+		this.pruneDebouncedFn?.delete(hash);
+		this.clearCheckedPruneRetry(hash);
+	}
+
 	onEntryRemoved(hash: string) {
+		this.clearCheckedPruneRetryForRemovedEntry(hash);
 		this.syncronizer.onEntryRemoved(hash);
 	}
 
 	private onEntryRemovedHashes(hashes: string[]) {
 		if (hashes.length === 0) {
 			return;
+		}
+		for (const hash of hashes) {
+			this.clearCheckedPruneRetryForRemovedEntry(hash);
 		}
 		if (this.syncronizer.onEntryRemovedHashes) {
 			this.syncronizer.onEntryRemovedHashes(hashes);

--- a/packages/programs/data/shared-log/test/checked-prune-handoff.spec.ts
+++ b/packages/programs/data/shared-log/test/checked-prune-handoff.spec.ts
@@ -1,0 +1,3068 @@
+import {
+	Ed25519Keypair,
+	fromHexString,
+	randomBytes,
+	toHexString,
+} from "@peerbit/crypto";
+import { AcknowledgeDelivery } from "@peerbit/stream-interface";
+import { TestSession } from "@peerbit/test-utils";
+import { waitForResolved } from "@peerbit/time";
+import { expect } from "chai";
+import pDefer from "p-defer";
+import sinon from "sinon";
+import {
+	RequestIPrune,
+	RequestIPruneV2,
+	ResponseIPrune,
+	ResponseIPruneV2,
+	SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+} from "../src/exchange-heads.js";
+import { AbsoluteReplicas } from "../src/replication.js";
+import { EventStore } from "./utils/stores/index.js";
+
+describe("checked prune correlated handoff", () => {
+	let session: TestSession | undefined;
+
+	afterEach(async () => {
+		await session?.stop();
+		session = undefined;
+	});
+
+	it("orders a later prune request after an admitted grant send", async () => {
+		session = await TestSession.disconnected(3);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-grant-send-barrier");
+		const prunePeer = session.peers[1].identity.publicKey.hashcode();
+		const requester = session.peers[2].identity.publicKey.hashcode();
+		const leaders = new Map([[prunePeer, { intersecting: true }]]);
+		const responseSendEntered = pDefer<void>();
+		const releaseResponseSend = pDefer<void>();
+		const events: string[] = [];
+
+		log._peerSyncCapabilities.set(
+			prunePeer,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const send = sinon
+			.stub(log.rpc, "send")
+			.callsFake(async (message: unknown, options: any) => {
+				if (message instanceof ResponseIPruneV2) {
+					expect(options.mode).to.be.instanceOf(AcknowledgeDelivery);
+					events.push("grant:start");
+					responseSendEntered.resolve();
+					await releaseResponseSend.promise;
+					events.push("grant:done");
+					return;
+				}
+				if (message instanceof RequestIPruneV2) {
+					events.push("request");
+				}
+			});
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const revalidateGrantLeader = sinon
+			.stub(log, "revalidateCheckedPruneGrantLocalLeaders")
+			.resolves(new Set([entry.hash]));
+
+		let firstPrune: Promise<unknown> | undefined;
+		let secondPrune: Promise<unknown> | undefined;
+		let secondOutcome: Promise<unknown> | undefined;
+		try {
+			[firstPrune] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			const firstOutcome = firstPrune!.catch((error) => {
+				// Start the replacement directly from the rejection reaction. This
+				// is the earliest a cancelled session can be replaced and catches
+				// any await-before-barrier ordering gap in grant admission.
+				[secondPrune] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+					timeout: 5_000,
+				});
+				secondOutcome = secondPrune!.catch((secondError) => secondError);
+				return error;
+			});
+			await waitForResolved(() => {
+				expect(events.filter((event) => event === "request")).to.have.length(1);
+			});
+			const firstPending = log._checkedPrune.getPendingDelete(entry.hash);
+			expect(firstPending).to.exist;
+
+			const granting = log.admitCheckedPruneGrants(
+				[
+					{
+						hash: entry.hash,
+						requestId: randomBytes(32),
+					},
+				],
+				requester,
+			);
+			await responseSendEntered.promise;
+			expect(await firstOutcome).to.be.instanceOf(Error);
+			expect(secondPrune).to.exist;
+			expect(
+				log._checkedPrune.getPendingDelete(entry.hash),
+			).to.exist.and.not.equal(firstPending);
+			let unrelatedMutationRan = false;
+			await log.withReplicationRangeMutationQueue(async () => {
+				unrelatedMutationRan = true;
+			});
+			expect(unrelatedMutationRan).to.be.true;
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(events).to.deep.equal(["request", "grant:start"]);
+
+			releaseResponseSend.resolve();
+			await granting;
+			await waitForResolved(() => {
+				expect(events.filter((event) => event === "request")).to.have.length(2);
+			});
+			expect(events).to.deep.equal([
+				"request",
+				"grant:start",
+				"grant:done",
+				"request",
+			]);
+
+			await log.cancelCheckedPruneForLocalLeader(entry.hash);
+			expect(await secondOutcome!).to.be.instanceOf(Error);
+		} finally {
+			releaseResponseSend.resolve();
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(
+				[firstPrune, secondPrune].filter(
+					(value): value is Promise<unknown> => value != null,
+				),
+			);
+			getClampedReplicas.restore();
+			revalidateGrantLeader.restore();
+			send.restore();
+		}
+	});
+
+	it("drains an admitted grant before a reopened lifecycle can request pruning", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-grant-close-reopen");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const responseSendEntered = pDefer<void>();
+		const releaseResponseSend = pDefer<void>();
+		const events: string[] = [];
+		const send = sinon
+			.stub(log.rpc, "send")
+			.callsFake(async (message: unknown) => {
+				if (message instanceof ResponseIPruneV2) {
+					events.push("grant:start");
+					responseSendEntered.resolve();
+					// Deliberately model a started transport that cannot be cancelled.
+					await releaseResponseSend.promise;
+					events.push("grant:done");
+					return;
+				}
+				if (message instanceof RequestIPruneV2) {
+					events.push("request");
+				}
+			});
+		const finalLeaderPlan = sinon
+			.stub(log, "revalidateCheckedPruneGrantLocalLeaders")
+			.resolves(new Set([entry.hash]));
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		let reopenedPrune: Promise<unknown> | undefined;
+
+		try {
+			const granting = log.admitCheckedPruneGrants(
+				[{ hash: entry.hash, requestId: randomBytes(32) }],
+				remoteHash,
+			);
+			await responseSendEntered.promise;
+
+			let closeSettled = false;
+			const closing = db.close().finally(() => {
+				closeSettled = true;
+			});
+			await new Promise<void>((resolve) => setTimeout(resolve, 25));
+			expect(closeSettled).to.be.false;
+			expect(events).to.deep.equal(["grant:start"]);
+
+			releaseResponseSend.resolve();
+			await Promise.all([granting, closing]);
+			expect(events).to.deep.equal(["grant:start", "grant:done"]);
+
+			await session.peers[0].open(db, {
+				args: {
+					replicate: false,
+					timeUntilRoleMaturity: 0,
+					waitForPruneDelay: 0,
+				},
+			});
+			log._peerSyncCapabilities.set(
+				remoteHash,
+				SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+			);
+			[reopenedPrune] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			void reopenedPrune!.catch(() => {});
+			await waitForResolved(() => {
+				expect(events).to.deep.equal(["grant:start", "grant:done", "request"]);
+			});
+		} finally {
+			releaseResponseSend.resolve();
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(reopenedPrune ? [reopenedPrune] : []);
+			getClampedReplicas.restore();
+			finalLeaderPlan.restore();
+			send.restore();
+			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("retries an acknowledged grant after its first delivery fails", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-grant-ack-retry");
+		const requester = session.peers[1].identity.publicKey.hashcode();
+		const request = { hash: entry.hash, requestId: randomBytes(32) };
+		const send = sinon.stub(log.rpc, "send");
+		const revalidateGrantLeader = sinon
+			.stub(log, "revalidateCheckedPruneGrantLocalLeaders")
+			.resolves(new Set([entry.hash]));
+		send.onFirstCall().rejects(new Error("grant ACK failed"));
+		send.onSecondCall().resolves();
+
+		try {
+			await expect(
+				log.admitCheckedPruneGrants([request], requester),
+			).to.be.rejectedWith("grant ACK failed");
+			expect(log._checkedPrune.grantSends?.size ?? 0).to.equal(0);
+
+			expect(
+				await log.admitCheckedPruneGrants([request], requester),
+			).to.deep.equal([entry.hash]);
+			expect(send.callCount).to.equal(2);
+			for (const call of send.getCalls()) {
+				expect(call.args[0]).to.be.instanceOf(ResponseIPruneV2);
+				expect(call.args[1].mode).to.be.instanceOf(AcknowledgeDelivery);
+				expect(call.args[1].mode.to).to.deep.equal([requester]);
+			}
+		} finally {
+			revalidateGrantLeader.restore();
+			send.restore();
+		}
+	});
+
+	it("rejects a stale leader plan and a missing block at final grant admission", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-final-grant-leader");
+		const requesterKey = session.peers[1].identity.publicKey;
+		const requester = requesterKey.hashcode();
+		const leaders = new Map([[requester, { intersecting: true }]]);
+		log._peerSyncCapabilities.set(
+			requester,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const initialLeaderPlan = sinon
+			.stub(log, "planCurrentNativeBackboneRequestPruneLeaderHints")
+			.resolves({
+				localLeaderHashes: new Set(),
+				replicaCounts: new Map(),
+				peerHistoryGids: [],
+				peerHistoryRemovedHashes: new Set(),
+				nativeAllConfirmed: true,
+				nativeBackbonePeerHistoryCleaned: true,
+			});
+		const finalLeaderPlan = sinon
+			.stub(log, "revalidateCheckedPruneGrantLocalLeaders")
+			.resolves(new Set());
+		let pruning: Promise<unknown> | undefined;
+		let hasMany: sinon.SinonStub | undefined;
+
+		try {
+			[pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			void pruning!.catch(() => {});
+			await waitForResolved(() => {
+				expect(
+					send
+						.getCalls()
+						.some((call) => call.args[0] instanceof RequestIPruneV2),
+				).to.be.true;
+			});
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			expect(pending).to.exist;
+
+			await db.log.onMessage(
+				new RequestIPruneV2({
+					requests: [{ hash: entry.hash, requestId: randomBytes(32) }],
+				}),
+				{ from: requesterKey } as any,
+			);
+			expect(initialLeaderPlan.calledOnce).to.be.true;
+			expect(finalLeaderPlan.calledOnce).to.be.true;
+			expect(
+				send
+					.getCalls()
+					.some((call) => call.args[0] instanceof ResponseIPruneV2),
+			).to.be.false;
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.equal(pending);
+
+			finalLeaderPlan.resolves(new Set([entry.hash]));
+			hasMany = sinon.stub(log.log.blocks, "hasMany").resolves([false]);
+			await db.log.onMessage(
+				new RequestIPruneV2({
+					requests: [{ hash: entry.hash, requestId: randomBytes(32) }],
+				}),
+				{ from: requesterKey } as any,
+			);
+			expect(
+				send
+					.getCalls()
+					.some((call) => call.args[0] instanceof ResponseIPruneV2),
+			).to.be.false;
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.equal(pending);
+		} finally {
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(pruning ? [pruning] : []);
+			hasMany?.restore();
+			finalLeaderPlan.restore();
+			initialLeaderPlan.restore();
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+
+	it("bounds grant sends instance-wide and aborts queued delivery at its deadline", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const log = db.log as any;
+		const entries = await Promise.all(
+			Array.from({ length: 5 }, (_, index) =>
+				db.add(`checked-prune-grant-queue-${index}`),
+			),
+		);
+		const requester = session.peers[1].identity.publicKey.hashcode();
+		const releaseSends = pDefer<void>();
+		let activeSends = 0;
+		let maxActiveSends = 0;
+		const sentHashes: string[] = [];
+		const send = sinon
+			.stub(log.rpc, "send")
+			.callsFake(async (message: unknown) => {
+				if (!(message instanceof ResponseIPruneV2)) {
+					return;
+				}
+				sentHashes.push(...message.requests.map(({ hash }) => hash));
+				activeSends++;
+				maxActiveSends = Math.max(maxActiveSends, activeSends);
+				await releaseSends.promise;
+				activeSends--;
+			});
+		const revalidateGrantLeader = sinon
+			.stub(log, "revalidateCheckedPruneGrantLocalLeaders")
+			.callsFake(async (...args: unknown[]) => new Set(args[0] as string[]));
+		const queuedDeadline = new AbortController();
+		let grants: Promise<string[]>[] = [];
+
+		try {
+			grants = entries.map(({ entry }, index) =>
+				log.admitCheckedPruneGrants(
+					[{ hash: entry.hash, requestId: randomBytes(32) }],
+					requester,
+					undefined,
+					index === entries.length - 1 ? queuedDeadline.signal : undefined,
+				),
+			);
+			await waitForResolved(() => {
+				expect(activeSends).to.equal(4);
+				expect(log._checkedPruneGrantSendQueue.size).to.equal(1);
+			});
+			expect(maxActiveSends).to.equal(4);
+
+			queuedDeadline.abort();
+			expect(await grants[4]).to.deep.equal([entries[4].entry.hash]);
+			expect(log._checkedPruneGrantSendQueue.size).to.equal(0);
+			expect(sentHashes).to.not.include(entries[4].entry.hash);
+
+			releaseSends.resolve();
+			await Promise.all(grants);
+			expect(maxActiveSends).to.equal(4);
+			expect(sentHashes).to.have.length(4);
+		} finally {
+			releaseSends.resolve();
+			await Promise.allSettled(grants);
+			revalidateGrantLeader.restore();
+			send.restore();
+		}
+	});
+
+	it("aborts a started grant send and releases request admission at five seconds", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-started-grant-deadline");
+		const requesterKey = session.peers[1].identity.publicKey;
+		const sendEntered = pDefer<void>();
+		const initialLeaderPlan = sinon
+			.stub(log, "planCurrentNativeBackboneRequestPruneLeaderHints")
+			.resolves({
+				localLeaderHashes: new Set(),
+				replicaCounts: new Map(),
+				peerHistoryGids: [],
+				peerHistoryRemovedHashes: new Set(),
+				nativeAllConfirmed: true,
+				nativeBackbonePeerHistoryCleaned: true,
+			});
+		const finalLeaderPlan = sinon
+			.stub(log, "revalidateCheckedPruneGrantLocalLeaders")
+			.resolves(new Set([entry.hash]));
+		const send = sinon
+			.stub(log.rpc, "send")
+			.callsFake(async (...args: unknown[]) => {
+				const message = args[0];
+				const options = args[1] as { signal: AbortSignal };
+				if (!(message instanceof ResponseIPruneV2)) {
+					return;
+				}
+				sendEntered.resolve();
+				await new Promise<void>((resolve, reject) => {
+					const onAbort = () =>
+						reject(options.signal.reason ?? new Error("aborted"));
+					if (options.signal.aborted) {
+						onAbort();
+						return;
+					}
+					options.signal.addEventListener("abort", onAbort, { once: true });
+				});
+			});
+		const clock = sinon.useFakeTimers({
+			now: 1_000,
+			shouldClearNativeTimers: true,
+		});
+
+		try {
+			const receiving = db.log.onMessage(
+				new RequestIPruneV2({
+					requests: [{ hash: entry.hash, requestId: randomBytes(32) }],
+				}),
+				{ from: requesterKey } as any,
+			);
+			await sendEntered.promise;
+			expect(log._checkedPruneRequestWorkAdmission.activeByPeer.size).to.equal(
+				1,
+			);
+			expect(log._checkedPruneGrantSendQueue.running).to.equal(1);
+
+			await clock.tickAsync(5_000);
+			await receiving;
+
+			expect(log._checkedPruneRequestWorkAdmission.activeByPeer.size).to.equal(
+				0,
+			);
+			expect(log._checkedPruneGrantSendQueue.running).to.equal(0);
+			expect(log._checkedPrune.grantSends?.size ?? 0).to.equal(0);
+		} finally {
+			clock.restore();
+			send.restore();
+			finalLeaderPlan.restore();
+			initialLeaderPlan.restore();
+		}
+	});
+
+	it("releases the ownership lane but retains admission until detached grant planning settles", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-final-plan-deadline");
+		const requesterKey = session.peers[1].identity.publicKey;
+		const initialLeaderPlan = sinon
+			.stub(log, "planCurrentNativeBackboneRequestPruneLeaderHints")
+			.resolves({
+				localLeaderHashes: new Set(),
+				replicaCounts: new Map(),
+				peerHistoryGids: [],
+				peerHistoryRemovedHashes: new Set(),
+				nativeAllConfirmed: true,
+				nativeBackbonePeerHistoryCleaned: true,
+			});
+		const hasMany = sinon.stub(log.log.blocks, "hasMany").resolves([true]);
+		const hasCustomFindLeaders = sinon
+			.stub(log, "hasCustomFindLeaders")
+			.returns(true);
+		const plannerEntered = pDefer<void>();
+		const releasePlanner = pDefer<void>();
+		const finalPlanner = sinon
+			.stub(log, "planEntryLeaders")
+			.callsFake(async () => {
+				plannerEntered.resolve();
+				await releasePlanner.promise;
+				return { isLeader: true };
+			});
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const markCancelled = sinon.spy(log._checkedPrune, "markCancelled");
+		const clock = sinon.useFakeTimers({
+			now: 1_000,
+			shouldClearNativeTimers: true,
+		});
+		let followerRan = false;
+
+		try {
+			const receiving = db.log.onMessage(
+				new RequestIPruneV2({
+					requests: [{ hash: entry.hash, requestId: randomBytes(32) }],
+				}),
+				{ from: requesterKey } as any,
+			);
+			await plannerEntered.promise;
+
+			const follower = log.withReplicationRangeMutationQueue(async () => {
+				followerRan = true;
+			});
+			await clock.tickAsync(4_999);
+			expect(followerRan).to.be.false;
+
+			await clock.tickAsync(1);
+			await Promise.all([receiving, follower]);
+			expect(followerRan).to.be.true;
+			expect(log._checkedPruneRequestWorkAdmission.activeByPeer.size).to.equal(
+				1,
+			);
+			expect(markCancelled.called).to.be.false;
+			expect(
+				send
+					.getCalls()
+					.some((call) => call.args[0] instanceof ResponseIPruneV2),
+			).to.be.false;
+
+			releasePlanner.resolve();
+			await clock.tickAsync(0);
+			expect(log._checkedPruneRequestWorkAdmission.activeByPeer.size).to.equal(
+				0,
+			);
+		} finally {
+			releasePlanner.resolve();
+			await clock.tickAsync(0);
+			clock.restore();
+			markCancelled.restore();
+			send.restore();
+			finalPlanner.restore();
+			hasCustomFindLeaders.restore();
+			hasMany.restore();
+			initialLeaderPlan.restore();
+		}
+	});
+
+	it("does not attach an old response to a later contact generation", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-delayed-resolver");
+		const remoteHash = (await Ed25519Keypair.create()).publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+
+		log._peerSyncCapabilities.set(
+			remoteHash,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+
+		let firstPrune: Promise<unknown> | undefined;
+		let secondPrune: Promise<unknown> | undefined;
+		try {
+			[firstPrune] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			const firstOutcome = firstPrune!.catch((error) => error);
+			const firstPending = log._checkedPrune.getPendingDelete(entry.hash);
+			expect(firstPending).to.exist;
+			await waitForResolved(() => {
+				expect(log._checkedPrune.getRequestId(entry.hash, remoteHash)).to.be.a(
+					"string",
+				);
+			});
+			const firstRequestId = log._checkedPrune.getRequestId(
+				entry.hash,
+				remoteHash,
+			);
+
+			await log.cancelCheckedPruneForLocalLeader(entry.hash);
+			expect(await firstOutcome).to.be.instanceOf(Error);
+
+			[secondPrune] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			const secondOutcome = secondPrune!.catch((error) => error);
+			await waitForResolved(() => {
+				expect(log._checkedPrune.getRequestId(entry.hash, remoteHash)).to.be.a(
+					"string",
+				);
+			});
+			const secondRequestId = log._checkedPrune.getRequestId(
+				entry.hash,
+				remoteHash,
+			);
+			expect(secondRequestId).to.not.equal(firstRequestId);
+
+			await firstPending.resolve(remoteHash, firstRequestId);
+			expect(
+				log._checkedPrune.getConfirmedReplicators(entry.hash)?.size ?? 0,
+			).to.equal(0);
+
+			await log.cancelCheckedPruneForLocalLeader(entry.hash);
+			expect(await secondOutcome).to.be.instanceOf(Error);
+		} finally {
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(
+				[firstPrune, secondPrune].filter(
+					(value): value is Promise<unknown> => value != null,
+				),
+			);
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+
+	it("coalesces background duplicates while admitting newly discovered leaders", async () => {
+		session = await TestSession.disconnected(3);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+				respondToIHaveTimeout: 500,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-coalesced-resends");
+		const leaderA = session.peers[1].identity.publicKey.hashcode();
+		const leaderB = session.peers[2].identity.publicKey.hashcode();
+		log._peerSyncCapabilities.set(
+			leaderA,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		log._peerSyncCapabilities.set(
+			leaderB,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const destinations: string[] = [];
+		const send = sinon
+			.stub(log.rpc, "send")
+			.callsFake(async (message: unknown, options: any) => {
+				if (message instanceof RequestIPruneV2) {
+					destinations.push(options.mode.to[0]);
+				}
+			});
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+		const attempts: Promise<unknown>[] = [];
+
+		try {
+			// Begin as an explicit generation, which intentionally has no periodic
+			// resend owner until the first background observer promotes it.
+			const [firstExplicit] = log.prune(
+				new Map([[entry.hash, { entry, leaders: new Map([[leaderA, {}]]) }]]),
+				{ timeout: 100 },
+			);
+			attempts.push(firstExplicit);
+			const firstExplicitOutcome = firstExplicit.catch(
+				(error: unknown) => error,
+			);
+			await clock.tickAsync(0);
+			expect(destinations).to.deep.equal([leaderA]);
+
+			for (let i = 0; i < 50; i++) {
+				const duplicate = log.prune(
+					new Map([[entry.hash, { entry, leaders: new Map([[leaderA, {}]]) }]]),
+				);
+				attempts.push(...duplicate);
+				for (const attempt of duplicate) void attempt.catch(() => {});
+			}
+			await clock.tickAsync(0);
+			// Exactly the first background observer emits while claiming the sole
+			// resend owner; the other 49 calls only share the pending promise.
+			expect(destinations).to.deep.equal([leaderA, leaderA]);
+
+			const expandedLeaders = new Map([
+				[leaderA, {}],
+				[leaderB, {}],
+			]);
+			const [expandedExplicit] = log.prune(
+				new Map([[entry.hash, { entry, leaders: expandedLeaders }]]),
+				{ timeout: 75 },
+			);
+			attempts.push(expandedExplicit);
+			const expandedExplicitOutcome = expandedExplicit.catch(
+				(error: unknown) => error,
+			);
+			await clock.tickAsync(0);
+			expect(destinations.filter((peer) => peer === leaderA)).to.have.length(3);
+			expect(destinations.filter((peer) => peer === leaderB)).to.have.length(1);
+
+			for (let i = 0; i < 50; i++) {
+				const duplicate = log.prune(
+					new Map([[entry.hash, { entry, leaders: expandedLeaders }]]),
+				);
+				attempts.push(...duplicate);
+				for (const attempt of duplicate) void attempt.catch(() => {});
+			}
+			await clock.tickAsync(0);
+			expect(destinations.filter((peer) => peer === leaderA)).to.have.length(3);
+			expect(destinations.filter((peer) => peer === leaderB)).to.have.length(1);
+
+			await clock.tickAsync(100);
+			expect(await firstExplicitOutcome).to.be.instanceOf(Error);
+			expect(await expandedExplicitOutcome).to.be.instanceOf(Error);
+			const promoted = log._checkedPrune.getPendingDelete(entry.hash);
+			expect(promoted).to.exist;
+			expect(promoted.background).to.be.true;
+
+			await clock.tickAsync(150);
+			// The inverse mixed-mode case above discovered B from an explicit
+			// duplicate of a background generation; B still owns one periodic resend.
+			expect(destinations.filter((peer) => peer === leaderA)).to.have.length(4);
+			expect(destinations.filter((peer) => peer === leaderB)).to.have.length(2);
+		} finally {
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			await pending?.reject(new Error("test cleanup"));
+			await clock.tickAsync(0);
+			await Promise.allSettled(attempts);
+			clock.restore();
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+
+	it("keeps a promoted generation's removal timer after its explicit caller times out", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 200,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-promoted-removal-timer");
+		const leader = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[leader, { intersecting: true }]]);
+		log._peerSyncCapabilities.set(
+			leader,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.resolves({ leaders, localLeader: false });
+		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+		let explicit: Promise<unknown> | undefined;
+		let background: Promise<unknown> | undefined;
+
+		try {
+			[explicit] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 50,
+			});
+			const explicitOutcome = explicit!.catch((error: unknown) => error);
+			await clock.tickAsync(0);
+
+			[background] = log.prune(new Map([[entry.hash, { entry, leaders }]]));
+			void background!.catch(() => {});
+			await clock.tickAsync(0);
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			expect(pending.background).to.be.true;
+			const requestId = log._checkedPrune.getRequestId(entry.hash, leader);
+			await pending.resolve(leader, requestId);
+
+			await clock.tickAsync(50);
+			expect(await explicitOutcome).to.be.instanceOf(Error);
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.equal(pending);
+			expect(await log.log.has(entry.hash)).to.be.true;
+
+			await clock.tickAsync(150);
+			await background;
+			expect(await log.log.has(entry.hash)).to.be.false;
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
+		} finally {
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			await pending?.reject(new Error("test cleanup"));
+			await clock.tickAsync(0);
+			await Promise.allSettled(
+				[explicit, background].filter(
+					(value): value is Promise<unknown> => value != null,
+				),
+			);
+			clock.restore();
+			revalidate.restore();
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+
+	it("does not let an old emit wave adopt a replacement generation", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-old-wave");
+		const leader = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[leader, { intersecting: true }]]);
+		log._peerSyncCapabilities.set(
+			leader,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const blockedOldWave = pDefer<void>();
+		let grantWaits = 0;
+		const waitForGrantSends = sinon
+			.stub(log._checkedPrune, "waitForGrantSends")
+			.callsFake(async () => {
+				grantWaits++;
+				if (grantWaits === 1) {
+					await blockedOldWave.promise;
+				}
+			});
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const attempts: Promise<unknown>[] = [];
+
+		try {
+			const [first] = log.prune(new Map([[entry.hash, { entry, leaders }]]));
+			attempts.push(first);
+			const firstOutcome = first.catch((error: unknown) => error);
+			await waitForResolved(() => expect(grantWaits).to.equal(1));
+			const firstId = log._checkedPrune.getRequestId(entry.hash, leader);
+
+			await log.cancelCheckedPruneForLocalLeader(entry.hash);
+			expect(await firstOutcome).to.be.instanceOf(Error);
+
+			const [replacement] = log.prune(
+				new Map([[entry.hash, { entry, leaders }]]),
+				{ timeout: 5_000 },
+			);
+			attempts.push(replacement);
+			void replacement.catch(() => {});
+			await waitForResolved(() => {
+				expect(
+					send
+						.getCalls()
+						.filter((call) => call.args[0] instanceof RequestIPruneV2),
+				).to.have.length(1);
+			});
+			const replacementId = log._checkedPrune.getRequestId(entry.hash, leader);
+			expect(replacementId).to.not.equal(firstId);
+
+			blockedOldWave.resolve();
+			await new Promise<void>((resolve) => setTimeout(resolve, 20));
+			const requests = send
+				.getCalls()
+				.map((call) => call.args[0])
+				.filter(
+					(message): message is RequestIPruneV2 =>
+						message instanceof RequestIPruneV2,
+				);
+			expect(requests).to.have.length(1);
+			expect(toHexString(requests[0]!.requests[0]!.requestId)).to.equal(
+				replacementId,
+			);
+		} finally {
+			blockedOldWave.resolve();
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(attempts);
+			getClampedReplicas.restore();
+			send.restore();
+			waitForGrantSends.restore();
+		}
+	});
+
+	it("cancels disconnected targets and retries only resilient generations", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const first = await db.add("checked-prune-disconnect-background");
+		const second = await db.add("checked-prune-disconnect-explicit");
+		const leader = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[leader, { intersecting: true }]]);
+		log._peerSyncCapabilities.set(
+			leader,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const random = sinon.stub(Math, "random").returns(0);
+		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+		let replacementPending: any;
+
+		try {
+			const [background] = log.prune(
+				new Map([[first.entry.hash, { entry: first.entry, leaders }]]),
+			);
+			const backgroundOutcome = background.catch((error: unknown) => error);
+			await clock.tickAsync(0);
+			const firstRequestId = log._checkedPrune.getRequestId(
+				first.entry.hash,
+				leader,
+			);
+
+			log.cleanupPeerDisconnectTracking(leader);
+			await clock.tickAsync(0);
+			const disconnected = await backgroundOutcome;
+			expect(disconnected).to.be.instanceOf(Error);
+			expect((disconnected as Error).name).to.equal(
+				"CheckedPruneTargetUnavailableError",
+			);
+			expect(log._checkedPrune.getPendingDelete(first.entry.hash)).to.be
+				.undefined;
+			expect(log._checkedPrune.getRetry(first.entry.hash)?.attempts).to.equal(
+				1,
+			);
+
+			log.recordPeerSyncCapabilities(
+				leader,
+				SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+			);
+			await log.pruneDebouncedFn.flush();
+			await clock.tickAsync(0);
+			replacementPending = log._checkedPrune.getPendingDelete(first.entry.hash);
+			expect(replacementPending).to.exist;
+			void replacementPending.promise.promise.catch(() => {});
+			expect(
+				log._checkedPrune.getRequestId(first.entry.hash, leader),
+			).to.not.equal(firstRequestId);
+
+			await log.cancelCheckedPruneForLocalLeader(first.entry.hash);
+			await clock.tickAsync(0);
+			expect(log._checkedPrune.getRetry(first.entry.hash)).to.be.undefined;
+
+			log._peerSyncCapabilities.set(
+				leader,
+				SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+			);
+			const [explicit] = log.prune(
+				new Map([[second.entry.hash, { entry: second.entry, leaders }]]),
+				{ timeout: 5_000 },
+			);
+			const explicitOutcome = explicit.catch((error: unknown) => error);
+			await clock.tickAsync(0);
+			log.cleanupPeerDisconnectTracking(leader);
+			await clock.tickAsync(0);
+			const explicitDisconnected = await explicitOutcome;
+			expect(explicitDisconnected).to.be.instanceOf(Error);
+			expect((explicitDisconnected as Error).name).to.equal(
+				"CheckedPruneTargetUnavailableError",
+			);
+			expect(log._checkedPrune.getPendingDelete(second.entry.hash)).to.be
+				.undefined;
+			expect(log._checkedPrune.getRetry(second.entry.hash)).to.be.undefined;
+		} finally {
+			await log
+				.cancelCheckedPruneForLocalLeader(first.entry.hash)
+				.catch(() => {});
+			await log
+				.cancelCheckedPruneForLocalLeader(second.entry.hash)
+				.catch(() => {});
+			clock.restore();
+			random.restore();
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+
+	it("observes an ignored background rejection when its target disconnects", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-background-disconnect");
+		const leader = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[leader, { intersecting: true }]]);
+		log._peerSyncCapabilities.set(
+			leader,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		let attempt: Promise<unknown> | undefined;
+		let unhandled: unknown;
+		const onUnhandled = (reason: unknown, promise: Promise<unknown>) => {
+			if (promise === attempt) {
+				unhandled = reason;
+			}
+		};
+		process.on("unhandledRejection", onUnhandled);
+
+		try {
+			[attempt] = log.prune(new Map([[entry.hash, { entry, leaders }]]));
+			await waitForResolved(() => {
+				expect(log._checkedPrune.getRequestId(entry.hash, leader)).to.be.a(
+					"string",
+				);
+			});
+
+			log.cleanupPeerDisconnectTracking(leader);
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			expect(unhandled).to.be.undefined;
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
+			expect(log._checkedPrune.getRetry(entry.hash)?.attempts).to.equal(1);
+		} finally {
+			process.off("unhandledRejection", onUnhandled);
+			void attempt?.catch(() => {});
+			log._checkedPrune.clearRetry(entry.hash);
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+
+	it("does not let an old removal timer cancel a replacement generation", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-old-removal-timer");
+		const leader = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[leader, { intersecting: true }]]);
+		log._peerSyncCapabilities.set(
+			leader,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const preliminaryStarted = pDefer<void>();
+		const releasePreliminary = pDefer<void>();
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.callsFake(async () => {
+				preliminaryStarted.resolve();
+				await releasePreliminary.promise;
+				return { leaders, localLeader: false };
+			});
+		let first: Promise<unknown> | undefined;
+		let replacement: Promise<unknown> | undefined;
+
+		try {
+			[first] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			const firstOutcome = first!.catch((error: unknown) => error);
+			await waitForResolved(() => {
+				expect(log._checkedPrune.getRequestId(entry.hash, leader)).to.be.a(
+					"string",
+				);
+			});
+			const firstPending = log._checkedPrune.getPendingDelete(entry.hash);
+			const firstRequestId = log._checkedPrune.getRequestId(entry.hash, leader);
+			await firstPending.resolve(leader, firstRequestId);
+			await preliminaryStarted.promise;
+
+			await log.cancelCheckedPruneForLocalLeader(entry.hash);
+			expect(await firstOutcome).to.be.instanceOf(Error);
+			[replacement] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			void replacement!.catch(() => {});
+			await waitForResolved(() => {
+				expect(log._checkedPrune.getPendingDelete(entry.hash)).to.exist;
+				expect(log._checkedPrune.getRequestId(entry.hash, leader)).to.not.equal(
+					firstRequestId,
+				);
+			});
+			const replacementPending = log._checkedPrune.getPendingDelete(entry.hash);
+			const replacementRequestId = log._checkedPrune.getRequestId(
+				entry.hash,
+				leader,
+			);
+
+			releasePreliminary.resolve();
+			await waitForResolved(() => expect(revalidate.calledOnce).to.be.true);
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.equal(
+				replacementPending,
+			);
+			expect(log._checkedPrune.getRequestId(entry.hash, leader)).to.equal(
+				replacementRequestId,
+			);
+		} finally {
+			releasePreliminary.resolve();
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(
+				[first, replacement].filter(
+					(value): value is Promise<unknown> => value != null,
+				),
+			);
+			revalidate.restore();
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+
+	it("does not let an old admitted remove erase a replacement generation", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-old-admitted-remove");
+		const leader = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[leader, { intersecting: true }]]);
+		log._peerSyncCapabilities.set(
+			leader,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.resolves({ leaders, localLeader: false });
+		const removeStarted = pDefer<void>();
+		const releaseRemove = pDefer<void>();
+		const remove = sinon.stub(log.log, "remove").callsFake(async () => {
+			removeStarted.resolve();
+			await releaseRemove.promise;
+		});
+		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+		let first: Promise<unknown> | undefined;
+		let replacement: Promise<unknown> | undefined;
+
+		try {
+			[first] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 100,
+			});
+			const firstOutcome = first!.catch((error: unknown) => error);
+			await clock.tickAsync(0);
+			const firstPending = log._checkedPrune.getPendingDelete(entry.hash);
+			const firstRequestId = log._checkedPrune.getRequestId(entry.hash, leader);
+			expect(firstPending).to.exist;
+			expect(firstRequestId).to.be.a("string");
+			await firstPending.resolve(leader, firstRequestId);
+			await clock.tickAsync(0);
+			await removeStarted.promise;
+
+			await clock.tickAsync(100);
+			expect(await firstOutcome).to.be.instanceOf(Error);
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
+
+			[replacement] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			void replacement!.catch(() => {});
+			await clock.tickAsync(0);
+			const replacementPending = log._checkedPrune.getPendingDelete(entry.hash);
+			const replacementRequestId = log._checkedPrune.getRequestId(
+				entry.hash,
+				leader,
+			);
+			expect(replacementPending).to.exist;
+			expect(replacementRequestId)
+				.to.be.a("string")
+				.and.not.equal(firstRequestId);
+
+			releaseRemove.resolve();
+			await clock.tickAsync(0);
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.equal(
+				replacementPending,
+			);
+			expect(log._checkedPrune.getRequestId(entry.hash, leader)).to.equal(
+				replacementRequestId,
+			);
+			expect(log._checkedPrune.isCurrentRequest(entry.hash, replacementPending))
+				.to.be.true;
+		} finally {
+			releaseRemove.resolve();
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(
+				[first, replacement].filter(
+					(value): value is Promise<unknown> => value != null,
+				),
+			);
+			clock.restore();
+			remove.restore();
+			revalidate.restore();
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+
+	it("makes exact response replays idempotent without leader-wait work", async () => {
+		session = await TestSession.disconnected(3);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-response-replay");
+		const remoteKey = session.peers[1].identity.publicKey;
+		const remoteHash = remoteKey.hashcode();
+		const secondRemoteHash = session.peers[2].identity.publicKey.hashcode();
+		const leaders = new Map([
+			[remoteHash, { intersecting: true }],
+			[secondRemoteHash, { intersecting: true }],
+		]);
+
+		for (const peerHash of leaders.keys()) {
+			log._peerSyncCapabilities.set(
+				peerHash,
+				SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+			);
+		}
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const waitForReplicators = sinon.spy(log, "_waitForEntryReplicators");
+		const addConfirmedReplicator = sinon.spy(
+			log._checkedPrune,
+			"addConfirmedReplicator",
+		);
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 2 });
+		let pruning: Promise<unknown> | undefined;
+
+		try {
+			[pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			const outcome = pruning!.catch((error) => error);
+			await waitForResolved(() => {
+				expect(log._checkedPrune.getRequestId(entry.hash, remoteHash)).to.be.a(
+					"string",
+				);
+			});
+			const requestId = log._checkedPrune.getRequestId(entry.hash, remoteHash);
+			const response = new ResponseIPruneV2({
+				requests: [
+					{
+						hash: entry.hash,
+						requestId: fromHexString(requestId),
+					},
+				],
+			});
+			const replays = Array.from({ length: 100 }, () =>
+				db.log.onMessage(response, { from: remoteKey } as any),
+			);
+			await Promise.all(replays);
+			expect(waitForReplicators.called).to.be.false;
+			expect(addConfirmedReplicator.calledOnce).to.be.true;
+			expect(
+				log._checkedPrune.getConfirmedReplicators(entry.hash)?.size,
+			).to.equal(1);
+
+			await db.log.onMessage(response, { from: remoteKey } as any);
+			expect(waitForReplicators.called).to.be.false;
+			expect(addConfirmedReplicator.calledOnce).to.be.true;
+
+			await log.cancelCheckedPruneForLocalLeader(entry.hash);
+			expect(await outcome).to.be.instanceOf(Error);
+		} finally {
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(pruning ? [pruning] : []);
+			getClampedReplicas.restore();
+			addConfirmedReplicator.restore();
+			waitForReplicators.restore();
+			send.restore();
+		}
+	});
+
+	it("requires every exact grant in a multi-replica quorum", async () => {
+		session = await TestSession.disconnected(3);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-multi-replica-quorum");
+		const remoteKeys = session.peers
+			.slice(1)
+			.map((peer) => peer.identity.publicKey);
+		const remoteHashes = remoteKeys.map((key) => key.hashcode());
+		const leaders = new Map(
+			remoteHashes.map((hash) => [hash, { intersecting: true }]),
+		);
+		for (const hash of remoteHashes) {
+			log._peerSyncCapabilities.set(
+				hash,
+				SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+			);
+		}
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 2 });
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.resolves({ leaders, localLeader: false });
+		const remove = sinon.spy(log.log, "remove");
+		let pruning: Promise<unknown> | undefined;
+
+		try {
+			[pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			await waitForResolved(() => {
+				for (const hash of remoteHashes) {
+					expect(log._checkedPrune.getRequestId(entry.hash, hash)).to.be.a(
+						"string",
+					);
+				}
+			});
+			const requestIds = remoteHashes.map((hash) =>
+				log._checkedPrune.getRequestId(entry.hash, hash),
+			);
+
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [
+						{
+							hash: entry.hash,
+							requestId: fromHexString(requestIds[0]),
+						},
+					],
+				}),
+				{ from: remoteKeys[1] } as any,
+			);
+			expect(
+				log._checkedPrune.getConfirmedReplicators(entry.hash)?.size ?? 0,
+			).to.equal(0);
+
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [
+						{
+							hash: entry.hash,
+							requestId: fromHexString(requestIds[0]),
+						},
+					],
+				}),
+				{ from: remoteKeys[0] } as any,
+			);
+			await new Promise<void>((resolve) => setTimeout(resolve, 20));
+			expect(remove.called).to.be.false;
+			expect(revalidate.called).to.be.false;
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.exist;
+			expect(await log.log.has(entry.hash)).to.be.true;
+
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [
+						{
+							hash: entry.hash,
+							requestId: fromHexString(requestIds[1]),
+						},
+					],
+				}),
+				{ from: remoteKeys[1] } as any,
+			);
+			await pruning;
+			expect(remove.calledOnce).to.be.true;
+			expect(await log.log.has(entry.hash)).to.be.false;
+		} finally {
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(pruning ? [pruning] : []);
+			remove.restore();
+			revalidate.restore();
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+
+	it("rejects a grant from a peer excluded by the final remote leader set", async () => {
+		session = await TestSession.disconnected(3);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-replaced-remote-leader");
+		const confirmingKey = session.peers[1].identity.publicKey;
+		const confirmingHash = confirmingKey.hashcode();
+		const replacementHash = session.peers[2].identity.publicKey.hashcode();
+		const originalLeaders = new Map([[confirmingHash, { intersecting: true }]]);
+		const replacementLeaders = new Map([
+			[replacementHash, { intersecting: true }],
+		]);
+		log._peerSyncCapabilities.set(
+			confirmingHash,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const revalidate = sinon.stub(log, "revalidateCheckedPruneOwnership");
+		revalidate.onFirstCall().resolves({
+			leaders: originalLeaders,
+			localLeader: false,
+		});
+		revalidate.onSecondCall().resolves({
+			leaders: replacementLeaders,
+			localLeader: false,
+		});
+		const remove = sinon.spy(log.log, "remove");
+		let pruning: Promise<unknown> | undefined;
+
+		try {
+			[pruning] = log.prune(
+				new Map([[entry.hash, { entry, leaders: originalLeaders }]]),
+				{ timeout: 5_000 },
+			);
+			await waitForResolved(() => {
+				expect(
+					log._checkedPrune.getRequestId(entry.hash, confirmingHash),
+				).to.be.a("string");
+			});
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [
+						{
+							hash: entry.hash,
+							requestId: fromHexString(
+								log._checkedPrune.getRequestId(entry.hash, confirmingHash),
+							),
+						},
+					],
+				}),
+				{ from: confirmingKey } as any,
+			);
+
+			await expect(pruning).to.be.rejectedWith(
+				"Checked prune confirmation is no longer active at the delete boundary",
+			);
+			expect(remove.called).to.be.false;
+			expect(await log.log.has(entry.hash)).to.be.true;
+		} finally {
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(pruning ? [pruning] : []);
+			remove.restore();
+			revalidate.restore();
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+
+	it("does not revive a stale self leader after nonreplicating revalidation", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-stale-self-leader");
+		const selfHash = session.peers[0].identity.publicKey.hashcode();
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		// The debounce union may retain an older self key even though its
+		// authoritative revalidation already established localLeader=false.
+		const leaders = new Map([
+			[selfHash, { intersecting: true }],
+			[remoteHash, { intersecting: true }],
+		]);
+		log._peerSyncCapabilities.set(
+			remoteHash,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		let pruning: Promise<unknown> | undefined;
+
+		try {
+			[pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			void pruning!.catch(() => {});
+			await waitForResolved(() => {
+				const request = send
+					.getCalls()
+					.map((call) => call.args[0])
+					.find((message) => message instanceof RequestIPruneV2);
+				expect(request).to.exist;
+				expect(
+					request!.requests.map(({ hash }: { hash: string }) => hash),
+				).to.deep.equal([entry.hash]);
+			});
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.exist;
+		} finally {
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(pruning ? [pruning] : []);
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+
+	it("uses returned leader maps when a planner omits callbacks", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const log = db.log as any;
+		const selfHash = session.peers[0].identity.publicKey.hashcode();
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+
+		const result = await log.waitForLeaderSelection(
+			[
+				{ key: remoteHash, replicator: true },
+				{ key: selfHash, replicator: false },
+			],
+			{ timeout: 100 },
+			async () => leaders,
+		);
+		expect(result).to.equal(leaders);
+	});
+
+	it("releases a read-only leader wait at its deadline without draining a stuck check", async () => {
+		session = await TestSession.disconnected(1);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = db.log as any;
+		const checkEntered = pDefer<void>();
+		const releaseCheck = pDefer<void>();
+
+		try {
+			const result = log.waitForLeaderSelection(
+				[{ key: "missing-replicator", replicator: true }],
+				{
+					timeout: 20,
+					persist: false,
+					drainInFlightChecks: false,
+				},
+				async () => {
+					checkEntered.resolve();
+					await releaseCheck.promise;
+					return new Map();
+				},
+			);
+			await checkEntered.promise;
+			expect(await result).to.be.false;
+		} finally {
+			releaseCheck.resolve();
+		}
+	});
+
+	it("breaks a three-peer circular checked-prune handoff", async () => {
+		session = await TestSession.disconnected(3);
+		const stores = await Promise.all(
+			session.peers.map((peer) =>
+				peer.open(new EventStore(), {
+					args: {
+						replicate: false,
+						timeUntilRoleMaturity: 0,
+						waitForPruneDelay: 0,
+					},
+				}),
+			),
+		);
+		const logs = stores.map((store) => store.log as any);
+		const { entry } = await stores[0].add("checked-prune-three-peer-cycle");
+		await stores[1].log.log.join([entry]);
+		await stores[2].log.log.join([entry]);
+		const peerHashes = session.peers.map((peer) =>
+			peer.identity.publicKey.hashcode(),
+		);
+		const sent: unknown[][] = [[], [], []];
+		const sendStubs = logs.map((log, index) =>
+			sinon.stub(log.rpc, "send").callsFake(async (message: unknown) => {
+				sent[index].push(message);
+			}),
+		);
+		const replicaStubs = logs.map((log) =>
+			sinon.stub(log, "getClampedReplicas").returns({ getValue: () => 1 }),
+		);
+		const revalidateGrantLeaderStubs = logs.map((log) =>
+			sinon
+				.stub(log, "revalidateCheckedPruneGrantLocalLeaders")
+				.resolves(new Set([entry.hash])),
+		);
+		const removeSpies = logs.map((log) => sinon.spy(log.log, "remove"));
+		const pruning: Promise<unknown>[] = [];
+
+		try {
+			for (let index = 0; index < logs.length; index++) {
+				const leaderIndex = (index + 1) % logs.length;
+				logs[index]._peerSyncCapabilities.set(
+					peerHashes[leaderIndex],
+					SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+				);
+				const [attempt] = logs[index].prune(
+					new Map([
+						[
+							entry.hash,
+							{
+								entry,
+								leaders: new Map([
+									[peerHashes[leaderIndex], { intersecting: true }],
+								]),
+							},
+						],
+					]),
+					{ timeout: 5_000 },
+				);
+				pruning.push(attempt);
+				void attempt.catch(() => {});
+			}
+
+			await waitForResolved(() => {
+				for (const messages of sent) {
+					expect(
+						messages.filter((message) => message instanceof RequestIPruneV2),
+					).to.have.length(1);
+				}
+			});
+			const requests = sent.map(
+				(messages) =>
+					messages.find(
+						(message) => message instanceof RequestIPruneV2,
+					) as RequestIPruneV2,
+			);
+
+			await Promise.all(
+				logs.map((_, requesterIndex) => {
+					const responderIndex = (requesterIndex + 1) % logs.length;
+					return logs[responderIndex].admitCheckedPruneGrants(
+						requests[requesterIndex].requests,
+						peerHashes[requesterIndex],
+					);
+				}),
+			);
+			const outcomes = await Promise.all(
+				pruning.map((attempt) => attempt.catch((error) => error)),
+			);
+			expect(outcomes.every((outcome) => outcome instanceof Error)).to.be.true;
+
+			for (
+				let requesterIndex = 0;
+				requesterIndex < logs.length;
+				requesterIndex++
+			) {
+				const responderIndex = (requesterIndex + 1) % logs.length;
+				const response = sent[responderIndex].find(
+					(message) => message instanceof ResponseIPruneV2,
+				) as ResponseIPruneV2;
+				expect(response).to.exist;
+				await stores[requesterIndex].log.onMessage(response, {
+					from: session.peers[responderIndex].identity.publicKey,
+				} as any);
+			}
+
+			for (let index = 0; index < logs.length; index++) {
+				expect(removeSpies[index].called).to.be.false;
+				expect(await logs[index].log.has(entry.hash)).to.be.true;
+				expect(await logs[index].log.blocks.has(entry.hash)).to.be.true;
+				expect(logs[index]._checkedPrune.getPendingDelete(entry.hash)).to.be
+					.undefined;
+			}
+		} finally {
+			await Promise.allSettled(pruning);
+			for (const spy of removeSpies) spy.restore();
+			for (const stub of revalidateGrantLeaderStubs) stub.restore();
+			for (const stub of replicaStubs) stub.restore();
+			for (const stub of sendStubs) stub.restore();
+		}
+	});
+
+	it("does not recursively delete an ancestor under a child's grant", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const parent = await db.add("checked-prune-parent", {
+			meta: { next: [] },
+		});
+		const child = await db.add("checked-prune-child", {
+			meta: { next: [parent.entry] },
+		});
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		log._peerSyncCapabilities.set(
+			remoteHash,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns(new AbsoluteReplicas(1));
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.resolves({ leaders, localLeader: false });
+		const planEntryLeaderBatch = sinon
+			.stub(log, "planEntryLeaderBatch")
+			.resolves([{ coordinates: [], leaders, isLeader: false }]);
+		const remove = sinon.spy(log.log, "remove");
+
+		try {
+			const [pruning] = log.prune(
+				new Map([[child.entry.hash, { entry: child.entry, leaders }]]),
+				{ timeout: 5_000 },
+			);
+			await waitForResolved(() => {
+				expect(
+					log._checkedPrune.getRequestId(child.entry.hash, remoteHash),
+				).to.be.a("string");
+			});
+			const pending = log._checkedPrune.getPendingDelete(child.entry.hash);
+			const requestId = log._checkedPrune.getRequestId(
+				child.entry.hash,
+				remoteHash,
+			);
+			await pending.resolve(remoteHash, requestId);
+			await pruning;
+
+			expect(remove.calledOnce).to.be.true;
+			expect(remove.firstCall.args[0].hash).to.equal(child.entry.hash);
+			expect(remove.firstCall.args[1]).to.deep.equal({ recursively: false });
+			expect(await log.log.has(child.entry.hash)).to.be.false;
+			expect(await log.log.has(parent.entry.hash)).to.be.true;
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			await log.pruneDebouncedFn.flush();
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			expect(log._checkedPrune.getRequestId(parent.entry.hash, remoteHash)).to
+				.be.undefined;
+			expect(
+				send
+					.getCalls()
+					.flatMap((call) =>
+						call.args[0] instanceof RequestIPruneV2
+							? call.args[0].requests
+							: [],
+					)
+					.some((request) => request.hash === parent.entry.hash),
+			).to.be.false;
+			expect(await log.log.has(parent.entry.hash)).to.be.true;
+		} finally {
+			remove.restore();
+			planEntryLeaderBatch.restore();
+			revalidate.restore();
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+
+	it("wakes a retained candidate when checked-prune capability arrives", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-capability-wake");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.resolves({ leaders, localLeader: false });
+
+		try {
+			const [initialAttempt] = log.prune(
+				new Map([[entry.hash, { entry, leaders }]]),
+			);
+			await expect(initialAttempt).to.be.rejectedWith(
+				"Insufficient checked-prune capable leaders",
+			);
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
+			expect(log._checkedPrune.getRetry(entry.hash)).to.exist;
+			log._checkedPrune.clearRetryTimer(entry.hash);
+
+			log.recordPeerSyncCapabilities(
+				remoteHash,
+				SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+			);
+			await waitForResolved(
+				() => {
+					expect(
+						send
+							.getCalls()
+							.filter((call) => call.args[0] instanceof RequestIPruneV2),
+					).to.have.length(1);
+				},
+				{ timeout: 3_000, delayInterval: 10 },
+			);
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			expect(pending).to.exist;
+			void pending.promise.promise.catch(() => {});
+			await log.cancelCheckedPruneForLocalLeader(entry.hash);
+		} finally {
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			log._checkedPrune.clearRetry(entry.hash);
+			revalidate.restore();
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+
+	it("treats capabilities as monotonic within a subscription", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: false },
+		});
+		const log = db.log as any;
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const wake = sinon.stub(log, "wakeCheckedPruneRetriesForPeer");
+
+		try {
+			log.recordPeerSyncCapabilities(
+				remoteHash,
+				SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+			);
+			log.recordPeerSyncCapabilities(remoteHash, 0);
+			log.recordPeerSyncCapabilities(
+				remoteHash,
+				SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+			);
+
+			expect(wake.calledOnceWithExactly(remoteHash)).to.be.true;
+			expect(log._peerSyncCapabilities.get(remoteHash)).to.equal(
+				SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+			);
+
+			log.cleanupPeerDisconnectTracking(remoteHash);
+			expect(log._peerSyncCapabilities.has(remoteHash)).to.be.false;
+			log.recordPeerSyncCapabilities(
+				remoteHash,
+				SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+			);
+			expect(wake.callCount).to.equal(2);
+		} finally {
+			wake.restore();
+		}
+	});
+
+	it("revokes an old confirmation when a peer contact id changes", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-contact-generation");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		log._peerSyncCapabilities.set(
+			remoteHash,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		let pruning: Promise<unknown> | undefined;
+
+		try {
+			[pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			const outcome = pruning!.catch((error) => error);
+			await waitForResolved(() => {
+				expect(log._checkedPrune.getRequestId(entry.hash, remoteHash)).to.be.a(
+					"string",
+				);
+			});
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			const firstRequestId = log._checkedPrune.getRequestId(
+				entry.hash,
+				remoteHash,
+			);
+			expect(
+				log._checkedPrune.addConfirmedReplicator(
+					entry.hash,
+					remoteHash,
+					pending,
+					firstRequestId,
+				),
+			).to.exist;
+
+			const secondRequestId = toHexString(randomBytes(32));
+			expect(secondRequestId).to.not.equal(firstRequestId);
+			expect(
+				log._checkedPrune.addRequestSent(
+					entry.hash,
+					remoteHash,
+					secondRequestId,
+				),
+			).to.be.true;
+			expect(
+				log._checkedPrune
+					.getConfirmedReplicators(entry.hash)
+					?.has(remoteHash) ?? false,
+			).to.be.false;
+			expect(log._checkedPrune.getConfirmedRequestId(entry.hash, remoteHash)).to
+				.be.undefined;
+
+			await log.cancelCheckedPruneForLocalLeader(entry.hash);
+			expect(await outcome).to.be.instanceOf(Error);
+		} finally {
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(pruning ? [pruning] : []);
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+
+	it("rejects duplicate, oversized, and overlong correlated prune input before work", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-vector-bounds");
+		const remoteKey = session.peers[1].identity.publicKey;
+		const remoteHash = remoteKey.hashcode();
+		const planner = sinon.spy(
+			log,
+			"planCurrentNativeBackboneRequestPruneLeaderHints",
+		);
+		const removeKnown = sinon.spy(log, "removeEntriesKnownByPeer");
+		const removeRequests = sinon.spy(log, "removePruneRequestsSent");
+		const removeConfirmations = sinon.spy(
+			log._checkedPrune,
+			"removeConfirmedReplicators",
+		);
+		const removePeerHistory = sinon.spy(
+			log,
+			"removePeerFromGidPeerHistoryBatch",
+		);
+		const send = sinon.stub(log.rpc, "send").resolves();
+
+		try {
+			await db.log.onMessage(
+				new RequestIPruneV2({
+					requests: [
+						{ hash: entry.hash, requestId: randomBytes(32) },
+						{ hash: entry.hash, requestId: randomBytes(32) },
+					],
+				}),
+				{ from: remoteKey } as any,
+			);
+			await db.log.onMessage(
+				new RequestIPruneV2({
+					requests: Array.from({ length: 1_025 }, (_, index) => ({
+						hash: `oversized-${index}`,
+						requestId: randomBytes(32),
+					})),
+				}),
+				{ from: remoteKey } as any,
+			);
+			for (const invalidHash of ["", "x".repeat(257)]) {
+				await db.log.onMessage(
+					new RequestIPruneV2({
+						requests: [
+							{ hash: invalidHash, requestId: randomBytes(32) },
+							{ hash: entry.hash, requestId: randomBytes(32) },
+						],
+					}),
+					{ from: remoteKey } as any,
+				);
+			}
+			expect(planner.called).to.be.false;
+			expect(removeKnown.called).to.be.false;
+			expect(removeRequests.called).to.be.false;
+			expect(removeConfirmations.called).to.be.false;
+			expect(removePeerHistory.called).to.be.false;
+			expect(log._pendingIHave.size).to.equal(0);
+			expect(log._pendingIHaveCountByPeer.size).to.equal(0);
+			expect(log._pendingIHaveRequesterCount).to.equal(0);
+			expect(
+				send
+					.getCalls()
+					.some((call) => call.args[0] instanceof ResponseIPruneV2),
+			).to.be.false;
+
+			const deferred = pDefer<void>();
+			const pending = {
+				promise: deferred,
+				clear: () => {},
+				resolve: sinon.spy(),
+				reject: () => {},
+			};
+			log._checkedPrune.setPendingDelete(
+				entry.hash,
+				pending,
+				entry,
+				new Map([[remoteHash, { intersecting: true }]]),
+			);
+			const requestIdBytes = randomBytes(32);
+			const requestId = toHexString(requestIdBytes);
+			log._checkedPrune.addRequestSent(entry.hash, remoteHash, requestId);
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [
+						{ hash: "x".repeat(257), requestId: randomBytes(32) },
+						{ hash: entry.hash, requestId: requestIdBytes },
+					],
+				}),
+				{ from: remoteKey } as any,
+			);
+			expect(pending.resolve.called).to.be.false;
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [
+						{ hash: entry.hash, requestId: requestIdBytes },
+						{ hash: entry.hash, requestId: requestIdBytes },
+					],
+				}),
+				{ from: remoteKey } as any,
+			);
+			expect(pending.resolve.called).to.be.false;
+			log._checkedPrune.deletePendingDelete(entry.hash, pending);
+		} finally {
+			removePeerHistory.restore();
+			removeConfirmations.restore();
+			removeRequests.restore();
+			removeKnown.restore();
+			planner.restore();
+			send.restore();
+		}
+	});
+
+	it("bounds active prune-request work per peer and globally", async () => {
+		session = await TestSession.disconnected(1);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const log = db.log as any;
+		const remoteKeys = (
+			await Promise.all(
+				Array.from({ length: 5 }, () => Ed25519Keypair.create()),
+			)
+		).map((keypair) => keypair.publicKey);
+		const releasePlanner = pDefer<void>();
+		const planner = sinon
+			.stub(log, "planCurrentNativeBackboneRequestPruneLeaderHints")
+			.callsFake(async () => {
+				await releasePlanner.promise;
+				return undefined;
+			});
+		const hasMany = sinon
+			.stub(log.log.blocks, "hasMany")
+			.callsFake(async (...args: unknown[]) =>
+				(args[0] as string[]).map(() => false),
+			);
+		const request = (peerIndex: number, hash: string) =>
+			db.log.onMessage(
+				new RequestIPruneV2({
+					requests: [{ hash, requestId: randomBytes(32) }],
+				}),
+				{ from: remoteKeys[peerIndex] } as any,
+			);
+
+		const active: Promise<void>[] = [];
+		try {
+			active.push(request(0, "active-request-peer-0"));
+			await waitForResolved(() => expect(planner.callCount).to.equal(1));
+
+			await request(0, "same-peer-overflow");
+			expect(planner.callCount).to.equal(1);
+
+			for (let peerIndex = 1; peerIndex < 4; peerIndex++) {
+				active.push(request(peerIndex, `active-request-peer-${peerIndex}`));
+			}
+			await waitForResolved(() => expect(planner.callCount).to.equal(4));
+			expect(log._checkedPruneRequestWorkAdmission.activeByPeer.size).to.equal(
+				4,
+			);
+
+			await request(4, "global-overflow");
+			expect(planner.callCount).to.equal(4);
+
+			releasePlanner.resolve();
+			await Promise.all(active);
+			expect(log._checkedPruneRequestWorkAdmission.activeByPeer.size).to.equal(
+				0,
+			);
+
+			await request(4, "retry-after-release");
+			expect(planner.callCount).to.equal(5);
+			expect(log._checkedPruneRequestWorkAdmission.activeByPeer.size).to.equal(
+				0,
+			);
+		} finally {
+			releasePlanner.resolve();
+			await Promise.allSettled(active);
+			log.clearPendingIHaves();
+			hasMany.restore();
+			planner.restore();
+		}
+	});
+
+	it("retains timed-out request capacity until reads settle and retires the old generation on reopen", async () => {
+		session = await TestSession.disconnected(1);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const log = db.log as any;
+		const remoteKeys = (
+			await Promise.all(
+				Array.from({ length: 5 }, () => Ed25519Keypair.create()),
+			)
+		).map((keypair) => keypair.publicKey);
+		const plannerReleases: ReturnType<typeof pDefer<void>>[] = [];
+		const planner = sinon
+			.stub(log, "planCurrentNativeBackboneRequestPruneLeaderHints")
+			.callsFake(() => {
+				const release = pDefer<void>();
+				plannerReleases.push(release);
+				return release.promise.then(() => undefined);
+			});
+		const request = (peerIndex: number, hash: string) =>
+			db.log.onMessage(
+				new RequestIPruneV2({
+					requests: [{ hash, requestId: randomBytes(32) }],
+				}),
+				{ from: remoteKeys[peerIndex] } as any,
+			);
+		const clock = sinon.useFakeTimers({
+			now: 1_000,
+			shouldClearNativeTimers: true,
+		});
+		let clockRestored = false;
+		let freshRequest: Promise<void> | undefined;
+
+		try {
+			const oldAdmission = log._checkedPruneRequestWorkAdmission;
+			const timedOut = Array.from({ length: 4 }, (_, peerIndex) =>
+				request(peerIndex, `detached-request-${peerIndex}`),
+			);
+			expect(planner.callCount).to.equal(4);
+
+			await clock.tickAsync(5_000);
+			await Promise.all(timedOut);
+			expect(oldAdmission.activeByPeer.size).to.equal(4);
+
+			// Neither reconnecting the same peer nor rotating identities may turn
+			// repeated deadline cycles into unbounded detached planner reads.
+			await request(0, "same-peer-detached-overflow");
+			await request(4, "global-detached-overflow");
+			expect(planner.callCount).to.equal(4);
+			expect(oldAdmission.activeByPeer.size).to.equal(4);
+
+			clock.restore();
+			clockRestored = true;
+			await db.close();
+			await session.peers[0].open(db, {
+				args: {
+					replicate: false,
+					timeUntilRoleMaturity: 0,
+				},
+			});
+
+			const freshAdmission = log._checkedPruneRequestWorkAdmission;
+			expect(freshAdmission).to.not.equal(oldAdmission);
+			expect(freshAdmission.activeByPeer.size).to.equal(0);
+
+			freshRequest = request(4, "fresh-lifecycle-request");
+			expect(planner.callCount).to.equal(5);
+			expect(freshAdmission.activeByPeer.size).to.equal(1);
+
+			for (const release of plannerReleases.slice(0, 4)) {
+				release.resolve();
+			}
+			await waitForResolved(() =>
+				expect(oldAdmission.activeByPeer.size).to.equal(0),
+			);
+			expect(freshAdmission.activeByPeer.size).to.equal(1);
+
+			plannerReleases[4]!.resolve();
+			await freshRequest;
+			await waitForResolved(() =>
+				expect(freshAdmission.activeByPeer.size).to.equal(0),
+			);
+		} finally {
+			for (const release of plannerReleases) {
+				release.resolve();
+			}
+			await Promise.allSettled(freshRequest ? [freshRequest] : []);
+			if (!clockRestored) {
+				clock.restore();
+			}
+			planner.restore();
+		}
+	});
+
+	it("bounds sequential leader waits to one five-second request budget", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const log = db.log as any;
+		const first = await db.add("checked-prune-work-budget-first");
+		const second = await db.add("checked-prune-work-budget-second");
+		const remoteKey = session.peers[1].identity.publicKey;
+		const backbonePlan = sinon
+			.stub(log, "planCurrentNativeBackboneRequestPruneLeaderHints")
+			.resolves(undefined);
+		const nativeMetadata = sinon
+			.stub(log, "getNativeLogEntryMetadataBatch")
+			.returns([null, null]);
+		const hasMany = sinon
+			.stub(log.log.blocks, "hasMany")
+			.resolves([true, true]);
+		const nativePlan = sinon
+			.stub(log, "planCurrentNativeRequestPruneLeaderHints")
+			.resolves({
+				localLeaderHashes: new Set(),
+				replicaCounts: new Map(),
+				peerHistoryGids: [],
+				peerHistoryRemovedHashes: new Set(),
+			});
+		const clock = sinon.useFakeTimers({ now: 1_000, toFake: ["Date"] });
+		const observedTimeouts: number[] = [];
+		const waitForReplicators = sinon
+			.stub(log, "_waitForEntryReplicators")
+			.callsFake(async (...args: unknown[]) => {
+				const timeout = (args[3] as { timeout: number }).timeout;
+				observedTimeouts.push(timeout);
+				clock.setSystemTime(Date.now() + timeout);
+				return false;
+			});
+		const send = sinon.stub(log.rpc, "send").resolves();
+
+		try {
+			await db.log.onMessage(
+				new RequestIPruneV2({
+					requests: [first.entry, second.entry].map((entry) => ({
+						hash: entry.hash,
+						requestId: randomBytes(32),
+					})),
+				}),
+				{ from: remoteKey } as any,
+			);
+
+			expect(observedTimeouts).to.deep.equal([5_000]);
+			expect(waitForReplicators.calledOnce).to.be.true;
+			expect(log._pendingIHave.size).to.equal(0);
+			expect(
+				send
+					.getCalls()
+					.some((call) => call.args[0] instanceof ResponseIPruneV2),
+			).to.be.false;
+			expect(log._checkedPruneRequestWorkAdmission.activeByPeer.size).to.equal(
+				0,
+			);
+		} finally {
+			clock.restore();
+			send.restore();
+			waitForReplicators.restore();
+			nativePlan.restore();
+			hasMany.restore();
+			nativeMetadata.restore();
+			backbonePlan.restore();
+		}
+	});
+
+	it("stops correlated prune work when the sender subscription changes", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const log = db.log as any;
+		const first = await db.add("checked-prune-epoch-first");
+		const second = await db.add("checked-prune-epoch-second");
+		const remoteKey = session.peers[1].identity.publicKey;
+		const remoteHash = remoteKey.hashcode();
+		const backbonePlan = sinon
+			.stub(log, "planCurrentNativeBackboneRequestPruneLeaderHints")
+			.resolves(undefined);
+		const nativeMetadata = sinon
+			.stub(log, "getNativeLogEntryMetadataBatch")
+			.returns([null, null]);
+		const hasMany = sinon
+			.stub(log.log.blocks, "hasMany")
+			.resolves([true, true]);
+		const nativePlan = sinon
+			.stub(log, "planCurrentNativeRequestPruneLeaderHints")
+			.resolves({
+				localLeaderHashes: new Set(),
+				replicaCounts: new Map(),
+				peerHistoryGids: [],
+				peerHistoryRemovedHashes: new Set(),
+			});
+		const waitForReplicators = sinon
+			.stub(log, "_waitForEntryReplicators")
+			.callsFake(async () => {
+				log.advanceSubscriptionEpoch(remoteHash);
+				return false;
+			});
+		const send = sinon.stub(log.rpc, "send").resolves();
+
+		try {
+			await db.log.onMessage(
+				new RequestIPruneV2({
+					requests: [first.entry, second.entry].map((entry) => ({
+						hash: entry.hash,
+						requestId: randomBytes(32),
+					})),
+				}),
+				{ from: remoteKey } as any,
+			);
+
+			expect(waitForReplicators.calledOnce).to.be.true;
+			expect(log._pendingIHave.size).to.equal(0);
+			expect(
+				send
+					.getCalls()
+					.some((call) => call.args[0] instanceof ResponseIPruneV2),
+			).to.be.false;
+			expect(log._checkedPruneRequestWorkAdmission.activeByPeer.size).to.equal(
+				0,
+			);
+		} finally {
+			send.restore();
+			waitForReplicators.restore();
+			nativePlan.restore();
+			hasMany.restore();
+			nativeMetadata.restore();
+			backbonePlan.restore();
+		}
+	});
+
+	it("bounds retained missing-entry requests per peer and globally", async () => {
+		session = await TestSession.disconnected(1);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+				respondToIHaveTimeout: 60_000,
+			},
+		});
+		const log = db.log as any;
+		const remoteKeys = (
+			await Promise.all(
+				Array.from({ length: 5 }, () => Ed25519Keypair.create()),
+			)
+		).map((keypair) => keypair.publicKey);
+		const hashesByPeer = remoteKeys.map((_, peerIndex) =>
+			Array.from(
+				{ length: 1_024 },
+				(__, hashIndex) => `pending-ihave-${peerIndex}-${hashIndex}`,
+			),
+		);
+		const hasMany = sinon
+			.stub(log.log.blocks, "hasMany")
+			.callsFake(async (...args: unknown[]) =>
+				(args[0] as string[]).map(() => false),
+			);
+
+		const request = async (
+			peerIndex: number,
+			hashes: string[],
+			requestIdByte: number,
+		) =>
+			db.log.onMessage(
+				new RequestIPruneV2({
+					requests: hashes.map((hash) => ({
+						hash,
+						requestId: new Uint8Array(32).fill(requestIdByte),
+					})),
+				}),
+				{ from: remoteKeys[peerIndex] } as any,
+			);
+
+		try {
+			for (let peerIndex = 0; peerIndex < 4; peerIndex++) {
+				await request(peerIndex, hashesByPeer[peerIndex], peerIndex + 1);
+			}
+			expect(log._pendingIHave.size).to.equal(4_096);
+			for (let peerIndex = 0; peerIndex < 4; peerIndex++) {
+				expect(
+					log._pendingIHaveCountByPeer.get(remoteKeys[peerIndex].hashcode()),
+				).to.equal(1_024);
+			}
+			expect(log._pendingIHaveRequesterCount).to.equal(4_096);
+
+			await request(4, hashesByPeer[4], 5);
+			expect(log._pendingIHave.size).to.equal(4_096);
+			expect(log._pendingIHaveCountByPeer.has(remoteKeys[4].hashcode())).to.be
+				.false;
+
+			const firstHash = hashesByPeer[0][0];
+			await request(4, [firstHash], 55);
+			expect(
+				log._pendingIHave
+					.get(firstHash)
+					.requesting.has(remoteKeys[4].hashcode()),
+			).to.be.false;
+			expect(log._pendingIHaveRequesterCount).to.equal(4_096);
+
+			const refreshedRequestId = new Uint8Array(32).fill(99);
+			await db.log.onMessage(
+				new RequestIPruneV2({
+					requests: [{ hash: firstHash, requestId: refreshedRequestId }],
+				}),
+				{ from: remoteKeys[0] } as any,
+			);
+			expect(
+				log._pendingIHave
+					.get(firstHash)
+					.requestIdsByPeer.get(remoteKeys[0].hashcode()),
+			).to.deep.equal(refreshedRequestId);
+			expect(
+				log._pendingIHaveCountByPeer.get(remoteKeys[0].hashcode()),
+			).to.equal(1_024);
+
+			log.cleanupPendingIHavePeer(remoteKeys[0].hashcode());
+			expect(log._pendingIHave.size).to.equal(3_072);
+			expect(log._pendingIHaveCountByPeer.has(remoteKeys[0].hashcode())).to.be
+				.false;
+			expect(log._pendingIHaveRequesterCount).to.equal(3_072);
+
+			await request(4, hashesByPeer[4], 6);
+			expect(log._pendingIHave.size).to.equal(4_096);
+			expect(
+				log._pendingIHaveCountByPeer.get(remoteKeys[4].hashcode()),
+			).to.equal(1_024);
+			expect(log._pendingIHaveRequesterCount).to.equal(4_096);
+		} finally {
+			log.clearPendingIHaves();
+			hasMany.restore();
+		}
+	});
+
+	it("chunks large outbound prune batches and reuses their request ids", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-outbound-chunking");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		log._peerSyncCapabilities.set(
+			remoteHash,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const entries = new Map<string, { entry: any; leaders: typeof leaders }>();
+		for (let index = 0; index < 1_025; index++) {
+			const hash = `checked-prune-chunk-${index}`;
+			entries.set(hash, {
+				entry: { hash, meta: entry.meta },
+				leaders,
+			});
+		}
+		const attempts: Promise<unknown>[] = [];
+
+		try {
+			const firstAttempts = log.prune(entries, { timeout: 30_000 });
+			attempts.push(...firstAttempts);
+			for (const attempt of firstAttempts) void attempt.catch(() => {});
+			await waitForResolved(() => {
+				expect(
+					send
+						.getCalls()
+						.filter((call) => call.args[0] instanceof RequestIPruneV2),
+				).to.have.length(2);
+			});
+			const firstBatches = send
+				.getCalls()
+				.map((call) => call.args[0])
+				.filter(
+					(message): message is RequestIPruneV2 =>
+						message instanceof RequestIPruneV2,
+				);
+			expect(firstBatches.map((batch) => batch.requests.length)).to.deep.equal([
+				1_024, 1,
+			]);
+			const firstIds = new Map(
+				firstBatches
+					.flatMap((batch) => batch.requests)
+					.map((request) => [request.hash, toHexString(request.requestId)]),
+			);
+			expect(firstIds.size).to.equal(1_025);
+
+			const secondAttempts = log.prune(entries, { timeout: 30_000 });
+			attempts.push(...secondAttempts);
+			for (const attempt of secondAttempts) void attempt.catch(() => {});
+			await waitForResolved(() => {
+				expect(
+					send
+						.getCalls()
+						.filter((call) => call.args[0] instanceof RequestIPruneV2),
+				).to.have.length(4);
+			});
+			const secondBatches = send
+				.getCalls()
+				.slice(2)
+				.map((call) => call.args[0])
+				.filter(
+					(message): message is RequestIPruneV2 =>
+						message instanceof RequestIPruneV2,
+				);
+			expect(secondBatches.map((batch) => batch.requests.length)).to.deep.equal(
+				[1_024, 1],
+			);
+			for (const request of secondBatches.flatMap((batch) => batch.requests)) {
+				expect(toHexString(request.requestId)).to.equal(
+					firstIds.get(request.hash),
+				);
+			}
+
+			send.resetHistory();
+			send.resetBehavior();
+			send.onFirstCall().rejects(new Error("first chunk failed"));
+			send.onSecondCall().resolves();
+			const thirdAttempts = log.prune(entries, { timeout: 30_000 });
+			attempts.push(...thirdAttempts);
+			for (const attempt of thirdAttempts) void attempt.catch(() => {});
+			await waitForResolved(() => {
+				expect(
+					send
+						.getCalls()
+						.filter((call) => call.args[0] instanceof RequestIPruneV2),
+				).to.have.length(2);
+			});
+			expect(
+				send
+					.getCalls()
+					.filter((call) => call.args[0] instanceof RequestIPruneV2)
+					.map((call) => call.args[0].requests.length),
+			).to.deep.equal([1_024, 1]);
+			expect(
+				send
+					.getCalls()
+					.filter((call) => call.args[0] instanceof RequestIPruneV2)
+					.every(
+						(call) =>
+							call.args[1].mode instanceof AcknowledgeDelivery &&
+							call.args[1].signal ===
+								log.captureReplicationOwnershipLifecycle().signal,
+					),
+			).to.be.true;
+
+			send.resetHistory();
+			send.resetBehavior();
+			const lastHash = "checked-prune-chunk-1024";
+			send.onFirstCall().callsFake(() => {
+				void log.cancelCheckedPruneForLocalLeader(lastHash);
+				return Promise.resolve();
+			});
+			send.resolves();
+			const fourthAttempts = log.prune(entries, { timeout: 30_000 });
+			attempts.push(...fourthAttempts);
+			for (const attempt of fourthAttempts) void attempt.catch(() => {});
+			await waitForResolved(() => {
+				expect(
+					send
+						.getCalls()
+						.filter((call) => call.args[0] instanceof RequestIPruneV2),
+				).to.have.length(1);
+			});
+			const fourthBatch = send
+				.getCalls()
+				.map((call) => call.args[0])
+				.find(
+					(message): message is RequestIPruneV2 =>
+						message instanceof RequestIPruneV2,
+				);
+			expect(fourthBatch?.requests).to.have.length(1_024);
+			expect(fourthBatch?.requests.some((request) => request.hash === lastHash))
+				.to.be.false;
+		} finally {
+			const rejections: Promise<unknown>[] = [];
+			for (const hash of entries.keys()) {
+				const pending = log._checkedPrune.getPendingDelete(hash);
+				if (!pending) continue;
+				try {
+					rejections.push(
+						Promise.resolve(pending.reject(new Error("test cleanup"))),
+					);
+				} catch (error) {
+					rejections.push(Promise.reject(error));
+				}
+			}
+			await Promise.allSettled(rejections);
+			await Promise.allSettled(attempts);
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+
+	it("bounds acknowledged prune sends globally across destinations", async () => {
+		session = await TestSession.disconnected(1);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-global-send-bound");
+		const entries = new Map<
+			string,
+			{ entry: any; leaders: Map<string, { intersecting: boolean }> }
+		>();
+		for (let index = 0; index < 1_025; index++) {
+			const hash = `checked-prune-global-send-${index}`;
+			const peer = `checked-prune-peer-${index}`;
+			const leaders = new Map([[peer, { intersecting: true }]]);
+			entries.set(hash, { entry: { hash, meta: entry.meta }, leaders });
+			log._peerSyncCapabilities.set(
+				peer,
+				SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+			);
+		}
+		const releaseSends = pDefer<void>();
+		const fourSendsEntered = pDefer<void>();
+		let activeSends = 0;
+		let maximumActiveSends = 0;
+		let totalSends = 0;
+		const send = sinon
+			.stub(log.rpc, "send")
+			.callsFake(async (message: unknown) => {
+				if (!(message instanceof RequestIPruneV2)) {
+					return;
+				}
+				activeSends++;
+				totalSends++;
+				maximumActiveSends = Math.max(maximumActiveSends, activeSends);
+				if (totalSends === 4) {
+					fourSendsEntered.resolve();
+				}
+				try {
+					await releaseSends.promise;
+				} finally {
+					activeSends--;
+				}
+			});
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const firstEntries = new Map(
+			[...entries].filter((_, index) => index % 2 === 0),
+		);
+		const secondEntries = new Map(
+			[...entries].filter((_, index) => index % 2 === 1),
+		);
+		// Two concurrent prune() calls prove this is an instance-wide bound, not
+		// merely a queue local to one invocation.
+		const attempts = [
+			...log.prune(firstEntries, { timeout: 30_000 }),
+			...log.prune(secondEntries, { timeout: 30_000 }),
+		];
+		for (const attempt of attempts) void attempt.catch(() => {});
+
+		try {
+			await fourSendsEntered.promise;
+			await new Promise<void>((resolve) => setTimeout(resolve, 20));
+			expect(totalSends).to.equal(4);
+			expect(activeSends).to.equal(4);
+			expect(maximumActiveSends).to.equal(4);
+
+			releaseSends.resolve();
+			await waitForResolved(() => expect(totalSends).to.equal(1_025), {
+				timeout: 5_000,
+				delayInterval: 10,
+			});
+			expect(maximumActiveSends).to.equal(4);
+		} finally {
+			releaseSends.resolve();
+			const rejections: Promise<unknown>[] = [];
+			for (const hash of entries.keys()) {
+				const pending = log._checkedPrune.getPendingDelete(hash);
+				if (!pending) continue;
+				try {
+					rejections.push(
+						Promise.resolve(pending.reject(new Error("test cleanup"))),
+					);
+				} catch (error) {
+					rejections.push(Promise.reject(error));
+				}
+			}
+			await Promise.allSettled(rejections);
+			await Promise.allSettled(attempts);
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+
+	it("retries an initially failed background request with the same request id", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+				respondToIHaveTimeout: 500,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-initial-send-retry");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		log._peerSyncCapabilities.set(
+			remoteHash,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const requestIds: string[] = [];
+		const send = sinon
+			.stub(log.rpc, "send")
+			.callsFake(async (message: unknown) => {
+				if (!(message instanceof RequestIPruneV2)) {
+					return;
+				}
+				requestIds.push(toHexString(message.requests[0].requestId));
+				if (requestIds.length === 1) {
+					throw new Error("forced initial send failure");
+				}
+			});
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const attempts = log.prune(new Map([[entry.hash, { entry, leaders }]]));
+		for (const attempt of attempts) void attempt.catch(() => {});
+
+		try {
+			await waitForResolved(
+				() => expect(requestIds.length).to.be.greaterThan(1),
+				{
+					timeout: 2_000,
+					delayInterval: 20,
+				},
+			);
+			expect(requestIds[1]).to.equal(requestIds[0]);
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			expect(pending).to.exist;
+			expect(
+				log._checkedPrune.isCurrentRequestForPeer(
+					entry.hash,
+					pending,
+					remoteHash,
+					requestIds[0],
+				),
+			).to.be.true;
+		} finally {
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			await pending?.reject(new Error("test cleanup"));
+			await Promise.allSettled(attempts);
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+
+	it("retries a background generation when preliminary revalidation fails", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-preliminary-revalidation");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		log._peerSyncCapabilities.set(
+			remoteHash,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const remove = sinon.spy(log.log, "remove");
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.rejects(new Error("forced preliminary planner failure"));
+		const [pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]));
+		const outcome = pruning.catch((error: unknown) => error);
+
+		try {
+			await waitForResolved(() => {
+				expect(log._checkedPrune.getRequestId(entry.hash, remoteHash)).to.be.a(
+					"string",
+				);
+			});
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			const requestId = log._checkedPrune.getRequestId(entry.hash, remoteHash);
+			await pending.resolve(remoteHash, requestId);
+			expect(await outcome).to.be.instanceOf(Error);
+			await waitForResolved(() => {
+				expect(log._checkedPrune.getRetry(entry.hash)?.attempts).to.equal(1);
+			});
+			expect(remove.called).to.be.false;
+		} finally {
+			log._checkedPrune.clearRetry(entry.hash);
+			revalidate.restore();
+			getClampedReplicas.restore();
+			remove.restore();
+			send.restore();
+		}
+	});
+
+	it("does not guess by retrying an ambiguous lower-log remove failure", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-remove-failure");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		log._peerSyncCapabilities.set(
+			remoteHash,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.resolves({ leaders, localLeader: false });
+		const remove = sinon
+			.stub(log.log, "remove")
+			.rejects(new Error("ambiguous lower-log remove failure"));
+		const [pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]));
+		const outcome = pruning.catch((error: unknown) => error);
+
+		try {
+			await waitForResolved(() => {
+				expect(log._checkedPrune.getRequestId(entry.hash, remoteHash)).to.be.a(
+					"string",
+				);
+			});
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			const requestId = log._checkedPrune.getRequestId(entry.hash, remoteHash);
+			await pending.resolve(remoteHash, requestId);
+			expect(await outcome).to.be.instanceOf(Error);
+			expect(remove.calledOnce).to.be.true;
+			expect(log._checkedPrune.getRetry(entry.hash)).to.be.undefined;
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
+		} finally {
+			log._checkedPrune.clearRetry(entry.hash);
+			remove.restore();
+			revalidate.restore();
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+
+	it("fails closed for legacy prune requests and responses", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-legacy-fail-closed");
+		const remoteKey = session.peers[1].identity.publicKey;
+		const remoteHash = remoteKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		log._peerSyncCapabilities.set(
+			remoteHash,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+
+		let pruning: Promise<unknown> | undefined;
+		try {
+			[pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			const outcome = pruning!.catch((error) => error);
+			await waitForResolved(() => {
+				expect(log._checkedPrune.getPendingDelete(entry.hash)).to.exist;
+				expect(log._checkedPrune.getRequestId(entry.hash, remoteHash)).to.be.a(
+					"string",
+				);
+			});
+			const pendingBeforeLegacy = log._checkedPrune.getPendingDelete(
+				entry.hash,
+			);
+			const requestIdBeforeLegacy = log._checkedPrune.getRequestId(
+				entry.hash,
+				remoteHash,
+			);
+			await db.log.onMessage(
+				new RequestIPrune({
+					hashes: [
+						entry.hash,
+						...Array.from(
+							{ length: 4_096 },
+							(_, index) => `legacy-unbounded-${index}`,
+						),
+					],
+				}),
+				{ from: remoteKey } as any,
+			);
+			expect(
+				send.getCalls().some((call) => call.args[0] instanceof ResponseIPrune),
+			).to.be.false;
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.equal(
+				pendingBeforeLegacy,
+			);
+			expect(log._checkedPrune.getRequestId(entry.hash, remoteHash)).to.equal(
+				requestIdBeforeLegacy,
+			);
+
+			await db.log.onMessage(new ResponseIPrune({ hashes: [entry.hash] }), {
+				from: remoteKey,
+			} as any);
+			expect(
+				log._checkedPrune.getConfirmedReplicators(entry.hash)?.size ?? 0,
+			).to.equal(0);
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.exist;
+
+			await log.cancelCheckedPruneForLocalLeader(entry.hash);
+			expect(await outcome).to.be.instanceOf(Error);
+		} finally {
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(pruning ? [pruning] : []);
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+});

--- a/packages/programs/data/shared-log/test/checked-prune-retry-state.spec.ts
+++ b/packages/programs/data/shared-log/test/checked-prune-retry-state.spec.ts
@@ -1,0 +1,382 @@
+import { TestSession } from "@peerbit/test-utils";
+import { waitForResolved } from "@peerbit/time";
+import { expect } from "chai";
+import pDefer from "p-defer";
+import sinon from "sinon";
+import {
+	RequestIPruneV2,
+	SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+} from "../src/exchange-heads.js";
+import { EventStore } from "./utils/stores/index.js";
+
+describe("checked prune retry state", () => {
+	let session: TestSession | undefined;
+
+	afterEach(async () => {
+		await session?.stop();
+		session = undefined;
+	});
+
+	it("retires a capability-ineligible candidate after the bounded retry window", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-retry-capability-bound");
+		log.pruneDebouncedFn.delete(entry.hash);
+		log._checkedPrune.clearRetry(entry.hash);
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const findLeaders = sinon
+			.stub(log, "findLeadersFromEntry")
+			.resolves(leaders);
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.resolves({ leaders, localLeader: false });
+		const random = sinon.stub(Math, "random").returns(0);
+		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+
+		try {
+			const [initial] = log.prune(new Map([[entry.hash, { entry, leaders }]]));
+			await expect(initial).to.be.rejectedWith(
+				"Insufficient checked-prune capable leaders",
+			);
+			expect(log._checkedPrune.getRetry(entry.hash)?.attempts).to.equal(1);
+
+			// 1s, 2s, and 4s retry delays, with one 500ms prune debounce after
+			// each attempt. The final debounce observes the exhausted generation
+			// and retires it instead of pinning entry/leader objects indefinitely.
+			await clock.tickAsync(9_000);
+			expect(log._checkedPrune.getRetry(entry.hash)).to.be.undefined;
+			expect(log._checkedPrune.hasActiveWork(entry.hash)).to.be.false;
+
+			// A later ownership scan can create a fresh retry generation.
+			const [rediscovered] = log.prune(
+				new Map([[entry.hash, { entry, leaders }]]),
+			);
+			await expect(rediscovered).to.be.rejectedWith(
+				"Insufficient checked-prune capable leaders",
+			);
+			expect(log._checkedPrune.getRetry(entry.hash)?.attempts).to.equal(1);
+		} finally {
+			log._checkedPrune.clearRetry(entry.hash);
+			clock.restore();
+			random.restore();
+			revalidate.restore();
+			findLeaders.restore();
+			getClampedReplicas.restore();
+		}
+	});
+
+	it("retires a retry generation after repeated callback failures", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-retry-failure-bound");
+		log.pruneDebouncedFn.delete(entry.hash);
+		log._checkedPrune.clearRetry(entry.hash);
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const findLeaders = sinon
+			.stub(log, "findLeadersFromEntry")
+			.resolves(leaders);
+		const enqueue = sinon
+			.stub(log, "pruneDebouncedFnAddIfNotKeeping")
+			.rejects(new Error("forced retry callback failure"));
+		const random = sinon.stub(Math, "random").returns(0);
+		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+
+		try {
+			log.scheduleCheckedPruneRetry({ entry, leaders });
+			expect(log._checkedPrune.getRetry(entry.hash)?.attempts).to.equal(1);
+
+			await clock.tickAsync(8_000);
+			expect(enqueue.callCount).to.equal(3);
+			expect(log._checkedPrune.getRetry(entry.hash)).to.be.undefined;
+			expect(log._checkedPrune.hasActiveWork(entry.hash)).to.be.false;
+		} finally {
+			log._checkedPrune.clearRetry(entry.hash);
+			clock.restore();
+			random.restore();
+			enqueue.restore();
+			findLeaders.restore();
+		}
+	});
+
+	it("retires a capability-woken retry when the entry is now retained", async () => {
+		session = await TestSession.disconnected(2);
+		const keep = sinon.stub().returns(false);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+				keep,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-capability-wake-retained");
+		log.pruneDebouncedFn.delete(entry.hash);
+		log._checkedPrune.clearRetry(entry.hash);
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const send = sinon.stub(log.rpc, "send").resolves();
+
+		try {
+			const [initial] = log.prune(new Map([[entry.hash, { entry, leaders }]]));
+			await expect(initial).to.be.rejectedWith(
+				"Insufficient checked-prune capable leaders",
+			);
+			expect(log._checkedPrune.getRetry(entry.hash)?.timer).to.exist;
+
+			keep.returns(true);
+			log.recordPeerSyncCapabilities(
+				remoteHash,
+				SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+			);
+			await waitForResolved(
+				() => expect(log._checkedPrune.getRetry(entry.hash)).to.be.undefined,
+			);
+
+			expect(log._checkedPrune.hasActiveWork(entry.hash)).to.be.false;
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
+			expect(
+				send.getCalls().some((call) => call.args[0] instanceof RequestIPruneV2),
+			).to.be.false;
+		} finally {
+			log._checkedPrune.clearRetry(entry.hash);
+			send.restore();
+			getClampedReplicas.restore();
+		}
+	});
+
+	it("reschedules a capability-woken retry when its keep check fails", async () => {
+		session = await TestSession.disconnected(2);
+		const keep = sinon.stub().returns(false);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+				keep,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-capability-wake-error");
+		log.pruneDebouncedFn.delete(entry.hash);
+		log._checkedPrune.clearRetry(entry.hash);
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+
+		try {
+			const [initial] = log.prune(new Map([[entry.hash, { entry, leaders }]]));
+			await expect(initial).to.be.rejectedWith(
+				"Insufficient checked-prune capable leaders",
+			);
+			expect(log._checkedPrune.getRetry(entry.hash)?.timer).to.exist;
+
+			keep.rejects(new Error("forced capability-wake keep failure"));
+			log.recordPeerSyncCapabilities(
+				remoteHash,
+				SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+			);
+			await waitForResolved(() => {
+				const retry = log._checkedPrune.getRetry(entry.hash);
+				expect(retry?.attempts).to.equal(1);
+				expect(retry?.timer).to.exist;
+			});
+		} finally {
+			log._checkedPrune.clearRetry(entry.hash);
+			getClampedReplicas.restore();
+		}
+	});
+
+	it("does not retain entry objects while a debounce-only candidate is queued", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-debounce-only-candidate");
+		log.pruneDebouncedFn.delete(entry.hash);
+		log._checkedPrune.clearRetry(entry.hash);
+		const queued = pDefer<void>();
+		const add = sinon.stub(log.pruneDebouncedFn, "add").returns(queued.promise);
+		const leaders = new Map([
+			[session.peers[1].identity.publicKey.hashcode(), { intersecting: true }],
+		]);
+
+		try {
+			expect(log._checkedPrune.sessions.size).to.equal(0);
+			expect(
+				await log.pruneDebouncedFnAddIfNotKeeping({
+					key: entry.hash,
+					value: { entry, leaders },
+				}),
+			).to.be.true;
+			expect(add.calledOnce).to.be.true;
+			expect(log._checkedPrune.sessions.size).to.equal(0);
+		} finally {
+			queued.resolve();
+			add.restore();
+		}
+	});
+
+	it("retires an ungranted background generation and schedules a bounded retry", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+				respondToIHaveTimeout: 60_000,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-ungranted-background");
+		log.pruneDebouncedFn.delete(entry.hash);
+		log._checkedPrune.clearRetry(entry.hash);
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		log._peerSyncCapabilities.set(
+			remoteHash,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+		);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const random = sinon.stub(Math, "random").returns(0);
+		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+		let attempt: Promise<unknown> | undefined;
+
+		try {
+			[attempt] = log.prune(new Map([[entry.hash, { entry, leaders }]]));
+			const outcome = attempt!.catch((error: unknown) => error);
+			await clock.tickAsync(0);
+
+			expect(
+				send.getCalls().some((call) => call.args[0] instanceof RequestIPruneV2),
+			).to.be.true;
+			const requestId = log._checkedPrune.getRequestId(entry.hash, remoteHash);
+			expect(requestId).to.be.a("string");
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.exist;
+
+			// The generation deadline is exactly 120s for these settings. Stop at
+			// that boundary so the separately scheduled 1s retry cannot execute.
+			await clock.tickAsync(120_000);
+			expect(await outcome).to.be.instanceOf(Error);
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
+			expect(log._checkedPrune.getRequestId(entry.hash, remoteHash)).to.be
+				.undefined;
+			expect(log._checkedPrune.getContactedReplicators(entry.hash)).to.be
+				.undefined;
+			expect(await log.log.has(entry.hash)).to.be.true;
+
+			const retry = log._checkedPrune.getRetry(entry.hash);
+			expect(retry?.attempts).to.equal(1);
+			expect(retry?.timer).to.exist;
+		} finally {
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			await pending?.reject(new Error("test cleanup"));
+			log._checkedPrune.clearRetry(entry.hash);
+			await Promise.allSettled(
+				[attempt].filter((value): value is Promise<unknown> => value != null),
+			);
+			clock.restore();
+			random.restore();
+			getClampedReplicas.restore();
+			send.restore();
+		}
+	});
+
+	it("clears removed entries and fences their in-flight retry callbacks", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const first = await db.add("checked-prune-retry-removed-single");
+		const second = await db.add("checked-prune-retry-removed-batch");
+		for (const { entry } of [first, second]) {
+			log.pruneDebouncedFn.delete(entry.hash);
+			log._checkedPrune.clearRetry(entry.hash);
+		}
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const plannerEntered = pDefer<void>();
+		const releasePlanner = pDefer<void>();
+		const findLeaders = sinon
+			.stub(log, "findLeadersFromEntry")
+			.callsFake(async () => {
+				plannerEntered.resolve();
+				await releasePlanner.promise;
+				return leaders;
+			});
+		const enqueue = sinon
+			.stub(log, "pruneDebouncedFnAddIfNotKeeping")
+			.resolves(true);
+		const random = sinon.stub(Math, "random").returns(0);
+		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+
+		try {
+			log.scheduleCheckedPruneRetry({ entry: first.entry, leaders });
+			await clock.tickAsync(1_000);
+			await plannerEntered.promise;
+
+			log.onEntryRemoved(first.entry.hash);
+			expect(log._checkedPrune.getRetry(first.entry.hash)).to.be.undefined;
+
+			releasePlanner.resolve();
+			await clock.tickAsync(0);
+			expect(enqueue.called).to.be.false;
+
+			const batchRetry = {
+				attempts: 1,
+				entry: second.entry,
+				leaders,
+				timer: setTimeout(() => {}, 60_000),
+			};
+			log._checkedPrune.setRetry(second.entry.hash, batchRetry);
+			log.onEntryRemovedHashes([second.entry.hash]);
+			expect(log._checkedPrune.getRetry(second.entry.hash)).to.be.undefined;
+			expect(log._checkedPrune.hasActiveWork(second.entry.hash)).to.be.false;
+		} finally {
+			releasePlanner.resolve();
+			log._checkedPrune.clearRetry(first.entry.hash);
+			log._checkedPrune.clearRetry(second.entry.hash);
+			clock.restore();
+			random.restore();
+			enqueue.restore();
+			findLeaders.restore();
+		}
+	});
+});

--- a/packages/programs/data/shared-log/test/events.spec.ts
+++ b/packages/programs/data/shared-log/test/events.spec.ts
@@ -1,4 +1,5 @@
 import { type PublicSignKey, randomBytes } from "@peerbit/crypto";
+import { AcknowledgeDelivery } from "@peerbit/stream-interface";
 import { TestSession } from "@peerbit/test-utils";
 import { delay, waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
@@ -7,6 +8,7 @@ import sinon from "sinon";
 import { v4 as uuid } from "uuid";
 import {
 	ExchangeHeadsMessage,
+	SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
 	SyncCapabilitiesMessage,
 } from "../src/exchange-heads.js";
 import { ReplicationIntent } from "../src/ranges.js";
@@ -16,6 +18,23 @@ import {
 	StoppedReplicating,
 } from "../src/replication.js";
 import { EventStore } from "./utils/stores/index.js";
+
+const enableCheckedPrunePeer = (log: any, peer: string) => {
+	log._peerSyncCapabilities.set(peer, SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF);
+};
+
+const resolveCurrentCheckedPrune = async (
+	log: any,
+	hash: string,
+	peer: string,
+	pending: any,
+) => {
+	await waitForResolved(() => {
+		expect(log._checkedPrune.getRequestId(hash, peer)).to.be.a("string");
+	});
+	const requestId = log._checkedPrune.getRequestId(hash, peer);
+	await pending.resolve(peer, requestId);
+};
 
 describe("events", () => {
 	let session: TestSession;
@@ -988,6 +1007,207 @@ describe("events", () => {
 		} finally {
 			send.restore();
 			log._replicationRangeMutationFailure = undefined;
+		}
+	});
+
+	it("acknowledges checked-prune capability before announcing ownership", async () => {
+		const { db, log } = await openDisconnectedLog(2);
+		await db.log.replicate({ factor: 0.2, offset: 0.1 });
+		const remoteKey = session.peers[1].identity.publicKey;
+		const capabilityStarted = pDefer<void>();
+		const releaseCapability = pDefer<void>();
+		const sent: Array<{ message: unknown; options: any }> = [];
+		const send = sinon
+			.stub(log.rpc, "send")
+			.callsFake(async (message: unknown, options: any) => {
+				sent.push({ message, options });
+				if (message instanceof SyncCapabilitiesMessage) {
+					capabilityStarted.resolve();
+					await releaseCapability.promise;
+				}
+			});
+		const scheduleRequests = sinon
+			.stub(log, "scheduleReplicationInfoRequests")
+			.callsFake(() => {});
+		let subscription: Promise<void> | undefined;
+
+		try {
+			subscription = log._onSubscription({
+				detail: { from: remoteKey, topics: [log.topic] },
+			});
+			await capabilityStarted.promise;
+			const capability = sent.find(
+				(call) => call.message instanceof SyncCapabilitiesMessage,
+			);
+			expect(capability?.options.mode).to.be.instanceOf(AcknowledgeDelivery);
+			expect(
+				sent.some(
+					(call) => call.message instanceof AllReplicatingSegmentsMessage,
+				),
+			).to.be.false;
+
+			releaseCapability.resolve();
+			await subscription;
+			const capabilityIndex = sent.findIndex(
+				(call) => call.message instanceof SyncCapabilitiesMessage,
+			);
+			const ownershipIndex = sent.findIndex(
+				(call) => call.message instanceof AllReplicatingSegmentsMessage,
+			);
+			expect(capabilityIndex).to.be.greaterThanOrEqual(0);
+			expect(ownershipIndex).to.be.greaterThan(capabilityIndex);
+		} finally {
+			releaseCapability.resolve();
+			await subscription?.catch(() => {});
+			scheduleRequests.restore();
+			send.restore();
+		}
+	});
+
+	it("retries a failed capability ACK within the subscription epoch", async () => {
+		const { db, log } = await openDisconnectedLog(2);
+		await db.log.replicate({ factor: 0.2, offset: 0.1 });
+		const remoteKey = session.peers[1].identity.publicKey;
+		const sent: Array<{ message: unknown; options: any }> = [];
+		let capabilityAttempts = 0;
+		const send = sinon
+			.stub(log.rpc, "send")
+			.callsFake(async (message: unknown, options: any) => {
+				sent.push({ message, options });
+				if (message instanceof SyncCapabilitiesMessage) {
+					capabilityAttempts++;
+					if (capabilityAttempts === 1) {
+						throw new Error("transient capability ACK failure");
+					}
+				}
+			});
+		const scheduleRequests = sinon
+			.stub(log, "scheduleReplicationInfoRequests")
+			.callsFake(() => {});
+
+		try {
+			await log._onSubscription({
+				detail: { from: remoteKey, topics: [log.topic] },
+			});
+			await waitForResolved(() => expect(capabilityAttempts).to.equal(2));
+			const capabilityIndexes = sent.flatMap((call, index) =>
+				call.message instanceof SyncCapabilitiesMessage ? [index] : [],
+			);
+			const ownershipIndex = sent.findIndex(
+				(call) => call.message instanceof AllReplicatingSegmentsMessage,
+			);
+			expect(capabilityIndexes).to.have.length(2);
+			expect(ownershipIndex).to.be.greaterThan(capabilityIndexes[0]);
+			expect(capabilityIndexes[1]).to.be.greaterThan(ownershipIndex);
+			expect(
+				capabilityIndexes.every(
+					(index) => sent[index].options.mode instanceof AcknowledgeDelivery,
+				),
+			).to.be.true;
+		} finally {
+			scheduleRequests.restore();
+			send.restore();
+		}
+	});
+
+	it("repairs capability advertisement until the route recovers", async () => {
+		const { db, log } = await openDisconnectedLog(2);
+		await db.log.replicate({ factor: 0.2, offset: 0.1 });
+		const remoteKey = session.peers[1].identity.publicKey;
+		const remoteHash = remoteKey.hashcode();
+		let capabilityAttempts = 0;
+		let routeHealthy = false;
+		const send = sinon
+			.stub(log.rpc, "send")
+			.callsFake(async (message: unknown) => {
+				if (message instanceof SyncCapabilitiesMessage) {
+					capabilityAttempts++;
+					if (!routeHealthy) {
+						throw new Error("capability route unavailable");
+					}
+				}
+			});
+		const scheduleRequests = sinon
+			.stub(log, "scheduleReplicationInfoRequests")
+			.callsFake(() => {});
+
+		try {
+			await log._onSubscription({
+				detail: { from: remoteKey, topics: [log.topic] },
+			});
+			await waitForResolved(() => expect(capabilityAttempts).to.equal(3));
+			expect(log._syncCapabilityRepairByPeer.has(remoteHash)).to.be.true;
+
+			routeHealthy = true;
+			await waitForResolved(() => expect(capabilityAttempts).to.equal(4), {
+				timeout: 2_000,
+				delayInterval: 10,
+			});
+			expect(log._syncCapabilityRepairByPeer.has(remoteHash)).to.be.false;
+		} finally {
+			log.cancelSyncCapabilityRepair(remoteHash);
+			scheduleRequests.restore();
+			send.restore();
+		}
+	});
+
+	it("aborts stale capability repair without cancelling the next epoch", async () => {
+		const { log } = await openDisconnectedLog(2);
+		const remoteKey = session.peers[1].identity.publicKey;
+		const remoteHash = remoteKey.hashcode();
+		const firstSendEntered = pDefer<void>();
+		let capabilityAttempts = 0;
+		const send = sinon
+			.stub(log.rpc, "send")
+			.callsFake(async (...args: unknown[]) => {
+				const message = args[0];
+				const options = args[1] as { signal?: AbortSignal };
+				if (!(message instanceof SyncCapabilitiesMessage)) {
+					return;
+				}
+				capabilityAttempts++;
+				if (capabilityAttempts !== 1) {
+					return;
+				}
+				firstSendEntered.resolve();
+				await new Promise<void>((resolve, reject) => {
+					const signal = options.signal!;
+					if (signal.aborted) {
+						reject(new Error("stale capability repair aborted"));
+						return;
+					}
+					signal.addEventListener(
+						"abort",
+						() => reject(new Error("stale capability repair aborted")),
+						{ once: true },
+					);
+				});
+			});
+		const firstEpoch = log.advanceSubscriptionEpoch(remoteHash);
+		log.scheduleSyncCapabilityRepair(
+			remoteKey,
+			SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+			log._replicationLifecycleController,
+			firstEpoch,
+		);
+
+		try {
+			await firstSendEntered.promise;
+			const secondEpoch = log.advanceSubscriptionEpoch(remoteHash);
+			log.scheduleSyncCapabilityRepair(
+				remoteKey,
+				SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+				log._replicationLifecycleController,
+				secondEpoch,
+			);
+			await waitForResolved(() => expect(capabilityAttempts).to.equal(2), {
+				timeout: 2_000,
+				delayInterval: 10,
+			});
+			expect(log._syncCapabilityRepairByPeer.has(remoteHash)).to.be.false;
+		} finally {
+			log.cancelSyncCapabilityRepair(remoteHash);
+			send.restore();
 		}
 	});
 
@@ -3418,11 +3638,9 @@ describe("events", () => {
 		const { entry } = await db.add("prune-race");
 		const remoteHash = session.peers[1].identity.publicKey.hashcode();
 		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		enableCheckedPrunePeer(log, remoteHash);
 		const plannerStarted = pDefer<void>();
 		const releasePlanner = pDefer<void>();
-		const waitForReplicators = sinon
-			.stub(log, "_waitForEntryReplicators")
-			.resolves(true);
 		const getClampedReplicas = sinon
 			.stub(log, "getClampedReplicas")
 			.returns({ getValue: () => 1 });
@@ -3442,7 +3660,7 @@ describe("events", () => {
 			});
 			const pending = log._checkedPrune.getPendingDelete(entry.hash);
 			expect(pending).to.exist;
-			await pending.resolve(remoteHash);
+			await resolveCurrentCheckedPrune(log, entry.hash, remoteHash, pending);
 			await plannerStarted.promise;
 
 			log.poisonReplicationOwnership(new Error("forced ownership poison"));
@@ -3455,7 +3673,6 @@ describe("events", () => {
 			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
 		} finally {
 			releasePlanner.resolve();
-			waitForReplicators.restore();
 			getClampedReplicas.restore();
 			send.restore();
 			findLeaders.restore();
@@ -3473,11 +3690,9 @@ describe("events", () => {
 		const { entry } = await db.add("prune-reopen-race");
 		const remoteHash = session.peers[1].identity.publicKey.hashcode();
 		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		enableCheckedPrunePeer(log, remoteHash);
 		const plannerStarted = pDefer<void>();
 		const releasePlanner = pDefer<void>();
-		const waitForReplicators = sinon
-			.stub(log, "_waitForEntryReplicators")
-			.resolves(true);
 		const getClampedReplicas = sinon
 			.stub(log, "getClampedReplicas")
 			.returns({ getValue: () => 1 });
@@ -3505,7 +3720,7 @@ describe("events", () => {
 			const oldCoordinator = log._checkedPrune;
 			const pending = oldCoordinator.getPendingDelete(entry.hash);
 			expect(pending).to.exist;
-			await pending.resolve(remoteHash);
+			await resolveCurrentCheckedPrune(log, entry.hash, remoteHash, pending);
 			await plannerStarted.promise;
 
 			log.poisonReplicationOwnership(new Error("forced ownership poison"));
@@ -3534,7 +3749,6 @@ describe("events", () => {
 			);
 		} finally {
 			releasePlanner.resolve();
-			waitForReplicators.restore();
 			getClampedReplicas.restore();
 			send.restore();
 			findLeaders.restore();
@@ -3553,11 +3767,9 @@ describe("events", () => {
 		const { entry } = await db.add("prune-post-remove-race");
 		const remoteHash = session.peers[1].identity.publicKey.hashcode();
 		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		enableCheckedPrunePeer(log, remoteHash);
 		const removeStarted = pDefer<void>();
 		const releaseRemove = pDefer<void>();
-		const waitForReplicators = sinon
-			.stub(log, "_waitForEntryReplicators")
-			.resolves(true);
 		const getClampedReplicas = sinon
 			.stub(log, "getClampedReplicas")
 			.returns({ getValue: () => 1 });
@@ -3581,7 +3793,7 @@ describe("events", () => {
 			});
 			const pending = log._checkedPrune.getPendingDelete(entry.hash);
 			expect(pending).to.exist;
-			await pending.resolve(remoteHash);
+			await resolveCurrentCheckedPrune(log, entry.hash, remoteHash, pending);
 			await removeStarted.promise;
 
 			log.poisonReplicationOwnership(new Error("forced ownership poison"));
@@ -3595,7 +3807,6 @@ describe("events", () => {
 		} finally {
 			process.removeListener("unhandledRejection", onUnhandledRejection);
 			releaseRemove.resolve();
-			waitForReplicators.restore();
 			getClampedReplicas.restore();
 			send.restore();
 			findLeaders.restore();
@@ -3616,11 +3827,9 @@ describe("events", () => {
 			);
 			const remoteHash = session.peers[1].identity.publicKey.hashcode();
 			const leaders = new Map([[remoteHash, { intersecting: true }]]);
+			enableCheckedPrunePeer(log, remoteHash);
 			const removeStarted = pDefer<void>();
 			const releaseRemove = pDefer<void>();
-			const waitForReplicators = sinon
-				.stub(log, "_waitForEntryReplicators")
-				.resolves(true);
 			const getClampedReplicas = sinon
 				.stub(log, "getClampedReplicas")
 				.returns({ getValue: () => 1 });
@@ -3641,7 +3850,12 @@ describe("events", () => {
 				if (!unchecked) {
 					const pending = log._checkedPrune.getPendingDelete(entry.hash);
 					expect(pending).to.exist;
-					await pending.resolve(remoteHash);
+					await resolveCurrentCheckedPrune(
+						log,
+						entry.hash,
+						remoteHash,
+						pending,
+					);
 				}
 				await removeStarted.promise;
 				expect(log._admittedPruneRemoves.size).to.equal(1);
@@ -3668,7 +3882,6 @@ describe("events", () => {
 				expect(log._admittedPruneRemoves.size).to.equal(0);
 			} finally {
 				releaseRemove.resolve();
-				waitForReplicators.restore();
 				getClampedReplicas.restore();
 				send.restore();
 				findLeaders.restore();

--- a/packages/programs/data/shared-log/test/exchange-heads.spec.ts
+++ b/packages/programs/data/shared-log/test/exchange-heads.spec.ts
@@ -1,12 +1,14 @@
-import { AnyBlockStore } from "@peerbit/blocks";
-import { Ed25519Keypair } from "@peerbit/crypto";
-import { Log } from "@peerbit/log";
 import { deserialize, serialize } from "@dao-xyz/borsh";
+import { AnyBlockStore } from "@peerbit/blocks";
+import { Ed25519Keypair, randomBytes } from "@peerbit/crypto";
+import { Log } from "@peerbit/log";
 import { expect } from "chai";
 import sinon from "sinon";
 import {
 	EXCHANGE_HEADS_RESOLVE_BATCH_SIZE,
 	RawExchangeHeadsMessage,
+	RequestIPruneV2,
+	ResponseIPruneV2,
 	createExchangeHeadsMessages,
 	createRawExchangeHeadsMessages,
 	materializeRawExchangeHeadsMessage,
@@ -25,6 +27,28 @@ describe("exchange heads", () => {
 
 	after(async () => {
 		await store.stop();
+	});
+
+	it("round-trips fixed-size checked-prune request correlation", () => {
+		const requestId = randomBytes(32);
+		for (const message of [
+			new RequestIPruneV2({
+				requests: [{ hash: "request-hash", requestId }],
+			}),
+			new ResponseIPruneV2({
+				requests: [{ hash: "response-hash", requestId }],
+			}),
+		]) {
+			const roundTrip = deserialize(serialize(message), TransportMessage) as
+				| RequestIPruneV2
+				| ResponseIPruneV2;
+			expect(roundTrip).to.be.instanceOf(message.constructor);
+			expect(roundTrip.requests).to.have.length(1);
+			expect(roundTrip.requests[0]!.hash).to.equal(message.requests[0]!.hash);
+			expect([...roundTrip.requests[0]!.requestId]).to.deep.equal([
+				...requestId,
+			]);
+		}
 	});
 
 	it("uses native graph reference gids for single-head messages", async () => {

--- a/packages/programs/data/shared-log/test/pending-ihave-work.spec.ts
+++ b/packages/programs/data/shared-log/test/pending-ihave-work.spec.ts
@@ -1,0 +1,402 @@
+import { randomBytes } from "@peerbit/crypto";
+import { TestSession } from "@peerbit/test-utils";
+import { waitForResolved } from "@peerbit/time";
+import { expect } from "chai";
+import pDefer from "p-defer";
+import sinon from "sinon";
+import { RequestIPruneV2 } from "../src/exchange-heads.js";
+import { EventStore } from "./utils/stores/event-store.js";
+
+describe("pending IHave callback work", () => {
+	it("bounds active callbacks, coalesces duplicate notifications, and retries overflow", async () => {
+		const session = await TestSession.disconnected(1);
+		try {
+			const store = await session.peers[0].open(new EventStore<string, any>(), {
+				args: { replicate: false },
+			});
+			const entries: Array<Awaited<ReturnType<typeof store.add>>["entry"]> = [];
+			for (let index = 0; index < 5; index++) {
+				entries.push((await store.add(`pending-ihave-${index}`)).entry);
+			}
+
+			const log = store.log as any;
+			const synchronizerEntryAdded = sinon
+				.stub(log.syncronizer, "onEntryAdded")
+				.callsFake(() => {});
+			const releases = entries.map(() => pDefer<void>());
+			let callbacksStarted = 0;
+			const peer = "pending-ihave-requester";
+
+			try {
+				for (let index = 0; index < entries.length; index++) {
+					const entry = entries[index]!;
+					let pending: any;
+					pending = {
+						requesting: new Set<string>(),
+						requestIdsByPeer: new Map(),
+						resetTimeout: () => {},
+						clear: () => {},
+						callback: async () => {
+							callbacksStarted++;
+							await releases[index]!.promise;
+						},
+					};
+					expect(log.addPendingIHaveRequester(pending, peer)).to.be.true;
+					log._pendingIHave.set(entry.hash, pending);
+				}
+
+				for (const entry of entries.slice(0, 4)) {
+					log.onEntryAdded(entry);
+				}
+				await waitForResolved(() => expect(callbacksStarted).to.equal(4));
+				expect(log._pendingIHaveActiveCallbacks).to.equal(4);
+				expect(log._pendingIHaveCallbacks.size).to.equal(4);
+
+				// Re-observing an admitted hash must not start the same callback twice.
+				log.onEntryAdded(entries[0]);
+				// A fifth hash is retained instead of joining an unbounded work queue.
+				log.onEntryAdded(entries[4]);
+				await new Promise<void>((resolve) => setTimeout(resolve, 0));
+				expect(callbacksStarted).to.equal(4);
+				expect(log._pendingIHave.get(entries[4].hash).callbackActive).to.not.be
+					.true;
+
+				releases[0]!.resolve();
+				await waitForResolved(() =>
+					expect(log._pendingIHaveActiveCallbacks).to.equal(3),
+				);
+
+				// A later notification can retry the retained overflow item.
+				log.onEntryAdded(entries[4]);
+				await waitForResolved(() => expect(callbacksStarted).to.equal(5));
+				expect(log._pendingIHaveActiveCallbacks).to.equal(4);
+
+				for (const release of releases) {
+					release.resolve();
+				}
+				await waitForResolved(() =>
+					expect(log._pendingIHaveCallbacks.size).to.equal(0),
+				);
+				expect(log._pendingIHaveActiveCallbacks).to.equal(0);
+				expect(log._pendingIHave.size).to.equal(0);
+				expect(log._pendingIHaveCountByPeer.size).to.equal(0);
+				expect(log._pendingIHaveRequesterCount).to.equal(0);
+			} finally {
+				for (const release of releases) {
+					release.resolve();
+				}
+				synchronizerEntryAdded.restore();
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("releases requester accounting when retained callback work expires", async () => {
+		const session = await TestSession.disconnected(1);
+		try {
+			const store = await session.peers[0].open(new EventStore<string, any>(), {
+				args: { replicate: false },
+			});
+			const { entry } = await store.add("pending-ihave-expiry");
+			const log = store.log as any;
+			const peer = "expiring-pending-ihave-requester";
+			let pending: any;
+			pending = {
+				requesting: new Set<string>(),
+				requestIdsByPeer: new Map(),
+				resetTimeout: () => log.resetPendingIHaveTimeout(pending),
+				clear: () => log.clearPendingIHaveTimeout(pending),
+				callback: async () => {},
+				expiresAt: Date.now() - 1,
+			};
+			expect(log.addPendingIHaveRequester(pending, peer)).to.be.true;
+			log._pendingIHave.set(entry.hash, pending);
+
+			log.expirePendingIHaves();
+
+			expect(log._pendingIHave.size).to.equal(0);
+			expect(log._pendingIHaveCountByPeer.size).to.equal(0);
+			expect(log._pendingIHaveRequesterCount).to.equal(0);
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("aborts callback work at its deadline and releases all accounting", async () => {
+		const session = await TestSession.disconnected(1);
+		try {
+			const store = await session.peers[0].open(new EventStore<string, any>(), {
+				args: { replicate: false },
+			});
+			const { entry } = await store.add("pending-ihave-callback-deadline");
+			const log = store.log as any;
+			const synchronizerEntryAdded = sinon
+				.stub(log.syncronizer, "onEntryAdded")
+				.callsFake(() => {});
+			const clock = sinon.useFakeTimers({
+				now: 1_000,
+				shouldClearNativeTimers: true,
+			});
+			const callbackStarted = pDefer<void>();
+			const peer = "deadline-pending-ihave-requester";
+			let callbackSignal: AbortSignal | undefined;
+			let pending: any;
+			pending = {
+				requesting: new Set<string>(),
+				requestIdsByPeer: new Map(),
+				resetTimeout: () => {},
+				clear: () => {},
+				callback: async (_entry: unknown, work: { signal: AbortSignal }) => {
+					callbackSignal = work.signal;
+					callbackStarted.resolve();
+					if (work.signal.aborted) {
+						return;
+					}
+					await new Promise<void>((resolve) => {
+						work.signal.addEventListener("abort", () => resolve(), {
+							once: true,
+						});
+					});
+				},
+			};
+
+			try {
+				expect(log.addPendingIHaveRequester(pending, peer)).to.be.true;
+				log._pendingIHave.set(entry.hash, pending);
+
+				log.onEntryAdded(entry);
+				await callbackStarted.promise;
+
+				expect(callbackSignal?.aborted).to.be.false;
+				expect(log._pendingIHaveActiveCallbacks).to.equal(1);
+				expect(log._pendingIHaveCallbacks.size).to.equal(1);
+				expect(log._pendingIHave.size).to.equal(1);
+				expect(log._pendingIHaveCountByPeer.get(peer)).to.equal(1);
+				expect(log._pendingIHaveRequesterCount).to.equal(1);
+
+				const [callbackWork] = [
+					...log._pendingIHaveCallbacks,
+				] as Promise<void>[];
+				await clock.tickAsync(5_000);
+				await callbackWork;
+				await clock.tickAsync(0);
+
+				expect(callbackSignal?.aborted).to.be.true;
+				expect(log._pendingIHaveActiveCallbacks).to.equal(0);
+				expect(log._pendingIHaveCallbacks.size).to.equal(0);
+				expect(log._pendingIHave.size).to.equal(0);
+				expect(log._pendingIHaveCountByPeer.size).to.equal(0);
+				expect(log._pendingIHaveRequesterCount).to.equal(0);
+			} finally {
+				clock.restore();
+				synchronizerEntryAdded.restore();
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("returns a pending-IHave callback at its deadline but retains its slot until a stuck leader wait settles", async () => {
+		const session = await TestSession.disconnected(2);
+		try {
+			const store = await session.peers[0].open(new EventStore<string, any>(), {
+				args: { replicate: false },
+			});
+			const { entry } = await store.add("pending-ihave-stuck-leader-wait");
+			const log = store.log as any;
+			const requester = session.peers[1].identity.publicKey;
+			const backbonePlan = sinon
+				.stub(log, "planCurrentNativeBackboneRequestPruneLeaderHints")
+				.resolves(undefined);
+			const nativeMetadata = sinon
+				.stub(log, "getNativeLogEntryMetadataBatch")
+				.returns([null]);
+			const hasMany = sinon.stub(log.log.blocks, "hasMany").resolves([false]);
+			const nativePlan = sinon
+				.stub(log, "planCurrentNativeRequestPruneLeaderHints")
+				.resolves({
+					localLeaderHashes: new Set(),
+					replicaCounts: new Map(),
+					peerHistoryGids: [],
+					peerHistoryRemovedHashes: new Set(),
+				});
+			const releaseLeaderWait = pDefer<void>();
+			const leaderWaitEntered = pDefer<void>();
+			const waitForReplicators = sinon
+				.stub(log, "_waitForEntryReplicators")
+				.callsFake(async () => {
+					leaderWaitEntered.resolve();
+					await releaseLeaderWait.promise;
+					return false;
+				});
+			const clock = sinon.useFakeTimers({
+				now: 1_000,
+				shouldClearNativeTimers: true,
+			});
+
+			try {
+				await store.log.onMessage(
+					new RequestIPruneV2({
+						requests: [{ hash: entry.hash, requestId: randomBytes(32) }],
+					}),
+					{ from: requester } as any,
+				);
+				const pending = log._pendingIHave.get(entry.hash);
+				expect(pending).to.exist;
+
+				expect(log.runPendingIHaveCallback(pending, entry)).to.be.true;
+				await leaderWaitEntered.promise;
+				expect(log._pendingIHaveActiveCallbacks).to.equal(1);
+				expect(log._pendingIHaveCallbacks.size).to.equal(1);
+
+				await clock.tickAsync(5_000);
+				await Promise.all([...log._pendingIHaveCallbacks]);
+				await clock.tickAsync(0);
+
+				expect(log._pendingIHaveCallbacks.size).to.equal(0);
+				expect(log._pendingIHave.size).to.equal(0);
+				expect(log._pendingIHaveCountByPeer.size).to.equal(0);
+				expect(log._pendingIHaveRequesterCount).to.equal(0);
+				expect(log._pendingIHaveActiveCallbacks).to.equal(1);
+
+				releaseLeaderWait.resolve();
+				await clock.tickAsync(0);
+				expect(log._pendingIHaveActiveCallbacks).to.equal(0);
+			} finally {
+				releaseLeaderWait.resolve();
+				clock.restore();
+				waitForReplicators.restore();
+				nativePlan.restore();
+				hasMany.restore();
+				nativeMetadata.restore();
+				backbonePlan.restore();
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("retains callback capacity for detached checks and retires old slots on reopen", async () => {
+		const session = await TestSession.disconnected(1);
+		try {
+			const store = await session.peers[0].open(new EventStore<string, any>(), {
+				args: { replicate: false },
+			});
+			const entries: Array<Awaited<ReturnType<typeof store.add>>["entry"]> = [];
+			for (let index = 0; index < 5; index++) {
+				entries.push((await store.add(`pending-detached-${index}`)).entry);
+			}
+			const log = store.log as any;
+			const peer = "detached-pending-ihave-requester";
+			const detachedReleases: ReturnType<typeof pDefer<void>>[] = [];
+			let callbacksStarted = 0;
+			const installPending = (
+				entry: (typeof entries)[number],
+				callback: (entry: unknown, work: any) => Promise<void>,
+			) => {
+				const pending = {
+					requesting: new Set<string>(),
+					requestIdsByPeer: new Map(),
+					resetTimeout: () => {},
+					clear: () => {},
+					callback,
+				};
+				expect(log.addPendingIHaveRequester(pending, peer)).to.be.true;
+				log._pendingIHave.set(entry.hash, pending);
+				return pending;
+			};
+			const clock = sinon.useFakeTimers({
+				now: 1_000,
+				shouldClearNativeTimers: true,
+			});
+			let clockRestored = false;
+			let freshRelease: ReturnType<typeof pDefer<void>> | undefined;
+
+			try {
+				const oldAdmission = log._pendingIHaveCallbackWorkAdmission;
+				for (const entry of entries.slice(0, 4)) {
+					const release = pDefer<void>();
+					detachedReleases.push(release);
+					const pending = installPending(entry, async (_entry, work) => {
+						callbacksStarted++;
+						work.settlingWork.track(release.promise);
+						if (work.signal.aborted) {
+							return;
+						}
+						await new Promise<void>((resolve) => {
+							work.signal.addEventListener("abort", () => resolve(), {
+								once: true,
+							});
+						});
+					});
+					expect(log.runPendingIHaveCallback(pending, entry)).to.be.true;
+				}
+				expect(callbacksStarted).to.equal(4);
+
+				await clock.tickAsync(5_000);
+				await Promise.all([...log._pendingIHaveCallbacks]);
+				await clock.tickAsync(0);
+				expect(log._pendingIHaveCallbacks.size).to.equal(0);
+				expect(oldAdmission.active).to.equal(4);
+				expect(log._pendingIHaveActiveCallbacks).to.equal(4);
+
+				const overflow = installPending(entries[4], async () => {
+					callbacksStarted++;
+				});
+				expect(log.runPendingIHaveCallback(overflow, entries[4])).to.be.false;
+				expect(callbacksStarted).to.equal(4);
+				expect(oldAdmission.active).to.equal(4);
+
+				clock.restore();
+				clockRestored = true;
+				await store.close();
+				await session.peers[0].open(store, {
+					args: { replicate: false },
+				});
+
+				const freshAdmission = log._pendingIHaveCallbackWorkAdmission;
+				expect(freshAdmission).to.not.equal(oldAdmission);
+				expect(freshAdmission.active).to.equal(0);
+				expect(log._pendingIHaveActiveCallbacks).to.equal(0);
+
+				freshRelease = pDefer<void>();
+				const freshPending = installPending(
+					entries[4],
+					async (_entry, work) => {
+						work.settlingWork.track(freshRelease!.promise);
+					},
+				);
+				expect(log.runPendingIHaveCallback(freshPending, entries[4])).to.be
+					.true;
+				await waitForResolved(() =>
+					expect(log._pendingIHaveCallbacks.size).to.equal(0),
+				);
+				expect(freshAdmission.active).to.equal(1);
+				expect(log._pendingIHaveActiveCallbacks).to.equal(1);
+
+				for (const release of detachedReleases) {
+					release.resolve();
+				}
+				await waitForResolved(() => expect(oldAdmission.active).to.equal(0));
+				expect(freshAdmission.active).to.equal(1);
+				expect(log._pendingIHaveActiveCallbacks).to.equal(1);
+
+				freshRelease.resolve();
+				await waitForResolved(() =>
+					expect(log._pendingIHaveActiveCallbacks).to.equal(0),
+				);
+			} finally {
+				for (const release of detachedReleases) {
+					release.resolve();
+				}
+				freshRelease?.resolve();
+				if (!clockRestored) {
+					clock.restore();
+				}
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+});

--- a/packages/programs/data/shared-log/test/prune-ownership-coherence.spec.ts
+++ b/packages/programs/data/shared-log/test/prune-ownership-coherence.spec.ts
@@ -5,7 +5,25 @@ import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
 import pDefer from "p-defer";
 import sinon from "sinon";
+import { SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF } from "../src/exchange-heads.js";
 import { EventStore } from "./utils/stores/index.js";
+
+const enableCheckedPrunePeer = (log: any, peer: string) => {
+	log._peerSyncCapabilities.set(peer, SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF);
+};
+
+const resolveCurrentCheckedPrune = async (
+	log: any,
+	hash: string,
+	peer: string,
+	pending: any,
+) => {
+	await waitForResolved(() => {
+		expect(log._checkedPrune.getRequestId(hash, peer)).to.be.a("string");
+	});
+	const requestId = log._checkedPrune.getRequestId(hash, peer);
+	await pending.resolve(peer, requestId);
+};
 
 describe("checked prune ownership coherence", () => {
 	let session: TestSession | undefined;
@@ -28,12 +46,10 @@ describe("checked prune ownership coherence", () => {
 		const selfHash = session.peers[0].identity.publicKey.hashcode();
 		const remoteHash = (await Ed25519Keypair.create()).publicKey.hashcode();
 		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		enableCheckedPrunePeer(log, remoteHash);
 		const preliminaryCheckFinished = pDefer<void>();
 		const releasePreliminaryCheck = pDefer<void>();
 
-		const waitForReplicators = sinon
-			.stub(log, "_waitForEntryReplicators")
-			.resolves(true);
 		const getClampedReplicas = sinon
 			.stub(log, "getClampedReplicas")
 			.returns({ getValue: () => 1 });
@@ -65,7 +81,7 @@ describe("checked prune ownership coherence", () => {
 			});
 			const pending = log._checkedPrune.getPendingDelete(entry.hash);
 			expect(pending).to.exist;
-			await pending.resolve(remoteHash);
+			await resolveCurrentCheckedPrune(log, entry.hash, remoteHash, pending);
 			await preliminaryCheckFinished.promise;
 
 			// Commit authoritative local ownership while the prune callback is
@@ -89,7 +105,6 @@ describe("checked prune ownership coherence", () => {
 			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
 		} finally {
 			releasePreliminaryCheck.resolve();
-			waitForReplicators.restore();
 			getClampedReplicas.restore();
 			send.restore();
 			remove.restore();
@@ -110,11 +125,9 @@ describe("checked prune ownership coherence", () => {
 		const { entry } = await db.add("checked-prune-final-planner-rejection");
 		const remoteHash = (await Ed25519Keypair.create()).publicKey.hashcode();
 		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		enableCheckedPrunePeer(log, remoteHash);
 		const plannerError = new Error("forced final ownership planner rejection");
 
-		const waitForReplicators = sinon
-			.stub(log, "_waitForEntryReplicators")
-			.resolves(true);
 		const getClampedReplicas = sinon
 			.stub(log, "getClampedReplicas")
 			.returns({ getValue: () => 1 });
@@ -144,7 +157,7 @@ describe("checked prune ownership coherence", () => {
 			});
 			const pending = log._checkedPrune.getPendingDelete(entry.hash);
 			expect(pending).to.exist;
-			await pending.resolve(remoteHash);
+			await resolveCurrentCheckedPrune(log, entry.hash, remoteHash, pending);
 
 			await expect(pruning).to.be.rejectedWith(plannerError.message);
 			expect(revalidate.callCount).to.equal(2);
@@ -156,7 +169,6 @@ describe("checked prune ownership coherence", () => {
 			expect(await log.log.blocks.has(entry.hash)).to.be.true;
 			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
 		} finally {
-			waitForReplicators.restore();
 			getClampedReplicas.restore();
 			send.restore();
 			cancelLocalLeader.restore();
@@ -179,10 +191,8 @@ describe("checked prune ownership coherence", () => {
 		const { entry } = await db.add("checked-prune-final-empty-ownership");
 		const remoteHash = (await Ed25519Keypair.create()).publicKey.hashcode();
 		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		enableCheckedPrunePeer(log, remoteHash);
 
-		const waitForReplicators = sinon
-			.stub(log, "_waitForEntryReplicators")
-			.resolves(true);
 		const getClampedReplicas = sinon
 			.stub(log, "getClampedReplicas")
 			.returns({ getValue: () => 1 });
@@ -211,7 +221,7 @@ describe("checked prune ownership coherence", () => {
 			const [pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]));
 			const pending = log._checkedPrune.getPendingDelete(entry.hash);
 			expect(pending).to.exist;
-			await pending.resolve(remoteHash);
+			await resolveCurrentCheckedPrune(log, entry.hash, remoteHash, pending);
 
 			await expect(pruning).to.be.rejectedWith(
 				"Could not establish current leaders at the checked-prune delete boundary",
@@ -230,7 +240,6 @@ describe("checked prune ownership coherence", () => {
 			expect(await log.log.blocks.has(entry.hash)).to.be.true;
 		} finally {
 			log._checkedPrune.clearRetry(entry.hash);
-			waitForReplicators.restore();
 			getClampedReplicas.restore();
 			send.restore();
 			cancelLocalLeader.restore();
@@ -254,12 +263,10 @@ describe("checked prune ownership coherence", () => {
 		const { entry } = await db.add("checked-prune-cancelled-at-lane");
 		const remoteHash = (await Ed25519Keypair.create()).publicKey.hashcode();
 		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		enableCheckedPrunePeer(log, remoteHash);
 		const laneEntered = pDefer<void>();
 		const releaseLane = pDefer<void>();
 
-		const waitForReplicators = sinon
-			.stub(log, "_waitForEntryReplicators")
-			.resolves(true);
 		const getClampedReplicas = sinon
 			.stub(log, "getClampedReplicas")
 			.returns({ getValue: () => 1 });
@@ -284,7 +291,7 @@ describe("checked prune ownership coherence", () => {
 			);
 			const pending = log._checkedPrune.getPendingDelete(entry.hash);
 			expect(pending).to.exist;
-			await pending.resolve(remoteHash);
+			await resolveCurrentCheckedPrune(log, entry.hash, remoteHash, pending);
 			await waitForResolved(
 				() => {
 					expect(revalidate.calledOnce).to.be.true;
@@ -309,7 +316,78 @@ describe("checked prune ownership coherence", () => {
 		} finally {
 			releaseLane.resolve();
 			await laneBlocker.catch(() => {});
-			waitForReplicators.restore();
+			getClampedReplicas.restore();
+			send.restore();
+			revalidate.restore();
+			remove.restore();
+		}
+	});
+
+	it("revokes a confirmation before the final delete boundary", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-revoked-confirmation");
+		const remoteHash = (await Ed25519Keypair.create()).publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		enableCheckedPrunePeer(log, remoteHash);
+		const laneEntered = pDefer<void>();
+		const releaseLane = pDefer<void>();
+
+		const getClampedReplicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.resolves({ leaders, localLeader: false });
+		const remove = sinon.spy(log.log, "remove");
+		const laneBlocker = log.withReplicationRangeMutationQueue(async () => {
+			laneEntered.resolve();
+			await releaseLane.promise;
+		});
+
+		try {
+			await laneEntered.promise;
+			const [pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			expect(pending).to.exist;
+			await resolveCurrentCheckedPrune(log, entry.hash, remoteHash, pending);
+			await waitForResolved(() => {
+				expect(revalidate.calledOnce).to.be.true;
+				expect(
+					log._checkedPrune
+						.getConfirmedReplicators(entry.hash)
+						?.has(remoteHash),
+				).to.be.true;
+			});
+
+			log._checkedPrune.removeRequestSent(entry.hash, remoteHash);
+			expect(
+				log._checkedPrune
+					.getConfirmedReplicators(entry.hash)
+					?.has(remoteHash) ?? false,
+			).to.be.false;
+			releaseLane.resolve();
+			await laneBlocker;
+
+			await expect(pruning).to.be.rejectedWith(
+				"Checked prune confirmation is no longer active at the delete boundary",
+			);
+			expect(remove.called).to.be.false;
+			expect(await log.log.has(entry.hash)).to.be.true;
+			expect(await log.log.blocks.has(entry.hash)).to.be.true;
+		} finally {
+			releaseLane.resolve();
+			await laneBlocker.catch(() => {});
 			getClampedReplicas.restore();
 			send.restore();
 			revalidate.restore();
@@ -357,6 +435,7 @@ describe("checked prune ownership coherence", () => {
 		const remoteKey = (await Ed25519Keypair.create()).publicKey;
 		const remoteHash = remoteKey.hashcode();
 		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		enableCheckedPrunePeer(log, remoteHash);
 		const remoteRange = new log.indexableDomain.constructorRange({
 			id: randomBytes(32),
 			offset: log.indexableDomain.numbers.denormalize(0.25),
@@ -365,9 +444,6 @@ describe("checked prune ownership coherence", () => {
 			timestamp: 1n,
 		});
 
-		const waitForReplicators = sinon
-			.stub(log, "_waitForEntryReplicators")
-			.resolves(true);
 		const getClampedReplicas = sinon
 			.stub(log, "getClampedReplicas")
 			.returns({ getValue: () => 1 });
@@ -382,7 +458,7 @@ describe("checked prune ownership coherence", () => {
 			});
 			const pending = log._checkedPrune.getPendingDelete(entry.hash);
 			expect(pending).to.exist;
-			await pending.resolve(remoteHash);
+			await resolveCurrentCheckedPrune(log, entry.hash, remoteHash, pending);
 			await Promise.all([
 				reentrantAttempted.promise,
 				removalCallbackHoldingLane.promise,
@@ -427,7 +503,6 @@ describe("checked prune ownership coherence", () => {
 			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
 		} finally {
 			releaseRemovalCallback.resolve();
-			waitForReplicators.restore();
 			getClampedReplicas.restore();
 			send.restore();
 			revalidate.restore();
@@ -468,10 +543,8 @@ describe("checked prune ownership coherence", () => {
 			);
 			const remoteHash = (await Ed25519Keypair.create()).publicKey.hashcode();
 			const leaders = new Map([[remoteHash, { intersecting: true }]]);
+			enableCheckedPrunePeer(log, remoteHash);
 
-			const waitForReplicators = sinon
-				.stub(log, "_waitForEntryReplicators")
-				.resolves(true);
 			const getClampedReplicas = sinon
 				.stub(log, "getClampedReplicas")
 				.returns({ getValue: () => 1 });
@@ -489,7 +562,7 @@ describe("checked prune ownership coherence", () => {
 				);
 				const pending = log._checkedPrune.getPendingDelete(entry.hash);
 				expect(pending).to.exist;
-				await pending.resolve(remoteHash);
+				await resolveCurrentCheckedPrune(log, entry.hash, remoteHash, pending);
 				await terminalAttempted.promise;
 
 				expect(terminalError).to.be.instanceOf(
@@ -520,7 +593,6 @@ describe("checked prune ownership coherence", () => {
 				}
 			} finally {
 				releaseRemovalCallback.resolve();
-				waitForReplicators.restore();
 				getClampedReplicas.restore();
 				send.restore();
 				revalidate.restore();

--- a/packages/programs/data/shared-log/test/receive-admission.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission.spec.ts
@@ -1,4 +1,6 @@
+import { randomBytes, toHexString } from "@peerbit/crypto";
 import { Entry } from "@peerbit/log";
+import { AcknowledgeDelivery } from "@peerbit/stream-interface";
 import { TestSession } from "@peerbit/test-utils";
 import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
@@ -8,8 +10,11 @@ import { v4 as uuid } from "uuid";
 import {
 	EntryWithRefs,
 	ExchangeHeadsMessage,
-	RequestIPrune,
+	RequestIPruneV2,
 	ResponseIPrune,
+	ResponseIPruneV2,
+	SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+	SYNC_CAPABILITY_RAW_EXCHANGE_HEADS,
 	SyncCapabilitiesMessage,
 } from "../src/exchange-heads.js";
 import { createReplicationDomainHash } from "../src/replication-domain-hash.js";
@@ -135,12 +140,28 @@ describe("receive admission", () => {
 				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
 					.true;
 
-				await target.log.onMessage(new SyncCapabilitiesMessage(), {
-					from: sourceKey,
-				} as any);
+				const advertisedCapabilities =
+					SYNC_CAPABILITY_RAW_EXCHANGE_HEADS |
+					SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF;
+				await target.log.onMessage(
+					new SyncCapabilitiesMessage({
+						capabilities: advertisedCapabilities,
+					}),
+					{
+						from: sourceKey,
+					} as any,
+				);
+				await target.log.onMessage(
+					new SyncCapabilitiesMessage({ capabilities: 0 }),
+					{
+						from: sourceKey,
+					} as any,
+				);
 				await subscription;
 
-				expect(sharedLog._peerSyncCapabilities.get(sourceHash)).to.equal(1);
+				expect(sharedLog._peerSyncCapabilities.get(sourceHash)).to.equal(
+					advertisedCapabilities,
+				);
 				expect(sharedLog._subscriptionOpeningEpochByPeer.has(sourceHash)).to.be
 					.false;
 				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
@@ -371,13 +392,13 @@ describe("receive admission", () => {
 		}
 	});
 
-	it("drains asynchronous prune-response side effects before cleanup", async () => {
+	it("drains asynchronous correlated prune-response side effects before cleanup", async () => {
 		const session = await TestSession.disconnected(2);
-		const pendingResolveEntered = pDefer<void>();
-		const lateResolveEntered = pDefer<void>();
-		const pendingResolveFinished = pDefer<void>();
-		const releasePendingResponse = pDefer<void>();
-		const releaseLateResponse = pDefer<void>();
+		const firstResolveEntered = pDefer<void>();
+		const secondResolveEntered = pDefer<void>();
+		const firstResolveFinished = pDefer<void>();
+		const releaseFirstResponse = pDefer<void>();
+		const releaseSecondResponse = pDefer<void>();
 		try {
 			const store = new EventStore<string, any>();
 			const source = await session.peers[0].open(store.clone(), {
@@ -389,60 +410,102 @@ describe("receive admission", () => {
 			const sharedLog = target.log as any;
 			const sourceKey = source.node.identity.publicKey;
 			const sourceHash = sourceKey.hashcode();
-			const pendingHash = "pending-prune-response";
-			const { entry: retryEntry } = await source.add(uuid(), {
+			const { entry: firstEntry } = await source.add(uuid(), {
 				meta: { next: [] },
 			});
-			const lateHash = retryEntry.hash;
+			const { entry: secondEntry } = await source.add(uuid(), {
+				meta: { next: [] },
+			});
+			const leaders = new Map([[sourceHash, { intersecting: true }]]);
+			let resolveCalls = 0;
 			const installPending = (
-				hash: string,
+				entry: Entry<any>,
+				requestIdBytes: Uint8Array,
 				entered: DeferredPromise<void>,
 				release: DeferredPromise<void>,
 				finished?: DeferredPromise<void>,
 			) => {
 				const pendingPromise = pDefer<void>();
-				sharedLog._checkedPrune.pendingDeletes.set(hash, {
+				const requestId = toHexString(requestIdBytes);
+				let pending: any;
+				pending = {
 					promise: pendingPromise,
 					clear: () => {},
 					reject: () => {},
-					resolve: async (peerHash: string) => {
+					resolve: async (peerHash: string, responseRequestId: string) => {
+						resolveCalls++;
+						expect(peerHash).to.equal(sourceHash);
+						expect(responseRequestId).to.equal(requestId);
 						entered.resolve();
 						await release.promise;
-						sharedLog._checkedPrune.addConfirmedReplicator(hash, peerHash);
+						sharedLog._checkedPrune.addConfirmedReplicator(
+							entry.hash,
+							peerHash,
+							pending,
+							responseRequestId,
+						);
 						finished?.resolve();
 					},
-				});
+				};
+				sharedLog._checkedPrune.setPendingDelete(
+					entry.hash,
+					pending,
+					entry,
+					leaders,
+				);
+				expect(
+					sharedLog._checkedPrune.addRequestSent(
+						entry.hash,
+						sourceHash,
+						requestId,
+					),
+				).to.be.true;
 			};
+			const firstRequestId = randomBytes(32);
+			const secondRequestId = randomBytes(32);
 			installPending(
-				pendingHash,
-				pendingResolveEntered,
-				releasePendingResponse,
-				pendingResolveFinished,
+				firstEntry,
+				firstRequestId,
+				firstResolveEntered,
+				releaseFirstResponse,
+				firstResolveFinished,
 			);
-			const leaders = new Map([[sourceHash, { intersecting: true }]]);
-			sharedLog._checkedPrune.setRetry(lateHash, {
-				attempts: 1,
-				entry: retryEntry,
-				leaders,
-			});
-			const findLeaders = sinon
-				.stub(sharedLog, "findLeadersFromEntry")
-				.resolves(leaders);
-			const prune = sinon.stub(sharedLog, "prune").callsFake((...args: unknown[]) => {
-				const entries = args[0] as Map<string, unknown>;
-				expect(entries.has(lateHash)).to.be.true;
-				installPending(lateHash, lateResolveEntered, releaseLateResponse);
-				return [Promise.resolve()];
-			});
+			installPending(
+				secondEntry,
+				secondRequestId,
+				secondResolveEntered,
+				releaseSecondResponse,
+			);
 
 			try {
+				await target.log.onMessage(
+					new SyncCapabilitiesMessage({
+						capabilities: SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+					}),
+					{ from: sourceKey } as any,
+				);
+				// Legacy hash-only responses are deliberately fail-closed and must
+				// not enter either exact-generation resolver.
+				await target.log.onMessage(
+					new ResponseIPrune({
+						hashes: [firstEntry.hash, secondEntry.hash],
+					}),
+					{ from: sourceKey } as any,
+				);
+				expect(resolveCalls).to.equal(0);
+
 				const receive = target.log.onMessage(
-					new ResponseIPrune({ hashes: [pendingHash, lateHash] }),
+					new ResponseIPruneV2({
+						requests: [
+							{ hash: firstEntry.hash, requestId: firstRequestId },
+							{ hash: secondEntry.hash, requestId: secondRequestId },
+						],
+					}),
 					{ from: sourceKey } as any,
 				);
 				await Promise.all([
-					pendingResolveEntered.promise,
-					lateResolveEntered.promise,
+					firstResolveEntered.promise,
+					secondResolveEntered.promise,
 				]);
 
 				let unsubscribeSettled = false;
@@ -459,15 +522,20 @@ describe("receive admission", () => {
 				);
 				expect(unsubscribeSettled).to.be.false;
 
-				releasePendingResponse.resolve();
-				await pendingResolveFinished.promise;
+				releaseFirstResponse.resolve();
+				await firstResolveFinished.promise;
+				expect(
+					sharedLog._checkedPrune
+						.getConfirmedReplicators(firstEntry.hash)
+						?.has(sourceHash),
+				).to.be.true;
 				await new Promise<void>((resolve) => setTimeout(resolve, 0));
 				expect(sharedLog._activeReceiveHandlersByPeer.has(sourceHash)).to.be.true;
 				expect(unsubscribeSettled).to.be.false;
 
-				releaseLateResponse.resolve();
+				releaseSecondResponse.resolve();
 				await Promise.all([receive, unsubscribe]);
-				for (const hash of [pendingHash, lateHash]) {
+				for (const hash of [firstEntry.hash, secondEntry.hash]) {
 					expect(
 						sharedLog._checkedPrune
 							.getConfirmedReplicators(hash)
@@ -478,14 +546,12 @@ describe("receive admission", () => {
 					.false;
 				expect(sharedLog._receiveCleanupGateByPeer.has(sourceHash)).to.be.false;
 			} finally {
-				releasePendingResponse.resolve();
-				releaseLateResponse.resolve();
-				prune.restore();
-				findLeaders.restore();
+				releaseFirstResponse.resolve();
+				releaseSecondResponse.resolve();
 			}
 		} finally {
-			releasePendingResponse.resolve();
-			releaseLateResponse.resolve();
+			releaseFirstResponse.resolve();
+			releaseSecondResponse.resolve();
 			await session.stop();
 		}
 	});
@@ -505,7 +571,11 @@ describe("receive admission", () => {
 			});
 			const sharedLog = target.log as any;
 			const sourceKey = source.node.identity.publicKey;
-			const hash = "close-cancels-prune-response-leader-wait";
+			const sourceHash = sourceKey.hashcode();
+			const { entry } = await source.add(uuid(), { meta: { next: [] } });
+			const hash = entry.hash;
+			const requestIdBytes = randomBytes(32);
+			const requestId = toHexString(requestIdBytes);
 			const pendingPromise = pDefer<void>();
 			let waitCount = 0;
 			let secondWaitHasEntered = false;
@@ -529,20 +599,40 @@ describe("receive admission", () => {
 				);
 			};
 
-			sharedLog._checkedPrune.pendingDeletes.set(hash, {
+			let pending: any;
+			pending = {
 				promise: pendingPromise,
 				clear: () => {},
 				reject: () => {},
-				resolve: async () => {
+				resolve: async (peerHash: string, responseRequestId: string) => {
+					expect(peerHash).to.equal(sourceHash);
+					expect(responseRequestId).to.equal(requestId);
 					expect(await waitForMissingLeader()).to.be.false;
 					// This wait begins after the close signal has already fired. It must
 					// observe the latched abort instead of waiting for its full timeout.
 					expect(await waitForMissingLeader()).to.be.false;
 				},
-			});
+			};
+			sharedLog._checkedPrune.setPendingDelete(
+				hash,
+				pending,
+				entry,
+				new Map([[sourceHash, { intersecting: true }]]),
+			);
+			expect(
+				sharedLog._checkedPrune.addRequestSent(hash, sourceHash, requestId),
+			).to.be.true;
+			await target.log.onMessage(
+				new SyncCapabilitiesMessage({
+					capabilities: SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+				}),
+				{ from: sourceKey } as any,
+			);
 
 			const receive = target.log.onMessage(
-				new ResponseIPrune({ hashes: [hash] }),
+				new ResponseIPruneV2({
+					requests: [{ hash, requestId: requestIdBytes }],
+				}),
 				{ from: sourceKey } as any,
 			);
 			await firstWaitEntered.promise;
@@ -656,20 +746,41 @@ describe("receive admission", () => {
 			const firstHash = firstKey.hashcode();
 			const secondKey = session.peers[2].identity.publicKey;
 			const secondHash = secondKey.hashcode();
+			const firstRequestId = randomBytes(32);
+			const secondRequestId = randomBytes(32);
 
+			for (const from of [firstKey, secondKey]) {
+				await target.log.onMessage(
+					new SyncCapabilitiesMessage({
+						capabilities: SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+					}),
+					{ from } as any,
+				);
+			}
 			await target.log.onMessage(
-				new RequestIPrune({ hashes: [entry.hash] }),
+				new RequestIPruneV2({
+					requests: [{ hash: entry.hash, requestId: firstRequestId }],
+				}),
 				{ from: firstKey } as any,
 			);
 			await target.log.onMessage(
-				new RequestIPrune({ hashes: [entry.hash] }),
+				new RequestIPruneV2({
+					requests: [{ hash: entry.hash, requestId: secondRequestId }],
+				}),
 				{ from: secondKey } as any,
 			);
 			const pending = sharedLog._pendingIHave.get(entry.hash);
 			expect([...pending.requesting]).to.have.members([firstHash, secondHash]);
+			expect([...pending.requestIdsByPeer.get(firstHash)]).to.deep.equal([
+				...firstRequestId,
+			]);
+			expect([...pending.requestIdsByPeer.get(secondHash)]).to.deep.equal([
+				...secondRequestId,
+			]);
 
 			sharedLog.cleanupPeerDisconnectTracking(firstHash);
 			expect([...pending.requesting]).to.deep.equal([secondHash]);
+			expect(pending.requestIdsByPeer.has(firstHash)).to.be.false;
 			expect(sharedLog._pendingIHave.get(entry.hash)).to.equal(pending);
 
 			const selfHash = target.node.identity.publicKey.hashcode();
@@ -679,23 +790,44 @@ describe("receive admission", () => {
 					args[3]?.onLeader?.(selfHash);
 					return new Map([[selfHash, { intersecting: true }]]);
 				});
-			const responseAdd = sinon.spy(sharedLog.responseToPruneDebouncedFn, "add");
+			const hasMany = sinon
+				.stub(sharedLog.log.blocks, "hasMany")
+				.resolves([true]);
+			const finalLeaderPlan = sinon
+				.stub(sharedLog, "revalidateCheckedPruneGrantLocalLeaders")
+				.resolves(new Set([entry.hash]));
+			const responses: Array<{ message: ResponseIPruneV2; options: any }> = [];
+			const responseSend = sinon
+				.stub(sharedLog.rpc, "send")
+				.callsFake(async (message: unknown, options: any) => {
+					if (message instanceof ResponseIPruneV2) {
+						responses.push({ message, options });
+					}
+				});
 			const synchronizerEntryAdded = sinon
 				.stub(sharedLog.syncronizer, "onEntryAdded")
 				.callsFake(() => {});
 
 			try {
 				sharedLog.onEntryAdded(entry);
-				await waitForResolved(() => expect(responseAdd.calledOnce).to.be.true);
-				const response = responseAdd.firstCall.args[0];
-				expect([...response.peers]).to.deep.equal([secondHash]);
-				await waitForResolved(() =>
-					expect(sharedLog._pendingIHave.has(entry.hash)).to.be.false,
+				await waitForResolved(() => expect(responses).to.have.length(1));
+				const response = responses[0]!;
+				expect(response.options.mode).to.be.instanceOf(AcknowledgeDelivery);
+				expect(response.options.mode.to).to.deep.equal([secondHash]);
+				expect(response.message.requests).to.have.length(1);
+				expect(response.message.requests[0]!.hash).to.equal(entry.hash);
+				expect([...response.message.requests[0]!.requestId]).to.deep.equal([
+					...secondRequestId,
+				]);
+				await waitForResolved(
+					() => expect(sharedLog._pendingIHave.has(entry.hash)).to.be.false,
 				);
 				expect(sharedLog._pendingIHaveCallbacks.size).to.equal(0);
 			} finally {
 				synchronizerEntryAdded.restore();
-				responseAdd.restore();
+				responseSend.restore();
+				finalLeaderPlan.restore();
+				hasMany.restore();
 				waitForEntryReplicators.restore();
 			}
 		} finally {

--- a/packages/programs/data/shared-log/test/replication.spec.ts
+++ b/packages/programs/data/shared-log/test/replication.spec.ts
@@ -15,8 +15,9 @@ import sinon from "sinon";
 import { BlocksMessage } from "../src/blocks.js";
 import {
 	ExchangeHeadsMessage,
-	RequestIPrune,
-	ResponseIPrune,
+	RequestIPruneV2,
+	ResponseIPruneV2,
+	SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
 } from "../src/exchange-heads.js";
 import {
 	type ReplicationOptions,
@@ -530,8 +531,11 @@ testSetups.forEach((setup) => {
 						return onMessageFn2(msg, cxt);
 					};
 
-					await waitForResolved(() => {
-						expect(db1.log.log.length).equal(0);
+					await waitForResolved(async () => {
+						// The child handoff is non-recursive. Its higher-replica parent
+						// remains local instead of being cascaded through the child delete.
+						expect(db1.log.log.length).equal(1);
+						expect(await db1.log.log.has(e1.entry.hash)).to.be.true;
 						expect(db2.log.log.length).greaterThanOrEqual(1);
 					});
 
@@ -3594,7 +3598,7 @@ testSetups.forEach((setup) => {
 							{ timeout: 3000 },
 						),
 					),
-				).rejectedWith("Timeout for checked pruning");
+				).rejectedWith("Insufficient checked-prune capable leaders (1/10)");
 				expect(db1.log.log.length).equal(1); // No deletions
 			});
 
@@ -3602,7 +3606,7 @@ testSetups.forEach((setup) => {
 				db1 = await session.peers[0].open(new EventStore<string, any>(), {
 					args: {
 						replicas: {
-							min: 10,
+							min: 1,
 						},
 						replicate: {
 							factor: 1,
@@ -3616,7 +3620,7 @@ testSetups.forEach((setup) => {
 					{
 						args: {
 							replicas: {
-								min: 10,
+								min: 1,
 							},
 							replicate: {
 								factor: 1,
@@ -3629,6 +3633,13 @@ testSetups.forEach((setup) => {
 				const e1 = await db1.add("hello");
 				await waitForResolved(() => expect(db1.log.log.length).equal(1));
 				await waitForResolved(() => expect(db2.log.log.length).equal(1));
+				await waitForResolved(() =>
+					expect(
+						((db1.log as any)._peerSyncCapabilities.get(
+							db2.node.identity.publicKey.hashcode(),
+						) ?? 0) & SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+					).to.equal(SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF),
+				);
 				await expect(
 					Promise.all(
 						db1.log.prune(
@@ -3728,7 +3739,15 @@ testSetups.forEach((setup) => {
 				// peer 1 observer
 				// peer 2 observer
 				expect(db2.log.log.length).equal(1);
-				await delay(2000);
+				await waitForResolved(
+					() =>
+						expect(
+							((db2.log as any)._peerSyncCapabilities.get(
+								db1.node.identity.publicKey.hashcode(),
+							) ?? 0) & SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+						).to.equal(SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF),
+					{ timeout: 30_000 },
+				);
 				// expect(db2ReorgCounter).equal(1); TODO limit distributions and test this
 
 				await db2.log.replicate(false);
@@ -3743,7 +3762,9 @@ testSetups.forEach((setup) => {
 				});
 
 				await waitForResolved(() => expect(db1.log.log.length).equal(1));
-				await waitForResolved(() => expect(db2.log.log.length).equal(0));
+				await waitForResolved(() => expect(db2.log.log.length).equal(0), {
+					timeout: 30_000,
+				});
 				// expect(db2ReorgCounter).equal(3); TODO
 			});
 			it("can override min on program level", async () => {
@@ -3819,6 +3840,10 @@ testSetups.forEach((setup) => {
 					return onMessageFn(msg, cxt);
 				};
 				const { entry } = await db1.add("hello");
+				(db1.log as any)._peerSyncCapabilities.set(
+					db2.node.identity.publicKey.hashcode(),
+					SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+				);
 				const expectPromise = expect(
 					Promise.all(
 						db1.log.prune(
@@ -3892,6 +3917,10 @@ testSetups.forEach((setup) => {
 				};
 
 				const { entry } = await db1.add("hello", { meta: { next: [] } });
+				(db1.log as any)._peerSyncCapabilities.set(
+					db2.node.identity.publicKey.hashcode(),
+					SYNC_CAPABILITY_CHECKED_PRUNE_HANDOFF,
+				);
 				await (db2.log.log.entryIndex as any).properties.index.put(
 					entry.toShallow(true),
 				);
@@ -4372,10 +4401,10 @@ testSetups.forEach((setup) => {
 							received.some(
 								(m) =>
 									m instanceof AddedReplicationSegmentMessage ||
-									m instanceof AllReplicatingSegmentsMessage,
+								m instanceof AllReplicatingSegmentsMessage,
 							),
 						).to.equal(true);
-						expect(received.some((m) => m instanceof RequestIPrune)).to.equal(true);
+						expect(received.some((m) => m instanceof RequestIPruneV2)).to.equal(true);
 					/* const entryRefs1 = await db1.log.entryCoordinatesIndex.iterate().all();
 					const entryRefs2 = await db2.log.entryCoordinatesIndex.iterate().all();
 		
@@ -5220,10 +5249,30 @@ testSetups.forEach((setup) => {
 					const slowController = new AbortController();
 
 					// Keep replication updates slow, but allow many prune messages to get "in flight".
-					slowDownMessage(db1.log, RequestIPrune, 1500, slowController.signal);
-					slowDownMessage(db2.log, RequestIPrune, 1500, slowController.signal);
-					slowDownMessage(db2.log, ResponseIPrune, 1500, slowController.signal);
-					slowDownMessage(db3.log, ResponseIPrune, 1500, slowController.signal);
+					slowDownMessage(
+						db1.log,
+						RequestIPruneV2,
+						1500,
+						slowController.signal,
+					);
+					slowDownMessage(
+						db2.log,
+						RequestIPruneV2,
+						1500,
+						slowController.signal,
+					);
+					slowDownMessage(
+						db2.log,
+						ResponseIPruneV2,
+						1500,
+						slowController.signal,
+					);
+					slowDownMessage(
+						db3.log,
+						ResponseIPruneV2,
+						1500,
+						slowController.signal,
+					);
 
 					const range1 = (
 						await db1.log.getMyReplicationSegments()

--- a/packages/programs/data/shared-log/test/sharding.spec.ts
+++ b/packages/programs/data/shared-log/test/sharding.spec.ts
@@ -1,15 +1,16 @@
 import { keys } from "@libp2p/crypto";
-import { randomBytes, toBase64 } from "@peerbit/crypto";
+import { randomBytes, toBase64, toHexString } from "@peerbit/crypto";
 import type { Entry } from "@peerbit/log";
 // Include test utilities
 import { TestSession } from "@peerbit/test-utils";
 import { delay, waitFor, waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
+import pDefer from "p-defer";
 import sinon from "sinon";
 import {
 	ExchangeHeadsMessage,
-	RequestIPrune,
-	ResponseIPrune,
+	RequestIPruneV2,
+	ResponseIPruneV2,
 } from "../src/exchange-heads.js";
 import {
 	type ReplicationDomainHash,
@@ -1600,15 +1601,18 @@ testSetups.forEach((setup) => {
 					const cleanupPubSubChaos: (() => Promise<void>)[] = [];
 					const chaosRules = [
 						{
-							type: RequestIPrune,
+							type: RequestIPruneV2,
 							minDelayMs: 20_000,
 							maxDelayMs: 45_000,
 							probability: 1,
 						},
 						{
-							type: ResponseIPrune,
-							minDelayMs: 20_000,
-							maxDelayMs: 45_000,
+							type: ResponseIPruneV2,
+							// Grant delivery is part of the responder's bounded five-second
+							// admission window. Keep this leg delayed but inside that budget;
+							// the request leg below still exercises 20-45s network latency.
+							minDelayMs: 500,
+							maxDelayMs: 1_500,
 							probability: 1,
 						},
 						{
@@ -1773,9 +1777,10 @@ testSetups.forEach((setup) => {
 								"expected delayed checked-prune traffic to leave at least one peer temporarily over the upper bound",
 							).to.equal(true);
 
-							// Phase 1 — prune liveness while every checked-prune handshake
-							// leg is still delayed by 20-45s: each peer must shed its join
-							// backlog below the upper bound at least once. Instantaneous
+							// Phase 1 — prune liveness while checked-prune requests are
+							// delayed by 20-45s and grants are delayed within the responder's
+							// five-second budget: each peer must shed its join backlog below
+							// the upper bound at least once. Instantaneous
 							// lengths legitimately oscillate above the bound for as long as
 							// the chaos is active: authoritative repair re-seeds already
 							// pruned entries in bulk (its roleAge-0 leader view runs ahead of
@@ -2419,11 +2424,30 @@ testSetups.forEach((setup) => {
 				});
 				const leavingHash = db3.node.identity.publicKey.hashcode();
 				const logInternals = db1.log as any;
-
-				logInternals._checkedPrune.addRequestSent(entry.hash, leavingHash);
+				const pendingDeferred = pDefer<void>();
+				const pendingDelete = {
+					promise: pendingDeferred,
+					clear: () => {},
+					resolve: () => {},
+					reject: () => {},
+				};
+				logInternals._checkedPrune.setPendingDelete(
+					entry.hash,
+					pendingDelete,
+					entry,
+					new Set([leavingHash]),
+				);
+				const requestId = toHexString(randomBytes(32));
+				logInternals._checkedPrune.addRequestSent(
+					entry.hash,
+					leavingHash,
+					requestId,
+				);
 				logInternals._checkedPrune.addConfirmedReplicator(
 					entry.hash,
 					leavingHash,
+					pendingDelete,
+					requestId,
 				);
 				expect(
 					logInternals._checkedPrune

--- a/packages/programs/data/shared-log/test/sync-raw-exchange-heads.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-raw-exchange-heads.spec.ts
@@ -1,6 +1,10 @@
 import { serialize } from "@dao-xyz/borsh";
 import { keys } from "@libp2p/crypto";
-import { DecryptedThing, getKeypairFromPrivateKey } from "@peerbit/crypto";
+import {
+	DecryptedThing,
+	getKeypairFromPrivateKey,
+	randomBytes,
+} from "@peerbit/crypto";
 import { create as createRustIndexer } from "@peerbit/indexer-rust";
 import { Entry } from "@peerbit/log";
 import {
@@ -21,7 +25,8 @@ import {
 	ExchangeHeadsMessage,
 	RawEntryWithRefs,
 	RawExchangeHeadsMessage,
-	RequestIPrune,
+	RequestIPruneV2,
+	ResponseIPruneV2,
 	collectRawExchangeHeadSendPlan,
 	createRawExchangeHeadsMessages,
 } from "../src/exchange-heads.js";
@@ -3004,9 +3009,7 @@ describe("raw exchange-head sync", () => {
 				db.log as any,
 				"removePeerFromGidPeerHistoryBatch",
 			);
-			const responseAddStub = sinon
-				.stub((db.log as any).responseToPruneDebouncedFn, "add")
-				.resolves();
+			const sendStub = sinon.stub((db.log as any).rpc, "send").resolves();
 			const hasManyStub = sinon
 				.stub(db.log.log.blocks as any, "hasMany")
 				.resolves(hashes.map(() => true));
@@ -3059,7 +3062,11 @@ describe("raw exchange-head sync", () => {
 					return new Map([[selfHash, { intersecting: true }]]);
 				});
 			try {
-				await db.log.onMessage(new RequestIPrune({ hashes }), {
+				const requests = hashes.map((hash) => ({
+					hash,
+					requestId: randomBytes(32),
+				}));
+				await db.log.onMessage(new RequestIPruneV2({ requests }), {
 					from: session.peers[0].identity.publicKey,
 				} as any);
 
@@ -3076,11 +3083,10 @@ describe("raw exchange-head sync", () => {
 				expect(
 					[...removeConfirmedReplicatorsSpy.firstCall.args[0]],
 				).to.deep.equal(hashes);
-				const queuedHashes: string[] = [];
 				expect(
 					(nativeLocalLeaderHashesStub?.callCount ?? 0) +
 						nativeBatchPlanStub.callCount,
-				).to.equal(1);
+				).to.equal(2);
 				const plannedItems = nativeLocalLeaderHashesStub?.called
 					? [...nativeLocalLeaderHashesStub.firstCall.args[0]]
 					: [...nativeBatchPlanStub.firstCall.args[0]].map(
@@ -3098,21 +3104,24 @@ describe("raw exchange-head sync", () => {
 					plannedItems.length,
 				);
 				expect(waitForGidStub.callCount).to.equal(0);
-				expect(responseAddStub.callCount).to.equal(
-					plannedItems.length > 0 ? 1 : 0,
-				);
+				const responses = sendStub
+					.getCalls()
+					.map((call) => call.args[0])
+					.filter(
+						(message): message is ResponseIPruneV2 =>
+							message instanceof ResponseIPruneV2,
+					);
+				expect(responses).to.have.length(plannedItems.length > 0 ? 1 : 0);
 				if (plannedItems.length > 0) {
-					const [queued] = responseAddStub.firstCall.args;
-					expect(queued.hashes).to.have.length(plannedItems.length);
-					expect(queued.peers).to.deep.equal([
-						session.peers[0].identity.publicKey.hashcode(),
-					]);
-					for (const queuedHash of queued.hashes) {
-						expect(hashes).to.include(queuedHash);
-						queuedHashes.push(queuedHash);
+					expect(responses[0].requests).to.have.length(plannedItems.length);
+					for (const response of responses[0].requests) {
+						const request = requests.find(
+							(candidate) => candidate.hash === response.hash,
+						);
+						expect(request).to.exist;
+						expect(response.requestId).to.deep.equal(request!.requestId);
 					}
 				}
-				expect(new Set(queuedHashes).size).to.equal(queuedHashes.length);
 				const profileNames = profileEvents.map((event) => event.name);
 				expect(profileNames).to.include.members([
 					"sharedLog.receive.requestPrune.coordinatorCleanup",
@@ -3148,7 +3157,7 @@ describe("raw exchange-head sync", () => {
 				nativeLocalLeaderHashesStub?.restore();
 				nativeMetadataStub.restore();
 				hasManyStub.restore();
-				responseAddStub.restore();
+				sendStub.restore();
 				removeGidBatchSpy.restore();
 				removeConfirmedReplicatorsSpy.restore();
 				removePruneRequestsSentSpy.restore();
@@ -3198,9 +3207,17 @@ describe("raw exchange-head sync", () => {
 				.stub(target.log.log.blocks as any, "hasMany")
 				.resolves(hashes.map(() => false));
 			try {
-				await target.log.onMessage(new RequestIPrune({ hashes }), {
-					from: source.node.identity.publicKey,
-				} as any);
+				await target.log.onMessage(
+					new RequestIPruneV2({
+						requests: hashes.map((hash) => ({
+							hash,
+							requestId: randomBytes(32),
+						})),
+					}),
+					{
+						from: source.node.identity.publicKey,
+					} as any,
+				);
 
 				expect(hasManyStub.callCount).to.equal(1);
 				expect(getShallowSpy.callCount).to.equal(0);
@@ -3209,10 +3226,7 @@ describe("raw exchange-head sync", () => {
 					{ clear?: () => void }
 				>;
 				expect(pending.size).to.equal(hashes.length);
-				for (const value of pending.values()) {
-					value.clear?.();
-				}
-				pending.clear();
+				(target.log as any).clearPendingIHaves();
 
 				const loopProfile = profileEvents.find(
 					(event) => event.name === "sharedLog.receive.requestPrune.loop",
@@ -3275,29 +3289,46 @@ describe("raw exchange-head sync", () => {
 				backbone,
 				"planRequestPruneLeaderHintColumns",
 			);
-			const responseAddStub = sinon
-				.stub(sharedLog.responseToPruneDebouncedFn, "add")
-				.resolves();
+			const finalLeaderPlanStub = sinon
+				.stub(sharedLog, "revalidateCheckedPruneGrantLocalLeaders")
+				.callsFake(async (...args: unknown[]) => new Set(args[0] as string[]));
+			const sendStub = sinon.stub(sharedLog.rpc, "send").resolves();
 			const waitForGidSpy = sinon.spy(sharedLog, "_waitForGidReplicators");
 			const waitForEntrySpy = sinon.spy(sharedLog, "_waitForEntryReplicators");
 			const blockHasManySpy = sinon.spy(target.log.log.blocks as any, "hasMany");
 			const getShallowSpy = sinon.spy(target.log.log.entryIndex, "getShallow");
 			try {
-				await target.log.onMessage(new RequestIPrune({ hashes }), {
+				const requests = hashes.map((hash) => ({
+					hash,
+					requestId: randomBytes(32),
+				}));
+				await target.log.onMessage(new RequestIPruneV2({ requests }), {
 					from: session.peers[0].identity.publicKey,
 				} as any);
 
 				expect(allConfirmedStub.callCount).to.equal(1);
 				expect(hintColumnsSpy.callCount).to.equal(0);
-				expect(blockHasManySpy.callCount).to.equal(0);
+				expect(finalLeaderPlanStub.callCount).to.equal(1);
+				expect(blockHasManySpy.callCount).to.equal(1);
 				expect(getShallowSpy.callCount).to.equal(0);
 				expect(waitForGidSpy.callCount).to.equal(0);
 				expect(waitForEntrySpy.callCount).to.equal(0);
-				expect(responseAddStub.callCount).to.equal(1);
-				expect(responseAddStub.firstCall.args[0].hashes).to.deep.equal(hashes);
-				expect(responseAddStub.firstCall.args[0].peers).to.deep.equal([
-					session.peers[0].identity.publicKey.hashcode(),
-				]);
+				const responses = sendStub
+					.getCalls()
+					.map((call) => call.args[0])
+					.filter(
+						(message): message is ResponseIPruneV2 =>
+							message instanceof ResponseIPruneV2,
+					);
+				expect(responses).to.have.length(1);
+				expect(responses[0].requests.map(({ hash }) => hash)).to.deep.equal(
+					hashes,
+				);
+				for (let index = 0; index < requests.length; index++) {
+					expect(responses[0].requests[index].requestId).to.deep.equal(
+						requests[index].requestId,
+					);
+				}
 				const backboneProfile = profileEvents.find(
 					(event) =>
 						event.name === "sharedLog.receive.requestPrune.nativeBackbonePlan",
@@ -3311,21 +3342,95 @@ describe("raw exchange-head sync", () => {
 				expect(loopProfile.details.nativeBatchConfirmed).to.equal(true);
 				expect(loopProfile.details.leaderResponses).to.equal(hashes.length);
 			} finally {
-				const pending = sharedLog._pendingIHave as Map<
-					string,
-					{ clear?: () => void }
-				>;
-				for (const value of pending.values()) {
-					value.clear?.();
-				}
-				pending.clear();
+				sharedLog.clearPendingIHaves();
 				getShallowSpy.restore();
+				finalLeaderPlanStub.restore();
 				blockHasManySpy.restore();
 				waitForEntrySpy.restore();
 				waitForGidSpy.restore();
-				responseAddStub.restore();
+				sendStub.restore();
 				hintColumnsSpy.restore();
 				allConfirmedStub.restore();
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("fences native all-confirmed peer-history mutation after a subscription changes", async () => {
+		const session = await TestSession.disconnected(2, {
+			indexer: (directory) => createRustIndexer(directory),
+		});
+
+		try {
+			const target = await session.peers[1].open(
+				new EventStore<string, any>(),
+				{
+					args: {
+						replicate: false,
+						setup: {
+							domain: createReplicationDomainHash("u32"),
+							type: "u32" as const,
+							syncronizer: SimpleSyncronizer,
+							name: "u32-simple-raw",
+						},
+						nativeGraph: true,
+						nativeBackbone: { optional: false },
+						keep: () => true,
+						timeUntilRoleMaturity: 0,
+					},
+				},
+			);
+			const { entry } = await target.add(uuid(), { meta: { next: [] } });
+			const sharedLog = target.log as any;
+			const backbone = sharedLog._nativeBackbone;
+			expect(backbone).to.exist;
+			const validContext = await sharedLog.createLeaderSelectionContext();
+			const contextEntered = pDefer<void>();
+			const releaseContext = pDefer<void>();
+			const contextStub = sinon
+				.stub(sharedLog, "createLeaderSelectionContext")
+				.callsFake(async () => {
+					contextEntered.resolve();
+					await releaseContext.promise;
+					return validContext;
+				});
+			const allConfirmedSpy = sinon.spy(
+				backbone,
+				"planRequestPruneAllConfirmed",
+			);
+			const sendStub = sinon.stub(sharedLog.rpc, "send").resolves();
+			const requesterKey = session.peers[0].identity.publicKey;
+			let receiving: Promise<void> | undefined;
+
+			try {
+				receiving = target.log.onMessage(
+					new RequestIPruneV2({
+						requests: [{ hash: entry.hash, requestId: randomBytes(32) }],
+					}),
+					{ from: requesterKey } as any,
+				);
+				await contextEntered.promise;
+
+				sharedLog.advanceSubscriptionEpoch(requesterKey.hashcode());
+				releaseContext.resolve();
+				await receiving;
+
+				expect(allConfirmedSpy.callCount).to.equal(0);
+				expect(
+					sendStub
+						.getCalls()
+						.some((call) => call.args[0] instanceof ResponseIPruneV2),
+				).to.be.false;
+				expect(
+					sharedLog._checkedPruneRequestWorkAdmission.activeByPeer.size,
+				).to.equal(0);
+			} finally {
+				releaseContext.resolve();
+				await Promise.allSettled(receiving ? [receiving] : []);
+				sendStub.restore();
+				allConfirmedSpy.restore();
+				contextStub.restore();
 			}
 		} finally {
 			await session.stop();


### PR DESCRIPTION
## Summary

- replace legacy checked-prune authorization with capability-gated, request-correlated handoffs
- revalidate block presence, leadership, requester ownership, and exact confirmation quorums at the final grant/deletion boundaries
- prevent child handoffs from deleting ancestors and fail closed for legacy or stale peers
- bound vectors, hash lengths, retries, pending missing-entry work, handler/callback work, and concurrent request/grant delivery
- retain admission charges for deadline-abandoned non-cancellable work until it actually settles

## Validation

- `pnpm run build`
- focused checked-prune, admission, retry, pending-IHave, raw-sync, exchange-heads, replication, and sharding tests pass
- final focused aggregate: 72 passing; dedicated protocol/resource aggregate: 50 passing
- full shared-log run reached 2,152 passing / 9 pending; one untouched accumulated-load synthetic memory threshold failed and then passed immediately in isolation
- 100-entry receive benchmark (3 measured runs): native-confirm ~144k ops/s; pending-IHave ~207k ops/s
- `git diff --check`

## Release

Includes a patch changeset for `@peerbit/shared-log`.