### PR TITLE
refactor(shared-log): stage-2 — introduce InstanceLifecycle and PeerSession

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -181,6 +181,7 @@ import {
 	materializeVerifiedRawExchangeHeadsMessage,
 } from "./exchange-heads.js";
 import { FanoutEnvelope } from "./fanout-envelope.js";
+import { InstanceLifecycle } from "./instance-lifecycle.js";
 import {
 	MAX_U32,
 	MAX_U64,
@@ -2028,7 +2029,16 @@ export class SharedLog<
 	// Explicit changes to the local replication role invalidate adaptive planners
 	// that were admitted under the previous role. The ownership lifecycle alone
 	// is insufficient because unreplicate() deliberately keeps the store open.
-	private _localReplicationRoleGeneration = 0;
+	// Stage 2: physically owned by the per-open InstanceLifecycle (role
+	// sub-generation); these accessors keep every legacy site verbatim.
+	private get _localReplicationRoleGeneration(): number {
+		return this._instanceLifecycle?.roleGeneration as number;
+	}
+	private set _localReplicationRoleGeneration(value: number) {
+		if (this._instanceLifecycle) {
+			this._instanceLifecycle.roleGeneration = value;
+		}
+	}
 	// If durable post-state cannot be reconciled to every native/runtime mirror,
 	// reject later writers and planners until reopen rehydrates those mirrors.
 	private _replicationRangeMutationFailure?: unknown;
@@ -2036,6 +2046,12 @@ export class SharedLog<
 	// opaque token on poison and every terminal/open boundary so an older runner
 	// can neither dispatch nor mutate a freshly opened lifecycle.
 	private _repairLifecycleController = new AbortController();
+	// design-note: not a new fence — this is the per-open identity object the
+	// fence ratchet is migrating TOWARD (stage 2 of the session/lifecycle
+	// refactor). It wraps the controllers, poison latch, terminal fences, and
+	// coordinator/debouncer identities via late-bound readers; stage 3 drains
+	// those fences into it one at a time.
+	private _instanceLifecycle?: InstanceLifecycle;
 	// Local receive generations fence replication-info handlers that were admitted
 	// before a liveness eviction but reach the per-peer apply lane after it. Unlike
 	// message timestamps, these tokens never compare clocks from different peers.
@@ -2113,6 +2129,7 @@ export class SharedLog<
 
 	private poisonReplicationOwnership(failure: unknown): unknown {
 		this._replicationRangeMutationFailure ??= failure;
+		this._instanceLifecycle?.markPoisoned(failure);
 		this.stopRepairLifecycle();
 		// Pending aggregate changes belong to the poisoned ownership generation.
 		// Closing also resolves ignored `add()` promises, while the guarded
@@ -3333,6 +3350,24 @@ export class SharedLog<
 		});
 	}
 
+	private createInstanceLifecycle(): InstanceLifecycle {
+		return new InstanceLifecycle({
+			getCurrentLifecycle: () => this._instanceLifecycle,
+			getOwnershipController: () => this._repairLifecycleController,
+			getMembershipController: () => this._replicationLifecycleController,
+			getCloseController: () => this._closeController,
+			getPoisonFailure: () => this._replicationRangeMutationFailure,
+			isHostClosed: () => this.closed,
+			isHostTerminating: () => this.isTerminating(),
+			getCheckedPruneCoordinator: () => this._checkedPrune,
+			areRangeMutationsClosing: () => this._replicationRangeMutationsClosing,
+			arePruneRemovesClosing: () => this._pruneRemovesClosing,
+			getPruneDebouncer: () => this.pruneDebouncedFn,
+			getReplicationChangeDebouncer: () => this.replicationChangeDebounceFn,
+			getRebalanceDebouncer: () => this.rebalanceParticipationDebounced,
+		});
+	}
+
 	constructor(properties?: { id?: Uint8Array }) {
 		super();
 		this.ensureNativeDurabilityRuntimeState();
@@ -3389,6 +3424,7 @@ export class SharedLog<
 		this._announcements = this.createReplicationAnnouncementCoordinator();
 		this.pendingMaturity = new Map();
 		this._closeController = new AbortController();
+		this._instanceLifecycle = this.createInstanceLifecycle();
 	}
 
 	private ensureNativeDurabilityRuntimeState(): void {
@@ -13682,12 +13718,20 @@ export class SharedLog<
 		this._replicationRangeMutationsClosing = false;
 		this._checkedPruneRemoveBlocksLocalRangeMutationAdmission = 0;
 		this._checkedPruneRemovalCallbackInvocationDepth = 0;
-		this._localReplicationRoleGeneration = 0;
 		this._receiveOwnershipRevision = 0;
 		this._receiveOwnershipMutationAdmissions = 0;
 		this._pruneRemovesClosing = false;
 		this._replicationRangeMutationFailure = undefined;
 		this.startRepairLifecycle();
+		// One InstanceLifecycle per open(): fresh identity, rotated together
+		// with the ownership controller above. Late-bound readers make it
+		// insensitive to the resets that follow (membership controller at
+		// resetSubscriptionChangeCallbackTracking below, _checkedPrune and
+		// _closeController and the debouncers in the setup blocks further
+		// down). The fresh object also supersedes the old per-open
+		// `_localReplicationRoleGeneration = 0` reset: roleGeneration starts
+		// at 0 on the incoming lifecycle.
+		this._instanceLifecycle = this.createInstanceLifecycle();
 		this._replicationRangeMutationTail = Promise.resolve();
 		this.resetSubscriptionChangeCallbackTracking();
 		const recoveringNativeDurableFailure =
@@ -14381,6 +14425,8 @@ export class SharedLog<
 		this.interval = setInterval(() => {
 			void this.rebalanceParticipationDebounced?.call();
 		}, RECALCULATE_PARTICIPATION_DEBOUNCE_INTERVAL);
+
+		this._instanceLifecycle!.markOpenComplete();
 	}
 
 	private toNativeReplicationRange(
@@ -16174,6 +16220,7 @@ export class SharedLog<
 
 	private async _close(options?: { preserveDropRetryResources?: boolean }) {
 		this.stopRepairLifecycle();
+		this._instanceLifecycle?.beginTerminal("internal-close");
 		const preserveDropRetryResources =
 			options?.preserveDropRetryResources === true;
 		let firstError: unknown;
@@ -16371,6 +16418,7 @@ export class SharedLog<
 		// SharedLog-specific await or observable teardown can admit a new owner.
 		this.preventParentAttachments();
 		this.stopRepairLifecycle();
+		this._instanceLifecycle?.beginTerminal("close");
 		const replicationRangeTerminalFence =
 			this.acquireReplicationRangeMutationTerminalFence();
 		const pruneRemoveTerminalFence = this.acquirePruneRemoveTerminalFence();
@@ -16511,6 +16559,7 @@ export class SharedLog<
 		// the terminal fence only after that precondition succeeds.
 		this.preventParentAttachments();
 		this.stopRepairLifecycle();
+		this._instanceLifecycle?.beginTerminal("drop");
 		const replicationRangeTerminalFence =
 			this.acquireReplicationRangeMutationTerminalFence();
 		const pruneRemoveTerminalFence = this.acquirePruneRemoveTerminalFence();

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -193,6 +193,7 @@ import { JoinWarmupCoordinator } from "./join-warmup.js";
 import { LeaderPlanCache } from "./leader-plan-cache.js";
 import { TransportMessage } from "./message.js";
 import { NativeBackboneWriteThroughBlockStore } from "./native-write-through-block-store.js";
+import { type PeerSessionKind, PeerSessionRegistry } from "./peer-session.js";
 import { PIDReplicationController } from "./pid.js";
 import {
 	type EntryReplicated,
@@ -2066,7 +2067,9 @@ export class SharedLog<
 	// Subscription callbacks can overlap because removing a replicator mutates the
 	// replication index asynchronously. Keep that lifecycle separate from message
 	// timestamps so a reconnect can synchronously revoke an older unsubscribe.
-	private _subscriptionEpochByPeer!: Map<string, object>;
+	// The epoch tokens are PeerSession objects (src/peer-session.ts); the map
+	// itself lives on the registry. Stage-2 of the fence refactor.
+	private _peerSessions!: PeerSessionRegistry;
 	// A superseded removal may be the queue item that actually observed an active
 	// replicator. Carry that leave obligation to the transition that ultimately
 	// wins, while a winning reconnect clears it without emitting a stale leave.
@@ -3350,6 +3353,20 @@ export class SharedLog<
 		});
 	}
 
+	private createPeerSessionRegistry(): PeerSessionRegistry {
+		return new PeerSessionRegistry({
+			// Delegators, not bound refs — instance spies must keep observing.
+			isReplicationLifecycleActive: (controller) =>
+				this.isReplicationLifecycleActive(controller),
+			getReplicationLifecycleController: () =>
+				this._replicationLifecycleController,
+			isReplicationInfoBlocked: (hash) =>
+				this._replicationInfoBlockedPeers.has(hash),
+			getReceiveCleanupGate: (hash) =>
+				this._receiveCleanupGateByPeer.get(hash) ?? 0,
+		});
+	}
+
 	private createInstanceLifecycle(): InstanceLifecycle {
 		return new InstanceLifecycle({
 			getCurrentLifecycle: () => this._instanceLifecycle,
@@ -3383,7 +3400,7 @@ export class SharedLog<
 		this._replicationInfoRequestByPeer = new Map();
 		this._replicationInfoApplyQueueByPeer = new Map();
 		this._replicationInfoReceiveEpochByPeer = new Map();
-		this._subscriptionEpochByPeer = new Map();
+		this._peerSessions = this.createPeerSessionRegistry();
 		this._pendingReplicatorLeaveByPeer = new Set();
 		this._activeReceiveHandlersByPeer = new Map();
 		this._receiveHandlerDrainByPeer = new Map();
@@ -6220,6 +6237,7 @@ export class SharedLog<
 					this.rebalanceParticipationDebounced?.call();
 				}
 				removed = true;
+				this._peerSessions?.noteReplicatorRemoved(keyHash);
 				if (!ownerHasRanges) {
 					options?.onRemoved?.({ wasReplicator });
 				}
@@ -13777,7 +13795,11 @@ export class SharedLog<
 		// install fresh lanes and opaque per-subscription ownership tokens.
 		this._replicationInfoApplyQueueByPeer = new Map();
 		this._replicationInfoReceiveEpochByPeer = new Map();
-		this._subscriptionEpochByPeer = new Map();
+		// Deserialized instances never ran the constructor; create the session
+		// registry lazily on first open. Reopens keep the SAME registry so stale
+		// continuations observe resetForOpen()'s map swap via property lookup.
+		this._peerSessions ??= this.createPeerSessionRegistry();
+		this._peerSessions.resetForOpen();
 		this._pendingReplicatorLeaveByPeer = new Set();
 		this._activeReceiveHandlersByPeer = new Map();
 		this._receiveHandlerDrainByPeer = new Map();
@@ -23819,14 +23841,15 @@ export class SharedLog<
 		return this.getReplicationInfoReceiveEpoch(peerHash) === epoch;
 	}
 
-	private advanceSubscriptionEpoch(peerHash: string): object {
-		const next = {};
-		this._subscriptionEpochByPeer.set(peerHash, next);
-		return next;
+	private advanceSubscriptionEpoch(
+		peerHash: string,
+		kind: PeerSessionKind = "opening",
+	): object {
+		return this._peerSessions.rotate(peerHash, kind);
 	}
 
 	private getSubscriptionEpoch(peerHash: string): object | null {
-		return this._subscriptionEpochByPeer.get(peerHash) ?? null;
+		return this._peerSessions.current(peerHash);
 	}
 
 	private isCurrentSubscriptionEpoch(
@@ -23939,7 +23962,11 @@ export class SharedLog<
 
 		const peerHash = publicKey.hashcode();
 		const expectedSubscriptionEpoch =
-			subscriptionEpoch ?? this.advanceSubscriptionEpoch(peerHash);
+			subscriptionEpoch ??
+			this.advanceSubscriptionEpoch(
+				peerHash,
+				subscribed ? "opening" : "departing",
+			);
 		const ownsSubscriptionEpoch = () =>
 			this.isCurrentSubscriptionEpoch(peerHash, expectedSubscriptionEpoch);
 		if (!ownsSubscriptionEpoch()) {
@@ -24057,6 +24084,7 @@ export class SharedLog<
 		this._replicationInfoBlockedPeers.delete(peerHash);
 		this._replicatorLivenessFailures.delete(peerHash);
 		this.markReplicatorActivity(peerHash);
+		this._peerSessions.markOpen(peerHash, expectedSubscriptionEpoch);
 
 		if (this._logProperties?.sync?.rawExchangeHeads === true) {
 			// One-shot capability advertisement so live append gossip can pick
@@ -25550,7 +25578,10 @@ export class SharedLog<
 		}
 
 		const fromHash = evt.detail.from.hashcode();
-		const subscriptionEpoch = this.advanceSubscriptionEpoch(fromHash);
+		const subscriptionEpoch = this.advanceSubscriptionEpoch(
+			fromHash,
+			"departing",
+		);
 		this._replicationInfoBlockedPeers.add(fromHash);
 		this._recentRepairDispatch.delete(fromHash);
 

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2033,7 +2033,7 @@ export class SharedLog<
 	// Stage 2: physically owned by the per-open InstanceLifecycle (role
 	// sub-generation); these accessors keep every legacy site verbatim.
 	private get _localReplicationRoleGeneration(): number {
-		return this._instanceLifecycle?.roleGeneration as number;
+		return this._instanceLifecycle?.roleGeneration ?? 0;
 	}
 	private set _localReplicationRoleGeneration(value: number) {
 		if (this._instanceLifecycle) {
@@ -6237,7 +6237,10 @@ export class SharedLog<
 					this.rebalanceParticipationDebounced?.call();
 				}
 				removed = true;
-				this._peerSessions?.noteReplicatorRemoved(keyHash);
+				this._peerSessions?.noteReplicatorRemoved(
+					keyHash,
+					options?.subscriptionEpoch,
+				);
 				if (!ownerHasRanges) {
 					options?.onRemoved?.({ wasReplicator });
 				}
@@ -13740,16 +13743,18 @@ export class SharedLog<
 		this._receiveOwnershipMutationAdmissions = 0;
 		this._pruneRemovesClosing = false;
 		this._replicationRangeMutationFailure = undefined;
-		this.startRepairLifecycle();
-		// One InstanceLifecycle per open(): fresh identity, rotated together
-		// with the ownership controller above. Late-bound readers make it
-		// insensitive to the resets that follow (membership controller at
+		// One InstanceLifecycle per open(): fresh identity, installed before
+		// the ownership-controller rotation so no statement in this reset
+		// block can observe the previous lifecycle's roleGeneration.
+		// Late-bound readers make it insensitive to the resets that follow
+		// (ownership controller next, membership controller at
 		// resetSubscriptionChangeCallbackTracking below, _checkedPrune and
 		// _closeController and the debouncers in the setup blocks further
 		// down). The fresh object also supersedes the old per-open
 		// `_localReplicationRoleGeneration = 0` reset: roleGeneration starts
 		// at 0 on the incoming lifecycle.
 		this._instanceLifecycle = this.createInstanceLifecycle();
+		this.startRepairLifecycle();
 		this._replicationRangeMutationTail = Promise.resolve();
 		this.resetSubscriptionChangeCallbackTracking();
 		const recoveringNativeDurableFailure =

--- a/packages/programs/data/shared-log/src/instance-lifecycle.ts
+++ b/packages/programs/data/shared-log/src/instance-lifecycle.ts
@@ -1,0 +1,244 @@
+// Stage 2 of the session/lifecycle refactor: one InstanceLifecycle per
+// SharedLog.open(). In stage 2 the object WRAPS the existing fences via
+// late-bound readers — it physically owns nothing except the role
+// sub-generation — so every existing check keeps working unchanged. Stage 3
+// migrates the eight documented multi-fence seams onto this API and deletes
+// the wrapped fences one at a time (each deletion shrinks the index.ts
+// baseline in scripts/ci/check-fence-ratchet.mjs).
+import { TerminalOperationNotStartedError } from "@peerbit/program";
+
+export type InstanceLifecyclePhase =
+	| "opening" // installed by open(); markOpenComplete() not yet reached
+	| "active" // open() returned; current, unfenced, unpoisoned
+	| "poisoned" // poisonReplicationOwnership latched (survives until reopen)
+	| "terminating" // ownership controller aborted by close()/drop()/_close()
+	| "closed"; // host Program reports closed
+
+export type InstanceLifecycleTerminalReason =
+	| "close"
+	| "drop"
+	| "internal-close";
+
+export type InstanceLifecycleDeps = {
+	/** host._instanceLifecycle — identity anchor for isCurrent() */
+	getCurrentLifecycle: () => InstanceLifecycle | undefined;
+	/** host._repairLifecycleController (ownership half, fence A1) */
+	getOwnershipController: () => AbortController | undefined;
+	/** host._replicationLifecycleController (membership half, fence A5) */
+	getMembershipController: () => AbortController | undefined;
+	/** host._closeController */
+	getCloseController: () => AbortController | undefined;
+	/** host._replicationRangeMutationFailure (poison latch, fence A2) */
+	getPoisonFailure: () => unknown;
+	/** host.closed */
+	isHostClosed: () => boolean;
+	/** host.isTerminating() — closed || parent-detach || closeController aborted */
+	isHostTerminating: () => boolean;
+	/** host._checkedPrune — identity only, never dereferenced (fence A3) */
+	getCheckedPruneCoordinator: () => object | undefined;
+	/** host._replicationRangeMutationsClosing (terminal lane fence, A4) */
+	areRangeMutationsClosing: () => boolean;
+	/** host._pruneRemovesClosing (terminal lane fence, A4) */
+	arePruneRemovesClosing: () => boolean;
+	/** host.pruneDebouncedFn — identity only */
+	getPruneDebouncer: () => object | undefined;
+	/** host.replicationChangeDebounceFn — identity only */
+	getReplicationChangeDebouncer: () => object | undefined;
+	/** host.rebalanceParticipationDebounced — identity only */
+	getRebalanceDebouncer: () => object | undefined;
+};
+
+export class InstanceLifecycle {
+	// The ONLY state that physically moves in stage 2 (absorbs
+	// SharedLog._localReplicationRoleGeneration). Bumped by replicate()'s
+	// fixed-role replacement and by full unreplication WITHOUT rotating the
+	// lifecycle: unreplicate() deliberately keeps the store open, so admitted
+	// adaptive planners are invalidated by this sub-generation, not by
+	// retiring the instance identity.
+	public roleGeneration = 0;
+
+	// Stage-2 bookkeeping. WRITE-ONLY in production paths: no query method
+	// consults these (phase() is derived from the wrapped fences), so a
+	// missed or doubled transition cannot change behavior. Stage 3 flips
+	// phase() onto declaredPhase once the transitions have soaked in CI.
+	public declaredPhase: InstanceLifecyclePhase = "opening";
+	public terminalReason?: InstanceLifecycleTerminalReason;
+	public poisonCause?: unknown;
+
+	constructor(private readonly deps: InstanceLifecycleDeps) {}
+
+	// ---- rotation-point transitions (stage 2: diagnostics only) ----
+
+	markOpenComplete(): void {
+		if (this.declaredPhase === "opening") this.declaredPhase = "active";
+	}
+
+	beginTerminal(reason: InstanceLifecycleTerminalReason): void {
+		this.terminalReason ??= reason;
+		if (this.declaredPhase !== "poisoned") this.declaredPhase = "terminating";
+	}
+
+	markPoisoned(cause: unknown): void {
+		this.poisonCause ??= cause;
+		this.declaredPhase = "poisoned";
+	}
+
+	// ---- role sub-generation (absorbed fence A6) ----
+
+	bumpRoleGeneration(): number {
+		return ++this.roleGeneration;
+	}
+
+	isRoleCurrent(capturedRoleGeneration: number): boolean {
+		return this.roleGeneration === capturedRoleGeneration;
+	}
+
+	// ---- identity ----
+
+	isCurrent(): boolean {
+		return this.deps.getCurrentLifecycle() === this;
+	}
+
+	// ---- derived phase (single source of truth = the wrapped fences) ----
+
+	phase(): InstanceLifecyclePhase {
+		if (this.deps.getPoisonFailure() !== undefined) return "poisoned";
+		if (this.deps.isHostClosed()) return "closed";
+		const ownership = this.deps.getOwnershipController();
+		if (!this.isCurrent() || ownership == null || ownership.signal.aborted) {
+			return "terminating";
+		}
+		return this.declaredPhase === "opening" ? "opening" : "active";
+	}
+
+	// ---- ownership half: exact folds of the legacy predicates ----
+
+	/** ≡ SharedLog.isRepairLifecycleActive(controller). */
+	isActiveFor(controller: AbortController | undefined): boolean {
+		return (
+			controller != null &&
+			controller === this.deps.getOwnershipController() &&
+			!controller.signal.aborted &&
+			this.deps.getPoisonFailure() === undefined &&
+			!this.deps.isHostClosed()
+		);
+	}
+
+	/**
+	 * Controller-free form for stage-3 seams. Because this object and
+	 * _repairLifecycleController rotate at the same single point (open()),
+	 * `capturedLifecycle.isActive()` ⇔
+	 * `isRepairLifecycleActive(capturedController)` for captures taken
+	 * together — the equivalence the unit spec asserts.
+	 */
+	isActive(): boolean {
+		return (
+			this.isCurrent() && this.isActiveFor(this.deps.getOwnershipController())
+		);
+	}
+
+	/** ≡ SharedLog.throwIfReplicationOwnershipPoisoned — message and `cause`
+	 * must stay byte-identical for stage-3 drop-in. */
+	throwIfPoisoned(): void {
+		const failure = this.deps.getPoisonFailure();
+		if (failure !== undefined) {
+			throw new Error(
+				"Replication ownership recovery is required before further planning",
+				{ cause: failure },
+			);
+		}
+	}
+
+	/** ≡ SharedLog.throwIfReplicationOwnershipLifecycleInactive. */
+	throwIfInactive(
+		controller: AbortController | undefined = this.deps.getOwnershipController(),
+	): void {
+		this.throwIfPoisoned();
+		if (!(this.isCurrent() && this.isActiveFor(controller))) {
+			throw new TerminalOperationNotStartedError(
+				"Replication ownership lifecycle is no longer active",
+			);
+		}
+	}
+
+	/** ≡ SharedLog.captureReplicationOwnershipLifecycle, but returns the
+	 * lifecycle; stage-3 sites capture this instead of the raw controller
+	 * (which stays reachable via ownershipSignal()). */
+	capture(): InstanceLifecycle {
+		this.throwIfInactive();
+		return this;
+	}
+
+	/** AbortControllers stay the signal carriers in stages 2 and 3. */
+	ownershipSignal(): AbortSignal | undefined {
+		return this.deps.getOwnershipController()?.signal;
+	}
+
+	// ---- membership half (fence A5): exact fold ----
+
+	/** ≡ SharedLog.isReplicationLifecycleActive(controller).
+	 * NOTE the asymmetry vs isActiveFor: this side uses isTerminating()
+	 * (closeController + parent-detach), not `closed` — preserve exactly. */
+	isMembershipActiveFor(controller: AbortController | undefined): boolean {
+		return (
+			controller != null &&
+			controller === this.deps.getMembershipController() &&
+			!controller.signal.aborted &&
+			!this.deps.isHostTerminating()
+		);
+	}
+
+	membershipSignal(): AbortSignal | undefined {
+		return this.deps.getMembershipController()?.signal;
+	}
+
+	closeSignal(): AbortSignal | undefined {
+		return this.deps.getCloseController()?.signal;
+	}
+
+	// ---- checked-prune identity (seams 4 and 7) ----
+
+	/** ≡ prune()'s isCheckedPruneLifecycleCurrent triple for captures taken
+	 * at the same admission point. */
+	isCheckedPruneCurrent(
+		coordinator: object | undefined,
+		closeController: AbortController | undefined,
+	): boolean {
+		return (
+			this.isCurrent() &&
+			this.isActiveFor(this.deps.getOwnershipController()) &&
+			coordinator === this.deps.getCheckedPruneCoordinator() &&
+			closeController === this.deps.getCloseController()
+		);
+	}
+
+	// ---- terminal lane fences (A4): exposed, NOT folded into isActive ----
+	// Folding them would change which TerminalOperationNotStartedError message
+	// the admission sites throw ("Replication range mutations are closing",
+	// "Prune removals are closing") — a behavior change.
+
+	areRangeMutationsClosing(): boolean {
+		return this.deps.areRangeMutationsClosing();
+	}
+
+	arePruneRemovesClosing(): boolean {
+		return this.deps.arePruneRemovesClosing();
+	}
+
+	// ---- debouncer identities (seam 6 et al.) ----
+	// Bare === on purpose: at rebalanceParticipation the captured default
+	// parameter may be undefined and `undefined === undefined` legitimately
+	// passes today. A null-guard would break that.
+
+	isPruneDebouncerCurrent(fn: object | undefined): boolean {
+		return fn === this.deps.getPruneDebouncer();
+	}
+
+	isReplicationChangeDebouncerCurrent(fn: object | undefined): boolean {
+		return fn === this.deps.getReplicationChangeDebouncer();
+	}
+
+	isRebalanceDebouncerCurrent(fn: object | undefined): boolean {
+		return fn === this.deps.getRebalanceDebouncer();
+	}
+}

--- a/packages/programs/data/shared-log/src/peer-session.ts
+++ b/packages/programs/data/shared-log/src/peer-session.ts
@@ -139,15 +139,31 @@ export class PeerSessionRegistry {
 	 *  the expected token was superseded meanwhile. */
 	markOpen(peerHash: string, expectedSession: object): void {
 		const current = this._subscriptionEpochByPeer.get(peerHash);
-		if (current === expectedSession && current.kind === "opening") {
+		if (
+			current !== undefined &&
+			current === expectedSession &&
+			current.kind === "opening"
+		) {
 			current.phase = "open";
 		}
 	}
 
-	/** Destructive removal committed for this peer's CURRENT epoch. */
-	noteReplicatorRemoved(peerHash: string): void {
+	/** Destructive removal committed for this peer. Mirrors the removal
+	 *  funnel's epoch scoping: an epoch-scoped removal only stamps the
+	 *  session it was scoped to — a reconnect during the removal's awaited
+	 *  lanes must not inherit the stamp. Undefined = unscoped removal,
+	 *  which stamps the current session as before; null scopes to "peer had
+	 *  no session at capture", so a session created meanwhile is never
+	 *  stamped. */
+	noteReplicatorRemoved(
+		peerHash: string,
+		expectedSession?: object | null,
+	): void {
 		const current = this._subscriptionEpochByPeer.get(peerHash);
-		if (current) {
+		if (
+			current &&
+			(expectedSession === undefined || current === expectedSession)
+		) {
 			current.replicatorRemoved = true;
 		}
 	}

--- a/packages/programs/data/shared-log/src/peer-session.ts
+++ b/packages/programs/data/shared-log/src/peer-session.ts
@@ -1,0 +1,173 @@
+// One PeerSession per peer connection-epoch. The session instance IS the
+// opaque subscription-epoch token introduced at index.ts advanceSubscriptionEpoch:
+// every existing `===` epoch comparison keeps working because tokens were
+// always compared by identity and never inspected. Stage 2 wraps; stage 3
+// migrates the compound predicates onto isCurrent()/isActive()/
+// isReceiveAdmissionOpen() and deletes the raw fences one at a time.
+
+export type PeerSessionKind = "opening" | "departing";
+
+export type PeerSessionPhase =
+	| "opening" // subscribe transition; reconnect barrier not yet completed
+	| "open" // reconnect barrier completed (replication-info unblocked)
+	| "departing" // created by an unsubscribe epoch-advance, fencing the old connection
+	| "superseded"; // a newer session replaced this one (terminal)
+
+export type PeerSessionDeps = {
+	// Late-bound readers into state that stays physically on SharedLog in
+	// stage 2. Delegating closures — NOT bound method refs — so sinon spies
+	// installed on the SharedLog instance keep intercepting (same constraint
+	// as the stage-1 coordinators).
+	isReplicationLifecycleActive: (
+		controller: AbortController | undefined,
+	) => boolean;
+	getReplicationLifecycleController: () => AbortController | undefined;
+	isReplicationInfoBlocked: (peerHash: string) => boolean;
+	getReceiveCleanupGate: (peerHash: string) => number;
+};
+
+export type PeerReceiveAdmissionOptions = {
+	allowReplicationInfoBlocked?: boolean;
+	allowCleanupGate?: boolean;
+};
+
+export class PeerSession {
+	readonly peerHash: string;
+	readonly kind: PeerSessionKind;
+	// The lifecycle controller live at rotation. All current seams pair the
+	// epoch check with a lifecycle check against a controller captured in the
+	// same synchronous window as the epoch advance; capturing it here
+	// reproduces that pairing exactly.
+	readonly replicationLifecycleController: AbortController | undefined;
+	phase: PeerSessionPhase;
+	// Diagnostics only in stage 2: the destructive removal funnel observed a
+	// committed replicator removal under this connection-epoch.
+	replicatorRemoved = false;
+	readonly createdAt = Date.now(); // diagnostics only
+
+	constructor(
+		private readonly registry: PeerSessionRegistry,
+		peerHash: string,
+		kind: PeerSessionKind,
+		replicationLifecycleController: AbortController | undefined,
+	) {
+		this.peerHash = peerHash;
+		this.kind = kind;
+		this.replicationLifecycleController = replicationLifecycleController;
+		this.phase = kind;
+	}
+
+	/** ≡ SharedLog.isCurrentSubscriptionEpoch(this.peerHash, this). */
+	isCurrent(): boolean {
+		return this.registry.current(this.peerHash) === this;
+	}
+
+	/** ≡ ownsReplicationLifecycle() && ownsSubscriptionEpoch() with both
+	 *  captured at the epoch-advance. */
+	isActive(): boolean {
+		return (
+			this.isCurrent() &&
+			this.registry.deps.isReplicationLifecycleActive(
+				this.replicationLifecycleController,
+			)
+		);
+	}
+
+	/** ≡ SharedLog.isPeerReceiveAdmissionOpen(peerHash,
+	 *  this.replicationLifecycleController, this, options). */
+	isReceiveAdmissionOpen(options?: PeerReceiveAdmissionOptions): boolean {
+		return this.registry.isReceiveAdmissionOpen(
+			this.peerHash,
+			this,
+			this.replicationLifecycleController,
+			options,
+		);
+	}
+}
+
+export class PeerSessionRegistry {
+	// Historic field name kept deliberately: the fence-ratchet baseline entry
+	// moves file-to-file exactly like the stage-1 extractions did for
+	// _joinWarmupGenerationByTarget (scripts/ci/check-fence-ratchet.mjs).
+	// The values ARE the epoch tokens. Stage 3 renames this to `sessions`
+	// once the last raw-token comparison in index.ts is gone.
+	_subscriptionEpochByPeer!: Map<string, PeerSession>;
+
+	constructor(readonly deps: PeerSessionDeps) {
+		this.resetForOpen();
+	}
+
+	/** open()-time re-init: REPLACE the map instance, matching today's
+	 *  `this._subscriptionEpochByPeer = new Map()` (index.ts ctor / open).
+	 *  The map is intentionally NOT cleared at _close — tokens must stay
+	 *  current across close so a late continuation's epoch check resolves
+	 *  exactly as it does today (close-safety comes from the paired
+	 *  lifecycle-controller check, not the epoch). There is NO clearForClose(). */
+	resetForOpen(): void {
+		this._subscriptionEpochByPeer = new Map();
+	}
+
+	current(peerHash: string): PeerSession | null {
+		return this._subscriptionEpochByPeer.get(peerHash) ?? null;
+	}
+
+	/** null is a VALID current value: a peer that never subscribed has no
+	 *  session, and today's isCurrentSubscriptionEpoch(peer, null) === true
+	 *  admits it (the `?? null` in getSubscriptionEpoch). Preserved exactly. */
+	isCurrent(peerHash: string, session: object | null): boolean {
+		return this.current(peerHash) === session;
+	}
+
+	/** The only creation point. Supersedes (never deletes) the previous
+	 *  session — per-peer entries are never removed, matching today's map. */
+	rotate(peerHash: string, kind: PeerSessionKind): PeerSession {
+		const previous = this._subscriptionEpochByPeer.get(peerHash);
+		if (previous) {
+			previous.phase = "superseded";
+		}
+		const next = new PeerSession(
+			this,
+			peerHash,
+			kind,
+			this.deps.getReplicationLifecycleController(),
+		);
+		this._subscriptionEpochByPeer.set(peerHash, next);
+		return next;
+	}
+
+	/** Reconnect barrier completed. Identity-guarded phase mark; no-op when
+	 *  the expected token was superseded meanwhile. */
+	markOpen(peerHash: string, expectedSession: object): void {
+		const current = this._subscriptionEpochByPeer.get(peerHash);
+		if (current === expectedSession && current.kind === "opening") {
+			current.phase = "open";
+		}
+	}
+
+	/** Destructive removal committed for this peer's CURRENT epoch. */
+	noteReplicatorRemoved(peerHash: string): void {
+		const current = this._subscriptionEpochByPeer.get(peerHash);
+		if (current) {
+			current.replicatorRemoved = true;
+		}
+	}
+
+	/** ≡ SharedLog.isPeerReceiveAdmissionOpen, term for term. `session` may
+	 *  be null (pre-session peer). Stage 3 migrates the host method's body
+	 *  onto this; stage 2 only proves parity in tests. */
+	isReceiveAdmissionOpen(
+		peerHash: string,
+		session: object | null,
+		replicationLifecycleController: AbortController | undefined,
+		options?: PeerReceiveAdmissionOptions,
+	): boolean {
+		return (
+			this.deps.isReplicationLifecycleActive(replicationLifecycleController) &&
+			this.isCurrent(peerHash, session) &&
+			(options?.allowReplicationInfoBlocked === true ||
+				!this.deps.isReplicationInfoBlocked(peerHash)) &&
+			(options?.allowCleanupGate === true ||
+				this.deps.getReceiveCleanupGate(peerHash) === 0)
+		);
+	}
+}

--- a/packages/programs/data/shared-log/test/instance-lifecycle.spec.ts
+++ b/packages/programs/data/shared-log/test/instance-lifecycle.spec.ts
@@ -1,0 +1,399 @@
+// Stage-2 lifecycle refactor guard: InstanceLifecycle wraps the existing
+// fences via late-bound readers, so the pure-unit half asserts truth-table
+// equivalence with the legacy predicates it folds, and the integration half
+// asserts the per-open rotation/identity semantics against a real SharedLog.
+import { deserialize, serialize } from "@dao-xyz/borsh";
+import { TerminalOperationNotStartedError } from "@peerbit/program";
+import { TestSession } from "@peerbit/test-utils";
+import { expect } from "chai";
+import {
+	InstanceLifecycle,
+	type InstanceLifecycleDeps,
+} from "../src/instance-lifecycle.js";
+import { EventStore } from "./utils/stores/index.js";
+
+type StubHost = {
+	lifecycle?: InstanceLifecycle;
+	ownership?: AbortController;
+	membership?: AbortController;
+	closeController?: AbortController;
+	poison?: unknown;
+	closed: boolean;
+	terminating: boolean;
+	checkedPrune?: object;
+	rangeMutationsClosing: boolean;
+	pruneRemovesClosing: boolean;
+	pruneDebouncer?: object;
+	replicationChangeDebouncer?: object;
+	rebalanceDebouncer?: object;
+};
+
+const createHost = (): StubHost => ({
+	ownership: new AbortController(),
+	membership: new AbortController(),
+	closeController: new AbortController(),
+	closed: false,
+	terminating: false,
+	checkedPrune: {},
+	rangeMutationsClosing: false,
+	pruneRemovesClosing: false,
+});
+
+const createDeps = (host: StubHost): InstanceLifecycleDeps => ({
+	getCurrentLifecycle: () => host.lifecycle,
+	getOwnershipController: () => host.ownership,
+	getMembershipController: () => host.membership,
+	getCloseController: () => host.closeController,
+	getPoisonFailure: () => host.poison,
+	isHostClosed: () => host.closed,
+	isHostTerminating: () => host.terminating,
+	getCheckedPruneCoordinator: () => host.checkedPrune,
+	areRangeMutationsClosing: () => host.rangeMutationsClosing,
+	arePruneRemovesClosing: () => host.pruneRemovesClosing,
+	getPruneDebouncer: () => host.pruneDebouncer,
+	getReplicationChangeDebouncer: () => host.replicationChangeDebouncer,
+	getRebalanceDebouncer: () => host.rebalanceDebouncer,
+});
+
+const createCurrentLifecycle = (host: StubHost): InstanceLifecycle => {
+	const lifecycle = new InstanceLifecycle(createDeps(host));
+	host.lifecycle = lifecycle;
+	return lifecycle;
+};
+
+describe("lifecycle instance identity", () => {
+	describe("unit", () => {
+		it("isActiveFor matches the legacy repair-lifecycle predicate on the full fence truth table", () => {
+			for (const stale of [false, true]) {
+				for (const aborted of [false, true]) {
+					for (const poisoned of [false, true]) {
+						for (const closed of [false, true]) {
+							const host = createHost();
+							const lifecycle = createCurrentLifecycle(host);
+							const controller = stale
+								? new AbortController()
+								: host.ownership!;
+							if (aborted) {
+								controller.abort();
+							}
+							if (poisoned) {
+								host.poison = new Error("poisoned");
+							}
+							host.closed = closed;
+							// Legacy isRepairLifecycleActive, condition for condition.
+							const legacy =
+								controller === host.ownership &&
+								!controller.signal.aborted &&
+								host.poison === undefined &&
+								!host.closed;
+							const label = `stale=${stale} aborted=${aborted} poisoned=${poisoned} closed=${closed}`;
+							expect(lifecycle.isActiveFor(controller)).to.equal(
+								legacy,
+								label,
+							);
+							// A capture taken under this lifecycle: controller-free form
+							// agrees with the legacy predicate on the current controller.
+							if (!stale) {
+								expect(lifecycle.isActive()).to.equal(legacy, label);
+							}
+						}
+					}
+				}
+			}
+		});
+
+		it("isActiveFor rejects an absent controller", () => {
+			const host = createHost();
+			const lifecycle = createCurrentLifecycle(host);
+			expect(lifecycle.isActiveFor(undefined)).to.be.false;
+			host.ownership = undefined;
+			expect(lifecycle.isActive()).to.be.false;
+		});
+
+		it("isMembershipActiveFor matches the legacy membership predicate including the terminating term", () => {
+			for (const stale of [false, true]) {
+				for (const aborted of [false, true]) {
+					for (const terminating of [false, true]) {
+						const host = createHost();
+						const lifecycle = createCurrentLifecycle(host);
+						const controller = stale
+							? new AbortController()
+							: host.membership!;
+						if (aborted) {
+							controller.abort();
+						}
+						host.terminating = terminating;
+						// Legacy isReplicationLifecycleActive, condition for condition.
+						const legacy =
+							controller != null &&
+							controller === host.membership &&
+							!controller.signal.aborted &&
+							!host.terminating;
+						expect(lifecycle.isMembershipActiveFor(controller)).to.equal(
+							legacy,
+							`stale=${stale} aborted=${aborted} terminating=${terminating}`,
+						);
+					}
+				}
+			}
+			const host = createHost();
+			const lifecycle = createCurrentLifecycle(host);
+			expect(lifecycle.isMembershipActiveFor(undefined)).to.be.false;
+			// The asymmetry vs the ownership half: `closed` alone does not gate
+			// membership (isTerminating() is the fence on this side).
+			host.closed = true;
+			expect(lifecycle.isMembershipActiveFor(host.membership)).to.be.true;
+		});
+
+		it("throwIfInactive throws the legacy error types and messages", () => {
+			const host = createHost();
+			const lifecycle = createCurrentLifecycle(host);
+			expect(() => lifecycle.throwIfInactive()).to.not.throw();
+			expect(lifecycle.capture()).to.equal(lifecycle);
+
+			// Poison wins and carries the failure as `cause`.
+			const failure = new Error("boom");
+			host.poison = failure;
+			try {
+				lifecycle.throwIfInactive();
+				expect.fail("expected throw");
+			} catch (error: any) {
+				expect(error).to.not.be.instanceOf(TerminalOperationNotStartedError);
+				expect(error.message).to.equal(
+					"Replication ownership recovery is required before further planning",
+				);
+				expect(error.cause).to.equal(failure);
+			}
+
+			// Aborted (unpoisoned) controller: TerminalOperationNotStartedError.
+			host.poison = undefined;
+			host.ownership!.abort();
+			try {
+				lifecycle.throwIfInactive();
+				expect.fail("expected throw");
+			} catch (error: any) {
+				expect(error).to.be.instanceOf(TerminalOperationNotStartedError);
+				expect(error.message).to.equal(
+					"Replication ownership lifecycle is no longer active",
+				);
+			}
+		});
+
+		it("capture throws once the lifecycle identity is superseded", () => {
+			const host = createHost();
+			const stale = createCurrentLifecycle(host);
+			// Reopen installs a fresh lifecycle on the host.
+			createCurrentLifecycle(host);
+			expect(() => stale.capture()).to.throw(
+				TerminalOperationNotStartedError,
+				"Replication ownership lifecycle is no longer active",
+			);
+			expect(host.lifecycle!.capture()).to.equal(host.lifecycle);
+		});
+
+		it("debouncer identity uses bare equality so undefined === undefined passes", () => {
+			const host = createHost();
+			const lifecycle = createCurrentLifecycle(host);
+			// The captured default parameter may legitimately be undefined while
+			// the host debouncer is also still undefined.
+			expect(lifecycle.isRebalanceDebouncerCurrent(undefined)).to.be.true;
+			expect(lifecycle.isPruneDebouncerCurrent(undefined)).to.be.true;
+			expect(lifecycle.isReplicationChangeDebouncerCurrent(undefined)).to.be
+				.true;
+			const fn = {};
+			host.rebalanceDebouncer = fn;
+			host.pruneDebouncer = fn;
+			host.replicationChangeDebouncer = fn;
+			expect(lifecycle.isRebalanceDebouncerCurrent(undefined)).to.be.false;
+			expect(lifecycle.isRebalanceDebouncerCurrent({})).to.be.false;
+			expect(lifecycle.isRebalanceDebouncerCurrent(fn)).to.be.true;
+			expect(lifecycle.isPruneDebouncerCurrent(fn)).to.be.true;
+			expect(lifecycle.isReplicationChangeDebouncerCurrent(fn)).to.be.true;
+		});
+
+		it("checked-prune currency requires identity, activity, and both captured identities", () => {
+			const host = createHost();
+			const lifecycle = createCurrentLifecycle(host);
+			const coordinator = host.checkedPrune;
+			const closeController = host.closeController;
+			expect(lifecycle.isCheckedPruneCurrent(coordinator, closeController)).to
+				.be.true;
+			expect(lifecycle.isCheckedPruneCurrent({}, closeController)).to.be.false;
+			expect(lifecycle.isCheckedPruneCurrent(coordinator, new AbortController()))
+				.to.be.false;
+			host.ownership!.abort();
+			expect(lifecycle.isCheckedPruneCurrent(coordinator, closeController)).to
+				.be.false;
+		});
+
+		it("terminal lane fences are exposed without being folded into isActive", () => {
+			const host = createHost();
+			const lifecycle = createCurrentLifecycle(host);
+			expect(lifecycle.areRangeMutationsClosing()).to.be.false;
+			expect(lifecycle.arePruneRemovesClosing()).to.be.false;
+			host.rangeMutationsClosing = true;
+			host.pruneRemovesClosing = true;
+			expect(lifecycle.areRangeMutationsClosing()).to.be.true;
+			expect(lifecycle.arePruneRemovesClosing()).to.be.true;
+			// Distinct admission errors depend on this NOT gating isActive.
+			expect(lifecycle.isActive()).to.be.true;
+		});
+
+		it("role sub-generation bumps and compares without touching identity", () => {
+			const host = createHost();
+			const lifecycle = createCurrentLifecycle(host);
+			expect(lifecycle.roleGeneration).to.equal(0);
+			expect(lifecycle.isRoleCurrent(0)).to.be.true;
+			expect(lifecycle.bumpRoleGeneration()).to.equal(1);
+			expect(lifecycle.isRoleCurrent(0)).to.be.false;
+			expect(lifecycle.isRoleCurrent(1)).to.be.true;
+			expect(lifecycle.isCurrent()).to.be.true;
+			expect(lifecycle.isActive()).to.be.true;
+		});
+
+		it("phase derives from the wrapped fences with poisoned > closed > terminating precedence", () => {
+			const host = createHost();
+			const lifecycle = createCurrentLifecycle(host);
+			expect(lifecycle.phase()).to.equal("opening");
+			lifecycle.markOpenComplete();
+			expect(lifecycle.phase()).to.equal("active");
+			// markOpenComplete is idempotent and does not resurrect later phases.
+			lifecycle.beginTerminal("close");
+			lifecycle.markOpenComplete();
+			expect(lifecycle.declaredPhase).to.equal("terminating");
+
+			// terminating: superseded identity or aborted/absent controller.
+			const staleHost = createHost();
+			const stale = createCurrentLifecycle(staleHost);
+			createCurrentLifecycle(staleHost);
+			expect(stale.phase()).to.equal("terminating");
+			const abortedHost = createHost();
+			const aborted = createCurrentLifecycle(abortedHost);
+			abortedHost.ownership!.abort();
+			expect(aborted.phase()).to.equal("terminating");
+
+			// closed beats terminating; poisoned beats both.
+			abortedHost.closed = true;
+			expect(aborted.phase()).to.equal("closed");
+			abortedHost.poison = new Error("poisoned");
+			expect(aborted.phase()).to.equal("poisoned");
+		});
+
+		it("declared transitions latch once", () => {
+			const host = createHost();
+			const lifecycle = createCurrentLifecycle(host);
+			lifecycle.beginTerminal("close");
+			lifecycle.beginTerminal("drop");
+			expect(lifecycle.terminalReason).to.equal("close");
+			expect(lifecycle.declaredPhase).to.equal("terminating");
+
+			const cause = new Error("first");
+			lifecycle.markPoisoned(cause);
+			lifecycle.markPoisoned(new Error("second"));
+			expect(lifecycle.poisonCause).to.equal(cause);
+			expect(lifecycle.declaredPhase).to.equal("poisoned");
+			// Terminal transitions after poison keep the poisoned declaration.
+			lifecycle.beginTerminal("internal-close");
+			expect(lifecycle.declaredPhase).to.equal("poisoned");
+		});
+	});
+
+	describe("integration", () => {
+		let session: TestSession;
+
+		afterEach(async () => {
+			await session?.stop();
+		});
+
+		it("reopen rotates the per-open lifecycle identity", async () => {
+			session = await TestSession.connected(1);
+			const db = await session.peers[0].open(new EventStore());
+			const log = db.log as any;
+			const first = log._instanceLifecycle as InstanceLifecycle;
+			expect(first).to.exist;
+			expect(first.isCurrent()).to.be.true;
+			expect(first.phase()).to.equal("active");
+
+			await db.close();
+			expect(first.isCurrent()).to.be.true;
+			expect(first.phase()).to.equal("closed");
+
+			const reopened = await session.peers[0].open(db);
+			const second = (reopened.log as any)
+				._instanceLifecycle as InstanceLifecycle;
+			expect(second).to.exist;
+			expect(second).to.not.equal(first);
+			expect(second.isCurrent()).to.be.true;
+			expect(second.phase()).to.equal("active");
+			expect(first.isCurrent()).to.be.false;
+			expect(first.phase()).to.equal("terminating");
+		});
+
+		it("stays predicate-equivalent with the live host before and after close", async () => {
+			session = await TestSession.connected(1);
+			const db = await session.peers[0].open(new EventStore());
+			const log = db.log as any;
+			const lifecycle = log._instanceLifecycle as InstanceLifecycle;
+			const controller = log._repairLifecycleController;
+			expect(log.isRepairLifecycleActive(controller)).to.be.true;
+			expect(lifecycle.isActiveFor(controller)).to.equal(
+				log.isRepairLifecycleActive(controller),
+			);
+			expect(lifecycle.isActive()).to.be.true;
+
+			await db.close();
+			expect(log.isRepairLifecycleActive(controller)).to.be.false;
+			expect(lifecycle.isActiveFor(controller)).to.equal(
+				log.isRepairLifecycleActive(controller),
+			);
+			expect(lifecycle.isActive()).to.be.false;
+		});
+
+		it("fixed replacement and full unreplication bump the role sub-generation; reopen resets it", async () => {
+			session = await TestSession.connected(1);
+			const db = await session.peers[0].open(new EventStore(), {
+				args: { replicate: { factor: 1 } },
+			});
+			const log = db.log as any;
+			const lifecycle = log._instanceLifecycle as InstanceLifecycle;
+			const initial = lifecycle.roleGeneration;
+			// Legacy accessor and the physically-moved field stay in lockstep.
+			expect(log._localReplicationRoleGeneration).to.equal(initial);
+
+			await db.log.replicate({ factor: 0.5 });
+			expect(lifecycle.roleGeneration).to.equal(initial + 1);
+			expect(log._localReplicationRoleGeneration).to.equal(initial + 1);
+
+			await db.log.unreplicate();
+			expect(lifecycle.roleGeneration).to.equal(initial + 2);
+
+			await db.close();
+			// An empty fixed role takes the no-bump path through open()'s
+			// role re-application (empty replacement, no unreplication, and no
+			// adaptive planner that could rebalance afterwards), so the fresh
+			// lifecycle's sub-generation is observable at its reset value.
+			const reopened = await session.peers[0].open(db, {
+				args: { replicate: [] },
+			});
+			const second = (reopened.log as any)
+				._instanceLifecycle as InstanceLifecycle;
+			expect(second).to.not.equal(lifecycle);
+			expect(second.roleGeneration).to.equal(0);
+			// The stale handle keeps its own sub-generation; it is not current.
+			expect(lifecycle.roleGeneration).to.equal(initial + 2);
+			expect(lifecycle.isCurrent()).to.be.false;
+		});
+
+		it("close on a deserialized never-opened clone resolves without a lifecycle", async () => {
+			session = await TestSession.connected(1);
+			const store = new EventStore();
+			const db = await session.peers[0].open(store);
+			const clone = deserialize(serialize(store), EventStore);
+			// borsh skips constructors: no lifecycle exists before open().
+			expect((clone.log as any)._instanceLifecycle).to.equal(undefined);
+			await clone.close();
+			expect((clone.log as any)._instanceLifecycle).to.equal(undefined);
+			await db.close();
+		});
+	});
+});

--- a/packages/programs/data/shared-log/test/peer-session.spec.ts
+++ b/packages/programs/data/shared-log/test/peer-session.spec.ts
@@ -1,0 +1,273 @@
+// Stage-2 lifecycle refactor guard: PeerSession instances ARE the opaque
+// subscription-epoch tokens, so this spec pins the identity semantics the
+// host relies on (rotation supersedes, null is a valid current value, the
+// open()-time map swap) and proves the registry's receive-admission
+// predicate is truth-table equivalent to a literal transcription of
+// SharedLog.isPeerReceiveAdmissionOpen over every input combination.
+import { expect } from "chai";
+import {
+	type PeerReceiveAdmissionOptions,
+	type PeerSessionDeps,
+	PeerSessionRegistry,
+} from "../src/peer-session.js";
+
+type StubHost = {
+	replicationLifecycleController?: AbortController;
+	terminating: boolean;
+	blockedPeers: Set<string>;
+	cleanupGateByPeer: Map<string, number>;
+};
+
+const createHost = (): StubHost => ({
+	replicationLifecycleController: new AbortController(),
+	terminating: false,
+	blockedPeers: new Set(),
+	cleanupGateByPeer: new Map(),
+});
+
+// Mirrors SharedLog.isReplicationLifecycleActive term for term.
+const isReplicationLifecycleActive = (
+	host: StubHost,
+	controller: AbortController | undefined,
+) =>
+	controller != null &&
+	controller === host.replicationLifecycleController &&
+	!controller.signal.aborted &&
+	!host.terminating;
+
+const createDeps = (host: StubHost): PeerSessionDeps => ({
+	isReplicationLifecycleActive: (controller) =>
+		isReplicationLifecycleActive(host, controller),
+	getReplicationLifecycleController: () => host.replicationLifecycleController,
+	isReplicationInfoBlocked: (hash) => host.blockedPeers.has(hash),
+	getReceiveCleanupGate: (hash) => host.cleanupGateByPeer.get(hash) ?? 0,
+});
+
+// Literal transcription of SharedLog.isPeerReceiveAdmissionOpen
+// (src/index.ts), reading the same host state the registry deps read.
+const legacyIsPeerReceiveAdmissionOpen = (
+	host: StubHost,
+	peerHash: string,
+	replicationLifecycleController: AbortController | undefined,
+	subscriptionEpoch: object | null,
+	currentEpoch: object | null,
+	options?: PeerReceiveAdmissionOptions,
+) =>
+	isReplicationLifecycleActive(host, replicationLifecycleController) &&
+	currentEpoch === subscriptionEpoch &&
+	(options?.allowReplicationInfoBlocked === true ||
+		!host.blockedPeers.has(peerHash)) &&
+	(options?.allowCleanupGate === true ||
+		(host.cleanupGateByPeer.get(peerHash) ?? 0) === 0);
+
+const PEER = "peer-a";
+
+describe("receive admission peer session parity", () => {
+	it("rotate supersedes the previous session with a fresh identity", () => {
+		const host = createHost();
+		const registry = new PeerSessionRegistry(createDeps(host));
+
+		const first = registry.rotate(PEER, "opening");
+		expect(first.kind).to.equal("opening");
+		expect(first.phase).to.equal("opening");
+		expect(first.isCurrent()).to.be.true;
+		expect(registry.current(PEER)).to.equal(first);
+
+		const second = registry.rotate(PEER, "departing");
+		expect(second).to.not.equal(first);
+		expect(second.kind).to.equal("departing");
+		expect(second.phase).to.equal("departing");
+		expect(second.isCurrent()).to.be.true;
+		expect(first.isCurrent()).to.be.false;
+		expect(first.phase).to.equal("superseded");
+		expect(registry.isCurrent(PEER, first)).to.be.false;
+		expect(registry.isCurrent(PEER, second)).to.be.true;
+	});
+
+	it("rotate captures the replication lifecycle controller live at rotation", () => {
+		const host = createHost();
+		const registry = new PeerSessionRegistry(createDeps(host));
+
+		const first = registry.rotate(PEER, "opening");
+		expect(first.replicationLifecycleController).to.equal(
+			host.replicationLifecycleController,
+		);
+		expect(first.isActive()).to.be.true;
+
+		const previousController = host.replicationLifecycleController;
+		host.replicationLifecycleController = new AbortController();
+		// Still current, but the captured controller lost the lifecycle: the
+		// A5+B1 pair fails exactly like today's paired checks.
+		expect(first.isCurrent()).to.be.true;
+		expect(first.isActive()).to.be.false;
+		expect(previousController).to.not.equal(
+			host.replicationLifecycleController,
+		);
+
+		const second = registry.rotate(PEER, "opening");
+		expect(second.replicationLifecycleController).to.equal(
+			host.replicationLifecycleController,
+		);
+		expect(second.isActive()).to.be.true;
+		expect(first.isActive()).to.be.false;
+	});
+
+	it("treats null as the valid current value for a pre-session peer", () => {
+		const host = createHost();
+		const registry = new PeerSessionRegistry(createDeps(host));
+
+		expect(registry.current(PEER)).to.equal(null);
+		expect(registry.isCurrent(PEER, null)).to.be.true;
+		expect(
+			registry.isReceiveAdmissionOpen(
+				PEER,
+				null,
+				host.replicationLifecycleController,
+			),
+		).to.be.true;
+
+		registry.rotate(PEER, "opening");
+		expect(registry.isCurrent(PEER, null)).to.be.false;
+		expect(
+			registry.isReceiveAdmissionOpen(
+				PEER,
+				null,
+				host.replicationLifecycleController,
+			),
+		).to.be.false;
+	});
+
+	it("matches the legacy receive-admission predicate over the full truth table", () => {
+		for (const lifecycleState of [
+			"active",
+			"aborted",
+			"replaced",
+			"terminating",
+			"undefined-controller",
+		] as const) {
+			for (const sessionState of ["current", "superseded", "null"] as const) {
+				for (const blocked of [false, true]) {
+					for (const gate of [0, 1]) {
+						for (const allowReplicationInfoBlocked of [
+							undefined,
+							true,
+						] as const) {
+							for (const allowCleanupGate of [undefined, true] as const) {
+								const host = createHost();
+								const registry = new PeerSessionRegistry(createDeps(host));
+
+								let session: ReturnType<typeof registry.rotate> | null = null;
+								if (sessionState === "current") {
+									session = registry.rotate(PEER, "opening");
+								} else if (sessionState === "superseded") {
+									session = registry.rotate(PEER, "opening");
+									registry.rotate(PEER, "opening");
+								}
+								const controller =
+									lifecycleState === "undefined-controller"
+										? undefined
+										: host.replicationLifecycleController;
+								if (lifecycleState === "aborted") {
+									host.replicationLifecycleController?.abort();
+								} else if (lifecycleState === "replaced") {
+									host.replicationLifecycleController = new AbortController();
+								} else if (lifecycleState === "terminating") {
+									host.terminating = true;
+								}
+								if (blocked) {
+									host.blockedPeers.add(PEER);
+								}
+								host.cleanupGateByPeer.set(PEER, gate);
+								const options: PeerReceiveAdmissionOptions = {
+									allowReplicationInfoBlocked,
+									allowCleanupGate,
+								};
+
+								const expected = legacyIsPeerReceiveAdmissionOpen(
+									host,
+									PEER,
+									controller,
+									session,
+									registry.current(PEER),
+									options,
+								);
+								const label = `lifecycle=${lifecycleState} session=${sessionState} blocked=${blocked} gate=${gate} allowBlocked=${allowReplicationInfoBlocked} allowGate=${allowCleanupGate}`;
+								expect(
+									registry.isReceiveAdmissionOpen(
+										PEER,
+										session,
+										controller,
+										options,
+									),
+									label,
+								).to.equal(expected);
+								if (sessionState !== "null") {
+									// The session-level convenience wrapper reads through the
+									// captured controller; parity only when that capture is the
+									// controller under test.
+									if (controller === session!.replicationLifecycleController) {
+										expect(
+											session!.isReceiveAdmissionOpen(options),
+											label,
+										).to.equal(expected);
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	});
+
+	it("resetForOpen replaces the map instance and demotes pre-reset sessions", () => {
+		const host = createHost();
+		const registry = new PeerSessionRegistry(createDeps(host));
+
+		const before = registry.rotate(PEER, "opening");
+		const mapBefore = registry._subscriptionEpochByPeer;
+		registry.resetForOpen();
+		expect(registry._subscriptionEpochByPeer).to.not.equal(mapBefore);
+		expect(registry.current(PEER)).to.equal(null);
+		expect(before.isCurrent()).to.be.false;
+		// Late continuations still resolve their captured token against the
+		// fresh map, mirroring today's open()-time map replacement.
+		expect(registry.isCurrent(PEER, before)).to.be.false;
+		expect(registry.isCurrent(PEER, null)).to.be.true;
+	});
+
+	it("markOpen is identity-guarded and only promotes opening sessions", () => {
+		const host = createHost();
+		const registry = new PeerSessionRegistry(createDeps(host));
+
+		const departing = registry.rotate(PEER, "departing");
+		registry.markOpen(PEER, departing);
+		expect(departing.phase).to.equal("departing");
+
+		const opening = registry.rotate(PEER, "opening");
+		registry.markOpen(PEER, {});
+		expect(opening.phase).to.equal("opening");
+		registry.markOpen(PEER, opening);
+		expect(opening.phase).to.equal("open");
+
+		const next = registry.rotate(PEER, "opening");
+		// Superseded token: no-op, and the superseded phase is terminal.
+		registry.markOpen(PEER, opening);
+		expect(opening.phase).to.equal("superseded");
+		expect(next.phase).to.equal("opening");
+	});
+
+	it("noteReplicatorRemoved marks only the current session", () => {
+		const host = createHost();
+		const registry = new PeerSessionRegistry(createDeps(host));
+
+		// No session: no-op, no throw.
+		registry.noteReplicatorRemoved(PEER);
+
+		const first = registry.rotate(PEER, "opening");
+		const second = registry.rotate(PEER, "departing");
+		registry.noteReplicatorRemoved(PEER);
+		expect(first.replicatorRemoved).to.be.false;
+		expect(second.replicatorRemoved).to.be.true;
+	});
+});

--- a/scripts/ci/check-fence-ratchet.mjs
+++ b/scripts/ci/check-fence-ratchet.mjs
@@ -29,7 +29,6 @@ const TARGETS = new Map([
 			"_repairLifecycleController",
 			"_replicationInfoReceiveEpochByPeer",
 			"_replicationLifecycleController",
-			"_subscriptionEpochByPeer",
 			"_subscriptionOpeningEpochByPeer",
 		],
 	],
@@ -40,6 +39,10 @@ const TARGETS = new Map([
 	[
 		"packages/programs/data/shared-log/src/native-write-through-block-store.ts",
 		["nativeBlockWriteGenerations", "nativeDeleteEpoch"],
+	],
+	[
+		"packages/programs/data/shared-log/src/peer-session.ts",
+		["_subscriptionEpochByPeer"],
 	],
 	[
 		"packages/programs/data/shared-log/src/join-warmup.ts",

--- a/scripts/ci/check-fence-ratchet.mjs
+++ b/scripts/ci/check-fence-ratchet.mjs
@@ -21,7 +21,7 @@ const TARGETS = new Map([
 		"packages/programs/data/shared-log/src/index.ts",
 		[
 			"_checkedPruneRemoveBlocksLocalRangeMutationAdmission",
-			"_localReplicationRoleGeneration",
+			"_instanceLifecycle",
 			"_nativeCoordinateMutationGenerations",
 			"_receiveCleanupGateByPeer",
 			"_receiveOwnershipMutationAdmissions",
@@ -32,6 +32,10 @@ const TARGETS = new Map([
 			"_subscriptionEpochByPeer",
 			"_subscriptionOpeningEpochByPeer",
 		],
+	],
+	[
+		"packages/programs/data/shared-log/src/instance-lifecycle.ts",
+		["roleGeneration"],
 	],
 	[
 		"packages/programs/data/shared-log/src/native-write-through-block-store.ts",


### PR DESCRIPTION
Stage 2 of the session/lifecycle refactor (stage 0 #1171, stage 1 #1172). The two identity objects the migration converges on now exist, **wrapping the existing fences with zero behavior change** — no fence is deleted; stage 3 migrates the eight documented multi-fence seams onto this API and deletes fences one at a time.

## InstanceLifecycle (`src/instance-lifecycle.ts`)

One object per `open()`. In stage 2 it physically owns only the role sub-generation (absorbing `_localReplicationRoleGeneration` behind byte-equivalent delegating accessors); everything else it reads through late-bound closures over the existing fences — `phase()` derives from them, so stored state can never drift into decisions. `declaredPhase`/`terminalReason`/`poisonCause` are write-only diagnostics (grep-verified: zero production reads) whose transitions are wired at open/close/drop/poison and soak in CI until stage 3 flips over. A truth-table unit spec proves its predicates equivalent to the legacy compound checks (`isRepairLifecycleActive` fold: controller identity + abort + poison + closed), including error type/message parity.

## PeerSession + PeerSessionRegistry (`src/peer-session.ts`)

One session per peer connection-epoch, **the session objects ARE the epoch tokens**: `_subscriptionEpochByPeer` physically moved into the registry with all three epoch helpers delegating, so the ~8 identity-compare sites (including tokens stored inside opening-capability values) work unchanged — verified site-by-site in review. Rotation kinds wired at exactly the three historical `advanceSubscriptionEpoch` call sites; `markOpen` at the reconnect-barrier tail (identity-guarded); `noteReplicatorRemoved` at the removal funnel's committed path, scoped by the funnel's own epoch option so a mid-removal reconnect never inherits the stamp. An exhaustive parity spec checks `isReceiveAdmissionOpen` against a literal transcription of the host predicate across 5 lifecycle states × 3 session states × blocked × gate × both allow flags.

## Validation

- 23-suite sweep (fresh worktree, Node 22): **528 tests passing, 0 failing** — includes 22 new truth-table/parity tests.
- Adversarial review (wrap-equivalence + new-object hazards): **zero confirmed defects**; all four equivalence lenses verified clean (byte-equivalent delegation, epoch identity semantics at all consumers, exact rotation wiring, write-only diagnostics). Four latent-hazard minors — all unreachable today — hardened in the final commit (never-opened getter, open()-window ordering, epoch-scoped removal stamp, markOpen guard).
- Fence ratchet: 19 fields across 8 files, all baselined (new TARGETS entries for both modules); shard coverage, lint, release security contracts all pass.

Next: stage 3 — seam collapse, migrating the eight multi-fence seams (`removeReplicator`'s quad-check, `onMessage`'s six captures, `isPeerReceiveAdmissionOpen`, the checked-prune triple, and four more) onto `lifecycle.phase()`/`session.isCurrent()`, deleting fences as their last consumers migrate.