### PR TITLE
fix(pubsub): cancel fanout loops on close

### DIFF
--- a/.changeset/calm-fanout-sleeps.md
+++ b/.changeset/calm-fanout-sleeps.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/pubsub": patch
+---
+
+Cancel fanout provider announce, provider watch, and channel background-loop sleeps during close and stop.

--- a/packages/transport/pubsub/src/fanout-tree.ts
+++ b/packages/transport/pubsub/src/fanout-tree.ts
@@ -956,6 +956,7 @@ type ProviderAnnounceState = {
 	bootstrapOverride?: Multiaddr[];
 	bootstrapDialTimeoutMs: number;
 	bootstrapMaxPeers: number;
+	closeController: AbortController;
 	closed: boolean;
 	loop?: Promise<void>;
 };
@@ -970,6 +971,7 @@ type ProviderWatchState = {
 	bootstrapMaxPeers: number;
 	onProviders: (providers: FanoutProviderCandidate[]) => void;
 	signal?: AbortSignal;
+	closeController: AbortController;
 	closed: boolean;
 	trackerPeers: string[];
 	loop?: Promise<void>;
@@ -1000,6 +1002,7 @@ type ChannelState = {
 	metrics: FanoutTreeChannelMetrics;
 	level: number;
 	isRoot: boolean;
+	closeController: AbortController;
 	closed: boolean;
 	parent?: string;
 	children: Map<string, ChildInfo>;
@@ -1399,7 +1402,36 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		);
 	}
 
+	private createLoopCloseController(): AbortController {
+		const controller = new AbortController();
+		const stopSignal = this.closeController.signal;
+		const abortOnStop = () => controller.abort();
+
+		if (stopSignal.aborted) {
+			abortOnStop();
+		} else {
+			stopSignal.addEventListener("abort", abortOnStop, { once: true });
+			controller.signal.addEventListener(
+				"abort",
+				() => stopSignal.removeEventListener("abort", abortOnStop),
+				{ once: true },
+			);
+		}
+		return controller;
+	}
+
 	public override async stop() {
+		for (const state of this.providerAnnounceBySuffixKey.values()) {
+			state.closeController.abort();
+		}
+		for (const watches of this.providerWatchesBySuffixKey.values()) {
+			for (const watch of watches) {
+				watch.closeController.abort();
+			}
+		}
+		for (const channel of this.channelsBySuffixKey.values()) {
+			channel.closeController.abort();
+		}
 		if (this.underlayPeerDisconnectHandler) {
 			this.components.events.removeEventListener(
 				"peer:disconnect",
@@ -1668,6 +1700,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 				bootstrapOverride,
 				bootstrapDialTimeoutMs,
 				bootstrapMaxPeers,
+				closeController: this.createLoopCloseController(),
 				closed: false,
 			};
 			this.providerAnnounceBySuffixKey.set(id.suffixKey, state);
@@ -1685,6 +1718,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 				const current = this.providerAnnounceBySuffixKey.get(id.suffixKey);
 				if (!current) return;
 				current.closed = true;
+				current.closeController.abort();
 				this.providerAnnounceBySuffixKey.delete(id.suffixKey);
 				// Best-effort immediate withdrawal (ttl=0).
 				void this.announceProviderOnce(
@@ -1739,6 +1773,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			bootstrapOverride,
 			bootstrapDialTimeoutMs,
 			bootstrapMaxPeers,
+			closeController: new AbortController(),
 			closed: false,
 		};
 
@@ -1748,7 +1783,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 	private async _providerAnnounceLoop(
 		state: ProviderAnnounceState,
 	): Promise<void> {
-		const signal = this.closeController.signal;
+		const signal = state.closeController.signal;
 		for (;;) {
 			if (signal.aborted || state.closed) return;
 			try {
@@ -1756,7 +1791,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			} catch {
 				// ignore
 			}
-			await delay(Math.max(50, state.announceIntervalMs));
+			await delay(Math.max(50, state.announceIntervalMs), { signal });
 		}
 	}
 
@@ -2008,6 +2043,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			),
 			onProviders: options.onProviders,
 			signal: options.signal,
+			closeController: this.createLoopCloseController(),
 			closed: false,
 			trackerPeers: [],
 		};
@@ -2036,6 +2072,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		const close = () => {
 			if (watch.closed) return;
 			watch.closed = true;
+			watch.closeController.abort();
 			localWatches?.delete(watch);
 			if (localWatches && localWatches.size === 0) {
 				this.providerWatchesBySuffixKey.delete(id.suffixKey);
@@ -2053,8 +2090,8 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		watch.signal?.addEventListener("abort", onAbort, { once: true });
 
 		const loopSignal = watch.signal
-			? anySignal([this.closeController.signal, watch.signal])
-			: this.closeController.signal;
+			? anySignal([watch.closeController.signal, watch.signal])
+			: watch.closeController.signal;
 
 		watch.loop = (async () => {
 			for (;;) {
@@ -2268,6 +2305,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			metrics: this.getMetricsForSuffixKey(id.suffixKey),
 			level: opts.role === "root" ? 0 : Number.POSITIVE_INFINITY,
 			isRoot: opts.role === "root",
+			closeController: this.createLoopCloseController(),
 			closed: false,
 			parent: undefined,
 			children: new Map(),
@@ -2624,6 +2662,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		if (!ch) return;
 		if (ch.closed) return;
 		ch.closed = true;
+		ch.closeController.abort();
 
 		// If a join is in-flight, surface that it won't complete.
 		try {
@@ -4900,7 +4939,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 	}
 
 	private async _announceLoop(ch: ChannelState): Promise<void> {
-		const signal = this.closeController.signal;
+		const signal = ch.closeController.signal;
 		for (;;) {
 			if (signal.aborted || ch.closed) return;
 			try {
@@ -4925,12 +4964,12 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 				// ignore
 			}
 			const sleepMs = ch.announceIntervalMs > 0 ? ch.announceIntervalMs : 1_000;
-			await delay(sleepMs);
+			await delay(sleepMs, { signal });
 		}
 	}
 
 	private async _repairLoop(ch: ChannelState): Promise<void> {
-		const signal = this.closeController.signal;
+		const signal = ch.closeController.signal;
 		for (;;) {
 			if (signal.aborted || ch.closed) return;
 			try {
@@ -4941,7 +4980,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 			const activeMs = ch.repairIntervalMs > 0 ? ch.repairIntervalMs : 200;
 			const sleepMs =
 				ch.missingSeqs.size > 0 ? activeMs : Math.max(activeMs, 1_000);
-			await delay(sleepMs);
+			await delay(sleepMs, { signal });
 		}
 	}
 
@@ -5179,7 +5218,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 	}
 
 	private async _meshLoop(ch: ChannelState): Promise<void> {
-		const signal = this.closeController.signal;
+		const signal = ch.closeController.signal;
 		let lastRefreshAt = 0;
 		for (;;) {
 			if (signal.aborted || ch.closed) return;
@@ -5209,7 +5248,7 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 				ch.neighborMeshRefreshIntervalMs,
 			].filter((v) => v > 0);
 			const sleepMs = intervals.length > 0 ? Math.min(...intervals) : 500;
-			await delay(Math.max(50, sleepMs));
+			await delay(Math.max(50, sleepMs), { signal });
 		}
 	}
 
@@ -5678,8 +5717,8 @@ export class FanoutTree extends DirectStream<FanoutTreeEvents> {
 		const start = Date.now();
 		const cooldownUntilByHash = new Map<string, number>();
 		const combinedSignal = joinOpts.signal
-			? anySignal([this.closeController.signal, joinOpts.signal])
-			: this.closeController.signal;
+			? anySignal([ch.closeController.signal, joinOpts.signal])
+			: ch.closeController.signal;
 		const signal = combinedSignal as AbortSignal & { clear?: () => void };
 		let nextParentUpgradeCheckAt = 0;
 		let parentUpgradeCheckSeq = 0;

--- a/packages/transport/pubsub/test/fanout-tree-lifecycle.spec.ts
+++ b/packages/transport/pubsub/test/fanout-tree-lifecycle.spec.ts
@@ -1,0 +1,211 @@
+import { TestSession } from "@peerbit/libp2p-test-utils";
+import { waitForResolved } from "@peerbit/time";
+import { expect } from "chai";
+import { FanoutTree } from "../src/fanout-tree.js";
+
+type FanoutServices = { fanout: FanoutTree };
+
+const createSession = () =>
+	TestSession.disconnected<FanoutServices>(1, {
+		services: {
+			fanout: (components) =>
+				new FanoutTree(components, { connectionManager: false }),
+		},
+	});
+
+const expectToSettlePromptly = async (
+	promises: Promise<unknown>[],
+	label: string,
+) => {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		await Promise.race([
+			Promise.all(promises),
+			new Promise<never>((_resolve, reject) => {
+				timeout = setTimeout(
+					() => reject(new Error(`${label} did not settle after close`)),
+					500,
+				);
+			}),
+		]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+};
+
+const longRunningChannelOptions = {
+	msgRate: 1,
+	msgSize: 8,
+	uploadLimitBps: 1_000_000,
+	maxChildren: 1,
+	repair: true,
+	repairIntervalMs: 2_000,
+	neighborRepair: true,
+	neighborMeshPeers: 1,
+	neighborAnnounceIntervalMs: 2_000,
+	neighborMeshRefreshIntervalMs: 2_000,
+} as const;
+
+describe("fanout-tree background loop lifecycle", () => {
+	it("cancels a provider announce sleep when its handle closes", async () => {
+		const session = await createSession();
+		try {
+			const fanout = session.peers[0]!.services.fanout;
+			const handle = fanout.provide("provider-close", {
+				announceIntervalMs: 2_000,
+			});
+			const state = [
+				...(fanout as any).providerAnnounceBySuffixKey.values(),
+			][0];
+			expect(state?.loop).to.be.instanceOf(Promise);
+
+			handle.close();
+
+			await expectToSettlePromptly([state.loop], "provider announce loop");
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("cancels a provider watch sleep when its handle closes", async () => {
+		const session = await createSession();
+		try {
+			const fanout = session.peers[0]!.services.fanout;
+			const handle = fanout.watchProviders("provider-watch-close", {
+				renewIntervalMs: 2_000,
+				onProviders: () => {},
+			});
+			const state = [...(fanout as any).providerWatchesBySuffixKey.values()][0]
+				.values()
+				.next().value;
+			expect(state?.loop).to.be.instanceOf(Promise);
+
+			handle.close();
+
+			await expectToSettlePromptly([state.loop], "provider watch loop");
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("cancels every channel loop when the channel closes", async () => {
+		const session = await createSession();
+		try {
+			const fanout = session.peers[0]!.services.fanout;
+			const topic = "channel-close";
+			const root = "unavailable-root";
+			const joining = fanout
+				.joinChannel(topic, root, longRunningChannelOptions, {
+					retryMs: 2_000,
+					timeoutMs: 10_000,
+					announceIntervalMs: 2_000,
+				})
+				.catch(() => {});
+			const id = fanout.getChannelId(topic, root);
+			let state: any;
+			await waitForResolved(
+				() => {
+					state = (fanout as any).channelsBySuffixKey.get(id.suffixKey);
+					expect(state?.announceLoop).to.be.instanceOf(Promise);
+					expect(state?.repairLoop).to.be.instanceOf(Promise);
+					expect(state?.meshLoop).to.be.instanceOf(Promise);
+					expect(state?.joinLoop).to.be.instanceOf(Promise);
+				},
+				{ timeout: 1_000, delayInterval: 10 },
+			);
+			const loops = [
+				state.announceLoop,
+				state.repairLoop,
+				state.meshLoop,
+				state.joinLoop,
+			];
+
+			await fanout.closeChannel(topic, root);
+
+			await expectToSettlePromptly(loops, "channel loops");
+			await joining;
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("cancels existing and concurrently-created loops when the service stops", async () => {
+		const session = await createSession();
+		try {
+			const fanout = session.peers[0]!.services.fanout;
+			fanout.provide("service-stop", { announceIntervalMs: 2_000 });
+			fanout.watchProviders("service-stop", {
+				renewIntervalMs: 2_000,
+				onProviders: () => {},
+			});
+			const providerState = [
+				...(fanout as any).providerAnnounceBySuffixKey.values(),
+			][0];
+			const watchState = [
+				...(fanout as any).providerWatchesBySuffixKey.values(),
+			][0]
+				.values()
+				.next().value;
+			const id = fanout.openChannel("service-stop", "unavailable-root", {
+				...longRunningChannelOptions,
+				role: "node",
+			});
+			const channelState = (fanout as any).channelsBySuffixKey.get(
+				id.suffixKey,
+			);
+			const loops = [
+				providerState.loop,
+				watchState.loop,
+				channelState.announceLoop,
+				channelState.repairLoop,
+				channelState.meshLoop,
+			];
+			for (const loop of loops) {
+				expect(loop).to.be.instanceOf(Promise);
+			}
+
+			const stopping = fanout.stop();
+			fanout.provide("late-service-stop", { announceIntervalMs: 2_000 });
+			fanout.watchProviders("late-service-stop", {
+				renewIntervalMs: 2_000,
+				onProviders: () => {},
+			});
+			const lateProviderState = [
+				...(fanout as any).providerAnnounceBySuffixKey.values(),
+			].at(-1);
+			const lateWatchState = [
+				...(fanout as any).providerWatchesBySuffixKey.values(),
+			]
+				.at(-1)
+				.values()
+				.next().value;
+			const lateId = fanout.openChannel(
+				"late-service-stop",
+				"unavailable-root",
+				{
+					...longRunningChannelOptions,
+					role: "node",
+				},
+			);
+			const lateChannelState = (fanout as any).channelsBySuffixKey.get(
+				lateId.suffixKey,
+			);
+			loops.push(
+				lateProviderState.loop,
+				lateWatchState.loop,
+				lateChannelState.announceLoop,
+				lateChannelState.repairLoop,
+				lateChannelState.meshLoop,
+			);
+			for (const loop of loops) {
+				expect(loop).to.be.instanceOf(Promise);
+			}
+
+			await stopping;
+
+			await expectToSettlePromptly(loops, "service loops");
+		} finally {
+			await session.stop();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- cancel provider announce and provider-watch sleeps when their handles close
- cancel channel announce, repair, mesh, and join sleeps when a channel closes
- link per-state cancellation to service shutdown, including state created during the async stop window
- add focused lifecycle regression coverage

This is a local lifecycle fix only. It does not change the fanout wire format, message selection, or steady-state transfer behavior.

## Why

Closed Peerbit instances could leave long fanout timers referenced until their full interval elapsed. In the downstream distributed-backup-v2 restart path, the database assertions completed but Node stayed alive with fanout provider/watch/channel timers.

## Validation

- `pnpm --filter @peerbit/pubsub build`
- lifecycle regression suite: 4/4 passing with natural process exit
- provider discovery/watch and child-capacity regressions: 3/3 passing
- direct ESLint/Prettier checks on changed files and `git diff --check`
- independent exact-diff review: no blocking findings
- exact built hotpatch against distributed-backup-v2: production `{ factor: 1 }` disk persistence close/reopen test passed with exact bytes and natural exit
- downstream browser persistence/logout suite and 64 MiB CRC-32 cold-download case passed with strict daemon shutdown
