### PR TITLE
fix(shared-log): correlate and harden checked-prune handoffs

### DIFF
--- a/.changeset/correlated-prune-handoffs.md
+++ b/.changeset/correlated-prune-handoffs.md
@@ -1,0 +1,7 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Correlate checked-prune grants with exact per-generation IDs and authenticated peers, then revalidate ownership and quorum at the serialized delete boundary. Revoke stale receipts across peer churn, retain expired background handoffs in a bounded low-rate audit, and prune newly exposed parents through independent nonrecursive generations.
+
+This is a fail-closed protocol cutover: legacy uncorrelated prune messages no longer authorize deletion. During a mixed-version rollout, peers retain extra copies until every participant in a handoff has upgraded.

--- a/packages/programs/data/shared-log/benchmark/receive-prune.ts
+++ b/packages/programs/data/shared-log/benchmark/receive-prune.ts
@@ -24,7 +24,7 @@ import { performance } from "node:perf_hooks";
 import { v4 as uuid } from "uuid";
 import {
 	type RawExchangeHeadsMessage,
-	RequestIPrune,
+	RequestIPruneV2,
 	createRawExchangeHeadsMessages,
 } from "../src/exchange-heads.js";
 import { TransportMessage } from "../src/message.js";
@@ -689,43 +689,29 @@ const runRawReceive = async (
 	}
 };
 
-const installFastLeaderWaits = (store: EventStore<string, any>) => {
+const suppressPruneResponses = (store: EventStore<string, any>) => {
 	const log = store.log as any;
-	const selfHash = store.node.identity.publicKey.hashcode();
-	const originalWaitForGid = log._waitForGidReplicators;
-	const originalWaitForEntry = log._waitForEntryReplicators;
-	log._waitForGidReplicators = async (
-		_gid: string,
-		_replicas: number,
-		_waitFor: unknown,
-		options: { onLeader?: (key: string) => void } | undefined,
+	const original = log.sendCheckedPruneResponse;
+	let granted = 0;
+	log.sendCheckedPruneResponse = async (
+		_to: string,
+		requests: Array<{ hash: string; requestId: Uint8Array }>,
 	) => {
-		options?.onLeader?.(selfHash);
-		return new Map([[selfHash, { intersecting: true }]]);
+		granted += requests.length;
 	};
-	log._waitForEntryReplicators = async (
-		_entry: unknown,
-		_replicas: number,
-		_waitFor: unknown,
-		options: { onLeader?: (key: string) => void } | undefined,
-	) => {
-		options?.onLeader?.(selfHash);
-		return new Map([[selfHash, { intersecting: true }]]);
-	};
-	return () => {
-		log._waitForGidReplicators = originalWaitForGid;
-		log._waitForEntryReplicators = originalWaitForEntry;
+	return {
+		granted: () => granted,
+		restore: () => {
+			log.sendCheckedPruneResponse = original;
+		},
 	};
 };
 
-const suppressPruneResponses = (store: EventStore<string, any>) => {
-	const debounced = (store.log as any).responseToPruneDebouncedFn;
-	const originalAdd = debounced.add;
-	debounced.add = () => undefined;
-	return () => {
-		debounced.add = originalAdd;
-	};
-};
+const correlatedPruneRequests = (hashes: string[]) =>
+	hashes.map((hash) => ({
+		hash,
+		requestId: new Uint8Array(32),
+	}));
 
 const clearPendingIHaves = (store: EventStore<string, any>) => {
 	const pending = (store.log as any)._pendingIHave as Map<
@@ -755,21 +741,31 @@ const runRequestPruneNativeConfirm = async (
 			},
 		});
 		const hashes = await appendIndependentEntries(db, count);
-		const restoreWaits = installFastLeaderWaits(db);
-		const restoreResponses = suppressPruneResponses(db);
+		const responses = suppressPruneResponses(db);
 		try {
 			const started = performance.now();
-			await db.log.onMessage(new RequestIPrune({ hashes }), {
-				from: session.peers[0].identity.publicKey,
-			} as any);
+			await db.log.onMessage(
+				new RequestIPruneV2({
+					requests: correlatedPruneRequests(hashes),
+				}),
+				{
+					from: session.peers[0].identity.publicKey,
+				} as any,
+			);
 			const elapsed = performance.now() - started;
+			const granted = responses.granted();
+			if (granted !== count) {
+				throw new Error(
+					`Expected ${count} checked-prune grants, got ${granted}`,
+				);
+			}
 
 			return {
 				scenario: options?.coordinateWal
 					? "request-prune-native-backbone-coordinate-wal-confirm"
 					: options?.nativeBackbone
 						? "request-prune-native-backbone-confirm"
-					: "request-prune-native-confirm",
+						: "request-prune-native-confirm",
 				count,
 				run,
 				elapsedMs: elapsed,
@@ -777,8 +773,7 @@ const runRequestPruneNativeConfirm = async (
 				profile: summarizeProfileEvents(profileEvents),
 			};
 		} finally {
-			restoreResponses();
-			restoreWaits();
+			responses.restore();
 			clearPendingIHaves(db);
 		}
 	} finally {
@@ -806,10 +801,21 @@ const runRequestPrunePendingIHave = async (
 
 		try {
 			const started = performance.now();
-			await target.log.onMessage(new RequestIPrune({ hashes }), {
-				from: source.node.identity.publicKey,
-			} as any);
+			await target.log.onMessage(
+				new RequestIPruneV2({
+					requests: correlatedPruneRequests(hashes),
+				}),
+				{
+					from: source.node.identity.publicKey,
+				} as any,
+			);
 			const elapsed = performance.now() - started;
+			const pendingCount = (target.log as any)._pendingIHave.size;
+			if (pendingCount !== count) {
+				throw new Error(
+					`Expected ${count} pending-IHave entries, got ${pendingCount}`,
+				);
+			}
 
 			return {
 				scenario: "request-prune-pending-ihave",

--- a/packages/programs/data/shared-log/src/checked-prune.ts
+++ b/packages/programs/data/shared-log/src/checked-prune.ts
@@ -10,10 +10,18 @@ export type CheckedPruneEntry<T, R extends "u32" | "u64"> =
 	| EntryReplicated<R>;
 
 export type CheckedPrunePendingDelete = {
+	requestId: Uint8Array;
+	retryOnInvalidation?: boolean;
 	promise: DeferredPromise<void>;
 	clear: () => void;
-	resolve: (publicKeyHash: string) => Promise<void> | void;
-	reject(reason: any): Promise<void> | void;
+	resolve: (
+		publicKeyHash: string,
+		requestId: Uint8Array,
+	) => Promise<void> | void;
+	reject(
+		reason: any,
+		options?: { preserveRetry?: boolean },
+	): Promise<void> | void;
 };
 
 export type CheckedPruneRetryState<T, R extends "u32" | "u64"> = {
@@ -22,6 +30,18 @@ export type CheckedPruneRetryState<T, R extends "u32" | "u64"> = {
 	entry: CheckedPruneEntry<T, R>;
 	leaders: CheckedPruneLeaderMap | Set<string>;
 };
+
+export type CheckedPruneInvalidatedGeneration<T, R extends "u32" | "u64"> = {
+	hash: string;
+	pending: CheckedPrunePendingDelete;
+	entry: CheckedPruneEntry<T, R>;
+	leaders: CheckedPruneLeaderMap | Set<string>;
+};
+
+export type CheckedPruneRestartCandidate<T, R extends "u32" | "u64"> = Omit<
+	CheckedPruneInvalidatedGeneration<T, R>,
+	"pending"
+>;
 
 type CheckedPruneSessionPhase =
 	| "candidate"
@@ -40,6 +60,7 @@ type CheckedPruneSession<T, R extends "u32" | "u64"> = {
 	retry?: CheckedPruneRetryState<T, R>;
 	contacted: Set<string>;
 	confirmed: Set<string>;
+	revoked: Set<string>;
 };
 
 export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
@@ -48,6 +69,10 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 	readonly responseReplicatorSet = new Map<string, Set<string>>();
 	readonly retries = new Map<string, CheckedPruneRetryState<T, R>>();
 	private readonly sessions = new Map<string, CheckedPruneSession<T, R>>();
+	private readonly grantSends = new Map<string, Set<Promise<void>>>();
+	private readonly peerRemovalFences = new Map<string, number>();
+	private readonly restartReservations = new Map<string, object>();
+	private readonly candidateTokens = new Map<string, object>();
 
 	private getOrCreateSession(hash: string): CheckedPruneSession<T, R> {
 		let session = this.sessions.get(hash);
@@ -56,6 +81,7 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 				phase: "candidate",
 				contacted: new Set(),
 				confirmed: new Set(),
+				revoked: new Set(),
 			};
 			this.sessions.set(hash, session);
 		}
@@ -82,7 +108,8 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 			this.pendingDeletes.has(hash) ||
 			this.requestIPruneSent.has(hash) ||
 			this.responseReplicatorSet.has(hash) ||
-			this.retries.has(hash)
+			this.retries.has(hash) ||
+			this.candidateTokens.has(hash)
 		) {
 			return;
 		}
@@ -94,10 +121,27 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 		entry: CheckedPruneEntry<T, R>,
 		leaders: CheckedPruneLeaderMap | Set<string>,
 	) {
+		this.restartReservations.delete(hash);
 		const session = this.remember(hash, entry, leaders);
 		if (!this.hasActiveWork(hash)) {
 			session.phase = "candidate";
 		}
+		const token = {};
+		this.candidateTokens.set(hash, token);
+		return token;
+	}
+
+	isCandidateTokenCurrent(hash: string, token: object) {
+		return this.candidateTokens.get(hash) === token;
+	}
+
+	hasCandidate(hash: string) {
+		return this.candidateTokens.has(hash);
+	}
+
+	invalidateCandidateToken(hash: string) {
+		this.candidateTokens.delete(hash);
+		this.deleteSessionIfIdle(hash);
 	}
 
 	hasActiveWork(hash: string) {
@@ -105,7 +149,8 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 			this.pendingDeletes.has(hash) ||
 			this.requestIPruneSent.has(hash) ||
 			this.responseReplicatorSet.has(hash) ||
-			this.retries.has(hash)
+			this.retries.has(hash) ||
+			this.candidateTokens.has(hash)
 		);
 	}
 
@@ -117,15 +162,39 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 		return this.pendingDeletes.has(hash);
 	}
 
+	getRestartCandidate(
+		hash: string,
+	): CheckedPruneRestartCandidate<T, R> | undefined {
+		const session = this.sessions.get(hash);
+		if (!session?.entry || !session.leaders) {
+			return undefined;
+		}
+		return {
+			hash,
+			entry: session.entry,
+			leaders:
+				session.leaders instanceof Map
+					? new Map(session.leaders)
+					: new Set(session.leaders),
+		};
+	}
+
 	setPendingDelete(
 		hash: string,
 		pending: CheckedPrunePendingDelete,
 		entry: CheckedPruneEntry<T, R>,
 		leaders: CheckedPruneLeaderMap | Set<string>,
 	) {
+		this.restartReservations.delete(hash);
+		this.candidateTokens.delete(hash);
+		this.requestIPruneSent.delete(hash);
+		this.responseReplicatorSet.delete(hash);
 		this.pendingDeletes.set(hash, pending);
 		const session = this.remember(hash, entry, leaders);
 		session.pending = pending;
+		session.contacted.clear();
+		session.confirmed.clear();
+		session.revoked.clear();
 		session.phase = "requested";
 	}
 
@@ -133,9 +202,14 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 		const current = this.pendingDeletes.get(hash);
 		if (!pending || current === pending) {
 			this.pendingDeletes.delete(hash);
+			this.requestIPruneSent.delete(hash);
+			this.responseReplicatorSet.delete(hash);
 			const session = this.sessions.get(hash);
 			if (session && session.pending === current) {
 				session.pending = undefined;
+				session.contacted.clear();
+				session.confirmed.clear();
+				session.revoked.clear();
 			}
 			this.deleteSessionIfIdle(hash);
 		}
@@ -150,6 +224,8 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 	}
 
 	setRetry(hash: string, state: CheckedPruneRetryState<T, R>) {
+		this.restartReservations.delete(hash);
+		this.candidateTokens.delete(hash);
 		this.retries.set(hash, state);
 		const session = this.remember(hash, state.entry, state.leaders);
 		session.retry = state;
@@ -157,6 +233,8 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 	}
 
 	clearRetry(hash: string) {
+		this.restartReservations.delete(hash);
+		this.candidateTokens.delete(hash);
 		const state = this.retries.get(hash);
 		if (state?.timer) {
 			clearTimeout(state.timer);
@@ -178,34 +256,78 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 		return state;
 	}
 
-	addRequestSent(hash: string, peer: string) {
+	isCurrentRequest(hash: string, pending: CheckedPrunePendingDelete) {
+		return this.pendingDeletes.get(hash) === pending;
+	}
+
+	isCurrentRequestId(
+		hash: string,
+		pending: CheckedPrunePendingDelete,
+		requestId: Uint8Array,
+	) {
+		if (!this.isCurrentRequest(hash, pending)) {
+			return false;
+		}
+		if (pending.requestId.byteLength !== requestId.byteLength) {
+			return false;
+		}
+		return pending.requestId.every(
+			(value, index) => value === requestId[index],
+		);
+	}
+
+	addRequestSent(
+		hash: string,
+		peer: string,
+		pending: CheckedPrunePendingDelete,
+	) {
+		if (!this.isCurrentRequest(hash, pending)) {
+			return false;
+		}
+		const session = this.getOrCreateSession(hash);
+		if (session.revoked.has(peer)) {
+			return false;
+		}
 		let set = this.requestIPruneSent.get(hash);
 		if (!set) {
 			set = new Set();
 			this.requestIPruneSent.set(hash, set);
 		}
 		set.add(peer);
-		const session = this.getOrCreateSession(hash);
 		session.contacted.add(peer);
 		if (session.phase === "candidate") {
 			session.phase = "requested";
 		}
+		return true;
 	}
 
 	removeRequestSent(hash: string, peer?: string) {
 		if (!peer) {
-			this.requestIPruneSent.delete(hash);
 			const session = this.sessions.get(hash);
+			if (session?.pending) {
+				for (const contactedPeer of session.contacted) {
+					session.revoked.add(contactedPeer);
+				}
+			}
+			this.requestIPruneSent.delete(hash);
 			session?.contacted.clear();
+			this.clearConfirmedReplicators(hash);
 			this.deleteSessionIfIdle(hash);
 			return;
 		}
+		const session = this.sessions.get(hash);
+		if (session?.pending) {
+			// A contact removed during this pending generation must never become
+			// authorized again by a delayed receipt carrying the old generation ID.
+			session.revoked.add(peer);
+		}
 		const set = this.requestIPruneSent.get(hash);
 		if (!set) {
+			this.removeConfirmedReplicator(hash, peer);
 			return;
 		}
 		set.delete(peer);
-		const session = this.sessions.get(hash);
+		this.removeConfirmedReplicator(hash, peer);
 		session?.contacted.delete(peer);
 		if (set.size === 0) {
 			this.requestIPruneSent.delete(hash);
@@ -214,15 +336,23 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 	}
 
 	removeRequestsSent(hashes: Iterable<string>, peer?: string) {
-		if (this.requestIPruneSent.size === 0) {
-			return;
-		}
 		for (const hash of hashes) {
 			this.removeRequestSent(hash, peer);
 		}
 	}
 
-	addConfirmedReplicator(hash: string, peer: string) {
+	addConfirmedReplicator(
+		hash: string,
+		peer: string,
+		pending: CheckedPrunePendingDelete,
+		requestId: Uint8Array,
+	) {
+		if (
+			!this.isCurrentRequestId(hash, pending, requestId) ||
+			!this.requestIPruneSent.get(hash)?.has(peer)
+		) {
+			return undefined;
+		}
 		let set = this.responseReplicatorSet.get(hash);
 		if (!set) {
 			set = new Set();
@@ -282,24 +412,178 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 		return this.requestIPruneSent.get(hash);
 	}
 
-	markRemoving(hash: string) {
-		const session = this.getOrCreateSession(hash);
-		session.phase = "removing";
+	hasRevokedLeader(
+		hash: string,
+		pending: CheckedPrunePendingDelete,
+		leaders: CheckedPruneLeaderMap | Set<string>,
+	) {
+		if (!this.isCurrentRequest(hash, pending)) {
+			return false;
+		}
+		const revoked = this.sessions.get(hash)?.revoked;
+		if (!revoked || revoked.size === 0) {
+			return false;
+		}
+		for (const leader of leaders.keys()) {
+			if (revoked.has(leader)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
-	markDone(hash: string) {
+	trackGrantSend(hashes: Iterable<string>, send: Promise<void>) {
+		const uniqueHashes = [...new Set(hashes)];
+		const observed = send.then(
+			() => undefined,
+			() => undefined,
+		);
+		for (const hash of uniqueHashes) {
+			let sends = this.grantSends.get(hash);
+			if (!sends) {
+				sends = new Set();
+				this.grantSends.set(hash, sends);
+			}
+			sends.add(observed);
+		}
+		void observed.finally(() => {
+			for (const hash of uniqueHashes) {
+				const sends = this.grantSends.get(hash);
+				sends?.delete(observed);
+				if (sends?.size === 0) {
+					this.grantSends.delete(hash);
+				}
+			}
+		});
+		return observed;
+	}
+
+	waitForGrantSends(hash: string): Promise<void> | undefined {
+		const sends = this.grantSends.get(hash);
+		if (!sends || sends.size === 0) {
+			return undefined;
+		}
+		return Promise.all(sends).then(() => undefined);
+	}
+
+	reserveRestart(hash: string) {
+		const reservation = {};
+		this.restartReservations.set(hash, reservation);
+		return reservation;
+	}
+
+	consumeRestartReservation(hash: string, reservation: object) {
+		if (this.restartReservations.get(hash) !== reservation) {
+			return false;
+		}
+		this.restartReservations.delete(hash);
+		return true;
+	}
+
+	cancelRestartReservation(hash: string, reservation: object) {
+		if (this.restartReservations.get(hash) === reservation) {
+			this.restartReservations.delete(hash);
+		}
+	}
+
+	hasRestartReservation(hash: string) {
+		return this.restartReservations.has(hash);
+	}
+
+	getExactConfirmedReplicators(
+		hash: string,
+		pending: CheckedPrunePendingDelete,
+	) {
+		const exact = new Set<string>();
+		if (!this.isCurrentRequest(hash, pending)) {
+			return exact;
+		}
+		const contacted = this.requestIPruneSent.get(hash);
+		const confirmed = this.responseReplicatorSet.get(hash);
+		const revoked = this.sessions.get(hash)?.revoked;
+		if (!contacted || !confirmed) {
+			return exact;
+		}
+		for (const peer of confirmed) {
+			if (
+				contacted.has(peer) &&
+				!revoked?.has(peer) &&
+				!this.isPeerRemovalFenced(peer)
+			) {
+				exact.add(peer);
+			}
+		}
+		return exact;
+	}
+
+	fencePeerRemoval(peer: string) {
+		this.peerRemovalFences.set(
+			peer,
+			(this.peerRemovalFences.get(peer) ?? 0) + 1,
+		);
+		let released = false;
+		return () => {
+			if (released) {
+				return;
+			}
+			released = true;
+			const remaining = (this.peerRemovalFences.get(peer) ?? 1) - 1;
+			if (remaining > 0) {
+				this.peerRemovalFences.set(peer, remaining);
+			} else {
+				this.peerRemovalFences.delete(peer);
+			}
+		};
+	}
+
+	isPeerRemovalFenced(peer: string) {
+		return (this.peerRemovalFences.get(peer) ?? 0) > 0;
+	}
+
+	markRemoving(hash: string, pending?: CheckedPrunePendingDelete) {
+		if (pending && !this.isCurrentRequest(hash, pending)) {
+			return false;
+		}
+		const session = this.getOrCreateSession(hash);
+		session.phase = "removing";
+		return true;
+	}
+
+	markDone(hash: string, pending?: CheckedPrunePendingDelete) {
+		if (pending && !this.isCurrentRequest(hash, pending)) {
+			return false;
+		}
 		const session = this.sessions.get(hash);
 		if (session) {
 			session.phase = "done";
 		}
+		this.restartReservations.delete(hash);
+		this.candidateTokens.delete(hash);
 		this.pendingDeletes.delete(hash);
 		this.requestIPruneSent.delete(hash);
 		this.responseReplicatorSet.delete(hash);
 		this.clearRetry(hash);
 		this.sessions.delete(hash);
+		return true;
 	}
 
-	markCancelled(hash: string, options?: { preserveRetry?: boolean }) {
+	markCancelled(
+		hash: string,
+		pendingOrOptions?: CheckedPrunePendingDelete | { preserveRetry?: boolean },
+		options?: { preserveRetry?: boolean },
+	) {
+		const pending =
+			pendingOrOptions && "promise" in pendingOrOptions
+				? pendingOrOptions
+				: undefined;
+		const resolvedOptions: { preserveRetry?: boolean } | undefined = pending
+			? options
+			: (pendingOrOptions as { preserveRetry?: boolean } | undefined);
+		if (pending && !this.isCurrentRequest(hash, pending)) {
+			return false;
+		}
+		this.restartReservations.delete(hash);
+		this.candidateTokens.delete(hash);
 		const retry = this.retries.get(hash);
 		const session = this.sessions.get(hash);
 		if (session) {
@@ -307,36 +591,57 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 			session.pending = undefined;
 			session.contacted.clear();
 			session.confirmed.clear();
-			if (!options?.preserveRetry || session.retry !== retry) {
+			session.revoked.clear();
+			if (!resolvedOptions?.preserveRetry || session.retry !== retry) {
 				session.retry = undefined;
 			}
 		}
+		if (!pending || this.pendingDeletes.get(hash) === pending) {
+			this.pendingDeletes.delete(hash);
+		}
 		this.requestIPruneSent.delete(hash);
 		this.responseReplicatorSet.delete(hash);
-		if (!options?.preserveRetry) {
+		if (!resolvedOptions?.preserveRetry) {
 			this.clearRetry(hash);
 		}
 		this.deleteSessionIfIdle(hash);
+		return true;
 	}
 
 	cleanupPeer(peer: string) {
-		for (const [hash, peers] of this.requestIPruneSent) {
-			peers.delete(peer);
-			this.sessions.get(hash)?.contacted.delete(peer);
-			if (peers.size === 0) {
-				this.requestIPruneSent.delete(hash);
-				this.deleteSessionIfIdle(hash);
+		const invalidated: CheckedPruneInvalidatedGeneration<T, R>[] = [];
+		// Fence the peer from every active generation, including generations that
+		// have not emitted their first request yet. A removal can begin between
+		// generation creation and message emission.
+		for (const [hash, session] of this.sessions) {
+			const pending = session.pending;
+			if (pending && this.pendingDeletes.get(hash) === pending) {
+				session.revoked.add(peer);
+				const candidate = this.getRestartCandidate(hash);
+				if (
+					candidate &&
+					(session.contacted.has(peer) || candidate.leaders.has(peer))
+				) {
+					invalidated.push({
+						...candidate,
+						pending,
+					});
+				}
 			}
 		}
 
-		for (const [hash, peers] of this.responseReplicatorSet) {
-			peers.delete(peer);
-			this.sessions.get(hash)?.confirmed.delete(peer);
-			if (peers.size === 0) {
-				this.responseReplicatorSet.delete(hash);
-				this.deleteSessionIfIdle(hash);
+		for (const [hash, peers] of [...this.requestIPruneSent]) {
+			if (peers.has(peer)) {
+				this.removeRequestSent(hash, peer);
 			}
 		}
+
+		for (const [hash, peers] of [...this.responseReplicatorSet]) {
+			if (peers.has(peer)) {
+				this.removeConfirmedReplicator(hash, peer);
+			}
+		}
+		return invalidated;
 	}
 
 	close() {
@@ -354,5 +659,9 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 		this.responseReplicatorSet.clear();
 		this.retries.clear();
 		this.sessions.clear();
+		this.grantSends.clear();
+		this.peerRemovalFences.clear();
+		this.restartReservations.clear();
+		this.candidateTokens.clear();
 	}
 }

--- a/packages/programs/data/shared-log/src/exchange-heads.ts
+++ b/packages/programs/data/shared-log/src/exchange-heads.ts
@@ -1106,6 +1106,58 @@ export class ResponseIPrune extends TransportMessage {
 	}
 }
 
+@variant(0)
+export class CheckedPruneRequest {
+	@field({ type: "string" })
+	hash: string;
+
+	@field({ type: fixedArray("u8", 32) })
+	requestId: Uint8Array;
+
+	constructor(props: { hash: string; requestId: Uint8Array }) {
+		this.hash = props.hash;
+		this.requestId = props.requestId;
+	}
+}
+
+@variant([0, 11])
+export class RequestIPruneV2 extends TransportMessage {
+	@field({ type: vec(CheckedPruneRequest) })
+	requests: CheckedPruneRequest[];
+
+	constructor(props: {
+		requests: Array<
+			CheckedPruneRequest | { hash: string; requestId: Uint8Array }
+		>;
+	}) {
+		super();
+		this.requests = props.requests.map((request) =>
+			request instanceof CheckedPruneRequest
+				? request
+				: new CheckedPruneRequest(request),
+		);
+	}
+}
+
+@variant([0, 12])
+export class ResponseIPruneV2 extends TransportMessage {
+	@field({ type: vec(CheckedPruneRequest) })
+	requests: CheckedPruneRequest[];
+
+	constructor(props: {
+		requests: Array<
+			CheckedPruneRequest | { hash: string; requestId: Uint8Array }
+		>;
+	}) {
+		super();
+		this.requests = props.requests.map((request) =>
+			request instanceof CheckedPruneRequest
+				? request
+				: new CheckedPruneRequest(request),
+		);
+	}
+}
+
 const MAX_EXCHANGE_MESSAGE_SIZE = 1e5; // 100kb. Too large size might not be faster (even if we can do 5mb)
 export const MAX_RAW_EXCHANGE_MESSAGE_SIZE = 512 * 1024;
 export const EXCHANGE_HEADS_RESOLVE_BATCH_SIZE = 256;

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -20,6 +20,7 @@ import {
 	PublicSignKey,
 	Secp256k1PublicKey,
 	getPublicKeyFromPeerId,
+	randomBytes,
 	sha256Base64Sync,
 	sha256Sync,
 	toHexString,
@@ -70,7 +71,6 @@ import type {
 	NativeBackboneRawReceiveGroupLeaderPlan,
 	NativeBackboneRawReceiveGroupPlan,
 	NativeBackboneRawReceiveSelectionPlan,
-	NativeBackboneRequestPruneHintColumns,
 	NativePeerbitBackbone,
 	NativeBackboneCoordinatePersistenceConfig as RuntimeNativeBackboneCoordinatePersistenceConfig,
 } from "@peerbit/native-backbone";
@@ -119,7 +119,6 @@ import {
 import {
 	AbortError,
 	TimeoutError,
-	debounceAccumulator,
 	debounceFixedInterval,
 	waitFor,
 } from "@peerbit/time";
@@ -131,6 +130,8 @@ import {
 	CheckedPruneCoordinator,
 	type CheckedPruneEntry,
 	type CheckedPruneLeaderMap,
+	type CheckedPrunePendingDelete,
+	type CheckedPruneRestartCandidate,
 	type CheckedPruneRetryState,
 } from "./checked-prune.js";
 import { type CPUUsage, CPUUsageIntervalLag } from "./cpu.js";
@@ -149,7 +150,9 @@ import {
 	RawExchangeHeadsMessage,
 	type RawReceiveHashSelection,
 	RequestIPrune,
+	RequestIPruneV2,
 	ResponseIPrune,
+	ResponseIPruneV2,
 	SYNC_CAPABILITY_RAW_EXCHANGE_HEADS,
 	StashBackedRawExchangeHeadsMessage,
 	SyncCapabilitiesMessage,
@@ -281,7 +284,7 @@ const mapMaybePromise = <T, R>(
 
 type PendingIHave<T> = {
 	resetTimeout: () => void;
-	requesting: Set<string>;
+	requesting: Map<string, Uint8Array>;
 	clear: () => void;
 	callback: (entry: Entry<T>) => MaybePromise<void>;
 	expiresAt?: number;
@@ -1658,106 +1661,6 @@ type ReusableReceiveCoordinatePlan<R extends "u32" | "u64"> = {
 };
 
 type DecodedReplicaCountMap = ReadonlyMap<string, number>;
-type NativeRequestPruneLeaderHints = {
-	localLeaderHashes: Set<string>;
-	replicaCounts: Map<string, number>;
-	replicaCountsByIndex?: ArrayLike<number | undefined>;
-	peerHistoryGids: string[];
-	peerHistoryRemovedHashes: Set<string>;
-	peerHistoryRemovedFlags?: ArrayLike<boolean | number>;
-	nativeEntries?: Map<
-		string,
-		{ gid: string; data?: Uint8Array; replicas?: number }
-	>;
-	nativeEntryMetadata?: Array<
-		{ gid: string; data?: Uint8Array; replicas?: number } | undefined | null
-	>;
-	nativeEntryGids?: ArrayLike<string | undefined | null>;
-	nativeEntryDataByIndex?: ArrayLike<Uint8Array | undefined | null>;
-	presentBlockHashes?: Set<string>;
-	presentBlocks?: ArrayLike<boolean | number>;
-	localLeaderFlags?: ArrayLike<boolean | number>;
-	nativeAllConfirmed?: boolean;
-	nativeBackbonePeerHistoryCleaned?: boolean;
-};
-
-const countTruthyValues = (values?: ArrayLike<boolean | number>) => {
-	if (!values) {
-		return 0;
-	}
-	let count = 0;
-	for (let i = 0; i < values.length; i++) {
-		if (values[i]) {
-			count += 1;
-		}
-	}
-	return count;
-};
-
-const countPresentValues = (values?: ArrayLike<unknown>) => {
-	if (!values) {
-		return 0;
-	}
-	let count = 0;
-	for (let i = 0; i < values.length; i++) {
-		if (values[i] != null) {
-			count += 1;
-		}
-	}
-	return count;
-};
-
-const countPositiveValues = (values?: ArrayLike<number | undefined>) => {
-	if (!values) {
-		return 0;
-	}
-	let count = 0;
-	for (let i = 0; i < values.length; i++) {
-		if ((values[i] ?? 0) > 0) {
-			count += 1;
-		}
-	}
-	return count;
-};
-
-const canConfirmNativeRequestPruneBatch = (
-	hints: NativeRequestPruneLeaderHints,
-	hashCount: number,
-) => {
-	if (hashCount > 0 && hints.nativeAllConfirmed === true) {
-		return true;
-	}
-	if (
-		hashCount === 0 ||
-		!hints.nativeEntryGids ||
-		!hints.presentBlocks ||
-		!hints.localLeaderFlags ||
-		!hints.replicaCountsByIndex ||
-		!hints.peerHistoryRemovedFlags ||
-		hints.nativeEntryGids.length < hashCount ||
-		hints.presentBlocks.length < hashCount ||
-		hints.localLeaderFlags.length < hashCount ||
-		hints.replicaCountsByIndex.length < hashCount ||
-		hints.peerHistoryRemovedFlags.length < hashCount
-	) {
-		return false;
-	}
-
-	for (let i = 0; i < hashCount; i++) {
-		if (
-			hints.nativeEntryGids[i] == null ||
-			!hints.presentBlocks[i] ||
-			!hints.localLeaderFlags[i] ||
-			(hints.replicaCountsByIndex[i] ?? 0) <= 0 ||
-			!hints.peerHistoryRemovedFlags[i]
-		) {
-			return false;
-		}
-	}
-
-	return true;
-};
-
 type SharedLogCoordinateNativeFields<R extends "u32" | "u64"> = {
 	hash: string;
 	hashNumber: NumberFromType<R>;
@@ -2706,6 +2609,8 @@ const CHECKED_PRUNE_RESEND_INTERVAL_MAX_MS = 5_000;
 const CHECKED_PRUNE_BACKGROUND_TIMEOUT_MIN_MS = 120_000;
 const CHECKED_PRUNE_RETRY_MAX_ATTEMPTS = 3;
 const CHECKED_PRUNE_RETRY_MAX_DELAY_MS = 30_000;
+const CHECKED_PRUNE_AUDIT_INTERVAL_MS = 30_000;
+const CHECKED_PRUNE_AUDIT_BATCH_SIZE = 128;
 
 // DONT SET THIS ANY LOWER, because it will make the pid controller unstable as the system responses are not fast enough to updates from the pid controller
 const RECALCULATE_PARTICIPATION_DEBOUNCE_INTERVAL = 1000;
@@ -3473,6 +3378,7 @@ export class SharedLog<
 
 	private startRepairLifecycle(): AbortController {
 		this._repairLifecycleController?.abort();
+		this.clearCheckedPruneAuditTimer();
 		this._repairLifecycleController = new AbortController();
 		return this._repairLifecycleController;
 	}
@@ -3516,6 +3422,7 @@ export class SharedLog<
 		this.replicationChangeDebounceFn?.close?.();
 		this.pruneDebouncedFn?.close?.();
 		this.rebalanceParticipationDebounced?.close();
+		this.clearCheckedPruneAuditTimer();
 		for (const hash of this._checkedPrune?.retries.keys() ?? []) {
 			this._checkedPrune.clearRetry(hash);
 		}
@@ -4549,17 +4456,9 @@ export class SharedLog<
 	pruneDebouncedFn!: DebouncedAccumulatorMap<{
 		entry: CheckedPruneEntry<T, R>;
 		leaders: CheckedPruneLeaderMap;
+		workToken?: object;
 	}>;
-	private responseToPruneDebouncedFn!: ReturnType<
-		typeof debounceAccumulator<
-			string,
-			{
-				hashes: string[];
-				peers: string[] | Set<string>;
-			},
-			Map<string, Set<string>>
-		>
-	>;
+	private _checkedPruneAuditTimer?: ReturnType<typeof setTimeout>;
 
 	private get _requestIPruneSent() {
 		return this._checkedPrune.requestIPruneSent;
@@ -4669,6 +4568,7 @@ export class SharedLog<
 		this.log = new Log(properties);
 		this.rpc = new RPC();
 		this._checkedPrune = new CheckedPruneCoordinator<T, R>();
+		this._checkedPruneAuditTimer = undefined;
 		this._admittedPruneRemoves = new Set();
 		this._pendingIHave = new Map();
 		this._pendingIHaveCallbacks = new Set();
@@ -7703,14 +7603,35 @@ export class SharedLog<
 		const isMe = this.node.identity.publicKey.hashcode() === keyHash;
 		let receiveAdmissionBlocked = false;
 		const receiveCleanupGateByPeer = this._receiveCleanupGateByPeer;
-		const blockAndDrainPeerReceives = async () => {
-			if (!receiveAdmissionBlocked) {
-				receiveCleanupGateByPeer.set(
-					keyHash,
-					(receiveCleanupGateByPeer.get(keyHash) ?? 0) + 1,
-				);
-				receiveAdmissionBlocked = true;
+		const checkedPruneCoordinator = this._checkedPrune;
+		const isSpeculativePeerRemoval =
+			!isMe && options?.shouldRemove !== undefined;
+		const releaseCheckedPrunePeerRemovalFence = isSpeculativePeerRemoval
+			? checkedPruneCoordinator.fencePeerRemoval(keyHash)
+			: undefined;
+		const blockPeerReceiveAdmission = () => {
+			if (receiveAdmissionBlocked) {
+				return;
 			}
+			receiveCleanupGateByPeer.set(
+				keyHash,
+				(receiveCleanupGateByPeer.get(keyHash) ?? 0) + 1,
+			);
+			receiveAdmissionBlocked = true;
+		};
+		if (!isMe && !isSpeculativePeerRemoval) {
+			// Revoke this peer's receipts synchronously, before this removal can
+			// wait behind either the per-peer apply queue or the ownership lane.
+			// Keep receive admission open until removal is actually admitted so
+			// fresh authenticated activity can still cancel a liveness eviction.
+			this.cleanupCheckedPrunePeer(
+				keyHash,
+				replicationOwnershipLifecycleController,
+				checkedPruneCoordinator,
+			);
+		}
+		const blockAndDrainPeerReceives = async () => {
+			blockPeerReceiveAdmission();
 			await this.drainPeerReceiveHandlers(keyHash);
 			this.throwIfReplicationOwnershipLifecycleInactive(
 				replicationOwnershipLifecycleController,
@@ -7722,7 +7643,10 @@ export class SharedLog<
 			);
 			await blockAndDrainPeerReceives();
 			this.removePeerFromGidPeerHistory(keyHash);
-			this.cleanupPeerDisconnectTracking(keyHash);
+			this.cleanupPeerDisconnectTracking(
+				keyHash,
+				replicationOwnershipLifecycleController,
+			);
 			this.removeRepairFrontierTarget(keyHash, {
 				expectedJoinWarmupGeneration,
 			});
@@ -7735,178 +7659,192 @@ export class SharedLog<
 			}
 		};
 		let removed = false;
+		let removalCallCompleted = false;
 
 		// Replication-info updates already serialize per peer. Put the hash-wide
 		// removal on the same queue so a newer reset cannot be deleted underneath
 		// itself by an older unsubscribe callback.
-		await this.withReplicationInfoApplyQueue(keyHash, async () => {
-			this.throwIfReplicationOwnershipLifecycleInactive(
-				replicationOwnershipLifecycleController,
-			);
-			if (!ownsReplicationLifecycle()) {
-				return;
-			}
-			if (!ownsSubscriptionEpoch()) {
-				// A reconnect may supersede an unsubscribe before its destructive
-				// removal starts. Still retire the old connection's sync/request state
-				// in lane order so the reconnect barrier cannot inherit stale caches.
-				if (options?.cleanupIfSubscriptionSuperseded) {
-					await cleanupDisconnectedPeer();
-				}
-				return;
-			}
-			if (options?.shouldRemove && !options.shouldRemove()) {
-				return;
-			}
-			// Stop and drain admitted receives before taking the global range lane.
-			// User receive hooks may re-enter replicate()/unreplicate(); holding the
-			// range lane while waiting for such a hook would deadlock on our own tail.
-			await blockAndDrainPeerReceives();
-			if (
-				!ownsReplicationOwnershipLifecycle() ||
-				!ownsReplicationLifecycle() ||
-				!ownsSubscriptionEpoch() ||
-				(options?.shouldRemove && !options.shouldRemove())
-			) {
-				if (
-					!ownsSubscriptionEpoch() &&
-					options?.cleanupIfSubscriptionSuperseded
-				) {
-					await cleanupDisconnectedPeer();
-				}
-				return;
-			}
-			let wasReplicator = false;
-			let deleted: ReplicationRangeIndexable<R>[] = [];
-			let ownerHasRanges = false;
-			let mutationError: unknown;
-			const mutationCommitted = await this.withReplicationRangeMutationQueue(
-				async () => {
-					if (
-						!ownsReplicationOwnershipLifecycle() ||
-						!ownsReplicationLifecycle() ||
-						!ownsSubscriptionEpoch() ||
-						(options?.shouldRemove && !options.shouldRemove())
-					) {
-						return false;
-					}
-					wasReplicator = this.uniqueReplicators.has(keyHash);
-					deleted = (
-						await this.replicationIndex
-							.iterate({
-								query: { hash: keyHash },
-							})
-							.all()
-					).map((result) => result.value);
-					this.throwIfReplicationOwnershipLifecycleInactive(
-						replicationOwnershipLifecycleController,
-					);
-					// Liveness evidence can arrive while the scan is pending. Admission is
-					// already blocked and older receives are drained; revalidate immediately
-					// before destructive mutation.
-					if (
-						!ownsReplicationOwnershipLifecycle() ||
-						!ownsReplicationLifecycle() ||
-						!ownsSubscriptionEpoch() ||
-						(options?.shouldRemove && !options.shouldRemove())
-					) {
-						return false;
-					}
-					cancelExpectedJoinWarmupTarget();
-					const deletion = await this.deleteReplicationRangesCoherently(
-						deleted,
-						keyHash,
-					);
-					deleted = deletion.removed;
-					ownerHasRanges = deletion.ownerHasRanges;
-					mutationError = deletion.error;
-					return true;
-				},
-				replicationOwnershipLifecycleController,
-			);
-			this.throwIfReplicationOwnershipLifecycleInactive(
-				replicationOwnershipLifecycleController,
-			);
-			if (!mutationCommitted) {
-				if (
-					!ownsSubscriptionEpoch() &&
-					options?.cleanupIfSubscriptionSuperseded
-				) {
-					await cleanupDisconnectedPeer();
-				}
-				return;
-			}
-
-			if (options?.noEvent !== true && deleted.length > 0) {
-				const publicKey = toLocalPublicSignKey(key);
-				if (publicKey) {
-					this.events.dispatchEvent(
-						new CustomEvent<ReplicationChangeEvent>("replication:change", {
-							detail: { publicKey },
-						}),
-					);
-				} else {
-					throw new Error("Key was not a PublicSignKey");
-				}
-			}
-			const timestamp = BigInt(+new Date());
-			for (const x of deleted) {
-				this.replicationChangeDebounceFn.add({
-					range: x,
-					type: "removed",
-					timestamp,
-				});
-			}
-
-			const pendingMaturity = this.pendingMaturity.get(keyHash);
-			if (!ownerHasRanges && pendingMaturity) {
-				for (const [_k, v] of pendingMaturity) {
-					clearTimeout(v.timeout);
-				}
-				pendingMaturity.clear();
-				this.pendingMaturity.delete(keyHash);
-			}
-
-			// Keep local sync/prune state consistent even when a peer disappears
-			// through replication-info updates without a topic unsubscribe event.
-			await cleanupDisconnectedPeer();
-
-			if (!isMe) {
-				// Replication-info handlers release their receive lease before joining
-				// this lane. Fence every handler queued behind this successful removal,
-				// regardless of whether it came from liveness, startup pruning, or an
-				// unsubscribe transition.
-				this.advanceReplicationInfoRecoveryEpoch(keyHash);
-				this.rebalanceParticipationDebounced?.call();
-			}
-			removed = true;
-			if (!ownerHasRanges) {
-				options?.onRemoved?.({ wasReplicator });
-			}
-			let announcementError: unknown;
-			if (isMe && !ownerHasRanges) {
-				try {
-					await this.sendReplicationAnnouncement(
-						new AllReplicatingSegmentsMessage({ segments: [] }),
-						replicationOwnershipLifecycleController,
-					);
-				} catch (error) {
-					announcementError = error;
-				}
-			}
-			if (mutationError !== undefined && announcementError !== undefined) {
-				throw new AggregateError(
-					[mutationError, announcementError],
-					"Replication ranges were removed but their announcement failed",
+		try {
+			await this.withReplicationInfoApplyQueue(keyHash, async () => {
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					replicationOwnershipLifecycleController,
 				);
-			}
-			if (mutationError !== undefined) {
-				throw mutationError;
-			}
-			if (announcementError !== undefined) {
-				throw announcementError;
-			}
-		}).finally(() => {
+				if (!ownsReplicationLifecycle()) {
+					return;
+				}
+				if (!ownsSubscriptionEpoch()) {
+					// A reconnect may supersede an unsubscribe before its destructive
+					// removal starts. Still retire the old connection's sync/request state
+					// in lane order so the reconnect barrier cannot inherit stale caches.
+					if (options?.cleanupIfSubscriptionSuperseded) {
+						await cleanupDisconnectedPeer();
+					}
+					return;
+				}
+				if (options?.shouldRemove && !options.shouldRemove()) {
+					return;
+				}
+				// Stop and drain admitted receives before taking the global range lane.
+				// User receive hooks may re-enter replicate()/unreplicate(); holding the
+				// range lane while waiting for such a hook would deadlock on our own tail.
+				await blockAndDrainPeerReceives();
+				if (
+					!ownsReplicationOwnershipLifecycle() ||
+					!ownsReplicationLifecycle() ||
+					!ownsSubscriptionEpoch() ||
+					(options?.shouldRemove && !options.shouldRemove())
+				) {
+					if (
+						!ownsSubscriptionEpoch() &&
+						options?.cleanupIfSubscriptionSuperseded
+					) {
+						await cleanupDisconnectedPeer();
+					}
+					return;
+				}
+				let wasReplicator = false;
+				let deleted: ReplicationRangeIndexable<R>[] = [];
+				let ownerHasRanges = false;
+				let mutationError: unknown;
+				const mutationCommitted = await this.withReplicationRangeMutationQueue(
+					async () => {
+						if (
+							!ownsReplicationOwnershipLifecycle() ||
+							!ownsReplicationLifecycle() ||
+							!ownsSubscriptionEpoch() ||
+							(options?.shouldRemove && !options.shouldRemove())
+						) {
+							return false;
+						}
+						wasReplicator = this.uniqueReplicators.has(keyHash);
+						deleted = (
+							await this.replicationIndex
+								.iterate({
+									query: { hash: keyHash },
+								})
+								.all()
+						).map((result) => result.value);
+						this.throwIfReplicationOwnershipLifecycleInactive(
+							replicationOwnershipLifecycleController,
+						);
+						// Liveness evidence can arrive while the scan is pending. Admission is
+						// already blocked and older receives are drained; revalidate immediately
+						// before destructive mutation.
+						if (
+							!ownsReplicationOwnershipLifecycle() ||
+							!ownsReplicationLifecycle() ||
+							!ownsSubscriptionEpoch() ||
+							(options?.shouldRemove && !options.shouldRemove())
+						) {
+							return false;
+						}
+						cancelExpectedJoinWarmupTarget();
+						if (isSpeculativePeerRemoval) {
+							// The final liveness check committed this removal. Convert its
+							// temporary quorum fence into permanent generation revocation
+							// before mutating ownership.
+							this.cleanupCheckedPrunePeer(
+								keyHash,
+								replicationOwnershipLifecycleController,
+								checkedPruneCoordinator,
+							);
+						}
+						const deletion = await this.deleteReplicationRangesCoherently(
+							deleted,
+							keyHash,
+						);
+						deleted = deletion.removed;
+						ownerHasRanges = deletion.ownerHasRanges;
+						mutationError = deletion.error;
+						return true;
+					},
+					replicationOwnershipLifecycleController,
+				);
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					replicationOwnershipLifecycleController,
+				);
+				if (!mutationCommitted) {
+					if (
+						!ownsSubscriptionEpoch() &&
+						options?.cleanupIfSubscriptionSuperseded
+					) {
+						await cleanupDisconnectedPeer();
+					}
+					return;
+				}
+
+				if (options?.noEvent !== true && deleted.length > 0) {
+					const publicKey = toLocalPublicSignKey(key);
+					if (publicKey) {
+						this.events.dispatchEvent(
+							new CustomEvent<ReplicationChangeEvent>("replication:change", {
+								detail: { publicKey },
+							}),
+						);
+					} else {
+						throw new Error("Key was not a PublicSignKey");
+					}
+				}
+				const timestamp = BigInt(+new Date());
+				for (const x of deleted) {
+					this.replicationChangeDebounceFn.add({
+						range: x,
+						type: "removed",
+						timestamp,
+					});
+				}
+
+				const pendingMaturity = this.pendingMaturity.get(keyHash);
+				if (!ownerHasRanges && pendingMaturity) {
+					for (const [_k, v] of pendingMaturity) {
+						clearTimeout(v.timeout);
+					}
+					pendingMaturity.clear();
+					this.pendingMaturity.delete(keyHash);
+				}
+
+				// Keep local sync/prune state consistent even when a peer disappears
+				// through replication-info updates without a topic unsubscribe event.
+				await cleanupDisconnectedPeer();
+
+				if (!isMe) {
+					// Replication-info handlers release their receive lease before joining
+					// this lane. Fence every handler queued behind this successful removal,
+					// regardless of whether it came from liveness, startup pruning, or an
+					// unsubscribe transition.
+					this.advanceReplicationInfoRecoveryEpoch(keyHash);
+					this.rebalanceParticipationDebounced?.call();
+				}
+				removed = true;
+				if (!ownerHasRanges) {
+					options?.onRemoved?.({ wasReplicator });
+				}
+				let announcementError: unknown;
+				if (isMe && !ownerHasRanges) {
+					try {
+						await this.sendReplicationAnnouncement(
+							new AllReplicatingSegmentsMessage({ segments: [] }),
+							replicationOwnershipLifecycleController,
+						);
+					} catch (error) {
+						announcementError = error;
+					}
+				}
+				if (mutationError !== undefined && announcementError !== undefined) {
+					throw new AggregateError(
+						[mutationError, announcementError],
+						"Replication ranges were removed but their announcement failed",
+					);
+				}
+				if (mutationError !== undefined) {
+					throw mutationError;
+				}
+				if (announcementError !== undefined) {
+					throw announcementError;
+				}
+			});
+			removalCallCompleted = true;
+		} finally {
 			if (receiveAdmissionBlocked) {
 				const remaining = (receiveCleanupGateByPeer.get(keyHash) ?? 1) - 1;
 				if (remaining > 0) {
@@ -7915,7 +7853,26 @@ export class SharedLog<
 					receiveCleanupGateByPeer.delete(keyHash);
 				}
 			}
-		});
+			if (isSpeculativePeerRemoval) {
+				const cancelledByFreshActivity =
+					removalCallCompleted &&
+					!removed &&
+					ownsReplicationOwnershipLifecycle() &&
+					ownsReplicationLifecycle() &&
+					ownsSubscriptionEpoch() &&
+					options.shouldRemove?.() === false;
+				if (!cancelledByFreshActivity) {
+					// Only current-epoch authenticated liveness evidence may preserve
+					// this generation. Errors and lifecycle/epoch changes fail closed.
+					this.cleanupCheckedPrunePeer(
+						keyHash,
+						replicationOwnershipLifecycleController,
+						checkedPruneCoordinator,
+					);
+				}
+			}
+			releaseCheckedPrunePeerRemovalFence?.();
+		}
 		return removed;
 	}
 
@@ -10743,9 +10700,11 @@ export class SharedLog<
 			value: {
 				entry: CheckedPruneEntry<T, R>;
 				leaders: CheckedPruneLeaderMap;
+				workToken?: object;
 			};
 		},
 		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+		additionalCurrentCheck?: () => boolean,
 	): Promise<boolean> {
 		if (this.closed || !this.pruneDebouncedFn) {
 			return false;
@@ -10755,7 +10714,8 @@ export class SharedLog<
 		const isCurrent = () =>
 			this.isRepairLifecycleActive(ownershipLifecycleController) &&
 			this._checkedPrune === checkedPruneCoordinator &&
-			this.pruneDebouncedFn === pruneDebouncedFn;
+			this.pruneDebouncedFn === pruneDebouncedFn &&
+			(additionalCurrentCheck?.() ?? true);
 		if (!isCurrent()) {
 			return false;
 		}
@@ -10768,33 +10728,157 @@ export class SharedLog<
 				return false;
 			}
 		}
-		checkedPruneCoordinator.trackCandidate(
+		const workToken = checkedPruneCoordinator.trackCandidate(
 			args.key,
 			args.value.entry,
 			args.value.leaders,
 		);
+		args.value.workToken = workToken;
 		void pruneDebouncedFn.add(args).catch((error) => {
+			if (
+				checkedPruneCoordinator.isCandidateTokenCurrent(args.key, workToken)
+			) {
+				checkedPruneCoordinator.invalidateCandidateToken(args.key);
+			}
 			if (isCurrent() && !isNotStartedError(error as Error)) {
 				logger.error(error);
+				try {
+					this.scheduleCheckedPruneRetry(
+						args.value,
+						ownershipLifecycleController,
+					);
+				} catch {
+					checkedPruneCoordinator.clearRetry(args.key);
+				}
 			}
 		});
 		return true;
+	}
+
+	private deleteQueuedCheckedPrune(
+		hash: string,
+		checkedPruneCoordinator = this._checkedPrune,
+	) {
+		this.pruneDebouncedFn.delete(hash);
+		checkedPruneCoordinator.invalidateCandidateToken(hash);
 	}
 
 	private async cancelCheckedPruneForLocalLeader(
 		hash: string,
 		options?: { preserveRetry?: boolean },
 	) {
-		this.pruneDebouncedFn.delete(hash);
+		this.deleteQueuedCheckedPrune(hash);
 		const pendingDelete = this._checkedPrune.getPendingDelete(hash);
-		this._checkedPrune.markCancelled(hash, {
-			preserveRetry: options?.preserveRetry,
-		});
+		if (pendingDelete) {
+			this._checkedPrune.markCancelled(hash, pendingDelete, {
+				preserveRetry: options?.preserveRetry,
+			});
+		} else {
+			this._checkedPrune.markCancelled(hash, {
+				preserveRetry: options?.preserveRetry,
+			});
+		}
 		await pendingDelete?.reject(new Error("Failed to delete, is leader again"));
+	}
+
+	private rearmCheckedPruneAfterTemporaryReceive(hash: string) {
+		const candidate = this._checkedPrune.getRestartCandidate(hash);
+		void this.cancelCheckedPruneForLocalLeader(hash, {
+			preserveRetry: true,
+		}).catch(() => {});
+		if (!candidate) {
+			// New receive work is reconsidered only after the lower-log join proves
+			// the hash was admitted. pruneJoinedEntriesNoLongerLed owns that path.
+			return;
+		}
+		try {
+			this.scheduleCheckedPruneRetry(candidate);
+		} catch {
+			this._checkedPrune.clearRetry(hash);
+		}
 	}
 
 	private hasActiveCheckedPruneWork(hash: string) {
 		return this._checkedPrune.hasActiveWork(hash);
+	}
+
+	private async revalidateCheckedPruneGrantLocalLeaders(
+		hashes: string[],
+		prunePeer: string,
+		ownershipLifecycleController: AbortController,
+	) {
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
+		const localLeaderHashes = new Set<string>();
+		const unresolvedHashes = new Set(hashes);
+		const nativePlanner = this._nativeBackbone ?? this._nativeRangePlanner;
+		const nativeEntryMetadata = this.getNativeLogEntryMetadataBatch(hashes);
+
+		if (nativePlanner && !this.hasCustomFindLeaders() && nativeEntryMetadata) {
+			const nativeItems: Array<{
+				hash: string;
+				gid: string;
+				replicas: number;
+			}> = [];
+			for (let index = 0; index < hashes.length; index++) {
+				const entry = nativeEntryMetadata[index];
+				if (!entry) {
+					continue;
+				}
+				this.removePeerFromGidPeerHistory(prunePeer, entry.gid);
+				nativeItems.push({
+					hash: hashes[index]!,
+					gid: entry.gid,
+					replicas:
+						entry.replicas ??
+						decodeReplicas({
+							meta: { data: entry.data },
+						}).getValue(this),
+				});
+			}
+			if (nativeItems.length > 0) {
+				const context = await this.createLeaderSelectionContext(
+					undefined,
+					ownershipLifecycleController,
+				);
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
+				const plans = nativePlanner.planLeadersForGidsBatch(
+					nativeItems.map(({ gid, replicas }) => ({ gid, replicas })),
+					this.createNativeLeaderOptions(context),
+				);
+				for (let index = 0; index < nativeItems.length; index++) {
+					const item = nativeItems[index]!;
+					unresolvedHashes.delete(item.hash);
+					if (plans[index]?.leaders.has(context.selfHash)) {
+						localLeaderHashes.add(item.hash);
+					}
+				}
+			}
+		}
+
+		for (const hash of unresolvedHashes) {
+			const indexedEntry = await this.log.entryIndex.getShallow(hash);
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+			if (!indexedEntry) {
+				continue;
+			}
+			this.removePeerFromGidPeerHistory(prunePeer, indexedEntry.value.meta.gid);
+			const plan = await this.planEntryLeaders(
+				indexedEntry.value,
+				decodeReplicas(indexedEntry.value).getValue(this),
+				{ persist: false },
+				ownershipLifecycleController,
+			);
+			if (plan.isLeader) {
+				localLeaderHashes.add(hash);
+			}
+		}
+		return localLeaderHashes;
 	}
 
 	private async revalidateCheckedPruneOwnership(args: {
@@ -10827,7 +10911,7 @@ export class SharedLog<
 		};
 		throwIfInactive();
 		const selfHash = this.node.identity.publicKey.hashcode();
-		if (args.leaders.has(selfHash)) {
+		if (!args.requireFreshLeaderDecision && args.leaders.has(selfHash)) {
 			if (args.selfReplicating === false) {
 				return { leaders: args.leaders, localLeader: false };
 			}
@@ -10894,6 +10978,27 @@ export class SharedLog<
 
 		throwIfInactive();
 		return { leaders: args.leaders, localLeader: false };
+	}
+
+	private async prunePromotedCheckedPruneParents(
+		parentHashes: Iterable<string>,
+		ownershipLifecycleController: AbortController,
+	) {
+		const parents: ShallowOrFullEntry<T>[] = [];
+		for (const hash of new Set(parentHashes)) {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+			const indexed = await this.log.entryIndex.getShallow(hash);
+			if (indexed?.value.head === true) {
+				parents.push(indexed.value);
+			}
+		}
+		await this.pruneJoinedEntriesNoLongerLed(
+			parents,
+			undefined,
+			ownershipLifecycleController,
+		);
 	}
 
 	private async pruneJoinedEntriesNoLongerLed(
@@ -11032,6 +11137,10 @@ export class SharedLog<
 			}
 
 			if (leaders.size === 0) {
+				this.scheduleCheckedPruneRetry(
+					{ entry, leaders },
+					ownershipLifecycleController,
+				);
 				continue;
 			}
 
@@ -11046,7 +11155,6 @@ export class SharedLog<
 				ownershipLifecycleController,
 			);
 			enqueuedPrune++;
-			this.responseToPruneDebouncedFn.delete(entry.hash);
 		}
 		emitSyncProfileDuration(options?.profile, loopStartedAt, {
 			name: "sharedLog.receive.checkedPrune.loop",
@@ -11108,6 +11216,10 @@ export class SharedLog<
 					}
 
 					if (leaders.size === 0) {
+						this.scheduleCheckedPruneRetry(
+							{ entry: entryReplicated, leaders },
+							ownershipLifecycleController,
+						);
 						continue;
 					}
 
@@ -11122,7 +11234,6 @@ export class SharedLog<
 					this.throwIfReplicationOwnershipLifecycleInactive(
 						ownershipLifecycleController,
 					);
-					this.responseToPruneDebouncedFn.delete(entryReplicated.hash);
 				}
 			}
 		} finally {
@@ -11189,6 +11300,10 @@ export class SharedLog<
 			}
 
 			if (leaders.size === 0) {
+				this.scheduleCheckedPruneRetry(
+					{ entry: head, leaders },
+					ownershipLifecycleController,
+				);
 				continue;
 			}
 
@@ -11203,7 +11318,6 @@ export class SharedLog<
 			this.throwIfReplicationOwnershipLifecycleInactive(
 				ownershipLifecycleController,
 			);
-			this.responseToPruneDebouncedFn.delete(head.hash);
 		}
 
 		if (enqueuedPrune) {
@@ -11288,6 +11402,67 @@ export class SharedLog<
 		this._checkedPrune.clearRetry(hash);
 	}
 
+	private clearCheckedPruneAuditTimer() {
+		if (this._checkedPruneAuditTimer) {
+			clearTimeout(this._checkedPruneAuditTimer);
+			this._checkedPruneAuditTimer = undefined;
+		}
+	}
+
+	private scheduleCheckedPruneAudit(
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	) {
+		const checkedPruneCoordinator = this._checkedPrune;
+		const isCurrent = () =>
+			this.isRepairLifecycleActive(ownershipLifecycleController) &&
+			this._checkedPrune === checkedPruneCoordinator;
+		if (!isCurrent() || this._checkedPruneAuditTimer) {
+			return;
+		}
+
+		const timer = setTimeout(() => {
+			if (this._checkedPruneAuditTimer !== timer) {
+				return;
+			}
+			this._checkedPruneAuditTimer = undefined;
+			if (!isCurrent()) {
+				return;
+			}
+
+			const eligible = [...checkedPruneCoordinator.retries].filter(
+				([hash, state]) =>
+					!state.timer &&
+					state.attempts >= CHECKED_PRUNE_RETRY_MAX_ATTEMPTS &&
+					!checkedPruneCoordinator.hasPendingDelete(hash) &&
+					!checkedPruneCoordinator.hasCandidate(hash) &&
+					!checkedPruneCoordinator.hasRestartReservation(hash),
+			);
+			const batch = eligible.slice(0, CHECKED_PRUNE_AUDIT_BATCH_SIZE);
+			for (const [hash, state] of batch) {
+				// Rotate serviced hashes behind the unserviced cohort. Otherwise an
+				// unreachable first batch could monopolize every audit interval.
+				checkedPruneCoordinator.retries.delete(hash);
+
+				// The fast budget is intentionally not reset by remote traffic.
+				// A low-rate, coalesced audit grants one final-budget attempt at a
+				// time so a quiet topology can still converge without one timer per
+				// retained hash.
+				state.attempts = CHECKED_PRUNE_RETRY_MAX_ATTEMPTS - 1;
+				checkedPruneCoordinator.setRetry(hash, state);
+				this.scheduleCheckedPruneRetry(
+					{ entry: state.entry, leaders: state.leaders },
+					ownershipLifecycleController,
+				);
+			}
+
+			if (eligible.length > batch.length) {
+				this.scheduleCheckedPruneAudit(ownershipLifecycleController);
+			}
+		}, CHECKED_PRUNE_AUDIT_INTERVAL_MS);
+		this._checkedPruneAuditTimer = timer;
+		timer.unref?.();
+	}
+
 	private scheduleCheckedPruneRetry(
 		args: {
 			entry: CheckedPruneEntry<T, R>;
@@ -11315,8 +11490,11 @@ export class SharedLog<
 
 		if (state.timer) return;
 		if (state.attempts >= CHECKED_PRUNE_RETRY_MAX_ATTEMPTS) {
-			// Avoid unbounded background retries; a new replication-change event can
-			// always re-enqueue pruning with fresh leader info.
+			// Fast per-hash retries are bounded. Exhausted obligations move to one
+			// coalesced low-rate audit instead of being forgotten while the topology
+			// is otherwise quiet.
+			checkedPruneCoordinator.setRetry(hash, state);
+			this.scheduleCheckedPruneAudit(ownershipLifecycleController);
 			return;
 		}
 
@@ -11328,14 +11506,20 @@ export class SharedLog<
 		);
 
 		state.attempts = attempt;
-		state.timer = setTimeout(() => {
+		const timer = setTimeout(() => {
 			const run = async () => {
 				const st = checkedPruneCoordinator.getRetry(hash);
-				if (st) st.timer = undefined;
-				if (!isCurrent()) return;
+				if (st !== state || state.timer !== timer || !isCurrent()) {
+					return;
+				}
+				state.timer = undefined;
+				const isExactAttempt = () =>
+					isCurrent() &&
+					checkedPruneCoordinator.getRetry(hash) === state &&
+					state.timer === undefined;
 				if (checkedPruneCoordinator.hasPendingDelete(hash)) return;
-				const retryEntry = st?.entry ?? args.entry;
-				const retryLeaders = st?.leaders ?? args.leaders;
+				const retryEntry = state.entry;
+				const retryLeaders = state.leaders;
 
 				let leadersMap: CheckedPruneLeaderMap | undefined;
 				try {
@@ -11347,115 +11531,69 @@ export class SharedLog<
 						ownershipLifecycleController,
 					);
 				} catch {
-					if (!isCurrent()) {
+					if (!isExactAttempt()) {
 						return;
 					}
 					// A current-generation planning failure is best-effort; fall back
 					// to the last confirmed leader set below.
 				}
-				if (!isCurrent()) return;
+				if (!isExactAttempt()) return;
 
 				if (!leadersMap || leadersMap.size === 0) {
 					leadersMap = this.checkedPruneLeadersToMap(retryLeaders);
 				}
+				if (leadersMap.size === 0) {
+					this.scheduleCheckedPruneRetry(
+						{ entry: retryEntry, leaders: retryLeaders },
+						ownershipLifecycleController,
+					);
+					return;
+				}
 
-				const leadersForRetry =
-					leadersMap ?? new Map<string, { intersecting: boolean }>();
-				await this.pruneDebouncedFnAddIfNotKeeping(
+				const leadersForRetry = leadersMap;
+				const enqueued = await this.pruneDebouncedFnAddIfNotKeeping(
 					{
 						key: hash,
 						value: { entry: retryEntry, leaders: leadersForRetry },
 					},
 					ownershipLifecycleController,
+					() =>
+						isExactAttempt() && !checkedPruneCoordinator.hasPendingDelete(hash),
 				);
+				if (
+					!enqueued &&
+					isExactAttempt() &&
+					!checkedPruneCoordinator.hasPendingDelete(hash)
+				) {
+					// A keep policy is terminal for this background prune. Do not
+					// retain a retry record with neither a timer nor pending work.
+					checkedPruneCoordinator.clearRetry(hash);
+				}
 			};
 			void run().catch((error) => {
 				if (isCurrent() && !isNotStartedError(error as Error)) {
 					logger.error(error);
+					const retry = checkedPruneCoordinator.getRetry(hash);
+					if (
+						retry === state &&
+						!retry.timer &&
+						!checkedPruneCoordinator.hasPendingDelete(hash)
+					) {
+						try {
+							this.scheduleCheckedPruneRetry(
+								{ entry: retry.entry, leaders: retry.leaders },
+								ownershipLifecycleController,
+							);
+						} catch {
+							checkedPruneCoordinator.clearRetry(hash);
+						}
+					}
 				}
 			});
 		}, delayMs);
-		state.timer.unref?.();
+		state.timer = timer;
+		timer.unref?.();
 		checkedPruneCoordinator.setRetry(hash, state);
-	}
-
-	private async recoverCheckedPruneFromLateResponses(
-		hashes: string[],
-		publicKeyHash: string,
-	) {
-		if (this.closed) return;
-		const selfHash = this.node.identity.publicKey.hashcode();
-		const toPrune = new Map<
-			string,
-			{
-				entry: CheckedPruneEntry<T, R>;
-				leaders: CheckedPruneLeaderMap;
-			}
-		>();
-		const responseStillApplies: string[] = [];
-
-		for (const hash of hashes) {
-			if (this.closed) {
-				break;
-			}
-			if (this._checkedPrune.hasPendingDelete(hash)) {
-				continue;
-			}
-			const retry = this._checkedPrune.clearRetryTimer(hash);
-			if (!retry) {
-				continue;
-			}
-
-			const entry = retry.entry;
-			let leaders = this.checkedPruneLeadersToMap(retry.leaders);
-			try {
-				const currentLeaders = await this.findLeadersFromEntry(
-					entry,
-					decodeReplicas(entry).getValue(this),
-					{ roleAge: 0 },
-				);
-				if (currentLeaders.size > 0) {
-					leaders = currentLeaders;
-				}
-			} catch {
-				// Best-effort only; the stored retry leaders came from a previous
-				// checked-prune decision for this exact entry.
-			}
-
-			if (leaders.has(selfHash)) {
-				await this.cancelCheckedPruneForLocalLeader(hash);
-				continue;
-			}
-			if (leaders.size === 0) {
-				continue;
-			}
-
-			toPrune.set(hash, { entry, leaders });
-			if (leaders.has(publicKeyHash)) {
-				responseStillApplies.push(hash);
-			}
-		}
-
-		if (toPrune.size === 0) {
-			return;
-		}
-
-		const pruneTasks = this.prune(toPrune);
-		const confirmationTasks: Promise<void>[] = [];
-		for (const hash of responseStillApplies) {
-			const pendingDelete = this._checkedPrune.getPendingDelete(hash);
-			if (pendingDelete) {
-				confirmationTasks.push(
-					Promise.resolve(pendingDelete.resolve(publicKeyHash)),
-				);
-			}
-		}
-		// The restarted prune session owns its own bounded timeout and revalidates
-		// before deletion. Only the peer-derived confirmations must remain inside
-		// this receive lease; waiting for the whole prune session could stall close
-		// or disconnect until its background timeout.
-		void Promise.allSettled(pruneTasks);
-		await Promise.allSettled(confirmationTasks);
 	}
 
 	async append(
@@ -15588,6 +15726,7 @@ export class SharedLog<
 		);
 		this._respondToIHaveTimeout = options?.respondToIHaveTimeout ?? 2e4;
 		this._checkedPrune = new CheckedPruneCoordinator<T, R>();
+		this._checkedPruneAuditTimer = undefined;
 		this._admittedPruneRemoves = new Set();
 		this._pendingIHave = new Map();
 		this._pendingIHaveCallbacks = new Set();
@@ -15948,13 +16087,26 @@ export class SharedLog<
 						{
 							entry: CheckedPruneEntry<T, R>;
 							leaders: CheckedPruneLeaderMap;
+							workToken?: object;
 						}
 					>();
+					const isCandidateCurrent = (
+						hash: string,
+						value: { workToken?: object },
+					) =>
+						value.workToken != null &&
+						checkedPruneCoordinator.isCandidateTokenCurrent(
+							hash,
+							value.workToken,
+						);
 					const selfReplicating = await this.isReplicating();
 					if (!isPruneDebounceCurrent()) {
 						return;
 					}
 					for (const [hash, value] of map) {
+						if (!isCandidateCurrent(hash, value)) {
+							continue;
+						}
 						const checkedPruneLeaders =
 							await this.revalidateCheckedPruneOwnership({
 								hash,
@@ -15967,15 +16119,25 @@ export class SharedLog<
 						if (!isPruneDebounceCurrent()) {
 							return;
 						}
+						if (!isCandidateCurrent(hash, value)) {
+							continue;
+						}
 						if (checkedPruneLeaders.localLeader) {
-							const preserveRetry = checkedPruneCoordinator.hasRetry(hash);
+							const retry = checkedPruneCoordinator.getRetry(hash);
 							await this.cancelCheckedPruneForLocalLeader(hash, {
-								preserveRetry,
+								preserveRetry: retry != null,
 							});
 							if (!isPruneDebounceCurrent()) {
 								return;
 							}
-							if (preserveRetry) {
+							if (retry) {
+								// A delayed confirmation of local ownership is terminal.
+								// Future ownership mutations will enqueue fresh work.
+								checkedPruneCoordinator.clearRetry(hash);
+							} else {
+								// A first positive view can be a transient membership
+								// snapshot. Confirm it once after the normal retry delay
+								// before forgetting the prune obligation.
 								this.scheduleCheckedPruneRetry(
 									{
 										entry: value.entry,
@@ -15992,16 +16154,43 @@ export class SharedLog<
 						});
 					}
 					if (current.size > 0 && isPruneDebounceCurrent()) {
+						for (const [hash, value] of current) {
+							if (!isCandidateCurrent(hash, value)) {
+								current.delete(hash);
+							}
+						}
 						this.prune(current, undefined, pruneOwnershipLifecycleController);
 					}
 				} catch (error) {
 					if (isPruneDebounceCurrent() && !isNotStartedError(error as Error)) {
 						logger.error(error);
+						for (const [hash, value] of map) {
+							if (
+								!isPruneDebounceCurrent() ||
+								value.workToken == null ||
+								!checkedPruneCoordinator.isCandidateTokenCurrent(
+									hash,
+									value.workToken,
+								) ||
+								checkedPruneCoordinator.hasPendingDelete(hash)
+							) {
+								continue;
+							}
+							try {
+								this.scheduleCheckedPruneRetry(
+									value,
+									pruneOwnershipLifecycleController,
+								);
+							} catch {
+								checkedPruneCoordinator.clearRetry(hash);
+							}
+						}
 					}
 				}
 			},
 			PRUNE_DEBOUNCE_INTERVAL,
 			(into, from) => {
+				into.workToken = from.workToken;
 				for (const [k, v] of from.leaders) {
 					if (!into.leaders.has(k)) {
 						into.leaders.set(k, v);
@@ -16010,63 +16199,6 @@ export class SharedLog<
 			},
 		);
 		this.pruneDebouncedFn = pruneDebouncedFn;
-
-		this.responseToPruneDebouncedFn = debounceAccumulator<
-			string,
-			{
-				hashes: string[];
-				peers: string[] | Set<string>;
-			},
-			Map<string, Set<string>>
-		>(
-			(result) => {
-				let allRequestingPeers = new Set<string>();
-				let hashes: string[] = [];
-				for (const [hash, requestingPeers] of result) {
-					for (const peer of requestingPeers) {
-						allRequestingPeers.add(peer);
-					}
-					hashes.push(hash);
-				}
-
-				if (hashes.length > 0 && allRequestingPeers.size > 0) {
-					this.rpc
-						.send(new ResponseIPrune({ hashes }), {
-							mode: new AcknowledgeDelivery({
-								to: allRequestingPeers,
-								redundancy: 1,
-							}),
-							priority: CONVERGENCE_MESSAGE_PRIORITY,
-						})
-						.catch(() => {});
-				}
-			},
-			() => {
-				let accumulator = new Map<string, Set<string>>();
-				return {
-					add: (props: { hashes: string[]; peers: string[] | Set<string> }) => {
-						for (const hash of props.hashes) {
-							let prev = accumulator.get(hash);
-							if (!prev) {
-								prev = new Set<string>();
-								accumulator.set(hash, prev);
-							}
-							for (const peer of props.peers) {
-								prev.add(peer);
-							}
-						}
-					},
-					delete: (hash: string) => {
-						accumulator.delete(hash);
-					},
-					size: () => accumulator.size,
-					clear: () => accumulator.clear(),
-					value: accumulator,
-					has: (hash: string) => accumulator.has(hash),
-				};
-			},
-			PRUNE_DEBOUNCE_INTERVAL,
-		);
 
 		await remoteBlocksStartPromise;
 		// Failed native prepares can leave content-addressed bytes behind. Recovery
@@ -17217,13 +17349,65 @@ export class SharedLog<
 		return this._replicatorLivenessTargets;
 	}
 
-	private cleanupPeerDisconnectTracking(peerHash: string) {
+	private cleanupCheckedPrunePeer(
+		peerHash: string,
+		ownershipLifecycleController: AbortController,
+		checkedPruneCoordinator = this._checkedPrune,
+	) {
+		const invalidated = checkedPruneCoordinator.cleanupPeer(peerHash);
+		for (const generation of invalidated) {
+			const canRetry =
+				generation.pending.retryOnInvalidation === true &&
+				this._checkedPrune === checkedPruneCoordinator &&
+				this.isRepairLifecycleActive(ownershipLifecycleController);
+			try {
+				void generation.pending.reject(
+					new Error(
+						`Checked prune generation invalidated by peer cleanup: ${peerHash}`,
+					),
+					{ preserveRetry: canRetry },
+				);
+			} catch {
+				// State was already invalidated above; retry admission is independent
+				// from a synchronous observer error.
+			}
+			if (
+				canRetry &&
+				this._checkedPrune === checkedPruneCoordinator &&
+				this.isRepairLifecycleActive(ownershipLifecycleController) &&
+				!checkedPruneCoordinator.hasPendingDelete(generation.hash)
+			) {
+				try {
+					this.scheduleCheckedPruneRetry(
+						{
+							entry: generation.entry,
+							leaders: generation.leaders,
+						},
+						ownershipLifecycleController,
+					);
+				} catch {
+					// Peer cleanup is the safety boundary. A best-effort background
+					// retry must not abort the ownership removal that invalidated it.
+					checkedPruneCoordinator.clearRetry(generation.hash);
+				}
+			}
+		}
+	}
+
+	private cleanupPeerDisconnectTracking(
+		peerHash: string,
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	) {
 		this.cancelReplicationInfoRequests(peerHash);
 		this._replicatorLivenessFailures.delete(peerHash);
 		this._replicatorLastActivityAt.delete(peerHash);
 		this._peerSyncCapabilities.delete(peerHash);
 		this.cleanupPendingIHavePeer(peerHash);
-		this._checkedPrune.cleanupPeer(peerHash);
+		this.cleanupCheckedPrunePeer(
+			peerHash,
+			ownershipLifecycleController,
+			this._checkedPrune,
+		);
 	}
 
 	private cleanupPendingIHavePeer(peerHash: string) {
@@ -18429,6 +18613,7 @@ export class SharedLog<
 		);
 		captureSync(() => {
 			this.cancelAllJoinWarmupTargets();
+			this.clearCheckedPruneAuditTimer();
 			for (const timer of this._repairRetryTimers ?? []) clearTimeout(timer);
 			this._repairRetryTimers?.clear();
 			this._recentRepairDispatch?.clear();
@@ -18495,7 +18680,6 @@ export class SharedLog<
 		captureSync(() => this.rebalanceParticipationDebounced?.close());
 		captureSync(() => this.replicationChangeDebounceFn?.close?.());
 		captureSync(() => this.pruneDebouncedFn?.close?.());
-		captureSync(() => this.responseToPruneDebouncedFn?.close?.());
 		this.pruneDebouncedFn = undefined as any;
 		this.rebalanceParticipationDebounced = undefined;
 		if (!preserveDropRetryResources) {
@@ -18600,7 +18784,6 @@ export class SharedLog<
 				this.rebalanceParticipationDebounced?.close();
 				this.replicationChangeDebounceFn?.close?.();
 				this.pruneDebouncedFn?.close?.();
-				this.responseToPruneDebouncedFn?.close?.();
 
 				// Ensure the "I'm leaving" replication reset is actually published before
 				// the RPC child program closes and unsubscribes from its topic. If we fire
@@ -18729,7 +18912,6 @@ export class SharedLog<
 				this.rebalanceParticipationDebounced?.close();
 				this.replicationChangeDebounceFn?.close?.();
 				this.pruneDebouncedFn?.close?.();
-				this.responseToPruneDebouncedFn?.close?.();
 
 				const abort = new AbortController();
 				const abortTimer = setTimeout(() => {
@@ -20062,13 +20244,23 @@ export class SharedLog<
 								if (isReplicating && group.isLeader === true) {
 									immediateReplicatingLeaderPlanHits++;
 								}
+								const temporaryRepairKeep =
+									group.isLeader !== true &&
+									isRepairHint &&
+									(group.fromIsLeader ?? false);
 								if (group.fromIsLeader) {
 									this.addPeersToGidPeerHistory(group.gid, contextFromHashes);
 								}
 								for (const entry of group.entries) {
 									const hash = getExchangeHeadHash(entry);
 									cleanupHashes.push(hash);
-									this.pruneDebouncedFn.delete(hash);
+									if (temporaryRepairKeep) {
+										this.rearmCheckedPruneAfterTemporaryReceive(hash);
+									} else {
+										void this.cancelCheckedPruneForLocalLeader(hash).catch(
+											() => {},
+										);
+									}
 									toMerge.push(entry);
 									toPersist.push(getReceiveHeadShallowOrEntry(entry));
 								}
@@ -20090,6 +20282,8 @@ export class SharedLog<
 								const fromIsLeader = group.fromIsLeader ?? false;
 								const keepAsLeader =
 									group.isLeader === true || (isRepairHint && fromIsLeader);
+								const temporaryRepairKeep =
+									group.isLeader !== true && isRepairHint && fromIsLeader;
 								let maybeDelete: EntryWithRefs<any>[][] | undefined;
 								const toMerge: EntryWithRefs<any>[] = [];
 								const toPersist: ShallowOrFullEntry<any>[] = [];
@@ -20099,7 +20293,13 @@ export class SharedLog<
 								if (keepAsLeader) {
 									for (const entry of group.entries) {
 										const hash = getExchangeHeadHash(entry);
-										this.pruneDebouncedFn.delete(hash);
+										if (temporaryRepairKeep) {
+											this.rearmCheckedPruneAfterTemporaryReceive(hash);
+										} else {
+											void this.cancelCheckedPruneForLocalLeader(hash).catch(
+												() => {},
+											);
+										}
 										this.removePruneRequestSent(hash);
 										this._checkedPrune.clearConfirmedReplicators(hash);
 										toMerge.push(entry);
@@ -20220,7 +20420,13 @@ export class SharedLog<
 								if (keepAsLeader) {
 									for (const entry of entries) {
 										const hash = getExchangeHeadHash(entry);
-										this.pruneDebouncedFn.delete(hash);
+										if (acceptsTargetedRepair && !isLeader) {
+											this.rearmCheckedPruneAfterTemporaryReceive(hash);
+										} else {
+											void this.cancelCheckedPruneForLocalLeader(hash).catch(
+												() => {},
+											);
+										}
 										this.removePruneRequestSent(hash);
 										this._checkedPrune.clearConfirmedReplicators(hash);
 									}
@@ -20243,6 +20449,11 @@ export class SharedLog<
 											: keepResult;
 									}
 									if (shouldKeep) {
+										if (!keepAsLeader) {
+											void this.cancelCheckedPruneForLocalLeader(
+												getExchangeHeadHash(entry),
+											).catch(() => {});
+										}
 										toMerge.push(entry);
 										toPersist.push(getReceiveHeadShallowOrEntry(entry));
 									} else if (entry.gidRefrences.length > 0) {
@@ -20777,449 +20988,153 @@ export class SharedLog<
 						}
 					}
 				}
-			} else if (msg instanceof RequestIPrune) {
+			} else if (msg instanceof RequestIPruneV2) {
 				const requestPruneStartedAt = syncProfileStart(syncProfile);
 				const from = context.from.hashcode();
+				const requestsByHash = new Map<string, Uint8Array>();
+				for (const request of msg.requests) {
+					if (requestsByHash.has(request.hash)) {
+						return;
+					}
+					requestsByHash.set(request.hash, request.requestId);
+				}
+				const hashes = [...requestsByHash.keys()];
+				if (hashes.length === 0) {
+					return;
+				}
+
 				const coordinatorCleanupStartedAt = syncProfileStart(syncProfile);
-				this.removeEntriesKnownByPeer(msg.hashes, from);
-				this.removePruneRequestsSent(msg.hashes, from);
-				this._checkedPrune.removeConfirmedReplicators(msg.hashes, from);
+				this.removeEntriesKnownByPeer(hashes, from);
+				// A prune request means the sender is preparing to stop retaining these
+				// hashes. Any receipt it gave our current generation is therefore stale,
+				// even when we cannot grant its reciprocal request.
+				this.removePruneRequestsSent(hashes, from);
 				if (syncProfile) {
 					emitSyncProfileDuration(syncProfile, coordinatorCleanupStartedAt, {
 						name: "sharedLog.receive.requestPrune.coordinatorCleanup",
 						component: "shared-log",
-						entries: msg.hashes.length,
+						entries: hashes.length,
 						messages: 1,
-						details: { hashes: msg.hashes.length },
-					});
-				}
-				let nativeEntryMetadata:
-					| Array<
-							| { gid: string; data?: Uint8Array; replicas?: number }
-							| undefined
-							| null
-					  >
-					| undefined;
-				let presentBlocks: boolean[] | undefined;
-				const nativeBackbonePlanStartedAt = syncProfileStart(syncProfile);
-				let nativeLeaderHints =
-					await this.planCurrentNativeBackboneRequestPruneLeaderHints(
-						msg.hashes,
-						from,
-					);
-				if (nativeLeaderHints) {
-					if (syncProfile) {
-						emitSyncProfileDuration(syncProfile, nativeBackbonePlanStartedAt, {
-							name: "sharedLog.receive.requestPrune.nativeBackbonePlan",
-							component: "shared-log",
-							entries: msg.hashes.length,
-							messages: 1,
-							details: {
-								nativeEntries:
-									(nativeLeaderHints.nativeAllConfirmed
-										? msg.hashes.length
-										: undefined) ??
-									nativeLeaderHints.nativeEntries?.size ??
-									countPresentValues(
-										nativeLeaderHints.nativeEntryGids ??
-											nativeLeaderHints.nativeEntryMetadata,
-									) ??
-									0,
-								presentBlocks:
-									(nativeLeaderHints.nativeAllConfirmed
-										? msg.hashes.length
-										: undefined) ??
-									nativeLeaderHints.presentBlockHashes?.size ??
-									countTruthyValues(nativeLeaderHints.presentBlocks) ??
-									0,
-								localLeaders: nativeLeaderHints.nativeAllConfirmed
-									? msg.hashes.length
-									: nativeLeaderHints.localLeaderHashes.size ||
-										countTruthyValues(nativeLeaderHints.localLeaderFlags) ||
-										0,
-								plannedEntries: nativeLeaderHints.nativeAllConfirmed
-									? msg.hashes.length
-									: nativeLeaderHints.replicaCounts.size ||
-										countPositiveValues(
-											nativeLeaderHints.replicaCountsByIndex,
-										) ||
-										0,
-								peerHistoryGids: nativeLeaderHints.peerHistoryGids.length,
-							},
-						});
-					}
-				} else {
-					const metadataStartedAt = syncProfileStart(syncProfile);
-					nativeEntryMetadata = this.getNativeLogEntryMetadataBatch(msg.hashes);
-					if (syncProfile) {
-						emitSyncProfileDuration(syncProfile, metadataStartedAt, {
-							name: "sharedLog.receive.requestPrune.nativeMetadata",
-							component: "shared-log",
-							entries: msg.hashes.length,
-							messages: 1,
-							details: {
-								nativeEntries:
-									nativeEntryMetadata?.reduce(
-										(sum, entry) => sum + (entry ? 1 : 0),
-										0,
-									) ?? 0,
-							},
-						});
-					}
-					const blockHasManyStartedAt = syncProfileStart(syncProfile);
-					presentBlocks = await this.log.blocks.hasMany?.(msg.hashes);
-					if (syncProfile) {
-						emitSyncProfileDuration(syncProfile, blockHasManyStartedAt, {
-							name: "sharedLog.receive.requestPrune.blockHasMany",
-							component: "shared-log",
-							entries: msg.hashes.length,
-							messages: 1,
-							details: {
-								batched: presentBlocks != null,
-								presentBlocks:
-									presentBlocks?.reduce(
-										(sum, present) => sum + (present ? 1 : 0),
-										0,
-									) ?? 0,
-							},
-						});
-					}
-					const nativeLeaderPlanStartedAt = syncProfileStart(syncProfile);
-					nativeLeaderHints =
-						await this.planCurrentNativeRequestPruneLeaderHints({
-							hashes: msg.hashes,
-							nativeEntryMetadata,
-							presentBlocks,
-						});
-					if (syncProfile) {
-						emitSyncProfileDuration(syncProfile, nativeLeaderPlanStartedAt, {
-							name: "sharedLog.receive.requestPrune.nativeLeaderPlan",
-							component: "shared-log",
-							entries: msg.hashes.length,
-							messages: 1,
-							details: {
-								localLeaders: nativeLeaderHints.localLeaderHashes.size,
-								plannedEntries: nativeLeaderHints.replicaCounts.size,
-								peerHistoryGids: nativeLeaderHints.peerHistoryGids.length,
-							},
-						});
-					}
-				}
-				const gidCleanupStartedAt = syncProfileStart(syncProfile);
-				this.removePeerFromGidPeerHistoryBatch(
-					from,
-					nativeLeaderHints.peerHistoryGids,
-					{
-						skipNativeBackbone:
-							nativeLeaderHints.nativeBackbonePeerHistoryCleaned === true,
-					},
-				);
-				if (syncProfile) {
-					emitSyncProfileDuration(syncProfile, gidCleanupStartedAt, {
-						name: "sharedLog.receive.requestPrune.gidCleanup",
-						component: "shared-log",
-						entries: nativeLeaderHints.peerHistoryGids.length,
-						messages: 1,
+						details: { hashes: hashes.length },
 					});
 				}
 
-				const requestPruneLoopStartedAt = syncProfileStart(syncProfile);
+				const admission = await this.admitAndSendCheckedPruneGrants(
+					from,
+					msg.requests,
+				);
 				if (
-					canConfirmNativeRequestPruneBatch(
-						nativeLeaderHints,
-						msg.hashes.length,
+					!this.isReplicationLifecycleActive(
+						receiveReplicationLifecycleController,
 					)
 				) {
-					this.responseToPruneDebouncedFn.add({
-						hashes: msg.hashes,
-						peers: [from],
-					});
-					if (syncProfile) {
-						emitSyncProfileDuration(syncProfile, requestPruneLoopStartedAt, {
-							name: "sharedLog.receive.requestPrune.loop",
-							component: "shared-log",
-							entries: msg.hashes.length,
-							messages: 1,
-							details: {
-								presentEntries: msg.hashes.length,
-								indexedFallbackLookups: 0,
-								fallbackBlockChecks: 0,
-								pendingDeleteEntries: 0,
-								leaderResponses: msg.hashes.length,
-								leaderResponseBatches: 1,
-								pendingIHaveCreated: 0,
-								pendingIHaveExtended: 0,
-								skippedIndexedLookupsForMissingBlocks: 0,
-								nativeBatchConfirmed: true,
-							},
-						});
-						emitSyncProfileDuration(syncProfile, requestPruneStartedAt, {
-							name: "sharedLog.receive.requestPrune.total",
-							component: "shared-log",
-							entries: msg.hashes.length,
-							messages: 1,
-						});
-					}
 					return;
 				}
-				let presentEntries = 0;
-				let indexedFallbackLookups = 0;
-				let fallbackBlockChecks = 0;
-				let skippedIndexedLookupsForMissingBlocks = 0;
-				let pendingDeleteEntries = 0;
-				let leaderResponses = 0;
+
 				let pendingIHaveCreated = 0;
 				let pendingIHaveExtended = 0;
-				const leaderResponseHashes: string[] = [];
-				for (let i = 0; i < msg.hashes.length; i++) {
-					if (
-						!this.isReplicationLifecycleActive(
-							receiveReplicationLifecycleController,
-						)
-					) {
-						return;
+				for (const request of admission.missing) {
+					const previous = this._pendingIHave.get(request.hash);
+					if (previous) {
+						pendingIHaveExtended += 1;
+						previous.requesting.set(from, request.requestId);
+						previous.resetTimeout();
+						continue;
 					}
-					const hash = msg.hashes[i]!;
 
-					const nativeEntryGid = nativeLeaderHints.nativeEntryGids?.[i];
-					const nativeEntryData = nativeLeaderHints.nativeEntryDataByIndex?.[i];
-					const nativeEntry =
-						nativeLeaderHints.nativeEntryMetadata?.[i] ??
-						nativeLeaderHints.nativeEntries?.get(hash) ??
-						nativeEntryMetadata?.[i];
-					const hasNativeEntry = nativeEntryGid != null || nativeEntry != null;
-					let indexedEntry:
-						| Awaited<ReturnType<typeof this.log.entryIndex.getShallow>>
-						| undefined;
-					let isLeader = false;
-
-					const hasPresentBlock = nativeLeaderHints.presentBlockHashes
-						? nativeLeaderHints.presentBlockHashes.has(hash)
-						: nativeLeaderHints.presentBlocks
-							? !!nativeLeaderHints.presentBlocks[i]
-							: presentBlocks
-								? presentBlocks[i] === true
-								: await this.log.blocks.has(hash);
-					if (
-						!presentBlocks &&
-						!nativeLeaderHints.presentBlockHashes &&
-						!nativeLeaderHints.presentBlocks
-					) {
-						fallbackBlockChecks += 1;
-					}
-					if (!hasNativeEntry && hasPresentBlock) {
-						indexedEntry = await this.log.entryIndex.getShallow(hash);
-						indexedFallbackLookups += 1;
-					} else if (!hasNativeEntry) {
-						skippedIndexedLookupsForMissingBlocks += 1;
-					}
-					if ((hasNativeEntry || indexedEntry) && hasPresentBlock) {
-						presentEntries += 1;
-						const pendingDelete = this._checkedPrune.getPendingDelete(hash);
-						if (pendingDelete) {
-							pendingDeleteEntries += 1;
-							const pendingEntry =
-								indexedEntry?.value ??
-								(await this.log.entryIndex.getShallow(hash))?.value;
-							if (pendingEntry) {
-								const ownership = await this.revalidateCheckedPruneOwnership({
-									hash,
-									entry: pendingEntry,
-									leaders: new Map(),
-								});
-								if (ownership.localLeader) {
-									await this.cancelCheckedPruneForLocalLeader(hash);
-									isLeader = true;
-								}
-							}
-						} else {
-							const gid =
-								nativeEntryGid ??
-								nativeEntry?.gid ??
-								indexedEntry!.value.meta.gid;
-							const replicaCountByIndex =
-								nativeLeaderHints.replicaCountsByIndex?.[i];
-							const replicas =
-								replicaCountByIndex != null && replicaCountByIndex > 0
-									? replicaCountByIndex
-									: (nativeLeaderHints.replicaCounts.get(hash) ??
-										decodeReplicas({
-											meta: {
-												data:
-													nativeEntryData ??
-													nativeEntry?.data ??
-													indexedEntry!.value.meta.data,
-											},
-										}).getValue(this));
-
+					pendingIHaveCreated += 1;
+					const requesting = new Map([[from, request.requestId]]);
+					let pendingIHave!: PendingIHave<T>;
+					pendingIHave = {
+						requesting,
+						resetTimeout: () => this.resetPendingIHaveTimeout(pendingIHave),
+						clear: () => this.clearPendingIHaveTimeout(pendingIHave),
+						callback: async (entry: Entry<T>) => {
 							if (
-								!nativeLeaderHints.peerHistoryRemovedFlags?.[i] &&
-								!nativeLeaderHints.peerHistoryRemovedHashes.has(hash)
+								!this.isReplicationLifecycleActive(
+									receiveReplicationLifecycleController,
+								) ||
+								requesting.size === 0
 							) {
-								this.removePeerFromGidPeerHistory(from, gid);
+								return;
 							}
-
-							if (
-								!!nativeLeaderHints.localLeaderFlags?.[i] ||
-								nativeLeaderHints.localLeaderHashes.has(hash)
-							) {
-								isLeader = true;
-							} else {
-								const selfHash = this.node.identity.publicKey.hashcode();
-								const waitFor: WaitForReplicator[] = [
-									{
-										key: selfHash,
-										replicator: true,
-									},
-								];
-								const waitOptions: WaitForReplicatorsOptions<R> = {
-									onLeader: (key) => {
-										isLeader = isLeader || key === selfHash;
-									},
-								};
-								if (hasNativeEntry) {
-									await this._waitForGidReplicators(
-										gid,
-										replicas,
-										waitFor,
-										waitOptions,
-									);
-								} else {
-									await this._waitForEntryReplicators(
-										indexedEntry!.value,
-										replicas,
-										waitFor,
-										waitOptions,
-									);
-								}
+							for (const requester of requesting.keys()) {
+								this.removePeerFromGidPeerHistory(requester, entry.meta.gid);
 							}
-						}
-					}
-
-					if (isLeader) {
-						leaderResponses += 1;
-						leaderResponseHashes.push(hash);
-					} else {
-						const prevPendingIHave = this._pendingIHave.get(hash);
-						if (prevPendingIHave) {
-							pendingIHaveExtended += 1;
-							prevPendingIHave.requesting.add(from);
-							prevPendingIHave.resetTimeout();
-						} else {
-							pendingIHaveCreated += 1;
-							const requesting = new Set([from]);
-							let pendingIHave!: PendingIHave<T>;
-							pendingIHave = {
-								requesting,
-								resetTimeout: () => this.resetPendingIHaveTimeout(pendingIHave),
-								clear: () => this.clearPendingIHaveTimeout(pendingIHave),
-								callback: async (entry: Entry<T>) => {
-									if (
-										!this.isReplicationLifecycleActive(
-											receiveReplicationLifecycleController,
-										) ||
-										requesting.size === 0
-									) {
-										return;
-									}
-									for (const requester of requesting) {
-										this.removePeerFromGidPeerHistory(
-											requester,
-											entry.meta.gid,
-										);
-										this.removePruneRequestSent(entry.hash, requester);
-									}
-									let isLeader = false;
-									await this._waitForEntryReplicators(
-										entry,
-										decodeReplicas(entry).getValue(this),
-										[
-											{
-												key: this.node.identity.publicKey.hashcode(),
-												replicator: true,
-											},
-										],
-										{
-											onLeader: (key) => {
-												isLeader =
-													isLeader ||
-													key === this.node.identity.publicKey.hashcode();
-											},
-										},
-									);
-									if (
-										!this.isReplicationLifecycleActive(
-											receiveReplicationLifecycleController,
-										) ||
-										requesting.size === 0
-									) {
-										return;
-									}
-									if (isLeader) {
-										this.responseToPruneDebouncedFn.add({
-											hashes: [entry.hash],
-											peers: new Set(requesting),
-										});
-									}
-								},
-							};
-
-							this._pendingIHave.set(hash, pendingIHave);
-							this.resetPendingIHaveTimeout(pendingIHave);
-						}
-					}
-				}
-				if (leaderResponseHashes.length > 0) {
-					this.responseToPruneDebouncedFn.add({
-						hashes: leaderResponseHashes,
-						peers: [from],
-					});
-				}
-				if (syncProfile) {
-					emitSyncProfileDuration(syncProfile, requestPruneLoopStartedAt, {
-						name: "sharedLog.receive.requestPrune.loop",
-						component: "shared-log",
-						entries: msg.hashes.length,
-						messages: 1,
-						details: {
-							presentEntries,
-							indexedFallbackLookups,
-							fallbackBlockChecks,
-							pendingDeleteEntries,
-							leaderResponses,
-							leaderResponseBatches: leaderResponseHashes.length > 0 ? 1 : 0,
-							pendingIHaveCreated,
-							pendingIHaveExtended,
-							skippedIndexedLookupsForMissingBlocks,
+							await Promise.all(
+								[...requesting].map(([requester, requestId]) =>
+									this.admitAndSendCheckedPruneGrants(requester, [
+										{ hash: entry.hash, requestId },
+									]),
+								),
+							);
 						},
-					});
+					};
+					this._pendingIHave.set(request.hash, pendingIHave);
+					this.resetPendingIHaveTimeout(pendingIHave);
+				}
+
+				// Close the arrival race between the in-lane presence check and
+				// installing pending-IHave. If admission completed in that window,
+				// run the same callback that onEntryAdded would have run.
+				for (const request of admission.missing) {
+					const pendingIHave = this._pendingIHave.get(request.hash);
+					if (!pendingIHave) {
+						continue;
+					}
+					let entry: Entry<T> | undefined;
+					try {
+						if (await this.log.blocks.has(request.hash)) {
+							entry = (await this.log.get(request.hash)) as
+								| Entry<T>
+								| undefined;
+						}
+					} catch {
+						// The normal entry-admission hook will retry this path.
+					}
+					if (entry && this._pendingIHave.get(request.hash) === pendingIHave) {
+						pendingIHave.clear();
+						this.runPendingIHaveCallback(pendingIHave, entry);
+					}
+				}
+
+				if (syncProfile) {
 					emitSyncProfileDuration(syncProfile, requestPruneStartedAt, {
 						name: "sharedLog.receive.requestPrune.total",
 						component: "shared-log",
-						entries: msg.hashes.length,
+						entries: hashes.length,
 						messages: 1,
+						details: {
+							presentEntries: hashes.length - admission.missing.length,
+							leaderResponses: admission.admitted.length,
+							pendingIHaveCreated,
+							pendingIHaveExtended,
+						},
 					});
 				}
-			} else if (msg instanceof ResponseIPrune) {
-				const lateResponses: string[] = [];
+			} else if (msg instanceof ResponseIPruneV2) {
+				const responseHashes = new Set<string>();
+				for (const request of msg.requests) {
+					if (responseHashes.has(request.hash)) {
+						return;
+					}
+					responseHashes.add(request.hash);
+				}
 				const responseTasks: Promise<void>[] = [];
-				for (const hash of msg.hashes) {
-					const pendingDelete = this._checkedPrune.getPendingDelete(hash);
+				for (const request of msg.requests) {
+					const pendingDelete = this._checkedPrune.getPendingDelete(
+						request.hash,
+					);
 					if (pendingDelete) {
 						responseTasks.push(
-							Promise.resolve(pendingDelete.resolve(context.from.hashcode())),
+							Promise.resolve(
+								pendingDelete.resolve(
+									context.from.hashcode(),
+									request.requestId,
+								),
+							),
 						);
-					} else {
-						lateResponses.push(hash);
 					}
-				}
-				if (lateResponses.length > 0) {
-					responseTasks.push(
-						this.recoverCheckedPruneFromLateResponses(
-							lateResponses,
-							context.from.hashcode(),
-						),
-					);
 				}
 				const results = await Promise.allSettled(responseTasks);
 				for (const result of results) {
@@ -21227,6 +21142,15 @@ export class SharedLog<
 						logger.error(result.reason?.toString?.() ?? String(result.reason));
 					}
 				}
+			} else if (
+				msg instanceof RequestIPrune ||
+				msg instanceof ResponseIPrune
+			) {
+				// Legacy checked-prune messages are signed but uncorrelated. They cannot
+				// authorize deletion for a particular active request generation. Mixed
+				// versions intentionally retain extra copies until peers upgrade; bounded
+				// background auditing preserves convergence without weakening this gate.
+				return;
 			} else if (msg instanceof ConfirmEntriesMessage) {
 				this.markEntriesKnownByPeer(msg.hashes, context.from.hashcode());
 				this.clearRepairFrontierHashes(context.from.hashcode(), msg.hashes);
@@ -22418,186 +22342,6 @@ export class SharedLog<
 		return backboneMetadata.map(
 			(entry, index) => entry ?? indexMetadata[index],
 		);
-	}
-
-	private async planCurrentNativeRequestPruneLeaderHints(properties: {
-		hashes: string[];
-		nativeEntryMetadata?: Array<
-			{ gid: string; data?: Uint8Array; replicas?: number } | undefined | null
-		>;
-		presentBlocks?: boolean[] | undefined;
-	}): Promise<NativeRequestPruneLeaderHints> {
-		const empty = (): NativeRequestPruneLeaderHints => ({
-			localLeaderHashes: new Set(),
-			replicaCounts: new Map(),
-			peerHistoryGids: [],
-			peerHistoryRemovedHashes: new Set(),
-		});
-		const planner = this._nativeBackbone ?? this._nativeRangePlanner;
-		if (
-			!planner ||
-			!properties.nativeEntryMetadata ||
-			!properties.presentBlocks
-		) {
-			return empty();
-		}
-
-		const hashes: string[] = [];
-		const entries: Array<{ gid: string; replicas: number }> = [];
-		const replicaCounts = new Map<string, number>();
-		const peerHistoryGids: string[] = [];
-		const peerHistoryRemovedHashes = new Set<string>();
-		for (let i = 0; i < properties.hashes.length; i++) {
-			const hash = properties.hashes[i]!;
-			const nativeEntry = properties.nativeEntryMetadata[i];
-			if (
-				!nativeEntry ||
-				properties.presentBlocks[i] !== true ||
-				this._checkedPrune.getPendingDelete(hash)
-			) {
-				continue;
-			}
-			const replicas =
-				nativeEntry.replicas ??
-				decodeReplicas({
-					meta: {
-						data: nativeEntry.data,
-					},
-				}).getValue(this);
-			hashes.push(hash);
-			replicaCounts.set(hash, replicas);
-			peerHistoryGids.push(nativeEntry.gid);
-			peerHistoryRemovedHashes.add(hash);
-			entries.push({
-				gid: nativeEntry.gid,
-				replicas,
-			});
-		}
-		if (entries.length === 0) {
-			return {
-				localLeaderHashes: new Set(),
-				replicaCounts,
-				peerHistoryGids,
-				peerHistoryRemovedHashes,
-			};
-		}
-
-		const context = await this.createLeaderSelectionContext();
-		const nativeLeaderOptions = this.createNativeLeaderOptions(context);
-		let localLeaderHashes = (
-			planner as {
-				planLocalLeaderHashesForGidsBatch?: (
-					items: Iterable<{ hash: string; gid: string; replicas: number }>,
-					options: typeof nativeLeaderOptions,
-				) => Set<string> | undefined;
-			}
-		).planLocalLeaderHashesForGidsBatch?.(
-			entries.map((entry, index) => ({
-				hash: hashes[index]!,
-				...entry,
-			})),
-			nativeLeaderOptions,
-		);
-		if (!localLeaderHashes) {
-			const nativePlans = planner.planLeadersForGidsBatch(
-				entries,
-				nativeLeaderOptions,
-			);
-			localLeaderHashes = new Set<string>();
-			for (let i = 0; i < nativePlans.length; i++) {
-				if (nativePlans[i]?.leaders.has(context.selfHash)) {
-					localLeaderHashes.add(hashes[i]!);
-				}
-			}
-		}
-		return {
-			localLeaderHashes,
-			replicaCounts,
-			peerHistoryGids,
-			peerHistoryRemovedHashes,
-		};
-	}
-
-	private async planCurrentNativeBackboneRequestPruneLeaderHints(
-		hashes: string[],
-		from: string,
-	): Promise<NativeRequestPruneLeaderHints | undefined> {
-		if (!this._nativeBackbone) {
-			return undefined;
-		}
-		const context = await this.createLeaderSelectionContext();
-		const skipHashes =
-			this._checkedPrune.pendingDeletes.size > 0
-				? [...this._checkedPrune.pendingDeletes.keys()]
-				: [];
-		const nativeBackboneHintArrays = this
-			._nativeBackbone as NativePeerbitBackbone & {
-			planRequestPruneAllConfirmed?: (
-				hashes: Iterable<string>,
-				prunePeer: string,
-				options?: { omitPeerHistoryGids?: boolean },
-			) => { allConfirmed: boolean; peerHistoryGids: string[] } | undefined;
-			planRequestPruneLeaderHintColumns?: (
-				hashes: Iterable<string>,
-				skipHashes: Iterable<string>,
-				options?: unknown,
-			) => NativeBackboneRequestPruneHintColumns | undefined;
-		};
-		if (skipHashes.length === 0) {
-			const allConfirmed =
-				nativeBackboneHintArrays.planRequestPruneAllConfirmed?.(hashes, from, {
-					...this.createNativeLeaderOptions(context),
-					omitPeerHistoryGids:
-						this._gidPeersHistory.size === 0 &&
-						this._nativeSharedLogState == null,
-				});
-			if (allConfirmed?.allConfirmed) {
-				return {
-					localLeaderHashes: new Set(),
-					replicaCounts: new Map(),
-					peerHistoryGids: allConfirmed.peerHistoryGids,
-					peerHistoryRemovedHashes: new Set(),
-					nativeAllConfirmed: true,
-					nativeBackbonePeerHistoryCleaned: true,
-				};
-			}
-		}
-		const hintColumns =
-			nativeBackboneHintArrays.planRequestPruneLeaderHintColumns?.(
-				hashes,
-				skipHashes,
-				this.createNativeLeaderOptions(context),
-			);
-		if (hintColumns) {
-			return {
-				localLeaderHashes: new Set(),
-				replicaCounts: new Map(),
-				replicaCountsByIndex: hintColumns.replicaCounts,
-				peerHistoryGids: hintColumns.peerHistoryGids,
-				peerHistoryRemovedHashes: new Set(),
-				peerHistoryRemovedFlags: hintColumns.peerHistoryRemovedFlags,
-				nativeEntryGids: hintColumns.gids,
-				nativeEntryDataByIndex: hintColumns.data,
-				presentBlocks: hintColumns.presentBlockFlags,
-				localLeaderFlags: hintColumns.localLeaderFlags,
-			};
-		}
-		const hints = this._nativeBackbone.planRequestPruneLeaderHints(
-			hashes,
-			skipHashes,
-			this.createNativeLeaderOptions(context),
-		);
-		if (!hints) {
-			return undefined;
-		}
-		return {
-			localLeaderHashes: hints.localLeaderHashes,
-			replicaCounts: hints.replicaCounts,
-			peerHistoryGids: hints.peerHistoryGids,
-			peerHistoryRemovedHashes: hints.peerHistoryRemovedHashes,
-			nativeEntries: hints.entries,
-			presentBlockHashes: hints.presentBlockHashes,
-		};
 	}
 
 	private createReusableReceiveCoordinatePlans(
@@ -26572,6 +26316,240 @@ export class SharedLog<
 		this._checkedPrune.removeRequestsSent(hashes, to);
 	}
 
+	private async sendCheckedPruneResponse(
+		to: string,
+		requests: Array<{ hash: string; requestId: Uint8Array }>,
+		signal?: AbortSignal,
+	) {
+		if (requests.length === 0) {
+			return;
+		}
+		await this.rpc.send(new ResponseIPruneV2({ requests }), {
+			mode: new AcknowledgeDelivery({
+				to: [to],
+				redundancy: 1,
+			}),
+			priority: CONVERGENCE_MESSAGE_PRIORITY,
+			signal,
+		});
+	}
+
+	private async admitAndSendCheckedPruneGrants(
+		to: string,
+		requests: Array<{ hash: string; requestId: Uint8Array }>,
+	) {
+		const latestByHash = new Map(
+			requests.map((request) => [request.hash, request]),
+		);
+		if (latestByHash.size === 0) {
+			return { admitted: [], missing: [] };
+		}
+		const checkedPruneCoordinator = this._checkedPrune;
+		const ownershipLifecycleController =
+			this.captureReplicationOwnershipLifecycle();
+		const admission = await this.withReplicationRangeMutationQueue(async () => {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+			if (this._checkedPrune !== checkedPruneCoordinator) {
+				return {
+					admitted: [] as typeof requests,
+					missing: [] as typeof requests,
+				};
+			}
+			const hashes = [...latestByHash.keys()];
+			let presentHashes: string[] | undefined;
+			let localLeaderHashes: Set<string> | undefined;
+			if (this._nativeBackbone && !this.hasCustomFindLeaders()) {
+				const context = await this.createLeaderSelectionContext(
+					undefined,
+					ownershipLifecycleController,
+				);
+				this.throwIfReplicationOwnershipLifecycleInactive(
+					ownershipLifecycleController,
+				);
+				const allConfirmed = this._nativeBackbone.planRequestPruneAllConfirmed(
+					hashes,
+					to,
+					{
+						...this.createNativeLeaderOptions(context),
+						omitPeerHistoryGids:
+							this._gidPeersHistory.size === 0 &&
+							this._nativeSharedLogState == null,
+					},
+				);
+				if (allConfirmed?.peerHistoryGids.length) {
+					this.removePeerFromGidPeerHistoryBatch(
+						to,
+						allConfirmed.peerHistoryGids,
+						{ skipNativeBackbone: true },
+					);
+				}
+				if (allConfirmed?.allConfirmed) {
+					presentHashes = hashes;
+					localLeaderHashes = new Set(hashes);
+				}
+			}
+			if (!presentHashes || !localLeaderHashes) {
+				const present =
+					(await this.log.blocks.hasMany?.(hashes)) ??
+					(await Promise.all(hashes.map((hash) => this.log.blocks.has(hash))));
+				presentHashes = hashes.filter(
+					(_hash, index) => present[index] === true,
+				);
+				localLeaderHashes = await this.revalidateCheckedPruneGrantLocalLeaders(
+					presentHashes,
+					to,
+					ownershipLifecycleController,
+				);
+			}
+			const presentHashSet = new Set(presentHashes);
+			const missing = hashes
+				.filter((hash) => !presentHashSet.has(hash))
+				.map((hash) => latestByHash.get(hash)!);
+			const admitted = presentHashes
+				.filter((hash) => localLeaderHashes.has(hash))
+				.map((hash) => latestByHash.get(hash)!);
+			if (admitted.length === 0) {
+				return { admitted, missing };
+			}
+
+			const barrier = pDefer<void>();
+			const observedBarrier = checkedPruneCoordinator.trackGrantSend(
+				admitted.map(({ hash }) => hash),
+				barrier.promise,
+			);
+			const restartCandidates: Array<{
+				candidate: CheckedPruneRestartCandidate<T, R>;
+				reservation: object;
+				retry?: CheckedPruneRetryState<T, R>;
+			}> = [];
+			for (const { hash } of admitted) {
+				const candidate = checkedPruneCoordinator.getRestartCandidate(hash);
+				const pending = checkedPruneCoordinator.getPendingDelete(hash);
+				const retry = checkedPruneCoordinator.getRetry(hash);
+				const hadQueuedCandidate = this.pruneDebouncedFn.has(hash);
+				const hadInFlightCandidate = checkedPruneCoordinator.hasCandidate(hash);
+				const shouldRestart =
+					candidate != null &&
+					(hadQueuedCandidate ||
+						hadInFlightCandidate ||
+						retry != null ||
+						pending?.retryOnInvalidation === true);
+				this.deleteQueuedCheckedPrune(hash, checkedPruneCoordinator);
+				if (pending) {
+					try {
+						void Promise.resolve(
+							pending.reject(
+								new Error(
+									"Failed to delete, granted checked prune to another peer",
+								),
+								{ preserveRetry: shouldRestart },
+							),
+						).catch(() => {});
+					} catch {
+						// Cancellation is enforced below. A synchronous observer error
+						// cannot revoke the admitted grant.
+					}
+					if (checkedPruneCoordinator.isCurrentRequest(hash, pending)) {
+						checkedPruneCoordinator.markCancelled(hash, pending, {
+							preserveRetry: shouldRestart,
+						});
+					}
+				} else if (
+					candidate ||
+					hadQueuedCandidate ||
+					hadInFlightCandidate ||
+					retry
+				) {
+					checkedPruneCoordinator.markCancelled(hash, {
+						preserveRetry: shouldRestart,
+					});
+				}
+				if (shouldRestart) {
+					restartCandidates.push({
+						candidate,
+						reservation: checkedPruneCoordinator.reserveRestart(hash),
+						retry,
+					});
+				}
+			}
+			return {
+				admitted,
+				missing,
+				barrier,
+				observedBarrier,
+				restartCandidates,
+			};
+		}, ownershipLifecycleController);
+
+		if (!admission.barrier) {
+			return {
+				admitted: admission.admitted,
+				missing: admission.missing,
+			};
+		}
+		try {
+			if (
+				this._checkedPrune === checkedPruneCoordinator &&
+				!ownershipLifecycleController.signal.aborted
+			) {
+				await this.sendCheckedPruneResponse(
+					to,
+					admission.admitted,
+					ownershipLifecycleController.signal,
+				);
+			}
+		} finally {
+			admission.barrier.resolve();
+			await admission.observedBarrier;
+			for (const {
+				candidate,
+				reservation,
+				retry,
+			} of admission.restartCandidates) {
+				if (
+					this._checkedPrune !== checkedPruneCoordinator ||
+					!this.isRepairLifecycleActive(ownershipLifecycleController)
+				) {
+					checkedPruneCoordinator.cancelRestartReservation(
+						candidate.hash,
+						reservation,
+					);
+					if (
+						retry &&
+						checkedPruneCoordinator.getRetry(candidate.hash) === retry
+					) {
+						checkedPruneCoordinator.clearRetry(candidate.hash);
+					}
+					continue;
+				}
+				if (
+					!checkedPruneCoordinator.consumeRestartReservation(
+						candidate.hash,
+						reservation,
+					)
+				) {
+					continue;
+				}
+				try {
+					this.scheduleCheckedPruneRetry(
+						candidate,
+						ownershipLifecycleController,
+					);
+				} catch {
+					// Granting the requester is the safety boundary. Best-effort
+					// liveness rearming must not turn a completed grant into failure.
+					checkedPruneCoordinator.clearRetry(candidate.hash);
+				}
+			}
+		}
+		return {
+			admitted: admission.admitted,
+			missing: admission.missing,
+		};
+	}
+
 	prune(
 		entries: Map<
 			string,
@@ -26657,49 +26635,82 @@ export class SharedLog<
 
 			const pendingPrev = checkedPruneCoordinator.getPendingDelete(entry.hash);
 			if (pendingPrev) {
-				// If a background prune is already in-flight, an explicit prune request should
-				// still respect the caller's timeout. Otherwise, tests (and user calls) can
-				// block on the longer "checked prune" timeout derived from
-				// `_respondToIHaveTimeout + waitForReplicatorTimeout`, which is intentionally
-				// large for resiliency.
-				if (explicitTimeout) {
-					const timeoutMs = Math.max(0, Math.floor(options?.timeout ?? 0));
-					promises.push(
-						new Promise((resolve, reject) => {
-							// Mirror the checked-prune error prefix so existing callers/tests can
-							// match on the message substring.
-							const timer = setTimeout(() => {
-								reject(
-									new Error(
-										`Timeout for checked pruning after ${timeoutMs}ms (pending=true closed=${this.closed})`,
-									),
-								);
-							}, timeoutMs);
-							timer.unref?.();
-							pendingPrev.promise.promise
-								.then(resolve, reject)
-								.finally(() => clearTimeout(timer));
-						}),
+				const replaceRevokedBackgroundGeneration =
+					!explicitTimeout &&
+					checkedPruneCoordinator.hasRevokedLeader(
+						entry.hash,
+						pendingPrev,
+						leaders,
 					);
+				if (replaceRevokedBackgroundGeneration) {
+					try {
+						void Promise.resolve(
+							pendingPrev.reject(
+								new Error(
+									"Checked prune ownership now requires a peer revoked from the current generation",
+								),
+								{ preserveRetry: true },
+							),
+						).catch(() => {});
+					} catch {
+						// Exact cancellation below still fences the old request ID.
+					}
+					if (
+						checkedPruneCoordinator.isCurrentRequest(entry.hash, pendingPrev)
+					) {
+						checkedPruneCoordinator.markCancelled(entry.hash, pendingPrev, {
+							preserveRetry: true,
+						});
+					}
 				} else {
-					promises.push(pendingPrev.promise.promise);
+					// If a background prune is already in-flight, an explicit prune request should
+					// still respect the caller's timeout. Otherwise, tests (and user calls) can
+					// block on the longer "checked prune" timeout derived from
+					// `_respondToIHaveTimeout + waitForReplicatorTimeout`, which is intentionally
+					// large for resiliency.
+					if (explicitTimeout) {
+						const timeoutMs = Math.max(0, Math.floor(options?.timeout ?? 0));
+						promises.push(
+							new Promise((resolve, reject) => {
+								// Mirror the checked-prune error prefix so existing callers/tests can
+								// match on the message substring.
+								const timer = setTimeout(() => {
+									reject(
+										new Error(
+											`Timeout for checked pruning after ${timeoutMs}ms (pending=true closed=${this.closed})`,
+										),
+									);
+								}, timeoutMs);
+								timer.unref?.();
+								pendingPrev.promise.promise
+									.then(resolve, reject)
+									.finally(() => clearTimeout(timer));
+							}),
+						);
+					} else {
+						promises.push(pendingPrev.promise.promise);
+					}
+					continue;
 				}
-				continue;
 			}
 
 			const minReplicas = decodeReplicas(entry);
+			const minReplicasValue =
+				this.getClampedReplicas(minReplicas).getValue(this);
+			const parentHashes = this.getEntryNext(entry);
+			const requestId = randomBytes(32);
 			const deferredPromise: DeferredPromise<void> = pDefer();
-			let finalOwnershipRevalidationFailed = false;
+			let deleteScheduled = false;
+			let pending!: CheckedPrunePendingDelete;
 
 			const clear = () => {
-				const pending = checkedPruneCoordinator.getPendingDelete(entry.hash);
-				if (pending?.promise === deferredPromise) {
+				if (checkedPruneCoordinator.isCurrentRequest(entry.hash, pending)) {
 					checkedPruneCoordinator.deletePendingDelete(entry.hash, pending);
 				}
 				clearTimeout(timeout);
 			};
 
-			const resolve = () => {
+			const resolveDelete = () => {
 				try {
 					throwIfCheckedPruneLifecycleInactive();
 				} catch (error) {
@@ -26707,74 +26718,48 @@ export class SharedLog<
 					return;
 				}
 				clearTimeout(timeout);
-				checkedPruneCoordinator.clearRetry(entry.hash);
 				cleanupTimer.push(
 					setTimeout(() => {
 						const run = async () => {
 							throwIfCheckedPruneLifecycleInactive();
-							const ownership = await this.revalidateCheckedPruneOwnership({
-								hash: entry.hash,
-								entry,
-								leaders: this.checkedPruneLeadersToMap(leaders),
-								selfReplicating: true,
-								ownershipLifecycleController,
-								checkedPruneCoordinator,
-							});
-							throwIfCheckedPruneLifecycleInactive();
-							if (ownership.localLeader) {
-								clear();
-								if (!explicitTimeout) {
-									this.scheduleCheckedPruneRetry(
-										{ entry, leaders },
-										ownershipLifecycleController,
-									);
-								}
-								deferredPromise.reject(
-									new Error("Failed to delete, is leader again"),
-								);
-								return;
-							}
-
 							try {
 								const removed = await this.withReplicationRangeMutationQueue(
 									async () => {
 										throwIfCheckedPruneLifecycleInactive();
 										if (
-											checkedPruneCoordinator.getPendingDelete(entry.hash)
-												?.promise !== deferredPromise
+											!checkedPruneCoordinator.isCurrentRequest(
+												entry.hash,
+												pending,
+											)
 										) {
 											throw new TerminalOperationNotStartedError(
 												"Checked prune session is no longer active at the delete boundary",
 											);
 										}
-										// The network confirmation and preliminary planner check
-										// deliberately happen outside the global ownership lane. Once
-										// admitted here, re-read leadership and keep the lower-log
-										// delete in the same lane so a durable range mutation cannot
-										// commit between the decision and the destructive operation.
+										// The correlated receipt is only evidence that a contacted peer
+										// granted this handoff. The sole ownership decision is made here
+										// in the global mutation lane, immediately before deletion.
 										let finalOwnership: {
 											leaders: CheckedPruneLeaderMap;
 											localLeader: boolean;
 										};
-										try {
-											finalOwnership =
-												await this.revalidateCheckedPruneOwnership({
-													hash: entry.hash,
-													entry,
-													leaders: this.checkedPruneLeadersToMap(leaders),
-													selfReplicating: true,
-													requireFreshLeaderDecision: true,
-													ownershipLifecycleController,
-													checkedPruneCoordinator,
-												});
-										} catch (error) {
-											finalOwnershipRevalidationFailed = true;
-											throw error;
-										}
+										finalOwnership = await this.revalidateCheckedPruneOwnership(
+											{
+												hash: entry.hash,
+												entry,
+												leaders: this.checkedPruneLeadersToMap(leaders),
+												selfReplicating: true,
+												requireFreshLeaderDecision: true,
+												ownershipLifecycleController,
+												checkedPruneCoordinator,
+											},
+										);
 										throwIfCheckedPruneLifecycleInactive();
 										if (
-											checkedPruneCoordinator.getPendingDelete(entry.hash)
-												?.promise !== deferredPromise
+											!checkedPruneCoordinator.isCurrentRequest(
+												entry.hash,
+												pending,
+											)
 										) {
 											throw new TerminalOperationNotStartedError(
 												"Checked prune session changed before removal",
@@ -26784,19 +26769,44 @@ export class SharedLog<
 											return false;
 										}
 
+										const exactConfirmations =
+											checkedPruneCoordinator.getExactConfirmedReplicators(
+												entry.hash,
+												pending,
+											);
+										let finalConfirmationCount = 0;
+										for (const peer of exactConfirmations) {
+											if (
+												finalOwnership.leaders.has(peer) &&
+												!this._replicationInfoBlockedPeers.has(peer) &&
+												(this._receiveCleanupGateByPeer.get(peer) ?? 0) === 0
+											) {
+												finalConfirmationCount += 1;
+											}
+										}
+										if (finalConfirmationCount < minReplicasValue) {
+											return false;
+										}
+
 										this.deleteGidPeerHistory(entry.meta.gid);
+										throwIfCheckedPruneLifecycleInactive();
+										if (
+											!checkedPruneCoordinator.markRemoving(entry.hash, pending)
+										) {
+											throw new TerminalOperationNotStartedError(
+												"Checked prune session changed before removal admission",
+											);
+										}
 										checkedPruneCoordinator.removeRequestSent(entry.hash);
 										checkedPruneCoordinator.clearConfirmedReplicators(
 											entry.hash,
 										);
-										throwIfCheckedPruneLifecycleInactive();
-										checkedPruneCoordinator.markRemoving(entry.hash);
 										this._checkedPruneRemoveBlocksLocalRangeMutationAdmission++;
 										try {
 											await this.trackAdmittedPruneRemove(
 												() =>
 													this.log.remove(entry, {
-														recursively: true,
+														recursively: false,
 													}),
 												ownershipLifecycleController,
 											);
@@ -26804,9 +26814,14 @@ export class SharedLog<
 											this
 												._checkedPruneRemoveBlocksLocalRangeMutationAdmission--;
 										}
+										if (
+											!checkedPruneCoordinator.markDone(entry.hash, pending)
+										) {
+											throw new TerminalOperationNotStartedError(
+												"Checked prune session changed while removal was admitted",
+											);
+										}
 										clear();
-										checkedPruneCoordinator.markDone(entry.hash);
-										deferredPromise.resolve();
 										return true;
 									},
 									ownershipLifecycleController,
@@ -26825,12 +26840,15 @@ export class SharedLog<
 									return;
 								}
 							} catch (error) {
-								clear();
-								checkedPruneCoordinator.markCancelled(entry.hash, {
-									preserveRetry:
-										!explicitTimeout && finalOwnershipRevalidationFailed,
+								const shouldRetry =
+									!explicitTimeout &&
+									isCheckedPruneLifecycleCurrent() &&
+									!isNotStartedError(error as Error);
+								checkedPruneCoordinator.markCancelled(entry.hash, pending, {
+									preserveRetry: shouldRetry,
 								});
-								if (!explicitTimeout && finalOwnershipRevalidationFailed) {
+								clear();
+								if (shouldRetry) {
 									this.scheduleCheckedPruneRetry(
 										{ entry, leaders },
 										ownershipLifecycleController,
@@ -26840,31 +26858,11 @@ export class SharedLog<
 								return;
 							}
 
-							// The delete has already settled. Diagnostics are best-effort:
-							// poison/close/reopen must not turn an ignored timer callback into
-							// an unhandled rejection or mutate the next lifecycle.
-							if (!isCheckedPruneLifecycleCurrent()) {
-								return;
-							}
 							try {
-								this.deleteGidPeerHistory(entry.meta.gid);
-								checkedPruneCoordinator.removeRequestSent(entry.hash);
-								checkedPruneCoordinator.clearConfirmedReplicators(entry.hash);
-								const postRemoveOwnership =
-									await this.revalidateCheckedPruneOwnership({
-										hash: entry.hash,
-										entry,
-										leaders: this.checkedPruneLeadersToMap(leaders),
-										selfReplicating: true,
-										ownershipLifecycleController,
-										checkedPruneCoordinator,
-									});
-								if (
-									isCheckedPruneLifecycleCurrent() &&
-									postRemoveOwnership.localLeader
-								) {
-									logger.error("Unexpected: Is leader after delete");
-								}
+								await this.prunePromotedCheckedPruneParents(
+									parentHashes,
+									ownershipLifecycleController,
+								);
 							} catch (error) {
 								if (
 									isCheckedPruneLifecycleCurrent() &&
@@ -26873,6 +26871,7 @@ export class SharedLog<
 									logger.error(error);
 								}
 							}
+							deferredPromise.resolve();
 						};
 						void run().catch((error) => {
 							reject(error);
@@ -26881,15 +26880,17 @@ export class SharedLog<
 				);
 			};
 
-			const reject = (e: any) => {
-				clear();
+			const reject = (e: any, rejectOptions?: { preserveRetry?: boolean }) => {
 				const isCheckedPruneTimeout =
 					e instanceof Error &&
 					typeof e.message === "string" &&
 					e.message.startsWith("Timeout for checked pruning");
-				checkedPruneCoordinator.markCancelled(entry.hash, {
-					preserveRetry: !explicitTimeout && isCheckedPruneTimeout,
+				checkedPruneCoordinator.markCancelled(entry.hash, pending, {
+					preserveRetry:
+						rejectOptions?.preserveRetry ??
+						(!explicitTimeout && isCheckedPruneTimeout),
 				});
+				clear();
 				deferredPromise.reject(e);
 			};
 
@@ -26911,74 +26912,74 @@ export class SharedLog<
 				// For internal/background prune flows (no explicit timeout), retry a few times
 				// to avoid "permanently prunable" entries when `_pendingIHave` expires under
 				// heavy load.
-				if (!explicitTimeout && isCheckedPruneLifecycleCurrent()) {
-					this.scheduleCheckedPruneRetry(
-						{ entry, leaders },
-						ownershipLifecycleController,
-					);
-				}
+				const shouldRetry =
+					!explicitTimeout && isCheckedPruneLifecycleCurrent();
 				reject(
 					new Error(
 						`Timeout for checked pruning after ${checkedPruneTimeoutMs}ms (closed=${this.closed})`,
 					),
 				);
+				// Requeue only after rejecting clears the current generation. Scheduling
+				// while it is still pending is deliberately ignored by the coordinator.
+				if (shouldRetry && isCheckedPruneLifecycleCurrent()) {
+					this.scheduleCheckedPruneRetry(
+						{ entry, leaders },
+						ownershipLifecycleController,
+					);
+				}
 			}, checkedPruneTimeoutMs);
 			timeout.unref?.();
 
-			checkedPruneCoordinator.setPendingDelete(
-				entry.hash,
-				{
-					promise: deferredPromise,
-					clear,
-					reject,
-					resolve: async (publicKeyHash: string) => {
-						try {
-							throwIfCheckedPruneLifecycleInactive();
-						} catch (error) {
-							reject(error);
-							return;
-						}
-						const minReplicasObj = this.getClampedReplicas(minReplicas);
-						const minReplicasValue = minReplicasObj.getValue(this);
-
-						// TODO is this check necessary
-						if (
-							!(await this._waitForEntryReplicators(
-								entry,
-								minReplicasValue,
-								[
-									{ key: publicKeyHash, replicator: true },
-									{
-										key: this.node.identity.publicKey.hashcode(),
-										replicator: false,
-									},
-								],
-								{
-									persist: false,
-								},
-							))
-						) {
-							return;
-						}
-						try {
-							throwIfCheckedPruneLifecycleInactive();
-						} catch (error) {
-							reject(error);
-							return;
-						}
-
-						const existCounter = checkedPruneCoordinator.addConfirmedReplicator(
+			pending = {
+				requestId,
+				retryOnInvalidation: !explicitTimeout,
+				promise: deferredPromise,
+				clear,
+				reject,
+				resolve: async (
+					publicKeyHash: string,
+					responseRequestId: Uint8Array,
+				) => {
+					try {
+						throwIfCheckedPruneLifecycleInactive();
+					} catch (error) {
+						reject(error);
+						return;
+					}
+					if (
+						!checkedPruneCoordinator.isCurrentRequestId(
+							entry.hash,
+							pending,
+							responseRequestId,
+						) ||
+						!checkedPruneCoordinator
+							.getContactedReplicators(entry.hash)
+							?.has(publicKeyHash)
+					) {
+						return;
+					}
+					const exactConfirmations =
+						checkedPruneCoordinator.addConfirmedReplicator(
 							entry.hash,
 							publicKeyHash,
+							pending,
+							responseRequestId,
 						);
-						// Seed provider hints so future remote reads can avoid extra round-trips.
-						this.remoteBlocks.hintProviders(entry.hash, [publicKeyHash]);
+					if (!exactConfirmations) {
+						return;
+					}
+					// Seed provider hints so future remote reads can avoid extra round-trips.
+					this.remoteBlocks.hintProviders(entry.hash, [publicKeyHash]);
 
-						if (minReplicasValue <= existCounter.size) {
-							resolve();
-						}
-					},
+					if (!deleteScheduled && minReplicasValue <= exactConfirmations.size) {
+						deleteScheduled = true;
+						resolveDelete();
+					}
 				},
+			};
+			checkedPruneCoordinator.setPendingDelete(
+				entry.hash,
+				pending,
 				entry,
 				leaders,
 			);
@@ -26988,23 +26989,35 @@ export class SharedLog<
 
 		const emitMessages = async (entries: string[], to: string) => {
 			throwIfCheckedPruneLifecycleInactive();
-			const filteredSet: string[] = [];
-			for (const entry of entries) {
-				/* TODO why can we not have this statement? 
-				if (set.has(to)) {
-					continue;
-				} */
-				checkedPruneCoordinator.addRequestSent(entry, to);
-				filteredSet.push(entry);
+			const pendingEntries = [...new Set(entries)].flatMap((hash) => {
+				const pending = checkedPruneCoordinator.getPendingDelete(hash);
+				return pending ? [{ hash, pending }] : [];
+			});
+			while (true) {
+				const grantSends = pendingEntries.flatMap(({ hash }) => {
+					const send = checkedPruneCoordinator.waitForGrantSends(hash);
+					return send ? [send] : [];
+				});
+				if (grantSends.length === 0) {
+					break;
+				}
+				await Promise.all(grantSends);
+				throwIfCheckedPruneLifecycleInactive();
 			}
-			if (filteredSet.length > 0) {
+			const requests: Array<{ hash: string; requestId: Uint8Array }> = [];
+			for (const { hash, pending } of pendingEntries) {
+				if (checkedPruneCoordinator.addRequestSent(hash, to, pending)) {
+					requests.push({ hash, requestId: pending.requestId });
+				}
+			}
+			if (requests.length > 0) {
 				const result = await this.rpc.send(
-					new RequestIPrune({
-						hashes: filteredSet,
+					new RequestIPruneV2({
+						requests,
 					}),
 					{
 						mode: new AcknowledgeDelivery({
-							to: [to], // TODO group by peers?
+							to: [to],
 							redundancy: 1,
 						}),
 						priority: CONVERGENCE_MESSAGE_PRIORITY,
@@ -27401,7 +27414,7 @@ export class SharedLog<
 						if (oldPeersSet) {
 							for (const oldPeer of oldPeersSet) {
 								if (!currentPeers.has(oldPeer)) {
-									this.removePruneRequestSent(entryReplicated.hash);
+									this.removePruneRequestSent(entryReplicated.hash, oldPeer);
 								}
 							}
 						}
@@ -27442,8 +27455,6 @@ export class SharedLog<
 							if (!isOwnershipLifecycleCurrent()) {
 								return false;
 							}
-
-							this.responseToPruneDebouncedFn.delete(entryReplicated.hash);
 						} else {
 							throwIfOwnershipLifecycleInactive();
 							await this.cancelCheckedPruneForLocalLeader(entryReplicated.hash);
@@ -27492,7 +27503,7 @@ export class SharedLog<
 					if (oldPeersSet) {
 						for (const oldPeer of oldPeersSet) {
 							if (!currentPeers.has(oldPeer)) {
-								this.removePruneRequestSent(entryReplicated.hash);
+								this.removePruneRequestSent(entryReplicated.hash, oldPeer);
 							}
 						}
 					}
@@ -27533,8 +27544,6 @@ export class SharedLog<
 						if (!isOwnershipLifecycleCurrent()) {
 							return false;
 						}
-
-						this.responseToPruneDebouncedFn.delete(entryReplicated.hash); // don't allow others to prune because of expecting me to replicating this entry
 					} else {
 						throwIfOwnershipLifecycleInactive();
 						await this.cancelCheckedPruneForLocalLeader(entryReplicated.hash);

--- a/packages/programs/data/shared-log/test/checked-prune-coordinator.spec.ts
+++ b/packages/programs/data/shared-log/test/checked-prune-coordinator.spec.ts
@@ -1,0 +1,331 @@
+import { expect } from "chai";
+import pDefer from "p-defer";
+import {
+	CheckedPruneCoordinator,
+	type CheckedPrunePendingDelete,
+} from "../src/checked-prune.js";
+
+const requestId = (value: number) => new Uint8Array(32).fill(value);
+
+const pendingDelete = (
+	id: Uint8Array,
+	onClear: () => void = () => {},
+): CheckedPrunePendingDelete => ({
+	requestId: id,
+	promise: pDefer<void>(),
+	clear: onClear,
+	resolve: () => {},
+	reject: () => {},
+});
+
+const setPending = (
+	coordinator: CheckedPruneCoordinator<Uint8Array, "u32">,
+	hash: string,
+	pending: CheckedPrunePendingDelete,
+) => coordinator.setPendingDelete(hash, pending, {} as any, new Map());
+
+describe("checked prune coordinator", () => {
+	it("accepts only exact responses from contacted peers", () => {
+		const coordinator = new CheckedPruneCoordinator<Uint8Array, "u32">();
+		const pending = pendingDelete(requestId(1));
+		setPending(coordinator, "hash", pending);
+		expect(coordinator.addRequestSent("hash", "peer", pending)).true;
+
+		expect(
+			coordinator.addConfirmedReplicator("hash", "peer", pending, requestId(2)),
+		).equal(undefined);
+		expect(
+			coordinator.addConfirmedReplicator(
+				"hash",
+				"other-peer",
+				pending,
+				pending.requestId,
+			),
+		).equal(undefined);
+
+		const confirmed = coordinator.addConfirmedReplicator(
+			"hash",
+			"peer",
+			pending,
+			pending.requestId,
+		);
+		expect(confirmed).to.deep.equal(new Set(["peer"]));
+		expect(
+			coordinator.addConfirmedReplicator(
+				"hash",
+				"peer",
+				pending,
+				pending.requestId,
+			),
+		).to.deep.equal(new Set(["peer"]));
+		expect(
+			coordinator.getExactConfirmedReplicators("hash", pending),
+		).to.deep.equal(new Set(["peer"]));
+	});
+
+	it("fences stale pending generations", () => {
+		const coordinator = new CheckedPruneCoordinator<Uint8Array, "u32">();
+		const first = pendingDelete(requestId(1));
+		const second = pendingDelete(requestId(2));
+		setPending(coordinator, "hash", first);
+		expect(coordinator.addRequestSent("hash", "peer", first)).true;
+		expect(
+			coordinator.addConfirmedReplicator(
+				"hash",
+				"peer",
+				first,
+				first.requestId,
+			),
+		).to.not.equal(undefined);
+
+		setPending(coordinator, "hash", second);
+		expect(coordinator.getContactedReplicators("hash")).equal(undefined);
+		expect(coordinator.getConfirmedReplicators("hash")).equal(undefined);
+		expect(coordinator.addRequestSent("hash", "peer", first)).false;
+		expect(coordinator.markRemoving("hash", first)).false;
+		expect(coordinator.markDone("hash", first)).false;
+		expect(coordinator.markCancelled("hash", first)).false;
+		expect(coordinator.getPendingDelete("hash")).equal(second);
+	});
+
+	it("permanently revokes a removed peer for the current generation", () => {
+		const coordinator = new CheckedPruneCoordinator<Uint8Array, "u32">();
+		const pending = pendingDelete(requestId(1));
+		setPending(coordinator, "hash", pending);
+		coordinator.addRequestSent("hash", "peer", pending);
+		coordinator.addConfirmedReplicator(
+			"hash",
+			"peer",
+			pending,
+			pending.requestId,
+		);
+
+		coordinator.removeRequestSent("hash", "peer");
+		expect(
+			coordinator.getExactConfirmedReplicators("hash", pending).size,
+		).equal(0);
+		expect(coordinator.addRequestSent("hash", "peer", pending)).false;
+
+		const replacement = pendingDelete(requestId(2));
+		setPending(coordinator, "hash", replacement);
+		expect(coordinator.addRequestSent("hash", "peer", replacement)).true;
+		coordinator.addConfirmedReplicator(
+			"hash",
+			"peer",
+			replacement,
+			replacement.requestId,
+		);
+		coordinator.cleanupPeer("peer");
+		expect(
+			coordinator.getExactConfirmedReplicators("hash", replacement).size,
+		).equal(0);
+		expect(coordinator.addRequestSent("hash", "peer", replacement)).false;
+	});
+
+	it("revokes a cleanup peer before the first request is emitted", () => {
+		const coordinator = new CheckedPruneCoordinator<Uint8Array, "u32">();
+		const pending = pendingDelete(requestId(1));
+		setPending(coordinator, "hash", pending);
+
+		coordinator.cleanupPeer("peer");
+		expect(coordinator.addRequestSent("hash", "peer", pending)).false;
+
+		const replacement = pendingDelete(requestId(2));
+		setPending(coordinator, "hash", replacement);
+		expect(coordinator.addRequestSent("hash", "peer", replacement)).true;
+	});
+
+	it("invalidates exact generations led by or sent to a removed peer", () => {
+		const coordinator = new CheckedPruneCoordinator<Uint8Array, "u32">();
+		const leaderPending = pendingDelete(requestId(1));
+		const contactedPending = pendingDelete(requestId(2));
+		const unrelatedPending = pendingDelete(requestId(3));
+		const leaderEntry = { hash: "leader" } as any;
+		const contactedEntry = { hash: "contacted" } as any;
+		const unrelatedEntry = { hash: "unrelated" } as any;
+		const leaderMap = new Map([["peer", { intersecting: true }]]);
+		const contactedLeaders = new Set(["other-peer"]);
+
+		coordinator.setPendingDelete(
+			"leader",
+			leaderPending,
+			leaderEntry,
+			leaderMap,
+		);
+		coordinator.setPendingDelete(
+			"contacted",
+			contactedPending,
+			contactedEntry,
+			contactedLeaders,
+		);
+		coordinator.setPendingDelete(
+			"unrelated",
+			unrelatedPending,
+			unrelatedEntry,
+			new Set(["other-peer"]),
+		);
+		expect(coordinator.addRequestSent("contacted", "peer", contactedPending))
+			.true;
+
+		const invalidated = coordinator.cleanupPeer("peer");
+		expect(invalidated.map(({ hash }) => hash).sort()).to.deep.equal([
+			"contacted",
+			"leader",
+		]);
+		expect(invalidated.find(({ hash }) => hash === "leader")?.pending).equal(
+			leaderPending,
+		);
+		expect(invalidated.find(({ hash }) => hash === "contacted")?.entry).equal(
+			contactedEntry,
+		);
+		const snapshottedLeaderMap = invalidated.find(
+			({ hash }) => hash === "leader",
+		)?.leaders;
+		expect(snapshottedLeaderMap).to.deep.equal(leaderMap);
+		expect(snapshottedLeaderMap).to.not.equal(leaderMap);
+		expect(coordinator.addRequestSent("leader", "peer", leaderPending)).false;
+		expect(coordinator.addRequestSent("contacted", "peer", contactedPending))
+			.false;
+		expect(coordinator.addRequestSent("unrelated", "peer", unrelatedPending))
+			.false;
+
+		for (const generation of invalidated) {
+			coordinator.markCancelled(generation.hash, generation.pending);
+		}
+		expect(coordinator.cleanupPeer("peer")).to.deep.equal([]);
+	});
+
+	it("keeps overlapping peer-removal fences until every owner releases", () => {
+		const coordinator = new CheckedPruneCoordinator<Uint8Array, "u32">();
+		const pending = pendingDelete(requestId(1));
+		setPending(coordinator, "hash", pending);
+		coordinator.addRequestSent("hash", "peer", pending);
+		coordinator.addConfirmedReplicator(
+			"hash",
+			"peer",
+			pending,
+			pending.requestId,
+		);
+
+		const releaseFirst = coordinator.fencePeerRemoval("peer");
+		const releaseSecond = coordinator.fencePeerRemoval("peer");
+		expect(coordinator.isPeerRemovalFenced("peer")).true;
+		expect(
+			coordinator.getExactConfirmedReplicators("hash", pending).size,
+		).equal(0);
+
+		releaseFirst();
+		releaseFirst();
+		expect(coordinator.isPeerRemovalFenced("peer")).true;
+		expect(
+			coordinator.getExactConfirmedReplicators("hash", pending).size,
+		).equal(0);
+
+		releaseSecond();
+		expect(coordinator.isPeerRemovalFenced("peer")).false;
+		expect(
+			coordinator.getExactConfirmedReplicators("hash", pending),
+		).deep.equal(new Set(["peer"]));
+	});
+
+	it("waits for every grant send and releases rejected barriers", async () => {
+		const coordinator = new CheckedPruneCoordinator<Uint8Array, "u32">();
+		const first = pDefer<void>();
+		const second = pDefer<void>();
+		coordinator.trackGrantSend(["hash"], first.promise);
+		coordinator.trackGrantSend(["hash"], second.promise);
+
+		const waiting = coordinator.waitForGrantSends("hash");
+		expect(waiting).to.exist;
+		let settled = false;
+		void waiting!.then(() => {
+			settled = true;
+		});
+
+		first.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(settled).to.be.false;
+
+		second.reject(new Error("grant send aborted"));
+		await waiting;
+		await Promise.resolve();
+		expect(settled).to.be.true;
+		expect(coordinator.waitForGrantSends("hash")).to.be.undefined;
+	});
+
+	it("consumes only the current deferred restart reservation", () => {
+		const coordinator = new CheckedPruneCoordinator<Uint8Array, "u32">();
+		const first = coordinator.reserveRestart("hash");
+		expect(coordinator.consumeRestartReservation("hash", first)).to.be.true;
+		expect(coordinator.consumeRestartReservation("hash", first)).to.be.false;
+
+		const supersededByCandidate = coordinator.reserveRestart("hash");
+		const candidateToken = coordinator.trackCandidate(
+			"hash",
+			{ hash: "hash" } as any,
+			new Set(["peer"]),
+		);
+		expect(coordinator.hasCandidate("hash")).to.be.true;
+		expect(coordinator.isCandidateTokenCurrent("hash", candidateToken)).to.be
+			.true;
+		expect(coordinator.consumeRestartReservation("hash", supersededByCandidate))
+			.to.be.false;
+		coordinator.invalidateCandidateToken("hash");
+		expect(coordinator.hasCandidate("hash")).to.be.false;
+		expect(coordinator.isCandidateTokenCurrent("hash", candidateToken)).to.be
+			.false;
+
+		const supersededByGeneration = coordinator.reserveRestart("hash");
+		const stalePending = pendingDelete(requestId(1));
+		coordinator.setPendingDelete(
+			"hash",
+			stalePending,
+			{ hash: "hash" } as any,
+			new Set(["peer"]),
+		);
+		expect(
+			coordinator.consumeRestartReservation("hash", supersededByGeneration),
+		).to.be.false;
+
+		const currentPending = pendingDelete(requestId(2));
+		coordinator.setPendingDelete(
+			"hash",
+			currentPending,
+			{ hash: "hash" } as any,
+			new Set(["peer"]),
+		);
+		const preservedAcrossStaleCancel = coordinator.reserveRestart("hash");
+		expect(coordinator.markCancelled("hash", stalePending)).to.be.false;
+		expect(
+			coordinator.consumeRestartReservation("hash", preservedAcrossStaleCancel),
+		).to.be.true;
+
+		const cancelled = coordinator.reserveRestart("hash");
+		expect(coordinator.markCancelled("hash", currentPending)).to.be.true;
+		expect(coordinator.consumeRestartReservation("hash", cancelled)).to.be
+			.false;
+	});
+
+	it("clears every authorization generation on close", () => {
+		let clears = 0;
+		const coordinator = new CheckedPruneCoordinator<Uint8Array, "u32">();
+		const pending = pendingDelete(requestId(1), () => {
+			clears += 1;
+		});
+		setPending(coordinator, "hash", pending);
+		coordinator.addRequestSent("hash", "peer", pending);
+		coordinator.addConfirmedReplicator(
+			"hash",
+			"peer",
+			pending,
+			pending.requestId,
+		);
+
+		coordinator.close();
+		expect(clears).equal(1);
+		expect(coordinator.pendingDeletes.size).equal(0);
+		expect(coordinator.requestIPruneSent.size).equal(0);
+		expect(coordinator.responseReplicatorSet.size).equal(0);
+	});
+});

--- a/packages/programs/data/shared-log/test/checked-prune-handoff.spec.ts
+++ b/packages/programs/data/shared-log/test/checked-prune-handoff.spec.ts
@@ -1,0 +1,2084 @@
+import { Ed25519Keypair, randomBytes } from "@peerbit/crypto";
+import { AcknowledgeDelivery } from "@peerbit/stream-interface";
+import { TestSession } from "@peerbit/test-utils";
+import { waitForResolved } from "@peerbit/time";
+import { expect } from "chai";
+import pDefer from "p-defer";
+import sinon from "sinon";
+import {
+	RequestIPrune,
+	RequestIPruneV2,
+	ResponseIPrune,
+	ResponseIPruneV2,
+} from "../src/exchange-heads.js";
+import { EventStore } from "./utils/stores/index.js";
+
+describe("checked prune correlated handoff", () => {
+	let session: TestSession | undefined;
+
+	afterEach(async () => {
+		await session?.stop();
+		session = undefined;
+	});
+
+	it("requires an exact id, contacted signer, and full quorum", async () => {
+		session = await TestSession.disconnected(3);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-exact-quorum");
+		const remoteKeys = session.peers
+			.slice(1)
+			.map((peer) => peer.identity.publicKey);
+		const remoteHashes = remoteKeys.map((key) => key.hashcode());
+		const leaders = new Map(
+			remoteHashes.map((hash) => [hash, { intersecting: true }]),
+		);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const replicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 2 });
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.resolves({ leaders, localLeader: false });
+		const remove = sinon.spy(log.log, "remove");
+		let pruning: Promise<unknown> | undefined;
+
+		try {
+			[pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			await waitForResolved(() => {
+				expect(
+					log._checkedPrune.getContactedReplicators(entry.hash)?.size,
+				).to.equal(2);
+			});
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			expect(pending).to.exist;
+			const outboundRequests = send
+				.getCalls()
+				.map((call) => call.args[0])
+				.filter(
+					(message): message is RequestIPruneV2 =>
+						message instanceof RequestIPruneV2,
+				);
+			expect(outboundRequests).to.have.length(2);
+			for (const message of outboundRequests) {
+				expect(message.requests).to.have.length(1);
+				expect(message.requests[0]?.requestId).to.deep.equal(pending.requestId);
+			}
+
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [
+						{ hash: entry.hash, requestId: pending.requestId },
+						{ hash: entry.hash, requestId: pending.requestId },
+					],
+				}),
+				{ from: remoteKeys[0] } as any,
+			);
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [
+						{ hash: entry.hash, requestId: new Uint8Array(32).fill(9) },
+					],
+				}),
+				{ from: remoteKeys[0] } as any,
+			);
+			const unknownKey = (await Ed25519Keypair.create()).publicKey;
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [{ hash: entry.hash, requestId: pending.requestId }],
+				}),
+				{ from: unknownKey } as any,
+			);
+			expect(
+				log._checkedPrune.getConfirmedReplicators(entry.hash)?.size ?? 0,
+			).to.equal(0);
+
+			const firstResponse = new ResponseIPruneV2({
+				requests: [{ hash: entry.hash, requestId: pending.requestId }],
+			});
+			await db.log.onMessage(firstResponse, { from: remoteKeys[0] } as any);
+			await db.log.onMessage(firstResponse, { from: remoteKeys[0] } as any);
+			expect(
+				log._checkedPrune.getConfirmedReplicators(entry.hash)?.size,
+			).to.equal(1);
+			expect(remove.called).false;
+
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [{ hash: entry.hash, requestId: pending.requestId }],
+				}),
+				{ from: remoteKeys[1] } as any,
+			);
+			await pruning;
+			expect(remove.calledOnce).true;
+			expect(await log.log.has(entry.hash)).false;
+		} finally {
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(pruning ? [pruning] : []);
+			remove.restore();
+			revalidate.restore();
+			replicas.restore();
+			send.restore();
+		}
+	});
+
+	it("does not attach an old response to a replacement generation", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-stale-generation");
+		const remoteKey = session.peers[1].identity.publicKey;
+		const remoteHash = remoteKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const replicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		let first: Promise<unknown> | undefined;
+		let second: Promise<unknown> | undefined;
+
+		try {
+			[first] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			const firstOutcome = first!.catch((error) => error);
+			await waitForResolved(() => {
+				expect(log._checkedPrune.getPendingDelete(entry.hash)).to.exist;
+				expect(
+					log._checkedPrune
+						.getContactedReplicators(entry.hash)
+						?.has(remoteHash),
+				).true;
+			});
+			const firstId = log._checkedPrune
+				.getPendingDelete(entry.hash)
+				.requestId.slice();
+			const firstPending = log._checkedPrune.getPendingDelete(entry.hash);
+			log._checkedPrune.cleanupPeer(remoteHash);
+			expect(
+				log._checkedPrune.addRequestSent(entry.hash, remoteHash, firstPending),
+			).false;
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [{ hash: entry.hash, requestId: firstId }],
+				}),
+				{ from: remoteKey } as any,
+			);
+			expect(
+				log._checkedPrune.getConfirmedReplicators(entry.hash)?.size ?? 0,
+			).to.equal(0);
+			await log.cancelCheckedPruneForLocalLeader(entry.hash);
+			expect(await firstOutcome).to.be.instanceOf(Error);
+
+			[second] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			const secondOutcome = second!.catch((error) => error);
+			await waitForResolved(() => {
+				const pending = log._checkedPrune.getPendingDelete(entry.hash);
+				expect(pending).to.exist;
+				expect(
+					log._checkedPrune
+						.getContactedReplicators(entry.hash)
+						?.has(remoteHash),
+				).true;
+				expect([...pending.requestId]).to.not.deep.equal([...firstId]);
+			});
+
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [{ hash: entry.hash, requestId: firstId }],
+				}),
+				{ from: remoteKey } as any,
+			);
+			expect(
+				log._checkedPrune.getConfirmedReplicators(entry.hash)?.size ?? 0,
+			).to.equal(0);
+
+			await log.cancelCheckedPruneForLocalLeader(entry.hash);
+			expect(await secondOutcome).to.be.instanceOf(Error);
+		} finally {
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(
+				[first, second].filter(
+					(value): value is Promise<unknown> => value != null,
+				),
+			);
+			replicas.restore();
+			send.restore();
+		}
+	});
+
+	it("uses a fresh generation when a revoked peer becomes a leader again", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-rejoined-leader");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const sent: RequestIPruneV2[] = [];
+		const send = sinon.stub(log.rpc, "send").callsFake(async (message) => {
+			if (message instanceof RequestIPruneV2) {
+				sent.push(message);
+			}
+		});
+		const replicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		let first: Promise<unknown> | undefined;
+		let second: Promise<unknown> | undefined;
+
+		try {
+			[first] = log.prune(new Map([[entry.hash, { entry, leaders }]]));
+			const firstOutcome = first!.catch((error) => error);
+			await waitForResolved(() => {
+				expect(
+					log._checkedPrune
+						.getContactedReplicators(entry.hash)
+						?.has(remoteHash),
+				).to.be.true;
+			});
+			const firstPending = log._checkedPrune.getPendingDelete(entry.hash);
+			const firstId = firstPending.requestId.slice();
+
+			log.removePruneRequestSent(entry.hash, remoteHash);
+			[second] = log.prune(new Map([[entry.hash, { entry, leaders }]]));
+			void second!.catch(() => {});
+
+			expect(await firstOutcome).to.be.instanceOf(Error);
+			const secondPending = log._checkedPrune.getPendingDelete(entry.hash);
+			expect(secondPending).to.exist;
+			expect(secondPending).to.not.equal(firstPending);
+			expect([...secondPending.requestId]).to.not.deep.equal([...firstId]);
+			await waitForResolved(() => {
+				expect(
+					log._checkedPrune
+						.getContactedReplicators(entry.hash)
+						?.has(remoteHash),
+				).to.be.true;
+			});
+			expect(
+				sent.some((message) =>
+					message.requests.some(
+						(request) =>
+							request.hash === entry.hash &&
+							request.requestId.every(
+								(value, index) => value === secondPending.requestId[index],
+							),
+					),
+				),
+			).to.be.true;
+		} finally {
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(
+				[first, second].filter(
+					(value): value is Promise<unknown> => value != null,
+				),
+			);
+			replicas.restore();
+			send.restore();
+		}
+	});
+
+	it("rejects confirmations excluded by the final leader set", async () => {
+		session = await TestSession.disconnected(3);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-final-leader-set");
+		const confirmingKey = session.peers[1].identity.publicKey;
+		const confirmingHash = confirmingKey.hashcode();
+		const replacementHash = session.peers[2].identity.publicKey.hashcode();
+		const originalLeaders = new Map([[confirmingHash, { intersecting: true }]]);
+		const replacementLeaders = new Map([
+			[replacementHash, { intersecting: true }],
+		]);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const replicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.resolves({
+				leaders: replacementLeaders,
+				localLeader: false,
+			});
+		const remove = sinon.spy(log.log, "remove");
+		let pruning: Promise<unknown> | undefined;
+
+		try {
+			[pruning] = log.prune(
+				new Map([[entry.hash, { entry, leaders: originalLeaders }]]),
+				{ timeout: 5_000 },
+			);
+			await waitForResolved(() => {
+				expect(log._checkedPrune.getPendingDelete(entry.hash)).to.exist;
+				expect(
+					log._checkedPrune
+						.getContactedReplicators(entry.hash)
+						?.has(confirmingHash),
+				).true;
+			});
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [{ hash: entry.hash, requestId: pending.requestId }],
+				}),
+				{ from: confirmingKey } as any,
+			);
+
+			await expect(pruning).to.be.rejectedWith("is leader again");
+			expect(remove.called).false;
+			expect(await log.log.has(entry.hash)).true;
+		} finally {
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(pruning ? [pruning] : []);
+			remove.restore();
+			revalidate.restore();
+			replicas.restore();
+			send.restore();
+		}
+	});
+
+	it("rejects confirmations from a peer whose unsubscribe has started", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-blocked-peer");
+		const remoteKey = session.peers[1].identity.publicKey;
+		const remoteHash = remoteKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const replicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.resolves({ leaders, localLeader: false });
+		const remove = sinon.spy(log.log, "remove");
+		let pruning: Promise<unknown> | undefined;
+
+		try {
+			[pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			await waitForResolved(
+				() =>
+					expect(
+						log._checkedPrune
+							.getContactedReplicators(entry.hash)
+							?.has(remoteHash),
+					).true,
+			);
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			log._replicationInfoBlockedPeers.add(remoteHash);
+			// Model a response that was already admitted by the receive handler just
+			// before unsubscribe blocked the peer. The final in-lane boundary must
+			// still exclude that peer from the destructive quorum.
+			await pending.resolve(remoteHash, pending.requestId);
+
+			await expect(pruning).to.be.rejectedWith("is leader again");
+			expect(remove.called).false;
+			expect(await log.log.has(entry.hash)).true;
+		} finally {
+			log._replicationInfoBlockedPeers.delete(remoteHash);
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(pruning ? [pruning] : []);
+			remove.restore();
+			revalidate.restore();
+			replicas.restore();
+			send.restore();
+		}
+	});
+
+	it("temporarily fences liveness removal without poisoning a cancelled handoff", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry: fencedEntry } = await db.add(
+			"checked-prune-liveness-removal-fenced",
+			{ meta: { next: [] } },
+		);
+		const { entry: resumedEntry } = await db.add(
+			"checked-prune-liveness-removal-resumed",
+			{ meta: { next: [] } },
+		);
+		const remoteKey = session.peers[1].identity.publicKey;
+		const remoteHash = remoteKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const replicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.resolves({ leaders, localLeader: false });
+		const remove = sinon.spy(log.log, "remove");
+		const releaseApplyQueue = pDefer<void>();
+		const applyQueueStarted = pDefer<void>();
+		const applyQueueBlocker = log.withReplicationInfoApplyQueue(
+			remoteHash,
+			async () => {
+				applyQueueStarted.resolve();
+				await releaseApplyQueue.promise;
+			},
+		);
+		const drain = sinon.spy(log, "drainPeerReceiveHandlers");
+		const observedActivityAt = log._replicatorLastActivityAt.get(remoteHash);
+		let fencedPruning: Promise<unknown> | undefined;
+		let resumedPruning: Promise<unknown> | undefined;
+		let removing: Promise<boolean> | undefined;
+
+		try {
+			await applyQueueStarted.promise;
+			[fencedPruning, resumedPruning] = log.prune(
+				new Map([
+					[fencedEntry.hash, { entry: fencedEntry, leaders }],
+					[resumedEntry.hash, { entry: resumedEntry, leaders }],
+				]),
+				{ timeout: 5_000 },
+			);
+			await waitForResolved(() => {
+				expect(
+					log._checkedPrune
+						.getContactedReplicators(fencedEntry.hash)
+						?.has(remoteHash),
+				).true;
+				expect(
+					log._checkedPrune
+						.getContactedReplicators(resumedEntry.hash)
+						?.has(remoteHash),
+				).true;
+			});
+			const fencedPending = log._checkedPrune.getPendingDelete(
+				fencedEntry.hash,
+			);
+			const resumedPending = log._checkedPrune.getPendingDelete(
+				resumedEntry.hash,
+			);
+
+			removing = log.removeReplicator(remoteKey, {
+				shouldRemove: () =>
+					log._replicatorLastActivityAt.get(remoteHash) === observedActivityAt,
+			});
+			expect(log._receiveCleanupGateByPeer.has(remoteHash)).to.be.false;
+			expect(log._checkedPrune.isPeerRemovalFenced(remoteHash)).to.be.true;
+
+			// A receipt admitted just before/during the speculative removal cannot
+			// authorize deletion while the liveness fence is active.
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [
+						{
+							hash: fencedEntry.hash,
+							requestId: fencedPending.requestId,
+						},
+					],
+				}),
+				{ from: remoteKey } as any,
+			);
+
+			await expect(fencedPruning).to.be.rejectedWith("is leader again");
+			expect(remove.called).to.be.false;
+			expect(await log.log.has(fencedEntry.hash)).to.be.true;
+
+			releaseApplyQueue.resolve();
+			expect(await removing).to.be.false;
+			expect(log._receiveCleanupGateByPeer.has(remoteHash)).to.be.false;
+			expect(log._checkedPrune.isPeerRemovalFenced(remoteHash)).to.be.false;
+			expect(drain.called).to.be.false;
+			await applyQueueBlocker;
+
+			// Fresh activity cancelled the speculative removal, so it must not have
+			// permanently revoked this peer from the still-active generation.
+			expect(
+				log._checkedPrune
+					.getContactedReplicators(resumedEntry.hash)
+					?.has(remoteHash),
+			).true;
+			expect(log._checkedPrune.getPendingDelete(resumedEntry.hash)).to.equal(
+				resumedPending,
+			);
+			expect(log._checkedPrune.hasRetry(resumedEntry.hash)).to.be.false;
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [
+						{
+							hash: resumedEntry.hash,
+							requestId: resumedPending.requestId,
+						},
+					],
+				}),
+				{ from: remoteKey } as any,
+			);
+			await resumedPruning;
+			expect(remove.calledOnce).true;
+			expect(await log.log.has(resumedEntry.hash)).to.be.false;
+		} finally {
+			log.markReplicatorActivity(remoteHash);
+			releaseApplyQueue.resolve();
+			await Promise.allSettled([
+				applyQueueBlocker,
+				...(fencedPruning ? [fencedPruning] : []),
+				...(resumedPruning ? [resumedPruning] : []),
+				...(removing ? [removing] : []),
+			]);
+			drain.restore();
+			remove.restore();
+			revalidate.restore();
+			replicas.restore();
+			send.restore();
+		}
+	});
+
+	it("restarts only background handoffs after a committed peer removal", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry: backgroundEntry } = await db.add(
+			"checked-prune-peer-cleanup-background",
+			{ meta: { next: [] } },
+		);
+		const { entry: explicitEntry } = await db.add(
+			"checked-prune-peer-cleanup-explicit",
+			{ meta: { next: [] } },
+		);
+		const remoteKey = session.peers[1].identity.publicKey;
+		const remoteHash = remoteKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const replicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const retry = sinon.spy(log, "scheduleCheckedPruneRetry");
+		let backgroundPruning: Promise<unknown> | undefined;
+		let explicitPruning: Promise<unknown> | undefined;
+
+		try {
+			log._checkedPrune.setRetry(backgroundEntry.hash, {
+				attempts: 1,
+				entry: backgroundEntry,
+				leaders,
+			});
+			[backgroundPruning] = log.prune(
+				new Map([[backgroundEntry.hash, { entry: backgroundEntry, leaders }]]),
+			);
+			const backgroundOutcome = backgroundPruning!.then(
+				() => ({ error: undefined }),
+				(error) => ({ error }),
+			);
+			[explicitPruning] = log.prune(
+				new Map([[explicitEntry.hash, { entry: explicitEntry, leaders }]]),
+				{ timeout: 5_000 },
+			);
+			const explicitOutcome = explicitPruning!.then(
+				() => ({ error: undefined }),
+				(error) => ({ error }),
+			);
+
+			await waitForResolved(() => {
+				expect(
+					log._checkedPrune
+						.getContactedReplicators(backgroundEntry.hash)
+						?.has(remoteHash),
+				).true;
+				expect(
+					log._checkedPrune
+						.getContactedReplicators(explicitEntry.hash)
+						?.has(remoteHash),
+				).true;
+			});
+			const backgroundRequestId = log._checkedPrune
+				.getPendingDelete(backgroundEntry.hash)
+				.requestId.slice();
+			const explicitRequestId = log._checkedPrune
+				.getPendingDelete(explicitEntry.hash)
+				.requestId.slice();
+			expect([...backgroundRequestId]).to.not.deep.equal([
+				...explicitRequestId,
+			]);
+
+			expect(
+				await log.removeReplicator(remoteKey, {
+					shouldRemove: () => true,
+				}),
+			).to.be.true;
+
+			const [backgroundResult, explicitResult] = await Promise.all([
+				backgroundOutcome,
+				explicitOutcome,
+			]);
+			expect(backgroundResult.error).to.be.instanceOf(Error);
+			expect((backgroundResult.error as Error).message).to.include(
+				"generation invalidated by peer cleanup",
+			);
+			expect(explicitResult.error).to.be.instanceOf(Error);
+			expect((explicitResult.error as Error).message).to.include(
+				"generation invalidated by peer cleanup",
+			);
+
+			expect(log._checkedPrune.getPendingDelete(backgroundEntry.hash)).to.be
+				.undefined;
+			expect(log._checkedPrune.getPendingDelete(explicitEntry.hash)).to.be
+				.undefined;
+			expect(await log.log.has(backgroundEntry.hash)).to.be.true;
+			expect(await log.log.has(explicitEntry.hash)).to.be.true;
+
+			// A committed removal cleans the peer in the mutation lane and again
+			// while retiring its disconnected state. The generation must only be
+			// invalidated and requeued once across those idempotent cleanup passes.
+			expect(retry.calledOnce).to.be.true;
+			expect(retry.firstCall.args[0].entry.hash).to.equal(backgroundEntry.hash);
+			const retryState = log._checkedPrune.getRetry(backgroundEntry.hash);
+			expect(retryState?.attempts).to.equal(2);
+			expect(retryState?.entry.hash).to.equal(backgroundEntry.hash);
+			expect(log._checkedPrune.hasPendingDelete(backgroundEntry.hash)).to.be
+				.false;
+			expect(log._checkedPrune.hasRetry(explicitEntry.hash)).to.be.false;
+		} finally {
+			log._checkedPrune.clearRetry(backgroundEntry.hash);
+			log._checkedPrune.clearRetry(explicitEntry.hash);
+			await log
+				.cancelCheckedPruneForLocalLeader(backgroundEntry.hash)
+				.catch(() => {});
+			await log
+				.cancelCheckedPruneForLocalLeader(explicitEntry.hash)
+				.catch(() => {});
+			await Promise.allSettled(
+				[backgroundPruning, explicitPruning].filter(
+					(value): value is Promise<unknown> => value != null,
+				),
+			);
+			retry.restore();
+			replicas.restore();
+			send.restore();
+		}
+	});
+
+	it("does not retain a retry when peer cleanup belongs to a stale lifecycle", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-stale-cleanup");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const replicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const retry = sinon.spy(log, "scheduleCheckedPruneRetry");
+		let pruning: Promise<unknown> | undefined;
+
+		try {
+			[pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]));
+			const outcome = pruning!.then(
+				() => ({ error: undefined }),
+				(error) => ({ error }),
+			);
+			await waitForResolved(() => {
+				expect(
+					log._checkedPrune
+						.getContactedReplicators(entry.hash)
+						?.has(remoteHash),
+				).true;
+			});
+
+			const staleLifecycle = log._repairLifecycleController;
+			log.startRepairLifecycle();
+			log.cleanupCheckedPrunePeer(
+				remoteHash,
+				staleLifecycle,
+				log._checkedPrune,
+			);
+
+			const result = await outcome;
+			expect(result.error).to.be.instanceOf(Error);
+			expect((result.error as Error).message).to.include(
+				"generation invalidated by peer cleanup",
+			);
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
+			expect(log._checkedPrune.hasRetry(entry.hash)).to.be.false;
+			expect(retry.called).to.be.false;
+			expect(await log.log.has(entry.hash)).to.be.true;
+		} finally {
+			log._checkedPrune.clearRetry(entry.hash);
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(pruning ? [pruning] : []);
+			retry.restore();
+			replicas.restore();
+			send.restore();
+		}
+	});
+
+	it("rearms ownership after a provisional targeted-repair keep", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-targeted-repair-keep");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const replicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		let pruning: Promise<unknown> | undefined;
+
+		try {
+			[pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]));
+			const outcome = pruning!.catch((error) => error);
+			await waitForResolved(() => {
+				expect(log._checkedPrune.getPendingDelete(entry.hash)).to.exist;
+			});
+
+			log.rearmCheckedPruneAfterTemporaryReceive(entry.hash);
+
+			expect(await outcome).to.be.instanceOf(Error);
+			expect(log._checkedPrune.hasPendingDelete(entry.hash)).to.be.false;
+			expect(log._checkedPrune.getRetry(entry.hash)?.attempts).to.equal(1);
+			expect(log._checkedPrune.getRetry(entry.hash)?.timer).to.exist;
+
+			log.rearmCheckedPruneAfterTemporaryReceive("never-admitted-hash");
+			expect(log.hasActiveCheckedPruneWork("never-admitted-hash")).to.be.false;
+		} finally {
+			log._checkedPrune.clearRetry(entry.hash);
+			log.clearCheckedPruneAuditTimer();
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(pruning ? [pruning] : []);
+			replicas.restore();
+			send.restore();
+		}
+	});
+
+	it("orders a replacement request after an admitted grant send", async () => {
+		session = await TestSession.disconnected(3);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-grant-barrier");
+		const prunePeer = session.peers[1].identity.publicKey.hashcode();
+		const requester = session.peers[2].identity.publicKey.hashcode();
+		const leaders = new Map([[prunePeer, { intersecting: true }]]);
+		const responseEntered = pDefer<void>();
+		const releaseResponse = pDefer<void>();
+		const events: string[] = [];
+		const send = sinon
+			.stub(log.rpc, "send")
+			.callsFake(async (message: unknown, options: any) => {
+				if (message instanceof ResponseIPruneV2) {
+					expect(options.mode).to.be.instanceOf(AcknowledgeDelivery);
+					events.push("grant:start");
+					responseEntered.resolve();
+					await releaseResponse.promise;
+					events.push("grant:done");
+				} else if (message instanceof RequestIPruneV2) {
+					events.push("request");
+				}
+			});
+		const replicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const grantLeaders = sinon
+			.stub(log, "revalidateCheckedPruneGrantLocalLeaders")
+			.resolves(new Set([entry.hash]));
+		let first: Promise<unknown> | undefined;
+		let second: Promise<unknown> | undefined;
+
+		try {
+			[first] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			const firstOutcome = first!.catch((error) => {
+				[second] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+					timeout: 5_000,
+				});
+				void second!.catch(() => {});
+				return error;
+			});
+			await waitForResolved(() => {
+				expect(events).to.deep.equal(["request"]);
+			});
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			const granting = log.admitAndSendCheckedPruneGrants(requester, [
+				{ hash: entry.hash, requestId: randomBytes(32) },
+			]);
+			await responseEntered.promise;
+			expect(await firstOutcome).to.be.instanceOf(Error);
+			expect(second).to.exist;
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(events).to.deep.equal(["request", "grant:start"]);
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.not.equal(
+				pending,
+			);
+
+			releaseResponse.resolve();
+			await granting;
+			await waitForResolved(() => {
+				expect(events).to.deep.equal([
+					"request",
+					"grant:start",
+					"grant:done",
+					"request",
+				]);
+			});
+		} finally {
+			releaseResponse.resolve();
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(
+				[first, second].filter(
+					(value): value is Promise<unknown> => value != null,
+				),
+			);
+			grantLeaders.restore();
+			replicas.restore();
+			send.restore();
+		}
+	});
+
+	it("waits for grant barriers added while a request is already waiting", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-overlapping-barriers");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const firstGrant = pDefer<void>();
+		const secondGrant = pDefer<void>();
+		const requests: RequestIPruneV2[] = [];
+		const send = sinon.stub(log.rpc, "send").callsFake(async (message) => {
+			if (message instanceof RequestIPruneV2) {
+				requests.push(message);
+			}
+		});
+		const replicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const waitForGrants = sinon.spy(log._checkedPrune, "waitForGrantSends");
+		let pruning: Promise<unknown> | undefined;
+
+		try {
+			log._checkedPrune.trackGrantSend([entry.hash], firstGrant.promise);
+			[pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			void pruning!.catch(() => {});
+			await waitForResolved(() => {
+				expect(waitForGrants.calledWith(entry.hash)).to.be.true;
+			});
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			expect(pending).to.exist;
+
+			log._checkedPrune.trackGrantSend([entry.hash], secondGrant.promise);
+			firstGrant.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(requests).to.be.empty;
+
+			secondGrant.resolve();
+			await waitForResolved(() => {
+				expect(requests).to.have.length(1);
+			});
+			expect(requests[0]?.requests[0]?.requestId).to.deep.equal(
+				pending.requestId,
+			);
+		} finally {
+			firstGrant.resolve();
+			secondGrant.resolve();
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(pruning ? [pruning] : []);
+			waitForGrants.restore();
+			replicas.restore();
+			send.restore();
+		}
+	});
+
+	it("rearms only background or queued work after an admitted grant is sent", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry: backgroundEntry } = await db.add(
+			"checked-prune-grant-background",
+			{ meta: { next: [] } },
+		);
+		const { entry: explicitEntry } = await db.add(
+			"checked-prune-grant-explicit",
+			{ meta: { next: [] } },
+		);
+		const { entry: queuedEntry } = await db.add("checked-prune-grant-queued", {
+			meta: { next: [] },
+		});
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const responseEntered = pDefer<void>();
+		const releaseResponse = pDefer<void>();
+		const send = sinon.stub(log.rpc, "send").callsFake(async (message) => {
+			if (message instanceof ResponseIPruneV2) {
+				responseEntered.resolve();
+				await releaseResponse.promise;
+			}
+		});
+		const replicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const grantLeaders = sinon
+			.stub(log, "revalidateCheckedPruneGrantLocalLeaders")
+			.resolves(
+				new Set([backgroundEntry.hash, explicitEntry.hash, queuedEntry.hash]),
+			);
+		const retry = sinon.spy(log, "scheduleCheckedPruneRetry");
+		let backgroundPruning: Promise<unknown> | undefined;
+		let explicitPruning: Promise<unknown> | undefined;
+		let queuedAdd: Promise<unknown> | undefined;
+
+		try {
+			[backgroundPruning] = log.prune(
+				new Map([[backgroundEntry.hash, { entry: backgroundEntry, leaders }]]),
+			);
+			const backgroundOutcome = backgroundPruning!.catch((error) => error);
+			[explicitPruning] = log.prune(
+				new Map([[explicitEntry.hash, { entry: explicitEntry, leaders }]]),
+				{ timeout: 5_000 },
+			);
+			const explicitOutcome = explicitPruning!.catch((error) => error);
+			const queuedWorkToken = log._checkedPrune.trackCandidate(
+				queuedEntry.hash,
+				queuedEntry,
+				leaders,
+			);
+			queuedAdd = log.pruneDebouncedFn.add({
+				key: queuedEntry.hash,
+				value: {
+					entry: queuedEntry,
+					leaders,
+					workToken: queuedWorkToken,
+				},
+			});
+			void queuedAdd!.catch(() => {});
+			await waitForResolved(() => {
+				expect(
+					log._checkedPrune
+						.getContactedReplicators(backgroundEntry.hash)
+						?.has(remoteHash),
+				).true;
+				expect(
+					log._checkedPrune
+						.getContactedReplicators(explicitEntry.hash)
+						?.has(remoteHash),
+				).true;
+			});
+
+			const granting = log.admitAndSendCheckedPruneGrants(remoteHash, [
+				{ hash: backgroundEntry.hash, requestId: randomBytes(32) },
+				{ hash: explicitEntry.hash, requestId: randomBytes(32) },
+				{ hash: queuedEntry.hash, requestId: randomBytes(32) },
+			]);
+			await responseEntered.promise;
+			const overlappingGrant = log.admitAndSendCheckedPruneGrants(remoteHash, [
+				{ hash: backgroundEntry.hash, requestId: randomBytes(32) },
+				{ hash: queuedEntry.hash, requestId: randomBytes(32) },
+			]);
+			await waitForResolved(() => {
+				expect(
+					send
+						.getCalls()
+						.filter((call) => call.args[0] instanceof ResponseIPruneV2).length,
+				).to.equal(2);
+			});
+			expect(await backgroundOutcome).to.be.instanceOf(Error);
+			expect(await explicitOutcome).to.be.instanceOf(Error);
+			expect(retry.called).to.be.false;
+
+			releaseResponse.resolve();
+			await Promise.all([granting, overlappingGrant]);
+			expect(retry.callCount).to.equal(2);
+			expect(
+				retry
+					.getCalls()
+					.map((call) => call.args[0].entry.hash)
+					.sort(),
+			).to.deep.equal([backgroundEntry.hash, queuedEntry.hash].sort());
+			expect(
+				log._checkedPrune.getRetry(backgroundEntry.hash)?.attempts,
+			).to.equal(1);
+			expect(log._checkedPrune.getRetry(queuedEntry.hash)?.attempts).to.equal(
+				1,
+			);
+			expect(log._checkedPrune.hasRetry(explicitEntry.hash)).to.be.false;
+		} finally {
+			releaseResponse.resolve();
+			log._checkedPrune.clearRetry(backgroundEntry.hash);
+			log._checkedPrune.clearRetry(explicitEntry.hash);
+			log._checkedPrune.clearRetry(queuedEntry.hash);
+			await Promise.all([
+				log
+					.cancelCheckedPruneForLocalLeader(backgroundEntry.hash)
+					.catch(() => {}),
+				log
+					.cancelCheckedPruneForLocalLeader(explicitEntry.hash)
+					.catch(() => {}),
+				log.cancelCheckedPruneForLocalLeader(queuedEntry.hash).catch(() => {}),
+			]);
+			await Promise.allSettled(
+				[backgroundPruning, explicitPruning, queuedAdd].filter(
+					(value): value is Promise<unknown> => value != null,
+				),
+			);
+			retry.restore();
+			grantLeaders.restore();
+			replicas.restore();
+			send.restore();
+		}
+	});
+
+	it("preserves both copies under reciprocal crossed handoffs", async () => {
+		session = await TestSession.disconnected(2);
+		const store = new EventStore();
+		const openOptions = {
+			args: {
+				replicate: false as const,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		};
+		const first = await session.peers[0].open(store.clone(), openOptions);
+		const second = await session.peers[1].open(store.clone(), openOptions);
+		const firstLog = first.log as any;
+		const secondLog = second.log as any;
+		const { entry } = await first.add("checked-prune-reciprocal-handoff");
+		await second.log.log.join([entry]);
+		const firstKey = session.peers[0].identity.publicKey;
+		const secondKey = session.peers[1].identity.publicKey;
+		const firstHash = firstKey.hashcode();
+		const secondHash = secondKey.hashcode();
+		const firstLeaders = new Map([[secondHash, { intersecting: true }]]);
+		const secondLeaders = new Map([[firstHash, { intersecting: true }]]);
+		const firstSent: unknown[] = [];
+		const secondSent: unknown[] = [];
+		const firstSend = sinon
+			.stub(firstLog.rpc, "send")
+			.callsFake(async (message) => {
+				firstSent.push(message);
+			});
+		const secondSend = sinon
+			.stub(secondLog.rpc, "send")
+			.callsFake(async (message) => {
+				secondSent.push(message);
+			});
+		const firstReplicas = sinon
+			.stub(firstLog, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const secondReplicas = sinon
+			.stub(secondLog, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const firstGrantLeaders = sinon
+			.stub(firstLog, "revalidateCheckedPruneGrantLocalLeaders")
+			.resolves(new Set([entry.hash]));
+		const secondGrantLeaders = sinon
+			.stub(secondLog, "revalidateCheckedPruneGrantLocalLeaders")
+			.resolves(new Set([entry.hash]));
+		const firstRemove = sinon.spy(firstLog.log, "remove");
+		const secondRemove = sinon.spy(secondLog.log, "remove");
+		let firstPruning: Promise<unknown> | undefined;
+		let secondPruning: Promise<unknown> | undefined;
+
+		try {
+			[firstPruning] = firstLog.prune(
+				new Map([[entry.hash, { entry, leaders: firstLeaders }]]),
+			);
+			expect(firstSent.some((message) => message instanceof RequestIPruneV2)).to
+				.be.true;
+			[secondPruning] = secondLog.prune(
+				new Map([[entry.hash, { entry, leaders: secondLeaders }]]),
+			);
+			expect(secondSent.some((message) => message instanceof RequestIPruneV2))
+				.to.be.true;
+			const firstOutcome = firstPruning!.catch((error) => error);
+			const secondOutcome = secondPruning!.catch((error) => error);
+			await waitForResolved(() => {
+				expect(firstSent.some((message) => message instanceof RequestIPruneV2))
+					.to.be.true;
+				expect(secondSent.some((message) => message instanceof RequestIPruneV2))
+					.to.be.true;
+			});
+			const firstRequest = firstSent.find(
+				(message): message is RequestIPruneV2 =>
+					message instanceof RequestIPruneV2,
+			)!;
+			const secondRequest = secondSent.find(
+				(message): message is RequestIPruneV2 =>
+					message instanceof RequestIPruneV2,
+			)!;
+
+			await Promise.all([
+				second.log.onMessage(firstRequest, { from: firstKey } as any),
+				first.log.onMessage(secondRequest, { from: secondKey } as any),
+			]);
+			expect(await firstOutcome).to.be.instanceOf(Error);
+			expect(await secondOutcome).to.be.instanceOf(Error);
+
+			const firstResponse = firstSent.find(
+				(message): message is ResponseIPruneV2 =>
+					message instanceof ResponseIPruneV2,
+			)!;
+			const secondResponse = secondSent.find(
+				(message): message is ResponseIPruneV2 =>
+					message instanceof ResponseIPruneV2,
+			)!;
+			expect(firstResponse).to.exist;
+			expect(secondResponse).to.exist;
+			await Promise.all([
+				second.log.onMessage(firstResponse, { from: firstKey } as any),
+				first.log.onMessage(secondResponse, { from: secondKey } as any),
+			]);
+
+			expect(firstRemove.called).to.be.false;
+			expect(secondRemove.called).to.be.false;
+			expect(await firstLog.log.has(entry.hash)).to.be.true;
+			expect(await secondLog.log.has(entry.hash)).to.be.true;
+			expect(firstLog._checkedPrune.getRetry(entry.hash)?.attempts).to.equal(1);
+			expect(secondLog._checkedPrune.getRetry(entry.hash)?.attempts).to.equal(
+				1,
+			);
+		} finally {
+			await Promise.all([
+				firstLog.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {}),
+				secondLog.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {}),
+			]);
+			await Promise.allSettled(
+				[firstPruning, secondPruning].filter(
+					(value): value is Promise<unknown> => value != null,
+				),
+			);
+			secondRemove.restore();
+			firstRemove.restore();
+			secondGrantLeaders.restore();
+			firstGrantLeaders.restore();
+			secondReplicas.restore();
+			firstReplicas.restore();
+			secondSend.restore();
+			firstSend.restore();
+		}
+	});
+
+	it("revokes an old receipt when that peer requests a reciprocal prune", async () => {
+		session = await TestSession.disconnected(3);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-crossed-receipt");
+		const remoteKeys = session.peers
+			.slice(1)
+			.map((peer) => peer.identity.publicKey);
+		const remoteHashes = remoteKeys.map((key) => key.hashcode());
+		const leaders = new Map(
+			remoteHashes.map((hash) => [hash, { intersecting: true }]),
+		);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const replicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 2 });
+		const grantLeaders = sinon
+			.stub(log, "revalidateCheckedPruneGrantLocalLeaders")
+			.resolves(new Set());
+		const remove = sinon.spy(log.log, "remove");
+		let pruning: Promise<unknown> | undefined;
+
+		try {
+			[pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			void pruning!.catch(() => {});
+			await waitForResolved(() => {
+				expect(
+					log._checkedPrune.getContactedReplicators(entry.hash)?.size,
+				).to.equal(2);
+			});
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [{ hash: entry.hash, requestId: pending.requestId }],
+				}),
+				{ from: remoteKeys[0] } as any,
+			);
+			expect(
+				log._checkedPrune.getConfirmedReplicators(entry.hash),
+			).to.deep.equal(new Set([remoteHashes[0]]));
+
+			await db.log.onMessage(
+				new RequestIPruneV2({
+					requests: [{ hash: entry.hash, requestId: randomBytes(32) }],
+				}),
+				{ from: remoteKeys[0] } as any,
+			);
+			expect(
+				log._checkedPrune
+					.getContactedReplicators(entry.hash)
+					?.has(remoteHashes[0]),
+			).to.be.false;
+			expect(
+				log._checkedPrune.getConfirmedReplicators(entry.hash)?.size ?? 0,
+			).to.equal(0);
+
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [{ hash: entry.hash, requestId: pending.requestId }],
+				}),
+				{ from: remoteKeys[0] } as any,
+			);
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [{ hash: entry.hash, requestId: pending.requestId }],
+				}),
+				{ from: remoteKeys[1] } as any,
+			);
+			expect(
+				log._checkedPrune.getConfirmedReplicators(entry.hash),
+			).to.deep.equal(new Set([remoteHashes[1]]));
+			expect(remove.called).to.be.false;
+		} finally {
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(pruning ? [pruning] : []);
+			remove.restore();
+			grantLeaders.restore();
+			replicas.restore();
+			send.restore();
+		}
+	});
+
+	it("grants only while the block is present and this peer is a leader", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-grant-revalidation");
+		const requester = session.peers[1].identity.publicKey.hashcode();
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const leaders = sinon.stub(log, "revalidateCheckedPruneGrantLocalLeaders");
+		leaders.resolves(new Set());
+
+		try {
+			await log.admitAndSendCheckedPruneGrants(requester, [
+				{ hash: entry.hash, requestId: randomBytes(32) },
+			]);
+			await log.admitAndSendCheckedPruneGrants(requester, [
+				{ hash: "missing", requestId: randomBytes(32) },
+			]);
+			expect(
+				send
+					.getCalls()
+					.some((call) => call.args[0] instanceof ResponseIPruneV2),
+			).false;
+
+			leaders.resolves(new Set([entry.hash]));
+			const requestId = randomBytes(32);
+			await log.admitAndSendCheckedPruneGrants(requester, [
+				{ hash: entry.hash, requestId },
+			]);
+			const response = send
+				.getCalls()
+				.map((call) => call.args[0])
+				.find(
+					(message): message is ResponseIPruneV2 =>
+						message instanceof ResponseIPruneV2,
+				);
+			expect(response?.requests).to.have.length(1);
+			expect(response?.requests[0]?.hash).to.equal(entry.hash);
+			expect(response?.requests[0]?.requestId).to.deep.equal(requestId);
+		} finally {
+			leaders.restore();
+			send.restore();
+		}
+	});
+
+	it("echoes the exact id when a missing block arrives before pending install", async () => {
+		session = await TestSession.disconnected(2);
+		const store = new EventStore();
+		const source = await session.peers[0].open(store.clone(), {
+			args: { replicate: false, keep: () => true, timeUntilRoleMaturity: 0 },
+		});
+		const target = await session.peers[1].open(store.clone(), {
+			args: { replicate: false, keep: () => true, timeUntilRoleMaturity: 0 },
+		});
+		const { entry } = await source.add("checked-prune-pending-arrival-race");
+		const sourceKey = session.peers[0].identity.publicKey;
+		const targetLog = target.log as any;
+		const requestId = randomBytes(32);
+		const originalHasMany = target.log.log.blocks.hasMany!.bind(
+			target.log.log.blocks,
+		);
+		let firstPresenceCheck = true;
+		const hasMany = sinon
+			.stub(target.log.log.blocks, "hasMany")
+			.callsFake(async (hashes) => {
+				if (!firstPresenceCheck) {
+					return originalHasMany(hashes);
+				}
+				firstPresenceCheck = false;
+				await target.log.log.join([entry]);
+				return [false];
+			});
+		const leaders = sinon
+			.stub(targetLog, "revalidateCheckedPruneGrantLocalLeaders")
+			.resolves(new Set([entry.hash]));
+		const responses: ResponseIPruneV2[] = [];
+		const send = sinon
+			.stub(targetLog.rpc, "send")
+			.callsFake(async (message) => {
+				if (message instanceof ResponseIPruneV2) {
+					responses.push(message);
+				}
+			});
+
+		try {
+			await target.log.onMessage(
+				new RequestIPruneV2({
+					requests: [{ hash: entry.hash, requestId }],
+				}),
+				{ from: sourceKey } as any,
+			);
+			await waitForResolved(() => {
+				expect(responses).to.have.length(1);
+				expect(targetLog._pendingIHave.has(entry.hash)).to.be.false;
+			});
+			expect(responses[0]?.requests).to.have.length(1);
+			expect(responses[0]?.requests[0]?.hash).to.equal(entry.hash);
+			expect(responses[0]?.requests[0]?.requestId).to.deep.equal(requestId);
+		} finally {
+			send.restore();
+			leaders.restore();
+			hasMany.restore();
+		}
+	});
+
+	it("prunes newly exposed ancestors through independent generations", async () => {
+		session = await TestSession.disconnected(2);
+		let keep = true;
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => keep,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const parent = await db.add("checked-prune-parent", {
+			meta: { next: [] },
+		});
+		const child = await db.add("checked-prune-child", {
+			meta: { next: [parent.entry] },
+		});
+		keep = false;
+		const remoteKey = session.peers[1].identity.publicKey;
+		const remoteHash = remoteKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const sent: RequestIPruneV2[] = [];
+		const send = sinon
+			.stub(log.rpc, "send")
+			.callsFake(async (message: unknown) => {
+				if (message instanceof RequestIPruneV2) {
+					sent.push(message);
+				}
+			});
+		const replicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.resolves({ leaders, localLeader: false });
+		const parentPlan = sinon
+			.stub(log, "planEntryLeaderBatch")
+			.resolves([{ coordinates: [], leaders, isLeader: false }]);
+
+		try {
+			const [pruning] = log.prune(
+				new Map([[child.entry.hash, { entry: child.entry, leaders }]]),
+				{ timeout: 5_000 },
+			);
+			await waitForResolved(() => {
+				expect(log._checkedPrune.getPendingDelete(child.entry.hash)).to.exist;
+				expect(
+					log._checkedPrune
+						.getContactedReplicators(child.entry.hash)
+						?.has(remoteHash),
+				).true;
+			});
+			const childPending = log._checkedPrune.getPendingDelete(child.entry.hash);
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [
+						{
+							hash: child.entry.hash,
+							requestId: childPending.requestId,
+						},
+					],
+				}),
+				{ from: remoteKey } as any,
+			);
+			await pruning;
+			expect(await log.log.has(child.entry.hash)).false;
+			expect(await log.log.has(parent.entry.hash)).true;
+
+			await log.pruneDebouncedFn.flush();
+			await waitForResolved(() => {
+				expect(log._checkedPrune.getPendingDelete(parent.entry.hash)).to.exist;
+			});
+			const parentPending = log._checkedPrune.getPendingDelete(
+				parent.entry.hash,
+			);
+			expect([...parentPending.requestId]).to.not.deep.equal([
+				...childPending.requestId,
+			]);
+			expect(
+				sent.flatMap((message) => message.requests).map(({ hash }) => hash),
+			).to.include.members([child.entry.hash, parent.entry.hash]);
+			await db.log.onMessage(
+				new ResponseIPruneV2({
+					requests: [
+						{
+							hash: parent.entry.hash,
+							requestId: parentPending.requestId,
+						},
+					],
+				}),
+				{ from: remoteKey } as any,
+			);
+			await parentPending.promise.promise;
+			expect(await log.log.has(parent.entry.hash)).false;
+		} finally {
+			await log
+				.cancelCheckedPruneForLocalLeader(parent.entry.hash)
+				.catch(() => {});
+			parentPlan.restore();
+			revalidate.restore();
+			replicas.restore();
+			send.restore();
+		}
+	});
+
+	it("requeues a background prune after its timed-out generation clears", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-timeout-retry");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const replicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const retry = sinon.stub(log, "scheduleCheckedPruneRetry").callsFake(() => {
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
+		});
+		const sentRequests: RequestIPruneV2[] = [];
+		send.callsFake(async (message) => {
+			if (message instanceof RequestIPruneV2) {
+				sentRequests.push(message);
+			}
+		});
+		const clock = sinon.useFakeTimers();
+		let pruning: Promise<unknown> | undefined;
+
+		try {
+			[pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]));
+			const outcome = pruning!.catch((error) => error);
+			await Promise.resolve();
+			await Promise.resolve();
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			expect(pending).to.exist;
+			const generationId = pending.requestId.slice();
+
+			await clock.tickAsync(120_000);
+			const error = await outcome;
+			expect(error).to.be.instanceOf(Error);
+			expect((error as Error).message).to.include(
+				"Timeout for checked pruning",
+			);
+			expect(retry.calledOnce).to.be.true;
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
+			expect(sentRequests.length).to.be.greaterThan(1);
+			for (const request of sentRequests) {
+				expect(request.requests[0]?.requestId).to.deep.equal(generationId);
+			}
+		} finally {
+			clock.restore();
+			await Promise.allSettled(pruning ? [pruning] : []);
+			retry.restore();
+			replicas.restore();
+			send.restore();
+		}
+	});
+
+	it("moves exhausted retries to one coalesced low-rate audit", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-retry-exhaustion");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const clock = sinon.useFakeTimers();
+
+		try {
+			log._checkedPrune.setRetry(entry.hash, {
+				attempts: 3,
+				entry,
+				leaders,
+			});
+			expect(log._checkedPrune.hasRetry(entry.hash)).to.be.true;
+
+			log.scheduleCheckedPruneRetry({ entry, leaders });
+
+			expect(log._checkedPrune.hasRetry(entry.hash)).to.be.true;
+			expect(log._checkedPrune.getRetry(entry.hash)?.timer).to.be.undefined;
+			expect(log._checkedPruneAuditTimer).to.exist;
+			expect(log.hasActiveCheckedPruneWork(entry.hash)).to.be.true;
+
+			await clock.tickAsync(30_000);
+			expect(log._checkedPruneAuditTimer).to.be.undefined;
+			expect(log._checkedPrune.getRetry(entry.hash)?.attempts).to.equal(3);
+			expect(log._checkedPrune.getRetry(entry.hash)?.timer).to.exist;
+		} finally {
+			log._checkedPrune.clearRetry(entry.hash);
+			log.clearCheckedPruneAuditTimer();
+			clock.restore();
+		}
+	});
+
+	it("rotates the coalesced audit fairly beyond one batch", async () => {
+		session = await TestSession.disconnected(1);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-audit-fairness");
+		const leaders = new Map<string, { intersecting: boolean }>();
+		const hashes = Array.from(
+			{ length: 129 },
+			(_value, index) => `checked-prune-audit-${index}`,
+		);
+		const clock = sinon.useFakeTimers();
+
+		try {
+			for (const hash of hashes) {
+				log._checkedPrune.setRetry(hash, {
+					attempts: 3,
+					entry: { hash, meta: entry.meta },
+					leaders,
+				});
+			}
+			log.scheduleCheckedPruneRetry({
+				entry: log._checkedPrune.getRetry(hashes[0])!.entry,
+				leaders,
+			});
+
+			await clock.tickAsync(30_000);
+			expect(log._checkedPrune.getRetry(hashes[0])?.timer).to.exist;
+			expect(log._checkedPrune.getRetry(hashes[127])?.timer).to.exist;
+			expect(log._checkedPrune.getRetry(hashes[128])?.timer).to.be.undefined;
+			expect(log._checkedPruneAuditTimer).to.exist;
+
+			for (const hash of hashes.slice(0, 128)) {
+				const state = log._checkedPrune.getRetry(hash);
+				if (state?.timer) {
+					clearTimeout(state.timer);
+					state.timer = undefined;
+				}
+			}
+			await clock.tickAsync(30_000);
+			expect(log._checkedPrune.getRetry(hashes[128])?.timer).to.exist;
+		} finally {
+			for (const hash of hashes) {
+				log._checkedPrune.clearRetry(hash);
+			}
+			log.clearCheckedPruneAuditTimer();
+			clock.restore();
+		}
+	});
+
+	it("releases a background retry rejected by the keep policy", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-retry-keep");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const findLeaders = sinon
+			.stub(log, "findLeadersFromEntry")
+			.resolves(leaders);
+		const clock = sinon.useFakeTimers();
+
+		try {
+			log.scheduleCheckedPruneRetry({ entry, leaders });
+			expect(log._checkedPrune.hasRetry(entry.hash)).to.be.true;
+
+			await clock.tickAsync(1_500);
+
+			expect(log._checkedPrune.hasRetry(entry.hash)).to.be.false;
+			expect(log.hasActiveCheckedPruneWork(entry.hash)).to.be.false;
+		} finally {
+			clock.restore();
+			log._checkedPrune.clearRetry(entry.hash);
+			findLeaders.restore();
+		}
+	});
+
+	it("rechecks a first transient local-leader decision", async () => {
+		session = await TestSession.disconnected(2);
+		let keep = true;
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => keep,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-transient-local-leader");
+		const selfHash = session.peers[0].identity.publicKey.hashcode();
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const localLeaders = new Map([[selfHash, { intersecting: true }]]);
+		const remoteLeaders = new Map([[remoteHash, { intersecting: true }]]);
+		const revalidate = sinon.stub(log, "revalidateCheckedPruneOwnership");
+		revalidate.onFirstCall().resolves({
+			leaders: localLeaders,
+			localLeader: true,
+		});
+		revalidate.onSecondCall().resolves({
+			leaders: remoteLeaders,
+			localLeader: false,
+		});
+		const findLeaders = sinon
+			.stub(log, "findLeadersFromEntry")
+			.resolves(remoteLeaders);
+		const replicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const clock = sinon.useFakeTimers();
+
+		try {
+			keep = false;
+			expect(
+				await log.pruneDebouncedFnAddIfNotKeeping({
+					key: entry.hash,
+					value: { entry, leaders: remoteLeaders },
+				}),
+			).to.be.true;
+			await log.pruneDebouncedFn.flush();
+
+			expect(revalidate.calledOnce).to.be.true;
+			expect(log._checkedPrune.hasPendingDelete(entry.hash)).to.be.false;
+			expect(log._checkedPrune.getRetry(entry.hash)?.attempts).to.equal(1);
+
+			await clock.tickAsync(1_500);
+			await log.pruneDebouncedFn.flush();
+
+			expect(revalidate.callCount).to.equal(2);
+			expect(log._checkedPrune.hasPendingDelete(entry.hash)).to.be.true;
+		} finally {
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			log._checkedPrune.clearRetry(entry.hash);
+			log.clearCheckedPruneAuditTimer();
+			clock.restore();
+			send.restore();
+			replicas.restore();
+			findLeaders.restore();
+			revalidate.restore();
+		}
+	});
+
+	it("retries an empty transient leader view instead of dropping it", async () => {
+		session = await TestSession.disconnected(1);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-empty-leader-view");
+		const findLeaders = sinon
+			.stub(log, "findLeadersFromEntry")
+			.resolves(new Map());
+
+		try {
+			await log.pruneCurrentHeadsNoLongerLed();
+
+			expect(findLeaders.called).to.be.true;
+			expect(log._checkedPrune.getRetry(entry.hash)?.attempts).to.equal(1);
+			expect(log._checkedPrune.getRetry(entry.hash)?.timer).to.exist;
+		} finally {
+			log._checkedPrune.clearRetry(entry.hash);
+			log.clearCheckedPruneAuditTimer();
+			findLeaders.restore();
+		}
+	});
+
+	it("does not enqueue a retry superseded during leader planning", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-retry-superseded");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const planningStarted = pDefer<void>();
+		const releasePlanning = pDefer<void>();
+		const findLeaders = sinon
+			.stub(log, "findLeadersFromEntry")
+			.callsFake(async () => {
+				planningStarted.resolve();
+				await releasePlanning.promise;
+				return leaders;
+			});
+		const enqueue = sinon.spy(log, "pruneDebouncedFnAddIfNotKeeping");
+		const clock = sinon.useFakeTimers();
+
+		try {
+			log.scheduleCheckedPruneRetry({ entry, leaders });
+			await clock.tickAsync(1_500);
+			await planningStarted.promise;
+
+			log._checkedPrune.clearRetry(entry.hash);
+			releasePlanning.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(enqueue.called).to.be.false;
+			expect(log._checkedPrune.hasRetry(entry.hash)).to.be.false;
+			expect(log.hasActiveCheckedPruneWork(entry.hash)).to.be.false;
+		} finally {
+			releasePlanning.resolve();
+			clock.restore();
+			log._checkedPrune.clearRetry(entry.hash);
+			enqueue.restore();
+			findLeaders.restore();
+		}
+	});
+
+	it("does not resume a debounced candidate superseded during planning", async () => {
+		session = await TestSession.disconnected(2);
+		let keep = true;
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => keep,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-candidate-superseded");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const planningStarted = pDefer<void>();
+		const releasePlanning = pDefer<void>();
+		const isReplicating = sinon
+			.stub(log, "isReplicating")
+			.callsFake(async () => {
+				planningStarted.resolve();
+				await releasePlanning.promise;
+				return true;
+			});
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.resolves({ leaders, localLeader: false });
+		let flushing: Promise<unknown> | undefined;
+
+		try {
+			keep = false;
+			expect(
+				await log.pruneDebouncedFnAddIfNotKeeping({
+					key: entry.hash,
+					value: { entry, leaders },
+				}),
+			).to.be.true;
+			flushing = log.pruneDebouncedFn.flush();
+			await planningStarted.promise;
+
+			await log.cancelCheckedPruneForLocalLeader(entry.hash);
+			releasePlanning.resolve();
+			await flushing;
+
+			expect(revalidate.called).to.be.false;
+			expect(log._checkedPrune.hasPendingDelete(entry.hash)).to.be.false;
+			expect(log._checkedPrune.hasRetry(entry.hash)).to.be.false;
+			expect(log.hasActiveCheckedPruneWork(entry.hash)).to.be.false;
+		} finally {
+			releasePlanning.resolve();
+			await Promise.allSettled(flushing ? [flushing] : []);
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			revalidate.restore();
+			isReplicating.restore();
+		}
+	});
+
+	it("rearms an in-flight candidate after an admitted grant is sent", async () => {
+		session = await TestSession.disconnected(2);
+		let keep = true;
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => keep,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-in-flight-grant");
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const planningStarted = pDefer<void>();
+		const releasePlanning = pDefer<void>();
+		const isReplicating = sinon
+			.stub(log, "isReplicating")
+			.callsFake(async () => {
+				planningStarted.resolve();
+				await releasePlanning.promise;
+				return true;
+			});
+		const revalidate = sinon
+			.stub(log, "revalidateCheckedPruneOwnership")
+			.resolves({ leaders, localLeader: false });
+		const grantLeaders = sinon
+			.stub(log, "revalidateCheckedPruneGrantLocalLeaders")
+			.resolves(new Set([entry.hash]));
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const retry = sinon.spy(log, "scheduleCheckedPruneRetry");
+		let flushing: Promise<unknown> | undefined;
+
+		try {
+			keep = false;
+			expect(
+				await log.pruneDebouncedFnAddIfNotKeeping({
+					key: entry.hash,
+					value: { entry, leaders },
+				}),
+			).to.be.true;
+			flushing = log.pruneDebouncedFn.flush();
+			await planningStarted.promise;
+
+			expect(log.pruneDebouncedFn.has(entry.hash)).to.be.false;
+			expect(log._checkedPrune.hasCandidate(entry.hash)).to.be.true;
+
+			await log.admitAndSendCheckedPruneGrants(remoteHash, [
+				{ hash: entry.hash, requestId: randomBytes(32) },
+			]);
+			expect(retry.calledOnce).to.be.true;
+			expect(log._checkedPrune.getRetry(entry.hash)?.attempts).to.equal(1);
+
+			releasePlanning.resolve();
+			await flushing;
+
+			expect(revalidate.called).to.be.false;
+			expect(log._checkedPrune.hasPendingDelete(entry.hash)).to.be.false;
+			expect(log._checkedPrune.hasRetry(entry.hash)).to.be.true;
+		} finally {
+			releasePlanning.resolve();
+			log._checkedPrune.clearRetry(entry.hash);
+			await Promise.allSettled(flushing ? [flushing] : []);
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			retry.restore();
+			send.restore();
+			grantLeaders.restore();
+			revalidate.restore();
+			isReplicating.restore();
+		}
+	});
+
+	it("fails closed for legacy prune messages", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+				waitForPruneDelay: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry } = await db.add("checked-prune-legacy");
+		const remoteKey = session.peers[1].identity.publicKey;
+		const remoteHash = remoteKey.hashcode();
+		const leaders = new Map([[remoteHash, { intersecting: true }]]);
+		const send = sinon.stub(log.rpc, "send").resolves();
+		const replicas = sinon
+			.stub(log, "getClampedReplicas")
+			.returns({ getValue: () => 1 });
+		let pruning: Promise<unknown> | undefined;
+
+		try {
+			[pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
+				timeout: 5_000,
+			});
+			const outcome = pruning!.catch((error) => error);
+			await waitForResolved(() => {
+				expect(log._checkedPrune.getPendingDelete(entry.hash)).to.exist;
+			});
+			const pending = log._checkedPrune.getPendingDelete(entry.hash);
+			const sendCountBeforeLegacy = send.callCount;
+			const pendingIHaveBeforeLegacy = [...log._pendingIHave.keys()];
+			const contactedBeforeLegacy = new Set(
+				log._checkedPrune.getContactedReplicators(entry.hash),
+			);
+			const confirmedBeforeLegacy = new Set(
+				log._checkedPrune.getConfirmedReplicators(entry.hash),
+			);
+			await db.log.onMessage(new RequestIPrune({ hashes: [entry.hash] }), {
+				from: remoteKey,
+			} as any);
+			await db.log.onMessage(new ResponseIPrune({ hashes: [entry.hash] }), {
+				from: remoteKey,
+			} as any);
+			expect(log._checkedPrune.getPendingDelete(entry.hash)).equal(pending);
+			expect(
+				log._checkedPrune.getConfirmedReplicators(entry.hash)?.size ?? 0,
+			).equal(0);
+			expect(send.callCount).to.equal(sendCountBeforeLegacy);
+			expect([...log._pendingIHave.keys()]).to.deep.equal(
+				pendingIHaveBeforeLegacy,
+			);
+			expect(
+				log._checkedPrune.getContactedReplicators(entry.hash),
+			).to.deep.equal(contactedBeforeLegacy);
+			expect(
+				new Set(log._checkedPrune.getConfirmedReplicators(entry.hash)),
+			).to.deep.equal(confirmedBeforeLegacy);
+
+			await log.cancelCheckedPruneForLocalLeader(entry.hash);
+			expect(await outcome).to.be.instanceOf(Error);
+		} finally {
+			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
+			await Promise.allSettled(pruning ? [pruning] : []);
+			replicas.restore();
+			send.restore();
+		}
+	});
+});

--- a/packages/programs/data/shared-log/test/events.spec.ts
+++ b/packages/programs/data/shared-log/test/events.spec.ts
@@ -36,6 +36,21 @@ describe("events", () => {
 		};
 	};
 
+	const resolveCurrentPrune = async (
+		log: any,
+		hash: string,
+		remoteHash: string,
+	) => {
+		const pending = log._checkedPrune.getPendingDelete(hash);
+		expect(pending).to.exist;
+		await waitForResolved(
+			() =>
+				expect(log._checkedPrune.getContactedReplicators(hash)?.has(remoteHash))
+					.true,
+		);
+		await pending.resolve(remoteHash, pending.requestId);
+	};
+
 	const makeReplicationRange = (
 		log: any,
 		properties: {
@@ -3420,9 +3435,6 @@ describe("events", () => {
 		const leaders = new Map([[remoteHash, { intersecting: true }]]);
 		const plannerStarted = pDefer<void>();
 		const releasePlanner = pDefer<void>();
-		const waitForReplicators = sinon
-			.stub(log, "_waitForEntryReplicators")
-			.resolves(true);
 		const getClampedReplicas = sinon
 			.stub(log, "getClampedReplicas")
 			.returns({ getValue: () => 1 });
@@ -3440,9 +3452,7 @@ describe("events", () => {
 			const [pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
 				timeout: 2_000,
 			});
-			const pending = log._checkedPrune.getPendingDelete(entry.hash);
-			expect(pending).to.exist;
-			await pending.resolve(remoteHash);
+			await resolveCurrentPrune(log, entry.hash, remoteHash);
 			await plannerStarted.promise;
 
 			log.poisonReplicationOwnership(new Error("forced ownership poison"));
@@ -3455,7 +3465,6 @@ describe("events", () => {
 			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
 		} finally {
 			releasePlanner.resolve();
-			waitForReplicators.restore();
 			getClampedReplicas.restore();
 			send.restore();
 			findLeaders.restore();
@@ -3464,7 +3473,7 @@ describe("events", () => {
 		}
 	});
 
-	it("keeps a stale checked prune out of the reopened coordinator", async () => {
+	it("drains a stale checked prune before reopening the coordinator", async () => {
 		session = await TestSession.disconnected(2);
 		const db = await session.peers[0].open(new EventStore(), {
 			args: { replicate: 1, timeUntilRoleMaturity: 0 },
@@ -3475,9 +3484,6 @@ describe("events", () => {
 		const leaders = new Map([[remoteHash, { intersecting: true }]]);
 		const plannerStarted = pDefer<void>();
 		const releasePlanner = pDefer<void>();
-		const waitForReplicators = sinon
-			.stub(log, "_waitForEntryReplicators")
-			.resolves(true);
 		const getClampedReplicas = sinon
 			.stub(log, "getClampedReplicas")
 			.returns({ getValue: () => 1 });
@@ -3503,38 +3509,37 @@ describe("events", () => {
 				(error: unknown) => ({ status: "rejected" as const, error }),
 			);
 			const oldCoordinator = log._checkedPrune;
-			const pending = oldCoordinator.getPendingDelete(entry.hash);
-			expect(pending).to.exist;
-			await pending.resolve(remoteHash);
+			await resolveCurrentPrune(log, entry.hash, remoteHash);
 			await plannerStarted.promise;
 
 			log.poisonReplicationOwnership(new Error("forced ownership poison"));
-			await db.close();
+			let closeSettled = false;
+			const closing = db.close().finally(() => {
+				closeSettled = true;
+			});
+			await delay(25);
+			expect(closeSettled).to.be.false;
+			releasePlanner.resolve();
+			await closing;
 			await session.peers[0].open(db, {
-				args: { replicate: false, timeUntilRoleMaturity: 0 },
+				args: {
+					replicate: false,
+					keep: () => true,
+					timeUntilRoleMaturity: 0,
+				},
 			});
 			const freshCoordinator = log._checkedPrune;
 			expect(freshCoordinator).to.not.equal(oldCoordinator);
-			const freshPendingBeforeRelease = freshCoordinator.getPendingDelete(
-				entry.hash,
-			);
 			freshMarkRemoving = sinon.spy(freshCoordinator, "markRemoving");
 
-			releasePlanner.resolve();
 			const outcome = await pruningOutcome;
-			// Terminal close deliberately settles old pending prunes so callers do
-			// not hang; the important boundary is that the resumed callback cannot
-			// perform the delete or touch the newly opened coordinator.
-			expect(outcome.status).to.equal("fulfilled");
+			expect(outcome.status).to.equal("rejected");
 			await delay(25);
 			expect(remove.called).to.be.false;
 			expect(freshMarkRemoving.called).to.be.false;
-			expect(freshCoordinator.getPendingDelete(entry.hash)).to.equal(
-				freshPendingBeforeRelease,
-			);
+			expect(freshCoordinator.getPendingDelete(entry.hash)).to.be.undefined;
 		} finally {
 			releasePlanner.resolve();
-			waitForReplicators.restore();
 			getClampedReplicas.restore();
 			send.restore();
 			findLeaders.restore();
@@ -3555,9 +3560,6 @@ describe("events", () => {
 		const leaders = new Map([[remoteHash, { intersecting: true }]]);
 		const removeStarted = pDefer<void>();
 		const releaseRemove = pDefer<void>();
-		const waitForReplicators = sinon
-			.stub(log, "_waitForEntryReplicators")
-			.resolves(true);
 		const getClampedReplicas = sinon
 			.stub(log, "getClampedReplicas")
 			.returns({ getValue: () => 1 });
@@ -3579,9 +3581,7 @@ describe("events", () => {
 			const [pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
 				timeout: 2_000,
 			});
-			const pending = log._checkedPrune.getPendingDelete(entry.hash);
-			expect(pending).to.exist;
-			await pending.resolve(remoteHash);
+			await resolveCurrentPrune(log, entry.hash, remoteHash);
 			await removeStarted.promise;
 
 			log.poisonReplicationOwnership(new Error("forced ownership poison"));
@@ -3595,7 +3595,6 @@ describe("events", () => {
 		} finally {
 			process.removeListener("unhandledRejection", onUnhandledRejection);
 			releaseRemove.resolve();
-			waitForReplicators.restore();
 			getClampedReplicas.restore();
 			send.restore();
 			findLeaders.restore();
@@ -3618,9 +3617,6 @@ describe("events", () => {
 			const leaders = new Map([[remoteHash, { intersecting: true }]]);
 			const removeStarted = pDefer<void>();
 			const releaseRemove = pDefer<void>();
-			const waitForReplicators = sinon
-				.stub(log, "_waitForEntryReplicators")
-				.resolves(true);
 			const getClampedReplicas = sinon
 				.stub(log, "getClampedReplicas")
 				.returns({ getValue: () => 1 });
@@ -3639,9 +3635,7 @@ describe("events", () => {
 					{ timeout: 2_000, unchecked },
 				);
 				if (!unchecked) {
-					const pending = log._checkedPrune.getPendingDelete(entry.hash);
-					expect(pending).to.exist;
-					await pending.resolve(remoteHash);
+					await resolveCurrentPrune(log, entry.hash, remoteHash);
 				}
 				await removeStarted.promise;
 				expect(log._admittedPruneRemoves.size).to.equal(1);
@@ -3668,7 +3662,6 @@ describe("events", () => {
 				expect(log._admittedPruneRemoves.size).to.equal(0);
 			} finally {
 				releaseRemove.resolve();
-				waitForReplicators.restore();
 				getClampedReplicas.restore();
 				send.restore();
 				findLeaders.restore();

--- a/packages/programs/data/shared-log/test/exchange-heads.spec.ts
+++ b/packages/programs/data/shared-log/test/exchange-heads.spec.ts
@@ -1,12 +1,15 @@
+import { deserialize, serialize } from "@dao-xyz/borsh";
 import { AnyBlockStore } from "@peerbit/blocks";
 import { Ed25519Keypair } from "@peerbit/crypto";
 import { Log } from "@peerbit/log";
-import { deserialize, serialize } from "@dao-xyz/borsh";
 import { expect } from "chai";
 import sinon from "sinon";
 import {
+	CheckedPruneRequest,
 	EXCHANGE_HEADS_RESOLVE_BATCH_SIZE,
 	RawExchangeHeadsMessage,
+	RequestIPruneV2,
+	ResponseIPruneV2,
 	createExchangeHeadsMessages,
 	createRawExchangeHeadsMessages,
 	materializeRawExchangeHeadsMessage,
@@ -25,6 +28,58 @@ describe("exchange heads", () => {
 
 	after(async () => {
 		await store.stop();
+	});
+
+	it("keeps the checked-prune correlation wire format stable", () => {
+		const requestId = Uint8Array.from({ length: 32 }, (_, index) => index);
+		const requestIdHex =
+			"000102030405060708090a0b0c0d0e0f" + "101112131415161718191a1b1c1d1e1f";
+		for (const [message, variant] of [
+			[
+				new RequestIPruneV2({
+					requests: [{ hash: "h", requestId }],
+				}),
+				"0b",
+			],
+			[
+				new ResponseIPruneV2({
+					requests: [{ hash: "h", requestId }],
+				}),
+				"0c",
+			],
+		] as const) {
+			const bytes = serialize(message);
+			expect(
+				Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+					"",
+				),
+			).to.equal(`0000${variant}01000000000100000068${requestIdHex}`);
+			const roundTrip = deserialize(bytes, TransportMessage) as
+				| RequestIPruneV2
+				| ResponseIPruneV2;
+			expect(roundTrip).to.be.instanceOf(message.constructor);
+			expect(roundTrip.requests).to.have.length(1);
+			expect(roundTrip.requests[0]).to.be.instanceOf(CheckedPruneRequest);
+			expect(roundTrip.requests[0]!.hash).to.equal("h");
+			expect([...roundTrip.requests[0]!.requestId]).to.deep.equal([
+				...requestId,
+			]);
+		}
+	});
+
+	it("rejects checked-prune correlation ids that are not 32 bytes", () => {
+		for (const create of [
+			(requestId: Uint8Array) =>
+				new RequestIPruneV2({ requests: [{ hash: "h", requestId }] }),
+			(requestId: Uint8Array) =>
+				new ResponseIPruneV2({ requests: [{ hash: "h", requestId }] }),
+		]) {
+			for (const length of [0, 31, 33]) {
+				expect(() => serialize(create(new Uint8Array(length)))).to.throw(
+					/Expected: 32/,
+				);
+			}
+		}
 	});
 
 	it("uses native graph reference gids for single-head messages", async () => {

--- a/packages/programs/data/shared-log/test/prune-ownership-coherence.spec.ts
+++ b/packages/programs/data/shared-log/test/prune-ownership-coherence.spec.ts
@@ -14,11 +14,31 @@ describe("checked prune ownership coherence", () => {
 		await session?.stop();
 	});
 
+	const resolveCurrentPrune = async (
+		log: any,
+		hash: string,
+		remoteHash: string,
+		beforeResolve?: (pending: any) => Promise<void>,
+	) => {
+		const pending = log._checkedPrune.getPendingDelete(hash);
+		expect(pending).to.exist;
+		await waitForResolved(
+			() =>
+				expect(log._checkedPrune.getContactedReplicators(hash)?.has(remoteHash))
+					.to.be.true,
+			{ timeout: 2_000, delayInterval: 5 },
+		);
+		await beforeResolve?.(pending);
+		await pending.resolve(remoteHash, pending.requestId);
+		return pending;
+	};
+
 	it("retains an entry when local ownership commits at the final prune boundary", async () => {
 		session = await TestSession.disconnected(2);
 		const db = await session.peers[0].open(new EventStore(), {
 			args: {
 				replicate: false,
+				keep: () => true,
 				timeUntilRoleMaturity: 0,
 				waitForPruneDelay: 0,
 			},
@@ -28,12 +48,6 @@ describe("checked prune ownership coherence", () => {
 		const selfHash = session.peers[0].identity.publicKey.hashcode();
 		const remoteHash = (await Ed25519Keypair.create()).publicKey.hashcode();
 		const leaders = new Map([[remoteHash, { intersecting: true }]]);
-		const preliminaryCheckFinished = pDefer<void>();
-		const releasePreliminaryCheck = pDefer<void>();
-
-		const waitForReplicators = sinon
-			.stub(log, "_waitForEntryReplicators")
-			.resolves(true);
 		const getClampedReplicas = sinon
 			.stub(log, "getClampedReplicas")
 			.returns({ getValue: () => 1 });
@@ -44,11 +58,6 @@ describe("checked prune ownership coherence", () => {
 			.stub(log, "revalidateCheckedPruneOwnership")
 			.callsFake(async (args: any) => {
 				revalidationCount++;
-				if (revalidationCount === 1) {
-					preliminaryCheckFinished.resolve();
-					await releasePreliminaryCheck.promise;
-					return { leaders: args.leaders, localLeader: false };
-				}
 				expect(await db.log.countReplicationSegments()).to.equal(1);
 				return {
 					leaders: new Map([[selfHash, { intersecting: true }]]),
@@ -63,33 +72,26 @@ describe("checked prune ownership coherence", () => {
 			const [pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
 				timeout: 5_000,
 			});
-			const pending = log._checkedPrune.getPendingDelete(entry.hash);
-			expect(pending).to.exist;
-			await pending.resolve(remoteHash);
-			await preliminaryCheckFinished.promise;
-
-			// Commit authoritative local ownership while the prune callback is
-			// paused after its preliminary planner result. The destructive path
-			// must revalidate in the range-mutation lane after this commit.
-			await db.log.replicate(
-				{ factor: 1, offset: 0 },
-				{ reset: true, rebalance: false },
-			);
+			await resolveCurrentPrune(log, entry.hash, remoteHash, async () => {
+				// Commit authoritative local ownership before the receipt is
+				// admitted to the destructive boundary.
+				await db.log.replicate(
+					{ factor: 1, offset: 0 },
+					{ reset: true, rebalance: false },
+				);
+			});
 			expect(await db.log.countReplicationSegments()).to.equal(1);
 
-			releasePreliminaryCheck.resolve();
 			await expect(pruning).to.be.rejectedWith(
 				"Failed to delete, is leader again",
 			);
 
-			expect(revalidationCount).to.equal(2);
+			expect(revalidationCount).to.equal(1);
 			expect(remove.called).to.be.false;
 			expect(await log.log.has(entry.hash)).to.be.true;
 			expect(await log.log.blocks.has(entry.hash)).to.be.true;
 			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
 		} finally {
-			releasePreliminaryCheck.resolve();
-			waitForReplicators.restore();
 			getClampedReplicas.restore();
 			send.restore();
 			remove.restore();
@@ -102,6 +104,7 @@ describe("checked prune ownership coherence", () => {
 		const db = await session.peers[0].open(new EventStore(), {
 			args: {
 				replicate: false,
+				keep: () => true,
 				timeUntilRoleMaturity: 0,
 				waitForPruneDelay: 0,
 			},
@@ -112,9 +115,6 @@ describe("checked prune ownership coherence", () => {
 		const leaders = new Map([[remoteHash, { intersecting: true }]]);
 		const plannerError = new Error("forced final ownership planner rejection");
 
-		const waitForReplicators = sinon
-			.stub(log, "_waitForEntryReplicators")
-			.resolves(true);
 		const getClampedReplicas = sinon
 			.stub(log, "getClampedReplicas")
 			.returns({ getValue: () => 1 });
@@ -142,13 +142,11 @@ describe("checked prune ownership coherence", () => {
 			const [pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
 				timeout: 5_000,
 			});
-			const pending = log._checkedPrune.getPendingDelete(entry.hash);
-			expect(pending).to.exist;
-			await pending.resolve(remoteHash);
+			await resolveCurrentPrune(log, entry.hash, remoteHash);
 
 			await expect(pruning).to.be.rejectedWith(plannerError.message);
-			expect(revalidate.callCount).to.equal(2);
-			expect(revalidate.secondCall.args[0].requireFreshLeaderDecision).to.be
+			expect(revalidate.callCount).to.equal(1);
+			expect(revalidate.firstCall.args[0].requireFreshLeaderDecision).to.be
 				.true;
 			expect(findLeaders.calledOnce).to.be.true;
 			expect(remove.called).to.be.false;
@@ -156,7 +154,6 @@ describe("checked prune ownership coherence", () => {
 			expect(await log.log.blocks.has(entry.hash)).to.be.true;
 			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
 		} finally {
-			waitForReplicators.restore();
 			getClampedReplicas.restore();
 			send.restore();
 			cancelLocalLeader.restore();
@@ -171,6 +168,7 @@ describe("checked prune ownership coherence", () => {
 		const db = await session.peers[0].open(new EventStore(), {
 			args: {
 				replicate: false,
+				keep: () => true,
 				timeUntilRoleMaturity: 0,
 				waitForPruneDelay: 0,
 			},
@@ -180,9 +178,6 @@ describe("checked prune ownership coherence", () => {
 		const remoteHash = (await Ed25519Keypair.create()).publicKey.hashcode();
 		const leaders = new Map([[remoteHash, { intersecting: true }]]);
 
-		const waitForReplicators = sinon
-			.stub(log, "_waitForEntryReplicators")
-			.resolves(true);
 		const getClampedReplicas = sinon
 			.stub(log, "getClampedReplicas")
 			.returns({ getValue: () => 1 });
@@ -209,15 +204,13 @@ describe("checked prune ownership coherence", () => {
 
 		try {
 			const [pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]));
-			const pending = log._checkedPrune.getPendingDelete(entry.hash);
-			expect(pending).to.exist;
-			await pending.resolve(remoteHash);
+			await resolveCurrentPrune(log, entry.hash, remoteHash);
 
 			await expect(pruning).to.be.rejectedWith(
 				"Could not establish current leaders at the checked-prune delete boundary",
 			);
-			expect(revalidate.callCount).to.equal(2);
-			expect(revalidate.secondCall.args[0].requireFreshLeaderDecision).to.be
+			expect(revalidate.callCount).to.equal(1);
+			expect(revalidate.firstCall.args[0].requireFreshLeaderDecision).to.be
 				.true;
 			expect(findLeaders.calledOnce).to.be.true;
 			expect(scheduleRetry.callCount).to.be.greaterThanOrEqual(1);
@@ -230,7 +223,6 @@ describe("checked prune ownership coherence", () => {
 			expect(await log.log.blocks.has(entry.hash)).to.be.true;
 		} finally {
 			log._checkedPrune.clearRetry(entry.hash);
-			waitForReplicators.restore();
 			getClampedReplicas.restore();
 			send.restore();
 			cancelLocalLeader.restore();
@@ -246,6 +238,7 @@ describe("checked prune ownership coherence", () => {
 		const db = await session.peers[0].open(new EventStore(), {
 			args: {
 				replicate: false,
+				keep: () => true,
 				timeUntilRoleMaturity: 0,
 				waitForPruneDelay: 0,
 			},
@@ -254,12 +247,8 @@ describe("checked prune ownership coherence", () => {
 		const { entry } = await db.add("checked-prune-cancelled-at-lane");
 		const remoteHash = (await Ed25519Keypair.create()).publicKey.hashcode();
 		const leaders = new Map([[remoteHash, { intersecting: true }]]);
-		const laneEntered = pDefer<void>();
 		const releaseLane = pDefer<void>();
 
-		const waitForReplicators = sinon
-			.stub(log, "_waitForEntryReplicators")
-			.resolves(true);
 		const getClampedReplicas = sinon
 			.stub(log, "getClampedReplicas")
 			.returns({ getValue: () => 1 });
@@ -268,13 +257,17 @@ describe("checked prune ownership coherence", () => {
 			.stub(log, "revalidateCheckedPruneOwnership")
 			.resolves({ leaders, localLeader: false });
 		const remove = sinon.spy(log.log, "remove");
-		const laneBlocker = log.withReplicationRangeMutationQueue(async () => {
-			laneEntered.resolve();
-			await releaseLane.promise;
-		});
+		const finalLaneQueued = pDefer<void>();
+		const originalQueue = log.withReplicationRangeMutationQueue.bind(log);
+		const queue = sinon
+			.stub(log, "withReplicationRangeMutationQueue")
+			.callsFake(async (...args: any[]) => {
+				finalLaneQueued.resolve();
+				await releaseLane.promise;
+				return originalQueue(...args);
+			});
 
 		try {
-			await laneEntered.promise;
 			const [pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
 				timeout: 5_000,
 			});
@@ -282,20 +275,13 @@ describe("checked prune ownership coherence", () => {
 				() => ({ status: "fulfilled" as const }),
 				(error: unknown) => ({ status: "rejected" as const, error }),
 			);
-			const pending = log._checkedPrune.getPendingDelete(entry.hash);
-			expect(pending).to.exist;
-			await pending.resolve(remoteHash);
-			await waitForResolved(
-				() => {
-					expect(revalidate.calledOnce).to.be.true;
-				},
-				{ timeout: 2_000, delayInterval: 5 },
-			);
+			await resolveCurrentPrune(log, entry.hash, remoteHash);
+			await finalLaneQueued.promise;
 
 			await log.cancelCheckedPruneForLocalLeader(entry.hash);
 			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
 			releaseLane.resolve();
-			await laneBlocker;
+			await Promise.allSettled([queue.firstCall.returnValue]);
 
 			const outcome = await pruningOutcome;
 			expect(outcome.status).to.equal("rejected");
@@ -308,8 +294,7 @@ describe("checked prune ownership coherence", () => {
 			expect(await log.log.blocks.has(entry.hash)).to.be.true;
 		} finally {
 			releaseLane.resolve();
-			await laneBlocker.catch(() => {});
-			waitForReplicators.restore();
+			queue.restore();
 			getClampedReplicas.restore();
 			send.restore();
 			revalidate.restore();
@@ -327,6 +312,7 @@ describe("checked prune ownership coherence", () => {
 		const db = await session.peers[0].open(new EventStore(), {
 			args: {
 				replicate: false,
+				keep: () => true,
 				timeUntilRoleMaturity: 0,
 				waitForPruneDelay: 0,
 				onChange: async (change) => {
@@ -365,9 +351,6 @@ describe("checked prune ownership coherence", () => {
 			timestamp: 1n,
 		});
 
-		const waitForReplicators = sinon
-			.stub(log, "_waitForEntryReplicators")
-			.resolves(true);
 		const getClampedReplicas = sinon
 			.stub(log, "getClampedReplicas")
 			.returns({ getValue: () => 1 });
@@ -380,9 +363,7 @@ describe("checked prune ownership coherence", () => {
 			const [pruning] = log.prune(new Map([[entry.hash, { entry, leaders }]]), {
 				timeout: 5_000,
 			});
-			const pending = log._checkedPrune.getPendingDelete(entry.hash);
-			expect(pending).to.exist;
-			await pending.resolve(remoteHash);
+			await resolveCurrentPrune(log, entry.hash, remoteHash);
 			await Promise.all([
 				reentrantAttempted.promise,
 				removalCallbackHoldingLane.promise,
@@ -427,7 +408,6 @@ describe("checked prune ownership coherence", () => {
 			expect(log._checkedPrune.getPendingDelete(entry.hash)).to.be.undefined;
 		} finally {
 			releaseRemovalCallback.resolve();
-			waitForReplicators.restore();
 			getClampedReplicas.restore();
 			send.restore();
 			revalidate.restore();
@@ -444,6 +424,7 @@ describe("checked prune ownership coherence", () => {
 			const db = await session.peers[0].open(new EventStore(), {
 				args: {
 					replicate: false,
+					keep: () => true,
 					timeUntilRoleMaturity: 0,
 					waitForPruneDelay: 0,
 					onChange: async (change) => {
@@ -469,9 +450,6 @@ describe("checked prune ownership coherence", () => {
 			const remoteHash = (await Ed25519Keypair.create()).publicKey.hashcode();
 			const leaders = new Map([[remoteHash, { intersecting: true }]]);
 
-			const waitForReplicators = sinon
-				.stub(log, "_waitForEntryReplicators")
-				.resolves(true);
 			const getClampedReplicas = sinon
 				.stub(log, "getClampedReplicas")
 				.returns({ getValue: () => 1 });
@@ -487,9 +465,7 @@ describe("checked prune ownership coherence", () => {
 					new Map([[entry.hash, { entry, leaders }]]),
 					{ timeout: 5_000 },
 				);
-				const pending = log._checkedPrune.getPendingDelete(entry.hash);
-				expect(pending).to.exist;
-				await pending.resolve(remoteHash);
+				await resolveCurrentPrune(log, entry.hash, remoteHash);
 				await terminalAttempted.promise;
 
 				expect(terminalError).to.be.instanceOf(
@@ -520,7 +496,6 @@ describe("checked prune ownership coherence", () => {
 				}
 			} finally {
 				releaseRemovalCallback.resolve();
-				waitForReplicators.restore();
 				getClampedReplicas.restore();
 				send.restore();
 				revalidate.restore();

--- a/packages/programs/data/shared-log/test/receive-admission.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission.spec.ts
@@ -8,8 +8,8 @@ import { v4 as uuid } from "uuid";
 import {
 	EntryWithRefs,
 	ExchangeHeadsMessage,
-	RequestIPrune,
-	ResponseIPrune,
+	RequestIPruneV2,
+	ResponseIPruneV2,
 	SyncCapabilitiesMessage,
 } from "../src/exchange-heads.js";
 import { createReplicationDomainHash } from "../src/replication-domain-hash.js";
@@ -390,54 +390,65 @@ describe("receive admission", () => {
 			const sourceKey = source.node.identity.publicKey;
 			const sourceHash = sourceKey.hashcode();
 			const pendingHash = "pending-prune-response";
-			const { entry: retryEntry } = await source.add(uuid(), {
-				meta: { next: [] },
-			});
-			const lateHash = retryEntry.hash;
+			const lateHash = "second-pending-prune-response";
 			const installPending = (
 				hash: string,
+				requestId: Uint8Array,
 				entered: DeferredPromise<void>,
 				release: DeferredPromise<void>,
 				finished?: DeferredPromise<void>,
 			) => {
 				const pendingPromise = pDefer<void>();
-				sharedLog._checkedPrune.pendingDeletes.set(hash, {
+				const pending = {
+					requestId,
 					promise: pendingPromise,
 					clear: () => {},
 					reject: () => {},
-					resolve: async (peerHash: string) => {
+					resolve: async (peerHash: string, responseRequestId: Uint8Array) => {
+						expect(responseRequestId).to.deep.equal(requestId);
 						entered.resolve();
 						await release.promise;
-						sharedLog._checkedPrune.addConfirmedReplicator(hash, peerHash);
+						sharedLog._checkedPrune.addConfirmedReplicator(
+							hash,
+							peerHash,
+							pending,
+							responseRequestId,
+						);
 						finished?.resolve();
 					},
-				});
+				};
+				sharedLog._checkedPrune.setPendingDelete(
+					hash,
+					pending,
+					{ hash } as any,
+					new Map(),
+				);
+				sharedLog._checkedPrune.addRequestSent(hash, sourceHash, pending);
 			};
+			const pendingRequestId = new Uint8Array(32).fill(1);
+			const lateRequestId = new Uint8Array(32).fill(2);
 			installPending(
 				pendingHash,
+				pendingRequestId,
 				pendingResolveEntered,
 				releasePendingResponse,
 				pendingResolveFinished,
 			);
-			const leaders = new Map([[sourceHash, { intersecting: true }]]);
-			sharedLog._checkedPrune.setRetry(lateHash, {
-				attempts: 1,
-				entry: retryEntry,
-				leaders,
-			});
-			const findLeaders = sinon
-				.stub(sharedLog, "findLeadersFromEntry")
-				.resolves(leaders);
-			const prune = sinon.stub(sharedLog, "prune").callsFake((...args: unknown[]) => {
-				const entries = args[0] as Map<string, unknown>;
-				expect(entries.has(lateHash)).to.be.true;
-				installPending(lateHash, lateResolveEntered, releaseLateResponse);
-				return [Promise.resolve()];
-			});
+			installPending(
+				lateHash,
+				lateRequestId,
+				lateResolveEntered,
+				releaseLateResponse,
+			);
 
 			try {
 				const receive = target.log.onMessage(
-					new ResponseIPrune({ hashes: [pendingHash, lateHash] }),
+					new ResponseIPruneV2({
+						requests: [
+							{ hash: pendingHash, requestId: pendingRequestId },
+							{ hash: lateHash, requestId: lateRequestId },
+						],
+					}),
 					{ from: sourceKey } as any,
 				);
 				await Promise.all([
@@ -480,8 +491,6 @@ describe("receive admission", () => {
 			} finally {
 				releasePendingResponse.resolve();
 				releaseLateResponse.resolve();
-				prune.restore();
-				findLeaders.restore();
 			}
 		} finally {
 			releasePendingResponse.resolve();
@@ -490,85 +499,53 @@ describe("receive admission", () => {
 		}
 	});
 
-	it("cancels leader waits before draining prune responses on close", async () => {
-		const session = await TestSession.disconnected(2);
-		const firstWaitEntered = pDefer<void>();
-		const secondWaitEntered = pDefer<void>();
-		const releaseFirstCheck = pDefer<void>();
+	it("drains in-flight leader checks and observes a latched lifecycle abort", async () => {
+		const session = await TestSession.disconnected(1);
+		const checkEntered = pDefer<void>();
+		const releaseCheck = pDefer<void>();
 		try {
-			const store = new EventStore<string, any>();
-			const source = await session.peers[0].open(store.clone(), {
-				args: { replicate: false, setup },
-			});
-			const target = await session.peers[1].open(store.clone(), {
-				args: { replicate: false, setup },
-			});
+			const target = await session.peers[0].open(
+				new EventStore<string, any>(),
+				{
+					args: { replicate: false, setup },
+				},
+			);
 			const sharedLog = target.log as any;
-			const sourceKey = source.node.identity.publicKey;
-			const hash = "close-cancels-prune-response-leader-wait";
-			const pendingPromise = pDefer<void>();
-			let waitCount = 0;
-			let secondWaitHasEntered = false;
-			const waitForMissingLeader = () => {
-				waitCount += 1;
-				const currentWait = waitCount;
-				if (currentWait === 2) {
-					secondWaitHasEntered = true;
-					secondWaitEntered.resolve();
-				}
-				return sharedLog.waitForLeaderSelection(
+			let settled = false;
+			const waiting = sharedLog
+				.waitForLeaderSelection(
 					[{ key: "missing-replicator", replicator: true }],
 					{ timeout: 60_000 },
 					async () => {
-						if (currentWait === 1) {
-							firstWaitEntered.resolve();
-							await releaseFirstCheck.promise;
-						}
+						checkEntered.resolve();
+						await releaseCheck.promise;
 						return new Map();
 					},
-				);
-			};
+				)
+				.then((result: unknown) => {
+					settled = true;
+					return result;
+				});
 
-			sharedLog._checkedPrune.pendingDeletes.set(hash, {
-				promise: pendingPromise,
-				clear: () => {},
-				reject: () => {},
-				resolve: async () => {
-					expect(await waitForMissingLeader()).to.be.false;
-					// This wait begins after the close signal has already fired. It must
-					// observe the latched abort instead of waiting for its full timeout.
-					expect(await waitForMissingLeader()).to.be.false;
-				},
-			});
-
-			const receive = target.log.onMessage(
-				new ResponseIPrune({ hashes: [hash] }),
-				{ from: sourceKey } as any,
-			);
-			await firstWaitEntered.promise;
-
-			let closeSettled = false;
-			const close = target.close().then(() => {
-				closeSettled = true;
-			});
-			await waitForResolved(() =>
-				expect(sharedLog._replicationLifecycleController.signal.aborted).to.be
-					.true,
-			);
-			expect(sharedLog._closeController.signal.aborted).to.be.false;
+			await checkEntered.promise;
+			sharedLog._replicationLifecycleController.abort();
 			await new Promise<void>((resolve) => setTimeout(resolve, 0));
-			// Aborting the outer wait must not release the receive lease while its
-			// already-admitted leader check can still perform local persistence.
-			expect(secondWaitHasEntered).to.be.false;
-			expect(closeSettled).to.be.false;
-			releaseFirstCheck.resolve();
-			await secondWaitEntered.promise;
-			await waitForResolved(() => expect(closeSettled).to.be.true, {
-				timeout: 2_000,
-			});
-			await Promise.all([receive, close]);
+			expect(settled).to.be.false;
+
+			const lateCheck = sinon.spy(async () => new Map());
+			expect(
+				await sharedLog.waitForLeaderSelection(
+					[{ key: "missing-replicator", replicator: true }],
+					{ timeout: 60_000 },
+					lateCheck,
+				),
+			).to.be.false;
+			expect(lateCheck.called).to.be.false;
+
+			releaseCheck.resolve();
+			expect(await waiting).to.be.false;
 		} finally {
-			releaseFirstCheck.resolve();
+			releaseCheck.resolve();
 			await session.stop();
 		}
 	});
@@ -656,47 +633,52 @@ describe("receive admission", () => {
 			const firstHash = firstKey.hashcode();
 			const secondKey = session.peers[2].identity.publicKey;
 			const secondHash = secondKey.hashcode();
+			const firstRequestId = new Uint8Array(32).fill(4);
+			const secondRequestId = new Uint8Array(32).fill(5);
 
 			await target.log.onMessage(
-				new RequestIPrune({ hashes: [entry.hash] }),
+				new RequestIPruneV2({
+					requests: [{ hash: entry.hash, requestId: firstRequestId }],
+				}),
 				{ from: firstKey } as any,
 			);
 			await target.log.onMessage(
-				new RequestIPrune({ hashes: [entry.hash] }),
+				new RequestIPruneV2({
+					requests: [{ hash: entry.hash, requestId: secondRequestId }],
+				}),
 				{ from: secondKey } as any,
 			);
 			const pending = sharedLog._pendingIHave.get(entry.hash);
-			expect([...pending.requesting]).to.have.members([firstHash, secondHash]);
+			expect([...pending.requesting.keys()]).to.have.members([
+				firstHash,
+				secondHash,
+			]);
 
 			sharedLog.cleanupPeerDisconnectTracking(firstHash);
-			expect([...pending.requesting]).to.deep.equal([secondHash]);
+			expect([...pending.requesting.keys()]).to.deep.equal([secondHash]);
 			expect(sharedLog._pendingIHave.get(entry.hash)).to.equal(pending);
 
-			const selfHash = target.node.identity.publicKey.hashcode();
-			const waitForEntryReplicators = sinon
-				.stub(sharedLog, "_waitForEntryReplicators")
-				.callsFake(async (...args: any[]) => {
-					args[3]?.onLeader?.(selfHash);
-					return new Map([[selfHash, { intersecting: true }]]);
-				});
-			const responseAdd = sinon.spy(sharedLog.responseToPruneDebouncedFn, "add");
+			const sendGrants = sinon
+				.stub(sharedLog, "admitAndSendCheckedPruneGrants")
+				.resolves();
 			const synchronizerEntryAdded = sinon
 				.stub(sharedLog.syncronizer, "onEntryAdded")
 				.callsFake(() => {});
 
 			try {
 				sharedLog.onEntryAdded(entry);
-				await waitForResolved(() => expect(responseAdd.calledOnce).to.be.true);
-				const response = responseAdd.firstCall.args[0];
-				expect([...response.peers]).to.deep.equal([secondHash]);
-				await waitForResolved(() =>
-					expect(sharedLog._pendingIHave.has(entry.hash)).to.be.false,
+				await waitForResolved(() => expect(sendGrants.calledOnce).to.be.true);
+				expect(sendGrants.firstCall.args[0]).to.equal(secondHash);
+				expect(sendGrants.firstCall.args[1]).to.deep.equal([
+					{ hash: entry.hash, requestId: secondRequestId },
+				]);
+				await waitForResolved(
+					() => expect(sharedLog._pendingIHave.has(entry.hash)).to.be.false,
 				);
 				expect(sharedLog._pendingIHaveCallbacks.size).to.equal(0);
 			} finally {
 				synchronizerEntryAdded.restore();
-				responseAdd.restore();
-				waitForEntryReplicators.restore();
+				sendGrants.restore();
 			}
 		} finally {
 			await session.stop();

--- a/packages/programs/data/shared-log/test/replication.spec.ts
+++ b/packages/programs/data/shared-log/test/replication.spec.ts
@@ -15,8 +15,8 @@ import sinon from "sinon";
 import { BlocksMessage } from "../src/blocks.js";
 import {
 	ExchangeHeadsMessage,
-	RequestIPrune,
-	ResponseIPrune,
+	RequestIPruneV2,
+	ResponseIPruneV2,
 } from "../src/exchange-heads.js";
 import {
 	type ReplicationOptions,
@@ -488,7 +488,7 @@ testSetups.forEach((setup) => {
 						replicas: new AbsoluteReplicas(3),
 						meta: { next: [] },
 					});
-					await db1.add("1", {
+					const e2 = await db1.add("1", {
 						replicas: new AbsoluteReplicas(1), // will be overriden by 'maxReplicas' above
 						meta: { next: [e1.entry] },
 					});
@@ -531,9 +531,13 @@ testSetups.forEach((setup) => {
 					};
 
 					await waitForResolved(() => {
-						expect(db1.log.log.length).equal(0);
-						expect(db2.log.log.length).greaterThanOrEqual(1);
+						expect(db1.log.log.length).equal(1);
+						expect(db2.log.log.length).equal(2);
 					});
+					expect(await db1.log.log.has(e1.entry.hash)).to.be.true;
+					expect(await db1.log.log.has(e2.entry.hash)).to.be.false;
+					expect(await db2.log.log.has(e1.entry.hash)).to.be.true;
+					expect(await db2.log.log.has(e2.entry.hash)).to.be.true;
 
 					expect(receivedMessageDb1).to.have.length(1);
 					expect(receivedMessageDb1[0]).to.be.instanceOf(BlockRequest);
@@ -4375,7 +4379,7 @@ testSetups.forEach((setup) => {
 									m instanceof AllReplicatingSegmentsMessage,
 							),
 						).to.equal(true);
-						expect(received.some((m) => m instanceof RequestIPrune)).to.equal(true);
+						expect(received.some((m) => m instanceof RequestIPruneV2)).to.equal(true);
 					/* const entryRefs1 = await db1.log.entryCoordinatesIndex.iterate().all();
 					const entryRefs2 = await db2.log.entryCoordinatesIndex.iterate().all();
 		
@@ -5220,10 +5224,30 @@ testSetups.forEach((setup) => {
 					const slowController = new AbortController();
 
 					// Keep replication updates slow, but allow many prune messages to get "in flight".
-					slowDownMessage(db1.log, RequestIPrune, 1500, slowController.signal);
-					slowDownMessage(db2.log, RequestIPrune, 1500, slowController.signal);
-					slowDownMessage(db2.log, ResponseIPrune, 1500, slowController.signal);
-					slowDownMessage(db3.log, ResponseIPrune, 1500, slowController.signal);
+					slowDownMessage(
+						db1.log,
+						RequestIPruneV2,
+						1500,
+						slowController.signal,
+					);
+					slowDownMessage(
+						db2.log,
+						RequestIPruneV2,
+						1500,
+						slowController.signal,
+					);
+					slowDownMessage(
+						db2.log,
+						ResponseIPruneV2,
+						1500,
+						slowController.signal,
+					);
+					slowDownMessage(
+						db3.log,
+						ResponseIPruneV2,
+						1500,
+						slowController.signal,
+					);
 
 					const range1 = (
 						await db1.log.getMyReplicationSegments()

--- a/packages/programs/data/shared-log/test/sharding.spec.ts
+++ b/packages/programs/data/shared-log/test/sharding.spec.ts
@@ -5,11 +5,12 @@ import type { Entry } from "@peerbit/log";
 import { TestSession } from "@peerbit/test-utils";
 import { delay, waitFor, waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
+import pDefer from "p-defer";
 import sinon from "sinon";
 import {
 	ExchangeHeadsMessage,
-	RequestIPrune,
-	ResponseIPrune,
+	RequestIPruneV2,
+	ResponseIPruneV2,
 } from "../src/exchange-heads.js";
 import {
 	type ReplicationDomainHash,
@@ -67,6 +68,7 @@ export const testSetups: TestSetupConfig<any>[] = [
 ];
 
 type CheckedPrunePendingDelete = {
+	requestId: Uint8Array;
 	promise: { promise: Promise<void> };
 	clear: () => void;
 	resolve: () => void;
@@ -495,7 +497,6 @@ testSetups.forEach((setup) => {
 						},
 					});
 				}
-
 				console.error(
 					`[shared-log-semantic-replication-diagnostics:${label}] ${JSON.stringify(
 						{
@@ -829,6 +830,7 @@ testSetups.forEach((setup) => {
 				const seedPendingDelete = () => {
 					let rejected: Error | undefined;
 					log._pendingDeletes.set(entry.hash, {
+						requestId: new Uint8Array(32),
 						promise: { promise: new Promise<void>(() => {}) },
 						clear: () => log._pendingDeletes.delete(entry.hash),
 						resolve: () => {},
@@ -882,6 +884,7 @@ testSetups.forEach((setup) => {
 					session.peers[1].identity.publicKey.hashcode();
 				let rejected: Error | undefined;
 				log._pendingDeletes.set(entry.hash, {
+					requestId: new Uint8Array(32),
 					promise: { promise: new Promise<void>(() => {}) },
 					clear: () => log._pendingDeletes.delete(entry.hash),
 					resolve: () => {},
@@ -1068,8 +1071,9 @@ testSetups.forEach((setup) => {
 				);
 				const db2Key = db2.log.node.identity.publicKey;
 				const db2Hash = db2Key.hashcode();
-				await waitForResolved(() =>
-					expect((db1.log as any).uniqueReplicators.has(db2Hash)).to.be.true,
+				await waitForResolved(
+					() =>
+						expect((db1.log as any).uniqueReplicators.has(db2Hash)).to.be.true,
 				);
 				await waitForResolved(async () =>
 					expect(
@@ -1600,13 +1604,13 @@ testSetups.forEach((setup) => {
 					const cleanupPubSubChaos: (() => Promise<void>)[] = [];
 					const chaosRules = [
 						{
-							type: RequestIPrune,
+							type: RequestIPruneV2,
 							minDelayMs: 20_000,
 							maxDelayMs: 45_000,
 							probability: 1,
 						},
 						{
-							type: ResponseIPrune,
+							type: ResponseIPruneV2,
 							minDelayMs: 20_000,
 							maxDelayMs: 45_000,
 							probability: 1,
@@ -1785,9 +1789,7 @@ testSetups.forEach((setup) => {
 							// races those waves — the historical "got 95" CI flake — so track
 							// a cumulative per-peer minimum instead, which is monotone and
 							// immune to sampling between waves.
-							const minLengths = [db1, db2, db3].map(
-								(db) => db.log.log.length,
-							);
+							const minLengths = [db1, db2, db3].map((db) => db.log.log.length);
 							await waitForResolved(
 								() => {
 									[db1, db2, db3].forEach((db, index) => {
@@ -2419,11 +2421,30 @@ testSetups.forEach((setup) => {
 				});
 				const leavingHash = db3.node.identity.publicKey.hashcode();
 				const logInternals = db1.log as any;
+				const pending = {
+					requestId: randomBytes(32),
+					promise: pDefer<void>(),
+					clear: () => {},
+					resolve: () => {},
+					reject: () => {},
+				};
 
-				logInternals._checkedPrune.addRequestSent(entry.hash, leavingHash);
+				logInternals._checkedPrune.setPendingDelete(
+					entry.hash,
+					pending,
+					entry,
+					new Map([[leavingHash, { intersecting: true }]]),
+				);
+				logInternals._checkedPrune.addRequestSent(
+					entry.hash,
+					leavingHash,
+					pending,
+				);
 				logInternals._checkedPrune.addConfirmedReplicator(
 					entry.hash,
 					leavingHash,
+					pending,
+					pending.requestId,
 				);
 				expect(
 					logInternals._checkedPrune
@@ -2912,7 +2933,12 @@ testSetups.forEach((setup) => {
 						timeout: 30_000,
 					});
 				} catch (error) {
-					await printShardingPruneDiagnostics("observer-unreplicate", db1, db2, db3);
+					await printShardingPruneDiagnostics(
+						"observer-unreplicate",
+						db1,
+						db2,
+						db3,
+					);
 					await dbgLogs([db1.log, db2.log, db3.log]);
 					throw error;
 				}

--- a/packages/programs/data/shared-log/test/sync-raw-exchange-heads.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-raw-exchange-heads.spec.ts
@@ -21,7 +21,8 @@ import {
 	ExchangeHeadsMessage,
 	RawEntryWithRefs,
 	RawExchangeHeadsMessage,
-	RequestIPrune,
+	RequestIPruneV2,
+	ResponseIPruneV2,
 	collectRawExchangeHeadSendPlan,
 	createRawExchangeHeadsMessages,
 } from "../src/exchange-heads.js";
@@ -2955,7 +2956,7 @@ describe("raw exchange-head sync", () => {
 		}
 	});
 
-	it("batches request-prune bookkeeping while queuing only newly confirmed hashes", async () => {
+	it("batches correlated request-prune bookkeeping and direct grants", async () => {
 		const session = await TestSession.disconnected(2, {
 			indexer: (directory) => createRustIndexer(directory),
 		});
@@ -2987,31 +2988,23 @@ describe("raw exchange-head sync", () => {
 				hashes.push(entry.hash);
 				entries.push(entry);
 			}
-
-			const removeKnownSpy = sinon.spy(
-				db.log as any,
-				"removeEntriesKnownByPeer",
-			);
-			const removePruneRequestsSentSpy = sinon.spy(
-				db.log as any,
-				"removePruneRequestsSent",
-			);
-			const removeConfirmedReplicatorsSpy = sinon.spy(
-				(db.log as any)._checkedPrune,
+			const requests = entries.map((entry, index) => ({
+				hash: entry.hash,
+				requestId: new Uint8Array(32).fill(index + 1),
+			}));
+			const log = db.log as any;
+			const sourceHash = session.peers[0].identity.publicKey.hashcode();
+			const removeKnown = sinon.spy(log, "removeEntriesKnownByPeer");
+			const removeOutbound = sinon.spy(log, "removePruneRequestsSent");
+			const removeConfirmations = sinon.spy(
+				log._checkedPrune,
 				"removeConfirmedReplicators",
 			);
-			const removeGidBatchSpy = sinon.spy(
-				db.log as any,
-				"removePeerFromGidPeerHistoryBatch",
-			);
-			const responseAddStub = sinon
-				.stub((db.log as any).responseToPruneDebouncedFn, "add")
-				.resolves();
-			const hasManyStub = sinon
+			const hasMany = sinon
 				.stub(db.log.log.blocks as any, "hasMany")
 				.resolves(hashes.map(() => true));
-			const nativeMetadataStub = sinon
-				.stub(db.log as any, "getNativeLogEntryMetadataBatch")
+			const nativeMetadata = sinon
+				.stub(log, "getNativeLogEntryMetadataBatch")
 				.returns(
 					entries.map((entry) => ({
 						hash: entry.hash,
@@ -3020,139 +3013,69 @@ describe("raw exchange-head sync", () => {
 					})),
 				);
 			const selfHash = db.node.identity.publicKey.hashcode();
-			const nativePlanner =
-				(db.log as any)._nativeBackbone ?? (db.log as any)._nativeRangePlanner;
+			const nativePlanner = log._nativeBackbone ?? log._nativeRangePlanner;
 			expect(nativePlanner).to.exist;
-			const nativeLocalLeaderHashesStub =
-				"planLocalLeaderHashesForGidsBatch" in nativePlanner &&
-				typeof nativePlanner.planLocalLeaderHashesForGidsBatch === "function"
-					? sinon
-							.stub(nativePlanner, "planLocalLeaderHashesForGidsBatch")
-							.callsFake((items: unknown) => {
-								return new Set(
-									[...(items as Iterable<{ hash: string }>)].map(
-										(item) => item.hash,
-									),
-								);
-							})
-					: undefined;
-			const nativeBatchPlanStub = sinon
+			const batchPlan = sinon
 				.stub(nativePlanner, "planLeadersForGidsBatch")
 				.callsFake((...args: unknown[]) =>
-					[
-						...(args[0] as Iterable<{ gid: string; replicas: number }>),
-					].map((_item, index) => ({
-						coordinates: [index],
-						leaders: new Map([[selfHash, { intersecting: true }]]),
-					})),
+					[...(args[0] as Iterable<{ gid: string; replicas: number }>)].map(
+						(_item, index) => ({
+							coordinates: [index],
+							leaders: new Map([[selfHash, { intersecting: true }]]),
+						}),
+					),
 				);
-			const waitForGidStub = sinon
-				.stub(db.log as any, "_waitForGidReplicators")
-				.callsFake(async (_gid, _replicas, _waitFor, options: any) => {
-					options?.onLeader?.(selfHash);
-					return new Map([[selfHash, { intersecting: true }]]);
-				});
-			const waitForEntryStub = sinon
-				.stub(db.log as any, "_waitForEntryReplicators")
-				.callsFake(async (_entry, _replicas, _waitFor, options: any) => {
-					options?.onLeader?.(selfHash);
-					return new Map([[selfHash, { intersecting: true }]]);
-				});
+			const send = sinon.stub(log.rpc, "send").resolves();
+
 			try {
-				await db.log.onMessage(new RequestIPrune({ hashes }), {
+				await db.log.onMessage(new RequestIPruneV2({ requests }), {
 					from: session.peers[0].identity.publicKey,
 				} as any);
 
-				expect(removeKnownSpy.callCount).to.equal(1);
-				expect([...removeKnownSpy.firstCall.args[0]]).to.deep.equal(hashes);
-				expect(removeKnownSpy.firstCall.args[1]).to.equal(
-					session.peers[0].identity.publicKey.hashcode(),
-				);
-				expect(removePruneRequestsSentSpy.callCount).to.equal(1);
-				expect([...removePruneRequestsSentSpy.firstCall.args[0]]).to.deep.equal(
-					hashes,
-				);
-				expect(removeConfirmedReplicatorsSpy.callCount).to.equal(1);
+				expect(removeKnown.calledOnce).true;
+				expect([...removeKnown.firstCall.args[0]]).to.deep.equal(hashes);
+				expect(removeKnown.firstCall.args[1]).to.equal(sourceHash);
+				expect(removeOutbound.calledOnce).true;
+				expect([...removeOutbound.firstCall.args[0]]).to.deep.equal(hashes);
+				expect(removeOutbound.firstCall.args[1]).to.equal(sourceHash);
+				expect(removeConfirmations.called).false;
+				expect(hasMany.calledOnce).true;
+				expect(batchPlan.calledOnce).true;
+
+				const response = send
+					.getCalls()
+					.map((call) => call.args[0])
+					.find(
+						(message): message is ResponseIPruneV2 =>
+							message instanceof ResponseIPruneV2,
+					);
+				expect(response).to.exist;
 				expect(
-					[...removeConfirmedReplicatorsSpy.firstCall.args[0]],
-				).to.deep.equal(hashes);
-				const queuedHashes: string[] = [];
-				expect(
-					(nativeLocalLeaderHashesStub?.callCount ?? 0) +
-						nativeBatchPlanStub.callCount,
-				).to.equal(1);
-				const plannedItems = nativeLocalLeaderHashesStub?.called
-					? [...nativeLocalLeaderHashesStub.firstCall.args[0]]
-					: [...nativeBatchPlanStub.firstCall.args[0]].map(
-							(item: { gid: string; replicas: number }, index) => ({
-								hash: hashes[index]!,
-								...item,
-							}),
-						);
-				expect(plannedItems.length).to.be.greaterThan(0);
-				expect(removeGidBatchSpy.callCount).to.equal(1);
-				expect(removeGidBatchSpy.firstCall.args[0]).to.equal(
-					session.peers[0].identity.publicKey.hashcode(),
-				);
-				expect([...removeGidBatchSpy.firstCall.args[1]]).to.have.length(
-					plannedItems.length,
-				);
-				expect(waitForGidStub.callCount).to.equal(0);
-				expect(responseAddStub.callCount).to.equal(
-					plannedItems.length > 0 ? 1 : 0,
-				);
-				if (plannedItems.length > 0) {
-					const [queued] = responseAddStub.firstCall.args;
-					expect(queued.hashes).to.have.length(plannedItems.length);
-					expect(queued.peers).to.deep.equal([
-						session.peers[0].identity.publicKey.hashcode(),
-					]);
-					for (const queuedHash of queued.hashes) {
-						expect(hashes).to.include(queuedHash);
-						queuedHashes.push(queuedHash);
-					}
-				}
-				expect(new Set(queuedHashes).size).to.equal(queuedHashes.length);
-				const profileNames = profileEvents.map((event) => event.name);
+					response!.requests.map(({ hash, requestId }) => ({
+						hash,
+						requestId,
+					})),
+				).to.deep.equal(requests);
+
+				const profileNames = profileEvents.map(({ name }) => name);
 				expect(profileNames).to.include.members([
 					"sharedLog.receive.requestPrune.coordinatorCleanup",
-					"sharedLog.receive.requestPrune.nativeMetadata",
-					"sharedLog.receive.requestPrune.blockHasMany",
-					"sharedLog.receive.requestPrune.nativeLeaderPlan",
-					"sharedLog.receive.requestPrune.gidCleanup",
-					"sharedLog.receive.requestPrune.loop",
 					"sharedLog.receive.requestPrune.total",
 				]);
-				const loopProfile = profileEvents.find(
-					(event) => event.name === "sharedLog.receive.requestPrune.loop",
+				const total = profileEvents.find(
+					({ name }) => name === "sharedLog.receive.requestPrune.total",
 				);
-				expect(loopProfile.entries).to.equal(hashes.length);
-				expect(loopProfile.details.leaderResponses).to.equal(
-					plannedItems.length,
-				);
-				expect(
-					loopProfile.details.leaderResponses +
-						loopProfile.details.pendingIHaveCreated +
-						loopProfile.details.pendingIHaveExtended,
-				).to.equal(hashes.length);
-				expect(loopProfile.details.leaderResponseBatches).to.equal(
-					plannedItems.length > 0 ? 1 : 0,
-				);
-				expect(loopProfile.details.pendingIHaveCreated).to.equal(
-					hashes.length - plannedItems.length,
-				);
+				expect(total.details.presentEntries).to.equal(hashes.length);
+				expect(total.details.leaderResponses).to.equal(hashes.length);
+				expect(total.details.pendingIHaveCreated).to.equal(0);
 			} finally {
-				waitForEntryStub.restore();
-				waitForGidStub.restore();
-				nativeBatchPlanStub.restore();
-				nativeLocalLeaderHashesStub?.restore();
-				nativeMetadataStub.restore();
-				hasManyStub.restore();
-				responseAddStub.restore();
-				removeGidBatchSpy.restore();
-				removeConfirmedReplicatorsSpy.restore();
-				removePruneRequestsSentSpy.restore();
-				removeKnownSpy.restore();
+				send.restore();
+				batchPlan.restore();
+				nativeMetadata.restore();
+				hasMany.restore();
+				removeConfirmations.restore();
+				removeOutbound.restore();
+				removeKnown.restore();
 			}
 		} finally {
 			await session.stop();
@@ -3192,13 +3115,17 @@ describe("raw exchange-head sync", () => {
 				const { entry } = await source.add(uuid(), { meta: { next: [] } });
 				hashes.push(entry.hash);
 			}
+			const requests = hashes.map((hash, index) => ({
+				hash,
+				requestId: new Uint8Array(32).fill(index + 1),
+			}));
 
 			const getShallowSpy = sinon.spy(target.log.log.entryIndex, "getShallow");
 			const hasManyStub = sinon
 				.stub(target.log.log.blocks as any, "hasMany")
 				.resolves(hashes.map(() => false));
 			try {
-				await target.log.onMessage(new RequestIPrune({ hashes }), {
+				await target.log.onMessage(new RequestIPruneV2({ requests }), {
 					from: source.node.identity.publicKey,
 				} as any);
 
@@ -3206,22 +3133,31 @@ describe("raw exchange-head sync", () => {
 				expect(getShallowSpy.callCount).to.equal(0);
 				const pending = (target.log as any)._pendingIHave as Map<
 					string,
-					{ clear?: () => void }
+					{
+						clear?: () => void;
+						requesting: Map<string, Uint8Array>;
+					}
 				>;
 				expect(pending.size).to.equal(hashes.length);
+				const sourceHash = source.node.identity.publicKey.hashcode();
+				for (let index = 0; index < requests.length; index++) {
+					expect(
+						pending.get(requests[index]!.hash)!.requesting.get(sourceHash),
+					).to.deep.equal(requests[index]!.requestId);
+				}
 				for (const value of pending.values()) {
 					value.clear?.();
 				}
 				pending.clear();
 
-				const loopProfile = profileEvents.find(
-					(event) => event.name === "sharedLog.receive.requestPrune.loop",
+				const totalProfile = profileEvents.find(
+					(event) => event.name === "sharedLog.receive.requestPrune.total",
 				);
-				expect(loopProfile.details.indexedFallbackLookups).to.equal(0);
-				expect(
-					loopProfile.details.skippedIndexedLookupsForMissingBlocks,
-				).to.equal(hashes.length);
-				expect(loopProfile.details.pendingIHaveCreated).to.equal(hashes.length);
+				expect(totalProfile.details.presentEntries).to.equal(0);
+				expect(totalProfile.details.leaderResponses).to.equal(0);
+				expect(totalProfile.details.pendingIHaveCreated).to.equal(
+					hashes.length,
+				);
 			} finally {
 				hasManyStub.restore();
 				getShallowSpy.restore();
@@ -3231,7 +3167,7 @@ describe("raw exchange-head sync", () => {
 		}
 	});
 
-	it("uses native-backbone request-prune all-confirmed path without per-hash waits", async () => {
+	it("uses the in-lane native all-confirmed path without fallback work", async () => {
 		const session = await TestSession.disconnected(2, {
 			indexer: (directory) => createRustIndexer(directory),
 		});
@@ -3264,6 +3200,10 @@ describe("raw exchange-head sync", () => {
 				const { entry } = await target.add(uuid(), { meta: { next: [] } });
 				hashes.push(entry.hash);
 			}
+			const requests = hashes.map((hash, index) => ({
+				hash,
+				requestId: new Uint8Array(32).fill(index + 1),
+			}));
 
 			const sharedLog = target.log as any;
 			const backbone = sharedLog._nativeBackbone;
@@ -3275,15 +3215,11 @@ describe("raw exchange-head sync", () => {
 				backbone,
 				"planRequestPruneLeaderHintColumns",
 			);
-			const responseAddStub = sinon
-				.stub(sharedLog.responseToPruneDebouncedFn, "add")
-				.resolves();
-			const waitForGidSpy = sinon.spy(sharedLog, "_waitForGidReplicators");
-			const waitForEntrySpy = sinon.spy(sharedLog, "_waitForEntryReplicators");
 			const blockHasManySpy = sinon.spy(target.log.log.blocks as any, "hasMany");
 			const getShallowSpy = sinon.spy(target.log.log.entryIndex, "getShallow");
+			const send = sinon.stub(sharedLog.rpc, "send").resolves();
 			try {
-				await target.log.onMessage(new RequestIPrune({ hashes }), {
+				await target.log.onMessage(new RequestIPruneV2({ requests }), {
 					from: session.peers[0].identity.publicKey,
 				} as any);
 
@@ -3291,39 +3227,30 @@ describe("raw exchange-head sync", () => {
 				expect(hintColumnsSpy.callCount).to.equal(0);
 				expect(blockHasManySpy.callCount).to.equal(0);
 				expect(getShallowSpy.callCount).to.equal(0);
-				expect(waitForGidSpy.callCount).to.equal(0);
-				expect(waitForEntrySpy.callCount).to.equal(0);
-				expect(responseAddStub.callCount).to.equal(1);
-				expect(responseAddStub.firstCall.args[0].hashes).to.deep.equal(hashes);
-				expect(responseAddStub.firstCall.args[0].peers).to.deep.equal([
-					session.peers[0].identity.publicKey.hashcode(),
-				]);
-				const backboneProfile = profileEvents.find(
-					(event) =>
-						event.name === "sharedLog.receive.requestPrune.nativeBackbonePlan",
+				const response = send
+					.getCalls()
+					.map((call) => call.args[0])
+					.find(
+						(message): message is ResponseIPruneV2 =>
+							message instanceof ResponseIPruneV2,
+					);
+				expect(response).to.exist;
+				expect(
+					response!.requests.map(({ hash, requestId }) => ({
+						hash,
+						requestId,
+					})),
+				).to.deep.equal(requests);
+				const total = profileEvents.find(
+					(event) => event.name === "sharedLog.receive.requestPrune.total",
 				);
-				expect(backboneProfile.details.nativeEntries).to.equal(hashes.length);
-				expect(backboneProfile.details.presentBlocks).to.equal(hashes.length);
-				expect(backboneProfile.details.localLeaders).to.equal(hashes.length);
-				const loopProfile = profileEvents.find(
-					(event) => event.name === "sharedLog.receive.requestPrune.loop",
-				);
-				expect(loopProfile.details.nativeBatchConfirmed).to.equal(true);
-				expect(loopProfile.details.leaderResponses).to.equal(hashes.length);
+				expect(total.details.presentEntries).to.equal(requests.length);
+				expect(total.details.leaderResponses).to.equal(requests.length);
+				expect(total.details.pendingIHaveCreated).to.equal(0);
 			} finally {
-				const pending = sharedLog._pendingIHave as Map<
-					string,
-					{ clear?: () => void }
-				>;
-				for (const value of pending.values()) {
-					value.clear?.();
-				}
-				pending.clear();
+				send.restore();
 				getShallowSpy.restore();
 				blockHasManySpy.restore();
-				waitForEntrySpy.restore();
-				waitForGidSpy.restore();
-				responseAddStub.restore();
 				hintColumnsSpy.restore();
 				allConfirmedStub.restore();
 			}


### PR DESCRIPTION
## Summary\n\n- replace uncorrelated checked-prune receipts with exact 32-byte per-generation request IDs from authenticated peers\n- serialize inbound grant admission and revalidate fresh ownership plus exact quorum at the final delete boundary\n- revoke stale receipts across peer cleanup and churn, fence stale debounce work, and retain exhausted background work in one bounded low-rate audit\n- prune newly exposed parents through independent nonrecursive generations\n- update the receive-prune benchmark and add adversarial coordinator, lifecycle, retry, grant-ordering, and churn coverage\n\n## Rollout behavior\n\nThis is intentionally fail closed. Legacy RequestIPrune and ResponseIPrune messages cannot authorize deletion for a V2 generation. During a mixed-version rollout, peers retain extra copies until every participant in a handoff has upgraded; no entry is deleted based on an uncorrelated legacy receipt.\n\nSupersedes #1130 with a clean branch containing only the reviewed checked-prune changes.\n\n## Validation\n\n- full shared-log Node suite: 2,280 passing, 10 pre-existing pending (22 minutes)\n- final focused and affected integration set: 56 passing\n- repeated combined u32/u64 join-leave churn: 3 of 3 runs passing\n- repository-wide pnpm run build\n- git diff --check