### PR TITLE
fix(shared-log): bound exchange payload lookahead

### DIFF
--- a/.changeset/small-heads-travel.md
+++ b/.changeset/small-heads-travel.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Bound count-based lookahead for hash-resolved full entries and raw JS blocks while preserving order and deduplication when a batch falls back. Caller-owned entries and individual entry size remain outside this count bound.

--- a/packages/programs/data/shared-log/src/exchange-heads.ts
+++ b/packages/programs/data/shared-log/src/exchange-heads.ts
@@ -1160,26 +1160,32 @@ export class ResponseIPruneV2 extends TransportMessage {
 
 const MAX_EXCHANGE_MESSAGE_SIZE = 1e5; // 100kb. Too large size might not be faster (even if we can do 5mb)
 export const MAX_RAW_EXCHANGE_MESSAGE_SIZE = 512 * 1024;
+// Hash-resolved full entries and raw JS blocks remain reachable while a yielded
+// message is being sent, so bound their count-based lookahead. Caller-owned
+// Entry[] values and an individual entry's bytes are not byte-bounded here;
+// native metadata-only planning can retain its larger batch.
+const EXCHANGE_HEADS_PAYLOAD_RESOLVE_BATCH_SIZE = 16;
 export const EXCHANGE_HEADS_RESOLVE_BATCH_SIZE = 256;
 
-export const createExchangeHeadsMessages = async function* (
+const createExchangeHeadsMessagesWithVisited = async function* (
 	log: Log<any>,
 	heads: Entry<any>[] | string[] | Set<string>,
+	visitedHeads: Set<string>,
 ): AsyncGenerator<ExchangeHeadsMessage<any>, void, void> {
 	let size = 0;
 	let current: EntryWithRefs<any>[] = [];
-	const visitedHeads = new Set<string>();
 	const headArray = Array.isArray(heads) ? heads : [...heads];
-	const canUseNativeReferenceGids = headArray.length === 1;
+	const canUseNativeReferenceGids =
+		headArray.length === 1 && visitedHeads.size === 0;
 
 	for (
 		let offset = 0;
 		offset < headArray.length;
-		offset += EXCHANGE_HEADS_RESOLVE_BATCH_SIZE
+		offset += EXCHANGE_HEADS_PAYLOAD_RESOLVE_BATCH_SIZE
 	) {
 		const headBatch = headArray.slice(
 			offset,
-			offset + EXCHANGE_HEADS_RESOLVE_BATCH_SIZE,
+			offset + EXCHANGE_HEADS_PAYLOAD_RESOLVE_BATCH_SIZE,
 		);
 		const nativeReferenceRowsByPosition =
 			canUseNativeReferenceGids === false
@@ -1192,6 +1198,7 @@ export const createExchangeHeadsMessages = async function* (
 		);
 		for (let i = 0; i < resolvedHeads.length; i++) {
 			const entry = resolvedHeads[i];
+			resolvedHeads[i] = undefined;
 			if (!entry) {
 				continue; // missing this entry, could be deleted while iterating
 			}
@@ -1290,6 +1297,13 @@ export const createExchangeHeadsMessages = async function* (
 	}
 };
 
+export const createExchangeHeadsMessages = async function* (
+	log: Log<any>,
+	heads: Entry<any>[] | string[] | Set<string>,
+): AsyncGenerator<ExchangeHeadsMessage<any>, void, void> {
+	yield* createExchangeHeadsMessagesWithVisited(log, heads, new Set<string>());
+};
+
 export const createRawExchangeHeadsMessages = async function* (
 	log: Log<any>,
 	heads: string[] | Set<string>,
@@ -1313,30 +1327,44 @@ export const createRawExchangeHeadsMessages = async function* (
 			});
 		}
 	};
+	const flushCurrent = () => {
+		if (current.length === 0) {
+			return undefined;
+		}
+		emitJsBlockBytes(current, size);
+		const message = new RawExchangeHeadsMessage({ heads: current });
+		size = 0;
+		current = [];
+		return message;
+	};
 
-	for (let offset = 0; offset < headArray.length; offset += EXCHANGE_HEADS_RESOLVE_BATCH_SIZE) {
+	for (
+		let offset = 0;
+		offset < headArray.length;
+		offset += EXCHANGE_HEADS_PAYLOAD_RESOLVE_BATCH_SIZE
+	) {
 		const headBatch = headArray.slice(
 			offset,
-			offset + EXCHANGE_HEADS_RESOLVE_BATCH_SIZE,
+			offset + EXCHANGE_HEADS_PAYLOAD_RESOLVE_BATCH_SIZE,
 		);
 		const nativeReferenceRowsByPosition = getNativeReferenceRowsByHeadInput(
 			log,
 			headBatch,
 			visitedHeads,
 		);
-		if (!nativeReferenceRowsByPosition) {
-			for await (const message of createExchangeHeadsMessages(log, headBatch)) {
-				yield message;
+		const blockRows = nativeReferenceRowsByPosition
+			? await resolveExchangeHeadBlocks(log, headBatch, visitedHeads)
+			: undefined;
+		if (!nativeReferenceRowsByPosition || !blockRows) {
+			const pending = flushCurrent();
+			if (pending) {
+				yield pending;
 			}
-			continue;
-		}
-		const blockRows = await resolveExchangeHeadBlocks(
-			log,
-			headBatch,
-			visitedHeads,
-		);
-		if (!blockRows) {
-			for await (const message of createExchangeHeadsMessages(log, headBatch)) {
+			for await (const message of createExchangeHeadsMessagesWithVisited(
+				log,
+				headBatch,
+				visitedHeads,
+			)) {
 				yield message;
 			}
 			continue;
@@ -1344,6 +1372,7 @@ export const createRawExchangeHeadsMessages = async function* (
 
 		for (let i = 0; i < blockRows.length; i++) {
 			const block = blockRows[i];
+			blockRows[i] = undefined;
 			if (!block) {
 				continue;
 			}
@@ -1376,16 +1405,16 @@ export const createRawExchangeHeadsMessages = async function* (
 			);
 			size += block.bytes.byteLength;
 			if (size > MAX_RAW_EXCHANGE_MESSAGE_SIZE) {
-				emitJsBlockBytes(current, size);
-				size = 0;
-				yield new RawExchangeHeadsMessage({ heads: current });
-				current = [];
+				const pending = flushCurrent();
+				if (pending) {
+					yield pending;
+				}
 			}
 		}
 	}
-	if (current.length > 0) {
-		emitJsBlockBytes(current, size);
-		yield new RawExchangeHeadsMessage({ heads: current });
+	const pending = flushCurrent();
+	if (pending) {
+		yield pending;
 	}
 };
 

--- a/packages/programs/data/shared-log/test/exchange-heads.spec.ts
+++ b/packages/programs/data/shared-log/test/exchange-heads.spec.ts
@@ -6,7 +6,7 @@ import { expect } from "chai";
 import sinon from "sinon";
 import {
 	CheckedPruneRequest,
-	EXCHANGE_HEADS_RESOLVE_BATCH_SIZE,
+	MAX_RAW_EXCHANGE_MESSAGE_SIZE,
 	RawExchangeHeadsMessage,
 	RequestIPruneV2,
 	ResponseIPruneV2,
@@ -15,6 +15,32 @@ import {
 	materializeRawExchangeHeadsMessage,
 } from "../src/exchange-heads.js";
 import { TransportMessage } from "../src/message.js";
+
+const LARGE_HEAD_PAYLOAD_BYTES = MAX_RAW_EXCHANGE_MESSAGE_SIZE + 1;
+const PAYLOAD_RESOLVE_BATCH_SIZE = 16;
+
+const appendLargeIndependentHeads = async (
+	log: Log<Uint8Array>,
+	count: number,
+) => {
+	const heads: string[] = [];
+	for (let i = 0; i < count; i++) {
+		const { entry } = await log.append(
+			new Uint8Array(LARGE_HEAD_PAYLOAD_BYTES),
+			{
+				meta: { next: [], gidSeed: new Uint8Array([i]) },
+			},
+		);
+		heads.push(entry.hash);
+	}
+	return heads;
+};
+
+const createMissingBlockHash = async (log: Log<Uint8Array>) => {
+	const hash = await log.blocks.put(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
+	await log.blocks.rm(hash);
+	return hash;
+};
 
 describe("exchange heads", () => {
 	let store: AnyBlockStore;
@@ -322,38 +348,278 @@ describe("exchange heads", () => {
 		}
 	});
 
-	it("resolves large hash head responses in bounded entry-index batches", async () => {
+	it("bounds full-entry lookahead while a large response is suspended", async () => {
 		const log = new Log<Uint8Array>();
 		await log.open(store, signKey, {
 			appendDurability: "strict",
 			nativeGraph: true,
 		});
 
-		const heads = [];
-		for (let i = 0; i < EXCHANGE_HEADS_RESOLVE_BATCH_SIZE + 2; i++) {
-			const { entry } = await log.append(new Uint8Array([i % 256]), {
-				meta: { next: [], gidSeed: new Uint8Array([i % 256, i >>> 8]) },
+		const heads = await appendLargeIndependentHeads(log, 18);
+		const missing = await createMissingBlockHash(log);
+		const requested = [...heads.slice(0, 17), missing, heads[17]!];
+		const getManySpy = sinon.spy(log.entryIndex, "getMany");
+		const generator = createExchangeHeadsMessages(log, requested);
+		try {
+			const first = await generator.next();
+			expect(first.done).to.equal(false);
+			expect(first.value!.heads.map((head) => head.entry.hash)).to.deep.equal([
+				heads[0],
+			]);
+			expect(getManySpy.callCount).to.equal(1);
+			expect(getManySpy.firstCall.args[0]).to.have.length(
+				PAYLOAD_RESOLVE_BATCH_SIZE,
+			);
+
+			const received = first.value!.heads.map((head) => head.entry.hash);
+			for await (const message of generator) {
+				received.push(...message.heads.map((head) => head.entry.hash));
+			}
+
+			expect(received).to.deep.equal(heads);
+			expect(getManySpy.callCount).to.equal(2);
+			expect(getManySpy.secondCall.args[0]).to.deep.equal(requested.slice(16));
+			expect(
+				getManySpy
+					.getCalls()
+					.every((call) => call.args[0].length <= PAYLOAD_RESOLVE_BATCH_SIZE),
+			).to.equal(true);
+		} finally {
+			await generator.return(undefined);
+			getManySpy.restore();
+			await log.close();
+		}
+	});
+
+	it("bounds raw-block lookahead while a large response is suspended", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			appendDurability: "strict",
+			nativeGraph: true,
+		});
+
+		const heads = await appendLargeIndependentHeads(log, 18);
+		const getManySpy = sinon.spy(log.blocks, "getMany");
+		const generator = createRawExchangeHeadsMessages(log, heads);
+		try {
+			const first = await generator.next();
+			expect(first.done).to.equal(false);
+			expect(first.value).to.be.instanceOf(RawExchangeHeadsMessage);
+			expect(
+				(first.value as RawExchangeHeadsMessage).heads.map((head) => head.hash),
+			).to.deep.equal(heads.slice(0, 1));
+			expect(getManySpy.callCount).to.equal(1);
+			expect(getManySpy.firstCall.args[0]).to.have.length(
+				PAYLOAD_RESOLVE_BATCH_SIZE,
+			);
+
+			const received = (first.value as RawExchangeHeadsMessage).heads.map(
+				(head) => head.hash,
+			);
+			for await (const message of generator) {
+				received.push(
+					...(message instanceof RawExchangeHeadsMessage
+						? message.heads.map((head) => head.hash)
+						: message.heads.map((head) => head.entry.hash)),
+				);
+			}
+
+			expect(received).to.deep.equal(heads);
+			expect(getManySpy.callCount).to.equal(2);
+			expect(getManySpy.secondCall.args[0]).to.deep.equal(heads.slice(16));
+			expect(
+				getManySpy
+					.getCalls()
+					.every((call) => call.args[0].length <= PAYLOAD_RESOLVE_BATCH_SIZE),
+			).to.equal(true);
+		} finally {
+			await generator.return(undefined);
+			getManySpy.restore();
+			await log.close();
+		}
+	});
+
+	it("preserves order when a later raw batch falls back", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			appendDurability: "strict",
+			nativeGraph: true,
+		});
+
+		const heads: string[] = [];
+		for (let i = 0; i < 17; i++) {
+			const { entry } = await log.append(new Uint8Array([i]), {
+				meta: { next: [], gidSeed: new Uint8Array([i]) },
 			});
 			heads.push(entry.hash);
 		}
+		await log.blocks.rm(heads[16]!);
 
-		const getManySpy = sinon.spy(log.entryIndex, "getMany");
 		try {
 			const messages = [];
-			for await (const message of createExchangeHeadsMessages(log, heads)) {
+			const profileEvents: Array<{
+				name: string;
+				entries?: number;
+				messages?: number;
+			}> = [];
+			for await (const message of createRawExchangeHeadsMessages(
+				log,
+				heads,
+				(event) => profileEvents.push(event),
+			)) {
 				messages.push(message);
 			}
-
-			expect(messages.flatMap((message) => message.heads)).to.have.length(
-				heads.length,
+			expect(messages).to.have.length(2);
+			expect(messages[0]).to.be.instanceOf(RawExchangeHeadsMessage);
+			expect(messages[1]).to.not.be.instanceOf(RawExchangeHeadsMessage);
+			expect(
+				messages.flatMap((message) =>
+					message instanceof RawExchangeHeadsMessage
+						? message.heads.map((head) => head.hash)
+						: message.heads.map((head) => head.entry.hash),
+				),
+			).to.deep.equal(heads);
+			const rawProfileEvents = profileEvents.filter(
+				(event) => event.name === "sharedLog.rawSend.jsBlockBytes",
 			);
-			expect(getManySpy.callCount).to.equal(2);
-			expect(getManySpy.firstCall.args[0]).to.have.length(
-				EXCHANGE_HEADS_RESOLVE_BATCH_SIZE,
-			);
-			expect(getManySpy.secondCall.args[0]).to.have.length(2);
+			expect(rawProfileEvents).to.have.length(1);
+			expect(rawProfileEvents[0]!.entries).to.equal(16);
+			expect(rawProfileEvents[0]!.messages).to.equal(1);
 		} finally {
-			getManySpy.restore();
+			await log.close();
+		}
+	});
+
+	it("does not repeat native reference gids in one-head fallback", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			appendDurability: "strict",
+			nativeGraph: true,
+		});
+
+		const roots = [];
+		for (const seed of [21, 22, 23]) {
+			const { entry } = await log.append(new Uint8Array([seed]), {
+				meta: { next: [], gidSeed: new Uint8Array([seed]) },
+			});
+			roots.push(entry);
+		}
+		roots.sort((left, right) =>
+			left.meta.gid < right.meta.gid
+				? -1
+				: left.meta.gid > right.meta.gid
+					? 1
+					: 0,
+		);
+		const { entry: rawHead } = await log.append(new Uint8Array([24]), {
+			meta: { next: [roots[0]!, roots[2]!] },
+		});
+		const { entry: fallbackHead } = await log.append(new Uint8Array([25]), {
+			meta: { next: [roots[1]!, roots[2]!] },
+		});
+		const sharedReference = roots[2]!;
+		const firstBatch = [rawHead.hash];
+		for (let i = 0; i < 15; i++) {
+			const { entry } = await log.append(new Uint8Array([i + 30]), {
+				meta: { next: [], gidSeed: new Uint8Array([i + 30]) },
+			});
+			firstBatch.push(entry.hash);
+		}
+		expect((await log.get(fallbackHead.hash))?.hash).to.equal(
+			fallbackHead.hash,
+		);
+		await log.blocks.rm(fallbackHead.hash);
+
+		try {
+			const sent: Array<{ hash: string; gidRefrences: string[] }> = [];
+			for await (const message of createRawExchangeHeadsMessages(log, [
+				...firstBatch,
+				fallbackHead.hash,
+			])) {
+				sent.push(
+					...(message instanceof RawExchangeHeadsMessage
+						? message.heads.map(({ hash, gidRefrences }) => ({
+								hash,
+								gidRefrences,
+							}))
+						: message.heads.map(({ entry, gidRefrences }) => ({
+								hash: entry.hash,
+								gidRefrences,
+							}))),
+				);
+			}
+
+			expect(sent.map(({ hash }) => hash)).to.deep.equal([
+				...firstBatch,
+				fallbackHead.hash,
+			]);
+			expect(
+				sent
+					.flatMap(({ gidRefrences }) => gidRefrences)
+					.filter((gid) => gid === sharedReference.meta.gid),
+			).to.have.length(1);
+			expect(
+				sent.find(({ hash }) => hash === rawHead.hash)!.gidRefrences,
+			).to.include(sharedReference.meta.gid);
+			expect(
+				sent.find(({ hash }) => hash === fallbackHead.hash)!.gidRefrences,
+			).to.not.include(sharedReference.meta.gid);
+		} finally {
+			await log.close();
+		}
+	});
+
+	it("deduplicates heads and references across raw fallback batches", async () => {
+		const log = new Log<Uint8Array>();
+		await log.open(store, signKey, {
+			appendDurability: "strict",
+			nativeGraph: false,
+		});
+
+		const { entry: left } = await log.append(new Uint8Array([1]), {
+			meta: { next: [], gidSeed: new Uint8Array([1]) },
+		});
+		const { entry: right } = await log.append(new Uint8Array([2]), {
+			meta: { next: [], gidSeed: new Uint8Array([2]) },
+		});
+		const { entry: head } = await log.append(new Uint8Array([3]), {
+			meta: { next: [left, right] },
+		});
+		const reference = [left, right].find(
+			(entry) => entry.meta.gid !== head.meta.gid,
+		)!;
+		const firstBatch = [head.hash];
+		for (let i = 0; i < 15; i++) {
+			const { entry } = await log.append(new Uint8Array([i + 4]), {
+				meta: { next: [], gidSeed: new Uint8Array([i + 4]) },
+			});
+			firstBatch.push(entry.hash);
+		}
+
+		try {
+			const sent: Array<{ hash: string; gidRefrences: string[] }> = [];
+			for await (const message of createRawExchangeHeadsMessages(log, [
+				...firstBatch,
+				reference.hash,
+				head.hash,
+			])) {
+				sent.push(
+					...(message instanceof RawExchangeHeadsMessage
+						? message.heads.map(({ hash, gidRefrences }) => ({
+								hash,
+								gidRefrences,
+							}))
+						: message.heads.map(({ entry, gidRefrences }) => ({
+								hash: entry.hash,
+								gidRefrences,
+							}))),
+				);
+			}
+			expect(sent.map(({ hash }) => hash)).to.deep.equal(firstBatch);
+			expect(
+				sent.find(({ hash }) => hash === head.hash)!.gidRefrences,
+			).to.include(reference.meta.gid);
+		} finally {
 			await log.close();
 		}
 	});


### PR DESCRIPTION
## Summary

- cap hash-resolved full-entry and raw-JS-block materialization at 16 items while keeping native metadata planning at 256
- clear consumed payload slots as exchange messages are yielded
- preserve request order and shared head/reference deduplication when a raw batch falls back to full entries

## Why

This is the small follow-up to #1133. That PR removed the dominant fallback-ancestry payload retention; the remaining JS payload paths could still materialize 256 entries or blocks before the first suspended yield. For 256 KiB chunks, the count cap reduces lookahead from roughly 64 MiB to roughly 4 MiB per generator.

This is intentionally a count bound, not a universal byte bound: caller-owned `Entry[]` values and an individual oversized entry remain outside the cap, while oversized entries still make progress one at a time.

Production code changes are limited to the exchange-head generator; most of the diff is regression coverage for bounded lookahead, oversized progress, missing-block fallback ordering, and cross-batch head/reference deduplication.

## Validation

- `pnpm run test:ci:part-6` — 1,821 shared-log tests and 1 proxy test passing
- full exchange-head suite and outbound raw-sync integration passing
- `pnpm --filter @peerbit/shared-log build`
- `git diff --check` and targeted formatting checks passing
- independent final review: no P0/P1/P2 findings
