### PR TITLE
refactor(shared-log): stage-4 PR-1 — worker sessions replace generation compounds

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -189,7 +189,7 @@ import {
 	type Numbers,
 	createNumbers,
 } from "./integers.js";
-import { JoinWarmupCoordinator } from "./join-warmup.js";
+import { JoinWarmupCoordinator, type WarmupSession } from "./join-warmup.js";
 import { LeaderPlanCache } from "./leader-plan-cache.js";
 import { TransportMessage } from "./message.js";
 import { NativeBackboneWriteThroughBlockStore } from "./native-write-through-block-store.js";
@@ -1460,7 +1460,7 @@ type RepairMetrics = Record<RepairDispatchMode, RepairMetricBucket>;
 
 type RepairSweepOptimisticPeerState = {
 	count: number;
-	generation: object;
+	session: WarmupSession;
 };
 
 const REPAIR_DISPATCH_MODES: RepairDispatchMode[] = [
@@ -2207,7 +2207,7 @@ export class SharedLog<
 		for (const peers of this._repairSweepPendingPeersByMode.values()) {
 			peers.clear();
 		}
-		this.joinWarmup._repairSweepJoinWarmupGenerationByTarget.clear();
+		this.joinWarmup.clearRepairSweepWarmupSessions();
 		this._repairSweepOptimisticGidPeersPending.clear();
 		this._repairSweepOptimisticGidsByPeer.clear();
 		for (const targets of this._repairFrontierByMode.values()) {
@@ -6025,7 +6025,7 @@ export class SharedLog<
 		key: PublicSignKey | string,
 		options?: {
 			cleanupIfSubscriptionSuperseded?: boolean;
-			expectedJoinWarmupGeneration?: object | null;
+			expectedWarmupSession?: WarmupSession | null;
 			noEvent?: boolean;
 			onRemoved?: (state: { wasReplicator: boolean }) => void;
 			replicationLifecycleController?: AbortController;
@@ -6041,10 +6041,10 @@ export class SharedLog<
 			replicationOwnershipLifecycleController,
 		);
 		const keyHash = typeof key === "string" ? key : key.hashcode();
-		const expectedJoinWarmupGeneration =
-			options?.expectedJoinWarmupGeneration !== undefined
-				? options.expectedJoinWarmupGeneration
-				: (this.joinWarmup._joinWarmupGenerationByTarget.get(keyHash) ?? null);
+		const expectedWarmupSession =
+			options?.expectedWarmupSession !== undefined
+				? options.expectedWarmupSession
+				: (this.joinWarmup._warmupSessionsByTarget.get(keyHash) ?? null);
 		// Stage 3 (seam 1): the three ownership predicates delegate onto the
 		// session registry / instance lifecycle. `undefined` keeps meaning
 		// "removal not scoped to that identity" — the guards stay in the
@@ -6063,9 +6063,9 @@ export class SharedLog<
 			);
 		const cancelExpectedJoinWarmupTarget = () => {
 			if (
-				expectedJoinWarmupGeneration !== null &&
-				this.joinWarmup._joinWarmupGenerationByTarget.get(keyHash) ===
-					expectedJoinWarmupGeneration
+				expectedWarmupSession !== null &&
+				this.joinWarmup._warmupSessionsByTarget.get(keyHash) ===
+					expectedWarmupSession
 			) {
 				this.joinWarmup.cancelJoinWarmupTarget(keyHash);
 			}
@@ -6117,7 +6117,7 @@ export class SharedLog<
 				replicationOwnershipLifecycleController,
 			);
 			this.removeRepairFrontierTarget(keyHash, {
-				expectedJoinWarmupGeneration,
+				expectedWarmupSession,
 			});
 			this._recentRepairDispatch.delete(keyHash);
 			if (!isMe) {
@@ -7456,7 +7456,7 @@ export class SharedLog<
 	private markRepairSweepOptimisticPeer(
 		gid: string,
 		peer: string,
-		generation: object,
+		session: WarmupSession,
 	) {
 		let peers = this._repairSweepOptimisticGidPeersPending.get(gid);
 		if (!peers) {
@@ -7465,8 +7465,8 @@ export class SharedLog<
 		}
 		const current = peers.get(peer);
 		peers.set(peer, {
-			count: current?.generation === generation ? current.count + 1 : 1,
-			generation,
+			count: current?.session === session ? current.count + 1 : 1,
+			session,
 		});
 		let gids = this._repairSweepOptimisticGidsByPeer.get(peer);
 		if (!gids) {
@@ -7667,13 +7667,13 @@ export class SharedLog<
 
 	private removeRepairFrontierTarget(
 		target: string,
-		options?: { expectedJoinWarmupGeneration?: object | null },
+		options?: { expectedWarmupSession?: WarmupSession | null },
 	) {
 		if (
-			options?.expectedJoinWarmupGeneration === undefined ||
-			(options.expectedJoinWarmupGeneration !== null &&
-				this.joinWarmup._joinWarmupGenerationByTarget.get(target) ===
-					options.expectedJoinWarmupGeneration)
+			options?.expectedWarmupSession === undefined ||
+			(options.expectedWarmupSession !== null &&
+				this.joinWarmup._warmupSessionsByTarget.get(target) ===
+					options.expectedWarmupSession)
 		) {
 			this.joinWarmup.cancelJoinWarmupTarget(target);
 		}
@@ -8189,9 +8189,9 @@ export class SharedLog<
 		const bucket = this._repairMetrics[options.mode];
 		bucket.dispatches += 1;
 		bucket.entries += filteredEntries.size;
-		const joinWarmupGeneration =
+		const warmupSession =
 			options.mode === "join-warmup"
-				? this.joinWarmup.getJoinWarmupGeneration(target)
+				? this.joinWarmup.ensureWarmupSession(target)
 				: undefined;
 		const bypassKnownPeerHints = this.shouldBypassKnownPeerHints(
 			options.mode,
@@ -8205,11 +8205,11 @@ export class SharedLog<
 			if (
 				transport === "simple" &&
 				options.mode === "join-warmup" &&
-				joinWarmupGeneration
+				warmupSession
 			) {
 				this.joinWarmup.queueJoinWarmupSend(
 					target,
-					joinWarmupGeneration,
+					warmupSession,
 					filteredEntries,
 					bypassKnownPeerHints,
 					repairLifecycleController,
@@ -8246,7 +8246,7 @@ export class SharedLog<
 			}
 			if (
 				options.mode === "join-warmup" &&
-				joinWarmupGeneration &&
+				warmupSession &&
 				transport === "simple"
 			) {
 				delayedJoinWarmupRetries.push(delayMs);
@@ -8264,10 +8264,10 @@ export class SharedLog<
 			timer.unref?.();
 			this._repairRetryTimers.add(timer);
 		});
-		if (joinWarmupGeneration && delayedJoinWarmupRetries.length > 0) {
+		if (warmupSession && delayedJoinWarmupRetries.length > 0) {
 			this.joinWarmup.scheduleJoinWarmupRetries(
 				target,
-				joinWarmupGeneration,
+				warmupSession,
 				delayedJoinWarmupRetries,
 				filteredEntries,
 				bypassKnownPeerHints,
@@ -8280,7 +8280,7 @@ export class SharedLog<
 		options: {
 			mode: RepairDispatchMode;
 			peers?: Iterable<string>;
-			joinWarmupGenerations?: ReadonlyMap<string, object>;
+			warmupSessions?: ReadonlyMap<string, WarmupSession>;
 		},
 		repairLifecycleController: AbortController = this
 			._repairLifecycleController,
@@ -8292,13 +8292,13 @@ export class SharedLog<
 		if (pendingPeers) {
 			for (const peer of options.peers ?? []) {
 				if (options.mode === "join-warmup") {
-					const generation =
-						options.joinWarmupGenerations?.get(peer) ??
-						this.joinWarmup.getJoinWarmupGeneration(peer);
-					if (this.joinWarmup._joinWarmupGenerationByTarget.get(peer) !== generation) {
+					const session =
+						options.warmupSessions?.get(peer) ??
+						this.joinWarmup.ensureWarmupSession(peer);
+					if (this.joinWarmup._warmupSessionsByTarget.get(peer) !== session) {
 						continue;
 					}
-					this.joinWarmup._repairSweepJoinWarmupGenerationByTarget.set(peer, generation);
+					this.joinWarmup._repairSweepWarmupSessionByTarget.set(peer, session);
 				}
 				pendingPeers.add(peer);
 			}
@@ -8381,14 +8381,14 @@ export class SharedLog<
 				const pendingPeersByMode = cloneRepairPendingPeersByMode(
 					this._repairSweepPendingPeersByMode,
 				);
-				const pendingJoinWarmupGenerations = new Map(
-					this.joinWarmup._repairSweepJoinWarmupGenerationByTarget,
+				const pendingWarmupSessions = new Map(
+					this.joinWarmup._repairSweepWarmupSessionByTarget,
 				);
 				this._repairSweepPendingModes.clear();
 				for (const peers of this._repairSweepPendingPeersByMode.values()) {
 					peers.clear();
 				}
-				this.joinWarmup._repairSweepJoinWarmupGenerationByTarget.clear();
+				this.joinWarmup._repairSweepWarmupSessionByTarget.clear();
 				const pendingJoinWarmupPeers = pendingPeersByMode.get("join-warmup");
 				const pruneStaleJoinWarmupPeers = () => {
 					if (!this.isRepairLifecycleActive(repairLifecycleController)) {
@@ -8396,8 +8396,8 @@ export class SharedLog<
 					}
 					for (const peer of [...(pendingJoinWarmupPeers ?? [])]) {
 						if (
-							this.joinWarmup._joinWarmupGenerationByTarget.get(peer) !==
-							pendingJoinWarmupGenerations.get(peer)
+							this.joinWarmup._warmupSessionsByTarget.get(peer) !==
+							pendingWarmupSessions.get(peer)
 						) {
 							pendingJoinWarmupPeers?.delete(peer);
 						}
@@ -8500,8 +8500,8 @@ export class SharedLog<
 					}
 					if (
 						mode === "join-warmup" &&
-						this.joinWarmup._joinWarmupGenerationByTarget.get(target) !==
-							pendingJoinWarmupGenerations.get(target)
+						this.joinWarmup._warmupSessionsByTarget.get(target) !==
+							pendingWarmupSessions.get(target)
 					) {
 						targets?.delete(target);
 						pendingJoinWarmupPeers?.delete(target);
@@ -8536,8 +8536,8 @@ export class SharedLog<
 					}
 					if (
 						mode === "join-warmup" &&
-						this.joinWarmup._joinWarmupGenerationByTarget.get(target) !==
-							pendingJoinWarmupGenerations.get(target)
+						this.joinWarmup._warmupSessionsByTarget.get(target) !==
+							pendingWarmupSessions.get(target)
 					) {
 						pendingJoinWarmupPeers?.delete(target);
 						if (pendingJoinWarmupPeers?.size === 0) {
@@ -8676,14 +8676,14 @@ export class SharedLog<
 						}
 						for (const [peer, consumed] of peerCounts) {
 							const current = pendingPeerCounts.get(peer);
-							if (!current || current.generation !== consumed.generation) {
+							if (!current || current.session !== consumed.session) {
 								continue;
 							}
 							const next = current.count - consumed.count;
 							if (next > 0) {
 								pendingPeerCounts.set(peer, {
 									count: next,
-									generation: current.generation,
+									session: current.session,
 								});
 							} else {
 								pendingPeerCounts.delete(peer);
@@ -16408,7 +16408,7 @@ export class SharedLog<
 			this._repairSweepPendingModes?.clear();
 			for (const peers of this._repairSweepPendingPeersByMode?.values() ?? [])
 				peers.clear();
-			this.joinWarmup?._repairSweepJoinWarmupGenerationByTarget?.clear();
+			this.joinWarmup?.clearRepairSweepWarmupSessions();
 			this._repairSweepOptimisticGidPeersPending?.clear();
 			this._repairSweepOptimisticGidsByPeer?.clear();
 			this._entryKnownPeers?.clear();
@@ -24128,8 +24128,8 @@ export class SharedLog<
 			// unreachable, and its own barrier `finally` still clears it.
 			this._openingSyncCapabilitiesByPeer.delete(peerHash);
 			this._replicationInfoBlockedPeers.add(peerHash);
-			const disconnectedJoinWarmupGeneration =
-				this.joinWarmup._joinWarmupGenerationByTarget.get(peerHash) ?? null;
+			const disconnectedWarmupSession =
+				this.joinWarmup._warmupSessionsByTarget.get(peerHash) ?? null;
 			this.joinWarmup.cancelJoinWarmupTarget(peerHash);
 
 			const now = BigInt(+new Date());
@@ -24144,7 +24144,7 @@ export class SharedLog<
 				// Proactively evict its ranges so leader selection doesn't keep stale owners.
 				removed = await this.removeReplicator(publicKey, {
 					cleanupIfSubscriptionSuperseded: true,
-					expectedJoinWarmupGeneration: disconnectedJoinWarmupGeneration,
+					expectedWarmupSession: disconnectedWarmupSession,
 					noEvent: true,
 					onRemoved: ({ wasReplicator }) => {
 						if (wasReplicator) {
@@ -25178,12 +25178,12 @@ export class SharedLog<
 			: [changeOrChanges as ReplicationChanges<ReplicationRangeIndexable<R>>];
 		const changes = batchedChanges.flat();
 		const selfHash = this.node.identity.publicKey.hashcode();
-		const joinWarmupGenerations = new Map<string, object>();
+		const warmupSessions = new Map<string, WarmupSession>();
 		for (const change of changes) {
 			if (change.type === "added" && change.range.hash !== selfHash) {
-				joinWarmupGenerations.set(
+				warmupSessions.set(
 					change.range.hash,
-					this.joinWarmup.getJoinWarmupGeneration(change.range.hash),
+					this.joinWarmup.ensureWarmupSession(change.range.hash),
 				);
 			}
 		}
@@ -25279,8 +25279,8 @@ export class SharedLog<
 		const isCurrentJoinWarmupTarget = (target: string) =>
 			isOwnershipLifecycleCurrent() &&
 			warmupPeers.has(target) &&
-			this.joinWarmup._joinWarmupGenerationByTarget.get(target) ===
-				joinWarmupGenerations.get(target);
+			this.joinWarmup._warmupSessionsByTarget.get(target) ===
+				warmupSessions.get(target);
 		const areJoinWarmupGenerationsCurrent = () =>
 			isOwnershipLifecycleCurrent() &&
 			[...warmupPeers].every(isCurrentJoinWarmupTarget);
@@ -25424,7 +25424,7 @@ export class SharedLog<
 								this.markRepairSweepOptimisticPeer(
 									entryReplicated.gid,
 									peer,
-									joinWarmupGenerations.get(peer)!,
+									warmupSessions.get(peer)!,
 								);
 							}
 						}
@@ -25513,7 +25513,7 @@ export class SharedLog<
 							this.markRepairSweepOptimisticPeer(
 								entryReplicated.gid,
 								peer,
-								joinWarmupGenerations.get(peer)!,
+								warmupSessions.get(peer)!,
 							);
 						}
 					}
@@ -25582,7 +25582,7 @@ export class SharedLog<
 						{
 							mode: "join-warmup",
 							peers,
-							joinWarmupGenerations,
+							warmupSessions,
 						},
 						ownershipLifecycleController,
 					);

--- a/packages/programs/data/shared-log/src/join-warmup.ts
+++ b/packages/programs/data/shared-log/src/join-warmup.ts
@@ -1,9 +1,33 @@
 const JOIN_WARMUP_SEND_SPACING_MS = 250;
 
+/**
+ * One WarmupSession per join-warmup attempt window for a target. The
+ * instance IS the legacy opaque generation token — always compared by
+ * identity, never inspected — now carrying diagnostics. Rotation points are
+ * unchanged: created on demand, dropped at cancelJoinWarmupTarget so the
+ * next touch mints a fresh identity. Deliberately NOT hosted on
+ * PeerSession: warmup windows rotate independently of subscription epochs
+ * (poison and committed removals leave the subscription session alone), and
+ * a warmup target may have no session at all — auto-creating one as a
+ * warmup side effect would flip `isCurrent(peer, null)` from true to false
+ * at every receive-admission seat.
+ */
+export class WarmupSession {
+	readonly target: string;
+	readonly createdAt = Date.now(); // diagnostics only
+
+	constructor(target: string) {
+		this.target = target;
+	}
+}
+
 export type JoinWarmupSendState<E> = {
 	bypassKnownPeerHints: boolean;
 	entries: Map<string, E>;
-	generation: object;
+	// Per-TARGET send state adopts the session it is currently draining for.
+	// lastCompletedAt spacing survives session rotation by design; do NOT
+	// move send state onto the session.
+	session: WarmupSession;
 	lastCompletedAt: number;
 	pending: boolean;
 	running: boolean;
@@ -33,7 +57,7 @@ export type JoinWarmupScheduledRetrySlot<E> = {
 };
 
 export type JoinWarmupScheduledRetries<E> = {
-	generation: object;
+	session: WarmupSession;
 	slotsByDelay: Map<number, JoinWarmupScheduledRetrySlot<E>>;
 };
 
@@ -58,34 +82,39 @@ export type JoinWarmupDeps<E> = {
 };
 
 export class JoinWarmupCoordinator<E> {
-	_joinWarmupGenerationByTarget!: Map<string, object>;
+	_warmupSessionsByTarget!: Map<string, WarmupSession>;
 	_joinWarmupSendStateByTarget!: Map<string, JoinWarmupSendState<E>>;
 	_joinWarmupRetryTimersByTarget!: Map<string, Set<JoinWarmupRetryTimer>>;
 	_joinWarmupScheduledRetriesByTarget!: Map<
 		string,
 		JoinWarmupScheduledRetries<E>
 	>;
-	_repairSweepJoinWarmupGenerationByTarget!: Map<string, object>;
+	_repairSweepWarmupSessionByTarget!: Map<string, WarmupSession>;
 
 	constructor(private readonly deps: JoinWarmupDeps<E>) {
 		this.reset();
 	}
 
 	reset() {
-		this._joinWarmupGenerationByTarget = new Map();
+		this._warmupSessionsByTarget = new Map();
 		this._joinWarmupSendStateByTarget = new Map();
 		this._joinWarmupRetryTimersByTarget = new Map();
 		this._joinWarmupScheduledRetriesByTarget = new Map();
-		this._repairSweepJoinWarmupGenerationByTarget = new Map();
+		this._repairSweepWarmupSessionByTarget = new Map();
 	}
 
-	getJoinWarmupGeneration(target: string) {
-		let generation = this._joinWarmupGenerationByTarget.get(target);
-		if (!generation) {
-			generation = {};
-			this._joinWarmupGenerationByTarget.set(target, generation);
+	ensureWarmupSession(target: string): WarmupSession {
+		let session = this._warmupSessionsByTarget.get(target);
+		if (!session) {
+			session = new WarmupSession(target);
+			this._warmupSessionsByTarget.set(target, session);
 		}
-		return generation;
+		return session;
+	}
+
+
+	clearRepairSweepWarmupSessions(): void {
+		this._repairSweepWarmupSessionByTarget.clear();
 	}
 
 	trackJoinWarmupTimer(target: string, timer: JoinWarmupRetryTimer) {
@@ -123,9 +152,9 @@ export class JoinWarmupCoordinator<E> {
 	}
 
 	cancelJoinWarmupTarget(target: string) {
-		this._joinWarmupGenerationByTarget.delete(target);
+		this._warmupSessionsByTarget.delete(target);
 		this.deps.onTargetCancelled(target);
-		this._repairSweepJoinWarmupGenerationByTarget.delete(target);
+		this._repairSweepWarmupSessionByTarget.delete(target);
 		this.cancelJoinWarmupTimers(target);
 		this._joinWarmupScheduledRetriesByTarget.delete(target);
 		const state = this._joinWarmupSendStateByTarget.get(target);
@@ -142,7 +171,7 @@ export class JoinWarmupCoordinator<E> {
 
 	cancelAllJoinWarmupTargets() {
 		const targets = new Set([
-			...this._joinWarmupGenerationByTarget.keys(),
+			...this._warmupSessionsByTarget.keys(),
 			...this._joinWarmupRetryTimersByTarget.keys(),
 			...this._joinWarmupScheduledRetriesByTarget.keys(),
 			...this._joinWarmupSendStateByTarget.keys(),
@@ -185,7 +214,7 @@ export class JoinWarmupCoordinator<E> {
 
 	scheduleJoinWarmupRetries(
 		target: string,
-		generation: object,
+		session: WarmupSession,
 		delaysMs: Iterable<number>,
 		entries: ReadonlyMap<string, E>,
 		bypassKnownPeerHints: boolean,
@@ -193,19 +222,19 @@ export class JoinWarmupCoordinator<E> {
 	) {
 		if (
 			!this.deps.isLifecycleActive(repairLifecycleController) ||
-			this._joinWarmupGenerationByTarget.get(target) !== generation
+			this._warmupSessionsByTarget.get(target) !== session
 		) {
 			return;
 		}
 		let scheduled = this._joinWarmupScheduledRetriesByTarget.get(target);
-		if (scheduled?.generation !== generation) {
+		if (scheduled?.session !== session) {
 			this.cancelJoinWarmupTimers(target);
 			this._joinWarmupScheduledRetriesByTarget.delete(target);
 			scheduled = undefined;
 		}
 		if (!scheduled) {
 			scheduled = {
-				generation,
+				session,
 				slotsByDelay: new Map(),
 			};
 			this._joinWarmupScheduledRetriesByTarget.set(target, scheduled);
@@ -307,12 +336,11 @@ export class JoinWarmupCoordinator<E> {
 				if (
 					dueEntries.size > 0 &&
 					!this.deps.isClosed() &&
-					this._joinWarmupGenerationByTarget.get(target) ===
-						scheduled.generation
+					this._warmupSessionsByTarget.get(target) === scheduled.session
 				) {
 					this.queueJoinWarmupSend(
 						target,
-						scheduled.generation,
+						scheduled.session,
 						dueEntries,
 						bypassKnownPeerHints,
 						repairLifecycleController,
@@ -348,14 +376,14 @@ export class JoinWarmupCoordinator<E> {
 
 	queueJoinWarmupSend(
 		target: string,
-		generation: object,
+		session: WarmupSession,
 		entries: ReadonlyMap<string, E>,
 		bypassKnownPeerHints: boolean,
 		repairLifecycleController: AbortController = this.deps.getCurrentLifecycleController(),
 	) {
 		if (
 			!this.deps.isLifecycleActive(repairLifecycleController) ||
-			this._joinWarmupGenerationByTarget.get(target) !== generation
+			this._warmupSessionsByTarget.get(target) !== session
 		) {
 			return;
 		}
@@ -364,13 +392,13 @@ export class JoinWarmupCoordinator<E> {
 			state = {
 				bypassKnownPeerHints: false,
 				entries: new Map(),
-				generation,
+				session,
 				lastCompletedAt: Number.NEGATIVE_INFINITY,
 				pending: false,
 				running: false,
 			};
 			this._joinWarmupSendStateByTarget.set(target, state);
-		} else if (state.generation !== generation) {
+		} else if (state.session !== session) {
 			state.bypassKnownPeerHints = false;
 			state.entries.clear();
 			state.pending = false;
@@ -379,7 +407,7 @@ export class JoinWarmupCoordinator<E> {
 			state.entries.set(hash, entry);
 		}
 		state.bypassKnownPeerHints ||= bypassKnownPeerHints;
-		state.generation = generation;
+		state.session = session;
 		state.pending = true;
 		if (state.running) {
 			return;
@@ -413,7 +441,7 @@ export class JoinWarmupCoordinator<E> {
 					return;
 				}
 				state.pending = false;
-				const generation = state.generation;
+				const session = state.session;
 				const entries = new Map(state.entries);
 				state.entries.clear();
 				const bypassKnownPeerHints = state.bypassKnownPeerHints;
@@ -429,8 +457,8 @@ export class JoinWarmupCoordinator<E> {
 				);
 				if (
 					!this.deps.isLifecycleActive(repairLifecycleController) ||
-					state.generation !== generation ||
-					this._joinWarmupGenerationByTarget.get(target) !== generation
+					state.session !== session ||
+					this._warmupSessionsByTarget.get(target) !== session
 				) {
 					continue;
 				}
@@ -470,7 +498,7 @@ export class JoinWarmupCoordinator<E> {
 						state,
 						currentRepairLifecycleController,
 					).catch((error: any) => this.deps.logError(error));
-				} else if (!this._joinWarmupGenerationByTarget.has(target)) {
+				} else if (!this._warmupSessionsByTarget.has(target)) {
 					this._joinWarmupSendStateByTarget.delete(target);
 				}
 			}

--- a/packages/programs/data/shared-log/src/replication-announcement.ts
+++ b/packages/programs/data/shared-log/src/replication-announcement.ts
@@ -137,17 +137,48 @@ const isTransientReplicationAnnouncementRepairError = (
 	);
 };
 
+/**
+ * One session per announcement window — rotated at exactly the sites that
+ * bumped the legacy retry-generation counter: construction, resetForOpen,
+ * cancelCurrentReplicationStateAnnouncementRetry, and the pre-send bump in
+ * sendReplicationAnnouncement. Identity comparison replaces every numeric
+ * generation compare. Unlike the number, identity cannot alias across open
+ * cycles (the legacy reset-to-0 was safe only by the convention that a
+ * companion controller check accompanied every compare site).
+ */
+export class AnnouncementWorkerSession {
+	readonly createdAt = Date.now(); // diagnostics only
+}
+
 type ReplicationAnnouncementRepairTarget = {
 	key: PublicSignKey;
-	generation: number;
+	session: AnnouncementWorkerSession;
 	attempts: number;
 	done: boolean;
 };
 
+/**
+ * Repair-side adoption of a session. Replaces the legacy compound of the
+ * repair generation number, its generation controller, and the repair
+ * pending / targets / cohort-selected fields. One binding per adopted
+ * session; every rotation aborts the old binding's controller FIRST, then
+ * reassigns (abort listeners run synchronously and must observe
+ * pre-rotation state, as before). The fair cursor hash and max attempts
+ * deliberately stay OUTSIDE the binding: the cursor rotates best-effort
+ * coverage ACROSS generations, and max-attempts is a setup-scoped tunable.
+ */
+export type ReplicationAnnouncementRepairBinding = {
+	session: AnnouncementWorkerSession;
+	controller: AbortController;
+	pending: boolean;
+	targets: Map<string, ReplicationAnnouncementRepairTarget>;
+	cohortSelected: boolean;
+};
+
 export type ReplicationAnnouncementRepairWorkerContext = {
-	generation: number;
+	session: AnnouncementWorkerSession;
 	lifecycleController: AbortController;
-	generationController: AbortController;
+	binding: ReplicationAnnouncementRepairBinding;
 };
 
 export type ReplicationAnnouncementDeps<R extends "u32" | "u64"> = {
@@ -180,7 +211,7 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 		| ReturnType<typeof debounceFixedInterval>
 		| undefined;
 	_replicationAnnouncementRetryPending!: boolean;
-	_replicationAnnouncementRetryGeneration!: number;
+	_announcementSession!: AnnouncementWorkerSession;
 	_replicationAnnouncementRetryController!: AbortController;
 	// Publish local ownership announcements in committed mutation order. This
 	// prevents an older Added message with a delayed transport completion from
@@ -189,38 +220,54 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 	replicationAnnouncementRepairDebounced:
 		| ReturnType<typeof debounceFixedInterval>
 		| undefined;
-	_replicationAnnouncementRepairPending!: boolean;
-	_replicationAnnouncementRepairGeneration!: number;
-	_replicationAnnouncementRepairGenerationController!: AbortController;
-	_replicationAnnouncementRepairTargets!: Map<
-		string,
-		ReplicationAnnouncementRepairTarget
-	>;
-	_replicationAnnouncementRepairCohortSelected!: boolean;
+	_announcementRepairBinding!: ReplicationAnnouncementRepairBinding;
 	_replicationAnnouncementRepairFairCursorHash!: string | undefined;
 	_replicationAnnouncementRepairMaxAttempts!: number;
 	_replicationAnnouncementRepairController!: AbortController;
 
+	// Test-visible compatibility accessors: the SharedLog instance (and the
+	// specs reaching through it) keep reading/writing the repair pending flag
+	// under its historical name.
+	get _replicationAnnouncementRepairPending(): boolean {
+		return this._announcementRepairBinding.pending;
+	}
+	set _replicationAnnouncementRepairPending(pending: boolean) {
+		this._announcementRepairBinding.pending = pending;
+	}
+
 	constructor(private readonly deps: ReplicationAnnouncementDeps<R>) {
 		this._replicationAnnouncementRetryPending = false;
-		this._replicationAnnouncementRetryGeneration = 0;
+		this._announcementSession = new AnnouncementWorkerSession();
 		this._replicationAnnouncementRetryController = new AbortController();
 		this._replicationAnnouncementSendTails = new WeakMap();
-		this._replicationAnnouncementRepairPending = false;
-		this._replicationAnnouncementRepairGeneration = 0;
-		this._replicationAnnouncementRepairGenerationController =
-			new AbortController();
-		this._replicationAnnouncementRepairTargets = new Map();
-		this._replicationAnnouncementRepairCohortSelected = false;
+		this._announcementRepairBinding = this.createRepairBinding(
+			this._announcementSession,
+		);
 		this._replicationAnnouncementRepairFairCursorHash = undefined;
 		this._replicationAnnouncementRepairMaxAttempts =
 			REPLICATION_ANNOUNCEMENT_REPAIR_MAX_ATTEMPTS;
 		this._replicationAnnouncementRepairController = new AbortController();
 	}
 
+	private rotateAnnouncementSession(): AnnouncementWorkerSession {
+		return (this._announcementSession = new AnnouncementWorkerSession());
+	}
+
+	private createRepairBinding(
+		session: AnnouncementWorkerSession,
+	): ReplicationAnnouncementRepairBinding {
+		return {
+			session,
+			controller: new AbortController(),
+			pending: false,
+			targets: new Map(),
+			cohortSelected: false,
+		};
+	}
+
 	resetForOpen(): void {
 		this._replicationAnnouncementRetryPending = false;
-		this._replicationAnnouncementRetryGeneration = 0;
+		this.rotateAnnouncementSession();
 	}
 
 	queueCurrentReplicationStateAnnouncementRetry(error: unknown): boolean {
@@ -274,15 +321,11 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 		}
 		this.replicationAnnouncementRepairDebounced?.close();
 		this._replicationAnnouncementRepairController?.abort();
-		this._replicationAnnouncementRepairGenerationController?.abort();
+		this._announcementRepairBinding?.controller.abort();
 		this._replicationAnnouncementRepairController = new AbortController();
-		this._replicationAnnouncementRepairGenerationController =
-			new AbortController();
-		this._replicationAnnouncementRepairPending = false;
-		this._replicationAnnouncementRepairGeneration =
-			this._replicationAnnouncementRetryGeneration;
-		this._replicationAnnouncementRepairTargets = new Map();
-		this._replicationAnnouncementRepairCohortSelected = false;
+		this._announcementRepairBinding = this.createRepairBinding(
+			this._announcementSession,
+		);
 		this._replicationAnnouncementRepairFairCursorHash = undefined;
 		this._replicationAnnouncementRepairMaxAttempts = maxAttempts;
 		this.replicationAnnouncementRepairDebounced = debounceFixedInterval(
@@ -299,29 +342,24 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 	}
 
 	cancelCurrentReplicationStateAnnouncementRepair(): void {
-		this._replicationAnnouncementRepairPending = false;
+		this._announcementRepairBinding.pending = false;
 		this._replicationAnnouncementRepairController?.abort();
-		this._replicationAnnouncementRepairGenerationController?.abort();
+		this._announcementRepairBinding.controller.abort();
 		this.replicationAnnouncementRepairDebounced?.close();
-		this._replicationAnnouncementRepairTargets?.clear();
+		this._announcementRepairBinding.targets.clear();
 	}
 
 	advanceCurrentReplicationStateAnnouncementRepairGeneration(): void {
-		const generation = this._replicationAnnouncementRetryGeneration;
-		if (generation === this._replicationAnnouncementRepairGeneration) {
+		const session = this._announcementSession;
+		if (session === this._announcementRepairBinding.session) {
 			return;
 		}
 
 		// Abort acknowledged sends carrying the old full-state snapshot before the
 		// primary announcement for the new mutation waits on transport. Otherwise a
 		// stale batch can hold the current state behind DirectStream's seek timeout.
-		this._replicationAnnouncementRepairGenerationController?.abort();
-		this._replicationAnnouncementRepairGenerationController =
-			new AbortController();
-		this._replicationAnnouncementRepairGeneration = generation;
-		this._replicationAnnouncementRepairPending = false;
-		this._replicationAnnouncementRepairTargets.clear();
-		this._replicationAnnouncementRepairCohortSelected = false;
+		this._announcementRepairBinding.controller.abort();
+		this._announcementRepairBinding = this.createRepairBinding(session);
 	}
 
 	queueCurrentReplicationStateAnnouncementRepair(): void {
@@ -342,11 +380,11 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 	/**
 	 * Single validity predicate for announcement-repair workers. "stale":
 	 * the store closed or a lifecycle controller aborted — exit silently.
-	 * "superseded": a newer announcement generation took over — the worker
-	 * must requeue so the current generation gets serviced. The
-	 * generation-controller identity comparison stays at the one call site
-	 * that historically required it; folding it in here is a stage-5
-	 * semantic decision, not a consolidation.
+	 * "superseded": a newer announcement session took over — the worker
+	 * must requeue so the current session gets serviced. The binding
+	 * identity comparison stays at the one call site that historically
+	 * required it; folding it in here is a stage-5 semantic decision, not a
+	 * consolidation.
 	 */
 	private announcementRepairWorkerStatus(
 		worker: ReplicationAnnouncementRepairWorkerContext,
@@ -355,36 +393,34 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 			this.deps.isClosed() ||
 			this.deps.getCloseSignal().aborted ||
 			worker.lifecycleController.signal.aborted ||
-			worker.generationController.signal.aborted
+			worker.binding.controller.signal.aborted
 		) {
 			return "stale";
 		}
-		if (worker.generation !== this._replicationAnnouncementRetryGeneration) {
+		if (worker.session !== this._announcementSession) {
 			return "superseded";
 		}
 		return "current";
 	}
 
 	async runCurrentReplicationStateAnnouncementRepair(): Promise<void> {
-		const generation = this._replicationAnnouncementRetryGeneration;
+		const session = this._announcementSession;
 		const lifecycleController = this._replicationAnnouncementRepairController;
-		const generationController =
-			this._replicationAnnouncementRepairGenerationController;
+		const binding = this._announcementRepairBinding;
 		try {
 			await this.repairCurrentReplicationStateAnnouncement({
-				generation,
+				session,
 				lifecycleController,
-				generationController,
+				binding,
 			});
 		} catch (error) {
 			if (
 				this.announcementRepairWorkerStatus({
-					generation,
+					session,
 					lifecycleController,
-					generationController,
+					binding,
 				}) !== "current" ||
-				generationController !==
-					this._replicationAnnouncementRepairGenerationController
+				binding !== this._announcementRepairBinding
 			) {
 				return;
 			}
@@ -392,10 +428,10 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 				return;
 			}
 
-			// Only the worker that still owns the current generation may conclude
+			// Only the worker that still owns the current session may conclude
 			// that its repair failed. A stale worker must not clear a newer call's
-			// pending flag or attribute its error to the new generation.
-			this._replicationAnnouncementRepairPending = false;
+			// pending flag or attribute its error to the new session.
+			this._announcementRepairBinding.pending = false;
 			logger.error(error);
 		}
 	}
@@ -403,25 +439,22 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 	async repairCurrentReplicationStateAnnouncement(
 		context?: ReplicationAnnouncementRepairWorkerContext,
 	): Promise<void> {
-		if (!this._replicationAnnouncementRepairPending) {
+		if (!this._announcementRepairBinding.pending) {
 			return;
 		}
-		const generation =
-			context?.generation ?? this._replicationAnnouncementRetryGeneration;
+		const session = context?.session ?? this._announcementSession;
 		const lifecycleController =
 			context?.lifecycleController ??
 			this._replicationAnnouncementRepairController;
-		const generationController =
-			context?.generationController ??
-			this._replicationAnnouncementRepairGenerationController;
+		const binding = context?.binding ?? this._announcementRepairBinding;
 		const segments = (await this.deps.getMyReplicationSegments()).map((range) =>
 			range.toReplicationRange(),
 		);
 		switch (
 			this.announcementRepairWorkerStatus({
-				generation,
+				session,
 				lifecycleController,
-				generationController,
+				binding,
 			})
 		) {
 			case "stale":
@@ -435,9 +468,9 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 		const subscribers = (await this.deps.getSubscribers()) ?? [];
 		switch (
 			this.announcementRepairWorkerStatus({
-				generation,
+				session,
 				lifecycleController,
-				generationController,
+				binding,
 			})
 		) {
 			case "stale":
@@ -460,14 +493,14 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 			}
 		}
 
-		for (const [hash, target] of this._replicationAnnouncementRepairTargets) {
-			if (target.generation !== generation || !currentTargets.has(hash)) {
-				this._replicationAnnouncementRepairTargets.delete(hash);
+		for (const [hash, target] of this._announcementRepairBinding.targets) {
+			if (target.session !== session || !currentTargets.has(hash)) {
+				this._announcementRepairBinding.targets.delete(hash);
 			} else {
 				target.key = currentTargets.get(hash)!;
 			}
 		}
-		if (!this._replicationAnnouncementRepairCohortSelected) {
+		if (!this._announcementRepairBinding.cohortSelected) {
 			const candidates = [...currentTargets.entries()].sort(([left], [right]) =>
 				left.localeCompare(right),
 			);
@@ -489,9 +522,9 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 				REPLICATION_ANNOUNCEMENT_REPAIR_TARGETS_PER_GENERATION,
 			);
 			for (const [hash, key] of cohort) {
-				this._replicationAnnouncementRepairTargets.set(hash, {
+				this._announcementRepairBinding.targets.set(hash, {
 					key,
-					generation,
+					session,
 					attempts: 0,
 					done: false,
 				});
@@ -500,12 +533,12 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 				this._replicationAnnouncementRepairFairCursorHash =
 					cohort[cohort.length - 1][0];
 			}
-			this._replicationAnnouncementRepairCohortSelected = true;
+			this._announcementRepairBinding.cohortSelected = true;
 		}
 
-		const batch = [
-			...this._replicationAnnouncementRepairTargets.entries(),
-		].filter(([, target]) => !target.done);
+		const batch = [...this._announcementRepairBinding.targets.entries()].filter(
+			([, target]) => !target.done,
+		);
 		const snapshot = new AllReplicatingSegmentsMessage({ segments });
 		const results = await Promise.allSettled(
 			batch.map(([, target]) =>
@@ -515,15 +548,15 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 						redundancy: 1,
 					}),
 					priority: CONVERGENCE_MESSAGE_PRIORITY,
-					signal: generationController.signal,
+					signal: binding.controller.signal,
 				}),
 			),
 		);
 		switch (
 			this.announcementRepairWorkerStatus({
-				generation,
+				session,
 				lifecycleController,
-				generationController,
+				binding,
 			})
 		) {
 			case "stale":
@@ -535,8 +568,8 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 
 		for (const [index, result] of results.entries()) {
 			const [hash, attemptedTarget] = batch[index];
-			const target = this._replicationAnnouncementRepairTargets.get(hash);
-			if (target !== attemptedTarget || target.generation !== generation) {
+			const target = this._announcementRepairBinding.targets.get(hash);
+			if (target !== attemptedTarget || target.session !== session) {
 				continue;
 			}
 			if (result.status === "fulfilled") {
@@ -562,12 +595,12 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 			}
 		}
 
-		if (generation !== this._replicationAnnouncementRetryGeneration) {
+		if (session !== this._announcementSession) {
 			this.queueCurrentReplicationStateAnnouncementRepair();
 			return;
 		}
 		if (
-			[...this._replicationAnnouncementRepairTargets.values()].some(
+			[...this._announcementRepairBinding.targets.values()].some(
 				(target) => !target.done,
 			)
 		) {
@@ -575,12 +608,12 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 			return;
 		}
 
-		this._replicationAnnouncementRepairPending = false;
-		this._replicationAnnouncementRepairTargets.clear();
+		this._announcementRepairBinding.pending = false;
+		this._announcementRepairBinding.targets.clear();
 	}
 
 	cancelCurrentReplicationStateAnnouncementRetry(): void {
-		this._replicationAnnouncementRetryGeneration += 1;
+		this.rotateAnnouncementSession();
 		this._replicationAnnouncementRetryPending = false;
 		this._replicationAnnouncementRetryController?.abort();
 		this.replicationAnnouncementRetryDebounced?.close();
@@ -612,9 +645,9 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 				}
 				// Advance before every post-mutation send, including successful ones. An
 				// authoritative retry already in flight may have captured the previous
-				// local state; the generation mismatch forces one more current snapshot
+				// local state; the session mismatch forces one more current snapshot
 				// after that stale send settles.
-				this._replicationAnnouncementRetryGeneration += 1;
+				this.rotateAnnouncementSession();
 				this.advanceCurrentReplicationStateAnnouncementRepairGeneration();
 				try {
 					await this.deps.getRpc().send(message, {
@@ -648,7 +681,7 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 	}
 
 	async retryCurrentReplicationStateAnnouncement(): Promise<void> {
-		const generation = this._replicationAnnouncementRetryGeneration;
+		const session = this._announcementSession;
 		const controller = this._replicationAnnouncementRetryController;
 		try {
 			const segments = (await this.deps.getMyReplicationSegments()).map(
@@ -661,7 +694,7 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 			) {
 				return;
 			}
-			if (generation !== this._replicationAnnouncementRetryGeneration) {
+			if (session !== this._announcementSession) {
 				void this.replicationAnnouncementRetryDebounced?.call();
 				return;
 			}
@@ -685,7 +718,7 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 			if (this.queueCurrentReplicationStateAnnouncementRetry(error)) {
 				return;
 			}
-			if (generation === this._replicationAnnouncementRetryGeneration) {
+			if (session === this._announcementSession) {
 				this._replicationAnnouncementRetryPending = false;
 			} else {
 				void this.replicationAnnouncementRetryDebounced?.call();
@@ -704,7 +737,7 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 		// in flight. In that case keep the repair pending so the newer current
 		// state is also announced in full, regardless of whether its incremental
 		// send succeeded or failed.
-		if (generation === this._replicationAnnouncementRetryGeneration) {
+		if (session === this._announcementSession) {
 			this._replicationAnnouncementRetryPending = false;
 			if (
 				!this.deps.isClosed() &&

--- a/packages/programs/data/shared-log/test/lifecycle.spec.ts
+++ b/packages/programs/data/shared-log/test/lifecycle.spec.ts
@@ -90,7 +90,7 @@ describe("lifecycle", () => {
 				await oldSimpleStarted;
 				const runningState =
 					sharedLog.joinWarmup._joinWarmupSendStateByTarget.get("target");
-				const oldGeneration = runningState.generation;
+				const oldGeneration = runningState.session;
 
 				sharedLog.poisonReplicationOwnership(
 					new Error("forced ownership poison"),
@@ -117,9 +117,9 @@ describe("lifecycle", () => {
 				);
 				const reopenedState =
 					sharedLog.joinWarmup._joinWarmupSendStateByTarget.get("target");
-				expect(reopenedState.generation).to.not.equal(oldGeneration);
-				expect(sharedLog.joinWarmup._joinWarmupGenerationByTarget.get("target")).to.equal(
-					reopenedState.generation,
+				expect(reopenedState.session).to.not.equal(oldGeneration);
+				expect(sharedLog.joinWarmup._warmupSessionsByTarget.get("target")).to.equal(
+					reopenedState.session,
 				);
 				expect(maxActiveSimpleSends).to.equal(2);
 
@@ -270,7 +270,7 @@ describe("lifecycle", () => {
 			const drainSubscriptionCallbacks = sinon
 				.stub(sharedLog, "drainSubscriptionChangeCallbacks")
 				.callsFake(async () => {
-					const generation = sharedLog.joinWarmup.getJoinWarmupGeneration(target);
+					const generation = sharedLog.joinWarmup.ensureWarmupSession(target);
 					sharedLog.joinWarmup.scheduleJoinWarmupRetries(
 						target,
 						generation,
@@ -278,7 +278,7 @@ describe("lifecycle", () => {
 						new Map([["late-entry", { hash: "late-entry" }]]),
 						false,
 					);
-					expect(sharedLog.joinWarmup._joinWarmupGenerationByTarget.get(target)).to.equal(
+					expect(sharedLog.joinWarmup._warmupSessionsByTarget.get(target)).to.equal(
 						generation,
 					);
 					expect(sharedLog.joinWarmup._joinWarmupRetryTimersByTarget.has(target)).to.be
@@ -290,7 +290,7 @@ describe("lifecycle", () => {
 				.stub(sharedLog, "drainReceiveHandlers")
 				.callsFake(async () => {
 					expect(
-						sharedLog.joinWarmup._joinWarmupGenerationByTarget.has(target),
+						sharedLog.joinWarmup._warmupSessionsByTarget.has(target),
 					).to.be.false;
 					expect(
 						sharedLog.joinWarmup._joinWarmupRetryTimersByTarget.has(target),

--- a/packages/programs/data/shared-log/test/replication-announcement-retry.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-announcement-retry.spec.ts
@@ -938,4 +938,189 @@ describe("replication announcement retries", () => {
 		expect(nonEmptySnapshots).to.deep.equal([]);
 		expect(log._replicationAnnouncementRetryPending).to.equal(false);
 	});
+
+	it("does not let a repair worker outlive a repair function reconfiguration", async () => {
+		session = await TestSession.disconnected(2);
+		const store = await session.peers[0].open(new EventStore<string, any>(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = store.log as any;
+		useFastAnnouncementRepair(log);
+		const target = session.peers[1].identity.publicKey;
+
+		let releaseStaleCollection!: () => void;
+		const staleCollection = new Promise<any[]>((resolve) => {
+			releaseStaleCollection = () => resolve([target]);
+		});
+		let markStaleCollectionStarted!: () => void;
+		const staleCollectionStarted = new Promise<void>((resolve) => {
+			markStaleCollectionStarted = resolve;
+		});
+		let subscriberCollections = 0;
+		sinon.stub(store.node.services.pubsub, "getSubscribers").callsFake(() => {
+			subscriberCollections += 1;
+			if (subscriberCollections === 1) {
+				markStaleCollectionStarted();
+				return staleCollection;
+			}
+			return [target];
+		});
+		let acknowledgedSnapshots = 0;
+		sinon
+			.stub(store.log.rpc, "send")
+			.callsFake(async (message: any, options?: any) => {
+				if (
+					message instanceof AllReplicatingSegmentsMessage &&
+					options?.mode instanceof AcknowledgeDelivery
+				) {
+					acknowledgedSnapshots += 1;
+				}
+			});
+
+		await store.log.replicate({ factor: 0.25, offset: 0.1 });
+		await staleCollectionStarted;
+
+		// Reconfiguration rotates the repair lifecycle out from under the
+		// in-flight worker without a new mutation generation. The old worker
+		// must neither send an acknowledged snapshot nor clear the
+		// reconfigured state's pending flag.
+		log.setupReplicationAnnouncementRepairFunction(10, 3);
+		log._replicationAnnouncementRepairPending = true;
+
+		releaseStaleCollection();
+		await delay(50);
+		expect(acknowledgedSnapshots).to.equal(0);
+		expect(log._replicationAnnouncementRepairPending).to.equal(true);
+	});
+
+	it("does not let a stale retry clear pending after retry reconfiguration", async () => {
+		const store = await openStore(false);
+		const log = store.log as any;
+		useFastAnnouncementRetry(log);
+
+		const timeout = new TimeoutError("detached shard timed out");
+		let incrementalFailed = false;
+		const snapshots: AllReplicatingSegmentsMessage[] = [];
+		sinon.stub(store.log.rpc, "send").callsFake(async (message: any) => {
+			if (
+				message instanceof AddedReplicationSegmentMessage &&
+				!incrementalFailed
+			) {
+				incrementalFailed = true;
+				throw timeout;
+			}
+			if (message instanceof AllReplicatingSegmentsMessage) {
+				snapshots.push(message);
+			}
+			return [] as any;
+		});
+
+		let hangCollections = false;
+		const heldCollections: (() => void)[] = [];
+		let markFirstCollectionHeld!: () => void;
+		const firstCollectionHeld = new Promise<void>((resolve) => {
+			markFirstCollectionHeld = resolve;
+		});
+		const originalGetSegments = store.log.getMyReplicationSegments.bind(
+			store.log,
+		);
+		sinon.stub(store.log, "getMyReplicationSegments").callsFake(async () => {
+			if (hangCollections) {
+				await new Promise<void>((resolve) => {
+					heldCollections.push(resolve);
+					markFirstCollectionHeld();
+				});
+			}
+			return originalGetSegments();
+		});
+
+		try {
+			try {
+				await store.log.replicate({ factor: 0.25, offset: 0.1 });
+			} catch (error) {
+				expect(error).to.equal(timeout);
+			}
+			expect(log._replicationAnnouncementRetryPending).to.equal(true);
+			hangCollections = true;
+			await firstCollectionHeld;
+
+			// Reconfiguration rotates the retry lifecycle out from under the
+			// in-flight worker; the mutation generation does not change. Queue a
+			// fresh retry into the reconfigured window: the stale worker must not
+			// send its snapshot nor clear the fresh pending flag.
+			log.setupReplicationAnnouncementRetryFunction(10);
+			expect(
+				log.queueCurrentReplicationStateAnnouncementRetry(
+					new TimeoutError("fresh retry after reconfiguration"),
+				),
+			).to.equal(true);
+			expect(log._replicationAnnouncementRetryPending).to.equal(true);
+
+			heldCollections.shift()!();
+			await delay(50);
+			expect(snapshots).to.deep.equal([]);
+			expect(log._replicationAnnouncementRetryPending).to.equal(true);
+		} finally {
+			hangCollections = false;
+			for (const release of heldCollections.splice(0)) {
+				release();
+			}
+		}
+	});
+
+	it("does not let a repair worker from a previous open service the reopened log", async () => {
+		session = await TestSession.disconnected(2);
+		const store = await session.peers[0].open(new EventStore<string, any>(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = store.log as any;
+		useFastAnnouncementRepair(log);
+		const target = session.peers[1].identity.publicKey;
+
+		let releaseStaleCollection!: () => void;
+		const staleCollection = new Promise<any[]>((resolve) => {
+			releaseStaleCollection = () => resolve([target]);
+		});
+		let markStaleCollectionStarted!: () => void;
+		const staleCollectionStarted = new Promise<void>((resolve) => {
+			markStaleCollectionStarted = resolve;
+		});
+		let subscriberCollections = 0;
+		sinon.stub(store.node.services.pubsub, "getSubscribers").callsFake(() => {
+			subscriberCollections += 1;
+			if (subscriberCollections === 1) {
+				markStaleCollectionStarted();
+				return staleCollection;
+			}
+			return [target];
+		});
+		let reopened = false;
+		let reopenedAcknowledgedSnapshots = 0;
+		sinon
+			.stub(store.log.rpc, "send")
+			.callsFake(async (message: any, options?: any) => {
+				if (
+					reopened &&
+					message instanceof AllReplicatingSegmentsMessage &&
+					options?.mode instanceof AcknowledgeDelivery
+				) {
+					reopenedAcknowledgedSnapshots += 1;
+				}
+			});
+
+		await store.log.replicate({ factor: 0.25, offset: 0.1 });
+		await staleCollectionStarted;
+
+		await store.close();
+		await session.peers[0].open(store, {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		reopened = true;
+		log._replicationAnnouncementRepairPending = true;
+
+		releaseStaleCollection();
+		await delay(50);
+		expect(reopenedAcknowledgedSnapshots).to.equal(0);
+		expect(log._replicationAnnouncementRepairPending).to.equal(true);
+	});
 });

--- a/packages/programs/data/shared-log/test/sync-session.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-session.spec.ts
@@ -1,4 +1,5 @@
 import { Cache } from "@peerbit/cache";
+import { TestSession } from "@peerbit/test-utils";
 import { expect } from "chai";
 import sinon from "sinon";
 import { SharedLog } from "../src/index.js";
@@ -6,6 +7,7 @@ import {
 	RequestMaybeSyncCoordinate,
 	SimpleSyncronizer,
 } from "../src/sync/simple.js";
+import { EventStore } from "./utils/stores/index.js";
 
 const emptyLog = {
 	has: async () => false,
@@ -451,7 +453,7 @@ describe("sync-repair-session", () => {
 			expect(simpleEntryBatches).to.deep.equal([["old"]]);
 
 			const disconnectedGeneration =
-				internals.joinWarmup._joinWarmupGenerationByTarget.get("target");
+				internals.joinWarmup._warmupSessionsByTarget.get("target");
 			internals.removeRepairFrontierTarget("target");
 			expect(internals.joinWarmup._joinWarmupRetryTimersByTarget.size).to.equal(0);
 			internals.dispatchMaybeMissingEntries(
@@ -465,14 +467,14 @@ describe("sync-repair-session", () => {
 			);
 			await clock.tickAsync(10);
 			const reconnectedGeneration =
-				internals.joinWarmup._joinWarmupGenerationByTarget.get("target");
+				internals.joinWarmup._warmupSessionsByTarget.get("target");
 			internals.removeRepairFrontierTarget("target", {
-				expectedJoinWarmupGeneration: disconnectedGeneration,
+				expectedWarmupSession: disconnectedGeneration,
 			});
 
 			expect(simpleEntryBatches).to.deep.equal([["old"]]);
 			expect(maxActiveSimpleSends).to.equal(1);
-			expect(internals.joinWarmup._joinWarmupGenerationByTarget.get("target")).to.equal(
+			expect(internals.joinWarmup._warmupSessionsByTarget.get("target")).to.equal(
 				reconnectedGeneration,
 			);
 			expect([
@@ -623,12 +625,12 @@ describe("sync-repair-session", () => {
 		log.closed = false;
 		const internals = log as any;
 		internals._repairSweepRunning = true;
-		const oldGeneration = internals.joinWarmup.getJoinWarmupGeneration("target");
+		const oldGeneration = internals.joinWarmup.ensureWarmupSession("target");
 		internals.joinWarmup.cancelJoinWarmupTarget("target");
-		const currentGeneration = internals.joinWarmup.getJoinWarmupGeneration("target");
+		const currentGeneration = internals.joinWarmup.ensureWarmupSession("target");
 
 		internals.scheduleRepairSweep({
-			joinWarmupGenerations: new Map([["target", oldGeneration]]),
+			warmupSessions: new Map([["target", oldGeneration]]),
 			mode: "join-warmup",
 			peers: ["target"],
 		});
@@ -638,7 +640,7 @@ describe("sync-repair-session", () => {
 		expect(internals._repairSweepPendingModes.has("join-warmup")).to.be.false;
 
 		internals.scheduleRepairSweep({
-			joinWarmupGenerations: new Map([["target", currentGeneration]]),
+			warmupSessions: new Map([["target", currentGeneration]]),
 			mode: "join-warmup",
 			peers: ["target"],
 		});
@@ -646,7 +648,7 @@ describe("sync-repair-session", () => {
 			internals._repairSweepPendingPeersByMode.get("join-warmup").has("target"),
 		).to.be.true;
 		expect(
-			internals.joinWarmup._repairSweepJoinWarmupGenerationByTarget.get("target"),
+			internals.joinWarmup._repairSweepWarmupSessionByTarget.get("target"),
 		).to.equal(currentGeneration);
 
 		internals.joinWarmup.cancelJoinWarmupTarget("target");
@@ -686,11 +688,11 @@ describe("sync-repair-session", () => {
 			.stub(internals, "getFullReplicaRepairCandidates")
 			.resolves(new Set(["self", "target"]));
 		const dispatch = sinon.stub(internals, "dispatchMaybeMissingEntries");
-		const oldGeneration = internals.joinWarmup.getJoinWarmupGeneration("target");
+		const oldGeneration = internals.joinWarmup.ensureWarmupSession("target");
 		internals.markRepairSweepOptimisticPeer("gid", "target", oldGeneration);
 		internals._repairSweepPendingModes.add("join-warmup");
 		internals._repairSweepPendingPeersByMode.get("join-warmup").add("target");
-		internals.joinWarmup._repairSweepJoinWarmupGenerationByTarget.set(
+		internals.joinWarmup._repairSweepWarmupSessionByTarget.set(
 			"target",
 			oldGeneration,
 		);
@@ -699,18 +701,18 @@ describe("sync-repair-session", () => {
 		const running = internals.runRepairSweep();
 		await planEntered;
 		internals.joinWarmup.cancelJoinWarmupTarget("target");
-		const newGeneration = internals.joinWarmup.getJoinWarmupGeneration("target");
+		const newGeneration = internals.joinWarmup.ensureWarmupSession("target");
 		internals.markRepairSweepOptimisticPeer("gid", "target", newGeneration);
 		releasePlan();
 		await running;
 
 		expect(dispatch.called).to.be.false;
-		expect(internals.joinWarmup._joinWarmupGenerationByTarget.get("target")).to.equal(
+		expect(internals.joinWarmup._warmupSessionsByTarget.get("target")).to.equal(
 			newGeneration,
 		);
 		expect(
 			internals._repairSweepOptimisticGidPeersPending.get("gid").get("target"),
-		).to.deep.equal({ count: 1, generation: newGeneration });
+		).to.deep.equal({ count: 1, session: newGeneration });
 		expect(
 			internals._repairSweepOptimisticGidsByPeer.get("target"),
 		).to.deep.equal(new Set(["gid"]));
@@ -767,15 +769,15 @@ describe("sync-repair-session", () => {
 
 			await trimEntered;
 			const oldGeneration =
-				internals.joinWarmup._joinWarmupGenerationByTarget.get("target");
+				internals.joinWarmup._warmupSessionsByTarget.get("target");
 			expect(oldGeneration).to.be.an("object");
 			internals.joinWarmup.cancelJoinWarmupTarget("target");
-			const newGeneration = internals.joinWarmup.getJoinWarmupGeneration("target");
+			const newGeneration = internals.joinWarmup.ensureWarmupSession("target");
 			releaseTrim!();
 			await changing;
 			await clock.tickAsync(250);
 
-			expect(internals.joinWarmup._joinWarmupGenerationByTarget.get("target")).to.equal(
+			expect(internals.joinWarmup._warmupSessionsByTarget.get("target")).to.equal(
 				newGeneration,
 			);
 			expect(
@@ -1033,5 +1035,43 @@ describe("sync-repair-session", () => {
 		expect(result[0]!.requestedTotal).to.equal(3);
 		expect(result[0]!.truncated).to.equal(true);
 		expect(result[0]!.unresolved).to.have.length(1);
+	});
+
+	it("scopes removeReplicator warmup cancellation to the captured warmup generation", async () => {
+		const testSession = await TestSession.disconnected(2);
+		try {
+			const store = await testSession.peers[0].open(
+				new EventStore<string, any>(),
+				{
+					args: { replicate: false, timeUntilRoleMaturity: 0 },
+				},
+			);
+			const log = store.log as any;
+			const peerHash = testSession.peers[1].identity.publicKey.hashcode();
+
+			const disconnectedGeneration =
+				log.joinWarmup.ensureWarmupSession(peerHash);
+			// Reconnect: the disconnected warmup window is cancelled and a fresh
+			// one is minted before the scoped removal commits.
+			log.joinWarmup.cancelJoinWarmupTarget(peerHash);
+			const reconnectedGeneration =
+				log.joinWarmup.ensureWarmupSession(peerHash);
+			expect(reconnectedGeneration).to.not.equal(disconnectedGeneration);
+
+			await log.removeReplicator(peerHash, {
+				expectedWarmupSession: disconnectedGeneration,
+			});
+			expect(
+				log.joinWarmup._warmupSessionsByTarget.get(peerHash),
+			).to.equal(reconnectedGeneration);
+
+			await log.removeReplicator(peerHash, {
+				expectedWarmupSession: reconnectedGeneration,
+			});
+			expect(log.joinWarmup._warmupSessionsByTarget.has(peerHash)).to.be
+				.false;
+		} finally {
+			await testSession.stop();
+		}
 	});
 });

--- a/scripts/ci/check-fence-ratchet.mjs
+++ b/scripts/ci/check-fence-ratchet.mjs
@@ -50,14 +50,7 @@ const TARGETS = new Map([
 			"_repairSweepJoinWarmupGenerationByTarget",
 		],
 	],
-	[
-		"packages/programs/data/shared-log/src/replication-announcement.ts",
-		[
-			"_replicationAnnouncementRepairGeneration",
-			"_replicationAnnouncementRepairGenerationController",
-			"_replicationAnnouncementRetryGeneration",
-		],
-	],
+	["packages/programs/data/shared-log/src/replication-announcement.ts", []],
 	["packages/programs/data/shared-log/src/replicator-liveness.ts", []],
 	["packages/programs/data/shared-log/src/sync/factory.ts", []],
 ]);

--- a/scripts/ci/check-fence-ratchet.mjs
+++ b/scripts/ci/check-fence-ratchet.mjs
@@ -43,13 +43,7 @@ const TARGETS = new Map([
 		"packages/programs/data/shared-log/src/peer-session.ts",
 		["_receiveCleanupGateByPeer", "_replicationInfoReceiveEpochByPeer"],
 	],
-	[
-		"packages/programs/data/shared-log/src/join-warmup.ts",
-		[
-			"_joinWarmupGenerationByTarget",
-			"_repairSweepJoinWarmupGenerationByTarget",
-		],
-	],
+	["packages/programs/data/shared-log/src/join-warmup.ts", []],
 	["packages/programs/data/shared-log/src/replication-announcement.ts", []],
 	["packages/programs/data/shared-log/src/replicator-liveness.ts", []],
 	["packages/programs/data/shared-log/src/sync/factory.ts", []],


### PR DESCRIPTION
First stage-4 PR (stage 3 completed in #1174–#1177). **Five fence deletions** — the largest single reduction of the migration — replacing the two remaining generation-number families with session identity.

## Part a: the announcement E-cluster (3 fences deleted)

`AnnouncementWorkerSession` identity replaces `_replicationAnnouncementRetryGeneration`; a single `ReplicationAnnouncementRepairBinding` object (session + controller + pending + targets + cohortSelected) replaces the five-field repair compound — the densest fence cluster in the original map, whose validity predicate was once hand-maintained in four divergent subsets, is now one object with one identity. Every abort order, rotation point, and error identity preserved verbatim (edit-table-driven); the ctor's generation-0 adoption becomes binding-bound-to-same-session; cancel keeps its abort-without-rotation semantics. Test-visible `_replicationAnnouncementRepairPending` survives via an accessor chain (grep-verified end-to-end through the `as any` reach-ins).

## Part b: warmup sessions (2 fences deleted)

Per-target `WarmupSession` objects replace the opaque-generation maps, coordinator-keyed (rotation is cancel/reconnect-driven, independent of subscription epochs). `removeReplicator`'s capture keeps its non-minting raw-get semantics; the sweep's snapshot-and-clear is byte-preserved. One API-visible option rename: `expectedJoinWarmupGeneration` → `expectedWarmupSession` (internal/test-only surface).

## Pins and review

Four pin tests landed green against pre-migration code before the edits applied; P1 and P4 mutation-tested post-migration (both kill their mutations). Adversarial review: **zero confirmed defects**; the one genuine identity-vs-number divergence — the resetForOpen→setup window where advance always rotates where old code could early-return on generation-0 aliasing — was traced and proven unobservable (and the aliasing it removes was itself a legacy hazard). Dead helper flagged by review removed.

## Validation

21-suite sweep 0 failing; full chaos green; ratchet **17 → 12** with the `replication-announcement.ts` and `join-warmup.ts` baselines now empty — two modules fully fence-free; lint/tsc strict/shard-coverage/contracts all pass.

Next: stage-4 PR-2 (B-group stragglers incl. the watermark deletion with its pin) and PR-3 (physical controller relocation).