### PR TITLE
fix(native-backbone): preserve metadata hint receiver

### DIFF
--- a/.changeset/bright-wasms-keep-context.md
+++ b/.changeset/bright-wasms-keep-context.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/native-backbone": patch
+---
+
+Preserve the native WASM receiver when reading batched entry metadata hints.

--- a/packages/utils/native-backbone/src/index.ts
+++ b/packages/utils/native-backbone/src/index.ts
@@ -5368,11 +5368,13 @@ class NativeBackboneLogGraph {
 	}
 
 	entryMetadataHintsBatch(hashes: Iterable<string>): Array<any | undefined> {
-		return (
-			this.native.graph_entry_metadata_hints_batch ??
-			this.native.graph_entry_metadata_batch
-		)([...hashes]).map((row) => {
-			if (row == null || !this.native.graph_entry_metadata_hints_batch) {
+		const normalized = [...hashes];
+		const usingHints = this.native.graph_entry_metadata_hints_batch != null;
+		const rows = usingHints
+			? this.native.graph_entry_metadata_hints_batch!(normalized)
+			: this.native.graph_entry_metadata_batch(normalized);
+		return rows.map((row) => {
+			if (row == null || !usingHints) {
 				return metadataEntryFromRow(row);
 			}
 			return requestPruneEntryFromRow(row);

--- a/packages/utils/native-backbone/test/index.spec.ts
+++ b/packages/utils/native-backbone/test/index.spec.ts
@@ -1473,6 +1473,38 @@ describe("native peerbit backbone", () => {
 		expect(backbone.graph.payloadSizeSum()).to.equal(4);
 	});
 
+	it("reads entry metadata hints through the WASM receiver", async () => {
+		const backbone = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
+		});
+		const prepared = backbone.storageBackedGraph.prepareEntryV0PlainEntryAndPut(
+			{
+				clockId: publicKey,
+				privateKey,
+				publicKey,
+				wallTime: 1n,
+				gid: "gid-metadata-hints",
+				metaData: new Uint8Array([7]),
+				payloadData: new Uint8Array([1]),
+				includeMaterializationBytes: false,
+				includeAppendFactsBytes: true,
+			},
+		);
+
+		expect(
+			backbone.graph.entryMetadataHintsBatch([prepared.hash, "missing"]),
+		).to.deep.equal([
+			{
+				hash: prepared.hash,
+				gid: "gid-metadata-hints",
+				data: new Uint8Array([7]),
+			},
+			undefined,
+		]);
+	});
+
 	it("commits blocks graph and coordinates in one native batch", async () => {
 		const source = await createNativePeerbitBackbone({
 			clockId: publicKey,


### PR DESCRIPTION
## Summary

- preserve the wasm-bindgen instance receiver when reading metadata hints
- preserve the receiver for the older metadata-batch fallback too
- add a real-WASM regression covering a present and missing hash

## Why

Extracting either WASM method before invoking it loses `this`, causing an `undefined.__wbg_ptr` error. Checked-prune final revalidation exercises this path in native mode.

## Validation

- `pnpm --filter @peerbit/native-backbone run test` (58 Rust and 113 Node tests)
- focused real-WASM regression
- ESLint, Prettier, and `git diff --check`