### PR TITLE
test(shared-log): await leave convergence

### DIFF
--- a/packages/programs/data/shared-log/test/sharding.spec.ts
+++ b/packages/programs/data/shared-log/test/sharding.spec.ts
@@ -2652,14 +2652,7 @@ testSetups.forEach((setup) => {
 				try {
 					await leavingDb.close();
 
-					await Promise.all([
-						waitForResolved(async () =>
-							expect(await sourceDb.log.replicationIndex?.getSize()).equal(2),
-						),
-						waitForResolved(async () =>
-							expect(await targetDb.log.replicationIndex?.getSize()).equal(2),
-						),
-					]);
+					await waitForReplicationIndexes(2, sourceDb, targetDb);
 
 					await waitForResolved(
 						async () =>


### PR DESCRIPTION
## Summary
- use the existing 120-second replication-index convergence helper for the peer-leave precondition
- keep the dropped-repair, target-hash, and full-coverage assertions unchanged

## Why
The old generic wait allowed 10 seconds, but teardown propagation is deliberately eventual. In 20 focused trials, six valid convergences took about 22 seconds; this made the unrelated precondition intermittently fail before the repair behavior was exercised.

## Validation
- focused test: 20/20 passing
- pnpm run build
- git diff --check

No changeset: this changes test timing only, not published behavior.