### PR TITLE
fix(pubsub): cancel obsolete root resolution

### DIFF
--- a/.changeset/tidy-roots-cancel.md
+++ b/.changeset/tidy-roots-cancel.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/pubsub": patch
+---
+
+Cancel obsolete topic-root resolver, tracker, peer-query, and shard-hosting work when callers abort, Pubsub stops, or root candidates change.

--- a/packages/transport/pubsub/src/index.ts
+++ b/packages/transport/pubsub/src/index.ts
@@ -70,7 +70,10 @@ import type {
 	FanoutTreeDataEvent,
 	FanoutTreeJoinOptions,
 } from "./fanout-tree.js";
-import { TopicRootControlPlane } from "./topic-root-control-plane.js";
+import {
+	TopicRootControlPlane,
+	type TopicRootResolutionOptions,
+} from "./topic-root-control-plane.js";
 
 export * from "./fanout-tree.js";
 // The complete /peerbit/fanout-tree/0.5.0 wire codec and the
@@ -107,6 +110,7 @@ const logErrorIfStarted = (e?: { message: string }) => {
 const withAbort = async <T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> => {
 	if (!signal) return promise;
 	if (signal.aborted) {
+		void promise.catch(() => {});
 		throw signal.reason ?? new AbortError("Operation was aborted");
 	}
 	return new Promise<T>((resolve, reject) => {
@@ -133,6 +137,53 @@ const withAbort = async <T>(promise: Promise<T>, signal?: AbortSignal): Promise<
 			},
 		);
 	});
+};
+
+const throwIfAborted = (signal?: AbortSignal): void => {
+	if (signal?.aborted) {
+		throw signal.reason ?? new AbortError("Operation was aborted");
+	}
+};
+
+type AbortSignalLink = {
+	signal: AbortSignal;
+	clear: () => void;
+};
+
+const linkAbortSignals = (
+	signals: Array<AbortSignal | undefined>,
+): AbortSignalLink => {
+	const unique = [...new Set(signals.filter((signal) => signal !== undefined))];
+	if (unique.length === 1) {
+		return { signal: unique[0]!, clear: () => {} };
+	}
+
+	const controller = new AbortController();
+	const listeners = new Map<AbortSignal, () => void>();
+	const clear = () => {
+		for (const [signal, listener] of listeners) {
+			signal.removeEventListener("abort", listener);
+		}
+		listeners.clear();
+	};
+	const abortFrom = (signal: AbortSignal) => {
+		clear();
+		controller.abort(
+			signal.reason ?? new AbortError("Topic-root resolution aborted"),
+		);
+	};
+
+	const aborted = unique.find((signal) => signal.aborted);
+	if (aborted) {
+		abortFrom(aborted);
+	} else {
+		for (const signal of unique) {
+			const listener = () => abortFrom(signal);
+			listeners.set(signal, listener);
+			signal.addEventListener("abort", listener, { once: true });
+		}
+	}
+	return { signal: controller.signal, clear };
 };
 
 const SUBSCRIBER_CACHE_MAX_ENTRIES_HARD_CAP = 100_000;
@@ -357,6 +408,9 @@ export class TopicControlPlane
 	private reconcileShardOverlaysDirty = false;
 	private topicControlPlaneStopping = false;
 	private topicControlPlaneLifecycleRevision = 0;
+	private topicRootResolutionAbortController = new AbortController();
+	private topicRootCandidateResolutionGeneration?: string;
+	private topicRootCandidateResolutionAbortController = new AbortController();
 	private hostOwnedShardRootsInFlight?: Promise<void>;
 	private hostOwnedShardRootsDirty = false;
 	private autoCandidatesBroadcastTimers: Array<ReturnType<typeof setTimeout>> =
@@ -561,6 +615,9 @@ export class TopicControlPlane
 
 	public override async start() {
 		this.topicControlPlaneStopping = false;
+		if (this.topicRootResolutionAbortController.signal.aborted) {
+			this.topicRootResolutionAbortController = new AbortController();
+		}
 		await this.fanout.start();
 		this._onFanoutPeerUnreachable =
 			this._onFanoutPeerUnreachable ||
@@ -584,6 +641,9 @@ export class TopicControlPlane
 
 	public override async stop() {
 		this.topicControlPlaneStopping = true;
+		this.topicRootResolutionAbortController.abort(
+			new AbortError("topic control plane stopped"),
+		);
 		this.clearAutoTopicRootCandidateUpdateSchedule();
 		this.topicControlPlaneLifecycleRevision += 1;
 		this.reconcileShardOverlaysDirty = false;
@@ -932,6 +992,7 @@ export class TopicControlPlane
 
 	private scheduleReconcileShardOverlays() {
 		const candidateGeneration = this.getTopicRootCandidateGeneration();
+		this.syncTopicRootCandidateResolutionSignal(candidateGeneration);
 		for (const opening of this.ensureFanoutChannelInFlight.values()) {
 			if (opening.candidateGeneration !== candidateGeneration) {
 				opening.abortController.abort(
@@ -1279,6 +1340,67 @@ export class TopicControlPlane
 		}
 	}
 
+	private syncTopicRootCandidateResolutionSignal(
+		candidateGeneration = this.getTopicRootCandidateGeneration(),
+	): AbortSignal {
+		if (this.topicRootCandidateResolutionGeneration === undefined) {
+			this.topicRootCandidateResolutionGeneration = candidateGeneration;
+		} else if (
+			candidateGeneration !== this.topicRootCandidateResolutionGeneration
+		) {
+			this.topicRootCandidateResolutionAbortController.abort(
+				new AbortError("topic root candidates changed"),
+			);
+			this.topicRootCandidateResolutionAbortController = new AbortController();
+			this.topicRootCandidateResolutionGeneration = candidateGeneration;
+		}
+		return this.topicRootCandidateResolutionAbortController.signal;
+	}
+
+	private async withTopicRootCandidateResolution<T>(
+		operation: (context: {
+			candidateGeneration: string;
+			signal: AbortSignal;
+		}) => Promise<T>,
+		terminalSignals: Array<AbortSignal | undefined> = [],
+	): Promise<T> {
+		for (;;) {
+			for (const signal of terminalSignals) throwIfAborted(signal);
+			const candidateGeneration = this.getTopicRootCandidateGeneration();
+			const candidateSignal = this.syncTopicRootCandidateResolutionSignal(
+				candidateGeneration,
+			);
+			const linked = linkAbortSignals([...terminalSignals, candidateSignal]);
+			try {
+				const result = await operation({
+					candidateGeneration,
+					signal: linked.signal,
+				});
+				for (const signal of terminalSignals) throwIfAborted(signal);
+				if (
+					candidateSignal.aborted ||
+					candidateGeneration !== this.getTopicRootCandidateGeneration()
+				) {
+					continue;
+				}
+				return result;
+			} catch (error) {
+				for (const signal of terminalSignals) {
+					if (signal?.aborted) throw signal.reason ?? error;
+				}
+				if (
+					candidateSignal.aborted ||
+					candidateGeneration !== this.getTopicRootCandidateGeneration()
+				) {
+					continue;
+				}
+				throw error;
+			} finally {
+				linked.clear();
+			}
+		}
+	}
+
 	private normalizePeerTopicRootState(
 		topic: string,
 		root: string,
@@ -1298,13 +1420,21 @@ export class TopicControlPlane
 
 	private async resolveTopicRootState(
 		topic: string,
+		options?: TopicRootResolutionOptions,
 	): Promise<{ root?: string; authoritative: boolean }> {
-		const tracked = await this.topicRootControlPlane.resolveTrackedTopicRoot(topic);
+		throwIfAborted(options?.signal);
+		const tracked = await this.topicRootControlPlane.resolveTrackedTopicRoot(
+			topic,
+			options,
+		);
 		if (tracked) {
 			return { root: tracked, authoritative: true };
 		}
 
-		const resolvedThroughPeers = await this.resolveTopicRootThroughPeers(topic);
+		const resolvedThroughPeers = await this.resolveTopicRootThroughPeers(
+			topic,
+			options,
+		);
 		if (resolvedThroughPeers) {
 			// Unconfigured peer-query replies cannot override the locally
 			// deterministic root for internal shards in auto mode. Roots, resolvers,
@@ -1321,8 +1451,11 @@ export class TopicControlPlane
 			this.getConnectedTopicRootTrackers().length > 0
 		) {
 			for (let attempt = 0; attempt < 8; attempt++) {
-				await delay(150 * (attempt < 4 ? 1 : 2));
-				const retried = await this.resolveTopicRootThroughPeers(topic);
+				await withAbort(
+					delay(150 * (attempt < 4 ? 1 : 2), options),
+					options?.signal,
+				);
+				const retried = await this.resolveTopicRootThroughPeers(topic, options);
 				if (retried) {
 					return this.normalizePeerTopicRootState(topic, retried);
 				}
@@ -1335,15 +1468,28 @@ export class TopicControlPlane
 		};
 	}
 
-	public async resolveTopicRoot(topic: string): Promise<string | undefined> {
-		return (await this.resolveTopicRootState(topic)).root;
+	public async resolveTopicRoot(
+		topic: string,
+		options?: TopicRootResolutionOptions,
+	): Promise<string | undefined> {
+		const lifecycleSignal =
+			this.started && !this.stopping && !this.topicControlPlaneStopping
+				? this.topicRootResolutionAbortController.signal
+				: undefined;
+		return this.withTopicRootCandidateResolution(
+			async ({ signal }) =>
+				(await this.resolveTopicRootState(topic, { signal })).root,
+			[lifecycleSignal, options?.signal],
+		);
 	}
 
 	private async resolveShardRootState(
 		shardTopic: string,
+		options?: TopicRootResolutionOptions,
 	): Promise<{ root: string; candidateGeneration: string }> {
 		const lifecycleRevision = this.topicControlPlaneLifecycleRevision;
 		for (;;) {
+			throwIfAborted(options?.signal);
 			this.assertTopicControlPlaneActive(lifecycleRevision);
 			// If someone configured topic-root candidates externally (e.g.
 			// TestSession router selection or Peerbit.bootstrap) after this peer
@@ -1360,7 +1506,7 @@ export class TopicControlPlane
 				return { root: cached.root, candidateGeneration };
 			}
 
-			const resolved = await this.resolveTopicRootState(shardTopic);
+			const resolved = await this.resolveTopicRootState(shardTopic, options);
 			this.assertTopicControlPlaneActive(lifecycleRevision);
 			if (candidateGeneration !== this.getTopicRootCandidateGeneration()) {
 				continue;
@@ -1446,40 +1592,65 @@ export class TopicControlPlane
 		peer: PeerStreams,
 		topic: string,
 		timeoutMs = DEFAULT_TOPIC_ROOT_QUERY_TIMEOUT_MS,
+		signal?: AbortSignal,
 	): Promise<string | undefined> {
+		throwIfAborted(signal);
 		if (!this.started || this.stopping) return undefined;
 
 		const expectedPeerHash = peer.publicKey.hashcode();
 		const requestId = this.nextTopicRootRequestIdValue();
 		const responsePromise = new Promise<string | undefined>((resolve) => {
-			const timer = setTimeout(() => {
-				this.pendingTopicRootQueries.delete(requestId);
-				resolve(undefined);
-			}, Math.max(1, Math.floor(timeoutMs)));
+			let settled = false;
+			const settle = (root: string | undefined) => {
+				if (settled) return;
+				settled = true;
+				const pending = this.pendingTopicRootQueries.get(requestId);
+				if (pending?.resolve === settle) {
+					this.pendingTopicRootQueries.delete(requestId);
+				}
+				clearTimeout(timer);
+				if (signal && onAbort) {
+					signal.removeEventListener("abort", onAbort);
+				}
+				resolve(root);
+			};
+			const onAbort = signal ? () => settle(undefined) : undefined;
+			const timer = setTimeout(
+				() => settle(undefined),
+				Math.max(1, Math.floor(timeoutMs)),
+			);
 			timer.unref?.();
 			this.pendingTopicRootQueries.set(requestId, {
 				expectedPeerHash,
 				topic,
-				resolve,
+				resolve: settle,
 				timer,
 			});
+			if (signal && onAbort) {
+				signal.addEventListener("abort", onAbort, { once: true });
+				if (signal.aborted) onAbort();
+			}
 		});
 
 		try {
-			await this.sendDirectControlMessage(
-				peer,
-				new TopicRootQuery({ requestId, topic }),
+			await withAbort(
+				this.sendDirectControlMessage(
+					peer,
+					new TopicRootQuery({ requestId, topic }),
+				),
+				signal,
 			);
-		} catch {
+		} catch (error) {
 			const pending = this.pendingTopicRootQueries.get(requestId);
 			if (pending) {
 				this.pendingTopicRootQueries.delete(requestId);
 				clearTimeout(pending.timer);
 				pending.resolve(undefined);
 			}
+			if (signal?.aborted) throw error;
 		}
 
-		return responsePromise;
+		return withAbort(responsePromise, signal);
 	}
 
 	private async confirmDirectShardRoot(
@@ -1499,6 +1670,7 @@ export class TopicControlPlane
 				rootPeer,
 				shardTopic,
 				DIRECT_SHARD_ROOT_CONFIRM_TIMEOUT_MS,
+				signal,
 			),
 			signal,
 		);
@@ -1523,49 +1695,56 @@ export class TopicControlPlane
 		topic: string,
 	): Promise<string | undefined> {
 		const lifecycleRevision = this.topicControlPlaneLifecycleRevision;
-		for (;;) {
-			this.assertTopicControlPlaneActive(lifecycleRevision);
-			const rootCandidateGeneration = this.getTopicRootCandidateGeneration();
-			const root =
-				await this.topicRootControlPlane.resolveCanonicalTopicRoot(topic);
-			this.assertTopicControlPlaneActive(lifecycleRevision);
-			if (rootCandidateGeneration !== this.getTopicRootCandidateGeneration()) {
-				continue;
-			}
-			if (root !== this.publicKeyHash) {
-				return root;
-			}
-			if (!topic.startsWith(this.shardTopicPrefix)) {
-				return root;
-			}
-
-			try {
-				await this.ensureFanoutChannel(topic, {
-					pin: true,
-					root,
-					rootCandidateGeneration,
-				});
+		const lifecycleSignal = this.topicRootResolutionAbortController.signal;
+		return this.withTopicRootCandidateResolution(
+			async ({ candidateGeneration, signal }) => {
+				throwIfAborted(signal);
 				this.assertTopicControlPlaneActive(lifecycleRevision);
-				if (
-					rootCandidateGeneration !== this.getTopicRootCandidateGeneration()
-				) {
-					continue;
+				const root =
+					await this.topicRootControlPlane.resolveCanonicalTopicRoot(topic, {
+						signal,
+					});
+				this.assertTopicControlPlaneActive(lifecycleRevision);
+				if (root !== this.publicKeyHash) {
+					return root;
 				}
-				return root;
-			} catch (error) {
-				warn(
-					`Failed to host shard root ${topic} before answering root query: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
-				);
-				return undefined;
-			}
-		}
+				if (!topic.startsWith(this.shardTopicPrefix)) {
+					return root;
+				}
+
+				try {
+					await this.ensureFanoutChannel(topic, {
+						pin: true,
+						root,
+						rootCandidateGeneration: candidateGeneration,
+						signal,
+					});
+					this.assertTopicControlPlaneActive(lifecycleRevision);
+					return root;
+				} catch (error) {
+					if (
+						signal.aborted ||
+						candidateGeneration !== this.getTopicRootCandidateGeneration()
+					) {
+						throw error;
+					}
+					warn(
+						`Failed to host shard root ${topic} before answering root query: ${
+							error instanceof Error ? error.message : String(error)
+						}`,
+					);
+					return undefined;
+				}
+			},
+			[lifecycleSignal],
+		);
 	}
 
 	private async resolveTopicRootThroughPeers(
 		topic: string,
+		options?: TopicRootResolutionOptions,
 	): Promise<string | undefined> {
+		throwIfAborted(options?.signal);
 		const peers = this.getConnectedTopicRootTrackers();
 		if (peers.length === 0) {
 			return undefined;
@@ -1573,14 +1752,22 @@ export class TopicControlPlane
 
 		for (let attempt = 0; attempt < 3; attempt++) {
 			for (const peer of peers) {
-				const resolved = await this.queryTopicRootFromPeer(peer, topic);
+				const resolved = await this.queryTopicRootFromPeer(
+					peer,
+					topic,
+					DEFAULT_TOPIC_ROOT_QUERY_TIMEOUT_MS,
+					options?.signal,
+				);
 				if (resolved) {
 					return resolved;
 				}
 			}
 
 			if (attempt < 2) {
-				await delay(150 * (attempt + 1));
+				await withAbort(
+					delay(150 * (attempt + 1), options),
+					options?.signal,
+				);
 			}
 		}
 		return undefined;
@@ -1724,7 +1911,9 @@ export class TopicControlPlane
 		const existing = this.fanoutChannels.get(t);
 		if (existing) {
 			if (!root) {
-				const resolved = await this.resolveShardRootState(t);
+				const resolved = await this.resolveShardRootState(t, {
+					signal: options?.signal,
+				});
 				this.assertTopicControlPlaneActive(lifecycleRevision);
 				root = resolved.root;
 				resolvedGeneration = resolved.candidateGeneration;
@@ -1768,7 +1957,9 @@ export class TopicControlPlane
 		}
 
 		if (!root) {
-			const resolved = await this.resolveShardRootState(t);
+			const resolved = await this.resolveShardRootState(t, {
+				signal: options?.signal,
+			});
 			this.assertTopicControlPlaneActive(lifecycleRevision);
 			root = resolved.root;
 			resolvedGeneration = resolved.candidateGeneration;
@@ -1993,22 +2184,37 @@ export class TopicControlPlane
 		}
 	}
 
-	public async hostShardRootsNow() {
+	public async hostShardRootsNow(options?: TopicRootResolutionOptions) {
 		if (!this.started) throw new NotStartedError();
-		const joins: Promise<void>[] = [];
-		for (let i = 0; i < this.shardCount; i++) {
-			const shardTopic = `${this.shardTopicPrefix}${i}`;
-			const resolved = await this.resolveShardRootState(shardTopic);
-			if (resolved.root !== this.publicKeyHash) continue;
-			joins.push(
-				this.ensureFanoutChannel(shardTopic, {
-					pin: true,
-					root: resolved.root,
-					rootCandidateGeneration: resolved.candidateGeneration,
-				}),
-			);
-		}
-		await Promise.all(joins);
+		const lifecycleSignal = this.topicRootResolutionAbortController.signal;
+		return this.withTopicRootCandidateResolution(
+			async ({ candidateGeneration, signal }) => {
+				const joins: Promise<void>[] = [];
+				try {
+					for (let i = 0; i < this.shardCount; i++) {
+						throwIfAborted(signal);
+						const shardTopic = `${this.shardTopicPrefix}${i}`;
+						const resolved = await this.resolveShardRootState(shardTopic, {
+							signal,
+						});
+						if (resolved.root !== this.publicKeyHash) continue;
+						const joining = this.ensureFanoutChannel(shardTopic, {
+							pin: true,
+							root: resolved.root,
+							rootCandidateGeneration: resolved.candidateGeneration,
+							signal,
+						});
+						void joining.catch(() => {});
+						joins.push(joining);
+					}
+					await Promise.all(joins);
+				} catch (error) {
+					await Promise.allSettled(joins);
+					throw error;
+				}
+			},
+			[lifecycleSignal, options?.signal],
+		);
 	}
 
 	async subscribe(topic: string) {

--- a/packages/transport/pubsub/src/topic-root-control-plane.ts
+++ b/packages/transport/pubsub/src/topic-root-control-plane.ts
@@ -1,4 +1,5 @@
 import type { RustTopicRootDirectoryState } from "@peerbit/stream";
+import { AbortError } from "@peerbit/time";
 
 const topicHash32 = (topic: string) => {
 	let hash = 0x811c9dc5; // FNV-1a
@@ -9,17 +10,62 @@ const topicHash32 = (topic: string) => {
 	return hash >>> 0;
 };
 
+export type TopicRootResolutionOptions = {
+	signal?: AbortSignal;
+};
+
 export type TopicRootResolver = (
 	topic: string,
+	options?: TopicRootResolutionOptions,
 ) => string | undefined | Promise<string | undefined>;
 
 export type TopicRootTracker = {
-	resolveRoot(topic: string): string | undefined | Promise<string | undefined>;
+	resolveRoot(
+		topic: string,
+		options?: TopicRootResolutionOptions,
+	): string | undefined | Promise<string | undefined>;
 };
 
 export type TopicRootDirectoryOptions = {
 	defaultCandidates?: string[];
 	resolver?: TopicRootResolver;
+};
+
+const abortReason = (signal: AbortSignal) =>
+	signal.reason ?? new AbortError("Topic-root resolution aborted");
+
+const throwIfAborted = (signal?: AbortSignal): void => {
+	if (signal?.aborted) throw abortReason(signal);
+};
+
+const awaitWithSignal = async <T>(
+	value: T | PromiseLike<T>,
+	signal?: AbortSignal,
+): Promise<T> => {
+	if (signal?.aborted) {
+		void Promise.resolve(value).catch(() => {});
+		throw abortReason(signal);
+	}
+	if (!signal) return await value;
+
+	return new Promise<T>((resolve, reject) => {
+		const onAbort = () => {
+			cleanup();
+			reject(abortReason(signal));
+		};
+		const cleanup = () => signal.removeEventListener("abort", onAbort);
+		signal.addEventListener("abort", onAbort, { once: true });
+		Promise.resolve(value).then(
+			(result) => {
+				cleanup();
+				resolve(result);
+			},
+			(error) => {
+				cleanup();
+				reject(error);
+			},
+		);
+	});
 };
 
 export class TopicRootDirectory {
@@ -103,18 +149,27 @@ export class TopicRootDirectory {
 		this.resolver = resolver;
 	}
 
-	public async resolveRoot(topic: string): Promise<string | undefined> {
-		const local = await this.resolveLocal(topic);
+	public async resolveRoot(
+		topic: string,
+		options?: TopicRootResolutionOptions,
+	): Promise<string | undefined> {
+		const local = await this.resolveLocal(topic, options);
 		if (local) return local;
 
+		throwIfAborted(options?.signal);
 		return this.resolveDeterministicCandidate(topic);
 	}
 
-	public async resolveLocal(topic: string): Promise<string | undefined> {
+	public async resolveLocal(
+		topic: string,
+		options?: TopicRootResolutionOptions,
+	): Promise<string | undefined> {
+		throwIfAborted(options?.signal);
 		const explicit = this.getRoot(topic);
 		if (explicit) return explicit;
 
-		return this.resolver?.(topic);
+		if (!this.resolver) return undefined;
+		return awaitWithSignal(this.resolver(topic, options), options?.signal);
 	}
 
 	public resolveDeterministicCandidate(topic: string): string | undefined {
@@ -183,45 +238,64 @@ export class TopicRootControlPlane {
 		return [...this.trackers];
 	}
 
-	public resolveLocalTopicRoot(topic: string) {
-		return this.directory.resolveLocal(topic);
+	public resolveLocalTopicRoot(
+		topic: string,
+		options?: TopicRootResolutionOptions,
+	) {
+		return this.directory.resolveLocal(topic, options);
 	}
 
 	public resolveDeterministicTopicRoot(topic: string) {
 		return this.directory.resolveDeterministicCandidate(topic);
 	}
 
-	public resolveCanonicalTopicRoot(topic: string) {
-		return this.directory.resolveRoot(topic);
+	public resolveCanonicalTopicRoot(
+		topic: string,
+		options?: TopicRootResolutionOptions,
+	) {
+		return this.directory.resolveRoot(topic, options);
 	}
 
-	public resolveTrackedTopicRoot(topic: string) {
-		return this.resolveWithTrackers(topic, false);
+	public resolveTrackedTopicRoot(
+		topic: string,
+		options?: TopicRootResolutionOptions,
+	) {
+		return this.resolveWithTrackers(topic, false, options);
 	}
 
-	public resolveTopicRoot(topic: string) {
-		return this.resolveWithTrackers(topic, true);
+	public resolveTopicRoot(
+		topic: string,
+		options?: TopicRootResolutionOptions,
+	) {
+		return this.resolveWithTrackers(topic, true, options);
 	}
 
 	private async resolveWithTrackers(
 		topic: string,
 		fallbackToDeterministic = true,
+		options?: TopicRootResolutionOptions,
 	): Promise<string | undefined> {
-		const local = await this.directory.resolveLocal(topic);
+		const local = await this.directory.resolveLocal(topic, options);
 		if (local) {
 			return local;
 		}
 
 		for (const tracker of this.trackers) {
 			try {
-				const resolved = await tracker.resolveRoot(topic);
+				throwIfAborted(options?.signal);
+				const resolved = await awaitWithSignal(
+					tracker.resolveRoot(topic, options),
+					options?.signal,
+				);
 				if (resolved) {
 					return resolved;
 				}
 			} catch {
+				throwIfAborted(options?.signal);
 				// ignore tracker failures and continue with remaining trackers
 			}
 		}
+		throwIfAborted(options?.signal);
 		return fallbackToDeterministic
 			? this.directory.resolveDeterministicCandidate(topic)
 			: undefined;

--- a/packages/transport/pubsub/test/subscribe-races.spec.ts
+++ b/packages/transport/pubsub/test/subscribe-races.spec.ts
@@ -1212,6 +1212,277 @@ describe("pubsub (subscribe race regressions)", function () {
 		);
 	});
 
+	it("clears a pending peer root query immediately when cancelled", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const send = sinon
+			.stub(internals, "sendDirectControlMessage")
+			.resolves();
+		const abortController = new AbortController();
+		const reason = new AbortError("root query cancelled");
+		const querying = internals.queryTopicRootFromPeer(
+			{ publicKey: pubsub.publicKey },
+			"/peerbit/pubsub-shard/1/cancelled-query",
+			10_000,
+			abortController.signal,
+		);
+
+		await waitForResolved(
+			() => expect(internals.pendingTopicRootQueries.size).to.equal(1),
+			{ timeout: 1_000, delayInterval: 10 },
+		);
+		abortController.abort(reason);
+		await expect(querying).to.be.rejectedWith(reason);
+		expect(internals.pendingTopicRootQueries.size).to.equal(0);
+		expect(send.calledOnce).to.equal(true);
+	});
+
+	it("aborts a hanging resolver when the control plane stops", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const resolutionEntered = deferred();
+		let resolverSignal: AbortSignal | undefined;
+		pubsub.topicRootControlPlane.setTopicRootResolver((_topic, options) => {
+			resolverSignal = options?.signal;
+			resolutionEntered.resolve();
+			return new Promise<string | undefined>(() => {});
+		});
+		const opening = internals
+			.ensureFanoutChannel("/peerbit/pubsub-shard/1/hanging-resolver")
+			.then(
+				(): undefined => undefined,
+				(error: unknown) => error,
+			);
+
+		await resolutionEntered.promise;
+		expect(resolverSignal?.aborted).to.equal(false);
+		await Promise.race([
+			pubsub.stop(),
+			delay(1_000).then(() => {
+				throw new Error("control-plane stop remained blocked");
+			}),
+		]);
+		expect(await opening).to.be.instanceOf(Error);
+		expect(resolverSignal?.aborted).to.equal(true);
+		expect(internals.ensureFanoutChannelInFlight.size).to.equal(0);
+	});
+
+	it("aborts stale root resolution when candidates change", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const firstResolutionEntered = deferred();
+		let firstSignal: AbortSignal | undefined;
+		let resolutionCalls = 0;
+		pubsub.topicRootControlPlane.setTopicRootResolver((_topic, options) => {
+			resolutionCalls += 1;
+			if (resolutionCalls === 1) {
+				firstSignal = options?.signal;
+				firstResolutionEntered.resolve();
+				return new Promise<string | undefined>(() => {});
+			}
+			return pubsub.publicKeyHash;
+		});
+		internals.hostShardRootsNow = async () => {};
+		internals.reconcileShardOverlays = async () => {};
+		const shardTopic = "/peerbit/pubsub-shard/1/candidate-cancel";
+		const opening = internals.ensureFanoutChannel(shardTopic);
+
+		await firstResolutionEntered.promise;
+		const currentCandidates =
+			pubsub.topicRootControlPlane.getTopicRootCandidates();
+		pubsub.topicRootControlPlane.setTopicRootCandidates([
+			...currentCandidates,
+			canonicalCandidate("cancel-stale-resolution"),
+		]);
+		internals.scheduleReconcileShardOverlays();
+
+		await Promise.race([
+			opening,
+			delay(2_000).then(() => {
+				throw new Error("candidate change did not restart root resolution");
+			}),
+		]);
+		expect(firstSignal?.aborted).to.equal(true);
+		expect(resolutionCalls).to.equal(2);
+		expect(internals.ensureFanoutChannelInFlight.size).to.equal(0);
+	});
+
+	it("preserves caller abort reasons and local lookup after stop", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1, {
+			pubsub: { shardCount: 1 },
+		});
+		const pubsub = session.peers[0]!.services.pubsub;
+		const entered = deferred();
+		let resolverSignal: AbortSignal | undefined;
+		pubsub.topicRootControlPlane.setTopicRootResolver((_topic, options) => {
+			resolverSignal = options?.signal;
+			entered.resolve();
+			return new Promise<string | undefined>(() => {});
+		});
+		const abortController = new AbortController();
+		const reason = new Error("caller cancelled exact root lookup");
+		const resolving = pubsub.resolveTopicRoot("caller-cancelled", {
+			signal: abortController.signal,
+		});
+
+		await entered.promise;
+		abortController.abort(reason);
+		await expect(resolving).to.be.rejectedWith(reason);
+		expect(resolverSignal?.reason).to.equal(reason);
+
+		const lifecycleEntered = deferred();
+		let lifecycleSignal: AbortSignal | undefined;
+		pubsub.topicRootControlPlane.setTopicRootResolver((_topic, options) => {
+			lifecycleSignal = options?.signal;
+			lifecycleEntered.resolve();
+			return new Promise<string | undefined>(() => {});
+		});
+		const lifecycleResolving = pubsub.resolveTopicRoot("stop-cancelled");
+		await lifecycleEntered.promise;
+		await pubsub.stop();
+		await expect(lifecycleResolving).to.be.rejectedWith(
+			"topic control plane stopped",
+		);
+		expect(lifecycleSignal?.aborted).to.equal(true);
+
+		pubsub.topicRootControlPlane.setTopicRootResolver(undefined);
+		expect(await pubsub.resolveTopicRoot("stopped-local-lookup")).to.equal(
+			pubsub.publicKeyHash,
+		);
+	});
+
+	it("handles a pre-aborted retry delay without an unhandled rejection", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1, {
+			pubsub: { shardCount: 1 },
+		});
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const abortController = new AbortController();
+		const reason = new Error("abort immediately before root retry delay");
+		const unhandled: unknown[] = [];
+		const onUnhandled = (error: unknown) => unhandled.push(error);
+		sinon
+			.stub(internals, "getConnectedTopicRootTrackers")
+			.returns([{ publicKey: pubsub.publicKey }]);
+		sinon
+			.stub(internals, "resolveTopicRootThroughPeers")
+			.callsFake(async () => {
+				abortController.abort(reason);
+				return undefined;
+			});
+		process.on("unhandledRejection", onUnhandled);
+
+		try {
+			await expect(
+				pubsub.resolveTopicRoot("pre-aborted-retry-delay", {
+					signal: abortController.signal,
+				}),
+			).to.be.rejectedWith(reason);
+			await delay(0);
+			expect(unhandled).to.deep.equal([]);
+		} finally {
+			process.removeListener("unhandledRejection", onUnhandled);
+		}
+	});
+
+	it("restarts a queryable resolver when candidates change", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1, {
+			pubsub: { shardCount: 1 },
+		});
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const entered = deferred();
+		const nextRoot = canonicalCandidate("queryable-resolution-next-root");
+		let firstSignal: AbortSignal | undefined;
+		let calls = 0;
+		pubsub.topicRootControlPlane.setTopicRootResolver((_topic, options) => {
+			calls += 1;
+			if (calls === 1) {
+				firstSignal = options?.signal;
+				entered.resolve();
+				return new Promise<string | undefined>(() => {});
+			}
+			return nextRoot;
+		});
+		internals.scheduleHostOwnedShardRoots = () => {};
+		internals.reconcileShardOverlays = async () => {};
+		const resolving = internals.resolveQueryableTopicRoot(
+			"/peerbit/pubsub-shard/1/queryable-candidate-change",
+		);
+
+		await entered.promise;
+		pubsub.setTopicRootCandidates([
+			pubsub.publicKeyHash,
+			canonicalCandidate("queryable-candidate-change"),
+		]);
+
+		expect(await resolving).to.equal(nextRoot);
+		expect(firstSignal?.aborted).to.equal(true);
+		expect(calls).to.equal(2);
+	});
+
+	it("restarts host resolution when candidates change", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1, {
+			pubsub: { shardCount: 1 },
+		});
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const entered = deferred();
+		let firstSignal: AbortSignal | undefined;
+		let calls = 0;
+		pubsub.topicRootControlPlane.setTopicRootResolver((_topic, options) => {
+			calls += 1;
+			if (calls === 1) {
+				firstSignal = options?.signal;
+				entered.resolve();
+				return new Promise<string | undefined>(() => {});
+			}
+			return pubsub.publicKeyHash;
+		});
+		internals.shardRootCache.clear();
+		internals.scheduleHostOwnedShardRoots = () => {};
+		internals.reconcileShardOverlays = async () => {};
+		const ensure = sinon.stub(internals, "ensureFanoutChannel").resolves();
+		const hosting = pubsub.hostShardRootsNow();
+
+		await entered.promise;
+		pubsub.setTopicRootCandidates([
+			pubsub.publicKeyHash,
+			canonicalCandidate("host-candidate-change"),
+		]);
+
+		await hosting;
+		expect(firstSignal?.aborted).to.equal(true);
+		expect(calls).to.equal(2);
+		expect(ensure.calledOnce).to.equal(true);
+	});
+
+	it("drains started host joins when a later shard resolution fails", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1, {
+			pubsub: { shardCount: 2 },
+		});
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const candidateGeneration = internals.getTopicRootCandidateGeneration();
+		const scanError = new Error("later shard resolution failed");
+		const joinError = new Error("earlier shard join failed");
+		let resolutions = 0;
+		sinon.stub(internals, "resolveShardRootState").callsFake(async () => {
+			resolutions += 1;
+			if (resolutions === 2) throw scanError;
+			return { root: pubsub.publicKeyHash, candidateGeneration };
+		});
+		sinon
+			.stub(internals, "ensureFanoutChannel")
+			.returns(Promise.reject(joinError));
+
+		await expect(pubsub.hostShardRootsNow()).to.be.rejectedWith(scanError);
+		expect(resolutions).to.equal(2);
+	});
+
 	it("does not install a channel after the control plane stops", async () => {
 		session = await createDisconnectedSessionWithPerPeerRoots(1);
 		const pubsub = session.peers[0]!.services.pubsub;

--- a/packages/transport/pubsub/test/topic-root-control-plane.spec.ts
+++ b/packages/transport/pubsub/test/topic-root-control-plane.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import { TestSession } from "@peerbit/libp2p-test-utils";
+import { delay } from "@peerbit/time";
 import { FanoutTree, TopicControlPlane, TopicRootControlPlane } from "../src/index.js";
 
 describe("topic-root-control-plane", () => {
@@ -71,6 +72,82 @@ describe("topic-root-control-plane", () => {
 		expect(await controlPlane.resolveTopicRoot("rpc")).to.equal("peer-a");
 		expect(await controlPlane.resolveTrackedTopicRoot("rpc")).to.equal(undefined);
 		expect(await controlPlane.resolveCanonicalTopicRoot("rpc")).to.equal("peer-a");
+	});
+
+	it("aborts a hanging resolver even when the callback ignores its signal", async () => {
+		let markEntered!: (signal?: AbortSignal) => void;
+		const entered = new Promise<AbortSignal | undefined>((resolve) => {
+			markEntered = resolve;
+		});
+		const controlPlane = new TopicRootControlPlane({
+			defaultCandidates: ["peer-a"],
+			resolver: (_topic, options) => {
+				markEntered(options?.signal);
+				return new Promise<string | undefined>(() => {});
+			},
+		});
+		const abortController = new AbortController();
+		const reason = new Error("caller cancelled root resolution");
+		const resolving = controlPlane.resolveTopicRoot("rpc", {
+			signal: abortController.signal,
+		});
+
+		expect(await entered).to.equal(abortController.signal);
+		abortController.abort(reason);
+		await expect(resolving).to.be.rejectedWith(reason);
+	});
+
+	it("handles a synchronous resolver abort without an unhandled rejection", async () => {
+		const abortController = new AbortController();
+		const reason = new Error("resolver cancelled its own lookup");
+		const unhandled: unknown[] = [];
+		const onUnhandled = (error: unknown) => unhandled.push(error);
+		const controlPlane = new TopicRootControlPlane({
+			resolver: () => {
+				abortController.abort(reason);
+				return Promise.reject(new Error("late resolver rejection"));
+			},
+		});
+		process.on("unhandledRejection", onUnhandled);
+
+		try {
+			await expect(
+				controlPlane.resolveTopicRoot("rpc", {
+					signal: abortController.signal,
+				}),
+			).to.be.rejectedWith(reason);
+			await delay(0);
+			expect(unhandled).to.deep.equal([]);
+		} finally {
+			process.removeListener("unhandledRejection", onUnhandled);
+		}
+	});
+
+	it("aborts a hanging tracker instead of falling back to candidates", async () => {
+		let markEntered!: (signal?: AbortSignal) => void;
+		const entered = new Promise<AbortSignal | undefined>((resolve) => {
+			markEntered = resolve;
+		});
+		const controlPlane = new TopicRootControlPlane({
+			defaultCandidates: ["peer-a"],
+			trackers: [
+				{
+					resolveRoot: (_topic, options) => {
+						markEntered(options?.signal);
+						return new Promise<string | undefined>(() => {});
+					},
+				},
+			],
+		});
+		const abortController = new AbortController();
+		const reason = new Error("caller cancelled tracker resolution");
+		const resolving = controlPlane.resolveTopicRoot("rpc", {
+			signal: abortController.signal,
+		});
+
+		expect(await entered).to.equal(abortController.signal);
+		abortController.abort(reason);
+		await expect(resolving).to.be.rejectedWith(reason);
 	});
 
 	it("can be injected into TopicControlPlane", async () => {


### PR DESCRIPTION
## Summary

- cancel obsolete topic-root resolver, tracker, peer-query, and host work on caller abort, lifecycle stop, or candidate-generation change
- immediately clean pending query listeners, timers, and state while preserving exact abort reasons and pre-start/post-stop local lookup compatibility
- add regression coverage for hanging callbacks, generation restarts, stopped control planes, join draining, and unhandled-rejection edges

This changes local control-plane lifecycle handling only. It does not change the Peerbit wire protocol or candidate-message format.

## Validation

- pnpm --filter @peerbit/pubsub run build
- focused/relevant Node test selection: 49 passing
- full exact-head @peerbit/pubsub package suite: 188 passing
- git diff --check origin/master...HEAD

The tests use local/mock transports, so their timing is independent of the current LAN speed.