### PR TITLE
perf(shared-log): memoize leader plans between topology changes

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -186,6 +186,7 @@ import {
 	type Numbers,
 	createNumbers,
 } from "./integers.js";
+import { LeaderPlanCache } from "./leader-plan-cache.js";
 import { TransportMessage } from "./message.js";
 import { PIDReplicationController } from "./pid.js";
 import {
@@ -2638,6 +2639,14 @@ const RECALCULATE_PARTICIPATION_MIN_RELATIVE_CHANGE_WITH_MEMORY_LIMIT = 0.001;
 const RECALCULATE_PARTICIPATION_RELATIVE_DENOMINATOR_FLOOR = 1e-3;
 const TOPIC_SUBSCRIBERS_CACHE_TTL_MS = 250;
 const LEADER_SELECTION_CONTEXT_CACHE_TTL_MS = 50;
+// Leader-plan results are invalidated structurally (replication:change,
+// replicator:mature, subscriber changes). The TTL bounds wall-clock maturity
+// flips that have no timer at all — a range re-crossing maturity after the
+// dynamic default roleAge regrew is only visible via expiry — so it is
+// load-bearing for that edge and must stay at the same order as the
+// leader-selection context TTL.
+const LEADER_PLAN_CACHE_TTL_MS = 50;
+const LEADER_PLAN_CACHE_MAX = 10_000;
 const ADAPTIVE_REBALANCE_IDLE_INTERVAL_MULTIPLIER = 5;
 const ADAPTIVE_REBALANCE_MIN_IDLE_AFTER_LOCAL_APPEND_MS = 10_000;
 
@@ -4536,6 +4545,7 @@ export class SharedLog<
 		expiresAt: number;
 		context: LeaderSelectionContext;
 	};
+	private _leaderPlanCache!: LeaderPlanCache;
 	// Sync capability bits advertised by peers (SyncCapabilitiesMessage), keyed
 	// by public key hash. Entries are dropped on unsubscribe/disconnect.
 	private _peerSyncCapabilities!: Map<string, number>;
@@ -5931,6 +5941,34 @@ export class SharedLog<
 	private invalidateLeaderSelectionContextCache() {
 		this._receiveOwnershipRevision++;
 		this._leaderSelectionContextCache = undefined;
+		this._leaderPlanCache?.invalidate();
+	}
+
+	/**
+	 * Cache key for a leader-plan lookup, or undefined when the call is
+	 * uncacheable: explicit freshness demands, per-call candidate filters,
+	 * roleAge outside the two hot buckets (dynamic default and 0), or an
+	 * in-flight replication-range mutation window (a plan observed
+	 * mid-transition must not outlive the transition).
+	 */
+	private leaderPlanCacheBucket(options?: {
+		roleAge?: number;
+		candidates?: Iterable<string>;
+		freshLeaderPlan?: boolean;
+	}): string | undefined {
+		if (options?.freshLeaderPlan || options?.candidates != null) {
+			return undefined;
+		}
+		if (this._receiveOwnershipMutationAdmissions !== 0) {
+			return undefined;
+		}
+		if (options?.roleAge == null) {
+			return "d";
+		}
+		if (options.roleAge === 0) {
+			return "0";
+		}
+		return undefined;
 	}
 
 	private isReceiveOwnershipSnapshotStable(revision: number): boolean {
@@ -7027,6 +7065,9 @@ export class SharedLog<
 		}
 
 		this._isReplicating = true;
+		// Flipping replication mode changes getDefaultMinRoleAge and the
+		// self-replicating context input even when no range is admitted.
+		this.invalidateLeaderSelectionContextCache();
 
 		if (isAdaptiveReplicatorOption(options!)) {
 			this._isAdaptiveReplicating = true;
@@ -10967,9 +11008,12 @@ export class SharedLog<
 
 		try {
 			throwIfInactive();
+			// Ownership decisions here feed prune/delete outcomes; never serve
+			// them from the leader-plan cache.
 			const currentLeaders = await this.findLeadersFromEntry(
 				args.entry,
 				decodeReplicas(args.entry).getValue(this),
+				{ freshLeaderPlan: true },
 			);
 			throwIfInactive();
 			if (currentLeaders.size > 0) {
@@ -15817,6 +15861,10 @@ export class SharedLog<
 		this._repairMetrics = createRepairMetrics();
 		this._topicSubscribersCache = new Map();
 		this._leaderSelectionContextCache = undefined;
+		this._leaderPlanCache = new LeaderPlanCache({
+			max: LEADER_PLAN_CACHE_MAX,
+			ttl: LEADER_PLAN_CACHE_TTL_MS,
+		});
 		this._peerSyncCapabilities = new Map();
 		this._liveRawGossipBatches = new Map();
 		this._liveRawGossipFlushScheduled = false;
@@ -17300,7 +17348,10 @@ export class SharedLog<
 									) {
 										return;
 									}
-									this.uniqueReplicators.add(keyHash);
+									if (!this.uniqueReplicators.has(keyHash)) {
+										this.uniqueReplicators.add(keyHash);
+										this.invalidateLeaderSelectionContextCache();
+									}
 
 									if (!this._replicatorJoinEmitted.has(keyHash)) {
 										this._replicatorJoinEmitted.add(keyHash);
@@ -24907,6 +24958,43 @@ export class SharedLog<
 		options?: {
 			roleAge?: number;
 			candidates?: Iterable<string>;
+			freshLeaderPlan?: boolean;
+		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	): Promise<Map<string, { intersecting: boolean }>> {
+		const cacheBucket = this.leaderPlanCacheBucket(options);
+		if (cacheBucket == null) {
+			return this._findLeadersUncached(
+				cursors,
+				options,
+				ownershipLifecycleController,
+			);
+		}
+		const cacheKey = `c:${cursors.join(",")}|${cacheBucket}`;
+		const cached = this._leaderPlanCache.get(cacheKey);
+		if (cached) {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+			return cached;
+		}
+		const capturedVersion = this._leaderPlanCache.capture();
+		const leaders = await this._findLeadersUncached(
+			cursors,
+			options,
+			ownershipLifecycleController,
+		);
+		if (this._receiveOwnershipMutationAdmissions === 0) {
+			this._leaderPlanCache.put(cacheKey, leaders, capturedVersion);
+		}
+		return leaders;
+	}
+
+	private async _findLeadersUncached(
+		cursors: NumberFromType<R>[],
+		options?: {
+			roleAge?: number;
+			candidates?: Iterable<string>;
 		},
 		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<Map<string, { intersecting: boolean }>> {
@@ -25358,6 +25446,46 @@ export class SharedLog<
 		options?: {
 			roleAge?: number;
 			candidates?: Iterable<string>;
+			freshLeaderPlan?: boolean;
+		},
+		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
+	): Promise<Map<string, { intersecting: boolean }> | undefined> {
+		const cacheBucket = this.leaderPlanCacheBucket(options);
+		if (cacheBucket == null) {
+			return this._findLeadersFromHashGidUncached(
+				gid,
+				replicas,
+				options,
+				ownershipLifecycleController,
+			);
+		}
+		const cacheKey = `g:${gid}:${replicas}|${cacheBucket}`;
+		const cached = this._leaderPlanCache.get(cacheKey);
+		if (cached) {
+			this.throwIfReplicationOwnershipLifecycleInactive(
+				ownershipLifecycleController,
+			);
+			return cached;
+		}
+		const capturedVersion = this._leaderPlanCache.capture();
+		const leaders = await this._findLeadersFromHashGidUncached(
+			gid,
+			replicas,
+			options,
+			ownershipLifecycleController,
+		);
+		if (leaders && this._receiveOwnershipMutationAdmissions === 0) {
+			this._leaderPlanCache.put(cacheKey, leaders, capturedVersion);
+		}
+		return leaders;
+	}
+
+	private async _findLeadersFromHashGidUncached(
+		gid: string,
+		replicas: number,
+		options?: {
+			roleAge?: number;
+			candidates?: Iterable<string>;
 		},
 		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<Map<string, { intersecting: boolean }> | undefined> {
@@ -25480,6 +25608,7 @@ export class SharedLog<
 		replicas: number,
 		options?: {
 			roleAge?: number;
+			freshLeaderPlan?: boolean;
 		},
 		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<Map<string, { intersecting: boolean }>> {

--- a/packages/programs/data/shared-log/src/leader-plan-cache.ts
+++ b/packages/programs/data/shared-log/src/leader-plan-cache.ts
@@ -1,0 +1,61 @@
+import { Cache } from "@peerbit/cache";
+
+type LeaderMap = Map<string, { intersecting: boolean }>;
+
+const cloneLeaders = (leaders: LeaderMap): LeaderMap => {
+	const cloned: LeaderMap = new Map();
+	for (const [hash, meta] of leaders) {
+		cloned.set(hash, { intersecting: meta.intersecting });
+	}
+	return cloned;
+};
+
+/**
+ * Memoizes leader-election plans between replication-topology changes.
+ *
+ * Coherence is structural, not temporal: a private monotonic version is
+ * bumped (and the store wiped) on every invalidation, and an async fill is
+ * only stored when the version captured before the computation still holds —
+ * a plan computed across a topology change is returned to its caller but
+ * never cached. The TTL bounds wall-clock maturity flips that fire no event
+ * (a range re-crossing maturity after the dynamic roleAge regrew has no
+ * pending timer), so it is load-bearing for that edge.
+ *
+ * Callers mutate returned maps and their value objects, so every hit and
+ * every store clones.
+ */
+export class LeaderPlanCache {
+	private cache: Cache<{ leaders: LeaderMap }>;
+	private version = 0;
+
+	constructor(options: { max: number; ttl: number }) {
+		this.cache = new Cache(options);
+	}
+
+	invalidate(): void {
+		this.version++;
+		this.cache.clear();
+	}
+
+	get(key: string): LeaderMap | undefined {
+		const entry = this.cache.get(key);
+		return entry ? cloneLeaders(entry.leaders) : undefined;
+	}
+
+	/** Capture the version before an awaited plan computation. */
+	capture(): number {
+		return this.version;
+	}
+
+	/** Store only if no invalidation happened since `capturedVersion`. */
+	put(key: string, leaders: LeaderMap, capturedVersion: number): void {
+		if (capturedVersion !== this.version) {
+			return;
+		}
+		this.cache.add(
+			key,
+			{ leaders: cloneLeaders(leaders) },
+			Math.max(1, leaders.size),
+		);
+	}
+}

--- a/packages/programs/data/shared-log/test/leader-plan-cache.spec.ts
+++ b/packages/programs/data/shared-log/test/leader-plan-cache.spec.ts
@@ -1,0 +1,69 @@
+import { delay } from "@peerbit/time";
+import { expect } from "chai";
+import { LeaderPlanCache } from "../src/leader-plan-cache.js";
+
+const plan = (...hashes: string[]) =>
+	new Map(hashes.map((hash) => [hash, { intersecting: true }]));
+
+describe("isLeader plan cache", () => {
+	it("returns stored plans and misses on unknown keys", () => {
+		const cache = new LeaderPlanCache({ max: 10, ttl: 1000 });
+		cache.put("a|d", plan("x", "y"), cache.capture());
+		expect(cache.get("a|d")).to.deep.eq(plan("x", "y"));
+		expect(cache.get("b|d")).to.eq(undefined);
+	});
+
+	it("isolates callers from mutation of served and stored plans", () => {
+		const cache = new LeaderPlanCache({ max: 10, ttl: 1000 });
+		const stored = plan("x");
+		cache.put("a|d", stored, cache.capture());
+
+		// mutating the map that was stored must not affect the cache
+		stored.set("z", { intersecting: true });
+		const first = cache.get("a|d")!;
+		expect([...first.keys()]).to.deep.eq(["x"]);
+
+		// mutating a served map or its value objects must not affect later hits
+		first.set("w", { intersecting: true });
+		first.get("x")!.intersecting = false;
+		const second = cache.get("a|d")!;
+		expect([...second.keys()]).to.deep.eq(["x"]);
+		expect(second.get("x")!.intersecting).to.eq(true);
+	});
+
+	it("drops stores whose captured version predates an invalidation", () => {
+		const cache = new LeaderPlanCache({ max: 10, ttl: 1000 });
+		const captured = cache.capture();
+		cache.invalidate(); // topology changed while the plan was computing
+		cache.put("a|d", plan("x"), captured);
+		expect(cache.get("a|d")).to.eq(undefined);
+
+		cache.put("a|d", plan("x"), cache.capture());
+		expect(cache.get("a|d")).to.not.eq(undefined);
+	});
+
+	it("clears stored plans on invalidation", () => {
+		const cache = new LeaderPlanCache({ max: 10, ttl: 1000 });
+		cache.put("a|d", plan("x"), cache.capture());
+		cache.invalidate();
+		expect(cache.get("a|d")).to.eq(undefined);
+	});
+
+	it("expires plans after the ttl backstop", async () => {
+		const cache = new LeaderPlanCache({ max: 10, ttl: 10 });
+		cache.put("a|d", plan("x"), cache.capture());
+		await delay(25);
+		expect(cache.get("a|d")).to.eq(undefined);
+	});
+
+	it("bounds the store by leader-count weighted size", () => {
+		const cache = new LeaderPlanCache({ max: 4, ttl: 1000 });
+		const version = cache.capture();
+		cache.put("a|d", plan("1", "2"), version);
+		cache.put("b|d", plan("3", "4"), version);
+		cache.put("c|d", plan("5", "6"), version);
+		// max 4 size-units with 2-unit entries: the oldest entry is evicted
+		expect(cache.get("a|d")).to.eq(undefined);
+		expect(cache.get("c|d")).to.not.eq(undefined);
+	});
+});


### PR DESCRIPTION
Leader election runs 2–3 times per received entry and once per entry in every rebalance/prune sweep. On the TS tier each run costs two full replication-index scans plus 4–12 range-index iterator reads per cursor; even on the native planner tier each run pays leader-selection-context construction (including a sorted replication-index query inside `getDefaultMinRoleAge`, context-cached for only 50ms). The results are pure functions of the replication-range set, so repeated elections between topology changes recompute identical plans.

## Design

- New `LeaderPlanCache` (own module), consulted by `_findLeaders` (cursor path) and `_findLeadersFromHashGid` (gid path). Coherence is **structural, not temporal**: a private version bumps and the store wipes inside `invalidateLeaderSelectionContextCache` — the existing chokepoint fired on `replication:change`, `replicator:mature`, subscriber-cache invalidation — and an async fill is only stored when the version captured before the computation still holds (the rateless-iblt encoder-cache pattern). Plans are neither served nor stored while replication-range mutations are in flight, mirroring the receive path's ownership-revision rule.
- Only the two hot roleAge buckets cache (dynamic default, and 0 as used by all sweeps); candidate filters or other explicit roleAge bypass. Served and stored plans are cloned — callers mutate the maps and their value objects.
- **The checked-prune delete boundary bypasses the cache** via a new `freshLeaderPlan` option: its invariant is a fresh ownership decision inside the global mutation lane immediately before `log.remove`. An adversarial multi-lens review traced every deletion path: no delete consumes a cached plan (the only other `log.remove` is the public `prune({unchecked: true})` opt-in). Staleness elsewhere is one-directional — a cached plan can only briefly under-report leaders, the conservative direction for every consumer (missed grants retry; overshoot corrects via later sweeps).
- The review also surfaced two pre-existing invalidation-chokepoint gaps that a result cache would amplify — `_isReplicating` flips on `replicate()`/`unreplicate()` denial paths, and `uniqueReplicators` adds in `pruneOfflineReplicators` — both now fire the chokepoint. TTL is 50ms, deliberately: a range re-crossing maturity after the dynamic roleAge regrew fires no timer event, so expiry is the correctness mechanism for that edge and the bound matches the previous context-cache window.

## Where the wins land (honest map, from the review trace)

The native-backbone receive fast path uses whole-message batch planners and is untouched by this cache. The wins are: rebalance and prune sweeps (per-gid reuse within a sweep; entries sharing a gid share a key), the dynamic-default-roleAge bucket (skips the recurring sorted index query + subscriber lookup per election), gid-reference merging on the append-delivery path, and the entire TS fallback tier (browsers), where each avoided election saves two full index scans plus per-cursor iterator reads.

## Validation

- Fresh-worktree local runs (fresh install, mock session): `isLeader` 21, `waitForReplicator` 18, `strict live-range leader routing` 1, `receive admission` 16, `checked prune` 45, `replicate` 28, `observer` 3 — all passing, exit codes verified individually.
- New unit spec for the cache class (clone isolation, version-guarded fills, invalidation, TTL, size bound) runs in shard part-6 under the existing `isLeader` grep.
- 4-lens adversarial review (staleness safety, invalidation completeness, implementation details, perf reality): no blockers; key-collision, lifecycle-contract, clone-depth, and cache-semantics checks all verified clean.
- PR CI runs the full shared-log matrix (part-4/6/7a–7e) plus the sync-batch hang gate; base-vs-head benchmark comparison and chaos-seed sims dispatched separately.