### PR TITLE
refactor(shared-log): stage-4 PR-2 — B-group stragglers

### DIFF
--- a/packages/programs/data/shared-log/src/checked-prune.ts
+++ b/packages/programs/data/shared-log/src/checked-prune.ts
@@ -79,6 +79,41 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 	private readonly peerRemovalFences = new Map<string, number>();
 	private readonly restartReservations = new Map<string, object>();
 	private readonly candidateTokens = new Map<string, object>();
+	// Moved from SharedLog (same name — the sanctioned file-to-file ratchet
+	// move). Depth of checked-prune removals currently holding the ownership
+	// lane across a lower-log `log.remove` whose program onChange callback
+	// re-enters this instance: while non-zero, invokeProgramOnChange
+	// classifies removal-bearing changes as checked-prune-driven. Reset comes
+	// free with the per-open coordinator replacement (index.ts open() creates
+	// a fresh coordinator); deliberately NOT touched by close() — the release
+	// closures drain it, matching the legacy host counter which was reset
+	// only at open.
+	private _checkedPruneRemoveBlocksLocalRangeMutationAdmission = 0;
+
+	/** ≡ the legacy inc / `finally`-dec pair around the admitted lower-log
+	 *  remove (old SharedLog site, one synchronous block from the admission
+	 *  checks). The returned release is idempotent and drains THIS coordinator
+	 *  instance — a release that survives into a later open decrements the
+	 *  retired coordinator, never the fresh one (the legacy global counter
+	 *  could go to −1 in that window; unreachable today because close() awaits
+	 *  the prune-remove terminal fence before open() can begin, but the
+	 *  instance scoping makes the proof unnecessary and future-caller-proof). */
+	blockLocalRangeMutation(): () => void {
+		this._checkedPruneRemoveBlocksLocalRangeMutationAdmission += 1;
+		let released = false;
+		return () => {
+			if (released) {
+				return;
+			}
+			released = true;
+			this._checkedPruneRemoveBlocksLocalRangeMutationAdmission -= 1;
+		};
+	}
+
+	/** ≡ the legacy `counter !== 0` read (site: invokeProgramOnChange). */
+	isBlockingLocalRangeMutation(): boolean {
+		return this._checkedPruneRemoveBlocksLocalRangeMutationAdmission > 0;
+	}
 
 	private getOrCreateSession(hash: string): CheckedPruneSession<T, R> {
 		let session = this.sessions.get(hash);

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2028,9 +2028,10 @@ export class SharedLog<
 	private _replicationRangeMutationTail: Promise<void> = Promise.resolve();
 	private _replicationRangeMutationsClosing = false;
 	// Log.remove awaits program onChange callbacks before its physical delete.
-	// Track when checked prune holds the ownership lane across that lower-log
-	// removal so the callback wrapper can identify its direct invocation.
-	private _checkedPruneRemoveBlocksLocalRangeMutationAdmission = 0;
+	// The counter tracking when checked prune holds the ownership lane across
+	// that lower-log removal lives on the CheckedPruneCoordinator
+	// (blockLocalRangeMutation / isBlockingLocalRangeMutation) so the callback
+	// wrapper can identify its direct invocation.
 	// Reject public local role/terminal operations invoked directly by that
 	// program callback rather than letting it await the lane that is awaiting the
 	// callback. Keep the guard for the callback's full async lifetime: a callback
@@ -13800,7 +13801,11 @@ export class SharedLog<
 		this.ensureNativeDurabilityRuntimeState();
 		this._nativeStrictDurableTransactionsClosing = false;
 		this._replicationRangeMutationsClosing = false;
-		this._checkedPruneRemoveBlocksLocalRangeMutationAdmission = 0;
+		// The legacy `_checkedPruneRemoveBlocksLocalRangeMutationAdmission = 0`
+		// reset that sat here comes free with the fresh CheckedPruneCoordinator
+		// created below: the counter physically lives on it now, and nothing
+		// between this point and that creation invokes invokeProgramOnChange
+		// (its only reader) or any log mutation.
 		this._checkedPruneRemovalCallbackInvocationDepth = 0;
 		// The legacy `_receiveOwnershipRevision = 0` and
 		// `_receiveOwnershipMutationAdmissions = 0` resets that sat here come
@@ -23395,7 +23400,7 @@ export class SharedLog<
 		}
 		if (
 			change.removed.length === 0 ||
-			this._checkedPruneRemoveBlocksLocalRangeMutationAdmission === 0
+			!this._checkedPrune.isBlockingLocalRangeMutation()
 		) {
 			return onChange(change);
 		}
@@ -24801,7 +24806,8 @@ export class SharedLog<
 										checkedPruneCoordinator.clearConfirmedReplicators(
 											entry.hash,
 										);
-										this._checkedPruneRemoveBlocksLocalRangeMutationAdmission++;
+										const releaseLocalRangeMutationBlock =
+											checkedPruneCoordinator.blockLocalRangeMutation();
 										try {
 											await this.trackAdmittedPruneRemove(
 												() =>
@@ -24811,8 +24817,7 @@ export class SharedLog<
 												ownershipLifecycleController,
 											);
 										} finally {
-											this
-												._checkedPruneRemoveBlocksLocalRangeMutationAdmission--;
+											releaseLocalRangeMutationBlock();
 										}
 										if (
 											!checkedPruneCoordinator.markDone(entry.hash, pending)

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2015,10 +2015,9 @@ export class SharedLog<
 	pendingMaturity!: Map<string, Map<string, PendingMaturityRecord<R>>>; // map of peerId to timeout
 
 	private latestReplicationInfoMessage!: Map<string, bigint>;
-	// Peers that have unsubscribed from this log's topic. We ignore replication-info
-	// messages from them until we see a new subscription, to avoid re-introducing
-	// stale membership state during close/unsubscribe races.
-	private _replicationInfoBlockedPeers!: Set<string>;
+	// The replication-info blocked set (fence B5) lives on the peer-session
+	// registry: unsubscribed peers whose replication-info is ignored until a
+	// reconnect barrier commits. See PeerSessionRegistry._replicationInfoBlockedPeers.
 	private _replicationInfoRequestByPeer!: Map<
 		string,
 		{ attempts: number; timer?: ReturnType<typeof setTimeout> }
@@ -3345,7 +3344,7 @@ export class SharedLog<
 				this.validatePersistedReplicationRangeSnapshot(ranges),
 			getSubscribers: () => this.node.services.pubsub.getSubscribers(this.topic),
 			getSelfHash: () => this.node.identity.publicKey.hashcode(),
-			isBlockedPeer: (hash) => this._replicationInfoBlockedPeers.has(hash),
+			isBlockedPeer: (hash) => this._peerSessions.isReplicationInfoBlocked(hash),
 			getRpc: () => this.rpc,
 			captureReplicationOwnershipLifecycle: () =>
 				this.captureReplicationOwnershipLifecycle(),
@@ -3387,7 +3386,7 @@ export class SharedLog<
 					}),
 				);
 			},
-			isBlockedPeer: (hash) => this._replicationInfoBlockedPeers.has(hash),
+			isBlockedPeer: (hash) => this._peerSessions.isReplicationInfoBlocked(hash),
 			scheduleReplicationInfoRequests: (peer, replicationLifecycleController) =>
 				this.scheduleReplicationInfoRequests(
 					peer,
@@ -3408,8 +3407,6 @@ export class SharedLog<
 				this.isReplicationLifecycleActive(controller),
 			getReplicationLifecycleController: () =>
 				this._replicationLifecycleController,
-			isReplicationInfoBlocked: (hash) =>
-				this._replicationInfoBlockedPeers.has(hash),
 		});
 	}
 
@@ -3442,9 +3439,11 @@ export class SharedLog<
 		this._pendingIHave = new Map();
 		this._pendingIHaveCallbacks = new Set();
 		this.latestReplicationInfoMessage = new Map();
-		this._replicationInfoBlockedPeers = new Set();
 		this._replicationInfoRequestByPeer = new Map();
 		this._replicationInfoApplyQueueByPeer = new Map();
+		// The registry constructor runs resetForOpen(), which creates the
+		// replication-info blocked set (fence B5) alongside the session maps —
+		// the legacy inline `new Set()` that sat above moved there.
 		this._peerSessions = this.createPeerSessionRegistry();
 		this._pendingReplicatorLeaveByPeer = new Set();
 		this._activeReceiveHandlersByPeer = new Map();
@@ -13862,7 +13861,6 @@ export class SharedLog<
 		this._pendingIHave = new Map();
 		this._pendingIHaveCallbacks = new Set();
 		this.latestReplicationInfoMessage = new Map();
-		this._replicationInfoBlockedPeers = new Set();
 		this._replicationInfoRequestByPeer = new Map();
 		// Terminal close/drop drains the previous lifecycle before another open can
 		// install fresh lanes and opaque per-subscription ownership tokens.
@@ -13871,9 +13869,11 @@ export class SharedLog<
 		// registry lazily on first open. Reopens keep the SAME registry so stale
 		// continuations observe resetForOpen()'s map swap via property lookup.
 		// resetForOpen also replaces the per-peer receive-epoch and receive
-		// cleanup-gate maps, matching the legacy open()-time
-		// `_replicationInfoReceiveEpochByPeer = new Map()` and
-		// `_receiveCleanupGateByPeer = new Map()`.
+		// cleanup-gate maps and the replication-info blocked set (fence B5),
+		// matching the legacy open()-time
+		// `_replicationInfoReceiveEpochByPeer = new Map()`,
+		// `_receiveCleanupGateByPeer = new Map()` and
+		// `_replicationInfoBlockedPeers = new Set()`.
 		this._peerSessions ??= this.createPeerSessionRegistry();
 		this._peerSessions.resetForOpen();
 		this._pendingReplicatorLeaveByPeer = new Set();
@@ -15290,7 +15290,7 @@ export class SharedLog<
 											replicationLifecycleController,
 										) ||
 										this.closed ||
-										this._replicationInfoBlockedPeers.has(keyHash)
+										this._peerSessions.isReplicationInfoBlocked(keyHash)
 									) {
 										return;
 									}
@@ -15303,7 +15303,7 @@ export class SharedLog<
 										!this.isReplicationLifecycleActive(
 											replicationLifecycleController,
 										) ||
-										this._replicationInfoBlockedPeers.has(keyHash)
+										this._peerSessions.isReplicationInfoBlocked(keyHash)
 									) {
 										return;
 									}
@@ -19010,7 +19010,7 @@ export class SharedLog<
 					// window state is exact: the legacy re-read of the opening map here
 					// could never observe a different value.
 					if (
-						this._replicationInfoBlockedPeers.has(receiveFromHash) &&
+						this._peerSessions.isReplicationInfoBlocked(receiveFromHash) &&
 						isOpeningSubscriptionReceive
 					) {
 						// A prior unsubscribe cleanup may still be ahead of this reconnect
@@ -19162,7 +19162,7 @@ export class SharedLog<
 						receiveFromHash,
 						receiveReplicationInfoReceiveEpoch,
 					) ||
-					this._replicationInfoBlockedPeers.has(fromHash)
+					this._peerSessions.isReplicationInfoBlocked(fromHash)
 				) {
 					return;
 				}
@@ -19183,7 +19183,7 @@ export class SharedLog<
 								fromHash,
 								receiveReplicationInfoReceiveEpoch,
 							) ||
-							this._replicationInfoBlockedPeers.has(fromHash)
+							this._peerSessions.isReplicationInfoBlocked(fromHash)
 						) {
 							return;
 						}
@@ -19250,7 +19250,7 @@ export class SharedLog<
 						receiveFromHash,
 						receiveReplicationInfoReceiveEpoch,
 					) ||
-					this._replicationInfoBlockedPeers.has(fromHash)
+					this._peerSessions.isReplicationInfoBlocked(fromHash)
 				) {
 					return;
 				}
@@ -19267,7 +19267,7 @@ export class SharedLog<
 							fromHash,
 							receiveReplicationInfoReceiveEpoch,
 						) ||
-						this._replicationInfoBlockedPeers.has(fromHash)
+						this._peerSessions.isReplicationInfoBlocked(fromHash)
 					) {
 						return;
 					}
@@ -24082,7 +24082,7 @@ export class SharedLog<
 			// subscription, then wait behind every queued replication mutation. A
 			// reconnect must not inherit metadata or ranges from the old connection.
 			try {
-				this._replicationInfoBlockedPeers.add(peerHash);
+				this._peerSessions.blockReplicationInfo(peerHash);
 				await this.drainPeerReceiveHandlers(peerHash);
 				await this.withReplicationInfoApplyQueue(peerHash, async () => {});
 				if (
@@ -24105,7 +24105,7 @@ export class SharedLog<
 					);
 					this._openingSyncCapabilitiesByPeer.delete(peerHash);
 				}
-				this._replicationInfoBlockedPeers.delete(peerHash);
+				this._peerSessions.unblockReplicationInfo(peerHash);
 			} finally {
 				if (
 					this._openingSyncCapabilitiesByPeer.get(peerHash)?.epoch ===
@@ -24127,7 +24127,7 @@ export class SharedLog<
 			// superseded — readers key off the CURRENT session, so that flag is
 			// unreachable, and its own barrier `finally` still clears it.
 			this._openingSyncCapabilitiesByPeer.delete(peerHash);
-			this._replicationInfoBlockedPeers.add(peerHash);
+			this._peerSessions.blockReplicationInfo(peerHash);
 			const disconnectedWarmupSession =
 				this.joinWarmup._warmupSessionsByTarget.get(peerHash) ?? null;
 			this.joinWarmup.cancelJoinWarmupTarget(peerHash);
@@ -24177,7 +24177,7 @@ export class SharedLog<
 			return;
 		}
 
-		this._replicationInfoBlockedPeers.delete(peerHash);
+		this._peerSessions.unblockReplicationInfo(peerHash);
 		this._replicatorLivenessFailures.delete(peerHash);
 		this.markReplicatorActivity(peerHash);
 		this._peerSessions.markOpen(peerHash, expectedSubscriptionEpoch);
@@ -24778,7 +24778,7 @@ export class SharedLog<
 										for (const peer of exactConfirmations) {
 											if (
 												finalOwnership.leaders.has(peer) &&
-												!this._replicationInfoBlockedPeers.has(peer) &&
+												!this._peerSessions.isReplicationInfoBlocked(peer) &&
 												this._peerSessions.isReceiveCleanupGateOpen(peer)
 											) {
 												finalConfirmationCount += 1;
@@ -25687,7 +25687,7 @@ export class SharedLog<
 			fromHash,
 			"departing",
 		);
-		this._replicationInfoBlockedPeers.add(fromHash);
+		this._peerSessions.blockReplicationInfo(fromHash);
 		this._recentRepairDispatch.delete(fromHash);
 
 		// Keep a per-peer timestamp watermark when we observe an unsubscribe. This
@@ -25721,7 +25721,7 @@ export class SharedLog<
 		const fromHash = evt.detail.from.hashcode();
 		const subscriptionEpoch = this.advanceSubscriptionEpoch(fromHash);
 		this.remoteBlocks.onReachable(evt.detail.from);
-		this._replicationInfoBlockedPeers.add(fromHash);
+		this._peerSessions.blockReplicationInfo(fromHash);
 		this.invalidateSharedLogTopicSubscribersCache();
 
 		await this.handleSubscriptionChange(

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2014,6 +2014,20 @@ export class SharedLog<
 	// public key hash to range id to range
 	pendingMaturity!: Map<string, Map<string, PendingMaturityRecord<R>>>; // map of peerId to timeout
 
+	// Stage-4 KEEP-OLD verdict (fence B8, split by role). The watermark's
+	// FENCING role — rejecting late replication-info across unsubscribe and
+	// eviction races — is fully subsumed by the per-peer receive epoch plus
+	// the blocked set and session identity: every unsubscribe-path `now` write
+	// is preceded in the same synchronous block by a blocked-add, so an
+	// admitted handler can never observe one. Its intra-epoch ORDERING role is
+	// NOT subsumed: within one (lifecycle, session, epoch, unblocked) regime
+	// the epoch token is constant across every message from the peer, so only
+	// the two apply-lane timestamp comparisons can drop an older reset
+	// delivered after a newer add (unordered pubsub / retransmits) — an
+	// identity token carries no order. Deletion is blocked until
+	// replication-info messages carry sender-authoritative sequence numbers
+	// (stage-5 schema change); the `receive admission replication-info
+	// ordering watermark` pins fail if the read sites are removed before then.
 	private latestReplicationInfoMessage!: Map<string, bigint>;
 	// The replication-info blocked set (fence B5) lives on the peer-session
 	// registry: unsubscribed peers whose replication-info is ignored until a

--- a/packages/programs/data/shared-log/src/peer-session.ts
+++ b/packages/programs/data/shared-log/src/peer-session.ts
@@ -22,7 +22,6 @@ export type PeerSessionDeps = {
 		controller: AbortController | undefined,
 	) => boolean;
 	getReplicationLifecycleController: () => AbortController | undefined;
-	isReplicationInfoBlocked: (peerHash: string) => boolean;
 };
 
 export type PeerReceiveAdmissionOptions = {
@@ -136,6 +135,22 @@ export class PeerSessionRegistry {
 	// would reopen receive admission mid-drain. The map instance is replaced
 	// only at open (resetForOpen) and cleared in place at _close.
 	_receiveCleanupGateByPeer!: Map<string, number>;
+	// Moved from SharedLog (fence B5, same name). Peers whose replication-info
+	// is fenced: added when a departure/unsubscribe rotation or a reconnect
+	// barrier starts, removed only when an opening barrier commits. Per-PEER,
+	// not per-session, on purpose (same reasoning as B2/B6 above): the block
+	// is set under one session (the departing rotation) and cleared under a
+	// LATER one (the opening barrier), so its lifetime deliberately spans
+	// session identities; readers (prune final-confirmation filter,
+	// announcement repair targeting, pruneOfflineReplicators) ask about peers
+	// that may have no session at all; and the `??`-fallback rotation in
+	// handleSubscriptionChange rotates WITHOUT touching blocked state — a
+	// per-session flag would silently reset it there. Replaced only at open
+	// (resetForOpen); deliberately NOT cleared at _close, matching the legacy
+	// host field site-for-site. Kept as a public field so existing tests can
+	// keep instrumenting the raw Set instance (events.spec.ts spies on its
+	// `delete`).
+	_replicationInfoBlockedPeers!: Set<string>;
 
 	constructor(readonly deps: PeerSessionDeps) {
 		this.resetForOpen();
@@ -152,6 +167,23 @@ export class PeerSessionRegistry {
 		this.sessions = new Map();
 		this._replicationInfoReceiveEpochByPeer = new Map();
 		this._receiveCleanupGateByPeer = new Map();
+		this._replicationInfoBlockedPeers = new Set();
+	}
+
+	/** ≡ the legacy `this._replicationInfoBlockedPeers.add(peerHash)` (host
+	 *  Set, fence B5). */
+	blockReplicationInfo(peerHash: string): void {
+		this._replicationInfoBlockedPeers.add(peerHash);
+	}
+
+	/** ≡ the legacy `this._replicationInfoBlockedPeers.delete(peerHash)`. */
+	unblockReplicationInfo(peerHash: string): void {
+		this._replicationInfoBlockedPeers.delete(peerHash);
+	}
+
+	/** ≡ the legacy `this._replicationInfoBlockedPeers.has(peerHash)`. */
+	isReplicationInfoBlocked(peerHash: string): boolean {
+		return this._replicationInfoBlockedPeers.has(peerHash);
 	}
 
 	/** _close counterpart of the legacy
@@ -298,7 +330,7 @@ export class PeerSessionRegistry {
 			this.deps.isReplicationLifecycleActive(replicationLifecycleController) &&
 			this.isCurrent(peerHash, session) &&
 			(options?.allowReplicationInfoBlocked === true ||
-				!this.deps.isReplicationInfoBlocked(peerHash)) &&
+				!this.isReplicationInfoBlocked(peerHash)) &&
 			(options?.allowCleanupGate === true ||
 				this.isReceiveCleanupGateOpen(peerHash))
 		);

--- a/packages/programs/data/shared-log/test/checked-prune-coordinator.spec.ts
+++ b/packages/programs/data/shared-log/test/checked-prune-coordinator.spec.ts
@@ -387,4 +387,38 @@ describe("checked prune coordinator", () => {
 		expect(coordinator.requestIPruneSent.size).equal(0);
 		expect(coordinator.responseReplicatorSet.size).equal(0);
 	});
+
+	it("local-range-mutation block release is idempotent and instance-scoped", () => {
+		const coordinator = new CheckedPruneCoordinator<Uint8Array, "u32">();
+		expect(coordinator.isBlockingLocalRangeMutation()).to.be.false;
+
+		const releaseFirst = coordinator.blockLocalRangeMutation();
+		const releaseSecond = coordinator.blockLocalRangeMutation();
+		expect(coordinator.isBlockingLocalRangeMutation()).to.be.true;
+
+		releaseFirst();
+		// Idempotent: a double release must not decrement twice.
+		releaseFirst();
+		expect(coordinator.isBlockingLocalRangeMutation()).to.be.true;
+
+		// close() must NOT zero the counter — the legacy host counter was reset
+		// only at open; the release closures are the only drain.
+		coordinator.close();
+		expect(coordinator.isBlockingLocalRangeMutation()).to.be.true;
+
+		releaseSecond();
+		expect(coordinator.isBlockingLocalRangeMutation()).to.be.false;
+
+		// A release captured from one coordinator drains that instance only: a
+		// straddling release must never drive a fresh open's counter negative.
+		const retired = new CheckedPruneCoordinator<Uint8Array, "u32">();
+		const straddlingRelease = retired.blockLocalRangeMutation();
+		const fresh = new CheckedPruneCoordinator<Uint8Array, "u32">();
+		const freshRelease = fresh.blockLocalRangeMutation();
+		straddlingRelease();
+		expect(retired.isBlockingLocalRangeMutation()).to.be.false;
+		expect(fresh.isBlockingLocalRangeMutation()).to.be.true;
+		freshRelease();
+		expect(fresh.isBlockingLocalRangeMutation()).to.be.false;
+	});
 });

--- a/packages/programs/data/shared-log/test/checked-prune-handoff.spec.ts
+++ b/packages/programs/data/shared-log/test/checked-prune-handoff.spec.ts
@@ -407,7 +407,7 @@ describe("checked prune correlated handoff", () => {
 					).true,
 			);
 			const pending = log._checkedPrune.getPendingDelete(entry.hash);
-			log._replicationInfoBlockedPeers.add(remoteHash);
+			log._peerSessions._replicationInfoBlockedPeers.add(remoteHash);
 			// Model a response that was already admitted by the receive handler just
 			// before unsubscribe blocked the peer. The final in-lane boundary must
 			// still exclude that peer from the destructive quorum.
@@ -417,7 +417,7 @@ describe("checked prune correlated handoff", () => {
 			expect(remove.called).false;
 			expect(await log.log.has(entry.hash)).true;
 		} finally {
-			log._replicationInfoBlockedPeers.delete(remoteHash);
+			log._peerSessions._replicationInfoBlockedPeers.delete(remoteHash);
 			await log.cancelCheckedPruneForLocalLeader(entry.hash).catch(() => {});
 			await Promise.allSettled(pruning ? [pruning] : []);
 			remove.restore();

--- a/packages/programs/data/shared-log/test/events.spec.ts
+++ b/packages/programs/data/shared-log/test/events.spec.ts
@@ -4252,7 +4252,7 @@ describe("events", () => {
 			});
 			await Promise.resolve();
 			expect(reconnectSettled).to.be.false;
-			expect(log._replicationInfoBlockedPeers.has(remoteHash)).to.be.true;
+			expect(log._peerSessions.isReplicationInfoBlocked(remoteHash)).to.be.true;
 
 			releaseDelete.resolve();
 			await Promise.all([oldUnsubscribe, reconnect]);
@@ -4271,7 +4271,7 @@ describe("events", () => {
 			expect(log._peerSyncCapabilities.get(remoteHash)).to.equal(7);
 			expect(log._replicatorLastActivityAt.has(remoteHash)).to.be.true;
 			expect(log._gidPeersHistory.get(gid)?.has(remoteHash)).to.be.true;
-			expect(log._replicationInfoBlockedPeers.has(remoteHash)).to.be.false;
+			expect(log._peerSessions.isReplicationInfoBlocked(remoteHash)).to.be.false;
 			expect(disconnected.calledOnceWith(remoteHash)).to.be.true;
 			expect(leaves).to.deep.equal([]);
 
@@ -4338,7 +4338,7 @@ describe("events", () => {
 			}
 			return originalDel(query, options);
 		}) as any);
-		const unblock = sinon.spy(log._replicationInfoBlockedPeers, "delete");
+		const unblock = sinon.spy(log._peerSessions._replicationInfoBlockedPeers, "delete");
 		const scheduleRequests = sinon.spy(log, "scheduleReplicationInfoRequests");
 		const disconnected = sinon.spy(log.syncronizer, "onPeerDisconnected");
 		const leaves: string[] = [];
@@ -4360,7 +4360,7 @@ describe("events", () => {
 			await Promise.resolve();
 			const winningUnsubscribe = log._onUnsubscription(unsubscribeEvent);
 			await Promise.resolve();
-			expect(log._replicationInfoBlockedPeers.has(remoteHash)).to.be.true;
+			expect(log._peerSessions.isReplicationInfoBlocked(remoteHash)).to.be.true;
 
 			releaseDelete.resolve();
 			await Promise.all([
@@ -4374,7 +4374,7 @@ describe("events", () => {
 			).to.have.length(0);
 			expect(log.uniqueReplicators.has(remoteHash)).to.be.false;
 			expect(log._replicatorJoinEmitted.has(remoteHash)).to.be.false;
-			expect(log._replicationInfoBlockedPeers.has(remoteHash)).to.be.true;
+			expect(log._peerSessions.isReplicationInfoBlocked(remoteHash)).to.be.true;
 			expect(unblock.neverCalledWith(remoteHash)).to.be.true;
 			expect(scheduleRequests.notCalled).to.be.true;
 			expect(disconnected.callCount).to.equal(2);

--- a/packages/programs/data/shared-log/test/peer-session.spec.ts
+++ b/packages/programs/data/shared-log/test/peer-session.spec.ts
@@ -50,6 +50,7 @@ const createDeps = (host: StubHost): PeerSessionDeps => ({
 // to the registry, so this inline replica is the regression oracle.
 const legacyIsPeerReceiveAdmissionOpen = (
 	host: StubHost,
+	blockedPeers: Set<string>,
 	cleanupGateByPeer: Map<string, number>,
 	peerHash: string,
 	replicationLifecycleController: AbortController | undefined,
@@ -60,7 +61,7 @@ const legacyIsPeerReceiveAdmissionOpen = (
 	isReplicationLifecycleActive(host, replicationLifecycleController) &&
 	currentEpoch === subscriptionEpoch &&
 	(options?.allowReplicationInfoBlocked === true ||
-		!host.blockedPeers.has(peerHash)) &&
+		!blockedPeers.has(peerHash)) &&
 	(options?.allowCleanupGate === true ||
 		(cleanupGateByPeer.get(peerHash) ?? 0) === 0);
 
@@ -192,6 +193,7 @@ describe("receive admission peer session parity", () => {
 
 								const expected = legacyIsPeerReceiveAdmissionOpen(
 									host,
+									host.blockedPeers,
 									registry._receiveCleanupGateByPeer,
 									PEER,
 									controller,

--- a/packages/programs/data/shared-log/test/peer-session.spec.ts
+++ b/packages/programs/data/shared-log/test/peer-session.spec.ts
@@ -18,13 +18,11 @@ import {
 type StubHost = {
 	replicationLifecycleController?: AbortController;
 	terminating: boolean;
-	blockedPeers: Set<string>;
 };
 
 const createHost = (): StubHost => ({
 	replicationLifecycleController: new AbortController(),
 	terminating: false,
-	blockedPeers: new Set(),
 });
 
 // Mirrors SharedLog.isReplicationLifecycleActive term for term.
@@ -41,7 +39,6 @@ const createDeps = (host: StubHost): PeerSessionDeps => ({
 	isReplicationLifecycleActive: (controller) =>
 		isReplicationLifecycleActive(host, controller),
 	getReplicationLifecycleController: () => host.replicationLifecycleController,
-	isReplicationInfoBlocked: (hash) => host.blockedPeers.has(hash),
 });
 
 // Literal transcription of the legacy (pre-stage-3) body of
@@ -180,7 +177,10 @@ describe("receive admission peer session parity", () => {
 									host.terminating = true;
 								}
 								if (blocked) {
-									host.blockedPeers.add(PEER);
+									// The blocked set moved into the registry (fence B5);
+									// seed it through the registry's block method, mirroring
+									// the legacy host-set add.
+									registry.blockReplicationInfo(PEER);
 								}
 								// The gate refcounts moved into the registry (fence B6);
 								// seed its map directly, mirroring the legacy host-map
@@ -193,7 +193,7 @@ describe("receive admission peer session parity", () => {
 
 								const expected = legacyIsPeerReceiveAdmissionOpen(
 									host,
-									host.blockedPeers,
+									registry._replicationInfoBlockedPeers,
 									registry._receiveCleanupGateByPeer,
 									PEER,
 									controller,

--- a/packages/programs/data/shared-log/test/peer-session.spec.ts
+++ b/packages/programs/data/shared-log/test/peer-session.spec.ts
@@ -191,10 +191,14 @@ describe("receive admission peer session parity", () => {
 									allowCleanupGate,
 								};
 
+								// The oracle must not read the registry state it just
+								// seeded (a silent no-op in block/set would make oracle
+								// and implementation agree wrongly): feed it independent
+								// structures built from the loop variables.
 								const expected = legacyIsPeerReceiveAdmissionOpen(
 									host,
-									registry._replicationInfoBlockedPeers,
-									registry._receiveCleanupGateByPeer,
+									blocked ? new Set([PEER]) : new Set(),
+									new Map(gate === 0 ? [] : [[PEER, gate]]),
 									PEER,
 									controller,
 									session,

--- a/packages/programs/data/shared-log/test/receive-admission-ordering.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission-ordering.spec.ts
@@ -1,0 +1,139 @@
+// Stage-4 B8 tripwire. The `latestReplicationInfoMessage` sender-timestamp
+// watermark carries TWO roles: a fencing role (rejecting traffic across
+// unsubscribe/eviction races) that the per-peer receive epoch now subsumes,
+// and an intra-epoch ORDERING role that nothing else covers — within one
+// (lifecycle, session, epoch, unblocked) regime the epoch token is constant
+// across every message from the peer, so only the watermark can distinguish
+// "older reset delivered after newer add". These pins convert that argument
+// into an executable invariant: they fail if the watermark read sites are
+// ever deleted on the "epoch subsumes it" theory. The sanctioned deletion
+// path is sender-authoritative sequence numbers on the replication-info
+// schema (stage 5); until then the watermark is KEEP-OLD.
+import { randomBytes } from "@peerbit/crypto";
+import { TestSession } from "@peerbit/test-utils";
+import { expect } from "chai";
+import sinon from "sinon";
+import { ReplicationIntent } from "../src/ranges.js";
+import {
+	AllReplicatingSegmentsMessage,
+	StoppedReplicating,
+} from "../src/replication.js";
+import { EventStore } from "./utils/stores/index.js";
+
+describe("receive admission replication-info ordering watermark", () => {
+	let session: TestSession;
+
+	afterEach(async () => {
+		await session.stop();
+	});
+
+	const openLogWithSyntheticOwner = async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = db.log as any;
+		const ownerKey = session.peers[1].identity.publicKey;
+		const ownerHash = ownerKey.hashcode();
+		const makeRange = (offset: number) =>
+			new log.indexableDomain.constructorRange({
+				id: randomBytes(32),
+				offset: log.indexableDomain.numbers.denormalize(offset),
+				width: log.indexableDomain.numbers.denormalize(0.2),
+				publicKeyHash: ownerHash,
+				mode: ReplicationIntent.NonStrict,
+				timestamp: 1n,
+			});
+		const receive = (message: unknown, timestamp: bigint) =>
+			db.log.onMessage(message as any, {
+				from: ownerKey,
+				message: { header: { timestamp } },
+			} as any);
+		return {
+			db,
+			log,
+			replicationIndex: db.log.replicationIndex as any,
+			ownerHash,
+			rangeA: makeRange(0.1),
+			rangeB: makeRange(0.5),
+			receive,
+		};
+	};
+
+	it("drops an out-of-order stale replication-info snapshot arriving after a newer one", async () => {
+		const { log, replicationIndex, ownerHash, rangeA, rangeB, receive } =
+			await openLogWithSyntheticOwner();
+
+		const newerTimestamp = 1_000n;
+		await receive(
+			new AllReplicatingSegmentsMessage({
+				segments: [rangeA.toReplicationRange(), rangeB.toReplicationRange()],
+			}),
+			newerTimestamp,
+		);
+		expect(
+			await replicationIndex.count({ query: { hash: ownerHash } }),
+		).to.equal(2);
+		expect(log.latestReplicationInfoMessage.get(ownerHash)).to.equal(
+			newerTimestamp,
+		);
+
+		// A stale RESET (only the first segment) delivered out of order — the
+		// unordered-pubsub / retransmit reorder the in-lane comment names. All
+		// four gate terms (lifecycle, session, receive epoch, unblocked) pass
+		// for it; only the ordering watermark can drop it.
+		const apply = sinon.spy(log, "addReplicationRange");
+		try {
+			await receive(
+				new AllReplicatingSegmentsMessage({
+					segments: [rangeA.toReplicationRange()],
+				}),
+				newerTimestamp - 1n,
+			);
+			// The stale reset never reached the apply path: no segment erased, no
+			// spurious removed-diff/rebalance source, watermark untouched.
+			expect(apply.notCalled).to.be.true;
+			expect(
+				await replicationIndex.count({ query: { hash: ownerHash } }),
+			).to.equal(2);
+			expect(log.latestReplicationInfoMessage.get(ownerHash)).to.equal(
+				newerTimestamp,
+			);
+		} finally {
+			apply.restore();
+		}
+	});
+
+	it("keeps dropping across the Stopped lane", async () => {
+		const { log, replicationIndex, ownerHash, rangeA, rangeB, receive } =
+			await openLogWithSyntheticOwner();
+
+		const newerTimestamp = 1_000n;
+		await receive(
+			new AllReplicatingSegmentsMessage({
+				segments: [rangeA.toReplicationRange(), rangeB.toReplicationRange()],
+			}),
+			newerTimestamp,
+		);
+		expect(
+			await replicationIndex.count({ query: { hash: ownerHash } }),
+		).to.equal(2);
+
+		const remove = sinon.spy(log, "removeReplicationRanges");
+		try {
+			await receive(
+				new StoppedReplicating({ segmentIds: [rangeA.id, rangeB.id] }),
+				newerTimestamp - 1n,
+			);
+			expect(remove.notCalled).to.be.true;
+			expect(
+				await replicationIndex.count({ query: { hash: ownerHash } }),
+			).to.equal(2);
+			expect(log.latestReplicationInfoMessage.get(ownerHash)).to.equal(
+				newerTimestamp,
+			);
+		} finally {
+			remove.restore();
+		}
+	});
+});

--- a/packages/programs/data/shared-log/test/receive-admission-pins.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission-pins.spec.ts
@@ -244,7 +244,7 @@ describe("receive admission opening-barrier windows", () => {
 			// With the peer replication-info-blocked but still no barrier window,
 			// the advert is not admitted at all — the pre-barrier "opening" phase
 			// must not widen admission or stage the advert.
-			sharedLog._replicationInfoBlockedPeers.add(sourceHash);
+			sharedLog._peerSessions._replicationInfoBlockedPeers.add(sourceHash);
 			try {
 				await target.log.onMessage(
 					new SyncCapabilitiesMessage({ capabilities: 5 }),
@@ -254,7 +254,7 @@ describe("receive admission opening-barrier windows", () => {
 					.false;
 				expect(sharedLog._peerSyncCapabilities.get(sourceHash)).to.equal(3);
 			} finally {
-				sharedLog._replicationInfoBlockedPeers.delete(sourceHash);
+				sharedLog._peerSessions._replicationInfoBlockedPeers.delete(sourceHash);
 			}
 		} finally {
 			await session.stop();

--- a/packages/programs/data/shared-log/test/receive-admission.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission.spec.ts
@@ -136,7 +136,7 @@ describe("receive admission", () => {
 				const subscription = sharedLog._onSubscription({
 					detail: { from: sourceKey, topics: [target.log.topic] },
 				});
-				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
+				expect(sharedLog._peerSessions.isReplicationInfoBlocked(sourceHash)).to.be
 					.true;
 
 				await target.log.onMessage(new SyncCapabilitiesMessage(), {
@@ -148,7 +148,7 @@ describe("receive admission", () => {
 				expect(
 					sharedLog._peerSessions.current(sourceHash)?.openingBarrierActive,
 				).to.be.false;
-				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
+				expect(sharedLog._peerSessions.isReplicationInfoBlocked(sourceHash)).to.be
 					.false;
 			} finally {
 				scheduleRequests.restore();
@@ -183,7 +183,7 @@ describe("receive admission", () => {
 				const subscription = sharedLog._onSubscription({
 					detail: { from: sourceKey, topics: [target.log.topic] },
 				});
-				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
+				expect(sharedLog._peerSessions.isReplicationInfoBlocked(sourceHash)).to.be
 					.true;
 
 				await target.log.onMessage(new RequestMaybeSync({ hashes: [] }), {
@@ -192,7 +192,7 @@ describe("receive admission", () => {
 				await subscription;
 
 				expect(synchronizerOnMessage.calledOnce).to.be.true;
-				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
+				expect(sharedLog._peerSessions.isReplicationInfoBlocked(sourceHash)).to.be
 					.false;
 			} finally {
 				synchronizerOnMessage.restore();
@@ -242,11 +242,11 @@ describe("receive admission", () => {
 				const unsubscribe = sharedLog._onUnsubscription({
 					detail: { from: sourceKey, topics: [target.log.topic] },
 				});
-				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
+				expect(sharedLog._peerSessions.isReplicationInfoBlocked(sourceHash)).to.be
 					.true;
 				await unsubscribe;
 				// …and the committed cleanup does not lift it.
-				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
+				expect(sharedLog._peerSessions.isReplicationInfoBlocked(sourceHash)).to.be
 					.true;
 				expect(
 					await target.log.replicationIndex.count({
@@ -283,7 +283,7 @@ describe("receive admission", () => {
 				);
 				// Mid-barrier the peer stays fenced (the opening rotation must NOT
 				// have reset the block)…
-				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
+				expect(sharedLog._peerSessions.isReplicationInfoBlocked(sourceHash)).to.be
 					.true;
 				expect(subscriptionSettled).to.be.false;
 				// …and replication-info admitted mid-barrier is dropped whole,
@@ -307,13 +307,13 @@ describe("receive admission", () => {
 				expect(sharedLog.latestReplicationInfoMessage.get(sourceHash)).to.equal(
 					watermarkBefore,
 				);
-				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
+				expect(sharedLog._peerSessions.isReplicationInfoBlocked(sourceHash)).to.be
 					.true;
 
 				releaseLane.resolve();
 				await Promise.all([parkedLane, subscription]);
 				// The committed barrier is the only unblock site.
-				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
+				expect(sharedLog._peerSessions.isReplicationInfoBlocked(sourceHash)).to.be
 					.false;
 			} finally {
 				releaseLane.resolve();

--- a/packages/programs/data/shared-log/test/receive-admission.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission.spec.ts
@@ -203,6 +203,133 @@ describe("receive admission", () => {
 		}
 	});
 
+	it("keeps a peer blocked across the departing-to-opening session handoff until the barrier commits", async () => {
+		// Stage-4 B5 pin: the replication-info block is set under the DEPARTING
+		// session (unsubscribe) and cleared only when a LATER opening session's
+		// reconnect barrier commits — its lifetime deliberately spans session
+		// identities. A per-session flag would silently reset at the opening
+		// rotation; this pin rules that design out.
+		const session = await TestSession.connected(2);
+		const laneEntered = pDefer<void>();
+		const releaseLane = pDefer<void>();
+		let parkedLane: Promise<void> | undefined;
+		let subscription: Promise<void> | undefined;
+		try {
+			const store = new EventStore<string, any>();
+			const target = await session.peers[0].open(store, {
+				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+			});
+			await session.peers[1].open(store.clone(), {
+				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+			});
+			const sharedLog = target.log as any;
+			const sourceKey = session.peers[1].identity.publicKey;
+			const sourceHash = sourceKey.hashcode();
+			let remoteRange: any;
+			await waitForResolved(async () => {
+				const ranges = await target.log.replicationIndex
+					.iterate({ query: { hash: sourceHash } })
+					.all();
+				expect(ranges).to.have.length.greaterThan(0);
+				remoteRange = ranges[0].value;
+			});
+			const scheduleRequests = sinon
+				.stub(sharedLog, "scheduleReplicationInfoRequests")
+				.callsFake(() => {});
+
+			try {
+				// The departing add fences the peer synchronously at unsubscribe…
+				const unsubscribe = sharedLog._onUnsubscription({
+					detail: { from: sourceKey, topics: [target.log.topic] },
+				});
+				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
+					.true;
+				await unsubscribe;
+				// …and the committed cleanup does not lift it.
+				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
+					.true;
+				expect(
+					await target.log.replicationIndex.count({
+						query: { hash: sourceHash },
+					}),
+				).to.equal(0);
+
+				// Park the per-peer apply lane so the reconnect barrier stalls
+				// between its drain and its commit.
+				parkedLane = sharedLog.withReplicationInfoApplyQueue(
+					sourceHash,
+					async () => {
+						laneEntered.resolve();
+						await releaseLane.promise;
+					},
+				);
+				await laneEntered.promise;
+				const parkedTail =
+					sharedLog._replicationInfoApplyQueueByPeer.get(sourceHash);
+
+				let subscriptionSettled = false;
+				subscription = sharedLog
+					._onSubscription({
+						detail: { from: sourceKey, topics: [target.log.topic] },
+					})
+					.then(() => {
+						subscriptionSettled = true;
+					});
+				// The barrier queued its commit behind the parked lane.
+				await waitForResolved(() =>
+					expect(
+						sharedLog._replicationInfoApplyQueueByPeer.get(sourceHash),
+					).to.not.equal(parkedTail),
+				);
+				// Mid-barrier the peer stays fenced (the opening rotation must NOT
+				// have reset the block)…
+				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
+					.true;
+				expect(subscriptionSettled).to.be.false;
+				// …and replication-info admitted mid-barrier is dropped whole,
+				// before the watermark write.
+				const watermarkBefore =
+					sharedLog.latestReplicationInfoMessage.get(sourceHash);
+				await target.log.onMessage(
+					new AllReplicatingSegmentsMessage({
+						segments: [remoteRange.toReplicationRange()],
+					}),
+					{
+						from: sourceKey,
+						message: { header: { timestamp: BigInt(Date.now() + 5_000) } },
+					} as any,
+				);
+				expect(
+					await target.log.replicationIndex.count({
+						query: { hash: sourceHash },
+					}),
+				).to.equal(0);
+				expect(sharedLog.latestReplicationInfoMessage.get(sourceHash)).to.equal(
+					watermarkBefore,
+				);
+				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
+					.true;
+
+				releaseLane.resolve();
+				await Promise.all([parkedLane, subscription]);
+				// The committed barrier is the only unblock site.
+				expect(sharedLog._replicationInfoBlockedPeers.has(sourceHash)).to.be
+					.false;
+			} finally {
+				releaseLane.resolve();
+				await Promise.allSettled(
+					[parkedLane, subscription].filter(
+						(value): value is Promise<void> => value != null,
+					),
+				);
+				scheduleRequests.restore();
+			}
+		} finally {
+			releaseLane.resolve();
+			await session.stop();
+		}
+	});
+
 	it("drains only pre-transition receives while a subscription opens", async () => {
 		const session = await TestSession.disconnected(2);
 		const oldReceiveEntered = pDefer<void>();

--- a/scripts/ci/check-fence-ratchet.mjs
+++ b/scripts/ci/check-fence-ratchet.mjs
@@ -20,11 +20,20 @@ const TARGETS = new Map([
 	[
 		"packages/programs/data/shared-log/src/index.ts",
 		[
-			"_checkedPruneRemoveBlocksLocalRangeMutationAdmission",
 			"_instanceLifecycle",
 			"_nativeCoordinateMutationGenerations",
 			"_repairLifecycleController",
 			"_replicationLifecycleController",
+		],
+	],
+	[
+		"packages/programs/data/shared-log/src/checked-prune.ts",
+		// peerRemovalFences predates this file's TARGETS entry; it entered the
+		// baseline as existing inventory when the admission counter relocated
+		// here, not as fence growth.
+		[
+			"_checkedPruneRemoveBlocksLocalRangeMutationAdmission",
+			"peerRemovalFences",
 		],
 	],
 	[


### PR DESCRIPTION
Second stage-4 PR (#1178 merged). Four commits: pins first, two migrations, one honest KEEP-OLD.

## The migrations

- **B5 folded**: `_replicationInfoBlockedPeers` moves onto `PeerSessionRegistry` — all 21 base sites rewritten 1:1 with add/delete timing, epoch guards, and reader term positions preserved (review-verified site-by-site); this retires the registry's last dependency on SharedLog-held state.
- **Prune-admission flag relocated** into `CheckedPruneCoordinator` with an idempotent, *instance-scoped* release replacing the raw inc/finally-dec. The one behavioral divergence lives in an interleaving both the commit body and the reviewer independently proved unreachable — and in that impossible world, base would drive its counter to −1 and misclassify unrelated removals, so the new form is strictly sounder. Close deliberately does not zero (matching base); open-reset is subsumed by the per-open coordinator.
- **B8 KEPT** (`latestReplicationInfoMessage`): the manifest's subsumption analysis concluded the watermark's *ordering* role — dropping out-of-order stale replication-info — is not expressible with identity tokens; only its fencing role was subsumed by the receive epoch (stage-3). The verdict and the stage-5 unlock (sender sequence numbers) are documented at the declaration, and the ordering pins landed anyway as permanent tripwires.

## Pins and review

New pin describes (replication-info ordering watermark; B5 blocked-peer handoff through a parked reconnect barrier) ran 3× green; both review mutations killed (watermark-compare deletion, unblock-at-barrier-start). Adversarial review: **zero confirmed defects**. The review's one test-power nitpick (the truth-table oracle reading registry state it had seeded) is fixed — the oracle now receives independent structures built from the loop variables.

## Validation

21-suite sweep 0 failing; full chaos green; ratchet at 13 across 9 files (index.ts down to 4; the checked-prune.ts entry brings the pre-existing `peerRemovalFences` into scan scope — inventory, not growth); lint/tsc/shard-coverage/contracts pass.

Next: stage-4 PR-3 — physical controller relocation into `InstanceLifecycle`.