### PR TITLE
refactor(shared-log): stage-3 PR-1 — delegate the proto-session predicates

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2027,19 +2027,12 @@ export class SharedLog<
 	// that yields before re-entering is still part of the same deadlock cycle.
 	// Remote/internal mutations bypass these public-operation admission checks.
 	private _checkedPruneRemovalCallbackInvocationDepth = 0;
-	// Explicit changes to the local replication role invalidate adaptive planners
-	// that were admitted under the previous role. The ownership lifecycle alone
-	// is insufficient because unreplicate() deliberately keeps the store open.
-	// Stage 2: physically owned by the per-open InstanceLifecycle (role
-	// sub-generation); these accessors keep every legacy site verbatim.
-	private get _localReplicationRoleGeneration(): number {
-		return this._instanceLifecycle?.roleGeneration ?? 0;
-	}
-	private set _localReplicationRoleGeneration(value: number) {
-		if (this._instanceLifecycle) {
-			this._instanceLifecycle.roleGeneration = value;
-		}
-	}
+	// The local replication role sub-generation lives on the per-open
+	// InstanceLifecycle (roleGeneration): explicit role changes invalidate
+	// adaptive planners admitted under the previous role, because the ownership
+	// lifecycle alone is insufficient — unreplicate() deliberately keeps the
+	// store open. Bumped via lifecycle.bumpRoleGeneration(), checked via
+	// lifecycle.isRoleCurrent(); the stage-2 accessor shim is gone.
 	// If durable post-state cannot be reconciled to every native/runtime mirror,
 	// reject later writers and planners until reopen rehydrates those mirrors.
 	private _replicationRangeMutationFailure?: unknown;
@@ -3325,9 +3318,9 @@ export class SharedLog<
 				this.isReplicationLifecycleActive(controller),
 			getSelfHash: () => this.node.identity.publicKey.hashcode(),
 			getUniqueReplicators: () => this.uniqueReplicators,
-			getSubscriptionEpoch: (peerHash) => this.getSubscriptionEpoch(peerHash),
-			isCurrentSubscriptionEpoch: (peerHash, epoch) =>
-				this.isCurrentSubscriptionEpoch(peerHash, epoch),
+			getPeerSession: (peerHash) => this._peerSessions.current(peerHash),
+			isPeerSessionCurrent: (peerHash, session) =>
+				this._peerSessions.isCurrent(peerHash, session),
 			resolvePublicKeyFromHash: (hash) => this._resolvePublicKeyFromHash(hash),
 			removeReplicator: (key, options) => this.removeReplicator(key, options),
 			getRpc: () => this.rpc,
@@ -4917,13 +4910,17 @@ export class SharedLog<
 			allowCleanupGate?: boolean;
 		},
 	) {
-		return (
-			this.isReplicationLifecycleActive(replicationLifecycleController) &&
-			this.isCurrentSubscriptionEpoch(peerHash, subscriptionEpoch) &&
-			(options?.allowReplicationInfoBlocked === true ||
-				!this._replicationInfoBlockedPeers.has(peerHash)) &&
-			(options?.allowCleanupGate === true ||
-				(this._receiveCleanupGateByPeer.get(peerHash) ?? 0) === 0)
+		// Stage 3: the registry owns the 4-term predicate (lifecycle -> epoch ->
+		// blocked -> gate, same short-circuit order); the registry deps are
+		// delegating closures back into this instance, so spies keep observing.
+		// The truth-table proof lives in test/peer-session.spec.ts against an
+		// inline transcription of the legacy predicate (NOT this method, which
+		// would be tautological now).
+		return this._peerSessions.isReceiveAdmissionOpen(
+			peerHash,
+			subscriptionEpoch,
+			replicationLifecycleController,
+			options,
 		);
 	}
 
@@ -5756,8 +5753,7 @@ export class SharedLog<
 			// entry-coordinate resolution or the ownership lane can yield, and
 			// prevent a new adaptive planner from starting while the fixed
 			// replacement is being committed.
-			this._localReplicationRoleGeneration =
-				(this._localReplicationRoleGeneration ?? 0) + 1;
+			this._instanceLifecycle?.bumpRoleGeneration();
 			this._isAdaptiveReplicating = false;
 		}
 		const entryRangeId = (entry: Entry<T>) =>
@@ -5878,8 +5874,7 @@ export class SharedLog<
 			// this operation waits for the ownership lane. Otherwise a planner
 			// that passed its preliminary role checks can enqueue a stale dynamic
 			// range after this full unreplication removes the previous role.
-			this._localReplicationRoleGeneration =
-				(this._localReplicationRoleGeneration ?? 0) + 1;
+			this._instanceLifecycle?.bumpRoleGeneration();
 			this._isReplicating = false;
 			this._isAdaptiveReplicating = false;
 			await this.removeReplicator(this.node.identity.publicKey, {
@@ -13750,9 +13745,8 @@ export class SharedLog<
 		// (ownership controller next, membership controller at
 		// resetSubscriptionChangeCallbackTracking below, _checkedPrune and
 		// _closeController and the debouncers in the setup blocks further
-		// down). The fresh object also supersedes the old per-open
-		// `_localReplicationRoleGeneration = 0` reset: roleGeneration starts
-		// at 0 on the incoming lifecycle.
+		// down). The fresh object is also the per-open role reset:
+		// roleGeneration starts at 0 on the incoming lifecycle.
 		this._instanceLifecycle = this.createInstanceLifecycle();
 		this.startRepairLifecycle();
 		this._replicationRangeMutationTail = Promise.resolve();
@@ -25636,15 +25630,21 @@ export class SharedLog<
 		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 		rebalanceParticipationDebounced = this.rebalanceParticipationDebounced,
 	) {
-		const localReplicationRoleGeneration =
-			this._localReplicationRoleGeneration ?? 0;
+		// Stage 3: the lifecycle owns all three identity terms. `lifecycle` may
+		// go stale later; its deps late-bind to the host, so the debouncer term
+		// still reads the current host field, and the role term can disagree
+		// with the current lifecycle's counter only after a rotation, where the
+		// isActiveFor term is already false (controller replaced in the same
+		// synchronous block).
+		const lifecycle = this._instanceLifecycle;
+		const capturedRoleGeneration = lifecycle?.roleGeneration ?? 0;
 		// update more participation rate to converge to the average expected rate or bounded by
 		// resources such as memory and or cpu
 		const isCurrent = () =>
-			this.isRepairLifecycleActive(ownershipLifecycleController) &&
-			this.rebalanceParticipationDebounced ===
-				rebalanceParticipationDebounced &&
-			this._localReplicationRoleGeneration === localReplicationRoleGeneration;
+			lifecycle != null &&
+			lifecycle.isActiveFor(ownershipLifecycleController) &&
+			lifecycle.isRebalanceDebouncerCurrent(rebalanceParticipationDebounced) &&
+			lifecycle.isRoleCurrent(capturedRoleGeneration);
 
 		const isClosedStoreRace = (error: any) => {
 			const message =

--- a/packages/programs/data/shared-log/src/instance-lifecycle.ts
+++ b/packages/programs/data/shared-log/src/instance-lifecycle.ts
@@ -49,8 +49,9 @@ export type InstanceLifecycleDeps = {
 };
 
 export class InstanceLifecycle {
-	// The ONLY state that physically moves in stage 2 (absorbs
-	// SharedLog._localReplicationRoleGeneration). Bumped by replicate()'s
+	// The ONLY state that physically moved in stage 2 (absorbed the former
+	// SharedLog._localReplicationRoleGeneration; the accessor shim was deleted
+	// in stage 3). Bumped by replicate()'s
 	// fixed-role replacement and by full unreplication WITHOUT rotating the
 	// lifecycle: unreplicate() deliberately keeps the store open, so admitted
 	// adaptive planners are invalidated by this sub-generation, not by

--- a/packages/programs/data/shared-log/src/replicator-liveness.ts
+++ b/packages/programs/data/shared-log/src/replicator-liveness.ts
@@ -8,6 +8,7 @@ import {
 } from "@peerbit/stream-interface";
 import { isNotStartedError } from "./errors.js";
 import type { TransportMessage } from "./message.js";
+import type { PeerSession } from "./peer-session.js";
 import { ReplicationPingMessage } from "./replication.js";
 
 const logger = loggerFn("peerbit:shared-log");
@@ -29,10 +30,12 @@ export type ReplicatorLivenessDeps = {
 	) => boolean;
 	getSelfHash: () => string;
 	getUniqueReplicators: () => Set<string>;
-	getSubscriptionEpoch: (peerHash: string) => object | null;
-	isCurrentSubscriptionEpoch: (
+	// Stage 3: probes capture the peer's PeerSession (the opaque
+	// subscription-epoch token) and check currency through the registry.
+	getPeerSession: (peerHash: string) => PeerSession | null;
+	isPeerSessionCurrent: (
 		peerHash: string,
-		epoch: object | null,
+		session: PeerSession | null,
 	) => boolean;
 	resolvePublicKeyFromHash: (
 		hash: string,
@@ -44,7 +47,7 @@ export type ReplicatorLivenessDeps = {
 			onRemoved?: (state: { wasReplicator: boolean }) => void;
 			replicationLifecycleController?: AbortController;
 			shouldRemove?: () => boolean;
-			subscriptionEpoch?: object | null;
+			subscriptionEpoch?: PeerSession | null;
 		},
 	) => Promise<boolean>;
 	getRpc: () => RPC<TransportMessage, TransportMessage>;
@@ -183,7 +186,7 @@ export class ReplicatorLivenessMonitor {
 		peerHash: string,
 		publicKey: PublicSignKey,
 		replicationLifecycleController: AbortController,
-		subscriptionEpoch: object | null,
+		subscriptionEpoch: PeerSession | null,
 		observedActivityAt: number | undefined,
 	) {
 		try {
@@ -203,7 +206,7 @@ export class ReplicatorLivenessMonitor {
 						!this.deps.isReplicationLifecycleActive(
 							replicationLifecycleController,
 						) ||
-						!this.deps.isCurrentSubscriptionEpoch(peerHash, subscriptionEpoch)
+						!this.deps.isPeerSessionCurrent(peerHash, subscriptionEpoch)
 					) {
 						return;
 					}
@@ -282,10 +285,10 @@ export class ReplicatorLivenessMonitor {
 		) {
 			return;
 		}
-		const subscriptionEpoch = this.deps.getSubscriptionEpoch(peerHash);
+		const subscriptionEpoch = this.deps.getPeerSession(peerHash);
 		const ownsProbe = () =>
 			this.deps.isReplicationLifecycleActive(replicationLifecycleController) &&
-			this.deps.isCurrentSubscriptionEpoch(peerHash, subscriptionEpoch);
+			this.deps.isPeerSessionCurrent(peerHash, subscriptionEpoch);
 		if (!this.deps.getUniqueReplicators().has(peerHash)) {
 			this._replicatorLivenessFailures.delete(peerHash);
 			return;

--- a/packages/programs/data/shared-log/test/instance-lifecycle.spec.ts
+++ b/packages/programs/data/shared-log/test/instance-lifecycle.spec.ts
@@ -357,12 +357,14 @@ describe("lifecycle instance identity", () => {
 			const log = db.log as any;
 			const lifecycle = log._instanceLifecycle as InstanceLifecycle;
 			const initial = lifecycle.roleGeneration;
-			// Legacy accessor and the physically-moved field stay in lockstep.
-			expect(log._localReplicationRoleGeneration).to.equal(initial);
+			// Stage 3 deleted the legacy _localReplicationRoleGeneration accessor
+			// shim: the lifecycle's counter is the only home, and isRoleCurrent
+			// pins the captured-generation comparison.
+			expect(lifecycle.isRoleCurrent(initial)).to.be.true;
 
 			await db.log.replicate({ factor: 0.5 });
 			expect(lifecycle.roleGeneration).to.equal(initial + 1);
-			expect(log._localReplicationRoleGeneration).to.equal(initial + 1);
+			expect(lifecycle.isRoleCurrent(initial)).to.be.false;
 
 			await db.log.unreplicate();
 			expect(lifecycle.roleGeneration).to.equal(initial + 2);

--- a/packages/programs/data/shared-log/test/peer-session.spec.ts
+++ b/packages/programs/data/shared-log/test/peer-session.spec.ts
@@ -1,9 +1,13 @@
-// Stage-2 lifecycle refactor guard: PeerSession instances ARE the opaque
+// Lifecycle refactor guard: PeerSession instances ARE the opaque
 // subscription-epoch tokens, so this spec pins the identity semantics the
 // host relies on (rotation supersedes, null is a valid current value, the
 // open()-time map swap) and proves the registry's receive-admission
-// predicate is truth-table equivalent to a literal transcription of
-// SharedLog.isPeerReceiveAdmissionOpen over every input combination.
+// predicate is truth-table equivalent to an INLINE transcription of the
+// legacy 4-term SharedLog.isPeerReceiveAdmissionOpen predicate over every
+// input combination. Since stage 3 the host method delegates to the
+// registry, so the legacy side here must stay this independent inline
+// replica (expected booleans computed in the test itself) — comparing
+// against the host method would be tautological and lose regression power.
 import { expect } from "chai";
 import {
 	type PeerReceiveAdmissionOptions,
@@ -43,8 +47,10 @@ const createDeps = (host: StubHost): PeerSessionDeps => ({
 	getReceiveCleanupGate: (hash) => host.cleanupGateByPeer.get(hash) ?? 0,
 });
 
-// Literal transcription of SharedLog.isPeerReceiveAdmissionOpen
-// (src/index.ts), reading the same host state the registry deps read.
+// Literal transcription of the legacy (pre-stage-3) body of
+// SharedLog.isPeerReceiveAdmissionOpen, reading the same host state the
+// registry deps read. Deliberately NOT the host method: that now delegates
+// to the registry, so this inline replica is the regression oracle.
 const legacyIsPeerReceiveAdmissionOpen = (
 	host: StubHost,
 	peerHash: string,


### PR DESCRIPTION
First of four stage-3 seam-collapse PRs (design in #1171/#1172/#1173). This is the first stage that changes code paths — three predicate seams migrate onto the stage-2 identity objects, chosen because their equivalence is pinned by the exhaustive parity/truth-table specs those objects shipped with. No fence fields deleted (the packaging plan defers deletions to PR-3/PR-4); the one removal here is the `_localReplicationRoleGeneration` accessor shim, whose consumers migrate onto `lifecycle.bumpRoleGeneration()`/`isRoleCurrent()`.

## Seams

- **Seam 3**: `isPeerReceiveAdmissionOpen`'s body delegates to `registry.isReceiveAdmissionOpen` — term-for-term identical (lifecycle → epoch → blocked → gate, same short-circuit, same `?? 0` and `=== true` semantics), with the lifecycle term still routing through the spy-visible host method. The parity spec's oracle was verified to be a genuine inline transcription (240-combination truth table), not the now-delegating host method — comments now pin that non-tautology requirement.
- **Seam 5**: replicator-liveness deps move from epoch-helper calls to session-based predicates (`getPeerSession`/`isPeerSessionCurrent`); captures retyped `PeerSession | null` with the host `removeReplicator` signature untouched. Host-routed probe/activity dispatch (sinon-spy visibility) unchanged.
- **Seam 6**: `rebalanceParticipation`'s compound `isCurrent` becomes `lifecycle.isActiveFor` + debouncer-identity + `lifecycle.isRoleCurrent`; both role-generation bump sites use the lifecycle; the accessor shim is deleted (zero remaining code references, verified repo-wide).

## Validation

- 21-suite sweep, 0 failing — now permanently including the `u32-simple replication degree` suite after yesterday's master flake (that failure was confirmed statistical: green on same-commit CI rerun and 2× locally; 132 vs 100±30 missed by 2).
- Chaos smoke green; adversarial review (seam-equivalence reconstruction from the pre-migration commit + blast-radius): **zero confirmed defects** across both lenses.
- Fence ratchet (19 fields/8 files), shard coverage, lint, contracts all pass.
- The implementing agent corrected two manifest errors rather than following them: the parity spec needed no re-point (already an independent oracle), and two test assertions reading the deleted shim via `(log as any)` were re-pointed onto `lifecycle.isRoleCurrent`.

Next: PR-2 delegates the ownership seams (the 400+-call-site helper family redefined onto `lifecycle.phase()`, bodies only), then PR-3 (onMessage session capture + first fence deletions, shipping the recovery-epoch pinning tests first), then PR-4 (state relocation).