### PR TITLE
fix(stream): make delivery modes copy-stable

### DIFF
--- a/.changeset/stable-delivery-mode-identity.md
+++ b/.changeset/stable-delivery-mode-identity.md
@@ -1,0 +1,7 @@
+---
+"@peerbit/stream-interface": patch
+"@peerbit/stream": patch
+"@peerbit/pubsub": patch
+---
+
+Classify delivery modes by their canonical Borsh wire schema so duplicate JavaScript module instances cannot silently drop targeted messages or misroute acknowledgements.

--- a/packages/transport/pubsub/src/index.ts
+++ b/packages/transport/pubsub/src/index.ts
@@ -47,6 +47,10 @@ import {
 	type WithExtraSigners,
 	deliveryModeHasReceiver,
 	getMsgId,
+	isAcknowledgeAnyWhereDeliveryMode,
+	isAcknowledgeDeliveryMode,
+	isAnyWhereDeliveryMode,
+	isSilentDeliveryMode,
 } from "@peerbit/stream-interface";
 import { AbortError, TimeoutError, delay } from "@peerbit/time";
 import { Uint8ArrayList } from "uint8arraylist";
@@ -2284,7 +2288,8 @@ export class TopicControlPlane
 				);
 			}
 
-			const silentDelivery = options?.mode instanceof SilentDelivery;
+			const silentDelivery =
+				options?.mode != null && isSilentDeliveryMode(options.mode);
 			try {
 				await this.publishMessage(
 					this.publicKey,
@@ -2427,7 +2432,7 @@ export class TopicControlPlane
 			}),
 		);
 
-		const silentDelivery = options.mode instanceof SilentDelivery;
+		const silentDelivery = isSilentDeliveryMode(options.mode);
 		try {
 			await this.publishMessage(
 				this.publicKey,
@@ -3145,8 +3150,8 @@ export class TopicControlPlane
 		if (deliveryModeHasReceiver(message.header.mode)) {
 			isForMe = message.header.mode.to.includes(this.publicKeyHash);
 		} else if (
-			message.header.mode instanceof AnyWhere ||
-			message.header.mode instanceof AcknowledgeAnyWhere
+			isAnyWhereDeliveryMode(message.header.mode) ||
+			isAcknowledgeAnyWhereDeliveryMode(message.header.mode)
 		) {
 			isForMe = true;
 		}
@@ -3177,8 +3182,8 @@ export class TopicControlPlane
 		}
 
 		if (
-			message.header.mode instanceof SilentDelivery ||
-			message.header.mode instanceof AcknowledgeDelivery
+			isSilentDeliveryMode(message.header.mode) ||
+			isAcknowledgeDeliveryMode(message.header.mode)
 		) {
 			if (
 				message.header.mode.to.length === 1 &&
@@ -3190,8 +3195,8 @@ export class TopicControlPlane
 
 		const shouldForward =
 			seenBefore === 0 ||
-			((message.header.mode instanceof AcknowledgeDelivery ||
-				message.header.mode instanceof AcknowledgeAnyWhere) &&
+			((isAcknowledgeDeliveryMode(message.header.mode) ||
+				isAcknowledgeAnyWhereDeliveryMode(message.header.mode)) &&
 				seenBefore < message.header.mode.redundancy);
 		if (shouldForward) {
 			this.relayMessage(from, message).catch(logErrorIfStarted);

--- a/packages/transport/pubsub/test/subscribe-races.spec.ts
+++ b/packages/transport/pubsub/test/subscribe-races.spec.ts
@@ -1,17 +1,42 @@
+import { field, variant, vec } from "@dao-xyz/borsh";
 import { getPublicKeyFromPeerId } from "@peerbit/crypto";
 import { TestSession } from "@peerbit/libp2p-test-utils";
 import {
 	TopicRootCandidates,
+	TopicRootQuery,
 	TopicRootQueryResponse,
 } from "@peerbit/pubsub-interface";
 import { waitForNeighbour } from "@peerbit/stream";
+import {
+	DataMessage,
+	type DeliveryMode,
+	MessageHeader,
+} from "@peerbit/stream-interface";
 import { delay, waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
+import sinon from "sinon";
 import {
 	FanoutTree,
 	TopicControlPlane,
 	TopicRootControlPlane,
 } from "../src/index.js";
+
+abstract class ForeignDeliveryMode {}
+
+@variant(0)
+class ForeignSilentDelivery extends ForeignDeliveryMode {
+	@field({ type: vec("string") })
+	to: string[];
+
+	@field({ type: "u8" })
+	redundancy: number;
+
+	constructor(to: string[], redundancy: number) {
+		super();
+		this.to = to;
+		this.redundancy = redundancy;
+	}
+}
 
 describe("pubsub (subscribe race regressions)", function () {
 	let session:
@@ -597,6 +622,49 @@ describe("pubsub (subscribe race regressions)", function () {
 		).to.equal(true);
 		expect(resolved).to.equal(true);
 		expect(internals.pendingTopicRootQueries.has(requestId)).to.equal(false);
+	});
+
+	it("processes targeted root control from another delivery-mode identity", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(2);
+		const receiver = session.peers[0]!.services.pubsub;
+		const sender = session.peers[1]!.services.pubsub;
+		const processDirect = sinon
+			.stub(receiver as any, "processDirectPubSubMessage")
+			.resolves();
+		sinon.stub(receiver, "verifyAndProcess").resolves(true);
+
+		const createMessage = (recipient: string) =>
+			new DataMessage({
+				data: new TopicRootQuery({
+					requestId: 1,
+					topic: "/peerbit/pubsub-shard/1/foreign-mode",
+				}).bytes(),
+				header: new MessageHeader({
+					mode: new ForeignSilentDelivery(
+						[recipient],
+						1,
+					) as unknown as DeliveryMode,
+					session: 1,
+				}),
+			});
+		const stream = { publicKey: sender.publicKey } as any;
+
+		await receiver.onDataMessage(
+			sender.publicKey,
+			stream,
+			createMessage(receiver.publicKeyHash),
+			0,
+		);
+		expect(processDirect.calledOnce).to.equal(true);
+
+		processDirect.resetHistory();
+		await receiver.onDataMessage(
+			sender.publicKey,
+			stream,
+			createMessage("different-recipient"),
+			0,
+		);
+		expect(processDirect.called).to.equal(false);
 	});
 
 	it("ignores direct root control signed by a different peer", async () => {

--- a/packages/transport/stream-interface/src/messages.ts
+++ b/packages/transport/stream-interface/src/messages.ts
@@ -3,6 +3,9 @@ import {
 	deserialize,
 	field,
 	fixedArray,
+	getDependencies,
+	getOffset,
+	getSchema,
 	option,
 	serialize,
 	variant,
@@ -39,11 +42,11 @@ export const getMsgId = async (msg: Uint8ArrayList | Uint8Array) => {
 
 export const deliveryModeHasReceiver = (
 	mode: DeliveryMode,
-): mode is { to: string[] } => {
-	if (mode instanceof SilentDelivery && mode.to.length > 0) {
+): mode is SilentDelivery | AcknowledgeDelivery => {
+	if (isSilentDeliveryMode(mode) && mode.to.length > 0) {
 		return true;
 	}
-	if (mode instanceof AcknowledgeDelivery && mode.to.length > 0) {
+	if (isAcknowledgeDeliveryMode(mode) && mode.to.length > 0) {
 		return true;
 	}
 	return false;
@@ -51,10 +54,201 @@ export const deliveryModeHasReceiver = (
 
 export abstract class DeliveryMode {}
 
+type DeliveryModeFieldType = "u8" | "string-vector";
+
+const DELIVERY_MODE_SCHEMAS = new Map<
+	number,
+	readonly { key: string; type: DeliveryModeFieldType }[]
+>([
+	[
+		0,
+		[
+			{ key: "to", type: "string-vector" },
+			{ key: "redundancy", type: "u8" },
+		],
+	],
+	[
+		1,
+		[
+			{ key: "to", type: "string-vector" },
+			{ key: "redundancy", type: "u8" },
+			{ key: "hops", type: "string-vector" },
+		],
+	],
+	[3, [{ key: "trace", type: "string-vector" }]],
+	[4, []],
+	[
+		5,
+		[
+			{ key: "redundancy", type: "u8" },
+			{ key: "hops", type: "string-vector" },
+		],
+	],
+]);
+
+const deliveryModeVariants = new WeakMap<Function, number | undefined>();
+
+const isStringArray = (value: unknown): value is string[] => {
+	if (!Array.isArray(value)) return false;
+	for (let index = 0; index < value.length; index++) {
+		if (!Object.hasOwn(value, index) || typeof value[index] !== "string") {
+			return false;
+		}
+	}
+	return true;
+};
+
+const isU8 = (value: unknown): value is number =>
+	typeof value === "number" &&
+	Number.isInteger(value) &&
+	value >= 0 &&
+	value <= 0xff;
+
+const hasExpectedDeliveryModeFieldType = (
+	type: unknown,
+	expected: DeliveryModeFieldType,
+) => {
+	if (expected === "u8") {
+		return type === "u8";
+	}
+	if (typeof type !== "object" || type == null) {
+		return false;
+	}
+	const vector = type as { elementType?: unknown; sizeEncoding?: unknown };
+	const keys = Object.keys(vector);
+	return (
+		keys.length === 2 &&
+		Object.hasOwn(vector, "elementType") &&
+		Object.hasOwn(vector, "sizeEncoding") &&
+		vector.elementType === "string" &&
+		vector.sizeEncoding === "u32" &&
+		!("serialize" in vector) &&
+		!("deserialize" in vector)
+	);
+};
+
+const getDeliveryModeVariantFromSchema = (
+	constructor: Function,
+): number | undefined => {
+	if (deliveryModeVariants.has(constructor)) {
+		return deliveryModeVariants.get(constructor);
+	}
+
+	let variant: number | undefined;
+	try {
+		const basePrototype = Object.getPrototypeOf(constructor.prototype);
+		const baseConstructor = Object.getOwnPropertyDescriptor(
+			basePrototype,
+			"constructor",
+		)?.value;
+		const schema = getSchema(constructor);
+		const schemaVariant = schema?.variant;
+		if (typeof schemaVariant === "number") {
+			const expected = DELIVERY_MODE_SCHEMAS.get(schemaVariant);
+			if (
+				expected &&
+				typeof baseConstructor === "function" &&
+				getOffset(constructor) === 1 &&
+				getSchema(baseConstructor) == null &&
+				getDependencies(baseConstructor, 0)?.includes(constructor) === true &&
+				schema.variantMarker === true &&
+				schema.serializer == null &&
+				schema.fields.length === expected.length &&
+				schema.fields.every(
+					(field, index) =>
+						field.key === expected[index]!.key &&
+						hasExpectedDeliveryModeFieldType(field.type, expected[index]!.type),
+				)
+			) {
+				variant = schemaVariant;
+			}
+		}
+	} catch {
+		// Unknown modes fail closed.
+	}
+	deliveryModeVariants.set(constructor, variant);
+	return variant;
+};
+
+const hasValidDeliveryModeFields = (mode: object, variant: number): boolean => {
+	const getValue = (key: string) => {
+		const descriptor = Object.getOwnPropertyDescriptor(mode, key);
+		return descriptor && "value" in descriptor ? descriptor.value : undefined;
+	};
+	if (variant === 0) {
+		return isStringArray(getValue("to")) && isU8(getValue("redundancy"));
+	}
+	if (variant === 1) {
+		return (
+			isStringArray(getValue("to")) &&
+			isU8(getValue("redundancy")) &&
+			isStringArray(getValue("hops"))
+		);
+	}
+	if (variant === 3) {
+		return isStringArray(getValue("trace"));
+	}
+	if (variant === 4) {
+		return true;
+	}
+	if (variant === 5) {
+		return isU8(getValue("redundancy")) && isStringArray(getValue("hops"));
+	}
+	return false;
+};
+
+const getDeliveryModeVariant = (mode: unknown): number | undefined => {
+	try {
+		if (typeof mode !== "object" || mode == null) {
+			return undefined;
+		}
+		const prototype = Object.getPrototypeOf(mode);
+		// Preserve the common local-instance fast path without accepting subclasses.
+		if (prototype === SilentDelivery.prototype) return 0;
+		if (prototype === AcknowledgeDelivery.prototype) return 1;
+		if (prototype === TracedDelivery.prototype) return 3;
+		if (prototype === AnyWhere.prototype) return 4;
+		if (prototype === AcknowledgeAnyWhere.prototype) return 5;
+
+		const constructor = Object.getOwnPropertyDescriptor(
+			prototype,
+			"constructor",
+		)?.value;
+		if (typeof constructor !== "function") {
+			return undefined;
+		}
+		if (constructor.prototype !== prototype) return undefined;
+		const variant = getDeliveryModeVariantFromSchema(constructor);
+		if (variant == null) {
+			return undefined;
+		}
+		return hasValidDeliveryModeFields(mode, variant) ? variant : undefined;
+	} catch {
+		return undefined;
+	}
+};
+
+export const isSilentDeliveryMode = (mode: unknown): mode is SilentDelivery =>
+	getDeliveryModeVariant(mode) === 0;
+
+export const isAcknowledgeDeliveryMode = (
+	mode: unknown,
+): mode is AcknowledgeDelivery => getDeliveryModeVariant(mode) === 1;
+
+export const isTracedDeliveryMode = (mode: unknown): mode is TracedDelivery =>
+	getDeliveryModeVariant(mode) === 3;
+
+export const isAnyWhereDeliveryMode = (mode: unknown): boolean =>
+	getDeliveryModeVariant(mode) === 4;
+
+export const isAcknowledgeAnyWhereDeliveryMode = (
+	mode: unknown,
+): mode is AcknowledgeAnyWhere => getDeliveryModeVariant(mode) === 5;
+
 export const isAcknowledgedDeliveryMode = (
 	mode: DeliveryMode,
 ): mode is AcknowledgeDelivery | AcknowledgeAnyWhere =>
-	mode instanceof AcknowledgeDelivery || mode instanceof AcknowledgeAnyWhere;
+	isAcknowledgeDeliveryMode(mode) || isAcknowledgeAnyWhereDeliveryMode(mode);
 
 export const getDeliveryHopTrace = (mode: DeliveryMode): string[] =>
 	isAcknowledgedDeliveryMode(mode) ? mode.hops : [];
@@ -271,29 +465,29 @@ export const FOREGROUND_READ_MESSAGE_PRIORITY = 2;
 export const ACK_CONTROL_PRIORITY = 3;
 
 const getDefaultPriorityFromMode = (mode: DeliveryMode) => {
-	if (mode instanceof SilentDelivery) {
+	if (isSilentDeliveryMode(mode)) {
 		return BACKGROUND_MESSAGE_PRIORITY;
 	}
-	if (mode instanceof AnyWhere) {
+	if (isAnyWhereDeliveryMode(mode)) {
 		return BACKGROUND_MESSAGE_PRIORITY;
 	}
-	if (mode instanceof AcknowledgeAnyWhere) {
+	if (isAcknowledgeAnyWhereDeliveryMode(mode)) {
 		return CONVERGENCE_MESSAGE_PRIORITY;
 	}
 
-	if (mode instanceof AcknowledgeDelivery) {
+	if (isAcknowledgeDeliveryMode(mode)) {
 		return CONVERGENCE_MESSAGE_PRIORITY;
 	}
-	if (mode instanceof TracedDelivery) {
+	if (isTracedDeliveryMode(mode)) {
 		return ACK_CONTROL_PRIORITY;
 	}
-	throw new Error("Unexpected mode: " + mode.constructor.name);
+	throw new Error("Unexpected delivery mode");
 };
 
 const getDefaultResponsePriorityFromMode = (mode: DeliveryMode) => {
 	if (
-		mode instanceof AcknowledgeAnyWhere ||
-		mode instanceof AcknowledgeDelivery
+		isAcknowledgeAnyWhereDeliveryMode(mode) ||
+		isAcknowledgeDeliveryMode(mode)
 	) {
 		return ACK_CONTROL_PRIORITY;
 	}

--- a/packages/transport/stream/src/index.ts
+++ b/packages/transport/stream/src/index.ts
@@ -54,7 +54,11 @@ import {
 	getDeliveryHopTrace,
 	getResponsePriorityFromMessage,
 	hasDeliveryHop,
+	isAcknowledgeAnyWhereDeliveryMode,
+	isAcknowledgeDeliveryMode,
 	isAcknowledgedDeliveryMode,
+	isAnyWhereDeliveryMode,
+	isSilentDeliveryMode,
 	setDeliveryOriginHop,
 } from "@peerbit/stream-interface";
 import type {
@@ -2631,16 +2635,16 @@ export abstract class DirectStream<
 
 		let isForMe = false;
 		if (
-			message.header.mode instanceof AnyWhere ||
-			message.header.mode instanceof AcknowledgeAnyWhere
+			isAnyWhereDeliveryMode(message.header.mode) ||
+			isAcknowledgeAnyWhereDeliveryMode(message.header.mode)
 		) {
 			isForMe = true;
 		} else {
 			const isFromSelf = this.publicKey.equals(from);
 			if (
 				!isFromSelf &&
-				(message.header.mode instanceof SilentDelivery ||
-					message.header.mode instanceof AcknowledgeDelivery)
+				(isSilentDeliveryMode(message.header.mode) ||
+					isAcknowledgeDeliveryMode(message.header.mode))
 			) {
 				isForMe = message.header.mode.to.includes(this.publicKeyHash);
 			}
@@ -2665,8 +2669,8 @@ export abstract class DirectStream<
 		}
 
 		if (
-			message.header.mode instanceof SilentDelivery ||
-			message.header.mode instanceof AcknowledgeDelivery
+			isSilentDeliveryMode(message.header.mode) ||
+			isAcknowledgeDeliveryMode(message.header.mode)
 		) {
 			if (
 				message.header.mode.to &&
@@ -2681,8 +2685,8 @@ export abstract class DirectStream<
 			// Forward
 			const shouldForward =
 				seenBefore === 0 ||
-				((message.header.mode instanceof AcknowledgeDelivery ||
-					message.header.mode instanceof AcknowledgeAnyWhere) &&
+				((isAcknowledgeDeliveryMode(message.header.mode) ||
+					isAcknowledgeAnyWhereDeliveryMode(message.header.mode)) &&
 					seenBefore < message.header.mode.redundancy);
 
 			if (shouldForward) {
@@ -2714,14 +2718,12 @@ export abstract class DirectStream<
 		message: DataMessage | Goodbye,
 		seenBefore: number,
 	) {
-		if (
-			message.header.mode instanceof AcknowledgeDelivery ||
-			message.header.mode instanceof AcknowledgeAnyWhere
-		) {
+		if (isAcknowledgedDeliveryMode(message.header.mode)) {
 			const isRecipient =
-				message.header.mode instanceof AcknowledgeAnyWhere
-					? true
-					: message.header.mode.to.includes(this.publicKeyHash);
+				isAcknowledgeAnyWhereDeliveryMode(message.header.mode) ||
+				(message.header.mode as AcknowledgeDelivery).to.includes(
+					this.publicKeyHash,
+				);
 			const shouldAcknowledge = this.rustCore
 				? this.rustCore.decisions.shouldAcknowledge({
 						isRecipient,
@@ -2754,8 +2756,7 @@ export abstract class DirectStream<
 							// only include once (seenBefore=0) and only if we have not recently pruned
 							// a connection to any signer in the path
 							origin:
-								(message.header.mode instanceof AcknowledgeAnyWhere ||
-									message.header.mode instanceof AcknowledgeDelivery) &&
+								isAcknowledgedDeliveryMode(message.header.mode) &&
 								seenBefore === 0 &&
 								!signers.find((x) =>
 									this.prunedConnectionsCache?.has(x),
@@ -2976,8 +2977,8 @@ export abstract class DirectStream<
 				});
 
 		if (
-			mode instanceof AcknowledgeDelivery ||
-			mode instanceof SilentDelivery
+			isAcknowledgeDeliveryMode(mode) ||
+			isSilentDeliveryMode(mode)
 		) {
 			if (mode.to) {
 				let preLength = mode.to.length;
@@ -3170,7 +3171,7 @@ export abstract class DirectStream<
 		relayed?: boolean,
 		signal?: AbortSignal,
 	): Promise<{ promise: Promise<void>; startTimeout: () => void }> {
-		if (message.header.mode instanceof AnyWhere) {
+		if (isAnyWhereDeliveryMode(message.header.mode)) {
 			return {
 				promise: Promise.resolve(),
 				startTimeout: () => {},
@@ -3335,7 +3336,7 @@ export abstract class DirectStream<
 				) {
 					const shouldKeepCallbackForRouteLearning =
 						!relayed &&
-						message.header.mode instanceof AcknowledgeDelivery &&
+						isAcknowledgeDeliveryMode(message.header.mode) &&
 						message.header.mode.redundancy > 1;
 					if (haveReceivers && !shouldKeepCallbackForRouteLearning) {
 						// If we have an explicit recipient list we can clear the ACK callback once we
@@ -3370,8 +3371,7 @@ export abstract class DirectStream<
 				// This matters because relays may modify `to`, and because "ack-anywhere" style probes intentionally
 				// do not provide an explicit recipient list.
 				if (
-					message.header.mode instanceof AcknowledgeDelivery ||
-					message.header.mode instanceof AcknowledgeAnyWhere
+					isAcknowledgedDeliveryMode(message.header.mode)
 				) {
 					const upstreamHash = messageFrom?.publicKey.hashcode();
 
@@ -3455,7 +3455,7 @@ export abstract class DirectStream<
 			(!message.header.signatures ||
 				message.header.signatures.publicKeys.length === 0) &&
 			message instanceof DataMessage &&
-			message.header.mode instanceof SilentDelivery === false
+			!isSilentDeliveryMode(message.header.mode)
 		) {
 			throw new Error("Missing signature");
 		}
@@ -3466,8 +3466,7 @@ export abstract class DirectStream<
 
 		if (
 			(message instanceof DataMessage || message instanceof Goodbye) &&
-			(message.header.mode instanceof AcknowledgeDelivery ||
-				message.header.mode instanceof AcknowledgeAnyWhere)
+			isAcknowledgedDeliveryMode(message.header.mode)
 		) {
 			const deliveryDeferredPromise = await this.createDeliveryPromise(
 				from,
@@ -3493,8 +3492,8 @@ export abstract class DirectStream<
 
 			if (message instanceof DataMessage) {
 				if (
-					(message.header.mode instanceof AcknowledgeDelivery ||
-						message.header.mode instanceof SilentDelivery) &&
+					(isAcknowledgeDeliveryMode(message.header.mode) ||
+						isSilentDeliveryMode(message.header.mode)) &&
 					!to
 				) {
 					if (message.header.mode.to.length === 0) {
@@ -3519,7 +3518,7 @@ export abstract class DirectStream<
 						for (const [neighbour, _distantPeers] of fanout) {
 							const stream = this.peers.get(neighbour);
 							if (!stream) continue;
-							if (message.header.mode instanceof SilentDelivery) {
+							if (isSilentDeliveryMode(message.header.mode)) {
 								message.header.mode.to = [..._distantPeers.keys()];
 								promises.push(
 									this.waitForPeerWrite(
@@ -3541,7 +3540,7 @@ export abstract class DirectStream<
 							}
 							usedNeighbours.add(neighbour);
 						}
-						if (message.header.mode instanceof SilentDelivery) {
+						if (isSilentDeliveryMode(message.header.mode)) {
 							message.header.mode.to = originalTo;
 						}
 
@@ -3551,7 +3550,7 @@ export abstract class DirectStream<
 						// a separate delivery mode.
 						if (
 							!isRelayed &&
-							message.header.mode instanceof AcknowledgeDelivery &&
+							isAcknowledgeDeliveryMode(message.header.mode) &&
 							usedNeighbours.size < message.header.mode.redundancy
 						) {
 							if (this.rustCore) {
@@ -3601,7 +3600,7 @@ export abstract class DirectStream<
 					// - For acknowledged deliveries, fall through to flooding (route discovery / repair).
 					// - For silent deliveries, relays should not flood (prevents unnecessary fanout); origin may still flood.
 					//   We still allow direct neighbour delivery to explicit recipients (if connected).
-					if (isRelayed && message.header.mode instanceof SilentDelivery) {
+					if (isRelayed && isSilentDeliveryMode(message.header.mode)) {
 						const promises: Promise<any>[] = [];
 						const originalTo = message.header.mode.to;
 						const recipients = this.rustCore

--- a/packages/transport/stream/test/delivery-mode-identity.spec.ts
+++ b/packages/transport/stream/test/delivery-mode-identity.spec.ts
@@ -1,0 +1,385 @@
+import { field, serialize, variant, vec } from "@dao-xyz/borsh";
+import { TestSession } from "@peerbit/libp2p-test-utils";
+import {
+	ACK_CONTROL_PRIORITY,
+	BACKGROUND_MESSAGE_PRIORITY,
+	CONVERGENCE_MESSAGE_PRIORITY,
+	DataMessage,
+	AcknowledgeAnyWhere as LocalAcknowledgeAnyWhere,
+	AcknowledgeDelivery as LocalAcknowledgeDelivery,
+	AnyWhere as LocalAnyWhere,
+	type DeliveryMode as LocalDeliveryMode,
+	SilentDelivery as LocalSilentDelivery,
+	TracedDelivery as LocalTracedDelivery,
+	MessageHeader,
+	appendDeliveryHop,
+	deliveryModeHasReceiver,
+	getDeliveryHopTrace,
+	hasDeliveryHop,
+	isAcknowledgeAnyWhereDeliveryMode,
+	isAcknowledgeDeliveryMode,
+	isAcknowledgedDeliveryMode,
+	isAnyWhereDeliveryMode,
+	isSilentDeliveryMode,
+	isTracedDeliveryMode,
+	setDeliveryOriginHop,
+} from "@peerbit/stream-interface";
+import { waitForResolved } from "@peerbit/time";
+import { expect } from "chai";
+import sinon from "sinon";
+import {
+	DirectStream,
+	type DirectStreamComponents,
+	waitForNeighbour,
+} from "../src/index.js";
+
+abstract class ForeignDeliveryMode {}
+
+@variant(0)
+class ForeignSilentDelivery extends ForeignDeliveryMode {
+	@field({ type: vec("string") })
+	to: string[];
+
+	@field({ type: "u8" })
+	redundancy: number;
+
+	constructor(to: string[], redundancy: number) {
+		super();
+		this.to = to;
+		this.redundancy = redundancy;
+	}
+}
+
+@variant(1)
+class ForeignAcknowledgeDelivery extends ForeignDeliveryMode {
+	@field({ type: vec("string") })
+	to: string[];
+
+	@field({ type: "u8" })
+	redundancy: number;
+
+	@field({ type: vec("string") })
+	hops: string[];
+
+	constructor(to: string[], redundancy: number, hops: string[] = []) {
+		super();
+		this.to = to;
+		this.redundancy = redundancy;
+		this.hops = hops;
+	}
+}
+
+@variant(3)
+class ForeignTracedDelivery extends ForeignDeliveryMode {
+	@field({ type: vec("string") })
+	trace: string[];
+
+	constructor(trace: string[]) {
+		super();
+		this.trace = trace;
+	}
+}
+
+@variant(4)
+class ForeignAnyWhere extends ForeignDeliveryMode {}
+
+@variant(5)
+class ForeignAcknowledgeAnyWhere extends ForeignDeliveryMode {
+	@field({ type: "u8" })
+	redundancy: number;
+
+	@field({ type: vec("string") })
+	hops: string[];
+
+	constructor(redundancy: number, hops: string[] = []) {
+		super();
+		this.redundancy = redundancy;
+		this.hops = hops;
+	}
+}
+
+@variant(2)
+class ForeignUnknownDelivery extends ForeignDeliveryMode {}
+
+abstract class MalformedDeliveryMode {}
+
+@variant(0)
+class ForeignSilentWithExtraField extends MalformedDeliveryMode {
+	@field({ type: vec("string") })
+	to: string[];
+
+	@field({ type: "u8" })
+	redundancy: number;
+
+	@field({ type: "u8" })
+	extra: number;
+
+	constructor(to: string[], redundancy: number) {
+		super();
+		this.to = to;
+		this.redundancy = redundancy;
+		this.extra = 0;
+	}
+}
+
+@variant(0)
+class StandaloneSilentDelivery {
+	@field({ type: vec("string") })
+	to: string[];
+
+	@field({ type: "u8" })
+	redundancy: number;
+
+	constructor(to: string[], redundancy: number) {
+		this.to = to;
+		this.redundancy = redundancy;
+	}
+}
+
+abstract class CustomCodecDeliveryMode {}
+
+@variant(0)
+class CustomCodecSilentDelivery extends CustomCodecDeliveryMode {
+	@field({
+		elementType: "string",
+		sizeEncoding: "u32",
+		serialize: () => {},
+		deserialize: (): string[] => [],
+	} as any)
+	to: string[];
+
+	@field({ type: "u8" })
+	redundancy: number;
+
+	constructor(to: string[], redundancy: number) {
+		super();
+		this.to = to;
+		this.redundancy = redundancy;
+	}
+}
+
+class LocalSilentSubclass extends LocalSilentDelivery {}
+
+const asDeliveryMode = (mode: ForeignDeliveryMode) =>
+	mode as unknown as LocalDeliveryMode;
+
+class DeliveryModeIdentityStream extends DirectStream {
+	constructor(components: DirectStreamComponents) {
+		super(components, ["/peerbit/delivery-mode-identity/1.0.0"], {
+			canRelayMessage: true,
+			connectionManager: false,
+		});
+	}
+}
+
+describe("delivery mode identity", () => {
+	it("classifies delivery modes from another module identity", () => {
+		const silent = new ForeignSilentDelivery(["recipient"], 1);
+		const acknowledge = new ForeignAcknowledgeDelivery(["recipient"], 2, [
+			"origin",
+		]);
+		const traced = new ForeignTracedDelivery(["origin"]);
+		const anywhere = new ForeignAnyWhere();
+		const acknowledgeAnyWhere = new ForeignAcknowledgeAnyWhere(2, ["origin"]);
+
+		expect(silent).to.not.be.instanceOf(LocalSilentDelivery);
+		expect(acknowledge).to.not.be.instanceOf(LocalAcknowledgeDelivery);
+		expect(traced).to.not.be.instanceOf(LocalTracedDelivery);
+		expect(anywhere).to.not.be.instanceOf(LocalAnyWhere);
+		expect(acknowledgeAnyWhere).to.not.be.instanceOf(LocalAcknowledgeAnyWhere);
+
+		expect(isSilentDeliveryMode(silent)).to.be.true;
+		expect(isAcknowledgeDeliveryMode(acknowledge)).to.be.true;
+		expect(isTracedDeliveryMode(traced)).to.be.true;
+		expect(isAnyWhereDeliveryMode(anywhere)).to.be.true;
+		expect(isAcknowledgeAnyWhereDeliveryMode(acknowledgeAnyWhere)).to.be.true;
+		expect(deliveryModeHasReceiver(asDeliveryMode(silent))).to.be.true;
+		expect(deliveryModeHasReceiver(asDeliveryMode(acknowledge))).to.be.true;
+		expect(
+			deliveryModeHasReceiver(asDeliveryMode(new ForeignSilentDelivery([], 1))),
+		).to.be.false;
+	});
+
+	it("preserves acknowledgement helpers and default priorities", () => {
+		const acknowledge = asDeliveryMode(
+			new ForeignAcknowledgeDelivery(["recipient"], 2, ["first"]),
+		);
+		const acknowledgeAnyWhere = asDeliveryMode(
+			new ForeignAcknowledgeAnyWhere(2, ["first"]),
+		);
+
+		for (const mode of [acknowledge, acknowledgeAnyWhere]) {
+			expect(isAcknowledgedDeliveryMode(mode)).to.be.true;
+			expect(getDeliveryHopTrace(mode)).to.deep.equal(["first"]);
+			expect(hasDeliveryHop(mode, "first")).to.be.true;
+			appendDeliveryHop(mode, "second");
+			expect(getDeliveryHopTrace(mode)).to.deep.equal(["first", "second"]);
+			setDeliveryOriginHop(mode, "origin");
+			expect(getDeliveryHopTrace(mode)).to.deep.equal(["origin"]);
+		}
+
+		const priorities: ReadonlyArray<
+			readonly [LocalDeliveryMode, number, number | undefined]
+		> = [
+			[
+				asDeliveryMode(new ForeignSilentDelivery(["recipient"], 1)),
+				BACKGROUND_MESSAGE_PRIORITY,
+				undefined,
+			],
+			[
+				asDeliveryMode(new ForeignAnyWhere()),
+				BACKGROUND_MESSAGE_PRIORITY,
+				undefined,
+			],
+			[
+				asDeliveryMode(new ForeignAcknowledgeDelivery(["recipient"], 1)),
+				CONVERGENCE_MESSAGE_PRIORITY,
+				ACK_CONTROL_PRIORITY,
+			],
+			[
+				asDeliveryMode(new ForeignAcknowledgeAnyWhere(1)),
+				CONVERGENCE_MESSAGE_PRIORITY,
+				ACK_CONTROL_PRIORITY,
+			],
+			[
+				asDeliveryMode(new ForeignTracedDelivery([])),
+				ACK_CONTROL_PRIORITY,
+				undefined,
+			],
+		];
+
+		for (const [mode, priority, responsePriority] of priorities) {
+			const header = new MessageHeader({ mode, session: 1 });
+			expect(header.priority).to.equal(priority);
+			expect(header.responsePriority).to.equal(responsePriority);
+		}
+	});
+
+	it("fails closed for unknown schemas and malformed values", () => {
+		const lookalike = { to: ["recipient"], redundancy: 1 };
+		const spoofedConstructor = {
+			constructor: ForeignSilentDelivery,
+			to: ["recipient"],
+			redundancy: 1,
+		};
+		const unknown = new ForeignUnknownDelivery();
+		const extraField = new ForeignSilentWithExtraField(["recipient"], 1);
+		const standalone = new StandaloneSilentDelivery(["recipient"], 1);
+		const customCodec = new CustomCodecSilentDelivery(["recipient"], 1);
+		const localSubclass = new LocalSilentSubclass({
+			to: ["recipient"],
+			redundancy: 1,
+		});
+		const hostileProxy = new Proxy(
+			{},
+			{
+				getPrototypeOf: () => {
+					throw new Error("hostile prototype");
+				},
+			},
+		);
+		const malformedTo = new ForeignSilentDelivery(["recipient"], 1);
+		(malformedTo as unknown as { to: unknown }).to = [1];
+		const sparseTo = new ForeignSilentDelivery(new Array<string>(1), 1);
+		const malformedRedundancy = new ForeignAcknowledgeDelivery(
+			["recipient"],
+			256,
+		);
+		const values = [
+			undefined,
+			null,
+			lookalike,
+			spoofedConstructor,
+			unknown,
+			extraField,
+			standalone,
+			customCodec,
+			localSubclass,
+			hostileProxy,
+			malformedTo,
+			sparseTo,
+			malformedRedundancy,
+		];
+
+		for (const value of values) {
+			expect(isSilentDeliveryMode(value)).to.be.false;
+			expect(isAcknowledgeDeliveryMode(value)).to.be.false;
+			expect(isTracedDeliveryMode(value)).to.be.false;
+			expect(isAnyWhereDeliveryMode(value)).to.be.false;
+			expect(isAcknowledgeAnyWhereDeliveryMode(value)).to.be.false;
+		}
+	});
+
+	it("preserves the canonical wire representation", () => {
+		const local = new LocalSilentDelivery({
+			to: ["recipient"],
+			redundancy: 1,
+		});
+		const foreign = new ForeignSilentDelivery(["recipient"], 1);
+		expect(serialize(foreign)).to.deep.equal(serialize(local));
+	});
+
+	it("does not acknowledge an empty targeted mode", async () => {
+		const session = await TestSession.connected<{
+			directstream: DeliveryModeIdentityStream;
+		}>(1, {
+			services: {
+				directstream: (components) =>
+					new DeliveryModeIdentityStream(components),
+			},
+		});
+		try {
+			const stream = session.peers[0]!.services.directstream;
+			const publishAck = sinon.stub(stream as any, "publishMessageMaybe");
+			await stream.maybeAcknowledgeMessage(
+				{} as any,
+				new DataMessage({
+					header: new MessageHeader({
+						mode: asDeliveryMode(new ForeignAcknowledgeDelivery([], 1)),
+						session: 1,
+					}),
+				}),
+				0,
+			);
+			expect(publishAck.called).to.equal(false);
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("routes silent and acknowledged modes from another identity", async () => {
+		const session = await TestSession.connected<{
+			directstream: DeliveryModeIdentityStream;
+		}>(2, {
+			services: {
+				directstream: (components) =>
+					new DeliveryModeIdentityStream(components),
+			},
+		});
+		try {
+			const sender = session.peers[0]!.services.directstream;
+			const receiver = session.peers[1]!.services.directstream;
+			await waitForNeighbour(sender, receiver);
+			const received: number[] = [];
+			receiver.addEventListener("data", (event) => {
+				received.push(event.detail.data![0]!);
+			});
+
+			await sender.publish(new Uint8Array([1]), {
+				mode: asDeliveryMode(
+					new ForeignSilentDelivery([receiver.publicKeyHash], 1),
+				),
+			});
+			await waitForResolved(() => expect(received).to.deep.equal([1]));
+
+			await sender.publish(new Uint8Array([2]), {
+				mode: asDeliveryMode(
+					new ForeignAcknowledgeDelivery([receiver.publicKeyHash], 1),
+				),
+			});
+			await waitForResolved(() => expect(received).to.deep.equal([1, 2]));
+		} finally {
+			await session.stop();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- classify delivery modes from compatible duplicate `@peerbit/stream-interface` module identities by their canonical Borsh variant, exact ordered field schema, and direct variant lineage
- replace constructor-identity checks in stream and pubsub routing, acknowledgement, forwarding, and priority paths with the centralized guards
- preserve a direct-prototype fast path for normal local messages while failing closed on malformed schemas, custom codecs, sparse values, spoofed constructors, proxies, subclasses, and unknown variants

## Root cause

A delivery mode created by one physical JavaScript package instance is not `instanceof` the equivalent class from another instance. A targeted `SilentDelivery` could therefore reach pubsub but fail receiver detection, causing direct topic-root control queries to be ignored and File Share opens to hang.

This is an implementation-identity fix, not a new network protocol. Existing Borsh variants and wire bytes are unchanged. The compatibility scope is duplicate delivery classes backed by compatible canonical Borsh metadata/runtime; arbitrary incompatible Borsh runtimes are not claimed.

## Safety

- exact schema shape and runtime values are validated once per foreign constructor and cached
- empty targeted acknowledged modes retain fail-closed behavior and do not become acknowledge-anywhere
- wire-equivalence, malformed negative cases, direct stream delivery, and the pubsub topic-root regression are covered

## Validation

- `pnpm run build`
- `pnpm --filter @peerbit/stream test` (46 passing)
- `pnpm --filter @peerbit/pubsub test` (164 passing)
- `pnpm changeset status --since=origin/master`
- independent review: no P0/P1 findings
