### PR TITLE
fix: gate raw sync requests by peer capability

### DIFF
--- a/.changeset/safe-raw-peer-sync.md
+++ b/.changeset/safe-raw-peer-sync.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Gate raw Simple sync request variants on each remote peer's advertised capability so mixed-version peers fall back to legacy messages.

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -16342,6 +16342,8 @@ export class SharedLog<
 				sync: options?.sync,
 				isEntryRecentlyKnownByPeer: (hash, peer, maxAgeMs) =>
 					this.isEntryRecentlyKnownByPeer(hash, peer, maxAgeMs),
+				peerSupportsRawExchangeHeads: (peer) =>
+					this.peerSupportsRawExchangeHeads(peer),
 				sendRawExchangeHeads,
 			});
 		} else {
@@ -16359,6 +16361,8 @@ export class SharedLog<
 					sync: options?.sync,
 					isEntryRecentlyKnownByPeer: (hash, peer, maxAgeMs) =>
 						this.isEntryRecentlyKnownByPeer(hash, peer, maxAgeMs),
+					peerSupportsRawExchangeHeads: (peer) =>
+						this.peerSupportsRawExchangeHeads(peer),
 					sendRawExchangeHeads,
 				});
 			} else {
@@ -16381,6 +16385,8 @@ export class SharedLog<
 					sync: options?.sync,
 					isEntryRecentlyKnownByPeer: (hash, peer, maxAgeMs) =>
 						this.isEntryRecentlyKnownByPeer(hash, peer, maxAgeMs),
+					peerSupportsRawExchangeHeads: (peer) =>
+						this.peerSupportsRawExchangeHeads(peer),
 					sendRawExchangeHeads,
 				}) as Syncronizer<R>;
 			}

--- a/packages/programs/data/shared-log/src/sync/index.ts
+++ b/packages/programs/data/shared-log/src/sync/index.ts
@@ -172,6 +172,7 @@ export type SynchronizerComponents<R extends "u32" | "u64"> = {
 		peer: string,
 		maxAgeMs: number,
 	) => boolean;
+	peerSupportsRawExchangeHeads?: (peer: string) => boolean;
 	sendRawExchangeHeads?: RawExchangeHeadsSender;
 };
 export type SynchronizerConstructor<R extends "u32" | "u64"> = new (

--- a/packages/programs/data/shared-log/src/sync/simple.ts
+++ b/packages/programs/data/shared-log/src/sync/simple.ts
@@ -558,6 +558,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		peer: string,
 		maxAgeMs: number,
 	) => boolean;
+	private peerSupportsRawExchangeHeads?: (peer: string) => boolean;
 	private sendRawExchangeHeads?: RawExchangeHeadsSender;
 	private recentlySentExchangeHeads: Map<string, Map<string, number>>;
 	private pendingMaybeSyncResponses: Map<
@@ -602,6 +603,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			peer: string,
 			maxAgeMs: number,
 		) => boolean;
+		peerSupportsRawExchangeHeads?: (peer: string) => boolean;
 		sendRawExchangeHeads?: RawExchangeHeadsSender;
 	}) {
 		this.syncInFlightQueue = new Map();
@@ -638,6 +640,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		this.resolveHashListForSymbols = properties.resolveHashListForSymbols;
 		this.syncOptions = properties.sync;
 		this.isEntryRecentlyKnownByPeer = properties.isEntryRecentlyKnownByPeer;
+		this.peerSupportsRawExchangeHeads = properties.peerSupportsRawExchangeHeads;
 		this.sendRawExchangeHeads = properties.sendRawExchangeHeads;
 		this.recentlySentExchangeHeads = new Map();
 		this.pendingMaybeSyncResponses = new Map();
@@ -3958,13 +3961,16 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 					this.maxCoordinatesPerMessage,
 				);
 				for (const target of targets) {
+					const requestRawExchangeHeads =
+						this.syncOptions?.rawExchangeHeads === true &&
+						this.peerSupportsRawExchangeHeads?.(target) === true;
 					for (const chunk of chunks) {
 						if (!this.isSyncDispatchLifecycleActive(lifecycle, target)) {
 							break;
 						}
 						try {
 							await this.rpc.send(
-								this.syncOptions?.rawExchangeHeads
+								requestRawExchangeHeads
 									? new RequestMaybeSyncCoordinateCapabilities({
 											hashNumbers: chunk,
 										})
@@ -3993,13 +3999,16 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			if (stringHashes.length > 0) {
 				const chunks = this.chunk(stringHashes, this.maxHashesPerMessage);
 				for (const target of targets) {
+					const requestRawExchangeHeads =
+						this.syncOptions?.rawExchangeHeads === true &&
+						this.peerSupportsRawExchangeHeads?.(target) === true;
 					for (const chunk of chunks) {
 						if (!this.isSyncDispatchLifecycleActive(lifecycle, target)) {
 							break;
 						}
 						try {
 							await this.rpc.send(
-								this.syncOptions?.rawExchangeHeads
+								requestRawExchangeHeads
 									? new ResponseMaybeSyncCapabilities({
 											hashes: chunk,
 										})

--- a/packages/programs/data/shared-log/test/sync-chunking.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-chunking.spec.ts
@@ -3199,7 +3199,7 @@ describe("sync-chunking", () => {
 		}
 	});
 
-	it("advertises raw exchange-head support when enabled", async () => {
+	it("keeps legacy requests until raw peer capability is known", async () => {
 		const send = sinon.stub().resolves();
 		const sync = new SimpleSyncronizer<"u64">({
 			rpc: { send } as any,
@@ -3216,14 +3216,55 @@ describe("sync-chunking", () => {
 		await (sync as any).requestSync(["h1", 2n], ["peer-a"]);
 
 		const messages = send.getCalls().map((call) => call.args[0]);
+		expect(send.callCount).to.equal(2);
 		const hashMessage = messages.find(
-			(message) => message instanceof ResponseMaybeSyncCapabilities,
-		) as ResponseMaybeSyncCapabilities | undefined;
+			(message) => message instanceof ResponseMaybeSync,
+		) as ResponseMaybeSync | undefined;
 		const coordinateMessage = messages.find(
-			(message) => message instanceof RequestMaybeSyncCoordinateCapabilities,
-		) as RequestMaybeSyncCoordinateCapabilities | undefined;
+			(message) => message instanceof RequestMaybeSyncCoordinate,
+		) as RequestMaybeSyncCoordinate | undefined;
 		expect(hashMessage?.hashes).to.deep.equal(["h1"]);
 		expect(coordinateMessage?.hashNumbers).to.deep.equal([2n]);
+		expect(
+			messages.some(
+				(message) => message instanceof ResponseMaybeSyncCapabilities,
+			),
+		).to.equal(false);
+		expect(
+			messages.some(
+				(message) => message instanceof RequestMaybeSyncCoordinateCapabilities,
+			),
+		).to.equal(false);
+	});
+
+	it("splits raw-capable and legacy request targets", async () => {
+		const send = sinon.stub().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: { count: async () => 0 } as any,
+			log: { has: async () => false } as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			peerSupportsRawExchangeHeads: (peer) => peer === "peer-raw",
+			sync: { rawExchangeHeads: true },
+		});
+
+		await (sync as any).requestSync(["h1", 2n], ["peer-raw", "peer-legacy"]);
+
+		expect(send.callCount).to.equal(4);
+		const [rawCoordinate, legacyCoordinate, rawHash, legacyHash] =
+			send.getCalls();
+		expect(rawCoordinate.args[0]).to.be.instanceOf(
+			RequestMaybeSyncCoordinateCapabilities,
+		);
+		expect(rawCoordinate.args[1].mode.to).to.deep.equal(["peer-raw"]);
+		expect(legacyCoordinate.args[0]).to.be.instanceOf(
+			RequestMaybeSyncCoordinate,
+		);
+		expect(legacyCoordinate.args[1].mode.to).to.deep.equal(["peer-legacy"]);
+		expect(rawHash.args[0]).to.be.instanceOf(ResponseMaybeSyncCapabilities);
+		expect(rawHash.args[1].mode.to).to.deep.equal(["peer-raw"]);
+		expect(legacyHash.args[0]).to.be.instanceOf(ResponseMaybeSync);
+		expect(legacyHash.args[1].mode.to).to.deep.equal(["peer-legacy"]);
 	});
 
 	it("responds with raw exchange heads only to capable requests", async () => {

--- a/packages/programs/data/shared-log/test/sync-raw-exchange-heads.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-raw-exchange-heads.spec.ts
@@ -28,11 +28,32 @@ import {
 } from "../src/exchange-heads.js";
 import { createReplicationDomainHash } from "../src/replication-domain-hash.js";
 import type { SyncProfileEvent } from "../src/sync/index.js";
-import { SimpleSyncronizer } from "../src/sync/simple.js";
+import {
+	ResponseMaybeSync,
+	ResponseMaybeSyncCapabilities,
+	SimpleSyncronizer,
+} from "../src/sync/simple.js";
 import { groupByGid, tryGroupByGidSync } from "../src/utils.js";
 import { EventStore } from "./utils/stores/event-store.js";
 
 describe("raw exchange-head sync", () => {
+	const waitForRawCapability = (
+		left: EventStore<string, any>,
+		right: EventStore<string, any>,
+	) =>
+		waitForResolved(() => {
+			expect(
+				(left.log as any).peerSupportsRawExchangeHeads(
+					right.node.identity.publicKey.hashcode(),
+				),
+			).to.equal(true);
+			expect(
+				(right.log as any).peerSupportsRawExchangeHeads(
+					left.node.identity.publicKey.hashcode(),
+				),
+			).to.equal(true);
+		});
+
 	it("groups already-materialized entry refs without async meta reads", async () => {
 		const session = await TestSession.disconnected(1, {
 			indexer: (directory) => createRustIndexer(directory),
@@ -217,6 +238,7 @@ describe("raw exchange-head sync", () => {
 			await waitForResolved(() =>
 				session.peers[0].dial(session.peers[1].getMultiaddrs()),
 			);
+			await waitForRawCapability(db1, db2);
 			await (
 				db1.log.syncronizer as SimpleSyncronizer<any>
 			).onMaybeMissingHashes({
@@ -3401,6 +3423,7 @@ describe("raw exchange-head sync", () => {
 		await waitForResolved(() =>
 			session.peers[0].dial(session.peers[1].getMultiaddrs()),
 		);
+		await waitForRawCapability(db1, db2);
 		await (db1.log.syncronizer as SimpleSyncronizer<any>).onMaybeMissingHashes({
 			hashes,
 			targets: [db2.node.identity.publicKey.hashcode()],
@@ -3915,6 +3938,7 @@ describe("raw exchange-head sync", () => {
 			await waitForResolved(() =>
 				session.peers[0].dial(session.peers[1].getMultiaddrs()),
 			);
+			await waitForRawCapability(db1, db2);
 			await (
 				db1.log.syncronizer as SimpleSyncronizer<any>
 			).onMaybeMissingHashes({
@@ -4085,10 +4109,16 @@ describe("raw exchange-head sync", () => {
 			await db2.log.waitForReplicator(db1.node.identity.publicKey);
 
 			let plainLiveMessages = 0;
+			let plainBulkRequests = 0;
+			let rawBulkRequests = 0;
 			const send1 = db1.log.rpc.send.bind(db1.log.rpc);
 			db1.log.rpc.send = async (message, options) => {
 				if (message instanceof ExchangeHeadsMessage) {
 					plainLiveMessages += 1;
+				} else if (message instanceof ResponseMaybeSyncCapabilities) {
+					rawBulkRequests += 1;
+				} else if (message instanceof ResponseMaybeSync) {
+					plainBulkRequests += 1;
 				}
 				return send1(message, options);
 			};
@@ -4112,6 +4142,17 @@ describe("raw exchange-head sync", () => {
 					db2.node.identity.publicKey.hashcode(),
 				),
 			).to.equal(false);
+
+			await (
+				db2.log.syncronizer as SimpleSyncronizer<any>
+			).onMaybeMissingHashes({
+				hashes: ["legacy-bulk-fallback"],
+				targets: [db1.node.identity.publicKey.hashcode()],
+			});
+			await waitForResolved(() => {
+				expect(plainBulkRequests).to.equal(1);
+			});
+			expect(rawBulkRequests).to.equal(0);
 		} finally {
 			await session.stop();
 		}


### PR DESCRIPTION
## Summary

- gate raw Simple sync request variants per target on that peer’s advertised capability
- fail closed to legacy request variants when capability information is missing or unknown
- pass the existing capability state through Simple, Rateless, and custom synchronizer construction paths
- cover missing-capability and mixed raw/legacy target behavior

## Why

Raw receive integrity and admission checks are already enforced, but local raw opt-in could previously select bulk request variants before knowing whether an older remote could decode them. This closes that mixed-version compatibility gap before any downstream file-chunk opt-in. It does not add another wire format.

## Validation

- `pnpm run build`
- `pnpm run test:part-4` — 2,286 shared-log tests and 1 proxy test passing
- focused sync-chunking/raw suite — 104 passing
- downstream 64 MiB, three-node filesystem hotpatch benchmark — both receivers matched exact chunk count, byte count, SHA-256, and CRC-32; raw profiling was active; all tracking and repair targets returned to zero
- `git diff --check`
- independent read-only review: no actionable findings

## Notes

The package-wide lint command currently reports pre-existing formatting errors in untouched files on master, so this PR avoids unrelated mass formatting. Release PR #1139 remains separately held by the fail-closed dependency audit.