### PR TITLE
refactor(shared-log): stage-4 PR-3 — the lifecycle owns its controllers

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -1968,7 +1968,16 @@ export class SharedLog<
 	private _onUnsubscriptionFn!: (arg: any) => any;
 	private _subscriptionChangeCallbacks?: Set<Promise<void>>;
 	private _acceptSubscriptionChangeCallbacks = false;
-	private _replicationLifecycleController?: AbortController;
+	// Stage 4: physically owned by the per-open InstanceLifecycle
+	// (membershipLifecycleController; the ratchet entry moved file-to-file —
+	// see src/instance-lifecycle.ts). The delegating accessor keeps every
+	// legacy site verbatim: undefined both for never-opened clones (no
+	// lifecycle) and pre-open lifecycles (membership begins at
+	// resetSubscriptionChangeCallbackTracking), matching the legacy
+	// `?: AbortController` field at every reachable read.
+	private get _replicationLifecycleController(): AbortController | undefined {
+		return this._instanceLifecycle?.membershipLifecycleController;
+	}
 	private _activeReceiveHandlersByPeer!: Map<string, PeerReceiveLeaseState>;
 	private _receiveHandlerDrainByPeer!: Map<string, Set<Promise<void>>>;
 	// The per-peer receive cleanup-gate refcounts now live on the
@@ -2061,15 +2070,23 @@ export class SharedLog<
 	// If durable post-state cannot be reconciled to every native/runtime mirror,
 	// reject later writers and planners until reopen rehydrates those mirrors.
 	private _replicationRangeMutationFailure?: unknown;
-	// Background repair work can outlive the await that admitted it. Replace this
-	// opaque token on poison and every terminal/open boundary so an older runner
-	// can neither dispatch nor mutate a freshly opened lifecycle.
-	private _repairLifecycleController = new AbortController();
+	// Stage 4: physically owned by the per-open InstanceLifecycle
+	// (ownershipLifecycleController; the ratchet entry and the design comment
+	// moved file-to-file — see src/instance-lifecycle.ts). The non-optional
+	// return type is the same static lie the legacy field decl told: on a
+	// borsh-deserialized never-opened clone (field initializers skipped, no
+	// lifecycle) the value is undefined at runtime in both worlds, and the
+	// clone fallbacks below preserve the legacy behavior verbatim.
+	private get _repairLifecycleController(): AbortController {
+		return this._instanceLifecycle
+			?.ownershipLifecycleController as AbortController;
+	}
 	// design-note: not a new fence — this is the per-open identity object the
-	// fence ratchet is migrating TOWARD (stage 2 of the session/lifecycle
-	// refactor). It wraps the controllers, poison latch, terminal fences, and
-	// coordinator/debouncer identities via late-bound readers; stage 3 drains
-	// those fences into it one at a time.
+	// fence ratchet is migrating TOWARD (the session/lifecycle refactor). As
+	// of stage 4 it physically owns the ownership/membership controllers (the
+	// accessors above) alongside the role sub-generation and receive counters;
+	// the poison latch, terminal fences, and coordinator/debouncer identities
+	// stay wrapped via late-bound readers until their own drain stages.
 	private _instanceLifecycle?: InstanceLifecycle;
 	// The local receive generations that fence replication-info handlers
 	// across liveness evictions now live on the PeerSessionRegistry
@@ -2143,15 +2160,24 @@ export class SharedLog<
 		lifecycle.throwIfPoisoned();
 	}
 
+	// THE single rotation point (stage 4): lifecycle + both controllers
+	// replace together by construction — a fresh InstanceLifecycle IS the
+	// rotation of the ownership controller it owns. The outgoing lifecycle's
+	// ownership controller MUST be aborted here (a re-abort no-op on every
+	// terminal path into open(), and the load-bearing abort for a direct
+	// mid-open rotation): the stale-captured-lifecycle predicates rely on
+	// non-current ⇒ aborted (see instance-lifecycle.ts). The abort runs
+	// BEFORE the fresh lifecycle is installed, preserving the legacy
+	// ordering: a synchronous abort listener observes pre-rotation state.
 	private startRepairLifecycle(): AbortController {
-		this._repairLifecycleController?.abort();
+		this._instanceLifecycle?.abortOwnership();
+		this._instanceLifecycle = this.createInstanceLifecycle();
 		this.clearCheckedPruneAuditTimer();
-		this._repairLifecycleController = new AbortController();
-		return this._repairLifecycleController;
+		return this._instanceLifecycle.ownershipLifecycleController;
 	}
 
 	private stopRepairLifecycle(): void {
-		this._repairLifecycleController?.abort();
+		this._instanceLifecycle?.abortOwnership();
 	}
 
 	private isRepairLifecycleActive(controller: AbortController): boolean {
@@ -3428,8 +3454,6 @@ export class SharedLog<
 	private createInstanceLifecycle(): InstanceLifecycle {
 		return new InstanceLifecycle({
 			getCurrentLifecycle: () => this._instanceLifecycle,
-			getOwnershipController: () => this._repairLifecycleController,
-			getMembershipController: () => this._replicationLifecycleController,
 			getCloseController: () => this._closeController,
 			getPoisonFailure: () => this._replicationRangeMutationFailure,
 			isHostClosed: () => this.closed,
@@ -4915,7 +4939,7 @@ export class SharedLog<
 	private resetSubscriptionChangeCallbackTracking() {
 		this._subscriptionChangeCallbacks = new Set();
 		this._acceptSubscriptionChangeCallbacks = true;
-		this._replicationLifecycleController = new AbortController();
+		this._instanceLifecycle!.beginMembership();
 	}
 
 	private runSubscriptionChangeCallback(
@@ -4939,11 +4963,9 @@ export class SharedLog<
 
 	private stopSubscriptionChangeCallbackAdmission() {
 		this._acceptSubscriptionChangeCallbacks = false;
-		if (!this._replicationLifecycleController?.signal.aborted) {
-			this._replicationLifecycleController?.abort(
-				new AbortError("SharedLog is terminating"),
-			);
-		}
+		this._instanceLifecycle?.abortMembership(
+			new AbortError("SharedLog is terminating"),
+		);
 		if (this._onSubscriptionFn) {
 			this.node.services.pubsub.removeEventListener(
 				"subscribe",
@@ -13828,19 +13850,24 @@ export class SharedLog<
 		// and that creation (straight-line assignments only).
 		this._pruneRemovesClosing = false;
 		this._replicationRangeMutationFailure = undefined;
-		// One InstanceLifecycle per open(): fresh identity, installed before
-		// the ownership-controller rotation so no statement in this reset
-		// block can observe the previous lifecycle's roleGeneration.
-		// Late-bound readers make it insensitive to the resets that follow
-		// (ownership controller next, membership controller at
-		// resetSubscriptionChangeCallbackTracking below, _checkedPrune and
+		// One InstanceLifecycle per open(), created inside
+		// startRepairLifecycle() (stage 4): the fresh object physically owns
+		// the ownership controller, so lifecycle and controller rotate
+		// together by construction and no statement in this reset block can
+		// observe the previous lifecycle's roleGeneration. Late-bound readers
+		// make it insensitive to the resets that follow (membership controller
+		// at resetSubscriptionChangeCallbackTracking below, _checkedPrune and
 		// _closeController and the debouncers in the setup blocks further
 		// down). The fresh object is also the per-open reset for the role
 		// sub-generation and the receive-ownership counters: roleGeneration,
 		// _receiveOwnershipRevision and _receiveOwnershipMutationAdmissions
 		// all start at 0 on the incoming lifecycle.
-		this._instanceLifecycle = this.createInstanceLifecycle();
 		this.startRepairLifecycle();
+		// Guard: between startRepairLifecycle() and
+		// resetSubscriptionChangeCallbackTracking() the fresh lifecycle's
+		// membership controller is undefined (legacy exposed the previous
+		// open's aborted controller in this window). Straight-line statements
+		// only; do not insert a _replicationLifecycleController read here.
 		this._replicationRangeMutationTail = Promise.resolve();
 		this.resetSubscriptionChangeCallbackTracking();
 		const recoveringNativeDurableFailure =
@@ -25759,8 +25786,8 @@ export class SharedLog<
 		// go stale later; its deps late-bind to the host, so the debouncer term
 		// still reads the current host field, and the role term can disagree
 		// with the current lifecycle's counter only after a rotation, where the
-		// isActiveFor term is already false (controller replaced in the same
-		// synchronous block).
+		// isActiveFor term is already false (the stale lifecycle's ownership
+		// controller is aborted in the same synchronous block).
 		const lifecycle = this._instanceLifecycle;
 		const capturedRoleGeneration = lifecycle?.roleGeneration ?? 0;
 		// update more participation rate to converge to the average expected rate or bounded by

--- a/packages/programs/data/shared-log/src/instance-lifecycle.ts
+++ b/packages/programs/data/shared-log/src/instance-lifecycle.ts
@@ -1,10 +1,13 @@
-// Stage 2 of the session/lifecycle refactor: one InstanceLifecycle per
-// SharedLog.open(). In stage 2 the object WRAPS the existing fences via
-// late-bound readers — it physically owns nothing except the role
-// sub-generation — so every existing check keeps working unchanged. Stage 3
-// migrates the eight documented multi-fence seams onto this API and deletes
-// the wrapped fences one at a time (each deletion shrinks the index.ts
-// baseline in scripts/ci/check-fence-ratchet.mjs).
+// One InstanceLifecycle per SharedLog.open(). Stage 2 of the
+// session/lifecycle refactor introduced the object as a WRAPPER over the
+// existing fences via late-bound readers; stage 3 migrated the documented
+// multi-fence seams onto this API; stage 4 makes it the physical owner of
+// the per-open state: the role sub-generation, the receive-ownership
+// counters, and the ownership/membership AbortControllers themselves (the
+// index.ts ratchet entries moved file-to-file into this file's baseline in
+// scripts/ci/check-fence-ratchet.mjs). The remaining deps are late-bound
+// readers for host state that outlives any single lifecycle (poison latch,
+// close controller, coordinator/debouncer identities).
 import { TerminalOperationNotStartedError } from "@peerbit/program";
 
 export type InstanceLifecyclePhase =
@@ -22,10 +25,6 @@ export type InstanceLifecycleTerminalReason =
 export type InstanceLifecycleDeps = {
 	/** host._instanceLifecycle — identity anchor for isCurrent() */
 	getCurrentLifecycle: () => InstanceLifecycle | undefined;
-	/** host._repairLifecycleController (ownership half, fence A1) */
-	getOwnershipController: () => AbortController | undefined;
-	/** host._replicationLifecycleController (membership half, fence A5) */
-	getMembershipController: () => AbortController | undefined;
 	/** host._closeController */
 	getCloseController: () => AbortController | undefined;
 	/** host._replicationRangeMutationFailure (poison latch, fence A2) */
@@ -74,6 +73,29 @@ export class InstanceLifecycle {
 	// starts.
 	public _receiveOwnershipMutationAdmissions = 0;
 
+	// ---- stage 4: physically owned controllers (moved from SharedLog) ----
+	// Fences A1/A5; the index.ts ratchet entries _repairLifecycleController /
+	// _replicationLifecycleController moved file-to-file under these names.
+	// Rotate-with-the-lifecycle by construction: a fresh InstanceLifecycle IS
+	// the rotation of both controllers; within one lifecycle the ownership
+	// controller identity never changes (readonly) — poison and terminal
+	// paths abort it IN PLACE, exactly like the legacy un-reassigned host
+	// field. Background repair work can outlive the await that admitted it;
+	// the per-open replacement of this whole object keeps an older runner
+	// from dispatching into or mutating a freshly opened lifecycle.
+	//
+	// INVARIANT every rotation site must keep: whatever installs a new
+	// host._instanceLifecycle aborts the outgoing lifecycle's ownership
+	// controller in the same synchronous block (startRepairLifecycle does).
+	// The stale-capture predicates in isActiveFor lean on
+	// non-current ⇒ aborted now that the identity term compares against the
+	// owned field rather than the host-current controller.
+	public readonly ownershipLifecycleController = new AbortController();
+	// undefined until open() reaches resetSubscriptionChangeCallbackTracking
+	// (beginMembership) — preserves the legacy `?: AbortController` decl-site
+	// semantics for constructed-but-never-opened hosts.
+	public membershipLifecycleController?: AbortController;
+
 	// Stage-2 bookkeeping. WRITE-ONLY in production paths: no query method
 	// consults these (phase() is derived from the wrapped fences), so a
 	// missed or doubled transition cannot change behavior. Stage 3 flips
@@ -100,6 +122,37 @@ export class InstanceLifecycle {
 		this.declaredPhase = "poisoned";
 	}
 
+	// ---- owned-controller transitions (stage 4) ----
+
+	/** ≡ legacy SharedLog.stopRepairLifecycle body (`controller?.abort()`),
+	 * and the abort half of legacy startRepairLifecycle. Abort-in-place: the
+	 * lifecycle identity is untouched (the poison contract — poison never
+	 * rotates the lifecycle, so captures keep passing the identity term and
+	 * fail on `signal.aborted`/poison exactly as before). */
+	abortOwnership(): void {
+		this.ownershipLifecycleController.abort();
+	}
+
+	/** ≡ the legacy guarded abort in stopSubscriptionChangeCallbackAdmission:
+	 * `if (!c?.signal.aborted) c?.abort(reason)`. */
+	abortMembership(reason?: unknown): void {
+		if (!this.membershipLifecycleController?.signal.aborted) {
+			this.membershipLifecycleController?.abort(reason);
+		}
+	}
+
+	/** ≡ legacy `this._replicationLifecycleController = new AbortController()`
+	 * in resetSubscriptionChangeCallbackTracking. Called exactly once per
+	 * lifecycle, from open(); plain assignment kept (KEEP-OLD overwrite: the
+	 * predecessor either is undefined or was aborted at close/drop). A
+	 * direct out-of-open rotation (test-only) leaves the NEW lifecycle's
+	 * membership undefined until the next open — a deliberate divergence
+	 * from legacy, where the host field survived direct rotations; the two
+	 * observables that path uses are pinned in the spec. */
+	beginMembership(): AbortController {
+		return (this.membershipLifecycleController = new AbortController());
+	}
+
 	// ---- role sub-generation (absorbed fence A6) ----
 
 	bumpRoleGeneration(): number {
@@ -121,8 +174,10 @@ export class InstanceLifecycle {
 	phase(): InstanceLifecyclePhase {
 		if (this.deps.getPoisonFailure() !== undefined) return "poisoned";
 		if (this.deps.isHostClosed()) return "closed";
-		const ownership = this.deps.getOwnershipController();
-		if (!this.isCurrent() || ownership == null || ownership.signal.aborted) {
+		// The legacy `ownership == null` arm is gone: a lifecycle object owns
+		// its controller, so the absent-controller state is unrepresentable
+		// (clones have no lifecycle and cannot reach phase()).
+		if (!this.isCurrent() || this.ownershipLifecycleController.signal.aborted) {
 			return "terminating";
 		}
 		return this.declaredPhase === "opening" ? "opening" : "active";
@@ -130,11 +185,17 @@ export class InstanceLifecycle {
 
 	// ---- ownership half: exact folds of the legacy predicates ----
 
-	/** ≡ SharedLog.isRepairLifecycleActive(controller). */
+	/** ≡ SharedLog.isRepairLifecycleActive(controller). Stage 4 note: the
+	 * identity term compares against the OWNED controller. For a stale
+	 * captured lifecycle with its co-captured controller the term now
+	 * passes where the legacy host-current compare failed; the predicate
+	 * still returns false via `signal.aborted`, guaranteed by the rotation
+	 * invariant (non-current ⇒ abortOwnership already ran — see the field
+	 * comment above). */
 	isActiveFor(controller: AbortController | undefined): boolean {
 		return (
 			controller != null &&
-			controller === this.deps.getOwnershipController() &&
+			controller === this.ownershipLifecycleController &&
 			!controller.signal.aborted &&
 			this.deps.getPoisonFailure() === undefined &&
 			!this.deps.isHostClosed()
@@ -142,15 +203,15 @@ export class InstanceLifecycle {
 	}
 
 	/**
-	 * Controller-free form for stage-3 seams. Because this object and
-	 * _repairLifecycleController rotate at the same single point (open()),
-	 * `capturedLifecycle.isActive()` ⇔
+	 * Controller-free form for stage-3 seams. Because this object OWNS its
+	 * ownership controller (stage 4), lifecycle and controller rotate
+	 * together by construction, so `capturedLifecycle.isActive()` ⇔
 	 * `isRepairLifecycleActive(capturedController)` for captures taken
 	 * together — the equivalence the unit spec asserts.
 	 */
 	isActive(): boolean {
 		return (
-			this.isCurrent() && this.isActiveFor(this.deps.getOwnershipController())
+			this.isCurrent() && this.isActiveFor(this.ownershipLifecycleController)
 		);
 	}
 
@@ -168,7 +229,7 @@ export class InstanceLifecycle {
 
 	/** ≡ SharedLog.throwIfReplicationOwnershipLifecycleInactive. */
 	throwIfInactive(
-		controller: AbortController | undefined = this.deps.getOwnershipController(),
+		controller: AbortController | undefined = this.ownershipLifecycleController,
 	): void {
 		this.throwIfPoisoned();
 		if (!(this.isCurrent() && this.isActiveFor(controller))) {
@@ -186,9 +247,9 @@ export class InstanceLifecycle {
 		return this;
 	}
 
-	/** AbortControllers stay the signal carriers in stages 2 and 3. */
+	/** AbortControllers stay the signal carriers. */
 	ownershipSignal(): AbortSignal | undefined {
-		return this.deps.getOwnershipController()?.signal;
+		return this.ownershipLifecycleController.signal;
 	}
 
 	// ---- membership half (fence A5): exact fold ----
@@ -199,14 +260,14 @@ export class InstanceLifecycle {
 	isMembershipActiveFor(controller: AbortController | undefined): boolean {
 		return (
 			controller != null &&
-			controller === this.deps.getMembershipController() &&
+			controller === this.membershipLifecycleController &&
 			!controller.signal.aborted &&
 			!this.deps.isHostTerminating()
 		);
 	}
 
 	membershipSignal(): AbortSignal | undefined {
-		return this.deps.getMembershipController()?.signal;
+		return this.membershipLifecycleController?.signal;
 	}
 
 	closeSignal(): AbortSignal | undefined {
@@ -224,7 +285,7 @@ export class InstanceLifecycle {
 	isCheckedPruneCurrent(
 		coordinator: object | undefined,
 		closeController?: AbortController,
-		controller: AbortController | undefined = this.deps.getOwnershipController(),
+		controller: AbortController | undefined = this.ownershipLifecycleController,
 	): boolean {
 		return (
 			this.isCurrent() &&
@@ -245,7 +306,7 @@ export class InstanceLifecycle {
 	throwIfCheckedPruneInactive(
 		coordinator: object | undefined,
 		closeController?: AbortController,
-		controller: AbortController | undefined = this.deps.getOwnershipController(),
+		controller: AbortController | undefined = this.ownershipLifecycleController,
 	): void {
 		this.throwIfInactive(controller);
 		if (

--- a/packages/programs/data/shared-log/test/instance-lifecycle.spec.ts
+++ b/packages/programs/data/shared-log/test/instance-lifecycle.spec.ts
@@ -1,7 +1,13 @@
-// Stage-2 lifecycle refactor guard: InstanceLifecycle wraps the existing
-// fences via late-bound readers, so the pure-unit half asserts truth-table
-// equivalence with the legacy predicates it folds, and the integration half
-// asserts the per-open rotation/identity semantics against a real SharedLog.
+// Lifecycle refactor guard: the pure-unit half asserts truth-table
+// equivalence with the legacy predicates InstanceLifecycle folds (transcribed
+// inline against the owned controllers — stage 4 made the lifecycle the
+// physical owner of the ownership/membership AbortControllers), and the
+// integration half asserts the per-open rotation/identity semantics against
+// a real SharedLog. The legacy `ownership == null` truth-table arm is gone:
+// a lifecycle object owns its (readonly) ownership controller, so the
+// absent-controller state is unrepresentable by construction; the reachable
+// undefined semantics stay pinned via isActiveFor(undefined) and the
+// never-opened-clone integration cases.
 import { deserialize, serialize } from "@dao-xyz/borsh";
 import { TerminalOperationNotStartedError } from "@peerbit/program";
 import { TestSession } from "@peerbit/test-utils";
@@ -14,8 +20,6 @@ import { EventStore } from "./utils/stores/index.js";
 
 type StubHost = {
 	lifecycle?: InstanceLifecycle;
-	ownership?: AbortController;
-	membership?: AbortController;
 	closeController?: AbortController;
 	poison?: unknown;
 	closed: boolean;
@@ -29,8 +33,6 @@ type StubHost = {
 };
 
 const createHost = (): StubHost => ({
-	ownership: new AbortController(),
-	membership: new AbortController(),
 	closeController: new AbortController(),
 	closed: false,
 	terminating: false,
@@ -41,8 +43,6 @@ const createHost = (): StubHost => ({
 
 const createDeps = (host: StubHost): InstanceLifecycleDeps => ({
 	getCurrentLifecycle: () => host.lifecycle,
-	getOwnershipController: () => host.ownership,
-	getMembershipController: () => host.membership,
 	getCloseController: () => host.closeController,
 	getPoisonFailure: () => host.poison,
 	isHostClosed: () => host.closed,
@@ -72,7 +72,7 @@ describe("lifecycle instance identity", () => {
 							const lifecycle = createCurrentLifecycle(host);
 							const controller = stale
 								? new AbortController()
-								: host.ownership!;
+								: lifecycle.ownershipLifecycleController;
 							if (aborted) {
 								controller.abort();
 							}
@@ -80,9 +80,11 @@ describe("lifecycle instance identity", () => {
 								host.poison = new Error("poisoned");
 							}
 							host.closed = closed;
-							// Legacy isRepairLifecycleActive, condition for condition.
+							// Legacy isRepairLifecycleActive, condition for condition
+							// (the current-controller term reads the owned field — its
+							// only home since stage 4).
 							const legacy =
-								controller === host.ownership &&
+								controller === lifecycle.ownershipLifecycleController &&
 								!controller.signal.aborted &&
 								host.poison === undefined &&
 								!host.closed;
@@ -103,11 +105,13 @@ describe("lifecycle instance identity", () => {
 		});
 
 		it("isActiveFor rejects an absent controller", () => {
+			// The legacy `host.ownership = undefined` sub-case is gone: the
+			// lifecycle owns a readonly controller, so that state is
+			// unrepresentable by construction (clone hosts have no lifecycle
+			// at all — pinned by the integration cases below).
 			const host = createHost();
 			const lifecycle = createCurrentLifecycle(host);
 			expect(lifecycle.isActiveFor(undefined)).to.be.false;
-			host.ownership = undefined;
-			expect(lifecycle.isActive()).to.be.false;
 		});
 
 		it("isMembershipActiveFor matches the legacy membership predicate including the terminating term", () => {
@@ -116,17 +120,18 @@ describe("lifecycle instance identity", () => {
 					for (const terminating of [false, true]) {
 						const host = createHost();
 						const lifecycle = createCurrentLifecycle(host);
-						const controller = stale
-							? new AbortController()
-							: host.membership!;
+						const membership = lifecycle.beginMembership();
+						const controller = stale ? new AbortController() : membership;
 						if (aborted) {
 							controller.abort();
 						}
 						host.terminating = terminating;
-						// Legacy isReplicationLifecycleActive, condition for condition.
+						// Legacy isReplicationLifecycleActive, condition for condition
+						// (the current-controller term reads the owned field — its
+						// only home since stage 4).
 						const legacy =
 							controller != null &&
-							controller === host.membership &&
+							controller === lifecycle.membershipLifecycleController &&
 							!controller.signal.aborted &&
 							!host.terminating;
 						expect(lifecycle.isMembershipActiveFor(controller)).to.equal(
@@ -138,11 +143,14 @@ describe("lifecycle instance identity", () => {
 			}
 			const host = createHost();
 			const lifecycle = createCurrentLifecycle(host);
+			// Pre-open lifecycles have no membership controller yet.
+			expect(lifecycle.isMembershipActiveFor(undefined)).to.be.false;
+			const membership = lifecycle.beginMembership();
 			expect(lifecycle.isMembershipActiveFor(undefined)).to.be.false;
 			// The asymmetry vs the ownership half: `closed` alone does not gate
 			// membership (isTerminating() is the fence on this side).
 			host.closed = true;
-			expect(lifecycle.isMembershipActiveFor(host.membership)).to.be.true;
+			expect(lifecycle.isMembershipActiveFor(membership)).to.be.true;
 		});
 
 		it("throwIfInactive throws the legacy error types and messages", () => {
@@ -167,7 +175,7 @@ describe("lifecycle instance identity", () => {
 
 			// Aborted (unpoisoned) controller: TerminalOperationNotStartedError.
 			host.poison = undefined;
-			host.ownership!.abort();
+			lifecycle.abortOwnership();
 			try {
 				lifecycle.throwIfInactive();
 				expect.fail("expected throw");
@@ -221,7 +229,7 @@ describe("lifecycle instance identity", () => {
 			expect(lifecycle.isCheckedPruneCurrent({}, closeController)).to.be.false;
 			expect(lifecycle.isCheckedPruneCurrent(coordinator, new AbortController()))
 				.to.be.false;
-			host.ownership!.abort();
+			lifecycle.abortOwnership();
 			expect(lifecycle.isCheckedPruneCurrent(coordinator, closeController)).to
 				.be.false;
 
@@ -244,7 +252,7 @@ describe("lifecycle instance identity", () => {
 				lifecycle2.isCheckedPruneCurrent(
 					host2.checkedPrune,
 					undefined,
-					host2.ownership,
+					lifecycle2.ownershipLifecycleController,
 				),
 			).to.be.true;
 		});
@@ -273,7 +281,7 @@ describe("lifecycle instance identity", () => {
 				"Checked prune lifecycle is no longer active",
 			);
 			// Ownership inactivity wins over the checked-prune mismatch.
-			host.ownership!.abort();
+			lifecycle.abortOwnership();
 			expect(() => lifecycle.throwIfCheckedPruneInactive({})).to.throw(
 				TerminalOperationNotStartedError,
 				"Replication ownership lifecycle is no longer active",
@@ -329,14 +337,14 @@ describe("lifecycle instance identity", () => {
 			lifecycle.markOpenComplete();
 			expect(lifecycle.declaredPhase).to.equal("terminating");
 
-			// terminating: superseded identity or aborted/absent controller.
+			// terminating: superseded identity or aborted controller.
 			const staleHost = createHost();
 			const stale = createCurrentLifecycle(staleHost);
 			createCurrentLifecycle(staleHost);
 			expect(stale.phase()).to.equal("terminating");
 			const abortedHost = createHost();
 			const aborted = createCurrentLifecycle(abortedHost);
-			abortedHost.ownership!.abort();
+			aborted.abortOwnership();
 			expect(aborted.phase()).to.equal("terminating");
 
 			// closed beats terminating; poisoned beats both.
@@ -462,6 +470,106 @@ describe("lifecycle instance identity", () => {
 			expect((clone.log as any)._instanceLifecycle).to.equal(undefined);
 			await clone.close();
 			expect((clone.log as any)._instanceLifecycle).to.equal(undefined);
+			await db.close();
+		});
+
+		it("poison aborts the ownership controller in place without rotating identity", async () => {
+			session = await TestSession.connected(1);
+			const db = await session.peers[0].open(new EventStore());
+			const log = db.log as any;
+			const c0 = log._repairLifecycleController as AbortController;
+			const l0 = log._instanceLifecycle as InstanceLifecycle;
+			const m0 = log._replicationLifecycleController as AbortController;
+			expect(c0.signal.aborted).to.be.false;
+			log.poisonReplicationOwnership(new Error("boom"));
+			// The critical abort-in-place transition: the ownership controller
+			// is aborted on the SAME object, the lifecycle identity is not
+			// rotated, and the membership half is untouched.
+			expect(log._repairLifecycleController).to.equal(c0);
+			expect(c0.signal.aborted).to.be.true;
+			expect(log._instanceLifecycle).to.equal(l0);
+			expect(log._replicationLifecycleController).to.equal(m0);
+			expect(m0.signal.aborted).to.be.false;
+		});
+
+		it("reopen rotates both controllers together with the instance identity", async () => {
+			session = await TestSession.connected(1);
+			const db = await session.peers[0].open(new EventStore());
+			const log = db.log as any;
+			const c0 = log._repairLifecycleController as AbortController;
+			const l0 = log._instanceLifecycle as InstanceLifecycle;
+			const m0 = log._replicationLifecycleController as AbortController;
+			// Repeated accessor reads within one open are identity-stable.
+			expect(log._repairLifecycleController).to.equal(c0);
+			expect(log._replicationLifecycleController).to.equal(m0);
+
+			await db.close();
+			const reopened = await session.peers[0].open(db);
+			const log2 = reopened.log as any;
+			expect(log2._instanceLifecycle).to.not.equal(l0);
+			expect(log2._repairLifecycleController).to.not.equal(c0);
+			expect(log2._replicationLifecycleController).to.not.equal(m0);
+			expect(log2._repairLifecycleController).to.equal(
+				log2._repairLifecycleController,
+			);
+			expect(log2._replicationLifecycleController).to.equal(
+				log2._replicationLifecycleController,
+			);
+		});
+
+		it("a membership capture from a previous open stays inactive after reopen", async () => {
+			session = await TestSession.connected(1);
+			const db = await session.peers[0].open(new EventStore());
+			const log = db.log as any;
+			const captured = log._replicationLifecycleController as AbortController;
+			expect(log.isReplicationLifecycleActive(captured)).to.be.true;
+
+			await db.close();
+			const reopened = await session.peers[0].open(db);
+			const log2 = reopened.log as any;
+			expect(log2.isReplicationLifecycleActive(captured)).to.be.false;
+			expect(
+				(log2._instanceLifecycle as InstanceLifecycle).isMembershipActiveFor(
+					captured,
+				),
+			).to.be.false;
+		});
+
+		it("startRepairLifecycle invalidates prior ownership captures and leaves a fresh active controller", async () => {
+			session = await TestSession.connected(1);
+			const db = await session.peers[0].open(new EventStore());
+			const log = db.log as any;
+			const c0 = log._repairLifecycleController as AbortController;
+			const l0 = log._instanceLifecycle;
+			expect(log.isRepairLifecycleActive(c0)).to.be.true;
+			log.startRepairLifecycle();
+			expect(log._repairLifecycleController).to.not.equal(c0);
+			expect(log.isRepairLifecycleActive(c0)).to.be.false;
+			// The load-bearing predecessor abort: stale-captured-lifecycle
+			// predicates rely on non-current => aborted, so the rotation must
+			// abort the outgoing controller, not merely supersede it.
+			expect(c0.signal.aborted).to.be.true;
+			expect(l0.isActiveFor(c0)).to.be.false;
+			expect(log.isRepairLifecycleActive(log._repairLifecycleController)).to.be
+				.true;
+		});
+
+		it("a never-opened deserialized clone exposes no controllers and closes cleanly", async () => {
+			session = await TestSession.connected(1);
+			const store = new EventStore();
+			const db = await session.peers[0].open(store);
+			const clone = deserialize(serialize(store), EventStore);
+			const cloneLog = clone.log as any;
+			expect(cloneLog._repairLifecycleController).to.equal(undefined);
+			expect(cloneLog._replicationLifecycleController).to.equal(undefined);
+			// The legacy TypeError a capture attempt raises on such a clone
+			// (reading `.signal` of the undefined controller).
+			expect(() => cloneLog.captureReplicationOwnershipLifecycle()).to.throw(
+				TypeError,
+			);
+			await clone.close();
+			expect(cloneLog._repairLifecycleController).to.equal(undefined);
+			expect(cloneLog._replicationLifecycleController).to.equal(undefined);
 			await db.close();
 		});
 	});

--- a/scripts/ci/check-fence-ratchet.mjs
+++ b/scripts/ci/check-fence-ratchet.mjs
@@ -19,12 +19,7 @@ import path from "node:path";
 const TARGETS = new Map([
 	[
 		"packages/programs/data/shared-log/src/index.ts",
-		[
-			"_instanceLifecycle",
-			"_nativeCoordinateMutationGenerations",
-			"_repairLifecycleController",
-			"_replicationLifecycleController",
-		],
+		["_instanceLifecycle", "_nativeCoordinateMutationGenerations"],
 	],
 	[
 		"packages/programs/data/shared-log/src/checked-prune.ts",
@@ -38,9 +33,15 @@ const TARGETS = new Map([
 	],
 	[
 		"packages/programs/data/shared-log/src/instance-lifecycle.ts",
+		// membershipLifecycleController/ownershipLifecycleController are the
+		// index.ts _replicationLifecycleController/_repairLifecycleController
+		// entries moved file-to-file (stage 4: the lifecycle owns its
+		// controllers), not fence growth.
 		[
 			"_receiveOwnershipMutationAdmissions",
 			"_receiveOwnershipRevision",
+			"membershipLifecycleController",
+			"ownershipLifecycleController",
 			"roleGeneration",
 		],
 	],


### PR DESCRIPTION
Third stage-4 PR (#1178, #1179 merged). The architectural endpoint of the migration becomes literal: `InstanceLifecycle` physically owns both AbortControllers, and `startRepairLifecycle` is **the single rotation point** — lifecycle-and-controllers atomicity holds by construction, not convention.

## The change

- `ownershipLifecycleController` is a readonly field created with the lifecycle; `membershipLifecycleController` is minted by `beginMembership()` from the reset path. SharedLog keeps same-name delegating getters, so all ~40 read sites, every module deps closure, and every test reach-in resolve unchanged.
- `poisonReplicationOwnership` keeps its exact abort-in-place transition (abort the owned controller, no rotation) — pinned.
- The rotation aborts the predecessor's ownership controller **before** installing the fresh lifecycle, preserving the legacy ordering so a synchronous abort listener observes pre-rotation state (review-driven restoration — the initial merge had install-first).
- Deps closures for the two controllers deleted; lifecycle-internal reads are direct; `phase()` drops its now-unreachable null arm.

## Review: the first confirmed finding of the refactor — in a pin, not the code

The adversarial review's mutation testing caught that deleting the load-bearing predecessor-abort left all 21 lifecycle tests passing: every assertion routed through the *current* lifecycle's identity term, which shadows the abort. The shipped code was correct (the abort was present; its sibling mutation was killed), but the pin guarding it had no teeth. Fixed: pin P4 now asserts `c0.signal.aborted` and the stale lifecycle's `isActiveFor(c0) === false` directly — re-verified to kill the mutation. Two doc/ordering minors from the same review also addressed.

## Validation

Final 21-suite sweep + chaos: 0 failing, run with exclusive worktree access after diagnosing the session's recurring ABI flips (root cause: concurrent agents rebuilding natives under different Node versions through pnpm's ABI-blind side-effects cache — now disabled for the worktree and documented). Ratchet 13 entries with both controller entries relocated to `instance-lifecycle.ts`; guards/lint/tsc all pass. Five new pins (poison in-place, reopen co-rotation, stale membership capture, mid-open rotation, clone fallbacks).

This completes the inventoried three-quarters of stage 4. Remaining: the receive-pipeline decomposition and sync-module unification, each getting its own planning pass.