### PR TITLE
refactor(shared-log): stage-4.5 PR-2 — receive dispatcher and control-plane handlers

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -313,6 +313,31 @@ type PeerReceiveLeaseState = {
 	activeBuckets: Set<PeerReceiveLeaseBucket>;
 };
 
+/**
+ * A one-shot handle over an acquired peer receive lease. The replication-info
+ * arms of `onMessage` release the lease BEFORE joining their apply lane and
+ * the shared finally releases it on every other path; only the first release
+ * has any effect (pinned by the stage-4.5 lease one-shot test).
+ */
+type PeerReceiveLease = {
+	release: () => void;
+};
+
+const createOneShotPeerReceiveLease = (
+	releaseFn: () => void,
+): PeerReceiveLease => {
+	let released = false;
+	return {
+		release: () => {
+			if (released) {
+				return;
+			}
+			released = true;
+			releaseFn();
+		},
+	};
+};
+
 const toLocalPublicSignKey = (
 	key: PublicSignKey | string,
 ): PublicSignKey | undefined => {
@@ -16941,7 +16966,7 @@ export class SharedLog<
 		const stashBackedRawMessage = isStashBackedRawExchangeHeadsMessage(msg)
 			? msg
 			: undefined;
-		let releasePeerReceiveLease: (() => void) | undefined;
+		let peerReceiveLease: PeerReceiveLease | undefined;
 		try {
 			this.throwIfNativeDurableCommitFailed();
 			if (!context.from) {
@@ -16962,7 +16987,7 @@ export class SharedLog<
 				receiveSession?.openingBarrierActive === true;
 			const isOpeningCapabilityAdvertisement =
 				msg instanceof SyncCapabilitiesMessage && isOpeningSubscriptionReceive;
-			releasePeerReceiveLease = this.acquirePeerReceiveLease(
+			const releasePeerReceiveLease = this.acquirePeerReceiveLease(
 				receiveFromHash,
 				receiveReplicationLifecycleController,
 				receiveSession,
@@ -16978,6 +17003,7 @@ export class SharedLog<
 			if (!releasePeerReceiveLease) {
 				return;
 			}
+			peerReceiveLease = createOneShotPeerReceiveLease(releasePeerReceiveLease);
 			const receiveOwnershipRevision = this._receiveOwnershipRevision;
 			const receiveOwnershipLifecycleController =
 				this.captureReplicationOwnershipLifecycle();
@@ -19204,8 +19230,7 @@ export class SharedLog<
 					return;
 				}
 				const messageTimestamp = context.message.header.timestamp;
-				releasePeerReceiveLease?.();
-				releasePeerReceiveLease = undefined;
+				peerReceiveLease.release();
 				await this.withReplicationInfoApplyQueue(fromHash, async () => {
 					try {
 						// The peer may have unsubscribed after this message was queued.
@@ -19292,8 +19317,7 @@ export class SharedLog<
 					return;
 				}
 				const messageTimestamp = context.message.header.timestamp;
-				releasePeerReceiveLease?.();
-				releasePeerReceiveLease = undefined;
+				peerReceiveLease.release();
 				await this.withReplicationInfoApplyQueue(fromHash, async () => {
 					if (
 						!this._instanceLifecycle!.isMembershipActiveFor(
@@ -19386,8 +19410,7 @@ export class SharedLog<
 				// Every return and every locally swallowed receive error passes this
 				// boundary. Release a native wire stash exactly once first, then surface
 				// any durable mutation poison that arose while handling the message.
-				releasePeerReceiveLease?.();
-				releasePeerReceiveLease = undefined;
+				peerReceiveLease?.release();
 				this.throwIfNativeDurableCommitFailed();
 			}
 		}

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -338,6 +338,26 @@ const createOneShotPeerReceiveLease = (
 	};
 };
 
+/**
+ * Receive-scope captures shared with the extracted control-plane handlers of
+ * `onMessage` (stage 4.5). Constructed only after the Raw/ExchangeHeads fast
+ * path has returned or fallen through, so the heads path allocates nothing
+ * for it. Every field is the `onMessage` prelude capture of the same
+ * `receive*` name; the handlers re-alias them locally so their bodies stay
+ * byte-identical with the pre-extraction branches.
+ */
+type ReceiveLaneContext = {
+	fromHash: string;
+	session: PeerSession | null;
+	lifecycleController: AbortController | undefined;
+	receiveEpoch: object | null;
+	syncProfile: SyncProfileFn | undefined;
+	lease: PeerReceiveLease;
+};
+
+/** `onMessage`'s prelude throws when `from` is missing; handlers run after. */
+type ReceiveRequestContext = RequestContext & { from: PublicSignKey };
+
 const toLocalPublicSignKey = (
 	key: PublicSignKey | string,
 ): PublicSignKey | undefined => {
@@ -18900,465 +18920,90 @@ export class SharedLog<
 						}
 					}
 				}
-			} else if (msg instanceof RequestIPruneV2) {
-				const requestPruneStartedAt = syncProfileStart(syncProfile);
-				const from = context.from.hashcode();
-				const requestsByHash = new Map<string, Uint8Array>();
-				for (const request of msg.requests) {
-					if (requestsByHash.has(request.hash)) {
-						return;
-					}
-					requestsByHash.set(request.hash, request.requestId);
-				}
-				const hashes = [...requestsByHash.keys()];
-				if (hashes.length === 0) {
-					return;
-				}
-
-				const coordinatorCleanupStartedAt = syncProfileStart(syncProfile);
-				this.removeEntriesKnownByPeer(hashes, from);
-				// A prune request means the sender is preparing to stop retaining these
-				// hashes. Any receipt it gave our current generation is therefore stale,
-				// even when we cannot grant its reciprocal request.
-				this.removePruneRequestsSent(hashes, from);
-				if (syncProfile) {
-					emitSyncProfileDuration(syncProfile, coordinatorCleanupStartedAt, {
-						name: "sharedLog.receive.requestPrune.coordinatorCleanup",
-						component: "shared-log",
-						entries: hashes.length,
-						messages: 1,
-						details: { hashes: hashes.length },
-					});
-				}
-
-				const admission = await this.admitAndSendCheckedPruneGrants(
-					from,
-					msg.requests,
-				);
-				if (
-					!this.isReplicationLifecycleActive(
-						receiveReplicationLifecycleController,
-					)
-				) {
-					return;
-				}
-
-				let pendingIHaveCreated = 0;
-				let pendingIHaveExtended = 0;
-				for (const request of admission.missing) {
-					const previous = this._pendingIHave.get(request.hash);
-					if (previous) {
-						pendingIHaveExtended += 1;
-						previous.requesting.set(from, request.requestId);
-						previous.resetTimeout();
-						continue;
-					}
-
-					pendingIHaveCreated += 1;
-					const requesting = new Map([[from, request.requestId]]);
-					let pendingIHave!: PendingIHave<T>;
-					pendingIHave = {
-						requesting,
-						resetTimeout: () => this.resetPendingIHaveTimeout(pendingIHave),
-						clear: () => this.clearPendingIHaveTimeout(pendingIHave),
-						callback: async (entry: Entry<T>) => {
-							if (
-								!this.isReplicationLifecycleActive(
-									receiveReplicationLifecycleController,
-								) ||
-								requesting.size === 0
-							) {
-								return;
-							}
-							for (const requester of requesting.keys()) {
-								this.removePeerFromGidPeerHistory(requester, entry.meta.gid);
-							}
-							await Promise.all(
-								[...requesting].map(([requester, requestId]) =>
-									this.admitAndSendCheckedPruneGrants(requester, [
-										{ hash: entry.hash, requestId },
-									]),
-								),
-							);
-						},
-					};
-					this._pendingIHave.set(request.hash, pendingIHave);
-					this.resetPendingIHaveTimeout(pendingIHave);
-				}
-
-				// Close the arrival race between the in-lane presence check and
-				// installing pending-IHave. If admission completed in that window,
-				// run the same callback that onEntryAdded would have run.
-				for (const request of admission.missing) {
-					const pendingIHave = this._pendingIHave.get(request.hash);
-					if (!pendingIHave) {
-						continue;
-					}
-					let entry: Entry<T> | undefined;
-					try {
-						if (await this.log.blocks.has(request.hash)) {
-							entry = (await this.log.get(request.hash)) as
-								| Entry<T>
-								| undefined;
-						}
-					} catch {
-						// The normal entry-admission hook will retry this path.
-					}
-					if (entry && this._pendingIHave.get(request.hash) === pendingIHave) {
-						pendingIHave.clear();
-						this.runPendingIHaveCallback(pendingIHave, entry);
-					}
-				}
-
-				if (syncProfile) {
-					emitSyncProfileDuration(syncProfile, requestPruneStartedAt, {
-						name: "sharedLog.receive.requestPrune.total",
-						component: "shared-log",
-						entries: hashes.length,
-						messages: 1,
-						details: {
-							presentEntries: hashes.length - admission.missing.length,
-							leaderResponses: admission.admitted.length,
-							pendingIHaveCreated,
-							pendingIHaveExtended,
-						},
-					});
-				}
-			} else if (msg instanceof ResponseIPruneV2) {
-				const responseHashes = new Set<string>();
-				for (const request of msg.requests) {
-					if (responseHashes.has(request.hash)) {
-						return;
-					}
-					responseHashes.add(request.hash);
-				}
-				const responseTasks: Promise<void>[] = [];
-				for (const request of msg.requests) {
-					const pendingDelete = this._checkedPrune.getPendingDelete(
-						request.hash,
-					);
-					if (pendingDelete) {
-						responseTasks.push(
-							Promise.resolve(
-								pendingDelete.resolve(
-									context.from.hashcode(),
-									request.requestId,
-								),
-							),
-						);
-					}
-				}
-				const results = await Promise.allSettled(responseTasks);
-				for (const result of results) {
-					if (result.status === "rejected") {
-						logger.error(result.reason?.toString?.() ?? String(result.reason));
-					}
-				}
-			} else if (
-				msg instanceof RequestIPrune ||
-				msg instanceof ResponseIPrune
-			) {
-				// Legacy checked-prune messages are signed but uncorrelated. They cannot
-				// authorize deletion for a particular active request generation. Mixed
-				// versions intentionally retain extra copies until peers upgrade; bounded
-				// background auditing preserves convergence without weakening this gate.
-				return;
-			} else if (msg instanceof ConfirmEntriesMessage) {
-				this.markEntriesKnownByPeer(msg.hashes, context.from.hashcode());
-				this.clearRepairFrontierHashes(context.from.hashcode(), msg.hashes);
-				return;
-			} else if (msg instanceof SyncCapabilitiesMessage) {
-				if (!context.from.equals(this.node.identity.publicKey)) {
-					// No await separates this from the capture above, so the captured
-					// window state is exact: the legacy re-read of the opening map here
-					// could never observe a different value.
-					if (
-						this._peerSessions.isReplicationInfoBlocked(receiveFromHash) &&
-						isOpeningSubscriptionReceive
-					) {
-						// A prior unsubscribe cleanup may still be ahead of this reconnect
-						// barrier. Stage the new generation's one-shot advertisement so that
-						// cleanup cannot erase it before the opening transition commits.
-						this._openingSyncCapabilitiesByPeer.set(receiveFromHash, {
-							epoch: receiveSession!,
-							capabilities: msg.capabilities,
-						});
-					} else {
-						this._peerSyncCapabilities.set(receiveFromHash, msg.capabilities);
-					}
-				}
-				return;
-			} else if (await this.syncronizer.onMessage(msg, context)) {
-				return; // the syncronizer has handled the message
-			} else if (msg instanceof BlocksMessage) {
-				await this.remoteBlocks.onMessage(msg.message, {
-					from: context.from!.hashcode(),
-					transport: createRequestTransportContext(context.message),
-				});
-			} else if (msg instanceof ReplicationPingMessage) {
-				// No-op: used as an ACKed unicast liveness probe.
-			} else if (msg instanceof RequestReplicationInfoMessage) {
-				if (context.from.equals(this.node.identity.publicKey)) {
-					return;
-				}
-				const replicationLifecycleController =
-					receiveReplicationLifecycleController;
-				if (
-					!replicationLifecycleController ||
-					!this.isPeerReceiveAdmissionOpen(
-						receiveFromHash,
-						replicationLifecycleController,
-						receiveSession,
-					)
-				) {
-					return;
-				}
-
-				let replicationSegments: ReplicationRangeIndexable<R>[];
-				try {
-					replicationSegments = await this.getMyReplicationSegments();
-				} catch (error) {
-					if (
-						!this.isPeerReceiveAdmissionOpen(
-							receiveFromHash,
-							replicationLifecycleController,
-							receiveSession,
-						) &&
-						isNotStartedError(error as Error)
-					) {
-						return;
-					}
-					throw error;
-				}
-				if (
-					!this.isPeerReceiveAdmissionOpen(
-						receiveFromHash,
-						replicationLifecycleController,
-						receiveSession,
-					)
-				) {
-					return;
-				}
-				const segments = replicationSegments.map((x) => x.toReplicationRange());
-				this.validatePersistedReplicationRangeSnapshot(segments);
-
-				await this.rpc
-					.send(new AllReplicatingSegmentsMessage({ segments }), {
-						mode: new AcknowledgeDelivery({
-							to: [context.from],
-							redundancy: 1,
-						}),
-						signal: replicationLifecycleController.signal,
-					})
-					.catch((error) =>
-						this.handleReplicationLifecycleSendError(
-							error,
-							replicationLifecycleController,
-						),
-					);
-				if (
-					!this.isPeerReceiveAdmissionOpen(
-						receiveFromHash,
-						replicationLifecycleController,
-						receiveSession,
-					)
-				) {
-					return;
-				}
-
-				// for backwards compatibility (v8) remove this when we are sure that all nodes are v9+
-				if (this.v8Behaviour) {
-					const role = this.getRoleFromReplicationSegments(replicationSegments);
-					if (role instanceof Replicator) {
-						const fixedSettings = !this._isAdaptiveReplicating;
-						if (fixedSettings) {
-							await this.rpc
-								.send(
-									new ResponseRoleMessage({
-										role,
-									}),
-									{
-										mode: new SilentDelivery({
-											to: [context.from],
-											redundancy: 1,
-										}),
-										signal: replicationLifecycleController.signal,
-									},
-								)
-								.catch((error) =>
-									this.handleReplicationLifecycleSendError(
-										error,
-										replicationLifecycleController,
-									),
-								);
-						}
-					}
-				}
-			} else if (
-				msg instanceof AllReplicatingSegmentsMessage ||
-				msg instanceof AddedReplicationSegmentMessage
-			) {
-				if (context.from.equals(this.node.identity.publicKey)) {
-					return;
-				}
-
-				const replicationInfoMessage = msg as
-					| AllReplicatingSegmentsMessage
-					| AddedReplicationSegmentMessage;
-
-				// Process replication updates even if the sender isn't yet considered "ready" by
-				// `Program.waitFor()`. Dropping these messages can lead to missing replicator info
-				// (and downstream `waitForReplicator()` timeouts) under timing-sensitive joins.
-				const from = context.from!;
-				const fromHash = from.hashcode();
-				// Pre-lane gate: lifecycle -> receive-epoch -> blocked, exactly the
-				// legacy order. isMembershipActiveFor is the unit-pinned fold of
-				// isReplicationLifecycleActive; isReceiveEpochCurrent is the
-				// relocated `===`-with-`?? null`. The DELIBERATE absence of a
-				// subscription-epoch term is preserved: the lease already validated
-				// it, and the in-lane recheck owns post-await staleness.
-				if (
-					!this._instanceLifecycle!.isMembershipActiveFor(
-						receiveReplicationLifecycleController,
-					) ||
-					!this._peerSessions.isReceiveEpochCurrent(
-						receiveFromHash,
-						receiveReplicationInfoReceiveEpoch,
-					) ||
-					this._peerSessions.isReplicationInfoBlocked(fromHash)
-				) {
-					return;
-				}
-				const messageTimestamp = context.message.header.timestamp;
-				peerReceiveLease.release();
-				await this.withReplicationInfoApplyQueue(fromHash, async () => {
-					try {
-						// The peer may have unsubscribed after this message was queued.
-						// In-lane gate: lifecycle -> subscription-epoch -> receive-epoch
-						// -> blocked, term for term as before the session migration.
-						if (
-							!this._instanceLifecycle!.isMembershipActiveFor(
-								receiveReplicationLifecycleController,
-							) ||
-							!this._peerSessions.isCurrent(fromHash, receiveSession) ||
-							!this._peerSessions.isReceiveEpochCurrent(
-								fromHash,
-								receiveReplicationInfoReceiveEpoch,
-							) ||
-							this._peerSessions.isReplicationInfoBlocked(fromHash)
-						) {
-							return;
-						}
-
-						// Process in-order to avoid races where repeated reset messages arrive
-						// concurrently and trigger spurious "added" diffs / rebalancing.
-						const prev = this.latestReplicationInfoMessage.get(fromHash);
-						if (prev && prev > messageTimestamp) {
-							return;
-						}
-
-						this.latestReplicationInfoMessage.set(fromHash, messageTimestamp);
-						this._replicatorLivenessFailures.delete(fromHash);
-
-						if (this.closed) {
-							return;
-						}
-
-						const reset = msg instanceof AllReplicatingSegmentsMessage;
-						await this.addReplicationRange(
-							replicationInfoMessage.segments.map((x) =>
-								x.toReplicationRangeIndexable(from),
-							),
-							from,
-							{
-								reset,
-								checkDuplicates: true,
-								timestamp: Number(messageTimestamp),
-								allowLegacyOrderedReplacementPairs:
-									msg instanceof AddedReplicationSegmentMessage,
-							},
-						);
-
-						// If the peer reports any replication segments, stop re-requesting.
-						// (Empty reports can be transient during startup.)
-						if (replicationInfoMessage.segments.length > 0) {
-							this.cancelReplicationInfoRequests(fromHash);
-						}
-					} catch (e) {
-						if (isNotStartedError(e as Error)) {
-							return;
-						}
-						logger.error(
-							`Failed to apply replication settings from '${fromHash}': ${
-								(e as any)?.message ?? e
-							}`,
-						);
-					}
-				});
-			} else if (msg instanceof StoppedReplicating) {
-				const from = context.from!;
-				const segmentIds = msg.segmentIds;
-				if (from.equals(this.node.identity.publicKey)) {
-					return;
-				}
-				const fromHash = from.hashcode();
-				// Same pre-lane gate shape as Added/All above (and the same
-				// intentional absence of a subscription-epoch term).
-				if (
-					!this._instanceLifecycle!.isMembershipActiveFor(
-						receiveReplicationLifecycleController,
-					) ||
-					!this._peerSessions.isReceiveEpochCurrent(
-						receiveFromHash,
-						receiveReplicationInfoReceiveEpoch,
-					) ||
-					this._peerSessions.isReplicationInfoBlocked(fromHash)
-				) {
-					return;
-				}
-				const messageTimestamp = context.message.header.timestamp;
-				peerReceiveLease.release();
-				await this.withReplicationInfoApplyQueue(fromHash, async () => {
-					if (
-						!this._instanceLifecycle!.isMembershipActiveFor(
-							receiveReplicationLifecycleController,
-						) ||
-						!this._peerSessions.isCurrent(fromHash, receiveSession) ||
-						!this._peerSessions.isReceiveEpochCurrent(
-							fromHash,
-							receiveReplicationInfoReceiveEpoch,
-						) ||
-						this._peerSessions.isReplicationInfoBlocked(fromHash)
-					) {
-						return;
-					}
-
-					const previousTimestamp =
-						this.latestReplicationInfoMessage.get(fromHash);
-					if (previousTimestamp && previousTimestamp > messageTimestamp) {
-						return;
-					}
-					this.latestReplicationInfoMessage.set(fromHash, messageTimestamp);
-					this._replicatorLivenessFailures.delete(fromHash);
-					if (this.closed) {
-						return;
-					}
-
-					const rangesToRemove =
-						await this.resolveReplicationRangesFromIdsAndKey(segmentIds, from);
-
-					await this.removeReplicationRanges(rangesToRemove, from);
-					const timestamp = BigInt(+new Date());
-					for (const range of rangesToRemove) {
-						this.replicationChangeDebounceFn.add({
-							range,
-							type: "removed",
-							timestamp,
-						});
-					}
-				});
 			} else {
-				throw new Error("Unexpected message");
+				// Control-plane dispatch (stage 4.5). The lane context is built
+				// only after the Raw/ExchangeHeads fast path has returned or
+				// fallen through, so the heads path allocates nothing for it.
+				// Branch order, branch bodies and the shared catch/finally
+				// envelope are unchanged: the five extracted handlers hold the
+				// former branch bodies verbatim behind alias preambles.
+				const lane: ReceiveLaneContext = {
+					fromHash: receiveFromHash,
+					session: receiveSession,
+					lifecycleController: receiveReplicationLifecycleController,
+					receiveEpoch: receiveReplicationInfoReceiveEpoch,
+					syncProfile,
+					lease: peerReceiveLease,
+				};
+				// The prelude already threw when `context.from` was missing.
+				const laneRequestContext = context as ReceiveRequestContext;
+				if (msg instanceof RequestIPruneV2) {
+					await this.handleRequestIPruneV2(msg, laneRequestContext, lane);
+				} else if (msg instanceof ResponseIPruneV2) {
+					await this.handleResponseIPruneV2(msg, laneRequestContext, lane);
+				} else if (
+					msg instanceof RequestIPrune ||
+					msg instanceof ResponseIPrune
+				) {
+					// Legacy checked-prune messages are signed but uncorrelated. They cannot
+					// authorize deletion for a particular active request generation. Mixed
+					// versions intentionally retain extra copies until peers upgrade; bounded
+					// background auditing preserves convergence without weakening this gate.
+					return;
+				} else if (msg instanceof ConfirmEntriesMessage) {
+					this.markEntriesKnownByPeer(msg.hashes, context.from.hashcode());
+					this.clearRepairFrontierHashes(context.from.hashcode(), msg.hashes);
+					return;
+				} else if (msg instanceof SyncCapabilitiesMessage) {
+					if (!context.from.equals(this.node.identity.publicKey)) {
+						// No await separates this from the capture above, so the captured
+						// window state is exact: the legacy re-read of the opening map here
+						// could never observe a different value.
+						if (
+							this._peerSessions.isReplicationInfoBlocked(receiveFromHash) &&
+							isOpeningSubscriptionReceive
+						) {
+							// A prior unsubscribe cleanup may still be ahead of this reconnect
+							// barrier. Stage the new generation's one-shot advertisement so that
+							// cleanup cannot erase it before the opening transition commits.
+							this._openingSyncCapabilitiesByPeer.set(receiveFromHash, {
+								epoch: receiveSession!,
+								capabilities: msg.capabilities,
+							});
+						} else {
+							this._peerSyncCapabilities.set(receiveFromHash, msg.capabilities);
+						}
+					}
+					return;
+				} else if (await this.syncronizer.onMessage(msg, context)) {
+					return; // the syncronizer has handled the message
+				} else if (msg instanceof BlocksMessage) {
+					await this.remoteBlocks.onMessage(msg.message, {
+						from: context.from!.hashcode(),
+						transport: createRequestTransportContext(context.message),
+					});
+				} else if (msg instanceof ReplicationPingMessage) {
+					// No-op: used as an ACKed unicast liveness probe.
+				} else if (msg instanceof RequestReplicationInfoMessage) {
+					await this.handleRequestReplicationInfo(
+						msg,
+						laneRequestContext,
+						lane,
+					);
+				} else if (
+					msg instanceof AllReplicatingSegmentsMessage ||
+					msg instanceof AddedReplicationSegmentMessage
+				) {
+					await this.handleReplicationInfoAnnouncement(
+						msg,
+						laneRequestContext,
+						lane,
+					);
+				} else if (msg instanceof StoppedReplicating) {
+					await this.handleStoppedReplicating(msg, laneRequestContext, lane);
+				} else {
+					throw new Error("Unexpected message");
+				}
 			}
 		} catch (e: any) {
 			if (e instanceof NativeDurableCommitError) {
@@ -19414,6 +19059,471 @@ export class SharedLog<
 				this.throwIfNativeDurableCommitFailed();
 			}
 		}
+	}
+
+	// -----------------------------------------------------------------
+	// Stage-4.5 control-plane receive handlers. Each holds the former
+	// `onMessage` branch body VERBATIM behind a small alias preamble that
+	// maps the receive-lane context back onto the prelude capture names;
+	// the preamble is the only glue. Throws intentionally traverse
+	// `onMessage`'s shared catch/finally envelope (error classification,
+	// wire-stash release, lease release, durable-poison recheck).
+	// -----------------------------------------------------------------
+
+	private async handleRequestIPruneV2(
+		msg: RequestIPruneV2,
+		context: ReceiveRequestContext,
+		lane: ReceiveLaneContext,
+	): Promise<void> {
+		const syncProfile = lane.syncProfile;
+		const receiveReplicationLifecycleController = lane.lifecycleController;
+		const requestPruneStartedAt = syncProfileStart(syncProfile);
+		const from = context.from.hashcode();
+		const requestsByHash = new Map<string, Uint8Array>();
+		for (const request of msg.requests) {
+			if (requestsByHash.has(request.hash)) {
+				return;
+			}
+			requestsByHash.set(request.hash, request.requestId);
+		}
+		const hashes = [...requestsByHash.keys()];
+		if (hashes.length === 0) {
+			return;
+		}
+
+		const coordinatorCleanupStartedAt = syncProfileStart(syncProfile);
+		this.removeEntriesKnownByPeer(hashes, from);
+		// A prune request means the sender is preparing to stop retaining these
+		// hashes. Any receipt it gave our current generation is therefore stale,
+		// even when we cannot grant its reciprocal request.
+		this.removePruneRequestsSent(hashes, from);
+		if (syncProfile) {
+			emitSyncProfileDuration(syncProfile, coordinatorCleanupStartedAt, {
+				name: "sharedLog.receive.requestPrune.coordinatorCleanup",
+				component: "shared-log",
+				entries: hashes.length,
+				messages: 1,
+				details: { hashes: hashes.length },
+			});
+		}
+
+		const admission = await this.admitAndSendCheckedPruneGrants(
+			from,
+			msg.requests,
+		);
+		if (
+			!this.isReplicationLifecycleActive(
+				receiveReplicationLifecycleController,
+			)
+		) {
+			return;
+		}
+
+		let pendingIHaveCreated = 0;
+		let pendingIHaveExtended = 0;
+		for (const request of admission.missing) {
+			const previous = this._pendingIHave.get(request.hash);
+			if (previous) {
+				pendingIHaveExtended += 1;
+				previous.requesting.set(from, request.requestId);
+				previous.resetTimeout();
+				continue;
+			}
+
+			pendingIHaveCreated += 1;
+			const requesting = new Map([[from, request.requestId]]);
+			let pendingIHave!: PendingIHave<T>;
+			pendingIHave = {
+				requesting,
+				resetTimeout: () => this.resetPendingIHaveTimeout(pendingIHave),
+				clear: () => this.clearPendingIHaveTimeout(pendingIHave),
+				callback: async (entry: Entry<T>) => {
+					if (
+						!this.isReplicationLifecycleActive(
+							receiveReplicationLifecycleController,
+						) ||
+						requesting.size === 0
+					) {
+						return;
+					}
+					for (const requester of requesting.keys()) {
+						this.removePeerFromGidPeerHistory(requester, entry.meta.gid);
+					}
+					await Promise.all(
+						[...requesting].map(([requester, requestId]) =>
+							this.admitAndSendCheckedPruneGrants(requester, [
+								{ hash: entry.hash, requestId },
+							]),
+						),
+					);
+				},
+			};
+			this._pendingIHave.set(request.hash, pendingIHave);
+			this.resetPendingIHaveTimeout(pendingIHave);
+		}
+
+		// Close the arrival race between the in-lane presence check and
+		// installing pending-IHave. If admission completed in that window,
+		// run the same callback that onEntryAdded would have run.
+		for (const request of admission.missing) {
+			const pendingIHave = this._pendingIHave.get(request.hash);
+			if (!pendingIHave) {
+				continue;
+			}
+			let entry: Entry<T> | undefined;
+			try {
+				if (await this.log.blocks.has(request.hash)) {
+					entry = (await this.log.get(request.hash)) as
+						| Entry<T>
+						| undefined;
+				}
+			} catch {
+				// The normal entry-admission hook will retry this path.
+			}
+			if (entry && this._pendingIHave.get(request.hash) === pendingIHave) {
+				pendingIHave.clear();
+				this.runPendingIHaveCallback(pendingIHave, entry);
+			}
+		}
+
+		if (syncProfile) {
+			emitSyncProfileDuration(syncProfile, requestPruneStartedAt, {
+				name: "sharedLog.receive.requestPrune.total",
+				component: "shared-log",
+				entries: hashes.length,
+				messages: 1,
+				details: {
+					presentEntries: hashes.length - admission.missing.length,
+					leaderResponses: admission.admitted.length,
+					pendingIHaveCreated,
+					pendingIHaveExtended,
+				},
+			});
+		}
+	}
+
+	private async handleResponseIPruneV2(
+		msg: ResponseIPruneV2,
+		context: ReceiveRequestContext,
+		_lane: ReceiveLaneContext,
+	): Promise<void> {
+		const responseHashes = new Set<string>();
+		for (const request of msg.requests) {
+			if (responseHashes.has(request.hash)) {
+				return;
+			}
+			responseHashes.add(request.hash);
+		}
+		const responseTasks: Promise<void>[] = [];
+		for (const request of msg.requests) {
+			const pendingDelete = this._checkedPrune.getPendingDelete(
+				request.hash,
+			);
+			if (pendingDelete) {
+				responseTasks.push(
+					Promise.resolve(
+						pendingDelete.resolve(
+							context.from.hashcode(),
+							request.requestId,
+						),
+					),
+				);
+			}
+		}
+		const results = await Promise.allSettled(responseTasks);
+		for (const result of results) {
+			if (result.status === "rejected") {
+				logger.error(result.reason?.toString?.() ?? String(result.reason));
+			}
+		}
+	}
+
+	private async handleRequestReplicationInfo(
+		_msg: RequestReplicationInfoMessage,
+		context: ReceiveRequestContext,
+		lane: ReceiveLaneContext,
+	): Promise<void> {
+		const receiveFromHash = lane.fromHash;
+		const receiveSession = lane.session;
+		const receiveReplicationLifecycleController = lane.lifecycleController;
+		if (context.from.equals(this.node.identity.publicKey)) {
+			return;
+		}
+		const replicationLifecycleController =
+			receiveReplicationLifecycleController;
+		if (
+			!replicationLifecycleController ||
+			!this.isPeerReceiveAdmissionOpen(
+				receiveFromHash,
+				replicationLifecycleController,
+				receiveSession,
+			)
+		) {
+			return;
+		}
+
+		let replicationSegments: ReplicationRangeIndexable<R>[];
+		try {
+			replicationSegments = await this.getMyReplicationSegments();
+		} catch (error) {
+			if (
+				!this.isPeerReceiveAdmissionOpen(
+					receiveFromHash,
+					replicationLifecycleController,
+					receiveSession,
+				) &&
+				isNotStartedError(error as Error)
+			) {
+				return;
+			}
+			throw error;
+		}
+		if (
+			!this.isPeerReceiveAdmissionOpen(
+				receiveFromHash,
+				replicationLifecycleController,
+				receiveSession,
+			)
+		) {
+			return;
+		}
+		const segments = replicationSegments.map((x) => x.toReplicationRange());
+		this.validatePersistedReplicationRangeSnapshot(segments);
+
+		await this.rpc
+			.send(new AllReplicatingSegmentsMessage({ segments }), {
+				mode: new AcknowledgeDelivery({
+					to: [context.from],
+					redundancy: 1,
+				}),
+				signal: replicationLifecycleController.signal,
+			})
+			.catch((error) =>
+				this.handleReplicationLifecycleSendError(
+					error,
+					replicationLifecycleController,
+				),
+			);
+		if (
+			!this.isPeerReceiveAdmissionOpen(
+				receiveFromHash,
+				replicationLifecycleController,
+				receiveSession,
+			)
+		) {
+			return;
+		}
+
+		// for backwards compatibility (v8) remove this when we are sure that all nodes are v9+
+		if (this.v8Behaviour) {
+			const role = this.getRoleFromReplicationSegments(replicationSegments);
+			if (role instanceof Replicator) {
+				const fixedSettings = !this._isAdaptiveReplicating;
+				if (fixedSettings) {
+					await this.rpc
+						.send(
+							new ResponseRoleMessage({
+								role,
+							}),
+							{
+								mode: new SilentDelivery({
+									to: [context.from],
+									redundancy: 1,
+								}),
+								signal: replicationLifecycleController.signal,
+							},
+						)
+						.catch((error) =>
+							this.handleReplicationLifecycleSendError(
+								error,
+								replicationLifecycleController,
+							),
+						);
+				}
+			}
+		}
+	}
+
+	private async handleReplicationInfoAnnouncement(
+		msg: AllReplicatingSegmentsMessage | AddedReplicationSegmentMessage,
+		context: ReceiveRequestContext,
+		lane: ReceiveLaneContext,
+	): Promise<void> {
+		const receiveFromHash = lane.fromHash;
+		const receiveSession = lane.session;
+		const receiveReplicationLifecycleController = lane.lifecycleController;
+		const receiveReplicationInfoReceiveEpoch = lane.receiveEpoch;
+		const peerReceiveLease = lane.lease;
+		if (context.from.equals(this.node.identity.publicKey)) {
+			return;
+		}
+
+		const replicationInfoMessage = msg as
+			| AllReplicatingSegmentsMessage
+			| AddedReplicationSegmentMessage;
+
+		// Process replication updates even if the sender isn't yet considered "ready" by
+		// `Program.waitFor()`. Dropping these messages can lead to missing replicator info
+		// (and downstream `waitForReplicator()` timeouts) under timing-sensitive joins.
+		const from = context.from!;
+		const fromHash = from.hashcode();
+		// Pre-lane gate: lifecycle -> receive-epoch -> blocked, exactly the
+		// legacy order. isMembershipActiveFor is the unit-pinned fold of
+		// isReplicationLifecycleActive; isReceiveEpochCurrent is the
+		// relocated `===`-with-`?? null`. The DELIBERATE absence of a
+		// subscription-epoch term is preserved: the lease already validated
+		// it, and the in-lane recheck owns post-await staleness.
+		if (
+			!this._instanceLifecycle!.isMembershipActiveFor(
+				receiveReplicationLifecycleController,
+			) ||
+			!this._peerSessions.isReceiveEpochCurrent(
+				receiveFromHash,
+				receiveReplicationInfoReceiveEpoch,
+			) ||
+			this._peerSessions.isReplicationInfoBlocked(fromHash)
+		) {
+			return;
+		}
+		const messageTimestamp = context.message.header.timestamp;
+		peerReceiveLease.release();
+		await this.withReplicationInfoApplyQueue(fromHash, async () => {
+			try {
+				// The peer may have unsubscribed after this message was queued.
+				// In-lane gate: lifecycle -> subscription-epoch -> receive-epoch
+				// -> blocked, term for term as before the session migration.
+				if (
+					!this._instanceLifecycle!.isMembershipActiveFor(
+						receiveReplicationLifecycleController,
+					) ||
+					!this._peerSessions.isCurrent(fromHash, receiveSession) ||
+					!this._peerSessions.isReceiveEpochCurrent(
+						fromHash,
+						receiveReplicationInfoReceiveEpoch,
+					) ||
+					this._peerSessions.isReplicationInfoBlocked(fromHash)
+				) {
+					return;
+				}
+
+				// Process in-order to avoid races where repeated reset messages arrive
+				// concurrently and trigger spurious "added" diffs / rebalancing.
+				const prev = this.latestReplicationInfoMessage.get(fromHash);
+				if (prev && prev > messageTimestamp) {
+					return;
+				}
+
+				this.latestReplicationInfoMessage.set(fromHash, messageTimestamp);
+				this._replicatorLivenessFailures.delete(fromHash);
+
+				if (this.closed) {
+					return;
+				}
+
+				const reset = msg instanceof AllReplicatingSegmentsMessage;
+				await this.addReplicationRange(
+					replicationInfoMessage.segments.map((x) =>
+						x.toReplicationRangeIndexable(from),
+					),
+					from,
+					{
+						reset,
+						checkDuplicates: true,
+						timestamp: Number(messageTimestamp),
+						allowLegacyOrderedReplacementPairs:
+							msg instanceof AddedReplicationSegmentMessage,
+					},
+				);
+
+				// If the peer reports any replication segments, stop re-requesting.
+				// (Empty reports can be transient during startup.)
+				if (replicationInfoMessage.segments.length > 0) {
+					this.cancelReplicationInfoRequests(fromHash);
+				}
+			} catch (e) {
+				if (isNotStartedError(e as Error)) {
+					return;
+				}
+				logger.error(
+					`Failed to apply replication settings from '${fromHash}': ${
+						(e as any)?.message ?? e
+					}`,
+				);
+			}
+		});
+	}
+
+	private async handleStoppedReplicating(
+		msg: StoppedReplicating,
+		context: ReceiveRequestContext,
+		lane: ReceiveLaneContext,
+	): Promise<void> {
+		const receiveFromHash = lane.fromHash;
+		const receiveSession = lane.session;
+		const receiveReplicationLifecycleController = lane.lifecycleController;
+		const receiveReplicationInfoReceiveEpoch = lane.receiveEpoch;
+		const peerReceiveLease = lane.lease;
+		const from = context.from!;
+		const segmentIds = msg.segmentIds;
+		if (from.equals(this.node.identity.publicKey)) {
+			return;
+		}
+		const fromHash = from.hashcode();
+		// Same pre-lane gate shape as Added/All above (and the same
+		// intentional absence of a subscription-epoch term).
+		if (
+			!this._instanceLifecycle!.isMembershipActiveFor(
+				receiveReplicationLifecycleController,
+			) ||
+			!this._peerSessions.isReceiveEpochCurrent(
+				receiveFromHash,
+				receiveReplicationInfoReceiveEpoch,
+			) ||
+			this._peerSessions.isReplicationInfoBlocked(fromHash)
+		) {
+			return;
+		}
+		const messageTimestamp = context.message.header.timestamp;
+		peerReceiveLease.release();
+		await this.withReplicationInfoApplyQueue(fromHash, async () => {
+			if (
+				!this._instanceLifecycle!.isMembershipActiveFor(
+					receiveReplicationLifecycleController,
+				) ||
+				!this._peerSessions.isCurrent(fromHash, receiveSession) ||
+				!this._peerSessions.isReceiveEpochCurrent(
+					fromHash,
+					receiveReplicationInfoReceiveEpoch,
+				) ||
+				this._peerSessions.isReplicationInfoBlocked(fromHash)
+			) {
+				return;
+			}
+
+			const previousTimestamp =
+				this.latestReplicationInfoMessage.get(fromHash);
+			if (previousTimestamp && previousTimestamp > messageTimestamp) {
+				return;
+			}
+			this.latestReplicationInfoMessage.set(fromHash, messageTimestamp);
+			this._replicatorLivenessFailures.delete(fromHash);
+			if (this.closed) {
+				return;
+			}
+
+			const rangesToRemove =
+				await this.resolveReplicationRangesFromIdsAndKey(segmentIds, from);
+
+			await this.removeReplicationRanges(rangesToRemove, from);
+			const timestamp = BigInt(+new Date());
+			for (const range of rangesToRemove) {
+				this.replicationChangeDebounceFn.add({
+					range,
+					type: "removed",
+					timestamp,
+				});
+			}
+		});
 	}
 
 	async calculateTotalParticipation(options?: { sum?: boolean }) {

--- a/packages/programs/data/shared-log/test/receive-admission-pins.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission-pins.spec.ts
@@ -19,15 +19,31 @@
 // internal window probes were re-pointed to the fences' stage-3 homes (the
 // receive-epoch map on the PeerSessionRegistry, the opening-barrier flag on
 // the PeerSession).
+import { BorshError } from "@dao-xyz/borsh";
+import { AccessError } from "@peerbit/crypto";
 import { TestSession } from "@peerbit/test-utils";
-import { waitForResolved } from "@peerbit/time";
+import { AbortError, waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
 import pDefer from "p-defer";
 import sinon from "sinon";
-import { SyncCapabilitiesMessage } from "../src/exchange-heads.js";
+import { NativeDurableCommitError } from "../src/errors.js";
+import {
+	RequestIPruneV2,
+	ResponseIPruneV2,
+	StashBackedRawExchangeHeadsMessage,
+	SyncCapabilitiesMessage,
+} from "../src/exchange-heads.js";
 import { createReplicationDomainHash } from "../src/replication-domain-hash.js";
-import { AddedReplicationSegmentMessage } from "../src/replication.js";
-import { RequestMaybeSync, SimpleSyncronizer } from "../src/sync/simple.js";
+import {
+	AddedReplicationSegmentMessage,
+	AllReplicatingSegmentsMessage,
+	RequestReplicationInfoMessage,
+} from "../src/replication.js";
+import {
+	ConfirmEntriesMessage,
+	RequestMaybeSync,
+	SimpleSyncronizer,
+} from "../src/sync/simple.js";
 import { EventStore } from "./utils/stores/event-store.js";
 
 const setup = {
@@ -357,6 +373,399 @@ describe("receive admission opening-barrier windows", () => {
 			}
 		} finally {
 			releasePark.resolve();
+			await session.stop();
+		}
+	});
+});
+
+// Stage-4.5 PR-2 pinning tests (P5-P7). These pin the dispatcher facts that
+// must survive the extraction of the five cold control-plane branches out of
+// `onMessage` (both checked-prune protocol arms and the three
+// replication-info arms):
+//
+// P5. DISPATCH PRECEDENCE: the control-plane arms declared ahead of the
+//     synchronizer delegation (checked prune, ConfirmEntries,
+//     SyncCapabilities) never reach `syncronizer.onMessage`, and the arms
+//     declared behind it (RequestReplicationInfoMessage) run only when the
+//     synchronizer declines.
+//
+// P6. LEASE ONE-SHOT: a replication-info announcement releases its receive
+//     lease BEFORE joining the per-peer apply lane (a stalled lane does not
+//     hold `_activeReceiveHandlersByPeer`), and the finally's release after
+//     the mid-branch release has no effect on concurrently held leases.
+//
+// P7. ERROR ENVELOPE: control-plane handler throws traverse the shared
+//     classifier (AccessError/BorshError/AbortError swallowed while
+//     NativeDurableCommitError propagates), and the wire-stash release in
+//     the finally runs exactly once, before the poison recheck.
+
+describe("receive admission control-plane dispatch precedence", () => {
+	it("handles prune, confirm and capability messages ahead of the synchronizer", async () => {
+		const session = await TestSession.disconnected(2);
+		try {
+			const store = new EventStore<string, any>();
+			const source = await session.peers[0].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const sharedLog = target.log as any;
+			const sourceKey = source.node.identity.publicKey;
+			const sourceHash = sourceKey.hashcode();
+			sharedLog.advanceSubscriptionEpoch(sourceHash, "opening");
+
+			const synchronizer = sinon.spy(sharedLog.syncronizer, "onMessage");
+			const removeKnown = sinon.spy(sharedLog, "removeEntriesKnownByPeer");
+			const admit = sinon
+				.stub(sharedLog, "admitAndSendCheckedPruneGrants")
+				.resolves({ missing: [], admitted: [] });
+			const pendingDelete = sinon.spy(
+				sharedLog._checkedPrune,
+				"getPendingDelete",
+			);
+			const markKnown = sinon.spy(sharedLog, "markEntriesKnownByPeer");
+			try {
+				const pruneRequest = new RequestIPruneV2({
+					requests: [{ hash: "hash-a", requestId: new Uint8Array(32) }],
+				});
+				await target.log.onMessage(pruneRequest, { from: sourceKey } as any);
+				expect(removeKnown.calledOnce).to.be.true;
+				expect(admit.calledOnce).to.be.true;
+
+				const pruneResponse = new ResponseIPruneV2({
+					requests: [{ hash: "hash-a", requestId: new Uint8Array(32) }],
+				});
+				await target.log.onMessage(pruneResponse, { from: sourceKey } as any);
+				expect(pendingDelete.calledOnce).to.be.true;
+
+				const confirm = new ConfirmEntriesMessage({ hashes: ["hash-a"] });
+				await target.log.onMessage(confirm, { from: sourceKey } as any);
+				expect(markKnown.calledOnce).to.be.true;
+
+				const capabilities = new SyncCapabilitiesMessage({ capabilities: 3 });
+				await target.log.onMessage(capabilities, { from: sourceKey } as any);
+				expect(sharedLog._peerSyncCapabilities.get(sourceHash)).to.equal(3);
+
+				// None of the pre-delegation arms consulted the synchronizer.
+				const seen = synchronizer.getCalls().map((call) => call.args[0]);
+				expect(seen).to.not.include(pruneRequest);
+				expect(seen).to.not.include(pruneResponse);
+				expect(seen).to.not.include(confirm);
+				expect(seen).to.not.include(capabilities);
+			} finally {
+				synchronizer.restore();
+				removeKnown.restore();
+				admit.restore();
+				pendingDelete.restore();
+				markKnown.restore();
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("reaches the replication-info request arm only when the synchronizer declines", async () => {
+		const session = await TestSession.disconnected(2);
+		try {
+			const store = new EventStore<string, any>();
+			const source = await session.peers[0].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: { replicate: 1, setup },
+			});
+			const sharedLog = target.log as any;
+			const sourceKey = source.node.identity.publicKey;
+			const sourceHash = sourceKey.hashcode();
+			sharedLog.advanceSubscriptionEpoch(sourceHash, "opening");
+
+			const send = sinon.stub(sharedLog.rpc, "send").resolves();
+			const segments = sinon.spy(sharedLog, "getMyReplicationSegments");
+			let claim = true;
+			const originalSynchronizerOnMessage =
+				sharedLog.syncronizer.onMessage.bind(sharedLog.syncronizer);
+			const synchronizer = sinon
+				.stub(sharedLog.syncronizer, "onMessage")
+				.callsFake(async (message: unknown, context: unknown) => {
+					if (message instanceof RequestReplicationInfoMessage) {
+						return claim;
+					}
+					return originalSynchronizerOnMessage(message, context);
+				});
+			const sentSegmentsMessages = () =>
+				send
+					.getCalls()
+					.filter(
+						(call) => call.args[0] instanceof AllReplicatingSegmentsMessage,
+					).length;
+			try {
+				// Claimed by the synchronizer: the arm behind the delegation must
+				// not run.
+				await target.log.onMessage(new RequestReplicationInfoMessage(), {
+					from: sourceKey,
+				} as any);
+				expect(segments.called).to.be.false;
+				expect(sentSegmentsMessages()).to.equal(0);
+
+				// Declined: the arm answers with the local segments.
+				claim = false;
+				await target.log.onMessage(new RequestReplicationInfoMessage(), {
+					from: sourceKey,
+				} as any);
+				expect(segments.called).to.be.true;
+				expect(sentSegmentsMessages()).to.equal(1);
+			} finally {
+				synchronizer.restore();
+				segments.restore();
+				send.restore();
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+});
+
+describe("receive admission control-plane lease one-shot", () => {
+	it("releases the receive lease before the apply lane and never twice", async () => {
+		const session = await TestSession.connected(2);
+		const laneEntered = pDefer<void>();
+		const releaseLane = pDefer<void>();
+		let parkedLane: Promise<void> | undefined;
+		let receive: Promise<void> | undefined;
+		try {
+			const store = new EventStore<string, any>();
+			const target = await session.peers[0].open(store, {
+				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+			});
+			await session.peers[1].open(store.clone(), {
+				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+			});
+			const sharedLog = target.log as any;
+			const sourceKey = session.peers[1].identity.publicKey;
+			const sourceHash = sourceKey.hashcode();
+			let remoteRange: any;
+			await waitForResolved(async () => {
+				const ranges = await target.log.replicationIndex
+					.iterate({ query: { hash: sourceHash } })
+					.all();
+				expect(ranges).to.have.length.greaterThan(0);
+				remoteRange = ranges[0].value;
+			});
+			const scheduleRequests = sinon
+				.stub(sharedLog, "scheduleReplicationInfoRequests")
+				.callsFake(() => {});
+			try {
+				// Hold a second lease in the same bucket: a lost mid-branch release
+				// would keep the bucket at 2, and any extra release (e.g. a finally
+				// that releases again) would drain this lease's slot too — both
+				// visibly different from the pinned steady state of 1.
+				const extraRelease = sharedLog.acquirePeerReceiveLease(
+					sourceHash,
+					sharedLog._replicationLifecycleController,
+					sharedLog._peerSessions.current(sourceHash),
+				);
+				expect(extraRelease).to.exist;
+				await waitForResolved(() =>
+					expect(
+						sharedLog._activeReceiveHandlersByPeer.get(sourceHash)?.current
+							.active,
+					).to.equal(1),
+				);
+
+				// Park the per-peer apply lane so the announcement's lane turn
+				// queues behind it.
+				parkedLane = sharedLog.withReplicationInfoApplyQueue(
+					sourceHash,
+					async () => {
+						laneEntered.resolve();
+						await releaseLane.promise;
+					},
+				);
+				await laneEntered.promise;
+				const parkedTail =
+					sharedLog._replicationInfoApplyQueueByPeer.get(sourceHash);
+
+				const timestamp = BigInt(Date.now() + 5_000);
+				let settled = false;
+				receive = target.log
+					.onMessage(
+						new AddedReplicationSegmentMessage({
+							segments: [remoteRange.toReplicationRange()],
+						}),
+						{
+							from: sourceKey,
+							message: { header: { timestamp } },
+						} as any,
+					)
+					.then(() => {
+						settled = true;
+					});
+				// The handler queued its apply-lane turn…
+				await waitForResolved(() =>
+					expect(
+						sharedLog._replicationInfoApplyQueueByPeer.get(sourceHash),
+					).to.not.equal(parkedTail),
+				);
+				// …and released its receive lease BEFORE that turn could run: with
+				// the lane still parked, only the concurrently held lease remains.
+				await waitForResolved(() =>
+					expect(
+						sharedLog._activeReceiveHandlersByPeer.get(sourceHash)?.current
+							.active,
+					).to.equal(1),
+				);
+				expect(settled).to.be.false;
+
+				releaseLane.resolve();
+				await receive;
+				// The announcement applied in its lane turn…
+				expect(sharedLog.latestReplicationInfoMessage.get(sourceHash)).to.equal(
+					timestamp,
+				);
+				// …and the finally's release after the mid-branch release had no
+				// effect: the concurrently held lease still occupies its slot.
+				await waitForResolved(() =>
+					expect(
+						sharedLog._activeReceiveHandlersByPeer.get(sourceHash)?.current
+							.active,
+					).to.equal(1),
+				);
+				extraRelease();
+				await waitForResolved(() =>
+					expect(sharedLog._activeReceiveHandlersByPeer.has(sourceHash)).to.be
+						.false,
+				);
+			} finally {
+				scheduleRequests.restore();
+			}
+		} finally {
+			releaseLane.resolve();
+			await Promise.allSettled(
+				[parkedLane, receive].filter(
+					(value): value is Promise<void> => value != null,
+				),
+			);
+			await session.stop();
+		}
+	});
+});
+
+describe("receive admission receive error envelope", () => {
+	it("swallows classified control-plane errors and rethrows durable poison", async () => {
+		const session = await TestSession.disconnected(2);
+		try {
+			const store = new EventStore<string, any>();
+			const source = await session.peers[0].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const target = await session.peers[1].open(store.clone(), {
+				args: { replicate: 1, setup },
+			});
+			const sharedLog = target.log as any;
+			const sourceKey = source.node.identity.publicKey;
+			const sourceHash = sourceKey.hashcode();
+			sharedLog.advanceSubscriptionEpoch(sourceHash, "opening");
+			const send = sinon.stub(sharedLog.rpc, "send").resolves();
+			try {
+				// AccessError from inside the prune arm is swallowed.
+				const admit = sinon
+					.stub(sharedLog, "admitAndSendCheckedPruneGrants")
+					.rejects(new AccessError("pinned"));
+				await target.log.onMessage(
+					new RequestIPruneV2({
+						requests: [{ hash: "hash-a", requestId: new Uint8Array(32) }],
+					}),
+					{ from: sourceKey } as any,
+				);
+				expect(admit.calledOnce).to.be.true;
+				admit.restore();
+
+				// BorshError from the confirm arm is swallowed.
+				const markKnown = sinon
+					.stub(sharedLog, "markEntriesKnownByPeer")
+					.throws(new BorshError("pinned"));
+				await target.log.onMessage(
+					new ConfirmEntriesMessage({ hashes: ["hash-a"] }),
+					{ from: sourceKey } as any,
+				);
+				expect(markKnown.calledOnce).to.be.true;
+				markKnown.restore();
+
+				// AbortError from the replication-info request arm is swallowed.
+				const segments = sinon
+					.stub(sharedLog, "getMyReplicationSegments")
+					.rejects(new AbortError("pinned"));
+				await target.log.onMessage(new RequestReplicationInfoMessage(), {
+					from: sourceKey,
+				} as any);
+				expect(segments.calledOnce).to.be.true;
+				segments.restore();
+
+				// NativeDurableCommitError is the one class the envelope rethrows.
+				const removeKnown = sinon
+					.stub(sharedLog, "removeEntriesKnownByPeer")
+					.throws(new NativeDurableCommitError(new Error("pinned")));
+				await expect(
+					target.log.onMessage(
+						new RequestIPruneV2({
+							requests: [{ hash: "hash-b", requestId: new Uint8Array(32) }],
+						}),
+						{ from: sourceKey } as any,
+					),
+				).to.be.rejectedWith(NativeDurableCommitError);
+				expect(removeKnown.calledOnce).to.be.true;
+				removeKnown.restore();
+			} finally {
+				send.restore();
+			}
+		} finally {
+			await session.stop();
+		}
+	});
+
+	it("releases a wire-backed raw stash exactly once, before the poison recheck", async () => {
+		const session = await TestSession.disconnected(1);
+		try {
+			const store = new EventStore<string, any>();
+			const target = await session.peers[0].open(store.clone(), {
+				args: { replicate: false, setup },
+			});
+			const sharedLog = target.log as any;
+			const order: string[] = [];
+			const stashRelease = sinon.stub().callsFake(() => {
+				order.push("stash");
+				return true;
+			});
+			const message = new StashBackedRawExchangeHeadsMessage({
+				messageId: new Uint8Array(32),
+				hashes: [],
+				gidRefrences: [],
+				byteLengths: new Uint32Array(0),
+				reserved: new Uint8Array(4),
+				stash: {
+					release: stashRelease,
+					stashedBlocks: () => undefined,
+				} as any,
+			});
+			const poison = sinon
+				.stub(sharedLog, "throwIfNativeDurableCommitFailed")
+				.callsFake(() => {
+					order.push("poison");
+				});
+			try {
+				// A context without `from` fails before any arm runs: the envelope
+				// still releases the stash exactly once, then rechecks the poison
+				// AFTER the release.
+				await target.log.onMessage(message, {} as any);
+				expect(order).to.deep.equal(["poison", "stash", "poison"]);
+				// The release is one-shot at the message level too.
+				expect(message.release()).to.be.false;
+				expect(stashRelease.calledOnce).to.be.true;
+			} finally {
+				poison.restore();
+			}
+		} finally {
 			await session.stop();
 		}
 	});


### PR DESCRIPTION
Second stage-4.5 PR (#1181 merged). The onMessage megafunction gains a dispatcher: the five cold control-plane branches (both prune-protocol arms, all three replication-info arms) extract into named handlers with **script-asserted byte-identical bodies** — while the fused Raw/ExchangeHeads unit (the hottest, most-fixed code in the repo) stays untouched per the plan's headline decision: the diff's first hunk starts exactly at the RequestIPruneV2 header.

## Structure (three commits, pins first)

1. **Pins P5–P7**: dispatch precedence (a replication-info request reaches its arm only when the syncronizer declines — claimed vs declined visibly different), lease one-shot semantics with a concurrent-lease discriminator, and the error envelope (swallow classification, propagation, stash→lease→poison finally ordering).
2. **One-shot `PeerReceiveLease` handle** wrapping the unchanged acquire closure — release points identical, including the load-bearing mid-branch releases that precede the apply lane.
3. **The five handlers** over a `ReceiveLaneContext` built only after the fused unit returns or falls through (the heads path allocates nothing). Legacy no-op arms, ConfirmEntries, SyncCapabilities, syncronizer delegation, and Blocks stay inline as KEEP-OLD.

## Review (zero confirmed defects)

Branch order/reachability reconstructed against base and verified identical; handler throws traverse the same catch classification; the one-shot wrapper proven a *redundant* idempotence layer (base's closure already self-guards — no maskable bug class); the P5 dispatch mutant killed; the LESSON-4 repo-wide consumer-stub census clean for every new symbol. Review-flagged dead lane fields trimmed.

## Validation

24-suite sweep 0 failing — now permanently including the document-package durable-native consumer suites (the lesson from #1181's part-2a); both chaos suites green; ratchet unchanged at 13; guards/lint/tsc pass. Benchmark A/B accompanies this PR per the plan (heads-path delta must be zero).

Remaining for stage 4: the sync-module unification.