### PR TITLE
fix(pubsub): converge auto-root overlays

### DIFF
--- a/.changeset/calm-roots-converge.md
+++ b/.changeset/calm-roots-converge.md
@@ -1,0 +1,7 @@
+---
+"@peerbit/pubsub": patch
+---
+
+Converge auto-discovered shard roots across late peer joins and bind direct root-control messages to their verified transport peer.
+
+Leaves that use a queried gateway's internal shard roots must disable automatic candidates with `setTopicRootCandidates([])`; locally configured roots, resolvers, and trackers remain authoritative.

--- a/packages/transport/pubsub/src/index.ts
+++ b/packages/transport/pubsub/src/index.ts
@@ -230,6 +230,14 @@ export type TopicControlPlaneOptions = DirectStreamOptions & {
 	subscriberCacheMaxEntries?: number;
 };
 
+type EnsureFanoutChannelOptions = {
+	ephemeral?: boolean;
+	pin?: boolean;
+	root?: string;
+	rootCandidateGeneration?: string;
+	signal?: AbortSignal;
+};
+
 export type TopicControlPlaneComponents = DirectStreamComponents;
 
 export type PeerId = Libp2pPeerId | PublicSignKey;
@@ -333,6 +341,9 @@ export class TopicControlPlane
 	private autoTopicRootCandidates = false;
 	private autoTopicRootCandidateSet?: Set<string>;
 	private reconcileShardOverlaysInFlight?: Promise<void>;
+	private reconcileShardOverlaysDirty = false;
+	private topicControlPlaneStopping = false;
+	private topicControlPlaneLifecycleRevision = 0;
 	private hostOwnedShardRootsInFlight?: Promise<void>;
 	private hostOwnedShardRootsDirty = false;
 	private autoCandidatesBroadcastTimers: Array<ReturnType<typeof setTimeout>> =
@@ -356,9 +367,18 @@ export class TopicControlPlane
 			idleCloseTimeout?: ReturnType<typeof setTimeout>;
 		}
 	>();
+	private ensureFanoutChannelInFlight = new Map<
+		string,
+		{
+			candidateGeneration: string;
+			lifecycleRevision: number;
+			opening: Promise<void>;
+		}
+	>();
 	private pendingTopicRootQueries = new Map<
 		number,
 		{
+			expectedPeerHash: string;
 			topic: string;
 			resolve: (root: string | undefined) => void;
 			timer: ReturnType<typeof setTimeout>;
@@ -524,6 +544,7 @@ export class TopicControlPlane
 	}
 
 	public override async start() {
+		this.topicControlPlaneStopping = false;
 		await this.fanout.start();
 		this._onFanoutPeerUnreachable =
 			this._onFanoutPeerUnreachable ||
@@ -540,9 +561,16 @@ export class TopicControlPlane
 		if (this.hostOwnedShardRootsDirty) {
 			this.scheduleHostOwnedShardRoots();
 		}
+		if (this.reconcileShardOverlaysDirty) {
+			this.scheduleReconcileShardOverlays();
+		}
 	}
 
 	public override async stop() {
+		this.topicControlPlaneStopping = true;
+		this.topicControlPlaneLifecycleRevision += 1;
+		this.reconcileShardOverlaysDirty = false;
+		this.ensureFanoutChannelInFlight.clear();
 		if (this._onFanoutPeerUnreachable) {
 			this.fanout.removeEventListener(
 				"fanout:peer-unreachable",
@@ -603,7 +631,8 @@ export class TopicControlPlane
 
 		this.debounceSubscribeAggregator.close();
 		this.debounceUnsubscribeAggregator.close();
-		return super.stop();
+		await super.stop();
+		this.reconcileShardOverlaysDirty = false;
 	}
 
 	public override async onPeerConnected(
@@ -840,21 +869,45 @@ export class TopicControlPlane
 	}
 
 	private scheduleReconcileShardOverlays() {
+		this.reconcileShardOverlaysDirty = true;
+		if (!this.started || this.stopping || this.topicControlPlaneStopping)
+			return;
 		if (this.reconcileShardOverlaysInFlight) return;
-		this.reconcileShardOverlaysInFlight = this.reconcileShardOverlays()
-			.catch(() => {
-				// best-effort retry: fanout streams/roots might not be ready yet.
-				if (!this.started || this.stopping) return;
-				const t = setTimeout(() => this.scheduleReconcileShardOverlays(), 250);
-				t.unref?.();
-			})
-			.finally(() => {
-				this.reconcileShardOverlaysInFlight = undefined;
-			});
+		this.reconcileShardOverlaysInFlight = (async () => {
+			for (;;) {
+				if (!this.started || this.stopping || this.topicControlPlaneStopping)
+					return;
+				if (!this.reconcileShardOverlaysDirty) return;
+				this.reconcileShardOverlaysDirty = false;
+				try {
+					await this.reconcileShardOverlays();
+				} catch {
+					// Fanout streams or roots might not be ready yet. Preserve both
+					// failures and root changes that arrived during the active pass.
+					if (!this.started || this.stopping || this.topicControlPlaneStopping)
+						return;
+					this.reconcileShardOverlaysDirty = true;
+					await new Promise<void>((resolve) => {
+						const timer = setTimeout(resolve, 250);
+						timer.unref?.();
+					});
+				}
+			}
+		})().finally(() => {
+			this.reconcileShardOverlaysInFlight = undefined;
+			if (
+				this.reconcileShardOverlaysDirty &&
+				this.started &&
+				!this.stopping &&
+				!this.topicControlPlaneStopping
+			) {
+				this.scheduleReconcileShardOverlays();
+			}
+		});
 	}
 
 	private async reconcileShardOverlays() {
-		if (!this.started) return;
+		if (!this.started || this.topicControlPlaneStopping) return;
 
 		const byShard = new Map<string, string[]>();
 		for (const topic of this.subscriptions.keys()) {
@@ -1134,6 +1187,41 @@ export class TopicControlPlane
 		return PubSubMessage.from(bytes);
 	}
 
+	private getTopicRootCandidateGeneration(): string {
+		return JSON.stringify([
+			this.autoTopicRootCandidates,
+			this.topicRootControlPlane.getTopicRootCandidates(),
+		]);
+	}
+
+	private assertTopicControlPlaneActive(lifecycleRevision: number): void {
+		if (
+			lifecycleRevision !== this.topicControlPlaneLifecycleRevision ||
+			!this.started ||
+			this.stopping ||
+			this.topicControlPlaneStopping
+		) {
+			throw new NotStartedError();
+		}
+	}
+
+	private normalizePeerTopicRootState(
+		topic: string,
+		root: string,
+	): { root: string; authoritative: boolean } {
+		const deterministic =
+			this.topicRootControlPlane.resolveDeterministicTopicRoot(topic);
+		if (
+			this.autoTopicRootCandidates &&
+			topic.startsWith(this.shardTopicPrefix) &&
+			deterministic &&
+			root !== deterministic
+		) {
+			return { root: deterministic, authoritative: false };
+		}
+		return { root, authoritative: true };
+	}
+
 	private async resolveTopicRootState(
 		topic: string,
 	): Promise<{ root?: string; authoritative: boolean }> {
@@ -1144,7 +1232,12 @@ export class TopicControlPlane
 
 		const resolvedThroughPeers = await this.resolveTopicRootThroughPeers(topic);
 		if (resolvedThroughPeers) {
-			return { root: resolvedThroughPeers, authoritative: true };
+			// Unconfigured peer-query replies cannot override the locally
+			// deterministic root for internal shards in auto mode. Roots, resolvers,
+			// and trackers explicitly configured on this control plane are resolved
+			// above and remain authoritative. A leaf relying on a queried gateway for
+			// shard roots must first disable auto mode with setTopicRootCandidates([]).
+			return this.normalizePeerTopicRootState(topic, resolvedThroughPeers);
 		}
 
 		const deterministic = this.topicRootControlPlane.resolveDeterministicTopicRoot(topic);
@@ -1157,46 +1250,65 @@ export class TopicControlPlane
 				await delay(150 * (attempt < 4 ? 1 : 2));
 				const retried = await this.resolveTopicRootThroughPeers(topic);
 				if (retried) {
-					return { root: retried, authoritative: true };
+					return this.normalizePeerTopicRootState(topic, retried);
 				}
 			}
 		}
 
-		return { root: deterministic, authoritative: false };
+		return {
+			root: this.topicRootControlPlane.resolveDeterministicTopicRoot(topic),
+			authoritative: false,
+		};
 	}
 
 	public async resolveTopicRoot(topic: string): Promise<string | undefined> {
 		return (await this.resolveTopicRootState(topic)).root;
 	}
 
-	private async resolveShardRoot(shardTopic: string): Promise<string> {
-		// If someone configured topic-root candidates externally (e.g. TestSession router
-		// selection or Peerbit.bootstrap) after this peer entered auto mode, disable auto
-		// mode before we cache any roots based on a stale candidate set.
-		if (this.autoTopicRootCandidates) {
-			this.maybeDisableAutoTopicRootCandidatesIfExternallyConfigured();
-		}
+	private async resolveShardRootState(
+		shardTopic: string,
+	): Promise<{ root: string; candidateGeneration: string }> {
+		const lifecycleRevision = this.topicControlPlaneLifecycleRevision;
+		for (;;) {
+			this.assertTopicControlPlaneActive(lifecycleRevision);
+			// If someone configured topic-root candidates externally (e.g.
+			// TestSession router selection or Peerbit.bootstrap) after this peer
+			// entered auto mode, disable auto mode before caching a root.
+			if (this.autoTopicRootCandidates) {
+				this.maybeDisableAutoTopicRootCandidatesIfExternallyConfigured();
+			}
 
-		const hasConnectedTrackers = this.getConnectedTopicRootTrackers().length > 0;
-		const cached = this.shardRootCache.get(shardTopic);
-		if (cached && (cached.authoritative || !hasConnectedTrackers)) {
-			return cached.root;
+			const candidateGeneration = this.getTopicRootCandidateGeneration();
+			const hasConnectedTrackers =
+				this.getConnectedTopicRootTrackers().length > 0;
+			const cached = this.shardRootCache.get(shardTopic);
+			if (cached && (cached.authoritative || !hasConnectedTrackers)) {
+				return { root: cached.root, candidateGeneration };
+			}
+
+			const resolved = await this.resolveTopicRootState(shardTopic);
+			this.assertTopicControlPlaneActive(lifecycleRevision);
+			if (candidateGeneration !== this.getTopicRootCandidateGeneration()) {
+				continue;
+			}
+			if (!resolved.root) {
+				throw new Error(
+					`No root resolved for shard topic ${shardTopic}. Configure TopicRootControlPlane candidates/resolver/trackers, or dial/bootstrap a peer that can resolve shard roots.`,
+				);
+			}
+			if (resolved.authoritative || !hasConnectedTrackers) {
+				this.shardRootCache.set(
+					shardTopic,
+					resolved as {
+						root: string;
+						authoritative: boolean;
+					},
+				);
+			} else {
+				this.shardRootCache.delete(shardTopic);
+			}
+			return { root: resolved.root, candidateGeneration };
 		}
-		const resolved = await this.resolveTopicRootState(shardTopic);
-		if (!resolved.root) {
-			throw new Error(
-				`No root resolved for shard topic ${shardTopic}. Configure TopicRootControlPlane candidates/resolver/trackers, or dial/bootstrap a peer that can resolve shard roots.`,
-			);
-		}
-		if (resolved.authoritative || !hasConnectedTrackers) {
-			this.shardRootCache.set(shardTopic, resolved as {
-				root: string;
-				authoritative: boolean;
-			});
-		} else {
-			this.shardRootCache.delete(shardTopic);
-		}
-		return resolved.root;
 	}
 
 	private getConnectedTopicRootTrackers(): PeerStreams[] {
@@ -1240,9 +1352,14 @@ export class TopicControlPlane
 
 	private resolvePendingTopicRootQuery(
 		message: TopicRootQueryResponse,
+		responderPeerHash: string,
 	): boolean {
 		const pending = this.pendingTopicRootQueries.get(message.requestId);
-		if (!pending || pending.topic !== message.topic) {
+		if (
+			!pending ||
+			pending.topic !== message.topic ||
+			pending.expectedPeerHash !== responderPeerHash
+		) {
 			return false;
 		}
 		this.pendingTopicRootQueries.delete(message.requestId);
@@ -1258,6 +1375,7 @@ export class TopicControlPlane
 	): Promise<string | undefined> {
 		if (!this.started || this.stopping) return undefined;
 
+		const expectedPeerHash = peer.publicKey.hashcode();
 		const requestId = this.nextTopicRootRequestIdValue();
 		const responsePromise = new Promise<string | undefined>((resolve) => {
 			const timer = setTimeout(() => {
@@ -1265,7 +1383,12 @@ export class TopicControlPlane
 				resolve(undefined);
 			}, Math.max(1, Math.floor(timeoutMs)));
 			timer.unref?.();
-			this.pendingTopicRootQueries.set(requestId, { topic, resolve, timer });
+			this.pendingTopicRootQueries.set(requestId, {
+				expectedPeerHash,
+				topic,
+				resolve,
+				timer,
+			});
 		});
 
 		try {
@@ -1288,8 +1411,11 @@ export class TopicControlPlane
 	private async confirmDirectShardRoot(
 		shardTopic: string,
 		root: string,
+		candidateGeneration: string,
+		lifecycleRevision: number,
 		signal?: AbortSignal,
 	): Promise<string> {
+		this.assertTopicControlPlaneActive(lifecycleRevision);
 		if (root === this.publicKeyHash) return root;
 		const rootPeer = this.peers.get(root);
 		if (!rootPeer) return root;
@@ -1302,37 +1428,64 @@ export class TopicControlPlane
 			),
 			signal,
 		);
+		this.assertTopicControlPlaneActive(lifecycleRevision);
+		if (candidateGeneration !== this.getTopicRootCandidateGeneration()) {
+			return root;
+		}
 		if (!confirmation) return root;
-		if (confirmation !== root) {
+		const resolved = this.normalizePeerTopicRootState(shardTopic, confirmation);
+		if (!resolved.authoritative) {
+			this.shardRootCache.delete(shardTopic);
+		} else if (resolved.root !== root) {
 			this.shardRootCache.set(shardTopic, {
-				root: confirmation,
+				root: resolved.root,
 				authoritative: true,
 			});
 		}
-		return confirmation;
+		return resolved.root;
 	}
 
 	private async resolveQueryableTopicRoot(
 		topic: string,
 	): Promise<string | undefined> {
-		const root = await this.topicRootControlPlane.resolveCanonicalTopicRoot(topic);
-		if (root !== this.publicKeyHash) {
-			return root;
-		}
-		if (!topic.startsWith(this.shardTopicPrefix)) {
-			return root;
-		}
+		const lifecycleRevision = this.topicControlPlaneLifecycleRevision;
+		for (;;) {
+			this.assertTopicControlPlaneActive(lifecycleRevision);
+			const rootCandidateGeneration = this.getTopicRootCandidateGeneration();
+			const root =
+				await this.topicRootControlPlane.resolveCanonicalTopicRoot(topic);
+			this.assertTopicControlPlaneActive(lifecycleRevision);
+			if (rootCandidateGeneration !== this.getTopicRootCandidateGeneration()) {
+				continue;
+			}
+			if (root !== this.publicKeyHash) {
+				return root;
+			}
+			if (!topic.startsWith(this.shardTopicPrefix)) {
+				return root;
+			}
 
-		try {
-			await this.ensureFanoutChannel(topic, { pin: true, root });
-			return root;
-		} catch (error) {
-			warn(
-				`Failed to host shard root ${topic} before answering root query: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
-			);
-			return undefined;
+			try {
+				await this.ensureFanoutChannel(topic, {
+					pin: true,
+					root,
+					rootCandidateGeneration,
+				});
+				this.assertTopicControlPlaneActive(lifecycleRevision);
+				if (
+					rootCandidateGeneration !== this.getTopicRootCandidateGeneration()
+				) {
+					continue;
+				}
+				return root;
+			} catch (error) {
+				warn(
+					`Failed to host shard root ${topic} before answering root query: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+				return undefined;
+			}
 		}
 	}
 
@@ -1361,14 +1514,69 @@ export class TopicControlPlane
 
 	private async ensureFanoutChannel(
 		shardTopic: string,
-		options?: {
-			ephemeral?: boolean;
-			pin?: boolean;
-			root?: string;
-			signal?: AbortSignal;
-		},
+		options?: EnsureFanoutChannelOptions,
 	): Promise<void> {
-		if (!this.started) throw new NotStartedError();
+		const topic = shardTopic.toString();
+		const lifecycleRevision = this.topicControlPlaneLifecycleRevision;
+		for (;;) {
+			this.assertTopicControlPlaneActive(lifecycleRevision);
+			const candidateGeneration = this.getTopicRootCandidateGeneration();
+			const active = this.ensureFanoutChannelInFlight.get(topic);
+			if (
+				active?.candidateGeneration === candidateGeneration &&
+				active.lifecycleRevision === lifecycleRevision
+			) {
+				try {
+					await withAbort(active.opening, options?.signal);
+				} catch (error) {
+					if (options?.signal?.aborted) throw error;
+					this.assertTopicControlPlaneActive(lifecycleRevision);
+				}
+				continue;
+			}
+
+			const opening = this.ensureFanoutChannelOnce(
+				topic,
+				options,
+				lifecycleRevision,
+				candidateGeneration,
+			);
+			const inFlight = {
+				candidateGeneration,
+				lifecycleRevision,
+				opening,
+			};
+			this.ensureFanoutChannelInFlight.set(topic, inFlight);
+			try {
+				await opening;
+				this.assertTopicControlPlaneActive(lifecycleRevision);
+				if (candidateGeneration !== this.getTopicRootCandidateGeneration()) {
+					continue;
+				}
+				return;
+			} catch (error) {
+				if (options?.signal?.aborted) throw error;
+				this.assertTopicControlPlaneActive(lifecycleRevision);
+				if (candidateGeneration !== this.getTopicRootCandidateGeneration()) {
+					continue;
+				}
+				throw error;
+			} finally {
+				if (this.ensureFanoutChannelInFlight.get(topic) === inFlight) {
+					this.ensureFanoutChannelInFlight.delete(topic);
+				}
+			}
+		}
+	}
+
+	private async ensureFanoutChannelOnce(
+		shardTopic: string,
+		options: EnsureFanoutChannelOptions | undefined,
+		lifecycleRevision: number,
+		candidateGeneration: string,
+	): Promise<void> {
+		this.assertTopicControlPlaneActive(lifecycleRevision);
+		if (candidateGeneration !== this.getTopicRootCandidateGeneration()) return;
 		const t = shardTopic.toString();
 		const pin = options?.pin === true;
 		const wantEphemeral = options?.ephemeral === true;
@@ -1376,10 +1584,31 @@ export class TopicControlPlane
 		// Allow callers that already resolved the shard root (e.g. hostShardRootsNow)
 		// to pass it through to avoid a race where the candidate set changes between
 		// two resolve calls, causing an unnecessary (and potentially slow) join.
-		let root: string | undefined = options?.root;
+		const suppliedRoot = options?.root;
+		const suppliedRootGeneration = options?.rootCandidateGeneration;
+		if (
+			suppliedRoot !== undefined &&
+			suppliedRootGeneration !== candidateGeneration
+		) {
+			return;
+		}
+		this.assertTopicControlPlaneActive(lifecycleRevision);
+		let resolvedGeneration = candidateGeneration;
+		let root = suppliedRoot;
 		const existing = this.fanoutChannels.get(t);
 		if (existing) {
-			root = root ?? (await this.resolveShardRoot(t));
+			if (!root) {
+				const resolved = await this.resolveShardRootState(t);
+				this.assertTopicControlPlaneActive(lifecycleRevision);
+				root = resolved.root;
+				resolvedGeneration = resolved.candidateGeneration;
+			}
+			if (
+				resolvedGeneration !== candidateGeneration ||
+				candidateGeneration !== this.getTopicRootCandidateGeneration()
+			) {
+				return;
+			}
 			if (root === existing.root) {
 				existing.lastUsedAt = Date.now();
 				if (existing.ephemeral && !wantEphemeral) {
@@ -1390,15 +1619,48 @@ export class TopicControlPlane
 				}
 				if (pin) this.pinnedShards.add(t);
 				await withAbort(existing.join, options?.signal);
+				this.assertTopicControlPlaneActive(lifecycleRevision);
+				if (
+					resolvedGeneration !== candidateGeneration ||
+					candidateGeneration !== this.getTopicRootCandidateGeneration()
+				) {
+					return;
+				}
 				return;
 			}
 
-			// Root mapping changed (candidate set updated): migrate to the new overlay.
-			await withAbort(this.closeFanoutChannel(t, { force: true }), options?.signal);
+			// Root mapping changed (candidate set updated): migrate to the new
+			// overlay.
+			await withAbort(
+				this.closeFanoutChannel(t, { force: true }),
+				options?.signal,
+			);
+			this.assertTopicControlPlaneActive(lifecycleRevision);
+			if (candidateGeneration !== this.getTopicRootCandidateGeneration()) {
+				return;
+			}
 		}
 
-		root = root ?? (await this.resolveShardRoot(t));
-		root = await this.confirmDirectShardRoot(t, root, options?.signal);
+		if (!root) {
+			const resolved = await this.resolveShardRootState(t);
+			this.assertTopicControlPlaneActive(lifecycleRevision);
+			root = resolved.root;
+			resolvedGeneration = resolved.candidateGeneration;
+		}
+		root = await this.confirmDirectShardRoot(
+			t,
+			root,
+			resolvedGeneration,
+			lifecycleRevision,
+			options?.signal,
+		);
+		this.assertTopicControlPlaneActive(lifecycleRevision);
+		if (
+			resolvedGeneration !== candidateGeneration ||
+			candidateGeneration !== this.getTopicRootCandidateGeneration()
+		) {
+			return;
+		}
 		const channel = new FanoutChannel(this.fanout, { topic: t, root });
 
 		const onPayload = (payload: Uint8Array) => {
@@ -1541,7 +1803,7 @@ export class TopicControlPlane
 
 		const lastUsedAt = Date.now();
 		if (pin) this.pinnedShards.add(t);
-		this.fanoutChannels.set(t, {
+		const channelState = {
 			root,
 			channel,
 			join,
@@ -1549,14 +1811,19 @@ export class TopicControlPlane
 			onUnicast,
 			ephemeral: wantEphemeral,
 			lastUsedAt,
-		});
+		};
+		this.fanoutChannels.set(t, channelState);
 		join.catch(() => {
-			this.fanoutChannels.delete(t);
+			if (this.fanoutChannels.get(t) === channelState) {
+				this.fanoutChannels.delete(t);
+			}
 		});
 		join
 			.then(() => {
 				const st = this.fanoutChannels.get(t);
-				if (st?.ephemeral) this.scheduleFanoutIdleClose(t);
+				if (st === channelState && st.ephemeral) {
+					this.scheduleFanoutIdleClose(t);
+				}
 			})
 			.catch(() => {
 				// ignore
@@ -1565,6 +1832,7 @@ export class TopicControlPlane
 			this.evictEphemeralFanoutChannels(t);
 		}
 		await withAbort(join, options?.signal);
+		this.assertTopicControlPlaneActive(lifecycleRevision);
 	}
 
 	private async closeFanoutChannel(
@@ -1604,9 +1872,15 @@ export class TopicControlPlane
 		const joins: Promise<void>[] = [];
 		for (let i = 0; i < this.shardCount; i++) {
 			const shardTopic = `${this.shardTopicPrefix}${i}`;
-			const root = await this.resolveShardRoot(shardTopic);
-			if (root !== this.publicKeyHash) continue;
-			joins.push(this.ensureFanoutChannel(shardTopic, { pin: true, root }));
+			const resolved = await this.resolveShardRootState(shardTopic);
+			if (resolved.root !== this.publicKeyHash) continue;
+			joins.push(
+				this.ensureFanoutChannel(shardTopic, {
+					pin: true,
+					root: resolved.root,
+					rootCandidateGeneration: resolved.candidateGeneration,
+				}),
+			);
 		}
 		await Promise.all(joins);
 	}
@@ -2503,6 +2777,19 @@ export class TopicControlPlane
 		stream: PeerStreams;
 	}): Promise<void> {
 		const { pubsubMessage, message, from, stream } = input;
+		const isDirectRootControl =
+			pubsubMessage instanceof TopicRootCandidates ||
+			pubsubMessage instanceof TopicRootQuery ||
+			pubsubMessage instanceof TopicRootQueryResponse;
+		const directRootSigner = isDirectRootControl
+			? message.header.signatures?.publicKeys[0]
+			: undefined;
+		if (
+			isDirectRootControl &&
+			(!directRootSigner || !directRootSigner.equals(stream.publicKey))
+		) {
+			return;
+		}
 
 		if (pubsubMessage instanceof TopicRootCandidates) {
 			// Used only to converge deterministic shard-root candidates in auto mode.
@@ -2524,7 +2811,8 @@ export class TopicControlPlane
 		}
 
 		if (pubsubMessage instanceof TopicRootQueryResponse) {
-			this.resolvePendingTopicRootQuery(pubsubMessage);
+			const senderHash = directRootSigner!.hashcode();
+			this.resolvePendingTopicRootQuery(pubsubMessage, senderHash);
 			return;
 		}
 

--- a/packages/transport/pubsub/test/subscribe-races.spec.ts
+++ b/packages/transport/pubsub/test/subscribe-races.spec.ts
@@ -1,9 +1,17 @@
 import { getPublicKeyFromPeerId } from "@peerbit/crypto";
 import { TestSession } from "@peerbit/libp2p-test-utils";
+import {
+	TopicRootCandidates,
+	TopicRootQueryResponse,
+} from "@peerbit/pubsub-interface";
 import { waitForNeighbour } from "@peerbit/stream";
 import { delay, waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
-import { FanoutTree, TopicControlPlane, TopicRootControlPlane } from "../src/index.js";
+import {
+	FanoutTree,
+	TopicControlPlane,
+	TopicRootControlPlane,
+} from "../src/index.js";
 
 describe("pubsub (subscribe race regressions)", function () {
 	let session:
@@ -124,6 +132,42 @@ describe("pubsub (subscribe race regressions)", function () {
 		return hash >>> 0;
 	};
 
+	const findCandidateTransitionTopic = (
+		beforeCandidates: string[],
+		afterCandidates: string[],
+		expectedBefore?: string,
+		expectedAfter?: string,
+		maxSearch = 10_000,
+	) => {
+		const before = new TopicRootControlPlane({
+			defaultCandidates: beforeCandidates,
+		});
+		const after = new TopicRootControlPlane({
+			defaultCandidates: afterCandidates,
+		});
+		for (let index = 0; index < maxSearch; index++) {
+			const topic = `/peerbit/pubsub-shard/1/${index}`;
+			const beforeRoot = before.resolveDeterministicTopicRoot(topic);
+			const afterRoot = after.resolveDeterministicTopicRoot(topic);
+			if (
+				beforeRoot !== afterRoot &&
+				(expectedBefore === undefined || beforeRoot === expectedBefore) &&
+				(expectedAfter === undefined || afterRoot === expectedAfter)
+			) {
+				return { afterRoot: afterRoot!, beforeRoot: beforeRoot!, index, topic };
+			}
+		}
+		throw new Error("Unable to find a topic whose candidate root changes");
+	};
+
+	const deferred = () => {
+		let resolve!: () => void;
+		const promise = new Promise<void>((next) => {
+			resolve = next;
+		});
+		return { promise, resolve };
+	};
+
 	afterEach(async () => {
 		if (session) {
 			await session.stop();
@@ -155,6 +199,458 @@ describe("pubsub (subscribe race regressions)", function () {
 		});
 	});
 
+	it("does not drop reconciliation requested during an in-flight pass", async () => {
+		session = await createDisconnectedSession(1);
+		const pubsub = session.peers[0]!.services.pubsub as any;
+		const firstGate = deferred();
+		const firstEntered = deferred();
+		let calls = 0;
+		pubsub.reconcileShardOverlays = async () => {
+			calls += 1;
+			if (calls === 1) {
+				firstEntered.resolve();
+				await firstGate.promise;
+			}
+		};
+
+		pubsub.scheduleReconcileShardOverlays();
+		await firstEntered.promise;
+		pubsub.scheduleReconcileShardOverlays();
+		firstGate.resolve();
+
+		await waitForResolved(() => expect(calls).to.equal(2), {
+			timeout: 1_000,
+			delayInterval: 10,
+		});
+	});
+
+	it("rejects a stale delayed-retry root after auto candidates change", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const staleRoot = pubsub.publicKeyHash;
+		const addedCandidate = "root-candidate-added-during-query";
+		const { afterRoot: currentRoot, topic } = findCandidateTransitionTopic(
+			[staleRoot],
+			[staleRoot, addedCandidate],
+		);
+
+		const queryGate = deferred();
+		const queryEntered = deferred();
+		internals.scheduleReconcileShardOverlays = () => {};
+		internals.scheduleHostOwnedShardRoots = () => {};
+		internals.scheduleAutoTopicRootCandidatesBroadcast = () => {};
+		internals.getConnectedTopicRootTrackers = () => [{}];
+		let queryCalls = 0;
+		internals.resolveTopicRootThroughPeers = async () => {
+			queryCalls += 1;
+			if (queryCalls === 1) return undefined;
+			queryEntered.resolve();
+			await queryGate.promise;
+			return staleRoot;
+		};
+
+		const resolving = internals.resolveTopicRootState(topic);
+		await queryEntered.promise;
+		expect(
+			internals.mergeAutoTopicRootCandidatesFromPeer([addedCandidate]),
+		).to.equal(true);
+		queryGate.resolve();
+
+		expect(await resolving).to.deep.equal({
+			authoritative: false,
+			root: currentRoot,
+		});
+	});
+
+	it("does not reinsert a stale shard root after candidates clear the cache", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const staleRoot = pubsub.publicKeyHash;
+		const addedCandidate = "root-candidate-added-before-cache-write";
+		const { afterRoot: currentRoot, topic } = findCandidateTransitionTopic(
+			[staleRoot],
+			[staleRoot, addedCandidate],
+		);
+
+		internals.scheduleReconcileShardOverlays = () => {};
+		internals.scheduleHostOwnedShardRoots = () => {};
+		internals.scheduleAutoTopicRootCandidatesBroadcast = () => {};
+		let queryCalls = 0;
+		internals.resolveTopicRootThroughPeers = async () => {
+			queryCalls += 1;
+			return queryCalls === 1 ? staleRoot : currentRoot;
+		};
+
+		const originalResolveTopicRootState =
+			internals.resolveTopicRootState.bind(pubsub);
+		const firstStateGate = deferred();
+		const firstStateReady = deferred();
+		let stateCalls = 0;
+		internals.resolveTopicRootState = async (...args: any[]) => {
+			const state = await originalResolveTopicRootState(...args);
+			stateCalls += 1;
+			if (stateCalls === 1) {
+				firstStateReady.resolve();
+				await firstStateGate.promise;
+			}
+			return state;
+		};
+
+		const resolving = internals
+			.resolveShardRootState(topic)
+			.then((state: { root: string }) => state.root);
+		await firstStateReady.promise;
+		expect(
+			internals.mergeAutoTopicRootCandidatesFromPeer([addedCandidate]),
+		).to.equal(true);
+		firstStateGate.resolve();
+
+		expect(await resolving).to.equal(currentRoot);
+		expect(internals.shardRootCache.get(topic)?.root).to.equal(currentRoot);
+		expect(stateCalls).to.equal(2);
+	});
+
+	it("does not let an old opener block or overwrite the current generation", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const fanout = session.peers[0]!.services.fanout as any;
+		const oldRoot = "stale-generation-root";
+		const addedCandidate = "new-generation-candidate";
+
+		internals.scheduleReconcileShardOverlays = () => {};
+		internals.scheduleHostOwnedShardRoots = () => {};
+		internals.scheduleAutoTopicRootCandidatesBroadcast = () => {};
+		expect(internals.mergeAutoTopicRootCandidatesFromPeer([oldRoot])).to.equal(
+			true,
+		);
+		const beforeCandidates =
+			pubsub.topicRootControlPlane.getTopicRootCandidates();
+		const afterCandidates = [...beforeCandidates, addedCandidate];
+		const { topic } = findCandidateTransitionTopic(
+			beforeCandidates,
+			afterCandidates,
+			oldRoot,
+			pubsub.publicKeyHash,
+		);
+		const oldGeneration = internals.getTopicRootCandidateGeneration();
+
+		const confirmationGate = deferred();
+		const confirmationEntered = deferred();
+		internals.peers.set(oldRoot, {
+			isReadable: false,
+			isWritable: false,
+		});
+		internals.queryTopicRootFromPeer = async () => {
+			confirmationEntered.resolve();
+			await confirmationGate.promise;
+			return oldRoot;
+		};
+
+		const channelEventTypes = new Set([
+			"fanout:data",
+			"fanout:unicast",
+			"fanout:joined",
+			"fanout:kicked",
+		]);
+		const originalAddEventListener = fanout.addEventListener.bind(fanout);
+		let channelListenerAdds = 0;
+		fanout.addEventListener = (...args: any[]) => {
+			if (channelEventTypes.has(args[0])) channelListenerAdds += 1;
+			return originalAddEventListener(...args);
+		};
+
+		const resolutionGate = deferred();
+		const resolutionEntered = deferred();
+		let resolutionCalls = 0;
+
+		const oldOpening = internals.ensureFanoutChannel(topic, {
+			root: oldRoot,
+			rootCandidateGeneration: oldGeneration,
+		});
+		try {
+			await confirmationEntered.promise;
+			expect(
+				internals.mergeAutoTopicRootCandidatesFromPeer([addedCandidate]),
+			).to.equal(true);
+			const currentGeneration = internals.getTopicRootCandidateGeneration();
+			internals.resolveShardRootState = async () => {
+				resolutionCalls += 1;
+				resolutionEntered.resolve();
+				await resolutionGate.promise;
+				return {
+					root: pubsub.publicKeyHash,
+					candidateGeneration: currentGeneration,
+				};
+			};
+
+			const currentOpening = internals.ensureFanoutChannel(topic);
+			await resolutionEntered.promise;
+			resolutionGate.resolve();
+			await currentOpening;
+			const currentChannel = internals.fanoutChannels.get(topic);
+			expect(currentChannel?.root).to.equal(pubsub.publicKeyHash);
+
+			confirmationGate.resolve();
+			await oldOpening;
+			expect(internals.fanoutChannels.get(topic)).to.equal(currentChannel);
+		} finally {
+			confirmationGate.resolve();
+			resolutionGate.resolve();
+			fanout.addEventListener = originalAddEventListener;
+			internals.peers.delete(oldRoot);
+		}
+
+		expect(resolutionCalls).to.equal(1);
+		expect(internals.fanoutChannels.size).to.equal(1);
+		expect(internals.fanoutChannels.get(topic)?.root).to.equal(
+			pubsub.publicKeyHash,
+		);
+		expect(channelListenerAdds).to.equal(4);
+	});
+
+	it("serializes concurrent opens for the same shard channel", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const fanout = session.peers[0]!.services.fanout as any;
+		const shardTopic = "/peerbit/pubsub-shard/1/concurrent-open";
+		const channelEventTypes = new Set([
+			"fanout:data",
+			"fanout:unicast",
+			"fanout:joined",
+			"fanout:kicked",
+		]);
+		const originalAddEventListener = fanout.addEventListener.bind(fanout);
+		let channelListenerAdds = 0;
+		fanout.addEventListener = (...args: any[]) => {
+			if (channelEventTypes.has(args[0])) channelListenerAdds += 1;
+			return originalAddEventListener(...args);
+		};
+
+		try {
+			await Promise.all([
+				internals.ensureFanoutChannel(shardTopic),
+				internals.ensureFanoutChannel(shardTopic),
+			]);
+		} finally {
+			fanout.addEventListener = originalAddEventListener;
+		}
+
+		expect(internals.fanoutChannels.size).to.equal(1);
+		expect(channelListenerAdds).to.equal(4);
+	});
+
+	it("ignores an in-flight opener from an older lifecycle", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const shardTopic = "/peerbit/pubsub-shard/1/old-lifecycle-opener";
+		const candidateGeneration = internals.getTopicRootCandidateGeneration();
+		const lifecycleRevision = internals.topicControlPlaneLifecycleRevision;
+		internals.ensureFanoutChannelInFlight.set(shardTopic, {
+			candidateGeneration,
+			lifecycleRevision: lifecycleRevision - 1,
+			opening: new Promise<void>(() => {}),
+		});
+
+		let settled = false;
+		await Promise.race([
+			internals.ensureFanoutChannel(shardTopic).then(() => {
+				settled = true;
+			}),
+			delay(500),
+		]);
+
+		expect(settled).to.equal(true);
+		expect(internals.fanoutChannels.get(shardTopic)?.root).to.equal(
+			pubsub.publicKeyHash,
+		);
+	});
+
+	it("keeps the lifecycle revision stable across an idempotent start", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const lifecycleRevision = internals.topicControlPlaneLifecycleRevision;
+
+		await pubsub.start();
+
+		expect(internals.topicControlPlaneLifecycleRevision).to.equal(
+			lifecycleRevision,
+		);
+	});
+
+	it("does not reinterpret a stale supplied root after leaving auto mode", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const shardTopic = "/peerbit/pubsub-shard/1/stale-supplied-root";
+		const staleRoot = pubsub.publicKeyHash;
+		const staleGeneration = internals.getTopicRootCandidateGeneration();
+		const currentRoot = "explicit-root-after-auto-mode";
+
+		internals.scheduleReconcileShardOverlays = () => {};
+		internals.scheduleHostOwnedShardRoots = () => {};
+		pubsub.setTopicRootCandidates([currentRoot]);
+		const currentGeneration = internals.getTopicRootCandidateGeneration();
+		let resolutionCalls = 0;
+		internals.resolveShardRootState = async () => {
+			resolutionCalls += 1;
+			return {
+				root: currentRoot,
+				candidateGeneration: currentGeneration,
+			};
+		};
+		let confirmationCalls = 0;
+		internals.confirmDirectShardRoot = async () => {
+			confirmationCalls += 1;
+			return currentRoot;
+		};
+
+		await internals.ensureFanoutChannel(shardTopic, {
+			root: staleRoot,
+			rootCandidateGeneration: staleGeneration,
+			pin: true,
+		});
+
+		expect(resolutionCalls).to.equal(0);
+		expect(confirmationCalls).to.equal(0);
+		expect(internals.fanoutChannels.has(shardTopic)).to.equal(false);
+		expect(internals.pinnedShards.has(shardTopic)).to.equal(false);
+	});
+
+	it("rejects a mismatched internal shard root while in auto mode", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const autoPeer = "auto-peer-with-stale-shard-root";
+		expect(internals.mergeAutoTopicRootCandidatesFromPeer([autoPeer])).to.equal(
+			true,
+		);
+		const candidates = pubsub.topicRootControlPlane.getTopicRootCandidates();
+		const { afterRoot: deterministicRoot, topic: shardTopic } =
+			findCandidateTransitionTopic(
+				[autoPeer],
+				candidates,
+				autoPeer,
+				pubsub.publicKeyHash,
+				1_000,
+			);
+		expect(
+			internals.normalizePeerTopicRootState(
+				shardTopic,
+				autoPeer,
+			),
+		).to.deep.equal({
+			authoritative: false,
+			root: deterministicRoot,
+		});
+	});
+
+	it("keeps a locally configured shard root authoritative in auto mode", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const shardTopic = "/peerbit/pubsub-shard/1/local-explicit-root";
+		const configuredRoot = "locally-configured-root";
+		pubsub.topicRootControlPlane.setTopicRoot(shardTopic, configuredRoot);
+
+		expect(internals.autoTopicRootCandidates).to.equal(true);
+		expect(await internals.resolveTopicRootState(shardTopic)).to.deep.equal({
+			authoritative: true,
+			root: configuredRoot,
+		});
+	});
+
+	it("ignores a topic-root response from a peer that was not queried", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const internals = session.peers[0]!.services.pubsub as any;
+		const requestId = 42;
+		const topic = "/peerbit/pubsub-shard/1/query-origin";
+		let resolved = false;
+		const timer = setTimeout(() => {}, 10_000);
+		timer.unref?.();
+		internals.pendingTopicRootQueries.set(requestId, {
+			expectedPeerHash: "expected-peer",
+			topic,
+			resolve: () => {
+				resolved = true;
+			},
+			timer,
+		});
+		const response = new TopicRootQueryResponse({
+			requestId,
+			root: "claimed-root",
+			topic,
+		});
+
+		expect(
+			internals.resolvePendingTopicRootQuery(response, "different-peer"),
+		).to.equal(false);
+		expect(resolved).to.equal(false);
+		expect(internals.pendingTopicRootQueries.has(requestId)).to.equal(true);
+		expect(
+			internals.resolvePendingTopicRootQuery(response, "expected-peer"),
+		).to.equal(true);
+		expect(resolved).to.equal(true);
+		expect(internals.pendingTopicRootQueries.has(requestId)).to.equal(false);
+	});
+
+	it("ignores direct root control signed by a different peer", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(3);
+		const receiver = session.peers[0]!.services.pubsub;
+		const directPeer = session.peers[1]!.services.pubsub as any;
+		const foreignSigner = session.peers[2]!.services.pubsub as any;
+		const internals = receiver as any;
+		const candidatesBefore =
+			receiver.topicRootControlPlane.getTopicRootCandidates();
+
+		await internals.processDirectPubSubMessage({
+			pubsubMessage: new TopicRootCandidates({
+				candidates: ["forged-auto-root-candidate"],
+			}),
+			message: {
+				header: {
+					signatures: { publicKeys: [foreignSigner.publicKey] },
+				},
+			},
+			from: directPeer.publicKey,
+			stream: { publicKey: directPeer.publicKey },
+		});
+
+		expect(receiver.topicRootControlPlane.getTopicRootCandidates()).to.deep.equal(
+			candidatesBefore,
+		);
+	});
+
+	it("does not install a channel after the control plane stops", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const shardTopic = "/peerbit/pubsub-shard/1/stop-during-resolution";
+		const candidateGeneration = internals.getTopicRootCandidateGeneration();
+		const resolutionGate = deferred();
+		const resolutionEntered = deferred();
+		internals.resolveShardRootState = async () => {
+			resolutionEntered.resolve();
+			await resolutionGate.promise;
+			return { root: pubsub.publicKeyHash, candidateGeneration };
+		};
+
+		const opening = internals.ensureFanoutChannel(shardTopic);
+		await resolutionEntered.promise;
+		await pubsub.stop();
+		resolutionGate.resolve();
+		await opening.catch(() => {});
+		await delay(0);
+
+		expect(internals.fanoutChannels.size).to.equal(0);
+		expect(internals.ensureFanoutChannelInFlight.size).to.equal(0);
+	});
+
 	it("does not track a topic on a peer that never subscribed", async () => {
 		const TOPIC = "non-subscriber-should-not-track-regression";
 		session = await createDisconnectedSession(2);
@@ -170,7 +666,9 @@ describe("pubsub (subscribe race regressions)", function () {
 			expect(b.subscriptions.has(TOPIC)).to.equal(true);
 			const bSubscribers = b.getSubscribers(TOPIC);
 			expect(
-				bSubscribers?.some((subscriber) => subscriber.hashcode() === b.publicKeyHash),
+				bSubscribers?.some(
+					(subscriber) => subscriber.hashcode() === b.publicKeyHash,
+				),
 			).to.equal(true);
 		});
 
@@ -210,6 +708,129 @@ describe("pubsub (subscribe race regressions)", function () {
 		expect(bTopics!.has(a.publicKeyHash)).to.equal(false);
 	});
 
+	it("converges a retained auto-root overlay after a late peer joins a star", async function () {
+		this.timeout(120_000);
+		const shardCount = 64;
+		session = await createDisconnectedSessionWithPerPeerRoots(3, {
+			pubsub: { shardCount },
+		});
+		const ordered = session.peers
+			.map((node) => ({ node, pubsub: node.services.pubsub }))
+			.sort((left, right) =>
+				left.pubsub.publicKeyHash.localeCompare(right.pubsub.publicKeyHash),
+			);
+		const retained = ordered[0]!;
+		const source = ordered[1]!;
+		const late = ordered[2]!;
+		const beforeCandidates = [
+			retained.pubsub.publicKeyHash,
+			source.pubsub.publicKeyHash,
+		].sort();
+		const afterCandidates = ordered
+			.map(({ pubsub }) => pubsub.publicKeyHash)
+			.sort();
+
+		await source.node.dial(retained.node.getMultiaddrs()[0]!);
+		await waitForNeighbour(source.pubsub, retained.pubsub);
+		await waitForResolved(
+			() => {
+				expect(
+					source.pubsub.topicRootControlPlane.getTopicRootCandidates(),
+				).to.deep.equal(beforeCandidates);
+				expect(
+					retained.pubsub.topicRootControlPlane.getTopicRootCandidates(),
+				).to.deep.equal(beforeCandidates);
+			},
+			{ timeout: 20_000, delayInterval: 50 },
+		);
+
+		const {
+			beforeRoot,
+			index: shardIndex,
+			topic: shardTopic,
+		} = findCandidateTransitionTopic(
+			beforeCandidates,
+			afterCandidates,
+			undefined,
+			late.pubsub.publicKeyHash,
+			shardCount,
+		);
+		let topic = "";
+		for (let index = 0; index < 10_000; index++) {
+			const candidate = `retained-auto-root-star-${index}`;
+			if (topicHash32(candidate) % shardCount === shardIndex) {
+				topic = candidate;
+				break;
+			}
+		}
+		expect(topic).to.not.equal("");
+		await Promise.all([
+			source.pubsub.subscribe(topic),
+			retained.pubsub.subscribe(topic),
+		]);
+		await waitForResolved(
+			() => {
+				expect(
+					(source.pubsub as any).fanoutChannels.get(shardTopic)?.root,
+				).to.equal(beforeRoot);
+				expect(
+					(retained.pubsub as any).fanoutChannels.get(shardTopic)?.root,
+				).to.equal(beforeRoot);
+			},
+			{ timeout: 20_000, delayInterval: 50 },
+		);
+		await late.pubsub.subscribe(topic);
+		expect((late.pubsub as any).fanoutChannels.get(shardTopic)?.root).to.equal(
+			late.pubsub.publicKeyHash,
+		);
+
+		await late.node.dial(source.node.getMultiaddrs()[0]!);
+		await waitForNeighbour(late.pubsub, source.pubsub);
+		await waitForResolved(
+			() => {
+				for (const { pubsub } of ordered) {
+					expect(
+						pubsub.topicRootControlPlane.getTopicRootCandidates(),
+					).to.deep.equal(afterCandidates);
+				}
+			},
+			{ timeout: 20_000, delayInterval: 50 },
+		);
+		await waitForResolved(
+			() => {
+				for (const { pubsub } of ordered) {
+					expect((pubsub as any).fanoutChannels.get(shardTopic)?.root).to.equal(
+						late.pubsub.publicKeyHash,
+					);
+					const subscribers = pubsub.getSubscribers(topic);
+					expect(
+						subscribers?.map((key) => key.hashcode()).sort(),
+					).to.deep.equal(afterCandidates);
+				}
+			},
+			{ timeout: 30_000, delayInterval: 100 },
+		);
+
+		let delivered = false;
+		const onData = (event: any) => {
+			if (event.detail?.data?.topics?.includes?.(topic)) {
+				delivered = true;
+			}
+		};
+		late.pubsub.addEventListener("data", onData);
+		try {
+			await source.pubsub.publish(new Uint8Array([1, 2, 3, 4]), {
+				topics: [topic],
+			});
+			await waitForResolved(() => expect(delivered).to.equal(true), {
+				timeout: 10_000,
+				delayInterval: 25,
+			});
+		} finally {
+			late.pubsub.removeEventListener("data", onData);
+		}
+	});
+
 	it("converges sparse relay topology without forced shard-root candidates", async function () {
 		this.timeout(120_000);
 
@@ -247,23 +868,28 @@ describe("pubsub (subscribe race regressions)", function () {
 			{ timeout: 20_000, delayInterval: 100 },
 		);
 
-		const resolvedRoot = await a.topicRootControlPlane.resolveTopicRoot(shardTopic);
+		const resolvedRoot =
+			await a.topicRootControlPlane.resolveTopicRoot(shardTopic);
 		expect(resolvedRoot).to.be.a("string");
-		const rootPeer = [a, b, relay].find((peer) => peer.publicKeyHash === resolvedRoot);
+		const rootPeer = [a, b, relay].find(
+			(peer) => peer.publicKeyHash === resolvedRoot,
+		);
 		expect(rootPeer, `resolved root ${resolvedRoot}`).to.exist;
 
 		await waitForResolved(
 			() => {
 				const rootChannel = (rootPeer as any).fanoutChannels?.get?.(shardTopic);
-				expect(rootChannel, `expected root ${resolvedRoot} to host ${shardTopic}`).to
-					.exist;
+				expect(
+					rootChannel,
+					`expected root ${resolvedRoot} to host ${shardTopic}`,
+				).to.exist;
 				expect(rootChannel.root).to.equal(resolvedRoot);
 			},
 			{ timeout: 20_000, delayInterval: 100 },
 		);
 	});
 
-	it("resolves shard roots through a dialed gateway without explicit candidates", async function () {
+	it("resolves shard roots through a gateway after auto mode is disabled", async function () {
 		this.timeout(120_000);
 
 		const TOPIC = "dial-gateway-root-tracker-discovery";
@@ -283,9 +909,46 @@ describe("pubsub (subscribe race regressions)", function () {
 		a.setTopicRootCandidates([]);
 		gateway.setTopicRootCandidates([root.publicKeyHash]);
 		root.setTopicRootCandidates([root.publicKeyHash]);
+		expect((a as any).autoTopicRootCandidates).to.equal(false);
 
-		const resolvedRoot = await (a as any).resolveShardRoot(shardTopic);
+		const resolvedRoot = (await (a as any).resolveShardRootState(shardTopic))
+			.root;
 		expect(resolvedRoot).to.equal(root.publicKeyHash);
+	});
+
+	it("trusts a stable explicit gateway root while the leaf remains in auto mode", async function () {
+		this.timeout(120_000);
+
+		session = await createDisconnectedSessionWithPerPeerRoots(2);
+		const leaf = session.peers[0]!.services.pubsub;
+		const gateway = session.peers[1]!.services.pubsub;
+
+		await session.peers[0]!.dial(session.peers[1]!.getMultiaddrs()[0]!);
+		await waitForNeighbour(leaf, gateway);
+		await waitForResolved(
+			() => {
+				const leafCandidates =
+					leaf.topicRootControlPlane.getTopicRootCandidates();
+				const gatewayCandidates =
+					gateway.topicRootControlPlane.getTopicRootCandidates();
+				expect(leafCandidates).to.deep.equal(gatewayCandidates);
+				expect(leafCandidates).to.have.length(2);
+			},
+			{ timeout: 20_000, delayInterval: 50 },
+		);
+
+		let topicIndex = 0;
+		let topic = `auto-leaf-explicit-gateway-${topicIndex}`;
+		while (
+			leaf.topicRootControlPlane.resolveDeterministicTopicRoot(topic) ===
+			gateway.publicKeyHash
+		) {
+			topicIndex += 1;
+			topic = `auto-leaf-explicit-gateway-${topicIndex}`;
+		}
+		gateway.topicRootControlPlane.setTopicRoot(topic, gateway.publicKeyHash);
+
+		expect(await leaf.resolveTopicRoot(topic)).to.equal(gateway.publicKeyHash);
 	});
 
 	it("confirms a gateway-resolved shard with the direct root before joining", async function () {
@@ -323,10 +986,13 @@ describe("pubsub (subscribe race regressions)", function () {
 		gateway.pubsub.setTopicRootCandidates([root.pubsub.publicKeyHash]);
 		root.pubsub.setTopicRootCandidates([root.pubsub.publicKeyHash]);
 		await root.pubsub.hostShardRootsNow();
-		await ((root.pubsub as any).hostOwnedShardRootsInFlight ?? Promise.resolve());
+		await ((root.pubsub as any).hostOwnedShardRootsInFlight ??
+			Promise.resolve());
 		await (root.pubsub as any).closeFanoutChannel(shardTopic, { force: true });
 		await delay(100);
-		expect((root.pubsub as any).fanoutChannels.get(shardTopic)).to.equal(undefined);
+		expect((root.pubsub as any).fanoutChannels.get(shardTopic)).to.equal(
+			undefined,
+		);
 		expect(
 			root.node.services.fanout.getChannelStats(
 				shardTopic,
@@ -336,8 +1002,12 @@ describe("pubsub (subscribe race regressions)", function () {
 
 		const leafInternals = leaf.pubsub as any;
 		leafInternals.shardRootCache.clear();
-		expect([...leafInternals.peers.keys()]).to.include(gateway.pubsub.publicKeyHash);
-		expect([...leafInternals.peers.keys()]).to.include(root.pubsub.publicKeyHash);
+		expect([...leafInternals.peers.keys()]).to.include(
+			gateway.pubsub.publicKeyHash,
+		);
+		expect([...leafInternals.peers.keys()]).to.include(
+			root.pubsub.publicKeyHash,
+		);
 		const originalQueryTopicRootFromPeer = leafInternals.queryTopicRootFromPeer;
 		const queriedPeers: string[] = [];
 		leafInternals.queryTopicRootFromPeer = async (...args: any[]) => {
@@ -391,7 +1061,8 @@ describe("pubsub (subscribe race regressions)", function () {
 		await (root as any).closeFanoutChannel(shardTopic, { force: true });
 		expect((root as any).fanoutChannels.get(shardTopic)).to.not.exist;
 
-		const resolvedRoot = await (leaf as any).resolveShardRoot(shardTopic);
+		const resolvedRoot = (await (leaf as any).resolveShardRootState(shardTopic))
+			.root;
 		expect(resolvedRoot).to.equal(root.publicKeyHash);
 
 		await waitForResolved(


### PR DESCRIPTION
## Summary

- converge retained shard overlays when automatic root candidates change during late peer joins
- reject differing peer-query shard roots while auto mode is active, while preserving locally configured roots, resolvers, and trackers
- fence root resolution and fanout opening by candidate generation and control-plane lifecycle
- preserve overlapping reconciliation requests with a dirty-loop scheduler
- bind direct root-control messages to their verified transport peer and bind query responses to the peer actually queried

A leaf that intentionally consumes a queried gateway's internal shard roots must first call `setTopicRootCandidates([])`. Non-shard queried roots and locally configured authorities retain their existing behavior.

## Validation

- `@peerbit/pubsub` full Node suite: **163 passing**
- focused subscribe race/security/topology suite: **22 passing**
- changeset validation: patch release (`@peerbit/pubsub` 5.3.6)
- exact packed commit hot-patched into `distributed-backup-v2`:
  - deterministic 64 MiB payload, 256 chunks, three isolated peers, two receivers
  - source force-stopped with SIGKILL before receiver validation
  - both receivers passed local-only metadata, pointer, byte/chunk count, SHA-256, and CRC-32 validation
  - receiver sync wall times: 1.60 s and 1.65 s
- `git diff --check` clean

## Review notes

The production change is isolated to pubsub. Most added lines are targeted race, lifecycle, security, gateway-compatibility, and real three-node star regressions; no shared-log hardening changes are bundled here.
