### PR TITLE
refactor(shared-log): stage-3 PR-3 — session capture in onMessage, first fence deletions

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -193,7 +193,11 @@ import { JoinWarmupCoordinator } from "./join-warmup.js";
 import { LeaderPlanCache } from "./leader-plan-cache.js";
 import { TransportMessage } from "./message.js";
 import { NativeBackboneWriteThroughBlockStore } from "./native-write-through-block-store.js";
-import { type PeerSessionKind, PeerSessionRegistry } from "./peer-session.js";
+import {
+	type PeerSession,
+	type PeerSessionKind,
+	PeerSessionRegistry,
+} from "./peer-session.js";
 import { PIDReplicationController } from "./pid.js";
 import {
 	type EntryReplicated,
@@ -1968,7 +1972,10 @@ export class SharedLog<
 	private _activeReceiveHandlersByPeer!: Map<string, PeerReceiveLeaseState>;
 	private _receiveHandlerDrainByPeer!: Map<string, Set<Promise<void>>>;
 	private _receiveCleanupGateByPeer!: Map<string, number>;
-	private _subscriptionOpeningEpochByPeer!: Map<string, object>;
+	// One-shot capability adverts staged while a peer's opening barrier is
+	// running (window truth = the session's openingBarrierActive sub-state;
+	// the legacy _subscriptionOpeningEpochByPeer map is gone). `epoch` is the
+	// PeerSession the advert was staged under; promote/delete key off it.
 	private _openingSyncCapabilitiesByPeer!: Map<
 		string,
 		{ epoch: object; capabilities: number }
@@ -2046,10 +2053,11 @@ export class SharedLog<
 	// coordinator/debouncer identities via late-bound readers; stage 3 drains
 	// those fences into it one at a time.
 	private _instanceLifecycle?: InstanceLifecycle;
-	// Local receive generations fence replication-info handlers that were admitted
-	// before a liveness eviction but reach the per-peer apply lane after it. Unlike
-	// message timestamps, these tokens never compare clocks from different peers.
-	private _replicationInfoReceiveEpochByPeer!: Map<string, object>;
+	// The local receive generations that fence replication-info handlers
+	// across liveness evictions now live on the PeerSessionRegistry
+	// (_replicationInfoReceiveEpochByPeer moved file-to-file; see
+	// src/peer-session.ts): advanced via advanceReplicationInfoReceiveEpoch,
+	// cleared at _close via clearReceiveEpochsForClose.
 	// Receive-side ownership plans may span lower-log joins that invoke user code.
 	// Increment synchronously with leader-cache invalidation so the handler can
 	// detect whether its pre-join plan needs one fresh post-persist audit.
@@ -3417,13 +3425,11 @@ export class SharedLog<
 		this._replicationInfoBlockedPeers = new Set();
 		this._replicationInfoRequestByPeer = new Map();
 		this._replicationInfoApplyQueueByPeer = new Map();
-		this._replicationInfoReceiveEpochByPeer = new Map();
 		this._peerSessions = this.createPeerSessionRegistry();
 		this._pendingReplicatorLeaveByPeer = new Set();
 		this._activeReceiveHandlersByPeer = new Map();
 		this._receiveHandlerDrainByPeer = new Map();
 		this._receiveCleanupGateByPeer = new Map();
-		this._subscriptionOpeningEpochByPeer = new Map();
 		this._openingSyncCapabilitiesByPeer = new Map();
 		this._gidPeersHistory = new Map();
 		this._repairRetryTimers = new Set();
@@ -13849,17 +13855,17 @@ export class SharedLog<
 		// Terminal close/drop drains the previous lifecycle before another open can
 		// install fresh lanes and opaque per-subscription ownership tokens.
 		this._replicationInfoApplyQueueByPeer = new Map();
-		this._replicationInfoReceiveEpochByPeer = new Map();
 		// Deserialized instances never ran the constructor; create the session
 		// registry lazily on first open. Reopens keep the SAME registry so stale
 		// continuations observe resetForOpen()'s map swap via property lookup.
+		// resetForOpen also replaces the per-peer receive-epoch map, matching
+		// the legacy open()-time `_replicationInfoReceiveEpochByPeer = new Map()`.
 		this._peerSessions ??= this.createPeerSessionRegistry();
 		this._peerSessions.resetForOpen();
 		this._pendingReplicatorLeaveByPeer = new Set();
 		this._activeReceiveHandlersByPeer = new Map();
 		this._receiveHandlerDrainByPeer = new Map();
 		this._receiveCleanupGateByPeer = new Map();
-		this._subscriptionOpeningEpochByPeer = new Map();
 		this._openingSyncCapabilitiesByPeer = new Map();
 		this._repairRetryTimers = new Set();
 		this._recentRepairDispatch = new Map();
@@ -16430,11 +16436,10 @@ export class SharedLog<
 			this._pendingIHave?.clear();
 			this._pendingIHaveCallbacks?.clear();
 			this.latestReplicationInfoMessage?.clear();
-			this._replicationInfoReceiveEpochByPeer?.clear();
+			this._peerSessions?.clearReceiveEpochsForClose();
 			this._activeReceiveHandlersByPeer?.clear();
 			this._receiveHandlerDrainByPeer?.clear();
 			this._receiveCleanupGateByPeer?.clear();
-			this._subscriptionOpeningEpochByPeer?.clear();
 			this._openingSyncCapabilitiesByPeer?.clear();
 			this._gidPeersHistory?.clear();
 			this._peerSyncCapabilities?.clear();
@@ -16898,17 +16903,19 @@ export class SharedLog<
 			const receiveFromHash = context.from.hashcode();
 			const receiveReplicationLifecycleController =
 				this._replicationLifecycleController;
-			const receiveSubscriptionEpoch =
-				this.getSubscriptionEpoch(receiveFromHash);
+			// ONE session capture replaces the per-peer subscription-epoch and
+			// opening-window captures: the PeerSession IS the epoch token, and
+			// the opening-barrier window is its sub-state. `null` = the peer
+			// never subscribed (a valid current value, preserved exactly).
+			const receiveSession = this._peerSessions.current(receiveFromHash);
 			const isOpeningSubscriptionReceive =
-				this._subscriptionOpeningEpochByPeer.get(receiveFromHash) ===
-				receiveSubscriptionEpoch;
+				receiveSession?.openingBarrierActive === true;
 			const isOpeningCapabilityAdvertisement =
 				msg instanceof SyncCapabilitiesMessage && isOpeningSubscriptionReceive;
 			releasePeerReceiveLease = this.acquirePeerReceiveLease(
 				receiveFromHash,
 				receiveReplicationLifecycleController,
-				receiveSubscriptionEpoch,
+				receiveSession,
 				{
 					// The replication-info fence existed before receive leases and is
 					// intentionally narrower than the subscription itself. Keep admitting
@@ -16925,7 +16932,7 @@ export class SharedLog<
 			const receiveOwnershipLifecycleController =
 				this.captureReplicationOwnershipLifecycle();
 			const receiveReplicationInfoReceiveEpoch =
-				this.getReplicationInfoReceiveEpoch(receiveFromHash);
+				this._peerSessions.receiveEpoch(receiveFromHash);
 			if (msg instanceof ResponseRoleMessage) {
 				msg = msg.toReplicationInfoMessage(); // migration
 			}
@@ -18986,17 +18993,18 @@ export class SharedLog<
 				return;
 			} else if (msg instanceof SyncCapabilitiesMessage) {
 				if (!context.from.equals(this.node.identity.publicKey)) {
-					const openingEpoch =
-						this._subscriptionOpeningEpochByPeer.get(receiveFromHash);
+					// No await separates this from the capture above, so the captured
+					// window state is exact: the legacy re-read of the opening map here
+					// could never observe a different value.
 					if (
 						this._replicationInfoBlockedPeers.has(receiveFromHash) &&
-						openingEpoch === receiveSubscriptionEpoch
+						isOpeningSubscriptionReceive
 					) {
 						// A prior unsubscribe cleanup may still be ahead of this reconnect
 						// barrier. Stage the new generation's one-shot advertisement so that
 						// cleanup cannot erase it before the opening transition commits.
 						this._openingSyncCapabilitiesByPeer.set(receiveFromHash, {
-							epoch: openingEpoch,
+							epoch: receiveSession!,
 							capabilities: msg.capabilities,
 						});
 					} else {
@@ -19024,7 +19032,7 @@ export class SharedLog<
 					!this.isPeerReceiveAdmissionOpen(
 						receiveFromHash,
 						replicationLifecycleController,
-						receiveSubscriptionEpoch,
+						receiveSession,
 					)
 				) {
 					return;
@@ -19038,7 +19046,7 @@ export class SharedLog<
 						!this.isPeerReceiveAdmissionOpen(
 							receiveFromHash,
 							replicationLifecycleController,
-							receiveSubscriptionEpoch,
+							receiveSession,
 						) &&
 						isNotStartedError(error as Error)
 					) {
@@ -19050,7 +19058,7 @@ export class SharedLog<
 					!this.isPeerReceiveAdmissionOpen(
 						receiveFromHash,
 						replicationLifecycleController,
-						receiveSubscriptionEpoch,
+						receiveSession,
 					)
 				) {
 					return;
@@ -19076,7 +19084,7 @@ export class SharedLog<
 					!this.isPeerReceiveAdmissionOpen(
 						receiveFromHash,
 						replicationLifecycleController,
-						receiveSubscriptionEpoch,
+						receiveSession,
 					)
 				) {
 					return;
@@ -19127,11 +19135,17 @@ export class SharedLog<
 				// (and downstream `waitForReplicator()` timeouts) under timing-sensitive joins.
 				const from = context.from!;
 				const fromHash = from.hashcode();
+				// Pre-lane gate: lifecycle -> receive-epoch -> blocked, exactly the
+				// legacy order. isMembershipActiveFor is the unit-pinned fold of
+				// isReplicationLifecycleActive; isReceiveEpochCurrent is the
+				// relocated `===`-with-`?? null`. The DELIBERATE absence of a
+				// subscription-epoch term is preserved: the lease already validated
+				// it, and the in-lane recheck owns post-await staleness.
 				if (
-					!this.isReplicationLifecycleActive(
+					!this._instanceLifecycle!.isMembershipActiveFor(
 						receiveReplicationLifecycleController,
 					) ||
-					!this.isCurrentReplicationInfoReceiveEpoch(
+					!this._peerSessions.isReceiveEpochCurrent(
 						receiveFromHash,
 						receiveReplicationInfoReceiveEpoch,
 					) ||
@@ -19145,15 +19159,14 @@ export class SharedLog<
 				await this.withReplicationInfoApplyQueue(fromHash, async () => {
 					try {
 						// The peer may have unsubscribed after this message was queued.
+						// In-lane gate: lifecycle -> subscription-epoch -> receive-epoch
+						// -> blocked, term for term as before the session migration.
 						if (
-							!this.isReplicationLifecycleActive(
+							!this._instanceLifecycle!.isMembershipActiveFor(
 								receiveReplicationLifecycleController,
 							) ||
-							!this.isCurrentSubscriptionEpoch(
-								fromHash,
-								receiveSubscriptionEpoch,
-							) ||
-							!this.isCurrentReplicationInfoReceiveEpoch(
+							!this._peerSessions.isCurrent(fromHash, receiveSession) ||
+							!this._peerSessions.isReceiveEpochCurrent(
 								fromHash,
 								receiveReplicationInfoReceiveEpoch,
 							) ||
@@ -19214,11 +19227,13 @@ export class SharedLog<
 					return;
 				}
 				const fromHash = from.hashcode();
+				// Same pre-lane gate shape as Added/All above (and the same
+				// intentional absence of a subscription-epoch term).
 				if (
-					!this.isReplicationLifecycleActive(
+					!this._instanceLifecycle!.isMembershipActiveFor(
 						receiveReplicationLifecycleController,
 					) ||
-					!this.isCurrentReplicationInfoReceiveEpoch(
+					!this._peerSessions.isReceiveEpochCurrent(
 						receiveFromHash,
 						receiveReplicationInfoReceiveEpoch,
 					) ||
@@ -19231,14 +19246,11 @@ export class SharedLog<
 				releasePeerReceiveLease = undefined;
 				await this.withReplicationInfoApplyQueue(fromHash, async () => {
 					if (
-						!this.isReplicationLifecycleActive(
+						!this._instanceLifecycle!.isMembershipActiveFor(
 							receiveReplicationLifecycleController,
 						) ||
-						!this.isCurrentSubscriptionEpoch(
-							fromHash,
-							receiveSubscriptionEpoch,
-						) ||
-						!this.isCurrentReplicationInfoReceiveEpoch(
+						!this._peerSessions.isCurrent(fromHash, receiveSession) ||
+						!this._peerSessions.isReceiveEpochCurrent(
 							fromHash,
 							receiveReplicationInfoReceiveEpoch,
 						) ||
@@ -23894,26 +23906,24 @@ export class SharedLog<
 	}
 
 	private advanceReplicationInfoReceiveEpoch(peerHash: string): object {
-		const next = {};
-		this._replicationInfoReceiveEpochByPeer.set(peerHash, next);
-		return next;
+		return this._peerSessions.advanceReceiveEpoch(peerHash);
 	}
 
 	private getReplicationInfoReceiveEpoch(peerHash: string): object | null {
-		return this._replicationInfoReceiveEpochByPeer.get(peerHash) ?? null;
+		return this._peerSessions.receiveEpoch(peerHash);
 	}
 
 	private isCurrentReplicationInfoReceiveEpoch(
 		peerHash: string,
 		epoch: object | null,
 	): boolean {
-		return this.getReplicationInfoReceiveEpoch(peerHash) === epoch;
+		return this._peerSessions.isReceiveEpochCurrent(peerHash, epoch);
 	}
 
 	private advanceSubscriptionEpoch(
 		peerHash: string,
 		kind: PeerSessionKind = "opening",
-	): object {
+	): PeerSession {
 		return this._peerSessions.rotate(peerHash, kind);
 	}
 
@@ -24016,7 +24026,7 @@ export class SharedLog<
 		publicKey: PublicSignKey,
 		topics: string[],
 		subscribed: boolean,
-		subscriptionEpoch?: object,
+		subscriptionEpoch?: PeerSession,
 	) {
 		if (!topics.includes(this.topic)) {
 			return;
@@ -24050,10 +24060,11 @@ export class SharedLog<
 			) {
 				this._openingSyncCapabilitiesByPeer.delete(peerHash);
 			}
-			this._subscriptionOpeningEpochByPeer.set(
-				peerHash,
-				expectedSubscriptionEpoch,
-			);
+			// Open the barrier WINDOW on the session (legacy: opening-epoch map
+			// set). Same synchronous window as the ownsSubscriptionEpoch() check
+			// above, so the flagged session is the current one — the invariant
+			// every reader's captured-session check relies on.
+			expectedSubscriptionEpoch.beginOpeningBarrier();
 			// Fence new messages immediately, drain handlers admitted by the previous
 			// subscription, then wait behind every queued replication mutation. A
 			// reconnect must not inherit metadata or ranges from the old connection.
@@ -24089,16 +24100,19 @@ export class SharedLog<
 				) {
 					this._openingSyncCapabilitiesByPeer.delete(peerHash);
 				}
-				if (
-					this._subscriptionOpeningEpochByPeer.get(peerHash) ===
-					expectedSubscriptionEpoch
-				) {
-					this._subscriptionOpeningEpochByPeer.delete(peerHash);
-				}
+				// Close the barrier window on every settle path, INCLUDING a
+				// barrier throw (legacy: identity-guarded map delete). The legacy
+				// guard only prevented deleting a newer session's entry; the
+				// per-session flag cannot collide, so the clear is unconditional.
+				expectedSubscriptionEpoch.finishOpeningBarrier();
 			}
 		}
 		if (!subscribed) {
-			this._subscriptionOpeningEpochByPeer.delete(peerHash);
+			// Legacy code also deleted the opening-epoch map entry here. The
+			// per-session equivalent is a no-op: any still-open barrier window
+			// belongs to an opening session this departing rotation already
+			// superseded — readers key off the CURRENT session, so that flag is
+			// unreachable, and its own barrier `finally` still clears it.
 			this._openingSyncCapabilitiesByPeer.delete(peerHash);
 			this._replicationInfoBlockedPeers.add(peerHash);
 			const disconnectedJoinWarmupGeneration =

--- a/packages/programs/data/shared-log/src/peer-session.ts
+++ b/packages/programs/data/shared-log/src/peer-session.ts
@@ -43,6 +43,18 @@ export class PeerSession {
 	// Diagnostics only in stage 2: the destructive removal funnel observed a
 	// committed replicator removal under this connection-epoch.
 	replicatorRemoved = false;
+	// Reconnect-barrier WINDOW sub-state (stage-3 home of the legacy
+	// _subscriptionOpeningEpochByPeer map entry, whose value was always this
+	// session). True exactly while the barrier window is open: set when
+	// handleSubscriptionChange starts the opening barrier (same synchronous
+	// window as the rotation that made this session current), cleared in the
+	// barrier's `finally` — including the barrier-throw path — where the map
+	// entry used to be deleted. Deliberately NOT derived from
+	// `phase === "opening"`: phase is "opening" from rotate() — BEFORE the
+	// barrier starts — and stays "opening" forever if the barrier throws
+	// (markOpen never runs), which would wrongly keep granting the opening
+	// lease bypasses that today's window drops.
+	openingBarrierActive = false;
 	readonly createdAt = Date.now(); // diagnostics only
 
 	constructor(
@@ -60,6 +72,21 @@ export class PeerSession {
 	/** ≡ SharedLog.isCurrentSubscriptionEpoch(this.peerHash, this). */
 	isCurrent(): boolean {
 		return this.registry.current(this.peerHash) === this;
+	}
+
+	/** Barrier window opens — ≡ the legacy
+	 *  `_subscriptionOpeningEpochByPeer.set(peerHash, thisSession)`. */
+	beginOpeningBarrier(): void {
+		this.openingBarrierActive = true;
+	}
+
+	/** Barrier window closes — ≡ the legacy identity-guarded
+	 *  `_subscriptionOpeningEpochByPeer.delete(peerHash)`. Unconditional:
+	 *  the map guard only avoided clobbering a NEWER peer-keyed entry, and
+	 *  per-session flags cannot collide (a newer barrier flags its own,
+	 *  already-rotated session). */
+	finishOpeningBarrier(): void {
+		this.openingBarrierActive = false;
 	}
 
 	/** ≡ ownsReplicationLifecycle() && ownsSubscriptionEpoch() with both
@@ -92,19 +119,59 @@ export class PeerSessionRegistry {
 	// The values ARE the epoch tokens. Stage 3 renames this to `sessions`
 	// once the last raw-token comparison in index.ts is gone.
 	_subscriptionEpochByPeer!: Map<string, PeerSession>;
+	// Moved from SharedLog (fence B2, same name — the sanctioned file-to-file
+	// ratchet move). Local receive generations fence replication-info handlers
+	// that were admitted before a liveness eviction but reach the per-peer
+	// apply lane after it. Per-PEER, not per-session, on purpose: the token
+	// advances at removeReplicator, where the session does NOT rotate (the
+	// peer stays subscribed), and it must also fence a peer that never had a
+	// session. Unlike sessions this map IS cleared at _close (see
+	// clearReceiveEpochsForClose) and replaced at open.
+	_replicationInfoReceiveEpochByPeer!: Map<string, object>;
 
 	constructor(readonly deps: PeerSessionDeps) {
 		this.resetForOpen();
 	}
 
-	/** open()-time re-init: REPLACE the map instance, matching today's
-	 *  `this._subscriptionEpochByPeer = new Map()` (index.ts ctor / open).
-	 *  The map is intentionally NOT cleared at _close — tokens must stay
-	 *  current across close so a late continuation's epoch check resolves
+	/** open()-time re-init: REPLACE the map instances, matching today's
+	 *  `= new Map()` re-inits (index.ts ctor / open).
+	 *  The session map is intentionally NOT cleared at _close — tokens must
+	 *  stay current across close so a late continuation's epoch check resolves
 	 *  exactly as it does today (close-safety comes from the paired
-	 *  lifecycle-controller check, not the epoch). There is NO clearForClose(). */
+	 *  lifecycle-controller check, not the epoch). There is NO clearForClose()
+	 *  for sessions; the receive-epoch map, by contrast, IS cleared at close. */
 	resetForOpen(): void {
 		this._subscriptionEpochByPeer = new Map();
+		this._replicationInfoReceiveEpochByPeer = new Map();
+	}
+
+	/** _close counterpart of the legacy
+	 *  `this._replicationInfoReceiveEpochByPeer?.clear()`: a receive-epoch
+	 *  capture held across close must compare against null, never against a
+	 *  surviving token. Sessions deliberately survive close (see
+	 *  resetForOpen); the paired membership-lifecycle term at every
+	 *  receive-epoch check site makes the ordering unobservable either way. */
+	clearReceiveEpochsForClose(): void {
+		this._replicationInfoReceiveEpochByPeer.clear();
+	}
+
+	/** ≡ legacy SharedLog.advanceReplicationInfoReceiveEpoch. Advances
+	 *  WITHOUT rotating the session — the recovery fence must survive
+	 *  removeReplicator, where the peer stays subscribed. */
+	advanceReceiveEpoch(peerHash: string): object {
+		const next = {};
+		this._replicationInfoReceiveEpochByPeer.set(peerHash, next);
+		return next;
+	}
+
+	/** ≡ legacy SharedLog.getReplicationInfoReceiveEpoch (`?? null`). */
+	receiveEpoch(peerHash: string): object | null {
+		return this._replicationInfoReceiveEpochByPeer.get(peerHash) ?? null;
+	}
+
+	/** ≡ legacy SharedLog.isCurrentReplicationInfoReceiveEpoch. */
+	isReceiveEpochCurrent(peerHash: string, epoch: object | null): boolean {
+		return this.receiveEpoch(peerHash) === epoch;
 	}
 
 	current(peerHash: string): PeerSession | null {

--- a/packages/programs/data/shared-log/test/peer-session.spec.ts
+++ b/packages/programs/data/shared-log/test/peer-session.spec.ts
@@ -276,4 +276,43 @@ describe("receive admission peer session parity", () => {
 		expect(first.replicatorRemoved).to.be.false;
 		expect(second.replicatorRemoved).to.be.true;
 	});
+
+	it("advances the receive recovery epoch per peer, independent of sessions", () => {
+		const host = createHost();
+		const registry = new PeerSessionRegistry(createDeps(host));
+
+		// Legacy map semantics: no advance yet -> current epoch is null, and a
+		// null capture is current — including for a peer with no session.
+		expect(registry.receiveEpoch(PEER)).to.equal(null);
+		expect(registry.isReceiveEpochCurrent(PEER, null)).to.be.true;
+
+		// Advancing works for a session-less peer (removeReplicator can fence a
+		// peer that never subscribed) and fences the null capture.
+		const first = registry.advanceReceiveEpoch(PEER);
+		expect(registry.isReceiveEpochCurrent(PEER, first)).to.be.true;
+		expect(registry.isReceiveEpochCurrent(PEER, null)).to.be.false;
+
+		// Session rotation does NOT rotate the receive epoch (the fence's whole
+		// point: removeReplicator advances it while the peer stays subscribed)…
+		registry.rotate(PEER, "opening");
+		expect(registry.isReceiveEpochCurrent(PEER, first)).to.be.true;
+
+		// …and the advance does not rotate the session.
+		const session = registry.current(PEER);
+		const second = registry.advanceReceiveEpoch(PEER);
+		expect(registry.isReceiveEpochCurrent(PEER, first)).to.be.false;
+		expect(registry.isReceiveEpochCurrent(PEER, second)).to.be.true;
+		expect(registry.current(PEER)).to.equal(session);
+
+		// _close clears receive epochs (captures compare against null) while
+		// sessions deliberately survive; open() replaces the map instance.
+		registry.clearReceiveEpochsForClose();
+		expect(registry.isReceiveEpochCurrent(PEER, second)).to.be.false;
+		expect(registry.isReceiveEpochCurrent(PEER, null)).to.be.true;
+		expect(registry.current(PEER)).to.equal(session);
+		const third = registry.advanceReceiveEpoch(PEER);
+		registry.resetForOpen();
+		expect(registry.isReceiveEpochCurrent(PEER, third)).to.be.false;
+		expect(registry.isReceiveEpochCurrent(PEER, null)).to.be.true;
+	});
 });

--- a/packages/programs/data/shared-log/test/receive-admission-pins.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission-pins.spec.ts
@@ -14,8 +14,11 @@
 //    stash capability adverts, and a barrier superseded mid-drain must not
 //    promote what it stashed.
 //
-// Both tests pass against current behavior and must keep passing, unchanged,
-// after the seam-2 migration.
+// Both tests were written (and passed) against the pre-migration fences; the
+// behavioral assertions are unchanged after the seam-2 migration — only the
+// internal window probes were re-pointed to the fences' stage-3 homes (the
+// receive-epoch map on the PeerSessionRegistry, the opening-barrier flag on
+// the PeerSession).
 import { TestSession } from "@peerbit/test-utils";
 import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
@@ -311,9 +314,10 @@ describe("receive admission opening-barrier windows", () => {
 					expect(sharedLog._receiveHandlerDrainByPeer.has(sourceHash)).to.be
 						.true,
 				);
-				const barrierEpoch =
-					sharedLog._subscriptionOpeningEpochByPeer.get(sourceHash);
-				expect(barrierEpoch).to.exist;
+				// Window-open probe (stage-3 home: the barrier flags its session).
+				const barrierSession = sharedLog._peerSessions.current(sourceHash);
+				expect(barrierSession).to.exist;
+				expect(barrierSession.openingBarrierActive).to.be.true;
 
 				// An advert arriving inside the barrier window is stashed for the
 				// opening generation, not applied.
@@ -340,8 +344,7 @@ describe("receive admission opening-barrier windows", () => {
 				expect(sharedLog._peerSyncCapabilities.has(sourceHash)).to.be.false;
 				expect(sharedLog._openingSyncCapabilitiesByPeer.has(sourceHash)).to.be
 					.false;
-				expect(sharedLog._subscriptionOpeningEpochByPeer.has(sourceHash)).to.be
-					.false;
+				expect(barrierSession.openingBarrierActive).to.be.false;
 			} finally {
 				releasePark.resolve();
 				await Promise.allSettled(

--- a/packages/programs/data/shared-log/test/receive-admission-pins.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission-pins.spec.ts
@@ -1,0 +1,360 @@
+// Stage-3 PR-3 pinning tests. These pin the two receive-path behaviors most
+// likely to break subtly when the D1/D2 fences migrate onto the peer-session
+// registry (stage-3 manifest, PART 5):
+//
+// 1. The replication-info RECOVERY EPOCH (`_replicationInfoReceiveEpochByPeer`)
+//    is the ONLY fence stopping a handler that released its receive lease
+//    before a committed removeReplicator from resurrecting the evicted
+//    replicator when it reaches the apply lane — the peer session does NOT
+//    rotate at removal (the peer stays subscribed).
+//
+// 2. The OPENING-BARRIER truth (`_subscriptionOpeningEpochByPeer`) is a
+//    WINDOW (barrier start -> settle/unsubscribe), not a phase: a session
+//    already rotated to "opening" whose barrier has not started must not
+//    stash capability adverts, and a barrier superseded mid-drain must not
+//    promote what it stashed.
+//
+// Both tests pass against current behavior and must keep passing, unchanged,
+// after the seam-2 migration.
+import { TestSession } from "@peerbit/test-utils";
+import { waitForResolved } from "@peerbit/time";
+import { expect } from "chai";
+import pDefer from "p-defer";
+import sinon from "sinon";
+import { SyncCapabilitiesMessage } from "../src/exchange-heads.js";
+import { createReplicationDomainHash } from "../src/replication-domain-hash.js";
+import { AddedReplicationSegmentMessage } from "../src/replication.js";
+import { RequestMaybeSync, SimpleSyncronizer } from "../src/sync/simple.js";
+import { EventStore } from "./utils/stores/event-store.js";
+
+const setup = {
+	domain: createReplicationDomainHash("u32"),
+	type: "u32" as const,
+	syncronizer: SimpleSyncronizer,
+	name: "u32-simple-receive-admission-pins",
+};
+
+describe("receive admission replication-info recovery epoch", () => {
+	it("fences a handler parked before its apply-lane turn across a committed liveness eviction", async () => {
+		const session = await TestSession.connected(2);
+		const handlerParked = pDefer<void>();
+		const releaseHandler = pDefer<void>();
+		try {
+			const store = new EventStore<string, any>();
+			const target = await session.peers[0].open(store, {
+				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+			});
+			await session.peers[1].open(store.clone(), {
+				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+			});
+			const sharedLog = target.log as any;
+			const sourceKey = session.peers[1].identity.publicKey;
+			const sourceHash = sourceKey.hashcode();
+			let remoteRange: any;
+			await waitForResolved(async () => {
+				const ranges = await target.log.replicationIndex
+					.iterate({ query: { hash: sourceHash } })
+					.all();
+				expect(ranges).to.have.length.greaterThan(0);
+				remoteRange = ranges[0].value;
+			});
+
+			// A committed removal schedules fresh replication-info requests to the
+			// still-subscribed peer; a genuine re-learn through those would mask
+			// what this test pins, so keep them from firing.
+			const scheduleRequests = sinon
+				.stub(sharedLog, "scheduleReplicationInfoRequests")
+				.callsFake(() => {});
+
+			const delayedMessage = new AddedReplicationSegmentMessage({
+				segments: [remoteRange.toReplicationRange()],
+			});
+			// Arm inside the synchronizer pass for exactly this message: from the
+			// synchronizer's decline to the apply-queue call the handler runs
+			// synchronously, so the next apply-queue call for this peer is its own.
+			let armed = false;
+			const originalSynchronizerOnMessage =
+				sharedLog.syncronizer.onMessage.bind(sharedLog.syncronizer);
+			const synchronizer = sinon
+				.stub(sharedLog.syncronizer, "onMessage")
+				.callsFake(async (message: unknown, context: unknown) => {
+					if (message === delayedMessage) {
+						armed = true;
+						return false;
+					}
+					return originalSynchronizerOnMessage(message, context);
+				});
+			// Park the handler BETWEEN its receive-lease release and its
+			// apply-lane turn: it is no longer drainable, but has not entered the
+			// lane. Only the receive-epoch fence can stop it now.
+			const originalApplyQueue =
+				sharedLog.withReplicationInfoApplyQueue.bind(sharedLog);
+			const applyQueue = sinon
+				.stub(sharedLog, "withReplicationInfoApplyQueue")
+				.callsFake(async (...args: unknown[]) => {
+					const [peerHash, fn] = args as [string, () => Promise<void>];
+					if (armed && peerHash === sourceHash) {
+						armed = false;
+						handlerParked.resolve();
+						await releaseHandler.promise;
+					}
+					return originalApplyQueue(peerHash, fn);
+				});
+
+			let joins = 0;
+			const onJoin = () => {
+				joins += 1;
+			};
+
+			try {
+				const receive = target.log.onMessage(delayedMessage, {
+					from: sourceKey,
+					message: { header: { timestamp: BigInt(Date.now()) } },
+				} as any);
+				await handlerParked.promise;
+
+				// Drive a liveness eviction through to a committed removeReplicator,
+				// exactly as the liveness monitor does it (the session does NOT
+				// rotate: the peer is still subscribed).
+				const liveness = sharedLog._liveness;
+				await liveness.evictReplicatorFromLiveness(
+					sourceHash,
+					sourceKey,
+					sharedLog._replicationLifecycleController,
+					sharedLog._peerSessions.current(sourceHash),
+					liveness._replicatorLastActivityAt.get(sourceHash),
+				);
+
+				// The eviction committed: ranges deleted, recovery epoch advanced,
+				// ordering watermark reset.
+				expect(
+					await target.log.replicationIndex.count({
+						query: { hash: sourceHash },
+					}),
+				).to.equal(0);
+				expect(
+					sharedLog.getReplicationInfoReceiveEpoch(sourceHash),
+				).to.not.equal(null);
+				expect(sharedLog.latestReplicationInfoMessage.has(sourceHash)).to.be
+					.false;
+
+				target.log.events.addEventListener("replicator:join", onJoin);
+				releaseHandler.resolve();
+				await receive;
+
+				// The parked handler reached its lane after the committed removal:
+				// it must not restore the range, must not re-fire replicator:join,
+				// and must not write a fresh ordering watermark.
+				expect(
+					await target.log.replicationIndex.count({
+						query: { hash: sourceHash },
+					}),
+				).to.equal(0);
+				expect(target.log.uniqueReplicators.has(sourceHash)).to.be.false;
+				expect(sharedLog.latestReplicationInfoMessage.has(sourceHash)).to.be
+					.false;
+				expect(joins).to.equal(0);
+			} finally {
+				target.log.events.removeEventListener("replicator:join", onJoin);
+				releaseHandler.resolve();
+				applyQueue.restore();
+				synchronizer.restore();
+				scheduleRequests.restore();
+			}
+		} finally {
+			releaseHandler.resolve();
+			await session.stop();
+		}
+	});
+
+	it("keeps a pre-close recovery-epoch capture stale after reopen", async () => {
+		const session = await TestSession.disconnected(1);
+		try {
+			const db = await session.peers[0].open(new EventStore<string, any>(), {
+				args: { replicate: false, setup },
+			});
+			const sharedLog = db.log as any;
+			const peerHash = "remote-peer-recovery-epoch";
+
+			const captured = sharedLog.advanceReplicationInfoReceiveEpoch(peerHash);
+			expect(
+				sharedLog.isCurrentReplicationInfoReceiveEpoch(peerHash, captured),
+			).to.be.true;
+
+			await db.close();
+			// The epoch map is cleared at close: a capture held across close
+			// compares against null, never against a surviving token.
+			expect(
+				sharedLog.isCurrentReplicationInfoReceiveEpoch(peerHash, captured),
+			).to.be.false;
+
+			await session.peers[0].open(db, {
+				args: { replicate: false, setup },
+			});
+			// After reopen the pre-close capture must still fail the current-check:
+			// close()+open() is a hard fence for every outstanding capture.
+			expect(
+				sharedLog.isCurrentReplicationInfoReceiveEpoch(peerHash, captured),
+			).to.be.false;
+
+			// Sanity: the reopened instance issues fresh, current tokens.
+			const fresh = sharedLog.advanceReplicationInfoReceiveEpoch(peerHash);
+			expect(sharedLog.isCurrentReplicationInfoReceiveEpoch(peerHash, fresh)).to
+				.be.true;
+			expect(fresh).to.not.equal(captured);
+		} finally {
+			await session.stop();
+		}
+	});
+});
+
+describe("receive admission opening-barrier windows", () => {
+	it("does not stash a capability advert before the reconnect barrier starts", async () => {
+		const session = await TestSession.disconnected(2);
+		try {
+			const store = new EventStore<string, any>();
+			const source = await session.peers[0].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const sharedLog = target.log as any;
+			const sourceKey = source.node.identity.publicKey;
+			const sourceHash = sourceKey.hashcode();
+
+			// The opening-barrier truth is a WINDOW (map entry set at barrier
+			// start), not a phase: rotate a session to "opening" WITHOUT starting
+			// its barrier.
+			sharedLog.advanceSubscriptionEpoch(sourceHash, "opening");
+
+			// An advert arriving now takes the plain path: applied directly, never
+			// staged in the opening stash.
+			await target.log.onMessage(
+				new SyncCapabilitiesMessage({ capabilities: 3 }),
+				{ from: sourceKey } as any,
+			);
+			expect(sharedLog._openingSyncCapabilitiesByPeer.has(sourceHash)).to.be
+				.false;
+			expect(sharedLog._peerSyncCapabilities.get(sourceHash)).to.equal(3);
+
+			// With the peer replication-info-blocked but still no barrier window,
+			// the advert is not admitted at all — the pre-barrier "opening" phase
+			// must not widen admission or stage the advert.
+			sharedLog._replicationInfoBlockedPeers.add(sourceHash);
+			try {
+				await target.log.onMessage(
+					new SyncCapabilitiesMessage({ capabilities: 5 }),
+					{ from: sourceKey } as any,
+				);
+				expect(sharedLog._openingSyncCapabilitiesByPeer.has(sourceHash)).to.be
+					.false;
+				expect(sharedLog._peerSyncCapabilities.get(sourceHash)).to.equal(3);
+			} finally {
+				sharedLog._replicationInfoBlockedPeers.delete(sourceHash);
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("does not promote a stashed advert when the reconnect barrier aborts mid-drain", async () => {
+		const session = await TestSession.disconnected(2);
+		const parkEntered = pDefer<void>();
+		const releasePark = pDefer<void>();
+		let oldReceive: Promise<void> | undefined;
+		let subscription: Promise<void> | undefined;
+		try {
+			const store = new EventStore<string, any>();
+			const source = await session.peers[0].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const sharedLog = target.log as any;
+			const sourceKey = source.node.identity.publicKey;
+			const sourceHash = sourceKey.hashcode();
+			const scheduleRequests = sinon
+				.stub(sharedLog, "scheduleReplicationInfoRequests")
+				.callsFake(() => {});
+			const parkMessage = new RequestMaybeSync({ hashes: [] });
+			const originalSynchronizerOnMessage =
+				sharedLog.syncronizer.onMessage.bind(sharedLog.syncronizer);
+			const synchronizer = sinon
+				.stub(sharedLog.syncronizer, "onMessage")
+				.callsFake(async (message: unknown, context: unknown) => {
+					if (message === parkMessage) {
+						parkEntered.resolve();
+						await releasePark.promise;
+						return true;
+					}
+					return originalSynchronizerOnMessage(message, context);
+				});
+
+			try {
+				// Hold an admitted receive so the reconnect barrier parks mid-drain.
+				oldReceive = target.log.onMessage(parkMessage, {
+					from: sourceKey,
+				} as any);
+				await parkEntered.promise;
+
+				let subscriptionSettled = false;
+				subscription = sharedLog
+					._onSubscription({
+						detail: { from: sourceKey, topics: [target.log.topic] },
+					})
+					.then(() => {
+						subscriptionSettled = true;
+					});
+				await waitForResolved(() =>
+					expect(sharedLog._receiveHandlerDrainByPeer.has(sourceHash)).to.be
+						.true,
+				);
+				const barrierEpoch =
+					sharedLog._subscriptionOpeningEpochByPeer.get(sourceHash);
+				expect(barrierEpoch).to.exist;
+
+				// An advert arriving inside the barrier window is stashed for the
+				// opening generation, not applied.
+				await target.log.onMessage(
+					new SyncCapabilitiesMessage({ capabilities: 3 }),
+					{ from: sourceKey } as any,
+				);
+				expect(
+					sharedLog._openingSyncCapabilitiesByPeer.get(sourceHash)
+						?.capabilities,
+				).to.equal(3);
+				expect(sharedLog._peerSyncCapabilities.has(sourceHash)).to.be.false;
+
+				// Abort the barrier mid-drain: a newer rotation supersedes its
+				// subscription epoch before the drain settles.
+				sharedLog.advanceSubscriptionEpoch(sourceHash, "departing");
+				expect(subscriptionSettled).to.be.false;
+
+				releasePark.resolve();
+				await Promise.all([oldReceive, subscription]);
+
+				// The aborted barrier must not promote the stashed advert, and the
+				// window state must be fully torn down.
+				expect(sharedLog._peerSyncCapabilities.has(sourceHash)).to.be.false;
+				expect(sharedLog._openingSyncCapabilitiesByPeer.has(sourceHash)).to.be
+					.false;
+				expect(sharedLog._subscriptionOpeningEpochByPeer.has(sourceHash)).to.be
+					.false;
+			} finally {
+				releasePark.resolve();
+				await Promise.allSettled(
+					[oldReceive, subscription].filter(
+						(value): value is Promise<void> => value != null,
+					),
+				);
+				synchronizer.restore();
+				scheduleRequests.restore();
+			}
+		} finally {
+			releasePark.resolve();
+			await session.stop();
+		}
+	});
+});

--- a/packages/programs/data/shared-log/test/receive-admission.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission.spec.ts
@@ -144,8 +144,9 @@ describe("receive admission", () => {
 				await subscription;
 
 				expect(sharedLog._peerSyncCapabilities.get(sourceHash)).to.equal(1);
-				expect(sharedLog._subscriptionOpeningEpochByPeer.has(sourceHash)).to.be
-					.false;
+				expect(
+					sharedLog._peerSessions.current(sourceHash)?.openingBarrierActive,
+				).to.be.false;
 				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
 					.false;
 			} finally {

--- a/scripts/ci/check-fence-ratchet.mjs
+++ b/scripts/ci/check-fence-ratchet.mjs
@@ -27,9 +27,7 @@ const TARGETS = new Map([
 			"_receiveOwnershipMutationAdmissions",
 			"_receiveOwnershipRevision",
 			"_repairLifecycleController",
-			"_replicationInfoReceiveEpochByPeer",
 			"_replicationLifecycleController",
-			"_subscriptionOpeningEpochByPeer",
 		],
 	],
 	[
@@ -42,7 +40,7 @@ const TARGETS = new Map([
 	],
 	[
 		"packages/programs/data/shared-log/src/peer-session.ts",
-		["_subscriptionEpochByPeer"],
+		["_replicationInfoReceiveEpochByPeer", "_subscriptionEpochByPeer"],
 	],
 	[
 		"packages/programs/data/shared-log/src/join-warmup.ts",


### PR DESCRIPTION
Third stage-3 PR (#1174, #1175 merged) — **the first fence deletions of the migration**, executed pin-first per the risk plan.

## Commit 1: the pinning tests

Two new describes in `test/receive-admission-pins.spec.ts`, landed and proven against pre-migration behavior, **mutation-verified sensitive** (three deliberate fence regressions each — always-true epoch check, phase-based window, dropped barrier abort — all caught, then reverted):
- **Recovery epoch**: a replication-info handler parked between lease release and its apply-lane turn must not resurrect an evicted replicator after a committed removal; pre-close epoch captures must stay stale across reopen.
- **Opening-barrier windows**: the barrier truth is a *window*, not a phase — adverts before the barrier starts are never stashed; a barrier aborted mid-drain never promotes its stash.

## Commit 2: the migration

- `onMessage`'s per-peer captures collapse onto **one session capture**; the four replication-info gates use `isMembershipActiveFor` + registry checks, preserving term order and the pre-lane's deliberate absence of a subscription-epoch term.
- **D1 deleted** (`_subscriptionOpeningEpochByPeer`): the barrier window lives on the session as explicit begin/finish (finally-cleared including the throw path; the old unsubscribe-path delete is a documented no-op, proven doubly unreachable in review).
- **D2 deleted** (`_replicationInfoReceiveEpochByPeer` as an index.ts fence): relocated into the registry as **per-peer** state — deliberately not session-bound, because the pinning tests proved a session token cannot satisfy the session-less-peer advance and rotation-survival semantics. Advance points, the atomic advance+watermark-delete pair at removal, open-replace and close-clear all at the exact legacy points.
- Ratchet: index.ts baseline 10 → 8 (net 19 → 18 across files).

## Validation

- 21-suite sweep 0 failing (the four late reds were worktree ABI drift — natives rebuilt under the wrong Node by a stray command; suites green at exact historical counts after a forced node-gyp rebuild).
- Both pin describes 3× green before and after migration; full `chaos` and `chaos:all` green.
- Adversarial review (deletion-safety + pins/guards): **zero confirmed defects**; the review's constructed interleaving attack on the no-op claim failed both ways; every old-fence reader mapped 1:1. One latent minor noted for stage 4: a mid-barrier session's window flag survives `_close` (unobservable today — the only reader is lease-gated).
- Benchmark A/B and chaos-sim dispatches accompany this PR (receive hot path touched).