### PR TITLE
fix(document): preserve explicit index accessors

### DIFF
--- a/.changeset/calm-apples-index-accessors.md
+++ b/.changeset/calm-apples-index-accessors.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/document": patch
+---
+
+Allow index transforms to explicitly preserve Borsh getter/setter fields when Documents adds its local context wrapper, enabling compatible persisted-index migrations that discard large derived payloads.

--- a/packages/programs/data/document/document/src/borsh.ts
+++ b/packages/programs/data/document/document/src/borsh.ts
@@ -1,19 +1,150 @@
-import { getSchema } from "@dao-xyz/borsh";
+import {
+	type CustomField,
+	type SimpleField,
+	field,
+	getSchema,
+} from "@dao-xyz/borsh";
+
+const serializedFieldAccessors = new WeakMap<
+	object,
+	ReadonlyMap<string, PropertyDescriptor>
+>();
+const copiedSerializations = new WeakMap<Function, ReadonlySet<Function>>();
+
+/**
+ * Register a Borsh field backed by an accessor and explicitly preserve that
+ * accessor when Documents wraps an indexed value with its local context.
+ *
+ * The accessor must not inherit from another Borsh-decorated class, must be
+ * defined directly on `clazz.prototype`, have both a getter and setter, and be
+ * safe when invoked with the generated wrapper as `this`. In particular, it
+ * cannot depend on private fields, constructor-only state, or state stored in a
+ * WeakMap keyed by instances of `clazz`. The setter is invoked while Borsh
+ * deserializes persisted index rows.
+ */
+export const registerIndexFieldAccessor = (
+	clazz: Function,
+	key: string,
+	properties: SimpleField | CustomField<any>,
+): void => {
+	if (typeof key !== "string") {
+		throw new Error("Index field accessor keys must be strings");
+	}
+
+	const prototype = clazz.prototype;
+	const descriptor = Object.getOwnPropertyDescriptor(prototype, key);
+	if (!descriptor?.get || !descriptor.set) {
+		throw new Error(
+			`Index field accessor '${key}' must define both a getter and setter`,
+		);
+	}
+
+	const registered = serializedFieldAccessors.get(prototype);
+	if (registered?.has(key)) {
+		return;
+	}
+	let parent = Object.getPrototypeOf(clazz);
+	while (parent && parent !== Function.prototype) {
+		if (getSchema(parent)) {
+			throw new Error(
+				"Index field accessors cannot inherit from a Borsh-decorated class",
+			);
+		}
+		parent = Object.getPrototypeOf(parent);
+	}
+	if (getSchema(clazz)?.fields.some((existing) => existing.key === key)) {
+		throw new Error(
+			`Index field accessor '${key}' is already registered as a Borsh field`,
+		);
+	}
+
+	(field(properties) as unknown as PropertyDecorator)(prototype, key);
+	serializedFieldAccessors.set(
+		prototype,
+		new Map([...(registered ?? []), [key, descriptor]]),
+	);
+};
+
+const getSerializedFieldAccessor = (
+	sourceClazz: any,
+	targetClazz: any,
+	targetSchema: ReturnType<typeof getSchema>,
+	key: string,
+): PropertyDescriptor | undefined => {
+	const sourcePrototype = sourceClazz.prototype;
+	const registeredDescriptor = serializedFieldAccessors
+		.get(sourcePrototype)
+		?.get(key);
+	if (!registeredDescriptor) {
+		return undefined;
+	}
+
+	if (targetSchema.fields.some((field) => field.key === key)) {
+		throw new Error(
+			`Cannot preserve index field accessor '${key}': the wrapper schema already contains that field`,
+		);
+	}
+	if (Object.getOwnPropertyDescriptor(targetClazz.prototype, key)) {
+		throw new Error(
+			`Cannot preserve index field accessor '${key}': the wrapper prototype already defines it`,
+		);
+	}
+
+	const descriptor = Object.getOwnPropertyDescriptor(sourcePrototype, key);
+	if (!descriptor?.get || !descriptor.set) {
+		throw new Error(
+			`Registered index field accessor '${key}' must define both a getter and setter`,
+		);
+	}
+	if (
+		descriptor.get !== registeredDescriptor.get ||
+		descriptor.set !== registeredDescriptor.set ||
+		descriptor.enumerable !== registeredDescriptor.enumerable ||
+		descriptor.configurable !== registeredDescriptor.configurable
+	) {
+		throw new Error(
+			`Registered index field accessor '${key}' changed after registration`,
+		);
+	}
+	return descriptor;
+};
 
 export const copySerialization = (sourceClazz: any, targetClazz: any) => {
-	const copiedFromAlready: any[] = targetClazz["__copiedFrom"] || [];
-	if (copiedFromAlready?.includes(sourceClazz)) {
+	const copiedFromAlready = copiedSerializations.get(targetClazz);
+	if (copiedFromAlready?.has(sourceClazz)) {
 		return;
 	}
 
-	copiedFromAlready.push(sourceClazz);
-	targetClazz["__copiedFrom"] = copiedFromAlready;
-
 	const targetSchema = getSchema(targetClazz);
 	const sourceSchema = getSchema(sourceClazz);
+	const accessors: Array<[string, PropertyDescriptor]> = [];
+	for (const sourceField of sourceSchema.fields) {
+		const descriptor = getSerializedFieldAccessor(
+			sourceClazz,
+			targetClazz,
+			targetSchema,
+			sourceField.key,
+		);
+		if (descriptor) {
+			accessors.push([sourceField.key, descriptor]);
+		}
+	}
+	if (accessors.length > 0 && !Object.isExtensible(targetClazz.prototype)) {
+		throw new Error(
+			"Cannot preserve index field accessors: the wrapper prototype is not extensible",
+		);
+	}
+
+	for (const [key, descriptor] of accessors) {
+		Object.defineProperty(targetClazz.prototype, key, descriptor);
+	}
 
 	targetSchema.fields = [...sourceSchema.fields, ...targetSchema.fields];
 	targetSchema.variant = sourceSchema.variant;
 	targetSchema.getDependencies =
 		sourceSchema.getDependencies.bind(sourceSchema);
+	copiedSerializations.set(
+		targetClazz,
+		new Set([...(copiedFromAlready ?? []), sourceClazz]),
+	);
 };

--- a/packages/programs/data/document/document/src/index.ts
+++ b/packages/programs/data/document/document/src/index.ts
@@ -35,6 +35,7 @@ export { coerceWithContext, coerceWithIndexed } from "./search.js";
 export * from "./operation.js";
 export { policy } from "./policy.js";
 export { transform } from "./transform.js";
+export { registerIndexFieldAccessor } from "./borsh.js";
 export { MAX_BATCH_SIZE as MAX_DOCUMENT_SIZE } from "./constants.js";
 export { ClosedError } from "@peerbit/program";
 export {

--- a/packages/programs/data/document/document/test/borsh.spec.ts
+++ b/packages/programs/data/document/document/test/borsh.spec.ts
@@ -1,6 +1,6 @@
-import { deserialize, field, serialize } from "@dao-xyz/borsh";
+import { deserialize, field, serialize, variant } from "@dao-xyz/borsh";
 import { expect } from "chai";
-import { copySerialization } from "../src/borsh.js";
+import { copySerialization, registerIndexFieldAccessor } from "../src/borsh.js";
 
 describe("borsh", () => {
 	it("can append fields to an already defined class", () => {
@@ -49,5 +49,269 @@ describe("borsh", () => {
 		const ser = serialize(indexedClass);
 		const der = deserialize(ser, IndexedClassWithContext);
 		expect(der).to.deep.equal(indexedClass);
+	});
+
+	it("preserves serialized field accessors on the wrapped index type", () => {
+		const empty = new Uint8Array();
+
+		@variant(0)
+		class LegacyIndexedClass {
+			@field({ type: "string" })
+			id: string;
+
+			@field({ type: Uint8Array })
+			content: Uint8Array;
+
+			constructor(id: string, content: Uint8Array) {
+				this.id = id;
+				this.content = content;
+			}
+		}
+
+		@variant(0)
+		class CompactIndexedClass {
+			@field({ type: "string" })
+			id: string;
+
+			get content(): Uint8Array {
+				return empty;
+			}
+
+			set content(content: Uint8Array) {
+				void content;
+			}
+
+			constructor(id: string) {
+				this.id = id;
+			}
+		}
+		registerIndexFieldAccessor(CompactIndexedClass, "content", {
+			type: Uint8Array,
+		});
+		registerIndexFieldAccessor(CompactIndexedClass, "content", {
+			type: Uint8Array,
+		});
+
+		class Context {
+			@field({ type: "string" })
+			context: string;
+
+			constructor(context: string) {
+				this.context = context;
+			}
+		}
+
+		class LegacyWithContext {
+			@field({ type: Context })
+			__context: Context;
+
+			constructor(value: LegacyIndexedClass, context: Context) {
+				Object.assign(this, value);
+				this.__context = context;
+			}
+		}
+
+		class CompactWithContext {
+			@field({ type: Context })
+			__context: Context;
+
+			constructor(value: CompactIndexedClass, context: Context) {
+				Object.assign(this, value);
+				this.__context = context;
+			}
+		}
+
+		copySerialization(LegacyIndexedClass, LegacyWithContext);
+		copySerialization(CompactIndexedClass, CompactWithContext);
+		copySerialization(CompactIndexedClass, CompactWithContext);
+
+		const legacyBytes = serialize(
+			new LegacyWithContext(
+				new LegacyIndexedClass("chunk", Uint8Array.from([1, 2, 3])),
+				new Context("head"),
+			),
+		);
+		const migrated = deserialize(
+			legacyBytes,
+			CompactWithContext,
+		) as CompactWithContext & CompactIndexedClass;
+
+		expect(migrated.id).to.equal("chunk");
+		expect(migrated.content).to.equal(empty);
+		expect(migrated).not.to.have.own.property("content");
+		expect(migrated.__context.context).to.equal("head");
+
+		const compact = new CompactWithContext(
+			new CompactIndexedClass("next"),
+			new Context("next-head"),
+		);
+		const roundTrip = deserialize(
+			serialize(compact),
+			CompactWithContext,
+		) as CompactWithContext & CompactIndexedClass;
+
+		expect(roundTrip.id).to.equal("next");
+		expect(roundTrip.content).to.equal(empty);
+		expect(roundTrip).not.to.have.own.property("content");
+		expect(roundTrip.__context.context).to.equal("next-head");
+	});
+
+	it("does not preserve an unregistered accessor", () => {
+		class Unregistered {
+			get content(): Uint8Array {
+				return new Uint8Array();
+			}
+
+			set content(content: Uint8Array) {
+				void content;
+			}
+		}
+		(field({ type: Uint8Array }) as unknown as PropertyDecorator)(
+			Unregistered.prototype,
+			"content",
+		);
+		(variant(0) as unknown as ClassDecorator)(Unregistered);
+
+		class Wrapped {
+			@field({ type: "string" })
+			context: string;
+		}
+		copySerialization(Unregistered, Wrapped);
+
+		expect(
+			Object.getOwnPropertyDescriptor(Wrapped.prototype, "content"),
+		).to.equal(undefined);
+	});
+
+	it("rejects inherited and already-decorated accessors", () => {
+		@variant(0)
+		class DecoratedBase {
+			@field({ type: "string" })
+			id: string;
+		}
+
+		class Derived extends DecoratedBase {
+			get content(): Uint8Array {
+				return new Uint8Array();
+			}
+
+			set content(content: Uint8Array) {
+				void content;
+			}
+		}
+		expect(() =>
+			registerIndexFieldAccessor(Derived, "content", {
+				type: Uint8Array,
+			}),
+		).to.throw("cannot inherit from a Borsh-decorated class");
+
+		class UndecoratedMiddle extends DecoratedBase {}
+		class Grandchild extends UndecoratedMiddle {
+			get content(): Uint8Array {
+				return new Uint8Array();
+			}
+
+			set content(content: Uint8Array) {
+				void content;
+			}
+		}
+		expect(() =>
+			registerIndexFieldAccessor(Grandchild, "content", {
+				type: Uint8Array,
+			}),
+		).to.throw("cannot inherit from a Borsh-decorated class");
+
+		class AlreadyDecorated {
+			get content(): Uint8Array {
+				return new Uint8Array();
+			}
+
+			set content(content: Uint8Array) {
+				void content;
+			}
+		}
+		(field({ type: Uint8Array }) as unknown as PropertyDecorator)(
+			AlreadyDecorated.prototype,
+			"content",
+		);
+		expect(() =>
+			registerIndexFieldAccessor(AlreadyDecorated, "content", {
+				type: Uint8Array,
+			}),
+		).to.throw("already registered as a Borsh field");
+	});
+
+	it("requires a two-sided accessor defined on the registered prototype", () => {
+		class GetterOnly {
+			get content(): Uint8Array {
+				return new Uint8Array();
+			}
+		}
+
+		class SetterOnly {
+			set content(content: Uint8Array) {
+				void content;
+			}
+		}
+
+		expect(() =>
+			registerIndexFieldAccessor(GetterOnly, "content", {
+				type: Uint8Array,
+			}),
+		).to.throw("must define both a getter and setter");
+		expect(() =>
+			registerIndexFieldAccessor(SetterOnly, "content", {
+				type: Uint8Array,
+			}),
+		).to.throw("must define both a getter and setter");
+		expect(() =>
+			registerIndexFieldAccessor(class Missing {}, "content", {
+				type: Uint8Array,
+			}),
+		).to.throw("must define both a getter and setter");
+	});
+
+	it("rejects wrapper field and prototype collisions", () => {
+		class IndexedClass {
+			get content(): Uint8Array {
+				return new Uint8Array();
+			}
+
+			set content(content: Uint8Array) {
+				void content;
+			}
+		}
+		registerIndexFieldAccessor(IndexedClass, "content", {
+			type: Uint8Array,
+		});
+
+		class SchemaCollision {
+			@field({ type: Uint8Array })
+			content: Uint8Array;
+		}
+		expect(() => copySerialization(IndexedClass, SchemaCollision)).to.throw(
+			"wrapper schema already contains that field",
+		);
+
+		class PrototypeCollision {
+			@field({ type: "string" })
+			context: string;
+
+			get content(): Uint8Array {
+				return new Uint8Array();
+			}
+		}
+		expect(() => copySerialization(IndexedClass, PrototypeCollision)).to.throw(
+			"wrapper prototype already defines it",
+		);
+
+		Reflect.deleteProperty(PrototypeCollision.prototype, "content");
+		copySerialization(IndexedClass, PrototypeCollision);
+		expect(
+			Object.getOwnPropertyDescriptor(PrototypeCollision.prototype, "content")
+				?.get,
+		).to.equal(
+			Object.getOwnPropertyDescriptor(IndexedClass.prototype, "content")?.get,
+		);
 	});
 });

--- a/packages/programs/data/document/document/test/index-field-accessor-persistence.spec.ts
+++ b/packages/programs/data/document/document/test/index-field-accessor-persistence.spec.ts
@@ -1,0 +1,181 @@
+import { field, variant } from "@dao-xyz/borsh";
+import { expect } from "chai";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Peerbit } from "peerbit";
+import { createRustPeerbitOptions } from "peerbit/rust";
+import { Documents, registerIndexFieldAccessor } from "../src/index.js";
+
+const EMPTY = new Uint8Array();
+const decodedContentLengths: number[] = [];
+
+@variant("index_field_accessor_document")
+class Chunk {
+	@field({ type: "string" })
+	id: string;
+
+	@field({ type: Uint8Array })
+	content: Uint8Array;
+
+	constructor(id: string, content: Uint8Array) {
+		this.id = id;
+		this.content = content;
+	}
+}
+
+@variant("index_field_accessor_index")
+class LegacyChunkIndex {
+	@field({ type: "string" })
+	id: string;
+
+	@field({ type: Uint8Array })
+	content: Uint8Array;
+
+	constructor(chunk: Chunk) {
+		this.id = chunk.id;
+		this.content = chunk.content;
+	}
+}
+
+@variant("index_field_accessor_index")
+class CompactChunkIndex {
+	@field({ type: "string" })
+	id: string;
+
+	get content(): Uint8Array {
+		return EMPTY;
+	}
+
+	set content(content: Uint8Array) {
+		decodedContentLengths.push(content.byteLength);
+	}
+
+	constructor(chunk: Chunk) {
+		this.id = chunk.id;
+	}
+}
+registerIndexFieldAccessor(CompactChunkIndex, "content", {
+	type: Uint8Array,
+});
+
+const storeId = Uint8Array.from(
+	{ length: 32 },
+	(_, index) => (index * 13 + 7) & 0xff,
+);
+const payload = Uint8Array.from(
+	{ length: 256 * 1024 },
+	(_, index) => (index * 31 + 17) & 0xff,
+);
+
+const openLegacy = (peer: Peerbit, docs: Documents<Chunk, LegacyChunkIndex>) =>
+	peer.open(docs, {
+		args: {
+			type: Chunk,
+			replicate: false,
+			index: {
+				idProperty: "id",
+				type: LegacyChunkIndex,
+				transform: (chunk) => new LegacyChunkIndex(chunk),
+			},
+		},
+	});
+
+const openCompact = (
+	peer: Peerbit,
+	docs: Documents<Chunk, CompactChunkIndex>,
+) =>
+	peer.open(docs, {
+		args: {
+			type: Chunk,
+			replicate: false,
+			index: {
+				idProperty: "id",
+				type: CompactChunkIndex,
+				transform: (chunk) => new CompactChunkIndex(chunk),
+			},
+		},
+	});
+
+const expectCompactIndex = async (
+	docs: Documents<Chunk, CompactChunkIndex>,
+) => {
+	const indexed = await docs.index.get("chunk", {
+		resolve: false,
+		remote: false,
+	});
+	expect(indexed).to.exist;
+	expect(indexed!.content).to.equal(EMPTY);
+	expect(Object.hasOwn(indexed!, "content")).to.equal(false);
+
+	const resolved = await docs.index.get("chunk", { remote: false });
+	expect(resolved?.content).to.deep.equal(payload);
+};
+
+describe("index field accessor persistence", () => {
+	for (const backend of [
+		{ label: "SQLite", options: () => ({}) },
+		{
+			label: "Rust",
+			options: () =>
+				createRustPeerbitOptions({
+					network: false,
+					indexer: { persistence: { compactAfterOperations: 1 } },
+				}),
+		},
+	]) {
+		it(`migrates legacy payload index rows with ${backend.label}`, async function () {
+			this.timeout(180_000);
+			const directory = await fs.mkdtemp(
+				path.join(os.tmpdir(), "peerbit-index-field-accessor-"),
+			);
+			let peer: Peerbit | undefined;
+
+			try {
+				peer = await Peerbit.create({ directory, ...backend.options() });
+				const legacy = await openLegacy(
+					peer,
+					new Documents<Chunk, LegacyChunkIndex>({ id: storeId }),
+				);
+				await legacy.put(new Chunk("chunk", payload), {
+					replicate: false,
+					target: "none",
+				});
+				expect(
+					(await legacy.index.get("chunk", { resolve: false }))?.content,
+				).to.deep.equal(payload);
+				const firstClone = legacy.clone() as Documents<
+					Chunk,
+					CompactChunkIndex
+				>;
+				await peer.stop();
+
+				decodedContentLengths.length = 0;
+				peer = await Peerbit.create({ directory, ...backend.options() });
+				const migrated = await openCompact(peer, firstClone);
+				await expectCompactIndex(migrated);
+				expect(decodedContentLengths).to.include(payload.byteLength);
+
+				await migrated.recover();
+				await expectCompactIndex(migrated);
+				const secondClone = migrated.clone() as Documents<
+					Chunk,
+					CompactChunkIndex
+				>;
+				await peer.stop();
+
+				decodedContentLengths.length = 0;
+				peer = await Peerbit.create({ directory, ...backend.options() });
+				const reopened = await openCompact(peer, secondClone);
+				await expectCompactIndex(reopened);
+				expect(decodedContentLengths).to.not.be.empty;
+				expect(decodedContentLengths.every((length) => length === 0)).to.equal(
+					true,
+				);
+			} finally {
+				await peer?.stop().catch(() => undefined);
+				await fs.rm(directory, { recursive: true, force: true });
+			}
+		});
+	}
+});


### PR DESCRIPTION
## Summary

- add an explicit `registerIndexFieldAccessor` opt-in for Borsh getter/setter fields used by document index transforms
- preserve only registered accessors when `Documents` adds its contextual index wrapper
- reject decorated ancestors, duplicate Borsh fields, one-sided or changed accessors, and target schema/prototype collisions
- keep copy idempotence private, per target/source, and record it only after a successful copy

This enables a schema-compatible local index migration: a large field remains in the persisted Borsh layout, while its setter can consume and discard legacy bytes and its getter can serialize an empty replacement. The full document remains in the log and still resolves normally.

## Scope

This changes local derived-index serialization only. It does not change Peerbit network messages, the sync protocol, document/log schemas, addresses, or replication behavior.

The runtime change is intentionally guarded; most of the diff is migration and misuse coverage rather than shipped machinery.

## Validation

- `@peerbit/document` TypeScript build
- 6 focused registration/collision/idempotence Borsh tests
- real SQLite legacy-row reopen, recovery rewrite, and second reopen
- real Rust snapshot legacy-row reopen, compaction rewrite, and second reopen
- Prettier and `git diff --check`

All 8 focused tests pass. An independent re-review found no P1/P2 issues.
