### PR TITLE
fix(stream): serialize shutdown lifecycle

### DIFF
--- a/.changeset/steady-stream-shutdown.md
+++ b/.changeset/steady-stream-shutdown.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/stream": patch
+---
+
+Coalesce stream shutdown and prevent disconnect callbacks from starting goodbye publication after teardown begins.

--- a/packages/transport/stream/src/index.ts
+++ b/packages/transport/stream/src/index.ts
@@ -1266,6 +1266,7 @@ export abstract class DirectStream<
 			private prunedConnectionsCache?: Cache<string>;
 			private pruneToLimitsInFlight?: Promise<void>;
 			private _startInFlight?: Promise<void>;
+			private _stopInFlight?: Promise<void>;
 			private routeMaxRetentionPeriod: number;
 	private routeCacheMaxFromEntries?: number;
 	private routeCacheMaxTargetsPerFrom?: number;
@@ -1545,8 +1546,11 @@ export abstract class DirectStream<
 		}
 
 		async start() {
+			// Do not queue a restart behind teardown; callers can retry after stop resolves.
+			if (this._stopInFlight) return;
 			if (this.started) return;
 			if (this._startInFlight) return this._startInFlight;
+			this.stopping = false;
 			this._startInFlight = this._startImpl().finally(() => {
 				this._startInFlight = undefined;
 			});
@@ -1669,7 +1673,6 @@ export abstract class DirectStream<
 		}
 
 		this.started = true;
-		this.stopping = false;
 		logger.trace("starting");
 
 		// Incoming streams
@@ -1780,11 +1783,50 @@ export abstract class DirectStream<
 	/**
 	 * Unregister the pubsub protocol and the streams with other peers will be closed.
 	 */
-	async stop() {
-		if (!this.started) {
-			return;
+	stop(): Promise<void> {
+		if (this._stopInFlight) return this._stopInFlight;
+		if (!this.started && !this._startInFlight) return Promise.resolve();
+		this.stopping = true;
+		const starting = this._startInFlight;
+		this._stopInFlight = this._stopAfterStart(starting).finally(() => {
+			this.stopping = false;
+			this._stopInFlight = undefined;
+		});
+		return this._stopInFlight;
+	}
+
+	private async _stopAfterStart(starting?: Promise<void>): Promise<void> {
+		let startFailed = false;
+		let startFailure: unknown;
+		try {
+			await starting;
+		} catch (error) {
+			startFailed = true;
+			startFailure = error;
 		}
 
+		let stopFailed = false;
+		let stopFailure: unknown;
+		if (this.started) {
+			try {
+				await this._stopImpl();
+			} catch (error) {
+				stopFailed = true;
+				stopFailure = error;
+			}
+		}
+
+		if (startFailed && stopFailed) {
+			throw new AggregateError(
+				[startFailure, stopFailure],
+				"DirectStream start and rollback stop failed",
+			);
+		}
+		if (stopFailed) throw stopFailure;
+		if (startFailed) throw startFailure;
+	}
+
+	private async _stopImpl(): Promise<void> {
 		const sharedState = this.sharedRoutingState;
 		const sharedKey = this.sharedRoutingKey;
 
@@ -1876,7 +1918,6 @@ export abstract class DirectStream<
 			}
 		}
 		logger.trace("stopped");
-		this.stopping = false;
 	}
 
 	isStarted() {
@@ -2030,6 +2071,10 @@ export abstract class DirectStream<
 	 * Registrar notifies a closing connection with pubsub protocol
 	 */
 	protected async onPeerDisconnected(peerId: PeerId, conn?: Connection) {
+		if (this.stopping || !this.started) {
+			return;
+		}
+
 		// PeerId could be me, if so, it means that I am disconnecting
 		const peerKey = getPublicKeyFromPeerId(peerId);
 		const peerKeyHash = peerKey.hashcode();
@@ -2056,6 +2101,9 @@ export abstract class DirectStream<
 		}
 		if (!this.publicKey.equals(peerKey)) {
 			await this._removePeer(peerKey);
+			if (this.stopping || !this.started) {
+				return;
+			}
 
 			// tell dependent peers that there is a node that might have left
 			const dependent = this.routes.getDependent(peerKeyHash);
@@ -2064,15 +2112,19 @@ export abstract class DirectStream<
 			this.removePeerFromRoutes(peerKeyHash, true);
 
 			if (dependent.length > 0) {
+				const goodbye = await new Goodbye({
+					leaving: [peerKeyHash],
+					header: new MessageHeader({
+						session: this.session,
+						mode: new SilentDelivery({ to: dependent, redundancy: 2 }),
+					}),
+				}).sign(this.sign);
+				if (this.stopping || !this.started) {
+					return;
+				}
 				await this.publishMessageMaybe(
 					this.publicKey,
-					await new Goodbye({
-						leaving: [peerKeyHash],
-						header: new MessageHeader({
-							session: this.session,
-							mode: new SilentDelivery({ to: dependent, redundancy: 2 }),
-						}),
-					}).sign(this.sign),
+					goodbye,
 				);
 			}
 

--- a/packages/transport/stream/test/stream.spec.ts
+++ b/packages/transport/stream/test/stream.spec.ts
@@ -4331,6 +4331,117 @@ describe("start/stop", () => {
 		await session.stop();
 	});
 
+	it("coalesces concurrent stop without resuming disconnect handling", async () => {
+		session = await connected(3);
+		const subject = stream(session, 0);
+		const disconnected = stream(session, 1);
+		const dependent = stream(session, 2);
+		await waitForNeighbour(subject, disconnected);
+		await waitForNeighbour(subject, dependent);
+
+		const peerStreams = subject.peers.get(disconnected.publicKeyHash)!;
+		const closeEntered = pDefer<void>();
+		const releaseClose = pDefer<void>();
+		const closeStub = sinon.stub(peerStreams, "close").callsFake(async () => {
+			closeEntered.resolve();
+			await releaseClose.promise;
+		});
+		const connectionsStub = sinon
+			.stub(subject.components.connectionManager, "getConnections")
+			.returns([]);
+		const dependentStub = sinon.stub(subject.routes, "getDependent");
+		dependentStub
+			.withArgs(disconnected.publicKeyHash)
+			.returns([dependent.publicKeyHash]);
+		const publishSpy = sinon.spy(subject, "publishMessageMaybe");
+
+		try {
+			const disconnectPromise = subject.__testOnPeerDisconnected(
+				disconnected.peerId,
+			);
+			await closeEntered.promise;
+
+			const stopPromise = subject.stop();
+			const concurrentStopPromise = subject.stop();
+			await waitFor(() => !subject.isStarted());
+			const startDuringStopPromise = subject.start();
+			releaseClose.resolve();
+
+			const [
+				disconnectResult,
+				stopResult,
+				concurrentStopResult,
+				startDuringStopResult,
+			] =
+				await Promise.allSettled([
+					disconnectPromise,
+					stopPromise,
+					concurrentStopPromise,
+					startDuringStopPromise,
+				]);
+			expect(disconnectResult.status).to.equal("fulfilled");
+			expect(stopResult.status).to.equal("fulfilled");
+			expect(concurrentStopResult.status).to.equal("fulfilled");
+			expect(startDuringStopResult.status).to.equal("fulfilled");
+			expect(subject.isStarted()).to.be.false;
+			expect(closeStub.callCount).to.equal(2);
+			expect(dependentStub.called).to.be.false;
+			expect(publishSpy.called).to.be.false;
+		} finally {
+			releaseClose.resolve();
+			closeStub.restore();
+			connectionsStub.restore();
+			dependentStub.restore();
+			publishSpy.restore();
+		}
+	});
+
+	it("honors stop requested during startup", async () => {
+		session = await connected(1);
+		const subject = stream(session, 0);
+		await subject.stop();
+
+		const startImpl = (subject as any)._startImpl.bind(subject);
+		const startEntered = pDefer<void>();
+		const releaseStart = pDefer<void>();
+		const startStub = sinon
+			.stub(subject as any, "_startImpl")
+			.callsFake(async () => {
+				startEntered.resolve();
+				await releaseStart.promise;
+				await startImpl();
+			});
+
+		try {
+			const startPromise = subject.start();
+			await startEntered.promise;
+			const stopPromise = subject.stop();
+			let stopSettled = false;
+			void stopPromise.then(
+				() => {
+					stopSettled = true;
+				},
+				() => {
+					stopSettled = true;
+				},
+			);
+			await Promise.resolve();
+			expect(stopSettled).to.be.false;
+
+			releaseStart.resolve();
+			const [startResult, stopResult] = await Promise.allSettled([
+				startPromise,
+				stopPromise,
+			]);
+			expect(startResult.status).to.equal("fulfilled");
+			expect(stopResult.status).to.equal("fulfilled");
+			expect(subject.isStarted()).to.be.false;
+		} finally {
+			releaseStart.resolve();
+			startStub.restore();
+		}
+	});
+
 	it("can restart", async () => {
 		session = await connected(2, {
 			transports: [tcp(), webSockets()],


### PR DESCRIPTION
## Summary

- coalesce concurrent stream shutdown so shared routing is released once
- make a stop requested during startup wait and then tear the stream down
- prevent disconnect callbacks from starting goodbye publication after teardown begins
- add deterministic coverage for disconnect/stop, stop/stop, start/stop, and stop/start overlap

## Why

A source peer with two connected receivers could fail during `peerbit.stop()` with `NotStartedError` when an already-running disconnect callback resumed after peer removal and tried to publish `Goodbye`. This is the shutdown failure reproduced by the distributed-backup-v2 late-join harness.

## Validation

- regression test failed on current `master` before the fix and passes after it
- `pnpm --filter @peerbit/stream test`
- `pnpm --filter @peerbit/blocks test` (69 passing)
- downstream Peerbit 5.3.18 hotpatch runs at 16 MiB and 64 MiB completed cleanly with offline B/C/B SHA-256 and CRC-32 validation