### PR TITLE
feat(pubsub): sign automatic root candidates

### DIFF
--- a/.changeset/signed-root-candidates.md
+++ b/.changeset/signed-root-candidates.md
@@ -1,0 +1,6 @@
+---
+"@peerbit/pubsub-interface": minor
+"@peerbit/pubsub": minor
+---
+
+Authenticate automatic topic-root candidate provenance with bounded, expiring self-claims on the dual-stack 2.1 control protocol. A directly connected legacy 2.0 peer can contribute only its authenticated stream identity, not transitively advertised hashes; sparse mixed-version topologies must use explicit candidates until their relays are upgraded. Claims prove key ownership, freshness, and configuration scope—not liveness, authorization, or Sybil resistance—so hostile deployments should configure explicit candidates or an authority-backed resolver.

--- a/packages/transport/pubsub-interface/src/index.ts
+++ b/packages/transport/pubsub-interface/src/index.ts
@@ -178,6 +178,7 @@ export interface PubSub
 
 export {
 	assertCanonicalTopicRootCandidates,
+	assertTopicRootCandidateClaimsFrame,
 	assertTopicRootCandidatesFrame,
 	GetSubscribers,
 	isCanonicalTopicRootCandidate,
@@ -187,6 +188,10 @@ export {
 	Subscribe,
 	TOPIC_ROOT_CANDIDATES_MAX,
 	TOPIC_ROOT_CANDIDATES_MAX_FRAME_BYTES,
+	TOPIC_ROOT_CANDIDATE_CLAIM_MAX_BYTES,
+	TOPIC_ROOT_CANDIDATE_CLAIMS_MAX,
+	TOPIC_ROOT_CANDIDATE_CLAIMS_MAX_FRAME_BYTES,
+	TopicRootCandidateClaims,
 	TopicRootCandidates,
 	TopicRootQuery,
 	TopicRootQueryResponse,

--- a/packages/transport/pubsub-interface/src/messages.ts
+++ b/packages/transport/pubsub-interface/src/messages.ts
@@ -13,6 +13,13 @@ const TOPIC_ROOT_CANDIDATE_LENGTH = 44;
 export const TOPIC_ROOT_CANDIDATES_MAX_FRAME_BYTES =
 	1 + 4 + TOPIC_ROOT_CANDIDATES_MAX * (4 + TOPIC_ROOT_CANDIDATE_LENGTH);
 
+export const TOPIC_ROOT_CANDIDATE_CLAIMS_MAX = 64;
+export const TOPIC_ROOT_CANDIDATE_CLAIM_MAX_BYTES = 512;
+export const TOPIC_ROOT_CANDIDATE_CLAIMS_MAX_FRAME_BYTES =
+	1 +
+	4 +
+	TOPIC_ROOT_CANDIDATE_CLAIMS_MAX * (4 + TOPIC_ROOT_CANDIDATE_CLAIM_MAX_BYTES);
+
 // A SHA-256 digest in canonical, padded RFC 4648 Base64 is 44 ASCII bytes.
 // The final data character has two zero padding bits, so only these Base64
 // indices can precede the trailing `=`.
@@ -71,6 +78,60 @@ export const assertTopicRootCandidatesFrame = (
 	}
 };
 
+export const assertTopicRootCandidateClaimsFrame = (
+	bytes: Uint8Array | Uint8ArrayList,
+): void => {
+	const byteLength = frameByteLength(bytes);
+	if (byteLength > TOPIC_ROOT_CANDIDATE_CLAIMS_MAX_FRAME_BYTES) {
+		throw new Error(
+			`Topic-root candidate claims frame exceeds ${TOPIC_ROOT_CANDIDATE_CLAIMS_MAX_FRAME_BYTES} bytes`,
+		);
+	}
+	if (byteLength < 5) {
+		throw new Error("Topic-root candidate claims frame is truncated");
+	}
+	if (frameByteAt(bytes, 0) !== 8) {
+		throw new Error("Invalid topic-root candidate claims frame variant");
+	}
+
+	const count =
+		frameByteAt(bytes, 1) |
+		(frameByteAt(bytes, 2) << 8) |
+		(frameByteAt(bytes, 3) << 16) |
+		(frameByteAt(bytes, 4) << 24);
+	if (count >>> 0 > TOPIC_ROOT_CANDIDATE_CLAIMS_MAX) {
+		throw new Error(
+			`Topic-root candidate claim count exceeds ${TOPIC_ROOT_CANDIDATE_CLAIMS_MAX}`,
+		);
+	}
+
+	let offset = 5;
+	for (let index = 0; index < count >>> 0; index++) {
+		if (offset + 4 > byteLength) {
+			throw new Error("Topic-root candidate claims frame is truncated");
+		}
+		const claimByteLength =
+			frameByteAt(bytes, offset) |
+			(frameByteAt(bytes, offset + 1) << 8) |
+			(frameByteAt(bytes, offset + 2) << 16) |
+			(frameByteAt(bytes, offset + 3) << 24);
+		offset += 4;
+		if (claimByteLength >>> 0 > TOPIC_ROOT_CANDIDATE_CLAIM_MAX_BYTES) {
+			throw new Error(
+				`Topic-root candidate claim exceeds ${TOPIC_ROOT_CANDIDATE_CLAIM_MAX_BYTES} bytes`,
+			);
+		}
+		if (offset + (claimByteLength >>> 0) > byteLength) {
+			throw new Error("Topic-root candidate claims frame is truncated");
+		}
+		offset += claimByteLength >>> 0;
+	}
+
+	if (offset !== byteLength) {
+		throw new Error("Topic-root candidate claims frame has trailing bytes");
+	}
+};
+
 export abstract class PubSubMessage {
 	abstract bytes(): Uint8Array | Uint8ArrayList;
 	static from(bytes: Uint8Array) {
@@ -103,6 +164,10 @@ export abstract class PubSubMessage {
 
 		if (first === 7) {
 			return TopicRootQueryResponse.from(bytes);
+		}
+
+		if (first === 8) {
+			return TopicRootCandidateClaims.from(bytes);
 		}
 
 		throw new Error("Unsupported");
@@ -283,6 +348,44 @@ export class TopicRootCandidates extends PubSubMessage {
 			TopicRootCandidates,
 		);
 		assertCanonicalTopicRootCandidates(ret.candidates);
+		if (bytes instanceof Uint8ArrayList) {
+			ret._serialized = bytes;
+		}
+		return ret;
+	}
+}
+
+/**
+ * Bounded aggregate of opaque, independently signed topic-root candidate
+ * claims. Each element is a serialized transport `DataMessage`; claim
+ * semantics and signature verification remain the responsibility of the
+ * topic-control-plane runtime.
+ */
+@variant(8)
+export class TopicRootCandidateClaims extends PubSubMessage {
+	@field({ type: vec(Uint8Array) })
+	claims: Uint8Array[];
+
+	constructor(options: { claims: Uint8Array[] }) {
+		super();
+		this.claims = options.claims;
+	}
+
+	private _serialized!: Uint8ArrayList;
+
+	bytes() {
+		if (this._serialized) {
+			return this._serialized;
+		}
+		return serialize(this);
+	}
+
+	static from(bytes: Uint8Array | Uint8ArrayList): TopicRootCandidateClaims {
+		assertTopicRootCandidateClaimsFrame(bytes);
+		const ret = deserialize(
+			bytes instanceof Uint8Array ? bytes : bytes.subarray(),
+			TopicRootCandidateClaims,
+		);
 		if (bytes instanceof Uint8ArrayList) {
 			ret._serialized = bytes;
 		}

--- a/packages/transport/pubsub/src/index.ts
+++ b/packages/transport/pubsub/src/index.ts
@@ -1,8 +1,9 @@
+import { type PeerId as Libp2pPeerId } from "@libp2p/interface";
 import {
-	type Connection,
-	type PeerId as Libp2pPeerId,
-} from "@libp2p/interface";
-import { PublicSignKey, getPublicKeyFromPeerId } from "@peerbit/crypto";
+	PublicSignKey,
+	getPublicKeyFromPeerId,
+	sha256Sync,
+} from "@peerbit/crypto";
 import { logger as loggerFn } from "@peerbit/logger";
 import {
 	assertCanonicalTopicRootCandidates,
@@ -20,6 +21,9 @@ import {
 	SubscriptionData,
 	SubscriptionEvent,
 	TOPIC_ROOT_CANDIDATES_MAX,
+	TOPIC_ROOT_CANDIDATE_CLAIMS_MAX,
+	TOPIC_ROOT_CANDIDATE_CLAIM_MAX_BYTES,
+	TopicRootCandidateClaims,
 	TopicRootCandidates,
 	TopicRootQuery,
 	TopicRootQueryResponse,
@@ -58,6 +62,7 @@ import {
 } from "@peerbit/stream-interface";
 import { AbortError, TimeoutError, delay } from "@peerbit/time";
 import { Uint8ArrayList } from "uint8arraylist";
+import { equals as bytesEqual } from "uint8arrays";
 import { toUint8Array } from "./bytes.js";
 import {
 	type DebouncedAccumulatorCounterMap,
@@ -194,6 +199,21 @@ const DEFAULT_PUBSUB_SHARD_COUNT = 256;
 const PUBSUB_SHARD_COUNT_HARD_CAP = 16_384;
 const DEFAULT_PUBSUB_SHARD_TOPIC_PREFIX = "/peerbit/pubsub-shard/1/";
 const AUTO_TOPIC_ROOT_CANDIDATE_UPDATE_COOLDOWN_MS = 2_000;
+const TOPIC_CONTROL_PLANE_PROTOCOL_V2_1 = "/peerbit/topic-control-plane/2.1.0";
+const TOPIC_CONTROL_PLANE_PROTOCOL_V2_0 = "/peerbit/topic-control-plane/2.0.0";
+const TOPIC_ROOT_CANDIDATE_CLAIM_DOMAIN = utf8Encoder.encode(
+	"peerbit/topic-root-candidate-claim/v1\0",
+);
+const TOPIC_ROOT_CANDIDATE_SCOPE_DOMAIN =
+	"peerbit/topic-root-candidate-scope/v1";
+const TOPIC_ROOT_CANDIDATE_CLAIM_MAX_LIFETIME_MS = 5 * 60_000;
+const TOPIC_ROOT_CANDIDATE_CLAIM_FUTURE_SKEW_MS = 30_000;
+const TOPIC_ROOT_CANDIDATE_CLAIM_REFRESH_MS = 60_000;
+const TOPIC_ROOT_CANDIDATE_CLAIM_REFRESH_JITTER_MS = 10_000;
+const TOPIC_ROOT_CANDIDATE_CLAIM_VERIFY_BURST = 128;
+const TOPIC_ROOT_CANDIDATE_CLAIM_GLOBAL_VERIFY_BURST = 512;
+const TOPIC_ROOT_CANDIDATE_CLAIM_VERIFY_REFILL_MS = 60_000;
+const TOPIC_ROOT_CANDIDATE_CLAIM_VERIFY_PEERS_MAX = 4_096;
 const sameCandidates = (left: string[], right: string[]) =>
 	left.length === right.length &&
 	left.every((candidate, index) => candidate === right[index]);
@@ -378,6 +398,7 @@ export class TopicControlPlane
 
 	private readonly shardCount: number;
 	private readonly shardTopicPrefix: string;
+	private readonly topicRootCandidateClaimData: Uint8Array;
 	private readonly hostShards: boolean;
 	private readonly shardRootCache = new Map<string, { root: string; authoritative: boolean }>();
 	private readonly shardTopicCache = new Map<string, string>();
@@ -413,10 +434,26 @@ export class TopicControlPlane
 	private topicRootCandidateResolutionAbortController = new AbortController();
 	private hostOwnedShardRootsInFlight?: Promise<void>;
 	private hostOwnedShardRootsDirty = false;
-	private autoCandidatesBroadcastTimers: Array<ReturnType<typeof setTimeout>> =
-		[];
-	private autoCandidatesGossipInterval?: ReturnType<typeof setInterval>;
-	private autoCandidatesGossipUntil = 0;
+	private readonly signedTopicRootCandidateClaims = new Map<
+		string,
+		{ bytes: Uint8Array; timestamp: bigint; expires: bigint }
+	>();
+	private localSignedTopicRootCandidateClaim?: {
+		bytes: Uint8Array;
+		timestamp: bigint;
+		expires: bigint;
+	};
+	private topicRootCandidateClaimMaintenanceTimer?: ReturnType<
+		typeof setTimeout
+	>;
+	private readonly topicRootCandidateClaimVerifyBudgets = new Map<
+		string,
+		{ remaining: number; refilledAt: number }
+	>();
+	private topicRootCandidateClaimGlobalVerifyBudget = {
+		remaining: TOPIC_ROOT_CANDIDATE_CLAIM_GLOBAL_VERIFY_BURST,
+		refilledAt: Date.now(),
+	};
 	private _onFanoutPeerUnreachable?: (
 		ev: CustomEvent<{ topic: string; root: string; publicKeyHash: string }>,
 	) => void;
@@ -459,7 +496,11 @@ export class TopicControlPlane
 		components: TopicControlPlaneComponents,
 		props?: TopicControlPlaneOptions,
 	) {
-		super(components, ["/peerbit/topic-control-plane/2.0.0"], props);
+		super(
+			components,
+			[TOPIC_CONTROL_PLANE_PROTOCOL_V2_1, TOPIC_CONTROL_PLANE_PROTOCOL_V2_0],
+			props,
+		);
 		this.subscriptions = new Map();
 		this.pendingSubscriptions = new Set();
 		this.topics = new Map();
@@ -484,8 +525,8 @@ export class TopicControlPlane
 		this.fanout = props.fanout;
 
 		// Default to a local-only shard-root candidate set so standalone peers can
-		// subscribe/publish without explicit bootstraps. We'll expand candidates
-		// opportunistically as neighbours connect.
+		// subscribe/publish without explicit bootstraps. Signed peer claims expand
+		// the set opportunistically as the ad-hoc overlay connects.
 		if (this.topicRootControlPlane.getTopicRootCandidates().length === 0) {
 			this.autoTopicRootCandidates = true;
 			this.autoTopicRootCandidateSet = new Set([this.publicKeyHash]);
@@ -499,6 +540,23 @@ export class TopicControlPlane
 		);
 		const prefix = props?.shardTopicPrefix ?? DEFAULT_PUBSUB_SHARD_TOPIC_PREFIX;
 		this.shardTopicPrefix = prefix.endsWith("/") ? prefix : prefix + "/";
+		const scopeDigest = sha256Sync(
+			utf8Encoder.encode(
+				JSON.stringify([
+					TOPIC_ROOT_CANDIDATE_SCOPE_DOMAIN,
+					this.shardTopicPrefix,
+					this.shardCount,
+				]),
+			),
+		);
+		this.topicRootCandidateClaimData = new Uint8Array(
+			TOPIC_ROOT_CANDIDATE_CLAIM_DOMAIN.byteLength + scopeDigest.byteLength,
+		);
+		this.topicRootCandidateClaimData.set(TOPIC_ROOT_CANDIDATE_CLAIM_DOMAIN, 0);
+		this.topicRootCandidateClaimData.set(
+			scopeDigest,
+			TOPIC_ROOT_CANDIDATE_CLAIM_DOMAIN.byteLength,
+		);
 		this.hostShards = props?.hostShards ?? false;
 
 		const baseFanoutChannelOptions = {
@@ -583,25 +641,21 @@ export class TopicControlPlane
 	 * candidate mode.
 	 *
 	 * Auto mode is a convenience for small ad-hoc networks where no bootstraps/
-	 * routers are configured. When an explicit candidate set is provided (e.g.
-	 * from bootstraps or a test harness), we must stop mutating/gossiping the
+	 * routers are configured. Automatic claims authenticate key ownership and
+	 * freshness, not liveness, admission, or Sybil resistance; hostile or isolated
+	 * deployments should configure explicit candidates. When an explicit candidate
+	 * set is provided (e.g. from bootstraps or a test harness), we stop mutating the
 	 * candidate set; otherwise shard root resolution can diverge and overlays can
 	 * partition (especially in sparse graphs).
 	 */
 	public setTopicRootCandidates(candidates: string[]) {
 		this.topicRootControlPlane.setTopicRootCandidates(candidates);
 
-		// Disable auto mode and stop its background gossip/timers.
+		// Disable auto mode and clear its signed-claim state/timers.
 		this.autoTopicRootCandidates = false;
 		this.autoTopicRootCandidateSet = undefined;
+		this.clearSignedTopicRootCandidateState();
 		this.clearAutoTopicRootCandidateUpdateSchedule();
-		for (const t of this.autoCandidatesBroadcastTimers) clearTimeout(t);
-		this.autoCandidatesBroadcastTimers = [];
-		if (this.autoCandidatesGossipInterval) {
-			clearInterval(this.autoCandidatesGossipInterval);
-			this.autoCandidatesGossipInterval = undefined;
-		}
-		this.autoCandidatesGossipUntil = 0;
 
 		// Re-resolve roots under the new mapping.
 		this.shardRootCache.clear();
@@ -615,6 +669,14 @@ export class TopicControlPlane
 
 	public override async start() {
 		this.topicControlPlaneStopping = false;
+		if (
+			this.autoTopicRootCandidates &&
+			!this.localSignedTopicRootCandidateClaim
+		) {
+			this.autoTopicRootCandidateSet = new Set([this.publicKeyHash]);
+			this.topicRootControlPlane.setTopicRootCandidates([this.publicKeyHash]);
+			this.shardRootCache.clear();
+		}
 		if (this.topicRootResolutionAbortController.signal.aborted) {
 			this.topicRootResolutionAbortController = new AbortController();
 		}
@@ -627,6 +689,10 @@ export class TopicControlPlane
 			this._onFanoutPeerUnreachable as any,
 		);
 		await super.start();
+		if (this.autoTopicRootCandidates) {
+			await this.refreshLocalTopicRootCandidateClaim();
+			this.scheduleTopicRootCandidateClaimMaintenance();
+		}
 
 		if (this.hostShards) {
 			await this.hostShardRootsNow();
@@ -645,6 +711,7 @@ export class TopicControlPlane
 			new AbortError("topic control plane stopped"),
 		);
 		this.clearAutoTopicRootCandidateUpdateSchedule();
+		this.clearSignedTopicRootCandidateState();
 		this.topicControlPlaneLifecycleRevision += 1;
 		this.reconcileShardOverlaysDirty = false;
 		for (const opening of this.ensureFanoutChannelInFlight.values()) {
@@ -683,13 +750,6 @@ export class TopicControlPlane
 			}
 		}
 		this.fanoutChannels.clear();
-		for (const t of this.autoCandidatesBroadcastTimers) clearTimeout(t);
-		this.autoCandidatesBroadcastTimers = [];
-		if (this.autoCandidatesGossipInterval) {
-			clearInterval(this.autoCandidatesGossipInterval);
-			this.autoCandidatesGossipInterval = undefined;
-		}
-		this.autoCandidatesGossipUntil = 0;
 		this.hostOwnedShardRootsDirty = false;
 
 		this.subscriptions.clear();
@@ -717,25 +777,8 @@ export class TopicControlPlane
 		this.reconcileShardOverlaysDirty = false;
 	}
 
-	public override async onPeerConnected(
-		peerId: Libp2pPeerId,
-		connection: Connection,
-	) {
-		await super.onPeerConnected(peerId, connection);
-
-		// If we're in auto-candidate mode, expand the deterministic shard-root
-		// candidate set as neighbours connect, then reconcile shard overlays and
-		// re-announce subscriptions so membership knowledge converges.
-		if (!this.autoTopicRootCandidates) return;
-		let peerHash: string;
-		try {
-			peerHash = getPublicKeyFromPeerId(peerId).hashcode();
-		} catch {
-			return;
-		}
-		void this.maybeUpdateAutoTopicRootCandidates(peerHash);
-	}
-
+	// Candidate trust starts only after protocol negotiation in `addPeer()`;
+	// a transport connection alone cannot bypass signed 2.1 self-claims.
 	// Ensure auto-candidate mode converges even when libp2p topology callbacks
 	// are delayed or only fire for one side of a connection. `addPeer()` runs for
 	// both inbound + outbound protocol streams once the remote public key is known.
@@ -745,12 +788,53 @@ export class TopicControlPlane
 		protocol: string,
 		connId: string,
 	): PeerStreams {
+		const existingPeer = this.peers.get(publicKey.hashcode());
 		const peer = super.addPeer(peerId, publicKey, protocol, connId);
 		if (this.autoTopicRootCandidates) {
-			void this.maybeUpdateAutoTopicRootCandidates(publicKey.hashcode());
-			this.scheduleAutoTopicRootCandidatesBroadcast([peer]);
+			if (peer.protocol === TOPIC_CONTROL_PLANE_PROTOCOL_V2_0) {
+				this.rebuildAutoTopicRootCandidatesFromClaims();
+			}
+			if (peer.protocol === TOPIC_CONTROL_PLANE_PROTOCOL_V2_1) {
+				const sendWhenOutboundReady = () => {
+					if (
+						!this.autoTopicRootCandidates ||
+						this.peers.get(publicKey.hashcode()) !== peer
+					) {
+						return;
+					}
+					void this.sendAutoTopicRootCandidates([peer]).catch(() => {});
+				};
+				if (peer.isWritable) {
+					void this.sendAutoTopicRootCandidates([peer]).catch(() => {});
+				}
+				if (!existingPeer) {
+					peer.addEventListener("stream:outbound", sendWhenOutboundReady);
+					peer.addEventListener(
+						"close",
+						() =>
+							peer.removeEventListener(
+								"stream:outbound",
+								sendWhenOutboundReady,
+							),
+						{ once: true },
+					);
+				}
+			}
 		}
 		return peer;
+	}
+
+	protected override async _removePeer(publicKey: PublicSignKey) {
+		const hash = publicKey.hashcode();
+		const protocol = this.peers.get(hash)?.protocol;
+		const removed = await super._removePeer(publicKey);
+		if (
+			this.autoTopicRootCandidates &&
+			protocol === TOPIC_CONTROL_PLANE_PROTOCOL_V2_0
+		) {
+			this.rebuildAutoTopicRootCandidatesFromClaims();
+		}
+		return removed;
 	}
 
 	private maybeDisableAutoTopicRootCandidatesIfExternallyConfigured(): boolean {
@@ -768,6 +852,7 @@ export class TopicControlPlane
 		// intact and reconcile shard overlays under the new mapping.
 		this.autoTopicRootCandidates = false;
 		this.autoTopicRootCandidateSet = undefined;
+		this.clearSignedTopicRootCandidateState();
 		this.clearAutoTopicRootCandidateUpdateSchedule();
 		this.shardRootCache.clear();
 
@@ -780,129 +865,418 @@ export class TopicControlPlane
 		return true;
 	}
 
-	private maybeUpdateAutoTopicRootCandidates(peerHash: string) {
-		if (!this.autoTopicRootCandidates) return;
+	private clearTopicRootCandidateClaimTimer() {
+		if (this.topicRootCandidateClaimMaintenanceTimer) {
+			clearTimeout(this.topicRootCandidateClaimMaintenanceTimer);
+			this.topicRootCandidateClaimMaintenanceTimer = undefined;
+		}
+	}
+
+	private clearSignedTopicRootCandidateState() {
+		this.clearTopicRootCandidateClaimTimer();
+		this.signedTopicRootCandidateClaims.clear();
+		this.localSignedTopicRootCandidateClaim = undefined;
+		this.topicRootCandidateClaimVerifyBudgets.clear();
+		this.topicRootCandidateClaimGlobalVerifyBudget = {
+			remaining: TOPIC_ROOT_CANDIDATE_CLAIM_GLOBAL_VERIFY_BURST,
+			refilledAt: Date.now(),
+		};
+	}
+
+	private async refreshLocalTopicRootCandidateClaim(): Promise<boolean> {
 		if (
-			!isCanonicalTopicRootCandidate(peerHash) ||
-			peerHash === this.publicKeyHash
-		)
-			return;
-
-		this.queueAutoTopicRootCandidateUpdate([peerHash]);
-	}
-
-	private normalizeAutoTopicRootCandidates(candidates: string[]): string[] {
-		const canonicalCandidates = candidates.filter(
-			isCanonicalTopicRootCandidate,
-		);
-		if (this.nativeTopicControl) {
-			return this.nativeTopicControl.normalizeAutoCandidates(
-				canonicalCandidates,
-				this.publicKeyHash,
-			);
+			!this.autoTopicRootCandidates ||
+			!this.started ||
+			this.stopping ||
+			this.topicControlPlaneStopping
+		) {
+			return false;
 		}
-		const unique = new Set<string>();
-		for (const c of canonicalCandidates) {
-			unique.add(c);
-		}
-		if (isCanonicalTopicRootCandidate(this.publicKeyHash)) {
-			unique.add(this.publicKeyHash);
-		}
-		const sorted = [...unique].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
-		return sorted.slice(0, TOPIC_ROOT_CANDIDATES_MAX);
-	}
-
-	private scheduleAutoTopicRootCandidatesBroadcast(targets?: PeerStreams[]) {
-		if (!this.autoTopicRootCandidates) return;
-		if (!this.started || this.stopping) return;
-
-		if (targets && targets.length > 0) {
-			void this.sendAutoTopicRootCandidates(targets).catch(() => {});
-			return;
-		}
-
-		for (const t of this.autoCandidatesBroadcastTimers) clearTimeout(t);
-		this.autoCandidatesBroadcastTimers = [];
-
-		// Burst a few times to survive early "stream not writable yet" races.
-		const delays = [25, 500, 2_000];
-		for (const delayMs of delays) {
-			const t = setTimeout(() => {
-				void this.sendAutoTopicRootCandidates().catch(() => {});
-			}, delayMs);
-			t.unref?.();
-			this.autoCandidatesBroadcastTimers.push(t);
-		}
-
-		// Keep gossiping for a while after changes so partially connected topologies
-		// converge even under slow stream negotiation.
-		this.autoCandidatesGossipUntil = Date.now() + 60_000;
-		this.ensureAutoCandidatesGossipInterval();
-	}
-
-	private ensureAutoCandidatesGossipInterval() {
-		if (!this.autoTopicRootCandidates) return;
-		if (!this.started || this.stopping) return;
-		if (this.autoCandidatesGossipInterval) return;
-		this.autoCandidatesGossipInterval = setInterval(() => {
-			if (!this.started || this.stopping || !this.autoTopicRootCandidates)
-				return;
-			if (
-				this.autoCandidatesGossipUntil > 0 &&
-				Date.now() > this.autoCandidatesGossipUntil
-			) {
-				if (this.autoCandidatesGossipInterval) {
-					clearInterval(this.autoCandidatesGossipInterval);
-					this.autoCandidatesGossipInterval = undefined;
-				}
-				return;
-			}
-			void this.sendAutoTopicRootCandidates().catch(() => {});
-		}, 2_000);
-		this.autoCandidatesGossipInterval.unref?.();
-	}
-
-	private async sendAutoTopicRootCandidates(targets?: PeerStreams[]) {
-		if (!this.started) throw new NotStartedError();
-		const streams = targets ?? [...this.peers.values()];
-		if (streams.length === 0) return;
-
-		const candidates = this.topicRootControlPlane.getTopicRootCandidates();
-		if (candidates.length === 0) return;
-
-		const msg = new TopicRootCandidates({ candidates });
-		const embedded = await this.createMessage(this.encodePubSubMessage(msg), {
+		const lifecycleRevision = this.topicControlPlaneLifecycleRevision;
+		const now = Date.now();
+		const claim = await this.createMessage(this.topicRootCandidateClaimData, {
 			mode: new AnyWhere(),
 			priority: 1,
+			expiresAt: now + TOPIC_ROOT_CANDIDATE_CLAIM_MAX_LIFETIME_MS,
 			skipRecipientValidation: true,
 		} as any);
-		await this.publishMessageMaybe(this.publicKey, embedded, streams);
+		const bytes = toUint8Array(claim.bytes());
+		if (bytes.byteLength > TOPIC_ROOT_CANDIDATE_CLAIM_MAX_BYTES) {
+			throw new Error(
+				`Local topic-root candidate claim exceeds ${TOPIC_ROOT_CANDIDATE_CLAIM_MAX_BYTES} bytes`,
+			);
+		}
+		if (
+			lifecycleRevision !== this.topicControlPlaneLifecycleRevision ||
+			!this.autoTopicRootCandidates ||
+			!this.started ||
+			this.stopping ||
+			this.topicControlPlaneStopping
+		) {
+			return false;
+		}
+		const record = {
+			bytes,
+			timestamp: claim.header.timestamp,
+			expires: claim.header.expires,
+		};
+		const current = this.localSignedTopicRootCandidateClaim;
+		if (
+			current &&
+			(record.timestamp <= current.timestamp ||
+				record.expires <= current.expires)
+		) {
+			return false;
+		}
+		this.localSignedTopicRootCandidateClaim = record;
+		this.retainSignedTopicRootCandidateClaim(this.publicKeyHash, record);
+		this.rebuildAutoTopicRootCandidatesFromClaims();
+		return true;
 	}
 
-	private mergeAutoTopicRootCandidatesFromPeer(candidates: string[]): boolean {
+	private scheduleTopicRootCandidateClaimMaintenance(minDelayMs = 0) {
+		if (
+			!this.autoTopicRootCandidates ||
+			!this.started ||
+			this.stopping ||
+			this.topicControlPlaneStopping
+		) {
+			return;
+		}
+		this.clearTopicRootCandidateClaimTimer();
+		const now = Date.now();
+		const local = this.localSignedTopicRootCandidateClaim;
+		let dueAt = local
+			? Number(local.timestamp) +
+				TOPIC_ROOT_CANDIDATE_CLAIM_REFRESH_MS +
+				Math.floor(Math.random() * TOPIC_ROOT_CANDIDATE_CLAIM_REFRESH_JITTER_MS)
+			: now;
+		for (const claim of this.signedTopicRootCandidateClaims.values()) {
+			dueAt = Math.min(dueAt, Number(claim.expires) + 1);
+		}
+		if (local) dueAt = Math.min(dueAt, Number(local.expires) + 1);
+		const delayMs = Math.max(minDelayMs, Math.min(2_147_483_647, dueAt - now));
+		const timer = setTimeout(() => {
+			if (this.topicRootCandidateClaimMaintenanceTimer !== timer) return;
+			this.topicRootCandidateClaimMaintenanceTimer = undefined;
+			void (async () => {
+				try {
+					const removed = this.pruneExpiredTopicRootCandidateClaims();
+					const currentLocal = this.localSignedTopicRootCandidateClaim;
+					const refreshDue =
+						!currentLocal ||
+						Date.now() - Number(currentLocal.timestamp) >=
+							TOPIC_ROOT_CANDIDATE_CLAIM_REFRESH_MS;
+					if (removed) this.rebuildAutoTopicRootCandidatesFromClaims();
+					if (
+						refreshDue &&
+						(await this.refreshLocalTopicRootCandidateClaim())
+					) {
+						await this.sendSignedTopicRootCandidateClaims([
+							this.localSignedTopicRootCandidateClaim!.bytes,
+						]);
+					}
+				} catch (error: any) {
+					logErrorIfStarted(error);
+					this.scheduleTopicRootCandidateClaimMaintenance(1_000);
+					return;
+				} finally {
+					if (!this.topicRootCandidateClaimMaintenanceTimer) {
+						this.scheduleTopicRootCandidateClaimMaintenance();
+					}
+				}
+			})();
+		}, delayMs);
+		timer.unref?.();
+		this.topicRootCandidateClaimMaintenanceTimer = timer;
+	}
+
+	private pruneExpiredTopicRootCandidateClaims(
+		now: bigint = BigInt(Date.now()),
+	) {
+		const localClaim = this.localSignedTopicRootCandidateClaim;
+		if (localClaim && localClaim.expires <= now) {
+			this.localSignedTopicRootCandidateClaim = undefined;
+		}
+		let changed = false;
+		for (const [origin, claim] of this.signedTopicRootCandidateClaims) {
+			if (claim.expires <= now) {
+				this.signedTopicRootCandidateClaims.delete(origin);
+				changed = true;
+			}
+		}
+		return changed;
+	}
+
+	private rebuildAutoTopicRootCandidatesFromClaims(): boolean {
 		if (!this.autoTopicRootCandidates) return false;
-		return this.queueAutoTopicRootCandidateUpdate(candidates);
+		this.pruneExpiredTopicRootCandidateClaims();
+		const legacyDirectCandidates = [...this.peers.values()]
+			.filter((peer) => peer.protocol === TOPIC_CONTROL_PLANE_PROTOCOL_V2_0)
+			.map((peer) => peer.publicKey.hashcode());
+		const next = [
+			...(this.localSignedTopicRootCandidateClaim ? [] : [this.publicKeyHash]),
+			...legacyDirectCandidates,
+			...this.signedTopicRootCandidateClaims.keys(),
+		]
+			.filter(isCanonicalTopicRootCandidate)
+			.filter(
+				(candidate, index, candidates) =>
+					candidates.indexOf(candidate) === index,
+			)
+			.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+			.slice(0, TOPIC_ROOT_CANDIDATES_MAX);
+		return this.setAutoTopicRootCandidateSnapshot(next);
 	}
 
-	private queueAutoTopicRootCandidateUpdate(
-		candidates: readonly string[],
+	private retainSignedTopicRootCandidateClaim(
+		origin: string,
+		claim: { bytes: Uint8Array; timestamp: bigint; expires: bigint },
 	): boolean {
+		const existing = this.signedTopicRootCandidateClaims.get(origin);
+		if (existing) {
+			if (
+				claim.timestamp <= existing.timestamp ||
+				claim.expires <= existing.expires
+			) {
+				return false;
+			}
+		} else {
+			if (
+				this.signedTopicRootCandidateClaims.size >= TOPIC_ROOT_CANDIDATES_MAX
+			) {
+				const highest = [...this.signedTopicRootCandidateClaims.keys()]
+					.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+					.at(-1)!;
+				if (origin >= highest) return false;
+				this.signedTopicRootCandidateClaims.delete(highest);
+			}
+		}
+		this.signedTopicRootCandidateClaims.set(origin, claim);
+		return true;
+	}
+
+	private consumeTopicRootCandidateClaimVerifyBudget(
+		peerHash: string,
+	): boolean {
+		const now = Date.now();
+		if (
+			now - this.topicRootCandidateClaimGlobalVerifyBudget.refilledAt >=
+			TOPIC_ROOT_CANDIDATE_CLAIM_VERIFY_REFILL_MS
+		) {
+			this.topicRootCandidateClaimGlobalVerifyBudget = {
+				remaining: TOPIC_ROOT_CANDIDATE_CLAIM_GLOBAL_VERIFY_BURST,
+				refilledAt: now,
+			};
+		}
+		if (this.topicRootCandidateClaimGlobalVerifyBudget.remaining <= 0) {
+			return false;
+		}
+		let budget = this.topicRootCandidateClaimVerifyBudgets.get(peerHash);
+		if (!budget) {
+			if (
+				this.topicRootCandidateClaimVerifyBudgets.size >=
+				TOPIC_ROOT_CANDIDATE_CLAIM_VERIFY_PEERS_MAX
+			) {
+				const oldest = this.topicRootCandidateClaimVerifyBudgets.keys().next()
+					.value as string | undefined;
+				if (oldest) this.topicRootCandidateClaimVerifyBudgets.delete(oldest);
+			}
+			budget = {
+				remaining: TOPIC_ROOT_CANDIDATE_CLAIM_VERIFY_BURST,
+				refilledAt: now,
+			};
+			this.topicRootCandidateClaimVerifyBudgets.set(peerHash, budget);
+		} else if (
+			now - budget.refilledAt >=
+			TOPIC_ROOT_CANDIDATE_CLAIM_VERIFY_REFILL_MS
+		) {
+			budget.remaining = TOPIC_ROOT_CANDIDATE_CLAIM_VERIFY_BURST;
+			budget.refilledAt = now;
+			// Refresh insertion order so bounded eviction remains O(1) and LRU-like.
+			this.topicRootCandidateClaimVerifyBudgets.delete(peerHash);
+			this.topicRootCandidateClaimVerifyBudgets.set(peerHash, budget);
+		}
+		if (budget.remaining <= 0) return false;
+		budget.remaining -= 1;
+		this.topicRootCandidateClaimGlobalVerifyBudget.remaining -= 1;
+		return true;
+	}
+
+	private async importSignedTopicRootCandidateClaim(
+		rawClaim: Uint8Array,
+		outerPeerHash: string,
+	): Promise<boolean> {
+		const lifecycleRevision = this.topicControlPlaneLifecycleRevision;
+		if (
+			rawClaim.byteLength === 0 ||
+			rawClaim.byteLength > TOPIC_ROOT_CANDIDATE_CLAIM_MAX_BYTES
+		) {
+			return false;
+		}
+		let claim: DataMessage;
+		try {
+			claim = DataMessage.from(new Uint8ArrayList(rawClaim));
+		} catch {
+			return false;
+		}
+		const canonicalBytes = toUint8Array(claim.bytes());
+		if (!bytesEqual(canonicalBytes, rawClaim)) return false;
+		if (
+			!claim.data ||
+			!bytesEqual(claim.data, this.topicRootCandidateClaimData)
+		) {
+			return false;
+		}
+		const signatures = claim.header.signatures?.signatures;
+		if (!signatures || signatures.length !== 1) return false;
+		const signer = signatures[0]?.publicKey;
+		if (!signer) return false;
+		const origin = signer.hashcode();
+		if (!isCanonicalTopicRootCandidate(origin)) return false;
+		if (origin === this.publicKeyHash) return false;
+
+		const now = BigInt(Date.now());
+		const timestamp = claim.header.timestamp;
+		const expires = claim.header.expires;
+		if (
+			expires <= now ||
+			expires <= timestamp ||
+			timestamp > now + BigInt(TOPIC_ROOT_CANDIDATE_CLAIM_FUTURE_SKEW_MS) ||
+			expires - timestamp > BigInt(TOPIC_ROOT_CANDIDATE_CLAIM_MAX_LIFETIME_MS)
+		) {
+			return false;
+		}
+
+		const pruned = this.pruneExpiredTopicRootCandidateClaims(now);
+		if (pruned) this.rebuildAutoTopicRootCandidatesFromClaims();
+		const existing = this.signedTopicRootCandidateClaims.get(origin);
+		if (existing) {
+			if (bytesEqual(existing.bytes, rawClaim)) return false;
+			if (timestamp <= existing.timestamp || expires <= existing.expires) {
+				return false;
+			}
+		}
+
+		if (
+			!existing &&
+			this.signedTopicRootCandidateClaims.size >= TOPIC_ROOT_CANDIDATES_MAX
+		) {
+			const highest = [...this.signedTopicRootCandidateClaims.keys()].sort(
+				(a, b) => (a < b ? -1 : a > b ? 1 : 0),
+			);
+			if (origin >= highest.at(-1)!) return false;
+		}
+		if (!this.consumeTopicRootCandidateClaimVerifyBudget(outerPeerHash)) {
+			return false;
+		}
+		this.seedNativeWireVerification(claim, rawClaim);
+		let verified = false;
+		try {
+			verified = await claim.verify(true);
+		} catch {
+			return false;
+		}
+		if (!verified) return false;
+		if (
+			lifecycleRevision !== this.topicControlPlaneLifecycleRevision ||
+			expires <= BigInt(Date.now()) ||
+			!this.autoTopicRootCandidates ||
+			!this.started ||
+			this.stopping ||
+			this.topicControlPlaneStopping
+		) {
+			return false;
+		}
+
+		if (
+			!this.retainSignedTopicRootCandidateClaim(origin, {
+				bytes: rawClaim.slice(),
+				timestamp,
+				expires,
+			})
+		) {
+			return false;
+		}
+		this.scheduleTopicRootCandidateClaimMaintenance();
+		return true;
+	}
+
+	private async sendSignedTopicRootCandidateClaims(
+		claims: Uint8Array[],
+		targets?: PeerStreams[],
+	) {
+		if (claims.length === 0) return;
+		const streams = (targets ?? [...this.peers.values()]).filter(
+			(stream) => stream.protocol === TOPIC_CONTROL_PLANE_PROTOCOL_V2_1,
+		);
+		if (streams.length === 0) return;
+		for (
+			let offset = 0;
+			offset < claims.length;
+			offset += TOPIC_ROOT_CANDIDATE_CLAIMS_MAX
+		) {
+			const message = new TopicRootCandidateClaims({
+				claims: claims.slice(offset, offset + TOPIC_ROOT_CANDIDATE_CLAIMS_MAX),
+			});
+			const embedded = await this.createMessage(
+				this.encodePubSubMessage(message),
+				{
+					mode: new AnyWhere(),
+					priority: 1,
+					skipRecipientValidation: true,
+				} as any,
+			);
+			await this.publishMessageMaybe(this.publicKey, embedded, streams);
+		}
+	}
+
+	private async sendAutoTopicRootCandidates(streams: PeerStreams[]) {
+		if (!this.started) throw new NotStartedError();
+		if (streams.length === 0) return;
+
+		const signedStreams = streams.filter(
+			(stream) => stream.protocol === TOPIC_CONTROL_PLANE_PROTOCOL_V2_1,
+		);
+		if (signedStreams.length > 0) {
+			if (this.pruneExpiredTopicRootCandidateClaims()) {
+				this.rebuildAutoTopicRootCandidatesFromClaims();
+			}
+			if (
+				!this.localSignedTopicRootCandidateClaim &&
+				!(await this.refreshLocalTopicRootCandidateClaim())
+			) {
+				return;
+			}
+			const localClaim = this.localSignedTopicRootCandidateClaim;
+			if (!localClaim) return;
+			const claims = [...this.signedTopicRootCandidateClaims.entries()]
+				.sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+				.map(([, claim]) => claim.bytes);
+			await this.sendSignedTopicRootCandidateClaims(claims, signedStreams);
+			if (!this.signedTopicRootCandidateClaims.has(this.publicKeyHash)) {
+				await this.sendSignedTopicRootCandidateClaims(
+					[localClaim.bytes],
+					signedStreams,
+				);
+			}
+		}
+	}
+
+	private setAutoTopicRootCandidateSnapshot(next: string[]): boolean {
 		if (
 			!this.autoTopicRootCandidates ||
 			this.stopping ||
 			this.topicControlPlaneStopping
-		)
+		) {
 			return false;
-		if (this.maybeDisableAutoTopicRootCandidatesIfExternallyConfigured())
+		}
+		if (this.maybeDisableAutoTopicRootCandidatesIfExternallyConfigured()) {
 			return false;
+		}
 		const managed = this.autoTopicRootCandidateSet;
 		if (!managed) return false;
-
 		const before = this.pendingAutoTopicRootCandidates ?? [...managed];
-		const next = this.normalizeAutoTopicRootCandidates([
-			...before,
-			...candidates,
-		]);
 		if (sameCandidates(before, next)) return false;
 
 		if (this.autoTopicRootCandidateUpdateTimer) {
@@ -921,7 +1295,6 @@ export class TopicControlPlane
 		this.shardRootCache.clear();
 		this.scheduleReconcileShardOverlays();
 		this.scheduleHostOwnedShardRoots();
-		this.scheduleAutoTopicRootCandidatesBroadcast();
 	}
 
 	private scheduleAutoTopicRootCandidateUpdateCooldown() {
@@ -1276,6 +1649,11 @@ export class TopicControlPlane
 	private decodePubSubMessage(bytes: Uint8Array): PubSubMessage {
 		if (bytes[0] === 4) {
 			assertTopicRootCandidatesFrame(bytes);
+		}
+		// Signed candidate claims are low-frequency opaque host-side frames. Keep
+		// this explicit seam ahead of the native variants 0-7 codec.
+		if (bytes[0] === 8) {
+			return TopicRootCandidateClaims.from(bytes);
 		}
 		const native = this.nativeTopicControl;
 		if (native) {
@@ -3112,6 +3490,7 @@ export class TopicControlPlane
 		const { pubsubMessage, message, from, stream } = input;
 		const isDirectRootControl =
 			pubsubMessage instanceof TopicRootCandidates ||
+			pubsubMessage instanceof TopicRootCandidateClaims ||
 			pubsubMessage instanceof TopicRootQuery ||
 			pubsubMessage instanceof TopicRootQueryResponse;
 		const directRootSigner = isDirectRootControl
@@ -3125,8 +3504,41 @@ export class TopicControlPlane
 		}
 
 		if (pubsubMessage instanceof TopicRootCandidates) {
-			// Used only to converge deterministic shard-root candidates in auto mode.
-			this.mergeAutoTopicRootCandidatesFromPeer(pubsubMessage.candidates);
+			if (stream.protocol !== TOPIC_CONTROL_PLANE_PROTOCOL_V2_0) {
+				return;
+			}
+			// `addPeer()` already admitted the authenticated direct stream identity.
+			// The advertised list is intentionally ignored.
+			return;
+		}
+
+		if (pubsubMessage instanceof TopicRootCandidateClaims) {
+			if (
+				stream.protocol !== TOPIC_CONTROL_PLANE_PROTOCOL_V2_1 ||
+				!this.autoTopicRootCandidates
+			) {
+				return;
+			}
+			const imported: Uint8Array[] = [];
+			const outerPeerHash = stream.publicKey.hashcode();
+			for (const claim of pubsubMessage.claims) {
+				if (
+					await this.importSignedTopicRootCandidateClaim(claim, outerPeerHash)
+				) {
+					imported.push(claim);
+				}
+			}
+			if (imported.length > 0) {
+				this.rebuildAutoTopicRootCandidatesFromClaims();
+				// Relay the exact nested claims; no relay signature is substituted for
+				// their origin signatures.
+				void this.sendSignedTopicRootCandidateClaims(
+					imported,
+					[...this.peers.values()].filter(
+						(peer) => peer.publicKey.hashcode() !== outerPeerHash,
+					),
+				).catch(() => {});
+			}
 			return;
 		}
 
@@ -3465,6 +3877,7 @@ export class TopicControlPlane
 		if (
 			!(pubsubMessage instanceof PubSubData) &&
 			!(pubsubMessage instanceof TopicRootCandidates) &&
+			!(pubsubMessage instanceof TopicRootCandidateClaims) &&
 			!(pubsubMessage instanceof TopicRootQuery) &&
 			!(pubsubMessage instanceof GetSubscribers) &&
 			!(pubsubMessage instanceof Subscribe) &&

--- a/packages/transport/pubsub/test/subscribe-races.spec.ts
+++ b/packages/transport/pubsub/test/subscribe-races.spec.ts
@@ -3,12 +3,14 @@ import { getPublicKeyFromPeerId, sha256Base64Sync } from "@peerbit/crypto";
 import { TestSession } from "@peerbit/libp2p-test-utils";
 import {
 	TOPIC_ROOT_CANDIDATES_MAX,
+	TopicRootCandidateClaims,
 	TopicRootCandidates,
 	TopicRootQuery,
 	TopicRootQueryResponse,
 } from "@peerbit/pubsub-interface";
 import { waitForNeighbour } from "@peerbit/stream";
 import {
+	AnyWhere,
 	DataMessage,
 	type DeliveryMode,
 	MessageHeader,
@@ -197,6 +199,25 @@ describe("pubsub (subscribe race regressions)", function () {
 
 	const canonicalCandidate = (label: string) =>
 		sha256Base64Sync(new TextEncoder().encode(label));
+	const nextAutoTopicRootCandidateSnapshot = (
+		pubsub: TopicControlPlane,
+		additions: readonly string[],
+	) => {
+		const internals = pubsub as any;
+		const before =
+			internals.pendingAutoTopicRootCandidates ??
+			pubsub.topicRootControlPlane.getTopicRootCandidates();
+		return [...new Set([...before, ...additions])]
+			.sort((left, right) => (left < right ? -1 : left > right ? 1 : 0))
+			.slice(0, TOPIC_ROOT_CANDIDATES_MAX);
+	};
+	const addAutoTopicRootCandidatesForTest = (
+		pubsub: TopicControlPlane,
+		additions: readonly string[],
+	) =>
+		(pubsub as any).setAutoTopicRootCandidateSnapshot(
+			nextAutoTopicRootCandidateSnapshot(pubsub, additions),
+		);
 	const preparePendingAutoTopicRootCandidateUpdate = (
 		pubsub: TopicControlPlane,
 		label: string,
@@ -204,14 +225,13 @@ describe("pubsub (subscribe race regressions)", function () {
 		const internals = pubsub as any;
 		internals.scheduleReconcileShardOverlays = () => {};
 		internals.scheduleHostOwnedShardRoots = () => {};
-		internals.scheduleAutoTopicRootCandidatesBroadcast = () => {};
 		expect(
-			internals.mergeAutoTopicRootCandidatesFromPeer([
+			addAutoTopicRootCandidatesForTest(pubsub, [
 				canonicalCandidate(`${label}-leading`),
 			]),
 		).to.equal(true);
 		expect(
-			internals.mergeAutoTopicRootCandidatesFromPeer([
+			addAutoTopicRootCandidatesForTest(pubsub, [
 				canonicalCandidate(`${label}-pending`),
 			]),
 		).to.equal(true);
@@ -335,7 +355,6 @@ describe("pubsub (subscribe race regressions)", function () {
 		const queryEntered = deferred();
 		internals.scheduleReconcileShardOverlays = () => {};
 		internals.scheduleHostOwnedShardRoots = () => {};
-		internals.scheduleAutoTopicRootCandidatesBroadcast = () => {};
 		internals.getConnectedTopicRootTrackers = () => [{}];
 		let queryCalls = 0;
 		internals.resolveTopicRootThroughPeers = async () => {
@@ -349,7 +368,7 @@ describe("pubsub (subscribe race regressions)", function () {
 		const resolving = internals.resolveTopicRootState(topic);
 		await queryEntered.promise;
 		expect(
-			internals.mergeAutoTopicRootCandidatesFromPeer([addedCandidate]),
+			addAutoTopicRootCandidatesForTest(pubsub, [addedCandidate]),
 		).to.equal(true);
 		queryGate.resolve();
 
@@ -372,7 +391,6 @@ describe("pubsub (subscribe race regressions)", function () {
 
 		internals.scheduleReconcileShardOverlays = () => {};
 		internals.scheduleHostOwnedShardRoots = () => {};
-		internals.scheduleAutoTopicRootCandidatesBroadcast = () => {};
 		let queryCalls = 0;
 		internals.resolveTopicRootThroughPeers = async () => {
 			queryCalls += 1;
@@ -399,54 +417,13 @@ describe("pubsub (subscribe race regressions)", function () {
 			.then((state: { root: string }) => state.root);
 		await firstStateReady.promise;
 		expect(
-			internals.mergeAutoTopicRootCandidatesFromPeer([addedCandidate]),
+			addAutoTopicRootCandidatesForTest(pubsub, [addedCandidate]),
 		).to.equal(true);
 		firstStateGate.resolve();
 
 		expect(await resolving).to.equal(currentRoot);
 		expect(internals.shardRootCache.get(topic)?.root).to.equal(currentRoot);
 		expect(stateCalls).to.equal(2);
-	});
-
-	it("bounds the managed auto-candidate set when normalization is a no-op", async () => {
-		session = await createDisconnectedSessionWithPerPeerRoots(1);
-		const pubsub = session.peers[0]!.services.pubsub;
-		const internals = pubsub as any;
-		const base64Alphabet =
-			"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-		const lowCandidates = [...base64Alphabet].map(
-			(character) => "A".repeat(41) + character + "A=",
-		);
-		const discardedHighCandidates = [...base64Alphabet].map(
-			(character) => "z".repeat(41) + character + "8=",
-		);
-
-		const scheduled = { broadcast: 0, host: 0, reconcile: 0 };
-		internals.scheduleReconcileShardOverlays = () => scheduled.reconcile++;
-		internals.scheduleHostOwnedShardRoots = () => scheduled.host++;
-		internals.scheduleAutoTopicRootCandidatesBroadcast = () =>
-			scheduled.broadcast++;
-		expect(
-			internals.mergeAutoTopicRootCandidatesFromPeer(lowCandidates),
-		).to.equal(true);
-		const before = pubsub.topicRootControlPlane.getTopicRootCandidates();
-		expect(before).to.have.length(64);
-
-		expect(
-			internals.mergeAutoTopicRootCandidatesFromPeer(discardedHighCandidates),
-		).to.equal(false);
-		expect(pubsub.topicRootControlPlane.getTopicRootCandidates()).to.deep.equal(
-			before,
-		);
-		expect(internals.autoTopicRootCandidateSet.size).to.equal(64);
-		expect([...internals.autoTopicRootCandidateSet]).to.have.members(before);
-
-		const afterMerge = { ...scheduled };
-		const discardedDirectPeer = discardedHighCandidates[0]!;
-		expect(before).not.to.include(discardedDirectPeer);
-		internals.maybeUpdateAutoTopicRootCandidates(discardedDirectPeer);
-		expect(scheduled).to.deep.equal(afterMerge);
-		expect(internals.autoTopicRootCandidateSet.size).to.equal(64);
 	});
 
 	it("coalesces auto-candidate generations globally on a fixed cooldown", async () => {
@@ -457,84 +434,68 @@ describe("pubsub (subscribe race regressions)", function () {
 			now: Date.now(),
 			toFake: ["Date", "clearTimeout", "setTimeout"],
 		});
-		const scheduled = { broadcast: 0, host: 0, reconcile: 0 };
+		const scheduled = { host: 0, reconcile: 0 };
 		internals.scheduleReconcileShardOverlays = () => scheduled.reconcile++;
 		internals.scheduleHostOwnedShardRoots = () => scheduled.host++;
-		internals.scheduleAutoTopicRootCandidatesBroadcast = () =>
-			scheduled.broadcast++;
-
-		const candidates = Array.from({ length: 160 }, (_, index) =>
+		const candidates = Array.from({ length: 4 }, (_, index) =>
 			canonicalCandidate(`coalesced-auto-root-${index}`),
-		).sort((left, right) => (left < right ? 1 : left > right ? -1 : 0));
+		);
+		const initial = pubsub.topicRootControlPlane.getTopicRootCandidates();
+		const leading = [...initial, candidates[0]!].sort();
+		const interim = [...leading, candidates[1]!].sort();
+		const trailing = [...interim, candidates[2]!].sort();
+		const final = [...trailing, candidates[3]!].sort();
 
 		try {
-			expect(
-				internals.mergeAutoTopicRootCandidatesFromPeer([candidates[0]]),
-			).to.equal(true);
-			expect(scheduled).to.deep.equal({ broadcast: 1, host: 1, reconcile: 1 });
+			expect(internals.setAutoTopicRootCandidateSnapshot(leading)).to.equal(
+				true,
+			);
+			expect(scheduled).to.deep.equal({ host: 1, reconcile: 1 });
 			expect(internals.pendingAutoTopicRootCandidates).to.equal(undefined);
 			const leadingTimer = internals.autoTopicRootCandidateUpdateTimer;
 			expect(leadingTimer).to.not.equal(undefined);
 
-			for (let index = 1; index < candidates.length; index++) {
-				if (index % 2 === 0) {
-					internals.maybeUpdateAutoTopicRootCandidates(candidates[index]);
-				} else {
-					expect(
-						internals.mergeAutoTopicRootCandidatesFromPeer([candidates[index]]),
-					).to.equal(true);
-				}
-				expect(internals.autoTopicRootCandidateUpdateTimer).to.equal(
-					leadingTimer,
-				);
-				expect(internals.pendingAutoTopicRootCandidates.length).to.be.at.most(
-					TOPIC_ROOT_CANDIDATES_MAX,
-				);
-			}
-
-			const expectedTrailing = internals.normalizeAutoTopicRootCandidates([
-				...candidates,
-				pubsub.publicKeyHash,
-			]);
-			expect(internals.pendingAutoTopicRootCandidates).to.deep.equal(
-				expectedTrailing,
+			expect(internals.setAutoTopicRootCandidateSnapshot(interim)).to.equal(
+				true,
 			);
-			expect(internals.pendingAutoTopicRootCandidates).to.have.length(
-				TOPIC_ROOT_CANDIDATES_MAX,
+			expect(internals.setAutoTopicRootCandidateSnapshot(trailing)).to.equal(
+				true,
 			);
+			expect(internals.autoTopicRootCandidateUpdateTimer).to.equal(
+				leadingTimer,
+			);
+			expect(internals.pendingAutoTopicRootCandidates).to.deep.equal(trailing);
 			expect(
 				internals.maybeDisableAutoTopicRootCandidatesIfExternallyConfigured(),
 			).to.equal(false);
 			expect([...internals.autoTopicRootCandidateSet]).to.deep.equal(
 				pubsub.topicRootControlPlane.getTopicRootCandidates(),
 			);
-			expect(scheduled).to.deep.equal({ broadcast: 1, host: 1, reconcile: 1 });
+			expect(scheduled).to.deep.equal({ host: 1, reconcile: 1 });
 
 			clock.tick(1_999);
-			expect(scheduled).to.deep.equal({ broadcast: 1, host: 1, reconcile: 1 });
+			expect(scheduled).to.deep.equal({ host: 1, reconcile: 1 });
 			clock.tick(1);
 			expect(
 				pubsub.topicRootControlPlane.getTopicRootCandidates(),
-			).to.deep.equal(expectedTrailing);
-			expect(scheduled).to.deep.equal({ broadcast: 2, host: 2, reconcile: 2 });
+			).to.deep.equal(trailing);
+			expect(scheduled).to.deep.equal({ host: 2, reconcile: 2 });
 			expect(internals.pendingAutoTopicRootCandidates).to.equal(undefined);
 
 			const trailingTimer = internals.autoTopicRootCandidateUpdateTimer;
 			expect(trailingTimer).to.not.equal(undefined);
 			expect(trailingTimer).to.not.equal(leadingTimer);
-			const nextCandidate = "A".repeat(43) + "=";
-			expect(expectedTrailing).not.to.include(nextCandidate);
-			internals.maybeUpdateAutoTopicRootCandidates(nextCandidate);
+			expect(internals.setAutoTopicRootCandidateSnapshot(final)).to.equal(true);
 			expect(internals.autoTopicRootCandidateUpdateTimer).to.equal(
 				trailingTimer,
 			);
-			expect(scheduled).to.deep.equal({ broadcast: 2, host: 2, reconcile: 2 });
+			expect(scheduled).to.deep.equal({ host: 2, reconcile: 2 });
 
 			clock.tick(2_000);
-			expect(pubsub.topicRootControlPlane.getTopicRootCandidates()).to.include(
-				nextCandidate,
-			);
-			expect(scheduled).to.deep.equal({ broadcast: 3, host: 3, reconcile: 3 });
+			expect(
+				pubsub.topicRootControlPlane.getTopicRootCandidates(),
+			).to.deep.equal(final);
+			expect(scheduled).to.deep.equal({ host: 3, reconcile: 3 });
 		} finally {
 			internals.clearAutoTopicRootCandidateUpdateSchedule();
 			clock.restore();
@@ -601,30 +562,6 @@ describe("pubsub (subscribe race regressions)", function () {
 		);
 	});
 
-	it("filters non-canonical candidates only from auto mode", async () => {
-		session = await createDisconnectedSessionWithPerPeerRoots(1);
-		const pubsub = session.peers[0]!.services.pubsub;
-		const internals = pubsub as any;
-		const nonCanonicalCandidate = "A".repeat(42) + "B=";
-		const before = pubsub.topicRootControlPlane.getTopicRootCandidates();
-
-		expect(
-			internals.mergeAutoTopicRootCandidatesFromPeer([nonCanonicalCandidate]),
-		).to.equal(false);
-		expect(pubsub.topicRootControlPlane.getTopicRootCandidates()).to.deep.equal(
-			before,
-		);
-		expect(
-			internals.autoTopicRootCandidateSet.has(nonCanonicalCandidate),
-		).to.equal(false);
-
-		pubsub.setTopicRootCandidates([nonCanonicalCandidate]);
-		expect(pubsub.topicRootControlPlane.getTopicRootCandidates()).to.deep.equal(
-			[nonCanonicalCandidate],
-		);
-		expect(internals.autoTopicRootCandidates).to.equal(false);
-	});
-
 	it("does not let an old opener block or overwrite the current generation", async () => {
 		session = await createDisconnectedSessionWithPerPeerRoots(1);
 		const pubsub = session.peers[0]!.services.pubsub;
@@ -635,10 +572,7 @@ describe("pubsub (subscribe race regressions)", function () {
 
 		internals.scheduleReconcileShardOverlays = () => {};
 		internals.scheduleHostOwnedShardRoots = () => {};
-		internals.scheduleAutoTopicRootCandidatesBroadcast = () => {};
-		expect(internals.mergeAutoTopicRootCandidatesFromPeer([oldRoot])).to.equal(
-			true,
-		);
+		expect(addAutoTopicRootCandidatesForTest(pubsub, [oldRoot])).to.equal(true);
 		// The first merge only establishes this race's stale generation. Expire its
 		// cooldown so the later merge remains the immediate generation change under test.
 		internals.clearAutoTopicRootCandidateUpdateSchedule();
@@ -689,7 +623,7 @@ describe("pubsub (subscribe race regressions)", function () {
 		try {
 			await confirmationEntered.promise;
 			expect(
-				internals.mergeAutoTopicRootCandidatesFromPeer([addedCandidate]),
+				addAutoTopicRootCandidatesForTest(pubsub, [addedCandidate]),
 			).to.equal(true);
 			const currentGeneration = internals.getTopicRootCandidateGeneration();
 			internals.resolveShardRootState = async () => {
@@ -735,9 +669,8 @@ describe("pubsub (subscribe race regressions)", function () {
 		const addedCandidate = canonicalCandidate("moved-root");
 
 		internals.scheduleHostOwnedShardRoots = () => {};
-		internals.scheduleAutoTopicRootCandidatesBroadcast = () => {};
 		expect(
-			internals.mergeAutoTopicRootCandidatesFromPeer([staleRoot]),
+			addAutoTopicRootCandidatesForTest(pubsub, [staleRoot]),
 		).to.equal(true);
 		// The first merge only establishes this race's stale generation. Expire its
 		// cooldown so the later merge remains the immediate generation change under test.
@@ -770,7 +703,7 @@ describe("pubsub (subscribe race regressions)", function () {
 			await staleJoin.started;
 
 			expect(
-				internals.mergeAutoTopicRootCandidatesFromPeer([addedCandidate]),
+				addAutoTopicRootCandidatesForTest(pubsub, [addedCandidate]),
 			).to.equal(true);
 			await Promise.race([
 				staleJoin.aborted,
@@ -800,15 +733,13 @@ describe("pubsub (subscribe race regressions)", function () {
 		const staleRoot = canonicalCandidate("queued-stale-join");
 		const addedCandidate = canonicalCandidate("queued-moved-root");
 		internals.scheduleHostOwnedShardRoots = () => {};
-		internals.scheduleAutoTopicRootCandidatesBroadcast = () => {};
 
 		expect(
-			internals.mergeAutoTopicRootCandidatesFromPeer([staleRoot]),
+			addAutoTopicRootCandidatesForTest(pubsub, [staleRoot]),
 		).to.equal(true);
 		const beforeCandidates =
 			pubsub.topicRootControlPlane.getTopicRootCandidates();
-		const afterCandidates = internals.normalizeAutoTopicRootCandidates([
-			...beforeCandidates,
+		const afterCandidates = nextAutoTopicRootCandidateSnapshot(pubsub, [
 			addedCandidate,
 		]);
 		const { topic } = findCandidateTransitionTopic(
@@ -839,7 +770,7 @@ describe("pubsub (subscribe race regressions)", function () {
 			await staleJoin.started;
 
 			expect(
-				internals.mergeAutoTopicRootCandidatesFromPeer([addedCandidate]),
+				addAutoTopicRootCandidatesForTest(pubsub, [addedCandidate]),
 			).to.equal(true);
 			expect(internals.getTopicRootCandidateGeneration()).to.equal(
 				staleGeneration,
@@ -887,10 +818,9 @@ describe("pubsub (subscribe race regressions)", function () {
 		const addedCandidate = canonicalCandidate("transient-root");
 
 		internals.scheduleHostOwnedShardRoots = () => {};
-		internals.scheduleAutoTopicRootCandidatesBroadcast = () => {};
 		internals.reconcileShardOverlays = async () => {};
 		expect(
-			internals.mergeAutoTopicRootCandidatesFromPeer([staleRoot]),
+			addAutoTopicRootCandidatesForTest(pubsub, [staleRoot]),
 		).to.equal(true);
 		const originalCandidates =
 			pubsub.topicRootControlPlane.getTopicRootCandidates();
@@ -1070,9 +1000,7 @@ describe("pubsub (subscribe race regressions)", function () {
 		const pubsub = session.peers[0]!.services.pubsub;
 		const internals = pubsub as any;
 		const autoPeer = canonicalCandidate("stale-auto-peer");
-		expect(internals.mergeAutoTopicRootCandidatesFromPeer([autoPeer])).to.equal(
-			true,
-		);
+		expect(addAutoTopicRootCandidatesForTest(pubsub, [autoPeer])).to.equal(true);
 		const candidates = pubsub.topicRootControlPlane.getTopicRootCandidates();
 		const { afterRoot: deterministicRoot, topic: shardTopic } =
 			findCandidateTransitionTopic(
@@ -1210,6 +1138,447 @@ describe("pubsub (subscribe race regressions)", function () {
 		expect(receiver.topicRootControlPlane.getTopicRootCandidates()).to.deep.equal(
 			candidatesBefore,
 		);
+	});
+
+	it("imports a relayed 2.1 candidate only from its nested self-signature", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(3);
+		const receiver = session.peers[0]!.services.pubsub;
+		const origin = session.peers[1]!.services.pubsub;
+		const relay = session.peers[2]!.services.pubsub;
+		const originInternals = origin as any;
+		const receiverInternals = receiver as any;
+		await originInternals.refreshLocalTopicRootCandidateClaim();
+		const rawClaim = originInternals.signedTopicRootCandidateClaims.get(
+			origin.publicKeyHash,
+		).bytes;
+		const relayDelta = sinon
+			.stub(receiverInternals, "sendSignedTopicRootCandidateClaims")
+			.resolves();
+		const relaySnapshot = sinon
+			.stub(receiverInternals, "sendAutoTopicRootCandidates")
+			.resolves();
+
+		await receiverInternals.processDirectPubSubMessage({
+			pubsubMessage: new TopicRootCandidateClaims({ claims: [rawClaim] }),
+			message: {
+				header: { signatures: { publicKeys: [relay.publicKey] } },
+			},
+			from: relay.publicKey,
+			stream: {
+				protocol: "/peerbit/topic-control-plane/2.1.0",
+				publicKey: relay.publicKey,
+			},
+		});
+
+		expect(receiver.topicRootControlPlane.getTopicRootCandidates()).to.include(
+			origin.publicKeyHash,
+		);
+		expect(
+			receiverInternals.signedTopicRootCandidateClaims.get(origin.publicKeyHash)
+				?.bytes,
+		).to.deep.equal(rawClaim);
+		expect(relayDelta.calledOnce).to.equal(true);
+		expect(relayDelta.firstCall.args[0]).to.deep.equal([rawClaim]);
+		expect(relaySnapshot.called).to.equal(false);
+	});
+
+	it("advertises 2.1 first and keeps signed claims outside the native variants codec", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		expect(pubsub.multicodecs).to.deep.equal([
+			"/peerbit/topic-control-plane/2.1.0",
+			"/peerbit/topic-control-plane/2.0.0",
+		]);
+		internals.nativeTopicControl = {
+			decodePubSubMessage: () => {
+				throw new Error("variant 8 reached native variants codec");
+			},
+		};
+		const encoded = internals.encodePubSubMessage(
+			new TopicRootCandidateClaims({ claims: [] }),
+		);
+
+		expect(encoded[0]).to.equal(8);
+		expect(internals.decodePubSubMessage(encoded)).to.be.instanceOf(
+			TopicRootCandidateClaims,
+		);
+	});
+
+	it("sends the signed snapshot on each outbound stream", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(2);
+		const receiver = session.peers[0]!.services.pubsub;
+		const sender = session.peers[1]!.services.pubsub;
+		const internals = receiver as any;
+		const send = sinon
+			.stub(internals, "sendAutoTopicRootCandidates")
+			.resolves();
+
+		const stream = receiver.addPeer(
+			sender.peerId,
+			sender.publicKey,
+			"/peerbit/topic-control-plane/2.1.0",
+			"outbound-ready-retry-test",
+		);
+		expect(send.called).to.equal(false);
+		stream.dispatchEvent(new CustomEvent("stream:outbound"));
+		await waitForResolved(() => expect(send.callCount).to.equal(1), {
+			timeout: 1_000,
+			delayInterval: 10,
+		});
+		stream.dispatchEvent(new CustomEvent("stream:outbound"));
+		await waitForResolved(() => expect(send.callCount).to.equal(2), {
+			timeout: 1_000,
+			delayInterval: 10,
+		});
+	});
+
+	it("rejects tampered, wrong-scope, expired, and multisigned 2.1 claims", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(3);
+		const receiver = session.peers[0]!.services.pubsub;
+		const origin = session.peers[1]!.services.pubsub;
+		const extraSigner = session.peers[2]!.services.pubsub;
+		const receiverInternals = receiver as any;
+		const originInternals = origin as any;
+		const encode = (message: DataMessage) => {
+			const bytes = message.bytes();
+			return bytes instanceof Uint8Array ? bytes : bytes.subarray();
+		};
+		const makeClaim = async (options?: {
+			data?: Uint8Array;
+			expiresAt?: number;
+			extraSigners?: any[];
+		}) =>
+			encode(
+				await originInternals.createMessage(
+					options?.data ?? originInternals.topicRootCandidateClaimData,
+					{
+						expiresAt: options?.expiresAt,
+						extraSigners: options?.extraSigners,
+						mode: new AnyWhere(),
+						priority: 1,
+						skipRecipientValidation: true,
+					},
+				),
+			);
+
+		const valid = await makeClaim();
+		const tampered = valid.slice();
+		tampered[tampered.length - 1] ^= 1;
+		const wrongScope = originInternals.topicRootCandidateClaimData.slice();
+		wrongScope[wrongScope.length - 1] ^= 1;
+		const future = await originInternals.createMessage(
+			originInternals.topicRootCandidateClaimData,
+			{
+				mode: new AnyWhere(),
+				priority: 1,
+				skipRecipientValidation: true,
+			},
+		);
+		future.header.timestamp = BigInt(Date.now() + 60_000);
+		future.header.expires = future.header.timestamp + 60_000n;
+		future.header.signatures = undefined;
+		await future.sign(origin.sign);
+		const unsupportedPrehash = await originInternals.createMessage(
+			originInternals.topicRootCandidateClaimData,
+			{
+				mode: new AnyWhere(),
+				priority: 1,
+				skipRecipientValidation: true,
+			},
+		);
+		unsupportedPrehash.header.signatures!.signatures[0]!.prehash = 2 as any;
+		const cases = [
+			tampered,
+			await makeClaim({ data: wrongScope }),
+			await makeClaim({ expiresAt: Date.now() - 1 }),
+			await makeClaim({ expiresAt: Date.now() + 10 * 60_000 }),
+			encode(future),
+			await makeClaim({ extraSigners: [extraSigner.sign] }),
+			encode(unsupportedPrehash),
+		];
+
+		for (const claim of cases) {
+			expect(
+				await receiverInternals.importSignedTopicRootCandidateClaim(
+					claim,
+					extraSigner.publicKeyHash,
+				),
+			).to.equal(false);
+		}
+		expect(
+			receiverInternals.signedTopicRootCandidateClaims.has(
+				origin.publicKeyHash,
+			),
+		).to.equal(false);
+	});
+
+	it("does not let a legacy peer inject its advertised candidate list", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(2);
+		const receiver = session.peers[0]!.services.pubsub;
+		const sender = session.peers[1]!.services.pubsub;
+		const receiverInternals = receiver as any;
+		const injected = Array.from(
+			{ length: TOPIC_ROOT_CANDIDATES_MAX },
+			(_, index) => canonicalCandidate(`legacy-injected-${index}`),
+		);
+		receiver.addPeer(
+			sender.peerId,
+			sender.publicKey,
+			"/peerbit/topic-control-plane/2.0.0",
+			"legacy-injection-test",
+		);
+		const admitted = receiver.topicRootControlPlane.getTopicRootCandidates();
+		expect(admitted).to.include(sender.publicKeyHash);
+
+		await receiverInternals.processDirectPubSubMessage({
+			pubsubMessage: new TopicRootCandidates({ candidates: injected }),
+			message: {
+				header: { signatures: { publicKeys: [sender.publicKey] } },
+			},
+			from: sender.publicKey,
+			stream: {
+				protocol: "/peerbit/topic-control-plane/2.0.0",
+				publicKey: sender.publicKey,
+			},
+		});
+
+		const after = receiver.topicRootControlPlane.getTopicRootCandidates();
+		expect(after).to.deep.equal(admitted);
+		expect(
+			after.filter((candidate) => injected.includes(candidate)),
+		).to.deep.equal([]);
+
+		await receiverInternals.processDirectPubSubMessage({
+			pubsubMessage: new TopicRootCandidates({ candidates: injected }),
+			message: {
+				header: { signatures: { publicKeys: [sender.publicKey] } },
+			},
+			from: sender.publicKey,
+			stream: {
+				protocol: "/peerbit/topic-control-plane/2.1.0",
+				publicKey: sender.publicKey,
+			},
+		});
+		expect(
+			receiver.topicRootControlPlane.getTopicRootCandidates(),
+		).to.deep.equal(admitted);
+	});
+
+	it("selects the same lowest 64 signed origins without preferring self", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(2);
+		const left = session.peers[0]!.services.pubsub;
+		const right = session.peers[1]!.services.pubsub;
+		const origins = [
+			left.publicKeyHash,
+			right.publicKeyHash,
+			...Array.from({ length: 63 }, (_, index) =>
+				canonicalCandidate(`signed-cap-${index}`),
+			),
+		];
+		const expected = [...origins].sort().slice(0, TOPIC_ROOT_CANDIDATES_MAX);
+		const record = (index: number) => ({
+			bytes: new Uint8Array([index]),
+			expires: BigInt(Date.now() + 60_000),
+			timestamp: BigInt(Date.now()),
+		});
+
+		for (const [peer, ordered] of [
+			[left, origins],
+			[right, [...origins].reverse()],
+		] as const) {
+			const internals = peer as any;
+			internals.signedTopicRootCandidateClaims.clear();
+			for (const [index, origin] of ordered.entries()) {
+				internals.retainSignedTopicRootCandidateClaim(origin, record(index));
+			}
+			expect(internals.signedTopicRootCandidateClaims.size).to.equal(
+				TOPIC_ROOT_CANDIDATES_MAX,
+			);
+			internals.rebuildAutoTopicRootCandidatesFromClaims();
+			expect(peer.topicRootControlPlane.getTopicRootCandidates()).to.deep.equal(
+				expected,
+			);
+		}
+	});
+
+	it("does not retain a claim whose verification finishes after stop", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(2);
+		const receiver = session.peers[0]!.services.pubsub;
+		const origin = session.peers[1]!.services.pubsub;
+		const receiverInternals = receiver as any;
+		const originInternals = origin as any;
+		await originInternals.refreshLocalTopicRootCandidateClaim();
+		const rawClaim = originInternals.localSignedTopicRootCandidateClaim.bytes;
+		const verification = deferred();
+		const verify = sinon
+			.stub(DataMessage.prototype, "verify")
+			.callsFake(async () => {
+				await verification.promise;
+				return true;
+			});
+
+		try {
+			const importing = receiverInternals.importSignedTopicRootCandidateClaim(
+				rawClaim,
+				origin.publicKeyHash,
+			);
+			await waitForResolved(() => expect(verify.calledOnce).to.equal(true), {
+				timeout: 1_000,
+				delayInterval: 10,
+			});
+			await receiver.stop();
+			verification.resolve();
+
+			expect(await importing).to.equal(false);
+			expect(receiverInternals.signedTopicRootCandidateClaims.size).to.equal(0);
+			expect(receiverInternals.localSignedTopicRootCandidateClaim).to.equal(
+				undefined,
+			);
+		} finally {
+			verification.resolve();
+			verify.restore();
+		}
+	});
+
+	it("does not retain an old claim after stop and restart", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(2);
+		const receiver = session.peers[0]!.services.pubsub;
+		const origin = session.peers[1]!.services.pubsub;
+		const receiverInternals = receiver as any;
+		const originInternals = origin as any;
+		await originInternals.refreshLocalTopicRootCandidateClaim();
+		const rawClaim = originInternals.localSignedTopicRootCandidateClaim.bytes;
+		const verification = deferred();
+		const verify = sinon
+			.stub(DataMessage.prototype, "verify")
+			.callsFake(async () => {
+				await verification.promise;
+				return true;
+			});
+
+		try {
+			const importing = receiverInternals.importSignedTopicRootCandidateClaim(
+				rawClaim,
+				origin.publicKeyHash,
+			);
+			await waitForResolved(() => expect(verify.calledOnce).to.equal(true), {
+				timeout: 1_000,
+				delayInterval: 10,
+			});
+			await receiver.stop();
+			await receiver.start();
+			verification.resolve();
+
+			expect(await importing).to.equal(false);
+			expect(
+				receiverInternals.signedTopicRootCandidateClaims.has(
+					origin.publicKeyHash,
+				),
+			).to.equal(false);
+		} finally {
+			verification.resolve();
+			verify.restore();
+		}
+	});
+
+	it("keeps the newest local claim when signing finishes out of order", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(1);
+		const pubsub = session.peers[0]!.services.pubsub;
+		const internals = pubsub as any;
+		const originalCreate = internals.createMessage.bind(pubsub);
+		const makeClaim = () =>
+			originalCreate(internals.topicRootCandidateClaimData, {
+				expiresAt: Date.now() + 5 * 60_000,
+				mode: new AnyWhere(),
+				priority: 1,
+				skipRecipientValidation: true,
+			});
+		const older = await makeClaim();
+		await delay(5);
+		const newer = await makeClaim();
+		let resolveOlder!: (claim: DataMessage) => void;
+		let resolveNewer!: (claim: DataMessage) => void;
+		const olderPending = new Promise<DataMessage>((resolve) => {
+			resolveOlder = resolve;
+		});
+		const newerPending = new Promise<DataMessage>((resolve) => {
+			resolveNewer = resolve;
+		});
+		const create = sinon.stub(internals, "createMessage");
+		create.onFirstCall().returns(olderPending);
+		create.onSecondCall().returns(newerPending);
+
+		try {
+			const first = internals.refreshLocalTopicRootCandidateClaim();
+			const second = internals.refreshLocalTopicRootCandidateClaim();
+			resolveNewer(newer);
+			expect(await second).to.equal(true);
+			resolveOlder(older);
+			expect(await first).to.equal(false);
+			expect(internals.localSignedTopicRootCandidateClaim.timestamp).to.equal(
+				newer.header.timestamp,
+			);
+		} finally {
+			resolveNewer(newer);
+			resolveOlder(older);
+			create.restore();
+		}
+	});
+
+	it("bounds claim verification globally and across reconnects", async () => {
+		session = await createDisconnectedSessionWithPerPeerRoots(2);
+		const receiver = session.peers[0]!.services.pubsub;
+		const sender = session.peers[1]!.services.pubsub;
+		const internals = receiver as any;
+		receiver.addPeer(
+			sender.peerId,
+			sender.publicKey,
+			"/peerbit/topic-control-plane/2.1.0",
+			"verification-budget-test",
+		);
+		for (let index = 0; index < 128; index++) {
+			expect(
+				internals.consumeTopicRootCandidateClaimVerifyBudget(
+					sender.publicKeyHash,
+				),
+			).to.equal(true);
+		}
+		expect(
+			internals.consumeTopicRootCandidateClaimVerifyBudget(
+				sender.publicKeyHash,
+			),
+		).to.equal(false);
+		await internals._removePeer(sender.publicKey);
+		receiver.addPeer(
+			sender.peerId,
+			sender.publicKey,
+			"/peerbit/topic-control-plane/2.1.0",
+			"verification-budget-reconnect-test",
+		);
+		expect(
+			internals.consumeTopicRootCandidateClaimVerifyBudget(
+				sender.publicKeyHash,
+			),
+		).to.equal(false);
+
+		internals.topicRootCandidateClaimVerifyBudgets.clear();
+		internals.topicRootCandidateClaimGlobalVerifyBudget = {
+			remaining: 512,
+			refilledAt: Date.now(),
+		};
+		for (let index = 0; index < 512; index++) {
+			expect(
+				internals.consumeTopicRootCandidateClaimVerifyBudget(
+					canonicalCandidate(`global-budget-${index}`),
+				),
+			).to.equal(true);
+		}
+		expect(
+			internals.consumeTopicRootCandidateClaimVerifyBudget(
+				canonicalCandidate("global-budget-exhausted"),
+			),
+		).to.equal(false);
 	});
 
 	it("clears a pending peer root query immediately when cancelled", async () => {

--- a/packages/transport/pubsub/test/topic-root-candidates.spec.ts
+++ b/packages/transport/pubsub/test/topic-root-candidates.spec.ts
@@ -1,6 +1,11 @@
 import {
+	PubSubMessage,
 	TOPIC_ROOT_CANDIDATES_MAX,
 	TOPIC_ROOT_CANDIDATES_MAX_FRAME_BYTES,
+	TOPIC_ROOT_CANDIDATE_CLAIMS_MAX,
+	TOPIC_ROOT_CANDIDATE_CLAIMS_MAX_FRAME_BYTES,
+	TOPIC_ROOT_CANDIDATE_CLAIM_MAX_BYTES,
+	TopicRootCandidateClaims,
 	TopicRootCandidates,
 } from "@peerbit/pubsub-interface";
 import { expect } from "chai";
@@ -52,5 +57,88 @@ describe("topic-root candidate messages", () => {
 		);
 
 		expect(decoded.candidates).to.deep.equal(candidates);
+	});
+
+	it("rejects an oversized signed-claim count before deserialization", () => {
+		const frame = new Uint8Array([
+			8,
+			TOPIC_ROOT_CANDIDATE_CLAIMS_MAX + 1,
+			0,
+			0,
+			0,
+		]);
+
+		expect(() => TopicRootCandidateClaims.from(frame)).to.throw(
+			`Topic-root candidate claim count exceeds ${TOPIC_ROOT_CANDIDATE_CLAIMS_MAX}`,
+		);
+	});
+
+	it("rejects an oversized signed-claims frame before deserialization", () => {
+		const frame = new Uint8Array(
+			TOPIC_ROOT_CANDIDATE_CLAIMS_MAX_FRAME_BYTES + 1,
+		);
+		frame[0] = 8;
+
+		expect(() => TopicRootCandidateClaims.from(frame)).to.throw(
+			`Topic-root candidate claims frame exceeds ${TOPIC_ROOT_CANDIDATE_CLAIMS_MAX_FRAME_BYTES} bytes`,
+		);
+	});
+
+	it("rejects an oversized individual signed claim", () => {
+		const oversizedClaimLength = TOPIC_ROOT_CANDIDATE_CLAIM_MAX_BYTES + 1;
+		const frame = new Uint8Array([
+			8,
+			1,
+			0,
+			0,
+			0,
+			oversizedClaimLength & 0xff,
+			(oversizedClaimLength >>> 8) & 0xff,
+			0,
+			0,
+		]);
+
+		expect(() => TopicRootCandidateClaims.from(frame)).to.throw(
+			`Topic-root candidate claim exceeds ${TOPIC_ROOT_CANDIDATE_CLAIM_MAX_BYTES} bytes`,
+		);
+	});
+
+	it("rejects truncated signed-claim lengths and payloads", () => {
+		const truncatedLength = new Uint8Array([8, 1, 0, 0, 0, 3, 0]);
+		const truncatedPayload = new Uint8Array([8, 1, 0, 0, 0, 3, 0, 0, 0, 1, 2]);
+
+		for (const frame of [truncatedLength, truncatedPayload]) {
+			expect(() => TopicRootCandidateClaims.from(frame)).to.throw(
+				"Topic-root candidate claims frame is truncated",
+			);
+		}
+	});
+
+	it("rejects trailing bytes after signed claims", () => {
+		const frame = new Uint8Array([8, 0, 0, 0, 0, 7]);
+
+		expect(() => TopicRootCandidateClaims.from(frame)).to.throw(
+			"Topic-root candidate claims frame has trailing bytes",
+		);
+	});
+
+	it("round-trips a maximally bounded opaque signed-claim aggregate", () => {
+		const claims = Array.from(
+			{ length: TOPIC_ROOT_CANDIDATE_CLAIMS_MAX },
+			(_, index) =>
+				new Uint8Array(TOPIC_ROOT_CANDIDATE_CLAIM_MAX_BYTES).fill(index),
+		);
+		const encoded = new TopicRootCandidateClaims({ claims }).bytes();
+		const decoded = TopicRootCandidateClaims.from(encoded);
+
+		expect(encoded.byteLength).to.equal(
+			TOPIC_ROOT_CANDIDATE_CLAIMS_MAX_FRAME_BYTES,
+		);
+		expect(decoded.claims).to.deep.equal(claims);
+		expect(
+			PubSubMessage.from(
+				encoded instanceof Uint8Array ? encoded : encoded.subarray(),
+			),
+		).to.be.instanceOf(TopicRootCandidateClaims);
 	});
 });


### PR DESCRIPTION
## Summary

- introduce topic-control-plane 2.1 candidate messages carrying bounded, nested DataMessage self-claims
- verify each candidate's signer, canonical encoding, configuration scope, timestamp, expiry, and signature before admission
- bound claim/frame sizes, retained origins, verification work, refresh state, and lifecycle races
- remove the old unsigned candidate-list gossip/burst paths while retaining direct-identity compatibility for negotiated 2.0 peers
- add protocol, tampering, cap, reconnect, stop/restart, convergence, and codec regression coverage

## Security boundary

These claims prove key ownership, freshness, and shard-configuration scope. They do **not** prove liveness, authorization, admission, or Sybil resistance. Hostile deployments should continue to use explicit root candidates or an authority-backed resolver. A sparse mixed 2.0/2.1 network may also need explicit candidates until relay peers are upgraded.

## Compatibility

The service advertises 2.1 first and retains 2.0 negotiation. Variant 8 is handled by the host-side codec seam, leaving existing native variants 0–7 unchanged. A changeset is included.

## Validation

- pnpm --filter @peerbit/pubsub test — 202 passing
- repository-wide pnpm run build — passed
- git diff --check — passed
- independent review — no P0/P1/P2 findings

This is intentionally draft until exact-head CI and final review complete.
