### PR TITLE
fix(pubsub): bound automatic root candidates

### DIFF
--- a/.changeset/calm-roots-bound.md
+++ b/.changeset/calm-roots-bound.md
@@ -1,0 +1,7 @@
+---
+"@peerbit/network-rust": patch
+"@peerbit/pubsub-interface": patch
+"@peerbit/pubsub": patch
+---
+
+Bound automatic topic-root candidate frames and managed state to canonical SHA-256 hashes, with matching TypeScript and native validation and no-op reconciliation guards.

--- a/packages/transport/network-rust/src/topic_control.rs
+++ b/packages/transport/network-rust/src/topic_control.rs
@@ -22,6 +22,12 @@ pub const PUBSUB_VARIANT_TOPIC_ROOT_QUERY_RESPONSE: u8 = 7;
 
 /// `AUTO_TOPIC_ROOT_CANDIDATES_MAX` in `pubsub/src/index.ts`.
 pub const AUTO_TOPIC_ROOT_CANDIDATES_MAX: usize = 64;
+/// A public-key SHA-256 hash encoded as canonical padded Base64.
+pub const TOPIC_ROOT_CANDIDATE_BYTES: usize = 44;
+/// Variant byte + vector length + 64 length-prefixed canonical candidates.
+pub const TOPIC_ROOT_CANDIDATES_FRAME_MAX: usize =
+    1 + 4 + AUTO_TOPIC_ROOT_CANDIDATES_MAX * (4 + TOPIC_ROOT_CANDIDATE_BYTES);
+const TOPIC_ROOT_CANDIDATE_LAST_SEXTETS: &[u8] = b"AEIMQUYcgkosw048";
 
 /// A decoded `PubSubMessage`. `Data` payload bytes are reported as a range
 /// into the input frame so the host can alias them without a copy.
@@ -72,6 +78,45 @@ fn read_bool(reader: &mut Reader) -> WireResult<bool> {
     }
 }
 
+fn is_base64_byte(value: u8) -> bool {
+    value.is_ascii_alphanumeric() || matches!(value, b'+' | b'/')
+}
+
+/// Standard padded Base64 has a unique 44-byte representation for a 32-byte
+/// SHA-256 digest. The last sextet can only carry four data bits, so its low
+/// two bits must be zero.
+pub fn is_canonical_topic_root_candidate(candidate: &str) -> bool {
+    let bytes = candidate.as_bytes();
+    bytes.len() == TOPIC_ROOT_CANDIDATE_BYTES
+        && bytes[..42].iter().copied().all(is_base64_byte)
+        && TOPIC_ROOT_CANDIDATE_LAST_SEXTETS.contains(&bytes[42])
+        && bytes[43] == b'='
+}
+
+fn read_topic_root_candidates(reader: &mut Reader, frame_length: usize) -> WireResult<Vec<String>> {
+    if frame_length > TOPIC_ROOT_CANDIDATES_FRAME_MAX {
+        return Err("topic-root candidates frame exceeds limit".to_string());
+    }
+    let length = reader.u32_le()? as usize;
+    if length > AUTO_TOPIC_ROOT_CANDIDATES_MAX {
+        return Err("too many topic-root candidates".to_string());
+    }
+    let mut candidates = Vec::with_capacity(length);
+    for _ in 0..length {
+        let candidate_length = reader.u32_le()? as usize;
+        if candidate_length != TOPIC_ROOT_CANDIDATE_BYTES {
+            return Err("invalid topic-root candidate length".to_string());
+        }
+        let candidate = std::str::from_utf8(reader.take(candidate_length)?)
+            .map_err(|_| "invalid utf8 in topic-root candidate".to_string())?;
+        if !is_canonical_topic_root_candidate(candidate) {
+            return Err("invalid topic-root candidate".to_string());
+        }
+        candidates.push(candidate.to_string());
+    }
+    Ok(candidates)
+}
+
 pub fn decode_pubsub_message(frame: &[u8]) -> WireResult<DecodedPubSubMessage> {
     let mut reader = Reader::new(frame);
     let variant = reader.u8()?;
@@ -100,7 +145,7 @@ pub fn decode_pubsub_message(frame: &[u8]) -> WireResult<DecodedPubSubMessage> {
             topics: reader.string_vec()?,
         },
         PUBSUB_VARIANT_TOPIC_ROOT_CANDIDATES => DecodedPubSubMessage::TopicRootCandidates {
-            candidates: reader.string_vec()?,
+            candidates: read_topic_root_candidates(&mut reader, frame.len())?,
         },
         PUBSUB_VARIANT_PEER_UNAVAILABLE => DecodedPubSubMessage::PeerUnavailable {
             public_key_hash: reader.string()?,
@@ -255,18 +300,20 @@ fn js_string_sort(values: &mut [String]) {
     });
 }
 
-/// `normalizeAutoTopicRootCandidates`: dedupe (dropping empties), always
-/// include self, sort by UTF-16 code units and cap at
+/// `normalizeAutoTopicRootCandidates`: retain canonical hashes, dedupe, add a
+/// canonical self hash before the shared UTF-16 sort and cap at
 /// [`AUTO_TOPIC_ROOT_CANDIDATES_MAX`].
 pub fn normalize_auto_candidates(candidates: &[String], me: &str) -> Vec<String> {
     let mut unique: HashSet<&str> = HashSet::new();
     for candidate in candidates {
-        if candidate.is_empty() {
+        if !is_canonical_topic_root_candidate(candidate) {
             continue;
         }
         unique.insert(candidate.as_str());
     }
-    unique.insert(me);
+    if is_canonical_topic_root_candidate(me) {
+        unique.insert(me);
+    }
     let mut sorted: Vec<String> = unique.into_iter().map(|value| value.to_string()).collect();
     js_string_sort(&mut sorted);
     sorted.truncate(AUTO_TOPIC_ROOT_CANDIDATES_MAX);
@@ -364,6 +411,17 @@ mod tests {
         values.iter().map(|value| value.to_string()).collect()
     }
 
+    fn candidate(index: usize) -> String {
+        const ALPHABET: &[u8; 64] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let mut value = vec![b'A'; TOPIC_ROOT_CANDIDATE_BYTES];
+        value[0] = ALPHABET[(index / 64) % 64];
+        value[1] = ALPHABET[index % 64];
+        value[42] = b'A';
+        value[43] = b'=';
+        String::from_utf8(value).unwrap()
+    }
+
     #[test]
     fn pubsub_data_encodes_borsh_layout() {
         let encoded = encode_pubsub_data(&strings(&["t1", "t2"]), true, &[7, 8]);
@@ -395,12 +453,13 @@ mod tests {
 
     #[test]
     fn pubsub_messages_roundtrip() {
+        let root_candidates = vec![candidate(1), candidate(2)];
         let frames = [
             encode_pubsub_data(&strings(&["a"]), false, &[1, 2, 3]),
             encode_subscribe(&strings(&["a", "b"]), true),
             encode_unsubscribe(&strings(&[])),
             encode_get_subscribers(&strings(&["x"])),
-            encode_topic_root_candidates(&strings(&["c1", "c2"])),
+            encode_topic_root_candidates(&root_candidates),
             encode_peer_unavailable("hash", u64::MAX, 0, &strings(&["t"])),
             encode_topic_root_query(42, "topic"),
             encode_topic_root_query_response(42, "topic", Some("root")),
@@ -422,7 +481,7 @@ mod tests {
                 topics: strings(&["x"]),
             },
             DecodedPubSubMessage::TopicRootCandidates {
-                candidates: strings(&["c1", "c2"]),
+                candidates: root_candidates,
             },
             DecodedPubSubMessage::PeerUnavailable {
                 public_key_hash: "hash".to_string(),
@@ -467,6 +526,30 @@ mod tests {
         let mut trailing = encode_unsubscribe(&strings(&["a"]));
         trailing.push(0);
         assert!(decode_pubsub_message(&trailing).is_err());
+
+        let mut too_many_candidates = vec![PUBSUB_VARIANT_TOPIC_ROOT_CANDIDATES];
+        too_many_candidates.extend_from_slice(&65u32.to_le_bytes());
+        assert!(decode_pubsub_message(&too_many_candidates).is_err());
+
+        let invalid_candidates = [
+            "short",
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA_",
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB=",
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        ];
+        for invalid in invalid_candidates {
+            assert!(
+                decode_pubsub_message(&encode_topic_root_candidates(&strings(&[invalid]))).is_err(),
+                "accepted invalid candidate {invalid:?}",
+            );
+        }
+
+        let mut oversized =
+            encode_topic_root_candidates(&vec![candidate(0); AUTO_TOPIC_ROOT_CANDIDATES_MAX]);
+        oversized.push(0);
+        assert!(oversized.len() > TOPIC_ROOT_CANDIDATES_FRAME_MAX);
+        assert!(decode_pubsub_message(&oversized).is_err());
     }
 
     #[test]
@@ -498,13 +581,28 @@ mod tests {
 
     #[test]
     fn normalize_auto_candidates_sorts_and_caps() {
-        let normalized = normalize_auto_candidates(&strings(&["b", "", "a", "b"]), "me");
-        assert_eq!(normalized, strings(&["a", "b", "me"]));
+        let me = candidate(0);
+        let one = candidate(1);
+        let two = candidate(2);
+        let normalized = normalize_auto_candidates(
+            &[two.clone(), "invalid".to_string(), one.clone(), two.clone()],
+            &me,
+        );
+        assert_eq!(normalized, vec![me.clone(), one, two]);
 
-        let many: Vec<String> = (0..80).map(|i| format!("peer-{i:03}")).collect();
-        let normalized = normalize_auto_candidates(&many, "peer-000");
+        let many: Vec<String> = (0..80).map(candidate).collect();
+        let normalized = normalize_auto_candidates(&many, &me);
         assert_eq!(normalized.len(), AUTO_TOPIC_ROOT_CANDIDATES_MAX);
-        assert_eq!(normalized[0], "peer-000");
+        assert!(normalized.contains(&me));
+        assert!(normalized
+            .windows(2)
+            .all(|pair| !js_string_lt(&pair[1], &pair[0])));
+        assert!(normalized
+            .iter()
+            .all(|candidate| is_canonical_topic_root_candidate(candidate)));
+
+        let high_self = candidate(80);
+        assert!(!normalize_auto_candidates(&many[..64], &high_self).contains(&high_self));
     }
 
     #[test]

--- a/packages/transport/network-rust/test/topic-control.spec.ts
+++ b/packages/transport/network-rust/test/topic-control.spec.ts
@@ -12,10 +12,12 @@ import {
 	PubSubData,
 	PubSubMessage,
 	Subscribe,
+	TOPIC_ROOT_CANDIDATES_MAX,
 	TopicRootCandidates,
 	TopicRootQuery,
 	TopicRootQueryResponse,
 	Unsubscribe,
+	isCanonicalTopicRootCandidate,
 } from "@peerbit/pubsub-interface";
 import type { RustTopicControl } from "@peerbit/stream";
 import { expect } from "chai";
@@ -55,6 +57,12 @@ const randomUtf16String = (rand: () => number, maxUnits: number) => {
 	return String.fromCharCode(...units);
 };
 
+const candidate = (index: number) => {
+	const alphabet =
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+	return `${alphabet[Math.floor(index / 64) % 64]}${alphabet[index % 64]}${"A".repeat(40)}A=`;
+};
+
 describe("topic-control parity", () => {
 	let topicControl: RustTopicControl;
 
@@ -80,7 +88,9 @@ describe("topic-control parity", () => {
 		new Subscribe({ topics: [], requestSubscribers: false }),
 		new Unsubscribe({ topics: ["t1", "t2"] }),
 		new GetSubscribers({ topics: ["héllo"] }),
-		new TopicRootCandidates({ candidates: ["c1", "c2", "c3"] }),
+		new TopicRootCandidates({
+			candidates: [candidate(1), candidate(2), candidate(3)],
+		}),
 		new PeerUnavailable({
 			publicKeyHash: "hash",
 			session: 18446744073709551615n,
@@ -249,6 +259,22 @@ describe("topic-control parity", () => {
 		];
 		const trailing = serialize(new Unsubscribe({ topics: ["a"] }));
 		bad.push(new Uint8Array([...trailing, 0]));
+		bad.push(
+			serialize(new TopicRootCandidates({ candidates: ["not-a-hash"] })),
+			serialize(
+				new TopicRootCandidates({
+					candidates: [`${"A".repeat(42)}B=`],
+				}),
+			),
+			serialize(
+				new TopicRootCandidates({
+					candidates: Array.from(
+						{ length: TOPIC_ROOT_CANDIDATES_MAX + 1 },
+						(_, index) => candidate(index),
+					),
+				}),
+			),
+		);
 		for (const frame of bad) {
 			expect(() => topicControl.decodePubSubMessage(frame)).to.throw();
 			expect(() => PubSubMessage.from(frame)).to.throw();
@@ -287,24 +313,25 @@ describe("topic-control parity", () => {
 		const tsNormalize = (candidates: string[], me: string) => {
 			const unique = new Set<string>();
 			for (const c of candidates) {
-				if (!c) continue;
+				if (!isCanonicalTopicRootCandidate(c)) continue;
 				unique.add(c);
 			}
-			unique.add(me);
+			if (isCanonicalTopicRootCandidate(me)) unique.add(me);
 			const sorted = [...unique].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
-			return sorted.slice(0, 64);
+			return sorted.slice(0, TOPIC_ROOT_CANDIDATES_MAX);
 		};
 		const cases: string[][] = [
 			[],
-			["b", "a", "b", ""],
-			["z", "y", "x"],
-			["\u{1d400}", "Ａ"], // surrogate-pair vs BMP sort order
-			Array.from({ length: 100 }, (_, i) => `peer-${(i * 7) % 100}`),
+			[candidate(2), candidate(1), candidate(2), ""],
+			[candidate(12), candidate(11), candidate(10)],
+			["\u{1d400}", "Ａ"],
+			Array.from({ length: 100 }, (_, i) => candidate((i * 7) % 100)),
 		];
+		const me = candidate(0);
 		for (const candidates of cases) {
 			expect(
-				topicControl.normalizeAutoCandidates(candidates, "me"),
-			).to.deep.equal(tsNormalize(candidates, "me"));
+				topicControl.normalizeAutoCandidates(candidates, me),
+			).to.deep.equal(tsNormalize(candidates, me));
 		}
 	});
 

--- a/packages/transport/pubsub-interface/src/index.ts
+++ b/packages/transport/pubsub-interface/src/index.ts
@@ -177,11 +177,16 @@ export interface PubSub
 }
 
 export {
+	assertCanonicalTopicRootCandidates,
+	assertTopicRootCandidatesFrame,
 	GetSubscribers,
+	isCanonicalTopicRootCandidate,
 	PeerUnavailable,
 	PubSubData,
 	PubSubMessage,
 	Subscribe,
+	TOPIC_ROOT_CANDIDATES_MAX,
+	TOPIC_ROOT_CANDIDATES_MAX_FRAME_BYTES,
 	TopicRootCandidates,
 	TopicRootQuery,
 	TopicRootQueryResponse,

--- a/packages/transport/pubsub-interface/src/messages.ts
+++ b/packages/transport/pubsub-interface/src/messages.ts
@@ -8,6 +8,69 @@ import {
 } from "@dao-xyz/borsh";
 import { Uint8ArrayList } from "uint8arraylist";
 
+export const TOPIC_ROOT_CANDIDATES_MAX = 64;
+const TOPIC_ROOT_CANDIDATE_LENGTH = 44;
+export const TOPIC_ROOT_CANDIDATES_MAX_FRAME_BYTES =
+	1 + 4 + TOPIC_ROOT_CANDIDATES_MAX * (4 + TOPIC_ROOT_CANDIDATE_LENGTH);
+
+// A SHA-256 digest in canonical, padded RFC 4648 Base64 is 44 ASCII bytes.
+// The final data character has two zero padding bits, so only these Base64
+// indices can precede the trailing `=`.
+const CANONICAL_SHA256_BASE64 = /^[A-Za-z0-9+/]{42}[AEIMQUYcgkosw048]=$/;
+
+export const isCanonicalTopicRootCandidate = (candidate: string): boolean =>
+	typeof candidate === "string" && CANONICAL_SHA256_BASE64.test(candidate);
+
+export const assertCanonicalTopicRootCandidates = (
+	candidates: readonly string[],
+): void => {
+	if (candidates.length > TOPIC_ROOT_CANDIDATES_MAX) {
+		throw new Error(
+			`Topic-root candidate count exceeds ${TOPIC_ROOT_CANDIDATES_MAX}`,
+		);
+	}
+	for (const candidate of candidates) {
+		if (!isCanonicalTopicRootCandidate(candidate)) {
+			throw new Error("Topic-root candidate is not a canonical SHA-256 hash");
+		}
+	}
+};
+
+const frameByteLength = (bytes: Uint8Array | Uint8ArrayList): number =>
+	bytes.byteLength;
+
+const frameByteAt = (
+	bytes: Uint8Array | Uint8ArrayList,
+	offset: number,
+): number => (bytes instanceof Uint8Array ? bytes[offset]! : bytes.get(offset));
+
+export const assertTopicRootCandidatesFrame = (
+	bytes: Uint8Array | Uint8ArrayList,
+): void => {
+	const byteLength = frameByteLength(bytes);
+	if (byteLength > TOPIC_ROOT_CANDIDATES_MAX_FRAME_BYTES) {
+		throw new Error(
+			`Topic-root candidates frame exceeds ${TOPIC_ROOT_CANDIDATES_MAX_FRAME_BYTES} bytes`,
+		);
+	}
+	if (byteLength < 5) {
+		throw new Error("Topic-root candidates frame is truncated");
+	}
+	if (frameByteAt(bytes, 0) !== 4) {
+		throw new Error("Invalid topic-root candidates frame variant");
+	}
+	const count =
+		frameByteAt(bytes, 1) |
+		(frameByteAt(bytes, 2) << 8) |
+		(frameByteAt(bytes, 3) << 16) |
+		(frameByteAt(bytes, 4) << 24);
+	if (count >>> 0 > TOPIC_ROOT_CANDIDATES_MAX) {
+		throw new Error(
+			`Topic-root candidate count exceeds ${TOPIC_ROOT_CANDIDATES_MAX}`,
+		);
+	}
+};
+
 export abstract class PubSubMessage {
 	abstract bytes(): Uint8Array | Uint8ArrayList;
 	static from(bytes: Uint8Array) {
@@ -214,10 +277,12 @@ export class TopicRootCandidates extends PubSubMessage {
 	}
 
 	static from(bytes: Uint8Array | Uint8ArrayList): TopicRootCandidates {
+		assertTopicRootCandidatesFrame(bytes);
 		const ret = deserialize(
 			bytes instanceof Uint8Array ? bytes : bytes.subarray(),
 			TopicRootCandidates,
 		);
+		assertCanonicalTopicRootCandidates(ret.candidates);
 		if (bytes instanceof Uint8ArrayList) {
 			ret._serialized = bytes;
 		}

--- a/packages/transport/pubsub/src/index.ts
+++ b/packages/transport/pubsub/src/index.ts
@@ -5,8 +5,11 @@ import {
 import { PublicSignKey, getPublicKeyFromPeerId } from "@peerbit/crypto";
 import { logger as loggerFn } from "@peerbit/logger";
 import {
+	assertCanonicalTopicRootCandidates,
+	assertTopicRootCandidatesFrame,
 	DataEvent,
 	GetSubscribers,
+	isCanonicalTopicRootCandidate,
 	PeerUnavailable,
 	type PubSub,
 	PubSubData,
@@ -16,6 +19,7 @@ import {
 	Subscribe,
 	SubscriptionData,
 	SubscriptionEvent,
+	TOPIC_ROOT_CANDIDATES_MAX,
 	TopicRootCandidates,
 	TopicRootQuery,
 	TopicRootQueryResponse,
@@ -138,7 +142,9 @@ const DEFAULT_FANOUT_PUBLISH_MAX_EPHEMERAL_CHANNELS = 64;
 const DEFAULT_PUBSUB_SHARD_COUNT = 256;
 const PUBSUB_SHARD_COUNT_HARD_CAP = 16_384;
 const DEFAULT_PUBSUB_SHARD_TOPIC_PREFIX = "/peerbit/pubsub-shard/1/";
-const AUTO_TOPIC_ROOT_CANDIDATES_MAX = 64;
+const sameCandidates = (left: string[], right: string[]) =>
+	left.length === right.length &&
+	left.every((candidate, index) => candidate === right[index]);
 // Topic-root queries may need to wait for the responder to finish opening an
 // outbound stream back to the requester after an inbound-only dial.
 const DEFAULT_TOPIC_ROOT_QUERY_TIMEOUT_MS = 12_000;
@@ -710,7 +716,11 @@ export class TopicControlPlane
 
 	private maybeUpdateAutoTopicRootCandidates(peerHash: string) {
 		if (!this.autoTopicRootCandidates) return;
-		if (!peerHash || peerHash === this.publicKeyHash) return;
+		if (
+			!isCanonicalTopicRootCandidate(peerHash) ||
+			peerHash === this.publicKeyHash
+		)
+			return;
 
 		if (this.maybeDisableAutoTopicRootCandidatesIfExternallyConfigured())
 			return;
@@ -725,6 +735,7 @@ export class TopicControlPlane
 			managed ? [...managed] : [...current, peerHash],
 		);
 		this.autoTopicRootCandidateSet = new Set(next);
+		if (sameCandidates(current, next)) return;
 		this.topicRootControlPlane.setTopicRootCandidates(next);
 		this.shardRootCache.clear();
 		this.scheduleReconcileShardOverlays();
@@ -742,20 +753,24 @@ export class TopicControlPlane
 	}
 
 	private normalizeAutoTopicRootCandidates(candidates: string[]): string[] {
+		const canonicalCandidates = candidates.filter(
+			isCanonicalTopicRootCandidate,
+		);
 		if (this.nativeTopicControl) {
 			return this.nativeTopicControl.normalizeAutoCandidates(
-				candidates,
+				canonicalCandidates,
 				this.publicKeyHash,
 			);
 		}
 		const unique = new Set<string>();
-		for (const c of candidates) {
-			if (!c) continue;
+		for (const c of canonicalCandidates) {
 			unique.add(c);
 		}
-		unique.add(this.publicKeyHash);
+		if (isCanonicalTopicRootCandidate(this.publicKeyHash)) {
+			unique.add(this.publicKeyHash);
+		}
 		const sorted = [...unique].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
-		return sorted.slice(0, AUTO_TOPIC_ROOT_CANDIDATES_MAX);
+		return sorted.slice(0, TOPIC_ROOT_CANDIDATES_MAX);
 	}
 
 	private scheduleAutoTopicRootCandidatesBroadcast(targets?: PeerStreams[]) {
@@ -834,18 +849,13 @@ export class TopicControlPlane
 
 		const before = this.topicRootControlPlane.getTopicRootCandidates();
 		for (const c of candidates) {
-			if (!c) continue;
+			if (!isCanonicalTopicRootCandidate(c)) continue;
 			managed.add(c);
 		}
 		const next = this.normalizeAutoTopicRootCandidates([...managed]);
-		if (
-			before.length === next.length &&
-			before.every((c, i) => c === next[i])
-		) {
-			return false;
-		}
-
 		this.autoTopicRootCandidateSet = new Set(next);
+		if (sameCandidates(before, next)) return false;
+
 		this.topicRootControlPlane.setTopicRootCandidates(next);
 		this.shardRootCache.clear();
 		this.scheduleReconcileShardOverlays();
@@ -1162,6 +1172,9 @@ export class TopicControlPlane
 	 * their fallback behavior).
 	 */
 	private decodePubSubMessage(bytes: Uint8Array): PubSubMessage {
+		if (bytes[0] === 4) {
+			assertTopicRootCandidatesFrame(bytes);
+		}
 		const native = this.nativeTopicControl;
 		if (native) {
 			const decoded = native.decodePubSubMessage(bytes);
@@ -1182,6 +1195,7 @@ export class TopicControlPlane
 				case "get-subscribers":
 					return new GetSubscribers({ topics: decoded.topics });
 				case "topic-root-candidates":
+					assertCanonicalTopicRootCandidates(decoded.candidates);
 					return new TopicRootCandidates({ candidates: decoded.candidates });
 				case "peer-unavailable":
 					return new PeerUnavailable({

--- a/packages/transport/pubsub/test/subscribe-races.spec.ts
+++ b/packages/transport/pubsub/test/subscribe-races.spec.ts
@@ -1,5 +1,5 @@
 import { field, variant, vec } from "@dao-xyz/borsh";
-import { getPublicKeyFromPeerId } from "@peerbit/crypto";
+import { getPublicKeyFromPeerId, sha256Base64Sync } from "@peerbit/crypto";
 import { TestSession } from "@peerbit/libp2p-test-utils";
 import {
 	TopicRootCandidates,
@@ -194,6 +194,9 @@ describe("pubsub (subscribe race regressions)", function () {
 		return { promise, resolve };
 	};
 
+	const canonicalCandidate = (label: string) =>
+		sha256Base64Sync(new TextEncoder().encode(label));
+
 	const stubFirstFanoutJoinUntilAbort = (
 		expectedRoot: string,
 		releaseAfterAbort?: Promise<void>,
@@ -288,7 +291,7 @@ describe("pubsub (subscribe race regressions)", function () {
 		const pubsub = session.peers[0]!.services.pubsub;
 		const internals = pubsub as any;
 		const staleRoot = pubsub.publicKeyHash;
-		const addedCandidate = "root-candidate-added-during-query";
+		const addedCandidate = canonicalCandidate("query-race");
 		const { afterRoot: currentRoot, topic } = findCandidateTransitionTopic(
 			[staleRoot],
 			[staleRoot, addedCandidate],
@@ -327,7 +330,7 @@ describe("pubsub (subscribe race regressions)", function () {
 		const pubsub = session.peers[0]!.services.pubsub;
 		const internals = pubsub as any;
 		const staleRoot = pubsub.publicKeyHash;
-		const addedCandidate = "root-candidate-added-before-cache-write";
+		const addedCandidate = canonicalCandidate("cache-race");
 		const { afterRoot: currentRoot, topic } = findCandidateTransitionTopic(
 			[staleRoot],
 			[staleRoot, addedCandidate],
@@ -371,13 +374,78 @@ describe("pubsub (subscribe race regressions)", function () {
 		expect(stateCalls).to.equal(2);
 	});
 
+	it("bounds the managed auto-candidate set when normalization is a no-op", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const base64Alphabet =
+			"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+		const lowCandidates = [...base64Alphabet].map(
+			(character) => "A".repeat(41) + character + "A=",
+		);
+		const discardedHighCandidates = [...base64Alphabet].map(
+			(character) => "z".repeat(41) + character + "8=",
+		);
+
+		const scheduled = { broadcast: 0, host: 0, reconcile: 0 };
+		internals.scheduleReconcileShardOverlays = () => scheduled.reconcile++;
+		internals.scheduleHostOwnedShardRoots = () => scheduled.host++;
+		internals.scheduleAutoTopicRootCandidatesBroadcast = () =>
+			scheduled.broadcast++;
+		expect(
+			internals.mergeAutoTopicRootCandidatesFromPeer(lowCandidates),
+		).to.equal(true);
+		const before = pubsub.topicRootControlPlane.getTopicRootCandidates();
+		expect(before).to.have.length(64);
+
+		expect(
+			internals.mergeAutoTopicRootCandidatesFromPeer(discardedHighCandidates),
+		).to.equal(false);
+		expect(pubsub.topicRootControlPlane.getTopicRootCandidates()).to.deep.equal(
+			before,
+		);
+		expect(internals.autoTopicRootCandidateSet.size).to.equal(64);
+		expect([...internals.autoTopicRootCandidateSet]).to.have.members(before);
+
+		const afterMerge = { ...scheduled };
+		const discardedDirectPeer = discardedHighCandidates[0]!;
+		expect(before).not.to.include(discardedDirectPeer);
+		internals.maybeUpdateAutoTopicRootCandidates(discardedDirectPeer);
+		expect(scheduled).to.deep.equal(afterMerge);
+		expect(internals.autoTopicRootCandidateSet.size).to.equal(64);
+	});
+
+	it("filters non-canonical candidates only from auto mode", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const nonCanonicalCandidate = "A".repeat(42) + "B=";
+		const before = pubsub.topicRootControlPlane.getTopicRootCandidates();
+
+		expect(
+			internals.mergeAutoTopicRootCandidatesFromPeer([nonCanonicalCandidate]),
+		).to.equal(false);
+		expect(pubsub.topicRootControlPlane.getTopicRootCandidates()).to.deep.equal(
+			before,
+		);
+		expect(
+			internals.autoTopicRootCandidateSet.has(nonCanonicalCandidate),
+		).to.equal(false);
+
+		pubsub.setTopicRootCandidates([nonCanonicalCandidate]);
+		expect(pubsub.topicRootControlPlane.getTopicRootCandidates()).to.deep.equal(
+			[nonCanonicalCandidate],
+		);
+		expect(internals.autoTopicRootCandidates).to.equal(false);
+	});
+
 	it("does not let an old opener block or overwrite the current generation", async () => {
 		session = await createDisconnectedSessionWithPerPeerRoots(1);
 		const pubsub = session.peers[0]!.services.pubsub;
 		const internals = pubsub as any;
 		const fanout = session.peers[0]!.services.fanout as any;
-		const oldRoot = "stale-generation-root";
-		const addedCandidate = "new-generation-candidate";
+		const oldRoot = canonicalCandidate("old-generation");
+		const addedCandidate = canonicalCandidate("new-generation");
 
 		internals.scheduleReconcileShardOverlays = () => {};
 		internals.scheduleHostOwnedShardRoots = () => {};
@@ -474,8 +542,8 @@ describe("pubsub (subscribe race regressions)", function () {
 		session = await createDisconnectedSessionWithPerPeerRoots(1);
 		const pubsub = session.peers[0]!.services.pubsub;
 		const internals = pubsub as any;
-		const staleRoot = "stale-join-root";
-		const addedCandidate = "candidate-that-moves-the-root";
+		const staleRoot = canonicalCandidate("stale-join");
+		const addedCandidate = canonicalCandidate("moved-root");
 
 		internals.scheduleHostOwnedShardRoots = () => {};
 		internals.scheduleAutoTopicRootCandidatesBroadcast = () => {};
@@ -533,8 +601,8 @@ describe("pubsub (subscribe race regressions)", function () {
 		const pubsub = session.peers[0]!.services.pubsub;
 		const fanout = session.peers[0]!.services.fanout;
 		const internals = pubsub as any;
-		const staleRoot = "stale-join-root-after-generation-cycle";
-		const addedCandidate = "transient-root-candidate";
+		const staleRoot = canonicalCandidate("cycle-root");
+		const addedCandidate = canonicalCandidate("transient-root");
 
 		internals.scheduleHostOwnedShardRoots = () => {};
 		internals.scheduleAutoTopicRootCandidatesBroadcast = () => {};
@@ -719,7 +787,7 @@ describe("pubsub (subscribe race regressions)", function () {
 		session = await createDisconnectedSessionWithPerPeerRoots(1);
 		const pubsub = session.peers[0]!.services.pubsub;
 		const internals = pubsub as any;
-		const autoPeer = "auto-peer-with-stale-shard-root";
+		const autoPeer = canonicalCandidate("stale-auto-peer");
 		expect(internals.mergeAutoTopicRootCandidatesFromPeer([autoPeer])).to.equal(
 			true,
 		);

--- a/packages/transport/pubsub/test/topic-root-candidates.spec.ts
+++ b/packages/transport/pubsub/test/topic-root-candidates.spec.ts
@@ -1,0 +1,56 @@
+import {
+	TOPIC_ROOT_CANDIDATES_MAX,
+	TOPIC_ROOT_CANDIDATES_MAX_FRAME_BYTES,
+	TopicRootCandidates,
+} from "@peerbit/pubsub-interface";
+import { expect } from "chai";
+
+describe("topic-root candidate messages", () => {
+	const canonicalCandidate = "A".repeat(43) + "=";
+
+	it("rejects an oversized candidate count before deserialization", () => {
+		const frame = new Uint8Array([4, TOPIC_ROOT_CANDIDATES_MAX + 1, 0, 0, 0]);
+
+		expect(() => TopicRootCandidates.from(frame)).to.throw(
+			`Topic-root candidate count exceeds ${TOPIC_ROOT_CANDIDATES_MAX}`,
+		);
+	});
+
+	it("rejects an oversized frame before deserialization", () => {
+		const frame = new Uint8Array(TOPIC_ROOT_CANDIDATES_MAX_FRAME_BYTES + 1);
+		frame[0] = 4;
+
+		expect(() => TopicRootCandidates.from(frame)).to.throw(
+			`Topic-root candidates frame exceeds ${TOPIC_ROOT_CANDIDATES_MAX_FRAME_BYTES} bytes`,
+		);
+	});
+
+	it("rejects non-canonical SHA-256 Base64 candidates", () => {
+		const invalidCandidates = [
+			canonicalCandidate.slice(0, -1),
+			"A".repeat(42) + "B=", // non-zero padding bits
+			"A".repeat(42) + "-=", // URL-safe/non-standard alphabet
+		];
+
+		for (const candidate of invalidCandidates) {
+			const frame = new TopicRootCandidates({
+				candidates: [candidate],
+			}).bytes();
+			expect(() => TopicRootCandidates.from(frame)).to.throw(
+				"Topic-root candidate is not a canonical SHA-256 hash",
+			);
+		}
+	});
+
+	it("accepts a bounded canonical candidate frame", () => {
+		const candidates = Array.from(
+			{ length: TOPIC_ROOT_CANDIDATES_MAX },
+			() => canonicalCandidate,
+		);
+		const decoded = TopicRootCandidates.from(
+			new TopicRootCandidates({ candidates }).bytes(),
+		);
+
+		expect(decoded.candidates).to.deep.equal(candidates);
+	});
+});


### PR DESCRIPTION
### Summary

- cap automatic topic-root snapshots and managed state at 64 canonical SHA-256/Base64 candidates
- reject frames larger than 3,077 bytes before decoding and keep TypeScript/native validation in parity
- replace bounded managed state even on visible no-ops, while avoiding unnecessary reconciliation, hosting, and gossip work
- preserve arbitrary explicit candidates configured through setTopicRootCandidates() for compatibility

### Security scope

This is resource-bound hardening. It limits allocation and work amplification from candidate advertisements, but does not establish per-candidate ownership or provenance. Signed, expiring candidate-origin statements and mixed-version handling remain a separate follow-up.

### Validation

- pnpm --filter @peerbit/network-rust test (97 Rust + 95 JS/WASM/native tests)
- pnpm --filter @peerbit/pubsub test (172 passing)
- focused candidate/race group (31/31)
- changed-file ESLint (no errors; two pre-existing unused-import warnings)
- cargo fmt --check
- git diff --check