### PR TITLE
ci: pre-install wasm32 target in benchmark workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -215,7 +215,12 @@ jobs:
 
       - name: Install wasm-pack
         if: steps.pr.outputs.same_repo == 'true' && steps.pr.outputs.run_any == 'true'
-        run: cargo install wasm-pack --version '=0.13.1' --locked
+        run: |
+          cargo install wasm-pack --version '=0.13.1' --locked
+          # Pre-install the wasm target once: concurrent wasm-pack builds
+          # otherwise race their own `rustup target add` and fail on a
+          # component conflict (observed in run 30832179916).
+          rustup target add wasm32-unknown-unknown
 
       - name: Install deps (base)
         if: steps.pr.outputs.same_repo == 'true' && steps.pr.outputs.run_any == 'true'


### PR DESCRIPTION
The benchmark A/B workflow installs wasm-pack but never adds the wasm32 target, so concurrent wasm-pack builds race their own `rustup target add` and fail on a rustlib component conflict — observed in [run 30832179916](https://github.com/dao-xyz/peerbit/actions/runs/30832179916) during Build (base). Every ci.yml job that compiles wasm already pre-adds the target once; this does the same in the one place it was missing. Dispatch-only workflow, so PR CI does not exercise it — validated by YAML parse, the release security contracts, and the next `benchmarks.yml` dispatch (re-running for PR #1168 after merge).