### PR TITLE
fix(shared-log): fence stale receive prune plans

### DIFF
--- a/.changeset/fresh-receive-prune-audit.md
+++ b/.changeset/fresh-receive-prune-audit.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Recheck receive-side prune ownership after joins and fence stale retry cleanup from newer work.

--- a/packages/programs/data/shared-log/src/checked-prune.ts
+++ b/packages/programs/data/shared-log/src/checked-prune.ts
@@ -26,9 +26,15 @@ export type CheckedPrunePendingDelete = {
 
 export type CheckedPruneRetryState<T, R extends "u32" | "u64"> = {
 	attempts: number;
+	generation: number;
 	timer?: ReturnType<typeof setTimeout>;
 	entry: CheckedPruneEntry<T, R>;
 	leaders: CheckedPruneLeaderMap | Set<string>;
+};
+
+export type CheckedPruneRetryIdentity<T, R extends "u32" | "u64"> = {
+	state: CheckedPruneRetryState<T, R>;
+	generation: number;
 };
 
 export type CheckedPruneInvalidatedGeneration<T, R extends "u32" | "u64"> = {
@@ -109,6 +115,7 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 			this.requestIPruneSent.has(hash) ||
 			this.responseReplicatorSet.has(hash) ||
 			this.retries.has(hash) ||
+			this.restartReservations.has(hash) ||
 			this.candidateTokens.has(hash)
 		) {
 			return;
@@ -219,6 +226,11 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 		return this.retries.get(hash);
 	}
 
+	getRetryIdentity(hash: string): CheckedPruneRetryIdentity<T, R> | undefined {
+		const state = this.retries.get(hash);
+		return state ? { state, generation: state.generation } : undefined;
+	}
+
 	hasRetry(hash: string) {
 		return this.retries.has(hash);
 	}
@@ -232,10 +244,14 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 		session.phase = "retrying";
 	}
 
-	clearRetry(hash: string) {
-		this.restartReservations.delete(hash);
-		this.candidateTokens.delete(hash);
+	clearRetry(hash: string, expected?: CheckedPruneRetryIdentity<T, R>) {
 		const state = this.retries.get(hash);
+		if (
+			expected &&
+			(state !== expected.state || state.generation !== expected.generation)
+		) {
+			return false;
+		}
 		if (state?.timer) {
 			clearTimeout(state.timer);
 		}
@@ -245,6 +261,7 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 			session.retry = undefined;
 		}
 		this.deleteSessionIfIdle(hash);
+		return true;
 	}
 
 	clearRetryTimer(hash: string) {
@@ -477,12 +494,14 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 			return false;
 		}
 		this.restartReservations.delete(hash);
+		this.deleteSessionIfIdle(hash);
 		return true;
 	}
 
 	cancelRestartReservation(hash: string, reservation: object) {
 		if (this.restartReservations.get(hash) === reservation) {
 			this.restartReservations.delete(hash);
+			this.deleteSessionIfIdle(hash);
 		}
 	}
 

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -132,6 +132,7 @@ import {
 	type CheckedPruneLeaderMap,
 	type CheckedPrunePendingDelete,
 	type CheckedPruneRestartCandidate,
+	type CheckedPruneRetryIdentity,
 	type CheckedPruneRetryState,
 } from "./checked-prune.js";
 import { type CPUUsage, CPUUsageIntervalLag } from "./cpu.js";
@@ -3349,6 +3350,13 @@ export class SharedLog<
 	// before a liveness eviction but reach the per-peer apply lane after it. Unlike
 	// message timestamps, these tokens never compare clocks from different peers.
 	private _replicationInfoReceiveEpochByPeer!: Map<string, object>;
+	// Receive-side ownership plans may span lower-log joins that invoke user code.
+	// Increment synchronously with leader-cache invalidation so the handler can
+	// detect whether its pre-join plan needs one fresh post-persist audit.
+	private _receiveOwnershipRevision = 0;
+	// Count ownership-changing range mutations from queue admission through
+	// settlement, including mutations already pending when a receive starts.
+	private _receiveOwnershipMutationAdmissions = 0;
 	// Subscription callbacks can overlap because removing a replicator mutates the
 	// replication index asynchronously. Keep that lifecycle separate from message
 	// timestamps so a reconnect can synchronously revoke an older unsubscribe.
@@ -5921,7 +5929,15 @@ export class SharedLog<
 	}
 
 	private invalidateLeaderSelectionContextCache() {
+		this._receiveOwnershipRevision++;
 		this._leaderSelectionContextCache = undefined;
+	}
+
+	private isReceiveOwnershipSnapshotStable(revision: number): boolean {
+		return (
+			this._receiveOwnershipMutationAdmissions === 0 &&
+			this._receiveOwnershipRevision === revision
+		);
 	}
 
 	private canCacheLeaderSelectionContext(options?: {
@@ -7706,7 +7722,7 @@ export class SharedLog<
 				let deleted: ReplicationRangeIndexable<R>[] = [];
 				let ownerHasRanges = false;
 				let mutationError: unknown;
-				const mutationCommitted = await this.withReplicationRangeMutationQueue(
+				const mutationCommitted = await this.withReceiveOwnershipMutationQueue(
 					async () => {
 						if (
 							!ownsReplicationOwnershipLifecycle() ||
@@ -7934,7 +7950,7 @@ export class SharedLog<
 		this.throwIfReplicationOwnershipLifecycleInactive(
 			replicationOwnershipLifecycleController,
 		);
-		return this.withReplicationRangeMutationQueue(
+		return this.withReceiveOwnershipMutationQueue(
 			() => this.removeReplicationRangesUnlocked(ranges, from, options),
 			replicationOwnershipLifecycleController,
 		);
@@ -8106,7 +8122,7 @@ export class SharedLog<
 		this.throwIfReplicationOwnershipLifecycleInactive(
 			replicationOwnershipLifecycleController,
 		);
-		return this.withReplicationRangeMutationQueue(
+		return this.withReceiveOwnershipMutationQueue(
 			() =>
 				this.addReplicationRangeUnlocked(
 					ranges,
@@ -11005,6 +11021,8 @@ export class SharedLog<
 		entries: ShallowOrFullEntry<T>[],
 		options?: {
 			decodedReplicaCounts?: DecodedReplicaCountMap;
+			freshReceiveOwnerAudit?: boolean;
+			preserveExistingPruneOnLocalResult?: boolean;
 			reusableLeaderPlans?: ReadonlyMap<
 				string,
 				Pick<ReusableReceiveCoordinatePlan<R>, "plan" | "replicas">
@@ -11020,11 +11038,17 @@ export class SharedLog<
 			return;
 		}
 		const selfHash = this.node.identity.publicKey.hashcode();
+		const freshReceiveRoleAge = options?.freshReceiveOwnerAudit
+			? await this.getDefaultMinRoleAge()
+			: undefined;
+		this.throwIfReplicationOwnershipLifecycleInactive(
+			ownershipLifecycleController,
+		);
 		const plans = new Array<EntryLeaderPlan<R> | undefined>(entries.length);
 		const leaderItems: Array<{
 			entry: ShallowOrFullEntry<T>;
 			replicas: number;
-			options: { roleAge: number; persist: false };
+			options: LeaderSelectionOptions<R>;
 		}> = [];
 		const leaderItemIndexes: number[] = [];
 		let reusableLeaderPlanHits = 0;
@@ -11033,7 +11057,9 @@ export class SharedLog<
 			const replicas =
 				options?.decodedReplicaCounts?.get(entry.hash) ??
 				decodeReplicas(entry).getValue(this);
-			const reusablePlan = options?.reusableLeaderPlans?.get(entry.hash);
+			const reusablePlan = options?.freshReceiveOwnerAudit
+				? undefined
+				: options?.reusableLeaderPlans?.get(entry.hash);
 			if (reusablePlan && reusablePlan.replicas === replicas) {
 				plans[i] = reusablePlan.plan;
 				reusableLeaderPlanHits++;
@@ -11042,7 +11068,9 @@ export class SharedLog<
 			leaderItems.push({
 				entry,
 				replicas,
-				options: { roleAge: 0, persist: false },
+				options: options?.freshReceiveOwnerAudit
+					? { roleAge: freshReceiveRoleAge!, persist: false }
+					: { roleAge: 0, persist: false },
 			});
 			leaderItemIndexes.push(i);
 		}
@@ -11116,6 +11144,7 @@ export class SharedLog<
 		const loopStartedAt = syncProfileStart(options?.profile);
 		let enqueuedPrune = 0;
 		let cancelledLocalLeader = 0;
+		let localLeaderResults = 0;
 		for (let i = 0; i < entries.length; i++) {
 			if (!this.isRepairLifecycleActive(ownershipLifecycleController)) {
 				continue;
@@ -11124,11 +11153,14 @@ export class SharedLog<
 			const leaders = plans[i]?.leaders ?? new Map();
 
 			if (leaders.has(selfHash)) {
-				await this.cancelCheckedPruneForLocalLeader(entry.hash);
-				this.throwIfReplicationOwnershipLifecycleInactive(
-					ownershipLifecycleController,
-				);
-				cancelledLocalLeader++;
+				if (!options?.preserveExistingPruneOnLocalResult) {
+					await this.cancelCheckedPruneForLocalLeader(entry.hash);
+					this.throwIfReplicationOwnershipLifecycleInactive(
+						ownershipLifecycleController,
+					);
+					cancelledLocalLeader++;
+				}
+				localLeaderResults++;
 				continue;
 			}
 
@@ -11162,7 +11194,7 @@ export class SharedLog<
 			entries: entries.length,
 			count: enqueuedPrune,
 			messages: 1,
-			details: { cancelledLocalLeader },
+			details: { cancelledLocalLeader, localLeaderResults },
 		});
 	}
 
@@ -11482,9 +11514,11 @@ export class SharedLog<
 			checkedPruneCoordinator.getRetry(hash) ??
 			({
 				attempts: 0,
+				generation: 0,
 				entry: args.entry,
 				leaders: args.leaders,
 			} satisfies CheckedPruneRetryState<T, R>);
+		state.generation++;
 		state.entry = args.entry;
 		state.leaders = args.leaders;
 
@@ -11507,6 +11541,7 @@ export class SharedLog<
 
 		state.attempts = attempt;
 		const timer = setTimeout(() => {
+			const generation = state.generation;
 			const run = async () => {
 				const st = checkedPruneCoordinator.getRetry(hash);
 				if (st !== state || state.timer !== timer || !isCurrent()) {
@@ -11516,6 +11551,7 @@ export class SharedLog<
 				const isExactAttempt = () =>
 					isCurrent() &&
 					checkedPruneCoordinator.getRetry(hash) === state &&
+					state.generation === generation &&
 					state.timer === undefined;
 				if (checkedPruneCoordinator.hasPendingDelete(hash)) return;
 				const retryEntry = state.entry;
@@ -11567,25 +11603,31 @@ export class SharedLog<
 				) {
 					// A keep policy is terminal for this background prune. Do not
 					// retain a retry record with neither a timer nor pending work.
-					checkedPruneCoordinator.clearRetry(hash);
+					checkedPruneCoordinator.clearRetry(hash, {
+						state,
+						generation,
+					});
 				}
 			};
 			void run().catch((error) => {
 				if (isCurrent() && !isNotStartedError(error as Error)) {
 					logger.error(error);
-					const retry = checkedPruneCoordinator.getRetry(hash);
 					if (
-						retry === state &&
-						!retry.timer &&
+						checkedPruneCoordinator.getRetry(hash) === state &&
+						state.generation === generation &&
+						!state.timer &&
 						!checkedPruneCoordinator.hasPendingDelete(hash)
 					) {
 						try {
 							this.scheduleCheckedPruneRetry(
-								{ entry: retry.entry, leaders: retry.leaders },
+								{ entry: state.entry, leaders: state.leaders },
 								ownershipLifecycleController,
 							);
 						} catch {
-							checkedPruneCoordinator.clearRetry(hash);
+							checkedPruneCoordinator.clearRetry(hash, {
+								state,
+								generation,
+							});
 						}
 					}
 				}
@@ -15689,6 +15731,8 @@ export class SharedLog<
 		this._checkedPruneRemoveBlocksLocalRangeMutationAdmission = 0;
 		this._checkedPruneRemovalCallbackInvocationDepth = 0;
 		this._localReplicationRoleGeneration = 0;
+		this._receiveOwnershipRevision = 0;
+		this._receiveOwnershipMutationAdmissions = 0;
 		this._pruneRemovesClosing = false;
 		this._replicationRangeMutationFailure = undefined;
 		this.startRepairLifecycle();
@@ -16123,7 +16167,9 @@ export class SharedLog<
 							continue;
 						}
 						if (checkedPruneLeaders.localLeader) {
-							const retry = checkedPruneCoordinator.getRetry(hash);
+							const retryIdentity =
+								checkedPruneCoordinator.getRetryIdentity(hash);
+							const retry = retryIdentity?.state;
 							await this.cancelCheckedPruneForLocalLeader(hash, {
 								preserveRetry: retry != null,
 							});
@@ -16133,7 +16179,7 @@ export class SharedLog<
 							if (retry) {
 								// A delayed confirmation of local ownership is terminal.
 								// Future ownership mutations will enqueue fresh work.
-								checkedPruneCoordinator.clearRetry(hash);
+								checkedPruneCoordinator.clearRetry(hash, retryIdentity);
 							} else {
 								// A first positive view can be a transient membership
 								// snapshot. Confirm it once after the normal retry delay
@@ -16182,6 +16228,15 @@ export class SharedLog<
 									pruneOwnershipLifecycleController,
 								);
 							} catch {
+								if (
+									value.workToken != null &&
+									checkedPruneCoordinator.isCandidateTokenCurrent(
+										hash,
+										value.workToken,
+									)
+								) {
+									checkedPruneCoordinator.invalidateCandidateToken(hash);
+								}
 								checkedPruneCoordinator.clearRetry(hash);
 							}
 						}
@@ -16982,7 +17037,7 @@ export class SharedLog<
 	) {
 		const ownershipLifecycleController =
 			this.captureReplicationOwnershipLifecycle();
-		return this.withReplicationRangeMutationQueue(async () => {
+		return this.withReceiveOwnershipMutationQueue(async () => {
 			this.throwIfReplicationOwnershipLifecycleInactive(
 				ownershipLifecycleController,
 			);
@@ -19157,6 +19212,9 @@ export class SharedLog<
 			if (!releasePeerReceiveLease) {
 				return;
 			}
+			const receiveOwnershipRevision = this._receiveOwnershipRevision;
+			const receiveOwnershipLifecycleController =
+				this.captureReplicationOwnershipLifecycle();
 			const receiveReplicationInfoReceiveEpoch =
 				this.getReplicationInfoReceiveEpoch(receiveFromHash);
 			if (msg instanceof ResponseRoleMessage) {
@@ -19440,6 +19498,7 @@ export class SharedLog<
 												heads,
 												hashes,
 											),
+											receiveOwnershipRevision,
 										}),
 							selectPreparedRawReceiveHashes: rawIsRepairHint
 								? undefined
@@ -19454,6 +19513,7 @@ export class SharedLog<
 												heads,
 												hashes,
 											),
+											receiveOwnershipRevision,
 										}),
 						},
 					);
@@ -20150,6 +20210,7 @@ export class SharedLog<
 						!isReplicating &&
 						!this.keep &&
 						!isRepairHint &&
+						this.isReceiveOwnershipSnapshotStable(receiveOwnershipRevision) &&
 						receiveGroups.length > 0 &&
 						receiveGroups.every(
 							(group) =>
@@ -20894,11 +20955,60 @@ export class SharedLog<
 							confirmedHashes.add(hash);
 						}
 						const checkedPruneStartedAt = syncProfileStart(syncProfile);
-						await this.pruneJoinedEntriesNoLongerLed(admittedShallowEntries, {
-							decodedReplicaCounts: receiveReplicaCounts,
-							reusableLeaderPlans: reusableCoordinatePlans,
-							profile: syncProfile,
-						});
+						const ownershipChangedDuringReceive =
+							!this.isReceiveOwnershipSnapshotStable(
+								receiveOwnershipRevision,
+							);
+						if (ownershipChangedDuringReceive) {
+							const freshAuditRevision = this._receiveOwnershipRevision;
+							const armFreshAuditRetry = () => {
+								for (const entry of admittedShallowEntries) {
+									this.scheduleCheckedPruneRetry(
+										{ entry, leaders: new Map() },
+										receiveOwnershipLifecycleController,
+									);
+								}
+							};
+							try {
+								await this.pruneJoinedEntriesNoLongerLed(
+									admittedShallowEntries,
+									{
+										decodedReplicaCounts: receiveReplicaCounts,
+										freshReceiveOwnerAudit: true,
+										preserveExistingPruneOnLocalResult: true,
+										profile: syncProfile,
+									},
+									receiveOwnershipLifecycleController,
+								);
+								this.throwIfReplicationOwnershipLifecycleInactive(
+									receiveOwnershipLifecycleController,
+								);
+								if (
+									!this.isReceiveOwnershipSnapshotStable(freshAuditRevision)
+								) {
+									armFreshAuditRetry();
+								}
+							} catch {
+								// The lower-log and coordinate commits are already durable. A
+								// sender retry will filter these hashes as present, so retain a
+								// bounded local obligation instead of failing the admitted receive.
+								this.throwIfReplicationOwnershipLifecycleInactive(
+									receiveOwnershipLifecycleController,
+								);
+								armFreshAuditRetry();
+							}
+						} else {
+							await this.pruneJoinedEntriesNoLongerLed(
+								admittedShallowEntries,
+								{
+									decodedReplicaCounts: receiveReplicaCounts,
+									preserveExistingPruneOnLocalResult: true,
+									reusableLeaderPlans: reusableCoordinatePlans,
+									profile: syncProfile,
+								},
+								receiveOwnershipLifecycleController,
+							);
+						}
 						if (syncProfile) {
 							emitSyncProfileDuration(syncProfile, checkedPruneStartedAt, {
 								name: "sharedLog.receive.checkedPrune",
@@ -24490,8 +24600,10 @@ export class SharedLog<
 		fromIsSelf: boolean;
 		syncProfile?: SyncProfileFn;
 		selection?: NativeBackboneRawReceiveSelectionPlan;
+		receiveOwnershipRevision: number;
 	}): Promise<boolean> {
 		const backbone = this._nativeBackbone;
+		const ownershipRevision = properties.receiveOwnershipRevision;
 		if (!backbone || !this.syncronizer.onReceivedEntryHashes) {
 			return false;
 		}
@@ -24499,7 +24611,11 @@ export class SharedLog<
 		const selection =
 			properties.selection ??
 			(await this.planNativePreparedRawReceiveSelection(properties));
-		if (!selection || selection.retainedHashes.length > 0) {
+		if (
+			!selection ||
+			selection.retainedHashes.length > 0 ||
+			!this.isReceiveOwnershipSnapshotStable(ownershipRevision)
+		) {
 			return false;
 		}
 
@@ -24534,6 +24650,9 @@ export class SharedLog<
 			hashes: selection.droppedHashes,
 			from: properties.from,
 		});
+		if (!this.isReceiveOwnershipSnapshotStable(ownershipRevision)) {
+			return false;
+		}
 		if (properties.syncProfile) {
 			emitSyncProfileDuration(properties.syncProfile, notifyStartedAt, {
 				name: "sharedLog.receive.notifySynchronizer",
@@ -24572,7 +24691,9 @@ export class SharedLog<
 		fromIsSelf: boolean;
 		syncProfile?: SyncProfileFn;
 		selection?: NativeBackboneRawReceiveSelectionPlan;
+		receiveOwnershipRevision: number;
 	}): Promise<RawReceiveHashSelection | undefined> {
+		const ownershipRevision = properties.receiveOwnershipRevision;
 		if (!this.syncronizer.onReceivedEntryHashes) {
 			return undefined;
 		}
@@ -24580,7 +24701,10 @@ export class SharedLog<
 		const selection =
 			properties.selection ??
 			(await this.planNativePreparedRawReceiveSelection(properties));
-		if (!selection) {
+		if (
+			!selection ||
+			!this.isReceiveOwnershipSnapshotStable(ownershipRevision)
+		) {
 			return undefined;
 		}
 		if (selection.droppedHashes.length === 0) {
@@ -24598,6 +24722,9 @@ export class SharedLog<
 			hashes: selection.droppedHashes,
 			from: properties.from,
 		});
+		if (!this.isReceiveOwnershipSnapshotStable(ownershipRevision)) {
+			return undefined;
+		}
 		emitSyncProfileDuration(properties.syncProfile, notifyStartedAt, {
 			name: "sharedLog.receive.notifySynchronizer",
 			component: "shared-log",
@@ -25465,6 +25592,7 @@ export class SharedLog<
 	private withReplicationRangeMutationQueue<T>(
 		fn: () => Promise<T>,
 		replicationOwnershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+		options?: { affectsReceiveOwnership?: boolean },
 	): Promise<T> {
 		try {
 			this.throwIfReplicationOwnershipLifecycleInactive(
@@ -25480,6 +25608,15 @@ export class SharedLog<
 				),
 			);
 		}
+		let releaseReceiveOwnershipMutationAdmission: (() => void) | undefined;
+		if (options?.affectsReceiveOwnership) {
+			this._receiveOwnershipMutationAdmissions++;
+			this.invalidateLeaderSelectionContextCache();
+			releaseReceiveOwnershipMutationAdmission = () => {
+				this._receiveOwnershipMutationAdmissions--;
+				this.invalidateLeaderSelectionContextCache();
+			};
+		}
 		const run = (this._replicationRangeMutationTail ?? Promise.resolve())
 			.catch(() => {
 				// A failed predecessor must not leave the queue permanently rejected.
@@ -25493,11 +25630,25 @@ export class SharedLog<
 				);
 				return fn();
 			});
-		this._replicationRangeMutationTail = run.then(
+		const fencedRun = releaseReceiveOwnershipMutationAdmission
+			? run.finally(releaseReceiveOwnershipMutationAdmission)
+			: run;
+		this._replicationRangeMutationTail = fencedRun.then(
 			() => undefined,
 			() => undefined,
 		);
-		return run;
+		return fencedRun;
+	}
+
+	private withReceiveOwnershipMutationQueue<T>(
+		fn: () => Promise<T>,
+		replicationOwnershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	): Promise<T> {
+		return this.withReplicationRangeMutationQueue(
+			fn,
+			replicationOwnershipLifecycleController,
+			{ affectsReceiveOwnership: true },
+		);
 	}
 
 	private acquireReplicationRangeMutationTerminalFence(): {
@@ -26428,12 +26579,13 @@ export class SharedLog<
 			const restartCandidates: Array<{
 				candidate: CheckedPruneRestartCandidate<T, R>;
 				reservation: object;
-				retry?: CheckedPruneRetryState<T, R>;
+				retryIdentity?: CheckedPruneRetryIdentity<T, R>;
 			}> = [];
 			for (const { hash } of admitted) {
 				const candidate = checkedPruneCoordinator.getRestartCandidate(hash);
 				const pending = checkedPruneCoordinator.getPendingDelete(hash);
-				const retry = checkedPruneCoordinator.getRetry(hash);
+				const retryIdentity = checkedPruneCoordinator.getRetryIdentity(hash);
+				const retry = retryIdentity?.state;
 				const hadQueuedCandidate = this.pruneDebouncedFn.has(hash);
 				const hadInFlightCandidate = checkedPruneCoordinator.hasCandidate(hash);
 				const shouldRestart =
@@ -26476,7 +26628,7 @@ export class SharedLog<
 					restartCandidates.push({
 						candidate,
 						reservation: checkedPruneCoordinator.reserveRestart(hash),
-						retry,
+						retryIdentity,
 					});
 				}
 			}
@@ -26512,7 +26664,7 @@ export class SharedLog<
 			for (const {
 				candidate,
 				reservation,
-				retry,
+				retryIdentity,
 			} of admission.restartCandidates) {
 				if (
 					this._checkedPrune !== checkedPruneCoordinator ||
@@ -26522,11 +26674,8 @@ export class SharedLog<
 						candidate.hash,
 						reservation,
 					);
-					if (
-						retry &&
-						checkedPruneCoordinator.getRetry(candidate.hash) === retry
-					) {
-						checkedPruneCoordinator.clearRetry(candidate.hash);
+					if (retryIdentity) {
+						checkedPruneCoordinator.clearRetry(candidate.hash, retryIdentity);
 					}
 					continue;
 				}

--- a/packages/programs/data/shared-log/test/checked-prune-coordinator.spec.ts
+++ b/packages/programs/data/shared-log/test/checked-prune-coordinator.spec.ts
@@ -307,6 +307,65 @@ describe("checked prune coordinator", () => {
 			.false;
 	});
 
+	it("fences stale retry cleanup without erasing newer work", () => {
+		const coordinator = new CheckedPruneCoordinator<Uint8Array, "u32">();
+		const entry = { hash: "candidate" } as any;
+		const leaders = new Set(["peer"]);
+		const state = { attempts: 1, generation: 1, entry, leaders };
+		coordinator.setRetry(entry.hash, state);
+		const staleIdentity = coordinator.getRetryIdentity(entry.hash)!;
+
+		state.generation++;
+		coordinator.setRetry(entry.hash, state);
+		const candidateToken = coordinator.trackCandidate(
+			entry.hash,
+			entry,
+			leaders,
+		);
+		expect(coordinator.clearRetry(entry.hash, staleIdentity)).to.be.false;
+		expect(coordinator.getRetry(entry.hash)).to.equal(state);
+		expect(coordinator.isCandidateTokenCurrent(entry.hash, candidateToken)).to
+			.be.true;
+
+		const currentIdentity = coordinator.getRetryIdentity(entry.hash)!;
+		expect(coordinator.clearRetry(entry.hash, currentIdentity)).to.be.true;
+		expect(coordinator.getRetry(entry.hash)).to.be.undefined;
+		expect(coordinator.isCandidateTokenCurrent(entry.hash, candidateToken)).to
+			.be.true;
+
+		const restartEntry = { hash: "restart" } as any;
+		const restartState = {
+			attempts: 1,
+			generation: 1,
+			entry: restartEntry,
+			leaders,
+		};
+		coordinator.setRetry(restartEntry.hash, restartState);
+		const restart = coordinator.reserveRestart(restartEntry.hash);
+		expect(
+			coordinator.clearRetry(
+				restartEntry.hash,
+				coordinator.getRetryIdentity(restartEntry.hash),
+			),
+		).to.be.true;
+		expect(coordinator.hasRestartReservation(restartEntry.hash)).to.be.true;
+		expect(coordinator.getRestartCandidate(restartEntry.hash)?.entry).to.equal(
+			restartEntry,
+		);
+		expect(coordinator.consumeRestartReservation(restartEntry.hash, restart)).to
+			.be.true;
+		expect(coordinator.getRestartCandidate(restartEntry.hash)).to.be.undefined;
+
+		coordinator.setRetry(restartEntry.hash, restartState);
+		const cancelledRestart = coordinator.reserveRestart(restartEntry.hash);
+		coordinator.clearRetry(
+			restartEntry.hash,
+			coordinator.getRetryIdentity(restartEntry.hash),
+		);
+		coordinator.cancelRestartReservation(restartEntry.hash, cancelledRestart);
+		expect(coordinator.getRestartCandidate(restartEntry.hash)).to.be.undefined;
+	});
+
 	it("clears every authorization generation on close", () => {
 		let clears = 0;
 		const coordinator = new CheckedPruneCoordinator<Uint8Array, "u32">();

--- a/packages/programs/data/shared-log/test/checked-prune-handoff.spec.ts
+++ b/packages/programs/data/shared-log/test/checked-prune-handoff.spec.ts
@@ -607,6 +607,7 @@ describe("checked prune correlated handoff", () => {
 		try {
 			log._checkedPrune.setRetry(backgroundEntry.hash, {
 				attempts: 1,
+				generation: 0,
 				entry: backgroundEntry,
 				leaders,
 			});
@@ -1614,6 +1615,111 @@ describe("checked prune correlated handoff", () => {
 		}
 	});
 
+	it("freshly replans received entries without cancelling newer prune work", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				keep: () => true,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const log = db.log as any;
+		const { entry: localEntry } = await db.add(
+			"checked-prune-fresh-receive-local",
+		);
+		const { entry: remoteEntry } = await db.add(
+			"checked-prune-fresh-receive-remote",
+		);
+		const selfHash = session.peers[0].identity.publicKey.hashcode();
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+		const localLeaders = new Map([[selfHash, { intersecting: true }]]);
+		const remoteLeaders = new Map([[remoteHash, { intersecting: true }]]);
+		const stalePlans = new Map([
+			[
+				localEntry.hash,
+				{
+					replicas: 1,
+					plan: {
+						coordinates: [],
+						leaders: remoteLeaders,
+						isLeader: false,
+					},
+				},
+			],
+			[
+				remoteEntry.hash,
+				{
+					replicas: 1,
+					plan: {
+						coordinates: [],
+						leaders: localLeaders,
+						isLeader: true,
+					},
+				},
+			],
+		]);
+		const getDefaultMinRoleAge = sinon
+			.stub(log, "getDefaultMinRoleAge")
+			.resolves(4_321);
+		const canPlanNative = sinon
+			.stub(log, "canPlanNativeEntryLeaderBatch")
+			.returns(false);
+		const plan = sinon.stub(log, "planEntryLeaderBatch").resolves([
+			{ coordinates: [], leaders: localLeaders, isLeader: true },
+			{ coordinates: [], leaders: remoteLeaders, isLeader: false },
+		]);
+		const cancel = sinon
+			.stub(log, "cancelCheckedPruneForLocalLeader")
+			.resolves();
+		const enqueue = sinon
+			.stub(log, "pruneDebouncedFnAddIfNotKeeping")
+			.resolves(true);
+		const candidateToken = log._checkedPrune.trackCandidate(
+			localEntry.hash,
+			localEntry,
+			remoteLeaders,
+		);
+
+		try {
+			await log.pruneJoinedEntriesNoLongerLed([localEntry, remoteEntry], {
+				decodedReplicaCounts: new Map([
+					[localEntry.hash, 1],
+					[remoteEntry.hash, 1],
+				]),
+				freshReceiveOwnerAudit: true,
+				preserveExistingPruneOnLocalResult: true,
+				reusableLeaderPlans: stalePlans,
+			});
+
+			expect(getDefaultMinRoleAge.calledOnce).to.be.true;
+			expect(plan.calledOnce).to.be.true;
+			expect(plan.firstCall.args[0]).to.have.length(2);
+			expect(
+				plan.firstCall.args[0].map((item: any) => item.options),
+			).to.deep.equal([
+				{ roleAge: 4_321, persist: false },
+				{ roleAge: 4_321, persist: false },
+			]);
+			expect(cancel.called).to.be.false;
+			expect(
+				log._checkedPrune.isCandidateTokenCurrent(
+					localEntry.hash,
+					candidateToken,
+				),
+			).to.be.true;
+			expect(enqueue.calledOnce).to.be.true;
+			expect(enqueue.firstCall.args[0].key).to.equal(remoteEntry.hash);
+		} finally {
+			log._checkedPrune.invalidateCandidateToken(localEntry.hash);
+			enqueue.restore();
+			cancel.restore();
+			plan.restore();
+			canPlanNative.restore();
+			getDefaultMinRoleAge.restore();
+		}
+	});
+
 	it("moves exhausted retries to one coalesced low-rate audit", async () => {
 		session = await TestSession.disconnected(2);
 		const db = await session.peers[0].open(new EventStore(), {
@@ -1632,6 +1738,7 @@ describe("checked prune correlated handoff", () => {
 		try {
 			log._checkedPrune.setRetry(entry.hash, {
 				attempts: 3,
+				generation: 0,
 				entry,
 				leaders,
 			});
@@ -1677,6 +1784,7 @@ describe("checked prune correlated handoff", () => {
 			for (const hash of hashes) {
 				log._checkedPrune.setRetry(hash, {
 					attempts: 3,
+					generation: 0,
 					entry: { hash, meta: entry.meta },
 					leaders,
 				});

--- a/packages/programs/data/shared-log/test/receive-admission.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission.spec.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "@peerbit/crypto";
 import { Entry } from "@peerbit/log";
 import { TestSession } from "@peerbit/test-utils";
 import { waitForResolved } from "@peerbit/time";
@@ -13,6 +14,7 @@ import {
 	SyncCapabilitiesMessage,
 } from "../src/exchange-heads.js";
 import { createReplicationDomainHash } from "../src/replication-domain-hash.js";
+import { ReplicationIntent } from "../src/ranges.js";
 import { AllReplicatingSegmentsMessage } from "../src/replication.js";
 import {
 	ConfirmEntriesMessage,
@@ -871,10 +873,160 @@ describe("receive admission", () => {
 				expect(
 					pruneSpy.lastCall.args[0].map((entry: any) => entry.hash),
 				).to.deep.equal([child.hash]);
+				expect(pruneSpy.lastCall.args[1].freshReceiveOwnerAudit).to.not.equal(
+					true,
+				);
+				expect(
+					pruneSpy.lastCall.args[1].preserveExistingPruneOnLocalResult,
+				).to.equal(true);
+				expect(pruneSpy.lastCall.args[1].reusableLeaderPlans).to.be.instanceOf(
+					Map,
+				);
 			} finally {
 				missingParentStub?.restore();
 				pruneSpy.restore();
 				confirmationStub.restore();
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("rearms a receive while a rebalance-disabled ownership mutation is pending", async () => {
+		const session = await TestSession.disconnected(2);
+		try {
+			const store = new EventStore<string, any>();
+			const source = await session.peers[0].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: {
+					replicate: false,
+					keep: () => true,
+					setup,
+					timeUntilRoleMaturity: 0,
+				},
+			});
+			const { entry } = await source.add(uuid(), { meta: { next: [] } });
+			const sharedLog = target.log as any;
+			const range = new sharedLog.indexableDomain.constructorRange({
+				id: randomBytes(32),
+				offset: sharedLog.indexableDomain.numbers.denormalize(0.1),
+				width: sharedLog.indexableDomain.numbers.denormalize(0.2),
+				publicKeyHash: source.node.identity.publicKey.hashcode(),
+				mode: ReplicationIntent.NonStrict,
+				timestamp: 1n,
+			});
+			const rangePersisted = pDefer<void>();
+			const releaseRangePut = pDefer<void>();
+			const originalPut = sharedLog.replicationIndex.put.bind(
+				sharedLog.replicationIndex,
+			);
+			const put = sinon
+				.stub(sharedLog.replicationIndex, "put")
+				.callsFake(async (...args: any[]) => {
+					const result = await originalPut(...args);
+					if (args[0].idString === range.idString) {
+						rangePersisted.resolve();
+						await releaseRangePut.promise;
+					}
+					return result;
+				});
+			const originalPlan = sharedLog.planEntryLeaderBatch.bind(sharedLog);
+			let rejectedFreshItems: any[] | undefined;
+			const leaderPlan = sinon
+				.stub(sharedLog, "planEntryLeaderBatch")
+				.callsFake(async (...callArgs: unknown[]) => {
+					const [items, ...args] = callArgs as [any[], ...any[]];
+					if (items.some((item) => item.options?.persist === false)) {
+						rejectedFreshItems = items;
+						throw new Error("fresh receive planner failed");
+					}
+					return originalPlan(items, ...args);
+				});
+			const audit = sinon.spy(sharedLog, "pruneJoinedEntriesNoLongerLed");
+			let adding: Promise<unknown> | undefined;
+
+			try {
+				adding = sharedLog.addReplicationRange(
+					[range],
+					source.node.identity.publicKey,
+					{ checkDuplicates: false, rebalance: false },
+				);
+				await rangePersisted.promise;
+				expect(sharedLog._receiveOwnershipMutationAdmissions).to.equal(1);
+				await target.log.onMessage(exchange(entry), {
+					from: source.node.identity.publicKey,
+				} as any);
+
+				expect(sharedLog._checkedPrune.hasRetry(entry.hash)).to.equal(true);
+				expect(audit.calledOnce).to.equal(true);
+				expect(audit.firstCall.args[1].freshReceiveOwnerAudit).to.equal(true);
+				expect(
+					audit.firstCall.args[1].preserveExistingPruneOnLocalResult,
+				).to.equal(true);
+				expect(audit.firstCall.args[1].reusableLeaderPlans).to.equal(undefined);
+				expect(rejectedFreshItems).to.have.length(1);
+				expect(rejectedFreshItems![0].options).to.deep.equal({
+					roleAge: 0,
+					persist: false,
+				});
+				expect(await target.log.log.has(entry.hash)).to.equal(true);
+				releaseRangePut.resolve();
+				await adding;
+				expect(sharedLog._receiveOwnershipMutationAdmissions).to.equal(0);
+			} finally {
+				releaseRangePut.resolve();
+				await adding;
+				sharedLog._checkedPrune.clearRetry(entry.hash);
+				audit.restore();
+				leaderPlan.restore();
+				put.restore();
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("falls back from raw hash drops when ownership changes during notification", async () => {
+		const session = await TestSession.disconnected(1);
+		try {
+			const target = await session.peers[0].open(new EventStore<string, any>(), {
+				args: { replicate: false, setup },
+			});
+			const sharedLog = target.log as any;
+			const originalBackbone = sharedLog._nativeBackbone;
+			const clearPrepared = sinon.spy();
+			sharedLog._nativeBackbone = {
+				clearPreparedRawReceiveEntries: clearPrepared,
+			};
+			const notify = sinon
+				.stub(sharedLog.syncronizer, "onReceivedEntryHashes")
+				.callsFake(async () => {
+					sharedLog.invalidateLeaderSelectionContextCache();
+				});
+			const revision = sharedLog._receiveOwnershipRevision;
+			try {
+				const dropped = await sharedLog.tryFastDropPreparedRawReceive({
+					heads: [],
+					hashes: ["raw-hash"],
+					from: target.node.identity.publicKey,
+					fromIsSelf: true,
+					selection: {
+						retainedHashes: [],
+						droppedHashes: ["raw-hash"],
+						groupCount: 1,
+						plannedHashCount: 1,
+						usedNativeFastDropPlan: true,
+						usedLeaderSamplePlans: true,
+					},
+					receiveOwnershipRevision: revision,
+				});
+				expect(dropped).to.equal(false);
+				expect(clearPrepared.called).to.equal(false);
+			} finally {
+				notify.restore();
+				sharedLog._nativeBackbone = originalBackbone;
 			}
 		} finally {
 			await session.stop();


### PR DESCRIPTION
## Summary

- detect ownership/cache invalidation while a network receive spans the lower-log join
- fence queued and in-flight replication-range mutations from admission through settlement, including `rebalance: false` updates that do not immediately emit a change event
- retain the reusable-plan fast path when ownership is stable, but run one fresh default-maturity post-persist audit after overlapping churn
- gate native raw early, partial, and final drop decisions on the same stable ownership snapshot
- preserve newer checked-prune work and bounded retry debt if a fresh audit fails or ownership changes again
- scope retry cleanup to an exact in-memory generation so stale async cleanup cannot erase newer work

This is local shared-log coordination only: no wire protocol, schema, coordinate persistence, or public API changes.

## Validation

- `pnpm --filter @peerbit/shared-log run build`
- focused ownership/receive regressions: 5/5 passing
- complete receive-admission suite: 16/16 passing
- complete raw exchange-head sync suite: 34/34 passing
- historical repeated join/leave regression: passing
- 1,000-entry native-backbone receive: 12,760 ops/s; checked-prune planning 0.005 ms
- 1,000-entry coordinate-WAL receive: 17,439 ops/s; checked-prune planning 0.002 ms
- `git diff --check`

Benchmarks are same-process loopback/in-memory path checks and are unaffected by LAN speed. Fresh full CI is required for the amended SHA.
