### PR TITLE
perf(shared-log): stop retaining transferred payload buffers

### DIFF
--- a/.changeset/owned-coordinate-metadata.md
+++ b/.changeset/owned-coordinate-metadata.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Copy coordinate metadata into exact-sized owned buffers so replication state does not retain oversized exchange-message backing stores.

--- a/.changeset/owned-coordinate-metadata.md
+++ b/.changeset/owned-coordinate-metadata.md
@@ -2,4 +2,4 @@
 "@peerbit/shared-log": patch
 ---
 
-Copy coordinate metadata into exact-sized owned buffers so replication state does not retain oversized exchange-message backing stores.
+Copy coordinate metadata into exact-sized owned buffers, compact leader-selection recheck inputs, and isolate receive-role observer closures so replication state does not retain oversized exchange-message backing stores.

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -1632,6 +1632,20 @@ type WaitForReplicatorsOptions<R extends "u32" | "u64"> =
 
 type WaitForReplicator = { key: string; replicator: boolean };
 
+type ReceiveLeaderObservation = {
+	isLeader: boolean;
+	fromIsLeader: boolean;
+};
+
+// Keep long-lived role callbacks outside the receive activation so event-target
+// wrappers cannot retain decoded entries through the callback's closure context.
+const createReceiveLeaderObserver =
+	(observation: ReceiveLeaderObservation, localKey: string, fromKey: string) =>
+	(key: string) => {
+		observation.isLeader ||= localKey === key;
+		observation.fromIsLeader ||= fromKey === key;
+	};
+
 type PendingMaturityRecord<R extends "u32" | "u64"> = {
 	range: ReplicationChange<ReplicationRangeIndexable<R>>;
 	timeout: ReturnType<typeof setTimeout>;
@@ -20473,6 +20487,10 @@ export class SharedLog<
 										isLeader = true;
 										fromIsLeader = leaders.has(contextFromHash);
 									} else {
+										const leaderObservation: ReceiveLeaderObservation = {
+											isLeader: false,
+											fromIsLeader: false,
+										};
 										leaders = await this._waitForEntryReplicators(
 											latestEntry,
 											maxMaxReplicas,
@@ -20486,15 +20504,15 @@ export class SharedLog<
 												// Let raw receive confirm immediate leadership against the current replicator set.
 												roleAge: 0,
 												timeout: 2e4,
-												onLeader: (key) => {
-													isLeader =
-														isLeader ||
-														this.node.identity.publicKey.hashcode() === key;
-													fromIsLeader =
-														fromIsLeader || contextFromHash === key;
-												},
+												onLeader: createReceiveLeaderObserver(
+													leaderObservation,
+													this.node.identity.publicKey.hashcode(),
+													contextFromHash,
+												),
 											},
 										);
+										isLeader = leaderObservation.isLeader;
+										fromIsLeader = leaderObservation.fromIsLeader;
 									}
 								} else {
 									if (plannedLeaders) {
@@ -22280,8 +22298,20 @@ export class SharedLog<
 			timeout: this.waitForReplicatorTimeout,
 		},
 	): Promise<LeaderMap | false> {
+		// Leader rechecks can outlive the receive call while replication roles
+		// settle. Keep the metadata they need, not the decoded entry's serialized
+		// backing buffer (which can be as large as the transferred block).
+		const leaderSelectionEntry =
+			entry instanceof Entry
+				? deserialize(
+						Uint8Array.from(serialize(entry.toShallow(true))),
+						ShallowEntry,
+					)
+				: entry instanceof ShallowEntry
+					? deserialize(Uint8Array.from(serialize(entry)), ShallowEntry)
+					: entry;
 		if (
-			this.canPlanNativeHashGid(entry) &&
+			this.canPlanNativeHashGid(leaderSelectionEntry) &&
 			(this._nativeBackbone ??
 				this._nativeSharedLogState ??
 				this._nativeRangePlanner)
@@ -22291,7 +22321,7 @@ export class SharedLog<
 				options,
 				async (checkOptions) => {
 					const plan = await this.planEntryLeaders(
-						entry,
+						leaderSelectionEntry,
 						replicas,
 						checkOptions,
 					);
@@ -22301,8 +22331,8 @@ export class SharedLog<
 		}
 
 		return this._waitForReplicators(
-			await this.createCoordinates(entry, replicas),
-			entry,
+			await this.createCoordinates(leaderSelectionEntry, replicas),
+			leaderSelectionEntry,
 			waitFor,
 			options,
 		);

--- a/packages/programs/data/shared-log/src/ranges.ts
+++ b/packages/programs/data/shared-log/src/ranges.ts
@@ -126,7 +126,7 @@ export class EntryReplicatedU32 implements EntryReplicated<"u32"> {
 	@field({ type: Uint8Array })
 	private _meta: Uint8Array;
 
-	private _metaResolved: ShallowMeta;
+	private _metaResolved?: ShallowMeta;
 
 	constructor(properties: {
 		coordinates: number[];
@@ -154,13 +154,16 @@ export class EntryReplicatedU32 implements EntryReplicated<"u32"> {
 			properties.meta?.clock.timestamp.wallTime ?? properties.wallTime!;
 		this.hashNumber = properties.hashNumber;
 		this._meta =
-			properties.metaBytes ??
-			serialize(
-				properties.meta instanceof Meta
-					? new ShallowMeta(properties.meta)
-					: properties.meta!,
-			);
-		this._metaResolved = properties.meta as ShallowMeta;
+			properties.metaBytes != null
+				? Uint8Array.from(properties.metaBytes)
+				: Uint8Array.from(
+						serialize(
+							properties.meta instanceof Meta
+								? new ShallowMeta(properties.meta)
+								: properties.meta!,
+						),
+					);
+		this._metaResolved = undefined;
 		this.assignedToRangeBoundary = properties.assignedToRangeBoundary;
 	}
 
@@ -199,7 +202,7 @@ export class EntryReplicatedU64 implements EntryReplicated<"u64"> {
 	@field({ type: Uint8Array })
 	private _meta: Uint8Array;
 
-	private _metaResolved: ShallowMeta;
+	private _metaResolved?: ShallowMeta;
 
 	constructor(properties: {
 		coordinates: bigint[];
@@ -227,13 +230,16 @@ export class EntryReplicatedU64 implements EntryReplicated<"u64"> {
 		this.wallTime =
 			properties.meta?.clock.timestamp.wallTime ?? properties.wallTime!;
 		this._meta =
-			properties.metaBytes ??
-			serialize(
-				properties.meta instanceof Meta
-					? new ShallowMeta(properties.meta)
-					: properties.meta!,
-			);
-		this._metaResolved = properties.meta as ShallowMeta;
+			properties.metaBytes != null
+				? Uint8Array.from(properties.metaBytes)
+				: Uint8Array.from(
+						serialize(
+							properties.meta instanceof Meta
+								? new ShallowMeta(properties.meta)
+								: properties.meta!,
+						),
+					);
+		this._metaResolved = undefined;
 		this.assignedToRangeBoundary = properties.assignedToRangeBoundary;
 	}
 

--- a/packages/programs/data/shared-log/test/ranges.spec.ts
+++ b/packages/programs/data/shared-log/test/ranges.spec.ts
@@ -1,4 +1,4 @@
-import { serialize } from "@dao-xyz/borsh";
+import { deserialize, serialize } from "@dao-xyz/borsh";
 import { Cache } from "@peerbit/cache";
 import {
 	Ed25519Keypair,
@@ -8,7 +8,7 @@ import {
 } from "@peerbit/crypto";
 import type { Index } from "@peerbit/indexer-interface";
 import { create as createIndices } from "@peerbit/indexer-sqlite3";
-import { LamportClock, Meta } from "@peerbit/log";
+import { LamportClock, Meta, ShallowMeta } from "@peerbit/log";
 import { expect } from "chai";
 import {
 	type NumberFromType,
@@ -2631,6 +2631,59 @@ resolutions.forEach((resolution) => {
 			let index: Index<EntryReplicated<R>>;
 			const entryClass =
 				resolution === "u32" ? EntryReplicatedU32 : EntryReplicatedU64;
+
+			it("owns metadata from oversized decoded backing buffers", () => {
+				for (const includeMetaBytes of [false, true]) {
+					const serialized = serialize(
+						new ShallowMeta({
+							clock: new LamportClock({ id: randomBytes(32) }),
+							data: randomBytes(16),
+							gid: "gid",
+							next: ["next"],
+							type: 0,
+						}),
+					);
+					const backing = new Uint8Array(1024 * 1024);
+					const metaBytes = backing.subarray(123, 123 + serialized.byteLength);
+					metaBytes.set(serialized);
+					const expected = Uint8Array.from(metaBytes);
+					const decoded = deserialize(metaBytes, ShallowMeta);
+					const expectedClockId = Uint8Array.from(decoded.clock.id);
+					const expectedData = Uint8Array.from(decoded.data!);
+					const common = {
+						assignedToRangeBoundary: false,
+						hash: "hash",
+						meta: decoded,
+						...(includeMetaBytes ? { metaBytes } : {}),
+					};
+					const entry =
+						resolution === "u32"
+							? new EntryReplicatedU32({
+									...common,
+									coordinates: [1],
+									hashNumber: 2,
+								})
+							: new EntryReplicatedU64({
+									...common,
+									coordinates: [1n],
+									hashNumber: 2n,
+								});
+
+					const retained = entry.getMetaBytes();
+					expect(retained).to.deep.equal(expected);
+					expect(retained).to.not.equal(metaBytes);
+					expect(retained.buffer).to.not.equal(backing.buffer);
+					expect(retained.buffer.byteLength).to.equal(retained.byteLength);
+
+					backing.fill(0);
+					expect(retained).to.deep.equal(expected);
+					expect(entry.meta).to.not.equal(decoded);
+					expect(entry.meta.clock.id).to.deep.equal(expectedClockId);
+					expect(entry.meta.data).to.deep.equal(expectedData);
+					expect(entry.meta.clock.id.buffer).to.not.equal(backing.buffer);
+					expect(entry.meta.data!.buffer).to.not.equal(backing.buffer);
+				}
+			});
 
 			let create = async (...rects: EntryReplicated<R>[]) => {
 				const indices = await createIndices();

--- a/packages/programs/data/shared-log/test/receive-admission.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission.spec.ts
@@ -1,5 +1,6 @@
+import { serialize } from "@dao-xyz/borsh";
 import { randomBytes } from "@peerbit/crypto";
-import { Entry } from "@peerbit/log";
+import { Entry, ShallowEntry } from "@peerbit/log";
 import { TestSession } from "@peerbit/test-utils";
 import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
@@ -548,6 +549,108 @@ describe("receive admission", () => {
 			expect(await waiting).to.be.false;
 		} finally {
 			releaseCheck.resolve();
+			await session.stop();
+		}
+	});
+
+	it("compacts entries retained by leader-selection rechecks", async () => {
+		const session = await TestSession.disconnected(1);
+		try {
+			const target = await session.peers[0].open(
+				new EventStore<string, any>(),
+				{
+					args: { replicate: false, setup },
+				},
+			);
+			const { entry } = await target.add(uuid(), { meta: { next: [] } });
+			const sharedLog = target.log as any;
+			const originalNativeBackbone = sharedLog._nativeBackbone;
+			const originalReserved = (entry as any)._reserved;
+			(entry as any)._reserved = new Uint8Array(1024 * 1024);
+			const oversizedBacking = new Uint8Array(1024 * 1024);
+			const shallow = entry.toShallow(true);
+			shallow.meta.data = oversizedBacking.subarray(16, 48);
+			shallow.meta.clock.id = oversizedBacking.subarray(64, 96);
+			(shallow as any).getMetaBytes = () => oversizedBacking;
+			const compactShallowByteLength = serialize(shallow).byteLength;
+			sharedLog._nativeBackbone = {};
+
+			const planningEntries: unknown[] = [];
+			const leaders = new Map([["leader", { intersecting: true }]]);
+			const planEntryLeaders = sinon
+				.stub(sharedLog, "planEntryLeaders")
+				.callsFake(async (candidate: unknown) => {
+					planningEntries.push(candidate);
+					return { coordinates: [1], leaders, isLeader: true };
+				});
+			const waitForLeaderSelection = sinon
+				.stub(sharedLog, "waitForLeaderSelection")
+				.callsFake(async (...args: unknown[]) => {
+					const options = args[1];
+					const checkLeaders = args[2] as (
+						options: unknown,
+					) => Promise<Map<string, unknown>>;
+					return checkLeaders(options);
+				});
+
+			try {
+				expect(
+					await sharedLog._waitForEntryReplicators(
+						entry,
+						1,
+						[{ key: "leader", replicator: true }],
+						{ timeout: 1_000 },
+					),
+				).to.equal(leaders);
+				expect(
+					await sharedLog._waitForEntryReplicators(
+						shallow,
+						1,
+						[{ key: "leader", replicator: true }],
+						{ timeout: 1_000 },
+					),
+				).to.equal(leaders);
+			} finally {
+				waitForLeaderSelection.restore();
+				planEntryLeaders.restore();
+				sharedLog._nativeBackbone = originalNativeBackbone;
+				(entry as any)._reserved = originalReserved;
+			}
+
+			expect(planningEntries).to.have.length(2);
+			const [fullPlanningEntry, shallowPlanningEntry] =
+				planningEntries as any[];
+			expect(fullPlanningEntry).to.be.instanceOf(ShallowEntry);
+			expect(fullPlanningEntry).to.not.equal(entry);
+			expect(fullPlanningEntry.hash).to.equal(entry.hash);
+			expect(fullPlanningEntry.meta.gid).to.equal(entry.meta.gid);
+			expect(fullPlanningEntry.meta.next).to.deep.equal(entry.meta.next);
+			expect(fullPlanningEntry.meta.type).to.equal(entry.meta.type);
+			expect(fullPlanningEntry.meta.data).to.deep.equal(entry.meta.data);
+			expect(fullPlanningEntry.meta.clock).to.deep.equal(entry.meta.clock);
+			expect(fullPlanningEntry._reserved).to.equal(undefined);
+
+			expect(shallowPlanningEntry).to.be.instanceOf(ShallowEntry);
+			expect(shallowPlanningEntry).to.not.equal(shallow);
+			expect(shallowPlanningEntry.hash).to.equal(shallow.hash);
+			expect(shallowPlanningEntry.meta.data).to.deep.equal(shallow.meta.data);
+			expect(shallowPlanningEntry.meta.data.buffer).to.not.equal(
+				oversizedBacking.buffer,
+			);
+			expect(shallowPlanningEntry.meta.data.buffer.byteLength).to.equal(
+				compactShallowByteLength,
+			);
+			expect(shallowPlanningEntry.meta.clock.id).to.deep.equal(
+				shallow.meta.clock.id,
+			);
+			expect(shallowPlanningEntry.meta.clock.id.buffer).to.not.equal(
+				oversizedBacking.buffer,
+			);
+			expect(shallowPlanningEntry.meta.clock.id.buffer.byteLength).to.equal(
+				compactShallowByteLength,
+			);
+			expect(shallowPlanningEntry.getMetaBytes).to.equal(undefined);
+		} finally {
 			await session.stop();
 		}
 	});


### PR DESCRIPTION
## Summary

- copy coordinate metadata into exact-sized owned buffers and decode it lazily from that owned copy
- detach full and prepared-raw shallow entries used by long-lived leader-selection rechecks
- isolate the receive-role observer so retained event wrappers capture only small state, not the receive activation and its decoded entries

No wire schema or event-listener lifecycle changes are included.

## Why

A downstream `distributed-backup-v2` heap trace showed a second retained copy of every transferred payload through leader-selection state. At the 32 MiB deterministic checkpoint, the baseline retained 32 payload-sized backings (67,122,732 bytes): 16 canonical block-store copies and 16 avoidable copies. This patch retains only the 16 canonical copies (33,560,278 bytes), with zero noncanonical payload backings.

## Validation

- Node 22 shared-log build
- metadata ownership tests for u32 and u64
- full `receive admission` suite: 17/17
- combined post-rebase relevant run: 19/19
- deterministic 32 MiB downstream integrity gate on B, C, and B re-read
  - SHA-256: `dcb7d8c9124fd28b1dc2d3ef773d1d102b2560f2969f4871409e93c7ec7ca696`
  - CRC-32: `0e5b542d`
  - total: 10.163 s; B transfer: 357.264 ms; C transfer: 549.035 ms
  - second/first-window ratios: B 1.377, C 0.971

## Follow-ups

The third-party event wrapper can still leave small inert listener objects behind, but they no longer retain payloads or receive activations. A 512 MiB+ enforced-throughput run and a filesystem-storage memory run remain useful follow-up benchmarks.
