### PR TITLE
refactor(shared-log): stage-3 PR-4 — relocate remaining receive-path state

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2065,10 +2065,28 @@ export class SharedLog<
 	// Receive-side ownership plans may span lower-log joins that invoke user code.
 	// Increment synchronously with leader-cache invalidation so the handler can
 	// detect whether its pre-join plan needs one fresh post-persist audit.
-	private _receiveOwnershipRevision = 0;
+	// Stage 3: physically owned by the per-open InstanceLifecycle
+	// (_receiveOwnershipRevision and _receiveOwnershipMutationAdmissions moved
+	// file-to-file; see src/instance-lifecycle.ts); these accessors keep every
+	// legacy site verbatim, and the fresh lifecycle at open() is the reset-to-0.
+	private get _receiveOwnershipRevision(): number {
+		return this._instanceLifecycle?._receiveOwnershipRevision ?? 0;
+	}
+	private set _receiveOwnershipRevision(value: number) {
+		if (this._instanceLifecycle) {
+			this._instanceLifecycle._receiveOwnershipRevision = value;
+		}
+	}
 	// Count ownership-changing range mutations from queue admission through
 	// settlement, including mutations already pending when a receive starts.
-	private _receiveOwnershipMutationAdmissions = 0;
+	private get _receiveOwnershipMutationAdmissions(): number {
+		return this._instanceLifecycle?._receiveOwnershipMutationAdmissions ?? 0;
+	}
+	private set _receiveOwnershipMutationAdmissions(value: number) {
+		if (this._instanceLifecycle) {
+			this._instanceLifecycle._receiveOwnershipMutationAdmissions = value;
+		}
+	}
 	// Subscription callbacks can overlap because removing a replicator mutates the
 	// replication index asynchronously. Keep that lifecycle separate from message
 	// timestamps so a reconnect can synchronously revoke an older unsubscribe.
@@ -13785,8 +13803,11 @@ export class SharedLog<
 		this._replicationRangeMutationsClosing = false;
 		this._checkedPruneRemoveBlocksLocalRangeMutationAdmission = 0;
 		this._checkedPruneRemovalCallbackInvocationDepth = 0;
-		this._receiveOwnershipRevision = 0;
-		this._receiveOwnershipMutationAdmissions = 0;
+		// The legacy `_receiveOwnershipRevision = 0` and
+		// `_receiveOwnershipMutationAdmissions = 0` resets that sat here come
+		// free with the fresh InstanceLifecycle created below: the counters
+		// physically live on it now, and no consumer runs between this point
+		// and that creation (straight-line assignments only).
 		this._pruneRemovesClosing = false;
 		this._replicationRangeMutationFailure = undefined;
 		// One InstanceLifecycle per open(): fresh identity, installed before
@@ -13796,8 +13817,10 @@ export class SharedLog<
 		// (ownership controller next, membership controller at
 		// resetSubscriptionChangeCallbackTracking below, _checkedPrune and
 		// _closeController and the debouncers in the setup blocks further
-		// down). The fresh object is also the per-open role reset:
-		// roleGeneration starts at 0 on the incoming lifecycle.
+		// down). The fresh object is also the per-open reset for the role
+		// sub-generation and the receive-ownership counters: roleGeneration,
+		// _receiveOwnershipRevision and _receiveOwnershipMutationAdmissions
+		// all start at 0 on the incoming lifecycle.
 		this._instanceLifecycle = this.createInstanceLifecycle();
 		this.startRepairLifecycle();
 		this._replicationRangeMutationTail = Promise.resolve();

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -1971,7 +1971,11 @@ export class SharedLog<
 	private _replicationLifecycleController?: AbortController;
 	private _activeReceiveHandlersByPeer!: Map<string, PeerReceiveLeaseState>;
 	private _receiveHandlerDrainByPeer!: Map<string, Set<Promise<void>>>;
-	private _receiveCleanupGateByPeer!: Map<string, number>;
+	// The per-peer receive cleanup-gate refcounts now live on the
+	// PeerSessionRegistry (_receiveCleanupGateByPeer moved file-to-file; see
+	// src/peer-session.ts): acquired via acquireReceiveCleanupGate, read via
+	// isReceiveCleanupGateOpen, cleared at _close via
+	// clearCleanupGatesForClose.
 	// One-shot capability adverts staged while a peer's opening barrier is
 	// running (window truth = the session's openingBarrierActive sub-state;
 	// the legacy _subscriptionOpeningEpochByPeer map is gone). `epoch` is the
@@ -3388,8 +3392,6 @@ export class SharedLog<
 				this._replicationLifecycleController,
 			isReplicationInfoBlocked: (hash) =>
 				this._replicationInfoBlockedPeers.has(hash),
-			getReceiveCleanupGate: (hash) =>
-				this._receiveCleanupGateByPeer.get(hash) ?? 0,
 		});
 	}
 
@@ -3429,7 +3431,6 @@ export class SharedLog<
 		this._pendingReplicatorLeaveByPeer = new Set();
 		this._activeReceiveHandlersByPeer = new Map();
 		this._receiveHandlerDrainByPeer = new Map();
-		this._receiveCleanupGateByPeer = new Map();
 		this._openingSyncCapabilitiesByPeer = new Map();
 		this._gidPeersHistory = new Map();
 		this._repairRetryTimers = new Set();
@@ -6052,12 +6053,13 @@ export class SharedLog<
 			}
 		};
 		const isMe = this.node.identity.publicKey.hashcode() === keyHash;
-		let receiveAdmissionBlocked = false;
-		// Capture the gate map instance: close/reopen replaces the map, and the
-		// release in this call's finally must drain the exact map it
-		// incremented — a late release against a fresh open's map would
-		// corrupt that open's refcounts.
-		const receiveCleanupGateByPeer = this._receiveCleanupGateByPeer;
+		// The registry acquire captures the gate-map instance: close/reopen
+		// replaces the map, and the release in this call's finally must drain
+		// the exact map it incremented — a late release against a fresh open's
+		// map would corrupt that open's refcounts. (Every path to the acquire
+		// runs behind an ownership-lifecycle throw, so the map current at
+		// acquisition is the map that was current at this call's entry.)
+		let releaseReceiveCleanupGate: (() => void) | undefined;
 		const checkedPruneCoordinator = this._checkedPrune;
 		const isSpeculativePeerRemoval =
 			!isMe && options?.shouldRemove !== undefined;
@@ -6065,14 +6067,8 @@ export class SharedLog<
 			? checkedPruneCoordinator.fencePeerRemoval(keyHash)
 			: undefined;
 		const blockPeerReceiveAdmission = () => {
-			if (receiveAdmissionBlocked) {
-				return;
-			}
-			receiveCleanupGateByPeer.set(
-				keyHash,
-				(receiveCleanupGateByPeer.get(keyHash) ?? 0) + 1,
-			);
-			receiveAdmissionBlocked = true;
+			releaseReceiveCleanupGate ??=
+				this._peerSessions.acquireReceiveCleanupGate(keyHash);
 		};
 		if (!isMe && !isSpeculativePeerRemoval) {
 			// Revoke this peer's receipts synchronously, before this removal can
@@ -6304,14 +6300,7 @@ export class SharedLog<
 			});
 			removalCallCompleted = true;
 		} finally {
-			if (receiveAdmissionBlocked) {
-				const remaining = (receiveCleanupGateByPeer.get(keyHash) ?? 1) - 1;
-				if (remaining > 0) {
-					receiveCleanupGateByPeer.set(keyHash, remaining);
-				} else {
-					receiveCleanupGateByPeer.delete(keyHash);
-				}
-			}
+			releaseReceiveCleanupGate?.();
 			if (isSpeculativePeerRemoval) {
 				const cancelledByFreshActivity =
 					removalCallCompleted &&
@@ -13858,14 +13847,15 @@ export class SharedLog<
 		// Deserialized instances never ran the constructor; create the session
 		// registry lazily on first open. Reopens keep the SAME registry so stale
 		// continuations observe resetForOpen()'s map swap via property lookup.
-		// resetForOpen also replaces the per-peer receive-epoch map, matching
-		// the legacy open()-time `_replicationInfoReceiveEpochByPeer = new Map()`.
+		// resetForOpen also replaces the per-peer receive-epoch and receive
+		// cleanup-gate maps, matching the legacy open()-time
+		// `_replicationInfoReceiveEpochByPeer = new Map()` and
+		// `_receiveCleanupGateByPeer = new Map()`.
 		this._peerSessions ??= this.createPeerSessionRegistry();
 		this._peerSessions.resetForOpen();
 		this._pendingReplicatorLeaveByPeer = new Set();
 		this._activeReceiveHandlersByPeer = new Map();
 		this._receiveHandlerDrainByPeer = new Map();
-		this._receiveCleanupGateByPeer = new Map();
 		this._openingSyncCapabilitiesByPeer = new Map();
 		this._repairRetryTimers = new Set();
 		this._recentRepairDispatch = new Map();
@@ -16437,9 +16427,9 @@ export class SharedLog<
 			this._pendingIHaveCallbacks?.clear();
 			this.latestReplicationInfoMessage?.clear();
 			this._peerSessions?.clearReceiveEpochsForClose();
+			this._peerSessions?.clearCleanupGatesForClose();
 			this._activeReceiveHandlersByPeer?.clear();
 			this._receiveHandlerDrainByPeer?.clear();
-			this._receiveCleanupGateByPeer?.clear();
 			this._openingSyncCapabilitiesByPeer?.clear();
 			this._gidPeersHistory?.clear();
 			this._peerSyncCapabilities?.clear();
@@ -24766,7 +24756,7 @@ export class SharedLog<
 											if (
 												finalOwnership.leaders.has(peer) &&
 												!this._replicationInfoBlockedPeers.has(peer) &&
-												(this._receiveCleanupGateByPeer.get(peer) ?? 0) === 0
+												this._peerSessions.isReceiveCleanupGateOpen(peer)
 											) {
 												finalConfirmationCount += 1;
 											}

--- a/packages/programs/data/shared-log/src/instance-lifecycle.ts
+++ b/packages/programs/data/shared-log/src/instance-lifecycle.ts
@@ -58,6 +58,22 @@ export class InstanceLifecycle {
 	// retiring the instance identity.
 	public roleGeneration = 0;
 
+	// Moved from SharedLog (fences C1/C2, same names — the sanctioned
+	// file-to-file ratchet move). Physically owned per-open counters read and
+	// written by the host through delegating accessors that keep every legacy
+	// site verbatim; the fresh lifecycle object at open() IS the legacy
+	// reset-to-0 (same pattern as roleGeneration above).
+	//
+	// Receive-side ownership plans may span lower-log joins that invoke user
+	// code. Incremented synchronously with leader-cache invalidation so the
+	// handler can detect whether its pre-join plan needs one fresh
+	// post-persist audit.
+	public _receiveOwnershipRevision = 0;
+	// Count of ownership-changing range mutations from queue admission
+	// through settlement, including mutations already pending when a receive
+	// starts.
+	public _receiveOwnershipMutationAdmissions = 0;
+
 	// Stage-2 bookkeeping. WRITE-ONLY in production paths: no query method
 	// consults these (phase() is derived from the wrapped fences), so a
 	// missed or doubled transition cannot change behavior. Stage 3 flips

--- a/packages/programs/data/shared-log/src/peer-session.ts
+++ b/packages/programs/data/shared-log/src/peer-session.ts
@@ -112,12 +112,12 @@ export class PeerSession {
 }
 
 export class PeerSessionRegistry {
-	// Historic field name kept deliberately: the fence-ratchet baseline entry
-	// moves file-to-file exactly like the stage-1 extractions did for
-	// _joinWarmupGenerationByTarget (scripts/ci/check-fence-ratchet.mjs).
-	// The values ARE the epoch tokens. Stage 3 renames this to `sessions`
-	// once the last raw-token comparison in index.ts is gone.
-	_subscriptionEpochByPeer!: Map<string, PeerSession>;
+	// The per-peer session map (formerly _subscriptionEpochByPeer; renamed
+	// once the last raw-token comparison in index.ts was gone — the values
+	// ARE the legacy epoch tokens, compared by identity and never inspected).
+	// The rename retires the map's fence-ratchet baseline entry: session
+	// identity is the mechanism the ratchet drains fences INTO, not a fence.
+	sessions!: Map<string, PeerSession>;
 	// Moved from SharedLog (fence B2, same name — the sanctioned file-to-file
 	// ratchet move). Local receive generations fence replication-info handlers
 	// that were admitted before a liveness eviction but reach the per-peer
@@ -149,7 +149,7 @@ export class PeerSessionRegistry {
 	 *  lifecycle-controller check, not the epoch). There is NO clearForClose()
 	 *  for sessions; the receive-epoch map, by contrast, IS cleared at close. */
 	resetForOpen(): void {
-		this._subscriptionEpochByPeer = new Map();
+		this.sessions = new Map();
 		this._replicationInfoReceiveEpochByPeer = new Map();
 		this._receiveCleanupGateByPeer = new Map();
 	}
@@ -225,7 +225,7 @@ export class PeerSessionRegistry {
 	}
 
 	current(peerHash: string): PeerSession | null {
-		return this._subscriptionEpochByPeer.get(peerHash) ?? null;
+		return this.sessions.get(peerHash) ?? null;
 	}
 
 	/** null is a VALID current value: a peer that never subscribed has no
@@ -238,7 +238,7 @@ export class PeerSessionRegistry {
 	/** The only creation point. Supersedes (never deletes) the previous
 	 *  session — per-peer entries are never removed, matching today's map. */
 	rotate(peerHash: string, kind: PeerSessionKind): PeerSession {
-		const previous = this._subscriptionEpochByPeer.get(peerHash);
+		const previous = this.sessions.get(peerHash);
 		if (previous) {
 			previous.phase = "superseded";
 		}
@@ -248,14 +248,14 @@ export class PeerSessionRegistry {
 			kind,
 			this.deps.getReplicationLifecycleController(),
 		);
-		this._subscriptionEpochByPeer.set(peerHash, next);
+		this.sessions.set(peerHash, next);
 		return next;
 	}
 
 	/** Reconnect barrier completed. Identity-guarded phase mark; no-op when
 	 *  the expected token was superseded meanwhile. */
 	markOpen(peerHash: string, expectedSession: object): void {
-		const current = this._subscriptionEpochByPeer.get(peerHash);
+		const current = this.sessions.get(peerHash);
 		if (
 			current !== undefined &&
 			current === expectedSession &&
@@ -276,7 +276,7 @@ export class PeerSessionRegistry {
 		peerHash: string,
 		expectedSession?: object | null,
 	): void {
-		const current = this._subscriptionEpochByPeer.get(peerHash);
+		const current = this.sessions.get(peerHash);
 		if (
 			current &&
 			(expectedSession === undefined || current === expectedSession)

--- a/packages/programs/data/shared-log/src/peer-session.ts
+++ b/packages/programs/data/shared-log/src/peer-session.ts
@@ -23,7 +23,6 @@ export type PeerSessionDeps = {
 	) => boolean;
 	getReplicationLifecycleController: () => AbortController | undefined;
 	isReplicationInfoBlocked: (peerHash: string) => boolean;
-	getReceiveCleanupGate: (peerHash: string) => number;
 };
 
 export type PeerReceiveAdmissionOptions = {
@@ -128,6 +127,15 @@ export class PeerSessionRegistry {
 	// session. Unlike sessions this map IS cleared at _close (see
 	// clearReceiveEpochsForClose) and replaced at open.
 	_replicationInfoReceiveEpochByPeer!: Map<string, object>;
+	// Moved from SharedLog (fence B6, same name — the sanctioned file-to-file
+	// ratchet move). Refcount of in-flight destructive peer cleanups: while
+	// non-zero, receive admission for the peer is closed and prune final
+	// confirmations ignore the peer. Per-PEER, not per-session, on purpose:
+	// the gate is held across removeReplicator's awaited lanes while a
+	// reconnect may rotate the session; a fresh session with a zero gate
+	// would reopen receive admission mid-drain. The map instance is replaced
+	// only at open (resetForOpen) and cleared in place at _close.
+	_receiveCleanupGateByPeer!: Map<string, number>;
 
 	constructor(readonly deps: PeerSessionDeps) {
 		this.resetForOpen();
@@ -143,6 +151,7 @@ export class PeerSessionRegistry {
 	resetForOpen(): void {
 		this._subscriptionEpochByPeer = new Map();
 		this._replicationInfoReceiveEpochByPeer = new Map();
+		this._receiveCleanupGateByPeer = new Map();
 	}
 
 	/** _close counterpart of the legacy
@@ -153,6 +162,47 @@ export class PeerSessionRegistry {
 	 *  receive-epoch check site makes the ordering unobservable either way. */
 	clearReceiveEpochsForClose(): void {
 		this._replicationInfoReceiveEpochByPeer.clear();
+	}
+
+	/** _close counterpart of the legacy
+	 *  `this._receiveCleanupGateByPeer?.clear()`: an in-place clear (NOT a
+	 *  map replacement) so an in-flight removal's captured release still
+	 *  drains the instance it incremented — see acquireReceiveCleanupGate. */
+	clearCleanupGatesForClose(): void {
+		this._receiveCleanupGateByPeer.clear();
+	}
+
+	/** ≡ removeReplicator's inline `blockPeerReceiveAdmission` +
+	 *  release-in-`finally` pair (fence B6). Acquire captures the CURRENT
+	 *  gate-map instance and increments once; the returned release is
+	 *  idempotent and decrements the captured map, deleting the entry at 0.
+	 *  The map-instance capture is load-bearing: close/reopen replaces the
+	 *  map (resetForOpen), and a late release must drain the exact map it
+	 *  incremented — a release against a fresh open's map would corrupt that
+	 *  open's refcounts. The `?? 1` mirrors the legacy release: an entry
+	 *  cleared at _close decrements to 0 and stays deleted. */
+	acquireReceiveCleanupGate(peerHash: string): () => void {
+		const gates = this._receiveCleanupGateByPeer;
+		gates.set(peerHash, (gates.get(peerHash) ?? 0) + 1);
+		let released = false;
+		return () => {
+			if (released) {
+				return;
+			}
+			released = true;
+			const remaining = (gates.get(peerHash) ?? 1) - 1;
+			if (remaining > 0) {
+				gates.set(peerHash, remaining);
+			} else {
+				gates.delete(peerHash);
+			}
+		};
+	}
+
+	/** ≡ the legacy `(this._receiveCleanupGateByPeer.get(peer) ?? 0) === 0`
+	 *  read (receive-admission term and prune final-confirmation filter). */
+	isReceiveCleanupGateOpen(peerHash: string): boolean {
+		return (this._receiveCleanupGateByPeer.get(peerHash) ?? 0) === 0;
 	}
 
 	/** ≡ legacy SharedLog.advanceReplicationInfoReceiveEpoch. Advances
@@ -250,7 +300,7 @@ export class PeerSessionRegistry {
 			(options?.allowReplicationInfoBlocked === true ||
 				!this.deps.isReplicationInfoBlocked(peerHash)) &&
 			(options?.allowCleanupGate === true ||
-				this.deps.getReceiveCleanupGate(peerHash) === 0)
+				this.isReceiveCleanupGateOpen(peerHash))
 		);
 	}
 }

--- a/packages/programs/data/shared-log/test/checked-prune-handoff.spec.ts
+++ b/packages/programs/data/shared-log/test/checked-prune-handoff.spec.ts
@@ -504,7 +504,8 @@ describe("checked prune correlated handoff", () => {
 				shouldRemove: () =>
 					log._replicatorLastActivityAt.get(remoteHash) === observedActivityAt,
 			});
-			expect(log._receiveCleanupGateByPeer.has(remoteHash)).to.be.false;
+			expect(log._peerSessions._receiveCleanupGateByPeer.has(remoteHash)).to.be
+				.false;
 			expect(log._checkedPrune.isPeerRemovalFenced(remoteHash)).to.be.true;
 
 			// A receipt admitted just before/during the speculative removal cannot
@@ -527,7 +528,8 @@ describe("checked prune correlated handoff", () => {
 
 			releaseApplyQueue.resolve();
 			expect(await removing).to.be.false;
-			expect(log._receiveCleanupGateByPeer.has(remoteHash)).to.be.false;
+			expect(log._peerSessions._receiveCleanupGateByPeer.has(remoteHash)).to.be
+				.false;
 			expect(log._checkedPrune.isPeerRemovalFenced(remoteHash)).to.be.false;
 			expect(drain.called).to.be.false;
 			await applyQueueBlocker;

--- a/packages/programs/data/shared-log/test/events.spec.ts
+++ b/packages/programs/data/shared-log/test/events.spec.ts
@@ -4452,7 +4452,8 @@ describe("events", () => {
 				});
 			releaseBlocker.resolve();
 			await cleanupStarted.promise;
-			expect(log._receiveCleanupGateByPeer.has(remoteHash)).to.be.true;
+			expect(log._peerSessions._receiveCleanupGateByPeer.has(remoteHash)).to.be
+				.true;
 			await db1.log.onMessage(new SyncCapabilitiesMessage(), {
 				from: remoteKey,
 			} as any);

--- a/packages/programs/data/shared-log/test/peer-session.spec.ts
+++ b/packages/programs/data/shared-log/test/peer-session.spec.ts
@@ -233,9 +233,9 @@ describe("receive admission peer session parity", () => {
 		const registry = new PeerSessionRegistry(createDeps(host));
 
 		const before = registry.rotate(PEER, "opening");
-		const mapBefore = registry._subscriptionEpochByPeer;
+		const mapBefore = registry.sessions;
 		registry.resetForOpen();
-		expect(registry._subscriptionEpochByPeer).to.not.equal(mapBefore);
+		expect(registry.sessions).to.not.equal(mapBefore);
 		expect(registry.current(PEER)).to.equal(null);
 		expect(before.isCurrent()).to.be.false;
 		// Late continuations still resolve their captured token against the

--- a/packages/programs/data/shared-log/test/peer-session.spec.ts
+++ b/packages/programs/data/shared-log/test/peer-session.spec.ts
@@ -19,14 +19,12 @@ type StubHost = {
 	replicationLifecycleController?: AbortController;
 	terminating: boolean;
 	blockedPeers: Set<string>;
-	cleanupGateByPeer: Map<string, number>;
 };
 
 const createHost = (): StubHost => ({
 	replicationLifecycleController: new AbortController(),
 	terminating: false,
 	blockedPeers: new Set(),
-	cleanupGateByPeer: new Map(),
 });
 
 // Mirrors SharedLog.isReplicationLifecycleActive term for term.
@@ -44,7 +42,6 @@ const createDeps = (host: StubHost): PeerSessionDeps => ({
 		isReplicationLifecycleActive(host, controller),
 	getReplicationLifecycleController: () => host.replicationLifecycleController,
 	isReplicationInfoBlocked: (hash) => host.blockedPeers.has(hash),
-	getReceiveCleanupGate: (hash) => host.cleanupGateByPeer.get(hash) ?? 0,
 });
 
 // Literal transcription of the legacy (pre-stage-3) body of
@@ -53,6 +50,7 @@ const createDeps = (host: StubHost): PeerSessionDeps => ({
 // to the registry, so this inline replica is the regression oracle.
 const legacyIsPeerReceiveAdmissionOpen = (
 	host: StubHost,
+	cleanupGateByPeer: Map<string, number>,
 	peerHash: string,
 	replicationLifecycleController: AbortController | undefined,
 	subscriptionEpoch: object | null,
@@ -64,7 +62,7 @@ const legacyIsPeerReceiveAdmissionOpen = (
 	(options?.allowReplicationInfoBlocked === true ||
 		!host.blockedPeers.has(peerHash)) &&
 	(options?.allowCleanupGate === true ||
-		(host.cleanupGateByPeer.get(peerHash) ?? 0) === 0);
+		(cleanupGateByPeer.get(peerHash) ?? 0) === 0);
 
 const PEER = "peer-a";
 
@@ -183,7 +181,10 @@ describe("receive admission peer session parity", () => {
 								if (blocked) {
 									host.blockedPeers.add(PEER);
 								}
-								host.cleanupGateByPeer.set(PEER, gate);
+								// The gate refcounts moved into the registry (fence B6);
+								// seed its map directly, mirroring the legacy host-map
+								// write.
+								registry._receiveCleanupGateByPeer.set(PEER, gate);
 								const options: PeerReceiveAdmissionOptions = {
 									allowReplicationInfoBlocked,
 									allowCleanupGate,
@@ -191,6 +192,7 @@ describe("receive admission peer session parity", () => {
 
 								const expected = legacyIsPeerReceiveAdmissionOpen(
 									host,
+									registry._receiveCleanupGateByPeer,
 									PEER,
 									controller,
 									session,
@@ -314,5 +316,57 @@ describe("receive admission peer session parity", () => {
 		registry.resetForOpen();
 		expect(registry.isReceiveEpochCurrent(PEER, third)).to.be.false;
 		expect(registry.isReceiveEpochCurrent(PEER, null)).to.be.true;
+	});
+
+	it("refcounts the receive cleanup gate with idempotent releases", () => {
+		const host = createHost();
+		const registry = new PeerSessionRegistry(createDeps(host));
+
+		expect(registry.isReceiveCleanupGateOpen(PEER)).to.be.true;
+		const releaseFirst = registry.acquireReceiveCleanupGate(PEER);
+		const releaseSecond = registry.acquireReceiveCleanupGate(PEER);
+		expect(registry._receiveCleanupGateByPeer.get(PEER)).to.equal(2);
+		expect(registry.isReceiveCleanupGateOpen(PEER)).to.be.false;
+
+		releaseFirst();
+		// Idempotent: a double release must not decrement twice.
+		releaseFirst();
+		expect(registry._receiveCleanupGateByPeer.get(PEER)).to.equal(1);
+		expect(registry.isReceiveCleanupGateOpen(PEER)).to.be.false;
+
+		releaseSecond();
+		// Entry deleted at zero, matching the legacy decrement-or-delete.
+		expect(registry._receiveCleanupGateByPeer.has(PEER)).to.be.false;
+		expect(registry.isReceiveCleanupGateOpen(PEER)).to.be.true;
+	});
+
+	it("binds a cleanup-gate release to the map instance it incremented", () => {
+		const host = createHost();
+		const registry = new PeerSessionRegistry(createDeps(host));
+
+		// Reopen during an in-flight removeReplicator: the release captured
+		// before resetForOpen must drain the OLD map, never the fresh open's.
+		const release = registry.acquireReceiveCleanupGate(PEER);
+		const mapBefore = registry._receiveCleanupGateByPeer;
+		registry.resetForOpen();
+		expect(registry._receiveCleanupGateByPeer).to.not.equal(mapBefore);
+		expect(registry.isReceiveCleanupGateOpen(PEER)).to.be.true;
+
+		const freshRelease = registry.acquireReceiveCleanupGate(PEER);
+		release();
+		// The late release drained the stale map without corrupting the fresh
+		// open's refcount.
+		expect(mapBefore.has(PEER)).to.be.false;
+		expect(registry._receiveCleanupGateByPeer.get(PEER)).to.equal(1);
+		freshRelease();
+		expect(registry.isReceiveCleanupGateOpen(PEER)).to.be.true;
+
+		// _close clears in place; a release straddling close decrements the
+		// cleared entry to zero (legacy `?? 1` shape) and stays deleted.
+		const releaseAcrossClose = registry.acquireReceiveCleanupGate(PEER);
+		registry.clearCleanupGatesForClose();
+		expect(registry._receiveCleanupGateByPeer.has(PEER)).to.be.false;
+		releaseAcrossClose();
+		expect(registry._receiveCleanupGateByPeer.has(PEER)).to.be.false;
 	});
 });

--- a/packages/programs/data/shared-log/test/receive-admission.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission.spec.ts
@@ -103,7 +103,8 @@ describe("receive admission", () => {
 
 				releaseCleanup.resolve();
 				await unsubscribe;
-				expect(sharedLog._receiveCleanupGateByPeer.has(sourceHash)).to.be.false;
+				expect(sharedLog._peerSessions._receiveCleanupGateByPeer.has(sourceHash))
+					.to.be.false;
 			} finally {
 				releaseCleanup.resolve();
 				disconnected.restore();
@@ -363,7 +364,8 @@ describe("receive admission", () => {
 				expect(sharedLog._activeReceiveHandlersByPeer.has(sourceHash)).to.be
 					.false;
 				expect(sharedLog._receiveHandlerDrainByPeer.has(sourceHash)).to.be.false;
-				expect(sharedLog._receiveCleanupGateByPeer.has(sourceHash)).to.be.false;
+				expect(sharedLog._peerSessions._receiveCleanupGateByPeer.has(sourceHash))
+					.to.be.false;
 			} finally {
 				releaseHasMany.resolve();
 				confirmation.restore();
@@ -491,7 +493,8 @@ describe("receive admission", () => {
 				}
 				expect(sharedLog._activeReceiveHandlersByPeer.has(sourceHash)).to.be
 					.false;
-				expect(sharedLog._receiveCleanupGateByPeer.has(sourceHash)).to.be.false;
+				expect(sharedLog._peerSessions._receiveCleanupGateByPeer.has(sourceHash))
+					.to.be.false;
 			} finally {
 				releasePendingResponse.resolve();
 				releaseLateResponse.resolve();

--- a/scripts/ci/check-fence-ratchet.mjs
+++ b/scripts/ci/check-fence-ratchet.mjs
@@ -41,11 +41,7 @@ const TARGETS = new Map([
 	],
 	[
 		"packages/programs/data/shared-log/src/peer-session.ts",
-		[
-			"_receiveCleanupGateByPeer",
-			"_replicationInfoReceiveEpochByPeer",
-			"_subscriptionEpochByPeer",
-		],
+		["_receiveCleanupGateByPeer", "_replicationInfoReceiveEpochByPeer"],
 	],
 	[
 		"packages/programs/data/shared-log/src/join-warmup.ts",

--- a/scripts/ci/check-fence-ratchet.mjs
+++ b/scripts/ci/check-fence-ratchet.mjs
@@ -23,15 +23,17 @@ const TARGETS = new Map([
 			"_checkedPruneRemoveBlocksLocalRangeMutationAdmission",
 			"_instanceLifecycle",
 			"_nativeCoordinateMutationGenerations",
-			"_receiveOwnershipMutationAdmissions",
-			"_receiveOwnershipRevision",
 			"_repairLifecycleController",
 			"_replicationLifecycleController",
 		],
 	],
 	[
 		"packages/programs/data/shared-log/src/instance-lifecycle.ts",
-		["roleGeneration"],
+		[
+			"_receiveOwnershipMutationAdmissions",
+			"_receiveOwnershipRevision",
+			"roleGeneration",
+		],
 	],
 	[
 		"packages/programs/data/shared-log/src/native-write-through-block-store.ts",
@@ -91,7 +93,6 @@ const matchesFenceTokens = (name) =>
 // excluded.
 const DECL =
 	/^\s*(?:(?:private|protected|public)\s+(?:static\s+)?(?:override\s+)?(?:readonly\s+)?([A-Za-z0-9_#]+)|(?:static\s+)?(?:readonly\s+)?([_#][A-Za-z0-9_]+))\s*[?!]?\s*[:=]/;
-
 
 const root = process.cwd();
 const errors = [];

--- a/scripts/ci/check-fence-ratchet.mjs
+++ b/scripts/ci/check-fence-ratchet.mjs
@@ -23,7 +23,6 @@ const TARGETS = new Map([
 			"_checkedPruneRemoveBlocksLocalRangeMutationAdmission",
 			"_instanceLifecycle",
 			"_nativeCoordinateMutationGenerations",
-			"_receiveCleanupGateByPeer",
 			"_receiveOwnershipMutationAdmissions",
 			"_receiveOwnershipRevision",
 			"_repairLifecycleController",
@@ -40,7 +39,11 @@ const TARGETS = new Map([
 	],
 	[
 		"packages/programs/data/shared-log/src/peer-session.ts",
-		["_replicationInfoReceiveEpochByPeer", "_subscriptionEpochByPeer"],
+		[
+			"_receiveCleanupGateByPeer",
+			"_replicationInfoReceiveEpochByPeer",
+			"_subscriptionEpochByPeer",
+		],
 	],
 	[
 		"packages/programs/data/shared-log/src/join-warmup.ts",


### PR DESCRIPTION
Final stage-3 PR (#1174, #1175, #1176 merged). Mechanical state relocation, one commit per move for bisectability — **this completes stage 3 of the session/lifecycle refactor**.

## The three relocations

1. **D3**: `_receiveCleanupGateByPeer` → `PeerSessionRegistry.acquireReceiveCleanupGate`, reproducing the old inline closure exactly: same refcount arithmetic, idempotent map-instance-bound release (a release after reopen drains the dead map it incremented, never the fresh open's counts — pinned by new unit tests including a reopen-during-removal case).
2. **D4+D5**: `_receiveOwnershipRevision` + `_receiveOwnershipMutationAdmissions` → plain fields on `InstanceLifecycle` behind stage-2-style delegating accessors; `isReceiveOwnershipSnapshotStable` verbatim, no identity-strengthening anywhere (review-verified); the `open()` reset-to-0 lines are subsumed by the fresh lifecycle object.
3. **D6**: the registry's internal epoch map renamed to `sessions` — the name now says what stage 2 made true.

`_replicationInfoBlockedPeers` (B5) deliberately stays: the deletion-order manifest scopes it to a separate liveness-focused PR.

## Validation

- Per-commit gates (build/lint/guards + five suites) green at every step; final 21-suite sweep 0 failing; full chaos green.
- Adversarial purity review: **zero confirmed defects**; the two theoretical caveats (acquire-time map capture after awaits; pre-open counter reads on deserialized clones) both proven unreachable.
- Ratchet: 17 entries — down from 19 at stage-3 start, with every relocated fence still frozen in its new home.

## Stage-3 tally

Across the four PRs: the eight documented multi-fence seams migrated onto `lifecycle`/`session` identity checks; two fences deleted outright (opening-epoch, recovery-epoch as an index.ts fence); three relocated; `removeReplicator`'s four loose fence parameters are now object calls; `onMessage` captures one session instead of six mechanisms. Stage 4 (physical controller relocation, warmup/announcement sub-sessions, B5/B8) has its scope already inventoried.