### PR TITLE
fix(trusted-network): normalize copied public keys

### DIFF
--- a/.changeset/silly-dingos-trust-copies.md
+++ b/.changeset/silly-dingos-trust-copies.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/trusted-network": patch
+---
+
+Canonicalize public keys from duplicate package copies and require identity-relation signers to match the relation source.

--- a/packages/programs/acl/trusted-network/src/controller.ts
+++ b/packages/programs/acl/trusted-network/src/controller.ts
@@ -1,4 +1,4 @@
-import { field, serialize, variant } from "@dao-xyz/borsh";
+import { deserialize, field, serialize, variant } from "@dao-xyz/borsh";
 import { type PeerId } from "@libp2p/interface";
 import {
 	PublicSignKey,
@@ -47,10 +47,17 @@ const openDocumentsLike = async <T, I extends Record<string, any> = any>(
 	return opened as DocumentsLike<T, I>;
 };
 
-const coercePublicKey = (publicKey: PublicSignKey | PeerId) => {
-	return publicKey instanceof PublicSignKey
-		? publicKey
-		: getPublicKeyFromPeerId(publicKey);
+const coercePublicKey = (publicKey: PublicSignKey | PeerId): PublicSignKey => {
+	if (publicKey instanceof PublicSignKey) {
+		return publicKey;
+	}
+
+	const bytes = (publicKey as { bytes?: unknown })?.bytes;
+	if (bytes instanceof Uint8Array) {
+		return deserialize(bytes, PublicSignKey);
+	}
+
+	return getPublicKeyFromPeerId(publicKey as PeerId);
 };
 const canPerformByRelation = async (
 	properties: CanPerformOperations<IdentityRelation>,
@@ -60,17 +67,15 @@ const canPerformByRelation = async (
 	const keys = await properties.entry.getPublicKeys();
 	const checkKey = async (key: PublicSignKey): Promise<boolean> => {
 		if (properties.type === "put") {
-			// TODO, this clause is only applicable when we modify the identityGraph, but it does not make sense that the canPerform method does not know what the payload will
-			// be, upon deserialization. There should be known in the `canPerform` method whether we are appending to the identityGraph.
-
-			const relation = properties.value;
-			if (relation instanceof IdentityRelation) {
-				if (!relation.from.equals(key)) {
+			try {
+				const from = coercePublicKey(properties.value.from);
+				const signer = coercePublicKey(key);
+				if (!from.equals(signer)) {
 					return false;
 				}
+			} catch {
+				return false;
 			}
-
-			// else assume the payload is accepted
 		}
 		if (isTrusted) {
 			const trusted = await isTrusted(key);
@@ -144,7 +149,9 @@ export class IdentityGraph extends Program<IdentityGraphArgs> {
 		await this.relationGraph.put(
 			new IdentityRelation({
 				to: coercePublicKey(to),
-				from: options?.identity?.publicKey || this.node.identity.publicKey,
+				from: coercePublicKey(
+					options?.identity?.publicKey || this.node.identity.publicKey,
+				),
 			}),
 			options,
 		);
@@ -204,19 +211,14 @@ export class TrustedNetwork extends Program<TrustedNetworkArgs> {
 		trustee: PublicSignKey | PeerId,
 		options?: AppendOptions<Operation>,
 	) {
-		const key =
-			trustee instanceof PublicSignKey
-				? trustee
-				: getPublicKeyFromPeerId(trustee);
+		const key = coercePublicKey(trustee);
+		const truster = coercePublicKey(this.node.identity.publicKey);
 
-		const existingRelation = await this.getRelation(
-			key,
-			this.node.identity.publicKey,
-		);
+		const existingRelation = await this.getRelation(key, truster);
 		if (!existingRelation) {
 			const relation = new IdentityRelation({
 				to: key,
-				from: this.node.identity.publicKey,
+				from: truster,
 			});
 			await this.trustGraph!.put(relation);
 			return relation;
@@ -252,15 +254,18 @@ export class TrustedNetwork extends Program<TrustedNetworkArgs> {
 	 * @returns true, if trusted
 	 */
 	async isTrusted(
-		trustee: PublicSignKey,
-		truster: PublicSignKey = this.rootTrust,
+		trustee: PublicSignKey | PeerId,
+		truster: PublicSignKey | PeerId = this.rootTrust,
 	): Promise<boolean> {
-		if (trustee.equals(this.rootTrust)) {
+		const trusteeKey = coercePublicKey(trustee);
+		const trusterKey = coercePublicKey(truster);
+
+		if (trusteeKey.equals(this.rootTrust)) {
 			return true;
 		}
 
 		// Fast local-only check first. This avoids stalling writes on cold-start or churn.
-		if (await this._isTrustedLocal(trustee, truster)) {
+		if (await this._isTrustedLocal(trusteeKey, trusterKey)) {
 			return true;
 		}
 

--- a/packages/programs/acl/trusted-network/test/index.spec.ts
+++ b/packages/programs/acl/trusted-network/test/index.spec.ts
@@ -1,6 +1,11 @@
 import { serialize, variant } from "@dao-xyz/borsh";
-import { AccessError, Ed25519Keypair, type Identity } from "@peerbit/crypto";
-import { Secp256k1PublicKey } from "@peerbit/crypto";
+import {
+	AccessError,
+	Ed25519Keypair,
+	type Identity,
+	PublicSignKey,
+	Secp256k1PublicKey,
+} from "@peerbit/crypto";
 import { Documents, SearchRequest } from "@peerbit/document";
 import { Program } from "@peerbit/program";
 import { TestSession } from "@peerbit/test-utils";
@@ -29,6 +34,9 @@ const createIdentity = async () => {
 	};
 };
 
+const asStructuralPublicKey = (key: PublicSignKey): PublicSignKey =>
+	({ bytes: key.bytes.slice() }) as unknown as PublicSignKey;
+
 // Tests in this workspace run in parallel across packages; allow extra headroom for
 // network/replication warmup under CI load.
 // CI can be significantly slower/noisier than local runs; replicator discovery is network-driven.
@@ -47,6 +55,107 @@ class AnyCanAppendIdentityGraph extends IdentityGraph {
 		return true;
 	}
 }
+describe("copy-stable public keys", () => {
+	it("canonicalizes structural Ed25519 and secp256k1 keys", async () => {
+		const keys = [
+			(await Ed25519Keypair.create()).publicKey,
+			await Secp256k1PublicKey.recover(await Wallet.createRandom()),
+		];
+
+		for (const key of keys) {
+			const local = new TrustedNetwork({ rootTrust: key });
+			expect(local.rootTrust).to.equal(key);
+
+			const structural = asStructuralPublicKey(key);
+			expect(structural).not.to.be.instanceof(PublicSignKey);
+			const normalized = new TrustedNetwork({ rootTrust: structural });
+			expect(normalized.rootTrust).to.be.instanceof(PublicSignKey);
+			expect(normalized.rootTrust.equals(key)).to.be.true;
+			expect(await normalized.isTrusted(structural)).to.be.true;
+		}
+	});
+
+	it("canonicalizes structural keys used by addRelation", async () => {
+		const signer = await Ed25519Keypair.create();
+		const trustee = await Secp256k1PublicKey.recover(
+			await Wallet.createRandom(),
+		);
+		let relation: IdentityRelation | undefined;
+		let receivedOptions: unknown;
+		const store = new IdentityGraph({
+			relationGraph: {
+				put: async (value: IdentityRelation, options: unknown) => {
+					relation = value;
+					receivedOptions = options;
+				},
+			} as any,
+		});
+		store.node = { identity: signer } as any;
+		const identity: Identity = {
+			publicKey: asStructuralPublicKey(signer.publicKey),
+			sign: signer.sign.bind(signer),
+		};
+		const options = { identity };
+
+		await store.addRelation(asStructuralPublicKey(trustee), options);
+
+		expect(relation?.from).to.be.instanceof(PublicSignKey);
+		expect(relation?.from.equals(signer.publicKey)).to.be.true;
+		expect(relation?.to).to.be.instanceof(PublicSignKey);
+		expect(relation?.to.equals(trustee)).to.be.true;
+		expect(receivedOptions).to.equal(options);
+	});
+
+	it("requires every structural relation put to match its signer", async () => {
+		const graph = new IdentityGraph();
+		const ed25519 = (await Ed25519Keypair.create()).publicKey;
+		const secp256k1 = await Secp256k1PublicKey.recover(
+			await Wallet.createRandom(),
+		);
+		const canPut = (from: PublicSignKey, signer: PublicSignKey) =>
+			graph.canPerform({
+				type: "put",
+				value: { from: asStructuralPublicKey(from) },
+				entry: {
+					getPublicKeys: async () => [asStructuralPublicKey(signer)],
+				},
+			} as any);
+
+		expect(await canPut(ed25519, ed25519)).to.be.true;
+		expect(await canPut(secp256k1, secp256k1)).to.be.true;
+		expect(await canPut(ed25519, secp256k1)).to.be.false;
+	});
+
+	it("accepts structural keys in add and getRelation", async () => {
+		const root = (await Ed25519Keypair.create()).publicKey;
+		const trustee = await Secp256k1PublicKey.recover(
+			await Wallet.createRandom(),
+		);
+		let stored: IdentityRelation | undefined;
+		const network = new TrustedNetwork({ rootTrust: root });
+		network.node = { identity: { publicKey: root } } as any;
+		network.trustGraph = {
+			index: {
+				get: async (id: Uint8Array) =>
+					stored && equals(stored.id, id) ? stored : undefined,
+			},
+			put: async (relation: IdentityRelation) => {
+				stored = relation;
+			},
+		} as any;
+
+		const relation = await network.add(asStructuralPublicKey(trustee));
+		expect(relation.to.equals(trustee)).to.be.true;
+		expect(relation.to).to.be.instanceof(PublicSignKey);
+
+		const found = await network.getRelation(
+			asStructuralPublicKey(root),
+			asStructuralPublicKey(trustee),
+		);
+		expect(found?.id).to.deep.equal(relation.id);
+	});
+});
+
 describe("index", () => {
 	describe("identity-graph", () => {
 		let session: TestSession, identites: Identity[], programs: Program[];


### PR DESCRIPTION
## Summary

- canonicalize public keys originating from a second physical `@peerbit/crypto` package copy
- require every identity-relation put to have a parseable `from` key matching its signer
- preserve normal PeerId conversion and the existing wire format

## Why

JavaScript `instanceof` is false across duplicate package copies. That made valid foreign-copy keys fail at TrustedNetwork boundaries and allowed the relation-source signer check to be skipped for structurally valid relation objects. The new boundary normalization uses the key serialization as the stable representation and denies malformed inputs.

This is local object-identity hardening; it does not add or change a network protocol, address, or serialized schema.

## Verification

- `pnpm --filter @peerbit/trusted-network run build`
- focused copy-stability tests: 4 passing
- root ESLint on changed TypeScript files
- independent review: actual duplicate-package Ed25519 and secp256k1 smoke tests passed; malformed, mismatched, and untrusted signers denied
- `git diff --check`