### PR TITLE
refactor(shared-log): pre-hardening for the session-lifecycle migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,7 @@ jobs:
         run: |
           pnpm run lint
           node ./scripts/ci/check-shard-coverage.mjs
+          node ./scripts/ci/check-fence-ratchet.mjs
       - name: Tests
         env:
           PEERBIT_MOCHA_LOG_TEST_START: ${{ (matrix.test_cmd == 'pnpm run test:ci:part-4' || matrix.test_cmd == 'pnpm run test:ci:part-6' || startsWith(matrix.test_cmd, 'pnpm run test:ci:part-7')) && '1' || '0' }}
@@ -420,6 +421,7 @@ jobs:
         run: |
           pnpm run lint
           node ./scripts/ci/check-shard-coverage.mjs
+          node ./scripts/ci/check-fence-ratchet.mjs
       - name: Tests
         env:
           PEERBIT_MOCHA_LOG_TEST_START: ${{ (matrix.test_cmd == 'pnpm run test:ci:part-4' || matrix.test_cmd == 'pnpm run test:ci:part-6' || startsWith(matrix.test_cmd, 'pnpm run test:ci:part-7')) && '1' || '0' }}

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -4637,6 +4637,7 @@ export class SharedLog<
 		this._repairSweepOptimisticGidPeersPending = new Map();
 		this._repairSweepOptimisticGidsByPeer = new Map();
 		this._entryKnownPeers = new Map();
+		this._entryKnownPeerObservedAt = new Map();
 		this._joinAuthoritativeRepairTimersByDelay = new Map();
 		this._joinAuthoritativeRepairPeersByDelay = new Map();
 		this._appendBackfillPendingByTarget = new Map();
@@ -6298,22 +6299,6 @@ export class SharedLog<
 		}
 	}
 
-	private blockPeerReceiveAdmission(peerHash: string) {
-		this._receiveCleanupGateByPeer.set(
-			peerHash,
-			(this._receiveCleanupGateByPeer.get(peerHash) ?? 0) + 1,
-		);
-	}
-
-	private unblockPeerReceiveAdmission(peerHash: string) {
-		const remaining = (this._receiveCleanupGateByPeer.get(peerHash) ?? 1) - 1;
-		if (remaining > 0) {
-			this._receiveCleanupGateByPeer.set(peerHash, remaining);
-		} else {
-			this._receiveCleanupGateByPeer.delete(peerHash);
-		}
-	}
-
 	private handleReplicationLifecycleSendError(
 		error: unknown,
 		controller = this._replicationLifecycleController,
@@ -6511,6 +6496,34 @@ export class SharedLog<
 		void this.replicationAnnouncementRepairDebounced.call();
 	}
 
+	/**
+	 * Single validity predicate for announcement-repair workers. "stale":
+	 * the store closed or a lifecycle controller aborted — exit silently.
+	 * "superseded": a newer announcement generation took over — the worker
+	 * must requeue so the current generation gets serviced. The
+	 * generation-controller identity comparison stays at the one call site
+	 * that historically required it; folding it in here is a stage-5
+	 * semantic decision, not a consolidation.
+	 */
+	private announcementRepairWorkerStatus(worker: {
+		generation: number;
+		lifecycleController: AbortController;
+		generationController: AbortController;
+	}): "current" | "stale" | "superseded" {
+		if (
+			this.closed ||
+			this._closeController.signal.aborted ||
+			worker.lifecycleController.signal.aborted ||
+			worker.generationController.signal.aborted
+		) {
+			return "stale";
+		}
+		if (worker.generation !== this._replicationAnnouncementRetryGeneration) {
+			return "superseded";
+		}
+		return "current";
+	}
+
 	private async runCurrentReplicationStateAnnouncementRepair(): Promise<void> {
 		const generation = this._replicationAnnouncementRetryGeneration;
 		const lifecycleController = this._replicationAnnouncementRepairController;
@@ -6524,11 +6537,11 @@ export class SharedLog<
 			});
 		} catch (error) {
 			if (
-				this.closed ||
-				this._closeController.signal.aborted ||
-				lifecycleController.signal.aborted ||
-				generationController.signal.aborted ||
-				generation !== this._replicationAnnouncementRetryGeneration ||
+				this.announcementRepairWorkerStatus({
+					generation,
+					lifecycleController,
+					generationController,
+				}) !== "current" ||
 				generationController !==
 					this._replicationAnnouncementRepairGenerationController
 			) {
@@ -6565,33 +6578,35 @@ export class SharedLog<
 		const segments = (await this.getMyReplicationSegments()).map((range) =>
 			range.toReplicationRange(),
 		);
-		if (
-			this.closed ||
-			this._closeController.signal.aborted ||
-			lifecycleController.signal.aborted ||
-			generationController.signal.aborted
+		switch (
+			this.announcementRepairWorkerStatus({
+				generation,
+				lifecycleController,
+				generationController,
+			})
 		) {
-			return;
-		}
-		if (generation !== this._replicationAnnouncementRetryGeneration) {
-			this.queueCurrentReplicationStateAnnouncementRepair();
-			return;
+			case "stale":
+				return;
+			case "superseded":
+				this.queueCurrentReplicationStateAnnouncementRepair();
+				return;
 		}
 		this.validatePersistedReplicationRangeSnapshot(segments);
 
 		const subscribers =
 			(await this.node.services.pubsub.getSubscribers(this.topic)) ?? [];
-		if (
-			this.closed ||
-			this._closeController.signal.aborted ||
-			lifecycleController.signal.aborted ||
-			generationController.signal.aborted
+		switch (
+			this.announcementRepairWorkerStatus({
+				generation,
+				lifecycleController,
+				generationController,
+			})
 		) {
-			return;
-		}
-		if (generation !== this._replicationAnnouncementRetryGeneration) {
-			this.queueCurrentReplicationStateAnnouncementRepair();
-			return;
+			case "stale":
+				return;
+			case "superseded":
+				this.queueCurrentReplicationStateAnnouncementRepair();
+				return;
 		}
 
 		const selfHash = this.node.identity.publicKey.hashcode();
@@ -6666,17 +6681,18 @@ export class SharedLog<
 				}),
 			),
 		);
-		if (
-			this.closed ||
-			this._closeController.signal.aborted ||
-			lifecycleController.signal.aborted ||
-			generationController.signal.aborted
+		switch (
+			this.announcementRepairWorkerStatus({
+				generation,
+				lifecycleController,
+				generationController,
+			})
 		) {
-			return;
-		}
-		if (generation !== this._replicationAnnouncementRetryGeneration) {
-			this.queueCurrentReplicationStateAnnouncementRepair();
-			return;
+			case "stale":
+				return;
+			case "superseded":
+				this.queueCurrentReplicationStateAnnouncementRepair();
+				return;
 		}
 
 		for (const [index, result] of results.entries()) {
@@ -7673,6 +7689,10 @@ export class SharedLog<
 		};
 		const isMe = this.node.identity.publicKey.hashcode() === keyHash;
 		let receiveAdmissionBlocked = false;
+		// Capture the gate map instance: close/reopen replaces the map, and the
+		// release in this call's finally must drain the exact map it
+		// incremented — a late release against a fresh open's map would
+		// corrupt that open's refcounts.
 		const receiveCleanupGateByPeer = this._receiveCleanupGateByPeer;
 		const checkedPruneCoordinator = this._checkedPrune;
 		const isSpeculativePeerRemoval =

--- a/scripts/ci/check-fence-ratchet.mjs
+++ b/scripts/ci/check-fence-ratchet.mjs
@@ -1,0 +1,123 @@
+// Ratchet against fence-per-symptom growth in shared-log (invoked from the
+// Lint step, next to check-shard-coverage.mjs).
+//
+// Between June and July 2026, packages/programs/data/shared-log/src/index.ts
+// grew 8k -> 28k lines and accumulated ~30 fence mechanisms (epoch /
+// generation / revision / gate / admission fields), each patching one
+// instance of the same bug class: async continuations outliving the state
+// they started under. The session/lifecycle refactor is draining these into
+// identity-checked session objects. This script freezes the inventory:
+// adding a NEW fence-pattern field fails CI unless a `design-note:` comment
+// sits within the five lines above the declaration, and removing one
+// requires shrinking the baseline (the intended direction).
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const TARGET = "packages/programs/data/shared-log/src/index.ts";
+// Token match is per camelCase/underscore segment so "generationOfLastPrune"
+// and "epochCounter" are caught while "aggregateTotals" is not.
+const TOKEN_SET = new Set([
+	"epoch",
+	"epochs",
+	"generation",
+	"generations",
+	"revision",
+	"revisions",
+	"fence",
+	"fences",
+	"gate",
+	"gates",
+	"watermark",
+	"admission",
+	"admissions",
+	"lifecycle",
+]);
+const matchesFenceTokens = (name) =>
+	name
+		.split(/(?=[A-Z])|_|#/)
+		.some((segment) => TOKEN_SET.has(segment.toLowerCase()));
+// Class fields with a visibility modifier, plus modifier-less/static fields
+// whose names use the file's _-prefix (or #private) field idiom. Bare
+// "name: Type;" type-literal members and local const/let bindings stay
+// excluded.
+const DECL =
+	/^\s*(?:(?:private|protected|public)\s+(?:static\s+)?(?:override\s+)?(?:readonly\s+)?([A-Za-z0-9_#]+)|(?:static\s+)?(?:readonly\s+)?([_#][A-Za-z0-9_]+))\s*[?!]?\s*[:=]/;
+
+// The fence inventory as of the 2026-08-03 refactor baseline. Shrink this
+// list as the session/lifecycle migration deletes fields; never grow it
+// without a design note on the new field.
+const BASELINE = new Set([
+	"_checkedPruneRemoveBlocksLocalRangeMutationAdmission",
+	"_joinWarmupGenerationByTarget",
+	"_localReplicationRoleGeneration",
+	"_nativeCoordinateMutationGenerations",
+	"_receiveCleanupGateByPeer",
+	"_receiveOwnershipMutationAdmissions",
+	"_receiveOwnershipRevision",
+	"_repairLifecycleController",
+	"_repairSweepJoinWarmupGenerationByTarget",
+	"_replicationAnnouncementRepairGeneration",
+	"_replicationAnnouncementRepairGenerationController",
+	"_replicationAnnouncementRetryGeneration",
+	"_replicationInfoReceiveEpochByPeer",
+	"_replicationLifecycleController",
+	"_subscriptionEpochByPeer",
+	"_subscriptionOpeningEpochByPeer",
+	"nativeBlockWriteGenerations",
+	"nativeDeleteEpoch",
+]);
+
+const root = process.cwd();
+const lines = readFileSync(path.join(root, TARGET), "utf8").split("\n");
+
+const found = new Map();
+for (let i = 0; i < lines.length; i++) {
+	const m = lines[i].match(DECL);
+	const name = m?.[1] ?? m?.[2];
+	if (!name || !matchesFenceTokens(name)) continue;
+	// Accept a design-note: anywhere in the contiguous comment block directly
+	// above the declaration (or within 5 lines when there is no block).
+	let start = i - 1;
+	while (
+		start >= 0 &&
+		/^\s*(\/\/|\/\*|\*)/.test(lines[start]) &&
+		i - start < 40
+	) {
+		start--;
+	}
+	const hasDesignNote = lines
+		.slice(Math.max(0, Math.min(start + 1, i - 5)), i)
+		.some((l) => l.includes("design-note:"));
+	found.set(name, { line: i + 1, hasDesignNote });
+}
+
+const errors = [];
+for (const [name, info] of found) {
+	if (!BASELINE.has(name) && !info.hasDesignNote) {
+		errors.push(
+			`NEW fence-pattern field "${name}" (${TARGET}:${info.line}). ` +
+				`Prefer extending the session/lifecycle identity objects over adding ` +
+				`another fence; if a new fence is genuinely required, put a ` +
+				`\`design-note:\` marker in the comment block directly above the ` +
+				`declaration explaining why identity does not cover this staleness, ` +
+				`and add the field to BASELINE in this script.`,
+		);
+	}
+}
+for (const name of BASELINE) {
+	if (!found.has(name)) {
+		errors.push(
+			`BASELINE entry "${name}" no longer exists in ${TARGET} — shrink ` +
+				`BASELINE in scripts/ci/check-fence-ratchet.mjs (this is the good ` +
+				`direction; the list must stay exact).`,
+		);
+	}
+}
+
+if (errors.length > 0) {
+	for (const e of errors) console.error(e);
+	process.exit(1);
+}
+console.log(
+	`OK: ${found.size} fence-pattern fields in shared-log, all in the ratchet baseline (${BASELINE.size} entries).`,
+);


### PR DESCRIPTION
Stage 0 of the shared-log session/lifecycle refactor (design brief from the five-lens fence map; the other maintenance agent is paused for the duration). **No behavior changes** — this fixes the latent hazards the map surfaced and freezes the fence inventory so it can only shrink from here.

## Changes

- **Delete dead gate helpers.** `blockPeerReceiveAdmission`/`unblockPeerReceiveAdmission` had zero call sites; `removeReplicator`'s inline copy is the live one, and its captured-map form is semantically required (a late release after close/reopen must drain the dead map, not corrupt the fresh open's refcounts). Now documented at the capture site. Dead-ness verified by repo-wide grep including tests.
- **Consolidate the announcement-repair validity predicate.** The same staleness check was hand-maintained in three mid-flight copies plus one divergent catch-path variant — flagged by the map as the densest drift risk in the file (8 fields fencing one worker, checked in non-identical subsets). All four sites now share `announcementRepairWorkerStatus` (`stale` → exit silently, `superseded` → requeue). The catch path keeps its extra generation-controller identity comparison at the call site: folding it in would change requeue behavior, which belongs to the worker-session stage as a deliberate decision. Equivalence proven truth-table style in review, including short-circuit order.
- **Fix ctor/open init drift**: `_entryKnownPeerObservedAt` is now constructor-initialized alongside its twin (it was open()-only; observationally inert but exactly the drift class that bites borsh-constructed instances).
- **Add the fence ratchet** (`scripts/ci/check-fence-ratchet.mjs`, wired into both Lint steps): the 18 fence-pattern fields (epoch/generation/revision/gate/admission/lifecycle) in shared-log are a frozen baseline. A new one fails CI unless a `design-note:` comment in the block above the declaration justifies why session identity doesn't cover the staleness; removing one requires shrinking the baseline — the intended direction. Token matching is per camelCase segment (catches `generationOfLastPrune`, not `aggregateTotals`); declarations are caught with or without visibility modifiers for the file's `_`-prefix idiom. Mutation-tested: new-field → fail, design-note → sanctioned, modifier-less evasion → caught, baseline removal → fail.

## Validation

- Fresh-worktree (Node 22) suites, exit codes verified individually: replication announcement retries 16, replicate 28, receive admission 17, checked prune 45, isLeader 21, waitForReplicator 18, events 91 — all passing. Build + lint clean.
- Two-lens adversarial review: behavior preservation confirmed (dead-method grep, truth table, init-window analysis); both review findings were against the ratchet script itself and are fixed and re-mutation-tested.
- Release security contracts pass; ci.yml Lint-step change is not covered by any contract assertion (verified).

Next stages per the design brief: mechanical extraction of the difficulty-2 subsystems (join warmup, announcement/liveness timers, sync-glue factory, native write-through store), then the `InstanceLifecycle`/`PeerSession` objects wrapping the existing fences, then seam-by-seam collapse.