### PR TITLE
fix(pubsub): cancel stale shard joins

### DIFF
--- a/.changeset/quick-shards-rejoin.md
+++ b/.changeset/quick-shards-rejoin.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/pubsub": patch
+---
+
+Cancel stale fanout shard joins when automatic topic-root candidates change so subscription reconciliation can retry the current root without waiting for the old join timeout.

--- a/packages/transport/pubsub/src/index.ts
+++ b/packages/transport/pubsub/src/index.ts
@@ -374,9 +374,11 @@ export class TopicControlPlane
 	private ensureFanoutChannelInFlight = new Map<
 		string,
 		{
+			abortController: AbortController;
 			candidateGeneration: string;
 			lifecycleRevision: number;
 			opening: Promise<void>;
+			settled: Promise<void>;
 		}
 	>();
 	private pendingTopicRootQueries = new Map<
@@ -574,6 +576,11 @@ export class TopicControlPlane
 		this.topicControlPlaneStopping = true;
 		this.topicControlPlaneLifecycleRevision += 1;
 		this.reconcileShardOverlaysDirty = false;
+		for (const opening of this.ensureFanoutChannelInFlight.values()) {
+			opening.abortController.abort(
+				new AbortError("topic control plane stopped"),
+			);
+		}
 		this.ensureFanoutChannelInFlight.clear();
 		if (this._onFanoutPeerUnreachable) {
 			this.fanout.removeEventListener(
@@ -873,6 +880,14 @@ export class TopicControlPlane
 	}
 
 	private scheduleReconcileShardOverlays() {
+		const candidateGeneration = this.getTopicRootCandidateGeneration();
+		for (const opening of this.ensureFanoutChannelInFlight.values()) {
+			if (opening.candidateGeneration !== candidateGeneration) {
+				opening.abortController.abort(
+					new AbortError("topic root candidates changed"),
+				);
+			}
+		}
 		this.reconcileShardOverlaysDirty = true;
 		if (!this.started || this.stopping || this.topicControlPlaneStopping)
 			return;
@@ -1524,6 +1539,12 @@ export class TopicControlPlane
 		const lifecycleRevision = this.topicControlPlaneLifecycleRevision;
 		for (;;) {
 			this.assertTopicControlPlaneActive(lifecycleRevision);
+			if (options?.signal?.aborted) {
+				throw (
+					options.signal.reason ??
+					new AbortError("fanout channel opening aborted")
+				);
+			}
 			const candidateGeneration = this.getTopicRootCandidateGeneration();
 			const active = this.ensureFanoutChannelInFlight.get(topic);
 			if (
@@ -1536,19 +1557,54 @@ export class TopicControlPlane
 					if (options?.signal?.aborted) throw error;
 					this.assertTopicControlPlaneActive(lifecycleRevision);
 				}
+				await withAbort(active.settled, options?.signal);
+				if (this.ensureFanoutChannelInFlight.get(topic) === active) {
+					this.ensureFanoutChannelInFlight.delete(topic);
+				}
 				continue;
+			}
+			if (active) {
+				active.abortController.abort(
+					new AbortError("topic root candidates changed"),
+				);
+				await withAbort(active.settled, options?.signal);
+				if (this.ensureFanoutChannelInFlight.get(topic) === active) {
+					this.ensureFanoutChannelInFlight.delete(topic);
+				}
+				continue;
+			}
+
+			const abortController = new AbortController();
+			const abortFromCaller = () => {
+				abortController.abort(
+					options?.signal?.reason ??
+						new AbortError("fanout channel opening aborted"),
+				);
+			};
+			if (options?.signal?.aborted) {
+				abortFromCaller();
+			} else {
+				options?.signal?.addEventListener("abort", abortFromCaller, {
+					once: true,
+				});
 			}
 
 			const opening = this.ensureFanoutChannelOnce(
 				topic,
-				options,
+				{ ...options, signal: abortController.signal },
 				lifecycleRevision,
 				candidateGeneration,
 			);
+			let resolveSettled!: () => void;
+			const settled = new Promise<void>((resolve) => {
+				resolveSettled = resolve;
+			});
 			const inFlight = {
+				abortController,
 				candidateGeneration,
 				lifecycleRevision,
 				opening,
+				settled,
 			};
 			this.ensureFanoutChannelInFlight.set(topic, inFlight);
 			try {
@@ -1561,14 +1617,25 @@ export class TopicControlPlane
 			} catch (error) {
 				if (options?.signal?.aborted) throw error;
 				this.assertTopicControlPlaneActive(lifecycleRevision);
+				if (abortController.signal.aborted) {
+					if (this.ensureFanoutChannelInFlight.get(topic) === inFlight) {
+						const staleJoin = this.fanoutChannels
+							.get(topic)
+							?.join.catch(() => {});
+						if (staleJoin) await withAbort(staleJoin, options?.signal);
+					}
+					continue;
+				}
 				if (candidateGeneration !== this.getTopicRootCandidateGeneration()) {
 					continue;
 				}
 				throw error;
 			} finally {
+				options?.signal?.removeEventListener("abort", abortFromCaller);
 				if (this.ensureFanoutChannelInFlight.get(topic) === inFlight) {
 					this.ensureFanoutChannelInFlight.delete(topic);
 				}
+				resolveSettled();
 			}
 		}
 	}

--- a/packages/transport/pubsub/test/subscribe-races.spec.ts
+++ b/packages/transport/pubsub/test/subscribe-races.spec.ts
@@ -12,10 +12,11 @@ import {
 	type DeliveryMode,
 	MessageHeader,
 } from "@peerbit/stream-interface";
-import { delay, waitForResolved } from "@peerbit/time";
+import { AbortError, delay, waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
 import sinon from "sinon";
 import {
+	FanoutChannel,
 	FanoutTree,
 	TopicControlPlane,
 	TopicRootControlPlane,
@@ -191,6 +192,39 @@ describe("pubsub (subscribe race regressions)", function () {
 			resolve = next;
 		});
 		return { promise, resolve };
+	};
+
+	const stubFirstFanoutJoinUntilAbort = (
+		expectedRoot: string,
+		releaseAfterAbort?: Promise<void>,
+	) => {
+		const started = deferred();
+		const aborted = deferred();
+		const join = sinon
+			.stub(FanoutChannel.prototype, "join")
+			.callsFake(function (this: FanoutChannel, _options, joinOptions) {
+				expect(this.root).to.equal(expectedRoot);
+				if (join.callCount > 1) return Promise.resolve();
+				started.resolve();
+				return new Promise<void>((_resolve, reject) => {
+					const onAbort = async () => {
+						aborted.resolve();
+						await releaseAfterAbort;
+						reject(
+							joinOptions?.signal?.reason ??
+								new AbortError("stale join aborted"),
+						);
+					};
+					if (joinOptions?.signal?.aborted) {
+						onAbort();
+					} else {
+						joinOptions?.signal?.addEventListener("abort", onAbort, {
+							once: true,
+						});
+					}
+				});
+			});
+		return { aborted: aborted.promise, join, started: started.promise };
 	};
 
 	afterEach(async () => {
@@ -436,6 +470,138 @@ describe("pubsub (subscribe race regressions)", function () {
 		expect(channelListenerAdds).to.equal(4);
 	});
 
+	it("aborts a stale shard join when auto-root candidates change", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const staleRoot = "stale-join-root";
+		const addedCandidate = "candidate-that-moves-the-root";
+
+		internals.scheduleHostOwnedShardRoots = () => {};
+		internals.scheduleAutoTopicRootCandidatesBroadcast = () => {};
+		expect(
+			internals.mergeAutoTopicRootCandidatesFromPeer([staleRoot]),
+		).to.equal(true);
+		const beforeCandidates =
+			pubsub.topicRootControlPlane.getTopicRootCandidates();
+		const afterCandidates = [...beforeCandidates, addedCandidate];
+		const { topic } = findCandidateTransitionTopic(
+			beforeCandidates,
+			afterCandidates,
+			staleRoot,
+			pubsub.publicKeyHash,
+		);
+		const staleGeneration = internals.getTopicRootCandidateGeneration();
+		internals.resolveShardRootState = async () => {
+			const candidateGeneration =
+				internals.getTopicRootCandidateGeneration();
+			return {
+				root:
+					candidateGeneration === staleGeneration
+						? staleRoot
+						: pubsub.publicKeyHash,
+				candidateGeneration,
+			};
+		};
+		const staleJoin = stubFirstFanoutJoinUntilAbort(staleRoot);
+
+		try {
+			const opening = internals.ensureFanoutChannel(topic);
+			await staleJoin.started;
+
+			expect(
+				internals.mergeAutoTopicRootCandidatesFromPeer([addedCandidate]),
+			).to.equal(true);
+			await Promise.race([
+				staleJoin.aborted,
+				delay(1_000).then(() => {
+					throw new Error("stale join was not aborted");
+				}),
+			]);
+			await opening;
+
+			expect(internals.fanoutChannels.get(topic)?.root).to.equal(
+				pubsub.publicKeyHash,
+			);
+		} finally {
+			staleJoin.join.restore();
+		}
+	});
+
+	it("retries a stale join when candidate generation cycles back", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const pubsub = session.peers[0]!.services.pubsub;
+		const fanout = session.peers[0]!.services.fanout;
+		const internals = pubsub as any;
+		const staleRoot = "stale-join-root-after-generation-cycle";
+		const addedCandidate = "transient-root-candidate";
+
+		internals.scheduleHostOwnedShardRoots = () => {};
+		internals.scheduleAutoTopicRootCandidatesBroadcast = () => {};
+		internals.reconcileShardOverlays = async () => {};
+		expect(
+			internals.mergeAutoTopicRootCandidatesFromPeer([staleRoot]),
+		).to.equal(true);
+		const originalCandidates =
+			pubsub.topicRootControlPlane.getTopicRootCandidates();
+		const { topic } = findCandidateTransitionTopic(
+			originalCandidates,
+			[...originalCandidates, addedCandidate],
+			staleRoot,
+		);
+		const originalGeneration = internals.getTopicRootCandidateGeneration();
+		internals.resolveShardRootState = async () => ({
+			root: staleRoot,
+			candidateGeneration: internals.getTopicRootCandidateGeneration(),
+		});
+
+		const waitFor = sinon.stub(fanout, "waitFor").resolves([]);
+		const releaseStaleJoin = deferred();
+		const staleJoin = stubFirstFanoutJoinUntilAbort(
+			staleRoot,
+			releaseStaleJoin.promise,
+		);
+
+		try {
+			const opening = internals.ensureFanoutChannel(topic);
+			await staleJoin.started;
+
+			pubsub.topicRootControlPlane.setTopicRootCandidates([
+				...originalCandidates,
+				addedCandidate,
+			]);
+			internals.scheduleReconcileShardOverlays();
+			await staleJoin.aborted;
+
+			const externalAbort = new AbortController();
+			const externalReason = new AbortError("caller stopped waiting");
+			const externallyCancelled = internals.ensureFanoutChannel(topic, {
+				signal: externalAbort.signal,
+			});
+			externalAbort.abort(externalReason);
+			await expect(externallyCancelled).to.be.rejectedWith(externalReason);
+
+			const concurrentOpening = internals.ensureFanoutChannel(topic);
+			pubsub.topicRootControlPlane.setTopicRootCandidates(originalCandidates);
+			internals.scheduleReconcileShardOverlays();
+
+			releaseStaleJoin.resolve();
+			await opening;
+			await concurrentOpening;
+
+			expect(internals.getTopicRootCandidateGeneration()).to.equal(
+				originalGeneration,
+			);
+			expect(staleJoin.join.callCount).to.equal(2);
+			expect(internals.fanoutChannels.get(topic)?.root).to.equal(staleRoot);
+			expect(internals.ensureFanoutChannelInFlight.size).to.equal(0);
+		} finally {
+			releaseStaleJoin.resolve();
+			staleJoin.join.restore();
+			waitFor.restore();
+		}
+	});
+
 	it("serializes concurrent opens for the same shard channel", async () => {
 		session = await createDisconnectedSessionWithPerPeerRoots(1);
 		const pubsub = session.peers[0]!.services.pubsub;
@@ -476,9 +642,11 @@ describe("pubsub (subscribe race regressions)", function () {
 		const candidateGeneration = internals.getTopicRootCandidateGeneration();
 		const lifecycleRevision = internals.topicControlPlaneLifecycleRevision;
 		internals.ensureFanoutChannelInFlight.set(shardTopic, {
+			abortController: new AbortController(),
 			candidateGeneration,
 			lifecycleRevision: lifecycleRevision - 1,
 			opening: new Promise<void>(() => {}),
+			settled: Promise.resolve(),
 		});
 
 		let settled = false;


### PR DESCRIPTION
## Summary

- cancel in-flight fanout shard joins when automatic root candidates change
- serialize generation handoff through an identity-safe cleanup boundary
- keep caller aborts terminal and lifecycle cleanup bounded
- cover root changes, A-to-B-to-A generation cycles, concurrent openers, external aborts, and stale lifecycle entries

## Root cause

In a three-peer source-only star, candidate gossip reached the late peer in about 100 ms, but reconciliation was already blocked awaiting obsolete fanout-root joins. Those joins remained alive until the 60-second FanoutTree join timeout, delaying subscription discovery and SharedLog synchronization. This is local pubsub lifecycle coordination; it does not change the wire protocol.

## Validation

- @peerbit/pubsub full suite: 166 passing
- focused root-change, generation-cycle/concurrent-abort, and old-lifecycle regressions: 3 passing
- distributed-backup-v2 exact 1 MiB loopback source-only-star validation: five final/refined runs passed; B completed in 211-646 ms and C final data progress in 321-1,229 ms
- every downstream run matched SHA-256 f6a34d4c79c3d12c297589206bf216b084347471a53ea5e7fe9a46bd1230f098 and CRC-32 4c312e16, validating B, C, and B-recheck
- no downstream runtime errors or orphaned workers
- git diff check and ESLint pass (two pre-existing unused-import warnings remain)