### PR TITLE
fix: generate complete bootstrap rollout updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
         run: |
           node --test scripts/validate-retired-domain-references.test.mjs
           node scripts/validate-retired-domain-references.mjs
+      - name: Validate bootstrap rollout PR generation
+        if: steps.workspace_dist_cache.outputs.cache-hit != 'true'
+        run: node --test tools/sync-bootstrap-rollout.spec.mjs
       - name: Validate managed DNS lease edge function
         if: steps.workspace_dist_cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   restore:
-    if: ${{ vars.ACTIONS_SECRETS_MIGRATED == 'true' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master' && vars.ENABLE_WORKSPACE_RESTORE == 'true' }}
+    if: ${{ vars.ACTIONS_SECRETS_MIGRATED == 'true' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_repository.full_name == github.repository && github.event.workflow_run.head_branch == 'master' && vars.ENABLE_WORKSPACE_RESTORE == 'true' }}
     runs-on: ubuntu-latest
     environment: post-release
     steps:
@@ -24,23 +24,24 @@ jobs:
             echo "RELEASE_PR_TOKEN is required for workspace restore pull requests" >&2
             exit 1
           fi
-          if ! authenticated_login=$(gh api user --jq .login); then
+          if ! authenticated_identity=$(gh api user --jq '"\(.login):\(.id)"'); then
             echo "RELEASE_PR_TOKEN could not authenticate with GitHub" >&2
             exit 1
           fi
-          if [ "$authenticated_login" != "peerbit-org" ]; then
-            echo "RELEASE_PR_TOKEN must authenticate as peerbit-org (got: $authenticated_login)" >&2
+          if [ "$authenticated_identity" != "peerbit-org:273107789" ]; then
+            echo "RELEASE_PR_TOKEN must authenticate as peerbit-org:273107789 (got: $authenticated_identity)" >&2
             exit 1
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 
@@ -64,19 +65,21 @@ jobs:
             ---
 
             _This PR was opened by the **Restore Workspace Dependencies** workflow._
+          base: master
           branch: chore/restore-workspace-deps
           labels: chore
           add-paths: |
             **/package.json
             tools/restore-workspace-deps.mjs
   bootstrap-rollout-pr:
-    if: ${{ vars.ACTIONS_SECRETS_MIGRATED == 'true' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master' && vars.ENABLE_BOOTSTRAP_ROLLOUT_PR == 'true' }}
+    if: ${{ vars.ACTIONS_SECRETS_MIGRATED == 'true' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_repository.full_name == github.repository && github.event.workflow_run.head_branch == 'master' && vars.ENABLE_BOOTSTRAP_ROLLOUT_PR == 'true' }}
     runs-on: ubuntu-latest
     environment: post-release
     steps:
       - name: Checkout peerbit
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 2
           persist-credentials: false
 
@@ -105,29 +108,43 @@ jobs:
             echo "PEERBIT_BOOTSTRAP_PR_TOKEN is required when @peerbit/server changes" >&2
             exit 1
           fi
-          if ! authenticated_login=$(gh api user --jq .login); then
+          if ! authenticated_identity=$(gh api user --jq '"\(.login):\(.id)"'); then
             echo "PEERBIT_BOOTSTRAP_PR_TOKEN could not authenticate with GitHub" >&2
             exit 1
           fi
-          if [ "$authenticated_login" != "peerbit-org" ]; then
-            echo "PEERBIT_BOOTSTRAP_PR_TOKEN must authenticate as peerbit-org (got: $authenticated_login)" >&2
+          if [ "$authenticated_identity" != "peerbit-org:273107789" ]; then
+            echo "PEERBIT_BOOTSTRAP_PR_TOKEN must authenticate as peerbit-org:273107789 (got: $authenticated_identity)" >&2
             exit 1
           fi
           echo "enabled=true" >> "$GITHUB_OUTPUT"
 
       - name: Checkout peerbit-bootstrap
         if: ${{ steps.server.outputs.changed == 'true' && steps.auth.outputs.enabled == 'true' }}
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: dao-xyz/peerbit-bootstrap
           token: ${{ secrets.PEERBIT_BOOTSTRAP_PR_TOKEN }}
           path: peerbit-bootstrap
           persist-credentials: false
 
+      - name: Use Node.js
+        if: ${{ steps.server.outputs.changed == 'true' && steps.auth.outputs.enabled == 'true' }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+
       - name: Sync rollout target
         if: ${{ steps.server.outputs.changed == 'true' && steps.auth.outputs.enabled == 'true' }}
         run: |
           node tools/sync-bootstrap-rollout.mjs peerbit-bootstrap "${{ steps.server.outputs.version }}"
+
+      - name: Validate generated rollout
+        if: ${{ steps.server.outputs.changed == 'true' && steps.auth.outputs.enabled == 'true' }}
+        working-directory: peerbit-bootstrap
+        run: |
+          npm ci --ignore-scripts --no-audit --no-fund
+          npm run validate:rollout
+          npm run test:rollout
 
       - name: Create bootstrap rollout pull request
         if: ${{ steps.server.outputs.changed == 'true' && steps.auth.outputs.enabled == 'true' }}
@@ -139,20 +156,27 @@ jobs:
           committer: "Peerbit Bot <273107789+peerbit-org@users.noreply.github.com>"
           commit-message: "chore: roll bootstrap-5 to @peerbit/server@${{ steps.server.outputs.version }}"
           title: "chore: roll bootstrap-5 to @peerbit/server@${{ steps.server.outputs.version }}"
+          draft: true
           body: |
             ## Summary
 
             * update `rollouts/bootstrap-5.json` to `@peerbit/server@${{ steps.server.outputs.version }}`
-            * align the bootstrap ops dependency on `@peerbit/server`
+            * promote the previously reviewed target into the rollback contract
+            * pin the exact bootstrap ops dependency and audited lockfile cohort
             * generated automatically after a successful `peerbit` release
 
-            Merging this PR triggers the bootstrap rollout workflow in `dao-xyz/peerbit-bootstrap`.
+            This PR intentionally opens as a draft. Before marking it ready, verify
+            that the latest successful production rollout left bootstrap-5 on the
+            promoted `expectedCurrentVersion`. Merging this PR triggers the bootstrap
+            rollout workflow in `dao-xyz/peerbit-bootstrap`.
 
             ---
 
             _This PR was opened by the **Post Release Automation** workflow after [Release](${{ github.event.workflow_run.html_url }})._
+          base: master
           branch: chore/bootstrap-5-rollout-server-v${{ steps.server.outputs.version }}
           delete-branch: false
           add-paths: |
             rollouts/bootstrap-5.json
             package.json
+            package-lock.json

--- a/scripts/test-release-security-contracts.mjs
+++ b/scripts/test-release-security-contracts.mjs
@@ -372,13 +372,39 @@ for (const [name, job] of [
 	);
 	assert.match(
 		job,
+		/head_repository\.full_name == github\.repository/,
+		`${name} must accept release runs only from this repository`,
+	);
+	assert.match(
+		job,
 		/vars\.ACTIONS_SECRETS_MIGRATED == 'true'/,
 		`${name} must wait for repository-wide secret migration`,
 	);
 	assert.match(
 		job,
+		/peerbit-org:273107789/,
+		`${name} must authenticate the immutable Peerbit Bot identity`,
+	);
+	assert.match(
+		job,
 		/^    environment: post-release$/m,
 		`${name} must obtain bot credentials from the master-restricted post-release environment`,
+	);
+	const peerbitCheckout = actionSteps(job, "actions/checkout").find(
+		(checkout) => !checkout.includes("repository: dao-xyz/peerbit-bootstrap"),
+	);
+	assert(peerbitCheckout, `${name} must check out peerbit`);
+	assert.match(
+		peerbitCheckout,
+		/ref: \$\{\{ github\.event\.workflow_run\.head_sha \}\}/,
+		`${name} must use the exact completed release SHA`,
+	);
+	const setupNode = actionSteps(job, "actions/setup-node");
+	assert.equal(setupNode.length, 1, `${name} must set up Node exactly once`);
+	assert.match(
+		setupNode[0],
+		/uses: actions\/setup-node@[0-9a-f]{40} # v4\.4\.0/,
+		`${name} must pin the Node setup action`,
 	);
 }
 const postReleaseCheckouts = actionSteps(
@@ -392,13 +418,11 @@ for (const checkout of postReleaseCheckouts) {
 		/persist-credentials: false/,
 		"every post-release checkout must avoid persisting default or bot credentials",
 	);
-	if (checkout.includes("PEERBIT_BOOTSTRAP_PR_TOKEN")) {
-		assert.match(
-			checkout,
-			/uses: actions\/checkout@[0-9a-f]{40} # v4/,
-			"the token-bearing cross-repository checkout must be commit-pinned",
-		);
-	}
+	assert.match(
+		checkout,
+		/uses: actions\/checkout@[0-9a-f]{40} # v4\.3\.1/,
+		"every post-release checkout must be commit-pinned",
+	);
 }
 const pullRequestActions = actionSteps(
 	postReleaseWorkflow,
@@ -411,7 +435,30 @@ for (const pullRequestAction of pullRequestActions) {
 		/uses: peter-evans\/create-pull-request@[0-9a-f]{40} # v6/,
 		"every bot-credentialed pull-request action must be commit-pinned",
 	);
+	assert.match(
+		pullRequestAction,
+		/^          base: master$/m,
+		"every post-release pull request must name its base after exact-SHA checkout",
+	);
 }
+const bootstrapRolloutJob = workflowJob(
+	postReleaseWorkflow,
+	"bootstrap-rollout-pr",
+);
+assert.match(
+	bootstrapRolloutJob,
+	/name: Validate generated rollout[\s\S]*?npm ci --ignore-scripts --no-audit --no-fund[\s\S]*?npm run validate:rollout[\s\S]*?npm run test:rollout/,
+	"generated bootstrap rollouts must pass the downstream repository's validators",
+);
+const bootstrapRolloutPullRequest = actionSteps(
+	bootstrapRolloutJob,
+	"peter-evans/create-pull-request",
+)[0];
+assert.match(
+	bootstrapRolloutPullRequest,
+	/^          draft: true$/m,
+	"bootstrap rollout pull requests must remain draft until production source state is verified",
+);
 assert.match(
 	postReleaseWorkflow,
 	/name: Use Node\.js[\s\S]*?node-version: 22/,

--- a/tools/sync-bootstrap-rollout.mjs
+++ b/tools/sync-bootstrap-rollout.mjs
@@ -1,58 +1,341 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const FINGERPRINT_KEYS = [
+	"peerbit",
+	"@peerbit/blocks",
+	"@peerbit/crypto",
+	"@peerbit/program",
+	"@peerbit/pubsub",
+	"@peerbit/time",
+];
 
 const ensure = (condition, message) => {
-  if (!condition) {
-    throw new Error(message);
-  }
+	if (!condition) throw new Error(message);
 };
 
 const readJson = (file) => JSON.parse(fs.readFileSync(file, "utf8"));
+const writeJson = (file, value) =>
+	fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
 
-const writeJson = (file, value) => {
-  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+const parseStableVersion = (version, label) => {
+	ensure(
+		typeof version === "string" &&
+			/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(version),
+		`${label} must be a stable exact semver`,
+	);
+	const parts = version.split(".").map(Number);
+	ensure(
+		parts.every(Number.isSafeInteger),
+		`${label} components must be safe integers`,
+	);
+	return parts;
 };
 
-const updateServerDependency = (bootstrapRoot, version) => {
-  const packageJsonFile = path.join(bootstrapRoot, "package.json");
-  const packageJson = readJson(packageJsonFile);
-  ensure(packageJson.dependencies, `Missing dependencies in ${packageJsonFile}`);
-  packageJson.dependencies["@peerbit/server"] = `^${version}`;
-  writeJson(packageJsonFile, packageJson);
+const compareVersions = (left, right) => {
+	for (let index = 0; index < 3; index++) {
+		if (left[index] !== right[index]) return left[index] - right[index];
+	}
+	return 0;
 };
 
-const updateRolloutConfig = (bootstrapRoot, version) => {
-  const rolloutFile = path.join(bootstrapRoot, "rollouts", "bootstrap-5.json");
-  if (!fs.existsSync(rolloutFile)) {
-    console.warn(`Skipping bootstrap rollout sync because ${rolloutFile} does not exist yet`);
-    return false;
-  }
-  const rollout = readJson(rolloutFile);
-  rollout.targetVersion = version;
-  writeJson(rolloutFile, rollout);
-  return true;
+const assertIntegrity = (integrity, label) => {
+	ensure(
+		typeof integrity === "string" &&
+			/^sha512-[A-Za-z0-9+/]{86}==$/.test(integrity),
+		`${label} must be a canonical SHA-512 integrity`,
+	);
+	const encoded = integrity.slice("sha512-".length);
+	ensure(
+		Buffer.from(encoded, "base64").toString("base64") === encoded,
+		`${label} is not canonical Base64`,
+	);
+};
+
+const readFingerprint = (entry, label) => {
+	ensure(
+		entry && typeof entry === "object" && !Array.isArray(entry),
+		`${label} is missing`,
+	);
+	ensure(
+		entry.dependencies && typeof entry.dependencies === "object",
+		`${label}.dependencies is missing`,
+	);
+	const fingerprint = {};
+	for (const key of FINGERPRINT_KEYS) {
+		const version = entry.dependencies[key];
+		parseStableVersion(version, `${label}.dependencies.${key}`);
+		fingerprint[key] = version;
+	}
+	return fingerprint;
+};
+
+const sameFingerprint = (left, right) =>
+	FINGERPRINT_KEYS.every((key) => left?.[key] === right?.[key]);
+
+const canonicalRegistryTarball = (name, version) => {
+	const basename = name.includes("/")
+		? name.slice(name.lastIndexOf("/") + 1)
+		: name;
+	return `https://registry.npmjs.org/${name}/-/${basename}-${version}.tgz`;
+};
+
+const assertCanonicalRegistryEntry = (entry, name, version, label) => {
+	ensure(entry?.version === version, `${label}.version must be ${version}`);
+	ensure(
+		entry.resolved === canonicalRegistryTarball(name, version),
+		`${label} must use the canonical npm tarball`,
+	);
+	assertIntegrity(entry.integrity, `${label} integrity`);
+};
+
+const assertCanonicalResolvedEntries = (lock) => {
+	for (const [lockPath, entry] of Object.entries(lock.packages ?? {})) {
+		if (!entry?.resolved) continue;
+		let resolved;
+		try {
+			resolved = new URL(entry.resolved);
+		} catch {
+			throw new Error(
+				`${lockPath || "package-lock root"} has an invalid resolved URL`,
+			);
+		}
+		ensure(
+			resolved.protocol === "https:" &&
+				resolved.origin === "https://registry.npmjs.org" &&
+				resolved.username === "" &&
+				resolved.password === "" &&
+				resolved.search === "" &&
+				resolved.hash === "",
+			`${lockPath || "package-lock root"} must resolve through credential-free https://registry.npmjs.org`,
+		);
+		assertIntegrity(
+			entry.integrity,
+			`${lockPath || "package-lock root"} integrity`,
+		);
+	}
+};
+
+const readServerLockState = (
+	bootstrapRoot,
+	version,
+	{ allowNestedFingerprint = false } = {},
+) => {
+	const lock = readJson(path.join(bootstrapRoot, "package-lock.json"));
+	ensure(
+		lock.lockfileVersion === 3,
+		"package-lock.json must use lockfileVersion 3",
+	);
+	const root = lock.packages?.[""];
+	const entry = lock.packages?.["node_modules/@peerbit/server"];
+	ensure(root?.dependencies, "package-lock.json root dependencies are missing");
+	assertCanonicalResolvedEntries(lock);
+	assertCanonicalRegistryEntry(
+		entry,
+		"@peerbit/server",
+		version,
+		"package-lock @peerbit/server",
+	);
+	const fingerprint = readFingerprint(entry, "package-lock @peerbit/server");
+	for (const [name, dependencyVersion] of Object.entries(fingerprint)) {
+		const nested =
+			lock.packages?.[`node_modules/@peerbit/server/node_modules/${name}`];
+		ensure(
+			allowNestedFingerprint || !nested,
+			`package-lock ${name} must not be shadowed below @peerbit/server`,
+		);
+		assertCanonicalRegistryEntry(
+			nested ?? lock.packages?.[`node_modules/${name}`],
+			name,
+			dependencyVersion,
+			`package-lock ${name}`,
+		);
+	}
+	return {
+		fingerprint,
+		integrity: entry.integrity,
+		root,
+	};
+};
+
+const assertReviewedCurrentTarget = ({
+	bootstrapRoot,
+	config,
+	packageJson,
+}) => {
+	const current = parseStableVersion(
+		config.targetVersion,
+		"current targetVersion",
+	);
+	ensure(
+		current[0] >= 8,
+		"current reviewed target must use signed-request v8 or newer",
+	);
+	assertIntegrity(config.targetIntegrity, "current targetIntegrity");
+	const lockState = readServerLockState(bootstrapRoot, config.targetVersion);
+	ensure(
+		packageJson.dependencies?.["@peerbit/server"] === config.targetVersion,
+		"package.json must exactly pin the current targetVersion",
+	);
+	ensure(
+		lockState.root.dependencies?.["@peerbit/server"] === config.targetVersion,
+		"package-lock root must exactly pin the current targetVersion",
+	);
+	const currentCrypto = lockState.fingerprint["@peerbit/crypto"];
+	ensure(
+		packageJson.dependencies?.["@peerbit/crypto"] === currentCrypto &&
+			lockState.root.dependencies?.["@peerbit/crypto"] === currentCrypto,
+		"package and lock roots must pin the current target crypto version",
+	);
+	ensure(
+		lockState.integrity === config.targetIntegrity,
+		"current target integrity does not match package-lock.json",
+	);
+	ensure(
+		sameFingerprint(lockState.fingerprint, config.targetFingerprint),
+		"current target fingerprint does not match package-lock.json",
+	);
+	return lockState;
+};
+
+const installPackageLock = (bootstrapRoot) => {
+	const command = process.platform === "win32" ? "npm.cmd" : "npm";
+	const result = spawnSync(
+		command,
+		[
+			"install",
+			"--package-lock-only",
+			"--ignore-scripts",
+			"--no-audit",
+			"--no-fund",
+		],
+		{
+			cwd: bootstrapRoot,
+			env: { ...process.env, npm_config_ignore_scripts: "true" },
+			stdio: "inherit",
+			timeout: 300_000,
+		},
+	);
+	if (result.error) throw result.error;
+	ensure(
+		result.status === 0,
+		`npm lockfile install failed with status ${result.status ?? "unknown"}`,
+	);
+};
+
+export const syncBootstrapRollout = ({
+	bootstrapRoot,
+	targetVersion,
+	installLockfile = installPackageLock,
+}) => {
+	const root = fs.realpathSync(path.resolve(bootstrapRoot));
+	const configFile = path.join(root, "rollouts", "bootstrap-5.json");
+	const packageFile = path.join(root, "package.json");
+	const lockFile = path.join(root, "package-lock.json");
+	ensure(fs.existsSync(configFile), `Missing rollout config: ${configFile}`);
+	ensure(fs.existsSync(packageFile), `Missing package.json: ${packageFile}`);
+	ensure(fs.existsSync(lockFile), `Missing package-lock.json: ${lockFile}`);
+
+	const config = readJson(configFile);
+	const packageJson = readJson(packageFile);
+	assertReviewedCurrentTarget({ bootstrapRoot: root, config, packageJson });
+
+	const currentVersion = parseStableVersion(
+		config.targetVersion,
+		"current targetVersion",
+	);
+	const nextVersion = parseStableVersion(targetVersion, "targetVersion");
+	ensure(
+		nextVersion[0] >= 8,
+		"targetVersion must use signed-request v8 or newer",
+	);
+	const comparison = compareVersions(nextVersion, currentVersion);
+	if (comparison === 0) {
+		return {
+			changed: false,
+			rollbackVersion: config.rollbackVersion,
+			targetVersion,
+			targetIntegrity: config.targetIntegrity,
+			targetFingerprint: { ...config.targetFingerprint },
+		};
+	}
+	ensure(
+		comparison > 0,
+		"targetVersion must be newer than the reviewed current target",
+	);
+
+	const rollbackVersion = config.targetVersion;
+	const rollbackIntegrity = config.targetIntegrity;
+	const rollbackFingerprint = { ...config.targetFingerprint };
+
+	const originals = new Map(
+		[configFile, packageFile, lockFile].map((file) => [
+			file,
+			fs.readFileSync(file),
+		]),
+	);
+
+	try {
+		packageJson.dependencies["@peerbit/server"] = targetVersion;
+		writeJson(packageFile, packageJson);
+		installLockfile(root);
+
+		let targetState = readServerLockState(root, targetVersion, {
+			allowNestedFingerprint: true,
+		});
+		const targetCrypto = targetState.fingerprint["@peerbit/crypto"];
+		if (packageJson.dependencies["@peerbit/crypto"] !== targetCrypto) {
+			packageJson.dependencies["@peerbit/crypto"] = targetCrypto;
+			writeJson(packageFile, packageJson);
+			installLockfile(root);
+		}
+		targetState = readServerLockState(root, targetVersion);
+
+		ensure(
+			targetState.root.dependencies?.["@peerbit/server"] === targetVersion &&
+				targetState.root.dependencies?.["@peerbit/crypto"] ===
+					targetState.fingerprint["@peerbit/crypto"],
+			"package-lock root does not match the exact target server/crypto cohort",
+		);
+
+		config.expectedCurrentVersion = rollbackVersion;
+		config.rollbackVersion = rollbackVersion;
+		config.rollbackIntegrity = rollbackIntegrity;
+		config.rollbackFingerprint = rollbackFingerprint;
+		config.targetVersion = targetVersion;
+		config.targetIntegrity = targetState.integrity;
+		config.targetFingerprint = targetState.fingerprint;
+		config.rerollReason = `peerbit-server-${targetVersion}-release-rollout`;
+		writeJson(configFile, config);
+
+		return {
+			changed: true,
+			rollbackVersion,
+			targetVersion,
+			targetIntegrity: targetState.integrity,
+			targetFingerprint: targetState.fingerprint,
+		};
+	} catch (error) {
+		for (const [file, contents] of originals) fs.writeFileSync(file, contents);
+		throw error;
+	}
 };
 
 const run = () => {
-  const bootstrapRootArg = process.argv[2];
-  const versionArg = process.argv[3];
-  ensure(
-    typeof bootstrapRootArg === "string" && bootstrapRootArg.length > 0,
-    "Usage: node tools/sync-bootstrap-rollout.mjs <bootstrap-root> <server-version>",
-  );
-  ensure(
-    typeof versionArg === "string" && versionArg.length > 0,
-    "Missing server version argument",
-  );
-
-  const bootstrapRoot = path.resolve(process.cwd(), bootstrapRootArg);
-  ensure(fs.existsSync(bootstrapRoot), `Missing bootstrap repo: ${bootstrapRoot}`);
-
-  const rolloutUpdated = updateRolloutConfig(bootstrapRoot, versionArg);
-  if (!rolloutUpdated) {
-    return;
-  }
-  updateServerDependency(bootstrapRoot, versionArg);
+	const bootstrapRoot = process.argv[2];
+	const targetVersion = process.argv[3];
+	ensure(
+		bootstrapRoot,
+		"Usage: node tools/sync-bootstrap-rollout.mjs <bootstrap-root> <server-version>",
+	);
+	ensure(targetVersion, "Missing server version argument");
+	syncBootstrapRollout({ bootstrapRoot, targetVersion });
 };
 
-run();
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+)
+	run();

--- a/tools/sync-bootstrap-rollout.spec.mjs
+++ b/tools/sync-bootstrap-rollout.spec.mjs
@@ -1,0 +1,326 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { syncBootstrapRollout } from "./sync-bootstrap-rollout.mjs";
+
+const integrity = (byte) =>
+	`sha512-${Buffer.alloc(64, byte).toString("base64")}`;
+const currentFingerprint = {
+	peerbit: "5.3.10",
+	"@peerbit/blocks": "4.2.6",
+	"@peerbit/crypto": "3.1.4",
+	"@peerbit/program": "6.0.39",
+	"@peerbit/pubsub": "5.3.4",
+	"@peerbit/time": "3.0.1",
+};
+const targetFingerprint = {
+	peerbit: "5.3.15",
+	"@peerbit/blocks": "4.2.8",
+	"@peerbit/crypto": "3.1.5",
+	"@peerbit/program": "6.0.43",
+	"@peerbit/pubsub": "5.3.8",
+	"@peerbit/time": "3.0.1",
+};
+
+const writeJson = (file, value) =>
+	fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+const readJson = (file) => JSON.parse(fs.readFileSync(file, "utf8"));
+const canonicalRegistryTarball = (name, version) => {
+	const basename = name.includes("/")
+		? name.slice(name.lastIndexOf("/") + 1)
+		: name;
+	return `https://registry.npmjs.org/${name}/-/${basename}-${version}.tgz`;
+};
+
+const writeLock = (
+	root,
+	{ version, packageDependencies, fingerprint, packageIntegrity },
+) => {
+	const fingerprintPackages = Object.fromEntries(
+		Object.entries(fingerprint).map(([name, dependencyVersion], index) => [
+			`node_modules/${name}`,
+			{
+				version: dependencyVersion,
+				resolved: canonicalRegistryTarball(name, dependencyVersion),
+				integrity: integrity(index + 10),
+			},
+		]),
+	);
+	writeJson(path.join(root, "package-lock.json"), {
+		lockfileVersion: 3,
+		requires: true,
+		packages: {
+			"": { dependencies: packageDependencies },
+			...fingerprintPackages,
+			"node_modules/@peerbit/server": {
+				version,
+				resolved: canonicalRegistryTarball("@peerbit/server", version),
+				integrity: packageIntegrity,
+				dependencies: fingerprint,
+			},
+		},
+	});
+};
+
+const createFixture = (t) => {
+	const root = fs.mkdtempSync(
+		path.join(os.tmpdir(), "peerbit-bootstrap-sync-"),
+	);
+	t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+	fs.mkdirSync(path.join(root, "rollouts"));
+	const packageDependencies = {
+		"@dao-xyz/borsh": "^6.0.1",
+		"@peerbit/crypto": currentFingerprint["@peerbit/crypto"],
+		"@peerbit/server": "8.0.0",
+	};
+	writeJson(path.join(root, "package.json"), {
+		dependencies: packageDependencies,
+	});
+	writeJson(path.join(root, "rollouts", "bootstrap-5.json"), {
+		bootstrapFile: "bootstrap-5.env",
+		expectedCurrentVersion: "6.0.36",
+		targetVersion: "8.0.0",
+		rollbackVersion: "6.0.36",
+		targetIntegrity: integrity(1),
+		rollbackIntegrity: integrity(2),
+		targetFingerprint: currentFingerprint,
+		rollbackFingerprint: { ...currentFingerprint, peerbit: "5.3.0" },
+		batchSize: 1,
+		waitReadyTimeoutMs: 180000,
+		waitReadyDelayMs: 3000,
+		rollbackOnFailure: true,
+		rerollReason: "completed-rollout",
+	});
+	writeLock(root, {
+		version: "8.0.0",
+		packageDependencies,
+		fingerprint: currentFingerprint,
+		packageIntegrity: integrity(1),
+	});
+	return root;
+};
+
+test("promotes the reviewed target and derives the new exact lock cohort", (t) => {
+	const root = createFixture(t);
+	const installs = [];
+	const installLockfile = () => {
+		const packageJson = readJson(path.join(root, "package.json"));
+		installs.push({ ...packageJson.dependencies });
+		writeLock(root, {
+			version: "8.0.5",
+			packageDependencies: packageJson.dependencies,
+			fingerprint: targetFingerprint,
+			packageIntegrity: integrity(3),
+		});
+		if (
+			packageJson.dependencies["@peerbit/crypto"] !==
+			targetFingerprint["@peerbit/crypto"]
+		) {
+			const lockFile = path.join(root, "package-lock.json");
+			const lock = readJson(lockFile);
+			lock.packages[
+				"node_modules/@peerbit/server/node_modules/@peerbit/crypto"
+			] = lock.packages["node_modules/@peerbit/crypto"];
+			const rootCrypto = packageJson.dependencies["@peerbit/crypto"];
+			lock.packages["node_modules/@peerbit/crypto"] = {
+				version: rootCrypto,
+				resolved: canonicalRegistryTarball("@peerbit/crypto", rootCrypto),
+				integrity: integrity(20),
+			};
+			writeJson(lockFile, lock);
+		}
+	};
+
+	const result = syncBootstrapRollout({
+		bootstrapRoot: root,
+		targetVersion: "8.0.5",
+		installLockfile,
+	});
+
+	assert.equal(
+		installs.length,
+		2,
+		"crypto pin changes require a second lock resolution",
+	);
+	assert.equal(installs[0]["@peerbit/server"], "8.0.5");
+	assert.equal(installs[0]["@peerbit/crypto"], "3.1.4");
+	assert.equal(installs[1]["@peerbit/crypto"], "3.1.5");
+	assert.equal(result.changed, true);
+	assert.deepEqual(result.targetFingerprint, targetFingerprint);
+
+	const config = readJson(path.join(root, "rollouts", "bootstrap-5.json"));
+	assert.equal(config.expectedCurrentVersion, "8.0.0");
+	assert.equal(config.rollbackVersion, "8.0.0");
+	assert.equal(config.rollbackIntegrity, integrity(1));
+	assert.deepEqual(config.rollbackFingerprint, currentFingerprint);
+	assert.equal(config.targetVersion, "8.0.5");
+	assert.equal(config.targetIntegrity, integrity(3));
+	assert.deepEqual(config.targetFingerprint, targetFingerprint);
+	assert.equal(config.rerollReason, "peerbit-server-8.0.5-release-rollout");
+});
+
+test("rejects stale reviewed metadata before changing files", (t) => {
+	const root = createFixture(t);
+	const configFile = path.join(root, "rollouts", "bootstrap-5.json");
+	const config = readJson(configFile);
+	config.targetIntegrity = integrity(9);
+	writeJson(configFile, config);
+	const beforePackage = fs.readFileSync(
+		path.join(root, "package.json"),
+		"utf8",
+	);
+
+	assert.throws(
+		() =>
+			syncBootstrapRollout({
+				bootstrapRoot: root,
+				targetVersion: "8.0.5",
+				installLockfile: () => assert.fail(),
+			}),
+		/current target integrity does not match/,
+	);
+	assert.equal(
+		fs.readFileSync(path.join(root, "package.json"), "utf8"),
+		beforePackage,
+	);
+});
+
+test("an already-current exact target is an unchanged no-op", (t) => {
+	const root = createFixture(t);
+	const files = [
+		path.join(root, "package.json"),
+		path.join(root, "package-lock.json"),
+		path.join(root, "rollouts", "bootstrap-5.json"),
+	];
+	const before = files.map((file) => fs.readFileSync(file));
+	const result = syncBootstrapRollout({
+		bootstrapRoot: root,
+		targetVersion: "8.0.0",
+		installLockfile: () => assert.fail("a no-op must not run npm"),
+	});
+
+	assert.equal(result.changed, false);
+	assert.equal(result.targetVersion, "8.0.0");
+	assert.equal(result.targetIntegrity, integrity(1));
+	assert.deepEqual(result.targetFingerprint, currentFingerprint);
+	for (const [index, file] of files.entries()) {
+		assert.deepEqual(fs.readFileSync(file), before[index]);
+	}
+});
+
+test("rejects downgrade, prerelease, and non-canonical versions", (t) => {
+	const root = createFixture(t);
+	for (const targetVersion of ["7.9.9", "8.0.5-rc.1", "08.0.5"]) {
+		assert.throws(
+			() =>
+				syncBootstrapRollout({
+					bootstrapRoot: root,
+					targetVersion,
+					installLockfile: () => assert.fail(),
+				}),
+			/(newer than|v8 or newer|stable exact semver)/,
+		);
+	}
+});
+
+test("restores all managed files after partial lock generation", (t) => {
+	const root = createFixture(t);
+	const files = [
+		path.join(root, "package.json"),
+		path.join(root, "package-lock.json"),
+		path.join(root, "rollouts", "bootstrap-5.json"),
+	];
+	const before = files.map((file) => fs.readFileSync(file));
+
+	assert.throws(
+		() =>
+			syncBootstrapRollout({
+				bootstrapRoot: root,
+				targetVersion: "8.0.5",
+				installLockfile: () => {
+					fs.writeFileSync(path.join(root, "package-lock.json"), "partial\n");
+					throw new Error("simulated npm failure");
+				},
+			}),
+		/simulated npm failure/,
+	);
+	for (const [index, file] of files.entries()) {
+		assert.deepEqual(fs.readFileSync(file), before[index]);
+	}
+});
+
+test("rejects a non-canonical generated lock and restores the fixture", (t) => {
+	const root = createFixture(t);
+	const files = [
+		path.join(root, "package.json"),
+		path.join(root, "package-lock.json"),
+		path.join(root, "rollouts", "bootstrap-5.json"),
+	];
+	const before = files.map((file) => fs.readFileSync(file));
+
+	assert.throws(
+		() =>
+			syncBootstrapRollout({
+				bootstrapRoot: root,
+				targetVersion: "8.0.5",
+				installLockfile: () => {
+					const packageJson = readJson(path.join(root, "package.json"));
+					writeLock(root, {
+						version: "8.0.5",
+						packageDependencies: packageJson.dependencies,
+						fingerprint: targetFingerprint,
+						packageIntegrity: integrity(3),
+					});
+					const lockFile = path.join(root, "package-lock.json");
+					const lock = readJson(lockFile);
+					lock.packages["node_modules/peerbit"].resolved += "?mirror=1";
+					writeJson(lockFile, lock);
+				},
+			}),
+		/must resolve through credential-free/,
+	);
+	for (const [index, file] of files.entries()) {
+		assert.deepEqual(fs.readFileSync(file), before[index]);
+	}
+});
+
+test("rejects a nested package that can shadow the fingerprint cohort", (t) => {
+	const root = createFixture(t);
+	const nestedFingerprint = {
+		...targetFingerprint,
+		"@peerbit/crypto": currentFingerprint["@peerbit/crypto"],
+	};
+	const installLockfile = () => {
+		const packageJson = readJson(path.join(root, "package.json"));
+		writeLock(root, {
+			version: "8.0.5",
+			packageDependencies: packageJson.dependencies,
+			fingerprint: nestedFingerprint,
+			packageIntegrity: integrity(3),
+		});
+		const lockFile = path.join(root, "package-lock.json");
+		const lock = readJson(lockFile);
+		lock.packages["node_modules/@peerbit/server/node_modules/@peerbit/crypto"] =
+			{
+				version: currentFingerprint["@peerbit/crypto"],
+				resolved: canonicalRegistryTarball(
+					"@peerbit/crypto",
+					currentFingerprint["@peerbit/crypto"],
+				),
+				integrity: integrity(20),
+			};
+		writeJson(lockFile, lock);
+	};
+
+	assert.throws(
+		() =>
+			syncBootstrapRollout({
+				bootstrapRoot: root,
+				targetVersion: "8.0.5",
+				installLockfile,
+			}),
+		/must not be shadowed below @peerbit\/server/,
+	);
+});


### PR DESCRIPTION
## Summary

- generate exact server and crypto pins plus a complete audited npm lock cohort
- promote the reviewed target into the rollback contract and validate downstream rollout invariants
- make generation atomic and idempotent, and open production rollout PRs as drafts pending source verification
- bind post-release jobs to same-repository successful master runs at the exact completed SHA and immutable Peerbit Bot identity

## Validation

- Node 22 rollout generator tests: 7/7
- release security contracts
- generated 8.0.5 files byte-identical to the repaired bootstrap rollout
- current 8.0.5 bootstrap checkout is a byte-identical no-op
- downstream bootstrap rollout validator and test suite: 48/48